### PR TITLE
refactor(ui): 処理フローエディタ UX 改善 (#309 #310 #313)

### DIFF
--- a/designer/e2e/marker-panel.spec.ts
+++ b/designer/e2e/marker-panel.spec.ts
@@ -34,7 +34,8 @@ async function setup(page: Page) {
 test.describe("MarkerPanel (#261)", () => {
   test("パネル既定折りたたみ、展開後に 0 件メッセージ表示", async ({ page }) => {
     await setup(page);
-    await expect(page.locator(".marker-panel")).toBeVisible();
+    // #309 タブバー化以降、.marker-panel は tabbar 側 (toggleOnly) と body 側の 2 箇所に出現
+    await expect(page.locator(".marker-panel").first()).toBeVisible();
     await expect(page.locator(".marker-panel .catalog-panel-toggle")).toContainText("0 未解決");
     // setup で展開済 → empty メッセージ可視
     await expect(page.locator(".marker-panel .catalog-empty")).toBeVisible();

--- a/designer/src/components/action/ActionEditor.tsx
+++ b/designer/src/components/action/ActionEditor.tsx
@@ -2,13 +2,11 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import type {
   ActionGroup,
-  ActionGroupType,
   ActionTrigger,
   Step,
   StepType,
 } from "../../types/action";
 import {
-  ACTION_GROUP_TYPE_LABELS,
   ACTION_TRIGGER_LABELS,
   STEP_TYPE_LABELS,
   STEP_TYPE_ICONS,
@@ -56,46 +54,12 @@ import { TableSubToolbar } from "../table/TableSubToolbar";
 import { SortableStepCard } from "./SortableStepCard";
 import { MaturityBadge } from "./MaturityBadge";
 import { ActionHttpContractPanel } from "./ActionHttpContractPanel";
-import { ErrorCatalogPanel } from "./ErrorCatalogPanel";
-import { AmbientVariablesPanel } from "./AmbientVariablesPanel";
-import { SecretsCatalogPanel } from "./SecretsCatalogPanel";
-import { ExternalSystemCatalogPanel } from "./ExternalSystemCatalogPanel";
-import { TypeCatalogPanel } from "./TypeCatalogPanel";
-import { MarkerPanel } from "./MarkerPanel";
+import { ActionMetaTabBar } from "./ActionMetaTabBar";
 import { DrawingOverlay } from "./DrawingOverlay";
 import { StructuredFieldsEditor } from "./StructuredFieldsEditor";
 import { EditorHeader } from "../common/EditorHeader";
 import { ServerChangeBanner } from "../common/ServerChangeBanner";
 import "../../styles/action.css";
-
-/** グループ内の全ステップを再帰的に走査して maturity 別カウント + 付箋合計を集計 (#196 / #200) */
-function countMaturity(group: ActionGroup): {
-  draft: number;
-  provisional: number;
-  committed: number;
-  total: number;
-  notes: number;
-} {
-  const acc = { draft: 0, provisional: 0, committed: 0, total: 0, notes: 0 };
-  const visit = (steps: Step[]) => {
-    for (const s of steps) {
-      const m = s.maturity ?? "draft";
-      if (m === "draft") acc.draft++;
-      else if (m === "provisional") acc.provisional++;
-      else acc.committed++;
-      acc.total++;
-      acc.notes += s.notes?.length ?? 0;
-      if (s.subSteps) visit(s.subSteps);
-      if (s.type === "branch") {
-        for (const b of s.branches) visit(b.steps);
-        if (s.elseBranch) visit(s.elseBranch.steps);
-      }
-      if (s.type === "loop") visit(s.steps);
-    }
-  };
-  for (const act of group.actions) visit(act.steps);
-  return acc;
-}
 
 /** ツールバーのドラッグ可能なステップ種別ボタン */
 function ToolbarStepButton({ type, onClick }: { type: StepType; onClick: () => void }) {
@@ -424,12 +388,6 @@ export function ActionEditor() {
     closeContextMenu();
   };
 
-  const handleGroupInfoChange = (field: string, value: string) => {
-    updateGroupSilent((g) => {
-      (g as unknown as Record<string, string>)[field] = value;
-    });
-  };
-
   // ── 選択操作 ──────────────────────────────────────────────────
   const handleStepClick = (stepId: string, e: React.MouseEvent) => {
     if (!activeAction) return;
@@ -716,134 +674,12 @@ export function ActionEditor() {
         </div>
       )}
 
-      {/* グループ情報 */}
-      <div className="action-editor-info">
-        <div className="row g-2">
-          <div className="col-md-4">
-            <label className="form-label small fw-semibold">名前</label>
-            <input
-              className="form-control form-control-sm"
-              value={group.name}
-              onChange={(e) => handleGroupInfoChange("name", e.target.value)}
-            />
-          </div>
-          <div className="col-md-2">
-            <label className="form-label small fw-semibold">種別</label>
-            <select
-              className="form-select form-select-sm"
-              value={group.type}
-              onChange={(e) => handleGroupInfoChange("type", e.target.value)}
-            >
-              {(["screen", "batch", "scheduled", "system", "common", "other"] as ActionGroupType[]).map((t) => (
-                <option key={t} value={t}>{ACTION_GROUP_TYPE_LABELS[t]}</option>
-              ))}
-            </select>
-          </div>
-          <div className="col-md-6">
-            <label className="form-label small fw-semibold">説明</label>
-            <input
-              className="form-control form-control-sm"
-              value={group.description}
-              onChange={(e) => handleGroupInfoChange("description", e.target.value)}
-              placeholder="処理フローの概要"
-            />
-          </div>
-        </div>
-        <div className="d-flex align-items-center gap-3 mt-2 small">
-          <div className="d-flex align-items-center gap-1">
-            <label className="form-label small fw-semibold mb-0">成熟度</label>
-            <MaturityBadge
-              maturity={group.maturity}
-              size="md"
-              onChange={(next) => handleGroupInfoChange("maturity", next)}
-            />
-          </div>
-          <div className="d-flex align-items-center gap-1">
-            <label className="form-label small fw-semibold mb-0">モード</label>
-            <div className="btn-group btn-group-sm" role="group" aria-label="モード切替">
-              <button
-                type="button"
-                className={`btn btn-outline-secondary${(group.mode ?? "upstream") === "upstream" ? " active" : ""}`}
-                onClick={() => handleGroupInfoChange("mode", "upstream")}
-                title="上流モード: 書きかけ・曖昧を許容"
-              >
-                <i className="bi bi-pencil me-1" />上流
-              </button>
-              <button
-                type="button"
-                className={`btn btn-outline-secondary${group.mode === "downstream" ? " active" : ""}`}
-                onClick={() => handleGroupInfoChange("mode", "downstream")}
-                title="下流モード: AI 実装用に確定"
-              >
-                <i className="bi bi-robot me-1" />下流
-              </button>
-            </div>
-          </div>
-        </div>
-        {(() => {
-          const counts = countMaturity(group);
-          if (counts.total === 0) return null;
-          return (
-            <div className="d-flex align-items-center gap-3 mt-2 small" style={{ fontSize: "0.8rem" }}>
-              <span className="text-muted">進捗:</span>
-              <span title={`確定 ${counts.committed} 件`} style={{ color: "#22c55e" }}>
-                <i className="bi bi-circle-fill" /> {counts.committed}
-              </span>
-              <span title={`暫定 ${counts.provisional} 件`} style={{ color: "#f97316" }}>
-                <i className="bi bi-circle-fill" /> {counts.provisional}
-              </span>
-              <span title={`下書き ${counts.draft} 件`} style={{ color: "#f59e0b" }}>
-                <i className="bi bi-circle-fill" /> {counts.draft}
-              </span>
-              <span className="text-muted">合計 {counts.total} ステップ</span>
-              {counts.notes > 0 && (
-                <span className="text-muted" title={`付箋 ${counts.notes} 件`}>
-                  <i className="bi bi-sticky" /> {counts.notes}
-                </span>
-              )}
-            </div>
-          );
-        })()}
-        {group.mode === "downstream" && (() => {
-          const counts = countMaturity(group);
-          const unfinished = counts.draft + counts.provisional;
-          if (unfinished === 0) return null;
-          return (
-            <div className="alert alert-warning py-1 px-2 mt-2 mb-0 small d-flex align-items-center gap-2" role="alert">
-              <i className="bi bi-exclamation-triangle-fill" />
-              <strong>下流モードで未確定ステップあり:</strong>
-              <span>🟡 draft {counts.draft} / 🟠 provisional {counts.provisional}</span>
-              <span className="text-muted">(AI 実装前に committed に昇格してください)</span>
-            </div>
-          );
-        })()}
-        {/* AI へのマーカー (#261 リアルタイム編集ワークフロー) — カタログより先に配置して目立たせる */}
-        <MarkerPanel
-          group={group}
-          onChange={(next) => { updateGroup((g) => { g.markers = next.markers; }); }}
-        />
-        {/* ActionGroup レベルカタログ編集 (#278) */}
-        <ErrorCatalogPanel
-          group={group}
-          onChange={(next) => { updateGroup((g) => { g.errorCatalog = next.errorCatalog; }); }}
-        />
-        <AmbientVariablesPanel
-          group={group}
-          onChange={(next) => { updateGroup((g) => { g.ambientVariables = next.ambientVariables; }); }}
-        />
-        <SecretsCatalogPanel
-          group={group}
-          onChange={(next) => { updateGroup((g) => { g.secretsCatalog = next.secretsCatalog; }); }}
-        />
-        <ExternalSystemCatalogPanel
-          group={group}
-          onChange={(next) => { updateGroup((g) => { g.externalSystemCatalog = next.externalSystemCatalog; }); }}
-        />
-        <TypeCatalogPanel
-          group={group}
-          onChange={(next) => { updateGroup((g) => { g.typeCatalog = next.typeCatalog; }); }}
-        />
-      </div>
+      {/* グループ情報 + カタログ群 (#309 タブバー化) */}
+      <ActionMetaTabBar
+        group={group}
+        updateGroup={updateGroup}
+        updateGroupSilent={updateGroupSilent}
+      />
 
       {/* アクションタブ */}
       <div className="action-tabs">

--- a/designer/src/components/action/ActionEditor.tsx
+++ b/designer/src/components/action/ActionEditor.tsx
@@ -498,13 +498,17 @@ export function ActionEditor() {
       // anchor があれば Marker.stepId / fieldPath にも自動反映:
       // /designer-work スラッシュコマンドは stepId / fieldPath を既存で読むので、
       // AI 側は「どの step のどのフィールドへの指示か」を即座に把握できる。
+      // ただし __meta-tab-* は ActionMetaTabBar の body 用擬似 ID (#309 フォローアップ) で
+      // 実 step ID ではないため、Marker.stepId / fieldPath にはコピーしない
+      // (shape.anchorStepId 側に残るので DrawingOverlay の位置追従は効く)。
+      const isMetaTabAnchor = shape.anchorStepId?.startsWith("__meta-tab-") ?? false;
       g.markers = [...(g.markers ?? []), {
         id: generateUUID(),
         kind: "todo",
         body: body.trim(),
         shape,
-        stepId: shape.anchorStepId,
-        fieldPath: shape.anchorFieldPath,
+        stepId: isMetaTabAnchor ? undefined : shape.anchorStepId,
+        fieldPath: isMetaTabAnchor ? undefined : shape.anchorFieldPath,
         author: "human",
         createdAt: new Date().toISOString(),
       }];

--- a/designer/src/components/action/ActionMetaTabBar.tsx
+++ b/designer/src/components/action/ActionMetaTabBar.tsx
@@ -1,0 +1,268 @@
+/**
+ * 処理フローエディタの上部タブバー (#309)
+ *
+ * 以前は名前/種別/説明/成熟度/モードに加え、6 つのカタログパネル (MarkerPanel /
+ * ErrorCatalogPanel / AmbientVariablesPanel / SecretsCatalogPanel /
+ * ExternalSystemCatalogPanel / TypeCatalogPanel) が action-editor-info に縦積みされ、
+ * 全閉じ状態でもステップ本体までスクロールが必要だった。
+ *
+ * ここでは各カタログパネルを「タブボタン + body」に分離し、排他的に 1 つだけ
+ * body を展開する。成熟度バッジ・進捗・下流モード警告はタブバーに常時表示。
+ */
+import { useState } from "react";
+import type { ActionGroup, ActionGroupType, Step } from "../../types/action";
+import { ACTION_GROUP_TYPE_LABELS } from "../../types/action";
+import { MaturityBadge } from "./MaturityBadge";
+import { MarkerPanel } from "./MarkerPanel";
+import { ErrorCatalogPanel } from "./ErrorCatalogPanel";
+import { AmbientVariablesPanel } from "./AmbientVariablesPanel";
+import { SecretsCatalogPanel } from "./SecretsCatalogPanel";
+import { ExternalSystemCatalogPanel } from "./ExternalSystemCatalogPanel";
+import { TypeCatalogPanel } from "./TypeCatalogPanel";
+
+type TabKey = "info" | "marker" | "error" | "ambient" | "secrets" | "external" | "type";
+
+/** グループ内の全ステップを再帰的に走査して maturity 別カウント + 付箋合計を集計 (#196 / #200) */
+function countMaturity(group: ActionGroup): {
+  draft: number;
+  provisional: number;
+  committed: number;
+  total: number;
+  notes: number;
+} {
+  const acc = { draft: 0, provisional: 0, committed: 0, total: 0, notes: 0 };
+  const visit = (steps: Step[]) => {
+    for (const s of steps) {
+      const m = s.maturity ?? "draft";
+      if (m === "draft") acc.draft++;
+      else if (m === "provisional") acc.provisional++;
+      else acc.committed++;
+      acc.total++;
+      acc.notes += s.notes?.length ?? 0;
+      if (s.subSteps) visit(s.subSteps);
+      if (s.type === "branch") {
+        for (const b of s.branches) visit(b.steps);
+        if (s.elseBranch) visit(s.elseBranch.steps);
+      }
+      if (s.type === "loop") visit(s.steps);
+    }
+  };
+  for (const act of group.actions) visit(act.steps);
+  return acc;
+}
+
+interface Props {
+  group: ActionGroup;
+  updateGroup: (recipe: (g: ActionGroup) => void) => void;
+  updateGroupSilent: (recipe: (g: ActionGroup) => void) => void;
+}
+
+export function ActionMetaTabBar({ group, updateGroup, updateGroupSilent }: Props) {
+  const [active, setActive] = useState<TabKey | null>(null);
+  const setActiveFrom = (k: TabKey, v: boolean) => setActive(v ? k : null);
+
+  const handleInfoChange = (field: string, value: string) => {
+    updateGroupSilent((g) => {
+      (g as unknown as Record<string, string>)[field] = value;
+    });
+  };
+
+  const counts = countMaturity(group);
+  const unfinished = counts.draft + counts.provisional;
+
+  // MarkerPanel / 各カタログパネルへの onChange を 1 箇所でまとめる
+  const onMarkersChange = (next: ActionGroup) => {
+    updateGroup((g) => { g.markers = next.markers; });
+  };
+  const onErrorCatalogChange = (next: ActionGroup) => {
+    updateGroup((g) => { g.errorCatalog = next.errorCatalog; });
+  };
+  const onAmbientChange = (next: ActionGroup) => {
+    updateGroup((g) => { g.ambientVariables = next.ambientVariables; });
+  };
+  const onSecretsChange = (next: ActionGroup) => {
+    updateGroup((g) => { g.secretsCatalog = next.secretsCatalog; });
+  };
+  const onExternalChange = (next: ActionGroup) => {
+    updateGroup((g) => { g.externalSystemCatalog = next.externalSystemCatalog; });
+  };
+  const onTypeChange = (next: ActionGroup) => {
+    updateGroup((g) => { g.typeCatalog = next.typeCatalog; });
+  };
+
+  return (
+    <div className="action-meta-tabbar">
+      <div className="action-meta-tabs" role="tablist">
+        {/* 基本情報タブ (名前/種別/説明/モード) */}
+        <div className={`catalog-panel action-meta-info-panel${active === "info" ? " expanded" : ""}`}>
+          <button
+            type="button"
+            className="catalog-panel-toggle"
+            onClick={() => setActive((p) => (p === "info" ? null : "info"))}
+          >
+            <i className={`bi bi-chevron-${active === "info" ? "down" : "right"}`} />
+            <i className="bi bi-info-circle" />
+            {" "}基本情報
+          </button>
+        </div>
+
+        <MarkerPanel
+          group={group}
+          onChange={onMarkersChange}
+          render="toggleOnly"
+          expanded={active === "marker"}
+          onExpandedChange={(v) => setActiveFrom("marker", v)}
+        />
+        <ErrorCatalogPanel
+          group={group}
+          onChange={onErrorCatalogChange}
+          render="toggleOnly"
+          expanded={active === "error"}
+          onExpandedChange={(v) => setActiveFrom("error", v)}
+        />
+        <AmbientVariablesPanel
+          group={group}
+          onChange={onAmbientChange}
+          render="toggleOnly"
+          expanded={active === "ambient"}
+          onExpandedChange={(v) => setActiveFrom("ambient", v)}
+        />
+        <SecretsCatalogPanel
+          group={group}
+          onChange={onSecretsChange}
+          render="toggleOnly"
+          expanded={active === "secrets"}
+          onExpandedChange={(v) => setActiveFrom("secrets", v)}
+        />
+        <ExternalSystemCatalogPanel
+          group={group}
+          onChange={onExternalChange}
+          render="toggleOnly"
+          expanded={active === "external"}
+          onExpandedChange={(v) => setActiveFrom("external", v)}
+        />
+        <TypeCatalogPanel
+          group={group}
+          onChange={onTypeChange}
+          render="toggleOnly"
+          expanded={active === "type"}
+          onExpandedChange={(v) => setActiveFrom("type", v)}
+        />
+
+        <div className="action-meta-tabbar-spacer" />
+
+        {/* 常時表示: 成熟度 + 進捗 */}
+        <div className="action-meta-tabbar-inline">
+          <span className="action-meta-maturity-label">成熟度</span>
+          <MaturityBadge
+            maturity={group.maturity}
+            size="md"
+            onChange={(next) => handleInfoChange("maturity", next)}
+          />
+          {counts.total > 0 && (
+            <span
+              className="action-meta-progress"
+              title={`確定 ${counts.committed} / 暫定 ${counts.provisional} / 下書き ${counts.draft} (合計 ${counts.total})`}
+            >
+              <span style={{ color: "#22c55e" }}><i className="bi bi-circle-fill" /> {counts.committed}</span>
+              <span style={{ color: "#f97316" }}><i className="bi bi-circle-fill" /> {counts.provisional}</span>
+              <span style={{ color: "#f59e0b" }}><i className="bi bi-circle-fill" /> {counts.draft}</span>
+              <span className="text-muted">/ {counts.total}</span>
+              {counts.notes > 0 && (
+                <span className="text-muted" title={`付箋 ${counts.notes} 件`}>
+                  <i className="bi bi-sticky" /> {counts.notes}
+                </span>
+              )}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* 下流モード未確定警告 (常時表示) */}
+      {group.mode === "downstream" && unfinished > 0 && (
+        <div className="alert alert-warning py-1 px-2 mb-0 small d-flex align-items-center gap-2" role="alert">
+          <i className="bi bi-exclamation-triangle-fill" />
+          <strong>下流モードで未確定ステップあり:</strong>
+          <span>🟡 draft {counts.draft} / 🟠 provisional {counts.provisional}</span>
+          <span className="text-muted">(AI 実装前に committed に昇格してください)</span>
+        </div>
+      )}
+
+      {/* アクティブタブの body を全幅で展開 */}
+      {active === "info" && (
+        <div className="action-meta-body action-meta-info-body">
+          <div className="row g-2">
+            <div className="col-md-4">
+              <label className="form-label small fw-semibold">名前</label>
+              <input
+                className="form-control form-control-sm"
+                value={group.name}
+                onChange={(e) => handleInfoChange("name", e.target.value)}
+              />
+            </div>
+            <div className="col-md-2">
+              <label className="form-label small fw-semibold">種別</label>
+              <select
+                className="form-select form-select-sm"
+                value={group.type}
+                onChange={(e) => handleInfoChange("type", e.target.value)}
+              >
+                {(["screen", "batch", "scheduled", "system", "common", "other"] as ActionGroupType[]).map((t) => (
+                  <option key={t} value={t}>{ACTION_GROUP_TYPE_LABELS[t]}</option>
+                ))}
+              </select>
+            </div>
+            <div className="col-md-6">
+              <label className="form-label small fw-semibold">説明</label>
+              <input
+                className="form-control form-control-sm"
+                value={group.description}
+                onChange={(e) => handleInfoChange("description", e.target.value)}
+                placeholder="処理フローの概要"
+              />
+            </div>
+          </div>
+          <div className="d-flex align-items-center gap-3 mt-2 small">
+            <label className="form-label small fw-semibold mb-0">モード</label>
+            <div className="btn-group btn-group-sm" role="group" aria-label="モード切替">
+              <button
+                type="button"
+                className={`btn btn-outline-secondary${(group.mode ?? "upstream") === "upstream" ? " active" : ""}`}
+                onClick={() => handleInfoChange("mode", "upstream")}
+                title="上流モード: 書きかけ・曖昧を許容"
+              >
+                <i className="bi bi-pencil me-1" />上流
+              </button>
+              <button
+                type="button"
+                className={`btn btn-outline-secondary${group.mode === "downstream" ? " active" : ""}`}
+                onClick={() => handleInfoChange("mode", "downstream")}
+                title="下流モード: AI 実装用に確定"
+              >
+                <i className="bi bi-robot me-1" />下流
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+      {active === "marker" && (
+        <MarkerPanel group={group} onChange={onMarkersChange} render="bodyOnly" />
+      )}
+      {active === "error" && (
+        <ErrorCatalogPanel group={group} onChange={onErrorCatalogChange} render="bodyOnly" />
+      )}
+      {active === "ambient" && (
+        <AmbientVariablesPanel group={group} onChange={onAmbientChange} render="bodyOnly" />
+      )}
+      {active === "secrets" && (
+        <SecretsCatalogPanel group={group} onChange={onSecretsChange} render="bodyOnly" />
+      )}
+      {active === "external" && (
+        <ExternalSystemCatalogPanel group={group} onChange={onExternalChange} render="bodyOnly" />
+      )}
+      {active === "type" && (
+        <TypeCatalogPanel group={group} onChange={onTypeChange} render="bodyOnly" />
+      )}
+    </div>
+  );
+}

--- a/designer/src/components/action/ActionMetaTabBar.tsx
+++ b/designer/src/components/action/ActionMetaTabBar.tsx
@@ -188,9 +188,12 @@ export function ActionMetaTabBar({ group, updateGroup, updateGroupSilent }: Prop
         </div>
       )}
 
-      {/* アクティブタブの body を全幅で展開 */}
+      {/* アクティブタブの body を全幅で展開。
+          data-step-id="__meta-tab-xxx" を付与することで DrawingOverlay が
+          描画マーカーを body 要素に anchor 追従させる (タブ切替で body が消えると
+          orphan 扱いで非表示、再度開くと元位置に戻る)。 */}
       {active === "info" && (
-        <div className="action-meta-body action-meta-info-body">
+        <div className="action-meta-body action-meta-info-body" data-step-id="__meta-tab-info">
           <div className="row g-2">
             <div className="col-md-4">
               <label className="form-label small fw-semibold">名前</label>
@@ -246,22 +249,34 @@ export function ActionMetaTabBar({ group, updateGroup, updateGroupSilent }: Prop
         </div>
       )}
       {active === "marker" && (
-        <MarkerPanel group={group} onChange={onMarkersChange} render="bodyOnly" />
+        <div className="action-meta-body" data-step-id="__meta-tab-marker">
+          <MarkerPanel group={group} onChange={onMarkersChange} render="bodyOnly" />
+        </div>
       )}
       {active === "error" && (
-        <ErrorCatalogPanel group={group} onChange={onErrorCatalogChange} render="bodyOnly" />
+        <div className="action-meta-body" data-step-id="__meta-tab-error">
+          <ErrorCatalogPanel group={group} onChange={onErrorCatalogChange} render="bodyOnly" />
+        </div>
       )}
       {active === "ambient" && (
-        <AmbientVariablesPanel group={group} onChange={onAmbientChange} render="bodyOnly" />
+        <div className="action-meta-body" data-step-id="__meta-tab-ambient">
+          <AmbientVariablesPanel group={group} onChange={onAmbientChange} render="bodyOnly" />
+        </div>
       )}
       {active === "secrets" && (
-        <SecretsCatalogPanel group={group} onChange={onSecretsChange} render="bodyOnly" />
+        <div className="action-meta-body" data-step-id="__meta-tab-secrets">
+          <SecretsCatalogPanel group={group} onChange={onSecretsChange} render="bodyOnly" />
+        </div>
       )}
       {active === "external" && (
-        <ExternalSystemCatalogPanel group={group} onChange={onExternalChange} render="bodyOnly" />
+        <div className="action-meta-body" data-step-id="__meta-tab-external">
+          <ExternalSystemCatalogPanel group={group} onChange={onExternalChange} render="bodyOnly" />
+        </div>
       )}
       {active === "type" && (
-        <TypeCatalogPanel group={group} onChange={onTypeChange} render="bodyOnly" />
+        <div className="action-meta-body" data-step-id="__meta-tab-type">
+          <TypeCatalogPanel group={group} onChange={onTypeChange} render="bodyOnly" />
+        </div>
       )}
     </div>
   );

--- a/designer/src/components/action/AmbientVariablesPanel.tsx
+++ b/designer/src/components/action/AmbientVariablesPanel.tsx
@@ -10,12 +10,21 @@ import type { ActionGroup, StructuredField, FieldType } from "../../types/action
 interface Props {
   group: ActionGroup;
   onChange: (group: ActionGroup) => void;
+  expanded?: boolean;
+  onExpandedChange?: (next: boolean) => void;
+  render?: "full" | "toggleOnly" | "bodyOnly";
 }
 
 const PRIMITIVE_TYPES: Array<FieldType & string> = ["string", "number", "boolean", "date"];
 
-export function AmbientVariablesPanel({ group, onChange }: Props) {
-  const [expanded, setExpanded] = useState(false);
+export function AmbientVariablesPanel({ group, onChange, expanded: expandedProp, onExpandedChange, render = "full" }: Props) {
+  const [expandedState, setExpandedState] = useState(false);
+  const isControlled = expandedProp !== undefined;
+  const expanded = isControlled ? expandedProp : expandedState;
+  const setExpanded = (next: boolean) => {
+    if (!isControlled) setExpandedState(next);
+    onExpandedChange?.(next);
+  };
   const vars = group.ambientVariables ?? [];
 
   const update = (idx: number, patch: Partial<StructuredField>) => {
@@ -33,18 +42,22 @@ export function AmbientVariablesPanel({ group, onChange }: Props) {
     onChange({ ...group, ambientVariables: next.length > 0 ? next : undefined });
   };
 
+  const showToggle = render !== "bodyOnly";
+  const showBody = render === "bodyOnly" || (render !== "toggleOnly" && expanded);
   return (
     <div className="catalog-panel ambient-variables-panel">
-      <button
-        type="button"
-        className="catalog-panel-toggle"
-        onClick={() => setExpanded((v) => !v)}
-      >
-        <i className={`bi bi-chevron-${expanded ? "down" : "right"}`} />
-        <i className="bi bi-box-arrow-in-down-left" />
-        {" "}Ambient 変数 (ambientVariables: {vars.length} 件)
-      </button>
-      {expanded && (
+      {showToggle && (
+        <button
+          type="button"
+          className="catalog-panel-toggle"
+          onClick={() => setExpanded(!expanded)}
+        >
+          <i className={`bi bi-chevron-${expanded ? "down" : "right"}`} />
+          <i className="bi bi-box-arrow-in-down-left" />
+          {" "}Ambient 変数 (ambientVariables: {vars.length} 件)
+        </button>
+      )}
+      {showBody && (
         <div className="catalog-panel-body">
           <div className="catalog-help">
             ミドルウェア / フレームワーク由来の自動注入変数を宣言。@requestId / @traceId /

--- a/designer/src/components/action/ErrorCatalogPanel.tsx
+++ b/designer/src/components/action/ErrorCatalogPanel.tsx
@@ -10,10 +10,19 @@ import type { ActionGroup, ErrorCatalogEntry } from "../../types/action";
 interface Props {
   group: ActionGroup;
   onChange: (group: ActionGroup) => void;
+  expanded?: boolean;
+  onExpandedChange?: (next: boolean) => void;
+  render?: "full" | "toggleOnly" | "bodyOnly";
 }
 
-export function ErrorCatalogPanel({ group, onChange }: Props) {
-  const [expanded, setExpanded] = useState(false);
+export function ErrorCatalogPanel({ group, onChange, expanded: expandedProp, onExpandedChange, render = "full" }: Props) {
+  const [expandedState, setExpandedState] = useState(false);
+  const isControlled = expandedProp !== undefined;
+  const expanded = isControlled ? expandedProp : expandedState;
+  const setExpanded = (next: boolean) => {
+    if (!isControlled) setExpandedState(next);
+    onExpandedChange?.(next);
+  };
   const [newKey, setNewKey] = useState("");
   const catalog = group.errorCatalog ?? {};
   const keys = Object.keys(catalog);
@@ -41,18 +50,22 @@ export function ErrorCatalogPanel({ group, onChange }: Props) {
     setNewKey("");
   };
 
+  const showToggle = render !== "bodyOnly";
+  const showBody = render === "bodyOnly" || (render !== "toggleOnly" && expanded);
   return (
     <div className="catalog-panel error-catalog-panel">
-      <button
-        type="button"
-        className="catalog-panel-toggle"
-        onClick={() => setExpanded((v) => !v)}
-      >
-        <i className={`bi bi-chevron-${expanded ? "down" : "right"}`} />
-        <i className="bi bi-exclamation-diamond" />
-        {" "}エラーカタログ (errorCatalog: {keys.length} 件)
-      </button>
-      {expanded && (
+      {showToggle && (
+        <button
+          type="button"
+          className="catalog-panel-toggle"
+          onClick={() => setExpanded(!expanded)}
+        >
+          <i className={`bi bi-chevron-${expanded ? "down" : "right"}`} />
+          <i className="bi bi-exclamation-diamond" />
+          {" "}エラーカタログ (errorCatalog: {keys.length} 件)
+        </button>
+      )}
+      {showBody && (
         <div className="catalog-panel-body">
           <div className="catalog-help">
             errorCode を 1 箇所に集約。affectedRowsCheck.errorCode /

--- a/designer/src/components/action/ExternalSystemCatalogPanel.tsx
+++ b/designer/src/components/action/ExternalSystemCatalogPanel.tsx
@@ -7,12 +7,21 @@ import type { ActionGroup, ExternalSystemCatalogEntry, ExternalAuthKind } from "
 interface Props {
   group: ActionGroup;
   onChange: (group: ActionGroup) => void;
+  expanded?: boolean;
+  onExpandedChange?: (next: boolean) => void;
+  render?: "full" | "toggleOnly" | "bodyOnly";
 }
 
 const AUTH_KINDS: ExternalAuthKind[] = ["bearer", "basic", "apiKey", "oauth2", "none"];
 
-export function ExternalSystemCatalogPanel({ group, onChange }: Props) {
-  const [expanded, setExpanded] = useState(false);
+export function ExternalSystemCatalogPanel({ group, onChange, expanded: expandedProp, onExpandedChange, render = "full" }: Props) {
+  const [expandedState, setExpandedState] = useState(false);
+  const isControlled = expandedProp !== undefined;
+  const expanded = isControlled ? expandedProp : expandedState;
+  const setExpanded = (next: boolean) => {
+    if (!isControlled) setExpandedState(next);
+    onExpandedChange?.(next);
+  };
   const [newKey, setNewKey] = useState("");
   const catalog = group.externalSystemCatalog ?? {};
   const keys = Object.keys(catalog);
@@ -38,18 +47,22 @@ export function ExternalSystemCatalogPanel({ group, onChange }: Props) {
     setNewKey("");
   };
 
+  const showToggle = render !== "bodyOnly";
+  const showBody = render === "bodyOnly" || (render !== "toggleOnly" && expanded);
   return (
     <div className="catalog-panel external-system-catalog-panel">
-      <button
-        type="button"
-        className="catalog-panel-toggle"
-        onClick={() => setExpanded((v) => !v)}
-      >
-        <i className={`bi bi-chevron-${expanded ? "down" : "right"}`} />
-        <i className="bi bi-cloud" />
-        {" "}外部システム (externalSystemCatalog: {keys.length} 件)
-      </button>
-      {expanded && (
+      {showToggle && (
+        <button
+          type="button"
+          className="catalog-panel-toggle"
+          onClick={() => setExpanded(!expanded)}
+        >
+          <i className={`bi bi-chevron-${expanded ? "down" : "right"}`} />
+          <i className="bi bi-cloud" />
+          {" "}外部システム (externalSystemCatalog: {keys.length} 件)
+        </button>
+      )}
+      {showBody && (
         <div className="catalog-panel-body">
           <div className="catalog-help">
             同じ外部システム (Stripe 等) を複数 step で使う場合の共通設定。

--- a/designer/src/components/action/MarkerPanel.tsx
+++ b/designer/src/components/action/MarkerPanel.tsx
@@ -38,6 +38,11 @@ function collectStepIds(group: ActionGroup): Set<string> {
 interface Props {
   group: ActionGroup;
   onChange: (group: ActionGroup) => void;
+  /** 親から排他展開を制御する場合に指定 (undefined なら内部 state) */
+  expanded?: boolean;
+  onExpandedChange?: (next: boolean) => void;
+  /** ActionMetaTabBar から toggle / body を別 DOM 位置に描画する場合に使用 */
+  render?: "full" | "toggleOnly" | "bodyOnly";
 }
 
 const KIND_LABELS: Record<MarkerKind, string> = {
@@ -53,10 +58,16 @@ const KIND_ICONS: Record<MarkerKind, string> = {
   question: "bi-question-circle",
 };
 
-export function MarkerPanel({ group, onChange }: Props) {
+export function MarkerPanel({ group, onChange, expanded: expandedProp, onExpandedChange, render = "full" }: Props) {
   // 既定で折りたたみ (#261 anchor 改善とセット): マーカー追加/解決時の
   // 縦方向レイアウト揺れを抑えて、描画マーカーの画面内位置ずれを減らす。
-  const [expanded, setExpanded] = useState(false);
+  const [expandedState, setExpandedState] = useState(false);
+  const isControlled = expandedProp !== undefined;
+  const expanded = isControlled ? expandedProp : expandedState;
+  const setExpanded = (next: boolean) => {
+    if (!isControlled) setExpandedState(next);
+    onExpandedChange?.(next);
+  };
   const [newKind, setNewKind] = useState<MarkerKind>("chat");
   const [newBody, setNewBody] = useState("");
   const [showResolved, setShowResolved] = useState(false);
@@ -125,18 +136,22 @@ export function MarkerPanel({ group, onChange }: Props) {
     onChange({ ...group, markers: next });
   };
 
+  const showToggle = render !== "bodyOnly";
+  const showBody = render === "bodyOnly" || (render !== "toggleOnly" && expanded);
   return (
     <div className="catalog-panel marker-panel">
-      <button
-        type="button"
-        className="catalog-panel-toggle"
-        onClick={() => setExpanded((v) => !v)}
-      >
-        <i className={`bi bi-chevron-${expanded ? "down" : "right"}`} />
-        <i className="bi bi-megaphone" />
-        {" "}AI へのマーカー ({unresolved} 未解決 / {markers.length} 総件数)
-      </button>
-      {expanded && (
+      {showToggle && (
+        <button
+          type="button"
+          className="catalog-panel-toggle"
+          onClick={() => setExpanded(!expanded)}
+        >
+          <i className={`bi bi-chevron-${expanded ? "down" : "right"}`} />
+          <i className="bi bi-megaphone" />
+          {" "}AI へのマーカー ({unresolved} 未解決 / {markers.length} 総件数)
+        </button>
+      )}
+      {showBody && (
         <div className="catalog-panel-body">
           <div className="catalog-help">
             AI (Claude Code) への指示・質問を保持。

--- a/designer/src/components/action/MarkerPanel.tsx
+++ b/designer/src/components/action/MarkerPanel.tsx
@@ -81,7 +81,11 @@ export function MarkerPanel({ group, onChange, expanded: expandedProp, onExpande
   const existingStepIds = useMemo(() => collectStepIds(group), [group]);
   const isOrphanAnchor = (m: Marker): boolean => {
     const anchorId = m.shape?.anchorStepId ?? m.stepId;
-    return !!anchorId && !existingStepIds.has(anchorId);
+    if (!anchorId) return false;
+    // ActionMetaTabBar の body (基本情報タブ/カタログタブ) に描画された場合の擬似 ID (#309 フォローアップ)
+    // これは group.actions[*].steps に存在しないが orphan ではなく「タブが閉じている」状態なので除外
+    if (anchorId.startsWith("__meta-tab-")) return false;
+    return !existingStepIds.has(anchorId);
   };
 
   const addMarker = () => {

--- a/designer/src/components/action/SecretsCatalogPanel.tsx
+++ b/designer/src/components/action/SecretsCatalogPanel.tsx
@@ -7,10 +7,19 @@ import type { ActionGroup, SecretRef } from "../../types/action";
 interface Props {
   group: ActionGroup;
   onChange: (group: ActionGroup) => void;
+  expanded?: boolean;
+  onExpandedChange?: (next: boolean) => void;
+  render?: "full" | "toggleOnly" | "bodyOnly";
 }
 
-export function SecretsCatalogPanel({ group, onChange }: Props) {
-  const [expanded, setExpanded] = useState(false);
+export function SecretsCatalogPanel({ group, onChange, expanded: expandedProp, onExpandedChange, render = "full" }: Props) {
+  const [expandedState, setExpandedState] = useState(false);
+  const isControlled = expandedProp !== undefined;
+  const expanded = isControlled ? expandedProp : expandedState;
+  const setExpanded = (next: boolean) => {
+    if (!isControlled) setExpandedState(next);
+    onExpandedChange?.(next);
+  };
   const [newKey, setNewKey] = useState("");
   const catalog = group.secretsCatalog ?? {};
   const keys = Object.keys(catalog);
@@ -33,18 +42,22 @@ export function SecretsCatalogPanel({ group, onChange }: Props) {
     setNewKey("");
   };
 
+  const showToggle = render !== "bodyOnly";
+  const showBody = render === "bodyOnly" || (render !== "toggleOnly" && expanded);
   return (
     <div className="catalog-panel secrets-catalog-panel">
-      <button
-        type="button"
-        className="catalog-panel-toggle"
-        onClick={() => setExpanded((v) => !v)}
-      >
-        <i className={`bi bi-chevron-${expanded ? "down" : "right"}`} />
-        <i className="bi bi-key" />
-        {" "}Secrets (secretsCatalog: {keys.length} 件)
-      </button>
-      {expanded && (
+      {showToggle && (
+        <button
+          type="button"
+          className="catalog-panel-toggle"
+          onClick={() => setExpanded(!expanded)}
+        >
+          <i className={`bi bi-chevron-${expanded ? "down" : "right"}`} />
+          <i className="bi bi-key" />
+          {" "}Secrets (secretsCatalog: {keys.length} 件)
+        </button>
+      )}
+      {showBody && (
         <div className="catalog-panel-body">
           <div className="catalog-help">
             秘匿値のメタデータのみ管理。値そのものは含まない。

--- a/designer/src/components/action/StructuredFieldsEditor.tsx
+++ b/designer/src/components/action/StructuredFieldsEditor.tsx
@@ -141,21 +141,31 @@ export function StructuredFieldsEditor({ label, fields, onChange, onCommit, plac
                     />
                   </td>
                   <td>
-                    <select
-                      className="form-select form-select-sm"
-                      value={typeof f.type === "string" ? f.type : "custom"}
+                    <input
+                      type="text"
+                      list="structured-fields-type-list"
+                      className="form-control form-control-sm"
+                      value={typeof f.type === "string"
+                        ? f.type
+                        : f.type.kind === "custom"
+                          ? f.type.label ?? ""
+                          : ""}
                       onChange={(e) => {
                         const v = e.target.value;
-                        if (PRIMITIVE_TYPES.includes(v as "string" | "number" | "boolean" | "date")) {
+                        if (v === "") {
+                          updateField(i, { type: "string" });
+                        } else if ((PRIMITIVE_TYPES as string[]).includes(v)) {
                           updateField(i, { type: v as FieldType });
                         } else {
-                          updateField(i, { type: { kind: "custom", label: "" } });
+                          updateField(i, { type: { kind: "custom", label: v } });
                         }
                       }}
-                    >
-                      {PRIMITIVE_TYPES.map((t) => <option key={t} value={t}>{t}</option>)}
-                      <option value="custom">custom</option>
-                    </select>
+                      onBlur={() => onCommit?.()}
+                      placeholder="型 (string/DTO名 等)"
+                      title={typeof f.type === "object" && f.type.kind === "custom"
+                        ? `カスタム型: ${f.type.label}`
+                        : undefined}
+                    />
                   </td>
                   <td className="text-center">
                     <input
@@ -199,6 +209,10 @@ export function StructuredFieldsEditor({ label, fields, onChange, onCommit, plac
           >
             <i className="bi bi-plus-lg" /> フィールド追加
           </button>
+          {/* 型入力の候補 (primitive のみ提示、自由入力も可) — 全 row 共有 */}
+          <datalist id="structured-fields-type-list">
+            {PRIMITIVE_TYPES.map((t) => <option key={t} value={t} />)}
+          </datalist>
         </div>
       )}
     </div>

--- a/designer/src/components/action/StructuredFieldsEditor.tsx
+++ b/designer/src/components/action/StructuredFieldsEditor.tsx
@@ -13,9 +13,9 @@ interface Props {
 const PRIMITIVE_TYPES: Array<"string" | "number" | "boolean" | "date"> = ["string", "number", "boolean", "date"];
 
 /**
- * ActionDefinition.inputs / outputs の編集 UI (#226)。
+ * ActionDefinition.inputs / outputs の編集 UI (#226 / #310)。
  * 自由記述モード (textarea) と表形式モード (StructuredField[]) を切替可能。
- * 表形式では name / type / required / description を編集。
+ * 表形式では 1 項目 1 行の <table> で name / label / type / required / description を編集。
  * FieldType は primitive + custom のみ対応、tableRow/tableList/screenInput は将来。
  */
 export function StructuredFieldsEditor({ label, fields, onChange, onCommit, placeholder }: Props) {
@@ -57,14 +57,13 @@ export function StructuredFieldsEditor({ label, fields, onChange, onCommit, plac
 
   return (
     <div className="structured-fields-editor">
-      <div className="d-flex align-items-center gap-2 mb-1">
+      <div className="structured-fields-header">
         <label className="form-label mb-0">{label}</label>
         <div className="btn-group btn-group-sm" role="group" aria-label="表示モード">
           <button
             type="button"
             className={`btn btn-outline-secondary${mode === "text" ? " active" : ""}`}
             onClick={switchToText}
-            style={{ fontSize: "0.7rem", padding: "0 6px" }}
             title="自由記述モード (改行区切り)"
           >
             <i className="bi bi-text-paragraph" />
@@ -73,7 +72,6 @@ export function StructuredFieldsEditor({ label, fields, onChange, onCommit, plac
             type="button"
             className={`btn btn-outline-secondary${mode === "table" ? " active" : ""}`}
             onClick={switchToTable}
-            style={{ fontSize: "0.7rem", padding: "0 6px" }}
             title="表形式モード (構造化)"
           >
             <i className="bi bi-table" />
@@ -91,91 +89,113 @@ export function StructuredFieldsEditor({ label, fields, onChange, onCommit, plac
           placeholder={placeholder}
         />
       ) : (
-        <div style={{ fontSize: "0.8rem" }}>
-          {isStructured && fields.length === 0 && (
-            <div className="text-muted small mb-1">フィールドなし</div>
-          )}
-          {isStructured && fields.map((f, i) => (
-            <div key={i} className="row g-1 mb-1 align-items-center">
-              <div className="col-3">
-                <input
-                  type="text"
-                  className="form-control form-control-sm"
-                  value={f.name}
-                  onChange={(e) => updateField(i, { name: e.target.value })}
-                  onBlur={() => onCommit?.()}
-                  placeholder="name"
-                  style={{ fontSize: "0.8rem" }}
-                />
-              </div>
-              <div className="col-2">
-                <input
-                  type="text"
-                  className="form-control form-control-sm"
-                  value={f.label ?? ""}
-                  onChange={(e) => updateField(i, { label: e.target.value || undefined })}
-                  onBlur={() => onCommit?.()}
-                  placeholder="label"
-                  style={{ fontSize: "0.8rem" }}
-                />
-              </div>
-              <div className="col-2">
-                <select
-                  className="form-select form-select-sm"
-                  value={typeof f.type === "string" ? f.type : "custom"}
-                  onChange={(e) => {
-                    const v = e.target.value;
-                    if (PRIMITIVE_TYPES.includes(v as "string" | "number" | "boolean" | "date")) {
-                      updateField(i, { type: v as FieldType });
-                    } else {
-                      updateField(i, { type: { kind: "custom", label: "" } });
-                    }
-                  }}
-                  style={{ fontSize: "0.8rem" }}
-                >
-                  {PRIMITIVE_TYPES.map((t) => <option key={t} value={t}>{t}</option>)}
-                  <option value="custom">custom</option>
-                </select>
-              </div>
-              <div className="col-auto" style={{ width: 70 }}>
-                <label className="form-check-label small">
-                  <input
-                    type="checkbox"
-                    className="form-check-input me-1"
-                    checked={!!f.required}
-                    onChange={(e) => updateField(i, { required: e.target.checked || undefined })}
-                  />
-                  必須
-                </label>
-              </div>
-              <div className="col">
-                <input
-                  type="text"
-                  className="form-control form-control-sm"
-                  value={f.description ?? ""}
-                  onChange={(e) => updateField(i, { description: e.target.value || undefined })}
-                  onBlur={() => onCommit?.()}
-                  placeholder="description"
-                  style={{ fontSize: "0.8rem" }}
-                />
-              </div>
-              <div className="col-auto">
-                <button
-                  type="button"
-                  className="btn btn-sm btn-link text-danger p-0"
-                  onClick={() => removeField(i)}
-                  title="削除"
-                >
-                  <i className="bi bi-x" />
-                </button>
-              </div>
-            </div>
-          ))}
+        <div className="structured-fields-body">
+          <table className="structured-fields-table">
+            <colgroup>
+              <col className="col-no" />
+              <col className="col-name" />
+              <col className="col-label" />
+              <col className="col-type" />
+              <col className="col-required" />
+              <col className="col-desc" />
+              <col className="col-actions" />
+            </colgroup>
+            <thead>
+              <tr>
+                <th scope="col">#</th>
+                <th scope="col">名前</th>
+                <th scope="col">日本語名</th>
+                <th scope="col">型</th>
+                <th scope="col" className="text-center">必須</th>
+                <th scope="col">説明</th>
+                <th scope="col" aria-label="操作" />
+              </tr>
+            </thead>
+            <tbody>
+              {isStructured && fields.length === 0 && (
+                <tr>
+                  <td colSpan={7} className="structured-fields-empty">フィールドなし</td>
+                </tr>
+              )}
+              {isStructured && fields.map((f, i) => (
+                <tr key={i}>
+                  <td className="structured-fields-no">{i + 1}</td>
+                  <td>
+                    <input
+                      type="text"
+                      className="form-control form-control-sm"
+                      value={f.name}
+                      onChange={(e) => updateField(i, { name: e.target.value })}
+                      onBlur={() => onCommit?.()}
+                      placeholder="name"
+                    />
+                  </td>
+                  <td>
+                    <input
+                      type="text"
+                      className="form-control form-control-sm"
+                      value={f.label ?? ""}
+                      onChange={(e) => updateField(i, { label: e.target.value || undefined })}
+                      onBlur={() => onCommit?.()}
+                      placeholder="label"
+                    />
+                  </td>
+                  <td>
+                    <select
+                      className="form-select form-select-sm"
+                      value={typeof f.type === "string" ? f.type : "custom"}
+                      onChange={(e) => {
+                        const v = e.target.value;
+                        if (PRIMITIVE_TYPES.includes(v as "string" | "number" | "boolean" | "date")) {
+                          updateField(i, { type: v as FieldType });
+                        } else {
+                          updateField(i, { type: { kind: "custom", label: "" } });
+                        }
+                      }}
+                    >
+                      {PRIMITIVE_TYPES.map((t) => <option key={t} value={t}>{t}</option>)}
+                      <option value="custom">custom</option>
+                    </select>
+                  </td>
+                  <td className="text-center">
+                    <input
+                      type="checkbox"
+                      className="form-check-input structured-fields-required"
+                      checked={!!f.required}
+                      onChange={(e) => updateField(i, { required: e.target.checked || undefined })}
+                      aria-label="必須"
+                    />
+                  </td>
+                  <td>
+                    <input
+                      type="text"
+                      className="form-control form-control-sm"
+                      value={f.description ?? ""}
+                      onChange={(e) => updateField(i, { description: e.target.value || undefined })}
+                      onBlur={() => onCommit?.()}
+                      placeholder="description"
+                      title={f.description ?? ""}
+                    />
+                  </td>
+                  <td className="text-center">
+                    <button
+                      type="button"
+                      className="btn btn-sm btn-link text-danger p-0 structured-fields-delete"
+                      onClick={() => removeField(i)}
+                      title="削除"
+                      aria-label="削除"
+                    >
+                      <i className="bi bi-x" />
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
           <button
             type="button"
-            className="btn btn-sm btn-outline-secondary py-0"
+            className="btn btn-sm btn-outline-secondary structured-fields-add"
             onClick={() => { addField(); onCommit?.(); }}
-            style={{ fontSize: "0.75rem" }}
           >
             <i className="bi bi-plus-lg" /> フィールド追加
           </button>

--- a/designer/src/components/action/TypeCatalogPanel.tsx
+++ b/designer/src/components/action/TypeCatalogPanel.tsx
@@ -10,6 +10,9 @@ import type { ActionGroup, TypeCatalogEntry } from "../../types/action";
 interface Props {
   group: ActionGroup;
   onChange: (group: ActionGroup) => void;
+  expanded?: boolean;
+  onExpandedChange?: (next: boolean) => void;
+  render?: "full" | "toggleOnly" | "bodyOnly";
 }
 
 interface EntryEditorProps {
@@ -75,8 +78,14 @@ function EntryEditor({ entryKey, entry, onChange, onRemove }: EntryEditorProps) 
   );
 }
 
-export function TypeCatalogPanel({ group, onChange }: Props) {
-  const [expanded, setExpanded] = useState(false);
+export function TypeCatalogPanel({ group, onChange, expanded: expandedProp, onExpandedChange, render = "full" }: Props) {
+  const [expandedState, setExpandedState] = useState(false);
+  const isControlled = expandedProp !== undefined;
+  const expanded = isControlled ? expandedProp : expandedState;
+  const setExpanded = (next: boolean) => {
+    if (!isControlled) setExpandedState(next);
+    onExpandedChange?.(next);
+  };
   const [newKey, setNewKey] = useState("");
   const catalog = group.typeCatalog ?? {};
   const keys = Object.keys(catalog);
@@ -102,18 +111,22 @@ export function TypeCatalogPanel({ group, onChange }: Props) {
     setNewKey("");
   };
 
+  const showToggle = render !== "bodyOnly";
+  const showBody = render === "bodyOnly" || (render !== "toggleOnly" && expanded);
   return (
     <div className="catalog-panel type-catalog-panel">
-      <button
-        type="button"
-        className="catalog-panel-toggle"
-        onClick={() => setExpanded((v) => !v)}
-      >
-        <i className={`bi bi-chevron-${expanded ? "down" : "right"}`} />
-        <i className="bi bi-braces" />
-        {" "}型カタログ (typeCatalog: {keys.length} 件)
-      </button>
-      {expanded && (
+      {showToggle && (
+        <button
+          type="button"
+          className="catalog-panel-toggle"
+          onClick={() => setExpanded(!expanded)}
+        >
+          <i className={`bi bi-chevron-${expanded ? "down" : "right"}`} />
+          <i className="bi bi-braces" />
+          {" "}型カタログ (typeCatalog: {keys.length} 件)
+        </button>
+      )}
+      {showBody && (
         <div className="catalog-panel-body">
           <div className="catalog-help">
             HttpResponseSpec.bodySchema = {"{"} typeRef: &lt;key&gt; {"}"} の解決先。

--- a/designer/src/styles/action.css
+++ b/designer/src/styles/action.css
@@ -239,9 +239,11 @@
 /* ─── I/O パネル ─────────────────────────────────────────────────── */
 
 .action-io-panel {
+  /* #310: 上下 2 段 (1fr) に変更。以前は 1fr 1fr で左右分割していたが
+     表形式モードで幅が狭く折り返して縦積みに見えていたため、全幅を確保。 */
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 12px;
+  grid-template-columns: 1fr;
+  gap: 10px;
   margin-bottom: 16px;
   padding: 12px;
   background: #f8fafc;
@@ -260,6 +262,91 @@
   font-size: 0.82rem;
   min-height: 32px;
   resize: vertical;
+}
+
+/* StructuredFieldsEditor (#310): 1 項目 1 行テーブル */
+.structured-fields-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.structured-fields-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.structured-fields-header .btn-group .btn {
+  font-size: 0.7rem;
+  padding: 0 6px;
+}
+.structured-fields-body {
+  font-size: 0.78rem;
+}
+.structured-fields-table {
+  width: 100%;
+  table-layout: fixed;
+  border-collapse: collapse;
+  margin: 0;
+}
+.structured-fields-table thead th {
+  font-size: 0.68rem;
+  font-weight: 600;
+  color: #64748b;
+  letter-spacing: 0.02em;
+  padding: 3px 4px;
+  border-bottom: 1px solid #cbd5e1;
+  text-align: left;
+  background: transparent;
+}
+.structured-fields-table tbody td {
+  padding: 2px 4px;
+  vertical-align: middle;
+  border-bottom: 1px solid #f1f5f9;
+}
+.structured-fields-table tbody tr:last-child td {
+  border-bottom: none;
+}
+.structured-fields-table input.form-control,
+.structured-fields-table select.form-select {
+  width: 100%;
+  padding: 2px 6px;
+  font-size: 0.78rem;
+  min-width: 0;
+  min-height: 24px;
+  height: 26px;
+}
+.structured-fields-table .col-no { width: 32px; }
+.structured-fields-table .col-name { width: 11em; }
+.structured-fields-table .col-label { width: 9em; }
+.structured-fields-table .col-type { width: 7em; }
+.structured-fields-table .col-required { width: 3.5em; }
+.structured-fields-table .col-desc { width: auto; }
+.structured-fields-table .col-actions { width: 28px; }
+.structured-fields-no {
+  color: #94a3b8;
+  font-size: 0.7rem;
+  text-align: center;
+}
+.structured-fields-required {
+  margin: 0 auto;
+  display: block;
+}
+.structured-fields-delete {
+  line-height: 1;
+  padding: 0 !important;
+}
+.structured-fields-empty {
+  color: #94a3b8;
+  padding: 10px;
+  text-align: center;
+  font-style: italic;
+  font-size: 0.78rem;
+}
+.structured-fields-add {
+  font-size: 0.75rem;
+  margin-top: 4px;
+  align-self: flex-start;
+  padding: 2px 10px;
 }
 
 /* ─── ステップエディタ ────────────────────────────────────────────── */

--- a/designer/src/styles/action.css
+++ b/designer/src/styles/action.css
@@ -11,7 +11,8 @@
 .action-content {
   flex: 1;
   overflow-y: auto;
-  padding: 20px;
+  /* #309 フォローアップ: 情報密度優先。4K で余白過多にならないよう縦 8px / 横 14px */
+  padding: 8px 14px;
 }
 
 /* ─── 処理フロー一覧 ─────────────────────────────────────────────── */
@@ -1258,19 +1259,19 @@
    ActionEditor 上部の基本情報 + 6 カタログを 1 行のタブバーに集約し、
    排他的に 1 つだけ body を全幅で展開する。 */
 .action-meta-tabbar {
-  padding: 6px 20px;
+  padding: 3px 14px;
   background: #fff;
   border-bottom: 1px solid #e2e8f0;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 2px;
 }
 .action-meta-tabs {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 4px;
-  row-gap: 4px;
+  gap: 3px;
+  row-gap: 3px;
 }
 .action-meta-tabs .catalog-panel {
   margin: 0;
@@ -1278,8 +1279,8 @@
 }
 .action-meta-tabs .catalog-panel-toggle {
   width: auto;
-  padding: 4px 10px;
-  font-size: 0.78rem;
+  padding: 2px 8px;
+  font-size: 0.76rem;
 }
 /* アクティブ (展開中) のパネルを強調: chevron-down アイコンの存在で判定 (:has) */
 .action-meta-tabs .catalog-panel:has(.bi-chevron-down) {
@@ -1314,15 +1315,15 @@
   border: 1px solid #e2e8f0;
 }
 .action-meta-body {
-  padding: 10px 14px;
+  padding: 6px 10px;
   background: #f8fafc;
   border: 1px solid #cbd5e1;
-  border-radius: 6px;
+  border-radius: 4px;
   max-height: 50vh;
   overflow-y: auto;
 }
 .action-meta-body.action-meta-info-body {
-  padding: 12px 14px;
+  padding: 8px 10px;
 }
 /* メタタブバー配下の body は外枠はタブバーが提供するので、
    各 Panel の border は解除して内側 padding のみにする */

--- a/designer/src/styles/action.css
+++ b/designer/src/styles/action.css
@@ -239,8 +239,9 @@
 /* ─── I/O パネル ─────────────────────────────────────────────────── */
 
 .action-io-panel {
-  /* #310: 上下 2 段 (1fr) に変更。以前は 1fr 1fr で左右分割していたが
-     表形式モードで幅が狭く折り返して縦積みに見えていたため、全幅を確保。 */
+  /* #310: 上下 2 段 (1fr) を既定に。以前は 1fr 1fr で左右分割していたが、
+     表形式モードで幅が狭く折り返して縦積みに見えていたため、全幅を確保。
+     #310 フォローアップ: 高解像度では左右 2 列に戻す (下の media query 参照)。 */
   display: grid;
   grid-template-columns: 1fr;
   gap: 10px;
@@ -249,6 +250,15 @@
   background: #f8fafc;
   border: 1px solid #e2e8f0;
   border-radius: 6px;
+}
+/* 1600px 以上 (4K 半分や 1920 以上の横広) では入出力を左右並びに戻す。
+   table-layout: fixed + col-*: 11em+9em+7em+... の合計 ≒ 400px 以上あれば折り返し
+   なく 1 項目 1 行が収まる。1600px / 2 ≒ 780px > 400px で十分余裕がある。 */
+@media (min-width: 1600px) {
+  .action-io-panel {
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+  }
 }
 
 .action-io-field .form-label {

--- a/designer/src/styles/action.css
+++ b/designer/src/styles/action.css
@@ -186,16 +186,6 @@
   text-decoration: underline;
 }
 
-.action-editor-info {
-  padding: 16px 20px;
-  background: #fff;
-  border-bottom: 1px solid #e2e8f0;
-}
-
-.action-editor-info .row {
-  gap: 8px 0;
-}
-
 /* ─── アクションタブ ──────────────────────────────────────────────── */
 
 .action-tabs {
@@ -1263,11 +1253,95 @@
   cursor: pointer;
 }
 .catalog-panel-toggle:hover { background: #f1f5f9; }
+
+/* ─── メタタブバー (#309) ─────────────────────────────────────────
+   ActionEditor 上部の基本情報 + 6 カタログを 1 行のタブバーに集約し、
+   排他的に 1 つだけ body を全幅で展開する。 */
+.action-meta-tabbar {
+  padding: 6px 20px;
+  background: #fff;
+  border-bottom: 1px solid #e2e8f0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.action-meta-tabs {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
+  row-gap: 4px;
+}
+.action-meta-tabs .catalog-panel {
+  margin: 0;
+  flex: 0 0 auto;
+}
+.action-meta-tabs .catalog-panel-toggle {
+  width: auto;
+  padding: 4px 10px;
+  font-size: 0.78rem;
+}
+/* アクティブ (展開中) のパネルを強調: chevron-down アイコンの存在で判定 (:has) */
+.action-meta-tabs .catalog-panel:has(.bi-chevron-down) {
+  background: #dbeafe;
+  border-color: #60a5fa;
+}
+.action-meta-tabs .catalog-panel:has(.bi-chevron-down) .catalog-panel-toggle {
+  color: #1e40af;
+}
+.action-meta-tabbar-spacer {
+  flex: 1 1 auto;
+}
+.action-meta-tabbar-inline {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.78rem;
+  padding: 0 4px;
+}
+.action-meta-maturity-label {
+  font-weight: 600;
+  color: #475569;
+  font-size: 0.75rem;
+}
+.action-meta-progress {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+}
+.action-meta-body {
+  padding: 10px 14px;
+  background: #f8fafc;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  max-height: 50vh;
+  overflow-y: auto;
+}
+.action-meta-body.action-meta-info-body {
+  padding: 12px 14px;
+}
+/* メタタブバー配下の body は外枠はタブバーが提供するので、
+   各 Panel の border は解除して内側 padding のみにする */
+.action-meta-body > .catalog-panel {
+  margin: 0;
+  border: none;
+  background: transparent;
+}
+.action-meta-body > .catalog-panel > .catalog-panel-body {
+  max-height: none;
+  padding: 0;
+  border-top: none;
+}
 .catalog-panel-body {
   padding: 8px 12px;
   border-top: 1px solid #e2e8f0;
-  /* 長くなった panel (MarkerPanel に marker が大量 等) が .action-editor-info を押し広げて
-     下のステップ領域を viewport 外に押し出すのを防ぐ。各 panel 個別に内部スクロール。 */
+  /* 長くなった panel (MarkerPanel に marker が大量 等) が上部領域を押し広げて
+     下のステップ領域を viewport 外に押し出すのを防ぐ。各 panel 個別に内部スクロール。
+     #309 タブバー化以降は .action-meta-body 内で overrideされる (max-height: none)。 */
   max-height: 40vh;
   overflow-y: auto;
 }

--- a/designer/src/styles/action.css
+++ b/designer/src/styles/action.css
@@ -362,8 +362,9 @@
 /* ─── ステップエディタ ────────────────────────────────────────────── */
 
 .step-editor {
-  padding: 20px;
-  max-width: 800px;
+  /* #313: max-width 800px を撤去し viewport 幅を活かす。padding は親の
+     .action-content が担当するので 0。4K でもパネル幅を有効利用する。 */
+  padding: 0;
 }
 
 .step-toolbar {


### PR DESCRIPTION
## 関連

- Closes #309 (上部カタログ群のサブタブバー化)
- Closes #310 (入出力定義の 1 項目 1 行化)
- Closes #313 (step-editor の max-width 撤去)
- base: `main`

> 当初 3 本に分けていた PR (#311 / #312 / #314) を、**同じ画面への連続修正は 1 機能として判断したい** とのレビューを受けて 1 本に統合。#312 / #314 は close 予定。

## 概要

処理フローエディタの UX を 3 ISSUE ぶん一括改善する:

1. **上部カタログ群のサブタブバー化 (#309)** — `action-editor-info` に縦積みされていた 6 カタログパネル + 基本情報を 1〜2 行のタブバーに集約し、排他的に 1 つだけ body を全幅展開
2. **入出力定義の 1 項目 1 行テーブル化 (#310)** — `StructuredFieldsEditor` を `<table>` に書き換えて画面幅に関わらず 1 項目 = 1 行を保証。幅が 1600px 以上なら入出力を左右 2 列に並べる
3. **step-editor の横幅拡張 (#313)** — `.step-editor { max-width: 800px }` を撤去して 4K 等の高解像度で viewport 幅を活用

加えて、視覚確認を通じてユーザーから得たフィードバックに沿って以下も同じ PR に含める:

- タブ body 内描画マーカーの位置ずれ修正 (タブ body に `data-step-id="__meta-tab-{key}"` を付与して既存 anchor 機構で追従)
- タブバー / body 周辺の余白詰め (情報密度優先)
- 型列の自由入力化 (`<select>` → `<input list="...">` で datalist + 任意文字列)

## 主な変更

### 新規
- [`ActionMetaTabBar.tsx`](designer/src/components/action/ActionMetaTabBar.tsx) — 基本情報 + 6 カタログを排他タブで集約。成熟度 / 進捗 / 下流モード警告を常時表示。body に `data-step-id="__meta-tab-{key}"` を付与して DrawingOverlay の anchor 追従対象化

### 変更
- [`ActionEditor.tsx`](designer/src/components/action/ActionEditor.tsx) — 旧 `action-editor-info` (120 行) を `ActionMetaTabBar` 呼び出しに置換。`handleCommitStrokes` で `__meta-tab-*` anchor は Marker.stepId にコピーしない (orphan 誤認防止)
- [`StructuredFieldsEditor.tsx`](designer/src/components/action/StructuredFieldsEditor.tsx) — Bootstrap `row/col` → `<table>` (`#` / `名前` / `日本語名` / `型` / `必須` / `説明` / `×`)。型列は `<input list="structured-fields-type-list">` で datalist + 自由入力
- [`MarkerPanel.tsx`](designer/src/components/action/MarkerPanel.tsx) ほか 5 パネル — `expanded?` / `onExpandedChange?` / `render?: "full" | "toggleOnly" | "bodyOnly"` prop を追加して tabbar からの排他制御対応。orphan 判定は `__meta-tab-*` プレフィックスを除外
- [`action.css`](designer/src/styles/action.css) — `.action-meta-tabbar` / `.action-meta-tabs` / `.action-meta-body` / `.structured-fields-table` 新設。`.step-editor` の `max-width: 800px` を撤去。`.action-io-panel` は `1fr` を既定にし `@media (min-width: 1600px)` で `1fr 1fr` に切替。`.action-content` padding を 20px → 8px 14px に縮小

### 既存 E2E 互換維持
- `.catalog-panel-toggle` / `.structured-fields-editor` / `input[placeholder="name"]` 等の既存セレクタは保持
- `marker-panel.spec.ts:37` の `.marker-panel` セレクタが strict mode 違反になるので `.first()` に更新 (tabbar 側と body 側で 2 箇所に出現するため)

## 仕様逐条突合 (自己申告)

### #309 の完了条件
- ✓ 閉じた状態でステップ領域が通常画面高で最低 3 ステップ分見える → タブバー 1〜2 行で占有 40〜80px 程度。action-content padding 縮小も合わせて HTTP 契約 + responses + 入出力が 900px viewport で収まる
- ✓ 件数バッジが正しく更新される → 各 Panel の既存 toggle テキスト (`AI へのマーカー (2 未解決 / 11 総件数)` など) をそのまま流用
- ✓ 既存 E2E が pass → Playwright 28 件 pass
- △ Playwright で「タブを開く/閉じる」の挙動を追加検証 → 既存 `.catalog-panel-toggle` クリック動線で間接カバー。専用テストは未追加

### #310 の完了条件
- ✓ 1 項目が幅 600px でも横 1 行に収まる → `table-layout: fixed` + 固定列幅 + input `min-width: 0`。`説明` のみ可変、input `title` でホバー全文表示
- ✓ 既存データ (StructuredField[] / string) 両方が表示・編集できる → 既存ヘルパ `isStructuredFields` / `fieldsToText` / `textToStructuredFields` 流用
- ✓ 既存テスト pass → Vitest 496 件 / Playwright `more-ui.spec.ts:170` pass

### #313 の完了条件
- ✓ 1920px で `.step-editor` が最低 1600px 使える → max-width 撤去で viewport - action-content padding = 1892px
- ✓ 4K で `.step-editor` が最低 3000px 使える → 3812px
- ✓ 狭い画面で見切れ・横スクロールなし → max-width 撤去は下限に影響しない
- ✓ StepCard / HTTP 契約 / 入出力が破綻しない → 既存 E2E 全件 pass。内部はもともと width: 100% で fluid

## レビューで特に見てほしい箇所

- **`__meta-tab-*` 擬似 stepId の使い方**: タブ body の DOM に anchor するため data-step-id に擬似値を入れている。Marker.stepId にはコピーしないので MarkerPanel 表示は汚染されないが、shape.anchorStepId は汚染される。schema 厳密性より UX 優先の判断
- **2 重 render**: 各 Panel をタブバー内 (`toggleOnly`) と body 展開時 (`bodyOnly`) で 2 箇所 render。Panel 内の入力 state (`newBody` / `newKey` 等) は body 側にしか立たないので実害なし
- **1600px 境界での切替**: 入出力が上下 2 段 ⇔ 左右 2 列に切替。ブラウザ幅を動かして挙動確認推奨
- **型自由入力の型推論**: 入力値が primitive にマッチなら `FieldType = "string"` 等、それ以外は `{ kind: "custom", label: 入力値 }`。datalist は候補提示のみで任意文字列も受付

## テスト

- Vitest: 496 件 (新規 0 件) — 全件 pass
- Playwright: 28 件 (catalog-panels / marker-panel / drawing-anchor / more-ui / save-reset-action) — 全件 pass
  - `marker-panel.spec.ts:37` の `.first()` 対応のみ軽微更新
- MCP E2E: N/A

## UI 影響 / マージ保留フラグ

- [x] **UI 影響あり (マージ前にユーザー目視確認必須)**

### 確認項目

- [ ] 処理フローエディタ上部: 基本情報 / AI マーカー / エラーカタログ / Ambient / Secrets / 外部 / 型 のタブが横並び、タブクリックで排他展開
- [ ] ステップ本体 (HTTP 契約〜入出力〜最初のステップ) がスクロールなしで見える
- [ ] 基本情報タブで赤線マーカーを引き、他タブに切替 → 再度基本情報を開いたとき元位置にマーカーが戻る
- [ ] 表形式モードで入出力が 1 項目 1 行 (`#` / `名前` / `日本語名` / `型` / `必須` / `説明` / `×`)
- [ ] 1600px 未満: 入出力が上下 2 段、1600px 以上: 左右 2 列
- [ ] 型列に `Order[]` / `CustomerDto` 等を直接入力でき、保存・リロード後も保持
- [ ] `.step-editor` が viewport 幅いっぱい広がる (max-width 800px の制約がない)
- [ ] ダークテーマ / コンパクトテーマでもレイアウト破綻なし

## spec 側の不足点 / 提案

N/A (3 issue とも UX 改善で spec 管轄外)

## レビュー担当への申し送り

- **当初 3 本だった PR (#311 / #312 / #314) を 1 本に統合**。旧 PR #312 と #314 は close、対応ブランチも削除予定 (feat/issue-310-io-table / feat/issue-313-step-editor-fluid)
- `__meta-tab-*` 擬似 stepId パターンは前例なし。ここだけ独立レビューの価値あり
- 型列の自由入力化により `custom.label` の格納は `StructuredFieldsEditor` だけで起きるが、`AmbientVariablesPanel` は従来の select + label 別入力のまま。ambient 側も自由入力化するなら follow-up issue