### PR TITLE
feat(schemas): 規約カタログ (@conv.*) の正式機能化 (#151-A / #261 残)

### DIFF
--- a/designer/src/schemas/conventionsValidator.test.ts
+++ b/designer/src/schemas/conventionsValidator.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from "vitest";
+import Ajv2020 from "ajv/dist/2020";
+import addFormats from "ajv-formats";
+import { checkConventionReferences, type ConventionsCatalog } from "./conventionsValidator";
+import type { ActionGroup } from "../types/action";
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve, join } from "node:path";
+
+const repoRoot = resolve(__dirname, "../../../");
+const catalogPath = resolve(repoRoot, "docs/sample-project/conventions/conventions-catalog.json");
+const catalogSchemaPath = resolve(repoRoot, "schemas/conventions.schema.json");
+const samplesDir = resolve(repoRoot, "docs/sample-project/actions");
+
+function loadCatalog(): ConventionsCatalog {
+  return JSON.parse(readFileSync(catalogPath, "utf-8")) as ConventionsCatalog;
+}
+
+function makeGroup(partial: Partial<ActionGroup>): ActionGroup {
+  return {
+    id: "a", name: "x", type: "screen", description: "",
+    actions: [],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...partial,
+  } as ActionGroup;
+}
+
+describe("conventions-catalog.json がスキーマに適合", () => {
+  it("ajv でスキーマ検証 pass", () => {
+    const ajv = new Ajv2020({ allErrors: true, strict: false });
+    addFormats(ajv);
+    const schema = JSON.parse(readFileSync(catalogSchemaPath, "utf-8"));
+    const catalog = JSON.parse(readFileSync(catalogPath, "utf-8"));
+    const validate = ajv.compile(schema);
+    const ok = validate(catalog);
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+});
+
+describe("checkConventionReferences", () => {
+  const catalog = loadCatalog();
+
+  it("既知の @conv.msg.* は accept", () => {
+    const issues = checkConventionReferences(
+      makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [{
+            id: "s1", type: "validation", description: "", conditions: "",
+            rules: [{ field: "x", type: "required", message: "@conv.msg.required" }],
+          }],
+        }],
+      }),
+      catalog,
+    );
+    expect(issues).toHaveLength(0);
+  });
+
+  it("未知の @conv.msg.* を検出", () => {
+    const issues = checkConventionReferences(
+      makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [{
+            id: "s1", type: "validation", description: "", conditions: "",
+            rules: [{ field: "x", type: "required", message: "@conv.msg.unknownKey" }],
+          }],
+        }],
+      }),
+      catalog,
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("UNKNOWN_CONV_MSG");
+  });
+
+  it("@conv.regex.email-simple は accept", () => {
+    const issues = checkConventionReferences(
+      makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [{
+            id: "s1", type: "validation", description: "", conditions: "@conv.regex.email-simple",
+            rules: [],
+          }],
+        }],
+      }),
+      catalog,
+    );
+    expect(issues).toHaveLength(0);
+  });
+
+  it("@conv.regex.unknownPattern を検出", () => {
+    const issues = checkConventionReferences(
+      makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [{
+            id: "s1", type: "validation", description: "", conditions: "@conv.regex.unknownPattern",
+            rules: [],
+          }],
+        }],
+      }),
+      catalog,
+    );
+    expect(issues.some((i) => i.code === "UNKNOWN_CONV_REGEX")).toBe(true);
+  });
+
+  it("@conv.limit.quantityMax は accept", () => {
+    const issues = checkConventionReferences(
+      makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [{
+            id: "s1", type: "other", description: "上限 @conv.limit.quantityMax まで",
+          }],
+        }],
+      }),
+      catalog,
+    );
+    expect(issues).toHaveLength(0);
+  });
+
+  it("未知のカテゴリ @conv.xxx.* は UNKNOWN_CONV_CATEGORY", () => {
+    const issues = checkConventionReferences(
+      makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [{
+            id: "s1", type: "other", description: "@conv.color.red",
+          }],
+        }],
+      }),
+      catalog,
+    );
+    expect(issues.some((i) => i.code === "UNKNOWN_CONV_CATEGORY")).toBe(true);
+  });
+
+  it("catalog が null (未ロード) なら検査スキップ", () => {
+    const issues = checkConventionReferences(
+      makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [{
+            id: "s1", type: "validation", description: "", conditions: "",
+            rules: [{ field: "x", type: "required", message: "@conv.msg.anything" }],
+          }],
+        }],
+      }),
+      null,
+    );
+    expect(issues).toHaveLength(0);
+  });
+});
+
+describe("checkConventionReferences — サンプル (docs/sample-project/actions/*.json) 横断", () => {
+  const catalog = loadCatalog();
+  const files = readdirSync(samplesDir).filter((f) => f.endsWith(".json"));
+
+  for (const f of files) {
+    it(`${f} の @conv.* 参照が全て解決`, () => {
+      const group = JSON.parse(readFileSync(join(samplesDir, f), "utf-8")) as ActionGroup;
+      const issues = checkConventionReferences(group, catalog);
+      if (issues.length > 0) {
+        throw new Error(
+          `@conv.* 違反:\n${issues.map((i) => `  - ${i.path}: ${i.value} (${i.message})`).join("\n")}`,
+        );
+      }
+      expect(issues).toHaveLength(0);
+    });
+  }
+});

