### PR TITLE
feat(ui): 成熟度バッジをクリックで編集可能に (#188)

### DIFF
--- a/designer/src/components/action/MaturityBadge.tsx
+++ b/designer/src/components/action/MaturityBadge.tsx
@@ -5,6 +5,11 @@ interface Props {
   maturity?: Maturity;
   /** 省略時のスタイル調整用: ステップカード内 inline / リスト行 standalone */
   size?: "sm" | "md";
+  /**
+   * 指定すると成熟度を編集可能に。クリックで draft → provisional → committed → draft を循環。
+   * 未指定時は表示のみ (#184)。
+   */
+  onChange?: (next: Maturity) => void;
 }
 
 /**
@@ -12,6 +17,8 @@ interface Props {
  * - draft (🟡): 下書き
  * - provisional (🟠): 暫定
  * - committed (🟢): 確定
+ *
+ * onChange 指定時はクリックで循環切替 (#188)。
  */
 const STYLE_MAP: Record<Maturity, { color: string; label: string; title: string }> = {
   draft: { color: "#f59e0b", label: "●", title: "下書き (draft)" },
@@ -19,14 +26,40 @@ const STYLE_MAP: Record<Maturity, { color: string; label: string; title: string 
   committed: { color: "#22c55e", label: "●", title: "確定 (committed)" },
 };
 
-export function MaturityBadge({ maturity, size = "sm" }: Props) {
+const CYCLE: Record<Maturity, Maturity> = {
+  draft: "provisional",
+  provisional: "committed",
+  committed: "draft",
+};
+
+export function MaturityBadge({ maturity, size = "sm", onChange }: Props) {
   const m: Maturity = maturity ?? "draft";
   const style = STYLE_MAP[m];
   const fontSize = size === "sm" ? 10 : 12;
+  const editable = !!onChange;
+  const title = editable
+    ? `${style.title} — クリックで切替`
+    : style.title;
+
+  const handleClick = (e: React.MouseEvent) => {
+    if (!onChange) return;
+    e.stopPropagation();
+    onChange(CYCLE[m]);
+  };
+
   return (
     <span
-      className="maturity-badge"
-      title={style.title}
+      className={`maturity-badge${editable ? " editable" : ""}`}
+      title={title}
+      role={editable ? "button" : undefined}
+      tabIndex={editable ? 0 : undefined}
+      onClick={editable ? handleClick : undefined}
+      onKeyDown={editable ? (e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onChange(CYCLE[m]);
+        }
+      } : undefined}
       style={{
         display: "inline-flex",
         alignItems: "center",
@@ -36,8 +69,9 @@ export function MaturityBadge({ maturity, size = "sm" }: Props) {
         fontSize,
         lineHeight: 1,
         flexShrink: 0,
+        cursor: editable ? "pointer" : undefined,
       }}
-      aria-label={`成熟度: ${style.title}`}
+      aria-label={`成熟度: ${style.title}${editable ? " (クリックで切替)" : ""}`}
     >
       <span style={{ fontSize: size === "sm" ? 8 : 10 }}>{style.label}</span>
     </span>

--- a/designer/src/components/action/StepCard.tsx
+++ b/designer/src/components/action/StepCard.tsx
@@ -410,7 +410,10 @@ export function StepCard({
           <span className="step-card-number">{label}</span>
           <i className={`step-card-icon ${STEP_TYPE_ICONS[step.type]}`} style={{ color }} />
           <span className="step-card-type-label">{STEP_TYPE_LABELS[step.type]}</span>
-          <MaturityBadge maturity={step.maturity} />
+          <MaturityBadge
+            maturity={step.maturity}
+            onChange={(next) => onChange({ maturity: next } as Partial<Step>)}
+          />
           <span className="step-card-description">{summaryText()}</span>
           {step.type === "commonProcess" && step.refId && (
             <button


### PR DESCRIPTION
## Summary

- #151 (C) UI 実装フェーズ第 3 弾
- MaturityBadge がクリックで状態を循環切替できるようになった
- ステップカードでは step.maturity をインラインで変更可能
- キーボード (Enter/Space) でも切替可能

## 変更

- `MaturityBadge` に `onChange?: (next: Maturity) => void` prop
- `StepCard` で onChange を渡し、step.maturity を更新

## 関連

- Closes #188
- Refs #151 (C), #184, #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)