### PR TITLE
feat(action-list): 「マーカーありのみ」フィルタ (#261)

### DIFF
--- a/designer/e2e/action-list-marker-badge.spec.ts
+++ b/designer/e2e/action-list-marker-badge.spec.ts
@@ -125,4 +125,14 @@ test.describe("処理フロー一覧 マーカー件数バッジ (#261)", () => 
     const headerSummary = page.locator(".action-list-header").locator("span[title*='マーカー']");
     await expect(headerSummary).toContainText("4");
   });
+
+  test("「マーカーありのみ」フィルタで marker 入りの AG だけ表示", async ({ page }) => {
+    await setup(page);
+    // チェックボックス ON → marker 入りのみ残る (ag-clean は非表示)
+    await page.locator(".action-list-check-label").filter({ hasText: "マーカーあり" }).click();
+    await expect(page.locator(".data-list-card").filter({ hasText: "マーカー入り" })).toBeVisible();
+    await expect(page.locator(".data-list-card").filter({ hasText: "マーカーなし" })).toHaveCount(0);
+    // FilterBar にラベル表示
+    await expect(page.locator(".filter-bar")).toContainText("マーカーあり");
+  });
 });

--- a/designer/src/components/action/ActionListView.tsx
+++ b/designer/src/components/action/ActionListView.tsx
@@ -62,6 +62,7 @@ export function ActionListView() {
   const navigate = useNavigate();
   const [filterType, setFilterType] = useState<ActionGroupType | "all">("all");
   const [filterErrorsOnly, setFilterErrorsOnly] = useState(false);
+  const [filterMarkersOnly, setFilterMarkersOnly] = useState(false);
   const [filterMaturity, setFilterMaturity] = useState<"all" | "draft" | "provisional" | "committed">("all");
   const [validationMap, setValidationMap] = useState<Map<string, ValidationSummary>>(new Map());
   const [markerMap, setMarkerMap] = useState<Map<string, MarkerSummary>>(new Map());
@@ -193,13 +194,14 @@ export function ActionListView() {
   useEffect(() => {
     const hasTypeFilter = filterType !== "all";
     const hasMaturityFilter = filterMaturity !== "all";
-    if (!hasTypeFilter && !filterErrorsOnly && !hasMaturityFilter) {
+    if (!hasTypeFilter && !filterErrorsOnly && !filterMarkersOnly && !hasMaturityFilter) {
       filter.applyFilter(null);
       return;
     }
     filter.applyFilter((g) => {
       if (hasTypeFilter && g.type !== filterType) return false;
       if (filterErrorsOnly && getErrorPriority(g.id) === 0) return false;
+      if (filterMarkersOnly && (markerMap.get(g.id)?.total ?? 0) === 0) return false;
       if (hasMaturityFilter) {
         const m = g.maturity ?? "draft";
         if (m !== filterMaturity) return false;
@@ -207,7 +209,7 @@ export function ActionListView() {
       return true;
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filterType, filterErrorsOnly, filterMaturity, validationMap]);
+  }, [filterType, filterErrorsOnly, filterMarkersOnly, filterMaturity, validationMap, markerMap]);
 
   const sortAccessor = useCallback((g: ActionGroupMeta, key: string): string | number => {
     switch (key) {
@@ -763,6 +765,15 @@ export function ActionListView() {
             エラーありのみ
           </label>
 
+          <label className="action-list-check-label">
+            <input
+              type="checkbox"
+              checked={filterMarkersOnly}
+              onChange={(e) => setFilterMarkersOnly(e.target.checked)}
+            />
+            <i className="bi bi-robot" /> マーカーありのみ
+          </label>
+
           <div className="action-list-filter-sep" />
 
           <label className="action-list-check-label" style={{ display: "flex", alignItems: "center", gap: 4 }}>
@@ -785,12 +796,15 @@ export function ActionListView() {
           isActive={filter.isActive}
           totalCount={filter.totalCount}
           visibleCount={filter.visibleCount}
-          label={
-            filterType !== "all"
-              ? `種別: ${ACTION_GROUP_TYPE_LABELS[filterType]}${filterErrorsOnly ? " + エラーあり" : ""}`
-              : filterErrorsOnly ? "エラーあり" : undefined
-          }
-          onClear={() => { setFilterType("all"); setFilterErrorsOnly(false); setFilterMaturity("all"); }}
+          label={(() => {
+            const parts: string[] = [];
+            if (filterType !== "all") parts.push(`種別: ${ACTION_GROUP_TYPE_LABELS[filterType]}`);
+            if (filterErrorsOnly) parts.push("エラーあり");
+            if (filterMarkersOnly) parts.push("マーカーあり");
+            if (filterMaturity !== "all") parts.push(`成熟度: ${filterMaturity}`);
+            return parts.length > 0 ? parts.join(" + ") : undefined;
+          })()}
+          onClear={() => { setFilterType("all"); setFilterErrorsOnly(false); setFilterMarkersOnly(false); setFilterMaturity("all"); }}
         />
 
         <SortBar sort={sort} columnLabels={columnLabels} />


### PR DESCRIPTION
## 関連

- 関連: #261 (リアルタイム編集ワークフロー強化の一環)
- 先行: #292 (一覧マーカー件数バッジ — 表示が整ったので絞り込みを重ねる)
- 仕様: N/A (UI フィルタ追加)

## 概要

処理フロー一覧のフィルタ群に「マーカーありのみ」チェックボックスを追加。未解決マーカーがある ActionGroup だけを絞り込めるようにする。バッジ表示 (#292) と併せて、どこに AI 依頼 / 質問が溜まっているかを素早く特定できる。

## 主な変更

- `filterMarkersOnly` state を追加、既存 `filterErrorsOnly` と同じ位置にチェックボックス配置
- `markerMap` を filter effect の dep に追加し、`(markerMap.get(g.id)?.total ?? 0) === 0` なら除外
- FilterBar ラベルを配列結合式に変更: `種別 + エラーあり + マーカーあり + 成熟度: X` のように複数条件を `+` 区切りで全部表示 (従来は種別とエラーのみ)
- `onClear` で `filterMarkersOnly` も reset

## 仕様逐条突合 (自己申告)

N/A — UI フィルタ追加のみで spec 影響なし

## レビューで特に見てほしい箇所

- **FilterBar ラベルの式** (`ActionListView.tsx`): `parts` 配列で組み立てるよう変更。既存 2 条件 (種別・エラー) の文字列連結より読みやすい
- **markerMap dep**: markerMap は非同期ロードなので、フィルタ ON 時に最初は未ロードで全件通過する可能性あり。マウント時点でロードが走っており、実用上は 1 秒以内に安定する

## テスト

- Vitest: 483 件 pass (変更なし)
- Playwright (action-list-marker-badge): 3 → **4 件** (新規 1)
  - チェックボックス ON で marker 入りのみ残る + ラベル表示
- 既存 action-list (3 件) + action-list-marker-badge (既存 3 件): 全 pass

## UI 影響 / マージ保留フラグ

- [x] UI 影響あり (マージ前にユーザー目視確認必須)
- [ ] UI 影響なし

### UI 影響ありの場合、確認項目

- [ ] 処理フロー一覧で「マーカーありのみ」チェック → marker 持ちの AG のみ残る
- [ ] チェック OFF で元の件数に戻る
- [ ] 「エラーありのみ」と併用可能 (両方 ON で and 条件)
- [ ] FilterBar ラベルが「種別: 画面 + マーカーあり + 成熟度: draft」のように連結表示される

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

- テストで post-clear 状態の assert を落としている: 環境により mcpBridge/WS が localStorage dummy を上書きするタイミングで flaky になるため、ON 状態の assert のみに絞った。OFF は既存の filter clear 機構の一部で本 PR 固有の挙動ではない

🤖 Generated with [Claude Code](https://claude.com/claude-code)