### PR TITLE
docs(user-guide): ユーザー向けワークフローガイド新設

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,8 @@ URL 規約: **`/category/feature[/:id]`** 形式（Java 風階層）。ルート
 
 検証テスト: `cd designer && npx vitest run src/schemas/process-flow.schema.test.ts` — `docs/sample-project/actions/*.json` の全件をスキーマで検証する。
 
+**ユーザー向けワークフロー**: [`docs/user-guide/`](docs/user-guide/README.md) — 業務設計者が処理フローを書いて AI と往復する使い方。
+
 ## UI Conventions
 
 詳細仕様は [docs/spec/](docs/spec/README.md) に集約。一覧系 UI を触る前に必ず読む:

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -1,0 +1,27 @@
+# ユーザーガイド
+
+`CLAUDE.md` / `docs/spec/` は AI / 開発者向けのリファレンスです。本ディレクトリは **このツールを使う人 (プロダクトマネージャー / 業務設計者 / AI エージェントを運用する開発リーダー)** 向けの手引きです。
+
+## 目的別ガイド
+
+- [処理フロー編集ワークフロー](process-flow-workflow.md) — 上流 (概要) → 下流 (実装) までの詳細化をリモート AI と往復しながら進める方法
+- [AI マーカーと `/designer-work`](marker-workflow.md) — 画面に指示を書いて Claude Code に処理させる使い方
+- [トラブルシューティング](troubleshooting.md) — よくある詰まりと回避策
+
+## 前提ツール
+
+- **designer (フロントエンド)** — `http://localhost:5173` で起動する React アプリ
+- **designer-mcp (バックエンド + MCP)** — `npm run dev` で stdio + WebSocket (5179) を起動
+- **Claude Code** — Anthropic の AI エージェント CLI。本プロジェクトを開くと designer-mcp が自動 spawn される (`.mcp.json` で設定済み)
+
+起動:
+
+```bash
+cd designer && npm run dev       # ブラウザ向けフロント
+cd designer-mcp && npm run dev   # バックエンド (単独起動の場合)
+# Claude Code は claude コマンドで起動 (designer-mcp は .mcp.json から自動起動)
+```
+
+## スクリーンショット索引
+
+代表的な画面は [`docs/ui-screenshots/`](../ui-screenshots/README.md) 参照。

