### PR TITLE
fix(app): URL /screen/design/:id 解決中の空領域とリソース不存在の袋小路を解消 (#124)

### DIFF
--- a/designer/e2e/resource-url-sync.spec.ts
+++ b/designer/e2e/resource-url-sync.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * resource-url-sync.spec.ts (#124)
+ *
+ * /screen/design/:id の URL to タブ同期の堅牢性テスト。
+ * - URL 解決中の空領域が出ないこと (ResourceLoading 表示)
+ * - 存在しないリソースはダッシュボードへフォールバックすること
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+
+const SCREEN_A = "screen-aaaa-0001";
+
+const projectWithScreen = {
+  version: 1,
+  name: "E2E",
+  screens: [
+    {
+      id: SCREEN_A,
+      name: "画面A",
+      type: "form",
+      description: "",
+      path: "/a",
+      position: { x: 0, y: 0 },
+      size: { width: 200, height: 100 },
+      hasDesign: true,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+  ],
+  groups: [],
+  edges: [],
+  updatedAt: new Date().toISOString(),
+};
+
+async function setupStorage(page: Page, opts: { tabs: unknown[]; active: string; project?: unknown }) {
+  await page.addInitScript((o) => {
+    if (o.project) localStorage.setItem("flow-project", JSON.stringify(o.project));
+    localStorage.setItem("designer-open-tabs", JSON.stringify(o.tabs));
+    localStorage.setItem("designer-active-tab", o.active);
+    // alert は goto をブロックするので握り潰す
+    window.alert = () => {};
+  }, opts);
+}
+
+test("デザイン URL 解決中でもヘッダーは生き残り、タブが確定する", async ({ page }) => {
+  await setupStorage(page, {
+    project: projectWithScreen,
+    tabs: [
+      { id: "dashboard:main", type: "dashboard", resourceId: "main", label: "ダッシュボード", isDirty: false, isPinned: false },
+    ],
+    active: "dashboard:main",
+  });
+
+  await page.goto(`/screen/design/${SCREEN_A}`);
+  await expect(page.locator(".common-header")).toBeVisible();
+  await expect(page.locator(".tabbar-tab")).not.toHaveCount(0);
+});
+
+test("存在しないスクリーン ID の URL はダッシュボードにフォールバックされエラーログに記録される", async ({ page }) => {
+  await setupStorage(page, {
+    project: projectWithScreen,
+    tabs: [
+      { id: "dashboard:main", type: "dashboard", resourceId: "main", label: "ダッシュボード", isDirty: false, isPinned: false },
+    ],
+    active: "dashboard:main",
+  });
+
+  await page.goto("/screen/design/non-existent-screen-id-xxxx");
+  await expect(page).toHaveURL(/\/$/);
+  await expect(page.locator(".common-header")).toBeVisible();
+
+  const errorLog = await page.evaluate(() => {
+    const raw = localStorage.getItem("designer-error-log");
+    return raw ? JSON.parse(raw) : [];
+  });
+  expect(errorLog.length).toBeGreaterThan(0);
+  expect(errorLog.some((e: { message: string }) => /見つかりません/.test(e.message))).toBe(true);
+});

--- a/designer/src/components/AppShell.tsx
+++ b/designer/src/components/AppShell.tsx
@@ -27,6 +27,8 @@ import {
 import { useTabKeyboard } from "../hooks/useTabKeyboard";
 import { ErrorBoundary } from "./common/ErrorBoundary";
 import { TabErrorFallback } from "./common/ErrorFallback";
+import { ResourceLoading } from "./common/ResourceLoading";
+import { recordError } from "../utils/errorLog";
 
 function useTabs() {
   const [tabs, setTabs] = useState<readonly TabItem[]>(getTabs);
@@ -56,6 +58,23 @@ export function AppShell() {
     document.documentElement.style.setProperty("--tabbar-h", h);
   }, [tabs.length]);
 
+  // リソース詳細 URL で対象が見つからなかったときにダッシュボードへ戻す共通処理。
+  // ブラウザが握っている URL を「存在しないリソース」のまま放置すると次回リロードで
+  // また袋小路に入るため、URL 自体も / に書き換える。
+  const fallbackToDashboard = (kind: string, id: string) => {
+    recordError({
+      source: "manual",
+      message: `URL が指すリソース (${kind}: ${id}) が見つかりません。ダッシュボードへフォールバック。`,
+      context: { kind, id, pathname: location.pathname },
+    });
+    if (typeof window !== "undefined") {
+      // ユーザーに明示。alert は UI ブロッキングだがトースト基盤が未導入なので暫定採用。
+      // 置き換えは将来の共通トースト導入時に実施する。
+      alert(`指定された${kind}が見つかりません。ダッシュボードに戻ります。`);
+    }
+    navigate("/", { replace: true });
+  };
+
   // URL → タブ同期（ブラウザの直接ナビゲーション / mcpBridge.navigateScreen）
   useEffect(() => {
     const designMatch = matchPath("/screen/design/:screenId", location.pathname);
@@ -70,8 +89,13 @@ export function AppShell() {
           const screen = project.screens.find((s) => s.id === screenId);
           if (screen) {
             openTab({ id: tabId, type: "design", resourceId: screenId, label: screen.name });
+          } else {
+            fallbackToDashboard("画面", screenId);
           }
-        }).catch(console.error);
+        }).catch((e) => {
+          recordError({ source: "manual", message: "loadProject 失敗", stack: e instanceof Error ? e.stack : undefined });
+          fallbackToDashboard("画面", screenId);
+        });
       }
       return;
     }
@@ -87,8 +111,13 @@ export function AppShell() {
         loadTable(tableId).then((table) => {
           if (table) {
             openTab({ id: tabId, type: "table", resourceId: tableId, label: table.logicalName ?? table.name });
+          } else {
+            fallbackToDashboard("テーブル", tableId);
           }
-        }).catch(console.error);
+        }).catch((e) => {
+          recordError({ source: "manual", message: "loadTable 失敗", stack: e instanceof Error ? e.stack : undefined });
+          fallbackToDashboard("テーブル", tableId);
+        });
       }
       return;
     }
