### PR TITLE
feat(schemas): typeCatalog 新設 + typeRef 参照整合性 (#261 v1.3)

### DIFF
--- a/designer/src/schemas/process-flow.schema.test.ts
+++ b/designer/src/schemas/process-flow.schema.test.ts
@@ -117,6 +117,59 @@ describe("process-flow.schema.json — v1.1 拡張 (#253)", () => {
   });
 });
 
+describe("process-flow.schema.json — typeCatalog (#261 v1.3)", () => {
+  const base = {
+    id: "a", name: "x", type: "screen", description: "",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  };
+
+  it("typeCatalog + bodySchema.typeRef で resolution 連携", () => {
+    const ok = validate({
+      ...base,
+      typeCatalog: {
+        ApiError: {
+          description: "共通エラーレスポンス",
+          schema: {
+            type: "object",
+            required: ["code", "message"],
+            properties: {
+              code: { type: "string" },
+              message: { type: "string" },
+              fieldErrors: { type: "object", additionalProperties: { type: "string" } },
+            },
+          },
+        },
+        CustomerResponse: {
+          schema: { type: "object", properties: { id: { type: "number" }, name: { type: "string" } } },
+        },
+      },
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        responses: [
+          { id: "400", status: 400, bodySchema: { typeRef: "ApiError" } },
+          { id: "200", status: 200, bodySchema: { typeRef: "CustomerResponse" } },
+        ],
+        steps: [],
+      }],
+    });
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("typeCatalog 省略 accept (optional)", () => {
+    expect(validate({ ...base, actions: [] })).toBe(true);
+  });
+
+  it("TypeCatalogEntry の schema 欠落は reject", () => {
+    expect(validate({
+      ...base,
+      typeCatalog: { X: { description: "desc only" } },
+      actions: [],
+    })).toBe(false);
+  });
+});
+
 describe("process-flow.schema.json — externalSystemCatalog + httpCall (#261 v1.3)", () => {
   const base = {
     id: "a", name: "x", type: "screen", description: "",

--- a/designer/src/schemas/referentialIntegrity.test.ts
+++ b/designer/src/schemas/referentialIntegrity.test.ts
@@ -159,6 +159,43 @@ describe("checkReferentialIntegrity — ネスト走査", () => {
   });
 });
 
+describe("checkReferentialIntegrity — typeRef (#261)", () => {
+  it("typeCatalog 定義時、未登録 typeRef を検出", () => {
+    const issues = checkReferentialIntegrity(makeGroup({
+      typeCatalog: { ApiError: { schema: { type: "object" } } },
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        responses: [{ id: "400", status: 400, bodySchema: { typeRef: "UnknownType" } }],
+        steps: [],
+      }],
+    }));
+    expect(issues.some((i) => i.code === "UNKNOWN_TYPE_REF")).toBe(true);
+  });
+
+  it("typeCatalog 未定義時は typeRef 検査をスキップ (後方互換)", () => {
+    const issues = checkReferentialIntegrity(makeGroup({
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        responses: [{ id: "400", status: 400, bodySchema: { typeRef: "AnyType" } }],
+        steps: [],
+      }],
+    }));
+    expect(issues).toHaveLength(0);
+  });
+
+  it("bodySchema が string 形式なら typeRef 検査対象外", () => {
+    const issues = checkReferentialIntegrity(makeGroup({
+      typeCatalog: { ApiError: { schema: {} } },
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        responses: [{ id: "400", status: 400, bodySchema: "UnknownType" }],
+        steps: [],
+      }],
+    }));
+    expect(issues).toHaveLength(0);
+  });
+});
+
 describe("checkReferentialIntegrity — systemRef (#261)", () => {
   it("externalSystemCatalog 定義時、未登録 systemRef を検出", () => {
     const issues = checkReferentialIntegrity(makeGroup({

--- a/designer/src/schemas/referentialIntegrity.ts
+++ b/designer/src/schemas/referentialIntegrity.ts
@@ -21,7 +21,8 @@ export interface IntegrityIssue {
   code:
     | "UNKNOWN_RESPONSE_REF"
     | "UNKNOWN_ERROR_CODE"
-    | "UNKNOWN_SYSTEM_REF";
+    | "UNKNOWN_SYSTEM_REF"
+    | "UNKNOWN_TYPE_REF";
   /** 参照しようとした値 */
   value: string;
   /** エラーメッセージ */
@@ -35,11 +36,26 @@ export function checkReferentialIntegrity(group: ActionGroup): IntegrityIssue[] 
   const hasErrorCatalog = errorCodes.size > 0;
   const systemIds = new Set(Object.keys(group.externalSystemCatalog ?? {}));
   const hasSystemCatalog = systemIds.size > 0;
+  const typeIds = new Set(Object.keys(group.typeCatalog ?? {}));
+  const hasTypeCatalog = typeIds.size > 0;
 
   group.actions.forEach((action, ai) => {
     const responseIds = new Set(
       (action.responses ?? []).map((r) => r.id).filter((x): x is string => !!x),
     );
+    // bodySchema.typeRef の参照検査
+    (action.responses ?? []).forEach((resp, ri) => {
+      if (resp.bodySchema && typeof resp.bodySchema === "object" && "typeRef" in resp.bodySchema && resp.bodySchema.typeRef) {
+        if (hasTypeCatalog && !typeIds.has(resp.bodySchema.typeRef)) {
+          issues.push({
+            path: `actions[${ai}].responses[${ri}].bodySchema.typeRef`,
+            code: "UNKNOWN_TYPE_REF",
+            value: resp.bodySchema.typeRef,
+            message: `bodySchema.typeRef "${resp.bodySchema.typeRef}" が ActionGroup.typeCatalog に存在しません`,
+          });
+        }
+      }
+    });
     walkSteps(action.steps ?? [], `actions[${ai}].steps`, (step, path) => {
       checkStep(step, path, responseIds, errorCodes, hasErrorCatalog, systemIds, hasSystemCatalog, issues);
     });

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -801,6 +801,18 @@ export interface ActionDefinition {
  * 同一 errorCode が affectedRowsCheck.errorCode / BranchConditionVariant.errorCode / responses[].description の
  * 複数箇所に散在する問題を解決するため、ActionGroup 単位で 1 箇所に集約する。
  */
+/**
+ * 型カタログの 1 エントリ (#261 v1.3)。
+ * schema プロパティに JSON Schema (draft 2020-12) を持つ。
+ * 型名単独での参照 (BodySchemaRef.typeRef) から解決される。
+ */
+export interface TypeCatalogEntry {
+  /** 説明 (任意) */
+  description?: string;
+  /** JSON Schema 本体 (draft 2020-12 の object) */
+  schema: Record<string, unknown>;
+}
+
 export interface ErrorCatalogEntry {
   /** 対応する HTTP ステータス (例: 409) */
   httpStatus?: number;
@@ -833,6 +845,12 @@ export interface ActionGroup {
    * ExternalSystemStep.systemRef から参照され、baseUrl/auth/timeoutMs 等の既定値を提供。
    */
   externalSystemCatalog?: Record<string, ExternalSystemCatalogEntry>;
+  /**
+   * 型カタログ (#261 v1.3)。キー: 型名 (例: "ApiError", "CustomerResponse")。
+   * HttpResponseSpec.bodySchema = { typeRef: "ApiError" } から参照される。
+   * 値は JSON Schema (inline) またはその略記形。
+   */
+  typeCatalog?: Record<string, TypeCatalogEntry>;
   createdAt: string;
   updatedAt: string;
 }

--- a/docs/spec/process-flow-extensions.md
+++ b/docs/spec/process-flow-extensions.md
@@ -169,6 +169,49 @@ httpCall?: ExternalHttpCall;         // 旧 protocol の後継
 protocol?: string;                   // DEPRECATED: httpCall への移行推奨
 ```
 
+### 3.0c typeCatalog (ActionGroup レベル, #261 v1.3)
+
+`HttpResponseSpec.bodySchema: { typeRef: string }` の解決先カタログ。同じ型 (`ApiError` 等) を複数 response で使い回すための DRY 化。
+
+```ts
+interface TypeCatalogEntry {
+  description?: string;
+  schema: object;                    // JSON Schema draft 2020-12
+}
+
+// ActionGroup に追加
+typeCatalog?: Record<string, TypeCatalogEntry>;
+```
+
+用例:
+
+```json
+"typeCatalog": {
+  "ApiError": {
+    "description": "共通エラーレスポンス",
+    "schema": {
+      "type": "object",
+      "required": ["code", "message"],
+      "properties": {
+        "code": { "type": "string" },
+        "message": { "type": "string" },
+        "fieldErrors": { "type": "object", "additionalProperties": { "type": "string" } }
+      }
+    }
+  }
+}
+```
+
+response 側:
+
+```json
+"responses": [
+  { "id": "400-validation", "status": 400, "bodySchema": { "typeRef": "ApiError" } }
+]
+```
+
+参照整合性バリデータが `typeRef → typeCatalog` 存在検査を行う (typeCatalog 未定義時は後方互換で skip)。
+
 ### 3.0b externalSystemCatalog (ActionGroup レベル, #261 v1.3)
 
 同じ外部システム (Stripe, SendGrid 等) を使う複数ステップで **auth / baseUrl / timeoutMs / retryPolicy / headers** を 1 箇所に集約。drift 防止と DRY 化。

--- a/schemas/process-flow.schema.json
+++ b/schemas/process-flow.schema.json
@@ -24,6 +24,11 @@
       "type": "object",
       "additionalProperties": { "$ref": "#/$defs/ExternalSystemCatalogEntry" }
     },
+    "typeCatalog": {
+      "description": "型カタログ (#261 v1.3)。キー: 型名 (例: \"ApiError\")。BodySchemaRef.typeRef から参照",
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/TypeCatalogEntry" }
+    },
     "actions": {
       "type": "array",
       "items": { "$ref": "#/$defs/ActionDefinition" }
@@ -70,6 +75,17 @@
         "auth": { "$ref": "#/$defs/HttpAuthRequirement" }
       }
     },
+    "TypeCatalogEntry": {
+      "description": "型カタログの 1 エントリ (#261 v1.3)。schema は JSON Schema draft 2020-12",
+      "type": "object",
+      "required": ["schema"],
+      "additionalProperties": false,
+      "properties": {
+        "description": { "type": "string" },
+        "schema": { "type": "object" }
+      }
+    },
+
     "ErrorCatalogEntry": {
       "type": "object",
       "additionalProperties": false,


### PR DESCRIPTION
## 関連

- 部分対応: #261 v1.3 (typeCatalog 新設)
- 仕様: docs/spec/process-flow-extensions.md §3.0c 新設

## 概要

BodySchemaRef.typeRef の解決先カタログを ActionGroup 単位で持つ。複数 response で \`ApiError\` 等の共通型を使い回す時の DRY 化 + 参照整合性検査の実現。

## 主な変更

- **TypeCatalogEntry**: description + JSON Schema (draft 2020-12) を持つ
- **ActionGroup.typeCatalog**: Record<string, TypeCatalogEntry>
- **JSON Schema**: \`\$defs/TypeCatalogEntry\` + ルートに typeCatalog (optional)
- **参照整合性バリデータ**: UNKNOWN_TYPE_REF 追加、typeCatalog 未定義時は skip
- **仕様書 §3.0c**: DRY 化の動機 + 用例 + 参照整合性説明

## 動作確認

- [x] typecheck pass
- [x] vitest: 403 → 409 (+6, 回帰なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)