### PR TITLE
feat(designer): 処理フロー定義機能の追加

### DIFF
--- a/designer-mcp/src/index.ts
+++ b/designer-mcp/src/index.ts
@@ -9,7 +9,7 @@ import {
 import { wsBridge } from "./wsBridge.js";
 import { tools } from "./tools.js";
 import { htmlToReact, toPascalCase } from "./reactExporter.js";
-import { readProject, readCustomBlocks, readTable, writeTable, deleteTable as deleteTableFile, writeProject, readErLayout } from "./projectStorage.js";
+import { readProject, readCustomBlocks, readTable, writeTable, deleteTable as deleteTableFile, writeProject, readErLayout, readActionGroup, writeActionGroup, deleteActionGroup as deleteActionGroupFile, listActionGroups as listActionGroupFiles } from "./projectStorage.js";
 
 // 親プロセス（Claude Code）が死んだら自動終了
 function setupLifecycle(): void {
@@ -775,6 +775,130 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             ].join("\n"),
           }],
         };
+      }
+
+      // ── 処理フロー定義 ──
+
+      case "designer__list_action_groups": {
+        const agList = await listActionGroupFiles() as Array<{ id: string; name: string; type: string; screenId?: string; actions?: unknown[]; updatedAt: string }>;
+        if (agList.length === 0) {
+          return { content: [{ type: "text", text: "処理フロー定義はまだありません。" }] };
+        }
+        const lines = agList.map(
+          (ag) => `- ${ag.id}  ${ag.name}（${ag.type}）アクション:${ag.actions?.length ?? 0}件`
+        );
+        return { content: [{ type: "text", text: `処理フロー一覧 (${agList.length}件):\n${lines.join("\n")}` }] };
+      }
+
+      case "designer__get_action_group": {
+        const a = (args ?? {}) as Record<string, unknown>;
+        if (typeof a.actionGroupId !== "string") {
+          throw new McpError(ErrorCode.InvalidParams, "actionGroupId は必須です");
+        }
+        const agData = await readActionGroup(a.actionGroupId);
+        if (!agData) {
+          throw new McpError(ErrorCode.InvalidParams, `処理フロー ${a.actionGroupId} が見つかりません`);
+        }
+        return { content: [{ type: "text", text: JSON.stringify(agData, null, 2) }] };
+      }
+
+      case "designer__add_action_group": {
+        const a = (args ?? {}) as Record<string, unknown>;
+        if (typeof a.name !== "string" || typeof a.type !== "string") {
+          throw new McpError(ErrorCode.InvalidParams, "name, type は必須です");
+        }
+        const agId = `ag-${Date.now()}`;
+        const agNow = new Date().toISOString();
+        const agDef = {
+          id: agId,
+          name: a.name,
+          type: a.type,
+          screenId: typeof a.screenId === "string" ? a.screenId : undefined,
+          description: typeof a.description === "string" ? a.description : "",
+          actions: [],
+          createdAt: agNow,
+          updatedAt: agNow,
+        };
+        await writeActionGroup(agId, agDef);
+        // project.json メタ更新
+        const agProject = (await readProject() ?? {}) as Record<string, unknown>;
+        const agMetas = (agProject.actionGroups ?? []) as Array<Record<string, unknown>>;
+        agMetas.push({ id: agId, name: a.name, type: a.type, screenId: a.screenId, actionCount: 0, updatedAt: agNow });
+        agProject.actionGroups = agMetas;
+        agProject.updatedAt = agNow;
+        await writeProject(agProject);
+        return { content: [{ type: "text", text: `処理フロー「${a.name}」(${a.type}) を追加しました（ID: ${agId}）` }] };
+      }
+
+      case "designer__update_action_group": {
+        const a = (args ?? {}) as Record<string, unknown>;
+        if (typeof a.actionGroupId !== "string" || !a.definition) {
+          throw new McpError(ErrorCode.InvalidParams, "actionGroupId, definition は必須です");
+        }
+        const agDef = a.definition as Record<string, unknown>;
+        agDef.updatedAt = new Date().toISOString();
+        await writeActionGroup(a.actionGroupId, agDef);
+        // project.json メタ更新
+        const agProject = (await readProject() ?? {}) as Record<string, unknown>;
+        const agMetas = (agProject.actionGroups ?? []) as Array<Record<string, unknown>>;
+        const agIdx = agMetas.findIndex((m) => m.id === a.actionGroupId);
+        const agActions = (agDef.actions ?? []) as unknown[];
+        const agMeta = { id: a.actionGroupId, name: agDef.name, type: agDef.type, screenId: agDef.screenId, actionCount: agActions.length, updatedAt: agDef.updatedAt };
+        if (agIdx >= 0) agMetas[agIdx] = agMeta; else agMetas.push(agMeta);
+        agProject.actionGroups = agMetas;
+        agProject.updatedAt = agDef.updatedAt as string;
+        await writeProject(agProject);
+        return { content: [{ type: "text", text: `処理フロー ${a.actionGroupId} を更新しました。` }] };
+      }
+
+      case "designer__delete_action_group": {
+        const a = (args ?? {}) as Record<string, unknown>;
+        if (typeof a.actionGroupId !== "string") {
+          throw new McpError(ErrorCode.InvalidParams, "actionGroupId は必須です");
+        }
+        await deleteActionGroupFile(a.actionGroupId);
+        const agProject = (await readProject() ?? {}) as Record<string, unknown>;
+        const agMetas = ((agProject.actionGroups ?? []) as Array<Record<string, unknown>>).filter((m) => m.id !== a.actionGroupId);
+        agProject.actionGroups = agMetas;
+        agProject.updatedAt = new Date().toISOString();
+        await writeProject(agProject);
+        return { content: [{ type: "text", text: `処理フロー ${a.actionGroupId} を削除しました。` }] };
+      }
+
+      case "designer__add_action": {
+        const a = (args ?? {}) as Record<string, unknown>;
+        if (typeof a.actionGroupId !== "string" || typeof a.name !== "string" || typeof a.trigger !== "string") {
+          throw new McpError(ErrorCode.InvalidParams, "actionGroupId, name, trigger は必須です");
+        }
+        const ag = await readActionGroup(a.actionGroupId) as Record<string, unknown> | null;
+        if (!ag) throw new McpError(ErrorCode.InvalidParams, `処理フロー ${a.actionGroupId} が見つかりません`);
+        const actions = (ag.actions ?? []) as Array<Record<string, unknown>>;
+        const actionId = `act-${Date.now()}`;
+        actions.push({ id: actionId, name: a.name, trigger: a.trigger, steps: [] });
+        ag.actions = actions;
+        ag.updatedAt = new Date().toISOString();
+        await writeActionGroup(a.actionGroupId, ag);
+        return { content: [{ type: "text", text: `アクション「${a.name}」を追加しました（ID: ${actionId}）` }] };
+      }
+
+      case "designer__add_step": {
+        const a = (args ?? {}) as Record<string, unknown>;
+        if (typeof a.actionGroupId !== "string" || typeof a.actionId !== "string" || typeof a.type !== "string") {
+          throw new McpError(ErrorCode.InvalidParams, "actionGroupId, actionId, type は必須です");
+        }
+        const ag = await readActionGroup(a.actionGroupId) as Record<string, unknown> | null;
+        if (!ag) throw new McpError(ErrorCode.InvalidParams, `処理フロー ${a.actionGroupId} が見つかりません`);
+        const actions = (ag.actions ?? []) as Array<Record<string, unknown>>;
+        const action = actions.find((act) => act.id === a.actionId);
+        if (!action) throw new McpError(ErrorCode.InvalidParams, `アクション ${a.actionId} が見つかりません`);
+        const steps = (action.steps ?? []) as Array<Record<string, unknown>>;
+        const stepId = `step-${Date.now()}`;
+        const detail = (a.detail ?? {}) as Record<string, unknown>;
+        steps.push({ id: stepId, type: a.type, description: a.description ?? "", ...detail });
+        action.steps = steps;
+        ag.updatedAt = new Date().toISOString();
+        await writeActionGroup(a.actionGroupId, ag);
+        return { content: [{ type: "text", text: `ステップ（${a.type}）を追加しました（ID: ${stepId}）` }] };
       }
 
       default:

--- a/designer-mcp/src/projectStorage.ts
+++ b/designer-mcp/src/projectStorage.ts
@@ -15,6 +15,7 @@ export const DATA_DIR =
 
 const SCREENS_DIR = path.join(DATA_DIR, "screens");
 const TABLES_DIR = path.join(DATA_DIR, "tables");
+const ACTIONS_DIR = path.join(DATA_DIR, "actions");
 export const PROJECT_FILE = path.join(DATA_DIR, "project.json");
 export const CUSTOM_BLOCKS_FILE = path.join(DATA_DIR, "custom-blocks.json");
 export const ER_LAYOUT_FILE = path.join(DATA_DIR, "er-layout.json");
@@ -24,6 +25,7 @@ export async function ensureDataDir(): Promise<void> {
   await fs.mkdir(DATA_DIR, { recursive: true });
   await fs.mkdir(SCREENS_DIR, { recursive: true });
   await fs.mkdir(TABLES_DIR, { recursive: true });
+  await fs.mkdir(ACTIONS_DIR, { recursive: true });
 }
 
 async function readJSON<T>(filePath: string): Promise<T | null> {
@@ -107,4 +109,39 @@ export async function deleteTable(tableId: string): Promise<void> {
   try {
     await fs.unlink(path.join(TABLES_DIR, `${tableId}.json`));
   } catch { /* file not found is OK */ }
+}
+
+/** actions/{actionGroupId}.json を読み込み */
+export async function readActionGroup(actionGroupId: string): Promise<unknown | null> {
+  return readJSON<unknown>(path.join(ACTIONS_DIR, `${actionGroupId}.json`));
+}
+
+/** actions/{actionGroupId}.json を書き込み */
+export async function writeActionGroup(actionGroupId: string, data: unknown): Promise<void> {
+  await ensureDataDir();
+  await writeJSON(path.join(ACTIONS_DIR, `${actionGroupId}.json`), data);
+}
+
+/** actions/{actionGroupId}.json を削除（存在しない場合は無視） */
+export async function deleteActionGroup(actionGroupId: string): Promise<void> {
+  try {
+    await fs.unlink(path.join(ACTIONS_DIR, `${actionGroupId}.json`));
+  } catch { /* file not found is OK */ }
+}
+
+/** actions/ ディレクトリ内の全アクショングループを読み込み */
+export async function listActionGroups(): Promise<unknown[]> {
+  try {
+    await ensureDataDir();
+    const files = await fs.readdir(ACTIONS_DIR);
+    const results: unknown[] = [];
+    for (const file of files) {
+      if (!file.endsWith(".json")) continue;
+      const data = await readJSON<unknown>(path.join(ACTIONS_DIR, file));
+      if (data) results.push(data);
+    }
+    return results;
+  } catch {
+    return [];
+  }
 }

--- a/designer-mcp/src/tools.ts
+++ b/designer-mcp/src/tools.ts
@@ -521,4 +521,150 @@ export const tools = [
       required: [],
     },
   },
+
+  // ── 処理フロー定義ツール ──
+
+  {
+    name: "designer__list_action_groups",
+    description:
+      "処理フロー定義（アクショングループ）の一覧を取得します。画面・バッチ・共通処理等のタイプ別に管理されます。",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+      required: [],
+    },
+  },
+  {
+    name: "designer__get_action_group",
+    description:
+      "指定した処理フロー定義の詳細（アクション・ステップ含む）を取得します。",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        actionGroupId: {
+          type: "string",
+          description: "取得するアクショングループのID",
+        },
+      },
+      required: ["actionGroupId"],
+    },
+  },
+  {
+    name: "designer__add_action_group",
+    description:
+      "新しい処理フロー定義（アクショングループ）を作成します。",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        name: {
+          type: "string",
+          description: "処理フロー名（例: ログイン画面、月次集計バッチ）",
+        },
+        type: {
+          type: "string",
+          enum: ["screen", "batch", "scheduled", "system", "common", "other"],
+          description: "種別（screen=画面, batch=バッチ, common=共通処理 等）",
+        },
+        screenId: {
+          type: "string",
+          description: "画面ID（type=screen の場合）。省略可。",
+        },
+        description: {
+          type: "string",
+          description: "処理フローの説明。省略可。",
+        },
+      },
+      required: ["name", "type"],
+    },
+  },
+  {
+    name: "designer__update_action_group",
+    description:
+      "処理フロー定義を更新します。アクション・ステップを含む完全な定義を渡します。",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        actionGroupId: {
+          type: "string",
+          description: "更新対象のアクショングループID",
+        },
+        definition: {
+          type: "object",
+          description: "アクショングループ定義の完全なJSON（ActionGroup型）",
+        },
+      },
+      required: ["actionGroupId", "definition"],
+    },
+  },
+  {
+    name: "designer__delete_action_group",
+    description:
+      "処理フロー定義を削除します。",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        actionGroupId: {
+          type: "string",
+          description: "削除するアクショングループID",
+        },
+      },
+      required: ["actionGroupId"],
+    },
+  },
+  {
+    name: "designer__add_action",
+    description:
+      "アクショングループにアクション（ボタンクリック等のイベント）を追加します。",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        actionGroupId: {
+          type: "string",
+          description: "対象のアクショングループID",
+        },
+        name: {
+          type: "string",
+          description: "アクション名（例: 登録ボタン、検索ボタン）",
+        },
+        trigger: {
+          type: "string",
+          enum: ["click", "submit", "select", "change", "load", "timer", "other"],
+          description: "トリガー種別",
+        },
+      },
+      required: ["actionGroupId", "name", "trigger"],
+    },
+  },
+  {
+    name: "designer__add_step",
+    description:
+      "アクションにステップ（処理手順）を追加します。",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        actionGroupId: {
+          type: "string",
+          description: "対象のアクショングループID",
+        },
+        actionId: {
+          type: "string",
+          description: "対象のアクションID",
+        },
+        type: {
+          type: "string",
+          enum: ["validation", "dbAccess", "externalSystem", "commonProcess", "screenTransition", "displayUpdate", "branch", "jump", "other"],
+          description: "ステップ種別",
+        },
+        description: {
+          type: "string",
+          description: "ステップの処理概要",
+        },
+        detail: {
+          type: "object",
+          description: "ステップ種別固有の詳細（tableName, operation, refId 等）。省略可。",
+        },
+      },
+      required: ["actionGroupId", "actionId", "type", "description"],
+    },
+  },
 ];

