### PR TITLE
feat(common): 一覧統一の基盤 DataList + 選択/キーボードフックを新設 (#133)

### DIFF
--- a/designer/src/components/common/DataList.tsx
+++ b/designer/src/components/common/DataList.tsx
@@ -1,0 +1,176 @@
+import type { ReactNode } from "react";
+import {
+  DndContext,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import type { ListSelection } from "../../hooks/useListSelection";
+import "../../styles/dataList.css";
+
+export interface DataListColumn<T> {
+  key: string;
+  header: ReactNode;
+  render: (item: T, index: number) => ReactNode;
+  width?: string;
+  align?: "left" | "center" | "right";
+  className?: string;
+}
+
+interface Props<T> {
+  items: T[];
+  columns: DataListColumn<T>[];
+  getId: (item: T) => string;
+  selection?: ListSelection<T>;
+  /** Double-click / Enter 相当のアクティベート */
+  onActivate?: (item: T, index: number) => void;
+  /** 行 D&D で並び替え。未指定時はハンドル非表示 & D&D 無効 */
+  onReorder?: (fromIndex: number, toIndex: number) => void;
+  /** No 列 (最左) を表示 */
+  showNumColumn?: boolean;
+  emptyMessage?: ReactNode;
+  className?: string;
+}
+
+export function DataList<T>({
+  items, columns, getId, selection,
+  onActivate, onReorder,
+  showNumColumn = true,
+  emptyMessage,
+  className,
+}: Props<T>) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+  );
+
+  const handleDragEnd = (e: DragEndEvent) => {
+    const { active, over } = e;
+    if (!over || !onReorder) return;
+    if (active.id === over.id) return;
+    const fromIndex = items.findIndex((it) => getId(it) === active.id);
+    const toIndex = items.findIndex((it) => getId(it) === over.id);
+    if (fromIndex < 0 || toIndex < 0) return;
+    onReorder(fromIndex, toIndex);
+  };
+
+  const showHandle = !!onReorder;
+  const ids = items.map(getId);
+
+  if (items.length === 0) {
+    return (
+      <div className={`data-list data-list-empty${className ? " " + className : ""}`}>
+        {emptyMessage ?? <span>データがありません</span>}
+      </div>
+    );
+  }
+
+  return (
+    <div className={`data-list${className ? " " + className : ""}`} data-testid="data-list">
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <SortableContext items={ids} strategy={verticalListSortingStrategy}>
+          <table className="data-list-table">
+            <thead>
+              <tr>
+                {showHandle && <th className="data-list-th-handle" aria-label="並び替えハンドル" />}
+                {showNumColumn && <th className="data-list-th-num">No</th>}
+                {columns.map((col) => (
+                  <th
+                    key={col.key}
+                    className={col.className}
+                    style={{ width: col.width, textAlign: col.align }}
+                  >
+                    {col.header}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((item, index) => (
+                <DataListRow
+                  key={getId(item)}
+                  item={item}
+                  index={index}
+                  getId={getId}
+                  columns={columns}
+                  selection={selection}
+                  onActivate={onActivate}
+                  showHandle={showHandle}
+                  showNumColumn={showNumColumn}
+                />
+              ))}
+            </tbody>
+          </table>
+        </SortableContext>
+      </DndContext>
+    </div>
+  );
+}
+
+interface RowProps<T> {
+  item: T;
+  index: number;
+  getId: (item: T) => string;
+  columns: DataListColumn<T>[];
+  selection?: ListSelection<T>;
+  onActivate?: (item: T, index: number) => void;
+  showHandle: boolean;
+  showNumColumn: boolean;
+}
+
+function DataListRow<T>({
+  item, index, getId, columns, selection, onActivate, showHandle, showNumColumn,
+}: RowProps<T>) {
+  const id = getId(item);
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : undefined,
+  };
+
+  const selected = selection?.isSelected(id) ?? false;
+
+  const handleClick = (e: React.MouseEvent) => {
+    selection?.handleRowClick(id, e);
+  };
+
+  const handleDoubleClick = () => {
+    onActivate?.(item, index);
+  };
+
+  return (
+    <tr
+      ref={setNodeRef}
+      style={style}
+      className={`data-list-row${selected ? " selected" : ""}`}
+      onClick={handleClick}
+      onDoubleClick={handleDoubleClick}
+      data-testid="data-list-row"
+      data-row-id={id}
+    >
+      {showHandle && (
+        <td className="data-list-td-handle" {...attributes} {...listeners}>
+          <i className="bi bi-grip-vertical" />
+        </td>
+      )}
+      {showNumColumn && <td className="data-list-td-num">{index + 1}</td>}
+      {columns.map((col) => (
+        <td
+          key={col.key}
+          className={col.className}
+          style={{ textAlign: col.align }}
+        >
+          {col.render(item, index)}
+        </td>
+      ))}
+    </tr>
+  );
+}

--- a/designer/src/hooks/useListKeyboard.test.ts
+++ b/designer/src/hooks/useListKeyboard.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useListSelection } from "./useListSelection";
+import { useListKeyboard } from "./useListKeyboard";
+
+interface Item {
+  id: string;
+  name: string;
+}
+
+const items: Item[] = [
+  { id: "a", name: "A" },
+  { id: "b", name: "B" },
+  { id: "c", name: "C" },
+];
+
+function fireKey(init: KeyboardEventInit) {
+  window.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, cancelable: true, ...init }));
+}
+
+interface Callbacks {
+  onActivate?: ReturnType<typeof vi.fn>;
+  onDelete?: ReturnType<typeof vi.fn>;
+  onCopy?: ReturnType<typeof vi.fn>;
+  onCut?: ReturnType<typeof vi.fn>;
+  onPaste?: ReturnType<typeof vi.fn>;
+  onDuplicate?: ReturnType<typeof vi.fn>;
+  onMoveUp?: ReturnType<typeof vi.fn>;
+  onMoveDown?: ReturnType<typeof vi.fn>;
+}
+
+function setup(cbs: Callbacks = {}) {
+  return renderHook(() => {
+    const sel = useListSelection(items, (it) => it.id);
+    useListKeyboard({ items, getId: (it) => it.id, selection: sel, ...cbs });
+    return sel;
+  });
+}
+
+describe("useListKeyboard", () => {
+  beforeEach(() => {
+    // フォーカスをリセット (前のテストで input にフォーカスされている可能性)
+    if (document.activeElement && document.activeElement !== document.body) {
+      (document.activeElement as HTMLElement).blur();
+    }
+  });
+
+  it("↓ キーで最初の行が選択される (未選択状態から)", () => {
+    const { result } = setup();
+    act(() => fireKey({ key: "ArrowDown" }));
+    expect(result.current.selectedIds).toEqual(new Set(["a"]));
+  });
+
+  it("↑ キーで最後の行が選択される (未選択状態から)", () => {
+    const { result } = setup();
+    act(() => fireKey({ key: "ArrowUp" }));
+    expect(result.current.selectedIds).toEqual(new Set(["c"]));
+  });
+
+  it("↓ キーで次の行に選択移動", () => {
+    const { result } = setup();
+    act(() => result.current.handleRowClick("a", {}));
+    act(() => fireKey({ key: "ArrowDown" }));
+    expect(result.current.selectedIds).toEqual(new Set(["b"]));
+  });
+
+  it("Shift+↓ で選択範囲を下へ拡張", () => {
+    const { result } = setup();
+    act(() => result.current.handleRowClick("a", {}));
+    act(() => fireKey({ key: "ArrowDown", shiftKey: true }));
+    expect(result.current.selectedIds).toEqual(new Set(["a", "b"]));
+  });
+
+  it("Ctrl+A で全選択", () => {
+    const { result } = setup();
+    act(() => fireKey({ key: "a", ctrlKey: true }));
+    expect(result.current.selectedIds).toEqual(new Set(["a", "b", "c"]));
+  });
+
+  it("Escape で選択解除", () => {
+    const { result } = setup();
+    act(() => result.current.selectAll());
+    act(() => fireKey({ key: "Escape" }));
+    expect(result.current.selectedIds.size).toBe(0);
+  });
+
+  it("Delete で onDelete が選択アイテムと共に呼ばれる", () => {
+    const onDelete = vi.fn();
+    const { result } = setup({ onDelete });
+    act(() => result.current.handleRowClick("b", {}));
+    act(() => fireKey({ key: "Delete" }));
+    expect(onDelete).toHaveBeenCalledWith([{ id: "b", name: "B" }]);
+  });
+
+  it("Ctrl+C で onCopy が選択アイテムで呼ばれる", () => {
+    const onCopy = vi.fn();
+    const { result } = setup({ onCopy });
+    act(() => result.current.handleRowClick("a", {}));
+    act(() => fireKey({ key: "c", ctrlKey: true }));
+    expect(onCopy).toHaveBeenCalledWith([{ id: "a", name: "A" }]);
+  });
+
+  it("Ctrl+X で onCut が呼ばれる", () => {
+    const onCut = vi.fn();
+    const { result } = setup({ onCut });
+    act(() => result.current.handleRowClick("a", {}));
+    act(() => fireKey({ key: "x", ctrlKey: true }));
+    expect(onCut).toHaveBeenCalled();
+  });
+
+  it("Ctrl+V 選択なし = insertIndex null (末尾に追記を意図)", () => {
+    const onPaste = vi.fn();
+    setup({ onPaste });
+    act(() => fireKey({ key: "v", ctrlKey: true }));
+    expect(onPaste).toHaveBeenCalledWith(null);
+  });
+
+  it("Ctrl+V 選択あり = insertIndex = 最終選択インデックス+1", () => {
+    const onPaste = vi.fn();
+    const { result } = setup({ onPaste });
+    act(() => result.current.handleRowClick("a", {}));
+    act(() => result.current.handleRowClick("b", { ctrlKey: true }));
+    act(() => fireKey({ key: "v", ctrlKey: true }));
+    expect(onPaste).toHaveBeenCalledWith(2);
+  });
+
+  it("Ctrl+D で onDuplicate", () => {
+    const onDuplicate = vi.fn();
+    const { result } = setup({ onDuplicate });
+    act(() => result.current.handleRowClick("a", {}));
+    act(() => fireKey({ key: "d", ctrlKey: true }));
+    expect(onDuplicate).toHaveBeenCalledWith([{ id: "a", name: "A" }]);
+  });
+
+  it("Enter で onActivate (単一選択時のみ)", () => {
+    const onActivate = vi.fn();
+    const { result } = setup({ onActivate });
+    act(() => result.current.handleRowClick("b", {}));
+    act(() => fireKey({ key: "Enter" }));
+    expect(onActivate).toHaveBeenCalledWith({ id: "b", name: "B" });
+  });
+
+  it("Enter は複数選択時は onActivate を呼ばない", () => {
+    const onActivate = vi.fn();
+    const { result } = setup({ onActivate });
+    act(() => result.current.selectAll());
+    act(() => fireKey({ key: "Enter" }));
+    expect(onActivate).not.toHaveBeenCalled();
+  });
+
+  it("F2 でも onActivate が発火する", () => {
+    const onActivate = vi.fn();
+    const { result } = setup({ onActivate });
+    act(() => result.current.handleRowClick("a", {}));
+    act(() => fireKey({ key: "F2" }));
+    expect(onActivate).toHaveBeenCalledWith({ id: "a", name: "A" });
+  });
+
+  it("Alt+↑ で onMoveUp", () => {
+    const onMoveUp = vi.fn();
+    const { result } = setup({ onMoveUp });
+    act(() => result.current.handleRowClick("b", {}));
+    act(() => fireKey({ key: "ArrowUp", altKey: true }));
+    expect(onMoveUp).toHaveBeenCalledWith([{ id: "b", name: "B" }]);
+  });
+
+  it("Alt+↓ で onMoveDown", () => {
+    const onMoveDown = vi.fn();
+    const { result } = setup({ onMoveDown });
+    act(() => result.current.handleRowClick("b", {}));
+    act(() => fireKey({ key: "ArrowDown", altKey: true }));
+    expect(onMoveDown).toHaveBeenCalledWith([{ id: "b", name: "B" }]);
+  });
+
+  it("input フォーカス中はキーが無効", () => {
+    const onDelete = vi.fn();
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+    try {
+      const { result } = setup({ onDelete });
+      act(() => result.current.setSelectedIds(new Set(["a"])));
+      const ev = new KeyboardEvent("keydown", { key: "Delete", bubbles: true, cancelable: true });
+      Object.defineProperty(ev, "target", { value: input });
+      act(() => window.dispatchEvent(ev));
+      expect(onDelete).not.toHaveBeenCalled();
+    } finally {
+      input.remove();
+    }
+  });
+
+  it("enabled=false なら全キー無効", () => {
+    const onCopy = vi.fn();
+    const { result } = renderHook(() => {
+      const sel = useListSelection(items, (it) => it.id);
+      useListKeyboard({ items, getId: (it) => it.id, selection: sel, onCopy, enabled: false });
+      return sel;
+    });
+    act(() => result.current.handleRowClick("a", {}));
+    act(() => fireKey({ key: "c", ctrlKey: true }));
+    expect(onCopy).not.toHaveBeenCalled();
+  });
+});

