### PR TITLE
feat(types): StepBase.runIf / ReturnStep / responses.id を追加 (5.0 到達用、#178)

### DIFF
--- a/designer/src/store/actionStore.ts
+++ b/designer/src/store/actionStore.ts
@@ -248,6 +248,8 @@ export function createDefaultStep(type: StepType): Step {
       return { ...base, type: "jump", jumpTo: "" };
     case "compute":
       return { ...base, type: "compute", expression: "" };
+    case "return":
+      return { ...base, type: "return" };
     case "other":
       return { ...base, type: "other" };
   }

--- a/designer/src/types/action.runIfReturn.test.ts
+++ b/designer/src/types/action.runIfReturn.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from "vitest";
+import type { ActionGroup, HttpResponseSpec, ReturnStep, Step } from "./action";
+import { STEP_TYPE_LABELS, STEP_TYPE_ICONS, STEP_TYPE_COLORS } from "./action";
+import { migrateActionGroup } from "../utils/actionMigration";
+
+describe("StepBase.runIf (#178)", () => {
+  it("ステップに runIf を付与できる", () => {
+    const step: Step = {
+      id: "s",
+      type: "externalSystem",
+      description: "決済 authorize",
+      systemName: "Stripe",
+      runIf: "@paymentMethod == 'credit_card'",
+    };
+    expect(step.runIf).toBe("@paymentMethod == 'credit_card'");
+  });
+
+  it("runIf は任意 (省略可能)", () => {
+    const step: Step = {
+      id: "s",
+      type: "other",
+      description: "",
+    };
+    expect(step.runIf).toBeUndefined();
+  });
+
+  it("全ステップタイプで runIf を付与できる", () => {
+    const types: Array<Step["type"]> = [
+      "validation", "dbAccess", "externalSystem", "commonProcess",
+      "screenTransition", "displayUpdate", "branch", "loop",
+      "loopBreak", "loopContinue", "jump", "compute", "return", "other",
+    ];
+    // 型コンパイルできることを確認するだけの smoke test
+    types.forEach((t) => {
+      const _step = { id: "s", type: t, description: "", runIf: "@x > 0" } as unknown as Step;
+      expect((_step as { runIf: string }).runIf).toBe("@x > 0");
+    });
+  });
+});
+
+describe("HttpResponseSpec.id (#178)", () => {
+  it("id を付与して ReturnStep から参照可能にできる", () => {
+    const spec: HttpResponseSpec = {
+      id: "409-stock-shortage",
+      status: 409,
+      bodySchema: "ApiError",
+      description: "在庫不足",
+    };
+    expect(spec.id).toBe("409-stock-shortage");
+  });
+
+  it("id は任意 (既存データ互換)", () => {
+    const spec: HttpResponseSpec = { status: 201 };
+    expect(spec.id).toBeUndefined();
+  });
+});
+
+describe("ReturnStep (#178)", () => {
+  it("responseRef + bodyExpression で返却を構造化できる", () => {
+    const step: ReturnStep = {
+      id: "s-ret",
+      type: "return",
+      description: "在庫不足レスポンス",
+      responseRef: "409-stock-shortage",
+      bodyExpression: "{ code: 'STOCK_SHORTAGE', detail: @shortageList }",
+    };
+    expect(step.type).toBe("return");
+    expect(step.responseRef).toBe("409-stock-shortage");
+    expect(step.bodyExpression).toContain("@shortageList");
+  });
+
+  it("responseRef / bodyExpression は任意", () => {
+    const step: ReturnStep = {
+      id: "s",
+      type: "return",
+      description: "",
+    };
+    expect(step.responseRef).toBeUndefined();
+    expect(step.bodyExpression).toBeUndefined();
+  });
+
+  it("STEP_TYPE_LABELS / ICONS / COLORS に return が追加されている", () => {
+    expect(STEP_TYPE_LABELS.return).toBe("レスポンス返却");
+    expect(STEP_TYPE_ICONS.return).toBe("bi-reply");
+    expect(STEP_TYPE_COLORS.return).toMatch(/^#[0-9a-f]{6}$/i);
+  });
+});
+
+describe("migrateActionGroup — runIf / ReturnStep / responses[].id 透過保持 (#178)", () => {
+  it("runIf を持つステップを冪等にマイグレーションできる", () => {
+    const raw = {
+      id: "g",
+      name: "x",
+      type: "screen",
+      description: "",
+      actions: [
+        {
+          id: "a",
+          name: "a",
+          trigger: "submit",
+          steps: [
+            {
+              id: "s",
+              type: "externalSystem",
+              description: "",
+              systemName: "Stripe",
+              runIf: "@paymentMethod == 'credit_card'",
+            },
+          ],
+        },
+      ],
+      createdAt: "",
+      updatedAt: "",
+    };
+    const once = migrateActionGroup(raw) as ActionGroup;
+    const twice = migrateActionGroup(once);
+    expect(JSON.stringify(twice)).toBe(JSON.stringify(once));
+    expect(once.actions[0].steps[0].runIf).toBe("@paymentMethod == 'credit_card'");
+  });
+
+  it("ReturnStep を冪等にマイグレーションできる", () => {
+    const raw = {
+      id: "g",
+      name: "x",
+      type: "screen",
+      description: "",
+      actions: [
+        {
+          id: "a",
+          name: "a",
+          trigger: "submit",
+          responses: [
+            { id: "409-stock-shortage", status: 409, bodySchema: "ApiError" },
+          ],
+          steps: [
+            {
+              id: "s",
+              type: "return",
+              description: "",
+              responseRef: "409-stock-shortage",
+              bodyExpression: "{ code: 'STOCK_SHORTAGE' }",
+            },
+          ],
+        },
+      ],
+      createdAt: "",
+      updatedAt: "",
+    };
+    const once = migrateActionGroup(raw) as ActionGroup;
+    const twice = migrateActionGroup(once);
+    expect(JSON.stringify(twice)).toBe(JSON.stringify(once));
+
+    const step = once.actions[0].steps[0] as ReturnStep;
+    expect(step.type).toBe("return");
+    expect(step.responseRef).toBe("409-stock-shortage");
+    expect(step.maturity).toBe("draft");
+
+    expect(once.actions[0].responses?.[0].id).toBe("409-stock-shortage");
+  });
+});

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -14,6 +14,7 @@ export type StepType =
   | "loopContinue"     // 次のループへ（continue）
   | "jump"             // 別大分類へのジャンプ
   | "compute"          // 計算式 / 変数代入 (#174)
+  | "return"           // HTTP レスポンス返却 (#178)
   | "other";           // その他
 
 /** ステップ種別ラベル */
@@ -30,6 +31,7 @@ export const STEP_TYPE_LABELS: Record<StepType, string> = {
   loopContinue: "次のループへ",
   jump: "ジャンプ",
   compute: "計算/代入",
+  return: "レスポンス返却",
   other: "その他",
 };
 
@@ -47,6 +49,7 @@ export const STEP_TYPE_ICONS: Record<StepType, string> = {
   loopContinue: "bi-skip-forward",
   jump: "bi-arrow-return-right",
   compute: "bi-calculator",
+  return: "bi-reply",
   other: "bi-three-dots",
 };
 
@@ -64,6 +67,7 @@ export const STEP_TYPE_COLORS: Record<StepType, string> = {
   loopContinue: "#14b8a6",
   jump: "#94a3b8",
   compute: "#0ea5e9",
+  return: "#22c55e",
   other: "#9ca3af",
 };
 
@@ -212,6 +216,12 @@ export interface StepBase {
   notes?: StepNote[];
   /** 成熟度。未指定は "draft" として解釈 */
   maturity?: Maturity;
+  /**
+   * ステップの条件実行ガード (#178)。
+   * 真偽式 (自由記述、例: "@paymentMethod == 'credit_card'") または @conv.* 参照。
+   * 偽または未評価の場合、ステップを skip する。未指定は常に実行。
+   */
+  runIf?: string;
   /**
    * ステップの結果を保持する変数。後続ステップは @変数名 で参照する。
    * 旧形式 (string) は assign 相当、新形式 (object) は operation で代入方式を指定可能。
@@ -518,6 +528,22 @@ export interface ComputeStep extends StepBase {
   expression: string;
 }
 
+/**
+ * HTTP レスポンス返却ステップ (#178)。
+ * action.responses[] への参照 (responseRef) で返却内容を指定する。
+ * 返却 body の具体値は bodyExpression で表現。
+ */
+export interface ReturnStep extends StepBase {
+  type: "return";
+  /** action.responses[].id への参照 (例: "409-stock-shortage") */
+  responseRef?: string;
+  /**
+   * 返却 body の式 (任意、自由記述)。
+   * 例: "{ code: 'STOCK_SHORTAGE', detail: @shortageList }"
+   */
+  bodyExpression?: string;
+}
+
 export type Step =
   | ValidationStep
   | DbAccessStep
@@ -531,6 +557,7 @@ export type Step =
   | LoopContinueStep
   | JumpStep
   | ComputeStep
+  | ReturnStep
   | OtherStep;
 
 // ── アクション定義 ───────────────────────────────────────────────────────
@@ -581,6 +608,8 @@ export interface HttpRoute {
 
 /** HTTP レスポンス仕様 (成功/エラーの各ケース) */
 export interface HttpResponseSpec {
+  /** ReturnStep.responseRef から参照するための識別子 (任意、例: "409-stock-shortage") */
+  id?: string;
   /** 数値 HTTP ステータス (例: 201, 400, 404) */
   status: number;
   /** MIME タイプ。未指定は "application/json" として解釈 */


### PR DESCRIPTION
## Summary

- #151 (B) スキーマ拡張の最終弾
- 344 ユニットテストパス、視覚影響なし

## 追加

- `StepBase.runIf?: string` — ステップレベル条件実行ガード
- `HttpResponseSpec.id?: string` — response 参照用 ID
- `ReturnStep` (type: "return") — 構造化された HTTP レスポンス返却
- `StepType` / Step union / ICONS / LABELS / COLORS / createDefaultStep 更新

## 関連

- Closes #178
- Refs #151 (B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)