### PR TITLE
feat(screen-items): 画面項目定義 仕様 v0.1 + 動作プロトタイプ (#318)

### DIFF
--- a/designer-mcp/src/projectStorage.ts
+++ b/designer-mcp/src/projectStorage.ts
@@ -17,6 +17,7 @@ const SCREENS_DIR = path.join(DATA_DIR, "screens");
 const TABLES_DIR = path.join(DATA_DIR, "tables");
 const ACTIONS_DIR = path.join(DATA_DIR, "actions");
 const CONVENTIONS_DIR = path.join(DATA_DIR, "conventions");
+const SCREEN_ITEMS_DIR = path.join(DATA_DIR, "screen-items");
 export const PROJECT_FILE = path.join(DATA_DIR, "project.json");
 export const CUSTOM_BLOCKS_FILE = path.join(DATA_DIR, "custom-blocks.json");
 export const ER_LAYOUT_FILE = path.join(DATA_DIR, "er-layout.json");
@@ -29,6 +30,7 @@ export async function ensureDataDir(): Promise<void> {
   await fs.mkdir(TABLES_DIR, { recursive: true });
   await fs.mkdir(ACTIONS_DIR, { recursive: true });
   await fs.mkdir(CONVENTIONS_DIR, { recursive: true });
+  await fs.mkdir(SCREEN_ITEMS_DIR, { recursive: true });
 }
 
 async function readJSON<T>(filePath: string): Promise<T | null> {
@@ -77,6 +79,7 @@ function resolveDataFile(kind: string, id?: string): string | null {
     case "screen": return id ? path.join(SCREENS_DIR, `${id}.json`) : null;
     case "table": return id ? path.join(TABLES_DIR, `${id}.json`) : null;
     case "actionGroup": return id ? path.join(ACTIONS_DIR, `${id}.json`) : null;
+    case "screenItems": return id ? path.join(SCREEN_ITEMS_DIR, `${id}.json`) : null;
     default: return null;
   }
 }
@@ -166,6 +169,24 @@ export async function readConventions(): Promise<unknown | null> {
 export async function writeConventions(data: unknown): Promise<void> {
   await ensureDataDir();
   await writeJSON(CONVENTIONS_FILE, data);
+}
+
+/** screen-items/{screenId}.json を読み込み (#318) */
+export async function readScreenItems(screenId: string): Promise<unknown | null> {
+  return readJSON<unknown>(path.join(SCREEN_ITEMS_DIR, `${screenId}.json`));
+}
+
+/** screen-items/{screenId}.json を書き込み (#318) */
+export async function writeScreenItems(screenId: string, data: unknown): Promise<void> {
+  await ensureDataDir();
+  await writeJSON(path.join(SCREEN_ITEMS_DIR, `${screenId}.json`), data);
+}
+
+/** screen-items/{screenId}.json を削除 (#318) */
+export async function deleteScreenItems(screenId: string): Promise<void> {
+  try {
+    await fs.unlink(path.join(SCREEN_ITEMS_DIR, `${screenId}.json`));
+  } catch { /* file not found is OK */ }
 }
 
 /** actions/ ディレクトリ内の全アクショングループを読み込み */

--- a/designer-mcp/src/wsBridge.ts
+++ b/designer-mcp/src/wsBridge.ts
@@ -23,6 +23,9 @@ import {
   listActionGroups as listActionGroupFiles,
   readConventions,
   writeConventions,
+  readScreenItems,
+  writeScreenItems,
+  deleteScreenItems,
   getFileMtime,
 } from "./projectStorage.js";
 
@@ -443,6 +446,26 @@ class WsBridge extends EventEmitter {
           await writeConventions(catalog);
           respond({ success: true });
           this.broadcast("conventionsChanged", {}, clientId);
+          break;
+        }
+        case "loadScreenItems": {
+          const { screenId } = (params ?? {}) as { screenId: string };
+          const items = await readScreenItems(screenId);
+          respond(items);
+          break;
+        }
+        case "saveScreenItems": {
+          const { screenId, data } = (params ?? {}) as { screenId: string; data: unknown };
+          await writeScreenItems(screenId, data);
+          respond({ success: true });
+          this.broadcast("screenItemsChanged", { screenId }, clientId);
+          break;
+        }
+        case "deleteScreenItems": {
+          const { screenId } = (params ?? {}) as { screenId: string };
+          await deleteScreenItems(screenId);
+          respond({ success: true });
+          this.broadcast("screenItemsChanged", { screenId, deleted: true }, clientId);
           break;
         }
         case "getFileMtime": {

--- a/designer/e2e/screen-items.spec.ts
+++ b/designer/e2e/screen-items.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * 画面項目定義プロトタイプ (#318 / PR #320) の基本 E2E。
+ *
+ * - /screen-items を開けること
+ * - 画面セレクタで画面を選べること
+ * - 新規項目の追加 / name / type / required 編集
+ * - 項目の削除
+ * - 保存ボタン押下で isDirty が解消されること
+ */
+import { test, expect, type Page } from "@playwright/test";
+
+const screenId1 = "scr-1";
+const screenId2 = "scr-2";
+
+const dummyProject = {
+  version: 1,
+  name: "screen-items-ui",
+  screens: [
+    { id: screenId1, no: 1, name: "ログイン画面", type: "standard", updatedAt: new Date().toISOString() },
+    { id: screenId2, no: 2, name: "顧客登録画面", type: "standard", updatedAt: new Date().toISOString() },
+  ],
+  groups: [], edges: [], tables: [], actionGroups: [],
+  updatedAt: new Date().toISOString(),
+};
+
+async function setup(page: Page) {
+  await page.addInitScript(({ project }) => {
+    localStorage.setItem("flow-project", JSON.stringify(project));
+    localStorage.removeItem("designer-open-tabs");
+    localStorage.removeItem("designer-active-tab");
+    // 既存の項目データをクリア
+    for (const k of Object.keys(localStorage)) {
+      if (k.startsWith("screen-items-")) localStorage.removeItem(k);
+    }
+  }, { project: dummyProject });
+  await page.goto("/screen-items");
+  await expect(page.locator(".screen-items-view")).toBeVisible({ timeout: 10000 });
+}
+
+test.describe("画面項目定義プロトタイプ (#318)", () => {
+  test("画面一覧が selector に反映される", async ({ page }) => {
+    await setup(page);
+    const sel = page.locator(".screen-items-screen-selector select");
+    await expect(sel).toBeVisible();
+    await expect(sel.locator("option")).toHaveCount(2);
+    await expect(sel).toContainText("ログイン画面");
+    await expect(sel).toContainText("顧客登録画面");
+  });
+
+  test("項目追加 → name 入力 → 保存", async ({ page }) => {
+    await setup(page);
+    await page.locator(".screen-items-view button:has-text('項目追加')").click();
+    // 1 行出現
+    await expect(page.locator(".screen-items-table tbody tr")).toHaveCount(1);
+    // name 入力
+    const nameInput = page.locator('.screen-items-table input[placeholder="email"]').first();
+    await nameInput.fill("userId");
+    await expect(nameInput).toHaveValue("userId");
+    // label 入力
+    const labelInput = page.locator('.screen-items-table input[placeholder="メールアドレス"]').first();
+    await labelInput.fill("ユーザー ID");
+    // 必須 チェック
+    await page.locator('.screen-items-table input[type="checkbox"][aria-label="必須"]').first().check();
+    // 保存
+    const saveBtn = page.locator(".screen-items-actions button:has-text('保存')");
+    await expect(saveBtn).toBeEnabled();
+    await saveBtn.click();
+    await expect(saveBtn).toBeDisabled({ timeout: 3000 }); // isDirty 解消
+  });
+
+  test("画面切替で項目リストがリセットされる", async ({ page }) => {
+    await setup(page);
+    // scr-1 に 1 件追加 + 保存
+    await page.locator(".screen-items-view button:has-text('項目追加')").click();
+    await page.locator('.screen-items-table input[placeholder="email"]').first().fill("field1");
+    await page.locator(".screen-items-actions button:has-text('保存')").click();
+    await expect(page.locator(".screen-items-actions button:has-text('保存')")).toBeDisabled({ timeout: 3000 });
+    // scr-2 に切替
+    await page.locator(".screen-items-screen-selector select").selectOption(screenId2);
+    // scr-2 は項目 0 件
+    await expect(page.locator(".screen-items-empty-row")).toBeVisible();
+    // scr-1 に戻す
+    await page.locator(".screen-items-screen-selector select").selectOption(screenId1);
+    await expect(page.locator('.screen-items-table input[value="field1"]')).toBeVisible({ timeout: 3000 });
+  });
+
+  test("削除ボタンで項目が消える", async ({ page }) => {
+    await setup(page);
+    await page.locator(".screen-items-view button:has-text('項目追加')").click();
+    await page.locator('.screen-items-table input[placeholder="email"]').first().fill("willDelete");
+    await expect(page.locator(".screen-items-table tbody tr")).toHaveCount(1);
+    await page.locator('.screen-items-table button[aria-label="削除"]').first().click();
+    await expect(page.locator(".screen-items-empty-row")).toBeVisible();
+  });
+});

--- a/designer/src/components/AppShell.tsx
+++ b/designer/src/components/AppShell.tsx
@@ -8,6 +8,7 @@ import { ErDiagram } from "./table/ErDiagram";
 import { ActionListView } from "./action/ActionListView";
 import { ActionEditor } from "./action/ActionEditor";
 import { ConventionsCatalogView } from "./conventions/ConventionsCatalogView";
+import { ScreenItemsView } from "./screen-items/ScreenItemsView";
 import { Designer } from "./Designer";
 import { DashboardView } from "./dashboard/DashboardView";
 import { TabBar } from "./TabBar";
@@ -159,6 +160,7 @@ export function AppShell() {
       { path: "/table/er",           type: "er",                 label: "ER図" },
       { path: "/process-flow/list",  type: "process-flow-list",  label: "処理フロー一覧" },
       { path: "/conventions/catalog", type: "conventions-catalog", label: "規約カタログ" },
+      { path: "/screen-items",       type: "screen-items",       label: "画面項目定義" },
     ];
     for (const { path, type, label } of singletonRoutes) {
       if (location.pathname === path) {
@@ -185,6 +187,7 @@ export function AppShell() {
       : activeTab.type === "er"               ? "/table/er"
       : activeTab.type === "process-flow-list" ? "/process-flow/list"
       : activeTab.type === "conventions-catalog" ? "/conventions/catalog"
+      : activeTab.type === "screen-items"     ? "/screen-items"
       : activeTab.type === "dashboard"        ? "/"
       : null;
     if (expectedPath && location.pathname !== expectedPath) {
@@ -260,6 +263,7 @@ export function AppShell() {
             <Route path="/process-flow/list" element={<ActionListView />} />
             <Route path="/process-flow/edit/:actionGroupId" element={<ActionEditor />} />
             <Route path="/conventions/catalog" element={<ConventionsCatalogView />} />
+            <Route path="/screen-items" element={<ScreenItemsView />} />
           </Routes>
         </ErrorBoundary>
       )}

--- a/designer/src/components/HeaderMenu.tsx
+++ b/designer/src/components/HeaderMenu.tsx
@@ -40,6 +40,10 @@ const MENU_ITEMS: MenuItem[] = [
     id: "conventions-catalog", label: "規約カタログ", icon: "bi-file-text", route: "/conventions/catalog",
     activePaths: ["/conventions/catalog"],
   },
+  {
+    id: "screen-items", label: "画面項目定義 (ドラフト)", icon: "bi-ui-checks-grid", route: "/screen-items",
+    activePaths: ["/screen-items"],
+  },
 ];
 
 const DASHBOARD_ITEM: MenuItem = {

--- a/designer/src/components/screen-items/ScreenItemsView.tsx
+++ b/designer/src/components/screen-items/ScreenItemsView.tsx
@@ -1,0 +1,291 @@
+/**
+ * 画面項目定義ビュー (#318 プロトタイプ)。
+ *
+ * MVP: シングルトンタブで、中で画面を選択して項目を編集する。
+ * 将来 (#318 v1.0 合意後): /screen/items/:screenId の per-screen タブに分割。
+ */
+import { useCallback, useEffect, useState } from "react";
+import { TableSubToolbar } from "../table/TableSubToolbar";
+import {
+  loadScreenItems,
+  saveScreenItems,
+} from "../../store/screenItemsStore";
+import { loadProject } from "../../store/flowStore";
+import type { ScreenItem, ScreenItemsFile } from "../../types/screenItem";
+import type { FieldType } from "../../types/action";
+import { generateUUID } from "../../utils/uuid";
+import "../../styles/screen-items.css";
+
+const PRIMITIVE_TYPES: Array<"string" | "number" | "boolean" | "date"> =
+  ["string", "number", "boolean", "date"];
+
+type ScreenMeta = { id: string; name: string };
+
+export function ScreenItemsView() {
+  const [screens, setScreens] = useState<ScreenMeta[]>([]);
+  const [selectedScreenId, setSelectedScreenId] = useState<string | null>(null);
+  const [file, setFile] = useState<ScreenItemsFile | null>(null);
+  const [isDirty, setIsDirty] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+
+  // 画面一覧をロード
+  useEffect(() => {
+    loadProject().then((p) => {
+      const metas = p.screens.map((s) => ({ id: s.id, name: s.name }));
+      setScreens(metas);
+      if (metas.length > 0 && !selectedScreenId) {
+        setSelectedScreenId(metas[0].id);
+      }
+    }).catch(console.error);
+  }, []);
+
+  // 選択画面が変わったら項目ファイルをロード
+  useEffect(() => {
+    if (!selectedScreenId) { setFile(null); return; }
+    loadScreenItems(selectedScreenId).then((f) => {
+      setFile(f);
+      setIsDirty(false);
+    }).catch(console.error);
+  }, [selectedScreenId]);
+
+  const update = useCallback((mut: (f: ScreenItemsFile) => void) => {
+    setFile((prev) => {
+      if (!prev) return prev;
+      const next = structuredClone(prev);
+      mut(next);
+      return next;
+    });
+    setIsDirty(true);
+  }, []);
+
+  const handleAddItem = () => {
+    update((f) => {
+      f.items.push({
+        id: generateUUID(),
+        name: "",
+        label: "",
+        type: "string",
+      });
+    });
+  };
+
+  const handleUpdateItem = (idx: number, patch: Partial<ScreenItem>) => {
+    update((f) => {
+      Object.assign(f.items[idx], patch);
+    });
+  };
+
+  const handleRemoveItem = (idx: number) => {
+    update((f) => {
+      f.items.splice(idx, 1);
+    });
+  };
+
+  const handleSave = async () => {
+    if (!file) return;
+    setIsSaving(true);
+    try {
+      await saveScreenItems(file);
+      setIsDirty(false);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="screen-items-view">
+      <TableSubToolbar />
+
+      <div className="screen-items-header">
+        <div className="screen-items-title">
+          <i className="bi bi-ui-checks-grid" /> 画面項目定義
+          <span className="badge bg-warning text-dark ms-2" style={{ fontSize: "0.7rem" }}>
+            ドラフト (#318)
+          </span>
+        </div>
+        <div className="screen-items-screen-selector">
+          <label className="form-label mb-0 small fw-semibold">画面</label>
+          <select
+            className="form-select form-select-sm"
+            value={selectedScreenId ?? ""}
+            onChange={(e) => setSelectedScreenId(e.target.value || null)}
+            disabled={screens.length === 0}
+          >
+            {screens.length === 0 && <option value="">画面がありません</option>}
+            {screens.map((s) => (
+              <option key={s.id} value={s.id}>{s.name}</option>
+            ))}
+          </select>
+        </div>
+        <div className="screen-items-actions">
+          <button
+            type="button"
+            className="btn btn-sm btn-primary"
+            onClick={handleSave}
+            disabled={!isDirty || isSaving}
+          >
+            <i className="bi bi-save me-1" />
+            {isSaving ? "保存中..." : "保存"}
+          </button>
+        </div>
+      </div>
+
+      <div className="screen-items-content">
+        {!selectedScreenId && (
+          <div className="screen-items-empty">
+            <p>画面を選択してください。</p>
+            <p className="text-muted small">
+              画面が 1 つも存在しない場合は、先に「画面一覧」から画面を作成してください。
+            </p>
+          </div>
+        )}
+        {selectedScreenId && file && (
+          <div className="screen-items-table-wrap">
+            <table className="screen-items-table">
+              <colgroup>
+                <col style={{ width: 40 }} />
+                <col style={{ width: "12em" }} />
+                <col style={{ width: "12em" }} />
+                <col style={{ width: "9em" }} />
+                <col style={{ width: "4em" }} />
+                <col style={{ width: "5em" }} />
+                <col style={{ width: "5em" }} />
+                <col style={{ width: "12em" }} />
+                <col />
+                <col style={{ width: 30 }} />
+              </colgroup>
+              <thead>
+                <tr>
+                  <th>#</th>
+                  <th>名前 (name)</th>
+                  <th>ラベル (label)</th>
+                  <th>型</th>
+                  <th className="text-center">必須</th>
+                  <th>最小長</th>
+                  <th>最大長</th>
+                  <th>pattern</th>
+                  <th>description</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                {file.items.length === 0 && (
+                  <tr>
+                    <td colSpan={10} className="screen-items-empty-row">項目がありません。下の「項目追加」から追加してください。</td>
+                  </tr>
+                )}
+                {file.items.map((item, i) => (
+                  <tr key={item.id}>
+                    <td className="screen-items-no">{i + 1}</td>
+                    <td>
+                      <input
+                        className="form-control form-control-sm"
+                        value={item.name}
+                        onChange={(e) => handleUpdateItem(i, { name: e.target.value })}
+                        placeholder="email"
+                      />
+                    </td>
+                    <td>
+                      <input
+                        className="form-control form-control-sm"
+                        value={item.label}
+                        onChange={(e) => handleUpdateItem(i, { label: e.target.value })}
+                        placeholder="メールアドレス"
+                      />
+                    </td>
+                    <td>
+                      <input
+                        type="text"
+                        list="screen-items-type-list"
+                        className="form-control form-control-sm"
+                        value={typeof item.type === "string"
+                          ? item.type
+                          : item.type.kind === "custom"
+                            ? item.type.label ?? ""
+                            : ""}
+                        onChange={(e) => {
+                          const v = e.target.value;
+                          if (v === "") {
+                            handleUpdateItem(i, { type: "string" });
+                          } else if ((PRIMITIVE_TYPES as string[]).includes(v)) {
+                            handleUpdateItem(i, { type: v as FieldType });
+                          } else {
+                            handleUpdateItem(i, { type: { kind: "custom", label: v } });
+                          }
+                        }}
+                        placeholder="string"
+                      />
+                    </td>
+                    <td className="text-center">
+                      <input
+                        type="checkbox"
+                        className="form-check-input"
+                        checked={!!item.required}
+                        onChange={(e) => handleUpdateItem(i, { required: e.target.checked || undefined })}
+                        aria-label="必須"
+                      />
+                    </td>
+                    <td>
+                      <input
+                        type="number"
+                        className="form-control form-control-sm"
+                        value={item.minLength ?? ""}
+                        min={0}
+                        onChange={(e) => handleUpdateItem(i, { minLength: e.target.value === "" ? undefined : Number(e.target.value) })}
+                      />
+                    </td>
+                    <td>
+                      <input
+                        type="number"
+                        className="form-control form-control-sm"
+                        value={item.maxLength ?? ""}
+                        min={0}
+                        onChange={(e) => handleUpdateItem(i, { maxLength: e.target.value === "" ? undefined : Number(e.target.value) })}
+                      />
+                    </td>
+                    <td>
+                      <input
+                        className="form-control form-control-sm"
+                        value={item.pattern ?? ""}
+                        onChange={(e) => handleUpdateItem(i, { pattern: e.target.value || undefined })}
+                        placeholder="@conv.regex.email-simple"
+                      />
+                    </td>
+                    <td>
+                      <input
+                        className="form-control form-control-sm"
+                        value={item.description ?? ""}
+                        onChange={(e) => handleUpdateItem(i, { description: e.target.value || undefined })}
+                      />
+                    </td>
+                    <td className="text-center">
+                      <button
+                        type="button"
+                        className="btn btn-sm btn-link text-danger p-0"
+                        onClick={() => handleRemoveItem(i)}
+                        title="削除"
+                        aria-label="削除"
+                      >
+                        <i className="bi bi-x" />
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <button
+              type="button"
+              className="btn btn-sm btn-outline-primary screen-items-add"
+              onClick={handleAddItem}
+            >
+              <i className="bi bi-plus-lg me-1" /> 項目追加
+            </button>
+            <datalist id="screen-items-type-list">
+              {PRIMITIVE_TYPES.map((t) => <option key={t} value={t} />)}
+            </datalist>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/designer/src/mcp/mcpBridge.ts
+++ b/designer/src/mcp/mcpBridge.ts
@@ -49,6 +49,10 @@ import {
   setConventionsStorageBackend,
   type ConventionsStorageBackend,
 } from "../store/conventionsStore";
+import {
+  setScreenItemsStorageBackend,
+  type ScreenItemsStorageBackend,
+} from "../store/screenItemsStore";
 import { loadTable } from "../store/tableStore";
 
 export type McpStatus = "disconnected" | "connecting" | "connected";
@@ -284,6 +288,13 @@ class McpBridgeImpl {
       saveConventions: (catalog) => this.request("saveConventions", { catalog }).then(() => undefined),
     };
     setConventionsStorageBackend(conventionsBackend);
+
+    const screenItemsBackend: ScreenItemsStorageBackend = {
+      loadScreenItems: (screenId) => this.request("loadScreenItems", { screenId }),
+      saveScreenItems: (screenId, data) => this.request("saveScreenItems", { screenId, data }).then(() => undefined),
+      deleteScreenItems: (screenId) => this.request("deleteScreenItems", { screenId }).then(() => undefined),
+    };
+    setScreenItemsStorageBackend(screenItemsBackend);
   }
 
   /** 切断時: localStorage フォールバックに戻す */
@@ -294,6 +305,7 @@ class McpBridgeImpl {
     setErLayoutStorageBackend(null);
     setActionStorageBackend(null);
     setConventionsStorageBackend(null);
+    setScreenItemsStorageBackend(null);
   }
 
   // ── メッセージ受信 ─────────────────────────────────────────────────────

--- a/designer/src/store/screenItemsStore.ts
+++ b/designer/src/store/screenItemsStore.ts
@@ -1,0 +1,58 @@
+/**
+ * screenItemsStore.ts
+ * 画面項目定義の永続化ストア (#318 プロトタイプ)。
+ *
+ * 正本は `data/screen-items/{screenId}.json`。wsBridge 経由で読み書きし、
+ * ws 未接続時は localStorage にフォールバック。
+ */
+import { createEmptyScreenItems, type ScreenItemsFile } from "../types/screenItem";
+
+export interface ScreenItemsStorageBackend {
+  loadScreenItems(screenId: string): Promise<unknown>;
+  saveScreenItems(screenId: string, data: unknown): Promise<void>;
+  deleteScreenItems(screenId: string): Promise<void>;
+}
+
+let _backend: ScreenItemsStorageBackend | null = null;
+
+export function setScreenItemsStorageBackend(b: ScreenItemsStorageBackend | null): void {
+  _backend = b;
+}
+
+const LS_PREFIX = "screen-items-";
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+export async function loadScreenItems(screenId: string): Promise<ScreenItemsFile> {
+  if (_backend) {
+    const data = await _backend.loadScreenItems(screenId);
+    if (data) return data as ScreenItemsFile;
+  } else {
+    const raw = localStorage.getItem(`${LS_PREFIX}${screenId}`);
+    if (raw) {
+      try {
+        return JSON.parse(raw) as ScreenItemsFile;
+      } catch { /* ignore */ }
+    }
+  }
+  return createEmptyScreenItems(screenId);
+}
+
+export async function saveScreenItems(file: ScreenItemsFile): Promise<void> {
+  file.updatedAt = now();
+  if (_backend) {
+    await _backend.saveScreenItems(file.screenId, file);
+    return;
+  }
+  localStorage.setItem(`${LS_PREFIX}${file.screenId}`, JSON.stringify(file));
+}
+
+export async function deleteScreenItems(screenId: string): Promise<void> {
+  if (_backend) {
+    await _backend.deleteScreenItems(screenId);
+    return;
+  }
+  localStorage.removeItem(`${LS_PREFIX}${screenId}`);
+}

--- a/designer/src/store/tabStore.ts
+++ b/designer/src/store/tabStore.ts
@@ -15,12 +15,13 @@ export type TabType =
   | "er"                 // ER 図
   | "process-flow-list"  // 処理フロー一覧
   | "conventions-catalog" // 規約カタログ (#317)
+  | "screen-items"       // 画面項目定義 (#318 プロトタイプ)
   | "dashboard";         // ダッシュボード（#86 PR-3 で有効化）
 
 const KNOWN_TAB_TYPES: ReadonlySet<TabType> = new Set([
   "design", "table", "action",
   "screen-flow", "screen-list", "table-list", "er", "process-flow-list",
-  "conventions-catalog", "dashboard",
+  "conventions-catalog", "screen-items", "dashboard",
 ]);
 
 export interface TabItem {

--- a/designer/src/styles/screen-items.css
+++ b/designer/src/styles/screen-items.css
@@ -1,0 +1,114 @@
+/* 画面項目定義ビュー (#318 プロトタイプ) */
+
+.screen-items-view {
+  height: calc(100vh - var(--common-header-h, 0px) - var(--tabbar-h, 0px));
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: #f8f9fa;
+}
+
+.screen-items-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 14px;
+  background: #fff;
+  border-bottom: 1px solid #e2e8f0;
+  flex-wrap: wrap;
+}
+
+.screen-items-title {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: #334155;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.screen-items-screen-selector {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.screen-items-screen-selector select {
+  min-width: 14em;
+}
+
+.screen-items-actions {
+  margin-left: auto;
+}
+
+.screen-items-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 14px;
+}
+
+.screen-items-empty {
+  padding: 40px;
+  text-align: center;
+  color: #64748b;
+}
+
+.screen-items-table-wrap {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  padding: 8px;
+}
+
+.screen-items-table {
+  width: 100%;
+  table-layout: fixed;
+  border-collapse: collapse;
+}
+
+.screen-items-table thead th {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #64748b;
+  padding: 4px 6px;
+  border-bottom: 1px solid #cbd5e1;
+  text-align: left;
+}
+
+.screen-items-table tbody td {
+  padding: 3px 6px;
+  vertical-align: middle;
+  border-bottom: 1px solid #f1f5f9;
+}
+
+.screen-items-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.screen-items-table input.form-control {
+  width: 100%;
+  padding: 2px 6px;
+  font-size: 0.8rem;
+  min-width: 0;
+  min-height: 26px;
+  height: 28px;
+}
+
+.screen-items-no {
+  color: #94a3b8;
+  font-size: 0.75rem;
+  text-align: center;
+}
+
+.screen-items-empty-row {
+  color: #94a3b8;
+  padding: 12px;
+  text-align: center;
+  font-style: italic;
+  font-size: 0.85rem;
+}
+
+.screen-items-add {
+  margin-top: 8px;
+  font-size: 0.82rem;
+}

--- a/designer/src/types/screenItem.ts
+++ b/designer/src/types/screenItem.ts
@@ -1,0 +1,89 @@
+/**
+ * 画面項目定義 (#318 / docs/spec/screen-items.md v0.1 相当)。
+ *
+ * 画面 (GrapesJS) のフォーム要素に紐付けるバリデーション・ラベル・表示制御を
+ * 宣言的に保持する。処理フローの inputs から screenItemRef で参照される想定。
+ *
+ * ファイル配置: data/screen-items/{screenId}.json (1 画面 = 1 ファイル)
+ */
+import type { FieldType } from "./action";
+
+export interface ScreenItemSelectOption {
+  value: string;
+  label: string;
+}
+
+export interface ScreenItemErrorMessages {
+  required?: string;
+  minLength?: string;
+  maxLength?: string;
+  invalidFormat?: string;
+  outOfRange?: string;
+  [code: string]: string | undefined;
+}
+
+export interface ScreenItem {
+  /** 画面内ユニークな ID。GrapesJS の data-item-id と対応する想定 (将来の紐付け用) */
+  id: string;
+  /** 論理名 (実装コードでのフィールド名 / API 上のキー) */
+  name: string;
+  /** 日本語表示名 (ラベル・エラーメッセージ内の {label}) */
+  label: string;
+  /** 型 (処理フロー FieldType と共通、primitive + { kind: "custom", label }) */
+  type: FieldType;
+
+  // ─── フォーム制御 ─────────────────────────────────────────────────
+  required?: boolean;
+  readonly?: boolean;
+  disabled?: boolean;
+
+  // ─── 文字列系制約 ───────────────────────────────────────────────
+  minLength?: number;
+  maxLength?: number;
+  /** 正規表現。@conv.regex.* 参照も直接パターンも可 */
+  pattern?: string;
+
+  // ─── 数値系制約 ─────────────────────────────────────────────────
+  min?: number;
+  max?: number;
+  step?: number;
+
+  // ─── 選択系 ─────────────────────────────────────────────────────
+  options?: ScreenItemSelectOption[];
+
+  // ─── 規定値・プレースホルダ・ヘルプ ─────────────────────────────
+  defaultValue?: string | number | boolean;
+  placeholder?: string;
+  helperText?: string;
+
+  // ─── エラーメッセージ (規約参照推奨) ───────────────────────────
+  errorMessages?: ScreenItemErrorMessages;
+
+  // ─── 表示制御 (式言語、process-flow-expression-language.md) ─
+  visibleWhen?: string;
+  enabledWhen?: string;
+
+  // ─── 備考 ──────────────────────────────────────────────────────
+  description?: string;
+}
+
+export interface ScreenItemsFile {
+  $schema?: string;
+  /** 紐付く画面 ID */
+  screenId: string;
+  /** SemVer */
+  version: string;
+  /** ISO 8601 */
+  updatedAt: string;
+  items: ScreenItem[];
+}
+
+/** 画面項目定義ファイルの初期状態 */
+export function createEmptyScreenItems(screenId: string): ScreenItemsFile {
+  return {
+    screenId,
+    version: "0.1.0",
+    updatedAt: new Date().toISOString(),
+    items: [],
+  };
+}

--- a/designer/src/utils/serverMtime.ts
+++ b/designer/src/utils/serverMtime.ts
@@ -7,7 +7,7 @@
  */
 import { mcpBridge } from "../mcp/mcpBridge";
 
-export type MtimeKind = "project" | "screen" | "table" | "actionGroup" | "erLayout" | "customBlocks" | "conventions";
+export type MtimeKind = "project" | "screen" | "table" | "actionGroup" | "erLayout" | "customBlocks" | "conventions" | "screenItems";
 
 const LAST_SEEN_PREFIX = "mtime-";
 

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -12,6 +12,7 @@
 | [process-flow-extensions.md](process-flow-extensions.md) | HTTP 契約 / TX / Saga / 外部 outcomes / ValidationRule / compute / return (Phase B) | #151 / #182 |
 | [process-flow-expression-language.md](process-flow-expression-language.md) | runIf / expression / bodyExpression の式言語 BNF (js-subset) | #253 |
 | [process-flow-runtime-conventions.md](process-flow-runtime-conventions.md) | SQL 式補間 / HTTP body シリアライズ / TX×throw×tryCatch / fireAndForget / sideEffects TX 境界等の実行時規約 | #261 |
+| [screen-items.md](screen-items.md) | 画面項目定義 (フォーム系バリデーション 3 層のうち「画面」層) — **ドラフト v0.1** | #318 |
 
 **一次成果物**: JSON スキーマ [`schemas/process-flow.schema.json`](../../schemas/process-flow.schema.json) ([README](../../schemas/README.md))。仕様書と突合する機械可読版。
 

--- a/docs/spec/screen-items.md
+++ b/docs/spec/screen-items.md
@@ -1,0 +1,225 @@
+# 画面項目定義 (Screen Items)
+
+**ステータス**: ドラフト v0.1 (仕様策定中)
+**策定開始**: 2026-04-22
+**関連 issue**: #318
+
+本書は画面項目定義 (画面 UI のフォーム項目に宣言的にバリデーション・ラベル・表示制御を紐付ける設計書) の仕様を定める。
+
+## 位置づけ
+
+バリデーションは 3 層構造 (#315 / #317 を経て確定):
+
+| 層 | 担当 | 実装ステータス |
+|---|---|---|
+| **画面項目定義** (本書) | フォーム UI 関心事: 必須 / 長さ / フォーマット / エラーメッセージ | 未実装 (本書で策定) |
+| **処理フロー** | 業務ロジック検証 (一意性 / 存在性 / 状態遷移) | 実装済 (#261 で 5/5 到達) |
+| **横断規約** | 正規表現 / メッセージ / 制限値の再利用ライブラリ | 実装済 (#317 で UI 編集化) |
+
+**境界のガイドライン**:
+- フィールド単体で完結する制約 → 画面項目定義 (例: `required` / `maxLength` / `pattern`)
+- 他フィールド・他レコードを跨ぐ検証 → 処理フロー (例: `unique(users, email)` / `stateTransition(from, to)`)
+- 再利用可能な定数・テンプレート → 規約カタログ (例: `@conv.regex.phone-jp`)
+
+## 論点と提案
+
+以下 5 つの論点について叩き台の提案を示す。ユーザーレビューで合意後、v1.0 として凍結する。
+
+---
+
+### (A) データモデル
+
+#### (A-1) ファイル配置: 画面ごとに独立 or 画面ファイル同梱
+
+**案 A-1a 独立ファイル (推奨)**: `data/screen-items/{screenId}.json` を別ファイルに
+- ✅ 画面デザインと粒度を揃えて CRUD しやすい
+- ✅ 既存の `data/screens/{id}.json` (GrapesJS 生データ) は触らず追加だけで済む
+- ✅ wsBridge で `loadScreenItems` / `saveScreenItems` ハンドラを対称に追加できる
+
+**案 A-1b 画面同梱**: `data/screens/{id}.json` に `items[]` を追加
+- 1 ファイルで完結するがファイルが肥大 + GrapesJS 生データとの責務混在
+- ❌ 不採用
+
+→ **(A-1a) 独立ファイル案**
+
+#### (A-2) 項目 1 件のスキーマ
+
+```typescript
+interface ScreenItem {
+  /** 項目 ID (画面内ユニーク、GrapesJS ブロック data-item-id と対応) */
+  id: string;
+  /** 論理名 (実装コードのフィールド名に使われる) */
+  name: string;
+  /** 日本語表示名 (ラベル、エラーメッセージの {label} に使われる) */
+  label: string;
+  /** 型 (処理フロー FieldType と同一、datalist + 自由入力) */
+  type: FieldType;  // "string" | "number" | "boolean" | "date" | { kind: "custom", label: string }
+  /** フォーム制御 */
+  required?: boolean;
+  readonly?: boolean;
+  disabled?: boolean;
+  /** 文字列系制約 */
+  minLength?: number;
+  maxLength?: number;
+  /** 正規表現 (規約参照 @conv.regex.* または直接パターン) */
+  pattern?: string;
+  /** 数値系制約 */
+  min?: number;
+  max?: number;
+  step?: number;
+  /** 選択系 */
+  options?: Array<{ value: string; label: string }>;
+  /** 規定値・プレースホルダ・ヘルプ */
+  defaultValue?: string | number | boolean;
+  placeholder?: string;
+  helperText?: string;
+  /** エラーメッセージ (規約参照推奨) */
+  errorMessages?: {
+    required?: string;       // "@conv.msg.required" 推奨
+    maxLength?: string;      // "@conv.msg.maxLength"
+    invalidFormat?: string;  // "@conv.msg.invalidFormat"
+    outOfRange?: string;     // "@conv.msg.outOfRange"
+    [code: string]: string | undefined;
+  };
+  /** 表示制御 (式言語、docs/spec/process-flow-expression-language.md と共有) */
+  visibleWhen?: string;
+  enabledWhen?: string;
+  /** 備考 */
+  description?: string;
+}
+
+interface ScreenItemsFile {
+  $schema?: string;
+  screenId: string;
+  version: string;  // SemVer
+  updatedAt: string;
+  items: ScreenItem[];
+}
+```
+
+**要決定**:
+- \[ \] `ScreenItem.id` と `name` を分離するか統合するか → **分離案** (GrapesJS ブロックと API フィールド名が乖離する可能性)
+- \[ \] `options` のようなマスタ依存項目をどう扱うか (静的リストか、テーブル参照か) → **MVP は静的、後続でテーブル参照サポート**
+
+---
+
+### (B) 処理フローとの関係
+
+処理フローの `inputs: StructuredField[]` と画面項目定義は重複する可能性がある。どう整合するか。
+
+**案 B-1 処理フロー inputs が画面項目を参照 (推奨)**:
+```json
+{
+  "action": {
+    "name": "登録",
+    "inputs": [
+      { "name": "email", "screenItemRef": "screen-login/email" }
+    ]
+  }
+}
+```
+- 画面項目定義が正本、処理フロー側は参照のみ
+- 画面項目で `required` / `maxLength` が定義されていれば処理フロー側は再宣言不要
+- ✅ 二重管理を避けられる
+
+**案 B-2 処理フロー inputs が画面項目と独立**: 従来通り
+- シンプルだが drift 発生
+
+→ **(B-1) 参照方式**
+
+**要決定**:
+- \[ \] 処理フロー inputs の従来 `required` / `description` 等との共存方法 (参照優先 / 上書き可 等)
+- \[ \] 画面なしフロー (batch / scheduled) での `screenItemRef` 無しケースの扱い
+
+---
+
+### (C) 規約カタログ連携
+
+画面項目定義から `@conv.regex.*` / `@conv.msg.*` / `@conv.limit.*` を参照可能にする。
+
+- `pattern`: 直接パターン or `@conv.regex.phone-jp` 参照
+- `errorMessages.required`: `@conv.msg.required` 参照 (既定)
+- `maxLength`: 直接数値 or `@conv.limit.nameMax` 参照
+
+→ **#317 で追加した規約カタログを UI の datalist で補完**。画面項目エディタ側で `@conv.` typing 時に候補表示。これは画面項目編集 UI (別 issue) のタスク。
+
+---
+
+### (D) フレームワーク中立 → 実装展開
+
+画面項目定義は**抽象的制約**のみ記述し、具象フレームワークコードには触れない。実装時に AI (Claude Code) が `docs/conventions/product-scope.md` のターゲットスタック宣言を読んで展開する。
+
+| ターゲット | 展開例 (`required + maxLength: 100`) |
+|---|---|
+| SpringBoot (Bean Validation) | `@NotBlank @Size(max = 100)` アノテーション |
+| React Hook Form + Zod | `z.string().min(1).max(100)` |
+| Next.js Server Action | action 関数内で Zod validate → `{errors: {...}}` 返却 |
+
+**要決定**:
+- \[ \] `product-scope.md` に stack 宣言セクション (JSON 化 or markdown 構造化) を追加するか → **本 issue 範囲外、別 issue で**
+
+---
+
+### (E) 画面デザイナーとの UX 統合
+
+#### (E-1) 編集画面の位置
+
+**案 E-1a 独立タブ (推奨)**: `/screen/items/:screenId` で専用タブ
+- 画面デザイナー (GrapesJS) とは別の一覧ビューで、1 項目 1 行テーブル形式 (規約カタログ UI と類似)
+- GrapesJS 側で選択した要素の `data-item-id` が自動でハイライト / ジャンプ
+- ✅ 一覧操作 (ソート / 一括編集) がしやすい
+- ✅ 既存の singleton/per-resource タブ運用と整合
+
+**案 E-1b インライン編集**: GrapesJS サイドバーで要素選択時に項目定義を出す
+- 文脈的にはクリアだが、一覧操作がしにくい
+- E-1a と両立可能 (後続で追加)
+
+→ **MVP は (E-1a) 独立タブ、後続で (E-1b) も追加**
+
+#### (E-2) GrapesJS ブロックとの紐付け
+
+- GrapesJS の `input` / `select` / `textarea` ブロックに **`data-item-id` 属性**を自動付与
+- 画面項目定義側で `id` を指定すると、GrapesJS 側でその属性を持つ要素がフィールドとして認識
+- 新規ブロック追加時は `data-item-id` を自動発番 (`generateUUID()`)
+
+#### (E-3) 既存画面からの移行
+
+既存の `data/screens/{id}.json` には `data-item-id` が無い。migration:
+- 画面を初めて編集するときに、既存ブロックから `name="email"` 等の属性を拾って自動で項目エントリを生成する提案 UI を出す
+- ユーザーがラベルや required を埋めれば項目化完了
+
+→ **migration は MVP で「空リストから手動追加」のみ、自動抽出は後続 issue**
+
+---
+
+## 実装の段階分割 (v1.0 確定後の後続 issue 候補)
+
+1. **画面項目スキーマ + ストレージ + Backend** (projectStorage / wsBridge / Store)
+2. **画面項目エディタ UI** (ScreenItemsView、ルーティング、HeaderMenu 配線)
+3. **処理フロー inputs から screenItemRef 参照対応**
+4. **GrapesJS ブロックとの `data-item-id` 紐付け + 選択連動**
+5. **既存画面からの自動項目抽出 migration**
+6. **実装コード生成 (Claude Code による Bean Validation / Zod 展開)**
+
+MVP は 1-2-3 まで。4-5-6 は段階的に。
+
+---
+
+## 対象外 (本 spec v1.0 の範囲外)
+
+- 動的依存 (フィールド A の値に応じて B の required が変わる 等) は `visibleWhen` / `enabledWhen` 式で最低限対応。より高度な依存ロジック表現は将来
+- 多言語化 (`label` の i18n) は将来
+- カスタムバリデータ (任意の JS 式) は処理フロー側で
+- マスタ連動 (`options` がテーブル参照) は後続 issue
+
+---
+
+## レビュー観点
+
+この v0.1 ドラフトで特に確認してほしい点:
+
+1. **論点 (A) の ScreenItem スキーマは十分か** — 不足フィールド / 過剰フィールドがないか
+2. **論点 (B) の screenItemRef 方式は妥当か** — 処理フロー側の既存 `inputs` との整合
+3. **論点 (C) の規約参照は自然か** — `@conv.*` を画面項目から参照する UX
+4. **論点 (E-1) 独立タブ案で問題ないか** — GrapesJS サイドバーでのインライン編集は MVP から外してよいか
+5. **命名 "画面項目定義" / "screen-items" / "ScreenItem"** — 用語の妥当性


### PR DESCRIPTION
## 関連

- Closes #318 (プロトタイプ触って v1.0 確定後にクローズ)
- base: \`main\`

## 概要

画面項目定義 (バリデーション 3 層構造のうち「画面」層) を **仕様 v0.1 ドラフト + 動作するプロトタイプ実装** でセット提供する。ユーザーがドキュメント読むだけでなく実際に触って判断できるようにした。

## 内容

### 1. 仕様ドラフト
- [\`docs/spec/screen-items.md\`](docs/spec/screen-items.md) v0.1 — 論点 (A) データモデル / (B) 処理フロー関係 / (C) 規約連携 / (D) フレームワーク中立 / (E) 画面デザイナー統合 に推奨案

### 2. 動作プロトタイプ (MVP 実装)
- [\`types/screenItem.ts\`](designer/src/types/screenItem.ts): \`ScreenItem\` / \`ScreenItemsFile\` 型 (spec v0.1 A-2)
- Backend: [\`projectStorage.ts\`](designer-mcp/src/projectStorage.ts) / [\`wsBridge.ts\`](designer-mcp/src/wsBridge.ts) で \`data/screen-items/{screenId}.json\` を read/write/delete
- Store: [\`screenItemsStore.ts\`](designer/src/store/screenItemsStore.ts) (backend 優先 + localStorage フォールバック)
- Bridge: [\`mcpBridge.ts\`](designer/src/mcp/mcpBridge.ts) に \`screenItemsBackend\` 配線、\`screenItemsChanged\` ブロードキャスト
- TabType: \`"screen-items"\` / MtimeKind: \`"screenItems"\` 追加
- UI: [\`ScreenItemsView.tsx\`](designer/src/components/screen-items/ScreenItemsView.tsx) — シングルトンタブで画面セレクタ + 1 項目 1 行テーブル (name/label/type/必須/min-maxLength/pattern/description)
- HeaderMenu「画面項目定義 (ドラフト)」エントリ + AppShell singleton route \`/screen-items\`

### 3. E2E
- [\`screen-items.spec.ts\`](designer/e2e/screen-items.spec.ts) 4 件: 画面セレクタ反映 / 項目追加 + 保存 / 画面切替でリストリセット / 削除

## v0.1 → v1.0 決定待ちの論点

触った上で確認してほしい:

1. **(A-2) \`ScreenItem\` スキーマ** — 不足フィールド / 過剰フィールドなしか
2. **(A-1) ファイル配置** — 独立ファイル (\`data/screen-items/{screenId}.json\`) で良いか
3. **(B) 処理フロー関係** — 今回未実装。\`screenItemRef\` で参照する方向で良いか
4. **(C) 規約カタログ参照** — 今回は \`pattern\` フィールドに \`@conv.regex.*\` を自由記述できるだけ。datalist 補完は後続
5. **(E-1) シングルトン vs per-screen** — 今回 MVP はシングルトン + 画面セレクタ内蔵。将来 per-screen (\`/screen/items/:screenId\`) に分割するか、シングルトンのままで良いか
6. **命名** — 「画面項目定義 (ドラフト)」/ \`/screen-items\` / \`ScreenItem\` で違和感ないか

## MVP 対象外 (v1.0 確定後)

- 処理フロー \`inputs\` → \`screenItemRef\` 参照
- GrapesJS ブロックの \`data-item-id\` 紐付け (選択連動)
- 既存画面からの自動項目抽出 migration
- 実装コード生成 (SpringBoot \`@NotBlank\` / Zod \`z.string().min()\` 等への展開)
- per-screen タブ分割

## テスト

- Vitest: 496 件 (frontend) + 37 件 (backend) pass
- Playwright: screen-items 新規 4 件 pass、conventions-catalog / marker-panel / save-reset-action 既存 22 件 regression pass
- \`vite build\` 成功

## UI 影響 / マージ保留フラグ

- [x] **UI 影響あり (マージ前にユーザー目視確認必須)**

### 確認項目 (触ってみてください)

- [ ] HeaderMenu → 「画面項目定義 (ドラフト)」で開ける
- [ ] 画面セレクタに既存プロジェクトの画面一覧が並ぶ
- [ ] 画面を切り替えると項目リストがリセットされる
- [ ] 「項目追加」で新規行が追加される
- [ ] name / label / type / 必須 / minLength / maxLength / pattern / description が編集できる
- [ ] 型欄に datalist (string/number/boolean/date 候補) が出つつ任意文字列 (\`Order\` / \`User\` 等) も入力可
- [ ] 保存ボタンで \`data/screen-items/{screenId}.json\` が更新される
- [ ] リロードしても保存した項目が復元される
- [ ] 上記触ってみて、spec v0.1 の論点に修正提案があれば PR コメントで

## spec 側の不足点 / 提案

触った上で spec v0.1 に不足・違和感があればご指摘ください。v1.0 確定後、対象外項目の実装 issue を段階分割で起票します。

## レビュー担当への申し送り

- **動作プロトタイプ PR** なので、マージ可否は「触ってみて方向性が良ければ v0.1 を確定、ダメなら別案で v0.2」の判断
- シングルトンタブ方式を採用した都合、画面ごとに dirty 状態を分離していない (画面切替時に未保存変更があれば上書きされる恐れ)。MVP の妥協点
- \`useResourceEditor\` を使わず独自の \`isDirty\` / \`isSaving\` state にしたのは MVP 簡略化のため。v1.0 → 実装成熟化時に統一する