### PR TITLE
feat(action): D&Dでステップの並べ替えに対応

### DIFF
--- a/designer/package-lock.json
+++ b/designer/package-lock.json
@@ -8,6 +8,9 @@
       "name": "designer",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@grapesjs/react": "^2.0.0",
         "@monaco-editor/react": "^4.7.0",
         "@xyflow/react": "^12.10.2",
@@ -65,7 +68,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -273,6 +275,82 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -985,7 +1063,6 @@
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -995,7 +1072,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1008,13 +1084,6 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
-    },
-    "node_modules/@types/trusted-types": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/@types/underscore": {
       "version": "1.13.0",
@@ -1067,7 +1136,6 @@
       "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.1",
         "@typescript-eslint/types": "8.58.1",
@@ -1382,7 +1450,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1555,7 +1622,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1770,7 +1836,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1859,6 +1924,7 @@
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
       "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -1899,7 +1965,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2224,7 +2289,6 @@
       "resolved": "https://registry.npmjs.org/grapesjs/-/grapesjs-0.22.15.tgz",
       "integrity": "sha512-A285579LiAWrRuN3G2doFn8gSdhA5lji4h7qGZ4X8FtSPIP/xJnx+sd+m0GAb3bTlJxQmAXYQYUwEIFOgt22sA==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@types/backbone": "1.4.15",
         "backbone": "1.4.1",
@@ -2739,6 +2803,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -2906,7 +2971,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2974,7 +3038,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2984,7 +3047,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3211,9 +3273,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -3234,7 +3294,6 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3345,7 +3404,6 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3470,7 +3528,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/designer/package.json
+++ b/designer/package.json
@@ -10,6 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@grapesjs/react": "^2.0.0",
     "@monaco-editor/react": "^4.7.0",
     "@xyflow/react": "^12.10.2",

--- a/designer/src/components/action/ActionEditor.tsx
+++ b/designer/src/components/action/ActionEditor.tsx
@@ -30,10 +30,19 @@ import { loadProject } from "../../store/flowStore";
 import { getStepLabel, clearJumpReferences } from "../../utils/actionUtils";
 import { generateUUID } from "../../utils/uuid";
 import { mcpBridge } from "../../mcp/mcpBridge";
+import {
+  DndContext,
+  closestCenter,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
 import { useUndoableState } from "../../hooks/useUndoableState";
 import { useUndoKeyboard } from "../../hooks/useUndoKeyboard";
 import { TableTopbar } from "../table/TableTopbar";
-import { StepCard } from "./StepCard";
+import { SortableStepCard } from "./SortableStepCard";
 import "../../styles/action.css";
 
 const ALL_STEP_TYPES: StepType[] = [
@@ -208,6 +217,15 @@ export function ActionEditor() {
       const act = g.actions.find((a) => a.id === activeActionId);
       if (act) moveStep(act, fromIndex, toIndex);
     });
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id || !activeAction) return;
+    const fromIndex = activeAction.steps.findIndex((s) => s.id === active.id);
+    const toIndex = activeAction.steps.findIndex((s) => s.id === over.id);
+    if (fromIndex < 0 || toIndex < 0) return;
+    handleMoveStep(fromIndex, toIndex);
   };
 
   const handleStepChange = (stepId: string, changes: Partial<Step>) => {
@@ -437,55 +455,59 @@ export function ActionEditor() {
                 ステップがありません。上のボタンから追加するか、テンプレートを使用してください。
               </div>
             ) : (
-              <div className="step-list">
-                {activeAction.steps.map((step, index) => (
-                  <div key={step.id}>
-                    {/* 挿入ポイント */}
-                    <div className="step-insert-point">
+              <DndContext onDragEnd={handleDragEnd} collisionDetection={closestCenter}>
+                <SortableContext items={activeAction.steps.map((s) => s.id)} strategy={verticalListSortingStrategy}>
+                  <div className="step-list">
+                    {activeAction.steps.map((step, index) => (
+                      <div key={step.id}>
+                        {/* 挿入ポイント */}
+                        <div className="step-insert-point">
+                          <button
+                            className="step-insert-btn"
+                            onClick={() => handleAddStep("other", index)}
+                            title="ステップを挿入"
+                          >
+                            <i className="bi bi-plus" />
+                          </button>
+                        </div>
+                        <SortableStepCard
+                          step={step}
+                          index={index}
+                          label={getStepLabel(index)}
+                          allSteps={activeAction.steps}
+                          tables={tables}
+                          screens={screens}
+                          commonGroups={commonGroups}
+                          onChange={(changes) => handleStepChange(step.id, changes)}
+                          onCommit={commitGroup}
+                          onMoveUp={index > 0 ? () => handleMoveStep(index, index - 1) : undefined}
+                          onMoveDown={index < activeAction.steps.length - 1 ? () => handleMoveStep(index, index + 1) : undefined}
+                          onDelete={() => handleDeleteStep(step.id)}
+                          onDuplicate={() => handleDuplicateStep(step.id)}
+                          onAddSubStep={(type) => handleAddSubStep(step.id, type)}
+                          onDeleteSubStep={(subId) => handleDeleteStep(subId, step.id)}
+                          onContextMenu={(e) => {
+                            e.preventDefault();
+                            setContextMenu({ x: e.clientX, y: e.clientY, stepId: step.id });
+                          }}
+                          onNavigateCommon={(refId) => navigate(`/actions/${refId}`)}
+                          defaultExpanded={newStepIdsRef.current.has(step.id)}
+                        />
+                      </div>
+                    ))}
+                    {/* 末尾の挿入ポイント */}
+                    <div className="step-insert-point" style={{ opacity: 1 }}>
                       <button
                         className="step-insert-btn"
-                        onClick={() => handleAddStep("other", index)}
-                        title="ステップを挿入"
+                        onClick={() => handleAddStep("other")}
+                        title="ステップを末尾に追加"
                       >
                         <i className="bi bi-plus" />
                       </button>
                     </div>
-                    <StepCard
-                      step={step}
-                      index={index}
-                      label={getStepLabel(index)}
-                      allSteps={activeAction.steps}
-                      tables={tables}
-                      screens={screens}
-                      commonGroups={commonGroups}
-                      onChange={(changes) => handleStepChange(step.id, changes)}
-                      onCommit={commitGroup}
-                      onMoveUp={index > 0 ? () => handleMoveStep(index, index - 1) : undefined}
-                      onMoveDown={index < activeAction.steps.length - 1 ? () => handleMoveStep(index, index + 1) : undefined}
-                      onDelete={() => handleDeleteStep(step.id)}
-                      onDuplicate={() => handleDuplicateStep(step.id)}
-                      onAddSubStep={(type) => handleAddSubStep(step.id, type)}
-                      onDeleteSubStep={(subId) => handleDeleteStep(subId, step.id)}
-                      onContextMenu={(e) => {
-                        e.preventDefault();
-                        setContextMenu({ x: e.clientX, y: e.clientY, stepId: step.id });
-                      }}
-                      onNavigateCommon={(refId) => navigate(`/actions/${refId}`)}
-                      defaultExpanded={newStepIdsRef.current.has(step.id)}
-                    />
                   </div>
-                ))}
-                {/* 末尾の挿入ポイント */}
-                <div className="step-insert-point" style={{ opacity: 1 }}>
-                  <button
-                    className="step-insert-btn"
-                    onClick={() => handleAddStep("other")}
-                    title="ステップを末尾に追加"
-                  >
-                    <i className="bi bi-plus" />
-                  </button>
-                </div>
-              </div>
+                </SortableContext>
+              </DndContext>
             )}
           </div>
         ) : (

--- a/designer/src/components/action/SortableStepCard.tsx
+++ b/designer/src/components/action/SortableStepCard.tsx
@@ -1,0 +1,53 @@
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { StepCard } from "./StepCard";
+import type { Step, StepType } from "../../types/action";
+
+interface SortableStepCardProps {
+  step: Step;
+  index: number;
+  label: string;
+  allSteps: Step[];
+  tables: { id: string; name: string; logicalName: string }[];
+  screens: { id: string; name: string }[];
+  commonGroups: { id: string; name: string }[];
+  onChange: (changes: Partial<Step>) => void;
+  onCommit?: () => void;
+  onMoveUp?: () => void;
+  onMoveDown?: () => void;
+  onDelete: () => void;
+  onDuplicate: () => void;
+  onAddSubStep: (type: StepType) => void;
+  onDeleteSubStep: (subStepId: string) => void;
+  onContextMenu: (e: React.MouseEvent) => void;
+  onNavigateCommon: (refId: string) => void;
+  defaultExpanded?: boolean;
+}
+
+export function SortableStepCard({ step, ...props }: SortableStepCardProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: step.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : undefined,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style}>
+      <StepCard
+        step={step}
+        {...props}
+        dragHandleListeners={listeners}
+        dragHandleAttributes={attributes}
+      />
+    </div>
+  );
+}

