### PR TITLE
fix(dashboard): 保存済みレイアウトの minW/minH 救済

### DIFF
--- a/designer/src/components/dashboard/DashboardView.tsx
+++ b/designer/src/components/dashboard/DashboardView.tsx
@@ -33,6 +33,41 @@ function loadStoredLayouts(): StoredLayouts | null {
   }
 }
 
+/**
+ * 既存の保存済みレイアウトに対し、panelRegistry の最新 min/max 制約を反映する。
+ * - 既存 item の w/h が minW/minH を下回っていれば引き上げる (過去の小さすぎる保存値の救済)
+ * - 未登録の新パネルがあれば default を末尾追加
+ */
+function reconcileLayouts(stored: StoredLayouts, defaults: LayoutItem[]): StoredLayouts {
+  const reconciled: StoredLayouts = {};
+  const defaultById = new Map(defaults.map((d) => [d.i, d]));
+  for (const [bp, layout] of Object.entries(stored)) {
+    if (!layout) continue;
+    const seen = new Set<string>();
+    const merged: LayoutItem[] = layout.map((item) => {
+      seen.add(item.i);
+      const def = defaultById.get(item.i);
+      if (!def) return item;
+      const minW = def.minW ?? item.minW;
+      const minH = def.minH ?? item.minH;
+      return {
+        ...item,
+        w: minW != null ? Math.max(item.w, minW) : item.w,
+        h: minH != null ? Math.max(item.h, minH) : item.h,
+        minW,
+        minH,
+        maxW: def.maxW ?? item.maxW,
+        maxH: def.maxH ?? item.maxH,
+      };
+    });
+    for (const def of defaults) {
+      if (!seen.has(def.i)) merged.push(def);
+    }
+    reconciled[bp] = merged;
+  }
+  return reconciled;
+}
+
 function storeLayouts(layouts: StoredLayouts): void {
   try {
     localStorage.setItem(LAYOUT_STORAGE_KEY, JSON.stringify(layouts));
@@ -64,7 +99,7 @@ export function DashboardView() {
   const defaultLayout = useMemo(() => buildDefaultLayout(), []);
   const [layouts, setLayouts] = useState<StoredLayouts>(() => {
     const stored = loadStoredLayouts();
-    if (stored) return stored;
+    if (stored) return reconcileLayouts(stored, defaultLayout);
     return { lg: defaultLayout };
   });
 


### PR DESCRIPTION
## 関連

- Closes N/A (UX バグ修正: 処理フロー成熟度パネル取得時に発見)
- 仕様: N/A (内部実装)

## 概要

既存ユーザーのブラウザに古い localStorage レイアウト (`dashboard-layout-v1`) が残っていると、process-flow-maturity パネルが `w:1, h:1` (110×78px) で表示され中身 (確定率 / 内訳バッジ / 未確定警告) が全く見えなくなる問題を修正。

## 主な変更

- **designer/src/components/dashboard/DashboardView.tsx**
  - `reconcileLayouts(stored, defaults)` 追加
  - 既存 item の w/h が minW/minH 未満なら引き上げ
  - stored に無い新規パネルは default を末尾追加
  - minW/minH/maxW/maxH 自体も最新値を伝播 (以降のリサイズ制約に反映)
  - `useState` の初期値で reconcile を必ず通す

## 仕様逐条突合 (自己申告)

N/A (内部実装の UX 修正)

動作確認 (Playwright MCP):
- 修正前: localStorage に `w:1,h:1, minW:undefined, minH:undefined` がある状態 → レンダリング 110×78px (中身見えず)
- 修正後: 同じ localStorage → レンダリング 475×258px (panelRegistry の `{minW:4, minH:3}` が適用)

## レビューで特に見てほしい箇所

- **reconcile は DashboardView 内部関数**: ユニットテストを書くには export が必要。テスト未追加。手動検証のみで OK か
- **後方互換性**: 古いレイアウトの `moved`, `static` 等のフィールドは `...item` で維持している
- **user のドラッグ済みレイアウトを勝手に変えないか**: w/h は Math.max でしか上書きしないので、既に minW 以上のユーザーは影響なし

## 動作確認

- [x] typecheck pass
- [x] lint pass
- [x] Playwright MCP でサイズ救済を目視確認
- [ ] GitHub 上で他ユーザーでの既存挙動を実地検証 (UI 影響あり、ユーザー目視待ち)

🤖 Generated with [Claude Code](https://claude.com/claude-code)