### PR TITLE
feat(action): 処理フロー表現力強化 フェーズ2〜6

### DIFF
--- a/.claude/skills/test-strategy/SKILL.md
+++ b/.claude/skills/test-strategy/SKILL.md
@@ -1,0 +1,105 @@
+---
+description: テスト実装・修正・Vitest・Playwright・E2E・スペック・spec・test
+paths:
+  - "designer/src/**/*.test.ts"
+  - "designer/e2e/**/*.spec.ts"
+  - "designer/e2e/**/*"
+---
+
+# テスト戦略
+
+このプロジェクトのテストは **3層・3視点** で実装する。同じ機能でも視点が異なるため、3つは競合ではなく補完関係にある。
+
+## 3層の役割分担
+
+| 層 | ツール | テストの主体 | 何を保証するか |
+|----|--------|------------|---------------|
+| ロジック層 | Vitest | 開発者 | コードの振る舞いの正しさ |
+| UI層 | Playwright (.spec.ts) | ユーザー | 見た目・操作の正しさ |
+| 統合層 | wsBridge E2E | ブラウザ↔ファイル | WebSocket通信とファイル永続化の正しさ |
+
+## 各層のスコープ
+
+**Vitest（`designer/src/**/*.test.ts`）**
+- ストアのロジック（tabStore の状態遷移、dirty フラグ管理など）
+- ユーティリティ関数
+- データ変換・バリデーション
+- GrapesJS / ReactFlow / WebSocket は含めない
+
+**Playwright（`designer/e2e/**/*.spec.ts`）**
+- TabBar の操作（開閉・右クリックメニュー・D&D）
+- ナビゲーション・ルーティング・URL 同期
+- 保存ボタンの表示/非表示（isDirty の UI 反映）
+- GrapesJS キャンバス内部はスコープ外（iframe 制約・費用対効果が低い）
+- テストコードは AI が生成し、実行は `npx playwright test` で自律実行する
+
+**MCP テスト（`designer/e2e/mcp/**/*.spec.ts`）**
+- ブラウザ役として `{ type: "request" }` プロトコルで wsBridge に接続し、ファイル操作を検証する
+- テスト可能: `loadProject` / `saveProject` / `loadScreen` / `saveScreen` / `deleteScreen`
+- テスト不可（stdio経由のみ）: `designer__open_tab` 等のタブ操作コマンド → Issue #67 参照
+- designer-mcp が ws://localhost:5179 で起動していない場合は自動スキップ
+
+## バグの切り分け方針
+
+```
+Vitest 失敗               → ロジックバグ（store/utils 層）
+Playwright 失敗のみ       → UI 実装バグ（コンポーネント層）
+MCP テスト失敗のみ        → WebSocket/ファイル永続化バグ
+```
+
+## Playwright 実装ルール
+
+### AI の役割
+- AI は `.spec.ts` ファイルを生成するだけ。テストの実行は `npx playwright test` で自律実行する
+- AI が Playwright MCP を直接操作するのは「探索・デバッグ」目的の一時的な用途に限定する
+- テスト失敗時のみ、失敗ログを AI に渡して修正を依頼する
+
+### addInitScript の挙動（重要）
+`page.addInitScript()` は `page.goto()` と `page.reload()` を含む**全ナビゲーションで再実行**される。
+
+- タブ状態の事前設定は addInitScript 内で行い、`designer-open-tabs` と `designer-active-tab` を両方セットする
+- 「UIで操作した状態がリロード後も保持される」テストは書けない（addInitScript が毎回上書きするため）
+  → 代わりにリロード後の期待状態を addInitScript で事前設定して検証する
+
+```typescript
+await page.addInitScript(({ project, tabs, activeTabId }) => {
+  localStorage.setItem("flow-project", JSON.stringify(project));
+  localStorage.setItem("designer-open-tabs", JSON.stringify(tabs));
+  localStorage.setItem("designer-active-tab", activeTabId);
+}, { project, tabs, activeTabId });
+```
+
+### ブラウザにインターセプトされるキー操作
+`Ctrl+Tab`（タブ切り替え）と `Ctrl+W`（タブを閉じる）はChromiumがページより先に処理するため、`page.keyboard.press()` では届かない。`document.dispatchEvent()` で直接送出する：
+
+```typescript
+await page.evaluate(() => {
+  document.dispatchEvent(new KeyboardEvent("keydown", {
+    key: "Tab", ctrlKey: true, bubbles: true, cancelable: true,
+  }));
+});
+```
+
+### opacity:0 要素のクリック
+タブの閉じるボタン（`.tabbar-tab-close`）はホバー前は `opacity: 0`。Playwright の actionability チェックをスキップするために `{ force: true }` を使う：
+
+```typescript
+await tabLocator.locator(".tabbar-tab-close").click({ force: true });
+```
+
+### 複数要素への toContainText は strict モード違反
+複数の要素にマッチするロケータに `toContainText()` を使うと strict モード違反になる。`.filter()` で絞り込む：
+
+```typescript
+// NG: locator(".tabbar-tab") が複数マッチすると失敗
+await expect(page.locator(".tabbar-tab")).toContainText("画面A");
+
+// OK
+await expect(page.locator(".tabbar-tab").filter({ hasText: "画面A" })).toBeVisible();
+```
+
+## テスト実装の優先順位
+
+1. **Vitest 優先** — 純ロジックは即効性が高くメンテコストが低い
+2. **Playwright 次** — TabBar・ナビゲーションはこのプロジェクトと相性が良い
+3. **MCP テスト** — ファイル永続化パイプラインなどこのシステム特有の価値がある箇所に適用

--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,8 @@ output/
 screenshots/
 *.png
 
-# Claude Code local settings
-.claude/
+# Claude Code local settings (skills/commands はチーム共有のため追跡対象)
+.claude/settings.local.json
 
 # Editor / OS
 .DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,102 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+業務システム デザイナー — Japanese business application WYSIWYG screen designer. Two main components:
