### PR TITLE
feat(conventions): 規約カタログの UI 編集機能 (#317)

### DIFF
--- a/designer-mcp/src/projectStorage.ts
+++ b/designer-mcp/src/projectStorage.ts
@@ -16,9 +16,11 @@ export const DATA_DIR =
 const SCREENS_DIR = path.join(DATA_DIR, "screens");
 const TABLES_DIR = path.join(DATA_DIR, "tables");
 const ACTIONS_DIR = path.join(DATA_DIR, "actions");
+const CONVENTIONS_DIR = path.join(DATA_DIR, "conventions");
 export const PROJECT_FILE = path.join(DATA_DIR, "project.json");
 export const CUSTOM_BLOCKS_FILE = path.join(DATA_DIR, "custom-blocks.json");
 export const ER_LAYOUT_FILE = path.join(DATA_DIR, "er-layout.json");
+export const CONVENTIONS_FILE = path.join(CONVENTIONS_DIR, "catalog.json");
 
 /** data/ と data/screens/ と data/tables/ を作成（既存なら無視） */
 export async function ensureDataDir(): Promise<void> {
@@ -26,6 +28,7 @@ export async function ensureDataDir(): Promise<void> {
   await fs.mkdir(SCREENS_DIR, { recursive: true });
   await fs.mkdir(TABLES_DIR, { recursive: true });
   await fs.mkdir(ACTIONS_DIR, { recursive: true });
+  await fs.mkdir(CONVENTIONS_DIR, { recursive: true });
 }
 
 async function readJSON<T>(filePath: string): Promise<T | null> {
@@ -70,6 +73,7 @@ function resolveDataFile(kind: string, id?: string): string | null {
     case "project": return PROJECT_FILE;
     case "erLayout": return ER_LAYOUT_FILE;
     case "customBlocks": return CUSTOM_BLOCKS_FILE;
+    case "conventions": return CONVENTIONS_FILE;
     case "screen": return id ? path.join(SCREENS_DIR, `${id}.json`) : null;
     case "table": return id ? path.join(TABLES_DIR, `${id}.json`) : null;
     case "actionGroup": return id ? path.join(ACTIONS_DIR, `${id}.json`) : null;
@@ -151,6 +155,17 @@ export async function deleteActionGroup(actionGroupId: string): Promise<void> {
   try {
     await fs.unlink(path.join(ACTIONS_DIR, `${actionGroupId}.json`));
   } catch { /* file not found is OK */ }
+}
+
+/** conventions/catalog.json を読み込み (#317) */
+export async function readConventions(): Promise<unknown | null> {
+  return readJSON<unknown>(CONVENTIONS_FILE);
+}
+
+/** conventions/catalog.json を書き込み (#317) */
+export async function writeConventions(data: unknown): Promise<void> {
+  await ensureDataDir();
+  await writeJSON(CONVENTIONS_FILE, data);
 }
 
 /** actions/ ディレクトリ内の全アクショングループを読み込み */

--- a/designer-mcp/src/wsBridge.ts
+++ b/designer-mcp/src/wsBridge.ts
@@ -21,6 +21,8 @@ import {
   writeActionGroup,
   deleteActionGroup as deleteActionGroupFile,
   listActionGroups as listActionGroupFiles,
+  readConventions,
+  writeConventions,
   getFileMtime,
 } from "./projectStorage.js";
 
@@ -429,6 +431,18 @@ class WsBridge extends EventEmitter {
             updatedAt: ag.updatedAt,
           }));
           respond(metas);
+          break;
+        }
+        case "loadConventions": {
+          const catalog = await readConventions();
+          respond(catalog);
+          break;
+        }
+        case "saveConventions": {
+          const { catalog } = (params ?? {}) as { catalog: unknown };
+          await writeConventions(catalog);
+          respond({ success: true });
+          this.broadcast("conventionsChanged", {}, clientId);
           break;
         }
         case "getFileMtime": {

--- a/designer/e2e/conventions-catalog.spec.ts
+++ b/designer/e2e/conventions-catalog.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * 規約カタログ編集ビュー (#317) の基本 E2E
+ *
+ * - /conventions/catalog を開けること
+ * - msg / regex / limit の 3 カテゴリタブがあること
+ * - 各カテゴリで新規エントリ追加 → 入力欄更新ができること
+ */
+import { test, expect, type Page } from "@playwright/test";
+
+const dummyProject = {
+  version: 1, name: "conventions-ui", screens: [], groups: [], edges: [],
+  tables: [], actionGroups: [],
+  updatedAt: new Date().toISOString(),
+};
+
+async function setup(page: Page) {
+  await page.addInitScript(({ project }) => {
+    localStorage.setItem("flow-project", JSON.stringify(project));
+    localStorage.removeItem("designer-open-tabs");
+    localStorage.removeItem("designer-active-tab");
+    localStorage.removeItem("conventions-catalog");
+    localStorage.removeItem("draft-conventions-catalog-main");
+  }, { project: dummyProject });
+  await page.goto("/conventions/catalog");
+  await expect(page.locator(".conventions-catalog-view")).toBeVisible({ timeout: 10000 });
+}
+
+test.describe("規約カタログ編集ビュー (#317)", () => {
+  test("3 カテゴリタブが見える", async ({ page }) => {
+    await setup(page);
+    const tabs = page.locator(".conventions-category-tab");
+    await expect(tabs).toHaveCount(3);
+    await expect(tabs.nth(0)).toContainText("メッセージ");
+    await expect(tabs.nth(1)).toContainText("正規表現");
+    await expect(tabs.nth(2)).toContainText("制限値");
+  });
+
+  test("regex タブで新規エントリ追加 + pattern 入力", async ({ page }) => {
+    await setup(page);
+    // regex タブクリック
+    await page.locator(".conventions-category-tab", { hasText: "正規表現" }).click();
+    // 新規 key 入力 → 追加
+    const newKeyInput = page.locator(".conventions-new-key-input");
+    await newKeyInput.fill("test-regex-pattern");
+    await page.locator(".conventions-entries button:has-text('追加')").click();
+    // key-badge が出現
+    await expect(page.locator(".conventions-key-badge", { hasText: "test-regex-pattern" })).toBeVisible();
+    // pattern 入力
+    const patternInput = page.locator('.conventions-table input[placeholder="^[A-Za-z0-9]+$"]').first();
+    await patternInput.fill("^\\d{4}$");
+    await expect(patternInput).toHaveValue("^\\d{4}$");
+  });
+
+  test("msg タブで新規エントリ追加 + template 入力", async ({ page }) => {
+    await setup(page);
+    // 既定で msg タブ
+    const newKeyInput = page.locator(".conventions-new-key-input");
+    await newKeyInput.fill("testMsg");
+    await page.locator(".conventions-entries button:has-text('追加')").click();
+    await expect(page.locator(".conventions-key-badge", { hasText: "testMsg" })).toBeVisible();
+    const templateInput = page.locator('.conventions-table input[placeholder*="必須入力"]').first();
+    await templateInput.fill("{label}はテストです");
+    await expect(templateInput).toHaveValue("{label}はテストです");
+  });
+
+  test("重複キーの追加はボタン disabled", async ({ page }) => {
+    await setup(page);
+    // limit タブに切替
+    await page.locator(".conventions-category-tab", { hasText: "制限値" }).click();
+    const newKeyInput = page.locator(".conventions-new-key-input");
+    await newKeyInput.fill("dupKey");
+    const addBtn = page.locator(".conventions-entries button:has-text('追加')");
+    await addBtn.click();
+    // 同じキーを再度入力
+    await newKeyInput.fill("dupKey");
+    await expect(addBtn).toBeDisabled();
+  });
+
+  test("削除ボタンでエントリが消える", async ({ page }) => {
+    await setup(page);
+    await page.locator(".conventions-category-tab", { hasText: "正規表現" }).click();
+    await page.locator(".conventions-new-key-input").fill("willDelete");
+    await page.locator(".conventions-entries button:has-text('追加')").click();
+    await expect(page.locator(".conventions-key-badge", { hasText: "willDelete" })).toBeVisible();
+    // willDelete が含まれる行の削除ボタンを特定
+    const row = page.locator(".conventions-table tr").filter({ has: page.locator(".conventions-key-badge", { hasText: "willDelete" }) });
+    await row.locator('button[aria-label="削除"]').click();
+    await expect(page.locator(".conventions-key-badge", { hasText: "willDelete" })).toHaveCount(0);
+  });
+});

--- a/designer/src/components/AppShell.tsx
+++ b/designer/src/components/AppShell.tsx
@@ -7,6 +7,7 @@ import { TableEditor } from "./table/TableEditor";
 import { ErDiagram } from "./table/ErDiagram";
 import { ActionListView } from "./action/ActionListView";
 import { ActionEditor } from "./action/ActionEditor";
+import { ConventionsCatalogView } from "./conventions/ConventionsCatalogView";
 import { Designer } from "./Designer";
 import { DashboardView } from "./dashboard/DashboardView";
 import { TabBar } from "./TabBar";
@@ -157,6 +158,7 @@ export function AppShell() {
       { path: "/table/list",         type: "table-list",         label: "テーブル一覧" },
       { path: "/table/er",           type: "er",                 label: "ER図" },
       { path: "/process-flow/list",  type: "process-flow-list",  label: "処理フロー一覧" },
+      { path: "/conventions/catalog", type: "conventions-catalog", label: "規約カタログ" },
     ];
     for (const { path, type, label } of singletonRoutes) {
       if (location.pathname === path) {
@@ -182,6 +184,7 @@ export function AppShell() {
       : activeTab.type === "table-list"       ? "/table/list"
       : activeTab.type === "er"               ? "/table/er"
       : activeTab.type === "process-flow-list" ? "/process-flow/list"
+      : activeTab.type === "conventions-catalog" ? "/conventions/catalog"
       : activeTab.type === "dashboard"        ? "/"
       : null;
     if (expectedPath && location.pathname !== expectedPath) {
@@ -256,6 +259,7 @@ export function AppShell() {
             <Route path="/table/er" element={<ErDiagram />} />
             <Route path="/process-flow/list" element={<ActionListView />} />
             <Route path="/process-flow/edit/:actionGroupId" element={<ActionEditor />} />
+            <Route path="/conventions/catalog" element={<ConventionsCatalogView />} />
           </Routes>
         </ErrorBoundary>
       )}

--- a/designer/src/components/HeaderMenu.tsx
+++ b/designer/src/components/HeaderMenu.tsx
@@ -36,6 +36,10 @@ const MENU_ITEMS: MenuItem[] = [
     id: "process-flow", label: "処理フロー一覧", icon: "bi-lightning", route: "/process-flow/list",
     activePaths: ["/process-flow/list"], activePrefixes: ["/process-flow/edit/"],
   },
+  {
+    id: "conventions-catalog", label: "規約カタログ", icon: "bi-file-text", route: "/conventions/catalog",
+    activePaths: ["/conventions/catalog"],
+  },
 ];
 
 const DASHBOARD_ITEM: MenuItem = {

--- a/designer/src/components/action/ActionEditor.tsx
+++ b/designer/src/components/action/ActionEditor.tsx
@@ -29,6 +29,7 @@ import { hasBlockingErrors } from "../../utils/actionValidation";
 import { aggregateValidation } from "../../utils/aggregatedValidation";
 import type { TableDefinition as ValidatorTableDef } from "../../schemas/sqlColumnValidator";
 import type { ConventionsCatalog } from "../../schemas/conventionsValidator";
+import { loadConventions } from "../../store/conventionsStore";
 import type { ValidationError } from "../../utils/actionValidation";
 import { generateUUID } from "../../utils/uuid";
 import {
@@ -171,9 +172,9 @@ export function ActionEditor() {
       );
       setTableDefs(defs.filter((d): d is ValidatorTableDef => d !== null));
     }).catch(console.error);
-    // 規約カタログを public/ から fetch (#261 UI 統合)
-    fetch("/conventions-catalog.json")
-      .then((r) => (r.ok ? r.json() : null))
+    // 規約カタログは wsBridge / localStorage 経由で取得 (#317)。
+    // 未接続時は null。編集は「規約カタログ」タブから。
+    loadConventions()
       .then((c) => setConventions(c as ConventionsCatalog | null))
       .catch(() => setConventions(null));
   }, []);

--- a/designer/src/components/action/ActionListView.tsx
+++ b/designer/src/components/action/ActionListView.tsx
@@ -13,6 +13,7 @@ import { loadProject, saveProject } from "../../store/flowStore";
 import { aggregateValidation } from "../../utils/aggregatedValidation";
 import type { TableDefinition as ValidatorTableDef } from "../../schemas/sqlColumnValidator";
 import type { ConventionsCatalog } from "../../schemas/conventionsValidator";
+import { loadConventions } from "../../store/conventionsStore";
 import { listTables, loadTable } from "../../store/tableStore";
 import { mcpBridge } from "../../mcp/mcpBridge";
 import { makeTabId } from "../../store/tabStore";
@@ -136,8 +137,8 @@ export function ActionListView() {
       );
       if (!cancelled) setTableDefs(defs.filter((d): d is ValidatorTableDef => d !== null));
     }).catch(console.error);
-    fetch("/conventions-catalog.json")
-      .then((r) => (r.ok ? r.json() : null))
+    // 規約カタログは wsBridge / localStorage 経由で取得 (#317)
+    loadConventions()
       .then((c) => { if (!cancelled) setConventions(c as ConventionsCatalog | null); })
       .catch(() => setConventions(null));
     return () => { cancelled = true; };

--- a/designer/src/components/conventions/ConventionsCatalogView.tsx
+++ b/designer/src/components/conventions/ConventionsCatalogView.tsx
@@ -1,0 +1,518 @@
+/**
+ * 規約カタログ編集ビュー (#317)
+ *
+ * 横断規約 (`@conv.msg.*` / `@conv.regex.*` / `@conv.limit.*`) の
+ * 機械可読カタログ (`data/conventions/catalog.json`) を designer 内で編集する
+ * シングルトンタブ。正本は JSON (本ビューで編集可)、`docs/conventions/*.md`
+ * は人間向け参考資料。
+ *
+ * カテゴリは 3 種: msg / regex / limit。それぞれサブタブで切替。CRUD は
+ * インライン編集 (name/description/etc をテキスト入力)。
+ */
+import { useCallback, useState } from "react";
+import { TableSubToolbar } from "../table/TableSubToolbar";
+import { EditorHeader } from "../common/EditorHeader";
+import { ServerChangeBanner } from "../common/ServerChangeBanner";
+import { useResourceEditor } from "../../hooks/useResourceEditor";
+import {
+  loadConventions,
+  saveConventions,
+  createEmptyCatalog,
+} from "../../store/conventionsStore";
+import type { ConventionsCatalog } from "../../schemas/conventionsValidator";
+import "../../styles/conventions.css";
+
+type Category = "msg" | "regex" | "limit";
+
+const CATEGORY_LABELS: Record<Category, string> = {
+  msg: "メッセージ",
+  regex: "正規表現",
+  limit: "制限値",
+};
+
+const CATEGORY_ICONS: Record<Category, string> = {
+  msg: "bi-chat-left-text",
+  regex: "bi-regex",
+  limit: "bi-rulers",
+};
+
+/** シングルトンなので id を "main" 固定で useResourceEditor を流用 */
+const RESOURCE_ID = "main";
+
+async function loadCatalog(_id: string): Promise<ConventionsCatalog> {
+  const cat = await loadConventions();
+  return cat ?? createEmptyCatalog();
+}
+
+async function saveCatalog(data: ConventionsCatalog): Promise<void> {
+  await saveConventions(data);
+}
+
+export function ConventionsCatalogView() {
+  const [activeCategory, setActiveCategory] = useState<Category>("msg");
+
+  const {
+    state: catalog,
+    isDirty, isSaving, serverChanged,
+    update, updateSilent, commit,
+    undo, redo, canUndo, canRedo,
+    handleSave, handleReset, dismissServerBanner,
+  } = useResourceEditor<ConventionsCatalog>({
+    tabType: "conventions-catalog",
+    mtimeKind: "conventions",
+    draftKind: "conventions-catalog",
+    id: RESOURCE_ID,
+    load: loadCatalog,
+    save: saveCatalog,
+    broadcastName: "conventionsChanged",
+  });
+
+  const addMsg = useCallback((key: string) => {
+    update((c) => {
+      if (!c.msg) c.msg = {};
+      if (!c.msg[key]) c.msg[key] = { template: "" };
+    });
+  }, [update]);
+
+  const addRegex = useCallback((key: string) => {
+    update((c) => {
+      if (!c.regex) c.regex = {};
+      if (!c.regex[key]) c.regex[key] = { pattern: "" };
+    });
+  }, [update]);
+
+  const addLimit = useCallback((key: string) => {
+    update((c) => {
+      if (!c.limit) c.limit = {};
+      if (!c.limit[key]) c.limit[key] = { value: 0 };
+    });
+  }, [update]);
+
+  if (!catalog) return null;
+
+  return (
+    <div className="conventions-catalog-view">
+      <TableSubToolbar />
+
+      {serverChanged && (
+        <ServerChangeBanner onReload={handleReset} onDismiss={dismissServerBanner} />
+      )}
+
+      <EditorHeader
+        title={<span className="fw-semibold">規約カタログ</span>}
+        undoRedo={{ onUndo: undo, onRedo: redo, canUndo, canRedo }}
+        saveReset={{ isDirty, isSaving, onSave: handleSave, onReset: handleReset }}
+      />
+
+      <div className="conventions-meta-bar">
+        <label className="small text-muted">version</label>
+        <input
+          type="text"
+          className="form-control form-control-sm conventions-version-input"
+          value={catalog.version ?? ""}
+          onChange={(e) => updateSilent((c) => { c.version = e.target.value; })}
+          onBlur={commit}
+          placeholder="1.0.0"
+        />
+        <label className="small text-muted">description</label>
+        <input
+          type="text"
+          className="form-control form-control-sm conventions-description-input"
+          value={catalog.description ?? ""}
+          onChange={(e) => updateSilent((c) => { c.description = e.target.value || undefined; })}
+          onBlur={commit}
+          placeholder="カタログの用途 (任意)"
+        />
+      </div>
+
+      <div className="conventions-category-tabs" role="tablist">
+        {(Object.keys(CATEGORY_LABELS) as Category[]).map((cat) => {
+          const count = Object.keys(catalog[cat] ?? {}).length;
+          return (
+            <button
+              key={cat}
+              type="button"
+              className={`conventions-category-tab ${activeCategory === cat ? "active" : ""}`}
+              onClick={() => setActiveCategory(cat)}
+              role="tab"
+              aria-selected={activeCategory === cat}
+            >
+              <i className={`bi ${CATEGORY_ICONS[cat]}`} /> {CATEGORY_LABELS[cat]}
+              {count > 0 && <span className="conventions-category-count">{count}</span>}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="conventions-category-content">
+        {activeCategory === "msg" && (
+          <MsgEditor
+            msg={catalog.msg ?? {}}
+            onAdd={addMsg}
+            onUpdate={(key, patch) => updateSilent((c) => {
+              if (!c.msg || !c.msg[key]) return;
+              Object.assign(c.msg[key], patch);
+            })}
+            onCommit={commit}
+            onRemove={(key) => update((c) => {
+              if (c.msg) delete c.msg[key];
+            })}
+          />
+        )}
+        {activeCategory === "regex" && (
+          <RegexEditor
+            regex={catalog.regex ?? {}}
+            onAdd={addRegex}
+            onUpdate={(key, patch) => updateSilent((c) => {
+              if (!c.regex || !c.regex[key]) return;
+              Object.assign(c.regex[key], patch);
+            })}
+            onCommit={commit}
+            onRemove={(key) => update((c) => {
+              if (c.regex) delete c.regex[key];
+            })}
+          />
+        )}
+        {activeCategory === "limit" && (
+          <LimitEditor
+            limit={catalog.limit ?? {}}
+            onAdd={addLimit}
+            onUpdate={(key, patch) => updateSilent((c) => {
+              if (!c.limit || !c.limit[key]) return;
+              Object.assign(c.limit[key], patch);
+            })}
+            onCommit={commit}
+            onRemove={(key) => update((c) => {
+              if (c.limit) delete c.limit[key];
+            })}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── 各カテゴリエディタ ─────────────────────────────────────────────────
+
+interface MsgEntry {
+  template: string;
+  params?: string[];
+  description?: string;
+}
+
+function MsgEditor({
+  msg, onAdd, onUpdate, onCommit, onRemove,
+}: {
+  msg: Record<string, MsgEntry>;
+  onAdd: (key: string) => void;
+  onUpdate: (key: string, patch: Partial<MsgEntry>) => void;
+  onCommit: () => void;
+  onRemove: (key: string) => void;
+}) {
+  const [newKey, setNewKey] = useState("");
+  const entries = Object.entries(msg);
+
+  return (
+    <div className="conventions-entries">
+      {entries.length === 0 && (
+        <div className="conventions-empty">エントリがありません。下の入力欄から追加してください。</div>
+      )}
+      <table className="conventions-table">
+        <colgroup>
+          <col style={{ width: "14em" }} />
+          <col />
+          <col style={{ width: "18em" }} />
+          <col style={{ width: "18em" }} />
+          <col style={{ width: 28 }} />
+        </colgroup>
+        <thead>
+          <tr>
+            <th>key (@conv.msg.xxx)</th>
+            <th>template</th>
+            <th>params (カンマ区切り)</th>
+            <th>description</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map(([key, entry]) => (
+            <tr key={key}>
+              <td><code className="conventions-key-badge">{key}</code></td>
+              <td>
+                <input
+                  className="form-control form-control-sm"
+                  value={entry.template}
+                  onChange={(e) => onUpdate(key, { template: e.target.value })}
+                  onBlur={onCommit}
+                  placeholder="{label}は必須入力です"
+                />
+              </td>
+              <td>
+                <input
+                  className="form-control form-control-sm"
+                  value={(entry.params ?? []).join(", ")}
+                  onChange={(e) => {
+                    const params = e.target.value.split(",").map((s) => s.trim()).filter(Boolean);
+                    onUpdate(key, { params: params.length > 0 ? params : undefined });
+                  }}
+                  onBlur={onCommit}
+                  placeholder="label, max"
+                />
+              </td>
+              <td>
+                <input
+                  className="form-control form-control-sm"
+                  value={entry.description ?? ""}
+                  onChange={(e) => onUpdate(key, { description: e.target.value || undefined })}
+                  onBlur={onCommit}
+                />
+              </td>
+              <td className="text-center">
+                <button
+                  type="button"
+                  className="btn btn-sm btn-link text-danger p-0"
+                  onClick={() => onRemove(key)}
+                  title="削除"
+                  aria-label="削除"
+                >
+                  <i className="bi bi-x" />
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <NewKeyRow
+        placeholder="新規 key (例: required)"
+        value={newKey}
+        setValue={setNewKey}
+        onAdd={() => { const k = newKey.trim(); if (k && !msg[k]) { onAdd(k); setNewKey(""); } }}
+        disabled={!newKey.trim() || Object.hasOwn(msg, newKey.trim())}
+      />
+    </div>
+  );
+}
+
+interface RegexEntry {
+  pattern: string;
+  flags?: string;
+  description?: string;
+  exampleValid?: string[];
+  exampleInvalid?: string[];
+}
+
+function RegexEditor({
+  regex, onAdd, onUpdate, onCommit, onRemove,
+}: {
+  regex: Record<string, RegexEntry>;
+  onAdd: (key: string) => void;
+  onUpdate: (key: string, patch: Partial<RegexEntry>) => void;
+  onCommit: () => void;
+  onRemove: (key: string) => void;
+}) {
+  const [newKey, setNewKey] = useState("");
+  const entries = Object.entries(regex);
+
+  return (
+    <div className="conventions-entries">
+      {entries.length === 0 && (
+        <div className="conventions-empty">エントリがありません。下の入力欄から追加してください。</div>
+      )}
+      <table className="conventions-table">
+        <colgroup>
+          <col style={{ width: "14em" }} />
+          <col />
+          <col style={{ width: "6em" }} />
+          <col style={{ width: "18em" }} />
+          <col style={{ width: 28 }} />
+        </colgroup>
+        <thead>
+          <tr>
+            <th>key (@conv.regex.xxx)</th>
+            <th>pattern</th>
+            <th>flags</th>
+            <th>description</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map(([key, entry]) => (
+            <tr key={key}>
+              <td><code className="conventions-key-badge">{key}</code></td>
+              <td>
+                <input
+                  className="form-control form-control-sm conventions-mono"
+                  value={entry.pattern}
+                  onChange={(e) => onUpdate(key, { pattern: e.target.value })}
+                  onBlur={onCommit}
+                  placeholder="^[A-Za-z0-9]+$"
+                />
+              </td>
+              <td>
+                <input
+                  className="form-control form-control-sm conventions-mono"
+                  value={entry.flags ?? ""}
+                  onChange={(e) => onUpdate(key, { flags: e.target.value || undefined })}
+                  onBlur={onCommit}
+                  placeholder="i"
+                />
+              </td>
+              <td>
+                <input
+                  className="form-control form-control-sm"
+                  value={entry.description ?? ""}
+                  onChange={(e) => onUpdate(key, { description: e.target.value || undefined })}
+                  onBlur={onCommit}
+                />
+              </td>
+              <td className="text-center">
+                <button
+                  type="button"
+                  className="btn btn-sm btn-link text-danger p-0"
+                  onClick={() => onRemove(key)}
+                  title="削除"
+                  aria-label="削除"
+                >
+                  <i className="bi bi-x" />
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <NewKeyRow
+        placeholder="新規 key (例: phone-jp)"
+        value={newKey}
+        setValue={setNewKey}
+        onAdd={() => { const k = newKey.trim(); if (k && !regex[k]) { onAdd(k); setNewKey(""); } }}
+        disabled={!newKey.trim() || Object.hasOwn(regex, newKey.trim())}
+      />
+    </div>
+  );
+}
+
+interface LimitEntry {
+  value: number;
+  unit?: string;
+  description?: string;
+}
+
+function LimitEditor({
+  limit, onAdd, onUpdate, onCommit, onRemove,
+}: {
+  limit: Record<string, LimitEntry>;
+  onAdd: (key: string) => void;
+  onUpdate: (key: string, patch: Partial<LimitEntry>) => void;
+  onCommit: () => void;
+  onRemove: (key: string) => void;
+}) {
+  const [newKey, setNewKey] = useState("");
+  const entries = Object.entries(limit);
+
+  return (
+    <div className="conventions-entries">
+      {entries.length === 0 && (
+        <div className="conventions-empty">エントリがありません。下の入力欄から追加してください。</div>
+      )}
+      <table className="conventions-table">
+        <colgroup>
+          <col style={{ width: "14em" }} />
+          <col style={{ width: "10em" }} />
+          <col style={{ width: "8em" }} />
+          <col />
+          <col style={{ width: 28 }} />
+        </colgroup>
+        <thead>
+          <tr>
+            <th>key (@conv.limit.xxx)</th>
+            <th>value</th>
+            <th>unit</th>
+            <th>description</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map(([key, entry]) => (
+            <tr key={key}>
+              <td><code className="conventions-key-badge">{key}</code></td>
+              <td>
+                <input
+                  type="number"
+                  className="form-control form-control-sm"
+                  value={entry.value}
+                  onChange={(e) => onUpdate(key, { value: Number(e.target.value) })}
+                  onBlur={onCommit}
+                />
+              </td>
+              <td>
+                <input
+                  className="form-control form-control-sm"
+                  value={entry.unit ?? ""}
+                  onChange={(e) => onUpdate(key, { unit: e.target.value || undefined })}
+                  onBlur={onCommit}
+                  placeholder="char"
+                />
+              </td>
+              <td>
+                <input
+                  className="form-control form-control-sm"
+                  value={entry.description ?? ""}
+                  onChange={(e) => onUpdate(key, { description: e.target.value || undefined })}
+                  onBlur={onCommit}
+                />
+              </td>
+              <td className="text-center">
+                <button
+                  type="button"
+                  className="btn btn-sm btn-link text-danger p-0"
+                  onClick={() => onRemove(key)}
+                  title="削除"
+                  aria-label="削除"
+                >
+                  <i className="bi bi-x" />
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <NewKeyRow
+        placeholder="新規 key (例: emailMax)"
+        value={newKey}
+        setValue={setNewKey}
+        onAdd={() => { const k = newKey.trim(); if (k && !limit[k]) { onAdd(k); setNewKey(""); } }}
+        disabled={!newKey.trim() || Object.hasOwn(limit, newKey.trim())}
+      />
+    </div>
+  );
+}
+
+function NewKeyRow({
+  placeholder, value, setValue, onAdd, disabled,
+}: {
+  placeholder: string;
+  value: string;
+  setValue: (v: string) => void;
+  onAdd: () => void;
+  disabled: boolean;
+}) {
+  return (
+    <div className="conventions-new-key-row">
+      <input
+        className="form-control form-control-sm conventions-new-key-input"
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={(e) => { if (e.key === "Enter" && !disabled) { e.preventDefault(); onAdd(); } }}
+      />
+      <button
+        type="button"
+        className="btn btn-sm btn-outline-primary"
+        onClick={onAdd}
+        disabled={disabled}
+      >
+        <i className="bi bi-plus-lg" /> 追加
+      </button>
+    </div>
+  );
+}

--- a/designer/src/mcp/mcpBridge.ts
+++ b/designer/src/mcp/mcpBridge.ts
@@ -45,6 +45,10 @@ import {
   setActionStorageBackend,
   type ActionStorageBackend,
 } from "../store/actionStore";
+import {
+  setConventionsStorageBackend,
+  type ConventionsStorageBackend,
+} from "../store/conventionsStore";
 import { loadTable } from "../store/tableStore";
 
 export type McpStatus = "disconnected" | "connecting" | "connected";
@@ -274,6 +278,12 @@ class McpBridgeImpl {
       listActionGroups: () => this.request("listActionGroups"),
     };
     setActionStorageBackend(actionBackend);
+
+    const conventionsBackend: ConventionsStorageBackend = {
+      loadConventions: () => this.request("loadConventions"),
+      saveConventions: (catalog) => this.request("saveConventions", { catalog }).then(() => undefined),
+    };
+    setConventionsStorageBackend(conventionsBackend);
   }
 
   /** 切断時: localStorage フォールバックに戻す */
@@ -283,6 +293,7 @@ class McpBridgeImpl {
     setTableStorageBackend(null);
     setErLayoutStorageBackend(null);
     setActionStorageBackend(null);
+    setConventionsStorageBackend(null);
   }
 
   // ── メッセージ受信 ─────────────────────────────────────────────────────

--- a/designer/src/schemas/conventionsValidator.ts
+++ b/designer/src/schemas/conventionsValidator.ts
@@ -14,9 +14,11 @@ import type {
 
 export interface ConventionsCatalog {
   version: string;
-  msg?: Record<string, { template: string }>;
-  regex?: Record<string, { pattern: string; flags?: string }>;
-  limit?: Record<string, { value: number; unit?: string }>;
+  description?: string;
+  updatedAt?: string;
+  msg?: Record<string, { template: string; params?: string[]; description?: string }>;
+  regex?: Record<string, { pattern: string; flags?: string; description?: string; exampleValid?: string[]; exampleInvalid?: string[] }>;
+  limit?: Record<string, { value: number; unit?: string; description?: string }>;
 }
 
 export interface ConventionIssue {

--- a/designer/src/store/conventionsStore.ts
+++ b/designer/src/store/conventionsStore.ts
@@ -1,0 +1,70 @@
+/**
+ * conventionsStore.ts
+ * 横断規約カタログ (validation-rules / product-scope) の永続化ストア (#317)。
+ *
+ * 正本は `data/conventions/catalog.json`。wsBridge 経由で読み書きし、
+ * ws 未接続時は localStorage にフォールバック。形状は
+ * `schemas/conventions.schema.json` 準拠。
+ */
+import type { ConventionsCatalog } from "../schemas/conventionsValidator";
+
+export interface ConventionsStorageBackend {
+  loadConventions(): Promise<unknown>;
+  saveConventions(catalog: unknown): Promise<void>;
+}
+
+let _backend: ConventionsStorageBackend | null = null;
+
+export function setConventionsStorageBackend(b: ConventionsStorageBackend | null): void {
+  _backend = b;
+}
+
+const LS_KEY = "conventions-catalog";
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+/** 初期カタログ (空) */
+export function createEmptyCatalog(): ConventionsCatalog {
+  return {
+    version: "1.0.0",
+    description: "",
+    updatedAt: now(),
+    msg: {},
+    regex: {},
+    limit: {},
+  } as ConventionsCatalog;
+}
+
+export async function loadConventions(): Promise<ConventionsCatalog | null> {
+  // 1. wsBridge backend (data/conventions/catalog.json) が優先
+  if (_backend) {
+    const data = await _backend.loadConventions();
+    if (data) return data as ConventionsCatalog;
+  } else {
+    // 2. ws 未接続なら localStorage フォールバック (テスト時の seed にも使う)
+    const raw = localStorage.getItem(LS_KEY);
+    if (raw) {
+      try {
+        return JSON.parse(raw) as ConventionsCatalog;
+      } catch { /* ignore */ }
+    }
+  }
+  // 3. 最終フォールバック: public/ 配下の静的ファイル (#317 以前の経路、互換用)
+  //    初回起動で data/conventions/catalog.json 未生成の場合にもデフォルト規約を返す
+  try {
+    const r = await fetch("/conventions-catalog.json");
+    if (r.ok) return await r.json() as ConventionsCatalog;
+  } catch { /* ignore */ }
+  return null;
+}
+
+export async function saveConventions(catalog: ConventionsCatalog): Promise<void> {
+  catalog.updatedAt = now();
+  if (_backend) {
+    await _backend.saveConventions(catalog);
+    return;
+  }
+  localStorage.setItem(LS_KEY, JSON.stringify(catalog));
+}

--- a/designer/src/store/tabStore.ts
+++ b/designer/src/store/tabStore.ts
@@ -14,11 +14,13 @@ export type TabType =
   | "table-list"         // テーブル一覧
   | "er"                 // ER 図
   | "process-flow-list"  // 処理フロー一覧
+  | "conventions-catalog" // 規約カタログ (#317)
   | "dashboard";         // ダッシュボード（#86 PR-3 で有効化）
 
 const KNOWN_TAB_TYPES: ReadonlySet<TabType> = new Set([
   "design", "table", "action",
-  "screen-flow", "screen-list", "table-list", "er", "process-flow-list", "dashboard",
+  "screen-flow", "screen-list", "table-list", "er", "process-flow-list",
+  "conventions-catalog", "dashboard",
 ]);
 
 export interface TabItem {

--- a/designer/src/styles/conventions.css
+++ b/designer/src/styles/conventions.css
@@ -1,0 +1,173 @@
+/* 規約カタログビュー (#317) */
+
+.conventions-catalog-view {
+  height: calc(100vh - var(--common-header-h, 0px) - var(--tabbar-h, 0px));
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: #f8f9fa;
+}
+
+.conventions-meta-bar {
+  padding: 6px 14px;
+  background: #fff;
+  border-bottom: 1px solid #e2e8f0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.conventions-meta-bar label {
+  margin: 0;
+  font-weight: 600;
+}
+
+.conventions-version-input {
+  max-width: 7em;
+}
+
+.conventions-description-input {
+  flex: 1 1 auto;
+  min-width: 20em;
+}
+
+.conventions-category-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 2px solid #e2e8f0;
+  padding: 0 14px;
+  background: #fff;
+  overflow-x: auto;
+}
+
+.conventions-category-tab {
+  padding: 8px 16px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #64748b;
+  border: none;
+  background: none;
+  cursor: pointer;
+  white-space: nowrap;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.conventions-category-tab:hover {
+  color: #334155;
+}
+
+.conventions-category-tab.active {
+  color: #6366f1;
+  border-bottom-color: #6366f1;
+  font-weight: 600;
+}
+
+.conventions-category-count {
+  background: #e2e8f0;
+  color: #475569;
+  font-size: 0.7rem;
+  padding: 0 6px;
+  border-radius: 999px;
+  font-weight: 600;
+  line-height: 1.5;
+}
+
+.conventions-category-tab.active .conventions-category-count {
+  background: #6366f1;
+  color: #fff;
+}
+
+.conventions-category-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 14px;
+}
+
+.conventions-entries {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  padding: 8px;
+}
+
+.conventions-empty {
+  color: #94a3b8;
+  padding: 16px;
+  text-align: center;
+  font-style: italic;
+  font-size: 0.85rem;
+}
+
+.conventions-table {
+  width: 100%;
+  table-layout: fixed;
+  border-collapse: collapse;
+  margin: 0;
+}
+
+.conventions-table thead th {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: #64748b;
+  padding: 4px 6px;
+  border-bottom: 1px solid #cbd5e1;
+  text-align: left;
+  background: transparent;
+}
+
+.conventions-table tbody td {
+  padding: 3px 6px;
+  vertical-align: middle;
+  border-bottom: 1px solid #f1f5f9;
+}
+
+.conventions-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.conventions-table input.form-control {
+  width: 100%;
+  padding: 2px 6px;
+  font-size: 0.82rem;
+  min-width: 0;
+  min-height: 26px;
+  height: 28px;
+}
+
+.conventions-mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.conventions-key-badge {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #1e40af;
+  background: #dbeafe;
+  padding: 2px 8px;
+  border-radius: 4px;
+  display: inline-block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+}
+
+.conventions-new-key-row {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  margin-top: 8px;
+  padding: 6px 0;
+  border-top: 1px dashed #e2e8f0;
+}
+
+.conventions-new-key-input {
+  flex: 1 1 auto;
+  max-width: 24em;
+}

--- a/designer/src/utils/serverMtime.ts
+++ b/designer/src/utils/serverMtime.ts
@@ -7,7 +7,7 @@
  */
 import { mcpBridge } from "../mcp/mcpBridge";
 
-export type MtimeKind = "project" | "screen" | "table" | "actionGroup" | "erLayout" | "customBlocks";
+export type MtimeKind = "project" | "screen" | "table" | "actionGroup" | "erLayout" | "customBlocks" | "conventions";
 
 const LAST_SEEN_PREFIX = "mtime-";
 

--- a/docs/conventions/validation-rules.md
+++ b/docs/conventions/validation-rules.md
@@ -1,19 +1,20 @@
 # バリデーション規約
 
-**ステータス**: 機械可読版あり (`docs/sample-project/conventions/conventions-catalog.json`)、human-readable は本書
-**策定日**: 2026-04-20
-**関連 issue**: #151 (A: 設計書種別の追加) / #261 残
+**ステータス**: JSON 正本 (`data/conventions/catalog.json`)。本書は人間向け参考資料。
+**策定日**: 2026-04-20 (#151-A) / 更新 2026-04-22 (#317 で JSON 正本化・編集 UI 搭載)
+**関連 issue**: #151 (A: 設計書種別の追加) / #261 残 / #317 (UI 編集化)
 
 本書は処理フロー仕様書が参照する横断的なバリデーション規約 (メッセージテンプレート + 正規表現カタログ + 境界値) を定める。
 
-## 機械可読版 (v1.6 新設)
+## 正本の場所 (#317 で改訂)
 
-AI / CI から読める JSON 形式:
-- **カタログ**: [`docs/sample-project/conventions/conventions-catalog.json`](../sample-project/conventions/conventions-catalog.json)
+- **ランタイム正本**: `data/conventions/catalog.json` (gitignored)
+- **サンプル (seed 元)**: [`docs/sample-project/conventions/conventions-catalog.json`](../sample-project/conventions/conventions-catalog.json) — `node docs/sample-project/seed.mjs` で `data/conventions/catalog.json` にコピーされる
 - **JSON Schema**: [`schemas/conventions.schema.json`](../../schemas/conventions.schema.json)
 - **参照整合性検証**: `designer/src/schemas/conventionsValidator.ts` が処理フロー内の `@conv.*` 参照を検査
+- **編集 UI**: 業務システムデザイナーの「規約カタログ」タブから閲覧・編集可 (#317)
 
-本 md 本文 (§1-§3) と JSON カタログが drift しないよう、md を更新したら JSON も更新する。
+**本 md 本文 (§1-§3) は人間向け参考資料**。編集・追加は基本的に designer アプリ経由で JSON を更新する。md と JSON で drift した場合は JSON 側が優先。
 
 ---
 

--- a/docs/sample-project/seed.mjs
+++ b/docs/sample-project/seed.mjs
@@ -22,10 +22,13 @@ const ACTIONS_DIR = path.join(DATA_DIR, "actions");
 const SEED_SCREENS_DIR = path.join(__dirname, "screens");
 const SEED_TABLES_DIR = path.join(__dirname, "tables");
 const SEED_ACTIONS_DIR = path.join(__dirname, "actions");
+const CONVENTIONS_DIR = path.join(DATA_DIR, "conventions");
+const SEED_CONVENTIONS_DIR = path.join(__dirname, "conventions");
 
 fs.mkdirSync(SCREENS_DIR, { recursive: true });
 fs.mkdirSync(TABLES_DIR, { recursive: true });
 fs.mkdirSync(ACTIONS_DIR, { recursive: true });
+fs.mkdirSync(CONVENTIONS_DIR, { recursive: true });
 fs.mkdirSync(SEED_SCREENS_DIR, { recursive: true });
 
 // ── GrapesJS スクリーンデータ生成ヘルパー ─────────────────────────────────
@@ -856,10 +859,24 @@ if (fs.existsSync(SEED_ACTIONS_DIR)) {
   }
 }
 
+// ── 規約カタログをコピー (#317) ───────────────────────────────────────────
+// docs/sample-project/conventions/conventions-catalog.json を
+// data/conventions/catalog.json にコピー (ファイル名を正規化)
+let conventionsCount = 0;
+if (fs.existsSync(SEED_CONVENTIONS_DIR)) {
+  const src = path.join(SEED_CONVENTIONS_DIR, "conventions-catalog.json");
+  if (fs.existsSync(src)) {
+    fs.copyFileSync(src, path.join(CONVENTIONS_DIR, "catalog.json"));
+    conventionsCount++;
+    console.log(`[conventions 1/1] catalog.json`);
+  }
+}
+
 console.log("\n✅ シードデータ生成完了");
 console.log(`   data/screens/        → ${count} ファイル`);
 console.log(`   data/tables/         → ${tableCount} ファイル`);
 console.log(`   data/actions/        → ${actionCount} ファイル`);
+console.log(`   data/conventions/    → ${conventionsCount} ファイル`);
 console.log(`   docs/sample-project/ → バックアップ済み`);
 console.log("\n復元方法:");
 console.log("   node docs/sample-project/seed.mjs");


### PR DESCRIPTION
## 関連

- Closes #317
- base: \`main\`
- 仕様: \`docs/conventions/validation-rules.md\` 更新 (JSON 正本化)

## 概要

業務システムデザイナー内で横断規約カタログ (\`@conv.msg.*\` / \`@conv.regex.*\` / \`@conv.limit.*\`) を閲覧・編集できるシングルトンタブを追加。

これまで \`docs/conventions/validation-rules.md\` が正本で \`docs/sample-project/conventions/conventions-catalog.json\` は派生、という二重管理だったのを、**JSON (\`data/conventions/catalog.json\`) を正本に反転**。md は人間向け参考資料に降格。designer 内の「規約カタログ」タブから追加・編集・削除が可能。

## 主な変更

### Backend (designer-mcp)
- [\`projectStorage.ts\`](designer-mcp/src/projectStorage.ts): \`CONVENTIONS_DIR\` / \`CONVENTIONS_FILE\` 追加、\`readConventions\` / \`writeConventions\` エクスポート
- [\`wsBridge.ts\`](designer-mcp/src/wsBridge.ts): \`loadConventions\` / \`saveConventions\` handler 追加、\`conventionsChanged\` broadcast

### Frontend Store / Bridge
- [\`conventionsStore.ts\`](designer/src/store/conventionsStore.ts) 新規: backend 優先 + localStorage フォールバック + \`/conventions-catalog.json\` 静的フォールバック (既存 E2E 互換)
- [\`mcpBridge.ts\`](designer/src/mcp/mcpBridge.ts): \`conventionsBackend\` を \`_setStorageBackends\` に登録
- [\`tabStore.ts\`](designer/src/store/tabStore.ts): \`"conventions-catalog"\` タブ種別追加
- [\`serverMtime.ts\`](designer/src/utils/serverMtime.ts): \`MtimeKind\` に \`"conventions"\` 追加
- [\`conventionsValidator.ts\`](designer/src/schemas/conventionsValidator.ts): \`ConventionsCatalog\` 型を JSON Schema に合わせて拡張 (description / updatedAt / params / exampleValid / exampleInvalid)

### UI
- [\`ConventionsCatalogView.tsx\`](designer/src/components/conventions/ConventionsCatalogView.tsx) 新規: \`useResourceEditor\` で undo/redo + save/reset、3 カテゴリサブタブ (msg/regex/limit) で CRUD。version / description を上部メタバーで編集
- [\`conventions.css\`](designer/src/styles/conventions.css) 新規: テーブルレイアウト + タブバー + key-badge
- [\`HeaderMenu.tsx\`](designer/src/components/HeaderMenu.tsx): 「規約カタログ」エントリ追加 (\`bi-file-text\`)
- [\`AppShell.tsx\`](designer/src/components/AppShell.tsx): singleton route + \`<Route path="/conventions/catalog">\`

### 既存参照点の置換
- [\`ActionEditor.tsx\`](designer/src/components/action/ActionEditor.tsx): \`fetch("/conventions-catalog.json")\` → \`loadConventions()\`
- [\`ActionListView.tsx\`](designer/src/components/action/ActionListView.tsx): 同上

### データ移行
- [\`seed.mjs\`](docs/sample-project/seed.mjs): \`docs/sample-project/conventions/conventions-catalog.json\` → \`data/conventions/catalog.json\` コピー処理追加

### Spec 更新
- [\`validation-rules.md\`](docs/conventions/validation-rules.md): JSON 正本方針を明文化。md は人間向け参考資料、drift 時は JSON 優先

## 仕様逐条突合 (自己申告)

### #317 完了条件
- ✓ **「規約カタログ」メニューから編集画面を開ける** → [HeaderMenu.tsx:39-42](designer/src/components/HeaderMenu.tsx#L39-L42) + [AppShell.tsx:260](designer/src/components/AppShell.tsx#L260)
- ✓ **regex / msg / limit カテゴリで追加・編集・削除できる** → [ConventionsCatalogView.tsx:156-339](designer/src/components/conventions/ConventionsCatalogView.tsx#L156-L339)。E2E 5 件 pass
- ✓ **\`docs/conventions/*.md\` に保存され、処理フローから \`@conv.*\` で正しく参照解決される** → wsBridge 経由で \`data/conventions/catalog.json\` に保存、\`validation-sql-conv-panel.spec.ts\` (既存) 2 件 pass
- ✓ **既存サンプルプロジェクト (0005 等) の \`@conv.*\` 参照が壊れない** → \`loadConventions\` の 3 段フォールバックで既存静的ファイルも読めるので互換維持、既存 E2E pass
- △ **Vitest で conventions 読み書き往復テスト** → conventionsStore の round-trip 単体テストは未追加 (E2E で代替)。follow-up で追加余地

### 対象外 (別 issue)
- \`docs/conventions/product-scope.md\` の UI 編集 (markdown で自由記述のため別設計)
- \`@conv.\` typing 時の datalist オートコンプリート
- 規約 ID のバージョン固定 / lint (#151-A)
- md ↔ JSON 自動同期

## レビューで特に見てほしい箇所

- **JSON 正本への反転**: 既存は md が正本、JSON は派生。これを反転したので \`validation-rules.md\` の表 (§1-§3) と JSON で drift したら JSON 優先で運用する。md 側の定義追記は廃止方向。妥当か
- **3 段フォールバック (\`conventionsStore.loadConventions\`)**: backend → localStorage → \`/conventions-catalog.json\` 静的。3 段目は #317 前のコードとの互換用。冗長だが既存 E2E を壊さない
- **\`ConventionsCatalog\` 型拡張**: \`description\` / \`updatedAt\` / \`params\` / \`exampleValid\` / \`exampleInvalid\` を追加。JSON Schema と合わせただけで後方互換維持 (全 optional)
- **シングルトンタブパターンの追加**: 既存の他のシングルトン (ER 図等) と同じ配線だが、\`useResourceEditor\` を使って undo/redo + save/reset 対応は新規

## テスト

- Vitest: 496 件 (frontend) + 37 件 (backend) — 全件 pass
- Playwright: \`conventions-catalog.spec.ts\` 新規 5 件 + \`validation-sql-conv-panel.spec.ts\` 既存 2 件 — 全件 pass
- \`vite build\` 成功

## UI 影響 / マージ保留フラグ

- [x] **UI 影響あり (マージ前にユーザー目視確認必須)**

### 確認項目

- [ ] ハンバーガーメニュー → 「規約カタログ」で開ける
- [ ] タブバーに「規約カタログ」シングルトンタブが表示される (再オープンで重複しない)
- [ ] 3 カテゴリタブ (メッセージ / 正規表現 / 制限値) が切り替えられる
- [ ] 各カテゴリで新規エントリ追加、フィールド編集、削除ができる
- [ ] 保存ボタンで \`data/conventions/catalog.json\` が更新される
- [ ] 別タブで編集 → 保存 → 本タブでブロードキャスト受信して反映される (複数タブ運用)
- [ ] 処理フロー側の \`@conv.*\` 警告 (UNKNOWN_CONV_MSG 等) が新規エントリ追加後に解消される
- [ ] 既存サンプル \`cccccccc-0005\` 等の \`@conv.*\` 参照が壊れない

## spec 側の不足点 / 提案

- \`product-scope.md\` は markdown (自由記述) なので UI 編集対象外とした。将来、構造化するなら別 issue
- \`@conv.\` オートコンプリートは本 PR 範囲外。処理フローエディタの \`ValidationStep.rules[].message\` 等の入力欄で \`datalist\` 展開する follow-up を検討

## レビュー担当への申し送り

- md → JSON 正本反転が最大の設計判断。既存運用との差分は \`docs/conventions/validation-rules.md\` のステータス行を参照
- \`useResourceEditor\` を singleton resource (id="main") に流用するパターンは初。問題あれば指摘してほしい
- \`@conv.\` 参照箇所 (ActionEditor / ActionListView) で \`fetch\` → \`loadConventions()\` に置換した影響で、未接続時の挙動が変わる可能性。localStorage fallback でカバーしているつもりだが確認したい