### PR TITLE
feat(designer): レスポンシブプレビュー（デバイス幅切替）を追加

### DIFF
--- a/designer/src/components/Designer.tsx
+++ b/designer/src/components/Designer.tsx
@@ -70,6 +70,14 @@ function buildGjsOptions(screenId: string) {
       ],
     },
     blockManager: { blocks: [] },
+    deviceManager: {
+      default: "desktop",
+      devices: [
+        { id: "desktop",     name: "PC",              width: ""      },
+        { id: "tablet",      name: "タブレット",        width: "768px" },
+        { id: "smartphone",  name: "スマートフォン",    width: "375px" },
+      ],
+    },
   };
 }
 

--- a/designer/src/components/Topbar.tsx
+++ b/designer/src/components/Topbar.tsx
@@ -39,6 +39,7 @@ export function Topbar({ ready, panelMode, onOpenPanel, activeTheme, onThemeChan
   const [codeModalHtml, setCodeModalHtml] = useState("");
   const [codeModalName, setCodeModalName] = useState("");
   const [helpOpen, setHelpOpen] = useState(false);
+  const [selectedDevice, setSelectedDevice] = useState("desktop");
 
   useEffect(() => {
     if (!editor) return;
@@ -56,13 +57,19 @@ export function Topbar({ ready, panelMode, onOpenPanel, activeTheme, onThemeChan
       setHasSelected(editor.getSelectedAll().length > 0);
     };
 
+    const onDeviceChange = () => {
+      setSelectedDevice(editor.Devices.getSelected()?.get("id") ?? "desktop");
+    };
+
     editor.on("component:add component:remove component:update", update);
     editor.on("undo redo", update);
     editor.on("storage:start:store", onStorageStart);
     editor.on("storage:end:store", onStorageEnd);
     editor.on("component:selected component:deselected", onSelectionChange);
+    editor.on("device:select", onDeviceChange);
     update();
     onSelectionChange();
+    onDeviceChange();
 
     return () => {
       editor.off("component:add component:remove component:update", update);
@@ -70,6 +77,7 @@ export function Topbar({ ready, panelMode, onOpenPanel, activeTheme, onThemeChan
       editor.off("storage:start:store", onStorageStart);
       editor.off("storage:end:store", onStorageEnd);
       editor.off("component:selected component:deselected", onSelectionChange);
+      editor.off("device:select", onDeviceChange);
     };
   }, [editor]);
 
@@ -262,6 +270,30 @@ ${html}
         >
           <i className="bi bi-trash" />
         </button>
+        <div className="divider" />
+        <div className="device-switcher">
+          <button
+            className={`device-btn${selectedDevice === "desktop" ? " active" : ""}`}
+            onClick={() => editor?.setDevice("desktop")}
+            title="PC（全幅）"
+          >
+            <i className="bi bi-display" />
+          </button>
+          <button
+            className={`device-btn${selectedDevice === "tablet" ? " active" : ""}`}
+            onClick={() => editor?.setDevice("tablet")}
+            title="タブレット (768px)"
+          >
+            <i className="bi bi-tablet" />
+          </button>
+          <button
+            className={`device-btn${selectedDevice === "smartphone" ? " active" : ""}`}
+            onClick={() => editor?.setDevice("smartphone")}
+            title="スマートフォン (375px)"
+          >
+            <i className="bi bi-phone" />
+          </button>
+        </div>
         <div className="divider" />
         <button
           className="icon-btn"

--- a/designer/src/styles/app.css
+++ b/designer/src/styles/app.css
@@ -946,3 +946,40 @@ body[data-gjs-dragging] .panel-left-wrapper.is-autohide .panel-left {
   color: var(--dz-text-dim);
   white-space: nowrap;
 }
+
+/* ==========================================================================
+   Device Switcher
+   ========================================================================== */
+.device-switcher {
+  display: flex;
+  gap: 2px;
+  background: var(--dz-bg-3);
+  border: 1px solid var(--dz-border);
+  border-radius: 6px;
+  padding: 2px;
+}
+
+.device-btn {
+  background: transparent;
+  border: none;
+  color: var(--dz-text-dim);
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  transition: background 0.15s, color 0.15s;
+}
+
+.device-btn:hover {
+  background: var(--dz-border);
+  color: var(--dz-text);
+}
+
+.device-btn.active {
+  background: var(--dz-accent);
+  color: #fff;
+}


### PR DESCRIPTION
## Summary

- GrapesJS DeviceManager に3デバイスを設定
  - PC（全幅）
  - タブレット（768px）
  - スマートフォン（375px）
- トップバー中央にデバイス切替ボタン群を追加（PC / タブレット / スマートフォン）
- 選択中デバイスはアクセントカラーでハイライト表示
- `device:select` イベントで選択状態をリアクティブに同期

## Test plan

1. デザイナーを起動し、トップバー中央のデバイスボタンを確認
2. タブレットボタンをクリック → キャンバスが768px幅に縮小することを確認
3. スマートフォンボタンをクリック → キャンバスが375px幅に縮小することを確認
4. PCボタンをクリック → キャンバスが全幅に戻ることを確認
5. 選択中のボタンがアクセントカラーで表示されることを確認

Closes #17