### PR TITLE
feat(types): ActionDefinition に httpRoute / responses[] を追加 (#160)

### DIFF
--- a/designer/src/types/action.httpRoute.test.ts
+++ b/designer/src/types/action.httpRoute.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import type { ActionDefinition, ActionGroup, HttpRoute, HttpResponseSpec } from "./action";
+import { migrateActionGroup } from "../utils/actionMigration";
+
+describe("ActionDefinition の httpRoute / responses (#160)", () => {
+  it("httpRoute を保持できる", () => {
+    const route: HttpRoute = { method: "POST", path: "/api/customers", auth: "none" };
+    const action: ActionDefinition = {
+      id: "a1",
+      name: "登録",
+      trigger: "submit",
+      httpRoute: route,
+      steps: [],
+    };
+    expect(action.httpRoute?.method).toBe("POST");
+    expect(action.httpRoute?.path).toBe("/api/customers");
+    expect(action.httpRoute?.auth).toBe("none");
+  });
+
+  it("responses[] を保持できる (成功 + エラー複数)", () => {
+    const responses: HttpResponseSpec[] = [
+      { status: 201, contentType: "application/json", bodySchema: "CustomerRegisterResponse", description: "登録成功" },
+      { status: 400, bodySchema: "ApiError", description: "バリデーションエラー", when: "fieldErrors 有" },
+      { status: 409, bodySchema: "ApiError", description: "メール重複", when: "@duplicateCustomer != null" },
+    ];
+    const action: ActionDefinition = {
+      id: "a2",
+      name: "登録",
+      trigger: "submit",
+      responses,
+      steps: [],
+    };
+    expect(action.responses).toHaveLength(3);
+    expect(action.responses![0].status).toBe(201);
+    expect(action.responses![1].status).toBe(400);
+    expect(action.responses![2].when).toBe("@duplicateCustomer != null");
+  });
+
+  it("httpRoute / responses は省略可能", () => {
+    const action: ActionDefinition = {
+      id: "a3",
+      name: "x",
+      trigger: "click",
+      steps: [],
+    };
+    expect(action.httpRoute).toBeUndefined();
+    expect(action.responses).toBeUndefined();
+  });
+
+  it("auth 省略時も型上は許容 (既定 'required' を値として書かなくて良い)", () => {
+    const route: HttpRoute = { method: "GET", path: "/api/orders" };
+    expect(route.auth).toBeUndefined();
+  });
+});
+
+describe("migrateActionGroup — httpRoute / responses 透過保持 (#160)", () => {
+  it("新フィールドを持つ action を冪等にマイグレーションできる", () => {
+    const raw = {
+      id: "g",
+      name: "x",
+      type: "screen",
+      description: "",
+      actions: [
+        {
+          id: "a",
+          name: "a",
+          trigger: "submit",
+          httpRoute: { method: "POST", path: "/api/x", auth: "required" },
+          responses: [
+            { status: 201, bodySchema: "R" },
+            { status: 400, description: "VALIDATION" },
+          ],
+          steps: [],
+        },
+      ],
+      createdAt: "",
+      updatedAt: "",
+    };
+    const once = migrateActionGroup(raw) as ActionGroup;
+    const twice = migrateActionGroup(once);
+    expect(JSON.stringify(twice)).toBe(JSON.stringify(once));
+
+    const action = once.actions[0];
+    expect(action.httpRoute?.method).toBe("POST");
+    expect(action.responses).toHaveLength(2);
+    expect(action.responses?.[0].status).toBe(201);
+  });
+
+  it("新フィールドなしの旧データでも破壊されない", () => {
+    const raw = {
+      id: "g",
+      name: "x",
+      type: "screen",
+      description: "",
+      actions: [{ id: "a", name: "a", trigger: "click", steps: [] }],
+      createdAt: "",
+      updatedAt: "",
+    };
+    const migrated = migrateActionGroup(raw) as ActionGroup;
+    expect(migrated.actions[0].httpRoute).toBeUndefined();
+    expect(migrated.actions[0].responses).toBeUndefined();
+  });
+});

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -363,6 +363,39 @@ export interface StructuredField {
 /** inputs / outputs の値型: 旧形式 (改行区切り文字列) と新形式 (StructuredField[]) の union */
 export type ActionFields = string | StructuredField[];
 
+// ── HTTP 契約 (docs/spec, #151 (B)) ─────────────────────────────────────
+
+export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+/** 認証要件。product-scope §6 参照 */
+export type HttpAuthRequirement = "required" | "optional" | "none";
+
+/** アクションが HTTP ハンドラの場合のルート定義 */
+export interface HttpRoute {
+  method: HttpMethod;
+  /** 例: "/api/customers" または "/api/customers/:id" */
+  path: string;
+  /** 認証要件。省略時は "required" として解釈 (product-scope §6 既定) */
+  auth?: HttpAuthRequirement;
+}
+
+/** HTTP レスポンス仕様 (成功/エラーの各ケース) */
+export interface HttpResponseSpec {
+  /** 数値 HTTP ステータス (例: 201, 400, 404) */
+  status: number;
+  /** MIME タイプ。未指定は "application/json" として解釈 */
+  contentType?: string;
+  /**
+   * レスポンスボディのスキーマ参照 (自由記述)。
+   * 例: "CustomerRegisterResponse" / "ApiError" / "{ code: string, fieldErrors: Record<string,string> }"
+   */
+  bodySchema?: string;
+  /** 説明 (発生条件、UI 文言のヒント等) */
+  description?: string;
+  /** 発生条件 (自由記述、例: "@duplicateCustomer != null") */
+  when?: string;
+}
+
 export interface ActionDefinition {
   id: string;
   name: string;
@@ -380,6 +413,16 @@ export interface ActionDefinition {
   outputs?: ActionFields;
   /** 成熟度。未指定は "draft" として解釈 */
   maturity?: Maturity;
+  /**
+   * HTTP ルート定義 (アクションが HTTP ハンドラの場合)。未指定は「非 HTTP」として解釈。
+   * docs/spec #151 (B)
+   */
+  httpRoute?: HttpRoute;
+  /**
+   * HTTP レスポンス仕様の配列。success / 各エラーケースをまとめて列挙。
+   * docs/spec #151 (B)
+   */
+  responses?: HttpResponseSpec[];
   steps: Step[];
 }
 


### PR DESCRIPTION
## Summary

- #151 (B) スキーマ拡張の第 2 弾
- HTTP 契約を構造化フィールドで表現
- 270 ユニットテストパス、視覚影響なし

## 追加型

- `HttpMethod` / `HttpAuthRequirement`
- `HttpRoute` ({method, path, auth?})
- `HttpResponseSpec` ({status, contentType?, bodySchema?, description?, when?})
- `ActionDefinition.httpRoute?` / `ActionDefinition.responses?`

## Test plan

- [x] 270 tests pass (新規 6)
- [x] Build OK
- [x] 既存データ破壊なし

## 関連

- Closes #160
- Refs #151 (B), #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)