### PR TITLE
refactor(ui): AmbientVariablesPanel の型入力を datalist 自由入力に統一 (#315)

### DIFF
--- a/designer/src/components/action/AmbientVariablesPanel.tsx
+++ b/designer/src/components/action/AmbientVariablesPanel.tsx
@@ -65,7 +65,6 @@ export function AmbientVariablesPanel({ group, onChange, expanded: expandedProp,
           </div>
           {vars.length === 0 && <div className="catalog-empty">まだエントリがありません。</div>}
           {vars.map((v, i) => {
-            const isPrimitive = typeof v.type === "string";
             return (
               <div className="catalog-row" key={i}>
                 <div className="catalog-row-header">
@@ -98,32 +97,30 @@ export function AmbientVariablesPanel({ group, onChange, expanded: expandedProp,
                   </label>
                   <label>
                     type
-                    <select
-                      className="form-select form-select-sm"
-                      value={isPrimitive ? (v.type as string) : "custom"}
+                    <input
+                      list="ambient-variables-type-list"
+                      className="form-control form-control-sm"
+                      value={typeof v.type === "string"
+                        ? v.type
+                        : v.type.kind === "custom"
+                          ? v.type.label ?? ""
+                          : ""}
                       onChange={(ev) => {
                         const t = ev.target.value;
-                        if (PRIMITIVE_TYPES.includes(t as never)) {
+                        if (t === "") {
+                          update(i, { type: "string" });
+                        } else if ((PRIMITIVE_TYPES as string[]).includes(t)) {
                           update(i, { type: t as FieldType });
                         } else {
-                          update(i, { type: { kind: "custom", label: "" } });
+                          update(i, { type: { kind: "custom", label: t } });
                         }
                       }}
-                    >
-                      {PRIMITIVE_TYPES.map((t) => <option key={t} value={t}>{t}</option>)}
-                      <option value="custom">custom (label 指定)</option>
-                    </select>
+                      placeholder="型 (string/DTO名 等)"
+                      title={typeof v.type === "object" && v.type.kind === "custom"
+                        ? `カスタム型: ${v.type.label}`
+                        : undefined}
+                    />
                   </label>
-                  {!isPrimitive && typeof v.type === "object" && v.type.kind === "custom" && (
-                    <label className="catalog-wide">
-                      custom label
-                      <input
-                        className="form-control form-control-sm"
-                        value={v.type.label}
-                        onChange={(ev) => update(i, { type: { kind: "custom", label: ev.target.value } })}
-                      />
-                    </label>
-                  )}
                   <label className="catalog-wide">
                     description
                     <input
@@ -142,6 +139,10 @@ export function AmbientVariablesPanel({ group, onChange, expanded: expandedProp,
               <i className="bi bi-plus-lg" /> 追加
             </button>
           </div>
+          {/* 型入力の候補 (primitive のみ提示、自由入力も可) — 全 row 共有 */}
+          <datalist id="ambient-variables-type-list">
+            {PRIMITIVE_TYPES.map((t) => <option key={t} value={t} />)}
+          </datalist>
         </div>
       )}
     </div>


### PR DESCRIPTION
## 関連

- Closes #315
- base: \`main\`
- 前提: #311 ( #310 を含む) が main にマージ済み

## 概要

#310 で \`StructuredFieldsEditor\` (アクションの inputs/outputs 編集 UI) の型入力を \`<select>\` + 条件付き \`custom label\` 入力から \`<input list="...">\` の datalist + 自由入力に変更したが、同じ \`FieldType\` を扱う \`AmbientVariablesPanel\` (ActionGroup.ambientVariables) は旧 UI のまま残っていた。操作感を揃えるため統一する。

## 主な変更

- [\`AmbientVariablesPanel.tsx\`](designer/src/components/action/AmbientVariablesPanel.tsx):
  - \`<select>\` + 条件付き \`custom label\` \`<input>\` を削除
  - \`<input list="ambient-variables-type-list">\` に置換
  - 入力値が primitive にマッチなら \`FieldType = "string"\` 等、それ以外は \`{ kind: "custom", label: 入力値 }\` として保存
  - 空文字列は \`"string"\` にフォールバック
  - \`isPrimitive\` ローカル変数は不要になったので削除
- panel 末尾に \`<datalist id="ambient-variables-type-list">\` を追加 (\`StructuredFieldsEditor\` とは別 id で共存を避ける)

## 仕様逐条突合 (自己申告)

- ✓ \`User\` / \`RequestContext\` 等のカスタム型名を直接入力できる → [AmbientVariablesPanel.tsx:100-122](designer/src/components/action/AmbientVariablesPanel.tsx#L100-L122)
- ✓ 既存データ (primitive / custom.label) の表示・編集ラウンドトリップが壊れない → \`typeof v.type === "string" ? v.type : v.type.kind === "custom" ? v.type.label ?? "" : ""\` で両形式を表示、onChange で両方向保存
- ✓ 既存 E2E が pass → catalog-panels.spec.ts 全 6 件 (うち ambientVariables 1 件) pass、テスト側の更新不要
- ✓ \`StructuredFieldsEditor\` と操作感が揃う → 同じ datalist パターン + 同じ placeholder 形式

## テスト

- Vitest: 496 件 — 全件 pass
- Playwright: \`catalog-panels.spec.ts\` 全 6 件 — 全件 pass
- MCP E2E: N/A

## UI 影響 / マージ保留フラグ

- [x] **UI 影響あり (マージ前にユーザー目視確認必須)**

### 確認項目

- [ ] Ambient 変数タブで型列に \`User\` / \`RequestContext\` 等を直接入力でき、保存・リロード後も保持される
- [ ] 空文字列にすると \`string\` に戻る
- [ ] 既存の custom 型 (\`{ kind: "custom", label: "..." }\`) を持つデータがあれば、開いたときに label がそのまま表示される
- [ ] datalist で primitive がプルダウン候補として出る (ブラウザ依存)

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

- \`FieldType\` を編集する UI は \`StructuredFieldsEditor\` と \`AmbientVariablesPanel\` の 2 箇所のみ。この PR で両者が同じ datalist + 自由入力方式に揃う
- \`tableRow\` / \`tableList\` / \`screenInput\` 型への対応は引き続き未実装 (両 UI 共通の将来拡張)