### PR TITLE
feat(drawing): DOM anchor で描画マーカーが step 要素を追従 (#261)

### DIFF
--- a/designer/e2e/drawing-anchor.spec.ts
+++ b/designer/e2e/drawing-anchor.spec.ts
@@ -1,0 +1,171 @@
+/**
+ * 描画マーカーの DOM アンカリング (#261)
+ *
+ * anchor 付き marker が対象 step/field の bbox を追従することを検証。
+ * MarkerPanel 展開などで step の画面内位置が変わっても、描画の視覚位置が
+ * step と一緒に動くこと (ずれないこと) が肝。
+ */
+import { test, expect, type Page } from "@playwright/test";
+
+const groupId = "ag-anchor";
+
+const dummyGroup = {
+  id: groupId, name: "anchor test", type: "screen", description: "",
+  mode: "upstream", maturity: "draft",
+  actions: [{
+    id: "act-1", name: "ボタン", trigger: "click", maturity: "draft",
+    responses: [{ id: "201-ok", status: 201 }],
+    steps: [
+      {
+        id: "step-sql-anchor",
+        type: "dbAccess",
+        description: "在庫更新",
+        tableName: "inventory",
+        operation: "UPDATE",
+        sql: "UPDATE inventory SET qty = qty - 1 WHERE id = @itemId",
+        maturity: "draft",
+      },
+    ],
+  }],
+  markers: [
+    // anchor 付き描画マーカー (step-sql-anchor の sql フィールドに紐付く)
+    {
+      id: "mk-anchored",
+      kind: "todo",
+      body: "SQL を条件付き UPDATE に修正",
+      stepId: "step-sql-anchor",
+      fieldPath: "sql",
+      author: "human",
+      createdAt: "2026-04-21T00:00:00Z",
+      shape: {
+        type: "path",
+        d: "M 5 20 L 95 20 L 95 80 L 5 80 L 5 20",
+        anchorStepId: "step-sql-anchor",
+        anchorFieldPath: "sql",
+      },
+    },
+    // anchor なしの旧形式マーカー (overlay 全体に描画される)
+    {
+      id: "mk-floating",
+      kind: "attention",
+      body: "前方互換: overlay 相対",
+      author: "human",
+      createdAt: "2026-04-21T00:00:00Z",
+      shape: {
+        type: "path",
+        d: "M 10 10 L 30 30",
+      },
+    },
+    // orphan: 存在しない stepId にアンカー (オーファン表示テスト用)
+    {
+      id: "mk-orphan",
+      kind: "todo",
+      body: "孤児になったマーカー",
+      stepId: "step-deleted",
+      author: "human",
+      createdAt: "2026-04-21T00:00:00Z",
+      shape: {
+        type: "path",
+        d: "M 5 5 L 95 95",
+        anchorStepId: "step-deleted",
+      },
+    },
+  ],
+  createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
+};
+
+const dummyProject = {
+  version: 1, name: "anchor", screens: [], groups: [], edges: [], tables: [],
+  actionGroups: [{ id: groupId, no: 1, name: dummyGroup.name, type: dummyGroup.type, actionCount: 1, updatedAt: dummyGroup.updatedAt, maturity: "draft" }],
+  updatedAt: new Date().toISOString(),
+};
+
+async function setup(page: Page) {
+  await page.addInitScript(({ project, group }) => {
+    localStorage.setItem("flow-project", JSON.stringify(project));
+    localStorage.setItem(`action-group-${group.id}`, JSON.stringify(group));
+    localStorage.removeItem("designer-open-tabs");
+    localStorage.removeItem("designer-active-tab");
+  }, { project: dummyProject, group: dummyGroup });
+  await page.goto(`/process-flow/edit/${groupId}`);
+  await expect(page.locator(".step-editor, .action-content").first()).toBeVisible({ timeout: 10000 });
+}
+
+test.describe("描画マーカー DOM anchor (#261)", () => {
+  test("anchor 付き marker が対象 step の field bbox に位置合わせされる", async ({ page }) => {
+    await setup(page);
+
+    // step を展開して sql フィールドを可視化
+    await page.locator('[data-step-id="step-sql-anchor"] .step-card-header').click();
+    await expect(page.locator('[data-step-id="step-sql-anchor"] [data-field-path="sql"]')).toBeVisible();
+
+    // 描画マーカーの SVG が sql フィールドの上に fixed positioned される
+    const anchored = page.locator('.drawing-anchored-shape[data-marker-id="mk-anchored"]');
+    await expect(anchored).toBeVisible();
+
+    const rects = await page.evaluate(() => {
+      const a = document.querySelector('.drawing-anchored-shape[data-marker-id="mk-anchored"]');
+      const s = document.querySelector('[data-step-id="step-sql-anchor"] [data-field-path="sql"]');
+      const ar = a?.getBoundingClientRect();
+      const sr = s?.getBoundingClientRect();
+      return { a: ar, s: sr };
+    });
+    // 1px 以内の誤差で一致 (fixed positioning + getBoundingClientRect)
+    expect(Math.abs(rects.a!.left - rects.s!.left)).toBeLessThan(1);
+    expect(Math.abs(rects.a!.top - rects.s!.top)).toBeLessThan(1);
+    expect(Math.abs(rects.a!.width - rects.s!.width)).toBeLessThan(1);
+    expect(Math.abs(rects.a!.height - rects.s!.height)).toBeLessThan(1);
+  });
+
+  test("MarkerPanel 展開で step が下にずれても anchor 付き marker は追従する", async ({ page }) => {
+    await setup(page);
+    await page.locator('[data-step-id="step-sql-anchor"] .step-card-header').click();
+    await expect(page.locator('[data-step-id="step-sql-anchor"] [data-field-path="sql"]')).toBeVisible();
+
+    // 展開前の top 位置
+    const beforeTop = await page.evaluate(() => {
+      return document.querySelector('[data-step-id="step-sql-anchor"] [data-field-path="sql"]')!.getBoundingClientRect().top;
+    });
+
+    // MarkerPanel を展開 → 上部に複数の marker 行が追加されて step が下にずれる
+    await page.locator('.marker-panel .catalog-panel-toggle').click();
+    await expect(page.locator('.marker-panel .catalog-panel-body')).toBeVisible();
+
+    // 追従判定: step が動いたことを確認、かつ anchored SVG も同じだけ動いた
+    await expect.poll(async () => {
+      return page.evaluate(() => {
+        const a = document.querySelector('.drawing-anchored-shape[data-marker-id="mk-anchored"]');
+        const s = document.querySelector('[data-step-id="step-sql-anchor"] [data-field-path="sql"]');
+        if (!a || !s) return { shifted: false, match: false };
+        const ar = a.getBoundingClientRect();
+        const sr = s.getBoundingClientRect();
+        return { shifted: sr.top !== 0, match: Math.abs(ar.top - sr.top) < 1 };
+      });
+    }, { timeout: 5000 }).toEqual({ shifted: true, match: true });
+
+    const afterTop = await page.evaluate(() => {
+      return document.querySelector('[data-step-id="step-sql-anchor"] [data-field-path="sql"]')!.getBoundingClientRect().top;
+    });
+    expect(afterTop).not.toBe(beforeTop); // 実際にずれていることを確認
+  });
+
+  test("anchor なしの旧形式 marker は overlay 内に描画される (前方互換)", async ({ page }) => {
+    await setup(page);
+    // mk-floating は overlay SVG 内の path として描画される
+    const floating = page.locator('.drawing-overlay path.drawing-existing-shape').first();
+    await expect(floating).toBeVisible();
+  });
+
+  test("anchor 対象 step が存在しない (orphan) marker は画面上に表示されないが MarkerPanel に残る", async ({ page }) => {
+    await setup(page);
+
+    // orphan marker は AnchoredMarker として描画されない
+    await expect(page.locator('.drawing-anchored-shape[data-marker-id="mk-orphan"]')).toHaveCount(0);
+
+    // MarkerPanel を展開して orphan バッジ確認
+    await page.locator('.marker-panel .catalog-panel-toggle').click();
+    const orphanRow = page.locator('.marker-panel .marker-row').filter({ hasText: "孤児になったマーカー" });
+    await expect(orphanRow).toBeVisible();
+    await expect(orphanRow.locator('.marker-orphan-badge')).toBeVisible();
+  });
+});

--- a/designer/e2e/marker-ergonomics.spec.ts
+++ b/designer/e2e/marker-ergonomics.spec.ts
@@ -75,6 +75,8 @@ test.describe("StepCard から marker 起票 (#261)", () => {
     });
     await page.waitForTimeout(300);
 
+    // MarkerPanel は既定折りたたみ、展開して行を確認
+    await page.locator(".marker-panel .catalog-panel-toggle").click();
     // marker が 3 件 (既存 2 + 新規 1)
     await expect(page.locator(".marker-panel .marker-row")).toHaveCount(3);
     // 新しいのは stepId=s1 紐付き、body は dialog で answered

--- a/designer/e2e/marker-panel.spec.ts
+++ b/designer/e2e/marker-panel.spec.ts
@@ -26,13 +26,17 @@ async function setup(page: Page) {
   }, { project: dummyProject, group: dummyGroup });
   await page.goto(`/process-flow/edit/${groupId}`);
   await expect(page.locator(".step-editor, .action-content").first()).toBeVisible({ timeout: 10000 });
