### PR TITLE
feat(designer): ER図の自動生成・編集機能の追加 (#41)

### DIFF
--- a/designer-mcp/src/index.ts
+++ b/designer-mcp/src/index.ts
@@ -9,7 +9,7 @@ import {
 import { wsBridge } from "./wsBridge.js";
 import { tools } from "./tools.js";
 import { htmlToReact, toPascalCase } from "./reactExporter.js";
-import { readProject, readCustomBlocks, readTable, writeTable, deleteTable as deleteTableFile, writeProject } from "./projectStorage.js";
+import { readProject, readCustomBlocks, readTable, writeTable, deleteTable as deleteTableFile, writeProject, readErLayout } from "./projectStorage.js";
 
 // 親プロセス（Claude Code）が死んだら自動終了
 function setupLifecycle(): void {
@@ -590,6 +590,101 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           return { content: [{ type: "text", text: "DDL生成対象のテーブルが見つかりません。" }] };
         }
         return { content: [{ type: "text", text: `\`\`\`sql\n${ddlParts.join("\n\n")}\n\`\`\`` }] };
+      }
+
+      // ── ER図 ──
+
+      case "designer__get_er_diagram":
+      case "designer__generate_er_mermaid": {
+        const project = (await readProject() ?? {}) as Record<string, unknown>;
+        const tableMetas = ((project.tables ?? []) as Array<{ id: string; name: string }>);
+        const allTables: Array<Record<string, unknown>> = [];
+        for (const tm of tableMetas) {
+          const td = await readTable(tm.id);
+          if (td) allTables.push(td as Record<string, unknown>);
+        }
+        const erLayout = await readErLayout() as { logicalRelations?: Array<Record<string, unknown>> } | null;
+
+        // Derive relations from FK
+        const relations: Array<{ source: string; sourceCol: string; target: string; targetCol: string; physical: boolean }> = [];
+        const tableNameMap = new Map(allTables.map((t) => [t.name as string, t]));
+        for (const table of allTables) {
+          const cols = (table.columns ?? []) as Array<Record<string, unknown>>;
+          for (const col of cols) {
+            const fk = col.foreignKey as { tableId: string; columnName: string } | undefined;
+            if (!fk) continue;
+            const target = tableNameMap.get(fk.tableId);
+            if (!target) continue;
+            relations.push({
+              source: table.name as string,
+              sourceCol: col.name as string,
+              target: target.name as string,
+              targetCol: fk.columnName,
+              physical: true,
+            });
+          }
+        }
+        // Add logical relations
+        for (const lr of erLayout?.logicalRelations ?? []) {
+          const srcTable = allTables.find((t) => t.id === lr.sourceTableId);
+          const tgtTable = allTables.find((t) => t.id === lr.targetTableId);
+          if (srcTable && tgtTable) {
+            relations.push({
+              source: srcTable.name as string,
+              sourceCol: lr.sourceColumnName as string,
+              target: tgtTable.name as string,
+              targetCol: lr.targetColumnName as string,
+              physical: false,
+            });
+          }
+        }
+
+        // Build Mermaid
+        const mLines = ["erDiagram"];
+        for (const table of allTables) {
+          mLines.push(`    ${table.name} {`);
+          for (const col of (table.columns ?? []) as Array<Record<string, unknown>>) {
+            const markers: string[] = [];
+            if (col.primaryKey) markers.push("PK");
+            if (col.foreignKey) markers.push("FK");
+            const m = markers.length > 0 ? ` ${markers.join(",")}` : "";
+            mLines.push(`        ${col.dataType} ${col.name}${m}`);
+          }
+          mLines.push("    }");
+        }
+        for (const rel of relations) {
+          const card = rel.physical ? "||--o{" : "..o{";
+          mLines.push(`    ${rel.target} ${card} ${rel.source} : "${rel.sourceCol}"`);
+        }
+        const mermaid = mLines.join("\n");
+
+        if (name === "designer__generate_er_mermaid") {
+          return { content: [{ type: "text", text: `\`\`\`mermaid\n${mermaid}\n\`\`\`` }] };
+        }
+
+        // Full ER data
+        const relLines = relations.map(
+          (r) => `  - ${r.source}.${r.sourceCol} → ${r.target}.${r.targetCol}${r.physical ? "" : " (論理)"}`
+        );
+        const tableLines = allTables.map(
+          (t) => `  - ${t.name}（${t.logicalName}）${(t.columns as unknown[]).length}カラム`
+        );
+        return {
+          content: [{
+            type: "text",
+            text: [
+              `# ER図`,
+              `\n## テーブル (${allTables.length}件)`,
+              ...tableLines,
+              `\n## リレーション (${relations.length}件)`,
+              ...relLines,
+              `\n## Mermaid`,
+              "```mermaid",
+              mermaid,
+              "```",
+            ].join("\n"),
+          }],
+        };
       }
 
       default:

--- a/designer-mcp/src/projectStorage.ts
+++ b/designer-mcp/src/projectStorage.ts
@@ -17,6 +17,7 @@ const SCREENS_DIR = path.join(DATA_DIR, "screens");
 const TABLES_DIR = path.join(DATA_DIR, "tables");
 export const PROJECT_FILE = path.join(DATA_DIR, "project.json");
 export const CUSTOM_BLOCKS_FILE = path.join(DATA_DIR, "custom-blocks.json");
+export const ER_LAYOUT_FILE = path.join(DATA_DIR, "er-layout.json");
 
 /** data/ と data/screens/ と data/tables/ を作成（既存なら無視） */
 export async function ensureDataDir(): Promise<void> {
@@ -77,6 +78,17 @@ export async function readCustomBlocks(): Promise<unknown[]> {
 export async function writeCustomBlocks(blocks: unknown[]): Promise<void> {
   await ensureDataDir();
   await writeJSON(CUSTOM_BLOCKS_FILE, blocks);
+}
+
+/** er-layout.json を読み込み */
+export async function readErLayout(): Promise<unknown | null> {
+  return readJSON<unknown>(ER_LAYOUT_FILE);
+}
+
+/** er-layout.json を書き込み */
+export async function writeErLayout(data: unknown): Promise<void> {
+  await ensureDataDir();
+  await writeJSON(ER_LAYOUT_FILE, data);
 }
 
 /** tables/{tableId}.json を読み込み */

--- a/designer-mcp/src/tools.ts
+++ b/designer-mcp/src/tools.ts
@@ -488,4 +488,27 @@ export const tools = [
       required: [],
     },
   },
+
+  // ── ER図ツール ──
+
+  {
+    name: "designer__get_er_diagram",
+    description:
+      "ER図データ（全テーブル・リレーション・Mermaid記法）を取得します。テーブル設計書の外部キー定義からリレーションを自動検出します。",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+      required: [],
+    },
+  },
+  {
+    name: "designer__generate_er_mermaid",
+    description:
+      "Mermaid ER図記法を生成します。テーブル設計書の外部キー定義と論理リレーションから生成します。",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+      required: [],
+    },
+  },
 ];

