### PR TITLE
feat(ui): Designer と FlowEditor を明示保存モデルに移行 (#84)

### DIFF
--- a/designer/e2e/save-reset-flow.spec.ts
+++ b/designer/e2e/save-reset-flow.spec.ts
@@ -1,0 +1,122 @@
+/**
+ * フロー画面：保存/リセットボタン E2E テスト
+ *
+ * 視点: ユーザーが画面フロー (/ の FlowEditor) で編集・保存・リセットを行う
+ * 前提: dev サーバーが起動済み (playwright.config.ts の webServer で自動起動)
+ *       MCP サーバーは不要 — localStorage でプロジェクトを直接セットアップ
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+
+const dummyProject = {
+  version: 1,
+  name: "E2Eテスト用プロジェクト",
+  screens: [],
+  groups: [],
+  edges: [],
+  updatedAt: new Date().toISOString(),
+};
+
+// ツールバーの保存/リセットを明示的に指し示すロケータ（モーダル内の「保存」と衝突しないよう）
+const toolbarSave = ".save-reset-buttons button.srb-btn-save";
+const toolbarReset = ".save-reset-buttons button.srb-btn-reset";
+
+async function setupFlowEditor(page: Page, draft: object | null = null) {
+  await page.addInitScript(
+    ({ project, draft }) => {
+      localStorage.setItem("flow-project", JSON.stringify(project));
+      localStorage.removeItem("designer-open-tabs");
+      localStorage.removeItem("designer-active-tab");
+      if (draft) {
+        localStorage.setItem("draft-flow-project", JSON.stringify(draft));
+      } else {
+        localStorage.removeItem("draft-flow-project");
+      }
+    },
+    { project: dummyProject, draft },
+  );
+  await page.goto("/");
+  await expect(page.locator(".flow-root")).toBeVisible();
+}
+
+async function addScreenViaModal(page: Page, name: string) {
+  await page.getByRole("button", { name: /画面を追加/ }).click();
+  await page.locator("#screen-name").fill(name);
+  await page.locator('.flow-modal button[type="submit"]').click();
+}
+
+test.describe("フロー画面：保存/リセットボタン", () => {
+  test("初期状態では保存・リセットボタンが無効", async ({ page }) => {
+    await setupFlowEditor(page);
+
+    await expect(page.locator(toolbarSave)).toBeDisabled();
+    await expect(page.locator(toolbarReset)).toBeDisabled();
+  });
+
+  test("画面追加後に保存・リセットボタンが有効になる", async ({ page }) => {
+    await setupFlowEditor(page);
+    await addScreenViaModal(page, "テスト画面");
+
+    await expect(page.locator(toolbarSave)).toBeEnabled();
+    await expect(page.locator(toolbarReset)).toBeEnabled();
+  });
+
+  test("リセット確認をキャンセルすると編集状態が保持される", async ({ page }) => {
+    await setupFlowEditor(page);
+    page.on("dialog", (d) => d.dismiss());
+
+    await addScreenViaModal(page, "テスト画面");
+
+    await page.locator(toolbarReset).click();
+
+    await expect(page.locator(toolbarSave)).toBeEnabled();
+    await expect(page.locator(toolbarReset)).toBeEnabled();
+  });
+
+  test("リセット確認を承認するとボタンが無効に戻る", async ({ page }) => {
+    await setupFlowEditor(page);
+    page.on("dialog", (d) => d.accept());
+
+    await addScreenViaModal(page, "テスト画面");
+
+    await page.locator(toolbarReset).click();
+
+    await expect(page.locator(toolbarSave)).toBeDisabled();
+    await expect(page.locator(toolbarReset)).toBeDisabled();
+  });
+
+  test("Ctrl+S で保存が実行されてボタンが無効に戻る", async ({ page }) => {
+    await setupFlowEditor(page);
+    await addScreenViaModal(page, "テスト画面");
+
+    await expect(page.locator(toolbarSave)).toBeEnabled();
+
+    await page.keyboard.press("Control+s");
+
+    await expect(page.locator(toolbarSave)).toBeDisabled();
+  });
+
+  test("ドラフトが事前に存在するとリロード後も isDirty 状態で復元される", async ({ page }) => {
+    const projectWithScreen = {
+      ...dummyProject,
+      screens: [
+        {
+          id: "aaaaaaaa-0001-4000-8000-000000000001",
+          name: "ドラフト画面",
+          type: "list",
+          description: "",
+          path: "/draft",
+          position: { x: 0, y: 0 },
+          size: { width: 200, height: 100 },
+          hasDesign: false,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      ],
+    };
+    await setupFlowEditor(page, projectWithScreen);
+
+    await expect(page.locator(toolbarSave)).toBeEnabled();
+    await expect(page.locator(toolbarReset)).toBeEnabled();
+  });
+});

--- a/designer/e2e/save-reset.spec.ts
+++ b/designer/e2e/save-reset.spec.ts
@@ -112,6 +112,7 @@ test.describe("テーブルエディタ：保存/リセットボタン", () => {
 
   test("リセット後に保存・リセットボタンが無効に戻る", async ({ page }) => {
     await setupTableEditor(page);
+    page.on("dialog", (d) => d.accept());
 
     await page.getByRole("button", { name: /カラム追加/ }).click();
     await expect(page.getByRole("button", { name: /保存/ })).toBeEnabled();
@@ -124,12 +125,61 @@ test.describe("テーブルエディタ：保存/リセットボタン", () => {
 
   test("リセット後に dirty インジケーターが消える", async ({ page }) => {
     await setupTableEditor(page);
+    page.on("dialog", (d) => d.accept());
 
     await page.getByRole("button", { name: /カラム追加/ }).click();
     await expect(page.locator(".tabbar-tab.dirty")).toBeVisible();
 
     await page.getByRole("button", { name: /リセット/ }).click();
 
+    await expect(page.locator(".tabbar-tab.dirty")).not.toBeVisible();
+  });
+
+  test("リセットクリックで確認ダイアログが表示される", async ({ page }) => {
+    await setupTableEditor(page);
+
+    await page.getByRole("button", { name: /カラム追加/ }).click();
+
+    // dialog は click() をブロックするため、handler を先に登録して await しない click と組み合わせる
+    let dialogType = "";
+    let dialogMessage = "";
+    page.once("dialog", async (d) => {
+      dialogType = d.type();
+      dialogMessage = d.message();
+      await d.dismiss();
+    });
+
+    await page.getByRole("button", { name: /リセット/ }).click();
+
+    expect(dialogType).toBe("confirm");
+    expect(dialogMessage).toContain("保存済み状態に戻します");
+  });
+
+  test("確認ダイアログをキャンセルすると編集状態が保持される", async ({ page }) => {
+    await setupTableEditor(page);
+    page.on("dialog", (d) => d.dismiss());
+
+    await page.getByRole("button", { name: /カラム追加/ }).click();
+    await expect(page.getByRole("button", { name: /保存/ })).toBeEnabled();
+
+    await page.getByRole("button", { name: /リセット/ }).click();
+
+    // キャンセルしたので編集状態が維持されている
+    await expect(page.getByRole("button", { name: /保存/ })).toBeEnabled();
+    await expect(page.getByRole("button", { name: /リセット/ })).toBeEnabled();
+    await expect(page.locator(".tabbar-tab.dirty")).toBeVisible();
+  });
+
+  test("確認ダイアログを承認するとリセットが実行される", async ({ page }) => {
+    await setupTableEditor(page);
+    page.on("dialog", (d) => d.accept());
+
+    await page.getByRole("button", { name: /カラム追加/ }).click();
+    await expect(page.getByRole("button", { name: /保存/ })).toBeEnabled();
+
+    await page.getByRole("button", { name: /リセット/ }).click();
+
+    await expect(page.getByRole("button", { name: /保存/ })).toBeDisabled();
     await expect(page.locator(".tabbar-tab.dirty")).not.toBeVisible();
   });
 

--- a/designer/src/components/Designer.tsx
+++ b/designer/src/components/Designer.tsx
@@ -11,10 +11,11 @@ import "grapesjs/dist/css/grapes.min.css";
 
 import { registerBlocks } from "../grapes/blocks";
 import { registerValidationTraits } from "../grapes/validationTraits";
-import { registerRemoteStorage, saveScreenToFile } from "../grapes/remoteStorage";
+import { registerRemoteStorage, saveScreenToFile, hasScreenDraft, clearScreenDraft } from "../grapes/remoteStorage";
 import { DesignSubToolbar } from "./design/DesignSubToolbar";
 import { BlocksPanel } from "./BlocksPanel";
 import { RightPanel } from "./RightPanel";
+import { ServerChangeBanner } from "./common/ServerChangeBanner";
 import { mcpBridge, type McpStatus } from "../mcp/mcpBridge";
 import { loadCustomBlocks, injectCustomBlockCss } from "../store/customBlockStore";
 import { loadProject, updateScreenThumbnail } from "../store/flowStore";
@@ -124,7 +125,10 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
   const gjsOptions = buildGjsOptions(screenId);
   const [ready, setReady] = useState(false);
   const [canvasEmpty, setCanvasEmpty] = useState(true);
-  const [isDirty, setIsDirtyState] = useState(false);
+  const [isDirty, setIsDirtyState] = useState(() => hasScreenDraft(screenId));
+  const [isSaving, setIsSaving] = useState(false);
+  const [serverChanged, setServerChanged] = useState(false);
+  const isDirtyRef = useRef(false);
   const [activeTheme, setActiveThemeState] = useState<ThemeId>(
     () => (localStorage.getItem(THEME_KEY) as ThemeId | null) ?? "standard"
   );
@@ -200,6 +204,7 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
     // 変更検知: component 操作または style 変更でdirtyフラグを立てる
     const markDirty = () => {
       setIsDirtyState(true);
+      isDirtyRef.current = true;
       setDirty(tabId, true);
     };
     editor.on("component:add component:remove component:update style:change", markDirty);
@@ -211,12 +216,16 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
     );
     mcpBridge.start(editor);
 
-    // 他タブで同じ画面が変更されたときにリロード
+    // 他タブ/クライアントで同じ画面が変更されたとき。
+    // dirty 中はバナー表示、clean なら即リロード。
     const unsubScreenChanged = mcpBridge.onBroadcast("screenChanged", (data) => {
       const d = data as { screenId?: string; deleted?: boolean };
-      if (d.screenId === screenId && !d.deleted) {
+      if (d.screenId !== screenId || d.deleted) return;
+      if (isDirtyRef.current) {
+        setServerChanged(true);
+      } else {
         console.log("[Designer] screenChanged broadcast, reloading...");
-        editor.store().then(() => editor.load()).catch(console.error);
+        editor.load().catch(console.error);
       }
     });
 
@@ -302,15 +311,39 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
   }, [panelMode]);
 
   const handleSaveToFile = useCallback(async () => {
+    if (isSaving) return;
+    setIsSaving(true);
     try {
       // GrapesJS の最新状態を localStorage に書き出してからファイル保存
       if (editorRef.current) await editorRef.current.store();
       await saveScreenToFile(screenId);
       setIsDirtyState(false);
+      isDirtyRef.current = false;
       setDirty(tabId, false);
+      setServerChanged(false);
     } catch (e) {
       console.error("[Designer] saveToFile failed:", e);
       alert("保存に失敗しました: " + String(e));
+    } finally {
+      setIsSaving(false);
+    }
+  }, [screenId, tabId, isSaving]);
+
+  const handleReset = useCallback(async () => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    // ドラフトマーカーを解除してからロード（load() が backend を優先するように）
+    clearScreenDraft(screenId);
+    try {
+      await editor.load();
+      editor.UndoManager.clear();
+      setIsDirtyState(false);
+      isDirtyRef.current = false;
+      setDirty(tabId, false);
+      setServerChanged(false);
+    } catch (e) {
+      console.error("[Designer] reset failed:", e);
+      alert("リセットに失敗しました: " + String(e));
     }
   }, [screenId, tabId]);
 
@@ -338,10 +371,19 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
             onThemeChange={handleThemeChange}
             mcpStatus={mcpStatus}
             isDirty={isDirty}
+            isSaving={isSaving}
             onSaveToFile={handleSaveToFile}
+            onReset={handleReset}
             backLink={onBack ? { label: screenName ?? "画面デザイン", onClick: onBack } : undefined}
           />
         </WithEditor>
+
+        {serverChanged && (
+          <ServerChangeBanner
+            onReload={handleReset}
+            onDismiss={() => setServerChanged(false)}
+          />
+        )}
 
         <div className="designer-body">
           <div className={`panel-left-wrapper is-${panelMode}`}>

--- a/designer/src/components/common/SaveResetButtons.tsx
+++ b/designer/src/components/common/SaveResetButtons.tsx
@@ -5,14 +5,29 @@ interface Props {
   isSaving: boolean;
   onSave: () => void;
   onReset: () => void;
+  /** リセット時の確認メッセージ。空文字を渡すと確認をスキップ（デフォルトは標準メッセージ） */
+  resetConfirmMessage?: string;
 }
 
