### PR TITLE
fix(test): setup.ts の beforeEach 型定義不足を修正 (#74)

### DIFF
--- a/designer/src/test/setup.ts
+++ b/designer/src/test/setup.ts
@@ -1,4 +1,5 @@
 import "@testing-library/jest-dom";
+import { beforeEach } from "vitest";
 
 // localStorage のモック（jsdom は実装済みだがテスト間でリセット）
 beforeEach(() => {


### PR DESCRIPTION
## Summary
- \`src/test/setup.ts\` で \`beforeEach\` を vitest から明示 import
- tabStore.test.ts と同じ流儀に統一。tsconfig に vitest globals を追加せずとも型エラーを解消

Closes #74

## Test plan
- [ ] \`npm run build\` が TS2593 なしで通ること
- [ ] \`npx vitest run\` 45/45 pass（setup.ts の localStorage.clear が各テスト前に実行されていること）

🤖 Generated with [Claude Code](https://claude.com/claude-code)