### PR TITLE
improve(action): ActionEditor のヘッダーを EditorHeader に統一 (#99)

### DIFF
--- a/designer/src/components/action/ActionEditor.tsx
+++ b/designer/src/components/action/ActionEditor.tsx
@@ -51,7 +51,7 @@ import { useSelectionKeyboard } from "../../hooks/useSelectionKeyboard";
 import { STEP_TYPE_COLORS } from "../../types/action";
 import { TableSubToolbar } from "../table/TableSubToolbar";
 import { SortableStepCard } from "./SortableStepCard";
-import { SaveResetButtons } from "../common/SaveResetButtons";
+import { EditorHeader } from "../common/EditorHeader";
 import { ServerChangeBanner } from "../common/ServerChangeBanner";
 import "../../styles/action.css";
 
@@ -467,50 +467,33 @@ export function ActionEditor() {
         <ServerChangeBanner onReload={handleReset} onDismiss={dismissServerBanner} />
       )}
 
-      {/* ヘッダー */}
-      <div className="action-editor-header">
-        <div className="action-editor-breadcrumb">
-          <Link to="/process-flow/list">処理フロー一覧</Link>
-          <span className="mx-2">/</span>
-          <span className="fw-semibold text-dark">{group.name}</span>
-        </div>
-        <div className="action-editor-undo-buttons">
-          <button
-            className="btn btn-outline-secondary btn-sm"
-            onClick={undo}
-            disabled={!canUndo}
-            title="元に戻す (Ctrl+Z)"
-          >
-            <i className="bi bi-arrow-counterclockwise" />
-          </button>
-          <button
-            className="btn btn-outline-secondary btn-sm"
-            onClick={redo}
-            disabled={!canRedo}
-            title="やり直し (Ctrl+Y)"
-          >
-            <i className="bi bi-arrow-clockwise" />
-          </button>
-          {validationErrors.filter((e) => e.severity === "error").length > 0 && (
-            <span className="validation-badge error">
-              <i className="bi bi-x-circle-fill" />
-              {validationErrors.filter((e) => e.severity === "error").length} エラー
-            </span>
-          )}
-          {validationErrors.filter((e) => e.severity === "warning").length > 0 && (
-            <span className="validation-badge warning">
-              <i className="bi bi-exclamation-triangle-fill" />
-              {validationErrors.filter((e) => e.severity === "warning").length} 警告
-            </span>
-          )}
-          <SaveResetButtons
-            isDirty={isDirty}
-            isSaving={isSaving}
-            onSave={handleSave}
-            onReset={handleReset}
-          />
-        </div>
-      </div>
+      <EditorHeader
+        title={
+          <div className="action-editor-breadcrumb">
+            <Link to="/process-flow/list">処理フロー一覧</Link>
+            <span className="mx-2">/</span>
+            <span className="fw-semibold text-dark">{group.name}</span>
+          </div>
+        }
+        undoRedo={{ onUndo: undo, onRedo: redo, canUndo, canRedo }}
+        extraRight={
+          <>
+            {validationErrors.filter((e) => e.severity === "error").length > 0 && (
+              <span className="validation-badge error">
+                <i className="bi bi-x-circle-fill" />
+                {validationErrors.filter((e) => e.severity === "error").length} エラー
+              </span>
+            )}
+            {validationErrors.filter((e) => e.severity === "warning").length > 0 && (
+              <span className="validation-badge warning">
+                <i className="bi bi-exclamation-triangle-fill" />
+                {validationErrors.filter((e) => e.severity === "warning").length} 警告
+              </span>
+            )}
+          </>
+        }
+        saveReset={{ isDirty, isSaving, onSave: handleSave, onReset: handleReset }}
+      />
 
       {/* グループ情報 */}
       <div className="action-editor-info">

--- a/designer/src/styles/action.css
+++ b/designer/src/styles/action.css
@@ -160,25 +160,6 @@
 
 /* ─── 処理フロー編集 ─────────────────────────────────────────────── */
 
-.action-editor-header {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 12px 20px;
-  background: #fff;
-  border-bottom: 1px solid #e2e8f0;
-}
-
-.action-editor-undo-buttons {
-  display: flex;
-  gap: 4px;
-  margin-left: auto;
-}
-
-.action-editor-undo-buttons .btn:disabled {
-  opacity: 0.35;
-}
-
 .action-editor-breadcrumb {
   font-size: 0.85rem;
   color: #64748b;

--- a/designer/src/styles/editorHeader.css
+++ b/designer/src/styles/editorHeader.css
@@ -40,8 +40,6 @@
 .editor-header-title {
   display: flex;
   align-items: center;
-  font-size: 15px;
-  font-weight: 600;
   min-width: 0;
 }
 


### PR DESCRIPTION
## Summary

#99 epic の PR 2/4。ActionEditor のカスタム header 実装を共通の `EditorHeader` コンポーネント (PR #134) に置き換える。

### 変更内容

- `ActionEditor.tsx`: `action-editor-header` ブロックを `EditorHeader` に置換
  - パンくずリンクを `title` slot に
  - Undo/Redo を `undoRedo` props に (既存の `btn-outline-secondary` が統一スタイルに)
  - バリデーションバッジ (error/warning) を `extraRight` slot に
  - SaveResetButtons を `saveReset` props に
- `action.css`: 不要になった `.action-editor-header` / `.action-editor-undo-buttons` を削除
  - `.action-editor-breadcrumb` は title slot 内で引き続き使用するので保持
- `editorHeader.css`: `.editor-header-title` からタイプセッティング (font-size/font-weight) を剥がした
  - 理由: breadcrumb の link が親から font-weight:600 を継承して bold になってしまう
  - スロット側が各自のタイポグラフィを制御する設計に

### 差分

```
 ActionEditor.tsx    | 73 ++++++++++---------------
 action.css          | 19 -------
 editorHeader.css    |  2 -
 3 files changed, 28 insertions(+), 66 deletions(-)
```

**-38 行**のコード削減。ロジックは一切変わらず UI 表現のみ。

### 視覚の変化点

- ヘッダー側面パディング: 20px → 16px (共通値に統一)
- Undo/Redo ボタンのスタイル: Bootstrap `btn btn-outline-secondary btn-sm` → 共通の `editor-header-undo-btn` (30×30 アイコンボタン)
- それ以外 (パンくず表示・バッジ・SaveResetButtons) は従来どおり

## Test plan

- [x] `npm run test:unit` — 112 pass
- [x] `npm run build` — OK
- [x] `npm run lint` — 新規エラーなし (既存の react-hooks/refs 警告は本 PR 範囲外)
- [x] `npx playwright test e2e/save-reset-action.spec.ts` — 8/8 pass
- [x] Playwright MCP で視覚確認:
  - `.editor-header` が `editor-header-light` クラスで描画される
  - 高さ 48px
  - 初期状態で Undo/Redo/保存 が disabled
  - パンくず・バッジ描画領域・SaveResetButtons の位置関係が正常
- [ ] **マージ前にユーザー目視確認** (memory rule に従い)

## 依存

- PR #134 (EditorHeader 基盤) にマージ済みの main を前提にしている

## 後続 PR

- PR 3/4: TableEditor を EditorHeader に移行
- PR 4/4: FlowEditor / Designer を EditorHeader に移行

Refs #99 #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)