+
+- **designer/** — Frontend (React + Vite + GrapesJS + ReactFlow)
+- **designer-mcp/** — MCP server + WebSocket bridge for file persistence
+
+## Commands
+
+### Designer (Frontend)
+
+```bash
+cd designer
+npm install        # Install dependencies
+npm run dev        # Dev server (http://localhost:5173)
+npm run build      # TypeScript check + Vite build
+npm run lint       # ESLint
+```
+
+### Designer-MCP (Backend)
+
+```bash
+cd designer-mcp
+npm install
+npm run dev        # Watch mode (tsx)
+npm run build      # Compile to dist/
+```
+
+Both servers must run simultaneously for file-based persistence. Without designer-mcp, the frontend falls back to localStorage.
+
+### Test Data
+
+```bash
+node docs/sample-project/seed.mjs   # Generate 10 sample screens into data/
+```
+
+## Architecture
+
+### Two-Process Design
+
+```
+Claude Code ──(stdio)──→ designer-mcp ←──(ws://0.0.0.0:5179)──→ Browser
+                              ↕
+                         data/ folder
+```
+
+- **MCP (stdio):** Claude Code sends commands (add screen, set components, etc.)
+- **WebSocket (port 5179):** Browser reads/writes screen data via wsBridge
+- **Shared storage:** Both access `data/` directory (project.json + screens/*.json)
+
+### Routing
+
+| Path | Component | Purpose |
+|------|-----------|---------|
+| `/` | FlowEditor | Screen flow diagram (ReactFlow) |
+| `/design/:screenId` | ScreenDesigner | WYSIWYG canvas (GrapesJS) |
+| `/tables` | TableListView | Table definitions list |
+| `/tables/:tableId` | TableEditor | Table column editor |
+| `/er` | ErDiagram | ER diagram |
+
+### Key Directories
+
+- `designer/src/components/flow/` — Flow diagram editor (ReactFlow-based)
+- `designer/src/grapes/blocks.ts` — 60+ pre-built block definitions
+- `designer/src/store/` — Persistence layer (flowStore, customBlockStore)
+- `designer/src/mcp/mcpBridge.ts` — Browser-side WebSocket client
+- `designer-mcp/src/tools.ts` — 20 MCP tool definitions
+- `designer-mcp/src/wsBridge.ts` — WebSocket server + broadcast
+
+### Data Flow
+
+- **Save:** GrapesJS autosave → remoteStorage → mcpBridge (WS) → wsBridge → `data/screens/{id}.json`
+- **Fallback:** If WS disconnected → localStorage (`gjs-screen-{id}`)
+- **Sync:** wsBridge broadcasts changes to all connected browser tabs
+
+## Environment Notes
+
+- **Windows:** `npx` may fail in Git Bash. Ensure Node.js is in PATH.
+- **gh CLI:** Added to PATH via `~/.bashrc`. No prefix needed — `gh` commands work directly.
+- **Ports:** Vite on 5173 (strictPort), WebSocket on 5179. Both listen on 0.0.0.0.
+- **HTTP access:** `crypto.randomUUID()` is unavailable in non-secure contexts. Use `generateUUID()` from `src/utils/uuid.ts` instead.
+- **Playwright MCP:** Do not use `--headless=false` flag on Windows.
+
+## Testing Strategy
+
+詳細は `/test-strategy` スキル参照（テスト実装・修正時に自動起動）。
+
+- Vitest: `designer/src/**/*.test.ts` — ストアロジック・ユーティリティ
+- Playwright: `designer/e2e/**/*.spec.ts` — UI・ナビゲーション操作
+- MCP E2E: `designer/e2e/mcp/**/*.spec.ts` — wsBridge ファイル操作（要 designer-mcp 起動）
+
+## Conventions
+
+- All UI text is in Japanese
+- Commit messages use conventional commits in Japanese (e.g., `feat(flow):`, `fix(designer):`, `improve:`)
+- `data/` directory is gitignored — runtime data only
+- Themes: standard (default Bootstrap), card, compact, dark — CSS injected into GrapesJS canvas iframe
+- Custom blocks persist to `data/custom-blocks.json` via customBlockStore

--- a/designer/src/components/action/ActionEditor.tsx
+++ b/designer/src/components/action/ActionEditor.tsx
@@ -23,11 +23,12 @@ import {
   removeStep,
   moveStep,
   addSubStep,
-  removeSubStep,
 } from "../../store/actionStore";
 import { listTables } from "../../store/tableStore";
 import { loadProject } from "../../store/flowStore";
 import { getStepLabel, clearJumpReferences } from "../../utils/actionUtils";
+import { validateActionGroup, hasBlockingErrors } from "../../utils/actionValidation";
+import type { ValidationError } from "../../utils/actionValidation";
 import { generateUUID } from "../../utils/uuid";
 import { mcpBridge } from "../../mcp/mcpBridge";
 import {
@@ -97,7 +98,14 @@ function StepInsertZone({ index, onClick, onPaste }: { index: number; onClick: (
 
 const ALL_STEP_TYPES: StepType[] = [
   "validation", "dbAccess", "externalSystem", "commonProcess",
-  "screenTransition", "displayUpdate", "branch", "jump", "other",
+  "screenTransition", "displayUpdate", "branch", "loop",
+  "loopBreak", "loopContinue", "jump", "other",
+];
+
+const ALL_SUB_STEP_TYPES: StepType[] = [
+  "validation", "dbAccess", "externalSystem", "commonProcess",
+  "screenTransition", "displayUpdate", "branch", "loop",
+  "loopBreak", "loopContinue", "jump", "other",
 ];
 
 const ALL_TRIGGERS: ActionTrigger[] = ["click", "submit", "select", "change", "load", "timer", "other"];
@@ -114,7 +122,9 @@ export function ActionEditor() {
   const [screens, setScreens] = useState<{ id: string; name: string }[]>([]);
   const [commonGroups, setCommonGroups] = useState<{ id: string; name: string }[]>([]);
   const [showTemplates, setShowTemplates] = useState(false);
-  const [contextMenu, setContextMenu] = useState<{ x: number; y: number; stepId: string; parentStepId?: string } | null>(null);
+  const [contextMenu, setContextMenu] = useState<{ x: number; y: number; stepId: string } | null>(null);
+  const [contextMenuSubTypePicker, setContextMenuSubTypePicker] = useState(false);
+  const [validationErrors, setValidationErrors] = useState<ValidationError[]>([]);
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const newStepIdsRef = useRef<Set<string>>(new Set());
 
@@ -126,8 +136,9 @@ export function ActionEditor() {
   } | null>(null);
   const lastSelectedIdRef = useRef<string | null>(null);
 
-  // 自動保存 (debounce 500ms)
+  // 自動保存 (debounce 500ms) — blocking error があれば保存しない
   const scheduleSave = useCallback((updatedGroup: ActionGroup) => {
+    if (hasBlockingErrors(validateActionGroup(updatedGroup))) return;
     if (saveTimer.current) clearTimeout(saveTimer.current);
     saveTimer.current = setTimeout(async () => {
       await saveActionGroup(updatedGroup);
@@ -195,6 +206,10 @@ export function ActionEditor() {
     });
     return unsub;
   }, [reload]);
+
+  useEffect(() => {
+    setValidationErrors(group ? validateActionGroup(group) : []);
+  }, [group]);
 
   /** 構造変化（履歴に積む）: ステップ追加・削除・移動、アクション追加・削除 */
   const updateGroup = useCallback(
@@ -273,19 +288,48 @@ export function ActionEditor() {
     setShowTemplates(false);
   };
 
-  const handleDeleteStep = (stepId: string, parentStepId?: string) => {
+  const closeContextMenu = useCallback(() => {
+    setContextMenu(null);
+    setContextMenuSubTypePicker(false);
+  }, []);
+
+  const handleDeleteStep = (stepId: string) => {
     updateGroup((g) => {
       const act = g.actions.find((a) => a.id === activeActionId);
       if (!act) return;
-      if (parentStepId) {
-        const parent = act.steps.find((s) => s.id === parentStepId);
-        if (parent) removeSubStep(parent, stepId);
-      } else {
-        clearJumpReferences(act.steps, stepId);
-        removeStep(act, stepId);
-      }
+      clearJumpReferences(act.steps, stepId);
+      removeStep(act, stepId);
     });
-    setContextMenu(null);
+    closeContextMenu();
+  };
+
+  const handleIndentStep = (stepId: string) => {
+    updateGroup((g) => {
+      const act = g.actions.find((a) => a.id === activeActionId);
+      if (!act) return;
+      const idx = act.steps.findIndex((s) => s.id === stepId);
+      if (idx <= 0) return;
+      const stepToMove = act.steps[idx];
+      const target = { ...act.steps[idx - 1] };
+      target.subSteps = [...(target.subSteps ?? []), stepToMove];
+      act.steps[idx - 1] = target;
+      act.steps.splice(idx, 1);
+    });
+  };
+
+  const handleOutdentSubStep = (parentStepId: string, subStepId: string) => {
+    updateGroup((g) => {
+      const act = g.actions.find((a) => a.id === activeActionId);
+      if (!act) return;
+      const parentIdx = act.steps.findIndex((s) => s.id === parentStepId);
+      if (parentIdx < 0) return;
+      const parent = act.steps[parentIdx];
+      const subIdx = (parent.subSteps ?? []).findIndex((s) => s.id === subStepId);
+      if (subIdx < 0) return;
+      const subStep = parent.subSteps![subIdx];
+      act.steps[parentIdx] = { ...parent, subSteps: parent.subSteps!.filter((s) => s.id !== subStepId) };
+      act.steps.splice(parentIdx + 1, 0, subStep);
+    });
   };
 
   const handleMoveStep = (fromIndex: number, toIndex: number) => {
@@ -332,7 +376,7 @@ export function ActionEditor() {
       const parent = act.steps.find((s) => s.id === parentStepId);
       if (parent) addSubStep(parent, type);
     });
-    setContextMenu(null);
+    closeContextMenu();
   };
 
   const handleDuplicateStep = (stepId: string) => {
@@ -348,7 +392,7 @@ export function ActionEditor() {
       }
       act.steps.splice(idx + 1, 0, clone);
     });
-    setContextMenu(null);
+    closeContextMenu();
   };
 
   const handleGroupInfoChange = (field: string, value: string) => {
@@ -452,7 +496,7 @@ export function ActionEditor() {
   if (!group) return null;
 
   return (
-    <div className="action-page" onClick={() => setContextMenu(null)}>
+    <div className="action-page" onClick={() => closeContextMenu()}>
       <TableTopbar projectName={projectName} />
 
       {/* ヘッダー */}
@@ -479,6 +523,18 @@ export function ActionEditor() {
           >
             <i className="bi bi-arrow-clockwise" />
           </button>
+          {validationErrors.filter((e) => e.severity === "error").length > 0 && (
+            <span className="validation-badge error">
+              <i className="bi bi-x-circle-fill" />
+              {validationErrors.filter((e) => e.severity === "error").length} エラー
+            </span>
+          )}
+          {validationErrors.filter((e) => e.severity === "warning").length > 0 && (
+            <span className="validation-badge warning">
+              <i className="bi bi-exclamation-triangle-fill" />
+              {validationErrors.filter((e) => e.severity === "warning").length} 警告
+            </span>
+          )}
         </div>
       </div>
 
@@ -652,7 +708,6 @@ export function ActionEditor() {
                           onDelete={() => handleDeleteStep(step.id)}
                           onDuplicate={() => handleDuplicateStep(step.id)}
                           onAddSubStep={(type) => handleAddSubStep(step.id, type)}
-                          onDeleteSubStep={(subId) => handleDeleteStep(subId, step.id)}
                           onContextMenu={(e) => {
                             e.preventDefault();
                             setContextMenu({ x: e.clientX, y: e.clientY, stepId: step.id });
@@ -661,6 +716,9 @@ export function ActionEditor() {
                           defaultExpanded={newStepIdsRef.current.has(step.id)}
                           selected={selectedIds.has(step.id)}
                           onHeaderClick={(e) => handleStepClick(step.id, e)}
+                          onIndent={index > 0 ? () => handleIndentStep(step.id) : undefined}
+                          onOutdentSubStep={(subId) => handleOutdentSubStep(step.id, subId)}
+                          validationErrors={validationErrors}
                         />
                       </div>
                     ))}
@@ -690,25 +748,49 @@ export function ActionEditor() {
           style={{ top: contextMenu.y, left: contextMenu.x }}
           onClick={(e) => e.stopPropagation()}
         >
-          <button
-            className="step-context-menu-item"
-            onClick={() => handleDuplicateStep(contextMenu.stepId)}
-          >
-            <i className="bi bi-copy" /> 複製
-          </button>
-          <button
-            className="step-context-menu-item"
-            onClick={() => handleAddSubStep(contextMenu.stepId, "other")}
-          >
-            <i className="bi bi-diagram-2" /> サブステップ追加
-          </button>
-          <div className="step-context-menu-sep" />
-          <button
-            className="step-context-menu-item danger"
-            onClick={() => handleDeleteStep(contextMenu.stepId)}
-          >
-            <i className="bi bi-trash" /> 削除
-          </button>
+          {!contextMenuSubTypePicker ? (
+            <>
+              <button
+                className="step-context-menu-item"
+                onClick={() => handleDuplicateStep(contextMenu.stepId)}
+              >
+                <i className="bi bi-copy" /> 複製
+              </button>
+              <button
+                className="step-context-menu-item"
+                onClick={() => setContextMenuSubTypePicker(true)}
+              >
+                <i className="bi bi-diagram-2" /> サブステップ追加 ▶
+              </button>
+              <div className="step-context-menu-sep" />
+              <button
+                className="step-context-menu-item danger"
+                onClick={() => handleDeleteStep(contextMenu.stepId)}
+              >
+                <i className="bi bi-trash" /> 削除
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                className="step-context-menu-item"
+                onClick={() => setContextMenuSubTypePicker(false)}
+              >
+                <i className="bi bi-arrow-left" /> 戻る
+              </button>
+              <div className="step-context-menu-sep" />
+              {ALL_SUB_STEP_TYPES.map((t) => (
+                <button
+                  key={t}
+                  className="step-context-menu-item"
+                  onClick={() => { handleAddSubStep(contextMenu.stepId, t); }}
+                >
+                  <i className={`bi ${STEP_TYPE_ICONS[t]}`} style={{ color: STEP_TYPE_COLORS[t] }} />
+                  {" "}{STEP_TYPE_LABELS[t]}
+                </button>
+              ))}
+            </>
+          )}
         </div>
       )}
 

--- a/designer/src/components/action/JumpTargetSelector.tsx
+++ b/designer/src/components/action/JumpTargetSelector.tsx
@@ -1,0 +1,168 @@
+import { useState, useRef, useEffect, useCallback } from "react";
+import type { Step } from "../../types/action";
+import { getJumpTargetOptions } from "../../utils/actionUtils";
+
+interface JumpTargetSelectorProps {
+  value: string;
+  allSteps: Step[];
+  excludeStepId: string;
+  onChange: (value: string) => void;
+  onBlur?: () => void;
+}
+
+export function JumpTargetSelector({
+  value,
+  allSteps,
+  excludeStepId,
+  onChange,
+  onBlur,
+}: JumpTargetSelectorProps) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const [activeIdx, setActiveIdx] = useState(-1);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const options = getJumpTargetOptions(allSteps, excludeStepId);
+  const filtered = search
+    ? options.filter(
+        (o) =>
+          o.label.toLowerCase().includes(search.toLowerCase()) ||
+          o.description.toLowerCase().includes(search.toLowerCase()),
+      )
+    : options;
+
+  const isResolved = !value || options.some((o) => o.id === value);
+  const matched = options.find((o) => o.id === value);
+  const displayValue = matched ? `${matched.label} ${matched.description}` : value;
+
+  const select = useCallback(
+    (id: string) => {
+      onChange(id);
+      setOpen(false);
+      setSearch("");
+      setActiveIdx(-1);
+    },
+    [onChange],
+  );
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (!open) {
+      if (e.key === "ArrowDown" || e.key === "Enter") {
+        setOpen(true);
+        setActiveIdx(0);
+        e.preventDefault();
+      }
+      return;
+    }
+    if (e.key === "ArrowDown") {
+      setActiveIdx((i) => Math.min(i + 1, filtered.length - 1));
+      e.preventDefault();
+    } else if (e.key === "ArrowUp") {
+      setActiveIdx((i) => Math.max(i - 1, 0));
+      e.preventDefault();
+    } else if (e.key === "Enter") {
+      if (activeIdx >= 0 && activeIdx < filtered.length) {
+        select(filtered[activeIdx].id);
+      } else if (search) {
+        onChange(search);
+        setOpen(false);
+        setSearch("");
+      }
+      e.preventDefault();
+    } else if (e.key === "Escape") {
+      setOpen(false);
+      setSearch("");
+      e.preventDefault();
+    }
+  };
+
+  useEffect(() => {
+    if (!open || activeIdx < 0 || !listRef.current) return;
+    const items = listRef.current.querySelectorAll<HTMLElement>(".jump-selector-option");
+    items[activeIdx]?.scrollIntoView({ block: "nearest" });
+  }, [activeIdx, open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handle = (e: MouseEvent) => {
+      if (!wrapRef.current?.contains(e.target as Node)) {
+        setOpen(false);
+        setSearch("");
+      }
+    };
+    document.addEventListener("mousedown", handle);
+    return () => document.removeEventListener("mousedown", handle);
+  }, [open]);
+
+  return (
+    <div className="jump-selector" ref={wrapRef}>
+      <div className={`jump-selector-input-wrap${!isResolved && value ? " unresolved" : ""}`}>
+        {!isResolved && value && (
+          <i className="bi bi-exclamation-triangle-fill jump-unresolved-icon" title="ジャンプ先が見つかりません" />
+        )}
+        <input
+          className="form-control form-control-sm"
+          value={open ? search : displayValue}
+          placeholder="ジャンプ先を検索または直接入力"
+          onChange={(e) => {
+            setSearch(e.target.value);
+            if (!open) setOpen(true);
+            setActiveIdx(0);
+          }}
+          onFocus={() => {
+            setOpen(true);
+            setSearch("");
+            setActiveIdx(0);
+          }}
+          onKeyDown={handleKeyDown}
+          onBlur={() => setTimeout(() => onBlur?.(), 150)}
+        />
+        {value && (
+          <button
+            className="jump-selector-clear"
+            onMouseDown={(e) => {
+              e.preventDefault();
+              onChange("");
+              setSearch("");
+            }}
+            title="クリア"
+          >
+            <i className="bi bi-x" />
+          </button>
+        )}
+      </div>
+      {open && (
+        <div className="jump-selector-dropdown" ref={listRef}>
+          {filtered.length === 0 ? (
+            search ? (
+              <div
+                className="jump-selector-option jump-selector-freetext"
+                onMouseDown={() => {
+                  onChange(search);
+                  setOpen(false);
+                  setSearch("");
+                }}
+              >
+                <i className="bi bi-pencil me-1" />「{search}」として設定
+              </div>
+            ) : (
+              <div className="jump-selector-option-empty">候補がありません</div>
+            )
+          ) : (
+            filtered.map((opt, i) => (
+              <div
+                key={opt.id}
+                className={`jump-selector-option${i === activeIdx ? " active" : ""}`}
+                onMouseDown={() => select(opt.id)}
+              >
+                <span className="jump-selector-option-label">{opt.label}</span>
+                <span className="jump-selector-option-desc">{opt.description}</span>
+              </div>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/designer/src/components/action/SortableStepCard.tsx
+++ b/designer/src/components/action/SortableStepCard.tsx
@@ -2,6 +2,7 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { StepCard } from "./StepCard";
 import type { Step, StepType } from "../../types/action";
+import type { ValidationError } from "../../utils/actionValidation";
 
 interface SortableStepCardProps {
   step: Step;
@@ -18,12 +19,14 @@ interface SortableStepCardProps {
   onDelete: () => void;
   onDuplicate: () => void;
   onAddSubStep: (type: StepType) => void;
-  onDeleteSubStep: (subStepId: string) => void;
   onContextMenu: (e: React.MouseEvent) => void;
   onNavigateCommon: (refId: string) => void;
   defaultExpanded?: boolean;
   selected?: boolean;
   onHeaderClick?: (e: React.MouseEvent) => void;
+  onIndent?: () => void;
+  onOutdentSubStep?: (subStepId: string) => void;
+  validationErrors?: ValidationError[];
 }
 
 export function SortableStepCard({ step, ...props }: SortableStepCardProps) {
@@ -49,6 +52,7 @@ export function SortableStepCard({ step, ...props }: SortableStepCardProps) {
         {...props}
         dragHandleListeners={listeners}
         dragHandleAttributes={attributes}
+        depth={0}
       />
     </div>
   );

--- a/designer/src/components/action/StepCard.tsx
+++ b/designer/src/components/action/StepCard.tsx
@@ -1,48 +1,33 @@
 import { useState, useRef, useEffect } from "react";
 import type { DraggableAttributes, DraggableSyntheticListeners } from "@dnd-kit/core";
-import type { Step, StepType, DbOperation } from "../../types/action";
+import type {
+  Branch,
+  Step,
+  StepType,
+  DbOperation,
+  LoopKind,
+  LoopConditionMode,
+} from "../../types/action";
 import {
   STEP_TYPE_LABELS,
   STEP_TYPE_ICONS,
   STEP_TYPE_COLORS,
   DB_OPERATION_LABELS,
 } from "../../types/action";
-import { getStepLabel, resolveJumpLabel, getJumpTargetOptions } from "../../utils/actionUtils";
+import { resolveJumpLabel } from "../../utils/actionUtils";
+import type { ValidationError } from "../../utils/actionValidation";
+import { generateUUID } from "../../utils/uuid";
+import { createDefaultStep } from "../../store/actionStore";
+import { JumpTargetSelector } from "./JumpTargetSelector";
 
-interface StepCardProps {
-  step: Step;
-  index: number;
-  label: string;
-  allSteps: Step[];
-  tables: { id: string; name: string; logicalName: string }[];
-  screens: { id: string; name: string }[];
-  commonGroups: { id: string; name: string }[];
-  onChange: (changes: Partial<Step>) => void;
-  /** Undo 履歴にスナップショットを積む（テキストフィールドの onBlur 時に呼ぶ） */
-  onCommit?: () => void;
-  onMoveUp?: () => void;
-  onMoveDown?: () => void;
-  onDelete: () => void;
-  onDuplicate: () => void;
-  onAddSubStep: (type: StepType) => void;
-  onDeleteSubStep: (subStepId: string) => void;
-  onContextMenu: (e: React.MouseEvent) => void;
-  onNavigateCommon: (refId: string) => void;
-  /** 新規追加ステップのデフォルト展開 */
-  defaultExpanded?: boolean;
-  /** D&D ドラッグハンドルの listeners（@dnd-kit 用） */
-  dragHandleListeners?: DraggableSyntheticListeners;
-  /** D&D ドラッグハンドルの attributes（@dnd-kit 用） */
-  dragHandleAttributes?: DraggableAttributes;
-  /** 選択状態 */
-  selected?: boolean;
-  /** ヘッダークリック（Ctrl/Shift選択用） */
-  onHeaderClick?: (e: React.MouseEvent) => void;
-}
+const ALL_SUB_STEP_TYPES: StepType[] = [
+  "validation", "dbAccess", "externalSystem", "commonProcess",
+  "screenTransition", "displayUpdate", "branch", "loop",
+  "loopBreak", "loopContinue", "jump", "other",
+];
 
-const DB_OPS: DbOperation[] = ["SELECT", "INSERT", "UPDATE", "DELETE"];
+// ─── ヘルパーコンポーネント ──────────────────────────────────────────────────
 
-/** 内容に応じて自動伸縮する textarea */
 function AutoResizeTextarea({
   value, onChange, onBlur, placeholder, className,
 }: {
@@ -72,6 +57,152 @@ function AutoResizeTextarea({
   );
 }
 
+// ─── インラインステップリスト ─────────────────────────────────────────────────
+// branch.steps / loop.steps の再帰レンダリング用。
+// function 宣言（ホイスティング）で定義することで StepCard との相互参照を実現。
+
+interface InlineStepListProps {
+  steps: Step[];
+  parentLabel: string;
+  allSteps: Step[];
+  tables: { id: string; name: string; logicalName: string }[];
+  screens: { id: string; name: string }[];
+  commonGroups: { id: string; name: string }[];
+  onChange: (steps: Step[]) => void;
+  onCommit?: () => void;
+  onNavigateCommon: (refId: string) => void;
+  validationErrors?: ValidationError[];
+}
+
+function InlineStepList({
+  steps,
+  parentLabel,
+  allSteps,
+  tables,
+  screens,
+  commonGroups,
+  onChange,
+  onCommit,
+  onNavigateCommon,
+  validationErrors,
+}: InlineStepListProps) {
+  const [showTypePicker, setShowTypePicker] = useState(false);
+
+  const addStep = (type: StepType) => {
+    const newStep = createDefaultStep(type);
+    onChange([...steps, newStep]);
+    onCommit?.();
+    setShowTypePicker(false);
+  };
+
+  return (
+    <div className="inline-step-list">
+      {steps.map((step, si) => (
+        <div key={step.id} className="mb-1">
+          <StepCard
+            step={step}
+            index={si}
+            label={`${parentLabel}-${si + 1}`}
+            allSteps={allSteps}
+            tables={tables}
+            screens={screens}
+            commonGroups={commonGroups}
+            onChange={(changes) => {
+              const arr = steps.slice();
+              arr[si] = { ...arr[si], ...changes } as Step;
+              onChange(arr);
+            }}
+            onCommit={onCommit}
+            onMoveUp={si > 0 ? () => {
+              const arr = steps.slice();
+              [arr[si - 1], arr[si]] = [arr[si], arr[si - 1]];
+              onChange(arr);
+              onCommit?.();
+            } : undefined}
+            onMoveDown={si < steps.length - 1 ? () => {
+              const arr = steps.slice();
+              [arr[si], arr[si + 1]] = [arr[si + 1], arr[si]];
+              onChange(arr);
+              onCommit?.();
+            } : undefined}
+            onDelete={() => {
+              onChange(steps.filter((s) => s.id !== step.id));
+              onCommit?.();
+            }}
+            onDuplicate={() => {
+              const clone = JSON.parse(JSON.stringify(step)) as Step;
+              clone.id = generateUUID();
+              const arr = steps.slice();
+              arr.splice(si + 1, 0, clone);
+              onChange(arr);
+              onCommit?.();
+            }}
+            onAddSubStep={(type) => {
+              const newSub = createDefaultStep(type);
+              const arr = steps.slice();
+              arr[si] = { ...arr[si], subSteps: [...(arr[si].subSteps ?? []), newSub] } as Step;
+              onChange(arr);
+              onCommit?.();
+            }}
+            onContextMenu={(e) => e.preventDefault()}
+            onNavigateCommon={onNavigateCommon}
+            depth={1}
+            validationErrors={validationErrors}
+          />
+        </div>
+      ))}
+      <div className="inline-step-add">
+        <button className="inline-add-btn" onClick={() => setShowTypePicker(!showTypePicker)}>
+          <i className="bi bi-plus" /> ステップを追加
+        </button>
+        {showTypePicker && (
+          <div className="inline-type-picker">
+            {ALL_SUB_STEP_TYPES.map((t) => (
+              <button key={t} className="inline-type-btn" onClick={() => addStep(t)}>
+                <i className={`bi ${STEP_TYPE_ICONS[t]}`} style={{ color: STEP_TYPE_COLORS[t] }} />
+                {STEP_TYPE_LABELS[t]}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── StepCard ────────────────────────────────────────────────────────────────
+
+interface StepCardProps {
+  step: Step;
+  index: number;
+  label: string;
+  allSteps: Step[];
+  tables: { id: string; name: string; logicalName: string }[];
+  screens: { id: string; name: string }[];
+  commonGroups: { id: string; name: string }[];
+  onChange: (changes: Partial<Step>) => void;
+  onCommit?: () => void;
+  onMoveUp?: () => void;
+  onMoveDown?: () => void;
+  onDelete: () => void;
+  onDuplicate: () => void;
+  onAddSubStep: (type: StepType) => void;
+  onContextMenu: (e: React.MouseEvent) => void;
+  onNavigateCommon: (refId: string) => void;
+  defaultExpanded?: boolean;
+  dragHandleListeners?: DraggableSyntheticListeners;
+  dragHandleAttributes?: DraggableAttributes;
+  selected?: boolean;
+  onHeaderClick?: (e: React.MouseEvent) => void;
+  onIndent?: () => void;
+  onOutdent?: () => void;
+  onOutdentSubStep?: (subStepId: string) => void;
+  depth?: number;
+  validationErrors?: ValidationError[];
+}
+
+const DB_OPS: DbOperation[] = ["SELECT", "INSERT", "UPDATE", "DELETE"];
+
 export function StepCard({
   step,
   index,
@@ -87,7 +218,6 @@ export function StepCard({
   onDelete,
   onDuplicate,
   onAddSubStep,
-  onDeleteSubStep,
   onContextMenu,
   onNavigateCommon,
   defaultExpanded,
@@ -95,11 +225,23 @@ export function StepCard({
   dragHandleAttributes,
   selected,
   onHeaderClick,
+  onIndent,
+  onOutdent,
+  onOutdentSubStep,
+  depth = 0,
+  validationErrors = [],
 }: StepCardProps) {
   const [expanded, setExpanded] = useState(defaultExpanded ?? false);
   const [showMenu, setShowMenu] = useState(false);
+  const [showSubTypePicker, setShowSubTypePicker] = useState(false);
+  const [collapsedBranchIds, setCollapsedBranchIds] = useState<Set<string>>(new Set());
+  const [loopBodyCollapsed, setLoopBodyCollapsed] = useState(false);
 
   const color = STEP_TYPE_COLORS[step.type];
+  const subSteps = step.subSteps ?? [];
+  const myErrors = validationErrors.filter((e) => e.stepId === step.id);
+  const hasError = myErrors.some((e) => e.severity === "error");
+  const hasWarning = myErrors.some((e) => e.severity === "warning");
 
   const summaryText = (): string => {
     switch (step.type) {
@@ -116,7 +258,15 @@ export function StepCard({
       case "displayUpdate":
         return step.target || step.description || "表示更新";
       case "branch":
-        return step.condition || step.description || "条件分岐";
+        return step.description || step.branches[0]?.condition || "条件分岐";
+      case "loop":
+        if (step.loopKind === "count") return step.countExpression || step.description || "ループ";
+        if (step.loopKind === "condition") return step.conditionExpression || step.description || "ループ";
+        return `${step.collectionSource || "コレクション"}${step.collectionItemName ? ` [${step.collectionItemName}]` : ""}`;
+      case "loopBreak":
+        return step.description || "ループ終了";
+      case "loopContinue":
+        return step.description || "次のループへ";
       case "jump": {
         const jumpLabel = resolveJumpLabel(step.jumpTo, allSteps);
         return `[${jumpLabel}] へ${step.description ? ` - ${step.description}` : ""}`;
@@ -126,32 +276,135 @@ export function StepCard({
     }
   };
 
+  // ── サブステップ管理 ────────────────────────────────────────────────────────
+
+  const handleSubAddSubStep = (parentSubIdx: number, type: StepType) => {
+    const newSub = createDefaultStep(type);
+    const arr = subSteps.slice();
+    arr[parentSubIdx] = {
+      ...arr[parentSubIdx],
+      subSteps: [...(arr[parentSubIdx].subSteps ?? []), newSub],
+    };
+    onChange({ subSteps: arr });
+    onCommit?.();
+  };
+
+  const handleOutdentFromSubSteps = (parentSubId: string, stepToOutdentId: string) => {
+    const arr = subSteps.slice();
+    const parentIdx = arr.findIndex((s) => s.id === parentSubId);
+    if (parentIdx < 0) return;
+    const parent = { ...arr[parentIdx] };
+    const outIdx = (parent.subSteps ?? []).findIndex((s) => s.id === stepToOutdentId);
+    if (outIdx < 0) return;
+    const outStep = parent.subSteps![outIdx];
+    parent.subSteps = parent.subSteps!.filter((s) => s.id !== stepToOutdentId);
+    arr[parentIdx] = parent;
+    arr.splice(parentIdx + 1, 0, outStep);
+    onChange({ subSteps: arr });
+    onCommit?.();
+  };
+
+  // ── 分岐管理 (Phase 3) ──────────────────────────────────────────────────────
+
+  const toggleBranchCollapse = (branchId: string) => {
+    setCollapsedBranchIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(branchId)) next.delete(branchId);
+      else next.add(branchId);
+      return next;
+    });
+  };
+
+  const setBranchAt = (idx: number, next: Branch) => {
+    if (step.type !== "branch") return;
+    const branches = step.branches.slice();
+    branches[idx] = next;
+    onChange({ branches } as Partial<Step>);
+  };
+
+  const moveBranchUp = (idx: number) => {
+    if (step.type !== "branch" || idx <= 0) return;
+    const branches = step.branches.map((b) => ({ ...b }));
+    [branches[idx - 1], branches[idx]] = [branches[idx], branches[idx - 1]];
+    branches.forEach((b, i) => { b.code = String.fromCharCode(65 + i); });
+    onChange({ branches } as Partial<Step>);
+    onCommit?.();
+  };
+
+  const moveBranchDown = (idx: number) => {
+    if (step.type !== "branch") return;
+    const branches = step.branches.map((b) => ({ ...b }));
+    if (idx >= branches.length - 1) return;
+    [branches[idx], branches[idx + 1]] = [branches[idx + 1], branches[idx]];
+    branches.forEach((b, i) => { b.code = String.fromCharCode(65 + i); });
+    onChange({ branches } as Partial<Step>);
+    onCommit?.();
+  };
+
+  const deleteBranch = (idx: number) => {
+    if (step.type !== "branch" || step.branches.length <= 1) return;
+    const branches = step.branches.filter((_, i) => i !== idx).map((b, i) => ({
+      ...b,
+      code: String.fromCharCode(65 + i),
+    }));
+    onChange({ branches } as Partial<Step>);
+    onCommit?.();
+  };
+
+  const addBranch = () => {
+    if (step.type !== "branch") return;
+    const code = String.fromCharCode(65 + step.branches.length);
+    const newBranch: Branch = { id: generateUUID(), code, condition: "", steps: [] };
+    onChange({ branches: [...step.branches, newBranch] } as Partial<Step>);
+    onCommit?.();
+  };
+
+  const addElseBranch = () => {
+    if (step.type !== "branch") return;
+    const elseBranch: Branch = { id: generateUUID(), code: "ELSE", condition: "", steps: [] };
+    onChange({ elseBranch } as Partial<Step>);
+    onCommit?.();
+  };
+
+  // ────────────────────────────────────────────────────────────────────────────
+
+  const cardClass = [
+    "step-card",
+    selected ? "selected" : "",
+    hasError ? "has-error" : "",
+    hasWarning && !hasError ? "has-warning" : "",
+  ].filter(Boolean).join(" ");
+
   return (
     <div>
       <div
-        className={`step-card${selected ? " selected" : ""}`}
+        className={cardClass}
         style={{ borderLeftColor: color }}
         onContextMenu={onContextMenu}
       >
-        <div className="step-card-header" onClick={(e) => {
-          // ドラッグハンドルからのクリックは無視
-          if ((e.target as HTMLElement).closest("[data-drag-handle]")) return;
-          if ((e.ctrlKey || e.metaKey || e.shiftKey) && onHeaderClick) {
-            onHeaderClick(e);
-          } else {
-            if (onHeaderClick) onHeaderClick(e); // clear selection on normal click
-            setExpanded(!expanded);
-          }
-        }}>
-          <span
-            className="step-card-drag-handle"
-            title="ドラッグで移動"
-            data-drag-handle
-            {...dragHandleAttributes}
-            {...dragHandleListeners}
-          >
-            <i className="bi bi-grip-vertical" />
-          </span>
+        <div
+          className="step-card-header"
+          onClick={(e) => {
+            if ((e.target as HTMLElement).closest("[data-drag-handle]")) return;
+            if ((e.ctrlKey || e.metaKey || e.shiftKey) && onHeaderClick) {
+              onHeaderClick(e);
+            } else {
+              if (onHeaderClick) onHeaderClick(e);
+              setExpanded(!expanded);
+            }
+          }}
+        >
+          {(dragHandleListeners || dragHandleAttributes) && (
+            <span
+              className="step-card-drag-handle"
+              title="ドラッグで移動"
+              data-drag-handle
+              {...dragHandleAttributes}
+              {...dragHandleListeners}
+            >
+              <i className="bi bi-grip-vertical" />
+            </span>
+          )}
           <span className="step-card-number">{label}</span>
           <i className={`step-card-icon ${STEP_TYPE_ICONS[step.type]}`} style={{ color }} />
           <span className="step-card-type-label">{STEP_TYPE_LABELS[step.type]}</span>
@@ -166,6 +419,16 @@ export function StepCard({
             </button>
           )}
           <div className="d-flex gap-1 ms-auto" style={{ flexShrink: 0 }}>
+            {onOutdent && (
+              <button className="step-card-menu-btn" onClick={(e) => { e.stopPropagation(); onOutdent(); }} title="上位レベルに移動（アウトデント）">
+                <i className="bi bi-chevron-left" />
+              </button>
+            )}
+            {onIndent && (
+              <button className="step-card-menu-btn" onClick={(e) => { e.stopPropagation(); onIndent(); }} title="前のステップのサブステップに移動（インデント）">
+                <i className="bi bi-chevron-right" />
+              </button>
+            )}
             {onMoveUp && (
               <button className="step-card-menu-btn" onClick={(e) => { e.stopPropagation(); onMoveUp(); }} title="上に移動">
                 <i className="bi bi-chevron-up" />
@@ -179,7 +442,7 @@ export function StepCard({
             <div style={{ position: "relative" }}>
               <button
                 className="step-card-menu-btn"
-                onClick={(e) => { e.stopPropagation(); setShowMenu(!showMenu); }}
+                onClick={(e) => { e.stopPropagation(); setShowMenu(!showMenu); setShowSubTypePicker(false); }}
               >
                 <i className="bi bi-three-dots" />
               </button>
@@ -189,21 +452,50 @@ export function StepCard({
                   style={{ top: "100%", right: 0, position: "absolute" }}
                   onClick={(e) => e.stopPropagation()}
                 >
-                  <button className="step-context-menu-item" onClick={() => { onDuplicate(); setShowMenu(false); }}>
-                    <i className="bi bi-copy" /> 複製
-                  </button>
-                  <button className="step-context-menu-item" onClick={() => { onAddSubStep("other"); setShowMenu(false); }}>
-                    <i className="bi bi-diagram-2" /> サブステップ追加
-                  </button>
-                  <div className="step-context-menu-sep" />
-                  <button className="step-context-menu-item danger" onClick={() => { onDelete(); setShowMenu(false); }}>
-                    <i className="bi bi-trash" /> 削除
-                  </button>
+                  {!showSubTypePicker ? (
+                    <>
+                      <button className="step-context-menu-item" onClick={() => { onDuplicate(); setShowMenu(false); }}>
+                        <i className="bi bi-copy" /> 複製
+                      </button>
+                      <button className="step-context-menu-item" onClick={() => setShowSubTypePicker(true)}>
+                        <i className="bi bi-diagram-2" /> サブステップ追加 ▶
+                      </button>
+                      <div className="step-context-menu-sep" />
+                      <button className="step-context-menu-item danger" onClick={() => { onDelete(); setShowMenu(false); }}>
+                        <i className="bi bi-trash" /> 削除
+                      </button>
+                    </>
+                  ) : (
+                    <>
+                      <button className="step-context-menu-item" onClick={() => setShowSubTypePicker(false)}>
+                        <i className="bi bi-arrow-left" /> 戻る
+                      </button>
+                      <div className="step-context-menu-sep" />
+                      {ALL_SUB_STEP_TYPES.map((t) => (
+                        <button
+                          key={t}
+                          className="step-context-menu-item"
+                          onClick={() => { onAddSubStep(t); setShowMenu(false); setShowSubTypePicker(false); }}
+                        >
+                          <i className={`bi ${STEP_TYPE_ICONS[t]}`} style={{ color: STEP_TYPE_COLORS[t] }} />
+                          {" "}{STEP_TYPE_LABELS[t]}
+                        </button>
+                      ))}
+                    </>
+                  )}
                 </div>
               )}
             </div>
           </div>
         </div>
+
+        {/* バリデーションメッセージ */}
+        {myErrors.map((e, i) => (
+          <div key={i} className={`step-validation-msg ${e.severity}`}>
+            <i className={`bi ${e.severity === "error" ? "bi-x-circle-fill" : "bi-exclamation-triangle-fill"}`} />
+            {e.message}
+          </div>
+        ))}
 
         {/* 展開時: 編集フォーム */}
         {expanded && (
@@ -220,7 +512,7 @@ export function StepCard({
               </div>
             </div>
 
-            {/* 種別ごとの編集フィールド */}
+            {/* ── バリデーション ───────────────────────────────── */}
             {step.type === "validation" && (
               <>
                 <div className="row g-2 mb-2">
@@ -266,6 +558,7 @@ export function StepCard({
               </>
             )}
 
+            {/* ── DB操作 ──────────────────────────────────────── */}
             {step.type === "dbAccess" && (
               <>
                 <div className="form-group">
@@ -311,6 +604,7 @@ export function StepCard({
               </>
             )}
 
+            {/* ── 外部システム ─────────────────────────────────── */}
             {step.type === "externalSystem" && (
               <div className="form-row-pair">
                 <div className="form-group">
@@ -336,6 +630,7 @@ export function StepCard({
               </div>
             )}
 
+            {/* ── 共通処理 ─────────────────────────────────────── */}
             {step.type === "commonProcess" && (
               <div className="row g-2 mb-2">
                 <div className="col-12">
@@ -357,6 +652,7 @@ export function StepCard({
               </div>
             )}
 
+            {/* ── 画面遷移 ─────────────────────────────────────── */}
             {step.type === "screenTransition" && (
               <div className="row g-2 mb-2">
                 <div className="col-12">
@@ -385,6 +681,7 @@ export function StepCard({
               </div>
             )}
 
+            {/* ── 表示更新 ─────────────────────────────────────── */}
             {step.type === "displayUpdate" && (
               <div className="row g-2 mb-2">
                 <div className="col-12">
@@ -400,70 +697,279 @@ export function StepCard({
               </div>
             )}
 
+            {/* ── 条件分岐 (Phase 3) ───────────────────────────── */}
             {step.type === "branch" && (
-              <>
-                <div className="row g-2 mb-2">
-                  <div className="col-12">
-                    <label className="form-label">分岐条件</label>
-                    <input
-                      className="form-control form-control-sm"
-                      value={step.condition}
-                      onChange={(e) => onChange({ condition: e.target.value } as Partial<Step>)}
-                      onBlur={onCommit}
-                      placeholder="条件式"
-                    />
-                  </div>
-                </div>
-                <div className="step-inline-branch">
-                  <div className="step-branch-box ok">
-                    <div className="step-branch-label">A: {step.branchA.label}</div>
-                    <input
-                      className="form-control form-control-sm"
-                      value={step.branchA.description}
-                      onChange={(e) =>
-                        onChange({ branchA: { ...step.branchA, description: e.target.value } } as Partial<Step>)
-                      }
-                      placeholder="A分岐の処理"
-                      onBlur={onCommit}
-                    />
-                  </div>
-                  <div className="step-branch-box ng">
-                    <div className="step-branch-label">B: {step.branchB.label}</div>
-                    <input
-                      className="form-control form-control-sm"
-                      value={step.branchB.description}
-                      onChange={(e) =>
-                        onChange({ branchB: { ...step.branchB, description: e.target.value } } as Partial<Step>)
-                      }
-                      placeholder="B分岐の処理"
-                      onBlur={onCommit}
-                    />
-                  </div>
-                </div>
-              </>
-            )}
+              <div className="branch-sections">
+                {step.branches.map((br, bi) => {
+                  const isCollapsed = collapsedBranchIds.has(br.id);
+                  return (
+                    <div key={br.id} className={`branch-section${isCollapsed ? " collapsed" : ""}`}>
+                      <div
+                        className="branch-section-header"
+                        onClick={() => toggleBranchCollapse(br.id)}
+                      >
+                        <span className="branch-code-badge">{br.code}</span>
+                        <input
+                          className="form-control form-control-sm branch-condition-input"
+                          value={br.condition}
+                          placeholder="分岐条件"
+                          onClick={(e) => e.stopPropagation()}
+                          onChange={(e) => setBranchAt(bi, { ...br, condition: e.target.value })}
+                          onBlur={onCommit}
+                        />
+                        {bi > 0 && (
+                          <button
+                            className="step-card-menu-btn"
+                            title="上に移動"
+                            onClick={(e) => { e.stopPropagation(); moveBranchUp(bi); }}
+                          >
+                            <i className="bi bi-chevron-up" />
+                          </button>
+                        )}
+                        {bi < step.branches.length - 1 && (
+                          <button
+                            className="step-card-menu-btn"
+                            title="下に移動"
+                            onClick={(e) => { e.stopPropagation(); moveBranchDown(bi); }}
+                          >
+                            <i className="bi bi-chevron-down" />
+                          </button>
+                        )}
+                        {step.branches.length > 1 && (
+                          <button
+                            className="step-card-menu-btn danger"
+                            title="分岐を削除"
+                            onClick={(e) => { e.stopPropagation(); deleteBranch(bi); }}
+                          >
+                            <i className="bi bi-trash" />
+                          </button>
+                        )}
+                        <i
+                          className={`bi bi-chevron-${isCollapsed ? "right" : "down"}`}
+                          style={{ color: "#94a3b8", flexShrink: 0 }}
+                        />
+                      </div>
+                      {!isCollapsed && (
+                        <div className="branch-section-body">
+                          <InlineStepList
+                            steps={br.steps}
+                            parentLabel={br.code}
+                            allSteps={allSteps}
+                            tables={tables}
+                            screens={screens}
+                            commonGroups={commonGroups}
+                            onChange={(newSteps) => setBranchAt(bi, { ...br, steps: newSteps })}
+                            onCommit={onCommit}
+                            onNavigateCommon={onNavigateCommon}
+                            validationErrors={validationErrors}
+                          />
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
 
-            {step.type === "jump" && (
-              <div className="row g-2 mb-2">
-                <div className="col-12">
-                  <label className="form-label">ジャンプ先</label>
-                  <select
-                    className="form-select form-select-sm"
-                    value={step.jumpTo}
-                    onChange={(e) => onChange({ jumpTo: e.target.value } as Partial<Step>)}
-                  >
-                    <option value="">（選択）</option>
-                    {getJumpTargetOptions(allSteps, step.id).map((opt) => (
-                      <option key={opt.id} value={opt.id}>
-                        {opt.label} {opt.description}
-                      </option>
-                    ))}
-                  </select>
+                {/* ELSE分岐 */}
+                {step.elseBranch && (() => {
+                  const el = step.elseBranch;
+                  const isCollapsed = collapsedBranchIds.has(el.id);
+                  return (
+                    <div className={`branch-section else${isCollapsed ? " collapsed" : ""}`}>
+                      <div
+                        className="branch-section-header"
+                        onClick={() => toggleBranchCollapse(el.id)}
+                      >
+                        <span className="branch-code-badge">ELSE</span>
+                        <span style={{ flex: 1, fontSize: "0.78rem", color: "#64748b" }}>
+                          その他の場合
+                        </span>
+                        <button
+                          className="step-card-menu-btn danger"
+                          title="ELSE分岐を削除"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onChange({ elseBranch: undefined } as Partial<Step>);
+                            onCommit?.();
+                          }}
+                        >
+                          <i className="bi bi-trash" />
+                        </button>
+                        <i
+                          className={`bi bi-chevron-${isCollapsed ? "right" : "down"}`}
+                          style={{ color: "#94a3b8", flexShrink: 0 }}
+                        />
+                      </div>
+                      {!isCollapsed && (
+                        <div className="branch-section-body">
+                          <InlineStepList
+                            steps={el.steps}
+                            parentLabel="ELSE"
+                            allSteps={allSteps}
+                            tables={tables}
+                            screens={screens}
+                            commonGroups={commonGroups}
+                            onChange={(newSteps) =>
+                              onChange({ elseBranch: { ...el, steps: newSteps } } as Partial<Step>)
+                            }
+                            onCommit={onCommit}
+                            onNavigateCommon={onNavigateCommon}
+                            validationErrors={validationErrors}
+                          />
+                        </div>
+                      )}
+                    </div>
+                  );
+                })()}
+
+                <div className="branch-add-row">
+                  <button className="branch-add-btn" onClick={addBranch}>
+                    <i className="bi bi-plus" /> 分岐を追加
+                  </button>
+                  {!step.elseBranch && (
+                    <button className="branch-add-btn" onClick={addElseBranch} style={{ flex: "0 0 auto" }}>
+                      <i className="bi bi-plus" /> ELSE分岐
+                    </button>
+                  )}
                 </div>
               </div>
             )}
 
-            {/* メモ */}
+            {/* ── ループ (Phase 4) ─────────────────────────────── */}
+            {step.type === "loop" && (
+              <div>
+                <div className="loop-kind-radios">
+                  {(["count", "condition", "collection"] as LoopKind[]).map((k) => (
+                    <label key={k}>
+                      <input
+                        type="radio"
+                        name={`loopkind-${step.id}`}
+                        value={k}
+                        checked={step.loopKind === k}
+                        onChange={() => onChange({ loopKind: k } as Partial<Step>)}
+                      />
+                      {k === "count" ? "回数" : k === "condition" ? "条件" : "コレクション"}
+                    </label>
+                  ))}
+                </div>
+
+                {step.loopKind === "count" && (
+                  <div className="form-group">
+                    <label className="form-label">回数 / 範囲</label>
+                    <input
+                      className="form-control form-control-sm"
+                      value={step.countExpression ?? ""}
+                      onChange={(e) => onChange({ countExpression: e.target.value } as Partial<Step>)}
+                      onBlur={onCommit}
+                      placeholder="例: 3回, 検索結果の件数分"
+                    />
+                  </div>
+                )}
+
+                {step.loopKind === "condition" && (
+                  <>
+                    <div className="form-group mb-2">
+                      <label className="form-label">条件モード</label>
+                      <div className="d-flex gap-3 flex-wrap">
+                        {(["continue", "exit"] as LoopConditionMode[]).map((m) => (
+                          <label key={m} style={{ display: "flex", alignItems: "center", gap: 4, fontSize: "0.82rem", cursor: "pointer" }}>
+                            <input
+                              type="radio"
+                              name={`condmode-${step.id}`}
+                              value={m}
+                              checked={(step.conditionMode ?? "exit") === m}
+                              onChange={() => onChange({ conditionMode: m } as Partial<Step>)}
+                            />
+                            {m === "continue" ? "条件の間繰り返す (while)" : "条件になるまで繰り返す (until)"}
+                          </label>
+                        ))}
+                      </div>
+                    </div>
+                    <div className="form-group">
+                      <label className="form-label">条件式</label>
+                      <input
+                        className="form-control form-control-sm"
+                        value={step.conditionExpression ?? ""}
+                        onChange={(e) => onChange({ conditionExpression: e.target.value } as Partial<Step>)}
+                        onBlur={onCommit}
+                        placeholder="例: 残件数 > 0"
+                      />
+                    </div>
+                  </>
+                )}
+
+                {step.loopKind === "collection" && (
+                  <div className="form-row-pair">
+                    <div className="form-group">
+                      <label className="form-label">コレクション</label>
+                      <input
+                        className="form-control form-control-sm"
+                        value={step.collectionSource ?? ""}
+                        onChange={(e) => onChange({ collectionSource: e.target.value } as Partial<Step>)}
+                        onBlur={onCommit}
+                        placeholder="例: 検索結果"
+                      />
+                    </div>
+                    <div className="form-group">
+                      <label className="form-label">要素変数名</label>
+                      <input
+                        className="form-control form-control-sm"
+                        value={step.collectionItemName ?? ""}
+                        onChange={(e) => onChange({ collectionItemName: e.target.value } as Partial<Step>)}
+                        onBlur={onCommit}
+                        placeholder="例: ユーザー"
+                      />
+                    </div>
+                  </div>
+                )}
+
+                <div className={`loop-body${loopBodyCollapsed ? " collapsed" : ""}`}>
+                  <div
+                    className="loop-body-header"
+                    onClick={() => setLoopBodyCollapsed(!loopBodyCollapsed)}
+                  >
+                    <i className="bi bi-arrow-repeat" />
+                    ループ本体
+                    <i
+                      className={`bi bi-chevron-${loopBodyCollapsed ? "right" : "down"} ms-auto`}
+                      style={{ color: "#94a3b8" }}
+                    />
+                  </div>
+                  {!loopBodyCollapsed && (
+                    <div className="loop-body-content">
+                      <InlineStepList
+                        steps={step.steps}
+                        parentLabel="L"
+                        allSteps={allSteps}
+                        tables={tables}
+                        screens={screens}
+                        commonGroups={commonGroups}
+                        onChange={(newSteps) => onChange({ steps: newSteps } as Partial<Step>)}
+                        onCommit={onCommit}
+                        onNavigateCommon={onNavigateCommon}
+                        validationErrors={validationErrors}
+                      />
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* ── ジャンプ (Phase 5) ───────────────────────────── */}
+            {step.type === "jump" && (
+              <div className="row g-2 mb-2">
+                <div className="col-12">
+                  <label className="form-label">ジャンプ先</label>
+                  <JumpTargetSelector
+                    value={step.jumpTo}
+                    allSteps={allSteps}
+                    excludeStepId={step.id}
+                    onChange={(val) => onChange({ jumpTo: val } as Partial<Step>)}
+                    onBlur={onCommit}
+                  />
+                </div>
+              </div>
+            )}
+
             <div className="row g-2">
               <div className="col-12">
                 <label className="form-label">メモ</label>
@@ -479,29 +985,60 @@ export function StepCard({
         )}
       </div>
 
-      {/* サブステップ */}
-      {step.subSteps && step.subSteps.length > 0 && (
+      {/* サブステップ（再帰レンダリング） */}
+      {subSteps.length > 0 && (
         <div className="sub-steps">
-          {step.subSteps.map((sub, si) => (
+          {subSteps.map((sub, si) => (
             <div key={sub.id} className="mb-1">
-              <div
-                className="step-card"
-                style={{ borderLeftColor: STEP_TYPE_COLORS[sub.type] }}
-              >
-                <div className="step-card-header">
-                  <span className="step-card-number">{getStepLabel(index, si)}</span>
-                  <i className={`step-card-icon ${STEP_TYPE_ICONS[sub.type]}`} style={{ color: STEP_TYPE_COLORS[sub.type] }} />
-                  <span className="step-card-type-label">{STEP_TYPE_LABELS[sub.type]}</span>
-                  <span className="step-card-description">{sub.description || sub.type}</span>
-                  <button
-                    className="step-card-menu-btn ms-auto"
-                    onClick={() => onDeleteSubStep(sub.id)}
-                    title="サブステップ削除"
-                  >
-                    <i className="bi bi-x-lg" />
-                  </button>
-                </div>
-              </div>
+              <StepCard
+                step={sub}
+                index={si}
+                label={`${index + 1}-${si + 1}`}
+                allSteps={allSteps}
+                tables={tables}
+                screens={screens}
+                commonGroups={commonGroups}
+                onChange={(changes) => {
+                  const arr = subSteps.slice();
+                  const idx = arr.findIndex((s) => s.id === sub.id);
+                  if (idx >= 0) {
+                    arr[idx] = { ...arr[idx], ...changes } as Step;
+                    onChange({ subSteps: arr });
+                  }
+                }}
+                onCommit={onCommit}
+                onMoveUp={si > 0 ? () => {
+                  const arr = subSteps.slice();
+                  [arr[si - 1], arr[si]] = [arr[si], arr[si - 1]];
+                  onChange({ subSteps: arr });
+                  onCommit?.();
+                } : undefined}
+                onMoveDown={si < subSteps.length - 1 ? () => {
+                  const arr = subSteps.slice();
+                  [arr[si], arr[si + 1]] = [arr[si + 1], arr[si]];
+                  onChange({ subSteps: arr });
+                  onCommit?.();
+                } : undefined}
+                onDelete={() => {
+                  onChange({ subSteps: subSteps.filter((s) => s.id !== sub.id) });
+                  onCommit?.();
+                }}
+                onDuplicate={() => {
+                  const clone = JSON.parse(JSON.stringify(sub)) as Step;
+                  clone.id = generateUUID();
+                  const arr = subSteps.slice();
+                  arr.splice(si + 1, 0, clone);
+                  onChange({ subSteps: arr });
+                  onCommit?.();
+                }}
+                onAddSubStep={(type) => handleSubAddSubStep(si, type)}
+                onContextMenu={(e) => e.preventDefault()}
+                onNavigateCommon={onNavigateCommon}
+                depth={depth + 1}
+                onOutdent={onOutdentSubStep ? () => onOutdentSubStep(sub.id) : undefined}
+                onOutdentSubStep={(subSubId) => handleOutdentFromSubSteps(sub.id, subSubId)}
+                validationErrors={validationErrors}
+              />
             </div>
           ))}
         </div>

--- a/designer/src/store/actionStore.ts
+++ b/designer/src/store/actionStore.ts
@@ -17,6 +17,7 @@ import type {
 import type { FlowProject } from "../types/flow";
 import { loadProject, saveProject } from "./flowStore";
 import { generateUUID } from "../utils/uuid";
+import { migrateActionGroup } from "../utils/actionMigration";
 
 // ─── ストレージバックエンド ──────────────────────────────────────────────
 
@@ -49,16 +50,16 @@ export async function listActionGroups(): Promise<ActionGroupMeta[]> {
   return (project.actionGroups ?? []) as ActionGroupMeta[];
 }
 
-/** アクショングループを読み込み */
+/** アクショングループを読み込み（旧形式データは自動マイグレーション） */
 export async function loadActionGroup(id: string): Promise<ActionGroup | null> {
   if (_backend) {
     const data = await _backend.loadActionGroup(id);
-    return data ? (data as ActionGroup) : null;
+    return data ? migrateActionGroup(data) : null;
   }
   const raw = localStorage.getItem(`${ACTION_PREFIX}${id}`);
   if (!raw) return null;
   try {
-    return JSON.parse(raw) as ActionGroup;
+    return migrateActionGroup(JSON.parse(raw));
   } catch {
     return null;
   }
@@ -190,7 +191,7 @@ export function removeSubStep(parentStep: Step, subStepId: string): void {
 
 // ─── 内部 ────────────────────────────────────────────────────────────────
 
-function createDefaultStep(type: StepType): Step {
+export function createDefaultStep(type: StepType): Step {
   const base = {
     id: generateUUID(),
     type,
@@ -210,7 +211,25 @@ function createDefaultStep(type: StepType): Step {
     case "displayUpdate":
       return { ...base, type: "displayUpdate", target: "" };
     case "branch":
-      return { ...base, type: "branch", condition: "", branchA: { label: "A", description: "" }, branchB: { label: "B", description: "" } };
+      return {
+        ...base,
+        type: "branch",
+        branches: [
+          { id: generateUUID(), code: "A", condition: "", steps: [] },
+          { id: generateUUID(), code: "B", condition: "", steps: [] },
+        ],
+      };
+    case "loop":
+      return {
+        ...base,
+        type: "loop",
+        loopKind: "count",
+        steps: [],
+      };
+    case "loopBreak":
+      return { ...base, type: "loopBreak" };
+    case "loopContinue":
+      return { ...base, type: "loopContinue" };
     case "jump":
       return { ...base, type: "jump", jumpTo: "" };
     case "other":

--- a/designer/src/styles/action.css
+++ b/designer/src/styles/action.css
@@ -697,3 +697,361 @@
   background: #e2e8f0;
   margin: 4px 0;
 }
+
+/* ─── 分岐セクション (Phase 3) ───────────────────────────────────── */
+
+.branch-sections {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.branch-section {
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  background: #fffbf7;
+  overflow: hidden;
+}
+
+.branch-section.else {
+  background: #f8fafc;
+}
+
+.branch-section-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px;
+  cursor: pointer;
+  background: #fff7ed;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.branch-section.else .branch-section-header {
+  background: #f1f5f9;
+}
+
+.branch-section.collapsed .branch-section-header {
+  border-bottom: none;
+}
+
+.branch-code-badge {
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 1px 7px;
+  border-radius: 3px;
+  background: #f97316;
+  color: #fff;
+  white-space: nowrap;
+  min-width: 22px;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.branch-section.else .branch-code-badge {
+  background: #94a3b8;
+}
+
+.branch-condition-input {
+  flex: 1;
+  min-width: 0;
+}
+
+.branch-section-body {
+  padding: 8px 10px;
+}
+
+.branch-add-row {
+  display: flex;
+  gap: 8px;
+  margin-top: 6px;
+}
+
+.branch-add-btn {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  border: 1px dashed #cbd5e1;
+  border-radius: 4px;
+  background: #fff;
+  font-size: 0.75rem;
+  color: #64748b;
+  cursor: pointer;
+  flex: 1;
+  justify-content: center;
+}
+
+.branch-add-btn:hover {
+  border-color: #f97316;
+  color: #f97316;
+  background: #fff7ed;
+}
+
+/* ─── ループ (Phase 4) ───────────────────────────────────────────── */
+
+.loop-kind-radios {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 10px;
+  flex-wrap: wrap;
+}
+
+.loop-kind-radios label {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.82rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+.loop-body {
+  border: 1px solid #a5f3fc;
+  border-radius: 6px;
+  background: #f0fdff;
+  margin-top: 8px;
+  overflow: hidden;
+}
+
+.loop-body-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-bottom: 1px solid #a5f3fc;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #0891b2;
+  cursor: pointer;
+  background: #ecfeff;
+  user-select: none;
+}
+
+.loop-body.collapsed .loop-body-header {
+  border-bottom: none;
+}
+
+.loop-body-content {
+  padding: 8px 10px;
+}
+
+/* ─── インライン型ピッカー ───────────────────────────────────────── */
+
+.inline-step-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.inline-step-add {
+  position: relative;
+  margin-top: 4px;
+}
+
+.inline-add-btn {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 8px;
+  border: 1px dashed #cbd5e1;
+  border-radius: 4px;
+  background: transparent;
+  font-size: 0.75rem;
+  color: #94a3b8;
+  cursor: pointer;
+}
+
+.inline-add-btn:hover {
+  border-color: #6366f1;
+  color: #6366f1;
+  background: #f5f3ff;
+}
+
+.inline-type-picker {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  z-index: 50;
+  padding: 4px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px;
+  min-width: 260px;
+}
+
+.inline-type-btn {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  padding: 3px 7px;
+  border: 1px solid #e2e8f0;
+  border-radius: 4px;
+  background: #fff;
+  font-size: 0.72rem;
+  color: #475569;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.inline-type-btn:hover {
+  background: #f5f3ff;
+  border-color: #6366f1;
+  color: #4338ca;
+}
+
+/* ─── ジャンプ先セレクター (Phase 5) ────────────────────────────── */
+
+.jump-selector {
+  position: relative;
+}
+
+.jump-selector-input-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.jump-selector-input-wrap.unresolved input {
+  border-color: #f59e0b;
+  padding-left: 28px;
+}
+
+.jump-unresolved-icon {
+  position: absolute;
+  left: 8px;
+  color: #f59e0b;
+  font-size: 0.82rem;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.jump-selector-clear {
+  position: absolute;
+  right: 4px;
+  border: none;
+  background: none;
+  color: #94a3b8;
+  cursor: pointer;
+  padding: 0 3px;
+  font-size: 0.9rem;
+  line-height: 1;
+  z-index: 1;
+}
+
+.jump-selector-clear:hover {
+  color: #475569;
+}
+
+.jump-selector-dropdown {
+  position: absolute;
+  top: calc(100% + 2px);
+  left: 0;
+  right: 0;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  z-index: 100;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.jump-selector-option {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  font-size: 0.82rem;
+  cursor: pointer;
+}
+
+.jump-selector-option:hover,
+.jump-selector-option.active {
+  background: #f5f3ff;
+}
+
+.jump-selector-option-label {
+  font-weight: 600;
+  color: #6366f1;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.jump-selector-option-desc {
+  color: #64748b;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.jump-selector-freetext {
+  color: #64748b;
+  font-style: italic;
+}
+
+.jump-selector-option-empty {
+  padding: 8px 10px;
+  font-size: 0.82rem;
+  color: #94a3b8;
+  text-align: center;
+}
+
+/* ─── バリデーションエラー表示 (Phase 6) ─────────────────────────── */
+
+.step-card.has-error {
+  border-left-color: #ef4444 !important;
+  box-shadow: 0 0 0 1px rgba(239, 68, 68, 0.2);
+}
+
+.step-card.has-warning:not(.has-error) {
+  border-left-color: #f59e0b !important;
+  box-shadow: 0 0 0 1px rgba(245, 158, 11, 0.15);
+}
+
+.step-validation-msg {
+  padding: 3px 12px 4px 48px;
+  font-size: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.step-validation-msg.error {
+  color: #dc2626;
+  background: #fef2f2;
+  border-top: 1px solid #fee2e2;
+}
+
+.step-validation-msg.warning {
+  color: #d97706;
+  background: #fffbeb;
+  border-top: 1px solid #fde68a;
+}
+
+.validation-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 0.72rem;
+  font-weight: 600;
+}
+
+.validation-badge.error {
+  background: #fef2f2;
+  color: #dc2626;
+  border: 1px solid #fecaca;
+}
+
+.validation-badge.warning {
+  background: #fffbeb;
+  color: #d97706;
+  border: 1px solid #fde68a;
+}

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -8,7 +8,10 @@ export type StepType =
   | "commonProcess"    // 共通処理参照
   | "screenTransition" // 画面遷移
   | "displayUpdate"    // 表示更新
-  | "branch"           // 条件分岐（インラインA/B）
+  | "branch"           // 条件分岐（多分岐）
+  | "loop"             // ループ
+  | "loopBreak"        // ループ終了（break）
+  | "loopContinue"     // 次のループへ（continue）
   | "jump"             // 別大分類へのジャンプ
   | "other";           // その他
 
@@ -21,6 +24,9 @@ export const STEP_TYPE_LABELS: Record<StepType, string> = {
   screenTransition: "画面遷移",
   displayUpdate: "表示更新",
   branch: "条件分岐",
+  loop: "ループ",
+  loopBreak: "ループ終了",
+  loopContinue: "次のループへ",
   jump: "ジャンプ",
   other: "その他",
 };
@@ -34,6 +40,9 @@ export const STEP_TYPE_ICONS: Record<StepType, string> = {
   screenTransition: "bi-arrow-right-square",
   displayUpdate: "bi-display",
   branch: "bi-signpost-split",
+  loop: "bi-arrow-repeat",
+  loopBreak: "bi-stop-circle",
+  loopContinue: "bi-skip-forward",
   jump: "bi-arrow-return-right",
   other: "bi-three-dots",
 };
@@ -47,6 +56,9 @@ export const STEP_TYPE_COLORS: Record<StepType, string> = {
   screenTransition: "#ec4899",
   displayUpdate: "#6366f1",
   branch: "#f97316",
+  loop: "#06b6d4",
+  loopBreak: "#ef4444",
+  loopContinue: "#14b8a6",
   jump: "#94a3b8",
   other: "#9ca3af",
 };
@@ -160,11 +172,57 @@ export interface DisplayUpdateStep extends StepBase {
   target: string;
 }
 
+/** 多分岐の1件 */
+export interface Branch {
+  /** 内部 UUID */
+  id: string;
+  /** 自動採番コード: "A", "B", "C", ... */
+  code: string;
+  /** 任意の自由入力ラベル */
+  label?: string;
+  /** 分岐条件（自由記述、LLM 解析前提） */
+  condition: string;
+  /** 任意のサブ処理（全カード配置可能） */
+  steps: Step[];
+}
+
 export interface BranchStep extends StepBase {
   type: "branch";
-  condition: string;
-  branchA: { label: string; description: string; jumpTo?: string };
-  branchB: { label: string; description: string; jumpTo?: string };
+  /** 最小 1 個、D&D で並び替え可能 */
+  branches: Branch[];
+  /** 任意、常に最後に描画 */
+  elseBranch?: Branch;
+}
+
+/** ループ種別 */
+export type LoopKind = "count" | "condition" | "collection";
+
+/** ループ条件モード */
+export type LoopConditionMode = "continue" | "exit";
+
+export interface LoopStep extends StepBase {
+  type: "loop";
+  loopKind: LoopKind;
+  /** loopKind="count" 用: "3回", "検索結果の件数分" 等 */
+  countExpression?: string;
+  /** loopKind="condition" 用、デフォルト "exit" */
+  conditionMode?: LoopConditionMode;
+  /** loopKind="condition" 用 */
+  conditionExpression?: string;
+  /** loopKind="collection" 用: 例 "検索結果" */
+  collectionSource?: string;
+  /** loopKind="collection" 用: 例 "ユーザー" */
+  collectionItemName?: string;
+  /** ループ本体 */
+  steps: Step[];
+}
+
+export interface LoopBreakStep extends StepBase {
+  type: "loopBreak";
+}
+
+export interface LoopContinueStep extends StepBase {
+  type: "loopContinue";
 }
 
 export interface JumpStep extends StepBase {
@@ -184,6 +242,9 @@ export type Step =
   | ScreenTransitionStep
   | DisplayUpdateStep
   | BranchStep
+  | LoopStep
+  | LoopBreakStep
+  | LoopContinueStep
   | JumpStep
   | OtherStep;
 

--- a/designer/src/utils/actionMigration.test.ts
+++ b/designer/src/utils/actionMigration.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect } from "vitest";
+import type { ActionGroup, BranchStep, OtherStep, JumpStep, LoopStep } from "../types/action";
+import { migrateActionGroup, migrateStep } from "./actionMigration";
+
+describe("migrateStep — BranchStep legacy → new", () => {
+  it("旧 branchA/branchB/condition を branches[] に変換する", () => {
+    const legacy = {
+      id: "step-001",
+      type: "branch",
+      description: "認証結果判定",
+      condition: "トークンが有効か",
+      branchA: { label: "有効", description: "処理を続行" },
+      branchB: { label: "無効", description: "ログイン画面へリダイレクト" },
+    };
+    const migrated = migrateStep(legacy) as BranchStep;
+
+    expect(migrated.type).toBe("branch");
+    expect(migrated.description).toBe("認証結果判定");
+    expect(migrated.branches).toHaveLength(2);
+
+    const a = migrated.branches[0];
+    expect(a.code).toBe("A");
+    expect(a.label).toBe("有効");
+    expect(a.condition).toBe("トークンが有効か");
+    expect(a.steps).toHaveLength(1);
+    expect((a.steps[0] as OtherStep).type).toBe("other");
+    expect((a.steps[0] as OtherStep).description).toBe("処理を続行");
+    expect(a.id).toMatch(/[0-9a-f-]{36}/);
+
+    const b = migrated.branches[1];
+    expect(b.code).toBe("B");
+    expect(b.label).toBe("無効");
+    expect(b.condition).toBe("");
+    expect((b.steps[0] as OtherStep).description).toBe("ログイン画面へリダイレクト");
+
+    // 旧フィールドが除去されている
+    expect((migrated as unknown as { condition?: string }).condition).toBeUndefined();
+    expect((migrated as unknown as { branchA?: unknown }).branchA).toBeUndefined();
+    expect((migrated as unknown as { branchB?: unknown }).branchB).toBeUndefined();
+  });
+
+  it("branchA/B の jumpTo は jump ステップに変換される", () => {
+    const legacy = {
+      id: "step-jump-001",
+      type: "branch",
+      description: "",
+      condition: "",
+      branchA: { label: "", description: "", jumpTo: "target-a" },
+      branchB: { label: "", description: "処理", jumpTo: "target-b" },
+    };
+    const migrated = migrateStep(legacy) as BranchStep;
+
+    expect(migrated.branches[0].steps).toHaveLength(1);
+    const jumpA = migrated.branches[0].steps[0] as JumpStep;
+    expect(jumpA.type).toBe("jump");
+    expect(jumpA.jumpTo).toBe("target-a");
+
+    // B は description と jumpTo 両方あり → other + jump の 2 ステップ
+    expect(migrated.branches[1].steps).toHaveLength(2);
+    expect((migrated.branches[1].steps[0] as OtherStep).description).toBe("処理");
+    expect((migrated.branches[1].steps[1] as JumpStep).jumpTo).toBe("target-b");
+  });
+
+  it("description も jumpTo も空なら空の steps を持つ Branch を生成", () => {
+    const legacy = {
+      id: "step-empty",
+      type: "branch",
+      description: "",
+      condition: "",
+      branchA: { label: "", description: "" },
+      branchB: { label: "", description: "" },
+    };
+    const migrated = migrateStep(legacy) as BranchStep;
+    expect(migrated.branches[0].steps).toEqual([]);
+    expect(migrated.branches[1].steps).toEqual([]);
+    expect(migrated.branches[0].label).toBeUndefined();
+  });
+
+  it("subSteps 内の旧 BranchStep も再帰的に変換される", () => {
+    const legacy = {
+      id: "parent",
+      type: "other",
+      description: "parent",
+      subSteps: [
+        {
+          id: "child-branch",
+          type: "branch",
+          description: "",
+          condition: "cond",
+          branchA: { label: "Y", description: "ok" },
+          branchB: { label: "N", description: "ng" },
+        },
+      ],
+    };
+    const migrated = migrateStep(legacy) as OtherStep;
+    const child = migrated.subSteps![0] as BranchStep;
+    expect(child.branches[0].condition).toBe("cond");
+    expect((child.branches[0].steps[0] as OtherStep).description).toBe("ok");
+  });
+
+  it("既に新形式の BranchStep は branches をそのまま保持する（冪等）", () => {
+    const newShape = {
+      id: "branch-new",
+      type: "branch",
+      description: "",
+      branches: [
+        { id: "br1", code: "A", label: "A", condition: "c1", steps: [] },
+        { id: "br2", code: "B", condition: "", steps: [] },
+      ],
+    };
+    const migrated = migrateStep(newShape) as BranchStep;
+    expect(migrated.branches).toHaveLength(2);
+    expect(migrated.branches[0].id).toBe("br1");
+    expect(migrated.branches[0].condition).toBe("c1");
+    expect(migrated.branches[1].code).toBe("B");
+  });
+
+  it("新形式の Branch.steps 内のネストした旧 branch も変換される", () => {
+    const newShape = {
+      id: "outer",
+      type: "branch",
+      description: "",
+      branches: [
+        {
+          id: "br1",
+          code: "A",
+          condition: "",
+          steps: [
+            {
+              id: "inner",
+              type: "branch",
+              description: "",
+              condition: "inner-cond",
+              branchA: { label: "", description: "x" },
+              branchB: { label: "", description: "y" },
+            },
+          ],
+        },
+      ],
+    };
+    const migrated = migrateStep(newShape) as BranchStep;
+    const inner = migrated.branches[0].steps[0] as BranchStep;
+    expect(inner.branches).toHaveLength(2);
+    expect(inner.branches[0].condition).toBe("inner-cond");
+  });
+
+  it("loop ステップの steps 内の旧 branch も再帰変換される", () => {
+    const loopLegacy = {
+      id: "loop-1",
+      type: "loop",
+      description: "",
+      loopKind: "count",
+      steps: [
+        {
+          id: "branch-inside-loop",
+          type: "branch",
+          description: "",
+          condition: "cc",
+          branchA: { label: "a", description: "" },
+          branchB: { label: "b", description: "" },
+        },
+      ],
+    };
+    const migrated = migrateStep(loopLegacy) as LoopStep;
+    const br = migrated.steps[0] as BranchStep;
+    expect(br.branches[0].condition).toBe("cc");
+    expect(br.branches[0].label).toBe("a");
+  });
+
+  it("非 branch ステップはそのまま保持される", () => {
+    const other = {
+      id: "x",
+      type: "dbAccess",
+      description: "",
+      tableName: "users",
+      operation: "SELECT",
+    };
+    const migrated = migrateStep(other);
+    expect(migrated).toEqual(other);
+    expect(migrated).not.toBe(other); // cloneされている
+  });
+
+  it("元データを破壊しない", () => {
+    const legacy = {
+      id: "s",
+      type: "branch",
+      description: "",
+      condition: "orig-condition",
+      branchA: { label: "A", description: "A-desc" },
+      branchB: { label: "B", description: "B-desc" },
+    };
+    const before = JSON.stringify(legacy);
+    migrateStep(legacy);
+    expect(JSON.stringify(legacy)).toBe(before);
+  });
+});
+
+describe("migrateActionGroup — ActionGroup 全体", () => {
+  it("既存サンプルの認証チェック ActionGroup を正しく変換する", () => {
+    // docs/sample-project/actions/cccccccc-0003 相当のデータ
+    const sample = {
+      id: "cccccccc-0003-4000-8000-cccccccccccc",
+      name: "認証チェック",
+      type: "common",
+      description: "セッション・トークン検証を行う共通処理",
+      actions: [
+        {
+          id: "act-auth-001",
+          name: "認証処理",
+          trigger: "other",
+          steps: [
+            {
+              id: "step-auth-001",
+              type: "validation",
+              description: "セッション有効性チェック",
+              conditions: "セッションIDの存在確認・有効期限チェック",
+              inlineBranch: { ok: "トークン検証へ", ng: "ログイン画面へリダイレクト" },
+            },
+            {
+              id: "step-auth-003",
+              type: "branch",
+              description: "認証結果判定",
+              condition: "トークンが有効か",
+              branchA: { label: "有効", description: "処理を続行" },
+              branchB: { label: "無効", description: "ログイン画面へリダイレクト", jumpTo: "" },
+            },
+          ],
+        },
+      ],
+      createdAt: "2026-04-14T00:00:00.000Z",
+      updatedAt: "2026-04-14T00:00:00.000Z",
+    };
+
+    const migrated = migrateActionGroup(sample) as ActionGroup;
+
+    expect(migrated.id).toBe(sample.id);
+    expect(migrated.actions).toHaveLength(1);
+    const steps = migrated.actions[0].steps;
+    expect(steps).toHaveLength(2);
+
+    // validation はそのまま
+    expect(steps[0].type).toBe("validation");
+
+    // branch は新形式に
+    const branch = steps[1] as BranchStep;
+    expect(branch.type).toBe("branch");
+    expect(branch.branches).toHaveLength(2);
+    expect(branch.branches[0].label).toBe("有効");
+    expect(branch.branches[0].condition).toBe("トークンが有効か");
+    expect(branch.branches[1].label).toBe("無効");
+    // 空文字 jumpTo は jump ステップを作らない
+    expect(branch.branches[1].steps).toHaveLength(1);
+    expect((branch.branches[1].steps[0] as OtherStep).type).toBe("other");
+  });
+
+  it("冪等性: 2 回マイグレーションしても結果が同じ", () => {
+    const sample = {
+      id: "g",
+      name: "x",
+      type: "common",
+      description: "",
+      actions: [
+        {
+          id: "a",
+          name: "a",
+          trigger: "other",
+          steps: [
+            {
+              id: "s",
+              type: "branch",
+              description: "",
+              condition: "c",
+              branchA: { label: "A", description: "ad" },
+              branchB: { label: "B", description: "bd" },
+            },
+          ],
+        },
+      ],
+      createdAt: "",
+      updatedAt: "",
+    };
+    const once = migrateActionGroup(sample);
+    const twice = migrateActionGroup(once);
+    // IDs in once/twice should match (twice doesn't regenerate since already new)
+    const onceJson = JSON.stringify(once);
+    const twiceJson = JSON.stringify(twice);
+    expect(twiceJson).toBe(onceJson);
+  });
+});

--- a/designer/src/utils/actionMigration.ts
+++ b/designer/src/utils/actionMigration.ts
@@ -1,0 +1,138 @@
+/**
+ * actionMigration.ts
+ * 処理フロー定義の旧データ → 新データ構造への変換
+ *
+ * 変換対象（Issue #68 Phase 1）:
+ *  - 旧 BranchStep { condition, branchA, branchB } → 新 { branches: Branch[], elseBranch? }
+ *
+ * 旧データとの互換性維持のため、JSON ロード時に必ず通す。
+ * 変換は冪等で、既に新形式の場合はそのまま返す。
+ */
+import type { ActionDefinition, ActionGroup, Branch, Step } from "../types/action";
+import { generateUUID } from "./uuid";
+
+interface LegacyBranchFields {
+  label?: string;
+  description?: string;
+  jumpTo?: string;
+}
+
+function isLegacyBranchStep(step: Record<string, unknown>): boolean {
+  if (step.type !== "branch") return false;
+  if (Array.isArray(step.branches)) return false;
+  return "branchA" in step || "branchB" in step || "condition" in step;
+}
+
+/** 旧 branchA/B フィールドを新 Branch に変換（description/jumpTo はサブ step に展開） */
+function legacyToBranch(
+  code: string,
+  condition: string,
+  raw: LegacyBranchFields | undefined,
+): Branch {
+  const steps: Step[] = [];
+  const description = raw?.description?.trim();
+  const jumpTo = raw?.jumpTo?.trim();
+
+  if (description) {
+    steps.push({
+      id: generateUUID(),
+      type: "other",
+      description,
+    });
+  }
+  if (jumpTo) {
+    steps.push({
+      id: generateUUID(),
+      type: "jump",
+      description: "",
+      jumpTo,
+    });
+  }
+
+  const label = raw?.label?.trim();
+  return {
+    id: generateUUID(),
+    code,
+    label: label || undefined,
+    condition,
+    steps,
+  };
+}
+
+/** ステップを再帰的にマイグレーション。引数は破壊的に書き換える想定（呼び出し側で cloneDeep する） */
+function migrateStepInPlace(raw: unknown): Step {
+  if (!raw || typeof raw !== "object") return raw as Step;
+  const step = raw as Record<string, unknown>;
+
+  if (Array.isArray(step.subSteps)) {
+    step.subSteps = (step.subSteps as unknown[]).map(migrateStepInPlace);
+  }
+
+  if (isLegacyBranchStep(step)) {
+    const condition = typeof step.condition === "string" ? step.condition : "";
+    const branchA = (step.branchA as LegacyBranchFields | undefined) ?? undefined;
+    const branchB = (step.branchB as LegacyBranchFields | undefined) ?? undefined;
+
+    const branches: Branch[] = [
+      legacyToBranch("A", condition, branchA),
+      legacyToBranch("B", "", branchB),
+    ];
+
+    delete step.condition;
+    delete step.branchA;
+    delete step.branchB;
+    step.branches = branches;
+  } else if (step.type === "branch" && Array.isArray(step.branches)) {
+    step.branches = (step.branches as unknown[]).map(migrateBranchInPlace);
+    if (step.elseBranch && typeof step.elseBranch === "object") {
+      step.elseBranch = migrateBranchInPlace(step.elseBranch);
+    }
+  } else if (step.type === "loop" && Array.isArray(step.steps)) {
+    step.steps = (step.steps as unknown[]).map(migrateStepInPlace);
+  }
+
+  return step as unknown as Step;
+}
+
+function migrateBranchInPlace(raw: unknown): Branch {
+  if (!raw || typeof raw !== "object") return raw as Branch;
+  const branch = raw as Record<string, unknown>;
+  if (Array.isArray(branch.steps)) {
+    branch.steps = (branch.steps as unknown[]).map(migrateStepInPlace);
+  } else {
+    branch.steps = [];
+  }
+  return branch as unknown as Branch;
+}
+
+/** アクション内の全ステップをマイグレーション */
+function migrateActionInPlace(raw: unknown): ActionDefinition {
+  if (!raw || typeof raw !== "object") return raw as ActionDefinition;
+  const action = raw as Record<string, unknown>;
+  if (Array.isArray(action.steps)) {
+    action.steps = (action.steps as unknown[]).map(migrateStepInPlace);
+  }
+  return action as unknown as ActionDefinition;
+}
+
+/**
+ * ActionGroup を旧形式から新形式に変換。
+ * 元データは変更せず、deep clone した結果を返す。
+ * 既に新形式の場合は実質コピーのみ。
+ */
+export function migrateActionGroup(raw: unknown): ActionGroup {
+  if (!raw || typeof raw !== "object") {
+    throw new Error("migrateActionGroup: input is not an object");
+  }
+  const cloned = JSON.parse(JSON.stringify(raw)) as Record<string, unknown>;
+  if (Array.isArray(cloned.actions)) {
+    cloned.actions = (cloned.actions as unknown[]).map(migrateActionInPlace);
+  }
+  return cloned as unknown as ActionGroup;
+}
+
+/** 単一 Step のマイグレーション（テスト・特定用途向け） */
+export function migrateStep(raw: unknown): Step {
+  const cloned = raw && typeof raw === "object" ? JSON.parse(JSON.stringify(raw)) : raw;
+  return migrateStepInPlace(cloned);
+}

--- a/designer/src/utils/actionUtils.ts
+++ b/designer/src/utils/actionUtils.ts
@@ -42,6 +42,21 @@ export function resolveJumpLabel(
 }
 
 /**
+ * ステップ配列を再帰的に走査（subSteps・branches[].steps・elseBranch.steps・loop.steps を含む）
+ */
+function walkSteps(steps: Step[], visit: (step: Step) => void): void {
+  for (const step of steps) {
+    visit(step);
+    if (step.subSteps) walkSteps(step.subSteps, visit);
+    if (step.type === "branch") {
+      for (const br of step.branches) walkSteps(br.steps, visit);
+      if (step.elseBranch) walkSteps(step.elseBranch.steps, visit);
+    }
+    if (step.type === "loop") walkSteps(step.steps, visit);
+  }
+}
+
+/**
  * ステップ内のジャンプ参照を更新
  * oldId → newId に置換
  */
@@ -50,42 +65,28 @@ export function updateJumpReferences(
   oldId: string,
   newId: string,
 ): void {
-  for (const step of steps) {
+  walkSteps(steps, (step) => {
     if (step.type === "jump" && step.jumpTo === oldId) {
       step.jumpTo = newId;
-    }
-    if (step.type === "branch") {
-      if (step.branchA.jumpTo === oldId) step.branchA.jumpTo = newId;
-      if (step.branchB.jumpTo === oldId) step.branchB.jumpTo = newId;
     }
     if (step.type === "validation" && step.inlineBranch?.ngJumpTo === oldId) {
       step.inlineBranch.ngJumpTo = newId;
     }
-    if (step.subSteps) {
-      updateJumpReferences(step.subSteps, oldId, newId);
-    }
-  }
+  });
 }
 
 /**
  * 削除されたステップへのジャンプ参照をクリア
  */
 export function clearJumpReferences(steps: Step[], deletedId: string): void {
-  for (const step of steps) {
+  walkSteps(steps, (step) => {
     if (step.type === "jump" && step.jumpTo === deletedId) {
       step.jumpTo = "";
-    }
-    if (step.type === "branch") {
-      if (step.branchA.jumpTo === deletedId) step.branchA.jumpTo = undefined;
-      if (step.branchB.jumpTo === deletedId) step.branchB.jumpTo = undefined;
     }
     if (step.type === "validation" && step.inlineBranch?.ngJumpTo === deletedId) {
       step.inlineBranch.ngJumpTo = undefined;
     }
-    if (step.subSteps) {
-      clearJumpReferences(step.subSteps, deletedId);
-    }
-  }
+  });
 }
 
 /**

--- a/designer/src/utils/actionValidation.ts
+++ b/designer/src/utils/actionValidation.ts
@@ -1,0 +1,84 @@
+import type { ActionGroup, Step } from "../types/action";
+
+export type ValidationSeverity = "error" | "warning";
+
+export interface ValidationError {
+  stepId: string;
+  severity: ValidationSeverity;
+  message: string;
+}
+
+function collectAllIds(steps: Step[], ids: Set<string>): void {
+  for (const step of steps) {
+    ids.add(step.id);
+    if (step.subSteps) collectAllIds(step.subSteps, ids);
+    if (step.type === "branch") {
+      for (const b of step.branches) collectAllIds(b.steps, ids);
+      if (step.elseBranch) collectAllIds(step.elseBranch.steps, ids);
+    }
+    if (step.type === "loop") collectAllIds(step.steps, ids);
+  }
+}
+
+function validateSteps(
+  steps: Step[],
+  loopDepth: number,
+  errors: ValidationError[],
+  allIds: Set<string>,
+): void {
+  for (const step of steps) {
+    switch (step.type) {
+      case "loopBreak":
+      case "loopContinue":
+        if (loopDepth === 0) {
+          errors.push({
+            stepId: step.id,
+            severity: "error",
+            message: step.type === "loopBreak"
+              ? "ループ終了 はループの中にのみ置けます"
+              : "次のループへ はループの中にのみ置けます",
+          });
+        }
+        break;
+      case "branch":
+        if (step.branches.length === 0) {
+          errors.push({ stepId: step.id, severity: "error", message: "分岐が1つもありません" });
+        }
+        for (const b of step.branches) validateSteps(b.steps, loopDepth, errors, allIds);
+        if (step.elseBranch) validateSteps(step.elseBranch.steps, loopDepth, errors, allIds);
+        break;
+      case "loop":
+        if (step.loopKind === "condition" && !step.conditionExpression) {
+          errors.push({ stepId: step.id, severity: "warning", message: "条件式が未入力です" });
+        }
+        if (step.loopKind === "collection" && !step.collectionSource) {
+          errors.push({ stepId: step.id, severity: "warning", message: "コレクションが未入力です" });
+        }
+        validateSteps(step.steps, loopDepth + 1, errors, allIds);
+        break;
+      case "jump":
+        if (!step.jumpTo) {
+          errors.push({ stepId: step.id, severity: "warning", message: "ジャンプ先が未設定です" });
+        } else if (!allIds.has(step.jumpTo)) {
+          errors.push({ stepId: step.id, severity: "warning", message: "ジャンプ先が見つかりません" });
+        }
+        break;
+    }
+    if (step.subSteps && step.subSteps.length > 0) {
+      validateSteps(step.subSteps, step.type === "loop" ? loopDepth + 1 : loopDepth, errors, allIds);
+    }
+  }
+}
+
+export function validateActionGroup(group: ActionGroup): ValidationError[] {
+  const allIds = new Set<string>();
+  for (const action of group.actions) collectAllIds(action.steps, allIds);
+
+  const errors: ValidationError[] = [];
+  for (const action of group.actions) validateSteps(action.steps, 0, errors, allIds);
+  return errors;
+}
+
+export function hasBlockingErrors(errors: ValidationError[]): boolean {
+  return errors.some((e) => e.severity === "error");
+}


### PR DESCRIPTION
## Summary

- **Phase 2**: StepCard 再帰化、サブステップ全種追加、インデント/アウトデント
- **Phase 3**: 分岐セクションをアコーディオンに刷新（A/B/C... 自動採番、ELSE分岐、折りたたみ）
- **Phase 4**: ループカード（回数/条件/コレクション、ループ本体再帰レンダリング）+ ツールバー追加
- **Phase 5**: `JumpTargetSelector` コンボボックス（検索・キーボードナビ・フリーテキスト・未解決警告）
- **Phase 6**: バリデーション基盤 (`actionValidation.ts`) + 赤エラーは保存ブロック + ヘッダーバッジ + カードインラインメッセージ

Closes #68

## Test plan

- [ ] 分岐ステップ展開 → A/B/C... セクションが縦積みで表示される
- [ ] 各分岐ボディにステップを追加・削除・並び替えできる
- [ ] ELSE分岐の追加/削除ができる
- [ ] ループステップ展開 → loopKind ラジオ切り替えでフィールドが切り替わる
- [ ] ループ本体にステップを追加できる
- [ ] ツールバーに loop / loopBreak / loopContinue が表示される
- [ ] ジャンプステップ展開 → JumpTargetSelector で検索・選択できる
- [ ] ジャンプ先未設定時に黄警告バッジが表示される
- [ ] loopBreak をループ外に置くと赤エラーバッジが表示され自動保存されない
- [ ] Ctrl+Z で全操作が元に戻せる

🤖 Generated with [Claude Code](https://claude.com/claude-code)