--- a/designer-mcp/src/wsBridge.ts
+++ b/designer-mcp/src/wsBridge.ts
@@ -14,6 +14,8 @@ import {
   readTable,
   writeTable,
   deleteTable as deleteTableFile,
+  readErLayout,
+  writeErLayout,
 } from "./projectStorage.js";
 
 type Command = { id: string; method: string; params?: unknown };
@@ -331,6 +333,18 @@ class WsBridge extends EventEmitter {
           await deleteTableFile(tableId);
           respond({ success: true });
           this.broadcast("tableChanged", { tableId, deleted: true }, clientId);
+          break;
+        }
+        case "loadErLayout": {
+          const layoutData = await readErLayout();
+          respond(layoutData);
+          break;
+        }
+        case "saveErLayout": {
+          const { data } = (params ?? {}) as { data: unknown };
+          await writeErLayout(data);
+          respond({ success: true });
+          this.broadcast("erLayoutChanged", {}, clientId);
           break;
         }
         default:

--- a/designer/src/App.tsx
+++ b/designer/src/App.tsx
@@ -3,6 +3,7 @@ import { FlowEditor } from "./components/flow/FlowEditor";
 import { ScreenDesigner } from "./components/ScreenDesigner";
 import { TableListView } from "./components/table/TableListView";
 import { TableEditor } from "./components/table/TableEditor";
+import { ErDiagram } from "./components/table/ErDiagram";
 import "./styles/app.css";
 
 function App() {
@@ -12,6 +13,7 @@ function App() {
       <Route path="/design/:screenId" element={<ScreenDesigner />} />
       <Route path="/tables" element={<TableListView />} />
       <Route path="/tables/:tableId" element={<TableEditor />} />
+      <Route path="/er" element={<ErDiagram />} />
     </Routes>
   );
 }

