### PR TITLE
feat(ui): ステップカードに成熟度バッジを表示 (#184)

### DIFF
--- a/designer/src/components/action/MaturityBadge.tsx
+++ b/designer/src/components/action/MaturityBadge.tsx
@@ -1,0 +1,45 @@
+import type { Maturity } from "../../types/action";
+
+interface Props {
+  /** 未指定は "draft" 既定として扱う (docs/spec/process-flow-maturity.md §3) */
+  maturity?: Maturity;
+  /** 省略時のスタイル調整用: ステップカード内 inline / リスト行 standalone */
+  size?: "sm" | "md";
+}
+
+/**
+ * 成熟度バッジ (#184、docs/spec/process-flow-maturity.md §6.1)
+ * - draft (🟡): 下書き
+ * - provisional (🟠): 暫定
+ * - committed (🟢): 確定
+ */
+const STYLE_MAP: Record<Maturity, { color: string; label: string; title: string }> = {
+  draft: { color: "#f59e0b", label: "●", title: "下書き (draft)" },
+  provisional: { color: "#f97316", label: "●", title: "暫定 (provisional)" },
+  committed: { color: "#22c55e", label: "●", title: "確定 (committed)" },
+};
+
+export function MaturityBadge({ maturity, size = "sm" }: Props) {
+  const m: Maturity = maturity ?? "draft";
+  const style = STYLE_MAP[m];
+  const fontSize = size === "sm" ? 10 : 12;
+  return (
+    <span
+      className="maturity-badge"
+      title={style.title}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 4,
+        padding: "0 4px",
+        color: style.color,
+        fontSize,
+        lineHeight: 1,
+        flexShrink: 0,
+      }}
+      aria-label={`成熟度: ${style.title}`}
+    >
+      <span style={{ fontSize: size === "sm" ? 8 : 10 }}>{style.label}</span>
+    </span>
+  );
+}

--- a/designer/src/components/action/StepCard.tsx
+++ b/designer/src/components/action/StepCard.tsx
@@ -19,6 +19,7 @@ import type { ValidationError } from "../../utils/actionValidation";
 import { getBranchConditionText } from "../../utils/branchCondition";
 import { generateUUID } from "../../utils/uuid";
 import { createDefaultStep } from "../../store/actionStore";
+import { MaturityBadge } from "./MaturityBadge";
 import { JumpTargetSelector } from "./JumpTargetSelector";
 
 const ALL_SUB_STEP_TYPES: StepType[] = [
@@ -409,6 +410,7 @@ export function StepCard({
           <span className="step-card-number">{label}</span>
           <i className={`step-card-icon ${STEP_TYPE_ICONS[step.type]}`} style={{ color }} />
           <span className="step-card-type-label">{STEP_TYPE_LABELS[step.type]}</span>
+          <MaturityBadge maturity={step.maturity} />
           <span className="step-card-description">{summaryText()}</span>
           {step.type === "commonProcess" && step.refId && (
             <button


### PR DESCRIPTION
## Summary

- #151 (C) UI 実装フェーズ第 1 弾
- ステップカードに成熟度バッジ (色付きドット) を読み取り専用で表示
- 編集 UI は後続 PR

## 変更

- `designer/src/components/action/MaturityBadge.tsx` 新規
- `designer/src/components/action/StepCard.tsx` でバッジをステップ種別ラベルの隣に配置

## 表示仕様

- 🟡 (#f59e0b) = draft (下書き)
- 🟠 (#f97316) = provisional (暫定)
- 🟢 (#22c55e) = committed (確定)
- 未指定は draft 扱い (バッジ表示)
- title 属性でホバー時に成熟度名を表示

## Test plan

- [x] npm run test:unit (347 pass)
- [x] npm run build 成功
- [ ] **ユーザー目視確認** (UI 影響のため、マージ前に必須)
  - 処理フロー編集画面を開く
  - ステップカードに色付きドットが表示されること
  - ホバーで「下書き (draft)」等の tooltip が出ること
  - 既存のレイアウトを崩していないこと

## 関連

- Refs #151 (C), docs/spec/process-flow-maturity.md §6.1
- Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)