### PR TITLE
feat(dashboard): MarkersSummaryPanel に最新マーカーリスト (#261)

### DIFF
--- a/designer/e2e/marker-ergonomics.spec.ts
+++ b/designer/e2e/marker-ergonomics.spec.ts
@@ -93,6 +93,25 @@ test.describe("Dashboard marker summary (#261)", () => {
     await expect(panel).toContainText("erg test"); // perGroup ランキング
   });
 
+  test("最新マーカーリストに body preview が表示される", async ({ page }) => {
+    await setupDashboard(page);
+    const recent = page.locator(".markers-summary-panel .markers-recent-list");
+    await expect(recent).toBeVisible();
+    // 2 件とも表示
+    await expect(recent.locator(".markers-recent-item")).toHaveCount(2);
+    // body preview と AG 名
+    await expect(recent).toContainText("A"); // body
+    await expect(recent).toContainText("B");
+    await expect(recent).toContainText("erg test"); // AG name
+  });
+
+  test("最新マーカーアイテムクリックで ActionEditor へ遷移", async ({ page }) => {
+    await setupDashboard(page);
+    const firstRecent = page.locator(".markers-summary-panel .markers-recent-list .markers-recent-btn").first();
+    await firstRecent.click();
+    await expect(page).toHaveURL(/\/process-flow\/edit\//);
+  });
+
   test("marker 0 件の AG は表示なし、未解決 0 件メッセージ表示", async ({ page }) => {
     // 解決済みだけの状態で開く
     const resolved = {

--- a/designer/src/components/dashboard/panels/MarkersSummaryPanel.tsx
+++ b/designer/src/components/dashboard/panels/MarkersSummaryPanel.tsx
@@ -10,21 +10,32 @@ import type { ActionGroup, MarkerKind } from "../../../types/action";
 import { listActionGroups, loadActionGroup } from "../../../store/actionStore";
 import { mcpBridge } from "../../../mcp/mcpBridge";
 
+interface RecentMarker {
+  id: string;
+  kind: MarkerKind;
+  body: string;
+  createdAt: string;
+  actionGroupId: string;
+  actionGroupName: string;
+}
+
 interface Summary {
   total: number;
   byKind: Record<MarkerKind, number>;
   perGroup: Array<{ id: string; name: string; count: number }>;
+  recent: RecentMarker[];
 }
 
 const INITIAL: Summary = {
   total: 0,
   byKind: { chat: 0, attention: 0, todo: 0, question: 0 },
   perGroup: [],
+  recent: [],
 };
 
 async function fetchSummary(): Promise<Summary> {
   const metas = await listActionGroups();
-  const s: Summary = { total: 0, byKind: { chat: 0, attention: 0, todo: 0, question: 0 }, perGroup: [] };
+  const s: Summary = { total: 0, byKind: { chat: 0, attention: 0, todo: 0, question: 0 }, perGroup: [], recent: [] };
   for (const meta of metas) {
     const g: ActionGroup | null = await loadActionGroup(meta.id);
     if (!g) continue;
@@ -33,10 +44,21 @@ async function fetchSummary(): Promise<Summary> {
     for (const m of unresolved) {
       s.byKind[m.kind] = (s.byKind[m.kind] ?? 0) + 1;
       s.total++;
+      s.recent.push({
+        id: m.id,
+        kind: m.kind,
+        body: m.body,
+        createdAt: m.createdAt,
+        actionGroupId: g.id,
+        actionGroupName: g.name,
+      });
     }
     s.perGroup.push({ id: g.id, name: g.name, count: unresolved.length });
   }
   s.perGroup.sort((a, b) => b.count - a.count);
+  // 新しい順 (desc)
+  s.recent.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  s.recent = s.recent.slice(0, 5);
   return s;
 }
 
@@ -121,6 +143,39 @@ export function MarkersSummaryPanel() {
             </li>
           )}
         </ul>
+      )}
+      {summary.recent.length > 0 && (
+        <div style={{ marginTop: 10, borderTop: "1px solid #e2e8f0", paddingTop: 6 }}>
+          <div style={{ fontSize: "0.72rem", color: "#94a3b8", marginBottom: 4, fontWeight: 600 }}>最新マーカー</div>
+          <ul className="markers-recent-list" style={{ listStyle: "none", margin: 0, padding: 0 }}>
+            {summary.recent.map((m) => (
+              <li
+                key={m.id}
+                className="markers-recent-item"
+                style={{ padding: "4px 0", borderBottom: "1px dotted #f1f5f9", fontSize: "0.78rem" }}
+              >
+                <button
+                  type="button"
+                  className="btn btn-sm btn-link p-0 markers-recent-btn"
+                  onClick={() => navigate(`/process-flow/edit/${m.actionGroupId}`)}
+                  style={{ textAlign: "left", width: "100%", textDecoration: "none" }}
+                  title={`${m.actionGroupName} — ${new Date(m.createdAt).toLocaleString("ja-JP")}`}
+                >
+                  <span style={{ color: KIND_COLOR[m.kind], fontWeight: 600, marginRight: 4 }}>
+                    <i className="bi bi-circle-fill" style={{ fontSize: "0.5rem", marginRight: 3 }} />
+                    {KIND_LABEL[m.kind]}
+                  </span>
+                  <span style={{ color: "#334155" }}>
+                    {m.body.length > 50 ? `${m.body.slice(0, 50)}…` : m.body}
+                  </span>
+                  <div style={{ color: "#94a3b8", fontSize: "0.7rem" }}>
+                    <i className="bi bi-diagram-3 me-1" />{m.actionGroupName}
+                  </div>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
       )}
       {summary.total === 0 && !loading && (
         <div style={{ marginTop: 6, color: "#94a3b8", fontSize: "0.8rem" }}>


### PR DESCRIPTION
## 関連

- 関連: #261 (リアルタイム編集ワークフロー)
- 仕様: N/A (UI 追加)

## 概要

Dashboard の MarkersSummaryPanel を拡張し、未解決マーカーの最新 5 件を body preview 付きで表示。クリックで該当 ActionEditor へ遷移できるようにする。perGroup (AG 単位件数) のみでは「内容」が見えなかった不足を補う。

## 主な変更

- `MarkersSummaryPanel.tsx`:
  - `RecentMarker` 型追加 (kind, body, createdAt, actionGroupId, actionGroupName)
  - `fetchSummary` で収集し createdAt desc で 5 件まで
  - UI: kind 色ドット + body 50 字 preview + AG 名 + クリックで navigate
- `marker-ergonomics.spec.ts`: +2 件 (最新リスト表示 / クリック遷移)

## 仕様逐条突合 (自己申告)

N/A — UI 追加のみ

## レビューで特に見てほしい箇所

- **件数 5 の決め打ち**: Dashboard カード 1 枚分に収まる上限。増やすと縦に伸びすぎるため保守的に 5
- **body 50 字トランケート**: ... を足すだけ。折り返しなし

## テスト

- Vitest: 483 pass (変更なし)
- Playwright (marker-ergonomics): 3 → **5 件** (新規 2)

## UI 影響 / マージ保留フラグ

- [x] UI 影響あり (マージ前にユーザー目視確認必須)
- [ ] UI 影響なし

### UI 影響ありの場合、確認項目

- [ ] Dashboard の MarkersSummaryPanel 下部に「最新マーカー」セクションが出る
- [ ] kind 色ドット + 本文 preview + AG 名が表示される
- [ ] クリックで該当 ActionEditor に遷移
- [ ] 未解決なしの時はセクション非表示

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

- 現状はブラウザ側で listActionGroups + loadActionGroup ループ。designer-mcp の find_all_markers (#296 別 PR) にリプレイスする余地あり (その PR マージ後に追従するのが妥当)

🤖 Generated with [Claude Code](https://claude.com/claude-code)