### PR TITLE
feat(mcp): MCP ツールをブラウザライブ状態ベースに変更 (#360 #361)

### DIFF
--- a/designer-mcp/src/handlers/actionGroup.ts
+++ b/designer-mcp/src/handlers/actionGroup.ts
@@ -58,7 +58,8 @@ export const handleActionGroupTool: ToolHandler = async (name, args) => {
         throw new McpError(ErrorCode.InvalidParams, `処理フロー ${a.actionGroupId} が見つかりません`);
       }
       const source = liveData ? "browser live (unsaved 変更を含む)" : "file";
-      return { content: [{ type: "text", text: `// source: ${source}\n${JSON.stringify(agData, null, 2)}` }] };
+      const enriched = { _mcpSource: source, ...(agData as Record<string, unknown>) };
+      return { content: [{ type: "text", text: JSON.stringify(enriched, null, 2) }] };
     }
 
     case "designer__add_action_group": {

--- a/designer-mcp/src/handlers/actionGroup.ts
+++ b/designer-mcp/src/handlers/actionGroup.ts
@@ -30,6 +30,7 @@ import {
   type CatalogName,
 } from "../actionGroupEdits.js";
 import { saveAndBroadcast, type ToolHandler } from "../mcpHelpers.js";
+import { wsBridge } from "../wsBridge.js";
 
 export const handleActionGroupTool: ToolHandler = async (name, args) => {
   const a = args ?? {};
@@ -50,11 +51,14 @@ export const handleActionGroupTool: ToolHandler = async (name, args) => {
       if (typeof a.actionGroupId !== "string") {
         throw new McpError(ErrorCode.InvalidParams, "actionGroupId は必須です");
       }
-      const agData = await readActionGroup(a.actionGroupId);
+      // browser-first: ActionEditor が開いていれば live 状態を取得
+      const liveData = await wsBridge.tryCommand("getActionGroup", { id: a.actionGroupId });
+      const agData = liveData ?? await readActionGroup(a.actionGroupId);
       if (!agData) {
         throw new McpError(ErrorCode.InvalidParams, `処理フロー ${a.actionGroupId} が見つかりません`);
       }
-      return { content: [{ type: "text", text: JSON.stringify(agData, null, 2) }] };
+      const source = liveData ? "browser live (unsaved 変更を含む)" : "file";
+      return { content: [{ type: "text", text: `// source: ${source}\n${JSON.stringify(agData, null, 2)}` }] };
     }
 
     case "designer__add_action_group": {
@@ -134,6 +138,14 @@ export const handleActionGroupTool: ToolHandler = async (name, args) => {
       if (typeof a.actionGroupId !== "string" || typeof a.actionId !== "string" || typeof a.type !== "string") {
         throw new McpError(ErrorCode.InvalidParams, "actionGroupId, actionId, type は必須です");
       }
+      // browser-first: ActionEditor が開いていれば in-memory に適用
+      const addApplied = await wsBridge.tryCommand("applyActionGroupMutation", {
+        id: a.actionGroupId, type: "designer__add_step", params: a,
+      });
+      if (addApplied) {
+        return { content: [{ type: "text", text: `ステップ（${a.type}）をブラウザで追加しました（保存で確定）` }] };
+      }
+      // fallback: ファイル書き
       const ag = await readActionGroup(a.actionGroupId) as ActionGroupDoc | null;
       if (!ag) throw new McpError(ErrorCode.InvalidParams, `処理フロー ${a.actionGroupId} が見つかりません`);
       const stepId = `step-${Date.now()}`;
@@ -148,14 +160,21 @@ export const handleActionGroupTool: ToolHandler = async (name, args) => {
       if (typeof a.actionGroupId !== "string" || typeof a.stepId !== "string" || typeof a.patch !== "object" || a.patch === null) {
         throw new McpError(ErrorCode.InvalidParams, "actionGroupId, stepId, patch は必須です");
       }
-      const ag = await readActionGroup(a.actionGroupId) as ActionGroupDoc | null;
-      if (!ag) throw new McpError(ErrorCode.InvalidParams, `処理フロー ${a.actionGroupId} が見つかりません`);
+      const updApplied = await wsBridge.tryCommand("applyActionGroupMutation", {
+        id: a.actionGroupId, type: "designer__update_step", params: a,
+      });
+      if (updApplied) {
+        return { content: [{ type: "text", text: `ステップ ${a.stepId} をブラウザで更新しました（保存で確定）` }] };
+      }
+      // fallback
+      const updAg = await readActionGroup(a.actionGroupId) as ActionGroupDoc | null;
+      if (!updAg) throw new McpError(ErrorCode.InvalidParams, `処理フロー ${a.actionGroupId} が見つかりません`);
       try {
-        editUpdateStep(ag, a.stepId, a.patch as Record<string, unknown>);
+        editUpdateStep(updAg, a.stepId, a.patch as Record<string, unknown>);
       } catch (e) {
         throw new McpError(ErrorCode.InvalidParams, (e as Error).message);
       }
-      await saveAndBroadcast(a.actionGroupId, ag);
+      await saveAndBroadcast(a.actionGroupId, updAg);
       return { content: [{ type: "text", text: `ステップ ${a.stepId} を更新しました。` }] };
     }
 
@@ -163,14 +182,21 @@ export const handleActionGroupTool: ToolHandler = async (name, args) => {
       if (typeof a.actionGroupId !== "string" || typeof a.stepId !== "string") {
         throw new McpError(ErrorCode.InvalidParams, "actionGroupId, stepId は必須です");
       }
-      const ag = await readActionGroup(a.actionGroupId) as ActionGroupDoc | null;
-      if (!ag) throw new McpError(ErrorCode.InvalidParams, `処理フロー ${a.actionGroupId} が見つかりません`);
+      const rmApplied = await wsBridge.tryCommand("applyActionGroupMutation", {
+        id: a.actionGroupId, type: "designer__remove_step", params: a,
+      });
+      if (rmApplied) {
+        return { content: [{ type: "text", text: `ステップ ${a.stepId} をブラウザで削除しました（保存で確定）` }] };
+      }
+      // fallback
+      const rmAg = await readActionGroup(a.actionGroupId) as ActionGroupDoc | null;
+      if (!rmAg) throw new McpError(ErrorCode.InvalidParams, `処理フロー ${a.actionGroupId} が見つかりません`);
       try {
-        editRemoveStep(ag, a.stepId);
+        editRemoveStep(rmAg, a.stepId);
       } catch (e) {
         throw new McpError(ErrorCode.InvalidParams, (e as Error).message);
       }
-      await saveAndBroadcast(a.actionGroupId, ag);
+      await saveAndBroadcast(a.actionGroupId, rmAg);
       return { content: [{ type: "text", text: `ステップ ${a.stepId} を削除しました。` }] };
     }
 
@@ -178,14 +204,21 @@ export const handleActionGroupTool: ToolHandler = async (name, args) => {
       if (typeof a.actionGroupId !== "string" || typeof a.stepId !== "string" || typeof a.newIndex !== "number") {
         throw new McpError(ErrorCode.InvalidParams, "actionGroupId, stepId, newIndex は必須です");
       }
-      const ag = await readActionGroup(a.actionGroupId) as ActionGroupDoc | null;
-      if (!ag) throw new McpError(ErrorCode.InvalidParams, `処理フロー ${a.actionGroupId} が見つかりません`);
+      const mvApplied = await wsBridge.tryCommand("applyActionGroupMutation", {
+        id: a.actionGroupId, type: "designer__move_step", params: a,
+      });
+      if (mvApplied) {
+        return { content: [{ type: "text", text: `ステップ ${a.stepId} をブラウザで位置 ${a.newIndex} に移動しました（保存で確定）` }] };
+      }
+      // fallback
+      const mvAg = await readActionGroup(a.actionGroupId) as ActionGroupDoc | null;
+      if (!mvAg) throw new McpError(ErrorCode.InvalidParams, `処理フロー ${a.actionGroupId} が見つかりません`);
       try {
-        editMoveStep(ag, a.stepId, a.newIndex);
+        editMoveStep(mvAg, a.stepId, a.newIndex);
       } catch (e) {
         throw new McpError(ErrorCode.InvalidParams, (e as Error).message);
       }
-      await saveAndBroadcast(a.actionGroupId, ag);
+      await saveAndBroadcast(a.actionGroupId, mvAg);
       return { content: [{ type: "text", text: `ステップ ${a.stepId} を位置 ${a.newIndex} に移動しました。` }] };
     }
 

--- a/designer-mcp/src/index.ts
+++ b/designer-mcp/src/index.ts
@@ -3,7 +3,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { randomUUID } from "node:crypto";
 import { handleMarkerTool } from "./handlers/marker.js";
 import { handleActionGroupTool } from "./handlers/actionGroup.js";
-import { renameScreenItemId, checkScreenItemRefs } from "./renameScreenItem.js";
+import { renameScreenItemId, checkScreenItemRefs, updateActionGroupRefs } from "./renameScreenItem.js";
 import { getRenameContext, applyRenameMapping } from "./renameContext.js";
 import {
   ListToolsRequestSchema,
@@ -939,9 +939,37 @@ function createMcpServer(): Server {
           throw new McpError(ErrorCode.InvalidParams, "mapping は {oldId: newId} オブジェクトが必須です");
         }
         const mapping = a.mapping as Record<string, string>;
+
+        // browser-first: ブラウザで in-memory 適用を試みる
+        const browserResult = await wsBridge.tryCommand("applyRenameInBrowser", {
+          screenId: a.screenId,
+          mapping,
+        }) as { succeeded: string[]; failed: Array<{ oldId: string; error: string }> } | null;
+
+        if (browserResult) {
+          // ブラウザ側で適用済み → action group refs のみファイル更新
+          const { actionGroupsUpdated } = await updateActionGroupRefs(a.screenId, mapping);
+          for (const agId of actionGroupsUpdated) {
+            wsBridge.broadcast("actionGroupChanged", { id: agId });
+          }
+          // screenChanged / screenItemsChanged は broadcast しない (browser dirty、ファイルは古いまま)
+
+          const lines: string[] = [
+            `リネーム完了 (browser): 成功 ${browserResult.succeeded.length} 件 / 失敗 ${browserResult.failed.length} 件`,
+            `処理フロー参照更新: ${actionGroupsUpdated.length} 件`,
+          ];
+          for (const oldId of browserResult.succeeded) {
+            lines.push(`  ✓ "${oldId}" → "${mapping[oldId]}"`);
+          }
+          for (const f of browserResult.failed) {
+            lines.push(`  ✗ "${f.oldId}": ${f.error}`);
+          }
+          return { content: [{ type: "text", text: lines.join("\n") }] };
+        }
+
+        // fallback: 従来のファイル全書き
         const result = await applyRenameMapping(a.screenId, mapping);
 
-        // broadcasts
         if (result.succeeded.length > 0) {
           wsBridge.broadcast("screenItemsChanged", { screenId: a.screenId });
           const allAgs = new Set(result.succeeded.flatMap((s) => s.actionGroupsUpdated));

--- a/designer-mcp/src/renameContext.ts
+++ b/designer-mcp/src/renameContext.ts
@@ -9,6 +9,7 @@
  */
 import { readScreenItems, readScreen } from "./projectStorage.js";
 import { renameScreenItemId, type RenameResult } from "./renameScreenItem.js";
+import { wsBridge } from "./wsBridge.js";
 
 // ── 自動生成 ID 判定 (designer/src/utils/screenItemNaming.ts と同一) ─────────
 
@@ -172,21 +173,38 @@ export interface ApplyRenameMappingResult {
 
 // ── 公開 API ────────────────────────────────────────────────────────────────
 
+type ScreenItemsFileShape = {
+  items: Array<{ id: string; type: string; label?: string; placeholder?: string }>;
+};
+
 /**
  * 指定画面の未命名画面項目と周辺 HTML コンテキストを返す。
- * 呼び出し元 (Claude Code) はこの情報を基に {oldId: newId} マッピングを推論する。
+ * ブラウザが開いていれば unsaved の canvas 状態を優先し、
+ * 未接続の場合はファイルベースの fallback を使用する。
  */
 export async function getRenameContext(screenId: string): Promise<GetRenameContextResult> {
-  const siFile = (await readScreenItems(screenId)) as {
-    items: Array<{ id: string; type: string; label?: string; placeholder?: string }>;
+  let siFile: ScreenItemsFileShape | null = null;
+  let html: string;
+
+  // ブラウザから live 状態を取得
+  const snapshot = await wsBridge.tryCommand("getCanvasSnapshot", { screenId }) as {
+    html: string;
+    screenItems: ScreenItemsFileShape | null;
   } | null;
+
+  if (snapshot) {
+    html = snapshot.html;
+    siFile = snapshot.screenItems;
+  } else {
+    // fallback: ファイルベース
+    siFile = (await readScreenItems(screenId)) as ScreenItemsFileShape | null;
+    const screenDoc = await readScreen(screenId);
+    html = screenToHtml(screenDoc);
+  }
 
   if (!siFile || !Array.isArray(siFile.items)) {
     return { screenId, unnamedItems: [], namedCount: 0 };
   }
-
-  const screenDoc = await readScreen(screenId);
-  const html = screenToHtml(screenDoc);
 
   let namedCount = 0;
   const unnamedItems: RenameContextItem[] = [];

--- a/designer-mcp/src/renameScreenItem.ts
+++ b/designer-mcp/src/renameScreenItem.ts
@@ -172,6 +172,44 @@ function renameInScreenValue(val: unknown, oldId: string, newId: string): { upda
   return { updated: val, changed: false };
 }
 
+// ── 複数 ID の一括 AG 参照更新 ──────────────────────────────────────────
+
+/**
+ * mapping の全エントリに対してアクショングループ内の screenItemRef.itemId を更新する。
+ * screen-items ファイルや画面 HTML は触らない (browser-first パスで使用)。
+ */
+export async function updateActionGroupRefs(
+  screenId: string,
+  mapping: Record<string, string>,
+): Promise<{ actionGroupsUpdated: string[]; refsRenamed: number }> {
+  const ags = (await listActionGroups()) as Array<{ id: string; name: string }>;
+  const updatedAgs: string[] = [];
+  let refsRenamed = 0;
+
+  for (const agMeta of ags) {
+    const ag = await readActionGroup(agMeta.id);
+    if (!ag) continue;
+
+    let current = ag as unknown;
+    let count = 0;
+
+    for (const [oldId, newId] of Object.entries(mapping)) {
+      const r = renameRefsInValue(current, screenId, oldId, newId);
+      count += r.count;
+      current = r.updated;
+    }
+
+    if (count > 0) {
+      (current as Record<string, unknown>).updatedAt = new Date().toISOString();
+      await writeActionGroup(agMeta.id, current);
+      updatedAgs.push(agMeta.id);
+      refsRenamed += count;
+    }
+  }
+
+  return { actionGroupsUpdated: updatedAgs, refsRenamed };
+}
+
 // ── 公開 API ────────────────────────────────────────────────────────────
 
 export async function renameScreenItemId(

--- a/designer-mcp/src/wsBridge.ts
+++ b/designer-mcp/src/wsBridge.ts
@@ -513,6 +513,17 @@ class WsBridge extends EventEmitter {
     }
   }
 
+  /**
+   * sendCommand のラッパー。ブラウザ未接続・エラー時は null を返す (browser-first fallback 用)。
+   */
+  async tryCommand(method: string, params?: unknown): Promise<unknown | null> {
+    try {
+      return await this.sendCommand(method, params);
+    } catch {
+      return null;
+    }
+  }
+
   /** MCP コマンドをアクティブクライアントへ送信 */
   async sendCommand(method: string, params?: unknown): Promise<unknown> {
     const ws = this.activeClient;

--- a/designer-mcp/src/wsBridge.ts
+++ b/designer-mcp/src/wsBridge.ts
@@ -519,7 +519,10 @@ class WsBridge extends EventEmitter {
   async tryCommand(method: string, params?: unknown): Promise<unknown | null> {
     try {
       return await this.sendCommand(method, params);
-    } catch {
+    } catch (e) {
+      if (process.env.NODE_ENV !== "production") {
+        console.error(`[WsBridge] tryCommand(${method}) failed, falling back to file:`, e);
+      }
       return null;
     }
   }

--- a/designer/src/components/Designer.tsx
+++ b/designer/src/components/Designer.tsx
@@ -242,6 +242,7 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
     mcpBridge.setThemeHandler((themeId) =>
       handleThemeChangeRef.current(themeId as ThemeId)
     );
+    mcpBridge.setCurrentScreenId(screenId);
     mcpBridge.start(editor);
 
     // 他タブ/クライアントで同じ画面が変更されたとき。
@@ -263,6 +264,7 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
       unsubscribe();
       unsubScreenChanged();
       mcpBridge.setThemeHandler(null);
+      mcpBridge.setCurrentScreenId(null);
       mcpBridge.stop();
     };
   }, [screenId, tabId]);

--- a/designer/src/components/Designer.tsx
+++ b/designer/src/components/Designer.tsx
@@ -23,6 +23,7 @@ import { mcpBridge, type McpStatus } from "../mcp/mcpBridge";
 import { loadCustomBlocks, injectCustomBlockCss } from "../store/customBlockStore";
 import { loadProject, updateScreenThumbnail } from "../store/flowStore";
 import { makeTabId, setDirty } from "../store/tabStore";
+import { clearItemsFromCache } from "../store/screenItemsStore";
 
 /**
  * editor.getComponents() は GrapesJS が load() 中の Frame.onRemove 経由で一時的に
@@ -266,6 +267,7 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
       mcpBridge.setThemeHandler(null);
       mcpBridge.setCurrentScreenId(null);
       mcpBridge.stop();
+      clearItemsFromCache(screenId);
     };
   }, [screenId, tabId]);
 

--- a/designer/src/components/action/ActionEditor.tsx
+++ b/designer/src/components/action/ActionEditor.tsx
@@ -1053,6 +1053,8 @@ export function ActionEditor() {
 }
 
 // ── browser-first 処理フロー変異ヘルパー (#361) ──────────────────────────────
+// add_step / remove_step / moveStep は actionStore の関数を再利用し、
+// ファイルベース (actionGroupEdits.ts) と実装が乖離しないようにする。
 
 function applyActionGroupMutation(
   g: ActionGroup,
@@ -1063,18 +1065,10 @@ function applyActionGroupMutation(
     case "designer__add_step": {
       const act = g.actions.find((a) => a.id === p.actionId);
       if (!act) return;
-      const step = {
-        id: `step-${Date.now()}`,
-        type: p.type as StepType,
-        description: (p.description as string) ?? "",
-        ...((p.detail ?? {}) as object),
-      } as unknown as Step;
       const pos = typeof p.position === "number" ? p.position : undefined;
-      if (pos !== undefined && pos >= 0 && pos <= act.steps.length) {
-        act.steps.splice(pos, 0, step);
-      } else {
-        act.steps.push(step);
-      }
+      const step = addStep(act, p.type as StepType, pos);
+      if (p.description) step.description = p.description as string;
+      Object.assign(step, (p.detail ?? {}) as object);
       break;
     }
     case "designer__update_step": {
@@ -1087,7 +1081,7 @@ function applyActionGroupMutation(
     case "designer__remove_step": {
       for (const act of g.actions) {
         const idx = act.steps.findIndex((s) => s.id === p.stepId);
-        if (idx >= 0) { act.steps.splice(idx, 1); return; }
+        if (idx >= 0) { removeStep(act, p.stepId as string); return; }
       }
       break;
     }
@@ -1095,11 +1089,7 @@ function applyActionGroupMutation(
       const newIndex = p.newIndex as number;
       for (const act of g.actions) {
         const fromIdx = act.steps.findIndex((s) => s.id === p.stepId);
-        if (fromIdx >= 0) {
-          const [step] = act.steps.splice(fromIdx, 1);
-          act.steps.splice(newIndex, 0, step);
-          return;
-        }
+        if (fromIdx >= 0) { moveStep(act, fromIdx, newIndex); return; }
       }
       break;
     }

--- a/designer/src/components/action/ActionEditor.tsx
+++ b/designer/src/components/action/ActionEditor.tsx
@@ -49,6 +49,7 @@ import {
 } from "@dnd-kit/sortable";
 import { useResourceEditor } from "../../hooks/useResourceEditor";
 import { useSaveShortcut } from "../../hooks/useSaveShortcut";
+import { mcpBridge } from "../../mcp/mcpBridge";
 import { useSelectionKeyboard } from "../../hooks/useSelectionKeyboard";
 import { STEP_TYPE_COLORS } from "../../types/action";
 import { TableSubToolbar } from "../table/TableSubToolbar";
@@ -204,6 +205,21 @@ export function ActionEditor() {
     onNotFound: handleNotFound,
     onLoaded: handleLoaded,
   });
+
+  // ActionEditor の live 状態を mcpBridge に公開 (#361 browser-first)
+  const groupRef = useRef<ActionGroup | null>(null);
+  groupRef.current = group ?? null;
+
+  useEffect(() => {
+    if (!actionGroupId) return;
+    mcpBridge.setActionGroupHandler(actionGroupId, {
+      get: () => groupRef.current,
+      mutate: (type, params) => {
+        updateGroup((g) => applyActionGroupMutation(g, type, params as Record<string, unknown>));
+      },
+    });
+    return () => mcpBridge.setActionGroupHandler(actionGroupId, null);
+  }, [actionGroupId, updateGroup]);
 
   // 保存時にバリデーションをチェック（blocking なエラーがあれば中断）
   const handleSave = useCallback(async () => {
@@ -1034,4 +1050,58 @@ export function ActionEditor() {
       />
     </div>
   );
+}
+
+// ── browser-first 処理フロー変異ヘルパー (#361) ──────────────────────────────
+
+function applyActionGroupMutation(
+  g: ActionGroup,
+  type: string,
+  p: Record<string, unknown>,
+): void {
+  switch (type) {
+    case "designer__add_step": {
+      const act = g.actions.find((a) => a.id === p.actionId);
+      if (!act) return;
+      const step = {
+        id: `step-${Date.now()}`,
+        type: p.type as StepType,
+        description: (p.description as string) ?? "",
+        ...((p.detail ?? {}) as object),
+      } as unknown as Step;
+      const pos = typeof p.position === "number" ? p.position : undefined;
+      if (pos !== undefined && pos >= 0 && pos <= act.steps.length) {
+        act.steps.splice(pos, 0, step);
+      } else {
+        act.steps.push(step);
+      }
+      break;
+    }
+    case "designer__update_step": {
+      for (const act of g.actions) {
+        const step = act.steps.find((s) => s.id === p.stepId);
+        if (step) { Object.assign(step, p.patch); return; }
+      }
+      break;
+    }
+    case "designer__remove_step": {
+      for (const act of g.actions) {
+        const idx = act.steps.findIndex((s) => s.id === p.stepId);
+        if (idx >= 0) { act.steps.splice(idx, 1); return; }
+      }
+      break;
+    }
+    case "designer__move_step": {
+      const newIndex = p.newIndex as number;
+      for (const act of g.actions) {
+        const fromIdx = act.steps.findIndex((s) => s.id === p.stepId);
+        if (fromIdx >= 0) {
+          const [step] = act.steps.splice(fromIdx, 1);
+          act.steps.splice(newIndex, 0, step);
+          return;
+        }
+      }
+      break;
+    }
+  }
 }

--- a/designer/src/mcp/mcpBridge.ts
+++ b/designer/src/mcp/mcpBridge.ts
@@ -970,12 +970,17 @@ class McpBridgeImpl {
           try {
             for (const [oldId, newId] of Object.entries(mapping)) {
               try {
-                if (wrapper) updateComponentIds(wrapper, oldId, newId);
+                const domHits = wrapper ? updateComponentIds(wrapper, oldId, newId) : 0;
+                let siHit = false;
                 if (siFile) {
                   const item = siFile.items.find((i) => i.id === oldId);
-                  if (item) item.id = newId;
+                  if (item) { item.id = newId; siHit = true; }
                 }
-                succeeded.push(oldId);
+                if (domHits === 0 && !siHit) {
+                  failed.push({ oldId, error: `id "${oldId}" が DOM にも screen-items にも見つかりません` });
+                } else {
+                  succeeded.push(oldId);
+                }
               } catch (e) {
                 failed.push({ oldId, error: String(e) });
               }
@@ -1004,16 +1009,18 @@ class McpBridgeImpl {
 
 // ── ヘルパー関数 ────────────────────────────────────────────────────────────
 
-function updateComponentIds(component: Component, oldId: string, newId: string): void {
+function updateComponentIds(component: Component, oldId: string, newId: string): number {
   const attrs = component.getAttributes();
   const updates: Record<string, string> = {};
   if (attrs.name === oldId) updates.name = newId;
   if (attrs.id === oldId) updates.id = newId;
-  if (Object.keys(updates).length > 0) component.addAttributes(updates);
+  let hits = Object.keys(updates).length > 0 ? 1 : 0;
+  if (hits > 0) component.addAttributes(updates);
   const children = component.components();
   for (let i = 0; i < children.length; i++) {
-    updateComponentIds(children.at(i) as Component, oldId, newId);
+    hits += updateComponentIds(children.at(i) as Component, oldId, newId);
   }
+  return hits;
 }
 
 function findFirstTextLeaf(c: Component): Component | null {

--- a/designer/src/mcp/mcpBridge.ts
+++ b/designer/src/mcp/mcpBridge.ts
@@ -400,8 +400,9 @@ class McpBridgeImpl {
       }
     };
 
-    // フロー操作・タブ操作・AG ハンドラはエディター不要
-    const flowMethods = [
+    // GrapesJS editor インスタンスが不要なメソッド一覧
+    // (フロー操作 / タブ操作 / ActionGroupHandler 操作)
+    const editorFreeMethods = [
       "listScreens", "addScreen", "updateScreenMeta", "removeScreenNode",
       "addFlowEdge", "removeFlowEdge", "getFlow", "navigateScreen",
       "listCustomBlocks",
@@ -409,7 +410,7 @@ class McpBridgeImpl {
       "getActionGroup", "applyActionGroupMutation",
     ];
 
-    if (!this.editor && !flowMethods.includes(method)) {
+    if (!this.editor && !editorFreeMethods.includes(method)) {
       respondError("エディターが初期化されていません");
       return;
     }

--- a/designer/src/mcp/mcpBridge.ts
+++ b/designer/src/mcp/mcpBridge.ts
@@ -50,9 +50,12 @@ import {
   type ConventionsStorageBackend,
 } from "../store/conventionsStore";
 import {
+  loadScreenItems,
+  setItemsInCache,
   setScreenItemsStorageBackend,
   type ScreenItemsStorageBackend,
 } from "../store/screenItemsStore";
+import type { ScreenItemsFile } from "../types/screenItem";
 import { loadTable } from "../store/tableStore";
 
 export type McpStatus = "disconnected" | "connecting" | "connected";
@@ -80,6 +83,7 @@ declare global {
 class McpBridgeImpl {
   private ws: WebSocket | null = null;
   private editor: GEditor | null = null;
+  private currentScreenId: string | null = null;
   private status: McpStatus = "disconnected";
   private statusCallbacks: Set<StatusCallback> = new Set();
   private themeHandler: ThemeHandler | null = null;
@@ -103,6 +107,10 @@ class McpBridgeImpl {
   }
 
   // ── ハンドラ setter ────────────────────────────────────────────────────
+
+  setCurrentScreenId(screenId: string | null): void {
+    this.currentScreenId = screenId;
+  }
 
   setThemeHandler(handler: ThemeHandler | null): void {
     this.themeHandler = handler;
@@ -869,6 +877,74 @@ class McpBridgeImpl {
           break;
         }
 
+        // ── browser-first 命名支援 ─────────────────────────────────────
+
+        case "getCanvasSnapshot": {
+          const { screenId: reqScreenId } = (params ?? {}) as { screenId: string };
+          if (this.currentScreenId !== reqScreenId) {
+            respondError(`画面 ${reqScreenId} はブラウザで開かれていません (current: ${this.currentScreenId ?? "none"})`);
+            break;
+          }
+          const html = editor.getHtml();
+          let screenItems: ScreenItemsFile | null = null;
+          try {
+            screenItems = await loadScreenItems(reqScreenId);
+          } catch { /* ignore */ }
+          respond({ html, screenItems });
+          break;
+        }
+
+        case "applyRenameInBrowser": {
+          const { screenId: reqScreenId, mapping } = (params ?? {}) as {
+            screenId: string;
+            mapping: Record<string, string>;
+          };
+          if (this.currentScreenId !== reqScreenId) {
+            respondError(`画面 ${reqScreenId} はブラウザで開かれていません`);
+            break;
+          }
+
+          let siFile: ScreenItemsFile | null = null;
+          try {
+            siFile = await loadScreenItems(reqScreenId);
+          } catch (e) {
+            respondError(`screenItems の読み込みに失敗: ${e}`);
+            break;
+          }
+
+          const succeeded: string[] = [];
+          const failed: Array<{ oldId: string; error: string }> = [];
+          const wrapper = editor.DomComponents.getWrapper();
+
+          // UndoManager を停止して直接更新
+          const um = editor.UndoManager;
+          um.stop();
+          try {
+            for (const [oldId, newId] of Object.entries(mapping)) {
+              try {
+                if (wrapper) updateComponentIds(wrapper, oldId, newId);
+                if (siFile) {
+                  const item = siFile.items.find((i) => i.id === oldId);
+                  if (item) item.id = newId;
+                }
+                succeeded.push(oldId);
+              } catch (e) {
+                failed.push({ oldId, error: String(e) });
+              }
+            }
+          } finally {
+            um.start();
+          }
+
+          if (succeeded.length > 0) {
+            if (siFile) setItemsInCache(siFile);
+            setDirty(makeTabId("design", reqScreenId), true);
+          }
+
+          respond({ succeeded, failed });
+          break;
+        }
+
         default:
           respondError(`未知のメソッド: ${method}`);
       }
@@ -879,6 +955,18 @@ class McpBridgeImpl {
 }
 
 // ── ヘルパー関数 ────────────────────────────────────────────────────────────
+
+function updateComponentIds(component: Component, oldId: string, newId: string): void {
+  const attrs = component.getAttributes();
+  const updates: Record<string, string> = {};
+  if (attrs.name === oldId) updates.name = newId;
+  if (attrs.id === oldId) updates.id = newId;
+  if (Object.keys(updates).length > 0) component.addAttributes(updates);
+  const children = component.components();
+  for (let i = 0; i < children.length; i++) {
+    updateComponentIds(children.at(i) as Component, oldId, newId);
+  }
+}
 
 function findFirstTextLeaf(c: Component): Component | null {
   const children = c.components();

--- a/designer/src/mcp/mcpBridge.ts
+++ b/designer/src/mcp/mcpBridge.ts
@@ -69,6 +69,11 @@ type BroadcastHandler = (data: unknown) => void;
 type Command = { id: string; method: string; params?: unknown };
 type Response = { id: string; result?: unknown; error?: string };
 
+type ActionGroupHandler = {
+  get: () => unknown;
+  mutate: (type: string, params: unknown) => void;
+};
+
 const WS_URL = `ws://${window.location.hostname}:5179`;
 const RETRY_DELAY_MS = 5000;
 const REQUEST_TIMEOUT_MS = 15000;
@@ -84,6 +89,7 @@ class McpBridgeImpl {
   private ws: WebSocket | null = null;
   private editor: GEditor | null = null;
   private currentScreenId: string | null = null;
+  private actionGroupHandlers = new Map<string, ActionGroupHandler>();
   private status: McpStatus = "disconnected";
   private statusCallbacks: Set<StatusCallback> = new Set();
   private themeHandler: ThemeHandler | null = null;
@@ -110,6 +116,14 @@ class McpBridgeImpl {
 
   setCurrentScreenId(screenId: string | null): void {
     this.currentScreenId = screenId;
+  }
+
+  setActionGroupHandler(id: string, handler: ActionGroupHandler | null): void {
+    if (handler) {
+      this.actionGroupHandlers.set(id, handler);
+    } else {
+      this.actionGroupHandlers.delete(id);
+    }
   }
 
   setThemeHandler(handler: ThemeHandler | null): void {
@@ -386,12 +400,13 @@ class McpBridgeImpl {
       }
     };
 
-    // フロー操作・タブ操作はエディター不要
+    // フロー操作・タブ操作・AG ハンドラはエディター不要
     const flowMethods = [
       "listScreens", "addScreen", "updateScreenMeta", "removeScreenNode",
       "addFlowEdge", "removeFlowEdge", "getFlow", "navigateScreen",
       "listCustomBlocks",
       "openTab", "closeTab", "switchTab", "listTabs", "saveScreen", "saveAll",
+      "getActionGroup", "applyActionGroupMutation",
     ];
 
     if (!this.editor && !flowMethods.includes(method)) {
@@ -874,6 +889,39 @@ class McpBridgeImpl {
             }
           }
           respond({ saved: results.filter((r) => r.success).length, total: dirtyTabs.length, results });
+          break;
+        }
+
+        // ── browser-first 処理フロー操作 ──────────────────────────────
+
+        case "getActionGroup": {
+          const { id: agId } = (params ?? {}) as { id: string };
+          const handler = this.actionGroupHandlers.get(agId);
+          if (!handler) {
+            respondError(`ActionEditor が開かれていません: ${agId}`);
+            break;
+          }
+          respond(handler.get());
+          break;
+        }
+
+        case "applyActionGroupMutation": {
+          const { id: agId, type: mutType, params: mutParams } = (params ?? {}) as {
+            id: string;
+            type: string;
+            params: unknown;
+          };
+          const handler = this.actionGroupHandlers.get(agId);
+          if (!handler) {
+            respondError(`ActionEditor が開かれていません: ${agId}`);
+            break;
+          }
+          try {
+            handler.mutate(mutType, mutParams);
+            respond({ success: true });
+          } catch (e) {
+            respondError(String(e));
+          }
           break;
         }
 

--- a/designer/src/store/screenItemsStore.ts
+++ b/designer/src/store/screenItemsStore.ts
@@ -19,6 +19,19 @@ export function setScreenItemsStorageBackend(b: ScreenItemsStorageBackend | null
   _backend = b;
 }
 
+/** in-memory キャッシュ: applyRenameInBrowser でファイル未保存のまま id を更新するために使用 */
+const _cache = new Map<string, ScreenItemsFile>();
+
+/** in-memory キャッシュを更新する (ファイルには書かない) */
+export function setItemsInCache(file: ScreenItemsFile): void {
+  _cache.set(file.screenId, { ...file });
+}
+
+/** in-memory キャッシュを削除する */
+export function clearItemsFromCache(screenId: string): void {
+  _cache.delete(screenId);
+}
+
 const LS_PREFIX = "screen-items-";
 
 function now(): string {
@@ -26,6 +39,8 @@ function now(): string {
 }
 
 export async function loadScreenItems(screenId: string): Promise<ScreenItemsFile> {
+  const cached = _cache.get(screenId);
+  if (cached) return cached;
   if (_backend) {
     const data = await _backend.loadScreenItems(screenId);
     if (data) return data as ScreenItemsFile;
@@ -42,6 +57,7 @@ export async function loadScreenItems(screenId: string): Promise<ScreenItemsFile
 
 export async function saveScreenItems(file: ScreenItemsFile): Promise<void> {
   file.updatedAt = now();
+  _cache.delete(file.screenId);
   if (_backend) {
     await _backend.saveScreenItems(file.screenId, file);
     return;


### PR DESCRIPTION
## Summary

Closes #360
Closes #361

- **#360**: `get_rename_context` / `apply_rename_mapping` を browser-first に変更。ブラウザが開いていれば unsaved canvas 状態を AI に渡し、rename 適用も in-memory で行う
- **#361**: `get_action_group` / `add_step` / `update_step` / `remove_step` / `move_step` を browser-first に変更。ActionEditor が開いていれば live state を読み書き、未接続時はファイル fallback

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `designer-mcp/src/wsBridge.ts` | `tryCommand()` 追加、非 production 時 console.error 出力 |
| `designer-mcp/src/renameScreenItem.ts` | `updateActionGroupRefs()` 追加 |
| `designer-mcp/src/renameContext.ts` | `getRenameContext` browser-first 化 |
| `designer-mcp/src/handlers/actionGroup.ts` | get/add/update/remove/move_step browser-first 化、出力を `_mcpSource` フィールド付き valid JSON に変更 |
| `designer-mcp/src/index.ts` | `apply_rename_mapping` browser-first 化 |
| `designer/src/store/screenItemsStore.ts` | in-memory キャッシュ追加 |
| `designer/src/mcp/mcpBridge.ts` | `editorFreeMethods` (旧 flowMethods) リネーム、`currentScreenId` / `ActionGroupHandler` 追加、4 コマンド追加、`updateComponentIds` ヒット数返り値化 |
| `designer/src/components/Designer.tsx` | `setCurrentScreenId` 呼び出し + unmount 時 `clearItemsFromCache` |
| `designer/src/components/action/ActionEditor.tsx` | `setActionGroupHandler` 登録・解除、`applyActionGroupMutation` で actionStore 再利用 |

## 仕様逐条突合 (#360)

- `wsBridge.ts` `tryCommand()` ✓
- `mcpBridge.ts` `getCanvasSnapshot`: html + screenItems 返却 ✓
- `mcpBridge.ts` `applyRenameInBrowser`: GrapesJS attr 更新 + siFile id 更新 + dirty。DOM/siFile 両方未ヒットは failed に分類 ✓
- `screenItemsStore.ts` in-memory キャッシュ優先 ✓
- `Designer.tsx` unmount 時 `clearItemsFromCache(screenId)` ✓
- `renameContext.ts` browser-first + fallback ✓
- `index.ts` `apply_rename_mapping` browser-first + AG refs のみファイル書き ✓
- 未接続時は従来通りファイル fallback ✓

## 仕様逐条突合 (#361)

- `mcpBridge.ts` `getActionGroup`: ActionEditor 開放中のみ応答 ✓
- `mcpBridge.ts` `applyActionGroupMutation`: `updateGroup` 経由で dirty ✓
- `ActionEditor.tsx` useEffect でハンドラ登録・解除 ✓
- `actionGroup.ts` `get_action_group` browser-first + fallback ✓
- `actionGroup.ts` add/update/remove/move_step browser-first + fallback ✓
- ActionEditor 未開放時はファイル fallback ✓

## レビュー指摘対応

| ラウンド | 指摘 | 対応 |
|---|---|---|
| 1st Must | `applyRenameInBrowser` silent success | `updateComponentIds` ヒット数返り値化、DOM+siFile 両方未ヒット → failed |
| 1st Must | Designer unmount 時 cache 残存 | cleanup に `clearItemsFromCache(screenId)` 追加 |
| 1st Should | `get_action_group` invalid JSON | `_mcpSource` フィールドをマージした valid JSON に変更 |
| 2nd Should | `flowMethods` 命名乖離 | `editorFreeMethods` にリネーム + コメント補足 |
| 2nd Nit | `tryCommand` 全例外吸収 | 非 production 時に `console.error` 出力 |
| 2nd Nit | `applyActionGroupMutation` 実装分岐 | `addStep` / `removeStep` / `moveStep` を actionStore から再利用 |

## Test plan

- [ ] TypeScript ビルドエラーなし ✓
- [ ] vitest 634 件通過 ✓
- [ ] ブラウザで画面デザイナーを開いた状態で `get_rename_context` → unsaved 変更が反映されること
- [ ] `apply_rename_mapping` 後にキャンバスの id/name 属性が更新され、タブが dirty になること
- [ ] ActionEditor を開いた状態で `get_action_group` → live state が返ること
- [ ] ActionEditor を開いた状態で `add_step` → ブラウザに即時反映されること
- [ ] ブラウザが未接続の状態では従来通りファイルベースで動作すること

🤖 Generated with [Claude Code](https://claude.ai/claude-code)