### PR TITLE
improve(schema): DbAccessStep.bulkValues + BranchStep.tryScope (#253)

### DIFF
--- a/designer/src/schemas/process-flow.schema.test.ts
+++ b/designer/src/schemas/process-flow.schema.test.ts
@@ -791,3 +791,77 @@ describe("process-flow.schema.json — StructuredField.format + ValidationRule.m
     expect(ok).toBe(true);
   });
 });
+
+describe("process-flow.schema.json — DbAccessStep.bulkValues + BranchStep.tryScope (#253)", () => {
+  const makeGroup = (action: object) => ({
+    id: "a", name: "x", type: "screen", description: "",
+    actions: [action],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  });
+
+  const baseAction = {
+    id: "act-1", name: "test", trigger: "submit",
+    steps: [{ id: "s1", type: "other", description: "" }],
+  };
+
+  it("DbAccessStep.bulkValues accept", () => {
+    const ok = validate(makeGroup({
+      ...baseAction,
+      steps: [{
+        id: "s1", type: "dbAccess", description: "",
+        tableName: "items", operation: "INSERT",
+        bulkValues: "@poItemValues",
+        sql: "INSERT INTO items SELECT ... FROM (VALUES @poItemValues) AS v(...)",
+      }],
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("DbAccessStep.bulkValues なしも accept (optional)", () => {
+    const ok = validate(makeGroup({
+      ...baseAction,
+      steps: [{
+        id: "s1", type: "dbAccess", description: "",
+        tableName: "items", operation: "SELECT",
+        sql: "SELECT * FROM items",
+      }],
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("BranchStep.tryScope accept", () => {
+    const ok = validate(makeGroup({
+      ...baseAction,
+      steps: [{
+        id: "s1", type: "branch", description: "",
+        tryScope: ["step-db-insert", "step-inventory-update"],
+        branches: [{
+          id: "br-1", code: "A", label: "catch",
+          condition: { kind: "tryCatch", errorCode: "DEADLOCK" },
+          steps: [],
+        }],
+      }],
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("BranchStep.tryScope なしも accept (optional)", () => {
+    const ok = validate(makeGroup({
+      ...baseAction,
+      steps: [{
+        id: "s1", type: "branch", description: "",
+        branches: [{
+          id: "br-1", code: "A", label: "x",
+          condition: "@val == null",
+          steps: [],
+        }],
+      }],
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+});

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -369,6 +369,11 @@ export interface DbAccessStep extends StepBase {
    */
   sql?: string;
   /**
+   * 一括 INSERT 時に VALUES 句へ展開する配列変数の参照 (例: "@poItemValues")。
+   * 配列の各要素が 1 レコードとして INSERT される (#253)。
+   */
+  bulkValues?: string;
+  /**
    * 影響行数チェック。UPDATE / DELETE で条件付き並行制御する場合に使う。
    * SELECT / INSERT では通常不要。
    */
@@ -618,6 +623,8 @@ export interface BranchStep extends StepBase {
   branches: Branch[];
   /** 任意、常に最後に描画 */
   elseBranch?: ElseBranch;
+  /** tryCatch 分岐がガードするステップ ID の一覧。kind=tryCatch の Branch と組み合わせて try 範囲を明示 (#253) */
+  tryScope?: string[];
 }
 
 /** ループ種別 */

--- a/docs/sample-project/actions/cccccccc-0005-4000-8000-cccccccccccc.json
+++ b/docs/sample-project/actions/cccccccc-0005-4000-8000-cccccccccccc.json
@@ -350,6 +350,7 @@
           "type": "branch",
           "maturity": "committed",
           "description": "TX 結果分岐",
+          "tryScope": ["step-or2-007", "step-or2-008", "step-or2-009"],
           "branches": [
             {
               "id": "br-tx-fail",

--- a/docs/sample-project/actions/cccccccc-0006-4000-8000-cccccccccccc.json
+++ b/docs/sample-project/actions/cccccccc-0006-4000-8000-cccccccccccc.json
@@ -416,6 +416,7 @@
           "maturity": "committed",
           "tableName": "purchase_order_items",
           "operation": "INSERT",
+          "bulkValues": "@poItemValues",
           "sql": "INSERT INTO purchase_order_items (purchase_order_id, item_id, quantity, unit_price, line_amount, created_at) SELECT @newOrder.id, v.item_id, v.quantity, v.unit_price, v.line_amount, NOW() FROM (VALUES @poItemValues) AS v(item_id, quantity, unit_price, line_amount)",
           "txBoundary": { "role": "end", "txId": "tx-po-register" }
         },

--- a/docs/spec/process-flow-extensions.md
+++ b/docs/spec/process-flow-extensions.md
@@ -364,6 +364,31 @@ interface AffectedRowsCheck {
 
 PR: #165
 
+### 4.3 `DbAccessStep.bulkValues` (#253)
+
+一括 INSERT 時に `VALUES` 句へ展開する配列変数を構造化宣言するフィールド。`sql` に `@arrayVar` を埋め込むだけでは「これが bulk insert である」という意図が機械可読でないため追加。
+
+```ts
+interface DbAccessStep extends StepBase {
+  // ... 既存フィールド省略 ...
+  bulkValues?: string;  // 例: "@poItemValues"
+}
+```
+
+**用法**: `bulkValues` に配列変数の参照を設定し、`sql` 内で同じ変数を `VALUES @poItemValues` のように展開する。両フィールドの整合は実装側の責務。
+
+```json
+{
+  "type": "dbAccess",
+  "tableName": "purchase_order_items",
+  "operation": "INSERT",
+  "bulkValues": "@poItemValues",
+  "sql": "INSERT INTO purchase_order_items (...) SELECT ... FROM (VALUES @poItemValues) AS v(...)"
+}
+```
+
+PR: #368 (#253)
+
 ## 5. バリデーションの構造化
 
 ### 5.1 `ValidationStep.rules[]`
@@ -476,7 +501,33 @@ type BranchCondition = string | BranchConditionVariant;
 
 PR: #177 / #265 (#261 v1.3)
 
-### 7.2 `ElseBranch` (#253 v1.1)
+### 7.2 `BranchStep.tryScope` (#253)
+
+`kind: "tryCatch"` の Branch を持つ `BranchStep` で、**どのステップが try 範囲に含まれるか**を明示するフィールド。これまでは読者がフロー図から類推するしかなかった。
+
+```ts
+interface BranchStep extends StepBase {
+  branches: Branch[];
+  elseBranch?: ElseBranch;
+  tryScope?: string[];  // try 範囲のステップ ID 一覧
+}
+```
+
+**用法**: tryCatch 分岐を持つ BranchStep に `tryScope` を設定する。ステップ ID の配列で宣言し、catch 側 Branch の `condition.kind == "tryCatch"` と対応する。
+
+```json
+{
+  "type": "branch",
+  "tryScope": ["step-db-insert", "step-inventory-update"],
+  "branches": [
+    { "condition": { "kind": "tryCatch", "errorCode": "DEADLOCK" }, "steps": [...] }
+  ]
+}
+```
+
+PR: #368 (#253)
+
+### 7.3 `ElseBranch` (#253 v1.1)
 
 `BranchStep.elseBranch` の型を `Branch` から `ElseBranch` に変更。else 分岐は本質的に condition 不要なため、`condition` を optional にした。旧データ (`condition: ""` 等の空文字列埋め) は後方互換で accept。
 
@@ -633,3 +684,4 @@ PR: #367 (#253 v1.3)
 
 - 2026-04-20: 初版。#155〜#181 の全 PR をカバー。
 - 2026-04-24: `StructuredField.format`, `ValidationRule.minRef/maxRef` 追加 (#367 / #253 v1.3)。§5.1・§8.6 を更新。
+- 2026-04-24: `DbAccessStep.bulkValues`, `BranchStep.tryScope` 追加 (#368 / #253)。§4.3・§7.2 を新設。

--- a/schemas/process-flow.schema.json
+++ b/schemas/process-flow.schema.json
@@ -850,6 +850,7 @@
             "tryScope": {
               "type": "array",
               "items": { "type": "string" },
+              "minItems": 1,
               "description": "tryCatch 分岐がガードするステップ ID の一覧。kind=tryCatch の Branch と組み合わせて try 範囲を明示する (#253)"
             }
           }

--- a/schemas/process-flow.schema.json
+++ b/schemas/process-flow.schema.json
@@ -528,6 +528,10 @@
             "operation": { "$ref": "#/$defs/DbOperation" },
             "fields": { "type": "string" },
             "sql": { "type": "string" },
+            "bulkValues": {
+              "type": "string",
+              "description": "一括 INSERT 時に VALUES 句へ展開する配列変数の参照 (例: \"@poItemValues\")。配列の各要素がレコードとして INSERT される (#253)"
+            },
             "affectedRowsCheck": { "$ref": "#/$defs/AffectedRowsCheck" }
           }
         }
@@ -842,7 +846,12 @@
               "minItems": 1,
               "items": { "$ref": "#/$defs/Branch" }
             },
-            "elseBranch": { "$ref": "#/$defs/ElseBranch" }
+            "elseBranch": { "$ref": "#/$defs/ElseBranch" },
+            "tryScope": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "tryCatch 分岐がガードするステップ ID の一覧。kind=tryCatch の Branch と組み合わせて try 範囲を明示する (#253)"
+            }
           }
         }
       ]


### PR DESCRIPTION
## 変更概要

Issue #253 低優先度のうち 2 件を実装 (`DbAccessStep.bulkValues` / `BranchStep.tryScope`)。

**本 PR マージ後も #253 には未完了項目が残るため自動クローズしない** (中優先度: 式言語構造化 / OutputBinding.initialValue/scope / ReturnStep.responseRef / HttpResponseSpec.bodySchema / 低優先度: ExternalSystemStep.idempotencyKey)。

## 変更内容

### `DbAccessStep.bulkValues?: string`

一括 INSERT 時に `VALUES` 句へ展開する配列変数を構造化宣言。これまで `sql` フィールドの文字列に `@poItemValues` を埋め込むだけでは「これが bulk insert である」という意図が機械可読でなかった。

### `BranchStep.tryScope?: string[]`

`kind: "tryCatch"` の Branch を持つ BranchStep で、try 範囲に含まれるステップ ID を明示。これまで読者がフロー図から類推するしかなかった。

## 変更ファイル

- `schemas/process-flow.schema.json` — 両フィールド追加
- `designer/src/types/action.ts` — 対応 TypeScript 型追加
- `docs/spec/process-flow-extensions.md` — §4.3・§7.2 新設、§12 更新
- `docs/sample-project/actions/cccccccc-0006-4000-8000-cccccccccccc.json` — step-10 に `bulkValues: "@poItemValues"` 追加
- `designer/src/schemas/process-flow.schema.test.ts` — 専用テスト 4 件追加

## テスト

- スキーマテスト: 69 passed (65 → 69、+4)
- TypeScript: エラーなし

## 仕様逐条突合

- `DbAccessStep.bulkValues` schema: `schemas/process-flow.schema.json:530-533`
- `DbAccessStep.bulkValues` TypeScript: `designer/src/types/action.ts:371-374`
- `DbAccessStep.bulkValues` spec: `docs/spec/process-flow-extensions.md §4.3`
- `DbAccessStep.bulkValues` サンプル実証: `cccccccc-0006:418`
- `BranchStep.tryScope` schema: `schemas/process-flow.schema.json:846-850`
- `BranchStep.tryScope` TypeScript: `designer/src/types/action.ts:621`
- `BranchStep.tryScope` spec: `docs/spec/process-flow-extensions.md §7.2`
- 後方互換: 既存 65 テスト全通過

Refs #253
