### PR TITLE
feat(editor): テーブル・処理フロー編集画面に明示的保存モデルを実装

### DIFF
--- a/designer/e2e/save-reset.spec.ts
+++ b/designer/e2e/save-reset.spec.ts
@@ -1,0 +1,146 @@
+/**
+ * 保存/リセットボタン E2E テスト
+ *
+ * 視点: ユーザーがテーブルエディタで編集・保存・リセットを行う
+ * 前提: dev サーバーが起動済み (playwright.config.ts の webServer で自動起動)
+ *       MCP サーバーは不要 — localStorage でテーブルを直接セットアップ
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+
+// ─── テスト用ダミーデータ ───────────────────────────────────────────────────
+
+const TABLE_ID = "test-table-0001-4000-8000-000000000001";
+
+const dummyTable = {
+  id: TABLE_ID,
+  name: "users",
+  logicalName: "ユーザーマスタ",
+  description: "",
+  category: "マスタ",
+  columns: [
+    {
+      id: "col-0001",
+      name: "id",
+      logicalName: "ユーザーID",
+      dataType: "INTEGER",
+      notNull: true,
+      primaryKey: true,
+      unique: false,
+      autoIncrement: true,
+    },
+  ],
+  indexes: [],
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+const dummyProject = {
+  version: 1,
+  name: "E2Eテスト用プロジェクト",
+  screens: [],
+  groups: [],
+  edges: [],
+  tables: [
+    {
+      id: TABLE_ID,
+      name: "users",
+      logicalName: "ユーザーマスタ",
+      description: "",
+      createdAt: dummyTable.createdAt,
+      updatedAt: dummyTable.updatedAt,
+    },
+  ],
+  updatedAt: new Date().toISOString(),
+};
+
+const dummyTab = {
+  id: `table:${TABLE_ID}`,
+  type: "table",
+  resourceId: TABLE_ID,
+  label: "ユーザーマスタ",
+  isDirty: false,
+  isPinned: false,
+};
+
+async function setupTableEditor(page: Page) {
+  await page.addInitScript(
+    ({ project, table, tableId, tab }) => {
+      localStorage.setItem("flow-project", JSON.stringify(project));
+      localStorage.setItem(`table-${tableId}`, JSON.stringify(table));
+      localStorage.setItem("designer-open-tabs", JSON.stringify([tab]));
+      localStorage.setItem("designer-active-tab", tab.id);
+      // 前回のテストの下書きを削除
+      localStorage.removeItem(`draft-table-${tableId}`);
+    },
+    { project: dummyProject, table: dummyTable, tableId: TABLE_ID, tab: dummyTab },
+  );
+  await page.goto(`/tables/${TABLE_ID}`);
+  // テーブルが読み込まれるまで待機
+  await expect(page.locator(".table-editor-page")).toBeVisible();
+}
+
+// ─── テスト ────────────────────────────────────────────────────────────────
+
+test.describe("テーブルエディタ：保存/リセットボタン", () => {
+  test("初期状態では保存・リセットボタンが無効", async ({ page }) => {
+    await setupTableEditor(page);
+
+    await expect(page.getByRole("button", { name: /保存/ })).toBeDisabled();
+    await expect(page.getByRole("button", { name: /リセット/ })).toBeDisabled();
+  });
+
+  test("カラム追加後に保存・リセットボタンが有効になる", async ({ page }) => {
+    await setupTableEditor(page);
+
+    await page.getByRole("button", { name: /カラム追加/ }).click();
+
+    await expect(page.getByRole("button", { name: /保存/ })).toBeEnabled();
+    await expect(page.getByRole("button", { name: /リセット/ })).toBeEnabled();
+  });
+
+  test("変更後にタブの dirty インジケーターが表示される", async ({ page }) => {
+    await setupTableEditor(page);
+
+    await page.getByRole("button", { name: /カラム追加/ }).click();
+
+    // タブに dirty クラスが付与される（オレンジ左ボーダー）
+    await expect(page.locator(".tabbar-tab.dirty")).toBeVisible();
+    // dirty ドット（●）が表示される
+    await expect(page.locator(".tabbar-tab-dirty")).toBeVisible();
+  });
+
+  test("リセット後に保存・リセットボタンが無効に戻る", async ({ page }) => {
+    await setupTableEditor(page);
+
+    await page.getByRole("button", { name: /カラム追加/ }).click();
+    await expect(page.getByRole("button", { name: /保存/ })).toBeEnabled();
+
+    await page.getByRole("button", { name: /リセット/ }).click();
+
+    await expect(page.getByRole("button", { name: /保存/ })).toBeDisabled();
+    await expect(page.getByRole("button", { name: /リセット/ })).toBeDisabled();
+  });
+
+  test("リセット後に dirty インジケーターが消える", async ({ page }) => {
+    await setupTableEditor(page);
+
+    await page.getByRole("button", { name: /カラム追加/ }).click();
+    await expect(page.locator(".tabbar-tab.dirty")).toBeVisible();
+
+    await page.getByRole("button", { name: /リセット/ }).click();
+
+    await expect(page.locator(".tabbar-tab.dirty")).not.toBeVisible();
+  });
+
+  test("Ctrl+S で保存が実行されて保存ボタンが無効に戻る", async ({ page }) => {
+    await setupTableEditor(page);
+
+    await page.getByRole("button", { name: /カラム追加/ }).click();
+    await expect(page.getByRole("button", { name: /保存/ })).toBeEnabled();
+
+    await page.keyboard.press("Control+s");
+
+    await expect(page.getByRole("button", { name: /保存/ })).toBeDisabled();
+  });
+});

--- a/designer/src/components/TabBar.tsx
+++ b/designer/src/components/TabBar.tsx
@@ -91,6 +91,7 @@ function TabItem({
         isActive ? "active" : "",
         tab.isPinned ? "pinned" : "",
         isDragging ? "tabbar-tab-drag" : "",
+        tab.isDirty ? "dirty" : "",
       ].filter(Boolean).join(" ")}
       onClick={handleClick}
       onAuxClick={handleAuxClick}

--- a/designer/src/components/action/ActionEditor.tsx
+++ b/designer/src/components/action/ActionEditor.tsx
@@ -52,6 +52,9 @@ import { useSelectionKeyboard } from "../../hooks/useSelectionKeyboard";
 import { STEP_TYPE_COLORS } from "../../types/action";
 import { TableSubToolbar } from "../table/TableSubToolbar";
 import { SortableStepCard } from "./SortableStepCard";
+import { SaveResetButtons } from "../common/SaveResetButtons";
+import { ServerChangeBanner } from "../common/ServerChangeBanner";
+import { saveDraft, loadDraft, clearDraft } from "../../utils/draftStorage";
 import "../../styles/action.css";
 
 /** ツールバーのドラッグ可能なステップ種別ボタン */
