### PR TITLE
feat(common): エディタヘッダー共通化の基盤 EditorHeader を新設 (#99)

### DIFF
--- a/designer/src/components/common/EditorHeader.test.tsx
+++ b/designer/src/components/common/EditorHeader.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { EditorHeader } from "./EditorHeader";
+
+describe("EditorHeader", () => {
+  it("最小構成で header がレンダリングされる", () => {
+    render(<EditorHeader />);
+    const header = screen.getByTestId("editor-header");
+    expect(header).toBeInTheDocument();
+    expect(header.className).toContain("editor-header-light");
+  });
+
+  it("variant='dark' でダーククラスが付与される", () => {
+    render(<EditorHeader variant="dark" />);
+    expect(screen.getByTestId("editor-header").className).toContain("editor-header-dark");
+  });
+
+  it("backLink を渡すと戻るボタンが出る", () => {
+    const onClick = vi.fn();
+    render(<EditorHeader backLink={{ label: "テーブル一覧", onClick }} />);
+    const btn = screen.getByTestId("editor-header-back");
+    expect(btn).toHaveTextContent("テーブル一覧");
+    fireEvent.click(btn);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("backLink を渡さないと戻るボタンは出ない", () => {
+    render(<EditorHeader />);
+    expect(screen.queryByTestId("editor-header-back")).toBeNull();
+  });
+
+  it("title スロットが描画される", () => {
+    render(<EditorHeader title={<span data-testid="t">タイトル</span>} />);
+    expect(screen.getByTestId("t")).toBeInTheDocument();
+  });
+
+  it("centerTools スロットが描画される", () => {
+    render(<EditorHeader centerTools={<div data-testid="center">中央</div>} />);
+    expect(screen.getByTestId("center")).toBeInTheDocument();
+  });
+
+  it("undoRedo を渡すと Undo/Redo ボタンが出て、canUndo/canRedo=false で disabled になる", () => {
+    const onUndo = vi.fn();
+    const onRedo = vi.fn();
+    render(
+      <EditorHeader
+        undoRedo={{ onUndo, onRedo, canUndo: false, canRedo: false }}
+      />,
+    );
+    const undo = screen.getByTestId("editor-header-undo");
+    const redo = screen.getByTestId("editor-header-redo");
+    expect(undo).toBeDisabled();
+    expect(redo).toBeDisabled();
+  });
+
+  it("canUndo/canRedo=true で有効化されクリックが届く", () => {
+    const onUndo = vi.fn();
+    const onRedo = vi.fn();
+    render(
+      <EditorHeader
+        undoRedo={{ onUndo, onRedo, canUndo: true, canRedo: true }}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("editor-header-undo"));
+    fireEvent.click(screen.getByTestId("editor-header-redo"));
+    expect(onUndo).toHaveBeenCalledTimes(1);
+    expect(onRedo).toHaveBeenCalledTimes(1);
+  });
+
+  it("undoRedo を渡さないと Undo/Redo は描画されない", () => {
+    render(<EditorHeader />);
+    expect(screen.queryByTestId("editor-header-undo-redo")).toBeNull();
+  });
+
+  it("extraRight スロットが描画される", () => {
+    render(<EditorHeader extraRight={<span data-testid="extra">X</span>} />);
+    expect(screen.getByTestId("extra")).toBeInTheDocument();
+  });
+
+  it("saveReset を渡すと SaveResetButtons が出て、isDirty=true で保存が押せる", () => {
+    const onSave = vi.fn();
+    const onReset = vi.fn();
+    render(
+      <EditorHeader
+        saveReset={{ isDirty: true, isSaving: false, onSave, onReset }}
+      />,
+    );
+    const save = screen.getByTitle("保存 (Ctrl+S)");
+    expect(save).not.toBeDisabled();
+    fireEvent.click(save);
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+
+  it("saveReset を渡さないと SaveResetButtons は描画されない", () => {
+    render(<EditorHeader />);
+    expect(screen.queryByTitle("保存 (Ctrl+S)")).toBeNull();
+  });
+});

--- a/designer/src/components/common/EditorHeader.tsx
+++ b/designer/src/components/common/EditorHeader.tsx
@@ -1,0 +1,112 @@
+import type { ReactNode } from "react";
+import "../../styles/editorHeader.css";
+import { SaveResetButtons } from "./SaveResetButtons";
+
+export interface EditorHeaderBackLink {
+  label: string;
+  onClick: () => void;
+  title?: string;
+  icon?: string;
+}
+
+export interface EditorHeaderUndoRedo {
+  onUndo: () => void;
+  onRedo: () => void;
+  canUndo: boolean;
+  canRedo: boolean;
+}
+
+export interface EditorHeaderSaveReset {
+  isDirty: boolean;
+  isSaving: boolean;
+  onSave: () => void;
+  onReset: () => void;
+  resetConfirmMessage?: string;
+}
+
+export type EditorHeaderVariant = "light" | "dark";
+
+interface Props {
+  backLink?: EditorHeaderBackLink;
+  title?: ReactNode;
+  centerTools?: ReactNode;
+  undoRedo?: EditorHeaderUndoRedo;
+  extraRight?: ReactNode;
+  saveReset?: EditorHeaderSaveReset;
+  variant?: EditorHeaderVariant;
+}
+
+export function EditorHeader({
+  backLink,
+  title,
+  centerTools,
+  undoRedo,
+  extraRight,
+  saveReset,
+  variant = "light",
+}: Props) {
+  return (
+    <header className={`editor-header editor-header-${variant}`} data-testid="editor-header">
+      <div className="editor-header-left">
+        {backLink && (
+          <button
+            type="button"
+            className="editor-header-back"
+            onClick={backLink.onClick}
+            title={backLink.title ?? backLink.label}
+            data-testid="editor-header-back"
+          >
+            <i className={`bi ${backLink.icon ?? "bi-arrow-left"}`} />
+            <span className="editor-header-back-label">{backLink.label}</span>
+          </button>
+        )}
+        {title !== undefined && (
+          <div className="editor-header-title">{title}</div>
+        )}
+      </div>
+
+      {centerTools !== undefined && (
+        <div className="editor-header-center">{centerTools}</div>
+      )}
+
+      <div className="editor-header-right">
+        {undoRedo && (
+          <div className="editor-header-undo-redo" data-testid="editor-header-undo-redo">
+            <button
+              type="button"
+              className="editor-header-undo-btn"
+              onClick={undoRedo.onUndo}
+              disabled={!undoRedo.canUndo}
+              title="元に戻す (Ctrl+Z)"
+              data-testid="editor-header-undo"
+            >
+              <i className="bi bi-arrow-counterclockwise" />
+            </button>
+            <button
+              type="button"
+              className="editor-header-undo-btn"
+              onClick={undoRedo.onRedo}
+              disabled={!undoRedo.canRedo}
+              title="やり直し (Ctrl+Y)"
+              data-testid="editor-header-redo"
+            >
+              <i className="bi bi-arrow-clockwise" />
+            </button>
+          </div>
+        )}
+        {extraRight !== undefined && (
+          <div className="editor-header-extra">{extraRight}</div>
+        )}
+        {saveReset && (
+          <SaveResetButtons
+            isDirty={saveReset.isDirty}
+            isSaving={saveReset.isSaving}
+            onSave={saveReset.onSave}
+            onReset={saveReset.onReset}
+            resetConfirmMessage={saveReset.resetConfirmMessage}
+          />
+        )}
+      </div>
+    </header>
+  );
+}

--- a/designer/src/styles/editorHeader.css
+++ b/designer/src/styles/editorHeader.css
@@ -1,0 +1,144 @@
+/* ==========================================================================
+   EditorHeader — 全エディタ共通ヘッダー (#99)
+   backLink / title / centerTools / undoRedo / extraRight / saveReset を
+   スロット API で提供する。light/dark 2 バリアント。
+   ========================================================================== */
+
+.editor-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 48px;
+  padding: 0 16px;
+  gap: 16px;
+  flex-shrink: 0;
+  border-bottom: 1px solid;
+  box-sizing: border-box;
+}
+
+.editor-header-left,
+.editor-header-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.editor-header-right {
+  justify-content: flex-end;
+}
+
+.editor-header-center {
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.editor-header-title {
+  display: flex;
+  align-items: center;
+  font-size: 15px;
+  font-weight: 600;
+  min-width: 0;
+}
+
+.editor-header-extra {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* ── Back button ─────────────────────────── */
+.editor-header-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  cursor: pointer;
+  font-size: 13px;
+  line-height: 1;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.editor-header-back-label {
+  white-space: nowrap;
+}
+
+/* ── Undo/Redo ───────────────────────────── */
+.editor-header-undo-redo {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.editor-header-undo-btn {
+  width: 30px;
+  height: 30px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  cursor: pointer;
+  font-size: 15px;
+  transition: background 0.15s, border-color 0.15s, color 0.15s, opacity 0.15s;
+}
+
+.editor-header-undo-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+/* ── Light variant (Flow / Table / Action 想定) ───────────────── */
+.editor-header-light {
+  background: #ffffff;
+  border-bottom-color: #e2e8f0;
+  color: #1e293b;
+}
+
+.editor-header-light .editor-header-back {
+  color: #475569;
+}
+.editor-header-light .editor-header-back:hover {
+  background: #f1f5f9;
+  color: #1e293b;
+}
+
+.editor-header-light .editor-header-undo-btn {
+  color: #475569;
+}
+.editor-header-light .editor-header-undo-btn:hover:not(:disabled) {
+  background: #f1f5f9;
+  border-color: #e2e8f0;
+  color: #1e293b;
+}
+
+/* ── Dark variant (Designer 想定) ────────────────────────────── */
+.editor-header-dark {
+  background: var(--dz-bg-2, #27293a);
+  border-bottom-color: var(--dz-border, #3b3e55);
+  color: var(--dz-text, #e4e6f0);
+}
+
+.editor-header-dark .editor-header-back {
+  color: var(--dz-text, #e4e6f0);
+}
+.editor-header-dark .editor-header-back:hover {
+  background: var(--dz-bg-3, #30334a);
+  border-color: var(--dz-border, #3b3e55);
+}
+
+.editor-header-dark .editor-header-undo-btn {
+  color: var(--dz-text, #e4e6f0);
+}
+.editor-header-dark .editor-header-undo-btn:hover:not(:disabled) {
+  background: var(--dz-bg-3, #30334a);
+  border-color: var(--dz-border, #3b3e55);
+}

--- a/designer/tsconfig.app.json
+++ b/designer/tsconfig.app.json
@@ -22,5 +22,5 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src"],
-  "exclude": ["src/**/*.test.ts", "src/test"]
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/test"]
 }

--- a/designer/vitest.config.ts
+++ b/designer/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: ["./src/test/setup.ts"],
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
     coverage: {
       include: ["src/store/**", "src/hooks/**", "src/grapes/**", "src/utils/**"],
     },


### PR DESCRIPTION
## Summary

#99 の epic (4 エディタのヘッダー統一) の PR 1/4。**破壊的変更なし**の基盤導入のみ。

- `components/common/EditorHeader.tsx` を新設 — `backLink / title / centerTools / undoRedo / extraRight / saveReset / variant` のスロット API
- `styles/editorHeader.css` を新設 — light (Flow/Table/Action 向け) / dark (Designer 向け) 2 バリアント、統一された Undo/Redo ボタン・戻るボタンスタイル
- `EditorHeader.test.tsx` (12 ケース) で全スロットの出しわけ・disabled・クリックハンドラを検証
- `vitest.config.ts` / `tsconfig.app.json` に `.test.tsx` 対応を追加

既存の 4 エディタからは**まだ参照しない**ため、この PR 単独ではランタイム動作は一切変わらない。後続 PR (Action → Table → Flow + Designer) で段階的に移行していく。

## 設計メモ

- Undo/Redo: 30×30 アイコンボタン (既存の `icon-btn` の小型版) に統一。各エディタの `flow-btn-secondary` / `icon-btn` / `tbl-btn-ghost` / `btn-outline-secondary` を後続 PR で置換していく
- variant の既定は `light` (#99 コメントで提案された方針)。Designer 側は dark で既存ダーク背景を維持できる退避路を残してある
- `SaveResetButtons` は既存の共通コンポーネントをラップして使用

## Test plan

- [x] `npm run test:unit` — 112 tests pass (12 new)
- [x] `npm run build` — TypeScript + Vite build 成功
- [x] 新規ファイルの ESLint 0 errors 0 warnings (既存の 22 errors / 13 warnings は本 PR の範囲外)
- [ ] 目視確認は**後続 PR で**実施 — この PR は未使用コンポーネント追加のみで視覚影響ゼロ

## 後続 PR 予定

- PR 2/4: ActionEditor を EditorHeader に移行
- PR 3/4: TableEditor を EditorHeader に移行
- PR 4/4: FlowEditor / Designer を EditorHeader に移行

Refs #99 #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)