### PR TITLE
improve(table): テーブル一覧を共通部品化、カード/表切替を追加 (#133 Phase E)

### DIFF
--- a/designer/e2e/table-list.spec.ts
+++ b/designer/e2e/table-list.spec.ts
@@ -1,0 +1,64 @@
+/**
+ * テーブル一覧 (/table/list) E2E スモークテスト — #133 Phase E
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+
+const dummyTables = [
+  { id: "tbl-0001", name: "users", logicalName: "ユーザーマスタ", description: "", category: "マスタ", createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+  { id: "tbl-0002", name: "orders", logicalName: "注文", description: "", category: "トランザクション", createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+  { id: "tbl-0003", name: "products", logicalName: "商品マスタ", description: "", category: "マスタ", createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+];
+
+const dummyProject = {
+  version: 1,
+  name: "E2Eテスト用プロジェクト",
+  screens: [],
+  groups: [],
+  edges: [],
+  tables: dummyTables,
+  updatedAt: new Date().toISOString(),
+};
+
+async function setupTableList(page: Page) {
+  await page.addInitScript(({ project, tables }) => {
+    localStorage.setItem("flow-project", JSON.stringify(project));
+    for (const t of tables) {
+      localStorage.setItem(`table-${t.id}`, JSON.stringify({ ...t, columns: [], indexes: [] }));
+    }
+    localStorage.removeItem("designer-open-tabs");
+    localStorage.removeItem("designer-active-tab");
+    localStorage.removeItem("list-view-mode:table-list");
+  }, { project: dummyProject, tables: dummyTables });
+  await page.goto("/table/list");
+  await expect(page.locator(".table-list-page")).toBeVisible();
+}
+
+test.describe("テーブル一覧", () => {
+  test("既定はカードレイアウトで全件表示", async ({ page }) => {
+    await setupTableList(page);
+    await expect(page.locator(".tables-data-list.data-list-layout-grid")).toBeVisible();
+    await expect(page.locator(".data-list-card")).toHaveCount(3);
+  });
+
+  test("ViewModeToggle で表レイアウトに切替できる", async ({ page }) => {
+    await setupTableList(page);
+    await page.getByRole("button", { name: "表表示" }).click();
+    await expect(page.locator(".tables-data-list .data-list-table")).toBeVisible();
+    await expect(page.locator(".data-list-row")).toHaveCount(3);
+  });
+
+  test("検索で絞り込みできる", async ({ page }) => {
+    await setupTableList(page);
+    await page.locator(".table-list-search input").fill("ユーザー");
+    await expect(page.locator(".data-list-card")).toHaveCount(1);
+    await expect(page.locator(".filter-bar")).toBeVisible();
+  });
+
+  test("カードのダブルクリックでテーブル編集画面へ遷移", async ({ page }) => {
+    await setupTableList(page);
+    const card = page.locator(".data-list-card").first();
+    await card.dblclick();
+    await expect(page).toHaveURL(/\/table\/edit\//);
+  });
+});

--- a/designer/src/components/table/TableListView.tsx
+++ b/designer/src/components/table/TableListView.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import type { TableMeta } from "../../types/flow";
 import type { TableDefinition, SqlDialect } from "../../types/table";
@@ -8,33 +8,38 @@ import { loadProject } from "../../store/flowStore";
 import { generateAllDdl, generateAllTableMarkdown } from "../../utils/ddlGenerator";
 import { mcpBridge } from "../../mcp/mcpBridge";
 import { TableSubToolbar } from "./TableSubToolbar";
+import { DataList, type DataListColumn } from "../common/DataList";
+import { FilterBar } from "../common/FilterBar";
+import { ViewModeToggle, type ViewMode } from "../common/ViewModeToggle";
+import { useListSelection } from "../../hooks/useListSelection";
+import { useListKeyboard } from "../../hooks/useListKeyboard";
+import { useListFilter } from "../../hooks/useListFilter";
+import { useListSort } from "../../hooks/useListSort";
+import { usePersistentState } from "../../hooks/usePersistentState";
 import "../../styles/table.css";
+
+const STORAGE_KEY = "list-view-mode:table-list";
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString("ja-JP");
+  } catch {
+    return iso;
+  }
+}
 
 export function TableListView() {
   const navigate = useNavigate();
   const [tables, setTables] = useState<TableMeta[]>([]);
   const [projectName, setProjectName] = useState("プロジェクト");
+  const [query, setQuery] = useState("");
+  const [viewMode, setViewMode] = usePersistentState<ViewMode>(STORAGE_KEY, "card");
   const [showAdd, setShowAdd] = useState(false);
   const [addName, setAddName] = useState("");
   const [addLogical, setAddLogical] = useState("");
   const [addCategory, setAddCategory] = useState("");
   const [exportDialect, setExportDialect] = useState<SqlDialect>("postgresql");
   const [showExport, setShowExport] = useState(false);
-  const [selectedId, setSelectedId] = useState<string | null>(null);
-  const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const handleCardClick = (id: string) => {
-    if (clickTimerRef.current) {
-      clearTimeout(clickTimerRef.current);
-      clickTimerRef.current = null;
-      navigate(`/table/edit/${id}`);
-    } else {
-      clickTimerRef.current = setTimeout(() => {
-        clickTimerRef.current = null;
-        setSelectedId((prev) => (prev === id ? null : id));
-      }, 250);
-    }
-  };
 
   const reload = useCallback(async () => {
     const t = await listTables();
@@ -52,6 +57,58 @@ export function TableListView() {
     return unsub;
   }, [reload]);
 
+  const filter = useListFilter(tables);
+
+  useEffect(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) {
+      filter.applyFilter(null);
+      return;
+    }
+    filter.applyFilter((t) =>
+      t.name.toLowerCase().includes(q) ||
+      t.logicalName.toLowerCase().includes(q) ||
+      (t.category ?? "").toLowerCase().includes(q),
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query]);
+
+  const sortAccessor = useCallback((t: TableMeta, key: string): string | number => {
+    switch (key) {
+      case "name": return t.name;
+      case "logicalName": return t.logicalName;
+      case "category": return t.category ?? "";
+      case "columnCount": return t.columnCount;
+      case "updatedAt": return t.updatedAt;
+      default: return "";
+    }
+  }, []);
+
+  const sort = useListSort(filter.filtered, sortAccessor);
+  const selection = useListSelection(sort.sorted, (t) => t.id);
+
+  const handleActivate = useCallback((t: TableMeta) => {
+    navigate(`/table/edit/${t.id}`);
+  }, [navigate]);
+
+  const handleDelete = async (items: TableMeta[]) => {
+    if (!confirm(`${items.length} 件のテーブル定義を削除しますか？`)) return;
+    for (const t of items) {
+      await deleteTable(t.id);
+    }
+    await reload();
+    selection.clearSelection();
+  };
+
+  useListKeyboard({
+    items: sort.sorted,
+    getId: (t) => t.id,
+    selection,
+    layout: viewMode === "card" ? "grid" : "list",
+    onActivate: handleActivate,
+    onDelete: handleDelete,
+  });
+
   const handleAdd = async () => {
     const name = addName.trim();
     const logical = addLogical.trim();
@@ -62,13 +119,6 @@ export function TableListView() {
     setAddLogical("");
     setAddCategory("");
     navigate(`/table/edit/${table.id}`);
-  };
-
-  const handleDelete = async (id: string, e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (!confirm("このテーブル定義を削除しますか？")) return;
-    await deleteTable(id);
-    await reload();
   };
 
   const handleExportDdl = async () => {
@@ -92,89 +142,137 @@ export function TableListView() {
     downloadText(`${projectName}_tables.md`, md);
   };
 
+  const columns = useMemo<DataListColumn<TableMeta>[]>(() => [
+    {
+      key: "name",
+      header: "テーブル名",
+      sortable: true,
+      sortAccessor: (t) => t.name,
+      render: (t) => <code className="table-list-name-code">{t.name}</code>,
+    },
+    {
+      key: "logicalName",
+      header: "論理名",
+      sortable: true,
+      sortAccessor: (t) => t.logicalName,
+      render: (t) => t.logicalName,
+    },
+    {
+      key: "category",
+      header: "カテゴリ",
+      width: "120px",
+      sortable: true,
+      sortAccessor: (t) => t.category ?? "",
+      render: (t) => t.category ? <span className="table-card-category">{t.category}</span> : null,
+    },
+    {
+      key: "columnCount",
+      header: "カラム",
+      width: "80px",
+      align: "right",
+      sortable: true,
+      sortAccessor: (t) => t.columnCount,
+      render: (t) => <span className="table-list-col-count">{t.columnCount}</span>,
+    },
+    {
+      key: "updatedAt",
+      header: "更新日",
+      width: "120px",
+      sortable: true,
+      sortAccessor: (t) => t.updatedAt,
+      render: (t) => <span className="table-list-date">{formatDate(t.updatedAt)}</span>,
+    },
+  ], []);
+
+  const renderCard = (t: TableMeta) => (
+    <div className="table-card-content">
+      <div className="table-card-header">
+        <span className="table-card-name">{t.name}</span>
+        {t.category && <span className="table-card-category">{t.category}</span>}
+      </div>
+      <div className="table-card-logical">{t.logicalName}</div>
+      <div className="table-card-meta">
+        <span><i className="bi bi-columns-gap" /> {t.columnCount} カラム</span>
+        <span className="table-card-date">{formatDate(t.updatedAt)}</span>
+      </div>
+    </div>
+  );
+
+  const selectedCount = selection.selectedIds.size;
+
   return (
     <div className="table-list-page">
       <TableSubToolbar />
 
-      <div className="table-list-content" onClick={() => setSelectedId(null)}>
+      <div className="table-list-content">
         <div className="table-list-header">
           <h2 className="table-list-title">
             <i className="bi bi-table" /> テーブル設計書
             <span className="table-list-count">{tables.length} テーブル</span>
           </h2>
           <div className="table-list-actions">
+            <div className="table-list-search">
+              <i className="bi bi-search" />
+              <input
+                type="text"
+                placeholder="名前・論理名・カテゴリで絞り込み..."
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+              />
+              {query && (
+                <button className="clear-btn" onClick={() => setQuery("")} title="クリア">
+                  <i className="bi bi-x-circle-fill" />
+                </button>
+              )}
+            </div>
+            <ViewModeToggle mode={viewMode} onChange={setViewMode} storageKey={STORAGE_KEY} />
             {tables.length > 0 && (
               <>
-                <button
-                  className="tbl-btn tbl-btn-ghost"
-                  onClick={handleExportMarkdown}
-                  title="Markdown エクスポート"
-                >
+                <button className="tbl-btn tbl-btn-ghost" onClick={handleExportMarkdown} title="Markdown エクスポート">
                   <i className="bi bi-file-earmark-text" /> Markdown
                 </button>
-                <button
-                  className="tbl-btn tbl-btn-ghost"
-                  onClick={() => setShowExport(true)}
-                  title="DDL エクスポート"
-                >
+                <button className="tbl-btn tbl-btn-ghost" onClick={() => setShowExport(true)} title="DDL エクスポート">
                   <i className="bi bi-code-square" /> DDL
                 </button>
               </>
             )}
-            <button
-              className="tbl-btn tbl-btn-primary"
-              onClick={() => setShowAdd(true)}
-            >
+            {selectedCount > 0 && (
+              <button className="tbl-btn tbl-btn-ghost danger" onClick={() => handleDelete(selection.selectedItems)}>
+                <i className="bi bi-trash" /> {selectedCount} 件削除
+              </button>
+            )}
+            <button className="tbl-btn tbl-btn-primary" onClick={() => setShowAdd(true)}>
               <i className="bi bi-plus-lg" /> テーブル追加
             </button>
           </div>
         </div>
 
-        {tables.length === 0 && !showAdd ? (
-          <div className="table-list-empty">
-            <i className="bi bi-table" />
-            <p>テーブル定義がまだありません</p>
-            <button
-              className="tbl-btn tbl-btn-primary"
-              onClick={() => setShowAdd(true)}
-            >
-              <i className="bi bi-plus-lg" /> 最初のテーブルを追加
-            </button>
-          </div>
-        ) : (
-          <div className="table-list-grid">
-            {tables.map((t) => (
-              <div
-                key={t.id}
-                className={`table-list-card${selectedId === t.id ? " selected" : ""}`}
-                onClick={(e) => { e.stopPropagation(); handleCardClick(t.id); }}
-              >
-                <div className="table-card-header">
-                  <span className="table-card-name">{t.name}</span>
-                  {t.category && (
-                    <span className="table-card-category">{t.category}</span>
-                  )}
-                </div>
-                <div className="table-card-logical">{t.logicalName}</div>
-                <div className="table-card-meta">
-                  <span>
-                    <i className="bi bi-columns-gap" /> {t.columnCount} カラム
-                  </span>
-                  <span className="table-card-date">
-                    {new Date(t.updatedAt).toLocaleDateString("ja-JP")}
-                  </span>
-                </div>
-                <button
-                  className="table-card-delete"
-                  onClick={(e) => handleDelete(t.id, e)}
-                  title="削除"
-                >
-                  <i className="bi bi-trash" />
-                </button>
-              </div>
-            ))}
-          </div>
-        )}
+        <FilterBar
+          isActive={filter.isActive}
+          totalCount={filter.totalCount}
+          visibleCount={filter.visibleCount}
+          label={query ? `検索: "${query}"` : undefined}
+          onClear={() => { setQuery(""); filter.clearFilter(); }}
+        />
+
+        <DataList
+          items={sort.sorted}
+          columns={columns}
+          getId={(t) => t.id}
+          selection={selection}
+          sort={sort}
+          onActivate={handleActivate}
+          layout={viewMode === "card" ? "grid" : "list"}
+          renderCard={renderCard}
+          showNumColumn={viewMode === "table"}
+          variant="dark"
+          className="tables-data-list"
+          emptyMessage={
+            query
+              ? <p>該当するテーブル定義がありません</p>
+              : <p>テーブル定義がまだありません。「テーブル追加」から作成してください。</p>
+          }
+        />
 
         {/* テーブル追加モーダル */}
         {showAdd && (

--- a/designer/src/styles/table.css
+++ b/designer/src/styles/table.css
@@ -87,34 +87,116 @@
   gap: 8px;
 }
 
-/* ── テーブルカード ─────────────────────────────────────────────────────── */
+/* ── テーブル一覧 検索ボックス ───────────────────────────────────── */
 
-.table-list-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 16px;
+.table-list-search {
+  position: relative;
+  display: flex;
+  align-items: center;
 }
 
-.table-list-card {
-  position: relative;
-  padding: 16px;
-  background: #222240;
-  border: 1px solid #333;
-  border-radius: 8px;
+.table-list-search > i {
+  position: absolute;
+  left: 8px;
+  color: #888;
+  pointer-events: none;
+  font-size: 13px;
+}
+
+.table-list-search input {
+  padding: 5px 28px 5px 28px;
+  border: 1px solid #444;
+  border-radius: 6px;
+  font-size: 13px;
+  background: #1a1a2e;
+  color: #e0e0e0;
+  outline: none;
+  min-width: 220px;
+}
+
+.table-list-search input:focus {
+  border-color: #7c6bff;
+}
+
+.table-list-search .clear-btn {
+  position: absolute;
+  right: 4px;
+  background: transparent;
+  border: none;
+  color: #888;
   cursor: pointer;
+  padding: 2px;
+}
+
+.table-list-search .clear-btn:hover {
+  color: #fff;
+}
+
+/* ── DataList (dark variant) カスタム ─────────────────────────────── */
+
+.tables-data-list.data-list {
+  background: #1a1a2e;
+  border-color: #333;
+}
+
+.tables-data-list .data-list-grid {
+  padding: 16px;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+}
+
+.tables-data-list .data-list-card {
+  background: #222240;
+  border-color: #333;
+  padding: 16px;
   transition: all 0.15s;
 }
 
-.table-list-card:hover {
+.tables-data-list .data-list-card:hover {
   border-color: #7c6bff;
   background: #28284a;
   transform: translateY(-1px);
   box-shadow: 0 4px 12px rgba(124,107,255,0.15);
 }
 
-.table-list-card.selected {
-  outline: 2px solid #7c6bff;
+.tables-data-list .data-list-card.selected {
   background: #28284a;
+  border-color: #7c6bff;
+  box-shadow: 0 0 0 1px #7c6bff inset;
+}
+
+.tables-data-list .data-list-table thead th {
+  background: #222240;
+  border-bottom-color: #333;
+  color: #999;
+}
+
+.tables-data-list .data-list-th-sortable:hover,
+.tables-data-list .data-list-th-sorted {
+  background: rgba(124,107,255,0.12);
+}
+
+.tables-data-list .data-list-row {
+  border-bottom-color: rgba(255,255,255,0.04);
+}
+
+.tables-data-list .data-list-row:hover {
+  background: rgba(255,255,255,0.03);
+}
+
+.tables-data-list .data-list-row.selected {
+  background: rgba(124,107,255,0.12);
+}
+
+.tables-data-list .data-list-td-num {
+  color: #666;
+}
+
+/* ── カード内コンテンツ ───────────────────────────────────────────── */
+
+.table-card-content {
+  display: flex;
+  flex-direction: column;
 }
 
 .table-card-header {
@@ -122,6 +204,7 @@
   align-items: center;
   justify-content: space-between;
   margin-bottom: 4px;
+  gap: 8px;
 }
 
 .table-card-name {
@@ -129,6 +212,9 @@
   font-size: 15px;
   color: #fff;
   font-family: "Consolas", "Monaco", monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .table-card-category {
@@ -137,6 +223,7 @@
   border-radius: 4px;
   background: rgba(124,107,255,0.15);
   color: #a99bff;
+  flex-shrink: 0;
 }
 
 .table-card-logical {
@@ -157,44 +244,36 @@
   margin-right: 4px;
 }
 
-.table-card-delete {
-  position: absolute;
-  top: 8px;
-  right: 8px;
-  background: none;
-  border: none;
-  color: #666;
-  cursor: pointer;
-  opacity: 0;
-  transition: all 0.15s;
-  padding: 4px;
-  border-radius: 4px;
+.table-card-date {
+  white-space: nowrap;
 }
 
-.table-list-card:hover .table-card-delete {
-  opacity: 1;
+/* ── 表モードセル ─────────────────────────────────────────────────── */
+
+.table-list-name-code {
+  font-family: "Consolas", "Monaco", monospace;
+  color: #ddd;
 }
 
-.table-card-delete:hover {
+.table-list-col-count {
+  font-variant-numeric: tabular-nums;
+  color: #aaa;
+}
+
+.table-list-date {
+  color: #888;
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+}
+
+/* ── danger ghost (削除ボタン) ───────────────────────────────────── */
+.tbl-btn-ghost.danger {
   color: #ff6b6b;
-  background: rgba(255,107,107,0.1);
 }
 
-/* ── 空状態 ────────────────────────────────────────────────────────────── */
-
-.table-list-empty {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 12px;
-  padding: 80px 0;
-  color: #777;
-}
-
-.table-list-empty i {
-  font-size: 48px;
-  color: #555;
+.tbl-btn-ghost.danger:hover {
+  background: rgba(255,107,107,0.12);
+  color: #ff8585;
 }
 
 /* ── 共通ボタン ────────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

TableListView を DataList + 共通フックで再実装。カード ⇔ 表切替と Excel/Explorer 準拠操作を追加。これで Issue #133 の Phase A〜E が全て完了。

## 主な変更

- `designer/src/components/table/TableListView.tsx` — DataList ベースに全面書き換え
- `designer/src/styles/table.css` — DataList (dark variant) 向けにスタイル整理、旧 \`.table-list-grid/card\` を置換
- `designer/e2e/table-list.spec.ts` — スモークテスト 4 件

## 有効になった機能

| 機能 | 内容 |
|---|---|
| 表示切替 | カード (既定) ⇔ 表、\`list-view-mode:table-list\` に永続化 |
| 選択 | Click / Ctrl+ / Shift+ / Ctrl+A / Esc |
| キーボード | ↑↓←→ 2D (カード) / ↑↓ (表) / Enter・F2 で編集画面 / Delete で複数削除 / Home・End |
| フィルタ | 検索 (名前/論理名/カテゴリ) — FilterBar で件数表示 |
| ソート | 列ヘッダクリック (単一/多段 Shift+) — 名前/論理名/カテゴリ/カラム数/更新日 |
| 複数削除 | 選択中のテーブルをまとめて削除 (確認ダイアログあり) |

## Issue #133 Phase 完了状況

- [x] Phase A: TanStack Table 導入 + 共通フック完全版 + DataList 差し替え + FilterBar + ViewModeToggle (PR #141)
- [x] Phase B: テーブル定義 > カラム一覧を共通部品に移行 (PR #142)
- [x] Phase C: 画面一覧の新設 (画面フローから分離) (PR #143)
- [x] Phase D: 処理フロー一覧を共通部品化 + カード/表切替 (PR #144)
- [x] Phase E: テーブル一覧を共通部品化 + カード/表切替 (本 PR)

## 受け入れ条件 (全体)

- [x] 共通フック 5 種 (useListSelection / useListKeyboard / useListClipboard / useListFilter / useListSort) 提供、Vitest 済
- [x] DataList が list / grid 両レイアウト対応
- [x] 対象 4 画面 (画面一覧 / テーブル一覧 / 処理フロー一覧 / テーブル定義 > カラム) が共通部品を使用
- [x] カード ⇔ 表切替が画面ごと localStorage に永続化
- [x] Excel/Explorer 準拠の全操作が統一動作
- [x] No 列表示、D&D / コピペ / Alt+↑↓ で物理順更新 (カラム一覧)
- [x] 多段ソートの視覚表示 (▲▼ ① ② ③)
- [x] 画面フロー / 画面一覧が分離、HeaderMenu・CLAUDE.md 更新

## Test plan

- [x] \`npm run build\` — TypeScript / Vite ビルド成功
- [x] \`npm run lint\` — 新規エラーなし
- [x] \`npm run test:unit\` — 13 files / 174 tests pass
- [x] \`npm run test:e2e\` — table-list (4) + action-list (4) + screen-list (5) + save-reset (29) = 42 pass
- [ ] 視覚確認 — /table/list の挙動をローカルで確認推奨

マージ後に Issue #133 をクローズ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)