### PR TITLE
feat(ui): アクションタブに成熟度バッジを表示 (#192)

### DIFF
--- a/designer/src/components/action/ActionEditor.tsx
+++ b/designer/src/components/action/ActionEditor.tsx
@@ -571,6 +571,15 @@ export function ActionEditor() {
               className={`action-tab ${activeActionId === act.id ? "active" : ""}`}
               onClick={() => setActiveActionId(act.id)}
             >
+              <MaturityBadge
+                maturity={act.maturity}
+                onChange={(next) => {
+                  updateGroupSilent((g) => {
+                    const a = g.actions.find((a2) => a2.id === act.id);
+                    if (a) a.maturity = next;
+                  });
+                }}
+              />
               {act.name}
               <span className="ms-1 text-muted small">({ACTION_TRIGGER_LABELS[act.trigger]})</span>
             </button>


### PR DESCRIPTION
#151 (C) UI 第 5 弾。ActionEditor のアクションタブに action レベル成熟度バッジを表示 (編集可)。

Closes #192
Refs #151 (C)

🤖 Generated with [Claude Code](https://claude.com/claude-code)