### PR TITLE
feat(dashboard): UnsavedDraftsPanel 実装 (#86 PR-6)

### DIFF
--- a/designer/src/components/dashboard/panelRegistry.ts
+++ b/designer/src/components/dashboard/panelRegistry.ts
@@ -12,6 +12,7 @@
  */
 import type { ComponentType } from "react";
 import { FunctionCountsPanel } from "./panels/FunctionCountsPanel";
+import { UnsavedDraftsPanel } from "./panels/UnsavedDraftsPanel";
 
 /** react-grid-layout の 1 パネルのレイアウト指定 */
 export interface PanelLayout {
@@ -57,5 +58,12 @@ export const dashboardPanels: DashboardPanel[] = [
     icon: "bi-bar-chart-line",
     defaultLayout: { w: 6, h: 3, minW: 4, minH: 3 },
     component: FunctionCountsPanel,
+  },
+  {
+    id: "unsaved-drafts",
+    title: "未保存ドラフト",
+    icon: "bi-hourglass-split",
+    defaultLayout: { w: 6, h: 4, minW: 4, minH: 3 },
+    component: UnsavedDraftsPanel,
   },
 ];

--- a/designer/src/components/dashboard/panels/UnsavedDraftsPanel.tsx
+++ b/designer/src/components/dashboard/panels/UnsavedDraftsPanel.tsx
@@ -1,0 +1,117 @@
+/**
+ * 未永続化ドラフトパネル
+ *
+ * localStorage に残っているがサーバーに保存されていないドラフトを一覧表示し、
+ * 「開く」（該当エディタへ遷移）「破棄」（localStorage から削除）を提供する。
+ */
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { listAllDrafts, clearDraft, type DraftMeta } from "../../../utils/draftStorage";
+
+interface DraftView extends DraftMeta {
+  kindLabel: string;
+  route: string | null;
+}
+
+const KIND_META: Record<string, { label: string; route: (id: string) => string }> = {
+  table: { label: "テーブル", route: (id) => `/table/edit/${id}` },
+  action: { label: "処理フロー", route: (id) => `/process-flow/edit/${id}` },
+  flow: { label: "画面フロー", route: () => "/screen/flow" },
+};
+
+function enrich(draft: DraftMeta): DraftView {
+  const meta = KIND_META[draft.kind];
+  return {
+    ...draft,
+    kindLabel: meta?.label ?? draft.kind,
+    route: meta?.route(draft.id) ?? null,
+  };
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function shortId(id: string): string {
+  if (id.length <= 12) return id;
+  return `${id.slice(0, 8)}…${id.slice(-4)}`;
+}
+
+export function UnsavedDraftsPanel() {
+  const navigate = useNavigate();
+  const [drafts, setDrafts] = useState<DraftView[]>([]);
+
+  const reload = useCallback(() => {
+    setDrafts(listAllDrafts().map(enrich));
+  }, []);
+
+  useEffect(() => {
+    reload();
+    // localStorage は他タブやエディタでの編集でも変わるため storage イベントで追随
+    window.addEventListener("storage", reload);
+    // 他タブからの変更以外は storage イベントが飛ばないため、定期リフレッシュで補完
+    const tid = window.setInterval(reload, 5000);
+    return () => {
+      window.removeEventListener("storage", reload);
+      clearInterval(tid);
+    };
+  }, [reload]);
+
+  const handleOpen = (d: DraftView) => {
+    if (d.route) navigate(d.route);
+  };
+
+  const handleDiscard = (d: DraftView) => {
+    if (!confirm(`${d.kindLabel}「${shortId(d.id)}」の未保存ドラフトを破棄しますか？`)) return;
+    clearDraft(d.kind, d.id);
+    reload();
+  };
+
+  if (drafts.length === 0) {
+    return (
+      <div className="drafts-empty">
+        <i className="bi bi-check-circle" />
+        <span>未保存のドラフトはありません</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="drafts-panel">
+      <div className="drafts-count">
+        <i className="bi bi-hourglass-split" /> {drafts.length} 件のドラフト
+      </div>
+      <ul className="drafts-list">
+        {drafts.map((d) => (
+          <li key={d.key} className="draft-row">
+            <div className="draft-info">
+              <span className="draft-kind">{d.kindLabel}</span>
+              <code className="draft-id">{shortId(d.id)}</code>
+              <span className="draft-size">{formatSize(d.size)}</span>
+            </div>
+            <div className="draft-actions">
+              {d.route && (
+                <button
+                  className="draft-btn draft-btn-open"
+                  onClick={() => handleOpen(d)}
+                  title="該当エディタを開く"
+                >
+                  <i className="bi bi-box-arrow-up-right" />
+                </button>
+              )}
+              <button
+                className="draft-btn draft-btn-discard"
+                onClick={() => handleDiscard(d)}
+                title="このドラフトを破棄"
+              >
+                <i className="bi bi-trash" />
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/designer/src/styles/dashboard.css
+++ b/designer/src/styles/dashboard.css
@@ -180,3 +180,122 @@
   color: #64748b;
   margin-top: 2px;
 }
+
+/* UnsavedDraftsPanel 固有 */
+.drafts-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  height: 100%;
+  color: #10b981;
+  font-size: 13px;
+}
+
+.drafts-empty .bi {
+  font-size: 18px;
+}
+
+.drafts-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  height: 100%;
+}
+
+.drafts-count {
+  font-size: 12px;
+  color: #64748b;
+  padding-bottom: 6px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.drafts-count .bi {
+  color: #f59e0b;
+  margin-right: 4px;
+}
+
+.drafts-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.draft-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 8px;
+  border-bottom: 1px solid #f1f5f9;
+  gap: 8px;
+}
+
+.draft-row:hover {
+  background: #f8fafc;
+}
+
+.draft-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
+}
+
+.draft-kind {
+  font-size: 11px;
+  font-weight: 600;
+  color: #334155;
+  background: #e0e7ff;
+  padding: 2px 6px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.draft-id {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 11px;
+  color: #64748b;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.draft-size {
+  font-size: 11px;
+  color: #94a3b8;
+  flex-shrink: 0;
+}
+
+.draft-actions {
+  display: flex;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.draft-btn {
+  border: 1px solid transparent;
+  background: transparent;
+  padding: 4px 6px;
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 12px;
+  color: #64748b;
+  transition: all 0.15s;
+}
+
+.draft-btn:hover {
+  border-color: #cbd5e1;
+  background: #fff;
+}
+
+.draft-btn-open:hover {
+  color: #6366f1;
+  border-color: #6366f1;
+}
+
+.draft-btn-discard:hover {
+  color: #dc2626;
+  border-color: #dc2626;
+}


### PR DESCRIPTION
Part of #86 (6/9)

## Summary

localStorage に残っている未保存ドラフトを一覧表示。開く/破棄アクション付き。

### データソース

- `listAllDrafts()`（utils/draftStorage.ts、#84 で追加済み）
- kind → route マッピング:
  - `table` → `/table/edit/:id`
  - `action` → `/process-flow/edit/:id`
  - `flow` → `/screen/flow`

### 自動更新

- `storage` イベント受信
- 5 秒間隔の setInterval（storage イベントは他タブの変更でしか飛ばないため同一タブ更新を補完）

### UI

- 0 件 → 「未保存のドラフトはありません」緑チェック
- 1 件以上 → kind バッジ + 短縮 id + サイズ + 開く/破棄ボタン
- 破棄は confirm 経由

### 登録

panelRegistry に 1 項目追加（w=6, h=4）。

## Test plan

- [x] Vitest 94/94 パス
- [x] `tsc -b` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)