--- a/designer/src/hooks/useListKeyboard.ts
+++ b/designer/src/hooks/useListKeyboard.ts
@@ -1,0 +1,155 @@
+import { useEffect } from "react";
+import type { ListSelection } from "./useListSelection";
+
+interface ListKeyboardOpts<T> {
+  items: T[];
+  getId: (item: T) => string;
+  selection: ListSelection<T>;
+  onActivate?: (item: T) => void;
+  onDelete?: (items: T[]) => void;
+  onCopy?: (items: T[]) => void;
+  onCut?: (items: T[]) => void;
+  onPaste?: (insertIndex: number | null) => void;
+  onDuplicate?: (items: T[]) => void;
+  onMoveUp?: (items: T[]) => void;
+  onMoveDown?: (items: T[]) => void;
+  enabled?: boolean;
+}
+
+/**
+ * リスト向けキーボードショートカット。window keydown に登録。
+ * - ↑/↓: 選択移動, Shift+↑/↓: 選択範囲拡張
+ * - Enter / F2: onActivate
+ * - Ctrl+A: 全選択, Delete: onDelete
+ * - Ctrl+C / X / V: onCopy / onCut / onPaste
+ * - Ctrl+D: onDuplicate
+ * - Alt+↑/↓: onMoveUp / onMoveDown
+ * - Escape: 選択解除
+ *
+ * input/textarea/select/contenteditable がフォーカス中は無効。
+ */
+export function useListKeyboard<T>(opts: ListKeyboardOpts<T>): void {
+  const {
+    items, getId, selection,
+    onActivate, onDelete, onCopy, onCut, onPaste, onDuplicate,
+    onMoveUp, onMoveDown,
+    enabled = true,
+  } = opts;
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handler = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (!target) return;
+      const tag = target.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+      if (target.isContentEditable) return;
+
+      const ctrl = e.ctrlKey || e.metaKey;
+      const itemIds = items.map(getId);
+
+      if (e.key === "Escape") {
+        if (selection.selectedIds.size > 0) {
+          e.preventDefault();
+          selection.clearSelection();
+        }
+        return;
+      }
+
+      if (ctrl && e.key === "a") {
+        e.preventDefault();
+        selection.selectAll();
+        return;
+      }
+
+      if (ctrl && !e.altKey && !e.shiftKey && e.key === "c") {
+        if (onCopy && selection.selectedItems.length > 0) {
+          e.preventDefault();
+          onCopy(selection.selectedItems);
+        }
+        return;
+      }
+
+      if (ctrl && !e.altKey && !e.shiftKey && e.key === "x") {
+        if (onCut && selection.selectedItems.length > 0) {
+          e.preventDefault();
+          onCut(selection.selectedItems);
+        }
+        return;
+      }
+
+      if (ctrl && !e.altKey && !e.shiftKey && e.key === "v") {
+        if (onPaste) {
+          e.preventDefault();
+          const ids = itemIds;
+          const selected = Array.from(selection.selectedIds);
+          const insertIndex = selected.length > 0
+            ? Math.max(...selected.map((id) => ids.indexOf(id))) + 1
+            : null;
+          onPaste(insertIndex);
+        }
+        return;
+      }
+
+      if (ctrl && !e.altKey && !e.shiftKey && e.key === "d") {
+        if (onDuplicate && selection.selectedItems.length > 0) {
+          e.preventDefault();
+          onDuplicate(selection.selectedItems);
+        }
+        return;
+      }
+
+      if (e.key === "Delete" && !ctrl && !e.altKey && !e.shiftKey) {
+        if (onDelete && selection.selectedItems.length > 0) {
+          e.preventDefault();
+          onDelete(selection.selectedItems);
+        }
+        return;
+      }
+
+      if ((e.key === "Enter" || e.key === "F2") && !ctrl && !e.altKey) {
+        if (onActivate && selection.selectedItems.length === 1) {
+          e.preventDefault();
+          onActivate(selection.selectedItems[0]);
+        }
+        return;
+      }
+
+      if (e.altKey && !ctrl && !e.shiftKey && (e.key === "ArrowUp" || e.key === "ArrowDown")) {
+        const handler = e.key === "ArrowUp" ? onMoveUp : onMoveDown;
+        if (handler && selection.selectedItems.length > 0) {
+          e.preventDefault();
+          handler(selection.selectedItems);
+        }
+        return;
+      }
+
+      if (!ctrl && !e.altKey && (e.key === "ArrowUp" || e.key === "ArrowDown")) {
+        e.preventDefault();
+        const ids = itemIds;
+        if (ids.length === 0) return;
+        const anchor = selection.getAnchorId();
+        const anchorIdx = anchor ? ids.indexOf(anchor) : -1;
+        const delta = e.key === "ArrowUp" ? -1 : 1;
+        const nextIdx = anchorIdx < 0
+          ? (delta > 0 ? 0 : ids.length - 1)
+          : Math.max(0, Math.min(ids.length - 1, anchorIdx + delta));
+        const nextId = ids[nextIdx];
+        if (e.shiftKey && anchor) {
+          const [lo, hi] = anchorIdx < nextIdx ? [anchorIdx, nextIdx] : [nextIdx, anchorIdx];
+          const range = new Set(ids.slice(lo, hi + 1));
+          selection.setSelectedIds(range);
+        } else {
+          selection.setSelectedIds(new Set([nextId]));
+        }
+      }
+    };
+
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [
+    enabled, items, getId, selection,
+    onActivate, onDelete, onCopy, onCut, onPaste, onDuplicate, onMoveUp, onMoveDown,
+  ]);
+}

