### PR TITLE
feat(ui): 処理フロー一覧カードに成熟度バッジを表示 (#186)

### DIFF
--- a/designer/src/components/action/ActionListView.tsx
+++ b/designer/src/components/action/ActionListView.tsx
@@ -19,6 +19,7 @@ import { FilterBar } from "../common/FilterBar";
 import { SortBar } from "../common/SortBar";
 import { ListContextMenu, type ContextMenuItem } from "../common/ListContextMenu";
 import { ViewModeToggle, type ViewMode } from "../common/ViewModeToggle";
+import { MaturityBadge } from "./MaturityBadge";
 import { useListSelection } from "../../hooks/useListSelection";
 import { useListClipboard } from "../../hooks/useListClipboard";
 import { useListKeyboard } from "../../hooks/useListKeyboard";
@@ -476,6 +477,7 @@ export function ActionListView() {
             <i className={`${ACTION_GROUP_TYPE_ICONS[g.type as ActionGroupType] ?? "bi-three-dots"} me-1`} />
             {ACTION_GROUP_TYPE_LABELS[g.type as ActionGroupType] ?? g.type}
           </span>
+          <MaturityBadge maturity={g.maturity} />
           <span className="action-card-name">{g.name}</span>
           {v && (hasError || hasWarning) && (
             <span className="action-validation-badges">

--- a/designer/src/store/actionStore.ts
+++ b/designer/src/store/actionStore.ts
@@ -269,6 +269,7 @@ async function syncActionGroupMeta(group: ActionGroup): Promise<void> {
     screenId: group.screenId,
     actionCount: group.actions.length,
     updatedAt: group.updatedAt,
+    maturity: group.maturity,
   };
 
   if (idx >= 0) {

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -689,6 +689,8 @@ export interface ActionGroupMeta {
   screenId?: string;
   actionCount: number;
   updatedAt: string;
+  /** 成熟度 (#186、docs/spec/process-flow-maturity.md §6.4)。未指定は "draft" として解釈 */
+  maturity?: Maturity;
 }
 
 // ── ステップテンプレート ─────────────────────────────────────────────────

--- a/designer/src/types/flow.ts
+++ b/designer/src/types/flow.ts
@@ -127,6 +127,8 @@ export interface ActionGroupMeta {
   screenId?: string;
   actionCount: number;
   updatedAt: string;
+  /** 成熟度 (#186、docs/spec/process-flow-maturity.md §6.4)。未指定は "draft" として解釈 */
+  maturity?: "draft" | "provisional" | "committed";
 }
 
 /** プロジェクト全体 */


### PR DESCRIPTION
## Summary

- #151 (C) UI 実装フェーズ第 2 弾
- 処理フロー一覧カードに group 成熟度バッジを追加
- 347 ユニットテストパス

## 変更

- `ActionGroupMeta` に `maturity?` 追加 (types/action.ts & types/flow.ts)
- `syncActionGroupMeta` が group.maturity をメタに反映
- `ActionListView.renderCard` で MaturityBadge 配置

## 関連

- Closes #186
- Refs #151 (C), #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)