### PR TITLE
feat(conventions): プロダクト規約カタログ層の正式機能化 (#346 #347 #348 #349)

### DIFF
--- a/designer/e2e/conv-completion.spec.ts
+++ b/designer/e2e/conv-completion.spec.ts
@@ -1,0 +1,156 @@
+/**
+ * @conv.* 補完ポップアップ E2E (#349)
+ *
+ * ActionEditor の ComputeStep expression 欄で @conv. 入力時に補完候補が
+ * 表示され、2 段選択 (category → key) でテキストが挿入されることを検証。
+ */
+import { test, expect, type Page } from "@playwright/test";
+
+const sampleCatalog = {
+  version: "1.0.0",
+  msg: { required: { template: "{label}は必須入力です" } },
+  regex: {},
+  limit: {},
+  scope: { customerRegion: { value: "domestic" } },
+  currency: { jpy: { code: "JPY", subunit: 0 }, usd: { code: "USD" } },
+  tax: { standard: { kind: "exclusive", rate: 0.1 } },
+  auth: { default: { scheme: "session-cookie" } },
+  db: { default: { engine: "postgresql@14" } },
+  numbering: { customerCode: { format: "C-NNNN" } },
+  tx: { singleOperation: { policy: "1 TX" } },
+  externalOutcomeDefaults: { failure: { outcome: "failure", action: "abort" } },
+};
+
+const sampleGroup = {
+  id: "ag-test-completion",
+  name: "補完テスト",
+  type: "screen",
+  description: "",
+  actions: [{
+    id: "act-001",
+    name: "テストアクション",
+    trigger: "click",
+    steps: [{
+      id: "step-001",
+      type: "compute",
+      description: "",
+      expression: "",
+      outputBinding: null,
+    }],
+  }],
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+const dummyProject = {
+  version: 1,
+  name: "補完 E2E テスト",
+  screens: [],
+  groups: [],
+  edges: [],
+  tables: [],
+  actionGroups: [{ id: sampleGroup.id, name: sampleGroup.name, type: sampleGroup.type, actionCount: 1, createdAt: sampleGroup.createdAt, updatedAt: sampleGroup.updatedAt }],
+  updatedAt: new Date().toISOString(),
+};
+
+async function setup(page: Page) {
+  await page.addInitScript(({ project, group, catalog }) => {
+    localStorage.setItem("flow-project", JSON.stringify(project));
+    localStorage.setItem(`action-group-${group.id}`, JSON.stringify(group));
+    localStorage.setItem("conventions-catalog", JSON.stringify(catalog));
+    localStorage.removeItem("designer-open-tabs");
+    localStorage.removeItem("designer-active-tab");
+  }, { project: dummyProject, group: sampleGroup, catalog: sampleCatalog });
+  await page.goto(`/process-flow/edit/${sampleGroup.id}`);
+  // ActionEditor が表示されるまで待機
+  await expect(page.locator(".action-editor, [class*='action-editor']")).toBeVisible({ timeout: 10000 });
+}
+
+async function openComputeStep(page: Page) {
+  // ComputeStep のヘッダーをクリックして展開
+  const stepHeader = page.locator(".step-card-header, [class*='step-header']").first();
+  await stepHeader.click();
+  // expression 入力欄が出るのを待つ
+  await expect(page.locator('[data-field-path="expression"]')).toBeVisible({ timeout: 5000 });
+}
+
+test.describe("@conv.* 補完ポップアップ (#349)", () => {
+  test("@conv. 入力でカテゴリ候補ポップアップが表示される", async ({ page }) => {
+    await setup(page);
+    await openComputeStep(page);
+    const exprInput = page.locator('[data-field-path="expression"] input');
+    await exprInput.click();
+    await exprInput.fill("@conv.");
+    await expect(page.locator('[role="listbox"]')).toBeVisible({ timeout: 3000 });
+    // 11 候補が表示されること
+    const items = page.locator('[role="listbox"] [role="option"]');
+    await expect(items).toHaveCount(11);
+  });
+
+  test("部分入力 @conv.curre で currency のみに絞り込まれる", async ({ page }) => {
+    await setup(page);
+    await openComputeStep(page);
+    const exprInput = page.locator('[data-field-path="expression"] input');
+    await exprInput.click();
+    await exprInput.fill("@conv.curre");
+    const items = page.locator('[role="listbox"] [role="option"]');
+    await expect(items).toHaveCount(1);
+    await expect(items.first()).toContainText("currency");
+  });
+
+  test("Enter で category を確定 → @conv.currency. に更新", async ({ page }) => {
+    await setup(page);
+    await openComputeStep(page);
+    const exprInput = page.locator('[data-field-path="expression"] input');
+    await exprInput.click();
+    await exprInput.fill("@conv.curre");
+    await expect(page.locator('[role="listbox"]')).toBeVisible();
+    await exprInput.press("Enter");
+    await expect(exprInput).toHaveValue("@conv.currency.");
+  });
+
+  test("category 確定後に key 候補が表示され、Enter で @conv.currency.* に確定", async ({ page }) => {
+    await setup(page);
+    await openComputeStep(page);
+    const exprInput = page.locator('[data-field-path="expression"] input');
+    await exprInput.click();
+    await exprInput.fill("@conv.curre");
+    await expect(page.locator('[role="listbox"]')).toBeVisible();
+    // category を確定
+    await exprInput.press("Enter");
+    await expect(exprInput).toHaveValue("@conv.currency.");
+    // key phase popup が出るのを待つ
+    await expect(page.locator('[role="listbox"]')).toBeVisible({ timeout: 3000 });
+    // 先頭候補 (activeIndex=0) を Enter で確定
+    await exprInput.press("Enter");
+    const val = await exprInput.inputValue();
+    expect(val).toMatch(/^@conv\.currency\.\w+$/);
+  });
+
+  test("Esc でポップアップが閉じる", async ({ page }) => {
+    await setup(page);
+    await openComputeStep(page);
+    const exprInput = page.locator('[data-field-path="expression"] input');
+    await exprInput.click();
+    await exprInput.fill("@conv.");
+    await expect(page.locator('[role="listbox"]')).toBeVisible();
+    await exprInput.press("Escape");
+    await expect(page.locator('[role="listbox"]')).toHaveCount(0);
+  });
+
+  test("↓↑ でハイライト移動", async ({ page }) => {
+    await setup(page);
+    await openComputeStep(page);
+    const exprInput = page.locator('[data-field-path="expression"] input');
+    await exprInput.click();
+    await exprInput.fill("@conv.");
+    await expect(page.locator('[role="listbox"]')).toBeVisible();
+    // 最初は先頭がハイライト
+    const first = page.locator('[role="option"][aria-selected="true"]');
+    await expect(first).toBeVisible();
+    await exprInput.press("ArrowDown");
+    // ハイライトが 2 番目に移動
+    const allOptions = page.locator('[role="option"]');
+    await expect(allOptions.nth(1)).toHaveAttribute("aria-selected", "true");
+  });
+});

--- a/designer/e2e/conventions-catalog-product.spec.ts
+++ b/designer/e2e/conventions-catalog-product.spec.ts
@@ -151,4 +151,38 @@ test.describe("プロダクト規約タブ (#347)", () => {
     await row.locator('button[aria-label="削除"]').click();
     await expect(page.locator(".conventions-key-badge", { hasText: "willDelete" })).toHaveCount(0);
   });
+
+  test("scope エントリを保存してリロード後も値が残る", async ({ page }) => {
+    // conventions-catalog を消さずに setup — リロード後に localStorage から復元できることを検証
+    await page.addInitScript(({ project }) => {
+      localStorage.setItem("flow-project", JSON.stringify(project));
+      localStorage.removeItem("designer-open-tabs");
+      localStorage.removeItem("designer-active-tab");
+      localStorage.removeItem("conventions-catalog");
+      localStorage.removeItem("draft-conventions-catalog-main");
+    }, { project: dummyProject });
+    await page.goto("/conventions/catalog");
+    await expect(page.locator(".conventions-catalog-view")).toBeVisible({ timeout: 10000 });
+
+    await page.locator(".conventions-category-tab", { hasText: "スコープ" }).click();
+    await page.locator(".conventions-new-key-input").fill("persistTest");
+    await page.locator(".conventions-entries button:has-text('追加')").click();
+    await expect(page.locator(".conventions-key-badge", { hasText: "persistTest" })).toBeVisible();
+    const valueInput = page.locator('.conventions-table input[placeholder="domestic"]').first();
+    await valueInput.fill("overseas");
+    await expect(valueInput).toHaveValue("overseas");
+
+    // 保存
+    await page.locator(".srb-btn-save").click();
+    await expect(page.locator(".srb-btn-save")).not.toHaveClass(/dirty/, { timeout: 5000 });
+
+    // リロード
+    await page.reload();
+    await expect(page.locator(".conventions-catalog-view")).toBeVisible({ timeout: 10000 });
+
+    // スコープタブを開いてエントリが残っていることを確認
+    await page.locator(".conventions-category-tab", { hasText: "スコープ" }).click();
+    await expect(page.locator(".conventions-key-badge", { hasText: "persistTest" })).toBeVisible();
+    await expect(page.locator('.conventions-table input[placeholder="domestic"]').first()).toHaveValue("overseas");
+  });
 });

--- a/designer/e2e/conventions-catalog-product.spec.ts
+++ b/designer/e2e/conventions-catalog-product.spec.ts
@@ -1,0 +1,154 @@
+/**
+ * プロダクト規約カテゴリの E2E (#347)
+ *
+ * scope / currency / tax / auth / db / numbering / tx / externalOutcomeDefaults
+ * の各タブで add / edit / delete が動作することを検証。
+ */
+import { test, expect, type Page } from "@playwright/test";
+
+const dummyProject = {
+  version: 1, name: "conventions-product", screens: [], groups: [], edges: [],
+  tables: [], actionGroups: [],
+  updatedAt: new Date().toISOString(),
+};
+
+async function setup(page: Page) {
+  await page.addInitScript(({ project }) => {
+    localStorage.setItem("flow-project", JSON.stringify(project));
+    localStorage.removeItem("designer-open-tabs");
+    localStorage.removeItem("designer-active-tab");
+    localStorage.removeItem("conventions-catalog");
+    localStorage.removeItem("draft-conventions-catalog-main");
+  }, { project: dummyProject });
+  await page.goto("/conventions/catalog");
+  await expect(page.locator(".conventions-catalog-view")).toBeVisible({ timeout: 10000 });
+}
+
+test.describe("プロダクト規約タブ (#347)", () => {
+  test("プロダクト規約 section header が見える", async ({ page }) => {
+    await setup(page);
+    await expect(page.locator(".conventions-tab-group-label", { hasText: "プロダクト規約" })).toBeVisible();
+  });
+
+  test("scope タブで新規エントリ追加 + value 入力", async ({ page }) => {
+    await setup(page);
+    await page.locator(".conventions-category-tab", { hasText: "スコープ" }).click();
+    await page.locator(".conventions-new-key-input").fill("customerRegion");
+    await page.locator(".conventions-entries button:has-text('追加')").click();
+    await expect(page.locator(".conventions-key-badge", { hasText: "customerRegion" })).toBeVisible();
+    const valueInput = page.locator('.conventions-table input[placeholder="domestic"]').first();
+    await valueInput.fill("domestic");
+    await expect(valueInput).toHaveValue("domestic");
+  });
+
+  test("currency タブで新規エントリ追加 + code 入力", async ({ page }) => {
+    await setup(page);
+    await page.locator(".conventions-category-tab", { hasText: "通貨" }).click();
+    await page.locator(".conventions-new-key-input").fill("jpy");
+    await page.locator(".conventions-entries button:has-text('追加')").click();
+    await expect(page.locator(".conventions-key-badge", { hasText: "jpy" })).toBeVisible();
+    const codeInput = page.locator('.conventions-table input[placeholder="JPY"]').first();
+    await codeInput.fill("JPY");
+    await expect(codeInput).toHaveValue("JPY");
+  });
+
+  test("currency タブで roundingMode select が動作する", async ({ page }) => {
+    await setup(page);
+    await page.locator(".conventions-category-tab", { hasText: "通貨" }).click();
+    await page.locator(".conventions-new-key-input").fill("jpy");
+    await page.locator(".conventions-entries button:has-text('追加')").click();
+    const rmSelect = page.locator(".conventions-table select").first();
+    await rmSelect.selectOption("floor");
+    await expect(rmSelect).toHaveValue("floor");
+  });
+
+  test("tax タブで新規エントリ追加 + kind/rate 入力", async ({ page }) => {
+    await setup(page);
+    await page.locator(".conventions-category-tab", { hasText: "税" }).click();
+    await page.locator(".conventions-new-key-input").fill("standard");
+    await page.locator(".conventions-entries button:has-text('追加')").click();
+    await expect(page.locator(".conventions-key-badge", { hasText: "standard" })).toBeVisible();
+    const kindSelect = page.locator(".conventions-table select").first();
+    await expect(kindSelect).toHaveValue("exclusive");
+    const rateInput = page.locator('.conventions-table input[placeholder="0.10"]').first();
+    await rateInput.fill("0.1");
+    await expect(rateInput).toHaveValue("0.1");
+  });
+
+  test("auth タブで新規エントリ追加 + scheme 入力", async ({ page }) => {
+    await setup(page);
+    await page.locator(".conventions-category-tab", { hasText: "認証" }).click();
+    await page.locator(".conventions-new-key-input").fill("default");
+    await page.locator(".conventions-entries button:has-text('追加')").click();
+    await expect(page.locator(".conventions-key-badge", { hasText: "default" })).toBeVisible();
+    const schemeInput = page.locator('.conventions-table input[placeholder="session-cookie"]').first();
+    await schemeInput.fill("session-cookie");
+    await expect(schemeInput).toHaveValue("session-cookie");
+  });
+
+  test("db タブで新規エントリ追加 + engine 入力", async ({ page }) => {
+    await setup(page);
+    await page.locator(".conventions-category-tab", { hasText: "DB" }).click();
+    await page.locator(".conventions-new-key-input").fill("default");
+    await page.locator(".conventions-entries button:has-text('追加')").click();
+    await expect(page.locator(".conventions-key-badge", { hasText: "default" })).toBeVisible();
+    const engineInput = page.locator('.conventions-table input[placeholder="postgresql@14"]').first();
+    await engineInput.fill("postgresql@14");
+    await expect(engineInput).toHaveValue("postgresql@14");
+  });
+
+  test("numbering タブで新規エントリ追加 + format 入力", async ({ page }) => {
+    await setup(page);
+    await page.locator(".conventions-category-tab", { hasText: "採番" }).click();
+    await page.locator(".conventions-new-key-input").fill("customerCode");
+    await page.locator(".conventions-entries button:has-text('追加')").click();
+    await expect(page.locator(".conventions-key-badge", { hasText: "customerCode" })).toBeVisible();
+    const formatInput = page.locator('.conventions-table input[placeholder="C-NNNN"]').first();
+    await formatInput.fill("C-NNNN");
+    await expect(formatInput).toHaveValue("C-NNNN");
+  });
+
+  test("tx タブで新規エントリ追加 + policy textarea 入力", async ({ page }) => {
+    await setup(page);
+    await page.locator(".conventions-category-tab", { hasText: "TX" }).click();
+    await page.locator(".conventions-new-key-input").fill("singleOperation");
+    await page.locator(".conventions-entries button:has-text('追加')").click();
+    await expect(page.locator(".conventions-key-badge", { hasText: "singleOperation" })).toBeVisible();
+    const policyTextarea = page.locator(".conventions-table-textarea").first();
+    await policyTextarea.fill("単一操作は 1 TX");
+    await expect(policyTextarea).toHaveValue("単一操作は 1 TX");
+  });
+
+  test("外部連携既定タブで新規エントリ追加 + outcome/action select", async ({ page }) => {
+    await setup(page);
+    await page.locator(".conventions-category-tab", { hasText: "外部連携既定" }).click();
+    await page.locator(".conventions-new-key-input").fill("failure");
+    await page.locator(".conventions-entries button:has-text('追加')").click();
+    await expect(page.locator(".conventions-key-badge", { hasText: "failure" })).toBeVisible();
+    const selects = page.locator(".conventions-table select");
+    await expect(selects.nth(0)).toHaveValue("failure");
+    await expect(selects.nth(1)).toHaveValue("abort");
+  });
+
+  test("プロダクト規約タブで重複キーの追加はボタン disabled", async ({ page }) => {
+    await setup(page);
+    await page.locator(".conventions-category-tab", { hasText: "通貨" }).click();
+    await page.locator(".conventions-new-key-input").fill("jpy");
+    await page.locator(".conventions-entries button:has-text('追加')").click();
+    await page.locator(".conventions-new-key-input").fill("jpy");
+    await expect(page.locator(".conventions-entries button:has-text('追加')")).toBeDisabled();
+  });
+
+  test("プロダクト規約タブで削除ボタンでエントリが消える", async ({ page }) => {
+    await setup(page);
+    await page.locator(".conventions-category-tab", { hasText: "スコープ" }).click();
+    await page.locator(".conventions-new-key-input").fill("willDelete");
+    await page.locator(".conventions-entries button:has-text('追加')").click();
+    await expect(page.locator(".conventions-key-badge", { hasText: "willDelete" })).toBeVisible();
+    const row = page.locator(".conventions-table tr").filter({
+      has: page.locator(".conventions-key-badge", { hasText: "willDelete" }),
+    });
+    await row.locator('button[aria-label="削除"]').click();
+    await expect(page.locator(".conventions-key-badge", { hasText: "willDelete" })).toHaveCount(0);
+  });
+});

