### PR TITLE
sample(0099): ドッグフード用 マーカー入り ActionGroup

### DIFF
--- a/docs/sample-project/actions/cccccccc-0099-4000-8000-cccccccccccc.json
+++ b/docs/sample-project/actions/cccccccc-0099-4000-8000-cccccccccccc.json
@@ -1,0 +1,150 @@
+{
+  "id": "cccccccc-0099-4000-8000-cccccccccccc",
+  "name": "注文登録 (詳細化途中・マーカー入りドッグフード)",
+  "type": "screen",
+  "screenId": "aaaaaaaa-0009-4000-8000-aaaaaaaaaaaa",
+  "description": "リアルタイム編集ワークフローの実地検証用サンプル (#261)。\nupstream モード + 概要レベルのステップ + 4 種 AI マーカー (todo/question/attention/chat) を投入。\n\n想定シナリオ: 業務担当者が概要を書き、AI に詳細化を依頼する途中の状態。\n\n使い方:\n1. /process-flow/edit/cccccccc-0099-4000-8000-cccccccccccc を開く\n2. MarkerPanel に 6 件の未解決マーカーが見える\n3. 別 Claude Code セッションで /designer-work cccccccc-0099-4000-8000-cccccccccccc を実行\n4. ブラウザで結果が自動更新されるのを観察",
+  "mode": "upstream",
+  "maturity": "draft",
+
+  "actions": [
+    {
+      "id": "act-orderreg-099",
+      "name": "注文確定ボタン",
+      "trigger": "submit",
+      "maturity": "draft",
+      "httpRoute": { "method": "POST", "path": "/api/orders", "auth": "required" },
+      "responses": [
+        { "id": "201-success", "status": 201, "description": "登録成功" }
+      ],
+      "inputs": [
+        { "name": "customerId", "label": "顧客ID", "type": "number", "required": true },
+        { "name": "items", "label": "明細一覧", "required": true, "type": { "kind": "array", "itemType": { "kind": "object", "fields": [
+          { "name": "itemId", "type": "number", "required": true },
+          { "name": "quantity", "type": "number", "required": true }
+        ]}}},
+        { "name": "paymentMethod", "label": "支払方法", "type": "string", "required": true }
+      ],
+      "outputs": [
+        { "name": "orderId", "label": "注文ID", "type": "number" }
+      ],
+      "steps": [
+        {
+          "id": "step-099-001",
+          "type": "validation",
+          "maturity": "draft",
+          "description": "入力バリデーション (概要)",
+          "conditions": "基本的な必須チェック + paymentMethod の列挙"
+        },
+        {
+          "id": "step-099-002",
+          "type": "dbAccess",
+          "maturity": "draft",
+          "description": "顧客存在確認",
+          "tableName": "customers",
+          "tableId": "bbbbbbbb-0002-4000-8000-bbbbbbbbbbbb",
+          "operation": "SELECT",
+          "sql": "SELECT id FROM customers WHERE id = @customerId"
+        },
+        {
+          "id": "step-099-003",
+          "type": "loop",
+          "maturity": "draft",
+          "description": "明細ごとに在庫を減算",
+          "loopKind": "collection",
+          "collectionSource": "@items",
+          "collectionItemName": "item",
+          "steps": [
+            {
+              "id": "step-099-003-1",
+              "type": "dbAccess",
+              "maturity": "draft",
+              "description": "在庫を減算",
+              "tableName": "inventory",
+              "operation": "UPDATE",
+              "sql": "UPDATE inventory SET stock = stock - @item.quantity WHERE item_id = @item.itemId"
+            }
+          ]
+        },
+        {
+          "id": "step-099-004",
+          "type": "externalSystem",
+          "maturity": "draft",
+          "description": "決済処理",
+          "systemName": "Stripe",
+          "protocol": "HTTPS POST /v1/payment_intents"
+        },
+        {
+          "id": "step-099-005",
+          "type": "dbAccess",
+          "maturity": "draft",
+          "description": "orders に INSERT",
+          "tableName": "orders",
+          "tableId": "bbbbbbbb-0003-4000-8000-bbbbbbbbbbbb",
+          "operation": "INSERT",
+          "sql": "INSERT INTO orders (customer_id, order_date, status) VALUES (@customerId, CURRENT_TIMESTAMP, 'processing')"
+        },
+        {
+          "id": "step-099-006",
+          "type": "return",
+          "maturity": "draft",
+          "description": "201 で成功を返す",
+          "responseRef": "201-success"
+        }
+      ]
+    }
+  ],
+
+  "markers": [
+    {
+      "id": "mk-099-todo-1",
+      "kind": "todo",
+      "body": "errorCatalog に STOCK_SHORTAGE (409) と PAYMENT_FAILED (402) を追加してください",
+      "author": "human",
+      "createdAt": "2026-04-21T10:00:00.000Z"
+    },
+    {
+      "id": "mk-099-todo-2",
+      "kind": "todo",
+      "body": "step-099-003-1 の在庫減算 SQL に affectedRowsCheck を追加してください。operator='>', expected=0, onViolation='throw', errorCode='STOCK_SHORTAGE' でお願いします",
+      "stepId": "step-099-003-1",
+      "fieldPath": "affectedRowsCheck",
+      "author": "human",
+      "createdAt": "2026-04-21T10:00:00.000Z"
+    },
+    {
+      "id": "mk-099-todo-3",
+      "kind": "todo",
+      "body": "externalSystemCatalog に stripe を追加してください。baseUrl=https://api.stripe.com, auth kind=bearer, Stripe-Version header 2024-06-20、form-urlencoded",
+      "author": "human",
+      "createdAt": "2026-04-21T10:00:00.000Z"
+    },
+    {
+      "id": "mk-099-question-1",
+      "kind": "question",
+      "body": "決済 (step-099-004) が失敗した時、在庫減算 (step-099-003) を巻き戻す必要ありますか? Saga 補償パターンの例を教えて",
+      "stepId": "step-099-004",
+      "author": "human",
+      "createdAt": "2026-04-21T10:00:00.000Z"
+    },
+    {
+      "id": "mk-099-attention-1",
+      "kind": "attention",
+      "body": "step-099-002 の customers SELECT、is_active=true の条件が抜けてる気がします",
+      "stepId": "step-099-002",
+      "fieldPath": "sql",
+      "author": "human",
+      "createdAt": "2026-04-21T10:00:00.000Z"
+    },
+    {
+      "id": "mk-099-chat-1",
+      "kind": "chat",
+      "body": "このフロー、将来的にメール通知も追加予定です。外部 API の構造化は今の設計で拡張できそうですか?",
+      "author": "human",
+      "createdAt": "2026-04-21T10:00:00.000Z"
+    }
+  ],
+
+  "createdAt": "2026-04-21T10:00:00.000Z",
+  "updatedAt": "2026-04-21T10:00:00.000Z"
+}

