### PR TITLE
feat(sync): サーバーファイル mtime クエリと差分検知を実装 (#84)

### DIFF
--- a/designer-mcp/src/projectStorage.ts
+++ b/designer-mcp/src/projectStorage.ts
@@ -53,6 +53,30 @@ export async function writeProject(project: unknown): Promise<void> {
   await writeJSON(PROJECT_FILE, project);
 }
 
+/** 各種データファイルの更新時刻を取得（存在しないなら null） */
+export async function getFileMtime(kind: string, id?: string): Promise<number | null> {
+  const filePath = resolveDataFile(kind, id);
+  if (!filePath) return null;
+  try {
+    const stat = await fs.stat(filePath);
+    return stat.mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+function resolveDataFile(kind: string, id?: string): string | null {
+  switch (kind) {
+    case "project": return PROJECT_FILE;
+    case "erLayout": return ER_LAYOUT_FILE;
+    case "customBlocks": return CUSTOM_BLOCKS_FILE;
+    case "screen": return id ? path.join(SCREENS_DIR, `${id}.json`) : null;
+    case "table": return id ? path.join(TABLES_DIR, `${id}.json`) : null;
+    case "actionGroup": return id ? path.join(ACTIONS_DIR, `${id}.json`) : null;
+    default: return null;
+  }
+}
+
 /** screens/{screenId}.json を読み込み */
 export async function readScreen(screenId: string): Promise<unknown | null> {
   return readJSON<unknown>(path.join(SCREENS_DIR, `${screenId}.json`));

--- a/designer-mcp/src/wsBridge.ts
+++ b/designer-mcp/src/wsBridge.ts
@@ -20,6 +20,7 @@ import {
   writeActionGroup,
   deleteActionGroup as deleteActionGroupFile,
   listActionGroups as listActionGroupFiles,
+  getFileMtime,
 } from "./projectStorage.js";
 
 type Command = { id: string; method: string; params?: unknown };
@@ -382,6 +383,12 @@ class WsBridge extends EventEmitter {
             updatedAt: ag.updatedAt,
           }));
           respond(metas);
+          break;
+        }
+        case "getFileMtime": {
+          const { kind, id: fid } = (params ?? {}) as { kind: string; id?: string };
+          const mtime = await getFileMtime(kind, fid);
+          respond({ mtime });
           break;
         }
         default:

--- a/designer/e2e/mcp/mcp-tools.spec.ts
+++ b/designer/e2e/mcp/mcp-tools.spec.ts
@@ -138,4 +138,77 @@ test.describe("wsBridge ファイル操作", () => {
     const loadResult = await sendBrowserRequest("loadScreen", { screenId });
     expect(loadResult).toBeNull();
   });
+
+  /**
+   * getFileMtime は本 PR で追加した新しい MCP メソッド。
+   * designer-mcp が古いビルドで起動していると「未知のメソッド」エラーが返るため、
+   * 本テストスイートはその場合は skip する。
+   */
+  async function supportsGetFileMtime(): Promise<boolean> {
+    try {
+      await sendBrowserRequest("getFileMtime", { kind: "project" });
+      return true;
+    } catch (e) {
+      if (String(e).includes("未知のリクエストメソッド")) return false;
+      return true;
+    }
+  }
+
+  test.describe("getFileMtime", () => {
+    test.beforeEach(async () => {
+      const supported = await supportsGetFileMtime();
+      if (!supported) test.skip(true, "designer-mcp に getFileMtime が実装されていません。再起動してください");
+    });
+
+    test("既存スクリーンの mtime が取得できる", async () => {
+      const screenId = "e2e-test-mtime-001";
+      await sendBrowserRequest("saveScreen", { screenId, data: { pages: [] } });
+
+      const result = (await sendBrowserRequest("getFileMtime", {
+        kind: "screen",
+        id: screenId,
+      })) as { mtime: number | null };
+      expect(result.mtime).not.toBeNull();
+      expect(typeof result.mtime).toBe("number");
+
+      await sendBrowserRequest("deleteScreen", { screenId });
+    });
+
+    test("存在しないファイルは null が返る", async () => {
+      const result = (await sendBrowserRequest("getFileMtime", {
+        kind: "screen",
+        id: "nonexistent-screen-xyz",
+      })) as { mtime: number | null };
+      expect(result.mtime).toBeNull();
+    });
+
+    test("未知の kind は null が返る", async () => {
+      const result = (await sendBrowserRequest("getFileMtime", {
+        kind: "unknown-kind",
+      })) as { mtime: number | null };
+      expect(result.mtime).toBeNull();
+    });
+
+    test("saveScreen 後の mtime は以前の mtime 以上", async () => {
+      const screenId = "e2e-test-mtime-increment-001";
+      await sendBrowserRequest("saveScreen", { screenId, data: { pages: [] } });
+      const r1 = (await sendBrowserRequest("getFileMtime", {
+        kind: "screen",
+        id: screenId,
+      })) as { mtime: number };
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      await sendBrowserRequest("saveScreen", {
+        screenId,
+        data: { pages: [{ frames: [] }] },
+      });
+      const r2 = (await sendBrowserRequest("getFileMtime", {
+        kind: "screen",
+        id: screenId,
+      })) as { mtime: number };
+
+      expect(r2.mtime).toBeGreaterThanOrEqual(r1.mtime);
+      await sendBrowserRequest("deleteScreen", { screenId });
+    });
+  });
 });