--- a/designer/src/schemas/conventionsValidator.ts
+++ b/designer/src/schemas/conventionsValidator.ts
@@ -1,0 +1,161 @@
+/**
+ * @conv.msg.* / @conv.regex.* / @conv.limit.* 参照の検証 (#151-A / #261 残)。
+ *
+ * 処理フロー JSON 内の式・メッセージ中に現れる @conv.<category>.<key> が
+ * conventions-catalog.json に存在するかを検査。
+ */
+import type {
+  ActionGroup,
+  Step,
+  ActionDefinition,
+  ValidationStep,
+  LoopStep,
+} from "../types/action";
+
+export interface ConventionsCatalog {
+  version: string;
+  msg?: Record<string, { template: string }>;
+  regex?: Record<string, { pattern: string; flags?: string }>;
+  limit?: Record<string, { value: number; unit?: string }>;
+}
+
+export interface ConventionIssue {
+  path: string;
+  code:
+    | "UNKNOWN_CONV_MSG"
+    | "UNKNOWN_CONV_REGEX"
+    | "UNKNOWN_CONV_LIMIT"
+    | "UNKNOWN_CONV_CATEGORY";
+  value: string;
+  message: string;
+}
+
+/** @conv.CAT.KEY / @conv.CAT.KEY.subpath にマッチ */
+const CONV_RE = /@conv\.([a-zA-Z_][\w-]*)\.([a-zA-Z_][\w-]*)/g;
+
+/** 1 文字列から @conv 参照を抽出 */
+function extractConvRefs(src: string): Array<{ category: string; key: string }> {
+  const results: Array<{ category: string; key: string }> = [];
+  let m: RegExpExecArray | null;
+  while ((m = CONV_RE.exec(src)) !== null) {
+    results.push({ category: m[1], key: m[2] });
+  }
+  return results;
+}
+
+function codeFor(category: string): ConventionIssue["code"] {
+  switch (category) {
+    case "msg": return "UNKNOWN_CONV_MSG";
+    case "regex": return "UNKNOWN_CONV_REGEX";
+    case "limit": return "UNKNOWN_CONV_LIMIT";
+    default: return "UNKNOWN_CONV_CATEGORY";
+  }
+}
+
+function resolveCategory(catalog: ConventionsCatalog, category: string): Record<string, unknown> | null {
+  if (category === "msg") return catalog.msg ?? null;
+  if (category === "regex") return catalog.regex ?? null;
+  if (category === "limit") return catalog.limit ?? null;
+  return null;
+}
+
+/** ActionGroup 全体で @conv.* 参照を検査。catalog が null なら検査 skip */
+export function checkConventionReferences(
+  group: ActionGroup,
+  catalog: ConventionsCatalog | null,
+): ConventionIssue[] {
+  if (!catalog) return [];
+  const issues: ConventionIssue[] = [];
+
+  group.actions.forEach((action, ai) => {
+    walkStepsInAction(action, `actions[${ai}]`, catalog, issues);
+  });
+
+  return issues;
+}
+
+function walkStepsInAction(
+  action: ActionDefinition,
+  basePath: string,
+  catalog: ConventionsCatalog,
+  issues: ConventionIssue[],
+): void {
+  walkSteps(action.steps ?? [], `${basePath}.steps`, catalog, issues);
+}
+
+function walkSteps(
+  steps: Step[],
+  basePath: string,
+  catalog: ConventionsCatalog,
+  issues: ConventionIssue[],
+): void {
+  steps.forEach((step, i) => {
+    const path = `${basePath}[${i}]`;
+    checkStep(step, path, catalog, issues);
+
+    if ("subSteps" in step && step.subSteps) walkSteps(step.subSteps, `${path}.subSteps`, catalog, issues);
+    if (step.type === "branch") {
+      step.branches.forEach((b, bi) => walkSteps(b.steps, `${path}.branches[${bi}].steps`, catalog, issues));
+      if (step.elseBranch) walkSteps(step.elseBranch.steps, `${path}.elseBranch.steps`, catalog, issues);
+    }
+    if (step.type === "loop") walkSteps((step as LoopStep).steps, `${path}.steps`, catalog, issues);
+    if (step.type === "externalSystem") {
+      Object.entries(step.outcomes ?? {}).forEach(([k, spec]) => {
+        if (spec?.sideEffects) walkSteps(spec.sideEffects, `${path}.outcomes.${k}.sideEffects`, catalog, issues);
+      });
+    }
+  });
+}
+
+function checkStep(step: Step, path: string, catalog: ConventionsCatalog, issues: ConventionIssue[]): void {
+  const texts: Array<{ src: string; field: string }> = [];
+
+  if (step.description) texts.push({ src: step.description, field: "description" });
+  if (step.runIf) texts.push({ src: step.runIf, field: "runIf" });
+
+  if (step.type === "compute") texts.push({ src: step.expression, field: "expression" });
+  if (step.type === "return" && step.bodyExpression) texts.push({ src: step.bodyExpression, field: "bodyExpression" });
+  if (step.type === "validation") {
+    const vStep = step as ValidationStep;
+    if (vStep.conditions) texts.push({ src: vStep.conditions, field: "conditions" });
+    (vStep.rules ?? []).forEach((r, ri) => {
+      if (r.condition) texts.push({ src: r.condition, field: `rules[${ri}].condition` });
+      if (r.message) texts.push({ src: r.message, field: `rules[${ri}].message` });
+      if (r.pattern) texts.push({ src: r.pattern, field: `rules[${ri}].pattern` });
+    });
+    if (vStep.inlineBranch?.ngBodyExpression) {
+      texts.push({ src: vStep.inlineBranch.ngBodyExpression, field: "inlineBranch.ngBodyExpression" });
+    }
+  }
+  if (step.type === "dbAccess") {
+    if (step.sql) texts.push({ src: step.sql, field: "sql" });
+  }
+  if (step.type === "externalSystem") {
+    if (step.protocol) texts.push({ src: step.protocol, field: "protocol" });
+    if (step.httpCall?.body) texts.push({ src: step.httpCall.body, field: "httpCall.body" });
+  }
+
+  for (const { src, field } of texts) {
+    const refs = extractConvRefs(src);
+    for (const { category, key } of refs) {
+      const cat = resolveCategory(catalog, category);
+      if (cat === null) {
+        issues.push({
+          path: `${path}.${field}`,
+          code: "UNKNOWN_CONV_CATEGORY",
+          value: `@conv.${category}.${key}`,
+          message: `@conv.${category}.* カテゴリは規約カタログに存在しません (msg/regex/limit のみ)`,
+        });
+        continue;
+      }
+      if (!(key in cat)) {
+        issues.push({
+          path: `${path}.${field}`,
+          code: codeFor(category),
+          value: `@conv.${category}.${key}`,
+          message: `@conv.${category}.${key} が規約カタログに存在しません`,
+        });
+      }
+    }
+  }
+}