--- a/docs/sample-project/project.json
+++ b/docs/sample-project/project.json
@@ -8,8 +8,14 @@
       "type": "login",
       "description": "ユーザー認証画面。IDとパスワードでシステムにログインする。",
       "path": "/login",
-      "position": { "x": 370, "y": 50 },
-      "size": { "width": 200, "height": 100 },
+      "position": {
+        "x": 370,
+        "y": 50
+      },
+      "size": {
+        "width": 200,
+        "height": 100
+      },
       "hasDesign": true,
       "createdAt": "2026-04-12T00:00:00.000Z",
       "updatedAt": "2026-04-12T00:00:00.000Z"
@@ -20,8 +26,14 @@
       "type": "dashboard",
       "description": "システム全体のナビゲーションハブ。顧客管理・注文管理・レポートへ遷移できる。",
       "path": "/menu",
-      "position": { "x": 370, "y": 220 },
-      "size": { "width": 200, "height": 100 },
+      "position": {
+        "x": 370,
+        "y": 220
+      },
+      "size": {
+        "width": 200,
+        "height": 100
+      },
       "hasDesign": true,
       "createdAt": "2026-04-12T00:00:00.000Z",
       "updatedAt": "2026-04-12T00:00:00.000Z"
@@ -32,8 +44,14 @@
       "type": "search",
       "description": "顧客名・電話番号での絞り込み検索と一覧表示。新規登録ボタンから顧客登録画面へ遷移。",
       "path": "/customers",
