### PR TITLE
feat(schemas): 処理フロー JSON Schema を一次成果物として分離

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,17 @@ URL 規約: **`/category/feature[/:id]`** 形式（Java 風階層）。ルート
 - Playwright: `designer/e2e/**/*.spec.ts` — UI・ナビゲーション操作
 - MCP E2E: `designer/e2e/mcp/**/*.spec.ts` — wsBridge ファイル操作（要 designer-mcp 起動）
 
+## Process Flow (処理フロー) — 一次成果物は JSON Schema
+
+処理フロー定義はこのプロジェクトの主出力 (AI が読んで実装する前提)。TypeScript 型は派生物、UI は最後尾の表示層。変更時の順序:
+
+1. 仕様書 [`docs/spec/process-flow-*.md`](docs/spec/README.md)
+2. JSON Schema [`schemas/process-flow.schema.json`](schemas/process-flow.schema.json)
+3. TypeScript 型 `designer/src/types/action.ts`
+4. UI / 実装
+
+検証テスト: `cd designer && npx vitest run src/schemas/process-flow.schema.test.ts` — `docs/sample-project/actions/*.json` の全件をスキーマで検証する。
+
 ## UI Conventions
 
 詳細仕様は [docs/spec/](docs/spec/README.md) に集約。一覧系 UI を触る前に必ず読む:

--- a/designer/package-lock.json
+++ b/designer/package-lock.json
@@ -35,6 +35,8 @@
         "@types/react-grid-layout": "^1.3.6",
         "@vitejs/plugin-react": "^6.0.1",
         "@vitest/ui": "^4.1.4",
+        "ajv": "^8.18.0",
+        "ajv-formats": "^3.0.1",
         "eslint": "^9.39.4",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
@@ -701,6 +703,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -713,6 +732,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint/js": {
       "version": "9.39.4",
@@ -2038,20 +2064,38 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-regex": {
@@ -2789,6 +2833,30 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/espree": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
@@ -2899,6 +2967,23 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -3277,9 +3362,9 @@
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },

--- a/designer/package.json
+++ b/designer/package.json
@@ -40,6 +40,8 @@
     "@types/react-grid-layout": "^1.3.6",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/ui": "^4.1.4",
+    "ajv": "^8.18.0",
+    "ajv-formats": "^3.0.1",
     "eslint": "^9.39.4",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",

