### PR TITLE
feat(schemas): HttpResponseSpec.bodySchema を union 化 (#253 v1.2)

### DIFF
--- a/designer/src/schemas/process-flow.schema.test.ts
+++ b/designer/src/schemas/process-flow.schema.test.ts
@@ -117,6 +117,57 @@ describe("process-flow.schema.json — v1.1 拡張 (#253)", () => {
   });
 });
 
+describe("process-flow.schema.json — HttpResponseSpec.bodySchema union (#253)", () => {
+  const base = {
+    id: "a", name: "x", type: "screen", description: "",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  };
+
+  function withResponses(responses: unknown[]) {
+    return {
+      ...base,
+      actions: [{ id: "a1", name: "f", trigger: "click", responses, steps: [] }],
+    };
+  }
+
+  it("bodySchema: string (旧形式) accept", () => {
+    const ok = validate(withResponses([{ id: "201", status: 201, bodySchema: "ApiResponse" }]));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("bodySchema: {typeRef} 構造化 accept", () => {
+    const ok = validate(withResponses([{ id: "201", status: 201, bodySchema: { typeRef: "CustomerResponse" } }]));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("bodySchema: {schema} インライン accept", () => {
+    const ok = validate(withResponses([{
+      id: "409", status: 409,
+      bodySchema: { schema: { type: "object", properties: { code: { type: "string" } } } },
+    }]));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("bodySchema 省略 accept", () => {
+    expect(validate(withResponses([{ id: "204", status: 204 }]))).toBe(true);
+  });
+
+  it("{typeRef, schema} 両方指定は reject (union で排他)", () => {
+    expect(validate(withResponses([{
+      id: "409", status: 409,
+      bodySchema: { typeRef: "X", schema: {} },
+    }]))).toBe(false);
+  });
+
+  it("{typeRef} が空文字列でも type ref は string として accept (運用で検査)", () => {
+    expect(validate(withResponses([{ id: "409", status: 409, bodySchema: { typeRef: "" } }]))).toBe(true);
+  });
+});
+
 describe("process-flow.schema.json — ExternalSystemStep auth/idempotency/headers (#253)", () => {
   const base = {
     id: "a", name: "x", type: "screen", description: "",

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -673,6 +673,18 @@ export interface HttpRoute {
   auth?: HttpAuthRequirement;
 }
 
+/**
+ * bodySchema の構造化参照 (#253 v1.2)。
+ * - `{ typeRef: string }`: 型カタログ (将来機能) への名前参照。今は規約的な型名 (例: "ApiError", "CustomerResponse")
+ * - `{ schema: object }`: インライン JSON Schema (ad hoc な応答形式用)
+ *
+ * 旧 string 形式 (自由記述) も union で残る。段階的に構造化へ移行する想定。
+ */
+export type BodySchemaRef =
+  | string
+  | { typeRef: string }
+  | { schema: Record<string, unknown> };
+
 /** HTTP レスポンス仕様 (成功/エラーの各ケース) */
 export interface HttpResponseSpec {
   /** ReturnStep.responseRef から参照するための識別子 (任意、例: "409-stock-shortage") */
@@ -682,10 +694,12 @@ export interface HttpResponseSpec {
   /** MIME タイプ。未指定は "application/json" として解釈 */
   contentType?: string;
   /**
-   * レスポンスボディのスキーマ参照 (自由記述)。
-   * 例: "CustomerRegisterResponse" / "ApiError" / "{ code: string, fieldErrors: Record<string,string> }"
+   * レスポンスボディのスキーマ。
+   * - 旧 string (自由記述): "CustomerRegisterResponse" / "ApiError" / "{ code, fieldErrors }"
+   * - 新 `{ typeRef }` (#253 v1.2): 型カタログへの名前参照
+   * - 新 `{ schema }` (#253 v1.2): インライン JSON Schema
    */
-  bodySchema?: string;
+  bodySchema?: BodySchemaRef;
   /** 説明 (発生条件、UI 文言のヒント等) */
   description?: string;
   /** 発生条件 (自由記述、例: "@duplicateCustomer != null") */

--- a/docs/spec/process-flow-extensions.md
+++ b/docs/spec/process-flow-extensions.md
@@ -37,17 +37,27 @@ PR: #161
 action が返し得る **HTTP レスポンス一覧**を列挙。成功・各エラーをまとめて表現。
 
 ```ts
+type BodySchemaRef =
+  | string                        // 旧: 自由記述 ("ApiError" / "{code, detail}")
+  | { typeRef: string }           // 新: 型カタログ名参照 (#253 v1.2)
+  | { schema: object };           // 新: インライン JSON Schema (#253 v1.2)
+
 interface HttpResponseSpec {
   id?: string;                     // ReturnStep.responseRef が参照する ID
   status: number;                  // 201, 400, 409, ...
   contentType?: string;            // 既定 "application/json"
-  bodySchema?: string;             // 自由記述 or 型名参照
+  bodySchema?: BodySchemaRef;      // 3 形式の union
   description?: string;
   when?: string;                   // 発生条件 (自由記述)
 }
 ```
 
-PR: #161 (初版) / #179 (`id` フィールド追加)
+**bodySchema の使い分け**:
+- `string`: 既存データ互換、または人間向け説明としてのみ
+- `{ typeRef: "CustomerResponse" }`: 共有される型を参照 (複数の response / action で同じ形式を使う場合)
+- `{ schema: {...} }`: その response 固有の ad hoc な形式 (JSON Schema draft 2020-12)
+
+PR: #161 (初版) / #179 (`id` フィールド追加) / #260 (BodySchemaRef union 化 #253)
 
 ### 1.3 典型例
 

--- a/schemas/process-flow.schema.json
+++ b/schemas/process-flow.schema.json
@@ -76,6 +76,28 @@
       }
     },
 
+    "BodySchemaRef": {
+      "description": "旧 string (自由記述) と新 {typeRef} / {schema} の union (#253)",
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "object",
+          "required": ["typeRef"],
+          "additionalProperties": false,
+          "properties": {
+            "typeRef": { "type": "string", "description": "型カタログへの名前参照 (例: \"CustomerResponse\")" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["schema"],
+          "additionalProperties": false,
+          "properties": {
+            "schema": { "type": "object", "description": "インライン JSON Schema" }
+          }
+        }
+      ]
+    },
     "HttpResponseSpec": {
       "type": "object",
       "required": ["status"],
@@ -84,7 +106,7 @@
         "id": { "type": "string" },
         "status": { "type": "integer", "minimum": 100, "maximum": 599 },
         "contentType": { "type": "string" },
-        "bodySchema": { "type": "string" },
+        "bodySchema": { "$ref": "#/$defs/BodySchemaRef" },
         "description": { "type": "string" },
         "when": { "type": "string" }
       }


### PR DESCRIPTION
## 関連

- 部分対応: #253 の HttpResponseSpec.bodySchema 構造化 (これで #253 高優先項目すべて完了)
- 仕様: docs/spec/process-flow-extensions.md §1.2

## 概要

#253 ドッグフードで指摘された「bodySchema が \`"ApiError"\` / \`"{orderId, orderNumber}"\` / \`"{code, detail}"\` の 3 形式が混在している」問題を解決。string はそのまま残し、構造化変種を union で追加。

## 主な変更

- **TS**: \`BodySchemaRef = string | {typeRef} | {schema}\`、\`HttpResponseSpec.bodySchema\` の型変更
- **JSON Schema**: \`\$defs/BodySchemaRef\` 追加、3 variant を \`oneOf\` で排他 (\`typeRef\` と \`schema\` 両指定は reject)
- **仕様書 §1.2**: 3 形式の使い分けガイド記載
- **回帰テスト**: 6 件

## 設計判断

### string を残す

既存サンプル (string 形式 100%) を壊さないため、union に string を残す。段階的に \`{typeRef}\` / \`{schema}\` へ移行させていく運用を想定。

### typeRef と schema の排他

\`typeRef\` (名前参照) と \`schema\` (インライン定義) は同時に使うケースがないため、\`oneOf\` で排他。同時指定は reject。

### schema は JSON Schema draft 2020-12

\`{ schema: {...} }\` の中身は完全な JSON Schema を想定。ただし JSON Schema 自体のバリデーションはしない (大きくなりすぎる)。実装者が draft 2020-12 として解釈する運用規約。

## #253 残タスク

本 PR で #253 の高優先項目を全て消化:
- [x] errorCatalog (PR #255)
- [x] OutputBindingObject.initialValue (PR #256)
- [x] 参照整合性テスト (PR #257)
- [x] 式言語 BNF (PR #258)
- [x] ExternalSystemStep auth/idempotency (PR #259)
- [x] bodySchema union (本 PR)

## 仕様逐条突合 (自己申告)

- TS `designer/src/types/action.ts` BodySchemaRef + HttpResponseSpec.bodySchema ✓
- JSON Schema `\$defs/BodySchemaRef` + HttpResponseSpec.bodySchema ref ✓
- 仕様書 §1.2 3 形式の union 化 ✓
- テスト 6 件 (各 variant / 省略 / 排他 reject) ✓

## 動作確認

- [x] typecheck pass
- [x] vitest run: 387 → 393 (+6, 回帰なし)
- [x] サンプル全件 (string 形式 bodySchema) 後方互換で通過

## スクリーンショット
N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)