### PR TITLE
improve(schema): StructuredField.format + ValidationRule.maxRef/minRef (#253)

### DIFF
--- a/designer/src/schemas/process-flow.schema.test.ts
+++ b/designer/src/schemas/process-flow.schema.test.ts
@@ -707,3 +707,87 @@ describe("process-flow.schema.json — 明示的な negative ケース", () => {
     expect(validate(invalid)).toBe(false);
   });
 });
+
+describe("process-flow.schema.json — StructuredField.format + ValidationRule.maxRef/minRef (#253 v1.3)", () => {
+  const makeGroup = (action: object) => ({
+    id: "a", name: "x", type: "screen", description: "",
+    actions: [action],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  });
+
+  const baseAction = {
+    id: "act-1", name: "test", trigger: "submit",
+    steps: [{ id: "s1", type: "other", description: "" }],
+  };
+
+  it("StructuredField.format accept (@conv.numbering 参照)", () => {
+    const ok = validate(makeGroup({
+      ...baseAction,
+      outputs: [{ name: "poNumber", type: "string", format: "@conv.numbering.orderNumber" }],
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("StructuredField.format accept (任意文字列)", () => {
+    const ok = validate(makeGroup({
+      ...baseAction,
+      outputs: [{ name: "code", type: "string", format: "^[A-Z]{3}-\\d{4}$" }],
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("StructuredField.format + description 併記 accept", () => {
+    const ok = validate(makeGroup({
+      ...baseAction,
+      outputs: [{
+        name: "poNumber", type: "string",
+        format: "@conv.numbering.orderNumber",
+        description: "ORD-YYYY-NNNN 形式",
+      }],
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("ValidationRule.maxRef accept (@conv.limit 参照)", () => {
+    const ok = validate(makeGroup({
+      ...baseAction,
+      steps: [{
+        id: "s1", type: "validation", description: "",
+        conditions: "",
+        rules: [{ field: "qty", type: "range", min: 1, maxRef: "@conv.limit.quantityMax", message: "@conv.msg.outOfRange" }],
+      }],
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("ValidationRule.minRef accept (@conv.limit 参照)", () => {
+    const ok = validate(makeGroup({
+      ...baseAction,
+      steps: [{
+        id: "s1", type: "validation", description: "",
+        conditions: "",
+        rules: [{ field: "qty", type: "range", minRef: "@conv.limit.quantityMin", max: 9999 }],
+      }],
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("ValidationRule.min + maxRef 混在 accept", () => {
+    const ok = validate(makeGroup({
+      ...baseAction,
+      steps: [{
+        id: "s1", type: "validation", description: "",
+        conditions: "",
+        rules: [{ field: "qty", type: "range", min: 1, maxRef: "@conv.limit.quantityMax" }],
+      }],
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+});

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -283,6 +283,10 @@ export interface ValidationRule {
   min?: number;
   /** type="range" 時の最大値 */
   max?: number;
+  /** type="range" 時の最小値を @conv.limit.* 参照で指定するバリアント (#253) */
+  minRef?: string;
+  /** type="range" 時の最大値を @conv.limit.* 参照で指定するバリアント (#253) */
+  maxRef?: string;
   /** type="enum" 時の許容値リスト */
   values?: string[];
   /** type="custom" 時の自由記述条件 (例: "@items.length >= 1") */
@@ -734,6 +738,8 @@ export interface StructuredField {
   type: FieldType;
   required?: boolean;
   description?: string;
+  /** 採番形式 / フォーマットパターン (@conv.numbering.* 参照 or 正規表現) (#253) */
+  format?: string;
   /** 自由記述の既定値 */
   defaultValue?: string;
   /**

--- a/docs/sample-project/actions/cccccccc-0006-4000-8000-cccccccccccc.json
+++ b/docs/sample-project/actions/cccccccc-0006-4000-8000-cccccccccccc.json
@@ -168,7 +168,8 @@
           "name": "poNumber",
           "label": "発注番号",
           "type": "string",
-          "format": "@conv.numbering.orderNumber"
+          "format": "@conv.numbering.orderNumber",
+          "description": "ORD-YYYY-NNNN 形式 (PG sequence + trigger で自動採番)"
         },
         {
           "name": "totalAmount",

--- a/docs/sample-project/actions/cccccccc-0006-4000-8000-cccccccccccc.json
+++ b/docs/sample-project/actions/cccccccc-0006-4000-8000-cccccccccccc.json
@@ -168,7 +168,7 @@
           "name": "poNumber",
           "label": "発注番号",
           "type": "string",
-          "description": "@conv.numbering.orderNumber 準拠 ORD-YYYY-NNNN"
+          "format": "@conv.numbering.orderNumber"
         },
         {
           "name": "totalAmount",
@@ -225,7 +225,7 @@
               "field": "items[*].quantity",
               "type": "range",
               "min": 1,
-              "max": 9999,
+              "maxRef": "@conv.limit.quantityMax",
               "message": "@conv.msg.outOfRange"
             }
           ],

--- a/docs/spec/process-flow-extensions.md
+++ b/docs/spec/process-flow-extensions.md
@@ -551,7 +551,7 @@ errorCatalog?: Record<string, ErrorCatalogEntry>;
 
 実装時は: `affectedRowsCheck.errorCode == "STOCK_SHORTAGE"` → `errorCatalog.STOCK_SHORTAGE` を引いて httpStatus / responseRef / defaultMessage を 1 箇所で解決。
 
-## 8.6 `StructuredField.format` (#253 v1.3)
+## 8.6 `StructuredField.format` と `ValidationRule.minRef/maxRef` (#253 v1.3)
 
 文字列型フィールドの採番形式・フォーマットパターンを `description` の地の文でなく**構造化フィールド**として宣言する。
 

--- a/docs/spec/process-flow-extensions.md
+++ b/docs/spec/process-flow-extensions.md
@@ -380,8 +380,10 @@ interface ValidationRule {
   type: ValidationRuleType;
   pattern?: string;                // regex 用
   length?: number;                 // maxLength/minLength 用
-  min?: number;                    // range 用
-  max?: number;
+  min?: number;                    // range 用: 数値リテラル
+  max?: number;                    // range 用: 数値リテラル
+  minRef?: string;                 // range 用: @conv.limit.* 参照 (min の代替, #253)
+  maxRef?: string;                 // range 用: @conv.limit.* 参照 (max の代替, #253)
   values?: string[];               // enum 用
   condition?: string;              // custom 用
   message?: string;                // @conv.msg.* 参照も可
@@ -549,6 +551,57 @@ errorCatalog?: Record<string, ErrorCatalogEntry>;
 
 実装時は: `affectedRowsCheck.errorCode == "STOCK_SHORTAGE"` → `errorCatalog.STOCK_SHORTAGE` を引いて httpStatus / responseRef / defaultMessage を 1 箇所で解決。
 
+## 8.6 `StructuredField.format` (#253 v1.3)
+
+文字列型フィールドの採番形式・フォーマットパターンを `description` の地の文でなく**構造化フィールド**として宣言する。
+
+```ts
+interface StructuredField {
+  name: string;
+  label?: string;
+  type: FieldType;
+  required?: boolean;
+  description?: string;
+  format?: string;          // 採番形式 / フォーマットパターン (#253)
+  defaultValue?: string;
+  screenItemRef?: { screenId: string; itemId: string };
+}
+```
+
+**`format` の値の形式**:
+
+| 値の形式 | 意味 | 例 |
+|---|---|---|
+| `@conv.numbering.*` | 採番規約への参照 | `"@conv.numbering.orderNumber"` → `ORD-YYYY-NNNN` |
+| 正規表現文字列 | 書式パターン (検証用) | `"^[A-Z]{3}-\\d{4}$"` |
+| 任意の記述文字列 | 人間可読ヒント | `"YYYY-MM-DD"` |
+
+**適用対象**: `type: "string"` のフィールド。数値・配列・オブジェクト型フィールドへの設定は無意味 (無視される)。
+
+**`description` との関係**: `format` と `description` は併記可。`format` が機械可読な構造化情報、`description` が人間向け補足 (例: `"ORD-YYYY-NNNN 形式"`) を担う。
+
+用例:
+
+```json
+{ "name": "poNumber", "type": "string", "format": "@conv.numbering.orderNumber", "description": "ORD-YYYY-NNNN 形式 (PG sequence + trigger)" }
+```
+
+PR: #367 (#253 v1.3)
+
+**`ValidationRule.minRef` / `maxRef`**:
+
+`range` バリデーションで `@conv.limit.*` 参照を指定できるバリアント。`max: 9999` のような数値リテラルハードコードを避ける。
+
+- `min` + `maxRef` の**混在は有効** (一方を数値、他方を参照にできる)
+- `max` と `maxRef` を**同時指定した場合は `maxRef` が優先** (規約参照が意図的な値を上書きする)
+- `minRef` も同様
+
+用例:
+
+```json
+{ "field": "items[*].quantity", "type": "range", "min": 1, "maxRef": "@conv.limit.quantityMax", "message": "@conv.msg.outOfRange" }
+```
+
 ## 9. 後方互換性
 
 すべての拡張は **Optional** かつ **Union 型** (string | structured) のいずれかで、既存データは破壊されない。`migrateActionGroup` が読み込み時に:
@@ -579,3 +632,4 @@ errorCatalog?: Record<string, ErrorCatalogEntry>;
 ## 12. 変更履歴
 
 - 2026-04-20: 初版。#155〜#181 の全 PR をカバー。
+- 2026-04-24: `StructuredField.format`, `ValidationRule.minRef/maxRef` 追加 (#367 / #253 v1.3)。§5.1・§8.6 を更新。

--- a/schemas/process-flow.schema.json
+++ b/schemas/process-flow.schema.json
@@ -274,6 +274,10 @@
         "type": { "$ref": "#/$defs/FieldType" },
         "required": { "type": "boolean" },
         "description": { "type": "string" },
+        "format": {
+          "type": "string",
+          "description": "採番形式・フォーマットパターン。文字列型フィールドで @conv.numbering.* 参照や正規表現パターンを構造化宣言する (#253)"
+        },
         "defaultValue": { "type": "string" },
         "screenItemRef": {
           "type": "object",
@@ -427,6 +431,14 @@
         "length": { "type": "integer", "minimum": 0 },
         "min": { "type": "number" },
         "max": { "type": "number" },
+        "minRef": {
+          "type": "string",
+          "description": "type=range 時の最小値を @conv.limit.* 参照で指定するバリアント (数値リテラルの代替) (#253)"
+        },
+        "maxRef": {
+          "type": "string",
+          "description": "type=range 時の最大値を @conv.limit.* 参照で指定するバリアント (数値リテラルの代替) (#253)"
+        },
         "values": {
           "type": "array",
           "items": { "type": "string" }


### PR DESCRIPTION
## 変更概要

Issue #253 中優先度 2 項目を実装。

## 変更内容

### `StructuredField.format?: string`

文字列型フィールドの採番形式・フォーマットパターンを構造化宣言できるようにした。
これまで `description` の地の文に書くしかなかった `@conv.numbering.orderNumber` 等の参照が、
`format` フィールドで機械可読な一次情報として記述できる。

### `ValidationRule.maxRef?: string` / `minRef?: string`

`range` バリデーションで `@conv.limit.*` 参照を指定できるバリアント。
`max: 9999` のような数値リテラルハードコードを避け、規約カタログの値を参照可能にした。
`maxRef` に加えて `minRef` も対称的に追加。

## 変更ファイル

- `schemas/process-flow.schema.json` — `StructuredField.format`, `ValidationRule.maxRef/minRef` 追加
- `designer/src/types/action.ts` — 対応する TypeScript 型追加
- `docs/sample-project/actions/cccccccc-0006-4000-8000-cccccccccccc.json` — 新フィールドを使用するよう更新:
  - `outputs.poNumber`: `description` → `format: "@conv.numbering.orderNumber"`
  - `items[*].quantity` range バリデーション: `max: 9999` → `maxRef: "@conv.limit.quantityMax"`

## テスト

- スキーマテスト: 59 passed (変更前後で件数変化なし・後方互換)
- TypeScript: エラーなし

## 仕様逐条突合

- `StructuredField.format` の schema 追加: `schemas/process-flow.schema.json:272-277`
- `ValidationRule.maxRef` の schema 追加: `schemas/process-flow.schema.json:434-441`
- TypeScript 型同期: `designer/src/types/action.ts:737` (`format`), `action.ts:287-290` (`minRef/maxRef`)
- サンプル実証 (format): `cccccccc-0006:169` (`format: "@conv.numbering.orderNumber"`)
- サンプル実証 (maxRef): `cccccccc-0006:224` (`maxRef: "@conv.limit.quantityMax"`)
- 後方互換: 既存サンプル 0001-0005, 0099 は `format`/`maxRef` を使用せず、テスト全通過

Closes #253