@@ -124,7 +127,10 @@ export function ActionEditor() {
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; stepId: string } | null>(null);
   const [contextMenuSubTypePicker, setContextMenuSubTypePicker] = useState(false);
   const [validationErrors, setValidationErrors] = useState<ValidationError[]>([]);
-  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [isDirty, setIsDirty] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [serverChanged, setServerChanged] = useState(false);
+  const lastSavedRef = useRef<ActionGroup | null>(null);
   const newStepIdsRef = useRef<Set<string>>(new Set());
 
   // 選択・クリップボード state
@@ -134,15 +140,6 @@ export function ActionEditor() {
     mode: "cut" | "copy";
   } | null>(null);
   const lastSelectedIdRef = useRef<string | null>(null);
-
-  // 自動保存 (debounce 500ms) — blocking error があれば保存しない
-  const scheduleSave = useCallback((updatedGroup: ActionGroup) => {
-    if (hasBlockingErrors(validateActionGroup(updatedGroup))) return;
-    if (saveTimer.current) clearTimeout(saveTimer.current);
-    saveTimer.current = setTimeout(async () => {
-      await saveActionGroup(updatedGroup);
-    }, 500);
-  }, []);
 
   // Undo/Redo 対応 state
   const {
@@ -155,7 +152,7 @@ export function ActionEditor() {
     canUndo,
     canRedo,
     reset: resetGroup,
-  } = useUndoableState<ActionGroup | null>(null, { onSave: (g) => { if (g) saveActionGroup(g); } });
+  } = useUndoableState<ActionGroup | null>(null);
 
   useUndoKeyboard(undo, redo);
 