--- a/designer-mcp/src/wsBridge.ts
+++ b/designer-mcp/src/wsBridge.ts
@@ -16,6 +16,10 @@ import {
   deleteTable as deleteTableFile,
   readErLayout,
   writeErLayout,
+  readActionGroup,
+  writeActionGroup,
+  deleteActionGroup as deleteActionGroupFile,
+  listActionGroups as listActionGroupFiles,
 } from "./projectStorage.js";
 
 type Command = { id: string; method: string; params?: unknown };
@@ -345,6 +349,39 @@ class WsBridge extends EventEmitter {
           await writeErLayout(data);
           respond({ success: true });
           this.broadcast("erLayoutChanged", {}, clientId);
+          break;
+        }
+        case "loadActionGroup": {
+          const { id: agId } = (params ?? {}) as { id: string };
+          const agData = await readActionGroup(agId);
+          respond(agData);
+          break;
+        }
+        case "saveActionGroup": {
+          const { id: agId, data: agData } = (params ?? {}) as { id: string; data: unknown };
+          await writeActionGroup(agId, agData);
+          respond({ success: true });
+          this.broadcast("actionGroupChanged", { id: agId }, clientId);
+          break;
+        }
+        case "deleteActionGroup": {
+          const { id: agId } = (params ?? {}) as { id: string };
+          await deleteActionGroupFile(agId);
+          respond({ success: true });
+          this.broadcast("actionGroupChanged", { id: agId, deleted: true }, clientId);
+          break;
+        }
+        case "listActionGroups": {
+          const agList = await listActionGroupFiles();
+          const metas = (agList as Array<{ id: string; name: string; type: string; screenId?: string; actions?: unknown[]; updatedAt: string }>).map((ag) => ({
+            id: ag.id,
+            name: ag.name,
+            type: ag.type,
+            screenId: ag.screenId,
+            actionCount: ag.actions?.length ?? 0,
+            updatedAt: ag.updatedAt,
+          }));
+          respond(metas);
           break;
         }
         default:

--- a/designer/src/App.tsx
+++ b/designer/src/App.tsx
@@ -4,6 +4,8 @@ import { ScreenDesigner } from "./components/ScreenDesigner";
 import { TableListView } from "./components/table/TableListView";
 import { TableEditor } from "./components/table/TableEditor";
 import { ErDiagram } from "./components/table/ErDiagram";
+import { ActionListView } from "./components/action/ActionListView";
+import { ActionEditor } from "./components/action/ActionEditor";
 import "./styles/app.css";
 
 function App() {
@@ -14,6 +16,8 @@ function App() {
       <Route path="/tables" element={<TableListView />} />
       <Route path="/tables/:tableId" element={<TableEditor />} />
       <Route path="/er" element={<ErDiagram />} />
+      <Route path="/actions" element={<ActionListView />} />
+      <Route path="/actions/:actionGroupId" element={<ActionEditor />} />
     </Routes>
   );
 }

