### PR TITLE
feat: アプリ全体にUndo/Redo機能を追加

### DIFF
--- a/designer/src/components/action/ActionEditor.tsx
+++ b/designer/src/components/action/ActionEditor.tsx
@@ -30,6 +30,8 @@ import { loadProject } from "../../store/flowStore";
 import { getStepLabel, clearJumpReferences } from "../../utils/actionUtils";
 import { generateUUID } from "../../utils/uuid";
 import { mcpBridge } from "../../mcp/mcpBridge";
+import { useUndoableState } from "../../hooks/useUndoableState";
+import { useUndoKeyboard } from "../../hooks/useUndoKeyboard";
 import { TableTopbar } from "../table/TableTopbar";
 import { StepCard } from "./StepCard";
 import "../../styles/action.css";
@@ -44,7 +46,6 @@ const ALL_TRIGGERS: ActionTrigger[] = ["click", "submit", "select", "change", "l
 export function ActionEditor() {
   const { actionGroupId } = useParams<{ actionGroupId: string }>();
   const navigate = useNavigate();
-  const [group, setGroup] = useState<ActionGroup | null>(null);
   const [projectName, setProjectName] = useState("プロジェクト");
   const [activeActionId, setActiveActionId] = useState<string | null>(null);
   const [showAddAction, setShowAddAction] = useState(false);
@@ -57,6 +58,29 @@ export function ActionEditor() {
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; stepId: string; parentStepId?: string } | null>(null);
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // 自動保存 (debounce 500ms)
+  const scheduleSave = useCallback((updatedGroup: ActionGroup) => {
+    if (saveTimer.current) clearTimeout(saveTimer.current);
+    saveTimer.current = setTimeout(async () => {
+      await saveActionGroup(updatedGroup);
+    }, 500);
+  }, []);
+
+  // Undo/Redo 対応 state
+  const {
+    state: group,
+    update: setGroup,
+    updateAndCommit: updateGroupCommit,
+    commit: commitGroup,
+    undo,
+    redo,
+    canUndo,
+    canRedo,
+    reset: resetGroup,
+  } = useUndoableState<ActionGroup | null>(null, { onSave: (g) => { if (g) saveActionGroup(g); } });
+
+  useUndoKeyboard(undo, redo);
+
   const reload = useCallback(async () => {
     if (!actionGroupId) return;
     const g = await loadActionGroup(actionGroupId);
@@ -64,7 +88,7 @@ export function ActionEditor() {
       navigate("/actions");
       return;
     }
-    setGroup(g);
+    resetGroup(g);
     if (!activeActionId && g.actions.length > 0) {
       setActiveActionId(g.actions[0].id);
     }
@@ -75,7 +99,7 @@ export function ActionEditor() {
     setCommonGroups(agMetas.filter((a) => a.type === "common").map((a) => ({ id: a.id, name: a.name })));
     const t = await listTables();
     setTables(t.map((tm) => ({ id: tm.id, name: tm.name, logicalName: tm.logicalName })));
-  }, [actionGroupId, activeActionId, navigate]);
+  }, [actionGroupId, activeActionId, navigate, resetGroup]);
 
   useEffect(() => {
     mcpBridge.startWithoutEditor();
@@ -86,15 +110,22 @@ export function ActionEditor() {
     return unsub;
   }, [reload]);
 
-  // 自動保存 (debounce 500ms)
-  const scheduleSave = useCallback((updatedGroup: ActionGroup) => {
-    if (saveTimer.current) clearTimeout(saveTimer.current);
-    saveTimer.current = setTimeout(async () => {
-      await saveActionGroup(updatedGroup);
-    }, 500);
-  }, []);
-
+  /** 構造変化（履歴に積む）: ステップ追加・削除・移動、アクション追加・削除 */
   const updateGroup = useCallback(
+    (updater: (g: ActionGroup) => void) => {
+      updateGroupCommit((prev) => {
+        if (!prev) return prev;
+        const next = JSON.parse(JSON.stringify(prev)) as ActionGroup;
+        updater(next);
+        scheduleSave(next);
+        return next;
+      });
+    },
+    [updateGroupCommit, scheduleSave],
+  );
+
+  /** テキスト変更（履歴に積まない）: フィールド編集中の一時状態 */
+  const updateGroupSilent = useCallback(
     (updater: (g: ActionGroup) => void) => {
       setGroup((prev) => {
         if (!prev) return prev;
@@ -104,7 +135,7 @@ export function ActionEditor() {
         return next;
       });
     },
-    [scheduleSave],
+    [setGroup, scheduleSave],
   );
 
   const activeAction = group?.actions.find((a) => a.id === activeActionId) ?? null;
@@ -176,7 +207,7 @@ export function ActionEditor() {
   };
 
   const handleStepChange = (stepId: string, changes: Partial<Step>) => {
-    updateGroup((g) => {
+    updateGroupSilent((g) => {
       const act = g.actions.find((a) => a.id === activeActionId);
       if (!act) return;
       const step = act.steps.find((s) => s.id === stepId);
@@ -211,7 +242,7 @@ export function ActionEditor() {
   };
 
   const handleGroupInfoChange = (field: string, value: string) => {
-    updateGroup((g) => {
+    updateGroupSilent((g) => {
       (g as unknown as Record<string, string>)[field] = value;
     });
   };
@@ -228,6 +259,24 @@ export function ActionEditor() {
           <Link to="/actions">処理フロー一覧</Link>
           <span className="mx-2">/</span>
           <span className="fw-semibold text-dark">{group.name}</span>
+        </div>
+        <div className="action-editor-undo-buttons">
+          <button
+            className="btn btn-outline-secondary btn-sm"
+            onClick={undo}
+            disabled={!canUndo}
+            title="元に戻す (Ctrl+Z)"
+          >
+            <i className="bi bi-arrow-counterclockwise" />
+          </button>
+          <button
+            className="btn btn-outline-secondary btn-sm"
+            onClick={redo}
+            disabled={!canRedo}
+            title="やり直し (Ctrl+Y)"
+          >
+            <i className="bi bi-arrow-clockwise" />
+          </button>
         </div>
       </div>
 
@@ -368,6 +417,7 @@ export function ActionEditor() {
                       screens={screens}
                       commonGroups={commonGroups}
                       onChange={(changes) => handleStepChange(step.id, changes)}
+                      onCommit={commitGroup}
                       onMoveUp={index > 0 ? () => handleMoveStep(index, index - 1) : undefined}
                       onMoveDown={index < activeAction.steps.length - 1 ? () => handleMoveStep(index, index + 1) : undefined}
                       onDelete={() => handleDeleteStep(step.id)}

--- a/designer/src/components/action/StepCard.tsx
+++ b/designer/src/components/action/StepCard.tsx
@@ -17,6 +17,8 @@ interface StepCardProps {
   screens: { id: string; name: string }[];
   commonGroups: { id: string; name: string }[];
   onChange: (changes: Partial<Step>) => void;
+  /** Undo 履歴にスナップショットを積む（テキストフィールドの onBlur 時に呼ぶ） */
+  onCommit?: () => void;
   onMoveUp?: () => void;
   onMoveDown?: () => void;
   onDelete: () => void;
@@ -38,6 +40,7 @@ export function StepCard({
   screens,
   commonGroups,
   onChange,
+  onCommit,
   onMoveUp,
   onMoveDown,
   onDelete,
@@ -151,6 +154,7 @@ export function StepCard({
                   className="form-control form-control-sm"
                   value={step.description}
                   onChange={(e) => onChange({ description: e.target.value })}
+                  onBlur={onCommit}
                   placeholder="処理の説明"
                 />
               </div>
@@ -166,6 +170,7 @@ export function StepCard({
                       className="form-control form-control-sm"
                       value={step.conditions}
                       onChange={(e) => onChange({ conditions: e.target.value } as Partial<Step>)}
+                      onBlur={onCommit}
                       placeholder="必須チェック、形式チェック等"
                     />
                   </div>
@@ -181,6 +186,7 @@ export function StepCard({
                           onChange({ inlineBranch: { ...step.inlineBranch!, ok: e.target.value } } as Partial<Step>)
                         }
                         placeholder="OK時の処理"
+                        onBlur={onCommit}
                       />
                     </div>
                     <div className="step-branch-box ng">
@@ -192,6 +198,7 @@ export function StepCard({
                           onChange({ inlineBranch: { ...step.inlineBranch!, ng: e.target.value } } as Partial<Step>)
                         }
                         placeholder="NG時の処理"
+                        onBlur={onCommit}
                       />
                     </div>
                   </div>
@@ -235,6 +242,7 @@ export function StepCard({
                     className="form-control form-control-sm"
                     value={step.fields ?? ""}
                     onChange={(e) => onChange({ fields: e.target.value } as Partial<Step>)}
+                    onBlur={onCommit}
                     placeholder="概要"
                   />
                 </div>
@@ -249,6 +257,7 @@ export function StepCard({
                     className="form-control form-control-sm"
                     value={step.systemName}
                     onChange={(e) => onChange({ systemName: e.target.value } as Partial<Step>)}
+                    onBlur={onCommit}
                     placeholder="システム名"
                   />
                 </div>
@@ -258,6 +267,7 @@ export function StepCard({
                     className="form-control form-control-sm"
                     value={step.protocol ?? ""}
                     onChange={(e) => onChange({ protocol: e.target.value } as Partial<Step>)}
+                    onBlur={onCommit}
                     placeholder="REST / SOAP / gRPC"
                   />
                 </div>
@@ -306,6 +316,7 @@ export function StepCard({
                     className="form-control form-control-sm mt-1"
                     value={step.targetScreenName}
                     onChange={(e) => onChange({ targetScreenName: e.target.value } as Partial<Step>)}
+                    onBlur={onCommit}
                     placeholder="画面名を直接入力"
                   />
                 </div>
@@ -320,6 +331,7 @@ export function StepCard({
                     className="form-control form-control-sm"
                     value={step.target}
                     onChange={(e) => onChange({ target: e.target.value } as Partial<Step>)}
+                    onBlur={onCommit}
                     placeholder="メッセージ表示、一覧テーブル更新 等"
                   />
                 </div>
@@ -335,6 +347,7 @@ export function StepCard({
                       className="form-control form-control-sm"
                       value={step.condition}
                       onChange={(e) => onChange({ condition: e.target.value } as Partial<Step>)}
+                      onBlur={onCommit}
                       placeholder="条件式"
                     />
                   </div>
@@ -349,6 +362,7 @@ export function StepCard({
                         onChange({ branchA: { ...step.branchA, description: e.target.value } } as Partial<Step>)
                       }
                       placeholder="A分岐の処理"
+                      onBlur={onCommit}
                     />
                   </div>
                   <div className="step-branch-box ng">
@@ -360,6 +374,7 @@ export function StepCard({
                         onChange({ branchB: { ...step.branchB, description: e.target.value } } as Partial<Step>)
                       }
                       placeholder="B分岐の処理"
+                      onBlur={onCommit}
                     />
                   </div>
                 </div>
@@ -394,6 +409,7 @@ export function StepCard({
                   className="form-control form-control-sm"
                   value={step.note ?? ""}
                   onChange={(e) => onChange({ note: e.target.value })}
+                  onBlur={onCommit}
                   placeholder="補足情報"
                 />
               </div>

--- a/designer/src/components/flow/FlowEditor.tsx
+++ b/designer/src/components/flow/FlowEditor.tsx
@@ -46,6 +46,7 @@ import {
   generateFlowMarkdown,
 } from "../../store/flowStore";
 import { mcpBridge } from "../../mcp/mcpBridge";
+import { useUndoKeyboard } from "../../hooks/useUndoKeyboard";
 import "../../styles/flow.css";
 
 const nodeTypes = {
@@ -120,6 +121,50 @@ function FlowEditorInner() {
   const [zoomLevel, setZoomLevel] = useState(1);
   const [viewMode, setViewMode] = useState<ViewMode>("flow");
   const needsFitViewRef = useRef(false);
+
+  // Undo/Redo スタック
+  const undoStackRef = useRef<FlowProject[]>([]);
+  const redoStackRef = useRef<FlowProject[]>([]);
+  const [canUndo, setCanUndo] = useState(false);
+  const [canRedo, setCanRedo] = useState(false);
+
+  const pushUndoSnapshot = useCallback(() => {
+    if (!projectRef.current) return;
+    undoStackRef.current = [...undoStackRef.current, JSON.parse(JSON.stringify(projectRef.current))].slice(-50);
+    redoStackRef.current = [];
+    setCanUndo(true);
+    setCanRedo(false);
+  }, []);
+
+  const handleUndo = useCallback(() => {
+    if (undoStackRef.current.length === 0 || !projectRef.current) return;
+    redoStackRef.current = [...redoStackRef.current, JSON.parse(JSON.stringify(projectRef.current))];
+    const prev = undoStackRef.current[undoStackRef.current.length - 1];
+    undoStackRef.current = undoStackRef.current.slice(0, -1);
+    projectRef.current = prev;
+    setNodes(toRFNodesWithGroups(prev.screens, prev.groups ?? []));
+    setEdges(toRFEdges(prev.edges));
+    setProjectName(prev.name);
+    saveProject(prev).catch(console.error);
+    setCanUndo(undoStackRef.current.length > 0);
+    setCanRedo(true);
+  }, [setNodes, setEdges]);
+
+  const handleRedo = useCallback(() => {
+    if (redoStackRef.current.length === 0 || !projectRef.current) return;
+    undoStackRef.current = [...undoStackRef.current, JSON.parse(JSON.stringify(projectRef.current))];
+    const next = redoStackRef.current[redoStackRef.current.length - 1];
+    redoStackRef.current = redoStackRef.current.slice(0, -1);
+    projectRef.current = next;
+    setNodes(toRFNodesWithGroups(next.screens, next.groups ?? []));
+    setEdges(toRFEdges(next.edges));
+    setProjectName(next.name);
+    saveProject(next).catch(console.error);
+    setCanUndo(true);
+    setCanRedo(redoStackRef.current.length > 0);
+  }, [setNodes, setEdges]);
+
+  useUndoKeyboard(handleUndo, handleRedo);
 
   // プロジェクトを読み込んで UI に反映
   const reloadProject = useCallback(async () => {
@@ -231,6 +276,7 @@ function FlowEditorInner() {
 
   const onConnect = useCallback((connection: Connection) => {
     if (!connection.source || !connection.target || !projectRef.current) return;
+    pushUndoSnapshot();
     storeAddEdge(
       projectRef.current,
       connection.source,
@@ -293,6 +339,7 @@ function FlowEditorInner() {
 
   const handleScreenSave = useCallback(async (data: ScreenFormData) => {
     if (!projectRef.current) return;
+    pushUndoSnapshot();
     if (screenModal.editId) {
       await updateScreen(projectRef.current, screenModal.editId, {
         name: data.name,
@@ -323,6 +370,7 @@ function FlowEditorInner() {
 
   const handleEdgeSave = useCallback(async (data: EdgeFormData) => {
     if (!edgeModal.editId || !projectRef.current) return;
+    pushUndoSnapshot();
     await storeUpdateEdge(projectRef.current, edgeModal.editId, {
       label: data.label,
       trigger: data.trigger,
@@ -365,6 +413,7 @@ function FlowEditorInner() {
 
   const handleDuplicateNode = useCallback(async () => {
     if (!contextMenu || !projectRef.current) return;
+    pushUndoSnapshot();
     const screen = projectRef.current.screens.find((s) => s.id === contextMenu.targetId);
     if (screen) {
       const dup = await addScreen(
@@ -388,6 +437,7 @@ function FlowEditorInner() {
 
   const handleDeleteNode = useCallback(async () => {
     if (!contextMenu || !projectRef.current) return;
+    pushUndoSnapshot();
     const screen = projectRef.current.screens.find((s) => s.id === contextMenu.targetId);
     if (screen && confirm(`「${screen.name}」を削除しますか？\nデザインデータも削除されます。`)) {
       await removeScreen(projectRef.current, contextMenu.targetId);
@@ -515,6 +565,7 @@ function FlowEditorInner() {
 
   const handleDeleteEdge = useCallback(async () => {
     if (!contextMenu || contextMenu.type !== "edge" || !projectRef.current) return;
+    pushUndoSnapshot();
     await storeRemoveEdge(projectRef.current, contextMenu.targetId);
     setEdges((eds) => eds.filter((e) => e.id !== contextMenu.targetId));
     setContextMenu(null);
@@ -655,6 +706,10 @@ function FlowEditorInner() {
         onZoomChange={handleZoomChange}
         onFitView={handleFitView}
         onViewModeChange={setViewMode}
+        onUndo={handleUndo}
+        onRedo={handleRedo}
+        canUndo={canUndo}
+        canRedo={canRedo}
       />
 
       <div className="flow-canvas">

--- a/designer/src/components/flow/FlowTopbar.tsx
+++ b/designer/src/components/flow/FlowTopbar.tsx
@@ -19,6 +19,10 @@ interface Props {
   onZoomChange: (zoom: number) => void;
   onFitView: () => void;
   onViewModeChange: (mode: ViewMode) => void;
+  onUndo?: () => void;
+  onRedo?: () => void;
+  canUndo?: boolean;
+  canRedo?: boolean;
 }
 
 export function FlowTopbar({
@@ -26,6 +30,7 @@ export function FlowTopbar({
   onAddScreen, onAddGroup, onRenameProject, onClearAll,
   onExportJSON, onImportJSON, onCopyMermaid, onExportMarkdown,
   onZoomChange, onFitView, onViewModeChange,
+  onUndo, onRedo, canUndo, canRedo,
 }: Props) {
   const navigate = useNavigate();
   const [editing, setEditing] = useState(false);
@@ -171,6 +176,27 @@ export function FlowTopbar({
       </div>
 
       <div className="flow-topbar-right">
+        {/* Undo/Redo */}
+        {onUndo && (
+          <button
+            className="flow-btn flow-btn-secondary"
+            onClick={onUndo}
+            disabled={!canUndo}
+            title="元に戻す (Ctrl+Z)"
+          >
+            <i className="bi bi-arrow-counterclockwise" />
+          </button>
+        )}
+        {onRedo && (
+          <button
+            className="flow-btn flow-btn-secondary"
+            onClick={onRedo}
+            disabled={!canRedo}
+            title="やり直し (Ctrl+Y)"
+          >
+            <i className="bi bi-arrow-clockwise" />
+          </button>
+        )}
         {/* ファイルメニュー */}
         <div style={{ position: "relative" }}>
           <button

--- a/designer/src/components/table/ErDiagram.tsx
+++ b/designer/src/components/table/ErDiagram.tsx
@@ -29,6 +29,7 @@ import { getAllRelations, autoLayout, generateErMermaid } from "../../utils/erUt
 import { generateSpecJson } from "../../utils/specExporter";
 import { mcpBridge } from "../../mcp/mcpBridge";
 import { generateUUID } from "../../utils/uuid";
+import { useUndoKeyboard } from "../../hooks/useUndoKeyboard";
 import html2canvas from "html2canvas";
 import "../../styles/er.css";
 
@@ -50,6 +51,50 @@ function ErDiagramInner() {
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const layoutRef = useRef<ErLayout | null>(null);
   const canvasRef = useRef<HTMLDivElement>(null);
+
+  // Undo/Redo スタック（レイアウト変更のみ対象）
+  const undoStackRef = useRef<ErLayout[]>([]);
+  const redoStackRef = useRef<ErLayout[]>([]);
+  const [canUndo, setCanUndo] = useState(false);
+  const [canRedo, setCanRedo] = useState(false);
+
+  const pushLayoutUndo = useCallback(() => {
+    if (!layoutRef.current) return;
+    undoStackRef.current = [...undoStackRef.current, JSON.parse(JSON.stringify(layoutRef.current))].slice(-50);
+    redoStackRef.current = [];
+    setCanUndo(true);
+    setCanRedo(false);
+  }, []);
+
+  const handleUndo = useCallback(() => {
+    if (undoStackRef.current.length === 0) return;
+    if (layoutRef.current) {
+      redoStackRef.current = [...redoStackRef.current, JSON.parse(JSON.stringify(layoutRef.current))];
+    }
+    const prev = undoStackRef.current[undoStackRef.current.length - 1];
+    undoStackRef.current = undoStackRef.current.slice(0, -1);
+    layoutRef.current = prev;
+    setLayout({ ...prev });
+    saveErLayout(prev);
+    setCanUndo(undoStackRef.current.length > 0);
+    setCanRedo(true);
+  }, []);
+
+  const handleRedo = useCallback(() => {
+    if (redoStackRef.current.length === 0) return;
+    if (layoutRef.current) {
+      undoStackRef.current = [...undoStackRef.current, JSON.parse(JSON.stringify(layoutRef.current))];
+    }
+    const next = redoStackRef.current[redoStackRef.current.length - 1];
+    redoStackRef.current = redoStackRef.current.slice(0, -1);
+    layoutRef.current = next;
+    setLayout({ ...next });
+    saveErLayout(next);
+    setCanUndo(true);
+    setCanRedo(redoStackRef.current.length > 0);
+  }, []);
+
+  useUndoKeyboard(handleUndo, handleRedo);
 
   // Load data
   useEffect(() => {
@@ -131,7 +176,16 @@ function ErDiagramInner() {
     saveTimerRef.current = setTimeout(() => saveErLayout(ly), 300);
   }, []);
 
+  const dragStartedRef = useRef(false);
+  const onNodeDragStart = useCallback(() => {
+    if (!dragStartedRef.current) {
+      pushLayoutUndo();
+      dragStartedRef.current = true;
+    }
+  }, [pushLayoutUndo]);
+
   const onNodeDragStop = useCallback((_: unknown, node: RFNode) => {
+    dragStartedRef.current = false;
     const ly = layoutRef.current ?? { positions: {}, logicalRelations: [], updatedAt: "" };
     ly.positions[node.id] = { x: Math.round(node.position.x), y: Math.round(node.position.y) };
     layoutRef.current = ly;
@@ -157,6 +211,7 @@ function ErDiagramInner() {
 
   // Auto layout
   const handleAutoLayout = useCallback(() => {
+    pushLayoutUndo();
     const relations = getAllRelations(tables, layout);
     const autoPos = autoLayout(tables, relations);
     const ly = layoutRef.current ?? { positions: {}, logicalRelations: [], updatedAt: "" };
@@ -174,6 +229,7 @@ function ErDiagramInner() {
 
   // Add logical relation
   const handleAddLogicalRelation = useCallback((rel: Omit<ErLogicalRelation, "id">) => {
+    pushLayoutUndo();
     const ly = layoutRef.current ?? { positions: {}, logicalRelations: [], updatedAt: "" };
     if (!ly.logicalRelations) ly.logicalRelations = [];
     ly.logicalRelations.push({ ...rel, id: `lr-${generateUUID()}` });
@@ -185,6 +241,7 @@ function ErDiagramInner() {
 
   // Remove logical relation
   const handleRemoveEdge = useCallback((edgeId: string) => {
+    pushLayoutUndo();
     const ly = layoutRef.current;
     if (!ly?.logicalRelations) return;
     ly.logicalRelations = ly.logicalRelations.filter((r) => r.id !== edgeId);
@@ -270,6 +327,7 @@ function ErDiagramInner() {
             onNodesChange={onNodesChange}
             onEdgesChange={onEdgesChange}
             nodeTypes={nodeTypes}
+            onNodeDragStart={onNodeDragStart}
             onNodeDragStop={onNodeDragStop}
             onNodeDoubleClick={onNodeDoubleClick}
             onConnect={onConnect}
@@ -302,6 +360,12 @@ function ErDiagramInner() {
       {/* Toolbar */}
       <div className="er-toolbar">
         <div className="er-toolbar-group">
+          <button className="tbl-btn tbl-btn-ghost tbl-btn-sm" onClick={handleUndo} disabled={!canUndo} title="元に戻す (Ctrl+Z)">
+            <i className="bi bi-arrow-counterclockwise" />
+          </button>
+          <button className="tbl-btn tbl-btn-ghost tbl-btn-sm" onClick={handleRedo} disabled={!canRedo} title="やり直し (Ctrl+Y)">
+            <i className="bi bi-arrow-clockwise" />
+          </button>
           <button className="tbl-btn tbl-btn-ghost tbl-btn-sm" onClick={handleAutoLayout} title="自動配置">
             <i className="bi bi-grid-3x3-gap" /> 自動配置
           </button>

--- a/designer/src/components/table/TableEditor.tsx
+++ b/designer/src/components/table/TableEditor.tsx
@@ -5,9 +5,10 @@ import { DATA_TYPE_LABELS, COLUMN_TEMPLATES, SQL_DIALECT_LABELS, DATA_TYPES_WITH
 import type { DataType } from "../../types/table";
 import { loadTable, saveTable, addColumn, removeColumn, addIndex, removeIndex } from "../../store/tableStore";
 import { listTables } from "../../store/tableStore";
-import { loadProject } from "../../store/flowStore";
 import { generateDdl, generateTableMarkdown } from "../../utils/ddlGenerator";
 import { mcpBridge } from "../../mcp/mcpBridge";
+import { useUndoableState } from "../../hooks/useUndoableState";
+import { useUndoKeyboard } from "../../hooks/useUndoKeyboard";
 import "../../styles/table.css";
 
 type TabId = "columns" | "indexes" | "ddl";
@@ -15,11 +16,9 @@ type TabId = "columns" | "indexes" | "ddl";
 export function TableEditor() {
   const { tableId } = useParams<{ tableId: string }>();
   const navigate = useNavigate();
-  const [table, setTable] = useState<TableDefinition | null>(null);
   const [tab, setTab] = useState<TabId>("columns");
   const [ddlDialect, setDdlDialect] = useState<SqlDialect>("postgresql");
   const [editingMeta, setEditingMeta] = useState(false);
-  const [projectName, setProjectName] = useState("プロジェクト");
   const [allTables, setAllTables] = useState<TableDefinition[]>([]);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -30,15 +29,27 @@ export function TableEditor() {
     }, 500);
   }, []);
 
+  // Undo/Redo 対応 state
+  const {
+    state: table,
+    update: setTable,
+    updateAndCommit,
+    undo,
+    redo,
+    canUndo,
+    canRedo,
+    reset: resetTable,
+  } = useUndoableState<TableDefinition | null>(null, { onSave: (t) => { if (t) saveTable(t); } });
+
+  useUndoKeyboard(undo, redo);
+
   useEffect(() => {
     mcpBridge.startWithoutEditor();
     if (!tableId) return;
     (async () => {
       const t = await loadTable(tableId);
-      if (t) setTable(t);
+      if (t) resetTable(t);
       else navigate("/tables");
-      const p = await loadProject();
-      setProjectName(p.name);
       const tl = await listTables();
       const allTds: TableDefinition[] = [];
       for (const m of tl) {
@@ -47,7 +58,7 @@ export function TableEditor() {
       }
       setAllTables(allTds);
     })();
-  }, [tableId, navigate]);
+  }, [tableId, navigate, resetTable]);
 
   // Cleanup save timer
   useEffect(() => {
@@ -56,15 +67,17 @@ export function TableEditor() {
     };
   }, []);
 
+  /** 構造変化（履歴に積む）: カラム追加・削除・移動 */
   const update = useCallback((fn: (t: TableDefinition) => void) => {
-    setTable((prev) => {
+    updateAndCommit((prev) => {
       if (!prev) return prev;
       const next = structuredClone(prev);
       fn(next);
       autoSave(next);
       return next;
     });
-  }, [autoSave]);
+  }, [updateAndCommit, autoSave]);
+
 
   if (!table) {
     return <div className="table-editor-loading"><i className="bi bi-hourglass-split" /> 読み込み中...</div>;
@@ -99,6 +112,22 @@ export function TableEditor() {
           )}
         </div>
         <div className="table-editor-header-actions">
+          <button
+            className="tbl-btn tbl-btn-ghost"
+            onClick={undo}
+            disabled={!canUndo}
+            title="元に戻す (Ctrl+Z)"
+          >
+            <i className="bi bi-arrow-counterclockwise" />
+          </button>
+          <button
+            className="tbl-btn tbl-btn-ghost"
+            onClick={redo}
+            disabled={!canRedo}
+            title="やり直し (Ctrl+Y)"
+          >
+            <i className="bi bi-arrow-clockwise" />
+          </button>
           <button
             className="tbl-btn tbl-btn-ghost"
             onClick={() => {

--- a/designer/src/hooks/useUndoKeyboard.ts
+++ b/designer/src/hooks/useUndoKeyboard.ts
@@ -1,0 +1,39 @@
+import { useEffect } from "react";
+
+/**
+ * Ctrl+Z / Ctrl+Y (Ctrl+Shift+Z) キーバインドフック
+ *
+ * @param undo Undo 関数
+ * @param redo Redo 関数
+ * @param enabled false のときキーバインドを無効化（GrapesJS競合回避等）
+ */
+export function useUndoKeyboard(
+  undo: () => void,
+  redo: () => void,
+  enabled = true,
+): void {
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handler = (e: KeyboardEvent) => {
+      // input / textarea / select / contenteditable 内では無視
+      const tag = (e.target as HTMLElement)?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+      if ((e.target as HTMLElement)?.isContentEditable) return;
+
+      const ctrl = e.ctrlKey || e.metaKey;
+      if (!ctrl) return;
+
+      if (e.key === "z" && !e.shiftKey) {
+        e.preventDefault();
+        undo();
+      } else if (e.key === "y" || (e.key === "z" && e.shiftKey)) {
+        e.preventDefault();
+        redo();
+      }
+    };
+
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [undo, redo, enabled]);
+}

--- a/designer/src/hooks/useUndoableState.ts
+++ b/designer/src/hooks/useUndoableState.ts
@@ -1,0 +1,136 @@
+import { useState, useCallback, useRef } from "react";
+
+interface UndoableOptions<T> {
+  /** Undo/Redo後に呼ばれる保存関数（デバウンスなし・即時） */
+  onSave?: (state: T) => void;
+  /** 履歴の最大件数（デフォルト50） */
+  maxHistory?: number;
+}
+
+interface UndoableReturn<T> {
+  /** 現在の状態 */
+  state: T;
+  /** 状態更新（履歴に積まない。テキスト入力中の一時状態用） */
+  update: (updater: (prev: T) => T) => void;
+  /** 状態更新＋履歴にスナップショット（構造変化用） */
+  updateAndCommit: (updater: (prev: T) => T) => void;
+  /** 現在の状態を履歴にスナップショット（onBlur時等に呼ぶ） */
+  commit: () => void;
+  /** 1つ戻す */
+  undo: () => void;
+  /** 1つ進める */
+  redo: () => void;
+  canUndo: boolean;
+  canRedo: boolean;
+  /** 初期値を再設定し履歴をクリア（データロード時に使用） */
+  reset: (value: T) => void;
+}
+
+/**
+ * Undo/Redo 対応の useState 代替フック
+ *
+ * past/present/future パターンで履歴を管理する。
+ * - update(): 履歴に積まずに状態を更新（テキスト入力中の一時状態）
+ * - updateAndCommit(): 更新前の状態を履歴に積んでから状態を更新（構造変化）
+ * - commit(): 現在の状態を履歴に積む（onBlur時など）
+ */
+export function useUndoableState<T>(
+  initial: T,
+  opts?: UndoableOptions<T>,
+): UndoableReturn<T> {
+  const maxHistory = opts?.maxHistory ?? 50;
+  const onSaveRef = useRef(opts?.onSave);
+  onSaveRef.current = opts?.onSave;
+
+  const [present, setPresent] = useState<T>(initial);
+
+  // useRef で履歴を管理（再レンダリングを最小化）
+  const historyRef = useRef<{ past: T[]; future: T[] }>({ past: [], future: [] });
+  // canUndo/canRedo はレンダリングに影響するため useState
+  const [canUndo, setCanUndo] = useState(false);
+  const [canRedo, setCanRedo] = useState(false);
+
+  const syncFlags = useCallback(() => {
+    setCanUndo(historyRef.current.past.length > 0);
+    setCanRedo(historyRef.current.future.length > 0);
+  }, []);
+
+  // commitRef: 最後にcommitした値を追跡し、重複commitを防ぐ
+  const lastCommittedRef = useRef<T>(initial);
+
+  const update = useCallback((updater: (prev: T) => T) => {
+    setPresent(updater);
+  }, []);
+
+  const updateAndCommit = useCallback((updater: (prev: T) => T) => {
+    setPresent((prev) => {
+      const h = historyRef.current;
+      h.past = [...h.past, prev].slice(-maxHistory);
+      h.future = [];
+      const next = updater(prev);
+      lastCommittedRef.current = next;
+      syncFlags();
+      return next;
+    });
+  }, [maxHistory, syncFlags]);
+
+  const commit = useCallback(() => {
+    setPresent((current) => {
+      // 最後にcommitした値と同じなら何もしない（重複防止）
+      if (current === lastCommittedRef.current) return current;
+      const h = historyRef.current;
+      h.past = [...h.past, lastCommittedRef.current].slice(-maxHistory);
+      h.future = [];
+      lastCommittedRef.current = current;
+      syncFlags();
+      return current;
+    });
+  }, [maxHistory, syncFlags]);
+
+  const undo = useCallback(() => {
+    setPresent((current) => {
+      const h = historyRef.current;
+      if (h.past.length === 0) return current;
+      const prev = h.past[h.past.length - 1];
+      h.past = h.past.slice(0, -1);
+      h.future = [current, ...h.future];
+      lastCommittedRef.current = prev;
+      syncFlags();
+      onSaveRef.current?.(prev);
+      return prev;
+    });
+  }, [syncFlags]);
+
+  const redo = useCallback(() => {
+    setPresent((current) => {
+      const h = historyRef.current;
+      if (h.future.length === 0) return current;
+      const next = h.future[0];
+      h.past = [...h.past, current];
+      h.future = h.future.slice(1);
+      lastCommittedRef.current = next;
+      syncFlags();
+      onSaveRef.current?.(next);
+      return next;
+    });
+  }, [syncFlags]);
+
+  const reset = useCallback((value: T) => {
+    setPresent(value);
+    historyRef.current = { past: [], future: [] };
+    lastCommittedRef.current = value;
+    syncFlags();
+  }, [syncFlags]);
+
+  return {
+    state: present,
+    update,
+    updateAndCommit,
+    commit,
+    undo,
+    redo,
+    canUndo,
+    canRedo,
+    reset,
+  };
+}

--- a/designer/src/styles/action.css
+++ b/designer/src/styles/action.css
@@ -119,6 +119,16 @@
   border-bottom: 1px solid #e2e8f0;
 }
 
+.action-editor-undo-buttons {
+  display: flex;
+  gap: 4px;
+  margin-left: auto;
+}
+
+.action-editor-undo-buttons .btn:disabled {
+  opacity: 0.35;
+}
+
 .action-editor-breadcrumb {
   font-size: 0.85rem;
   color: #64748b;


### PR DESCRIPTION
## Summary

Closes #51

- `useUndoableState` フック: past/present/future パターンの共通Undo/Redoステート管理（update / updateAndCommit / commit API）
- `useUndoKeyboard` フック: Ctrl+Z / Ctrl+Y キーバインド共通化
- ActionEditor / TableEditor: `useUndoableState` でステップ・カラムの追加・削除・移動をUndo可能に
- FlowEditor / ErDiagram: `useRef` ベースのUndoスタック（ReactFlow二重管理に対応）
- 各画面にUndo/Redoボタンを追加

## 対応画面

| 画面 | 方式 | Undoボタン |
|---|---|---|
| 処理フローエディタ | `useUndoableState` | ヘッダー右 |
| テーブルエディタ | `useUndoableState` | ヘッダー右 |
| 画面フロー | `useRef` スタック | FlowTopbar |
| ER図 | `useRef` スタック | ツールバー左 |
| GrapesJS | 既存UndoManager | 変更なし |

## Test plan

- [ ] 処理フローエディタでステップ追加→Ctrl+Z→ステップが消える
- [ ] テーブルエディタでカラム追加→Ctrl+Z→カラムが消える
- [ ] 画面フローでノード追加→Ctrl+Z→ノードが消える
- [ ] ER図でノードドラッグ→Ctrl+Z→元の位置に戻る
- [ ] 各画面のUndo/Redoボタンが正常に動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)