### PR TITLE
fix(table): 未使用変数ビルドエラー修正 (#73)

### DIFF
--- a/designer/src/components/table/ErDiagram.tsx
+++ b/designer/src/components/table/ErDiagram.tsx
@@ -20,7 +20,7 @@ import "@xyflow/react/dist/style.css";
 
 import ErTableNodeComponent, { type ErTableNodeData } from "./ErTableNode";
 import { TableTopbar } from "./TableTopbar";
-import type { TableDefinition, ErLayout, ErLogicalRelation, ErCardinality, SqlDialect } from "../../types/table";
+import type { TableDefinition, ErLayout, ErLogicalRelation, ErCardinality } from "../../types/table";
 import { CARDINALITY_LABELS } from "../../types/table";
 import { listTables, loadTable, createTable } from "../../store/tableStore";
 import { loadErLayout, saveErLayout } from "../../store/erLayoutStore";

--- a/designer/src/components/table/TableEditor.tsx
+++ b/designer/src/components/table/TableEditor.tsx
@@ -32,7 +32,6 @@ export function TableEditor() {
   // Undo/Redo 対応 state
   const {
     state: table,
-    update: setTable,
     updateAndCommit,
     undo,
     redo,
@@ -479,8 +478,6 @@ function ColumnDetailEditor({
   showLength: boolean;
   showScale: boolean;
 }) {
-  const hasFk = !!col.foreignKey;
-
   return (
     <div className="column-detail">
       <div className="column-detail-grid">

--- a/designer/src/utils/ddlGenerator.ts
+++ b/designer/src/utils/ddlGenerator.ts
@@ -3,14 +3,14 @@
  * テーブル定義から DDL (CREATE TABLE) を生成するユーティリティ
  * MySQL / PostgreSQL / Oracle / SQLite / 標準SQL に対応
  */
-import type { TableDefinition, TableColumn, SqlDialect } from "../types/table";
+import type { TableDefinition, SqlDialect } from "../types/table";
 
 export function generateDdl(table: TableDefinition, dialect: SqlDialect): string {
   const colDefs: string[] = [];
   const pks: string[] = [];
 
   for (const col of table.columns) {
-    let typeStr = col.autoIncrement
+    const typeStr = col.autoIncrement
       ? autoIncrementType(col.dataType, dialect)
       : mapDataType(col.dataType, col.length, col.scale, dialect);
 


### PR DESCRIPTION
## Summary
- \`ErDiagram.tsx\`: 未使用の \`SqlDialect\` import を削除
- \`TableEditor.tsx\`: 未使用の \`update: setTable\` 分割代入、\`ColumnDetail\` 内の未使用 \`hasFk\` を削除
- \`ddlGenerator.ts\`: 未使用の \`TableColumn\` import を削除、\`let typeStr\` → \`const\`

Closes #73

## Test plan
- [ ] \`npm run build\` が TS6133 / TS6196 なしで通ること
- [ ] \`npx vitest run\` 45/45 pass
- [ ] テーブル編集・ER 図・DDL 生成が従来どおり動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)