### PR TITLE
fix(rename-context): validation-input の type→tagName フォールバック追加 (#357)

### DIFF
--- a/designer-mcp/src/renameContext.test.ts
+++ b/designer-mcp/src/renameContext.test.ts
@@ -225,7 +225,8 @@ describe("getRenameContext", () => {
     const result = await getRenameContext(SCREEN_ID);
     expect(result.unnamedItems).toHaveLength(1);
     const item = result.unnamedItems[0];
-    expect(item.htmlFragment).toContain("textInput1");
+    // void-element として <input ...> が正しく出力されることを確認
+    expect(item.htmlFragment).toMatch(/<input[^>]*id="textInput1"/);
     expect(item.headingContext).toContain("ユーザー情報");
   });
 
@@ -254,8 +255,10 @@ describe("getRenameContext", () => {
     };
     const result = await getRenameContext(SCREEN_ID);
     expect(result.unnamedItems).toHaveLength(2);
-    expect(result.unnamedItems[0].htmlFragment).toContain("select1");
-    expect(result.unnamedItems[1].htmlFragment).toContain("textarea1");
+    const selectItem   = result.unnamedItems.find((i) => i.id === "select1");
+    const textareaItem = result.unnamedItems.find((i) => i.id === "textarea1");
+    expect(selectItem?.htmlFragment).toContain("select1");
+    expect(textareaItem?.htmlFragment).toContain("textarea1");
   });
 
   it("label / placeholder が screen-items から引き継がれる", async () => {

--- a/designer-mcp/src/renameContext.test.ts
+++ b/designer-mcp/src/renameContext.test.ts
@@ -198,6 +198,66 @@ describe("getRenameContext", () => {
     expect(result.unnamedItems[0].headingContext).toEqual([]);
   });
 
+  it("validation-input (tagName なし) の htmlFragment が取得できる (#357)", async () => {
+    store.screenItems[SCREEN_ID] = {
+      screenId: SCREEN_ID,
+      version: "0.1.0",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      items: [{ id: "textInput1", label: "氏名", type: "string" }],
+    };
+    store.screens[SCREEN_ID] = {
+      pages: [{
+        frames: [{
+          component: {
+            type: "wrapper",
+            components: [
+              { tagName: "h3", components: [{ type: "textnode", content: "ユーザー情報" }] },
+              {
+                type: "validation-input",
+                void: true,
+                attributes: { type: "text", id: "textInput1", name: "textInput1", placeholder: "お名前" },
+              },
+            ],
+          },
+        }],
+      }],
+    };
+    const result = await getRenameContext(SCREEN_ID);
+    expect(result.unnamedItems).toHaveLength(1);
+    const item = result.unnamedItems[0];
+    expect(item.htmlFragment).toContain("textInput1");
+    expect(item.headingContext).toContain("ユーザー情報");
+  });
+
+  it("validation-select / validation-textarea も HTML 断片に含まれる (#357)", async () => {
+    store.screenItems[SCREEN_ID] = {
+      screenId: SCREEN_ID,
+      version: "0.1.0",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      items: [
+        { id: "select1",   label: "種別",     type: "string" },
+        { id: "textarea1", label: "備考",     type: "string" },
+      ],
+    };
+    store.screens[SCREEN_ID] = {
+      pages: [{
+        frames: [{
+          component: {
+            type: "wrapper",
+            components: [
+              { type: "validation-select",   attributes: { id: "select1",   name: "select1" } },
+              { type: "validation-textarea", attributes: { id: "textarea1", name: "textarea1" } },
+            ],
+          },
+        }],
+      }],
+    };
+    const result = await getRenameContext(SCREEN_ID);
+    expect(result.unnamedItems).toHaveLength(2);
+    expect(result.unnamedItems[0].htmlFragment).toContain("select1");
+    expect(result.unnamedItems[1].htmlFragment).toContain("textarea1");
+  });
+
   it("label / placeholder が screen-items から引き継がれる", async () => {
     store.screenItems[SCREEN_ID] = {
       screenId: SCREEN_ID,

--- a/designer-mcp/src/renameContext.ts
+++ b/designer-mcp/src/renameContext.ts
@@ -36,6 +36,13 @@ const VOID_TAGS = new Set([
   "link", "meta", "param", "source", "track", "wbr",
 ]);
 
+const CUSTOM_TYPE_TO_TAG: Record<string, string> = {
+  "validation-input": "input",
+  "validation-select": "select",
+  "validation-textarea": "textarea",
+  "checkbox": "input",
+};
+
 function serializeComponent(val: unknown): string {
   if (!val) return "";
   if (typeof val === "string") return val;
@@ -46,7 +53,9 @@ function serializeComponent(val: unknown): string {
   if (c.type === "textnode") return String(c.content ?? "");
   if (c.type === "comment") return `<!--${c.content ?? ""}-->`;
 
-  const tag = typeof c.tagName === "string" ? c.tagName : null;
+  const tag = typeof c.tagName === "string"
+    ? c.tagName
+    : (typeof c.type === "string" ? (CUSTOM_TYPE_TO_TAG[c.type] ?? null) : null);
   if (!tag) {
     // wrapper など tagName なし → 子だけ
     return serializeComponent(c.components);

--- a/designer-mcp/src/renameContext.ts
+++ b/designer-mcp/src/renameContext.ts
@@ -36,6 +36,9 @@ const VOID_TAGS = new Set([
   "link", "meta", "param", "source", "track", "wbr",
 ]);
 
+// designer/src/utils/screenItemExtractor.ts の CUSTOM_TYPE_TO_TAG と同一マッピング。
+// "checkbox" は GrapesJS カスタムブロック型として checkbox コンポーネントが
+// type フィールドのみで保存される場合の備え (screenItemExtractor.ts との一貫性)。
 const CUSTOM_TYPE_TO_TAG: Record<string, string> = {
   "validation-input": "input",
   "validation-select": "select",


### PR DESCRIPTION
## 概要

`AI でIDを再命名` ボタンが常に「0件のリネームを提案します」を返すバグを修正。

Closes #357

## 根本原因

`designer-mcp/src/renameContext.ts` の `serializeComponent()` が `tagName` フィールドを持たないコンポーネントを子要素のみ返す設計になっていた。  
`validation-input` 等のカスタムブロックは GrapesJS JSON 上で `type` フィールドのみ持ち `tagName` を持たないため、`screenToHtml()` が空文字を返し htmlFragment が空になっていた。

## 修正内容

`CUSTOM_TYPE_TO_TAG` マッピングを追加し、`tagName` がない場合に `type` から HTML タグ名を解決するフォールバックを実装。

```typescript
const CUSTOM_TYPE_TO_TAG: Record<string, string> = {
  "validation-input":    "input",
  "validation-select":   "select",
  "validation-textarea": "textarea",
  "checkbox":            "input",
};
```

`designer/src/utils/screenItemExtractor.ts` (line 44-51) に既に同等のマッピングが存在しており、それと整合させる形の修正。

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `designer-mcp/src/renameContext.ts` | `CUSTOM_TYPE_TO_TAG` 定数追加、`serializeComponent` の tag 算出を変更 |
| `designer-mcp/src/renameContext.test.ts` | `validation-input` / `validation-select` / `validation-textarea` の HTML 断片取得テスト 2 件追加 |

## テスト

- `designer-mcp` ビルド: `tsc` ✅
- `designer` ビルド: `npm run build` ✅
- 単体: `vitest run src/renameContext.test.ts` — 24/24 ✅

## 仕様逐条突合 (自己申告)

| 受け入れ基準 | 対応 | 箇所 |
|---|---|---|
| `validation-input` が `unnamedItems` に含まれる | ✅ テスト追加 | renameContext.test.ts:213 |
| `validation-select` / `validation-textarea` も同様 | ✅ テスト追加 | renameContext.test.ts:249 |
| TypeScript ビルドエラーなし | ✅ | tsc 0 errors |

## 備考

UI 変更なし。`designer-mcp` サーバ側のみの修正のためユーザー目視確認は N/A。  
実際に AI 命名が動作することは MCP E2E テスト or 手動テストで確認推奨。