### PR TITLE
feat(drawing): マルチストローク + 消しゴム対応 (#261)

### DIFF
--- a/designer/e2e/drawing-marker.spec.ts
+++ b/designer/e2e/drawing-marker.spec.ts
@@ -1,5 +1,7 @@
 /**
  * 赤線 free-form 描画マーカー (#261)
+ *
+ * マルチストローク対応 + 消しゴムツールの動作検証。
  */
 import { test, expect, type Page } from "@playwright/test";
 
@@ -10,7 +12,7 @@ const dummyGroup = {
   mode: "upstream", maturity: "draft",
   actions: [{ id: "act-1", name: "ボタン", trigger: "click", maturity: "draft", responses: [{id:"201-ok",status:201}], steps: [] }],
   markers: [
-    // 既存 shape 付き marker (表示テスト用)
+    // 既存 shape 付き marker (表示 + 消しゴムテスト用)
     {
       id: "mk-pre",
       kind: "attention",
@@ -39,6 +41,14 @@ async function setup(page: Page) {
   await expect(page.locator(".step-editor, .action-content").first()).toBeVisible({ timeout: 10000 });
 }
 
+async function drawStroke(page: Page, x0: number, y0: number, dx: number, dy: number) {
+  await page.mouse.move(x0, y0);
+  await page.mouse.down();
+  await page.mouse.move(x0 + dx / 2, y0 + dy / 2, { steps: 4 });
+  await page.mouse.move(x0 + dx, y0 + dy, { steps: 4 });
+  await page.mouse.up();
+}
+
 test.describe("描画マーカー (#261)", () => {
   test("既存 shape marker が SVG overlay に描画される (path 要素)", async ({ page }) => {
     await setup(page);
@@ -50,40 +60,112 @@ test.describe("描画マーカー (#261)", () => {
     expect(d).toContain("M 10 10");
   });
 
-  test("描画ボタン ON で pointer-events が有効化", async ({ page }) => {
+  test("描画ボタン ON で pointer-events が有効化しツールバーが表示される", async ({ page }) => {
     await setup(page);
     const overlay = page.locator(".drawing-overlay");
     // 既定 off: pointer-events:none
     await expect(overlay).toHaveCSS("pointer-events", "none");
+    // ツールバーは描画モード OFF では非表示
+    await expect(page.locator(".drawing-toolbar")).toHaveCount(0);
+
     await page.locator("button:has-text('描画')").click();
     await expect(overlay).toHaveCSS("pointer-events", "auto");
     await expect(page.locator("button:has-text('描画中')")).toBeVisible();
+    // ツールバー表示
+    await expect(page.locator(".drawing-toolbar")).toBeVisible();
+    // ペンが既定でアクティブ
+    await expect(page.locator(".drawing-toolbar-btn.active")).toContainText("");
   });
 
-  test("page.mouse ジェスチャで path が svg に反映", async ({ page }) => {
+  test("複数ストロークを描画してから確定で 1 marker として起票される", async ({ page }) => {
     await setup(page);
-    // Prompt は cancel (marker 起票までは検証しない、gesture → path 描画のみ)
-    page.on("dialog", async (d) => { if (d.type() === "prompt") await d.dismiss(); });
-
+    page.on("dialog", async (d) => {
+      if (d.type() === "prompt") await d.accept("まとめて修正して");
+    });
     await page.locator("button:has-text('描画')").click();
-    await expect(page.locator("button:has-text('描画中')")).toBeVisible();
 
     const overlay = page.locator(".drawing-overlay");
     const box = await overlay.boundingBox();
     if (!box) throw new Error("overlay bbox missing");
 
-    // Playwright page.mouse は PointerEvent も発火する
-    const startX = box.x + box.width * 0.3;
-    const startY = box.y + box.height * 0.3;
-    await page.mouse.move(startX, startY);
-    await page.mouse.down();
-    await page.mouse.move(startX + 100, startY + 50, { steps: 5 });
-    await page.mouse.move(startX + 200, startY + 100, { steps: 5 });
-    await page.mouse.up();
+    // 2 ストローク描画
+    await drawStroke(page, box.x + box.width * 0.3, box.y + box.height * 0.3, 100, 50);
+    await drawStroke(page, box.x + box.width * 0.5, box.y + box.height * 0.5, -80, 60);
 
-    // prompt が cancel されたので新規 marker は生まれない
-    // ただし描画中の current path が途中で生成されたかどうかは確認不能 (既に state reset)
-    // → 1 プロセス内で path が描画されたことを確認するため、pre-existing path を確認
-    await expect(page.locator(".drawing-overlay path")).toHaveCount(1); // 既存のみ
+    // ストローク数表示 (2 ストローク)
+    await expect(page.locator(".drawing-toolbar-info")).toContainText("2 ストローク");
+
+    // 確定で marker 起票
+    await page.locator(".drawing-toolbar-commit").click();
+
+    // ツールバーは閉じて描画モード OFF
+    await expect(page.locator(".drawing-toolbar")).toHaveCount(0);
+    await expect(page.locator("button:has-text('描画')")).toBeVisible();
+
+    // 新 marker が 1 件追加された (既存 1 + 新 1 = 2)
+    await expect(overlay.locator("path")).toHaveCount(2);
+
+    // 新 marker の d 属性に 2 つの M セグメントが含まれる (マルチストローク合体)
+    const paths = await overlay.locator("path").all();
+    let foundMulti = false;
+    for (const p of paths) {
+      const d = (await p.getAttribute("d")) ?? "";
+      const mCount = (d.match(/M /g) ?? []).length;
+      if (mCount >= 2) { foundMulti = true; break; }
+    }
+    expect(foundMulti).toBe(true);
+  });
+
+  test("undo ボタンで 1 ストローク戻せる", async ({ page }) => {
+    await setup(page);
+    await page.locator("button:has-text('描画')").click();
+
+    const overlay = page.locator(".drawing-overlay");
+    const box = await overlay.boundingBox();
+    if (!box) throw new Error("overlay bbox missing");
+
+    await drawStroke(page, box.x + box.width * 0.2, box.y + box.height * 0.2, 60, 40);
+    await drawStroke(page, box.x + box.width * 0.4, box.y + box.height * 0.4, 60, 40);
+
+    await expect(page.locator(".drawing-toolbar-info")).toContainText("2 ストローク");
+
+    // undo (1 ストローク戻す)
+    await page.locator(".drawing-toolbar-btn[title*='ストローク戻す']").click();
+    await expect(page.locator(".drawing-toolbar-info")).toContainText("1 ストローク");
+  });
+
+  test("キャンセルで描画破棄・marker は増えない", async ({ page }) => {
+    await setup(page);
+    await page.locator("button:has-text('描画')").click();
+
+    const overlay = page.locator(".drawing-overlay");
+    const box = await overlay.boundingBox();
+    if (!box) throw new Error("overlay bbox missing");
+
+    await drawStroke(page, box.x + box.width * 0.3, box.y + box.height * 0.3, 100, 50);
+
+    // キャンセル
+    await page.locator(".drawing-toolbar-cancel").click();
+    await expect(page.locator(".drawing-toolbar")).toHaveCount(0);
+
+    // 既存 marker のみ
+    await expect(overlay.locator("path")).toHaveCount(1);
+  });
+
+  test("消しゴムツールで既存 shape marker を削除できる", async ({ page }) => {
+    await setup(page);
+    await page.locator("button:has-text('描画')").click();
+
+    // 消しゴムに切替
+    await page.locator(".drawing-toolbar-btn[title*='消しゴム']").click();
+    await expect(page.locator(".drawing-toolbar-btn.active")).toHaveAttribute("title", /消しゴム/);
+
+    const overlay = page.locator(".drawing-overlay");
+    // 既存 path をクリックで削除 (pointer-events:stroke のため stroke 上のクリックイベントを直接 dispatch)
+    await overlay.locator("path.drawing-existing-shape").first().evaluate((el) => {
+      el.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+
+    await expect(overlay.locator("path")).toHaveCount(0);
   });
 });

--- a/designer/src/components/action/ActionEditor.tsx
+++ b/designer/src/components/action/ActionEditor.tsx
@@ -524,7 +524,7 @@ export function ActionEditor() {
 
   if (!group) return null;
 
-  const handleDrawComplete = (shape: { type: "path"; d: string }) => {
+  const handleCommitStrokes = (shape: { type: "path"; d: string }) => {
     const body = window.prompt(
       "描画マーカーへの指示を入力:\n(例: ここの SQL を affectedRowsCheck で補強して)",
     );
@@ -539,6 +539,16 @@ export function ActionEditor() {
         createdAt: new Date().toISOString(),
       }];
     });
+    setDrawingMode(false);
+  };
+
+  const handleEraseMarker = (markerId: string) => {
+    updateGroup((g) => {
+      g.markers = (g.markers ?? []).filter((m) => m.id !== markerId);
+    });
+  };
+
+  const handleExitDrawing = () => {
     setDrawingMode(false);
   };
 
@@ -1125,7 +1135,9 @@ export function ActionEditor() {
       <DrawingOverlay
         markers={group.markers ?? []}
         drawing={drawingMode}
-        onDrawComplete={handleDrawComplete}
+        onCommitStrokes={handleCommitStrokes}
+        onEraseMarker={handleEraseMarker}
+        onExitDrawing={handleExitDrawing}
       />
     </div>
   );

--- a/designer/src/components/action/DrawingOverlay.tsx
+++ b/designer/src/components/action/DrawingOverlay.tsx
@@ -1,31 +1,45 @@
 /**
- * 赤線 free-form マーカー (#261)
+ * 赤線 free-form マーカー オーバーレイ (#261)
  *
- * ActionEditor 上に被せる SVG オーバーレイ。
- * - drawing=true のとき pointer-events:auto で描画を受け付ける (マウス追跡で SVG path を生成)
- * - 既存の shape 付きマーカーは常に表示 (pointer-events:none で下の UI 操作を邪魔しない)
- * - 座標は container の bounding rect に対する 0-100 % で保存 (リサイズ耐性)
+ * ActionEditor 上に被せる SVG オーバーレイ。描画モード ON で:
+ * - ペンツール: ドラッグで自由描画。複数ストロークは path "d" 内で M 区切り合体
+ * - 消しゴムツール: 既存 shape 付き marker をクリックで削除
+ * - 確定ボタン: 現在のストローク群を 1 マーカー (kind=todo) として起票
+ * - キャンセルボタン: ストロークを破棄して描画モード終了
+ *
+ * 座標は container の bounding rect に対する 0-100 % で保存 (リサイズ耐性)。
+ * SVG path "d" が複数の M セグメントを含む = 複数ストロークがまとまった 1 marker。
  */
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { Marker } from "../../types/action";
 
+type Tool = "pen" | "eraser";
+
 interface Props {
   markers: Marker[];
   drawing: boolean;
-  /** 完成した path を受け取り、prompt で body を聞いて marker を作る */
-  onDrawComplete: (shape: { type: "path"; d: string }) => void;
+  /** 完成した shape を受け取り、body を聞いて marker を作る */
+  onCommitStrokes: (shape: { type: "path"; d: string }) => void;
+  /** eraser で既存 marker を消去 */
+  onEraseMarker: (markerId: string) => void;
+  /** 描画モード終了時のコールバック (キャンセル時、または commit 完了後) */
+  onExitDrawing: () => void;
 }
 
-export function DrawingOverlay({ markers, drawing, onDrawComplete }: Props) {
+export function DrawingOverlay({ markers, drawing, onCommitStrokes, onEraseMarker, onExitDrawing }: Props) {
   const svgRef = useRef<SVGSVGElement>(null);
-  const [currentPath, setCurrentPath] = useState<string>("");
+  const [tool, setTool] = useState<Tool>("pen");
+  const [strokes, setStrokes] = useState<string[]>([]); // 完了した個別ストローク (各々 "M ... L ... L ...")
+  const [currentStroke, setCurrentStroke] = useState<string>(""); // 描画中
   const isDrawingRef = useRef(false);
 
-  // 描画モード終了時に in-progress をクリア
+  // 描画モード終了時に state リセット
   useEffect(() => {
     if (!drawing) {
       isDrawingRef.current = false;
-      setCurrentPath("");
+      setStrokes([]);
+      setCurrentStroke("");
+      setTool("pen");
     }
   }, [drawing]);
 
@@ -38,29 +52,45 @@ export function DrawingOverlay({ markers, drawing, onDrawComplete }: Props) {
   }, []);
 
   const onPointerDown = (e: React.PointerEvent) => {
-    if (!drawing) return;
+    if (!drawing || tool !== "pen") return;
     const { x, y } = toPercent(e.clientX, e.clientY);
     isDrawingRef.current = true;
-    setCurrentPath(`M ${x.toFixed(2)} ${y.toFixed(2)}`);
+    setCurrentStroke(`M ${x.toFixed(2)} ${y.toFixed(2)}`);
     (e.target as Element).setPointerCapture(e.pointerId);
   };
 
   const onPointerMove = (e: React.PointerEvent) => {
-    if (!drawing || !isDrawingRef.current) return;
+    if (!drawing || tool !== "pen" || !isDrawingRef.current) return;
     const { x, y } = toPercent(e.clientX, e.clientY);
-    setCurrentPath((p) => `${p} L ${x.toFixed(2)} ${y.toFixed(2)}`);
+    setCurrentStroke((p) => `${p} L ${x.toFixed(2)} ${y.toFixed(2)}`);
   };
 
   const onPointerUp = () => {
-    if (!drawing || !isDrawingRef.current) return;
+    if (!drawing || tool !== "pen" || !isDrawingRef.current) return;
     isDrawingRef.current = false;
-    if (currentPath && currentPath.includes("L")) {
-      onDrawComplete({ type: "path", d: currentPath });
+    if (currentStroke && currentStroke.includes("L")) {
+      setStrokes((s) => [...s, currentStroke]);
     }
-    setCurrentPath("");
+    setCurrentStroke("");
   };
 
-  // 既存 shape の表示 (pointer-events:none)
+  const commit = () => {
+    if (strokes.length === 0) { onExitDrawing(); return; }
+    onCommitStrokes({ type: "path", d: strokes.join(" ") });
+    // ActionEditor 側が drawing=false にするので useEffect でリセットされる
+  };
+
+  const cancel = () => {
+    setStrokes([]);
+    setCurrentStroke("");
+    onExitDrawing();
+  };
+
+  const undoLastStroke = () => {
+    setStrokes((s) => s.slice(0, -1));
+  };
+
+  // 既存の shape 付き marker (表示 + eraser クリックターゲット)
   const existingShapes = markers
     .filter((m) => m.shape && m.shape.type === "path" && !m.resolvedAt)
     .map((m) => ({ id: m.id, shape: m.shape!, body: m.body, kind: m.kind }));
@@ -69,26 +99,28 @@ export function DrawingOverlay({ markers, drawing, onDrawComplete }: Props) {
     position: "absolute",
     inset: 0,
     pointerEvents: drawing ? "auto" : "none",
-    cursor: drawing ? "crosshair" : "default",
+    cursor: drawing ? (tool === "pen" ? "crosshair" : "not-allowed") : "default",
     zIndex: 30,
   };
 
   return (
-    <svg
-      ref={svgRef}
-      className="drawing-overlay"
-      viewBox="0 0 100 100"
-      preserveAspectRatio="none"
-      style={containerStyle}
-      onPointerDown={onPointerDown}
-      onPointerMove={onPointerMove}
-      onPointerUp={onPointerUp}
-      onPointerLeave={onPointerUp}
-    >
-      {/* 既存 shape (非インタラクティブ) */}
-      {existingShapes.map((s) => (
-        <g key={s.id}>
+    <>
+      <svg
+        ref={svgRef}
+        className="drawing-overlay"
+        viewBox="0 0 100 100"
+        preserveAspectRatio="none"
+        style={containerStyle}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerLeave={onPointerUp}
+      >
+        {/* 既存 shape */}
+        {existingShapes.map((s) => (
           <path
+            key={s.id}
+            className="drawing-existing-shape"
             d={s.shape.d}
             stroke={s.shape.color ?? "#ef4444"}
             strokeWidth={s.shape.strokeWidth ?? 2}
@@ -97,23 +129,100 @@ export function DrawingOverlay({ markers, drawing, onDrawComplete }: Props) {
             strokeLinejoin="round"
             opacity={0.75}
             vectorEffect="non-scaling-stroke"
+            style={{ pointerEvents: drawing && tool === "eraser" ? "stroke" : "none", cursor: drawing && tool === "eraser" ? "pointer" : "default" }}
+            onClick={(e) => {
+              if (drawing && tool === "eraser") {
+                e.stopPropagation();
+                onEraseMarker(s.id);
+              }
+            }}
           >
-            <title>{`[${s.kind}] ${s.body}`}</title>
+            <title>{`[${s.kind}] ${s.body}${drawing && tool === "eraser" ? " (クリックで削除)" : ""}`}</title>
           </path>
-        </g>
-      ))}
-      {/* 描画中の path */}
-      {currentPath && (
-        <path
-          d={currentPath}
-          stroke="#ef4444"
-          strokeWidth={2}
-          fill="none"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          vectorEffect="non-scaling-stroke"
-        />
+        ))}
+        {/* 確定済みストローク (まだ commit 前、描画セッション内) */}
+        {strokes.map((s, i) => (
+          <path
+            key={`s-${i}`}
+            d={s}
+            stroke="#ef4444"
+            strokeWidth={2}
+            fill="none"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            vectorEffect="non-scaling-stroke"
+          />
+        ))}
+        {/* 描画中の path */}
+        {currentStroke && (
+          <path
+            d={currentStroke}
+            stroke="#ef4444"
+            strokeWidth={2}
+            fill="none"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            vectorEffect="non-scaling-stroke"
+          />
+        )}
+      </svg>
+
+      {/* ツールバー (drawing 時のみ表示) */}
+      {drawing && (
+        <div className="drawing-toolbar">
+          <div className="drawing-toolbar-group">
+            <button
+              type="button"
+              className={`drawing-toolbar-btn ${tool === "pen" ? "active" : ""}`}
+              onClick={() => setTool("pen")}
+              title="ペン (ドラッグで描画)"
+            >
+              <i className="bi bi-pencil-fill" />
+            </button>
+            <button
+              type="button"
+              className={`drawing-toolbar-btn ${tool === "eraser" ? "active" : ""}`}
+              onClick={() => setTool("eraser")}
+              title="消しゴム (既存の赤線をクリックで削除)"
+            >
+              <i className="bi bi-eraser-fill" />
+            </button>
+          </div>
+          <div className="drawing-toolbar-group">
+            <button
+              type="button"
+              className="drawing-toolbar-btn"
+              onClick={undoLastStroke}
+              disabled={strokes.length === 0}
+              title={`1 ストローク戻す (現在 ${strokes.length})`}
+            >
+              <i className="bi bi-arrow-counterclockwise" />
+            </button>
+          </div>
+          <div className="drawing-toolbar-group">
+            <span className="drawing-toolbar-info">
+              {strokes.length} ストローク
+            </span>
+            <button
+              type="button"
+              className="drawing-toolbar-btn drawing-toolbar-commit"
+              onClick={commit}
+              disabled={strokes.length === 0}
+              title="ストロークを確定して marker 起票"
+            >
+              <i className="bi bi-check-lg" /> 確定
+            </button>
+            <button
+              type="button"
+              className="drawing-toolbar-btn drawing-toolbar-cancel"
+              onClick={cancel}
+              title="破棄して描画モード終了"
+            >
+              <i className="bi bi-x-lg" />
+            </button>
+          </div>
+        </div>
       )}
-    </svg>
+    </>
   );
 }

--- a/designer/src/styles/action.css
+++ b/designer/src/styles/action.css
@@ -1328,3 +1328,89 @@
 }
 .marker-timestamps { padding-top: 4px; }
 .marker-add-row { flex-wrap: wrap; gap: 4px; }
+
+/* 赤線描画オーバーレイ (#261) */
+.drawing-overlay {
+  /* pointer-events / cursor は inline style で drawing に応じて切替 */
+}
+.drawing-existing-shape {
+  transition: opacity 0.15s ease;
+}
+.drawing-existing-shape:hover {
+  opacity: 1 !important;
+}
+
+/* 描画ツールバー (描画モード ON 時のみ表示) */
+.drawing-toolbar {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: #1f2937;
+  color: #f9fafb;
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  z-index: 40;
+  font-size: 0.85rem;
+}
+.drawing-toolbar-group {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 6px;
+  border-right: 1px solid #374151;
+}
+.drawing-toolbar-group:last-child {
+  border-right: none;
+}
+.drawing-toolbar-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 10px;
+  background: transparent;
+  color: #e5e7eb;
+  border: 1px solid #374151;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background 0.1s ease, border-color 0.1s ease;
+}
+.drawing-toolbar-btn:hover:not(:disabled) {
+  background: #374151;
+  border-color: #4b5563;
+}
+.drawing-toolbar-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.drawing-toolbar-btn.active {
+  background: #ef4444;
+  border-color: #ef4444;
+  color: #fff;
+}
+.drawing-toolbar-btn.drawing-toolbar-commit:not(:disabled) {
+  background: #16a34a;
+  border-color: #16a34a;
+  color: #fff;
+}
+.drawing-toolbar-btn.drawing-toolbar-commit:hover:not(:disabled) {
+  background: #15803d;
+  border-color: #15803d;
+}
+.drawing-toolbar-btn.drawing-toolbar-cancel {
+  border-color: #6b7280;
+}
+.drawing-toolbar-btn.drawing-toolbar-cancel:hover {
+  background: #4b5563;
+}
+.drawing-toolbar-info {
+  color: #9ca3af;
+  font-size: 0.8rem;
+  padding: 0 4px;
+  white-space: nowrap;
+}


### PR DESCRIPTION
## 関連

- 関連: #261 (元 issue の延長 — 後続強化)
- 直前 PR: #290 で単発ストロークの元実装を merge。その使用感から不足が見えたため、マルチストローク / undo / 消しゴムを追加。
- 仕様: N/A (UI 改善 — spec 影響なし)

## 概要

赤線マーカーの描画ツールを実用レベルに引き上げる。単発ストロークのみでは範囲指摘が描きづらく、誤描画の undo や既存 marker の削除手段も無かった。これらをまとめて追加。

## 主な変更

- **ツールバー新設**: 描画モード ON 時のみ画面下中央に表示。ペン / 消しゴム / undo / 確定 / キャンセル
- **マルチストローク**: 描画を重ねるとストロークが累積し、確定で 1 marker (path d を M 区切りで合体) として起票
- **ストローク undo**: 直前 1 本を取り消し
- **キャンセル**: 未確定ストロークを全て破棄して描画モード終了
- **消しゴム**: 既存 shape 付き marker をクリックで削除 (pointer-events:stroke で hit 判定)
- **Props 変更**: `onDrawComplete` → `onCommitStrokes` / `onEraseMarker` / `onExitDrawing` の 3 分割

## 仕様逐条突合 (自己申告)

N/A — UI 改善のみで spec 条項なし

## レビューで特に見てほしい箇所

- **DrawingOverlay の state リセット useEffect** (`DrawingOverlay.tsx:37-44`): `drawing=false` で全 state を初期化。React 19 の set-state-in-effect lint 警告が出るが、props 変化時の同期的リセットとして妥当と判断 (既存実装と同パターン)
- **多 M 区切り path**: `strokes.join(" ")` で "M x1 y1 L ... M x2 y2 L ..." 形式を生成。SVG 仕様上 1 path 内で複数 moveTo は合法
- **消しゴムの pointer-events**: 描画モード + eraser ツール時のみ既存 path に stroke イベントを割り当て。ペン時は下の UI を貫通させる

## テスト

- Vitest: 483 件 (変更なし) pass
- Playwright (drawing-marker): 6 件 (全て新規 / 更新)
  - 既存 shape 表示
  - 描画 ON でツールバー表示
  - 複数ストローク → 確定で multi-M path 生成
  - undo ボタンでストローク数が減る
  - キャンセルで破棄
  - 消しゴムで既存 shape 削除
- Playwright 全体: 191 pass / 2 failed は pre-existing (tab-management Ctrl+Tab と validation-warnings-panel 閉じるボタン) で本 PR と無関係

## UI 影響 / マージ保留フラグ

- [x] UI 影響あり (マージ前にユーザー目視確認必須)
- [ ] UI 影響なし

### UI 影響ありの場合、確認項目

- [ ] ActionEditor で「描画」ボタン → ツールバーが下中央に表示される
- [ ] 複数回ドラッグしてストロークを重ねられ、ストローク数カウンタが増える
- [ ] undo ボタンで直前ストロークのみ消える
- [ ] 「確定」で prompt → 1 marker として起票 (MarkerPanel に 1 行追加)
- [ ] 「キャンセル」で何も起票されない
- [ ] 消しゴムに切替後、既存 shape 付き marker をクリックで削除できる

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

- 描画モード終了時の state リセット useEffect は既存パターンの踏襲。ここを effect を使わない設計に変えるなら、親側で key={drawing ? "on" : "off"} で remount する手もあるが、規模相応ではないため見送り
- 消しゴムの hit 範囲 (pointer-events:stroke) がタッチデバイスで狭すぎないかは実機未検証。Windows 実機なので 2px stroke でも問題なかったが、タッチでは strokeWidth を持ち上げる余地あり

🤖 Generated with [Claude Code](https://claude.com/claude-code)