### PR TITLE
fix(action): D&Dドラッグハンドルが動作しない問題を修正

### DIFF
--- a/designer/src/components/action/StepCard.tsx
+++ b/designer/src/components/action/StepCard.tsx
@@ -140,7 +140,19 @@ export function StepCard({
             setExpanded(!expanded);
           }
         }}>
-          <span className="step-card-drag-handle" title="ドラッグで移動" {...dragHandleListeners} {...dragHandleAttributes}>
+          <span
+            className="step-card-drag-handle"
+            title="ドラッグで移動"
+            {...dragHandleAttributes}
+            {...dragHandleListeners}
+            onClick={(e) => e.stopPropagation()}
+            onPointerDown={(e) => {
+              e.stopPropagation();
+              // dnd-kit の onPointerDown を呼び出す
+              const handler = (dragHandleListeners as Record<string, (e: React.PointerEvent) => void> | undefined)?.onPointerDown;
+              if (handler) handler(e);
+            }}
+          >
             <i className="bi bi-grip-vertical" />
           </span>
           <span className="step-card-number">{label}</span>

--- a/designer/src/styles/action.css
+++ b/designer/src/styles/action.css
@@ -398,7 +398,9 @@
   cursor: grab;
   color: #cbd5e1;
   font-size: 0.9rem;
-  padding: 2px;
+  padding: 4px 2px;
+  touch-action: none;
+  user-select: none;
 }
 
 .step-card-drag-handle:active {


### PR DESCRIPTION
## Summary

- ドラッグハンドルの `onPointerDown` で `stopPropagation` を追加（ヘッダーの `onClick` へのバブリングを防止し、展開/折りたたみの誤発火を防ぐ）
- CSS に `touch-action: none` と `user-select: none` を追加（ブラウザのデフォルトドラッグ動作を抑制）
- dnd-kit の `onPointerDown` ハンドラを明示的に呼び出してD&D開始を確実にする

## Test plan

- [ ] ステップカード左端のグリップアイコンをドラッグして順序変更できる
- [ ] ドラッグ中にカードが展開/折りたたみされない
- [ ] ドラッグ後にカードが正しい位置に移動する

🤖 Generated with [Claude Code](https://claude.com/claude-code)