### PR TITLE
feat(action): アクション定義にI/Oデータ記述を追加

### DIFF
--- a/designer/src/components/action/ActionEditor.tsx
+++ b/designer/src/components/action/ActionEditor.tsx
@@ -353,6 +353,44 @@ export function ActionEditor() {
       <div className="action-content">
         {activeAction ? (
           <div className="step-editor">
+            {/* I/O パネル */}
+            <div className="action-io-panel">
+              <div className="action-io-field">
+                <label className="form-label"><i className="bi bi-box-arrow-in-right me-1" />入力データ</label>
+                <textarea
+                  className="form-control form-control-sm action-io-textarea"
+                  rows={1}
+                  value={activeAction.inputs ?? ""}
+                  onChange={(e) => {
+                    const val = e.target.value;
+                    updateGroupSilent((g) => {
+                      const act = g.actions.find((a) => a.id === activeActionId);
+                      if (act) act.inputs = val;
+                    });
+                  }}
+                  onBlur={commitGroup}
+                  placeholder="例: ユーザID、パスワード（改行で複数項目）"
+                />
+              </div>
+              <div className="action-io-field">
+                <label className="form-label"><i className="bi bi-box-arrow-right me-1" />出力データ</label>
+                <textarea
+                  className="form-control form-control-sm action-io-textarea"
+                  rows={1}
+                  value={activeAction.outputs ?? ""}
+                  onChange={(e) => {
+                    const val = e.target.value;
+                    updateGroupSilent((g) => {
+                      const act = g.actions.find((a) => a.id === activeActionId);
+                      if (act) act.outputs = val;
+                    });
+                  }}
+                  onBlur={commitGroup}
+                  placeholder="例: セッションID、認証トークン（改行で複数項目）"
+                />
+              </div>
+            </div>
+
             {/* ツールバー */}
             <div className="step-toolbar">
               {ALL_STEP_TYPES.map((type) => (

--- a/designer/src/styles/action.css
+++ b/designer/src/styles/action.css
@@ -202,6 +202,32 @@
   color: #6366f1;
 }
 
+/* ─── I/O パネル ─────────────────────────────────────────────────── */
+
+.action-io-panel {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  margin-bottom: 16px;
+  padding: 12px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+}
+
+.action-io-field .form-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #64748b;
+  margin-bottom: 4px;
+}
+
+.action-io-textarea {
+  font-size: 0.82rem;
+  min-height: 32px;
+  resize: vertical;
+}
+
 /* ─── ステップエディタ ────────────────────────────────────────────── */
 
 .step-editor {

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -195,6 +195,10 @@ export interface ActionDefinition {
   trigger: ActionTrigger;
   elementRef?: string;
   description?: string;
+  /** 入力データ（自由記述、改行区切り） */
+  inputs?: string;
+  /** 出力データ（自由記述、改行区切り） */
+  outputs?: string;
   steps: Step[];
 }
 

--- a/designer/src/utils/specExporter.ts
+++ b/designer/src/utils/specExporter.ts
@@ -104,6 +104,8 @@ export interface SpecActionGroup {
 export interface SpecAction {
   name: string;
   trigger: string;
+  inputs?: string;
+  outputs?: string;
   steps: SpecStep[];
 }
 
@@ -173,6 +175,8 @@ export function generateSpecJson(
         actions: g.actions.map((a) => ({
           name: a.name,
           trigger: a.trigger,
+          inputs: a.inputs || undefined,
+          outputs: a.outputs || undefined,
           steps: a.steps.map((s, i) => toSpecStep(s, i)),
         })),
       };


### PR DESCRIPTION
## Summary

Closes #50

- `ActionDefinition` に `inputs` / `outputs` フィールドを追加（自由記述、改行区切り）
- ステップ一覧の上に入力/出力テキストエリアの I/O パネルを追加（2カラムグリッド）
- 仕様書出力（specExporter）に inputs/outputs を含める
- Undo/Redo（#51）と連携済み（`updateGroupSilent` + `onBlur` で `commitGroup`）

## Test plan

- [ ] アクションタブ選択時、ステップ一覧の上に入力/出力テキストエリアが表示される
- [ ] 入力/出力の値が保存・復元される
- [ ] 仕様書JSON出力に inputs/outputs が含まれる

🤖 Generated with [Claude Code](https://claude.com/claude-code)