### PR TITLE
improve(designer): キーボードショートカットを追加

### DIFF
--- a/designer/src/components/Topbar.tsx
+++ b/designer/src/components/Topbar.tsx
@@ -38,6 +38,7 @@ export function Topbar({ ready, panelMode, onOpenPanel, activeTheme, onThemeChan
   const [codeModalOpen, setCodeModalOpen] = useState(false);
   const [codeModalHtml, setCodeModalHtml] = useState("");
   const [codeModalName, setCodeModalName] = useState("");
+  const [helpOpen, setHelpOpen] = useState(false);
 
   useEffect(() => {
     if (!editor) return;
@@ -137,6 +138,61 @@ ${html}
     URL.revokeObjectURL(url);
   };
 
+  // キーボードショートカット
+  useEffect(() => {
+    if (!editor) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // 入力フィールド内では無効化
+      const target = e.target as HTMLElement;
+      if (
+        target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.isContentEditable
+      ) {
+        return;
+      }
+
+      const ctrl = e.ctrlKey || e.metaKey;
+
+      if (ctrl && e.key === "s") {
+        e.preventDefault();
+        editor.store();
+      } else if (ctrl && e.key === "p") {
+        e.preventDefault();
+        editor.runCommand("preview");
+      } else if (ctrl && e.key === "d") {
+        e.preventDefault();
+        const selected = editor.getSelected();
+        if (selected) {
+          editor.runCommand("tlb-clone");
+        }
+      } else if (ctrl && e.key === "e") {
+        e.preventDefault();
+        const selected = editor.getSelected();
+        if (selected) {
+          const html = selected.toHTML();
+          const name = selected.getName() || selected.get("tagName") || "コンポーネント";
+          setCodeModalHtml(html);
+          setCodeModalName(name as string);
+          setCodeModalOpen(true);
+        }
+      } else if (e.key === "Delete" && !ctrl && !e.shiftKey && !e.altKey) {
+        const selected = editor.getSelected();
+        if (selected) {
+          editor.runCommand("tlb-delete");
+        }
+      } else if (e.key === "?") {
+        setHelpOpen((v) => !v);
+      } else if (e.key === "Escape") {
+        setHelpOpen(false);
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [editor]);
+
   return (
     <header className="topbar">
       <div className="topbar-left">
@@ -155,7 +211,7 @@ ${html}
         ) : (
           <>
             <i className="bi bi-palette2 topbar-logo" />
-            <span className="topbar-title">業務シス���ム デ��イナー</span>
+            <span className="topbar-title">業務システム デザイナー</span>
           </>
         )}
         {panelMode === "hidden" && (
@@ -188,14 +244,14 @@ ${html}
           <i className="bi bi-arrow-clockwise" />
         </button>
         <div className="divider" />
-        <button className="icon-btn" onClick={handlePreview} title="プレビュー">
+        <button className="icon-btn" onClick={handlePreview} title="プレビュー (Ctrl+P)">
           <i className="bi bi-eye" />
         </button>
         <button
           className="icon-btn"
           onClick={handleOpenCodeEditor}
           disabled={!hasSelected}
-          title="HTMLソースを編集"
+          title="HTMLソースを編集 (Ctrl+E)"
         >
           <i className="bi bi-code-slash" />
         </button>
@@ -205,6 +261,14 @@ ${html}
           title="キャンバスをクリア"
         >
           <i className="bi bi-trash" />
+        </button>
+        <div className="divider" />
+        <button
+          className="icon-btn"
+          onClick={() => setHelpOpen(true)}
+          title="キーボードショートカット一覧 (?)"
+        >
+          <i className="bi bi-keyboard" />
         </button>
       </div>
 
@@ -254,7 +318,7 @@ ${html}
             </>
           )}
         </span>
-        <button className="btn-primary-sm" onClick={handleSaveNow}>
+        <button className="btn-primary-sm" onClick={handleSaveNow} title="今すぐ保存 (Ctrl+S)">
           <i className="bi bi-save" /> 今すぐ保存
         </button>
         <button className="btn-secondary-sm" onClick={handleExportHtml} title="HTMLファイルとしてダウンロード">
@@ -271,6 +335,8 @@ ${html}
         onApply={handleCodeApply}
         onClose={() => setCodeModalOpen(false)}
       />
+
+      {helpOpen && <ShortcutsHelp onClose={() => setHelpOpen(false)} />}
     </header>
   );
 }
@@ -289,6 +355,42 @@ function McpIndicator({ status }: { status: McpStatus }) {
     <div className={`mcp-indicator mcp-${status}`} title={title}>
       <span className="mcp-dot" />
       <span className="mcp-label">{label}</span>
+    </div>
+  );
+}
+
+const SHORTCUTS = [
+  { key: "Ctrl + Z",       desc: "元に戻す" },
+  { key: "Ctrl + Shift + Z", desc: "やり直し" },
+  { key: "Ctrl + S",       desc: "今すぐ保存" },
+  { key: "Ctrl + P",       desc: "プレビュー" },
+  { key: "Ctrl + D",       desc: "選択コンポーネントを複製" },
+  { key: "Ctrl + E",       desc: "HTMLソースエディタを開く" },
+  { key: "Delete",         desc: "選択コンポーネントを削除" },
+  { key: "?",              desc: "このヘルプを表示 / 非表示" },
+  { key: "Esc",            desc: "ヘルプを閉じる" },
+];
+
+function ShortcutsHelp({ onClose }: { onClose: () => void }) {
+  return (
+    <div className="shortcuts-overlay" onClick={onClose}>
+      <div className="shortcuts-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="shortcuts-modal-header">
+          <i className="bi bi-keyboard" />
+          <span>キーボードショートカット</span>
+          <button className="shortcuts-close" onClick={onClose}>
+            <i className="bi bi-x-lg" />
+          </button>
+        </div>
+        <ul className="shortcuts-list">
+          {SHORTCUTS.map(({ key, desc }) => (
+            <li key={key}>
+              <span className="shortcuts-desc">{desc}</span>
+              <kbd className="shortcuts-key">{key}</kbd>
+            </li>
+          ))}
+        </ul>
+      </div>
     </div>
   );
 }

--- a/designer/src/styles/app.css
+++ b/designer/src/styles/app.css
@@ -853,3 +853,96 @@ body[data-gjs-dragging] .panel-left-wrapper.is-autohide .panel-left {
   background: var(--dz-border);
   color: var(--dz-text);
 }
+
+/* ==========================================================================
+   Keyboard Shortcuts Help Modal
+   ========================================================================== */
+.shortcuts-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+}
+
+.shortcuts-modal {
+  background: var(--dz-bg-2);
+  border: 1px solid var(--dz-border);
+  border-radius: 12px;
+  width: 420px;
+  max-width: 90vw;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+}
+
+.shortcuts-modal-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--dz-border);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--dz-text);
+}
+
+.shortcuts-modal-header i {
+  font-size: 16px;
+  color: var(--dz-accent);
+}
+
+.shortcuts-close {
+  margin-left: auto;
+  background: transparent;
+  border: none;
+  color: var(--dz-text-dim);
+  cursor: pointer;
+  font-size: 14px;
+  padding: 2px 4px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+}
+.shortcuts-close:hover {
+  color: var(--dz-text);
+  background: var(--dz-bg-3);
+}
+
+.shortcuts-list {
+  list-style: none;
+  margin: 0;
+  padding: 12px 20px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.shortcuts-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 0;
+  border-bottom: 1px solid var(--dz-border);
+  font-size: 13px;
+}
+
+.shortcuts-list li:last-child {
+  border-bottom: none;
+}
+
+.shortcuts-desc {
+  color: var(--dz-text);
+}
+
+.shortcuts-key {
+  background: var(--dz-bg-3);
+  border: 1px solid var(--dz-border);
+  border-bottom-width: 2px;
+  border-radius: 4px;
+  padding: 2px 8px;
+  font-family: monospace;
+  font-size: 12px;
+  color: var(--dz-text-dim);
+  white-space: nowrap;
+}


### PR DESCRIPTION
## Summary

- `Ctrl+S`: 今すぐ保存
- `Ctrl+P`: プレビュー
- `Ctrl+D`: 選択コンポーネントを複製（`tlb-clone` コマンド）
- `Ctrl+E`: HTMLソースエディタを開く
- `Delete`: 選択コンポーネントを削除（`tlb-delete` コマンド）
- `?`: ショートカット一覧ヘルプモーダルを表示 / 非表示
- `Esc`: ヘルプモーダルを閉じる
- ツールバーにキーボードアイコンボタンを追加（クリックでヘルプを開く）
- 入力フィールド内ではショートカットを無効化

## Test plan

1. デザイナーを起動する
2. `?` キーを押してショートカット一覧が表示されることを確認
3. `Esc` でモーダルが閉じることを確認
4. ブロックをドロップしてコンポーネントを選択後：
   - `Ctrl+D` で複製されることを確認
   - `Delete` で削除されることを確認
   - `Ctrl+E` でコードエディタが開くことを確認
5. `Ctrl+S` で保存されることを確認
6. `Ctrl+P` でプレビューが開くことを確認

Closes #21