### PR TITLE
feat(action-list): マーカー件数バッジ (#261)

### DIFF
--- a/designer/e2e/action-list-marker-badge.spec.ts
+++ b/designer/e2e/action-list-marker-badge.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * 処理フロー一覧 マーカー件数バッジ (#261)
+ *
+ * カード / 表の両ビューで、各 ActionGroup の未解決マーカー数が kind 別に表示されることを検証。
+ */
+import { test, expect, type Page } from "@playwright/test";
+
+const dummyGroups = [
+  {
+    id: "ag-with-markers",
+    name: "マーカー入り",
+    type: "screen",
+    actionCount: 1,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  },
+  {
+    id: "ag-clean",
+    name: "マーカーなし",
+    type: "batch",
+    actionCount: 1,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  },
+];
+
+const fullGroupWithMarkers = {
+  id: "ag-with-markers",
+  name: "マーカー入り",
+  type: "screen",
+  description: "",
+  mode: "upstream",
+  maturity: "draft",
+  actions: [{ id: "act-1", name: "", trigger: "click", maturity: "draft", responses: [{id:"201-ok",status:201}], steps: [] }],
+  markers: [
+    { id: "m1", kind: "todo", body: "ここ直して", author: "human", createdAt: "2026-04-21T00:00:00.000Z" },
+    { id: "m2", kind: "todo", body: "これも", author: "human", createdAt: "2026-04-21T00:00:00.000Z" },
+    { id: "m3", kind: "question", body: "なぜ?", author: "human", createdAt: "2026-04-21T00:00:00.000Z" },
+    { id: "m4", kind: "attention", body: "注意", author: "human", createdAt: "2026-04-21T00:00:00.000Z" },
+    // 解決済は件数に含まれない
+    { id: "m5", kind: "todo", body: "処理済", author: "human", createdAt: "2026-04-21T00:00:00.000Z", resolvedAt: "2026-04-21T01:00:00.000Z", resolvedBy: "ai" },
+  ],
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+const fullGroupClean = {
+  id: "ag-clean",
+  name: "マーカーなし",
+  type: "batch",
+  description: "",
+  mode: "upstream",
+  maturity: "draft",
+  actions: [{ id: "act-2", name: "", trigger: "click", maturity: "draft", responses: [{id:"201-ok",status:201}], steps: [] }],
+  markers: [],
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+const dummyProject = {
+  version: 1,
+  name: "marker badge test",
+  screens: [],
+  groups: [],
+  edges: [],
+  tables: [],
+  actionGroups: dummyGroups,
+  updatedAt: new Date().toISOString(),
+};
+
+async function setup(page: Page) {
+  await page.addInitScript((data) => {
+    localStorage.setItem("flow-project", JSON.stringify(data.project));
+    localStorage.setItem(`action-group-${data.fullMarkers.id}`, JSON.stringify(data.fullMarkers));
+    localStorage.setItem(`action-group-${data.fullClean.id}`, JSON.stringify(data.fullClean));
+    localStorage.removeItem("designer-open-tabs");
+    localStorage.removeItem("designer-active-tab");
+    localStorage.removeItem("list-view-mode:process-flow-list");
+  }, { project: dummyProject, fullMarkers: fullGroupWithMarkers, fullClean: fullGroupClean });
+  await page.goto("/process-flow/list");
+  await expect(page.locator(".action-page")).toBeVisible();
+  // マーカー集計は非同期バックグラウンド処理なので待つ
+  await expect(page.locator(".action-marker-badges").first()).toBeVisible({ timeout: 10000 });
+}
+
+test.describe("処理フロー一覧 マーカー件数バッジ (#261)", () => {
+  test("カードビューで marker 件数バッジが kind 別に表示される", async ({ page }) => {
+    await setup(page);
+
+    const markerCard = page.locator(".data-list-card").filter({ hasText: "マーカー入り" });
+    const cleanCard = page.locator(".data-list-card").filter({ hasText: "マーカーなし" });
+
+    // todo 2 件
+    await expect(markerCard.locator(".action-marker-badge.kind-todo")).toContainText("2");
+    // question 1 件
+    await expect(markerCard.locator(".action-marker-badge.kind-question")).toContainText("1");
+    // attention 1 件
+    await expect(markerCard.locator(".action-marker-badge.kind-attention")).toContainText("1");
+    // chat は 0 件なので表示されない
+    await expect(markerCard.locator(".action-marker-badge.kind-chat")).toHaveCount(0);
+
+    // resolved なマーカーはカウントされない (todo の総数が 2 であることで担保)
+    // mk5 (resolved) を含めれば 3 になるはず
+    await expect(markerCard.locator(".action-marker-badge.kind-todo")).not.toContainText("3");
+
+    // マーカーなしグループには badges 自体が表示されない
+    await expect(cleanCard.locator(".action-marker-badges")).toHaveCount(0);
+  });
+
+  test("表ビューに マーカー 列が出て、badge が表示される", async ({ page }) => {
+    await setup(page);
+    await page.getByRole("button", { name: "表表示" }).click();
+
+    // ヘッダ "マーカー"
+    await expect(page.locator("thead th").filter({ hasText: "マーカー" })).toBeVisible();
+
+    const markerRow = page.locator(".data-list-row").filter({ hasText: "マーカー入り" });
+    await expect(markerRow.locator(".action-marker-badge.kind-todo")).toContainText("2");
+    await expect(markerRow.locator(".action-marker-badge.kind-question")).toContainText("1");
+  });
+
+  test("ヘッダ全体サマリにマーカー合計が表示される", async ({ page }) => {
+    await setup(page);
+    // 合計: todo 2 + question 1 + attention 1 = 4
+    const headerSummary = page.locator(".action-list-header").locator("span[title*='マーカー']");
+    await expect(headerSummary).toContainText("4");
+  });
+});

--- a/designer/src/components/action/ActionListView.tsx
+++ b/designer/src/components/action/ActionListView.tsx
@@ -43,12 +43,28 @@ interface ValidationSummary {
   warnings: number;
 }
 
+interface MarkerSummary {
+  todo: number;
+  question: number;
+  attention: number;
+  chat: number;
+  total: number;
+}
+
+const MARKER_BADGE_META: Array<{ kind: "todo" | "question" | "attention" | "chat"; icon: string; label: string }> = [
+  { kind: "todo", icon: "bi-robot", label: "AI 依頼" },
+  { kind: "question", icon: "bi-question-circle-fill", label: "質問" },
+  { kind: "attention", icon: "bi-exclamation-triangle-fill", label: "注意" },
+  { kind: "chat", icon: "bi-chat-dots-fill", label: "メモ" },
+];
+
 export function ActionListView() {
   const navigate = useNavigate();
   const [filterType, setFilterType] = useState<ActionGroupType | "all">("all");
   const [filterErrorsOnly, setFilterErrorsOnly] = useState(false);
   const [filterMaturity, setFilterMaturity] = useState<"all" | "draft" | "provisional" | "committed">("all");
   const [validationMap, setValidationMap] = useState<Map<string, ValidationSummary>>(new Map());
+  const [markerMap, setMarkerMap] = useState<Map<string, MarkerSummary>>(new Map());
   const [showAdd, setShowAdd] = useState(false);
   const [addName, setAddName] = useState("");
   const [addType, setAddType] = useState<ActionGroupType>("screen");
@@ -146,6 +162,19 @@ export function ActionListView() {
           });
           return next;
         });
+        const openMarkers = (group.markers ?? []).filter((m) => !m.resolvedAt);
+        const summary: MarkerSummary = {
+          todo: openMarkers.filter((m) => m.kind === "todo").length,
+          question: openMarkers.filter((m) => m.kind === "question").length,
+          attention: openMarkers.filter((m) => m.kind === "attention").length,
+          chat: openMarkers.filter((m) => m.kind === "chat").length,
+          total: openMarkers.length,
+        };
+        setMarkerMap((prev) => {
+          const next = new Map(prev);
+          next.set(meta.id, summary);
+          return next;
+        });
       }
     })();
     return () => { cancelled = true; };
