### PR TITLE
feat(designer): アクセシビリティ（a11y）ツールの追加

### DIFF
--- a/designer/src/components/A11yPanel.tsx
+++ b/designer/src/components/A11yPanel.tsx
@@ -1,0 +1,354 @@
+import { useState, useEffect, useCallback } from "react";
+import { useEditorMaybe } from "@grapesjs/react";
+import type { Component } from "grapesjs";
+
+// ── WCAG コントラスト計算 ────────────────────────────────────────────────────
+
+function hexToRgb(hex: string): [number, number, number] | null {
+  const m = hex.replace("#", "").match(/^([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i);
+  if (!m) return null;
+  return [parseInt(m[1], 16), parseInt(m[2], 16), parseInt(m[3], 16)];
+}
+
+function relativeLuminance(hex: string): number {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return 0;
+  const [r, g, b] = rgb.map((c) => {
+    const s = c / 255;
+    return s <= 0.04045 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function contrastRatio(fg: string, bg: string): number {
+  const l1 = relativeLuminance(fg);
+  const l2 = relativeLuminance(bg);
+  const lighter = Math.max(l1, l2);
+  const darker = Math.min(l1, l2);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+// ── ARIA 属性サジェスト ────────────────────────────────────────────────────────
+
+interface AriaAttr {
+  attr: string;
+  hint: string;
+  defaultValue?: string;
+}
+
+const ARIA_BY_TAG: Record<string, AriaAttr[]> = {
+  button: [
+    { attr: "aria-label",    hint: "ボタンの説明（アイコンのみの場合に必須）" },
+    { attr: "aria-pressed",  hint: "トグル状態", defaultValue: "false" },
+    { attr: "aria-expanded", hint: "ドロップダウン等の展開状態", defaultValue: "false" },
+    { attr: "aria-disabled", hint: "無効状態", defaultValue: "true" },
+    { attr: "aria-haspopup", hint: "ポップアップあり", defaultValue: "true" },
+  ],
+  a: [
+    { attr: "aria-label",   hint: "リンクの説明（テキストを補足）" },
+    { attr: "aria-current", hint: "現在のページ/ステップ", defaultValue: "page" },
+  ],
+  input: [
+    { attr: "aria-label",       hint: "入力欄の説明（label要素がない場合）" },
+    { attr: "aria-required",    hint: "必須入力", defaultValue: "true" },
+    { attr: "aria-invalid",     hint: "入力エラー", defaultValue: "true" },
+    { attr: "aria-describedby", hint: "エラーメッセージ要素のID" },
+    { attr: "aria-autocomplete", hint: "オートコンプリート", defaultValue: "list" },
+  ],
+  select: [
+    { attr: "aria-label",    hint: "選択欄の説明" },
+    { attr: "aria-required", hint: "必須選択", defaultValue: "true" },
+    { attr: "aria-invalid",  hint: "選択エラー", defaultValue: "true" },
+  ],
+  textarea: [
+    { attr: "aria-label",    hint: "テキストエリアの説明" },
+    { attr: "aria-required", hint: "必須入力", defaultValue: "true" },
+    { attr: "aria-invalid",  hint: "入力エラー", defaultValue: "true" },
+  ],
+  img: [
+    { attr: "alt",         hint: "代替テキスト（必須）" },
+    { attr: "aria-hidden", hint: "装飾画像として支援技術から除外", defaultValue: "true" },
+  ],
+  nav: [
+    { attr: "aria-label", hint: "ナビゲーション領域の名前" },
+  ],
+  table: [
+    { attr: "aria-label",   hint: "表の説明" },
+    { attr: "role",         hint: "グリッド用途の場合", defaultValue: "grid" },
+  ],
+  th: [
+    { attr: "scope", hint: "ヘッダーの適用範囲", defaultValue: "col" },
+  ],
+  form: [
+    { attr: "aria-label",      hint: "フォームの名前" },
+    { attr: "aria-labelledby", hint: "見出し要素のID" },
+    { attr: "novalidate",      hint: "ブラウザのバリデーションを無効化", defaultValue: "" },
+  ],
+  dialog: [
+    { attr: "role",           hint: "ダイアログとして明示", defaultValue: "dialog" },
+    { attr: "aria-modal",     hint: "モーダルダイアログ", defaultValue: "true" },
+    { attr: "aria-labelledby", hint: "タイトル要素のID" },
+  ],
+};
+
+const GENERIC_ARIA: AriaAttr[] = [
+  { attr: "role",            hint: "要素の役割を明示（landmark, widget等）" },
+  { attr: "aria-label",      hint: "要素の説明" },
+  { attr: "aria-labelledby", hint: "ラベル要素のID" },
+  { attr: "aria-hidden",     hint: "支援技術から非表示", defaultValue: "true" },
+  { attr: "aria-live",       hint: "動的コンテンツの通知", defaultValue: "polite" },
+  { attr: "tabindex",        hint: "フォーカス順序", defaultValue: "0" },
+];
+
+// ── コンポーネント ────────────────────────────────────────────────────────────
+
+export function A11yPanel() {
+  const editor = useEditorMaybe();
+  const [selected, setSelected] = useState<Component | null>(null);
+  const [currentAttrs, setCurrentAttrs] = useState<Record<string, string>>({});
+  const [addingAttr, setAddingAttr] = useState<string | null>(null);
+  const [addValue, setAddValue] = useState("");
+
+  // コントラストチェッカー
+  const [fgColor, setFgColor] = useState("#000000");
+  const [bgColor, setBgColor] = useState("#ffffff");
+
+  // コンポーネント選択追跡
+  useEffect(() => {
+    if (!editor) return;
+    const onToggle = () => {
+      const comp = editor.getSelected() ?? null;
+      setSelected(comp);
+      if (comp) {
+        const attrs = comp.getAttributes() as Record<string, string>;
+        setCurrentAttrs(attrs);
+      } else {
+        setCurrentAttrs({});
+      }
+      setAddingAttr(null);
+    };
+    editor.on("component:toggled", onToggle);
+    return () => {
+      editor.off("component:toggled", onToggle);
+    };
+  }, [editor]);
+
+  const tagName = selected?.get("tagName") as string | undefined ?? "";
+  const suggestions = ARIA_BY_TAG[tagName.toLowerCase()] ?? GENERIC_ARIA;
+  const ariaAttrs = Object.entries(currentAttrs).filter(
+    ([k]) => k.startsWith("aria-") || k === "role" || k === "alt" || k === "tabindex"
+  );
+
+  const handleAddAttr = useCallback(() => {
+    if (!selected || !addingAttr) return;
+    const val = addValue.trim();
+    selected.addAttributes({ [addingAttr]: val });
+    setCurrentAttrs(selected.getAttributes() as Record<string, string>);
+    setAddingAttr(null);
+    setAddValue("");
+  }, [selected, addingAttr, addValue]);
+
+  const handleRemoveAttr = useCallback((attr: string) => {
+    if (!selected) return;
+    selected.removeAttributes([attr]);
+    setCurrentAttrs(selected.getAttributes() as Record<string, string>);
+  }, [selected]);
+
+  const startAdding = (attr: string, defaultVal?: string) => {
+    setAddingAttr(attr);
+    setAddValue(defaultVal ?? "");
+  };
+
+  // コントラスト計算
+  const ratio = contrastRatio(fgColor, bgColor);
+  const ratioStr = ratio.toFixed(2);
+  const passAA     = ratio >= 4.5;
+  const passAALarge = ratio >= 3;
+  const passAAA    = ratio >= 7;
+  const passAAALarge = ratio >= 4.5;
+
+  return (
+    <div className="a11y-panel">
+      {/* ── コントラストチェッカー ── */}
+      <section className="a11y-section">
+        <div className="a11y-section-title">
+          <i className="bi bi-circle-half" />
+          コントラストチェッカー
+        </div>
+        <div className="a11y-contrast-colors">
+          <label className="a11y-color-pick">
+            <span>前景色</span>
+            <div className="a11y-color-row">
+              <input
+                type="color"
+                value={fgColor}
+                onChange={(e) => setFgColor(e.target.value)}
+                className="a11y-color-input"
+              />
+              <input
+                type="text"
+                value={fgColor}
+                onChange={(e) => {
+                  const v = e.target.value;
+                  if (/^#[0-9a-fA-F]{6}$/.test(v)) setFgColor(v);
+                }}
+                className="a11y-color-hex"
+                maxLength={7}
+              />
+            </div>
+          </label>
+          <label className="a11y-color-pick">
+            <span>背景色</span>
+            <div className="a11y-color-row">
+              <input
+                type="color"
+                value={bgColor}
+                onChange={(e) => setBgColor(e.target.value)}
+                className="a11y-color-input"
+              />
+              <input
+                type="text"
+                value={bgColor}
+                onChange={(e) => {
+                  const v = e.target.value;
+                  if (/^#[0-9a-fA-F]{6}$/.test(v)) setBgColor(v);
+                }}
+                className="a11y-color-hex"
+                maxLength={7}
+              />
+            </div>
+          </label>
+        </div>
+
+        <div className="a11y-contrast-preview" style={{ color: fgColor, background: bgColor }}>
+          <span className="a11y-preview-lg">Aa</span>
+          <span className="a11y-preview-sm">サンプルテキスト</span>
+        </div>
+
+        <div className="a11y-ratio-display">
+          <span className="a11y-ratio-value">{ratioStr}</span>
+          <span className="a11y-ratio-label">: 1</span>
+        </div>
+
+        <div className="a11y-wcag-grid">
+          <div className={`a11y-wcag-cell ${passAA ? "pass" : "fail"}`}>
+            <span className="a11y-wcag-level">AA</span>
+            <span className="a11y-wcag-size">標準文字</span>
+            <span className="a11y-wcag-status">{passAA ? "✓ 合格" : "✗ 不合格"}</span>
+            <span className="a11y-wcag-req">≥ 4.5</span>
+          </div>
+          <div className={`a11y-wcag-cell ${passAALarge ? "pass" : "fail"}`}>
+            <span className="a11y-wcag-level">AA</span>
+            <span className="a11y-wcag-size">大文字</span>
+            <span className="a11y-wcag-status">{passAALarge ? "✓ 合格" : "✗ 不合格"}</span>
+            <span className="a11y-wcag-req">≥ 3.0</span>
+          </div>
+          <div className={`a11y-wcag-cell ${passAAA ? "pass" : "fail"}`}>
+            <span className="a11y-wcag-level">AAA</span>
+            <span className="a11y-wcag-size">標準文字</span>
+            <span className="a11y-wcag-status">{passAAA ? "✓ 合格" : "✗ 不合格"}</span>
+            <span className="a11y-wcag-req">≥ 7.0</span>
+          </div>
+          <div className={`a11y-wcag-cell ${passAAALarge ? "pass" : "fail"}`}>
+            <span className="a11y-wcag-level">AAA</span>
+            <span className="a11y-wcag-size">大文字</span>
+            <span className="a11y-wcag-status">{passAAALarge ? "✓ 合格" : "✗ 不合格"}</span>
+            <span className="a11y-wcag-req">≥ 4.5</span>
+          </div>
+        </div>
+      </section>
+
+      {/* ── ARIA 属性ヘルパー ── */}
+      <section className="a11y-section">
+        <div className="a11y-section-title">
+          <i className="bi bi-universal-access" />
+          ARIA 属性ヘルパー
+        </div>
+
+        {!selected ? (
+          <div className="a11y-empty">
+            <i className="bi bi-cursor" />
+            <p>コンポーネントを選択してください</p>
+          </div>
+        ) : (
+          <>
+            <div className="a11y-tag-badge">
+              <code>&lt;{tagName || "div"}&gt;</code>
+            </div>
+
+            {/* 現在の ARIA 属性 */}
+            {ariaAttrs.length > 0 && (
+              <div className="a11y-current-attrs">
+                <div className="a11y-attrs-label">現在の属性</div>
+                {ariaAttrs.map(([key, val]) => (
+                  <div key={key} className="a11y-attr-row">
+                    <span className="a11y-attr-key">{key}</span>
+                    <span className="a11y-attr-val">{String(val)}</span>
+                    <button
+                      className="a11y-attr-remove"
+                      onClick={() => handleRemoveAttr(key)}
+                      title="削除"
+                    >
+                      <i className="bi bi-x" />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* 属性追加フォーム */}
+            {addingAttr && (
+              <div className="a11y-add-form">
+                <span className="a11y-add-attr-name">{addingAttr}</span>
+                <input
+                  className="a11y-add-input"
+                  type="text"
+                  value={addValue}
+                  onChange={(e) => setAddValue(e.target.value)}
+                  placeholder="値を入力..."
+                  autoFocus
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") handleAddAttr();
+                    if (e.key === "Escape") { setAddingAttr(null); setAddValue(""); }
+                  }}
+                />
+                <div className="a11y-add-btns">
+                  <button className="a11y-add-cancel" onClick={() => { setAddingAttr(null); setAddValue(""); }}>
+                    キャンセル
+                  </button>
+                  <button className="a11y-add-ok" onClick={handleAddAttr}>
+                    追加
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {/* サジェスト一覧 */}
+            <div className="a11y-suggest-label">サジェスト</div>
+            <div className="a11y-suggestions">
+              {suggestions.map((s) => {
+                const alreadySet = s.attr in currentAttrs;
+                return (
+                  <div key={s.attr} className={`a11y-suggest-item${alreadySet ? " set" : ""}`}>
+                    <div className="a11y-suggest-info">
+                      <span className="a11y-suggest-attr">{s.attr}</span>
+                      <span className="a11y-suggest-hint">{s.hint}</span>
+                    </div>
+                    <button
+                      className="a11y-suggest-btn"
+                      disabled={alreadySet || !!addingAttr}
+                      onClick={() => startAdding(s.attr, s.defaultValue)}
+                      title={alreadySet ? "設定済み" : "追加"}
+                    >
+                      {alreadySet ? <i className="bi bi-check-lg" /> : <i className="bi bi-plus-lg" />}
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          </>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/designer/src/components/RightPanel.tsx
+++ b/designer/src/components/RightPanel.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useRef } from "react";
 import { useEditorMaybe } from "@grapesjs/react";
+import { A11yPanel } from "./A11yPanel";
 
-type TabId = "styles" | "traits" | "layers";
+type TabId = "styles" | "traits" | "layers" | "a11y";
 
 /**
  * GrapesJS のネイティブ UI を render() メソッドで取得し、
@@ -100,6 +101,13 @@ export function RightPanel() {
         >
           <i className="bi bi-stack" /> レイヤー
         </button>
+        <button
+          className={tab === "a11y" ? "active" : ""}
+          onClick={() => setTab("a11y")}
+          title="アクセシビリティ"
+        >
+          <i className="bi bi-universal-access" /> a11y
+        </button>
       </div>
 
       <div className="right-content">
@@ -140,6 +148,9 @@ export function RightPanel() {
             <div className="panel-block-title">レイヤー</div>
             <div ref={layerRef} />
           </div>
+        </div>
+        <div hidden={tab !== "a11y"}>
+          <A11yPanel />
         </div>
       </div>
     </div>

--- a/designer/src/styles/app.css
+++ b/designer/src/styles/app.css
@@ -1360,3 +1360,381 @@ body[data-gjs-dragging] .panel-left-wrapper.is-autohide .panel-left {
   padding: 12px 20px;
   border-top: 1px solid var(--dz-border);
 }
+
+/* ==========================================================================
+   A11y Panel
+   ========================================================================== */
+
+.a11y-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.a11y-section {
+  border-bottom: 1px solid var(--dz-border);
+  padding: 14px 12px;
+}
+
+.a11y-section-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--dz-text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 12px;
+}
+
+.a11y-section-title i {
+  font-size: 13px;
+  color: var(--dz-accent);
+}
+
+/* Contrast checker */
+.a11y-contrast-colors {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.a11y-color-pick {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 11px;
+  color: var(--dz-text-dim);
+}
+
+.a11y-color-row {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+}
+
+.a11y-color-input {
+  width: 32px;
+  height: 28px;
+  border: 1px solid var(--dz-border);
+  border-radius: 4px;
+  padding: 1px;
+  cursor: pointer;
+  background: transparent;
+  flex-shrink: 0;
+}
+
+.a11y-color-hex {
+  flex: 1;
+  background: var(--dz-bg-3);
+  border: 1px solid var(--dz-border);
+  border-radius: 4px;
+  color: var(--dz-text);
+  padding: 4px 6px;
+  font-size: 11px;
+  font-family: monospace;
+  outline: none;
+  min-width: 0;
+}
+
+.a11y-color-hex:focus {
+  border-color: var(--dz-accent);
+}
+
+.a11y-contrast-preview {
+  border-radius: 6px;
+  padding: 10px 14px;
+  margin-bottom: 10px;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  border: 1px solid var(--dz-border);
+}
+
+.a11y-preview-lg {
+  font-size: 22px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.a11y-preview-sm {
+  font-size: 12px;
+}
+
+.a11y-ratio-display {
+  text-align: center;
+  margin-bottom: 10px;
+}
+
+.a11y-ratio-value {
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--dz-text);
+}
+
+.a11y-ratio-label {
+  font-size: 14px;
+  color: var(--dz-text-dim);
+}
+
+.a11y-wcag-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+}
+
+.a11y-wcag-cell {
+  border-radius: 6px;
+  padding: 8px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto auto;
+  gap: 2px;
+  font-size: 11px;
+}
+
+.a11y-wcag-cell.pass {
+  background: rgba(34, 197, 94, 0.1);
+  border: 1px solid rgba(34, 197, 94, 0.25);
+}
+
+.a11y-wcag-cell.fail {
+  background: rgba(239, 68, 68, 0.08);
+  border: 1px solid rgba(239, 68, 68, 0.2);
+}
+
+.a11y-wcag-level {
+  font-weight: 700;
+  font-size: 12px;
+  color: var(--dz-text);
+  grid-column: 1;
+  grid-row: 1;
+}
+
+.a11y-wcag-size {
+  font-size: 10px;
+  color: var(--dz-text-dim);
+  grid-column: 1;
+  grid-row: 2;
+}
+
+.a11y-wcag-status {
+  font-weight: 600;
+  grid-column: 2;
+  grid-row: 1;
+  text-align: right;
+}
+
+.a11y-wcag-cell.pass .a11y-wcag-status { color: #22c55e; }
+.a11y-wcag-cell.fail .a11y-wcag-status { color: #ef4444; }
+
+.a11y-wcag-req {
+  font-size: 10px;
+  color: var(--dz-text-dim);
+  grid-column: 2;
+  grid-row: 2;
+  text-align: right;
+}
+
+/* ARIA helper */
+.a11y-empty {
+  text-align: center;
+  padding: 16px 8px;
+  color: var(--dz-text-dim);
+}
+.a11y-empty i {
+  font-size: 24px;
+  opacity: 0.4;
+}
+.a11y-empty p {
+  font-size: 11px;
+  margin: 6px 0 0;
+}
+
+.a11y-tag-badge {
+  margin-bottom: 10px;
+}
+
+.a11y-tag-badge code {
+  background: var(--dz-bg-3);
+  border: 1px solid var(--dz-border);
+  border-radius: 4px;
+  padding: 2px 8px;
+  font-size: 12px;
+  color: var(--dz-accent);
+}
+
+.a11y-current-attrs {
+  margin-bottom: 10px;
+}
+
+.a11y-attrs-label,
+.a11y-suggest-label {
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--dz-text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 5px;
+}
+
+.a11y-attr-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: var(--dz-bg-3);
+  border-radius: 4px;
+  padding: 4px 6px;
+  margin-bottom: 3px;
+  font-size: 11px;
+}
+
+.a11y-attr-key {
+  color: var(--dz-accent);
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.a11y-attr-val {
+  color: var(--dz-text-dim);
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.a11y-attr-remove {
+  background: none;
+  border: none;
+  color: var(--dz-text-dim);
+  cursor: pointer;
+  padding: 0 2px;
+  font-size: 12px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+.a11y-attr-remove:hover { color: var(--dz-danger); }
+
+.a11y-add-form {
+  background: var(--dz-bg-3);
+  border: 1px solid var(--dz-accent);
+  border-radius: 6px;
+  padding: 8px;
+  margin-bottom: 10px;
+}
+
+.a11y-add-attr-name {
+  display: block;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--dz-accent);
+  margin-bottom: 5px;
+}
+
+.a11y-add-input {
+  width: 100%;
+  background: var(--dz-bg);
+  border: 1px solid var(--dz-border);
+  border-radius: 4px;
+  color: var(--dz-text);
+  padding: 5px 8px;
+  font-size: 12px;
+  outline: none;
+  box-sizing: border-box;
+  margin-bottom: 6px;
+}
+.a11y-add-input:focus { border-color: var(--dz-accent); }
+
+.a11y-add-btns {
+  display: flex;
+  justify-content: flex-end;
+  gap: 4px;
+}
+
+.a11y-add-cancel,
+.a11y-add-ok {
+  border: none;
+  border-radius: 4px;
+  font-size: 11px;
+  padding: 3px 10px;
+  cursor: pointer;
+}
+.a11y-add-cancel {
+  background: var(--dz-bg-3);
+  color: var(--dz-text-dim);
+  border: 1px solid var(--dz-border);
+}
+.a11y-add-ok {
+  background: var(--dz-accent);
+  color: #fff;
+}
+.a11y-add-ok:hover { background: var(--dz-accent-hover); }
+
+.a11y-suggestions {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.a11y-suggest-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--dz-bg-3);
+  border-radius: 4px;
+  padding: 5px 6px;
+  font-size: 11px;
+}
+
+.a11y-suggest-item.set {
+  opacity: 0.5;
+}
+
+.a11y-suggest-info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.a11y-suggest-attr {
+  font-weight: 600;
+  color: var(--dz-accent);
+  font-family: monospace;
+  font-size: 11px;
+}
+
+.a11y-suggest-hint {
+  color: var(--dz-text-dim);
+  font-size: 10px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.a11y-suggest-btn {
+  background: none;
+  border: 1px solid var(--dz-border);
+  border-radius: 4px;
+  color: var(--dz-text-dim);
+  cursor: pointer;
+  width: 22px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  flex-shrink: 0;
+}
+.a11y-suggest-btn:not(:disabled):hover {
+  background: var(--dz-accent);
+  color: #fff;
+  border-color: var(--dz-accent);
+}
+.a11y-suggest-btn:disabled {
+  cursor: default;
+  opacity: 0.4;
+}

--- a/designer/src/utils/uuid.ts
+++ b/designer/src/utils/uuid.ts
@@ -1,0 +1,17 @@
+/**
+ * HTTP（非セキュアコンテキスト）でも動作する UUID v4 生成
+ * crypto.randomUUID() は HTTPS または localhost でのみ使用可能なため、
+ * フォールバックとして crypto.getRandomValues() を使用する。
+ */
+export function generateUUID(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  // crypto.getRandomValues はセキュアコンテキスト不要
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
+  bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant 1
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}


### PR DESCRIPTION
## Summary
- WCAG コントラストチェッカーを実装（前景色・背景色を入力し AA/AAA 合否をリアルタイム表示）
- ARIA 属性ヘルパーを実装（選択コンポーネントのタグに応じたサジェスト表示、属性の追加・削除）
- RightPanel に a11y タブを追加（スタイル・属性・レイヤーに続く 4 番目のタブ）
- uuid.ts を追加（HTTP 環境での crypto.randomUUID() フォールバック対応）

## Test plan
- [ ] a11y タブをクリックしてコントラストチェッカーが表示されることを確認
- [ ] 前景色・背景色を変更してコントラスト比がリアルタイムで更新されることを確認
- [ ] コンポーネントを選択して ARIA サジェストが表示されることを確認
- [ ] ARIA 属性を追加・削除できることを確認

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)