### PR TITLE
fix(er): erUtils.ts の型エラー修正 (#72)

### DIFF
--- a/designer/src/utils/erUtils.ts
+++ b/designer/src/utils/erUtils.ts
@@ -46,7 +46,7 @@ export function convertLogicalRelations(
   const tableIdMap = new Map(tables.map((t) => [t.id, t]));
 
   return logicals
-    .map((lr) => {
+    .map((lr): ErRelation | null => {
       const src = tableIdMap.get(lr.sourceTableId);
       const tgt = tableIdMap.get(lr.targetTableId);
       if (!src || !tgt) return null;
@@ -61,7 +61,7 @@ export function convertLogicalRelations(
         cardinality: lr.cardinality,
         physical: false,
         label: lr.label,
-      } satisfies ErRelation;
+      };
     })
     .filter((r): r is ErRelation => r !== null);
 }


### PR DESCRIPTION
## Summary
- \`convertLogicalRelations\` の map コールバックに明示的な戻り型 \`ErRelation | null\` を付与
- \`satisfies ErRelation\` を除去し、filter の型ガード \`(r): r is ErRelation\` を正しく成立させる

Closes #72

## Test plan
- [ ] \`npm run build\` が erUtils.ts のエラー TS2322 / TS2677 なしで通ること
- [ ] \`npx vitest run\` 45/45 pass
- [ ] ER 図の論理リレーション表示が従来どおり動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)