### PR TITLE
feat(types): outputBinding を構造化 (operation: assign/accumulate/push) (#168)

### DIFF
--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -152,6 +152,29 @@ export interface StepNote {
 /** アクショングループのモード (docs/spec/process-flow-maturity.md §5) */
 export type ActionGroupMode = "upstream" | "downstream";
 
+// ── outputBinding の構造化 (docs/spec, #151 (B)) ──────────────────────────
+
+/**
+ * outputBinding の代入方式。
+ * - "assign": 新規代入 / 上書き (既定)
+ * - "accumulate": 数値加算 (subtotal += ... のような累積)
+ * - "push": 配列への要素追加 (shortageList.push(...) / enrichedItems.push(...))
+ */
+export type OutputBindingOperation = "assign" | "accumulate" | "push";
+
+/** 構造化版 outputBinding */
+export interface OutputBindingObject {
+  name: string;
+  /** 既定は "assign" */
+  operation?: OutputBindingOperation;
+}
+
+/**
+ * outputBinding の値型: 旧 string (assign 相当) と新 OutputBindingObject の union。
+ * ヘルパー getBindingName / getBindingOperation を使うと透過的に扱える。
+ */
+export type OutputBinding = string | OutputBindingObject;
+
 // ── TX 境界 / Saga / 外部チェーン (docs/spec, #151 (B)) ─────────────────────
 
 /** TX 境界におけるステップの役割 */
@@ -186,10 +209,11 @@ export interface StepBase {
   /** 成熟度。未指定は "draft" として解釈 */
   maturity?: Maturity;
   /**
-   * ステップの結果を保持する変数名。後続ステップは @変数名 で参照する。
-   * docs/spec/process-flow-variables.md §3.2
+   * ステップの結果を保持する変数。後続ステップは @変数名 で参照する。
+   * 旧形式 (string) は assign 相当、新形式 (object) は operation で代入方式を指定可能。
+   * docs/spec/process-flow-variables.md §3.2, #151 (B)
    */
-  outputBinding?: string;
+  outputBinding?: OutputBinding;
   /**
    * トランザクション境界。同一 txId を持つステップ群が単一 TX 内で実行される。
    * docs/spec, #151 (B)

--- a/designer/src/utils/outputBinding.test.ts
+++ b/designer/src/utils/outputBinding.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import type { OutputBinding } from "../types/action";
+import {
+  getBindingName,
+  getBindingOperation,
+  isStructuredBinding,
+} from "./outputBinding";
+
+describe("getBindingName", () => {
+  it("string 形式はそのまま返す", () => {
+    expect(getBindingName("duplicates")).toBe("duplicates");
+  });
+
+  it("object 形式は .name を返す", () => {
+    expect(getBindingName({ name: "shortageList", operation: "push" })).toBe("shortageList");
+  });
+
+  it("undefined は undefined", () => {
+    expect(getBindingName(undefined)).toBeUndefined();
+  });
+
+  it("空白のみは undefined として扱う", () => {
+    expect(getBindingName("   ")).toBeUndefined();
+    expect(getBindingName({ name: "  ", operation: "assign" })).toBeUndefined();
+  });
+});
+
+describe("getBindingOperation", () => {
+  it("string 形式は 'assign' 既定", () => {
+    expect(getBindingOperation("users")).toBe("assign");
+  });
+
+  it("object 形式で operation 未指定は 'assign'", () => {
+    expect(getBindingOperation({ name: "x" })).toBe("assign");
+  });
+
+  it("object 形式で operation 明示時はその値", () => {
+    expect(getBindingOperation({ name: "subtotal", operation: "accumulate" })).toBe("accumulate");
+    expect(getBindingOperation({ name: "list", operation: "push" })).toBe("push");
+  });
+
+  it("undefined は 'assign'", () => {
+    expect(getBindingOperation(undefined)).toBe("assign");
+  });
+});
+
+describe("isStructuredBinding", () => {
+  it("string は false", () => {
+    expect(isStructuredBinding("users")).toBe(false);
+  });
+
+  it("object は true", () => {
+    expect(isStructuredBinding({ name: "x" })).toBe(true);
+  });
+
+  it("undefined は false", () => {
+    expect(isStructuredBinding(undefined)).toBe(false);
+  });
+});
+
+describe("OutputBinding union の運用パターン", () => {
+  it("typical accumulation: 小計の累積", () => {
+    const binding: OutputBinding = { name: "subtotal", operation: "accumulate" };
+    expect(getBindingName(binding)).toBe("subtotal");
+    expect(getBindingOperation(binding)).toBe("accumulate");
+  });
+
+  it("typical push: 配列の要素追加", () => {
+    const binding: OutputBinding = { name: "enrichedItems", operation: "push" };
+    expect(getBindingName(binding)).toBe("enrichedItems");
+    expect(getBindingOperation(binding)).toBe("push");
+  });
+
+  it("typical assign: 単純代入 (string 形式で十分)", () => {
+    const binding: OutputBinding = "authResult";
+    expect(getBindingName(binding)).toBe("authResult");
+    expect(getBindingOperation(binding)).toBe("assign");
+  });
+});

--- a/designer/src/utils/outputBinding.ts
+++ b/designer/src/utils/outputBinding.ts
@@ -1,0 +1,30 @@
+/**
+ * outputBinding.ts
+ * StepBase.outputBinding の union (string | OutputBindingObject) を透過的に扱うヘルパー。
+ *
+ * docs/spec, #151 (B)
+ */
+import type { OutputBinding, OutputBindingOperation } from "../types/action";
+
+/** outputBinding の変数名を取得 (string 形式はそのまま、object 形式は .name) */
+export function getBindingName(ob: OutputBinding | undefined): string | undefined {
+  if (ob == null) return undefined;
+  if (typeof ob === "string") return ob.trim() || undefined;
+  return ob.name.trim() || undefined;
+}
+
+/** outputBinding の代入方式を取得 (未指定や string 形式は "assign" 既定) */
+export function getBindingOperation(
+  ob: OutputBinding | undefined,
+): OutputBindingOperation {
+  if (ob == null) return "assign";
+  if (typeof ob === "string") return "assign";
+  return ob.operation ?? "assign";
+}
+
+/** 型ガード: object 形式か */
+export function isStructuredBinding(
+  ob: OutputBinding | undefined,
+): ob is Exclude<OutputBinding, string> {
+  return ob != null && typeof ob === "object";
+}


### PR DESCRIPTION
## Summary

- #151 (B) スキーマ拡張の第 6 弾
- outputBinding を `string | {name, operation?}` union に拡張
- 305 ユニットテストパス、視覚影響なし

## 追加型・ヘルパー

- `OutputBindingOperation` = `"assign" | "accumulate" | "push"`
- `OutputBindingObject` ({name, operation?})
- `OutputBinding` = `string | OutputBindingObject`
- `StepBase.outputBinding` を `OutputBinding` に拡張 (旧 string 互換)
- `designer/src/utils/outputBinding.ts` ヘルパー新規 (getBindingName / getBindingOperation / isStructuredBinding)

## 用途

- `{ name: "subtotal", operation: "accumulate" }` — 累積 (ループ内 sum)
- `{ name: "enrichedItems", operation: "push" }` — 配列追加 (ループ内 collect)
- `"authResult"` (string) — 単純代入 (assign 既定)

## 関連

- Closes #168
- Refs #151 (B), #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)