### PR TITLE
feat(dashboard): FunctionCountsPanel 実装 (#86 PR-5)

### DIFF
--- a/designer/src/components/dashboard/panelRegistry.ts
+++ b/designer/src/components/dashboard/panelRegistry.ts
@@ -11,6 +11,7 @@
  * 他パネルに影響しないこと。
  */
 import type { ComponentType } from "react";
+import { FunctionCountsPanel } from "./panels/FunctionCountsPanel";
 
 /** react-grid-layout の 1 パネルのレイアウト指定 */
 export interface PanelLayout {
@@ -49,4 +50,12 @@ export interface DashboardPanel {
  * 登録されたダッシュボードパネル一覧。
  * 配列の順序が初期表示順を決める（y, x が未指定の場合）。
  */
-export const dashboardPanels: DashboardPanel[] = [];
+export const dashboardPanels: DashboardPanel[] = [
+  {
+    id: "function-counts",
+    title: "機能別定義数",
+    icon: "bi-bar-chart-line",
+    defaultLayout: { w: 6, h: 3, minW: 4, minH: 3 },
+    component: FunctionCountsPanel,
+  },
+];

--- a/designer/src/components/dashboard/panels/FunctionCountsPanel.tsx
+++ b/designer/src/components/dashboard/panels/FunctionCountsPanel.tsx
@@ -1,0 +1,107 @@
+/**
+ * 機能別定義数パネル
+ *
+ * プロジェクト内の主要リソース（画面 / テーブル / 処理フロー / FK 関係）の
+ * 総数を集計してカード形式で表示する。
+ */
+import { useEffect, useState } from "react";
+import { loadProject } from "../../../store/flowStore";
+import { listTables, loadTable } from "../../../store/tableStore";
+import { mcpBridge } from "../../../mcp/mcpBridge";
+
+interface Counts {
+  screens: number;
+  tables: number;
+  actionGroups: number;
+  foreignKeys: number;
+}
+
+const INITIAL: Counts = { screens: 0, tables: 0, actionGroups: 0, foreignKeys: 0 };
+
+async function fetchCounts(): Promise<Counts> {
+  const project = await loadProject();
+  const screens = project.screens?.length ?? 0;
+  const actionGroups = project.actionGroups?.length ?? 0;
+
+  const tableMetas = await listTables();
+  const tables = tableMetas.length;
+
+  // FK 数は各テーブル定義の columns を舐める必要あり
+  let foreignKeys = 0;
+  for (const m of tableMetas) {
+    const td = await loadTable(m.id);
+    if (!td) continue;
+    for (const col of td.columns ?? []) {
+      if (col.foreignKey?.tableId && col.foreignKey?.columnName) foreignKeys++;
+    }
+  }
+
+  return { screens, tables, actionGroups, foreignKeys };
+}
+
+export function FunctionCountsPanel() {
+  const [counts, setCounts] = useState<Counts>(INITIAL);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const reload = async () => {
+      try {
+        const c = await fetchCounts();
+        if (!cancelled) {
+          setCounts(c);
+          setError(null);
+        }
+      } catch (e) {
+        if (!cancelled) setError(String(e));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    reload();
+
+    // プロジェクト変更 / テーブル変更 / 処理フロー変更で再集計
+    const unsubProject = mcpBridge.onBroadcast("projectChanged", reload);
+    const unsubTable = mcpBridge.onBroadcast("tableChanged", reload);
+    const unsubAction = mcpBridge.onBroadcast("actionGroupChanged", reload);
+    const unsubStatus = mcpBridge.onStatusChange((s) => {
+      if (s === "connected") reload();
+    });
+
+    return () => {
+      cancelled = true;
+      unsubProject();
+      unsubTable();
+      unsubAction();
+      unsubStatus();
+    };
+  }, []);
+
+  if (error) {
+    return <div className="panel-error"><i className="bi bi-exclamation-triangle" /> 集計失敗: {error}</div>;
+  }
+
+  const items: Array<{ label: string; value: number; icon: string; color: string }> = [
+    { label: "画面", value: counts.screens, icon: "bi-window", color: "#6366f1" },
+    { label: "テーブル", value: counts.tables, icon: "bi-table", color: "#0284c7" },
+    { label: "処理フロー", value: counts.actionGroups, icon: "bi-lightning-charge", color: "#f59e0b" },
+    { label: "FK 関係", value: counts.foreignKeys, icon: "bi-share", color: "#10b981" },
+  ];
+
+  return (
+    <div className="function-counts-panel">
+      {items.map((it) => (
+        <div key={it.label} className="count-card" style={{ borderLeftColor: it.color }}>
+          <i className={`bi ${it.icon}`} style={{ color: it.color }} />
+          <div className="count-body">
+            <div className="count-value">{loading ? "…" : it.value}</div>
+            <div className="count-label">{it.label}</div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/designer/src/styles/dashboard.css
+++ b/designer/src/styles/dashboard.css
@@ -131,3 +131,52 @@
   opacity: 0.2;
   border-radius: 8px;
 }
+
+.panel-error {
+  padding: 12px;
+  color: #b91c1c;
+  font-size: 12px;
+  background: #fef2f2;
+  border-radius: 4px;
+}
+
+/* FunctionCountsPanel 固有 */
+.function-counts-panel {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+  height: 100%;
+}
+
+.count-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px;
+  background: #f8fafc;
+  border-left: 4px solid #6366f1;
+  border-radius: 6px;
+  min-height: 64px;
+}
+
+.count-card .bi {
+  font-size: 24px;
+}
+
+.count-body {
+  display: flex;
+  flex-direction: column;
+}
+
+.count-value {
+  font-size: 22px;
+  font-weight: 700;
+  color: #1e293b;
+  line-height: 1;
+}
+
+.count-label {
+  font-size: 12px;
+  color: #64748b;
+  margin-top: 2px;
+}


### PR DESCRIPTION
Part of #86 (5/9)

## Summary

機能別定義数パネル。画面 / テーブル / 処理フロー / FK 関係の総数をカード表示。

### データソース

- 画面: `loadProject().screens.length`
- テーブル: `listTables().length`
- 処理フロー: `loadProject().actionGroups.length`
- FK 関係: 各 `loadTable(id).columns` を走査して `foreignKey` 設定ありを集計

### 自動更新

- `projectChanged` broadcast 受信 → 再集計
- `tableChanged` broadcast 受信 → 再集計
- `actionGroupChanged` broadcast 受信 → 再集計
- WS 再接続時（`onStatusChange("connected")`) → 再集計

### 登録

panelRegistry に 1 項目追加（w=6, h=3, minW=4, minH=3）。

## Test plan

- [x] Vitest 94/94 パス
- [x] `tsc -b` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)