### PR TITLE
feat(ui): ActionEditor に mode トグルと group 成熟度編集を追加 (#190)

### DIFF
--- a/designer/src/components/action/ActionEditor.tsx
+++ b/designer/src/components/action/ActionEditor.tsx
@@ -52,6 +52,7 @@ import { useSelectionKeyboard } from "../../hooks/useSelectionKeyboard";
 import { STEP_TYPE_COLORS } from "../../types/action";
 import { TableSubToolbar } from "../table/TableSubToolbar";
 import { SortableStepCard } from "./SortableStepCard";
+import { MaturityBadge } from "./MaturityBadge";
 import { EditorHeader } from "../common/EditorHeader";
 import { ServerChangeBanner } from "../common/ServerChangeBanner";
 import "../../styles/action.css";
@@ -527,6 +528,37 @@ export function ActionEditor() {
               onChange={(e) => handleGroupInfoChange("description", e.target.value)}
               placeholder="処理フローの概要"
             />
+          </div>
+        </div>
+        <div className="d-flex align-items-center gap-3 mt-2 small">
+          <div className="d-flex align-items-center gap-1">
+            <label className="form-label small fw-semibold mb-0">成熟度</label>
+            <MaturityBadge
+              maturity={group.maturity}
+              size="md"
+              onChange={(next) => handleGroupInfoChange("maturity", next)}
+            />
+          </div>
+          <div className="d-flex align-items-center gap-1">
+            <label className="form-label small fw-semibold mb-0">モード</label>
+            <div className="btn-group btn-group-sm" role="group" aria-label="モード切替">
+              <button
+                type="button"
+                className={`btn btn-outline-secondary${(group.mode ?? "upstream") === "upstream" ? " active" : ""}`}
+                onClick={() => handleGroupInfoChange("mode", "upstream")}
+                title="上流モード: 書きかけ・曖昧を許容"
+              >
+                <i className="bi bi-pencil me-1" />上流
+              </button>
+              <button
+                type="button"
+                className={`btn btn-outline-secondary${group.mode === "downstream" ? " active" : ""}`}
+                onClick={() => handleGroupInfoChange("mode", "downstream")}
+                title="下流モード: AI 実装用に確定"
+              >
+                <i className="bi bi-robot me-1" />下流
+              </button>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- #151 (C) UI 第 4 弾
- グループ情報パネルに成熟度バッジ (編集) + モード切替 (上流/下流) を追加

## 関連

- Closes #190
- Refs #151 (C), #184-188

🤖 Generated with [Claude Code](https://claude.com/claude-code)