### PR TITLE
feat(types): DbAccessStep に sql フィールドを追加 (#170)

### DIFF
--- a/designer/src/types/action.dbSql.test.ts
+++ b/designer/src/types/action.dbSql.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import type { ActionGroup, DbAccessStep } from "./action";
+import { migrateActionGroup } from "../utils/actionMigration";
+
+describe("DbAccessStep の sql フィールド (#170)", () => {
+  it("sql に完全な SELECT 文を保持できる", () => {
+    const step: DbAccessStep = {
+      id: "s1",
+      type: "dbAccess",
+      description: "JOIN つき検索",
+      tableName: "orders",
+      operation: "SELECT",
+      sql: "SELECT o.id, o.order_number, c.name FROM orders o JOIN customers c ON c.id = o.customer_id WHERE o.order_date BETWEEN @from AND @to",
+    };
+    expect(step.sql).toContain("JOIN customers");
+  });
+
+  it("sql に INSERT ... RETURNING を保持できる", () => {
+    const step: DbAccessStep = {
+      id: "s2",
+      type: "dbAccess",
+      description: "注文ヘッダ登録",
+      tableName: "orders",
+      operation: "INSERT",
+      sql: "INSERT INTO orders (customer_id, subtotal, total_amount) VALUES (@customerId, @subtotal, @total) RETURNING id, order_number",
+    };
+    expect(step.sql).toContain("RETURNING");
+  });
+
+  it("sql と fields は併用可能 (sql が優先する運用規約)", () => {
+    const step: DbAccessStep = {
+      id: "s3",
+      type: "dbAccess",
+      description: "",
+      tableName: "customers",
+      operation: "SELECT",
+      sql: "SELECT id FROM customers WHERE email = @email AND is_deleted = false LIMIT 1",
+      fields: "id (email で検索)",
+    };
+    expect(step.sql).toBeTruthy();
+    expect(step.fields).toBeTruthy();
+  });
+
+  it("sql なしの旧データも引き続き動作 (fields + operation のみ)", () => {
+    const step: DbAccessStep = {
+      id: "s4",
+      type: "dbAccess",
+      description: "",
+      tableName: "customers",
+      operation: "SELECT",
+      fields: "name, email",
+    };
+    expect(step.sql).toBeUndefined();
+    expect(step.fields).toBe("name, email");
+  });
+});
+
+describe("migrateActionGroup — dbAccess.sql 透過保持 (#170)", () => {
+  it("sql を持つ DbAccessStep を冪等マイグレーションできる", () => {
+    const raw = {
+      id: "g", name: "x", type: "screen", description: "",
+      actions: [{
+        id: "a", name: "a", trigger: "submit",
+        steps: [{
+          id: "s", type: "dbAccess", description: "",
+          tableName: "customers", operation: "INSERT",
+          sql: "INSERT INTO customers (name) VALUES (@name) RETURNING id",
+        }],
+      }],
+      createdAt: "", updatedAt: "",
+    };
+    const once = migrateActionGroup(raw) as ActionGroup;
+    const twice = migrateActionGroup(once);
+    expect(JSON.stringify(twice)).toBe(JSON.stringify(once));
+    const step = once.actions[0].steps[0] as DbAccessStep;
+    expect(step.sql).toContain("RETURNING id");
+  });
+
+  it("sql なしの旧データは破壊なし", () => {
+    const raw = {
+      id: "g", name: "x", type: "screen", description: "",
+      actions: [{
+        id: "a", name: "a", trigger: "click",
+        steps: [{ id: "s", type: "dbAccess", description: "", tableName: "x", operation: "SELECT", fields: "col1, col2" }],
+      }],
+      createdAt: "", updatedAt: "",
+    };
+    const migrated = migrateActionGroup(raw) as ActionGroup;
+    const step = migrated.actions[0].steps[0] as DbAccessStep;
+    expect(step.sql).toBeUndefined();
+    expect(step.fields).toBe("col1, col2");
+  });
+});

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -318,7 +318,17 @@ export interface DbAccessStep extends StepBase {
   tableName: string;
   tableId?: string;
   operation: DbOperation;
+  /**
+   * 自由記述の列リスト / WHERE 補足 (後方互換)。
+   * 単純な INSERT/SELECT ではこちらで十分。複雑クエリは sql を使う。
+   */
   fields?: string;
+  /**
+   * 完全な SQL 文 (例: "SELECT ... FROM ... WHERE ...", "INSERT ... RETURNING ..." 等)。
+   * 指定時は fields / operation より優先。複雑クエリ (JOIN / CTE / サブクエリ / RETURNING 等) に使う。
+   * docs/spec #151 (B)
+   */
+  sql?: string;
   /**
    * 影響行数チェック。UPDATE / DELETE で条件付き並行制御する場合に使う。
    * SELECT / INSERT では通常不要。


### PR DESCRIPTION
## Summary

- #151 (B) スキーマ拡張の第 7 弾
- 完全な SQL 文 (JOIN / RETURNING / サブクエリ等) を sql フィールドに書ける
- 311 ユニットテストパス、視覚影響なし

## 追加

- `DbAccessStep.sql?: string` (fields 優先で併用可)

## 関連

- Closes #170
- Refs #151 (B), #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)