@@ -193,9 +222,10 @@ export function ActionListView() {
         return order[g.maturity ?? "draft"] ?? 0;
       }
       case "notesCount": return g.notesCount ?? 0;
+      case "markerCount": return markerMap.get(g.id)?.total ?? 0;
       default: return "";
     }
-  }, [getErrorPriority]);
+  }, [getErrorPriority, markerMap]);
 
   const sort = useListSort(filter.filtered, sortAccessor);
   const selection = useListSelection(sort.sorted, (g) => g.id);
@@ -322,6 +352,7 @@ export function ActionListView() {
     actionCount: "アクション",
     screenId: "画面紐付け",
     errorPriority: "検証",
+    markerCount: "マーカー",
   }), []);
 
   const handleAdd = async () => {
@@ -451,6 +482,29 @@ export function ActionListView() {
     selection.clearSelection();
   };
 
+  const renderMarkerBadges = (g: ActionGroupMeta) => {
+    const m = markerMap.get(g.id);
+    if (!m || m.total === 0) return null;
+    const tooltip = MARKER_BADGE_META
+      .filter((b) => m[b.kind] > 0)
+      .map((b) => `${b.label}: ${m[b.kind]}`)
+      .join(" / ");
+    return (
+      <span className="action-marker-badges" title={`AI 依頼マーカー ${m.total} 件 (${tooltip})`}>
+        {MARKER_BADGE_META.map((b) => {
+          const count = m[b.kind];
+          if (count === 0) return null;
+          return (
+            <span key={b.kind} className={`action-marker-badge kind-${b.kind}`}>
+              <i className={`bi ${b.icon}`} />
+              {count}
+            </span>
+          );
+        })}
+      </span>
+    );
+  };
+
   const columns = useMemo<DataListColumn<ActionGroupMeta>[]>(() => [
     {
       key: "name",
@@ -503,6 +557,15 @@ export function ActionListView() {
       render: (g) => (g.notesCount ?? 0) > 0 ? <span><i className="bi bi-sticky me-1" />{g.notesCount}</span> : null,
     },
     {
+      key: "markerCount",
+      header: "マーカー",
+      width: "140px",
+      align: "left",
+      sortable: true,
+      sortAccessor: (g) => markerMap.get(g.id)?.total ?? 0,
+      render: (g) => renderMarkerBadges(g),
+    },
+    {
       key: "screenId",
       header: "画面紐付け",
       width: "110px",
@@ -526,7 +589,7 @@ export function ActionListView() {
         return <i className="bi bi-check-lg action-validation-ok" title="問題なし" />;
       },
     },
-  ], [validationMap, getErrorPriority]);
+  ], [validationMap, getErrorPriority, markerMap]);
 
   const renderCard = (g: ActionGroupMeta) => {
     const v = validationMap.get(g.id);
@@ -556,6 +619,7 @@ export function ActionListView() {
               <i className="bi bi-sticky me-1" />付箋: {g.notesCount}
             </span>
           )}
