### PR TITLE
docs(skills): レビュー前に PR/ISSUE 最新状態を読んで初回/再レビューを判断

### DIFF
--- a/.claude/skills/review-issue/SKILL.md
+++ b/.claude/skills/review-issue/SKILL.md
@@ -44,15 +44,17 @@ ISSUE 本文・コメントが**実装計画の一次ソース**。その上に 
 
 ### Step 0: 情報収集 — 並列実行
 
+**同じ ISSUE への 2 回目以降の呼び出しかもしれないため、最新状態とコメント履歴を必ず取得して現状を判断する。** 過去の Claude Review (ISSUE 完了監査) コメントがあっても「既に監査済み」で即終了せず、追加 PR マージや実装状況の変化を踏まえて **初回監査** / **再監査** / **再監査不要 (変化なし)** のいずれかを判断する。
+
 以下を並列で:
 
-- `gh issue view $ARGUMENTS --comments`
+- `gh issue view $ARGUMENTS --comments` (**過去の Claude Review コメントも確認**)
 - `gh issue view $ARGUMENTS --json title,state,body,labels,assignees,closedAt`
 - 紐づく PR 一覧: `gh pr list --search "$ARGUMENTS in:body" --state all --json number,title,state,mergedAt,body`
   - または ISSUE 本文・コメント内の `#<N>` 参照から抽出
 - spec 参照: ISSUE 本文から `docs/spec/` へのリンクを抽出し全文読む
 
-**前提チェック**: 紐づく PR に `OPEN` / `DRAFT` があれば、「全 PR マージ後に再実行してください」と報告して終了。
+**前提チェック**: 紐づく PR に `OPEN` / `DRAFT` があれば、「全 PR マージ後に再実行してください」と報告して終了。過去の Claude Review コメントがあれば、前回監査以降の追加 PR マージ有無を確認して再監査の要否を判断する。
 
 ### Step 1: 実装計画項目の列挙
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -41,14 +41,17 @@ PR #$ARGUMENTS を独立視点で厳格にレビューしてください。
 
 ### Step 0: 情報収集 — 並列実行
 
+**同じ PR への 2 回目以降の呼び出しかもしれないため、最新状態とコメント履歴を必ず取得して現状を判断する。** 過去の Claude Review コメントがあっても「既にレビュー済み」で即終了せず、PR を読んだ上で **初回レビュー** / **再レビュー (対応監査)** / **再レビュー不要 (対応コミットなし)** のいずれかを判断する。
+
 以下を並列で:
 
 - `gh pr view $ARGUMENTS --json title,state,body,additions,deletions,changedFiles,baseRefName,headRefName,mergeable`
+- `gh pr view $ARGUMENTS --comments` (**過去の Claude Review コメントも取得**)
 - `gh pr diff $ARGUMENTS --name-only`
 - PR 本文から関連 issue 番号を抽出し `gh issue view <N> --comments` で決定経緯を追う
 - PR 本文「関連」節の spec ファイルを特定し全文読む (該当節だけでなく前後関係も)
 
-情報収集が終わったら、PR 本文「レビュー担当への申し送り」節を熟読し、何を重点的に見るかを決める。
+情報収集が終わったら、PR 本文「レビュー担当への申し送り」節を熟読し、何を重点的に見るかを決める。過去の Claude Review コメントがあれば、前回指摘と最新コミットを突合して対応状況を確認する (再レビュー時)。
 
 ### Step 1: spec 逐条突合
 


### PR DESCRIPTION
## 関連

- Closes N/A (運用修正)
- 仕様: N/A

## 概要

再レビュー目的で `/review-pr <N>` を再実行したところ「既にレビュー完了」と即終了される誤動作を修正。SKILL.md Step 0 に「最新状態とコメント履歴を読んで判断」を明記し、判断ロジックは Claude に委ねる (過剰な構造化を避ける)。

## 主な変更

- `.claude/skills/review-pr/SKILL.md` Step 0: 過去コメント取得指示 + 初回/再レビュー判断指示
- `.claude/skills/review-issue/SKILL.md` Step 0: 同

## 仕様逐条突合

N/A

## レビューで特に見てほしい箇所

- Step 0 の文言が Claude に「過去コメントで即終了しない」を伝える十分さか

## テスト

- N/A (事後検証: 過去 Claude Review ある PR に対して `/review-pr` 再実行して拒否されないか)

## UI 影響 / マージ保留フラグ

- [ ] UI 影響あり
- [x] UI 影響なし

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

SKILL.md 文言のみの修正。Sonnet が `feat/issue-337-ai-rename-button` で作業中のため、本 PR は **git worktree で別 working tree** から作成し、同一ワークスペースでの並行作業の干渉を回避している。PR #341 で発生した branch 切り替え事故の教訓を反映した運用。
