### PR TITLE
feat(schemas): ActionGroup.errorCatalog 新設 (#253 v1.2)

### DIFF
--- a/designer/src/schemas/process-flow.schema.test.ts
+++ b/designer/src/schemas/process-flow.schema.test.ts
@@ -117,6 +117,59 @@ describe("process-flow.schema.json — v1.1 拡張 (#253)", () => {
   });
 });
 
+describe("process-flow.schema.json — errorCatalog (#253)", () => {
+  const base = {
+    id: "a", name: "x", type: "screen", description: "",
+    actions: [],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  };
+
+  it("errorCatalog 全フィールド accept", () => {
+    const ok = validate({
+      ...base,
+      errorCatalog: {
+        STOCK_SHORTAGE: {
+          httpStatus: 409,
+          defaultMessage: "在庫不足",
+          responseRef: "409-stock-shortage",
+          description: "引当 UPDATE で rowCount=0",
+        },
+        VALIDATION: {
+          httpStatus: 400,
+          responseRef: "400-validation",
+        },
+      },
+    });
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("errorCatalog 省略 accept (optional)", () => {
+    expect(validate({ ...base })).toBe(true);
+  });
+
+  it("errorCatalog 空オブジェクト accept", () => {
+    expect(validate({ ...base, errorCatalog: {} })).toBe(true);
+  });
+
+  it("ErrorCatalogEntry の未知フィールドは reject", () => {
+    expect(validate({
+      ...base,
+      errorCatalog: {
+        FOO: { httpStatus: 400, unknownField: "x" },
+      },
+    })).toBe(false);
+  });
+
+  it("httpStatus 範囲外は reject", () => {
+    expect(validate({
+      ...base,
+      errorCatalog: { FOO: { httpStatus: 99 } },
+    })).toBe(false);
+  });
+});
+
 describe("process-flow.schema.json — 明示的な negative ケース", () => {
   it("必須フィールド欠落で reject される", () => {
     const invalid = {

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -685,6 +685,22 @@ export interface ActionDefinition {
 
 // ── アクショングループ ───────────────────────────────────────────────────
 
+/**
+ * エラーコードカタログの 1 エントリ (#253)。
+ * 同一 errorCode が affectedRowsCheck.errorCode / BranchConditionVariant.errorCode / responses[].description の
+ * 複数箇所に散在する問題を解決するため、ActionGroup 単位で 1 箇所に集約する。
+ */
+export interface ErrorCatalogEntry {
+  /** 対応する HTTP ステータス (例: 409) */
+  httpStatus?: number;
+  /** 既定メッセージ (@conv.msg.* 参照も可) */
+  defaultMessage?: string;
+  /** action.responses[].id への参照。ReturnStep / 分岐処理で返却すべき response */
+  responseRef?: string;
+  /** 補足説明 */
+  description?: string;
+}
+
 export interface ActionGroup {
   id: string;
   name: string;
@@ -696,6 +712,11 @@ export interface ActionGroup {
   maturity?: Maturity;
   /** 上流/下流モード。未指定は "upstream" として解釈 (docs/spec/process-flow-maturity.md §5) */
   mode?: ActionGroupMode;
+  /**
+   * エラーコードカタログ (#253)。キー: errorCode (例: "STOCK_SHORTAGE")、値: HTTP ステータス / 既定メッセージ / 対応する responseRef。
+   * affectedRowsCheck.errorCode / BranchConditionVariant.errorCode から参照される。
+   */
+  errorCatalog?: Record<string, ErrorCatalogEntry>;
   createdAt: string;
   updatedAt: string;
 }

--- a/docs/spec/process-flow-extensions.md
+++ b/docs/spec/process-flow-extensions.md
@@ -362,6 +362,39 @@ type OutputBinding = string | OutputBindingObject;
 
 PR: #169
 
+## 8.5 エラーカタログ (ActionGroup.errorCatalog, #253 v1.2)
+
+同一 `errorCode` が `affectedRowsCheck.errorCode` / `BranchConditionVariant.errorCode` / `responses[].description` の複数箇所に散在する問題を解決するため、ActionGroup 単位で 1 箇所に集約する。
+
+```ts
+interface ErrorCatalogEntry {
+  httpStatus?: number;          // 例: 409
+  defaultMessage?: string;      // @conv.msg.* 参照も可
+  responseRef?: string;         // action.responses[].id への参照
+  description?: string;
+}
+
+// ActionGroup に追加
+errorCatalog?: Record<string, ErrorCatalogEntry>;
+```
+
+用例:
+
+```json
+"errorCatalog": {
+  "STOCK_SHORTAGE": {
+    "httpStatus": 409,
+    "defaultMessage": "在庫不足",
+    "responseRef": "409-stock-shortage",
+    "description": "引当 UPDATE で rowCount=0"
+  },
+  "VALIDATION": { "httpStatus": 400, "responseRef": "400-validation" },
+  "PAYMENT_FAILED": { "httpStatus": 402, "responseRef": "402-payment-failed" }
+}
+```
+
+実装時は: `affectedRowsCheck.errorCode == "STOCK_SHORTAGE"` → `errorCatalog.STOCK_SHORTAGE` を引いて httpStatus / responseRef / defaultMessage を 1 箇所で解決。
+
 ## 9. 後方互換性
 
 すべての拡張は **Optional** かつ **Union 型** (string | structured) のいずれかで、既存データは破壊されない。`migrateActionGroup` が読み込み時に:

--- a/schemas/process-flow.schema.json
+++ b/schemas/process-flow.schema.json
@@ -14,6 +14,11 @@
     "description": { "type": "string" },
     "maturity": { "$ref": "#/$defs/Maturity" },
     "mode": { "$ref": "#/$defs/ActionGroupMode" },
+    "errorCatalog": {
+      "description": "エラーコードカタログ (#253)。キーは errorCode (例: STOCK_SHORTAGE)。affectedRowsCheck.errorCode / BranchConditionVariant.errorCode から参照される",
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/ErrorCatalogEntry" }
+    },
     "actions": {
       "type": "array",
       "items": { "$ref": "#/$defs/ActionDefinition" }
@@ -60,6 +65,17 @@
         "auth": { "$ref": "#/$defs/HttpAuthRequirement" }
       }
     },
+    "ErrorCatalogEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "httpStatus": { "type": "integer", "minimum": 100, "maximum": 599 },
+        "defaultMessage": { "type": "string" },
+        "responseRef": { "type": "string" },
+        "description": { "type": "string" }
+      }
+    },
+
     "HttpResponseSpec": {
       "type": "object",
       "required": ["status"],


### PR DESCRIPTION
## 関連

- 部分対応: #253 の高優先項目 (errorCatalog 新設)
- 仕様: docs/spec/process-flow-extensions.md §8.5 (新設)

## 概要

#253 ドッグフードで指摘された「errorCode が複数箇所に散在して突合できない」問題を解決する。\`STOCK_SHORTAGE\` のような errorCode が:
- \`DbAccessStep.affectedRowsCheck.errorCode\`
- \`BranchConditionVariant.errorCode\` (tryCatch)
- \`HttpResponseSpec.description\`

に散在していたのを、ActionGroup 単位で 1 箇所に集約する。

## 主な変更

- **TS 型**: \`ErrorCatalogEntry\` + \`ActionGroup.errorCatalog?: Record<string, ErrorCatalogEntry>\`
- **JSON Schema**: \`\$defs/ErrorCatalogEntry\` 追加、ルートに \`errorCatalog\` 追加 (optional)
- **仕様書**: docs/spec/process-flow-extensions.md §8.5 新設、利用例つき
- **回帰テスト**: 5 件追加 (accept / 省略 / 空 / 未知フィールド reject / httpStatus 範囲外 reject)

## 仕様逐条突合 (自己申告)

- TS 型 `designer/src/types/action.ts:ErrorCatalogEntry` ✓
- JSON Schema `schemas/process-flow.schema.json` `$defs/ErrorCatalogEntry` + ルート errorCatalog ✓
- 仕様書 `docs/spec/process-flow-extensions.md §8.5` ✓
- テスト `designer/src/schemas/process-flow.schema.test.ts` errorCatalog describe ブロック 5 件 ✓

## 動作確認

- [x] typecheck pass
- [x] vitest run: 359 → 364 tests pass (+5、回帰なし)
- [x] 既存サンプル (errorCatalog なし) の後方互換

## スクリーンショット

N/A

## 残タスク (#253)

次 PR で順次対応:
- initialValue on OutputBindingObject
- responseRef 参照整合性テスト
- 式言語 convention (spec のみ)
- ExternalSystemStep auth/idempotency
- HttpResponseSpec.bodySchema union 化

🤖 Generated with [Claude Code](https://claude.com/claude-code)