+          {renderMarkerBadges(g)}
         </div>
       </div>
     );
@@ -606,6 +670,23 @@ export function ActionListView() {
                     <i className="bi bi-sticky" /> {summary.notes}
                   </span>
                 )}
+                {(() => {
+                  const total = MARKER_BADGE_META.reduce((acc, b) => {
+                    for (const m of markerMap.values()) acc += m[b.kind];
+                    return acc;
+                  }, 0);
+                  if (total === 0) return null;
+                  const tooltip = MARKER_BADGE_META.map((b) => {
+                    let n = 0;
+                    for (const m of markerMap.values()) n += m[b.kind];
+                    return n > 0 ? `${b.label}: ${n}` : null;
+                  }).filter(Boolean).join(" / ");
+                  return (
+                    <span title={`マーカー ${total} 件 (${tooltip})`} className="text-muted">
+                      <i className="bi bi-robot" /> {total}
+                    </span>
+                  );
+                })()}
               </div>
             );
           })()}

--- a/designer/src/styles/action.css
+++ b/designer/src/styles/action.css
@@ -128,6 +128,31 @@
   flex-shrink: 0;
 }
 
+/* ─── 処理フロー一覧 マーカー件数バッジ (#261) ──────────────────────── */
+.action-marker-badges {
+  display: inline-flex;
+  gap: 3px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.action-marker-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 6px;
+  border-radius: 10px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+.action-marker-badge i {
+  font-size: 0.7rem;
+}
+.action-marker-badge.kind-todo { background: #d1fae5; color: #065f46; }
+.action-marker-badge.kind-question { background: #ede9fe; color: #5b21b6; }
+.action-marker-badge.kind-attention { background: #fef3c7; color: #92400e; }
+.action-marker-badge.kind-chat { background: #dbeafe; color: #1e40af; }
+
 .action-list-filter-sep {
   width: 1px;
   background: #e2e8f0;


### PR DESCRIPTION
## 関連

- 関連: #261 (リアルタイム編集ワークフロー強化の一環)
- 先行: #290 / #291 (描画マーカー) + #280 (カタログ UI)
- 仕様: N/A (UI 可視化 — spec 影響なし)

## 概要

処理フロー一覧でどの ActionGroup に AI 依頼 / 質問 / 注意マーカーが溜まっているかを kind 別バッジで可視化する。従来は一覧から件数が分からず、編集画面を 1 個ずつ開いて確認する必要があった。

## 主な変更

- **markerMap state**: バックグラウンドで各 ActionGroup を full load している既存ループに、未解決マーカーの kind 別集計を追加
- **カードビュー**: `.action-card-meta` 内に `<span class="action-marker-badge kind-*">` を kind 別に描画
- **表ビュー**: ソート可能な「マーカー」列を追加 (width: 140px)
- **ヘッダサマリ**: 一覧全体の未解決マーカー合計を表示 (i class=bi-robot)
- **CSS**: kind-todo (緑) / kind-question (紫) / kind-attention (橙) / kind-chat (青) の色分けチップ

## 仕様逐条突合 (自己申告)

N/A — UI 可視化のみで spec 条項なし

## レビューで特に見てほしい箇所

- **markerMap の更新箇所** (`ActionListView.tsx:146-159`): validationMap と同じループで同期更新。別ループに分けるとマウント時の N+1 load が 2 倍になるため相乗り
- **resolvedAt 判定** (`ActionListView.tsx:147`): 現行スキーマで「解決済」は resolvedAt 付きを意味。これは /designer-work スラッシュコマンドが付ける想定
- **badge 並び順**: 重要度順 (todo → question → attention → chat) で `MARKER_BADGE_META` 配列を定義し、両ビューで同一順序

## テスト

- Vitest: 483 件 pass (変更なし)
- Playwright (action-list-marker-badge): **3 件新規**
  - カードビューで kind 別件数表示
  - 表ビューでマーカー列と badge 表示
  - ヘッダサマリに合計表示
- Playwright regression (action-list 既存 3 件): 全 pass

## UI 影響 / マージ保留フラグ

- [x] UI 影響あり (マージ前にユーザー目視確認必須)
- [ ] UI 影響なし

### UI 影響ありの場合、確認項目

- [ ] 処理フロー一覧で marker 入りの ActionGroup カードに色分け badge が表示される
- [ ] 表ビューに切り替えると「マーカー」列が出て同じ badge が並ぶ
- [ ] 表ビューで「マーカー」列ヘッダクリックでソートできる
- [ ] resolved (resolvedAt 付き) なマーカーはカウントされない
- [ ] ヘッダの 🟢🟠🟡 付箋カウント の右に bi-robot アイコンで全体合計が出る

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

- markerMap を validationMap と同じループで更新する選択は、N+1 load を避けるため。将来 marker サマリをメタ (ActionGroupMeta) に昇格できれば全体 load 不要になるが、現状は full load 済のタイミングで相乗りさせるのが最小変更
- kind の色は既存 `.marker-kind-*` と一致 (MarkerPanel と揃えるため)

🤖 Generated with [Claude Code](https://claude.com/claude-code)