--- a/designer/src/components/action/ActionEditor.tsx
+++ b/designer/src/components/action/ActionEditor.tsx
@@ -1,0 +1,475 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useParams, useNavigate, Link } from "react-router-dom";
+import type {
+  ActionGroup,
+  ActionGroupType,
+  ActionTrigger,
+  Step,
+  StepType,
+} from "../../types/action";
+import {
+  ACTION_GROUP_TYPE_LABELS,
+  ACTION_TRIGGER_LABELS,
+  STEP_TYPE_LABELS,
+  STEP_TYPE_ICONS,
+  STEP_TEMPLATES,
+} from "../../types/action";
+import {
+  loadActionGroup,
+  saveActionGroup,
+  addAction,
+  removeAction,
+  addStep,
+  removeStep,
+  moveStep,
+  addSubStep,
+  removeSubStep,
+} from "../../store/actionStore";
+import { listTables } from "../../store/tableStore";
+import { loadProject } from "../../store/flowStore";
+import { getStepLabel, clearJumpReferences } from "../../utils/actionUtils";
+import { generateUUID } from "../../utils/uuid";
+import { mcpBridge } from "../../mcp/mcpBridge";
+import { TableTopbar } from "../table/TableTopbar";
+import { StepCard } from "./StepCard";
+import "../../styles/action.css";
+
+const ALL_STEP_TYPES: StepType[] = [
+  "validation", "dbAccess", "externalSystem", "commonProcess",
+  "screenTransition", "displayUpdate", "branch", "jump", "other",
+];
+
+const ALL_TRIGGERS: ActionTrigger[] = ["click", "submit", "select", "change", "load", "timer", "other"];
+
+export function ActionEditor() {
+  const { actionGroupId } = useParams<{ actionGroupId: string }>();
+  const navigate = useNavigate();
+  const [group, setGroup] = useState<ActionGroup | null>(null);
+  const [projectName, setProjectName] = useState("プロジェクト");
+  const [activeActionId, setActiveActionId] = useState<string | null>(null);
+  const [showAddAction, setShowAddAction] = useState(false);
+  const [newActionName, setNewActionName] = useState("");
+  const [newActionTrigger, setNewActionTrigger] = useState<ActionTrigger>("click");
+  const [tables, setTables] = useState<{ id: string; name: string; logicalName: string }[]>([]);
+  const [screens, setScreens] = useState<{ id: string; name: string }[]>([]);
+  const [commonGroups, setCommonGroups] = useState<{ id: string; name: string }[]>([]);
+  const [showTemplates, setShowTemplates] = useState(false);
+  const [contextMenu, setContextMenu] = useState<{ x: number; y: number; stepId: string; parentStepId?: string } | null>(null);
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const reload = useCallback(async () => {
+    if (!actionGroupId) return;
+    const g = await loadActionGroup(actionGroupId);
+    if (!g) {
+      navigate("/actions");
+      return;
+    }
+    setGroup(g);
+    if (!activeActionId && g.actions.length > 0) {
+      setActiveActionId(g.actions[0].id);
+    }
+    const p = await loadProject();
+    setProjectName(p.name);
+    setScreens(p.screens.map((s) => ({ id: s.id, name: s.name })));
+    const agMetas = p.actionGroups ?? [];
+    setCommonGroups(agMetas.filter((a) => a.type === "common").map((a) => ({ id: a.id, name: a.name })));
+    const t = await listTables();
+    setTables(t.map((tm) => ({ id: tm.id, name: tm.name, logicalName: tm.logicalName })));
+  }, [actionGroupId, activeActionId, navigate]);
+
+  useEffect(() => {
+    mcpBridge.startWithoutEditor();
+    reload();
+    const unsub = mcpBridge.onStatusChange((s) => {
+      if (s === "connected") reload();
+    });
+    return unsub;
+  }, [reload]);
+
+  // 自動保存 (debounce 500ms)
+  const scheduleSave = useCallback((updatedGroup: ActionGroup) => {
+    if (saveTimer.current) clearTimeout(saveTimer.current);
+    saveTimer.current = setTimeout(async () => {
+      await saveActionGroup(updatedGroup);
+    }, 500);
+  }, []);
+
+  const updateGroup = useCallback(
+    (updater: (g: ActionGroup) => void) => {
+      setGroup((prev) => {
+        if (!prev) return prev;
+        const next = JSON.parse(JSON.stringify(prev)) as ActionGroup;
+        updater(next);
+        scheduleSave(next);
+        return next;
+      });
+    },
+    [scheduleSave],
+  );
+
+  const activeAction = group?.actions.find((a) => a.id === activeActionId) ?? null;
+
+  const handleAddAction = () => {
+    const name = newActionName.trim();
+    if (!name || !group) return;
+    updateGroup((g) => {
+      const act = addAction(g, name, newActionTrigger);
+      setActiveActionId(act.id);
+    });
+    setShowAddAction(false);
+    setNewActionName("");
+    setNewActionTrigger("click");
+  };
+
+  const handleDeleteAction = (actionId: string) => {
+    if (!confirm("このアクションを削除しますか？")) return;
+    updateGroup((g) => {
+      removeAction(g, actionId);
+      if (activeActionId === actionId) {
+        setActiveActionId(g.actions.length > 0 ? g.actions[0].id : null);
+      }
+    });
+  };
+
+  const handleAddStep = (type: StepType, insertIndex?: number) => {
+    if (!activeAction) return;
+    updateGroup((g) => {
+      const act = g.actions.find((a) => a.id === activeActionId);
+      if (act) addStep(act, type, insertIndex);
+    });
+  };
+
+  const handleAddTemplate = (templateId: string) => {
+    const tpl = STEP_TEMPLATES.find((t) => t.id === templateId);
+    if (!tpl || !activeAction) return;
+    updateGroup((g) => {
+      const act = g.actions.find((a) => a.id === activeActionId);
+      if (!act) return;
+      for (const stepDef of tpl.steps) {
+        const step = { ...stepDef, id: generateUUID() } as Step;
+        act.steps.push(step);
+      }
+    });
+    setShowTemplates(false);
+  };
+
+  const handleDeleteStep = (stepId: string, parentStepId?: string) => {
+    updateGroup((g) => {
+      const act = g.actions.find((a) => a.id === activeActionId);
+      if (!act) return;
+      if (parentStepId) {
+        const parent = act.steps.find((s) => s.id === parentStepId);
+        if (parent) removeSubStep(parent, stepId);
+      } else {
+        clearJumpReferences(act.steps, stepId);
+        removeStep(act, stepId);
+      }
+    });
+    setContextMenu(null);
+  };
+
+  const handleMoveStep = (fromIndex: number, toIndex: number) => {
+    updateGroup((g) => {
+      const act = g.actions.find((a) => a.id === activeActionId);
+      if (act) moveStep(act, fromIndex, toIndex);
+    });
+  };
+
+  const handleStepChange = (stepId: string, changes: Partial<Step>) => {
+    updateGroup((g) => {
+      const act = g.actions.find((a) => a.id === activeActionId);
+      if (!act) return;
+      const step = act.steps.find((s) => s.id === stepId);
+      if (step) Object.assign(step, changes);
+    });
+  };
+
+  const handleAddSubStep = (parentStepId: string, type: StepType) => {
+    updateGroup((g) => {
+      const act = g.actions.find((a) => a.id === activeActionId);
+      if (!act) return;
+      const parent = act.steps.find((s) => s.id === parentStepId);
+      if (parent) addSubStep(parent, type);
+    });
+    setContextMenu(null);
+  };
+
+  const handleDuplicateStep = (stepId: string) => {
+    updateGroup((g) => {
+      const act = g.actions.find((a) => a.id === activeActionId);
+      if (!act) return;
+      const idx = act.steps.findIndex((s) => s.id === stepId);
+      if (idx < 0) return;
+      const clone = JSON.parse(JSON.stringify(act.steps[idx])) as Step;
+      clone.id = generateUUID();
+      if (clone.subSteps) {
+        clone.subSteps = clone.subSteps.map((s) => ({ ...s, id: generateUUID() }));
+      }
+      act.steps.splice(idx + 1, 0, clone);
+    });
+    setContextMenu(null);
+  };
+
+  const handleGroupInfoChange = (field: string, value: string) => {
+    updateGroup((g) => {
+      (g as unknown as Record<string, string>)[field] = value;
+    });
+  };
+
+  if (!group) return null;
+
+  return (
+    <div className="action-page" onClick={() => setContextMenu(null)}>
+      <TableTopbar projectName={projectName} />
+
+      {/* ヘッダー */}
+      <div className="action-editor-header">
+        <div className="action-editor-breadcrumb">
+          <Link to="/actions">処理フロー一覧</Link>
+          <span className="mx-2">/</span>
+          <span className="fw-semibold text-dark">{group.name}</span>
+        </div>
+      </div>
+
+      {/* グループ情報 */}
+      <div className="action-editor-info">
+        <div className="row g-2">
+          <div className="col-md-4">
+            <label className="form-label small fw-semibold">名前</label>
+            <input
+              className="form-control form-control-sm"
+              value={group.name}
+              onChange={(e) => handleGroupInfoChange("name", e.target.value)}
+            />
+          </div>
+          <div className="col-md-2">
+            <label className="form-label small fw-semibold">種別</label>
+            <select
+              className="form-select form-select-sm"
+              value={group.type}
+              onChange={(e) => handleGroupInfoChange("type", e.target.value)}
+            >
+              {(["screen", "batch", "scheduled", "system", "common", "other"] as ActionGroupType[]).map((t) => (
+                <option key={t} value={t}>{ACTION_GROUP_TYPE_LABELS[t]}</option>
+              ))}
+            </select>
+          </div>
+          <div className="col-md-6">
+            <label className="form-label small fw-semibold">説明</label>
+            <input
+              className="form-control form-control-sm"
+              value={group.description}
+              onChange={(e) => handleGroupInfoChange("description", e.target.value)}
+              placeholder="処理フローの概要"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* アクションタブ */}
+      <div className="action-tabs">
+        {group.actions.map((act) => (
+          <div key={act.id} className="d-flex align-items-center">
+            <button
+              className={`action-tab ${activeActionId === act.id ? "active" : ""}`}
+              onClick={() => setActiveActionId(act.id)}
+            >
+              {act.name}
+              <span className="ms-1 text-muted small">({ACTION_TRIGGER_LABELS[act.trigger]})</span>
+            </button>
+            <button
+              className="btn btn-link btn-sm text-muted p-0 ms-1"
+              onClick={() => handleDeleteAction(act.id)}
+              title="アクション削除"
+              style={{ fontSize: "0.7rem" }}
+            >
+              <i className="bi bi-x" />
+            </button>
+          </div>
+        ))}
+        <button
+          className="action-tab-add"
+          onClick={() => setShowAddAction(true)}
+          title="アクション追加"
+        >
+          <i className="bi bi-plus-lg" />
+        </button>
+      </div>
+
+      {/* ステップエディタ */}
+      <div className="action-content">
+        {activeAction ? (
+          <div className="step-editor">
+            {/* ツールバー */}
+            <div className="step-toolbar">
+              {ALL_STEP_TYPES.map((type) => (
+                <button
+                  key={type}
+                  className="step-toolbar-btn"
+                  onClick={() => handleAddStep(type)}
+                  title={STEP_TYPE_LABELS[type]}
+                >
+                  <i className={STEP_TYPE_ICONS[type]} />
+                  {STEP_TYPE_LABELS[type]}
+                </button>
+              ))}
+              <div className="step-toolbar-sep" />
+              <div style={{ position: "relative" }}>
+                <button
+                  className="step-template-btn"
+                  onClick={() => setShowTemplates(!showTemplates)}
+                >
+                  <i className="bi bi-collection" />
+                  テンプレート
+                </button>
+                {showTemplates && (
+                  <div className="template-dropdown">
+                    {STEP_TEMPLATES.map((tpl) => (
+                      <div
+                        key={tpl.id}
+                        className="template-dropdown-item"
+                        onClick={() => handleAddTemplate(tpl.id)}
+                      >
+                        <div className="template-dropdown-item-label">{tpl.label}</div>
+                        <div className="template-dropdown-item-desc">{tpl.description}</div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* ステップリスト */}
+            {activeAction.steps.length === 0 ? (
+              <div className="step-empty">
+                <i className="bi bi-plus-circle" />
+                ステップがありません。上のボタンから追加するか、テンプレートを使用してください。
+              </div>
+            ) : (
+              <div className="step-list">
+                {activeAction.steps.map((step, index) => (
+                  <div key={step.id}>
+                    {/* 挿入ポイント */}
+                    <div className="step-insert-point">
+                      <button
+                        className="step-insert-btn"
+                        onClick={() => handleAddStep("other", index)}
+                        title="ステップを挿入"
+                      >
+                        <i className="bi bi-plus" />
+                      </button>
+                    </div>
+                    <StepCard
+                      step={step}
+                      index={index}
+                      label={getStepLabel(index)}
+                      allSteps={activeAction.steps}
+                      tables={tables}
+                      screens={screens}
+                      commonGroups={commonGroups}
+                      onChange={(changes) => handleStepChange(step.id, changes)}
+                      onMoveUp={index > 0 ? () => handleMoveStep(index, index - 1) : undefined}
+                      onMoveDown={index < activeAction.steps.length - 1 ? () => handleMoveStep(index, index + 1) : undefined}
+                      onDelete={() => handleDeleteStep(step.id)}
+                      onDuplicate={() => handleDuplicateStep(step.id)}
+                      onAddSubStep={(type) => handleAddSubStep(step.id, type)}
+                      onDeleteSubStep={(subId) => handleDeleteStep(subId, step.id)}
+                      onContextMenu={(e) => {
+                        e.preventDefault();
+                        setContextMenu({ x: e.clientX, y: e.clientY, stepId: step.id });
+                      }}
+                      onNavigateCommon={(refId) => navigate(`/actions/${refId}`)}
+                    />
+                  </div>
+                ))}
+                {/* 末尾の挿入ポイント */}
+                <div className="step-insert-point" style={{ opacity: 1 }}>
+                  <button
+                    className="step-insert-btn"
+                    onClick={() => handleAddStep("other")}
+                    title="ステップを末尾に追加"
+                  >
+                    <i className="bi bi-plus" />
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="step-empty">
+            <i className="bi bi-lightning" />
+            アクションがありません。「+」ボタンからアクションを追加してください。
+          </div>
+        )}
+      </div>
+
+      {/* コンテキストメニュー */}
+      {contextMenu && (
+        <div
+          className="step-context-menu"
+          style={{ top: contextMenu.y, left: contextMenu.x }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <button
+            className="step-context-menu-item"
+            onClick={() => handleDuplicateStep(contextMenu.stepId)}
+          >
+            <i className="bi bi-copy" /> 複製
+          </button>
+          <button
+            className="step-context-menu-item"
+            onClick={() => handleAddSubStep(contextMenu.stepId, "other")}
+          >
+            <i className="bi bi-diagram-2" /> サブステップ追加
+          </button>
+          <div className="step-context-menu-sep" />
+          <button
+            className="step-context-menu-item danger"
+            onClick={() => handleDeleteStep(contextMenu.stepId)}
+          >
+            <i className="bi bi-trash" /> 削除
+          </button>
+        </div>
+      )}
+
+      {/* アクション追加モーダル */}
+      {showAddAction && (
+        <div className="action-modal-overlay" onClick={() => setShowAddAction(false)}>
+          <div className="action-modal" onClick={(e) => e.stopPropagation()}>
+            <h6>アクション追加</h6>
+            <div className="form-group">
+              <label className="form-label">アクション名 *</label>
+              <input
+                className="form-control form-control-sm"
+                value={newActionName}
+                onChange={(e) => setNewActionName(e.target.value)}
+                placeholder="例: 登録ボタン、検索ボタン"
+                autoFocus
+              />
+            </div>
+            <div className="form-group">
+              <label className="form-label">トリガー</label>
+              <select
+                className="form-select form-select-sm"
+                value={newActionTrigger}
+                onChange={(e) => setNewActionTrigger(e.target.value as ActionTrigger)}
+              >
+                {ALL_TRIGGERS.map((t) => (
+                  <option key={t} value={t}>{ACTION_TRIGGER_LABELS[t]}</option>
+                ))}
+              </select>
+            </div>
+            <div className="action-modal-footer">
+              <button className="btn btn-outline-secondary btn-sm" onClick={() => setShowAddAction(false)}>
+                キャンセル
+              </button>
+              <button className="btn btn-primary btn-sm" onClick={handleAddAction} disabled={!newActionName.trim()}>
+                追加
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/designer/src/components/action/ActionListView.tsx
+++ b/designer/src/components/action/ActionListView.tsx
@@ -1,0 +1,219 @@
+import { useState, useEffect, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import type { ActionGroupMeta, ActionGroupType } from "../../types/action";
+import { ACTION_GROUP_TYPE_LABELS, ACTION_GROUP_TYPE_ICONS } from "../../types/action";
+import { listActionGroups, createActionGroup, deleteActionGroup } from "../../store/actionStore";
+import { loadProject } from "../../store/flowStore";
+import { mcpBridge } from "../../mcp/mcpBridge";
+import { TableTopbar } from "../table/TableTopbar";
+import "../../styles/action.css";
+
+const ALL_TYPES: ActionGroupType[] = ["screen", "batch", "scheduled", "system", "common", "other"];
+
+export function ActionListView() {
+  const navigate = useNavigate();
+  const [groups, setGroups] = useState<ActionGroupMeta[]>([]);
+  const [projectName, setProjectName] = useState("プロジェクト");
+  const [filterType, setFilterType] = useState<ActionGroupType | "all">("all");
+  const [showAdd, setShowAdd] = useState(false);
+  const [addName, setAddName] = useState("");
+  const [addType, setAddType] = useState<ActionGroupType>("screen");
+  const [addScreenId, setAddScreenId] = useState("");
+  const [addDescription, setAddDescription] = useState("");
+  const [screens, setScreens] = useState<{ id: string; name: string }[]>([]);
+
+  const reload = useCallback(async () => {
+    const g = await listActionGroups();
+    setGroups(g);
+    const p = await loadProject();
+    setProjectName(p.name);
+    setScreens(p.screens.map((s) => ({ id: s.id, name: s.name })));
+  }, []);
+
+  useEffect(() => {
+    mcpBridge.startWithoutEditor();
+    reload();
+    // 接続完了後にリロード
+    const unsub = mcpBridge.onStatusChange((s) => {
+      if (s === "connected") reload();
+    });
+    return unsub;
+  }, [reload]);
+
+  const handleAdd = async () => {
+    const name = addName.trim();
+    if (!name) return;
+    const group = await createActionGroup(
+      name,
+      addType,
+      addType === "screen" && addScreenId ? addScreenId : undefined,
+      addDescription.trim() || undefined,
+    );
+    setShowAdd(false);
+    setAddName("");
+    setAddType("screen");
+    setAddScreenId("");
+    setAddDescription("");
+    navigate(`/actions/${group.id}`);
+  };
+
+  const handleDelete = async (id: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!confirm("この処理フロー定義を削除しますか？")) return;
+    await deleteActionGroup(id);
+    await reload();
+  };
+
+  const filtered = filterType === "all"
+    ? groups
+    : groups.filter((g) => g.type === filterType);
+
+  return (
+    <div className="action-page">
+      <TableTopbar projectName={projectName} />
+
+      <div className="action-content">
+        <div className="action-list-header">
+          <h5><i className="bi bi-diagram-3 me-2" />処理フロー定義</h5>
+          <button className="btn btn-primary btn-sm" onClick={() => setShowAdd(true)}>
+            <i className="bi bi-plus-lg me-1" />新規作成
+          </button>
+        </div>
+
+        <div className="action-list-filters">
+          <button
+            className={`btn btn-sm ${filterType === "all" ? "btn-primary" : "btn-outline-secondary"}`}
+            onClick={() => setFilterType("all")}
+          >
+            すべて ({groups.length})
+          </button>
+          {ALL_TYPES.map((t) => {
+            const count = groups.filter((g) => g.type === t).length;
+            if (count === 0) return null;
+            return (
+              <button
+                key={t}
+                className={`btn btn-sm ${filterType === t ? "btn-primary" : "btn-outline-secondary"}`}
+                onClick={() => setFilterType(t)}
+              >
+                {ACTION_GROUP_TYPE_LABELS[t]} ({count})
+              </button>
+            );
+          })}
+        </div>
+
+        {filtered.length === 0 ? (
+          <div className="step-empty">
+            <i className="bi bi-diagram-3" />
+            {groups.length === 0
+              ? "処理フロー定義がまだありません。「新規作成」から追加してください。"
+              : "該当する処理フロー定義がありません。"}
+          </div>
+        ) : (
+          <div className="action-list-grid">
+            {filtered.map((g) => (
+              <div
+                key={g.id}
+                className="action-group-card"
+                onClick={() => navigate(`/actions/${g.id}`)}
+              >
+                <div className="action-group-card-header">
+                  <span className={`action-group-type-badge ${g.type}`}>
+                    <i className={`${ACTION_GROUP_TYPE_ICONS[g.type as ActionGroupType] ?? "bi-three-dots"} me-1`} />
+                    {ACTION_GROUP_TYPE_LABELS[g.type as ActionGroupType] ?? g.type}
+                  </span>
+                  <span className="action-group-card-name">{g.name}</span>
+                </div>
+                <div className="action-group-card-meta">
+                  <span>
+                    <i className="bi bi-lightning me-1" />
+                    アクション: {g.actionCount}件
+                  </span>
+                  {g.screenId && (
+                    <span>
+                      <i className="bi bi-display me-1" />
+                      画面紐付き
+                    </span>
+                  )}
+                </div>
+                <div className="action-group-card-actions">
+                  <button
+                    className="btn btn-outline-danger btn-sm py-0 px-2"
+                    onClick={(e) => handleDelete(g.id, e)}
+                    title="削除"
+                  >
+                    <i className="bi bi-trash" />
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* 新規作成モーダル */}
+      {showAdd && (
+        <div className="action-modal-overlay" onClick={() => setShowAdd(false)}>
+          <div className="action-modal" onClick={(e) => e.stopPropagation()}>
+            <h6>処理フロー定義の新規作成</h6>
+            <div className="form-group">
+              <label className="form-label">名前 *</label>
+              <input
+                className="form-control form-control-sm"
+                value={addName}
+                onChange={(e) => setAddName(e.target.value)}
+                placeholder="例: ログイン画面、月次集計バッチ"
+                autoFocus
+              />
+            </div>
+            <div className="form-group">
+              <label className="form-label">種別 *</label>
+              <select
+                className="form-select form-select-sm"
+                value={addType}
+                onChange={(e) => setAddType(e.target.value as ActionGroupType)}
+              >
+                {ALL_TYPES.map((t) => (
+                  <option key={t} value={t}>{ACTION_GROUP_TYPE_LABELS[t]}</option>
+                ))}
+              </select>
+            </div>
+            {addType === "screen" && (
+              <div className="form-group">
+                <label className="form-label">紐付け画面</label>
+                <select
+                  className="form-select form-select-sm"
+                  value={addScreenId}
+                  onChange={(e) => setAddScreenId(e.target.value)}
+                >
+                  <option value="">（なし）</option>
+                  {screens.map((s) => (
+                    <option key={s.id} value={s.id}>{s.name}</option>
+                  ))}
+                </select>
+              </div>
+            )}
+            <div className="form-group">
+              <label className="form-label">説明</label>
+              <textarea
+                className="form-control form-control-sm"
+                rows={2}
+                value={addDescription}
+                onChange={(e) => setAddDescription(e.target.value)}
+                placeholder="処理フローの概要"
+              />
+            </div>
+            <div className="action-modal-footer">
+              <button className="btn btn-outline-secondary btn-sm" onClick={() => setShowAdd(false)}>
+                キャンセル
+              </button>
+              <button className="btn btn-primary btn-sm" onClick={handleAdd} disabled={!addName.trim()}>
+                作成
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/designer/src/components/action/StepCard.tsx
+++ b/designer/src/components/action/StepCard.tsx
@@ -1,0 +1,434 @@
+import { useState } from "react";
+import type { Step, StepType, DbOperation } from "../../types/action";
+import {
+  STEP_TYPE_LABELS,
+  STEP_TYPE_ICONS,
+  STEP_TYPE_COLORS,
+  DB_OPERATION_LABELS,
+} from "../../types/action";
+import { getStepLabel, resolveJumpLabel, getJumpTargetOptions } from "../../utils/actionUtils";
+
+interface StepCardProps {
+  step: Step;
+  index: number;
+  label: string;
+  allSteps: Step[];
+  tables: { id: string; name: string; logicalName: string }[];
+  screens: { id: string; name: string }[];
+  commonGroups: { id: string; name: string }[];
+  onChange: (changes: Partial<Step>) => void;
+  onMoveUp?: () => void;
+  onMoveDown?: () => void;
+  onDelete: () => void;
+  onDuplicate: () => void;
+  onAddSubStep: (type: StepType) => void;
+  onDeleteSubStep: (subStepId: string) => void;
+  onContextMenu: (e: React.MouseEvent) => void;
+  onNavigateCommon: (refId: string) => void;
+}
+
+const DB_OPS: DbOperation[] = ["SELECT", "INSERT", "UPDATE", "DELETE"];
+
+export function StepCard({
+  step,
+  index,
+  label,
+  allSteps,
+  tables,
+  screens,
+  commonGroups,
+  onChange,
+  onMoveUp,
+  onMoveDown,
+  onDelete,
+  onDuplicate,
+  onAddSubStep,
+  onDeleteSubStep,
+  onContextMenu,
+  onNavigateCommon,
+}: StepCardProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [showMenu, setShowMenu] = useState(false);
+
+  const color = STEP_TYPE_COLORS[step.type];
+
+  const summaryText = (): string => {
+    switch (step.type) {
+      case "validation":
+        return step.conditions || step.description || "バリデーション";
+      case "dbAccess":
+        return `${step.tableName || "?"} ${DB_OPERATION_LABELS[step.operation] ?? step.operation}${step.description ? ` - ${step.description}` : ""}`;
+      case "externalSystem":
+        return `${step.systemName || "?"}${step.protocol ? ` (${step.protocol})` : ""}${step.description ? ` - ${step.description}` : ""}`;
+      case "commonProcess":
+        return step.refName || step.description || "共通処理";
+      case "screenTransition":
+        return `${step.targetScreenName || "?"}${step.description ? ` - ${step.description}` : ""}`;
+      case "displayUpdate":
+        return step.target || step.description || "表示更新";
+      case "branch":
+        return step.condition || step.description || "条件分岐";
+      case "jump": {
+        const jumpLabel = resolveJumpLabel(step.jumpTo, allSteps);
+        return `[${jumpLabel}] へ${step.description ? ` - ${step.description}` : ""}`;
+      }
+      default:
+        return step.description || "その他";
+    }
+  };
+
+  return (
+    <div>
+      <div
+        className="step-card"
+        style={{ borderLeftColor: color }}
+        onContextMenu={onContextMenu}
+      >
+        <div className="step-card-header" onClick={() => setExpanded(!expanded)}>
+          <span className="step-card-drag-handle" title="ドラッグで移動">
+            <i className="bi bi-grip-vertical" />
+          </span>
+          <span className="step-card-number">{label}</span>
+          <i className={`step-card-icon ${STEP_TYPE_ICONS[step.type]}`} style={{ color }} />
+          <span className="step-card-type-label">{STEP_TYPE_LABELS[step.type]}</span>
+          <span className="step-card-description">{summaryText()}</span>
+          {step.type === "commonProcess" && step.refId && (
+            <button
+              className="btn btn-link btn-sm p-0 text-success"
+              onClick={(e) => { e.stopPropagation(); onNavigateCommon(step.refId); }}
+              title="共通処理の定義を開く"
+            >
+              <i className="bi bi-box-arrow-up-right" />
+            </button>
+          )}
+          <div className="d-flex gap-1 ms-auto" style={{ flexShrink: 0 }}>
+            {onMoveUp && (
+              <button className="step-card-menu-btn" onClick={(e) => { e.stopPropagation(); onMoveUp(); }} title="上に移動">
+                <i className="bi bi-chevron-up" />
+              </button>
+            )}
+            {onMoveDown && (
+              <button className="step-card-menu-btn" onClick={(e) => { e.stopPropagation(); onMoveDown(); }} title="下に移動">
+                <i className="bi bi-chevron-down" />
+              </button>
+            )}
+            <div style={{ position: "relative" }}>
+              <button
+                className="step-card-menu-btn"
+                onClick={(e) => { e.stopPropagation(); setShowMenu(!showMenu); }}
+              >
+                <i className="bi bi-three-dots" />
+              </button>
+              {showMenu && (
+                <div
+                  className="step-context-menu"
+                  style={{ top: "100%", right: 0, position: "absolute" }}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <button className="step-context-menu-item" onClick={() => { onDuplicate(); setShowMenu(false); }}>
+                    <i className="bi bi-copy" /> 複製
+                  </button>
+                  <button className="step-context-menu-item" onClick={() => { onAddSubStep("other"); setShowMenu(false); }}>
+                    <i className="bi bi-diagram-2" /> サブステップ追加
+                  </button>
+                  <div className="step-context-menu-sep" />
+                  <button className="step-context-menu-item danger" onClick={() => { onDelete(); setShowMenu(false); }}>
+                    <i className="bi bi-trash" /> 削除
+                  </button>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* 展開時: 編集フォーム */}
+        {expanded && (
+          <div className="step-card-body">
+            <div className="row g-2 mb-2">
+              <div className="col-12">
+                <label className="form-label">処理概要</label>
+                <input
+                  className="form-control form-control-sm"
+                  value={step.description}
+                  onChange={(e) => onChange({ description: e.target.value })}
+                  placeholder="処理の説明"
+                />
+              </div>
+            </div>
+
+            {/* 種別ごとの編集フィールド */}
+            {step.type === "validation" && (
+              <>
+                <div className="row g-2 mb-2">
+                  <div className="col-12">
+                    <label className="form-label">バリデーション条件</label>
+                    <input
+                      className="form-control form-control-sm"
+                      value={step.conditions}
+                      onChange={(e) => onChange({ conditions: e.target.value } as Partial<Step>)}
+                      placeholder="必須チェック、形式チェック等"
+                    />
+                  </div>
+                </div>
+                {step.inlineBranch && (
+                  <div className="step-inline-branch">
+                    <div className="step-branch-box ok">
+                      <div className="step-branch-label">A: OK</div>
+                      <input
+                        className="form-control form-control-sm"
+                        value={step.inlineBranch.ok}
+                        onChange={(e) =>
+                          onChange({ inlineBranch: { ...step.inlineBranch!, ok: e.target.value } } as Partial<Step>)
+                        }
+                        placeholder="OK時の処理"
+                      />
+                    </div>
+                    <div className="step-branch-box ng">
+                      <div className="step-branch-label">B: NG</div>
+                      <input
+                        className="form-control form-control-sm"
+                        value={step.inlineBranch.ng}
+                        onChange={(e) =>
+                          onChange({ inlineBranch: { ...step.inlineBranch!, ng: e.target.value } } as Partial<Step>)
+                        }
+                        placeholder="NG時の処理"
+                      />
+                    </div>
+                  </div>
+                )}
+              </>
+            )}
+
+            {step.type === "dbAccess" && (
+              <div className="row g-2 mb-2">
+                <div className="col-md-6">
+                  <label className="form-label">テーブル</label>
+                  <select
+                    className="form-select form-select-sm"
+                    value={step.tableName}
+                    onChange={(e) => {
+                      const t = tables.find((t) => t.name === e.target.value);
+                      onChange({ tableName: e.target.value, tableId: t?.id } as Partial<Step>);
+                    }}
+                  >
+                    <option value="">（選択）</option>
+                    {tables.map((t) => (
+                      <option key={t.id} value={t.name}>{t.name}（{t.logicalName}）</option>
+                    ))}
+                  </select>
+                </div>
+                <div className="col-md-3">
+                  <label className="form-label">操作</label>
+                  <select
+                    className="form-select form-select-sm"
+                    value={step.operation}
+                    onChange={(e) => onChange({ operation: e.target.value as DbOperation } as Partial<Step>)}
+                  >
+                    {DB_OPS.map((op) => (
+                      <option key={op} value={op}>{DB_OPERATION_LABELS[op]}</option>
+                    ))}
+                  </select>
+                </div>
+                <div className="col-md-3">
+                  <label className="form-label">対象フィールド</label>
+                  <input
+                    className="form-control form-control-sm"
+                    value={step.fields ?? ""}
+                    onChange={(e) => onChange({ fields: e.target.value } as Partial<Step>)}
+                    placeholder="概要"
+                  />
+                </div>
+              </div>
+            )}
+
+            {step.type === "externalSystem" && (
+              <div className="row g-2 mb-2">
+                <div className="col-md-6">
+                  <label className="form-label">接続先</label>
+                  <input
+                    className="form-control form-control-sm"
+                    value={step.systemName}
+                    onChange={(e) => onChange({ systemName: e.target.value } as Partial<Step>)}
+                    placeholder="システム名"
+                  />
+                </div>
+                <div className="col-md-6">
+                  <label className="form-label">プロトコル</label>
+                  <input
+                    className="form-control form-control-sm"
+                    value={step.protocol ?? ""}
+                    onChange={(e) => onChange({ protocol: e.target.value } as Partial<Step>)}
+                    placeholder="REST / SOAP / gRPC"
+                  />
+                </div>
+              </div>
+            )}
+
+            {step.type === "commonProcess" && (
+              <div className="row g-2 mb-2">
+                <div className="col-12">
+                  <label className="form-label">共通処理</label>
+                  <select
+                    className="form-select form-select-sm"
+                    value={step.refId}
+                    onChange={(e) => {
+                      const cg = commonGroups.find((g) => g.id === e.target.value);
+                      onChange({ refId: e.target.value, refName: cg?.name ?? "" } as Partial<Step>);
+                    }}
+                  >
+                    <option value="">（選択）</option>
+                    {commonGroups.map((g) => (
+                      <option key={g.id} value={g.id}>{g.name}</option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+            )}
+
+            {step.type === "screenTransition" && (
+              <div className="row g-2 mb-2">
+                <div className="col-12">
+                  <label className="form-label">遷移先画面</label>
+                  <select
+                    className="form-select form-select-sm"
+                    value={step.targetScreenId ?? ""}
+                    onChange={(e) => {
+                      const s = screens.find((s) => s.id === e.target.value);
+                      onChange({ targetScreenId: e.target.value, targetScreenName: s?.name ?? e.target.value } as Partial<Step>);
+                    }}
+                  >
+                    <option value="">（選択または手入力）</option>
+                    {screens.map((s) => (
+                      <option key={s.id} value={s.id}>{s.name}</option>
+                    ))}
+                  </select>
+                  <input
+                    className="form-control form-control-sm mt-1"
+                    value={step.targetScreenName}
+                    onChange={(e) => onChange({ targetScreenName: e.target.value } as Partial<Step>)}
+                    placeholder="画面名を直接入力"
+                  />
+                </div>
+              </div>
+            )}
+
+            {step.type === "displayUpdate" && (
+              <div className="row g-2 mb-2">
+                <div className="col-12">
+                  <label className="form-label">更新対象</label>
+                  <input
+                    className="form-control form-control-sm"
+                    value={step.target}
+                    onChange={(e) => onChange({ target: e.target.value } as Partial<Step>)}
+                    placeholder="メッセージ表示、一覧テーブル更新 等"
+                  />
+                </div>
+              </div>
+            )}
+
+            {step.type === "branch" && (
+              <>
+                <div className="row g-2 mb-2">
+                  <div className="col-12">
+                    <label className="form-label">分岐条件</label>
+                    <input
+                      className="form-control form-control-sm"
+                      value={step.condition}
+                      onChange={(e) => onChange({ condition: e.target.value } as Partial<Step>)}
+                      placeholder="条件式"
+                    />
+                  </div>
+                </div>
+                <div className="step-inline-branch">
+                  <div className="step-branch-box ok">
+                    <div className="step-branch-label">A: {step.branchA.label}</div>
+                    <input
+                      className="form-control form-control-sm"
+                      value={step.branchA.description}
+                      onChange={(e) =>
+                        onChange({ branchA: { ...step.branchA, description: e.target.value } } as Partial<Step>)
+                      }
+                      placeholder="A分岐の処理"
+                    />
+                  </div>
+                  <div className="step-branch-box ng">
+                    <div className="step-branch-label">B: {step.branchB.label}</div>
+                    <input
+                      className="form-control form-control-sm"
+                      value={step.branchB.description}
+                      onChange={(e) =>
+                        onChange({ branchB: { ...step.branchB, description: e.target.value } } as Partial<Step>)
+                      }
+                      placeholder="B分岐の処理"
+                    />
+                  </div>
+                </div>
+              </>
+            )}
+
+            {step.type === "jump" && (
+              <div className="row g-2 mb-2">
+                <div className="col-12">
+                  <label className="form-label">ジャンプ先</label>
+                  <select
+                    className="form-select form-select-sm"
+                    value={step.jumpTo}
+                    onChange={(e) => onChange({ jumpTo: e.target.value } as Partial<Step>)}
+                  >
+                    <option value="">（選択）</option>
+                    {getJumpTargetOptions(allSteps, step.id).map((opt) => (
+                      <option key={opt.id} value={opt.id}>
+                        {opt.label} {opt.description}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+            )}
+
+            {/* メモ */}
+            <div className="row g-2">
+              <div className="col-12">
+                <label className="form-label">メモ</label>
+                <input
+                  className="form-control form-control-sm"
+                  value={step.note ?? ""}
+                  onChange={(e) => onChange({ note: e.target.value })}
+                  placeholder="補足情報"
+                />
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* サブステップ */}
+      {step.subSteps && step.subSteps.length > 0 && (
+        <div className="sub-steps">
+          {step.subSteps.map((sub, si) => (
+            <div key={sub.id} className="mb-1">
+              <div
+                className="step-card"
+                style={{ borderLeftColor: STEP_TYPE_COLORS[sub.type] }}
+              >
+                <div className="step-card-header">
+                  <span className="step-card-number">{getStepLabel(index, si)}</span>
+                  <i className={`step-card-icon ${STEP_TYPE_ICONS[sub.type]}`} style={{ color: STEP_TYPE_COLORS[sub.type] }} />
+                  <span className="step-card-type-label">{STEP_TYPE_LABELS[sub.type]}</span>
+                  <span className="step-card-description">{sub.description || sub.type}</span>
+                  <button
+                    className="step-card-menu-btn ms-auto"
+                    onClick={() => onDeleteSubStep(sub.id)}
+                    title="サブステップ削除"
+                  >
+                    <i className="bi bi-x-lg" />
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/designer/src/components/flow/FlowTopbar.tsx
+++ b/designer/src/components/flow/FlowTopbar.tsx
@@ -108,6 +108,9 @@ export function FlowTopbar({
           <button className="global-nav-btn" onClick={() => navigate("/er")}>
             <i className="bi bi-share" /> ER図
           </button>
+          <button className="global-nav-btn" onClick={() => navigate("/actions")}>
+            <i className="bi bi-lightning" /> 処理フロー
+          </button>
         </nav>
       </div>
 

--- a/designer/src/components/table/TableTopbar.tsx
+++ b/designer/src/components/table/TableTopbar.tsx
@@ -10,6 +10,7 @@ export function TableTopbar({ projectName }: Props) {
   const isFlow = location.pathname === "/";
   const isTable = location.pathname.startsWith("/tables");
   const isEr = location.pathname === "/er";
+  const isAction = location.pathname.startsWith("/actions");
 
   return (
     <header className="flow-topbar">
@@ -34,6 +35,12 @@ export function TableTopbar({ projectName }: Props) {
             onClick={() => navigate("/er")}
           >
             <i className="bi bi-share" /> ER図
+          </button>
+          <button
+            className={`global-nav-btn${isAction ? " active" : ""}`}
+            onClick={() => navigate("/actions")}
+          >
+            <i className="bi bi-lightning" /> 処理フロー
           </button>
         </nav>
       </div>

--- a/designer/src/mcp/mcpBridge.ts
+++ b/designer/src/mcp/mcpBridge.ts
@@ -31,6 +31,10 @@ import {
   setErLayoutStorageBackend,
   type ErLayoutStorageBackend,
 } from "../store/erLayoutStore";
+import {
+  setActionStorageBackend,
+  type ActionStorageBackend,
+} from "../store/actionStore";
 
 export type McpStatus = "disconnected" | "connecting" | "connected";
 export type ThemeIdLike = "standard" | "card" | "compact" | "dark";
@@ -252,6 +256,14 @@ class McpBridgeImpl {
       saveErLayout: (data) => self.request("saveErLayout", { data }).then(() => undefined),
     };
     setErLayoutStorageBackend(erLayoutBackend);
+
+    const actionBackend: ActionStorageBackend = {
+      loadActionGroup: (id) => self.request("loadActionGroup", { id }),
+      saveActionGroup: (id, data) => self.request("saveActionGroup", { id, data }).then(() => undefined),
+      deleteActionGroup: (id) => self.request("deleteActionGroup", { id }).then(() => undefined),
+      listActionGroups: () => self.request("listActionGroups"),
+    };
+    setActionStorageBackend(actionBackend);
   }
 
   /** 切断時: localStorage フォールバックに戻す */
@@ -260,6 +272,7 @@ class McpBridgeImpl {
     setCustomBlocksBackend(null);
     setTableStorageBackend(null);
     setErLayoutStorageBackend(null);
+    setActionStorageBackend(null);
   }
 
   // ── メッセージ受信 ─────────────────────────────────────────────────────

--- a/designer/src/store/actionStore.ts
+++ b/designer/src/store/actionStore.ts
@@ -1,0 +1,242 @@
+/**
+ * actionStore.ts
+ * 処理フロー定義の永続化ストア
+ *
+ * - wsBridge 接続済み: サーバー側ファイルに保存（mcpBridge 経由）
+ * - 未接続: localStorage にフォールバック
+ */
+import type {
+  ActionGroup,
+  ActionGroupMeta,
+  ActionDefinition,
+  Step,
+  StepType,
+  ActionTrigger,
+  ActionGroupType,
+} from "../types/action";
+import type { FlowProject } from "../types/flow";
+import { loadProject, saveProject } from "./flowStore";
+import { generateUUID } from "../utils/uuid";
+
+// ─── ストレージバックエンド ──────────────────────────────────────────────
+
+export interface ActionStorageBackend {
+  loadActionGroup(id: string): Promise<unknown>;
+  saveActionGroup(id: string, data: unknown): Promise<void>;
+  deleteActionGroup(id: string): Promise<void>;
+  listActionGroups(): Promise<unknown>;
+}
+
+let _backend: ActionStorageBackend | null = null;
+
+export function setActionStorageBackend(b: ActionStorageBackend | null): void {
+  _backend = b;
+}
+
+// ─── localStorage キー ───────────────────────────────────────────────────
+
+const ACTION_PREFIX = "action-group-";
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+// ─── 公開 API ────────────────────────────────────────────────────────────
+
+/** アクショングループ一覧を取得（project.json のメタ情報） */
+export async function listActionGroups(): Promise<ActionGroupMeta[]> {
+  const project = await loadProject();
+  return (project.actionGroups ?? []) as ActionGroupMeta[];
+}
+
+/** アクショングループを読み込み */
+export async function loadActionGroup(id: string): Promise<ActionGroup | null> {
+  if (_backend) {
+    const data = await _backend.loadActionGroup(id);
+    return data ? (data as ActionGroup) : null;
+  }
+  const raw = localStorage.getItem(`${ACTION_PREFIX}${id}`);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as ActionGroup;
+  } catch {
+    return null;
+  }
+}
+
+/** アクショングループを保存（project.json のメタも同期） */
+export async function saveActionGroup(group: ActionGroup): Promise<void> {
+  group.updatedAt = now();
+
+  if (_backend) {
+    await _backend.saveActionGroup(group.id, group);
+  } else {
+    localStorage.setItem(`${ACTION_PREFIX}${group.id}`, JSON.stringify(group));
+  }
+
+  await syncActionGroupMeta(group);
+}
+
+/** アクショングループを新規作成 */
+export async function createActionGroup(
+  name: string,
+  type: ActionGroupType,
+  screenId?: string,
+  description?: string,
+): Promise<ActionGroup> {
+  const id = generateUUID();
+  const ts = now();
+  const group: ActionGroup = {
+    id,
+    name,
+    type,
+    screenId,
+    description: description ?? "",
+    actions: [],
+    createdAt: ts,
+    updatedAt: ts,
+  };
+  await saveActionGroup(group);
+  return group;
+}
+
+/** アクショングループを削除 */
+export async function deleteActionGroup(id: string): Promise<void> {
+  if (_backend) {
+    await _backend.deleteActionGroup(id);
+  } else {
+    localStorage.removeItem(`${ACTION_PREFIX}${id}`);
+  }
+
+  const project = await loadProject();
+  if (project.actionGroups) {
+    project.actionGroups = project.actionGroups.filter((a) => a.id !== id);
+    await saveProject(project);
+  }
+}
+
+/** アクションを追加 */
+export function addAction(
+  group: ActionGroup,
+  name: string,
+  trigger: ActionTrigger,
+): ActionDefinition {
+  const action: ActionDefinition = {
+    id: generateUUID(),
+    name,
+    trigger,
+    steps: [],
+  };
+  group.actions.push(action);
+  return action;
+}
+
+/** アクションを削除 */
+export function removeAction(group: ActionGroup, actionId: string): void {
+  const idx = group.actions.findIndex((a) => a.id === actionId);
+  if (idx >= 0) group.actions.splice(idx, 1);
+}
+
+/** ステップを追加 */
+export function addStep(
+  action: ActionDefinition,
+  type: StepType,
+  insertIndex?: number,
+): Step {
+  const step = createDefaultStep(type);
+  if (insertIndex !== undefined && insertIndex >= 0 && insertIndex <= action.steps.length) {
+    action.steps.splice(insertIndex, 0, step);
+  } else {
+    action.steps.push(step);
+  }
+  return step;
+}
+
+/** ステップを削除 */
+export function removeStep(action: ActionDefinition, stepId: string): void {
+  const idx = action.steps.findIndex((s) => s.id === stepId);
+  if (idx >= 0) action.steps.splice(idx, 1);
+}
+
+/** ステップを移動 */
+export function moveStep(
+  action: ActionDefinition,
+  fromIndex: number,
+  toIndex: number,
+): void {
+  if (fromIndex < 0 || fromIndex >= action.steps.length) return;
+  if (toIndex < 0 || toIndex >= action.steps.length) return;
+  const [step] = action.steps.splice(fromIndex, 1);
+  action.steps.splice(toIndex, 0, step);
+}
+
+/** サブステップを追加 */
+export function addSubStep(
+  parentStep: Step,
+  type: StepType,
+): Step {
+  if (!parentStep.subSteps) parentStep.subSteps = [];
+  const step = createDefaultStep(type);
+  parentStep.subSteps.push(step);
+  return step;
+}
+
+/** サブステップを削除 */
+export function removeSubStep(parentStep: Step, subStepId: string): void {
+  if (!parentStep.subSteps) return;
+  const idx = parentStep.subSteps.findIndex((s) => s.id === subStepId);
+  if (idx >= 0) parentStep.subSteps.splice(idx, 1);
+}
+
+// ─── 内部 ────────────────────────────────────────────────────────────────
+
+function createDefaultStep(type: StepType): Step {
+  const base = {
+    id: generateUUID(),
+    type,
+    description: "",
+  };
+  switch (type) {
+    case "validation":
+      return { ...base, type: "validation", conditions: "", inlineBranch: { ok: "続行", ng: "エラー表示" } };
+    case "dbAccess":
+      return { ...base, type: "dbAccess", tableName: "", operation: "SELECT" as const };
+    case "externalSystem":
+      return { ...base, type: "externalSystem", systemName: "" };
+    case "commonProcess":
+      return { ...base, type: "commonProcess", refId: "", refName: "" };
+    case "screenTransition":
+      return { ...base, type: "screenTransition", targetScreenName: "" };
+    case "displayUpdate":
+      return { ...base, type: "displayUpdate", target: "" };
+    case "branch":
+      return { ...base, type: "branch", condition: "", branchA: { label: "A", description: "" }, branchB: { label: "B", description: "" } };
+    case "jump":
+      return { ...base, type: "jump", jumpTo: "" };
+    case "other":
+      return { ...base, type: "other" };
+  }
+}
+
+/** project.json のアクショングループメタを同期 */
+async function syncActionGroupMeta(group: ActionGroup): Promise<void> {
+  const project = await loadProject();
+  if (!project.actionGroups) project.actionGroups = [];
+
+  const meta: FlowProject["actionGroups"] extends (infer T)[] | undefined ? T : never = {
+    id: group.id,
+    name: group.name,
+    type: group.type,
+    screenId: group.screenId,
+    actionCount: group.actions.length,
+    updatedAt: group.updatedAt,
+  };
+
+  const idx = project.actionGroups.findIndex((a) => a.id === group.id);
+  if (idx >= 0) {
+    project.actionGroups[idx] = meta;
+  } else {
+    project.actionGroups.push(meta);
+  }
+  await saveProject(project);
+}

--- a/designer/src/styles/action.css
+++ b/designer/src/styles/action.css
@@ -1,0 +1,592 @@
+/* ─── 処理フロー定義 共通 ─────────────────────────────────────────── */
+
+.action-page {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: #f8f9fa;
+}
+
+.action-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px;
+}
+
+/* ─── 処理フロー一覧 ─────────────────────────────────────────────── */
+
+.action-list-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.action-list-header h5 {
+  margin: 0;
+  font-weight: 700;
+}
+
+.action-list-filters {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.action-list-filters .btn {
+  font-size: 0.82rem;
+  padding: 4px 12px;
+}
+
+.action-list-filters .btn.active {
+  font-weight: 600;
+}
+
+.action-list-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 12px;
+}
+
+.action-group-card {
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 16px;
+  background: #fff;
+  cursor: pointer;
+  transition: box-shadow 0.15s, border-color 0.15s;
+}
+
+.action-group-card:hover {
+  border-color: #6366f1;
+  box-shadow: 0 2px 8px rgba(99, 102, 241, 0.15);
+}
+
+.action-group-card-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.action-group-type-badge {
+  font-size: 0.72rem;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.action-group-type-badge.screen { background: #dbeafe; color: #1d4ed8; }
+.action-group-type-badge.batch { background: #fef3c7; color: #92400e; }
+.action-group-type-badge.scheduled { background: #e0e7ff; color: #4338ca; }
+.action-group-type-badge.system { background: #fce7f3; color: #9d174d; }
+.action-group-type-badge.common { background: #d1fae5; color: #065f46; }
+.action-group-type-badge.other { background: #f1f5f9; color: #475569; }
+
+.action-group-card-name {
+  font-weight: 600;
+  font-size: 0.95rem;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.action-group-card-meta {
+  font-size: 0.8rem;
+  color: #64748b;
+  display: flex;
+  gap: 12px;
+}
+
+.action-group-card-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 8px;
+}
+
+/* ─── 処理フロー編集 ─────────────────────────────────────────────── */
+
+.action-editor-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 20px;
+  background: #fff;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.action-editor-breadcrumb {
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.action-editor-breadcrumb a {
+  color: #6366f1;
+  text-decoration: none;
+}
+
+.action-editor-breadcrumb a:hover {
+  text-decoration: underline;
+}
+
+.action-editor-info {
+  padding: 16px 20px;
+  background: #fff;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.action-editor-info .row {
+  gap: 8px 0;
+}
+
+/* ─── アクションタブ ──────────────────────────────────────────────── */
+
+.action-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 2px solid #e2e8f0;
+  padding: 0 20px;
+  background: #fff;
+  overflow-x: auto;
+}
+
+.action-tab {
+  padding: 10px 16px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #64748b;
+  border: none;
+  background: none;
+  cursor: pointer;
+  white-space: nowrap;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.action-tab:hover {
+  color: #334155;
+}
+
+.action-tab.active {
+  color: #6366f1;
+  border-bottom-color: #6366f1;
+  font-weight: 600;
+}
+
+.action-tab-add {
+  padding: 10px 12px;
+  font-size: 0.85rem;
+  color: #94a3b8;
+  border: none;
+  background: none;
+  cursor: pointer;
+  margin-bottom: -2px;
+}
+
+.action-tab-add:hover {
+  color: #6366f1;
+}
+
+/* ─── ステップエディタ ────────────────────────────────────────────── */
+
+.step-editor {
+  padding: 20px;
+  max-width: 800px;
+}
+
+.step-toolbar {
+  display: flex;
+  gap: 6px;
+  padding: 12px 0;
+  flex-wrap: wrap;
+  border-bottom: 1px solid #e2e8f0;
+  margin-bottom: 16px;
+}
+
+.step-toolbar-btn {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 5px 10px;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  background: #fff;
+  font-size: 0.78rem;
+  color: #475569;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+  white-space: nowrap;
+}
+
+.step-toolbar-btn:hover {
+  border-color: #6366f1;
+  background: #f5f3ff;
+  color: #4338ca;
+}
+
+.step-toolbar-btn i {
+  font-size: 0.85rem;
+}
+
+.step-toolbar-sep {
+  width: 1px;
+  background: #e2e8f0;
+  margin: 0 4px;
+}
+
+.step-template-btn {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 5px 10px;
+  border: 1px dashed #cbd5e1;
+  border-radius: 6px;
+  background: #f8fafc;
+  font-size: 0.78rem;
+  color: #64748b;
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+
+.step-template-btn:hover {
+  border-color: #6366f1;
+  color: #4338ca;
+}
+
+/* ─── ステップカード ──────────────────────────────────────────────── */
+
+.step-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.step-insert-point {
+  display: flex;
+  justify-content: center;
+  padding: 4px 0;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.step-list:hover .step-insert-point,
+.step-insert-point:focus-within {
+  opacity: 1;
+}
+
+.step-insert-btn {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 1px dashed #cbd5e1;
+  background: #fff;
+  color: #94a3b8;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 0.75rem;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.step-insert-btn:hover {
+  border-color: #6366f1;
+  color: #6366f1;
+  background: #f5f3ff;
+}
+
+.step-card {
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  background: #fff;
+  border-left: 4px solid #e2e8f0;
+  transition: box-shadow 0.15s, border-color 0.15s;
+}
+
+.step-card:hover {
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+}
+
+.step-card.dragging {
+  opacity: 0.5;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.step-card-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  cursor: pointer;
+}
+
+.step-card-drag-handle {
+  cursor: grab;
+  color: #cbd5e1;
+  font-size: 0.9rem;
+  padding: 2px;
+}
+
+.step-card-drag-handle:active {
+  cursor: grabbing;
+}
+
+.step-card-number {
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: #6366f1;
+  min-width: 28px;
+}
+
+.step-card-icon {
+  font-size: 0.9rem;
+}
+
+.step-card-type-label {
+  font-size: 0.72rem;
+  font-weight: 600;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: #f1f5f9;
+  color: #475569;
+  white-space: nowrap;
+}
+
+.step-card-description {
+  flex: 1;
+  font-size: 0.85rem;
+  color: #334155;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.step-card-menu-btn {
+  border: none;
+  background: none;
+  color: #94a3b8;
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.85rem;
+}
+
+.step-card-menu-btn:hover {
+  color: #475569;
+  background: #f1f5f9;
+}
+
+/* ─── ステップカード展開時 ────────────────────────────────────────── */
+
+.step-card-body {
+  padding: 0 12px 12px 48px;
+  font-size: 0.85rem;
+}
+
+.step-card-body .form-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #64748b;
+  margin-bottom: 2px;
+}
+
+.step-card-body .form-control,
+.step-card-body .form-select {
+  font-size: 0.85rem;
+}
+
+.step-card-body .row {
+  gap: 8px 0;
+}
+
+/* ─── インライン分岐 ──────────────────────────────────────────────── */
+
+.step-inline-branch {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.step-branch-box {
+  flex: 1;
+  padding: 8px 10px;
+  border-radius: 6px;
+  font-size: 0.8rem;
+}
+
+.step-branch-box.ok {
+  background: #f0fdf4;
+  border: 1px solid #bbf7d0;
+}
+
+.step-branch-box.ng {
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+}
+
+.step-branch-label {
+  font-weight: 600;
+  font-size: 0.72rem;
+  margin-bottom: 2px;
+}
+
+/* ─── サブステップ ────────────────────────────────────────────────── */
+
+.sub-steps {
+  margin-left: 24px;
+  margin-top: 8px;
+  padding-left: 12px;
+  border-left: 2px solid #e2e8f0;
+}
+
+.sub-steps .step-card {
+  border-left-width: 3px;
+}
+
+/* ─── ステップなし表示 ────────────────────────────────────────────── */
+
+.step-empty {
+  text-align: center;
+  padding: 40px 20px;
+  color: #94a3b8;
+  font-size: 0.9rem;
+}
+
+.step-empty i {
+  font-size: 2rem;
+  display: block;
+  margin-bottom: 8px;
+}
+
+/* ─── モーダル ────────────────────────────────────────────────────── */
+
+.action-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.action-modal {
+  background: #fff;
+  border-radius: 12px;
+  padding: 24px;
+  width: 90%;
+  max-width: 480px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15);
+}
+
+.action-modal h6 {
+  font-weight: 700;
+  margin-bottom: 16px;
+}
+
+.action-modal .form-group {
+  margin-bottom: 12px;
+}
+
+.action-modal .form-label {
+  font-size: 0.82rem;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.action-modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 20px;
+}
+
+/* ─── テンプレートドロップダウン ───────────────────────────────────── */
+
+.template-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  z-index: 100;
+  min-width: 280px;
+  padding: 8px 0;
+}
+
+.template-dropdown-item {
+  padding: 8px 16px;
+  cursor: pointer;
+  font-size: 0.82rem;
+  transition: background 0.1s;
+}
+
+.template-dropdown-item:hover {
+  background: #f5f3ff;
+}
+
+.template-dropdown-item-label {
+  font-weight: 600;
+  color: #334155;
+}
+
+.template-dropdown-item-desc {
+  font-size: 0.75rem;
+  color: #94a3b8;
+  margin-top: 1px;
+}
+
+/* ─── コンテキストメニュー ────────────────────────────────────────── */
+
+.step-context-menu {
+  position: fixed;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  z-index: 200;
+  min-width: 160px;
+  padding: 4px 0;
+}
+
+.step-context-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  font-size: 0.82rem;
+  color: #334155;
+  cursor: pointer;
+  border: none;
+  background: none;
+  width: 100%;
+  text-align: left;
+}
+
+.step-context-menu-item:hover {
+  background: #f5f3ff;
+}
+
+.step-context-menu-item.danger {
+  color: #dc2626;
+}
+
+.step-context-menu-item.danger:hover {
+  background: #fef2f2;
+}
+
+.step-context-menu-sep {
+  height: 1px;
+  background: #e2e8f0;
+  margin: 4px 0;
+}

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -1,0 +1,308 @@
+// ── 処理フロー定義 型定義 ─────────────────────────────────────────────────
+
+/** ステップ種別 */
+export type StepType =
+  | "validation"       // バリデーション
+  | "dbAccess"         // DB操作
+  | "externalSystem"   // 外部システム呼び出し
+  | "commonProcess"    // 共通処理参照
+  | "screenTransition" // 画面遷移
+  | "displayUpdate"    // 表示更新
+  | "branch"           // 条件分岐（インラインA/B）
+  | "jump"             // 別大分類へのジャンプ
+  | "other";           // その他
+
+/** ステップ種別ラベル */
+export const STEP_TYPE_LABELS: Record<StepType, string> = {
+  validation: "バリデーション",
+  dbAccess: "DB操作",
+  externalSystem: "外部システム",
+  commonProcess: "共通処理",
+  screenTransition: "画面遷移",
+  displayUpdate: "表示更新",
+  branch: "条件分岐",
+  jump: "ジャンプ",
+  other: "その他",
+};
+
+/** ステップ種別アイコン */
+export const STEP_TYPE_ICONS: Record<StepType, string> = {
+  validation: "bi-check-circle",
+  dbAccess: "bi-database",
+  externalSystem: "bi-cloud",
+  commonProcess: "bi-box-seam",
+  screenTransition: "bi-arrow-right-square",
+  displayUpdate: "bi-display",
+  branch: "bi-signpost-split",
+  jump: "bi-arrow-return-right",
+  other: "bi-three-dots",
+};
+
+/** ステップ種別カラー（左ボーダー色） */
+export const STEP_TYPE_COLORS: Record<StepType, string> = {
+  validation: "#f59e0b",
+  dbAccess: "#3b82f6",
+  externalSystem: "#8b5cf6",
+  commonProcess: "#10b981",
+  screenTransition: "#ec4899",
+  displayUpdate: "#6366f1",
+  branch: "#f97316",
+  jump: "#94a3b8",
+  other: "#9ca3af",
+};
+
+/** DB操作種別 */
+export type DbOperation = "SELECT" | "INSERT" | "UPDATE" | "DELETE";
+
+export const DB_OPERATION_LABELS: Record<DbOperation, string> = {
+  SELECT: "検索",
+  INSERT: "登録",
+  UPDATE: "更新",
+  DELETE: "削除",
+};
+
+/** ActionGroupの種別 */
+export type ActionGroupType =
+  | "screen"     // 画面のアクション
+  | "batch"      // バッチ処理
+  | "scheduled"  // スケジュール処理
+  | "system"     // セッションタイムアウト等
+  | "common"     // 共通処理
+  | "other";
+
+export const ACTION_GROUP_TYPE_LABELS: Record<ActionGroupType, string> = {
+  screen: "画面",
+  batch: "バッチ",
+  scheduled: "スケジュール",
+  system: "システム",
+  common: "共通処理",
+  other: "その他",
+};
+
+export const ACTION_GROUP_TYPE_ICONS: Record<ActionGroupType, string> = {
+  screen: "bi-display",
+  batch: "bi-gear",
+  scheduled: "bi-clock",
+  system: "bi-cpu",
+  common: "bi-box-seam",
+  other: "bi-three-dots",
+};
+
+/** トリガー種別 */
+export type ActionTrigger =
+  | "click"   // ボタン/リンククリック
+  | "submit"  // フォーム送信
+  | "select"  // 行選択
+  | "change"  // 値変更
+  | "load"    // 画面読み込み
+  | "timer"   // タイマー
+  | "other";  // その他
+
+export const ACTION_TRIGGER_LABELS: Record<ActionTrigger, string> = {
+  click: "クリック",
+  submit: "フォーム送信",
+  select: "行選択",
+  change: "値変更",
+  load: "画面読み込み",
+  timer: "タイマー",
+  other: "その他",
+};
+
+// ── ステップ定義 ─────────────────────────────────────────────────────────
+
+/** ステップ共通フィールド */
+export interface StepBase {
+  id: string;
+  type: StepType;
+  description: string;
+  note?: string;
+  subSteps?: Step[];
+}
+
+export interface ValidationStep extends StepBase {
+  type: "validation";
+  conditions: string;
+  inlineBranch?: {
+    ok: string;
+    ng: string;
+    ngJumpTo?: string;
+  };
+}
+
+export interface DbAccessStep extends StepBase {
+  type: "dbAccess";
+  tableName: string;
+  tableId?: string;
+  operation: DbOperation;
+  fields?: string;
+}
+
+export interface ExternalSystemStep extends StepBase {
+  type: "externalSystem";
+  systemName: string;
+  protocol?: string;
+}
+
+export interface CommonProcessStep extends StepBase {
+  type: "commonProcess";
+  refId: string;
+  refName?: string;
+}
+
+export interface ScreenTransitionStep extends StepBase {
+  type: "screenTransition";
+  targetScreenId?: string;
+  targetScreenName: string;
+}
+
+export interface DisplayUpdateStep extends StepBase {
+  type: "displayUpdate";
+  target: string;
+}
+
+export interface BranchStep extends StepBase {
+  type: "branch";
+  condition: string;
+  branchA: { label: string; description: string; jumpTo?: string };
+  branchB: { label: string; description: string; jumpTo?: string };
+}
+
+export interface JumpStep extends StepBase {
+  type: "jump";
+  jumpTo: string;
+}
+
+export interface OtherStep extends StepBase {
+  type: "other";
+}
+
+export type Step =
+  | ValidationStep
+  | DbAccessStep
+  | ExternalSystemStep
+  | CommonProcessStep
+  | ScreenTransitionStep
+  | DisplayUpdateStep
+  | BranchStep
+  | JumpStep
+  | OtherStep;
+
+// ── アクション定義 ───────────────────────────────────────────────────────
+
+export interface ActionDefinition {
+  id: string;
+  name: string;
+  trigger: ActionTrigger;
+  elementRef?: string;
+  description?: string;
+  steps: Step[];
+}
+
+// ── アクショングループ ───────────────────────────────────────────────────
+
+export interface ActionGroup {
+  id: string;
+  name: string;
+  type: ActionGroupType;
+  screenId?: string;
+  description: string;
+  actions: ActionDefinition[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** project.json用メタデータ */
+export interface ActionGroupMeta {
+  id: string;
+  name: string;
+  type: ActionGroupType;
+  screenId?: string;
+  actionCount: number;
+  updatedAt: string;
+}
+
+// ── ステップテンプレート ─────────────────────────────────────────────────
+
+/** テンプレート用のステップ定義（id省略、種別固有フィールドは any） */
+export type TemplateStep = Omit<StepBase, "id"> & Record<string, unknown>;
+
+export interface StepTemplate {
+  id: string;
+  label: string;
+  description: string;
+  steps: TemplateStep[];
+}
+
+export const STEP_TEMPLATES: StepTemplate[] = [
+  {
+    id: "tpl-validate-error",
+    label: "バリデーション + エラー表示",
+    description: "入力チェック → NG時エラーメッセージ表示",
+    steps: [
+      {
+        type: "validation",
+        description: "入力値チェック",
+        conditions: "必須項目、形式チェック",
+        inlineBranch: {
+          ok: "次のステップへ続行",
+          ng: "エラーメッセージを表示、処理中断",
+        },
+      },
+    ],
+  },
+  {
+    id: "tpl-db-search-display",
+    label: "DB検索 + 結果表示",
+    description: "テーブル検索 → 結果を画面に表示",
+    steps: [
+      {
+        type: "dbAccess",
+        description: "データ検索",
+        tableName: "",
+        operation: "SELECT",
+      },
+      {
+        type: "displayUpdate",
+        description: "検索結果を一覧に表示",
+        target: "一覧テーブル",
+      },
+    ],
+  },
+  {
+    id: "tpl-db-insert-transition",
+    label: "DB登録 + 完了画面遷移",
+    description: "テーブル登録 → 完了画面へ遷移",
+    steps: [
+      {
+        type: "dbAccess",
+        description: "データ登録",
+        tableName: "",
+        operation: "INSERT" as DbOperation,
+      },
+      {
+        type: "screenTransition",
+        description: "完了画面へ遷移",
+        targetScreenName: "",
+      },
+    ],
+  },
+  {
+    id: "tpl-auth-check",
+    label: "認証 + 権限チェック",
+    description: "認証チェック → 権限チェック → NG時ログイン画面",
+    steps: [
+      {
+        type: "commonProcess",
+        description: "認証チェック",
+        refId: "",
+        refName: "認証チェック",
+      },
+      {
+        type: "commonProcess",
+        description: "権限チェック",
+        refId: "",
+        refName: "権限チェック",
+      },
+    ],
+  },
+];

--- a/designer/src/types/flow.ts
+++ b/designer/src/types/flow.ts
@@ -113,6 +113,16 @@ export interface TableMeta {
   updatedAt: string;
 }
 
+/** アクショングループメタ情報（project.json 管理用） */
+export interface ActionGroupMeta {
+  id: string;
+  name: string;
+  type: string;
+  screenId?: string;
+  actionCount: number;
+  updatedAt: string;
+}
+
 /** プロジェクト全体 */
 export interface FlowProject {
   version: 1;
@@ -121,5 +131,6 @@ export interface FlowProject {
   groups: ScreenGroup[];
   edges: ScreenEdge[];
   tables?: TableMeta[];
+  actionGroups?: ActionGroupMeta[];
   updatedAt: string;
 }

--- a/designer/src/utils/actionUtils.ts
+++ b/designer/src/utils/actionUtils.ts
@@ -1,0 +1,109 @@
+/**
+ * actionUtils.ts
+ * 処理フローの自動採番・ジャンプ参照解決ユーティリティ
+ */
+import type { Step } from "../types/action";
+
+/**
+ * ステップの表示ラベルを生成（1, 2, 3... / 1-1, 1-2...）
+ */
+export function getStepLabel(stepIndex: number, subStepIndex?: number): string {
+  const major = stepIndex + 1;
+  if (subStepIndex === undefined) return `${major}`;
+  return `${major}-${subStepIndex + 1}`;
+}
+
+/**
+ * ステップIDから表示ラベルを解決するマップを作成
+ */
+export function buildStepLabelMap(steps: Step[]): Map<string, string> {
+  const map = new Map<string, string>();
+  for (let i = 0; i < steps.length; i++) {
+    const step = steps[i];
+    map.set(step.id, getStepLabel(i));
+    if (step.subSteps) {
+      for (let j = 0; j < step.subSteps.length; j++) {
+        map.set(step.subSteps[j].id, getStepLabel(i, j));
+      }
+    }
+  }
+  return map;
+}
+
+/**
+ * ジャンプ参照先のラベルを解決
+ */
+export function resolveJumpLabel(
+  jumpTo: string,
+  steps: Step[],
+): string {
+  const labelMap = buildStepLabelMap(steps);
+  return labelMap.get(jumpTo) ?? "?";
+}
+
+/**
+ * ステップ内のジャンプ参照を更新
+ * oldId → newId に置換
+ */
+export function updateJumpReferences(
+  steps: Step[],
+  oldId: string,
+  newId: string,
+): void {
+  for (const step of steps) {
+    if (step.type === "jump" && step.jumpTo === oldId) {
+      step.jumpTo = newId;
+    }
+    if (step.type === "branch") {
+      if (step.branchA.jumpTo === oldId) step.branchA.jumpTo = newId;
+      if (step.branchB.jumpTo === oldId) step.branchB.jumpTo = newId;
+    }
+    if (step.type === "validation" && step.inlineBranch?.ngJumpTo === oldId) {
+      step.inlineBranch.ngJumpTo = newId;
+    }
+    if (step.subSteps) {
+      updateJumpReferences(step.subSteps, oldId, newId);
+    }
+  }
+}
+
+/**
+ * 削除されたステップへのジャンプ参照をクリア
+ */
+export function clearJumpReferences(steps: Step[], deletedId: string): void {
+  for (const step of steps) {
+    if (step.type === "jump" && step.jumpTo === deletedId) {
+      step.jumpTo = "";
+    }
+    if (step.type === "branch") {
+      if (step.branchA.jumpTo === deletedId) step.branchA.jumpTo = undefined;
+      if (step.branchB.jumpTo === deletedId) step.branchB.jumpTo = undefined;
+    }
+    if (step.type === "validation" && step.inlineBranch?.ngJumpTo === deletedId) {
+      step.inlineBranch.ngJumpTo = undefined;
+    }
+    if (step.subSteps) {
+      clearJumpReferences(step.subSteps, deletedId);
+    }
+  }
+}
+
+/**
+ * ステップ一覧からジャンプ先候補を取得（自分自身は除く）
+ */
+export function getJumpTargetOptions(
+  steps: Step[],
+  excludeStepId: string,
+): { id: string; label: string; description: string }[] {
+  const labelMap = buildStepLabelMap(steps);
+  const options: { id: string; label: string; description: string }[] = [];
+  for (const step of steps) {
+    if (step.id === excludeStepId) continue;
+    options.push({
+      id: step.id,
+      label: `[${labelMap.get(step.id) ?? "?"}]`,
+      description: step.description || step.type,
+    });
+  }
+  return options;
+}

--- a/designer/src/utils/specExporter.ts
+++ b/designer/src/utils/specExporter.ts
@@ -8,7 +8,9 @@
 import type { TableDefinition } from "../types/table";
 import type { ErRelation, ErLayout } from "../types/table";
 import type { FlowProject } from "../types/flow";
+import type { ActionGroup, Step } from "../types/action";
 import { getAllRelations } from "./erUtils";
+import { getStepLabel } from "./actionUtils";
 
 export interface SpecJson {
   /** プロジェクト名 */
@@ -23,6 +25,10 @@ export interface SpecJson {
   screens: SpecScreen[];
   /** 画面遷移 */
   transitions: SpecTransition[];
+  /** 処理フロー定義 */
+  actionGroups?: SpecActionGroup[];
+  /** 共通処理定義 */
+  commonProcesses?: SpecCommonProcess[];
 }
 
 export interface SpecTable {
@@ -87,6 +93,34 @@ export interface SpecTransition {
   trigger: string;
 }
 
+export interface SpecActionGroup {
+  name: string;
+  type: string;
+  screenName?: string;
+  description: string;
+  actions: SpecAction[];
+}
+
+export interface SpecAction {
+  name: string;
+  trigger: string;
+  steps: SpecStep[];
+}
+
+export interface SpecStep {
+  number: string;
+  type: string;
+  description: string;
+  detail: Record<string, unknown>;
+}
+
+export interface SpecCommonProcess {
+  id: string;
+  name: string;
+  description: string;
+  steps: SpecStep[];
+}
+
 /**
  * 統合JSON仕様書を生成
  */
@@ -94,10 +128,15 @@ export function generateSpecJson(
   project: FlowProject,
   tables: TableDefinition[],
   erLayout: ErLayout | null,
+  actionGroups?: ActionGroup[],
 ): SpecJson {
   const relations = getAllRelations(tables, erLayout);
 
-  return {
+  // 共通処理とそれ以外を分離
+  const commonGroups = (actionGroups ?? []).filter((g) => g.type === "common");
+  const nonCommonGroups = (actionGroups ?? []).filter((g) => g.type !== "common");
+
+  const result: SpecJson = {
     projectName: project.name,
     generatedAt: new Date().toISOString(),
     tables: tables.map((t) => toSpecTable(t)),
@@ -120,6 +159,38 @@ export function generateSpecJson(
       };
     }),
   };
+
+  if (actionGroups && actionGroups.length > 0) {
+    result.actionGroups = nonCommonGroups.map((g) => {
+      const screenName = g.screenId
+        ? project.screens.find((s) => s.id === g.screenId)?.name
+        : undefined;
+      return {
+        name: g.name,
+        type: g.type,
+        screenName,
+        description: g.description,
+        actions: g.actions.map((a) => ({
+          name: a.name,
+          trigger: a.trigger,
+          steps: a.steps.map((s, i) => toSpecStep(s, i)),
+        })),
+      };
+    });
+
+    if (commonGroups.length > 0) {
+      result.commonProcesses = commonGroups.map((g) => ({
+        id: g.id,
+        name: g.name,
+        description: g.description,
+        steps: g.actions.length > 0
+          ? g.actions[0].steps.map((s, i) => toSpecStep(s, i))
+          : [],
+      }));
+    }
+  }
+
+  return result;
 }
 
 function toSpecTable(t: TableDefinition): SpecTable {
@@ -186,5 +257,48 @@ function toSpecRelation(r: ErRelation): SpecRelation {
     cardinality: r.cardinality,
     constraintType,
     memo: r.label,
+  };
+}
+
+function toSpecStep(s: Step, index: number): SpecStep {
+  const detail: Record<string, unknown> = {};
+  switch (s.type) {
+    case "validation":
+      detail.conditions = s.conditions;
+      if (s.inlineBranch) detail.inlineBranch = s.inlineBranch;
+      break;
+    case "dbAccess":
+      detail.tableName = s.tableName;
+      detail.operation = s.operation;
+      if (s.fields) detail.fields = s.fields;
+      break;
+    case "externalSystem":
+      detail.systemName = s.systemName;
+      if (s.protocol) detail.protocol = s.protocol;
+      break;
+    case "commonProcess":
+      detail.refId = s.refId;
+      detail.refName = s.refName;
+      break;
+    case "screenTransition":
+      detail.targetScreenName = s.targetScreenName;
+      break;
+    case "displayUpdate":
+      detail.target = s.target;
+      break;
+    case "branch":
+      detail.condition = s.condition;
+      detail.branchA = s.branchA;
+      detail.branchB = s.branchB;
+      break;
+    case "jump":
+      detail.jumpTo = s.jumpTo;
+      break;
+  }
+  return {
+    number: getStepLabel(index),
+    type: s.type,
+    description: s.description,
+    detail,
   };
 }

--- a/docs/sample-project/actions/cccccccc-0001-4000-8000-cccccccccccc.json
+++ b/docs/sample-project/actions/cccccccc-0001-4000-8000-cccccccccccc.json
@@ -1,0 +1,64 @@
+{
+  "id": "cccccccc-0001-4000-8000-cccccccccccc",
+  "name": "ログイン画面",
+  "type": "screen",
+  "screenId": "aaaaaaaa-0001-4000-8000-aaaaaaaaaaaa",
+  "description": "ログイン画面の処理フロー定義",
+  "actions": [
+    {
+      "id": "act-login-001",
+      "name": "ログインボタン",
+      "trigger": "click",
+      "steps": [
+        {
+          "id": "step-login-001",
+          "type": "validation",
+          "description": "入力値チェック",
+          "conditions": "ユーザーID・パスワードの必須チェック",
+          "inlineBranch": {
+            "ok": "次のステップへ続行",
+            "ng": "エラーメッセージを表示、処理中断"
+          }
+        },
+        {
+          "id": "step-login-002",
+          "type": "commonProcess",
+          "description": "認証チェック",
+          "refId": "cccccccc-0003-4000-8000-cccccccccccc",
+          "refName": "認証チェック"
+        },
+        {
+          "id": "step-login-003",
+          "type": "dbAccess",
+          "description": "ユーザー情報取得",
+          "tableName": "users",
+          "tableId": "bbbbbbbb-0001-4000-8000-bbbbbbbbbbbb",
+          "operation": "SELECT",
+          "fields": "ユーザー名、権限情報"
+        },
+        {
+          "id": "step-login-004",
+          "type": "screenTransition",
+          "description": "ダッシュボードへ遷移",
+          "targetScreenId": "aaaaaaaa-0002-4000-8000-aaaaaaaaaaaa",
+          "targetScreenName": "ダッシュボード"
+        }
+      ]
+    },
+    {
+      "id": "act-login-002",
+      "name": "パスワードリセットリンク",
+      "trigger": "click",
+      "steps": [
+        {
+          "id": "step-login-005",
+          "type": "screenTransition",
+          "description": "パスワードリセット画面へ遷移",
+          "targetScreenName": "パスワードリセット画面"
+        }
+      ]
+    }
+  ],
+  "createdAt": "2026-04-14T00:00:00.000Z",
+  "updatedAt": "2026-04-14T00:00:00.000Z"
+}

--- a/docs/sample-project/actions/cccccccc-0002-4000-8000-cccccccccccc.json
+++ b/docs/sample-project/actions/cccccccc-0002-4000-8000-cccccccccccc.json
@@ -1,0 +1,93 @@
+{
+  "id": "cccccccc-0002-4000-8000-cccccccccccc",
+  "name": "顧客一覧画面",
+  "type": "screen",
+  "screenId": "aaaaaaaa-0003-4000-8000-aaaaaaaaaaaa",
+  "description": "顧客一覧画面の処理フロー定義",
+  "actions": [
+    {
+      "id": "act-custlist-001",
+      "name": "検索ボタン",
+      "trigger": "click",
+      "steps": [
+        {
+          "id": "step-custlist-001",
+          "type": "validation",
+          "description": "検索条件チェック",
+          "conditions": "検索条件の形式チェック（電話番号、メール形式）",
+          "inlineBranch": {
+            "ok": "検索処理を実行",
+            "ng": "エラーメッセージを表示"
+          }
+        },
+        {
+          "id": "step-custlist-002",
+          "type": "dbAccess",
+          "description": "顧客データ検索",
+          "tableName": "customers",
+          "tableId": "bbbbbbbb-0002-4000-8000-bbbbbbbbbbbb",
+          "operation": "SELECT",
+          "fields": "顧客名、フリガナ、電話番号、メールアドレス"
+        },
+        {
+          "id": "step-custlist-003",
+          "type": "displayUpdate",
+          "description": "検索結果を一覧テーブルに表示",
+          "target": "顧客一覧テーブル"
+        }
+      ]
+    },
+    {
+      "id": "act-custlist-002",
+      "name": "新規登録ボタン",
+      "trigger": "click",
+      "steps": [
+        {
+          "id": "step-custlist-004",
+          "type": "screenTransition",
+          "description": "顧客登録画面へ遷移",
+          "targetScreenId": "aaaaaaaa-0004-4000-8000-aaaaaaaaaaaa",
+          "targetScreenName": "顧客登録"
+        }
+      ]
+    },
+    {
+      "id": "act-custlist-003",
+      "name": "詳細ボタン",
+      "trigger": "click",
+      "steps": [
+        {
+          "id": "step-custlist-005",
+          "type": "dbAccess",
+          "description": "顧客詳細データ取得",
+          "tableName": "customers",
+          "tableId": "bbbbbbbb-0002-4000-8000-bbbbbbbbbbbb",
+          "operation": "SELECT",
+          "fields": "全カラム"
+        },
+        {
+          "id": "step-custlist-006",
+          "type": "screenTransition",
+          "description": "顧客詳細画面へ遷移",
+          "targetScreenId": "aaaaaaaa-0005-4000-8000-aaaaaaaaaaaa",
+          "targetScreenName": "顧客詳細"
+        }
+      ]
+    },
+    {
+      "id": "act-custlist-004",
+      "name": "クリアボタン",
+      "trigger": "click",
+      "steps": [
+        {
+          "id": "step-custlist-007",
+          "type": "displayUpdate",
+          "description": "検索条件と一覧をクリア",
+          "target": "検索フォーム・一覧テーブル"
+        }
+      ]
+    }
+  ],
+  "createdAt": "2026-04-14T00:00:00.000Z",
+  "updatedAt": "2026-04-14T00:00:00.000Z"
+}

--- a/docs/sample-project/actions/cccccccc-0003-4000-8000-cccccccccccc.json
+++ b/docs/sample-project/actions/cccccccc-0003-4000-8000-cccccccccccc.json
@@ -1,0 +1,51 @@
+{
+  "id": "cccccccc-0003-4000-8000-cccccccccccc",
+  "name": "認証チェック",
+  "type": "common",
+  "description": "セッション・トークン検証を行う共通処理",
+  "actions": [
+    {
+      "id": "act-auth-001",
+      "name": "認証処理",
+      "trigger": "other",
+      "steps": [
+        {
+          "id": "step-auth-001",
+          "type": "validation",
+          "description": "セッション有効性チェック",
+          "conditions": "セッションIDの存在確認・有効期限チェック",
+          "inlineBranch": {
+            "ok": "トークン検証へ",
+            "ng": "ログイン画面へリダイレクト"
+          }
+        },
+        {
+          "id": "step-auth-002",
+          "type": "dbAccess",
+          "description": "トークン検証",
+          "tableName": "users",
+          "tableId": "bbbbbbbb-0001-4000-8000-bbbbbbbbbbbb",
+          "operation": "SELECT",
+          "fields": "認証トークン、有効期限"
+        },
+        {
+          "id": "step-auth-003",
+          "type": "branch",
+          "description": "認証結果判定",
+          "condition": "トークンが有効か",
+          "branchA": {
+            "label": "有効",
+            "description": "処理を続行"
+          },
+          "branchB": {
+            "label": "無効",
+            "description": "ログイン画面へリダイレクト",
+            "jumpTo": ""
+          }
+        }
+      ]
+    }
+  ],
+  "createdAt": "2026-04-14T00:00:00.000Z",
+  "updatedAt": "2026-04-14T00:00:00.000Z"
+}

--- a/docs/sample-project/actions/cccccccc-0004-4000-8000-cccccccccccc.json
+++ b/docs/sample-project/actions/cccccccc-0004-4000-8000-cccccccccccc.json
@@ -1,0 +1,48 @@
+{
+  "id": "cccccccc-0004-4000-8000-cccccccccccc",
+  "name": "月次売上集計バッチ",
+  "type": "batch",
+  "description": "月次の売上データを集計するバッチ処理",
+  "actions": [
+    {
+      "id": "act-batch-001",
+      "name": "集計実行",
+      "trigger": "timer",
+      "steps": [
+        {
+          "id": "step-batch-001",
+          "type": "dbAccess",
+          "description": "注文データ取得",
+          "tableName": "orders",
+          "tableId": "bbbbbbbb-0003-4000-8000-bbbbbbbbbbbb",
+          "operation": "SELECT",
+          "fields": "対象月の全注文データ"
+        },
+        {
+          "id": "step-batch-002",
+          "type": "other",
+          "description": "売上集計処理",
+          "note": "顧客別・商品別の売上を集計"
+        },
+        {
+          "id": "step-batch-003",
+          "type": "dbAccess",
+          "description": "集計結果登録",
+          "tableName": "orders",
+          "tableId": "bbbbbbbb-0003-4000-8000-bbbbbbbbbbbb",
+          "operation": "UPDATE",
+          "fields": "月次集計ステータス更新"
+        },
+        {
+          "id": "step-batch-004",
+          "type": "commonProcess",
+          "description": "処理完了ログ出力",
+          "refId": "",
+          "refName": "ログ出力"
+        }
+      ]
+    }
+  ],
+  "createdAt": "2026-04-14T00:00:00.000Z",
+  "updatedAt": "2026-04-14T00:00:00.000Z"
+}

--- a/docs/sample-project/project.json
+++ b/docs/sample-project/project.json
@@ -294,5 +294,37 @@
       "updatedAt": "2026-04-13T00:00:00.000Z"
     }
   ],
-  "updatedAt": "2026-04-13T00:00:00.000Z"
+  "actionGroups": [
+    {
+      "id": "cccccccc-0001-4000-8000-cccccccccccc",
+      "name": "ログイン画面",
+      "type": "screen",
+      "screenId": "aaaaaaaa-0001-4000-8000-aaaaaaaaaaaa",
+      "actionCount": 2,
+      "updatedAt": "2026-04-14T00:00:00.000Z"
+    },
+    {
+      "id": "cccccccc-0002-4000-8000-cccccccccccc",
+      "name": "顧客一覧画面",
+      "type": "screen",
+      "screenId": "aaaaaaaa-0003-4000-8000-aaaaaaaaaaaa",
+      "actionCount": 4,
+      "updatedAt": "2026-04-14T00:00:00.000Z"
+    },
+    {
+      "id": "cccccccc-0003-4000-8000-cccccccccccc",
+      "name": "認証チェック",
+      "type": "common",
+      "actionCount": 1,
+      "updatedAt": "2026-04-14T00:00:00.000Z"
+    },
+    {
+      "id": "cccccccc-0004-4000-8000-cccccccccccc",
+      "name": "月次売上集計バッチ",
+      "type": "batch",
+      "actionCount": 1,
+      "updatedAt": "2026-04-14T00:00:00.000Z"
+    }
+  ],
+  "updatedAt": "2026-04-14T00:00:00.000Z"
 }

--- a/docs/sample-project/seed.mjs
+++ b/docs/sample-project/seed.mjs
@@ -18,11 +18,14 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DATA_DIR = path.resolve(__dirname, "../../data");
 const SCREENS_DIR = path.join(DATA_DIR, "screens");
 const TABLES_DIR = path.join(DATA_DIR, "tables");
+const ACTIONS_DIR = path.join(DATA_DIR, "actions");
 const SEED_SCREENS_DIR = path.join(__dirname, "screens");
 const SEED_TABLES_DIR = path.join(__dirname, "tables");
+const SEED_ACTIONS_DIR = path.join(__dirname, "actions");
 
 fs.mkdirSync(SCREENS_DIR, { recursive: true });
 fs.mkdirSync(TABLES_DIR, { recursive: true });
+fs.mkdirSync(ACTIONS_DIR, { recursive: true });
 fs.mkdirSync(SEED_SCREENS_DIR, { recursive: true });
 
 // ── GrapesJS スクリーンデータ生成ヘルパー ─────────────────────────────────
@@ -839,9 +842,24 @@ if (fs.existsSync(SEED_TABLES_DIR)) {
   }
 }
 
+// ── 処理フロー定義データをコピー ──────────────────────────────────────────
+let actionCount = 0;
+if (fs.existsSync(SEED_ACTIONS_DIR)) {
+  const actionFiles = fs.readdirSync(SEED_ACTIONS_DIR).filter((f) => f.endsWith(".json"));
+  for (const file of actionFiles) {
+    fs.copyFileSync(
+      path.join(SEED_ACTIONS_DIR, file),
+      path.join(ACTIONS_DIR, file),
+    );
+    actionCount++;
+    console.log(`[action ${actionCount}/${actionFiles.length}] ${file.replace(".json", "")}`);
+  }
+}
+
 console.log("\n✅ シードデータ生成完了");
 console.log(`   data/screens/        → ${count} ファイル`);
 console.log(`   data/tables/         → ${tableCount} ファイル`);
+console.log(`   data/actions/        → ${actionCount} ファイル`);
 console.log(`   docs/sample-project/ → バックアップ済み`);
 console.log("\n復元方法:");
 console.log("   node docs/sample-project/seed.mjs");


### PR DESCRIPTION
## Summary

- 画面のアクション（ボタンクリック等）に対する処理の概要フローを定義する機能を追加
- カード型UIでステップを視覚的に操作（追加・並べ替え・展開編集）
- 9種類のステップタイプ（バリデーション、DB操作、外部システム、共通処理、画面遷移、表示更新、条件分岐、ジャンプ、その他）
- 自動採番（挿入・削除時に番号＋ジャンプ参照先も自動更新）
- 共通処理のテンプレート化・再利用（type: common のActionGroup）
- 統合仕様書JSONにactionGroups/commonProcessesを追加

## 変更内容

### 新規ファイル (12件)
- `designer/src/types/action.ts` — 型定義（ActionGroup, Step等）
- `designer/src/store/actionStore.ts` — 永続化ストア
- `designer/src/utils/actionUtils.ts` — 自動採番・ジャンプ参照
- `designer/src/components/action/ActionListView.tsx` — 一覧ページ
- `designer/src/components/action/ActionEditor.tsx` — 編集ページ
- `designer/src/components/action/StepCard.tsx` — ステップカード
- `designer/src/styles/action.css` — スタイル
- `docs/sample-project/actions/*.json` — サンプルデータ4件

### 既存ファイル変更 (11件)
- ルーティング、トップバー、mcpBridge、specExporter
- projectStorage、wsBridge、MCPツール定義・ハンドラ
- サンプルproject.json、seed.mjs

## Test plan

- [x] Viteビルド成功
- [x] designer-mcpビルド成功
- [x] 処理フロー一覧ページ表示（4件のサンプルデータ）
- [x] タイプ別フィルタ動作
- [x] 処理フロー編集ページ表示（アクションタブ、ステップカード）
- [x] ステップカード展開・編集フォーム表示
- [x] トップバーナビゲーション（画面フロー⇔処理フロー）
- [ ] ステップ追加・削除・並べ替え
- [ ] 新規作成モーダル
- [ ] 共通処理ダブルクリック遷移

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)