### PR TITLE
feat(routing): URL 規約を /category/feature[/:id] 形式に統一 (#86 PR-1)

### DIFF
--- a/designer/e2e/save-flow.spec.ts
+++ b/designer/e2e/save-flow.spec.ts
@@ -51,7 +51,7 @@ async function setupWithTabs(page: Page, screenIds: string[], labels: Record<str
 test.describe("ページリロード後のタブ復元", () => {
   test("リロード後に1タブが復元される", async ({ page }) => {
     await setupWithTabs(page, [SCREEN_A], { [SCREEN_A]: "画面A" });
-    await page.goto(`/design/${SCREEN_A}`);
+    await page.goto(`/screen/design/${SCREEN_A}`);
     await expect(page.locator(".tabbar-tab")).toHaveCount(1, { timeout: 10000 });
     await expect(page.locator(".tabbar-tab")).toContainText("画面A");
 
@@ -62,7 +62,7 @@ test.describe("ページリロード後のタブ復元", () => {
 
   test("リロード後に複数タブが復元される", async ({ page }) => {
     await setupWithTabs(page, [SCREEN_A, SCREEN_B], { [SCREEN_A]: "画面A", [SCREEN_B]: "画面B" });
-    await page.goto(`/design/${SCREEN_B}`);
+    await page.goto(`/screen/design/${SCREEN_B}`);
     await expect(page.locator(".tabbar-tab")).toHaveCount(2, { timeout: 10000 });
 
     await page.reload();
@@ -74,7 +74,7 @@ test.describe("ページリロード後のタブ復元", () => {
   test("リロード後にアクティブタブが復元される", async ({ page }) => {
     // SCREEN_A を最後に置くことで addInitScript が active=SCREEN_A を設定する
     await setupWithTabs(page, [SCREEN_B, SCREEN_A], { [SCREEN_A]: "画面A", [SCREEN_B]: "画面B" });
-    await page.goto(`/design/${SCREEN_A}`);
+    await page.goto(`/screen/design/${SCREEN_A}`);
     await expect(page.locator(".tabbar-tab")).toHaveCount(2, { timeout: 10000 });
 
     await page.reload();
@@ -98,7 +98,7 @@ test.describe("isPinned の永続化", () => {
       },
       { project: dummyProject, tabs, activeTabId: `design:${SCREEN_B}` }
     );
-    await page.goto(`/design/${SCREEN_B}`);
+    await page.goto(`/screen/design/${SCREEN_B}`);
     await expect(page.locator(".tabbar-tab")).toHaveCount(2, { timeout: 10000 });
     await expect(page.locator(".tabbar-tab.pinned")).toContainText("画面A");
 

--- a/designer/e2e/save-reset-action.spec.ts
+++ b/designer/e2e/save-reset-action.spec.ts
@@ -1,7 +1,7 @@
 /**
  * 処理フローエディタ：保存/リセットボタン E2E テスト
  *
- * 視点: ユーザーが処理フローエディタ (/actions/:id) で編集・保存・リセットを行う
+ * 視点: ユーザーが処理フローエディタ (/process-flow/edit/:id) で編集・保存・リセットを行う
  * 前提: dev サーバーが起動済み (playwright.config.ts の webServer で自動起動)
  *       MCP サーバーは不要 — localStorage でアクショングループを直接セットアップ
  */
@@ -74,7 +74,7 @@ async function setupActionEditor(page: Page, draft: object | null = null) {
       draft,
     },
   );
-  await page.goto(`/actions/${ACTION_GROUP_ID}`);
+  await page.goto(`/process-flow/edit/${ACTION_GROUP_ID}`);
   await expect(page.locator(".action-page")).toBeVisible();
 }
 

--- a/designer/e2e/save-reset.spec.ts
+++ b/designer/e2e/save-reset.spec.ts
@@ -75,7 +75,7 @@ async function setupTableEditor(page: Page) {
     },
     { project: dummyProject, table: dummyTable, tableId: TABLE_ID, tab: dummyTab },
   );
-  await page.goto(`/tables/${TABLE_ID}`);
+  await page.goto(`/table/edit/${TABLE_ID}`);
   // テーブルが読み込まれるまで待機
   await expect(page.locator(".table-editor-page")).toBeVisible();
 }

--- a/designer/e2e/tab-management.spec.ts
+++ b/designer/e2e/tab-management.spec.ts
@@ -67,7 +67,7 @@ async function setupWithScreens(page: Page, screenIds: string[]) {
     { project: dummyProject, tabs, activeTabId }
   );
 
-  await page.goto(`/design/${screenIds[screenIds.length - 1]}`);
+  await page.goto(`/screen/design/${screenIds[screenIds.length - 1]}`);
   // タブバーが表示されるまで待機
   await expect(page.locator(".tabbar-tab")).toHaveCount(screenIds.length);
 }
@@ -97,7 +97,7 @@ test.describe("タブ切り替え", () => {
   test("タブをクリックすると切り替わる", async ({ page }) => {
     await page.locator(".tabbar-tab").filter({ hasText: "画面A" }).click();
     await expect(page.locator(".tabbar-tab.active")).toContainText("画面A");
-    await expect(page).toHaveURL(`/design/${SCREEN_A}`);
+    await expect(page).toHaveURL(`/screen/design/${SCREEN_A}`);
   });
 
   test("Ctrl+Tab で次のタブに移動する", async ({ page }) => {

--- a/designer/src/components/AppShell.tsx
+++ b/designer/src/components/AppShell.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Routes, Route, useLocation, useNavigate, matchPath } from "react-router-dom";
+import { Routes, Route, Navigate, useLocation, useNavigate, matchPath } from "react-router-dom";
 import { FlowEditor } from "./flow/FlowEditor";
 import { TableListView } from "./table/TableListView";
 import { TableEditor } from "./table/TableEditor";
@@ -53,7 +53,7 @@ export function AppShell() {
 
   // URL → タブ同期（ブラウザの直接ナビゲーション / mcpBridge.navigateScreen）
   useEffect(() => {
-    const designMatch = matchPath("/design/:screenId", location.pathname);
+    const designMatch = matchPath("/screen/design/:screenId", location.pathname);
     if (designMatch?.params.screenId) {
       const screenId = designMatch.params.screenId;
       const tabId = makeTabId("design", screenId);
@@ -71,7 +71,7 @@ export function AppShell() {
       return;
     }
 
-    const tableMatch = matchPath("/tables/:tableId", location.pathname);
+    const tableMatch = matchPath("/table/edit/:tableId", location.pathname);
     if (tableMatch?.params.tableId) {
       const tableId = tableMatch.params.tableId;
       const tabId = makeTabId("table", tableId);
@@ -88,7 +88,7 @@ export function AppShell() {
       return;
     }
 
-    const actionMatch = matchPath("/actions/:actionGroupId", location.pathname);
+    const actionMatch = matchPath("/process-flow/edit/:actionGroupId", location.pathname);
     if (actionMatch?.params.actionGroupId) {
       const actionGroupId = actionMatch.params.actionGroupId;
       const tabId = makeTabId("action", actionGroupId);
@@ -111,11 +111,11 @@ export function AppShell() {
     if (!activeTab) return;
     const expectedPath =
       activeTab.type === "design"
-        ? `/design/${activeTab.resourceId}`
+        ? `/screen/design/${activeTab.resourceId}`
         : activeTab.type === "table"
-        ? `/tables/${activeTab.resourceId}`
+        ? `/table/edit/${activeTab.resourceId}`
         : activeTab.type === "action"
-        ? `/actions/${activeTab.resourceId}`
+        ? `/process-flow/edit/${activeTab.resourceId}`
         : null;
     if (expectedPath && location.pathname !== expectedPath) {
       navigate(expectedPath, { replace: true });
@@ -147,13 +147,15 @@ export function AppShell() {
       {/* 非デザインコンテンツ: 通常ルーティング */}
       {!activeIsDesign && (
         <Routes>
-          <Route path="/" element={<FlowEditor />} />
-          <Route path="/tables" element={<TableListView />} />
-          <Route path="/tables/:tableId" element={<TableEditor />} />
-          <Route path="/er" element={<ErDiagram />} />
-          <Route path="/actions" element={<ActionListView />} />
-          <Route path="/actions/:actionGroupId" element={<ActionEditor />} />
-          <Route path="/design/:screenId" element={null} />
+          {/* / は PR-3 で Dashboard に差し替え。それまでは /screen/flow にリダイレクト */}
+          <Route path="/" element={<Navigate to="/screen/flow" replace />} />
+          <Route path="/screen/flow" element={<FlowEditor />} />
+          <Route path="/screen/design/:screenId" element={null} />
+          <Route path="/table/list" element={<TableListView />} />
+          <Route path="/table/edit/:tableId" element={<TableEditor />} />
+          <Route path="/table/er" element={<ErDiagram />} />
+          <Route path="/process-flow/list" element={<ActionListView />} />
+          <Route path="/process-flow/edit/:actionGroupId" element={<ActionEditor />} />
         </Routes>
       )}
     </>

--- a/designer/src/components/HeaderMenu.tsx
+++ b/designer/src/components/HeaderMenu.tsx
@@ -8,15 +8,30 @@ type MenuItem = {
   label: string;
   icon: string;
   route: string;
-  matchPrefix?: boolean;
+  /** active 判定に一致する pathname（完全一致） */
+  activePaths?: string[];
+  /** active 判定に一致する pathname の接頭辞（例: "/table/edit/" で編集ページも active にする） */
+  activePrefixes?: string[];
   disabled?: boolean;
 };
 
 const MENU_ITEMS: MenuItem[] = [
-  { id: "flow",      label: "画面フロー",  icon: "bi-diagram-3",    route: "/"        },
-  { id: "tables",    label: "テーブル設計", icon: "bi-table",        route: "/tables", matchPrefix: true },
-  { id: "er",        label: "ER図",        icon: "bi-share",        route: "/er"      },
-  { id: "actions",   label: "処理フロー",  icon: "bi-lightning",    route: "/actions", matchPrefix: true },
+  {
+    id: "screen-flow", label: "画面フロー", icon: "bi-diagram-3", route: "/screen/flow",
+    activePaths: ["/screen/flow"], activePrefixes: ["/screen/design/"],
+  },
+  {
+    id: "table-list", label: "テーブル一覧", icon: "bi-table", route: "/table/list",
+    activePaths: ["/table/list"], activePrefixes: ["/table/edit/"],
+  },
+  {
+    id: "er", label: "ER図", icon: "bi-share", route: "/table/er",
+    activePaths: ["/table/er"],
+  },
+  {
+    id: "process-flow", label: "処理フロー一覧", icon: "bi-lightning", route: "/process-flow/list",
+    activePaths: ["/process-flow/list"], activePrefixes: ["/process-flow/edit/"],
+  },
 ];
 
 const DASHBOARD_ITEM: MenuItem = {
@@ -68,10 +83,8 @@ export function HeaderMenu() {
   };
 
   const isActive = (item: MenuItem) => {
-    if (item.route === "/") return location.pathname === "/";
-    return item.matchPrefix
-      ? location.pathname.startsWith(item.route)
-      : location.pathname === item.route;
+    if (item.activePaths?.includes(location.pathname)) return true;
+    return item.activePrefixes?.some((p) => location.pathname.startsWith(p)) ?? false;
   };
 
   return (

--- a/designer/src/components/ScreenDesigner.tsx
+++ b/designer/src/components/ScreenDesigner.tsx
@@ -71,7 +71,7 @@ export function ScreenDesigner() {
         <h2 style={{ margin: 0, color: "#334155" }}>画面が見つかりません</h2>
         <p>指定された画面ID は存在しないか、削除されています。</p>
         <button
-          onClick={() => navigate("/")}
+          onClick={() => navigate("/screen/flow")}
           style={{
             padding: "8px 20px", border: "none", borderRadius: 6,
             background: "#6366f1", color: "#fff", cursor: "pointer", fontSize: 14,
@@ -87,7 +87,7 @@ export function ScreenDesigner() {
     <Designer
       screenId={screenId}
       screenName={screen.name}
-      onBack={() => navigate("/")}
+      onBack={() => navigate("/screen/flow")}
     />
   );
 }

--- a/designer/src/components/action/ActionEditor.tsx
+++ b/designer/src/components/action/ActionEditor.tsx
@@ -135,7 +135,7 @@ export function ActionEditor() {
   } | null>(null);
   const lastSelectedIdRef = useRef<string | null>(null);
 
-  const handleNotFound = useCallback(() => navigate("/actions"), [navigate]);
+  const handleNotFound = useCallback(() => navigate("/process-flow/list"), [navigate]);
 
   const handleLoaded = useCallback((g: ActionGroup) => {
     setActiveActionId((cur) => cur ?? (g.actions.length > 0 ? g.actions[0].id : null));
@@ -470,7 +470,7 @@ export function ActionEditor() {
       {/* ヘッダー */}
       <div className="action-editor-header">
         <div className="action-editor-breadcrumb">
-          <Link to="/actions">処理フロー一覧</Link>
+          <Link to="/process-flow/list">処理フロー一覧</Link>
           <span className="mx-2">/</span>
           <span className="fw-semibold text-dark">{group.name}</span>
         </div>
@@ -686,7 +686,7 @@ export function ActionEditor() {
                             e.preventDefault();
                             setContextMenu({ x: e.clientX, y: e.clientY, stepId: step.id });
                           }}
-                          onNavigateCommon={(refId) => navigate(`/actions/${refId}`)}
+                          onNavigateCommon={(refId) => navigate(`/process-flow/edit/${refId}`)}
                           defaultExpanded={newStepIdsRef.current.has(step.id)}
                           selected={selectedIds.has(step.id)}
                           onHeaderClick={(e) => handleStepClick(step.id, e)}

--- a/designer/src/components/action/ActionListView.tsx
+++ b/designer/src/components/action/ActionListView.tsx
@@ -90,7 +90,7 @@ export function ActionListView() {
     setAddType("screen");
     setAddScreenId("");
     setAddDescription("");
-    navigate(`/actions/${group.id}`);
+    navigate(`/process-flow/edit/${group.id}`);
   };
 
   const handleDelete = async (id: string, e: React.MouseEvent) => {
@@ -105,7 +105,7 @@ export function ActionListView() {
     if (clickTimerRef.current) {
       clearTimeout(clickTimerRef.current);
       clickTimerRef.current = null;
-      navigate(`/actions/${id}`);
+      navigate(`/process-flow/edit/${id}`);
     } else {
       clickTimerRef.current = setTimeout(() => {
         clickTimerRef.current = null;
@@ -220,7 +220,7 @@ export function ActionListView() {
                     {v && (hasError || hasWarning) && (
                       <span
                         className="action-validation-badges"
-                        onClick={(e) => { e.stopPropagation(); navigate(`/actions/${g.id}`); }}
+                        onClick={(e) => { e.stopPropagation(); navigate(`/process-flow/edit/${g.id}`); }}
                         title="編集画面でエラーを確認"
                       >
                         {hasError && (

--- a/designer/src/components/flow/FlowEditor.tsx
+++ b/designer/src/components/flow/FlowEditor.tsx
@@ -358,7 +358,7 @@ function FlowEditorInner() {
       const screenName = (node.data as { name?: string }).name ?? node.id;
       openTab({ id: makeTabId("design", node.id), type: "design", resourceId: node.id, label: screenName });
     }
-    navigate(`/design/${node.id}`);
+    navigate(`/screen/design/${node.id}`);
   }, [navigate]);
 
   const onNodeContextMenu: NodeMouseHandler = useCallback((event, node) => {
@@ -514,7 +514,7 @@ function FlowEditorInner() {
       ? ((nodes.find((n) => n.id === screenId)!.data as { name?: string }).name ?? screenId)
       : screenId;
     openTab({ id: makeTabId("design", screenId), type: "design", resourceId: screenId, label: screenName });
-    navigate(`/design/${screenId}`);
+    navigate(`/screen/design/${screenId}`);
     setContextMenu(null);
   }, [contextMenu, navigate, nodes]);
 

--- a/designer/src/components/flow/ScreenTableView.tsx
+++ b/designer/src/components/flow/ScreenTableView.tsx
@@ -36,7 +36,7 @@ export function ScreenTableView({ screens, onEdit, onDelete, onAdd }: Props) {
     if (clickTimerRef.current) {
       clearTimeout(clickTimerRef.current);
       clickTimerRef.current = null;
-      navigate(`/design/${id}`);
+      navigate(`/screen/design/${id}`);
     } else {
       clickTimerRef.current = setTimeout(() => {
         clickTimerRef.current = null;
@@ -178,7 +178,7 @@ export function ScreenTableView({ screens, onEdit, onDelete, onAdd }: Props) {
                     <div className="screen-table-actions">
                       <button
                         className="screen-table-btn"
-                        onClick={(e) => { e.stopPropagation(); navigate(`/design/${screen.id}`); }}
+                        onClick={(e) => { e.stopPropagation(); navigate(`/screen/design/${screen.id}`); }}
                         title="デザインを編集"
                       >
                         <i className="bi bi-palette" />

--- a/designer/src/components/table/ErDiagram.tsx
+++ b/designer/src/components/table/ErDiagram.tsx
@@ -195,7 +195,7 @@ function ErDiagramInner() {
 
   // Double click to navigate to table editor
   const onNodeDoubleClick: NodeMouseHandler = useCallback((_event, node) => {
-    navigate(`/tables/${node.id}`);
+    navigate(`/table/edit/${node.id}`);
   }, [navigate]);
 
   // Handle drag-to-connect: open logical relation modal pre-filled
@@ -316,7 +316,7 @@ function ErDiagramInner() {
           <div style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 12, color: "#777", height: "100%" }}>
             <i className="bi bi-diagram-3" style={{ fontSize: 48, color: "#555" }} />
             <p>テーブル定義がまだありません</p>
-            <button className="tbl-btn tbl-btn-primary" onClick={() => navigate("/tables")}>
+            <button className="tbl-btn tbl-btn-primary" onClick={() => navigate("/table/list")}>
               <i className="bi bi-table" /> テーブル設計へ
             </button>
           </div>

--- a/designer/src/components/table/TableEditor.tsx
+++ b/designer/src/components/table/TableEditor.tsx
@@ -23,7 +23,7 @@ export function TableEditor() {
   const [editingMeta, setEditingMeta] = useState(false);
   const [allTables, setAllTables] = useState<TableDefinition[]>([]);
 
-  const handleNotFound = useCallback(() => navigate("/tables"), [navigate]);
+  const handleNotFound = useCallback(() => navigate("/table/list"), [navigate]);
 
   const {
     state: table,
@@ -74,7 +74,7 @@ export function TableEditor() {
 
       {/* Header */}
       <header className="table-editor-header">
-        <button className="tbl-btn tbl-btn-ghost table-back-btn" onClick={() => navigate("/tables")}>
+        <button className="tbl-btn tbl-btn-ghost table-back-btn" onClick={() => navigate("/table/list")}>
           <i className="bi bi-arrow-left" /> テーブル一覧
         </button>
         <div className="table-editor-title-area">

--- a/designer/src/components/table/TableListView.tsx
+++ b/designer/src/components/table/TableListView.tsx
@@ -27,7 +27,7 @@ export function TableListView() {
     if (clickTimerRef.current) {
       clearTimeout(clickTimerRef.current);
       clickTimerRef.current = null;
-      navigate(`/tables/${id}`);
+      navigate(`/table/edit/${id}`);
     } else {
       clickTimerRef.current = setTimeout(() => {
         clickTimerRef.current = null;
@@ -61,7 +61,7 @@ export function TableListView() {
     setAddName("");
     setAddLogical("");
     setAddCategory("");
-    navigate(`/tables/${table.id}`);
+    navigate(`/table/edit/${table.id}`);
   };
 
   const handleDelete = async (id: string, e: React.MouseEvent) => {

--- a/designer/src/mcp/mcpBridge.ts
+++ b/designer/src/mcp/mcpBridge.ts
@@ -657,7 +657,7 @@ class McpBridgeImpl {
             break;
           }
           if (this.navigateHandler) {
-            this.navigateHandler(`/design/${screenId}`);
+            this.navigateHandler(`/screen/design/${screenId}`);
             respond({ success: true });
           } else {
             respondError("ナビゲーションハンドラが登録されていません");
@@ -762,12 +762,12 @@ class McpBridgeImpl {
             const screen = project.screens.find((s) => s.id === tScreenId);
             if (!screen) { respondError(`画面が見つかりません: ${tScreenId}`); break; }
             openTab({ id: makeTabId("design", tScreenId), type: "design", resourceId: tScreenId, label: screen.name });
-            if (this.navigateHandler) this.navigateHandler(`/design/${tScreenId}`);
+            if (this.navigateHandler) this.navigateHandler(`/screen/design/${tScreenId}`);
           } else if (tTableId) {
             const table = await loadTable(tTableId);
             if (!table) { respondError(`テーブルが見つかりません: ${tTableId}`); break; }
             openTab({ id: makeTabId("table", tTableId), type: "table", resourceId: tTableId, label: table.logicalName ?? table.name });
-            if (this.navigateHandler) this.navigateHandler(`/tables/${tTableId}`);
+            if (this.navigateHandler) this.navigateHandler(`/table/edit/${tTableId}`);
           } else {
             respondError("screenId または tableId が必要です");
             break;
@@ -793,7 +793,11 @@ class McpBridgeImpl {
           setActiveTab(sTabId);
           const tab = tabs.find((t) => t.id === sTabId)!;
           if (this.navigateHandler) {
-            const path = tab.type === "design" ? `/design/${tab.resourceId}` : `/tables/${tab.resourceId}`;
+            const path =
+              tab.type === "design" ? `/screen/design/${tab.resourceId}`
+              : tab.type === "table" ? `/table/edit/${tab.resourceId}`
+              : tab.type === "action" ? `/process-flow/edit/${tab.resourceId}`
+              : `/screen/flow`;
             this.navigateHandler(path);
           }
           respond({ success: true });


### PR DESCRIPTION
Part of #86 (1/9)

## Summary

Java 風 \`/category/feature[/:id]\` 形式に統一。\"flow\" 単体では画面/処理どちらのフローか不明だった曖昧性を解消。

| 旧 | 新 |
|----|----|
| \`/\` (FlowEditor) | \`/screen/flow\`（暫定: \`/\` は \`<Navigate>\` でリダイレクト。PR-3 で Dashboard に差し替え）|
| \`/design/:id\` | \`/screen/design/:id\` |
| \`/tables\` | \`/table/list\` |
| \`/tables/:id\` | \`/table/edit/:id\` |
| \`/er\` | \`/table/er\` |
| \`/actions\` | \`/process-flow/list\` |
| \`/actions/:id\` | \`/process-flow/edit/:id\` |

## 変更範囲

- \`AppShell.tsx\`: Route 定義・matchPath・URL↔タブ同期ロジック
- \`HeaderMenu.tsx\`: MENU_ITEMS を新 route に、\`matchPrefix\` を \`activePaths\` / \`activePrefixes\` に刷新
- 全 navigate() 箇所: ScreenDesigner / FlowEditor / ScreenTableView / TableEditor / TableListView / ErDiagram / ActionEditor / ActionListView
- \`mcpBridge.ts\`: navigateHandler の発行パス
- Playwright 全テスト: goto() / toHaveURL を新 URL に

## Test plan

- [x] Vitest 94/94 パス
- [x] Playwright 53/55 パス
- [x] 残 2 件: \`Ctrl+Tab\` の flaky は **main でも再現する pre-existing**（今回の変更起因ではない）
- [x] \`tsc -b\`: 新規エラーなし

## 次の PR

- PR-2: 全一覧・シングルトンのタブ化
- PR-3: Dashboard placeholder + HeaderMenu のダッシュボード有効化

🤖 Generated with [Claude Code](https://claude.com/claude-code)