### PR TITLE
refactor(editor): useResourceEditor フックを新設 (#100 PR-a)

### DIFF
--- a/designer/package-lock.json
+++ b/designer/package-lock.json
@@ -26,6 +26,7 @@
         "@eslint/js": "^9.39.4",
         "@playwright/test": "^1.59.1",
         "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^24.12.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -290,6 +291,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1231,6 +1242,46 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -1251,6 +1302,34 @@
         "yarn": ">=1"
       }
     },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1261,6 +1340,14 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/backbone": {
       "version": "1.4.15",
@@ -1921,6 +2008,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2427,6 +2525,17 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -3452,6 +3561,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3786,6 +3906,36 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/promise-polyfill": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.3.0.tgz",
@@ -3822,6 +3972,14 @@
       "peerDependencies": {
         "react": "^19.2.5"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-router": {
       "version": "7.14.0",

--- a/designer/package.json
+++ b/designer/package.json
@@ -31,6 +31,7 @@
     "@eslint/js": "^9.39.4",
     "@playwright/test": "^1.59.1",
     "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^24.12.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/designer/src/hooks/useResourceEditor.test.ts
+++ b/designer/src/hooks/useResourceEditor.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useResourceEditor } from "./useResourceEditor";
+import { _resetForTests as resetTabs, getTabs, openTab, makeTabId } from "../store/tabStore";
+import { saveDraft, loadDraft, hasDraft } from "../utils/draftStorage";
+import { setLastSeenMtime } from "../utils/serverMtime";
+
+// ── mcpBridge を stub ─────────────────────────────────────────────────────────
+vi.mock("../mcp/mcpBridge", () => {
+  type BroadcastHandler = (data: unknown) => void;
+  const handlers = new Map<string, Set<BroadcastHandler>>();
+  const statusCallbacks = new Set<(s: string) => void>();
+  return {
+    mcpBridge: {
+      onBroadcast(event: string, handler: BroadcastHandler) {
+        if (!handlers.has(event)) handlers.set(event, new Set());
+        handlers.get(event)!.add(handler);
+        return () => handlers.get(event)?.delete(handler);
+      },
+      onStatusChange(cb: (s: string) => void) {
+        statusCallbacks.add(cb);
+        cb("disconnected");
+        return () => statusCallbacks.delete(cb);
+      },
+      request: async () => ({ mtime: null }),
+      _emit(event: string, data: unknown) {
+        handlers.get(event)?.forEach((h) => h(data));
+      },
+    },
+  };
+});
+
+// エミッタに触るためのヘルパー
+async function emitBroadcast(event: string, data: unknown) {
+  const m = await import("../mcp/mcpBridge");
+  (m.mcpBridge as unknown as { _emit: (e: string, d: unknown) => void })._emit(event, data);
+}
+
+interface TestData {
+  id: string;
+  name: string;
+  count: number;
+}
+
+function setup(overrides: {
+  id?: string | undefined;
+  load?: (id: string) => Promise<TestData | null>;
+  save?: (data: TestData) => Promise<void>;
+  onNotFound?: () => void;
+  onLoaded?: (data: TestData) => void;
+  broadcastName?: string;
+  autoReloadOnClean?: boolean;
+} = {}) {
+  const load = overrides.load ?? vi.fn(async (id: string) => ({ id, name: "initial", count: 0 }));
+  const save = overrides.save ?? vi.fn(async () => { /* ok */ });
+  const resolvedId = "id" in overrides ? overrides.id : "abc";
+  const hook = renderHook(() =>
+    useResourceEditor<TestData>({
+      tabType: "table",
+      mtimeKind: "table",
+      draftKind: "table",
+      id: resolvedId,
+      load,
+      save,
+      broadcastName: overrides.broadcastName ?? "tableChanged",
+      broadcastIdField: "id",
+      onNotFound: overrides.onNotFound,
+      onLoaded: overrides.onLoaded,
+      autoReloadOnClean: overrides.autoReloadOnClean,
+      enableUndoKeyboard: false, // テスト中のキーバインド無効化
+    }),
+  );
+  return { hook, load, save };
+}
+
+beforeEach(() => {
+  resetTabs();
+  localStorage.clear();
+  // tabStore.setDirty の副作用を観測するために、事前にタブを開いておく
+  openTab({ id: makeTabId("table", "abc"), type: "table", resourceId: "abc", label: "テスト" });
+});
+
+// ── 初回ロード ───────────────────────────────────────────────────────────────
+
+describe("useResourceEditor: 初回ロード", () => {
+  it("draft が無ければ backend のデータをロードして isDirty=false", async () => {
+    const { hook, load } = setup();
+    await waitFor(() => expect(hook.result.current.state).not.toBeNull());
+    expect(hook.result.current.state).toEqual({ id: "abc", name: "initial", count: 0 });
+    expect(hook.result.current.isDirty).toBe(false);
+    expect(load).toHaveBeenCalledWith("abc");
+  });
+
+  it("draft があれば draft を優先して isDirty=true", async () => {
+    saveDraft("table", "abc", { id: "abc", name: "drafted", count: 99 });
+    const { hook } = setup();
+    await waitFor(() => expect(hook.result.current.state).not.toBeNull());
+    expect(hook.result.current.state).toEqual({ id: "abc", name: "drafted", count: 99 });
+    expect(hook.result.current.isDirty).toBe(true);
+  });
+
+  it("load が null を返したら onNotFound を呼ぶ", async () => {
+    const onNotFound = vi.fn();
+    setup({ load: async () => null, onNotFound });
+    await waitFor(() => expect(onNotFound).toHaveBeenCalledTimes(1));
+  });
+
+  it("onLoaded は draft 有無に関わらず backend データで呼ばれる", async () => {
+    const onLoaded = vi.fn();
+    saveDraft("table", "abc", { id: "abc", name: "drafted", count: 99 });
+    setup({ onLoaded });
+    await waitFor(() => expect(onLoaded).toHaveBeenCalledWith({ id: "abc", name: "initial", count: 0 }));
+  });
+
+  it("id が undefined の間はロードしない", async () => {
+    const load = vi.fn();
+    setup({ id: undefined, load });
+    // 少し待ってから呼ばれていないことを確認
+    await new Promise((r) => setTimeout(r, 30));
+    expect(load).not.toHaveBeenCalled();
+  });
+});
+
+// ── update / updateSilent / dirty 追跡 ────────────────────────────────────────
+
+describe("useResourceEditor: update / dirty 追跡", () => {
+  it("update で draft が保存され isDirty=true、タブも dirty", async () => {
+    const { hook } = setup();
+    await waitFor(() => expect(hook.result.current.state).not.toBeNull());
+
+    act(() => hook.result.current.update((d) => { d.name = "changed"; }));
+
+    expect(hook.result.current.state?.name).toBe("changed");
+    expect(hook.result.current.isDirty).toBe(true);
+    expect(loadDraft<TestData>("table", "abc")?.name).toBe("changed");
+    expect(getTabs().find((t) => t.id === makeTabId("table", "abc"))?.isDirty).toBe(true);
+  });
+
+  it("updateSilent も draft 保存 + dirty 立てるが undo に積まない", async () => {
+    const { hook } = setup();
+    await waitFor(() => expect(hook.result.current.state).not.toBeNull());
+    expect(hook.result.current.canUndo).toBe(false);
+
+    act(() => hook.result.current.updateSilent((d) => { d.name = "silent"; }));
+
+    expect(hook.result.current.state?.name).toBe("silent");
+    expect(hook.result.current.isDirty).toBe(true);
+    expect(hook.result.current.canUndo).toBe(false); // undo 履歴には積まれない
+    expect(loadDraft<TestData>("table", "abc")?.name).toBe("silent");
+  });
+});
+
+// ── handleSave ───────────────────────────────────────────────────────────────
+
+describe("useResourceEditor: handleSave", () => {
+  it("保存成功で draft 削除・isDirty=false・タブ clean", async () => {
+    const { hook, save } = setup();
+    await waitFor(() => expect(hook.result.current.state).not.toBeNull());
+    act(() => hook.result.current.update((d) => { d.name = "changed"; }));
+    expect(hook.result.current.isDirty).toBe(true);
+
+    await act(async () => { await hook.result.current.handleSave(); });
+
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(save).toHaveBeenCalledWith(expect.objectContaining({ name: "changed" }));
+    expect(hook.result.current.isDirty).toBe(false);
+    expect(hasDraft("table", "abc")).toBe(false);
+    expect(getTabs().find((t) => t.id === makeTabId("table", "abc"))?.isDirty).toBe(false);
+  });
+
+  it("保存中は isSaving=true、完了後に false", async () => {
+    let resolveSave: () => void = () => { /* noop */ };
+    const save = vi.fn(() => new Promise<void>((res) => { resolveSave = res; }));
+    const { hook } = setup({ save });
+    await waitFor(() => expect(hook.result.current.state).not.toBeNull());
+    act(() => hook.result.current.update((d) => { d.name = "changed"; }));
+
+    let savePromise: Promise<void> = Promise.resolve();
+    act(() => { savePromise = hook.result.current.handleSave(); });
+    await waitFor(() => expect(hook.result.current.isSaving).toBe(true));
+
+    resolveSave();
+    await act(async () => { await savePromise; });
+    expect(hook.result.current.isSaving).toBe(false);
+  });
+});
+
+// ── handleReset ──────────────────────────────────────────────────────────────
+
+describe("useResourceEditor: handleReset", () => {
+  it("リセットで draft 削除・backend から再ロード・isDirty=false", async () => {
+    saveDraft("table", "abc", { id: "abc", name: "drafted", count: 99 });
+    const { hook } = setup();
+    await waitFor(() => expect(hook.result.current.isDirty).toBe(true));
+    expect(hook.result.current.state?.name).toBe("drafted");
+
+    await act(async () => { await hook.result.current.handleReset(); });
+
+    expect(hook.result.current.state?.name).toBe("initial");
+    expect(hook.result.current.isDirty).toBe(false);
+    expect(hasDraft("table", "abc")).toBe(false);
+    expect(getTabs().find((t) => t.id === makeTabId("table", "abc"))?.isDirty).toBe(false);
+  });
+
+  it("serverChanged もリセットでクリアされる", async () => {
+    saveDraft("table", "abc", { id: "abc", name: "drafted", count: 99 });
+    // サーバー mtime を古く設定して「更新あり」を検知させる
+    setLastSeenMtime("table", "abc", 0);
+    const { hook } = setup({
+      load: async (id) => ({ id, name: "initial", count: 0 }),
+    });
+    // 初回ロード中に serverChanged を true にするため broadcast で誘発
+    await waitFor(() => expect(hook.result.current.state).not.toBeNull());
+    await act(async () => emitBroadcast("tableChanged", { id: "abc" }));
+    await waitFor(() => expect(hook.result.current.serverChanged).toBe(true));
+
+    await act(async () => { await hook.result.current.handleReset(); });
+    expect(hook.result.current.serverChanged).toBe(false);
+  });
+});
+
+// ── broadcast 受信 ───────────────────────────────────────────────────────────
+
+describe("useResourceEditor: broadcast", () => {
+  it("dirty 中の broadcast は serverChanged=true", async () => {
+    const { hook } = setup();
+    await waitFor(() => expect(hook.result.current.state).not.toBeNull());
+    act(() => hook.result.current.update((d) => { d.name = "editing"; }));
+
+    await act(async () => emitBroadcast("tableChanged", { id: "abc" }));
+    await waitFor(() => expect(hook.result.current.serverChanged).toBe(true));
+  });
+
+  it("clean 中の broadcast は自動リロード（デフォルト）", async () => {
+    let current = { id: "abc", name: "v1", count: 0 };
+    const load = vi.fn(async () => current);
+    const { hook } = setup({ load });
+    await waitFor(() => expect(hook.result.current.state?.name).toBe("v1"));
+
+    current = { id: "abc", name: "v2", count: 1 };
+    await act(async () => emitBroadcast("tableChanged", { id: "abc" }));
+    await waitFor(() => expect(hook.result.current.state?.name).toBe("v2"));
+    expect(hook.result.current.serverChanged).toBe(false);
+  });
+
+  it("autoReloadOnClean=false のとき clean でも serverChanged=true", async () => {
+    const { hook } = setup({ autoReloadOnClean: false });
+    await waitFor(() => expect(hook.result.current.state).not.toBeNull());
+
+    await act(async () => emitBroadcast("tableChanged", { id: "abc" }));
+    await waitFor(() => expect(hook.result.current.serverChanged).toBe(true));
+  });
+
+  it("自分以外の id の broadcast は無視", async () => {
+    const { hook } = setup();
+    await waitFor(() => expect(hook.result.current.state).not.toBeNull());
+
+    await act(async () => emitBroadcast("tableChanged", { id: "different" }));
+    await new Promise((r) => setTimeout(r, 20));
+    expect(hook.result.current.serverChanged).toBe(false);
+  });
+});

