### PR TITLE
feat(flow): 画面のグループ化・階層化を追加

### DIFF
--- a/designer/src/components/flow/FlowEditor.tsx
+++ b/designer/src/components/flow/FlowEditor.tsx
@@ -21,11 +21,12 @@ import {
 import "@xyflow/react/dist/style.css";
 
 import ScreenNodeComponent from "./ScreenNode";
+import GroupNodeComponent from "./GroupNodeComponent";
 import { FlowTopbar, type ViewMode } from "./FlowTopbar";
 import { ScreenTableView } from "./ScreenTableView";
 import { ScreenEditModal, type ScreenFormData } from "./ScreenEditModal";
 import { EdgeEditModal, type EdgeFormData, type HandlePosition } from "./EdgeEditModal";
-import type { FlowProject, ScreenNode, ScreenEdge, TransitionTrigger } from "../../types/flow";
+import type { FlowProject, ScreenNode, ScreenEdge, ScreenGroup, TransitionTrigger } from "../../types/flow";
 import { TRIGGER_LABELS } from "../../types/flow";
 import {
   loadProject,
@@ -36,6 +37,9 @@ import {
   addEdge as storeAddEdge,
   updateEdge as storeUpdateEdge,
   removeEdge as storeRemoveEdge,
+  addGroup as storeAddGroup,
+  updateGroup as storeUpdateGroup,
+  removeGroup as storeRemoveGroup,
   exportProjectJSON,
   importProjectJSON,
   generateMermaid,
@@ -44,15 +48,39 @@ import {
 import { mcpBridge } from "../../mcp/mcpBridge";
 import "../../styles/flow.css";
 
-const nodeTypes = { screenNode: ScreenNodeComponent };
+const nodeTypes = {
+  screenNode: ScreenNodeComponent,
+  groupNode: GroupNodeComponent,
+};
 
-function toRFNodes(screens: ScreenNode[]): RFNode[] {
-  return screens.map((s) => ({
-    id: s.id,
-    type: "screenNode",
-    position: s.position,
-    data: s,
+function toRFNodesWithGroups(screens: ScreenNode[], groups: ScreenGroup[]): RFNode[] {
+  // Group nodes must come first so ReactFlow knows about parents before children
+  const groupNodes: RFNode[] = (groups ?? []).map((g) => ({
+    id: g.id,
+    type: "groupNode",
+    position: g.position,
+    style: { width: g.size.width, height: g.size.height },
+    data: { ...g },
+    zIndex: -1,
+    selectable: true,
+    draggable: true,
   }));
+
+  const screenNodes: RFNode[] = screens.map((s) => {
+    const node: RFNode = {
+      id: s.id,
+      type: "screenNode",
+      position: s.position,
+      data: { ...s },
+    };
+    if (s.groupId) {
+      node.parentId = s.groupId;
+      node.extent = "parent";
+    }
+    return node;
+  });
+
+  return [...groupNodes, ...screenNodes];
 }
 
 function toRFEdges(edges: ScreenEdge[]): RFEdge[] {
@@ -76,7 +104,7 @@ function toRFEdges(edges: ScreenEdge[]): RFEdge[] {
 interface ContextMenu {
   x: number;
   y: number;
-  type: "node" | "edge";
+  type: "node" | "group" | "edge";
   targetId: string;
 }
 
@@ -97,7 +125,7 @@ function FlowEditorInner() {
   const reloadProject = useCallback(async () => {
     const project = await loadProject();
     projectRef.current = project;
-    setNodes(toRFNodes(project.screens));
+    setNodes(toRFNodesWithGroups(project.screens, project.groups ?? []));
     setEdges(toRFEdges(project.edges));
     setProjectName(project.name);
     needsFitViewRef.current = project.screens.length > 0;
@@ -192,6 +220,12 @@ function FlowEditorInner() {
     if (screen) {
       screen.position = node.position;
       syncAndSave();
+      return;
+    }
+    const group = (projectRef.current.groups ?? []).find((g) => g.id === node.id);
+    if (group) {
+      group.position = node.position;
+      syncAndSave();
     }
   }, [syncAndSave]);
 
@@ -225,7 +259,8 @@ function FlowEditorInner() {
 
   const onNodeContextMenu: NodeMouseHandler = useCallback((event, node) => {
     event.preventDefault();
-    setContextMenu({ x: event.clientX, y: event.clientY, type: "node", targetId: node.id });
+    const type = node.type === "groupNode" ? "group" : "node";
+    setContextMenu({ x: event.clientX, y: event.clientY, type, targetId: node.id });
   }, []);
 
   const onEdgeContextMenu = useCallback((event: React.MouseEvent, edge: RFEdge) => {
@@ -278,7 +313,7 @@ function FlowEditorInner() {
         id: screen.id,
         type: "screenNode" as const,
         position: screen.position,
-        data: screen,
+        data: { ...screen },
       }]);
     }
     setScreenModal({ open: false });
@@ -370,6 +405,94 @@ function FlowEditorInner() {
     setContextMenu(null);
   }, [contextMenu, navigate]);
 
+  // ── Group Actions ──
+
+  const handleAddGroup = useCallback(async () => {
+    if (!projectRef.current) return;
+    const name = prompt("グループ名を入力してください", "グループ");
+    if (!name) return;
+    const group = await storeAddGroup(projectRef.current, name.trim(), { x: 80, y: 80 });
+    setNodes((nds) => [{
+      id: group.id,
+      type: "groupNode",
+      position: group.position,
+      style: { width: group.size.width, height: group.size.height },
+      data: { ...group },
+      zIndex: -1,
+      selectable: true,
+      draggable: true,
+    }, ...nds]);
+  }, [setNodes]);
+
+  const handleRenameGroup = useCallback(async () => {
+    if (!contextMenu || !projectRef.current) return;
+    const group = (projectRef.current.groups ?? []).find((g) => g.id === contextMenu.targetId);
+    if (!group) return;
+    const name = prompt("新しいグループ名を入力してください", group.name);
+    if (!name || name.trim() === group.name) { setContextMenu(null); return; }
+    await storeUpdateGroup(projectRef.current, group.id, { name: name.trim() });
+    setNodes((nds) => nds.map((n) =>
+      n.id === group.id ? { ...n, data: { ...n.data, name: name.trim() } } : n
+    ));
+    setContextMenu(null);
+  }, [contextMenu, setNodes]);
+
+  const handleDeleteGroup = useCallback(async () => {
+    if (!contextMenu || !projectRef.current) return;
+    const group = (projectRef.current.groups ?? []).find((g) => g.id === contextMenu.targetId);
+    if (!group) return;
+    if (!confirm(`グループ「${group.name}」を削除しますか？\n（画面はグループから外れますが削除されません）`)) {
+      setContextMenu(null);
+      return;
+    }
+    await storeRemoveGroup(projectRef.current, contextMenu.targetId);
+    setNodes(toRFNodesWithGroups(projectRef.current.screens, projectRef.current.groups ?? []));
+    setContextMenu(null);
+  }, [contextMenu, setNodes]);
+
+  const handleAssignGroup = useCallback(async (groupId: string) => {
+    if (!contextMenu || !projectRef.current) return;
+    const screen = projectRef.current.screens.find((s) => s.id === contextMenu.targetId);
+    const group = (projectRef.current.groups ?? []).find((g) => g.id === groupId);
+    if (!screen || !group) return;
+    // Convert absolute position to relative within the group
+    const absPos = screen.groupId
+      ? (() => {
+          const cur = (projectRef.current!.groups ?? []).find((g) => g.id === screen.groupId);
+          return cur
+            ? { x: screen.position.x + cur.position.x, y: screen.position.y + cur.position.y }
+            : screen.position;
+        })()
+      : screen.position;
+    screen.position = {
+      x: Math.max(10, absPos.x - group.position.x),
+      y: Math.max(32, absPos.y - group.position.y),
+    };
+    screen.groupId = groupId;
+    screen.updatedAt = new Date().toISOString();
+    await saveProject(projectRef.current);
+    setNodes(toRFNodesWithGroups(projectRef.current.screens, projectRef.current.groups ?? []));
+    setContextMenu(null);
+  }, [contextMenu, setNodes]);
+
+  const handleUnassignGroup = useCallback(async () => {
+    if (!contextMenu || !projectRef.current) return;
+    const screen = projectRef.current.screens.find((s) => s.id === contextMenu.targetId);
+    if (!screen || !screen.groupId) return;
+    const group = (projectRef.current.groups ?? []).find((g) => g.id === screen.groupId);
+    if (group) {
+      screen.position = {
+        x: screen.position.x + group.position.x,
+        y: screen.position.y + group.position.y,
+      };
+    }
+    screen.groupId = undefined;
+    screen.updatedAt = new Date().toISOString();
+    await saveProject(projectRef.current);
+    setNodes(toRFNodesWithGroups(projectRef.current.screens, projectRef.current.groups ?? []));
+    setContextMenu(null);
+  }, [contextMenu, setNodes]);
+
   // ── Edge Context Menu Actions ──
 
   const handleEditEdge = useCallback(() => {
@@ -415,9 +538,24 @@ function FlowEditorInner() {
 
   const onNodesDelete = useCallback((deletedNodes: RFNode[]) => {
     if (!projectRef.current) return;
-    Promise.all(deletedNodes.map((n) => removeScreen(projectRef.current!, n.id)))
-      .catch(console.error);
-  }, []);
+    const project = projectRef.current;
+    const promises = deletedNodes.map((n) => {
+      if (project.screens.find((s) => s.id === n.id)) {
+        return removeScreen(project, n.id);
+      }
+      if ((project.groups ?? []).find((g) => g.id === n.id)) {
+        return storeRemoveGroup(project, n.id).then(() => {
+          // Rebuild nodes to reflect ungrouped screens
+          if (projectRef.current) {
+            setNodes(toRFNodesWithGroups(projectRef.current.screens, projectRef.current.groups ?? []));
+          }
+          return true;
+        });
+      }
+      return Promise.resolve(false);
+    });
+    Promise.all(promises).catch(console.error);
+  }, [setNodes]);
 
   // ── Project-level Actions ──
 
@@ -457,7 +595,7 @@ function FlowEditorInner() {
     try {
       const imported = await importProjectJSON(json);
       projectRef.current = imported;
-      setNodes(toRFNodes(imported.screens));
+      setNodes(toRFNodesWithGroups(imported.screens, imported.groups ?? []));
       setEdges(toRFEdges(imported.edges));
       setProjectName(imported.name);
       needsFitViewRef.current = imported.screens.length > 0;
@@ -496,8 +634,8 @@ function FlowEditorInner() {
     URL.revokeObjectURL(url);
   }, []);
 
-  const isEmpty = !isLoading && nodes.length === 0;
-  const screenCount = nodes.length;
+  const isEmpty = !isLoading && nodes.filter((n) => n.type === "screenNode").length === 0;
+  const screenCount = nodes.filter((n) => n.type === "screenNode").length;
 
   return (
     <div className="flow-root">
@@ -507,6 +645,7 @@ function FlowEditorInner() {
         zoomLevel={zoomLevel}
         viewMode={viewMode}
         onAddScreen={handleOpenAddScreen}
+        onAddGroup={() => { handleAddGroup().catch(console.error); }}
         onRenameProject={(name) => { handleRenameProject(name).catch(console.error); }}
         onClearAll={() => { handleClearAll().catch(console.error); }}
         onExportJSON={handleExportJSON}
@@ -600,7 +739,17 @@ function FlowEditorInner() {
           style={{ left: contextMenu.x, top: contextMenu.y }}
           onClick={(e) => e.stopPropagation()}
         >
-          {contextMenu.type === "node" ? (
+          {contextMenu.type === "group" ? (
+            <>
+              <button className="flow-context-menu-item" onClick={() => { handleRenameGroup().catch(console.error); }}>
+                <i className="bi bi-pencil" /> グループ名を変更
+              </button>
+              <div className="flow-context-menu-separator" />
+              <button className="flow-context-menu-item danger" onClick={() => { handleDeleteGroup().catch(console.error); }}>
+                <i className="bi bi-trash" /> グループを削除
+              </button>
+            </>
+          ) : contextMenu.type === "node" ? (
             <>
               <button className="flow-context-menu-item" onClick={handleDesignNode}>
                 <i className="bi bi-pencil-square" /> デザインを開く
@@ -611,6 +760,34 @@ function FlowEditorInner() {
               <button className="flow-context-menu-item" onClick={() => { handleDuplicateNode().catch(console.error); }}>
                 <i className="bi bi-copy" /> 複製
               </button>
+              {(() => {
+                const screen = projectRef.current?.screens.find((s) => s.id === contextMenu.targetId);
+                const groups = projectRef.current?.groups ?? [];
+                if (!screen) return null;
+                if (screen.groupId) {
+                  return (
+                    <>
+                      <div className="flow-context-menu-separator" />
+                      <button className="flow-context-menu-item" onClick={() => { handleUnassignGroup().catch(console.error); }}>
+                        <i className="bi bi-collection" /> グループから外す
+                      </button>
+                    </>
+                  );
+                }
+                if (groups.length > 0) {
+                  return (
+                    <>
+                      <div className="flow-context-menu-separator" />
+                      {groups.map((g) => (
+                        <button key={g.id} className="flow-context-menu-item" onClick={() => { handleAssignGroup(g.id).catch(console.error); }}>
+                          <i className="bi bi-collection" /> 「{g.name}」に追加
+                        </button>
+                      ))}
+                    </>
+                  );
+                }
+                return null;
+              })()}
               <div className="flow-context-menu-separator" />
               <button className="flow-context-menu-item danger" onClick={() => { handleDeleteNode().catch(console.error); }}>
                 <i className="bi bi-trash" /> 削除

--- a/designer/src/components/flow/FlowTopbar.tsx
+++ b/designer/src/components/flow/FlowTopbar.tsx
@@ -8,6 +8,7 @@ interface Props {
   zoomLevel: number;
   viewMode: ViewMode;
   onAddScreen: () => void;
+  onAddGroup: () => void;
   onRenameProject: (name: string) => void;
   onClearAll: () => void;
   onExportJSON: () => void;
@@ -21,7 +22,7 @@ interface Props {
 
 export function FlowTopbar({
   projectName, screenCount, zoomLevel, viewMode,
-  onAddScreen, onRenameProject, onClearAll,
+  onAddScreen, onAddGroup, onRenameProject, onClearAll,
   onExportJSON, onImportJSON, onCopyMermaid, onExportMarkdown,
   onZoomChange, onFitView, onViewModeChange,
 }: Props) {
@@ -197,6 +198,11 @@ export function FlowTopbar({
           />
         </div>
 
+        {viewMode === "flow" && (
+          <button className="flow-btn flow-btn-secondary" onClick={onAddGroup} title="グループを追加">
+            <i className="bi bi-collection" /> グループ
+          </button>
+        )}
         <button className="flow-btn flow-btn-primary" onClick={onAddScreen}>
           <i className="bi bi-plus-lg" /> 画面を追加
         </button>

--- a/designer/src/components/flow/GroupNodeComponent.tsx
+++ b/designer/src/components/flow/GroupNodeComponent.tsx
@@ -1,0 +1,35 @@
+import { memo } from "react";
+import type { NodeProps } from "@xyflow/react";
+import type { ScreenGroup } from "../../types/flow";
+
+export type GroupNodeData = ScreenGroup;
+
+type GroupNodeProps = NodeProps & {
+  data: GroupNodeData;
+  selected?: boolean;
+};
+
+const DEFAULT_COLOR = "#6366f1";
+
+function GroupNodeComponent({ data, selected }: GroupNodeProps) {
+  const color = data.color ?? DEFAULT_COLOR;
+
+  return (
+    <div
+      className={`group-node${selected ? " selected" : ""}`}
+      style={{
+        width: "100%",
+        height: "100%",
+        borderColor: color,
+        backgroundColor: `${color}0d`,
+      }}
+    >
+      <div className="group-node-label" style={{ color }}>
+        <i className="bi bi-collection-fill" />
+        <span>{data.name}</span>
+      </div>
+    </div>
+  );
+}
+
+export default memo(GroupNodeComponent);

--- a/designer/src/store/flowStore.ts
+++ b/designer/src/store/flowStore.ts
@@ -8,7 +8,7 @@
  * NOTE: I/O バックエンドは mcpBridge.ts が setFlowStorageBackend() で差し替える。
  *       循環依存を避けるため flowStore は mcpBridge をインポートしない。
  */
-import type { FlowProject, ScreenNode, ScreenEdge, ScreenType, TransitionTrigger } from "../types/flow";
+import type { FlowProject, ScreenNode, ScreenEdge, ScreenGroup, ScreenType, TransitionTrigger } from "../types/flow";
 import { SCREEN_TYPE_LABELS, TRIGGER_LABELS } from "../types/flow";
 
 // ─── ストレージバックエンドインターフェース ────────────────────────────────
@@ -45,6 +45,7 @@ function createEmptyProject(): FlowProject {
     version: 1,
     name: "新規プロジェクト",
     screens: [],
+    groups: [],
     edges: [],
     updatedAt: now(),
   };
@@ -96,11 +97,20 @@ export function loadProjectFromLocalStorage(): FlowProject | null {
 
 // ─── 公開 API（非同期）────────────────────────────────────────────────────
 
+/** 旧プロジェクトデータに不足フィールドを補完 */
+function ensureProjectDefaults(project: FlowProject): FlowProject {
+  if (!project.groups) project.groups = [];
+  for (const s of project.screens) {
+    if (s.groupId === undefined) s.groupId = undefined;
+  }
+  return project;
+}
+
 /** プロジェクトを読み込み */
 export async function loadProject(): Promise<FlowProject> {
   if (_backend) {
     const data = await _backend.loadProject();
-    if (data) return data as FlowProject;
+    if (data) return ensureProjectDefaults(data as FlowProject);
     // ファイルが存在しない → localStorage から移行
     const local = loadProjectFromLocalStorage();
     if (local) {
@@ -268,6 +278,71 @@ export function screenStorageKey(screenId: string): string {
 /** 画面が存在するか */
 export function screenExists(project: FlowProject, screenId: string): boolean {
   return project.screens.some((s) => s.id === screenId);
+}
+
+// ─── グループ操作 ─────────────────────────────────────────────────────────
+
+/** グループを追加 */
+export async function addGroup(
+  project: FlowProject,
+  name: string,
+  position: { x: number; y: number },
+): Promise<ScreenGroup> {
+  const group: ScreenGroup = {
+    id: crypto.randomUUID(),
+    name,
+    position,
+    size: { width: 360, height: 280 },
+    createdAt: now(),
+    updatedAt: now(),
+  };
+  project.groups.push(group);
+  await saveProject(project);
+  return group;
+}
+
+/** グループを更新 */
+export async function updateGroup(
+  project: FlowProject,
+  groupId: string,
+  patch: Partial<Pick<ScreenGroup, "name" | "position" | "size" | "color">>,
+): Promise<ScreenGroup | null> {
+  const group = project.groups.find((g) => g.id === groupId);
+  if (!group) return null;
+  Object.assign(group, patch, { updatedAt: now() });
+  await saveProject(project);
+  return group;
+}
+
+/** グループを削除（所属画面は ungrouped に戻す） */
+export async function removeGroup(
+  project: FlowProject,
+  groupId: string,
+): Promise<boolean> {
+  const idx = project.groups.findIndex((g) => g.id === groupId);
+  if (idx === -1) return false;
+  project.groups.splice(idx, 1);
+  // 所属画面の groupId をクリア
+  for (const s of project.screens) {
+    if (s.groupId === groupId) {
+      s.groupId = undefined;
+    }
+  }
+  await saveProject(project);
+  return true;
+}
+
+/** 画面をグループに割り当て（null でグループ解除） */
+export async function assignScreenGroup(
+  project: FlowProject,
+  screenId: string,
+  groupId: string | undefined,
+): Promise<void> {
+  const screen = project.screens.find((s) => s.id === screenId);
+  if (!screen) return;
+  screen.groupId = groupId;
+  screen.updatedAt = now();
+  await saveProject(project);
 }
 
 // ─── エクスポート / インポート ────────────────────────────────────────────

--- a/designer/src/styles/flow.css
+++ b/designer/src/styles/flow.css
@@ -899,3 +899,39 @@
   color: #ef4444;
   border-color: #fca5a5;
 }
+
+/* ==========================================================================
+   Group Node
+   ========================================================================== */
+.group-node {
+  box-sizing: border-box;
+  border: 2px dashed #6366f1;
+  border-radius: 12px;
+  position: relative;
+  pointer-events: all;
+}
+
+.group-node.selected {
+  border-style: solid;
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.25);
+}
+
+.group-node-label {
+  position: absolute;
+  top: -1px;
+  left: 12px;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  background: #fff;
+  border-radius: 4px;
+  padding: 1px 8px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #6366f1;
+  user-select: none;
+  pointer-events: none;
+  transform: translateY(-50%);
+  white-space: nowrap;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+}

--- a/designer/src/types/flow.ts
+++ b/designer/src/types/flow.ts
@@ -73,8 +73,21 @@ export interface ScreenNode {
   position: { x: number; y: number };
   size: { width: number; height: number };
   hasDesign: boolean;
+  /** 所属グループID */
+  groupId?: string;
   /** デザインのサムネイル（data:image/jpeg;base64,...） */
   thumbnail?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** 画面グループ */
+export interface ScreenGroup {
+  id: string;
+  name: string;
+  color?: string;
+  position: { x: number; y: number };
+  size: { width: number; height: number };
   createdAt: string;
   updatedAt: string;
 }
@@ -95,6 +108,7 @@ export interface FlowProject {
   version: 1;
   name: string;
   screens: ScreenNode[];
+  groups: ScreenGroup[];
   edges: ScreenEdge[];
   updatedAt: string;
 }


### PR DESCRIPTION
## Summary
- ScreenGroup データモデルを types/flow.ts と flowStore.ts に追加（CRUD 操作含む）
- GroupNodeComponent.tsx で ReactFlow のグループノードを実装（ダッシュ枠＋ラベル表示）
- FlowEditor.tsx でグループの追加・削除・リネーム・画面の割り当て/解除に対応
- FlowTopbar.tsx に「グループ」ボタンを追加（フロー図モード時のみ表示）
- 右クリックコンテキストメニューからグループへの追加/解除が可能

## Test plan
- [ ] 「グループ」ボタンをクリックしてグループ名を入力 → グループノードが追加される
- [ ] 画面ノードを右クリック → 「〇〇に追加」でグループへ割り当てられる
- [ ] グループに入った画面はグループ内で移動できる
- [ ] 画面ノード右クリック → 「グループから外す」で解除できる
- [ ] グループノード右クリック → 「グループ名を変更」「グループを削除」が動作する
- [ ] グループ削除時に所属していた画面はグループから外れて残る

Generated with Claude Code