### PR TITLE
feat(schemas): v1.1 — ElseBranch 分離 + FieldType 複合型 (#253)

### DIFF
--- a/designer/src/schemas/process-flow.schema.test.ts
+++ b/designer/src/schemas/process-flow.schema.test.ts
@@ -39,6 +39,84 @@ describe("process-flow.schema.json — docs/sample-project/actions/*.json", () =
   }
 });
 
+describe("process-flow.schema.json — v1.1 拡張 (#253)", () => {
+  const base = {
+    id: "a", name: "x", type: "screen", description: "",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  };
+
+  it("FieldType.array (itemType 再帰) が accept される", () => {
+    const ok = validate({
+      ...base,
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        inputs: [{
+          name: "items",
+          type: { kind: "array", itemType: { kind: "object", fields: [
+            { name: "itemId", type: "number" },
+            { name: "quantity", type: "number", required: true },
+          ]}},
+        }],
+        steps: [],
+      }],
+    });
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("FieldType.object.fields で StructuredField 再帰", () => {
+    const ok = validate({
+      ...base,
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        inputs: [{
+          name: "customer",
+          type: { kind: "object", fields: [
+            { name: "id", type: "number" },
+            { name: "name", type: "string", required: true },
+            { name: "addresses", type: { kind: "array", itemType: "string" } },
+          ]},
+        }],
+        steps: [],
+      }],
+    });
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("BranchStep.elseBranch は condition を省略可能", () => {
+    const ok = validate({
+      ...base,
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "s1", type: "branch", description: "",
+          branches: [{ id: "b1", code: "A", condition: "@flag == true", steps: [] }],
+          elseBranch: { id: "b-else", code: "else", steps: [] },
+        }],
+      }],
+    });
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("elseBranch に condition: \"\" があっても後方互換で accept", () => {
+    const ok = validate({
+      ...base,
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "s1", type: "branch", description: "",
+          branches: [{ id: "b1", code: "A", condition: "@flag", steps: [] }],
+          elseBranch: { id: "b-else", code: "else", condition: "", steps: [] },
+        }],
+      }],
+    });
+    expect(ok).toBe(true);
+  });
+});
+
 describe("process-flow.schema.json — 明示的な negative ケース", () => {
   it("必須フィールド欠落で reject される", () => {
     const invalid = {

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -472,12 +472,25 @@ export interface Branch {
   steps: Step[];
 }
 
+/**
+ * else 分岐 (otherwise)。構造は Branch とほぼ同じだが condition は本質的に不要 (#253)。
+ * 旧データ (condition: "" 等の空文字列埋め) を壊さないため、後方互換で condition は optional。
+ */
+export interface ElseBranch {
+  id: string;
+  code: string;
+  label?: string;
+  /** 後方互換用のみ保持。新規データは省略可 */
+  condition?: BranchCondition;
+  steps: Step[];
+}
+
 export interface BranchStep extends StepBase {
   type: "branch";
   /** 最小 1 個、D&D で並び替え可能 */
   branches: Branch[];
   /** 任意、常に最後に描画 */
-  elseBranch?: Branch;
+  elseBranch?: ElseBranch;
 }
 
 /** ループ種別 */
@@ -571,12 +584,20 @@ export type Step =
 
 // ── 入出力の構造化 (docs/spec/process-flow-variables.md §3.1) ─────────────
 
-/** 入出力フィールドの型。primitive + テーブル/画面参照 + 自由記述型の union */
+/**
+ * 入出力フィールドの型。primitive + 複合型 (array/object) + テーブル/画面参照 + 自由記述型の union。
+ *
+ * `array` / `object` は #253 で追加。`custom` の `label` に
+ * `"Array<{itemId, quantity}>"` のような自由記述で逃げていたケースを構造化可能にする。
+ * 従来は custom で表現していたものも、可能なら array / object に移行するのが望ましい。
+ */
 export type FieldType =
   | "string"
   | "number"
   | "boolean"
   | "date"
+  | { kind: "array"; itemType: FieldType }
+  | { kind: "object"; fields: StructuredField[] }
   | { kind: "tableRow"; tableId: string }
   | { kind: "tableList"; tableId: string }
   | { kind: "screenInput"; screenId: string }

--- a/docs/spec/process-flow-extensions.md
+++ b/docs/spec/process-flow-extensions.md
@@ -322,6 +322,20 @@ type BranchCondition = string | BranchConditionVariant;
 
 PR: #177
 
+### 7.2 `ElseBranch` (#253 v1.1)
+
+`BranchStep.elseBranch` の型を `Branch` から `ElseBranch` に変更。else 分岐は本質的に condition 不要なため、`condition` を optional にした。旧データ (`condition: ""` 等の空文字列埋め) は後方互換で accept。
+
+```ts
+interface ElseBranch {
+  id: string;
+  code: string;
+  label?: string;
+  condition?: BranchCondition;  // 後方互換用のみ
+  steps: Step[];
+}
+```
+
 ## 8. 変数の構造化 (outputBinding 拡張)
 
 ### 8.1 `OutputBinding` union

--- a/docs/spec/process-flow-variables.md
+++ b/docs/spec/process-flow-variables.md
@@ -49,10 +49,12 @@ interface StructuredField {
 
 type FieldType =
   | "string" | "number" | "boolean" | "date"
+  | { kind: "array"; itemType: FieldType }              // 配列型 (#253 v1.1)
+  | { kind: "object"; fields: StructuredField[] }       // オブジェクト型 (#253 v1.1)
   | { kind: "tableRow"; tableId: string }        // テーブル 1 行
   | { kind: "tableList"; tableId: string }       // テーブルの配列
   | { kind: "screenInput"; screenId: string }    // 画面の入力セット
-  | { kind: "custom"; label: string };           // 自由記述型
+  | { kind: "custom"; label: string };           // 自由記述型 (array/object で表現できない場合の最終手段)
 
 interface ActionDefinition {
   inputs?: string | StructuredField[];

--- a/schemas/process-flow.schema.json
+++ b/schemas/process-flow.schema.json
@@ -78,6 +78,29 @@
       "oneOf": [
         { "type": "string", "enum": ["string", "number", "boolean", "date"] },
         {
+          "description": "配列型。itemType で要素型を再帰的に表現。例: Array<{itemId, quantity}>",
+          "type": "object",
+          "required": ["kind", "itemType"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "array" },
+            "itemType": { "$ref": "#/$defs/FieldType" }
+          }
+        },
+        {
+          "description": "オブジェクト型。fields[] で構造を表現。custom の label 逃げを置き換える",
+          "type": "object",
+          "required": ["kind", "fields"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "object" },
+            "fields": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/StructuredField" }
+            }
+          }
+        },
+        {
           "type": "object",
           "required": ["kind", "tableId"],
           "additionalProperties": false,
@@ -516,6 +539,22 @@
         }
       }
     },
+    "ElseBranch": {
+      "description": "else 分岐。condition は不要 (旧データ互換で optional として残す)",
+      "type": "object",
+      "required": ["id", "code", "steps"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string" },
+        "code": { "type": "string" },
+        "label": { "type": "string" },
+        "condition": { "$ref": "#/$defs/BranchCondition" },
+        "steps": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Step" }
+        }
+      }
+    },
     "BranchStep": {
       "allOf": [
         { "$ref": "#/$defs/StepBaseProps" },
@@ -534,7 +573,7 @@
               "minItems": 1,
               "items": { "$ref": "#/$defs/Branch" }
             },
-            "elseBranch": { "$ref": "#/$defs/Branch" }
+            "elseBranch": { "$ref": "#/$defs/ElseBranch" }
           }
         }
       ]


