### PR TITLE
feat(dashboard): Dashboard 骨組み + HeaderMenu 有効化 (#86 PR-3)

### DIFF
--- a/designer/e2e/save-reset-flow.spec.ts
+++ b/designer/e2e/save-reset-flow.spec.ts
@@ -35,7 +35,7 @@ async function setupFlowEditor(page: Page, draft: object | null = null) {
     },
     { project: dummyProject, draft },
   );
-  await page.goto("/");
+  await page.goto("/screen/flow");
   await expect(page.locator(".flow-root")).toBeVisible();
 }
 

--- a/designer/src/components/AppShell.tsx
+++ b/designer/src/components/AppShell.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Routes, Route, Navigate, useLocation, useNavigate, matchPath } from "react-router-dom";
+import { Routes, Route, useLocation, useNavigate, matchPath } from "react-router-dom";
 import { FlowEditor } from "./flow/FlowEditor";
 import { TableListView } from "./table/TableListView";
 import { TableEditor } from "./table/TableEditor";
@@ -7,6 +7,7 @@ import { ErDiagram } from "./table/ErDiagram";
 import { ActionListView } from "./action/ActionListView";
 import { ActionEditor } from "./action/ActionEditor";
 import { Designer } from "./Designer";
+import { DashboardView } from "./dashboard/DashboardView";
 import { TabBar } from "./TabBar";
 import { CommonHeader } from "./CommonHeader";
 import { loadProject } from "../store/flowStore";
@@ -108,6 +109,7 @@ export function AppShell() {
 
     // シングルトンタブ: list / workspace 系は resourceId="main" で 1 インスタンスのみ
     const singletonRoutes: ReadonlyArray<{ path: string; type: TabType; label: string }> = [
+      { path: "/",                   type: "dashboard",          label: "ダッシュボード" },
       { path: "/screen/flow",        type: "screen-flow",        label: "画面フロー" },
       { path: "/table/list",         type: "table-list",         label: "テーブル一覧" },
       { path: "/table/er",           type: "er",                 label: "ER図" },
@@ -168,8 +170,7 @@ export function AppShell() {
       {/* 非デザインコンテンツ: 通常ルーティング */}
       {!activeIsDesign && (
         <Routes>
-          {/* / は PR-3 で Dashboard に差し替え。それまでは /screen/flow にリダイレクト */}
-          <Route path="/" element={<Navigate to="/screen/flow" replace />} />
+          <Route path="/" element={<DashboardView />} />
           <Route path="/screen/flow" element={<FlowEditor />} />
           <Route path="/screen/design/:screenId" element={null} />
           <Route path="/table/list" element={<TableListView />} />

--- a/designer/src/components/HeaderMenu.tsx
+++ b/designer/src/components/HeaderMenu.tsx
@@ -38,8 +38,8 @@ const DASHBOARD_ITEM: MenuItem = {
   id: "dashboard",
   label: "ダッシュボード",
   icon: "bi-speedometer2",
-  route: "/dashboard",
-  disabled: true,
+  route: "/",
+  activePaths: ["/"],
 };
 
 function isDesignTabActive(): boolean {
@@ -105,14 +105,12 @@ export function HeaderMenu() {
 
           <button
             key={DASHBOARD_ITEM.id}
-            className="header-menu-item disabled"
-            disabled
+            className={`header-menu-item${isActive(DASHBOARD_ITEM) ? " active" : ""}`}
+            onClick={() => handleSelect(DASHBOARD_ITEM.route)}
             role="menuitem"
-            title="ダッシュボード（準備中）"
           >
             <i className={`bi ${DASHBOARD_ITEM.icon}`} />
             <span>{DASHBOARD_ITEM.label}</span>
-            <span className="header-menu-badge">準備中</span>
           </button>
 
           <div className="header-menu-separator" />

--- a/designer/src/components/dashboard/DashboardView.tsx
+++ b/designer/src/components/dashboard/DashboardView.tsx
@@ -1,0 +1,25 @@
+/**
+ * ダッシュボード画面（placeholder）
+ *
+ * PR-4 で react-grid-layout + panelRegistry を導入し、パネル 3 種を表示する。
+ * 本 PR-3 では骨組みだけを提供する。
+ */
+import "../../styles/dashboard.css";
+
+export function DashboardView() {
+  return (
+    <div className="dashboard-view">
+      <div className="dashboard-header">
+        <h1 className="dashboard-title">
+          <i className="bi bi-speedometer2" /> ダッシュボード
+        </h1>
+        <p className="dashboard-subtitle">プロジェクト全体の状況を俯瞰</p>
+      </div>
+
+      <div className="dashboard-placeholder">
+        <i className="bi bi-grid-3x3-gap" />
+        <p>パネル実装準備中（Issue #86 PR-4 以降で追加予定）</p>
+      </div>
+    </div>
+  );
+}

--- a/designer/src/styles/dashboard.css
+++ b/designer/src/styles/dashboard.css
@@ -1,0 +1,57 @@
+/* ダッシュボード画面のベーススタイル（PR-3 skeleton） */
+
+.dashboard-view {
+  padding: 24px;
+  height: calc(100vh - var(--common-header-h, 40px) - var(--tabbar-h, 0px));
+  overflow-y: auto;
+  background: #f8fafc;
+}
+
+.dashboard-header {
+  margin-bottom: 24px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.dashboard-title {
+  margin: 0 0 4px 0;
+  font-size: 20px;
+  font-weight: 600;
+  color: #1e293b;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.dashboard-title .bi {
+  color: #6366f1;
+  font-size: 22px;
+}
+
+.dashboard-subtitle {
+  margin: 0;
+  font-size: 13px;
+  color: #64748b;
+}
+
+.dashboard-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 64px 24px;
+  background: #fff;
+  border: 1px dashed #cbd5e1;
+  border-radius: 8px;
+  color: #94a3b8;
+  gap: 12px;
+}
+
+.dashboard-placeholder .bi {
+  font-size: 48px;
+}
+
+.dashboard-placeholder p {
+  margin: 0;
+  font-size: 14px;
+}


### PR DESCRIPTION
Part of #86 (3/9)

## Summary

\`/\` に Dashboard placeholder を配置し、HeaderMenu の「ダッシュボード」項目を有効化。

### 変更

- \`components/dashboard/DashboardView.tsx\` 新設（placeholder UI）
- \`styles/dashboard.css\` 新設
- \`AppShell.tsx\`: \`/\` ルートに \`<DashboardView />\`、URL↔タブ同期に dashboard singleton を追加
- \`HeaderMenu.tsx\`: DASHBOARD_ITEM を \`disabled=\"準備中\"\` から有効化、route を \`/\` に
- \`save-reset-flow.spec.ts\`: \`goto(\"/\")\` → \`goto(\"/screen/flow\")\` に更新

### 挙動

- \`/\` アクセス → Dashboard タブを自動オープン + 表示
- HeaderMenu クリック → ダッシュボードタブ有効化
- 現時点では placeholder のみ。パネルは PR-4 以降で追加

## Test plan

- [x] Vitest 94/94 パス
- [x] Playwright save-reset 系 23/23 パス
- [x] \`tsc -b\`: 新規エラーなし

## 次の PR

- PR-4: react-grid-layout 導入 + panelRegistry 型定義 + 1 placeholder panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)