### PR TITLE
test(schemas): responseRef / errorCode の参照整合性バリデータ (#253)

### DIFF
--- a/designer/src/schemas/referentialIntegrity.test.ts
+++ b/designer/src/schemas/referentialIntegrity.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from "vitest";
+import { checkReferentialIntegrity } from "./referentialIntegrity";
+import type { ActionGroup } from "../types/action";
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve, join } from "node:path";
+
+const samplesDir = resolve(__dirname, "../../../docs/sample-project/actions");
+
+function makeGroup(partial: Partial<ActionGroup>): ActionGroup {
+  return {
+    id: "a", name: "x", type: "screen", description: "",
+    actions: [],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...partial,
+  } as ActionGroup;
+}
+
+describe("checkReferentialIntegrity — responseRef", () => {
+  it("未定義 responseRef を検出", () => {
+    const issues = checkReferentialIntegrity(makeGroup({
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        responses: [{ id: "201-ok", status: 201 }],
+        steps: [
+          { id: "s1", type: "return", description: "", responseRef: "999-missing" },
+        ],
+      }],
+    }));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("UNKNOWN_RESPONSE_REF");
+    expect(issues[0].value).toBe("999-missing");
+  });
+
+  it("定義済み responseRef は問題なし", () => {
+    const issues = checkReferentialIntegrity(makeGroup({
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        responses: [{ id: "201-ok", status: 201 }],
+        steps: [{ id: "s1", type: "return", description: "", responseRef: "201-ok" }],
+      }],
+    }));
+    expect(issues).toHaveLength(0);
+  });
+
+  it("ValidationStep.inlineBranch.ngResponseRef も検査", () => {
+    const issues = checkReferentialIntegrity(makeGroup({
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        responses: [],
+        steps: [{
+          id: "s1", type: "validation", description: "", conditions: "",
+          inlineBranch: { ok: "ok", ng: "ng", ngResponseRef: "400-not-defined" },
+        }],
+      }],
+    }));
+    expect(issues.some((i) => i.code === "UNKNOWN_RESPONSE_REF")).toBe(true);
+  });
+
+  it("errorCatalog.responseRef も検査", () => {
+    const issues = checkReferentialIntegrity(makeGroup({
+      errorCatalog: {
+        STOCK_SHORTAGE: { responseRef: "409-missing" },
+      },
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        responses: [{ id: "409-stock-shortage", status: 409 }],
+        steps: [],
+      }],
+    }));
+    expect(issues.some((i) => i.code === "UNKNOWN_RESPONSE_REF")).toBe(true);
+  });
+});
+
+describe("checkReferentialIntegrity — errorCode", () => {
+  it("errorCatalog 定義時、未登録 errorCode を検出", () => {
+    const issues = checkReferentialIntegrity(makeGroup({
+      errorCatalog: { STOCK_SHORTAGE: { httpStatus: 409 } },
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "s1", type: "dbAccess", description: "",
+          tableName: "t", operation: "UPDATE",
+          affectedRowsCheck: { operator: ">", expected: 0, onViolation: "throw", errorCode: "UNKNOWN_CODE" },
+        }],
+      }],
+    }));
+    expect(issues.some((i) => i.code === "UNKNOWN_ERROR_CODE")).toBe(true);
+  });
+
+  it("errorCatalog 未定義時は errorCode 検査をスキップ (後方互換)", () => {
+    const issues = checkReferentialIntegrity(makeGroup({
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "s1", type: "dbAccess", description: "",
+          tableName: "t", operation: "UPDATE",
+          affectedRowsCheck: { operator: ">", expected: 0, onViolation: "throw", errorCode: "ANY" },
+        }],
+      }],
+    }));
+    expect(issues).toHaveLength(0);
+  });
+
+  it("BranchConditionVariant.errorCode も検査", () => {
+    const issues = checkReferentialIntegrity(makeGroup({
+      errorCatalog: { STOCK_SHORTAGE: {} },
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "s1", type: "branch", description: "",
+          branches: [{
+            id: "b1", code: "A",
+            condition: { kind: "tryCatch", errorCode: "NOT_REGISTERED" },
+            steps: [],
+          }],
+        }],
+      }],
+    }));
+    expect(issues.some((i) => i.code === "UNKNOWN_ERROR_CODE")).toBe(true);
+  });
+});
+
+describe("checkReferentialIntegrity — ネスト走査", () => {
+  it("loop.steps 内の ReturnStep も検査", () => {
+    const issues = checkReferentialIntegrity(makeGroup({
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        responses: [{ id: "200-ok", status: 200 }],
+        steps: [{
+          id: "lp", type: "loop", description: "", loopKind: "count",
+          steps: [{ id: "ret", type: "return", description: "", responseRef: "missing" }],
+        }],
+      }],
+    }));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].path).toContain("steps[0].steps[0]");
+  });
+
+  it("externalSystem.outcomes.sideEffects 内も検査", () => {
+    const issues = checkReferentialIntegrity(makeGroup({
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        responses: [],
+        steps: [{
+          id: "ext", type: "externalSystem", description: "", systemName: "s",
+          outcomes: {
+            failure: {
+              action: "continue",
+              sideEffects: [
+                { id: "ret", type: "return", description: "", responseRef: "missing" },
+              ],
+            },
+          },
+        }],
+      }],
+    }));
+    expect(issues.some((i) => i.path.includes("sideEffects"))).toBe(true);
+  });
+});
+
+describe("checkReferentialIntegrity — サンプル (docs/sample-project/actions/*.json)", () => {
+  const files = readdirSync(samplesDir).filter((f) => f.endsWith(".json"));
+  for (const f of files) {
+    it(`${f} は参照整合性を満たす`, () => {
+      const group = JSON.parse(readFileSync(join(samplesDir, f), "utf-8")) as ActionGroup;
+      const issues = checkReferentialIntegrity(group);
+      if (issues.length > 0) {
+        throw new Error(
+          `参照整合性違反:\n${issues.map((i) => `  - [${i.code}] ${i.path}: ${i.message}`).join("\n")}`,
+        );
+      }
+      expect(issues).toHaveLength(0);
+    });
+  }
+});

