### PR TITLE
feat(types): ExternalCallOutcomeSpec に sideEffects / sameAs を追加 (#172)

### DIFF
--- a/designer/src/types/action.outcomeSideEffects.test.ts
+++ b/designer/src/types/action.outcomeSideEffects.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import type { ActionGroup, ExternalSystemStep, ExternalCallOutcomeSpec, Step } from "./action";
+import { migrateActionGroup } from "../utils/actionMigration";
+
+describe("ExternalCallOutcomeSpec の sideEffects (#172)", () => {
+  it("outcome.failure.sideEffects に副作用ステップ列を保持できる (capture 失敗時の例)", () => {
+    const failure: ExternalCallOutcomeSpec = {
+      action: "continue",
+      description: "同期レスポンスは 201 維持、後段で手動対応",
+      sideEffects: [
+        {
+          id: "se-1",
+          type: "dbAccess",
+          description: "orders.status を payment_failed に更新",
+          tableName: "orders",
+          operation: "UPDATE",
+          sql: "UPDATE orders SET status='payment_failed', updated_at=CURRENT_TIMESTAMP WHERE id = @registeredOrder.id",
+        } as Step,
+        {
+          id: "se-2",
+          type: "other",
+          description: "Sentry error 記録 + 運用通知チャネルに送信",
+        } as Step,
+      ],
+    };
+    expect(failure.sideEffects).toHaveLength(2);
+    expect(failure.sideEffects?.[0].type).toBe("dbAccess");
+    expect(failure.sideEffects?.[1].type).toBe("other");
+  });
+
+  it("sideEffects は空配列 / 省略どちらも許容", () => {
+    const spec1: ExternalCallOutcomeSpec = { action: "continue" };
+    const spec2: ExternalCallOutcomeSpec = { action: "abort", sideEffects: [] };
+    expect(spec1.sideEffects).toBeUndefined();
+    expect(spec2.sideEffects).toEqual([]);
+  });
+
+  it("sameAs で他 outcome の定義を流用できる (timeout=failure と同じ)", () => {
+    const step: ExternalSystemStep = {
+      id: "s",
+      type: "externalSystem",
+      description: "",
+      systemName: "X",
+      outcomes: {
+        success: { action: "continue" },
+        failure: { action: "abort", description: "失敗時は中断" },
+        timeout: { action: "abort", sameAs: "failure" },
+      },
+    };
+    expect(step.outcomes?.timeout?.sameAs).toBe("failure");
+  });
+
+  it("abort + sideEffects の組合せ (補償後に中断する Saga パターン)", () => {
+    const spec: ExternalCallOutcomeSpec = {
+      action: "abort",
+      description: "HTTP 402 で return する前に補償を行う",
+      sideEffects: [
+        { id: "comp-1", type: "other", description: "Stripe void_authorization 呼出" } as Step,
+      ],
+      jumpTo: "end-of-action",
+    };
+    expect(spec.action).toBe("abort");
+    expect(spec.sideEffects).toHaveLength(1);
+    expect(spec.jumpTo).toBe("end-of-action");
+  });
+});
+
+describe("migrateActionGroup — outcome sideEffects / sameAs 透過保持 (#172)", () => {
+  it("新フィールドを持つ outcome を冪等にマイグレーションできる", () => {
+    const raw = {
+      id: "g",
+      name: "x",
+      type: "screen",
+      description: "",
+      actions: [
+        {
+          id: "a",
+          name: "a",
+          trigger: "submit",
+          steps: [
+            {
+              id: "s",
+              type: "externalSystem",
+              description: "capture",
+              systemName: "Stripe",
+              outcomes: {
+                success: { action: "continue" },
+                failure: {
+                  action: "continue",
+                  description: "稀なケース",
+                  sideEffects: [
+                    {
+                      id: "se",
+                      type: "dbAccess",
+                      description: "status 更新",
+                      tableName: "orders",
+                      operation: "UPDATE",
+                    },
+                  ],
+                },
+                timeout: { action: "continue", sameAs: "failure" },
+              },
+            },
+          ],
+        },
+      ],
+      createdAt: "",
+      updatedAt: "",
+    };
+    const once = migrateActionGroup(raw) as ActionGroup;
+    const twice = migrateActionGroup(once);
+    expect(JSON.stringify(twice)).toBe(JSON.stringify(once));
+
+    const step = once.actions[0].steps[0] as ExternalSystemStep;
+    expect(step.outcomes?.failure?.sideEffects).toHaveLength(1);
+    // sideEffects 内のステップも通常通りマイグレーションされている (maturity 既定)
+    const sideStep = step.outcomes?.failure?.sideEffects?.[0] as Step;
+    expect(sideStep.maturity).toBe("draft");
+    expect(step.outcomes?.timeout?.sameAs).toBe("failure");
+  });
+});

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -356,6 +356,18 @@ export interface ExternalCallOutcomeSpec {
   description?: string;
   /** abort 時のジャンプ先ラベル (任意) */
   jumpTo?: string;
+  /**
+   * 副作用として action 実行前に実行するステップ列。
+   * 例: capture 失敗時に orders.status を 'payment_failed' に UPDATE + 運用通知。
+   * docs/spec, #151 (B) / #172
+   */
+  sideEffects?: Step[];
+  /**
+   * 他の outcome の定義を流用する短縮記法 (例: timeout が failure と同じ扱い時)。
+   * 指定時は他フィールド (action/description/sideEffects 等) を無視し、sameAs 先の定義を使う。
+   * product-scope §11 の既定 (timeout 省略時は failure と同じ) を明示的に表現可能。
+   */
+  sameAs?: ExternalCallOutcome;
 }
 
 /** 外部呼出のリトライ方針 */

--- a/designer/src/utils/actionMigration.ts
+++ b/designer/src/utils/actionMigration.ts
@@ -143,6 +143,17 @@ function migrateStepInPlace(raw: unknown): Step {
     step.steps = (step.steps as unknown[]).map(migrateStepInPlace);
   }
 
+  // #172: outcome.sideEffects 内のステップも再帰的にマイグレーション
+  if (step.type === "externalSystem" && step.outcomes && typeof step.outcomes === "object") {
+    const outcomes = step.outcomes as Record<string, Record<string, unknown>>;
+    for (const key of Object.keys(outcomes)) {
+      const spec = outcomes[key];
+      if (spec && Array.isArray(spec.sideEffects)) {
+        spec.sideEffects = (spec.sideEffects as unknown[]).map(migrateStepInPlace);
+      }
+    }
+  }
+
   return step as unknown as Step;
 }
 


### PR DESCRIPTION
## Summary

- #151 (B) スキーマ拡張の第 8 弾
- ドッグフード 7 (0017) で指摘された outcome 副作用の description 依存を解消
- 316 ユニットテストパス

## 追加フィールド

- `ExternalCallOutcomeSpec.sideEffects?: Step[]` (副作用ステップ列)
- `ExternalCallOutcomeSpec.sameAs?: ExternalCallOutcome` (他 outcome 定義の流用)

## 用途例

```json
{
  "outcomes": {
    "failure": {
      "action": "continue",
      "sideEffects": [
        { "type": "dbAccess", "operation": "UPDATE", "sql": "UPDATE orders SET status='payment_failed' ..." },
        { "type": "other", "description": "Sentry error 記録 + 運用通知" }
      ]
    },
    "timeout": { "action": "continue", "sameAs": "failure" }
  }
}
```

## 関連

- Closes #172
- Refs #151 (B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)