### PR TITLE
feat(types): Branch.condition に tryCatch variant を追加 (#176)

### DIFF
--- a/designer/src/components/action/StepCard.tsx
+++ b/designer/src/components/action/StepCard.tsx
@@ -16,6 +16,7 @@ import {
 } from "../../types/action";
 import { resolveJumpLabel } from "../../utils/actionUtils";
 import type { ValidationError } from "../../utils/actionValidation";
+import { getBranchConditionText } from "../../utils/branchCondition";
 import { generateUUID } from "../../utils/uuid";
 import { createDefaultStep } from "../../store/actionStore";
 import { JumpTargetSelector } from "./JumpTargetSelector";
@@ -258,7 +259,7 @@ export function StepCard({
       case "displayUpdate":
         return step.target || step.description || "表示更新";
       case "branch":
-        return step.description || step.branches[0]?.condition || "条件分岐";
+        return step.description || getBranchConditionText(step.branches[0]?.condition) || "条件分岐";
       case "loop":
         if (step.loopKind === "count") return step.countExpression || step.description || "ループ";
         if (step.loopKind === "condition") return step.conditionExpression || step.description || "ループ";
@@ -711,7 +712,7 @@ export function StepCard({
                         <span className="branch-code-badge">{br.code}</span>
                         <input
                           className="form-control form-control-sm branch-condition-input"
-                          value={br.condition}
+                          value={getBranchConditionText(br.condition)}
                           placeholder="分岐条件"
                           onClick={(e) => e.stopPropagation()}
                           onChange={(e) => setBranchAt(bi, { ...br, condition: e.target.value })}

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -420,6 +420,22 @@ export interface DisplayUpdateStep extends StepBase {
   target: string;
 }
 
+/**
+ * Branch の分岐条件 variant (#176)。
+ * 旧 string と新しい型付き表現 (tryCatch 等) の union。
+ */
+export type BranchConditionVariant =
+  | {
+      /** TX catch / try-catch 文脈。errorCode が補足されているエラーが捕捉された時に成立 */
+      kind: "tryCatch";
+      /** DbAccessStep.affectedRowsCheck.errorCode 等と対応する識別子 */
+      errorCode: string;
+      description?: string;
+    };
+
+/** Branch.condition の値型: 旧 string (自由記述) と新 BranchConditionVariant の union */
+export type BranchCondition = string | BranchConditionVariant;
+
 /** 多分岐の1件 */
 export interface Branch {
   /** 内部 UUID */
@@ -428,8 +444,13 @@ export interface Branch {
   code: string;
   /** 任意の自由入力ラベル */
   label?: string;
-  /** 分岐条件（自由記述、LLM 解析前提） */
-  condition: string;
+  /**
+   * 分岐条件。
+   * - 旧: string (自由記述、LLM 解析前提)
+   * - 新: BranchConditionVariant (tryCatch 等の型付き表現)
+   * docs/spec, #151 (B) / #176
+   */
+  condition: BranchCondition;
   /** 任意のサブ処理（全カード配置可能） */
   steps: Step[];
 }

--- a/designer/src/utils/branchCondition.test.ts
+++ b/designer/src/utils/branchCondition.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import type { BranchCondition } from "../types/action";
+import {
+  getBranchConditionText,
+  isStructuredCondition,
+  isTryCatchCondition,
+} from "./branchCondition";
+
+describe("getBranchConditionText", () => {
+  it("string はそのまま返す", () => {
+    expect(getBranchConditionText("@x > 0")).toBe("@x > 0");
+  });
+
+  it("tryCatch variant は catch 記法の文字列に変換", () => {
+    const cond: BranchCondition = { kind: "tryCatch", errorCode: "STOCK_SHORTAGE" };
+    expect(getBranchConditionText(cond)).toBe("catch STOCK_SHORTAGE");
+  });
+
+  it("tryCatch variant に description があれば併記", () => {
+    const cond: BranchCondition = {
+      kind: "tryCatch",
+      errorCode: "STOCK_SHORTAGE",
+      description: "在庫不足で TX rollback",
+    };
+    expect(getBranchConditionText(cond)).toBe("catch STOCK_SHORTAGE (在庫不足で TX rollback)");
+  });
+
+  it("undefined は空文字列", () => {
+    expect(getBranchConditionText(undefined)).toBe("");
+  });
+});
+
+describe("isTryCatchCondition", () => {
+  it("string は false", () => {
+    expect(isTryCatchCondition("text")).toBe(false);
+  });
+
+  it("tryCatch variant は true", () => {
+    expect(isTryCatchCondition({ kind: "tryCatch", errorCode: "X" })).toBe(true);
+  });
+
+  it("undefined は false", () => {
+    expect(isTryCatchCondition(undefined)).toBe(false);
+  });
+});
+
+describe("isStructuredCondition", () => {
+  it("string は false (構造化でない)", () => {
+    expect(isStructuredCondition("anything")).toBe(false);
+  });
+
+  it("variant は true", () => {
+    expect(isStructuredCondition({ kind: "tryCatch", errorCode: "X" })).toBe(true);
+  });
+
+  it("undefined は false", () => {
+    expect(isStructuredCondition(undefined)).toBe(false);
+  });
+});
+
+describe("BranchCondition union の典型運用", () => {
+  it("TX 失敗時の branch 定義 (StockShortageError catch)", () => {
+    const cond: BranchCondition = {
+      kind: "tryCatch",
+      errorCode: "STOCK_SHORTAGE",
+      description: "在庫不足",
+    };
+    expect(isTryCatchCondition(cond)).toBe(true);
+    expect(getBranchConditionText(cond)).toContain("STOCK_SHORTAGE");
+  });
+
+  it("通常の式ベース分岐 (string)", () => {
+    const cond: BranchCondition = "@shortageList.length > 0";
+    expect(isStructuredCondition(cond)).toBe(false);
+    expect(getBranchConditionText(cond)).toBe("@shortageList.length > 0");
+  });
+});

--- a/designer/src/utils/branchCondition.ts
+++ b/designer/src/utils/branchCondition.ts
@@ -1,0 +1,33 @@
+/**
+ * branchCondition.ts
+ * Branch.condition の union (string | BranchConditionVariant) を扱うヘルパー。
+ *
+ * docs/spec, #151 (B) / #176
+ */
+import type { BranchCondition, BranchConditionVariant } from "../types/action";
+
+/** condition を人間可読な文字列に変換 (UI 表示・description ログ用) */
+export function getBranchConditionText(cond: BranchCondition | undefined): string {
+  if (cond == null) return "";
+  if (typeof cond === "string") return cond;
+  switch (cond.kind) {
+    case "tryCatch":
+      return `catch ${cond.errorCode}${cond.description ? ` (${cond.description})` : ""}`;
+    default:
+      return "";
+  }
+}
+
+/** 型ガード: tryCatch variant か */
+export function isTryCatchCondition(
+  cond: BranchCondition | undefined,
+): cond is Extract<BranchConditionVariant, { kind: "tryCatch" }> {
+  return cond != null && typeof cond === "object" && (cond as BranchConditionVariant).kind === "tryCatch";
+}
+
+/** 型ガード: 構造化された variant か (string でないか) */
+export function isStructuredCondition(
+  cond: BranchCondition | undefined,
+): cond is BranchConditionVariant {
+  return cond != null && typeof cond === "object";
+}


### PR DESCRIPTION
## Summary

- #151 (B) スキーマ拡張の第 10 弾
- TX catch / try-catch 文脈を型化
- 334 ユニットテストパス、視覚変更なし (UI は string 表示継続)

## 追加

- `BranchConditionVariant` ({kind: "tryCatch", errorCode, description?})
- `BranchCondition` = `string | BranchConditionVariant`
- `Branch.condition` を union に拡張
- `designer/src/utils/branchCondition.ts` ヘルパー新規

## 用途

```json
{
  "code": "A",
  "condition": { "kind": "tryCatch", "errorCode": "STOCK_SHORTAGE" },
  "steps": [ ... compensation + 409 response ... ]
}
```

## 関連

- Closes #176
- Refs #151 (B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)