--- a/docs/user-guide/marker-workflow.md
+++ b/docs/user-guide/marker-workflow.md
@@ -1,0 +1,116 @@
+# AI マーカーと `/designer-work`
+
+designer 画面に残した指示・質問・TODO・チャットを Claude Code が読み取り、処理フローを自動編集する仕組みです。
+
+## 4 種類のマーカー (kind)
+
+| kind | 色 | 用途 | AI の対応 |
+|------|---|------|---------|
+| `todo` | 緑 | 作業指示 (命令形) | 構造的に編集して resolve |
+| `question` | 紫 | 質問 (疑問形) | chat 返信 marker を追加して resolve |
+| `attention` | オレンジ | 注意喚起・レビュー依頼 | **編集せず** 提案を resolution に書いて resolve |
+| `chat` | 青 | 雑談・確認 | chat 返信 marker を追加して resolve |
+
+## マーカー追加の 4 経路
+
+### (A) MarkerPanel で直接追加
+
+ActionEditor を開くと上部に「AI へのマーカー」パネル。kind を選んで body を入力。
+
+### (B) 警告から 1-click 起票
+
+画面右上「N 警告」バッジをクリック → 詳細パネルの各行「AI に依頼」ボタン。validator コード (UNKNOWN_RESPONSE_REF 等) + path 付きで kind=todo が自動起票される。
+
+### (C) step card の 3-dots メニュー
+
+対象 step の右上「...」→「AI に指摘」→ prompt で body 入力。stepId が自動で紐付く。
+
+### (D) 外部ツール / API
+
+MCP tool `designer__add_marker` を Claude Code や外部スクリプトから呼ぶ。`author: "ai"` で AI 側からの返信にも使う。
+
+## スクショ例
+
+- [22-warning-to-marker.png](../ui-screenshots/22-warning-to-marker.png) — 警告からの 1-click 起票
+- [24-step-marker-badge.png](../ui-screenshots/24-step-marker-badge.png) — step card 上のバッジ
+
+## `/designer-work` の実行
+
+### 基本
+
+新しい Claude Code 窓 (本プロジェクト内で `claude` 起動) で:
+
+```
+/designer-work <actionGroupId>
+```
+
+例: `/designer-work cccccccc-0005-4000-8000-cccccccccccc`
+
+### 動作
+
+Claude Code は内部で以下を順次実行:
+
+1. `designer__list_markers(actionGroupId, unresolvedOnly=true)` で未解決 marker を取得
+2. 各 marker を kind 別に処理:
+   - `todo` + 命令形 + 範囲明示 → MCP tool で編集 + `designer__resolve_marker`
+   - `question` / `chat` → `designer__add_marker(kind="chat", author="ai", body=回答)` + 元を resolve
+   - `attention` → 編集せず resolution に提案を書いて resolve
+3. **参照整合性チェック**: 新しい responseRef / tableId / typeRef / systemRef / @secret / @conv を追加する前に対象が存在するか確認。未定義なら別 attention を起票
+4. **committed 保護**: ActionGroup / action / step が committed の場合、body が命令形 + 範囲明示でない限り編集しない
+
+### リアルタイム観察
+
+開いているブラウザは wsBridge broadcast で自動更新される。人間は画面を見ながら結果を確認し、追加 marker を書いて次の往復へ。
+
+### サンプル実行結果
+
+[20-dogfood-before.png](../ui-screenshots/20-dogfood-before.png) / [21-dogfood-after.png](../ui-screenshots/21-dogfood-after.png) — 4 marker 投入 → /designer-work (シミュレータ) → AI 返信 2 + errorCatalog 追加 + 4 resolve。
+
+## 事前準備 (初回のみ)
+
+### `.mcp.json` を確認
+
+本プロジェクトには `.mcp.json` に `designer-mcp` が登録済み。Claude Code を本ディレクトリで起動すると自動 spawn される。
+
+```json
+{
+  "mcpServers": {
+    "designer-mcp": {
+      "command": "npx",
+      "args": ["tsx", "designer-mcp/src/index.ts"]
+    }
+  }
+}
+```
+
+### ポート 5179 の扱い
+
+designer-mcp は WebSocket を port 5179 で listen する。他の designer-mcp インスタンス (dev server 経由で起動したもの等) が先に掴んでいる場合、新インスタンスが起動時に古い方の終了を待つ。明示的に killしたい場合:
+
+```bash
+netstat -ano | grep :5179  # PID 取得
+taskkill /F /PID <PID>     # Windows
+# kill -9 <PID>            # macOS/Linux
+```
+
+## トラブル例
+
+### 「designer-mcp が起動しない」
+
+- `.mcp.json` が正しく読まれているか (`claude` を本プロジェクト内で起動したか)
+- `designer-mcp` の依存がインストール済みか (`cd designer-mcp && npm install`)
+- ポート 5179 が別プロセスで専有されていないか
+
+### 「marker 起票したのにブラウザに反映されない」
+
+- ブラウザが wsBridge に接続できているか (DevTools Console で `mcpBridge` のログ確認)
+- designer-mcp が古いプロセスのままで、新しい Claude Code 窓の tool 呼出を聞いていない可能性 → designer-mcp 再起動
+
+### 「/designer-work が committed ステップを一切触らない」
+
+仕様通り。committed は AI の独断編集を保護。編集させたい場合:
+- kind を `todo` にする (attention では編集されない)
+- body を命令形に (「〜を追加して」「〜を削除して」)
+- 対象 step / field を明示
+
+詳細は `.claude/commands/designer-work.md` 参照。

