### PR TITLE
improve: Ctrl+S を useSaveShortcut フックに統一 (#97)

### DIFF
--- a/designer/src/components/action/ActionEditor.tsx
+++ b/designer/src/components/action/ActionEditor.tsx
@@ -48,6 +48,7 @@ import {
 } from "@dnd-kit/sortable";
 import { useUndoableState } from "../../hooks/useUndoableState";
 import { useUndoKeyboard } from "../../hooks/useUndoKeyboard";
+import { useSaveShortcut } from "../../hooks/useSaveShortcut";
 import { useSelectionKeyboard } from "../../hooks/useSelectionKeyboard";
 import { STEP_TYPE_COLORS } from "../../types/action";
 import { TableSubToolbar } from "../table/TableSubToolbar";
@@ -230,16 +231,8 @@ export function ActionEditor() {
     });
   }, [actionGroupId]);
 
-  // Ctrl+S for save
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if ((e.ctrlKey || e.metaKey) && e.key === "s") {
-        e.preventDefault();
-        if (isDirty && !isSaving) handleSave();
-      }
-    };
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
+  useSaveShortcut(() => {
+    if (isDirty && !isSaving) handleSave();
   });
 
   useEffect(() => {

--- a/designer/src/components/design/DesignSubToolbar.tsx
+++ b/designer/src/components/design/DesignSubToolbar.tsx
@@ -5,6 +5,7 @@ import type { McpStatus } from "../../mcp/mcpBridge";
 import { CodeEditorModal } from "../CodeEditorModal";
 import { SaveBlockModal } from "../SaveBlockModal";
 import { SaveResetButtons } from "../common/SaveResetButtons";
+import { useSaveShortcut } from "../../hooks/useSaveShortcut";
 import { upsertCustomBlock } from "../../store/customBlockStore";
 
 export const CUSTOM_BLOCK_CATEGORY = "マイブロック";
@@ -219,10 +220,7 @@ ${html}
 
       const ctrl = e.ctrlKey || e.metaKey;
 
-      if (ctrl && e.key === "s") {
-        e.preventDefault();
-        onSaveToFile?.();
-      } else if (ctrl && e.key === "p") {
+      if (ctrl && e.key === "p") {
         e.preventDefault();
         editor.runCommand("preview");
       } else if (ctrl && e.key === "d") {
@@ -255,7 +253,11 @@ ${html}
 
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [editor, onSaveToFile]);
+  }, [editor]);
+
+  useSaveShortcut(() => {
+    void onSaveToFile?.();
+  });
 
   return (
     <header className="topbar">

--- a/designer/src/components/flow/FlowEditor.tsx
+++ b/designer/src/components/flow/FlowEditor.tsx
@@ -52,6 +52,7 @@ import {
 } from "../../store/flowStore";
 import { mcpBridge } from "../../mcp/mcpBridge";
 import { useUndoKeyboard } from "../../hooks/useUndoKeyboard";
+import { useSaveShortcut } from "../../hooks/useSaveShortcut";
 import { openTab, makeTabId } from "../../store/tabStore";
 import { ServerChangeBanner } from "../common/ServerChangeBanner";
 import { acknowledgeServerMtime, hasServerBeenUpdated } from "../../utils/serverMtime";
@@ -775,19 +776,9 @@ function FlowEditorInner() {
     await acknowledgeServerMtime("project");
   }, [reloadProject]);
 
-  // Ctrl+S で保存
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if ((e.ctrlKey || e.metaKey) && e.key === "s") {
-        const t = e.target as HTMLElement;
-        if (t.tagName === "INPUT" || t.tagName === "TEXTAREA" || t.isContentEditable) return;
-        e.preventDefault();
-        if (isDirty && !isSaving) handleSave();
-      }
-    };
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
-  }, [isDirty, isSaving, handleSave]);
+  useSaveShortcut(() => {
+    if (isDirty && !isSaving) handleSave();
+  });
 
   const isEmpty = !isLoading && nodes.filter((n) => n.type === "screenNode").length === 0;
   const screenCount = nodes.filter((n) => n.type === "screenNode").length;