-      "position": { "x": 100, "y": 400 },
-      "size": { "width": 200, "height": 100 },
+      "position": {
+        "x": 100,
+        "y": 400
+      },
+      "size": {
+        "width": 200,
+        "height": 100
+      },
       "hasDesign": true,
       "createdAt": "2026-04-12T00:00:00.000Z",
       "updatedAt": "2026-04-12T00:00:00.000Z"
@@ -44,8 +62,14 @@
       "type": "detail",
       "description": "顧客の詳細情報表示。修正・削除・注文一覧の各操作ボタンあり。",
       "path": "/customers/:id",
-      "position": { "x": 100, "y": 580 },
-      "size": { "width": 200, "height": 100 },
+      "position": {
+        "x": 100,
+        "y": 580
+      },
+      "size": {
+        "width": 200,
+        "height": 100
+      },
       "hasDesign": true,
       "createdAt": "2026-04-12T00:00:00.000Z",
       "updatedAt": "2026-04-12T00:00:00.000Z"
@@ -56,8 +80,14 @@
       "type": "form",
       "description": "新規顧客の入力フォーム。氏名・フリガナ・連絡先・住所を入力して登録。",
       "path": "/customers/new",
-      "position": { "x": 100, "y": 760 },
-      "size": { "width": 200, "height": 100 },
+      "position": {
+        "x": 100,
+        "y": 760
+      },
+      "size": {
+        "width": 200,
+        "height": 100
+      },
       "hasDesign": true,
       "createdAt": "2026-04-12T00:00:00.000Z",
       "updatedAt": "2026-04-12T00:00:00.000Z"
@@ -68,8 +98,14 @@
       "type": "form",
       "description": "既存顧客情報の修正フォーム。登録画面と同じ項目を編集できる。",
       "path": "/customers/:id/edit",
-      "position": { "x": 340, "y": 760 },
-      "size": { "width": 200, "height": 100 },
+      "position": {
+        "x": 340,
+        "y": 760
+      },
+      "size": {
+        "width": 200,
+        "height": 100
+      },
       "hasDesign": true,
       "createdAt": "2026-04-12T00:00:00.000Z",
       "updatedAt": "2026-04-12T00:00:00.000Z"
@@ -80,8 +116,14 @@
       "type": "confirm",
       "description": "顧客データの削除確認ダイアログ。削除実行またはキャンセルを選択する。",
       "path": "/customers/:id/delete",
-      "position": { "x": 340, "y": 580 },
-      "size": { "width": 200, "height": 100 },
+      "position": {
+        "x": 340,
+        "y": 580
+      },
+      "size": {
+        "width": 200,
+        "height": 100
+      },
       "hasDesign": true,
       "createdAt": "2026-04-12T00:00:00.000Z",
       "updatedAt": "2026-04-12T00:00:00.000Z"
@@ -92,8 +134,14 @@
       "type": "list",
       "description": "注文の検索・一覧表示。顧客名・期間での絞り込みができる。新規注文登録ボタンあり。",
       "path": "/orders",
-      "position": { "x": 640, "y": 400 },
-      "size": { "width": 200, "height": 100 },
+      "position": {
+        "x": 640,
+        "y": 400
+      },
+      "size": {
+        "width": 200,
+        "height": 100
+      },
       "hasDesign": true,
       "createdAt": "2026-04-12T00:00:00.000Z",
       "updatedAt": "2026-04-12T00:00:00.000Z"
@@ -104,8 +152,14 @@
       "type": "form",
       "description": "新規注文の入力フォーム。顧客選択・商品明細・合計金額を入力して登録。",
       "path": "/orders/new",
-      "position": { "x": 640, "y": 580 },
-      "size": { "width": 200, "height": 100 },
+      "position": {
+        "x": 640,
+        "y": 580
+      },
+      "size": {
+        "width": 200,
+        "height": 100
+      },
       "hasDesign": true,
       "createdAt": "2026-04-12T00:00:00.000Z",
       "updatedAt": "2026-04-12T00:00:00.000Z"
