### PR TITLE
feat(ui): 共通ヘッダーにドロップダウン型メニューを実装

### DIFF
--- a/designer/src/components/CommonHeader.tsx
+++ b/designer/src/components/CommonHeader.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { HeaderMenu } from "./HeaderMenu";
 import "../styles/commonHeader.css";
 
 interface Props {
@@ -10,6 +11,7 @@ export function CommonHeader({ notification, userName }: Props) {
   return (
     <header className="common-header">
       <div className="common-header-left">
+        <HeaderMenu />
         <i className="bi bi-palette2 common-header-logo" />
         <span className="common-header-title">業務システム デザイナー</span>
       </div>

--- a/designer/src/components/HeaderMenu.tsx
+++ b/designer/src/components/HeaderMenu.tsx
@@ -1,0 +1,122 @@
+import { useState, useEffect, useRef } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
+import { clearActiveTab, getTabs, getActiveTabId } from "../store/tabStore";
+import "../styles/headerMenu.css";
+
+type MenuItem = {
+  id: string;
+  label: string;
+  icon: string;
+  route: string;
+  matchPrefix?: boolean;
+  disabled?: boolean;
+};
+
+const MENU_ITEMS: MenuItem[] = [
+  { id: "flow",      label: "画面フロー",  icon: "bi-diagram-3",    route: "/"        },
+  { id: "tables",    label: "テーブル設計", icon: "bi-table",        route: "/tables", matchPrefix: true },
+  { id: "er",        label: "ER図",        icon: "bi-share",        route: "/er"      },
+  { id: "actions",   label: "処理フロー",  icon: "bi-lightning",    route: "/actions", matchPrefix: true },
+];
+
+const DASHBOARD_ITEM: MenuItem = {
+  id: "dashboard",
+  label: "ダッシュボード",
+  icon: "bi-speedometer2",
+  route: "/dashboard",
+  disabled: true,
+};
+
+function isDesignTabActive(): boolean {
+  const activeId = getActiveTabId();
+  return getTabs().some((t) => t.id === activeId && t.type === "design");
+}
+
+export function HeaderMenu() {
+  const [open, setOpen] = useState(false);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const close = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", close);
+    return () => document.removeEventListener("mousedown", close);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  const handleSelect = (route: string) => {
+    // デザインタブがアクティブな場合は解除して非デザインルートを表示できるようにする
+    if (isDesignTabActive()) {
+      clearActiveTab();
+    }
+    navigate(route);
+    setOpen(false);
+  };
+
+  const isActive = (item: MenuItem) => {
+    if (item.route === "/") return location.pathname === "/";
+    return item.matchPrefix
+      ? location.pathname.startsWith(item.route)
+      : location.pathname === item.route;
+  };
+
+  return (
+    <div className="header-menu" ref={menuRef}>
+      <button
+        className={`header-menu-btn${open ? " open" : ""}`}
+        onClick={() => setOpen((v) => !v)}
+        title="メニュー"
+        aria-haspopup="true"
+        aria-expanded={open}
+      >
+        <i className="bi bi-list" />
+      </button>
+
+      {open && (
+        <div className="header-menu-dropdown" role="menu">
+          <div className="header-menu-section-label">ナビゲーション</div>
+
+          <button
+            key={DASHBOARD_ITEM.id}
+            className="header-menu-item disabled"
+            disabled
+            role="menuitem"
+            title="ダッシュボード（準備中）"
+          >
+            <i className={`bi ${DASHBOARD_ITEM.icon}`} />
+            <span>{DASHBOARD_ITEM.label}</span>
+            <span className="header-menu-badge">準備中</span>
+          </button>
+
+          <div className="header-menu-separator" />
+
+          {MENU_ITEMS.map((item) => (
+            <button
+              key={item.id}
+              className={`header-menu-item${isActive(item) ? " active" : ""}`}
+              onClick={() => handleSelect(item.route)}
+              role="menuitem"
+            >
+              <i className={`bi ${item.icon}`} />
+              <span>{item.label}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/designer/src/store/tabStore.ts
+++ b/designer/src/store/tabStore.ts
@@ -106,6 +106,13 @@ export function setActiveTab(id: string): void {
   _notify();
 }
 
+export function clearActiveTab(): void {
+  if (_activeTabId === "") return;
+  _activeTabId = "";
+  _persist();
+  _notify();
+}
+
 export function reorderTabs(fromIndex: number, toIndex: number): void {
   const arr = [..._tabs];
   const [removed] = arr.splice(fromIndex, 1);

--- a/designer/src/styles/headerMenu.css
+++ b/designer/src/styles/headerMenu.css
@@ -1,0 +1,115 @@
+.header-menu {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.header-menu-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: #9a9db5;
+  font-size: 20px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.header-menu-btn:hover {
+  background: #2d2d44;
+  color: #e4e6f0;
+}
+
+.header-menu-btn.open {
+  background: #3b3e55;
+  color: #e4e6f0;
+}
+
+.header-menu-dropdown {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 1000;
+  min-width: 200px;
+  background: #27293a;
+  border: 1px solid #3b3e55;
+  border-radius: 6px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  padding: 6px 0;
+  animation: header-menu-open 0.12s ease;
+}
+
+@keyframes header-menu-open {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.header-menu-section-label {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  color: #6b6e8a;
+  padding: 4px 14px 6px;
+}
+
+.header-menu-separator {
+  height: 1px;
+  background: #3b3e55;
+  margin: 4px 0;
+}
+
+.header-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 7px 14px;
+  border: none;
+  background: transparent;
+  color: #c4c6d8;
+  font-size: 13px;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.1s, color 0.1s;
+}
+
+.header-menu-item:hover:not(.disabled) {
+  background: #3b3e55;
+  color: #e4e6f0;
+}
+
+.header-menu-item.active {
+  color: #7c7ff1;
+  background: rgba(99, 102, 241, 0.1);
+}
+
+.header-menu-item.active i {
+  color: #7c7ff1;
+}
+
+.header-menu-item.disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.header-menu-item i {
+  font-size: 14px;
+  width: 16px;
+  text-align: center;
+  color: #9a9db5;
+  flex-shrink: 0;
+}
+
+.header-menu-badge {
+  margin-left: auto;
+  font-size: 10px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: #3b3e55;
+  color: #9a9db5;
+  font-weight: 500;
+}


### PR DESCRIPTION
## Summary

- `HeaderMenu.tsx` 新規作成 — ハンバーガーボタン + ドロップダウン型ナビゲーションメニュー
- `CommonHeader.tsx` 左端に `<HeaderMenu />` を組み込み
- ナビゲーション項目: 画面フロー / テーブル設計 / ER図 / 処理フロー
- ダッシュボードは「準備中」バッジ付き無効化（Issue D 完了後に有効化）
- アクティブルートを紫ハイライトで視覚表示
- デザインタブがアクティブな状態でも選択すると `clearActiveTab()` でアクティブ解除後に遷移
- 外側クリック / Esc キーで閉じる
- `tabStore` に `clearActiveTab()` を追加

## Test plan

- [x] `npm run build` がエラーゼロで通過
- [x] ハンバーガーボタンクリックでドロップダウン開閉
- [x] デザイン画面から「画面フロー」をクリック → FlowEditor へ遷移
- [x] FlowEditor から「テーブル設計」をクリック → `/tables` へ遷移
- [x] アクティブルートが紫ハイライト表示されることを確認
- [x] ダッシュボード項目がグレーアウト＋「準備中」バッジ表示

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)