--- a/docs/user-guide/process-flow-workflow.md
+++ b/docs/user-guide/process-flow-workflow.md
@@ -1,0 +1,125 @@
+# 処理フロー編集ワークフロー
+
+**目的**: 業務担当者が書く「概要レベルの処理フロー」を、AI エージェント (Claude Code) と往復しながら「AI 実装者が迷わず実装できる詳細レベル」まで引き上げる。
+
+## 位置づけと原則
+
+1. **一次成果物は JSON スキーマに準拠した処理フロー JSON** (`schemas/process-flow.schema.json`)
+2. 上流の概要は人間が書く、詳細化は AI が行う (完全自動ではなく、人間と対話しながら)
+3. API 課金は発生しない (Anthropic Claude Code Max プラン内で完結)
+4. designer 画面は**リッチなコンテキスト保持器** (AI への指示・質問・注目点を保存)
+
+## 全体の流れ
+
+```
+┌─ 上流 (人間主体、maturity=draft) ──────────────────────────────────┐
+│ 1. 新規処理フロー作成 (処理フロー一覧 → 新規作成)                   │
+│ 2. アクション (ボタンクリック等) と ステップ (検証/DB/外部/...) を追加 │
+│ 3. 各ステップは概要だけ書く (description に 1-2 行)                │
+│ 4. 穴は付箋 (StepNote) や AI マーカーで明示                        │
+└────────────────────────────────────────────────────────────────────┘
+                            ↓
+┌─ AI 往復 (人間がマーキング → Claude Code が MCP で編集) ────────────┐
+│ 5. 画面上でマーキング (AI マーカー追加)                             │
+│    - 「ここの SQL 書いて」→ kind=todo + stepId で該当 step に付ける │
+│    - 「これで合ってる?」→ kind=question                             │
+│    - 「ここ注意して見て」→ kind=attention                           │
+│ 6. 別 Claude Code 窓で `/designer-work <actionGroupId>` 実行          │
+│ 7. Claude Code は MCP tool で list_markers → 各 marker を kind 別に処理 │
+│    → update_step / add_catalog_entry 等で編集                      │
+│    → resolve_marker で応答メモを残す                               │
+│ 8. ブラウザは wsBridge broadcast で自動再描画                       │
+│ 9. 人間は結果を観察、未解決/新規質問があれば追加マーキング → 6 へ戻る │
+└────────────────────────────────────────────────────────────────────┘
+                            ↓
+┌─ 下流 (AI 実装前チェック、maturity=committed) ──────────────────────┐
+│ 10. モードを "downstream" に切替                                    │
+│ 11. 未確定警告を解消 (maturity 昇格、カタログ埋め、参照整合性)       │
+│ 12. Schema 検証 + 参照整合性バリデータで clean 確認                  │
+│ 13. 別 AI セッションに JSON を渡して実装依頼                         │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+## 1. 新規作成
+
+「処理フロー一覧」画面 (`/process-flow/list`) から「+ 新規作成」で ActionGroup を作る。
+
+- **名前**: 画面/画面遷移の業務名 (例: 注文登録画面)
+- **種別**: screen / batch / scheduled / system / common / other
+- **モード**: 初期は `upstream` (概要レベル)
+- **成熟度**: 初期は `draft`
+
+## 2. アクション・ステップの追加
+
+ActionGroup 内に複数の **アクション** (ボタンクリック等のイベント単位) を作り、アクション内に **ステップ** (検証/DB操作/外部呼出/画面遷移 等) を積む。
+
+ステップ種別は 14 種:
+
+| 種別 | 用途 |
+|------|------|
+| validation | 入力検証 |
+| dbAccess | DB CRUD |
+| externalSystem | 外部 API 呼出 |
+| commonProcess | 共通処理参照 |
+| screenTransition | 画面遷移 |
+| displayUpdate | 表示更新 |
+| branch | 条件分岐 |
+| loop / loopBreak / loopContinue | ループ |
+| jump | ジャンプ |
+| compute | 計算・代入 |
+| return | HTTP レスポンス返却 |
+| other | その他 |
+
+## 3. 概要だけ書く (draft)
+
+各ステップの詳細 (SQL 本文、外部 API 仕様、条件式) は未確定でよい。最小限:
+
+- `description` に 1-2 行で「何をするステップか」
+- 必要なら `note` (付箋) で「想定:」「TODO:」等を明示
+
+## 4. カタログを埋める
+
+詳細化の過程で、ActionGroup レベルのカタログに情報を集約する (ActionEditor 上部に編集パネル):
+
+- **errorCatalog** — エラーコード (STOCK_SHORTAGE 等) の HTTP ステータス・デフォルトメッセージ
+- **typeCatalog** — 共通型 (ApiError 等) の JSON Schema
+- **externalSystemCatalog** — 外部 API (stripe 等) の baseUrl / auth / timeout
+- **secretsCatalog** — API キー等のメタデータ (`@secret.stripeKey` で参照、値は含まない)
+- **ambientVariables** — ミドルウェア由来変数 (`@requestId` 等) の宣言
+
+## 5. 検証 (警告パネル)
+
+画面右上の「N 警告」バッジをクリックで詳細パネルが開く。以下のバリデータが走る:
+
+- **参照整合性** (referentialIntegrity) — responseRef / errorCode / systemRef / typeRef / secretRef の未定義参照
+- **@identifier スコープ** (identifierScope) — inputs / outputBinding / ambient / ループ変数との突合
+- **SQL 列** (sqlColumnValidator) — DbAccessStep.sql の列がテーブル定義にあるか
+- **@conv.* 参照** (conventionsValidator) — 規約カタログのキーに存在するか
+
+各警告の行の「AI に依頼」ボタンで、kind=todo の marker が 1-click 起票される。パネル上の「全て AI に依頼」で一括起票も可能。
+
+## 6-9. AI 往復 (詳しくは [marker-workflow.md](marker-workflow.md))
+
+## 10-13. 下流モード切替と実装引き渡し
+
+- モード切替ボタンで `downstream` に
+- MarkerPanel / 警告バッジが clean (0 未解決 / 0 警告) になるまで詰める
+- `designer/src/schemas/process-flow.schema.test.ts` に類する検証ツールで最終確認
+- この JSON を別 AI セッション (実装担当) に渡して実装開始
+
+## 成熟度 (maturity) の目安
+
+| maturity | 状態 | 何を意味するか |
+|----------|------|---------------|
+| `draft` | 下書き | 頻繁に変わる。外部に出さない |
+| `provisional` | 暫定 | AI 依頼中 / レビュー中 |
+| `committed` | 確定 | 下流に渡して良い。以降は保守的に編集 |
+
+ActionGroup / action / step の 3 粒度で設定可。step が committed なら、`/designer-work` は編集を保留 (人間承認待ち) する。
+
+## 関連ドキュメント
+
+- 仕様: [`docs/spec/process-flow-extensions.md`](../spec/process-flow-extensions.md)
+- 式言語: [`docs/spec/process-flow-expression-language.md`](../spec/process-flow-expression-language.md)
+- 実行時規約: [`docs/spec/process-flow-runtime-conventions.md`](../spec/process-flow-runtime-conventions.md)
+- JSON Schema: [`schemas/process-flow.schema.json`](../../schemas/process-flow.schema.json)

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -1,0 +1,95 @@
+# トラブルシューティング
+
+よくある詰まりと回避策。issue 報告の前にまず確認。
+
+## 起動・接続
+
+### ブラウザで処理フローが見えない (一覧が空)
+
+- `data/project.json` に `actionGroups[]` があるか確認
+- designer-mcp (ws://localhost:5179) が起動しているか: `netstat -ano | grep :5179`
+- ブラウザ DevTools Console で `[mcpBridge] connected` ログがあるか
+- localStorage が古い可能性: Application タブから `flow-project` を削除して reload
+
+### dev server が起動しない
+
+- ポート 5173 が占有されていないか (`netstat -ano | grep :5173`)
+- `cd designer && npm install` で依存解決済みか
+- `vite.config.ts` で `strictPort: true` にしているので、5173 が使えないと起動失敗
+
+### designer-mcp が多重起動
+
+`.mcp.json` に登録済みのため、Claude Code 起動ごとに新インスタンスが spawn される可能性あり。`wsBridge.start()` で古いプロセスの終了を待つロジックがあるが、うまくいかなければ手動 kill:
+
+```bash
+netstat -ano | grep :5179  # PID 特定
+taskkill /F /PID <PID>     # Windows
+# kill -9 <PID>            # mac/linux
+```
+
+## マーカーと /designer-work
+
+### MarkerPanel に保存した marker が消える
+
+- ActionGroup の保存 (Ctrl+S / 保存ボタン) を実行したか
+- wsBridge 接続が切れていると localStorage にしか残らない
+- 保存したのに次回表示で消える → data/ フォルダの書込み権限を確認
+
+### /designer-work 実行で「designer__list_markers is not a function」
+
+- designer-mcp が Claude Code のセッションから見えていない
+- `.mcp.json` が正しく読まれているか (プロジェクトルートで `claude` を起動したか)
+- designer-mcp のビルドエラーがないか: `cd designer-mcp && npm run build`
+
+### marker の編集対象 step を間違えて指定した
+
+- MarkerPanel の削除ボタンで消してから新規作成
+- または resolve して resolution に「間違いだった」と書く → `/designer-work` は既解決を無視
+
+### 「全て AI に依頼」で警告が起票されない
+
+- 警告の `path` フィールドがない (構造エラー系は除外される、warning のみ)
+- 既に同じ code+path の marker が未解決で存在 → 重複ガードで skip
+
+## バリデータ関連
+
+### 意図せず未解決警告が増えた
+
+- 新規追加した step や catalog が参照整合性違反を起こしている
+- 警告詳細パネルで code と path を確認
+- よくあるパターン:
+  - `UNKNOWN_RESPONSE_REF`: ReturnStep.responseRef が action.responses[].id にない → responses に追加 or 別値に変更
+  - `UNKNOWN_IDENTIFIER`: `@xxx` が inputs/outputBinding/ambient にない → ambient 宣言 or 変数作成
+  - `UNKNOWN_SECRET_REF`: `@secret.xxx` が secretsCatalog にない → カタログ追加
+  - `UNKNOWN_COLUMN`: SQL の列がテーブル定義にない → テーブル or SQL を修正
+
+### 警告が消えない
+
+- ブラウザが localStorage の古いデータを見ている可能性 → reload
+- ActionEditor が再計算していない → 保存して reload
+
+## データ周り
+
+### data/ フォルダが gitignored なのでバックアップ方法は?
+
+- 設計上 data/ はランタイム。正本は `docs/sample-project/` のサンプル
+- 実データは wsBridge 経由で保存されるため、別の場所に data/ 全体をコピーすればバックアップ
+- designer-mcp を停止してから data/ をコピー推奨
+
+### project.json と action-group ファイルが整合しない
+
+- project.json: 一覧表示用の軽量メタ
+- data/actions/*.json: 実体
+- どちらかだけ編集した場合、不整合で「処理フローが見つかりません」等のエラーに
+- 復旧: project.json に該当 ID があるか、data/actions/<ID>.json が存在するか、両方確認
+
+## Playwright E2E
+
+### `page.click` が timeout する
+
+- React の onClick が発火していない可能性。force: true より `page.evaluate(() => element.dispatchEvent(...))` の方が確実な場合あり
+- `.action-validation-panel` のように scroll 内部の要素で pointer events がクリップされる → `dispatchEvent` 推奨
+
+### Playwright MCP で `--headless=false` が効かない (Windows)
+
+- 仕様。Windows では `--headless=false` の使用は避ける。`mcp.headed` 等別フラグ参照


### PR DESCRIPTION
## 概要

CLAUDE.md / docs/spec/ は AI・開発者向け。業務設計者 (このツールのメインユーザー) 向けの手引きが無かったので新設。

## 追加

- \`docs/user-guide/README.md\` — インデックス
- \`docs/user-guide/process-flow-workflow.md\` — 上流→AI往復→下流の全体フロー
- \`docs/user-guide/marker-workflow.md\` — 4 種 marker の使い分け、/designer-work の実行
- \`docs/user-guide/troubleshooting.md\` — 起動・接続・バリデータ・E2E の既知問題

## 役割分担

- docs/user-guide/ = "how" (業務担当者向け)
- docs/spec/ = "what/why" (スキーマ仕様・BNF・規約)
- CLAUDE.md = プロジェクト全体の土台

## 動作確認

- [x] vitest 478 pass (コード変更なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)