### PR TITLE
feat(types): DbAccessStep に affectedRowsCheck を追加 (#164)

### DIFF
--- a/designer/src/types/action.affectedRows.test.ts
+++ b/designer/src/types/action.affectedRows.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import type { ActionGroup, AffectedRowsCheck, DbAccessStep } from "./action";
+import { migrateActionGroup } from "../utils/actionMigration";
+
+describe("DbAccessStep の affectedRowsCheck (#164)", () => {
+  it("在庫引当の条件付き UPDATE + throw パターンを表現できる", () => {
+    const check: AffectedRowsCheck = {
+      operator: ">",
+      expected: 0,
+      onViolation: "throw",
+      errorCode: "STOCK_SHORTAGE",
+      description: "在庫不足 (並行引当)",
+    };
+    const step: DbAccessStep = {
+      id: "s",
+      type: "dbAccess",
+      description: "在庫引当",
+      tableName: "inventory",
+      operation: "UPDATE",
+      fields: "SET stock = stock - @qty WHERE item_id = @id AND stock >= @qty",
+      affectedRowsCheck: check,
+    };
+    expect(step.affectedRowsCheck?.operator).toBe(">");
+    expect(step.affectedRowsCheck?.expected).toBe(0);
+    expect(step.affectedRowsCheck?.onViolation).toBe("throw");
+    expect(step.affectedRowsCheck?.errorCode).toBe("STOCK_SHORTAGE");
+  });
+
+  it("onViolation の 4 値 (throw / abort / log / continue) を許容", () => {
+    const patterns = (["throw", "abort", "log", "continue"] as const).map((v) => ({
+      operator: "=" as const,
+      expected: 1,
+      onViolation: v,
+    }));
+    patterns.forEach((p) => {
+      const step: DbAccessStep = {
+        id: "s", type: "dbAccess", description: "",
+        tableName: "x", operation: "DELETE",
+        affectedRowsCheck: p,
+      };
+      expect(step.affectedRowsCheck?.onViolation).toBe(p.onViolation);
+    });
+  });
+
+  it("operator の 5 値 (>, >=, =, <, <=) を許容", () => {
+    const ops: AffectedRowsCheck["operator"][] = [">", ">=", "=", "<", "<="];
+    ops.forEach((op) => {
+      const step: DbAccessStep = {
+        id: "s", type: "dbAccess", description: "",
+        tableName: "x", operation: "UPDATE",
+        affectedRowsCheck: { operator: op, expected: 1, onViolation: "throw" },
+      };
+      expect(step.affectedRowsCheck?.operator).toBe(op);
+    });
+  });
+
+  it("省略可能 (既存データ互換)", () => {
+    const step: DbAccessStep = {
+      id: "s", type: "dbAccess", description: "",
+      tableName: "x", operation: "SELECT",
+    };
+    expect(step.affectedRowsCheck).toBeUndefined();
+  });
+});
+
+describe("migrateActionGroup — affectedRowsCheck 透過保持 (#164)", () => {
+  it("新フィールドを持つ DbAccessStep を冪等にマイグレーションできる", () => {
+    const raw = {
+      id: "g", name: "x", type: "screen", description: "",
+      actions: [{
+        id: "a", name: "a", trigger: "submit",
+        steps: [{
+          id: "s", type: "dbAccess", description: "",
+          tableName: "inventory", operation: "UPDATE",
+          fields: "SET stock = stock - @q WHERE stock >= @q",
+          affectedRowsCheck: {
+            operator: ">", expected: 0,
+            onViolation: "throw", errorCode: "STOCK_SHORTAGE",
+          },
+        }],
+      }],
+      createdAt: "", updatedAt: "",
+    };
+    const once = migrateActionGroup(raw) as ActionGroup;
+    const twice = migrateActionGroup(once);
+    expect(JSON.stringify(twice)).toBe(JSON.stringify(once));
+    const step = once.actions[0].steps[0] as DbAccessStep;
+    expect(step.affectedRowsCheck?.errorCode).toBe("STOCK_SHORTAGE");
+  });
+
+  it("新フィールドなしの旧データでも破壊なし", () => {
+    const raw = {
+      id: "g", name: "x", type: "screen", description: "",
+      actions: [{
+        id: "a", name: "a", trigger: "click",
+        steps: [{ id: "s", type: "dbAccess", description: "", tableName: "x", operation: "SELECT" }],
+      }],
+      createdAt: "", updatedAt: "",
+    };
+    const migrated = migrateActionGroup(raw) as ActionGroup;
+    const step = migrated.actions[0].steps[0] as DbAccessStep;
+    expect(step.affectedRowsCheck).toBeUndefined();
+  });
+});

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -220,12 +220,42 @@ export interface ValidationStep extends StepBase {
   };
 }
 
+// ── 条件付き UPDATE + 影響行数チェック (docs/spec, #151 (B)) ────────────────
+
+export type AffectedRowsOperator = ">" | ">=" | "=" | "<" | "<=";
+
+/**
+ * 影響行数チェック。条件付き UPDATE (WHERE 条件で並行制御するパターン) の結果検証用。
+ * 典型例: 在庫引当の "UPDATE inventory SET stock = stock - @qty WHERE stock >= @qty" で、
+ * rowCount === 0 なら並行競合による在庫不足として throw する。
+ */
+export interface AffectedRowsCheck {
+  operator: AffectedRowsOperator;
+  expected: number;
+  /**
+   * 違反時の挙動:
+   * - "throw": 例外を投げて TX ROLLBACK (errorCode で識別)
+   * - "abort": アクション中断 (HTTP エラーレスポンス等)
+   * - "log": ログ記録のみ、処理続行
+   * - "continue": 黙って続行 (明示的に無視する場合)
+   */
+  onViolation: "throw" | "abort" | "log" | "continue";
+  /** throw / abort 時のエラー識別子 (例: "STOCK_SHORTAGE") */
+  errorCode?: string;
+  description?: string;
+}
+
 export interface DbAccessStep extends StepBase {
   type: "dbAccess";
   tableName: string;
   tableId?: string;
   operation: DbOperation;
   fields?: string;
+  /**
+   * 影響行数チェック。UPDATE / DELETE で条件付き並行制御する場合に使う。
+   * SELECT / INSERT では通常不要。
+   */
+  affectedRowsCheck?: AffectedRowsCheck;
 }
 
 // ── 外部システム呼出の outcome / タイムアウト / リトライ (docs/spec, #151 (B)) ──


### PR DESCRIPTION
## Summary

- #151 (B) スキーマ拡張の第 4 弾
- 条件付き UPDATE の並行制御パターンを型化
- 284 ユニットテストパス、視覚影響なし

## 追加型

- `AffectedRowsOperator` = `">" | ">=" | "=" | "<" | "<="`
- `AffectedRowsCheck` ({operator, expected, onViolation: throw|abort|log|continue, errorCode?, description?})
- `DbAccessStep.affectedRowsCheck?`

## 用途例

在庫引当の条件付き UPDATE + throw パターンをフォーマットで表現可能に (dogfood 5 で note の assumption 埋没していた内容)。

## 関連

- Closes #164
- Refs #151 (B), #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)