### PR TITLE
refactor(action): ActionEditor を useResourceEditor に移行 + #96 解消 (#100 PR-c)

### DIFF
--- a/designer/src/components/AppShell.tsx
+++ b/designer/src/components/AppShell.tsx
@@ -11,6 +11,7 @@ import { TabBar } from "./TabBar";
 import { CommonHeader } from "./CommonHeader";
 import { loadProject } from "../store/flowStore";
 import { loadTable } from "../store/tableStore";
+import { loadActionGroup } from "../store/actionStore";
 import {
   getTabs,
   getActiveTabId,
@@ -84,6 +85,23 @@ export function AppShell() {
           }
         }).catch(console.error);
       }
+      return;
+    }
+
+    const actionMatch = matchPath("/actions/:actionGroupId", location.pathname);
+    if (actionMatch?.params.actionGroupId) {
+      const actionGroupId = actionMatch.params.actionGroupId;
+      const tabId = makeTabId("action", actionGroupId);
+      const existing = getTabs().find((t) => t.id === tabId);
+      if (existing) {
+        setActiveTab(tabId);
+      } else {
+        loadActionGroup(actionGroupId).then((ag) => {
+          if (ag) {
+            openTab({ id: tabId, type: "action", resourceId: actionGroupId, label: ag.name });
+          }
+        }).catch(console.error);
+      }
     }
   }, [location.pathname]);
 
