### PR TITLE
feat(flow): フローノードに画面デザインのサムネイルを表示

### DIFF
--- a/designer/src/components/Designer.tsx
+++ b/designer/src/components/Designer.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import type { Editor as GEditor } from "grapesjs";
+import html2canvas from "html2canvas";
 import GjsEditor, {
   Canvas,
   BlocksProvider,
@@ -15,6 +16,34 @@ import { BlocksPanel } from "./BlocksPanel";
 import { RightPanel } from "./RightPanel";
 import { mcpBridge, type McpStatus } from "../mcp/mcpBridge";
 import { loadCustomBlocks, injectCustomBlockCss } from "../store/customBlockStore";
+
+/** キャンバスの縮小サムネイルを生成して data URL で返す */
+async function captureThumbnail(editor: GEditor): Promise<string | null> {
+  try {
+    const canvasDoc = editor.Canvas.getDocument();
+    if (!canvasDoc?.body) return null;
+    const canvasEl = await html2canvas(canvasDoc.body, {
+      backgroundColor: "#ffffff",
+      scale: 0.5,
+      logging: false,
+      useCORS: true,
+      allowTaint: true,
+    });
+    // 最大幅 320px にリサイズ
+    const maxWidth = 320;
+    if (canvasEl.width <= maxWidth) {
+      return canvasEl.toDataURL("image/jpeg", 0.6);
+    }
+    const scale = maxWidth / canvasEl.width;
+    const resized = document.createElement("canvas");
+    resized.width = maxWidth;
+    resized.height = Math.round(canvasEl.height * scale);
+    resized.getContext("2d")?.drawImage(canvasEl, 0, 0, resized.width, resized.height);
+    return resized.toDataURL("image/jpeg", 0.6);
+  } catch {
+    return null;
+  }
+}
 
 const PANEL_MODE_KEY = "designer-panel-left-mode";
 const THEME_KEY = "designer-theme";
@@ -199,6 +228,26 @@ export function Designer({ screenId, screenName, onBack }: DesignerProps) {
       } catch { /* ignore */ }
     }
   }, [activeTheme]);
