### PR TITLE
feat(screen-items): @conv.* lint + ConvCompletionInput 装着 + errorMessages UI (#351 #352)

### DIFF
--- a/designer/e2e/screen-items.spec.ts
+++ b/designer/e2e/screen-items.spec.ts
@@ -6,11 +6,29 @@
  * - 新規項目の追加 / name / type / required 編集
  * - 項目の削除
  * - 保存ボタン押下で isDirty が解消されること
+ * - @conv.* lint バナー表示 (#351)
+ * - pattern 欄の @conv.* 補完 (#352)
+ * - errorMessages.* 保存・リロード後の永続化 (#352)
  */
 import { test, expect, type Page } from "@playwright/test";
 
 const screenId1 = "scr-1";
 const screenId2 = "scr-2";
+
+const sampleCatalog = {
+  version: "1.0.0",
+  msg: { required: { template: "{label}は必須入力です" } },
+  regex: { "email-simple": { pattern: "^[^@]+@[^@]+$", description: "メールアドレス" } },
+  limit: {},
+  scope: {},
+  currency: {},
+  tax: {},
+  auth: {},
+  db: {},
+  numbering: {},
+  tx: {},
+  externalOutcomeDefaults: {},
+};
 
 const dummyProject = {
   version: 1,
@@ -23,14 +41,21 @@ const dummyProject = {
   updatedAt: new Date().toISOString(),
 };
 
-async function setup(page: Page) {
+interface SetupOptions {
+  /** 規約カタログを localStorage にシード (lint / 補完テスト用) */
+  catalog?: typeof sampleCatalog;
+  /** 画面項目定義を localStorage にシード */
+  screenItems?: Record<string, unknown>;
+}
+
+async function setup(page: Page, opts: SetupOptions = {}) {
   // MCP WebSocket をブロックして localStorage モードに固定する。
   // 接続が成立するとプロジェクトが実 MCP データで上書きされ、
   // テスト途中で画面切替が発生して状態がリセットされるため。
   await page.routeWebSocket(/ws:\/\/localhost:5179/, (ws) => {
     ws.close();
   });
-  await page.addInitScript(({ project }) => {
+  await page.addInitScript(({ project, catalog, screenItems }) => {
     localStorage.setItem("flow-project", JSON.stringify(project));
     localStorage.removeItem("designer-open-tabs");
     localStorage.removeItem("designer-active-tab");
@@ -39,7 +64,17 @@ async function setup(page: Page) {
         localStorage.removeItem(k);
       }
     }
-  }, { project: dummyProject });
+    if (catalog) {
+      localStorage.setItem("conventions-catalog", JSON.stringify(catalog));
+    } else {
+      localStorage.removeItem("conventions-catalog");
+    }
+    if (screenItems) {
+      for (const [key, val] of Object.entries(screenItems)) {
+        localStorage.setItem(key, JSON.stringify(val));
+      }
+    }
+  }, { project: dummyProject, catalog: opts.catalog ?? null, screenItems: opts.screenItems ?? null });
   await page.goto("/screen-items");
   await expect(page.locator(".screen-items-view")).toBeVisible({ timeout: 10000 });
 }
@@ -183,5 +218,110 @@ test.describe("画面項目定義プロトタイプ (#318)", () => {
     await labelInput.click();
     await expect.poll(() => alertFired, { timeout: 3000 }).toBe(true);
     await expect(idInput).toHaveValue("myField", { timeout: 2000 });
+  });
+});
+
+test.describe("@conv.* lint + 補完 + errorMessages 永続化 (#351 #352)", () => {
+  test("存在しない @conv.regex を pattern に書いて保存すると lint バナーが表示される", async ({ page }) => {
+    await setup(page, { catalog: sampleCatalog });
+    // 項目追加
+    await page.locator(".screen-items-view button:has-text('項目追加')").click();
+    const row = page.locator(".screen-items-table tbody tr:last-child");
+    await row.locator('input[placeholder="email"]').fill("phone");
+    // pattern 欄に存在しないキー
+    const patternInput = row.locator('input[placeholder="@conv.regex.email-simple"]');
+    await patternInput.fill("@conv.regex.no-such-key");
+    await patternInput.blur();
+    // 保存
+    await page.locator(".srb-btn-save").click();
+    await expect(page.locator(".srb-btn-save")).toBeDisabled({ timeout: 3000 });
+    // lint バナーが表示される
+    await expect(page.locator(".screen-items-lint-warnings")).toBeVisible({ timeout: 3000 });
+    await expect(page.locator(".screen-items-lint-warnings")).toContainText("@conv.regex.no-such-key");
+  });
+
+  test("実在する @conv.regex を pattern に書いても lint バナーが出ない", async ({ page }) => {
+    await setup(page, { catalog: sampleCatalog });
+    await page.locator(".screen-items-view button:has-text('項目追加')").click();
+    const row = page.locator(".screen-items-table tbody tr:last-child");
+    await row.locator('input[placeholder="email"]').fill("email");
+    const patternInput = row.locator('input[placeholder="@conv.regex.email-simple"]');
+    await patternInput.fill("@conv.regex.email-simple");
+    await patternInput.blur();
+    await page.locator(".srb-btn-save").click();
+    await expect(page.locator(".srb-btn-save")).toBeDisabled({ timeout: 3000 });
+    await expect(page.locator(".screen-items-lint-warnings")).toHaveCount(0);
+  });
+
+  test("pattern 欄で @conv. と打つと補完ポップアップが表示される", async ({ page }) => {
+    await setup(page, { catalog: sampleCatalog });
+    await page.locator(".screen-items-view button:has-text('項目追加')").click();
+    const row = page.locator(".screen-items-table tbody tr:last-child");
+    const patternInput = row.locator('input[placeholder="@conv.regex.email-simple"]');
+    await patternInput.click();
+    await patternInput.fill("@conv.");
+    await expect(page.locator('[role="listbox"]')).toBeVisible({ timeout: 3000 });
+  });
+
+  test("errorMessages.required を入力して保存すると localStorage に永続化される", async ({ page }) => {
+    await setup(page, { catalog: sampleCatalog });
+    await page.locator(".screen-items-view button:has-text('項目追加')").click();
+    const row = page.locator(".screen-items-table tbody tr:last-child");
+    await row.locator('input[placeholder="email"]').fill("email");
+    // 💬 ボタンで errorMessages 展開
+    await row.locator('button[aria-label="エラーメッセージ展開"]').click();
+    const errorRow = page.locator(".screen-items-error-row").last();
+    await expect(errorRow).toBeVisible({ timeout: 3000 });
+    // required フィールドに入力
+    const requiredInput = errorRow.locator('input[placeholder="@conv.msg.required"]');
+    await requiredInput.fill("@conv.msg.required");
+    await requiredInput.blur();
+    // 保存
+    await page.locator(".srb-btn-save").click();
+    await expect(page.locator(".srb-btn-save")).toBeDisabled({ timeout: 3000 });
+    // localStorage に errorMessages が書き込まれていることを確認
+    const stored = await page.evaluate((sid) => {
+      const raw = localStorage.getItem(`screen-items-${sid}`);
+      return raw ? JSON.parse(raw) : null;
+    }, screenId1);
+    expect(stored).not.toBeNull();
+    expect(stored.items[0].errorMessages?.required).toBe("@conv.msg.required");
+  });
+
+  test("保存済み errorMessages を持つ画面項目は展開後に値が表示される", async ({ page }) => {
+    // リロード相当: 初期 localStorage に errorMessages 込みのデータを seed して表示を検証
+    const preSeeded = {
+      screenId: screenId1,
+      version: "0.1.0",
+      updatedAt: new Date().toISOString(),
+      items: [{ id: "email", label: "メール", type: "string", errorMessages: { required: "@conv.msg.required" } }],
+    };
+    await setup(page, {
+      catalog: sampleCatalog,
+      screenItems: { [`screen-items-${screenId1}`]: preSeeded },
+    });
+    // 展開して値を確認
+    const row = page.locator(".screen-items-table tbody tr:last-child");
+    await row.locator('button[aria-label="エラーメッセージ展開"]').click();
+    const errorRow = page.locator(".screen-items-error-row").last();
+    await expect(errorRow.locator('input[placeholder="@conv.msg.required"]')).toHaveValue("@conv.msg.required", { timeout: 3000 });
+  });
+
+  test("画面切替で errorMessages 展開状態がリセットされる", async ({ page }) => {
+    await setup(page, { catalog: sampleCatalog });
+    await page.locator(".screen-items-view button:has-text('項目追加')").click();
+    const row = page.locator(".screen-items-table tbody tr:last-child");
+    // 💬 ボタンで展開
+    await row.locator('button[aria-label="エラーメッセージ展開"]').click();
+    await expect(page.locator(".screen-items-error-row")).toBeVisible({ timeout: 3000 });
+    // 保存して画面切替
+    await page.locator(".srb-btn-save").click();
+    await expect(page.locator(".srb-btn-save")).toBeDisabled({ timeout: 3000 });
+    await page.locator(".screen-items-screen-select").selectOption(screenId2);
+    // scr-2 では展開行なし
+    await expect(page.locator(".screen-items-error-row")).toHaveCount(0);
+    // scr-1 に戻っても展開状態はリセットされている
+    await page.locator(".screen-items-screen-select").selectOption(screenId1);
+    await expect(page.locator(".screen-items-error-row")).toHaveCount(0);
   });
 });

--- a/designer/src/components/action/ActionHttpContractPanel.tsx
+++ b/designer/src/components/action/ActionHttpContractPanel.tsx
@@ -138,7 +138,7 @@ export function ActionHttpContractPanel({ action, onChange }: Props) {
                 <input
                   type="text"
                   className="form-control form-control-sm"
-                  value={r.bodySchema ?? ""}
+                  value={typeof r.bodySchema === "string" ? (r.bodySchema ?? "") : ""}
                   onChange={(e) => updateResponse(i, { bodySchema: e.target.value || undefined })}
                   placeholder="bodySchema"
                   style={{ fontSize: "0.8rem" }}

--- a/designer/src/components/action/ActionHttpContractPanel.tsx
+++ b/designer/src/components/action/ActionHttpContractPanel.tsx
@@ -138,7 +138,7 @@ export function ActionHttpContractPanel({ action, onChange }: Props) {
                 <input
                   type="text"
                   className="form-control form-control-sm"
-                  value={typeof r.bodySchema === "string" ? (r.bodySchema ?? "") : ""}
+                  value={typeof r.bodySchema === "string" ? r.bodySchema : ""}
                   onChange={(e) => updateResponse(i, { bodySchema: e.target.value || undefined })}
                   placeholder="bodySchema"
                   style={{ fontSize: "0.8rem" }}

--- a/designer/src/components/action/StepCard.tsx
+++ b/designer/src/components/action/StepCard.tsx
@@ -1292,7 +1292,7 @@ export function StepCard({
                             <span className="badge bg-info text-dark" style={{ fontSize: "0.7rem" }}>tryCatch</span>
                             <input
                               className="form-control form-control-sm"
-                              value={br.condition.errorCode}
+                              value={(br.condition as { kind: "tryCatch"; errorCode: string }).errorCode}
                               placeholder="errorCode (例: STOCK_SHORTAGE)"
                               onChange={(e) => setBranchAt(bi, {
                                 ...br,

--- a/designer/src/components/screen-items/ScreenItemsView.tsx
+++ b/designer/src/components/screen-items/ScreenItemsView.tsx
@@ -471,9 +471,10 @@ export function ScreenItemsView() {
     });
   }, []);
 
-  // ファイル切替時に選択を解除
+  // ファイル切替時に選択・展開状態をリセット
   useEffect(() => {
     setSelectedIndices(new Set());
+    setExpandedErrorRows(new Set());
   }, [selectedScreenId]);
 
   const selectedScreenName = screens.find((s) => s.id === selectedScreenId)?.name;
@@ -741,7 +742,7 @@ export function ScreenItemsView() {
                                 onCommit={commit}
                                 conventions={conventions}
                                 className="form-control form-control-sm"
-                                placeholder={`@conv.msg.${key === "required" ? "required" : key === "invalidFormat" ? "invalidFormat" : key}`}
+                                placeholder={`@conv.msg.${key}`}
                               />
                             </label>
                           ))}

--- a/designer/src/components/screen-items/ScreenItemsView.tsx
+++ b/designer/src/components/screen-items/ScreenItemsView.tsx
@@ -9,7 +9,7 @@
  * 2. 画面デザインから選択 (#323 — モーダルで候補リスト + チェックボックス)
  * 3. (将来) GrapesJS サイドバーからの直接追加 (#322)
  */
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { usePersistentState } from "../../hooks/usePersistentState";
 import { TableSubToolbar } from "../table/TableSubToolbar";
 import { EditorHeader } from "../common/EditorHeader";
@@ -20,9 +20,13 @@ import {
   saveScreenItems,
 } from "../../store/screenItemsStore";
 import { loadProject } from "../../store/flowStore";
+import { loadConventions } from "../../store/conventionsStore";
+import { checkScreenItemConventionReferences } from "../../schemas/conventionsValidator";
+import type { ConventionsCatalog, ConventionIssue } from "../../schemas/conventionsValidator";
 import { mcpBridge } from "../../mcp/mcpBridge";
 import type { ScreenItem, ScreenItemsFile } from "../../types/screenItem";
 import type { FieldType } from "../../types/action";
+import { ConvCompletionInput } from "../common/ConvCompletionInput";
 import { ScreenItemCandidatesModal } from "./ScreenItemCandidatesModal";
 import type { ExtractedCandidate } from "../../utils/screenItemExtractor";
 import { generateAutoId, getFieldTypePrefix } from "../../utils/screenItemNaming";
@@ -50,6 +54,9 @@ export function ScreenItemsView() {
     undefined,
   );
   const [candidatesModalOpen, setCandidatesModalOpen] = useState(false);
+  const [conventions, setConventions] = useState<ConventionsCatalog | null>(null);
+  const [lintIssues, setLintIssues] = useState<ConventionIssue[]>([]);
+  const [expandedErrorRows, setExpandedErrorRows] = useState<Set<number>>(new Set());
 
   /** ID フィールドのフォーカス時の値 (行インデックス → 元の値) */
   const idFocusVals = useRef<Map<number, string>>(new Map());
@@ -72,6 +79,11 @@ export function ScreenItemsView() {
 
   /** 複数選択中の行インデックス */
   const [selectedIndices, setSelectedIndices] = useState<Set<number>>(new Set());
+
+  // 規約カタログをロード (初回のみ)
+  useEffect(() => {
+    loadConventions().then(setConventions).catch(console.error);
+  }, []);
 
   // 画面一覧をロード (初回 + MCP 接続復帰時)
   useEffect(() => {
@@ -144,6 +156,14 @@ export function ScreenItemsView() {
       f.items.splice(idx, 1);
     });
     setSelectedIndices((prev) => {
+      const next = new Set<number>();
+      for (const i of prev) {
+        if (i < idx) next.add(i);
+        else if (i > idx) next.add(i - 1);
+      }
+      return next;
+    });
+    setExpandedErrorRows((prev) => {
       const next = new Set<number>();
       for (const i of prev) {
         if (i < idx) next.add(i);
@@ -396,6 +416,26 @@ export function ScreenItemsView() {
     setPendingRename(null);
   }, [pendingRename, updateSilent, commit]);
 
+  // @conv.* lint (file または conventions 更新時)
+  useEffect(() => {
+    if (!file || !conventions) { setLintIssues([]); return; }
+    setLintIssues(checkScreenItemConventionReferences(file, conventions));
+  }, [file, conventions]);
+
+  // 行インデックスごとの lint issues (行ハイライト用)
+  const lintByRow = useMemo(() => {
+    const map = new Map<number, ConventionIssue[]>();
+    for (const issue of lintIssues) {
+      const m = issue.path.match(/^items\[(\d+)\]/);
+      if (m) {
+        const idx = +m[1];
+        if (!map.has(idx)) map.set(idx, []);
+        map.get(idx)!.push(issue);
+      }
+    }
+    return map;
+  }, [lintIssues]);
+
   const existingIds = useMemo(
     () => new Set((file?.items ?? []).map((i) => i.id).filter(Boolean)),
     [file]
@@ -412,6 +452,24 @@ export function ScreenItemsView() {
       setSelectedIndices(new Set(Array.from({ length: itemCount }, (_, i) => i)));
     }
   }, [allSelected, itemCount]);
+
+  const handleUpdateErrorMessage = useCallback((idx: number, key: string, val: string) => {
+    updateSilent((f) => {
+      const em = { ...(f.items[idx].errorMessages ?? {}) };
+      if (val) em[key] = val;
+      else delete em[key];
+      f.items[idx].errorMessages = Object.keys(em).length > 0 ? em : undefined;
+    });
+  }, [updateSilent]);
+
+  const handleToggleErrorRow = useCallback((idx: number) => {
+    setExpandedErrorRows((prev) => {
+      const next = new Set(prev);
+      if (next.has(idx)) next.delete(idx);
+      else next.add(idx);
+      return next;
+    });
+  }, []);
 
   // ファイル切替時に選択を解除
   useEffect(() => {
@@ -466,6 +524,22 @@ export function ScreenItemsView() {
           </div>
         )}
         {selectedScreenId && file && (
+          <>
+          {lintIssues.length > 0 && (
+            <div className="screen-items-lint-warnings">
+              <i className="bi bi-exclamation-triangle-fill me-1" />
+              <strong>@conv.* 参照エラー {lintIssues.length} 件</strong>
+              <ul className="mb-0 mt-1">
+                {lintIssues.map((issue, i) => (
+                  <li key={i}>
+                    <code className="me-1">{issue.value}</code>
+                    <span className="text-muted">({issue.path})</span>
+                    <span className="ms-1">{issue.message}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
           <div className="screen-items-table-wrap">
             <table className="screen-items-table">
               <colgroup>
@@ -479,7 +553,7 @@ export function ScreenItemsView() {
                 <col style={{ width: "5em" }} />
                 <col style={{ width: "12em" }} />
                 <col />
-                <col style={{ width: 54 }} />
+                <col style={{ width: 76 }} />
               </colgroup>
               <thead>
                 <tr>
@@ -514,7 +588,8 @@ export function ScreenItemsView() {
                   </tr>
                 )}
                 {file.items.map((item, i) => (
-                  <tr key={i} className={selectedIndices.has(i) ? "screen-items-row-selected" : ""}>
+                  <React.Fragment key={i}>
+                  <tr className={selectedIndices.has(i) ? "screen-items-row-selected" : ""}>
                     <td className="text-center">
                       <input
                         type="checkbox"
@@ -524,7 +599,15 @@ export function ScreenItemsView() {
                         aria-label={`行${i + 1}を選択`}
                       />
                     </td>
-                    <td className="screen-items-no">{i + 1}</td>
+                    <td className="screen-items-no">
+                      {i + 1}
+                      {lintByRow.has(i) && (
+                        <i
+                          className="bi bi-exclamation-circle-fill text-warning ms-1"
+                          title={lintByRow.get(i)!.map((e) => e.message).join("\n")}
+                        />
+                      )}
+                    </td>
                     <td>
                       <input
                         className="form-control form-control-sm"
@@ -598,11 +681,12 @@ export function ScreenItemsView() {
                       />
                     </td>
                     <td>
-                      <input
-                        className="form-control form-control-sm"
+                      <ConvCompletionInput
                         value={item.pattern ?? ""}
-                        onChange={(e) => handleUpdateItem(i, { pattern: e.target.value || undefined })}
-                        onBlur={commit}
+                        onValueChange={(v) => handleUpdateItem(i, { pattern: v || undefined })}
+                        onCommit={commit}
+                        conventions={conventions}
+                        className="form-control form-control-sm"
                         placeholder="@conv.regex.email-simple"
                       />
                     </td>
@@ -615,6 +699,15 @@ export function ScreenItemsView() {
                       />
                     </td>
                     <td className="text-center screen-items-actions-cell">
+                      <button
+                        type="button"
+                        className={`btn btn-sm btn-link p-0 ${expandedErrorRows.has(i) ? "text-primary" : "text-secondary"}`}
+                        onClick={() => handleToggleErrorRow(i)}
+                        title="エラーメッセージ欄を展開"
+                        aria-label="エラーメッセージ展開"
+                      >
+                        <i className={`bi bi-${expandedErrorRows.has(i) ? "chat-text-fill" : "chat-text"}`} />
+                      </button>
                       <button
                         type="button"
                         className="btn btn-sm btn-link text-secondary p-0"
@@ -635,6 +728,28 @@ export function ScreenItemsView() {
                       </button>
                     </td>
                   </tr>
+                  {expandedErrorRows.has(i) && (
+                    <tr className="screen-items-error-row">
+                      <td colSpan={11}>
+                        <div className="screen-items-error-fields">
+                          {(["required", "minLength", "maxLength", "invalidFormat", "outOfRange"] as const).map((key) => (
+                            <label key={key} className="screen-items-error-field">
+                              <span className="screen-items-error-label">{key}</span>
+                              <ConvCompletionInput
+                                value={item.errorMessages?.[key] ?? ""}
+                                onValueChange={(v) => handleUpdateErrorMessage(i, key, v)}
+                                onCommit={commit}
+                                conventions={conventions}
+                                className="form-control form-control-sm"
+                                placeholder={`@conv.msg.${key === "required" ? "required" : key === "invalidFormat" ? "invalidFormat" : key}`}
+                              />
+                            </label>
+                          ))}
+                        </div>
+                      </td>
+                    </tr>
+                  )}
+                  </React.Fragment>
                 ))}
               </tbody>
             </table>
@@ -670,6 +785,7 @@ export function ScreenItemsView() {
               {PRIMITIVE_TYPES.map((t) => <option key={t} value={t} />)}
             </datalist>
           </div>
+          </>
         )}
       </div>
 

--- a/designer/src/hooks/useConvCompletion.ts
+++ b/designer/src/hooks/useConvCompletion.ts
@@ -32,7 +32,7 @@ export function computeCompletion(
     const candidates = ALL_CONV_CATEGORIES.filter((c) => c.startsWith(prefix));
     return { phase: "category", prefix, candidates: [...candidates] };
   } else {
-    const cat = (catalog as Record<string, unknown>)[catPart!];
+    const cat = (catalog as unknown as Record<string, unknown>)[catPart!];
     if (!cat || typeof cat !== "object") return { phase: "idle" };
     const keys = Object.keys(cat);
     const candidates = keys.filter((k) => k.startsWith(keyPart));

--- a/designer/src/schemas/conventionsValidator.test.ts
+++ b/designer/src/schemas/conventionsValidator.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from "vitest";
 import Ajv2020 from "ajv/dist/2020";
 import addFormats from "ajv-formats";
-import { checkConventionReferences, type ConventionsCatalog } from "./conventionsValidator";
+import { checkConventionReferences, checkScreenItemConventionReferences, type ConventionsCatalog } from "./conventionsValidator";
 import type { ActionGroup } from "../types/action";
+import type { ScreenItemsFile } from "../types/screenItem";
 import { readFileSync, readdirSync } from "node:fs";
 import { resolve, join } from "node:path";
 
@@ -327,6 +328,79 @@ describe("checkConventionReferences", () => {
       null,
     );
     expect(issues).toHaveLength(0);
+  });
+});
+
+// ── checkScreenItemConventionReferences (#351) ────────────────────────────
+
+function makeScreenItemsFile(partial: Partial<ScreenItemsFile>): ScreenItemsFile {
+  return {
+    screenId: "scr1",
+    version: "0.1.0",
+    updatedAt: "2026-01-01T00:00:00Z",
+    items: [],
+    ...partial,
+  };
+}
+
+describe("checkScreenItemConventionReferences", () => {
+  const catalog = loadCatalog();
+
+  it("catalog が null なら空配列", () => {
+    const file = makeScreenItemsFile({ items: [{ id: "email", label: "メール", type: "string", pattern: "@conv.regex.email-simple" }] });
+    expect(checkScreenItemConventionReferences(file, null)).toHaveLength(0);
+  });
+
+  it("items が空なら空配列", () => {
+    expect(checkScreenItemConventionReferences(makeScreenItemsFile({}), catalog)).toHaveLength(0);
+  });
+
+  it("pattern に実在する @conv.regex.* を書くとエラーなし", () => {
+    const file = makeScreenItemsFile({
+      items: [{ id: "phone", label: "電話", type: "string", pattern: "@conv.regex.phone-jp" }],
+    });
+    const issues = checkScreenItemConventionReferences(file, catalog);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("pattern に存在しない @conv.regex を書くと UNKNOWN_CONV_REGEX", () => {
+    const file = makeScreenItemsFile({
+      items: [{ id: "f", label: "F", type: "string", pattern: "@conv.regex.no-such-key" }],
+    });
+    const issues = checkScreenItemConventionReferences(file, catalog);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("UNKNOWN_CONV_REGEX");
+    expect(issues[0].path).toBe("items[0].pattern");
+  });
+
+  it("errorMessages.required に存在しない @conv.msg を書くと UNKNOWN_CONV_MSG", () => {
+    const file = makeScreenItemsFile({
+      items: [{ id: "f", label: "F", type: "string", errorMessages: { required: "@conv.msg.no-such-msg" } }],
+    });
+    const issues = checkScreenItemConventionReferences(file, catalog);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("UNKNOWN_CONV_MSG");
+    expect(issues[0].path).toBe("items[0].errorMessages.required");
+  });
+
+  it("pattern に @conv 参照なし (直接正規表現) はエラーなし", () => {
+    const file = makeScreenItemsFile({
+      items: [{ id: "f", label: "F", type: "string", pattern: "^[0-9]+$" }],
+    });
+    expect(checkScreenItemConventionReferences(file, catalog)).toHaveLength(0);
+  });
+
+  it("複数 items に問題があれば全件返す", () => {
+    const file = makeScreenItemsFile({
+      items: [
+        { id: "f1", label: "F1", type: "string", pattern: "@conv.regex.bad1" },
+        { id: "f2", label: "F2", type: "string", errorMessages: { maxLength: "@conv.msg.bad2" } },
+      ],
+    });
+    const issues = checkScreenItemConventionReferences(file, catalog);
+    expect(issues).toHaveLength(2);
+    expect(issues[0].path).toBe("items[0].pattern");
+    expect(issues[1].path).toBe("items[1].errorMessages.maxLength");
   });
 });
 

--- a/designer/src/schemas/conventionsValidator.ts
+++ b/designer/src/schemas/conventionsValidator.ts
@@ -3,7 +3,9 @@
  *
  * 処理フロー JSON 内の式・メッセージ中に現れる @conv.<category>.<key> が
  * conventions-catalog.json に存在するかを検査。
+ * 画面項目定義 (ScreenItemsFile) の pattern / errorMessages.* も対象 (#351)。
  */
+import type { ScreenItemsFile } from "../types/screenItem";
 import type {
   ActionGroup,
   Step,
@@ -153,6 +155,28 @@ function walkSteps(
   });
 }
 
+/** 1 文字列値の @conv.* 参照を検査し issues に追記する */
+function checkValue(src: string, path: string, catalog: ConventionsCatalog, issues: ConventionIssue[]): void {
+  for (const { category, key } of extractConvRefs(src)) {
+    const cat = resolveCategory(catalog, category);
+    if (cat === null) {
+      issues.push({
+        path,
+        code: "UNKNOWN_CONV_CATEGORY",
+        value: `@conv.${category}.${key}`,
+        message: `@conv.${category}.* カテゴリは規約カタログに存在しません`,
+      });
+    } else if (!(key in cat)) {
+      issues.push({
+        path,
+        code: codeFor(category),
+        value: `@conv.${category}.${key}`,
+        message: `@conv.${category}.${key} が規約カタログに存在しません`,
+      });
+    }
+  }
+}
+
 function checkStep(step: Step, path: string, catalog: ConventionsCatalog, issues: ConventionIssue[]): void {
   const texts: Array<{ src: string; field: string }> = [];
 
@@ -182,26 +206,28 @@ function checkStep(step: Step, path: string, catalog: ConventionsCatalog, issues
   }
 
   for (const { src, field } of texts) {
-    const refs = extractConvRefs(src);
-    for (const { category, key } of refs) {
-      const cat = resolveCategory(catalog, category);
-      if (cat === null) {
-        issues.push({
-          path: `${path}.${field}`,
-          code: "UNKNOWN_CONV_CATEGORY",
-          value: `@conv.${category}.${key}`,
-          message: `@conv.${category}.* カテゴリは規約カタログに存在しません`,
-        });
-        continue;
-      }
-      if (!(key in cat)) {
-        issues.push({
-          path: `${path}.${field}`,
-          code: codeFor(category),
-          value: `@conv.${category}.${key}`,
-          message: `@conv.${category}.${key} が規約カタログに存在しません`,
-        });
-      }
-    }
+    checkValue(src, `${path}.${field}`, catalog, issues);
   }
+}
+
+/** 画面項目定義ファイル全体で @conv.* 参照を検査 (#351)。catalog が null なら skip */
+export function checkScreenItemConventionReferences(
+  file: ScreenItemsFile,
+  catalog: ConventionsCatalog | null,
+): ConventionIssue[] {
+  if (!catalog) return [];
+  const issues: ConventionIssue[] = [];
+
+  file.items.forEach((item, i) => {
+    if (item.pattern) {
+      checkValue(item.pattern, `items[${i}].pattern`, catalog, issues);
+    }
+    if (item.errorMessages) {
+      Object.entries(item.errorMessages).forEach(([key, val]) => {
+        if (val) checkValue(val, `items[${i}].errorMessages.${key}`, catalog, issues);
+      });
+    }
+  });
+
+  return issues;
 }

--- a/designer/src/styles/screen-items.css
+++ b/designer/src/styles/screen-items.css
@@ -101,6 +101,49 @@
   min-width: 14em;
 }
 
+/* lint 警告バナー (#351) */
+.screen-items-lint-warnings {
+  background: #fef9c3;
+  border: 1px solid #fde047;
+  border-radius: 6px;
+  padding: 8px 12px;
+  margin-bottom: 8px;
+  font-size: 0.8rem;
+  color: #713f12;
+}
+.screen-items-lint-warnings ul {
+  padding-left: 1.2em;
+  margin: 0;
+}
+.screen-items-lint-warnings li {
+  margin-top: 2px;
+}
+
+/* errorMessages 展開行 (#352) */
+.screen-items-error-row > td {
+  background: #f8f9fa;
+  padding: 6px 8px;
+  border-bottom: 1px solid #e2e8f0;
+}
+.screen-items-error-fields {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.screen-items-error-field {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 13em;
+  flex: 1;
+}
+.screen-items-error-label {
+  font-size: 0.68rem;
+  font-weight: 600;
+  color: #64748b;
+  font-family: ui-monospace, SFMono-Regular, monospace;
+}
+
 /* 画面項目候補モーダル (#323) */
 .screen-item-candidates-overlay {
   position: fixed;


### PR DESCRIPTION
## 概要

Closes #351
Closes #352

画面項目定義に `@conv.*` lint と入力補完を追加し、`errorMessages.*` の編集 UI を実装。

## 変更内容

### #351: @conv.* lint を画面項目定義に拡張

| ファイル | 変更 |
|---|---|
| `conventionsValidator.ts` | `checkScreenItemConventionReferences(file, catalog)` を追加。`items[].pattern` / `items[].errorMessages.*` の `@conv.*` 参照を検査 |
| `conventionsValidator.test.ts` | 7 件のテスト追加 (計 39 件全通過) |
| `useConvCompletion.ts` / `ActionHttpContractPanel.tsx` / `StepCard.tsx` | 既存の TS ビルドエラー 3 件を修正 |

### #352: ConvCompletionInput 装着 + errorMessages UI

| ファイル | 変更 |
|---|---|
| `ScreenItemsView.tsx` | 規約カタログロード、lint 結果の警告バナー + 行アイコン表示、`pattern` 列を `<ConvCompletionInput>` に差し替え、💬 ボタンで `errorMessages.*` 展開 UI を追加 |
| `screen-items.css` | lint 警告バナー・errorMessages 展開行のスタイル追加 |

### レビュー指摘修正

| 種別 | 内容 | 対応コミット |
|---|---|---|
| Should-fix | `expandedErrorRows` の画面切替リセット漏れ | `4c5019e` |
| Should-fix | E2E テスト不在 | `8b5abe9` (5 件追加、14 件全通過) |
| Nit | `errorMessages` placeholder の冗長三項式 | `4c5019e` |
| Nit | `ActionHttpContractPanel` デッドコード除去 | `4c5019e` |

## 動作確認ポイント

- [ ] `pattern` 欄で `@conv.` と打つと補完ポップアップが表示される
- [ ] 存在しないキー (例: `@conv.regex.no-such`) を保存すると警告バナーと行アイコンが表示される
- [ ] 💬 ボタンで `errorMessages` 欄が展開し、`@conv.msg.` 補完が効く
- [ ] `errorMessages.*` フィールドが保存・リロード後も維持される
- [ ] `@conv.regex.phone-jp` など実在キーではエラーが出ない
- [ ] 画面を切り替えると展開状態がリセットされる

## 仕様逐条突合

**#351: `checkScreenItemConventionReferences`**
- `items[].pattern` を走査対象に含める ✅
- `items[].errorMessages.*` の各値を走査対象に含める ✅
- 既存の `extractConvRefs` / `resolveCategory` / `codeFor` を再利用 ✅
- `ConventionIssue[]` 戻り値、`path` に `items[N].pattern` 等を含める ✅
- `catalog === null` なら空配列 ✅
- UI に警告表示 ✅ (Playwright E2E で検証済み)

**#352: ConvCompletionInput 装着**
- `pattern` 列の `<input>` を `<ConvCompletionInput>` に差し替え ✅
- `@conv.` 入力で補完ポップアップ表示 ✅ (Playwright E2E で検証済み)
- `errorMessages.*` の編集 UI 追加 ✅
- 各フィールドも `ConvCompletionInput` で補完 ✅
- lint 結果の表示 ✅
- 規約カタログのロード ✅
- 画面切替時に `expandedErrorRows` をリセット ✅ (Playwright E2E で検証済み)
- `errorMessages.*` の保存永続化 ✅ (localStorage 直接検証 + pre-seed 表示確認)

## 受け入れ基準との対比

- [x] TS ビルドエラーなし (`npm run build` 通過)
- [x] Vitest 全通過 (39 件)
- [x] Playwright E2E 全通過 (14 件)
- [ ] UI 影響あり → ユーザーの目視確認必須

🤖 Generated with [Claude Code](https://claude.ai/claude-code)