### PR DESCRIPTION
## 関連

- Closes N/A (部分対応: #253 の高優先 2 点)
- 仕様: docs/spec/process-flow-extensions.md §7.2 (新設) / docs/spec/process-flow-variables.md §3.1

## 概要

#253 (スキーマ凍結後の再ドッグフードで 4/5 評価、描画できない箇所を洗い出し) に対する第一波 v1.1 対応。高優先の小規模 2 点のみ先行着地。残りの中優先 (式言語構造化、OutputBinding.initialValue 等) は別 PR で検討。

## 主な変更

### 1. `BranchStep.elseBranch` の型分離

旧: `elseBranch?: Branch` — `Branch.condition` が required のため、else 用途で `condition: ""` のハックが必要だった。
新: `elseBranch?: ElseBranch` — 新設の \`ElseBranch\` で `condition` を optional に。

```ts
export interface ElseBranch {
  id: string;
  code: string;
  label?: string;
  condition?: BranchCondition;  // 後方互換用のみ
  steps: Step[];
}
```

### 2. `FieldType` に複合型追加

`custom.label` 文字列 (\`"Array<{itemId, quantity}>"\` 等) で description 依存に逃げていたケースを構造化可能に:

```ts
type FieldType =
  | "string" | "number" | "boolean" | "date"
  | { kind: "array"; itemType: FieldType }              // 配列、再帰定義
  | { kind: "object"; fields: StructuredField[] }       // オブジェクト
  | { kind: "tableRow"|"tableList"|"screenInput"; ... }
  | { kind: "custom"; label: string };                  // 最終手段に格下げ
```

## 仕様逐条突合 (自己申告)

- **TS 型** designer/src/types/action.ts:457-490 (ElseBranch 新設、BranchStep.elseBranch 型変更、FieldType 拡張) ✓
- **JSON Schema** schemas/process-flow.schema.json `$defs/ElseBranch` / `$defs/FieldType` array & object variants 追加 ✓
- **回帰テスト** designer/src/schemas/process-flow.schema.test.ts に 4 件追加:
  - \`FieldType.array\` (itemType 再帰) accept ✓
  - \`FieldType.object.fields\` accept ✓
  - \`elseBranch\` condition 省略 accept ✓
  - \`elseBranch.condition: ""\` の旧データ後方互換 accept ✓
- **仕様書更新** docs/spec/process-flow-extensions.md §7.2 (新設) / process-flow-variables.md §3.1 ✓

## レビューで特に見てほしい箇所

- **TS 型の後方互換性**: \`Branch\` 型自体は変更せず、\`ElseBranch\` を新設。Structural typing により、既存コードが \`elseBranch\` に \`Branch\` 値を代入している箇所はそのまま動く (Branch は ElseBranch の subtype 相当)
- **FieldType.custom を残す判断**: array/object で表現できない型 (Generic な Promise / Observable / 独自 DSL 型など) のために残す。仕様書で「最終手段」と明記
- **JSON Schema の recursive $ref**: \`FieldType.array.itemType\` が自身を参照、\`object.fields[].type\` も FieldType を参照。ajv が循環参照を正しく扱うことをテストで確認済

## 動作確認

- [x] typecheck pass (designer)
- [x] lint pass (新規コード)
- [x] vitest run: 359 → 363 tests pass (4 件追加、既存回帰なし)
- [x] v1.1 新機能の accept / 旧データの backwards-compat を個別テスト

## スクリーンショット

N/A (スキーマ / 型定義変更のみ、UI 影響なし)

## #253 の残タスク (本 PR スコープ外)

- [ ] 式言語の構造化 `{ lang, src }` 包装
- [ ] OutputBindingObject.initialValue / scope
- [ ] ReturnStep.responseRef の参照整合性を JSON Schema で
- [ ] HttpResponseSpec.bodySchema を JSON Schema 参照化
- [ ] ActionGroup.errorCatalog の新設
- [ ] ExternalSystemStep.idempotencyKey / headers / auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)