--- a/designer/src/components/flow/FlowTopbar.tsx
+++ b/designer/src/components/flow/FlowTopbar.tsx
@@ -105,6 +105,9 @@ export function FlowTopbar({
           <button className="global-nav-btn" onClick={() => navigate("/tables")}>
             <i className="bi bi-table" /> テーブル設計
           </button>
+          <button className="global-nav-btn" onClick={() => navigate("/er")}>
+            <i className="bi bi-share" /> ER図
+          </button>
         </nav>
       </div>
 

--- a/designer/src/components/table/ErDiagram.tsx
+++ b/designer/src/components/table/ErDiagram.tsx
@@ -1,0 +1,419 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  ReactFlow,
+  ReactFlowProvider,
+  Background,
+  MiniMap,
+  useNodesState,
+  useEdgesState,
+  useReactFlow,
+  type Edge as RFEdge,
+  type Node as RFNode,
+  type NodeMouseHandler,
+  MarkerType,
+  BackgroundVariant,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+
+import ErTableNodeComponent, { type ErTableNodeData } from "./ErTableNode";
+import { TableTopbar } from "./TableTopbar";
+import type { TableDefinition, ErLayout, ErLogicalRelation, ErCardinality, SqlDialect } from "../../types/table";
+import { CARDINALITY_LABELS } from "../../types/table";
+import { listTables, loadTable } from "../../store/tableStore";
+import { loadErLayout, saveErLayout } from "../../store/erLayoutStore";
+import { loadProject } from "../../store/flowStore";
+import { getAllRelations, autoLayout, generateErMermaid } from "../../utils/erUtils";
+import { mcpBridge } from "../../mcp/mcpBridge";
+import { generateUUID } from "../../utils/uuid";
+import html2canvas from "html2canvas";
+import "../../styles/er.css";
+
+const nodeTypes = { erTableNode: ErTableNodeComponent };
+
+function ErDiagramInner() {
+  const navigate = useNavigate();
+  const { fitView } = useReactFlow();
+  const [nodes, setNodes, onNodesChange] = useNodesState<RFNode>([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState<RFEdge>([]);
+  const [projectName, setProjectName] = useState("プロジェクト");
+  const [tables, setTables] = useState<TableDefinition[]>([]);
+  const [layout, setLayout] = useState<ErLayout | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [showAddRelation, setShowAddRelation] = useState(false);
+  const [showExport, setShowExport] = useState(false);
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const layoutRef = useRef<ErLayout | null>(null);
+  const canvasRef = useRef<HTMLDivElement>(null);
+
+  // Load data
+  useEffect(() => {
+    mcpBridge.startWithoutEditor();
+    (async () => {
+      const p = await loadProject();
+      setProjectName(p.name);
+      const metas = await listTables();
+      const allTables: TableDefinition[] = [];
+      for (const m of metas) {
+        const td = await loadTable(m.id);
+        if (td) allTables.push(td);
+      }
+      setTables(allTables);
+      const ly = await loadErLayout();
+      setLayout(ly);
+      layoutRef.current = ly;
+      setIsLoading(false);
+    })();
+  }, []);
+
+  // Build nodes and edges when data changes
+  useEffect(() => {
+    if (isLoading || tables.length === 0) return;
+
+    const positions = layout?.positions ?? {};
+    const needsAutoLayout = tables.some((t) => !positions[t.id]);
+
+    let finalPositions = positions;
+    if (needsAutoLayout) {
+      const relations = getAllRelations(tables, layout);
+      const autoPos = autoLayout(tables, relations);
+      finalPositions = { ...autoPos, ...positions };
+    }
+
+    const rfNodes: RFNode[] = tables.map((t) => ({
+      id: t.id,
+      type: "erTableNode",
+      position: finalPositions[t.id] ?? { x: 0, y: 0 },
+      data: {
+        tableId: t.id,
+        name: t.name,
+        logicalName: t.logicalName,
+        category: t.category,
+        columns: t.columns,
+      } satisfies ErTableNodeData,
+    }));
+    setNodes(rfNodes);
+
+    const relations = getAllRelations(tables, layout);
+    const rfEdges: RFEdge[] = relations.map((rel) => ({
+      id: rel.id,
+      source: rel.sourceTableId,
+      target: rel.targetTableId,
+      sourceHandle: "right",
+      targetHandle: "left",
+      label: rel.sourceColumnName,
+      markerEnd: { type: MarkerType.ArrowClosed, width: 16, height: 16 },
+      style: {
+        strokeWidth: 2,
+        stroke: rel.physical ? "#64748b" : "#7c6bff",
+        strokeDasharray: rel.physical ? undefined : "6 4",
+      },
+      labelStyle: { fontSize: 11, fill: rel.physical ? "#475569" : "#7c6bff" },
+      labelBgStyle: { fill: "#fff", fillOpacity: 0.9 },
+      labelBgPadding: [6, 4] as [number, number],
+      labelBgBorderRadius: 4,
+      data: { physical: rel.physical, cardinality: rel.cardinality },
+    }));
+    setEdges(rfEdges);
+
+    // Fit view on first load
+    setTimeout(() => fitView({ padding: 0.3, maxZoom: 1, duration: 200 }), 100);
+  }, [isLoading, tables, layout, setNodes, setEdges, fitView]);
+
+  // Save positions on node drag
+  const debouncedSave = useCallback((ly: ErLayout) => {
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    saveTimerRef.current = setTimeout(() => saveErLayout(ly), 300);
+  }, []);
+
+  const onNodeDragStop = useCallback((_: unknown, node: RFNode) => {
+    const ly = layoutRef.current ?? { positions: {}, logicalRelations: [], updatedAt: "" };
+    ly.positions[node.id] = { x: Math.round(node.position.x), y: Math.round(node.position.y) };
+    layoutRef.current = ly;
+    setLayout({ ...ly });
+    debouncedSave(ly);
+  }, [debouncedSave]);
+
+  // Double click to navigate to table editor
+  const onNodeDoubleClick: NodeMouseHandler = useCallback((_event, node) => {
+    navigate(`/tables/${node.id}`);
+  }, [navigate]);
+
+  // Auto layout
+  const handleAutoLayout = useCallback(() => {
+    const relations = getAllRelations(tables, layout);
+    const autoPos = autoLayout(tables, relations);
+    const ly = layoutRef.current ?? { positions: {}, logicalRelations: [], updatedAt: "" };
+    ly.positions = autoPos;
+    layoutRef.current = ly;
+    setLayout({ ...ly });
+    debouncedSave(ly);
+
+    setNodes((nds) => nds.map((n) => ({
+      ...n,
+      position: autoPos[n.id] ?? n.position,
+    })));
+    setTimeout(() => fitView({ padding: 0.3, maxZoom: 1, duration: 300 }), 50);
+  }, [tables, layout, setNodes, fitView, debouncedSave]);
+
+  // Add logical relation
+  const handleAddLogicalRelation = useCallback((rel: Omit<ErLogicalRelation, "id">) => {
+    const ly = layoutRef.current ?? { positions: {}, logicalRelations: [], updatedAt: "" };
+    if (!ly.logicalRelations) ly.logicalRelations = [];
+    ly.logicalRelations.push({ ...rel, id: `lr-${generateUUID()}` });
+    layoutRef.current = ly;
+    setLayout({ ...ly });
+    debouncedSave(ly);
+    setShowAddRelation(false);
+  }, [debouncedSave]);
+
+  // Remove logical relation
+  const handleRemoveEdge = useCallback((edgeId: string) => {
+    const ly = layoutRef.current;
+    if (!ly?.logicalRelations) return;
+    ly.logicalRelations = ly.logicalRelations.filter((r) => r.id !== edgeId);
+    layoutRef.current = ly;
+    setLayout({ ...ly });
+    debouncedSave(ly);
+  }, [debouncedSave]);
+
+  // Export Mermaid
+  const handleExportMermaid = useCallback(() => {
+    const relations = getAllRelations(tables, layout);
+    const mermaid = generateErMermaid(tables, relations);
+    navigator.clipboard.writeText(mermaid);
+    setShowExport(false);
+  }, [tables, layout]);
+
+  // Export PNG
+  const handleExportPng = useCallback(async () => {
+    setShowExport(false);
+    const el = canvasRef.current?.querySelector(".react-flow__viewport") as HTMLElement | null;
+    if (!el) return;
+    const canvas = await html2canvas(el, { backgroundColor: "#1a1a2e", scale: 2, logging: false, useCORS: true });
+    const url = canvas.toDataURL("image/png");
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${projectName}_er.png`;
+    a.click();
+  }, [projectName]);
+
+  if (isLoading) {
+    return (
+      <div className="er-diagram-page">
+        <TableTopbar projectName={projectName} />
+        <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", color: "#888" }}>
+          <i className="bi bi-hourglass-split" /> 読み込み中...
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="er-diagram-page">
+      <TableTopbar projectName={projectName} />
+
+      <div className="er-diagram-canvas" ref={canvasRef}>
+        {tables.length === 0 ? (
+          <div style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 12, color: "#777", height: "100%" }}>
+            <i className="bi bi-diagram-3" style={{ fontSize: 48, color: "#555" }} />
+            <p>テーブル定義がまだありません</p>
+            <button className="tbl-btn tbl-btn-primary" onClick={() => navigate("/tables")}>
+              <i className="bi bi-table" /> テーブル設計へ
+            </button>
+          </div>
+        ) : (
+          <ReactFlow
+            nodes={nodes}
+            edges={edges}
+            onNodesChange={onNodesChange}
+            onEdgesChange={onEdgesChange}
+            nodeTypes={nodeTypes}
+            onNodeDragStop={onNodeDragStop}
+            onNodeDoubleClick={onNodeDoubleClick}
+            onEdgeDoubleClick={(_e, edge) => {
+              if (!(edge.data as { physical?: boolean })?.physical) {
+                if (confirm("この論理リレーションを削除しますか？")) {
+                  handleRemoveEdge(edge.id);
+                }
+              }
+            }}
+            deleteKeyCode={[]}
+            fitView
+            fitViewOptions={{ padding: 0.3, maxZoom: 1 }}
+            defaultEdgeOptions={{
+              markerEnd: { type: MarkerType.ArrowClosed, width: 16, height: 16 },
+              style: { strokeWidth: 2, stroke: "#64748b" },
+            }}
+          >
+            <Background variant={BackgroundVariant.Dots} gap={20} size={1} color="#334155" />
+            <MiniMap
+              nodeColor="#7c6bff"
+              maskColor="rgba(26,26,46,0.7)"
+              style={{ borderRadius: 8 }}
+            />
+          </ReactFlow>
+        )}
+      </div>
+
+      {/* Toolbar */}
+      <div className="er-toolbar">
+        <div className="er-toolbar-group">
+          <button className="tbl-btn tbl-btn-ghost tbl-btn-sm" onClick={handleAutoLayout} title="自動配置">
+            <i className="bi bi-grid-3x3-gap" /> 自動配置
+          </button>
+          <button className="tbl-btn tbl-btn-ghost tbl-btn-sm" onClick={() => fitView({ padding: 0.3, maxZoom: 1, duration: 300 })} title="全体表示">
+            <i className="bi bi-arrows-fullscreen" /> 全体表示
+          </button>
+        </div>
+        <div className="er-toolbar-sep" />
+        <button
+          className="tbl-btn tbl-btn-ghost tbl-btn-sm"
+          onClick={() => setShowAddRelation(true)}
+          title="論理リレーション追加"
+        >
+          <i className="bi bi-link-45deg" /> 論理リレーション追加
+        </button>
+        <div className="er-toolbar-sep" />
+        <div style={{ position: "relative" }}>
+          <button className="tbl-btn tbl-btn-ghost tbl-btn-sm" onClick={() => setShowExport(!showExport)}>
+            <i className="bi bi-download" /> エクスポート
+          </button>
+          {showExport && (
+            <div className="er-export-menu">
+              <button onClick={handleExportMermaid}>
+                <i className="bi bi-clipboard" /> Mermaid をコピー
+              </button>
+              <button onClick={handleExportPng}>
+                <i className="bi bi-image" /> PNG ダウンロード
+              </button>
+            </div>
+          )}
+        </div>
+        <span className="er-toolbar-info">
+          {tables.length} テーブル / {edges.length} リレーション
+          <span style={{ marginLeft: 8, fontSize: 11, color: "#666" }}>ダブルクリックでテーブル編集</span>
+        </span>
+      </div>
+
+      {/* Add Logical Relation Modal */}
+      {showAddRelation && (
+        <AddRelationModal
+          tables={tables}
+          onAdd={handleAddLogicalRelation}
+          onClose={() => setShowAddRelation(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+export function ErDiagram() {
+  return (
+    <ReactFlowProvider>
+      <ErDiagramInner />
+    </ReactFlowProvider>
+  );
+}
+
+// ── 論理リレーション追加モーダル ──────────────────────────────────────────
+
+function AddRelationModal({
+  tables, onAdd, onClose,
+}: {
+  tables: TableDefinition[];
+  onAdd: (rel: Omit<ErLogicalRelation, "id">) => void;
+  onClose: () => void;
+}) {
+  const [srcTableId, setSrcTableId] = useState("");
+  const [srcCol, setSrcCol] = useState("");
+  const [tgtTableId, setTgtTableId] = useState("");
+  const [tgtCol, setTgtCol] = useState("");
+  const [cardinality, setCardinality] = useState<ErCardinality>("one-to-many");
+
+  const srcTable = tables.find((t) => t.id === srcTableId);
+  const tgtTable = tables.find((t) => t.id === tgtTableId);
+
+  const handleSubmit = () => {
+    if (!srcTableId || !srcCol || !tgtTableId || !tgtCol) return;
+    onAdd({
+      sourceTableId: srcTableId,
+      sourceColumnName: srcCol,
+      targetTableId: tgtTableId,
+      targetColumnName: tgtCol,
+      cardinality,
+    });
+  };
+
+  return (
+    <div className="tbl-modal-overlay" onClick={onClose}>
+      <div className="er-relation-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="tbl-modal-title">
+          <i className="bi bi-link-45deg" /> 論理リレーション追加
+        </div>
+        <p style={{ fontSize: 12, color: "#999", marginBottom: 16 }}>
+          FK制約なしの論理的なリレーションをER図上に追加します（点線で表示）
+        </p>
+
+        <div className="er-relation-row">
+          <div style={{ flex: 1 }}>
+            <label className="tbl-field">
+              <span>参照元テーブル（FK側）</span>
+              <select value={srcTableId} onChange={(e) => { setSrcTableId(e.target.value); setSrcCol(""); }}>
+                <option value="">選択...</option>
+                {tables.map((t) => <option key={t.id} value={t.id}>{t.name}（{t.logicalName}）</option>)}
+              </select>
+            </label>
+            <label className="tbl-field">
+              <span>参照元カラム</span>
+              <select value={srcCol} onChange={(e) => setSrcCol(e.target.value)} disabled={!srcTable}>
+                <option value="">選択...</option>
+                {srcTable?.columns.map((c) => <option key={c.id} value={c.name}>{c.name}（{c.logicalName}）</option>)}
+              </select>
+            </label>
+          </div>
+          <span className="er-relation-arrow">→</span>
+          <div style={{ flex: 1 }}>
+            <label className="tbl-field">
+              <span>参照先テーブル</span>
+              <select value={tgtTableId} onChange={(e) => { setTgtTableId(e.target.value); setTgtCol(""); }}>
+                <option value="">選択...</option>
+                {tables.map((t) => <option key={t.id} value={t.id}>{t.name}（{t.logicalName}）</option>)}
+              </select>
+            </label>
+            <label className="tbl-field">
+              <span>参照先カラム</span>
+              <select value={tgtCol} onChange={(e) => setTgtCol(e.target.value)} disabled={!tgtTable}>
+                <option value="">選択...</option>
+                {tgtTable?.columns.map((c) => {
+                  const icons = c.primaryKey ? "🔑 " : c.unique ? "🔗 " : "";
+                  return <option key={c.id} value={c.name}>{icons}{c.name}（{c.logicalName}）</option>;
+                })}
+              </select>
+            </label>
+          </div>
+        </div>
+
+        <label className="tbl-field">
+          <span>カーディナリティ</span>
+          <select value={cardinality} onChange={(e) => setCardinality(e.target.value as ErCardinality)}>
+            {Object.entries(CARDINALITY_LABELS).map(([k, v]) => (
+              <option key={k} value={k}>{v}</option>
+            ))}
+          </select>
+        </label>
+
+        <div className="tbl-modal-btns">
+          <button className="tbl-btn tbl-btn-ghost" onClick={onClose}>キャンセル</button>
+          <button
+            className="tbl-btn tbl-btn-primary"
+            onClick={handleSubmit}
+            disabled={!srcTableId || !srcCol || !tgtTableId || !tgtCol}
+          >
+            追加
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/designer/src/components/table/ErTableNode.tsx
+++ b/designer/src/components/table/ErTableNode.tsx
@@ -1,0 +1,95 @@
+import { memo, useState, useCallback } from "react";
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+import type { TableColumn } from "../../types/table";
+
+export interface ErTableNodeData {
+  tableId: string;
+  name: string;
+  logicalName: string;
+  category?: string;
+  columns: TableColumn[];
+  [key: string]: unknown;
+}
+
+function ErTableNodeComponent({ data, selected }: NodeProps) {
+  const d = data as unknown as ErTableNodeData;
+  const [expanded, setExpanded] = useState(false);
+
+  const pkColumns = d.columns.filter((c) => c.primaryKey);
+  const fkColumns = d.columns.filter((c) => c.foreignKey && !c.primaryKey);
+  const otherColumns = d.columns.filter((c) => !c.primaryKey && !c.foreignKey);
+  const hiddenCount = otherColumns.length;
+
+  const toggleExpand = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    setExpanded((v) => !v);
+  }, []);
+
+  const dataTypeShort = (col: TableColumn) => {
+    const dt = col.dataType;
+    if (dt === "VARCHAR" || dt === "CHAR") return `${dt}(${col.length ?? ""})`;
+    if (dt === "DECIMAL") return `DEC(${col.length ?? ""},${col.scale ?? ""})`;
+    return dt;
+  };
+
+  return (
+    <>
+      <Handle type="target" position={Position.Top} id="top" className="er-handle" />
+      <Handle type="target" position={Position.Left} id="left" className="er-handle" />
+
+      <div className={`er-table-node${selected ? " selected" : ""}`}>
+        {/* Header */}
+        <div className="er-node-header">
+          <span className="er-node-name">{d.name}</span>
+          {d.category && <span className="er-node-category">{d.category}</span>}
+        </div>
+        <div className="er-node-logical">{d.logicalName}</div>
+
+        {/* PK columns */}
+        <div className="er-node-columns">
+          {pkColumns.map((col) => (
+            <div key={col.id} className="er-col pk">
+              <i className="bi bi-key-fill er-col-icon pk-icon" />
+              <span className="er-col-name">{col.name}</span>
+              <span className="er-col-type">{dataTypeShort(col)}</span>
+            </div>
+          ))}
+
+          {/* FK columns */}
+          {fkColumns.map((col) => (
+            <div key={col.id} className="er-col fk">
+              <i className="bi bi-link-45deg er-col-icon fk-icon" />
+              <span className="er-col-name">{col.name}</span>
+              <span className="er-col-type">{dataTypeShort(col)}</span>
+            </div>
+          ))}
+
+          {/* Other columns (expandable) */}
+          {expanded && otherColumns.map((col) => (
+            <div key={col.id} className="er-col">
+              <span className="er-col-icon-space" />
+              <span className="er-col-name">{col.name}</span>
+              <span className="er-col-type">{dataTypeShort(col)}</span>
+            </div>
+          ))}
+
+          {/* Expand/collapse toggle */}
+          {hiddenCount > 0 && (
+            <div className="er-col-toggle" onClick={toggleExpand}>
+              {expanded ? (
+                <><i className="bi bi-chevron-up" /> 折りたたむ</>
+              ) : (
+                <><i className="bi bi-chevron-down" /> 他 {hiddenCount} カラム</>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <Handle type="source" position={Position.Bottom} id="bottom" className="er-handle" />
+      <Handle type="source" position={Position.Right} id="right" className="er-handle" />
+    </>
+  );
+}
+
+export default memo(ErTableNodeComponent);

--- a/designer/src/components/table/TableEditor.tsx
+++ b/designer/src/components/table/TableEditor.tsx
@@ -20,7 +20,7 @@ export function TableEditor() {
   const [ddlDialect, setDdlDialect] = useState<SqlDialect>("postgresql");
   const [editingMeta, setEditingMeta] = useState(false);
   const [projectName, setProjectName] = useState("プロジェクト");
-  const [allTables, setAllTables] = useState<Array<{ id: string; name: string }>>([]);
+  const [allTables, setAllTables] = useState<TableDefinition[]>([]);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const autoSave = useCallback((t: TableDefinition) => {
@@ -40,7 +40,12 @@ export function TableEditor() {
       const p = await loadProject();
       setProjectName(p.name);
       const tl = await listTables();
-      setAllTables(tl.map((m) => ({ id: m.id, name: m.name })));
+      const allTds: TableDefinition[] = [];
+      for (const m of tl) {
+        const td = await loadTable(m.id);
+        if (td) allTds.push(td);
+      }
+      setAllTables(allTds);
     })();
   }, [tableId, navigate]);
 
@@ -198,7 +203,7 @@ function ColumnsTab({
 }: {
   table: TableDefinition;
   update: (fn: (t: TableDefinition) => void) => void;
-  allTables: Array<{ id: string; name: string }>;
+  allTables: TableDefinition[];
 }) {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [showTemplates, setShowTemplates] = useState(false);
@@ -376,7 +381,7 @@ function ColumnRow({
   isEditing: boolean;
   isFirst: boolean;
   isLast: boolean;
-  allTables: Array<{ id: string; name: string }>;
+  allTables: TableDefinition[];
   onEdit: () => void;
   onUpdate: (patch: Partial<TableColumn>) => void;
   onRemove: () => void;
@@ -441,7 +446,7 @@ function ColumnDetailEditor({
 }: {
   col: TableColumn;
   onUpdate: (patch: Partial<TableColumn>) => void;
-  allTables: Array<{ id: string; name: string }>;
+  allTables: TableDefinition[];
   showLength: boolean;
   showScale: boolean;
 }) {
@@ -544,42 +549,82 @@ function ColumnDetailEditor({
           />
         </label>
 
-        <div className="column-fk-section">
-          <label className="column-flag-label">
-            <input
-              type="checkbox"
-              checked={hasFk}
-              onChange={(e) => {
-                if (e.target.checked) {
-                  onUpdate({ foreignKey: { tableId: "", columnName: "" } });
-                } else {
-                  onUpdate({ foreignKey: undefined });
-                }
-              }}
-            />
-            外部キー (FK)
-          </label>
-          {hasFk && (
-            <div className="column-fk-fields">
-              <select
-                value={col.foreignKey?.tableId ?? ""}
-                onChange={(e) => onUpdate({ foreignKey: { ...col.foreignKey!, tableId: e.target.value } })}
-              >
-                <option value="">参照先テーブル...</option>
-                {allTables.map((t) => (
-                  <option key={t.id} value={t.name}>{t.name}</option>
-                ))}
-              </select>
-              <input
-                type="text"
-                value={col.foreignKey?.columnName ?? ""}
-                onChange={(e) => onUpdate({ foreignKey: { ...col.foreignKey!, columnName: e.target.value } })}
-                placeholder="参照先カラム名 (例: id)"
-              />
-            </div>
-          )}
-        </div>
+        <ForeignKeyEditor col={col} allTables={allTables} onUpdate={onUpdate} />
       </div>
+    </div>
+  );
+}
+
+// ── FK入力コンポーネント ──────────────────────────────────────────────────────
+
+function ForeignKeyEditor({
+  col, allTables, onUpdate,
+}: {
+  col: TableColumn;
+  allTables: TableDefinition[];
+  onUpdate: (patch: Partial<TableColumn>) => void;
+}) {
+  const hasFk = !!col.foreignKey;
+  const refTable = allTables.find((t) => t.name === col.foreignKey?.tableId);
+
+  const handleTableChange = (tableName: string) => {
+    const table = allTables.find((t) => t.name === tableName);
+    // PKカラムを自動選択
+    const pkCol = table?.columns.find((c) => c.primaryKey);
+    onUpdate({
+      foreignKey: {
+        tableId: tableName,
+        columnName: pkCol?.name ?? "",
+      },
+    });
+  };
+
+  return (
+    <div className="column-fk-section">
+      <label className="column-flag-label">
+        <input
+          type="checkbox"
+          checked={hasFk}
+          onChange={(e) => {
+            if (e.target.checked) {
+              onUpdate({ foreignKey: { tableId: "", columnName: "" } });
+            } else {
+              onUpdate({ foreignKey: undefined });
+            }
+          }}
+        />
+        外部キー (FK)
+      </label>
+      {hasFk && (
+        <div className="column-fk-fields">
+          <select
+            value={col.foreignKey?.tableId ?? ""}
+            onChange={(e) => handleTableChange(e.target.value)}
+          >
+            <option value="">参照先テーブル...</option>
+            {allTables.map((t) => (
+              <option key={t.id} value={t.name}>
+                {t.name}（{t.logicalName}）
+              </option>
+            ))}
+          </select>
+          <select
+            value={col.foreignKey?.columnName ?? ""}
+            onChange={(e) => onUpdate({ foreignKey: { ...col.foreignKey!, columnName: e.target.value } })}
+            disabled={!refTable}
+          >
+            <option value="">参照先カラム...</option>
+            {refTable?.columns.map((c) => {
+              const icon = c.primaryKey ? "🔑 " : c.unique ? "✦ " : "";
+              return (
+                <option key={c.id} value={c.name}>
+                  {icon}{c.name}（{c.logicalName}）— {c.dataType}
+                </option>
+              );
+            })}
+          </select>
+        </div>
+      )}
     </div>
   );
 }

--- a/designer/src/components/table/TableTopbar.tsx
+++ b/designer/src/components/table/TableTopbar.tsx
@@ -9,6 +9,7 @@ export function TableTopbar({ projectName }: Props) {
   const location = useLocation();
   const isFlow = location.pathname === "/";
   const isTable = location.pathname.startsWith("/tables");
+  const isEr = location.pathname === "/er";
 
   return (
     <header className="flow-topbar">
@@ -27,6 +28,12 @@ export function TableTopbar({ projectName }: Props) {
             onClick={() => navigate("/tables")}
           >
             <i className="bi bi-table" /> テーブル設計
+          </button>
+          <button
+            className={`global-nav-btn${isEr ? " active" : ""}`}
+            onClick={() => navigate("/er")}
+          >
+            <i className="bi bi-share" /> ER図
           </button>
         </nav>
       </div>

--- a/designer/src/mcp/mcpBridge.ts
+++ b/designer/src/mcp/mcpBridge.ts
@@ -27,6 +27,10 @@ import {
   setTableStorageBackend,
   type TableStorageBackend,
 } from "../store/tableStore";
+import {
+  setErLayoutStorageBackend,
+  type ErLayoutStorageBackend,
+} from "../store/erLayoutStore";
 
 export type McpStatus = "disconnected" | "connecting" | "connected";
 export type ThemeIdLike = "standard" | "card" | "compact" | "dark";
@@ -242,6 +246,12 @@ class McpBridgeImpl {
       deleteTable: (tableId) => self.request("deleteTable", { tableId }).then(() => undefined),
     };
     setTableStorageBackend(tableBackend);
+
+    const erLayoutBackend: ErLayoutStorageBackend = {
+      loadErLayout: () => self.request("loadErLayout"),
+      saveErLayout: (data) => self.request("saveErLayout", { data }).then(() => undefined),
+    };
+    setErLayoutStorageBackend(erLayoutBackend);
   }
 
   /** 切断時: localStorage フォールバックに戻す */
@@ -249,6 +259,7 @@ class McpBridgeImpl {
     setFlowStorageBackend(null);
     setCustomBlocksBackend(null);
     setTableStorageBackend(null);
+    setErLayoutStorageBackend(null);
   }
 
   // ── メッセージ受信 ─────────────────────────────────────────────────────

--- a/designer/src/store/erLayoutStore.ts
+++ b/designer/src/store/erLayoutStore.ts
@@ -1,0 +1,56 @@
+/**
+ * erLayoutStore.ts
+ * ER図レイアウトの永続化ストア
+ */
+import type { ErLayout } from "../types/table";
+
+// ─── ストレージバックエンド ──────────────────────────────────────────────
+
+export interface ErLayoutStorageBackend {
+  loadErLayout(): Promise<unknown>;
+  saveErLayout(data: unknown): Promise<void>;
+}
+
+let _backend: ErLayoutStorageBackend | null = null;
+
+export function setErLayoutStorageBackend(b: ErLayoutStorageBackend | null): void {
+  _backend = b;
+}
+
+// ─── localStorage キー ───────────────────────────────────────────────────
+
+const ER_LAYOUT_KEY = "er-layout";
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function createEmptyLayout(): ErLayout {
+  return { positions: {}, logicalRelations: [], updatedAt: now() };
+}
+
+// ─── 公開 API ────────────────────────────────────────────────────────────
+
+export async function loadErLayout(): Promise<ErLayout> {
+  if (_backend) {
+    const data = await _backend.loadErLayout();
+    if (data) return data as ErLayout;
+    return createEmptyLayout();
+  }
+  const raw = localStorage.getItem(ER_LAYOUT_KEY);
+  if (raw) {
+    try {
+      return JSON.parse(raw) as ErLayout;
+    } catch { /* ignore */ }
+  }
+  return createEmptyLayout();
+}
+
+export async function saveErLayout(layout: ErLayout): Promise<void> {
+  layout.updatedAt = now();
+  if (_backend) {
+    await _backend.saveErLayout(layout);
+    return;
+  }
+  localStorage.setItem(ER_LAYOUT_KEY, JSON.stringify(layout));
+}

--- a/designer/src/styles/er.css
+++ b/designer/src/styles/er.css
@@ -1,0 +1,327 @@
+/* ═══════════════════════════════════════════════════════════════════════════
+   er.css — ER図のスタイル
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/* ── ER図ページ ───────────────────────────────────────────────────────── */
+
+.er-diagram-page {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: #1a1a2e;
+  color: #e0e0e0;
+}
+
+.er-diagram-canvas {
+  flex: 1;
+  position: relative;
+}
+
+/* ReactFlow 背景を暗くする */
+.er-diagram-canvas .react-flow__background {
+  background: #1a1a2e;
+}
+
+/* ── ツールバー ────────────────────────────────────────────────────────── */
+
+.er-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  background: #222240;
+  border-top: 1px solid #333;
+}
+
+.er-toolbar-group {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.er-toolbar-sep {
+  width: 1px;
+  height: 20px;
+  background: #444;
+  margin: 0 8px;
+}
+
+.er-toolbar-info {
+  font-size: 12px;
+  color: #888;
+  margin-left: auto;
+}
+
+/* ── テーブルノード ────────────────────────────────────────────────────── */
+
+.er-table-node {
+  background: #fff;
+  border: 2px solid #e2e8f0;
+  border-radius: 8px;
+  min-width: 200px;
+  max-width: 280px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  cursor: grab;
+  font-size: 12px;
+  overflow: hidden;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.er-table-node:hover {
+  border-color: #7c6bff;
+  box-shadow: 0 4px 12px rgba(124,107,255,0.15);
+}
+
+.er-table-node.selected {
+  border-color: #7c6bff;
+  box-shadow: 0 0 0 3px rgba(124,107,255,0.25);
+}
+
+/* ヘッダー */
+.er-node-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  padding: 8px 10px 2px;
+  background: #f8fafc;
+}
+
+.er-node-name {
+  font-weight: 700;
+  font-size: 13px;
+  color: #1e293b;
+  font-family: "Consolas", "Monaco", monospace;
+}
+
+.er-node-category {
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: rgba(124,107,255,0.1);
+  color: #7c6bff;
+  white-space: nowrap;
+}
+
+.er-node-logical {
+  padding: 0 10px 6px;
+  font-size: 11px;
+  color: #94a3b8;
+  background: #f8fafc;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+/* カラム一覧 */
+.er-node-columns {
+  padding: 4px 0;
+}
+
+.er-col {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 10px;
+  transition: background 0.1s;
+}
+
+.er-col:hover {
+  background: #f1f5f9;
+}
+
+.er-col.pk {
+  background: #fefce8;
+}
+
+.er-col.pk:hover {
+  background: #fef9c3;
+}
+
+.er-col.fk {
+  background: #eff6ff;
+}
+
+.er-col.fk:hover {
+  background: #dbeafe;
+}
+
+.er-col-icon {
+  font-size: 11px;
+  flex-shrink: 0;
+  width: 14px;
+  text-align: center;
+}
+
+.pk-icon {
+  color: #ca8a04;
+}
+
+.fk-icon {
+  color: #3b82f6;
+}
+
+.er-col-icon-space {
+  width: 14px;
+  flex-shrink: 0;
+}
+
+.er-col-name {
+  flex: 1;
+  font-family: "Consolas", "Monaco", monospace;
+  color: #334155;
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.er-col-type {
+  font-size: 10px;
+  color: #94a3b8;
+  font-family: "Consolas", "Monaco", monospace;
+  white-space: nowrap;
+}
+
+.er-col-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 4px 10px;
+  font-size: 10px;
+  color: #7c6bff;
+  cursor: pointer;
+  border-top: 1px dashed #e2e8f0;
+  margin-top: 2px;
+  transition: background 0.1s;
+}
+
+.er-col-toggle:hover {
+  background: #f1f5f9;
+}
+
+/* ── ハンドル ──────────────────────────────────────────────────────────── */
+
+.er-handle {
+  width: 8px !important;
+  height: 8px !important;
+  background: #cbd5e1 !important;
+  border: 2px solid #fff !important;
+  transition: background 0.15s !important;
+}
+
+.er-handle:hover {
+  background: #7c6bff !important;
+}
+
+/* ── エッジ（リレーション線） ──────────────────────────────────────────── */
+
+.er-edge-physical {
+  stroke: #64748b;
+  stroke-width: 2;
+}
+
+.er-edge-logical {
+  stroke: #7c6bff;
+  stroke-width: 2;
+  stroke-dasharray: 6 4;
+}
+
+/* ── IE記法（Crow's foot）マーカー ─────────────────────────────────────── */
+
+.er-marker-one line {
+  stroke: #64748b;
+  stroke-width: 2;
+}
+
+.er-marker-many line {
+  stroke: #64748b;
+  stroke-width: 2;
+}
+
+/* ── 論理リレーション追加モーダル ──────────────────────────────────────── */
+
+.er-relation-modal {
+  background: #2a2a4a;
+  border-radius: 10px;
+  padding: 24px;
+  min-width: 420px;
+  max-width: 520px;
+  border: 1px solid #444;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.4);
+}
+
+.er-relation-modal .tbl-modal-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: #fff;
+  margin-bottom: 16px;
+}
+
+.er-relation-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.er-relation-arrow {
+  color: #7c6bff;
+  font-size: 18px;
+  flex-shrink: 0;
+}
+
+.er-badge-physical {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: rgba(100,116,139,0.15);
+  color: #94a3b8;
+}
+
+.er-badge-logical {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: rgba(124,107,255,0.15);
+  color: #a99bff;
+}
+
+/* ── エクスポートメニュー ──────────────────────────────────────────────── */
+
+.er-export-menu {
+  position: absolute;
+  bottom: 100%;
+  right: 0;
+  margin-bottom: 4px;
+  background: #2a2a4a;
+  border: 1px solid #444;
+  border-radius: 8px;
+  padding: 4px;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.3);
+  z-index: 10;
+}
+
+.er-export-menu button {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 12px;
+  border: none;
+  background: none;
+  color: #ddd;
+  font-size: 13px;
+  cursor: pointer;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
+.er-export-menu button:hover {
+  background: rgba(255,255,255,0.06);
+}

--- a/designer/src/types/table.ts
+++ b/designer/src/types/table.ts
@@ -104,6 +104,49 @@ export interface TableMeta {
   updatedAt: string;
 }
 
+// ── ER図関連 ──────────────────────────────────────────────────────────────
+
+/** ER図レイアウト（data/er-layout.json） */
+export interface ErLayout {
+  positions: Record<string, { x: number; y: number }>;
+  /** 論理リレーション（FK定義なしだが事実上のリレーション） */
+  logicalRelations?: ErLogicalRelation[];
+  updatedAt: string;
+}
+
+/** 論理リレーション（ER図上のみ、テーブル定義には反映しない） */
+export interface ErLogicalRelation {
+  id: string;
+  sourceTableId: string;
+  sourceColumnName: string;
+  targetTableId: string;
+  targetColumnName: string;
+  cardinality: ErCardinality;
+  label?: string;
+}
+
+/** ER図リレーション（物理FK + 論理の統合ビュー） */
+export interface ErRelation {
+  id: string;
+  sourceTableId: string;
+  sourceTableName: string;
+  sourceColumnName: string;
+  targetTableId: string;
+  targetTableName: string;
+  targetColumnName: string;
+  cardinality: ErCardinality;
+  physical: boolean;
+  label?: string;
+}
+
+export type ErCardinality = "one-to-many" | "one-to-one" | "many-to-many";
+
+export const CARDINALITY_LABELS: Record<ErCardinality, string> = {
+  "one-to-many": "1:N",
+  "one-to-one": "1:1",
+  "many-to-many": "N:N",
+};
+
 /** テーブルカテゴリ */
 export const TABLE_CATEGORIES = [
   "マスタ",

--- a/designer/src/utils/erUtils.ts
+++ b/designer/src/utils/erUtils.ts
@@ -1,0 +1,210 @@
+/**
+ * erUtils.ts
+ * ER図のリレーション導出・Mermaid生成・自動配置ユーティリティ
+ */
+import type { TableDefinition, ErRelation, ErLayout, ErLogicalRelation } from "../types/table";
+
+/**
+ * テーブル定義群から物理FK リレーションを導出する
+ */
+export function derivePhysicalRelations(tables: TableDefinition[]): ErRelation[] {
+  const relations: ErRelation[] = [];
+  const tableMap = new Map(tables.map((t) => [t.name, t]));
+  const tableIdMap = new Map(tables.map((t) => [t.id, t]));
+
+  for (const table of tables) {
+    for (const col of table.columns) {
+      if (!col.foreignKey) continue;
+      // foreignKey.tableId は実際にはテーブル名が入っている（UIの仕様）
+      const targetTable = tableMap.get(col.foreignKey.tableId) ?? tableIdMap.get(col.foreignKey.tableId);
+      if (!targetTable) continue;
+
+      relations.push({
+        id: `fk-${table.id}-${col.id}`,
+        sourceTableId: table.id,
+        sourceTableName: table.name,
+        sourceColumnName: col.name,
+        targetTableId: targetTable.id,
+        targetTableName: targetTable.name,
+        targetColumnName: col.foreignKey.columnName,
+        cardinality: "one-to-many",
+        physical: true,
+      });
+    }
+  }
+
+  return relations;
+}
+
+/**
+ * 論理リレーションを ErRelation 形式に変換
+ */
+export function convertLogicalRelations(
+  logicals: ErLogicalRelation[],
+  tables: TableDefinition[],
+): ErRelation[] {
+  const tableIdMap = new Map(tables.map((t) => [t.id, t]));
+
+  return logicals
+    .map((lr) => {
+      const src = tableIdMap.get(lr.sourceTableId);
+      const tgt = tableIdMap.get(lr.targetTableId);
+      if (!src || !tgt) return null;
+      return {
+        id: lr.id,
+        sourceTableId: lr.sourceTableId,
+        sourceTableName: src.name,
+        sourceColumnName: lr.sourceColumnName,
+        targetTableId: lr.targetTableId,
+        targetTableName: tgt.name,
+        targetColumnName: lr.targetColumnName,
+        cardinality: lr.cardinality,
+        physical: false,
+        label: lr.label,
+      } satisfies ErRelation;
+    })
+    .filter((r): r is ErRelation => r !== null);
+}
+
+/**
+ * 全リレーション（物理 + 論理）を統合
+ */
+export function getAllRelations(
+  tables: TableDefinition[],
+  layout: ErLayout | null,
+): ErRelation[] {
+  const physical = derivePhysicalRelations(tables);
+  const logical = layout?.logicalRelations
+    ? convertLogicalRelations(layout.logicalRelations, tables)
+    : [];
+  return [...physical, ...logical];
+}
+
+/**
+ * Mermaid ER図を生成
+ */
+export function generateErMermaid(
+  tables: TableDefinition[],
+  relations: ErRelation[],
+): string {
+  if (tables.length === 0) return "erDiagram\n    %% テーブルなし";
+
+  const lines: string[] = ["erDiagram"];
+
+  // テーブル定義
+  for (const table of tables) {
+    lines.push(`    ${table.name} {`);
+    for (const col of table.columns) {
+      const markers: string[] = [];
+      if (col.primaryKey) markers.push("PK");
+      if (col.foreignKey) markers.push("FK");
+      if (col.unique && !col.primaryKey) markers.push("UK");
+      const marker = markers.length > 0 ? ` ${markers.join(",")}` : "";
+      const comment = col.logicalName ? ` "${col.logicalName}"` : "";
+      lines.push(`        ${col.dataType} ${col.name}${marker}${comment}`);
+    }
+    lines.push("    }");
+  }
+
+  // リレーション
+  for (const rel of relations) {
+    const cardStr = rel.cardinality === "one-to-one"
+      ? "||--||"
+      : rel.cardinality === "many-to-many"
+        ? "}|--|{"
+        : "||--o{";
+    const label = rel.sourceColumnName;
+    const lineStyle = rel.physical ? cardStr : "..";
+    if (rel.physical) {
+      lines.push(`    ${rel.targetTableName} ${cardStr} ${rel.sourceTableName} : "${label}"`);
+    } else {
+      lines.push(`    ${rel.targetTableName} ${lineStyle} ${rel.sourceTableName} : "${label} (論理)"`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * FK依存関係に基づく自動配置
+ * 被参照テーブル（親）を上・左に、参照元（子）を下・右に配置
+ */
+export function autoLayout(
+  tables: TableDefinition[],
+  relations: ErRelation[],
+): Record<string, { x: number; y: number }> {
+  if (tables.length === 0) return {};
+
+  // 被参照回数（入次数）を計算
+  const inDegree = new Map<string, number>();
+  const outEdges = new Map<string, string[]>();
+  for (const t of tables) {
+    inDegree.set(t.id, 0);
+    outEdges.set(t.id, []);
+  }
+  for (const rel of relations) {
+    // source(FK側) → target(参照先) : target は親
+    inDegree.set(rel.sourceTableId, (inDegree.get(rel.sourceTableId) ?? 0) + 1);
+    outEdges.get(rel.targetTableId)?.push(rel.sourceTableId);
+  }
+
+  // トポロジカルソート（BFS）でレイヤー割り当て
+  const layers: string[][] = [];
+  const assigned = new Set<string>();
+
+  // ルートノード（被参照されない＝入次数0のテーブル or FK なしのテーブル）
+  // ここでは「他テーブルからFKで参照されている数」ではなく「自身がFKを持つ数」で判断
+  const fkCount = new Map<string, number>();
+  for (const t of tables) {
+    const count = t.columns.filter((c) => c.foreignKey).length;
+    fkCount.set(t.id, count);
+  }
+
+  // FK を持たないテーブル（マスタ系）をルートに
+  let roots = tables.filter((t) => (fkCount.get(t.id) ?? 0) === 0).map((t) => t.id);
+  if (roots.length === 0) roots = [tables[0].id]; // 循環の場合は最初のテーブル
+
+  let current = roots;
+  while (current.length > 0) {
+    layers.push(current);
+    current.forEach((id) => assigned.add(id));
+    const next: string[] = [];
+    for (const id of current) {
+      for (const childId of outEdges.get(id) ?? []) {
+        if (!assigned.has(childId)) {
+          next.push(childId);
+          assigned.add(childId);
+        }
+      }
+    }
+    current = [...new Set(next)];
+  }
+
+  // 未割り当てのテーブル（孤立テーブル）を最後のレイヤーに追加
+  for (const t of tables) {
+    if (!assigned.has(t.id)) {
+      if (layers.length === 0) layers.push([]);
+      layers[layers.length - 1].push(t.id);
+    }
+  }
+
+  // 位置を計算
+  const NODE_WIDTH = 240;
+  const NODE_GAP_X = 80;
+  const NODE_GAP_Y = 120;
+  const positions: Record<string, { x: number; y: number }> = {};
+
+  for (let row = 0; row < layers.length; row++) {
+    const layer = layers[row];
+    const totalWidth = layer.length * NODE_WIDTH + (layer.length - 1) * NODE_GAP_X;
+    const startX = -totalWidth / 2;
+    for (let col = 0; col < layer.length; col++) {
+      positions[layer[col]] = {
+        x: startX + col * (NODE_WIDTH + NODE_GAP_X),
+        y: row * (200 + NODE_GAP_Y),
+      };
+    }
+  }
+
+  return positions;
+}


### PR DESCRIPTION
## Summary
- ReactFlowベースのインタラクティブER図ビューを実装
- テーブル定義のFKからリレーション自動導出（実線）+ 論理リレーション手動追加（点線）
- テーブルノード: PK/FKカラム表示 + クリック展開 + ダブルクリックでテーブル編集に遷移
- FK依存関係に基づく自動配置、ドラッグで手動調整（位置自動保存）
- Mermaid ER図コピー + PNG画像エクスポート
- FK入力UIをプルダウン化: テーブル選択時にカラム一覧を動的表示、PKカラム自動選択
- グローバルナビに ER図 タブ追加（画面フロー / テーブル設計 / ER図）

## Test plan
- [ ] /er でER図が表示されることを確認
- [ ] テーブルノードにPK/FKカラムが表示され、クリックで全カラム展開されることを確認
- [ ] FK定義のあるテーブル間にリレーション線（実線）が表示されることを確認
- [ ] 論理リレーション追加モーダルで点線リレーションを追加できることを確認
- [ ] 自動配置ボタンでテーブルが整列されることを確認
- [ ] ダブルクリックでテーブル編集画面に遷移することを確認
- [ ] Mermaidコピー・PNGエクスポートが動作することを確認
- [ ] テーブル編集のFK入力でプルダウン選択・PKカラム自動選択が動作することを確認
- [ ] グローバルナビで画面フロー ↔ テーブル設計 ↔ ER図を行き来できることを確認

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)