### PR TITLE
feat(types): ValidationStep に rules[] (構造化バリデーション) を追加 (#166)

### DIFF
--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -210,9 +210,53 @@ export interface StepBase {
   subSteps?: Step[];
 }
 
+// ── 構造化バリデーション (docs/spec, #151 (B)) ─────────────────────────────
+
+export type ValidationRuleType =
+  | "required"    // 非空必須
+  | "regex"       // 正規表現マッチ
+  | "maxLength"   // 最大文字数
+  | "minLength"   // 最小文字数
+  | "range"       // 数値範囲
+  | "enum"        // 許容値セット
+  | "custom";     // 自由記述
+
+/**
+ * 1 件のバリデーションルール。同一 field に複数ルールを付けられる (配列の順で適用)。
+ * message は直接文字列か @conv.msg.* 参照を想定。
+ */
+export interface ValidationRule {
+  /** 検証対象フィールド名 (inputs[].name を参照) */
+  field: string;
+  type: ValidationRuleType;
+  /** type="regex" 時のパターン (生 regex or @conv.regex.* 参照) */
+  pattern?: string;
+  /** type="maxLength" / "minLength" 時の文字数 */
+  length?: number;
+  /** type="range" 時の最小値 */
+  min?: number;
+  /** type="range" 時の最大値 */
+  max?: number;
+  /** type="enum" 時の許容値リスト */
+  values?: string[];
+  /** type="custom" 時の自由記述条件 (例: "@items.length >= 1") */
+  condition?: string;
+  /** エラーメッセージ (直接文字列 or @conv.msg.* 参照) */
+  message?: string;
+}
+
 export interface ValidationStep extends StepBase {
   type: "validation";
+  /**
+   * 自由記述のバリデーション条件 (後方互換、人間可読の補足として残す)。
+   * 構造化済なら rules[] を優先。
+   */
   conditions: string;
+  /**
+   * 構造化バリデーションルール。AI / UI はこちらを機械可読な一次情報として使う。
+   * 未指定時は conditions の自由記述を読むしかない (後方互換)。
+   */
+  rules?: ValidationRule[];
   inlineBranch?: {
     ok: string;
     ng: string;

--- a/designer/src/types/action.validationRules.test.ts
+++ b/designer/src/types/action.validationRules.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import type { ActionGroup, ValidationRule, ValidationStep } from "./action";
+import { migrateActionGroup } from "../utils/actionMigration";
+
+describe("ValidationStep の rules[] (#166)", () => {
+  it("required / regex / maxLength を同一ステップで定義できる", () => {
+    const rules: ValidationRule[] = [
+      { field: "email", type: "required", message: "@conv.msg.required" },
+      { field: "email", type: "regex", pattern: "@conv.regex.email-simple", message: "@conv.msg.invalidFormat" },
+      { field: "email", type: "maxLength", length: 255, message: "@conv.msg.maxLength" },
+      { field: "phone", type: "required" },
+      { field: "phone", type: "regex", pattern: "@conv.regex.phone-jp" },
+    ];
+    const step: ValidationStep = {
+      id: "s", type: "validation", description: "",
+      conditions: "emailとphoneの検証",
+      rules,
+    };
+    expect(step.rules).toHaveLength(5);
+    expect(step.rules![0]).toEqual({ field: "email", type: "required", message: "@conv.msg.required" });
+    expect(step.rules![1].pattern).toBe("@conv.regex.email-simple");
+    expect(step.rules![2].length).toBe(255);
+  });
+
+  it("range / enum / custom の各ルールタイプを表現できる", () => {
+    const rules: ValidationRule[] = [
+      { field: "quantity", type: "range", min: 1, max: 9999, message: "@conv.msg.outOfRange" },
+      { field: "paymentMethod", type: "enum", values: ["credit_card", "bank_transfer", "cash_on_delivery"] },
+      { field: "items", type: "custom", condition: "@items.length >= 1", message: "明細は1件以上必要です" },
+    ];
+    expect(rules[0].min).toBe(1);
+    expect(rules[0].max).toBe(9999);
+    expect(rules[1].values).toContain("credit_card");
+    expect(rules[2].condition).toBe("@items.length >= 1");
+  });
+
+  it("conditions と rules[] は併用可能 (後方互換)", () => {
+    const step: ValidationStep = {
+      id: "s", type: "validation", description: "",
+      conditions: "人間可読の自由記述",
+      rules: [{ field: "x", type: "required" }],
+    };
+    expect(step.conditions).toBe("人間可読の自由記述");
+    expect(step.rules).toHaveLength(1);
+  });
+
+  it("rules[] 省略時は conditions のみ (旧データ互換)", () => {
+    const step: ValidationStep = {
+      id: "s", type: "validation", description: "",
+      conditions: "既存の自由記述のみ",
+    };
+    expect(step.rules).toBeUndefined();
+  });
+
+  it("inlineBranch と併用できる", () => {
+    const step: ValidationStep = {
+      id: "s", type: "validation", description: "",
+      conditions: "",
+      rules: [{ field: "a", type: "required" }],
+      inlineBranch: { ok: "続行", ng: "エラー表示" },
+    };
+    expect(step.inlineBranch?.ok).toBe("続行");
+    expect(step.rules).toHaveLength(1);
+  });
+});
+
+describe("migrateActionGroup — ValidationStep.rules[] 透過保持 (#166)", () => {
+  it("rules[] を持つ ValidationStep を冪等にマイグレーションできる", () => {
+    const raw = {
+      id: "g", name: "x", type: "screen", description: "",
+      actions: [{
+        id: "a", name: "a", trigger: "submit",
+        steps: [{
+          id: "s", type: "validation", description: "",
+          conditions: "旧 conditions",
+          rules: [
+            { field: "email", type: "required" },
+            { field: "email", type: "regex", pattern: "@conv.regex.email-simple" },
+          ],
+          inlineBranch: { ok: "ok", ng: "ng" },
+        }],
+      }],
+      createdAt: "", updatedAt: "",
+    };
+    const once = migrateActionGroup(raw) as ActionGroup;
+    const twice = migrateActionGroup(once);
+    expect(JSON.stringify(twice)).toBe(JSON.stringify(once));
+    const step = once.actions[0].steps[0] as ValidationStep;
+    expect(step.rules).toHaveLength(2);
+    expect(step.rules?.[1].pattern).toBe("@conv.regex.email-simple");
+    expect(step.conditions).toBe("旧 conditions");
+  });
+
+  it("rules[] なしの旧 ValidationStep でも破壊なし", () => {
+    const raw = {
+      id: "g", name: "x", type: "screen", description: "",
+      actions: [{
+        id: "a", name: "a", trigger: "submit",
+        steps: [{
+          id: "s", type: "validation", description: "",
+          conditions: "旧",
+          inlineBranch: { ok: "o", ng: "n" },
+        }],
+      }],
+      createdAt: "", updatedAt: "",
+    };
+    const migrated = migrateActionGroup(raw) as ActionGroup;
+    const step = migrated.actions[0].steps[0] as ValidationStep;
+    expect(step.rules).toBeUndefined();
+    expect(step.conditions).toBe("旧");
+  });
+});


### PR DESCRIPTION
## Summary

- #151 (B) スキーマ拡張の第 5 弾
- バリデーションを構造化ルール配列で表現
- 291 ユニットテストパス、視覚影響なし

## 追加型

- `ValidationRuleType` (7 値: required/regex/maxLength/minLength/range/enum/custom)
- `ValidationRule` ({field, type, pattern?, length?, min?, max?, values?, condition?, message?})
- `ValidationStep.rules?` 追加 (conditions は後方互換で維持)

## 関連

- Closes #166
- Refs #151 (B), #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)