### PR TITLE
docs: ブランチ/PR ワークフロールールを CLAUDE.md に明文化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,8 @@ Claude Code ──(stdio)──→ designer-mcp ←──(ws://0.0.0.0:5179)─�
 
 - All UI text is in Japanese
 - Commit messages use conventional commits in Japanese (e.g., `feat(flow):`, `fix(designer):`, `improve:`)
+- **Workflow: one issue = one branch = one PR.** Never commit directly to `main`. Branch naming: `feat/issue-<N>-<slug>` for features, `fix/issue-<N>` or `fix/<slug>` for bug fixes, `docs/<slug>` for documentation-only changes. Create the branch from `origin/main` before starting work.
+- PRs are squash-merged into `main`. The PR title should include the issue number (e.g., `feat(ui): ... (#83)`) so the merge commit references it.
 - `data/` directory is gitignored — runtime data only
 - Themes: standard (default Bootstrap), card, compact, dark — CSS injected into GrapesJS canvas iframe
 - Custom blocks persist to `data/custom-blocks.json` via customBlockStore


### PR DESCRIPTION
## Summary

- プロジェクトで運用されている「Issue 1件 = ブランチ1本 = PR 1本、main 直コミット禁止」ルールを `CLAUDE.md` の Conventions セクションに明文化
- ブランチ命名規則 (`feat/issue-<N>-<slug>` / `fix/issue-<N>` / `docs/<slug>`) を追記
- PR タイトルに Issue 番号を含める規約を追記

## 背景

直近 15 件の PR (#63〜#89) はすべてこのルールに従って運用されているが、`CLAUDE.md` に明記されていなかったため、AI モデルが見落とすことがあった。文書化することで、Claude / 人間を問わず規則違反を防ぐ。

## Test plan

- [x] `CLAUDE.md` の Conventions セクションの箇条書きが 7 項目に増えていること
- [x] 追記内容が既存の英語表記と整合していること
- [ ] マージ後、次のイシュー対応時に Sonnet も含めてルールが読まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)