@@ -116,8 +170,14 @@
       "type": "complete",
       "description": "登録・修正・削除の完了通知画面。処理内容のサマリーと一覧へ戻るボタンを表示。",
       "path": "/complete",
-      "position": { "x": 490, "y": 940 },
-      "size": { "width": 200, "height": 100 },
+      "position": {
+        "x": 490,
+        "y": 940
+      },
+      "size": {
+        "width": 200,
+        "height": 100
+      },
       "hasDesign": true,
       "createdAt": "2026-04-12T00:00:00.000Z",
       "updatedAt": "2026-04-12T00:00:00.000Z"
@@ -324,7 +384,27 @@
       "type": "batch",
       "actionCount": 1,
       "updatedAt": "2026-04-14T00:00:00.000Z"
+    },
+    {
+      "id": "cccccccc-0005-4000-8000-cccccccccccc",
+      "no": 5,
+      "name": "注文登録画面 (v1.3 全機能実証版)",
+      "type": "screen",
+      "screenId": "aaaaaaaa-0009-4000-8000-aaaaaaaaaaaa",
+      "actionCount": 1,
+      "updatedAt": "2026-04-20T19:00:00.000Z",
+      "maturity": "committed"
+    },
+    {
+      "id": "cccccccc-0099-4000-8000-cccccccccccc",
+      "no": 99,
+      "name": "注文登録 (詳細化途中・マーカー入りドッグフード)",
+      "type": "screen",
+      "screenId": "aaaaaaaa-0009-4000-8000-aaaaaaaaaaaa",
+      "actionCount": 1,
+      "updatedAt": "2026-04-21T10:00:00.000Z",
+      "maturity": "draft"
     }
   ],
-  "updatedAt": "2026-04-14T00:00:00.000Z"
+  "updatedAt": "2026-04-21T10:00:00.000Z"
 }

--- a/docs/user-guide/marker-workflow.md
+++ b/docs/user-guide/marker-workflow.md
@@ -66,6 +66,10 @@ Claude Code は内部で以下を順次実行:
 
 [20-dogfood-before.png](../ui-screenshots/20-dogfood-before.png) / [21-dogfood-after.png](../ui-screenshots/21-dogfood-after.png) — 4 marker 投入 → /designer-work (シミュレータ) → AI 返信 2 + errorCatalog 追加 + 4 resolve。
 
+### 試用サンプル
+
+`docs/sample-project/actions/cccccccc-0099-4000-8000-cccccccccccc.json` に「詳細化途中」の ActionGroup サンプルを同梱。6 種マーカー (3 todo + 1 question + 1 attention + 1 chat) 入り。`node docs/sample-project/seed.mjs` で data/ に展開、ブラウザで `/process-flow/edit/cccccccc-0099-4000-8000-cccccccccccc` を開いて `/designer-work` を試せる。
+
 ## 事前準備 (初回のみ)
 
 ### `.mcp.json` を確認


### PR DESCRIPTION
## 概要

帰宅後の /designer-work 実地検証用に、詳細化途中状態 + 6 種マーカー入りのサンプル ActionGroup を canonical リポジトリに追加。

## 追加

- \`docs/sample-project/actions/cccccccc-0099-4000-8000-cccccccccccc.json\` — 注文登録 (upstream/draft) + 6 marker
- \`docs/sample-project/project.json\` — actionGroups に 0005 / 0099 を追加
- \`docs/user-guide/marker-workflow.md\` — 0099 試用方法を追記

## 使い方

1. \`node docs/sample-project/seed.mjs\` で data/ に展開
2. ブラウザで \`/process-flow/edit/cccccccc-0099-4000-8000-cccccccccccc\` を開く
3. 別 Claude Code 窓で \`/designer-work cccccccc-0099-4000-8000-cccccccccccc\`
4. リアルタイムで UI 更新を観察

## 動作確認

- [x] vitest 478 → 483 (サンプル追加で schema tests +5)
- [x] 参照整合性 clean (responseRef / identifier いずれもエラーなし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)