-export function SaveResetButtons({ isDirty, isSaving, onSave, onReset }: Props) {
+const DEFAULT_RESET_CONFIRM = "編集内容を破棄して保存済み状態に戻します。よろしいですか？";
+
+export function SaveResetButtons({
+  isDirty,
+  isSaving,
+  onSave,
+  onReset,
+  resetConfirmMessage = DEFAULT_RESET_CONFIRM,
+}: Props) {
+  const handleResetClick = () => {
+    if (resetConfirmMessage && !window.confirm(resetConfirmMessage)) return;
+    onReset();
+  };
+
   return (
     <div className="save-reset-buttons">
       <button
         className="srb-btn srb-btn-reset"
-        onClick={onReset}
+        onClick={handleResetClick}
         disabled={!isDirty || isSaving}
         title="最後に保存した状態に戻す"
       >

--- a/designer/src/components/design/DesignSubToolbar.tsx
+++ b/designer/src/components/design/DesignSubToolbar.tsx
@@ -4,6 +4,7 @@ import type { PanelMode, ThemeId } from "../Designer";
 import type { McpStatus } from "../../mcp/mcpBridge";
 import { CodeEditorModal } from "../CodeEditorModal";
 import { SaveBlockModal } from "../SaveBlockModal";
+import { SaveResetButtons } from "../common/SaveResetButtons";
 import { upsertCustomBlock } from "../../store/customBlockStore";
 
 export const CUSTOM_BLOCK_CATEGORY = "マイブロック";
@@ -40,10 +41,12 @@ interface Props {
   mcpStatus: McpStatus;
   backLink?: BackLink;
   isDirty?: boolean;
+  isSaving?: boolean;
   onSaveToFile?: () => Promise<void>;
+  onReset?: () => Promise<void>;
 }
 
-export function DesignSubToolbar({ ready, panelMode, onOpenPanel, activeTheme, onThemeChange, mcpStatus, backLink, isDirty, onSaveToFile }: Props) {
+export function DesignSubToolbar({ ready, panelMode, onOpenPanel, activeTheme, onThemeChange, mcpStatus, backLink, isDirty, isSaving, onSaveToFile, onReset }: Props) {
   const [themeMenuOpen, setThemeMenuOpen] = useState(false);
   const editor = useEditor();
   const [saveState, setSaveState] = useState<"idle" | "saving" | "saved">("idle");
@@ -388,21 +391,15 @@ ${html}
           )}
         </div>
         <div className="divider" />
-        {isDirty ? (
-          <button
-            className="btn-primary-sm"
-            onClick={handleSaveNow}
-            title="変更を保存 (Ctrl+S)"
-            disabled={!ready}
-            style={{ background: "#f59e0b", animation: "none" }}
-          >
-            <i className="bi bi-save" /> 保存
-          </button>
-        ) : (
-          <span className="save-indicator saved" style={{ visibility: saveState === "saved" ? "visible" : "hidden" }}>
-            <i className="bi bi-check-circle-fill" /> 保存済み
-          </span>
-        )}
+        <SaveResetButtons
+          isDirty={!!isDirty}
+          isSaving={!!isSaving}
+          onSave={handleSaveNow}
+          onReset={() => { void onReset?.(); }}
+        />
+        <span className="save-indicator saved" style={{ visibility: saveState === "saved" ? "visible" : "hidden", marginLeft: 4 }}>
+          <i className="bi bi-check-circle-fill" /> 保存済み
+        </span>
         <button className="btn-secondary-sm" onClick={handleExportHtml} title="HTMLファイルとしてダウンロード">
           <i className="bi bi-download" /> HTMLエクスポート
         </button>

--- a/designer/src/components/flow/FlowEditor.tsx
+++ b/designer/src/components/flow/FlowEditor.tsx
@@ -31,6 +31,11 @@ import { TRIGGER_LABELS } from "../../types/flow";
 import {
   loadProject,
   saveProject,
+  persistProject,
+  setFlowDraftMode,
+  loadFlowDraft,
+  clearFlowDraft,
+  subscribeToFlowDraftSaves,
   addScreen,
   updateScreen,
   removeScreen,
@@ -48,6 +53,7 @@ import {
 import { mcpBridge } from "../../mcp/mcpBridge";
 import { useUndoKeyboard } from "../../hooks/useUndoKeyboard";
 import { openTab, makeTabId } from "../../store/tabStore";
+import { ServerChangeBanner } from "../common/ServerChangeBanner";
 import "../../styles/flow.css";
 
 const nodeTypes = {
@@ -121,6 +127,10 @@ function FlowEditorInner() {
   const [isLoading, setIsLoading] = useState(true);
   const [zoomLevel, setZoomLevel] = useState(1);
   const [viewMode, setViewMode] = useState<ViewMode>("flow");
+  const [isDirty, setIsDirty] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [serverChanged, setServerChanged] = useState(false);
+  const isDirtyRef = useRef(false);
   const needsFitViewRef = useRef(false);
 
   // Undo/Redo スタック
@@ -167,15 +177,25 @@ function FlowEditorInner() {
 
   useUndoKeyboard(handleUndo, handleRedo);
 
-  // プロジェクトを読み込んで UI に反映
+  // プロジェクトを読み込んで UI に反映（ドラフトがあれば優先的に復元）
+  // loadProject は draftMode の影響を受けないため、モード切替は不要。
   const reloadProject = useCallback(async () => {
     const project = await loadProject();
-    projectRef.current = project;
-    setNodes(toRFNodesWithGroups(project.screens, project.groups ?? []));
-    setEdges(toRFEdges(project.edges));
-    setProjectName(project.name);
-    needsFitViewRef.current = project.screens.length > 0;
+    const draft = loadFlowDraft();
+    const active = draft ?? project;
+    projectRef.current = active;
+    setNodes(toRFNodesWithGroups(active.screens, active.groups ?? []));
+    setEdges(toRFEdges(active.edges));
+    setProjectName(active.name);
+    needsFitViewRef.current = active.screens.length > 0;
     setIsLoading(false);
+    if (draft) {
+      setIsDirty(true);
+      isDirtyRef.current = true;
+    } else {
+      setIsDirty(false);
+      isDirtyRef.current = false;
+    }
   }, [setNodes, setEdges]);
 
   // ロード完了 or ノード変更後に全体フィット
@@ -192,22 +212,41 @@ function FlowEditorInner() {
   useEffect(() => {
     let mounted = true;
 
+    // UI 起点の変更はドラフトに書き込む
+    setFlowDraftMode(true);
+
+    // draft 保存が発生したら isDirty を立てる
+    const unsubDraft = subscribeToFlowDraftSaves(() => {
+      setIsDirty(true);
+      isDirtyRef.current = true;
+    });
+
+    const handleExternalChange = () => {
+      if (!mounted) return;
+      if (isDirtyRef.current) {
+        // ユーザーに未保存編集があるのでバナー表示
+        setServerChanged(true);
+      } else {
+        reloadProject().catch(console.error);
+      }
+    };
+
     mcpBridge.setNavigateHandler((path) => navigate(path));
 
     // MCP 経由でフローが変更されたとき（addScreen 等）
-    mcpBridge.setFlowChangeHandler(() => {
-      if (mounted) reloadProject().catch(console.error);
-    });
+    mcpBridge.setFlowChangeHandler(handleExternalChange);
 
     // 他タブ/ブラウザでプロジェクトが変更されたとき
-    const unsubProject = mcpBridge.onBroadcast("projectChanged", () => {
-      if (mounted) reloadProject().catch(console.error);
-    });
+    const unsubProject = mcpBridge.onBroadcast("projectChanged", handleExternalChange);
 
     // WS 接続完了時にファイルから再ロード（初回ロード時にバックエンドが未設定だった場合の補完）
     const unsubStatus = mcpBridge.onStatusChange((status) => {
       if (status === "connected" && mounted) {
-        reloadProject().catch(console.error);
+        if (isDirtyRef.current) {
+          setServerChanged(true);
+        } else {
+          reloadProject().catch(console.error);
+        }
       }
     });
 
@@ -219,8 +258,10 @@ function FlowEditorInner() {
 
     return () => {
       mounted = false;
+      setFlowDraftMode(false);
       mcpBridge.setNavigateHandler(null);
       mcpBridge.setFlowChangeHandler(null);
+      unsubDraft();
       unsubProject();
       unsubStatus();
     };
@@ -695,11 +736,57 @@ function FlowEditorInner() {
     URL.revokeObjectURL(url);
   }, []);
 
+  const handleSave = useCallback(async () => {
+    if (!projectRef.current || isSaving) return;
+    setIsSaving(true);
+    try {
+      await persistProject(projectRef.current);
+      setIsDirty(false);
+      isDirtyRef.current = false;
+      setServerChanged(false);
+    } catch (e) {
+      console.error("[FlowEditor] save failed:", e);
+      alert("保存に失敗しました: " + String(e));
+    } finally {
+      setIsSaving(false);
+    }
+  }, [isSaving]);
+
+  const handleReset = useCallback(async () => {
+    clearFlowDraft();
+    undoStackRef.current = [];
+    redoStackRef.current = [];
+    setCanUndo(false);
+    setCanRedo(false);
+    await reloadProject();
+    setServerChanged(false);
+  }, [reloadProject]);
+
+  // Ctrl+S で保存
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === "s") {
+        const t = e.target as HTMLElement;
+        if (t.tagName === "INPUT" || t.tagName === "TEXTAREA" || t.isContentEditable) return;
+        e.preventDefault();
+        if (isDirty && !isSaving) handleSave();
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [isDirty, isSaving, handleSave]);
+
   const isEmpty = !isLoading && nodes.filter((n) => n.type === "screenNode").length === 0;
   const screenCount = nodes.filter((n) => n.type === "screenNode").length;
 
   return (
     <div className="flow-root">
+      {serverChanged && (
+        <ServerChangeBanner
+          onReload={handleReset}
+          onDismiss={() => setServerChanged(false)}
+        />
+      )}
       <FlowSubToolbar
         projectName={projectName}
         screenCount={screenCount}
@@ -720,6 +807,10 @@ function FlowEditorInner() {
         onRedo={handleRedo}
         canUndo={canUndo}
         canRedo={canRedo}
+        isDirty={isDirty}
+        isSaving={isSaving}
+        onSave={() => { handleSave().catch(console.error); }}
+        onReset={() => { handleReset().catch(console.error); }}
       />
 
       <div className="flow-canvas">

--- a/designer/src/components/flow/FlowSubToolbar.tsx
+++ b/designer/src/components/flow/FlowSubToolbar.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from "react";
+import { SaveResetButtons } from "../common/SaveResetButtons";
 
 export type ViewMode = "flow" | "table";
 
@@ -22,6 +23,10 @@ interface Props {
   onRedo?: () => void;
   canUndo?: boolean;
   canRedo?: boolean;
+  isDirty?: boolean;
+  isSaving?: boolean;
+  onSave?: () => void;
+  onReset?: () => void;
 }
 
 export function FlowSubToolbar({
@@ -30,6 +35,7 @@ export function FlowSubToolbar({
   onExportJSON, onImportJSON, onCopyMermaid, onExportMarkdown,
   onZoomChange, onFitView, onViewModeChange,
   onUndo, onRedo, canUndo, canRedo,
+  isDirty, isSaving, onSave, onReset,
 }: Props) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(projectName);
@@ -226,6 +232,14 @@ export function FlowSubToolbar({
         <button className="flow-btn flow-btn-primary" onClick={onAddScreen}>
           <i className="bi bi-plus-lg" /> 画面を追加
         </button>
+        {onSave && onReset && (
+          <SaveResetButtons
+            isDirty={!!isDirty}
+            isSaving={!!isSaving}
+            onSave={onSave}
+            onReset={onReset}
+          />
+        )}
       </div>
     </header>
   );

--- a/designer/src/grapes/remoteStorage.ts
+++ b/designer/src/grapes/remoteStorage.ts
@@ -2,19 +2,43 @@
  * remoteStorage.ts
  *
  * GrapesJS カスタムストレージマネージャー。
- * store() はlocalStorageのみに書き込む（変更キャッシュ）。
+ * store() はlocalStorageのみに書き込み、ドラフトマーカーをセットする（未保存状態）。
  * ファイルへの永続化は saveScreenToFile() を明示的に呼ぶことで行う。
+ * 画面を閉じて再オープンしたときドラフトマーカーがあれば localStorage を優先して復元する。
  */
 import type { Editor as GEditor } from "grapesjs";
 import { mcpBridge } from "../mcp/mcpBridge";
 import { screenStorageKey } from "../store/flowStore";
 
+/** ドラフトマーカーのキー（localStorage 内容が未保存であることを示す） */
+export function screenDraftMarkerKey(screenId: string): string {
+  return `gjs-screen-${screenId}-draft`;
+}
+
+/** 画面にドラフト（未保存編集）が残っているか */
+export function hasScreenDraft(screenId: string): boolean {
+  return localStorage.getItem(screenDraftMarkerKey(screenId)) === "1";
+}
+
+/** ドラフトマーカーを解除（明示保存成功時／リセット時に呼ぶ） */
+export function clearScreenDraft(screenId: string): void {
+  try { localStorage.removeItem(screenDraftMarkerKey(screenId)); } catch { /* ignore */ }
+}
+
 /** GrapesJS に "remote" ストレージタイプを登録 */
 export function registerRemoteStorage(editor: GEditor, screenId: string): void {
   const localKey = screenStorageKey(screenId);
+  const draftKey = screenDraftMarkerKey(screenId);
 
   editor.StorageManager.add("remote", {
     async load(): Promise<Record<string, unknown>> {
+      // ドラフトマーカーがあれば localStorage を優先（未保存の編集を復元）
+      if (localStorage.getItem(draftKey) === "1") {
+        const localRaw = localStorage.getItem(localKey);
+        if (localRaw) {
+          try { return JSON.parse(localRaw) as Record<string, unknown>; } catch { /* fallthrough */ }
+        }
+      }
       try {
         const data = await mcpBridge.request("loadScreen", { screenId }) as Record<string, unknown> | null;
         if (data && Object.keys(data).length > 0) {
@@ -41,7 +65,10 @@ export function registerRemoteStorage(editor: GEditor, screenId: string): void {
 
     async store(data: Record<string, unknown>): Promise<void> {
       // localStorage のみ（変更キャッシュ）。ファイル書き込みは saveScreenToFile() で行う
-      try { localStorage.setItem(localKey, JSON.stringify(data)); } catch { /* ignore */ }
+      try {
+        localStorage.setItem(localKey, JSON.stringify(data));
+        localStorage.setItem(draftKey, "1");
+      } catch { /* ignore */ }
     },
   });
 }
@@ -55,4 +82,5 @@ export async function saveScreenToFile(screenId: string): Promise<void> {
   }
   const data = JSON.parse(raw) as Record<string, unknown>;
   await mcpBridge.request("saveScreen", { screenId, data });
+  clearScreenDraft(screenId);
 }

--- a/designer/src/store/flowStore.ts
+++ b/designer/src/store/flowStore.ts
@@ -11,6 +11,7 @@
 import type { FlowProject, ScreenNode, ScreenEdge, ScreenGroup, ScreenType, TransitionTrigger } from "../types/flow";
 import { SCREEN_TYPE_LABELS, TRIGGER_LABELS } from "../types/flow";
 import { generateUUID } from "../utils/uuid";
+import { saveDraft, clearDraft, loadDraft } from "../utils/draftStorage";
 
 // ─── ストレージバックエンドインターフェース ────────────────────────────────
 
@@ -25,6 +26,41 @@ let _backend: FlowStorageBackend | null = null;
 /** mcpBridge が接続時にセット、切断時に null をセット */
 export function setFlowStorageBackend(b: FlowStorageBackend | null): void {
   _backend = b;
+}
+
+// ─── ドラフトモード（UI 起点の編集を localStorage ドラフトに流す） ─────────
+//
+// FlowEditor のような明示的保存画面で setDraftMode(true) を呼ぶと、
+// saveProject() は backend へ書かず draft-flow-project に書き込むようになる。
+// persistProject() を呼ぶと draft をクリアして backend に永続化する。
+
+const FLOW_DRAFT_KIND = "flow";
+const FLOW_DRAFT_ID = "project";
+
+let _draftMode = false;
+
+const _draftSaveListeners: Set<() => void> = new Set();
+
+export function setFlowDraftMode(enabled: boolean): void {
+  _draftMode = enabled;
+}
+
+export function isFlowDraftMode(): boolean {
+  return _draftMode;
+}
+
+export function loadFlowDraft(): FlowProject | null {
+  return loadDraft<FlowProject>(FLOW_DRAFT_KIND, FLOW_DRAFT_ID);
+}
+
+export function clearFlowDraft(): void {
+  clearDraft(FLOW_DRAFT_KIND, FLOW_DRAFT_ID);
+}
+
+/** draft モード中に saveProject が呼ばれると通知される（FlowEditor の isDirty 検知用） */
+export function subscribeToFlowDraftSaves(cb: () => void): () => void {
+  _draftSaveListeners.add(cb);
+  return () => _draftSaveListeners.delete(cb);
 }
 
 // ─── localStorage キー ────────────────────────────────────────────────────
@@ -133,14 +169,30 @@ export async function loadProject(): Promise<FlowProject> {
   })();
 }
 
-/** プロジェクトを保存 */
+/** プロジェクトを保存（draftMode 有効時は localStorage のドラフトに書き込む） */
 export async function saveProject(project: FlowProject): Promise<void> {
   project.updatedAt = now();
+  if (_draftMode) {
+    saveDraft(FLOW_DRAFT_KIND, FLOW_DRAFT_ID, project);
+    _draftSaveListeners.forEach((cb) => cb());
+    return;
+  }
   if (_backend) {
     await _backend.saveProject(project);
     return;
   }
   localStorage.setItem(FLOW_PROJECT_KEY, JSON.stringify(project));
+}
+
+/** ドラフトを介さず必ず永続化する（明示的保存ボタン用） */
+export async function persistProject(project: FlowProject): Promise<void> {
+  project.updatedAt = now();
+  if (_backend) {
+    await _backend.saveProject(project);
+  } else {
+    localStorage.setItem(FLOW_PROJECT_KEY, JSON.stringify(project));
+  }
+  clearDraft(FLOW_DRAFT_KIND, FLOW_DRAFT_ID);
 }
 
 /** 画面を追加 */


### PR DESCRIPTION
## Summary

Issue #84 の残作業の一環として、Designer (GrapesJS) と FlowEditor を明示保存/リセットモデルに移行。

**Designer (GrapesJS 画面):**
- `gjs-screen-{id}-draft` マーカーで未保存状態を localStorage に記録
- タブを閉じて再オープンしても編集中の状態を復元（マーカーがあれば localStorage 優先）
- `handleReset` でマーカー破棄 + `editor.load()` で backend から再ロード + UndoManager クリア
- `DesignSubToolbar` の独自保存ボタンを共通 `SaveResetButtons` に置換
- 他クライアントの `screenChanged` 通知は `isDirty` 中はバナー表示、clean なら即リロード
- 既存の「保存済み」インジケータは維持（アクセント表示）

**FlowEditor (画面フロー):**
- `flowStore` に `draftMode` を導入（UI 起点の `saveProject` は `draft-flow-project` に書き込み、backend には書かない）
- `subscribeToFlowDraftSaves` で draft 保存を検知して `isDirty` を立てる
- `persistProject()` で明示的に永続化し draft をクリア
- `handleReset` で draft 破棄 + backend から再ロード + undo/redo 履歴クリア
- `projectChanged` / MCP 経由のフロー変更は `isDirty` 中はバナー表示、clean なら即リロード
- Ctrl+S で保存、`FlowSubToolbar` 右端に `SaveResetButtons`、最上段に `ServerChangeBanner`
- `reloadProject` はドラフトが存在すればドラフトを優先

## Test plan

- [x] TypeScript: `npx tsc --noEmit` エラーなし
- [x] Vitest: 55 件すべて pass
- [x] 新規 E2E テスト `save-reset-flow.spec.ts` 6件すべて pass
  - 初期状態ではボタン無効
  - 画面追加後にボタン有効化
  - リセット確認キャンセル → 編集保持
  - リセット確認承認 → 元に戻る
  - Ctrl+S で保存 → ボタン無効化
  - 事前ドラフトあり → リロード後も isDirty 復元
- [x] 既存テスト `save-reset.spec.ts` 9件すべて pass
- [x] 全 Playwright 36/37 pass（`tab-management.spec.ts` の「Ctrl+Tab で次のタブに移動する」1件は origin/main でも同様に失敗する**プレ既存の flaky テスト**で、本 PR と無関係であることを worktree で確認済み）

## 依存関係

- #91（リセット確認ダイアログの fix）を含む（ベースとしてリベース済み）
- Issue #84 の残作業: PR 3 でサーバー差分検知の mtime クエリ + tabStore hasDraft + ErDiagram debounce 廃止を予定

関連: #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)