### PR TITLE
improve(table): TableEditor のヘッダーを EditorHeader に統一 (#99)

### DIFF
--- a/designer/src/components/table/TableEditor.tsx
+++ b/designer/src/components/table/TableEditor.tsx
@@ -9,7 +9,7 @@ import { generateDdl, generateTableMarkdown } from "../../utils/ddlGenerator";
 import { mcpBridge } from "../../mcp/mcpBridge";
 import { useResourceEditor } from "../../hooks/useResourceEditor";
 import { useSaveShortcut } from "../../hooks/useSaveShortcut";
-import { SaveResetButtons } from "../common/SaveResetButtons";
+import { EditorHeader } from "../common/EditorHeader";
 import { ServerChangeBanner } from "../common/ServerChangeBanner";
 import "../../styles/table.css";
 
@@ -72,13 +72,11 @@ export function TableEditor() {
         <ServerChangeBanner onReload={handleReset} onDismiss={dismissServerBanner} />
       )}
 
-      {/* Header */}
-      <header className="table-editor-header">
-        <button className="tbl-btn tbl-btn-ghost table-back-btn" onClick={() => navigate("/table/list")}>
-          <i className="bi bi-arrow-left" /> テーブル一覧
-        </button>
-        <div className="table-editor-title-area">
-          {editingMeta ? (
+      <EditorHeader
+        variant="dark"
+        backLink={{ label: "テーブル一覧", onClick: () => navigate("/table/list") }}
+        title={
+          editingMeta ? (
             <TableMetaEditor
               table={table}
               onSave={(patch) => {
@@ -94,27 +92,12 @@ export function TableEditor() {
               {table.category && <span className="table-category-badge">{table.category}</span>}
               <i className="bi bi-pencil table-edit-icon" />
             </div>
-          )}
-        </div>
-        <div className="table-editor-header-actions">
+          )
+        }
+        undoRedo={{ onUndo: undo, onRedo: redo, canUndo, canRedo }}
+        extraRight={
           <button
-            className="tbl-btn tbl-btn-ghost"
-            onClick={undo}
-            disabled={!canUndo}
-            title="元に戻す (Ctrl+Z)"
-          >
-            <i className="bi bi-arrow-counterclockwise" />
-          </button>
-          <button
-            className="tbl-btn tbl-btn-ghost"
-            onClick={redo}
-            disabled={!canRedo}
-            title="やり直し (Ctrl+Y)"
-          >
-            <i className="bi bi-arrow-clockwise" />
-          </button>
-          <button
-            className="tbl-btn tbl-btn-ghost"
+            className="editor-header-undo-btn"
             onClick={() => {
               const md = generateTableMarkdown(table);
               navigator.clipboard.writeText(md);
@@ -123,14 +106,9 @@ export function TableEditor() {
           >
             <i className="bi bi-clipboard" />
           </button>
-          <SaveResetButtons
-            isDirty={isDirty}
-            isSaving={isSaving}
-            onSave={handleSave}
-            onReset={handleReset}
-          />
-        </div>
-      </header>
+        }
+        saveReset={{ isDirty, isSaving, onSave: handleSave, onReset: handleReset }}
+      />
 
       {/* Tabs */}
       <div className="table-editor-tabs">

--- a/designer/src/styles/editorHeader.css
+++ b/designer/src/styles/editorHeader.css
@@ -8,7 +8,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  height: 48px;
+  min-height: 48px;
   padding: 0 16px;
   gap: 16px;
   flex-shrink: 0;

--- a/designer/src/styles/table.css
+++ b/designer/src/styles/table.css
@@ -378,25 +378,6 @@
 
 /* ── ヘッダー ──────────────────────────────────────────────────────────── */
 
-.table-editor-header {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 10px 20px;
-  background: #222240;
-  border-bottom: 1px solid #333;
-  min-height: 52px;
-}
-
-.table-back-btn {
-  flex-shrink: 0;
-}
-
-.table-editor-title-area {
-  flex: 1;
-  min-width: 0;
-}
-
 .table-editor-title {
   display: flex;
   align-items: center;
@@ -440,11 +421,6 @@
 
 .table-editor-title:hover .table-edit-icon {
   opacity: 1;
-}
-
-.table-editor-header-actions {
-  display: flex;
-  gap: 4px;
 }
 
 /* メタ編集 */


### PR DESCRIPTION
## Summary

#99 epic の PR 3/4。TableEditor のカスタム header 実装を共通の `EditorHeader` (variant=\"dark\") に置き換える。

### 変更内容

- `TableEditor.tsx`: `table-editor-header` ブロックを `EditorHeader` に置換
  - 戻るボタン「テーブル一覧」→ `backLink`
  - タイトル (表示モード ⇔ `TableMetaEditor` 切替) → `title` slot
  - Undo/Redo → `undoRedo` props
  - Markdown コピー → `extraRight`
  - SaveResetButtons → `saveReset`
- `table.css`: 不要になった `.table-editor-header` / `.table-back-btn` / `.table-editor-title-area` / `.table-editor-header-actions` を削除。title slot 内で引き続き使う `.table-editor-title` / `.table-meta-editor` 等は保持
- `editorHeader.css`: `.editor-header` の `height: 48px` → `min-height: 48px` に変更。TableEditor の meta editor 展開時にヘッダーが縦に伸びるケースへ対応

### 差分

```
 TableEditor.tsx  | 50 ++++++++-------------------
 editorHeader.css |  2 +-
 table.css        | 24 -------------
 3 files changed, 15 insertions(+), 61 deletions(-)
```

**-46 行**のコード削減。ダーク背景は `variant=\"dark\"` で維持。

### 視覚の変化点

- 背景色: `#222240` → `var(--dz-bg-2)` (`#27293a`) — Designer と同じダーク系に統合
- ボーダー色: `#333` → `var(--dz-border)` (`#3b3e55`) — 同様に Designer 側に統合
- Undo/Redo/Markdown ボタン: `tbl-btn tbl-btn-ghost` → `editor-header-undo-btn` (30×30 アイコンボタン)
- 側面パディング: 20px → 16px
- 戻るボタンの位置が若干ずれる可能性 (統一 `editor-header-back` スタイル適用)

### 視覚検証済 (Playwright MCP)

- Header 高さ 48px (`editor-header-dark` クラス付与)
- テーブル一覧戻るボタン / Undo / Redo / Markdown / リセット / 保存が正しく配置
- タイトルクリックで `TableMetaEditor` が inline 展開 (4 入力フィールドが横並びで 48px 内に収まる)
- ダーク背景がちゃんと保たれている

## Test plan

- [x] `npm run test:unit` — 112 pass
- [x] `npm run build` — OK
- [x] 既存 e2e (`save-reset.spec.ts` の `.table-editor-page` 参照) は影響なし
- [x] Playwright MCP で視覚確認 (表示モード・編集モード両方)
- [ ] **マージ前にユーザー目視確認**

## 依存

- PR #134, #135 (既にマージ済み) の main を前提

## 後続 PR

- PR 4/4: FlowEditor / Designer を EditorHeader に移行 (最大・Designer はダーク背景継続)

Refs #99 #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)