### PR TITLE
feat(marker): MarkerPanel にインライン手動解決 UI (#261)

### DIFF
--- a/designer/e2e/marker-panel.spec.ts
+++ b/designer/e2e/marker-panel.spec.ts
@@ -47,17 +47,67 @@ test.describe("MarkerPanel (#261)", () => {
     await expect(page.locator(".marker-panel .marker-body")).toContainText("条件付き UPDATE");
   });
 
-  test("解決ボタンで resolved、表示切替で見える", async ({ page }) => {
+  test("解決ボタンでインライン解決フォームが開く", async ({ page }) => {
     await setup(page);
     await page.locator(".marker-panel .marker-add-row input").fill("A");
     await page.locator(".marker-panel button:has-text('追加')").click();
-    // resolve (check icon)
-    await page.locator(".marker-panel .marker-row .bi-check-circle").first().click();
+    // 解決ボタンクリック → フォーム表示
+    await page.locator(".marker-panel .marker-resolve-btn").first().click();
+    await expect(page.locator(".marker-panel .marker-resolve-form")).toBeVisible();
+    await expect(page.locator(".marker-panel .marker-resolve-form textarea")).toBeFocused();
+    // まだ resolved 状態にはなっていない
+    await expect(page.locator(".marker-panel .marker-row.resolved")).toHaveCount(0);
+  });
+
+  test("解決フォームでメモを記入して 解決 ボタン押下で resolved に", async ({ page }) => {
+    await setup(page);
+    await page.locator(".marker-panel .marker-add-row input").fill("A");
+    await page.locator(".marker-panel button:has-text('追加')").click();
+    await page.locator(".marker-panel .marker-resolve-btn").first().click();
+    await page.locator(".marker-panel .marker-resolve-form textarea").fill("自分で対応済み");
+    await page.locator(".marker-panel .marker-resolve-form button:has-text('解決')").click();
     // 既定で解決済み非表示
     await expect(page.locator(".marker-panel .marker-row")).toHaveCount(0);
     // 解決済みも表示に切替
     await page.locator(".marker-panel input[type='checkbox']").check();
     await expect(page.locator(".marker-panel .marker-row.resolved")).toHaveCount(1);
+    await expect(page.locator(".marker-panel .marker-resolution")).toContainText("自分で対応済み");
+  });
+
+  test("解決フォームで キャンセル 押下でフォームを閉じる (未解決のまま)", async ({ page }) => {
+    await setup(page);
+    await page.locator(".marker-panel .marker-add-row input").fill("A");
+    await page.locator(".marker-panel button:has-text('追加')").click();
+    await page.locator(".marker-panel .marker-resolve-btn").first().click();
+    await page.locator(".marker-panel .marker-resolve-form textarea").fill("中止する");
+    await page.locator(".marker-panel .marker-resolve-form button:has-text('キャンセル')").click();
+    await expect(page.locator(".marker-panel .marker-resolve-form")).toHaveCount(0);
+    await expect(page.locator(".marker-panel .marker-row.resolved")).toHaveCount(0);
+    // 再度開くとメモはクリアされている
+    await page.locator(".marker-panel .marker-resolve-btn").first().click();
+    await expect(page.locator(".marker-panel .marker-resolve-form textarea")).toHaveValue("");
+  });
+
+  test("メモ空のまま解決するとデフォルトメモが入る", async ({ page }) => {
+    await setup(page);
+    await page.locator(".marker-panel .marker-add-row input").fill("A");
+    await page.locator(".marker-panel button:has-text('追加')").click();
+    await page.locator(".marker-panel .marker-resolve-btn").first().click();
+    await page.locator(".marker-panel .marker-resolve-form button:has-text('解決')").click();
+    await page.locator(".marker-panel input[type='checkbox']").check();
+    await expect(page.locator(".marker-panel .marker-resolution")).toContainText("人間が手動で解決");
+  });
+
+  test("解決済み marker の チェック済アイコン押下で未解決に戻る", async ({ page }) => {
+    await setup(page);
+    await page.locator(".marker-panel .marker-add-row input").fill("A");
+    await page.locator(".marker-panel button:has-text('追加')").click();
+    await page.locator(".marker-panel .marker-resolve-btn").first().click();
+    await page.locator(".marker-panel .marker-resolve-form button:has-text('解決')").click();
+    await page.locator(".marker-panel input[type='checkbox']").check();
+    // resolved 状態のチェックアイコンをクリック (unresolve)
+    await page.locator(".marker-panel .marker-row.resolved .bi-check-circle-fill").click();
+    await expect(page.locator(".marker-panel .marker-row.resolved")).toHaveCount(0);
   });
 
   test("削除ボタンで marker 消去", async ({ page }) => {

--- a/designer/src/components/action/MarkerPanel.tsx
+++ b/designer/src/components/action/MarkerPanel.tsx
@@ -35,6 +35,8 @@ export function MarkerPanel({ group, onChange }: Props) {
   const [newKind, setNewKind] = useState<MarkerKind>("chat");
   const [newBody, setNewBody] = useState("");
   const [showResolved, setShowResolved] = useState(false);
+  const [resolvingId, setResolvingId] = useState<string | null>(null);
+  const [resolveNote, setResolveNote] = useState("");
 
   const markers = group.markers ?? [];
   const displayed = showResolved ? markers : markers.filter((m) => !m.resolvedAt);
@@ -59,13 +61,36 @@ export function MarkerPanel({ group, onChange }: Props) {
     onChange({ ...group, markers: next.length > 0 ? next : undefined });
   };
 
-  const toggleResolve = (id: string) => {
-    const next = markers.map((m) => {
-      if (m.id !== id) return m;
-      return m.resolvedAt
-        ? { ...m, resolvedAt: undefined, resolution: undefined }
-        : { ...m, resolvedAt: new Date().toISOString() };
-    });
+  const startResolve = (id: string) => {
+    setResolvingId(id);
+    setResolveNote("");
+  };
+
+  const cancelResolve = () => {
+    setResolvingId(null);
+    setResolveNote("");
+  };
+
+  const confirmResolve = (id: string) => {
+    const note = resolveNote.trim();
+    const next = markers.map((m) => (
+      m.id === id
+        ? {
+            ...m,
+            resolvedAt: new Date().toISOString(),
+            resolution: note || "(人間が手動で解決)",
+          }
+        : m
+    ));
+    onChange({ ...group, markers: next });
+    setResolvingId(null);
+    setResolveNote("");
+  };
+
+  const unresolve = (id: string) => {
+    const next = markers.map((m) => (
+      m.id === id ? { ...m, resolvedAt: undefined, resolution: undefined } : m
+    ));
     onChange({ ...group, markers: next });
   };
 
@@ -106,6 +131,7 @@ export function MarkerPanel({ group, onChange }: Props) {
           )}
           {displayed.map((m) => {
             const resolved = !!m.resolvedAt;
+            const isResolving = resolvingId === m.id;
             return (
               <div className={`catalog-row marker-row marker-kind-${m.kind} ${resolved ? "resolved" : ""}`} key={m.id}>
                 <div className="catalog-row-header">
@@ -121,14 +147,26 @@ export function MarkerPanel({ group, onChange }: Props) {
                       {m.fieldPath && `.${m.fieldPath}`}
                     </span>
                   )}
-                  <button
-                    type="button"
-                    className={`btn btn-sm btn-link ${resolved ? "text-success" : ""} ms-auto`}
-                    onClick={() => toggleResolve(m.id)}
-                    title={resolved ? "未解決に戻す" : "解決済みにする"}
-                  >
-                    <i className={`bi ${resolved ? "bi-check-circle-fill" : "bi-check-circle"}`} />
-                  </button>
+                  {resolved ? (
+                    <button
+                      type="button"
+                      className="btn btn-sm btn-link text-success ms-auto"
+                      onClick={() => unresolve(m.id)}
+                      title="未解決に戻す"
+                    >
+                      <i className="bi bi-check-circle-fill" />
+                    </button>
+                  ) : (
+                    <button
+                      type="button"
+                      className="btn btn-sm btn-link ms-auto marker-resolve-btn"
+                      onClick={() => startResolve(m.id)}
+                      title="解決済みにする (メモ付き)"
+                      disabled={isResolving}
+                    >
+                      <i className="bi bi-check-circle" />
+                    </button>
+                  )}
                   <button
                     type="button"
                     className="btn btn-sm btn-link text-danger"
@@ -139,6 +177,45 @@ export function MarkerPanel({ group, onChange }: Props) {
                   </button>
                 </div>
                 <div className="marker-body">{m.body}</div>
+                {isResolving && !resolved && (
+                  <div className="marker-resolve-form">
+                    <textarea
+                      className="form-control form-control-sm"
+                      rows={2}
+                      value={resolveNote}
+                      placeholder="解決メモ (任意): 何をしたか・なぜ閉じるか"
+                      onChange={(e) => setResolveNote(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+                          e.preventDefault();
+                          confirmResolve(m.id);
+                        } else if (e.key === "Escape") {
+                          e.preventDefault();
+                          cancelResolve();
+                        }
+                      }}
+                      autoFocus
+                    />
+                    <div className="marker-resolve-form-actions">
+                      <button
+                        type="button"
+                        className="btn btn-sm btn-success"
+                        onClick={() => confirmResolve(m.id)}
+                        title="解決済みとして閉じる (Ctrl+Enter)"
+                      >
+                        <i className="bi bi-check-lg" /> 解決
+                      </button>
+                      <button
+                        type="button"
+                        className="btn btn-sm btn-outline-secondary"
+                        onClick={cancelResolve}
+                        title="キャンセル (Esc)"
+                      >
+                        キャンセル
+                      </button>
+                    </div>
+                  </div>
+                )}
                 {resolved && m.resolution && (
                   <div className="marker-resolution">
                     <strong>解決メモ:</strong> {m.resolution}

--- a/designer/src/styles/action.css
+++ b/designer/src/styles/action.css
@@ -1354,6 +1354,23 @@
 .marker-timestamps { padding-top: 4px; }
 .marker-add-row { flex-wrap: wrap; gap: 4px; }
 
+/* インライン解決フォーム (#261) */
+.marker-resolve-form {
+  margin-top: 6px;
+  padding: 8px;
+  background: #f0fdf4;
+  border: 1px dashed #86efac;
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.marker-resolve-form-actions {
+  display: flex;
+  gap: 6px;
+  justify-content: flex-end;
+}
+
 /* 赤線描画オーバーレイ (#261) */
 .drawing-overlay {
   /* pointer-events / cursor は inline style で drawing に応じて切替 */


### PR DESCRIPTION
## 関連

- 関連: #261 (リアルタイム編集ワークフロー強化の一環)
- 直前: #290-#292 (描画マーカー / カタログ UI / 一覧バッジ)
- 仕様: N/A (UI 改善 — Marker スキーマに変更なし)

## 概要

MarkerPanel の resolve ボタンを「単純 toggle」から「解決メモを任意記入できるインラインフォーム」に拡張する。これで AI (/designer-work) を経由せずに手動で marker を閉じる運用が完結する。自己処理済・様子見・誤起票などのケースで使う。

## 主な変更

- `MarkerPanel.tsx`: `toggleResolve` を `startResolve` / `confirmResolve` / `cancelResolve` / `unresolve` に分解
- 未解決 marker の ✓ ボタン: クリックで行内に textarea + 解決/キャンセルボタンを展開 (自動 focus)
- Ctrl+Enter で解決、Esc でキャンセル
- 空メモで解決すると resolution に `"(人間が手動で解決)"` をデフォルト挿入 (/designer-work 側が判別しやすいように)
- 解決済 ✓ の再クリックは従来通りワンクリックで未解決に戻す (resolution と resolvedAt を同時にクリア)
- CSS: `.marker-resolve-form` / `.marker-resolve-form-actions` を新設

## 仕様逐条突合 (自己申告)

N/A — Marker スキーマ (resolvedAt / resolution) は既存のまま。UI からの書込タイミングが増えるのみ

## レビューで特に見てほしい箇所

- **`confirmResolve` のデフォルトメモ挿入** (`MarkerPanel.tsx`): `resolution: note || "(人間が手動で解決)"` としており、空メモでも必ず resolution が埋まる設計にした。/designer-work 側で「AI 解決」と「手動解決」を区別したいケースのため
- **autoFocus + Ctrl+Enter / Esc ハンドラ**: キーボード操作で完結するよう意識。textarea autoFocus はキーボード派に便利
- **unresolve の分離**: 旧 `toggleResolve` を廃し読み取りやすくした。resolved 状態のクリックは一段即時で十分 (確認プロンプトなし)

## テスト

- Vitest: 483 件 pass (変更なし)
- Playwright (marker-panel): 既存 5 → **9 件** (新規 4 / 既存 1 更新)
  - 解決ボタンでフォームが開く (まだ resolved ではない)
  - メモ記入 + 解決で resolved になりメモ保存
  - キャンセルでフォーム破棄・メモもクリア
  - 空メモ解決でデフォルトメモ挿入
  - resolved の ✓ 押下で未解決に戻る
- 関連 E2E regression (drawing-marker / warning-to-marker / marker-ergonomics / action-list-marker-badge): 全 15 件 pass

## UI 影響 / マージ保留フラグ

- [x] UI 影響あり (マージ前にユーザー目視確認必須)
- [ ] UI 影響なし

### UI 影響ありの場合、確認項目

- [ ] 未解決 marker の ✓ アイコンクリックでインラインフォームが展開し textarea に focus
- [ ] メモを書いて「解決」ボタンで marker が resolved に (非表示)
- [ ] 「解決済みも表示」で見ると「解決メモ:」欄に入力文が出る
- [ ] メモなしで解決するとメモ欄に「人間が手動で解決」が出る
- [ ] キャンセルでフォーム閉じ・marker は未解決のまま・メモはクリア
- [ ] resolved 状態の ✓ 緑アイコンをクリックすると未解決に戻る (ワンクリック)
- [ ] Ctrl+Enter で確定、Esc で中止

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

- Marker.resolution に必ず文字列を入れる設計にしたが、schema 上は optional のまま (undefined 挿入を回避しただけ)
- 既存の /designer-work スラッシュコマンドは resolution 文字列を既に埋めて resolve する実装。今回の手動解決でも同じフィールドを使うので互換

🤖 Generated with [Claude Code](https://claude.com/claude-code)