@@ -177,14 +174,23 @@ export function ActionEditor() {
     return closestCenter(args);
   }, []);
 
-  const reload = useCallback(async () => {
+  const reload = useCallback(async (useDraft = false) => {
     if (!actionGroupId) return;
     const g = await loadActionGroup(actionGroupId);
     if (!g) {
       navigate("/actions");
       return;
     }
-    resetGroup(g);
+    lastSavedRef.current = g;
+    const draft = useDraft ? null : loadDraft<ActionGroup>("action", actionGroupId);
+    if (draft) {
+      resetGroup(draft);
+      setIsDirty(true);
+    } else {
+      resetGroup(g);
+      setIsDirty(false);
+      clearDraft("action", actionGroupId);
+    }
     if (!activeActionId && g.actions.length > 0) {
       setActiveActionId(g.actions[0].id);
     }
@@ -199,15 +205,58 @@ export function ActionEditor() {
   useEffect(() => {
     mcpBridge.startWithoutEditor();
     reload();
-    const unsub = mcpBridge.onStatusChange((s) => {
+    const unsubStatus = mcpBridge.onStatusChange((s) => {
       if (s === "connected") reload();
     });
-    return unsub;
+    return unsubStatus;
   }, [reload]);
+
+  useEffect(() => {
+    if (!actionGroupId) return;
+    return mcpBridge.onBroadcast("actionGroupChanged", (data) => {
+      const d = data as { id?: string };
+      if (d.id === actionGroupId) setServerChanged(true);
+    });
+  }, [actionGroupId]);
+
+  // Ctrl+S for save
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === "s") {
+        e.preventDefault();
+        if (isDirty && !isSaving) handleSave();
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  });
 
   useEffect(() => {
     setValidationErrors(group ? validateActionGroup(group) : []);
   }, [group]);
+
+  const markGroupDirty = useCallback((g: ActionGroup) => {
+    if (actionGroupId) saveDraft("action", actionGroupId, g);
+    setIsDirty(true);
+  }, [actionGroupId]);
+
+  const handleSave = useCallback(async () => {
+    if (!group || hasBlockingErrors(validateActionGroup(group))) return;
+    setIsSaving(true);
+    try {
+      await saveActionGroup(group);
+      lastSavedRef.current = group;
+      if (actionGroupId) clearDraft("action", actionGroupId);
+      setIsDirty(false);
+    } finally {
+      setIsSaving(false);
+    }
+  }, [group, actionGroupId]);
+
+  const handleReset = useCallback(async () => {
+    await reload(true);
+    setServerChanged(false);
+  }, [reload]);
 
   /** 構造変化（履歴に積む）: ステップ追加・削除・移動、アクション追加・削除 */
   const updateGroup = useCallback(
@@ -216,11 +265,12 @@ export function ActionEditor() {
         if (!prev) return prev;
         const next = JSON.parse(JSON.stringify(prev)) as ActionGroup;
         updater(next);
-        scheduleSave(next);
+        markGroupDirty(next);
         return next;
       });
+      setIsDirty(true);
     },
-    [updateGroupCommit, scheduleSave],
+    [updateGroupCommit, markGroupDirty],
   );
 
   /** テキスト変更（履歴に積まない）: フィールド編集中の一時状態 */
@@ -230,11 +280,12 @@ export function ActionEditor() {
         if (!prev) return prev;
         const next = JSON.parse(JSON.stringify(prev)) as ActionGroup;
         updater(next);
-        scheduleSave(next);
+        markGroupDirty(next);
         return next;
       });
+      setIsDirty(true);
     },
-    [setGroup, scheduleSave],
+    [setGroup, markGroupDirty],
   );
 
   const activeAction = group?.actions.find((a) => a.id === activeActionId) ?? null;
