### PR TITLE
fix(designer): 破損画面データで Canvas.init が落ちる問題を修正 (#131)

### DIFF
--- a/designer/e2e/designer-corrupt-data.spec.ts
+++ b/designer/e2e/designer-corrupt-data.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * 画面データが空・破損している場合でも Designer が起動できることを検証する (#131)。
+ *
+ * 背景: remoteStorage.load() が空 {} や pages 欠落データを返すと、GrapesJS の Canvas.init が
+ *       getFrames() undefined で落ち、RightPanel もその editor を触ってクラッシュする連鎖があった。
+ * 対応: ensureValidProject() で最小構造を常に保証。抑制対象のイベント（初期ロード時の
+ *       Canvas.init）が実際に発火する不正データ形状で検証する。
+ */
+import { test, expect, type Page } from "@playwright/test";
+
+const SCREEN_ID = "bbbbbbbb-0001-4000-8000-bbbbbbbbbbbb";
+
+const project = {
+  version: 1,
+  name: "corrupt-data test",
+  screens: [
+    {
+      id: SCREEN_ID,
+      name: "破損テスト画面",
+      path: "/corrupt",
+      description: "",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+  ],
+  groups: [],
+  edges: [],
+  tables: [],
+  updatedAt: new Date().toISOString(),
+};
+
+const dummyTab = {
+  id: `design:${SCREEN_ID}`,
+  type: "design",
+  resourceId: SCREEN_ID,
+  label: "破損テスト画面",
+  isDirty: false,
+  isPinned: false,
+};
+
+async function setupDesignerWithRawData(page: Page, rawData: unknown, withDraft: boolean) {
+  await page.addInitScript(
+    ({ project, screenId, tab, rawData, withDraft }) => {
+      localStorage.setItem("flow-project", JSON.stringify(project));
+      localStorage.setItem(`gjs-screen-${screenId}`, JSON.stringify(rawData));
+      localStorage.setItem("designer-open-tabs", JSON.stringify([tab]));
+      localStorage.setItem("designer-active-tab", tab.id);
+      if (withDraft) {
+        // draftKey="1" にすると load() は localStorage を優先参照するため破損データが直接使われる
+        localStorage.setItem(`gjs-screen-${screenId}-draft`, "1");
+      } else {
+        localStorage.removeItem(`gjs-screen-${screenId}-draft`);
+      }
+    },
+    { project, screenId: SCREEN_ID, tab: dummyTab, rawData, withDraft },
+  );
+  await page.goto(`/screen/design/${SCREEN_ID}`);
+}
+
+test.describe("Designer 破損データ耐性 (#131)", () => {
+  test("空オブジェクト {} でも起動し、TabErrorFallback が出ない", async ({ page }) => {
+    await setupDesignerWithRawData(page, {}, /* withDraft */ true);
+
+    // エラーフォールバックが出ていないこと
+    await expect(page.locator(".tab-error-fallback")).not.toBeVisible();
+    await expect(page.locator(".app-error-fallback")).not.toBeVisible();
+
+    // リセットボタン（= Designer 起動成功のマーカー）が出ること
+    await expect(page.locator(".srb-btn-reset")).toBeVisible({ timeout: 15000 });
+  });
+
+  test("pages 欠落データでも起動し、ErrorDialog も出ない", async ({ page }) => {
+    await setupDesignerWithRawData(
+      page,
+      { assets: [], styles: [], dataSources: [] }, // pages 欠落
+      /* withDraft */ true,
+    );
+
+    await expect(page.locator(".tab-error-fallback")).not.toBeVisible();
+    await expect(page.locator(".error-dialog-panel")).not.toBeVisible();
+    await expect(page.locator(".srb-btn-reset")).toBeVisible({ timeout: 15000 });
+  });
+
+  test("破損データ起動時に errorLog に痕跡が残る", async ({ page }) => {
+    await setupDesignerWithRawData(page, {}, /* withDraft */ true);
+    await expect(page.locator(".srb-btn-reset")).toBeVisible({ timeout: 15000 });
+
+    const log = await page.evaluate(() => {
+      const raw = localStorage.getItem("designer-error-log");
+      return raw ? JSON.parse(raw) : [];
+    });
+    // デバッグ用: 失敗時に実際のログを見られるよう assertion 前にダンプ
+    console.log("[test] errorLog entries:", log.map((e: { message: string }) => e.message));
+    expect(log.length).toBeGreaterThan(0);
+    // "画面データ" または "pages" を含むメッセージが残っていること
+    expect(
+      log.some((e: { message: string }) => /画面データ|pages/.test(e.message)),
+    ).toBe(true);
+  });
+});

--- a/designer/src/components/Designer.tsx
+++ b/designer/src/components/Designer.tsx
@@ -23,6 +23,20 @@ import { loadCustomBlocks, injectCustomBlockCss } from "../store/customBlockStor
 import { loadProject, updateScreenThumbnail } from "../store/flowStore";
 import { makeTabId, setDirty } from "../store/tabStore";
 
+/**
+ * editor.getComponents() は GrapesJS が load() 中の Frame.onRemove 経由で一時的に
+ * 内部参照を undefined にするタイミングがあり、そこで `.length` を呼ぶと落ちる (#131)。
+ * 取得失敗時は 0 として扱い、listener 側がクラッシュしないようにする。
+ */
+function safeComponentsLength(editor: GEditor): number {
+  try {
+    const comps = editor.getComponents?.();
+    return comps?.length ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
 /** キャンバスの縮小サムネイルを生成して data URL で返す */
 async function captureThumbnail(editor: GEditor): Promise<string | null> {
   try {
@@ -258,7 +272,10 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
       isDirtyRef.current = false;
       setDirty(tabId, false);
     }
-    isInternalLoadRef.current = false;
+    // GrapesJS が component:add を遅延発火するケース（ensureValidProject による
+    // 最小 pages 補正で空データからでも load() 後に 1 回発火する）に備え、
+    // 次のマクロタスクでガードを下げる (#131)。
+    setTimeout(() => { isInternalLoadRef.current = false; }, 0);
     if (editorRef.current) {
       if (activeTheme !== "standard") {
         applyThemeToCanvas(editorRef.current, activeTheme);
@@ -287,7 +304,7 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
 
     const onStoreEnd = () => {
       // 空のキャンバスはスキップ
-      if (editor.getComponents().length === 0) return;
+      if (safeComponentsLength(editor) === 0) return;
       captureThumbnail(editor).then(async (thumbnail) => {
         if (!thumbnail) return;
         try {
@@ -309,7 +326,7 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
   useEffect(() => {
     if (!ready || !editorRef.current) return;
     const editor = editorRef.current;
-    const check = () => setCanvasEmpty(editor.getComponents().length === 0);
+    const check = () => setCanvasEmpty(safeComponentsLength(editor) === 0);
     check();
     editor.on("component:add", check);
     editor.on("component:remove", check);
@@ -376,7 +393,9 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
         context: { screenId, tabId },
       });
     } finally {
-      isInternalLoadRef.current = false;
+      // GrapesJS が component:add / autosave を遅延発火するケースに備えて
+      // 次のマクロタスクでガードを下げる。遅延中に発火した markDirty も抑制したい。
+      setTimeout(() => { isInternalLoadRef.current = false; }, 0);
     }
   }, [screenId, tabId, showError]);
 

--- a/designer/src/components/RightPanel.tsx
+++ b/designer/src/components/RightPanel.tsx
@@ -30,9 +30,16 @@ export function RightPanel() {
 
     const onLoad = () => setLoaded(true);
 
-    // 既にロード済みならすぐセット
-    if (editor.getComponents().length > 0 || editor.getStyle().length > 0) {
-      setLoaded(true);
+    // 既にロード済みならすぐセット。editor が半壊状態（初期化中 or 破損データで
+    // Canvas.init が失敗した直後）でも throw しないよう防御する (#131)。
+    try {
+      const comps = editor.getComponents?.();
+      const styles = editor.getStyle?.();
+      if ((comps && comps.length > 0) || (styles && styles.length > 0)) {
+        setLoaded(true);
+      }
+    } catch {
+      /* editor 未初期化は load イベントで拾う */
     }
     editor.on("load", onLoad);
     return () => {

--- a/designer/src/grapes/remoteStorage.ts
+++ b/designer/src/grapes/remoteStorage.ts
@@ -9,6 +9,47 @@
 import type { Editor as GEditor } from "grapesjs";
 import { mcpBridge } from "../mcp/mcpBridge";
 import { screenStorageKey } from "../store/flowStore";
+import { recordError } from "../utils/errorLog";
+
+/**
+ * GrapesJS が期待する最小プロジェクト構造。pages が欠落していると
+ * Canvas.init の postLoad で getFrames() が undefined.length で落ちる (#131)。
+ * この形状を load() の全フォールバック経路で保証する。
+ */
+const EMPTY_PROJECT: Record<string, unknown> = Object.freeze({
+  assets: [],
+  styles: [],
+  pages: [{ frames: [{ component: { type: "wrapper" } }] }],
+});
+
+/**
+ * 破損・不正形のプロジェクトデータを最低限起動可能な形に補正する。
+ * 補正が発生した場合は errorLog に痕跡を残し、ユーザーが事後にエラーダイアログから
+ * 履歴として確認できるようにする。
+ */
+function ensureValidProject(
+  raw: Record<string, unknown> | null | undefined,
+  screenId: string,
+  source: string,
+): Record<string, unknown> {
+  if (!raw || typeof raw !== "object") {
+    recordError({
+      source: "manual",
+      message: `画面データが空/不正のため、空のプロジェクトで起動します (screenId=${screenId}, source=${source})`,
+      context: { screenId, source },
+    });
+    return { ...EMPTY_PROJECT };
+  }
+  if (!Array.isArray(raw.pages) || raw.pages.length === 0) {
+    recordError({
+      source: "manual",
+      message: `画面データの pages が欠落しています。デフォルト構造で補正しました (screenId=${screenId}, source=${source})`,
+      context: { screenId, source, keys: Object.keys(raw) },
+    });
+    return { ...raw, pages: EMPTY_PROJECT.pages };
+  }
+  return raw;
+}
 
 /** ドラフトマーカーのキー（localStorage 内容が未保存であることを示す） */
 export function screenDraftMarkerKey(screenId: string): string {
@@ -36,30 +77,42 @@ export function registerRemoteStorage(editor: GEditor, screenId: string): void {
       if (localStorage.getItem(draftKey) === "1") {
         const localRaw = localStorage.getItem(localKey);
         if (localRaw) {
-          try { return JSON.parse(localRaw) as Record<string, unknown>; } catch { /* fallthrough */ }
+          try {
+            return ensureValidProject(
+              JSON.parse(localRaw) as Record<string, unknown>,
+              screenId,
+              "draft-localStorage",
+            );
+          } catch { /* fallthrough */ }
         }
       }
       try {
         const data = await mcpBridge.request("loadScreen", { screenId }) as Record<string, unknown> | null;
         if (data && Object.keys(data).length > 0) {
           try { localStorage.setItem(localKey, JSON.stringify(data)); } catch { /* ignore */ }
-          return data;
+          return ensureValidProject(data, screenId, "mcp-loadScreen");
         }
         const localRaw = localStorage.getItem(localKey);
         if (localRaw) {
           try {
             const localData = JSON.parse(localRaw) as Record<string, unknown>;
             await mcpBridge.request("saveScreen", { screenId, data: localData });
-            return localData;
+            return ensureValidProject(localData, screenId, "localStorage-fallback");
           } catch { /* ignore */ }
         }
-        return {};
+        return ensureValidProject(null, screenId, "no-data");
       } catch {
         const raw = localStorage.getItem(localKey);
         if (raw) {
-          try { return JSON.parse(raw) as Record<string, unknown>; } catch { /* ignore */ }
+          try {
+            return ensureValidProject(
+              JSON.parse(raw) as Record<string, unknown>,
+              screenId,
+              "mcp-error-localStorage",
+            );
+          } catch { /* ignore */ }
         }
-        return {};
+        return ensureValidProject(null, screenId, "mcp-error-no-data");
       }
     },
 


### PR DESCRIPTION
closes #131

## Summary

ユーザー環境のエラーログから、画面デザインタブを開いた際に Canvas.init が undefined.length で落ちて起動不能になる連鎖を特定し、3 層で防御しました。

## Root causes (2つ)

### 1. remoteStorage.load() の空データパス
\`return {}\` を GrapesJS に渡すと pages 未定義で Canvas.init の \`getFrames\` が落ちる。

### 2. Designer の listener が editor 半壊状態を触る
\`editor.load()\` は Frame.onRemove を経由して一時的に editor.getComponents() を undefined にするタイミングがあり、そこで \`onStoreEnd\` / \`canvasEmpty check\` / \`RightPanel\` の \`.length\` 呼び出しが throw していた。

## Fix

- \`remoteStorage.load()\` 全パスで \`ensureValidProject()\` を通し、pages を含む最小構造を保証
- 補正時は \`recordError()\` で痕跡を残す
- \`safeComponentsLength(editor)\` ヘルパーで optional chain + try/catch
- \`RightPanel\` の editor 初期アクセスも同じく防御
- \`onReady\` / \`handleReset\` の isInternalLoadRef 解除を次のマクロタスクに遅延

## Test plan

- [x] \`designer-corrupt-data.spec.ts\` 新規 3 件（空/pages 欠落で起動できる + errorLog 痕跡）
- [x] save-reset-designer.spec.ts 6/6 pass（MCP 接続あり環境でも通過）
- [x] \`npm run build\` / Vitest 100/100 pass / Playwright 81/83（既知 flaky 除き全通過）