### PR TITLE
fix(flow): project.json データ消失バグの修正 (urgent)

### DIFF
--- a/designer/src/store/flowStore.test.ts
+++ b/designer/src/store/flowStore.test.ts
@@ -1,0 +1,158 @@
+/**
+ * flowStore データ消失ガードの回帰テスト (2026-04-22)。
+ *
+ * 2 つの destructive path をカバー:
+ * 1. loadProject: backend が null を返した時、空 project を backend に書き戻さないこと
+ * 2. saveProject / persistProject: 空 project で非空 backend を上書きしないこと
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { FlowStorageBackend } from "./flowStore";
+import {
+  loadProject,
+  saveProject,
+  persistProject,
+  setFlowStorageBackend,
+  setFlowDraftMode,
+} from "./flowStore";
+import type { FlowProject } from "../types/flow";
+
+function mkEmptyProject(): FlowProject {
+  return {
+    version: 1,
+    name: "テスト",
+    screens: [],
+    groups: [],
+    edges: [],
+    updatedAt: new Date().toISOString(),
+  } as FlowProject;
+}
+
+function mkNonEmptyProject(): FlowProject {
+  return {
+    version: 1,
+    name: "実プロジェクト",
+    screens: [
+      { id: "s1", no: 1, name: "画面1", type: "standard", description: "", path: "", position: { x: 0, y: 0 }, size: { w: 200, h: 100 }, hasDesign: false, createdAt: "", updatedAt: "" } as any,
+    ],
+    groups: [],
+    edges: [],
+    updatedAt: new Date().toISOString(),
+  } as FlowProject;
+}
+
+describe("flowStore データ消失ガード (2026-04-22)", () => {
+  beforeEach(() => {
+    setFlowStorageBackend(null);
+    setFlowDraftMode(false);
+    localStorage.clear();
+  });
+
+  it("loadProject: backend が null を返しても空 project を backend に書き戻さない", async () => {
+    const saveMock = vi.fn().mockResolvedValue(undefined);
+    const backend: FlowStorageBackend = {
+      loadProject: vi.fn().mockResolvedValue(null),
+      saveProject: saveMock,
+      deleteScreenData: vi.fn().mockResolvedValue(undefined),
+    };
+    setFlowStorageBackend(backend);
+
+    const result = await loadProject();
+
+    expect(result.screens).toHaveLength(0);
+    // 重要: backend.saveProject が呼ばれていないこと
+    expect(saveMock).not.toHaveBeenCalled();
+  });
+
+  it("loadProject: backend null + localStorage 空でも backend には書き戻さない", async () => {
+    const saveMock = vi.fn().mockResolvedValue(undefined);
+    const backend: FlowStorageBackend = {
+      loadProject: vi.fn().mockResolvedValue(null),
+      saveProject: saveMock,
+      deleteScreenData: vi.fn().mockResolvedValue(undefined),
+    };
+    setFlowStorageBackend(backend);
+    // localStorage も空
+    localStorage.removeItem("flow-project");
+
+    const result = await loadProject();
+
+    expect(result.name).toBe("新規プロジェクト");
+    expect(saveMock).not.toHaveBeenCalled();
+  });
+
+  it("loadProject: localStorage に有意データがあれば backend に移行する", async () => {
+    const saveMock = vi.fn().mockResolvedValue(undefined);
+    const backend: FlowStorageBackend = {
+      loadProject: vi.fn().mockResolvedValue(null),
+      saveProject: saveMock,
+      deleteScreenData: vi.fn().mockResolvedValue(undefined),
+    };
+    setFlowStorageBackend(backend);
+    localStorage.setItem("flow-project", JSON.stringify(mkNonEmptyProject()));
+
+    const result = await loadProject();
+
+    expect(result.screens).toHaveLength(1);
+    // 有意データがあるので backend 移行は走る
+    expect(saveMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("saveProject: 空 project で非空 backend を上書きしない (data-loss guard)", async () => {
+    const saveMock = vi.fn().mockResolvedValue(undefined);
+    const backend: FlowStorageBackend = {
+      loadProject: vi.fn().mockResolvedValue(mkNonEmptyProject()),
+      saveProject: saveMock,
+      deleteScreenData: vi.fn().mockResolvedValue(undefined),
+    };
+    setFlowStorageBackend(backend);
+
+    await saveProject(mkEmptyProject());
+
+    // backend にデータがあるので空上書きは拒否される
+    expect(saveMock).not.toHaveBeenCalled();
+  });
+
+  it("saveProject: 空 project でも backend が空ならそのまま保存する (初回)", async () => {
+    const saveMock = vi.fn().mockResolvedValue(undefined);
+    const backend: FlowStorageBackend = {
+      loadProject: vi.fn().mockResolvedValue(null),
+      saveProject: saveMock,
+      deleteScreenData: vi.fn().mockResolvedValue(undefined),
+    };
+    setFlowStorageBackend(backend);
+
+    await saveProject(mkEmptyProject());
+
+    // backend にデータなし → 書き込み成功
+    expect(saveMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("saveProject: 非空 project はガードの影響を受けない (通常の保存)", async () => {
+    const saveMock = vi.fn().mockResolvedValue(undefined);
+    const backend: FlowStorageBackend = {
+      loadProject: vi.fn().mockResolvedValue(mkNonEmptyProject()),
+      saveProject: saveMock,
+      deleteScreenData: vi.fn().mockResolvedValue(undefined),
+    };
+    setFlowStorageBackend(backend);
+
+    await saveProject(mkNonEmptyProject());
+
+    // 非空 → 無条件保存
+    expect(saveMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("persistProject: 同じ data-loss guard が適用される", async () => {
+    const saveMock = vi.fn().mockResolvedValue(undefined);
+    const backend: FlowStorageBackend = {
+      loadProject: vi.fn().mockResolvedValue(mkNonEmptyProject()),
+      saveProject: saveMock,
+      deleteScreenData: vi.fn().mockResolvedValue(undefined),
+    };
+    setFlowStorageBackend(backend);
+
+    await persistProject(mkEmptyProject());
+
+    expect(saveMock).not.toHaveBeenCalled();
+  });
+});

--- a/designer/src/store/flowStore.ts
+++ b/designer/src/store/flowStore.ts
@@ -151,22 +151,44 @@ function ensureProjectDefaults(project: FlowProject): FlowProject {
   return project;
 }
 
-/** プロジェクトを読み込み */
+/** プロジェクトを読み込み
+ *
+ * !!! データ消失バグ修正 (2026-04-22) !!!
+ *
+ * 以前は backend.loadProject() が null を返した場合、createEmptyProject() を
+ * 即座に backend に書き戻していた。これが Playwright テスト並行実行や
+ * designer-mcp 一瞬不通などの race condition で backend が誤って null を
+ * 返した際に、既存の data/project.json を空で上書きしてデータ消失を引き起
+ * こしていた (ユーザー報告で検知: 画面作成ダイアログ閉じたら画面一覧
+ * が空になった現象)。
+ *
+ * 今後は null を受け取っても backend への書き戻しは行わない。最初の
+ * 明示的な saveProject / persistProject が走るまで backend は触らない。
+ * localStorage 側のみ（接続なし時のフォールバック）は従来通り。
+ */
 export async function loadProject(): Promise<FlowProject> {
   if (_backend) {
     const data = await _backend.loadProject();
     if (data) return ensureProjectDefaults(data as FlowProject);
-    // ファイルが存在しない → localStorage から移行
+    // backend にファイルが存在しない (or readProject が一時的に null を返した)
+    // → localStorage に有意義なデータがあればそれを使う、なければメモリのみの空 project
     const local = loadProjectFromLocalStorage();
-    if (local) {
-      await _backend.saveProject(local);
-      console.log("[flowStore] Migrated project from localStorage to file");
+    if (local && (local.screens.length > 0 || (local.tables?.length ?? 0) > 0 || (local.actionGroups?.length ?? 0) > 0)) {
+      // localStorage に意味のあるデータがある場合のみ、backend への移行を試みる。
+      // 空 localStorage をきっかけに既存 backend を上書きする事態を避ける。
+      try {
+        await _backend.saveProject(local);
+        console.log("[flowStore] Migrated project from localStorage to file");
+      } catch (e) {
+        console.warn("[flowStore] migration save failed, returning local without persist", e);
+      }
       return local;
     }
-    // 新規プロジェクト
-    const empty = createEmptyProject();
-    await _backend.saveProject(empty);
-    return empty;
+    // 空 localStorage + null backend → メモリ上で空プロジェクトを返すだけに留める。
+    // backend へ書き込むと既存ファイルを壊す race condition になり得る。
+    // 本当に新規プロジェクトなら、ユーザーの最初の操作 (画面追加 → save) で
+    // persistProject 経由で backend に初めて書き込まれる。
+    return createEmptyProject();
   }
   // localStorage フォールバック
   return loadProjectFromLocalStorage() ?? (() => {
@@ -176,7 +198,17 @@ export async function loadProject(): Promise<FlowProject> {
   })();
 }
 
-/** プロジェクトを保存（draftMode 有効時は localStorage のドラフトに書き込む） */
+/** プロジェクトを保存（draftMode 有効時は localStorage のドラフトに書き込む）
+ *
+ * !!! データ消失防止ガード (2026-04-22) !!!
+ *
+ * 書き込み前に backend の既存データと比較し、「既存に有意義なデータ
+ * (screens/tables/actionGroups が 1 件以上) があるのに空プロジェクトで
+ * 上書きしようとしている」ケースを検知したらキャンセル + warning ログ。
+ * 普通の編集フロー (screen 削除 → 0 件に) は一旦有意義だった後に空に
+ * なるので、このガードは「0 件で始まるセッションから 0 件のまま書き込む」
+ * race conditionケースのみを弾く意図。
+ */
 export async function saveProject(project: FlowProject): Promise<void> {
   project.updatedAt = now();
   if (_draftMode) {
@@ -185,16 +217,61 @@ export async function saveProject(project: FlowProject): Promise<void> {
     return;
   }
   if (_backend) {
+    // データ消失防止ガード: 空プロジェクトで非空ファイルを上書きしないかチェック
+    const isProjectEmpty =
+      (project.screens?.length ?? 0) === 0 &&
+      (project.tables?.length ?? 0) === 0 &&
+      (project.actionGroups?.length ?? 0) === 0;
+    if (isProjectEmpty) {
+      try {
+        const current = await _backend.loadProject() as FlowProject | null;
+        const hasExistingData = !!current && (
+          (current.screens?.length ?? 0) > 0 ||
+          (current.tables?.length ?? 0) > 0 ||
+          (current.actionGroups?.length ?? 0) > 0
+        );
+        if (hasExistingData) {
+          console.warn("[flowStore] saveProject canceled: refusing to overwrite non-empty file with empty project (data-loss guard)");
+          return;
+        }
+      } catch {
+        // read 失敗は書き込みを続行 (backend 一時不通等で loadProject が 500 等の場合、
+        // write は成功する可能性があるので試す)
+      }
+    }
     await _backend.saveProject(project);
     return;
   }
   localStorage.setItem(FLOW_PROJECT_KEY, JSON.stringify(project));
 }
 
-/** ドラフトを介さず必ず永続化する（明示的保存ボタン用） */
+/** ドラフトを介さず必ず永続化する（明示的保存ボタン用）
+ *
+ * saveProject と同じデータ消失ガードを適用 (2026-04-22)。
+ */
 export async function persistProject(project: FlowProject): Promise<void> {
   project.updatedAt = now();
   if (_backend) {
+    const isProjectEmpty =
+      (project.screens?.length ?? 0) === 0 &&
+      (project.tables?.length ?? 0) === 0 &&
+      (project.actionGroups?.length ?? 0) === 0;
+    if (isProjectEmpty) {
+      try {
+        const current = await _backend.loadProject() as FlowProject | null;
+        const hasExistingData = !!current && (
+          (current.screens?.length ?? 0) > 0 ||
+          (current.tables?.length ?? 0) > 0 ||
+          (current.actionGroups?.length ?? 0) > 0
+        );
+        if (hasExistingData) {
+          console.warn("[flowStore] persistProject canceled: refusing to overwrite non-empty file with empty project (data-loss guard)");
+          return;
+        }
+      } catch {
+        // read 失敗は書き込みを続行
+      }
+    }
     await _backend.saveProject(project);
   } else {
     localStorage.setItem(FLOW_PROJECT_KEY, JSON.stringify(project));


### PR DESCRIPTION
## 関連

- **緊急修正**: ユーザーから画面作成ダイアログ閉じたら画面一覧が空になった報告 (2026-04-22)
- base: \`main\`
- このセッションで data/project.json が \`screens:[]\` で上書きされていた事実を確認済み。seed.mjs で復旧済

## バグ

1. 画面デザイン or 画面一覧で「新規画面」ダイアログを閉じると、画面一覧から既存画面含めて全て消える
2. \`data/project.json\` の \`screens / tables / actionGroups\` が \`[]\` になる
3. 個別ファイル (\`data/screens/*.json\` 等) は残っているが、project.json のインデックスが壊れているため UI 上見えなくなる

## 原因

\`flowStore.loadProject()\` (designer/src/store/flowStore.ts:155-170) の destructive path:

\`\`\`typescript
if (_backend) {
  const data = await _backend.loadProject();
  if (data) return ensureProjectDefaults(data as FlowProject);
  ...
  // 新規プロジェクト
  const empty = createEmptyProject();
  await _backend.saveProject(empty);  // ← BUG: 常に書き戻してしまう
  return empty;
}
\`\`\`

backend が **null を返した瞬間に** \`createEmptyProject()\` を backend に書き戻していた。Playwright 並行実行や designer-mcp 一瞬不通などの race condition で backend が誤って null を返した瞬間、既存の \`data/project.json\` を空で上書きしていた。

バックアップファイル \`data/project.json.bak.1776800573\` に以下のコンテンツを観測、これが \`createEmptyProject()\` の出力と完全一致:
\`\`\`json
{
  "version": 1,
  "name": "新規プロジェクト",
  "screens": [], "groups": [], "edges": [],
  "updatedAt": "2026-04-21T15:08:22.961Z"
}
\`\`\`

## 修正

1. **loadProject**: backend が null を返しても backend への書き戻しを一切しない。localStorage に有意データ (screens/tables/actionGroups のいずれかが非空) がある時のみ backend に移行を試みる。空 localStorage + null backend ならメモリ上の空プロジェクトを返すだけ
2. **saveProject / persistProject**: 書き込み前に backend の既存状態を照会し、「空プロジェクトで非空ファイルを上書きしそう」なら警告ログ + 書き込みキャンセル (data-loss guard)

普通の編集フロー (screen 削除 → 0 件に) は一旦有意だった後の編集なので、中間状態 (非空) が既に backend にあるはずなので影響なし。このガードは「backend が無くなったことにして新規セッションで空のまま save」に特化。

## 仕様逐条突合

- ✓ loadProject の auto-save-empty を削除 → [flowStore.ts:166-194](designer/src/store/flowStore.ts#L166-L194)
- ✓ saveProject に data-loss guard 追加 → [flowStore.ts:208-234](designer/src/store/flowStore.ts#L208-L234)
- ✓ persistProject に同じ data-loss guard 追加 → [flowStore.ts:239-258](designer/src/store/flowStore.ts#L239-L258)
- ✓ 回帰テスト 7 件追加 → [flowStore.test.ts](designer/src/store/flowStore.test.ts)

## テスト

- Vitest: 509 件 (新規 7 件 flowStore) pass
- Playwright: screen-items 5 件 + marker-panel 9 件 = 14 件 pass
- \`vite build\` 成功

## UI 影響 / マージ保留フラグ

- [x] **UI 影響あり (データ消失修正、緊急マージ推奨)**

### 確認項目

- [ ] main マージ後、\`node docs/sample-project/seed.mjs\` で project.json を再生成 (既に実行済)
- [ ] 画面一覧で新規画面作成 → ダイアログ閉じる → 画面一覧にちゃんと追加される
- [ ] 複数タブで同時に画面一覧開く → どちらかで画面追加しても、既存データは維持される
- [ ] console に \`saveProject canceled: refusing to overwrite...\` が出る場面があれば、何が消失を試みたか確認

## 影響範囲

- このバグは **長期間存在していた**可能性が高い (loadProject の問題は #18 等の古い issue まで遡れる実装)
- Playwright テスト (localStorage seed + 並行実行) と designer-mcp の race condition が重なった時に発動
- 実際にユーザーの data/project.json を空化した事案が今回発覚したため、main への緊急マージ推奨

## レビュー担当への申し送り

- 正直 \`loadProject\` の destructive save は長く潜在していたと思われる。Playwright テスト体制が整い並行実行が増えたタイミングで顕在化
- もし **「新規プロジェクトは backend に自動作成されるべき」** という要件があれば、ユーザー操作トリガー (FlowEditor 初回 mount 時等) で明示的に \`persistProject(createEmptyProject())\` を呼ぶ実装に切り替えるべき。ただしそれ自体が同じ race condition を生むリスクあり
- 今回のガードは「空で非空を上書きしない」のみ。非空で非空の上書き (例えば古いバージョンの project を save してしまう) は別問題で、将来 optimistic concurrency (updatedAt 比較) を検討する余地あり