### PR TITLE
feat(screen-items): 画面デザイナーから AI 命名ボタン (サーバ経由 claude CLI) (#337)

### DIFF
--- a/designer-mcp/src/aiRename.ts
+++ b/designer-mcp/src/aiRename.ts
@@ -1,0 +1,204 @@
+/**
+ * ブラウザからの「IDを AI で再命名」ボタン用 HTTP endpoints (#337)。
+ *
+ * GET  /ai/rename-screen-ids/auth-check  → { authenticated: boolean, message?: string }
+ * POST /ai/rename-screen-ids/propose     → { mapping: Record<string,string> }
+ *
+ * propose は SKILL.md を読み込み `claude -p` を spawn し、
+ * stream-json を readline で parse しながら aiRenameProgress を対象 clientId へ送信する。
+ * 完了後に FINAL_MAPPING: {...} 行から mapping を抽出して返す。
+ */
+import { execFileSync, spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { wsBridge } from "./wsBridge.js";
+
+const SKILL_PATH = ".claude/skills/rename-screen-ids/SKILL.md";
+const TIMEOUT_MS = 60_000;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export interface AiRenameProgressEvent {
+  stage: "auth-check" | "analyzing" | "inferring" | "proposed" | "applying" | "done" | "error";
+  message: string;
+  error?: string;
+  mapping?: Record<string, string>;
+}
+
+function sendProgress(clientId: string, event: AiRenameProgressEvent): void {
+  wsBridge.sendToClient(clientId, "aiRenameProgress", event);
+}
+
+function jsonBody(res: ServerResponse, status: number, body: unknown): void {
+  const json = JSON.stringify(body);
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(json);
+}
+
+async function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
+    req.on("error", reject);
+  });
+}
+
+/** claude auth status で認証確認 */
+function checkAuth(): boolean {
+  try {
+    execFileSync("claude", ["auth", "status"], { encoding: "utf8", windowsHide: true, timeout: 10_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** GET /ai/rename-screen-ids/auth-check */
+export async function handleAuthCheck(_req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const authenticated = checkAuth();
+  jsonBody(res, authenticated ? 200 : 503, {
+    authenticated,
+    message: authenticated
+      ? "claude CLI に認証されています"
+      : "claude CLI が未認証です。ターミナルで `claude login` を実行してください。",
+  });
+}
+
+/** POST /ai/rename-screen-ids/propose */
+export async function handlePropose(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  let body: { screenId?: string; clientId?: string };
+  try {
+    body = JSON.parse(await readBody(req)) as { screenId?: string; clientId?: string };
+  } catch {
+    jsonBody(res, 400, { error: "リクエストボディが不正です" });
+    return;
+  }
+
+  const { screenId, clientId } = body;
+
+  if (typeof screenId !== "string" || !UUID_RE.test(screenId)) {
+    jsonBody(res, 400, { error: "screenId は UUID 形式で指定してください" });
+    return;
+  }
+  if (typeof clientId !== "string") {
+    jsonBody(res, 400, { error: "clientId は必須です" });
+    return;
+  }
+
+  if (!checkAuth()) {
+    sendProgress(clientId, {
+      stage: "error",
+      message: "claude CLI が未認証です",
+      error: "claude login を実行してください",
+    });
+    jsonBody(res, 503, { error: "claude CLI が未認証です。`claude login` を実行してください。" });
+    return;
+  }
+
+  let skillContent: string;
+  try {
+    skillContent = await fs.readFile(path.resolve(SKILL_PATH), "utf-8");
+  } catch {
+    jsonBody(res, 500, { error: `SKILL.md が見つかりません: ${SKILL_PATH}` });
+    return;
+  }
+
+  const prompt =
+    skillContent +
+    `\n\n引数 $ARGUMENTS = "${screenId}"\n\n` +
+    "**重要**: ブラウザから起動のため Step 4/5 のユーザー対話と apply はスキップ。\n" +
+    "Step 1-3 を実行し、推論した mapping を最終行に `FINAL_MAPPING: {\"oldId\": \"newId\", ...}` の JSON 形式で出力。\n" +
+    "apply_rename_mapping は呼ばない (ブラウザ側で確認後に別途実行される)。";
+
+  sendProgress(clientId, { stage: "analyzing", message: "未命名項目を取得中..." });
+
+  let mapping: Record<string, string> = {};
+  let timedOut = false;
+
+  await new Promise<void>((resolve) => {
+    const child = spawn(
+      "claude",
+      ["-p", prompt, "--mcp-config", "./.mcp.json", "--output-format", "stream-json", "--max-turns", "20"],
+      { cwd: process.cwd(), windowsHide: true },
+    );
+
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill();
+    }, TIMEOUT_MS);
+
+    const rl = createInterface({ input: child.stdout });
+    let inferringNotified = false;
+
+    rl.on("line", (line) => {
+      if (!line.trim()) return;
+
+      // FINAL_MAPPING 行を捕捉
+      const finalMatch = /FINAL_MAPPING:\s*(\{[^}]*\})/.exec(line);
+      if (finalMatch) {
+        try {
+          mapping = JSON.parse(finalMatch[1]) as Record<string, string>;
+        } catch { /* ignore */ }
+        return;
+      }
+
+      // stream-json イベントを parse して進捗通知
+      try {
+        const evt = JSON.parse(line) as Record<string, unknown>;
+        const type = evt.type as string;
+
+        if (type === "assistant" && !inferringNotified) {
+          inferringNotified = true;
+          sendProgress(clientId, { stage: "inferring", message: "業務名を推論中..." });
+        }
+
+        // content_block_delta に text があれば進捗として流す
+        if (type === "content_block_delta") {
+          const delta = evt.delta as Record<string, unknown> | undefined;
+          if (delta?.type === "text_delta") {
+            const text = (delta.text as string ?? "").trim();
+            if (text) {
+              // FINAL_MAPPING 行も delta 内に来る場合に備えて再チェック
+              const fm = /FINAL_MAPPING:\s*(\{[^}]*\})/.exec(text);
+              if (fm) {
+                try { mapping = JSON.parse(fm[1]) as Record<string, string>; } catch { /* ignore */ }
+              }
+            }
+          }
+        }
+      } catch { /* non-JSON lines are ignored */ }
+    });
+
+    child.stderr.on("data", (_d: Buffer) => { /* suppress stderr */ });
+
+    child.on("close", () => {
+      clearTimeout(timeout);
+      resolve();
+    });
+
+    child.on("error", () => {
+      clearTimeout(timeout);
+      resolve();
+    });
+  });
+
+  if (timedOut) {
+    sendProgress(clientId, {
+      stage: "error",
+      message: "タイムアウト (60秒) しました",
+      error: "claude CLI の実行がタイムアウトしました",
+    });
+    jsonBody(res, 504, { error: "タイムアウト" });
+    return;
+  }
+
+  sendProgress(clientId, {
+    stage: "proposed",
+    message: `${Object.keys(mapping).length} 件のリネームを提案します`,
+    mapping,
+  });
+
+  jsonBody(res, 200, { mapping });
+}

