### PR TITLE
feat(slash): /designer-work スラッシュコマンド + ドッグフード反映 (#261 PR 3)

### DIFF
--- a/.claude/commands/designer-work.md
+++ b/.claude/commands/designer-work.md
@@ -1,0 +1,107 @@
+---
+description: designer 画面で付けられたマーカー (指示・質問・TODO・チャット) を読み取り、ActionGroup を編集して解決する
+argument-hint: <actionGroupId> [--dry-run]
+---
+
+<!--
+  使い方:
+    - designer を開き、対象 ActionGroup でマーカーを複数付ける
+      (MarkerPanel で「AI へのマーカー」に追加、または step カードの付箋)
+    - Claude Code で `/designer-work <actionGroupId>` を実行
+    - Claude Code は MCP 経由で markers を読み、順に対応し、
+      ActionGroup を編集 (step/catalog) し、marker を resolve する
+    - 人間は browser でリアルタイム更新を観察、追加の markers で指示を出す
+
+  目的:
+    - 上流 → 下流 の詳細化を「人間は概要を書き、AI が詳細を埋める」で回す
+    - 人間は画面を見て指示、AI は構造化された markers で受け取り構造化された編集で返す
+    - API 課金なし (Claude Code Max プラン内で完結)
+
+  前提:
+    - designer-mcp サーバが起動していること (stdio で Claude Code に接続済み)
+    - 対象 ActionGroup の ID を把握していること (URL の /process-flow/edit/{id})
+-->
+
+ActionGroup `$ARGUMENTS` の未解決マーカーを処理します。
+
+## 実行手順
+
+### 1. 受信と確認
+
+- `designer__list_markers` を呼び、未解決マーカー一覧を取得する (unresolvedOnly: true、既定)
+- `designer__get_action_group` で現在の ActionGroup 全体を取得し、コンテキストを把握する
+- 必要に応じて関連テーブル定義 (`designer__get_table`) や規約カタログ
+  (`docs/sample-project/conventions/conventions-catalog.json`) を参照する
+- マーカー件数と種別 (chat/attention/todo/question) の要約を**まず人間に報告**する
+
+### 2. 1 件ずつ対応
+
+**各 marker 処理の直前に `designer__list_markers` を呼び直す** (人間が並行して追加していないか + 他 marker 処理で依存カタログが既に追加されていないか確認)。
+
+#### kind 別ハンドリング (重要)
+
+| kind | 想定意図 | 既定の対応 |
+|------|---------|-----------|
+| `todo` | 作業指示 (命令形) | 構造的に解決して resolve |
+| `question` | 回答を求める | 分析結果を `add_marker(kind="chat", author="ai")` で返信 + 元を resolve (resolution に回答) |
+| `attention` | 注意喚起・レビュー依頼 | **編集しない**が既定。resolution に分析・推奨を書いて resolve (committed 編集の命令と解釈しない) |
+| `chat` | 雑談・確認 | `add_marker(kind="chat", author="ai")` で返信 + 元を resolve |
+
+#### 編集許可の境界 (committed 保護)
+
+ActionGroup / action / step の `maturity` が `committed` の場合、**編集は以下の全てを満たす場合のみ**:
+- kind = `todo` (質問や注意喚起では編集しない)
+- body が命令形 (「追加して / 修正して / 削除して / 置換して」など)
+- 編集範囲が body で明示されている (対象 step/field が特定できる)
+
+上記を満たさない committed への編集提案は `resolution` に「提案: X を推奨、承認待ち」と書いて resolve のみ、実編集はしない。
+
+#### 参照整合性の事前チェック
+
+catalog エントリ追加や step 編集で以下を参照する場合、対象が存在するか先に確認する:
+- `responseRef` → action.responses[].id
+- `tableId` → designer__list_tables / get_table
+- `typeRef` → ActionGroup.typeCatalog キー
+- `systemRef` → ActionGroup.externalSystemCatalog キー
+- `@secret.*` → ActionGroup.secretsCatalog キー
+- `@conv.*` → `docs/sample-project/conventions/conventions-catalog.json` キー
+
+**参照先が未定義なら、値から当該フィールドを省き、不足分を `add_marker(kind="attention")` で別起票**してから元を resolve する。ダングリング参照を新規作成しない。
+
+#### 全置換系の扱い
+
+`designer__update_action_group` (definition 全置換) は**破壊的**。
+- `--dry-run` 無しでは**人間承認を待つ**。
+- 代わりに粒度 tool (`update_step` / `add_catalog_entry` 等) で済む経路を優先。
+- どうしても全置換が必要なら: 変更 diff を marker の resolution 欄に先に書いて resolve せず保留、人間に判断を仰ぐ。
+
+#### 処理手順まとめ
+
+各 marker について:
+
+1. **解析**: kind / body / stepId / fieldPath を把握。関連 step / catalog を get_action_group から参照。
+2. **kind + maturity で分岐**: 上記「kind 別ハンドリング」「committed 保護」に従って編集 or 保留を決定。
+3. **参照整合性チェック**: 必要なら参照先を確認、未定義なら別 attention を起票。
+4. **実行**: 粒度 MCP tool で編集 (broadcast → 画面自動更新)。
+5. **resolve**: `designer__resolve_marker` で resolution を付けてクローズ。question/chat なら返信 chat marker を並行して追加。
+6. **次へ**: `designer__list_markers` を再取得して次の marker へ。
+
+### 3. 応答サマリ
+
+全マーカー処理後、以下を人間向けに報告:
+- 処理件数 (解決 / 質問返し / 提案保留 の内訳)
+- 主な変更箇所 (step 編集、catalog 追加、maturity 昇格 等)
+- 未解決のまま残した marker とその理由
+
+## スコープとガードレール
+
+- **ActionGroup 以外は触らない**: screen / table 定義は読み取り専用扱い。修正が必要なら marker に "前提: テーブル定義の変更必要" と書いて保留
+- **下流モード × committed 成熟度のステップは保守的に**: 既に確定済みの内容を勝手に書き換えない。marker.body が明示的に許可している場合のみ編集
+- **@conv.* / @secret.* / @identifier の未定義参照は作らない**: 編集前に参照整合性を確認し、必要なら先にカタログへ追加してから step 参照
+- **`--dry-run` 引数があれば**: 何を変更するか提案のみで、実際の `update_step` 等は呼ばない
+
+## 想定外のケース
+
+- **MCP サーバ未接続** (designer-mcp が起動していない): 人間に designer-mcp 起動を促す
+- **actionGroupId が見つからない**: list_action_groups で候補を提示
+- **marker 0 件**: "現在未解決のマーカーはありません" と報告して終了

--- a/designer/src/components/action/MarkerPanel.tsx
+++ b/designer/src/components/action/MarkerPanel.tsx
@@ -85,6 +85,9 @@ export function MarkerPanel({ group, onChange }: Props) {
           <div className="catalog-help">
             AI (Claude Code) への指示・質問を保持。
             <code>/designer-work</code> で未解決マーカーをまとめて処理させる。
+            <br />
+            <strong>committed な内容を編集させたい場合は kind=TODO + 命令形</strong>で
+            (「〜を追加して」「〜を削除して」)。質問や注目は AI が保守的に保留します。
           </div>
           <div className="d-flex align-items-center gap-2 mb-2">
             <label className="small d-flex align-items-center gap-1">


### PR DESCRIPTION
## 関連

- 完結: #261 リアルタイム編集ワークフロー 3 段階目 (MCP tool → Marker UI/MCP → スラッシュコマンド)

## 概要

PR #281 (MCP 粒度 tool) + PR #282 (Marker UI/data/MCP) を束ねて人間と AI の対話ワークフローを成立させるスラッシュコマンド \`/designer-work <actionGroupId>\` を追加。

## ワークフロー

1. 人間が designer で ActionGroup を開き、MarkerPanel でマーカー追加 (kind: todo/question/attention/chat、本文)
2. Claude Code で \`/designer-work <id>\` 実行
3. Claude Code が MCP 経由で list_markers → 各 marker を kind に応じて処理 → update_step / add_catalog_entry 等で編集 → resolve_marker
4. wsBridge broadcast で browser 自動再描画、人間は結果を観察

## ドッグフード反映

sub-agent による机上シミュレーション (4 marker シナリオ) で以下の欠陥が判明、本 PR で反映:

- kind 別ハンドリング表を追加 (todo=解決 / question=chat 返信 / attention=保留既定 / chat=返信)
- committed 編集許可 = kind=todo + 命令形 + 範囲明示の AND (attention では編集しない)
- 参照整合性 (responseRef / tableId / typeRef / systemRef / @secret.* / @conv.*) を事前チェック、未定義なら別 attention 起票
- update_action_group (全置換) の安全ガード
- 各 marker 処理前に list_markers 再取得

MarkerPanel の catalog-help にも「committed 編集引き出すには kind=TODO + 命令形」を明示。

🤖 Generated with [Claude Code](https://claude.com/claude-code)