### PR TITLE
feat(types): StepBase に txBoundary / transactional / compensatesFor / externalChain を追加 (#162)

### DIFF
--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -152,6 +152,28 @@ export interface StepNote {
 /** アクショングループのモード (docs/spec/process-flow-maturity.md §5) */
 export type ActionGroupMode = "upstream" | "downstream";
 
+// ── TX 境界 / Saga / 外部チェーン (docs/spec, #151 (B)) ─────────────────────
+
+/** TX 境界におけるステップの役割 */
+export type TxBoundaryRole = "begin" | "member" | "end";
+
+/** トランザクション境界。同一 txId を持つステップ群が単一 TX 内で実行される想定 */
+export interface TxBoundary {
+  role: TxBoundaryRole;
+  /** TX 識別子。同一アクション内で一意 */
+  txId: string;
+}
+
+/** 外部呼出チェーンのフェーズ (例: Stripe の authorize → capture → cancel) */
+export type ExternalChainPhase = "authorize" | "capture" | "cancel" | "other";
+
+/** 同一外部リソースを参照する複数ステップを束ねる識別子 */
+export interface ExternalChain {
+  /** chain 識別子。同一アクション内で一意 */
+  chainId: string;
+  phase: ExternalChainPhase;
+}
+
 /** ステップ共通フィールド */
 export interface StepBase {
   id: string;
@@ -168,6 +190,23 @@ export interface StepBase {
    * docs/spec/process-flow-variables.md §3.2
    */
   outputBinding?: string;
+  /**
+   * トランザクション境界。同一 txId を持つステップ群が単一 TX 内で実行される。
+   * docs/spec, #151 (B)
+   */
+  txBoundary?: TxBoundary;
+  /** 簡易フラグ: TX 内であることだけ示唆 (txId 管理不要な場合) */
+  transactional?: boolean;
+  /**
+   * Saga 補償の逆参照。補償対象のステップ ID を指す (例: authorize ステップの ID)。
+   * 主に cancel / reversal ステップに付ける。
+   */
+  compensatesFor?: string;
+  /**
+   * 外部呼出チェーン。同一 chainId を持つステップ群は同じ外部リソースを扱う。
+   * 例: Stripe の PaymentIntent に対する authorize → capture → cancel の 3 ステップ。
+   */
+  externalChain?: ExternalChain;
   subSteps?: Step[];
 }
 

--- a/designer/src/types/action.txSaga.test.ts
+++ b/designer/src/types/action.txSaga.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from "vitest";
+import type {
+  ActionGroup,
+  DbAccessStep,
+  ExternalSystemStep,
+  TxBoundary,
+  ExternalChain,
+} from "./action";
+import { migrateActionGroup } from "../utils/actionMigration";
+
+describe("StepBase の txBoundary / transactional / compensatesFor / externalChain (#162)", () => {
+  it("txBoundary を保持できる", () => {
+    const tx: TxBoundary = { role: "begin", txId: "tx-order" };
+    const step: DbAccessStep = {
+      id: "s",
+      type: "dbAccess",
+      description: "",
+      tableName: "orders",
+      operation: "INSERT",
+      txBoundary: tx,
+    };
+    expect(step.txBoundary?.role).toBe("begin");
+    expect(step.txBoundary?.txId).toBe("tx-order");
+  });
+
+  it("transactional 簡易フラグを保持できる", () => {
+    const step: DbAccessStep = {
+      id: "s",
+      type: "dbAccess",
+      description: "",
+      tableName: "x",
+      operation: "UPDATE",
+      transactional: true,
+    };
+    expect(step.transactional).toBe(true);
+  });
+
+  it("compensatesFor で別ステップ ID を指せる", () => {
+    const cancel: ExternalSystemStep = {
+      id: "step-cancel",
+      type: "externalSystem",
+      description: "Stripe 与信解放",
+      systemName: "Stripe",
+      compensatesFor: "step-authorize",
+    };
+    expect(cancel.compensatesFor).toBe("step-authorize");
+  });
+
+  it("externalChain で authorize/capture/cancel を同一 chainId で紐付けられる", () => {
+    const auth: ExternalSystemStep = {
+      id: "s-auth",
+      type: "externalSystem",
+      description: "",
+      systemName: "Stripe",
+      externalChain: { chainId: "stripe-pi-1", phase: "authorize" },
+    };
+    const capture: ExternalSystemStep = {
+      id: "s-cap",
+      type: "externalSystem",
+      description: "",
+      systemName: "Stripe",
+      externalChain: { chainId: "stripe-pi-1", phase: "capture" },
+    };
+    const cancel: ExternalSystemStep = {
+      id: "s-canc",
+      type: "externalSystem",
+      description: "",
+      systemName: "Stripe",
+      externalChain: { chainId: "stripe-pi-1", phase: "cancel" },
+    };
+    expect(auth.externalChain?.chainId).toBe("stripe-pi-1");
+    expect(capture.externalChain?.phase).toBe("capture");
+    expect(cancel.externalChain?.phase).toBe("cancel");
+  });
+
+  it("外部チェーンの phase='other' (将来拡張用) も許容", () => {
+    const chain: ExternalChain = { chainId: "x", phase: "other" };
+    expect(chain.phase).toBe("other");
+  });
+
+  it("すべて省略可能 (optional)", () => {
+    const step: DbAccessStep = {
+      id: "s",
+      type: "dbAccess",
+      description: "",
+      tableName: "x",
+      operation: "SELECT",
+    };
+    expect(step.txBoundary).toBeUndefined();
+    expect(step.transactional).toBeUndefined();
+    expect(step.compensatesFor).toBeUndefined();
+    expect(step.externalChain).toBeUndefined();
+  });
+});
+
+describe("migrateActionGroup — TX/Saga/externalChain 透過保持 (#162)", () => {
+  it("新フィールドを持つ複数ステップの冪等マイグレーション (TX chain + Saga)", () => {
+    const raw = {
+      id: "g",
+      name: "x",
+      type: "screen",
+      description: "",
+      actions: [
+        {
+          id: "a",
+          name: "注文確定",
+          trigger: "submit",
+          steps: [
+            {
+              id: "auth",
+              type: "externalSystem",
+              description: "決済 authorize",
+              systemName: "Stripe",
+              externalChain: { chainId: "pi-1", phase: "authorize" },
+            },
+            {
+              id: "ins-order",
+              type: "dbAccess",
+              description: "INSERT orders",
+              tableName: "orders",
+              operation: "INSERT",
+              txBoundary: { role: "begin", txId: "tx-main" },
+            },
+            {
+              id: "ins-items",
+              type: "dbAccess",
+              description: "INSERT order_items",
+              tableName: "order_items",
+              operation: "INSERT",
+              txBoundary: { role: "member", txId: "tx-main" },
+              transactional: true,
+            },
+            {
+              id: "upd-inv",
+              type: "dbAccess",
+              description: "在庫引当",
+              tableName: "inventory",
+              operation: "UPDATE",
+              txBoundary: { role: "end", txId: "tx-main" },
+            },
+            {
+              id: "cap",
+              type: "externalSystem",
+              description: "capture",
+              systemName: "Stripe",
+              externalChain: { chainId: "pi-1", phase: "capture" },
+            },
+            {
+              id: "cancel",
+              type: "externalSystem",
+              description: "TX 失敗時の補償",
+              systemName: "Stripe",
+              externalChain: { chainId: "pi-1", phase: "cancel" },
+              compensatesFor: "auth",
+            },
+          ],
+        },
+      ],
+      createdAt: "",
+      updatedAt: "",
+    };
+    const once = migrateActionGroup(raw) as ActionGroup;
+    const twice = migrateActionGroup(once);
+    expect(JSON.stringify(twice)).toBe(JSON.stringify(once));
+
+    const steps = once.actions[0].steps;
+    expect((steps[0] as ExternalSystemStep).externalChain?.phase).toBe("authorize");
+    expect((steps[1] as DbAccessStep).txBoundary?.role).toBe("begin");
+    expect((steps[2] as DbAccessStep).transactional).toBe(true);
+    expect((steps[5] as ExternalSystemStep).compensatesFor).toBe("auth");
+  });
+
+  it("新フィールドなしの旧データでも破壊なし", () => {
+    const raw = {
+      id: "g",
+      name: "x",
+      type: "screen",
+      description: "",
+      actions: [
+        {
+          id: "a",
+          name: "a",
+          trigger: "click",
+          steps: [
+            { id: "s", type: "dbAccess", description: "", tableName: "x", operation: "SELECT" },
+          ],
+        },
+      ],
+      createdAt: "",
+      updatedAt: "",
+    };
+    const migrated = migrateActionGroup(raw) as ActionGroup;
+    const step = migrated.actions[0].steps[0] as DbAccessStep;
+    expect(step.txBoundary).toBeUndefined();
+    expect(step.externalChain).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- #151 (B) スキーマ拡張の第 3 弾
- ステップ横断の概念 (TX 境界 / Saga 補償 / 外部呼出チェーン) を型化
- 278 ユニットテストパス、視覚影響なし

## 追加型

- `TxBoundary` ({role: begin|member|end, txId})
- `ExternalChain` ({chainId, phase: authorize|capture|cancel|other})

## StepBase 拡張 (すべて optional)

- `txBoundary?` — 単一 TX 内の複数ステップを束ねる
- `transactional?: boolean` — 簡易フラグ
- `compensatesFor?: string` — Saga 補償の逆参照
- `externalChain?` — authorize/capture/cancel の同一 chain 関係

## 関連

- Closes #162
- Refs #151 (B), #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)