+
+  // 保存後にサムネイルを撮影してフローノードに反映
+  useEffect(() => {
+    if (!ready || !editorRef.current) return;
+    const editor = editorRef.current;
+
+    const onStoreEnd = () => {
+      // 空のキャンバスはスキップ
+      if (editor.getComponents().length === 0) return;
+      captureThumbnail(editor).then((thumbnail) => {
+        if (!thumbnail) return;
+        mcpBridge.request("updateScreenMeta", { screenId, thumbnail }).catch(() => {});
+      });
+    };
+
+    editor.on("storage:end:store", onStoreEnd);
+    return () => {
+      editor.off("storage:end:store", onStoreEnd);
+    };
+  }, [ready, screenId]);
 
   // キャンバスの空状態を追跡
   useEffect(() => {

--- a/designer/src/components/flow/ScreenNode.tsx
+++ b/designer/src/components/flow/ScreenNode.tsx
@@ -21,18 +21,24 @@ function ScreenNodeComponent({ data, selected }: ScreenNodeProps) {
           <i className={`bi ${icon} screen-node-icon`} />
           <span className="screen-node-name">{data.name}</span>
         </div>
-        <div className="screen-node-body">
-          <span className="screen-node-type">
-            {typeLabel}
-          </span>
-          {data.path && (
-            <div className="screen-node-path">{data.path}</div>
-          )}
-          <div className={`screen-node-design-badge${data.hasDesign ? "" : " empty"}`}>
-            <i className={`bi ${data.hasDesign ? "bi-brush-fill" : "bi-brush"}`} />
-            {data.hasDesign ? "デザイン済み" : "未デザイン"}
+        {data.thumbnail ? (
+          <div className="screen-node-thumbnail">
+            <img src={data.thumbnail} alt={data.name} draggable={false} />
           </div>
-        </div>
+        ) : (
+          <div className="screen-node-body">
+            <span className="screen-node-type">
+              {typeLabel}
+            </span>
+            {data.path && (
+              <div className="screen-node-path">{data.path}</div>
+            )}
+            <div className={`screen-node-design-badge${data.hasDesign ? "" : " empty"}`}>
+              <i className={`bi ${data.hasDesign ? "bi-brush-fill" : "bi-brush"}`} />
+              {data.hasDesign ? "デザイン済み" : "未デザイン"}
+            </div>
+          </div>
+        )}
       </div>
       <Handle type="source" position={Position.Bottom} id="bottom" />
       <Handle type="source" position={Position.Right} id="right" />

--- a/designer/src/mcp/mcpBridge.ts
+++ b/designer/src/mcp/mcpBridge.ts
@@ -6,6 +6,7 @@ import {
   saveProject,
   addScreen,
   updateScreen,
+  updateScreenThumbnail,
   removeScreen,
   addEdge,
   removeEdge,
@@ -514,22 +515,28 @@ class McpBridgeImpl {
         }
 
         case "updateScreenMeta": {
-          const { screenId, ...patch } = (params ?? {}) as {
+          const { screenId, thumbnail, ...patch } = (params ?? {}) as {
             screenId: string;
             name?: string;
             type?: ScreenType;
             description?: string;
             path?: string;
+            thumbnail?: string;
           };
           if (!screenId) {
             respondError("screenId は必須です");
             break;
           }
           const project = await loadProject();
-          const updated = await updateScreen(project, screenId, patch);
-          if (!updated) {
-            respondError(`画面が見つかりません: ${screenId}`);
-            break;
+          if (thumbnail !== undefined) {
+            await updateScreenThumbnail(project, screenId, thumbnail);
+          }
+          if (Object.keys(patch).length > 0) {
+            const updated = await updateScreen(project, screenId, patch);
+            if (!updated) {
+              respondError(`画面が見つかりません: ${screenId}`);
+              break;
+            }
           }
           this.flowChangeHandler?.();
           respond({ success: true });

--- a/designer/src/store/flowStore.ts
+++ b/designer/src/store/flowStore.ts
@@ -234,6 +234,19 @@ export async function removeEdge(project: FlowProject, edgeId: string): Promise<
   return true;
 }
 
+/** 画面のサムネイルを更新 */
+export async function updateScreenThumbnail(
+  project: FlowProject,
+  screenId: string,
+  thumbnail: string,
+): Promise<void> {
+  const screen = project.screens.find((s) => s.id === screenId);
+  if (!screen) return;
+  screen.thumbnail = thumbnail;
+  screen.updatedAt = now();
+  await saveProject(project);
+}
+
 /** 画面のデザインデータ有無を更新 */
 export async function markScreenHasDesign(
   project: FlowProject,

--- a/designer/src/styles/flow.css
+++ b/designer/src/styles/flow.css
@@ -300,6 +300,27 @@
   color: #cbd5e1;
 }
 
+/* ── Thumbnail ─────────────────────────────── */
+.screen-node-thumbnail {
+  width: 100%;
+  overflow: hidden;
+  border-top: 1px solid #e2e8f0;
+  border-radius: 0 0 8px 8px;
+  background: #f8fafc;
+  max-height: 120px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+}
+
+.screen-node-thumbnail img {
+  width: 100%;
+  height: auto;
+  display: block;
+  object-fit: cover;
+  max-height: 120px;
+}
+
 /* ── Handles ───────────────────────────────── */
 .screen-node .react-flow__handle {
   width: 10px;

--- a/designer/src/types/flow.ts
+++ b/designer/src/types/flow.ts
@@ -73,6 +73,8 @@ export interface ScreenNode {
   position: { x: number; y: number };
   size: { width: number; height: number };
   hasDesign: boolean;
+  /** デザインのサムネイル（data:image/jpeg;base64,...） */
+  thumbnail?: string;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Summary

- `ScreenNode` 型に `thumbnail?: string` フィールドを追加
- `flowStore.updateScreenThumbnail()` 関数を追加
- `mcpBridge` の `updateScreenMeta` ハンドラにサムネイル更新を追加
- デザイナーで `storage:end:store` イベント後に html2canvas で自動撮影
  - `scale: 0.5` で縮小キャプチャ
  - 最大幅 320px に縮小 + JPEG 圧縮（quality 0.6）で軽量化
  - キャンバスが空の場合はスキップ
- `ScreenNode.tsx` でサムネイルがある場合はプレビュー画像を表示（最大高さ 120px）

## Test plan

1. フロー画面から画面を選択してデザイナーを開く
2. ブロックをキャンバスに配置する
3. 保存（Ctrl+S または自動保存）する
4. フロー画面に戻る
5. 対象ノードにサムネイルが表示されることを確認
6. 別の画面を開いてデザインを変更・保存 → フローでサムネイルが更新されることを確認

Closes #19