--- a/designer/src/schemas/process-flow.schema.test.ts
+++ b/designer/src/schemas/process-flow.schema.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import Ajv2020, { type ValidateFunction } from "ajv/dist/2020";
+import addFormats from "ajv-formats";
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve, join } from "node:path";
+
+const repoRoot = resolve(__dirname, "../../../");
+const schemaPath = resolve(repoRoot, "schemas/process-flow.schema.json");
+const samplesDir = resolve(repoRoot, "docs/sample-project/actions");
+
+let validate: ValidateFunction;
+
+beforeAll(() => {
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const schema = JSON.parse(readFileSync(schemaPath, "utf-8"));
+  validate = ajv.compile(schema);
+});
+
+describe("process-flow.schema.json — docs/sample-project/actions/*.json", () => {
+  const files = readdirSync(samplesDir).filter((f) => f.endsWith(".json"));
+
+  it("サンプルファイルが存在する (防御)", () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  for (const file of files) {
+    it(`${file} がスキーマに適合する`, () => {
+      const data = JSON.parse(readFileSync(join(samplesDir, file), "utf-8"));
+      const ok = validate(data);
+      if (!ok) {
+        const msg = validate.errors
+          ?.map((e) => `  - ${e.instancePath} ${e.message}${e.params ? " " + JSON.stringify(e.params) : ""}`)
+          .join("\n");
+        throw new Error(`スキーマ違反 (${file}):\n${msg}`);
+      }
+      expect(ok).toBe(true);
+    });
+  }
+});
+
+describe("process-flow.schema.json — 明示的な negative ケース", () => {
+  it("必須フィールド欠落で reject される", () => {
+    const invalid = {
+      id: "a", name: "x", type: "screen", description: "", actions: [],
+      createdAt: "2026-01-01T00:00:00Z",
+      // updatedAt 欠落
+    };
+    expect(validate(invalid)).toBe(false);
+  });
+
+  it("未知の type で reject される", () => {
+    const invalid = {
+      id: "a", name: "x", type: "screen", description: "", actions: [
+        {
+          id: "act1", name: "ボタン", trigger: "click",
+          steps: [
+            { id: "s1", type: "UNKNOWN_TYPE", description: "" },
+          ],
+        },
+      ],
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+    };
+    expect(validate(invalid)).toBe(false);
+  });
+
+  it("maturity が enum 外だと reject", () => {
+    const invalid = {
+      id: "a", name: "x", type: "screen", description: "", actions: [],
+      maturity: "FINAL",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+    };
+    expect(validate(invalid)).toBe(false);
+  });
+});

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -7,6 +7,11 @@
 | ファイル | 対象 | 関連 issue |
 |---|---|---|
 | [list-common.md](list-common.md) | 一覧系画面の操作・見た目・内部 API (選択・キーボード・D&D・コピペ・ソート・フィルタ・Read-only モード・No 列永続フィールド) | #133 / #148 |
+| [process-flow-maturity.md](process-flow-maturity.md) | 成熟度・付箋・上流/下流モード (Phase 1 基盤) | #151 / #152 |
+| [process-flow-variables.md](process-flow-variables.md) | 変数・入出力・outputBinding (Phase 1 基盤) | #151 / #152 |
+| [process-flow-extensions.md](process-flow-extensions.md) | HTTP 契約 / TX / Saga / 外部 outcomes / ValidationRule / compute / return (Phase B) | #151 / #182 |
+
+**一次成果物**: JSON スキーマ [`schemas/process-flow.schema.json`](../../schemas/process-flow.schema.json) ([README](../../schemas/README.md))。仕様書と突合する機械可読版。
 
 ## 位置づけ
 

--- a/docs/spec/process-flow-extensions.md
+++ b/docs/spec/process-flow-extensions.md
@@ -8,6 +8,8 @@ Issue: #182 (親: #151, #152)
 
 **UI 対応**: 各機能の実際の UI は [`docs/ui-screenshots/`](../ui-screenshots/README.md) を参照。
 
+**一次成果物 (機械可読)**: [`schemas/process-flow.schema.json`](../../schemas/process-flow.schema.json) — 外部 AI / CI からも参照可能な JSON Schema 2020-12。本ドキュメントの各節と 1:1 対応。
+
 ## 位置づけ
 
 - **Phase 1 (基盤)**: `process-flow-maturity.md` / `process-flow-variables.md` に記載。maturity / notes / mode / StructuredField / outputBinding / argumentMapping の基盤

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -39,7 +39,7 @@ if (!ok) {
 }
 ```
 
-`$id`: `https://github.com/csilost2001/html-designer/schemas/process-flow.schema.json` — 外部から参照する場合はこの URL を使用 (リモート参照は reliability トレードオフを考慮)。
+`$id`: `https://raw.githubusercontent.com/csilost2001/html-designer/main/schemas/process-flow.schema.json` — 外部から参照する場合はこの URL を使用。main ブランチの最新版を指す。特定バージョンに固定したい場合はコミット SHA を含む raw URL を使う (例: `.../html-designer/<SHA>/schemas/process-flow.schema.json`)。
 
 ### 本リポジトリ内の検証テスト
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,70 @@
+# JSON Schema (処理フロー一次成果物)
+
+このディレクトリは、html-designer の JSON 資産の**正規スキーマ**を保持する。designer フロントエンドの外 (別リポジトリの AI エージェント、CI パイプライン、外部エディタ等) からでも spec に準拠してデータを検証・生成できるようにする。
+
+## 位置づけ
+
+本プロジェクトは **AI が処理フロー JSON を読み取って実装する** ことを主用途とする。したがって:
+
+- **JSON スキーマが一次成果物**
+- TypeScript 型 (`designer/src/types/action.ts`) は designer 内部でのみ利用される派生物
+- UI は最後尾の表示層に過ぎない
+
+この原則は `docs/spec/process-flow-extensions.md` 等の仕様と本スキーマを突合させることで担保する。
+
+## ファイル
+
+| ファイル | 対象 | TS 型 |
+|----------|------|-------|
+| `process-flow.schema.json` | ActionGroup (処理フロー定義) | `ActionGroup` @ `designer/src/types/action.ts` |
+
+スキーマドラフト: **JSON Schema 2020-12**
+
+## 使い方
+
+### 外部プロジェクト (別 AI エージェント / CI) からの検証
+
+```ts
+import Ajv2020 from "ajv/dist/2020";
+import addFormats from "ajv-formats";
+import schema from "./schemas/process-flow.schema.json" assert { type: "json" };
+
+const ajv = new Ajv2020({ allErrors: true, strict: false });
+addFormats(ajv);
+const validate = ajv.compile(schema);
+
+const ok = validate(actionGroupJson);
+if (!ok) {
+  console.error(validate.errors);
+}
+```
+
+`$id`: `https://github.com/csilost2001/html-designer/schemas/process-flow.schema.json` — 外部から参照する場合はこの URL を使用 (リモート参照は reliability トレードオフを考慮)。
+
+### 本リポジトリ内の検証テスト
+
+```bash
+cd designer
+npx vitest run src/schemas/process-flow.schema.test.ts
+```
+
+`docs/sample-project/actions/*.json` の全ファイルを自動検証する。新しいサンプルを追加する場合も、このテストを通過させる必要がある。
+
+## バージョニング方針
+
+- **Phase B 時点で初版** (2026-04-20)
+- 後方互換を破壊する変更時はスキーマを別ファイル (`process-flow.v2.schema.json` 等) に分けて、旧版を残す
+- フィールド追加は optional で加える (既存データは影響を受けない)
+- TypeScript 型を変更した場合は本スキーマも同時に更新し、テストで突合確認 (`npx vitest` 必須)
+
+## 対応する仕様書
+
+- [`docs/spec/process-flow-extensions.md`](../docs/spec/process-flow-extensions.md) — Phase B スキーマ拡張の網羅リファレンス
+- [`docs/spec/process-flow-maturity.md`](../docs/spec/process-flow-maturity.md) — 成熟度・付箋・モード (Phase 1 基盤)
+- [`docs/spec/process-flow-variables.md`](../docs/spec/process-flow-variables.md) — 変数・入出力・outputBinding (Phase 1 基盤)
+
+## 関連コード
+
+- `designer/src/types/action.ts` — TypeScript 型定義 (本スキーマと同期保守)
+- `designer/src/utils/actionMigration.ts` — 旧形式からの変換 (新スキーマは旧形式も union 側で受け入れる)
+- `designer/src/schemas/process-flow.schema.test.ts` — サンプル検証 + negative ケース

--- a/schemas/process-flow.schema.json
+++ b/schemas/process-flow.schema.json
@@ -1,0 +1,704 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/csilost2001/html-designer/schemas/process-flow.schema.json",
+  "title": "ActionGroup (処理フロー定義)",
+  "description": "html-designer の処理フロー (ActionGroup) の正規スキーマ。data/actions/*.json の各ファイル・docs/sample-project/actions/*.json の各ファイルに一致する。TypeScript 型は designer/src/types/action.ts の ActionGroup と等価。",
+  "type": "object",
+  "required": ["id", "name", "type", "description", "actions", "createdAt", "updatedAt"],
+  "additionalProperties": false,
+  "properties": {
+    "id": { "type": "string" },
+    "name": { "type": "string" },
+    "type": { "$ref": "#/$defs/ActionGroupType" },
+    "screenId": { "type": "string" },
+    "description": { "type": "string" },
+    "maturity": { "$ref": "#/$defs/Maturity" },
+    "mode": { "$ref": "#/$defs/ActionGroupMode" },
+    "actions": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/ActionDefinition" }
+    },
+    "createdAt": { "type": "string", "format": "date-time" },
+    "updatedAt": { "type": "string", "format": "date-time" }
+  },
+
+  "$defs": {
+    "ActionGroupType": {
+      "type": "string",
+      "enum": ["screen", "batch", "scheduled", "system", "common", "other"]
+    },
+    "ActionGroupMode": {
+      "type": "string",
+      "enum": ["upstream", "downstream"],
+      "description": "上流/下流モード。未指定は upstream 相当"
+    },
+    "Maturity": {
+      "type": "string",
+      "enum": ["draft", "provisional", "committed"],
+      "description": "成熟度 3 値。未指定は draft 相当"
+    },
+    "ActionTrigger": {
+      "type": "string",
+      "enum": ["click", "submit", "select", "change", "load", "timer", "other"]
+    },
+    "HttpMethod": {
+      "type": "string",
+      "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"]
+    },
+    "HttpAuthRequirement": {
+      "type": "string",
+      "enum": ["required", "optional", "none"],
+      "description": "認証要件。未指定は required 相当"
+    },
+    "HttpRoute": {
+      "type": "object",
+      "required": ["method", "path"],
+      "additionalProperties": false,
+      "properties": {
+        "method": { "$ref": "#/$defs/HttpMethod" },
+        "path": { "type": "string" },
+        "auth": { "$ref": "#/$defs/HttpAuthRequirement" }
+      }
+    },
+    "HttpResponseSpec": {
+      "type": "object",
+      "required": ["status"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string" },
+        "status": { "type": "integer", "minimum": 100, "maximum": 599 },
+        "contentType": { "type": "string" },
+        "bodySchema": { "type": "string" },
+        "description": { "type": "string" },
+        "when": { "type": "string" }
+      }
+    },
+
+    "FieldType": {
+      "oneOf": [
+        { "type": "string", "enum": ["string", "number", "boolean", "date"] },
+        {
+          "type": "object",
+          "required": ["kind", "tableId"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "tableRow" },
+            "tableId": { "type": "string" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "tableId"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "tableList" },
+            "tableId": { "type": "string" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "screenId"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "screenInput" },
+            "screenId": { "type": "string" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "label"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "custom" },
+            "label": { "type": "string" }
+          }
+        }
+      ]
+    },
+    "StructuredField": {
+      "type": "object",
+      "required": ["name", "type"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "label": { "type": "string" },
+        "type": { "$ref": "#/$defs/FieldType" },
+        "required": { "type": "boolean" },
+        "description": { "type": "string" },
+        "defaultValue": { "type": "string" }
+      }
+    },
+    "ActionFields": {
+      "description": "旧形式 (改行区切り文字列) と新形式 (StructuredField[]) の union",
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "array",
+          "items": { "$ref": "#/$defs/StructuredField" }
+        }
+      ]
+    },
+
+    "ActionDefinition": {
+      "type": "object",
+      "required": ["id", "name", "trigger", "steps"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string" },
+        "name": { "type": "string" },
+        "trigger": { "$ref": "#/$defs/ActionTrigger" },
+        "elementRef": { "type": "string" },
+        "description": { "type": "string" },
+        "inputs": { "$ref": "#/$defs/ActionFields" },
+        "outputs": { "$ref": "#/$defs/ActionFields" },
+        "maturity": { "$ref": "#/$defs/Maturity" },
+        "httpRoute": { "$ref": "#/$defs/HttpRoute" },
+        "responses": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/HttpResponseSpec" }
+        },
+        "steps": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Step" }
+        }
+      }
+    },
+
+    "StepNoteType": {
+      "type": "string",
+      "enum": ["assumption", "prerequisite", "todo", "deferred", "question"]
+    },
+    "StepNote": {
+      "type": "object",
+      "required": ["id", "type", "body", "createdAt"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string" },
+        "type": { "$ref": "#/$defs/StepNoteType" },
+        "body": { "type": "string" },
+        "createdAt": { "type": "string", "format": "date-time" }
+      }
+    },
+
+    "OutputBindingOperation": {
+      "type": "string",
+      "enum": ["assign", "accumulate", "push"]
+    },
+    "OutputBindingObject": {
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "operation": { "$ref": "#/$defs/OutputBindingOperation" }
+      }
+    },
+    "OutputBinding": {
+      "oneOf": [
+        { "type": "string" },
+        { "$ref": "#/$defs/OutputBindingObject" }
+      ]
+    },
+
+    "TxBoundaryRole": { "type": "string", "enum": ["begin", "member", "end"] },
+    "TxBoundary": {
+      "type": "object",
+      "required": ["role", "txId"],
+      "additionalProperties": false,
+      "properties": {
+        "role": { "$ref": "#/$defs/TxBoundaryRole" },
+        "txId": { "type": "string" }
+      }
+    },
+    "ExternalChainPhase": {
+      "type": "string",
+      "enum": ["authorize", "capture", "cancel", "other"]
+    },
+    "ExternalChain": {
+      "type": "object",
+      "required": ["chainId", "phase"],
+      "additionalProperties": false,
+      "properties": {
+        "chainId": { "type": "string" },
+        "phase": { "$ref": "#/$defs/ExternalChainPhase" }
+      }
+    },
+
+    "StepBaseProps": {
+      "description": "全ステップ共通フィールド (StepBase のプロパティ集合)。各 Step variant はこれを allOf でマージする",
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "description": { "type": "string" },
+        "note": { "type": "string" },
+        "notes": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/StepNote" }
+        },
+        "maturity": { "$ref": "#/$defs/Maturity" },
+        "runIf": { "type": "string" },
+        "outputBinding": { "$ref": "#/$defs/OutputBinding" },
+        "txBoundary": { "$ref": "#/$defs/TxBoundary" },
+        "transactional": { "type": "boolean" },
+        "compensatesFor": { "type": "string" },
+        "externalChain": { "$ref": "#/$defs/ExternalChain" },
+        "subSteps": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Step" }
+        }
+      }
+    },
+
+    "ValidationRuleType": {
+      "type": "string",
+      "enum": ["required", "regex", "maxLength", "minLength", "range", "enum", "custom"]
+    },
+    "ValidationRule": {
+      "type": "object",
+      "required": ["field", "type"],
+      "additionalProperties": false,
+      "properties": {
+        "field": { "type": "string" },
+        "type": { "$ref": "#/$defs/ValidationRuleType" },
+        "pattern": { "type": "string" },
+        "length": { "type": "integer", "minimum": 0 },
+        "min": { "type": "number" },
+        "max": { "type": "number" },
+        "values": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "condition": { "type": "string" },
+        "message": { "type": "string" }
+      }
+    },
+    "ValidationInlineBranch": {
+      "type": "object",
+      "required": ["ok", "ng"],
+      "additionalProperties": false,
+      "properties": {
+        "ok": { "type": "string" },
+        "ng": { "type": "string" },
+        "ngJumpTo": { "type": "string" },
+        "ngResponseRef": { "type": "string" },
+        "ngBodyExpression": { "type": "string" }
+      }
+    },
+    "ValidationStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "type", "description", "conditions"],
+          "additionalProperties": false,
+          "properties": {
+            "id": true, "description": true, "note": true, "notes": true,
+            "maturity": true, "runIf": true, "outputBinding": true,
+            "txBoundary": true, "transactional": true, "compensatesFor": true,
+            "externalChain": true, "subSteps": true,
+            "type": { "const": "validation" },
+            "conditions": { "type": "string" },
+            "rules": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/ValidationRule" }
+            },
+            "inlineBranch": { "$ref": "#/$defs/ValidationInlineBranch" }
+          }
+        }
+      ]
+    },
+
+    "DbOperation": {
+      "type": "string",
+      "enum": ["SELECT", "INSERT", "UPDATE", "DELETE"]
+    },
+    "AffectedRowsOperator": {
+      "type": "string",
+      "enum": [">", ">=", "=", "<", "<="]
+    },
+    "AffectedRowsCheck": {
+      "type": "object",
+      "required": ["operator", "expected", "onViolation"],
+      "additionalProperties": false,
+      "properties": {
+        "operator": { "$ref": "#/$defs/AffectedRowsOperator" },
+        "expected": { "type": "integer" },
+        "onViolation": {
+          "type": "string",
+          "enum": ["throw", "abort", "log", "continue"]
+        },
+        "errorCode": { "type": "string" },
+        "description": { "type": "string" }
+      }
+    },
+    "DbAccessStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "type", "description", "tableName", "operation"],
+          "additionalProperties": false,
+          "properties": {
+            "id": true, "description": true, "note": true, "notes": true,
+            "maturity": true, "runIf": true, "outputBinding": true,
+            "txBoundary": true, "transactional": true, "compensatesFor": true,
+            "externalChain": true, "subSteps": true,
+            "type": { "const": "dbAccess" },
+            "tableName": { "type": "string" },
+            "tableId": { "type": "string" },
+            "operation": { "$ref": "#/$defs/DbOperation" },
+            "fields": { "type": "string" },
+            "sql": { "type": "string" },
+            "affectedRowsCheck": { "$ref": "#/$defs/AffectedRowsCheck" }
+          }
+        }
+      ]
+    },
+
+    "ExternalCallOutcome": {
+      "type": "string",
+      "enum": ["success", "failure", "timeout"]
+    },
+    "ExternalCallOutcomeSpec": {
+      "type": "object",
+      "required": ["action"],
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": ["continue", "abort", "compensate"]
+        },
+        "description": { "type": "string" },
+        "jumpTo": { "type": "string" },
+        "sideEffects": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Step" }
+        },
+        "sameAs": { "$ref": "#/$defs/ExternalCallOutcome" }
+      }
+    },
+    "RetryPolicy": {
+      "type": "object",
+      "required": ["maxAttempts"],
+      "additionalProperties": false,
+      "properties": {
+        "maxAttempts": { "type": "integer", "minimum": 1 },
+        "backoff": {
+          "type": "string",
+          "enum": ["fixed", "exponential"]
+        },
+        "initialDelayMs": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "ExternalSystemStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "type", "description", "systemName"],
+          "additionalProperties": false,
+          "properties": {
+            "id": true, "description": true, "note": true, "notes": true,
+            "maturity": true, "runIf": true, "outputBinding": true,
+            "txBoundary": true, "transactional": true, "compensatesFor": true,
+            "externalChain": true, "subSteps": true,
+            "type": { "const": "externalSystem" },
+            "systemName": { "type": "string" },
+            "protocol": { "type": "string" },
+            "outcomes": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "success": { "$ref": "#/$defs/ExternalCallOutcomeSpec" },
+                "failure": { "$ref": "#/$defs/ExternalCallOutcomeSpec" },
+                "timeout": { "$ref": "#/$defs/ExternalCallOutcomeSpec" }
+              }
+            },
+            "timeoutMs": { "type": "integer", "minimum": 0 },
+            "retryPolicy": { "$ref": "#/$defs/RetryPolicy" },
+            "fireAndForget": { "type": "boolean" }
+          }
+        }
+      ]
+    },
+
+    "CommonProcessStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "type", "description", "refId"],
+          "additionalProperties": false,
+          "properties": {
+            "id": true, "description": true, "note": true, "notes": true,
+            "maturity": true, "runIf": true, "outputBinding": true,
+            "txBoundary": true, "transactional": true, "compensatesFor": true,
+            "externalChain": true, "subSteps": true,
+            "type": { "const": "commonProcess" },
+            "refId": { "type": "string" },
+            "refName": { "type": "string" },
+            "argumentMapping": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            }
+          }
+        }
+      ]
+    },
+
+    "ScreenTransitionStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "type", "description", "targetScreenName"],
+          "additionalProperties": false,
+          "properties": {
+            "id": true, "description": true, "note": true, "notes": true,
+            "maturity": true, "runIf": true, "outputBinding": true,
+            "txBoundary": true, "transactional": true, "compensatesFor": true,
+            "externalChain": true, "subSteps": true,
+            "type": { "const": "screenTransition" },
+            "targetScreenId": { "type": "string" },
+            "targetScreenName": { "type": "string" }
+          }
+        }
+      ]
+    },
+
+    "DisplayUpdateStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "type", "description", "target"],
+          "additionalProperties": false,
+          "properties": {
+            "id": true, "description": true, "note": true, "notes": true,
+            "maturity": true, "runIf": true, "outputBinding": true,
+            "txBoundary": true, "transactional": true, "compensatesFor": true,
+            "externalChain": true, "subSteps": true,
+            "type": { "const": "displayUpdate" },
+            "target": { "type": "string" }
+          }
+        }
+      ]
+    },
+
+    "BranchConditionVariant": {
+      "type": "object",
+      "required": ["kind", "errorCode"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "const": "tryCatch" },
+        "errorCode": { "type": "string" },
+        "description": { "type": "string" }
+      }
+    },
+    "BranchCondition": {
+      "oneOf": [
+        { "type": "string" },
+        { "$ref": "#/$defs/BranchConditionVariant" }
+      ]
+    },
+    "Branch": {
+      "type": "object",
+      "required": ["id", "code", "condition", "steps"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string" },
+        "code": { "type": "string" },
+        "label": { "type": "string" },
+        "condition": { "$ref": "#/$defs/BranchCondition" },
+        "steps": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Step" }
+        }
+      }
+    },
+    "BranchStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "type", "description", "branches"],
+          "additionalProperties": false,
+          "properties": {
+            "id": true, "description": true, "note": true, "notes": true,
+            "maturity": true, "runIf": true, "outputBinding": true,
+            "txBoundary": true, "transactional": true, "compensatesFor": true,
+            "externalChain": true, "subSteps": true,
+            "type": { "const": "branch" },
+            "branches": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/$defs/Branch" }
+            },
+            "elseBranch": { "$ref": "#/$defs/Branch" }
+          }
+        }
+      ]
+    },
+
+    "LoopKind": { "type": "string", "enum": ["count", "condition", "collection"] },
+    "LoopConditionMode": { "type": "string", "enum": ["continue", "exit"] },
+    "LoopStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "type", "description", "loopKind", "steps"],
+          "additionalProperties": false,
+          "properties": {
+            "id": true, "description": true, "note": true, "notes": true,
+            "maturity": true, "runIf": true, "outputBinding": true,
+            "txBoundary": true, "transactional": true, "compensatesFor": true,
+            "externalChain": true, "subSteps": true,
+            "type": { "const": "loop" },
+            "loopKind": { "$ref": "#/$defs/LoopKind" },
+            "countExpression": { "type": "string" },
+            "conditionMode": { "$ref": "#/$defs/LoopConditionMode" },
+            "conditionExpression": { "type": "string" },
+            "collectionSource": { "type": "string" },
+            "collectionItemName": { "type": "string" },
+            "steps": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/Step" }
+            }
+          }
+        }
+      ]
+    },
+
+    "LoopBreakStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "type", "description"],
+          "additionalProperties": false,
+          "properties": {
+            "id": true, "description": true, "note": true, "notes": true,
+            "maturity": true, "runIf": true, "outputBinding": true,
+            "txBoundary": true, "transactional": true, "compensatesFor": true,
+            "externalChain": true, "subSteps": true,
+            "type": { "const": "loopBreak" }
+          }
+        }
+      ]
+    },
+    "LoopContinueStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "type", "description"],
+          "additionalProperties": false,
+          "properties": {
+            "id": true, "description": true, "note": true, "notes": true,
+            "maturity": true, "runIf": true, "outputBinding": true,
+            "txBoundary": true, "transactional": true, "compensatesFor": true,
+            "externalChain": true, "subSteps": true,
+            "type": { "const": "loopContinue" }
+          }
+        }
+      ]
+    },
+
+    "JumpStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "type", "description", "jumpTo"],
+          "additionalProperties": false,
+          "properties": {
+            "id": true, "description": true, "note": true, "notes": true,
+            "maturity": true, "runIf": true, "outputBinding": true,
+            "txBoundary": true, "transactional": true, "compensatesFor": true,
+            "externalChain": true, "subSteps": true,
+            "type": { "const": "jump" },
+            "jumpTo": { "type": "string" }
+          }
+        }
+      ]
+    },
+
+    "ComputeStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "type", "description", "expression"],
+          "additionalProperties": false,
+          "properties": {
+            "id": true, "description": true, "note": true, "notes": true,
+            "maturity": true, "runIf": true, "outputBinding": true,
+            "txBoundary": true, "transactional": true, "compensatesFor": true,
+            "externalChain": true, "subSteps": true,
+            "type": { "const": "compute" },
+            "expression": { "type": "string" }
+          }
+        }
+      ]
+    },
+
+    "ReturnStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "type", "description"],
+          "additionalProperties": false,
+          "properties": {
+            "id": true, "description": true, "note": true, "notes": true,
+            "maturity": true, "runIf": true, "outputBinding": true,
+            "txBoundary": true, "transactional": true, "compensatesFor": true,
+            "externalChain": true, "subSteps": true,
+            "type": { "const": "return" },
+            "responseRef": { "type": "string" },
+            "bodyExpression": { "type": "string" }
+          }
+        }
+      ]
+    },
+
+    "OtherStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "type", "description"],
+          "additionalProperties": false,
+          "properties": {
+            "id": true, "description": true, "note": true, "notes": true,
+            "maturity": true, "runIf": true, "outputBinding": true,
+            "txBoundary": true, "transactional": true, "compensatesFor": true,
+            "externalChain": true, "subSteps": true,
+            "type": { "const": "other" }
+          }
+        }
+      ]
+    },
+
+    "Step": {
+      "description": "discriminator: type プロパティの値で variant を決定",
+      "oneOf": [
+        { "$ref": "#/$defs/ValidationStep" },
+        { "$ref": "#/$defs/DbAccessStep" },
+        { "$ref": "#/$defs/ExternalSystemStep" },
+        { "$ref": "#/$defs/CommonProcessStep" },
+        { "$ref": "#/$defs/ScreenTransitionStep" },
+        { "$ref": "#/$defs/DisplayUpdateStep" },
+        { "$ref": "#/$defs/BranchStep" },
+        { "$ref": "#/$defs/LoopStep" },
+        { "$ref": "#/$defs/LoopBreakStep" },
+        { "$ref": "#/$defs/LoopContinueStep" },
+        { "$ref": "#/$defs/JumpStep" },
+        { "$ref": "#/$defs/ComputeStep" },
+        { "$ref": "#/$defs/ReturnStep" },
+        { "$ref": "#/$defs/OtherStep" }
+      ]
+    }
+  }
+}

