### PR TITLE
improve(action): ステップカードのNotionスタイル編集とフィールド幅統一

### DIFF
--- a/designer/src/components/action/ActionEditor.tsx
+++ b/designer/src/components/action/ActionEditor.tsx
@@ -57,6 +57,7 @@ export function ActionEditor() {
   const [showTemplates, setShowTemplates] = useState(false);
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; stepId: string; parentStepId?: string } | null>(null);
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const newStepIdsRef = useRef<Set<string>>(new Set());
 
   // 自動保存 (debounce 500ms)
   const scheduleSave = useCallback((updatedGroup: ActionGroup) => {
@@ -166,7 +167,10 @@ export function ActionEditor() {
     if (!activeAction) return;
     updateGroup((g) => {
       const act = g.actions.find((a) => a.id === activeActionId);
-      if (act) addStep(act, type, insertIndex);
+      if (act) {
+        const step = addStep(act, type, insertIndex);
+        newStepIdsRef.current.add(step.id);
+      }
     });
   };
 
@@ -429,6 +433,7 @@ export function ActionEditor() {
                         setContextMenu({ x: e.clientX, y: e.clientY, stepId: step.id });
                       }}
                       onNavigateCommon={(refId) => navigate(`/actions/${refId}`)}
+                      defaultExpanded={newStepIdsRef.current.has(step.id)}
                     />
                   </div>
                 ))}

