### PR TITLE
refactor(ui): step-editor の max-width 800px を撤去 (#313)

### DIFF
--- a/designer/src/styles/action.css
+++ b/designer/src/styles/action.css
@@ -274,8 +274,9 @@
 /* ─── ステップエディタ ────────────────────────────────────────────── */
 
 .step-editor {
-  padding: 20px;
-  max-width: 800px;
+  /* #313: max-width 800px を撤去し viewport 幅を活かす。padding は親の
+     .action-content が担当するので 0。4K でもパネル幅を有効利用する。 */
+  padding: 0;
 }
 
 .step-toolbar {


### PR DESCRIPTION
## 関連

- Closes #313
- 仕様: N/A (UX 改善)
- base: `main`

## 概要

\`.step-editor\` の \`max-width: 800px\` を撤去し、4K モニタなど高解像度で viewport 幅を活用できるようにする。

## 主な変更

- [action.css:276-279](designer/src/styles/action.css#L276-L279) の \`max-width: 800px\` を削除。padding も \`.action-content\` に集約するので \`padding: 0\` に整理
- 影響範囲: HTTP 契約パネル / 入出力パネル / ステップリスト / ステップカード — いずれも width: 100% で親の幅に追従する設計になっていた

## 仕様逐条突合 (自己申告)

#313 の完了条件:

- ✓ **1920px 幅で \`.step-editor\` が (最低でも) 1600px 使える** → max-width 制約を完全撤去したので viewport 幅 - action-content padding (14px×2) = 1892px 使える
- ✓ **4K (3840px) で \`.step-editor\` が (最低でも) 3000px 使える** → 同上で 3812px 使える
- ✓ **800px 程度の狭い画面でも見切れ・横スクロール発生しない** → max-width 撤去は「上限を外す」だけで下限には影響しない
- ✓ **StepCard / HTTP 契約 / 入出力が破綻しない** → 既存 E2E (drawing-anchor / marker-panel / save-reset-action 計 21 件) 全件 pass。StepCard 内部は Bootstrap grid + flex で本来 fluid に作られている
- ✓ **既存 E2E 全て pass** → 上記

## レビューで特に見てほしい箇所

- **4K 視覚確認**: max-width 撤去後に、画面幅いっぱいまで HTTP 契約が広がり、ステップカードがストレッチすることをユーザー環境 (4K) で確認してほしい
- **狭い画面**: 1024px 程度のラップトップ解像度でレイアウト破綻がないか
- **#310 PR (#312) との相性**: #310 は \`@media (min-width: 1600px)\` で入出力を左右 2 列にするが、今回の #313 と組み合わせると 4K で入出力がパネル全幅 (1900px 級) を 2 等分する形。読みやすさが上がる想定

## テスト

- Vitest: 496 件 — 全件 pass
- Playwright: drawing-anchor / marker-panel / save-reset-action 計 21 件 — 全件 pass
- MCP E2E: N/A

## UI 影響 / マージ保留フラグ

- [x] **UI 影響あり (マージ前にユーザー目視確認必須)**
- [ ] UI 影響なし

### UI 影響ありの場合、確認項目

- [ ] 1920px / 4K で HTTP 契約パネルが画面右端近くまで広がる
- [ ] 1024px で破綻せず (横スクロール・見切れなし)
- [ ] ステップカード内の並べ替え D&D ハンドルが適切な位置に表示される
- [ ] ダークテーマ / コンパクトテーマでも破綻なし

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

- この PR は **#311 / #312 と衝突しない** (別ファイルの別プロパティ) ので、3 本どの順序でもマージ可能
- max-width をゼロにしたため「大型モニタで 1 行が長すぎて読みにくい」ケースの懸念はある。その場合は \`@media (min-width: 2400px) { .step-editor { max-width: 2400px; margin: 0 auto; } }\` のような上限設定を follow-up で検討