### PR TITLE
chore(lint): 自明な lint 違反 2 件を修正

### DIFF
--- a/designer/src/mcp/mcpBridge.ts
+++ b/designer/src/mcp/mcpBridge.ts
@@ -240,39 +240,38 @@ class McpBridgeImpl {
 
   /** 接続時: flowStore と customBlockStore にリモートバックエンドをセット */
   private _setStorageBackends(): void {
-    const self = this;
-
+    // arrow 関数内の this は lexical なので、enclosing method の this (インスタンス) をそのまま使う
     const flowBackend: FlowStorageBackend = {
-      loadProject: () => self.request("loadProject"),
-      saveProject: (project) => self.request("saveProject", { project }).then(() => undefined),
-      deleteScreenData: (screenId) => self.request("deleteScreen", { screenId }).then(() => undefined),
+      loadProject: () => this.request("loadProject"),
+      saveProject: (project) => this.request("saveProject", { project }).then(() => undefined),
+      deleteScreenData: (screenId) => this.request("deleteScreen", { screenId }).then(() => undefined),
     };
     setFlowStorageBackend(flowBackend);
 
     const blocksBackend: CustomBlocksStorageBackend = {
-      loadCustomBlocks: () => self.request("loadCustomBlocks").then((r) => (r ?? []) as unknown[]),
-      saveCustomBlocks: (blocks) => self.request("saveCustomBlocks", { blocks }).then(() => undefined),
+      loadCustomBlocks: () => this.request("loadCustomBlocks").then((r) => (r ?? []) as unknown[]),
+      saveCustomBlocks: (blocks) => this.request("saveCustomBlocks", { blocks }).then(() => undefined),
     };
     setCustomBlocksBackend(blocksBackend);
 
     const tableBackend: TableStorageBackend = {
-      loadTable: (tableId) => self.request("loadTable", { tableId }),
-      saveTable: (tableId, data) => self.request("saveTable", { tableId, data }).then(() => undefined),
-      deleteTable: (tableId) => self.request("deleteTable", { tableId }).then(() => undefined),
+      loadTable: (tableId) => this.request("loadTable", { tableId }),
+      saveTable: (tableId, data) => this.request("saveTable", { tableId, data }).then(() => undefined),
+      deleteTable: (tableId) => this.request("deleteTable", { tableId }).then(() => undefined),
     };
     setTableStorageBackend(tableBackend);
 
     const erLayoutBackend: ErLayoutStorageBackend = {
-      loadErLayout: () => self.request("loadErLayout"),
-      saveErLayout: (data) => self.request("saveErLayout", { data }).then(() => undefined),
+      loadErLayout: () => this.request("loadErLayout"),
+      saveErLayout: (data) => this.request("saveErLayout", { data }).then(() => undefined),
     };
     setErLayoutStorageBackend(erLayoutBackend);
 
     const actionBackend: ActionStorageBackend = {
-      loadActionGroup: (id) => self.request("loadActionGroup", { id }),
-      saveActionGroup: (id, data) => self.request("saveActionGroup", { id, data }).then(() => undefined),
-      deleteActionGroup: (id) => self.request("deleteActionGroup", { id }).then(() => undefined),
-      listActionGroups: () => self.request("listActionGroups"),
+      loadActionGroup: (id) => this.request("loadActionGroup", { id }),
+      saveActionGroup: (id, data) => this.request("saveActionGroup", { id, data }).then(() => undefined),
+      deleteActionGroup: (id) => this.request("deleteActionGroup", { id }).then(() => undefined),
+      listActionGroups: () => this.request("listActionGroups"),
     };
     setActionStorageBackend(actionBackend);
   }

--- a/designer/src/utils/errorLog.ts
+++ b/designer/src/utils/errorLog.ts
@@ -46,7 +46,6 @@ export function recordError(entry: Omit<ErrorLogEntry, "ts" | "url"> & Partial<P
     /* localStorage 全滅時は諦める */
   }
   // 開発中に気付けるよう console にも流す
-  // eslint-disable-next-line no-console
   console.error(`[errorLog/${full.source}]`, full.message, full.stack ?? "");
 }
 


### PR DESCRIPTION
## 概要

リモート確認作業中の objective にテストできる範囲の掃除。

## 修正

- `mcpBridge.ts`: `const self = this` を削除、arrow 関数内で直接 `this` を使用 (no-this-alias 解消)
- `errorLog.ts`: 不要になった eslint-disable-next-line no-console コメントを削除

## 残存

lint エラー 22 件 (react-hooks/set-state-in-effect 等) は大きなリファクタを要するため別機会。

## テスト

- Vitest: 496 pass
- tsc: OK
- Lint: 37 → 35 (-2)

## UI 影響 / マージ保留フラグ

- [ ] UI 影響あり
- [x] UI 影響なし (code cleanup のみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)