### PR TITLE
feat(schemas): v1.3 quick wins — custom deprecated / sideEffects return 禁止 / runIf 連鎖 / idempotencyKey 規約 (#261)

### DIFF
--- a/designer/src/schemas/process-flow.schema.test.ts
+++ b/designer/src/schemas/process-flow.schema.test.ts
@@ -117,6 +117,49 @@ describe("process-flow.schema.json — v1.1 拡張 (#253)", () => {
   });
 });
 
+describe("process-flow.schema.json — sideEffects の return 禁止 (#261)", () => {
+  const base = {
+    id: "a", name: "x", type: "screen", description: "",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  };
+
+  function extWithSideEffects(sideEffects: unknown[]) {
+    return {
+      ...base,
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "s1", type: "externalSystem", description: "",
+          systemName: "Stripe",
+          outcomes: {
+            failure: { action: "continue", sideEffects },
+          },
+        }],
+      }],
+    };
+  }
+
+  it("sideEffects に dbAccess / other は accept", () => {
+    const ok = validate(extWithSideEffects([
+      { id: "se1", type: "dbAccess", description: "", tableName: "t", operation: "UPDATE" },
+      { id: "se2", type: "other", description: "" },
+    ]));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("sideEffects 内 ReturnStep は reject", () => {
+    expect(validate(extWithSideEffects([
+      { id: "ret", type: "return", description: "", responseRef: "201" },
+    ]))).toBe(false);
+  });
+
+  it("sideEffects 空配列 accept", () => {
+    expect(validate(extWithSideEffects([]))).toBe(true);
+  });
+});
+
 describe("process-flow.schema.json — HttpResponseSpec.bodySchema union (#253)", () => {
   const base = {
     id: "a", name: "x", type: "screen", description: "",

--- a/docs/spec/process-flow-expression-language.md
+++ b/docs/spec/process-flow-expression-language.md
@@ -153,6 +153,69 @@ argList         = expression (',' expression)*
 | `OutputBindingObject.initialValue` | 任意式 | `"0"` / `"[]"` |
 | `ExternalCallOutcomeSpec.jumpTo` | ステップ ID 文字列 (式ではない) | `"step-error-handler"` |
 | `CommonProcessStep.argumentMapping[k]` | 任意式 | `"@customerId"` |
+| `ExternalSystemStep.protocol` (#261) | 自由記述。URL 中の `@path` 式補間を許容 (例: `"HTTPS POST /v1/payment_intents/@paymentAuth.id/cancel"`) | URL 構造化は v1.3-b 以降の `httpCall` フィールドで予定 |
+| `ExternalSystemStep.idempotencyKey` (#253 v1.2) | 任意式 (下記 §8 参照) | `"order-@registeredOrder.id"` |
+| `ExternalSystemStep.headers[k]` (#253 v1.2) | 任意式 (値のみ。キーは静的文字列) | `"@traceId"` / `"2024-06-20"` |
+
+## 7. runIf 連鎖規則 (#261)
+
+`runIf` はステップ実行の条件ガード。ネスト構造での評価規則を以下に規定する。
+
+### 7.1 short-circuit
+
+親ステップの `runIf` が false の場合、**その子ステップ (subSteps / branch 内 / loop 内 / outcomes.sideEffects 内) の runIf は一切評価されない**。子ステップの変数参照は未初期化扱い。
+
+### 7.2 branch / loop 内の評価順序
+
+`BranchStep.branches[i].steps[j]` の step.runIf は、
+
+```
+effective = branch.condition && step.runIf
+```
+
+で評価される。すなわち **branch.condition が false → step.runIf 評価不要**。
+
+`LoopStep.steps[j]` の step.runIf は、**ループ 1 イテレーションごとに評価**される (count/condition/collection いずれでも同じ)。ループ入口で 1 回だけ評価する挙動は非採用。
+
+### 7.3 outcomes.sideEffects
+
+`ExternalCallOutcomeSpec.sideEffects[]` は outcome 条件 (success/failure/timeout) が matched した時のみ実行される。各 sideEffect の `runIf` は outcome matched 後に評価。
+
+### 7.4 短絡と副作用
+
+`runIf` 式内で副作用を起こす関数呼出は禁止 (§5 で変数代入 `=` を禁止済みのため自動的に担保)。短絡評価を前提とした同等書き換え (`@a && @a.b` 等) は安全に動作する。
+
+## 8. idempotencyKey の評価規約 (#261)
+
+`ExternalSystemStep.idempotencyKey` は以下を満たすべし。
+
+### 8.1 retry 間で安定
+
+`retryPolicy.maxAttempts > 1` の場合、同一 step の複数回試行で idempotencyKey は**同じ値**でなければならない。そうでないと外部 API の冪等性保証が機能しない。
+
+→ 実装上は step 入口で 1 回評価し、retry ループ内で再評価しない方針。
+
+### 8.2 TX ROLLBACK 後の retry は別キー
+
+`txBoundary` に含まれる外部呼出が ROLLBACK 後にユーザ操作で再試行された場合、**新しいリクエストとして別キー**を生成するべき。具体的には `idempotencyKey` の式が `@order.id` のような DB 永続値ではなく、`@requestId` のような**リクエスト単位の識別子**を含むのが望ましい。
+
+### 8.3 フォールバック
+
+`idempotencyKey` 未指定時、実装側は:
+1. 外部 API が `Idempotency-Key` を必須とする場合 → UUID v4 を自動生成して送信
+2. 任意の場合 → ヘッダを送信しない
+
+スキーマでは必須化しない (多くの外部 API は Idempotency-Key をオプション扱い)。
+
+## 9. sideEffects 内で return 禁止 (#261)
+
+`ExternalCallOutcomeSpec.sideEffects` 配列には `ReturnStep` を置けない (JSON Schema レベルで `NonReturnStep` 制約化)。
+
+**理由**: `outcome.action` が `"abort"` (処理中断) の意味と `return` ステップ (HTTP レスポンス返却) の意味が衝突する。
+
+**書き方**:
+- レスポンスで返したい場合: outcome.action = "continue" にして、外側のフロー上に ReturnStep を配置
+- 処理中断する場合: outcome.action = "abort" のみ。body は `errorCatalog` / middleware で生成
 
 ## 7. 参照整合性
 

--- a/schemas/process-flow.schema.json
+++ b/schemas/process-flow.schema.json
@@ -166,6 +166,8 @@
           }
         },
         {
+          "description": "DEPRECATED (#261 v1.3): 新規データは array / object / primitive を優先。label 文字列に型情報を自由記述するパターンは AI 実装者が構造パースを強いられるため非推奨。",
+          "deprecated": true,
           "type": "object",
           "required": ["kind", "label"],
           "additionalProperties": false,
@@ -436,11 +438,30 @@
         "description": { "type": "string" },
         "jumpTo": { "type": "string" },
         "sideEffects": {
+          "description": "副作用ステップ列 (#261): ReturnStep は禁止。action=abort との意味衝突を避けるため。レスポンス返却は ReturnStep として通常のフロー上に配置する",
           "type": "array",
-          "items": { "$ref": "#/$defs/Step" }
+          "items": { "$ref": "#/$defs/NonReturnStep" }
         },
         "sameAs": { "$ref": "#/$defs/ExternalCallOutcome" }
       }
+    },
+    "NonReturnStep": {
+      "description": "sideEffects 配列で使える Step の制限サブセット。ReturnStep を除外 (#261)",
+      "oneOf": [
+        { "$ref": "#/$defs/ValidationStep" },
+        { "$ref": "#/$defs/DbAccessStep" },
+        { "$ref": "#/$defs/ExternalSystemStep" },
+        { "$ref": "#/$defs/CommonProcessStep" },
+        { "$ref": "#/$defs/ScreenTransitionStep" },
+        { "$ref": "#/$defs/DisplayUpdateStep" },
+        { "$ref": "#/$defs/BranchStep" },
+        { "$ref": "#/$defs/LoopStep" },
+        { "$ref": "#/$defs/LoopBreakStep" },
+        { "$ref": "#/$defs/LoopContinueStep" },
+        { "$ref": "#/$defs/JumpStep" },
+        { "$ref": "#/$defs/ComputeStep" },
+        { "$ref": "#/$defs/OtherStep" }
+      ]
     },
     "RetryPolicy": {
       "type": "object",


### PR DESCRIPTION
## 関連

- 部分対応: #261 の小規模項目
- 仕様: docs/spec/process-flow-expression-language.md §6-§9 追補

## 概要

#261 (v1.2 後再ドッグフード 4.5/5、5/5 未達) の指摘のうち、スキーマ制約追加と仕様書追補だけで済む 5 項目を一括対応。\`protocol\` 構造化 / \`externalSystemCatalog\` 等の大規模設計変更は別 PR。

## 主な変更

### JSON Schema
- \`FieldType.custom\` に \`deprecated: true\` + description で非推奨化 (array/object 移行を促す、既存データ影響なし)
- \`ExternalCallOutcomeSpec.sideEffects\` の items を \`NonReturnStep\` に変更 (13 variant の oneOf、ReturnStep を除外)
- 回帰テスト 3 件

### 仕様書 (docs/spec/process-flow-expression-language.md)
- §6 式フィールド一覧に protocol / idempotencyKey / headers を追加 (protocol の URL 式補間を明示)
- §7 runIf 連鎖規則 (新設):
  - short-circuit (親 false なら子を評価しない)
  - branch.condition && step.runIf の AND 評価
  - loop は 1 イテレーションごと評価
- §8 idempotencyKey 評価規約 (新設):
  - retry 間安定 (step 入口 1 回評価)
  - TX ROLLBACK 後は別キー
  - 未指定時のフォールバック (UUID v4 自動 or ヘッダ送信なし)
- §9 sideEffects 内 return 禁止の理由 (action: "abort" と意味衝突)

## 設計判断

### NonReturnStep の新設 vs Step の if-then 制約

ajv strict mode で if-then-else で特定 type を禁止するより、**sideEffects 用の別 \$defs を作る方が読みやすく**、AI が schema を読んで制約を把握しやすい。

### custom は deprecated で留める

destructive migration (custom → array/object 強制変換) は既存データ (cccccccc-0019 等) を壊すので今は JSON Schema の deprecated フラグだけ。サンプル側の migration は別 PR。

### runIf 連鎖を期待値ベースで明文化

「親 false なら子は評価しない」を暗黙にしていたが、実装者は暗黙規則を見つけにくい。式言語仕様書の §7 として成文化。

## 仕様逐条突合 (自己申告)

- \`schemas/process-flow.schema.json\` FieldType.custom deprecated ✓
- \`schemas/process-flow.schema.json\` \$defs/NonReturnStep + ExternalCallOutcomeSpec.sideEffects ref ✓
- \`docs/spec/process-flow-expression-language.md\` §6 追補 / §7 / §8 / §9 新設 ✓
- \`designer/src/schemas/process-flow.schema.test.ts\` sideEffects describe 3 件 ✓

## 動作確認

- [x] typecheck pass
- [x] vitest run: 393 → 396 (+3, 回帰なし)
- [x] 既存サンプル (sideEffects なし) 影響なし

## #261 残タスク (本 PR スコープ外)

大規模設計変更は別 PR で検討:
- externalSystem.protocol の構造化
- ActionGroup.externalSystemCatalog / typeCatalog
- BranchConditionVariant kind 拡張
- @ 参照の型推論
- tableId → SQL 列検査
- サンプル cccccccc-0019 の custom → array/object migration 等

## スクリーンショット
N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)