### PR TITLE
feat(tabs): 全一覧・シングルトンワークスペースをタブ化 (#86 PR-2)

### DIFF
--- a/designer/src/components/AppShell.tsx
+++ b/designer/src/components/AppShell.tsx
@@ -20,6 +20,7 @@ import {
   setActiveTab,
   makeTabId,
   type TabItem,
+  type TabType,
 } from "../store/tabStore";
 import { useTabKeyboard } from "../hooks/useTabKeyboard";
 
@@ -102,6 +103,24 @@ export function AppShell() {
           }
         }).catch(console.error);
       }
+      return;
+    }
+
+    // シングルトンタブ: list / workspace 系は resourceId="main" で 1 インスタンスのみ
+    const singletonRoutes: ReadonlyArray<{ path: string; type: TabType; label: string }> = [
+      { path: "/screen/flow",        type: "screen-flow",        label: "画面フロー" },
+      { path: "/table/list",         type: "table-list",         label: "テーブル一覧" },
+      { path: "/table/er",           type: "er",                 label: "ER図" },
+      { path: "/process-flow/list",  type: "process-flow-list",  label: "処理フロー一覧" },
+    ];
+    for (const { path, type, label } of singletonRoutes) {
+      if (location.pathname === path) {
+        const tabId = makeTabId(type, "main");
+        const existing = getTabs().find((t) => t.id === tabId);
+        if (existing) setActiveTab(tabId);
+        else openTab({ id: tabId, type, resourceId: "main", label });
+        return;
+      }
     }
   }, [location.pathname]);
 
@@ -110,13 +129,15 @@ export function AppShell() {
   useEffect(() => {
     if (!activeTab) return;
     const expectedPath =
-      activeTab.type === "design"
-        ? `/screen/design/${activeTab.resourceId}`
-        : activeTab.type === "table"
-        ? `/table/edit/${activeTab.resourceId}`
-        : activeTab.type === "action"
-        ? `/process-flow/edit/${activeTab.resourceId}`
-        : null;
+      activeTab.type === "design"             ? `/screen/design/${activeTab.resourceId}`
+      : activeTab.type === "table"            ? `/table/edit/${activeTab.resourceId}`
+      : activeTab.type === "action"           ? `/process-flow/edit/${activeTab.resourceId}`
+      : activeTab.type === "screen-flow"      ? "/screen/flow"
+      : activeTab.type === "table-list"       ? "/table/list"
+      : activeTab.type === "er"               ? "/table/er"
+      : activeTab.type === "process-flow-list" ? "/process-flow/list"
+      : activeTab.type === "dashboard"        ? "/"
+      : null;
     if (expectedPath && location.pathname !== expectedPath) {
       navigate(expectedPath, { replace: true });
     }

--- a/designer/src/components/TabBar.tsx
+++ b/designer/src/components/TabBar.tsx
@@ -65,8 +65,13 @@ function TabItem({
 
   const icon =
     tab.type === "design" ? "bi-window"
-    : tab.type === "table" ? "bi-table"
-    : tab.type === "action" ? "bi-lightning"
+    : tab.type === "table" ? "bi-columns-gap"
+    : tab.type === "action" ? "bi-lightning-charge"
+    : tab.type === "screen-flow" ? "bi-diagram-3"
+    : tab.type === "table-list" ? "bi-table"
+    : tab.type === "er" ? "bi-share"
+    : tab.type === "process-flow-list" ? "bi-list-task"
+    : tab.type === "dashboard" ? "bi-speedometer2"
     : "bi-file-earmark";
 
   const handleClick = () => setActiveTab(tab.id);

--- a/designer/src/store/tabStore.ts
+++ b/designer/src/store/tabStore.ts
@@ -1,7 +1,17 @@
 const TABS_KEY = "designer-open-tabs";
 const ACTIVE_KEY = "designer-active-tab";
 
-export type TabType = "design" | "table" | "action";
+export type TabType =
+  // マルチインスタンス（リソース ID 毎に独立タブ）
+  | "design"          // 画面デザイナー
+  | "table"           // テーブル編集
+  | "action"          // 処理フロー編集
+  // シングルトン（1 インスタンス固定。resourceId は "main" で統一）
+  | "screen-flow"        // 画面フロー図
+  | "table-list"         // テーブル一覧
+  | "er"                 // ER 図
+  | "process-flow-list"  // 処理フロー一覧
+  | "dashboard";         // ダッシュボード（#86 PR-3 で有効化）
 
 export interface TabItem {
   id: string;


### PR DESCRIPTION
Part of #86 (2/9)

## Summary

HeaderMenu から到達できる画面をすべてシングルトンタブとして扱えるよう、TabType を拡張し URL↔タブ同期を追加。

### TabType 拡張

\`\`\`ts
export type TabType =
  // マルチインスタンス（リソース ID 毎に独立タブ）
  | \"design\" | \"table\" | \"action\"
  // シングルトン（1 インスタンス固定。resourceId は \"main\"）
  | \"screen-flow\" | \"table-list\" | \"er\" | \"process-flow-list\"
  | \"dashboard\";  // PR-3 で有効化
\`\`\`

### 動作

- \`/screen/flow\` アクセス → \`screen-flow:main\` タブを自動オープン（既にあれば切替）
- \`/table/list\` → \`table-list:main\` タブ
- \`/table/er\` → \`er:main\` タブ
- \`/process-flow/list\` → \`process-flow-list:main\` タブ
- タブ切替時のアクティブ→URL sync も全 type に対応

### 変更ファイル

- \`tabStore.ts\`: TabType 拡張
- \`AppShell.tsx\`: URL↔タブ同期を新 type に拡張（singletonRoutes 配列で統一的に処理）
- \`TabBar.tsx\`: 新 type のアイコン定義

## 互換性の注意

\`table\` タイプ（テーブル編集）のアイコンを \`bi-table\` → \`bi-columns-gap\` に変更。\`bi-table\` は新 \`table-list\` タブで使用するため。

## Test plan

- [x] Vitest 94/94 パス
- [x] Playwright save-reset / save-reset-flow / save-reset-action: 23/23 パス
- [x] Playwright tab-management: 13/14 パス（1 件は pre-existing Ctrl+Tab flaky）
- [x] \`tsc -b\`: 新規エラーなし

## 次の PR

- PR-3: Dashboard placeholder + \`/\` ルート + HeaderMenu のダッシュボード有効化

🤖 Generated with [Claude Code](https://claude.com/claude-code)