### PR TITLE
fix(ui): MarkerPanel 展開時に main content が viewport 外に追い出される問題

### DIFF
--- a/designer/src/styles/action.css
+++ b/designer/src/styles/action.css
@@ -1266,6 +1266,10 @@
 .catalog-panel-body {
   padding: 8px 12px;
   border-top: 1px solid #e2e8f0;
+  /* 長くなった panel (MarkerPanel に marker が大量 等) が .action-editor-info を押し広げて
+     下のステップ領域を viewport 外に押し出すのを防ぐ。各 panel 個別に内部スクロール。 */
+  max-height: 40vh;
+  overflow-y: auto;
 }
 .catalog-help {
   font-size: 0.75rem;


### PR DESCRIPTION
## 発見経緯

実地 /designer-work 検証中のユーザー発見 (2026-04-21)。マーカー 10+ 件ある状態で MarkerPanel を展開すると、下のステップカード領域が画面外に押し出される。

## 原因

`.action-editor-info` に height 制約なし + `.action-page` が overflow:hidden。catalog panel が展開して内部コンテンツが長くなると、直接 `.action-editor-info` の高さが伸びて、下の `.action-tabs` / `.action-content` を viewport 外に押し出す。

## 修正

`.catalog-panel-body` に `max-height: 40vh; overflow-y: auto` を追加。panel 内部で scroll 処理するため、外側レイアウトは影響を受けない。MarkerPanel 以外の catalog (error/ambient/secrets/external/type) にも同じルールが適用されるが、max-height 指定なので短い時は通常表示、長い時だけ scroll bar が出る。

## UI 影響 / マージ保留フラグ

- [x] UI 影響あり (panel 内部スクロールに挙動変化)
- [ ] UI 影響なし

実地検証中のユーザーが即確認できるので、マージ後すぐブラウザ reload で動作確認可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)