### PR TITLE
feat(types): ExternalCallStep に outcomes / timeoutMs / retryPolicy / fireAndForget を追加 (#158)

### DIFF
--- a/designer/src/types/action.externalStep.test.ts
+++ b/designer/src/types/action.externalStep.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "vitest";
+import type { ActionGroup, ExternalSystemStep } from "./action";
+import { EXTERNAL_CALL_OUTCOME_VALUES } from "./action";
+import { migrateActionGroup } from "../utils/actionMigration";
+
+describe("ExternalSystemStep の新規フィールド (#158)", () => {
+  it("outcomes / timeoutMs / retryPolicy / fireAndForget をすべて保持できる", () => {
+    const step: ExternalSystemStep = {
+      id: "s1",
+      type: "externalSystem",
+      description: "決済呼出",
+      systemName: "Stripe",
+      protocol: "HTTPS",
+      outcomes: {
+        success: { action: "continue" },
+        failure: { action: "abort", description: "402 で返す" },
+        timeout: { action: "abort", description: "failure と同じ扱い" },
+      },
+      timeoutMs: 10000,
+      retryPolicy: { maxAttempts: 2, backoff: "exponential", initialDelayMs: 500 },
+      fireAndForget: false,
+    };
+    expect(step.outcomes?.success?.action).toBe("continue");
+    expect(step.outcomes?.failure?.action).toBe("abort");
+    expect(step.timeoutMs).toBe(10000);
+    expect(step.retryPolicy?.maxAttempts).toBe(2);
+    expect(step.fireAndForget).toBe(false);
+  });
+
+  it("すべて省略可能 (既存コードの型互換)", () => {
+    const step: ExternalSystemStep = {
+      id: "s2",
+      type: "externalSystem",
+      description: "",
+      systemName: "SomeService",
+    };
+    expect(step.outcomes).toBeUndefined();
+    expect(step.timeoutMs).toBeUndefined();
+    expect(step.retryPolicy).toBeUndefined();
+    expect(step.fireAndForget).toBeUndefined();
+  });
+
+  it("EXTERNAL_CALL_OUTCOME_VALUES に 3 値が列挙されている", () => {
+    expect(EXTERNAL_CALL_OUTCOME_VALUES).toEqual(["success", "failure", "timeout"]);
+  });
+
+  it("outcomes の partial 指定 (success のみ) も可能", () => {
+    const step: ExternalSystemStep = {
+      id: "s3",
+      type: "externalSystem",
+      description: "",
+      systemName: "X",
+      outcomes: {
+        success: { action: "continue", description: "ログ記録" },
+      },
+    };
+    expect(step.outcomes?.success).toBeDefined();
+    expect(step.outcomes?.failure).toBeUndefined();
+  });
+
+  it("fireAndForget=true の形式", () => {
+    const step: ExternalSystemStep = {
+      id: "s4",
+      type: "externalSystem",
+      description: "メール送信",
+      systemName: "SendGrid",
+      fireAndForget: true,
+      outcomes: {
+        failure: { action: "continue", description: "ログのみ、続行" },
+        timeout: { action: "continue", description: "同上" },
+      },
+    };
+    expect(step.fireAndForget).toBe(true);
+    expect(step.outcomes?.failure?.action).toBe("continue");
+  });
+});
+
+describe("migrateActionGroup — ExternalSystemStep の新フィールド透過保持 (#158)", () => {
+  it("新フィールドを持つ ExternalSystemStep を冪等にマイグレーションできる", () => {
+    const raw = {
+      id: "g",
+      name: "x",
+      type: "screen",
+      description: "",
+      actions: [
+        {
+          id: "a",
+          name: "a",
+          trigger: "submit",
+          steps: [
+            {
+              id: "s",
+              type: "externalSystem",
+              description: "",
+              systemName: "Stripe",
+              timeoutMs: 10000,
+              fireAndForget: false,
+              outcomes: {
+                success: { action: "continue" },
+                failure: { action: "abort" },
+              },
+              retryPolicy: { maxAttempts: 3, backoff: "fixed", initialDelayMs: 1000 },
+            },
+          ],
+        },
+      ],
+      createdAt: "",
+      updatedAt: "",
+    };
+    const once = migrateActionGroup(raw) as ActionGroup;
+    const twice = migrateActionGroup(once);
+    expect(JSON.stringify(twice)).toBe(JSON.stringify(once));
+
+    const step = once.actions[0].steps[0] as ExternalSystemStep;
+    expect(step.timeoutMs).toBe(10000);
+    expect(step.retryPolicy?.maxAttempts).toBe(3);
+    expect(step.outcomes?.success?.action).toBe("continue");
+    expect(step.outcomes?.failure?.action).toBe("abort");
+    expect(step.fireAndForget).toBe(false);
+    // maturity は既定付与 (既存挙動)
+    expect(step.maturity).toBe("draft");
+  });
+
+  it("新フィールドなしの旧データでも破壊されない", () => {
+    const raw = {
+      id: "g",
+      name: "x",
+      type: "screen",
+      description: "",
+      actions: [
+        {
+          id: "a",
+          name: "a",
+          trigger: "submit",
+          steps: [
+            {
+              id: "s",
+              type: "externalSystem",
+              description: "",
+              systemName: "Legacy",
+            },
+          ],
+        },
+      ],
+      createdAt: "",
+      updatedAt: "",
+    };
+    const migrated = migrateActionGroup(raw) as ActionGroup;
+    const step = migrated.actions[0].steps[0] as ExternalSystemStep;
+    expect(step.systemName).toBe("Legacy");
+    expect(step.outcomes).toBeUndefined();
+    expect(step.timeoutMs).toBeUndefined();
+  });
+});

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -189,10 +189,50 @@ export interface DbAccessStep extends StepBase {
   fields?: string;
 }
 
+// ── 外部システム呼出の outcome / タイムアウト / リトライ (docs/spec, #151 (B)) ──
+
+/** 外部呼出の結果種別。product-scope §11 の 3 値を型化 */
+export type ExternalCallOutcome = "success" | "failure" | "timeout";
+
+export const EXTERNAL_CALL_OUTCOME_VALUES: readonly ExternalCallOutcome[] =
+  ["success", "failure", "timeout"] as const;
+
+/** outcome ごとのハンドリング定義 */
+export interface ExternalCallOutcomeSpec {
+  /**
+   * - "continue": 次ステップへ続行 (fire-and-forget で failure/timeout 時の既定)
+   * - "abort": 処理中断 (HTTP エラーレスポンス等)
+   * - "compensate": Saga 補償 (別途 compensatesFor などで指定する想定)
+   */
+  action: "continue" | "abort" | "compensate";
+  /** 補足説明 (任意、エラーメッセージ文面のヒント等) */
+  description?: string;
+  /** abort 時のジャンプ先ラベル (任意) */
+  jumpTo?: string;
+}
+
+/** 外部呼出のリトライ方針 */
+export interface RetryPolicy {
+  maxAttempts: number;
+  backoff?: "fixed" | "exponential";
+  initialDelayMs?: number;
+}
+
 export interface ExternalSystemStep extends StepBase {
   type: "externalSystem";
   systemName: string;
   protocol?: string;
+  /**
+   * 各 outcome (success / failure / timeout) のハンドリング定義。
+   * 省略時は product-scope §11 の既定 (failure/timeout=abort、success=continue) を適用。
+   */
+  outcomes?: Partial<Record<ExternalCallOutcome, ExternalCallOutcomeSpec>>;
+  /** タイムアウト (ミリ秒)。未指定は product-scope §11 の既定 10000 */
+  timeoutMs?: number;
+  /** リトライ方針。未指定は「リトライなし」 */
+  retryPolicy?: RetryPolicy;
+  /** true なら TX 後・非同期 fire-and-forget。同期レスポンスを待たない */
+  fireAndForget?: boolean;
 }
 
 export interface CommonProcessStep extends StepBase {


### PR DESCRIPTION
## Summary

- #151 (B) スキーマ拡張の第 1 弾
- 外部システム呼出の結果ハンドリングを構造化フィールドで表現
- 264 ユニットテストパス、ビルド成功、視覚影響なし (型追加のみ)

## 追加型

- `ExternalCallOutcome` = `"success" | "failure" | "timeout"`
- `ExternalCallOutcomeSpec` ({action: 'continue'|'abort'|'compensate', description?, jumpTo?})
- `RetryPolicy` ({maxAttempts, backoff?, initialDelayMs?})

## ExternalSystemStep 拡張 (すべて optional)

- `outcomes?: Partial<Record<ExternalCallOutcome, ExternalCallOutcomeSpec>>`
- `timeoutMs?: number`
- `retryPolicy?: RetryPolicy`
- `fireAndForget?: boolean`

## Test plan

- [x] `npm run test:unit` — 21 files / 264 tests (新規 7 件追加)
- [x] `npm run build` — 成功
- [x] 既存 ExternalSystemStep の旧データ破壊なし
- [x] マイグレーション冪等性維持

## 関連

- Closes #158
- Refs #151 (B), #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)