### PR TITLE
feat(dashboard): RecentEditsPanel 実装 (#86 PR-7)

### DIFF
--- a/designer/src/components/dashboard/panelRegistry.ts
+++ b/designer/src/components/dashboard/panelRegistry.ts
@@ -13,6 +13,7 @@
 import type { ComponentType } from "react";
 import { FunctionCountsPanel } from "./panels/FunctionCountsPanel";
 import { UnsavedDraftsPanel } from "./panels/UnsavedDraftsPanel";
+import { RecentEditsPanel } from "./panels/RecentEditsPanel";
 
 /** react-grid-layout の 1 パネルのレイアウト指定 */
 export interface PanelLayout {
@@ -65,5 +66,12 @@ export const dashboardPanels: DashboardPanel[] = [
     icon: "bi-hourglass-split",
     defaultLayout: { w: 6, h: 4, minW: 4, minH: 3 },
     component: UnsavedDraftsPanel,
+  },
+  {
+    id: "recent-edits",
+    title: "最近編集したもの",
+    icon: "bi-clock-history",
+    defaultLayout: { w: 6, h: 5, minW: 4, minH: 4 },
+    component: RecentEditsPanel,
   },
 ];

--- a/designer/src/components/dashboard/panels/RecentEditsPanel.tsx
+++ b/designer/src/components/dashboard/panels/RecentEditsPanel.tsx
@@ -1,0 +1,153 @@
+/**
+ * 最近編集したものパネル
+ *
+ * サーバー側ファイルの mtime を取得し、画面 / テーブル / 処理フローを
+ * 横断した更新日時降順リストを表示。クリックで該当エディタを開く。
+ */
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { loadProject } from "../../../store/flowStore";
+import { listTables } from "../../../store/tableStore";
+import { fetchServerMtime, type MtimeKind } from "../../../utils/serverMtime";
+import { mcpBridge } from "../../../mcp/mcpBridge";
+
+const MAX_ITEMS = 10;
+
+interface RecentItem {
+  kind: "screen" | "table" | "actionGroup";
+  id: string;
+  name: string;
+  mtime: number;
+  route: string;
+}
+
+const KIND_META: Record<RecentItem["kind"], { label: string; icon: string; color: string; route: (id: string) => string }> = {
+  screen: { label: "画面", icon: "bi-window", color: "#6366f1", route: (id) => `/screen/design/${id}` },
+  table: { label: "テーブル", icon: "bi-table", color: "#0284c7", route: (id) => `/table/edit/${id}` },
+  actionGroup: { label: "処理フロー", icon: "bi-lightning-charge", color: "#f59e0b", route: (id) => `/process-flow/edit/${id}` },
+};
+
+function formatRelative(mtime: number, now: number): string {
+  const diff = now - mtime;
+  const sec = Math.floor(diff / 1000);
+  if (sec < 60) return `${sec} 秒前`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min} 分前`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr} 時間前`;
+  const day = Math.floor(hr / 24);
+  if (day < 30) return `${day} 日前`;
+  return new Date(mtime).toLocaleDateString();
+}
+
+async function fetchAll(): Promise<RecentItem[]> {
+  const [project, tables] = await Promise.all([loadProject(), listTables()]);
+
+  const resources: Array<{ kind: MtimeKind; id: string; name: string; displayKind: RecentItem["kind"] }> = [
+    ...project.screens.map((s) => ({ kind: "screen" as MtimeKind, id: s.id, name: s.name, displayKind: "screen" as RecentItem["kind"] })),
+    ...tables.map((t) => ({ kind: "table" as MtimeKind, id: t.id, name: t.logicalName ?? t.name, displayKind: "table" as RecentItem["kind"] })),
+    ...(project.actionGroups ?? []).map((a) => ({ kind: "actionGroup" as MtimeKind, id: a.id, name: a.name, displayKind: "actionGroup" as RecentItem["kind"] })),
+  ];
+
+  const withMtime = await Promise.all(
+    resources.map(async (r) => {
+      const mtime = await fetchServerMtime(r.kind, r.id);
+      if (mtime === null) return null;
+      return {
+        kind: r.displayKind,
+        id: r.id,
+        name: r.name,
+        mtime,
+        route: KIND_META[r.displayKind].route(r.id),
+      } satisfies RecentItem;
+    }),
+  );
+
+  return withMtime
+    .filter((x): x is RecentItem => x !== null)
+    .sort((a, b) => b.mtime - a.mtime)
+    .slice(0, MAX_ITEMS);
+}
+
+export function RecentEditsPanel() {
+  const navigate = useNavigate();
+  const [items, setItems] = useState<RecentItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [now, setNow] = useState(() => Date.now());
+
+  const reload = useCallback(async () => {
+    try {
+      const list = await fetchAll();
+      setItems(list);
+      setError(null);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    reload();
+    const unsubProject = mcpBridge.onBroadcast("projectChanged", reload);
+    const unsubScreen = mcpBridge.onBroadcast("screenChanged", reload);
+    const unsubTable = mcpBridge.onBroadcast("tableChanged", reload);
+    const unsubAction = mcpBridge.onBroadcast("actionGroupChanged", reload);
+    const unsubStatus = mcpBridge.onStatusChange((s) => {
+      if (s === "connected") reload();
+    });
+    // 相対時間を 30 秒毎に更新
+    const tid = window.setInterval(() => setNow(Date.now()), 30_000);
+    return () => {
+      unsubProject();
+      unsubScreen();
+      unsubTable();
+      unsubAction();
+      unsubStatus();
+      clearInterval(tid);
+    };
+  }, [reload]);
+
+  if (error) {
+    return <div className="panel-error"><i className="bi bi-exclamation-triangle" /> 取得失敗: {error}</div>;
+  }
+
+  if (loading) {
+    return <div className="recent-loading"><i className="bi bi-hourglass" /> 読み込み中...</div>;
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className="recent-empty">
+        <i className="bi bi-inbox" />
+        <span>編集履歴がまだありません</span>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="recent-list">
+      {items.map((it) => {
+        const meta = KIND_META[it.kind];
+        return (
+          <li
+            key={`${it.kind}:${it.id}`}
+            className="recent-row"
+            onClick={() => navigate(it.route)}
+            title={`${meta.label}: ${it.name}`}
+          >
+            <i className={`bi ${meta.icon} recent-icon`} style={{ color: meta.color }} />
+            <div className="recent-body">
+              <div className="recent-name">{it.name}</div>
+              <div className="recent-meta">
+                <span className="recent-kind">{meta.label}</span>
+                <span className="recent-time">{formatRelative(it.mtime, now)}</span>
+              </div>
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/designer/src/styles/dashboard.css
+++ b/designer/src/styles/dashboard.css
@@ -299,3 +299,76 @@
   color: #dc2626;
   border-color: #dc2626;
 }
+
+/* RecentEditsPanel 固有 */
+.recent-loading, .recent-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  height: 100%;
+  color: #94a3b8;
+  font-size: 13px;
+}
+
+.recent-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  overflow-y: auto;
+  height: 100%;
+}
+
+.recent-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px;
+  border-bottom: 1px solid #f1f5f9;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.recent-row:hover {
+  background: #f1f5f9;
+}
+
+.recent-icon {
+  font-size: 18px;
+  flex-shrink: 0;
+}
+
+.recent-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.recent-name {
+  font-size: 13px;
+  color: #1e293b;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.recent-meta {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-top: 2px;
+}
+
+.recent-kind {
+  font-size: 10px;
+  font-weight: 600;
+  color: #64748b;
+  background: #e2e8f0;
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+
+.recent-time {
+  font-size: 11px;
+  color: #94a3b8;
+}


### PR DESCRIPTION
Part of #86 (7/9)

## Summary

画面 / テーブル / 処理フローを横断した更新日時降順リスト。上位 10 件表示。クリックで該当エディタへ。

### データソース

- `loadProject().screens` + `listTables()` + `loadProject().actionGroups` で全リソース取得
- `getFileMtime` を並列発行して mtime を取得
- mtime が null（ファイル無し）は除外
- mtime 降順ソート → `slice(0, 10)`

### UI

- 相対時間（N 秒前 / N 分前 / N 時間前 / N 日前 / 日付）
- 30 秒毎に相対時間を自動更新
- クリック → 該当エディタ URL へ navigate

### 自動更新

- broadcast: `projectChanged` / `screenChanged` / `tableChanged` / `actionGroupChanged`
- WS 再接続時

### 登録

panelRegistry に 1 項目追加（w=6, h=5）。

## 完了状況

これで #86 の 3 パネル全てが揃いました。残るは PR-8（結合テスト）。

## Test plan

- [x] Vitest 94/94 パス
- [x] `tsc -b` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)