### PR TITLE
fix(ui): リセット操作に確認ダイアログを追加 (#84)

### DIFF
--- a/designer/e2e/save-reset.spec.ts
+++ b/designer/e2e/save-reset.spec.ts
@@ -112,6 +112,7 @@ test.describe("テーブルエディタ：保存/リセットボタン", () => {
 
   test("リセット後に保存・リセットボタンが無効に戻る", async ({ page }) => {
     await setupTableEditor(page);
+    page.on("dialog", (d) => d.accept());
 
     await page.getByRole("button", { name: /カラム追加/ }).click();
     await expect(page.getByRole("button", { name: /保存/ })).toBeEnabled();
@@ -124,12 +125,61 @@ test.describe("テーブルエディタ：保存/リセットボタン", () => {
 
   test("リセット後に dirty インジケーターが消える", async ({ page }) => {
     await setupTableEditor(page);
+    page.on("dialog", (d) => d.accept());
 
     await page.getByRole("button", { name: /カラム追加/ }).click();
     await expect(page.locator(".tabbar-tab.dirty")).toBeVisible();
 
     await page.getByRole("button", { name: /リセット/ }).click();
 
+    await expect(page.locator(".tabbar-tab.dirty")).not.toBeVisible();
+  });
+
+  test("リセットクリックで確認ダイアログが表示される", async ({ page }) => {
+    await setupTableEditor(page);
+
+    await page.getByRole("button", { name: /カラム追加/ }).click();
+
+    // dialog は click() をブロックするため、handler を先に登録して await しない click と組み合わせる
+    let dialogType = "";
+    let dialogMessage = "";
+    page.once("dialog", async (d) => {
+      dialogType = d.type();
+      dialogMessage = d.message();
+      await d.dismiss();
+    });
+
+    await page.getByRole("button", { name: /リセット/ }).click();
+
+    expect(dialogType).toBe("confirm");
+    expect(dialogMessage).toContain("保存済み状態に戻します");
+  });
+
+  test("確認ダイアログをキャンセルすると編集状態が保持される", async ({ page }) => {
+    await setupTableEditor(page);
+    page.on("dialog", (d) => d.dismiss());
+
+    await page.getByRole("button", { name: /カラム追加/ }).click();
+    await expect(page.getByRole("button", { name: /保存/ })).toBeEnabled();
+
+    await page.getByRole("button", { name: /リセット/ }).click();
+
+    // キャンセルしたので編集状態が維持されている
+    await expect(page.getByRole("button", { name: /保存/ })).toBeEnabled();
+    await expect(page.getByRole("button", { name: /リセット/ })).toBeEnabled();
+    await expect(page.locator(".tabbar-tab.dirty")).toBeVisible();
+  });
+
+  test("確認ダイアログを承認するとリセットが実行される", async ({ page }) => {
+    await setupTableEditor(page);
+    page.on("dialog", (d) => d.accept());
+
+    await page.getByRole("button", { name: /カラム追加/ }).click();
+    await expect(page.getByRole("button", { name: /保存/ })).toBeEnabled();
+
+    await page.getByRole("button", { name: /リセット/ }).click();
+
+    await expect(page.getByRole("button", { name: /保存/ })).toBeDisabled();
     await expect(page.locator(".tabbar-tab.dirty")).not.toBeVisible();
   });
 

--- a/designer/src/components/common/SaveResetButtons.tsx
+++ b/designer/src/components/common/SaveResetButtons.tsx
@@ -5,14 +5,29 @@ interface Props {
   isSaving: boolean;
   onSave: () => void;
   onReset: () => void;
+  /** リセット時の確認メッセージ。空文字を渡すと確認をスキップ（デフォルトは標準メッセージ） */
+  resetConfirmMessage?: string;
 }
 
-export function SaveResetButtons({ isDirty, isSaving, onSave, onReset }: Props) {
+const DEFAULT_RESET_CONFIRM = "編集内容を破棄して保存済み状態に戻します。よろしいですか？";
+
+export function SaveResetButtons({
+  isDirty,
+  isSaving,
+  onSave,
+  onReset,
+  resetConfirmMessage = DEFAULT_RESET_CONFIRM,
+}: Props) {
+  const handleResetClick = () => {
+    if (resetConfirmMessage && !window.confirm(resetConfirmMessage)) return;
+    onReset();
+  };
+
   return (
     <div className="save-reset-buttons">
       <button
         className="srb-btn srb-btn-reset"
-        onClick={onReset}
+        onClick={handleResetClick}
         disabled={!isDirty || isSaving}
         title="最後に保存した状態に戻す"
       >


### PR DESCRIPTION
## Summary

Issue #84 の受け入れ条件「リセット時に確認ダイアログが出る」が実装されていなかったため追加。

- 共通コンポーネント `SaveResetButtons` にリセット実行前の `window.confirm()` を組み込み
- デフォルトメッセージ: 「編集内容を破棄して保存済み状態に戻します。よろしいですか？」
- `resetConfirmMessage` prop で上書き可。空文字を渡すと確認スキップ（ServerChangeBanner 経由のリロードなど、既に同意済みの経路で使用）

## 背景

現状の `handleReset` は即座に破棄を実行していたため、誤クリックで編集内容が失われるリスクがあった。undo 履歴は既に `useUndoableState.reset()` でクリアされており、確認ダイアログが最後のセーフティネット。

## 変更ファイル

- `designer/src/components/common/SaveResetButtons.tsx` — confirm 組み込み
- `designer/e2e/save-reset.spec.ts` — 既存テストに dialog handler 追加、新規テスト3件追加

## Test plan

- [x] Vitest: 55 件すべて pass
- [x] Playwright: `save-reset.spec.ts` 9 件すべて pass（新規3件含む）
- [x] 全 Playwright: 31 件すべて pass
- [x] 新規テスト: 確認ダイアログ表示・キャンセル保持・承認実行をそれぞれ検証

関連: #84（残タスク完了のための PR 1/3）

🤖 Generated with [Claude Code](https://claude.com/claude-code)