### PR TITLE
feat(types): 処理フロー型に StructuredField / outputBinding / argumentMapping を追加 (#156)

### DIFF
--- a/designer/src/components/action/ActionEditor.tsx
+++ b/designer/src/components/action/ActionEditor.tsx
@@ -27,6 +27,7 @@ import {
 import { listTables } from "../../store/tableStore";
 import { loadProject } from "../../store/flowStore";
 import { getStepLabel, clearJumpReferences } from "../../utils/actionUtils";
+import { fieldsToText } from "../../utils/actionFields";
 import { validateActionGroup, hasBlockingErrors } from "../../utils/actionValidation";
 import type { ValidationError } from "../../utils/actionValidation";
 import { generateUUID } from "../../utils/uuid";
@@ -571,7 +572,7 @@ export function ActionEditor() {
                 <textarea
                   className="form-control form-control-sm action-io-textarea"
                   rows={1}
-                  value={activeAction.inputs ?? ""}
+                  value={fieldsToText(activeAction.inputs)}
                   onChange={(e) => {
                     const val = e.target.value;
                     updateGroupSilent((g) => {
@@ -588,7 +589,7 @@ export function ActionEditor() {
                 <textarea
                   className="form-control form-control-sm action-io-textarea"
                   rows={1}
-                  value={activeAction.outputs ?? ""}
+                  value={fieldsToText(activeAction.outputs)}
                   onChange={(e) => {
                     const val = e.target.value;
                     updateGroupSilent((g) => {

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -163,6 +163,11 @@ export interface StepBase {
   notes?: StepNote[];
   /** 成熟度。未指定は "draft" として解釈 */
   maturity?: Maturity;
+  /**
+   * ステップの結果を保持する変数名。後続ステップは @変数名 で参照する。
+   * docs/spec/process-flow-variables.md §3.2
+   */
+  outputBinding?: string;
   subSteps?: Step[];
 }
 
@@ -194,6 +199,11 @@ export interface CommonProcessStep extends StepBase {
   type: "commonProcess";
   refId: string;
   refName?: string;
+  /**
+   * 呼び先フローの入力名 → 値表現 (リテラル or "@変数名") のマッピング。
+   * docs/spec/process-flow-variables.md §3.4
+   */
+  argumentMapping?: Record<string, string>;
 }
 
 export interface ScreenTransitionStep extends StepBase {
@@ -285,16 +295,49 @@ export type Step =
 
 // ── アクション定義 ───────────────────────────────────────────────────────
 
+// ── 入出力の構造化 (docs/spec/process-flow-variables.md §3.1) ─────────────
+
+/** 入出力フィールドの型。primitive + テーブル/画面参照 + 自由記述型の union */
+export type FieldType =
+  | "string"
+  | "number"
+  | "boolean"
+  | "date"
+  | { kind: "tableRow"; tableId: string }
+  | { kind: "tableList"; tableId: string }
+  | { kind: "screenInput"; screenId: string }
+  | { kind: "custom"; label: string };
+
+export interface StructuredField {
+  /** 識別子 (例: "userId")。@変数参照のキーにもなる */
+  name: string;
+  /** 表示名 (例: "ユーザーID") */
+  label?: string;
+  type: FieldType;
+  required?: boolean;
+  description?: string;
+  /** 自由記述の既定値 */
+  defaultValue?: string;
+}
+
+/** inputs / outputs の値型: 旧形式 (改行区切り文字列) と新形式 (StructuredField[]) の union */
+export type ActionFields = string | StructuredField[];
+
 export interface ActionDefinition {
   id: string;
   name: string;
   trigger: ActionTrigger;
   elementRef?: string;
   description?: string;
-  /** 入力データ（自由記述、改行区切り） */
-  inputs?: string;
-  /** 出力データ（自由記述、改行区切り） */
-  outputs?: string;
+  /**
+   * 入力データ。
+   * - 旧形式: 改行区切り文字列 (既存データ互換)
+   * - 新形式: StructuredField[]
+   * docs/spec/process-flow-variables.md §3.1
+   */
+  inputs?: ActionFields;
+  /** 出力データ。inputs と同じ union 型 */
+  outputs?: ActionFields;
   /** 成熟度。未指定は "draft" として解釈 */
   maturity?: Maturity;
   steps: Step[];

--- a/designer/src/utils/actionFields.test.ts
+++ b/designer/src/utils/actionFields.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import type { ActionFields, StructuredField } from "../types/action";
+import {
+  fieldsToText,
+  isStructuredFields,
+  textToStructuredFields,
+} from "./actionFields";
+
+describe("isStructuredFields", () => {
+  it("string の場合は false", () => {
+    expect(isStructuredFields("userId\npassword")).toBe(false);
+  });
+
+  it("配列の場合は true", () => {
+    const v: StructuredField[] = [{ name: "userId", type: "string" }];
+    expect(isStructuredFields(v)).toBe(true);
+  });
+
+  it("undefined の場合は false", () => {
+    expect(isStructuredFields(undefined)).toBe(false);
+  });
+
+  it("空配列も true (型的に StructuredField[] として扱える)", () => {
+    expect(isStructuredFields([])).toBe(true);
+  });
+});
+
+describe("fieldsToText", () => {
+  it("string はそのまま返す", () => {
+    expect(fieldsToText("userId\npassword")).toBe("userId\npassword");
+  });
+
+  it("undefined は空文字列", () => {
+    expect(fieldsToText(undefined)).toBe("");
+  });
+
+  it("StructuredField[] は name を改行区切りで連結", () => {
+    const v: StructuredField[] = [
+      { name: "userId", label: "ユーザーID", type: "string", required: true },
+      { name: "password", type: "string" },
+    ];
+    expect(fieldsToText(v)).toBe("userId\npassword");
+  });
+
+  it("空配列は空文字列", () => {
+    const v: StructuredField[] = [];
+    expect(fieldsToText(v)).toBe("");
+  });
+});
+
+describe("textToStructuredFields", () => {
+  it("改行区切りテキストを StructuredField[] に変換 (type は string 既定)", () => {
+    const fields = textToStructuredFields("userId\npassword\nemail");
+    expect(fields).toHaveLength(3);
+    expect(fields[0]).toEqual({ name: "userId", type: "string" });
+    expect(fields[1]).toEqual({ name: "password", type: "string" });
+    expect(fields[2]).toEqual({ name: "email", type: "string" });
+  });
+
+  it("空白行・前後の空白は無視", () => {
+    const fields = textToStructuredFields("  userId  \n\n  password\n");
+    expect(fields).toHaveLength(2);
+    expect(fields[0].name).toBe("userId");
+    expect(fields[1].name).toBe("password");
+  });
+
+  it("空文字列は空配列", () => {
+    expect(textToStructuredFields("")).toEqual([]);
+  });
+
+  it("CRLF 改行も処理できる", () => {
+    const fields = textToStructuredFields("a\r\nb\r\nc");
+    expect(fields).toHaveLength(3);
+  });
+});
+
+describe("fieldsToText ↔ textToStructuredFields の往復", () => {
+  it("StructuredField[] → text → StructuredField[] で name が保たれる (type は string リセット)", () => {
+    const original: StructuredField[] = [
+      { name: "userId", label: "ユーザーID", type: "number", required: true, description: "ID" },
+      { name: "role", type: { kind: "custom", label: "UserRole" } },
+    ];
+    const text = fieldsToText(original);
+    const roundTripped = textToStructuredFields(text);
+    expect(roundTripped.map((f) => f.name)).toEqual(["userId", "role"]);
+    // type/label/required/description は text 変換で失われる (既知の仕様)
+    expect(roundTripped[0].type).toBe("string");
+  });
+});
+
+describe("ActionFields union の透過的扱い", () => {
+  it("string と StructuredField[] のいずれも fieldsToText / isStructuredFields で判別可能", () => {
+    const stringVal: ActionFields = "a\nb";
+    const arrayVal: ActionFields = [{ name: "a", type: "string" }];
+    expect(isStructuredFields(stringVal)).toBe(false);
+    expect(isStructuredFields(arrayVal)).toBe(true);
+    expect(fieldsToText(stringVal)).toBe("a\nb");
+    expect(fieldsToText(arrayVal)).toBe("a");
+  });
+});

--- a/designer/src/utils/actionFields.ts
+++ b/designer/src/utils/actionFields.ts
@@ -1,0 +1,43 @@
+/**
+ * actionFields.ts
+ * ActionDefinition.inputs / outputs の `string | StructuredField[]` union を扱うヘルパー。
+ *
+ * docs/spec/process-flow-variables.md §5 「読み込み時の自動移行」に従い、
+ * 旧 string 形式と新 StructuredField[] 形式を UI で共通に扱うための補助関数を提供する。
+ *
+ * 現行 UI は自由記述 (string) のみ対応のため、表形式は fieldsToText でテキスト化して表示する。
+ * Phase 1 時点では StructuredField[] の編集は未サポート (名前のみのテキスト表示)。
+ */
+import type { ActionFields, StructuredField } from "../types/action";
+
+/** 値が StructuredField[] (新形式) かを判定する型ガード */
+export function isStructuredFields(
+  v: ActionFields | undefined,
+): v is StructuredField[] {
+  return Array.isArray(v);
+}
+
+/**
+ * 入出力フィールドをテキスト (改行区切り) に変換。
+ * - string: そのまま返す
+ * - StructuredField[]: name を改行区切りで返す (Phase 1 の textarea 表示用)
+ * - undefined: 空文字列
+ */
+export function fieldsToText(v: ActionFields | undefined): string {
+  if (v == null) return "";
+  if (typeof v === "string") return v;
+  return v.map((f) => f.name).join("\n");
+}
+
+/**
+ * 将来、StructuredField[] を自由記述モードに戻した時の変換用ユーティリティ。
+ * v1 では textarea 編集は常に string として保存される (union の string 側)。
+ * 旧形式の改行区切りから StructuredField[] に昇格する際に使う予定。
+ */
+export function textToStructuredFields(text: string): StructuredField[] {
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((name) => ({ name, type: "string" as const }));
+}

--- a/designer/src/utils/specExporter.ts
+++ b/designer/src/utils/specExporter.ts
@@ -11,6 +11,7 @@ import type { FlowProject } from "../types/flow";
 import type { ActionGroup, Step } from "../types/action";
 import { getAllRelations } from "./erUtils";
 import { getStepLabel } from "./actionUtils";
+import { fieldsToText } from "./actionFields";
 
 export interface SpecJson {
   /** プロジェクト名 */
@@ -175,8 +176,8 @@ export function generateSpecJson(
         actions: g.actions.map((a) => ({
           name: a.name,
           trigger: a.trigger,
-          inputs: a.inputs || undefined,
-          outputs: a.outputs || undefined,
+          inputs: fieldsToText(a.inputs) || undefined,
+          outputs: fieldsToText(a.outputs) || undefined,
           steps: a.steps.map((s, i) => toSpecStep(s, i)),
         })),
       };


### PR DESCRIPTION
## Summary

- docs/spec/process-flow-variables.md §7 Phase 1 の**型定義部分を実装**
- UI の表形式エディタは後続 PR で対応、本 PR は型拡張と後方互換ヘルパーのみ
- 257 ユニットテスト全パス (新規 14 件追加)、ビルド成功
- 既存 UI (自由記述 textarea) は fieldsToText 経由で継続動作 (視覚影響なし)

## 追加内容

### 型定義 (`designer/src/types/action.ts`)

- `FieldType` union: primitive 4 種 + `tableRow` / `tableList` / `screenInput` / `custom`
- `StructuredField` interface (name, label?, type, required?, description?, defaultValue?)
- `ActionFields` = `string \| StructuredField[]` union
- `ActionDefinition.inputs` / `outputs` を `ActionFields` に拡張 (旧 string 互換)
- `StepBase.outputBinding?: string`
- `CommonProcessStep.argumentMapping?: Record<string, string>`

### ヘルパー (`designer/src/utils/actionFields.ts` 新規)

- `isStructuredFields(v)` — 型ガード
- `fieldsToText(v)` — union → 改行区切り文字列 (既存 textarea 表示用)
- `textToStructuredFields(text)` — 改行区切り → `StructuredField[]` (将来の昇格用)

### 後方互換修正

- `ActionEditor.tsx` — inputs/outputs textarea の value を `fieldsToText()` でラップ (既存の string ベース UI はそのまま動作、視覚影響なし)
- `specExporter.ts` — エクスポート時に `fieldsToText()` で string 化 (SpecAction 型は変更なし)

## スコープ外 (別 PR)

- 表形式 UI エディタ (§7 Phase 1 の UI 部分)
- `@` 補完付き参照入力 (§7 Phase 3)
- 共通処理の引数マッピング UI (§7 Phase 4)
- テーブル/画面連携型の UI 展開 (§7 Phase 5, 任意)

## Test plan

- [x] `npm run test:unit` — 20 files / 257 tests pass (新規 14 件追加)
- [x] `npm run build` — TypeScript + Vite ビルド成功
- [x] 変更ファイルの ESLint エラーなし (ActionEditor.tsx の 1 件は pre-existing、本 PR 無関係)
- [x] 視覚影響なし — 既存 textarea は fieldsToText 経由で同じ string 表示

## 関連

- Closes #156
- Refs #151 (親トラッキング), #152 (spec 策定)
- Refs docs/spec/process-flow-variables.md §7 Phase 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)