### PR TITLE
右パネルの空状態に案内表示を追加

### DIFF
--- a/designer/src/components/Designer.tsx
+++ b/designer/src/components/Designer.tsx
@@ -82,6 +82,7 @@ export interface DesignerProps {
 export function Designer({ screenId, screenName, onBack }: DesignerProps) {
   const gjsOptions = buildGjsOptions(screenId);
   const [ready, setReady] = useState(false);
+  const [canvasEmpty, setCanvasEmpty] = useState(true);
   const [activeTheme, setActiveThemeState] = useState<ThemeId>(
     () => (localStorage.getItem(THEME_KEY) as ThemeId | null) ?? "standard"
   );
@@ -191,6 +192,20 @@ export function Designer({ screenId, screenName, onBack }: DesignerProps) {
     }
   }, [activeTheme]);
 
+  // キャンバスの空状態を追跡
+  useEffect(() => {
+    if (!ready || !editorRef.current) return;
+    const editor = editorRef.current;
+    const check = () => setCanvasEmpty(editor.getComponents().length === 0);
+    check();
+    editor.on("component:add", check);
+    editor.on("component:remove", check);
+    return () => {
+      editor.off("component:add", check);
+      editor.off("component:remove", check);
+    };
+  }, [ready]);
+
   // topbar-left の幅を panelMode に合わせて同期
   useEffect(() => {
     const root = document.documentElement;
@@ -260,6 +275,12 @@ export function Designer({ screenId, screenName, onBack }: DesignerProps) {
 
           <main className="panel-canvas">
             <Canvas className="designer-canvas" />
+            {canvasEmpty && ready && (
+              <div className="canvas-empty-hint">
+                <i className="bi bi-grid-1x2" />
+                <p>左のパネルからブロックをここにドラッグしてください</p>
+              </div>
+            )}
           </main>
 
           <aside className="panel-right">

--- a/designer/src/components/RightPanel.tsx
+++ b/designer/src/components/RightPanel.tsx
@@ -15,6 +15,7 @@ export function RightPanel() {
   const [tab, setTab] = useState<TabId>("styles");
   const editor = useEditorMaybe();
   const [loaded, setLoaded] = useState(false);
+  const [hasSelection, setHasSelection] = useState(false);
 
   const selectorRef = useRef<HTMLDivElement>(null);
   const styleRef = useRef<HTMLDivElement>(null);
@@ -35,6 +36,16 @@ export function RightPanel() {
     editor.on("load", onLoad);
     return () => {
       editor.off("load", onLoad);
+    };
+  }, [editor]);
+
+  // コンポーネント選択状態を追跡
+  useEffect(() => {
+    if (!editor) return;
+    const onToggle = () => setHasSelection(!!editor.getSelected());
+    editor.on("component:toggled", onToggle);
+    return () => {
+      editor.off("component:toggled", onToggle);
     };
   }, [editor]);
 
@@ -93,19 +104,35 @@ export function RightPanel() {
 
       <div className="right-content">
         <div hidden={tab !== "styles"}>
-          <div className="panel-block">
-            <div className="panel-block-title">セレクタ</div>
-            <div ref={selectorRef} />
-          </div>
-          <div className="panel-block">
-            <div className="panel-block-title">スタイル</div>
-            <div ref={styleRef} />
+          {!hasSelection && (
+            <div className="right-panel-empty">
+              <i className="bi bi-cursor" />
+              <p>コンポーネントを選択してください</p>
+            </div>
+          )}
+          <div style={{ display: hasSelection ? undefined : "none" }}>
+            <div className="panel-block">
+              <div className="panel-block-title">セレクタ</div>
+              <div ref={selectorRef} />
+            </div>
+            <div className="panel-block">
+              <div className="panel-block-title">スタイル</div>
+              <div ref={styleRef} />
+            </div>
           </div>
         </div>
         <div hidden={tab !== "traits"}>
-          <div className="panel-block">
-            <div className="panel-block-title">属性</div>
-            <div ref={traitRef} />
+          {!hasSelection && (
+            <div className="right-panel-empty">
+              <i className="bi bi-cursor" />
+              <p>コンポーネントを選択してください</p>
+            </div>
+          )}
+          <div style={{ display: hasSelection ? undefined : "none" }}>
+            <div className="panel-block">
+              <div className="panel-block-title">属性</div>
+              <div ref={traitRef} />
+            </div>
           </div>
         </div>
         <div hidden={tab !== "layers"}>

--- a/designer/src/styles/app.css
+++ b/designer/src/styles/app.css
@@ -494,6 +494,27 @@ body[data-gjs-dragging] .panel-left-wrapper.is-autohide .panel-left {
   background-color: #13141f;
   padding: 16px;
   overflow: hidden;
+  position: relative;
+}
+
+.canvas-empty-hint {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  color: rgba(255, 255, 255, 0.35);
+  pointer-events: none;
+  z-index: 1;
+}
+.canvas-empty-hint i {
+  font-size: 48px;
+}
+.canvas-empty-hint p {
+  font-size: 13px;
+  margin: 0;
 }
 
 .designer-canvas {
@@ -561,6 +582,20 @@ body[data-gjs-dragging] .panel-left-wrapper.is-autohide .panel-left {
   flex: 1 1 auto;
   overflow-y: auto;
   padding: 8px 0;
+}
+
+.right-panel-empty {
+  text-align: center;
+  padding: 32px 16px;
+  color: var(--dz-text-dim);
+}
+.right-panel-empty i {
+  font-size: 28px;
+  opacity: 0.5;
+}
+.right-panel-empty p {
+  font-size: 12px;
+  margin: 8px 0 0;
 }
 
 .panel-block {


### PR DESCRIPTION
## Summary

- コンポーネント未選択時、スタイル・属性タブに「コンポーネントを選択してください」案内を表示
- `component:toggled` イベントで選択状態を追跡し、選択時のみパネルコンテンツを表示
- キャンバスが空のとき「ブロックをここにドラッグしてください」ヒントオーバーレイを表示（`pointer-events: none` でドラッグ操作を妨げない）

## Test plan

1. デザイナーを起動する
2. キャンバスが空の状態でドラッグヒントが表示されることを確認
3. 右パネルのスタイル・属性タブに案内メッセージが表示されることを確認
4. ブロックをキャンバスにドロップするとドラッグヒントが消えることを確認
5. コンポーネントをクリック選択するとスタイル・属性パネルが表示されることを確認
6. コンポーネントの選択を解除すると再び案内メッセージが表示されることを確認

Closes #3