### PR TITLE
feat(ui): ステップカード header に付箋件数バッジを追加 (#198)

### DIFF
--- a/designer/src/components/action/StepCard.tsx
+++ b/designer/src/components/action/StepCard.tsx
@@ -415,6 +415,24 @@ export function StepCard({
             maturity={step.maturity}
             onChange={(next) => onChange({ maturity: next } as Partial<Step>)}
           />
+          {step.notes && step.notes.length > 0 && (
+            <span
+              className="step-notes-count-badge"
+              title={`付箋 ${step.notes.length} 件`}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 2,
+                padding: "0 4px",
+                color: "#64748b",
+                fontSize: 11,
+                flexShrink: 0,
+              }}
+            >
+              <i className="bi bi-sticky" />
+              {step.notes.length}
+            </span>
+          )}
           <span className="step-card-description">{summaryText()}</span>
           {step.type === "commonProcess" && step.refId && (
             <button


### PR DESCRIPTION
Closes #198
Refs #151 (C), #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)