### PR TITLE
feat(schemas): ambientVariables + ValidationStep.fieldErrorsVar (#261 v1.4)

### DIFF
--- a/designer/src/schemas/process-flow.schema.test.ts
+++ b/designer/src/schemas/process-flow.schema.test.ts
@@ -117,6 +117,48 @@ describe("process-flow.schema.json — v1.1 拡張 (#253)", () => {
   });
 });
 
+describe("process-flow.schema.json — ambientVariables + fieldErrorsVar (#261 v1.4)", () => {
+  const base = {
+    id: "a", name: "x", type: "screen", description: "",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  };
+
+  it("ambientVariables + ValidationStep.fieldErrorsVar accept", () => {
+    const ok = validate({
+      ...base,
+      ambientVariables: [
+        { name: "requestId", type: "string", required: true },
+        { name: "traceId", type: "string" },
+        { name: "fieldErrors", type: { kind: "custom", label: "Record<string, string>" } },
+      ],
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "s1", type: "validation", description: "",
+          conditions: "",
+          rules: [{ field: "x", type: "required" }],
+          fieldErrorsVar: "fieldErrors",
+        }],
+      }],
+    });
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("ambientVariables 省略 accept", () => {
+    expect(validate({ ...base, actions: [] })).toBe(true);
+  });
+
+  it("ambientVariables.items が StructuredField 型外なら reject", () => {
+    expect(validate({
+      ...base,
+      ambientVariables: [{ foo: "bar" }],
+      actions: [],
+    })).toBe(false);
+  });
+});
+
 describe("process-flow.schema.json — BranchConditionVariant 拡張 (#261 v1.3)", () => {
   const base = {
     id: "a", name: "x", type: "screen", description: "",

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -303,6 +303,12 @@ export interface ValidationStep extends StepBase {
    * 未指定時は conditions の自由記述を読むしかない (後方互換)。
    */
   rules?: ValidationRule[];
+  /**
+   * rules[] の評価結果を格納する変数名 (#261 v1.4)。
+   * 既定は "fieldErrors"。inlineBranch.ngBodyExpression 等で \@fieldErrors として参照される。
+   * 型は Record<fieldName, message> を想定。
+   */
+  fieldErrorsVar?: string;
   inlineBranch?: {
     ok: string;
     ng: string;
@@ -871,6 +877,12 @@ export interface ActionGroup {
    * 値は JSON Schema (inline) またはその略記形。
    */
   typeCatalog?: Record<string, TypeCatalogEntry>;
+  /**
+   * Ambient 変数カタログ (#261 v1.4)。ミドルウェア・フレームワーク由来の自動注入変数 (例: @requestId, @traceId, @fieldErrors)。
+   * @param 記法で参照される際に「inputs にも outputBinding にも無い」と未定義エラー扱いされないよう、
+   * アクション側で明示宣言する。実装側は各フレームワーク (Express/Fastify/Nest) の仕組みで値を供給する責務。
+   */
+  ambientVariables?: StructuredField[];
   createdAt: string;
   updatedAt: string;
 }

--- a/docs/sample-project/actions/cccccccc-0005-4000-8000-cccccccccccc.json
+++ b/docs/sample-project/actions/cccccccc-0005-4000-8000-cccccccccccc.json
@@ -7,6 +7,12 @@
   "mode": "downstream",
   "maturity": "committed",
 
+  "ambientVariables": [
+    { "name": "requestId", "type": "string", "required": true, "description": "リクエスト毎に一意。冪等性キー生成やログ相関に使う。通常はリバプロ/ミドルウェア (X-Request-Id) から注入" },
+    { "name": "traceId", "type": "string", "required": false, "description": "分散トレース用。OpenTelemetry 等から注入" },
+    { "name": "sessionId", "type": "string", "required": false, "description": "セッション識別子。auth 経由" }
+  ],
+
   "errorCatalog": {
     "VALIDATION": {
       "httpStatus": 400,
@@ -131,6 +137,7 @@
             { "field": "items", "type": "custom", "condition": "@items.every(i => i.quantity >= 1 && i.quantity <= 9999)", "message": "@conv.msg.outOfRange" },
             { "field": "paymentMethod", "type": "enum", "values": ["credit_card", "bank_transfer", "cash_on_delivery"] }
           ],
+          "fieldErrorsVar": "fieldErrors",
           "inlineBranch": {
             "ok": "次へ",
             "ng": "400 VALIDATION で return",

--- a/docs/spec/process-flow-expression-language.md
+++ b/docs/spec/process-flow-expression-language.md
@@ -157,6 +157,28 @@ argList         = expression (',' expression)*
 | `ExternalSystemStep.idempotencyKey` (#253 v1.2) | 任意式 (下記 §8 参照) | `"order-@registeredOrder.id"` |
 | `ExternalSystemStep.headers[k]` (#253 v1.2) | 任意式 (値のみ。キーは静的文字列) | `"@traceId"` / `"2024-06-20"` |
 
+## 6.5 Ambient 変数 (#261 v1.4)
+
+`@requestId` / `@traceId` / `@fieldErrors` 等、**ミドルウェア・フレームワーク由来の自動注入変数**は `ActionGroup.ambientVariables?: StructuredField[]` で宣言する。
+
+```json
+"ambientVariables": [
+  { "name": "requestId", "type": "string", "required": true,
+    "description": "リクエスト単位の一意 ID。ミドルウェアが注入" },
+  { "name": "traceId",   "type": "string" },
+  { "name": "fieldErrors", "type": { "kind": "custom", "label": "Record<string, string>" },
+    "description": "ValidationStep.rules[] の結果。既定変数名 (ValidationStep.fieldErrorsVar で上書き可)" }
+]
+```
+
+`@` 参照時、**inputs / outputBinding / ループ変数 / ambientVariables のいずれにも無い変数は未定義エラー**扱い (将来の型推論バリデータで検査)。現状は運用規約として扱う。
+
+### 6.5a `ValidationStep.fieldErrorsVar` (#261 v1.4)
+
+`ValidationStep.rules[]` の評価結果を格納する変数名を明示するフィールド。既定 `"fieldErrors"`。`inlineBranch.ngBodyExpression` 等で `@fieldErrors` として参照する。
+
+型は `Record<fieldName, errorMessage>`。`ambientVariables` で明示宣言すれば式参照との整合性が取れる。
+
 ## 7. runIf 連鎖規則 (#261)
 
 `runIf` はステップ実行の条件ガード。ネスト構造での評価規則を以下に規定する。

--- a/schemas/process-flow.schema.json
+++ b/schemas/process-flow.schema.json
@@ -29,6 +29,11 @@
       "type": "object",
       "additionalProperties": { "$ref": "#/$defs/TypeCatalogEntry" }
     },
+    "ambientVariables": {
+      "description": "Ambient 変数カタログ (#261 v1.4)。ミドルウェア由来 (@requestId, @traceId, @fieldErrors 等) を宣言",
+      "type": "array",
+      "items": { "$ref": "#/$defs/StructuredField" }
+    },
     "actions": {
       "type": "array",
       "items": { "$ref": "#/$defs/ActionDefinition" }
@@ -389,6 +394,10 @@
             "rules": {
               "type": "array",
               "items": { "$ref": "#/$defs/ValidationRule" }
+            },
+            "fieldErrorsVar": {
+              "type": "string",
+              "description": "rules[] の評価結果変数名 (#261 v1.4)。既定 \"fieldErrors\""
             },
             "inlineBranch": { "$ref": "#/$defs/ValidationInlineBranch" }
           }


### PR DESCRIPTION
## 関連

- 部分対応: #261 v1.4 (ambient 変数宣言 + ValidationStep 出力変数)

## 概要

v1.3 再ドッグフード 4.7/5 で残った主要因「\`@requestId\` / \`@fieldErrors\` 等の ambient 変数が schema に無い」「ValidationStep の出力変数名が暗黙」を解消。

## 主な変更

- **ActionGroup.ambientVariables**: StructuredField[] 形式で requestId/traceId 等を宣言可能に
- **ValidationStep.fieldErrorsVar**: rules[] の結果変数名 (既定 "fieldErrors")
- **仕様書 §6.5 / §6.5a 新設**: ambient 変数と未定義参照扱いの規約
- **サンプル 0005**: ambientVariables 3 件 + ValidationStep.fieldErrorsVar 追加
- **テスト 3 件**

## #261 残 (v1.5+、5/5 後でも継続改善の余地)

- tableId → SQL 列検査 (SQL パーサ必要)
- tryCatch の捕捉範囲スコープ指定
- txBoundary.commitPoint 明示
- sideEffects 実行タイミング (before/after) schema 化

🤖 Generated with [Claude Code](https://claude.com/claude-code)