### PR TITLE
fix(test): pre-existing E2E flake 2 件を修正

### DIFF
--- a/designer/e2e/tab-management.spec.ts
+++ b/designer/e2e/tab-management.spec.ts
@@ -104,13 +104,20 @@ test.describe("タブ切り替え", () => {
     // 画面A をアクティブにしてから Ctrl+Tab
     await page.locator(".tabbar-tab").filter({ hasText: "画面A" }).click();
     await expect(page.locator(".tabbar-tab.active")).toContainText("画面A");
-    // Ctrl+Tab はブラウザにインターセプトされる可能性があるため document に直接送出
-    await page.evaluate(() => {
-      document.dispatchEvent(new KeyboardEvent("keydown", {
-        key: "Tab", ctrlKey: true, bubbles: true, cancelable: true,
-      }));
-    });
-    await expect(page.locator(".tabbar-tab.active")).toContainText("画面B");
+    // page.keyboard.press と document 直接 dispatch の両方を試行:
+    // Playwright driver は Ctrl+Tab を通常のブラウザインターセプトから逃がす模様。
+    // もし page.keyboard で駄目でも dispatch で確実に document listener に届ける。
+    await page.keyboard.press("Control+Tab");
+    try {
+      await expect(page.locator(".tabbar-tab.active")).toContainText("画面B", { timeout: 1000 });
+    } catch {
+      await page.evaluate(() => {
+        document.dispatchEvent(new KeyboardEvent("keydown", {
+          key: "Tab", code: "Tab", keyCode: 9, ctrlKey: true, bubbles: true, cancelable: true,
+        }));
+      });
+      await expect(page.locator(".tabbar-tab.active")).toContainText("画面B");
+    }
   });
 
   test("Ctrl+Shift+Tab で前のタブに移動する", async ({ page }) => {

--- a/designer/e2e/validation-warnings-panel.spec.ts
+++ b/designer/e2e/validation-warnings-panel.spec.ts
@@ -122,7 +122,8 @@ test.describe("警告パネル UI 配線 (#261 UI 統合)", () => {
     await page.locator(".validation-badge.warning").click();
     await expect(page.locator(".action-validation-panel")).toBeVisible();
 
-    await page.locator(".action-validation-panel-header button").click();
+    // ヘッダには「全て AI に依頼」ボタンもあるため title="閉じる" で指定
+    await page.locator('.action-validation-panel-header button[title="閉じる"]').click();
     await expect(page.locator(".action-validation-panel")).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## 概要

Playwright 全体実行で常に 2 件失敗していた flake を修正。UI 影響なし、テストファイルのみ変更。

## 修正内容

1. **tab-management Ctrl+Tab**: dispatchEvent fallback を keyboard.press 優先に変更。Playwright は Ctrl+Tab のブラウザインターセプトを回避するので通常は press で OK、駄目なら dispatch でフォールバック
2. **validation-warnings-panel 閉じる**: strict mode violation 修正 (2 button matching)

## テスト

Playwright 全体: **212 passed / 1 skipped / 0 failed** (従来 2 failed)

## UI 影響 / マージ保留フラグ

- [ ] UI 影響あり
- [x] UI 影響なし (test only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)