### PR TITLE
feat(dashboard): react-grid-layout + panelRegistry 土台 (#86 PR-4)

### DIFF
--- a/designer/package-lock.json
+++ b/designer/package-lock.json
@@ -20,6 +20,7 @@
         "html2canvas": "^1.4.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-grid-layout": "^2.2.3",
         "react-router-dom": "^7.14.0"
       },
       "devDependencies": {
@@ -30,6 +31,7 @@
         "@types/node": "^24.12.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "@types/react-grid-layout": "^1.3.6",
         "@vitejs/plugin-react": "^6.0.1",
         "@vitest/ui": "^4.1.4",
         "eslint": "^9.39.4",
@@ -1474,6 +1476,16 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/react-grid-layout": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@types/react-grid-layout/-/react-grid-layout-1.3.6.tgz",
+      "integrity": "sha512-Cw7+sb3yyjtmxwwJiXtEXcu5h4cgs+sCGkHwHXsFmPyV30bf14LeD/fa2LwQovuD2HWxCcjIdNhDlcYGj95qGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/underscore": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.13.0.tgz",
@@ -2265,6 +2277,15 @@
       "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
       "license": "MIT"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/codemirror": {
       "version": "5.63.0",
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.63.0.tgz",
@@ -2825,6 +2846,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-equals": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-4.0.3.tgz",
+      "integrity": "sha512-G3BSX9cfKttjr+2o1O22tYMLq0DPluZnYtq1rXumE1SpL/F/SLIfHx08WYQoWSIpeMYf8sRbJ8++71+v6Pnxfg==",
+      "license": "MIT"
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -3129,7 +3156,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -3551,6 +3577,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3685,6 +3723,15 @@
       "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/obug": {
       "version": "2.1.1",
@@ -3942,6 +3989,23 @@
       "integrity": "sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==",
       "license": "MIT"
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3973,6 +4037,38 @@
         "react": "^19.2.5"
       }
     },