@@ -497,6 +548,10 @@ export function ActionEditor() {
     <div className="action-page" onClick={() => closeContextMenu()}>
       <TableSubToolbar />
 
+      {serverChanged && (
+        <ServerChangeBanner onReload={handleReset} onDismiss={() => setServerChanged(false)} />
+      )}
+
       {/* ヘッダー */}
       <div className="action-editor-header">
         <div className="action-editor-breadcrumb">
@@ -533,6 +588,12 @@ export function ActionEditor() {
               {validationErrors.filter((e) => e.severity === "warning").length} 警告
             </span>
           )}
+          <SaveResetButtons
+            isDirty={isDirty}
+            isSaving={isSaving}
+            onSave={handleSave}
+            onReset={handleReset}
+          />
         </div>
       </div>
 

--- a/designer/src/components/common/SaveResetButtons.tsx
+++ b/designer/src/components/common/SaveResetButtons.tsx
@@ -1,0 +1,34 @@
+import "../../styles/saveReset.css";
+
+interface Props {
+  isDirty: boolean;
+  isSaving: boolean;
+  onSave: () => void;
+  onReset: () => void;
+}
+
+export function SaveResetButtons({ isDirty, isSaving, onSave, onReset }: Props) {
+  return (
+    <div className="save-reset-buttons">
+      <button
+        className="srb-btn srb-btn-reset"
+        onClick={onReset}
+        disabled={!isDirty || isSaving}
+        title="最後に保存した状態に戻す"
+      >
+        <i className="bi bi-arrow-counterclockwise" /> リセット
+      </button>
+      <button
+        className={`srb-btn srb-btn-save${isDirty ? " dirty" : ""}`}
+        onClick={onSave}
+        disabled={!isDirty || isSaving}
+        title="保存 (Ctrl+S)"
+      >
+        {isSaving
+          ? <><i className="bi bi-hourglass-split" /> 保存中...</>
+          : <><i className="bi bi-floppy" /> 保存</>
+        }
+      </button>
+    </div>
+  );
+}

--- a/designer/src/components/common/ServerChangeBanner.tsx
+++ b/designer/src/components/common/ServerChangeBanner.tsx
@@ -1,0 +1,17 @@
+import "../../styles/serverChangeBanner.css";
+
+interface Props {
+  onReload: () => void;
+  onDismiss: () => void;
+}
+
+export function ServerChangeBanner({ onReload, onDismiss }: Props) {
+  return (
+    <div className="server-change-banner" role="alert">
+      <i className="bi bi-exclamation-triangle-fill" />
+      <span>別のクライアントでデータが変更されました</span>
+      <button className="scb-btn scb-btn-reload" onClick={onReload}>再読み込み</button>
+      <button className="scb-btn scb-btn-dismiss" onClick={onDismiss}>無視</button>
+    </div>
+  );
+}

--- a/designer/src/components/table/TableEditor.tsx
+++ b/designer/src/components/table/TableEditor.tsx
@@ -9,6 +9,10 @@ import { generateDdl, generateTableMarkdown } from "../../utils/ddlGenerator";
 import { mcpBridge } from "../../mcp/mcpBridge";
 import { useUndoableState } from "../../hooks/useUndoableState";
 import { useUndoKeyboard } from "../../hooks/useUndoKeyboard";
+import { setDirty as setTabDirty, makeTabId } from "../../store/tabStore";
+import { saveDraft, loadDraft, clearDraft } from "../../utils/draftStorage";
+import { SaveResetButtons } from "../common/SaveResetButtons";
+import { ServerChangeBanner } from "../common/ServerChangeBanner";
 import "../../styles/table.css";
 
 type TabId = "columns" | "indexes" | "ddl";
