### PR TITLE
improve(schemas): #253 残 5 項目まとめ実装 (#378)

### DIFF
--- a/designer/src/schemas/identifierScope.test.ts
+++ b/designer/src/schemas/identifierScope.test.ts
@@ -30,6 +30,38 @@ describe("checkIdentifierScopes — inputs / outputs", () => {
     expect(issues).toHaveLength(0);
   });
 
+  it("@inputs 全体参照 (@inputs.items) は OK (structured inputs がある場合)", () => {
+    const issues = checkIdentifierScopes(makeGroup({
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        inputs: [{ name: "items", type: { kind: "array", itemType: "number" } }],
+        steps: [{
+          id: "s1", type: "loop", description: "",
+          loopKind: "collection",
+          collectionSource: "@inputs.items",
+          collectionItemName: "item",
+          steps: [],
+        }],
+      }],
+    }));
+    expect(issues).toHaveLength(0);
+  });
+
+  it("@outputs 全体参照は OK (structured outputs がある場合)", () => {
+    const issues = checkIdentifierScopes(makeGroup({
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        outputs: [{ name: "result", type: "string" }],
+        steps: [{
+          id: "s1", type: "compute", description: "",
+          expression: "@outputs.result",
+          outputBinding: "x",
+        }],
+      }],
+    }));
+    expect(issues).toHaveLength(0);
+  });
+
   it("未定義 @identifier を検出", () => {
     const issues = checkIdentifierScopes(makeGroup({
       actions: [{

--- a/designer/src/schemas/identifierScope.ts
+++ b/designer/src/schemas/identifierScope.ts
@@ -59,12 +59,14 @@ export function checkIdentifierScopes(group: ActionGroup): IdentifierIssue[] {
 
   group.actions.forEach((action, ai) => {
     const knownInAction = new Set<string>(ambientNames);
-    // inputs
+    // inputs: 個別フィールド名 + "inputs" 全体 (@inputs.field 参照を許容)
     if (Array.isArray(action.inputs)) {
+      knownInAction.add("inputs");
       for (const f of action.inputs) knownInAction.add(f.name);
     }
-    // outputs (宣言済み変数として扱う、書込は step 側の outputBinding 経由だがここでは参照許容)
+    // outputs: 個別フィールド名 + "outputs" 全体
     if (Array.isArray(action.outputs)) {
+      knownInAction.add("outputs");
       for (const f of action.outputs) knownInAction.add(f.name);
     }
 
@@ -209,8 +211,8 @@ function checkStep(step: Step, path: string, availableIn: Set<string>, issues: I
     });
   }
 
-  // outputBinding.initialValue も式扱い
-  if (typeof step.outputBinding === "object" && step.outputBinding?.initialValue) {
+  // outputBinding.initialValue: 文字列式のみ識別子検査 (JSON 値なら skip)
+  if (typeof step.outputBinding === "object" && typeof step.outputBinding?.initialValue === "string" && step.outputBinding.initialValue) {
     expressions.push({ src: step.outputBinding.initialValue, field: "outputBinding.initialValue" });
   }
 

--- a/designer/src/schemas/process-flow.schema.test.ts
+++ b/designer/src/schemas/process-flow.schema.test.ts
@@ -792,6 +792,187 @@ describe("process-flow.schema.json — StructuredField.format + ValidationRule.m
   });
 });
 
+describe("process-flow.schema.json — OutputBindingObject.initialValue JSON 値 (#253 #378)", () => {
+  const base = {
+    id: "a", name: "x", type: "screen", description: "",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  };
+
+  it("initialValue: [] (実 JSON 配列) accept", () => {
+    const ok = validate({
+      ...base,
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "s1", type: "compute", description: "",
+          expression: "@line",
+          outputBinding: { name: "lines", operation: "push", initialValue: [] },
+        }],
+      }],
+    });
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("initialValue: 0 (数値) accept", () => {
+    const ok = validate({
+      ...base,
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "s1", type: "compute", description: "",
+          expression: "@line.amount",
+          outputBinding: { name: "subtotal", operation: "accumulate", initialValue: 0 },
+        }],
+      }],
+    });
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("initialValue: {} (空オブジェクト) accept", () => {
+    expect(validate({
+      ...base,
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "s1", type: "compute", description: "",
+          expression: "{ ...@acc, [@key]: @val }",
+          outputBinding: { name: "result", operation: "assign", initialValue: {} },
+        }],
+      }],
+    })).toBe(true);
+  });
+
+  it("initialValue: 文字列式 '[]' も引き続き accept (後方互換)", () => {
+    expect(validate({
+      ...base,
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "s1", type: "compute", description: "",
+          expression: "@line",
+          outputBinding: { name: "lines", operation: "push", initialValue: "[]" },
+        }],
+      }],
+    })).toBe(true);
+  });
+});
+
+describe("process-flow.schema.json — HttpResponseSpec.bodySchema {schema} inline (#253 #378)", () => {
+  const base = {
+    id: "a", name: "x", type: "screen", description: "",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  };
+
+  function withResponses(responses: unknown[]) {
+    return {
+      ...base,
+      actions: [{ id: "a1", name: "f", trigger: "click", responses, steps: [] }],
+    };
+  }
+
+  it("bodySchema: {schema} インライン JSON Schema accept", () => {
+    const ok = validate(withResponses([{
+      id: "200", status: 200,
+      bodySchema: {
+        schema: {
+          type: "object",
+          required: ["sessionId", "userId"],
+          properties: {
+            sessionId: { type: "string" },
+            userId: { type: "integer" },
+            permissions: { type: "array", items: { type: "string" } },
+          },
+        },
+      },
+    }]));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("bodySchema: {typeRef} 型カタログ参照 accept", () => {
+    expect(validate(withResponses([{ id: "200", status: 200, bodySchema: { typeRef: "LoginResponse" } }]))).toBe(true);
+  });
+
+  it("bodySchema: string (旧形式) 後方互換 accept", () => {
+    expect(validate(withResponses([{ id: "200", status: 200, bodySchema: "LoginResponse" }]))).toBe(true);
+  });
+});
+
+describe("process-flow.schema.json — ReturnStep.responseRef スキーマ検証 (#378)", () => {
+  const base = {
+    id: "a", name: "x", type: "screen", description: "",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  };
+
+  it("ReturnStep.responseRef 任意文字列 accept (参照整合性はランタイム)", () => {
+    const ok = validate({
+      ...base,
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        responses: [{ id: "201-created", status: 201 }],
+        steps: [{
+          id: "s1", type: "return", description: "",
+          responseRef: "201-created",
+          bodyExpression: "{ poId: @newOrder.id }",
+        }],
+      }],
+    });
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("responseRef 省略 accept (optional)", () => {
+    expect(validate({
+      ...base,
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{ id: "s1", type: "return", description: "" }],
+      }],
+    })).toBe(true);
+  });
+});
+
+describe("process-flow.schema.json — ExternalSystemStep auth structured (#253 #378)", () => {
+  const base = {
+    id: "a", name: "x", type: "screen", description: "",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  };
+
+  it("auth.kind=bearer + secretsCatalog + idempotencyKey + headers フル構成 accept", () => {
+    const ok = validate({
+      ...base,
+      secretsCatalog: { stripeKey: { source: "env", name: "STRIPE_SECRET_KEY" } },
+      externalSystemCatalog: {
+        stripe: {
+          name: "Stripe Japan",
+          baseUrl: "https://api.stripe.com",
+          auth: { kind: "bearer", tokenRef: "@secret.stripeKey" },
+          headers: { "Stripe-Version": "2024-06-20" },
+        },
+      },
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "s1", type: "externalSystem", description: "",
+          systemName: "Stripe", systemRef: "stripe",
+          httpCall: { method: "POST", path: "/v1/payment_intents" },
+          idempotencyKey: "order-@registeredOrder.id",
+          headers: { "X-Trace-Id": "@requestId" },
+          auth: { kind: "bearer", tokenRef: "@secret.stripeKey" },
+        }],
+      }],
+    });
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+});
+
 describe("process-flow.schema.json — DbAccessStep.bulkValues + BranchStep.tryScope (#253)", () => {
   const makeGroup = (action: object) => ({
     id: "a", name: "x", type: "screen", description: "",

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -176,13 +176,13 @@ export interface OutputBindingObject {
   /** 既定は "assign" */
   operation?: OutputBindingOperation;
   /**
-   * 初期値の式 (#253)。
-   * - operation="accumulate": 数値初期化 (例: "0")。未指定は "0" として解釈
-   * - operation="push": 配列初期化 (例: "[]")。未指定は "[]" として解釈
-   * - operation="assign": 通常不要 (代入前に初期化する意味がないため)
-   * 初期化タイミングは変数のスコープ開始時 (通常はアクション開始、ループ入口は operation=accumulate/push を含むループの入口)。
+   * 初期値 (#253)。JSON 値 (例: [], 0) または式文字列 (例: "[]", "@emptyArr")。
+   * - operation="accumulate": 数値 (既定 0)
+   * - operation="push": 配列 (既定 [])
+   * - operation="assign": 通常不要
+   * 初期化タイミング: 変数スコープ開始時 (通常はアクション開始)。
    */
-  initialValue?: string;
+  initialValue?: unknown;
 }
 
 /**

--- a/docs/sample-project/actions/cccccccc-0001-4000-8000-cccccccccccc.json
+++ b/docs/sample-project/actions/cccccccc-0001-4000-8000-cccccccccccc.json
@@ -12,19 +12,73 @@
       "name": "ログインボタン",
       "trigger": "click",
       "maturity": "provisional",
-      "httpRoute": { "method": "POST", "path": "/api/auth/login", "auth": "none" },
+      "httpRoute": {
+        "method": "POST",
+        "path": "/api/auth/login",
+        "auth": "none"
+      },
       "responses": [
-        { "id": "200-success", "status": 200, "bodySchema": "{ sessionId, userId, permissions }", "description": "ログイン成功" },
-        { "id": "400-validation", "status": 400, "bodySchema": "ApiError", "description": "入力不正" },
-        { "id": "401-unauthorized", "status": 401, "bodySchema": "ApiError", "description": "認証失敗" }
+        {
+          "id": "200-success",
+          "status": 200,
+          "bodySchema": {
+            "schema": {
+              "type": "object",
+              "required": ["sessionId", "userId"],
+              "properties": {
+                "sessionId": { "type": "string" },
+                "userId": { "type": "integer" },
+                "permissions": { "type": "array", "items": { "type": "string" } }
+              }
+            }
+          },
+          "description": "ログイン成功"
+        },
+        {
+          "id": "400-validation",
+          "status": 400,
+          "bodySchema": {
+            "typeRef": "ApiError"
+          },
+          "description": "入力不正"
+        },
+        {
+          "id": "401-unauthorized",
+          "status": 401,
+          "bodySchema": {
+            "typeRef": "ApiError"
+          },
+          "description": "認証失敗"
+        }
       ],
       "inputs": [
-        { "name": "userId", "label": "ユーザーID", "type": "string", "required": true },
-        { "name": "password", "label": "パスワード", "type": "string", "required": true }
+        {
+          "name": "userId",
+          "label": "ユーザーID",
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "password",
+          "label": "パスワード",
+          "type": "string",
+          "required": true
+        }
       ],
       "outputs": [
-        { "name": "sessionId", "label": "セッションID", "type": "string" },
-        { "name": "permissions", "label": "権限情報", "type": { "kind": "custom", "label": "string[]" } }
+        {
+          "name": "sessionId",
+          "label": "セッションID",
+          "type": "string"
+        },
+        {
+          "name": "permissions",
+          "label": "権限情報",
+          "type": {
+            "kind": "custom",
+            "label": "string[]"
+          }
+        }
       ],
       "steps": [
         {
@@ -34,8 +88,16 @@
           "description": "入力値チェック",
           "conditions": "ユーザーID・パスワードの必須チェック",
           "rules": [
-            { "field": "userId", "type": "required", "message": "@conv.msg.required" },
-            { "field": "password", "type": "required", "message": "@conv.msg.required" }
+            {
+              "field": "userId",
+              "type": "required",
+              "message": "@conv.msg.required"
+            },
+            {
+              "field": "password",
+              "type": "required",
+              "message": "@conv.msg.required"
+            }
           ],
           "inlineBranch": {
             "ok": "次のステップへ続行",
@@ -56,7 +118,12 @@
             "password": "@password"
           },
           "notes": [
-            { "id": "n-login-001", "type": "assumption", "body": "@authResult.success で成功判定、@authResult.sessionId で session 取得", "createdAt": "2026-04-14T00:00:00.000Z" }
+            {
+              "id": "n-login-001",
+              "type": "assumption",
+              "body": "@authResult.success で成功判定、@authResult.sessionId で session 取得",
+              "createdAt": "2026-04-14T00:00:00.000Z"
+            }
           ]
         },
         {
@@ -93,7 +160,12 @@
           "description": "パスワードリセット画面へ遷移",
           "targetScreenName": "パスワードリセット画面",
           "notes": [
-            { "id": "n-login-002", "type": "prerequisite", "body": "パスワードリセット画面は未設計", "createdAt": "2026-04-14T00:00:00.000Z" }
+            {
+              "id": "n-login-002",
+              "type": "prerequisite",
+              "body": "パスワードリセット画面は未設計",
+              "createdAt": "2026-04-14T00:00:00.000Z"
+            }
           ]
         }
       ]

--- a/docs/sample-project/actions/cccccccc-0002-4000-8000-cccccccccccc.json
+++ b/docs/sample-project/actions/cccccccc-0002-4000-8000-cccccccccccc.json
@@ -12,18 +12,56 @@
       "name": "検索ボタン",
       "trigger": "click",
       "maturity": "provisional",
-      "httpRoute": { "method": "GET", "path": "/api/customers/search", "auth": "required" },
+      "httpRoute": {
+        "method": "GET",
+        "path": "/api/customers/search",
+        "auth": "required"
+      },
       "responses": [
-        { "id": "200-success", "status": 200, "bodySchema": "CustomerSearchResult", "description": "検索結果" },
-        { "id": "400-validation", "status": 400, "bodySchema": "ApiError", "description": "検索条件不正" }
+        {
+          "id": "200-success",
+          "status": 200,
+          "bodySchema": {
+            "typeRef": "CustomerSearchResult"
+          },
+          "description": "検索結果"
+        },
+        {
+          "id": "400-validation",
+          "status": 400,
+          "bodySchema": {
+            "typeRef": "ApiError"
+          },
+          "description": "検索条件不正"
+        }
       ],
       "inputs": [
-        { "name": "name", "label": "顧客名", "type": "string", "description": "部分一致" },
-        { "name": "phone", "label": "電話番号", "type": "string" },
-        { "name": "email", "label": "メール", "type": "string" }
+        {
+          "name": "name",
+          "label": "顧客名",
+          "type": "string",
+          "description": "部分一致"
+        },
+        {
+          "name": "phone",
+          "label": "電話番号",
+          "type": "string"
+        },
+        {
+          "name": "email",
+          "label": "メール",
+          "type": "string"
+        }
       ],
       "outputs": [
-        { "name": "customers", "label": "検索結果", "type": { "kind": "tableList", "tableId": "bbbbbbbb-0002-4000-8000-bbbbbbbbbbbb" } }
+        {
+          "name": "customers",
+          "label": "検索結果",
+          "type": {
+            "kind": "tableList",
+            "tableId": "bbbbbbbb-0002-4000-8000-bbbbbbbbbbbb"
+          }
+        }
       ],
       "steps": [
         {
@@ -33,8 +71,18 @@
           "description": "検索条件チェック",
           "conditions": "検索条件の形式チェック（電話番号、メール形式）",
           "rules": [
-            { "field": "phone", "type": "regex", "pattern": "@conv.regex.phone-jp", "message": "@conv.msg.invalidFormat" },
-            { "field": "email", "type": "regex", "pattern": "@conv.regex.email-simple", "message": "@conv.msg.invalidFormat" }
+            {
+              "field": "phone",
+              "type": "regex",
+              "pattern": "@conv.regex.phone-jp",
+              "message": "@conv.msg.invalidFormat"
+            },
+            {
+              "field": "email",
+              "type": "regex",
+              "pattern": "@conv.regex.email-simple",
+              "message": "@conv.msg.invalidFormat"
+            }
           ],
           "inlineBranch": {
             "ok": "検索処理を実行",
@@ -84,7 +132,12 @@
       "trigger": "click",
       "maturity": "provisional",
       "inputs": [
-        { "name": "customerId", "label": "顧客ID", "type": "number", "required": true }
+        {
+          "name": "customerId",
+          "label": "顧客ID",
+          "type": "number",
+          "required": true
+        }
       ],
       "steps": [
         {

--- a/docs/sample-project/actions/cccccccc-0006-4000-8000-cccccccccccc.json
+++ b/docs/sample-project/actions/cccccccc-0006-4000-8000-cccccccccccc.json
@@ -246,7 +246,7 @@
           "maturity": "committed",
           "tableName": "suppliers",
           "operation": "SELECT",
-          "sql": "SELECT id, name, email FROM suppliers WHERE id = @supplierId AND is_deleted = false",
+          "sql": "SELECT id, name, email FROM suppliers WHERE id = @inputs.supplierId AND is_deleted = false",
           "outputBinding": "supplier"
         },
 
@@ -404,7 +404,7 @@
           "maturity": "committed",
           "tableName": "purchase_orders",
           "operation": "INSERT",
-          "sql": "INSERT INTO purchase_orders (supplier_id, subtotal, tax_amount, total_amount, delivery_note, created_by, created_at, updated_at) VALUES (@supplierId, @subtotal, @taxAmount, @subtotal + @taxAmount, @inputs.deliveryNote, @sessionUserId, NOW(), NOW()) RETURNING id, po_number",
+          "sql": "INSERT INTO purchase_orders (supplier_id, subtotal, tax_amount, total_amount, delivery_note, created_by, created_at, updated_at) VALUES (@inputs.supplierId, @subtotal, @taxAmount, @subtotal + @taxAmount, @inputs.deliveryNote, @sessionUserId, NOW(), NOW()) RETURNING id, po_number",
           "txBoundary": { "role": "begin", "txId": "tx-po-register" },
           "outputBinding": "newOrder"
         },

--- a/docs/sample-project/actions/cccccccc-0006-4000-8000-cccccccccccc.json
+++ b/docs/sample-project/actions/cccccccc-0006-4000-8000-cccccccccccc.json
@@ -341,7 +341,7 @@
                     "description": "明細オブジェクト生成 (lineAmount = 単価 × 数量、@conv.currency.jpy subunit=0 で整数演算) → poItemValues に追加",
                     "maturity": "committed",
                     "expression": "{ itemId: @item.itemId, quantity: @item.quantity, unitPrice: @itemInfo.unit_price, lineAmount: @itemInfo.unit_price * @item.quantity }",
-                    "outputBinding": { "name": "poItemValues", "operation": "push" }
+                    "outputBinding": { "name": "poItemValues", "operation": "push", "initialValue": [] }
                   }
                 ]
               }

--- a/docs/spec/process-flow-expression-language.md
+++ b/docs/spec/process-flow-expression-language.md
@@ -67,6 +67,7 @@ argList         = expression (',' expression)*
 - `@identifier` が変数参照の基本形。`@` はこのフロー言語固有のマーカー
 - ドット/ブラケット記法でネストアクセス: `@customer.address.postalCode` / `@items[0].quantity`
 - Optional chain: `@paymentAuth?.id` — undefined プロパティへのアクセス時に null を返す
+- **`@inputs` / `@outputs` 全体参照**: `ActionDefinition.inputs` / `outputs` の配列全体をオブジェクトとして参照できる。例: `@inputs.items` (inputs フィールド "items" へのアクセス)、`@outputs.result`。個別フィールド名 (`@items` 等) と全体参照 (`@inputs.items`) は**どちらも解決可能**だが、**全体参照スタイルを推奨** (名前衝突が生じにくい)。
 
 ### 3.3 比較・論理
 

--- a/docs/spec/process-flow-expression-language.md
+++ b/docs/spec/process-flow-expression-language.md
@@ -150,7 +150,7 @@ argList         = expression (',' expression)*
 | `LoopStep.countExpression` | 数値式 | `"@items.length"` |
 | `LoopStep.conditionExpression` | 真偽式 | `"@remaining > 0"` |
 | `LoopStep.collectionSource` | 配列式 | `"@items"` |
-| `OutputBindingObject.initialValue` | 任意式 | `"0"` / `"[]"` |
+| `OutputBindingObject.initialValue` | JSON 値 または 式文字列 | `0` / `[]` / `"@emptyArr"` |
 | `ExternalCallOutcomeSpec.jumpTo` | ステップ ID 文字列 (式ではない) | `"step-error-handler"` |
 | `CommonProcessStep.argumentMapping[k]` | 任意式 | `"@customerId"` |
 | `ExternalSystemStep.protocol` (#261) | 自由記述。URL 中の `@path` 式補間を許容 (例: `"HTTPS POST /v1/payment_intents/@paymentAuth.id/cancel"`) | URL 構造化は v1.3-b 以降の `httpCall` フィールドで予定 |

--- a/schemas/process-flow.schema.json
+++ b/schemas/process-flow.schema.json
@@ -360,8 +360,7 @@
         "name": { "type": "string" },
         "operation": { "$ref": "#/$defs/OutputBindingOperation" },
         "initialValue": {
-          "type": "string",
-          "description": "初期値の式 (#253)。accumulate 時は数値 (既定 '0')、push 時は配列 (既定 '[]')"
+          "description": "初期値。JSON 値 (例: [], 0) または式文字列 (例: '[]', '@emptyArr') (#253)。accumulate: 数値 (既定 0)、push: 配列 (既定 [])"
         }
       }
     },

--- a/scripts/migrate-response-body-schema.mjs
+++ b/scripts/migrate-response-body-schema.mjs
@@ -17,7 +17,7 @@
  *   dir...   : 対象ディレクトリ (省略時は docs/sample-project/actions data/actions)
  */
 
-import { readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
+import { readFileSync, writeFileSync, readdirSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 const APPLY = process.argv.includes("--apply");
@@ -32,7 +32,11 @@ if (dirs.length === 0) {
   );
 }
 
-/** bodySchema が単純識別子かどうか (typeRef に変換可能) */
+/**
+ * bodySchema が単純識別子かどうか (typeRef に変換可能)。
+ * アルファベット + 数字のみ (アンダースコアは含まない)。
+ * 例: "ApiError" → true, "ApiError_V2" → false (手動対応)
+ */
 function isSimpleIdentifier(s) {
   return /^[A-Za-z][A-Za-z0-9]*$/.test(s);
 }
@@ -86,7 +90,9 @@ for (const dir of dirs) {
     const after = JSON.stringify(data);
 
     const changed = before !== after;
-    const converted = (before.match(/"bodySchema"\s*:\s*"[^"]+"/g) || []).length;
+    // 変換前 string bodySchema 数 - スキップ数 = 実変換数
+    const totalStringBefore = (before.match(/"bodySchema"\s*:\s*"[^"]+"/g) || []).length;
+    const converted = totalStringBefore - warnings.length;
 
     totalFiles++;
     if (warnings.length) {

--- a/scripts/migrate-response-body-schema.mjs
+++ b/scripts/migrate-response-body-schema.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * migrate-response-body-schema.mjs
+ *
+ * HttpResponseSpec.bodySchema を旧 string 形式から構造化形式へ移行する。
+ *
+ * 変換ルール:
+ *   - 単純識別子 (英数字のみ, 例: "ApiError", "CustomerResponse")
+ *     → { "typeRef": "ApiError" }
+ *   - その他の文字列 (スペース・記号含む, 例: "{ sessionId, userId }")
+ *     → 変換せず警告 (手動対応)
+ *
+ * 使い方:
+ *   node scripts/migrate-response-body-schema.mjs [--apply] [dir...]
+ *
+ *   --apply  : ファイルを上書き (省略時は dry-run)
+ *   dir...   : 対象ディレクトリ (省略時は docs/sample-project/actions data/actions)
+ */
+
+import { readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const APPLY = process.argv.includes("--apply");
+const dirs = process.argv
+  .filter((a) => !a.startsWith("--") && a !== process.argv[0] && a !== process.argv[1])
+  .map((d) => resolve(d));
+
+if (dirs.length === 0) {
+  dirs.push(
+    resolve("docs/sample-project/actions"),
+    resolve("data/actions"),
+  );
+}
+
+/** bodySchema が単純識別子かどうか (typeRef に変換可能) */
+function isSimpleIdentifier(s) {
+  return /^[A-Za-z][A-Za-z0-9]*$/.test(s);
+}
+
+/** ActionGroup JSON を再帰的に走査し bodySchema を変換する */
+function migrateBodySchemas(obj, path, warnings) {
+  if (Array.isArray(obj)) {
+    obj.forEach((item, i) => migrateBodySchemas(item, `${path}[${i}]`, warnings));
+  } else if (obj && typeof obj === "object") {
+    if ("bodySchema" in obj && typeof obj.bodySchema === "string") {
+      const raw = obj.bodySchema;
+      if (isSimpleIdentifier(raw)) {
+        obj.bodySchema = { typeRef: raw };
+      } else {
+        warnings.push(`${path}.bodySchema: "${raw}" — 単純識別子ではないため変換スキップ (手動対応)`);
+      }
+    }
+    for (const key of Object.keys(obj)) {
+      if (key !== "bodySchema") {
+        migrateBodySchemas(obj[key], `${path}.${key}`, warnings);
+      }
+    }
+  }
+}
+
+let totalConverted = 0;
+let totalWarnings = 0;
+let totalFiles = 0;
+
+for (const dir of dirs) {
+  let files;
+  try {
+    files = readdirSync(dir).filter((f) => f.endsWith(".json"));
+  } catch {
+    continue;
+  }
+
+  for (const file of files) {
+    const fullPath = join(dir, file);
+    let data;
+    try {
+      data = JSON.parse(readFileSync(fullPath, "utf-8"));
+    } catch {
+      console.warn(`[SKIP] ${fullPath} — JSON parse error`);
+      continue;
+    }
+
+    const warnings = [];
+    const before = JSON.stringify(data);
+    migrateBodySchemas(data, "", warnings);
+    const after = JSON.stringify(data);
+
+    const changed = before !== after;
+    const converted = (before.match(/"bodySchema"\s*:\s*"[^"]+"/g) || []).length;
+
+    totalFiles++;
+    if (warnings.length) {
+      totalWarnings += warnings.length;
+      warnings.forEach((w) => console.warn(`[WARN] ${file}: ${w}`));
+    }
+
+    if (changed) {
+      totalConverted += converted;
+      if (APPLY) {
+        writeFileSync(fullPath, JSON.stringify(data, null, 2) + "\n", "utf-8");
+        console.log(`[APPLY] ${fullPath} — string bodySchema を typeRef に変換`);
+      } else {
+        console.log(`[DRY-RUN] ${fullPath} — string bodySchema が見つかりました (--apply で変換)`);
+      }
+    }
+  }
+}
+
+console.log(`\n合計: ${totalFiles} ファイル, 変換対象 ${totalConverted} 件, 警告 ${totalWarnings} 件`);
+if (!APPLY && totalConverted > 0) {
+  console.log("--apply オプションで実際に変換します。");
+}


### PR DESCRIPTION
Closes #378

## 概要

#253 の残り 5 項目を 1 PR で実装。

## 実装内容

### 1. 式言語 BNF — スキーマ変更なし (既存 docs で完了)
`docs/spec/process-flow-expression-language.md` は前 PR で整備済み。`initialValue` 行の表記を「JSON 値 または 式文字列」に更新。§3.2 に `@inputs` / `@outputs` 全体参照スタイルを追記 (レビュー指摘 S-1 対応)。

### 2. OutputBindingObject.initialValue: string → unknown
- **schema**: `"type": "string"` を削除し、任意 JSON 値を許容
- **型**: `initialValue?: string` → `initialValue?: unknown`
- **identifierScope**: 文字列式のみ `extractIdentifiers` に渡すよう型ガード追加
- **サンプル** (`cccccccc-0006`): `step-05-03` に `"initialValue": []` を追加

### 3. ReturnStep.responseRef 参照整合性 — 既実装 (変更なし)
`referentialIntegrity.ts` に既存実装済み。テスト追加のみ。

### 4. HttpResponseSpec.bodySchema 移行
- `scripts/migrate-response-body-schema.mjs` 作成 (dry-run / --apply)
- サンプル `cccccccc-0001`, `cccccccc-0002`: string → `{ typeRef }` / `{ schema }` 形式に変換

### 5. ExternalSystemStep idempotencyKey / headers / auth — 既実装 (変更なし)
既存実装済み。テスト追加のみ。

### バグ修正 (pre-existing)
`identifierScope.ts`: `@inputs` / `@outputs` 全体参照を known に追加 (`@inputs.items` が UNKNOWN_IDENTIFIER で誤検出されていた)

## テスト追加
- `OutputBindingObject.initialValue JSON 値` — `[]`, `0`, `{}`, 後方互換 string
- `HttpResponseSpec.bodySchema {schema} inline`
- `ReturnStep.responseRef スキーマ検証`
- `ExternalSystemStep auth フル構成`
- `identifierScope: @inputs/@outputs 全体参照` (レビュー指摘対応)

## 仕様逐条突合

| 受け入れ基準 | 対応箇所 |
|---|---|
| JS subset BNF | `docs/spec/process-flow-expression-language.md` (既存) |
| `@inputs`/`@outputs` 全体参照スタイル明記 | `docs/spec/process-flow-expression-language.md:§3.2` |
| `OutputBindingObject.initialValue` 追加 + サンプル活用 | `schemas/process-flow.schema.json:350-361`, `designer/src/types/action.ts:178-185`, `cccccccc-0006:343` |
| `ReturnStep.responseRef` UNKNOWN_RESPONSE_REF 警告 | `designer/src/schemas/referentialIntegrity.ts:174-181` (既実装) |
| `HttpResponseSpec.bodySchema` 移行 + schema pass | `scripts/migrate-response-body-schema.mjs`, 全サンプル schema test pass |
| `ExternalCallStep.idempotencyKey/headers/auth` スキーマ+型 | `schemas/process-flow.schema.json:679-686`, `designer/src/types/action.ts:519-527` (既実装) |
| スキーマテスト全 pass | `183 passed (183)` |
| TypeScript ビルドエラーなし | `tsc --noEmit` OK |

## テスト
```
npx vitest run src/schemas/
# → Tests 183 passed (183)
```