### PR TITLE
feat(screen-items): ツールバー統一 + 画面デザインからの項目一括抽出 (#323)

### DIFF
--- a/designer/e2e/screen-items.spec.ts
+++ b/designer/e2e/screen-items.spec.ts
@@ -40,7 +40,7 @@ async function setup(page: Page) {
 test.describe("画面項目定義プロトタイプ (#318)", () => {
   test("画面一覧が selector に反映される", async ({ page }) => {
     await setup(page);
-    const sel = page.locator(".screen-items-screen-selector select");
+    const sel = page.locator(".screen-items-screen-select");
     await expect(sel).toBeVisible();
     await expect(sel.locator("option")).toHaveCount(2);
     await expect(sel).toContainText("ログイン画面");
@@ -61,8 +61,8 @@ test.describe("画面項目定義プロトタイプ (#318)", () => {
     await labelInput.fill("ユーザー ID");
     // 必須 チェック
     await page.locator('.screen-items-table input[type="checkbox"][aria-label="必須"]').first().check();
-    // 保存
-    const saveBtn = page.locator(".screen-items-actions button:has-text('保存')");
+    // 保存 (EditorHeader 内の SaveResetButtons)
+    const saveBtn = page.locator(".srb-btn-save");
     await expect(saveBtn).toBeEnabled();
     await saveBtn.click();
     await expect(saveBtn).toBeDisabled({ timeout: 3000 }); // isDirty 解消
@@ -73,15 +73,26 @@ test.describe("画面項目定義プロトタイプ (#318)", () => {
     // scr-1 に 1 件追加 + 保存
     await page.locator(".screen-items-view button:has-text('項目追加')").click();
     await page.locator('.screen-items-table input[placeholder="email"]').first().fill("field1");
-    await page.locator(".screen-items-actions button:has-text('保存')").click();
-    await expect(page.locator(".screen-items-actions button:has-text('保存')")).toBeDisabled({ timeout: 3000 });
+    await page.locator(".srb-btn-save").click();
+    await expect(page.locator(".srb-btn-save")).toBeDisabled({ timeout: 3000 });
     // scr-2 に切替
-    await page.locator(".screen-items-screen-selector select").selectOption(screenId2);
+    await page.locator(".screen-items-screen-select").selectOption(screenId2);
     // scr-2 は項目 0 件
     await expect(page.locator(".screen-items-empty-row")).toBeVisible();
     // scr-1 に戻す
-    await page.locator(".screen-items-screen-selector select").selectOption(screenId1);
+    await page.locator(".screen-items-screen-select").selectOption(screenId1);
     await expect(page.locator('.screen-items-table input[value="field1"]')).toBeVisible({ timeout: 3000 });
+  });
+
+  test("画面デザインから追加モーダルを開ける", async ({ page }) => {
+    await setup(page);
+    const btn = page.locator(".screen-items-view button:has-text('画面デザインから追加')");
+    await expect(btn).toBeVisible();
+    await btn.click();
+    await expect(page.locator(".screen-item-candidates")).toBeVisible();
+    // キャンセルで閉じる
+    await page.locator(".screen-item-candidates-footer button:has-text('キャンセル')").click();
+    await expect(page.locator(".screen-item-candidates")).toHaveCount(0);
   });
 
   test("削除ボタンで項目が消える", async ({ page }) => {

--- a/designer/src/components/screen-items/ScreenItemCandidatesModal.tsx
+++ b/designer/src/components/screen-items/ScreenItemCandidatesModal.tsx
@@ -1,0 +1,193 @@
+/**
+ * 画面デザインから項目候補を抽出してチェックボックスで選択するモーダル (#323)。
+ *
+ * `screenItemExtractor.extractScreenItemCandidates()` で input/select/textarea を走査し、
+ * ユーザーが複数選択 → 画面項目として一括追加する UX。
+ */
+import { useEffect, useMemo, useState } from "react";
+import { mcpBridge } from "../../mcp/mcpBridge";
+import { extractScreenItemCandidates, type ExtractedCandidate } from "../../utils/screenItemExtractor";
+
+interface Props {
+  open: boolean;
+  screenId: string | null;
+  screenName?: string;
+  /** 既存項目の name セット (重複チェック用) */
+  existingNames: Set<string>;
+  onClose: () => void;
+  /** 選択された候補群を一括追加 */
+  onAddCandidates: (candidates: ExtractedCandidate[]) => void;
+}
+
+export function ScreenItemCandidatesModal({ open, screenId, screenName, existingNames, onClose, onAddCandidates }: Props) {
+  const [candidates, setCandidates] = useState<ExtractedCandidate[]>([]);
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open || !screenId) return;
+    setLoading(true);
+    setError(null);
+    setCandidates([]);
+    setSelected(new Set());
+    mcpBridge.request("loadScreen", { screenId })
+      .then((data) => {
+        if (!data) {
+          setError("画面データが取得できませんでした");
+          return;
+        }
+        const cands = extractScreenItemCandidates(data);
+        setCandidates(cands);
+      })
+      .catch((e) => setError(`抽出エラー: ${String(e)}`))
+      .finally(() => setLoading(false));
+  }, [open, screenId]);
+
+  const newCandidateIndices = useMemo(() => {
+    // 既存 name と重複しないものだけデフォルト選択対象に
+    return candidates
+      .map((c, i) => ({ c, i }))
+      .filter(({ c }) => c.name && !existingNames.has(c.name))
+      .map(({ i }) => i);
+  }, [candidates, existingNames]);
+
+  const toggle = (idx: number) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(idx)) next.delete(idx); else next.add(idx);
+      return next;
+    });
+  };
+
+  const selectAll = () => setSelected(new Set(newCandidateIndices));
+  const clearAll = () => setSelected(new Set());
+
+  const handleAdd = () => {
+    const picked = [...selected].sort((a, b) => a - b).map((i) => candidates[i]);
+    onAddCandidates(picked);
+    onClose();
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="screen-item-candidates-overlay" onClick={onClose}>
+      <div className="screen-item-candidates" onClick={(e) => e.stopPropagation()}>
+        <div className="screen-item-candidates-header">
+          <h6 className="mb-0">
+            <i className="bi bi-ui-checks me-1" />
+            画面デザインから追加{screenName ? `: ${screenName}` : ""}
+          </h6>
+          <button type="button" className="btn btn-sm btn-link" onClick={onClose} aria-label="閉じる">
+            <i className="bi bi-x-lg" />
+          </button>
+        </div>
+        <div className="screen-item-candidates-body">
+          {loading && <div className="small text-muted">読み込み中...</div>}
+          {error && <div className="small text-danger">{error}</div>}
+          {!loading && !error && candidates.length === 0 && (
+            <div className="small text-muted">
+              input / select / textarea 要素が見つかりませんでした。画面デザイナーでフォーム要素を配置してから再度お試しください。
+            </div>
+          )}
+          {candidates.length > 0 && (
+            <>
+              <div className="screen-item-candidates-toolbar">
+                <span className="small text-muted">
+                  {candidates.length} 件検出、{newCandidateIndices.length} 件が新規 (name 重複除く)
+                </span>
+                <div className="ms-auto d-flex gap-2">
+                  <button type="button" className="btn btn-sm btn-outline-secondary" onClick={selectAll}>
+                    新規を全選択
+                  </button>
+                  <button type="button" className="btn btn-sm btn-outline-secondary" onClick={clearAll}>
+                    選択解除
+                  </button>
+                </div>
+              </div>
+              <table className="screen-item-candidates-table">
+                <colgroup>
+                  <col style={{ width: 30 }} />
+                  <col style={{ width: "10em" }} />
+                  <col style={{ width: "4em" }} />
+                  <col style={{ width: "5em" }} />
+                  <col style={{ width: "12em" }} />
+                  <col style={{ width: "4em" }} />
+                  <col style={{ width: "5em" }} />
+                  <col style={{ width: "5em" }} />
+                  <col />
+                </colgroup>
+                <thead>
+                  <tr>
+                    <th />
+                    <th>name</th>
+                    <th>tag</th>
+                    <th>型</th>
+                    <th>label (推定)</th>
+                    <th className="text-center">必須</th>
+                    <th>min</th>
+                    <th>max</th>
+                    <th>pattern</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {candidates.map((c, i) => {
+                    const isDup = !!c.name && existingNames.has(c.name);
+                    const isChecked = selected.has(i);
+                    return (
+                      <tr key={i} className={isDup ? "dup" : undefined}>
+                        <td>
+                          <input
+                            type="checkbox"
+                            className="form-check-input"
+                            checked={isChecked}
+                            onChange={() => toggle(i)}
+                            disabled={isDup}
+                            aria-label={`${c.name} を追加`}
+                          />
+                        </td>
+                        <td>
+                          <code>{c.name || <span className="text-muted">(無名)</span>}</code>
+                          {isDup && <span className="badge bg-warning text-dark ms-1" style={{ fontSize: "0.65rem" }}>重複</span>}
+                        </td>
+                        <td><span className="badge bg-light text-dark">{c.tag}</span></td>
+                        <td>
+                          <code>
+                            {typeof c.type === "string" ? c.type : c.type.kind === "custom" ? c.type.label : "?"}
+                          </code>
+                        </td>
+                        <td className="small">{c.label}</td>
+                        <td className="text-center">{c.required ? "✓" : ""}</td>
+                        <td>{c.minLength ?? ""}</td>
+                        <td>{c.maxLength ?? ""}</td>
+                        <td className="small text-muted">{c.pattern ?? ""}</td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </>
+          )}
+        </div>
+        <div className="screen-item-candidates-footer">
+          <div className="small text-muted">選択 {selected.size} 件</div>
+          <div className="ms-auto d-flex gap-2">
+            <button type="button" className="btn btn-sm btn-outline-secondary" onClick={onClose}>
+              キャンセル
+            </button>
+            <button
+              type="button"
+              className="btn btn-sm btn-primary"
+              onClick={handleAdd}
+              disabled={selected.size === 0}
+            >
+              <i className="bi bi-plus-lg me-1" />
+              選択した {selected.size} 件を追加
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/designer/src/components/screen-items/ScreenItemsView.tsx
+++ b/designer/src/components/screen-items/ScreenItemsView.tsx
@@ -1,11 +1,19 @@
 /**
- * 画面項目定義ビュー (#318 プロトタイプ)。
+ * 画面項目定義ビュー (#318 プロトタイプ、#323 既存画面からの抽出対応)。
  *
  * MVP: シングルトンタブで、中で画面を選択して項目を編集する。
- * 将来 (#318 v1.0 合意後): /screen/items/:screenId の per-screen タブに分割。
+ * 保存・リセット・undo/redo は useResourceEditor + EditorHeader に統一 (#318 改善)。
+ *
+ * 項目追加経路 3 つ:
+ * 1. 空欄追加 (従来)
+ * 2. 画面デザインから選択 (#323 — モーダルで候補リスト + チェックボックス)
+ * 3. (将来) GrapesJS サイドバーからの直接追加 (#322)
  */
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { TableSubToolbar } from "../table/TableSubToolbar";
+import { EditorHeader } from "../common/EditorHeader";
+import { ServerChangeBanner } from "../common/ServerChangeBanner";
+import { useResourceEditor } from "../../hooks/useResourceEditor";
 import {
   loadScreenItems,
   saveScreenItems,
@@ -14,6 +22,8 @@ import { loadProject } from "../../store/flowStore";
 import type { ScreenItem, ScreenItemsFile } from "../../types/screenItem";
 import type { FieldType } from "../../types/action";
 import { generateUUID } from "../../utils/uuid";
+import { ScreenItemCandidatesModal } from "./ScreenItemCandidatesModal";
+import type { ExtractedCandidate } from "../../utils/screenItemExtractor";
 import "../../styles/screen-items.css";
 
 const PRIMITIVE_TYPES: Array<"string" | "number" | "boolean" | "date"> =
@@ -21,44 +31,54 @@ const PRIMITIVE_TYPES: Array<"string" | "number" | "boolean" | "date"> =
 
 type ScreenMeta = { id: string; name: string };
 
+/** useResourceEditor 互換のため ScreenItemsFile を読み書きする load/save ラッパー */
+async function loadFile(screenId: string): Promise<ScreenItemsFile | null> {
+  return loadScreenItems(screenId);
+}
+async function saveFile(data: ScreenItemsFile): Promise<void> {
+  await saveScreenItems(data);
+}
+
 export function ScreenItemsView() {
   const [screens, setScreens] = useState<ScreenMeta[]>([]);
-  const [selectedScreenId, setSelectedScreenId] = useState<string | null>(null);
-  const [file, setFile] = useState<ScreenItemsFile | null>(null);
-  const [isDirty, setIsDirty] = useState(false);
-  const [isSaving, setIsSaving] = useState(false);
+  const [selectedScreenId, setSelectedScreenId] = useState<string | undefined>(undefined);
+  const [candidatesModalOpen, setCandidatesModalOpen] = useState(false);
 
-  // 画面一覧をロード
+  // 画面一覧をロード (初回 + プロジェクト変更)
   useEffect(() => {
     loadProject().then((p) => {
       const metas = p.screens.map((s) => ({ id: s.id, name: s.name }));
       setScreens(metas);
-      if (metas.length > 0 && !selectedScreenId) {
-        setSelectedScreenId(metas[0].id);
-      }
+      setSelectedScreenId((cur) => cur ?? (metas.length > 0 ? metas[0].id : undefined));
     }).catch(console.error);
   }, []);
 
-  // 選択画面が変わったら項目ファイルをロード
-  useEffect(() => {
-    if (!selectedScreenId) { setFile(null); return; }
-    loadScreenItems(selectedScreenId).then((f) => {
-      setFile(f);
-      setIsDirty(false);
-    }).catch(console.error);
-  }, [selectedScreenId]);
+  const {
+    state: file,
+    isDirty, isSaving, serverChanged,
+    update, updateSilent, commit,
+    undo, redo, canUndo, canRedo,
+    handleSave, handleReset, dismissServerBanner,
+  } = useResourceEditor<ScreenItemsFile>({
+    tabType: "screen-items",
+    mtimeKind: "screenItems",
+    draftKind: "screen-items",
+    id: selectedScreenId,
+    load: loadFile,
+    save: saveFile,
+    broadcastName: "screenItemsChanged",
+    broadcastIdField: "screenId",
+  });
 
-  const update = useCallback((mut: (f: ScreenItemsFile) => void) => {
-    setFile((prev) => {
-      if (!prev) return prev;
-      const next = structuredClone(prev);
-      mut(next);
-      return next;
-    });
-    setIsDirty(true);
-  }, []);
+  const handleSwitchScreen = (nextId: string) => {
+    if (isDirty) {
+      const ok = window.confirm("未保存の変更があります。破棄して別の画面に切り替えますか?");
+      if (!ok) return;
+    }
+    setSelectedScreenId(nextId);
+  };
 
-  const handleAddItem = () => {
+  const handleAddItem = useCallback(() => {
     update((f) => {
       f.items.push({
         id: generateUUID(),
@@ -67,76 +87,90 @@ export function ScreenItemsView() {
         type: "string",
       });
     });
-  };
+  }, [update]);
 
-  const handleUpdateItem = (idx: number, patch: Partial<ScreenItem>) => {
-    update((f) => {
+  const handleUpdateItem = useCallback((idx: number, patch: Partial<ScreenItem>) => {
+    updateSilent((f) => {
       Object.assign(f.items[idx], patch);
     });
-  };
+  }, [updateSilent]);
 
-  const handleRemoveItem = (idx: number) => {
+  const handleRemoveItem = useCallback((idx: number) => {
     update((f) => {
       f.items.splice(idx, 1);
     });
-  };
+  }, [update]);
 
-  const handleSave = async () => {
-    if (!file) return;
-    setIsSaving(true);
-    try {
-      await saveScreenItems(file);
-      setIsDirty(false);
-    } finally {
-      setIsSaving(false);
-    }
-  };
+  /** 候補モーダルから受け取った ExtractedCandidate[] を ScreenItem[] として一括追加 */
+  const handleAddCandidates = useCallback((cands: ExtractedCandidate[]) => {
+    if (cands.length === 0) return;
+    update((f) => {
+      for (const c of cands) {
+        f.items.push({
+          id: generateUUID(),
+          name: c.name || "",
+          label: c.label || "",
+          type: c.type,
+          required: c.required,
+          minLength: c.minLength,
+          maxLength: c.maxLength,
+          pattern: c.pattern,
+          placeholder: c.placeholder,
+        });
+      }
+    });
+  }, [update]);
+
+  const existingNames = useMemo(
+    () => new Set((file?.items ?? []).map((i) => i.name).filter(Boolean)),
+    [file]
+  );
+
+  const selectedScreenName = screens.find((s) => s.id === selectedScreenId)?.name;
 
   return (
     <div className="screen-items-view">
       <TableSubToolbar />
 
-      <div className="screen-items-header">
-        <div className="screen-items-title">
-          <i className="bi bi-ui-checks-grid" /> 画面項目定義
-          <span className="badge bg-warning text-dark ms-2" style={{ fontSize: "0.7rem" }}>
-            ドラフト (#318)
+      {serverChanged && (
+        <ServerChangeBanner onReload={handleReset} onDismiss={dismissServerBanner} />
+      )}
+
+      <EditorHeader
+        title={
+          <span className="fw-semibold">
+            <i className="bi bi-ui-checks-grid me-1" />
+            画面項目定義
+            <span className="badge bg-warning text-dark ms-2" style={{ fontSize: "0.7rem" }}>
+              ドラフト (#318)
+            </span>
           </span>
-        </div>
-        <div className="screen-items-screen-selector">
-          <label className="form-label mb-0 small fw-semibold">画面</label>
-          <select
-            className="form-select form-select-sm"
-            value={selectedScreenId ?? ""}
-            onChange={(e) => setSelectedScreenId(e.target.value || null)}
-            disabled={screens.length === 0}
-          >
-            {screens.length === 0 && <option value="">画面がありません</option>}
-            {screens.map((s) => (
-              <option key={s.id} value={s.id}>{s.name}</option>
-            ))}
-          </select>
-        </div>
-        <div className="screen-items-actions">
-          <button
-            type="button"
-            className="btn btn-sm btn-primary"
-            onClick={handleSave}
-            disabled={!isDirty || isSaving}
-          >
-            <i className="bi bi-save me-1" />
-            {isSaving ? "保存中..." : "保存"}
-          </button>
-        </div>
-      </div>
+        }
+        centerTools={
+          <div className="d-flex align-items-center gap-2">
+            <label className="form-label mb-0 small fw-semibold">画面</label>
+            <select
+              className="form-select form-select-sm screen-items-screen-select"
+              value={selectedScreenId ?? ""}
+              onChange={(e) => handleSwitchScreen(e.target.value)}
+              disabled={screens.length === 0}
+            >
+              {screens.length === 0 && <option value="">画面がありません</option>}
+              {screens.map((s) => (
+                <option key={s.id} value={s.id}>{s.name}</option>
+              ))}
+            </select>
+          </div>
+        }
+        undoRedo={{ onUndo: undo, onRedo: redo, canUndo, canRedo }}
+        saveReset={{ isDirty, isSaving, onSave: handleSave, onReset: handleReset }}
+      />
 
       <div className="screen-items-content">
         {!selectedScreenId && (
           <div className="screen-items-empty">
             <p>画面を選択してください。</p>
-            <p className="text-muted small">
-              画面が 1 つも存在しない場合は、先に「画面一覧」から画面を作成してください。
-            </p>
+            <p className="text-muted small">画面が存在しない場合は、先に「画面一覧」で画面を作成してください。</p>
           </div>
         )}
         {selectedScreenId && file && (
@@ -171,7 +205,9 @@ export function ScreenItemsView() {
               <tbody>
                 {file.items.length === 0 && (
                   <tr>
-                    <td colSpan={10} className="screen-items-empty-row">項目がありません。下の「項目追加」から追加してください。</td>
+                    <td colSpan={10} className="screen-items-empty-row">
+                      項目がありません。下のボタンから追加してください。
+                    </td>
                   </tr>
                 )}
                 {file.items.map((item, i) => (
@@ -182,6 +218,7 @@ export function ScreenItemsView() {
                         className="form-control form-control-sm"
                         value={item.name}
                         onChange={(e) => handleUpdateItem(i, { name: e.target.value })}
+                        onBlur={commit}
                         placeholder="email"
                       />
                     </td>
@@ -190,6 +227,7 @@ export function ScreenItemsView() {
                         className="form-control form-control-sm"
                         value={item.label}
                         onChange={(e) => handleUpdateItem(i, { label: e.target.value })}
+                        onBlur={commit}
                         placeholder="メールアドレス"
                       />
                     </td>
@@ -213,6 +251,7 @@ export function ScreenItemsView() {
                             handleUpdateItem(i, { type: { kind: "custom", label: v } });
                           }
                         }}
+                        onBlur={commit}
                         placeholder="string"
                       />
                     </td>
@@ -232,6 +271,7 @@ export function ScreenItemsView() {
                         value={item.minLength ?? ""}
                         min={0}
                         onChange={(e) => handleUpdateItem(i, { minLength: e.target.value === "" ? undefined : Number(e.target.value) })}
+                        onBlur={commit}
                       />
                     </td>
                     <td>
@@ -241,6 +281,7 @@ export function ScreenItemsView() {
                         value={item.maxLength ?? ""}
                         min={0}
                         onChange={(e) => handleUpdateItem(i, { maxLength: e.target.value === "" ? undefined : Number(e.target.value) })}
+                        onBlur={commit}
                       />
                     </td>
                     <td>
@@ -248,6 +289,7 @@ export function ScreenItemsView() {
                         className="form-control form-control-sm"
                         value={item.pattern ?? ""}
                         onChange={(e) => handleUpdateItem(i, { pattern: e.target.value || undefined })}
+                        onBlur={commit}
                         placeholder="@conv.regex.email-simple"
                       />
                     </td>
@@ -256,6 +298,7 @@ export function ScreenItemsView() {
                         className="form-control form-control-sm"
                         value={item.description ?? ""}
                         onChange={(e) => handleUpdateItem(i, { description: e.target.value || undefined })}
+                        onBlur={commit}
                       />
                     </td>
                     <td className="text-center">
@@ -273,19 +316,38 @@ export function ScreenItemsView() {
                 ))}
               </tbody>
             </table>
-            <button
-              type="button"
-              className="btn btn-sm btn-outline-primary screen-items-add"
-              onClick={handleAddItem}
-            >
-              <i className="bi bi-plus-lg me-1" /> 項目追加
-            </button>
+            <div className="screen-items-toolbar">
+              <button
+                type="button"
+                className="btn btn-sm btn-outline-primary screen-items-add"
+                onClick={handleAddItem}
+              >
+                <i className="bi bi-plus-lg me-1" /> 項目追加
+              </button>
+              <button
+                type="button"
+                className="btn btn-sm btn-outline-primary screen-items-add"
+                onClick={() => setCandidatesModalOpen(true)}
+                title="現在選択中の画面デザインから input/select/textarea を抽出してチェックで追加"
+              >
+                <i className="bi bi-ui-checks me-1" /> 画面デザインから追加
+              </button>
+            </div>
             <datalist id="screen-items-type-list">
               {PRIMITIVE_TYPES.map((t) => <option key={t} value={t} />)}
             </datalist>
           </div>
         )}
       </div>
+
+      <ScreenItemCandidatesModal
+        open={candidatesModalOpen}
+        screenId={selectedScreenId ?? null}
+        screenName={selectedScreenName}
+        existingNames={existingNames}
+        onClose={() => setCandidatesModalOpen(false)}
+        onAddCandidates={handleAddCandidates}
+      />
     </div>
   );
 }

--- a/designer/src/styles/screen-items.css
+++ b/designer/src/styles/screen-items.css
@@ -8,38 +8,7 @@
   background: #f8f9fa;
 }
 
-.screen-items-header {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 6px 14px;
-  background: #fff;
-  border-bottom: 1px solid #e2e8f0;
-  flex-wrap: wrap;
-}
-
-.screen-items-title {
-  font-weight: 600;
-  font-size: 0.95rem;
-  color: #334155;
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-}
-
-.screen-items-screen-selector {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.screen-items-screen-selector select {
-  min-width: 14em;
-}
-
-.screen-items-actions {
-  margin-left: auto;
-}
+/* 旧 screen-items-header / title / actions は EditorHeader に置換 (#318 改善) */
 
 .screen-items-content {
   flex: 1;
@@ -108,7 +77,89 @@
   font-size: 0.85rem;
 }
 
-.screen-items-add {
+.screen-items-toolbar {
+  display: flex;
+  gap: 8px;
   margin-top: 8px;
+  flex-wrap: wrap;
+}
+.screen-items-add {
   font-size: 0.82rem;
+}
+.screen-items-screen-select {
+  min-width: 14em;
+}
+
+/* 画面項目候補モーダル (#323) */
+.screen-item-candidates-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+.screen-item-candidates {
+  background: #fff;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 1000px;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15);
+}
+.screen-item-candidates-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  border-bottom: 1px solid #e2e8f0;
+}
+.screen-item-candidates-body {
+  flex: 1;
+  overflow: auto;
+  padding: 10px 14px;
+}
+.screen-item-candidates-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid #e2e8f0;
+  margin-bottom: 8px;
+}
+.screen-item-candidates-table {
+  width: 100%;
+  table-layout: fixed;
+  border-collapse: collapse;
+  font-size: 0.82rem;
+}
+.screen-item-candidates-table thead th {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #64748b;
+  padding: 4px 6px;
+  border-bottom: 1px solid #cbd5e1;
+  text-align: left;
+}
+.screen-item-candidates-table tbody td {
+  padding: 3px 6px;
+  vertical-align: middle;
+  border-bottom: 1px solid #f1f5f9;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.screen-item-candidates-table tbody tr.dup {
+  background: #fef3c7;
+  opacity: 0.7;
+}
+.screen-item-candidates-footer {
+  padding: 10px 14px;
+  border-top: 1px solid #e2e8f0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }

--- a/designer/src/utils/screenItemExtractor.test.ts
+++ b/designer/src/utils/screenItemExtractor.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { extractScreenItemCandidates } from "./screenItemExtractor";
+
+/** GrapesJS 風の char-array components を作るヘルパー */
+function gjsFromHtml(html: string): unknown {
+  return {
+    pages: [{
+      frames: [{
+        component: {
+          components: html.split(""),
+        },
+      }],
+    }],
+  };
+}
+
+describe("extractScreenItemCandidates", () => {
+  it("input[text] を name / label 付きで抽出", () => {
+    const html = `
+      <form>
+        <label for="email">メールアドレス</label>
+        <input id="email" name="email" type="text" placeholder="a@b.com" required maxlength="255" />
+      </form>
+    `;
+    const cands = extractScreenItemCandidates(gjsFromHtml(html));
+    expect(cands).toHaveLength(1);
+    expect(cands[0].name).toBe("email");
+    expect(cands[0].label).toBe("メールアドレス");
+    expect(cands[0].type).toBe("string");
+    expect(cands[0].required).toBe(true);
+    expect(cands[0].maxLength).toBe(255);
+    expect(cands[0].placeholder).toBe("a@b.com");
+  });
+
+  it("input[number] / input[date] / input[checkbox] は type を適切に推定", () => {
+    const html = `
+      <input name="qty" type="number" min="1" max="9999" />
+      <input name="birthday" type="date" />
+      <input name="agree" type="checkbox" />
+    `;
+    const cands = extractScreenItemCandidates(gjsFromHtml(html));
+    expect(cands).toHaveLength(3);
+    expect(cands[0].name).toBe("qty");
+    expect(cands[0].type).toBe("number");
+    expect(cands[1].type).toBe("date");
+    expect(cands[2].type).toBe("boolean");
+  });
+
+  it("button / submit / hidden は除外", () => {
+    const html = `
+      <input name="csrf" type="hidden" value="x" />
+      <input type="submit" value="送信" />
+      <button type="button">キャンセル</button>
+      <input name="real" type="text" />
+    `;
+    const cands = extractScreenItemCandidates(gjsFromHtml(html));
+    // button タグ自体は対象外、submit/hidden は除外、残るは real の 1 件
+    expect(cands).toHaveLength(1);
+    expect(cands[0].name).toBe("real");
+  });
+
+  it("textarea / select も抽出", () => {
+    const html = `
+      <label for="bio">自己紹介</label>
+      <textarea id="bio" name="bio" required></textarea>
+      <label>性別
+        <select name="gender">
+          <option value="m">男性</option>
+          <option value="f">女性</option>
+        </select>
+      </label>
+    `;
+    const cands = extractScreenItemCandidates(gjsFromHtml(html));
+    expect(cands).toHaveLength(2);
+    expect(cands[0].tag).toBe("textarea");
+    expect(cands[0].name).toBe("bio");
+    expect(cands[0].required).toBe(true);
+    expect(cands[1].tag).toBe("select");
+    expect(cands[1].name).toBe("gender");
+    expect(cands[1].label).toContain("性別");
+  });
+
+  it("components に何も無ければ空配列", () => {
+    expect(extractScreenItemCandidates({})).toEqual([]);
+    expect(extractScreenItemCandidates({ pages: [] })).toEqual([]);
+  });
+
+  it("pattern / minLength / maxLength も抽出", () => {
+    const html = `<input name="phone" type="text" pattern="\\d{3}-\\d{4}-\\d{4}" minlength="12" maxlength="13" />`;
+    const cands = extractScreenItemCandidates(gjsFromHtml(html));
+    expect(cands[0].pattern).toBe("\\d{3}-\\d{4}-\\d{4}");
+    expect(cands[0].minLength).toBe(12);
+    expect(cands[0].maxLength).toBe(13);
+  });
+});

--- a/designer/src/utils/screenItemExtractor.ts
+++ b/designer/src/utils/screenItemExtractor.ts
@@ -1,0 +1,149 @@
+/**
+ * 画面 (GrapesJS JSON) からフォーム要素を走査し、画面項目定義の候補として抽出する。
+ * #323 / #318 ユーザーフィードバックへの対応 — 既存画面をモーダルで参照して
+ * チェックボックス選択で項目を一括追加する UX を支える。
+ *
+ * GrapesJS の JSON 構造:
+ *   pages[].frames[].component.components  —  char 配列 (joined = 生 HTML) または
+ *                                              ネスト構造化コンポーネント
+ * ここでは出てくる全ての文字列断片を再帰的に連結して 1 つの HTML にし、
+ * ブラウザの DOMParser で input/select/textarea を抽出する。
+ */
+import type { FieldType } from "../types/action";
+
+export interface ExtractedCandidate {
+  /** 元 HTML 要素の outerHTML (モーダルで表示するプレビュー用) */
+  elementHtml: string;
+  /** HTML name 属性 (なければ placeholder ベースの推測) */
+  name: string;
+  /** label 推定 (nearby <label> or placeholder or name) */
+  label: string;
+  /** 推定型 */
+  type: FieldType;
+  /** HTML required 属性 */
+  required?: boolean;
+  /** HTML pattern 属性 */
+  pattern?: string;
+  /** HTML maxlength 属性 */
+  maxLength?: number;
+  /** HTML minlength 属性 */
+  minLength?: number;
+  /** HTML placeholder 属性 */
+  placeholder?: string;
+  /** 元タグ種別 (input / select / textarea) */
+  tag: string;
+}
+
+/** GrapesJS JSON から components の文字列断片を集めて連結 */
+function gatherHtml(node: unknown, buf: string[]): void {
+  if (typeof node === "string") {
+    buf.push(node);
+    return;
+  }
+  if (Array.isArray(node)) {
+    for (const item of node) gatherHtml(item, buf);
+    return;
+  }
+  if (node && typeof node === "object") {
+    const obj = node as Record<string, unknown>;
+    // components は配列 or 文字列
+    if ("components" in obj) gatherHtml(obj.components, buf);
+    // 子要素を持つ他のプロパティも一応覗く (pages / frames / component)
+    if ("pages" in obj) gatherHtml(obj.pages, buf);
+    if ("frames" in obj) gatherHtml(obj.frames, buf);
+    if ("component" in obj) gatherHtml(obj.component, buf);
+  }
+}
+
+function inferType(tag: string, typeAttr: string): FieldType {
+  if (tag === "textarea") return "string";
+  if (tag === "select") return "string";
+  // input の type 属性で判別
+  switch (typeAttr) {
+    case "number":
+    case "range":
+      return "number";
+    case "checkbox":
+    case "radio":
+      return "boolean";
+    case "date":
+    case "datetime-local":
+    case "month":
+    case "week":
+    case "time":
+      return "date";
+    default:
+      return "string";
+  }
+}
+
+/** input/select/textarea の直近 <label> を探す (for 属性一致 or 祖先ラップ) */
+function findNearbyLabel(el: Element): string | null {
+  const id = el.getAttribute("id");
+  if (id) {
+    const lbl = el.ownerDocument?.querySelector(`label[for="${CSS.escape(id)}"]`);
+    if (lbl?.textContent) return lbl.textContent.trim();
+  }
+  // 祖先の <label>
+  let p: Element | null = el.parentElement;
+  while (p) {
+    if (p.tagName.toLowerCase() === "label") {
+      return p.textContent?.replace(/\s+/g, " ").trim() ?? null;
+    }
+    p = p.parentElement;
+  }
+  // 直前兄弟の <label>
+  const prev = el.previousElementSibling;
+  if (prev?.tagName.toLowerCase() === "label") {
+    return prev.textContent?.trim() ?? null;
+  }
+  return null;
+}
+
+function parseIntOrUndefined(v: string | null): number | undefined {
+  if (v == null) return undefined;
+  const n = parseInt(v, 10);
+  return isNaN(n) ? undefined : n;
+}
+
+/**
+ * GrapesJS 画面 JSON から input/select/textarea 要素を抽出。
+ * DOMParser を使うためブラウザ環境でのみ動作 (node 環境は jsdom 要)。
+ */
+export function extractScreenItemCandidates(screenData: unknown): ExtractedCandidate[] {
+  const buf: string[] = [];
+  gatherHtml(screenData, buf);
+  const html = buf.join("");
+  if (!html) return [];
+
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, "text/html");
+  const candidates: ExtractedCandidate[] = [];
+
+  for (const el of doc.querySelectorAll("input, select, textarea")) {
+    const tag = el.tagName.toLowerCase();
+    const typeAttr = (el.getAttribute("type") || "text").toLowerCase();
+    // button / submit / reset / hidden は除外
+    if (tag === "input" && ["button", "submit", "reset", "hidden"].includes(typeAttr)) continue;
+
+    const name = el.getAttribute("name") || "";
+    const placeholder = el.getAttribute("placeholder") || "";
+    const label = findNearbyLabel(el) || placeholder || name || `(${tag})`;
+    const type = inferType(tag, typeAttr);
+
+    candidates.push({
+      elementHtml: (el as HTMLElement).outerHTML.slice(0, 300),
+      name,
+      label,
+      type,
+      required: el.hasAttribute("required") || undefined,
+      pattern: el.getAttribute("pattern") || undefined,
+      maxLength: parseIntOrUndefined(el.getAttribute("maxlength")),
+      minLength: parseIntOrUndefined(el.getAttribute("minlength")),
+      placeholder: placeholder || undefined,
+      tag,
+    });
+  }
+
+  return candidates;
+}


### PR DESCRIPTION
## 関連

- Closes #323 (既存画面からの自動項目抽出 migration のコア部分)
- 関連: #318 (ツールバー統一は #318 プロトタイプのフィードバック対応)
- base: \`main\`

## 概要

画面項目定義ビュー (#318) へのユーザーフィードバック 2 点に対応:

1. **ツールバーが他画面と異なる** → EditorHeader + useResourceEditor に統一
2. **項目追加に空欄以外の選択肢を** → 画面デザインから input / select / textarea を抽出してチェックボックスで一括追加するモーダルを追加

## 主な変更

### ツールバー統一
- [\`ScreenItemsView.tsx\`](designer/src/components/screen-items/ScreenItemsView.tsx) を \`useResourceEditor\` + \`EditorHeader\` ベースに書き直し
- 保存 / リセット / undo / redo は SaveResetButtons + undoRedo ボタンで他画面と完全統一
- ドラフト永続化 (draftStorage) / サーバー変更検知 (serverMtime) / broadcast 受信の仕組みも自動付与
- 画面セレクタは EditorHeader の \`centerTools\` に配置
- 画面切替時は \`isDirty\` チェックで破棄確認ダイアログ

### 画面デザインからの抽出
- 新規 [\`screenItemExtractor.ts\`](designer/src/utils/screenItemExtractor.ts):
  - GrapesJS JSON の char 配列 \`components\` を再帰的に連結 → 1 つの HTML 文字列
  - DOMParser で input / select / textarea を走査
  - 推定 name / label (for 属性一致 label / 祖先 label / 兄弟 label / placeholder / name の順) / type / required / pattern / minLength / maxLength / placeholder
  - button / submit / reset / hidden は除外
- 新規 [\`ScreenItemCandidatesModal.tsx\`](designer/src/components/screen-items/ScreenItemCandidatesModal.tsx):
  - 現在選択中の画面のデータをロード → extractor で候補リスト
  - チェックボックスで多重選択、既存項目と \`name\` 重複する候補は disabled + 重複バッジ
  - 「新規を全選択」「選択解除」ボタン
  - 「選択した N 件を追加」で一括追加 → \`update\` で undo 単位 1 件として積む

### テスト
- 新規 Vitest: [\`screenItemExtractor.test.ts\`](designer/src/utils/screenItemExtractor.test.ts) 6 件
  - input[text] / number / date / checkbox の型推定
  - button / submit / hidden 除外
  - textarea / select 対応
  - pattern / minLength / maxLength の抽出
- 既存 Playwright 4 件を新セレクタ (\`.screen-items-screen-select\` / \`.srb-btn-save\`) に更新 + 候補モーダル表示テスト新規 1 件

## 仕様逐条突合

### ツールバー統一
- ✓ EditorHeader に title / centerTools (画面セレクタ) / undoRedo / saveReset を配置
- ✓ useResourceEditor で save / reset / undo / redo / serverChanged / ドラフト永続化
- ✓ 画面切替時に isDirty 警告 → confirm

### #323 前倒し部分
- ✓ 画面デザイン走査 utility (\`screenItemExtractor.ts\`) — E2E + Vitest
- ✓ 取り込み提案モーダル UI (\`ScreenItemCandidatesModal.tsx\`) — 候補表示 + チェック選択 + 一括追加
- △ **GrapesJS 要素への \`data-item-id\` 書き込み (双方向紐付け)** は #322 の範囲で未実装。本 PR は「一方向の抽出」のみ

## レビューで特に見てほしい箇所

- **GrapesJS JSON の components が char 配列**: 調査結果、\`page.frames[].component.components\` は 1 文字ずつの配列で、連結して HTML にする必要があった。extractor では \`gatherHtml()\` で再帰的に連結している。ネスト構造化コンポーネントにも対応するはずだが、実サンプルは char 配列のみでテスト。構造化コンポーネントのサンプルが出てきたら extractor を調整する必要あり
- **name 重複の扱い**: 既存項目と \`name\` が同じなら候補チェックボックスを disabled + 重複バッジ表示。強引に上書きしたい場合は、一旦既存項目を削除してから再取り込みする運用
- **label 推定の精度**: for 属性一致 label > 祖先 label > 兄弟 label > placeholder > name の順。GrapesJS の生成する HTML 次第で外れる場合あり。初期値として提案するだけで、ユーザーが編集できるので許容範囲
- **画面切替時の破棄確認**: useResourceEditor は id 変更で自動リロードするが、isDirty の場合に confirm ダイアログを出す挙動は ScreenItemsView 側で実装。useResourceEditor 自体には組み込まれていない

## テスト

- Vitest: 502 件 (新規 6 件、extractor 関連) pass
- Playwright: screen-items 5 件 (新規 1 件含む) + regression (marker-panel 9 / conventions-catalog 5 / more-ui 1) = 20 件 pass
- vite build 成功

## UI 影響 / マージ保留フラグ

- [x] **UI 影響あり (マージ前にユーザー目視確認必須)**

### 確認項目 (触ってみてください)

- [ ] HeaderMenu → 「画面項目定義」でツールバーが他画面と同じ (保存 / リセット / undo / redo / 画面セレクタ) 揃って表示
- [ ] 画面を切り替えると項目リストがリセットされる (未保存があれば confirm 表示)
- [ ] Ctrl+S で保存できる
- [ ] Ctrl+Z / Ctrl+Y で undo / redo できる
- [ ] 「画面デザインから追加」ボタンでモーダル表示
- [ ] input / select / textarea がある画面なら候補リストに出る (例: 既存サンプル \`aaaaaaaa-0005\` 等)
- [ ] 既存項目と \`name\` 重複の候補は disabled + 重複バッジ表示
- [ ] 「新規を全選択」→「選択した N 件を追加」で一括追加できる
- [ ] 追加後の項目は undo 1 回で一括キャンセルできる (undo 単位は一括)

## spec 側の不足点 / 提案

- GrapesJS ブロックへの \`data-item-id\` 書き込み (双方向紐付け) は #322 で別途
- 画面デザイナー (GrapesJS サイドバー) からの直接追加は #322 の範疇
- label 推定に GrapesJS の component metadata (\`attributes-extra\` 等) を活用する余地あり (follow-up)

## レビュー担当への申し送り

- useResourceEditor を \`id=selectedScreenId\` で使い、画面切替で id を変えることでリロードさせる運用。tab id は \`screen-items-{screenId}\` になるが実タブは singleton の \`screen-items-main\` なので、tabBar 上の dirty 表示は SaveResetButtons 経由のみ。問題ないと判断
- extractor の DOMParser は jsdom なら vitest でも動くが、本 PR では E2E (実ブラウザ) + vitest 単体で別軸カバー