### PR TITLE
feat(stepcard): kind 別マーカーバッジ (#261)

### DIFF
--- a/designer/e2e/stepcard-marker-kind-badge.spec.ts
+++ b/designer/e2e/stepcard-marker-kind-badge.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * StepCard の kind 別マーカーバッジ (#261)
+ *
+ * StepCard ヘッダに todo/question/attention/chat 各色のチップが表示されることを検証。
+ */
+import { test, expect, type Page } from "@playwright/test";
+
+const groupId = "ag-stepchip";
+
+const dummyGroup = {
+  id: groupId, name: "stepchip test", type: "screen", description: "",
+  mode: "upstream", maturity: "draft",
+  actions: [{
+    id: "act-1", name: "ボタン", trigger: "click", maturity: "draft",
+    responses: [{ id: "201-ok", status: 201 }],
+    steps: [
+      { id: "s1", type: "validation", description: "チェック", conditions: "", maturity: "draft" },
+      { id: "s2", type: "compute", description: "計算", expression: "", maturity: "draft" },
+    ],
+  }],
+  markers: [
+    // s1 に 3 kind (todo ×2, question ×1, attention ×1)
+    { id: "m1", kind: "todo", body: "A", stepId: "s1", author: "human", createdAt: "2026-04-20T00:00:00Z" },
+    { id: "m2", kind: "todo", body: "B", stepId: "s1", author: "human", createdAt: "2026-04-20T00:00:00Z" },
+    { id: "m3", kind: "question", body: "?", stepId: "s1", author: "human", createdAt: "2026-04-20T00:00:00Z" },
+    { id: "m4", kind: "attention", body: "!", stepId: "s1", author: "human", createdAt: "2026-04-20T00:00:00Z" },
+    // resolved は除外される
+    { id: "m5", kind: "todo", body: "done", stepId: "s1", author: "human", createdAt: "2026-04-20T00:00:00Z", resolvedAt: "2026-04-20T01:00:00Z" },
+    // s2 には未解決 marker なし (バッジなし)
+  ],
+  createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
+};
+const dummyProject = {
+  version: 1, name: "stepchip", screens: [], groups: [], edges: [], tables: [],
+  actionGroups: [{ id: groupId, no: 1, name: dummyGroup.name, type: dummyGroup.type, actionCount: 1, updatedAt: dummyGroup.updatedAt, maturity: "draft" }],
+  updatedAt: new Date().toISOString(),
+};
+
+async function setup(page: Page) {
+  await page.addInitScript(({ project, group }) => {
+    localStorage.setItem("flow-project", JSON.stringify(project));
+    localStorage.setItem(`action-group-${group.id}`, JSON.stringify(group));
+    localStorage.removeItem("designer-open-tabs");
+    localStorage.removeItem("designer-active-tab");
+  }, { project: dummyProject, group: dummyGroup });
+  await page.goto(`/process-flow/edit/${groupId}`);
+  await expect(page.locator(".step-editor, .action-content").first()).toBeVisible({ timeout: 10000 });
+}
+
+test.describe("StepCard kind 別マーカーバッジ (#261)", () => {
+  test("s1 に todo/question/attention 色分けチップが表示される", async ({ page }) => {
+    await setup(page);
+    // s1 の StepCard ヘッダ内に step-marker-chip 要素あり
+    const chips = page.locator(".step-card").filter({ hasText: "チェック" }).locator(".step-marker-chip");
+    // 3 種類 (chat は 0 件なので表示されない)
+    await expect(chips).toHaveCount(3);
+    // todo は 2、question/attention は 1
+    await expect(chips.filter({ has: page.locator(".bi-robot") })).toContainText("2");
+    await expect(chips.filter({ has: page.locator(".bi-question-circle-fill") })).toContainText("1");
+    await expect(chips.filter({ has: page.locator(".bi-exclamation-triangle-fill") })).toContainText("1");
+  });
+
+  test("s2 (未解決なし) にはバッジ表示なし", async ({ page }) => {
+    await setup(page);
+    const s2Card = page.locator(".step-card").filter({ hasText: "計算" });
+    await expect(s2Card.locator(".step-marker-chip")).toHaveCount(0);
+    await expect(s2Card.locator(".step-marker-badge")).toHaveCount(0);
+  });
+
+  test("resolved marker はカウントに含まれない (todo が 2、3 にならない)", async ({ page }) => {
+    await setup(page);
+    const todoChip = page.locator(".step-card").filter({ hasText: "チェック" })
+      .locator(".step-marker-chip.kind-todo");
+    await expect(todoChip).toContainText("2");
+    await expect(todoChip).not.toContainText("3");
+  });
+});

--- a/designer/src/components/action/ActionEditor.tsx
+++ b/designer/src/components/action/ActionEditor.tsx
@@ -969,6 +969,12 @@ export function ActionEditor() {
                       const markerTooltip = markerCount > 0
                         ? `AI 依頼マーカー ${markerCount} 件:\n${stepMarkers.map((m) => `- [${m.kind}] ${m.body.slice(0, 60)}`).join("\n")}`
                         : undefined;
+                      const markerKinds = markerCount > 0 ? {
+                        todo: stepMarkers.filter((m) => m.kind === "todo").length,
+                        question: stepMarkers.filter((m) => m.kind === "question").length,
+                        attention: stepMarkers.filter((m) => m.kind === "attention").length,
+                        chat: stepMarkers.filter((m) => m.kind === "chat").length,
+                      } : undefined;
                       return (
                       <div key={step.id}>
                         <StepInsertZone
@@ -1017,6 +1023,7 @@ export function ActionEditor() {
                           }}
                           markerCount={markerCount}
                           markerTooltip={markerTooltip}
+                          markerKinds={markerKinds}
                         />
                       </div>
                       );

--- a/designer/src/components/action/SortableStepCard.tsx
+++ b/designer/src/components/action/SortableStepCard.tsx
@@ -30,6 +30,7 @@ interface SortableStepCardProps {
   onAddMarker?: (body: string, kind?: "todo" | "question" | "attention" | "chat") => void;
   markerCount?: number;
   markerTooltip?: string;
+  markerKinds?: { todo: number; question: number; attention: number; chat: number };
 }
 
 export function SortableStepCard({ step, ...props }: SortableStepCardProps) {

--- a/designer/src/components/action/StepCard.tsx
+++ b/designer/src/components/action/StepCard.tsx
@@ -212,6 +212,8 @@ interface StepCardProps {
   markerCount?: number;
   /** この step の未解決 marker tooltip 本文 */
   markerTooltip?: string;
+  /** kind 別未解決件数 (#261 色分け badge 表示用、省略時は markerCount のみ表示) */
+  markerKinds?: { todo: number; question: number; attention: number; chat: number };
 }
 
 const DB_OPS: DbOperation[] = ["SELECT", "INSERT", "UPDATE", "DELETE"];
@@ -246,6 +248,7 @@ export function StepCard({
   onAddMarker,
   markerCount = 0,
   markerTooltip,
+  markerKinds,
 }: StepCardProps) {
   const [expanded, setExpanded] = useState(defaultExpanded ?? false);
   const [showMenu, setShowMenu] = useState(false);
@@ -447,13 +450,41 @@ export function StepCard({
             </span>
           )}
           {markerCount > 0 && (
-            <span
-              className="step-marker-badge"
-              title={markerTooltip ?? `AI 依頼マーカー ${markerCount} 件`}
-            >
-              <i className="bi bi-megaphone-fill" />
-              {markerCount}
-            </span>
+            markerKinds ? (
+              <span
+                className="step-marker-badges"
+                title={markerTooltip ?? `AI 依頼マーカー ${markerCount} 件`}
+              >
+                {markerKinds.todo > 0 && (
+                  <span className="step-marker-chip kind-todo" title={`AI 依頼 (TODO) ${markerKinds.todo} 件`}>
+                    <i className="bi bi-robot" />{markerKinds.todo}
+                  </span>
+                )}
+                {markerKinds.question > 0 && (
+                  <span className="step-marker-chip kind-question" title={`質問 ${markerKinds.question} 件`}>
+                    <i className="bi bi-question-circle-fill" />{markerKinds.question}
+                  </span>
+                )}
+                {markerKinds.attention > 0 && (
+                  <span className="step-marker-chip kind-attention" title={`注意 ${markerKinds.attention} 件`}>
+                    <i className="bi bi-exclamation-triangle-fill" />{markerKinds.attention}
+                  </span>
+                )}
+                {markerKinds.chat > 0 && (
+                  <span className="step-marker-chip kind-chat" title={`メモ ${markerKinds.chat} 件`}>
+                    <i className="bi bi-chat-dots-fill" />{markerKinds.chat}
+                  </span>
+                )}
+              </span>
+            ) : (
+              <span
+                className="step-marker-badge"
+                title={markerTooltip ?? `AI 依頼マーカー ${markerCount} 件`}
+              >
+                <i className="bi bi-megaphone-fill" />
+                {markerCount}
+              </span>
+            )
           )}
           {step.runIf && (
             <button

--- a/designer/src/styles/action.css
+++ b/designer/src/styles/action.css
@@ -1193,6 +1193,31 @@
 .step-marker-badge:hover {
   background: #bfdbfe;
 }
+
+/* StepCard の kind 別マーカーバッジ (#261) */
+.step-marker-badges {
+  display: inline-flex;
+  gap: 3px;
+  flex-shrink: 0;
+  cursor: help;
+}
+.step-marker-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 0 5px;
+  font-size: 10px;
+  font-weight: 600;
+  border-radius: 9px;
+  line-height: 1.3;
+  flex-shrink: 0;
+  border: 1px solid transparent;
+}
+.step-marker-chip i { font-size: 9px; }
+.step-marker-chip.kind-todo { background: #d1fae5; color: #065f46; border-color: #6ee7b7; }
+.step-marker-chip.kind-question { background: #ede9fe; color: #5b21b6; border-color: #c4b5fd; }
+.step-marker-chip.kind-attention { background: #fef3c7; color: #92400e; border-color: #fcd34d; }
+.step-marker-chip.kind-chat { background: #dbeafe; color: #1e40af; border-color: #93c5fd; }
 .validation-code {
   font-family: ui-monospace, monospace;
   font-size: 0.7rem;


### PR DESCRIPTION
## 関連

- 関連: #261 (リアルタイム編集ワークフロー強化の一環)
- 先行: #292 (一覧マーカー件数バッジ — 同じ kind 色分け配色を流用)
- 仕様: N/A (UI 可視化)

## 概要

StepCard ヘッダの AI マーカーバッジを「件数のみ」から「kind 別色分けチップ」に拡張する。大規模 AG で 10 件中 todo 2 + question 8 のような分布を把握できるようにする。

## 主な変更

- `StepCard.tsx`: 新 prop `markerKinds?: { todo, question, attention, chat }`
  - 指定時は色分けチップ列、省略時は従来の単一 megaphone badge にフォールバック
  - 0 件の kind は非表示
- `SortableStepCard.tsx`: prop をパススルー
- `ActionEditor.tsx`: `stepMarkers` から kind 別件数を派生させて渡す (未解決 marker 数が > 0 の時のみ生成)
- CSS `.step-marker-chip`: kind-todo (緑) / kind-question (紫) / kind-attention (橙) / kind-chat (青) — 一覧バッジ (#292) と同じパレット

## 仕様逐条突合 (自己申告)

N/A — UI 可視化のみで spec 条項なし

## レビューで特に見てほしい箇所

- **フォールバック設計** (`StepCard.tsx`): `markerKinds` 未指定時も従来の単一 badge が動作するため、段階的な統合が可能 (ActionEditor 以外の呼出元を後から更新できる)
- **配色の整合**: 一覧バッジ (#292) とステップバッジ (本 PR) で同一パレット。Dashboard の MarkersSummaryPanel は別パレットだが、ここは緑/紫/橙/青の業界色準拠の方が優先

## テスト

- Vitest: 483 件 pass (変更なし)
- Playwright (新規): stepcard-marker-kind-badge **3 件**
  - 色分けチップ表示 + 件数確認
  - 未解決なし step はバッジ非表示
  - resolved marker 除外
- regression (marker-ergonomics): 全 3 件 pass

## UI 影響 / マージ保留フラグ

- [x] UI 影響あり (マージ前にユーザー目視確認必須)
- [ ] UI 影響なし

### UI 影響ありの場合、確認項目

- [ ] 複数 kind のマーカーがある step のヘッダに小さな色分けチップが並ぶ
- [ ] 0 件の kind は非表示 (すべて揃わない)
- [ ] チップ hover で各 kind 名 + 件数の tooltip が出る
- [ ] 解決済 marker は反映されない
- [ ] 一覧画面のバッジ (#292) と配色が一致している

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

- Dashboard `MarkersSummaryPanel` は独自配色 (#3b82f6 / #f59e0b / #10b981 / #8b5cf6)。将来的に一覧・StepCard と揃えるかは別 PR で検討
- 3 kind 以上あると横幅を食うため、チップはコンパクトサイズ (font 10px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)