--- a/designer/src/components/action/StepCard.tsx
+++ b/designer/src/components/action/StepCard.tsx
@@ -29,6 +29,10 @@ interface StepCardProps {
   onNavigateCommon: (refId: string) => void;
   /** 新規追加ステップのデフォルト展開 */
   defaultExpanded?: boolean;
+  /** D&D ドラッグハンドルの listeners（@dnd-kit 用） */
+  dragHandleListeners?: Record<string, unknown>;
+  /** D&D ドラッグハンドルの attributes（@dnd-kit 用） */
+  dragHandleAttributes?: Record<string, unknown>;
 }
 
 const DB_OPS: DbOperation[] = ["SELECT", "INSERT", "UPDATE", "DELETE"];
@@ -82,6 +86,8 @@ export function StepCard({
   onContextMenu,
   onNavigateCommon,
   defaultExpanded,
+  dragHandleListeners,
+  dragHandleAttributes,
 }: StepCardProps) {
   const [expanded, setExpanded] = useState(defaultExpanded ?? false);
   const [showMenu, setShowMenu] = useState(false);
@@ -121,7 +127,7 @@ export function StepCard({
         onContextMenu={onContextMenu}
       >
         <div className="step-card-header" onClick={() => setExpanded(!expanded)}>
-          <span className="step-card-drag-handle" title="ドラッグで移動">
+          <span className="step-card-drag-handle" title="ドラッグで移動" {...dragHandleListeners} {...dragHandleAttributes}>
             <i className="bi bi-grip-vertical" />
           </span>
           <span className="step-card-number">{label}</span>


### PR DESCRIPTION
## Summary

Closes #47

- `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities` を導入
- `SortableStepCard`: `useSortable` でラップした薄いラッパーコンポーネント
- `StepCard`: `dragHandleListeners`/`dragHandleAttributes` props で既存のグリップアイコン（`bi-grip-vertical`）をD&Dハンドルに接続
- `ActionEditor`: `DndContext` + `SortableContext` でステップリストをラップ、`handleDragEnd` で並べ替え + Undo連携

## Test plan

- [ ] ステップカード左端のグリップアイコンをドラッグして順序を変更できる
- [ ] 並べ替え後、ステップ番号が自動更新される
- [ ] Ctrl+Z で並べ替えを元に戻せる
- [ ] ↑↓ ボタンも引き続き動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)