### PR TITLE
feat(schemas): ExternalSystemStep auth/idempotency/headers (#253)

### DIFF
--- a/designer/src/schemas/process-flow.schema.test.ts
+++ b/designer/src/schemas/process-flow.schema.test.ts
@@ -117,6 +117,56 @@ describe("process-flow.schema.json — v1.1 拡張 (#253)", () => {
   });
 });
 
+describe("process-flow.schema.json — ExternalSystemStep auth/idempotency/headers (#253)", () => {
+  const base = {
+    id: "a", name: "x", type: "screen", description: "",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  };
+
+  function ext(patch: Record<string, unknown>) {
+    return {
+      ...base,
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "s1", type: "externalSystem", description: "",
+          systemName: "Stripe", ...patch,
+        }],
+      }],
+    };
+  }
+
+  it("auth.kind=bearer + tokenRef accept", () => {
+    const ok = validate(ext({ auth: { kind: "bearer", tokenRef: "ENV:STRIPE_SECRET_KEY" } }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("auth.kind=apiKey + headerName accept", () => {
+    expect(validate(ext({ auth: { kind: "apiKey", tokenRef: "ENV:X_KEY", headerName: "X-API-Key" } }))).toBe(true);
+  });
+
+  it("auth.kind=none (tokenRef なし) accept", () => {
+    expect(validate(ext({ auth: { kind: "none" } }))).toBe(true);
+  });
+
+  it("auth.kind enum 外は reject", () => {
+    expect(validate(ext({ auth: { kind: "custom-kind" } }))).toBe(false);
+  });
+
+  it("idempotencyKey + headers accept", () => {
+    expect(validate(ext({
+      idempotencyKey: "order-@registeredOrder.id",
+      headers: { "Stripe-Version": "2024-06-20", "X-Trace-Id": "@traceId" },
+    }))).toBe(true);
+  });
+
+  it("auth / idempotencyKey / headers 全省略 accept (後方互換)", () => {
+    expect(validate(ext({}))).toBe(true);
+  });
+});
+
 describe("process-flow.schema.json — OutputBindingObject.initialValue (#253)", () => {
   const base = {
     id: "a", name: "x", type: "screen", description: "",

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -406,6 +406,22 @@ export interface RetryPolicy {
   initialDelayMs?: number;
 }
 
+/** 外部システムの認証方式 (#253 v1.2) */
+export type ExternalAuthKind = "bearer" | "basic" | "apiKey" | "oauth2" | "none";
+
+/**
+ * 外部呼出の認証設定 (#253 v1.2)。
+ * secretRef は規約文字列で運用する (例: "ENV:STRIPE_SECRET_KEY", "SECRET:stripe/api-key")。
+ * 正式な secret 管理機能は将来別途追加予定。
+ */
+export interface ExternalAuth {
+  kind: ExternalAuthKind;
+  /** 秘密値の参照 (例: "ENV:STRIPE_SECRET_KEY")。kind="none" では不要 */
+  tokenRef?: string;
+  /** apiKey 時のヘッダ名 (例: "X-API-Key"、既定 "Authorization") */
+  headerName?: string;
+}
+
 export interface ExternalSystemStep extends StepBase {
   type: "externalSystem";
   systemName: string;
@@ -421,6 +437,21 @@ export interface ExternalSystemStep extends StepBase {
   retryPolicy?: RetryPolicy;
   /** true なら TX 後・非同期 fire-and-forget。同期レスポンスを待たない */
   fireAndForget?: boolean;
+  /**
+   * 認証方式 (#253 v1.2)。未指定は "none" として解釈。
+   * tokenRef は "ENV:FOO" / "SECRET:path/to/key" 等の規約文字列で秘密値を参照。
+   */
+  auth?: ExternalAuth;
+  /**
+   * 冪等性キーを生成する式 (#253 v1.2)。例: "order-@registeredOrder.id"。
+   * Stripe 等の外部 API が Idempotency-Key ヘッダを要求する場合に設定。
+   */
+  idempotencyKey?: string;
+  /**
+   * 追加 HTTP ヘッダ (#253 v1.2)。値は式可 (例: @stripeVersion)。
+   * auth / idempotencyKey で表現できない任意ヘッダを設定する場合に使用。
+   */
+  headers?: Record<string, string>;
 }
 
 export interface CommonProcessStep extends StepBase {

--- a/docs/spec/process-flow-extensions.md
+++ b/docs/spec/process-flow-extensions.md
@@ -143,6 +143,27 @@ outcomes?: Partial<Record<ExternalCallOutcome, ExternalCallOutcomeSpec>>;
 
 PR: #159 (初版) / #173 (sideEffects / sameAs 追加)
 
+### 3.1a 認証・冪等性・カスタムヘッダ (#253 v1.2)
+
+```ts
+type ExternalAuthKind = "bearer" | "basic" | "apiKey" | "oauth2" | "none";
+
+interface ExternalAuth {
+  kind: ExternalAuthKind;
+  tokenRef?: string;       // "ENV:STRIPE_SECRET_KEY" / "SECRET:stripe/api-key" 等の規約参照
+  headerName?: string;     // apiKey 時のヘッダ名 (既定 "Authorization")
+}
+
+// ExternalSystemStep に追加
+auth?: ExternalAuth;
+idempotencyKey?: string;                // 式 (例: "order-@registeredOrder.id")
+headers?: Record<string, string>;       // 任意の追加ヘッダ (値は式可)
+```
+
+**tokenRef の規約** (2026-04-20 時点):
+- `"ENV:<var_name>"` — 環境変数参照 (例: `"ENV:STRIPE_SECRET_KEY"`)
+- `"SECRET:<path>"` — 将来の secrets 管理機能への参照 (現状は運用規約)
+
 ### 3.2 `timeoutMs` / `retryPolicy` / `fireAndForget`
 
 ```ts

--- a/schemas/process-flow.schema.json
+++ b/schemas/process-flow.schema.json
@@ -433,6 +433,23 @@
         "initialDelayMs": { "type": "integer", "minimum": 0 }
       }
     },
+    "ExternalAuthKind": {
+      "type": "string",
+      "enum": ["bearer", "basic", "apiKey", "oauth2", "none"]
+    },
+    "ExternalAuth": {
+      "type": "object",
+      "required": ["kind"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "$ref": "#/$defs/ExternalAuthKind" },
+        "tokenRef": {
+          "type": "string",
+          "description": "秘密値の参照文字列 (例: \"ENV:STRIPE_SECRET_KEY\", \"SECRET:stripe/api-key\")"
+        },
+        "headerName": { "type": "string" }
+      }
+    },
     "ExternalSystemStep": {
       "allOf": [
         { "$ref": "#/$defs/StepBaseProps" },
@@ -459,7 +476,13 @@
             },
             "timeoutMs": { "type": "integer", "minimum": 0 },
             "retryPolicy": { "$ref": "#/$defs/RetryPolicy" },
-            "fireAndForget": { "type": "boolean" }
+            "fireAndForget": { "type": "boolean" },
+            "auth": { "$ref": "#/$defs/ExternalAuth" },
+            "idempotencyKey": { "type": "string" },
+            "headers": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            }
           }
         }
       ]


### PR DESCRIPTION
## 関連

- 部分対応: #253 の ExternalSystemStep 拡張
- 仕様: docs/spec/process-flow-extensions.md §3.1a (新設)

## 概要

#253 ドッグフードで指摘された「Stripe 等の外部 API 呼出で、API キー / 冪等性キー / カスタムヘッダの受け渡し方法がスキーマにない」問題を解決。最小版 (vault 連携等は将来機能) として追加。

## 主な変更

- **TS 型**:
  - \`ExternalAuthKind = "bearer"|"basic"|"apiKey"|"oauth2"|"none"\`
  - \`ExternalAuth { kind, tokenRef?, headerName? }\`
  - \`ExternalSystemStep\` に \`auth?\` / \`idempotencyKey?\` / \`headers?\` 追加
- **JSON Schema**: \`\$defs/ExternalAuth\` / \`ExternalAuthKind\` 追加、\`ExternalSystemStep\` 3 フィールド
- **仕様書 §3.1a**: tokenRef の規約 (\`"ENV:<name>"\` / \`"SECRET:<path>"\`) を明示
- **回帰テスト**: 6 件

## 設計判断

### tokenRef は規約文字列でまず運用

正式な secrets 管理機能 (secret store / rotation / encryption) は重い設計になるので、まずは:
- \`"ENV:STRIPE_SECRET_KEY"\` — 環境変数参照
- \`"SECRET:stripe/api-key"\` — 将来の secrets 機能を予約

この 2 つの prefix だけで運用し、後で必要に応じて拡張 (YAGNI)。

### enum でガード

\`kind\` は 5 値 (bearer/basic/apiKey/oauth2/none) の enum。独自認証方式は将来 "custom" で逃げるより「必要な時だけ enum 拡張する」方針。

### idempotencyKey は式

静的な値ではなく \`order-@registeredOrder.id\` のような式で渡す。式言語は #258 で策定した js-subset。

## 仕様逐条突合 (自己申告)

- TS designer/src/types/action.ts ExternalAuth / ExternalSystemStep.auth/idempotencyKey/headers ✓
- JSON Schema \`\$defs/ExternalAuth\` + ExternalSystemStep 3 プロパティ ✓
- 仕様書 §3.1a ✓
- テスト 6 件 ✓

## 動作確認

- [x] typecheck pass
- [x] vitest run: 381 → 387 (+6, 回帰なし)
- [x] 既存 ExternalSystemStep (auth なし) 後方互換

## スクリーンショット
N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)