--- a/schemas/process-flow.schema.json
+++ b/schemas/process-flow.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/csilost2001/html-designer/schemas/process-flow.schema.json",
+  "$id": "https://raw.githubusercontent.com/csilost2001/html-designer/main/schemas/process-flow.schema.json",
   "title": "ActionGroup (処理フロー定義)",
   "description": "html-designer の処理フロー (ActionGroup) の正規スキーマ。data/actions/*.json の各ファイル・docs/sample-project/actions/*.json の各ファイルに一致する。TypeScript 型は designer/src/types/action.ts の ActionGroup と等価。",
   "type": "object",


### PR DESCRIPTION
## 関連

- Closes N/A (Phase B 凍結後の deliverable 拡張)
- 関連: #151 (Phase B 親トラッカー) / #182
- 仕様: docs/spec/process-flow-extensions.md 全節 + process-flow-maturity.md + process-flow-variables.md

## 概要

処理フロー定義はこのプロジェクトの主出力 (AI が読んで実装する前提)。TypeScript 型は designer 内部の派生物に過ぎず、**designer の外からは参照できない**状態だった。Phase B スキーマが 5.0/5 ドッグフードで凍結したのを機に、JSON Schema 2020-12 を正規の一次成果物として `schemas/` に分離する。

## 主な変更