--- a/designer/src/hooks/useListSelection.test.ts
+++ b/designer/src/hooks/useListSelection.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useListSelection } from "./useListSelection";
+
+interface Item {
+  id: string;
+  name: string;
+}
+
+const items: Item[] = [
+  { id: "a", name: "A" },
+  { id: "b", name: "B" },
+  { id: "c", name: "C" },
+  { id: "d", name: "D" },
+];
+
+function setup() {
+  return renderHook(() => useListSelection(items, (it) => it.id));
+}
+
+describe("useListSelection", () => {
+  it("初期状態は空選択", () => {
+    const { result } = setup();
+    expect(result.current.selectedIds.size).toBe(0);
+    expect(result.current.selectedItems).toEqual([]);
+  });
+
+  it("通常クリックで単一選択になる", () => {
+    const { result } = setup();
+    act(() => result.current.handleRowClick("b", {}));
+    expect(result.current.selectedIds).toEqual(new Set(["b"]));
+    expect(result.current.selectedItems).toEqual([{ id: "b", name: "B" }]);
+  });
+
+  it("別の行を通常クリックすると単一選択が切り替わる", () => {
+    const { result } = setup();
+    act(() => result.current.handleRowClick("a", {}));
+    act(() => result.current.handleRowClick("c", {}));
+    expect(result.current.selectedIds).toEqual(new Set(["c"]));
+  });
+
+  it("Ctrl+クリックで追加選択できる", () => {
+    const { result } = setup();
+    act(() => result.current.handleRowClick("a", {}));
+    act(() => result.current.handleRowClick("c", { ctrlKey: true }));
+    expect(result.current.selectedIds).toEqual(new Set(["a", "c"]));
+  });
+
+  it("Ctrl+クリックで選択済み行は選択解除される (トグル)", () => {
+    const { result } = setup();
+    act(() => result.current.handleRowClick("a", {}));
+    act(() => result.current.handleRowClick("b", { ctrlKey: true }));
+    act(() => result.current.handleRowClick("a", { ctrlKey: true }));
+    expect(result.current.selectedIds).toEqual(new Set(["b"]));
+  });
+
+  it("metaKey も Ctrl と同等に扱われる (Mac 向け)", () => {
+    const { result } = setup();
+    act(() => result.current.handleRowClick("a", {}));
+    act(() => result.current.handleRowClick("c", { metaKey: true }));
+    expect(result.current.selectedIds).toEqual(new Set(["a", "c"]));
+  });
+
+  it("Shift+クリックでアンカーから範囲選択できる", () => {
+    const { result } = setup();
+    act(() => result.current.handleRowClick("a", {}));
+    act(() => result.current.handleRowClick("c", { shiftKey: true }));
+    expect(result.current.selectedIds).toEqual(new Set(["a", "b", "c"]));
+  });
+
+  it("Shift+クリックは逆順 (下→上) でも範囲選択できる", () => {
+    const { result } = setup();
+    act(() => result.current.handleRowClick("d", {}));
+    act(() => result.current.handleRowClick("b", { shiftKey: true }));
+    expect(result.current.selectedIds).toEqual(new Set(["b", "c", "d"]));
+  });
+
+  it("selectAll で全選択になる", () => {
+    const { result } = setup();
+    act(() => result.current.selectAll());
+    expect(result.current.selectedIds).toEqual(new Set(["a", "b", "c", "d"]));
+  });
+
+  it("clearSelection で選択解除される", () => {
+    const { result } = setup();
+    act(() => result.current.selectAll());
+    act(() => result.current.clearSelection());
+    expect(result.current.selectedIds.size).toBe(0);
+  });
+
+  it("isSelected で特定 ID の選択状態を取得できる", () => {
+    const { result } = setup();
+    act(() => result.current.handleRowClick("b", {}));
+    expect(result.current.isSelected("b")).toBe(true);
+    expect(result.current.isSelected("a")).toBe(false);
+  });
+
+  it("setSelectedIds で外部から選択状態を上書きできる", () => {
+    const { result } = setup();
+    act(() => result.current.setSelectedIds(new Set(["a", "d"])));
+    expect(result.current.selectedIds).toEqual(new Set(["a", "d"]));
+  });
+});

