### PR TITLE
improve(flow,design): FlowEditor と Designer のヘッダーを EditorHeader に統一 (#99)

### DIFF
--- a/designer/e2e/save-reset-flow.spec.ts
+++ b/designer/e2e/save-reset-flow.spec.ts
@@ -41,7 +41,7 @@ async function setupFlowEditor(page: Page, draft: object | null = null) {
 
 async function addScreenViaModal(page: Page, name: string) {
   // ツールバーの「画面を追加」（空状態 CTA "最初の画面を追加" とは別）
-  await page.locator('.flow-topbar-right button.flow-btn-primary').filter({ hasText: "画面を追加" }).click();
+  await page.locator('.editor-header button.flow-btn-primary').filter({ hasText: "画面を追加" }).click();
   await page.locator("#screen-name").fill(name);
   await page.locator('.flow-modal button[type="submit"]').click();
 }

--- a/designer/src/components/Designer.tsx
+++ b/designer/src/components/Designer.tsx
@@ -336,16 +336,6 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
     };
   }, [ready]);
 
-  // topbar-left の幅を panelMode に合わせて同期
-  useEffect(() => {
-    const root = document.documentElement;
-    if (panelMode === "pinned") {
-      root.style.setProperty("--topbar-left-w", "var(--panel-left-w)");
-    } else {
-      root.style.setProperty("--topbar-left-w", "160px");
-    }
-  }, [panelMode]);
-
   const handleSaveToFile = useCallback(async () => {
     if (isSaving) return;
     setIsSaving(true);

--- a/designer/src/components/design/DesignSubToolbar.tsx
+++ b/designer/src/components/design/DesignSubToolbar.tsx
@@ -5,6 +5,7 @@ import type { McpStatus } from "../../mcp/mcpBridge";
 import { CodeEditorModal } from "../CodeEditorModal";
 import { SaveBlockModal } from "../SaveBlockModal";
 import { SaveResetButtons } from "../common/SaveResetButtons";
+import { EditorHeader } from "../common/EditorHeader";
 import { useSaveShortcut } from "../../hooks/useSaveShortcut";
 import { upsertCustomBlock } from "../../store/customBlockStore";
 
@@ -259,154 +260,130 @@ ${html}
   });
 
   return (
-    <header className="topbar">
-      <div className="topbar-left">
-        {backLink && (
-          <>
+    <>
+      <EditorHeader
+        variant="dark"
+        backLink={backLink ? { label: backLink.label, onClick: backLink.onClick, title: "フロー図に戻る" } : undefined}
+        title={
+          panelMode === "hidden" ? (
             <button
               className="icon-btn"
-              onClick={backLink.onClick}
-              title="フロー図に戻る"
-              style={{ marginRight: 6 }}
+              onClick={onOpenPanel}
+              title="ブロックパネルを開く"
             >
-              <i className="bi bi-arrow-left" />
+              <i className="bi bi-layout-sidebar" />
             </button>
-            <span className="topbar-title">{backLink.label}</span>
-          </>
-        )}
-        {panelMode === "hidden" && (
-          <button
-            className="icon-btn"
-            onClick={onOpenPanel}
-            title="ブロックパネルを開く"
-            style={{ marginLeft: backLink ? 4 : 0 }}
-          >
-            <i className="bi bi-layout-sidebar" />
-          </button>
-        )}
-      </div>
-
-      <div className="topbar-center">
-        <button
-          className="icon-btn"
-          onClick={handleUndo}
-          disabled={!canUndo}
-          title="元に戻す (Ctrl+Z)"
-        >
-          <i className="bi bi-arrow-counterclockwise" />
-        </button>
-        <button
-          className="icon-btn"
-          onClick={handleRedo}
-          disabled={!canRedo}
-          title="やり直し (Ctrl+Shift+Z)"
-        >
-          <i className="bi bi-arrow-clockwise" />
-        </button>
-        <div className="divider" />
-        <button className="icon-btn" onClick={handlePreview} title="プレビュー (Ctrl+P)">
-          <i className="bi bi-eye" />
-        </button>
-        <button
-          className="icon-btn"
-          onClick={handleOpenCodeEditor}
-          disabled={!hasSelected}
-          title="HTMLソースを編集 (Ctrl+E)"
-        >
-          <i className="bi bi-code-slash" />
-        </button>
-        <button
-          className="icon-btn"
-          onClick={handleOpenSaveBlock}
-          disabled={!hasSelected}
-          title="マイブロックとして保存"
-        >
-          <i className="bi bi-bookmark-plus" />
-        </button>
-        <button
-          className="icon-btn danger"
-          onClick={handleClear}
-          title="キャンバスをクリア"
-        >
-          <i className="bi bi-trash" />
-        </button>
-        <div className="divider" />
-        <div className="device-switcher">
-          <button
-            className={`device-btn${selectedDevice === "desktop" ? " active" : ""}`}
-            onClick={() => editor?.setDevice("desktop")}
-            title="PC（全幅）"
-          >
-            <i className="bi bi-display" />
-          </button>
-          <button
-            className={`device-btn${selectedDevice === "tablet" ? " active" : ""}`}
-            onClick={() => editor?.setDevice("tablet")}
-            title="タブレット (768px)"
-          >
-            <i className="bi bi-tablet" />
-          </button>
-          <button
-            className={`device-btn${selectedDevice === "smartphone" ? " active" : ""}`}
-            onClick={() => editor?.setDevice("smartphone")}
-            title="スマートフォン (375px)"
-          >
-            <i className="bi bi-phone" />
-          </button>
-        </div>
-        <div className="divider" />
-        <button
-          className="icon-btn"
-          onClick={() => setHelpOpen(true)}
-          title="キーボードショートカット一覧 (?)"
-        >
-          <i className="bi bi-keyboard" />
-        </button>
-      </div>
-
-      <div className="topbar-right">
-        <div className="theme-selector">
-          <button
-            className="theme-selector-btn"
-            onClick={() => setThemeMenuOpen((v) => !v)}
-            title="デザインテーマを選択"
-          >
-            <i className={`bi ${THEMES.find((t) => t.id === activeTheme)?.icon ?? "bi-palette"}`} />
-            <span>{THEMES.find((t) => t.id === activeTheme)?.label ?? "テーマ"}</span>
-            <i className="bi bi-chevron-down" style={{ fontSize: 10 }} />
-          </button>
-          {themeMenuOpen && (
-            <div className="theme-menu">
-              {THEMES.map((t) => (
-                <button
-                  key={t.id}
-                  className={`theme-menu-item${activeTheme === t.id ? " active" : ""}`}
-                  onClick={() => { onThemeChange(t.id); setThemeMenuOpen(false); }}
-                >
-                  <span className="theme-swatch" style={{ background: t.color }} />
-                  <i className={`bi ${t.icon}`} />
-                  {t.label}
-                </button>
-              ))}
+          ) : undefined
+        }
+        centerTools={
+          <>
+            <button className="icon-btn" onClick={handlePreview} title="プレビュー (Ctrl+P)">
+              <i className="bi bi-eye" />
+            </button>
+            <button
+              className="icon-btn"
+              onClick={handleOpenCodeEditor}
+              disabled={!hasSelected}
+              title="HTMLソースを編集 (Ctrl+E)"
+            >
+              <i className="bi bi-code-slash" />
+            </button>
+            <button
+              className="icon-btn"
+              onClick={handleOpenSaveBlock}
+              disabled={!hasSelected}
+              title="マイブロックとして保存"
+            >
+              <i className="bi bi-bookmark-plus" />
+            </button>
+            <button
+              className="icon-btn danger"
+              onClick={handleClear}
+              title="キャンバスをクリア"
+            >
+              <i className="bi bi-trash" />
+            </button>
+            <div className="divider" />
+            <div className="device-switcher">
+              <button
+                className={`device-btn${selectedDevice === "desktop" ? " active" : ""}`}
+                onClick={() => editor?.setDevice("desktop")}
+                title="PC（全幅）"
+              >
+                <i className="bi bi-display" />
+              </button>
+              <button
+                className={`device-btn${selectedDevice === "tablet" ? " active" : ""}`}
+                onClick={() => editor?.setDevice("tablet")}
+                title="タブレット (768px)"
+              >
+                <i className="bi bi-tablet" />
+              </button>
+              <button
+                className={`device-btn${selectedDevice === "smartphone" ? " active" : ""}`}
+                onClick={() => editor?.setDevice("smartphone")}
+                title="スマートフォン (375px)"
+              >
+                <i className="bi bi-phone" />
+              </button>
             </div>
-          )}
-        </div>
-        <div className="divider" />
-        <SaveResetButtons
-          isDirty={!!isDirty}
-          isSaving={!!isSaving}
-          onSave={handleSaveNow}
-          onReset={() => { void onReset?.(); }}
-        />
-        <span className="save-indicator saved" style={{ visibility: saveState === "saved" ? "visible" : "hidden", marginLeft: 4 }}>
-          <i className="bi bi-check-circle-fill" /> 保存済み
-        </span>
-        <button className="btn-secondary-sm" onClick={handleExportHtml} title="HTMLファイルとしてダウンロード">
-          <i className="bi bi-download" /> HTMLエクスポート
-        </button>
-        <div className="divider" />
-        <McpIndicator status={mcpStatus} />
-      </div>
+            <div className="divider" />
+            <button
+              className="icon-btn"
+              onClick={() => setHelpOpen(true)}
+              title="キーボードショートカット一覧 (?)"
+            >
+              <i className="bi bi-keyboard" />
+            </button>
+          </>
+        }
+        undoRedo={{ onUndo: handleUndo, onRedo: handleRedo, canUndo, canRedo }}
+        extraRight={
+          <>
+            <div className="theme-selector">
+              <button
+                className="theme-selector-btn"
+                onClick={() => setThemeMenuOpen((v) => !v)}
+                title="デザインテーマを選択"
+              >
+                <i className={`bi ${THEMES.find((t) => t.id === activeTheme)?.icon ?? "bi-palette"}`} />
+                <span>{THEMES.find((t) => t.id === activeTheme)?.label ?? "テーマ"}</span>
+                <i className="bi bi-chevron-down" style={{ fontSize: 10 }} />
+              </button>
+              {themeMenuOpen && (
+                <div className="theme-menu">
+                  {THEMES.map((t) => (
+                    <button
+                      key={t.id}
+                      className={`theme-menu-item${activeTheme === t.id ? " active" : ""}`}
+                      onClick={() => { onThemeChange(t.id); setThemeMenuOpen(false); }}
+                    >
+                      <span className="theme-swatch" style={{ background: t.color }} />
+                      <i className={`bi ${t.icon}`} />
+                      {t.label}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+            <div className="divider" />
+            <SaveResetButtons
+              isDirty={!!isDirty}
+              isSaving={!!isSaving}
+              onSave={handleSaveNow}
+              onReset={() => { void onReset?.(); }}
+            />
+            <span className="save-indicator saved" style={{ visibility: saveState === "saved" ? "visible" : "hidden", marginLeft: 4 }}>
+              <i className="bi bi-check-circle-fill" /> 保存済み
+            </span>
+            <button className="btn-secondary-sm" onClick={handleExportHtml} title="HTMLファイルとしてダウンロード">
+              <i className="bi bi-download" /> HTMLエクスポート
+            </button>
+            <div className="divider" />
+            <McpIndicator status={mcpStatus} />
+          </>
+        }
+      />
 
       <CodeEditorModal
         open={codeModalOpen}
@@ -424,7 +401,7 @@ ${html}
         onSave={handleSaveBlock}
         onClose={() => setSaveBlockOpen(false)}
       />
-    </header>
+    </>
   );
 }
 

--- a/designer/src/components/flow/FlowSubToolbar.tsx
+++ b/designer/src/components/flow/FlowSubToolbar.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from "react";
-import { SaveResetButtons } from "../common/SaveResetButtons";
+import { EditorHeader } from "../common/EditorHeader";
 
 export type ViewMode = "flow" | "table";
 
@@ -81,9 +81,10 @@ export function FlowSubToolbar({
   };
 
   return (
-    <header className="flow-topbar">
-      <div className="flow-topbar-left">
-        {editing ? (
+    <EditorHeader
+      variant="light"
+      title={
+        editing ? (
           <input
             ref={inputRef}
             className="flow-topbar-title-input"
@@ -103,144 +104,120 @@ export function FlowSubToolbar({
           >
             {projectName} <i className="bi bi-pencil flow-topbar-edit-icon" />
           </span>
-        )}
-      </div>
-
-      <div className="flow-topbar-center">
-        <div className="flow-view-toggle">
-          <button
-            className={`flow-view-btn${viewMode === "flow" ? " active" : ""}`}
-            onClick={() => onViewModeChange("flow")}
-            title="フロー図"
-          >
-            <i className="bi bi-diagram-3" /> フロー図
-          </button>
-          <button
-            className={`flow-view-btn${viewMode === "table" ? " active" : ""}`}
-            onClick={() => onViewModeChange("table")}
-            title="一覧"
-          >
-            <i className="bi bi-table" /> 一覧
-          </button>
-        </div>
-        <span className="flow-zoom-separator" />
-        <span className="flow-topbar-screen-count">{screenCount} 画面</span>
-        <span className="flow-zoom-separator" />
-        <div className={`flow-zoom-control${viewMode === "table" ? " hidden" : ""}`}>
-          <button
-            className="flow-zoom-btn"
-            onClick={() => onZoomChange(zoomLevel - 0.1)}
-            title="縮小"
-          >
-            <i className="bi bi-dash" />
-          </button>
-          <input
-            type="range"
-            className="flow-zoom-slider"
-            min={0.25} max={2} step={0.05}
-            value={zoomLevel}
-            onChange={(e) => onZoomChange(parseFloat(e.target.value))}
-            title={`${Math.round(zoomLevel * 100)}%`}
-          />
-          <button
-            className="flow-zoom-btn"
-            onClick={() => onZoomChange(zoomLevel + 0.1)}
-            title="拡大"
-          >
-            <i className="bi bi-plus" />
-          </button>
-          <span className="flow-zoom-label">{Math.round(zoomLevel * 100)}%</span>
-        </div>
-        {viewMode === "flow" && (
-          <button
-            className="flow-btn flow-btn-ghost flow-fit-view-btn"
-            onClick={onFitView}
-            title="全体表示"
-          >
-            <i className="bi bi-arrows-fullscreen" />
-          </button>
-        )}
-      </div>
-
-      <div className="flow-topbar-right">
-        {onUndo && (
-          <button
-            className="flow-btn flow-btn-secondary"
-            onClick={onUndo}
-            disabled={!canUndo}
-            title="元に戻す (Ctrl+Z)"
-          >
-            <i className="bi bi-arrow-counterclockwise" />
-          </button>
-        )}
-        {onRedo && (
-          <button
-            className="flow-btn flow-btn-secondary"
-            onClick={onRedo}
-            disabled={!canRedo}
-            title="やり直し (Ctrl+Y)"
-          >
-            <i className="bi bi-arrow-clockwise" />
-          </button>
-        )}
-        <div style={{ position: "relative" }}>
-          <button
-            className="flow-btn flow-btn-secondary"
-            onClick={(e) => { e.stopPropagation(); setMenuOpen((v) => !v); }}
-          >
-            <i className="bi bi-three-dots-vertical" /> ファイル
-          </button>
-          {menuOpen && (
-            <div className="flow-file-menu" onClick={(e) => e.stopPropagation()}>
-              <button className="flow-file-menu-item" onClick={() => { onExportJSON(); setMenuOpen(false); }}>
-                <i className="bi bi-download" /> JSON エクスポート
-              </button>
-              <button className="flow-file-menu-item" onClick={() => { fileRef.current?.click(); setMenuOpen(false); }}>
-                <i className="bi bi-upload" /> JSON インポート
-              </button>
-              <div className="flow-context-menu-separator" />
-              <button className="flow-file-menu-item" onClick={() => { onExportMarkdown(); setMenuOpen(false); }}>
-                <i className="bi bi-file-earmark-text" /> Markdown エクスポート
-              </button>
-              <button className="flow-file-menu-item" onClick={() => { onCopyMermaid(); setMenuOpen(false); }}>
-                <i className="bi bi-clipboard" /> Mermaid をコピー
-              </button>
-              <div className="flow-context-menu-separator" />
-              <button
-                className="flow-file-menu-item danger"
-                onClick={() => { onClearAll(); setMenuOpen(false); }}
-                disabled={screenCount === 0}
-              >
-                <i className="bi bi-trash" /> 全クリア
-              </button>
-            </div>
+        )
+      }
+      centerTools={
+        <>
+          <div className="flow-view-toggle">
+            <button
+              className={`flow-view-btn${viewMode === "flow" ? " active" : ""}`}
+              onClick={() => onViewModeChange("flow")}
+              title="フロー図"
+            >
+              <i className="bi bi-diagram-3" /> フロー図
+            </button>
+            <button
+              className={`flow-view-btn${viewMode === "table" ? " active" : ""}`}
+              onClick={() => onViewModeChange("table")}
+              title="一覧"
+            >
+              <i className="bi bi-table" /> 一覧
+            </button>
+          </div>
+          <span className="flow-zoom-separator" />
+          <span className="flow-topbar-screen-count">{screenCount} 画面</span>
+          <span className="flow-zoom-separator" />
+          <div className={`flow-zoom-control${viewMode === "table" ? " hidden" : ""}`}>
+            <button
+              className="flow-zoom-btn"
+              onClick={() => onZoomChange(zoomLevel - 0.1)}
+              title="縮小"
+            >
+              <i className="bi bi-dash" />
+            </button>
+            <input
+              type="range"
+              className="flow-zoom-slider"
+              min={0.25} max={2} step={0.05}
+              value={zoomLevel}
+              onChange={(e) => onZoomChange(parseFloat(e.target.value))}
+              title={`${Math.round(zoomLevel * 100)}%`}
+            />
+            <button
+              className="flow-zoom-btn"
+              onClick={() => onZoomChange(zoomLevel + 0.1)}
+              title="拡大"
+            >
+              <i className="bi bi-plus" />
+            </button>
+            <span className="flow-zoom-label">{Math.round(zoomLevel * 100)}%</span>
+          </div>
+          {viewMode === "flow" && (
+            <button
+              className="flow-btn flow-btn-ghost flow-fit-view-btn"
+              onClick={onFitView}
+              title="全体表示"
+            >
+              <i className="bi bi-arrows-fullscreen" />
+            </button>
           )}
-          <input
-            ref={fileRef}
-            type="file"
-            accept=".json"
-            style={{ display: "none" }}
-            onChange={handleImportFile}
-          />
-        </div>
+        </>
+      }
+      undoRedo={onUndo && onRedo ? { onUndo, onRedo, canUndo: !!canUndo, canRedo: !!canRedo } : undefined}
+      extraRight={
+        <>
+          <div style={{ position: "relative" }}>
+            <button
+              className="flow-btn flow-btn-secondary"
+              onClick={(e) => { e.stopPropagation(); setMenuOpen((v) => !v); }}
+            >
+              <i className="bi bi-three-dots-vertical" /> ファイル
+            </button>
+            {menuOpen && (
+              <div className="flow-file-menu" onClick={(e) => e.stopPropagation()}>
+                <button className="flow-file-menu-item" onClick={() => { onExportJSON(); setMenuOpen(false); }}>
+                  <i className="bi bi-download" /> JSON エクスポート
+                </button>
+                <button className="flow-file-menu-item" onClick={() => { fileRef.current?.click(); setMenuOpen(false); }}>
+                  <i className="bi bi-upload" /> JSON インポート
+                </button>
+                <div className="flow-context-menu-separator" />
+                <button className="flow-file-menu-item" onClick={() => { onExportMarkdown(); setMenuOpen(false); }}>
+                  <i className="bi bi-file-earmark-text" /> Markdown エクスポート
+                </button>
+                <button className="flow-file-menu-item" onClick={() => { onCopyMermaid(); setMenuOpen(false); }}>
+                  <i className="bi bi-clipboard" /> Mermaid をコピー
+                </button>
+                <div className="flow-context-menu-separator" />
+                <button
+                  className="flow-file-menu-item danger"
+                  onClick={() => { onClearAll(); setMenuOpen(false); }}
+                  disabled={screenCount === 0}
+                >
+                  <i className="bi bi-trash" /> 全クリア
+                </button>
+              </div>
+            )}
+            <input
+              ref={fileRef}
+              type="file"
+              accept=".json"
+              style={{ display: "none" }}
+              onChange={handleImportFile}
+            />
+          </div>
 
-        {viewMode === "flow" && (
-          <button className="flow-btn flow-btn-secondary" onClick={onAddGroup} title="グループを追加">
-            <i className="bi bi-collection" /> グループ
+          {viewMode === "flow" && (
+            <button className="flow-btn flow-btn-secondary" onClick={onAddGroup} title="グループを追加">
+              <i className="bi bi-collection" /> グループ
+            </button>
+          )}
+          <button className="flow-btn flow-btn-primary" onClick={onAddScreen}>
+            <i className="bi bi-plus-lg" /> 画面を追加
           </button>
-        )}
-        <button className="flow-btn flow-btn-primary" onClick={onAddScreen}>
-          <i className="bi bi-plus-lg" /> 画面を追加
-        </button>
-        {onSave && onReset && (
-          <SaveResetButtons
-            isDirty={!!isDirty}
-            isSaving={!!isSaving}
-            onSave={onSave}
-            onReset={onReset}
-          />
-        )}
-      </div>
-    </header>
+        </>
+      }
+      saveReset={onSave && onReset ? { isDirty: !!isDirty, isSaving: !!isSaving, onSave, onReset } : undefined}
+    />
   );
 }

--- a/designer/src/styles/app.css
+++ b/designer/src/styles/app.css
@@ -4,7 +4,6 @@
 
 :root {
   --common-header-h: 40px;
-  --topbar-h: 48px;
   --panel-left-w: 280px;
   --panel-right-w: 300px;
   --dz-bg: #1e1e2e;
@@ -41,52 +40,9 @@
 }
 
 /* ==========================================================================
-   Topbar
+   Topbar — EditorHeader の centerTools / extraRight slot 内で使用する
+   ボタン類のスタイル。ヘッダー外装は editorHeader.css が担当。
    ========================================================================== */
-.topbar {
-  height: var(--topbar-h);
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
-  background-color: var(--dz-bg-2);
-  border-bottom: 1px solid var(--dz-border);
-  padding: 0 16px;
-  gap: 16px;
-}
-
-.topbar-left {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  min-width: var(--topbar-left-w, var(--panel-left-w));
-  transition: min-width 0.2s ease;
-}
-.topbar-logo {
-  font-size: 22px;
-  color: var(--dz-accent);
-}
-.topbar-title {
-  font-weight: 700;
-  font-size: 15px;
-  letter-spacing: 0.2px;
-}
-
-.topbar-center {
-  flex: 1 1 auto;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 4px;
-}
-
-.topbar-right {
-  min-width: var(--panel-right-w);
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 12px;
-}
-
 .icon-btn {
   background: transparent;
   border: 1px solid transparent;
@@ -113,12 +69,6 @@
 .icon-btn.danger:hover {
   background-color: rgba(239, 68, 68, 0.15);
   color: var(--dz-danger);
-}
-.topbar-center .divider {
-  width: 1px;
-  height: 20px;
-  background-color: var(--dz-border);
-  margin: 0 8px;
 }
 
 .save-indicator {

--- a/designer/src/styles/editorHeader.css
+++ b/designer/src/styles/editorHeader.css
@@ -94,6 +94,22 @@
   cursor: not-allowed;
 }
 
+/* ── Divider (縦棒セパレータ) ────────────────────────────────── */
+.editor-header .divider {
+  width: 1px;
+  height: 20px;
+  margin: 0 6px;
+  flex-shrink: 0;
+}
+
+.editor-header-light .divider {
+  background: #e2e8f0;
+}
+
+.editor-header-dark .divider {
+  background: var(--dz-border, #3b3e55);
+}
+
 /* ── Light variant (Flow / Table / Action 想定) ───────────────── */
 .editor-header-light {
   background: #ffffff;

--- a/designer/src/styles/flow.css
+++ b/designer/src/styles/flow.css
@@ -7,30 +7,7 @@
   font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
 }
 
-/* ── Flow Topbar ───────────────────────────── */
-.flow-topbar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 48px;
-  padding: 0 16px;
-  background: #fff;
-  border-bottom: 1px solid #e2e8f0;
-  flex-shrink: 0;
-  z-index: 10;
-}
-
-.flow-topbar-left {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.flow-topbar-left .topbar-logo {
-  font-size: 20px;
-  color: #6366f1;
-}
-
+/* ── Flow Topbar (EditorHeader の title/center/extraRight slot 内で使用) ─── */
 .flow-topbar-title {
   font-size: 15px;
   font-weight: 600;
@@ -64,18 +41,6 @@
   outline: none;
   background: #fff;
   width: 200px;
-}
-
-.flow-topbar-subtitle {
-  font-size: 12px;
-  color: #94a3b8;
-  margin-left: 4px;
-}
-
-.flow-topbar-center {
-  display: flex;
-  align-items: center;
-  gap: 6px;
 }
 
 .flow-topbar-screen-count {
@@ -165,12 +130,6 @@
 
 .flow-fit-view-btn {
   padding: 5px 8px;
-}
-
-.flow-topbar-right {
-  display: flex;
-  align-items: center;
-  gap: 8px;
 }
 
 .flow-btn {


### PR DESCRIPTION
## Summary

#99 epic の**最終 PR (4/4)**。FlowSubToolbar と DesignSubToolbar のカスタム header 実装を共通の `EditorHeader` に置き換える。**これで 4 エディタすべてが同一のヘッダー基盤 (EditorHeader) を共有**する状態になる。

### 変更内容

**FlowSubToolbar (variant='light'):**
- プロジェクト名編集 → `title` slot
- ビュー切替 + 画面数 + ズーム + FitView → `centerTools`
- Undo/Redo → `undoRedo` props (`flow-btn-secondary` → 統一 30×30)
- ファイル/グループ/画面追加 → `extraRight`
- SaveResetButtons → `saveReset` props

**DesignSubToolbar (variant='dark'):**
- `backLink` → EditorHeader の `backLink` slot
- パネル開閉ボタン → `title` slot
- プレビュー/コード/マイブロック/クリア/デバイス/ヘルプ → `centerTools`
- Undo/Redo は `icon-btn` から統一 30×30 `undoRedo` slot へ
- テーマ/SaveReset/保存済/HTMLエクスポート/MCP → `extraRight`
  - SaveReset と MCP の位置関係は現状維持のため extraRight 内に手動配置 (SaveReset を `saveReset` slot に入れると MCP が先になってしまうため)

**CSS クリーンアップ:**
- `flow.css`: `.flow-topbar`, `.flow-topbar-left/center/right`, `.flow-topbar-subtitle`, `.flow-topbar-left .topbar-logo` を削除
- `app.css`: `.topbar`, `.topbar-left/center/right`, `.topbar-logo`, `.topbar-title`, `.topbar-center .divider`, `--topbar-h` を削除
- `editorHeader.css`: 共通 `.divider` スタイル (light/dark 対応) を追加

**その他:**
- `Designer.tsx`: 使われなくなった `--topbar-left-w` 同期 useEffect を削除
- `save-reset-flow.spec.ts`: `.flow-topbar-right` セレクタを `.editor-header` に追随

### 差分

```
 save-reset-flow.spec.ts       |   2 +-
 Designer.tsx                  |  10 -
 DesignSubToolbar.tsx          | 261 ++++++++++-----------
 FlowSubToolbar.tsx            | 257 +++++++++-----------
 app.css                       |  54 +----
 editorHeader.css              |  16 ++
 flow.css                      |  43 +---
 7 files changed, 256 insertions(+), 387 deletions(-)
```

**-131 行**の正味減。JSX がスロット API に寄ったことで構造が明快に。

### 視覚の変化点

- **Flow**: 背景色・高さ等は既存と同じ (light variant の既定)。Undo/Redo のボタン形状が `flow-btn-secondary` (角丸 pill) → `editor-header-undo-btn` (30×30 アイコンボタン) に変わる
- **Designer**:
  - 背景色は既存の `--dz-bg-2` を dark variant でそのまま継承 (変化なし)
  - 左側の幅同期 (`--topbar-left-w`) が削除され、backLink の位置が panelMode に依らず一定 16px offset に (微小な視覚変化)
  - Undo/Redo のボタンが centerTools から undoRedo slot (= 右側) に移動。これは大きな配置変化 ⚠️
  - ダーク背景と MCP indicator は従来どおり

### 視覚検証済 (Playwright MCP)

- FlowEditor:
  - `.editor-header-light` クラス、高さ 48px
  - プロジェクト名クリックで input 展開可
  - ビュー切替/画面数/ズーム/FitView が centerTools に配置
  - Undo/Redo + ファイル + グループ + 画面を追加 + SaveReset が右側に配置
- Designer: 直接 URL での確認は環境都合で難しかったが、ビルド・型・ユニットテスト・既存 e2e が全通過

## Test plan

- [x] `npm run test:unit` — 112 pass
- [x] `npm run build` — OK
- [x] `npx playwright test e2e/save-reset-flow.spec.ts e2e/save-reset-designer.spec.ts` — **12/12 pass**
- [x] FlowEditor 視覚確認 (Playwright MCP screenshot)
- [ ] **マージ前に Designer の視覚確認 (ユーザー)** — Undo/Redo 移動が最大の変化点
- [ ] 各エディタを一通り触って副作用がないか確認

## 依存

- PR #134, #135, #136 (既にマージ済み) の main を前提

## 完了条件 (#99 受け入れ条件)

- [x] `components/common/EditorHeader.tsx` が存在し、スロット API を提供 (PR #134 で達成)
- [x] 4 エディタすべてが EditorHeader を使用 (本 PR で達成)
- [x] Undo/Redo ボタンのスタイルが 1 種類 (`editor-header-undo-btn`) に統一
- [x] `flow-btn-secondary` / `icon-btn` / `tbl-btn-ghost` / `btn-outline-secondary` の重複した Undo/Redo 用途が整理
- [x] Playwright のヘッダー関連テストがパスする
- [ ] 視覚回帰の手動確認 (この PR のレビューで)

Refs #99 #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)