### PR TITLE
fix(samples): 旧サンプル 0001/0003/0004 の SQL × テーブル drift 解消 (Closes #271)

### DIFF
--- a/designer/src/schemas/sqlColumnValidator.test.ts
+++ b/designer/src/schemas/sqlColumnValidator.test.ts
@@ -92,11 +92,7 @@ describe("checkSqlColumns — サンプル (docs/sample-project) 横断", () => 
 
   // 旧サンプルのアクション/テーブル間 drift は別 issue で追跡 (本 PR のスコープ外)。
   // 0001/0003/0004 は既存データのため skip、0002/0005 のみ厳密検査。
-  const LEGACY_DRIFT_FILES = new Set<string>([
-    "cccccccc-0001-4000-8000-cccccccccccc.json",
-    "cccccccc-0003-4000-8000-cccccccccccc.json",
-    "cccccccc-0004-4000-8000-cccccccccccc.json",
-  ]);
+  const LEGACY_DRIFT_FILES = new Set<string>([]);
 
   it("テーブル定義ロード (防御)", () => {
     expect(tables.length).toBeGreaterThan(0);

--- a/docs/sample-project/actions/cccccccc-0001-4000-8000-cccccccccccc.json
+++ b/docs/sample-project/actions/cccccccc-0001-4000-8000-cccccccccccc.json
@@ -67,7 +67,7 @@
           "tableName": "users",
           "tableId": "bbbbbbbb-0001-4000-8000-bbbbbbbbbbbb",
           "operation": "SELECT",
-          "sql": "SELECT id, username, role FROM users WHERE id = @authResult.userId AND is_deleted = false LIMIT 1",
+          "sql": "SELECT id, login_id, display_name, role FROM users WHERE id = @authResult.userId AND is_active = true LIMIT 1",
           "outputBinding": "user"
         },
         {

--- a/docs/sample-project/actions/cccccccc-0003-4000-8000-cccccccccccc.json
+++ b/docs/sample-project/actions/cccccccc-0003-4000-8000-cccccccccccc.json
@@ -18,7 +18,7 @@
       "outputs": [
         { "name": "success", "label": "認証成功判定", "type": "boolean" },
         { "name": "sessionId", "label": "セッションID", "type": "string" },
-        { "name": "permissions", "label": "権限一覧", "type": { "kind": "custom", "label": "string[]" } }
+        { "name": "role", "label": "権限", "type": "string" }
       ],
       "steps": [
         {
@@ -44,7 +44,7 @@
           "tableName": "users",
           "tableId": "bbbbbbbb-0001-4000-8000-bbbbbbbbbbbb",
           "operation": "SELECT",
-          "sql": "SELECT id, password_hash, permissions FROM users WHERE login_id = @userId AND is_deleted = false LIMIT 1",
+          "sql": "SELECT id, password_hash, role FROM users WHERE login_id = @userId AND is_active = true LIMIT 1",
           "outputBinding": "userRow",
           "notes": [
             { "id": "n-auth-001", "type": "assumption", "body": "password_hash は bcrypt (cost 12) 想定 (product-scope §6)", "createdAt": "2026-04-14T00:00:00.000Z" }

--- a/docs/sample-project/tables/bbbbbbbb-0003-4000-8000-bbbbbbbbbbbb.json
+++ b/docs/sample-project/tables/bbbbbbbb-0003-4000-8000-bbbbbbbbbbbb.json
@@ -15,6 +15,7 @@
     { "id": "col-o08", "name": "total_amount", "logicalName": "合計金額", "dataType": "DECIMAL", "length": 12, "scale": 2, "notNull": true, "primaryKey": false, "unique": false, "defaultValue": "0" },
     { "id": "col-o09", "name": "payment_method", "logicalName": "支払方法", "dataType": "VARCHAR", "length": 30, "notNull": false, "primaryKey": false, "unique": false, "comment": "bank_transfer / credit_card / cash_on_delivery" },
     { "id": "col-o09b", "name": "payment_id", "logicalName": "決済ID", "dataType": "VARCHAR", "length": 100, "notNull": false, "primaryKey": false, "unique": false, "comment": "Stripe PaymentIntent ID 等" },
+    { "id": "col-o09c", "name": "monthly_aggregated", "logicalName": "月次集計済", "dataType": "BOOLEAN", "notNull": true, "primaryKey": false, "unique": false, "defaultValue": "false", "comment": "月次バッチで集計処理完了を記録" },
     { "id": "col-o10", "name": "shipping_address", "logicalName": "配送先住所", "dataType": "VARCHAR", "length": 500, "notNull": false, "primaryKey": false, "unique": false },
     { "id": "col-o11", "name": "notes", "logicalName": "備考", "dataType": "TEXT", "notNull": false, "primaryKey": false, "unique": false },
     { "id": "col-o12", "name": "created_by", "logicalName": "登録者ID", "dataType": "INTEGER", "notNull": false, "primaryKey": false, "unique": false, "foreignKey": { "tableId": "users", "columnName": "id" } },


### PR DESCRIPTION
## 関連

- Closes #271

## 概要

PR #272 の SQL 列検査で検出された旧サンプルの drift を修正し、\`LEGACY_DRIFT_FILES\` の skip を解除。

## 修正方針

| サンプル | drift | 修正 |
|--------|------|------|
| 0001 (ログイン) | SQL が \`username\` / \`is_deleted\` を参照 | users テーブルに存在する \`login_id\` / \`display_name\` / \`is_active\` に書き換え |
| 0003 (認証チェック) | SQL が \`permissions\` を参照、outputs も同名 | \`role\` に統一 (users テーブルの既存列) |
| 0004 (月次バッチ) | \`monthly_aggregated\` を参照 | orders テーブルに当該列を追加 (batch 完了記録として正当) |

2/3 はサンプル側の誤記を修正、1/3 はテーブル定義側に不足列を追加。

## 動作確認

- [x] vitest: 478 pass (+3、skip 解除した分が新規 pass)
- [x] サンプル 5 件 (0001-0005) 全てが SQL 列検査 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)