### PR TITLE
feat(schemas): OutputBindingObject.initialValue 追加 (#253 v1.2)

### DIFF
--- a/designer/src/schemas/process-flow.schema.test.ts
+++ b/designer/src/schemas/process-flow.schema.test.ts
@@ -117,6 +117,73 @@ describe("process-flow.schema.json — v1.1 拡張 (#253)", () => {
   });
 });
 
+describe("process-flow.schema.json — OutputBindingObject.initialValue (#253)", () => {
+  const base = {
+    id: "a", name: "x", type: "screen", description: "",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  };
+
+  it("accumulate + initialValue='0' accept", () => {
+    const ok = validate({
+      ...base,
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "s1", type: "compute", description: "",
+          expression: "@subtotal + @line.amount",
+          outputBinding: { name: "subtotal", operation: "accumulate", initialValue: "0" },
+        }],
+      }],
+    });
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("push + initialValue='[]' accept", () => {
+    const ok = validate({
+      ...base,
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "s1", type: "compute", description: "",
+          expression: "@line",
+          outputBinding: { name: "lines", operation: "push", initialValue: "[]" },
+        }],
+      }],
+    });
+    expect(ok).toBe(true);
+  });
+
+  it("initialValue 省略 accept (optional)", () => {
+    expect(validate({
+      ...base,
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "s1", type: "compute", description: "",
+          expression: "x",
+          outputBinding: { name: "subtotal", operation: "accumulate" },
+        }],
+      }],
+    })).toBe(true);
+  });
+
+  it("string 形式 outputBinding との併用 — string 側は影響なし", () => {
+    expect(validate({
+      ...base,
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "s1", type: "compute", description: "",
+          expression: "x",
+          outputBinding: "result",
+        }],
+      }],
+    })).toBe(true);
+  });
+});
+
 describe("process-flow.schema.json — errorCatalog (#253)", () => {
   const base = {
     id: "a", name: "x", type: "screen", description: "",

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -175,6 +175,14 @@ export interface OutputBindingObject {
   name: string;
   /** 既定は "assign" */
   operation?: OutputBindingOperation;
+  /**
+   * 初期値の式 (#253)。
+   * - operation="accumulate": 数値初期化 (例: "0")。未指定は "0" として解釈
+   * - operation="push": 配列初期化 (例: "[]")。未指定は "[]" として解釈
+   * - operation="assign": 通常不要 (代入前に初期化する意味がないため)
+   * 初期化タイミングは変数のスコープ開始時 (通常はアクション開始、ループ入口は operation=accumulate/push を含むループの入口)。
+   */
+  initialValue?: string;
 }
 
 /**

--- a/docs/spec/process-flow-extensions.md
+++ b/docs/spec/process-flow-extensions.md
@@ -355,12 +355,14 @@ type OutputBinding = string | OutputBindingObject;
 
 用例:
 - `"authResult"` (string = assign 既定)
-- `{ "name": "subtotal", "operation": "accumulate" }` (ループ内累積)
-- `{ "name": "enrichedItems", "operation": "push" }` (配列追加)
+- `{ "name": "subtotal", "operation": "accumulate", "initialValue": "0" }` (ループ内累積、初期値明示)
+- `{ "name": "enrichedItems", "operation": "push", "initialValue": "[]" }` (配列追加、初期値明示)
+
+**initialValue (#253 v1.2)**: `accumulate` / `push` 時の初期値を式で明示。未指定時の既定は `accumulate` → `"0"`、`push` → `"[]"`。実装側は変数スコープ開始時 (アクション先頭、またはループ入口) で初期化する。
 
 ヘルパー: `designer/src/utils/outputBinding.ts` の `getBindingName` / `getBindingOperation`
 
-PR: #169
+PR: #169 / #255 (#253 v1.2)
 
 ## 8.5 エラーカタログ (ActionGroup.errorCatalog, #253 v1.2)
 

--- a/schemas/process-flow.schema.json
+++ b/schemas/process-flow.schema.json
@@ -229,7 +229,11 @@
       "additionalProperties": false,
       "properties": {
         "name": { "type": "string" },
-        "operation": { "$ref": "#/$defs/OutputBindingOperation" }
+        "operation": { "$ref": "#/$defs/OutputBindingOperation" },
+        "initialValue": {
+          "type": "string",
+          "description": "初期値の式 (#253)。accumulate 時は数値 (既定 '0')、push 時は配列 (既定 '[]')"
+        }
       }
     },
     "OutputBinding": {


### PR DESCRIPTION
## 関連

- 部分対応: #253 の OutputBindingObject.initialValue
- 仕様: docs/spec/process-flow-extensions.md §8.1

## 概要

\`operation: "accumulate"\` / \`"push"\` の初期値がスキーマ未規定で、実装側が毎回推測していた問題を解決。

## 主な変更

- **TS**: \`OutputBindingObject.initialValue?: string\` 追加
- **JSON Schema**: OutputBindingObject に initialValue プロパティ追加
- **仕様書**: §8.1 に initialValue の意味と既定値 (accumulate="0", push="[]") 記載
- **回帰テスト**: 4 件 (accumulate + initialValue / push + initialValue / 省略 / string 併用)

## 仕様逐条突合 (自己申告)

- TS `designer/src/types/action.ts` OutputBindingObject.initialValue ✓
- JSON Schema \`\$defs/OutputBindingObject\` initialValue ✓
- 仕様書 §8.1 ✓
- テスト 4 件 ✓

## 動作確認

- [x] typecheck pass
- [x] vitest run: 364 → 368 (+4, 回帰なし)
- [x] 既存 string / object 形式 outputBinding 後方互換

## スクリーンショット
N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)