### PR TITLE
feat(screen-items): GrapesJS フォーム要素と data-item-id で紐付け (#322)

### DIFF
--- a/designer/src/components/Designer.tsx
+++ b/designer/src/components/Designer.tsx
@@ -11,6 +11,7 @@ import "grapesjs/dist/css/grapes.min.css";
 
 import { registerBlocks } from "../grapes/blocks";
 import { registerValidationTraits } from "../grapes/validationTraits";
+import { attachDataItemIdAutoAssign } from "../grapes/dataItemId";
 import { registerRemoteStorage, saveScreenToFile, hasScreenDraft, clearScreenDraft } from "../grapes/remoteStorage";
 import { acknowledgeServerMtime, hasServerBeenUpdated } from "../utils/serverMtime";
 import { DesignSubToolbar } from "./design/DesignSubToolbar";
@@ -233,6 +234,9 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
     };
     editor.on("component:add component:remove component:update style:change", markDirty);
 
+    // #322: input/select/textarea ブロック drop 時に data-item-id を自動発番
+    const unsubDataItemId = attachDataItemIdAutoAssign(editor);
+
     // MCPブリッジ起動
     const unsubscribe = mcpBridge.onStatusChange(setMcpStatus);
     mcpBridge.setThemeHandler((themeId) =>
@@ -255,6 +259,7 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
 
     return () => {
       editor.off("component:add component:remove component:update style:change", markDirty);
+      unsubDataItemId();
       unsubscribe();
       unsubScreenChanged();
       mcpBridge.setThemeHandler(null);

--- a/designer/src/components/screen-items/ScreenItemsView.tsx
+++ b/designer/src/components/screen-items/ScreenItemsView.tsx
@@ -101,13 +101,15 @@ export function ScreenItemsView() {
     });
   }, [update]);
 