+  // MarkerPanel は既定で折りたたみ (#261 anchor 対応): 明示的に展開する
+  await page.locator(".marker-panel .catalog-panel-toggle").click();
+  await expect(page.locator(".marker-panel .catalog-panel-body")).toBeVisible();
 }
 
 test.describe("MarkerPanel (#261)", () => {
-  test("初期は展開、0 件表示", async ({ page }) => {
+  test("パネル既定折りたたみ、展開後に 0 件メッセージ表示", async ({ page }) => {
     await setup(page);
     await expect(page.locator(".marker-panel")).toBeVisible();
     await expect(page.locator(".marker-panel .catalog-panel-toggle")).toContainText("0 未解決");
+    // setup で展開済 → empty メッセージ可視
     await expect(page.locator(".marker-panel .catalog-empty")).toBeVisible();
   });
 

--- a/designer/e2e/warning-to-marker.spec.ts
+++ b/designer/e2e/warning-to-marker.spec.ts
@@ -50,6 +50,9 @@ test.describe("警告 → Marker 起票 (#261)", () => {
       btn?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, view: window }));
     });
 
+    // MarkerPanel は既定折りたたみなので展開して確認
+    await page.locator(".marker-panel .catalog-panel-toggle").click();
+
     // marker が 1 件起票
     await expect(page.locator(".marker-panel .marker-row")).toHaveCount(1);
     await expect(page.locator(".marker-panel .marker-kind-badge")).toContainText("TODO");
@@ -68,8 +71,9 @@ test.describe("警告 → Marker 起票 (#261)", () => {
     await page.evaluate(() => {
       document.querySelector(".action-validation-panel-bulk-ai")?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, view: window }));
     });
+    // MarkerPanel 展開
+    await page.locator(".marker-panel .catalog-panel-toggle").click();
     // 警告は少なくとも 2 件起票される (UNKNOWN_IDENTIFIER + UNKNOWN_RESPONSE_REF)
-    await expect(page.locator(".marker-panel .marker-row")).toHaveCount(await page.locator(".marker-panel .marker-row").count());
     const rows = await page.locator(".marker-panel .marker-row").count();
     expect(rows).toBeGreaterThanOrEqual(2);
   });

