### PR TITLE
feat(action): ステップの複数選択・切り取り・コピー・貼り付けに対応

### DIFF
--- a/designer/src/components/action/ActionEditor.tsx
+++ b/designer/src/components/action/ActionEditor.tsx
@@ -43,6 +43,7 @@ import {
 } from "@dnd-kit/sortable";
 import { useUndoableState } from "../../hooks/useUndoableState";
 import { useUndoKeyboard } from "../../hooks/useUndoKeyboard";
+import { useSelectionKeyboard } from "../../hooks/useSelectionKeyboard";
 import { STEP_TYPE_COLORS } from "../../types/action";
 import { TableTopbar } from "../table/TableTopbar";
 import { SortableStepCard } from "./SortableStepCard";
@@ -71,16 +72,21 @@ function ToolbarStepButton({ type, onClick }: { type: StepType; onClick: () => v
 }
 
 /** ステップ間のドロップゾーン */
-function StepInsertZone({ index, onClick }: { index: number; onClick: () => void }) {
+function StepInsertZone({ index, onClick, onPaste }: { index: number; onClick: () => void; onPaste?: () => void }) {
   const { setNodeRef, isOver } = useDroppable({
     id: `insert-${index}`,
     data: { kind: "insert-zone", insertIndex: index },
   });
   return (
-    <div ref={setNodeRef} className={`step-insert-point${isOver ? " drop-active" : ""}`}>
+    <div ref={setNodeRef} className={`step-insert-point${isOver ? " drop-active" : ""}${onPaste ? " has-paste" : ""}`}>
       <button className="step-insert-btn" onClick={onClick} title="ステップを挿入">
         <i className="bi bi-plus" />
       </button>
+      {onPaste && (
+        <button className="step-paste-btn" onClick={onPaste} title="ここに貼り付け">
+          <i className="bi bi-clipboard-plus me-1" />貼り付け
+        </button>
+      )}
     </div>
   );
 }
@@ -107,6 +113,14 @@ export function ActionEditor() {
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; stepId: string; parentStepId?: string } | null>(null);
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const newStepIdsRef = useRef<Set<string>>(new Set());
+
+  // 選択・クリップボード state
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [clipboard, setClipboard] = useState<{
+    steps: Step[];
+    mode: "cut" | "copy";
+  } | null>(null);
+  const lastSelectedIdRef = useRef<string | null>(null);
 
   // 自動保存 (debounce 500ms)
   const scheduleSave = useCallback((updatedGroup: ActionGroup) => {
@@ -321,6 +335,98 @@ export function ActionEditor() {
     });
   };
 
+  // ── 選択操作 ──────────────────────────────────────────────────
+  const handleStepClick = (stepId: string, e: React.MouseEvent) => {
+    if (!activeAction) return;
+    if (e.ctrlKey || e.metaKey) {
+      // Ctrl+Click: トグル
+      setSelectedIds((prev) => {
+        const next = new Set(prev);
+        if (next.has(stepId)) next.delete(stepId);
+        else next.add(stepId);
+        return next;
+      });
+      lastSelectedIdRef.current = stepId;
+    } else if (e.shiftKey && lastSelectedIdRef.current) {
+      // Shift+Click: 範囲選択
+      const steps = activeAction.steps;
+      const lastIdx = steps.findIndex((s) => s.id === lastSelectedIdRef.current);
+      const curIdx = steps.findIndex((s) => s.id === stepId);
+      if (lastIdx >= 0 && curIdx >= 0) {
+        const [from, to] = lastIdx < curIdx ? [lastIdx, curIdx] : [curIdx, lastIdx];
+        const range = new Set<string>();
+        for (let i = from; i <= to; i++) range.add(steps[i].id);
+        setSelectedIds(range);
+      }
+    } else {
+      // 通常クリック: 選択解除（展開/折りたたみはStepCard内で処理）
+      setSelectedIds(new Set());
+      lastSelectedIdRef.current = null;
+    }
+  };
+
+  // ── クリップボード操作 ────────────────────────────────────────
+  const handleCut = useCallback(() => {
+    if (selectedIds.size === 0 || !activeAction) return;
+    const steps = activeAction.steps.filter((s) => selectedIds.has(s.id));
+    setClipboard({ steps: JSON.parse(JSON.stringify(steps)), mode: "cut" });
+    updateGroup((g) => {
+      const act = g.actions.find((a) => a.id === activeActionId);
+      if (!act) return;
+      for (const id of selectedIds) {
+        clearJumpReferences(act.steps, id);
+        removeStep(act, id);
+      }
+    });
+    setSelectedIds(new Set());
+  }, [selectedIds, activeAction, activeActionId, updateGroup]);
+
+  const handleCopy = useCallback(() => {
+    if (selectedIds.size === 0 || !activeAction) return;
+    const steps = activeAction.steps.filter((s) => selectedIds.has(s.id));
+    setClipboard({ steps: JSON.parse(JSON.stringify(steps)), mode: "copy" });
+  }, [selectedIds, activeAction]);
+
+  const handlePaste = useCallback((insertIndex?: number) => {
+    if (!clipboard || !activeAction) return;
+    const targetIndex = insertIndex ?? (() => {
+      // 選択中のステップがある場合: 最後の選択ステップの直後
+      if (selectedIds.size > 0) {
+        const lastIdx = Math.max(...activeAction.steps.map((s, i) => selectedIds.has(s.id) ? i : -1));
+        return lastIdx >= 0 ? lastIdx + 1 : activeAction.steps.length;
+      }
+      return activeAction.steps.length;
+    })();
+
+    updateGroup((g) => {
+      const act = g.actions.find((a) => a.id === activeActionId);
+      if (!act) return;
+      const newSteps = clipboard.steps.map((s) => {
+        const clone = JSON.parse(JSON.stringify(s)) as Step;
+        clone.id = generateUUID();
+        if (clone.subSteps) {
+          clone.subSteps = clone.subSteps.map((sub: Step) => ({ ...sub, id: generateUUID() }));
+        }
+        return clone;
+      });
+      act.steps.splice(targetIndex, 0, ...newSteps);
+    });
+    if (clipboard.mode === "cut") setClipboard(null);
+    setSelectedIds(new Set());
+  }, [clipboard, activeAction, activeActionId, selectedIds, updateGroup]);
+
+  const handleEscapeSelection = useCallback(() => {
+    setSelectedIds(new Set());
+  }, []);
+
+  useSelectionKeyboard({
+    onCut: handleCut,
+    onCopy: handleCopy,
+    onPaste: () => handlePaste(),
+    onEscape: handleEscapeSelection,
+    enabled: selectedIds.size > 0 || clipboard !== null,
+  });
+
   if (!group) return null;
 
   return (
@@ -504,7 +610,11 @@ export function ActionEditor() {
                   <div className="step-list">
                     {activeAction.steps.map((step, index) => (
                       <div key={step.id}>
-                        <StepInsertZone index={index} onClick={() => handleAddStep("other", index)} />
+                        <StepInsertZone
+                          index={index}
+                          onClick={() => handleAddStep("other", index)}
+                          onPaste={clipboard ? () => handlePaste(index) : undefined}
+                        />
                         <SortableStepCard
                           step={step}
                           index={index}
@@ -527,6 +637,8 @@ export function ActionEditor() {
                           }}
                           onNavigateCommon={(refId) => navigate(`/actions/${refId}`)}
                           defaultExpanded={newStepIdsRef.current.has(step.id)}
+                          selected={selectedIds.has(step.id)}
+                          onHeaderClick={(e) => handleStepClick(step.id, e)}
                         />
                       </div>
                     ))}
@@ -534,6 +646,7 @@ export function ActionEditor() {
                     <StepInsertZone
                       index={activeAction.steps.length}
                       onClick={() => handleAddStep("other")}
+                      onPaste={clipboard ? () => handlePaste(activeAction.steps.length) : undefined}
                     />
                   </div>
                 </SortableContext>

--- a/designer/src/components/action/SortableStepCard.tsx
+++ b/designer/src/components/action/SortableStepCard.tsx
@@ -22,6 +22,8 @@ interface SortableStepCardProps {
   onContextMenu: (e: React.MouseEvent) => void;
   onNavigateCommon: (refId: string) => void;
   defaultExpanded?: boolean;
+  selected?: boolean;
+  onHeaderClick?: (e: React.MouseEvent) => void;
 }
 
 export function SortableStepCard({ step, ...props }: SortableStepCardProps) {

--- a/designer/src/components/action/StepCard.tsx
+++ b/designer/src/components/action/StepCard.tsx
@@ -33,6 +33,10 @@ interface StepCardProps {
   dragHandleListeners?: Record<string, unknown>;
   /** D&D ドラッグハンドルの attributes（@dnd-kit 用） */
   dragHandleAttributes?: Record<string, unknown>;
+  /** 選択状態 */
+  selected?: boolean;
+  /** ヘッダークリック（Ctrl/Shift選択用） */
+  onHeaderClick?: (e: React.MouseEvent) => void;
 }
 
 const DB_OPS: DbOperation[] = ["SELECT", "INSERT", "UPDATE", "DELETE"];
@@ -88,6 +92,8 @@ export function StepCard({
   defaultExpanded,
   dragHandleListeners,
   dragHandleAttributes,
+  selected,
+  onHeaderClick,
 }: StepCardProps) {
   const [expanded, setExpanded] = useState(defaultExpanded ?? false);
   const [showMenu, setShowMenu] = useState(false);
@@ -122,11 +128,18 @@ export function StepCard({
   return (
     <div>
       <div
-        className="step-card"
+        className={`step-card${selected ? " selected" : ""}`}
         style={{ borderLeftColor: color }}
         onContextMenu={onContextMenu}
       >
-        <div className="step-card-header" onClick={() => setExpanded(!expanded)}>
+        <div className="step-card-header" onClick={(e) => {
+          if ((e.ctrlKey || e.metaKey || e.shiftKey) && onHeaderClick) {
+            onHeaderClick(e);
+          } else {
+            if (onHeaderClick) onHeaderClick(e); // clear selection on normal click
+            setExpanded(!expanded);
+          }
+        }}>
           <span className="step-card-drag-handle" title="ドラッグで移動" {...dragHandleListeners} {...dragHandleAttributes}>
             <i className="bi bi-grip-vertical" />
           </span>

--- a/designer/src/hooks/useSelectionKeyboard.ts
+++ b/designer/src/hooks/useSelectionKeyboard.ts
@@ -1,0 +1,54 @@
+import { useEffect } from "react";
+
+interface SelectionKeyboardOpts {
+  onCut: () => void;
+  onCopy: () => void;
+  onPaste: () => void;
+  onEscape: () => void;
+  enabled?: boolean;
+}
+
+/**
+ * Ctrl+X / Ctrl+C / Ctrl+V / Esc キーバインドフック
+ */
+export function useSelectionKeyboard({
+  onCut,
+  onCopy,
+  onPaste,
+  onEscape,
+  enabled = true,
+}: SelectionKeyboardOpts): void {
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handler = (e: KeyboardEvent) => {
+      const tag = (e.target as HTMLElement)?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+      if ((e.target as HTMLElement)?.isContentEditable) return;
+
+      const ctrl = e.ctrlKey || e.metaKey;
+
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onEscape();
+        return;
+      }
+
+      if (!ctrl) return;
+
+      if (e.key === "x") {
+        e.preventDefault();
+        onCut();
+      } else if (e.key === "c") {
+        e.preventDefault();
+        onCopy();
+      } else if (e.key === "v") {
+        e.preventDefault();
+        onPaste();
+      }
+    };
+
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onCut, onCopy, onPaste, onEscape, enabled]);
+}

--- a/designer/src/styles/action.css
+++ b/designer/src/styles/action.css
@@ -344,6 +344,25 @@
   background: #f5f3ff;
 }
 
+.step-insert-point.has-paste {
+  opacity: 1;
+}
+
+.step-paste-btn {
+  font-size: 0.72rem;
+  padding: 2px 8px;
+  border: 1px dashed #6366f1;
+  border-radius: 4px;
+  background: #f5f3ff;
+  color: #6366f1;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.step-paste-btn:hover {
+  background: #ede9fe;
+}
+
 .step-card {
   border: 1px solid #e2e8f0;
   border-radius: 8px;
@@ -367,6 +386,12 @@
   gap: 8px;
   padding: 10px 12px;
   cursor: pointer;
+}
+
+/* 選択状態 */
+.step-card.selected {
+  outline: 2px solid #6366f1;
+  background-color: rgba(99, 102, 241, 0.05);
 }
 
 .step-card-drag-handle {


### PR DESCRIPTION
## Summary

Closes #48

- `useSelectionKeyboard` フック: Ctrl+X/C/V/Esc キーバインド
- Ctrl+Click で複数任意選択、Shift+Click で範囲選択
- 通常クリック（修飾キーなし）は従来の展開/折りたたみ動作を維持（選択はクリア）
- Ctrl+X: 選択ステップを切り取り → クリップボードに保持、Ctrl+C: コピー
- Ctrl+V: 最後の選択ステップの直後、または末尾に貼り付け
- クリップボードがある時、ステップ間に「貼り付け」ボタンを表示（明示的な挿入位置指定）
- 選択中のカードにアウトライン表示
- ステップIDは貼り付け時に新規発行（重複防止）

## Test plan

- [ ] Ctrl+Click でステップを複数選択できる（アウトライン表示）
- [ ] Shift+Click で範囲選択できる
- [ ] 通常クリックで展開/折りたたみが動作する（選択はクリア）
- [ ] Ctrl+X で選択ステップが切り取られる
- [ ] Ctrl+C で選択ステップがコピーされる
- [ ] Ctrl+V で末尾に貼り付けられる
- [ ] クリップボードがある時「貼り付け」ボタンが表示される
- [ ] 「貼り付け」ボタンクリックでその位置に挿入される
- [ ] Esc で選択が解除される

🤖 Generated with [Claude Code](https://claude.com/claude-code)