### PR TITLE
docs: Closes 記法を正しく + Command を Skill 形式に移行

### DIFF
--- a/.claude/skills/review-issue/SKILL.md
+++ b/.claude/skills/review-issue/SKILL.md
@@ -1,12 +1,14 @@
 ---
+name: review-issue
 description: ISSUE の実装計画が全 PR 横断で網羅されているかを検証し、結果を ISSUE コメントに投稿
 argument-hint: <ISSUE 番号>
+disable-model-invocation: true
 ---
 
 <!--
   使い方:
     - 新しい Claude Code セッション (別ウィンドウ/別タブ) で `/clear` してから起動
-    - `/review-issue 148` のように ISSUE 番号を指定
+    - `/review-issue 148` のように ISSUE 番号を指定して **明示的に** 呼び出す
     - ISSUE に紐づく PR が「全て」マージ済みになったタイミングで実行する
     - レビュー結果は `gh issue comment` で ISSUE に投稿される
 
@@ -14,6 +16,10 @@ argument-hint: <ISSUE 番号>
     - 1 ISSUE が複数 PR に分割された場合でも、ISSUE 本文の実装計画が漏れなく実装されたかを確認する
     - `/review-pr` は PR 単位のコード品質・spec 準拠を見る。こちらは **ISSUE 単位の網羅性** を見る
     - AI エージェントは ISSUE のチェックリスト項目を取りこぼしやすいため、最終的な deliverable 確認が重要
+
+  発動制御:
+    - frontmatter の `disable-model-invocation: true` により、Claude が description マッチで
+      自動起動することを禁止している。ユーザーが明示的に `/review-issue <N>` と打った時のみ起動。
 -->
 
 ISSUE #$ARGUMENTS の実装計画が、紐づく全 PR 横断で網羅されているかを検証してください。

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,18 +1,25 @@
 ---
+name: review-pr
 description: PR を別セッション視点で厳格にレビューし、結果を PR コメントに投稿
 argument-hint: <PR 番号>
+disable-model-invocation: true
 ---
 
 <!--
   使い方:
     - 新しい Claude Code セッション (別ウィンドウ/別タブ) で `/clear` してから起動
-    - `/review-pr 149` のように PR 番号を指定
+    - `/review-pr 149` のように PR 番号を指定して **明示的に** 呼び出す
     - レビュー結果は `gh pr comment` で PR に投稿される
 
   目的:
     - 実装担当とは別セッションで独立レビューすることで、筆者の盲点を洗い出す
     - 「機械 CI = 網羅的・構文的チェック」に加え「意味論的・仕様準拠レビュー」を担う
     - Max プラン内で完結 (追加 API 課金なし)
+
+  発動制御:
+    - frontmatter の `disable-model-invocation: true` により、Claude が description マッチで
+      自動起動することを禁止している。ユーザーが明示的に `/review-pr <N>` と打った時のみ起動。
+    - 「レビュー指摘を確認して」「レビューに対応して」等の指示では起動しない (別ワークフロー)。
 -->
 
 PR #$ARGUMENTS を独立視点で厳格にレビューしてください。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,13 @@ URL 規約: **`/category/feature[/:id]`** 形式（Java 風階層）。ルート
   - シリーズ起票された ISSUE 群で、起票時点で PR グルーピングが宣言されている
   - 同じ画面に対する複数 ISSUE の同時修正
 
