### PR TITLE
feat(action): D&Dでツールバーからステップを任意位置に挿入

### DIFF
--- a/designer/src/components/action/ActionEditor.tsx
+++ b/designer/src/components/action/ActionEditor.tsx
@@ -33,6 +33,8 @@ import { mcpBridge } from "../../mcp/mcpBridge";
 import {
   DndContext,
   closestCenter,
+  useDraggable,
+  useDroppable,
   type DragEndEvent,
 } from "@dnd-kit/core";
 import {
@@ -41,9 +43,47 @@ import {
 } from "@dnd-kit/sortable";
 import { useUndoableState } from "../../hooks/useUndoableState";
 import { useUndoKeyboard } from "../../hooks/useUndoKeyboard";
+import { STEP_TYPE_COLORS } from "../../types/action";
 import { TableTopbar } from "../table/TableTopbar";
 import { SortableStepCard } from "./SortableStepCard";
 import "../../styles/action.css";
+
+/** ツールバーのドラッグ可能なステップ種別ボタン */
+function ToolbarStepButton({ type, onClick }: { type: StepType; onClick: () => void }) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: `toolbar-${type}`,
+    data: { kind: "toolbar-step", stepType: type },
+  });
+  return (
+    <button
+      ref={setNodeRef}
+      {...listeners}
+      {...attributes}
+      className={`step-toolbar-btn${isDragging ? " dragging" : ""}`}
+      onClick={onClick}
+      title={`${STEP_TYPE_LABELS[type]}（ドラッグで挿入）`}
+      style={isDragging ? { opacity: 0.5, borderColor: STEP_TYPE_COLORS[type] } : undefined}
+    >
+      <i className={STEP_TYPE_ICONS[type]} />
+      {STEP_TYPE_LABELS[type]}
+    </button>
+  );
+}
+
+/** ステップ間のドロップゾーン */
+function StepInsertZone({ index, onClick }: { index: number; onClick: () => void }) {
+  const { setNodeRef, isOver } = useDroppable({
+    id: `insert-${index}`,
+    data: { kind: "insert-zone", insertIndex: index },
+  });
+  return (
+    <div ref={setNodeRef} className={`step-insert-point${isOver ? " drop-active" : ""}`}>
+      <button className="step-insert-btn" onClick={onClick} title="ステップを挿入">
+        <i className="bi bi-plus" />
+      </button>
+    </div>
+  );
+}
 
 const ALL_STEP_TYPES: StepType[] = [
   "validation", "dbAccess", "externalSystem", "commonProcess",
@@ -221,11 +261,23 @@ export function ActionEditor() {
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
-    if (!over || active.id === over.id || !activeAction) return;
-    const fromIndex = activeAction.steps.findIndex((s) => s.id === active.id);
-    const toIndex = activeAction.steps.findIndex((s) => s.id === over.id);
-    if (fromIndex < 0 || toIndex < 0) return;
-    handleMoveStep(fromIndex, toIndex);
+    if (!over || !activeAction) return;
+
+    const dragKind = active.data.current?.kind;
+
+    if (dragKind === "toolbar-step") {
+      // #46: ツールバーからドロップ → 新規ステップを挿入
+      const stepType = active.data.current?.stepType as StepType;
+      const insertIndex = over.data.current?.insertIndex as number | undefined;
+      handleAddStep(stepType, insertIndex ?? activeAction.steps.length);
+    } else {
+      // #47: ステップカードの並べ替え
+      if (active.id === over.id) return;
+      const fromIndex = activeAction.steps.findIndex((s) => s.id === active.id);
+      const toIndex = activeAction.steps.findIndex((s) => s.id === over.id);
+      if (fromIndex < 0 || toIndex < 0) return;
+      handleMoveStep(fromIndex, toIndex);
+    }
   };
 
   const handleStepChange = (stepId: string, changes: Partial<Step>) => {
@@ -412,15 +464,7 @@ export function ActionEditor() {
             {/* ツールバー */}
             <div className="step-toolbar">
               {ALL_STEP_TYPES.map((type) => (
-                <button
-                  key={type}
-                  className="step-toolbar-btn"
-                  onClick={() => handleAddStep(type)}
-                  title={STEP_TYPE_LABELS[type]}
-                >
-                  <i className={STEP_TYPE_ICONS[type]} />
-                  {STEP_TYPE_LABELS[type]}
-                </button>
+                <ToolbarStepButton key={type} type={type} onClick={() => handleAddStep(type)} />
               ))}
               <div className="step-toolbar-sep" />
               <div style={{ position: "relative" }}>
@@ -460,16 +504,7 @@ export function ActionEditor() {
                   <div className="step-list">
                     {activeAction.steps.map((step, index) => (
                       <div key={step.id}>
-                        {/* 挿入ポイント */}
-                        <div className="step-insert-point">
-                          <button
-                            className="step-insert-btn"
-                            onClick={() => handleAddStep("other", index)}
-                            title="ステップを挿入"
-                          >
-                            <i className="bi bi-plus" />
-                          </button>
-                        </div>
+                        <StepInsertZone index={index} onClick={() => handleAddStep("other", index)} />
                         <SortableStepCard
                           step={step}
                           index={index}
@@ -496,15 +531,10 @@ export function ActionEditor() {
                       </div>
                     ))}
                     {/* 末尾の挿入ポイント */}
-                    <div className="step-insert-point" style={{ opacity: 1 }}>
-                      <button
-                        className="step-insert-btn"
-                        onClick={() => handleAddStep("other")}
-                        title="ステップを末尾に追加"
-                      >
-                        <i className="bi bi-plus" />
-                      </button>
-                    </div>
+                    <StepInsertZone
+                      index={activeAction.steps.length}
+                      onClick={() => handleAddStep("other")}
+                    />
                   </div>
                 </SortableContext>
               </DndContext>

--- a/designer/src/styles/action.css
+++ b/designer/src/styles/action.css
@@ -315,6 +315,14 @@
   opacity: 1;
 }
 
+.step-insert-point.drop-active {
+  opacity: 1;
+  padding: 12px 0;
+  background: rgba(99, 102, 241, 0.08);
+  border-radius: 6px;
+  border: 2px dashed #6366f1;
+}
+
 .step-insert-btn {
   width: 24px;
   height: 24px;


### PR DESCRIPTION
## Summary

Closes #46

- `ToolbarStepButton`: `useDraggable` でツールバーのステップ種別ボタンをドラッグ可能に
- `StepInsertZone`: `useDroppable` でステップ間にドロップゾーンを設置
- `handleDragEnd`: `data.kind` で `toolbar-step`（ツールバーからの新規挿入）と `step-card`（並べ替え）を判別
- ドラッグ中にドロップゾーンがハイライト表示
- クリックでの末尾追加は引き続き動作

## Test plan

- [ ] ツールバーのステップ種別ボタンをドラッグしてステップ間にドロップ → その位置に挿入される
- [ ] ドラッグ中に挿入可能な位置がハイライトされる
- [ ] ツールバーボタンのクリックで末尾に追加される（従来動作）
- [ ] ステップのD&D並べ替え（#47）も引き続き動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)