--- a/designer/e2e/save-reset-flow.spec.ts
+++ b/designer/e2e/save-reset-flow.spec.ts
@@ -40,7 +40,8 @@ async function setupFlowEditor(page: Page, draft: object | null = null) {
 }
 
 async function addScreenViaModal(page: Page, name: string) {
-  await page.getByRole("button", { name: /画面を追加/ }).click();
+  // ツールバーの「画面を追加」（空状態 CTA "最初の画面を追加" とは別）
+  await page.locator('.flow-topbar-right button.flow-btn-primary').filter({ hasText: "画面を追加" }).click();
   await page.locator("#screen-name").fill(name);
   await page.locator('.flow-modal button[type="submit"]').click();
 }

--- a/designer/src/components/Designer.tsx
+++ b/designer/src/components/Designer.tsx
@@ -12,6 +12,7 @@ import "grapesjs/dist/css/grapes.min.css";
 import { registerBlocks } from "../grapes/blocks";
 import { registerValidationTraits } from "../grapes/validationTraits";
 import { registerRemoteStorage, saveScreenToFile, hasScreenDraft, clearScreenDraft } from "../grapes/remoteStorage";
+import { acknowledgeServerMtime, hasServerBeenUpdated } from "../utils/serverMtime";
 import { DesignSubToolbar } from "./design/DesignSubToolbar";
 import { BlocksPanel } from "./BlocksPanel";
 import { RightPanel } from "./RightPanel";
@@ -321,6 +322,7 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
       isDirtyRef.current = false;
       setDirty(tabId, false);
       setServerChanged(false);
+      await acknowledgeServerMtime("screen", screenId);
     } catch (e) {
       console.error("[Designer] saveToFile failed:", e);
       alert("保存に失敗しました: " + String(e));
@@ -341,11 +343,26 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
       isDirtyRef.current = false;
       setDirty(tabId, false);
       setServerChanged(false);
+      await acknowledgeServerMtime("screen", screenId);
     } catch (e) {
       console.error("[Designer] reset failed:", e);
       alert("リセットに失敗しました: " + String(e));
     }
   }, [screenId, tabId]);
