### PR TITLE
fix(action): D&Dドラッグハンドルの操作性を改善

### DIFF
--- a/designer/src/components/action/ActionEditor.tsx
+++ b/designer/src/components/action/ActionEditor.tsx
@@ -35,6 +35,9 @@ import {
   closestCenter,
   useDraggable,
   useDroppable,
+  PointerSensor,
+  useSensor,
+  useSensors,
   type DragEndEvent,
 } from "@dnd-kit/core";
 import {
@@ -144,6 +147,11 @@ export function ActionEditor() {
   } = useUndoableState<ActionGroup | null>(null, { onSave: (g) => { if (g) saveActionGroup(g); } });
 
   useUndoKeyboard(undo, redo);
+
+  // D&D: PointerSensor に移動距離閾値を設定（クリックとドラッグを区別）
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+  );
 
   const reload = useCallback(async () => {
     if (!actionGroupId) return;
@@ -605,7 +613,7 @@ export function ActionEditor() {
                 ステップがありません。上のボタンから追加するか、テンプレートを使用してください。
               </div>
             ) : (
-              <DndContext onDragEnd={handleDragEnd} collisionDetection={closestCenter}>
+              <DndContext sensors={sensors} onDragEnd={handleDragEnd} collisionDetection={closestCenter}>
                 <SortableContext items={activeAction.steps.map((s) => s.id)} strategy={verticalListSortingStrategy}>
                   <div className="step-list">
                     {activeAction.steps.map((step, index) => (

--- a/designer/src/components/action/StepCard.tsx
+++ b/designer/src/components/action/StepCard.tsx
@@ -133,6 +133,8 @@ export function StepCard({
         onContextMenu={onContextMenu}
       >
         <div className="step-card-header" onClick={(e) => {
+          // ドラッグハンドルからのクリックは無視
+          if ((e.target as HTMLElement).closest("[data-drag-handle]")) return;
           if ((e.ctrlKey || e.metaKey || e.shiftKey) && onHeaderClick) {
             onHeaderClick(e);
           } else {
@@ -143,15 +145,9 @@ export function StepCard({
           <span
             className="step-card-drag-handle"
             title="ドラッグで移動"
+            data-drag-handle
             {...dragHandleAttributes}
             {...dragHandleListeners}
-            onClick={(e) => e.stopPropagation()}
-            onPointerDown={(e) => {
-              e.stopPropagation();
-              // dnd-kit の onPointerDown を呼び出す
-              const handler = (dragHandleListeners as Record<string, (e: React.PointerEvent) => void> | undefined)?.onPointerDown;
-              if (handler) handler(e);
-            }}
           >
             <i className="bi bi-grip-vertical" />
           </span>

--- a/designer/src/styles/action.css
+++ b/designer/src/styles/action.css
@@ -397,10 +397,11 @@
 .step-card-drag-handle {
   cursor: grab;
   color: #cbd5e1;
-  font-size: 0.9rem;
-  padding: 4px 2px;
+  font-size: 1rem;
+  padding: 8px 6px;
   touch-action: none;
   user-select: none;
+  margin: -8px -2px -8px -6px;
 }
 
 .step-card-drag-handle:active {


### PR DESCRIPTION
## Summary

D&Dでカードがドラッグできなかった問題を修正。

**原因（2つ）:**
1. 前回の修正で `onPointerDown` をオーバーライドして dnd-kit のハンドラーを手動呼び出ししていたが、PointerCapture の仕組みと競合してドラッグが開始されなかった
2. ドラッグハンドルの当たり判定が 16.6px × 26.9px と小さすぎた

**修正内容:**
- `onPointerDown` のオーバーライドを廃止し、dnd-kit の listeners をそのまま適用
- ヘッダーの `onClick` で `data-drag-handle` 属性を持つ要素からのクリックを除外（`closest` チェック）
- ハンドルのパディングを拡大（`padding: 8px 6px`）、フォントサイズを `1rem` に
- `PointerSensor` に `activationConstraint: { distance: 8 }` を明示設定

## Test plan

- [x] ネイティブマウス操作でステップカードをドラッグして順序変更できることを確認済み
- [ ] ドラッグハンドルをクリックしてもカードが展開/折りたたみされない
- [ ] ハンドル以外のカードヘッダー部分をクリックすると展開/折りたたみが動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)