### PR TITLE
fix(action): DndContext をツールバーごと包むよう修正してD&Dを有効化

### DIFF
--- a/designer/src/components/action/ActionEditor.tsx
+++ b/designer/src/components/action/ActionEditor.tsx
@@ -575,45 +575,45 @@ export function ActionEditor() {
               </div>
             </div>
 
-            {/* ツールバー */}
-            <div className="step-toolbar">
-              {ALL_STEP_TYPES.map((type) => (
-                <ToolbarStepButton key={type} type={type} onClick={() => handleAddStep(type)} />
-              ))}
-              <div className="step-toolbar-sep" />
-              <div style={{ position: "relative" }}>
-                <button
-                  className="step-template-btn"
-                  onClick={() => setShowTemplates(!showTemplates)}
-                >
-                  <i className="bi bi-collection" />
-                  テンプレート
-                </button>
-                {showTemplates && (
-                  <div className="template-dropdown">
-                    {STEP_TEMPLATES.map((tpl) => (
-                      <div
-                        key={tpl.id}
-                        className="template-dropdown-item"
-                        onClick={() => handleAddTemplate(tpl.id)}
-                      >
-                        <div className="template-dropdown-item-label">{tpl.label}</div>
-                        <div className="template-dropdown-item-desc">{tpl.description}</div>
-                      </div>
-                    ))}
-                  </div>
-                )}
+            <DndContext sensors={sensors} onDragEnd={handleDragEnd} collisionDetection={closestCenter}>
+              {/* ツールバー */}
+              <div className="step-toolbar">
+                {ALL_STEP_TYPES.map((type) => (
+                  <ToolbarStepButton key={type} type={type} onClick={() => handleAddStep(type)} />
+                ))}
+                <div className="step-toolbar-sep" />
+                <div style={{ position: "relative" }}>
+                  <button
+                    className="step-template-btn"
+                    onClick={() => setShowTemplates(!showTemplates)}
+                  >
+                    <i className="bi bi-collection" />
+                    テンプレート
+                  </button>
+                  {showTemplates && (
+                    <div className="template-dropdown">
+                      {STEP_TEMPLATES.map((tpl) => (
+                        <div
+                          key={tpl.id}
+                          className="template-dropdown-item"
+                          onClick={() => handleAddTemplate(tpl.id)}
+                        >
+                          <div className="template-dropdown-item-label">{tpl.label}</div>
+                          <div className="template-dropdown-item-desc">{tpl.description}</div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
               </div>
-            </div>
 
-            {/* ステップリスト */}
-            {activeAction.steps.length === 0 ? (
-              <div className="step-empty">
-                <i className="bi bi-plus-circle" />
-                ステップがありません。上のボタンから追加するか、テンプレートを使用してください。
-              </div>
-            ) : (
-              <DndContext sensors={sensors} onDragEnd={handleDragEnd} collisionDetection={closestCenter}>
+              {/* ステップリスト */}
+              {activeAction.steps.length === 0 ? (
+                <div className="step-empty">
+                  <i className="bi bi-plus-circle" />
+                  ステップがありません。上のボタンから追加するか、テンプレートを使用してください。
+                </div>
+              ) : (
                 <SortableContext items={activeAction.steps.map((s) => s.id)} strategy={verticalListSortingStrategy}>
                   <div className="step-list">
                     {activeAction.steps.map((step, index) => (
@@ -658,8 +658,8 @@ export function ActionEditor() {
                     />
                   </div>
                 </SortableContext>
-              </DndContext>
-            )}
+              )}
+            </DndContext>
           </div>
         ) : (
           <div className="step-empty">

--- a/designer/src/components/action/StepCard.tsx
+++ b/designer/src/components/action/StepCard.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from "react";
+import type { DraggableAttributes, DraggableSyntheticListeners } from "@dnd-kit/core";
 import type { Step, StepType, DbOperation } from "../../types/action";
 import {
   STEP_TYPE_LABELS,
@@ -30,9 +31,9 @@ interface StepCardProps {
   /** 新規追加ステップのデフォルト展開 */
   defaultExpanded?: boolean;
   /** D&D ドラッグハンドルの listeners（@dnd-kit 用） */
-  dragHandleListeners?: Record<string, unknown>;
+  dragHandleListeners?: DraggableSyntheticListeners;
   /** D&D ドラッグハンドルの attributes（@dnd-kit 用） */
-  dragHandleAttributes?: Record<string, unknown>;
+  dragHandleAttributes?: DraggableAttributes;
   /** 選択状態 */
   selected?: boolean;
   /** ヘッダークリック（Ctrl/Shift選択用） */


### PR DESCRIPTION
## 問題

`ToolbarStepButton` は `useDraggable` を使用しているが、`DndContext` の**外**に配置されていた。
`useDraggable` / `useSortable` は必ず `DndContext` の内側でなければ動作しない。

これにより：
- ツールバーボタンのドラッグ（→挿入ゾーンへのドロップ）が完全に機能しない
- ステップカードの並べ替えD&Dも同コンテキスト外のため動作しない

## 修正

- `DndContext` をツールバーとステップリストの両方を包む位置に移動
- ステップ数が 0 の空状態でも `DndContext` 内に収める
- `StepCard` の prop 型を `Record<string, unknown>` → `DraggableAttributes` / `DraggableSyntheticListeners` に修正（型安全性向上）

## テスト

- [ ] ツールバーの「バリデーション」等をドラッグして挿入ゾーンにドロップできること
- [ ] ステップカードのグリップをドラッグして順番を並べ替えられること

🤖 Generated with [Claude Code](https://claude.com/claude-code)