+
+  // タブを開いた時点でサーバーに新しい変更がないか確認（初回ロード完了後）
+  useEffect(() => {
+    if (!ready) return;
+    (async () => {
+      if (hasScreenDraft(screenId)) {
+        if (await hasServerBeenUpdated("screen", screenId)) {
+          setServerChanged(true);
+        }
+      } else {
+        await acknowledgeServerMtime("screen", screenId);
+      }
+    })();
+  }, [ready, screenId]);
 
   return (
     <GjsEditor

--- a/designer/src/components/action/ActionEditor.tsx
+++ b/designer/src/components/action/ActionEditor.tsx
@@ -54,7 +54,8 @@ import { TableSubToolbar } from "../table/TableSubToolbar";
 import { SortableStepCard } from "./SortableStepCard";
 import { SaveResetButtons } from "../common/SaveResetButtons";
 import { ServerChangeBanner } from "../common/ServerChangeBanner";
-import { saveDraft, loadDraft, clearDraft } from "../../utils/draftStorage";
+import { saveDraft, loadDraft, clearDraft, hasDraft } from "../../utils/draftStorage";
+import { acknowledgeServerMtime, hasServerBeenUpdated } from "../../utils/serverMtime";
 import "../../styles/action.css";
 
 /** ツールバーのドラッグ可能なステップ種別ボタン */
@@ -204,12 +205,22 @@ export function ActionEditor() {
 
   useEffect(() => {
     mcpBridge.startWithoutEditor();
-    reload();
+    reload().then(async () => {
+      if (!actionGroupId) return;
+      // タブを開いた時点でサーバー側に新しい変更がないか確認
+      if (hasDraft("action", actionGroupId)) {
+        if (await hasServerBeenUpdated("actionGroup", actionGroupId)) {
+          setServerChanged(true);
+        }
+      } else {
+        await acknowledgeServerMtime("actionGroup", actionGroupId);
+      }
+    }).catch(console.error);
     const unsubStatus = mcpBridge.onStatusChange((s) => {
       if (s === "connected") reload();
     });
     return unsubStatus;
-  }, [reload]);
+  }, [reload, actionGroupId]);
 
   useEffect(() => {
     if (!actionGroupId) return;
@@ -246,7 +257,10 @@ export function ActionEditor() {
     try {
       await saveActionGroup(group);
       lastSavedRef.current = group;
-      if (actionGroupId) clearDraft("action", actionGroupId);
+      if (actionGroupId) {
+        clearDraft("action", actionGroupId);
+        await acknowledgeServerMtime("actionGroup", actionGroupId);
+      }
       setIsDirty(false);
     } finally {
       setIsSaving(false);
@@ -256,7 +270,8 @@ export function ActionEditor() {
   const handleReset = useCallback(async () => {
     await reload(true);
     setServerChanged(false);
-  }, [reload]);
+    if (actionGroupId) await acknowledgeServerMtime("actionGroup", actionGroupId);
+  }, [reload, actionGroupId]);
 
   /** 構造変化（履歴に積む）: ステップ追加・削除・移動、アクション追加・削除 */
   const updateGroup = useCallback(

--- a/designer/src/components/flow/FlowEditor.tsx
+++ b/designer/src/components/flow/FlowEditor.tsx
@@ -54,6 +54,8 @@ import { mcpBridge } from "../../mcp/mcpBridge";
 import { useUndoKeyboard } from "../../hooks/useUndoKeyboard";
 import { openTab, makeTabId } from "../../store/tabStore";
 import { ServerChangeBanner } from "../common/ServerChangeBanner";
+import { acknowledgeServerMtime, hasServerBeenUpdated } from "../../utils/serverMtime";
+import { hasDraft } from "../../utils/draftStorage";
 import "../../styles/flow.css";
 
 const nodeTypes = {
@@ -254,7 +256,16 @@ function FlowEditorInner() {
     mcpBridge.startWithoutEditor();
 
     // 初回ロード（WS 未接続時は localStorage フォールバック）
-    reloadProject().catch(console.error);
+    reloadProject().then(async () => {
+      // タブを開いた時点でサーバー側に新しい変更がないか確認
+      if (hasDraft("flow", "project")) {
+        if (await hasServerBeenUpdated("project")) {
+          if (mounted) setServerChanged(true);
+        }
+      } else {
+        await acknowledgeServerMtime("project");
+      }
+    }).catch(console.error);
 
     return () => {
       mounted = false;
@@ -744,6 +755,7 @@ function FlowEditorInner() {
       setIsDirty(false);
       isDirtyRef.current = false;
       setServerChanged(false);
+      await acknowledgeServerMtime("project");
     } catch (e) {
       console.error("[FlowEditor] save failed:", e);
       alert("保存に失敗しました: " + String(e));
@@ -760,6 +772,7 @@ function FlowEditorInner() {
     setCanRedo(false);
     await reloadProject();
     setServerChanged(false);
+    await acknowledgeServerMtime("project");
   }, [reloadProject]);
 
   // Ctrl+S で保存

--- a/designer/src/components/table/TableEditor.tsx
+++ b/designer/src/components/table/TableEditor.tsx
@@ -10,7 +10,8 @@ import { mcpBridge } from "../../mcp/mcpBridge";
 import { useUndoableState } from "../../hooks/useUndoableState";
 import { useUndoKeyboard } from "../../hooks/useUndoKeyboard";
 import { setDirty as setTabDirty, makeTabId } from "../../store/tabStore";
-import { saveDraft, loadDraft, clearDraft } from "../../utils/draftStorage";
+import { saveDraft, loadDraft, clearDraft, hasDraft } from "../../utils/draftStorage";
+import { acknowledgeServerMtime, hasServerBeenUpdated } from "../../utils/serverMtime";
 import { SaveResetButtons } from "../common/SaveResetButtons";
 import { ServerChangeBanner } from "../common/ServerChangeBanner";
 import "../../styles/table.css";
@@ -65,6 +66,14 @@ export function TableEditor() {
         setIsDirty(false);
         setTabDirty(makeTabId("table", tableId), false);
       }
+      // タブを開いた時点でサーバー側に新しい変更がないか確認（ドラフトが古い版に基づいている場合に備えて）
+      if (hasDraft("table", tableId)) {
+        if (await hasServerBeenUpdated("table", tableId)) {
+          setServerChanged(true);
+        }
+      } else {
+        await acknowledgeServerMtime("table", tableId);
+      }
       const tl = await listTables();
       const allTds: TableDefinition[] = [];
       for (const m of tl) {
@@ -110,16 +119,17 @@ export function TableEditor() {
   }, [updateAndCommit, tableId]);
 
   const handleSave = useCallback(async () => {
-    if (!table) return;
+    if (!table || !tableId) return;
     setIsSaving(true);
     try {
       await saveTable(table);
       lastSavedRef.current = table;
       markClean();
+      await acknowledgeServerMtime("table", tableId);
     } finally {
       setIsSaving(false);
     }
-  }, [table, markClean]);
+  }, [table, tableId, markClean]);
 
   const handleReset = useCallback(async () => {
     if (!tableId) return;
@@ -129,6 +139,7 @@ export function TableEditor() {
     resetTable(t);
     markClean();
     setServerChanged(false);
+    await acknowledgeServerMtime("table", tableId);
   }, [tableId, resetTable, markClean]);
 
   const handleServerReload = useCallback(async () => {

--- a/designer/src/utils/draftStorage.test.ts
+++ b/designer/src/utils/draftStorage.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { saveDraft, loadDraft, clearDraft } from "./draftStorage";
+import { saveDraft, loadDraft, clearDraft, listAllDrafts, hasDraft } from "./draftStorage";
 
 describe("saveDraft / loadDraft", () => {
   it("保存したデータを読み込める", () => {
@@ -66,5 +66,52 @@ describe("clearDraft", () => {
     clearDraft("table", "abc");
     saveDraft("table", "abc", { name: "new" });
     expect(loadDraft("table", "abc")).toEqual({ name: "new" });
+  });
+});
+
+describe("hasDraft", () => {
+  it("保存済みキーは true", () => {
+    saveDraft("table", "abc", { name: "users" });
+    expect(hasDraft("table", "abc")).toBe(true);
+  });
+
+  it("未保存キーは false", () => {
+    expect(hasDraft("table", "nonexistent")).toBe(false);
+  });
+
+  it("削除後は false", () => {
+    saveDraft("table", "abc", { name: "users" });
+    clearDraft("table", "abc");
+    expect(hasDraft("table", "abc")).toBe(false);
+  });
+});
+
+describe("listAllDrafts", () => {
+  it("draft-* キーだけ列挙する（他の localStorage キーは無視）", () => {
+    localStorage.setItem("other-key", "ignored");
+    saveDraft("table", "abc", { name: "users" });
+    saveDraft("action", "xyz", { name: "actions" });
+    const drafts = listAllDrafts();
+    expect(drafts.map((d) => d.key).sort()).toEqual(["draft-action-xyz", "draft-table-abc"]);
+  });
+
+  it("UUID（ハイフン含み）を正しく kind/id に分解する", () => {
+    const uuid = "aaaaaaaa-0001-4000-8000-000000000001";
+    saveDraft("table", uuid, { name: "x" });
+    const drafts = listAllDrafts();
+    const d = drafts.find((x) => x.kind === "table" && x.id === uuid);
+    expect(d).toBeDefined();
+  });
+
+  it("各ドラフトのサイズを返す", () => {
+    saveDraft("flow", "project", { foo: "bar" });
+    const drafts = listAllDrafts();
+    const d = drafts.find((x) => x.kind === "flow" && x.id === "project");
+    expect(d?.size).toBeGreaterThan(0);
+  });
+
+  it("ドラフトが無ければ空配列", () => {
+    // beforeEach で localStorage.clear() されているので空のまま
+    expect(listAllDrafts()).toEqual([]);
   });
 });

--- a/designer/src/utils/draftStorage.ts
+++ b/designer/src/utils/draftStorage.ts
@@ -16,3 +16,39 @@ export function clearDraft(kind: string, id: string): void {
     localStorage.removeItem(`draft-${kind}-${id}`);
   } catch { /* ignore */ }
 }
+
+export interface DraftMeta {
+  kind: string;
+  id: string;
+  key: string;
+  size: number;
+}
+
+/** localStorage 内の全ドラフトを列挙（Issue D ダッシュボードの未永続化ドラフトパネル等で使用） */
+export function listAllDrafts(): DraftMeta[] {
+  const out: DraftMeta[] = [];
+  try {
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (!key || !key.startsWith("draft-")) continue;
+      // "draft-<kind>-<id>" の id 部分は UUID でハイフンを含むため、最初のハイフンで split
+      const rest = key.slice("draft-".length);
+      const firstDash = rest.indexOf("-");
+      if (firstDash < 0) continue;
+      const kind = rest.slice(0, firstDash);
+      const id = rest.slice(firstDash + 1);
+      const value = localStorage.getItem(key) ?? "";
+      out.push({ kind, id, key, size: value.length });
+    }
+  } catch { /* ignore */ }
+  return out;
+}
+
+/** 指定 kind/id にドラフトが存在するか */
+export function hasDraft(kind: string, id: string): boolean {
+  try {
+    return localStorage.getItem(`draft-${kind}-${id}`) !== null;
+  } catch {
+    return false;
+  }
+}

--- a/designer/src/utils/serverMtime.test.ts
+++ b/designer/src/utils/serverMtime.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import {
+  getLastSeenMtime,
+  setLastSeenMtime,
+  clearLastSeenMtime,
+} from "./serverMtime";
+
+describe("getLastSeenMtime / setLastSeenMtime / clearLastSeenMtime", () => {
+  it("保存した mtime を取得できる", () => {
+    setLastSeenMtime("table", "abc", 12345);
+    expect(getLastSeenMtime("table", "abc")).toBe(12345);
+  });
+
+  it("id なし（project 等）の kind でも動作する", () => {
+    setLastSeenMtime("project", undefined, 999);
+    expect(getLastSeenMtime("project")).toBe(999);
+  });
+
+  it("未保存のキーは null を返す", () => {
+    expect(getLastSeenMtime("table", "nonexistent")).toBeNull();
+  });
+
+  it("clearLastSeenMtime で削除できる", () => {
+    setLastSeenMtime("table", "abc", 12345);
+    clearLastSeenMtime("table", "abc");
+    expect(getLastSeenMtime("table", "abc")).toBeNull();
+  });
+
+  it("kind と id が独立したキーに保存される", () => {
+    setLastSeenMtime("table", "abc", 1);
+    setLastSeenMtime("table", "def", 2);
+    setLastSeenMtime("actionGroup", "abc", 3);
+    expect(getLastSeenMtime("table", "abc")).toBe(1);
+    expect(getLastSeenMtime("table", "def")).toBe(2);
+    expect(getLastSeenMtime("actionGroup", "abc")).toBe(3);
+  });
+
+  it("上書き保存できる", () => {
+    setLastSeenMtime("screen", "s1", 100);
+    setLastSeenMtime("screen", "s1", 200);
+    expect(getLastSeenMtime("screen", "s1")).toBe(200);
+  });
+});

--- a/designer/src/utils/serverMtime.ts
+++ b/designer/src/utils/serverMtime.ts
@@ -1,0 +1,75 @@
+/**
+ * serverMtime.ts
+ *
+ * サーバー側ファイルの更新時刻 (mtime) を取得するユーティリティ。
+ * タブを開いた/フォーカスした時のサーバー差分検知、
+ * 未保存ドラフトが古いバージョン由来かどうかの判定に使用する。
+ */
+import { mcpBridge } from "../mcp/mcpBridge";
+
+export type MtimeKind = "project" | "screen" | "table" | "actionGroup" | "erLayout" | "customBlocks";
+
+const LAST_SEEN_PREFIX = "mtime-";
+
+/** サーバーから最新の mtime を取得（未接続または未存在なら null） */
+export async function fetchServerMtime(kind: MtimeKind, id?: string): Promise<number | null> {
+  try {
+    const res = await mcpBridge.request("getFileMtime", { kind, id }) as { mtime: number | null };
+    return res?.mtime ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function lastSeenKey(kind: MtimeKind, id?: string): string {
+  return `${LAST_SEEN_PREFIX}${kind}${id ? `-${id}` : ""}`;
+}
+
+/** ブラウザが最後に認識したサーバー mtime を取得 */
+export function getLastSeenMtime(kind: MtimeKind, id?: string): number | null {
+  try {
+    const raw = localStorage.getItem(lastSeenKey(kind, id));
+    return raw ? Number(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** 最後に認識したサーバー mtime を記録 */
+export function setLastSeenMtime(kind: MtimeKind, id: string | undefined, mtime: number): void {
+  try {
+    localStorage.setItem(lastSeenKey(kind, id), String(mtime));
+  } catch { /* ignore */ }
+}
+
+export function clearLastSeenMtime(kind: MtimeKind, id?: string): void {
+  try {
+    localStorage.removeItem(lastSeenKey(kind, id));
+  } catch { /* ignore */ }
+}
+
+/**
+ * サーバーと比較し、前回認識時より新しければ true を返す。
+ * 戻り値が true の場合、呼び出し側はバナー表示等の対応を行う想定。
+ * 初回（前回認識なし）は常に false を返し、現在の mtime を記録する。
+ */
+export async function hasServerBeenUpdated(kind: MtimeKind, id?: string): Promise<boolean> {
+  const current = await fetchServerMtime(kind, id);
+  if (current === null) return false;
+  const last = getLastSeenMtime(kind, id);
+  if (last === null) {
+    setLastSeenMtime(kind, id, current);
+    return false;
+  }
+  if (current > last) {
+    // 更新を検知しても lastSeen は呼び出し側が「認識した」と明示するまで更新しない
+    return true;
+  }
+  return false;
+}
+
+/** 呼び出し側が「変更を認識した」として lastSeen を現在値に追従させる */
+export async function acknowledgeServerMtime(kind: MtimeKind, id?: string): Promise<void> {
+  const current = await fetchServerMtime(kind, id);
+  if (current !== null) setLastSeenMtime(kind, id, current);
+}


### PR DESCRIPTION
## Summary

Issue #84 の残作業の最終段。タブを開いた/フォーカスした時点でサーバー側のファイル更新を検知し、ドラフトが古い版に基づいている場合は `ServerChangeBanner` を表示する。

**注**: 元 PR #93 は base branch (feat/issue-84-designer-flow-migration) が削除されて自動クローズされたため、main 向けに再作成。

### designer-mcp 側

- `projectStorage` に `getFileMtime(kind, id)` を追加（project / screen / table / actionGroup / erLayout / customBlocks 対応）
- `wsBridge` に `getFileMtime` リクエストハンドラを追加

### designer 側

- **`utils/serverMtime.ts`** （新規）
  - `fetchServerMtime` / `hasServerBeenUpdated` / `acknowledgeServerMtime`
- **`utils/draftStorage.ts`** 拡張
  - `listAllDrafts` / `hasDraft`
- TableEditor / ActionEditor / Designer / FlowEditor に統合
  - タブ open 時: ドラフトがあればサーバー差分を確認
  - 保存・リセット時: lastSeen mtime を最新値に追従

## Test plan

- [x] TypeScript: エラーなし
- [x] Vitest: 68/68 pass（新規 13 件）
- [x] Playwright: 15/15 pass (save-reset 系)
- [x] MCP E2E: 8/8 pass（`getFileMtime` 4 件が実 designer-mcp で実行成功）

関連: #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)