### PR TITLE
fix(action): グリップハンドルの視認性と操作性を改善

### DIFF
--- a/designer/src/styles/action.css
+++ b/designer/src/styles/action.css
@@ -396,16 +396,27 @@
 
 .step-card-drag-handle {
   cursor: grab;
-  color: #cbd5e1;
-  font-size: 1rem;
-  padding: 8px 6px;
+  color: #94a3b8;
+  font-size: 1.25rem;
+  padding: 10px 8px;
   touch-action: none;
   user-select: none;
-  margin: -8px -2px -8px -6px;
+  margin: -10px -4px -10px -8px;
+  display: flex;
+  align-items: center;
+  border-radius: 4px;
+  transition: color 0.15s, background-color 0.15s;
+}
+
+.step-card-drag-handle:hover {
+  color: #475569;
+  background-color: #f1f5f9;
 }
 
 .step-card-drag-handle:active {
   cursor: grabbing;
+  color: #334155;
+  background-color: #e2e8f0;
 }
 
 .step-card-number {


### PR DESCRIPTION
## 変更内容

ステップカードのドラッグハンドルに関する2点の問題を修正。

### 問題
1. グリップアイコンが白背景に対して見えない（色が `#cbd5e1` で薄すぎる）
2. ハンドルが小さくて操作しづらい

### 修正
- カラーを `#cbd5e1` → `#94a3b8` に変更（視認性向上）
- フォントサイズを `1rem` → `1.25rem` に拡大
- パディング増加でタップ/クリック領域を拡大
- ホバー時に背景色ハイライト追加（どこを掴むかわかりやすく）
- アクティブ時にもビジュアルフィードバック追加

## テスト

- [ ] ステップカードのグリップアイコンが白背景で見えること
- [ ] ホバー時にハイライト表示されること
- [ ] D&D でステップ並び替えが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)