### PR TITLE
sample: 在庫発注登録 @conv.* 全カテゴリ活用実証サンプル (#253 Task 3)

### DIFF
--- a/docs/sample-project/actions/cccccccc-0006-4000-8000-cccccccccccc.json
+++ b/docs/sample-project/actions/cccccccc-0006-4000-8000-cccccccccccc.json
@@ -282,10 +282,10 @@
         {
           "id": "step-04",
           "type": "compute",
-          "description": "行金額配列を初期化 (@conv.currency.jpy: JPY, subunit=0 前提で整数演算)",
+          "description": "発注明細値オブジェクト配列を初期化 (ループで push し step-10 の一括 INSERT に使用)",
           "maturity": "committed",
           "expression": "[]",
-          "outputBinding": "lineAmounts"
+          "outputBinding": "poItemValues"
         },
 
         {
@@ -337,10 +337,10 @@
                   {
                     "id": "step-05-03",
                     "type": "compute",
-                    "description": "行金額 = 単価 × 数量 (整数演算、@conv.currency.jpy subunit=0)",
+                    "description": "明細オブジェクト生成 (lineAmount = 単価 × 数量、@conv.currency.jpy subunit=0 で整数演算) → poItemValues に追加",
                     "maturity": "committed",
-                    "expression": "@itemInfo.unit_price * @item.quantity",
-                    "outputBinding": { "name": "lineAmounts", "operation": "push" }
+                    "expression": "{ itemId: @item.itemId, quantity: @item.quantity, unitPrice: @itemInfo.unit_price, lineAmount: @itemInfo.unit_price * @item.quantity }",
+                    "outputBinding": { "name": "poItemValues", "operation": "push" }
                   }
                 ]
               }
@@ -353,7 +353,7 @@
           "type": "compute",
           "description": "小計 = Σ 行金額",
           "maturity": "committed",
-          "expression": "@lineAmounts.reduce((a, b) => a + b, 0)",
+          "expression": "@poItemValues.reduce((a, b) => a + b.lineAmount, 0)",
           "outputBinding": "subtotal"
         },
 
