### PR TITLE
feat(schemas): @identifier 参照スコープ検証 (#261 残 第一段)

### DIFF
--- a/designer/src/schemas/identifierScope.test.ts
+++ b/designer/src/schemas/identifierScope.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from "vitest";
+import { checkIdentifierScopes } from "./identifierScope";
+import type { ActionGroup } from "../types/action";
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve, join } from "node:path";
+
+const samplesDir = resolve(__dirname, "../../../docs/sample-project/actions");
+
+function makeGroup(partial: Partial<ActionGroup>): ActionGroup {
+  return {
+    id: "a", name: "x", type: "screen", description: "",
+    actions: [],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...partial,
+  } as ActionGroup;
+}
+
+describe("checkIdentifierScopes — inputs / outputs", () => {
+  it("inputs で宣言された識別子は参照 OK", () => {
+    const issues = checkIdentifierScopes(makeGroup({
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        inputs: [{ name: "userId", type: "number" }],
+        steps: [
+          { id: "s1", type: "compute", description: "", expression: "@userId + 1", outputBinding: "doubled" },
+        ],
+      }],
+    }));
+    expect(issues).toHaveLength(0);
+  });
+
+  it("未定義 @identifier を検出", () => {
+    const issues = checkIdentifierScopes(makeGroup({
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [
+          { id: "s1", type: "compute", description: "", expression: "@unknownVar * 2", outputBinding: "r" },
+        ],
+      }],
+    }));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].identifier).toBe("unknownVar");
+    expect(issues[0].code).toBe("UNKNOWN_IDENTIFIER");
+  });
+});
+
+describe("checkIdentifierScopes — outputBinding が後続ステップで参照可能", () => {
+  it("step1.outputBinding → step2 で参照 OK", () => {
+    const issues = checkIdentifierScopes(makeGroup({
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        inputs: [{ name: "x", type: "number" }],
+        steps: [
+          { id: "s1", type: "compute", description: "", expression: "@x * 2", outputBinding: "doubled" },
+          { id: "s2", type: "compute", description: "", expression: "@doubled + 1", outputBinding: "r" },
+        ],
+      }],
+    }));
+    expect(issues).toHaveLength(0);
+  });
+});
+
+describe("checkIdentifierScopes — ambient 変数", () => {
+  it("ambientVariables で宣言されれば参照 OK", () => {
+    const issues = checkIdentifierScopes(makeGroup({
+      ambientVariables: [{ name: "requestId", type: "string" }],
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [
+          { id: "s1", type: "externalSystem", description: "", systemName: "x",
+            idempotencyKey: "key-@requestId" },
+        ],
+      }],
+    }));
+    expect(issues).toHaveLength(0);
+  });
+});
+
+describe("checkIdentifierScopes — ループ変数のスコープ", () => {
+  it("ループ配下では collectionItemName が参照可能", () => {
+    const issues = checkIdentifierScopes(makeGroup({
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        inputs: [{ name: "items", type: "string" }],
+        steps: [
+          {
+            id: "lp", type: "loop", description: "",
+            loopKind: "collection", collectionSource: "@items",
+            collectionItemName: "item",
+            steps: [
+              { id: "s1", type: "compute", description: "", expression: "@item.quantity", outputBinding: "q" },
+            ],
+          },
+        ],
+      }],
+    }));
+    expect(issues).toHaveLength(0);
+  });
+
+  it("ループ外では item は未定義", () => {
+    const issues = checkIdentifierScopes(makeGroup({
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        inputs: [{ name: "items", type: "string" }],
+        steps: [
+          {
+            id: "lp", type: "loop", description: "",
+            loopKind: "collection", collectionSource: "@items",
+            collectionItemName: "item",
+            steps: [],
+          },
+          { id: "s-after", type: "compute", description: "", expression: "@item.quantity", outputBinding: "q" },
+        ],
+      }],
+    }));
+    expect(issues.some((i) => i.identifier === "item")).toBe(true);
+  });
+});
+
+describe("checkIdentifierScopes — ValidationStep.fieldErrorsVar", () => {
+  it("既定 fieldErrors が ngBodyExpression で参照可能", () => {
+    const issues = checkIdentifierScopes(makeGroup({
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [
+          {
+            id: "s1", type: "validation", description: "", conditions: "",
+            rules: [{ field: "x", type: "required" }],
+            inlineBranch: { ok: "ok", ng: "ng", ngBodyExpression: "{ errors: @fieldErrors }" },
+          },
+        ],
+      }],
+    }));
+    expect(issues).toHaveLength(0);
+  });
+
+  it("カスタム fieldErrorsVar 名で宣言し参照可能", () => {
+    const issues = checkIdentifierScopes(makeGroup({
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [
+          {
+            id: "s1", type: "validation", description: "", conditions: "",
+            rules: [{ field: "x", type: "required" }],
+            fieldErrorsVar: "myErrors",
+          },
+          {
+            id: "s2", type: "return", description: "",
+            bodyExpression: "{ errors: @myErrors }",
+          },
+        ],
+      }],
+    }));
+    expect(issues).toHaveLength(0);
+  });
+});
+
+describe("checkIdentifierScopes — @conv.* は検査対象外", () => {
+  it("@conv.msg.* などは未定義扱いしない (別機能で解決)", () => {
+    const issues = checkIdentifierScopes(makeGroup({
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [
+          {
+            id: "s1", type: "validation", description: "", conditions: "",
+            rules: [{ field: "x", type: "custom", message: "@conv.msg.required" }],
+          },
+        ],
+      }],
+    }));
+    expect(issues).toHaveLength(0);
+  });
+});
+
+describe("checkIdentifierScopes — SQL 内の @identifier", () => {
+  it("SQL 内の @ 参照も検査", () => {
+    const issues = checkIdentifierScopes(makeGroup({
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        inputs: [{ name: "customerId", type: "number" }],
+        steps: [
+          {
+            id: "s1", type: "dbAccess", description: "",
+            tableName: "customers", operation: "SELECT",
+            sql: "SELECT id FROM customers WHERE id = @customerId AND org_id = @unknownOrg",
+          },
+        ],
+      }],
+    }));
+    expect(issues.some((i) => i.identifier === "unknownOrg")).toBe(true);
+    expect(issues.every((i) => i.identifier !== "customerId")).toBe(true);
+  });
+});
+
+describe("checkIdentifierScopes — サンプル (docs/sample-project/actions/*.json)", () => {
+  const files = readdirSync(samplesDir).filter((f) => f.endsWith(".json"));
+  for (const f of files) {
+    it(`${f} の @ 参照が全て解決`, () => {
+      const group = JSON.parse(readFileSync(join(samplesDir, f), "utf-8")) as ActionGroup;
+      const issues = checkIdentifierScopes(group);
+      if (issues.length > 0) {
+        throw new Error(
+          `識別子スコープ違反:\n${issues.map((i) => `  - ${i.path}: @${i.identifier} (${i.message})`).join("\n")}`,
+        );
+      }
+      expect(issues).toHaveLength(0);
+    });
+  }
+});

