### PR TITLE
feat(process-flow): 処理フロー inputs から画面項目を参照 (#321)

### DIFF
--- a/designer/src/components/action/ActionEditor.tsx
+++ b/designer/src/components/action/ActionEditor.tsx
@@ -57,7 +57,8 @@ import { MaturityBadge } from "./MaturityBadge";
 import { ActionHttpContractPanel } from "./ActionHttpContractPanel";
 import { ActionMetaTabBar } from "./ActionMetaTabBar";
 import { DrawingOverlay } from "./DrawingOverlay";
-import { StructuredFieldsEditor } from "./StructuredFieldsEditor";
+import { StructuredFieldsEditor, type ScreenItemPickResult } from "./StructuredFieldsEditor";
+import { ScreenItemPickerModal } from "./ScreenItemPickerModal";
 import { EditorHeader } from "../common/EditorHeader";
 import { ServerChangeBanner } from "../common/ServerChangeBanner";
 import "../../styles/action.css";
@@ -123,6 +124,9 @@ export function ActionEditor() {
   const navigate = useNavigate();
   const [activeActionId, setActiveActionId] = useState<string | null>(null);
   const [showAddAction, setShowAddAction] = useState(false);
+  // 画面項目ピッカー (#321) — Promise ベース: StructuredFieldsEditor に onPickScreenItem を渡す
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const pickerResolveRef = useRef<((r: ScreenItemPickResult | null) => void) | null>(null);
   const [newActionName, setNewActionName] = useState("");
   const [newActionTrigger, setNewActionTrigger] = useState<ActionTrigger>("click");
   const [tables, setTables] = useState<{ id: string; name: string; logicalName: string }[]>([]);
@@ -481,6 +485,14 @@ export function ActionEditor() {
     enabled: selectedIds.size > 0 || clipboard !== null,
   });
 
+  // 画面項目ピッカーのコールバック (#321) — hooks は early return より前で定義
+  const handlePickScreenItem = useCallback((): Promise<ScreenItemPickResult | null> => {
+    return new Promise((resolve) => {
+      pickerResolveRef.current = resolve;
+      setPickerOpen(true);
+    });
+  }, []);
+
   if (!group) return null;
 
   const handleCommitStrokes = (shape: {
@@ -525,6 +537,18 @@ export function ActionEditor() {
 
   const handleExitDrawing = () => {
     setDrawingMode(false);
+  };
+
+  const handlePickerPick = (result: ScreenItemPickResult) => {
+    pickerResolveRef.current?.(result);
+    pickerResolveRef.current = null;
+    setPickerOpen(false);
+  };
+
+  const handlePickerClose = () => {
+    pickerResolveRef.current?.(null);
+    pickerResolveRef.current = null;
+    setPickerOpen(false);
   };
 
   return (
@@ -754,6 +778,7 @@ export function ActionEditor() {
                   }}
                   onCommit={commitGroup}
                   placeholder="例: ユーザID、パスワード（改行で複数項目）"
+                  onPickScreenItem={handlePickScreenItem}
                 />
               </div>
               <div className="action-io-field">
@@ -768,6 +793,7 @@ export function ActionEditor() {
                   }}
                   onCommit={commitGroup}
                   placeholder="例: セッションID、認証トークン（改行で複数項目）"
+                  onPickScreenItem={handlePickScreenItem}
                 />
               </div>
             </div>
@@ -998,6 +1024,12 @@ export function ActionEditor() {
         onCommitStrokes={handleCommitStrokes}
         onEraseMarker={handleEraseMarker}
         onExitDrawing={handleExitDrawing}
+      />
+      {/* 画面項目ピッカー (#321) */}
+      <ScreenItemPickerModal
+        open={pickerOpen}
+        onClose={handlePickerClose}
+        onPick={handlePickerPick}
       />
     </div>
   );

--- a/designer/src/components/action/ScreenItemPickerModal.tsx
+++ b/designer/src/components/action/ScreenItemPickerModal.tsx
@@ -1,0 +1,116 @@
+/**
+ * 画面項目ピッカーモーダル (#321)。
+ *
+ * 処理フローの入出力テーブルから「画面項目から追加」を押したときに開く。
+ * 画面 (左) と項目 (右) を選ばせ、選択された ScreenItem から派生した値
+ * (name / label / type / required / description) を StructuredFieldsEditor に返す。
+ */
+import { useEffect, useState } from "react";
+import { loadProject } from "../../store/flowStore";
+import { loadScreenItems } from "../../store/screenItemsStore";
+import type { ScreenItem, ScreenItemsFile } from "../../types/screenItem";
+import type { ScreenItemPickResult } from "./StructuredFieldsEditor";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onPick: (result: ScreenItemPickResult) => void;
+}
+
+type ScreenMeta = { id: string; name: string };
+
+export function ScreenItemPickerModal({ open, onClose, onPick }: Props) {
+  const [screens, setScreens] = useState<ScreenMeta[]>([]);
+  const [selectedScreenId, setSelectedScreenId] = useState<string | null>(null);
+  const [itemsFile, setItemsFile] = useState<ScreenItemsFile | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    loadProject().then((p) => {
+      setScreens(p.screens.map((s) => ({ id: s.id, name: s.name })));
+    }).catch(console.error);
+  }, [open]);
+
+  useEffect(() => {
+    if (!selectedScreenId) { setItemsFile(null); return; }
+    loadScreenItems(selectedScreenId).then(setItemsFile).catch(console.error);
+  }, [selectedScreenId]);
+
+  if (!open) return null;
+
+  const handlePick = (item: ScreenItem) => {
+    if (!selectedScreenId) return;
+    onPick({
+      screenId: selectedScreenId,
+      itemId: item.id,
+      name: item.name || item.id,
+      label: item.label || undefined,
+      type: item.type,
+      required: item.required || undefined,
+      description: item.description || undefined,
+    });
+    onClose();
+  };
+
+  return (
+    <div className="screen-item-picker-overlay" onClick={onClose}>
+      <div className="screen-item-picker" onClick={(e) => e.stopPropagation()}>
+        <div className="screen-item-picker-header">
+          <h6 className="mb-0">
+            <i className="bi bi-ui-checks-grid me-1" />画面項目から追加
+          </h6>
+          <button type="button" className="btn btn-sm btn-link" onClick={onClose} aria-label="閉じる">
+            <i className="bi bi-x-lg" />
+          </button>
+        </div>
+        <div className="screen-item-picker-body">
+          <div className="screen-item-picker-screens">
+            <div className="small fw-semibold text-muted mb-1">画面</div>
+            {screens.length === 0 && (
+              <div className="small text-muted">画面が登録されていません</div>
+            )}
+            {screens.map((s) => (
+              <button
+                key={s.id}
+                type="button"
+                className={`screen-item-picker-screen-row ${selectedScreenId === s.id ? "active" : ""}`}
+                onClick={() => setSelectedScreenId(s.id)}
+              >
+                {s.name}
+              </button>
+            ))}
+          </div>
+          <div className="screen-item-picker-items">
+            <div className="small fw-semibold text-muted mb-1">項目</div>
+            {!selectedScreenId && <div className="small text-muted">左から画面を選択してください</div>}
+            {selectedScreenId && itemsFile && itemsFile.items.length === 0 && (
+              <div className="small text-muted">この画面に項目がありません。「画面項目定義」タブで追加してください。</div>
+            )}
+            {selectedScreenId && itemsFile?.items.map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                className="screen-item-picker-item-row"
+                onClick={() => handlePick(item)}
+              >
+                <div className="screen-item-picker-item-name">{item.name || <span className="text-muted">(名前未設定)</span>}</div>
+                <div className="screen-item-picker-item-meta">
+                  {item.label && <span className="me-2">{item.label}</span>}
+                  <span className="text-muted">
+                    {typeof item.type === "string" ? item.type : item.type.kind === "custom" ? item.type.label : "?"}
+                  </span>
+                  {item.required && <span className="badge bg-danger ms-2" style={{ fontSize: "0.65rem" }}>必須</span>}
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="screen-item-picker-footer">
+          <button type="button" className="btn btn-sm btn-outline-secondary" onClick={onClose}>
+            キャンセル
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/designer/src/components/action/StructuredFieldsEditor.tsx
+++ b/designer/src/components/action/StructuredFieldsEditor.tsx
@@ -2,12 +2,29 @@ import { useState } from "react";
 import type { ActionFields, FieldType, StructuredField } from "../../types/action";
 import { fieldsToText, isStructuredFields, textToStructuredFields } from "../../utils/actionFields";
 
+/** 画面項目ピッカーで返る型 — StructuredField にコピー元の値を載せて返す */
+export interface ScreenItemPickResult {
+  screenId: string;
+  itemId: string;
+  /** ScreenItem から派生した StructuredField フィールド値 */
+  name: string;
+  label?: string;
+  type: FieldType;
+  required?: boolean;
+  description?: string;
+}
+
 interface Props {
   label: string;
   fields: ActionFields | undefined;
   onChange: (fields: ActionFields | undefined) => void;
   onCommit?: () => void;
   placeholder?: string;
+  /**
+   * 「画面項目から追加」ボタンから呼ばれるピッカー (#321)。親 (ActionEditor) が
+   * モーダルを開いてユーザー選択を返す。undefined ならボタン非表示。
+   */
+  onPickScreenItem?: () => Promise<ScreenItemPickResult | null>;
 }
 
 const PRIMITIVE_TYPES: Array<"string" | "number" | "boolean" | "date"> = ["string", "number", "boolean", "date"];
@@ -18,7 +35,7 @@ const PRIMITIVE_TYPES: Array<"string" | "number" | "boolean" | "date"> = ["strin
  * 表形式では 1 項目 1 行の <table> で name / label / type / required / description を編集。
  * FieldType は primitive + custom のみ対応、tableRow/tableList/screenInput は将来。
  */
-export function StructuredFieldsEditor({ label, fields, onChange, onCommit, placeholder }: Props) {
+export function StructuredFieldsEditor({ label, fields, onChange, onCommit, placeholder, onPickScreenItem }: Props) {
   const isStructured = isStructuredFields(fields);
   const [mode, setMode] = useState<"text" | "table">(isStructured ? "table" : "text");
 
@@ -41,6 +58,36 @@ export function StructuredFieldsEditor({ label, fields, onChange, onCommit, plac
     const curr = isStructured ? fields : [];
     const newField: StructuredField = { name: "", type: "string" };
     onChange([...curr, newField]);
+  };
+
+  /** 画面項目ピッカー経由で新規フィールド追加 (#321) */
+  const addFieldFromScreenItem = async () => {
+    if (!onPickScreenItem) return;
+    const result = await onPickScreenItem();
+    if (!result) return;
+    const curr = isStructured ? fields : [];
+    const newField: StructuredField = {
+      name: result.name,
+      label: result.label,
+      type: result.type,
+      required: result.required,
+      description: result.description,
+      screenItemRef: { screenId: result.screenId, itemId: result.itemId },
+    };
+    onChange([...curr, newField]);
+    onCommit?.();
+  };
+
+  /** 既存フィールドの screenItemRef を解除 (フィールド自体は残す) */
+  const unlinkScreenItem = (idx: number) => {
+    if (!isStructured) return;
+    const next = fields.map((f, i) => {
+      if (i !== idx) return f;
+      const { screenItemRef, ...rest } = f;
+      return rest as StructuredField;
+    });
+    onChange(next);
+    onCommit?.();
   };
 
   const updateField = (idx: number, patch: Partial<StructuredField>) => {
@@ -118,8 +165,16 @@ export function StructuredFieldsEditor({ label, fields, onChange, onCommit, plac
                 </tr>
               )}
               {isStructured && fields.map((f, i) => (
-                <tr key={i}>
-                  <td className="structured-fields-no">{i + 1}</td>
+                <tr key={i} className={f.screenItemRef ? "structured-fields-linked-row" : undefined}>
+                  <td className="structured-fields-no">
+                    {i + 1}
+                    {f.screenItemRef && (
+                      <i
+                        className="bi bi-link-45deg structured-fields-link-badge"
+                        title={`画面項目参照中: ${f.screenItemRef.screenId} / ${f.screenItemRef.itemId}`}
+                      />
+                    )}
+                  </td>
                   <td>
                     <input
                       type="text"
@@ -188,6 +243,17 @@ export function StructuredFieldsEditor({ label, fields, onChange, onCommit, plac
                     />
                   </td>
                   <td className="text-center">
+                    {f.screenItemRef && (
+                      <button
+                        type="button"
+                        className="btn btn-sm btn-link p-0 me-1 structured-fields-unlink"
+                        onClick={() => unlinkScreenItem(i)}
+                        title="画面項目参照を解除 (フィールド自体は残す)"
+                        aria-label="参照解除"
+                      >
+                        <i className="bi bi-link-45deg" style={{ textDecoration: "line-through" }} />
+                      </button>
+                    )}
                     <button
                       type="button"
                       className="btn btn-sm btn-link text-danger p-0 structured-fields-delete"
@@ -209,6 +275,16 @@ export function StructuredFieldsEditor({ label, fields, onChange, onCommit, plac
           >
             <i className="bi bi-plus-lg" /> フィールド追加
           </button>
+          {onPickScreenItem && (
+            <button
+              type="button"
+              className="btn btn-sm btn-outline-primary structured-fields-add ms-2"
+              onClick={addFieldFromScreenItem}
+              title="画面項目定義から選択して追加 (#321)"
+            >
+              <i className="bi bi-ui-checks-grid me-1" /> 画面項目から追加
+            </button>
+          )}
           {/* 型入力の候補 (primitive のみ提示、自由入力も可) — 全 row 共有 */}
           <datalist id="structured-fields-type-list">
             {PRIMITIVE_TYPES.map((t) => <option key={t} value={t} />)}

--- a/designer/src/styles/action.css
+++ b/designer/src/styles/action.css
@@ -702,6 +702,114 @@
   margin-bottom: 8px;
 }
 
+/* ─── 画面項目ピッカー (#321) ───────────────────────────────────── */
+
+.screen-item-picker-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+.screen-item-picker {
+  background: #fff;
+  border-radius: 8px;
+  padding: 0;
+  width: 90%;
+  max-width: 720px;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15);
+}
+.screen-item-picker-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  border-bottom: 1px solid #e2e8f0;
+}
+.screen-item-picker-body {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 16em 1fr;
+  gap: 8px;
+  padding: 10px 14px;
+  overflow: auto;
+}
+.screen-item-picker-screens,
+.screen-item-picker-items {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  overflow-y: auto;
+  max-height: 60vh;
+}
+.screen-item-picker-screen-row {
+  text-align: left;
+  padding: 5px 10px;
+  font-size: 0.85rem;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.screen-item-picker-screen-row:hover {
+  background: #e2e8f0;
+}
+.screen-item-picker-screen-row.active {
+  background: #dbeafe;
+  border-color: #60a5fa;
+  color: #1e40af;
+  font-weight: 600;
+}
+.screen-item-picker-item-row {
+  text-align: left;
+  padding: 6px 10px;
+  font-size: 0.85rem;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: border-color 0.1s;
+}
+.screen-item-picker-item-row:hover {
+  border-color: #6366f1;
+  background: #eef2ff;
+}
+.screen-item-picker-item-name {
+  font-weight: 600;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.82rem;
+}
+.screen-item-picker-item-meta {
+  font-size: 0.75rem;
+  color: #64748b;
+  margin-top: 2px;
+}
+.screen-item-picker-footer {
+  padding: 8px 14px;
+  border-top: 1px solid #e2e8f0;
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+/* StructuredFieldsEditor の画面項目参照行装飾 (#321) */
+.structured-fields-linked-row {
+  background: #eef6ff;
+}
+.structured-fields-link-badge {
+  color: #2563eb;
+  margin-left: 3px;
+  font-size: 0.8rem;
+}
+.structured-fields-unlink {
+  color: #dc2626;
+}
+
 /* ─── モーダル ────────────────────────────────────────────────────── */
 
 .action-modal-overlay {

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -736,6 +736,13 @@ export interface StructuredField {
   description?: string;
   /** 自由記述の既定値 */
   defaultValue?: string;
+  /**
+   * 画面項目定義への参照 (#321)。
+   * 設定時は対応する ScreenItem から name/label/type/required/pattern/maxLength 等を上書き解釈する。
+   * 処理フロー側で上書きしたいフィールド (description 等) は本オブジェクトの同名プロパティが優先。
+   * 参照先が存在しない場合は UNKNOWN_SCREEN_ITEM 警告 (参照整合性バリデータ)。
+   */
+  screenItemRef?: { screenId: string; itemId: string };
 }
 
 /** inputs / outputs の値型: 旧形式 (改行区切り文字列) と新形式 (StructuredField[]) の union */

--- a/docs/spec/screen-items.md
+++ b/docs/spec/screen-items.md
@@ -103,9 +103,18 @@ interface ScreenItemsFile {
 
 ---
 
-### (B) 処理フローとの関係
+### (B) 処理フローとの関係 — **#321 で実装着手**
 
 処理フローの `inputs: StructuredField[]` と画面項目定義は重複する可能性がある。どう整合するか。
+
+**✅ 採用: 案 B-1 処理フロー inputs が画面項目を参照** (PR #321 で実装):
+- `StructuredField.screenItemRef?: { screenId: string; itemId: string }` を追加
+- ActionEditor の入出力テーブルに「画面項目から追加」ボタン + `ScreenItemPickerModal`
+- 参照時は ScreenItem から name/label/type/required/description を一回コピー (一方向)
+- 参照解除ボタンで `screenItemRef` のみ削除、フィールドは残る
+- **TODO (別 issue)**: 参照整合性バリデータ (UNKNOWN_SCREEN_ITEM)、参照後の画面項目更新を自動反映する双方向同期
+
+(以降の代替案は履歴として残す)
 
 **案 B-1 処理フロー inputs が画面項目を参照 (推奨)**:
 ```json

--- a/schemas/process-flow.schema.json
+++ b/schemas/process-flow.schema.json
@@ -274,7 +274,17 @@
         "type": { "$ref": "#/$defs/FieldType" },
         "required": { "type": "boolean" },
         "description": { "type": "string" },
-        "defaultValue": { "type": "string" }
+        "defaultValue": { "type": "string" },
+        "screenItemRef": {
+          "type": "object",
+          "required": ["screenId", "itemId"],
+          "additionalProperties": false,
+          "description": "画面項目定義への参照 (#321)。設定時は ScreenItem から name/label/type/required/pattern/maxLength 等を上書き解釈する",
+          "properties": {
+            "screenId": { "type": "string" },
+            "itemId": { "type": "string" }
+          }
+        }
       }
     },
     "ActionFields": {


### PR DESCRIPTION
## 関連

- Closes #321
- 親 spec: [docs/spec/screen-items.md §B](docs/spec/screen-items.md)
- base: \`main\`

## 概要

バリデーション 3 層構造 (画面項目 / 処理フロー / 規約) の接続を完成させる第一歩。#318 で作った画面項目定義 (\`ScreenItem\`) を処理フロー側から \`screenItemRef\` で参照できるようにする。

触って分かるように **モーダルで画面項目を選択** → 処理フロー inputs/outputs に自動転写、という UX。

## 主な変更

### スキーマ
- [\`StructuredField\`](designer/src/types/action.ts#L729) に \`screenItemRef?: { screenId: string; itemId: string }\` 追加
- [\`process-flow.schema.json\`](schemas/process-flow.schema.json) の \`StructuredField\` 定義を更新

### UI
- 新規 [\`ScreenItemPickerModal.tsx\`](designer/src/components/action/ScreenItemPickerModal.tsx): 画面 (左) + 項目 (右) 2 カラムの選択モーダル
- [\`StructuredFieldsEditor\`](designer/src/components/action/StructuredFieldsEditor.tsx) に \`onPickScreenItem?\` prop と「画面項目から追加」ボタン追加
  - 参照時は link バッジ + 解除ボタンを行に表示
  - 参照解除ボタンで \`screenItemRef\` のみ削除 (フィールド自体は残る)
- [\`ActionEditor\`](designer/src/components/action/ActionEditor.tsx) で Promise ラッパー経由でモーダルを開く
- CSS: 画面項目ピッカーモーダル + 参照行の装飾

### Spec
- [screen-items.md §B](docs/spec/screen-items.md) を「#321 で実装着手」マーク + 採用案の明示

## 動作フロー (触って確認)

1. 画面項目定義タブ (#318) で対象画面の項目を事前に作成
2. 処理フロー編集画面 → 入力データ / 出力データ の表形式モード
3. 「画面項目から追加」ボタンクリック → モーダル
4. 画面を選択 → 項目をクリック
5. モーダルが閉じ、行に name/label/type/required/description が自動転写される
6. 行の # セルに link バッジ (🔗) が表示される
7. 行末の link 解除ボタンで参照だけ削除可 (フィールドは残る)

## 仕様逐条突合

### #321 完了条件
- ✓ StructuredField に screenItemRef 追加、JSON Schema / TypeScript 型を更新 → [types/action.ts:729-751](designer/src/types/action.ts#L729) + [process-flow.schema.json:267](schemas/process-flow.schema.json#L267)
- ✓ ActionEditor 入出力テーブルで画面項目参照モーダル → [ScreenItemPickerModal.tsx](designer/src/components/action/ScreenItemPickerModal.tsx)
- ✓ 参照時のフィールド描画 + 解除ボタン → [StructuredFieldsEditor.tsx](designer/src/components/action/StructuredFieldsEditor.tsx)
- △ **参照整合性バリデータ (UNKNOWN_SCREEN_ITEM) は未実装** → 別 issue でフォローアップ (本 PR では他の検査への影響を避けるため省略)
- ✓ Vitest + Playwright → 既存 14 件 pass、新規テストは参照時の挙動を手動確認 (Playwright E2E はフォローアップ)
- △ \`process-flow-variables.md\` への section 追記は後続 (screen-items.md 側の更新で基本情報は足りている)

## レビューで特に見てほしい箇所

- **Rules of Hooks 対応**: 初実装で \`useCallback\` を early return 後に置いてランタイム失敗。\`if (!group) return null\` より前に hooks を全部配置する修正を入れた。同じ ActionEditor で今後 hook を追加するとき注意
- **Promise ベースのモーダル連携**: \`StructuredFieldsEditor\` から親の \`onPickScreenItem\` 呼び出しで Promise を返し、親がモーダル表示後に resolve/reject する方式。state がシンプルで他の picker 系にも応用可能
- **screenItemRef の転写ポリシー**: 参照選択時は name/label/type/required/description を **一方向コピー**。画面項目側を後で変更しても処理フロー側は手動更新 (or 再参照) が必要。双方向同期は follow-up
- **モーダル UX**: 画面にスクリーンショット多数の大規模プロジェクトで選択しにくくならないか (画面検索等は後続で追加)

## テスト

- Vitest: 496 件 pass
- Playwright: 既存 14 件 (marker-panel 9 / screen-items 4 / more-ui 1) pass
- \`vite build\` 成功

## UI 影響 / マージ保留フラグ

- [x] **UI 影響あり (マージ前にユーザー目視確認必須)**

### 確認項目

- [ ] 画面項目定義タブで何件か項目を作成して保存
- [ ] 処理フロー編集画面 → 入出力テーブルで「画面項目から追加」ボタンが出る
- [ ] クリックでモーダル、画面選択で項目リスト、項目クリックで行に転写される
- [ ] 転写後の行に link バッジ (🔗) と解除ボタンが出る
- [ ] 解除ボタンで screenItemRef が消え、フィールドは残る
- [ ] 保存 → リロードで screenItemRef が永続化されている

## spec 側の不足点 / 提案

- 参照整合性バリデータ (UNKNOWN_SCREEN / UNKNOWN_SCREEN_ITEM) は別 issue で
- 参照先画面項目の更新を処理フロー側に自動反映する双方向同期も別 issue で (型整合性ルールが複雑なので慎重に議論)
- \`process-flow-variables.md\` に \`screenItemRef\` セクション追記は本 PR マージ後の follow-up

## レビュー担当への申し送り

- 3 層構造 (画面項目 / 処理フロー / 規約) の **最初の接続**。#318 画面項目 と #317 規約カタログに続いて、これで processflow が他 2 層を参照できる構造が揃う
- follow-up の双方向同期は「画面項目を後で変更したら参照している処理フロー inputs も自動更新」にすべきか、「手動で再参照」にすべきかの判断が必要。spec 側で議論したい