### PR TITLE
fix(list): 仕様 #133 の未実装箇所を一括補完 (fixup)

### DIFF
--- a/designer/e2e/action-list.spec.ts
+++ b/designer/e2e/action-list.spec.ts
@@ -1,5 +1,5 @@
 /**
- * 処理フロー一覧 (/process-flow/list) E2E スモークテスト — #133 Phase D
+ * 処理フロー一覧 (/process-flow/list) E2E テスト — #133
  */
 
 import { test, expect, type Page } from "@playwright/test";
@@ -58,31 +58,38 @@ async function setupActionList(page: Page) {
 }
 
 test.describe("処理フロー一覧", () => {
-  test("既定はカードレイアウトで全件表示", async ({ page }) => {
+  test("カード既定、表切替・種別フィルタ・ダブルクリック遷移", async ({ page }) => {
     await setupActionList(page);
-    await expect(page.locator(".data-list-layout-grid")).toBeVisible();
+    await expect(page.locator(".data-list-layout-grid")).toHaveCount(1);
     await expect(page.locator(".data-list-card")).toHaveCount(3);
-  });
-
-  test("ViewModeToggle で表レイアウトに切替できる", async ({ page }) => {
-    await setupActionList(page);
+    // 表切替
     await page.getByRole("button", { name: "表表示" }).click();
-    await expect(page.locator(".data-list-table")).toBeVisible();
     await expect(page.locator(".data-list-row")).toHaveCount(3);
-  });
-
-  test("種別フィルタで絞り込める", async ({ page }) => {
-    await setupActionList(page);
-    // "バッチ" フィルタボタンをクリック
+    // カードに戻して種別フィルタ
+    await page.getByRole("button", { name: "カード表示" }).click();
     await page.getByRole("button", { name: /^バッチ \(/ }).click();
     await expect(page.locator(".data-list-card")).toHaveCount(1);
     await expect(page.locator(".filter-bar")).toBeVisible();
+    // ダブルクリックで遷移
+    await page.locator(".data-list-card").first().dblclick();
+    await expect(page).toHaveURL(/\/process-flow\/edit\//);
   });
 
-  test("カードのダブルクリックで編集画面へ遷移", async ({ page }) => {
+  test("削除マークで ghost 表示、保存で確定", async ({ page }) => {
     await setupActionList(page);
-    const card = page.locator(".data-list-card").first();
-    await card.dblclick();
-    await expect(page).toHaveURL(/\/process-flow\/edit\//);
+    await page.locator(".data-list-card").first().click();
+    await page.keyboard.press("Delete");
+    await expect(page.locator(".data-list-card.ghost")).toHaveCount(1);
+    await expect(page.getByTestId("list-save-btn")).toBeEnabled();
+    await page.getByTestId("list-save-btn").click();
+    await expect(page.locator(".data-list-card")).toHaveCount(2);
+  });
+
+  test("Ctrl+D で複製", async ({ page }) => {
+    await setupActionList(page);
+    await page.locator(".data-list-card").first().click();
+    await page.keyboard.press("Control+d");
+    // 複製は即時永続化 → reload 後に 4 件
+    await expect(page.locator(".data-list-card")).toHaveCount(4);
   });
 });

--- a/designer/e2e/screen-list.spec.ts
+++ b/designer/e2e/screen-list.spec.ts
@@ -1,8 +1,5 @@
 /**
- * 画面一覧 (/screen/list) E2E スモークテスト — #133 Phase C
- *
- * 視点: HeaderMenu から画面一覧に遷移し、カード ⇔ 表切替と検索が動作するか確認
- * 前提: dev サーバー起動済み (playwright.config.ts の webServer で自動起動)
+ * 画面一覧 (/screen/list) E2E テスト — #133
  */
 
 import { test, expect, type Page } from "@playwright/test";
@@ -59,7 +56,6 @@ async function setupScreenList(page: Page) {
     localStorage.setItem("flow-project", JSON.stringify(project));
     localStorage.removeItem("designer-open-tabs");
     localStorage.removeItem("designer-active-tab");
-    // 表示モード設定をリセット
     localStorage.removeItem("list-view-mode:screen-list");
   }, dummyProject);
   await page.goto("/screen/list");
@@ -67,40 +63,37 @@ async function setupScreenList(page: Page) {
 }
 
 test.describe("画面一覧", () => {
-  test("/screen/list でカードレイアウトが既定表示される", async ({ page }) => {
+  test("カード既定で 3 件、表切替可、検索絞り込み", async ({ page }) => {
     await setupScreenList(page);
-    await expect(page.locator(".data-list-grid")).toBeVisible();
     await expect(page.locator(".data-list-card")).toHaveCount(3);
-    await expect(page.locator(".screen-list-count")).toHaveText("3 画面");
-  });
-
-  test("ViewModeToggle で表レイアウトに切替できる", async ({ page }) => {
-    await setupScreenList(page);
     await page.getByRole("button", { name: "表表示" }).click();
-    await expect(page.locator(".data-list-table")).toBeVisible();
     await expect(page.locator(".data-list-row")).toHaveCount(3);
-  });
-
-  test("検索で絞り込みできる", async ({ page }) => {
-    await setupScreenList(page);
+    await page.getByRole("button", { name: "カード表示" }).click();
     await page.locator(".screen-list-search input").fill("ログイン");
     await expect(page.locator(".data-list-card")).toHaveCount(1);
-    await expect(page.locator(".filter-bar")).toBeVisible();
   });
 
-  test("カードクリックで選択、ダブルクリックで画面デザイナーへ遷移", async ({ page }) => {
+  test("ダブルクリックで画面デザイナーへ遷移", async ({ page }) => {
     await setupScreenList(page);
     const card = page.locator(".data-list-card").first();
-    await card.click();
-    await expect(card).toHaveClass(/selected/);
     await card.dblclick();
-    await expect(page).toHaveURL(/\/screen\/design\/screen-0001/);
+    await expect(page).toHaveURL(/\/screen\/design\//);
   });
 
-  test("HeaderMenu に「画面一覧」が出て active になる", async ({ page }) => {
+  test("Delete で ghost 表示、リセットで戻る", async ({ page }) => {
+    await setupScreenList(page);
+    page.on("dialog", (d) => d.accept());
+    await page.locator(".data-list-card").first().click();
+    await page.keyboard.press("Delete");
+    await expect(page.locator(".data-list-card.ghost")).toHaveCount(1);
+    await expect(page.getByTestId("list-save-btn")).toBeEnabled();
+    await page.getByTestId("list-reset-btn").click();
+    await expect(page.locator(".data-list-card.ghost")).toHaveCount(0);
+  });
+
+  test("HeaderMenu に「画面一覧」が出て active", async ({ page }) => {
     await setupScreenList(page);
     await page.locator(".header-menu-btn").click();
-    const menuItem = page.locator(".header-menu-item.active", { hasText: "画面一覧" });
-    await expect(menuItem).toBeVisible();
+    await expect(page.locator(".header-menu-item.active", { hasText: "画面一覧" })).toBeVisible();
   });
 });

--- a/designer/e2e/table-list.spec.ts
+++ b/designer/e2e/table-list.spec.ts
@@ -1,5 +1,12 @@
 /**
- * テーブル一覧 (/table/list) E2E スモークテスト — #133 Phase E
+ * テーブル一覧 (/table/list) E2E テスト — #133
+ *
+ * 仕様 docs/spec/list-common.md に基づく主要操作を検証:
+ * - カード/表切替 (§4.3)
+ * - 選択 (§3.1) / キーボード操作 (§3.2, 3.3)
+ * - ソート (§3.6)
+ * - D&D 並び替え + 保存/リセット (§3.5)
+ * - 削除 ghost 方式
  */
 
 import { test, expect, type Page } from "@playwright/test";
@@ -34,31 +41,127 @@ async function setupTableList(page: Page) {
   await expect(page.locator(".table-list-page")).toBeVisible();
 }
 
-test.describe("テーブル一覧", () => {
-  test("既定はカードレイアウトで全件表示", async ({ page }) => {
+test.describe("テーブル一覧 / 表示切替・検索", () => {
+  test("既定はカードレイアウト、ViewModeToggle で表に切替可能", async ({ page }) => {
     await setupTableList(page);
     await expect(page.locator(".tables-data-list.data-list-layout-grid")).toBeVisible();
     await expect(page.locator(".data-list-card")).toHaveCount(3);
-  });
-
-  test("ViewModeToggle で表レイアウトに切替できる", async ({ page }) => {
-    await setupTableList(page);
     await page.getByRole("button", { name: "表表示" }).click();
     await expect(page.locator(".tables-data-list .data-list-table")).toBeVisible();
     await expect(page.locator(".data-list-row")).toHaveCount(3);
   });
 
-  test("検索で絞り込みできる", async ({ page }) => {
+  test("検索で絞り込み、FilterBar 表示", async ({ page }) => {
     await setupTableList(page);
     await page.locator(".table-list-search input").fill("ユーザー");
     await expect(page.locator(".data-list-card")).toHaveCount(1);
     await expect(page.locator(".filter-bar")).toBeVisible();
+    await page.locator(".filter-bar-clear").click();
+    await expect(page.locator(".data-list-card")).toHaveCount(3);
   });
 
-  test("カードのダブルクリックでテーブル編集画面へ遷移", async ({ page }) => {
+  test("ダブルクリックで編集画面へ遷移", async ({ page }) => {
     await setupTableList(page);
     const card = page.locator(".data-list-card").first();
     await card.dblclick();
     await expect(page).toHaveURL(/\/table\/edit\//);
+  });
+});
+
+test.describe("テーブル一覧 / 選択・キーボード", () => {
+  test("クリックで選択、Ctrl+クリックで複数選択", async ({ page }) => {
+    await setupTableList(page);
+    const cards = page.locator(".data-list-card");
+    await cards.nth(0).click();
+    await expect(cards.nth(0)).toHaveClass(/selected/);
+    await cards.nth(2).click({ modifiers: ["Control"] });
+    await expect(cards.nth(0)).toHaveClass(/selected/);
+    await expect(cards.nth(2)).toHaveClass(/selected/);
+    await expect(cards.nth(1)).not.toHaveClass(/selected/);
+  });
+
+  test("Shift+クリックで範囲選択", async ({ page }) => {
+    await setupTableList(page);
+    const cards = page.locator(".data-list-card");
+    await cards.nth(0).click();
+    await cards.nth(2).click({ modifiers: ["Shift"] });
+    await expect(cards).toHaveClass([/selected/, /selected/, /selected/]);
+  });
+
+  test("Ctrl+A で全選択、Esc で選択解除", async ({ page }) => {
+    await setupTableList(page);
+    await page.locator(".data-list-card").first().click();
+    await page.keyboard.press("Control+a");
+    const cards = page.locator(".data-list-card");
+    await expect(cards).toHaveClass([/selected/, /selected/, /selected/]);
+    await page.keyboard.press("Escape");
+    await expect(cards.nth(0)).not.toHaveClass(/selected/);
+  });
+
+  test("空領域クリックで選択解除", async ({ page }) => {
+    await setupTableList(page);
+    await page.locator(".data-list-card").first().click();
+    // DataList のルート領域を直接クリック (カードの外側)
+    const dataList = page.locator(".tables-data-list");
+    const box = await dataList.boundingBox();
+    if (!box) throw new Error("data-list boundingBox not found");
+    // 右下の余白付近をクリック
+    await page.mouse.click(box.x + box.width - 5, box.y + box.height - 5);
+    await expect(page.locator(".data-list-card.selected")).toHaveCount(0);
+  });
+});
+
+test.describe("テーブル一覧 / 保存フロー", () => {
+  test("初期状態では保存・リセットボタンが無効", async ({ page }) => {
+    await setupTableList(page);
+    await expect(page.getByTestId("list-save-btn")).toBeDisabled();
+    await expect(page.getByTestId("list-reset-btn")).toBeDisabled();
+  });
+
+  test("削除マーク後に保存ボタンが有効、ghost 表示になる", async ({ page }) => {
+    await setupTableList(page);
+    await page.locator(".data-list-card").first().click();
+    await page.keyboard.press("Delete");
+    // ghost クラスが付く
+    await expect(page.locator(".data-list-card.ghost")).toHaveCount(1);
+    // 保存ボタンが有効化される
+    await expect(page.getByTestId("list-save-btn")).toBeEnabled();
+    // タブバーで dirty インジケータが出る
+    await expect(page.locator(".tabbar-tab.dirty")).toBeVisible();
+  });
+
+  test("リセットで削除マークが取り消される", async ({ page }) => {
+    await setupTableList(page);
+    page.on("dialog", (d) => d.accept());
+    await page.locator(".data-list-card").first().click();
+    await page.keyboard.press("Delete");
+    await expect(page.locator(".data-list-card.ghost")).toHaveCount(1);
+    await page.getByTestId("list-reset-btn").click();
+    await expect(page.locator(".data-list-card.ghost")).toHaveCount(0);
+    await expect(page.getByTestId("list-save-btn")).toBeDisabled();
+  });
+
+  test("保存後に削除マークが確定され、アイテム数が減る", async ({ page }) => {
+    await setupTableList(page);
+    await page.locator(".data-list-card").first().click();
+    await page.keyboard.press("Delete");
+    await page.getByTestId("list-save-btn").click();
+    // 保存後にカードが 2 件になる
+    await expect(page.locator(".data-list-card")).toHaveCount(2);
+    await expect(page.getByTestId("list-save-btn")).toBeDisabled();
+  });
+});
+
+test.describe("テーブル一覧 / ソート", () => {
+  test("表モードで列ヘッダクリックでソートが動作し、▲が表示される", async ({ page }) => {
+    await setupTableList(page);
+    await page.getByRole("button", { name: "表表示" }).click();
+    // テーブル名列ヘッダをクリック
+    await page.locator(".data-list-th-sortable").filter({ hasText: "テーブル名" }).click();
+    await expect(page.locator(".data-list-th-sorted")).toHaveCount(1);
+    await expect(page.locator(".bi-caret-up-fill")).toHaveCount(1);
+    // 再クリックで降順
+    await page.locator(".data-list-th-sortable").filter({ hasText: "テーブル名" }).click();
+    await expect(page.locator(".bi-caret-down-fill")).toHaveCount(1);
   });
 });

--- a/designer/src/components/action/ActionListView.tsx
+++ b/designer/src/components/action/ActionListView.tsx
@@ -222,10 +222,13 @@ export function ActionListView() {
   };
 
   const handleDuplicate = async (items: ActionGroupMeta[]) => {
+    const newIds: string[] = [];
     for (const g of items) {
-      await duplicateGroup(g);
+      const id = await duplicateGroup(g);
+      if (id) newIds.push(id);
     }
     await editor.reload();
+    if (newIds.length > 0) selection.setSelectedIds(new Set(newIds));
   };
 
   const handlePaste = async (insertIdx: number | null) => {

--- a/designer/src/components/action/ActionListView.tsx
+++ b/designer/src/components/action/ActionListView.tsx
@@ -1,29 +1,35 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
-import type { ActionGroupMeta, ActionGroupType } from "../../types/action";
+import type { ActionGroupMeta, ActionGroupType, ActionGroup } from "../../types/action";
 import { ACTION_GROUP_TYPE_LABELS, ACTION_GROUP_TYPE_ICONS } from "../../types/action";
 import {
   listActionGroups,
   loadActionGroup,
+  saveActionGroup,
   createActionGroup,
   deleteActionGroup,
 } from "../../store/actionStore";
-import { loadProject } from "../../store/flowStore";
+import { loadProject, saveProject } from "../../store/flowStore";
 import { validateActionGroup } from "../../utils/actionValidation";
 import { mcpBridge } from "../../mcp/mcpBridge";
+import { makeTabId } from "../../store/tabStore";
 import { TableSubToolbar } from "../table/TableSubToolbar";
 import { DataList, type DataListColumn } from "../common/DataList";
 import { FilterBar } from "../common/FilterBar";
 import { ViewModeToggle, type ViewMode } from "../common/ViewModeToggle";
 import { useListSelection } from "../../hooks/useListSelection";
+import { useListClipboard } from "../../hooks/useListClipboard";
 import { useListKeyboard } from "../../hooks/useListKeyboard";
 import { useListFilter } from "../../hooks/useListFilter";
 import { useListSort } from "../../hooks/useListSort";
+import { useListEditor } from "../../hooks/useListEditor";
 import { usePersistentState } from "../../hooks/usePersistentState";
+import { generateUUID } from "../../utils/uuid";
 import "../../styles/action.css";
 
 const ALL_TYPES: ActionGroupType[] = ["screen", "batch", "scheduled", "system", "common", "other"];
 const STORAGE_KEY = "list-view-mode:process-flow-list";
+const TAB_ID = makeTabId("process-flow-list", "main");
 
 interface ValidationSummary {
   errors: number;
@@ -32,7 +38,6 @@ interface ValidationSummary {
 
 export function ActionListView() {
   const navigate = useNavigate();
-  const [groups, setGroups] = useState<ActionGroupMeta[]>([]);
   const [filterType, setFilterType] = useState<ActionGroupType | "all">("all");
   const [filterErrorsOnly, setFilterErrorsOnly] = useState(false);
   const [validationMap, setValidationMap] = useState<Map<string, ValidationSummary>>(new Map());
@@ -44,21 +49,48 @@ export function ActionListView() {
   const [screens, setScreens] = useState<{ id: string; name: string }[]>([]);
   const [viewMode, setViewMode] = usePersistentState<ViewMode>(STORAGE_KEY, "card");
 
-  const reload = useCallback(async () => {
-    const g = await listActionGroups();
-    setGroups(g);
+  const loadGroups = useCallback(async () => {
+    mcpBridge.startWithoutEditor();
     const p = await loadProject();
     setScreens(p.screens.map((s) => ({ id: s.id, name: s.name })));
+    return await listActionGroups();
   }, []);
 
+  const commitGroups = useCallback(async ({ itemsInOrder, deletedIds }: { itemsInOrder: ActionGroupMeta[]; deletedIds: string[] }) => {
+    for (const id of deletedIds) {
+      await deleteActionGroup(id);
+    }
+    const project = await loadProject();
+    if (project.actionGroups) {
+      const deletedSet = new Set(deletedIds);
+      const orderMap = new Map(itemsInOrder.map((g, i) => [g.id, i]));
+      project.actionGroups = project.actionGroups
+        .filter((g) => !deletedSet.has(g.id))
+        .sort((a, b) => (orderMap.get(a.id) ?? 0) - (orderMap.get(b.id) ?? 0));
+      await saveProject(project);
+    }
+  }, []);
+
+  const editor = useListEditor<ActionGroupMeta>({
+    getId: (g) => g.id,
+    load: loadGroups,
+    commit: commitGroups,
+    tabId: TAB_ID,
+  });
+
   useEffect(() => {
-    mcpBridge.startWithoutEditor();
-    reload();
-    const unsub = mcpBridge.onStatusChange((s) => {
-      if (s === "connected") reload();
+    editor.reload();
+    const unsubStatus = mcpBridge.onStatusChange((s) => {
+      if (s === "connected" && !editor.isDirty) editor.reload();
     });
-    return unsub;
-  }, [reload]);
+    const unsubProj = mcpBridge.onBroadcast("projectChanged", () => {
+      if (!editor.isDirty) editor.reload();
+    });
+    return () => { unsubStatus(); unsubProj(); };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const groups = editor.items;
 
   // バックグラウンドでバリデーション実行
   useEffect(() => {
@@ -120,27 +152,130 @@ export function ActionListView() {
 
   const sort = useListSort(filter.filtered, sortAccessor);
   const selection = useListSelection(sort.sorted, (g) => g.id);
+  const clipboard = useListClipboard<ActionGroupMeta>((g) => g.id);
 
   const handleActivate = useCallback((g: ActionGroupMeta) => {
+    if (editor.isDeleted(g.id)) return;
     navigate(`/process-flow/edit/${g.id}`);
-  }, [navigate]);
+  }, [navigate, editor]);
 
-  const handleDelete = async (items: ActionGroupMeta[]) => {
-    if (!confirm(`${items.length} 件の処理フロー定義を削除しますか？`)) return;
-    for (const g of items) {
-      await deleteActionGroup(g.id);
+  const handleDelete = (items: ActionGroupMeta[]) => {
+    editor.markDeleted(items.map((g) => g.id));
+  };
+
+  const handleReorder = (fromIdx: number, toIdx: number) => {
+    const visible = sort.sorted;
+    const fromId = visible[fromIdx]?.id;
+    const toId = visible[toIdx]?.id;
+    if (!fromId || !toId) return;
+    const realFrom = editor.items.findIndex((g) => g.id === fromId);
+    const realTo = editor.items.findIndex((g) => g.id === toId);
+    if (realFrom < 0 || realTo < 0) return;
+    if (sort.sortKeys.length > 0) sort.clearSort();
+    editor.reorder(realFrom, realTo);
+  };
+
+  const moveBlock = (items: ActionGroupMeta[], direction: "up" | "down") => {
+    const ids = new Set(items.map((g) => g.id));
+    const idxs = editor.items
+      .map((g, i) => (ids.has(g.id) ? i : -1))
+      .filter((i) => i >= 0)
+      .sort((a, b) => a - b);
+    if (idxs.length === 0) return;
+    if (sort.sortKeys.length > 0) sort.clearSort();
+    if (direction === "up") {
+      if (idxs[0] === 0) return;
+      editor.setItems((prev) => {
+        const next = [...prev];
+        const [moved] = next.splice(idxs[0] - 1, 1);
+        next.splice(idxs[idxs.length - 1], 0, moved);
+        return next;
+      });
+    } else {
+      if (idxs[idxs.length - 1] === editor.items.length - 1) return;
+      editor.setItems((prev) => {
+        const next = [...prev];
+        const [moved] = next.splice(idxs[idxs.length - 1] + 1, 1);
+        next.splice(idxs[0], 0, moved);
+        return next;
+      });
     }
-    await reload();
-    selection.clearSelection();
+  };
+
+  const duplicateGroup = async (src: ActionGroupMeta): Promise<string | null> => {
+    const full = await loadActionGroup(src.id);
+    if (!full) return null;
+    const dup: ActionGroup = {
+      ...full,
+      id: generateUUID(),
+      name: full.name + " (コピー)",
+      actions: full.actions.map((a) => ({
+        ...a,
+        id: generateUUID(),
+        steps: a.steps.map((s) => ({ ...s, id: generateUUID() })),
+      })),
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    await saveActionGroup(dup);
+    return dup.id;
+  };
+
+  const handleDuplicate = async (items: ActionGroupMeta[]) => {
+    for (const g of items) {
+      await duplicateGroup(g);
+    }
+    await editor.reload();
+  };
+
+  const handlePaste = async (insertIdx: number | null) => {
+    const mode = clipboard.clipboard.mode;
+    const clipItems = clipboard.clipboard.items;
+    if (!clipItems.length) return;
+
+    if (mode === "cut") {
+      const cutIds = new Set(clipItems.map((c) => c.id));
+      const selIds = selection.selectedIds;
+      const sameSet = selIds.size === cutIds.size && [...selIds].every((id) => cutIds.has(id));
+      if (sameSet) return;
+
+      if (sort.sortKeys.length > 0) sort.clearSort();
+      clipboard.consume();
+      const moved = clipItems;
+      const pos0 = insertIdx ?? editor.items.length;
+      const removedBefore = editor.items.slice(0, pos0).filter((g) => cutIds.has(g.id)).length;
+      const remaining = editor.items.filter((g) => !cutIds.has(g.id));
+      const pos = Math.min(remaining.length, pos0 - removedBefore);
+      editor.setItems(() => {
+        const next = [...remaining];
+        next.splice(pos, 0, ...moved);
+        return next;
+      });
+      selection.setSelectedIds(new Set(moved.map((g) => g.id)));
+    } else {
+      const newIds: string[] = [];
+      for (const g of clipItems) {
+        const id = await duplicateGroup(g);
+        if (id) newIds.push(id);
+      }
+      clipboard.consume();
+      await editor.reload();
+      selection.setSelectedIds(new Set(newIds));
+    }
   };
 
   useListKeyboard({
     items: sort.sorted,
     getId: (g) => g.id,
     selection,
+    clipboard,
     layout: viewMode === "card" ? "grid" : "list",
     onActivate: handleActivate,
     onDelete: handleDelete,
+    onDuplicate: (items) => { handleDuplicate(items).catch(console.error); },
+    onMoveUp: (items) => moveBlock(items, "up"),
+    onMoveDown: (items) => moveBlock(items, "down"),
+    onPaste: (idx) => { handlePaste(idx).catch(console.error); },
   });
 
   const handleAdd = async () => {
@@ -158,6 +293,17 @@ export function ActionListView() {
     setAddScreenId("");
     setAddDescription("");
     navigate(`/process-flow/edit/${group.id}`);
+  };
+
+  const handleSave = () => {
+    editor.save().catch(console.error);
+    selection.clearSelection();
+  };
+
+  const handleReset = () => {
+    if (!confirm("未保存の変更を破棄してサーバの状態に戻しますか？")) return;
+    editor.reset().catch(console.error);
+    selection.clearSelection();
   };
 
   const columns = useMemo<DataListColumn<ActionGroupMeta>[]>(() => [
@@ -249,17 +395,41 @@ export function ActionListView() {
     return c;
   }, [groups]);
 
+  const deletedCount = editor.deletedIds.size;
+
   return (
     <div className="action-page">
       <TableSubToolbar />
 
       <div className="action-content">
         <div className="action-list-header">
-          <h5><i className="bi bi-diagram-3 me-2" />処理フロー定義</h5>
+          <h5>
+            <i className="bi bi-diagram-3 me-2" />処理フロー定義
+            {deletedCount > 0 && <span className="action-list-deleted-count"> (削除予定 {deletedCount})</span>}
+          </h5>
           <div className="action-list-header-right">
             <ViewModeToggle mode={viewMode} onChange={setViewMode} storageKey={STORAGE_KEY} />
             <button className="btn btn-primary btn-sm" onClick={() => setShowAdd(true)}>
               <i className="bi bi-plus-lg me-1" />新規作成
+            </button>
+            <span className="action-saveline-sep" />
+            <button
+              className="btn btn-outline-secondary btn-sm"
+              data-testid="list-reset-btn"
+              onClick={handleReset}
+              disabled={!editor.isDirty || editor.isSaving}
+              title="変更を破棄"
+            >
+              <i className="bi bi-arrow-counterclockwise" /> リセット
+            </button>
+            <button
+              className="btn btn-primary btn-sm"
+              data-testid="list-save-btn"
+              onClick={handleSave}
+              disabled={!editor.isDirty || editor.isSaving}
+              title="変更を保存"
+            >
+              <i className="bi bi-save" /> {editor.isSaving ? "保存中..." : "保存"}
             </button>
           </div>
         </div>
@@ -315,12 +485,15 @@ export function ActionListView() {
           columns={columns}
           getId={(g) => g.id}
           selection={selection}
+          clipboard={clipboard}
           sort={sort}
           onActivate={handleActivate}
+          onReorder={handleReorder}
           layout={viewMode === "card" ? "grid" : "list"}
           renderCard={renderCard}
           showNumColumn={viewMode === "table"}
           className="action-data-list"
+          isItemGhost={(id) => editor.isDeleted(id)}
           emptyMessage={
             groups.length === 0
               ? <p>処理フロー定義がまだありません。「新規作成」から追加してください。</p>

--- a/designer/src/components/common/DataList.tsx
+++ b/designer/src/components/common/DataList.tsx
@@ -138,12 +138,18 @@ export function DataList<T>({
     className ?? "",
   ].filter(Boolean).join(" ");
 
-  /** 空領域クリックで選択解除。ルート要素を直接クリックした場合のみ発火 */
+  /**
+   * 仕様 §3.1「何もない領域のクリック: 選択解除 (一覧コンテナの背景領域に限定)」
+   * 行/カード/ヘッダ/インタラクティブ要素の外側クリックで選択解除する。
+   */
   const handleRootClick = (e: ReactMouseEvent<HTMLDivElement>) => {
     if (!selection) return;
-    if (e.target === e.currentTarget) {
-      selection.clearSelection();
+    const target = e.target as HTMLElement | null;
+    if (!target) return;
+    if (target.closest('[data-row-id], button, input, select, textarea, th, a')) {
+      return;
     }
+    selection.clearSelection();
   };
 
   if (items.length === 0) {

--- a/designer/src/components/common/DataList.tsx
+++ b/designer/src/components/common/DataList.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type ReactNode } from "react";
+import { useMemo, useState, type ReactNode, type MouseEvent as ReactMouseEvent } from "react";
 import {
   DndContext,
   PointerSensor,
@@ -6,6 +6,7 @@ import {
   useSensor,
   useSensors,
   type DragEndEvent,
+  type DragOverEvent,
 } from "@dnd-kit/core";
 import {
   SortableContext,
@@ -57,6 +58,8 @@ interface Props<T> {
   emptyMessage?: ReactNode;
   className?: string;
   variant?: "light" | "dark";
+  /** 削除マーク等で ghost 表示する項目判定 (clipboard.isItemCut と OR される) */
+  isItemGhost?: (id: string) => boolean;
 }
 
 export function DataList<T>({
@@ -68,10 +71,14 @@ export function DataList<T>({
   emptyMessage,
   className,
   variant = "light",
+  isItemGhost,
 }: Props<T>) {
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
   );
+
+  const [activeDragId, setActiveDragId] = useState<string | null>(null);
+  const [overId, setOverId] = useState<string | null>(null);
 
   const tanstackColumns = useMemo<ColumnDef<T>[]>(() => {
     const helper = createColumnHelper<T>();
@@ -95,14 +102,30 @@ export function DataList<T>({
     getRowId: (row) => getId(row),
   });
 
+  const handleDragStart = (e: { active: { id: string | number } }) => {
+    setActiveDragId(String(e.active.id));
+    setOverId(null);
+  };
+
+  const handleDragOver = (e: DragOverEvent) => {
+    setOverId(e.over ? String(e.over.id) : null);
+  };
+
   const handleDragEnd = (e: DragEndEvent) => {
     const { active, over } = e;
+    setActiveDragId(null);
+    setOverId(null);
     if (!over || !onReorder) return;
     if (active.id === over.id) return;
     const fromIndex = items.findIndex((it) => getId(it) === active.id);
     const toIndex = items.findIndex((it) => getId(it) === over.id);
     if (fromIndex < 0 || toIndex < 0) return;
     onReorder(fromIndex, toIndex);
+  };
+
+  const handleDragCancel = () => {
+    setActiveDragId(null);
+    setOverId(null);
   };
 
   const showHandle = !!onReorder && layout === "list";
@@ -115,15 +138,47 @@ export function DataList<T>({
     className ?? "",
   ].filter(Boolean).join(" ");
 
+  /** 空領域クリックで選択解除。ルート要素を直接クリックした場合のみ発火 */
+  const handleRootClick = (e: ReactMouseEvent<HTMLDivElement>) => {
+    if (!selection) return;
+    if (e.target === e.currentTarget) {
+      selection.clearSelection();
+    }
+  };
+
   if (items.length === 0) {
-    return <div className={rootClass}>{emptyMessage ?? <span>データがありません</span>}</div>;
+    return <div className={rootClass} onClick={handleRootClick}>{emptyMessage ?? <span>データがありません</span>}</div>;
   }
 
   const strategy = layout === "grid" ? rectSortingStrategy : verticalListSortingStrategy;
 
+  /** ドロップ位置インジケータ: 対象行が active より下なら bottom-line、上なら top-line */
+  const dropIndicatorFor = (rowId: string): "top" | "bottom" | null => {
+    if (!activeDragId || !overId) return null;
+    if (rowId !== overId) return null;
+    if (activeDragId === overId) return null;
+    const activeIdx = items.findIndex((it) => getId(it) === activeDragId);
+    const overIdx = items.findIndex((it) => getId(it) === overId);
+    if (activeIdx < 0 || overIdx < 0) return null;
+    return activeIdx < overIdx ? "bottom" : "top";
+  };
+
+  const isRowGhost = (id: string): boolean => {
+    if (isItemGhost?.(id)) return true;
+    if (clipboard?.isItemCut(id)) return true;
+    return false;
+  };
+
   return (
-    <div className={rootClass} data-testid="data-list">
-      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+    <div className={rootClass} data-testid="data-list" onClick={handleRootClick}>
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragStart={handleDragStart}
+        onDragOver={handleDragOver}
+        onDragEnd={handleDragEnd}
+        onDragCancel={handleDragCancel}
+      >
         <SortableContext items={ids} strategy={strategy}>
           {layout === "list" ? (
             <table className="data-list-table">
@@ -154,37 +209,45 @@ export function DataList<T>({
                 </tr>
               </thead>
               <tbody>
-                {items.map((item, index) => (
-                  <DataListRow
-                    key={getId(item)}
-                    item={item}
-                    index={index}
-                    getId={getId}
-                    columns={columns}
-                    selection={selection}
-                    clipboard={clipboard}
-                    onActivate={onActivate}
-                    showHandle={showHandle}
-                    showNumColumn={showNumColumn}
-                  />
-                ))}
+                {items.map((item, index) => {
+                  const id = getId(item);
+                  return (
+                    <DataListRow
+                      key={id}
+                      item={item}
+                      index={index}
+                      getId={getId}
+                      columns={columns}
+                      selection={selection}
+                      ghost={isRowGhost(id)}
+                      onActivate={onActivate}
+                      showHandle={showHandle}
+                      showNumColumn={showNumColumn}
+                      dropIndicator={dropIndicatorFor(id)}
+                    />
+                  );
+                })}
               </tbody>
             </table>
           ) : (
             <div className="data-list-grid">
-              {items.map((item, index) => (
-                <DataListCard
-                  key={getId(item)}
-                  item={item}
-                  index={index}
-                  getId={getId}
-                  selection={selection}
-                  clipboard={clipboard}
-                  onActivate={onActivate}
-                  renderCard={renderCard}
-                  draggable={!!onReorder}
-                />
-              ))}
+              {items.map((item, index) => {
+                const id = getId(item);
+                return (
+                  <DataListCard
+                    key={id}
+                    item={item}
+                    index={index}
+                    getId={getId}
+                    selection={selection}
+                    ghost={isRowGhost(id)}
+                    onActivate={onActivate}
+                    renderCard={renderCard}
+                    draggable={!!onReorder}
+                    dropIndicator={dropIndicatorFor(id)}
+                  />
+                );
+              })}
             </div>
           )}
         </SortableContext>
@@ -199,38 +262,43 @@ interface RowProps<T> {
   getId: (item: T) => string;
   columns: DataListColumn<T>[];
   selection?: ListSelection<T>;
-  clipboard?: ListClipboard<T>;
+  ghost: boolean;
   onActivate?: (item: T, index: number) => void;
   showHandle: boolean;
   showNumColumn: boolean;
+  dropIndicator: "top" | "bottom" | null;
 }
 
 function DataListRow<T>({
-  item, index, getId, columns, selection, clipboard, onActivate, showHandle, showNumColumn,
+  item, index, getId, columns, selection, ghost, onActivate, showHandle, showNumColumn, dropIndicator,
 }: RowProps<T>) {
   const id = getId(item);
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id });
-  const cut = clipboard?.isItemCut(id) ?? false;
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
-    opacity: isDragging ? 0.5 : cut ? 0.5 : undefined,
+    opacity: isDragging ? 0.5 : ghost ? 0.5 : undefined,
   };
 
   const selected = selection?.isSelected(id) ?? false;
+  const indicatorClass = dropIndicator === "top"
+    ? " drop-indicator-top"
+    : dropIndicator === "bottom"
+      ? " drop-indicator-bottom"
+      : "";
 
   return (
     <tr
       ref={setNodeRef}
       style={style}
-      className={`data-list-row${selected ? " selected" : ""}${cut ? " cut" : ""}`}
+      className={`data-list-row${selected ? " selected" : ""}${ghost ? " ghost" : ""}${indicatorClass}`}
       onClick={(e) => selection?.handleRowClick(id, e)}
       onDoubleClick={() => onActivate?.(item, index)}
       data-testid="data-list-row"
       data-row-id={id}
     >
       {showHandle && (
-        <td className="data-list-td-handle" {...attributes} {...listeners}>
+        <td className="data-list-td-handle" {...attributes} {...listeners} aria-label="並び替え">
           <i className="bi bi-grip-vertical" />
         </td>
       )}
@@ -253,33 +321,38 @@ interface CardProps<T> {
   index: number;
   getId: (item: T) => string;
   selection?: ListSelection<T>;
-  clipboard?: ListClipboard<T>;
+  ghost: boolean;
   onActivate?: (item: T, index: number) => void;
   renderCard?: (item: T, index: number) => ReactNode;
   draggable: boolean;
+  dropIndicator: "top" | "bottom" | null;
 }
 
 function DataListCard<T>({
-  item, index, getId, selection, clipboard, onActivate, renderCard, draggable,
+  item, index, getId, selection, ghost, onActivate, renderCard, draggable, dropIndicator,
 }: CardProps<T>) {
   const id = getId(item);
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id,
     disabled: !draggable,
   });
-  const cut = clipboard?.isItemCut(id) ?? false;
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
-    opacity: isDragging ? 0.5 : cut ? 0.5 : undefined,
+    opacity: isDragging ? 0.5 : ghost ? 0.5 : undefined,
   };
   const selected = selection?.isSelected(id) ?? false;
+  const indicatorClass = dropIndicator === "top"
+    ? " drop-indicator-left"
+    : dropIndicator === "bottom"
+      ? " drop-indicator-right"
+      : "";
 
   return (
     <div
       ref={setNodeRef}
       style={style}
-      className={`data-list-card${selected ? " selected" : ""}${cut ? " cut" : ""}`}
+      className={`data-list-card${selected ? " selected" : ""}${ghost ? " ghost" : ""}${indicatorClass}`}
       onClick={(e) => selection?.handleRowClick(id, e)}
       onDoubleClick={() => onActivate?.(item, index)}
       data-testid="data-list-card"

--- a/designer/src/components/flow/ScreenListView.tsx
+++ b/designer/src/components/flow/ScreenListView.tsx
@@ -1,9 +1,11 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
-import type { FlowProject, ScreenNode } from "../../types/flow";
+import type { ScreenNode } from "../../types/flow";
 import { SCREEN_TYPE_LABELS, SCREEN_TYPE_ICONS } from "../../types/flow";
-import { loadProject, saveProject, addScreen, removeScreen } from "../../store/flowStore";
+import { loadProject, saveProject, addScreen, removeScreen, DEFAULT_NODE_SIZE } from "../../store/flowStore";
 import { mcpBridge } from "../../mcp/mcpBridge";
+import { makeTabId } from "../../store/tabStore";
+import { generateUUID } from "../../utils/uuid";
 import { DataList, type DataListColumn } from "../common/DataList";
 import { FilterBar } from "../common/FilterBar";
 import { ViewModeToggle, type ViewMode } from "../common/ViewModeToggle";
@@ -12,12 +14,14 @@ import { useListClipboard } from "../../hooks/useListClipboard";
 import { useListKeyboard } from "../../hooks/useListKeyboard";
 import { useListFilter } from "../../hooks/useListFilter";
 import { useListSort } from "../../hooks/useListSort";
+import { useListEditor } from "../../hooks/useListEditor";
 import { usePersistentState } from "../../hooks/usePersistentState";
 import { ScreenEditModal, type ScreenFormData } from "./ScreenEditModal";
 import "../../styles/flow.css";
 import "../../styles/screenList.css";
 
 const STORAGE_KEY = "list-view-mode:screen-list";
+const TAB_ID = makeTabId("screen-list", "main");
 
 function formatDate(iso: string): string {
   try {
@@ -32,25 +36,51 @@ function formatDate(iso: string): string {
 
 export function ScreenListView() {
   const navigate = useNavigate();
-  const [project, setProject] = useState<FlowProject | null>(null);
   const [query, setQuery] = useState("");
   const [viewMode, setViewMode] = usePersistentState<ViewMode>(STORAGE_KEY, "card");
   const [screenModal, setScreenModal] = useState<{ open: boolean; editId?: string; initial?: Partial<ScreenFormData> }>({ open: false });
 
-  const reload = useCallback(async () => {
+  const loadScreens = useCallback(async (): Promise<ScreenNode[]> => {
+    mcpBridge.startWithoutEditor();
     const p = await loadProject();
-    setProject(p);
+    return p.screens;
   }, []);
 
-  useEffect(() => {
-    mcpBridge.startWithoutEditor();
-    reload();
-    const unsub = mcpBridge.onStatusChange((s) => { if (s === "connected") reload(); });
-    const unsubProj = mcpBridge.onBroadcast("projectChanged", () => { reload(); });
-    return () => { unsub(); unsubProj(); };
-  }, [reload]);
+  const commitScreens = useCallback(async ({ itemsInOrder, deletedIds }: { itemsInOrder: ScreenNode[]; deletedIds: string[] }) => {
+    const project = await loadProject();
+    // 削除: removeScreen はデザインデータも削除 + edges 掃除
+    for (const id of deletedIds) {
+      await removeScreen(project, id);
+    }
+    // 並び順反映
+    const deletedSet = new Set(deletedIds);
+    const orderMap = new Map(itemsInOrder.map((s, i) => [s.id, i]));
+    project.screens = project.screens
+      .filter((s) => !deletedSet.has(s.id))
+      .sort((a, b) => (orderMap.get(a.id) ?? 0) - (orderMap.get(b.id) ?? 0));
+    await saveProject(project);
+  }, []);
 
-  const screens = project?.screens ?? [];
+  const editor = useListEditor<ScreenNode>({
+    getId: (s) => s.id,
+    load: loadScreens,
+    commit: commitScreens,
+    tabId: TAB_ID,
+  });
+
+  useEffect(() => {
+    editor.reload();
+    const unsubStatus = mcpBridge.onStatusChange((s) => {
+      if (s === "connected" && !editor.isDirty) editor.reload();
+    });
+    const unsubProj = mcpBridge.onBroadcast("projectChanged", () => {
+      if (!editor.isDirty) editor.reload();
+    });
+    return () => { unsubStatus(); unsubProj(); };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const screens = editor.items;
 
   const filter = useListFilter(screens);
 
@@ -65,7 +95,6 @@ export function ScreenListView() {
       (s.path || "").toLowerCase().includes(q) ||
       (SCREEN_TYPE_LABELS[s.type] || "").toLowerCase().includes(q),
     );
-    // filter は安定 API
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query]);
 
@@ -85,40 +114,136 @@ export function ScreenListView() {
   const clipboard = useListClipboard<ScreenNode>((s) => s.id);
 
   const handleActivate = useCallback((s: ScreenNode) => {
+    if (editor.isDeleted(s.id)) return;
     navigate(`/screen/design/${s.id}`);
-  }, [navigate]);
+  }, [navigate, editor]);
 
-  const handleDelete = async (items: ScreenNode[]) => {
-    if (!project) return;
-    if (!confirm(`${items.length} 件の画面を削除しますか？\nデザインデータも削除されます。`)) return;
-    for (const s of items) {
-      await removeScreen(project, s.id);
-    }
-    await reload();
-    selection.clearSelection();
+  const handleDelete = (items: ScreenNode[]) => {
+    editor.markDeleted(items.map((s) => s.id));
   };
 
   const handleReorder = (fromIdx: number, toIdx: number) => {
-    if (!project) return;
-    if (sort.sortKeys.length > 0) sort.clearSort();
-    const visible = filter.filtered;
+    const visible = sort.sorted;
     const fromId = visible[fromIdx]?.id;
     const toId = visible[toIdx]?.id;
     if (!fromId || !toId) return;
-    const realFrom = project.screens.findIndex((s) => s.id === fromId);
-    const realTo = project.screens.findIndex((s) => s.id === toId);
+    const realFrom = editor.items.findIndex((s) => s.id === fromId);
+    const realTo = editor.items.findIndex((s) => s.id === toId);
     if (realFrom < 0 || realTo < 0) return;
-    const [moved] = project.screens.splice(realFrom, 1);
-    project.screens.splice(realTo, 0, moved);
-    saveProject(project).then(reload).catch(console.error);
+    if (sort.sortKeys.length > 0) sort.clearSort();
+    editor.reorder(realFrom, realTo);
   };
+
+  const moveBlock = (items: ScreenNode[], direction: "up" | "down") => {
+    const ids = new Set(items.map((s) => s.id));
+    const idxs = editor.items
+      .map((s, i) => (ids.has(s.id) ? i : -1))
+      .filter((i) => i >= 0)
+      .sort((a, b) => a - b);
+    if (idxs.length === 0) return;
+    if (sort.sortKeys.length > 0) sort.clearSort();
+    if (direction === "up") {
+      if (idxs[0] === 0) return;
+      editor.setItems((prev) => {
+        const next = [...prev];
+        const [moved] = next.splice(idxs[0] - 1, 1);
+        next.splice(idxs[idxs.length - 1], 0, moved);
+        return next;
+      });
+    } else {
+      if (idxs[idxs.length - 1] === editor.items.length - 1) return;
+      editor.setItems((prev) => {
+        const next = [...prev];
+        const [moved] = next.splice(idxs[idxs.length - 1] + 1, 1);
+        next.splice(idxs[0], 0, moved);
+        return next;
+      });
+    }
+  };
+
+  const duplicateScreen = async (src: ScreenNode): Promise<string | null> => {
+    const project = await loadProject();
+    const s = project.screens.find((sc) => sc.id === src.id);
+    if (!s) return null;
+    const dup: ScreenNode = {
+      ...s,
+      id: generateUUID(),
+      name: s.name + " (コピー)",
+      position: { x: s.position.x + 40, y: s.position.y + 40 },
+      size: { ...DEFAULT_NODE_SIZE },
+      hasDesign: false,
+      thumbnail: undefined,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    project.screens.push(dup);
+    await saveProject(project);
+    return dup.id;
+  };
+
+  const handleDuplicate = async (items: ScreenNode[]) => {
+    for (const s of items) {
+      await duplicateScreen(s);
+    }
+    await editor.reload();
+  };
+
+  const handlePaste = async (insertIdx: number | null) => {
+    const mode = clipboard.clipboard.mode;
+    const clipItems = clipboard.clipboard.items;
+    if (!clipItems.length) return;
+
+    if (mode === "cut") {
+      const cutIds = new Set(clipItems.map((c) => c.id));
+      const selIds = selection.selectedIds;
+      const sameSet = selIds.size === cutIds.size && [...selIds].every((id) => cutIds.has(id));
+      if (sameSet) return;
+
+      if (sort.sortKeys.length > 0) sort.clearSort();
+      clipboard.consume();
+      const moved = clipItems;
+      const pos0 = insertIdx ?? editor.items.length;
+      const removedBefore = editor.items.slice(0, pos0).filter((s) => cutIds.has(s.id)).length;
+      const remaining = editor.items.filter((s) => !cutIds.has(s.id));
+      const pos = Math.min(remaining.length, pos0 - removedBefore);
+      editor.setItems(() => {
+        const next = [...remaining];
+        next.splice(pos, 0, ...moved);
+        return next;
+      });
+      selection.setSelectedIds(new Set(moved.map((s) => s.id)));
+    } else {
+      const newIds: string[] = [];
+      for (const s of clipItems) {
+        const id = await duplicateScreen(s);
+        if (id) newIds.push(id);
+      }
+      clipboard.consume();
+      await editor.reload();
+      selection.setSelectedIds(new Set(newIds));
+    }
+  };
+
+  useListKeyboard({
+    items: sort.sorted,
+    getId: (s) => s.id,
+    selection,
+    clipboard,
+    layout: viewMode === "card" ? "grid" : "list",
+    onActivate: handleActivate,
+    onDelete: handleDelete,
+    onDuplicate: (items) => { handleDuplicate(items).catch(console.error); },
+    onMoveUp: (items) => moveBlock(items, "up"),
+    onMoveDown: (items) => moveBlock(items, "down"),
+    onPaste: (idx) => { handlePaste(idx).catch(console.error); },
+  });
 
   const handleAddNew = () => {
     setScreenModal({ open: true });
   };
 
   const handleScreenSave = async (data: ScreenFormData) => {
-    if (!project) return;
+    const project = await loadProject();
     if (screenModal.editId) {
       const s = project.screens.find((sc) => sc.id === screenModal.editId);
       if (s) {
@@ -135,18 +260,19 @@ export function ScreenListView() {
       await saveProject(project);
     }
     setScreenModal({ open: false });
-    await reload();
+    await editor.reload();
   };
 
-  useListKeyboard({
-    items: sort.sorted,
-    getId: (s) => s.id,
-    selection,
-    clipboard,
-    layout: viewMode === "card" ? "grid" : "list",
-    onActivate: handleActivate,
-    onDelete: handleDelete,
-  });
+  const handleSave = () => {
+    editor.save().catch(console.error);
+    selection.clearSelection();
+  };
+
+  const handleReset = () => {
+    if (!confirm("未保存の変更を破棄してサーバの状態に戻しますか？")) return;
+    editor.reset().catch(console.error);
+    selection.clearSelection();
+  };
 
   const columns = useMemo<DataListColumn<ScreenNode>[]>(() => [
     {
@@ -217,12 +343,16 @@ export function ScreenListView() {
     </div>
   );
 
+  const deletedCount = editor.deletedIds.size;
+
   return (
     <div className="screen-list-page">
       <div className="screen-list-header">
         <h2 className="screen-list-title">
           <i className="bi bi-list-ul" /> 画面一覧
-          <span className="screen-list-count">{screens.length} 画面</span>
+          <span className="screen-list-count">
+            {screens.length - deletedCount} 画面{deletedCount > 0 ? ` (削除予定 ${deletedCount})` : ""}
+          </span>
         </h2>
         <div className="screen-list-header-tools">
           <div className="screen-list-search">
@@ -242,6 +372,25 @@ export function ScreenListView() {
           <ViewModeToggle mode={viewMode} onChange={setViewMode} storageKey={STORAGE_KEY} />
           <button className="flow-btn flow-btn-primary" onClick={handleAddNew}>
             <i className="bi bi-plus-lg" /> 画面を追加
+          </button>
+          <span className="screen-list-saveline-sep" />
+          <button
+            className="flow-btn flow-btn-ghost"
+            data-testid="list-reset-btn"
+            onClick={handleReset}
+            disabled={!editor.isDirty || editor.isSaving}
+            title="変更を破棄"
+          >
+            <i className="bi bi-arrow-counterclockwise" /> リセット
+          </button>
+          <button
+            className="flow-btn flow-btn-primary"
+            data-testid="list-save-btn"
+            onClick={handleSave}
+            disabled={!editor.isDirty || editor.isSaving}
+            title="変更を保存"
+          >
+            <i className="bi bi-save" /> {editor.isSaving ? "保存中..." : "保存"}
           </button>
         </div>
       </div>
@@ -267,6 +416,7 @@ export function ScreenListView() {
           layout={viewMode === "card" ? "grid" : "list"}
           renderCard={renderCard}
           showNumColumn={viewMode === "table"}
+          isItemGhost={(id) => editor.isDeleted(id)}
           emptyMessage={
             query
               ? <p>該当する画面がありません</p>

--- a/designer/src/components/flow/ScreenListView.tsx
+++ b/designer/src/components/flow/ScreenListView.tsx
@@ -182,10 +182,13 @@ export function ScreenListView() {
   };
 
   const handleDuplicate = async (items: ScreenNode[]) => {
+    const newIds: string[] = [];
     for (const s of items) {
-      await duplicateScreen(s);
+      const id = await duplicateScreen(s);
+      if (id) newIds.push(id);
     }
     await editor.reload();
+    if (newIds.length > 0) selection.setSelectedIds(new Set(newIds));
   };
 
   const handlePaste = async (insertIdx: number | null) => {

--- a/designer/src/components/table/TableEditor.tsx
+++ b/designer/src/components/table/TableEditor.tsx
@@ -210,6 +210,7 @@ function ColumnsTab({
   allTables: TableDefinition[];
 }) {
   const [showTemplates, setShowTemplates] = useState(false);
+  const [activeColId, setActiveColId] = useState<string | null>(null);
 
   const sortAccessor = useCallback((col: TableColumn, key: string): string | number => {
     switch (key) {
@@ -242,6 +243,7 @@ function ColumnsTab({
     update((t) => { newColId = addColumn(t).id; });
     sort.clearSort();
     selection.setSelectedIds(new Set([newColId]));
+    setActiveColId(newColId);
   };
 
   const handleAddFromTemplate = (tpl: ColumnTemplate) => {
@@ -249,6 +251,7 @@ function ColumnsTab({
     update((t) => { newColId = addColumn(t, { ...tpl.column }).id; });
     sort.clearSort();
     selection.setSelectedIds(new Set([newColId]));
+    setActiveColId(newColId);
     setShowTemplates(false);
   };
 
@@ -258,6 +261,7 @@ function ColumnsTab({
       for (const id of ids) removeColumn(t, id);
     });
     selection.clearSelection();
+    if (activeColId && ids.has(activeColId)) setActiveColId(null);
   };
 
   const handleDuplicate = (cols: TableColumn[]) => {
@@ -345,6 +349,7 @@ function ColumnsTab({
     selection,
     clipboard,
     layout: "list",
+    onActivate: (c) => setActiveColId(c.id),
     onDelete: handleDelete,
     onDuplicate: handleDuplicate,
     onMoveUp: (cols) => moveBlock(cols, "up"),
@@ -352,7 +357,31 @@ function ColumnsTab({
     onPaste: handlePaste,
   });
 
-  const detailCol = selection.selectedItems.length === 1 ? selection.selectedItems[0] : null;
+  // Esc で詳細パネルを閉じる (開いていれば選択解除より優先)
+  useEffect(() => {
+    if (!activeColId) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      const target = e.target as HTMLElement | null;
+      const tag = target?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+      if (target?.isContentEditable) return;
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      setActiveColId(null);
+    };
+    window.addEventListener("keydown", handler, { capture: true });
+    return () => window.removeEventListener("keydown", handler, { capture: true });
+  }, [activeColId]);
+
+  // activeColId のカラムが消えたら閉じる
+  useEffect(() => {
+    if (activeColId && !table.columns.some((c) => c.id === activeColId)) {
+      setActiveColId(null);
+    }
+  }, [activeColId, table.columns]);
+
+  const detailCol = activeColId ? table.columns.find((c) => c.id === activeColId) ?? null : null;
 
   const columns = useMemo<DataListColumn<TableColumn>[]>(() => [
     {
@@ -407,7 +436,7 @@ function ColumnsTab({
       {/* 選択操作バー */}
       <div className="columns-selection-bar">
         <span className="columns-selection-count">
-          {anySelected ? `${selectedCount} 件選択中` : "クリックで選択、Ctrl+A で全選択"}
+          {anySelected ? `${selectedCount} 件選択中 (ダブルクリック/Enter で編集)` : "クリックで選択、ダブルクリックで編集"}
         </span>
         <div className="columns-selection-actions">
           <button className="tbl-btn tbl-btn-ghost tbl-btn-sm" disabled={!anySelected} onClick={() => moveBlock(selection.selectedItems, "up")} title="上へ移動 (Alt+↑)">
@@ -433,6 +462,7 @@ function ColumnsTab({
         selection={selection}
         clipboard={clipboard}
         sort={sort}
+        onActivate={(c) => setActiveColId(c.id)}
         onReorder={handleReorder}
         showNumColumn
         variant="dark"
@@ -440,9 +470,18 @@ function ColumnsTab({
         emptyMessage={<p>カラムがまだありません。テンプレートから追加するか、空のカラムを追加してください。</p>}
       />
 
-      {/* Detail panel (single selection) */}
+      {/* Detail panel: ダブルクリック/Enter/F2 で開く。Esc または ✕ で閉じる */}
       {detailCol && (
         <div className="column-detail">
+          <div className="column-detail-header">
+            <span className="column-detail-title">
+              <i className="bi bi-pencil-square" /> 編集中: <code>{detailCol.name}</code>
+              <span className="column-detail-hint">(Esc で閉じる)</span>
+            </span>
+            <button className="tbl-btn-icon" onClick={() => setActiveColId(null)} title="閉じる">
+              <i className="bi bi-x-lg" />
+            </button>
+          </div>
           <ColumnDetailEditor
             col={detailCol}
             onUpdate={(patch) => handleUpdateCol(detailCol.id, patch)}

--- a/designer/src/components/table/TableListView.tsx
+++ b/designer/src/components/table/TableListView.tsx
@@ -171,6 +171,7 @@ export function TableListView() {
 
   const handleDuplicate = async (items: TableMeta[]) => {
     // 複製は新規エンティティ生成 → 即永続化。Save フローには乗せない。
+    const newIds: string[] = [];
     for (const t of items) {
       const full = await loadTable(t.id);
       if (!full) continue;
@@ -185,8 +186,10 @@ export function TableListView() {
         updatedAt: new Date().toISOString(),
       };
       await saveTable(dup);
+      newIds.push(dup.id);
     }
     await editor.reload();
+    if (newIds.length > 0) selection.setSelectedIds(new Set(newIds));
   };
 
   const handlePaste = async (insertIdx: number | null) => {

--- a/designer/src/components/table/TableListView.tsx
+++ b/designer/src/components/table/TableListView.tsx
@@ -3,22 +3,27 @@ import { useNavigate } from "react-router-dom";
 import type { TableMeta } from "../../types/flow";
 import type { TableDefinition, SqlDialect } from "../../types/table";
 import { SQL_DIALECT_LABELS } from "../../types/table";
-import { listTables, createTable, deleteTable, loadTable } from "../../store/tableStore";
-import { loadProject } from "../../store/flowStore";
+import { listTables, createTable, deleteTable, loadTable, saveTable } from "../../store/tableStore";
+import { loadProject, saveProject } from "../../store/flowStore";
 import { generateAllDdl, generateAllTableMarkdown } from "../../utils/ddlGenerator";
 import { mcpBridge } from "../../mcp/mcpBridge";
+import { makeTabId } from "../../store/tabStore";
 import { TableSubToolbar } from "./TableSubToolbar";
 import { DataList, type DataListColumn } from "../common/DataList";
 import { FilterBar } from "../common/FilterBar";
 import { ViewModeToggle, type ViewMode } from "../common/ViewModeToggle";
 import { useListSelection } from "../../hooks/useListSelection";
+import { useListClipboard } from "../../hooks/useListClipboard";
 import { useListKeyboard } from "../../hooks/useListKeyboard";
 import { useListFilter } from "../../hooks/useListFilter";
 import { useListSort } from "../../hooks/useListSort";
+import { useListEditor } from "../../hooks/useListEditor";
 import { usePersistentState } from "../../hooks/usePersistentState";
+import { generateUUID } from "../../utils/uuid";
 import "../../styles/table.css";
 
 const STORAGE_KEY = "list-view-mode:table-list";
+const TAB_ID = makeTabId("table-list", "main");
 
 function formatDate(iso: string): string {
   try {
@@ -30,7 +35,6 @@ function formatDate(iso: string): string {
 
 export function TableListView() {
   const navigate = useNavigate();
-  const [tables, setTables] = useState<TableMeta[]>([]);
   const [projectName, setProjectName] = useState("プロジェクト");
   const [query, setQuery] = useState("");
   const [viewMode, setViewMode] = usePersistentState<ViewMode>(STORAGE_KEY, "card");
@@ -41,24 +45,52 @@ export function TableListView() {
   const [exportDialect, setExportDialect] = useState<SqlDialect>("postgresql");
   const [showExport, setShowExport] = useState(false);
 
-  const reload = useCallback(async () => {
-    const t = await listTables();
-    setTables(t);
+  const loadTables = useCallback(async () => {
+    mcpBridge.startWithoutEditor();
     const p = await loadProject();
     setProjectName(p.name);
+    return await listTables();
   }, []);
 
+  const commitTables = useCallback(async ({ itemsInOrder, deletedIds }: { itemsInOrder: TableMeta[]; deletedIds: string[] }) => {
+    // 1. 削除対象を削除
+    for (const id of deletedIds) {
+      await deleteTable(id);
+    }
+    // 2. 並び順を project.tables に反映
+    const project = await loadProject();
+    if (project.tables) {
+      const deletedSet = new Set(deletedIds);
+      const orderMap = new Map(itemsInOrder.map((t, i) => [t.id, i]));
+      project.tables = project.tables
+        .filter((t) => !deletedSet.has(t.id))
+        .sort((a, b) => (orderMap.get(a.id) ?? 0) - (orderMap.get(b.id) ?? 0));
+      await saveProject(project);
+    }
+  }, []);
+
+  const editor = useListEditor<TableMeta>({
+    getId: (t) => t.id,
+    load: loadTables,
+    commit: commitTables,
+    tabId: TAB_ID,
+  });
+
   useEffect(() => {
-    mcpBridge.startWithoutEditor();
-    reload();
-    const unsub = mcpBridge.onStatusChange((s) => {
-      if (s === "connected") reload();
+    editor.reload();
+    const unsubStatus = mcpBridge.onStatusChange((s) => {
+      if (s === "connected" && !editor.isDirty) editor.reload();
     });
-    return unsub;
-  }, [reload]);
+    const unsubProj = mcpBridge.onBroadcast("projectChanged", () => {
+      if (!editor.isDirty) editor.reload();
+    });
+    return () => { unsubStatus(); unsubProj(); };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  const filter = useListFilter(tables);
+  const allTables = editor.items;
 
+  const filter = useListFilter(allTables);
   useEffect(() => {
     const q = query.trim().toLowerCase();
     if (!q) {
@@ -86,27 +118,140 @@ export function TableListView() {
 
   const sort = useListSort(filter.filtered, sortAccessor);
   const selection = useListSelection(sort.sorted, (t) => t.id);
+  const clipboard = useListClipboard<TableMeta>((t) => t.id);
 
   const handleActivate = useCallback((t: TableMeta) => {
+    if (editor.isDeleted(t.id)) return; // 削除マーク中は編集画面に遷移しない
     navigate(`/table/edit/${t.id}`);
-  }, [navigate]);
+  }, [navigate, editor]);
 
-  const handleDelete = async (items: TableMeta[]) => {
-    if (!confirm(`${items.length} 件のテーブル定義を削除しますか？`)) return;
-    for (const t of items) {
-      await deleteTable(t.id);
+  const handleDelete = (items: TableMeta[]) => {
+    // ghost 方式: マークするだけ
+    editor.markDeleted(items.map((t) => t.id));
+  };
+
+  const handleReorder = (fromIdx: number, toIdx: number) => {
+    const visible = sort.sorted;
+    const fromId = visible[fromIdx]?.id;
+    const toId = visible[toIdx]?.id;
+    if (!fromId || !toId) return;
+    const realFrom = editor.items.findIndex((t) => t.id === fromId);
+    const realTo = editor.items.findIndex((t) => t.id === toId);
+    if (realFrom < 0 || realTo < 0) return;
+    if (sort.sortKeys.length > 0) sort.clearSort();
+    editor.reorder(realFrom, realTo);
+  };
+
+  const moveBlock = (items: TableMeta[], direction: "up" | "down") => {
+    const ids = new Set(items.map((t) => t.id));
+    const idxs = editor.items
+      .map((t, i) => (ids.has(t.id) ? i : -1))
+      .filter((i) => i >= 0)
+      .sort((a, b) => a - b);
+    if (idxs.length === 0) return;
+    if (sort.sortKeys.length > 0) sort.clearSort();
+    if (direction === "up") {
+      if (idxs[0] === 0) return;
+      editor.setItems((prev) => {
+        const next = [...prev];
+        const [moved] = next.splice(idxs[0] - 1, 1);
+        next.splice(idxs[idxs.length - 1], 0, moved);
+        return next;
+      });
+    } else {
+      if (idxs[idxs.length - 1] === editor.items.length - 1) return;
+      editor.setItems((prev) => {
+        const next = [...prev];
+        const [moved] = next.splice(idxs[idxs.length - 1] + 1, 1);
+        next.splice(idxs[0], 0, moved);
+        return next;
+      });
     }
-    await reload();
-    selection.clearSelection();
+  };
+
+  const handleDuplicate = async (items: TableMeta[]) => {
+    // 複製は新規エンティティ生成 → 即永続化。Save フローには乗せない。
+    for (const t of items) {
+      const full = await loadTable(t.id);
+      if (!full) continue;
+      const dup: TableDefinition = {
+        ...full,
+        id: generateUUID(),
+        name: full.name + "_copy",
+        logicalName: full.logicalName + " (コピー)",
+        columns: full.columns.map((c) => ({ ...c, id: generateUUID() })),
+        indexes: full.indexes.map((i) => ({ ...i, id: generateUUID() })),
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+      await saveTable(dup);
+    }
+    await editor.reload();
+  };
+
+  const handlePaste = async (insertIdx: number | null) => {
+    const mode = clipboard.clipboard.mode;
+    const clipItems = clipboard.clipboard.items;
+    if (!clipItems.length) return;
+
+    if (mode === "cut") {
+      // No-op: 貼り付け対象自身が選択中
+      const cutIds = new Set(clipItems.map((c) => c.id));
+      const selIds = selection.selectedIds;
+      const sameSet = selIds.size === cutIds.size && [...selIds].every((id) => cutIds.has(id));
+      if (sameSet) return;
+
+      // Cut → 並び替え (draft)
+      if (sort.sortKeys.length > 0) sort.clearSort();
+      clipboard.consume();
+      const moved = clipItems;
+      const pos0 = insertIdx ?? editor.items.length;
+      const removedBefore = editor.items.slice(0, pos0).filter((t) => cutIds.has(t.id)).length;
+      const remaining = editor.items.filter((t) => !cutIds.has(t.id));
+      const pos = Math.min(remaining.length, pos0 - removedBefore);
+      editor.setItems(() => {
+        const next = [...remaining];
+        next.splice(pos, 0, ...moved);
+        return next;
+      });
+      selection.setSelectedIds(new Set(moved.map((t) => t.id)));
+    } else {
+      // Copy → 新規エンティティ生成 (即永続化)
+      const newIds: string[] = [];
+      for (const t of clipItems) {
+        const full = await loadTable(t.id);
+        if (!full) continue;
+        const dup: TableDefinition = {
+          ...full,
+          id: generateUUID(),
+          name: full.name + "_copy",
+          logicalName: full.logicalName + " (コピー)",
+          columns: full.columns.map((c) => ({ ...c, id: generateUUID() })),
+          indexes: full.indexes.map((i) => ({ ...i, id: generateUUID() })),
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        };
+        await saveTable(dup);
+        newIds.push(dup.id);
+      }
+      clipboard.consume();
+      await editor.reload();
+      selection.setSelectedIds(new Set(newIds));
+    }
   };
 
   useListKeyboard({
     items: sort.sorted,
     getId: (t) => t.id,
     selection,
+    clipboard,
     layout: viewMode === "card" ? "grid" : "list",
     onActivate: handleActivate,
     onDelete: handleDelete,
+    onDuplicate: (items) => { handleDuplicate(items).catch(console.error); },
+    onMoveUp: (items) => moveBlock(items, "up"),
+    onMoveDown: (items) => moveBlock(items, "down"),
+    onPaste: (idx) => { handlePaste(idx).catch(console.error); },
   });
 
   const handleAdd = async () => {
@@ -122,24 +267,37 @@ export function TableListView() {
   };
 
   const handleExportDdl = async () => {
-    const allTables: TableDefinition[] = [];
-    for (const t of tables) {
+    const defs: TableDefinition[] = [];
+    for (const t of allTables) {
+      if (editor.isDeleted(t.id)) continue;
       const td = await loadTable(t.id);
-      if (td) allTables.push(td);
+      if (td) defs.push(td);
     }
-    const ddl = generateAllDdl(allTables, exportDialect);
+    const ddl = generateAllDdl(defs, exportDialect);
     downloadText(`${projectName}_ddl.sql`, ddl);
     setShowExport(false);
   };
 
   const handleExportMarkdown = async () => {
-    const allTables: TableDefinition[] = [];
-    for (const t of tables) {
+    const defs: TableDefinition[] = [];
+    for (const t of allTables) {
+      if (editor.isDeleted(t.id)) continue;
       const td = await loadTable(t.id);
-      if (td) allTables.push(td);
+      if (td) defs.push(td);
     }
-    const md = generateAllTableMarkdown(allTables, projectName);
+    const md = generateAllTableMarkdown(defs, projectName);
     downloadText(`${projectName}_tables.md`, md);
+  };
+
+  const handleSave = () => {
+    editor.save().catch(console.error);
+    selection.clearSelection();
+  };
+
+  const handleReset = () => {
+    if (!confirm("未保存の変更を破棄してサーバの状態に戻しますか？")) return;
+    editor.reset().catch(console.error);
+    selection.clearSelection();
   };
 
   const columns = useMemo<DataListColumn<TableMeta>[]>(() => [
@@ -199,6 +357,7 @@ export function TableListView() {
   );
 
   const selectedCount = selection.selectedIds.size;
+  const deletedCount = editor.deletedIds.size;
 
   return (
     <div className="table-list-page">
@@ -208,7 +367,7 @@ export function TableListView() {
         <div className="table-list-header">
           <h2 className="table-list-title">
             <i className="bi bi-table" /> テーブル設計書
-            <span className="table-list-count">{tables.length} テーブル</span>
+            <span className="table-list-count">{allTables.length - deletedCount} テーブル{deletedCount > 0 ? ` (削除予定 ${deletedCount})` : ""}</span>
           </h2>
           <div className="table-list-actions">
             <div className="table-list-search">
@@ -226,7 +385,7 @@ export function TableListView() {
               )}
             </div>
             <ViewModeToggle mode={viewMode} onChange={setViewMode} storageKey={STORAGE_KEY} />
-            {tables.length > 0 && (
+            {allTables.length > 0 && (
               <>
                 <button className="tbl-btn tbl-btn-ghost" onClick={handleExportMarkdown} title="Markdown エクスポート">
                   <i className="bi bi-file-earmark-text" /> Markdown
@@ -244,6 +403,25 @@ export function TableListView() {
             <button className="tbl-btn tbl-btn-primary" onClick={() => setShowAdd(true)}>
               <i className="bi bi-plus-lg" /> テーブル追加
             </button>
+            <span className="tbl-saveline-sep" />
+            <button
+              className="tbl-btn tbl-btn-ghost"
+              data-testid="list-reset-btn"
+              onClick={handleReset}
+              disabled={!editor.isDirty || editor.isSaving}
+              title="変更を破棄"
+            >
+              <i className="bi bi-arrow-counterclockwise" /> リセット
+            </button>
+            <button
+              className="tbl-btn tbl-btn-primary"
+              data-testid="list-save-btn"
+              onClick={handleSave}
+              disabled={!editor.isDirty || editor.isSaving}
+              title="変更を保存"
+            >
+              <i className="bi bi-save" /> {editor.isSaving ? "保存中..." : "保存"}
+            </button>
           </div>
         </div>
 
@@ -260,13 +438,16 @@ export function TableListView() {
           columns={columns}
           getId={(t) => t.id}
           selection={selection}
+          clipboard={clipboard}
           sort={sort}
           onActivate={handleActivate}
+          onReorder={handleReorder}
           layout={viewMode === "card" ? "grid" : "list"}
           renderCard={renderCard}
           showNumColumn={viewMode === "table"}
           variant="dark"
           className="tables-data-list"
+          isItemGhost={(id) => editor.isDeleted(id)}
           emptyMessage={
             query
               ? <p>該当するテーブル定義がありません</p>

--- a/designer/src/hooks/useListEditor.test.ts
+++ b/designer/src/hooks/useListEditor.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useListEditor } from "./useListEditor";
+
+interface Item {
+  id: string;
+  name: string;
+}
+
+function makeItems(n: number): Item[] {
+  return Array.from({ length: n }, (_, i) => ({ id: `id-${i + 1}`, name: `item-${i + 1}` }));
+}
+
+function setup(opts: { initial?: Item[]; commit?: ReturnType<typeof vi.fn> } = {}) {
+  const items = opts.initial ?? makeItems(3);
+  const load = vi.fn(async () => items);
+  const commit = opts.commit ?? vi.fn(async () => undefined);
+  const result = renderHook(() =>
+    useListEditor<Item>({
+      getId: (it) => it.id,
+      load,
+      commit,
+    }),
+  );
+  return { ...result, load, commit };
+}
+
+describe("useListEditor", () => {
+  it("初期は空、reload 後に items が入る", async () => {
+    const { result } = setup();
+    expect(result.current.items).toEqual([]);
+    await act(async () => { await result.current.reload(); });
+    expect(result.current.items).toHaveLength(3);
+    expect(result.current.isDirty).toBe(false);
+  });
+
+  it("reorder で draft が並び替わり、dirty=true になる", async () => {
+    const { result } = setup();
+    await act(async () => { await result.current.reload(); });
+    act(() => result.current.reorder(0, 2));
+    expect(result.current.items.map((x) => x.id)).toEqual(["id-2", "id-3", "id-1"]);
+    expect(result.current.isDirty).toBe(true);
+  });
+
+  it("reorder が同じインデックスだと何もしない", async () => {
+    const { result } = setup();
+    await act(async () => { await result.current.reload(); });
+    act(() => result.current.reorder(1, 1));
+    expect(result.current.items.map((x) => x.id)).toEqual(["id-1", "id-2", "id-3"]);
+    expect(result.current.isDirty).toBe(false);
+  });
+
+  it("markDeleted で deletedIds に追加され、dirty=true", async () => {
+    const { result } = setup();
+    await act(async () => { await result.current.reload(); });
+    act(() => result.current.markDeleted(["id-2"]));
+    expect(result.current.deletedIds.has("id-2")).toBe(true);
+    expect(result.current.isDeleted("id-2")).toBe(true);
+    expect(result.current.isDirty).toBe(true);
+  });
+
+  it("unmarkDeleted で元に戻り、dirty=false に戻る", async () => {
+    const { result } = setup();
+    await act(async () => { await result.current.reload(); });
+    act(() => result.current.markDeleted(["id-2"]));
+    act(() => result.current.unmarkDeleted(["id-2"]));
+    expect(result.current.deletedIds.size).toBe(0);
+    expect(result.current.isDirty).toBe(false);
+  });
+
+  it("toggleDeleted は複数回呼ぶと状態が切り替わる", async () => {
+    const { result } = setup();
+    await act(async () => { await result.current.reload(); });
+    act(() => result.current.toggleDeleted(["id-1"]));
+    expect(result.current.isDeleted("id-1")).toBe(true);
+    act(() => result.current.toggleDeleted(["id-1"]));
+    expect(result.current.isDeleted("id-1")).toBe(false);
+  });
+
+  it("save で commit が呼ばれ、削除と並び順が反映される", async () => {
+    const commit = vi.fn(async () => undefined);
+    const { result } = setup({ commit });
+    await act(async () => { await result.current.reload(); });
+    act(() => result.current.reorder(0, 2));
+    act(() => result.current.markDeleted(["id-3"]));
+    await act(async () => { await result.current.save(); });
+    expect(commit).toHaveBeenCalledOnce();
+    const [arg] = commit.mock.calls[0];
+    expect(arg.deletedIds).toEqual(["id-3"]);
+    expect(arg.itemsInOrder.map((x: Item) => x.id)).toEqual(["id-2", "id-1"]);
+  });
+
+  it("save 後は isDirty=false に戻る", async () => {
+    const { result } = setup();
+    await act(async () => { await result.current.reload(); });
+    act(() => result.current.markDeleted(["id-1"]));
+    expect(result.current.isDirty).toBe(true);
+    await act(async () => { await result.current.save(); });
+    expect(result.current.isDirty).toBe(false);
+    expect(result.current.deletedIds.size).toBe(0);
+  });
+
+  it("reset でドラフト破棄、reload される", async () => {
+    const { result } = setup();
+    await act(async () => { await result.current.reload(); });
+    act(() => result.current.reorder(0, 2));
+    act(() => result.current.markDeleted(["id-1"]));
+    await act(async () => { await result.current.reset(); });
+    expect(result.current.items.map((x) => x.id)).toEqual(["id-1", "id-2", "id-3"]);
+    expect(result.current.isDirty).toBe(false);
+    expect(result.current.deletedIds.size).toBe(0);
+  });
+
+  it("insert で末尾に追加、dirty=true", async () => {
+    const { result } = setup();
+    await act(async () => { await result.current.reload(); });
+    act(() => result.current.insert([{ id: "id-new", name: "new" }]));
+    expect(result.current.items.map((x) => x.id)).toEqual(["id-1", "id-2", "id-3", "id-new"]);
+    expect(result.current.isDirty).toBe(true);
+  });
+
+  it("insertAt で指定位置に挿入", async () => {
+    const { result } = setup();
+    await act(async () => { await result.current.reload(); });
+    act(() => result.current.insertAt([{ id: "id-new", name: "new" }], 1));
+    expect(result.current.items.map((x) => x.id)).toEqual(["id-1", "id-new", "id-2", "id-3"]);
+  });
+
+  it("tabId を指定しても hook はエラーにならず dirty 追跡が動く", async () => {
+    // tabStore の副作用は e2e で検証。ここでは hook が落ちないこと + dirty 追跡のみ確認。
+    const load = vi.fn(async () => makeItems(2));
+    const commit = vi.fn(async () => undefined);
+    const { result } = renderHook(() =>
+      useListEditor<Item>({
+        getId: (it) => it.id,
+        load,
+        commit,
+        tabId: "nonexistent-tab-for-test",
+      }),
+    );
+    await act(async () => { await result.current.reload(); });
+    expect(result.current.isDirty).toBe(false);
+    act(() => result.current.markDeleted(["id-1"]));
+    expect(result.current.isDirty).toBe(true);
+  });
+});

--- a/designer/src/hooks/useListEditor.ts
+++ b/designer/src/hooks/useListEditor.ts
@@ -1,0 +1,195 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { setDirty as setTabDirty } from "../store/tabStore";
+
+export interface UseListEditorOpts<T> {
+  /** 識別子 */
+  getId: (item: T) => string;
+  /** バックエンドから全件ロード */
+  load: () => Promise<T[]>;
+  /**
+   * 変更を永続化する。順序変更後の配列と、削除対象 ID を受け取る。
+   * 実装側で「削除 → 順序保存」の順で永続化することを想定。
+   */
+  commit: (opts: { itemsInOrder: T[]; deletedIds: string[] }) => Promise<void>;
+  /** タブ dirty 連動用。指定するとタブのインジケータが連動する */
+  tabId?: string;
+}
+
+export interface UseListEditorResult<T> {
+  /** 画面表示用: 並び順は draft、削除マーク中の項目も含まれる */
+  items: T[];
+  /** 削除マーク中の ID */
+  deletedIds: Set<string>;
+  /** 指定 ID が削除マーク中か */
+  isDeleted: (id: string) => boolean;
+  isDirty: boolean;
+  isSaving: boolean;
+  /** 外部からバックエンド変更が来て、未保存がある場合に true */
+  externalChangeWhileDirty: boolean;
+  /** 明示リロード (外部からの変更検知時など) */
+  reload: () => Promise<void>;
+  /** 並び順変更 (draft) */
+  reorder: (fromIndex: number, toIndex: number) => void;
+  /** 指定位置への挿入 (Ctrl+V の貼付など) */
+  insertAt: (newItems: T[], atIndex: number) => void;
+  /** 削除マーク追加 */
+  markDeleted: (ids: string[]) => void;
+  /** 削除マーク解除 */
+  unmarkDeleted: (ids: string[]) => void;
+  /** 削除マークをトグル */
+  toggleDeleted: (ids: string[]) => void;
+  /** 追加 (即 draft に追加、isDirty=true) */
+  insert: (items: T[], atIndex?: number) => void;
+  /** draft を直接操作 (アイテム内容変更など) */
+  setItems: (updater: (prev: T[]) => T[]) => void;
+  /** 保存 (削除 → 並び順コミット) */
+  save: () => Promise<void>;
+  /** ドラフトを破棄してバックエンドから再ロード */
+  reset: () => Promise<void>;
+  /** 外部変更バナーを閉じる */
+  dismissExternalChange: () => void;
+}
+
+/**
+ * 一覧画面向けのドラフト/保存/リセット/削除ゴースト管理フック。
+ *
+ * - 並び順の変更・削除マークはすべて draft 状態。明示 save で永続化。
+ * - 削除はゴースト方式: 削除マークされたアイテムは items に残る (表示側で opacity を下げる)
+ * - reset でドラフト破棄 → reload
+ */
+export function useListEditor<T>(opts: UseListEditorOpts<T>): UseListEditorResult<T> {
+  const { getId, load, commit, tabId } = opts;
+
+  const [items, setItemsState] = useState<T[]>([]);
+  const [loadedItems, setLoadedItems] = useState<T[]>([]);
+  const [deletedIds, setDeletedIds] = useState<Set<string>>(new Set());
+  const [isSaving, setIsSaving] = useState(false);
+  const [externalChangeWhileDirty, setExternalChangeWhileDirty] = useState(false);
+  const dirtyRef = useRef(false);
+
+  const isDirty = useMemo(() => {
+    if (deletedIds.size > 0) return true;
+    if (items.length !== loadedItems.length) return true;
+    for (let i = 0; i < items.length; i++) {
+      if (getId(items[i]) !== getId(loadedItems[i])) return true;
+    }
+    return false;
+  }, [items, loadedItems, deletedIds, getId]);
+
+  useEffect(() => {
+    dirtyRef.current = isDirty;
+    if (tabId) setTabDirty(tabId, isDirty);
+  }, [tabId, isDirty]);
+
+  const reload = useCallback(async () => {
+    const loaded = await load();
+    setLoadedItems(loaded);
+    setItemsState(loaded);
+    setDeletedIds(new Set());
+    setExternalChangeWhileDirty(false);
+  }, [load]);
+
+  const reorder = useCallback((fromIndex: number, toIndex: number) => {
+    if (fromIndex === toIndex) return;
+    setItemsState((prev) => {
+      if (fromIndex < 0 || toIndex < 0) return prev;
+      if (fromIndex >= prev.length || toIndex >= prev.length) return prev;
+      const next = [...prev];
+      const [moved] = next.splice(fromIndex, 1);
+      next.splice(toIndex, 0, moved);
+      return next;
+    });
+  }, []);
+
+  const insertAt = useCallback((newItems: T[], atIndex: number) => {
+    setItemsState((prev) => {
+      const idx = Math.max(0, Math.min(prev.length, atIndex));
+      const next = [...prev];
+      next.splice(idx, 0, ...newItems);
+      return next;
+    });
+  }, []);
+
+  const insert = useCallback((newItems: T[], atIndex?: number) => {
+    setItemsState((prev) => {
+      const idx = atIndex == null ? prev.length : Math.max(0, Math.min(prev.length, atIndex));
+      const next = [...prev];
+      next.splice(idx, 0, ...newItems);
+      return next;
+    });
+  }, []);
+
+  const markDeleted = useCallback((ids: string[]) => {
+    setDeletedIds((prev) => {
+      const next = new Set(prev);
+      ids.forEach((id) => next.add(id));
+      return next;
+    });
+  }, []);
+
+  const unmarkDeleted = useCallback((ids: string[]) => {
+    setDeletedIds((prev) => {
+      const next = new Set(prev);
+      ids.forEach((id) => next.delete(id));
+      return next;
+    });
+  }, []);
+
+  const toggleDeleted = useCallback((ids: string[]) => {
+    setDeletedIds((prev) => {
+      const next = new Set(prev);
+      ids.forEach((id) => {
+        if (next.has(id)) next.delete(id);
+        else next.add(id);
+      });
+      return next;
+    });
+  }, []);
+
+  const isDeleted = useCallback((id: string) => deletedIds.has(id), [deletedIds]);
+
+  const setItems = useCallback((updater: (prev: T[]) => T[]) => {
+    setItemsState(updater);
+  }, []);
+
+  const save = useCallback(async () => {
+    if (isSaving) return;
+    setIsSaving(true);
+    try {
+      const deleted = Array.from(deletedIds);
+      const itemsInOrder = items.filter((it) => !deletedIds.has(getId(it)));
+      await commit({ itemsInOrder, deletedIds: deleted });
+      await reload();
+    } finally {
+      setIsSaving(false);
+    }
+  }, [isSaving, deletedIds, items, commit, reload, getId]);
+
+  const reset = useCallback(async () => {
+    await reload();
+  }, [reload]);
+
+  const dismissExternalChange = useCallback(() => {
+    setExternalChangeWhileDirty(false);
+  }, []);
+
+  return {
+    items,
+    deletedIds,
+    isDeleted,
+    isDirty,
+    isSaving,
+    externalChangeWhileDirty,
+    reload,
+    reorder,
+    insertAt,
+    markDeleted,
+    unmarkDeleted,
+    toggleDeleted,
+    insert,
+    setItems,
+    save,
+    reset,
+    dismissExternalChange,
+  };
+}

--- a/designer/src/hooks/useListInteraction.test.ts
+++ b/designer/src/hooks/useListInteraction.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useListFilter } from "./useListFilter";
+import { useListSort } from "./useListSort";
+import { useListSelection } from "./useListSelection";
+
+interface Item {
+  id: string;
+  group: "a" | "b";
+  order: number;
+}
+
+const items: Item[] = [
+  { id: "x1", group: "a", order: 3 },
+  { id: "x2", group: "b", order: 1 },
+  { id: "x3", group: "a", order: 2 },
+  { id: "x4", group: "b", order: 4 },
+];
+
+/**
+ * §3.8 「選択状態とソート / フィルタの相互作用」のユーザーフロー検証
+ *
+ * フィルタ/ソート/選択を組み合わせたフックを連結し、仕様の相互作用が
+ * 期待通りに動作することを確認する。
+ */
+function setup() {
+  return renderHook(() => {
+    const filter = useListFilter(items);
+    const sort = useListSort(filter.filtered, (it, key) =>
+      key === "order" ? it.order : key === "group" ? it.group : "",
+    );
+    const selection = useListSelection(sort.sorted, (it) => it.id);
+    return { filter, sort, selection };
+  });
+}
+
+describe("List hooks interaction (§3.8)", () => {
+  it("ソート適用後も選択は維持される", () => {
+    const { result } = setup();
+    act(() => result.current.selection.handleRowClick("x1", {}));
+    act(() => result.current.sort.toggleSort("order"));
+    expect(result.current.selection.selectedIds).toEqual(new Set(["x1"]));
+  });
+
+  it("ソート解除後も選択は維持される", () => {
+    const { result } = setup();
+    act(() => result.current.sort.toggleSort("order"));
+    act(() => result.current.selection.handleRowClick("x2", {}));
+    act(() => result.current.sort.clearSort());
+    expect(result.current.selection.selectedIds).toEqual(new Set(["x2"]));
+  });
+
+  it("フィルタ適用で非表示になった項目は selectedItems から除かれる", () => {
+    const { result } = setup();
+    // 全件から x2 と x4 (group=b) を選択
+    act(() => result.current.selection.setSelectedIds(new Set(["x2", "x4"])));
+    expect(result.current.selection.selectedItems.map((x) => x.id).sort()).toEqual(["x2", "x4"]);
+    // group=a でフィルタ
+    act(() => result.current.filter.applyFilter((x) => x.group === "a"));
+    // filtered 配列に x2, x4 がいないので selectedItems から除かれる
+    expect(result.current.selection.selectedItems.map((x) => x.id)).toEqual([]);
+    // 内部 selectedIds は保持 (再表示時に復活しない仕様なので消えないだけ)
+    expect(result.current.selection.selectedIds.has("x2")).toBe(true);
+  });
+
+  it("フィルタクリア後に items が戻っても、selectedItems は selectedIds から再構築される", () => {
+    const { result } = setup();
+    act(() => result.current.selection.setSelectedIds(new Set(["x2"])));
+    act(() => result.current.filter.applyFilter((x) => x.group === "a"));
+    act(() => result.current.filter.clearFilter());
+    expect(result.current.selection.selectedItems.map((x) => x.id)).toEqual(["x2"]);
+  });
+
+  it("Ctrl+A は見えている項目のみを選択対象とする", () => {
+    const { result } = setup();
+    act(() => result.current.filter.applyFilter((x) => x.group === "a"));
+    act(() => result.current.selection.selectAll());
+    // a のみが全選択されるべき (x1, x3)
+    expect(result.current.selection.selectedIds).toEqual(new Set(["x1", "x3"]));
+  });
+
+  it("多段ソート→同列の通常クリックで単一ソートに縮約", () => {
+    const { result } = setup();
+    act(() => result.current.sort.toggleSort("group"));
+    act(() => result.current.sort.toggleSort("order", { addKey: true }));
+    expect(result.current.sort.sortKeys).toHaveLength(2);
+    act(() => result.current.sort.toggleSort("order"));
+    expect(result.current.sort.sortKeys).toEqual([{ columnKey: "order", direction: "asc" }]);
+  });
+
+  it("ソート後の Shift+ クリックは sort 適用後の表示順でアンカーから範囲選択される", () => {
+    const { result } = setup();
+    // order 昇順でソート: x2(1), x3(2), x1(3), x4(4)
+    act(() => result.current.sort.toggleSort("order"));
+    act(() => result.current.selection.handleRowClick("x2", {}));
+    act(() => result.current.selection.handleRowClick("x1", { shiftKey: true }));
+    // x2, x3, x1 が選択される (ソート順での範囲)
+    expect(result.current.selection.selectedIds).toEqual(new Set(["x2", "x3", "x1"]));
+  });
+});

--- a/designer/src/hooks/useListInteraction.test.ts
+++ b/designer/src/hooks/useListInteraction.test.ts
@@ -50,25 +50,36 @@ describe("List hooks interaction (§3.8)", () => {
     expect(result.current.selection.selectedIds).toEqual(new Set(["x2"]));
   });
 
-  it("フィルタ適用で非表示になった項目は selectedItems から除かれる", () => {
+  it("フィルタ適用で非表示になった項目は選択から除かれる (§3.8)", () => {
     const { result } = setup();
     // 全件から x2 と x4 (group=b) を選択
     act(() => result.current.selection.setSelectedIds(new Set(["x2", "x4"])));
     expect(result.current.selection.selectedItems.map((x) => x.id).sort()).toEqual(["x2", "x4"]);
     // group=a でフィルタ
     act(() => result.current.filter.applyFilter((x) => x.group === "a"));
-    // filtered 配列に x2, x4 がいないので selectedItems から除かれる
+    // selectedItems も selectedIds も空になる
     expect(result.current.selection.selectedItems.map((x) => x.id)).toEqual([]);
-    // 内部 selectedIds は保持 (再表示時に復活しない仕様なので消えないだけ)
-    expect(result.current.selection.selectedIds.has("x2")).toBe(true);
+    expect(result.current.selection.selectedIds.size).toBe(0);
   });
 
-  it("フィルタクリア後に items が戻っても、selectedItems は selectedIds から再構築される", () => {
+  it("フィルタクリア後、非表示だった項目の選択は復活しない (§3.8)", () => {
     const { result } = setup();
     act(() => result.current.selection.setSelectedIds(new Set(["x2"])));
     act(() => result.current.filter.applyFilter((x) => x.group === "a"));
+    // フィルタで x2 が除外された時点で selectedIds からも消えている
+    expect(result.current.selection.selectedIds.size).toBe(0);
     act(() => result.current.filter.clearFilter());
-    expect(result.current.selection.selectedItems.map((x) => x.id)).toEqual(["x2"]);
+    // クリア後 x2 は再表示されるが、選択は復活しない
+    expect(result.current.selection.selectedItems.map((x) => x.id)).toEqual([]);
+  });
+
+  it("フィルタ適用で可視範囲に残った項目の選択は維持される", () => {
+    const { result } = setup();
+    // x1 (group=a), x2 (group=b) を選択
+    act(() => result.current.selection.setSelectedIds(new Set(["x1", "x2"])));
+    // group=a でフィルタ → x2 だけ外れる
+    act(() => result.current.filter.applyFilter((x) => x.group === "a"));
+    expect(result.current.selection.selectedIds).toEqual(new Set(["x1"]));
   });
 
   it("Ctrl+A は見えている項目のみを選択対象とする", () => {

--- a/designer/src/hooks/useListSelection.ts
+++ b/designer/src/hooks/useListSelection.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useMemo } from "react";
+import { useState, useCallback, useRef, useMemo, useEffect } from "react";
 
 export interface ListSelection<T> {
   selectedIds: Set<string>;
@@ -26,6 +26,25 @@ export function useListSelection<T>(
   const anchorIdRef = useRef<string | null>(null);
 
   const itemIds = useMemo(() => items.map(getId), [items, getId]);
+
+  // 仕様 §3.8: items (フィルタ後の表示範囲) から消えた項目は selectedIds からも除外。
+  // これにより、フィルタクリア時に「再表示された項目の選択が復活しない」挙動が成立する。
+  useEffect(() => {
+    const visible = new Set(itemIds);
+    setSelectedIdsState((prev) => {
+      if (prev.size === 0) return prev;
+      let changed = false;
+      const next = new Set<string>();
+      for (const id of prev) {
+        if (visible.has(id)) next.add(id);
+        else changed = true;
+      }
+      return changed ? next : prev;
+    });
+    if (anchorIdRef.current && !visible.has(anchorIdRef.current)) {
+      anchorIdRef.current = null;
+    }
+  }, [itemIds]);
 
   const isSelected = useCallback(
     (id: string) => selectedIds.has(id),

--- a/designer/src/store/actionStore.ts
+++ b/designer/src/store/actionStore.ts
@@ -116,6 +116,18 @@ export async function deleteActionGroup(id: string): Promise<void> {
   }
 }
 
+/** 処理フロー一覧の並び順を変更する (project.actionGroups の物理順) */
+export async function reorderActionGroups(fromIndex: number, toIndex: number): Promise<void> {
+  const project = await loadProject();
+  if (!project.actionGroups) return;
+  if (fromIndex < 0 || toIndex < 0) return;
+  if (fromIndex >= project.actionGroups.length || toIndex >= project.actionGroups.length) return;
+  if (fromIndex === toIndex) return;
+  const [moved] = project.actionGroups.splice(fromIndex, 1);
+  project.actionGroups.splice(toIndex, 0, moved);
+  await saveProject(project);
+}
+
 /** アクションを追加 */
 export function addAction(
   group: ActionGroup,

--- a/designer/src/store/flowStore.ts
+++ b/designer/src/store/flowStore.ts
@@ -69,7 +69,7 @@ const FLOW_PROJECT_KEY = "flow-project";
 const SCREEN_DATA_PREFIX = "gjs-screen-";
 const LEGACY_KEY = "gjs-designer-project";
 
-const DEFAULT_NODE_SIZE = { width: 200, height: 100 };
+export const DEFAULT_NODE_SIZE = { width: 200, height: 100 };
 
 function now(): string {
   return new Date().toISOString();

--- a/designer/src/store/tableStore.ts
+++ b/designer/src/store/tableStore.ts
@@ -168,6 +168,18 @@ export function removeIndex(table: TableDefinition, indexId: string): void {
   if (idx >= 0) table.indexes.splice(idx, 1);
 }
 
+/** テーブル一覧の並び順を変更する (project.tables の物理順) */
+export async function reorderTables(fromIndex: number, toIndex: number): Promise<void> {
+  const project = await loadProject();
+  if (!project.tables) return;
+  if (fromIndex < 0 || toIndex < 0) return;
+  if (fromIndex >= project.tables.length || toIndex >= project.tables.length) return;
+  if (fromIndex === toIndex) return;
+  const [moved] = project.tables.splice(fromIndex, 1);
+  project.tables.splice(toIndex, 0, moved);
+  await saveProject(project);
+}
+
 // ─── 内部 ────────────────────────────────────────────────────────────────
 
 /** project.json のテーブルメタを同期 */

--- a/designer/src/styles/dataList.css
+++ b/designer/src/styles/dataList.css
@@ -156,8 +156,42 @@
   background: #1d4ed8;
 }
 
-.data-list-row.cut > td {
+.data-list-row.ghost > td {
   font-style: italic;
+  text-decoration: line-through;
+  text-decoration-color: rgba(239, 68, 68, 0.5);
+}
+
+/* D&D ドロップ位置マーカー (水平線) */
+.data-list-row.drop-indicator-top > td:first-child::before,
+.data-list-row.drop-indicator-bottom > td:first-child::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: #6366f1;
+  box-shadow: 0 0 4px rgba(99, 102, 241, 0.5);
+  pointer-events: none;
+  z-index: 2;
+}
+
+.data-list-row.drop-indicator-top > td:first-child::before {
+  top: 0;
+}
+
+.data-list-row.drop-indicator-bottom > td:first-child::after {
+  bottom: 0;
+}
+
+/* 行を relative に (::before/::after の基準点にする) */
+.data-list-row.drop-indicator-top,
+.data-list-row.drop-indicator-bottom {
+  position: relative;
+}
+.data-list-row.drop-indicator-top > td:first-child,
+.data-list-row.drop-indicator-bottom > td:first-child {
+  position: relative;
 }
 
 /* ------- Grid (card) layout -------- */
@@ -205,8 +239,45 @@
   border-color: #60a5fa;
 }
 
-.data-list-card.cut {
+.data-list-card.ghost {
   font-style: italic;
+}
+
+.data-list-card.ghost::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 10%;
+  right: 10%;
+  height: 1px;
+  background: rgba(239, 68, 68, 0.4);
+  pointer-events: none;
+}
+
+.data-list-card {
+  position: relative;
+}
+
+/* D&D ドロップ位置マーカー (垂直線、カード間) */
+.data-list-card.drop-indicator-left::before,
+.data-list-card.drop-indicator-right::after {
+  content: "";
+  position: absolute;
+  top: 4px;
+  bottom: 4px;
+  width: 2px;
+  background: #6366f1;
+  box-shadow: 0 0 4px rgba(99, 102, 241, 0.5);
+  pointer-events: none;
+  z-index: 2;
+}
+
+.data-list-card.drop-indicator-left::before {
+  left: -7px;
+}
+
+.data-list-card.drop-indicator-right::after {
+  right: -7px;
 }
 
 /* ==========================================================================

--- a/designer/src/styles/table.css
+++ b/designer/src/styles/table.css
@@ -695,6 +695,35 @@
 
 /* ── カラム詳細編集 ────────────────────────────────────────────────────── */
 
+.column-detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 16px;
+  background: rgba(124,107,255,0.08);
+  border-top: 1px solid rgba(124,107,255,0.15);
+  border-bottom: 1px solid rgba(124,107,255,0.15);
+  font-size: 13px;
+  color: #ddd;
+}
+
+.column-detail-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.column-detail-title code {
+  color: #7c6bff;
+  font-weight: 600;
+}
+
+.column-detail-hint {
+  color: #888;
+  font-size: 11px;
+  margin-left: 8px;
+}
+
 .column-detail {
   padding: 16px 20px;
   background: rgba(124,107,255,0.04);


### PR DESCRIPTION
Phase A〜E マージ後の監査で見つかった 9 項目の未実装・仕様違反を一括対応。

## 対応項目 (Issue #133 の再オープン時コメント参照)

### 1. 保存/ドラフトフロー (§3.5, §3.4)
- `useListEditor` フックを新設: 一覧画面向けの draft/保存/リセット/削除 ghost 管理
- 並び替え (D&D / Alt+↑↓ / Ctrl+X→V) と削除はすべて draft → 明示保存
- 保存/リセットボタンを 3 一覧に追加 (\`data-testid=\"list-save-btn\"/\"list-reset-btn\"\`)
- タブ dirty インジケータ連動 (\`tabStore.setDirty\`)

### 2. クリップボード完全実装
- テーブル/処理フロー/画面一覧で \`useListClipboard\` + \`onPaste\` を接続
- Ctrl+C → 貼付時に複製 (即時永続化)
- Ctrl+X → 貼付時に並び順変更 (draft)
- 仕様 §3.4 の「貼り付け対象自身が選択中」no-op 含む

### 3. Ctrl+D / Alt+↑↓ の一覧 3 画面対応
- Ctrl+D 複製 (即時)・Alt+↑↓ 移動 (draft) を全一覧で動作
- ブロック単位の連続移動も対応

### 4. D&D ハンドル (#138 の指摘)
- \`onReorder\` を全一覧に接続、表モードでは左端に grip-vertical アイコン表示
- \`reorderTables\` / \`reorderActionGroups\` ストアヘルパ追加

### 5. 空領域クリックで選択解除 (§3.1)
- DataList ルート直接クリック (\`e.target === e.currentTarget\`) で \`clearSelection\`

### 6. D&D ドロップマーカー (§3.5)
- 表: 行間に 2px 水平線 (インジゴ色)
- カード: カード間に 2px 垂直線

### 7. カラム一覧の UX を戻し
- 旧「単一選択で自動展開」を廃止、ダブルクリック/Enter/F2 で明示的に開く
- 詳細パネルにヘッダ + ✕ ボタン、Esc でキャプチャ phase 優先で閉じる

### 8. ghost 表示の統一
- Ctrl+X 切取・削除予定ともに \`opacity 0.5 + 取消線\`
- \`isItemGhost\` プロパティを DataList に追加、\`clipboard.isItemCut\` と統合

### 9. テスト拡充
- Vitest: \`useListEditor\` 12 ケース、§3.8 相互作用 7 ケース (合計 193 pass)
- E2E: 選択/キー/保存フロー/ソート/ghost — テーブル 12 / 処理フロー 3 / 画面 4 = 19 ケース

## 受け入れ条件再確認 (§8)

- [x] 共通フック 5 種 + 新設 \`useListEditor\` 提供、Vitest で主要ケース検証
- [x] DataList が list/grid 両レイアウト対応
- [x] 対象 4 画面すべて共通部品を使用
- [x] カード ⇔ 表切替が画面ごと localStorage 永続化
- [x] Excel/Explorer 準拠の全操作が統一動作 (Click/Ctrl/Shift/Ctrl+A/Esc/↑↓←→/Home/End/Enter/F2/Delete/Ctrl+C/X/V/D/Alt+↑↓)
- [x] No 列表示、D&D / コピペ / Alt+↑↓ / 追加 / 削除で物理順が正しく更新・永続化
- [x] 列ヘッダクリックソート (単一・多段) ▲▼ ① ② ③
- [x] フィルタ API 動作、FilterBar 共通
- [x] 画面フロー / 画面一覧が分離済、HeaderMenu・CLAUDE.md 更新済 (Phase C で対応済)
- [x] Playwright テスト拡充

## Test plan

- [x] \`npm run build\` — 成功
- [x] \`npm run lint\` — 新規エラーなし
- [x] \`npm run test:unit\` — 15 files / 193 tests pass
- [x] \`npm run test:e2e\` — 100 pass, 1 skipped, 1 pre-existing failure (\`tab-management\` Ctrl+Tab、main でも同じ失敗を確認済)
- [ ] 視覚確認 — 4 一覧画面の挙動をローカルで確認推奨

マージ後に Issue #133 をクローズ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)