### PR TITLE
feat(designer): フォームバリデーションルールの定義機能を追加

### DIFF
--- a/designer/src/components/Designer.tsx
+++ b/designer/src/components/Designer.tsx
@@ -10,6 +10,7 @@ import grapesjs from "grapesjs";
 import "grapesjs/dist/css/grapes.min.css";
 
 import { registerBlocks } from "../grapes/blocks";
+import { registerValidationTraits } from "../grapes/validationTraits";
 import { registerRemoteStorage } from "../grapes/remoteStorage";
 import { Topbar } from "./Topbar";
 import { BlocksPanel } from "./BlocksPanel";
@@ -168,6 +169,7 @@ export function Designer({ screenId, screenName, onBack }: DesignerProps) {
     registerRemoteStorage(editor, screenId);
 
     registerBlocks(editor);
+    registerValidationTraits(editor);
     (window as unknown as { editor?: GEditor }).editor = editor;
 
     // カスタムブロック復元（非同期で読み込んで GrapesJS に登録）

--- a/designer/src/grapes/validationTraits.ts
+++ b/designer/src/grapes/validationTraits.ts
@@ -1,0 +1,133 @@
+/**
+ * validationTraits.ts
+ * フォームフィールドコンポーネントにバリデーションルールのトレイトを追加する。
+ *
+ * 対象要素: <input>, <select>, <textarea>
+ * 追加トレイト:
+ *   - required         (checkbox)
+ *   - minlength        (number)
+ *   - maxlength        (number)
+ *   - pattern          (text, 正規表現)
+ *   - data-min         (number, 数値最小値)
+ *   - data-max         (number, 数値最大値)
+ *   - data-error-msg   (text, カスタムエラーメッセージ)
+ */
+import type { Editor } from "grapesjs";
+
+const VALIDATION_TRAITS = [
+  {
+    type: "checkbox",
+    name: "required",
+    label: "必須入力",
+  },
+  {
+    type: "number",
+    name: "minlength",
+    label: "最小文字数",
+    placeholder: "例: 8",
+  },
+  {
+    type: "number",
+    name: "maxlength",
+    label: "最大文字数",
+    placeholder: "例: 100",
+  },
+  {
+    type: "text",
+    name: "pattern",
+    label: "パターン（正規表現）",
+    placeholder: "例: [a-zA-Z0-9]+",
+  },
+  {
+    type: "number",
+    name: "data-min",
+    label: "最小値（数値フィールド）",
+    placeholder: "例: 0",
+  },
+  {
+    type: "number",
+    name: "data-max",
+    label: "最大値（数値フィールド）",
+    placeholder: "例: 999",
+  },
+  {
+    type: "text",
+    name: "data-error-msg",
+    label: "エラーメッセージ",
+    placeholder: "例: 入力内容を確認してください",
+  },
+];
+
+/** input 要素向けデフォルトトレイト */
+const INPUT_BASE_TRAITS = [
+  { type: "text",   name: "name",        label: "フィールド名" },
+  { type: "text",   name: "placeholder", label: "プレースホルダー" },
+  {
+    type: "select",
+    name: "type",
+    label: "入力タイプ",
+    options: [
+      { id: "text",     label: "テキスト" },
+      { id: "number",   label: "数値" },
+      { id: "email",    label: "メールアドレス" },
+      { id: "password", label: "パスワード" },
+      { id: "date",     label: "日付" },
+      { id: "tel",      label: "電話番号" },
+      { id: "url",      label: "URL" },
+      { id: "search",   label: "検索" },
+    ],
+  },
+  ...VALIDATION_TRAITS,
+];
+
+/** textarea 要素向けデフォルトトレイト */
+const TEXTAREA_BASE_TRAITS = [
+  { type: "text",   name: "name",        label: "フィールド名" },
+  { type: "text",   name: "placeholder", label: "プレースホルダー" },
+  { type: "number", name: "rows",        label: "行数" },
+  ...VALIDATION_TRAITS,
+];
+
+/** select 要素向けデフォルトトレイト */
+const SELECT_BASE_TRAITS = [
+  { type: "text",     name: "name",     label: "フィールド名" },
+  { type: "checkbox", name: "multiple", label: "複数選択" },
+  ...VALIDATION_TRAITS.filter((t) => ["required", "data-error-msg"].includes(t.name)),
+];
+
+export function registerValidationTraits(editor: Editor): void {
+  const dc = editor.DomComponents;
+
+  // ── <input> ──────────────────────────────────────────────────────────────
+  dc.addType("validation-input", {
+    isComponent: (el) => el.tagName === "INPUT",
+    model: {
+      defaults: {
+        tagName: "input",
+        traits: INPUT_BASE_TRAITS,
+      },
+    },
+  });
+
+  // ── <textarea> ────────────────────────────────────────────────────────────
+  dc.addType("validation-textarea", {
+    isComponent: (el) => el.tagName === "TEXTAREA",
+    model: {
+      defaults: {
+        tagName: "textarea",
+        traits: TEXTAREA_BASE_TRAITS,
+      },
+    },
+  });
+
+  // ── <select> ─────────────────────────────────────────────────────────────
+  dc.addType("validation-select", {
+    isComponent: (el) => el.tagName === "SELECT",
+    model: {
+      defaults: {
+        tagName: "select",
+        traits: SELECT_BASE_TRAITS,
+      },
+    },
+  });
+}


### PR DESCRIPTION
## Summary

- `validationTraits.ts` を新規作成し、フォーム要素専用のバリデーショントレイトを定義
- GrapesJS の `DomComponents.addType()` で `<input>` / `<textarea>` / `<select>` をカスタムコンポーネントとして登録
- 属性タブに以下のトレイトを追加:
  - **必須入力** (`required`) - チェックボックス
  - **最小文字数** (`minlength`) - 数値入力
  - **最大文字数** (`maxlength`) - 数値入力
  - **パターン（正規表現）** (`pattern`) - テキスト入力
  - **最小値** (`data-min`) - 数値用
  - **最大値** (`data-max`) - 数値用
  - **エラーメッセージ** (`data-error-msg`) - カスタムメッセージ
- `<input>` にはさらにフィールド名・プレースホルダー・入力タイプのトレイトも追加

## Test plan

1. デザイナーを起動し、フィールドブロックをキャンバスに配置
2. `<input>` 要素をクリックして選択
3. 右パネルの「属性」タブを開く
4. バリデーションルールのトレイト（必須・最大文字数など）が表示されることを確認
5. 「必須入力」チェックボックスを有効にして HTML に `required` 属性が追加されることを確認
6. 「最大文字数」に数値を入力して `maxlength` 属性が反映されることを確認

Closes #20