### PR TITLE
improve(table): TableListView をカード→テーブル表示に統一 (#133)

### DIFF
--- a/designer/src/components/table/TableListView.tsx
+++ b/designer/src/components/table/TableListView.tsx
@@ -1,13 +1,16 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import type { TableMeta } from "../../types/flow";
 import type { TableDefinition, SqlDialect } from "../../types/table";
 import { SQL_DIALECT_LABELS } from "../../types/table";
 import { listTables, createTable, deleteTable, loadTable } from "../../store/tableStore";
-import { loadProject } from "../../store/flowStore";
+import { loadProject, saveProject } from "../../store/flowStore";
 import { generateAllDdl, generateAllTableMarkdown } from "../../utils/ddlGenerator";
 import { mcpBridge } from "../../mcp/mcpBridge";
 import { TableSubToolbar } from "./TableSubToolbar";
+import { DataList, type DataListColumn } from "../common/DataList";
+import { useListSelection } from "../../hooks/useListSelection";
+import { useListKeyboard } from "../../hooks/useListKeyboard";
 import "../../styles/table.css";
 
 export function TableListView() {
@@ -20,21 +23,8 @@ export function TableListView() {
   const [addCategory, setAddCategory] = useState("");
   const [exportDialect, setExportDialect] = useState<SqlDialect>("postgresql");
   const [showExport, setShowExport] = useState(false);
-  const [selectedId, setSelectedId] = useState<string | null>(null);
-  const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const handleCardClick = (id: string) => {
-    if (clickTimerRef.current) {
-      clearTimeout(clickTimerRef.current);
-      clickTimerRef.current = null;
-      navigate(`/table/edit/${id}`);
-    } else {
-      clickTimerRef.current = setTimeout(() => {
-        clickTimerRef.current = null;
-        setSelectedId((prev) => (prev === id ? null : id));
-      }, 250);
-    }
-  };
+  const selection = useListSelection(tables, (t) => t.id);
 
   const reload = useCallback(async () => {
     const t = await listTables();
@@ -52,6 +42,38 @@ export function TableListView() {
     return unsub;
   }, [reload]);
 
+  const handleReorder = useCallback(async (fromIndex: number, toIndex: number) => {
+    const project = await loadProject();
+    const metas = project.tables ?? [];
+    if (fromIndex < 0 || fromIndex >= metas.length || toIndex < 0 || toIndex >= metas.length) return;
+    const next = [...metas];
+    const [moved] = next.splice(fromIndex, 1);
+    next.splice(toIndex, 0, moved);
+    await saveProject({ ...project, tables: next, updatedAt: new Date().toISOString() });
+    await reload();
+  }, [reload]);
+
+  const handleDeleteItems = useCallback(async (items: TableMeta[]) => {
+    if (items.length === 0) return;
+    const msg = items.length === 1
+      ? `テーブル「${items[0].name}」を削除しますか？`
+      : `${items.length} 件のテーブルを削除しますか？`;
+    if (!confirm(msg)) return;
+    for (const item of items) {
+      await deleteTable(item.id);
+    }
+    selection.clearSelection();
+    await reload();
+  }, [reload, selection]);
+
+  useListKeyboard({
+    items: tables,
+    getId: (t) => t.id,
+    selection,
+    onActivate: (t) => navigate(`/table/edit/${t.id}`),
+    onDelete: handleDeleteItems,
+  });
+
   const handleAdd = async () => {
     const name = addName.trim();
     const logical = addLogical.trim();
@@ -62,13 +84,6 @@ export function TableListView() {
     setAddLogical("");
     setAddCategory("");
     navigate(`/table/edit/${table.id}`);
-  };
-
-  const handleDelete = async (id: string, e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (!confirm("このテーブル定義を削除しますか？")) return;
-    await deleteTable(id);
-    await reload();
   };
 
   const handleExportDdl = async () => {
@@ -92,11 +107,61 @@ export function TableListView() {
     downloadText(`${projectName}_tables.md`, md);
   };
 
+  const columns: DataListColumn<TableMeta>[] = [
+    {
+      key: "name",
+      header: "テーブル名",
+      render: (t) => <code className="table-list-name">{t.name}</code>,
+    },
+    {
+      key: "logicalName",
+      header: "論理名",
+      render: (t) => <span className="table-list-logical">{t.logicalName}</span>,
+    },
+    {
+      key: "category",
+      header: "カテゴリ",
+      width: "120px",
+      render: (t) => t.category ? <span className="table-list-category-badge">{t.category}</span> : null,
+    },
+    {
+      key: "columnCount",
+      header: "カラム数",
+      width: "80px",
+      align: "right",
+      render: (t) => <>{t.columnCount}</>,
+    },
+    {
+      key: "updatedAt",
+      header: "更新日時",
+      width: "120px",
+      render: (t) => new Date(t.updatedAt).toLocaleDateString("ja-JP"),
+    },
+    {
+      key: "actions",
+      header: "",
+      width: "40px",
+      align: "center",
+      render: (t) => (
+        <button
+          className="table-list-row-delete"
+          onClick={(e) => {
+            e.stopPropagation();
+            void handleDeleteItems([t]);
+          }}
+          title="削除"
+        >
+          <i className="bi bi-trash" />
+        </button>
+      ),
+    },
+  ];
+
   return (
     <div className="table-list-page">
       <TableSubToolbar />
 
-      <div className="table-list-content" onClick={() => setSelectedId(null)}>
+      <div className="table-list-content">
         <div className="table-list-header">
           <h2 className="table-list-title">
             <i className="bi bi-table" /> テーブル設計書
@@ -142,38 +207,15 @@ export function TableListView() {
             </button>
           </div>
         ) : (
-          <div className="table-list-grid">
-            {tables.map((t) => (
-              <div
-                key={t.id}
-                className={`table-list-card${selectedId === t.id ? " selected" : ""}`}
-                onClick={(e) => { e.stopPropagation(); handleCardClick(t.id); }}
-              >
-                <div className="table-card-header">
-                  <span className="table-card-name">{t.name}</span>
-                  {t.category && (
-                    <span className="table-card-category">{t.category}</span>
-                  )}
-                </div>
-                <div className="table-card-logical">{t.logicalName}</div>
-                <div className="table-card-meta">
-                  <span>
-                    <i className="bi bi-columns-gap" /> {t.columnCount} カラム
-                  </span>
-                  <span className="table-card-date">
-                    {new Date(t.updatedAt).toLocaleDateString("ja-JP")}
-                  </span>
-                </div>
-                <button
-                  className="table-card-delete"
-                  onClick={(e) => handleDelete(t.id, e)}
-                  title="削除"
-                >
-                  <i className="bi bi-trash" />
-                </button>
-              </div>
-            ))}
-          </div>
+          <DataList
+            items={tables}
+            columns={columns}
+            getId={(t) => t.id}
+            selection={selection}
+            onActivate={(t) => navigate(`/table/edit/${t.id}`)}
+            onReorder={handleReorder}
+            className="table-list-datalist"
+          />
         )}
 
         {/* テーブル追加モーダル */}

--- a/designer/src/styles/table.css
+++ b/designer/src/styles/table.css
@@ -87,95 +87,82 @@
   gap: 8px;
 }
 
-/* ── テーブルカード ─────────────────────────────────────────────────────── */
+/* ── テーブル一覧 (DataList 利用) ─────────────────────────────────────── */
 
-.table-list-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 16px;
-}
-
-.table-list-card {
-  position: relative;
-  padding: 16px;
+/* DataList をダーク系パレットに上書き (TableListView 固有) */
+.table-list-page .data-list {
   background: #222240;
-  border: 1px solid #333;
-  border-radius: 8px;
-  cursor: pointer;
-  transition: all 0.15s;
+  border-color: #333;
+  color: #e0e0e0;
 }
 
-.table-list-card:hover {
-  border-color: #7c6bff;
+.table-list-page .data-list-table thead th {
+  background: #1a1a2e;
+  border-bottom-color: #333;
+  color: #888;
+}
+
+.table-list-page .data-list-row {
+  border-bottom-color: #2a2a45;
+}
+
+.table-list-page .data-list-row:hover {
   background: #28284a;
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(124,107,255,0.15);
 }
 
-.table-list-card.selected {
-  outline: 2px solid #7c6bff;
-  background: #28284a;
+.table-list-page .data-list-row.selected {
+  background: #2e2a5f;
 }
 
-.table-card-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 4px;
+.table-list-page .data-list-row.selected:hover {
+  background: #363062;
 }
 
-.table-card-name {
+.table-list-page .data-list-td-handle {
+  color: #555;
+}
+
+.table-list-page .data-list-td-num {
+  color: #aaa;
+}
+
+.table-list-page .data-list-row > td {
+  color: #ccc;
+}
+
+.table-list-name {
   font-weight: 600;
-  font-size: 15px;
+  font-size: 14px;
   color: #fff;
   font-family: "Consolas", "Monaco", monospace;
+  background: none;
+  padding: 0;
 }
 
-.table-card-category {
+.table-list-logical {
+  color: #ccc;
+}
+
+.table-list-category-badge {
   font-size: 11px;
   padding: 2px 8px;
   border-radius: 4px;
   background: rgba(124,107,255,0.15);
   color: #a99bff;
+  white-space: nowrap;
 }
 
-.table-card-logical {
-  font-size: 13px;
-  color: #999;
-  margin-bottom: 12px;
-}
-
-.table-card-meta {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  font-size: 12px;
-  color: #777;
-}
-
-.table-card-meta i {
-  margin-right: 4px;
-}
-
-.table-card-delete {
-  position: absolute;
-  top: 8px;
-  right: 8px;
+.table-list-row-delete {
   background: none;
   border: none;
   color: #666;
   cursor: pointer;
-  opacity: 0;
-  transition: all 0.15s;
-  padding: 4px;
+  padding: 4px 6px;
   border-radius: 4px;
+  transition: all 0.15s;
 }
 
-.table-list-card:hover .table-card-delete {
-  opacity: 1;
-}
-
-.table-card-delete:hover {
+.table-list-row-delete:hover {
   color: #ff6b6b;
   background: rgba(255,107,107,0.1);
 }


### PR DESCRIPTION
## Summary

#133 epic の **Phase 2 / PR 2**。TableListView をカード・グリッドから DataList ベースの表形式に置き換える。

## 機能

- カラム: **No / テーブル名 / 論理名 / カテゴリ / カラム数 / 更新日時 / 削除**
- 行 D&D で並び替え → project.json の tables 配列順を保存
- クリックで選択 (単一 / Ctrl+ 複数 / Shift+ 範囲)
- ダブルクリックで編集画面へ遷移 (\`/table/edit/:id\`)
- Enter / F2 で遷移
- Delete で複数削除 (確認付き)
- Ctrl+A 全選択 / Escape 選択解除 (useListKeyboard 提供)

## 実装

- カード/グリッド固有 JSX を削除し DataList + columns 定義に移行
- useListSelection / useListKeyboard フックで状態とキー操作を取得
- 従来の \`clickTimerRef\` による click/dblclick 分離ロジックを削除
- \`.table-list-grid\` / \`.table-list-card*\` / \`.table-card-*\` の CSS を削除
- 代わりに \`.table-list-page .data-list\` にダーク系パレットの上書きを追加

## 視覚変化 (大きい)

- **カード → 表** 形式に全面的に変更 (issue #133 の明示的な方針)
- クリック挙動: 「1 回目=選択 / 2 回目=遷移」の timer 方式 → 「クリック=選択 / ダブルクリック=遷移」の標準 UX
- ダーク背景 (\`#1a1a2e\` / \`#222240\`) は維持。カテゴリバッジ・テーブル名 monospace 等のスタイルは踏襲

## 差分

\`\`\`
 TableListView.tsx | 154 ++++++++++++++++---------
 table.css         | 103 +++++++---------
 2 files, +143 / -114
\`\`\`

## Test plan

- [x] \`npm run test:unit\` — 143 pass (前回と同数、機能テストが fork していないことを確認)
- [x] \`npm run build\` — OK
- [x] Playwright MCP で視覚確認:
  - 4 テーブル (users / customers / orders / order_items) が表形式で表示
  - No / テーブル名 (monospace) / 論理名 / カテゴリ badge / カラム数 / 更新日時 全カラム可視
  - D&D grip ハンドル・削除アイコンが各行に表示
  - キーボード ↓ 操作で選択が動く (useListKeyboard 連動確認)
- [ ] **マージ前にユーザー目視確認** — カード→表の大きい UI 変更のため必須

## 依存

- PR #138 (DataList 基盤) がマージ済みの main を前提

## 後続 PR

- **Phase 3**: ActionListView を DataList に (同じパターン)
- **Phase 4**: TableEditor / ActionEditor 内のカラム・ステップテーブルを DataList へ
- **Phase 5**: キャンバス系にフック適用

Refs #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)