--- a/designer/src/hooks/useListSelection.ts
+++ b/designer/src/hooks/useListSelection.ts
@@ -1,0 +1,95 @@
+import { useState, useCallback, useRef, useMemo } from "react";
+
+export interface ListSelection<T> {
+  selectedIds: Set<string>;
+  selectedItems: T[];
+  isSelected: (id: string) => boolean;
+  setSelectedIds: (ids: Set<string>) => void;
+  clearSelection: () => void;
+  selectAll: () => void;
+  handleRowClick: (id: string, e: { ctrlKey?: boolean; metaKey?: boolean; shiftKey?: boolean }) => void;
+  /** キーボード操作のアンカー (Shift+↑↓ の基準点)。外部読み取り用 */
+  getAnchorId: () => string | null;
+}
+
+/**
+ * リスト行の複数選択ロジック。
+ * - 通常クリック: 単一選択
+ * - Ctrl+クリック: 選択のトグル (複数選択)
+ * - Shift+クリック: アンカーからの範囲選択
+ */
+export function useListSelection<T>(
+  items: T[],
+  getId: (item: T) => string,
+): ListSelection<T> {
+  const [selectedIds, setSelectedIdsState] = useState<Set<string>>(new Set());
+  const anchorIdRef = useRef<string | null>(null);
+
+  const itemIds = useMemo(() => items.map(getId), [items, getId]);
+
+  const isSelected = useCallback(
+    (id: string) => selectedIds.has(id),
+    [selectedIds],
+  );
+
+  const setSelectedIds = useCallback((ids: Set<string>) => {
+    setSelectedIdsState(new Set(ids));
+  }, []);
+
+  const clearSelection = useCallback(() => {
+    setSelectedIdsState(new Set());
+    anchorIdRef.current = null;
+  }, []);
+
+  const selectAll = useCallback(() => {
+    setSelectedIdsState(new Set(itemIds));
+    if (itemIds.length > 0) anchorIdRef.current = itemIds[0];
+  }, [itemIds]);
+
+  const handleRowClick = useCallback(
+    (id: string, e: { ctrlKey?: boolean; metaKey?: boolean; shiftKey?: boolean }) => {
+      const ctrl = e.ctrlKey || e.metaKey;
+      if (ctrl) {
+        setSelectedIdsState((prev) => {
+          const next = new Set(prev);
+          if (next.has(id)) next.delete(id);
+          else next.add(id);
+          return next;
+        });
+        anchorIdRef.current = id;
+        return;
+      }
+      if (e.shiftKey && anchorIdRef.current) {
+        const anchor = anchorIdRef.current;
+        const fromIdx = itemIds.indexOf(anchor);
+        const toIdx = itemIds.indexOf(id);
+        if (fromIdx >= 0 && toIdx >= 0) {
+          const [lo, hi] = fromIdx < toIdx ? [fromIdx, toIdx] : [toIdx, fromIdx];
+          setSelectedIdsState(new Set(itemIds.slice(lo, hi + 1)));
+        }
+        return;
+      }
+      setSelectedIdsState(new Set([id]));
+      anchorIdRef.current = id;
+    },
+    [itemIds],
+  );
+
+  const selectedItems = useMemo(
+    () => items.filter((it) => selectedIds.has(getId(it))),
+    [items, selectedIds, getId],
+  );
+
+  const getAnchorId = useCallback(() => anchorIdRef.current, []);
+
+  return {
+    selectedIds,
+    selectedItems,
+    isSelected,
+    setSelectedIds,
+    clearSelection,
+    selectAll,
+    handleRowClick,
+    getAnchorId,
+  };
+}