@@ -96,6 +114,8 @@ export function AppShell() {
         ? `/design/${activeTab.resourceId}`
         : activeTab.type === "table"
         ? `/tables/${activeTab.resourceId}`
+        : activeTab.type === "action"
+        ? `/actions/${activeTab.resourceId}`
         : null;
     if (expectedPath && location.pathname !== expectedPath) {
       navigate(expectedPath, { replace: true });

--- a/designer/src/components/TabBar.tsx
+++ b/designer/src/components/TabBar.tsx
@@ -63,13 +63,11 @@ function TabItem({
     transition,
   };
 
-  const icon = tab.type === "design"
-    ? "bi-window"
-    : tab.type === "table"
-    ? "bi-table"
-    : tab.type === "er"
-    ? "bi-diagram-3"
-    : "bi-lightning";
+  const icon =
+    tab.type === "design" ? "bi-window"
+    : tab.type === "table" ? "bi-table"
+    : tab.type === "action" ? "bi-lightning"
+    : "bi-file-earmark";
 
   const handleClick = () => setActiveTab(tab.id);
 

--- a/designer/src/components/action/ActionEditor.tsx
+++ b/designer/src/components/action/ActionEditor.tsx
@@ -30,7 +30,6 @@ import { getStepLabel, clearJumpReferences } from "../../utils/actionUtils";
 import { validateActionGroup, hasBlockingErrors } from "../../utils/actionValidation";
 import type { ValidationError } from "../../utils/actionValidation";
 import { generateUUID } from "../../utils/uuid";
-import { mcpBridge } from "../../mcp/mcpBridge";
 import {
   DndContext,
   closestCenter,
@@ -46,8 +45,7 @@ import {
   SortableContext,
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
-import { useUndoableState } from "../../hooks/useUndoableState";
-import { useUndoKeyboard } from "../../hooks/useUndoKeyboard";
+import { useResourceEditor } from "../../hooks/useResourceEditor";
 import { useSaveShortcut } from "../../hooks/useSaveShortcut";
 import { useSelectionKeyboard } from "../../hooks/useSelectionKeyboard";
 import { STEP_TYPE_COLORS } from "../../types/action";
@@ -55,8 +53,6 @@ import { TableSubToolbar } from "../table/TableSubToolbar";
 import { SortableStepCard } from "./SortableStepCard";
 import { SaveResetButtons } from "../common/SaveResetButtons";
 import { ServerChangeBanner } from "../common/ServerChangeBanner";
-import { saveDraft, loadDraft, clearDraft, hasDraft } from "../../utils/draftStorage";
-import { acknowledgeServerMtime, hasServerBeenUpdated } from "../../utils/serverMtime";
 import "../../styles/action.css";
 
 /** ツールバーのドラッグ可能なステップ種別ボタン */
@@ -129,10 +125,6 @@ export function ActionEditor() {
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; stepId: string } | null>(null);
   const [contextMenuSubTypePicker, setContextMenuSubTypePicker] = useState(false);
   const [validationErrors, setValidationErrors] = useState<ValidationError[]>([]);
-  const [isDirty, setIsDirty] = useState(false);
-  const [isSaving, setIsSaving] = useState(false);
-  const [serverChanged, setServerChanged] = useState(false);
-  const lastSavedRef = useRef<ActionGroup | null>(null);
   const newStepIdsRef = useRef<Set<string>>(new Set());
 
   // 選択・クリップボード state
@@ -143,20 +135,47 @@ export function ActionEditor() {
   } | null>(null);
   const lastSelectedIdRef = useRef<string | null>(null);
 
-  // Undo/Redo 対応 state
+  const handleNotFound = useCallback(() => navigate("/actions"), [navigate]);
+
+  const handleLoaded = useCallback((g: ActionGroup) => {
+    setActiveActionId((cur) => cur ?? (g.actions.length > 0 ? g.actions[0].id : null));
+    loadProject().then((p) => {
+      setScreens(p.screens.map((s) => ({ id: s.id, name: s.name })));
+      const agMetas = p.actionGroups ?? [];
+      setCommonGroups(agMetas.filter((a) => a.type === "common").map((a) => ({ id: a.id, name: a.name })));
+    }).catch(console.error);
+    listTables().then((t) => {
+      setTables(t.map((tm) => ({ id: tm.id, name: tm.name, logicalName: tm.logicalName })));
+    }).catch(console.error);
+  }, []);
+
   const {
     state: group,
-    update: setGroup,
-    updateAndCommit: updateGroupCommit,
+    isDirty, isSaving, serverChanged,
+    update: updateGroup,
+    updateSilent: updateGroupSilent,
     commit: commitGroup,
-    undo,
-    redo,
-    canUndo,
-    canRedo,
-    reset: resetGroup,
-  } = useUndoableState<ActionGroup | null>(null);
+    undo, redo, canUndo, canRedo,
+    handleSave: hookHandleSave,
+    handleReset, dismissServerBanner,
+  } = useResourceEditor<ActionGroup>({
+    tabType: "action",
+    mtimeKind: "actionGroup",
+    draftKind: "action",
+    id: actionGroupId,
+    load: loadActionGroup,
+    save: saveActionGroup,
+    broadcastName: "actionGroupChanged",
+    broadcastIdField: "id",
+    onNotFound: handleNotFound,
+    onLoaded: handleLoaded,
+  });
 
-  useUndoKeyboard(undo, redo);
+  // 保存時にバリデーションをチェック（blocking なエラーがあれば中断）
+  const handleSave = useCallback(async () => {
+    if (!group || hasBlockingErrors(validateActionGroup(group))) return;
+    await hookHandleSave();
+  }, [group, hookHandleSave]);
 
   // D&D: PointerSensor に移動距離閾値を設定（クリックとドラッグを区別）
   const sensors = useSensors(
@@ -176,61 +195,6 @@ export function ActionEditor() {
     return closestCenter(args);
   }, []);
 
-  const reload = useCallback(async (useDraft = false) => {
-    if (!actionGroupId) return;
-    const g = await loadActionGroup(actionGroupId);
-    if (!g) {
-      navigate("/actions");
-      return;
-    }
-    lastSavedRef.current = g;
-    const draft = useDraft ? null : loadDraft<ActionGroup>("action", actionGroupId);
-    if (draft) {
-      resetGroup(draft);
-      setIsDirty(true);
-    } else {
-      resetGroup(g);
-      setIsDirty(false);
-      clearDraft("action", actionGroupId);
-    }
-    if (!activeActionId && g.actions.length > 0) {
-      setActiveActionId(g.actions[0].id);
-    }
-    const p = await loadProject();
-    setScreens(p.screens.map((s) => ({ id: s.id, name: s.name })));
-    const agMetas = p.actionGroups ?? [];
-    setCommonGroups(agMetas.filter((a) => a.type === "common").map((a) => ({ id: a.id, name: a.name })));
-    const t = await listTables();
-    setTables(t.map((tm) => ({ id: tm.id, name: tm.name, logicalName: tm.logicalName })));
-  }, [actionGroupId, activeActionId, navigate, resetGroup]);
-
-  useEffect(() => {
-    mcpBridge.startWithoutEditor();
-    reload().then(async () => {
-      if (!actionGroupId) return;
-      // タブを開いた時点でサーバー側に新しい変更がないか確認
-      if (hasDraft("action", actionGroupId)) {
-        if (await hasServerBeenUpdated("actionGroup", actionGroupId)) {
-          setServerChanged(true);
-        }
-      } else {
-        await acknowledgeServerMtime("actionGroup", actionGroupId);
-      }
-    }).catch(console.error);
-    const unsubStatus = mcpBridge.onStatusChange((s) => {
-      if (s === "connected") reload();
-    });
-    return unsubStatus;
-  }, [reload, actionGroupId]);
-
-  useEffect(() => {
-    if (!actionGroupId) return;
-    return mcpBridge.onBroadcast("actionGroupChanged", (data) => {
-      const d = data as { id?: string };
-      if (d.id === actionGroupId) setServerChanged(true);
-    });
-  }, [actionGroupId]);
-
   useSaveShortcut(() => {
     if (isDirty && !isSaving) handleSave();
   });
@@ -238,63 +202,6 @@ export function ActionEditor() {
   useEffect(() => {
     setValidationErrors(group ? validateActionGroup(group) : []);
   }, [group]);
-
-  const markGroupDirty = useCallback((g: ActionGroup) => {
-    if (actionGroupId) saveDraft("action", actionGroupId, g);
-    setIsDirty(true);
-  }, [actionGroupId]);
-
-  const handleSave = useCallback(async () => {
-    if (!group || hasBlockingErrors(validateActionGroup(group))) return;
-    setIsSaving(true);
-    try {
-      await saveActionGroup(group);
-      lastSavedRef.current = group;
-      if (actionGroupId) {
-        clearDraft("action", actionGroupId);
-        await acknowledgeServerMtime("actionGroup", actionGroupId);
-      }
-      setIsDirty(false);
-    } finally {
-      setIsSaving(false);
-    }
-  }, [group, actionGroupId]);
-
-  const handleReset = useCallback(async () => {
-    await reload(true);
-    setServerChanged(false);
-    if (actionGroupId) await acknowledgeServerMtime("actionGroup", actionGroupId);
-  }, [reload, actionGroupId]);
-
-  /** 構造変化（履歴に積む）: ステップ追加・削除・移動、アクション追加・削除 */
-  const updateGroup = useCallback(
-    (updater: (g: ActionGroup) => void) => {
-      updateGroupCommit((prev) => {
-        if (!prev) return prev;
-        const next = JSON.parse(JSON.stringify(prev)) as ActionGroup;
-        updater(next);
-        markGroupDirty(next);
-        return next;
-      });
-      setIsDirty(true);
-    },
-    [updateGroupCommit, markGroupDirty],
-  );
-
-  /** テキスト変更（履歴に積まない）: フィールド編集中の一時状態 */
-  const updateGroupSilent = useCallback(
-    (updater: (g: ActionGroup) => void) => {
-      setGroup((prev) => {
-        if (!prev) return prev;
-        const next = JSON.parse(JSON.stringify(prev)) as ActionGroup;
-        updater(next);
-        markGroupDirty(next);
-        return next;
-      });
-      setIsDirty(true);
-    },
-    [setGroup, markGroupDirty],
-  );
 
   const activeAction = group?.actions.find((a) => a.id === activeActionId) ?? null;
 
@@ -557,7 +464,7 @@ export function ActionEditor() {
       <TableSubToolbar />
 
       {serverChanged && (
-        <ServerChangeBanner onReload={handleReset} onDismiss={() => setServerChanged(false)} />
+        <ServerChangeBanner onReload={handleReset} onDismiss={dismissServerBanner} />
       )}
 
       {/* ヘッダー */}

--- a/designer/src/store/tabStore.ts
+++ b/designer/src/store/tabStore.ts
@@ -1,7 +1,7 @@
 const TABS_KEY = "designer-open-tabs";
 const ACTIVE_KEY = "designer-active-tab";
 
-export type TabType = "design" | "table" | "er" | "actions";
+export type TabType = "design" | "table" | "action";
 
 export interface TabItem {
   id: string;


### PR DESCRIPTION
Part of #100 (3/5)

## Summary

ActionEditor の保存・リセット・初回ロード・broadcast・dirty 追跡を \`useResourceEditor\` に委譲。
**65 insertions / 140 deletions（-75 行）**。

## #96 の自動解消

このマイグレーションにより、以前 #96 で指摘されていた「ActionEditor のタブに dirty ● が出ない」問題が解消されます。

## 変更内訳

| ファイル | 変更 |
|---------|------|
| \`ActionEditor.tsx\` | useResourceEditor に委譲。保存時のバリデーションのみ残す |
| \`AppShell.tsx\` | \`/actions/:actionGroupId\` の URL→タブ同期を追加 |
| \`tabStore.ts\` | TabType の整理（\"er\" 削除、\"actions\" → \"action\"）|
| \`TabBar.tsx\` | tab.type === \"action\" で lightning アイコン |

## TabType の変更理由

| 旧 | 新 | 理由 |
|----|----|------|
| \`\"er\"\` | （削除）| #98 で決定: ER 図はタブ化しない |
| \`\"actions\"\` | \`\"action\"\` | design/table と同じ単数形に統一 |

どちらの旧値も実際には \`openTab()\` で呼ばれていなかったため、永続化された localStorage に旧値は存在せず破壊的変更にならない。

## 副次的改善

- 未使用の \`lastSavedRef\` を削除
- \`reload(useDraft)\` の 2 モード挙動を \`handleReset\` / \`reload\` に分離
- \`mcpBridge.startWithoutEditor\` の呼び出しをフック内 \`onStatusChange\` に統合

## Test plan

- [x] Vitest 94/94 パス
- [x] Playwright save-reset / save-reset-flow 15/15 パス
- [x] Playwright tab-management 27/28 パス
  - 残 1 件（Ctrl+Tab 次タブ遷移）は **main でも再現する pre-existing な flaky**。本 PR の改変範囲外。
- [x] \`tsc -b\`: 本 PR による新規 TS エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)