### PR TITLE
feat: キャンバス上の選択範囲をマイブロックとして保存する機能

### DIFF
--- a/designer/src/components/BlocksPanel.tsx
+++ b/designer/src/components/BlocksPanel.tsx
@@ -1,10 +1,14 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, useCallback } from "react";
 import type { BlocksResultProps } from "@grapesjs/react";
+import { useEditorMaybe } from "@grapesjs/react";
 import type { Block } from "grapesjs";
+import { CUSTOM_BLOCK_CATEGORY } from "./Topbar";
+import { deleteCustomBlock } from "../store/customBlockStore";
 
 export function BlocksPanel({ mapCategoryBlocks, dragStart, dragStop }: BlocksResultProps) {
   const [query, setQuery] = useState("");
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
+  const editor = useEditorMaybe();
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -22,6 +26,17 @@ export function BlocksPanel({ mapCategoryBlocks, dragStart, dragStop }: BlocksRe
 
   const toggle = (cat: string) =>
     setCollapsed((s) => ({ ...s, [cat]: !s[cat] }));
+
+  const handleDeleteBlock = useCallback(async (block: Block, e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+    if (!editor) return;
+    const id = block.getId();
+    const label = block.get("label") || id;
+    if (!confirm(`「${label}」を削除しますか？`)) return;
+    editor.BlockManager.remove(id);
+    await deleteCustomBlock(id);
+  }, [editor]);
 
   return (
     <div className="blocks-panel">
@@ -50,6 +65,7 @@ export function BlocksPanel({ mapCategoryBlocks, dragStart, dragStop }: BlocksRe
         {filtered.map(([cat, blocks]) => {
           // 検索中は強制展開して一致ブロックを見えるようにする
           const isCollapsed = query.trim() ? false : !!collapsed[cat];
+          const isCustomCategory = cat === CUSTOM_BLOCK_CATEGORY;
           return (
             <section key={cat} className="blocks-category">
               <header
@@ -67,7 +83,7 @@ export function BlocksPanel({ mapCategoryBlocks, dragStart, dragStop }: BlocksRe
                   {blocks.map((block) => (
                     <div
                       key={block.getId()}
-                      className="block-item"
+                      className={`block-item${isCustomCategory ? " custom-block" : ""}`}
                       draggable
                       onDragStart={(ev) => dragStart(block, ev.nativeEvent)}
                       onDragEnd={() => dragStop(false)}
@@ -80,6 +96,15 @@ export function BlocksPanel({ mapCategoryBlocks, dragStart, dragStop }: BlocksRe
                         }}
                       />
                       <div className="block-label">{block.get("label")}</div>
+                      {isCustomCategory && (
+                        <button
+                          className="block-delete-btn"
+                          onClick={(e) => handleDeleteBlock(block, e)}
+                          title="削除"
+                        >
+                          <i className="bi bi-trash3" />
+                        </button>
+                      )}
                     </div>
                   ))}
                 </div>

--- a/designer/src/components/SaveBlockModal.tsx
+++ b/designer/src/components/SaveBlockModal.tsx
@@ -1,0 +1,66 @@
+import { useState } from "react";
+
+interface Props {
+  open: boolean;
+  defaultName: string;
+  onSave: (name: string) => void;
+  onClose: () => void;
+}
+
+export function SaveBlockModal({ open, defaultName, onSave, onClose }: Props) {
+  const [name, setName] = useState(defaultName);
+
+  if (!open) return null;
+
+  const handleSave = () => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    onSave(trimmed);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") handleSave();
+    if (e.key === "Escape") onClose();
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div
+        className="save-block-modal"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={handleKeyDown}
+      >
+        <div className="save-block-header">
+          <i className="bi bi-bookmark-plus" />
+          <span>マイブロックとして保存</span>
+          <button className="shortcuts-close" onClick={onClose}>
+            <i className="bi bi-x-lg" />
+          </button>
+        </div>
+        <div className="save-block-body">
+          <label className="save-block-label">ブロック名</label>
+          <input
+            className="save-block-input"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="例: 検索フォーム"
+            autoFocus
+          />
+        </div>
+        <div className="save-block-footer">
+          <button className="code-btn code-btn-secondary" onClick={onClose}>
+            キャンセル
+          </button>
+          <button
+            className="code-btn code-btn-primary"
+            onClick={handleSave}
+            disabled={!name.trim()}
+          >
+            <i className="bi bi-bookmark-check" /> 保存
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/designer/src/components/Topbar.tsx
+++ b/designer/src/components/Topbar.tsx
@@ -3,6 +3,10 @@ import { useEditor } from "@grapesjs/react";
 import type { PanelMode, ThemeId } from "./Designer";
 import type { McpStatus } from "../mcp/mcpBridge";
 import { CodeEditorModal } from "./CodeEditorModal";
+import { SaveBlockModal } from "./SaveBlockModal";
+import { upsertCustomBlock } from "../store/customBlockStore";
+
+export const CUSTOM_BLOCK_CATEGORY = "マイブロック";
 
 const THEMES: { id: ThemeId; label: string; icon: string; color: string }[] = [
   { id: "standard", label: "標準",    icon: "bi-grid-3x3",     color: "#6c757d" },
@@ -40,6 +44,8 @@ export function Topbar({ ready, panelMode, onOpenPanel, activeTheme, onThemeChan
   const [codeModalName, setCodeModalName] = useState("");
   const [helpOpen, setHelpOpen] = useState(false);
   const [selectedDevice, setSelectedDevice] = useState("desktop");
+  const [saveBlockOpen, setSaveBlockOpen] = useState(false);
+  const [saveBlockDefaultName, setSaveBlockDefaultName] = useState("");
 
   useEffect(() => {
     if (!editor) return;
@@ -100,6 +106,44 @@ export function Topbar({ ready, panelMode, onOpenPanel, activeTheme, onThemeChan
     setCodeModalHtml(html);
     setCodeModalName(name);
     setCodeModalOpen(true);
+  }, [editor]);
+
+  const handleOpenSaveBlock = useCallback(() => {
+    if (!editor) return;
+    const selected = editor.getSelected();
+    if (!selected) return;
+    const defaultName = selected.getName() || selected.get("tagName") || "マイブロック";
+    setSaveBlockDefaultName(defaultName as string);
+    setSaveBlockOpen(true);
+  }, [editor]);
+
+  const handleSaveBlock = useCallback(async (name: string) => {
+    if (!editor) return;
+    const selected = editor.getSelected();
+    if (!selected) return;
+
+    const id = `custom-block-${Date.now()}`;
+    const content = selected.toHTML();
+    const now = new Date().toISOString();
+
+    const customBlock = {
+      id,
+      label: name,
+      category: CUSTOM_BLOCK_CATEGORY,
+      content,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await upsertCustomBlock(customBlock);
+
+    editor.BlockManager.add(id, {
+      label: name,
+      category: CUSTOM_BLOCK_CATEGORY,
+      content,
+    });
+
+    setSaveBlockOpen(false);
   }, [editor]);
 
   const handleCodeApply = useCallback((newHtml: string) => {
@@ -264,6 +308,14 @@ ${html}
           <i className="bi bi-code-slash" />
         </button>
         <button
+          className="icon-btn"
+          onClick={handleOpenSaveBlock}
+          disabled={!hasSelected}
+          title="マイブロックとして保存"
+        >
+          <i className="bi bi-bookmark-plus" />
+        </button>
+        <button
           className="icon-btn danger"
           onClick={handleClear}
           title="キャンバスをクリア"
@@ -369,6 +421,13 @@ ${html}
       />
 
       {helpOpen && <ShortcutsHelp onClose={() => setHelpOpen(false)} />}
+
+      <SaveBlockModal
+        open={saveBlockOpen}
+        defaultName={saveBlockDefaultName}
+        onSave={handleSaveBlock}
+        onClose={() => setSaveBlockOpen(false)}
+      />
     </header>
   );
 }

--- a/designer/src/styles/app.css
+++ b/designer/src/styles/app.css
@@ -983,3 +983,109 @@ body[data-gjs-dragging] .panel-left-wrapper.is-autohide .panel-left {
   background: var(--dz-accent);
   color: #fff;
 }
+
+/* ==========================================================================
+   Save Block Modal
+   ========================================================================== */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+}
+
+.save-block-modal {
+  background: var(--dz-bg-2);
+  border: 1px solid var(--dz-border);
+  border-radius: 12px;
+  width: 360px;
+  max-width: 90vw;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+}
+
+.save-block-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--dz-border);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--dz-text);
+}
+
+.save-block-header i {
+  font-size: 16px;
+  color: var(--dz-accent);
+}
+
+.save-block-body {
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.save-block-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--dz-text-dim);
+}
+
+.save-block-input {
+  background: var(--dz-bg-3);
+  border: 1px solid var(--dz-border);
+  border-radius: 6px;
+  color: var(--dz-text);
+  padding: 8px 12px;
+  font-size: 13px;
+  outline: none;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.save-block-input:focus {
+  border-color: var(--dz-accent);
+}
+
+.save-block-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 20px;
+  border-top: 1px solid var(--dz-border);
+}
+
+/* Custom block delete button */
+.block-item.custom-block {
+  position: relative;
+}
+
+.block-delete-btn {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  background: rgba(239, 68, 68, 0.85);
+  border: none;
+  color: #fff;
+  border-radius: 4px;
+  width: 20px;
+  height: 20px;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  cursor: pointer;
+  padding: 0;
+}
+
+.block-item.custom-block:hover .block-delete-btn {
+  display: flex;
+}
+
+.block-delete-btn:hover {
+  background: rgb(220, 38, 38);
+}


### PR DESCRIPTION
## Summary

- トップバーに「マイブロックとして保存」ボタン（ブックマークアイコン）を追加（コンポーネント選択時に有効化）
- `SaveBlockModal` コンポーネントでブロック名を入力し保存
- `customBlockStore.upsertCustomBlock()` で localStorage（MCP 接続時はファイル）に永続化
- `editor.BlockManager.add()` でリアルタイムに GrapesJS に登録し「マイブロック」カテゴリに即座に反映
- `BlocksPanel` でマイブロックカテゴリのブロックにホバー時削除ボタンを表示
- 削除は `BlockManager.remove()` + `customBlockStore.deleteCustomBlock()` で両方から削除

## Test plan

1. キャンバスにブロックをドロップし、コンポーネントを選択
2. トップバーのブックマークボタンをクリック
3. ブロック名を入力して「保存」をクリック
4. ブロックパネルの「マイブロック」カテゴリに保存されたブロックが表示されることを確認
5. マイブロックをドラッグしてキャンバスに配置できることを確認
6. マイブロックにホバーして削除ボタンをクリック → 確認ダイアログ → ブロックが削除されることを確認
7. ページリロード後もマイブロックが保持されることを確認

Closes #6