@@ -20,16 +24,11 @@ export function TableEditor() {
   const [ddlDialect, setDdlDialect] = useState<SqlDialect>("postgresql");
   const [editingMeta, setEditingMeta] = useState(false);
   const [allTables, setAllTables] = useState<TableDefinition[]>([]);
-  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [isDirty, setIsDirty] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [serverChanged, setServerChanged] = useState(false);
+  const lastSavedRef = useRef<TableDefinition | null>(null);
 
-  const autoSave = useCallback((t: TableDefinition) => {
-    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
-    saveTimerRef.current = setTimeout(() => {
-      saveTable(t);
-    }, 500);
-  }, []);
-
-  // Undo/Redo 対応 state
   const {
     state: table,
     updateAndCommit,
@@ -38,17 +37,34 @@ export function TableEditor() {
     canUndo,
     canRedo,
     reset: resetTable,
-  } = useUndoableState<TableDefinition | null>(null, { onSave: (t) => { if (t) saveTable(t); } });
+  } = useUndoableState<TableDefinition | null>(null);
 
   useUndoKeyboard(undo, redo);
+
+  const markClean = useCallback(() => {
+    if (!tableId) return;
+    clearDraft("table", tableId);
+    setIsDirty(false);
+    setTabDirty(makeTabId("table", tableId), false);
+  }, [tableId]);
 
   useEffect(() => {
     mcpBridge.startWithoutEditor();
     if (!tableId) return;
     (async () => {
       const t = await loadTable(tableId);
-      if (t) resetTable(t);
-      else navigate("/tables");
+      if (!t) { navigate("/tables"); return; }
+      lastSavedRef.current = t;
+      const draft = loadDraft<TableDefinition>("table", tableId);
+      if (draft) {
+        resetTable(draft);
+        setIsDirty(true);
+        setTabDirty(makeTabId("table", tableId), true);
+      } else {
+        resetTable(t);
+        setIsDirty(false);
+        setTabDirty(makeTabId("table", tableId), false);
+      }
       const tl = await listTables();
       const allTds: TableDefinition[] = [];
       for (const m of tl) {
@@ -59,24 +75,66 @@ export function TableEditor() {
     })();
   }, [tableId, navigate, resetTable]);
 
-  // Cleanup save timer
   useEffect(() => {
-    return () => {
-      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
-    };
-  }, []);
+    if (!tableId) return;
+    return mcpBridge.onBroadcast("tableChanged", (data) => {
+      const d = data as { tableId?: string };
+      if (d.tableId === tableId) setServerChanged(true);
+    });
+  }, [tableId]);
 
-  /** 構造変化（履歴に積む）: カラム追加・削除・移動 */
+  // Ctrl+S for save
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === "s") {
+        e.preventDefault();
+        if (isDirty && !isSaving) handleSave();
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  });
+
   const update = useCallback((fn: (t: TableDefinition) => void) => {
     updateAndCommit((prev) => {
       if (!prev) return prev;
       const next = structuredClone(prev);
       fn(next);
-      autoSave(next);
+      if (tableId) {
+        saveDraft("table", tableId, next);
+        setTabDirty(makeTabId("table", tableId), true);
+      }
       return next;
     });
-  }, [updateAndCommit, autoSave]);
+    setIsDirty(true);
+  }, [updateAndCommit, tableId]);
 