--- a/docs/conventions/validation-rules.md
+++ b/docs/conventions/validation-rules.md
@@ -1,12 +1,19 @@
-# バリデーション規約 (プレースホルダー)
+# バリデーション規約
 
-**ステータス**: Placeholder (仮)
+**ステータス**: 機械可読版あり (`docs/sample-project/conventions/conventions-catalog.json`)、human-readable は本書
 **策定日**: 2026-04-20
-**関連 issue**: #151 (A: 設計書種別の追加)
+**関連 issue**: #151 (A: 設計書種別の追加) / #261 残
 
 本書は処理フロー仕様書が参照する横断的なバリデーション規約 (メッセージテンプレート + 正規表現カタログ + 境界値) を定める。
 
-**位置づけ**: 将来 designer アプリ内の「バリデーション定義」機能 (issue #151-A) で置き換えられる予定。現時点はテキスト形式の placeholder。
+## 機械可読版 (v1.6 新設)
+
+AI / CI から読める JSON 形式:
+- **カタログ**: [`docs/sample-project/conventions/conventions-catalog.json`](../sample-project/conventions/conventions-catalog.json)
+- **JSON Schema**: [`schemas/conventions.schema.json`](../../schemas/conventions.schema.json)
+- **参照整合性検証**: `designer/src/schemas/conventionsValidator.ts` が処理フロー内の `@conv.*` 参照を検査
+
+本 md 本文 (§1-§3) と JSON カタログが drift しないよう、md を更新したら JSON も更新する。
 
 ---
 

--- a/docs/sample-project/conventions/conventions-catalog.json
+++ b/docs/sample-project/conventions/conventions-catalog.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://raw.githubusercontent.com/csilost2001/html-designer/main/schemas/conventions.schema.json",
+  "version": "1.0.0",
+  "description": "処理フロー仕様書 / ActionGroup から @conv.* で参照される横断規約カタログ。docs/conventions/validation-rules.md の構造化版",
+  "updatedAt": "2026-04-20T00:00:00.000Z",
+
+  "msg": {
+    "required": {
+      "template": "{label}は必須入力です",
+      "params": ["label"],
+      "description": "非空必須エラーの既定メッセージ"
+    },
+    "maxLength": {
+      "template": "{label}は{max}文字以内で入力してください",
+      "params": ["label", "max"]
+    },
+    "invalidFormat": {
+      "template": "{label}の形式が正しくありません",
+      "params": ["label"]
+    },
+    "duplicate": {
+      "template": "この{label}は既に登録されています",
+      "params": ["label"]
+    },
+    "outOfRange": {
+      "template": "{label}は{min}〜{max}の範囲で入力してください",
+      "params": ["label", "min", "max"]
+    },
+    "mustBePositive": {
+      "template": "{label}は1以上の数値を入力してください",
+      "params": ["label"]
+    }
+  },
+
+  "regex": {
+    "email-simple": {
+      "pattern": "^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$",
+      "description": "メールアドレス (RFC5322 簡易)",
+      "exampleValid": ["a@b.jp", "user@example.com"],
+      "exampleInvalid": ["a@b", "no-at-sign"]
+    },
+    "phone-jp": {
+      "pattern": "^0\\d{1,4}-\\d{1,4}-\\d{4}$",
+      "description": "国内電話番号 (固定/携帯、ハイフン必須)",
+      "exampleValid": ["080-1234-5678", "03-1234-5678"],
+      "exampleInvalid": ["+81-80-1234-5678", "08012345678"]
+    },
+    "postal-jp": {
+      "pattern": "^\\d{3}-?\\d{4}$",
+      "description": "日本の郵便番号 (ハイフン任意、保存時は NNN-NNNN 正規化)",
+      "exampleValid": ["100-0001", "1000001"],
+      "exampleInvalid": ["10-00001"]
+    },
+    "kana-fullwidth": {
+      "pattern": "^[\\u30A0-\\u30FF ー・]+$",
+      "description": "全角カタカナ (長音符・中黒・半角空白許容)",
+      "exampleValid": ["ヤマダ タロウ", "オオノ・ケンイチ"],
+      "exampleInvalid": ["やまだ", "YAMADA"]
+    },
+    "alnum": {
+      "pattern": "^[A-Za-z0-9]+$",
+      "description": "英数字のみ",
+      "exampleValid": ["Abc123"],
+      "exampleInvalid": ["あいう", "A-1"]
+    }
+  },
+
+  "limit": {
+    "nameMax": { "value": 100, "unit": "char", "description": "氏名最大長 (customers.name 等)" },
+    "nameKanaMax": { "value": 100, "unit": "char" },
+    "emailMax": { "value": 255, "unit": "char", "description": "RFC5321 準拠" },
+    "phoneMax": { "value": 20, "unit": "char" },
+    "postalMax": { "value": 10, "unit": "char", "description": "NNN-NNNN 正規化後は 8 文字" },
+    "addressMax": { "value": 500, "unit": "char" },
+    "companyNameMax": { "value": 200, "unit": "char" },
+    "quantityMax": { "value": 9999, "unit": "integer", "description": "発注可能数量の上限" },
+    "quantityMin": { "value": 1, "unit": "integer" },
+    "amountMax": { "value": 999999999999, "unit": "yen", "description": "DECIMAL(12,0) の上限、JPY" }
+  }
+}

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -17,6 +17,7 @@
 | ファイル | 対象 | TS 型 |
 |----------|------|-------|
 | `process-flow.schema.json` | ActionGroup (処理フロー定義) | `ActionGroup` @ `designer/src/types/action.ts` |