--- a/designer/src/schemas/referentialIntegrity.ts
+++ b/designer/src/schemas/referentialIntegrity.ts
@@ -1,0 +1,146 @@
+/**
+ * 処理フロー JSON のクロスリファレンス検証 (#253)。
+ *
+ * JSON Schema 2020-12 では cross-reference (別フィールドに存在する値への参照検証) は
+ * $dynamicRef を駆使しても読みにくくなるため、スキーマ外のバリデータとして実装。
+ *
+ * 検証する規約:
+ * 1. ReturnStep.responseRef は action.responses[].id に存在すること
+ * 2. ValidationStep.inlineBranch.ngResponseRef は action.responses[].id に存在すること
+ * 3. BranchConditionVariant.errorCode は ActionGroup.errorCatalog のキーに存在すること
+ *    (errorCatalog が定義されている場合のみ)
+ * 4. DbAccessStep.affectedRowsCheck.errorCode も同上
+ * 5. ErrorCatalogEntry.responseRef は action.responses[].id に存在すること (errorCatalog → responses)
+ */
+import type { ActionGroup, ActionDefinition, Step } from "../types/action";
+
+export interface IntegrityIssue {
+  /** ドットパス (例: "actions[0].steps[2].responseRef") */
+  path: string;
+  /** 問題の識別子 */
+  code:
+    | "UNKNOWN_RESPONSE_REF"
+    | "UNKNOWN_ERROR_CODE";
+  /** 参照しようとした値 */
+  value: string;
+  /** エラーメッセージ */
+  message: string;
+}
+
+/** ActionGroup 全体のクロスリファレンス検証。空配列なら OK */
+export function checkReferentialIntegrity(group: ActionGroup): IntegrityIssue[] {
+  const issues: IntegrityIssue[] = [];
+  const errorCodes = new Set(Object.keys(group.errorCatalog ?? {}));
+  const hasErrorCatalog = errorCodes.size > 0;
+
+  group.actions.forEach((action, ai) => {
+    const responseIds = new Set(
+      (action.responses ?? []).map((r) => r.id).filter((x): x is string => !!x),
+    );
+    walkSteps(action.steps ?? [], `actions[${ai}].steps`, (step, path) => {
+      checkStep(step, path, responseIds, errorCodes, hasErrorCatalog, issues);
+    });
+
+    // errorCatalog → responses 参照
+    Object.entries(group.errorCatalog ?? {}).forEach(([key, entry]) => {
+      if (entry.responseRef && !responseIds.has(entry.responseRef)) {
+        issues.push({
+          path: `errorCatalog.${key}.responseRef (actions[${ai}])`,
+          code: "UNKNOWN_RESPONSE_REF",
+          value: entry.responseRef,
+          message: `errorCatalog.${key}.responseRef "${entry.responseRef}" が action "${action.name}" の responses[].id に存在しません`,
+        });
+      }
+    });
+  });
+
+  return issues;
+}
+
+function walkSteps(
+  steps: Step[],
+  basePath: string,
+  visit: (step: Step, path: string) => void,
+): void {
+  steps.forEach((step, i) => {
+    const path = `${basePath}[${i}]`;
+    visit(step, path);
+    // ネストした steps を持つ variant
+    if ("subSteps" in step && step.subSteps) {
+      walkSteps(step.subSteps, `${path}.subSteps`, visit);
+    }
+    if (step.type === "branch") {
+      step.branches.forEach((b, bi) => {
+        walkSteps(b.steps, `${path}.branches[${bi}].steps`, visit);
+      });
+      if (step.elseBranch) {
+        walkSteps(step.elseBranch.steps, `${path}.elseBranch.steps`, visit);
+      }
+    }
+    if (step.type === "loop") {
+      walkSteps(step.steps, `${path}.steps`, visit);
+    }
+    if (step.type === "externalSystem") {
+      Object.entries(step.outcomes ?? {}).forEach(([k, spec]) => {
+        if (spec?.sideEffects) {
+          walkSteps(spec.sideEffects, `${path}.outcomes.${k}.sideEffects`, visit);
+        }
+      });
+    }
+  });
+}
+
+function checkStep(
+  step: Step,
+  path: string,
+  responseIds: Set<string>,
+  errorCodes: Set<string>,
+  hasErrorCatalog: boolean,
+  issues: IntegrityIssue[],
+): void {
+  if (step.type === "return" && step.responseRef && !responseIds.has(step.responseRef)) {
+    issues.push({
+      path: `${path}.responseRef`,
+      code: "UNKNOWN_RESPONSE_REF",
+      value: step.responseRef,
+      message: `ReturnStep.responseRef "${step.responseRef}" が action.responses[].id に存在しません`,
+    });
+  }
+  if (step.type === "validation" && step.inlineBranch?.ngResponseRef) {
+    const r = step.inlineBranch.ngResponseRef;
+    if (!responseIds.has(r)) {
+      issues.push({
+        path: `${path}.inlineBranch.ngResponseRef`,
+        code: "UNKNOWN_RESPONSE_REF",
+        value: r,
+        message: `ValidationStep.inlineBranch.ngResponseRef "${r}" が action.responses[].id に存在しません`,
+      });
+    }
+  }
+  if (step.type === "dbAccess" && step.affectedRowsCheck?.errorCode && hasErrorCatalog) {
+    const e = step.affectedRowsCheck.errorCode;
+    if (!errorCodes.has(e)) {
+      issues.push({
+        path: `${path}.affectedRowsCheck.errorCode`,
+        code: "UNKNOWN_ERROR_CODE",
+        value: e,
+        message: `DbAccessStep.affectedRowsCheck.errorCode "${e}" が ActionGroup.errorCatalog に存在しません`,
+      });
+    }
+  }
+  if (step.type === "branch") {
+    step.branches.forEach((b, bi) => {
+      const c = b.condition;
+      if (typeof c === "object" && c.kind === "tryCatch" && hasErrorCatalog) {
+        if (!errorCodes.has(c.errorCode)) {
+          issues.push({
+            path: `${path}.branches[${bi}].condition.errorCode`,
+            code: "UNKNOWN_ERROR_CODE",
+            value: c.errorCode,
+            message: `BranchConditionVariant.errorCode "${c.errorCode}" が ActionGroup.errorCatalog に存在しません`,
+          });
+        }
+      }
+    });
+  }
+}

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -45,10 +45,26 @@ if (!ok) {
 
 ```bash
 cd designer
-npx vitest run src/schemas/process-flow.schema.test.ts
+npx vitest run src/schemas/                  # スキーマ検証 + 参照整合性の両方
+npx vitest run src/schemas/process-flow.schema.test.ts       # スキーマ準拠だけ
+npx vitest run src/schemas/referentialIntegrity.test.ts      # 参照整合性だけ
 ```
 
 `docs/sample-project/actions/*.json` の全ファイルを自動検証する。新しいサンプルを追加する場合も、このテストを通過させる必要がある。
+
+### 参照整合性 (Schema だけでは検査できない規約)
+
+JSON Schema 2020-12 では他フィールド値への参照検証 (cross-reference) が表現困難なため、スキーマの外に `designer/src/schemas/referentialIntegrity.ts` を置いて検証する:
+
+- `ReturnStep.responseRef` / `ValidationStep.inlineBranch.ngResponseRef` / `ErrorCatalogEntry.responseRef` が `action.responses[].id` に存在すること
+- `DbAccessStep.affectedRowsCheck.errorCode` / `BranchConditionVariant.errorCode` (tryCatch) が `ActionGroup.errorCatalog` のキーに存在すること (errorCatalog 定義時のみ)
+- ネスト構造 (`loop.steps` / `branch.branches[].steps` / `externalSystem.outcomes.*.sideEffects` / `subSteps`) も再帰的に検査
+
+```ts
+import { checkReferentialIntegrity } from "./schemas/referentialIntegrity";
+const issues = checkReferentialIntegrity(actionGroup);
+// issues.length === 0 なら OK
+```
 
 ## バージョニング方針
 


### PR DESCRIPTION
## 関連

- 部分対応: #253 の参照整合性検証
- 仕様: schemas/README.md 「参照整合性」節 (新設)

## 概要

JSON Schema 2020-12 は他フィールド値への参照検証 (例: \`responseRef\` が \`responses[].id\` に存在するか) を表現できない。\`\$dynamicRef\` 駆使で無理やりやれるが読みにくくなる。スキーマ外のバリデータとして分離する。

## 主な変更

- **新規** designer/src/schemas/referentialIntegrity.ts — \`checkReferentialIntegrity(group)\` で \`IntegrityIssue[]\` を返す
- **テスト** designer/src/schemas/referentialIntegrity.test.ts:
  - 責務テスト 9 件 (responseRef 系 4 / errorCode 系 3 / ネスト走査 2)
  - サンプル検証 4 件 (docs/sample-project/actions/*.json が全件 clean)
- **schemas/README.md**: 「参照整合性」節を追加、使い方コード付き

## 検査する規約

1. \`ReturnStep.responseRef\` → \`action.responses[].id\`
2. \`ValidationStep.inlineBranch.ngResponseRef\` → \`action.responses[].id\`
3. \`ErrorCatalogEntry.responseRef\` → \`action.responses[].id\`
4. \`DbAccessStep.affectedRowsCheck.errorCode\` → \`ActionGroup.errorCatalog\` キー (errorCatalog 定義時のみ)
5. \`BranchConditionVariant.errorCode\` (tryCatch) → \`ActionGroup.errorCatalog\` キー (errorCatalog 定義時のみ)
6. 上記をネスト構造 (loop / branch / subSteps / sideEffects) で再帰走査

## 設計判断

- **JSON Schema に混ぜない**: \`\$dynamicRef\` / \`unevaluatedProperties\` で表現可能だが読めなくなる。AJV 拡張 keyword も選択肢だがポータビリティが下がる。
- **errorCatalog 未定義時はスキップ**: errorCatalog が optional なので、既存サンプル (errorCatalog なし) が突然壊れるのを避ける。errorCatalog を 1 度でも定義したら全 errorCode を埋める必要がある運用。

## 動作確認

- [x] typecheck pass
- [x] vitest run: 368 → 381 (+13, 回帰なし)
- [x] サンプル 4 件全てが参照整合性 clean

## スクリーンショット
N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)