+    "node_modules/react-draggable": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.5.0.tgz",
+      "integrity": "sha512-VC+HBLEZ0XJxnOxVAZsdRi8rD04Iz3SiiKOoYzamjylUcju/hP9np/aZdLHf/7WOD268WMoNJMvYfB5yAK45cw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/react-grid-layout": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-grid-layout/-/react-grid-layout-2.2.3.tgz",
+      "integrity": "sha512-OAEJHBxmfuxQfVtZwRzmsokijGlBgzYIJ7MUlLk/VSa43SaGzu15w5D0P2RDrfX5EvP9POMbL6bFrai/huDzbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "fast-equals": "^4.0.3",
+        "prop-types": "^15.8.1",
+        "react-draggable": "^4.4.6",
+        "react-resizable": "^3.1.3",
+        "resize-observer-polyfill": "^1.5.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -3980,6 +4076,20 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-resizable": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-3.1.3.tgz",
+      "integrity": "sha512-liJBNayhX7qA4tBJiBD321FDhJxgGTJ07uzH5zSORXoE8h7PyEZ8mLqmosST7ppf6C4zUsbd2gzDMmBCfFp9Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "15.x",
+        "react-draggable": "^4.5.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3",
+        "react-dom": ">= 16.3"
+      }
     },
     "node_modules/react-router": {
       "version": "7.14.0",
@@ -4042,6 +4152,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",

--- a/designer/package.json
+++ b/designer/package.json
@@ -25,6 +25,7 @@
     "html2canvas": "^1.4.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-grid-layout": "^2.2.3",
     "react-router-dom": "^7.14.0"
   },
   "devDependencies": {
@@ -35,6 +36,7 @@
     "@types/node": "^24.12.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@types/react-grid-layout": "^1.3.6",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/ui": "^4.1.4",
     "eslint": "^9.39.4",

--- a/designer/src/components/dashboard/DashboardView.tsx
+++ b/designer/src/components/dashboard/DashboardView.tsx
@@ -1,25 +1,133 @@
 /**
- * ダッシュボード画面（placeholder）
+ * ダッシュボード画面
  *
- * PR-4 で react-grid-layout + panelRegistry を導入し、パネル 3 種を表示する。
- * 本 PR-3 では骨組みだけを提供する。
+ * react-grid-layout でパネルをドラッグ/リサイズ可能に配置し、
+ * レイアウト状態を localStorage に永続化する。
+ *
+ * パネルの定義は `panelRegistry.ts` に集約。新規パネル追加時は
+ * 本ファイルの変更は不要。
  */
+import { useCallback, useMemo, useState } from "react";
+import { Responsive, WidthProvider, type Layout, type LayoutItem } from "react-grid-layout/legacy";
+import { dashboardPanels } from "./panelRegistry";
+import "react-grid-layout/css/styles.css";
+import "react-resizable/css/styles.css";
 import "../../styles/dashboard.css";
 
+const ResponsiveGridLayout = WidthProvider(Responsive);
+
+const LAYOUT_STORAGE_KEY = "dashboard-layout-v1";
+const ROW_HEIGHT = 80;
+const BREAKPOINTS = { lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0 };
+const COLS = { lg: 12, md: 10, sm: 6, xs: 4, xxs: 2 };
+
+// react-grid-layout v2: Layout = LayoutItem[]（breakpoint 毎の layout を保持する map）
+type StoredLayouts = Partial<Record<string, Layout>>;
+
+function loadStoredLayouts(): StoredLayouts | null {
+  try {
+    const raw = localStorage.getItem(LAYOUT_STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as StoredLayouts) : null;
+  } catch {
+    return null;
+  }
+}
+
+function storeLayouts(layouts: StoredLayouts): void {
+  try {
+    localStorage.setItem(LAYOUT_STORAGE_KEY, JSON.stringify(layouts));
+  } catch { /* ignore */ }
+}
+
+/** 登録済みパネルから初期レイアウトを生成 */
+function buildDefaultLayout(): LayoutItem[] {
+  let cursorY = 0;
+  return dashboardPanels.map((p, i) => {
+    const x = p.defaultLayout.x ?? (i * p.defaultLayout.w) % COLS.lg;
+    const y = p.defaultLayout.y ?? cursorY;
+    cursorY = y + p.defaultLayout.h;
+    return {
+      i: p.id,
+      x,
+      y,
+      w: p.defaultLayout.w,
+      h: p.defaultLayout.h,
+      minW: p.defaultLayout.minW,
+      minH: p.defaultLayout.minH,
+      maxW: p.defaultLayout.maxW,
+      maxH: p.defaultLayout.maxH,
+    };
+  });
+}
+
 export function DashboardView() {
+  const defaultLayout = useMemo(() => buildDefaultLayout(), []);
+  const [layouts, setLayouts] = useState<StoredLayouts>(() => {
+    const stored = loadStoredLayouts();
+    if (stored) return stored;
+    return { lg: defaultLayout };
+  });
+
+  const handleLayoutChange = useCallback(
+    (_current: Layout, allLayouts: StoredLayouts) => {
+      setLayouts(allLayouts);
+      storeLayouts(allLayouts);
+    },
+    [],
+  );
+
+  if (dashboardPanels.length === 0) {
+    return (
+      <div className="dashboard-view">
+        <div className="dashboard-header">
+          <h1 className="dashboard-title">
+            <i className="bi bi-speedometer2" /> ダッシュボード
+          </h1>
+          <p className="dashboard-subtitle">プロジェクト全体の状況を俯瞰</p>
+        </div>
+        <div className="dashboard-placeholder">
+          <i className="bi bi-grid-3x3-gap" />
+          <p>パネルが未登録です（Issue #86 PR-5 以降で追加予定）</p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="dashboard-view">
       <div className="dashboard-header">
         <h1 className="dashboard-title">
           <i className="bi bi-speedometer2" /> ダッシュボード
         </h1>
-        <p className="dashboard-subtitle">プロジェクト全体の状況を俯瞰</p>
+        <p className="dashboard-subtitle">
+          プロジェクト全体の状況を俯瞰 <span className="dashboard-hint">（パネルはドラッグ/リサイズ可能）</span>
+        </p>
       </div>
 
-      <div className="dashboard-placeholder">
-        <i className="bi bi-grid-3x3-gap" />
-        <p>パネル実装準備中（Issue #86 PR-4 以降で追加予定）</p>
-      </div>
+      <ResponsiveGridLayout
+        className="dashboard-grid"
+        layouts={layouts}
+        breakpoints={BREAKPOINTS}
+        cols={COLS}
+        rowHeight={ROW_HEIGHT}
+        onLayoutChange={handleLayoutChange}
+        draggableHandle=".panel-drag-handle"
+      >
+        {dashboardPanels.map((p) => {
+          const PanelComponent = p.component;
+          return (
+            <div key={p.id} className="dashboard-panel">
+              <div className="panel-header panel-drag-handle">
+                {p.icon && <i className={`bi ${p.icon}`} />}
+                <span className="panel-title">{p.title}</span>
+              </div>
+              <div className="panel-body">
+                <PanelComponent />
+              </div>
+            </div>
+          );
+        })}
+      </ResponsiveGridLayout>
     </div>
   );
 }

--- a/designer/src/components/dashboard/panelRegistry.ts
+++ b/designer/src/components/dashboard/panelRegistry.ts
@@ -1,0 +1,52 @@
+/**
+ * ダッシュボードパネルレジストリ
+ *
+ * 新しいパネルを追加する際は、本ファイルの `dashboardPanels` 配列に項目を追加するだけで
+ * ダッシュボードに表示されるようにする拡張性重視の設計。
+ *
+ * 各パネルは独立コンポーネントとして以下を自己完結:
+ *  - データ取得
+ *  - レンダリング
+ *  - エラーハンドリング
+ * 他パネルに影響しないこと。
+ */
+import type { ComponentType } from "react";
+
+/** react-grid-layout の 1 パネルのレイアウト指定 */
+export interface PanelLayout {
+  /** 幅（カラム数、ダッシュボードは 12 カラム想定）*/
+  w: number;
+  /** 高さ（行数、1 行 = `rowHeight` px）*/
+  h: number;
+  /** 初期 X 位置（省略時は自動配置）*/
+  x?: number;
+  /** 初期 Y 位置（省略時は自動配置）*/
+  y?: number;
+  /** 最小幅 */
+  minW?: number;
+  /** 最小高さ */
+  minH?: number;
+  /** 最大幅 */
+  maxW?: number;
+  /** 最大高さ */
+  maxH?: number;
+}
+
+export interface DashboardPanel {
+  /** ユニーク ID（localStorage キーや react-grid-layout の item key に使う）*/
+  id: string;
+  /** パネルタイトル（ヘッダーに表示）*/
+  title: string;
+  /** Bootstrap Icons クラス名（例: "bi-bar-chart"）*/
+  icon?: string;
+  /** 初期レイアウト指定 */
+  defaultLayout: PanelLayout;
+  /** パネル本体コンポーネント（props は受け取らない。データ取得は自身で行う）*/
+  component: ComponentType;
+}
+
+/**
+ * 登録されたダッシュボードパネル一覧。
+ * 配列の順序が初期表示順を決める（y, x が未指定の場合）。
+ */
+export const dashboardPanels: DashboardPanel[] = [];

--- a/designer/src/styles/dashboard.css
+++ b/designer/src/styles/dashboard.css
@@ -55,3 +55,79 @@
   margin: 0;
   font-size: 14px;
 }
+
+.dashboard-hint {
+  font-size: 11px;
+  color: #94a3b8;
+  margin-left: 8px;
+}
+
+/* react-grid-layout カスタマイズ */
+.dashboard-grid {
+  position: relative;
+}
+
+.dashboard-panel {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  transition: box-shadow 0.15s;
+}
+
+.dashboard-panel:hover {
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.08);
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  background: #f8fafc;
+  border-bottom: 1px solid #e2e8f0;
+  font-weight: 600;
+  color: #334155;
+  font-size: 13px;
+  user-select: none;
+}
+
+.panel-drag-handle {
+  cursor: move;
+}
+
+.panel-header .bi {
+  color: #6366f1;
+  font-size: 14px;
+}
+
+.panel-title {
+  flex: 1;
+}
+
+.panel-body {
+  flex: 1;
+  padding: 12px 14px;
+  overflow: auto;
+  font-size: 13px;
+  color: #475569;
+}
+
+/* react-grid-layout のハンドル色を少し薄く */
+.react-grid-item > .react-resizable-handle {
+  opacity: 0.3;
+  transition: opacity 0.15s;
+}
+
+.react-grid-item:hover > .react-resizable-handle {
+  opacity: 0.7;
+}
+
+.react-grid-item.react-grid-placeholder {
+  background: #6366f1;
+  opacity: 0.2;
+  border-radius: 8px;
+}