--- a/designer/e2e/conventions-catalog.spec.ts
+++ b/designer/e2e/conventions-catalog.spec.ts
@@ -26,13 +26,16 @@ async function setup(page: Page) {
 }
 
 test.describe("規約カタログ編集ビュー (#317)", () => {
-  test("3 カテゴリタブが見える", async ({ page }) => {
+  test("11 カテゴリタブが 2 グループで見える", async ({ page }) => {
     await setup(page);
     const tabs = page.locator(".conventions-category-tab");
-    await expect(tabs).toHaveCount(3);
+    await expect(tabs).toHaveCount(11);
     await expect(tabs.nth(0)).toContainText("メッセージ");
     await expect(tabs.nth(1)).toContainText("正規表現");
     await expect(tabs.nth(2)).toContainText("制限値");
+    const groupLabels = page.locator(".conventions-tab-group-label");
+    await expect(groupLabels.nth(0)).toContainText("入力バリデーション");
+    await expect(groupLabels.nth(1)).toContainText("プロダクト規約");
   });
 
   test("regex タブで新規エントリ追加 + pattern 入力", async ({ page }) => {

--- a/designer/src/components/action/ActionEditor.tsx
+++ b/designer/src/components/action/ActionEditor.tsx
@@ -903,6 +903,7 @@ export function ActionEditor() {
                           markerCount={markerCount}
                           markerTooltip={markerTooltip}
                           markerKinds={markerKinds}
+                          conventions={conventions}
                         />
                       </div>
                       );

--- a/designer/src/components/action/SortableStepCard.tsx
+++ b/designer/src/components/action/SortableStepCard.tsx
@@ -3,6 +3,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { StepCard } from "./StepCard";
 import type { Step, StepType } from "../../types/action";
 import type { ValidationError } from "../../utils/actionValidation";
+import type { ConventionsCatalog } from "../../schemas/conventionsValidator";
 
 interface SortableStepCardProps {
   step: Step;
@@ -31,6 +32,7 @@ interface SortableStepCardProps {
   markerCount?: number;
   markerTooltip?: string;
   markerKinds?: { todo: number; question: number; attention: number; chat: number };
+  conventions?: ConventionsCatalog | null;
 }
 
 export function SortableStepCard({ step, ...props }: SortableStepCardProps) {

--- a/designer/src/components/action/StepCard.tsx
+++ b/designer/src/components/action/StepCard.tsx
@@ -80,6 +80,7 @@ interface InlineStepListProps {
   onCommit?: () => void;
   onNavigateCommon: (refId: string) => void;
   validationErrors?: ValidationError[];
+  conventions?: import("../../schemas/conventionsValidator").ConventionsCatalog | null;
 }
 
 function InlineStepList({
@@ -93,6 +94,7 @@ function InlineStepList({
   onCommit,
   onNavigateCommon,
   validationErrors,
+  conventions,
 }: InlineStepListProps) {
   const [showTypePicker, setShowTypePicker] = useState(false);
 
@@ -156,6 +158,7 @@ function InlineStepList({
             onNavigateCommon={onNavigateCommon}
             depth={1}
             validationErrors={validationErrors}
+            conventions={conventions}
           />
         </div>
       ))}
@@ -1378,6 +1381,7 @@ export function StepCard({
                             onCommit={onCommit}
                             onNavigateCommon={onNavigateCommon}
                             validationErrors={validationErrors}
+                            conventions={conventions}
                           />
                         </div>
                       )}
@@ -1430,6 +1434,7 @@ export function StepCard({
                             onCommit={onCommit}
                             onNavigateCommon={onNavigateCommon}
                             validationErrors={validationErrors}
+                            conventions={conventions}
                           />
                         </div>
                       )}
@@ -1563,6 +1568,7 @@ export function StepCard({
                         onCommit={onCommit}
                         onNavigateCommon={onNavigateCommon}
                         validationErrors={validationErrors}
+                        conventions={conventions}
                       />
                     </div>
                   )}

--- a/designer/src/components/action/StepCard.tsx
+++ b/designer/src/components/action/StepCard.tsx
@@ -24,6 +24,7 @@ import { MaturityBadge } from "./MaturityBadge";
 import { NotesPanel } from "./NotesPanel";
 import { StepAdvancedMetadataPanel } from "./StepAdvancedMetadataPanel";
 import { ValidationRulesPanel } from "./ValidationRulesPanel";
+import { ConvCompletionInput } from "../common/ConvCompletionInput";
 import { ExternalOutcomesPanel } from "./ExternalOutcomesPanel";
 import { JumpTargetSelector } from "./JumpTargetSelector";
 
@@ -187,6 +188,7 @@ interface StepCardProps {
   tables: { id: string; name: string; logicalName: string }[];
   screens: { id: string; name: string }[];
   commonGroups: { id: string; name: string }[];
+  conventions?: import("../../schemas/conventionsValidator").ConventionsCatalog | null;
   onChange: (changes: Partial<Step>) => void;
   onCommit?: () => void;
   onMoveUp?: () => void;
@@ -226,6 +228,7 @@ export function StepCard({
   tables,
   screens,
   commonGroups,
+  conventions,
   onChange,
   onCommit,
   onMoveUp,
@@ -770,6 +773,7 @@ export function StepCard({
                 <ValidationRulesPanel
                   rules={step.rules}
                   onChange={(rules) => onChange({ rules } as Partial<Step>)}
+                  conventions={conventions ?? null}
                 />
                 {step.inlineBranch && (
                   <div className="step-inline-branch">
@@ -1176,12 +1180,12 @@ export function StepCard({
                     <i className="bi bi-calculator me-1" />
                     代入式 (expression)
                   </label>
-                  <input
-                    type="text"
+                  <ConvCompletionInput
                     className="form-control form-control-sm"
                     value={step.expression}
-                    onChange={(e) => onChange({ expression: e.target.value } as Partial<Step>)}
-                    onBlur={onCommit}
+                    onValueChange={(v) => onChange({ expression: v } as Partial<Step>)}
+                    onCommit={onCommit}
+                    conventions={conventions ?? null}
                     placeholder="例: Math.floor(@subtotal * 0.10) / @subtotal + @taxAmount"
                     style={{ fontFamily: "monospace" }}
                   />
@@ -1209,12 +1213,12 @@ export function StepCard({
                   </div>
                   <div className="col-6" data-field-path="bodyExpression">
                     <label className="form-label">bodyExpression</label>
-                    <input
-                      type="text"
+                    <ConvCompletionInput
                       className="form-control form-control-sm"
                       value={step.bodyExpression ?? ""}
-                      onChange={(e) => onChange({ bodyExpression: e.target.value || undefined } as Partial<Step>)}
-                      onBlur={onCommit}
+                      onValueChange={(v) => onChange({ bodyExpression: v || undefined } as Partial<Step>)}
+                      onCommit={onCommit}
+                      conventions={conventions ?? null}
                       placeholder="例: { code: 'STOCK_SHORTAGE', detail: @shortageList }"
                       style={{ fontFamily: "monospace" }}
                     />

--- a/designer/src/components/action/ValidationRulesPanel.tsx
+++ b/designer/src/components/action/ValidationRulesPanel.tsx
@@ -1,9 +1,12 @@
 import { useState } from "react";
 import type { ValidationRule, ValidationRuleType } from "../../types/action";
+import type { ConventionsCatalog } from "../../schemas/conventionsValidator";
+import { ConvCompletionInput } from "../common/ConvCompletionInput";
 
 interface Props {
   rules: ValidationRule[] | undefined;
   onChange: (rules: ValidationRule[]) => void;
+  conventions?: ConventionsCatalog | null;
 }
 
 const RULE_TYPES: Array<{ value: ValidationRuleType; label: string }> = [
@@ -20,7 +23,7 @@ const RULE_TYPES: Array<{ value: ValidationRuleType; label: string }> = [
  * ValidationStep.rules[] 編集 UI (#212)。
  * 構造化ルール配列の追加/編集/削除。
  */
-export function ValidationRulesPanel({ rules, onChange }: Props) {
+export function ValidationRulesPanel({ rules, onChange, conventions }: Props) {
   const list = rules ?? [];
   const [expanded, setExpanded] = useState(list.length > 0);
 
@@ -143,22 +146,22 @@ export function ValidationRulesPanel({ rules, onChange }: Props) {
           )}
           {r.type === "custom" && (
             <div className="col">
-              <input
-                type="text"
+              <ConvCompletionInput
                 className="form-control form-control-sm"
                 value={r.condition ?? ""}
-                onChange={(e) => updateRule(i, { condition: e.target.value })}
+                onValueChange={(v) => updateRule(i, { condition: v })}
+                conventions={conventions ?? null}
                 placeholder="condition (例: @items.length >= 1)"
                 style={{ fontSize: "0.8rem" }}
               />
             </div>
           )}
           <div className="col-auto" style={{ width: 140 }}>
-            <input
-              type="text"
+            <ConvCompletionInput
               className="form-control form-control-sm"
               value={r.message ?? ""}
-              onChange={(e) => updateRule(i, { message: e.target.value || undefined })}
+              onValueChange={(v) => updateRule(i, { message: v || undefined })}
+              conventions={conventions ?? null}
               placeholder="message (例: @conv.msg.required)"
               style={{ fontSize: "0.8rem" }}
             />

--- a/designer/src/components/common/ConvCompletionInput.tsx
+++ b/designer/src/components/common/ConvCompletionInput.tsx
@@ -1,0 +1,155 @@
+import { useState, useRef, useCallback } from "react";
+import type { ConventionsCatalog } from "../../schemas/conventionsValidator";
+import { computeCompletion, insertCandidate } from "../../hooks/useConvCompletion";
+
+interface ConvCompletionInputProps {
+  value: string;
+  onValueChange: (v: string) => void;
+  onCommit?: () => void;
+  conventions: ConventionsCatalog | null;
+  className?: string;
+  style?: React.CSSProperties;
+  placeholder?: string;
+  autoComplete?: string;
+}
+
+/**
+ * @conv.* 補完ポップアップ付き input。
+ * `@conv.` 入力でカテゴリ一覧、`@conv.currency.` で key 一覧を表示する。
+ * ↑↓ で選択、Enter/Tab で確定、Esc で閉じる。
+ */
+export function ConvCompletionInput({
+  value,
+  onValueChange,
+  onCommit,
+  conventions,
+  className,
+  style,
+  placeholder,
+}: ConvCompletionInputProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [cursorPos, setCursorPos] = useState(0);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [suppressed, setSuppressed] = useState(false);
+
+  const state = suppressed
+    ? ({ phase: "idle" } as const)
+    : computeCompletion(value, cursorPos, conventions);
+
+  const candidates = state.phase !== "idle" ? state.candidates : [];
+  const isOpen = candidates.length > 0;
+  const safeIndex = candidates.length > 0 ? Math.min(activeIndex, candidates.length - 1) : 0;
+
+  const pick = useCallback((candidate: string) => {
+    const pos = inputRef.current?.selectionStart ?? value.length;
+    const st = computeCompletion(value, pos, conventions);
+    if (st.phase === "idle") return;
+    const { newValue, newCursor } = insertCandidate(value, pos, st, candidate);
+    onValueChange(newValue);
+    setSuppressed(false);
+    setActiveIndex(0);
+    setCursorPos(newCursor);
+    requestAnimationFrame(() => {
+      inputRef.current?.setSelectionRange(newCursor, newCursor);
+      inputRef.current?.focus();
+    });
+  }, [value, conventions, onValueChange]);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!isOpen) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveIndex((i) => (i + 1) % candidates.length);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIndex((i) => (i - 1 + candidates.length) % candidates.length);
+    } else if (e.key === "Enter" || e.key === "Tab") {
+      if (candidates[safeIndex]) {
+        e.preventDefault();
+        pick(candidates[safeIndex]);
+      }
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      setSuppressed(true);
+    }
+  };
+
+  return (
+    <div style={{ position: "relative" }}>
+      <input
+        ref={inputRef}
+        type="text"
+        className={className}
+        style={style}
+        value={value}
+        placeholder={placeholder}
+        autoComplete="off"
+        onChange={(e) => {
+          const pos = e.target.selectionStart ?? e.target.value.length;
+          setCursorPos(pos);
+          setActiveIndex(0);
+          setSuppressed(false);
+          onValueChange(e.target.value);
+        }}
+        onKeyDown={handleKeyDown}
+        onSelect={(e) => {
+          setCursorPos((e.target as HTMLInputElement).selectionStart ?? 0);
+        }}
+        onBlur={() => {
+          setTimeout(() => setSuppressed(true), 150);
+          onCommit?.();
+        }}
+        onFocus={() => setSuppressed(false)}
+      />
+      {isOpen && (
+        <ul
+          role="listbox"
+          aria-label="@conv 補完候補"
+          style={{
+            position: "absolute",
+            top: "100%",
+            left: 0,
+            zIndex: 9999,
+            background: "#fff",
+            border: "1px solid #cbd5e1",
+            borderRadius: 6,
+            boxShadow: "0 4px 16px rgba(0,0,0,0.12)",
+            margin: "2px 0 0",
+            padding: "4px 0",
+            minWidth: "16em",
+            maxHeight: "14em",
+            overflowY: "auto",
+            listStyle: "none",
+          }}
+        >
+          {candidates.map((c, i) => (
+            <li
+              key={c}
+              role="option"
+              aria-selected={i === safeIndex}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                pick(c);
+              }}
+              style={{
+                padding: "4px 12px",
+                cursor: "pointer",
+                fontSize: "0.82rem",
+                fontFamily: "ui-monospace, SFMono-Regular, monospace",
+                background: i === safeIndex ? "#6366f1" : "transparent",
+                color: i === safeIndex ? "#fff" : "#1e293b",
+                borderRadius: i === safeIndex ? 3 : 0,
+                margin: "0 4px",
+              }}
+            >
+              {state.phase === "category"
+                ? <><span style={{ opacity: 0.6 }}>@conv.</span><strong>{c}</strong></>
+                : c
+              }
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/designer/src/components/common/ConvCompletionInput.tsx
+++ b/designer/src/components/common/ConvCompletionInput.tsx
@@ -10,7 +10,6 @@ interface ConvCompletionInputProps {
   className?: string;
   style?: React.CSSProperties;
   placeholder?: string;
-  autoComplete?: string;
 }
 
 /**

--- a/designer/src/components/conventions/ConventionsCatalogView.tsx
+++ b/designer/src/components/conventions/ConventionsCatalogView.tsx
@@ -1,13 +1,10 @@
 /**
- * 規約カタログ編集ビュー (#317)
+ * 規約カタログ編集ビュー (#317, #347)
  *
- * 横断規約 (`@conv.msg.*` / `@conv.regex.*` / `@conv.limit.*`) の
- * 機械可読カタログ (`data/conventions/catalog.json`) を designer 内で編集する
- * シングルトンタブ。正本は JSON (本ビューで編集可)、`docs/conventions/*.md`
- * は人間向け参考資料。
- *
- * カテゴリは 3 種: msg / regex / limit。それぞれサブタブで切替。CRUD は
- * インライン編集 (name/description/etc をテキスト入力)。
+ * 横断規約の機械可読カタログ (`data/conventions/catalog.json`) を designer 内で編集する
+ * シングルトンタブ。カテゴリは 11 種、2 グループで表示:
+ *   - 入力バリデーション: msg / regex / limit
+ *   - プロダクト規約: scope / currency / tax / auth / db / numbering / tx / externalOutcomeDefaults
  */
 import { useCallback, useState } from "react";
 import { TableSubToolbar } from "../table/TableSubToolbar";
@@ -20,23 +17,56 @@ import {
   createEmptyCatalog,
 } from "../../store/conventionsStore";
 import type { ConventionsCatalog } from "../../schemas/conventionsValidator";
+import type {
+  ScopeEntry,
+  CurrencyEntry,
+  TaxEntry,
+  AuthEntry,
+  DbEntry,
+  NumberingEntry,
+  TxEntry,
+  ExternalOutcomeDefaultEntry,
+} from "../../types/conventions";
 import "../../styles/conventions.css";
 
-type Category = "msg" | "regex" | "limit";
+type Category =
+  | "msg" | "regex" | "limit"
+  | "scope" | "currency" | "tax" | "auth"
+  | "db" | "numbering" | "tx" | "externalOutcomeDefaults";
+
+const VALIDATION_CATEGORIES: Category[] = ["msg", "regex", "limit"];
+const PRODUCT_CATEGORIES: Category[] = [
+  "scope", "currency", "tax", "auth", "db", "numbering", "tx", "externalOutcomeDefaults",
+];
 
 const CATEGORY_LABELS: Record<Category, string> = {
   msg: "メッセージ",
   regex: "正規表現",
   limit: "制限値",
+  scope: "スコープ",
+  currency: "通貨",
+  tax: "税",
+  auth: "認証",
+  db: "DB",
+  numbering: "採番",
+  tx: "TX",
+  externalOutcomeDefaults: "外部連携既定",
 };
 
 const CATEGORY_ICONS: Record<Category, string> = {
   msg: "bi-chat-left-text",
   regex: "bi-regex",
   limit: "bi-rulers",
+  scope: "bi-globe",
+  currency: "bi-currency-yen",
+  tax: "bi-calculator",
+  auth: "bi-lock",
+  db: "bi-database",
+  numbering: "bi-hash",
+  tx: "bi-arrow-repeat",
+  externalOutcomeDefaults: "bi-broadcast",
 };
 
-/** シングルトンなので id を "main" 固定で useResourceEditor を流用 */
 const RESOURCE_ID = "main";
 
 async function loadCatalog(_id: string): Promise<ConventionsCatalog> {
@@ -46,6 +76,11 @@ async function loadCatalog(_id: string): Promise<ConventionsCatalog> {
 
 async function saveCatalog(data: ConventionsCatalog): Promise<void> {
   await saveConventions(data);
+}
+
+function countCategoryEntries(catalog: ConventionsCatalog, cat: Category): number {
+  const v = catalog[cat as keyof ConventionsCatalog];
+  return v ? Object.keys(v as object).length : 0;
 }
 
 export function ConventionsCatalogView() {
@@ -68,27 +103,77 @@ export function ConventionsCatalogView() {
   });
 
   const addMsg = useCallback((key: string) => {
-    update((c) => {
-      if (!c.msg) c.msg = {};
-      if (!c.msg[key]) c.msg[key] = { template: "" };
-    });
+    update((c) => { if (!c.msg) c.msg = {}; if (!c.msg[key]) c.msg[key] = { template: "" }; });
   }, [update]);
 
   const addRegex = useCallback((key: string) => {
-    update((c) => {
-      if (!c.regex) c.regex = {};
-      if (!c.regex[key]) c.regex[key] = { pattern: "" };
-    });
+    update((c) => { if (!c.regex) c.regex = {}; if (!c.regex[key]) c.regex[key] = { pattern: "" }; });
   }, [update]);
 
   const addLimit = useCallback((key: string) => {
+    update((c) => { if (!c.limit) c.limit = {}; if (!c.limit[key]) c.limit[key] = { value: 0 }; });
+  }, [update]);
+
+  const addScope = useCallback((key: string) => {
+    update((c) => { if (!c.scope) c.scope = {}; if (!c.scope[key]) c.scope[key] = { value: "" }; });
+  }, [update]);
+
+  const addCurrency = useCallback((key: string) => {
+    update((c) => { if (!c.currency) c.currency = {}; if (!c.currency[key]) c.currency[key] = { code: "" }; });
+  }, [update]);
+
+  const addTax = useCallback((key: string) => {
+    update((c) => { if (!c.tax) c.tax = {}; if (!c.tax[key]) c.tax[key] = { kind: "exclusive", rate: 0 }; });
+  }, [update]);
+
+  const addAuth = useCallback((key: string) => {
+    update((c) => { if (!c.auth) c.auth = {}; if (!c.auth[key]) c.auth[key] = { scheme: "" }; });
+  }, [update]);
+
+  const addDb = useCallback((key: string) => {
+    update((c) => { if (!c.db) c.db = {}; if (!c.db[key]) c.db[key] = {}; });
+  }, [update]);
+
+  const addNumbering = useCallback((key: string) => {
+    update((c) => { if (!c.numbering) c.numbering = {}; if (!c.numbering[key]) c.numbering[key] = { format: "" }; });
+  }, [update]);
+
+  const addTx = useCallback((key: string) => {
+    update((c) => { if (!c.tx) c.tx = {}; if (!c.tx[key]) c.tx[key] = { policy: "" }; });
+  }, [update]);
+
+  const addExternalOutcomeDefault = useCallback((key: string) => {
     update((c) => {
-      if (!c.limit) c.limit = {};
-      if (!c.limit[key]) c.limit[key] = { value: 0 };
+      if (!c.externalOutcomeDefaults) c.externalOutcomeDefaults = {};
+      if (!c.externalOutcomeDefaults[key]) c.externalOutcomeDefaults[key] = { outcome: "failure", action: "abort" };
     });
   }, [update]);
 
   if (!catalog) return null;
+
+  const renderTabGroup = (label: string, categories: Category[]) => (
+    <div className="conventions-tab-group">
+      <span className="conventions-tab-group-label">{label}</span>
+      <div className="conventions-category-tabs" role="tablist">
+        {categories.map((cat) => {
+          const count = countCategoryEntries(catalog, cat);
+          return (
+            <button
+              key={cat}
+              type="button"
+              className={`conventions-category-tab ${activeCategory === cat ? "active" : ""}`}
+              onClick={() => setActiveCategory(cat)}
+              role="tab"
+              aria-selected={activeCategory === cat}
+            >
+              <i className={`bi ${CATEGORY_ICONS[cat]}`} /> {CATEGORY_LABELS[cat]}
+              {count > 0 && <span className="conventions-category-count">{count}</span>}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
 
   return (
     <div className="conventions-catalog-view">
@@ -125,23 +210,9 @@ export function ConventionsCatalogView() {
         />
       </div>
 
-      <div className="conventions-category-tabs" role="tablist">
-        {(Object.keys(CATEGORY_LABELS) as Category[]).map((cat) => {
-          const count = Object.keys(catalog[cat] ?? {}).length;
-          return (
-            <button
-              key={cat}
-              type="button"
-              className={`conventions-category-tab ${activeCategory === cat ? "active" : ""}`}
-              onClick={() => setActiveCategory(cat)}
-              role="tab"
-              aria-selected={activeCategory === cat}
-            >
-              <i className={`bi ${CATEGORY_ICONS[cat]}`} /> {CATEGORY_LABELS[cat]}
-              {count > 0 && <span className="conventions-category-count">{count}</span>}
-            </button>
-          );
-        })}
+      <div className="conventions-tabs-area">
+        {renderTabGroup("入力バリデーション", VALIDATION_CATEGORIES)}
+        {renderTabGroup("プロダクト規約", PRODUCT_CATEGORIES)}
       </div>
 
       <div className="conventions-category-content">
@@ -149,42 +220,101 @@ export function ConventionsCatalogView() {
           <MsgEditor
             msg={catalog.msg ?? {}}
             onAdd={addMsg}
-            onUpdate={(key, patch) => updateSilent((c) => {
-              if (!c.msg || !c.msg[key]) return;
-              Object.assign(c.msg[key], patch);
-            })}
+            onUpdate={(key, patch) => updateSilent((c) => { if (c.msg?.[key]) Object.assign(c.msg[key], patch); })}
             onCommit={commit}
-            onRemove={(key) => update((c) => {
-              if (c.msg) delete c.msg[key];
-            })}
+            onRemove={(key) => update((c) => { if (c.msg) delete c.msg[key]; })}
           />
         )}
         {activeCategory === "regex" && (
           <RegexEditor
             regex={catalog.regex ?? {}}
             onAdd={addRegex}
-            onUpdate={(key, patch) => updateSilent((c) => {
-              if (!c.regex || !c.regex[key]) return;
-              Object.assign(c.regex[key], patch);
-            })}
+            onUpdate={(key, patch) => updateSilent((c) => { if (c.regex?.[key]) Object.assign(c.regex[key], patch); })}
             onCommit={commit}
-            onRemove={(key) => update((c) => {
-              if (c.regex) delete c.regex[key];
-            })}
+            onRemove={(key) => update((c) => { if (c.regex) delete c.regex[key]; })}
           />
         )}
         {activeCategory === "limit" && (
           <LimitEditor
             limit={catalog.limit ?? {}}
             onAdd={addLimit}
+            onUpdate={(key, patch) => updateSilent((c) => { if (c.limit?.[key]) Object.assign(c.limit[key], patch); })}
+            onCommit={commit}
+            onRemove={(key) => update((c) => { if (c.limit) delete c.limit[key]; })}
+          />
+        )}
+        {activeCategory === "scope" && (
+          <ScopeEditor
+            scope={catalog.scope ?? {}}
+            onAdd={addScope}
+            onUpdate={(key, patch) => updateSilent((c) => { if (c.scope?.[key]) Object.assign(c.scope[key], patch); })}
+            onCommit={commit}
+            onRemove={(key) => update((c) => { if (c.scope) delete c.scope[key]; })}
+          />
+        )}
+        {activeCategory === "currency" && (
+          <CurrencyEditor
+            currency={catalog.currency ?? {}}
+            onAdd={addCurrency}
+            onUpdate={(key, patch) => updateSilent((c) => { if (c.currency?.[key]) Object.assign(c.currency[key], patch); })}
+            onCommit={commit}
+            onRemove={(key) => update((c) => { if (c.currency) delete c.currency[key]; })}
+          />
+        )}
+        {activeCategory === "tax" && (
+          <TaxEditor
+            tax={catalog.tax ?? {}}
+            onAdd={addTax}
+            onUpdate={(key, patch) => updateSilent((c) => { if (c.tax?.[key]) Object.assign(c.tax[key], patch); })}
+            onCommit={commit}
+            onRemove={(key) => update((c) => { if (c.tax) delete c.tax[key]; })}
+          />
+        )}
+        {activeCategory === "auth" && (
+          <AuthEditor
+            auth={catalog.auth ?? {}}
+            onAdd={addAuth}
+            onUpdate={(key, patch) => updateSilent((c) => { if (c.auth?.[key]) Object.assign(c.auth[key], patch); })}
+            onCommit={commit}
+            onRemove={(key) => update((c) => { if (c.auth) delete c.auth[key]; })}
+          />
+        )}
+        {activeCategory === "db" && (
+          <DbEditor
+            db={catalog.db ?? {}}
+            onAdd={addDb}
+            onUpdate={(key, patch) => updateSilent((c) => { if (c.db?.[key]) Object.assign(c.db[key], patch); })}
+            onCommit={commit}
+            onRemove={(key) => update((c) => { if (c.db) delete c.db[key]; })}
+          />
+        )}
+        {activeCategory === "numbering" && (
+          <NumberingEditor
+            numbering={catalog.numbering ?? {}}
+            onAdd={addNumbering}
+            onUpdate={(key, patch) => updateSilent((c) => { if (c.numbering?.[key]) Object.assign(c.numbering[key], patch); })}
+            onCommit={commit}
+            onRemove={(key) => update((c) => { if (c.numbering) delete c.numbering[key]; })}
+          />
+        )}
+        {activeCategory === "tx" && (
+          <TxEditor
+            tx={catalog.tx ?? {}}
+            onAdd={addTx}
+            onUpdate={(key, patch) => updateSilent((c) => { if (c.tx?.[key]) Object.assign(c.tx[key], patch); })}
+            onCommit={commit}
+            onRemove={(key) => update((c) => { if (c.tx) delete c.tx[key]; })}
+          />
+        )}
+        {activeCategory === "externalOutcomeDefaults" && (
+          <ExternalOutcomeDefaultEditor
+            entries={catalog.externalOutcomeDefaults ?? {}}
+            onAdd={addExternalOutcomeDefault}
             onUpdate={(key, patch) => updateSilent((c) => {
-              if (!c.limit || !c.limit[key]) return;
-              Object.assign(c.limit[key], patch);
+              if (c.externalOutcomeDefaults?.[key]) Object.assign(c.externalOutcomeDefaults[key], patch);
             })}
             onCommit={commit}
-            onRemove={(key) => update((c) => {
-              if (c.limit) delete c.limit[key];
-            })}
+            onRemove={(key) => update((c) => { if (c.externalOutcomeDefaults) delete c.externalOutcomeDefaults[key]; })}
           />
         )}
       </div>
@@ -192,9 +322,64 @@ export function ConventionsCatalogView() {
   );
 }
 
-// ── 各カテゴリエディタ ─────────────────────────────────────────────────
+// ── 共通部品 ────────────────────────────────────────────────────────────
 
-interface MsgEntry {
+function DeleteBtn({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      className="btn btn-sm btn-link text-danger p-0"
+      onClick={onClick}
+      title="削除"
+      aria-label="削除"
+    >
+      <i className="bi bi-x" />
+    </button>
+  );
+}
+
+function NewKeyRow({
+  placeholder, value, setValue, onAdd, disabled,
+}: {
+  placeholder: string;
+  value: string;
+  setValue: (v: string) => void;
+  onAdd: () => void;
+  disabled: boolean;
+}) {
+  return (
+    <div className="conventions-new-key-row">
+      <input
+        className="form-control form-control-sm conventions-new-key-input"
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={(e) => { if (e.key === "Enter" && !disabled) { e.preventDefault(); onAdd(); } }}
+      />
+      <button
+        type="button"
+        className="btn btn-sm btn-outline-primary"
+        onClick={onAdd}
+        disabled={disabled}
+      >
+        <i className="bi bi-plus-lg" /> 追加
+      </button>
+    </div>
+  );
+}
+
+function EntriesWrapper({ children, empty }: { children: React.ReactNode; empty: boolean }) {
+  return (
+    <div className="conventions-entries">
+      {empty && <div className="conventions-empty">エントリがありません。下の入力欄から追加してください。</div>}
+      {children}
+    </div>
+  );
+}
+
+// ── 既存 3 エディタ ─────────────────────────────────────────────────────
+
+interface MsgEntryLocal {
   template: string;
   params?: string[];
   description?: string;
@@ -203,9 +388,9 @@ interface MsgEntry {
 function MsgEditor({
   msg, onAdd, onUpdate, onCommit, onRemove,
 }: {
-  msg: Record<string, MsgEntry>;
+  msg: Record<string, MsgEntryLocal>;
   onAdd: (key: string) => void;
-  onUpdate: (key: string, patch: Partial<MsgEntry>) => void;
+  onUpdate: (key: string, patch: Partial<MsgEntryLocal>) => void;
   onCommit: () => void;
   onRemove: (key: string) => void;
 }) {
@@ -213,10 +398,7 @@ function MsgEditor({
   const entries = Object.entries(msg);
 
   return (
-    <div className="conventions-entries">
-      {entries.length === 0 && (
-        <div className="conventions-empty">エントリがありません。下の入力欄から追加してください。</div>
-      )}
+    <EntriesWrapper empty={entries.length === 0}>
       <table className="conventions-table">
         <colgroup>
           <col style={{ width: "14em" }} />
@@ -267,17 +449,7 @@ function MsgEditor({
                   onBlur={onCommit}
                 />
               </td>
-              <td className="text-center">
-                <button
-                  type="button"
-                  className="btn btn-sm btn-link text-danger p-0"
-                  onClick={() => onRemove(key)}
-                  title="削除"
-                  aria-label="削除"
-                >
-                  <i className="bi bi-x" />
-                </button>
-              </td>
+              <td className="text-center"><DeleteBtn onClick={() => onRemove(key)} /></td>
             </tr>
           ))}
         </tbody>
@@ -289,24 +461,22 @@ function MsgEditor({
         onAdd={() => { const k = newKey.trim(); if (k && !msg[k]) { onAdd(k); setNewKey(""); } }}
         disabled={!newKey.trim() || Object.hasOwn(msg, newKey.trim())}
       />
-    </div>
+    </EntriesWrapper>
   );
 }
 
-interface RegexEntry {
+interface RegexEntryLocal {
   pattern: string;
   flags?: string;
   description?: string;
-  exampleValid?: string[];
-  exampleInvalid?: string[];
 }
 
 function RegexEditor({
   regex, onAdd, onUpdate, onCommit, onRemove,
 }: {
-  regex: Record<string, RegexEntry>;
+  regex: Record<string, RegexEntryLocal>;
   onAdd: (key: string) => void;
-  onUpdate: (key: string, patch: Partial<RegexEntry>) => void;
+  onUpdate: (key: string, patch: Partial<RegexEntryLocal>) => void;
   onCommit: () => void;
   onRemove: (key: string) => void;
 }) {
@@ -314,10 +484,7 @@ function RegexEditor({
   const entries = Object.entries(regex);
 
   return (
-    <div className="conventions-entries">
-      {entries.length === 0 && (
-        <div className="conventions-empty">エントリがありません。下の入力欄から追加してください。</div>
-      )}
+    <EntriesWrapper empty={entries.length === 0}>
       <table className="conventions-table">
         <colgroup>
           <col style={{ width: "14em" }} />
@@ -365,17 +532,7 @@ function RegexEditor({
                   onBlur={onCommit}
                 />
               </td>
-              <td className="text-center">
-                <button
-                  type="button"
-                  className="btn btn-sm btn-link text-danger p-0"
-                  onClick={() => onRemove(key)}
-                  title="削除"
-                  aria-label="削除"
-                >
-                  <i className="bi bi-x" />
-                </button>
-              </td>
+              <td className="text-center"><DeleteBtn onClick={() => onRemove(key)} /></td>
             </tr>
           ))}
         </tbody>
@@ -387,11 +544,11 @@ function RegexEditor({
         onAdd={() => { const k = newKey.trim(); if (k && !regex[k]) { onAdd(k); setNewKey(""); } }}
         disabled={!newKey.trim() || Object.hasOwn(regex, newKey.trim())}
       />
-    </div>
+    </EntriesWrapper>
   );
 }
 
-interface LimitEntry {
+interface LimitEntryLocal {
   value: number;
   unit?: string;
   description?: string;
@@ -400,9 +557,9 @@ interface LimitEntry {
 function LimitEditor({
   limit, onAdd, onUpdate, onCommit, onRemove,
 }: {
-  limit: Record<string, LimitEntry>;
+  limit: Record<string, LimitEntryLocal>;
   onAdd: (key: string) => void;
-  onUpdate: (key: string, patch: Partial<LimitEntry>) => void;
+  onUpdate: (key: string, patch: Partial<LimitEntryLocal>) => void;
   onCommit: () => void;
   onRemove: (key: string) => void;
 }) {
@@ -410,10 +567,7 @@ function LimitEditor({
   const entries = Object.entries(limit);
 
   return (
-    <div className="conventions-entries">
-      {entries.length === 0 && (
-        <div className="conventions-empty">エントリがありません。下の入力欄から追加してください。</div>
-      )}
+    <EntriesWrapper empty={entries.length === 0}>
       <table className="conventions-table">
         <colgroup>
           <col style={{ width: "14em" }} />
@@ -461,17 +615,7 @@ function LimitEditor({
                   onBlur={onCommit}
                 />
               </td>
-              <td className="text-center">
-                <button
-                  type="button"
-                  className="btn btn-sm btn-link text-danger p-0"
-                  onClick={() => onRemove(key)}
-                  title="削除"
-                  aria-label="削除"
-                >
-                  <i className="bi bi-x" />
-                </button>
-              </td>
+              <td className="text-center"><DeleteBtn onClick={() => onRemove(key)} /></td>
             </tr>
           ))}
         </tbody>
@@ -483,36 +627,694 @@ function LimitEditor({
         onAdd={() => { const k = newKey.trim(); if (k && !limit[k]) { onAdd(k); setNewKey(""); } }}
         disabled={!newKey.trim() || Object.hasOwn(limit, newKey.trim())}
       />
-    </div>
+    </EntriesWrapper>
   );
 }
 
-function NewKeyRow({
-  placeholder, value, setValue, onAdd, disabled,
+// ── 新規 8 エディタ ─────────────────────────────────────────────────────
+
+function ScopeEditor({
+  scope, onAdd, onUpdate, onCommit, onRemove,
 }: {
-  placeholder: string;
-  value: string;
-  setValue: (v: string) => void;
-  onAdd: () => void;
-  disabled: boolean;
+  scope: Record<string, ScopeEntry>;
+  onAdd: (key: string) => void;
+  onUpdate: (key: string, patch: Partial<ScopeEntry>) => void;
+  onCommit: () => void;
+  onRemove: (key: string) => void;
 }) {
+  const [newKey, setNewKey] = useState("");
+  const entries = Object.entries(scope);
+
   return (
-    <div className="conventions-new-key-row">
-      <input
-        className="form-control form-control-sm conventions-new-key-input"
-        placeholder={placeholder}
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-        onKeyDown={(e) => { if (e.key === "Enter" && !disabled) { e.preventDefault(); onAdd(); } }}
+    <EntriesWrapper empty={entries.length === 0}>
+      <table className="conventions-table">
+        <colgroup>
+          <col style={{ width: "14em" }} />
+          <col style={{ width: "16em" }} />
+          <col />
+          <col style={{ width: 28 }} />
+        </colgroup>
+        <thead>
+          <tr>
+            <th>key (@conv.scope.xxx)</th>
+            <th>value</th>
+            <th>description</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map(([key, entry]) => (
+            <tr key={key}>
+              <td><code className="conventions-key-badge">{key}</code></td>
+              <td>
+                <input
+                  className="form-control form-control-sm"
+                  value={entry.value}
+                  onChange={(e) => onUpdate(key, { value: e.target.value })}
+                  onBlur={onCommit}
+                  placeholder="domestic"
+                />
+              </td>
+              <td>
+                <input
+                  className="form-control form-control-sm"
+                  value={entry.description ?? ""}
+                  onChange={(e) => onUpdate(key, { description: e.target.value || undefined })}
+                  onBlur={onCommit}
+                />
+              </td>
+              <td className="text-center"><DeleteBtn onClick={() => onRemove(key)} /></td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <NewKeyRow
+        placeholder="新規 key (例: customerRegion)"
+        value={newKey}
+        setValue={setNewKey}
+        onAdd={() => { const k = newKey.trim(); if (k && !scope[k]) { onAdd(k); setNewKey(""); } }}
+        disabled={!newKey.trim() || Object.hasOwn(scope, newKey.trim())}
       />
-      <button
-        type="button"
-        className="btn btn-sm btn-outline-primary"
-        onClick={onAdd}
-        disabled={disabled}
-      >
-        <i className="bi bi-plus-lg" /> 追加
-      </button>
-    </div>
+    </EntriesWrapper>
+  );
+}
+
+const ROUNDING_OPTIONS = ["", "floor", "ceil", "round"] as const;
+
+function CurrencyEditor({
+  currency, onAdd, onUpdate, onCommit, onRemove,
+}: {
+  currency: Record<string, CurrencyEntry>;
+  onAdd: (key: string) => void;
+  onUpdate: (key: string, patch: Partial<CurrencyEntry>) => void;
+  onCommit: () => void;
+  onRemove: (key: string) => void;
+}) {
+  const [newKey, setNewKey] = useState("");
+  const entries = Object.entries(currency);
+
+  return (
+    <EntriesWrapper empty={entries.length === 0}>
+      <table className="conventions-table">
+        <colgroup>
+          <col style={{ width: "12em" }} />
+          <col style={{ width: "7em" }} />
+          <col style={{ width: "8em" }} />
+          <col style={{ width: "10em" }} />
+          <col />
+          <col style={{ width: 28 }} />
+        </colgroup>
+        <thead>
+          <tr>
+            <th>key (@conv.currency.xxx)</th>
+            <th>code (ISO 4217)</th>
+            <th>subunit</th>
+            <th>roundingMode</th>
+            <th>description</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map(([key, entry]) => (
+            <tr key={key}>
+              <td><code className="conventions-key-badge">{key}</code></td>
+              <td>
+                <input
+                  className="form-control form-control-sm conventions-mono"
+                  value={entry.code}
+                  onChange={(e) => onUpdate(key, { code: e.target.value })}
+                  onBlur={onCommit}
+                  placeholder="JPY"
+                />
+              </td>
+              <td>
+                <input
+                  type="number"
+                  className="form-control form-control-sm"
+                  value={entry.subunit ?? ""}
+                  onChange={(e) => onUpdate(key, { subunit: e.target.value === "" ? undefined : Number(e.target.value) })}
+                  onBlur={onCommit}
+                  placeholder="0"
+                  min={0}
+                />
+              </td>
+              <td>
+                <select
+                  className="form-select form-select-sm"
+                  value={entry.roundingMode ?? ""}
+                  onChange={(e) => {
+                    onUpdate(key, { roundingMode: (e.target.value || undefined) as CurrencyEntry["roundingMode"] });
+                    onCommit();
+                  }}
+                >
+                  {ROUNDING_OPTIONS.map((o) => <option key={o} value={o}>{o || "(未指定)"}</option>)}
+                </select>
+              </td>
+              <td>
+                <input
+                  className="form-control form-control-sm"
+                  value={entry.description ?? ""}
+                  onChange={(e) => onUpdate(key, { description: e.target.value || undefined })}
+                  onBlur={onCommit}
+                />
+              </td>
+              <td className="text-center"><DeleteBtn onClick={() => onRemove(key)} /></td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <NewKeyRow
+        placeholder="新規 key (例: jpy)"
+        value={newKey}
+        setValue={setNewKey}
+        onAdd={() => { const k = newKey.trim(); if (k && !currency[k]) { onAdd(k); setNewKey(""); } }}
+        disabled={!newKey.trim() || Object.hasOwn(currency, newKey.trim())}
+      />
+    </EntriesWrapper>
+  );
+}
+
+function TaxEditor({
+  tax, onAdd, onUpdate, onCommit, onRemove,
+}: {
+  tax: Record<string, TaxEntry>;
+  onAdd: (key: string) => void;
+  onUpdate: (key: string, patch: Partial<TaxEntry>) => void;
+  onCommit: () => void;
+  onRemove: (key: string) => void;
+}) {
+  const [newKey, setNewKey] = useState("");
+  const entries = Object.entries(tax);
+
+  return (
+    <EntriesWrapper empty={entries.length === 0}>
+      <table className="conventions-table">
+        <colgroup>
+          <col style={{ width: "12em" }} />
+          <col style={{ width: "10em" }} />
+          <col style={{ width: "10em" }} />
+          <col style={{ width: "10em" }} />
+          <col />
+          <col style={{ width: 28 }} />
+        </colgroup>
+        <thead>
+          <tr>
+            <th>key (@conv.tax.xxx)</th>
+            <th>kind</th>
+            <th>rate (0〜1)</th>
+            <th>roundingMode</th>
+            <th>description</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map(([key, entry]) => (
+            <tr key={key}>
+              <td><code className="conventions-key-badge">{key}</code></td>
+              <td>
+                <select
+                  className="form-select form-select-sm"
+                  value={entry.kind}
+                  onChange={(e) => { onUpdate(key, { kind: e.target.value as TaxEntry["kind"] }); onCommit(); }}
+                >
+                  <option value="exclusive">exclusive (外税)</option>
+                  <option value="inclusive">inclusive (内税)</option>
+                </select>
+              </td>
+              <td>
+                <input
+                  type="number"
+                  className="form-control form-control-sm"
+                  value={entry.rate}
+                  onChange={(e) => onUpdate(key, { rate: Number(e.target.value) })}
+                  onBlur={onCommit}
+                  step={0.01}
+                  min={0}
+                  max={1}
+                  placeholder="0.10"
+                />
+              </td>
+              <td>
+                <select
+                  className="form-select form-select-sm"
+                  value={entry.roundingMode ?? ""}
+                  onChange={(e) => {
+                    onUpdate(key, { roundingMode: (e.target.value || undefined) as TaxEntry["roundingMode"] });
+                    onCommit();
+                  }}
+                >
+                  {ROUNDING_OPTIONS.map((o) => <option key={o} value={o}>{o || "(未指定)"}</option>)}
+                </select>
+              </td>
+              <td>
+                <input
+                  className="form-control form-control-sm"
+                  value={entry.description ?? ""}
+                  onChange={(e) => onUpdate(key, { description: e.target.value || undefined })}
+                  onBlur={onCommit}
+                />
+              </td>
+              <td className="text-center"><DeleteBtn onClick={() => onRemove(key)} /></td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <NewKeyRow
+        placeholder="新規 key (例: standard)"
+        value={newKey}
+        setValue={setNewKey}
+        onAdd={() => { const k = newKey.trim(); if (k && !tax[k]) { onAdd(k); setNewKey(""); } }}
+        disabled={!newKey.trim() || Object.hasOwn(tax, newKey.trim())}
+      />
+    </EntriesWrapper>
+  );
+}
+
+function AuthEditor({
+  auth, onAdd, onUpdate, onCommit, onRemove,
+}: {
+  auth: Record<string, AuthEntry>;
+  onAdd: (key: string) => void;
+  onUpdate: (key: string, patch: Partial<AuthEntry>) => void;
+  onCommit: () => void;
+  onRemove: (key: string) => void;
+}) {
+  const [newKey, setNewKey] = useState("");
+  const entries = Object.entries(auth);
+
+  return (
+    <EntriesWrapper empty={entries.length === 0}>
+      <table className="conventions-table">
+        <colgroup>
+          <col style={{ width: "12em" }} />
+          <col style={{ width: "14em" }} />
+          <col style={{ width: "14em" }} />
+          <col style={{ width: "14em" }} />
+          <col />
+          <col style={{ width: 28 }} />
+        </colgroup>
+        <thead>
+          <tr>
+            <th>key (@conv.auth.xxx)</th>
+            <th>scheme</th>
+            <th>sessionStorage</th>
+            <th>passwordHash</th>
+            <th>description</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map(([key, entry]) => (
+            <tr key={key}>
+              <td><code className="conventions-key-badge">{key}</code></td>
+              <td>
+                <input
+                  className="form-control form-control-sm"
+                  value={entry.scheme}
+                  onChange={(e) => onUpdate(key, { scheme: e.target.value })}
+                  onBlur={onCommit}
+                  placeholder="session-cookie"
+                />
+              </td>
+              <td>
+                <input
+                  className="form-control form-control-sm"
+                  value={entry.sessionStorage ?? ""}
+                  onChange={(e) => onUpdate(key, { sessionStorage: e.target.value || undefined })}
+                  onBlur={onCommit}
+                  placeholder="httpOnly-cookie"
+                />
+              </td>
+              <td>
+                <input
+                  className="form-control form-control-sm"
+                  value={entry.passwordHash ?? ""}
+                  onChange={(e) => onUpdate(key, { passwordHash: e.target.value || undefined })}
+                  onBlur={onCommit}
+                  placeholder="bcrypt(cost=12)"
+                />
+              </td>
+              <td>
+                <input
+                  className="form-control form-control-sm"
+                  value={entry.description ?? ""}
+                  onChange={(e) => onUpdate(key, { description: e.target.value || undefined })}
+                  onBlur={onCommit}
+                />
+              </td>
+              <td className="text-center"><DeleteBtn onClick={() => onRemove(key)} /></td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <NewKeyRow
+        placeholder="新規 key (例: default)"
+        value={newKey}
+        setValue={setNewKey}
+        onAdd={() => { const k = newKey.trim(); if (k && !auth[k]) { onAdd(k); setNewKey(""); } }}
+        disabled={!newKey.trim() || Object.hasOwn(auth, newKey.trim())}
+      />
+    </EntriesWrapper>
+  );
+}
+
+function DbEditor({
+  db, onAdd, onUpdate, onCommit, onRemove,
+}: {
+  db: Record<string, DbEntry>;
+  onAdd: (key: string) => void;
+  onUpdate: (key: string, patch: Partial<DbEntry>) => void;
+  onCommit: () => void;
+  onRemove: (key: string) => void;
+}) {
+  const [newKey, setNewKey] = useState("");
+  const entries = Object.entries(db);
+
+  return (
+    <EntriesWrapper empty={entries.length === 0}>
+      <table className="conventions-table">
+        <colgroup>
+          <col style={{ width: "12em" }} />
+          <col style={{ width: "12em" }} />
+          <col style={{ width: "10em" }} />
+          <col style={{ width: "16em" }} />
+          <col style={{ width: "12em" }} />
+          <col />
+          <col style={{ width: 28 }} />
+        </colgroup>
+        <thead>
+          <tr>
+            <th>key (@conv.db.xxx)</th>
+            <th>engine</th>
+            <th>namingConvention</th>
+            <th>timestampColumns (カンマ区切り)</th>
+            <th>logicalDeleteColumn</th>
+            <th>description</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map(([key, entry]) => (
+            <tr key={key}>
+              <td><code className="conventions-key-badge">{key}</code></td>
+              <td>
+                <input
+                  className="form-control form-control-sm"
+                  value={entry.engine ?? ""}
+                  onChange={(e) => onUpdate(key, { engine: e.target.value || undefined })}
+                  onBlur={onCommit}
+                  placeholder="postgresql@14"
+                />
+              </td>
+              <td>
+                <input
+                  className="form-control form-control-sm"
+                  value={entry.namingConvention ?? ""}
+                  onChange={(e) => onUpdate(key, { namingConvention: e.target.value || undefined })}
+                  onBlur={onCommit}
+                  placeholder="snake_case"
+                />
+              </td>
+              <td>
+                <input
+                  className="form-control form-control-sm"
+                  value={(entry.timestampColumns ?? []).join(", ")}
+                  onChange={(e) => {
+                    const cols = e.target.value.split(",").map((s) => s.trim()).filter(Boolean);
+                    onUpdate(key, { timestampColumns: cols.length > 0 ? cols : undefined });
+                  }}
+                  onBlur={onCommit}
+                  placeholder="created_at, updated_at"
+                />
+              </td>
+              <td>
+                <input
+                  className="form-control form-control-sm"
+                  value={entry.logicalDeleteColumn ?? ""}
+                  onChange={(e) => onUpdate(key, { logicalDeleteColumn: e.target.value || undefined })}
+                  onBlur={onCommit}
+                  placeholder="is_deleted"
+                />
+              </td>
+              <td>
+                <input
+                  className="form-control form-control-sm"
+                  value={entry.description ?? ""}
+                  onChange={(e) => onUpdate(key, { description: e.target.value || undefined })}
+                  onBlur={onCommit}
+                />
+              </td>
+              <td className="text-center"><DeleteBtn onClick={() => onRemove(key)} /></td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <NewKeyRow
+        placeholder="新規 key (例: default)"
+        value={newKey}
+        setValue={setNewKey}
+        onAdd={() => { const k = newKey.trim(); if (k && !db[k]) { onAdd(k); setNewKey(""); } }}
+        disabled={!newKey.trim() || Object.hasOwn(db, newKey.trim())}
+      />
+    </EntriesWrapper>
+  );
+}
+
+function NumberingEditor({
+  numbering, onAdd, onUpdate, onCommit, onRemove,
+}: {
+  numbering: Record<string, NumberingEntry>;
+  onAdd: (key: string) => void;
+  onUpdate: (key: string, patch: Partial<NumberingEntry>) => void;
+  onCommit: () => void;
+  onRemove: (key: string) => void;
+}) {
+  const [newKey, setNewKey] = useState("");
+  const entries = Object.entries(numbering);
+
+  return (
+    <EntriesWrapper empty={entries.length === 0}>
+      <table className="conventions-table">
+        <colgroup>
+          <col style={{ width: "14em" }} />
+          <col style={{ width: "14em" }} />
+          <col style={{ width: "18em" }} />
+          <col />
+          <col style={{ width: 28 }} />
+        </colgroup>
+        <thead>
+          <tr>
+            <th>key (@conv.numbering.xxx)</th>
+            <th>format</th>
+            <th>implementation</th>
+            <th>description</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map(([key, entry]) => (
+            <tr key={key}>
+              <td><code className="conventions-key-badge">{key}</code></td>
+              <td>
+                <input
+                  className="form-control form-control-sm conventions-mono"
+                  value={entry.format}
+                  onChange={(e) => onUpdate(key, { format: e.target.value })}
+                  onBlur={onCommit}
+                  placeholder="C-NNNN"
+                />
+              </td>
+              <td>
+                <input
+                  className="form-control form-control-sm"
+                  value={entry.implementation ?? ""}
+                  onChange={(e) => onUpdate(key, { implementation: e.target.value || undefined })}
+                  onBlur={onCommit}
+                  placeholder="PG sequence + DEFAULT"
+                />
+              </td>
+              <td>
+                <input
+                  className="form-control form-control-sm"
+                  value={entry.description ?? ""}
+                  onChange={(e) => onUpdate(key, { description: e.target.value || undefined })}
+                  onBlur={onCommit}
+                />
+              </td>
+              <td className="text-center"><DeleteBtn onClick={() => onRemove(key)} /></td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <NewKeyRow
+        placeholder="新規 key (例: customerCode)"
+        value={newKey}
+        setValue={setNewKey}
+        onAdd={() => { const k = newKey.trim(); if (k && !numbering[k]) { onAdd(k); setNewKey(""); } }}
+        disabled={!newKey.trim() || Object.hasOwn(numbering, newKey.trim())}
+      />
+    </EntriesWrapper>
+  );
+}
+
+function TxEditor({
+  tx, onAdd, onUpdate, onCommit, onRemove,
+}: {
+  tx: Record<string, TxEntry>;
+  onAdd: (key: string) => void;
+  onUpdate: (key: string, patch: Partial<TxEntry>) => void;
+  onCommit: () => void;
+  onRemove: (key: string) => void;
+}) {
+  const [newKey, setNewKey] = useState("");
+  const entries = Object.entries(tx);
+
+  return (
+    <EntriesWrapper empty={entries.length === 0}>
+      <table className="conventions-table">
+        <colgroup>
+          <col style={{ width: "14em" }} />
+          <col />
+          <col style={{ width: "18em" }} />
+          <col style={{ width: 28 }} />
+        </colgroup>
+        <thead>
+          <tr>
+            <th>key (@conv.tx.xxx)</th>
+            <th>policy</th>
+            <th>description</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map(([key, entry]) => (
+            <tr key={key}>
+              <td><code className="conventions-key-badge">{key}</code></td>
+              <td>
+                <textarea
+                  className="form-control form-control-sm conventions-table-textarea"
+                  value={entry.policy}
+                  onChange={(e) => onUpdate(key, { policy: e.target.value })}
+                  onBlur={onCommit}
+                  rows={2}
+                  placeholder="単一操作は 1 TX..."
+                />
+              </td>
+              <td>
+                <input
+                  className="form-control form-control-sm"
+                  value={entry.description ?? ""}
+                  onChange={(e) => onUpdate(key, { description: e.target.value || undefined })}
+                  onBlur={onCommit}
+                />
+              </td>
+              <td className="text-center"><DeleteBtn onClick={() => onRemove(key)} /></td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <NewKeyRow
+        placeholder="新規 key (例: singleOperation)"
+        value={newKey}
+        setValue={setNewKey}
+        onAdd={() => { const k = newKey.trim(); if (k && !tx[k]) { onAdd(k); setNewKey(""); } }}
+        disabled={!newKey.trim() || Object.hasOwn(tx, newKey.trim())}
+      />
+    </EntriesWrapper>
+  );
+}
+
+const OUTCOME_OPTIONS: ExternalOutcomeDefaultEntry["outcome"][] = ["success", "failure", "timeout"];
+const ACTION_OPTIONS: ExternalOutcomeDefaultEntry["action"][] = ["continue", "abort", "compensate"];
+const RETRY_OPTIONS = ["", "none", "fixed", "exponential"] as const;
+
+function ExternalOutcomeDefaultEditor({
+  entries: entriesMap, onAdd, onUpdate, onCommit, onRemove,
+}: {
+  entries: Record<string, ExternalOutcomeDefaultEntry>;
+  onAdd: (key: string) => void;
+  onUpdate: (key: string, patch: Partial<ExternalOutcomeDefaultEntry>) => void;
+  onCommit: () => void;
+  onRemove: (key: string) => void;
+}) {
+  const [newKey, setNewKey] = useState("");
+  const entries = Object.entries(entriesMap);
+
+  return (
+    <EntriesWrapper empty={entries.length === 0}>
+      <table className="conventions-table">
+        <colgroup>
+          <col style={{ width: "12em" }} />
+          <col style={{ width: "10em" }} />
+          <col style={{ width: "10em" }} />
+          <col style={{ width: "12em" }} />
+          <col />
+          <col style={{ width: 28 }} />
+        </colgroup>
+        <thead>
+          <tr>
+            <th>key (@conv.externalOutcomeDefaults.xxx)</th>
+            <th>outcome</th>
+            <th>action</th>
+            <th>retry</th>
+            <th>description</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map(([key, entry]) => (
+            <tr key={key}>
+              <td><code className="conventions-key-badge">{key}</code></td>
+              <td>
+                <select
+                  className="form-select form-select-sm"
+                  value={entry.outcome}
+                  onChange={(e) => { onUpdate(key, { outcome: e.target.value as ExternalOutcomeDefaultEntry["outcome"] }); onCommit(); }}
+                >
+                  {OUTCOME_OPTIONS.map((o) => <option key={o} value={o}>{o}</option>)}
+                </select>
+              </td>
+              <td>
+                <select
+                  className="form-select form-select-sm"
+                  value={entry.action}
+                  onChange={(e) => { onUpdate(key, { action: e.target.value as ExternalOutcomeDefaultEntry["action"] }); onCommit(); }}
+                >
+                  {ACTION_OPTIONS.map((o) => <option key={o} value={o}>{o}</option>)}
+                </select>
+              </td>
+              <td>
+                <select
+                  className="form-select form-select-sm"
+                  value={entry.retry ?? ""}
+                  onChange={(e) => {
+                    onUpdate(key, { retry: (e.target.value || undefined) as ExternalOutcomeDefaultEntry["retry"] });
+                    onCommit();
+                  }}
+                >
+                  {RETRY_OPTIONS.map((o) => <option key={o} value={o}>{o || "(未指定)"}</option>)}
+                </select>
+              </td>
+              <td>
+                <input
+                  className="form-control form-control-sm"
+                  value={entry.description ?? ""}
+                  onChange={(e) => onUpdate(key, { description: e.target.value || undefined })}
+                  onBlur={onCommit}
+                />
+              </td>
+              <td className="text-center"><DeleteBtn onClick={() => onRemove(key)} /></td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <NewKeyRow
+        placeholder="新規 key (例: failure)"
+        value={newKey}
+        setValue={setNewKey}
+        onAdd={() => { const k = newKey.trim(); if (k && !entriesMap[k]) { onAdd(k); setNewKey(""); } }}
+        disabled={!newKey.trim() || Object.hasOwn(entriesMap, newKey.trim())}
+      />
+    </EntriesWrapper>
   );
 }

--- a/designer/src/hooks/useConvCompletion.test.ts
+++ b/designer/src/hooks/useConvCompletion.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+import { computeCompletion, insertCandidate } from "./useConvCompletion";
+import type { ConventionsCatalog } from "../schemas/conventionsValidator";
+
+const catalog: ConventionsCatalog = {
+  version: "1.0.0",
+  msg: { required: { template: "{label}は必須入力です" } },
+  regex: { "email-simple": { pattern: "^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$" } },
+  limit: { nameMax: { value: 100, unit: "char" } },
+  scope: { customerRegion: { value: "domestic" } },
+  currency: { jpy: { code: "JPY" }, usd: { code: "USD" } },
+  tax: { standard: { kind: "exclusive", rate: 0.1 } },
+  auth: { default: { scheme: "session-cookie" } },
+  db: { default: { engine: "postgresql@14" } },
+  numbering: { customerCode: { format: "C-NNNN" }, orderNumber: { format: "ORD-YYYY-NNNN" } },
+  tx: { singleOperation: { policy: "1 TX" } },
+  externalOutcomeDefaults: {
+    success: { outcome: "success", action: "continue" },
+    failure: { outcome: "failure", action: "abort" },
+  },
+};
+
+describe("computeCompletion", () => {
+  it("catalog が null → idle", () => {
+    expect(computeCompletion("@conv.", 6, null)).toEqual({ phase: "idle" });
+  });
+
+  it("@conv. → category phase / 全 11 候補", () => {
+    const r = computeCompletion("@conv.", 6, catalog);
+    expect(r.phase).toBe("category");
+    if (r.phase === "category") {
+      expect(r.candidates).toHaveLength(11);
+      expect(r.prefix).toBe("");
+    }
+  });
+
+  it("@conv.curre → category phase / 1 候補 (currency)", () => {
+    const v = "@conv.curre";
+    const r = computeCompletion(v, v.length, catalog);
+    expect(r.phase).toBe("category");
+    if (r.phase === "category") {
+      expect(r.candidates).toEqual(["currency"]);
+      expect(r.prefix).toBe("curre");
+    }
+  });
+
+  it("@conv.currency. → key phase / catalog.currency の全キー", () => {
+    const v = "@conv.currency.";
+    const r = computeCompletion(v, v.length, catalog);
+    expect(r.phase).toBe("key");
+    if (r.phase === "key") {
+      expect(r.candidates).toContain("jpy");
+      expect(r.candidates).toContain("usd");
+      expect(r.prefix).toBe("");
+    }
+  });
+
+  it("@conv.currency.j → key phase / prefix 'j' でフィルタ", () => {
+    const v = "@conv.currency.j";
+    const r = computeCompletion(v, v.length, catalog);
+    expect(r.phase).toBe("key");
+    if (r.phase === "key") {
+      expect(r.candidates).toEqual(["jpy"]);
+      expect(r.prefix).toBe("j");
+    }
+  });
+
+  it("文中 @conv.msg.req でカーソルが 'req' 末尾 → key phase / msg カテゴリ", () => {
+    const v = "foo @conv.msg.req bar";
+    const cursor = "foo @conv.msg.req".length;
+    const r = computeCompletion(v, cursor, catalog);
+    expect(r.phase).toBe("key");
+    if (r.phase === "key") {
+      expect(r.category).toBe("msg");
+      expect(r.candidates).toEqual(["required"]);
+    }
+  });
+
+  it("@conv.unknown. → idle (catalog に存在しないカテゴリ)", () => {
+    const v = "@conv.unknown.";
+    const r = computeCompletion(v, v.length, catalog);
+    expect(r.phase).toBe("idle");
+  });
+
+  it("@conv だけで '.' がない → category phase / prefix ''", () => {
+    const v = "@conv";
+    const r = computeCompletion(v, v.length, catalog);
+    expect(r.phase).toBe("category");
+  });
+
+  it("関係ないテキスト → idle", () => {
+    const v = "Math.floor(subtotal * 0.10)";
+    const r = computeCompletion(v, v.length, catalog);
+    expect(r.phase).toBe("idle");
+  });
+
+  it("scope / tax / auth / db / numbering / tx / externalOutcomeDefaults も key phase を返す", () => {
+    for (const cat of ["scope", "tax", "auth", "db", "numbering", "tx", "externalOutcomeDefaults"]) {
+      const v = `@conv.${cat}.`;
+      const r = computeCompletion(v, v.length, catalog);
+      expect(r.phase).toBe("key");
+    }
+  });
+});
+
+describe("insertCandidate", () => {
+  it("category phase: prefix を置換し末尾に '.' を追加", () => {
+    const v = "@conv.curre";
+    const state = computeCompletion(v, v.length, catalog);
+    const { newValue, newCursor } = insertCandidate(v, v.length, state, "currency");
+    expect(newValue).toBe("@conv.currency.");
+    expect(newCursor).toBe(newValue.length);
+  });
+
+  it("key phase: prefix を置換 (末尾に '.' なし)", () => {
+    const v = "@conv.currency.j";
+    const state = computeCompletion(v, v.length, catalog);
+    const { newValue, newCursor } = insertCandidate(v, v.length, state, "jpy");
+    expect(newValue).toBe("@conv.currency.jpy");
+    expect(newCursor).toBe(newValue.length);
+  });
+
+  it("カーソルが文中: カーソル以降を保持", () => {
+    const v = "@conv.curre xxx";
+    const cursor = "@conv.curre".length;
+    const state = computeCompletion(v, cursor, catalog);
+    const { newValue, newCursor } = insertCandidate(v, cursor, state, "currency");
+    expect(newValue).toBe("@conv.currency. xxx");
+    expect(newCursor).toBe("@conv.currency.".length);
+  });
+
+  it("idle state → 変更なし", () => {
+    const v = "hello";
+    const { newValue, newCursor } = insertCandidate(v, 5, { phase: "idle" }, "anything");
+    expect(newValue).toBe("hello");
+    expect(newCursor).toBe(5);
+  });
+});

--- a/designer/src/hooks/useConvCompletion.ts
+++ b/designer/src/hooks/useConvCompletion.ts
@@ -1,0 +1,60 @@
+import type { ConventionsCatalog } from "../schemas/conventionsValidator";
+
+export const ALL_CONV_CATEGORIES = [
+  "msg", "regex", "limit", "scope", "currency", "tax", "auth",
+  "db", "numbering", "tx", "externalOutcomeDefaults",
+] as const;
+
+export type CompletionState =
+  | { phase: "idle" }
+  | { phase: "category"; prefix: string; candidates: string[] }
+  | { phase: "key"; category: string; prefix: string; candidates: string[] };
+
+/**
+ * カーソル直前の @conv.* パターンから補完状態を計算する純粋関数。
+ * catalog が null なら常に idle を返す。
+ */
+export function computeCompletion(
+  value: string,
+  cursorPos: number,
+  catalog: ConventionsCatalog | null,
+): CompletionState {
+  if (!catalog) return { phase: "idle" };
+  const before = value.slice(0, cursorPos);
+  const m = before.match(/@conv(?:\.([\w-]*)(?:\.([\w-]*))?)?$/);
+  if (!m) return { phase: "idle" };
+
+  const catPart = m[1];
+  const keyPart = m[2];
+
+  if (keyPart === undefined) {
+    const prefix = catPart ?? "";
+    const candidates = ALL_CONV_CATEGORIES.filter((c) => c.startsWith(prefix));
+    return { phase: "category", prefix, candidates: [...candidates] };
+  } else {
+    const cat = (catalog as Record<string, unknown>)[catPart!];
+    if (!cat || typeof cat !== "object") return { phase: "idle" };
+    const keys = Object.keys(cat);
+    const candidates = keys.filter((k) => k.startsWith(keyPart));
+    return { phase: "key", category: catPart!, prefix: keyPart, candidates };
+  }
+}
+
+/**
+ * 補完候補を確定してテキストに挿入する純粋関数。
+ * category phase では末尾に "." を付与し、key phase では置換のみ。
+ */
+export function insertCandidate(
+  value: string,
+  cursorPos: number,
+  state: CompletionState,
+  picked: string,
+): { newValue: string; newCursor: number } {
+  if (state.phase === "idle") return { newValue: value, newCursor: cursorPos };
+  const before = value.slice(0, cursorPos);
+  const after = value.slice(cursorPos);
+  const prefixLen = state.prefix.length;
+  const trailing = state.phase === "category" ? "." : "";
+  const newBefore = before.slice(0, before.length - prefixLen) + picked + trailing;
+  return { newValue: newBefore + after, newCursor: newBefore.length };
+}

--- a/designer/src/schemas/conventionsValidator.test.ts
+++ b/designer/src/schemas/conventionsValidator.test.ts
@@ -136,6 +136,123 @@ describe("checkConventionReferences", () => {
     expect(issues.some((i) => i.code === "UNKNOWN_CONV_CATEGORY")).toBe(true);
   });
 
+  it("@conv.scope.customerRegion は accept", () => {
+    const issues = checkConventionReferences(
+      makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [{ id: "s1", type: "other", description: "対象: @conv.scope.customerRegion" }],
+        }],
+      }),
+      catalog,
+    );
+    expect(issues).toHaveLength(0);
+  });
+
+  it("@conv.scope.unknownKey は UNKNOWN_CONV_CATEGORY", () => {
+    const issues = checkConventionReferences(
+      makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [{ id: "s1", type: "other", description: "@conv.scope.unknownKey" }],
+        }],
+      }),
+      catalog,
+    );
+    expect(issues.some((i) => i.code === "UNKNOWN_CONV_CATEGORY")).toBe(true);
+  });
+
+  it("@conv.currency.jpy は accept", () => {
+    const issues = checkConventionReferences(
+      makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [{ id: "s1", type: "other", description: "通貨: @conv.currency.jpy" }],
+        }],
+      }),
+      catalog,
+    );
+    expect(issues).toHaveLength(0);
+  });
+
+  it("@conv.tax.standard は accept", () => {
+    const issues = checkConventionReferences(
+      makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [{ id: "s1", type: "other", description: "税率: @conv.tax.standard" }],
+        }],
+      }),
+      catalog,
+    );
+    expect(issues).toHaveLength(0);
+  });
+
+  it("@conv.auth.default は accept", () => {
+    const issues = checkConventionReferences(
+      makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [{ id: "s1", type: "other", description: "認証: @conv.auth.default" }],
+        }],
+      }),
+      catalog,
+    );
+    expect(issues).toHaveLength(0);
+  });
+
+  it("@conv.db.default は accept", () => {
+    const issues = checkConventionReferences(
+      makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [{ id: "s1", type: "other", description: "DB: @conv.db.default" }],
+        }],
+      }),
+      catalog,
+    );
+    expect(issues).toHaveLength(0);
+  });
+
+  it("@conv.numbering.customerCode は accept", () => {
+    const issues = checkConventionReferences(
+      makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [{ id: "s1", type: "other", description: "採番: @conv.numbering.customerCode" }],
+        }],
+      }),
+      catalog,
+    );
+    expect(issues).toHaveLength(0);
+  });
+
+  it("@conv.tx.singleOperation は accept", () => {
+    const issues = checkConventionReferences(
+      makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [{ id: "s1", type: "other", description: "TX: @conv.tx.singleOperation" }],
+        }],
+      }),
+      catalog,
+    );
+    expect(issues).toHaveLength(0);
+  });
+
+  it("@conv.externalOutcomeDefaults.failure は accept", () => {
+    const issues = checkConventionReferences(
+      makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [{ id: "s1", type: "other", description: "失敗時: @conv.externalOutcomeDefaults.failure" }],
+        }],
+      }),
+      catalog,
+    );
+    expect(issues).toHaveLength(0);
+  });
+
   it("catalog が null (未ロード) なら検査スキップ", () => {
     const issues = checkConventionReferences(
       makeGroup({

--- a/designer/src/schemas/conventionsValidator.test.ts
+++ b/designer/src/schemas/conventionsValidator.test.ts
@@ -149,7 +149,7 @@ describe("checkConventionReferences", () => {
     expect(issues).toHaveLength(0);
   });
 
-  it("@conv.scope.unknownKey は UNKNOWN_CONV_CATEGORY", () => {
+  it("@conv.scope.unknownKey は UNKNOWN_CONV_SCOPE", () => {
     const issues = checkConventionReferences(
       makeGroup({
         actions: [{
@@ -159,7 +159,7 @@ describe("checkConventionReferences", () => {
       }),
       catalog,
     );
-    expect(issues.some((i) => i.code === "UNKNOWN_CONV_CATEGORY")).toBe(true);
+    expect(issues.some((i) => i.code === "UNKNOWN_CONV_SCOPE")).toBe(true);
   });
 
   it("@conv.currency.jpy は accept", () => {
@@ -251,6 +251,66 @@ describe("checkConventionReferences", () => {
       catalog,
     );
     expect(issues).toHaveLength(0);
+  });
+
+  // ── 新カテゴリ: 不在キーは専用エラーコード (PR-A3) ──────────────────
+
+  const makeGroupWithDesc = (desc: string) => makeGroup({
+    actions: [{ id: "a1", name: "f", trigger: "click", steps: [{ id: "s1", type: "other", description: desc }] }],
+  });
+
+  it("@conv.currency.unknown は UNKNOWN_CONV_CURRENCY", () => {
+    const issues = checkConventionReferences(makeGroupWithDesc("@conv.currency.unknown"), catalog);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("UNKNOWN_CONV_CURRENCY");
+  });
+
+  it("@conv.tax.unknown は UNKNOWN_CONV_TAX", () => {
+    const issues = checkConventionReferences(makeGroupWithDesc("@conv.tax.unknown"), catalog);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("UNKNOWN_CONV_TAX");
+  });
+
+  it("@conv.auth.unknown は UNKNOWN_CONV_AUTH", () => {
+    const issues = checkConventionReferences(makeGroupWithDesc("@conv.auth.unknown"), catalog);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("UNKNOWN_CONV_AUTH");
+  });
+
+  it("@conv.db.unknown は UNKNOWN_CONV_DB", () => {
+    const issues = checkConventionReferences(makeGroupWithDesc("@conv.db.unknown"), catalog);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("UNKNOWN_CONV_DB");
+  });
+
+  it("@conv.numbering.unknown は UNKNOWN_CONV_NUMBERING", () => {
+    const issues = checkConventionReferences(makeGroupWithDesc("@conv.numbering.unknown"), catalog);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("UNKNOWN_CONV_NUMBERING");
+  });
+
+  it("@conv.tx.unknown は UNKNOWN_CONV_TX", () => {
+    const issues = checkConventionReferences(makeGroupWithDesc("@conv.tx.unknown"), catalog);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("UNKNOWN_CONV_TX");
+  });
+
+  it("@conv.externalOutcomeDefaults.unknown は UNKNOWN_CONV_EXTERNAL_OUTCOME_DEFAULTS", () => {
+    const issues = checkConventionReferences(makeGroupWithDesc("@conv.externalOutcomeDefaults.unknown"), catalog);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("UNKNOWN_CONV_EXTERNAL_OUTCOME_DEFAULTS");
+  });
+
+  it("@conv.scope.unknown は UNKNOWN_CONV_SCOPE (inline catalog)", () => {
+    const inlineCatalog: ConventionsCatalog = { version: "1.0.0", scope: { customerRegion: { value: "domestic" } } };
+    const issues = checkConventionReferences(makeGroupWithDesc("@conv.scope.unknown"), inlineCatalog);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("UNKNOWN_CONV_SCOPE");
+  });
+
+  it("@conv.color.red は (未定義カテゴリ) UNKNOWN_CONV_CATEGORY", () => {
+    const issues = checkConventionReferences(makeGroupWithDesc("@conv.color.red"), catalog);
+    expect(issues.some((i) => i.code === "UNKNOWN_CONV_CATEGORY")).toBe(true);
   });
 
   it("catalog が null (未ロード) なら検査スキップ", () => {

--- a/designer/src/schemas/conventionsValidator.ts
+++ b/designer/src/schemas/conventionsValidator.ts
@@ -45,6 +45,14 @@ export interface ConventionIssue {
     | "UNKNOWN_CONV_MSG"
     | "UNKNOWN_CONV_REGEX"
     | "UNKNOWN_CONV_LIMIT"
+    | "UNKNOWN_CONV_SCOPE"
+    | "UNKNOWN_CONV_CURRENCY"
+    | "UNKNOWN_CONV_TAX"
+    | "UNKNOWN_CONV_AUTH"
+    | "UNKNOWN_CONV_DB"
+    | "UNKNOWN_CONV_NUMBERING"
+    | "UNKNOWN_CONV_TX"
+    | "UNKNOWN_CONV_EXTERNAL_OUTCOME_DEFAULTS"
     | "UNKNOWN_CONV_CATEGORY";
   value: string;
   message: string;
@@ -68,6 +76,14 @@ function codeFor(category: string): ConventionIssue["code"] {
     case "msg": return "UNKNOWN_CONV_MSG";
     case "regex": return "UNKNOWN_CONV_REGEX";
     case "limit": return "UNKNOWN_CONV_LIMIT";
+    case "scope": return "UNKNOWN_CONV_SCOPE";
+    case "currency": return "UNKNOWN_CONV_CURRENCY";
+    case "tax": return "UNKNOWN_CONV_TAX";
+    case "auth": return "UNKNOWN_CONV_AUTH";
+    case "db": return "UNKNOWN_CONV_DB";
+    case "numbering": return "UNKNOWN_CONV_NUMBERING";
+    case "tx": return "UNKNOWN_CONV_TX";
+    case "externalOutcomeDefaults": return "UNKNOWN_CONV_EXTERNAL_OUTCOME_DEFAULTS";
     default: return "UNKNOWN_CONV_CATEGORY";
   }
 }

--- a/designer/src/schemas/conventionsValidator.ts
+++ b/designer/src/schemas/conventionsValidator.ts
@@ -93,14 +93,14 @@ function resolveCategory(catalog: ConventionsCatalog, category: string): Record<
     case "msg": return catalog.msg ?? null;
     case "regex": return catalog.regex ?? null;
     case "limit": return catalog.limit ?? null;
-    case "scope": return catalog.scope as Record<string, unknown> ?? null;
-    case "currency": return catalog.currency as Record<string, unknown> ?? null;
-    case "tax": return catalog.tax as Record<string, unknown> ?? null;
-    case "auth": return catalog.auth as Record<string, unknown> ?? null;
-    case "db": return catalog.db as Record<string, unknown> ?? null;
-    case "numbering": return catalog.numbering as Record<string, unknown> ?? null;
-    case "tx": return catalog.tx as Record<string, unknown> ?? null;
-    case "externalOutcomeDefaults": return catalog.externalOutcomeDefaults as Record<string, unknown> ?? null;
+    case "scope": return catalog.scope ?? null;
+    case "currency": return catalog.currency ?? null;
+    case "tax": return catalog.tax ?? null;
+    case "auth": return catalog.auth ?? null;
+    case "db": return catalog.db ?? null;
+    case "numbering": return catalog.numbering ?? null;
+    case "tx": return catalog.tx ?? null;
+    case "externalOutcomeDefaults": return catalog.externalOutcomeDefaults ?? null;
     default: return null;
   }
 }

--- a/designer/src/schemas/conventionsValidator.ts
+++ b/designer/src/schemas/conventionsValidator.ts
@@ -11,6 +11,16 @@ import type {
   ValidationStep,
   LoopStep,
 } from "../types/action";
+import type {
+  ScopeEntry,
+  CurrencyEntry,
+  TaxEntry,
+  AuthEntry,
+  DbEntry,
+  NumberingEntry,
+  TxEntry,
+  ExternalOutcomeDefaultEntry,
+} from "../types/conventions";
 
 export interface ConventionsCatalog {
   version: string;
@@ -19,6 +29,14 @@ export interface ConventionsCatalog {
   msg?: Record<string, { template: string; params?: string[]; description?: string }>;
   regex?: Record<string, { pattern: string; flags?: string; description?: string; exampleValid?: string[]; exampleInvalid?: string[] }>;
   limit?: Record<string, { value: number; unit?: string; description?: string }>;
+  scope?: Record<string, ScopeEntry>;
+  currency?: Record<string, CurrencyEntry>;
+  tax?: Record<string, TaxEntry>;
+  auth?: Record<string, AuthEntry>;
+  db?: Record<string, DbEntry>;
+  numbering?: Record<string, NumberingEntry>;
+  tx?: Record<string, TxEntry>;
+  externalOutcomeDefaults?: Record<string, ExternalOutcomeDefaultEntry>;
 }
 
 export interface ConventionIssue {
@@ -55,10 +73,20 @@ function codeFor(category: string): ConventionIssue["code"] {
 }
 
 function resolveCategory(catalog: ConventionsCatalog, category: string): Record<string, unknown> | null {
-  if (category === "msg") return catalog.msg ?? null;
-  if (category === "regex") return catalog.regex ?? null;
-  if (category === "limit") return catalog.limit ?? null;
-  return null;
+  switch (category) {
+    case "msg": return catalog.msg ?? null;
+    case "regex": return catalog.regex ?? null;
+    case "limit": return catalog.limit ?? null;
+    case "scope": return catalog.scope as Record<string, unknown> ?? null;
+    case "currency": return catalog.currency as Record<string, unknown> ?? null;
+    case "tax": return catalog.tax as Record<string, unknown> ?? null;
+    case "auth": return catalog.auth as Record<string, unknown> ?? null;
+    case "db": return catalog.db as Record<string, unknown> ?? null;
+    case "numbering": return catalog.numbering as Record<string, unknown> ?? null;
+    case "tx": return catalog.tx as Record<string, unknown> ?? null;
+    case "externalOutcomeDefaults": return catalog.externalOutcomeDefaults as Record<string, unknown> ?? null;
+    default: return null;
+  }
 }
 
 /** ActionGroup 全体で @conv.* 参照を検査。catalog が null なら検査 skip */
@@ -146,7 +174,7 @@ function checkStep(step: Step, path: string, catalog: ConventionsCatalog, issues
           path: `${path}.${field}`,
           code: "UNKNOWN_CONV_CATEGORY",
           value: `@conv.${category}.${key}`,
-          message: `@conv.${category}.* カテゴリは規約カタログに存在しません (msg/regex/limit のみ)`,
+          message: `@conv.${category}.* カテゴリは規約カタログに存在しません`,
         });
         continue;
       }

--- a/designer/src/store/conventionsStore.ts
+++ b/designer/src/store/conventionsStore.ts
@@ -34,7 +34,15 @@ export function createEmptyCatalog(): ConventionsCatalog {
     msg: {},
     regex: {},
     limit: {},
-  } as ConventionsCatalog;
+    scope: {},
+    currency: {},
+    tax: {},
+    auth: {},
+    db: {},
+    numbering: {},
+    tx: {},
+    externalOutcomeDefaults: {},
+  };
 }
 
 export async function loadConventions(): Promise<ConventionsCatalog | null> {

--- a/designer/src/styles/conventions.css
+++ b/designer/src/styles/conventions.css
@@ -32,13 +32,35 @@
   min-width: 20em;
 }
 
+.conventions-tabs-area {
+  background: #fff;
+  border-bottom: 2px solid #e2e8f0;
+}
+
+.conventions-tab-group {
+  display: flex;
+  align-items: center;
+  padding: 0 14px;
+  gap: 0;
+}
+
+.conventions-tab-group-label {
+  font-size: 0.68rem;
+  font-weight: 700;
+  color: #94a3b8;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+  padding-right: 10px;
+  flex-shrink: 0;
+  min-width: 8em;
+}
+
 .conventions-category-tabs {
   display: flex;
   gap: 0;
-  border-bottom: 2px solid #e2e8f0;
-  padding: 0 14px;
-  background: #fff;
   overflow-x: auto;
+  flex: 1;
 }
 
 .conventions-category-tab {
@@ -170,4 +192,13 @@
 .conventions-new-key-input {
   flex: 1 1 auto;
   max-width: 24em;
+}
+
+.conventions-table-textarea {
+  font-size: 0.82rem;
+  padding: 2px 6px;
+  resize: vertical;
+  min-height: 36px;
+  height: auto;
+  width: 100%;
 }

--- a/designer/src/types/conventions.ts
+++ b/designer/src/types/conventions.ts
@@ -1,0 +1,51 @@
+export interface ScopeEntry {
+  value: string;
+  description?: string;
+}
+
+export interface CurrencyEntry {
+  code: string;
+  subunit?: number;
+  roundingMode?: "floor" | "ceil" | "round";
+  description?: string;
+}
+
+export interface TaxEntry {
+  kind: "inclusive" | "exclusive";
+  rate: number;
+  roundingMode?: "floor" | "ceil" | "round";
+  description?: string;
+}
+
+export interface AuthEntry {
+  scheme: string;
+  sessionStorage?: string;
+  passwordHash?: string;
+  description?: string;
+}
+
+export interface DbEntry {
+  engine?: string;
+  namingConvention?: string;
+  timestampColumns?: string[];
+  logicalDeleteColumn?: string;
+  description?: string;
+}
+
+export interface NumberingEntry {
+  format: string;
+  implementation?: string;
+  description?: string;
+}
+
+export interface TxEntry {
+  policy: string;
+  description?: string;
+}
+
+export interface ExternalOutcomeDefaultEntry {
+  outcome: "success" | "failure" | "timeout";
+  action: "continue" | "abort" | "compensate";
+  retry?: "none" | "fixed" | "exponential";
+  description?: string;
+}

--- a/docs/conventions/product-scope.md
+++ b/docs/conventions/product-scope.md
@@ -1,12 +1,14 @@
-# プロダクトスコープ規約 (プレースホルダー)
+# プロダクトスコープ規約 (人間向け参考資料)
 
-**ステータス**: Placeholder (仮)
+> **正本は `data/conventions/catalog.json`** (scope / currency / tax / auth / db / numbering / tx / externalOutcomeDefaults カテゴリ)。
+> 本 md はその人間向け参考資料であり、AI・ツールは JSON を参照すること (#346)。
+> `docs/sample-project/conventions/conventions-catalog.json` が seed データ。
+> `docs/conventions/validation-rules.md` と同じ扱い。
+
 **策定日**: 2026-04-20
-**関連 issue**: #151 (A: 設計書種別の追加)
+**関連 issue**: #151 (A: 設計書種別の追加), #346
 
 本書は処理フロー仕様書が暗黙の前提とするプロダクトの**業務スコープ**を定める。個別の仕様書で「国内のみか? 多言語対応要否?」等を毎回書かなくて済むよう、ここで一括宣言する。
-
-**位置づけ**: 将来 designer アプリ内の「システム全体の規約」機能 (issue #151-A) で置き換えられる予定。現時点はテキスト形式の placeholder。
 
 ---
 

--- a/docs/sample-project/conventions/conventions-catalog.json
+++ b/docs/sample-project/conventions/conventions-catalog.json
@@ -76,5 +76,93 @@
     "quantityMax": { "value": 9999, "unit": "integer", "description": "発注可能数量の上限" },
     "quantityMin": { "value": 1, "unit": "integer" },
     "amountMax": { "value": 999999999999, "unit": "yen", "description": "DECIMAL(12,0) の上限、JPY" }
+  },
+
+  "scope": {
+    "customerRegion": { "value": "domestic", "description": "国内顧客のみ (日本国内在住/在所)" },
+    "timezone": { "value": "Asia/Tokyo", "description": "JST 固定。海外顧客はスコープ外" },
+    "language": { "value": "ja", "description": "日本語のみ。多言語化 (i18n) はスコープ外" }
+  },
+
+  "currency": {
+    "jpy": {
+      "code": "JPY",
+      "subunit": 0,
+      "roundingMode": "floor",
+      "description": "日本円のみ。外税 10%、1 円未満切り捨て、DECIMAL(12,0) 保存"
+    }
+  },
+
+  "tax": {
+    "standard": {
+      "kind": "exclusive",
+      "rate": 0.10,
+      "roundingMode": "floor",
+      "description": "消費税 外税 10% (2026 年時点)、1 円未満切り捨て"
+    }
+  },
+
+  "auth": {
+    "default": {
+      "scheme": "session-cookie",
+      "sessionStorage": "httpOnly-cookie",
+      "passwordHash": "bcrypt(cost=12)",
+      "description": "httpOnly Cookie セッション + bcrypt(cost=12) パスワードハッシュ"
+    }
+  },
+
+  "db": {
+    "default": {
+      "engine": "postgresql@14",
+      "namingConvention": "snake_case",
+      "timestampColumns": ["created_at", "updated_at"],
+      "logicalDeleteColumn": "is_deleted",
+      "description": "PostgreSQL 14+、snake_case、論理削除 is_deleted、タイムスタンプ自動管理"
+    }
+  },
+
+  "numbering": {
+    "customerCode": {
+      "format": "C-NNNN",
+      "implementation": "PG sequence + DEFAULT",
+      "description": "顧客コード 4 桁ゼロパディング (例: C-0001)"
+    },
+    "orderNumber": {
+      "format": "ORD-YYYY-NNNN",
+      "implementation": "PG sequence + trigger",
+      "description": "注文番号 年+4 桁ゼロパディング (例: ORD-2026-0001)"
+    }
+  },
+
+  "tx": {
+    "singleOperation": {
+      "policy": "単一操作は 1 TX。複数操作が原子的である必要があれば明示的に TX 境界を指定",
+      "description": "標準トランザクション方針"
+    },
+    "externalApi": {
+      "policy": "外部 API 呼出は TX 外を原則とする (DB ロック時間短縮、冪等性の外部管理)",
+      "description": "外部 API 連携トランザクション方針"
+    }
+  },
+
+  "externalOutcomeDefaults": {
+    "success": {
+      "outcome": "success",
+      "action": "continue",
+      "retry": "none",
+      "description": "正常完了: 続行"
+    },
+    "failure": {
+      "outcome": "failure",
+      "action": "abort",
+      "retry": "none",
+      "description": "4xx/5xx 明示エラー: クリティカルな呼出は中断。v1 はリトライなし"
+    },
+    "timeout": {
+      "outcome": "timeout",
+      "action": "abort",
+      "retry": "none",
+      "description": "タイムアウト (既定 10 秒): failure と同じ扱い。v1 はリトライなし"
+    }
   }
 }

--- a/schemas/conventions.schema.json
+++ b/schemas/conventions.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/csilost2001/html-designer/main/schemas/conventions.schema.json",
   "title": "ConventionsCatalog (横断規約カタログ)",
-  "description": "処理フロー仕様書から @conv.msg.* / @conv.regex.* / @conv.limit.* として参照される横断規約の正規 JSON 形式 (#151-A / #261 残)。docs/conventions/validation-rules.md の構造化版。",
+  "description": "処理フロー仕様書から @conv.* として参照される横断規約の正規 JSON 形式 (#151-A / #261 残)。docs/conventions/validation-rules.md / product-scope.md の構造化版。",
   "type": "object",
   "required": ["version"],
   "additionalProperties": false,
@@ -26,6 +26,47 @@
       "type": "object",
       "description": "境界値カタログ。@conv.limit.<key> で参照",
       "additionalProperties": { "$ref": "#/$defs/LimitEntry" }
+    },
+
+    "scope": {
+      "type": "object",
+      "description": "顧客・業務スコープ定義。@conv.scope.<key> で参照",
+      "additionalProperties": { "$ref": "#/$defs/ScopeEntry" }
+    },
+    "currency": {
+      "type": "object",
+      "description": "通貨定義。@conv.currency.<key> で参照",
+      "additionalProperties": { "$ref": "#/$defs/CurrencyEntry" }
+    },
+    "tax": {
+      "type": "object",
+      "description": "税率定義。@conv.tax.<key> で参照",
+      "additionalProperties": { "$ref": "#/$defs/TaxEntry" }
+    },
+    "auth": {
+      "type": "object",
+      "description": "認証・セッション定義。@conv.auth.<key> で参照",
+      "additionalProperties": { "$ref": "#/$defs/AuthEntry" }
+    },
+    "db": {
+      "type": "object",
+      "description": "DB 規約定義。@conv.db.<key> で参照",
+      "additionalProperties": { "$ref": "#/$defs/DbEntry" }
+    },
+    "numbering": {
+      "type": "object",
+      "description": "採番規約定義。@conv.numbering.<key> で参照",
+      "additionalProperties": { "$ref": "#/$defs/NumberingEntry" }
+    },
+    "tx": {
+      "type": "object",
+      "description": "トランザクション方針定義。@conv.tx.<key> で参照",
+      "additionalProperties": { "$ref": "#/$defs/TxEntry" }
+    },
+    "externalOutcomeDefaults": {
+      "type": "object",
+      "description": "外部連携 outcome 規約。@conv.externalOutcomeDefaults.<key> で参照",
+      "additionalProperties": { "$ref": "#/$defs/ExternalOutcomeDefaultEntry" }
     }
   },
 
@@ -76,6 +117,97 @@
           "description": "char / integer / yen / ms 等の単位",
           "examples": ["char", "integer", "yen", "ms"]
         },
+        "description": { "type": "string" }
+      }
+    },
+
+    "ScopeEntry": {
+      "type": "object",
+      "required": ["value"],
+      "additionalProperties": false,
+      "properties": {
+        "value": { "type": "string" },
+        "description": { "type": "string" }
+      }
+    },
+
+    "CurrencyEntry": {
+      "type": "object",
+      "required": ["code"],
+      "additionalProperties": false,
+      "properties": {
+        "code": { "type": "string", "description": "ISO 4217 通貨コード (例: JPY)" },
+        "subunit": { "type": "integer", "description": "小数点以下桁数 (0=円単位、2=セント単位)" },
+        "roundingMode": { "type": "string", "enum": ["floor", "ceil", "round"] },
+        "description": { "type": "string" }
+      }
+    },
+
+    "TaxEntry": {
+      "type": "object",
+      "required": ["kind", "rate"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "type": "string", "enum": ["inclusive", "exclusive"] },
+        "rate": { "type": "number", "minimum": 0, "maximum": 1, "description": "0..1 (例: 0.10)" },
+        "roundingMode": { "type": "string", "enum": ["floor", "ceil", "round"] },
+        "description": { "type": "string" }
+      }
+    },
+
+    "AuthEntry": {
+      "type": "object",
+      "required": ["scheme"],
+      "additionalProperties": false,
+      "properties": {
+        "scheme": { "type": "string", "description": "session-cookie / bearer-jwt / basic" },
+        "sessionStorage": { "type": "string", "description": "httpOnly-cookie / redis / memory" },
+        "passwordHash": { "type": "string", "description": "bcrypt(cost=12) / argon2id" },
+        "description": { "type": "string" }
+      }
+    },
+
+    "DbEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "engine": { "type": "string", "description": "例: postgresql@14" },
+        "namingConvention": { "type": "string", "description": "例: snake_case" },
+        "timestampColumns": { "type": "array", "items": { "type": "string" } },
+        "logicalDeleteColumn": { "type": "string", "description": "例: is_deleted" },
+        "description": { "type": "string" }
+      }
+    },
+
+    "NumberingEntry": {
+      "type": "object",
+      "required": ["format"],
+      "additionalProperties": false,
+      "properties": {
+        "format": { "type": "string", "description": "例: C-NNNN / ORD-YYYY-NNNN" },
+        "implementation": { "type": "string", "description": "例: PG sequence + DEFAULT" },
+        "description": { "type": "string" }
+      }
+    },
+
+    "TxEntry": {
+      "type": "object",
+      "required": ["policy"],
+      "additionalProperties": false,
+      "properties": {
+        "policy": { "type": "string" },
+        "description": { "type": "string" }
+      }
+    },
+
+    "ExternalOutcomeDefaultEntry": {
+      "type": "object",
+      "required": ["outcome", "action"],
+      "additionalProperties": false,
+      "properties": {
+        "outcome": { "type": "string", "enum": ["success", "failure", "timeout"] },
+        "action": { "type": "string", "enum": ["continue", "abort", "compensate"] },
+        "retry": { "type": "string", "enum": ["none", "fixed", "exponential"] },
         "description": { "type": "string" }
       }
     }

--- a/scripts/migrate-product-scope.mjs
+++ b/scripts/migrate-product-scope.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * product-scope.md の内容を data/conventions/catalog.json の 8 新カテゴリとしてマージする。
+ *
+ * Dry-run (差分表示のみ):  node scripts/migrate-product-scope.mjs
+ * 適用:                    node scripts/migrate-product-scope.mjs --apply
+ *
+ * 動作:
+ *   - 既存 catalog に無いキーを seed から追加 (ADD 表示)
+ *   - 既存 catalog に既にあるキーは上書きしない (SKIP 表示)
+ *   - msg / regex / limit など既存カテゴリは一切触らない
+ *   - 冪等 (2 回目実行で差分 0)
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "..");
+
+const catalogPath = resolve(repoRoot, "data/conventions/catalog.json");
+const seedPath = resolve(repoRoot, "docs/sample-project/conventions/conventions-catalog.json");
+
+const NEW_CATEGORIES = [
+  "scope",
+  "currency",
+  "tax",
+  "auth",
+  "db",
+  "numbering",
+  "tx",
+  "externalOutcomeDefaults",
+];
+
+const applyMode = process.argv.includes("--apply");
+
+// seed を読む
+const seed = JSON.parse(readFileSync(seedPath, "utf-8"));
+
+// 既存 catalog を読む。なければ seed 全体を copy して完了
+if (!existsSync(catalogPath)) {
+  if (applyMode) {
+    mkdirSync(dirname(catalogPath), { recursive: true });
+    writeFileSync(catalogPath, JSON.stringify(seed, null, 2) + "\n", "utf-8");
+    console.log("CREATED data/conventions/catalog.json from seed (file did not exist)");
+  } else {
+    console.log("data/conventions/catalog.json not found. --apply で seed 全体を copy します。");
+  }
+  process.exit(0);
+}
+
+const catalog = JSON.parse(readFileSync(catalogPath, "utf-8"));
+
+let hasChanges = false;
+
+for (const cat of NEW_CATEGORIES) {
+  const seedEntries = seed[cat];
+  if (!seedEntries || typeof seedEntries !== "object") continue;
+
+  if (!catalog[cat]) catalog[cat] = {};
+
+  for (const [key, entry] of Object.entries(seedEntries)) {
+    if (key in catalog[cat]) {
+      console.log(`SKIP existing  ${cat}.${key}`);
+    } else {
+      console.log(`ADD            ${cat}.${key}`);
+      catalog[cat][key] = entry;
+      hasChanges = true;
+    }
+  }
+}
+
+if (!hasChanges) {
+  console.log("差分なし (catalog は既に最新です)");
+  process.exit(0);
+}
+
+if (applyMode) {
+  catalog.updatedAt = new Date().toISOString();
+  writeFileSync(catalogPath, JSON.stringify(catalog, null, 2) + "\n", "utf-8");
+  console.log("\ndata/conventions/catalog.json を更新しました。");
+} else {
+  console.log("\n--apply を付けて実行すると上記の差分を適用します。");
+}


### PR DESCRIPTION
## 概要

メタ ISSUE #151-A 残作業「プロダクト規約カタログ層の正式機能化」を 4 PR シリーズで実装。

Closes #346
Closes #347
Closes #348
Closes #349

## 変更内容

### PR-A1 (#346): データ層 — 型・スキーマ・seed・migration
- `designer/src/types/conventions.ts` (新規): 8 entry 型 (ScopeEntry / CurrencyEntry / TaxEntry / AuthEntry / DbEntry / NumberingEntry / TxEntry / ExternalOutcomeDefaultEntry)
- `schemas/conventions.schema.json`: 8 カテゴリの `$defs` + `properties` 追加
- `docs/sample-project/conventions/conventions-catalog.json`: product-scope.md 由来の seed データ
- `designer/src/schemas/conventionsValidator.ts`: `ConventionsCatalog` に 8 フィールド追加、`resolveCategory` 拡張
- `designer/src/store/conventionsStore.ts`: `createEmptyCatalog()` に 8 カテゴリ初期化
- `docs/conventions/product-scope.md`: 「正本は JSON」注記を冒頭に追加
- `scripts/migrate-product-scope.mjs` (新規): dry-run / `--apply` / 冪等マイグレーション

### PR-A2 (#347): UI — ConventionsCatalogView に 8 タブ追加
- `ConventionsCatalogView.tsx`: 11 タブ 2 グループ構成 (入力バリデーション / プロダクト規約)、8 新 Editor コンポーネント
- `conventions.css`: グループヘッダースタイル追加
- Playwright 更新 + 新規 12 件追加

### PR-A3 (#348): Lint — @conv.* エラーコードを 8 カテゴリ専用に細分化
- `ConventionIssue.code`: `UNKNOWN_CONV_SCOPE` 〜 `UNKNOWN_CONV_EXTERNAL_OUTCOME_DEFAULTS` の 8 コード追加
- `codeFor()`: 8 新カテゴリに専用コードを返す分岐追加
- Vitest 新規 9 件追加

### PR-A4 (#349): @conv.* 入力補完ポップアップ
- `useConvCompletion.ts` (新規): `computeCompletion` / `insertCandidate` 純粋関数
- `ConvCompletionInput.tsx` (新規): ↑↓ Enter Esc 対応の補完ポップアップ付き input
- `StepCard.tsx` / `SortableStepCard.tsx` / `ActionEditor.tsx` / `ValidationRulesPanel.tsx`: `conventions` props 追加、ComputeStep.expression / ReturnStep.bodyExpression / ValidationRule.message・condition に適用
- Vitest 14 件 + Playwright 6 件追加

## テスト結果

- Vitest: **627 件 green** (44 ファイル)
- Playwright: **conventions-catalog 関連 17 件 + conv-completion 6 件 全 pass**

## 仕様逐条突合 (自己申告)

### #346 受け入れ条件
- [x] 8 カテゴリの型が追加されスキーマと整合 (ajv pass): `schemas/conventions.schema.json:line62-160` + `conventionsValidator.test.ts:line29-38`
- [x] seed に 8 カテゴリそれぞれ最低 1 件: `docs/sample-project/conventions/conventions-catalog.json:line81-165`
- [x] migration script が冪等: `scripts/migrate-product-scope.mjs` (手動確認済み)
- [x] 既存 Vitest / Playwright green: 上記テスト結果
- [x] `product-scope.md` 冒頭に「正本は JSON」注記: `docs/conventions/product-scope.md:line1-9`
- [x] 本 ISSUE 単独では PR を作らない: 統合 PR で対応

### #347 受け入れ条件
- [x] 11 タブが 2 段グループで表示: `ConventionsCatalogView.tsx:renderTabGroup()` + `conventions.css:.conventions-tab-group-label`
- [x] 8 新カテゴリそれぞれで add / edit / delete / save が動作: Playwright 12 件 (`conventions-catalog-product.spec.ts`)
- [x] unsaved 警告が動作: 既存 `useResourceEditor` 流用 (`ConventionsCatalogView.tsx:line68-70`)
- [x] Playwright 新規 spec 全件 green: 17 件 pass
- [x] 既存 Playwright green: 確認済み
- [x] 本 ISSUE 単独では PR を作らない: 統合 PR で対応

### #348 受け入れ条件
- [x] 新カテゴリ 8 種の UNKNOWN_CONV_* コードが追加: `conventionsValidator.ts:line44-54`
- [x] 既存 3 カテゴリの挙動は回帰なし: Vitest 627 件 green
- [x] 新カテゴリの解決成功 / 不在キー / 不在カテゴリの 3 パターン: `conventionsValidator.test.ts:line156-270`
- [x] 本 ISSUE 単独では PR を作らない: 統合 PR で対応

### #349 受け入れ条件
- [x] `@conv.` 入力で popup が表示される: `conv-completion.spec.ts:line78`
- [x] 2 段選択 (category → key) でテキスト挿入できる: `conv-completion.spec.ts:line112`
- [x] Vitest `useConvCompletion.test.ts` 全件 green: 14 件 pass
- [x] Playwright 新規 spec 全件 green: 6 件 pass
- [x] 既存 ActionEditor E2E に回帰なし: 確認済み
- [x] 統合 PR の description に 4 ISSUE 全て `Closes` 記法で列挙: 本 PR 冒頭

## レビュー指摘対応 (b9d8c08)

| 種別 | 箇所 | 対応 |
|------|------|------|
| Must-fix | `StepCard.tsx` InlineStepList | `conventions` prop 追加 + branch/else/loop 3 call site に伝播 |
| Should-fix | `ConvCompletionInput.tsx:13` | 未使用 `autoComplete?: string` を削除 |
| Should-fix | `conventions-catalog-product.spec.ts` | save → reload → 値が残る E2E テストを追加 |
| Nit | `conventionsValidator.ts:96-103` | 不要な `as Record<string, unknown>` キャストを除去 |

## UI 影響

- **ConventionsCatalogView** (`/conventions/catalog`): タブ 2 グループ化 + 8 新カテゴリ編集 UI
- **ActionEditor** (ComputeStep / ReturnStep / ValidationStep): `@conv.` 入力で補完ポップアップ表示

**UI 影響あり → ユーザーの目視確認必須。auto テスト green 単独ではマージ不可。**  
レビューは別セッションで `/review-pr <PR番号>` を実施してください。

## スコープ外 (follow-up)

- ホバープレビュー (catalog.description を tooltip 表示)
- typed 引数チェック (msg.params と {placeholder} 整合)
- バージョン固定 / 破壊的変更検知

🤖 Generated with [Claude Code](https://claude.com/claude-code)