### PR TITLE
feat(mcp): designer__find_all_markers で全 AG 横断取得 (#261)

### DIFF
--- a/designer-mcp/src/actionGroupEdits.test.ts
+++ b/designer-mcp/src/actionGroupEdits.test.ts
@@ -10,6 +10,7 @@ import {
   insertStepAt,
   findStep,
   listMarkers,
+  findAllMarkers,
   addMarker,
   resolveMarker,
   removeMarker,
@@ -203,6 +204,57 @@ describe("markers (#261)", () => {
     const ag = makeGroup();
     expect(() => resolveMarker(ag, "nope")).toThrow();
     expect(() => removeMarker(ag, "nope")).toThrow();
+  });
+});
+
+describe("findAllMarkers", () => {
+  function group(id: string, name: string, markers: Array<{ kind: "chat" | "attention" | "todo" | "question"; body: string; resolved?: boolean }>): { id: string; name: string; ag: ActionGroupDoc } {
+    const ag: ActionGroupDoc = { id, actions: [{ id: `${id}-a`, steps: [] }] };
+    for (const m of markers) {
+      const added = addMarker(ag, { kind: m.kind, body: m.body, author: "human" });
+      if (m.resolved) resolveMarker(ag, added.id, "ok");
+    }
+    return { id, name, ag };
+  }
+
+  it("複数 AG を横断し actionGroupId / actionGroupName 付きで返す", () => {
+    const groups = [
+      group("ag-a", "A", [{ kind: "todo", body: "X" }, { kind: "question", body: "Y" }]),
+      group("ag-b", "B", [{ kind: "chat", body: "Z" }]),
+    ];
+    const all = findAllMarkers(groups);
+    expect(all).toHaveLength(3);
+    expect(all[0].actionGroupId).toBe("ag-a");
+    expect(all[0].actionGroupName).toBe("A");
+    expect(all[2].actionGroupId).toBe("ag-b");
+  });
+
+  it("unresolvedOnly=true (既定) で解決済みは除外", () => {
+    const groups = [
+      group("ag-a", "A", [{ kind: "todo", body: "open" }, { kind: "todo", body: "done", resolved: true }]),
+    ];
+    expect(findAllMarkers(groups, { unresolvedOnly: true })).toHaveLength(1);
+    expect(findAllMarkers(groups, { unresolvedOnly: false })).toHaveLength(2);
+  });
+
+  it("kind フィルタで特定種別のみ抽出", () => {
+    const groups = [
+      group("ag-a", "A", [{ kind: "todo", body: "t" }, { kind: "question", body: "q" }]),
+      group("ag-b", "B", [{ kind: "todo", body: "t2" }]),
+    ];
+    const onlyTodo = findAllMarkers(groups, { kind: "todo" });
+    expect(onlyTodo).toHaveLength(2);
+    expect(onlyTodo.every((m) => m.kind === "todo")).toBe(true);
+  });
+
+  it("マーカーなし AG は結果に含まれない (空配列を返すだけ)", () => {
+    const groups = [
+      group("ag-empty", "Empty", []),
+      group("ag-has", "Has", [{ kind: "chat", body: "x" }]),
+    ];
+    const all = findAllMarkers(groups);
+    expect(all).toHaveLength(1);
+    expect(all[0].actionGroupId).toBe("ag-has");
   });
 });
 

