### PR TITLE
feat(ui): 一覧に付箋件数列 + maturity ソート列 (#228)

### DIFF
--- a/designer/src/components/action/ActionListView.tsx
+++ b/designer/src/components/action/ActionListView.tsx
@@ -158,6 +158,12 @@ export function ActionListView() {
       case "actionCount": return g.actionCount;
       case "screenId": return g.screenId ? 1 : 0;
       case "errorPriority": return getErrorPriority(g.id);
+      case "maturity": {
+        // draft < provisional < committed で昇順ソート (未指定は draft 扱い)
+        const order: Record<string, number> = { draft: 0, provisional: 1, committed: 2 };
+        return order[g.maturity ?? "draft"] ?? 0;
+      }
+      case "notesCount": return g.notesCount ?? 0;
       default: return "";
     }
   }, [getErrorPriority]);
@@ -438,6 +444,18 @@ export function ActionListView() {
       ),
     },
     {
+      key: "maturity",
+      header: "成熟度",
+      width: "80px",
+      align: "center",
+      sortable: true,
+      sortAccessor: (g) => {
+        const order: Record<string, number> = { draft: 0, provisional: 1, committed: 2 };
+        return order[g.maturity ?? "draft"] ?? 0;
+      },
+      render: (g) => <MaturityBadge maturity={g.maturity} />,
+    },
+    {
       key: "actionCount",
       header: "アクション",
       width: "90px",
@@ -445,6 +463,15 @@ export function ActionListView() {
       sortable: true,
       sortAccessor: (g) => g.actionCount,
       render: (g) => <span>{g.actionCount}</span>,
+    },
+    {
+      key: "notesCount",
+      header: "付箋",
+      width: "70px",
+      align: "right",
+      sortable: true,
+      sortAccessor: (g) => g.notesCount ?? 0,
+      render: (g) => (g.notesCount ?? 0) > 0 ? <span><i className="bi bi-sticky me-1" />{g.notesCount}</span> : null,
     },
     {
       key: "screenId",
@@ -495,6 +522,11 @@ export function ActionListView() {
         <div className="action-card-meta">
           <span><i className="bi bi-lightning me-1" />アクション: {g.actionCount}件</span>
           {g.screenId && <span><i className="bi bi-display me-1" />画面紐付き</span>}
+          {(g.notesCount ?? 0) > 0 && (
+            <span title={`付箋 ${g.notesCount} 件`}>
+              <i className="bi bi-sticky me-1" />付箋: {g.notesCount}
+            </span>
+          )}
         </div>
       </div>
     );

--- a/designer/src/store/actionStore.ts
+++ b/designer/src/store/actionStore.ts
@@ -255,6 +255,24 @@ export function createDefaultStep(type: StepType): Step {
   }
 }
 
+/** グループ内の全ステップを再帰走査して付箋合計をカウント (#228) */
+function countGroupNotes(group: ActionGroup): number {
+  let count = 0;
+  const visit = (steps: Step[]) => {
+    for (const s of steps) {
+      count += s.notes?.length ?? 0;
+      if (s.subSteps) visit(s.subSteps);
+      if (s.type === "branch") {
+        for (const b of s.branches) visit(b.steps);
+        if (s.elseBranch) visit(s.elseBranch.steps);
+      }
+      if (s.type === "loop") visit(s.steps);
+    }
+  };
+  for (const a of group.actions) visit(a.steps);
+  return count;
+}
+
 /** project.json のアクショングループメタを同期 */
 async function syncActionGroupMeta(group: ActionGroup): Promise<void> {
   const project = await loadProject();
@@ -270,6 +288,7 @@ async function syncActionGroupMeta(group: ActionGroup): Promise<void> {
     actionCount: group.actions.length,
     updatedAt: group.updatedAt,
     maturity: group.maturity,
+    notesCount: countGroupNotes(group),
   };
 
   if (idx >= 0) {

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -691,6 +691,8 @@ export interface ActionGroupMeta {
   updatedAt: string;
   /** 成熟度 (#186、docs/spec/process-flow-maturity.md §6.4)。未指定は "draft" として解釈 */
   maturity?: Maturity;
+  /** グループ全体の付箋合計件数 (#228、一覧表示用) */
+  notesCount?: number;
 }
 
 // ── ステップテンプレート ─────────────────────────────────────────────────

--- a/designer/src/types/flow.ts
+++ b/designer/src/types/flow.ts
@@ -129,6 +129,8 @@ export interface ActionGroupMeta {
   updatedAt: string;
   /** 成熟度 (#186、docs/spec/process-flow-maturity.md §6.4)。未指定は "draft" として解釈 */
   maturity?: "draft" | "provisional" | "committed";
+  /** グループ全体の付箋合計件数 (#228、一覧表示用) */
+  notesCount?: number;
 }
 
 /** プロジェクト全体 */


### PR DESCRIPTION
Closes #228
Refs #151 (C), #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)