-  束ねる場合: PR description に `Closes #A, #B, #C` で全 ISSUE を明示、コミットは ISSUE 単位で分ける。UI 目視確認 / `/review-pr` は**統合 PR 単位で 1 回**。Never commit directly to `main`. Branch naming: `feat/issue-<N>-<slug>` (単独 PR) / `feat/<topic-slug>` (統合 PR) for features, `fix/issue-<N>` or `fix/<slug>` for bug fixes, `docs/<slug>` for documentation-only changes. Create the branch from `origin/main` before starting work.
+  束ねる場合: PR description に **各 ISSUE の前に `Closes` キーワードを必ず書く** (GitHub 仕様 "Use full syntax for each issue")。改行区切り推奨:
+  ```
+  Closes #A
+  Closes #B
+  Closes #C
+  ```
+  **NG**: `Closes #A, #B, #C` は**先頭しか自動 close されない** (PR #340 で実例あり)。コミットは ISSUE 単位で分ける。UI 目視確認 / `/review-pr` は**統合 PR 単位で 1 回**。Never commit directly to `main`. Branch naming: `feat/issue-<N>-<slug>` (単独 PR) / `feat/<topic-slug>` (統合 PR) for features, `fix/issue-<N>` or `fix/<slug>` for bug fixes, `docs/<slug>` for documentation-only changes. Create the branch from `origin/main` before starting work.
 - PRs are squash-merged into `main`. The PR title should include the issue number (e.g., `feat(ui): ... (#83)`) so the merge commit references it.
 - `data/` directory is gitignored — runtime data only
 - Themes: standard (default Bootstrap), card, compact, dark — CSS injected into GrapesJS canvas iframe
@@ -169,8 +175,8 @@ URL 規約: **`/category/feature[/:id]`** 形式（Java 風階層）。ルート
 
 - PR 作成時は [`.github/pull_request_template.md`](.github/pull_request_template.md) を**全項目埋める**。不要な項目は削除せず「N/A」と明記 (レビュアーが見落としと区別するため)
 - 「仕様逐条突合 (自己申告)」節は各条項を `file:line` で**個別に列挙**。「全条項 ✓」の一括表記は不可。大規模実装の完了報告前に仕様を逐条突合すること
-- 大規模実装 / spec 絡み / UI 影響のある PR は、別の Claude Code セッション (新しいウィンドウで `/clear` 後) で [`/review-pr <N>`](.claude/commands/review-pr.md) を実行し、独立レビュー結果を PR コメントに投稿してからマージ判断する
-- **1 ISSUE を複数 PR に分割したケース**は、全 PR マージ後に [`/review-issue <N>`](.claude/commands/review-issue.md) で ISSUE 単位の実装網羅性を監査する。PR 単位レビューでは検出できない実装漏れ (ISSUE 計画と全 PR 実装の突合) を拾う
+- 大規模実装 / spec 絡み / UI 影響のある PR は、別の Claude Code セッション (新しいウィンドウで `/clear` 後) で [`/review-pr <N>`](.claude/skills/review-pr/SKILL.md) を実行し、独立レビュー結果を PR コメントに投稿してからマージ判断する
+- **1 ISSUE を複数 PR に分割したケース**は、全 PR マージ後に [`/review-issue <N>`](.claude/skills/review-issue/SKILL.md) で ISSUE 単位の実装網羅性を監査する。PR 単位レビューでは検出できない実装漏れ (ISSUE 計画と全 PR 実装の突合) を拾う
 - レビュー結果が Must-fix を含む場合はマージしない。Should-fix は対応可否をユーザーに確認
 - UI 影響のある PR は auto テスト pass ≠ マージ可。**ユーザーの目視確認必須**
 
@@ -181,7 +187,13 @@ ISSUE 本文の冒頭に `## 🔗 統合 PR 情報` セクションがある ISS
 1. セクションに記載された **統合ブランチ** を `origin/main` (または指定 base) から切る (既に存在すれば checkout して継続)
 2. 自分の担当 ISSUE 分のコミットをそのブランチに積む (ISSUE 単位で commit メッセージを分ける)
 3. **他の統合対象 ISSUE が全て完了するまで PR を作らない** (draft も不可)
-4. 最後の ISSUE 完了時に PR を作成、description に `Closes #A, #B, #C` で全 ISSUE を列挙
+4. 最後の ISSUE 完了時に PR を作成、description に **各 ISSUE の前に `Closes` を必ず書いて** 全 ISSUE を列挙 (GitHub 仕様: 改行区切り推奨):
+   ```
+   Closes #A
+   Closes #B
+   Closes #C
+   ```
+   **NG**: `Closes #A, #B, #C` は先頭しか自動 close されない
 5. UI 目視確認 / `/review-pr` は統合 PR 単位で 1 回のみ (個別 ISSUE で実行しない)
 
 ユーザーからの指示が `#<N> やって` のように単一 ISSUE 番号でも、本文に本セクションがあれば上記に従う。セクションが無い場合は通常の 1 ISSUE = 1 PR 運用。

--- a/docs/pr-review-workflow.md
+++ b/docs/pr-review-workflow.md
@@ -5,8 +5,8 @@
 AI エージェント (Claude Code) 向けの規則・手順書は別途以下にある:
 
 - [`.github/pull_request_template.md`](../.github/pull_request_template.md) — 実装 Claude が PR 本文を埋める時のテンプレ
-- [`.claude/commands/review-pr.md`](../.claude/commands/review-pr.md) — PR レビュー Claude への手順書 (`/review-pr <N>` で起動)
-- [`.claude/commands/review-issue.md`](../.claude/commands/review-issue.md) — ISSUE 完了監査 Claude への手順書 (`/review-issue <N>` で起動)
+- [`.claude/skills/review-pr/SKILL.md`](../.claude/skills/review-pr/SKILL.md) — PR レビュー Claude への手順書 (`/review-pr <N>` で起動)
+- [`.claude/skills/review-issue/SKILL.md`](../.claude/skills/review-issue/SKILL.md) — ISSUE 完了監査 Claude への手順書 (`/review-issue <N>` で起動)
 - [`CLAUDE.md`](../CLAUDE.md) の「PR 作成・レビューの規約」節 — 全 Claude セッションに効く規則
 
 ---
@@ -186,8 +186,8 @@ Step 2 と同じ: 新ウィンドウ → `/clear` → `/review-pr <N>`
 | ファイル | 役割 | 誰が読む |
 |---|---|---|
 | `.github/pull_request_template.md` | PR 作成時の briefing | 実装 Claude |
-| `.claude/commands/review-pr.md` | PR レビュー手順書 | レビュー Claude |
-| `.claude/commands/review-issue.md` | ISSUE 完了監査手順書 | レビュー Claude |
+| `.claude/skills/review-pr/SKILL.md` | PR レビュー手順書 | レビュー Claude |
+| `.claude/skills/review-issue/SKILL.md` | ISSUE 完了監査手順書 | レビュー Claude |
 | `CLAUDE.md` の「PR 作成・レビューの規約」 | 全体ルール | 全 Claude セッション |
 | `tmp/review-cache/` | レビュー結果の一時保存 (gitignored) | 人間 / Claude |
 | **このファイル (`docs/pr-review-workflow.md`)** | 運用手引き | **あなた (人間)** |


### PR DESCRIPTION
## 関連

- Closes N/A (ISSUE なし、運用修正)
- 仕様: N/A

## 概要

PR #340 マージ時に `Closes #331, #333, #332, #334` の先頭のみ自動 close された事故を受けて、GitHub 公式仕様 "Use full syntax for each issue" に従う正しい記法に CLAUDE.md を修正。併せて Command を Skill 形式に移行し `disable-model-invocation: true` で誤発動を構造的に防ぐ。

## 主な変更

- **CLAUDE.md**: `Closes #A, #B, #C` 記法を「各 ISSUE 前に `Closes` を書く改行区切り」形式に修正 (2 箇所)
- **Command → Skill 移行**:
  - `.claude/commands/review-pr.md` → `.claude/skills/review-pr/SKILL.md`
  - `.claude/commands/review-issue.md` → `.claude/skills/review-issue/SKILL.md`
- **frontmatter に `disable-model-invocation: true` 追加**: description マッチによる Claude 自動起動を禁止 ([公式仕様](https://code.claude.com/docs/en/skills.md#control-who-invokes-a-skill))
- **ファイル path 参照更新**: CLAUDE.md (2) / docs/pr-review-workflow.md (4)

## 仕様逐条突合

N/A — spec 文書の変更なし。運用規約と Skill 定義のみ。

## レビューで特に見てほしい箇所

- CLAUDE.md の closes 記法 (改行区切りが正しく書かれているか)
- SKILL.md の frontmatter `disable-model-invocation: true` が定義されているか
- path 参照の漏れがないか (Grep で 6 箇所確認済み)

## テスト

- N/A (docs / Skill 定義の変更のみ)
- 事後検証: マージ後、Sonnet セッションで「レビュー指摘を確認して」と指示して `/review-pr` が起動しないことを確認

## UI 影響 / マージ保留フラグ

- [ ] UI 影響あり
- [x] UI 影響なし (docs / Skill 定義の変更のみ、auto テスト pass でマージ可)

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

運用規約の修正。コード動作への影響なし。
