### PR TITLE
fix(action): D&D UX改善 - グリップ視認性・エリア外キャンセル

### DIFF
--- a/designer/src/components/action/ActionEditor.tsx
+++ b/designer/src/components/action/ActionEditor.tsx
@@ -39,6 +39,7 @@ import {
   useSensor,
   useSensors,
   type DragEndEvent,
+  type CollisionDetection,
 } from "@dnd-kit/core";
 import {
   SortableContext,
@@ -152,6 +153,19 @@ export function ActionEditor() {
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
   );
+
+  // D&D: ステップリストの境界外でのドロップをキャンセルするための ref
+  const stepListRef = useRef<HTMLDivElement>(null);
+
+  // ポインターがステップリスト内にあるときのみ衝突判定を行う
+  const collisionDetection = useCallback<CollisionDetection>((args) => {
+    const pointer = args.pointerCoordinates;
+    if (pointer && stepListRef.current) {
+      const { top, bottom } = stepListRef.current.getBoundingClientRect();
+      if (pointer.y < top || pointer.y > bottom) return [];
+    }
+    return closestCenter(args);
+  }, []);
 
   const reload = useCallback(async () => {
     if (!actionGroupId) return;
@@ -575,7 +589,7 @@ export function ActionEditor() {
               </div>
             </div>
 
-            <DndContext sensors={sensors} onDragEnd={handleDragEnd} collisionDetection={closestCenter}>
+            <DndContext sensors={sensors} onDragEnd={handleDragEnd} collisionDetection={collisionDetection}>
               {/* ツールバー */}
               <div className="step-toolbar">
                 {ALL_STEP_TYPES.map((type) => (
@@ -615,7 +629,7 @@ export function ActionEditor() {
                 </div>
               ) : (
                 <SortableContext items={activeAction.steps.map((s) => s.id)} strategy={verticalListSortingStrategy}>
-                  <div className="step-list">
+                  <div className="step-list" ref={stepListRef}>
                     {activeAction.steps.map((step, index) => (
                       <div key={step.id}>
                         <StepInsertZone

--- a/designer/src/styles/action.css
+++ b/designer/src/styles/action.css
@@ -396,7 +396,7 @@
 
 .step-card-drag-handle {
   cursor: grab;
-  color: #94a3b8;
+  color: #64748b;
   font-size: 1.25rem;
   padding: 10px 8px;
   touch-action: none;
@@ -405,18 +405,19 @@
   display: flex;
   align-items: center;
   border-radius: 4px;
+  background-color: #f1f5f9;
   transition: color 0.15s, background-color 0.15s;
 }
 
 .step-card-drag-handle:hover {
-  color: #475569;
-  background-color: #f1f5f9;
+  color: #334155;
+  background-color: #e2e8f0;
 }
 
 .step-card-drag-handle:active {
   cursor: grabbing;
-  color: #334155;
-  background-color: #e2e8f0;
+  color: #1e293b;
+  background-color: #cbd5e1;
 }
 
 .step-card-number {


### PR DESCRIPTION
## 修正内容

### 1. グリップアイコンの視認性向上

グリップアイコン (`⠿`) が白背景に対して見えにくかった問題を修正。

| 項目 | 変更前 | 変更後 |
|------|--------|--------|
| カラー | `#94a3b8` (薄いグレー) | `#64748b` (濃いグレー) |
| 背景 | なし | 常時 `#f1f5f9` (薄い青灰) |
| ホバー | 少し濃く | より濃く `#e2e8f0` |

→ ドラッグ可能エリアが一目でわかるようになる。

### 2. エリア外でのドロップキャンセル

`closestCenter` をそのまま使うと、ポインターがステップリスト外に出ても
最寄りカードへのソートプレビューが表示され、リリースするとそのままソートされていた。

**カスタム `collisionDetection` で修正：**

```ts
const collisionDetection = useCallback<CollisionDetection>((args) => {
  const pointer = args.pointerCoordinates;
  if (pointer && stepListRef.current) {
    const { top, bottom } = stepListRef.current.getBoundingClientRect();
    if (pointer.y < top || pointer.y > bottom) return []; // 境界外→衝突なし
  }
  return closestCenter(args);
}, []);
```

- ポインターがリスト上端より上 or 下端より下 → 衝突判定 `[]` を返す
  - ソートプレビューが消える (2a の「エリア外でキャンセル」)
  - リリースしても `over === null` になるため並び替えが起きない (2b)
- ポインターが戻ってきたら → 通常の `closestCenter` に戻る (2a の「再開」)

## テスト

- [ ] ステップカードのグリップが薄い背景で常時見えること
- [ ] ドラッグ中にポインターをリスト上部（ツールバー）に持っていくとプレビューが消えること
- [ ] リスト外でリリースしても並び替えが起きないこと
- [ ] リスト内に戻るとプレビューが再表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)