--- a/designer/src/schemas/identifierScope.ts
+++ b/designer/src/schemas/identifierScope.ts
@@ -1,0 +1,233 @@
+/**
+ * 処理フロー @ 参照の識別子スコープ検証 (#261 残タスク)。
+ *
+ * 全ての @identifier が以下のいずれかに存在するかを検査:
+ * - ActionDefinition.inputs[].name
+ * - ActionDefinition.outputs[].name
+ * - ActionGroup.ambientVariables[].name
+ * - 先行ステップの StepBase.outputBinding (string or object.name)
+ * - LoopStep.collectionItemName (ループ配下のスコープのみ)
+ * - ValidationStep.fieldErrorsVar の宣言
+ *
+ * 単純な regex ベースの識別子抽出 + スコープ走査。
+ * 式の完全パースや型推論は今は行わない (path 部分は無視、root 識別子のみ検査)。
+ */
+import type {
+  ActionGroup,
+  ActionDefinition,
+  Step,
+  OutputBinding,
+  ValidationStep,
+  LoopStep,
+  StructuredField,
+} from "../types/action";
+
+export interface IdentifierIssue {
+  path: string;
+  code: "UNKNOWN_IDENTIFIER";
+  identifier: string;
+  message: string;
+}
+
+/** 任意の文字列から @identifier の root 部分を抽出 (property path は無視) */
+function extractIdentifiers(src: string): string[] {
+  const result: string[] = [];
+  const re = /@([a-zA-Z_][\w]*)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(src)) !== null) {
+    result.push(m[1]);
+  }
+  return result;
+}
+
+function getBindingName(binding: OutputBinding | undefined): string | null {
+  if (!binding) return null;
+  if (typeof binding === "string") return binding;
+  return binding.name;
+}
+
+function fieldNames(fields: StructuredField[] | undefined): string[] {
+  return fields?.map((f) => f.name) ?? [];
+}
+
+/**
+ * 全 @ 参照の識別子スコープ検証。
+ * 空配列なら問題なし。
+ */
+export function checkIdentifierScopes(group: ActionGroup): IdentifierIssue[] {
+  const issues: IdentifierIssue[] = [];
+  const ambientNames = new Set(fieldNames(group.ambientVariables));
+
+  group.actions.forEach((action, ai) => {
+    const knownInAction = new Set<string>(ambientNames);
+    // inputs
+    if (Array.isArray(action.inputs)) {
+      for (const f of action.inputs) knownInAction.add(f.name);
+    }
+    // outputs (宣言済み変数として扱う、書込は step 側の outputBinding 経由だがここでは参照許容)
+    if (Array.isArray(action.outputs)) {
+      for (const f of action.outputs) knownInAction.add(f.name);
+    }
+
+    walkSteps(
+      action.steps ?? [],
+      `actions[${ai}].steps`,
+      knownInAction,
+      [],
+      issues,
+    );
+  });
+
+  return issues;
+}
+
+/**
+ * ステップ列を走査。
+ * @param known  このスコープで参照可能な識別子の set (mutable: outputBinding で add)
+ * @param loopItems 包含ループの collectionItemName 列 (ネスト可)
+ */
+function walkSteps(
+  steps: Step[],
+  basePath: string,
+  known: Set<string>,
+  loopItems: string[],
+  issues: IdentifierIssue[],
+): void {
+  steps.forEach((step, i) => {
+    const path = `${basePath}[${i}]`;
+    const available = new Set<string>([...known, ...loopItems]);
+    checkStep(step, path, available, issues);
+
+    // この step の outputBinding を known に追加 (後続ステップから参照可能に)
+    const bindName = getBindingName(step.outputBinding);
+    if (bindName) known.add(bindName);
+    // ValidationStep の fieldErrorsVar も known に
+    if (step.type === "validation") {
+      const vStep = step as ValidationStep;
+      if (vStep.fieldErrorsVar) known.add(vStep.fieldErrorsVar);
+      else known.add("fieldErrors"); // 既定
+    }
+    // ReturnStep は新変数を作らない
+
+    // ネスト構造。known は共有 (ループ/ブランチ/sideEffects 内で宣言された
+    // outputBinding は親スコープからも参照可能とする -- accumulate/push を
+    // ループ外で参照するパターンを許容するため、現時点では permissive)。
+    // loopItems はループ配下のみ有効 (ループ外に leak させない)。
+    if ("subSteps" in step && step.subSteps) {
+      walkSteps(step.subSteps, `${path}.subSteps`, known, loopItems, issues);
+    }
+    if (step.type === "branch") {
+      step.branches.forEach((b, bi) => {
+        walkSteps(b.steps, `${path}.branches[${bi}].steps`, known, loopItems, issues);
+      });
+      if (step.elseBranch) {
+        walkSteps(step.elseBranch.steps, `${path}.elseBranch.steps`, known, loopItems, issues);
+      }
+    }
+    if (step.type === "loop") {
+      const loopStep = step as LoopStep;
+      const childLoopItems = loopStep.collectionItemName
+        ? [...loopItems, loopStep.collectionItemName]
+        : loopItems;
+      walkSteps(loopStep.steps, `${path}.steps`, known, childLoopItems, issues);
+    }
+    if (step.type === "externalSystem") {
+      Object.entries(step.outcomes ?? {}).forEach(([k, spec]) => {
+        if (spec?.sideEffects) {
+          walkSteps(spec.sideEffects, `${path}.outcomes.${k}.sideEffects`, known, loopItems, issues);
+        }
+      });
+    }
+  });
+}
+
+/** 1 step の式フィールドを全走査、@ 識別子を known と突合 */
+function checkStep(step: Step, path: string, availableIn: Set<string>, issues: IdentifierIssue[]): void {
+  // ValidationStep は自分自身の rules[] 評価結果 fieldErrors を同じ step の ngBodyExpression
+  // で使う (同時に可視) ので、available に足してから式チェック
+  const available = new Set(availableIn);
+  if (step.type === "validation") {
+    const vStep = step as ValidationStep;
+    available.add(vStep.fieldErrorsVar ?? "fieldErrors");
+  }
+
+  const expressions: Array<{ src: string; field: string }> = [];
+
+  if (step.runIf) expressions.push({ src: step.runIf, field: "runIf" });
+
+  if (step.type === "compute") {
+    expressions.push({ src: step.expression, field: "expression" });
+  }
+  if (step.type === "return") {
+    if (step.bodyExpression) expressions.push({ src: step.bodyExpression, field: "bodyExpression" });
+  }
+  if (step.type === "validation") {
+    if (step.conditions) expressions.push({ src: step.conditions, field: "conditions" });
+    (step.rules ?? []).forEach((r, ri) => {
+      if (r.condition) expressions.push({ src: r.condition, field: `rules[${ri}].condition` });
+      if (r.message) expressions.push({ src: r.message, field: `rules[${ri}].message` });
+    });
+    if (step.inlineBranch?.ngBodyExpression) {
+      expressions.push({ src: step.inlineBranch.ngBodyExpression, field: "inlineBranch.ngBodyExpression" });
+    }
+  }
+  if (step.type === "branch") {
+    step.branches.forEach((b, bi) => {
+      if (typeof b.condition === "string") {
+        expressions.push({ src: b.condition, field: `branches[${bi}].condition` });
+      }
+    });
+  }
+  if (step.type === "loop") {
+    if (step.countExpression) expressions.push({ src: step.countExpression, field: "countExpression" });
+    if (step.conditionExpression) expressions.push({ src: step.conditionExpression, field: "conditionExpression" });
+    if (step.collectionSource) expressions.push({ src: step.collectionSource, field: "collectionSource" });
+  }
+  if (step.type === "dbAccess") {
+    if (step.sql) expressions.push({ src: step.sql, field: "sql" });
+    if (step.fields) expressions.push({ src: step.fields, field: "fields" });
+  }
+  if (step.type === "externalSystem") {
+    if (step.protocol) expressions.push({ src: step.protocol, field: "protocol" });
+    if (step.idempotencyKey) expressions.push({ src: step.idempotencyKey, field: "idempotencyKey" });
+    if (step.httpCall?.path) expressions.push({ src: step.httpCall.path, field: "httpCall.path" });
+    if (step.httpCall?.body) expressions.push({ src: step.httpCall.body, field: "httpCall.body" });
+    Object.entries(step.httpCall?.query ?? {}).forEach(([k, v]) => {
+      expressions.push({ src: v, field: `httpCall.query.${k}` });
+    });
+    Object.entries(step.headers ?? {}).forEach(([k, v]) => {
+      expressions.push({ src: v, field: `headers.${k}` });
+    });
+    Object.entries((step as { argumentMapping?: Record<string, string> }).argumentMapping ?? {}).forEach(
+      ([k, v]) => {
+        expressions.push({ src: v, field: `argumentMapping.${k}` });
+      },
+    );
+  }
+  if (step.type === "commonProcess" && step.argumentMapping) {
+    Object.entries(step.argumentMapping).forEach(([k, v]) => {
+      expressions.push({ src: v, field: `argumentMapping.${k}` });
+    });
+  }
+
+  // outputBinding.initialValue も式扱い
+  if (typeof step.outputBinding === "object" && step.outputBinding?.initialValue) {
+    expressions.push({ src: step.outputBinding.initialValue, field: "outputBinding.initialValue" });
+  }
+
+  for (const { src, field } of expressions) {
+    const ids = extractIdentifiers(src);
+    for (const id of ids) {
+      // @conv.* は規約カタログ (別機能) なので今は除外
+      if (id === "conv") continue;
+      if (!available.has(id)) {
+        issues.push({
+          path: `${path}.${field}`,
+          code: "UNKNOWN_IDENTIFIER",
+          identifier: id,
+          message: `@${id} がこのスコープで宣言されていません (inputs / outputs / outputBinding / ambientVariables / loop item のいずれにも無い)`,
+        });
+      }
+    }
+  }
+}

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -86,3 +86,5 @@ const issues = checkReferentialIntegrity(actionGroup);
 - `designer/src/types/action.ts` — TypeScript 型定義 (本スキーマと同期保守)
 - `designer/src/utils/actionMigration.ts` — 旧形式からの変換 (新スキーマは旧形式も union 側で受け入れる)
 - `designer/src/schemas/process-flow.schema.test.ts` — サンプル検証 + negative ケース