+  const handleSave = useCallback(async () => {
+    if (!table) return;
+    setIsSaving(true);
+    try {
+      await saveTable(table);
+      lastSavedRef.current = table;
+      markClean();
+    } finally {
+      setIsSaving(false);
+    }
+  }, [table, markClean]);
+
+  const handleReset = useCallback(async () => {
+    if (!tableId) return;
+    const t = await loadTable(tableId);
+    if (!t) return;
+    lastSavedRef.current = t;
+    resetTable(t);
+    markClean();
+    setServerChanged(false);
+  }, [tableId, resetTable, markClean]);
+
+  const handleServerReload = useCallback(async () => {
+    await handleReset();
+    setServerChanged(false);
+  }, [handleReset]);
 
   if (!table) {
     return <div className="table-editor-loading"><i className="bi bi-hourglass-split" /> 読み込み中...</div>;
@@ -86,6 +144,10 @@ export function TableEditor() {
 
   return (
     <div className="table-editor-page">
+      {serverChanged && (
+        <ServerChangeBanner onReload={handleServerReload} onDismiss={() => setServerChanged(false)} />
+      )}
+
       {/* Header */}
       <header className="table-editor-header">
         <button className="tbl-btn tbl-btn-ghost table-back-btn" onClick={() => navigate("/tables")}>
@@ -137,6 +199,12 @@ export function TableEditor() {
           >
             <i className="bi bi-clipboard" />
           </button>
+          <SaveResetButtons
+            isDirty={isDirty}
+            isSaving={isSaving}
+            onSave={handleSave}
+            onReset={handleReset}
+          />
         </div>
       </header>
 
@@ -290,8 +358,7 @@ function ColumnsTab({
     update((t) => {
       const src = t.columns.find((c) => c.id === colId);
       if (!src) return;
-      const { id: _, ...rest } = src;
-      const col = addColumn(t, { ...rest, name: src.name + "_copy" });
+      const col = addColumn(t, { ...src, name: src.name + "_copy" });
       newColId = col.id;
     });
     if (newColId) setEditingId(newColId);

--- a/designer/src/styles/saveReset.css
+++ b/designer/src/styles/saveReset.css
@@ -1,0 +1,52 @@
+.save-reset-buttons {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.srb-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 10px;
+  border-radius: 4px;
+  font-size: 12px;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: background 0.1s, color 0.1s, border-color 0.1s;
+  white-space: nowrap;
+}
+
+.srb-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.srb-btn-reset {
+  background: transparent;
+  color: #9a9db5;
+  border-color: #3b3e55;
+}
+
+.srb-btn-reset:hover:not(:disabled) {
+  background: #2d2d44;
+  color: #e4e6f0;
+}
+
+.srb-btn-save {
+  background: #2d2d44;
+  color: #9a9db5;
+  border-color: #3b3e55;
+}
+
+.srb-btn-save.dirty {
+  background: #1d3461;
+  color: #60a5fa;
+  border-color: #2563eb;
+}
+
+.srb-btn-save:hover:not(:disabled) {
+  background: #2563eb;
+  color: #fff;
+  border-color: #2563eb;
+}

--- a/designer/src/styles/serverChangeBanner.css
+++ b/designer/src/styles/serverChangeBanner.css
@@ -1,0 +1,49 @@
+.server-change-banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 14px;
+  background: #1e2d45;
+  border-bottom: 1px solid #2563eb;
+  font-size: 13px;
+  color: #93c5fd;
+  flex-shrink: 0;
+}
+
+.server-change-banner i {
+  color: #f59e0b;
+  flex-shrink: 0;
+}
+
+.server-change-banner span {
+  flex: 1;
+}
+
+.scb-btn {
+  padding: 3px 10px;
+  border-radius: 4px;
+  font-size: 12px;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: background 0.1s;
+}
+
+.scb-btn-reload {
+  background: #2563eb;
+  color: #fff;
+  border-color: #2563eb;
+}
+
+.scb-btn-reload:hover {
+  background: #1d4ed8;
+}
+
+.scb-btn-dismiss {
+  background: transparent;
+  color: #93c5fd;
+  border-color: #2563eb;
+}
+
+.scb-btn-dismiss:hover {
+  background: rgba(37, 99, 235, 0.2);
+}

--- a/designer/src/styles/tabbar.css
+++ b/designer/src/styles/tabbar.css
@@ -74,6 +74,10 @@
   white-space: nowrap;
 }
 
+.tabbar-tab.dirty {
+  box-shadow: inset 3px 0 0 #f59e0b;
+}
+
 .tabbar-tab-dirty {
   font-size: 10px;
   color: #f59e0b;

--- a/designer/src/utils/draftStorage.test.ts
+++ b/designer/src/utils/draftStorage.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { saveDraft, loadDraft, clearDraft } from "./draftStorage";
+
+describe("saveDraft / loadDraft", () => {
+  it("保存したデータを読み込める", () => {
+    saveDraft("table", "abc", { name: "users" });
+    expect(loadDraft("table", "abc")).toEqual({ name: "users" });
+  });
+
+  it("存在しないキーは null を返す", () => {
+    expect(loadDraft("table", "nonexistent")).toBeNull();
+  });
+
+  it("上書き保存できる", () => {
+    saveDraft("table", "abc", { name: "old" });
+    saveDraft("table", "abc", { name: "new" });
+    expect(loadDraft("table", "abc")).toEqual({ name: "new" });
+  });
+
+  it("種別が異なれば別々のキーに保存される", () => {
+    saveDraft("table", "abc", { name: "users" });
+    saveDraft("action", "abc", { name: "actions" });
+    expect(loadDraft("table", "abc")).toEqual({ name: "users" });
+    expect(loadDraft("action", "abc")).toEqual({ name: "actions" });
+  });
+
+  it("IDが異なれば別々のキーに保存される", () => {
+    saveDraft("table", "abc", { name: "users" });
+    saveDraft("table", "def", { name: "orders" });
+    expect(loadDraft("table", "abc")).toEqual({ name: "users" });
+    expect(loadDraft("table", "def")).toEqual({ name: "orders" });
+  });
+
+  it("複雑なオブジェクトを保存・復元できる", () => {
+    const data = {
+      id: "t1",
+      columns: [{ id: "c1", name: "col1", type: "VARCHAR" }],
+      nested: { a: 1, b: [2, 3] },
+    };
+    saveDraft("table", "t1", data);
+    expect(loadDraft("table", "t1")).toEqual(data);
+  });
+});
+
+describe("clearDraft", () => {
+  it("下書きを削除できる", () => {
+    saveDraft("table", "abc", { name: "users" });
+    clearDraft("table", "abc");
+    expect(loadDraft("table", "abc")).toBeNull();
+  });
+
+  it("存在しないキーを削除してもエラーにならない", () => {
+    expect(() => clearDraft("table", "nonexistent")).not.toThrow();
+  });
+
+  it("別のキーに影響しない", () => {
+    saveDraft("table", "abc", { name: "users" });
+    saveDraft("table", "def", { name: "orders" });
+    clearDraft("table", "abc");
+    expect(loadDraft("table", "abc")).toBeNull();
+    expect(loadDraft("table", "def")).toEqual({ name: "orders" });
+  });
+
+  it("削除後に再度保存できる", () => {
+    saveDraft("table", "abc", { name: "old" });
+    clearDraft("table", "abc");
+    saveDraft("table", "abc", { name: "new" });
+    expect(loadDraft("table", "abc")).toEqual({ name: "new" });
+  });
+});

--- a/designer/src/utils/draftStorage.ts
+++ b/designer/src/utils/draftStorage.ts
@@ -1,0 +1,18 @@
+export function saveDraft<T>(kind: string, id: string, data: T): void {
+  try {
+    localStorage.setItem(`draft-${kind}-${id}`, JSON.stringify(data));
+  } catch { /* ignore */ }
+}
+
+export function loadDraft<T>(kind: string, id: string): T | null {
+  try {
+    const raw = localStorage.getItem(`draft-${kind}-${id}`);
+    return raw ? (JSON.parse(raw) as T) : null;
+  } catch { return null; }
+}
+
+export function clearDraft(kind: string, id: string): void {
+  try {
+    localStorage.removeItem(`draft-${kind}-${id}`);
+  } catch { /* ignore */ }
+}


### PR DESCRIPTION
## Summary

- 自動保存（デバウンス500ms）を廃止し、明示的な「保存」「リセット」ボタンに統一
- 未保存変更を localStorage に下書き保存し、次回アクセス時に自動復元
- 別クライアント（MCP等）によるデータ変更を `ServerChangeBanner` でリアルタイム通知
- 未保存タブにオレンジ左ボーダー（`dirty` CSS class）を表示
- Ctrl+S ショートカットで保存可能

## Changes

- `src/utils/draftStorage.ts` — localStorage 下書き API (saveDraft / loadDraft / clearDraft)
- `src/components/common/SaveResetButtons.tsx` — 共通保存/リセットボタンコンポーネント
- `src/components/common/ServerChangeBanner.tsx` — サーバー変更通知バナー
- `src/components/table/TableEditor.tsx` — 明示的保存モデルへ移行、`tableChanged` broadcast 購読
- `src/components/action/ActionEditor.tsx` — 明示的保存モデルへ移行、`actionGroupChanged` broadcast 購読
- `src/components/TabBar.tsx` + `tabbar.css` — dirty タブのオレンジ左ボーダー

## Test plan

- [x] Vitest: `draftStorage.test.ts` 10件すべてパス
- [x] Playwright: `e2e/save-reset.spec.ts` 6件すべてパス（初期無効、変更後有効、リセット、Ctrl+S、dirty インジケーター）
- [x] 既存テスト: Vitest 55件・Playwright 27件、新規失敗なし

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)