- **`schemas/process-flow.schema.json`** (新規)
  - ActionGroup + ActionDefinition + 14 Step variant
  - Phase B 拡張: HTTP 契約 (httpRoute/responses) / runIf / TxBoundary / compensatesFor / ExternalChain / ExternalCallOutcome + sideEffects + sameAs / affectedRowsCheck / ValidationRule[] / BranchCondition union (tryCatch variant) / OutputBinding union / ComputeStep / ReturnStep
  - union 型は `oneOf`、discriminator は Step.type の const
  - `additionalProperties: false` で厳密化
- **`schemas/README.md`** (新規)
  - 位置づけ (「AI 読み取りが主、JSON Schema が一次成果物、TS 型は派生」)
  - 外部プロジェクトからの使い方 (ajv 使用例)
  - バージョニング方針 (破壊的変更は別ファイル化)
- **`designer/src/schemas/process-flow.schema.test.ts`** (新規)
  - `docs/sample-project/actions/*.json` 全 4 件をスキーマ検証
  - negative ケース 3 件 (必須欠落 / 未知 type / 不正 maturity enum)
- **`docs/spec/README.md` / `process-flow-extensions.md`**: スキーマリンク追加
- **`CLAUDE.md`**: 変更順序 (仕様書 → JSON Schema → TS 型 → UI) を明文化
- **`designer/package.json`**: ajv / ajv-formats を devDependencies に追加