### PR DESCRIPTION
Part of #86 (4/9)

## Summary

Dashboard にパネルを載せるための基盤を追加。

### 依存追加

- \`react-grid-layout@2.2.3\`
- \`@types/react-grid-layout\` (devDep)

v2 は新 API（hooks）に移行中。当面は \`react-grid-layout/legacy\` 経由の \`WidthProvider\` + \`Responsive\` を使用。

### 新設

- \`components/dashboard/panelRegistry.ts\`
  - \`DashboardPanel\` 型（id, title, icon, defaultLayout, component）
  - \`dashboardPanels\` 配列（初期は空）
- \`components/dashboard/DashboardView.tsx\` を react-grid-layout 化
  - 5 ブレークポイント対応（lg/md/sm/xs/xxs）
  - \`localStorage[\"dashboard-layout-v1\"]\` にレイアウト永続化
  - パネルヘッダーをドラッグハンドル化

### 拡張性

今後パネル追加は **panelRegistry.ts の配列に 1 項目追加** で完結。DashboardView の変更は不要。

```ts
dashboardPanels.push({
  id: \"my-panel\",
  title: \"...\",
  icon: \"bi-...\",
  defaultLayout: { w: 4, h: 3 },
  component: MyPanel,
});
```

## Test plan

- [x] Vitest 94/94 パス
- [x] Playwright save-reset 系 23/23 パス
- [x] \`tsc -b\` + \`vite build\` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)