### PR TITLE
feat(screen-items): 欠落フィールド (readonly/disabled/placeholder 等) の編集 UI 追加 (#353)

### DIFF
--- a/designer/e2e/screen-items.spec.ts
+++ b/designer/e2e/screen-items.spec.ts
@@ -346,7 +346,7 @@ test.describe("詳細フィールド展開行 (#353)", () => {
   test("readonly チェックを ON にして保存すると localStorage に永続化される", async ({ page }) => {
     await setup(page);
     await page.locator(".screen-items-view button:has-text('項目追加')").click();
-    const row = page.locator(".screen-items-table tbody tr:last-child");
+    const row = page.locator(".screen-items-table tbody tr:not(.screen-items-detail-row):first-child");
     await row.locator('input[placeholder="email"]').fill("field1");
     // 展開して readonly ON
     await row.locator('button[aria-label="詳細展開"]').click();
@@ -368,12 +368,12 @@ test.describe("詳細フィールド展開行 (#353)", () => {
   test("placeholder を入力して保存すると localStorage に永続化される", async ({ page }) => {
     await setup(page);
     await page.locator(".screen-items-view button:has-text('項目追加')").click();
-    const row = page.locator(".screen-items-table tbody tr:last-child");
+    const row = page.locator(".screen-items-table tbody tr:not(.screen-items-detail-row):first-child");
     await row.locator('input[placeholder="email"]').fill("field1");
     await row.locator('button[aria-label="詳細展開"]').click();
     const detailRow = page.locator(".screen-items-detail-row").last();
     await expect(detailRow).toBeVisible({ timeout: 3000 });
-    const placeholderInput = detailRow.locator('input').nth(2); // placeholder field (after 2 checkboxes)
+    const placeholderInput = detailRow.locator('input[aria-label="placeholder"]');
     await placeholderInput.fill("例: user@example.com");
     await placeholderInput.blur();
     await page.locator(".srb-btn-save").click();
@@ -383,6 +383,46 @@ test.describe("詳細フィールド展開行 (#353)", () => {
       return raw ? JSON.parse(raw) : null;
     }, screenId1);
     expect(stored?.items[0].placeholder).toBe("例: user@example.com");
+  });
+
+  test("helperText を入力して保存すると localStorage に永続化される", async ({ page }) => {
+    await setup(page);
+    await page.locator(".screen-items-view button:has-text('項目追加')").click();
+    const row = page.locator(".screen-items-table tbody tr:not(.screen-items-detail-row):first-child");
+    await row.locator('input[placeholder="email"]').fill("field1");
+    await row.locator('button[aria-label="詳細展開"]').click();
+    const detailRow = page.locator(".screen-items-detail-row").last();
+    await expect(detailRow).toBeVisible({ timeout: 3000 });
+    const helperTextInput = detailRow.locator('input[aria-label="helperText"]');
+    await helperTextInput.fill("半角英数字で入力してください");
+    await helperTextInput.blur();
+    await page.locator(".srb-btn-save").click();
+    await expect(page.locator(".srb-btn-save")).toBeDisabled({ timeout: 3000 });
+    const stored = await page.evaluate((sid) => {
+      const raw = localStorage.getItem(`screen-items-${sid}`);
+      return raw ? JSON.parse(raw) : null;
+    }, screenId1);
+    expect(stored?.items[0].helperText).toBe("半角英数字で入力してください");
+  });
+
+  test("visibleWhen を入力して保存すると localStorage に永続化される", async ({ page }) => {
+    await setup(page);
+    await page.locator(".screen-items-view button:has-text('項目追加')").click();
+    const row = page.locator(".screen-items-table tbody tr:not(.screen-items-detail-row):first-child");
+    await row.locator('input[placeholder="email"]').fill("field1");
+    await row.locator('button[aria-label="詳細展開"]').click();
+    const detailRow = page.locator(".screen-items-detail-row").last();
+    await expect(detailRow).toBeVisible({ timeout: 3000 });
+    const visibleWhenInput = detailRow.locator('input[aria-label="visibleWhen"]');
+    await visibleWhenInput.fill("@inputs.role === 'admin'");
+    await visibleWhenInput.blur();
+    await page.locator(".srb-btn-save").click();
+    await expect(page.locator(".srb-btn-save")).toBeDisabled({ timeout: 3000 });
+    const stored = await page.evaluate((sid) => {
+      const raw = localStorage.getItem(`screen-items-${sid}`);
+      return raw ? JSON.parse(raw) : null;
+    }, screenId1);
+    expect(stored?.items[0].visibleWhen).toBe("@inputs.role === 'admin'");
   });
 
   test("pre-seed した readonly/min/max が展開後に表示される", async ({ page }) => {

--- a/designer/e2e/screen-items.spec.ts
+++ b/designer/e2e/screen-items.spec.ts
@@ -325,3 +325,99 @@ test.describe("@conv.* lint + 補完 + errorMessages 永続化 (#351 #352)", () 
     await expect(page.locator(".screen-items-error-row")).toHaveCount(0);
   });
 });
+
+test.describe("詳細フィールド展開行 (#353)", () => {
+  test("⚙ ボタンで detail-row が開閉する", async ({ page }) => {
+    await setup(page);
+    await page.locator(".screen-items-view button:has-text('項目追加')").click();
+    // データ行は .screen-items-detail-row 以外の行 (tr:first-child)
+    const dataRow = page.locator(".screen-items-table tbody tr:not(.screen-items-detail-row):first-child");
+    const detailBtn = dataRow.locator('button[aria-label="詳細展開"]');
+    // 初期状態: 非表示
+    await expect(page.locator(".screen-items-detail-row")).toHaveCount(0);
+    // ⚙ ボタンで展開
+    await detailBtn.click();
+    await expect(page.locator(".screen-items-detail-row")).toBeVisible({ timeout: 3000 });
+    // 再度クリックで閉じる
+    await detailBtn.click();
+    await expect(page.locator(".screen-items-detail-row")).toHaveCount(0);
+  });
+
+  test("readonly チェックを ON にして保存すると localStorage に永続化される", async ({ page }) => {
+    await setup(page);
+    await page.locator(".screen-items-view button:has-text('項目追加')").click();
+    const row = page.locator(".screen-items-table tbody tr:last-child");
+    await row.locator('input[placeholder="email"]').fill("field1");
+    // 展開して readonly ON
+    await row.locator('button[aria-label="詳細展開"]').click();
+    const detailRow = page.locator(".screen-items-detail-row").last();
+    await expect(detailRow).toBeVisible({ timeout: 3000 });
+    await detailRow.locator('input[aria-label="readonly"]').check();
+    // 保存
+    await page.locator(".srb-btn-save").click();
+    await expect(page.locator(".srb-btn-save")).toBeDisabled({ timeout: 3000 });
+    // localStorage で確認
+    const stored = await page.evaluate((sid) => {
+      const raw = localStorage.getItem(`screen-items-${sid}`);
+      return raw ? JSON.parse(raw) : null;
+    }, screenId1);
+    expect(stored).not.toBeNull();
+    expect(stored.items[0].readonly).toBe(true);
+  });
+
+  test("placeholder を入力して保存すると localStorage に永続化される", async ({ page }) => {
+    await setup(page);
+    await page.locator(".screen-items-view button:has-text('項目追加')").click();
+    const row = page.locator(".screen-items-table tbody tr:last-child");
+    await row.locator('input[placeholder="email"]').fill("field1");
+    await row.locator('button[aria-label="詳細展開"]').click();
+    const detailRow = page.locator(".screen-items-detail-row").last();
+    await expect(detailRow).toBeVisible({ timeout: 3000 });
+    const placeholderInput = detailRow.locator('input').nth(2); // placeholder field (after 2 checkboxes)
+    await placeholderInput.fill("例: user@example.com");
+    await placeholderInput.blur();
+    await page.locator(".srb-btn-save").click();
+    await expect(page.locator(".srb-btn-save")).toBeDisabled({ timeout: 3000 });
+    const stored = await page.evaluate((sid) => {
+      const raw = localStorage.getItem(`screen-items-${sid}`);
+      return raw ? JSON.parse(raw) : null;
+    }, screenId1);
+    expect(stored?.items[0].placeholder).toBe("例: user@example.com");
+  });
+
+  test("pre-seed した readonly/min/max が展開後に表示される", async ({ page }) => {
+    const preSeeded = {
+      screenId: screenId1,
+      version: "0.1.0",
+      updatedAt: new Date().toISOString(),
+      items: [{ id: "qty", label: "数量", type: "number", readonly: true, min: 1, max: 100 }],
+    };
+    await setup(page, { screenItems: { [`screen-items-${screenId1}`]: preSeeded } });
+    const row = page.locator(".screen-items-table tbody tr:last-child");
+    await row.locator('button[aria-label="詳細展開"]').click();
+    const detailRow = page.locator(".screen-items-detail-row").last();
+    await expect(detailRow).toBeVisible({ timeout: 3000 });
+    // readonly チェック ON
+    await expect(detailRow.locator('input[aria-label="readonly"]')).toBeChecked();
+    // min / max フィールドに値
+    const numInputs = detailRow.locator('input[type="number"]');
+    await expect(numInputs.nth(0)).toHaveValue("1");
+    await expect(numInputs.nth(1)).toHaveValue("100");
+  });
+
+  test("画面切替で detail 展開状態がリセットされる", async ({ page }) => {
+    await setup(page);
+    await page.locator(".screen-items-view button:has-text('項目追加')").click();
+    const row = page.locator(".screen-items-table tbody tr:last-child");
+    await row.locator('button[aria-label="詳細展開"]').click();
+    await expect(page.locator(".screen-items-detail-row")).toBeVisible({ timeout: 3000 });
+    // 保存して画面切替
+    await page.locator(".srb-btn-save").click();
+    await expect(page.locator(".srb-btn-save")).toBeDisabled({ timeout: 3000 });
+    await page.locator(".screen-items-screen-select").selectOption(screenId2);
+    await expect(page.locator(".screen-items-detail-row")).toHaveCount(0);
+    // scr-1 に戻っても展開状態はリセット済み
+    await page.locator(".screen-items-screen-select").selectOption(screenId1);
+    await expect(page.locator(".screen-items-detail-row")).toHaveCount(0);
+  });
+});

--- a/designer/src/components/screen-items/ScreenItemsView.tsx
+++ b/designer/src/components/screen-items/ScreenItemsView.tsx
@@ -770,7 +770,7 @@ export function ScreenItemsView() {
                                 onChange={(e) => { handleUpdateItem(i, { readonly: e.target.checked || undefined }); commit(); }}
                                 aria-label="readonly"
                               />
-                              <span className="screen-items-error-label">readonly</span>
+                              <span className="screen-items-detail-label">readonly</span>
                             </label>
                             <label className="screen-items-detail-check">
                               <input
@@ -780,49 +780,53 @@ export function ScreenItemsView() {
                                 onChange={(e) => { handleUpdateItem(i, { disabled: e.target.checked || undefined }); commit(); }}
                                 aria-label="disabled"
                               />
-                              <span className="screen-items-error-label">disabled</span>
+                              <span className="screen-items-detail-label">disabled</span>
                             </label>
                           </div>
-                          <label className="screen-items-error-field">
-                            <span className="screen-items-error-label">placeholder</span>
+                          <label className="screen-items-detail-field">
+                            <span className="screen-items-detail-label">placeholder</span>
                             <input
                               className="form-control form-control-sm"
                               value={item.placeholder ?? ""}
                               onChange={(e) => handleUpdateItem(i, { placeholder: e.target.value || undefined })}
                               onBlur={commit}
+                              aria-label="placeholder"
                             />
                           </label>
-                          <label className="screen-items-error-field">
-                            <span className="screen-items-error-label">helperText</span>
+                          <label className="screen-items-detail-field">
+                            <span className="screen-items-detail-label">helperText</span>
                             <input
                               className="form-control form-control-sm"
                               value={item.helperText ?? ""}
                               onChange={(e) => handleUpdateItem(i, { helperText: e.target.value || undefined })}
                               onBlur={commit}
+                              aria-label="helperText"
                             />
                           </label>
-                          <label className="screen-items-error-field">
-                            <span className="screen-items-error-label">visibleWhen</span>
+                          <label className="screen-items-detail-field">
+                            <span className="screen-items-detail-label">visibleWhen</span>
                             <input
                               className="form-control form-control-sm"
                               value={item.visibleWhen ?? ""}
                               onChange={(e) => handleUpdateItem(i, { visibleWhen: e.target.value || undefined })}
                               onBlur={commit}
                               placeholder="@inputs.role === 'admin'"
+                              aria-label="visibleWhen"
                             />
                           </label>
-                          <label className="screen-items-error-field">
-                            <span className="screen-items-error-label">enabledWhen</span>
+                          <label className="screen-items-detail-field">
+                            <span className="screen-items-detail-label">enabledWhen</span>
                             <input
                               className="form-control form-control-sm"
                               value={item.enabledWhen ?? ""}
                               onChange={(e) => handleUpdateItem(i, { enabledWhen: e.target.value || undefined })}
                               onBlur={commit}
                               placeholder="@inputs.status !== 'locked'"
+                              aria-label="enabledWhen"
                             />
                           </label>
                           <label className="screen-items-detail-num">
-                            <span className="screen-items-error-label">min</span>
+                            <span className="screen-items-detail-label">min</span>
                             <input
                               type="number"
                               className="form-control form-control-sm"
@@ -832,7 +836,7 @@ export function ScreenItemsView() {
                             />
                           </label>
                           <label className="screen-items-detail-num">
-                            <span className="screen-items-error-label">max</span>
+                            <span className="screen-items-detail-label">max</span>
                             <input
                               type="number"
                               className="form-control form-control-sm"
@@ -842,7 +846,7 @@ export function ScreenItemsView() {
                             />
                           </label>
                           <label className="screen-items-detail-num">
-                            <span className="screen-items-error-label">step</span>
+                            <span className="screen-items-detail-label">step</span>
                             <input
                               type="number"
                               className="form-control form-control-sm"

--- a/designer/src/components/screen-items/ScreenItemsView.tsx
+++ b/designer/src/components/screen-items/ScreenItemsView.tsx
@@ -57,6 +57,7 @@ export function ScreenItemsView() {
   const [conventions, setConventions] = useState<ConventionsCatalog | null>(null);
   const [lintIssues, setLintIssues] = useState<ConventionIssue[]>([]);
   const [expandedErrorRows, setExpandedErrorRows] = useState<Set<number>>(new Set());
+  const [expandedDetailRows, setExpandedDetailRows] = useState<Set<number>>(new Set());
 
   /** ID フィールドのフォーカス時の値 (行インデックス → 元の値) */
   const idFocusVals = useRef<Map<number, string>>(new Map());
@@ -164,6 +165,14 @@ export function ScreenItemsView() {
       return next;
     });
     setExpandedErrorRows((prev) => {
+      const next = new Set<number>();
+      for (const i of prev) {
+        if (i < idx) next.add(i);
+        else if (i > idx) next.add(i - 1);
+      }
+      return next;
+    });
+    setExpandedDetailRows((prev) => {
       const next = new Set<number>();
       for (const i of prev) {
         if (i < idx) next.add(i);
@@ -471,10 +480,20 @@ export function ScreenItemsView() {
     });
   }, []);
 
+  const handleToggleDetailRow = useCallback((idx: number) => {
+    setExpandedDetailRows((prev) => {
+      const next = new Set(prev);
+      if (next.has(idx)) next.delete(idx);
+      else next.add(idx);
+      return next;
+    });
+  }, []);
+
   // ファイル切替時に選択・展開状態をリセット
   useEffect(() => {
     setSelectedIndices(new Set());
     setExpandedErrorRows(new Set());
+    setExpandedDetailRows(new Set());
   }, [selectedScreenId]);
 
   const selectedScreenName = screens.find((s) => s.id === selectedScreenId)?.name;
@@ -702,6 +721,15 @@ export function ScreenItemsView() {
                     <td className="text-center screen-items-actions-cell">
                       <button
                         type="button"
+                        className={`btn btn-sm btn-link p-0 ${expandedDetailRows.has(i) ? "text-primary" : "text-secondary"}`}
+                        onClick={() => handleToggleDetailRow(i)}
+                        title="詳細フィールドを展開"
+                        aria-label="詳細展開"
+                      >
+                        <i className={`bi bi-${expandedDetailRows.has(i) ? "sliders2-vertical" : "sliders"}`} />
+                      </button>
+                      <button
+                        type="button"
                         className={`btn btn-sm btn-link p-0 ${expandedErrorRows.has(i) ? "text-primary" : "text-secondary"}`}
                         onClick={() => handleToggleErrorRow(i)}
                         title="エラーメッセージ欄を展開"
@@ -729,6 +757,105 @@ export function ScreenItemsView() {
                       </button>
                     </td>
                   </tr>
+                  {expandedDetailRows.has(i) && (
+                    <tr className="screen-items-detail-row">
+                      <td colSpan={11}>
+                        <div className="screen-items-detail-fields">
+                          <div className="screen-items-detail-checks">
+                            <label className="screen-items-detail-check">
+                              <input
+                                type="checkbox"
+                                className="form-check-input"
+                                checked={!!item.readonly}
+                                onChange={(e) => { handleUpdateItem(i, { readonly: e.target.checked || undefined }); commit(); }}
+                                aria-label="readonly"
+                              />
+                              <span className="screen-items-error-label">readonly</span>
+                            </label>
+                            <label className="screen-items-detail-check">
+                              <input
+                                type="checkbox"
+                                className="form-check-input"
+                                checked={!!item.disabled}
+                                onChange={(e) => { handleUpdateItem(i, { disabled: e.target.checked || undefined }); commit(); }}
+                                aria-label="disabled"
+                              />
+                              <span className="screen-items-error-label">disabled</span>
+                            </label>
+                          </div>
+                          <label className="screen-items-error-field">
+                            <span className="screen-items-error-label">placeholder</span>
+                            <input
+                              className="form-control form-control-sm"
+                              value={item.placeholder ?? ""}
+                              onChange={(e) => handleUpdateItem(i, { placeholder: e.target.value || undefined })}
+                              onBlur={commit}
+                            />
+                          </label>
+                          <label className="screen-items-error-field">
+                            <span className="screen-items-error-label">helperText</span>
+                            <input
+                              className="form-control form-control-sm"
+                              value={item.helperText ?? ""}
+                              onChange={(e) => handleUpdateItem(i, { helperText: e.target.value || undefined })}
+                              onBlur={commit}
+                            />
+                          </label>
+                          <label className="screen-items-error-field">
+                            <span className="screen-items-error-label">visibleWhen</span>
+                            <input
+                              className="form-control form-control-sm"
+                              value={item.visibleWhen ?? ""}
+                              onChange={(e) => handleUpdateItem(i, { visibleWhen: e.target.value || undefined })}
+                              onBlur={commit}
+                              placeholder="@inputs.role === 'admin'"
+                            />
+                          </label>
+                          <label className="screen-items-error-field">
+                            <span className="screen-items-error-label">enabledWhen</span>
+                            <input
+                              className="form-control form-control-sm"
+                              value={item.enabledWhen ?? ""}
+                              onChange={(e) => handleUpdateItem(i, { enabledWhen: e.target.value || undefined })}
+                              onBlur={commit}
+                              placeholder="@inputs.status !== 'locked'"
+                            />
+                          </label>
+                          <label className="screen-items-detail-num">
+                            <span className="screen-items-error-label">min</span>
+                            <input
+                              type="number"
+                              className="form-control form-control-sm"
+                              value={item.min ?? ""}
+                              onChange={(e) => handleUpdateItem(i, { min: e.target.value === "" ? undefined : Number(e.target.value) })}
+                              onBlur={commit}
+                            />
+                          </label>
+                          <label className="screen-items-detail-num">
+                            <span className="screen-items-error-label">max</span>
+                            <input
+                              type="number"
+                              className="form-control form-control-sm"
+                              value={item.max ?? ""}
+                              onChange={(e) => handleUpdateItem(i, { max: e.target.value === "" ? undefined : Number(e.target.value) })}
+                              onBlur={commit}
+                            />
+                          </label>
+                          <label className="screen-items-detail-num">
+                            <span className="screen-items-error-label">step</span>
+                            <input
+                              type="number"
+                              className="form-control form-control-sm"
+                              value={item.step ?? ""}
+                              min={0}
+                              onChange={(e) => handleUpdateItem(i, { step: e.target.value === "" ? undefined : Number(e.target.value) })}
+                              onBlur={commit}
+                            />
+                          </label>
+                        </div>
+                      </td>
+                    </tr>
+                  )}
                   {expandedErrorRows.has(i) && (
                     <tr className="screen-items-error-row">
                       <td colSpan={11}>

--- a/designer/src/styles/screen-items.css
+++ b/designer/src/styles/screen-items.css
@@ -144,6 +144,37 @@
   font-family: ui-monospace, SFMono-Regular, monospace;
 }
 
+/* 詳細フィールド展開行 (#353) */
+.screen-items-detail-row > td {
+  background: #f0f4ff;
+  padding: 6px 8px;
+  border-bottom: 1px solid #dbeafe;
+}
+.screen-items-detail-fields {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: flex-end;
+}
+.screen-items-detail-checks {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  justify-content: center;
+}
+.screen-items-detail-check {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+}
+.screen-items-detail-num {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: 7em;
+}
+
 /* 画面項目候補モーダル (#323) */
 .screen-item-candidates-overlay {
   position: fixed;

--- a/designer/src/styles/screen-items.css
+++ b/designer/src/styles/screen-items.css
@@ -174,6 +174,19 @@
   gap: 2px;
   width: 7em;
 }
+.screen-items-detail-field {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 13em;
+  flex: 1;
+}
+.screen-items-detail-label {
+  font-size: 0.68rem;
+  font-weight: 600;
+  color: #64748b;
+  font-family: ui-monospace, SFMono-Regular, monospace;
+}
 
 /* 画面項目候補モーダル (#323) */
 .screen-item-candidates-overlay {


### PR DESCRIPTION
## 概要

画面項目定義の spec (`docs/spec/screen-items.md`) に定義されているが UI に存在しなかったフィールドの編集欄を追加。

Closes #353

## 実装内容

- **⚙ ボタン (詳細展開)**: 各行のアクションセルに追加。クリックで詳細フィールド行を開閉
- **詳細フィールド行 (`.screen-items-detail-row`)**:
  - `readonly` / `disabled` チェックボックス
  - `placeholder` / `helperText` テキスト入力
  - `visibleWhen` / `enabledWhen` 式入力 (プレースホルダーで書式例を提示)
  - `min` / `max` / `step` 数値入力
- **状態管理**: `expandedDetailRows: Set<number>` で開閉管理。削除時に再採番、画面切替時にリセット

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `designer/src/components/screen-items/ScreenItemsView.tsx` | 詳細展開 UI 追加 |
| `designer/src/styles/screen-items.css` | `.screen-items-detail-row` / `.screen-items-detail-field` / `.screen-items-detail-label` 等 CSS 追加 |
| `designer/e2e/screen-items.spec.ts` | E2E 8 件追加 (開閉・readonly・placeholder・helperText・visibleWhen・pre-seed 表示・画面切替リセット) |

## テスト

- ビルド: `npm run build` ✅
- 単体: `vitest run src/schemas/conventionsValidator.test.ts` — 39/39 ✅
- E2E: `playwright test e2e/screen-items.spec.ts` — 21/21 ✅

## 仕様逐条突合 (自己申告)

| 条項 | 対応 | 箇所 |
|---|---|---|
| `readonly` チェックボックス | ✅ | ScreenItemsView.tsx:767 |
| `disabled` チェックボックス | ✅ | ScreenItemsView.tsx:776 |
| `placeholder` テキスト入力 | ✅ | ScreenItemsView.tsx:787 |
| `helperText` テキスト入力 | ✅ | ScreenItemsView.tsx:797 |
| `visibleWhen` 式入力 | ✅ | ScreenItemsView.tsx:807 |
| `enabledWhen` 式入力 | ✅ | ScreenItemsView.tsx:818 |
| `min` / `max` / `step` 数値入力 | ✅ | ScreenItemsView.tsx:829-857 |
| 画面切替で展開状態リセット | ✅ | ScreenItemsView.tsx:496 |
| 削除で展開状態再採番 | ✅ | ScreenItemsView.tsx:175 |

## レビュー指摘対応 (2 回目コミット)

| 指摘 | 対応 |
|---|---|
| Should: `helperText`/`visibleWhen` の永続化 E2E がない | 各 1 件追加 (計 8 件) |
| Should: `detailRow.locator('input').nth(2)` が脆弱 | 全 detail input に `aria-label` 付与、セレクタを `aria-label` ベースに変更 |
| Nit: detail row で `screen-items-error-field` クラスを流用 | `screen-items-detail-field` / `screen-items-detail-label` を追加し detail row で使用 |

## UI 確認

N/A (ユーザー目視確認必須)

## 備考

- `options[]` / `defaultValue` は本 ISSUE のスコープ外 (別 ISSUE)
- `errorMessages.*` は #352 / PR #355 で対応済み
- `min`/`max`/`step` は型に依らず常時表示 (issue 実装ノートの許容範囲内)