### PR TITLE
improve(designer): ブロック検索時に空カテゴリを非表示にする

### DIFF
--- a/designer/src/components/BlocksPanel.tsx
+++ b/designer/src/components/BlocksPanel.tsx
@@ -48,7 +48,8 @@ export function BlocksPanel({ mapCategoryBlocks, dragStart, dragStop }: BlocksRe
           </div>
         )}
         {filtered.map(([cat, blocks]) => {
-          const isCollapsed = !!collapsed[cat];
+          // 検索中は強制展開して一致ブロックを見えるようにする
+          const isCollapsed = query.trim() ? false : !!collapsed[cat];
           return (
             <section key={cat} className="blocks-category">
               <header


### PR DESCRIPTION
## Summary

- 検索クエリにマッチするブロックがないカテゴリは `filtered` から除外し、非表示にする（`if (matched.length)` によるフィルタ済み）
- 検索中は折りたたまれているカテゴリも強制展開し、一致ブロックをすぐ確認できるようにする

## Test plan

1. デザイナーを起動し、ブロックパネルを開く
2. 検索ボックスに存在するブロック名（例: "テキスト"）を入力
3. 該当ブロックを持つカテゴリのみ表示され、他のカテゴリが非表示になることを確認
4. 検索中は折りたたみ状態だったカテゴリも自動展開されることを確認
5. 検索をクリアすると全カテゴリが元の状態（折りたたみ含む）に戻ることを確認

Closes #22