### PR TITLE
feat(flow): 画面一覧テーブルビューを追加

### DIFF
--- a/designer/src/components/flow/FlowEditor.tsx
+++ b/designer/src/components/flow/FlowEditor.tsx
@@ -21,7 +21,8 @@ import {
 import "@xyflow/react/dist/style.css";
 
 import ScreenNodeComponent from "./ScreenNode";
-import { FlowTopbar } from "./FlowTopbar";
+import { FlowTopbar, type ViewMode } from "./FlowTopbar";
+import { ScreenTableView } from "./ScreenTableView";
 import { ScreenEditModal, type ScreenFormData } from "./ScreenEditModal";
 import { EdgeEditModal, type EdgeFormData, type HandlePosition } from "./EdgeEditModal";
 import type { FlowProject, ScreenNode, ScreenEdge, TransitionTrigger } from "../../types/flow";
@@ -89,6 +90,7 @@ function FlowEditorInner() {
   const [projectName, setProjectName] = useState("読み込み中...");
   const [isLoading, setIsLoading] = useState(true);
   const [zoomLevel, setZoomLevel] = useState(1);
+  const [viewMode, setViewMode] = useState<ViewMode>("flow");
   const needsFitViewRef = useRef(false);
 
   // プロジェクトを読み込んで UI に反映
@@ -503,6 +505,7 @@ function FlowEditorInner() {
         projectName={projectName}
         screenCount={screenCount}
         zoomLevel={zoomLevel}
+        viewMode={viewMode}
         onAddScreen={handleOpenAddScreen}
         onRenameProject={(name) => { handleRenameProject(name).catch(console.error); }}
         onClearAll={() => { handleClearAll().catch(console.error); }}
@@ -512,6 +515,7 @@ function FlowEditorInner() {
         onExportMarkdown={handleExportMarkdown}
         onZoomChange={handleZoomChange}
         onFitView={handleFitView}
+        onViewModeChange={setViewMode}
       />
 
       <div className="flow-canvas">
@@ -520,6 +524,31 @@ function FlowEditorInner() {
             <div className="spinner" />
             <p>プロジェクトを読み込み中...</p>
           </div>
+        ) : viewMode === "table" ? (
+          <ScreenTableView
+            screens={projectRef.current?.screens ?? []}
+            onAdd={handleOpenAddScreen}
+            onEdit={(screenId) => {
+              if (!projectRef.current) return;
+              const s = projectRef.current.screens.find((sc) => sc.id === screenId);
+              if (s) {
+                setScreenModal({
+                  open: true,
+                  editId: screenId,
+                  initial: { name: s.name, type: s.type, path: s.path, description: s.description },
+                });
+              }
+            }}
+            onDelete={async (screenId) => {
+              if (!projectRef.current) return;
+              const s = projectRef.current.screens.find((sc) => sc.id === screenId);
+              if (s && confirm(`「${s.name}」を削除しますか？\nデザインデータも削除されます。`)) {
+                await removeScreen(projectRef.current, screenId);
+                setNodes((nds) => nds.filter((n) => n.id !== screenId));
+                setEdges((eds) => eds.filter((e) => e.source !== screenId && e.target !== screenId));
+              }
+            }}
+          />
         ) : (
           <ReactFlow
             nodes={nodes}
@@ -553,7 +582,7 @@ function FlowEditorInner() {
           </ReactFlow>
         )}
 
-        {isEmpty && (
+        {isEmpty && viewMode === "flow" && (
           <div className="flow-empty-state">
             <i className="bi bi-diagram-3" />
             <p>画面がまだありません</p>

--- a/designer/src/components/flow/FlowTopbar.tsx
+++ b/designer/src/components/flow/FlowTopbar.tsx
@@ -1,9 +1,12 @@
 import { useState, useRef, useEffect } from "react";
 
+export type ViewMode = "flow" | "table";
+
 interface Props {
   projectName: string;
   screenCount: number;
   zoomLevel: number;
+  viewMode: ViewMode;
   onAddScreen: () => void;
   onRenameProject: (name: string) => void;
   onClearAll: () => void;
@@ -13,13 +16,14 @@ interface Props {
   onExportMarkdown: () => void;
   onZoomChange: (zoom: number) => void;
   onFitView: () => void;
+  onViewModeChange: (mode: ViewMode) => void;
 }
 
 export function FlowTopbar({
-  projectName, screenCount, zoomLevel,
+  projectName, screenCount, zoomLevel, viewMode,
   onAddScreen, onRenameProject, onClearAll,
   onExportJSON, onImportJSON, onCopyMermaid, onExportMarkdown,
-  onZoomChange, onFitView,
+  onZoomChange, onFitView, onViewModeChange,
 }: Props) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(projectName);
@@ -95,9 +99,26 @@ export function FlowTopbar({
       </div>
 
       <div className="flow-topbar-center">
+        <div className="flow-view-toggle">
+          <button
+            className={`flow-view-btn${viewMode === "flow" ? " active" : ""}`}
+            onClick={() => onViewModeChange("flow")}
+            title="フロー図"
+          >
+            <i className="bi bi-diagram-3" /> フロー図
+          </button>
+          <button
+            className={`flow-view-btn${viewMode === "table" ? " active" : ""}`}
+            onClick={() => onViewModeChange("table")}
+            title="一覧"
+          >
+            <i className="bi bi-table" /> 一覧
+          </button>
+        </div>
+        <span className="flow-zoom-separator" />
         <span className="flow-topbar-screen-count">{screenCount} 画面</span>
         <span className="flow-zoom-separator" />
-        <div className="flow-zoom-control">
+        <div className={`flow-zoom-control${viewMode === "table" ? " hidden" : ""}`}>
           <button
             className="flow-zoom-btn"
             onClick={() => onZoomChange(zoomLevel - 0.1)}
@@ -122,13 +143,15 @@ export function FlowTopbar({
           </button>
           <span className="flow-zoom-label">{Math.round(zoomLevel * 100)}%</span>
         </div>
-        <button
-          className="flow-btn flow-btn-ghost flow-fit-view-btn"
-          onClick={onFitView}
-          title="全体表示"
-        >
-          <i className="bi bi-arrows-fullscreen" />
-        </button>
+        {viewMode === "flow" && (
+          <button
+            className="flow-btn flow-btn-ghost flow-fit-view-btn"
+            onClick={onFitView}
+            title="全体表示"
+          >
+            <i className="bi bi-arrows-fullscreen" />
+          </button>
+        )}
       </div>
 
       <div className="flow-topbar-right">

--- a/designer/src/components/flow/ScreenTableView.tsx
+++ b/designer/src/components/flow/ScreenTableView.tsx
@@ -1,0 +1,191 @@
+import { useState, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import type { ScreenNode } from "../../types/flow";
+import { SCREEN_TYPE_LABELS, SCREEN_TYPE_ICONS } from "../../types/flow";
+
+type SortKey = "name" | "type" | "path" | "hasDesign" | "updatedAt";
+type SortDir = "asc" | "desc";
+
+interface Props {
+  screens: ScreenNode[];
+  onEdit: (screenId: string) => void;
+  onDelete: (screenId: string) => void;
+  onAdd: () => void;
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString("ja-JP", {
+      year: "numeric", month: "2-digit", day: "2-digit",
+      hour: "2-digit", minute: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+export function ScreenTableView({ screens, onEdit, onDelete, onAdd }: Props) {
+  const navigate = useNavigate();
+  const [query, setQuery] = useState("");
+  const [sortKey, setSortKey] = useState<SortKey>("updatedAt");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+
+  const handleSort = (key: SortKey) => {
+    if (key === sortKey) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setSortDir("asc");
+    }
+  };
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return screens
+      .filter((s) => {
+        if (!q) return true;
+        return (
+          s.name.toLowerCase().includes(q) ||
+          (s.path || "").toLowerCase().includes(q) ||
+          (SCREEN_TYPE_LABELS[s.type] || "").toLowerCase().includes(q)
+        );
+      })
+      .sort((a, b) => {
+        let cmp = 0;
+        switch (sortKey) {
+          case "name":
+            cmp = a.name.localeCompare(b.name, "ja");
+            break;
+          case "type":
+            cmp = (SCREEN_TYPE_LABELS[a.type] || "").localeCompare(SCREEN_TYPE_LABELS[b.type] || "", "ja");
+            break;
+          case "path":
+            cmp = (a.path || "").localeCompare(b.path || "");
+            break;
+          case "hasDesign":
+            cmp = (a.hasDesign ? 1 : 0) - (b.hasDesign ? 1 : 0);
+            break;
+          case "updatedAt":
+            cmp = a.updatedAt.localeCompare(b.updatedAt);
+            break;
+        }
+        return sortDir === "asc" ? cmp : -cmp;
+      });
+  }, [screens, query, sortKey, sortDir]);
+
+  const SortIcon = ({ key }: { key: SortKey }) => {
+    if (sortKey !== key) return <i className="bi bi-arrow-down-up table-sort-icon inactive" />;
+    return <i className={`bi bi-arrow-${sortDir === "asc" ? "up" : "down"} table-sort-icon`} />;
+  };
+
+  return (
+    <div className="screen-table-view">
+      <div className="screen-table-toolbar">
+        <div className="screen-table-search">
+          <i className="bi bi-search" />
+          <input
+            type="text"
+            placeholder="画面名・URL・種別で絞り込み..."
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+          {query && (
+            <button className="clear-btn" onClick={() => setQuery("")}>
+              <i className="bi bi-x-circle-fill" />
+            </button>
+          )}
+        </div>
+        <span className="screen-table-count">{filtered.length} 件</span>
+        <button className="flow-btn flow-btn-primary" onClick={onAdd}>
+          <i className="bi bi-plus-lg" /> 画面を追加
+        </button>
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="screen-table-empty">
+          <i className="bi bi-inbox" />
+          <p>{query ? "該当する画面がありません" : "画面がまだありません"}</p>
+        </div>
+      ) : (
+        <div className="screen-table-wrap">
+          <table className="screen-table">
+            <thead>
+              <tr>
+                <th className="screen-table-th sortable" onClick={() => handleSort("name")}>
+                  画面名 <SortIcon key="name" />
+                </th>
+                <th className="screen-table-th sortable" onClick={() => handleSort("type")}>
+                  種別 <SortIcon key="type" />
+                </th>
+                <th className="screen-table-th sortable" onClick={() => handleSort("path")}>
+                  URL <SortIcon key="path" />
+                </th>
+                <th className="screen-table-th sortable" onClick={() => handleSort("hasDesign")}>
+                  デザイン <SortIcon key="hasDesign" />
+                </th>
+                <th className="screen-table-th sortable" onClick={() => handleSort("updatedAt")}>
+                  更新日時 <SortIcon key="updatedAt" />
+                </th>
+                <th className="screen-table-th">操作</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((screen) => (
+                <tr key={screen.id} className="screen-table-row">
+                  <td className="screen-table-td">
+                    <div className="screen-table-name">
+                      <i className={`bi ${SCREEN_TYPE_ICONS[screen.type] ?? "bi-circle"} screen-table-icon`} />
+                      <span>{screen.name}</span>
+                    </div>
+                  </td>
+                  <td className="screen-table-td">
+                    <span className="screen-type-badge">
+                      {SCREEN_TYPE_LABELS[screen.type] ?? screen.type}
+                    </span>
+                  </td>
+                  <td className="screen-table-td screen-table-path">
+                    {screen.path || <span className="screen-table-empty-cell">—</span>}
+                  </td>
+                  <td className="screen-table-td">
+                    <span className={`screen-design-badge${screen.hasDesign ? "" : " empty"}`}>
+                      <i className={`bi ${screen.hasDesign ? "bi-brush-fill" : "bi-brush"}`} />
+                      {screen.hasDesign ? "デザイン済み" : "未デザイン"}
+                    </span>
+                  </td>
+                  <td className="screen-table-td screen-table-date">
+                    {formatDate(screen.updatedAt)}
+                  </td>
+                  <td className="screen-table-td">
+                    <div className="screen-table-actions">
+                      <button
+                        className="screen-table-btn"
+                        onClick={() => navigate(`/design/${screen.id}`)}
+                        title="デザインを編集"
+                      >
+                        <i className="bi bi-palette" />
+                      </button>
+                      <button
+                        className="screen-table-btn"
+                        onClick={() => onEdit(screen.id)}
+                        title="画面情報を編集"
+                      >
+                        <i className="bi bi-pencil" />
+                      </button>
+                      <button
+                        className="screen-table-btn danger"
+                        onClick={() => onDelete(screen.id)}
+                        title="削除"
+                      >
+                        <i className="bi bi-trash" />
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/designer/src/styles/flow.css
+++ b/designer/src/styles/flow.css
@@ -640,3 +640,262 @@
 .flow-empty-state .flow-btn {
   pointer-events: auto;
 }
+
+/* ==========================================================================
+   View Toggle
+   ========================================================================== */
+.flow-view-toggle {
+  display: flex;
+  gap: 2px;
+  background: #f1f5f9;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  padding: 2px;
+}
+
+.flow-view-btn {
+  background: transparent;
+  border: none;
+  color: #64748b;
+  padding: 5px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  transition: background 0.15s, color 0.15s;
+}
+
+.flow-view-btn:hover {
+  background: #e2e8f0;
+  color: #1e293b;
+}
+
+.flow-view-btn.active {
+  background: #fff;
+  color: #6366f1;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+}
+
+.flow-zoom-control.hidden {
+  visibility: hidden;
+  pointer-events: none;
+}
+
+/* ==========================================================================
+   Screen Table View
+   ========================================================================== */
+.screen-table-view {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  padding: 20px;
+  gap: 16px;
+}
+
+.screen-table-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.screen-table-search {
+  display: flex;
+  align-items: center;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 6px 10px;
+  gap: 6px;
+  flex: 1;
+  max-width: 400px;
+}
+
+.screen-table-search i {
+  color: #94a3b8;
+  font-size: 13px;
+}
+
+.screen-table-search input {
+  border: none;
+  outline: none;
+  font-size: 13px;
+  flex: 1;
+  background: transparent;
+  color: #1e293b;
+}
+
+.screen-table-count {
+  font-size: 12px;
+  color: #64748b;
+  white-space: nowrap;
+}
+
+.screen-table-empty {
+  text-align: center;
+  padding: 60px 20px;
+  color: #94a3b8;
+}
+
+.screen-table-empty i {
+  font-size: 40px;
+  display: block;
+  margin-bottom: 12px;
+  opacity: 0.5;
+}
+
+.screen-table-empty p {
+  font-size: 14px;
+  margin: 0;
+}
+
+.screen-table-wrap {
+  flex: 1;
+  overflow: auto;
+  border-radius: 8px;
+  border: 1px solid #e2e8f0;
+  background: #fff;
+}
+
+.screen-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.screen-table-th {
+  padding: 10px 14px;
+  text-align: left;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: #64748b;
+  background: #f8fafc;
+  border-bottom: 1px solid #e2e8f0;
+  white-space: nowrap;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.screen-table-th.sortable {
+  cursor: pointer;
+  user-select: none;
+}
+
+.screen-table-th.sortable:hover {
+  background: #f1f5f9;
+  color: #1e293b;
+}
+
+.table-sort-icon {
+  margin-left: 4px;
+  font-size: 11px;
+  vertical-align: middle;
+}
+
+.table-sort-icon.inactive {
+  opacity: 0.35;
+}
+
+.screen-table-row:hover {
+  background: #f8fafc;
+}
+
+.screen-table-row:not(:last-child) {
+  border-bottom: 1px solid #f1f5f9;
+}
+
+.screen-table-td {
+  padding: 10px 14px;
+  vertical-align: middle;
+  color: #334155;
+}
+
+.screen-table-name {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 500;
+}
+
+.screen-table-icon {
+  color: #6366f1;
+  font-size: 14px;
+  flex-shrink: 0;
+}
+
+.screen-type-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 11px;
+  color: #64748b;
+  background: #f1f5f9;
+  padding: 2px 8px;
+  border-radius: 10px;
+  white-space: nowrap;
+}
+
+.screen-table-path {
+  font-family: "SF Mono", "Consolas", monospace;
+  font-size: 12px;
+  color: #64748b;
+}
+
+.screen-table-date {
+  font-size: 12px;
+  color: #94a3b8;
+  white-space: nowrap;
+}
+
+.screen-table-empty-cell {
+  color: #cbd5e1;
+}
+
+.screen-design-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  color: #22c55e;
+}
+
+.screen-design-badge.empty {
+  color: #cbd5e1;
+}
+
+.screen-table-actions {
+  display: flex;
+  gap: 4px;
+}
+
+.screen-table-btn {
+  background: transparent;
+  border: 1px solid #e2e8f0;
+  color: #64748b;
+  border-radius: 5px;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 13px;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.screen-table-btn:hover {
+  background: #f1f5f9;
+  color: #1e293b;
+  border-color: #cbd5e1;
+}
+
+.screen-table-btn.danger:hover {
+  background: #fee2e2;
+  color: #ef4444;
+  border-color: #fca5a5;
+}


### PR DESCRIPTION
## Summary

- FlowTopbar に「フロー図 / 一覧」ビュー切替ボタン群を追加
- `ScreenTableView` コンポーネントを新規作成
  - 列: 画面名、種別（バッジ）、URL（パス）、デザイン状態、更新日時、操作
  - 列ヘッダークリックで昇順/降順ソート
  - 検索ボックスで画面名・URL・種別によるリアルタイムフィルタ
  - 操作ボタン: デザイン編集・画面情報編集・削除
- テーブルビュー中はズームコントロールを非表示

## Test plan

1. フロー画面のトップバー中央に「フロー図 / 一覧」ボタンが表示されることを確認
2. 「一覧」ボタンをクリックしてテーブルビューに切り替わることを確認
3. 各列ヘッダーをクリックしてソートが動作することを確認
4. 検索ボックスに入力して絞り込みが動作することを確認
5. 操作ボタンからデザイン編集・画面情報編集・削除ができることを確認
6. 「フロー図」ボタンでフロービューに戻れることを確認

Closes #24