-  /** 候補モーダルから受け取った ExtractedCandidate[] を ScreenItem[] として一括追加 */
+  /** 候補モーダルから受け取った ExtractedCandidate[] を ScreenItem[] として一括追加。
+   *  candidate が data-item-id を持つなら ScreenItem.id として採用し、画面 DOM と
+   *  1:1 でリンクする (#322)。持たない場合は UUID を新規発番。 */
   const handleAddCandidates = useCallback((cands: ExtractedCandidate[]) => {
     if (cands.length === 0) return;
     update((f) => {
       for (const c of cands) {
         f.items.push({
-          id: generateUUID(),
+          id: c.dataItemId || generateUUID(),
           name: c.name || "",
           label: c.label || "",
           type: c.type,

--- a/designer/src/grapes/dataItemId.ts
+++ b/designer/src/grapes/dataItemId.ts
@@ -1,0 +1,87 @@
+/**
+ * GrapesJS 画面デザイナーで input/select/textarea 要素に `data-item-id` を
+ * 自動発番するフック (#322)。
+ *
+ * 画面項目定義 (#318) の ScreenItem.id と画面 DOM 要素を紐付けるキーとなる。
+ * ScreenItemsView の候補抽出モーダル (#323) が data-item-id を読み取って
+ * ScreenItem.id として採用することで、同じ要素に対する再抽出がべき等になる。
+ *
+ * 発番戦略:
+ * - component:add: 新規追加 (ブロック drop / カスタムブロック挿入) 時に
+ *   form field であり data-item-id 未設定なら UUID を発番
+ * - 子孫コンポーネントも再帰的にチェック (ブロックが input を内包するケース)
+ * - 既存画面の未発番要素は load 後に自動付与しない (dirty 化を避けるため)
+ *   → 必要なら別コマンド (Follow-up) で一括付与を提供
+ */
+import type { Editor as GEditor, Component } from "grapesjs";
+import { generateUUID } from "../utils/uuid";
+
+const FORM_FIELD_TAGS = new Set(["input", "select", "textarea"]);
+const EXCLUDED_INPUT_TYPES = new Set(["button", "submit", "reset", "hidden", "image"]);
+
+function isFormField(cmp: Component): boolean {
+  const tag = String(cmp.get("tagName") ?? "").toLowerCase();
+  if (!FORM_FIELD_TAGS.has(tag)) return false;
+  if (tag === "input") {
+    const attrs = cmp.getAttributes() ?? {};
+    const t = String(attrs.type ?? "text").toLowerCase();
+    if (EXCLUDED_INPUT_TYPES.has(t)) return false;
+  }
+  return true;
+}
+
+function getDataItemId(cmp: Component): string | undefined {
+  const attrs = cmp.getAttributes() ?? {};
+  const v = attrs["data-item-id"];
+  return v ? String(v) : undefined;
+}
+
+/** form field であり data-item-id 未設定なら発番。発番した場合 true */
+export function ensureDataItemId(cmp: Component): boolean {
+  if (!isFormField(cmp)) return false;
+  if (getDataItemId(cmp)) return false;
+  cmp.addAttributes({ "data-item-id": generateUUID() });
+  return true;
+}
+
+/** component とその子孫を再帰走査 */
+function walk(cmp: Component, visit: (c: Component) => void): void {
+  visit(cmp);
+  const children = cmp.components?.();
+  if (children) {
+    children.forEach((c) => walk(c, visit));
+  }
+}
+
+/**
+ * GrapesJS editor にフックを張って新規 form field に data-item-id を発番する。
+ * @returns unsubscribe 関数
+ */
+export function attachDataItemIdAutoAssign(editor: GEditor): () => void {
+  const onAdd = (cmp: Component) => {
+    // 自身 + 子孫を走査 (ブロック drop 時にラッパー要素経由で来ることが多い)
+    walk(cmp, (c) => { ensureDataItemId(c); });
+  };
+  editor.on("component:add", onAdd);
+
+  return () => {
+    editor.off("component:add", onAdd);
+  };
+}
+
+/**
+ * 画面全体をスキャンして未発番の form field に data-item-id を一括発番する。
+ * ScreenItemsView の「画面デザインから追加」モーダル等、明示的なユーザー操作
+ * から呼び出す想定 (load 時の自動実行はしない)。
+ *
+ * @returns 発番した要素数
+ */
+export function assignAllMissingDataItemIds(editor: GEditor): number {
+  const wrapper = editor.getWrapper();
+  if (!wrapper) return 0;
+  let count = 0;
+  walk(wrapper, (c) => {
+    if (ensureDataItemId(c)) count++;
+  });
+  return count;
+}

--- a/designer/src/utils/screenItemExtractor.test.ts
+++ b/designer/src/utils/screenItemExtractor.test.ts
@@ -92,4 +92,16 @@ describe("extractScreenItemCandidates", () => {
     expect(cands[0].minLength).toBe(12);
     expect(cands[0].maxLength).toBe(13);
   });
+
+  it("data-item-id 属性 (#322) が抽出される", () => {
+    const html = `<input name="email" type="text" data-item-id="abc-123-item-id" />`;
+    const cands = extractScreenItemCandidates(gjsFromHtml(html));
+    expect(cands[0].dataItemId).toBe("abc-123-item-id");
+  });
+
+  it("data-item-id 無しなら dataItemId は undefined", () => {
+    const html = `<input name="name" type="text" />`;
+    const cands = extractScreenItemCandidates(gjsFromHtml(html));
+    expect(cands[0].dataItemId).toBeUndefined();
+  });
 });

--- a/designer/src/utils/screenItemExtractor.ts
+++ b/designer/src/utils/screenItemExtractor.ts
@@ -14,6 +14,8 @@ import type { FieldType } from "../types/action";
 export interface ExtractedCandidate {
   /** 元 HTML 要素の outerHTML (モーダルで表示するプレビュー用) */
   elementHtml: string;
+  /** GrapesJS 側で発番された data-item-id (#322)。ScreenItem.id として使う */
+  dataItemId?: string;
   /** HTML name 属性 (なければ placeholder ベースの推測) */
   name: string;
   /** label 推定 (nearby <label> or placeholder or name) */
@@ -133,6 +135,7 @@ export function extractScreenItemCandidates(screenData: unknown): ExtractedCandi
 
     candidates.push({
       elementHtml: (el as HTMLElement).outerHTML.slice(0, 300),
+      dataItemId: el.getAttribute("data-item-id") || undefined,
       name,
       label,
       type,


### PR DESCRIPTION
## 関連

- Closes #322 (コア機能)
- 関連: #318 (画面項目定義) / #323 (既存画面抽出)
- base: \`main\`

## 概要

画面デザイン (GrapesJS) の input / select / textarea に **\`data-item-id\`** を自動発番し、画面項目定義の \`ScreenItem.id\` と 1:1 でリンクする基盤を整える。これで:

- 同じ画面要素に対する「画面デザインから追加」再抽出が **同一の ScreenItem に対応づく** (べき等)
- 将来 (follow-up): Designer で要素選択 → ScreenItemsView で該当項目ハイライト、その逆方向の連動が可能に

## 主な変更

### 新規 utility
- [\`grapes/dataItemId.ts\`](designer/src/grapes/dataItemId.ts):
  - \`isFormField(cmp)\`: input / select / textarea 判定 (button/submit/reset/hidden/image は除外)
  - \`ensureDataItemId(cmp)\`: form field であり data-item-id 未設定なら UUID 発番 → true
  - \`attachDataItemIdAutoAssign(editor)\`: \`component:add\` イベントで自身 + 子孫を再帰走査して自動発番
  - \`assignAllMissingDataItemIds(editor)\`: 明示的な一括発番 (follow-up 用の API)

### Designer 統合
- [\`Designer.tsx\`](designer/src/components/Designer.tsx) の \`onEditor\` で \`attachDataItemIdAutoAssign\` を呼び出し、unsubscribe も cleanup で回収

### extractor 拡張
- [\`screenItemExtractor.ts\`](designer/src/utils/screenItemExtractor.ts): \`ExtractedCandidate.dataItemId\` を追加、\`data-item-id\` 属性を読み取って載せる

### ScreenItemsView 統合
- 候補追加ロジックで \`candidate.dataItemId\` があれば \`ScreenItem.id\` として採用、無ければ従来通り \`generateUUID()\`

## 仕様逐条突合

### #322 完了条件
- ✓ 新規画面のフォーム要素に data-item-id が自動付与される → \`attachDataItemIdAutoAssign\` + \`component:add\` で発番
- △ **画面項目定義タブで画面選択時に、GrapesJS の data-item-id と突合した項目リストが表示される** → 候補抽出モーダルで dataItemId を拾って ScreenItem.id にリンクする形で実現 (より直接的な「画面デザイン上でハイライト」UI は follow-up)
- ✓ E2E: 既存の screen-items 5 件 pass + extractor Vitest 2 件追加 (dataItemId 抽出)

## レビューで特に見てほしい箇所

- **\`component:add\` 戦略**: ブロック drop 時に発番。既存画面 (data-item-id 無し) の load 時は自動発番しない方針にした。理由: load 時に発番すると全画面がいきなり dirty になって保存プレッシャーを与えるため。既存画面は候補抽出モーダル経由で手動マイグレーションする運用
- **子孫再帰**: ブロック (例: ログインフォーム) は内部に複数の input を持つ → drop 時の component:add は親要素のみ発火することもあるため、walk() で子孫まで回して発番している
- **除外タイプ**: button / submit / reset / hidden / image は除外。\`type\` 属性未指定 (デフォルト text) は対象
- **発番タイミングの副作用**: \`addAttributes\` は \`component:update\` を発火 → markDirty が動く。ユーザーからは「ブロックを drop したら dirty になる」だけで体感通り

## テスト

- Vitest: 504 件 (frontend) + 37 (backend) — 全件 pass
  - 新規: extractor が \`data-item-id\` を抽出、無いと undefined の 2 件
- Playwright: screen-items 5 件 + regression (marker-panel 9 / more-ui 1) 全 15 件 pass
- vite build 成功

**注意**: GrapesJS エディタを必要とするユニットテスト (Designer への統合) は E2E でのみカバー可能。\`attachDataItemIdAutoAssign\` の動作は手動確認推奨 (画面デザインで input をドロップ → 保存 → ScreenItemsView で「画面デザインから追加」→ 候補に \`data-item-id\` が載っているか)。

## UI 影響 / マージ保留フラグ

- [x] **UI 影響あり (マージ前にユーザー目視確認必須)**

### 確認項目

- [ ] 画面デザイナーで input ブロックをドロップ → 保存
- [ ] ブラウザ DevTools で当該 input に \`data-item-id="..."\` が付いているか確認
- [ ] 画面項目定義タブ → 「画面デザインから追加」モーダル → 候補が表示される
- [ ] 候補を選んで追加 → 保存後、\`data/screen-items/{screenId}.json\` の \`items[].id\` が DOM の \`data-item-id\` と一致する
- [ ] 同じ画面で再抽出しても既に追加済み項目は「重複」扱いで disabled (name ベース検出のため name が同じ必要あり)

## spec 側の不足点 / 提案

- GrapesJS サイドバーで選択要素の ScreenItem 情報を inline 表示する UI は別 issue (follow-up)
- ScreenItemsView ⇄ Designer 間の双方向ジャンプ (行クリック → キャンバスでハイライト) も follow-up
- 既存画面 (data-item-id 無し) への一括付与コマンド (ツールバーボタン or save 時の自動発動) も follow-up

## レビュー担当への申し送り

- \`component:add\` の子孫走査はブロック単位を想定。ブロックが動的に子を追加するタイプ (タブ切替でネスト追加される等) で発番漏れる可能性はあるが、現在の blocks.ts では事例なし
- \`assignAllMissingDataItemIds\` は公開 API として用意したが呼び出し側は未実装。一括マイグレーション UI を今後追加するときに使う