+| `conventions.schema.json` | 横断規約カタログ (msg / regex / limit) | 対応 TS 型は `designer/src/schemas/conventionsValidator.ts` の `ConventionsCatalog` |
 
 スキーマドラフト: **JSON Schema 2020-12**
 
@@ -90,3 +91,5 @@ const issues = checkReferentialIntegrity(actionGroup);
 - `designer/src/schemas/identifierScope.test.ts` — scope 検証のユニット + サンプル全件検査
 - `designer/src/schemas/sqlColumnValidator.ts` — DbAccessStep.sql 内列参照をテーブル定義と突合 (node-sql-parser + PostgreSQL dialect)
 - `designer/src/schemas/sqlColumnValidator.test.ts` — SQL 検査のユニット + サンプル横断
+- `designer/src/schemas/conventionsValidator.ts` — `@conv.msg.*` / `@conv.regex.*` / `@conv.limit.*` 参照を conventions-catalog.json と突合
+- `designer/src/schemas/conventionsValidator.test.ts` — 規約 ID 解決のユニット + サンプル横断

--- a/schemas/conventions.schema.json
+++ b/schemas/conventions.schema.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/csilost2001/html-designer/main/schemas/conventions.schema.json",
+  "title": "ConventionsCatalog (横断規約カタログ)",
+  "description": "処理フロー仕様書から @conv.msg.* / @conv.regex.* / @conv.limit.* として参照される横断規約の正規 JSON 形式 (#151-A / #261 残)。docs/conventions/validation-rules.md の構造化版。",
+  "type": "object",
+  "required": ["version"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+    "version": { "type": "string", "description": "SemVer (例: 1.0.0)" },
+    "description": { "type": "string" },
+    "updatedAt": { "type": "string", "format": "date-time" },
+
+    "msg": {
+      "type": "object",
+      "description": "エラーメッセージテンプレート。@conv.msg.<key> で参照",
+      "additionalProperties": { "$ref": "#/$defs/MessageTemplate" }
+    },
+    "regex": {
+      "type": "object",
+      "description": "正規表現カタログ。@conv.regex.<key> で参照",
+      "additionalProperties": { "$ref": "#/$defs/RegexEntry" }
+    },
+    "limit": {
+      "type": "object",
+      "description": "境界値カタログ。@conv.limit.<key> で参照",
+      "additionalProperties": { "$ref": "#/$defs/LimitEntry" }
+    }
+  },
+
+  "$defs": {
+    "MessageTemplate": {
+      "type": "object",
+      "required": ["template"],
+      "additionalProperties": false,
+      "properties": {
+        "template": {
+          "type": "string",
+          "description": "{placeholder} 記法で params を展開 (例: \"{label}は必須入力です\")"
+        },
+        "params": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "template 内に現れる placeholder 名"
+        },
+        "description": { "type": "string" }
+      }
+    },
+    "RegexEntry": {
+      "type": "object",
+      "required": ["pattern"],
+      "additionalProperties": false,
+      "properties": {
+        "pattern": {
+          "type": "string",
+          "description": "ECMAScript 互換の正規表現本体 (スラッシュ囲み無し、フラグは実装側で指定)"
+        },
+        "flags": {
+          "type": "string",
+          "description": "正規表現フラグ (例: \"i\" / \"gm\")。未指定は空"
+        },
+        "description": { "type": "string" },
+        "exampleValid": { "type": "array", "items": { "type": "string" } },
+        "exampleInvalid": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "LimitEntry": {
+      "type": "object",
+      "required": ["value"],
+      "additionalProperties": false,
+      "properties": {
+        "value": { "type": ["number", "integer"] },
+        "unit": {
+          "type": "string",
+          "description": "char / integer / yen / ms 等の単位",
+          "examples": ["char", "integer", "yen", "ms"]
+        },
+        "description": { "type": "string" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 関連

- 部分対応: #151-A (設計書種別 — バリデーション規約 / ルール / 定義の正式機能化)
- 部分対応: #261 残 (規約 ID 解決)

## 概要

docs/conventions/validation-rules.md の placeholder を JSON 機械可読版に昇格。処理フロー仕様から \`@conv.msg.*\` / \`@conv.regex.*\` / \`@conv.limit.*\` で参照される ID を型付きカタログで管理し、参照整合性も検証。

## 主な変更

- **schemas/conventions.schema.json**: ConventionsCatalog JSON Schema (draft 2020-12)
  - \`msg\`: MessageTemplate { template, params?, description? }
  - \`regex\`: RegexEntry { pattern, flags?, description?, exampleValid/Invalid }
  - \`limit\`: LimitEntry { value, unit?, description? }
- **docs/sample-project/conventions/conventions-catalog.json**: 実装カタログ (validation-rules.md 同期)
- **designer/src/schemas/conventionsValidator.ts**: \`checkConventionReferences(group, catalog)\`
  - 正規表現で \`@conv.<cat>.<key>\` を抽出、カタログキーと突合
  - 4 issue code (UNKNOWN_CONV_MSG/REGEX/LIMIT/CATEGORY)
  - walk 対象: step.description / runIf / expression / bodyExpression / rules / sql / httpCall.body
- **テスト 13 件**: カタログ自身のスキーマ検証 + accept/reject 7 + サンプル横断 5

## 設計判断

- **カタログを JSON に分離**: md は human-readable、JSON は machine-readable の両立
- **3 カテゴリ固定**: msg/regex/limit のみ。将来必要になったら \`additionalProperties\` で拡張
- **null catalog でスキップ**: カタログをロードできない環境 (gitignore 等) で後方互換

## 動作確認

- [x] typecheck pass
- [x] vitest: 449 → 462 (+13、3 skip 含む、回帰なし)

## 残 (#261)

- secrets 管理の正式機能化 (現 tokenRef は \`ENV:\` / \`SECRET:\` の規約)

🤖 Generated with [Claude Code](https://claude.com/claude-code)