--- a/designer-mcp/src/actionGroupEdits.ts
+++ b/designer-mcp/src/actionGroupEdits.ts
@@ -221,6 +221,29 @@ export function listMarkers(ag: ActionGroupDoc, filter: { unresolvedOnly?: boole
   return list;
 }
 
+/**
+ * 複数 ActionGroup を横断して marker を収集する (#261)。
+ * 各 marker に actionGroupId / actionGroupName を prepend して返す。
+ */
+export interface MarkerWithAg extends Marker {
+  actionGroupId: string;
+  actionGroupName: string;
+}
+export function findAllMarkers(
+  groups: Array<{ id: string; name: string; ag: ActionGroupDoc }>,
+  filter: { unresolvedOnly?: boolean; kind?: Marker["kind"] } = {},
+): MarkerWithAg[] {
+  const results: MarkerWithAg[] = [];
+  for (const { id, name, ag } of groups) {
+    const markers = listMarkers(ag, { unresolvedOnly: filter.unresolvedOnly });
+    for (const m of markers) {
+      if (filter.kind && m.kind !== filter.kind) continue;
+      results.push({ actionGroupId: id, actionGroupName: name, ...m });
+    }
+  }
+  return results;
+}
+
 export function addMarker(ag: ActionGroupDoc, marker: Omit<Marker, "id" | "createdAt">): Marker {
   const next: Marker = {
     id: `mk-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,

--- a/designer-mcp/src/index.ts
+++ b/designer-mcp/src/index.ts
@@ -20,6 +20,7 @@ import {
   removeCatalogEntry as editRemoveCatalogEntry,
   insertStepAt as editInsertStepAt,
   listMarkers as editListMarkers,
+  findAllMarkers as editFindAllMarkers,
   addMarker as editAddMarker,
   resolveMarker as editResolveMarker,
   removeMarker as editRemoveMarker,
@@ -1034,6 +1035,22 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           stepId: typeof a.stepId === "string" ? a.stepId : undefined,
         });
         return { content: [{ type: "text", text: JSON.stringify(markers, null, 2) }] };
+      }
+
+      case "designer__find_all_markers": {
+        const a = (args ?? {}) as Record<string, unknown>;
+        const unresolvedOnly = a.unresolvedOnly !== false; // 既定 true
+        const kindFilter = typeof a.kind === "string"
+          ? (a.kind as "chat" | "attention" | "todo" | "question")
+          : undefined;
+        const agList = await listActionGroupFiles() as Array<{ id: string; name: string }>;
+        const loaded: Array<{ id: string; name: string; ag: ActionGroupDoc }> = [];
+        for (const meta of agList) {
+          const ag = await readActionGroup(meta.id) as ActionGroupDoc | null;
+          if (ag) loaded.push({ id: meta.id, name: meta.name, ag });
+        }
+        const results = editFindAllMarkers(loaded, { unresolvedOnly, kind: kindFilter });
+        return { content: [{ type: "text", text: JSON.stringify({ count: results.length, markers: results }, null, 2) }] };
       }
 
       case "designer__add_marker": {

--- a/designer-mcp/src/tools.ts
+++ b/designer-mcp/src/tools.ts
@@ -874,6 +874,21 @@ export const tools = [
     },
   },
   {
+    name: "designer__find_all_markers",
+    description: "全 ActionGroup を横断して未解決マーカーを取得します。/designer-work で「今対応すべき人間指示をまず一望する」ために使用。各マーカーに actionGroupId / actionGroupName が付く。",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        unresolvedOnly: { type: "boolean", description: "true で未解決のみ (既定 true)" },
+        kind: {
+          type: "string",
+          enum: ["chat", "attention", "todo", "question"],
+          description: "特定 kind のみ抽出 (省略時は全 kind)",
+        },
+      },
+    },
+  },
+  {
     name: "designer__add_marker",
     description: "ActionGroup にマーカーを追加します。AI 側からの質問・返信・報告等を人間に届ける用途。",
     inputSchema: {


### PR DESCRIPTION
## 関連

- 関連: #261 (リアルタイム編集ワークフロー強化)
- 依存: 既存の designer__list_markers / list_action_groups
- 仕様: N/A (MCP 追加のみ、スキーマ無影響)

## 概要

/designer-work 初手で「いま対応すべき人間指示を一望する」ための MCP ツールを追加。従来 N+1 呼出 (list_action_groups × N × list_markers) を 1 呼出に圧縮する。

## 主な変更

- **新ツール** `designer__find_all_markers`: 全 ActionGroup を横断して marker を返す
  - オプション `unresolvedOnly` (既定 true) / `kind` (chat|attention|todo|question)
  - 戻り値: `{ count, markers: [{ actionGroupId, actionGroupName, ...marker }] }`
- **新関数** `actionGroupEdits.findAllMarkers` に横断ロジックを抽出
- ユニットテスト 4 件 (33 件 total)
  - 横断収集で ag 情報付く
  - unresolvedOnly の既定挙動
  - kind フィルタ絞込
  - 空 AG は結果から外れる

## 仕様逐条突合 (自己申告)

N/A — MCP ツール追加のみで process-flow spec 条項なし

## レビューで特に見てほしい箇所

- **N+1 を避けつつテスタビリティ確保** (`actionGroupEdits.ts` `findAllMarkers`): ファイル I/O は index.ts 側の handler で扱い、純関数として切り出し。テストは構築済 AG 配列を渡すだけで済む
- **kind フィルタの型** (`index.ts`): `a.kind` は MCP 入力なので any。`"chat" | "attention" | "todo" | "question"` にキャスト。tools.ts 側で enum 制約している前提

## テスト

- Vitest (designer-mcp): 29 → **33 件** (新規 4)
- tsc: pass

## UI 影響 / マージ保留フラグ

- [ ] UI 影響あり (マージ前にユーザー目視確認必須)
- [x] UI 影響なし (auto テスト pass でマージ可)

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

- 将来 dashboard の MarkersSummaryPanel をこのツールに差し替え可能 (現状はブラウザ側で listActionGroups + loadActionGroup を個別 fetch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)