### PR TITLE
feat(schemas): secretsCatalog + @secret.* 参照 (#261 残最終)

### DIFF
--- a/designer/src/schemas/process-flow.schema.test.ts
+++ b/designer/src/schemas/process-flow.schema.test.ts
@@ -117,6 +117,49 @@ describe("process-flow.schema.json — v1.1 拡張 (#253)", () => {
   });
 });
 
+describe("process-flow.schema.json — secretsCatalog (#261 v1.6)", () => {
+  const base = {
+    id: "a", name: "x", type: "screen", description: "",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  };
+
+  it("secretsCatalog 全 source (env/vault/file) accept", () => {
+    const ok = validate({
+      ...base,
+      secretsCatalog: {
+        stripeKey: { source: "env", name: "STRIPE_SECRET_KEY", rotationDays: 90 },
+        dbPass: { source: "vault", name: "secret/db/main", description: "main DB" },
+        devSsh: { source: "file", name: "/etc/secrets/dev.pem" },
+      },
+      actions: [],
+    });
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("source が enum 外なら reject", () => {
+    expect(validate({
+      ...base,
+      secretsCatalog: { x: { source: "aws", name: "foo" } },
+      actions: [],
+    })).toBe(false);
+  });
+
+  it("source / name 欠落は reject", () => {
+    expect(validate({
+      ...base,
+      secretsCatalog: { x: { source: "env" } },
+      actions: [],
+    })).toBe(false);
+    expect(validate({
+      ...base,
+      secretsCatalog: { x: { name: "foo" } },
+      actions: [],
+    })).toBe(false);
+  });
+});
+
 describe("process-flow.schema.json — ambientVariables + fieldErrorsVar (#261 v1.4)", () => {
   const base = {
     id: "a", name: "x", type: "screen", description: "",

--- a/designer/src/schemas/referentialIntegrity.test.ts
+++ b/designer/src/schemas/referentialIntegrity.test.ts
@@ -159,6 +159,66 @@ describe("checkReferentialIntegrity — ネスト走査", () => {
   });
 });
 
+describe("checkReferentialIntegrity — @secret.* (#261 v1.6)", () => {
+  it("secretsCatalog 定義時、未登録 @secret を検出", () => {
+    const issues = checkReferentialIntegrity(makeGroup({
+      secretsCatalog: { stripeKey: { source: "env", name: "STRIPE_SECRET_KEY" } },
+      externalSystemCatalog: {
+        stripe: { name: "Stripe", auth: { kind: "bearer", tokenRef: "@secret.unknown" } },
+      },
+      actions: [],
+    }));
+    expect(issues.some((i) => i.code === "UNKNOWN_SECRET_REF")).toBe(true);
+  });
+
+  it("catalog にある @secret は OK", () => {
+    const issues = checkReferentialIntegrity(makeGroup({
+      secretsCatalog: { stripeKey: { source: "env", name: "STRIPE_SECRET_KEY" } },
+      externalSystemCatalog: {
+        stripe: { name: "Stripe", auth: { kind: "bearer", tokenRef: "@secret.stripeKey" } },
+      },
+      actions: [],
+    }));
+    expect(issues).toHaveLength(0);
+  });
+
+  it("step 側 auth.tokenRef の @secret も検査", () => {
+    const issues = checkReferentialIntegrity(makeGroup({
+      secretsCatalog: { stripeKey: { source: "env", name: "STRIPE_SECRET_KEY" } },
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "s1", type: "externalSystem", description: "",
+          systemName: "Stripe",
+          auth: { kind: "bearer", tokenRef: "@secret.unknownKey" },
+        }],
+      }],
+    }));
+    expect(issues.some((i) => i.code === "UNKNOWN_SECRET_REF")).toBe(true);
+  });
+
+  it("secretsCatalog 未定義時は @secret 検査をスキップ (後方互換)", () => {
+    const issues = checkReferentialIntegrity(makeGroup({
+      externalSystemCatalog: {
+        stripe: { name: "Stripe", auth: { kind: "bearer", tokenRef: "@secret.anything" } },
+      },
+      actions: [],
+    }));
+    expect(issues).toHaveLength(0);
+  });
+
+  it("ENV: / SECRET: 規約文字列は @secret と無関係で後方互換", () => {
+    const issues = checkReferentialIntegrity(makeGroup({
+      secretsCatalog: { k: { source: "env", name: "X" } },
+      externalSystemCatalog: {
+        stripe: { name: "Stripe", auth: { kind: "bearer", tokenRef: "ENV:STRIPE_SECRET_KEY" } },
+      },
+      actions: [],
+    }));
+    expect(issues).toHaveLength(0);
+  });
+});
+
 describe("checkReferentialIntegrity — typeRef (#261)", () => {
   it("typeCatalog 定義時、未登録 typeRef を検出", () => {
     const issues = checkReferentialIntegrity(makeGroup({

--- a/designer/src/schemas/referentialIntegrity.ts
+++ b/designer/src/schemas/referentialIntegrity.ts
@@ -22,12 +22,16 @@ export interface IntegrityIssue {
     | "UNKNOWN_RESPONSE_REF"
     | "UNKNOWN_ERROR_CODE"
     | "UNKNOWN_SYSTEM_REF"
-    | "UNKNOWN_TYPE_REF";
+    | "UNKNOWN_TYPE_REF"
+    | "UNKNOWN_SECRET_REF";
   /** 参照しようとした値 */
   value: string;
   /** エラーメッセージ */
   message: string;
 }
+
+/** @secret.KEY にマッチ */
+const SECRET_RE = /@secret\.([a-zA-Z_][\w-]*)/g;
 
 /** ActionGroup 全体のクロスリファレンス検証。空配列なら OK */
 export function checkReferentialIntegrity(group: ActionGroup): IntegrityIssue[] {
@@ -38,6 +42,28 @@ export function checkReferentialIntegrity(group: ActionGroup): IntegrityIssue[] 
   const hasSystemCatalog = systemIds.size > 0;
   const typeIds = new Set(Object.keys(group.typeCatalog ?? {}));
   const hasTypeCatalog = typeIds.size > 0;
+  const secretKeys = new Set(Object.keys(group.secretsCatalog ?? {}));
+  const hasSecretsCatalog = secretKeys.size > 0;
+
+  // externalSystemCatalog.*.auth.tokenRef 内の @secret.* 参照を検査
+  if (hasSecretsCatalog) {
+    Object.entries(group.externalSystemCatalog ?? {}).forEach(([k, entry]) => {
+      const tok = entry.auth?.tokenRef;
+      if (tok) {
+        let m: RegExpExecArray | null;
+        while ((m = SECRET_RE.exec(tok)) !== null) {
+          if (!secretKeys.has(m[1])) {
+            issues.push({
+              path: `externalSystemCatalog.${k}.auth.tokenRef`,
+              code: "UNKNOWN_SECRET_REF",
+              value: `@secret.${m[1]}`,
+              message: `@secret.${m[1]} が ActionGroup.secretsCatalog に存在しません`,
+            });
+          }
+        }
+      }
+    });
+  }
 
   group.actions.forEach((action, ai) => {
     const responseIds = new Set(
@@ -57,7 +83,7 @@ export function checkReferentialIntegrity(group: ActionGroup): IntegrityIssue[] 
       }
     });
     walkSteps(action.steps ?? [], `actions[${ai}].steps`, (step, path) => {
-      checkStep(step, path, responseIds, errorCodes, hasErrorCatalog, systemIds, hasSystemCatalog, issues);
+      checkStep(step, path, responseIds, errorCodes, hasErrorCatalog, systemIds, hasSystemCatalog, issues, secretKeys, hasSecretsCatalog);
     });
 
     // errorCatalog → responses 参照
@@ -118,6 +144,8 @@ function checkStep(
   systemIds: Set<string>,
   hasSystemCatalog: boolean,
   issues: IntegrityIssue[],
+  secretKeys?: Set<string>,
+  hasSecretsCatalog?: boolean,
 ): void {
   if (step.type === "externalSystem" && step.systemRef && hasSystemCatalog && !systemIds.has(step.systemRef)) {
     issues.push({
@@ -126,6 +154,22 @@ function checkStep(
       value: step.systemRef,
       message: `ExternalSystemStep.systemRef "${step.systemRef}" が ActionGroup.externalSystemCatalog に存在しません`,
     });
+  }
+  // step 側 auth.tokenRef の @secret.* 参照を検査
+  if (step.type === "externalSystem" && step.auth?.tokenRef && hasSecretsCatalog && secretKeys) {
+    const tok = step.auth.tokenRef;
+    const re = /@secret\.([a-zA-Z_][\w-]*)/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(tok)) !== null) {
+      if (!secretKeys.has(m[1])) {
+        issues.push({
+          path: `${path}.auth.tokenRef`,
+          code: "UNKNOWN_SECRET_REF",
+          value: `@secret.${m[1]}`,
+          message: `@secret.${m[1]} が ActionGroup.secretsCatalog に存在しません`,
+        });
+      }
+    }
   }
   if (step.type === "return" && step.responseRef && !responseIds.has(step.responseRef)) {
     issues.push({

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -828,6 +828,33 @@ export interface ActionDefinition {
  * 複数箇所に散在する問題を解決するため、ActionGroup 単位で 1 箇所に集約する。
  */
 /**
+ * Secrets カタログの 1 エントリ (#261 v1.6)。
+ * 秘匿値そのものは JSON に含めない。取得方法のメタデータのみ。
+ */
+export interface SecretRef {
+  /**
+   * 秘匿値の取得元。
+   * - "env": プロセス環境変数 (`process.env[name]`)
+   * - "vault": 外部 secret store (HashiCorp Vault / AWS Secrets Manager / GCP Secret Manager 等)
+   * - "file": ローカルファイルパス (開発時のみ)
+   */
+  source: "env" | "vault" | "file";
+  /**
+   * source 毎の具体的な名前/パス:
+   * - env: 環境変数名 (例: "STRIPE_SECRET_KEY")
+   * - vault: vault 内パス (例: "secret/stripe/api-key")
+   * - file: ファイルパス (例: "/etc/secrets/stripe.pem")
+   */
+  name: string;
+  /** 人間向け説明 */
+  description?: string;
+  /** ローテーション周期 (日)。未指定は運用規約依存 */
+  rotationDays?: number;
+  /** 最終ローテーション時刻 (ISO timestamp) */
+  lastRotatedAt?: string;
+}
+
+/**
  * 型カタログの 1 エントリ (#261 v1.3)。
  * schema プロパティに JSON Schema (draft 2020-12) を持つ。
  * 型名単独での参照 (BodySchemaRef.typeRef) から解決される。
@@ -883,6 +910,12 @@ export interface ActionGroup {
    * アクション側で明示宣言する。実装側は各フレームワーク (Express/Fastify/Nest) の仕組みで値を供給する責務。
    */
   ambientVariables?: StructuredField[];
+  /**
+   * Secrets カタログ (#261 v1.6)。API キー・DB パスワード・署名鍵等の秘匿値の**メタデータ**。
+   * 値そのものは JSON に保存せず、`source` で実際の取得先を指す (ENV / vault / file 等)。
+   * ExternalAuth.tokenRef から `@secret.<key>` 記法で参照される。
+   */
+  secretsCatalog?: Record<string, SecretRef>;
   createdAt: string;
   updatedAt: string;
 }

--- a/docs/sample-project/actions/cccccccc-0005-4000-8000-cccccccccccc.json
+++ b/docs/sample-project/actions/cccccccc-0005-4000-8000-cccccccccccc.json
@@ -73,11 +73,26 @@
     }
   },
 
+  "secretsCatalog": {
+    "stripeApiKey": {
+      "source": "env",
+      "name": "STRIPE_SECRET_KEY",
+      "description": "Stripe Payment Intents API 認証用 secret key",
+      "rotationDays": 90
+    },
+    "sendgridApiKey": {
+      "source": "env",
+      "name": "SENDGRID_API_KEY",
+      "description": "SendGrid Mail API 送信用 API key",
+      "rotationDays": 180
+    }
+  },
+
   "externalSystemCatalog": {
     "stripe": {
       "name": "Stripe Japan",
       "baseUrl": "https://api.stripe.com",
-      "auth": { "kind": "bearer", "tokenRef": "ENV:STRIPE_SECRET_KEY" },
+      "auth": { "kind": "bearer", "tokenRef": "@secret.stripeApiKey" },
       "timeoutMs": 10000,
       "retryPolicy": { "maxAttempts": 3, "backoff": "exponential", "initialDelayMs": 500 },
       "headers": {
@@ -89,7 +104,7 @@
     "sendgrid": {
       "name": "SendGrid",
       "baseUrl": "https://api.sendgrid.com",
-      "auth": { "kind": "bearer", "tokenRef": "ENV:SENDGRID_API_KEY" },
+      "auth": { "kind": "bearer", "tokenRef": "@secret.sendgridApiKey" },
       "timeoutMs": 10000,
       "description": "SendGrid Mail API v3"
     }

--- a/docs/spec/process-flow-runtime-conventions.md
+++ b/docs/spec/process-flow-runtime-conventions.md
@@ -202,6 +202,32 @@ step-or2-011 (capture) が失敗
 
 プロジェクト全体で採用している認証方式 (Bearer JWT / Session / OAuth2 等) は `docs/conventions/product-scope.md` に宣言。処理フロー個別のスキーマではなく**プロダクト横断規約**として管理。
 
+### 8.5 secretsCatalog と tokenRef の連携 (#261 v1.6)
+
+ExternalAuth.tokenRef は以下 3 形式を受け付ける:
+
+1. **`@secret.<key>`** (推奨): ActionGroup.secretsCatalog 参照。参照整合性バリデータが未登録エラーを検出
+2. **`ENV:<envName>`** (後方互換): 環境変数名直書き
+3. **`SECRET:<path>`** (後方互換): 外部 secret store パス直書き
+
+新規データは \`@secret.*\` を使い、catalog 側で source (env/vault/file) と name を管理する。catalog は値そのものを持たず、**メタデータのみ**。
+
+```json
+"secretsCatalog": {
+  "stripeApiKey": {
+    "source": "env",
+    "name": "STRIPE_SECRET_KEY",
+    "description": "Stripe API 認証",
+    "rotationDays": 90
+  }
+}
+```
+
+実装時は source 毎に:
+- `env` → `process.env[secretRef.name]`
+- `vault` → HashiCorp Vault / AWS Secrets Manager / GCP Secret Manager の API
+- `file` → ファイルから読込 (開発時のみ)
+
 ### 8.4 inbound auth 具体スキーム決定フロー
 
 実装者が `httpRoute.auth: "required"` を見たとき、以下の順で具体スキームを決定する:

--- a/schemas/process-flow.schema.json
+++ b/schemas/process-flow.schema.json
@@ -34,6 +34,11 @@
       "type": "array",
       "items": { "$ref": "#/$defs/StructuredField" }
     },
+    "secretsCatalog": {
+      "description": "Secrets カタログ (#261 v1.6)。秘匿値のメタデータ (取得元・ローテーション)。値そのものは含まない",
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/SecretRef" }
+    },
     "actions": {
       "type": "array",
       "items": { "$ref": "#/$defs/ActionDefinition" }
@@ -80,6 +85,20 @@
         "auth": { "$ref": "#/$defs/HttpAuthRequirement" }
       }
     },
+    "SecretRef": {
+      "description": "Secrets カタログの 1 エントリ (#261 v1.6)。値は含まない",
+      "type": "object",
+      "required": ["source", "name"],
+      "additionalProperties": false,
+      "properties": {
+        "source": { "type": "string", "enum": ["env", "vault", "file"] },
+        "name": { "type": "string" },
+        "description": { "type": "string" },
+        "rotationDays": { "type": "integer", "minimum": 1 },
+        "lastRotatedAt": { "type": "string", "format": "date-time" }
+      }
+    },
+
     "TypeCatalogEntry": {
       "description": "型カタログの 1 エントリ (#261 v1.3)。schema は JSON Schema draft 2020-12",
       "type": "object",


### PR DESCRIPTION
## 関連

- 最終対応: #261 残タスク (secrets 管理の正式機能化)

## 概要

ExternalAuth.tokenRef の "ENV:STRIPE_SECRET_KEY" 規約文字列を ActionGroup.secretsCatalog + @secret.<key> 参照に昇格。秘匿値そのものは JSON に含めず、**メタデータのみ** (source/name/rotation) 管理。

## 主な変更

- **SecretRef 新設**: { source: "env"|"vault"|"file", name, description?, rotationDays?, lastRotatedAt? }
- **ActionGroup.secretsCatalog**: Record<string, SecretRef>
- **参照整合性**: externalSystemCatalog.*.auth.tokenRef と step 側 auth.tokenRef の @secret.* を検査 (UNKNOWN_SECRET_REF、catalog 未定義時は skip)
- **サンプル 0005**: secretsCatalog (stripeApiKey/sendgridApiKey) 追加、tokenRef を @secret.* に移行
- **仕様書 §8.5**: 3 形式 (@secret / ENV: / SECRET:) と source 別実装ガイド追加

## 設計判断

- **値そのものは JSON に含めない**: セキュリティ上当然だが明文化
- **3 source (env/vault/file)**: 現実的な最小セット、vault は HashiCorp / AWS / GCP のどれでも。将来拡張余地
- **後方互換**: "ENV:X" / "SECRET:X" は @secret なしでそのまま通る
- **rotation メタデータのみ**: 実際のローテーションは運用側、schema は notification 用 (rotationDays 経過チェック等の lint hook として将来拡張可)

## 動作確認

- [x] typecheck pass
- [x] vitest: 462 → 470 (+8, 回帰なし)

## #261 最終ステータス

本 PR で **#261 残タスク全 4 件完了**:
- [x] tableId → SQL 列検査 (PR #272)
- [x] @ 参照の型推論 (PR #270 参照 scope 検証)
- [x] 規約 ID 解決 (@conv.*) — #151-A (PR #273)
- [x] secrets 管理の正式機能化 (本 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)