--- a/designer/src/styles/dataList.css
+++ b/designer/src/styles/dataList.css
@@ -1,0 +1,86 @@
+/* ==========================================================================
+   DataList — 全画面共通の表形式リスト (#133)
+   ========================================================================== */
+
+.data-list {
+  width: 100%;
+  overflow: auto;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  box-sizing: border-box;
+}
+
+.data-list-empty {
+  padding: 32px 16px;
+  text-align: center;
+  color: #94a3b8;
+  font-size: 13px;
+}
+
+.data-list-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+  color: #1e293b;
+  table-layout: auto;
+}
+
+.data-list-table thead th {
+  position: sticky;
+  top: 0;
+  background: #f8fafc;
+  border-bottom: 1px solid #e2e8f0;
+  padding: 8px 12px;
+  text-align: left;
+  font-weight: 600;
+  color: #475569;
+  font-size: 12px;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+
+.data-list-th-handle,
+.data-list-td-handle {
+  width: 28px;
+  text-align: center;
+  color: #94a3b8;
+  cursor: grab;
+  padding: 0 !important;
+  user-select: none;
+}
+
+.data-list-td-handle:active {
+  cursor: grabbing;
+}
+
+.data-list-th-num,
+.data-list-td-num {
+  width: 48px;
+  text-align: right;
+  color: #64748b;
+  font-variant-numeric: tabular-nums;
+  padding-right: 12px;
+}
+
+.data-list-row {
+  border-bottom: 1px solid #f1f5f9;
+  transition: background 0.1s;
+}
+
+.data-list-row > td {
+  padding: 6px 12px;
+  vertical-align: middle;
+}
+
+.data-list-row:hover {
+  background: #f8fafc;
+}
+
+.data-list-row.selected {
+  background: #eef2ff;
+}
+
+.data-list-row.selected:hover {
+  background: #e0e7ff;
+}


### PR DESCRIPTION
## Summary

#133 epic (一覧表示系の操作・見た目統一) の **Phase 1 / PR 1**。共通コンポーネントと再利用可能なフックを新設する。**破壊的変更なし** (既存画面はまだ参照しない)。

## 新設ファイル

### フック (ヘッドレス・再利用可能)

**`designer/src/hooks/useListSelection.ts`**
- 選択状態 (`Set<string>`) の管理
- 通常 / Ctrl / Shift クリックのロジック
- `selectAll` / `clearSelection` / `isSelected` など
- 12 ケースの Vitest

**`designer/src/hooks/useListKeyboard.ts`**
- ↑↓ で選択移動
- Shift+↑↓ で範囲拡張
- Ctrl+A / Delete / Ctrl+C / Ctrl+X / Ctrl+V / Ctrl+D
- Alt+↑↓ で行移動
- Enter / F2 で activate (単一選択時のみ)
- Escape で選択解除
- input/textarea/select/contenteditable がフォーカス中は無効
- 19 ケースの Vitest

### コンポーネント

**`designer/src/components/common/DataList.tsx`**
- ジェネリック型 (`DataList<T>`) の表コンポーネント
- `columns` でカラム定義、`render` で各セルの描画を制御
- No 列 (最左) を永続順序として表示 (`showNumColumn`, デフォルト on)
- 行 D&D (`@dnd-kit/sortable`) でインデックス並び替え (`onReorder`)
- `selection` (useListSelection の戻り値) を渡すと選択状態が自動連動
- ダブルクリックで `onActivate` (キーボードの Enter/F2 と同等)
- 空状態のカスタマイズ (`emptyMessage`)

**`designer/src/styles/dataList.css`**
- `.data-list` / `.data-list-table` / `.data-list-row` / `.data-list-td-handle` / `.data-list-td-num` のスタイル

## 設計方針

issue の「ヘッドレス寄り設計」に沿い、フックは UI から独立して使えるようにした。これにより Phase 5 のキャンバス系 (FlowEditor / ActionEditor のステップ配置) でも `useListSelection` / `useListKeyboard` を再利用して操作感を揃えられる。

## 差分

```
 DataList.tsx           | 新規 175 行
 useListKeyboard.ts     | 新規 151 行
 useListKeyboard.test.ts| 新規 189 行
 useListSelection.ts    | 新規  94 行
 useListSelection.test.ts| 新規 110 行
 dataList.css           | 新規  99 行
 6 files, +818 行 / 0 削除
```

## Test plan

- [x] `npm run test:unit` — **143 pass** (前回 112 + 本 PR 31)
- [x] `npm run build` — TypeScript + Vite OK
- [x] 新規ファイルの ESLint 0 errors 0 warnings
- [ ] 未統合のため視覚影響ゼロ。マージは低リスク

## 後続 PR

- **Phase 2**: TableListView を DataList に移行 (カード → テーブル表示)
- **Phase 3**: ActionListView を DataList に移行
- **Phase 4**: TableEditor / ActionEditor 内の既存テーブルを DataList へ
- **Phase 5**: キャンバス系 (FlowEditor / ActionEditor フロー配置) でフックを再利用し操作感を揃える

Refs #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)