@@ -429,7 +429,7 @@
           "httpCall": {
             "method": "POST",
             "path": "/v3/mail/send",
-            "body": "{ to: @supplier.email, subject: '発注確認 ' + @newOrder.po_number, content: '発注金額: ' + (@subtotal + @taxAmount) + '円 (税込, @conv.scope.timezone: JST)' }"
+            "body": "{ to: @supplier.email, subject: '発注確認 ' + @newOrder.po_number, content: '発注金額: ' + (@subtotal + @taxAmount) + '円 (税込)' }"
           },
           "fireAndForget": true,
           "outcomes": {

--- a/docs/sample-project/actions/cccccccc-0006-4000-8000-cccccccccccc.json
+++ b/docs/sample-project/actions/cccccccc-0006-4000-8000-cccccccccccc.json
@@ -1,0 +1,459 @@
+{
+  "id": "cccccccc-0006-4000-8000-cccccccccccc",
+  "name": "在庫発注登録画面",
+  "type": "screen",
+  "screenId": "aaaaaaaa-0006-4000-8000-aaaaaaaaaaaa",
+  "description": "2026-04-24 ドッグフード Task 3: @conv.* 全カテゴリ活用実証サンプル。仕入先への在庫発注を登録し、発注確認メールを送信する。scope/currency/tax/db/numbering/tx/externalOutcomeDefaults を構造化フィールドに可能な限り埋め込む。",
+  "mode": "downstream",
+  "maturity": "committed",
+
+  "ambientVariables": [
+    {
+      "name": "requestId",
+      "type": "string",
+      "required": true,
+      "description": "リクエスト毎一意 ID。冪等性キー生成とログ相関に使用"
+    },
+    {
+      "name": "sessionUserId",
+      "type": "number",
+      "required": true,
+      "description": "@conv.auth.default (scheme: session-cookie)。ミドルウェアがセッション Cookie から注入"
+    },
+    {
+      "name": "fieldErrors",
+      "type": { "kind": "custom", "label": "Record<string, string>" },
+      "required": false,
+      "description": "ValidationStep.rules[] 評価結果。fieldErrorsVar で宣言"
+    }
+  ],
+
+  "errorCatalog": {
+    "VALIDATION": {
+      "httpStatus": 400,
+      "defaultMessage": "入力値エラー",
+      "responseRef": "400-validation",
+      "description": "ValidationStep.rules[] unsatisfied"
+    },
+    "SUPPLIER_NOT_FOUND": {
+      "httpStatus": 404,
+      "defaultMessage": "仕入先が存在しません",
+      "responseRef": "404-not-found"
+    },
+    "ITEM_NOT_FOUND": {
+      "httpStatus": 404,
+      "defaultMessage": "商品が存在しません",
+      "responseRef": "404-not-found"
+    },
+    "AMOUNT_EXCEEDED": {
+      "httpStatus": 422,
+      "defaultMessage": "発注金額が上限を超えています",
+      "responseRef": "422-amount-exceeded"
+    }
+  },
+
+  "typeCatalog": {
+    "ApiError": {
+      "description": "共通エラーレスポンス (product-scope §7)",
+      "schema": {
+        "type": "object",
+        "required": ["code", "message"],
+        "properties": {
+          "code": { "type": "string" },
+          "message": { "type": "string" },
+          "fieldErrors": { "type": "object", "additionalProperties": { "type": "string" } }
+        }
+      }
+    },
+    "PurchaseOrderResponse": {
+      "description": "発注登録成功レスポンス",
+      "schema": {
+        "type": "object",
+        "required": ["poId", "poNumber", "subtotal", "taxAmount", "totalAmount"],
+        "properties": {
+          "poId": { "type": "integer" },
+          "poNumber": {
+            "type": "string",
+            "description": "@conv.numbering.orderNumber 準拠 ORD-YYYY-NNNN 形式 (PG sequence + trigger)"
+          },
+          "subtotal": { "type": "integer" },
+          "taxAmount": { "type": "integer" },
+          "totalAmount": { "type": "integer" }
+        }
+      }
+    }
+  },
+
+  "externalSystemCatalog": {
+    "sendgrid": {
+      "name": "SendGrid Mail API",
+      "baseUrl": "https://api.sendgrid.com",
+      "auth": { "kind": "bearer", "tokenRef": "@secret.sendgridApiKey" },
+      "timeoutMs": 5000,
+      "headers": { "Content-Type": "application/json" },
+      "description": "発注確認メール送信。@conv.tx.externalApi: TX 外呼出"
+    }
+  },
+
+  "secretsCatalog": {
+    "sendgridApiKey": {
+      "source": "env",
+      "name": "SENDGRID_API_KEY",
+      "rotationDays": 180
+    }
+  },
+
+  "actions": [
+    {
+      "id": "act-001",
+      "name": "発注登録ボタン押下",
+      "trigger": "submit",
+      "description": "発注フォームを送信し、仕入先確認 → 商品確認 → 金額計算 → DB 登録 → メール通知を行う",
+      "maturity": "committed",
+      "httpRoute": {
+        "method": "POST",
+        "path": "/api/purchase-orders",
+        "auth": "required"
+      },
+      "inputs": [
+        {
+          "name": "supplierId",
+          "label": "仕入先ID",
+          "type": "number",
+          "required": true,
+          "screenItemRef": {
+            "screenId": "aaaaaaaa-0006-4000-8000-aaaaaaaaaaaa",
+            "itemId": "supplier-select"
+          }
+        },
+        {
+          "name": "items",
+          "label": "発注明細",
+          "type": {
+            "kind": "array",
+            "itemType": {
+              "kind": "object",
+              "fields": [
+                { "name": "itemId", "type": "number", "required": true, "label": "商品ID" },
+                {
+                  "name": "quantity",
+                  "type": "number",
+                  "required": true,
+                  "label": "発注数量",
+                  "description": "1 以上 9999 以下 (@conv.limit.quantityMax)"
+                }
+              ]
+            }
+          },
+          "required": true,
+          "screenItemRef": {
+            "screenId": "aaaaaaaa-0006-4000-8000-aaaaaaaaaaaa",
+            "itemId": "order-items-table"
+          }
+        },
+        {
+          "name": "deliveryNote",
+          "label": "納品備考",
+          "type": "string",
+          "required": false,
+          "screenItemRef": {
+            "screenId": "aaaaaaaa-0006-4000-8000-aaaaaaaaaaaa",
+            "itemId": "delivery-note"
+          }
+        }
+      ],
+      "outputs": [
+        { "name": "poId", "label": "発注ID", "type": "number" },
+        {
+          "name": "poNumber",
+          "label": "発注番号",
+          "type": "string",
+          "description": "@conv.numbering.orderNumber 準拠 ORD-YYYY-NNNN"
+        },
+        {
+          "name": "totalAmount",
+          "label": "合計金額 (税込)",
+          "type": "number",
+          "description": "@conv.currency.jpy: JPY, subunit=0, roundingMode=floor"
+        }
+      ],
+      "responses": [
+        {
+          "id": "201-created",
+          "status": 201,
+          "bodySchema": { "typeRef": "PurchaseOrderResponse" },
+          "when": "正常登録完了"
+        },
+        {
+          "id": "400-validation",
+          "status": 400,
+          "bodySchema": { "typeRef": "ApiError" },
+          "when": "@fieldErrors が空でない"
+        },
+        {
+          "id": "404-not-found",
+          "status": 404,
+          "bodySchema": { "typeRef": "ApiError" },
+          "when": "supplierId または items[*].itemId が存在しない"
+        },
+        {
+          "id": "422-amount-exceeded",
+          "status": 422,
+          "bodySchema": { "typeRef": "ApiError" },
+          "when": "@subtotal > @conv.limit.amountMax.value (999999999999)"
+        }
+      ],
+      "steps": [
+        {
+          "id": "step-01",
+          "type": "validation",
+          "description": "入力バリデーション: 仕入先ID必須、明細最低1件、各数量は1〜9999",
+          "maturity": "committed",
+          "conditions": "supplierId 必須、items 必須・最低1件、各 quantity は 1 以上 9999 以下",
+          "rules": [
+            {
+              "field": "supplierId",
+              "type": "required",
+              "message": "@conv.msg.required"
+            },
+            {
+              "field": "items",
+              "type": "required",
+              "message": "@conv.msg.required"
+            },
+            {
+              "field": "items[*].quantity",
+              "type": "range",
+              "min": 1,
+              "max": 9999,
+              "message": "@conv.msg.outOfRange"
+            }
+          ],
+          "fieldErrorsVar": "fieldErrors",
+          "inlineBranch": {
+            "ok": "次のステップへ続行",
+            "ng": "400 バリデーションエラー返却",
+            "ngResponseRef": "400-validation",
+            "ngBodyExpression": "{ code: 'VALIDATION', message: '入力値エラー', fieldErrors: @fieldErrors }"
+          }
+        },
+
+        {
+          "id": "step-02",
+          "type": "dbAccess",
+          "description": "仕入先存在確認 (@conv.db.default: PostgreSQL, snake_case, is_deleted 論理削除)",
+          "maturity": "committed",
+          "tableName": "suppliers",
+          "operation": "SELECT",
+          "sql": "SELECT id, name, email FROM suppliers WHERE id = @supplierId AND is_deleted = false",
+          "outputBinding": "supplier"
+        },
+
+        {
+          "id": "step-03",
+          "type": "branch",
+          "description": "仕入先不存在分岐",
+          "maturity": "committed",
+          "branches": [
+            {
+              "id": "br-03-a",
+              "code": "A",
+              "label": "仕入先なし → 404",
+              "condition": "@supplier == null",
+              "steps": [
+                {
+                  "id": "step-03-a-01",
+                  "type": "return",
+                  "description": "404 仕入先不存在",
+                  "responseRef": "404-not-found",
+                  "bodyExpression": "{ code: 'SUPPLIER_NOT_FOUND', message: '仕入先が存在しません' }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-03-else",
+            "code": "B",
+            "label": "仕入先あり → 続行",
+            "steps": []
+          }
+        },
+
+        {
+          "id": "step-04",
+          "type": "compute",
+          "description": "行金額配列を初期化 (@conv.currency.jpy: JPY, subunit=0 前提で整数演算)",
+          "maturity": "committed",
+          "expression": "[]",
+          "outputBinding": "lineAmounts"
+        },
+
+        {
+          "id": "step-05",
+          "type": "loop",
+          "description": "各発注明細の商品確認と行金額計算",
+          "maturity": "committed",
+          "loopKind": "collection",
+          "collectionSource": "@inputs.items",
+          "collectionItemName": "item",
+          "steps": [
+            {
+              "id": "step-05-01",
+              "type": "dbAccess",
+              "description": "商品マスタ確認 (@conv.db.default: snake_case, is_deleted 論理削除)",
+              "maturity": "committed",
+              "tableName": "items",
+              "operation": "SELECT",
+              "sql": "SELECT id, name, unit_price FROM items WHERE id = @item.itemId AND is_deleted = false",
+              "outputBinding": "itemInfo"
+            },
+            {
+              "id": "step-05-02",
+              "type": "branch",
+              "description": "商品不存在分岐",
+              "maturity": "committed",
+              "branches": [
+                {
+                  "id": "br-05-02-a",
+                  "code": "A",
+                  "label": "商品なし → 404",
+                  "condition": "@itemInfo == null",
+                  "steps": [
+                    {
+                      "id": "step-05-02-a-01",
+                      "type": "return",
+                      "description": "404 商品不存在",
+                      "responseRef": "404-not-found",
+                      "bodyExpression": "{ code: 'ITEM_NOT_FOUND', message: '商品が存在しません', detail: { itemId: @item.itemId } }"
+                    }
+                  ]
+                }
+              ],
+              "elseBranch": {
+                "id": "br-05-02-else",
+                "code": "B",
+                "label": "商品あり → 行金額計算",
+                "steps": [
+                  {
+                    "id": "step-05-03",
+                    "type": "compute",
+                    "description": "行金額 = 単価 × 数量 (整数演算、@conv.currency.jpy subunit=0)",
+                    "maturity": "committed",
+                    "expression": "@itemInfo.unit_price * @item.quantity",
+                    "outputBinding": { "name": "lineAmounts", "operation": "push" }
+                  }
+                ]
+              }
+            }
+          ]
+        },
+
+        {
+          "id": "step-06",
+          "type": "compute",
+          "description": "小計 = Σ 行金額",
+          "maturity": "committed",
+          "expression": "@lineAmounts.reduce((a, b) => a + b, 0)",
+          "outputBinding": "subtotal"
+        },
+
+        {
+          "id": "step-07",
+          "type": "compute",
+          "description": "消費税計算: @conv.tax.standard (外税 10%, 切り捨て)",
+          "maturity": "committed",
+          "expression": "Math.floor(@subtotal * @conv.tax.standard.rate)",
+          "outputBinding": "taxAmount"
+        },
+
+        {
+          "id": "step-08",
+          "type": "branch",
+          "description": "発注上限チェック",
+          "maturity": "committed",
+          "branches": [
+            {
+              "id": "br-08-a",
+              "code": "A",
+              "label": "上限超過 → 422",
+              "condition": "@subtotal > @conv.limit.amountMax.value",
+              "steps": [
+                {
+                  "id": "step-08-a-01",
+                  "type": "return",
+                  "description": "422 金額上限超過",
+                  "responseRef": "422-amount-exceeded",
+                  "bodyExpression": "{ code: 'AMOUNT_EXCEEDED', message: '発注金額が上限を超えています' }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-08-else",
+            "code": "B",
+            "label": "上限以内 → 発注登録",
+            "steps": []
+          }
+        },
+
+        {
+          "id": "step-09",
+          "type": "dbAccess",
+          "description": "発注ヘッダ登録 (@conv.db.default: PostgreSQL + snake_case + created_at/updated_at 自動管理; @conv.numbering.orderNumber: po_number は ORD-YYYY-NNNN 形式 PG sequence + trigger で自動採番)",
+          "maturity": "committed",
+          "tableName": "purchase_orders",
+          "operation": "INSERT",
+          "sql": "INSERT INTO purchase_orders (supplier_id, subtotal, tax_amount, total_amount, delivery_note, created_by, created_at, updated_at) VALUES (@supplierId, @subtotal, @taxAmount, @subtotal + @taxAmount, @inputs.deliveryNote, @sessionUserId, NOW(), NOW()) RETURNING id, po_number",
+          "txBoundary": { "role": "begin", "txId": "tx-po-register" },
+          "outputBinding": "newOrder"
+        },
+
+        {
+          "id": "step-10",
+          "type": "dbAccess",
+          "description": "発注明細一括登録 (@conv.tx.singleOperation: 発注ヘッダと同一 TX)",
+          "maturity": "committed",
+          "tableName": "purchase_order_items",
+          "operation": "INSERT",
+          "sql": "INSERT INTO purchase_order_items (purchase_order_id, item_id, quantity, unit_price, line_amount, created_at) SELECT @newOrder.id, v.item_id, v.quantity, v.unit_price, v.line_amount, NOW() FROM (VALUES @poItemValues) AS v(item_id, quantity, unit_price, line_amount)",
+          "txBoundary": { "role": "end", "txId": "tx-po-register" }
+        },
+
+        {
+          "id": "step-11",
+          "type": "externalSystem",
+          "description": "仕入先への発注確認メール送信 (@conv.tx.externalApi: TX 外呼出原則; fireAndForget: メール失敗で発注ロールバックしない — @conv.externalOutcomeDefaults.failure (abort) の既定から意図的に逸脱)",
+          "maturity": "committed",
+          "systemName": "SendGrid",
+          "systemRef": "sendgrid",
+          "httpCall": {
+            "method": "POST",
+            "path": "/v3/mail/send",
+            "body": "{ to: @supplier.email, subject: '発注確認 ' + @newOrder.po_number, content: '発注金額: ' + (@subtotal + @taxAmount) + '円 (税込, @conv.scope.timezone: JST)' }"
+          },
+          "fireAndForget": true,
+          "outcomes": {
+            "success": { "action": "continue" },
+            "failure": {
+              "action": "continue",
+              "description": "メール失敗は業務継続。@conv.externalOutcomeDefaults.failure (abort 既定) から意図的に逸脱"
+            },
+            "timeout": { "action": "continue", "sameAs": "failure" }
+          }
+        },
+
+        {
+          "id": "step-12",
+          "type": "return",
+          "description": "201 Created — 発注登録完了",
+          "maturity": "committed",
+          "responseRef": "201-created",
+          "bodyExpression": "{ poId: @newOrder.id, poNumber: @newOrder.po_number, subtotal: @subtotal, taxAmount: @taxAmount, totalAmount: @subtotal + @taxAmount }"
+        }
+      ]
+    }
+  ],
+
+  "createdAt": "2026-04-24T00:00:00.000Z",
+  "updatedAt": "2026-04-24T00:00:00.000Z"
+}


### PR DESCRIPTION
## 概要

#253 Task 3 — 5/5 到達再ドッグフード用サンプル追加。
2026-04-24 ドッグフード実施結果: **4.6/5** (厳格モード: description 完全無視)。

## 変更内容

### 新規ファイル
`docs/sample-project/actions/cccccccc-0006-4000-8000-cccccccccccc.json`

**題材**: 在庫発注登録画面 (POST /api/purchase-orders)、12 ステップ

**主な @conv.* 活用箇所 (構造化フィールド内)**:
- `@conv.tax.standard.rate` → ComputeStep.expression で消費税計算
- `@conv.limit.amountMax.value` → BranchStep.branches[].condition で上限チェック
- `@conv.msg.required` / `@conv.msg.outOfRange` → ValidationRule.message で参照
- `FieldType.array/object` → inputs.items の複合型定義
- `screenItemRef` → 3 フィールドで画面項目参照
- `OutputBindingObject.push` → poItemValues の蓄積 (各明細オブジェクトを push)
- `errorCatalog / typeCatalog / externalSystemCatalog / secretsCatalog` 全カタログ活用
- `txBoundary begin/end` → INSERT 2 ステップを 1 TX に束縛

## 自己評価: 4.6/5

詳細報告書: `.tmp/dogfood-2026-04-24-report.md` (gitignored)

**到達点**: @conv.tax/limit/msg が構造化フィールドで参照可能 (前回 4/5 から改善)

**残ギャップ** (Opus 判断待ち):
- `@conv.numbering.*` は DB レイヤー採番のため処理フロー JSON で structurally 表現困難
- 一括 INSERT の VALUES 展開方法 (poItemValues の SQL 展開規約) が未定義
- `@conv.scope.timezone` (JST) が structurally 宣言不可
- `ValidationRule.max` (数値型) に @conv.limit.* を文字列参照できない

## レビュー指摘対応 (358e7bd)

**Should-fix**: `step-10 @poItemValues 未定義` → 修正済み
- step-04: `lineAmounts = []` を `poItemValues = []` に変更
- step-05-03: expression を数値スカラー → `{itemId, quantity, unitPrice, lineAmount}` オブジェクトに変更、outputBinding も `poItemValues` へ
- step-06: `@lineAmounts.reduce((a,b)=>a+b,0)` → `@poItemValues.reduce((a,b)=>a+b.lineAmount,0)`

**Nit**: `step-11 httpCall.body に @conv.scope.timezone: JST 混入` → 修正済み
- body 文字列から `@conv.scope.timezone: JST` 表記を除去

## 仕様逐条突合 (自己申告)

- [x] スキーマバリデーション pass (59/59)
- [x] FieldType.array/object を活用
- [x] screenItemRef を活用
- [x] OutputBindingObject.operation=push を活用 (poItemValues に構造体を蓄積)
- [x] 全カタログ (errorCatalog/typeCatalog/externalSystemCatalog/secretsCatalog) を活用
- [x] txBoundary begin/end を活用
- [x] @conv.tax/limit/msg を構造化フィールドで参照
- [x] @poItemValues が step-04 で初期化・step-05-03 で push・step-10 SQL で参照 (整合)

## テスト

- [x] `cd designer && npx vitest run src/schemas/process-flow.schema.test.ts` — 59 passed
- N/A (sample JSON のみ、UI 変更なし)