--- a/designer/src/hooks/useResourceEditor.ts
+++ b/designer/src/hooks/useResourceEditor.ts
@@ -1,0 +1,249 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useUndoableState } from "./useUndoableState";
+import { useUndoKeyboard } from "./useUndoKeyboard";
+import { saveDraft, loadDraft, clearDraft, hasDraft } from "../utils/draftStorage";
+import { acknowledgeServerMtime, hasServerBeenUpdated, type MtimeKind } from "../utils/serverMtime";
+import { setDirty as setTabDirty, makeTabId, type TabType } from "../store/tabStore";
+import { mcpBridge } from "../mcp/mcpBridge";
+
+export interface UseResourceEditorOptions<T> {
+  /** tabStore で使うタブ種別 */
+  tabType: TabType;
+  /** serverMtime の kind */
+  mtimeKind: MtimeKind;
+  /** draftStorage の kind（通常は tabType と同じ、違う場合のみ指定） */
+  draftKind: string;
+  /** リソース ID（undefined の間はロード等を行わない） */
+  id: string | undefined;
+  /** リソースをバックエンドから読み込む */
+  load: (id: string) => Promise<T | null>;
+  /** リソースを保存する */
+  save: (data: T) => Promise<void>;
+  /** 外部変更を通知する broadcast 名（例: "tableChanged"）*/
+  broadcastName: string;
+  /** broadcast payload のうち、自分のリソースか判定するフィールド名（デフォルト "id"）*/
+  broadcastIdField?: string;
+  /** load が null を返した時のハンドラ（例: リスト画面へリダイレクト）*/
+  onNotFound?: () => void;
+  /** ロード成功時のフック（副次データの fetch 等、初回・リセット両方で呼ばれる）*/
+  onLoaded?: (data: T) => void;
+  /** Ctrl+Z / Ctrl+Y のキーバインドを登録するか（デフォルト true）*/
+  enableUndoKeyboard?: boolean;
+  /** broadcast 受信時に dirty でなければ自動リロードするか（デフォルト true）*/
+  autoReloadOnClean?: boolean;
+}
+
+export interface UseResourceEditorResult<T> {
+  state: T | null;
+  isDirty: boolean;
+  isSaving: boolean;
+  serverChanged: boolean;
+
+  /** 構造変化（undo スタックに積む）。draft 保存 + isDirty 立てあり */
+  update: (fn: (draft: T) => void) => void;
+  /** テキスト編集中の一時更新（undo スタックに積まない）。draft 保存 + isDirty 立てあり */
+  updateSilent: (fn: (draft: T) => void) => void;
+  /** onBlur 時に呼ぶ: 現在の state を undo スタックに積む */
+  commit: () => void;
+
+  undo: () => void;
+  redo: () => void;
+  canUndo: boolean;
+  canRedo: boolean;
+
+  /** 保存実行（clean 化 + mtime ack）*/
+  handleSave: () => Promise<void>;
+  /** リセット実行（draft 破棄 + backend 再ロード + undo クリア）*/
+  handleReset: () => Promise<void>;
+  /** バナーのみ閉じる（state は変えない）*/
+  dismissServerBanner: () => void;
+  /** 再ロード（draft があれば優先、なければ backend）*/
+  reload: () => Promise<void>;
+}
+
+/**
+ * エディタ共通の保存・リセット・ロード・broadcast・dirty 追跡を集約するフック。
+ *
+ * 単一リソース（テーブル 1 件、処理フロー 1 件、画面 1 件）を編集する各エディタで
+ * ほぼ同じパターンが 4 回コピペされていたロジックを 1 箇所に集約する。
+ */
+export function useResourceEditor<T>(opts: UseResourceEditorOptions<T>): UseResourceEditorResult<T> {
+  const {
+    tabType, mtimeKind, draftKind, id,
+    load, save,
+    broadcastName, broadcastIdField = "id",
+    onNotFound, onLoaded,
+    enableUndoKeyboard = true,
+    autoReloadOnClean = true,
+  } = opts;
+
+  const [isDirty, setIsDirty] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [serverChanged, setServerChanged] = useState(false);
+  const isDirtyRef = useRef(false);
+
+  const onNotFoundRef = useRef(onNotFound);
+  const onLoadedRef = useRef(onLoaded);
+  onNotFoundRef.current = onNotFound;
+  onLoadedRef.current = onLoaded;
+
+  const {
+    state, update: updateRaw, updateAndCommit, commit,
+    undo, redo, canUndo, canRedo, reset: resetState,
+  } = useUndoableState<T | null>(null);
+
+  useUndoKeyboard(undo, redo, enableUndoKeyboard);
+
+  const markDirty = useCallback(() => {
+    if (!id) return;
+    setIsDirty(true);
+    isDirtyRef.current = true;
+    setTabDirty(makeTabId(tabType, id), true);
+  }, [id, tabType]);
+
+  const markClean = useCallback(() => {
+    if (!id) return;
+    clearDraft(draftKind, id);
+    setIsDirty(false);
+    isDirtyRef.current = false;
+    setTabDirty(makeTabId(tabType, id), false);
+  }, [id, draftKind, tabType]);
+
+  const update = useCallback((fn: (draft: T) => void) => {
+    if (!id) return;
+    updateAndCommit((prev) => {
+      if (prev == null) return prev;
+      const next = structuredClone(prev);
+      fn(next);
+      saveDraft(draftKind, id, next);
+      return next;
+    });
+    markDirty();
+  }, [id, updateAndCommit, draftKind, markDirty]);
+
+  const updateSilent = useCallback((fn: (draft: T) => void) => {
+    if (!id) return;
+    updateRaw((prev) => {
+      if (prev == null) return prev;
+      const next = structuredClone(prev);
+      fn(next);
+      saveDraft(draftKind, id, next);
+      return next;
+    });
+    markDirty();
+  }, [id, updateRaw, draftKind, markDirty]);
+
+  const reload = useCallback(async (): Promise<void> => {
+    if (!id) return;
+    const loaded = await load(id);
+    if (!loaded) {
+      onNotFoundRef.current?.();
+      return;
+    }
+    const draft = loadDraft<T>(draftKind, id);
+    if (draft) {
+      resetState(draft);
+      setIsDirty(true);
+      isDirtyRef.current = true;
+      setTabDirty(makeTabId(tabType, id), true);
+    } else {
+      resetState(loaded);
+      setIsDirty(false);
+      isDirtyRef.current = false;
+      setTabDirty(makeTabId(tabType, id), false);
+      clearDraft(draftKind, id);
+    }
+    onLoadedRef.current?.(loaded);
+  }, [id, load, draftKind, tabType, resetState]);
+
+  const handleSave = useCallback(async () => {
+    if (!state || !id) return;
+    setIsSaving(true);
+    try {
+      await save(state);
+      markClean();
+      await acknowledgeServerMtime(mtimeKind, id);
+      setServerChanged(false);
+    } finally {
+      setIsSaving(false);
+    }
+  }, [state, id, save, markClean, mtimeKind]);
+
+  const handleReset = useCallback(async () => {
+    if (!id) return;
+    clearDraft(draftKind, id);
+    const loaded = await load(id);
+    if (!loaded) {
+      onNotFoundRef.current?.();
+      return;
+    }
+    resetState(loaded);
+    setIsDirty(false);
+    isDirtyRef.current = false;
+    setTabDirty(makeTabId(tabType, id), false);
+    setServerChanged(false);
+    await acknowledgeServerMtime(mtimeKind, id);
+    onLoadedRef.current?.(loaded);
+  }, [id, draftKind, load, tabType, mtimeKind, resetState]);
+
+  const dismissServerBanner = useCallback(() => {
+    setServerChanged(false);
+  }, []);
+
+  // 初回ロード + mtime 初期化
+  useEffect(() => {
+    if (!id) return;
+    let cancelled = false;
+    (async () => {
+      await reload();
+      if (cancelled) return;
+      if (hasDraft(draftKind, id)) {
+        if (await hasServerBeenUpdated(mtimeKind, id)) {
+          if (!cancelled) setServerChanged(true);
+        }
+      } else {
+        await acknowledgeServerMtime(mtimeKind, id);
+      }
+    })().catch(console.error);
+    return () => { cancelled = true; };
+  }, [id, draftKind, mtimeKind, reload]);
+
+  // 外部 broadcast 受信: dirty ならバナー、clean なら自動リロード
+  useEffect(() => {
+    if (!id) return;
+    return mcpBridge.onBroadcast(broadcastName, (data) => {
+      const d = data as Record<string, unknown>;
+      if (d[broadcastIdField] !== id) return;
+      if (isDirtyRef.current || !autoReloadOnClean) {
+        setServerChanged(true);
+      } else {
+        reload().catch(console.error);
+      }
+    });
+  }, [id, broadcastName, broadcastIdField, autoReloadOnClean, reload]);
+
+  // MCP 接続復帰時の自動リロード（dirty でなければ）
+  useEffect(() => {
+    return mcpBridge.onStatusChange((s) => {
+      if (s === "connected" && !isDirtyRef.current) reload().catch(console.error);
+    });
+  }, [reload]);
+
+  return {
+    state,
+    isDirty,
+    isSaving,
+    serverChanged,
+    update,
+    updateSilent,
+    commit,
+    undo,
+    redo,
+    canUndo,
+    canRedo,
+    handleSave,
+    handleReset,
+    dismissServerBanner,
+    reload,
+  };
+}