## 仕様逐条突合 (自己申告)

TS 型 (designer/src/types/action.ts) に対する schema の網羅性:

- ActionGroup 全フィールド → schema root ✓
- ActionDefinition + httpRoute + responses[] → `$defs/ActionDefinition` ✓
- Maturity / ActionGroupMode / ActionTrigger 全 enum ✓
- StepBase 全共通フィールド (note/notes/runIf/outputBinding/txBoundary/transactional/compensatesFor/externalChain/subSteps) → `$defs/StepBaseProps` ✓
- 14 Step variant → `$defs/{Validation|DbAccess|ExternalSystem|CommonProcess|ScreenTransition|DisplayUpdate|Branch|Loop|LoopBreak|LoopContinue|Jump|Compute|Return|Other}Step` ✓
- ValidationRule 7 種 (required/regex/maxLength/minLength/range/enum/custom) ✓
- ExternalCallOutcomeSpec (action/sideEffects/sameAs) ✓
- BranchCondition union (string | tryCatch) ✓
- OutputBinding union (string | {name, operation}) ✓
- AffectedRowsCheck (5 operator + 4 onViolation) ✓
- FieldType union (primitive 4 + tableRow/tableList/screenInput/custom) ✓

動作確認:
```
$ cd designer && npx vitest run src/schemas/process-flow.schema.test.ts
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

## レビューで特に見てほしい箇所

- **`additionalProperties: false` の徹底**: 各 Step variant で `additionalProperties: false` にしている。将来フィールド追加時に schema 更新が必要になるトレードオフだが、タイプミス検出のため優先
- **allOf + StepBaseProps パターン**: Step variant ごとに共通プロパティを `allOf` でマージし、variant 固有プロパティだけ書き足す構造。他の流儀 (別 ref での継承等) もある
- **union の oneOf 衝突**: BranchCondition が `string | object` など、ajv の strict mode で解釈が分かれる可能性。`strict: false` で回避済みだが代替案あれば
- **サンプルが 4 件だけ**: より多様なケースを検証するには data/actions/*.json (19 件、gitignored) も含めたいが、テスト時にファイルが無い可能性があるので docs/sample-project/actions/ に限定。サンプル拡充は別 PR

## 動作確認

- [x] typecheck pass
- [x] lint pass (新規ファイルは warning/error なし、既存の pre-existing エラー 21 件は本 PR と無関係)
- [x] vitest run で 8 tests pass
- [x] ajv の 2020-12 draft 対応 (`ajv/dist/2020` import)
- [ ] 外部プロジェクトからの GitHub raw URL 参照確認 (merge 後に実機確認)

## スクリーンショット

N/A (バックエンド/スキーマ変更のみ、UI 影響なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)