--- a/designer/src/components/action/ActionEditor.tsx
+++ b/designer/src/components/action/ActionEditor.tsx
@@ -524,17 +524,29 @@ export function ActionEditor() {
 
   if (!group) return null;
 
-  const handleCommitStrokes = (shape: { type: "path"; d: string; color?: string; strokeWidth?: number }) => {
+  const handleCommitStrokes = (shape: {
+    type: "path";
+    d: string;
+    color?: string;
+    strokeWidth?: number;
+    anchorStepId?: string;
+    anchorFieldPath?: string;
+  }) => {
     const body = window.prompt(
       "描画マーカーへの指示を入力:\n(例: ここの SQL を affectedRowsCheck で補強して)",
     );
     if (!body || !body.trim()) return;
     updateGroup((g) => {
+      // anchor があれば Marker.stepId / fieldPath にも自動反映:
+      // /designer-work スラッシュコマンドは stepId / fieldPath を既存で読むので、
+      // AI 側は「どの step のどのフィールドへの指示か」を即座に把握できる。
       g.markers = [...(g.markers ?? []), {
         id: generateUUID(),
         kind: "todo",
         body: body.trim(),
         shape,
+        stepId: shape.anchorStepId,
+        fieldPath: shape.anchorFieldPath,
         author: "human",
         createdAt: new Date().toISOString(),
       }];

--- a/designer/src/components/action/DrawingOverlay.tsx
+++ b/designer/src/components/action/DrawingOverlay.tsx
@@ -5,14 +5,18 @@
  * - ペンツール: ドラッグで自由描画。複数ストロークは path "d" 内で M 区切り合体
  *   色 / 太さ をツールバーで選択可能 (MarkerShape.color / strokeWidth に格納)
  * - 消しゴムツール: 既存 shape 付き marker をクリックで削除
- * - 確定ボタン: 現在のストローク群を 1 マーカー (kind=todo) として起票
+ * - 確定ボタン: 現在のストローク群を 1 マーカー (kind=todo) として起票。
+ *   ストローク中点の直下 DOM 要素から anchorStepId / anchorFieldPath を決定し、
+ *   座標を anchor 要素の bbox 相対に変換 (anchor が取れなければ overlay 相対のまま保存)。
  * - キャンセルボタン: ストロークを破棄して描画モード終了
  *
- * 座標は container の bounding rect に対する 0-100 % で保存 (リサイズ耐性)。
- * SVG path "d" が複数の M セグメントを含む = 複数ストロークがまとまった 1 marker。
+ * 既存 marker の render:
+ * - anchor あり: 要素の bbox 上に fixed 位置の SVG を配置、reflow/scroll/resize で追従
+ * - anchor なし: 従来通り overlay 全体の SVG に描画
  */
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { Marker } from "../../types/action";
+import { convertPathToAnchorRelative, strokesCenterInViewport } from "../../utils/markerAnchor";
 
 type Tool = "pen" | "eraser";
 
@@ -31,15 +35,121 @@ const WIDTH_PRESETS: Array<{ value: number; label: string; icon: string }> = [
 ];
 const DEFAULT_WIDTH = WIDTH_PRESETS[0].value;
 
+interface CommitShape {
+  type: "path";
+  d: string;
+  color?: string;
+  strokeWidth?: number;
+  anchorStepId?: string;
+  anchorFieldPath?: string;
+}
+
 interface Props {
   markers: Marker[];
   drawing: boolean;
   /** 完成した shape を受け取り、body を聞いて marker を作る */
-  onCommitStrokes: (shape: { type: "path"; d: string; color?: string; strokeWidth?: number }) => void;
+  onCommitStrokes: (shape: CommitShape) => void;
   /** eraser で既存 marker を消去 */
   onEraseMarker: (markerId: string) => void;
   /** 描画モード終了時のコールバック (キャンセル時、または commit 完了後) */
   onExitDrawing: () => void;
+}
+
+/**
+ * anchor 付き marker の個別レンダラ。
+ * 対象要素を querySelector で探し、bbox 上に fixed positioned な SVG を被せる。
+ * reflow / scroll / resize を監視して位置追従。対象が無ければ null (orphan)。
+ */
+function AnchoredMarker({
+  marker,
+  eraserMode,
+  onEraseMarker,
+}: {
+  marker: Marker;
+  eraserMode: boolean;
+  onEraseMarker: (id: string) => void;
+}) {
+  const [rect, setRect] = useState<DOMRect | null>(null);
+
+  useLayoutEffect(() => {
+    const stepId = marker.shape?.anchorStepId;
+    if (!stepId) return;
+    const fieldPath = marker.shape?.anchorFieldPath;
+    const selector = fieldPath
+      ? `[data-step-id="${CSS.escape(stepId)}"] [data-field-path="${CSS.escape(fieldPath)}"]`
+      : `[data-step-id="${CSS.escape(stepId)}"]`;
+
+    let raf = 0;
+    const measure = () => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(() => {
+        const el = document.querySelector<HTMLElement>(selector);
+        if (el) {
+          const r = el.getBoundingClientRect();
+          // 0 幅/高さの要素 (非表示等) は orphan 扱い
+          if (r.width > 0 && r.height > 0) { setRect(r); return; }
+        }
+        setRect(null);
+      });
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(document.body);
+    const mo = new MutationObserver(measure);
+    // .action-page 全体を観察 (.action-editor-info の MarkerPanel 展開も含む)。
+    // attributeFilter で style/class 変化のみに絞り、入力文字列の変更などノイズを避ける。
+    const scope = document.querySelector(".action-page") ?? document.body;
+    mo.observe(scope, { childList: true, subtree: true, attributes: true, attributeFilter: ["style", "class"] });
+    window.addEventListener("scroll", measure, true);
+    window.addEventListener("resize", measure);
+    return () => {
+      cancelAnimationFrame(raf);
+      ro.disconnect();
+      mo.disconnect();
+      window.removeEventListener("scroll", measure, true);
+      window.removeEventListener("resize", measure);
+    };
+  }, [marker.shape?.anchorStepId, marker.shape?.anchorFieldPath]);
+
+  const shape = marker.shape;
+  if (!shape || !rect) return null;
+
+  return (
+    <svg
+      className="drawing-anchored-shape"
+      data-marker-id={marker.id}
+      viewBox="0 0 100 100"
+      preserveAspectRatio="none"
+      style={{
+        position: "fixed",
+        left: rect.left,
+        top: rect.top,
+        width: rect.width,
+        height: rect.height,
+        pointerEvents: eraserMode ? "auto" : "none",
+        zIndex: 30,
+        overflow: "visible",
+      }}
+    >
+      <path
+        className="drawing-existing-shape"
+        d={shape.d}
+        stroke={shape.color ?? "#ef4444"}
+        strokeWidth={shape.strokeWidth ?? 2}
+        fill="none"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        opacity={0.75}
+        vectorEffect="non-scaling-stroke"
+        style={{ pointerEvents: eraserMode ? "stroke" : "none", cursor: eraserMode ? "pointer" : "default" }}
+        onClick={(e) => {
+          if (eraserMode) { e.stopPropagation(); onEraseMarker(marker.id); }
+        }}
+      >
+        <title>{`[${marker.kind}] ${marker.body}${eraserMode ? " (クリックで削除)" : ""}`}</title>
+      </path>
+    </svg>
+  );
 }
 
 export function DrawingOverlay({ markers, drawing, onCommitStrokes, onEraseMarker, onExitDrawing }: Props) {
@@ -47,8 +157,10 @@ export function DrawingOverlay({ markers, drawing, onCommitStrokes, onEraseMarke
   const [tool, setTool] = useState<Tool>("pen");
   const [color, setColor] = useState<string>(DEFAULT_COLOR);
   const [width, setWidth] = useState<number>(DEFAULT_WIDTH);
-  const [strokes, setStrokes] = useState<string[]>([]); // 完了した個別ストローク (各々 "M ... L ... L ...")
-  const [currentStroke, setCurrentStroke] = useState<string>(""); // 描画中
+  // 完了した個別ストローク。各ストロークが確定時点の色・幅を保持することで、
+  // 以降にツールバーで色・幅を切り替えても既存ストロークに影響が及ばない (#261 修正)
+  const [strokes, setStrokes] = useState<Array<{ d: string; color: string; width: number }>>([]);
+  const [currentStroke, setCurrentStroke] = useState<string>(""); // 描画中 (色・幅は現在の toolbar 設定)
   const isDrawingRef = useRef(false);
 
   // 描画モード終了時に state リセット
@@ -89,19 +201,57 @@ export function DrawingOverlay({ markers, drawing, onCommitStrokes, onEraseMarke
     if (!drawing || tool !== "pen" || !isDrawingRef.current) return;
     isDrawingRef.current = false;
     if (currentStroke && currentStroke.includes("L")) {
-      setStrokes((s) => [...s, currentStroke]);
+      // 確定時点の色・幅を固定して保存
+      setStrokes((s) => [...s, { d: currentStroke, color, width }]);
     }
     setCurrentStroke("");
   };
 
   const commit = () => {
     if (strokes.length === 0) { onExitDrawing(); return; }
+    // 各ストロークの d を連結 (複数 M セグメント = 1 marker)。
+    // 色/幅は最新ストロークの値を採用 (ユーザーの最後の選択を尊重)。
+    const d = strokes.map((s) => s.d).join(" ");
+    const last = strokes[strokes.length - 1];
+    const overlayEl = svgRef.current;
+    const overlayRect = overlayEl?.getBoundingClientRect();
+
+    let anchorStepId: string | undefined;
+    let anchorFieldPath: string | undefined;
+    let finalD = d;
+
+    if (overlayEl && overlayRect) {
+      const center = strokesCenterInViewport(strokes.map((s) => s.d), overlayRect);
+      if (center) {
+        // overlay 自身を pointer-events から除外して下の要素を取得
+        const prevPE = overlayEl.style.pointerEvents;
+        overlayEl.style.pointerEvents = "none";
+        const el = document.elementFromPoint(center.x, center.y);
+        overlayEl.style.pointerEvents = prevPE;
+        if (el) {
+          const stepEl = el.closest<HTMLElement>("[data-step-id]");
+          if (stepEl) {
+            anchorStepId = stepEl.dataset.stepId;
+            const fieldEl = el.closest<HTMLElement>("[data-field-path]");
+            // field は step 内のみ採用
+            if (fieldEl && stepEl.contains(fieldEl)) {
+              anchorFieldPath = fieldEl.dataset.fieldPath;
+            }
+            const anchorEl = anchorFieldPath ? (fieldEl as HTMLElement) : stepEl;
+            finalD = convertPathToAnchorRelative(d, overlayRect, anchorEl.getBoundingClientRect());
+          }
+        }
+      }
+    }
+
     onCommitStrokes({
       type: "path",
-      d: strokes.join(" "),
+      d: finalD,
       // デフォルトから変更されている時のみ保存 (既存 marker の shape を冗長化しない)
-      color: color !== DEFAULT_COLOR ? color : undefined,
-      strokeWidth: width !== DEFAULT_WIDTH ? width : undefined,
+      color: last.color !== DEFAULT_COLOR ? last.color : undefined,
+      strokeWidth: last.width !== DEFAULT_WIDTH ? last.width : undefined,
+      anchorStepId,
+      anchorFieldPath,
     });
     // ActionEditor 側が drawing=false にするので useEffect でリセットされる
   };
@@ -116,10 +266,12 @@ export function DrawingOverlay({ markers, drawing, onCommitStrokes, onEraseMarke
     setStrokes((s) => s.slice(0, -1));
   };
 
-  // 既存の shape 付き marker (表示 + eraser クリックターゲット)
-  const existingShapes = markers
-    .filter((m) => m.shape && m.shape.type === "path" && !m.resolvedAt)
-    .map((m) => ({ id: m.id, shape: m.shape!, body: m.body, kind: m.kind }));
+  // 既存 marker を anchor 有無で分割
+  const visibleMarkers = markers.filter((m) => m.shape && m.shape.type === "path" && !m.resolvedAt);
+  const anchoredMarkers = visibleMarkers.filter((m) => m.shape?.anchorStepId);
+  const floatingMarkers = visibleMarkers.filter((m) => !m.shape?.anchorStepId);
+
+  const eraserMode = drawing && tool === "eraser";
 
   const containerStyle: React.CSSProperties = {
     position: "absolute",
@@ -131,6 +283,11 @@ export function DrawingOverlay({ markers, drawing, onCommitStrokes, onEraseMarke
 
   return (
     <>
+      {/* anchor 付き marker (DOM 要素に追従) */}
+      {anchoredMarkers.map((m) => (
+        <AnchoredMarker key={m.id} marker={m} eraserMode={eraserMode} onEraseMarker={onEraseMarker} />
+      ))}
+
       <svg
         ref={svgRef}
         className="drawing-overlay"
@@ -142,37 +299,40 @@ export function DrawingOverlay({ markers, drawing, onCommitStrokes, onEraseMarke
         onPointerUp={onPointerUp}
         onPointerLeave={onPointerUp}
       >
-        {/* 既存 shape */}
-        {existingShapes.map((s) => (
-          <path
-            key={s.id}
-            className="drawing-existing-shape"
-            d={s.shape.d}
-            stroke={s.shape.color ?? "#ef4444"}
-            strokeWidth={s.shape.strokeWidth ?? 2}
-            fill="none"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            opacity={0.75}
-            vectorEffect="non-scaling-stroke"
-            style={{ pointerEvents: drawing && tool === "eraser" ? "stroke" : "none", cursor: drawing && tool === "eraser" ? "pointer" : "default" }}
-            onClick={(e) => {
-              if (drawing && tool === "eraser") {
-                e.stopPropagation();
-                onEraseMarker(s.id);
-              }
-            }}
-          >
-            <title>{`[${s.kind}] ${s.body}${drawing && tool === "eraser" ? " (クリックで削除)" : ""}`}</title>
-          </path>
-        ))}
-        {/* 確定済みストローク (まだ commit 前、描画セッション内) */}
+        {/* anchor なし marker (overlay 全体の % で描画) */}
+        {floatingMarkers.map((m) => {
+          const s = m.shape!;
+          return (
+            <path
+              key={m.id}
+              className="drawing-existing-shape"
+              d={s.d}
+              stroke={s.color ?? "#ef4444"}
+              strokeWidth={s.strokeWidth ?? 2}
+              fill="none"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              opacity={0.75}
+              vectorEffect="non-scaling-stroke"
+              style={{ pointerEvents: eraserMode ? "stroke" : "none", cursor: eraserMode ? "pointer" : "default" }}
+              onClick={(e) => {
+                if (eraserMode) {
+                  e.stopPropagation();
+                  onEraseMarker(m.id);
+                }
+              }}
+            >
+              <title>{`[${m.kind}] ${m.body}${eraserMode ? " (クリックで削除)" : ""}`}</title>
+            </path>
+          );
+        })}
+        {/* 確定済みストローク (まだ commit 前、描画セッション内) — 各ストロークが個別の色/幅を保持 */}
         {strokes.map((s, i) => (
           <path
             key={`s-${i}`}
-            d={s}
-            stroke={color}
-            strokeWidth={width}
+            d={s.d}
+            stroke={s.color}
+            strokeWidth={s.width}
             fill="none"
             strokeLinecap="round"
             strokeLinejoin="round"

--- a/designer/src/components/action/MarkerPanel.tsx
+++ b/designer/src/components/action/MarkerPanel.tsx
@@ -8,9 +8,32 @@
  * Claude Code が /designer-work でこれを MCP 経由で読み取り、
  * 対応後 resolvedAt を埋めて resolution コメントを付ける。
  */
-import { useState } from "react";
-import type { ActionGroup, Marker, MarkerKind } from "../../types/action";
+import { useMemo, useState } from "react";
+import type { ActionGroup, Marker, MarkerKind, Step } from "../../types/action";
 import { generateUUID } from "../../utils/uuid";
+
+/** ActionGroup 内の全 step.id を再帰的に収集 (anchor orphan 判定用) */
+function collectStepIds(group: ActionGroup): Set<string> {
+  const ids = new Set<string>();
+  const visit = (steps: Step[]) => {
+    for (const s of steps) {
+      ids.add(s.id);
+      if (s.subSteps) visit(s.subSteps);
+      if (s.type === "branch") {
+        for (const b of s.branches) visit(b.steps);
+        if (s.elseBranch) visit(s.elseBranch.steps);
+      }
+      if (s.type === "loop") visit(s.steps);
+      if (s.type === "externalSystem" && s.outcomes) {
+        for (const oc of Object.values(s.outcomes)) {
+          if (oc?.sideEffects) visit(oc.sideEffects);
+        }
+      }
+    }
+  };
+  for (const a of group.actions) visit(a.steps);
+  return ids;
+}
 
 interface Props {
   group: ActionGroup;
@@ -31,7 +54,9 @@ const KIND_ICONS: Record<MarkerKind, string> = {
 };
 
 export function MarkerPanel({ group, onChange }: Props) {
-  const [expanded, setExpanded] = useState(true);
+  // 既定で折りたたみ (#261 anchor 改善とセット): マーカー追加/解決時の
+  // 縦方向レイアウト揺れを抑えて、描画マーカーの画面内位置ずれを減らす。
+  const [expanded, setExpanded] = useState(false);
   const [newKind, setNewKind] = useState<MarkerKind>("chat");
   const [newBody, setNewBody] = useState("");
   const [showResolved, setShowResolved] = useState(false);
@@ -41,6 +66,12 @@ export function MarkerPanel({ group, onChange }: Props) {
   const markers = group.markers ?? [];
   const displayed = showResolved ? markers : markers.filter((m) => !m.resolvedAt);
   const unresolved = markers.filter((m) => !m.resolvedAt).length;
+  // anchor の追跡先 step が現存するかを判定するために step id セットを memo 化
+  const existingStepIds = useMemo(() => collectStepIds(group), [group]);
+  const isOrphanAnchor = (m: Marker): boolean => {
+    const anchorId = m.shape?.anchorStepId ?? m.stepId;
+    return !!anchorId && !existingStepIds.has(anchorId);
+  };
 
   const addMarker = () => {
     const body = newBody.trim();
@@ -145,6 +176,14 @@ export function MarkerPanel({ group, onChange }: Props) {
                     <span className="marker-step-ref small text-muted">
                       step: {m.stepId}
                       {m.fieldPath && `.${m.fieldPath}`}
+                    </span>
+                  )}
+                  {isOrphanAnchor(m) && !resolved && (
+                    <span
+                      className="marker-orphan-badge small"
+                      title="紐付く step が削除されたため、描画マーカーは画面に表示されません"
+                    >
+                      <i className="bi bi-unlock" /> 該当 step なし
                     </span>
                   )}
                   {resolved ? (

--- a/designer/src/components/action/StepCard.tsx
+++ b/designer/src/components/action/StepCard.tsx
@@ -398,6 +398,7 @@ export function StepCard({
     <div>
       <div
         className={cardClass}
+        data-step-id={step.id}
         style={{ borderLeftColor: color }}
         onContextMenu={onContextMenu}
       >
@@ -672,7 +673,7 @@ export function StepCard({
                 />
               </div>
             </div>
-            <div className="row g-2 mb-2">
+            <div className="row g-2 mb-2" data-field-path="runIf">
               <div className="col-12">
                 <label className="form-label small">
                   <i className="bi bi-funnel me-1" />
@@ -754,7 +755,7 @@ export function StepCard({
             {/* ── バリデーション ───────────────────────────────── */}
             {step.type === "validation" && (
               <>
-                <div className="row g-2 mb-2">
+                <div className="row g-2 mb-2" data-field-path="conditions">
                   <div className="col-12">
                     <label className="form-label">バリデーション条件 (自由記述)</label>
                     <input
@@ -890,7 +891,7 @@ export function StepCard({
                     />
                   </div>
                 </div>
-                <div className="form-group">
+                <div className="form-group" data-field-path="sql">
                   <label className="form-label">完全 SQL (sql、fields より優先)</label>
                   <textarea
                     className="form-control form-control-sm"
@@ -1169,7 +1170,7 @@ export function StepCard({
 
             {/* ── 計算ステップ (ComputeStep) ───────────────────── */}
             {step.type === "compute" && (
-              <div className="row g-2 mb-2">
+              <div className="row g-2 mb-2" data-field-path="expression">
                 <div className="col-12">
                   <label className="form-label">
                     <i className="bi bi-calculator me-1" />
@@ -1206,7 +1207,7 @@ export function StepCard({
                       placeholder="例: 409-stock-shortage"
                     />
                   </div>
-                  <div className="col-6">
+                  <div className="col-6" data-field-path="bodyExpression">
                     <label className="form-label">bodyExpression</label>
                     <input
                       type="text"

--- a/designer/src/styles/action.css
+++ b/designer/src/styles/action.css
@@ -1379,6 +1379,31 @@
 .marker-timestamps { padding-top: 4px; }
 .marker-add-row { flex-wrap: wrap; gap: 4px; }
 
+/* anchor orphan バッジ (#261) */
+.marker-orphan-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 6px;
+  background: #fee2e2;
+  color: #991b1b;
+  border-radius: 8px;
+  font-size: 0.72rem;
+  font-weight: 600;
+}
+.marker-orphan-badge i { font-size: 0.7rem; }
+
+/* anchor 付き描画マーカー (fixed positioned、bbox 上にオーバーレイ) */
+.drawing-anchored-shape {
+  /* position / left / top / width / height は JS 側で設定 */
+}
+.drawing-anchored-shape .drawing-existing-shape {
+  transition: opacity 0.15s ease;
+}
+.drawing-anchored-shape .drawing-existing-shape:hover {
+  opacity: 1 !important;
+}
+
 /* インライン解決フォーム (#261) */
 .marker-resolve-form {
   margin-top: 6px;

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -881,12 +881,26 @@ export interface Marker {
  */
 export interface MarkerShape {
   type: "path";
-  /** SVG path の `d` 属性値 (各座標は 0-100 の % 表記、viewBox="0 0 100 100") */
+  /**
+   * SVG path の `d` 属性値。座標は 0-100 の % 表記、viewBox="0 0 100 100"。
+   * `anchorStepId` 指定時はその DOM 要素 (step card / field) の bbox に対する %、
+   * 未指定時は画面全体 (ActionEditor コンテンツ領域) に対する %。
+   */
   d: string;
   /** 描画色 (省略時は #ef4444 赤) */
   color?: string;
   /** 線幅 (省略時は 2) */
   strokeWidth?: number;
+  /**
+   * DOM anchor: 描画を特定 step に紐付ける (#261 anchor 改善)。
+   * 指定時は `d` 座標がこの step (+ field) の bbox 相対。step が削除されると orphan になる。
+   */
+  anchorStepId?: string;
+  /**
+   * DOM anchor の field 細分。step 内の特定フィールド (例: "sql", "conditions",
+   * "expression") に紐付ける場合に指定。step レベルで十分な場合は省略。
+   */
+  anchorFieldPath?: string;
 }
 
 /**

--- a/designer/src/utils/markerAnchor.test.ts
+++ b/designer/src/utils/markerAnchor.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import {
+  parsePathPoints,
+  computeBBox,
+  convertPathToAnchorRelative,
+  strokesCenterInViewport,
+} from "./markerAnchor";
+
+describe("parsePathPoints", () => {
+  it("M / L の座標を全て抽出", () => {
+    const d = "M 10 20 L 30 40 L 50 60";
+    expect(parsePathPoints(d)).toEqual([
+      { x: 10, y: 20 }, { x: 30, y: 40 }, { x: 50, y: 60 },
+    ]);
+  });
+  it("複数 M (マルチストローク合体) も対応", () => {
+    const d = "M 1 2 L 3 4 M 5 6 L 7 8";
+    expect(parsePathPoints(d)).toHaveLength(4);
+  });
+  it("小数点を含む座標を抽出", () => {
+    expect(parsePathPoints("M 12.34 56.78")).toEqual([{ x: 12.34, y: 56.78 }]);
+  });
+  it("空文字 / コマンドなしは空配列", () => {
+    expect(parsePathPoints("")).toEqual([]);
+    expect(parsePathPoints("Z")).toEqual([]);
+  });
+});
+
+describe("computeBBox", () => {
+  it("点群の min/max/center を返す", () => {
+    const bb = computeBBox([{ x: 0, y: 0 }, { x: 100, y: 50 }, { x: 50, y: 100 }]);
+    expect(bb).toEqual({
+      min: { x: 0, y: 0 },
+      max: { x: 100, y: 100 },
+      center: { x: 50, y: 50 },
+    });
+  });
+  it("1 点なら min=max=center", () => {
+    const bb = computeBBox([{ x: 42, y: 42 }]);
+    expect(bb?.center).toEqual({ x: 42, y: 42 });
+  });
+  it("空配列は null", () => {
+    expect(computeBBox([])).toBeNull();
+  });
+});
+
+describe("convertPathToAnchorRelative", () => {
+  it("overlay が全画面、anchor が中央 50% の場合 (コーナー)", () => {
+    // overlay: viewport 全体 (0,0) 1000x1000
+    // anchor:  viewport 中央 (250, 250) 500x500 = 25-75% of viewport
+    // overlay 座標 (50, 50) = viewport 中央 (500, 500) = anchor 中央 (50%, 50%)
+    const out = convertPathToAnchorRelative(
+      "M 50 50",
+      { left: 0, top: 0, width: 1000, height: 1000 },
+      { left: 250, top: 250, width: 500, height: 500 },
+    );
+    expect(out).toBe("M 50.00 50.00");
+  });
+
+  it("overlay 左上 (0,0) は anchor 基準で負値", () => {
+    // anchor が (250, 250) から始まる → overlay の (0,0) は anchor の (-50%, -50%)
+    const out = convertPathToAnchorRelative(
+      "M 0 0",
+      { left: 0, top: 0, width: 1000, height: 1000 },
+      { left: 250, top: 250, width: 500, height: 500 },
+    );
+    expect(out).toBe("M -50.00 -50.00");
+  });
+
+  it("複数コマンドを全部変換", () => {
+    const out = convertPathToAnchorRelative(
+      "M 25 25 L 75 75",
+      { left: 0, top: 0, width: 1000, height: 1000 },
+      { left: 250, top: 250, width: 500, height: 500 },
+    );
+    // (25,25) in overlay = vp (250,250) = anchor (0%, 0%)
+    // (75,75) in overlay = vp (750,750) = anchor (100%, 100%)
+    expect(out).toBe("M 0.00 0.00 L 100.00 100.00");
+  });
+
+  it("anchor width=0 はそのまま返す (zero divide 回避)", () => {
+    const out = convertPathToAnchorRelative(
+      "M 50 50",
+      { left: 0, top: 0, width: 1000, height: 1000 },
+      { left: 0, top: 0, width: 0, height: 100 },
+    );
+    expect(out).toBe("M 50 50");
+  });
+});
+
+describe("strokesCenterInViewport", () => {
+  it("全ストロークの中点を viewport px で返す", () => {
+    const strokes = ["M 0 0 L 100 0", "M 0 100 L 100 100"];
+    const center = strokesCenterInViewport(strokes, {
+      left: 200, top: 300, width: 400, height: 500,
+    });
+    // bbox center in overlay % = (50, 50)
+    // = viewport (200 + 0.5*400, 300 + 0.5*500) = (400, 550)
+    expect(center).toEqual({ x: 400, y: 550 });
+  });
+  it("空のストロークは null", () => {
+    expect(strokesCenterInViewport([], { left: 0, top: 0, width: 100, height: 100 })).toBeNull();
+    expect(strokesCenterInViewport([""], { left: 0, top: 0, width: 100, height: 100 })).toBeNull();
+  });
+});

--- a/designer/src/utils/markerAnchor.ts
+++ b/designer/src/utils/markerAnchor.ts
@@ -1,0 +1,100 @@
+/**
+ * 描画マーカーの DOM アンカリング (#261)。
+ *
+ * 描画ストロークが特定の step 要素 / field 要素の上で行われた場合、
+ * その要素の id (step.id / fieldPath) を保存して、ストローク座標を
+ * その要素の bounding box に対する % に変換する。これにより:
+ *
+ * - MarkerPanel の折畳/展開、step 並び替え、前後への step 挿入で
+ *   描画の視覚位置が step 要素と一緒に動く (ずれない)
+ * - step 削除時は orphan として扱える (該当なし表示)
+ *
+ * この file は副作用のない純粋関数のみ置き、DOM 依存部分は最小限。
+ * 呼び出し側が DOMRect を取得して渡す前提 (テスト容易性のため)。
+ */
+
+export interface Point { x: number; y: number }
+export interface Rect { left: number; top: number; width: number; height: number }
+
+/**
+ * SVG path の `d` 属性文字列から `M x y` / `L x y` の座標を抽出する。
+ * 他のコマンド (C / Z 等) は現状未使用だが、将来拡張する場合は
+ * ここを拡張する。
+ */
+export function parsePathPoints(d: string): Point[] {
+  const points: Point[] = [];
+  const re = /([ML])\s+(-?\d+(?:\.\d+)?)\s+(-?\d+(?:\.\d+)?)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(d)) !== null) {
+    points.push({ x: parseFloat(m[2]), y: parseFloat(m[3]) });
+  }
+  return points;
+}
+
+/** 点群の bounding box. 空配列なら null */
+export function computeBBox(points: Point[]): { min: Point; max: Point; center: Point } | null {
+  if (points.length === 0) return null;
+  let minX = points[0].x, maxX = points[0].x;
+  let minY = points[0].y, maxY = points[0].y;
+  for (const p of points) {
+    if (p.x < minX) minX = p.x;
+    if (p.x > maxX) maxX = p.x;
+    if (p.y < minY) minY = p.y;
+    if (p.y > maxY) maxY = p.y;
+  }
+  return {
+    min: { x: minX, y: minY },
+    max: { x: maxX, y: maxY },
+    center: { x: (minX + maxX) / 2, y: (minY + maxY) / 2 },
+  };
+}
+
+/**
+ * path `d` 内の座標を viewBox 空間 (overlay の 0-100) から
+ * anchor rect の 0-100 % に変換する。
+ *
+ * @param d  元の path 文字列 (overlay viewBox 0-100 相対)
+ * @param overlay  overlay 全体の viewport rect
+ * @param anchor  anchor 要素の viewport rect
+ */
+export function convertPathToAnchorRelative(
+  d: string,
+  overlay: Rect,
+  anchor: Rect,
+): string {
+  if (anchor.width <= 0 || anchor.height <= 0) return d;
+  return d.replace(
+    /([ML])\s+(-?\d+(?:\.\d+)?)\s+(-?\d+(?:\.\d+)?)/g,
+    (_match, cmd, xStr, yStr) => {
+      const pctX = parseFloat(xStr);
+      const pctY = parseFloat(yStr);
+      // overlay % → viewport px
+      const vpX = overlay.left + (pctX / 100) * overlay.width;
+      const vpY = overlay.top + (pctY / 100) * overlay.height;
+      // viewport px → anchor %
+      const aX = ((vpX - anchor.left) / anchor.width) * 100;
+      const aY = ((vpY - anchor.top) / anchor.height) * 100;
+      return `${cmd} ${aX.toFixed(2)} ${aY.toFixed(2)}`;
+    },
+  );
+}
+
+/**
+ * 描画ストロークの中点 (bbox 中央) を overlay viewBox 空間 (0-100) から
+ * viewport px に変換。後続の elementFromPoint などに使う。
+ */
+export function strokesCenterInViewport(
+  strokeDs: string[],
+  overlay: Rect,
+): Point | null {
+  const allPoints: Point[] = [];
+  for (const d of strokeDs) {
+    for (const p of parsePathPoints(d)) allPoints.push(p);
+  }
+  const bb = computeBBox(allPoints);
+  if (!bb) return null;
+  return {
+    x: overlay.left + (bb.center.x / 100) * overlay.width,
+    y: overlay.top + (bb.center.y / 100) * overlay.height,
+  };
+}

--- a/schemas/process-flow.schema.json
+++ b/schemas/process-flow.schema.json
@@ -112,7 +112,7 @@
     },
 
     "MarkerShape": {
-      "description": "自由描画マーカーの形状 (#261)。SVG viewBox=0 0 100 100 の相対座標",
+      "description": "自由描画マーカーの形状 (#261)。SVG viewBox=0 0 100 100 の相対座標。anchorStepId 指定時はその DOM 要素 bbox 相対",
       "type": "object",
       "required": ["type", "d"],
       "additionalProperties": false,
@@ -120,7 +120,9 @@
         "type": { "type": "string", "enum": ["path"] },
         "d": { "type": "string", "description": "SVG path の d 属性 (0-100 の % 座標)" },
         "color": { "type": "string", "description": "描画色 (#ef4444 既定)" },
-        "strokeWidth": { "type": "number", "minimum": 0.1 }
+        "strokeWidth": { "type": "number", "minimum": 0.1 },
+        "anchorStepId": { "type": "string", "description": "DOM anchor: 描画を特定 step に紐付け (座標はこの step の bbox 相対 %)" },
+        "anchorFieldPath": { "type": "string", "description": "DOM anchor 内の field 細分 (例: sql / conditions / expression)" }
       }
     },
 


### PR DESCRIPTION
## 関連

- 関連: #261 (リアルタイム編集ワークフロー)
- 修正対象: ユーザー報告 2 点
  1. 描画マーカーが MarkerPanel 展開/解決メモ追加で位置ずれ → 指摘対象から乖離
  2. 細線/太線切替が既存ストロークにも波及

## 概要

ユーザーが画面上の特定要素 (例: SQL テキストエリア) を丸で囲んで指示した際、以降のレイアウト変動で描画の視覚位置がずれる問題を DOM 要素アンカリングで解決する。

## 主な変更

### DOM anchor 方式
- **StepCard/StepField に属性付与**: `data-step-id` / `data-field-path`
- **描画確定時**: ストローク中点下の DOM 要素から anchor 決定、座標を anchor bbox 相対 % に変換
- **レンダ時**: 対象要素の bbox 上に fixed positioned な SVG を被せ、ResizeObserver + MutationObserver (.action-page スコープ) + scroll で追従
- **Marker.stepId / fieldPath にも反映**: `/designer-work` スラッシュコマンドは既存で stepId/fieldPath を読むため、AI が自動的に「どの step のどのフィールドへの指示か」を把握できる (MCP 層の変更不要)
- **Orphan 処理**: anchor 対象 step が削除されたら画面から消えて、MarkerPanel に「該当 step なし」バッジ

### 合わせて直した不具合
- **細線/太線 state の波及**: `strokes` を `string[]` から `Array<{d, color, width}>` に変更、ストローク確定時点の値を固定
- **MarkerPanel 既定折りたたみ**: 縦方向レイアウト揺れを抑制

### スキーマ拡張
- `MarkerShape` に `anchorStepId?` / `anchorFieldPath?` (TypeScript + JSON Schema)
- 前方互換: anchor なし marker は overlay 全体 % で描画 (従来通り)

## 仕様逐条突合 (自己申告)

N/A — スキーマ追加は新 optional フィールドのみで既存サンプルに影響なし。`schemas/process-flow.schema.json` の description を更新。

## レビューで特に見てほしい箇所

- **`AnchoredMarker` component** (DrawingOverlay.tsx): 対象の bbox 継続再測定。`.action-page` スコープの MutationObserver + RAF debounce。初期は `.action-content` 内のみ観察していて MarkerPanel 展開を取りこぼしたため、ブラウザ実地検証で検知して `.action-page` に広げた
- **`markerAnchor.ts`** の純関数 3 つ: parsePathPoints / convertPathToAnchorRelative / strokesCenterInViewport。座標変換の単体テスト 13 件で網羅
- **Marker.stepId 自動反映** (ActionEditor.handleCommitStrokes): anchor 情報を Marker レベルにも伝搬して AI 側実装の変更不要化

## テスト

- Vitest: **483 → 496 件** (markerAnchor 新規 13 件)
- Playwright (drawing-anchor): **新規 4 件** 全 pass
  - anchor bbox 位置合わせ (1px 誤差未満)
  - MarkerPanel 展開で step が 415px 下移動しても追従
  - 前方互換 (旧 marker は overlay 描画)
  - orphan (該当 step 削除) → 非表示 + MarkerPanel バッジ
- Playwright 全体: 210 passed / 2 failed (両方 pre-existing flake: tab-management Ctrl+Tab, validation-warnings-panel 閉じるボタン — 本 PR 無関係) / 1 skipped
- **Playwright MCP で実地検証**: dogfood サンプル (`ag-dogfood-test` / step-sql) に anchor 付き marker を localStorage 経由で注入し、MarkerPanel 展開前後で anchor 描画 SVG の bbox が sql フィールドに 1px 未満の誤差で一致することを確認

## UI 影響 / マージ保留フラグ

- [x] UI 影響あり (マージ前にユーザー目視確認必須)
- [ ] UI 影響なし

### UI 影響ありの場合、確認項目

- [ ] 描画ツールバーで太線を選択 → 新規描画だけに適用、既存ストロークは元の太さのまま
- [ ] MarkerPanel が既定で折りたたまれている (ヘッダのみ表示)
- [ ] step の SQL 欄を赤丸で囲んで commit → MarkerPanel を展開しても赤丸が SQL 欄を追従
- [ ] step を並び替え → 赤丸も一緒に移動
- [ ] step を削除 → 画面から赤丸が消え、MarkerPanel に「該当 step なし」バッジ表示

## spec 側の不足点 / 提案

N/A — スキーマ拡張のみ

## レビュー担当への申し送り

- MutationObserver のスコープ `.action-page` は MarkerPanel / Catalog 類を含む最小スコープ。広げすぎると perf 劣化するので、追加領域を観察したくなったら同スコープで OK
- 将来: anchor なしマーカーの migration (既存サンプル / localStorage) は行わない。anchor なしは overlay 全体に描画され続ける
- 将来: ストローク個別に色/幅を保存する完全版 multi-path shape は別案件 (本 PR は「session 中の視覚のみ per-stroke、保存は最終ストローク値」で実用)

🤖 Generated with [Claude Code](https://claude.com/claude-code)