--- a/designer/src/components/table/TableEditor.tsx
+++ b/designer/src/components/table/TableEditor.tsx
@@ -9,6 +9,7 @@ import { generateDdl, generateTableMarkdown } from "../../utils/ddlGenerator";
 import { mcpBridge } from "../../mcp/mcpBridge";
 import { useUndoableState } from "../../hooks/useUndoableState";
 import { useUndoKeyboard } from "../../hooks/useUndoKeyboard";
+import { useSaveShortcut } from "../../hooks/useSaveShortcut";
 import { setDirty as setTabDirty, makeTabId } from "../../store/tabStore";
 import { saveDraft, loadDraft, clearDraft, hasDraft } from "../../utils/draftStorage";
 import { acknowledgeServerMtime, hasServerBeenUpdated } from "../../utils/serverMtime";
@@ -92,16 +93,8 @@ export function TableEditor() {
     });
   }, [tableId]);
 
-  // Ctrl+S for save
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if ((e.ctrlKey || e.metaKey) && e.key === "s") {
-        e.preventDefault();
-        if (isDirty && !isSaving) handleSave();
-      }
-    };
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
+  useSaveShortcut(() => {
+    if (isDirty && !isSaving) handleSave();
   });
 
   const update = useCallback((fn: (t: TableDefinition) => void) => {

--- a/designer/src/hooks/useSaveShortcut.test.ts
+++ b/designer/src/hooks/useSaveShortcut.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { shouldTriggerSaveShortcut } from "./useSaveShortcut";
+
+function makeEvent(overrides: {
+  ctrlKey?: boolean;
+  metaKey?: boolean;
+  key?: string;
+  targetTag?: string;
+  isContentEditable?: boolean;
+}) {
+  const target = overrides.targetTag
+    ? ({ tagName: overrides.targetTag, isContentEditable: overrides.isContentEditable ?? false } as unknown as HTMLElement)
+    : null;
+  return {
+    ctrlKey: overrides.ctrlKey ?? false,
+    metaKey: overrides.metaKey ?? false,
+    key: overrides.key ?? "s",
+    target,
+  } as const;
+}
+
+describe("shouldTriggerSaveShortcut", () => {
+  it("Ctrl+S で true を返す", () => {
+    expect(shouldTriggerSaveShortcut(makeEvent({ ctrlKey: true, key: "s" }))).toBe(true);
+  });
+
+  it("Cmd+S（metaKey）で true を返す", () => {
+    expect(shouldTriggerSaveShortcut(makeEvent({ metaKey: true, key: "s" }))).toBe(true);
+  });
+
+  it("修飾キーなしの s では false を返す", () => {
+    expect(shouldTriggerSaveShortcut(makeEvent({ key: "s" }))).toBe(false);
+  });
+
+  it("Ctrl+他キー では false を返す", () => {
+    expect(shouldTriggerSaveShortcut(makeEvent({ ctrlKey: true, key: "a" }))).toBe(false);
+    expect(shouldTriggerSaveShortcut(makeEvent({ ctrlKey: true, key: "S" }))).toBe(false);
+  });
+
+  it("INPUT にフォーカスがあるとき false を返す", () => {
+    expect(
+      shouldTriggerSaveShortcut(makeEvent({ ctrlKey: true, key: "s", targetTag: "INPUT" })),
+    ).toBe(false);
+  });
+
+  it("TEXTAREA にフォーカスがあるとき false を返す", () => {
+    expect(
+      shouldTriggerSaveShortcut(makeEvent({ ctrlKey: true, key: "s", targetTag: "TEXTAREA" })),
+    ).toBe(false);
+  });
+
+  it("SELECT にフォーカスがあるとき false を返す", () => {
+    expect(
+      shouldTriggerSaveShortcut(makeEvent({ ctrlKey: true, key: "s", targetTag: "SELECT" })),
+    ).toBe(false);
+  });
+
+  it("contentEditable 要素にフォーカスがあるとき false を返す", () => {
+    expect(
+      shouldTriggerSaveShortcut(
+        makeEvent({ ctrlKey: true, key: "s", targetTag: "DIV", isContentEditable: true }),
+      ),
+    ).toBe(false);
+  });
+
+  it("allowInForm=true のとき INPUT でも true を返す", () => {
+    expect(
+      shouldTriggerSaveShortcut(
+        makeEvent({ ctrlKey: true, key: "s", targetTag: "INPUT" }),
+        true,
+      ),
+    ).toBe(true);
+  });
+
+  it("target が null（body 等）のとき true を返す", () => {
+    expect(shouldTriggerSaveShortcut(makeEvent({ ctrlKey: true, key: "s" }))).toBe(true);
+  });
+
+  it("BUTTON にフォーカス中は true を返す（フォーム要素外）", () => {
+    expect(
+      shouldTriggerSaveShortcut(makeEvent({ ctrlKey: true, key: "s", targetTag: "BUTTON" })),
+    ).toBe(true);
+  });
+});

--- a/designer/src/hooks/useSaveShortcut.ts
+++ b/designer/src/hooks/useSaveShortcut.ts
@@ -1,0 +1,52 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * キーイベントが「保存ショートカット」として発火すべきかを判定する純関数。
+ * デフォルトでは `<input>` / `<textarea>` / `<select>` / contenteditable に
+ * フォーカスがあるときは発火しない（フォーム編集中の誤保存を防ぐ）。
+ *
+ * テスト容易性のためエクスポートしている。
+ */
+export function shouldTriggerSaveShortcut(
+  e: Pick<KeyboardEvent, "ctrlKey" | "metaKey" | "key" | "target">,
+  allowInForm = false,
+): boolean {
+  const ctrl = e.ctrlKey || e.metaKey;
+  if (!ctrl || e.key !== "s") return false;
+  if (allowInForm) return true;
+
+  const target = e.target as HTMLElement | null;
+  const tag = target?.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return false;
+  if (target?.isContentEditable) return false;
+  return true;
+}
+
+/**
+ * Ctrl+S / Cmd+S で保存ハンドラを呼ぶキーバインドフック。
+ *
+ * @param onSave 保存ハンドラ
+ * @param enabled false のとき登録しない
+ * @param allowInForm true なら INPUT/TEXTAREA 上でも発火させる
+ */
+export function useSaveShortcut(
+  onSave: () => void,
+  enabled = true,
+  allowInForm = false,
+): void {
+  const onSaveRef = useRef(onSave);
+  onSaveRef.current = onSave;
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handler = (e: KeyboardEvent) => {
+      if (!shouldTriggerSaveShortcut(e, allowInForm)) return;
+      e.preventDefault();
+      onSaveRef.current();
+    };
+
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [enabled, allowInForm]);
+}


### PR DESCRIPTION
Closes #97

## Summary

- 4 エディタ（Designer / FlowEditor / TableEditor / ActionEditor）に個別実装されていた Ctrl+S を `hooks/useSaveShortcut` に集約
- フォーム内ガード（INPUT/TEXTAREA/SELECT/contentEditable）を全エディタで統一
  - 旧 TableEditor / ActionEditor はガード無しだった → ガード付与（仕様変更）
- `shouldTriggerSaveShortcut` を純関数として分離し、Vitest で 11 ケース検証

## Changes

| File | Before | After |
|------|--------|-------|
| `src/hooks/useSaveShortcut.ts` | — | 新規（フック + 純関数） |
| `src/hooks/useSaveShortcut.test.ts` | — | 新規（11 テスト） |
| `src/components/design/DesignSubToolbar.tsx` | 独自 useEffect で Ctrl+S | `useSaveShortcut` 呼び出し |
| `src/components/flow/FlowEditor.tsx` | 同上 | 同上 |
| `src/components/table/TableEditor.tsx` | 同上（**ガード無し**） | 同上（ガード付） |
| `src/components/action/ActionEditor.tsx` | 同上（**ガード無し**） | 同上（ガード付） |

## Test plan

- [x] Vitest `useSaveShortcut.test.ts` 11/11 パス
- [x] Vitest 全体 79/79 パス
- [x] `tsc -b`: 本 PR による新規 TS エラー無し（pre-existing の `ready` 未使用 1 件は #97 のスコープ外）
- [ ] 手動検証: 各エディタで Ctrl+S が保存を発火すること
- [ ] 手動検証: 各エディタで INPUT/TEXTAREA フォーカス中に Ctrl+S を押してもブラウザのデフォルト（名前を付けて保存）を抑止し、保存ハンドラは発火しないこと

## スコープ外

- pre-existing な TS 警告（`ready` 未使用）
- `useResourceEditor` フック化（#100）
- エディタヘッダー統一（#99）

🤖 Generated with [Claude Code](https://claude.com/claude-code)