### PR TITLE
chore(hooks): 自分の新設フックの lint エラーを解消

### DIFF
--- a/designer/src/hooks/useResourceEditor.ts
+++ b/designer/src/hooks/useResourceEditor.ts
@@ -84,8 +84,10 @@ export function useResourceEditor<T>(opts: UseResourceEditorOptions<T>): UseReso
 
   const onNotFoundRef = useRef(onNotFound);
   const onLoadedRef = useRef(onLoaded);
-  onNotFoundRef.current = onNotFound;
-  onLoadedRef.current = onLoaded;
+  useEffect(() => {
+    onNotFoundRef.current = onNotFound;
+    onLoadedRef.current = onLoaded;
+  });
 
   const {
     state, update: updateRaw, updateAndCommit, commit,

--- a/designer/src/hooks/useSaveShortcut.ts
+++ b/designer/src/hooks/useSaveShortcut.ts
@@ -35,7 +35,9 @@ export function useSaveShortcut(
   allowInForm = false,
 ): void {
   const onSaveRef = useRef(onSave);
-  onSaveRef.current = onSave;
+  useEffect(() => {
+    onSaveRef.current = onSave;
+  });
 
   useEffect(() => {
     if (!enabled) return;


### PR DESCRIPTION
## Summary

\`npm run lint\` で検出された \`react-hooks/refs\` ルール違反のうち、本セッションで私が新設した 2 つのフック（\`useSaveShortcut\` / \`useResourceEditor\`）の違反を解消。

## Why

React 19 + eslint-plugin-react-hooks@7 は render 中の ref 書き込みを禁止するようになった。同パターンは pre-existing の \`useUndoableState.ts\` にもあるが、**本 PR は自分の新設コードのリグレッションのみを直す** ことに絞る。

## 修正方法

```ts
// Before
const onSaveRef = useRef(onSave);
onSaveRef.current = onSave;  // render 中

// After
const onSaveRef = useRef(onSave);
useEffect(() => { onSaveRef.current = onSave; });
```

## Test plan

- [x] Vitest 94/94 パス
- [x] \`npm run lint\` で本 PR 対象ファイルの警告が消えた
- [x] pre-existing な違反（\`useUndoableState.ts:43\` や他の setState-in-effect 等）は意図的に残す — 別イシューで整理すべき

## スコープ外

- \`useUndoableState.ts\` の同パターン修正
- その他 pre-existing lint 警告（setState in effect、this alias 等、合計 19 件ほど）
- npm audit の dompurify 脆弱性（別 PR で対応可）

🤖 Generated with [Claude Code](https://claude.com/claude-code)