--- a/designer-mcp/src/aiRename.ts
+++ b/designer-mcp/src/aiRename.ts
@@ -30,9 +30,15 @@ function sendProgress(clientId: string, event: AiRenameProgressEvent): void {
   wsBridge.sendToClient(clientId, "aiRenameProgress", event);
 }
 
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+};
+
 function jsonBody(res: ServerResponse, status: number, body: unknown): void {
   const json = JSON.stringify(body);
-  res.writeHead(status, { "Content-Type": "application/json" });
+  res.writeHead(status, { "Content-Type": "application/json", ...CORS_HEADERS });
   res.end(json);
 }
 
@@ -56,7 +62,8 @@ function checkAuth(): boolean {
 }
 
 /** GET /ai/rename-screen-ids/auth-check */
-export async function handleAuthCheck(_req: IncomingMessage, res: ServerResponse): Promise<void> {
+export async function handleAuthCheck(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  if (req.method === "OPTIONS") { res.writeHead(204, CORS_HEADERS); res.end(); return; }
   const authenticated = checkAuth();
   jsonBody(res, authenticated ? 200 : 503, {
     authenticated,
@@ -68,6 +75,7 @@ export async function handleAuthCheck(_req: IncomingMessage, res: ServerResponse
 
 /** POST /ai/rename-screen-ids/propose */
 export async function handlePropose(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  if (req.method === "OPTIONS") { res.writeHead(204, CORS_HEADERS); res.end(); return; }
   let body: { screenId?: string; clientId?: string };
   try {
     body = JSON.parse(await readBody(req)) as { screenId?: string; clientId?: string };

--- a/designer-mcp/src/aiRename.ts
+++ b/designer-mcp/src/aiRename.ts
@@ -127,6 +127,7 @@ export async function handlePropose(req: IncomingMessage, res: ServerResponse): 
 
   let mapping: Record<string, string> = {};
   let timedOut = false;
+  let spawnError = false;
 
   await new Promise<void>((resolve) => {
     const child = spawn(
@@ -189,8 +190,14 @@ export async function handlePropose(req: IncomingMessage, res: ServerResponse): 
       resolve();
     });
 
-    child.on("error", () => {
+    child.on("error", (err) => {
       clearTimeout(timeout);
+      spawnError = true;
+      sendProgress(clientId, sessionId, {
+        stage: "error",
+        message: "claude CLI の起動に失敗しました",
+        error: String(err),
+      });
       resolve();
     });
   });
@@ -202,6 +209,11 @@ export async function handlePropose(req: IncomingMessage, res: ServerResponse): 
       error: "claude CLI の実行がタイムアウトしました",
     });
     jsonBody(res, 504, { error: "タイムアウト" });
+    return;
+  }
+
+  if (spawnError) {
+    jsonBody(res, 500, { error: "claude CLI の起動に失敗しました" });
     return;
   }
 

--- a/designer-mcp/src/aiRename.ts
+++ b/designer-mcp/src/aiRename.ts
@@ -15,7 +15,10 @@ import * as path from "node:path";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { wsBridge } from "./wsBridge.js";
 
-const SKILL_PATH = ".claude/skills/rename-screen-ids/SKILL.md";
+// projectStorage.ts と同一パターン: src/aiRename.ts → src/ → designer-mcp/ → html-designer/
+const PROJECT_ROOT = path.resolve(import.meta.dirname, "../..");
+const SKILL_PATH = path.join(PROJECT_ROOT, ".claude/skills/rename-screen-ids/SKILL.md");
+const MCP_CONFIG = path.join(PROJECT_ROOT, ".mcp.json");
 const TIMEOUT_MS = 60_000;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -26,8 +29,8 @@ export interface AiRenameProgressEvent {
   mapping?: Record<string, string>;
 }
 
-function sendProgress(clientId: string, event: AiRenameProgressEvent): void {
-  wsBridge.sendToClient(clientId, "aiRenameProgress", event);
+function sendProgress(clientId: string, sessionId: string | undefined, event: AiRenameProgressEvent): void {
+  wsBridge.sendToClient(clientId, "aiRenameProgress", { ...event, sessionId });
 }
 
 const CORS_HEADERS = {
@@ -76,15 +79,15 @@ export async function handleAuthCheck(req: IncomingMessage, res: ServerResponse)
 /** POST /ai/rename-screen-ids/propose */
 export async function handlePropose(req: IncomingMessage, res: ServerResponse): Promise<void> {
   if (req.method === "OPTIONS") { res.writeHead(204, CORS_HEADERS); res.end(); return; }
-  let body: { screenId?: string; clientId?: string };
+  let body: { screenId?: string; clientId?: string; sessionId?: string };
   try {
-    body = JSON.parse(await readBody(req)) as { screenId?: string; clientId?: string };
+    body = JSON.parse(await readBody(req)) as { screenId?: string; clientId?: string; sessionId?: string };
   } catch {
     jsonBody(res, 400, { error: "リクエストボディが不正です" });
     return;
   }
 
-  const { screenId, clientId } = body;
+  const { screenId, clientId, sessionId } = body;
 
   if (typeof screenId !== "string" || !UUID_RE.test(screenId)) {
     jsonBody(res, 400, { error: "screenId は UUID 形式で指定してください" });
@@ -96,7 +99,7 @@ export async function handlePropose(req: IncomingMessage, res: ServerResponse): 
   }
 
   if (!checkAuth()) {
-    sendProgress(clientId, {
+    sendProgress(clientId, sessionId, {
       stage: "error",
       message: "claude CLI が未認証です",
       error: "claude login を実行してください",
@@ -107,7 +110,7 @@ export async function handlePropose(req: IncomingMessage, res: ServerResponse): 
 
   let skillContent: string;
   try {
-    skillContent = await fs.readFile(path.resolve(SKILL_PATH), "utf-8");
+    skillContent = await fs.readFile(SKILL_PATH, "utf-8");
   } catch {
     jsonBody(res, 500, { error: `SKILL.md が見つかりません: ${SKILL_PATH}` });
     return;
@@ -120,7 +123,7 @@ export async function handlePropose(req: IncomingMessage, res: ServerResponse): 
     "Step 1-3 を実行し、推論した mapping を最終行に `FINAL_MAPPING: {\"oldId\": \"newId\", ...}` の JSON 形式で出力。\n" +
     "apply_rename_mapping は呼ばない (ブラウザ側で確認後に別途実行される)。";
 
-  sendProgress(clientId, { stage: "analyzing", message: "未命名項目を取得中..." });
+  sendProgress(clientId, sessionId, { stage: "analyzing", message: "未命名項目を取得中..." });
 
   let mapping: Record<string, string> = {};
   let timedOut = false;
@@ -128,8 +131,8 @@ export async function handlePropose(req: IncomingMessage, res: ServerResponse): 
   await new Promise<void>((resolve) => {
     const child = spawn(
       "claude",
-      ["-p", prompt, "--mcp-config", "./.mcp.json", "--output-format", "stream-json", "--max-turns", "20"],
-      { cwd: process.cwd(), windowsHide: true },
+      ["-p", prompt, "--mcp-config", MCP_CONFIG, "--output-format", "stream-json", "--max-turns", "20"],
+      { cwd: PROJECT_ROOT, windowsHide: true },
     );
 
     const timeout = setTimeout(() => {
@@ -159,7 +162,7 @@ export async function handlePropose(req: IncomingMessage, res: ServerResponse): 
 
         if (type === "assistant" && !inferringNotified) {
           inferringNotified = true;
-          sendProgress(clientId, { stage: "inferring", message: "業務名を推論中..." });
+          sendProgress(clientId, sessionId, { stage: "inferring", message: "業務名を推論中..." });
         }
 
         // content_block_delta に text があれば進捗として流す
@@ -179,7 +182,7 @@ export async function handlePropose(req: IncomingMessage, res: ServerResponse): 
       } catch { /* non-JSON lines are ignored */ }
     });
 
-    child.stderr.on("data", (_d: Buffer) => { /* suppress stderr */ });
+    child.stderr.on("data", (d: Buffer) => { console.error("[aiRename] claude stderr:", d.toString().trim()); });
 
     child.on("close", () => {
       clearTimeout(timeout);
@@ -193,7 +196,7 @@ export async function handlePropose(req: IncomingMessage, res: ServerResponse): 
   });
 
   if (timedOut) {
-    sendProgress(clientId, {
+    sendProgress(clientId, sessionId, {
       stage: "error",
       message: "タイムアウト (60秒) しました",
       error: "claude CLI の実行がタイムアウトしました",
@@ -202,7 +205,7 @@ export async function handlePropose(req: IncomingMessage, res: ServerResponse): 
     return;
   }
 
-  sendProgress(clientId, {
+  sendProgress(clientId, sessionId, {
     stage: "proposed",
     message: `${Object.keys(mapping).length} 件のリネームを提案します`,
     mapping,

--- a/designer-mcp/src/index.ts
+++ b/designer-mcp/src/index.ts
@@ -13,6 +13,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { wsBridge } from "./wsBridge.js";
 import { tools } from "./tools.js";
+import { handleAuthCheck, handlePropose } from "./aiRename.js";
 import { htmlToReact, toPascalCase } from "./reactExporter.js";
 import { readProject, readCustomBlocks, readTable, writeTable, deleteTable as deleteTableFile, writeProject, readErLayout, readActionGroup, writeActionGroup, deleteActionGroup as deleteActionGroupFile, listActionGroups as listActionGroupFiles } from "./projectStorage.js";
 
@@ -1124,6 +1125,11 @@ async function main() {
       try { await server.close(); } catch { /* ignore */ }
     }
   });
+
+  // AI 命名 endpoints (#337)
+  wsBridge.registerHttpHandler("/ai/rename-screen-ids/auth-check", handleAuthCheck);
+  wsBridge.registerHttpHandler("/ai/rename-screen-ids/propose", handlePropose);
+
   console.error(`[MCP] designer-mcp HTTP transport mounted at http://localhost:${process.env.DESIGNER_MCP_PORT ?? 5179}/mcp`);
 }
 

--- a/designer-mcp/src/wsBridge.ts
+++ b/designer-mcp/src/wsBridge.ts
@@ -280,6 +280,15 @@ class WsBridge extends EventEmitter {
     });
   }
 
+  /** 特定クライアントへイベントを送信 */
+  sendToClient(clientId: string, event: string, data: unknown): void {
+    const ws = this.clients.get(clientId);
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    try {
+      ws.send(JSON.stringify({ type: "broadcast", event, data }));
+    } catch { /* ignore */ }
+  }
+
   /** 全クライアント（送信元除く）へブロードキャスト */
   broadcast(event: string, data: unknown, excludeClientId?: string): void {
     const msg = JSON.stringify({ type: "broadcast", event, data });

--- a/designer/src/components/Designer.tsx
+++ b/designer/src/components/Designer.tsx
@@ -435,6 +435,7 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
             onSaveToFile={handleSaveToFile}
             onReset={handleReset}
             backLink={onBack ? { label: screenName ?? "画面デザイン", onClick: onBack } : undefined}
+            screenId={screenId}
           />
         </WithEditor>
 

--- a/designer/src/components/design/DesignSubToolbar.tsx
+++ b/designer/src/components/design/DesignSubToolbar.tsx
@@ -68,9 +68,10 @@ export function DesignSubToolbar({ panelMode, onOpenPanel, activeTheme, onThemeC
   const [aiRenameAuthOk, setAiRenameAuthOk] = useState<boolean | null>(null);
   const [aiRenameProgress, setAiRenameProgress] = useState<AiRenameProgress | null>(null);
   const [aiRenameMapping, setAiRenameMapping] = useState<Record<string, string> | null>(null);
-  const [aiRenameToast, setAiRenameToast] = useState<string | null>(null);
+  const [aiRenameToast, setAiRenameToast] = useState<{ msg: string; warn: boolean } | null>(null);
   const aiRenameAbortRef = useRef<AbortController | null>(null);
   const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const aiRenameSessionRef = useRef<string | null>(null);
 
   // auth-check: MCP 接続時に 1 回だけ実行
   useEffect(() => {
@@ -81,10 +82,11 @@ export function DesignSubToolbar({ panelMode, onOpenPanel, activeTheme, onThemeC
       .catch(() => { setAiRenameAuthOk(false); });
   }, [mcpStatus, screenId]);
 
-  // aiRenameProgress イベントを購読
+  // aiRenameProgress イベントを購読（セッション ID が一致するイベントのみ処理）
   useEffect(() => {
     const unsub = mcpBridge.onBroadcast("aiRenameProgress", (data) => {
-      const ev = data as AiRenameProgress;
+      const ev = data as AiRenameProgress & { sessionId?: string };
+      if (ev.sessionId && ev.sessionId !== aiRenameSessionRef.current) return;
       setAiRenameProgress(ev);
       if (ev.stage === "proposed" && ev.mapping) {
         setAiRenameMapping(ev.mapping);
@@ -93,14 +95,16 @@ export function DesignSubToolbar({ panelMode, onOpenPanel, activeTheme, onThemeC
     return unsub;
   }, []);
 
-  const showToast = useCallback((msg: string) => {
+  const showToast = useCallback((msg: string, warn = false) => {
     if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
-    setAiRenameToast(msg);
+    setAiRenameToast({ msg, warn });
     toastTimerRef.current = setTimeout(() => setAiRenameToast(null), 4000);
   }, []);
 
   const handleAiRename = useCallback(async () => {
     if (!screenId) return;
+    const sessionId = crypto.randomUUID();
+    aiRenameSessionRef.current = sessionId;
     const abort = new AbortController();
     aiRenameAbortRef.current = abort;
     setAiRenameProgress({ stage: "auth-check", message: "接続中..." });
@@ -109,7 +113,7 @@ export function DesignSubToolbar({ panelMode, onOpenPanel, activeTheme, onThemeC
       const res = await fetch(`${MCP_HTTP_BASE}/ai/rename-screen-ids/propose`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ screenId, clientId: mcpBridge.getClientId() }),
+        body: JSON.stringify({ screenId, clientId: mcpBridge.getClientId(), sessionId }),
         signal: abort.signal,
       });
       if (!res.ok) {
@@ -124,6 +128,7 @@ export function DesignSubToolbar({ panelMode, onOpenPanel, activeTheme, onThemeC
   }, [screenId]);
 
   const handleAiRenameCancel = useCallback(() => {
+    aiRenameSessionRef.current = null;
     aiRenameAbortRef.current?.abort();
     setAiRenameProgress(null);
     setAiRenameMapping(null);
@@ -153,7 +158,7 @@ export function DesignSubToolbar({ panelMode, onOpenPanel, activeTheme, onThemeC
     setAiRenameProgress({ stage: "done", message: "完了" });
     setAiRenameMapping(null);
     setTimeout(() => setAiRenameProgress(null), 800);
-    showToast(`リネーム完了: 成功 ${succeeded} 件、失敗 ${failed} 件${skipped > 0 ? `、スキップ ${skipped} 件` : ""}`);
+    showToast(`リネーム完了: 成功 ${succeeded} 件、失敗 ${failed} 件${skipped > 0 ? `、スキップ ${skipped} 件` : ""}`, failed > 0);
   }, [screenId, aiRenameMapping, showToast]);
   const [saveState, setSaveState] = useState<"idle" | "saving" | "saved">("idle");
   const [canUndo, setCanUndo] = useState(false);
@@ -519,8 +524,9 @@ ${html}
       )}
 
       {aiRenameToast && (
-        <div className="ai-rename-toast">
-          <i className="bi bi-check-circle-fill" /> {aiRenameToast}
+        <div className={`ai-rename-toast${aiRenameToast.warn ? " is-warn" : ""}`}>
+          <i className={`bi ${aiRenameToast.warn ? "bi-exclamation-triangle-fill" : "bi-check-circle-fill"}`} />
+          {aiRenameToast.msg}
         </div>
       )}
 

--- a/designer/src/components/design/DesignSubToolbar.tsx
+++ b/designer/src/components/design/DesignSubToolbar.tsx
@@ -3,6 +3,7 @@ import { useEditor } from "@grapesjs/react";
 import type { PanelMode, ThemeId } from "../Designer";
 import type { McpStatus } from "../../mcp/mcpBridge";
 import { mcpBridge } from "../../mcp/mcpBridge";
+import { generateUUID } from "../../utils/uuid";
 import { CodeEditorModal } from "../CodeEditorModal";
 import { SaveBlockModal } from "../SaveBlockModal";
 import { SaveResetButtons } from "../common/SaveResetButtons";
@@ -95,6 +96,8 @@ export function DesignSubToolbar({ panelMode, onOpenPanel, activeTheme, onThemeC
     return unsub;
   }, []);
 
+  useEffect(() => () => { if (toastTimerRef.current) clearTimeout(toastTimerRef.current); }, []);
+
   const showToast = useCallback((msg: string, warn = false) => {
     if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
     setAiRenameToast({ msg, warn });
@@ -103,7 +106,7 @@ export function DesignSubToolbar({ panelMode, onOpenPanel, activeTheme, onThemeC
 
   const handleAiRename = useCallback(async () => {
     if (!screenId) return;
-    const sessionId = crypto.randomUUID();
+    const sessionId = generateUUID();
     aiRenameSessionRef.current = sessionId;
     const abort = new AbortController();
     aiRenameAbortRef.current = abort;
@@ -154,11 +157,10 @@ export function DesignSubToolbar({ panelMode, onOpenPanel, activeTheme, onThemeC
         failed++;
       }
     }
-    const skipped = Object.keys(aiRenameMapping).length - succeeded - failed;
     setAiRenameProgress({ stage: "done", message: "完了" });
     setAiRenameMapping(null);
     setTimeout(() => setAiRenameProgress(null), 800);
-    showToast(`リネーム完了: 成功 ${succeeded} 件、失敗 ${failed} 件${skipped > 0 ? `、スキップ ${skipped} 件` : ""}`, failed > 0);
+    showToast(`リネーム完了: 成功 ${succeeded} 件、失敗 ${failed} 件`, failed > 0);
   }, [screenId, aiRenameMapping, showToast]);
   const [saveState, setSaveState] = useState<"idle" | "saving" | "saved">("idle");
   const [canUndo, setCanUndo] = useState(false);

--- a/designer/src/components/design/DesignSubToolbar.tsx
+++ b/designer/src/components/design/DesignSubToolbar.tsx
@@ -106,12 +106,16 @@ export function DesignSubToolbar({ panelMode, onOpenPanel, activeTheme, onThemeC
     setAiRenameProgress({ stage: "auth-check", message: "接続中..." });
     setAiRenameMapping(null);
     try {
-      await fetch(`${MCP_HTTP_BASE}/ai/rename-screen-ids/propose`, {
+      const res = await fetch(`${MCP_HTTP_BASE}/ai/rename-screen-ids/propose`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ screenId, clientId: mcpBridge.getClientId() }),
         signal: abort.signal,
       });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ error: "不明なエラー" })) as { error?: string };
+        setAiRenameProgress({ stage: "error", message: "サーバーエラー", error: err.error });
+      }
     } catch (e) {
       if ((e as Error).name !== "AbortError") {
         setAiRenameProgress({ stage: "error", message: "通信エラー", error: String(e) });
@@ -570,7 +574,7 @@ function AiRenameModal({ progress, mapping, onCancel, onApply }: AiRenameModalPr
         </div>
 
         <div className="ai-rename-modal-body">
-          <div className={`ai-rename-stage ${isError ? "is-error" : ""}`}>
+          <div className={`ai-rename-stage is-${progress.stage}`}>
             <i className={`bi ${stageIcon[progress.stage]}`} />
             <span>{progress.message}</span>
           </div>

--- a/designer/src/components/design/DesignSubToolbar.tsx
+++ b/designer/src/components/design/DesignSubToolbar.tsx
@@ -1,13 +1,25 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { useEditor } from "@grapesjs/react";
 import type { PanelMode, ThemeId } from "../Designer";
 import type { McpStatus } from "../../mcp/mcpBridge";
+import { mcpBridge } from "../../mcp/mcpBridge";
 import { CodeEditorModal } from "../CodeEditorModal";
 import { SaveBlockModal } from "../SaveBlockModal";
 import { SaveResetButtons } from "../common/SaveResetButtons";
 import { EditorHeader } from "../common/EditorHeader";
 import { useSaveShortcut } from "../../hooks/useSaveShortcut";
 import { upsertCustomBlock } from "../../store/customBlockStore";
+
+const MCP_HTTP_BASE = `http://${window.location.hostname}:5179`;
+
+type AiRenameStage = "auth-check" | "analyzing" | "inferring" | "proposed" | "applying" | "done" | "error";
+
+interface AiRenameProgress {
+  stage: AiRenameStage;
+  message: string;
+  error?: string;
+  mapping?: Record<string, string>;
+}
 
 export const CUSTOM_BLOCK_CATEGORY = "マイブロック";
 
@@ -45,11 +57,100 @@ interface Props {
   isSaving?: boolean;
   onSaveToFile?: () => Promise<void>;
   onReset?: () => Promise<void>;
+  screenId?: string;
 }
 
-export function DesignSubToolbar({ panelMode, onOpenPanel, activeTheme, onThemeChange, mcpStatus, backLink, isDirty, isSaving, onSaveToFile, onReset }: Props) {
+export function DesignSubToolbar({ panelMode, onOpenPanel, activeTheme, onThemeChange, mcpStatus, backLink, isDirty, isSaving, onSaveToFile, onReset, screenId }: Props) {
   const [themeMenuOpen, setThemeMenuOpen] = useState(false);
   const editor = useEditor();
+
+  // ── AI 命名 (#337) ───────────────────────────────────────────────────────
+  const [aiRenameAuthOk, setAiRenameAuthOk] = useState<boolean | null>(null);
+  const [aiRenameProgress, setAiRenameProgress] = useState<AiRenameProgress | null>(null);
+  const [aiRenameMapping, setAiRenameMapping] = useState<Record<string, string> | null>(null);
+  const [aiRenameToast, setAiRenameToast] = useState<string | null>(null);
+  const aiRenameAbortRef = useRef<AbortController | null>(null);
+  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // auth-check: MCP 接続時に 1 回だけ実行
+  useEffect(() => {
+    if (mcpStatus !== "connected" || !screenId) return;
+    fetch(`${MCP_HTTP_BASE}/ai/rename-screen-ids/auth-check`)
+      .then((r) => r.json())
+      .then((d: unknown) => { setAiRenameAuthOk((d as { authenticated: boolean }).authenticated); })
+      .catch(() => { setAiRenameAuthOk(false); });
+  }, [mcpStatus, screenId]);
+
+  // aiRenameProgress イベントを購読
+  useEffect(() => {
+    const unsub = mcpBridge.onBroadcast("aiRenameProgress", (data) => {
+      const ev = data as AiRenameProgress;
+      setAiRenameProgress(ev);
+      if (ev.stage === "proposed" && ev.mapping) {
+        setAiRenameMapping(ev.mapping);
+      }
+    });
+    return unsub;
+  }, []);
+
+  const showToast = useCallback((msg: string) => {
+    if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+    setAiRenameToast(msg);
+    toastTimerRef.current = setTimeout(() => setAiRenameToast(null), 4000);
+  }, []);
+
+  const handleAiRename = useCallback(async () => {
+    if (!screenId) return;
+    const abort = new AbortController();
+    aiRenameAbortRef.current = abort;
+    setAiRenameProgress({ stage: "auth-check", message: "接続中..." });
+    setAiRenameMapping(null);
+    try {
+      await fetch(`${MCP_HTTP_BASE}/ai/rename-screen-ids/propose`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ screenId, clientId: mcpBridge.getClientId() }),
+        signal: abort.signal,
+      });
+    } catch (e) {
+      if ((e as Error).name !== "AbortError") {
+        setAiRenameProgress({ stage: "error", message: "通信エラー", error: String(e) });
+      }
+    }
+  }, [screenId]);
+
+  const handleAiRenameCancel = useCallback(() => {
+    aiRenameAbortRef.current?.abort();
+    setAiRenameProgress(null);
+    setAiRenameMapping(null);
+  }, []);
+
+  const handleAiRenameApply = useCallback(async () => {
+    if (!screenId || !aiRenameMapping) return;
+    const entries = Object.entries(aiRenameMapping);
+    if (entries.length === 0) {
+      setAiRenameProgress(null);
+      setAiRenameMapping(null);
+      showToast("リネーム対象がありません");
+      return;
+    }
+    setAiRenameProgress({ stage: "applying", message: `${entries.length} 件を適用中...` });
+    let succeeded = 0;
+    let failed = 0;
+    for (const [oldId, newId] of entries) {
+      try {
+        await mcpBridge.request("renameScreenItem", { screenId, oldId, newId });
+        succeeded++;
+      } catch {
+        failed++;
+      }
+    }
+    const skipped = Object.keys(aiRenameMapping).length - succeeded - failed;
+    setAiRenameProgress({ stage: "done", message: "完了" });
+    setAiRenameMapping(null);
+    setTimeout(() => setAiRenameProgress(null), 800);
+    showToast(`リネーム完了: 成功 ${succeeded} 件、失敗 ${failed} 件${skipped > 0 ? `、スキップ ${skipped} 件` : ""}`);
+  }, [screenId, aiRenameMapping, showToast]);
   const [saveState, setSaveState] = useState<"idle" | "saving" | "saved">("idle");
   const [canUndo, setCanUndo] = useState(false);
   const [canRedo, setCanRedo] = useState(false);
@@ -277,6 +378,25 @@ ${html}
         }
         centerTools={
           <>
+            {screenId && (
+              <>
+                <button
+                  className="icon-btn"
+                  onClick={() => { void handleAiRename(); }}
+                  disabled={!aiRenameAuthOk || aiRenameProgress !== null}
+                  title={
+                    aiRenameAuthOk === false
+                      ? "claude CLI が未認証です (claude login を実行してください)"
+                      : aiRenameAuthOk === null
+                      ? "認証を確認中..."
+                      : "ID を AI で再命名"
+                  }
+                >
+                  <i className="bi bi-stars" />
+                </button>
+                <div className="divider" />
+              </>
+            )}
             <button className="icon-btn" onClick={handlePreview} title="プレビュー (Ctrl+P)">
               <i className="bi bi-eye" />
             </button>
@@ -385,6 +505,21 @@ ${html}
         }
       />
 
+      {aiRenameProgress && (
+        <AiRenameModal
+          progress={aiRenameProgress}
+          mapping={aiRenameMapping}
+          onCancel={handleAiRenameCancel}
+          onApply={() => { void handleAiRenameApply(); }}
+        />
+      )}
+
+      {aiRenameToast && (
+        <div className="ai-rename-toast">
+          <i className="bi bi-check-circle-fill" /> {aiRenameToast}
+        </div>
+      )}
+
       <CodeEditorModal
         open={codeModalOpen}
         initialHtml={codeModalHtml}
@@ -402,6 +537,92 @@ ${html}
         onClose={() => setSaveBlockOpen(false)}
       />
     </>
+  );
+}
+
+interface AiRenameModalProps {
+  progress: AiRenameProgress;
+  mapping: Record<string, string> | null;
+  onCancel: () => void;
+  onApply: () => void;
+}
+
+function AiRenameModal({ progress, mapping, onCancel, onApply }: AiRenameModalProps) {
+  const isApplying = progress.stage === "applying" || progress.stage === "done";
+  const isProposed = progress.stage === "proposed" && mapping !== null;
+  const isError = progress.stage === "error";
+
+  const stageIcon: Record<AiRenameStage, string> = {
+    "auth-check": "bi-shield-check",
+    "analyzing": "bi-search",
+    "inferring": "bi-cpu",
+    "proposed": "bi-list-check",
+    "applying": "bi-arrow-repeat",
+    "done": "bi-check-circle-fill",
+    "error": "bi-exclamation-triangle-fill",
+  };
+
+  return (
+    <div className="ai-rename-overlay">
+      <div className="ai-rename-modal">
+        <div className="ai-rename-modal-header">
+          <i className="bi bi-stars" /> IDを AI で再命名
+        </div>
+
+        <div className="ai-rename-modal-body">
+          <div className={`ai-rename-stage ${isError ? "is-error" : ""}`}>
+            <i className={`bi ${stageIcon[progress.stage]}`} />
+            <span>{progress.message}</span>
+          </div>
+
+          {isError && progress.error && (
+            <div className="ai-rename-error-detail">{progress.error}</div>
+          )}
+
+          {isProposed && mapping && (
+            <div className="ai-rename-mapping">
+              <p className="ai-rename-mapping-title">
+                以下の {Object.keys(mapping).length} 件をリネームします:
+              </p>
+              <table className="ai-rename-table">
+                <thead>
+                  <tr>
+                    <th>現在の ID</th>
+                    <th>推論した名前</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {Object.entries(mapping).map(([oldId, newId]) => (
+                    <tr key={oldId}>
+                      <td><code>{oldId}</code></td>
+                      <td><code>{newId}</code></td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+
+        <div className="ai-rename-modal-footer">
+          {!isApplying && (
+            <button className="btn-secondary-sm" onClick={onCancel}>
+              キャンセル
+            </button>
+          )}
+          {isProposed && (
+            <button className="btn-primary-sm" onClick={onApply}>
+              <i className="bi bi-check-lg" /> 適用する
+            </button>
+          )}
+          {isError && (
+            <button className="btn-secondary-sm" onClick={onCancel}>
+              閉じる
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/designer/src/mcp/mcpBridge.ts
+++ b/designer/src/mcp/mcpBridge.ts
@@ -98,6 +98,10 @@ class McpBridgeImpl {
     { resolve: (r: unknown) => void; reject: (e: Error) => void; timer: ReturnType<typeof setTimeout> }
   >();
 
+  getClientId(): string {
+    return this.clientId;
+  }
+
   // ── ハンドラ setter ────────────────────────────────────────────────────
 
   setThemeHandler(handler: ThemeHandler | null): void {

--- a/designer/src/styles/app.css
+++ b/designer/src/styles/app.css
@@ -1756,6 +1756,11 @@ body[data-gjs-dragging] .panel-left-wrapper.is-autohide .panel-left {
   animation: none;
 }
 
+.ai-rename-stage.is-proposed i,
+.ai-rename-stage.is-done i {
+  animation: none;
+}
+
 @keyframes ai-spin {
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }

--- a/designer/src/styles/app.css
+++ b/designer/src/styles/app.css
@@ -1689,3 +1689,148 @@ body[data-gjs-dragging] .panel-left-wrapper.is-autohide .panel-left {
   cursor: default;
   opacity: 0.4;
 }
+
+/* ── AI 命名 (#337) ─────────────────────────────────────────────────────────── */
+
+.ai-rename-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+}
+
+.ai-rename-modal {
+  background: var(--dz-bg-2);
+  border: 1px solid var(--dz-border);
+  border-radius: 12px;
+  width: 520px;
+  max-width: 90vw;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+}
+
+.ai-rename-modal-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--dz-border);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--dz-text);
+}
+
+.ai-rename-modal-header i {
+  font-size: 16px;
+  color: var(--dz-accent);
+}
+
+.ai-rename-modal-body {
+  padding: 20px;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.ai-rename-stage {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 14px;
+  color: var(--dz-text);
+  margin-bottom: 12px;
+}
+
+.ai-rename-stage i {
+  font-size: 18px;
+  color: var(--dz-accent);
+  animation: ai-spin 1.5s linear infinite;
+}
+
+.ai-rename-stage.is-error i {
+  color: #dc3545;
+  animation: none;
+}
+
+@keyframes ai-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.ai-rename-error-detail {
+  font-size: 12px;
+  color: #dc3545;
+  background: rgba(220, 53, 69, 0.1);
+  border-radius: 6px;
+  padding: 8px 12px;
+  margin-top: 8px;
+}
+
+.ai-rename-mapping-title {
+  font-size: 13px;
+  color: var(--dz-text-dim);
+  margin: 0 0 10px;
+}
+
+.ai-rename-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.ai-rename-table th {
+  text-align: left;
+  padding: 6px 10px;
+  background: var(--dz-bg-3);
+  border-bottom: 1px solid var(--dz-border);
+  color: var(--dz-text-dim);
+  font-weight: 600;
+}
+
+.ai-rename-table td {
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--dz-border);
+  color: var(--dz-text);
+}
+
+.ai-rename-table td code {
+  background: var(--dz-bg-3);
+  border-radius: 4px;
+  padding: 1px 5px;
+  font-size: 12px;
+  font-family: monospace;
+}
+
+.ai-rename-modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 14px 20px;
+  border-top: 1px solid var(--dz-border);
+}
+
+.ai-rename-toast {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  background: #198754;
+  color: #fff;
+  padding: 10px 16px;
+  border-radius: 8px;
+  font-size: 13px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  z-index: 20000;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  animation: toast-in 0.2s ease-out;
+}
+
+@keyframes toast-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}

--- a/designer/src/styles/app.css
+++ b/designer/src/styles/app.css
@@ -1835,6 +1835,10 @@ body[data-gjs-dragging] .panel-left-wrapper.is-autohide .panel-left {
   animation: toast-in 0.2s ease-out;
 }
 
+.ai-rename-toast.is-warn {
+  background: #fd7e14;
+}
+
 @keyframes toast-in {
   from { opacity: 0; transform: translateY(8px); }
   to   { opacity: 1; transform: translateY(0); }

--- a/docs/user-guide/rename-screen-ids-workflow.md
+++ b/docs/user-guide/rename-screen-ids-workflow.md
@@ -84,6 +84,41 @@ A: ブラウザで `/screen/design/<id>` を開いてから再実行してくだ
 **Q: screen-items ファイルがないと言われた**
 A: 画面デザイナーで一度フォーム要素をドロップして保存すると、`data/screen-items/<id>.json` が生成されます。
 
+---
+
+## ブラウザボタン版 (#337)
+
+Claude Code セッションを開かずにブラウザだけで AI 命名を実行できます。
+
+### 前提
+
+- `designer-mcp` が稼働していること (`cd designer-mcp && npm run dev`)
+- `designer-mcp` が稼働するマシンで `claude login` 済みであること
+
+認証確認コマンド:
+
+```
+claude auth status
+```
+
+### 使い方
+
+1. ブラウザで画面デザイナーを開く (`/screen/design/<id>`)
+2. ツールバー左端の **✦ ボタン** (IDを AI で再命名) をクリック
+3. AI が未命名項目を分析 → マッピングを提示
+4. 内容を確認して **「適用する」** をクリック
+5. 完了トーストで成功 / 失敗件数を確認
+
+> **ボタンが無効の場合**: `claude login` 未実行または `designer-mcp` 未起動です。
+
+### トラブルシューティング
+
+| 症状 | 対処 |
+|------|------|
+| ボタンが灰色でクリックできない | `claude auth status` で認証確認 / `claude login` を実行 |
+| 「通信エラー」が出る | `designer-mcp` が起動しているか確認 |
+| タイムアウト (60秒) | 画面項目数が多すぎる場合は `/rename-screen-ids` コマンド版を使用 |
+
 ## 関連
 
 - MCP ツール仕様: [`docs/spec/screen-items.md` — AI 推論セクション](../spec/screen-items.md)


### PR DESCRIPTION
Closes #337

## 概要

- 画面デザイナーのツールバーに「IDを AI で再命名」ボタン (✦) を追加
- `designer-mcp` から `claude -p` を spawn して推論を実行、進捗を WebSocket で中継
- ブラウザ側で確認ダイアログ → yes で既存 WS `renameScreenItem` 経由で apply

## 変更内容

### `designer-mcp/src/wsBridge.ts`
- `sendToClient(clientId, event, data)` メソッドを追加

### `designer-mcp/src/aiRename.ts` (新規)
- `GET /ai/rename-screen-ids/auth-check` — `claude auth status` で認証判定
- `POST /ai/rename-screen-ids/propose` — SKILL.md 読み込み → `claude -p` spawn → stream-json parse → `aiRenameProgress` event 中継 → mapping 返却
- `screenId` UUID バリデーション、60 秒タイムアウト、`--max-turns 20`
- CORS ヘッダー + OPTIONS preflight 対応
- `PROJECT_ROOT` を `import.meta.dirname` 基準に修正 (`process.cwd()` バグ)
- `sessionId` を WS progress イベントに付与 (キャンセル後の再表示防止)
- `child.on("error")` 時に WS error イベントを送信・HTTP 500 を返す

### `designer-mcp/src/index.ts`
- 2 endpoints を `registerHttpHandler` で登録

### `designer/src/mcp/mcpBridge.ts`
- `getClientId()` public getter を追加

### `designer/src/components/design/DesignSubToolbar.tsx`
- `screenId` prop 追加、auth-check → ✦ ボタン → 進捗モーダル → 確認ダイアログ → apply → トースト
- `res.ok` チェック追加
- トースト warn フラグ追加 (部分失敗時はオレンジ色)
- `aiRenameSessionRef` + sessionId ガード
- `generateUUID()` 使用 (`crypto.randomUUID()` は HTTP 環境で使用不可)
- toastTimerRef を unmount 時にクリーンアップ

### `designer/src/components/Designer.tsx`
- `screenId` を DesignSubToolbar へ渡す

### `designer/src/styles/app.css`
- AI 命名モーダル / トーストのスタイル追加
- `is-proposed` / `is-done` ステージのアイコン回転を停止
- `.ai-rename-toast.is-warn { background: #fd7e14; }` 追加

### `docs/user-guide/rename-screen-ids-workflow.md`
- ブラウザボタン版の使い方・前提・トラブルシューティングを追記

## 仕様逐条突合

| 完了条件 | file:line | 状態 |
|----------|-----------|------|
| `wsBridge.ts` に `sendToClient` 追加 | `designer-mcp/src/wsBridge.ts:283` | ✓ |
| `GET /ai/rename-screen-ids/auth-check` endpoint | `designer-mcp/src/aiRename.ts:68` | ✓ |
| `POST /ai/rename-screen-ids/propose` endpoint | `designer-mcp/src/aiRename.ts:80` | ✓ |
| SKILL.md 読み込み + `claude -p` spawn | `designer-mcp/src/aiRename.ts:119` | ✓ |
| stream-json parse + `aiRenameProgress` 中継 | `designer-mcp/src/aiRename.ts:142` | ✓ |
| `screenId` UUID バリデーション | `designer-mcp/src/aiRename.ts:86` | ✓ |
| `--max-turns 20` + 60 秒タイムアウト | `designer-mcp/src/aiRename.ts:113,167` | ✓ |
| Designer ツールバーにボタン追加 | `designer/src/components/design/DesignSubToolbar.tsx:394` | ✓ |
| auth-check でボタン有効化判定 | `designer/src/components/design/DesignSubToolbar.tsx:167` | ✓ |
| 進捗モーダル UI (stage 遷移) | `designer/src/components/design/DesignSubToolbar.tsx:559` | ✓ |
| 確認ダイアログ → WS apply | `designer/src/components/design/DesignSubToolbar.tsx:221` | ✓ |
| 結果トースト | `designer/src/components/design/DesignSubToolbar.tsx:235` | ✓ |
| docs にブラウザボタン版追記 | `docs/user-guide/rename-screen-ids-workflow.md:91` | ✓ |
| Skill / Command を新規作成していない | — (SKILL.md 再利用) | ✓ |

## テスト

- 自動テスト対象外 (claude CLI 依存)
- 手動 E2E: ボタン押下 → 推論 → 確認 → apply → トーストの目視確認をお願いします

## UI 影響

あり — **ユーザーの目視確認後にマージ** (CLAUDE.md)