### PR TITLE
feat(types): ComputeStep (計算/代入ステップ) を追加 (#174)

### DIFF
--- a/designer/src/store/actionStore.ts
+++ b/designer/src/store/actionStore.ts
@@ -246,6 +246,8 @@ export function createDefaultStep(type: StepType): Step {
       return { ...base, type: "loopContinue" };
     case "jump":
       return { ...base, type: "jump", jumpTo: "" };
+    case "compute":
+      return { ...base, type: "compute", expression: "" };
     case "other":
       return { ...base, type: "other" };
   }

--- a/designer/src/types/action.computeStep.test.ts
+++ b/designer/src/types/action.computeStep.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import type { ActionGroup, ComputeStep, Step } from "./action";
+import { STEP_TYPE_LABELS, STEP_TYPE_ICONS, STEP_TYPE_COLORS } from "./action";
+import { migrateActionGroup } from "../utils/actionMigration";
+
+describe("ComputeStep (#174)", () => {
+  it("税額計算の典型パターンを表現できる", () => {
+    const step: ComputeStep = {
+      id: "s-tax",
+      type: "compute",
+      description: "税額計算 (外税 10% 切り捨て)",
+      expression: "Math.floor(@subtotal * 0.10)",
+      outputBinding: "taxAmount",
+    };
+    expect(step.type).toBe("compute");
+    expect(step.expression).toBe("Math.floor(@subtotal * 0.10)");
+    expect(step.outputBinding).toBe("taxAmount");
+  });
+
+  it("合計算出のパターン", () => {
+    const step: ComputeStep = {
+      id: "s-total",
+      type: "compute",
+      description: "合計金額",
+      expression: "@subtotal + @taxAmount",
+      outputBinding: "totalAmount",
+    };
+    expect(step.expression).toContain("@subtotal");
+    expect(step.expression).toContain("@taxAmount");
+  });
+
+  it("構造化 outputBinding と組合せできる", () => {
+    const step: ComputeStep = {
+      id: "s",
+      type: "compute",
+      description: "カウント",
+      expression: "@items.length",
+      outputBinding: { name: "itemCount", operation: "assign" },
+    };
+    expect(step.outputBinding).toEqual({ name: "itemCount", operation: "assign" });
+  });
+
+  it("STEP_TYPE_LABELS / ICONS / COLORS に compute が追加されている", () => {
+    expect(STEP_TYPE_LABELS.compute).toBe("計算/代入");
+    expect(STEP_TYPE_ICONS.compute).toBe("bi-calculator");
+    expect(STEP_TYPE_COLORS.compute).toMatch(/^#[0-9a-f]{6}$/i);
+  });
+});
+
+describe("migrateActionGroup — ComputeStep 透過保持 (#174)", () => {
+  it("ComputeStep を冪等にマイグレーションできる", () => {
+    const raw = {
+      id: "g",
+      name: "x",
+      type: "screen",
+      description: "",
+      actions: [
+        {
+          id: "a",
+          name: "a",
+          trigger: "submit",
+          steps: [
+            {
+              id: "s",
+              type: "compute",
+              description: "税額",
+              expression: "Math.floor(@subtotal * 0.10)",
+              outputBinding: "taxAmount",
+            },
+          ],
+        },
+      ],
+      createdAt: "",
+      updatedAt: "",
+    };
+    const once = migrateActionGroup(raw) as ActionGroup;
+    const twice = migrateActionGroup(once);
+    expect(JSON.stringify(twice)).toBe(JSON.stringify(once));
+    const step = once.actions[0].steps[0] as ComputeStep;
+    expect(step.type).toBe("compute");
+    expect(step.expression).toBe("Math.floor(@subtotal * 0.10)");
+    // maturity 既定が付与される
+    expect(step.maturity).toBe("draft");
+  });
+
+  it("ComputeStep を branch の elseBranch に入れても再帰マイグレーションされる", () => {
+    const raw = {
+      id: "g",
+      name: "x",
+      type: "screen",
+      description: "",
+      actions: [
+        {
+          id: "a",
+          name: "a",
+          trigger: "submit",
+          steps: [
+            {
+              id: "br",
+              type: "branch",
+              description: "",
+              branches: [{ id: "b1", code: "A", condition: "", steps: [] }],
+              elseBranch: {
+                id: "be",
+                code: "ELSE",
+                condition: "",
+                steps: [
+                  { id: "c", type: "compute", description: "", expression: "@a + @b", outputBinding: "sum" },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+      createdAt: "",
+      updatedAt: "",
+    };
+    const migrated = migrateActionGroup(raw) as ActionGroup;
+    const br = migrated.actions[0].steps[0] as unknown as {
+      elseBranch: { steps: Step[] };
+    };
+    const compute = br.elseBranch.steps[0] as ComputeStep;
+    expect(compute.type).toBe("compute");
+    expect(compute.maturity).toBe("draft");
+  });
+});

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -13,6 +13,7 @@ export type StepType =
   | "loopBreak"        // ループ終了（break）
   | "loopContinue"     // 次のループへ（continue）
   | "jump"             // 別大分類へのジャンプ
+  | "compute"          // 計算式 / 変数代入 (#174)
   | "other";           // その他
 
 /** ステップ種別ラベル */
@@ -28,6 +29,7 @@ export const STEP_TYPE_LABELS: Record<StepType, string> = {
   loopBreak: "ループ終了",
   loopContinue: "次のループへ",
   jump: "ジャンプ",
+  compute: "計算/代入",
   other: "その他",
 };
 
@@ -44,6 +46,7 @@ export const STEP_TYPE_ICONS: Record<StepType, string> = {
   loopBreak: "bi-stop-circle",
   loopContinue: "bi-skip-forward",
   jump: "bi-arrow-return-right",
+  compute: "bi-calculator",
   other: "bi-three-dots",
 };
 
@@ -60,6 +63,7 @@ export const STEP_TYPE_COLORS: Record<StepType, string> = {
   loopBreak: "#ef4444",
   loopContinue: "#14b8a6",
   jump: "#94a3b8",
+  compute: "#0ea5e9",
   other: "#9ca3af",
 };
 
@@ -478,6 +482,21 @@ export interface OtherStep extends StepBase {
   type: "other";
 }
 
+/**
+ * 計算・代入ステップ (docs/spec, #151 (B) / #174)。
+ * 純粋計算 (税額・合計・集計など) や、@変数 の代入を構造化する。
+ * DB / 外部呼出に依存しない「内部ロジック」の表現用。
+ * 結果格納先は outputBinding で指定。
+ */
+export interface ComputeStep extends StepBase {
+  type: "compute";
+  /**
+   * 代入式 (自由記述、AI 実装時に言語依存で翻訳)。
+   * 例: "Math.floor(@subtotal * 0.10)" / "@subtotal + @taxAmount" / "@items.length"
+   */
+  expression: string;
+}
+
 export type Step =
   | ValidationStep
   | DbAccessStep
@@ -490,6 +509,7 @@ export type Step =
   | LoopBreakStep
   | LoopContinueStep
   | JumpStep
+  | ComputeStep
   | OtherStep;
 
 // ── アクション定義 ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- #151 (B) スキーマ拡張の第 9 弾
- 計算式 / 変数代入式を構造化 (description 依存を解消)
- 322 ユニットテストパス、視覚影響なし (UI 非公開の型追加のみ)

## 追加

- StepType に `"compute"` 追加
- `ComputeStep` interface
- `STEP_TYPE_LABELS.compute` / `ICONS.compute` / `COLORS.compute`
- `actionStore.createDefaultStep` に compute ケース

## 用途

```json
{ "type": "compute", "expression": "Math.floor(@subtotal * 0.10)", "outputBinding": "taxAmount" }
```

## 関連

- Closes #174
- Refs #151 (B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)