+- `designer/src/schemas/identifierScope.ts` — `@identifier` 参照の scope 検証 (inputs / outputBinding / ambientVariables / ループ変数 との突合)
+- `designer/src/schemas/identifierScope.test.ts` — scope 検証のユニット + サンプル全件検査


### PR DESCRIPTION
## 関連

- 部分対応: #261 残タスク「@ 参照の型推論」の第一段
- 仕様: schemas/README.md の「参照整合性」節に追記

## 概要

処理フロー JSON 内の全 \`@identifier\` root 参照が、以下のいずれかで宣言されているかを正規表現ベースで検査。式の完全パースは将来課題として残すが、**未宣言変数を即座に検出できる**レベルの現実的バリデータを実装。

## 検査ロジック

宣言源:
- ActionDefinition.inputs[].name
- ActionDefinition.outputs[].name
- ActionGroup.ambientVariables[].name
- 先行ステップの outputBinding (string or object.name)
- LoopStep.collectionItemName (配下スコープのみ)
- ValidationStep.fieldErrorsVar (既定 "fieldErrors")

走査対象フィールド:
runIf / expression / bodyExpression / conditions / rules[].condition /
rules[].message / inlineBranch.ngBodyExpression / branches[].condition
(string) / countExpression / conditionExpression / collectionSource /
sql / fields / protocol / idempotencyKey / httpCall.{path,body,query} /
headers / argumentMapping / outputBinding.initialValue

## 設計判断

- **正規表現ベース**: \`/@([a-zA-Z_][\w]*)/g\` で root 識別子のみ抽出。path (\`.itemId\`) は無視。パーサ導入は別 PR で
- **scope の permissive 化**: outputBinding はスコープを跨いで参照可能 (sample 0005 の accumulate/push パターン許容)。loopItems だけ厳密スコープ
- **ValidationStep 自己可視**: ngBodyExpression 内の @fieldErrors を同じ step で可視化
- **@conv.* は除外**: 規約カタログ解決は別機能 (#151-A) のため

## 動作確認

- [x] typecheck pass
- [x] vitest: 420 → 435 (+15、回帰なし)
- [x] サンプル 0005 の全 @ 参照が scope-clean

## 次ステップ

残 3 件 (#261):
- tableId → SQL 列検査 (SQL parser 導入)
- 規約 ID 解決 (@conv.*) — #151-A
- secrets 管理の正式機能化

🤖 Generated with [Claude Code](https://claude.com/claude-code)