### PR DESCRIPTION
Part of #100 (5 PR シリーズの 1/5)

## Summary

4 エディタで 4 回コピペされていた保存・リセット・初回ロード・broadcast・dirty 追跡ロジックを 1 箇所に集約する共通フック \`useResourceEditor\` を新設。

本 PR は **フック本体とテストのみ** で、既存エディタには未適用（レビュー容易性のため分割）。

## フック API

\`\`\`ts
const {
  state, isDirty, isSaving, serverChanged,
  update, updateSilent, commit,
  undo, redo, canUndo, canRedo,
  handleSave, handleReset,
  dismissServerBanner, reload,
} = useResourceEditor<TableDefinition>({
  tabType: "table",
  mtimeKind: "table",
  draftKind: "table",
  id: tableId,
  load: loadTable,
  save: saveTable,
  broadcastName: "tableChanged",
  broadcastIdField: "tableId",
  onNotFound: () => navigate("/tables"),
});
\`\`\`

## 内部で吸収する責務

1. \`useUndoableState\` のラップ（undo/redo 公開）
2. \`draftStorage\` の自動呼び出し（saveDraft / loadDraft / clearDraft）
3. \`serverMtime\` の自動呼び出し（hasServerBeenUpdated / acknowledgeServerMtime）
4. \`tabStore.setDirty(makeTabId(tabType, id), isDirty)\` の自動同期
5. \`mcpBridge.onBroadcast\` 購読（dirty ならバナー、clean なら自動リロード）
6. \`mcpBridge.onStatusChange(\"connected\")\` 時の自動リロード

## 今後のロードマップ

- [x] PR-a（本 PR）: フック本体 + Vitest 単体テスト
- [ ] PR-b: TableEditor 移行（一番素直）
- [ ] PR-c: ActionEditor 移行（#96 の tab dirty ● を自動解消）
- [ ] PR-d: FlowEditor 移行（flowStore の draftMode 調整）
- [ ] PR-e: Designer 移行（GrapesJS storage manager と調整）

## Test plan

- [x] Vitest 全体 94/94 パス（新規 15 ケース含む）
  - 初回ロード: draft あり/なし、load が null、onLoaded 呼び出し、id=undefined で no-op
  - update / updateSilent: draft 保存 + dirty フラグ
  - handleSave: clean 化 + mtime ack + isSaving 遷移
  - handleReset: draft 破棄 + 再ロード + serverChanged クリア
  - broadcast: 自分の id のみ反応、dirty 中はバナー、clean 中は自動リロード
- [x] \`tsc -b\`: 本 PR による新規 TS エラーなし（pre-existing の \`ready\` 未使用 1 件は #99 等のスコープ）

## 依存関係追加

- \`@testing-library/react\` を devDependencies に追加（React フック単体テスト用、以降の PR でも利用）

🤖 Generated with [Claude Code](https://claude.com/claude-code)