### PR TITLE
feat(drawing): 色 / 太さ選択プリセット (#261)

### DIFF
--- a/designer/e2e/drawing-marker.spec.ts
+++ b/designer/e2e/drawing-marker.spec.ts
@@ -73,8 +73,8 @@ test.describe("描画マーカー (#261)", () => {
     await expect(page.locator("button:has-text('描画中')")).toBeVisible();
     // ツールバー表示
     await expect(page.locator(".drawing-toolbar")).toBeVisible();
-    // ペンが既定でアクティブ
-    await expect(page.locator(".drawing-toolbar-btn.active")).toContainText("");
+    // ペンが既定でアクティブ (色スウォッチも active を持つのでツール group に限定)
+    await expect(page.locator(".drawing-toolbar-btn[title*='ペン']")).toHaveClass(/active/);
   });
 
   test("複数ストロークを描画してから確定で 1 marker として起票される", async ({ page }) => {
@@ -150,6 +150,67 @@ test.describe("描画マーカー (#261)", () => {
 
     // 既存 marker のみ
     await expect(overlay.locator("path")).toHaveCount(1);
+  });
+
+  test("色/太さを変更してコミット → shape.color / strokeWidth に反映", async ({ page }) => {
+    await setup(page);
+    page.on("dialog", async (d) => {
+      if (d.type() === "prompt") await d.accept("色変更テスト");
+    });
+    await page.locator("button:has-text('描画')").click();
+
+    // 色・太さ プリセットが表示される (ペン時のみ)
+    await expect(page.locator(".drawing-color-swatch")).toHaveCount(4);
+    await expect(page.locator(".drawing-width-btn")).toHaveCount(2);
+
+    // 青に切替
+    await page.locator(".drawing-color-swatch[data-color='#3b82f6']").click();
+    await expect(page.locator(".drawing-color-swatch[data-color='#3b82f6']")).toHaveClass(/active/);
+    // 太線に切替
+    await page.locator(".drawing-width-btn[data-width='4']").click();
+    await expect(page.locator(".drawing-width-btn[data-width='4']")).toHaveClass(/active/);
+
+    const overlay = page.locator(".drawing-overlay");
+    const box = await overlay.boundingBox();
+    if (!box) throw new Error("overlay bbox missing");
+    await drawStroke(page, box.x + box.width * 0.3, box.y + box.height * 0.3, 80, 50);
+
+    // 描画中/確定済みストロークが青・太線でレンダされる
+    // (確定前: svg 内の新規 path で stroke 色を確認)
+    const newStrokes = overlay.locator("path:not(.drawing-existing-shape)");
+    const strokeAttr = await newStrokes.first().getAttribute("stroke");
+    expect(strokeAttr).toBe("#3b82f6");
+    const widthAttr = await newStrokes.first().getAttribute("stroke-width");
+    expect(widthAttr).toBe("4");
+
+    // 確定で marker 起票
+    await page.locator(".drawing-toolbar-commit").click();
+
+    // 新 marker が描画オーバーレイに既存 shape として表示される (既存 1 + 新 1 = 2)
+    await expect(overlay.locator("path.drawing-existing-shape")).toHaveCount(2);
+
+    // 新 shape は青・太線で描画される
+    // (既存 mk-pre は M 10 10 開始、新マーカーはそれ以外の M で始まる)
+    const newShapeColors = await overlay.locator("path.drawing-existing-shape").evaluateAll((paths) => {
+      return paths.map((p) => ({
+        d: p.getAttribute("d"),
+        stroke: p.getAttribute("stroke"),
+        strokeWidth: p.getAttribute("stroke-width"),
+      }));
+    });
+    const newOne = newShapeColors.find((s) => !s.d?.startsWith("M 10 10"));
+    expect(newOne?.stroke).toBe("#3b82f6");
+    expect(newOne?.strokeWidth).toBe("4");
+  });
+
+  test("消しゴムツール時は色選択UIが非表示になる", async ({ page }) => {
+    await setup(page);
+    await page.locator("button:has-text('描画')").click();
+    // ペン時は色スウォッチあり
+    await expect(page.locator(".drawing-color-swatch")).toHaveCount(4);
+    // 消しゴムに切替 → 色スウォッチ消える
+    await page.locator(".drawing-toolbar-btn[title*='消しゴム']").click();
+    await expect(page.locator(".drawing-color-swatch")).toHaveCount(0);
   });
 
   test("消しゴムツールで既存 shape marker を削除できる", async ({ page }) => {

--- a/designer/src/components/action/ActionEditor.tsx
+++ b/designer/src/components/action/ActionEditor.tsx
@@ -524,7 +524,7 @@ export function ActionEditor() {
 
   if (!group) return null;
 
-  const handleCommitStrokes = (shape: { type: "path"; d: string }) => {
+  const handleCommitStrokes = (shape: { type: "path"; d: string; color?: string; strokeWidth?: number }) => {
     const body = window.prompt(
       "描画マーカーへの指示を入力:\n(例: ここの SQL を affectedRowsCheck で補強して)",
     );

--- a/designer/src/components/action/DrawingOverlay.tsx
+++ b/designer/src/components/action/DrawingOverlay.tsx
@@ -3,6 +3,7 @@
  *
  * ActionEditor 上に被せる SVG オーバーレイ。描画モード ON で:
  * - ペンツール: ドラッグで自由描画。複数ストロークは path "d" 内で M 区切り合体
+ *   色 / 太さ をツールバーで選択可能 (MarkerShape.color / strokeWidth に格納)
  * - 消しゴムツール: 既存 shape 付き marker をクリックで削除
  * - 確定ボタン: 現在のストローク群を 1 マーカー (kind=todo) として起票
  * - キャンセルボタン: ストロークを破棄して描画モード終了
@@ -15,11 +16,26 @@ import type { Marker } from "../../types/action";
 
 type Tool = "pen" | "eraser";
 
+/** ツールバーのプリセット色 (MarkerShape.color に保存される) */
+const COLOR_PRESETS: Array<{ value: string; label: string }> = [
+  { value: "#ef4444", label: "赤 (注意・重要)" },
+  { value: "#f97316", label: "橙 (要確認)" },
+  { value: "#3b82f6", label: "青 (質問・情報)" },
+  { value: "#10b981", label: "緑 (補足・提案)" },
+];
+const DEFAULT_COLOR = COLOR_PRESETS[0].value;
+
+const WIDTH_PRESETS: Array<{ value: number; label: string; icon: string }> = [
+  { value: 2, label: "細線", icon: "bi-slash-lg" },
+  { value: 4, label: "太線", icon: "bi-dash-lg" },
+];
+const DEFAULT_WIDTH = WIDTH_PRESETS[0].value;
+
 interface Props {
   markers: Marker[];
   drawing: boolean;
   /** 完成した shape を受け取り、body を聞いて marker を作る */
-  onCommitStrokes: (shape: { type: "path"; d: string }) => void;
+  onCommitStrokes: (shape: { type: "path"; d: string; color?: string; strokeWidth?: number }) => void;
   /** eraser で既存 marker を消去 */
   onEraseMarker: (markerId: string) => void;
   /** 描画モード終了時のコールバック (キャンセル時、または commit 完了後) */
@@ -29,6 +45,8 @@ interface Props {
 export function DrawingOverlay({ markers, drawing, onCommitStrokes, onEraseMarker, onExitDrawing }: Props) {
   const svgRef = useRef<SVGSVGElement>(null);
   const [tool, setTool] = useState<Tool>("pen");
+  const [color, setColor] = useState<string>(DEFAULT_COLOR);
+  const [width, setWidth] = useState<number>(DEFAULT_WIDTH);
   const [strokes, setStrokes] = useState<string[]>([]); // 完了した個別ストローク (各々 "M ... L ... L ...")
   const [currentStroke, setCurrentStroke] = useState<string>(""); // 描画中
   const isDrawingRef = useRef(false);
@@ -40,6 +58,8 @@ export function DrawingOverlay({ markers, drawing, onCommitStrokes, onEraseMarke
       setStrokes([]);
       setCurrentStroke("");
       setTool("pen");
+      setColor(DEFAULT_COLOR);
+      setWidth(DEFAULT_WIDTH);
     }
   }, [drawing]);
 
@@ -76,7 +96,13 @@ export function DrawingOverlay({ markers, drawing, onCommitStrokes, onEraseMarke
 
   const commit = () => {
     if (strokes.length === 0) { onExitDrawing(); return; }
-    onCommitStrokes({ type: "path", d: strokes.join(" ") });
+    onCommitStrokes({
+      type: "path",
+      d: strokes.join(" "),
+      // デフォルトから変更されている時のみ保存 (既存 marker の shape を冗長化しない)
+      color: color !== DEFAULT_COLOR ? color : undefined,
+      strokeWidth: width !== DEFAULT_WIDTH ? width : undefined,
+    });
     // ActionEditor 側が drawing=false にするので useEffect でリセットされる
   };
 
@@ -145,8 +171,8 @@ export function DrawingOverlay({ markers, drawing, onCommitStrokes, onEraseMarke
           <path
             key={`s-${i}`}
             d={s}
-            stroke="#ef4444"
-            strokeWidth={2}
+            stroke={color}
+            strokeWidth={width}
             fill="none"
             strokeLinecap="round"
             strokeLinejoin="round"
@@ -157,8 +183,8 @@ export function DrawingOverlay({ markers, drawing, onCommitStrokes, onEraseMarke
         {currentStroke && (
           <path
             d={currentStroke}
-            stroke="#ef4444"
-            strokeWidth={2}
+            stroke={color}
+            strokeWidth={width}
             fill="none"
             strokeLinecap="round"
             strokeLinejoin="round"
@@ -188,6 +214,38 @@ export function DrawingOverlay({ markers, drawing, onCommitStrokes, onEraseMarke
               <i className="bi bi-eraser-fill" />
             </button>
           </div>
+          {tool === "pen" && (
+            <>
+              <div className="drawing-toolbar-group drawing-toolbar-colors">
+                {COLOR_PRESETS.map((c) => (
+                  <button
+                    key={c.value}
+                    type="button"
+                    className={`drawing-color-swatch ${color === c.value ? "active" : ""}`}
+                    style={{ backgroundColor: c.value }}
+                    onClick={() => setColor(c.value)}
+                    title={c.label}
+                    aria-label={c.label}
+                    data-color={c.value}
+                  />
+                ))}
+              </div>
+              <div className="drawing-toolbar-group">
+                {WIDTH_PRESETS.map((w) => (
+                  <button
+                    key={w.value}
+                    type="button"
+                    className={`drawing-toolbar-btn drawing-width-btn ${width === w.value ? "active" : ""}`}
+                    onClick={() => setWidth(w.value)}
+                    title={`${w.label} (${w.value}px)`}
+                    data-width={w.value}
+                  >
+                    <i className={`bi ${w.icon}`} style={{ fontSize: `${0.5 + w.value * 0.15}rem` }} />
+                  </button>
+                ))}
+              </div>
+            </>
+          )}
           <div className="drawing-toolbar-group">
             <button
               type="button"

--- a/designer/src/styles/action.css
+++ b/designer/src/styles/action.css
@@ -1439,3 +1439,27 @@
   padding: 0 4px;
   white-space: nowrap;
 }
+
+/* カラースウォッチ + 太さ選択 (#261) */
+.drawing-toolbar-colors {
+  gap: 4px;
+}
+.drawing-color-swatch {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 2px solid #374151;
+  cursor: pointer;
+  padding: 0;
+  transition: transform 0.1s ease, border-color 0.1s ease;
+}
+.drawing-color-swatch:hover {
+  transform: scale(1.1);
+}
+.drawing-color-swatch.active {
+  border-color: #fff;
+  box-shadow: 0 0 0 2px #1f2937;
+}
+.drawing-width-btn i {
+  line-height: 1;
+}


### PR DESCRIPTION
## 関連

- 関連: #261 (リアルタイム編集ワークフロー強化の一環)
- 直前: #290-#293 (描画マーカー基本 / マルチストローク / カタログ UI / 一覧バッジ / 手動解決)
- 仕様: N/A (既存の MarkerShape.color / strokeWidth optional フィールドを使うだけ)

## 概要

描画ツールバーに色 4 色 + 太さ 2 段階のプリセットを追加し、選択中の値を確定後の MarkerShape に保存する。全マーカーが赤一色では視認性が悪いため、色と太さで重要度・種別を区別できるようにする。

## 主な変更

- `DrawingOverlay.tsx`: `color` / `width` state 追加、ツールバーに `.drawing-color-swatch` x 4 + `.drawing-width-btn` x 2 を表示
- ペンツール時のみ色/太さ選択を表示 (消しゴム時は非表示にして作業モードに集中)
- デフォルト値 (red #ef4444 / 2px) の時は `shape.color` / `strokeWidth` を省略して冗長化回避
- `ActionEditor.handleCommitStrokes`: 型を `{ color?, strokeWidth? }` まで受け取るよう拡張
- CSS: `.drawing-color-swatch` (22px 丸ボタン、active 時に白枠) / `.drawing-width-btn`

## 仕様逐条突合 (自己申告)

N/A — MarkerShape スキーマに変更なし。既存の optional フィールドを UI から埋めるだけ

## レビューで特に見てほしい箇所

- **デフォルト省略ロジック** (`DrawingOverlay.tsx` `commit` 関数): `color !== DEFAULT_COLOR ? color : undefined` で保存。既存 marker (#290 以前に作成) との JSON 差分を最小に
- **色プリセット**: red/orange/blue/green の 4 色。多すぎると選択肢疲労、少なすぎると区別不能。semantic な tooltip を付けてユーザー判断の補助にした
- **消しゴム時の色非表示**: UX 判断。消しゴム時は色選択しても意味がないので隠す方がツールバー幅を節約できる

## テスト

- Vitest: 483 件 pass (変更なし)
- Playwright (drawing-marker): 既存 6 → **8 件** (新規 2)
  - 色/太さ変更 → 描画時点で stroke 属性反映 → commit 後も shape 属性保持
  - 消しゴム時は色選択 UI が非表示
- 既存 drawing-marker 6 件: 全 pass (既存挙動リグレッションなし)

## UI 影響 / マージ保留フラグ

- [x] UI 影響あり (マージ前にユーザー目視確認必須)
- [ ] UI 影響なし

### UI 影響ありの場合、確認項目

- [ ] 描画 ON でツールバーに丸い色スウォッチ 4 色が並ぶ
- [ ] 各色クリックで active (白枠) になり、新規ストロークがその色で描ける
- [ ] 細線/太線ボタンで太さが切り替わる (太線は視認して細線より太いと分かる程度)
- [ ] 消しゴム切替で色/太さ選択が消え、ペン切替で再表示される
- [ ] 色・太さを変えてコミットすると、その後の描画オーバーレイに残る既存 shape も同じ色で表示される
- [ ] デフォルト (赤・細線) のまま commit した marker は JSON で color/strokeWidth が省略されている

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

- 色の持ち方を kind (todo/question/attention/chat) と二重にするのを避けるため、色は純粋に装飾 (semantic な意味は tooltip のみ)。kind は別途 prompt 時の質問で決まる仕様のまま
- 将来: shape タイプ (arrow / rectangle / highlight) を追加するなら、色・太さは流用可能な形で state 配置済

🤖 Generated with [Claude Code](https://claude.com/claude-code)