@@ -104,8 +133,13 @@ export function AppShell() {
         loadActionGroup(actionGroupId).then((ag) => {
           if (ag) {
             openTab({ id: tabId, type: "action", resourceId: actionGroupId, label: ag.name });
+          } else {
+            fallbackToDashboard("処理フロー", actionGroupId);
           }
-        }).catch(console.error);
+        }).catch((e) => {
+          recordError({ source: "manual", message: "loadActionGroup 失敗", stack: e instanceof Error ? e.stack : undefined });
+          fallbackToDashboard("処理フロー", actionGroupId);
+        });
       }
       return;
     }
@@ -205,7 +239,10 @@ export function AppShell() {
           <Routes>
             <Route path="/" element={<DashboardView />} />
             <Route path="/screen/flow" element={<FlowEditor />} />
-            <Route path="/screen/design/:screenId" element={null} />
+            {/* design は designTabs 経由で別レンダーされるが、
+                 URL→タブ同期 effect の解決中に一瞬こちらのブランチが描画される。
+                 以前は element={null} で真っ白だったのを ResourceLoading に置換 (#124) */}
+            <Route path="/screen/design/:screenId" element={<ResourceLoading kind="screen" />} />
             <Route path="/table/list" element={<TableListView />} />
             <Route path="/table/edit/:tableId" element={<TableEditor />} />
             <Route path="/table/er" element={<ErDiagram />} />

--- a/designer/src/components/common/ResourceLoading.tsx
+++ b/designer/src/components/common/ResourceLoading.tsx
@@ -1,0 +1,31 @@
+/**
+ * リソース詳細 URL (/screen/design/:id 等) にヒットしたが
+ * 対応するタブがまだ解決されていない短い時間に表示するプレースホルダ。
+ *
+ * URL→タブ同期 effect が非同期で loadProject/loadTable/loadActionGroup を
+ * 叩くため、1〜数フレームこの UI が出る可能性がある。
+ * 以前は element={null} だったため、この間コンテンツ領域が完全に空になって
+ * 「真っ白」の症状を招いていた (#124)。
+ */
+import "../../styles/resourceLoading.css";
+
+interface Props {
+  kind: "screen" | "table" | "action-group";
+}
+
+const LABEL: Record<Props["kind"], string> = {
+  "screen": "画面",
+  "table": "テーブル",
+  "action-group": "処理フロー",
+};
+
+export function ResourceLoading({ kind }: Props) {
+  return (
+    <div className="resource-loading" role="status" aria-live="polite">
+      <div className="resource-loading-inner">
+        <div className="resource-loading-spinner" aria-hidden="true" />
+        <p>{LABEL[kind]}を読み込んでいます…</p>
+      </div>
+    </div>
+  );
+}

--- a/designer/src/styles/resourceLoading.css
+++ b/designer/src/styles/resourceLoading.css
@@ -1,0 +1,31 @@
+.resource-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: calc(100vh - var(--common-header-h, 0px) - var(--tabbar-h, 0px));
+  background: #fafbfc;
+}
+
+.resource-loading-inner {
+  text-align: center;
+  color: #6c757d;
+}
+
+.resource-loading-inner p {
+  margin: 0.75rem 0 0;
+  font-size: 0.95rem;
+}
+
+.resource-loading-spinner {
+  display: inline-block;
+  width: 28px;
+  height: 28px;
+  border: 3px solid #dee2e6;
+  border-top-color: #6c757d;
+  border-radius: 50%;
+  animation: resource-loading-spin 0.9s linear infinite;
+}
+
+@keyframes resource-loading-spin {
+  to { transform: rotate(360deg); }
+}


### PR DESCRIPTION
Fixes #124

## Summary
- \`<Route path=\"/screen/design/:screenId\" element={null} />\` が URL→タブ同期 effect の解決中に空を描画していた問題に対し、\`ResourceLoading\` 表示を導入
- URL→タブ同期 effect が対象画面／テーブル／処理フローを見つけられなかった場合、エラーログに記録してダッシュボード \`/\` に replace-navigate する共通ハンドラ \`fallbackToDashboard\` を追加
- \`loadProject\` / \`loadTable\` / \`loadActionGroup\` 自体の reject も同ハンドラで拾う

## Test plan
- [x] Vitest: 100 pass
- [x] Playwright: `e2e/resource-url-sync.spec.ts` 2 pass, `e2e/error-boundary.spec.ts` 3 pass, `e2e/tab-management.spec.ts` 13/14 pass (1 件は既知 Ctrl+Tab flaky)
- [x] TS build: `npm run build` 通過

## 動作確認
1. localStorage で \`active=dashboard:main\`, \`tabs=[dashboard]\`, URL=/screen/design/実在ID → ResourceLoading が短く出た後、design タブが開く
2. URL=/screen/design/存在しないID → alert が出てダッシュボードへ戻る。\`designer-error-log\` にエラーが記録される
3. \`/table/edit/:id\` と \`/process-flow/edit/:id\` も同様のフォールバック

## 注記
- リソース不存在通知は alert で暫定実装。共通トースト基盤が入り次第差し替え
- URL→タブ / タブ→URL の2 effect 競合は本 PR では温存 (挙動は実用上の収束を確認済み)。整理は別 PR で

🤖 Generated with [Claude Code](https://claude.com/claude-code)