### PR TITLE
feat(schemas): BranchConditionVariant に affectedRowsZero / externalOutcome 追加 (#261 v1.3)

### DIFF
--- a/designer/src/schemas/process-flow.schema.test.ts
+++ b/designer/src/schemas/process-flow.schema.test.ts
@@ -117,6 +117,57 @@ describe("process-flow.schema.json — v1.1 拡張 (#253)", () => {
   });
 });
 
+describe("process-flow.schema.json — BranchConditionVariant 拡張 (#261 v1.3)", () => {
+  const base = {
+    id: "a", name: "x", type: "screen", description: "",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  };
+
+  function withBranch(condition: unknown) {
+    return {
+      ...base,
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "s1", type: "branch", description: "",
+          branches: [{ id: "b1", code: "A", condition, steps: [] }],
+        }],
+      }],
+    };
+  }
+
+  it("tryCatch variant (既存) accept", () => {
+    const ok = validate(withBranch({ kind: "tryCatch", errorCode: "STOCK_SHORTAGE" }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("affectedRowsZero variant accept", () => {
+    const ok = validate(withBranch({ kind: "affectedRowsZero", stepRef: "step-dbupd" }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("externalOutcome variant accept", () => {
+    const ok = validate(withBranch({ kind: "externalOutcome", outcome: "failure" }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("externalOutcome.outcome enum 外は reject", () => {
+    expect(validate(withBranch({ kind: "externalOutcome", outcome: "partial" }))).toBe(false);
+  });
+
+  it("未知 kind は reject", () => {
+    expect(validate(withBranch({ kind: "unknownKind" }))).toBe(false);
+  });
+
+  it("string condition (旧) も引き続き accept", () => {
+    expect(validate(withBranch("@flag == true"))).toBe(true);
+  });
+});
+
 describe("process-flow.schema.json — typeCatalog (#261 v1.3)", () => {
   const base = {
     id: "a", name: "x", type: "screen", description: "",

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -535,8 +535,12 @@ export interface DisplayUpdateStep extends StepBase {
 }
 
 /**
- * Branch の分岐条件 variant (#176)。
+ * Branch の分岐条件 variant (#176 / #261 v1.3 で拡張)。
  * 旧 string と新しい型付き表現 (tryCatch 等) の union。
+ *
+ * v1.3 で追加:
+ * - `affectedRowsZero`: 直前の DbAccessStep (affectedRowsCheck) で rowCount が期待を満たさなかった場合
+ * - `externalOutcome`: 直前の ExternalSystemStep の outcome (success/failure/timeout) を分岐条件に
  */
 export type BranchConditionVariant =
   | {
@@ -544,6 +548,22 @@ export type BranchConditionVariant =
       kind: "tryCatch";
       /** DbAccessStep.affectedRowsCheck.errorCode 等と対応する識別子 */
       errorCode: string;
+      description?: string;
+    }
+  | {
+      /** 直前の DbAccess (UPDATE/DELETE) の rowCount が期待を満たさなかった時に成立 (#261 v1.3) */
+      kind: "affectedRowsZero";
+      /** 対象の DbAccessStep ID (省略時は直前の DbAccess) */
+      stepRef?: string;
+      description?: string;
+    }
+  | {
+      /** 直前の ExternalSystemStep の outcome に基づく分岐 (#261 v1.3) */
+      kind: "externalOutcome";
+      /** 対象の ExternalSystemStep ID (省略時は直前の external call) */
+      stepRef?: string;
+      /** マッチ対象の outcome */
+      outcome: ExternalCallOutcome;
       description?: string;
     };
 

--- a/docs/spec/process-flow-extensions.md
+++ b/docs/spec/process-flow-extensions.md
@@ -451,18 +451,28 @@ PR: #179
 
 ```ts
 type BranchConditionVariant =
-  | { kind: "tryCatch"; errorCode: string; description?: string };
+  | { kind: "tryCatch"; errorCode: string; description?: string }
+  // v1.3 で追加:
+  | { kind: "affectedRowsZero"; stepRef?: string; description?: string }
+  | { kind: "externalOutcome"; stepRef?: string; outcome: "success"|"failure"|"timeout"; description?: string };
 
 type BranchCondition = string | BranchConditionVariant;
 ```
 
-用例 (Saga catch):
+用例:
 
 ```json
+// Saga catch
 "condition": { "kind": "tryCatch", "errorCode": "STOCK_SHORTAGE" }
+
+// 在庫 UPDATE で rowCount が期待未満
+"condition": { "kind": "affectedRowsZero", "stepRef": "step-inventory-update" }
+
+// 外部 API の失敗分岐
+"condition": { "kind": "externalOutcome", "outcome": "failure" }
 ```
 
-PR: #177
+PR: #177 / #265 (#261 v1.3)
 
 ### 7.2 `ElseBranch` (#253 v1.1)
 

--- a/schemas/process-flow.schema.json
+++ b/schemas/process-flow.schema.json
@@ -658,14 +658,43 @@
     },
 
     "BranchConditionVariant": {
-      "type": "object",
-      "required": ["kind", "errorCode"],
-      "additionalProperties": false,
-      "properties": {
-        "kind": { "const": "tryCatch" },
-        "errorCode": { "type": "string" },
-        "description": { "type": "string" }
-      }
+      "description": "分岐条件の型付き variant (#176 / #261 v1.3)",
+      "oneOf": [
+        {
+          "description": "tryCatch: errorCode 付きエラーを捕捉",
+          "type": "object",
+          "required": ["kind", "errorCode"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "tryCatch" },
+            "errorCode": { "type": "string" },
+            "description": { "type": "string" }
+          }
+        },
+        {
+          "description": "affectedRowsZero: 直前の DbAccess の rowCount が期待未満 (#261 v1.3)",
+          "type": "object",
+          "required": ["kind"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "affectedRowsZero" },
+            "stepRef": { "type": "string" },
+            "description": { "type": "string" }
+          }
+        },
+        {
+          "description": "externalOutcome: 直前の ExternalSystem の outcome 分岐 (#261 v1.3)",
+          "type": "object",
+          "required": ["kind", "outcome"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "externalOutcome" },
+            "stepRef": { "type": "string" },
+            "outcome": { "$ref": "#/$defs/ExternalCallOutcome" },
+            "description": { "type": "string" }
+          }
+        }
+      ]
     },
     "BranchCondition": {
       "oneOf": [


### PR DESCRIPTION
## 関連

- 部分対応: #261 v1.3 (BranchConditionVariant 拡張)
- 仕様: docs/spec/process-flow-extensions.md §7.1

## 概要

\`BranchConditionVariant\` に \`affectedRowsZero\` / \`externalOutcome\` を追加。在庫引当分岐 / Stripe failure 分岐等で自由記述 string に逃げる必要を減らす。

## 主な変更

- **TS**: BranchConditionVariant が \`tryCatch | affectedRowsZero | externalOutcome\` の 3 variant union に
- **JSON Schema**: oneOf で 3 variant を表現
- **仕様書 §7.1**: 3 variant の用例
- **テスト 6 件**

## 動作確認

- [x] typecheck pass
- [x] vitest: 409 → 415 (+6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)