### PR TITLE
feat(schemas): externalSystemCatalog + httpCall 構造化 (#261 v1.3)

### DIFF
--- a/designer/src/schemas/process-flow.schema.test.ts
+++ b/designer/src/schemas/process-flow.schema.test.ts
@@ -117,6 +117,107 @@ describe("process-flow.schema.json — v1.1 拡張 (#253)", () => {
   });
 });
 
+describe("process-flow.schema.json — externalSystemCatalog + httpCall (#261 v1.3)", () => {
+  const base = {
+    id: "a", name: "x", type: "screen", description: "",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  };
+
+  it("externalSystemCatalog + ExternalSystemStep.systemRef + httpCall", () => {
+    const ok = validate({
+      ...base,
+      externalSystemCatalog: {
+        stripe: {
+          name: "Stripe Japan",
+          baseUrl: "https://api.stripe.com",
+          auth: { kind: "bearer", tokenRef: "ENV:STRIPE_SECRET_KEY" },
+          timeoutMs: 10000,
+          retryPolicy: { maxAttempts: 3, backoff: "exponential", initialDelayMs: 500 },
+          headers: { "Stripe-Version": "2024-06-20" },
+        },
+      },
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "s1", type: "externalSystem", description: "",
+          systemName: "Stripe Japan", systemRef: "stripe",
+          httpCall: {
+            method: "POST",
+            path: "/v1/payment_intents/@paymentAuth.id/cancel",
+            query: { expand: "charges" },
+          },
+          idempotencyKey: "cancel-@paymentAuth.id",
+        }],
+      }],
+    });
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("httpCall 構造 (method / path / body)", () => {
+    const ok = validate({
+      ...base,
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "s1", type: "externalSystem", description: "",
+          systemName: "Stripe",
+          httpCall: {
+            method: "POST",
+            path: "/v1/payment_intents",
+            body: "{ amount: @order.totalAmount, currency: 'jpy' }",
+          },
+        }],
+      }],
+    });
+    expect(ok).toBe(true);
+  });
+
+  it("protocol (legacy) と httpCall 併用 accept (後方互換)", () => {
+    expect(validate({
+      ...base,
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "s1", type: "externalSystem", description: "",
+          systemName: "Stripe",
+          protocol: "HTTPS POST /v1/foo",
+          httpCall: { method: "POST", path: "/v1/foo" },
+        }],
+      }],
+    })).toBe(true);
+  });
+
+  it("systemRef / httpCall 省略 accept (後方互換)", () => {
+    expect(validate({
+      ...base,
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "s1", type: "externalSystem", description: "",
+          systemName: "Stripe",
+          protocol: "HTTPS POST /v1/foo",
+        }],
+      }],
+    })).toBe(true);
+  });
+
+  it("httpCall.method enum 外は reject", () => {
+    expect(validate({
+      ...base,
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "s1", type: "externalSystem", description: "",
+          systemName: "Stripe",
+          httpCall: { method: "CONNECT", path: "/x" },
+        }],
+      }],
+    })).toBe(false);
+  });
+});
+
 describe("process-flow.schema.json — sideEffects の return 禁止 (#261)", () => {
   const base = {
     id: "a", name: "x", type: "screen", description: "",

--- a/designer/src/schemas/referentialIntegrity.test.ts
+++ b/designer/src/schemas/referentialIntegrity.test.ts
@@ -159,6 +159,35 @@ describe("checkReferentialIntegrity — ネスト走査", () => {
   });
 });
 
+describe("checkReferentialIntegrity — systemRef (#261)", () => {
+  it("externalSystemCatalog 定義時、未登録 systemRef を検出", () => {
+    const issues = checkReferentialIntegrity(makeGroup({
+      externalSystemCatalog: { stripe: { name: "Stripe" } },
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "s1", type: "externalSystem", description: "",
+          systemName: "SendGrid", systemRef: "sendgrid",
+        }],
+      }],
+    }));
+    expect(issues.some((i) => i.code === "UNKNOWN_SYSTEM_REF")).toBe(true);
+  });
+
+  it("externalSystemCatalog 未定義時は systemRef 検査をスキップ (後方互換)", () => {
+    const issues = checkReferentialIntegrity(makeGroup({
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "s1", type: "externalSystem", description: "",
+          systemName: "Stripe", systemRef: "any",
+        }],
+      }],
+    }));
+    expect(issues).toHaveLength(0);
+  });
+});
+
 describe("checkReferentialIntegrity — サンプル (docs/sample-project/actions/*.json)", () => {
   const files = readdirSync(samplesDir).filter((f) => f.endsWith(".json"));
   for (const f of files) {

--- a/designer/src/schemas/referentialIntegrity.ts
+++ b/designer/src/schemas/referentialIntegrity.ts
@@ -20,7 +20,8 @@ export interface IntegrityIssue {
   /** 問題の識別子 */
   code:
     | "UNKNOWN_RESPONSE_REF"
-    | "UNKNOWN_ERROR_CODE";
+    | "UNKNOWN_ERROR_CODE"
+    | "UNKNOWN_SYSTEM_REF";
   /** 参照しようとした値 */
   value: string;
   /** エラーメッセージ */
@@ -32,13 +33,15 @@ export function checkReferentialIntegrity(group: ActionGroup): IntegrityIssue[] 
   const issues: IntegrityIssue[] = [];
   const errorCodes = new Set(Object.keys(group.errorCatalog ?? {}));
   const hasErrorCatalog = errorCodes.size > 0;
+  const systemIds = new Set(Object.keys(group.externalSystemCatalog ?? {}));
+  const hasSystemCatalog = systemIds.size > 0;
 
   group.actions.forEach((action, ai) => {
     const responseIds = new Set(
       (action.responses ?? []).map((r) => r.id).filter((x): x is string => !!x),
     );
     walkSteps(action.steps ?? [], `actions[${ai}].steps`, (step, path) => {
-      checkStep(step, path, responseIds, errorCodes, hasErrorCatalog, issues);
+      checkStep(step, path, responseIds, errorCodes, hasErrorCatalog, systemIds, hasSystemCatalog, issues);
     });
 
     // errorCatalog → responses 参照
@@ -96,8 +99,18 @@ function checkStep(
   responseIds: Set<string>,
   errorCodes: Set<string>,
   hasErrorCatalog: boolean,
+  systemIds: Set<string>,
+  hasSystemCatalog: boolean,
   issues: IntegrityIssue[],
 ): void {
+  if (step.type === "externalSystem" && step.systemRef && hasSystemCatalog && !systemIds.has(step.systemRef)) {
+    issues.push({
+      path: `${path}.systemRef`,
+      code: "UNKNOWN_SYSTEM_REF",
+      value: step.systemRef,
+      message: `ExternalSystemStep.systemRef "${step.systemRef}" が ActionGroup.externalSystemCatalog に存在しません`,
+    });
+  }
   if (step.type === "return" && step.responseRef && !responseIds.has(step.responseRef)) {
     issues.push({
       path: `${path}.responseRef`,

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -422,10 +422,68 @@ export interface ExternalAuth {
   headerName?: string;
 }
 
+/**
+ * HTTP 呼出の構造化 (#261 v1.3)。
+ * 旧 `protocol: string` (例: "HTTPS POST /v1/payment_intents/@id/cancel") を
+ * method / path / pathParams / query / body に分解する。
+ * path は式補間を許容 (js-subset の @identifier)。
+ */
+export interface ExternalHttpCall {
+  method: HttpMethod;
+  /** URL パス。式補間可 (例: "/v1/payment_intents/@paymentAuth.id/cancel") */
+  path: string;
+  /** クエリ文字列。値は式可 (例: { limit: "@pageSize", cursor: "@nextCursor" }) */
+  query?: Record<string, string>;
+  /** リクエスト body の式 (例: "{ amount: @order.totalAmount, currency: 'jpy' }")。
+   *  GET 等で body 不要な場合は省略。 */
+  body?: string;
+}
+
+/**
+ * ActionGroup.externalSystemCatalog エントリ (#261 v1.3)。
+ * 同一外部システム (Stripe, SendGrid 等) を使う複数ステップで auth/baseUrl/timeoutMs/retryPolicy を集約し、
+ * step 側は systemRef で参照する。DRY 化と drift 防止。
+ */
+export interface ExternalSystemCatalogEntry {
+  /** 人間可読名 (例: "Stripe Japan") */
+  name: string;
+  /** HTTP ベース URL (例: "https://api.stripe.com") */
+  baseUrl?: string;
+  /** 既定認証 (step 側の auth が優先) */
+  auth?: ExternalAuth;
+  /** 既定タイムアウト (ms) */
+  timeoutMs?: number;
+  /** 既定リトライ方針 */
+  retryPolicy?: RetryPolicy;
+  /** 既定ヘッダ (step 側で上書き可) */
+  headers?: Record<string, string>;
+  /** 補足説明 */
+  description?: string;
+}
+
 export interface ExternalSystemStep extends StepBase {
   type: "externalSystem";
+  /**
+   * 外部システム名。systemRef 指定時はカタログから継承する情報の override ラベル。
+   * 従来互換のため必須継続 (systemRef だけの運用でも表示用に書く)。
+   */
   systemName: string;
+  /**
+   * ActionGroup.externalSystemCatalog のキー参照 (#261 v1.3)。
+   * 指定時はカタログの baseUrl/auth/timeoutMs/retryPolicy/headers を既定値とし、
+   * この step の同名フィールドで override 可能。
+   */
+  systemRef?: string;
+  /**
+   * @deprecated (#261 v1.3): 自由記述。httpCall への移行推奨。
+   * 後方互換のため残す。新規データは httpCall を使用。
+   */
   protocol?: string;
+  /**
+   * HTTP 呼出の構造化 (#261 v1.3)。protocol の後継。
+   * method / path / query / body に分解、path は式補間可。
+   */
+  httpCall?: ExternalHttpCall;
   /**
    * 各 outcome (success / failure / timeout) のハンドリング定義。
    * 省略時は product-scope §11 の既定 (failure/timeout=abort、success=continue) を適用。
@@ -770,6 +828,11 @@ export interface ActionGroup {
    * affectedRowsCheck.errorCode / BranchConditionVariant.errorCode から参照される。
    */
   errorCatalog?: Record<string, ErrorCatalogEntry>;
+  /**
+   * 外部システムカタログ (#261 v1.3)。キー: systemId (例: "stripe", "sendgrid")。
+   * ExternalSystemStep.systemRef から参照され、baseUrl/auth/timeoutMs 等の既定値を提供。
+   */
+  externalSystemCatalog?: Record<string, ExternalSystemCatalogEntry>;
   createdAt: string;
   updatedAt: string;
 }

--- a/docs/spec/process-flow-extensions.md
+++ b/docs/spec/process-flow-extensions.md
@@ -153,7 +153,75 @@ outcomes?: Partial<Record<ExternalCallOutcome, ExternalCallOutcomeSpec>>;
 
 PR: #159 (初版) / #173 (sideEffects / sameAs 追加)
 
-### 3.1a 認証・冪等性・カスタムヘッダ (#253 v1.2)
+### 3.0 HTTP 呼出の構造化 (`httpCall` / `systemRef`, #261 v1.3)
+
+```ts
+interface ExternalHttpCall {
+  method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+  path: string;                       // 式補間可: "/v1/payment_intents/@paymentAuth.id/cancel"
+  query?: Record<string, string>;     // 値は式可
+  body?: string;                      // JSON literal 式
+}
+
+// ExternalSystemStep に追加
+systemRef?: string;                  // ActionGroup.externalSystemCatalog のキー
+httpCall?: ExternalHttpCall;         // 旧 protocol の後継
+protocol?: string;                   // DEPRECATED: httpCall への移行推奨
+```
+
+### 3.0b externalSystemCatalog (ActionGroup レベル, #261 v1.3)
+
+同じ外部システム (Stripe, SendGrid 等) を使う複数ステップで **auth / baseUrl / timeoutMs / retryPolicy / headers** を 1 箇所に集約。drift 防止と DRY 化。
+
+```ts
+interface ExternalSystemCatalogEntry {
+  name: string;                         // 表示名
+  baseUrl?: string;                     // "https://api.stripe.com"
+  auth?: ExternalAuth;                  // 既定認証 (step 側 override 可)
+  timeoutMs?: number;
+  retryPolicy?: RetryPolicy;
+  headers?: Record<string, string>;
+  description?: string;
+}
+
+// ActionGroup に追加
+externalSystemCatalog?: Record<string, ExternalSystemCatalogEntry>;
+```
+
+用例:
+
+```json
+"externalSystemCatalog": {
+  "stripe": {
+    "name": "Stripe Japan",
+    "baseUrl": "https://api.stripe.com",
+    "auth": { "kind": "bearer", "tokenRef": "ENV:STRIPE_SECRET_KEY" },
+    "timeoutMs": 10000,
+    "retryPolicy": { "maxAttempts": 3, "backoff": "exponential", "initialDelayMs": 500 },
+    "headers": { "Stripe-Version": "2024-06-20" }
+  }
+}
+```
+
+step 側:
+
+```json
+{
+  "type": "externalSystem",
+  "systemName": "Stripe Japan",
+  "systemRef": "stripe",
+  "httpCall": {
+    "method": "POST",
+    "path": "/v1/payment_intents",
+    "body": "{ amount: @order.totalAmount, currency: 'jpy' }"
+  },
+  "idempotencyKey": "auth-@order.id"
+}
+```
+
+step 側の auth/timeoutMs 等を指定した場合は catalog を上書き。
+
+### 3.1b 認証・冪等性・カスタムヘッダ (#253 v1.2)
 
 ```ts
 type ExternalAuthKind = "bearer" | "basic" | "apiKey" | "oauth2" | "none";

--- a/schemas/process-flow.schema.json
+++ b/schemas/process-flow.schema.json
@@ -19,6 +19,11 @@
       "type": "object",
       "additionalProperties": { "$ref": "#/$defs/ErrorCatalogEntry" }
     },
+    "externalSystemCatalog": {
+      "description": "外部システムカタログ (#261 v1.3)。キー: systemId (例: \"stripe\")。ExternalSystemStep.systemRef から参照",
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/ExternalSystemCatalogEntry" }
+    },
     "actions": {
       "type": "array",
       "items": { "$ref": "#/$defs/ActionDefinition" }
@@ -493,6 +498,39 @@
         "headerName": { "type": "string" }
       }
     },
+    "ExternalHttpCall": {
+      "description": "外部 HTTP 呼出の構造化 (#261 v1.3)。path は式補間可",
+      "type": "object",
+      "required": ["method", "path"],
+      "additionalProperties": false,
+      "properties": {
+        "method": { "$ref": "#/$defs/HttpMethod" },
+        "path": { "type": "string" },
+        "query": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "body": { "type": "string" }
+      }
+    },
+    "ExternalSystemCatalogEntry": {
+      "description": "外部システムカタログの 1 エントリ (#261 v1.3)",
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "baseUrl": { "type": "string" },
+        "auth": { "$ref": "#/$defs/ExternalAuth" },
+        "timeoutMs": { "type": "integer", "minimum": 0 },
+        "retryPolicy": { "$ref": "#/$defs/RetryPolicy" },
+        "headers": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "description": { "type": "string" }
+      }
+    },
     "ExternalSystemStep": {
       "allOf": [
         { "$ref": "#/$defs/StepBaseProps" },
@@ -507,7 +545,16 @@
             "externalChain": true, "subSteps": true,
             "type": { "const": "externalSystem" },
             "systemName": { "type": "string" },
-            "protocol": { "type": "string" },
+            "systemRef": {
+              "type": "string",
+              "description": "ActionGroup.externalSystemCatalog のキー参照 (#261 v1.3)"
+            },
+            "protocol": {
+              "type": "string",
+              "deprecated": true,
+              "description": "DEPRECATED (#261): httpCall への移行推奨"
+            },
+            "httpCall": { "$ref": "#/$defs/ExternalHttpCall" },
             "outcomes": {
               "type": "object",
               "additionalProperties": false,


### PR DESCRIPTION
## 関連

- 部分対応: #261 v1.3 (protocol 構造化 + DRY 化)
- 仕様: docs/spec/process-flow-extensions.md §3.0 / §3.0b 新設

## 概要

再ドッグフード 4.5/5 の最頻出地の文依存だった \`externalSystem.protocol\` (Stripe 3 回呼出等) を構造化。同じ外部システムを使う複数 step の DRY 化も同時に対応。

## 主な変更

- **ExternalHttpCall** 新設: \`{ method, path, query?, body? }\`。path は式補間可 (\`/v1/payment_intents/@paymentAuth.id/cancel\`)
- **ExternalSystemCatalogEntry** 新設: baseUrl/auth/timeoutMs/retryPolicy/headers の集約
- **ActionGroup.externalSystemCatalog**: キー → エントリの map
- **ExternalSystemStep**: \`systemRef?\` / \`httpCall?\` 追加、\`protocol\` は \`deprecated\` 明記
- **参照整合性バリデータ**: \`UNKNOWN_SYSTEM_REF\` コード追加
- **テスト**: スキーマ 5 件 + 参照整合性 2 件

## 設計判断

- **protocol 後方互換**: 既存 0019 サンプル (全 Stripe 呼出で protocol 使用) を壊さないため \`protocol\` は残す。新規データは httpCall 推奨
- **catalog の step 側 override**: catalog に auth があっても step.auth があれば step 側優先。drift 防止より柔軟性優先
- **UNKNOWN_SYSTEM_REF は catalog 定義時のみ検査**: errorCatalog と同じパターン (未定義時は後方互換で skip)

## 動作確認

- [x] typecheck pass
- [x] vitest: 396 → 403 (+7、回帰なし)

## #261 残タスク
- typeCatalog (PR 264)
- BranchConditionVariant 拡張 (PR 265)
- サンプル 0019 migration (PR 266)
- 最終再ドッグフード (PR 267)

🤖 Generated with [Claude Code](https://claude.com/claude-code)