### PR TITLE
refactor(ui): 入出力定義を 1 項目 1 行のテーブル形式に刷新 (#310)

### DIFF
--- a/designer/src/components/action/StructuredFieldsEditor.tsx
+++ b/designer/src/components/action/StructuredFieldsEditor.tsx
@@ -141,21 +141,31 @@ export function StructuredFieldsEditor({ label, fields, onChange, onCommit, plac
                     />
                   </td>
                   <td>
-                    <select
-                      className="form-select form-select-sm"
-                      value={typeof f.type === "string" ? f.type : "custom"}
+                    <input
+                      type="text"
+                      list="structured-fields-type-list"
+                      className="form-control form-control-sm"
+                      value={typeof f.type === "string"
+                        ? f.type
+                        : f.type.kind === "custom"
+                          ? f.type.label ?? ""
+                          : ""}
                       onChange={(e) => {
                         const v = e.target.value;
-                        if (PRIMITIVE_TYPES.includes(v as "string" | "number" | "boolean" | "date")) {
+                        if (v === "") {
+                          updateField(i, { type: "string" });
+                        } else if ((PRIMITIVE_TYPES as string[]).includes(v)) {
                           updateField(i, { type: v as FieldType });
                         } else {
-                          updateField(i, { type: { kind: "custom", label: "" } });
+                          updateField(i, { type: { kind: "custom", label: v } });
                         }
                       }}
-                    >
-                      {PRIMITIVE_TYPES.map((t) => <option key={t} value={t}>{t}</option>)}
-                      <option value="custom">custom</option>
-                    </select>
+                      onBlur={() => onCommit?.()}
+                      placeholder="型 (string/DTO名 等)"
+                      title={typeof f.type === "object" && f.type.kind === "custom"
+                        ? `カスタム型: ${f.type.label}`
+                        : undefined}
+                    />
                   </td>
                   <td className="text-center">
                     <input
@@ -199,6 +209,10 @@ export function StructuredFieldsEditor({ label, fields, onChange, onCommit, plac
           >
             <i className="bi bi-plus-lg" /> フィールド追加
           </button>
+          {/* 型入力の候補 (primitive のみ提示、自由入力も可) — 全 row 共有 */}
+          <datalist id="structured-fields-type-list">
+            {PRIMITIVE_TYPES.map((t) => <option key={t} value={t} />)}
+          </datalist>
         </div>
       )}
     </div>

--- a/designer/src/components/action/StructuredFieldsEditor.tsx
+++ b/designer/src/components/action/StructuredFieldsEditor.tsx
@@ -13,9 +13,9 @@ interface Props {
 const PRIMITIVE_TYPES: Array<"string" | "number" | "boolean" | "date"> = ["string", "number", "boolean", "date"];
 
 /**
- * ActionDefinition.inputs / outputs の編集 UI (#226)。
+ * ActionDefinition.inputs / outputs の編集 UI (#226 / #310)。
  * 自由記述モード (textarea) と表形式モード (StructuredField[]) を切替可能。
- * 表形式では name / type / required / description を編集。
+ * 表形式では 1 項目 1 行の <table> で name / label / type / required / description を編集。
  * FieldType は primitive + custom のみ対応、tableRow/tableList/screenInput は将来。
  */
 export function StructuredFieldsEditor({ label, fields, onChange, onCommit, placeholder }: Props) {
@@ -57,14 +57,13 @@ export function StructuredFieldsEditor({ label, fields, onChange, onCommit, plac
 
   return (
     <div className="structured-fields-editor">
-      <div className="d-flex align-items-center gap-2 mb-1">
+      <div className="structured-fields-header">
         <label className="form-label mb-0">{label}</label>
         <div className="btn-group btn-group-sm" role="group" aria-label="表示モード">
           <button
             type="button"
             className={`btn btn-outline-secondary${mode === "text" ? " active" : ""}`}
             onClick={switchToText}
-            style={{ fontSize: "0.7rem", padding: "0 6px" }}
             title="自由記述モード (改行区切り)"
           >
             <i className="bi bi-text-paragraph" />
@@ -73,7 +72,6 @@ export function StructuredFieldsEditor({ label, fields, onChange, onCommit, plac
             type="button"
             className={`btn btn-outline-secondary${mode === "table" ? " active" : ""}`}
             onClick={switchToTable}
-            style={{ fontSize: "0.7rem", padding: "0 6px" }}
             title="表形式モード (構造化)"
           >
             <i className="bi bi-table" />
@@ -91,91 +89,113 @@ export function StructuredFieldsEditor({ label, fields, onChange, onCommit, plac
           placeholder={placeholder}
         />
       ) : (
-        <div style={{ fontSize: "0.8rem" }}>
-          {isStructured && fields.length === 0 && (
-            <div className="text-muted small mb-1">フィールドなし</div>
-          )}
-          {isStructured && fields.map((f, i) => (
-            <div key={i} className="row g-1 mb-1 align-items-center">
-              <div className="col-3">
-                <input
-                  type="text"
-                  className="form-control form-control-sm"
-                  value={f.name}
-                  onChange={(e) => updateField(i, { name: e.target.value })}
-                  onBlur={() => onCommit?.()}
-                  placeholder="name"
-                  style={{ fontSize: "0.8rem" }}
-                />
-              </div>
-              <div className="col-2">
-                <input
-                  type="text"
-                  className="form-control form-control-sm"
-                  value={f.label ?? ""}
-                  onChange={(e) => updateField(i, { label: e.target.value || undefined })}
-                  onBlur={() => onCommit?.()}
-                  placeholder="label"
-                  style={{ fontSize: "0.8rem" }}
-                />
-              </div>
-              <div className="col-2">
-                <select
-                  className="form-select form-select-sm"
-                  value={typeof f.type === "string" ? f.type : "custom"}
-                  onChange={(e) => {
-                    const v = e.target.value;
-                    if (PRIMITIVE_TYPES.includes(v as "string" | "number" | "boolean" | "date")) {
-                      updateField(i, { type: v as FieldType });
-                    } else {
-                      updateField(i, { type: { kind: "custom", label: "" } });
-                    }
-                  }}
-                  style={{ fontSize: "0.8rem" }}
-                >
-                  {PRIMITIVE_TYPES.map((t) => <option key={t} value={t}>{t}</option>)}
-                  <option value="custom">custom</option>
-                </select>
-              </div>
-              <div className="col-auto" style={{ width: 70 }}>
-                <label className="form-check-label small">
-                  <input
-                    type="checkbox"
-                    className="form-check-input me-1"
-                    checked={!!f.required}
-                    onChange={(e) => updateField(i, { required: e.target.checked || undefined })}
-                  />
-                  必須
-                </label>
-              </div>
-              <div className="col">
-                <input
-                  type="text"
-                  className="form-control form-control-sm"
-                  value={f.description ?? ""}
-                  onChange={(e) => updateField(i, { description: e.target.value || undefined })}
-                  onBlur={() => onCommit?.()}
-                  placeholder="description"
-                  style={{ fontSize: "0.8rem" }}
-                />
-              </div>
-              <div className="col-auto">
-                <button
-                  type="button"
-                  className="btn btn-sm btn-link text-danger p-0"
-                  onClick={() => removeField(i)}
-                  title="削除"
-                >
-                  <i className="bi bi-x" />
-                </button>
-              </div>
-            </div>
-          ))}
+        <div className="structured-fields-body">
+          <table className="structured-fields-table">
+            <colgroup>
+              <col className="col-no" />
+              <col className="col-name" />
+              <col className="col-label" />
+              <col className="col-type" />
+              <col className="col-required" />
+              <col className="col-desc" />
+              <col className="col-actions" />
+            </colgroup>
+            <thead>
+              <tr>
+                <th scope="col">#</th>
+                <th scope="col">名前</th>
+                <th scope="col">日本語名</th>
+                <th scope="col">型</th>
+                <th scope="col" className="text-center">必須</th>
+                <th scope="col">説明</th>
+                <th scope="col" aria-label="操作" />
+              </tr>
+            </thead>
+            <tbody>
+              {isStructured && fields.length === 0 && (
+                <tr>
+                  <td colSpan={7} className="structured-fields-empty">フィールドなし</td>
+                </tr>
+              )}
+              {isStructured && fields.map((f, i) => (
+                <tr key={i}>
+                  <td className="structured-fields-no">{i + 1}</td>
+                  <td>
+                    <input
+                      type="text"
+                      className="form-control form-control-sm"
+                      value={f.name}
+                      onChange={(e) => updateField(i, { name: e.target.value })}
+                      onBlur={() => onCommit?.()}
+                      placeholder="name"
+                    />
+                  </td>
+                  <td>
+                    <input
+                      type="text"
+                      className="form-control form-control-sm"
+                      value={f.label ?? ""}
+                      onChange={(e) => updateField(i, { label: e.target.value || undefined })}
+                      onBlur={() => onCommit?.()}
+                      placeholder="label"
+                    />
+                  </td>
+                  <td>
+                    <select
+                      className="form-select form-select-sm"
+                      value={typeof f.type === "string" ? f.type : "custom"}
+                      onChange={(e) => {
+                        const v = e.target.value;
+                        if (PRIMITIVE_TYPES.includes(v as "string" | "number" | "boolean" | "date")) {
+                          updateField(i, { type: v as FieldType });
+                        } else {
+                          updateField(i, { type: { kind: "custom", label: "" } });
+                        }
+                      }}
+                    >
+                      {PRIMITIVE_TYPES.map((t) => <option key={t} value={t}>{t}</option>)}
+                      <option value="custom">custom</option>
+                    </select>
+                  </td>
+                  <td className="text-center">
+                    <input
+                      type="checkbox"
+                      className="form-check-input structured-fields-required"
+                      checked={!!f.required}
+                      onChange={(e) => updateField(i, { required: e.target.checked || undefined })}
+                      aria-label="必須"
+                    />
+                  </td>
+                  <td>
+                    <input
+                      type="text"
+                      className="form-control form-control-sm"
+                      value={f.description ?? ""}
+                      onChange={(e) => updateField(i, { description: e.target.value || undefined })}
+                      onBlur={() => onCommit?.()}
+                      placeholder="description"
+                      title={f.description ?? ""}
+                    />
+                  </td>
+                  <td className="text-center">
+                    <button
+                      type="button"
+                      className="btn btn-sm btn-link text-danger p-0 structured-fields-delete"
+                      onClick={() => removeField(i)}
+                      title="削除"
+                      aria-label="削除"
+                    >
+                      <i className="bi bi-x" />
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
           <button
             type="button"
-            className="btn btn-sm btn-outline-secondary py-0"
+            className="btn btn-sm btn-outline-secondary structured-fields-add"
             onClick={() => { addField(); onCommit?.(); }}
-            style={{ fontSize: "0.75rem" }}
           >
             <i className="bi bi-plus-lg" /> フィールド追加
           </button>

--- a/designer/src/styles/action.css
+++ b/designer/src/styles/action.css
@@ -239,9 +239,11 @@
 /* ─── I/O パネル ─────────────────────────────────────────────────── */
 
 .action-io-panel {
+  /* #310: 上下 2 段 (1fr) に変更。以前は 1fr 1fr で左右分割していたが
+     表形式モードで幅が狭く折り返して縦積みに見えていたため、全幅を確保。 */
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 12px;
+  grid-template-columns: 1fr;
+  gap: 10px;
   margin-bottom: 16px;
   padding: 12px;
   background: #f8fafc;
@@ -260,6 +262,91 @@
   font-size: 0.82rem;
   min-height: 32px;
   resize: vertical;
+}
+
+/* StructuredFieldsEditor (#310): 1 項目 1 行テーブル */
+.structured-fields-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.structured-fields-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.structured-fields-header .btn-group .btn {
+  font-size: 0.7rem;
+  padding: 0 6px;
+}
+.structured-fields-body {
+  font-size: 0.78rem;
+}
+.structured-fields-table {
+  width: 100%;
+  table-layout: fixed;
+  border-collapse: collapse;
+  margin: 0;
+}
+.structured-fields-table thead th {
+  font-size: 0.68rem;
+  font-weight: 600;
+  color: #64748b;
+  letter-spacing: 0.02em;
+  padding: 3px 4px;
+  border-bottom: 1px solid #cbd5e1;
+  text-align: left;
+  background: transparent;
+}
+.structured-fields-table tbody td {
+  padding: 2px 4px;
+  vertical-align: middle;
+  border-bottom: 1px solid #f1f5f9;
+}
+.structured-fields-table tbody tr:last-child td {
+  border-bottom: none;
+}
+.structured-fields-table input.form-control,
+.structured-fields-table select.form-select {
+  width: 100%;
+  padding: 2px 6px;
+  font-size: 0.78rem;
+  min-width: 0;
+  min-height: 24px;
+  height: 26px;
+}
+.structured-fields-table .col-no { width: 32px; }
+.structured-fields-table .col-name { width: 11em; }
+.structured-fields-table .col-label { width: 9em; }
+.structured-fields-table .col-type { width: 7em; }
+.structured-fields-table .col-required { width: 3.5em; }
+.structured-fields-table .col-desc { width: auto; }
+.structured-fields-table .col-actions { width: 28px; }
+.structured-fields-no {
+  color: #94a3b8;
+  font-size: 0.7rem;
+  text-align: center;
+}
+.structured-fields-required {
+  margin: 0 auto;
+  display: block;
+}
+.structured-fields-delete {
+  line-height: 1;
+  padding: 0 !important;
+}
+.structured-fields-empty {
+  color: #94a3b8;
+  padding: 10px;
+  text-align: center;
+  font-style: italic;
+  font-size: 0.78rem;
+}
+.structured-fields-add {
+  font-size: 0.75rem;
+  margin-top: 4px;
+  align-self: flex-start;
+  padding: 2px 10px;
 }
 
 /* ─── ステップエディタ ────────────────────────────────────────────── */

--- a/designer/src/styles/action.css
+++ b/designer/src/styles/action.css
@@ -239,8 +239,9 @@
 /* ─── I/O パネル ─────────────────────────────────────────────────── */
 
 .action-io-panel {
-  /* #310: 上下 2 段 (1fr) に変更。以前は 1fr 1fr で左右分割していたが
-     表形式モードで幅が狭く折り返して縦積みに見えていたため、全幅を確保。 */
+  /* #310: 上下 2 段 (1fr) を既定に。以前は 1fr 1fr で左右分割していたが、
+     表形式モードで幅が狭く折り返して縦積みに見えていたため、全幅を確保。
+     #310 フォローアップ: 高解像度では左右 2 列に戻す (下の media query 参照)。 */
   display: grid;
   grid-template-columns: 1fr;
   gap: 10px;
@@ -249,6 +250,15 @@
   background: #f8fafc;
   border: 1px solid #e2e8f0;
   border-radius: 6px;
+}
+/* 1600px 以上 (4K 半分や 1920 以上の横広) では入出力を左右並びに戻す。
+   table-layout: fixed + col-*: 11em+9em+7em+... の合計 ≒ 400px 以上あれば折り返し
+   なく 1 項目 1 行が収まる。1600px / 2 ≒ 780px > 400px で十分余裕がある。 */
+@media (min-width: 1600px) {
+  .action-io-panel {
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+  }
 }
 
 .action-io-field .form-label {


### PR DESCRIPTION
## 関連

- Closes #310
- **base: `feat/issue-309-action-editor-subtab` (#311 へスタック)**。#311 がマージされたら自動的に `main` に切り替わる。
- 仕様: N/A (UX 改善)

## 概要

`StructuredFieldsEditor` の表形式モードを `<table>` に書き換え、画面幅に関わらず 1 項目 = 1 行を保証する。併せて `action-io-panel` を左右 2 分割から上下 2 段に変更し (狭い画面対応)、1600px 以上の広い画面では再度左右 2 列に戻す。さらに型入力を自由入力対応。

## 主な変更

### 1st commit: 入出力 1 行化 + 上下 2 段化
- `StructuredFieldsEditor.tsx` を `<table>` ベースに刷新。列 (`#` / `名前` / `日本語名` / `型` / `必須` / `説明` / `×`) で 1 項目 = 1 行
- `table-layout: fixed` + `<colgroup>` で列幅を固定 (名前 11em / 日本語名 9em / 型 7em / 必須 3.5em / 操作 28px)、`説明` のみ `auto`
- `action-io-panel` の `grid-template-columns: 1fr 1fr` → `1fr` に変更 (上下 2 段、全幅)
- 既存 E2E (`more-ui.spec.ts:169`) 互換のためクラス名 / placeholder / ボタン文言は維持

### 2nd commit: 型自由入力 + 4K で横並び復活
- 型列を `<select>` → `<input list="structured-fields-type-list">` に置換。primitive (string/number/boolean/date) を datalist で候補提示しつつ、任意文字列 (`Order[]` / `CustomerDto` / `Promise<Foo>` 等) を自由記述可能に。ドロップダウン + 別途 custom label 入力の 2 手が 1 手に減る
- `action-io-panel` に `@media (min-width: 1600px)` を追加し、4K や 1920 以上の環境では左右 2 列に戻す。1600px 未満では従来どおり上下 2 段

## 仕様逐条突合 (自己申告)

#310 の完了条件:
- ✓ 1 項目が幅 600px でも横 1 行に収まる (`説明` は ellipsis + ホバー tooltip) → [StructuredFieldsEditor.tsx](designer/src/components/action/StructuredFieldsEditor.tsx)
- ✓ 既存データ (StructuredField[] / string) 両方が表示・編集できる → 既存ヘルパ `isStructuredFields` / `fieldsToText` / `textToStructuredFields` そのまま利用
- ✓ 既存テスト pass → Vitest 496 件、Playwright `more-ui.spec.ts:170` pass
- ✓ スクリーンショット確認 → ユーザー目視確認必須

## レビューで特に見てほしい箇所

- **型自由入力の型推論**: 入力値が primitive にマッチすれば `FieldType = "string"` 等の primitive として保存、それ以外は `{ kind: "custom", label: 入力値 }` として保存。datalist は候補の提示だけなので任意文字列を受け付ける
- **1600px 境界での切替**: `@media (min-width: 1600px)` ちょうどでレイアウトが切り替わる。ブラウザ幅を動かして挙動確認推奨
- **`description` の折り返し扱い**: input のまま (改行なし)。長文は input 右端で見切れ → `title` 属性でホバー全文表示
- **custom 型の label 表示**: 既存データで `{ kind: "custom", label: "Order[]" }` の場合、表示は `Order[]`。編集・保存ラウンドトリップで壊れない

## テスト

- Vitest: 496 件 (新規 0 件) — 全件 pass
- Playwright: `more-ui.spec.ts:170` (既存) — pass
- MCP E2E: N/A

## UI 影響 / マージ保留フラグ

- [x] **UI 影響あり (マージ前にユーザー目視確認必須)**
- [ ] UI 影響なし

### UI 影響ありの場合、確認項目

- [ ] 表形式モードで 1 項目 = 1 行が viewport に関わらず成立
- [ ] 1600px 未満: 入出力が上下 2 段
- [ ] 1600px 以上 (4K): 入出力が左右 2 列
- [ ] 型列に `User` / `Order[]` など直接入力でき、保存・リロード後も保持される
- [ ] datalist で primitive がプルダウン候補として出る (ブラウザ依存)
- [ ] 自由記述モード → 表形式モード → 自由記述モード の往復で値が保持される

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

- 本 PR は **#311 (#309 サブタブバー化) にスタック** している。#311 がマージされれば GitHub が自動で base=main に切り替える。
- `#313` (step-editor の max-width 撤去) と組み合わせると 4K で入出力が左右 2 列、それぞれ 1900px 幅近く確保できる。非常に見やすくなる想定。