### PR TITLE
feat(types): ValidationStep.inlineBranch.ngResponseRef を追加 (#180)

### DIFF
--- a/designer/src/types/action.inlineBranchResponseRef.test.ts
+++ b/designer/src/types/action.inlineBranchResponseRef.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import type { ActionGroup, ValidationStep } from "./action";
+import { migrateActionGroup } from "../utils/actionMigration";
+
+describe("ValidationStep.inlineBranch.ngResponseRef (#180)", () => {
+  it("NG 時のレスポンス参照と body 式を保持できる", () => {
+    const step: ValidationStep = {
+      id: "s",
+      type: "validation",
+      description: "",
+      conditions: "",
+      rules: [{ field: "x", type: "required" }],
+      inlineBranch: {
+        ok: "次へ",
+        ng: "400 VALIDATION で return",
+        ngResponseRef: "400-validation",
+        ngBodyExpression: "{ code: 'VALIDATION', fieldErrors: @fieldErrors }",
+      },
+    };
+    expect(step.inlineBranch?.ngResponseRef).toBe("400-validation");
+    expect(step.inlineBranch?.ngBodyExpression).toContain("fieldErrors");
+  });
+
+  it("ngResponseRef / ngBodyExpression は任意 (既存データ互換)", () => {
+    const step: ValidationStep = {
+      id: "s",
+      type: "validation",
+      description: "",
+      conditions: "",
+      inlineBranch: { ok: "OK", ng: "NG" },
+    };
+    expect(step.inlineBranch?.ngResponseRef).toBeUndefined();
+    expect(step.inlineBranch?.ngBodyExpression).toBeUndefined();
+  });
+
+  it("migrateActionGroup で冪等保持", () => {
+    const raw = {
+      id: "g", name: "x", type: "screen", description: "",
+      actions: [{
+        id: "a", name: "a", trigger: "submit",
+        responses: [{ id: "400-validation", status: 400, bodySchema: "ApiError" }],
+        steps: [{
+          id: "s", type: "validation", description: "",
+          conditions: "",
+          rules: [{ field: "x", type: "required" }],
+          inlineBranch: {
+            ok: "next",
+            ng: "error",
+            ngResponseRef: "400-validation",
+            ngBodyExpression: "{ code: 'VALIDATION' }",
+          },
+        }],
+      }],
+      createdAt: "", updatedAt: "",
+    };
+    const once = migrateActionGroup(raw) as ActionGroup;
+    const twice = migrateActionGroup(once);
+    expect(JSON.stringify(twice)).toBe(JSON.stringify(once));
+    const step = once.actions[0].steps[0] as ValidationStep;
+    expect(step.inlineBranch?.ngResponseRef).toBe("400-validation");
+  });
+});

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -299,6 +299,13 @@ export interface ValidationStep extends StepBase {
     ok: string;
     ng: string;
     ngJumpTo?: string;
+    /**
+     * バリデーション NG 時に返却する HTTP レスポンス参照 (#180)。
+     * action.responses[].id を指す。
+     */
+    ngResponseRef?: string;
+    /** NG 時の返却 body 式 (任意、自由記述) */
+    ngBodyExpression?: string;
   };
 }
 


### PR DESCRIPTION
## Summary

- #151 (B) 最終拡張 (5.0 到達目標)
- 347 ユニットテスト pass

## 追加

- `ValidationStep.inlineBranch.ngResponseRef?: string`
- `ValidationStep.inlineBranch.ngBodyExpression?: string`

## 関連

- Closes #180
- Refs #151 (B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)