--- a/designer/src/components/action/StepCard.tsx
+++ b/designer/src/components/action/StepCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import type { Step, StepType, DbOperation } from "../../types/action";
 import {
   STEP_TYPE_LABELS,
@@ -27,9 +27,41 @@ interface StepCardProps {
   onDeleteSubStep: (subStepId: string) => void;
   onContextMenu: (e: React.MouseEvent) => void;
   onNavigateCommon: (refId: string) => void;
+  /** 新規追加ステップのデフォルト展開 */
+  defaultExpanded?: boolean;
 }
 
 const DB_OPS: DbOperation[] = ["SELECT", "INSERT", "UPDATE", "DELETE"];
+
+/** 内容に応じて自動伸縮する textarea */
+function AutoResizeTextarea({
+  value, onChange, onBlur, placeholder, className,
+}: {
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  onBlur?: () => void;
+  placeholder?: string;
+  className?: string;
+}) {
+  const ref = useRef<HTMLTextAreaElement>(null);
+  useEffect(() => {
+    if (ref.current) {
+      ref.current.style.height = "auto";
+      ref.current.style.height = `${ref.current.scrollHeight}px`;
+    }
+  }, [value]);
+  return (
+    <textarea
+      ref={ref}
+      className={className ?? "form-control form-control-sm auto-resize"}
+      value={value}
+      rows={1}
+      onChange={onChange}
+      onBlur={onBlur}
+      placeholder={placeholder}
+    />
+  );
+}
 
 export function StepCard({
   step,
@@ -49,8 +81,9 @@ export function StepCard({
   onDeleteSubStep,
   onContextMenu,
   onNavigateCommon,
+  defaultExpanded,
 }: StepCardProps) {
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(defaultExpanded ?? false);
   const [showMenu, setShowMenu] = useState(false);
 
   const color = STEP_TYPE_COLORS[step.type];
@@ -150,8 +183,7 @@ export function StepCard({
             <div className="row g-2 mb-2">
               <div className="col-12">
                 <label className="form-label">処理概要</label>
-                <input
-                  className="form-control form-control-sm"
+                <AutoResizeTextarea
                   value={step.description}
                   onChange={(e) => onChange({ description: e.target.value })}
                   onBlur={onCommit}
@@ -207,8 +239,8 @@ export function StepCard({
             )}
 
             {step.type === "dbAccess" && (
-              <div className="row g-2 mb-2">
-                <div className="col-md-6">
+              <>
+                <div className="form-group">
                   <label className="form-label">テーブル</label>
                   <select
                     className="form-select form-select-sm"
@@ -224,34 +256,36 @@ export function StepCard({
                     ))}
                   </select>
                 </div>
-                <div className="col-md-3">
-                  <label className="form-label">操作</label>
-                  <select
-                    className="form-select form-select-sm"
-                    value={step.operation}
-                    onChange={(e) => onChange({ operation: e.target.value as DbOperation } as Partial<Step>)}
-                  >
-                    {DB_OPS.map((op) => (
-                      <option key={op} value={op}>{DB_OPERATION_LABELS[op]}</option>
-                    ))}
-                  </select>
+                <div className="form-row-pair">
+                  <div className="form-group">
+                    <label className="form-label">操作</label>
+                    <select
+                      className="form-select form-select-sm"
+                      value={step.operation}
+                      onChange={(e) => onChange({ operation: e.target.value as DbOperation } as Partial<Step>)}
+                    >
+                      {DB_OPS.map((op) => (
+                        <option key={op} value={op}>{DB_OPERATION_LABELS[op]}</option>
+                      ))}
+                    </select>
+                  </div>
+                  <div className="form-group">
+                    <label className="form-label">対象フィールド</label>
+                    <input
+                      className="form-control form-control-sm"
+                      value={step.fields ?? ""}
+                      onChange={(e) => onChange({ fields: e.target.value } as Partial<Step>)}
+                      onBlur={onCommit}
+                      placeholder="概要"
+                    />
+                  </div>
                 </div>
-                <div className="col-md-3">
-                  <label className="form-label">対象フィールド</label>
-                  <input
-                    className="form-control form-control-sm"
-                    value={step.fields ?? ""}
-                    onChange={(e) => onChange({ fields: e.target.value } as Partial<Step>)}
-                    onBlur={onCommit}
-                    placeholder="概要"
-                  />
-                </div>
-              </div>
+              </>
             )}
 
             {step.type === "externalSystem" && (
-              <div className="row g-2 mb-2">
-                <div className="col-md-6">
+              <div className="form-row-pair">
+                <div className="form-group">
                   <label className="form-label">接続先</label>
                   <input
                     className="form-control form-control-sm"
@@ -261,7 +295,7 @@ export function StepCard({
                     placeholder="システム名"
                   />
                 </div>
-                <div className="col-md-6">
+                <div className="form-group">
                   <label className="form-label">プロトコル</label>
                   <input
                     className="form-control form-control-sm"
@@ -405,8 +439,7 @@ export function StepCard({
             <div className="row g-2">
               <div className="col-12">
                 <label className="form-label">メモ</label>
-                <input
-                  className="form-control form-control-sm"
+                <AutoResizeTextarea
                   value={step.note ?? ""}
                   onChange={(e) => onChange({ note: e.target.value })}
                   onBlur={onCommit}

--- a/designer/src/styles/action.css
+++ b/designer/src/styles/action.css
@@ -407,11 +407,34 @@
 
 .step-card-body .form-control,
 .step-card-body .form-select {
+  width: 100%;
   font-size: 0.85rem;
+}
+
+.step-card-body .form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-bottom: 8px;
+}
+
+/* ペアフィールド用 2カラム grid */
+.step-card-body .form-row-pair {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin-bottom: 8px;
 }
 
 .step-card-body .row {
   gap: 8px 0;
+}
+
+/* textarea 自動伸縮 */
+.step-card-body .auto-resize {
+  resize: none;
+  overflow: hidden;
+  min-height: 32px;
 }
 
 /* ─── インライン分岐 ──────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

Closes #49

- 新規追加ステップをデフォルト展開（`defaultExpanded` prop で StepCard にローカル管理を維持しつつ対応）
- 処理概要・メモフィールドを `<textarea>` + 自動伸縮（`AutoResizeTextarea` コンポーネント）に変更
- DB操作・外部システムのペアフィールドを `form-row-pair` CSS Grid 2カラムに統一
- 全フィールドに `width: 100%` を適用、`form-group` 縦並びレイアウト追加

## Test plan

- [ ] ステップ追加時にカードが自動展開される
- [ ] 処理概要・メモ欄が複数行に対応し、内容に応じて伸縮する
- [ ] DB操作の「操作」と「対象フィールド」が横並び2カラムで表示される
- [ ] 外部システムの「接続先」と「プロトコル」が横並び2カラムで表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)