### PR TITLE
feat(table-editor): Supabase 式 DB エディタ β-1〜4 (#370 #371 #372 #373)

### DIFF
--- a/designer-mcp/src/index.ts
+++ b/designer-mcp/src/index.ts
@@ -1082,6 +1082,79 @@ function generateDdl(table: Record<string, unknown>, dialect: string): string {
     ddl += `\n\nCREATE ${unique}INDEX ${idxName} ON ${name} (${colNames.join(", ")});`;
   }
 
+  // Constraints (β-2)
+  for (const c of (table.constraints ?? []) as Array<Record<string, unknown>>) {
+    const kind = c.kind as string;
+    const cid = c.id as string;
+    const cols = (c.columns ?? []) as string[];
+    if (kind === "unique") {
+      ddl += `\n\nALTER TABLE ${name} ADD CONSTRAINT ${cid} UNIQUE (${cols.join(", ")});`;
+    } else if (kind === "check") {
+      ddl += `\n\nALTER TABLE ${name} ADD CONSTRAINT ${cid} CHECK (${c.expression});`;
+    } else if (kind === "foreignKey") {
+      const refTable = c.referencedTable as string;
+      const refCols = (c.referencedColumns ?? []) as string[];
+      let s = `ALTER TABLE ${name} ADD CONSTRAINT ${cid}\n  FOREIGN KEY (${cols.join(", ")}) REFERENCES ${refTable}(${refCols.join(", ")})`;
+      if (c.onDelete) s += `\n  ON DELETE ${c.onDelete}`;
+      if (c.onUpdate) s += `\n  ON UPDATE ${c.onUpdate}`;
+      ddl += `\n\n${s};`;
+    }
+  }
+
+  // DEFAULT values (β-4)
+  for (const def of (table.defaults ?? []) as Array<Record<string, unknown>>) {
+    const defCol = def.column as string;
+    const defKind = def.kind as string;
+    let expr: string;
+    if (defKind === "sequence" && dialect === "postgresql") {
+      expr = `nextval('${def.value}')`;
+    } else if (defKind === "conventionRef") {
+      expr = `NULL /* ${def.value} */`;
+    } else {
+      expr = def.value as string;
+    }
+    if (dialect === "oracle") {
+      ddl += `\n\nALTER TABLE ${name} MODIFY (${defCol} DEFAULT ${expr});`;
+    } else {
+      ddl += `\n\nALTER TABLE ${name} ALTER COLUMN ${defCol} SET DEFAULT ${expr};`;
+    }
+  }
+
+  // Triggers (β-4)
+  for (const trg of (table.triggers ?? []) as Array<Record<string, unknown>>) {
+    const trgId = trg.id as string;
+    const timing = trg.timing as string;
+    const events = ((trg.events ?? []) as string[]).join(" OR ");
+    const trgWhen = trg.whenCondition ? `\n  WHEN (${trg.whenCondition})` : "";
+    const body = trg.body as string;
+    const trgEvents = (trg.events ?? []) as string[];
+    if (dialect === "postgresql") {
+      const fnName = `${trgId}_fn`;
+      const returnStmt = trgEvents.length === 1 && trgEvents[0] === "DELETE" ? "RETURN OLD;" : "RETURN NEW;";
+      ddl += "\n\n" + [
+        `CREATE OR REPLACE FUNCTION ${fnName}() RETURNS TRIGGER AS $$`,
+        `BEGIN`,
+        `  ${body.split("\n").join("\n  ")}`,
+        `  ${returnStmt}`,
+        `END;`,
+        `$$ LANGUAGE plpgsql;`,
+        ``,
+        `CREATE TRIGGER ${trgId}`,
+        `${timing} ${events} ON ${name}${trgWhen}`,
+        `FOR EACH ROW EXECUTE FUNCTION ${fnName}();`,
+      ].join("\n");
+    } else {
+      ddl += "\n\n" + [
+        `CREATE TRIGGER ${trgId}`,
+        `${timing} ${events} ON ${name}${trgWhen}`,
+        `FOR EACH ROW`,
+        `BEGIN`,
+        `  ${body.split("\n").join("\n  ")}`,
+        `END;`,
+      ].join("\n");
+    }
+  }
+
   // PostgreSQL / Oracle comments
   if (dialect === "postgresql" || dialect === "oracle") {
     const logicalName = table.logicalName as string | undefined;

--- a/designer-mcp/src/index.ts
+++ b/designer-mcp/src/index.ts
@@ -646,14 +646,21 @@ function createMcpServer(): Server {
                 }
                 return col;
               }),
-              indexes: ((t.indexes ?? []) as Array<Record<string, unknown>>).map((idx) => ({
-                name: idx.name,
-                columns: ((idx.columns ?? []) as string[]).map((cid) => {
-                  const c = cols.find((cc) => cc.id === cid);
-                  return c ? c.name : cid;
-                }),
-                unique: idx.unique,
-              })),
+              indexes: ((t.indexes ?? []) as Array<Record<string, unknown>>).map((idx) => {
+                const rawCols = (idx.columns ?? []) as Array<string | { name?: string; order?: string }>;
+                const colNames = rawCols.map((c) => {
+                  if (typeof c === "string") {
+                    const col = cols.find((cc) => cc.id === c);
+                    return col ? col.name : c;
+                  }
+                  return (c as { name?: string }).name ?? "";
+                });
+                return {
+                  name: (idx.id ?? idx.name) as string,
+                  columns: colNames,
+                  unique: idx.unique,
+                };
+              }),
             };
           }),
           relations: [] as Array<Record<string, unknown>>,
@@ -1056,16 +1063,23 @@ function generateDdl(table: Record<string, unknown>, dialect: string): string {
   if (dialect === "mysql") ddl += " ENGINE=InnoDB DEFAULT CHARSET=utf8mb4";
   ddl += ";";
 
-  // Indexes
+  // Indexes (新形式 IndexDefinition + 旧形式 TableIndex 両対応)
   for (const idx of indexes) {
-    const idxCols = (idx.columns ?? []) as string[];
-    // resolve column IDs to names
-    const colNames = idxCols.map((cid) => {
-      const c = columns.find((cc) => cc.id === cid);
-      return c ? c.name as string : cid;
+    const rawCols = (idx.columns ?? []) as Array<string | { name?: string; order?: string }>;
+    const colNames = rawCols.map((c) => {
+      if (typeof c === "string") {
+        // 旧形式: 列 ID → 列名に解決
+        const col = columns.find((cc) => cc.id === c);
+        return col ? col.name as string : c;
+      }
+      // 新形式: IndexColumn { name, order? }
+      const colName = (c as { name?: string }).name ?? "";
+      const ord = (c as { order?: string }).order === "desc" ? " DESC" : "";
+      return `${colName}${ord}`;
     });
     const unique = idx.unique ? "UNIQUE " : "";
-    ddl += `\n\nCREATE ${unique}INDEX ${idx.name} ON ${name} (${colNames.join(", ")});`;
+    const idxName = ((idx.id ?? idx.name) as string | undefined) ?? "";
+    ddl += `\n\nCREATE ${unique}INDEX ${idxName} ON ${name} (${colNames.join(", ")});`;
   }
 
   // PostgreSQL / Oracle comments

--- a/designer/src/components/table/ConstraintsTab.tsx
+++ b/designer/src/components/table/ConstraintsTab.tsx
@@ -424,7 +424,7 @@ function kindBadge(kind: ConstraintDefinition["kind"]): string {
   }
 }
 
-function constraintSummary(c: ConstraintDefinition, table: TableDefinition): string {
+function constraintSummary(c: ConstraintDefinition, _table: TableDefinition): string {
   switch (c.kind) {
     case "unique":
       return c.columns.length > 0 ? `列: ${c.columns.join(", ")}` : "(列未選択)";

--- a/designer/src/components/table/ConstraintsTab.tsx
+++ b/designer/src/components/table/ConstraintsTab.tsx
@@ -1,0 +1,441 @@
+import { useState } from "react";
+import type {
+  TableDefinition,
+  ConstraintDefinition,
+  UniqueConstraint,
+  CheckConstraint,
+  ForeignKeyConstraint,
+  FkAction,
+} from "../../types/table";
+import { addConstraint, removeConstraint } from "../../store/tableStore";
+
+const FK_ACTIONS: FkAction[] = ["CASCADE", "SET NULL", "SET DEFAULT", "RESTRICT", "NO ACTION"];
+
+interface Props {
+  table: TableDefinition;
+  update: (fn: (t: TableDefinition) => void) => void;
+  allTables: TableDefinition[];
+}
+
+type ConstraintKind = "unique" | "check" | "foreignKey";
+
+export function ConstraintsTab({ table, update, allTables }: Props) {
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [addMenuOpen, setAddMenuOpen] = useState(false);
+
+  const constraints = table.constraints ?? [];
+
+  const handleAdd = (kind: ConstraintKind) => {
+    setAddMenuOpen(false);
+    let newId = "";
+    update((t) => {
+      const base = buildDefault(kind, t.name);
+      const c = addConstraint(t, base);
+      newId = c.id;
+    });
+    // Open editor for the new constraint
+    setTimeout(() => setEditingId(newId), 0);
+  };
+
+  const handleDelete = (id: string) => {
+    update((t) => removeConstraint(t, id));
+    if (editingId === id) setEditingId(null);
+  };
+
+  const handleUpdate = (id: string, patch: Partial<ConstraintDefinition>) => {
+    update((t) => {
+      const c = (t.constraints ?? []).find((x) => x.id === id);
+      if (c) Object.assign(c, patch);
+    });
+  };
+
+  return (
+    <div className="constraints-tab">
+      <div className="constraints-toolbar">
+        <span className="constraints-count">
+          {constraints.length === 0
+            ? "制約がまだありません"
+            : `${constraints.length} 件`}
+        </span>
+        <div className="constraints-add-wrap">
+          <button
+            className="tbl-btn tbl-btn-primary"
+            onClick={() => setAddMenuOpen((v) => !v)}
+          >
+            <i className="bi bi-plus-lg" /> 制約を追加
+            <i className="bi bi-chevron-down" style={{ marginLeft: 4, fontSize: 11 }} />
+          </button>
+          {addMenuOpen && (
+            <div className="constraints-add-menu" onMouseLeave={() => setAddMenuOpen(false)}>
+              <button onClick={() => handleAdd("unique")}>
+                <i className="bi bi-check2-square" /> UNIQUE
+              </button>
+              <button onClick={() => handleAdd("check")}>
+                <i className="bi bi-shield-check" /> CHECK
+              </button>
+              <button onClick={() => handleAdd("foreignKey")}>
+                <i className="bi bi-link-45deg" /> FOREIGN KEY
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {constraints.length === 0 ? (
+        <div className="constraints-empty">
+          <i className="bi bi-shield-check constraints-empty-icon" />
+          <p>制約を追加すると DDL プレビューに <code>ALTER TABLE ... ADD CONSTRAINT</code> として出力されます。</p>
+        </div>
+      ) : (
+        <div className="constraints-list">
+          {constraints.map((c) =>
+            editingId === c.id ? (
+              <ConstraintEditor
+                key={c.id}
+                constraint={c}
+                table={table}
+                allTables={allTables}
+                onUpdate={(patch) => handleUpdate(c.id, patch)}
+                onClose={() => setEditingId(null)}
+                onDelete={() => handleDelete(c.id)}
+              />
+            ) : (
+              <ConstraintRow
+                key={c.id}
+                constraint={c}
+                table={table}
+                onEdit={() => setEditingId(c.id)}
+                onDelete={() => handleDelete(c.id)}
+              />
+            ),
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── 一覧行（折りたたみ状態） ─────────────────────────────────────────────────
+
+function ConstraintRow({
+  constraint, table, onEdit, onDelete,
+}: {
+  constraint: ConstraintDefinition;
+  table: TableDefinition;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  const badge = kindBadge(constraint.kind);
+  const summary = constraintSummary(constraint, table);
+
+  return (
+    <div className="constraint-row">
+      <div className="constraint-row-main">
+        <span className={`constraint-kind-badge constraint-kind-badge--${constraint.kind}`}>{badge}</span>
+        <code className="constraint-id">{constraint.id}</code>
+        {constraint.description && (
+          <span className="constraint-desc-inline">{constraint.description}</span>
+        )}
+      </div>
+      <div className="constraint-row-summary">{summary}</div>
+      <div className="constraint-row-actions">
+        <button className="tbl-btn tbl-btn-ghost tbl-btn-sm" onClick={onEdit}>
+          <i className="bi bi-pencil" /> 編集
+        </button>
+        <button className="tbl-btn tbl-btn-ghost tbl-btn-sm danger" onClick={onDelete}>
+          <i className="bi bi-trash" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── インライン編集カード ──────────────────────────────────────────────────────
+
+function ConstraintEditor({
+  constraint, table, allTables, onUpdate, onClose, onDelete,
+}: {
+  constraint: ConstraintDefinition;
+  table: TableDefinition;
+  allTables: TableDefinition[];
+  onUpdate: (patch: Partial<ConstraintDefinition>) => void;
+  onClose: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <div className="constraint-editor-card">
+      <div className="constraint-editor-header">
+        <span className={`constraint-kind-badge constraint-kind-badge--${constraint.kind}`}>
+          {kindBadge(constraint.kind)}
+        </span>
+        <div className="constraint-editor-id-wrap">
+          <label className="constraint-editor-label">制約名</label>
+          <input
+            className="constraint-id-input"
+            value={constraint.id}
+            onChange={(e) => onUpdate({ id: e.target.value } as Partial<ConstraintDefinition>)}
+            placeholder="constraint_name"
+          />
+        </div>
+        <button className="tbl-btn-icon" onClick={onClose} title="閉じる">
+          <i className="bi bi-x-lg" />
+        </button>
+      </div>
+
+      <div className="constraint-editor-body">
+        {constraint.kind === "unique" && (
+          <UniqueEditor c={constraint} table={table} onUpdate={onUpdate} />
+        )}
+        {constraint.kind === "check" && (
+          <CheckEditor c={constraint} onUpdate={onUpdate} />
+        )}
+        {constraint.kind === "foreignKey" && (
+          <FkEditor c={constraint} table={table} allTables={allTables} onUpdate={onUpdate} />
+        )}
+
+        <label className="constraint-editor-field">
+          <span>説明 (任意)</span>
+          <input
+            type="text"
+            value={constraint.description ?? ""}
+            onChange={(e) =>
+              onUpdate({ description: e.target.value || undefined } as Partial<ConstraintDefinition>)
+            }
+            placeholder="制約の目的・理由"
+          />
+        </label>
+      </div>
+
+      <div className="constraint-editor-footer">
+        <button className="tbl-btn tbl-btn-ghost tbl-btn-sm danger" onClick={onDelete}>
+          <i className="bi bi-trash" /> 削除
+        </button>
+        <button className="tbl-btn tbl-btn-primary tbl-btn-sm" onClick={onClose}>
+          完了
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── UNIQUE 編集 ───────────────────────────────────────────────────────────────
+
+function UniqueEditor({
+  c, table, onUpdate,
+}: {
+  c: UniqueConstraint;
+  table: TableDefinition;
+  onUpdate: (patch: Partial<ConstraintDefinition>) => void;
+}) {
+  const toggle = (colName: string) => {
+    const cols = c.columns.includes(colName)
+      ? c.columns.filter((x) => x !== colName)
+      : [...c.columns, colName];
+    onUpdate({ columns: cols } as Partial<UniqueConstraint>);
+  };
+
+  return (
+    <div className="constraint-editor-field">
+      <span>対象列 (1 つ以上選択)</span>
+      <div className="constraint-col-chips">
+        {table.columns.map((col) => (
+          <label
+            key={col.id}
+            className={`constraint-col-chip${c.columns.includes(col.name) ? " selected" : ""}`}
+          >
+            <input
+              type="checkbox"
+              checked={c.columns.includes(col.name)}
+              onChange={() => toggle(col.name)}
+            />
+            {col.name}
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── CHECK 編集 ────────────────────────────────────────────────────────────────
+
+function CheckEditor({
+  c, onUpdate,
+}: {
+  c: CheckConstraint;
+  onUpdate: (patch: Partial<ConstraintDefinition>) => void;
+}) {
+  return (
+    <label className="constraint-editor-field">
+      <span>SQL 式</span>
+      <input
+        type="text"
+        value={c.expression}
+        onChange={(e) => onUpdate({ expression: e.target.value } as Partial<CheckConstraint>)}
+        placeholder="amount > 0"
+        className="constraint-expr-input"
+      />
+    </label>
+  );
+}
+
+// ── FOREIGN KEY 編集 ──────────────────────────────────────────────────────────
+
+function FkEditor({
+  c, table, allTables, onUpdate,
+}: {
+  c: ForeignKeyConstraint;
+  table: TableDefinition;
+  allTables: TableDefinition[];
+  onUpdate: (patch: Partial<ConstraintDefinition>) => void;
+}) {
+  const refTable = allTables.find((t) => t.name === c.referencedTable);
+
+  const toggleSrcCol = (colName: string) => {
+    const cols = c.columns.includes(colName)
+      ? c.columns.filter((x) => x !== colName)
+      : [...c.columns, colName];
+    onUpdate({ columns: cols } as Partial<ForeignKeyConstraint>);
+  };
+
+  const toggleRefCol = (colName: string) => {
+    const cols = c.referencedColumns.includes(colName)
+      ? c.referencedColumns.filter((x) => x !== colName)
+      : [...c.referencedColumns, colName];
+    onUpdate({ referencedColumns: cols } as Partial<ForeignKeyConstraint>);
+  };
+
+  return (
+    <>
+      <div className="constraint-editor-field">
+        <span>自テーブルの列</span>
+        <div className="constraint-col-chips">
+          {table.columns.map((col) => (
+            <label
+              key={col.id}
+              className={`constraint-col-chip${c.columns.includes(col.name) ? " selected" : ""}`}
+            >
+              <input
+                type="checkbox"
+                checked={c.columns.includes(col.name)}
+                onChange={() => toggleSrcCol(col.name)}
+              />
+              {col.name}
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <label className="constraint-editor-field">
+        <span>参照先テーブル</span>
+        <select
+          value={c.referencedTable}
+          onChange={(e) =>
+            onUpdate({ referencedTable: e.target.value, referencedColumns: [] } as Partial<ForeignKeyConstraint>)
+          }
+        >
+          <option value="">テーブルを選択...</option>
+          {allTables.map((t) => (
+            <option key={t.id} value={t.name}>
+              {t.name}（{t.logicalName}）
+            </option>
+          ))}
+        </select>
+      </label>
+
+      {refTable && (
+        <div className="constraint-editor-field">
+          <span>参照先列</span>
+          <div className="constraint-col-chips">
+            {refTable.columns.map((col) => (
+              <label
+                key={col.id}
+                className={`constraint-col-chip${c.referencedColumns.includes(col.name) ? " selected" : ""}`}
+              >
+                <input
+                  type="checkbox"
+                  checked={c.referencedColumns.includes(col.name)}
+                  onChange={() => toggleRefCol(col.name)}
+                />
+                {col.name}
+                {col.primaryKey && <i className="bi bi-key-fill" style={{ marginLeft: 3, fontSize: 10 }} />}
+              </label>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="constraint-fk-actions-row">
+        <label className="constraint-editor-field">
+          <span>ON DELETE</span>
+          <select
+            value={c.onDelete ?? ""}
+            onChange={(e) =>
+              onUpdate({ onDelete: (e.target.value as FkAction) || undefined } as Partial<ForeignKeyConstraint>)
+            }
+          >
+            <option value="">(指定なし)</option>
+            {FK_ACTIONS.map((a) => <option key={a} value={a}>{a}</option>)}
+          </select>
+        </label>
+        <label className="constraint-editor-field">
+          <span>ON UPDATE</span>
+          <select
+            value={c.onUpdate ?? ""}
+            onChange={(e) =>
+              onUpdate({ onUpdate: (e.target.value as FkAction) || undefined } as Partial<ForeignKeyConstraint>)
+            }
+          >
+            <option value="">(指定なし)</option>
+            {FK_ACTIONS.map((a) => <option key={a} value={a}>{a}</option>)}
+          </select>
+        </label>
+      </div>
+    </>
+  );
+}
+
+// ── ヘルパー ──────────────────────────────────────────────────────────────────
+
+function buildDefault(kind: ConstraintKind, _tableName: string): Omit<ConstraintDefinition, "id"> {
+  switch (kind) {
+    case "unique":
+      return { kind, columns: [], description: "" } as Omit<UniqueConstraint, "id">;
+    case "check":
+      return { kind, expression: "", description: "" } as Omit<CheckConstraint, "id">;
+    case "foreignKey":
+      return {
+        kind,
+        columns: [],
+        referencedTable: "",
+        referencedColumns: [],
+        description: "",
+      } as Omit<ForeignKeyConstraint, "id">;
+  }
+  // unreachable — satisfies exhaustiveness check
+  const _never: never = kind;
+  return _never;
+}
+
+function kindBadge(kind: ConstraintDefinition["kind"]): string {
+  switch (kind) {
+    case "unique": return "UNIQUE";
+    case "check": return "CHECK";
+    case "foreignKey": return "FK";
+  }
+}
+
+function constraintSummary(c: ConstraintDefinition, table: TableDefinition): string {
+  switch (c.kind) {
+    case "unique":
+      return c.columns.length > 0 ? `列: ${c.columns.join(", ")}` : "(列未選択)";
+    case "check":
+      return c.expression ? `式: ${c.expression}` : "(式未設定)";
+    case "foreignKey": {
+      const srcCols = c.columns.join(", ") || "(列未選択)";
+      const refCols = c.referencedColumns.join(", ") || "?";
+      const ref = c.referencedTable ? `${c.referencedTable}(${refCols})` : "(参照先未設定)";
+      return `${srcCols} → ${ref}${c.onDelete ? ` ON DELETE ${c.onDelete}` : ""}`;
+    }
+  }
+}
+

--- a/designer/src/components/table/DdlPreviewDrawer.tsx
+++ b/designer/src/components/table/DdlPreviewDrawer.tsx
@@ -1,0 +1,56 @@
+import { useState } from "react";
+import type { SqlDialect } from "../../types/table";
+import { SQL_DIALECT_LABELS } from "../../types/table";
+
+interface Props {
+  ddl: string;
+  dialect: SqlDialect;
+  onDialectChange: (d: SqlDialect) => void;
+  /** 初期展開状態 (responsive 初期値を呼び出し側が計算して渡す) */
+  defaultOpen?: boolean;
+}
+
+export function DdlPreviewDrawer({ ddl, dialect, onDialectChange, defaultOpen = false }: Props) {
+  const [open, setOpen] = useState(defaultOpen);
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(ddl);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className={`ddl-drawer${open ? " ddl-drawer--open" : ""}`}>
+      <div className="ddl-drawer-header" onClick={() => setOpen((v) => !v)}>
+        <span className="ddl-drawer-title">
+          <i className={`bi bi-chevron-${open ? "down" : "right"} ddl-drawer-chevron`} />
+          <i className="bi bi-code-square" />
+          DDL プレビュー
+        </span>
+        {open && (
+          <div className="ddl-drawer-controls" onClick={(e) => e.stopPropagation()}>
+            <select
+              value={dialect}
+              onChange={(e) => onDialectChange(e.target.value as SqlDialect)}
+              className="ddl-dialect-select"
+            >
+              {Object.entries(SQL_DIALECT_LABELS).map(([k, v]) => (
+                <option key={k} value={k}>{v}</option>
+              ))}
+            </select>
+            <button className="tbl-btn tbl-btn-ghost tbl-btn-sm" onClick={handleCopy}>
+              <i className={`bi ${copied ? "bi-check-lg" : "bi-clipboard"}`} />
+              {copied ? "コピーしました" : "コピー"}
+            </button>
+          </div>
+        )}
+      </div>
+      {open && (
+        <div className="ddl-drawer-body">
+          <pre className="ddl-preview"><code>{ddl}</code></pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/designer/src/components/table/IndexesTab.tsx
+++ b/designer/src/components/table/IndexesTab.tsx
@@ -1,0 +1,271 @@
+import { useState } from "react";
+import type { TableDefinition, IndexDefinition, IndexColumn, IndexMethod } from "../../types/table";
+import { addIndex, removeIndex } from "../../store/tableStore";
+
+const INDEX_METHODS: IndexMethod[] = ["btree", "hash", "gin", "gist"];
+
+interface Props {
+  table: TableDefinition;
+  update: (fn: (t: TableDefinition) => void) => void;
+}
+
+export function IndexesTab({ table, update }: Props) {
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  const indexes = table.indexes;
+
+  const handleAdd = () => {
+    let newId = "";
+    update((t) => {
+      const idx = addIndex(t);
+      newId = idx.id;
+    });
+    setTimeout(() => setEditingId(newId), 0);
+  };
+
+  const handleDelete = (id: string) => {
+    update((t) => removeIndex(t, id));
+    if (editingId === id) setEditingId(null);
+  };
+
+  const handleUpdate = (id: string, patch: Partial<IndexDefinition>) => {
+    update((t) => {
+      const idx = t.indexes.find((i) => i.id === id);
+      if (idx) Object.assign(idx, patch);
+    });
+  };
+
+  return (
+    <div className="indexes-tab2">
+      <div className="indexes-toolbar2">
+        <span className="indexes-count">
+          {indexes.length === 0 ? "インデックスがまだありません" : `${indexes.length} 件`}
+        </span>
+        <button className="tbl-btn tbl-btn-primary" onClick={handleAdd}>
+          <i className="bi bi-plus-lg" /> 追加
+        </button>
+      </div>
+
+      {indexes.length === 0 ? (
+        <div className="indexes-empty2">
+          <i className="bi bi-lightning indexes-empty-icon" />
+          <p>インデックスを追加すると DDL プレビューに <code>CREATE INDEX</code> として出力されます。</p>
+        </div>
+      ) : (
+        <div className="indexes-list2">
+          {indexes.map((idx) =>
+            editingId === idx.id ? (
+              <IndexEditorCard
+                key={idx.id}
+                idx={idx}
+                table={table}
+                onUpdate={(patch) => handleUpdate(idx.id, patch)}
+                onClose={() => setEditingId(null)}
+                onDelete={() => handleDelete(idx.id)}
+              />
+            ) : (
+              <IndexRow
+                key={idx.id}
+                idx={idx}
+                onEdit={() => setEditingId(idx.id)}
+                onDelete={() => handleDelete(idx.id)}
+              />
+            ),
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── 一覧行 ────────────────────────────────────────────────────────────────────
+
+function IndexRow({
+  idx, onEdit, onDelete,
+}: {
+  idx: IndexDefinition;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  const colSummary = idx.columns.length > 0
+    ? idx.columns.map((ic) => `${ic.name}${ic.order === "desc" ? " DESC" : ""}`).join(", ")
+    : "(列未選択)";
+
+  return (
+    <div className="index-row2">
+      <div className="index-row-main">
+        {idx.unique && <span className="index-unique-badge">UNIQUE</span>}
+        {idx.method && idx.method !== "btree" && (
+          <span className="index-method-badge">{idx.method.toUpperCase()}</span>
+        )}
+        <code className="index-row-id">{idx.id}</code>
+        {idx.description && <span className="index-row-desc">{idx.description}</span>}
+      </div>
+      <div className="index-row-summary">
+        <span>列: {colSummary}</span>
+        {idx.where && <span className="index-row-where">WHERE {idx.where}</span>}
+      </div>
+      <div className="index-row-actions">
+        <button className="tbl-btn tbl-btn-ghost tbl-btn-sm" onClick={onEdit}>
+          <i className="bi bi-pencil" /> 編集
+        </button>
+        <button className="tbl-btn tbl-btn-ghost tbl-btn-sm danger" onClick={onDelete}>
+          <i className="bi bi-trash" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── インライン編集カード ──────────────────────────────────────────────────────
+
+function IndexEditorCard({
+  idx, table, onUpdate, onClose, onDelete,
+}: {
+  idx: IndexDefinition;
+  table: TableDefinition;
+  onUpdate: (patch: Partial<IndexDefinition>) => void;
+  onClose: () => void;
+  onDelete: () => void;
+}) {
+  const colNames = table.columns.map((c) => c.name);
+
+  const handleColNameChange = (i: number, name: string) => {
+    const cols = [...idx.columns];
+    cols[i] = { ...cols[i], name };
+    onUpdate({ columns: cols });
+  };
+
+  const handleColOrderChange = (i: number, order: "asc" | "desc") => {
+    const cols = [...idx.columns];
+    cols[i] = { ...cols[i], order };
+    onUpdate({ columns: cols });
+  };
+
+  const handleColRemove = (i: number) => {
+    const cols = idx.columns.filter((_, j) => j !== i);
+    onUpdate({ columns: cols });
+  };
+
+  const handleColAdd = () => {
+    onUpdate({ columns: [...idx.columns, { name: "" }] });
+  };
+
+  return (
+    <div className="index-editor-card">
+      <div className="index-editor-header">
+        <div className="index-editor-name-wrap">
+          <label className="index-editor-label">インデックス名</label>
+          <input
+            className="index-name-input2"
+            value={idx.id}
+            onChange={(e) => onUpdate({ id: e.target.value })}
+            placeholder="idx_tablename_column"
+          />
+        </div>
+        <button className="tbl-btn-icon" onClick={onClose} title="閉じる">
+          <i className="bi bi-x-lg" />
+        </button>
+      </div>
+
+      <div className="index-editor-body">
+        {/* Columns */}
+        <div className="index-editor-field">
+          <span>対象列</span>
+          <div className="index-columns-list">
+            {idx.columns.map((ic, i) => (
+              <div key={i} className="index-col-row">
+                <select
+                  value={ic.name}
+                  onChange={(e) => handleColNameChange(i, e.target.value)}
+                  className="index-col-select"
+                >
+                  <option value="">列を選択...</option>
+                  {colNames.map((n) => (
+                    <option key={n} value={n}>{n}</option>
+                  ))}
+                </select>
+                <select
+                  value={ic.order ?? "asc"}
+                  onChange={(e) => handleColOrderChange(i, e.target.value as "asc" | "desc")}
+                  className="index-order-select"
+                >
+                  <option value="asc">ASC</option>
+                  <option value="desc">DESC</option>
+                </select>
+                <button
+                  className="tbl-btn-icon"
+                  onClick={() => handleColRemove(i)}
+                  title="削除"
+                >
+                  <i className="bi bi-x" />
+                </button>
+              </div>
+            ))}
+            <button className="tbl-btn tbl-btn-ghost tbl-btn-sm" onClick={handleColAdd}>
+              <i className="bi bi-plus" /> 列を追加
+            </button>
+          </div>
+        </div>
+
+        {/* Flags */}
+        <div className="index-editor-flags">
+          <label className="column-flag-label">
+            <input
+              type="checkbox"
+              checked={idx.unique ?? false}
+              onChange={(e) => onUpdate({ unique: e.target.checked })}
+            />
+            UNIQUE インデックス
+          </label>
+        </div>
+
+        {/* Method */}
+        <label className="index-editor-field">
+          <span>インデックス方式 (PostgreSQL)</span>
+          <select
+            value={idx.method ?? "btree"}
+            onChange={(e) => onUpdate({ method: e.target.value as IndexMethod })}
+            className="index-method-select"
+          >
+            {INDEX_METHODS.map((m) => (
+              <option key={m} value={m}>{m.toUpperCase()}</option>
+            ))}
+          </select>
+        </label>
+
+        {/* WHERE */}
+        <label className="index-editor-field">
+          <span>部分インデックス条件 (WHERE) — 省略可</span>
+          <input
+            type="text"
+            value={idx.where ?? ""}
+            onChange={(e) => onUpdate({ where: e.target.value || undefined })}
+            placeholder="status = 'active'"
+            className="index-where-input"
+          />
+        </label>
+
+        {/* Description */}
+        <label className="index-editor-field">
+          <span>目的 (任意)</span>
+          <input
+            type="text"
+            value={idx.description ?? ""}
+            onChange={(e) => onUpdate({ description: e.target.value || undefined })}
+            placeholder="日付範囲検索の高速化"
+          />
+        </label>
+      </div>
+
+      <div className="index-editor-footer">
+        <button className="tbl-btn tbl-btn-ghost tbl-btn-sm danger" onClick={onDelete}>
+          <i className="bi bi-trash" /> 削除
+        </button>
+        <button className="tbl-btn tbl-btn-primary tbl-btn-sm" onClick={onClose}>
+          完了
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/designer/src/components/table/IndexesTab.tsx
+++ b/designer/src/components/table/IndexesTab.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import type { TableDefinition, IndexDefinition, IndexColumn, IndexMethod } from "../../types/table";
+import type { TableDefinition, IndexDefinition, IndexMethod } from "../../types/table";
 import { addIndex, removeIndex } from "../../store/tableStore";
 
 const INDEX_METHODS: IndexMethod[] = ["btree", "hash", "gin", "gist"];

--- a/designer/src/components/table/TableEditor.tsx
+++ b/designer/src/components/table/TableEditor.tsx
@@ -21,6 +21,7 @@ import { ListContextMenu, type ContextMenuItem } from "../common/ListContextMenu
 import { DdlPreviewDrawer } from "./DdlPreviewDrawer";
 import { ConstraintsTab } from "./ConstraintsTab";
 import { IndexesTab } from "./IndexesTab";
+import { TriggersDefaultsTab } from "./TriggersDefaultsTab";
 import { generateUUID } from "../../utils/uuid";
 import { renumber } from "../../utils/listOrder";
 import "../../styles/table.css";
@@ -139,7 +140,10 @@ export function TableEditor() {
           <i className="bi bi-lightning" /> インデックス <span className="tab-count">{table.indexes.length}</span>
         </button>
         <button className={tab === "triggers" ? "active" : ""} onClick={() => setTab("triggers")}>
-          <i className="bi bi-play-btn" /> トリガー
+          <i className="bi bi-play-btn" /> トリガー/DEFAULT
+          {((table.triggers?.length ?? 0) + (table.defaults?.length ?? 0)) > 0 && (
+            <span className="tab-count">{(table.triggers?.length ?? 0) + (table.defaults?.length ?? 0)}</span>
+          )}
         </button>
         <button className={tab === "comment" ? "active" : ""} onClick={() => setTab("comment")}>
           <i className="bi bi-chat-left-text" /> コメント
@@ -159,11 +163,7 @@ export function TableEditor() {
             <IndexesTab key="indexes" table={table} update={update} />
           )}
           {tab === "triggers" && (
-            <PlaceholderTab
-              icon="bi-play-btn"
-              title="トリガー (β-4 で実装予定)"
-              description="BEFORE/AFTER INSERT/UPDATE/DELETE トリガーを一覧・編集します。"
-            />
+            <TriggersDefaultsTab table={table} update={update} />
           )}
           {tab === "comment" && (
             <CommentTab table={table} update={update} />

--- a/designer/src/components/table/TableEditor.tsx
+++ b/designer/src/components/table/TableEditor.tsx
@@ -34,7 +34,7 @@ export function TableEditor() {
   const [tab, setTab] = useState<TabId>("columns");
   const [ddlDialect, setDdlDialect] = useState<SqlDialect>("postgresql");
   // FHD (≤1920) は閉じた状態、WQHD (2560+) は開いた状態で初期化
-  const [ddlOpen, setDdlOpen] = useState(() => window.innerWidth >= 2560);
+  const ddlOpen = window.innerWidth >= 2560;
   const [editingMeta, setEditingMeta] = useState(false);
   const [allTables, setAllTables] = useState<TableDefinition[]>([]);
 

--- a/designer/src/components/table/TableEditor.tsx
+++ b/designer/src/components/table/TableEditor.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import type { TableDefinition, TableColumn, TableIndex, SqlDialect, ColumnTemplate } from "../../types/table";
-import { DATA_TYPE_LABELS, COLUMN_TEMPLATES, SQL_DIALECT_LABELS, DATA_TYPES_WITH_LENGTH, DATA_TYPES_WITH_SCALE, TABLE_CATEGORIES } from "../../types/table";
+import { DATA_TYPE_LABELS, COLUMN_TEMPLATES, DATA_TYPES_WITH_LENGTH, DATA_TYPES_WITH_SCALE, TABLE_CATEGORIES } from "../../types/table";
 import type { DataType } from "../../types/table";
 import { loadTable, saveTable, addColumn, removeColumn, addIndex, removeIndex } from "../../store/tableStore";
 import { listTables } from "../../store/tableStore";
@@ -18,17 +18,20 @@ import { ServerChangeBanner } from "../common/ServerChangeBanner";
 import { DataList, type DataListColumn } from "../common/DataList";
 import { SortBar } from "../common/SortBar";
 import { ListContextMenu, type ContextMenuItem } from "../common/ListContextMenu";
+import { DdlPreviewDrawer } from "./DdlPreviewDrawer";
 import { generateUUID } from "../../utils/uuid";
 import { renumber } from "../../utils/listOrder";
 import "../../styles/table.css";
 
-type TabId = "columns" | "indexes" | "ddl";
+type TabId = "columns" | "constraints" | "indexes" | "triggers" | "comment";
 
 export function TableEditor() {
   const { tableId } = useParams<{ tableId: string }>();
   const navigate = useNavigate();
   const [tab, setTab] = useState<TabId>("columns");
   const [ddlDialect, setDdlDialect] = useState<SqlDialect>("postgresql");
+  // FHD (≤1920) は閉じた状態、WQHD (2560+) は開いた状態で初期化
+  const [ddlOpen, setDdlOpen] = useState(() => window.innerWidth >= 2560);
   const [editingMeta, setEditingMeta] = useState(false);
   const [allTables, setAllTables] = useState<TableDefinition[]>([]);
 
@@ -122,27 +125,57 @@ export function TableEditor() {
       {/* Tabs */}
       <div className="table-editor-tabs">
         <button className={tab === "columns" ? "active" : ""} onClick={() => setTab("columns")}>
-          <i className="bi bi-columns-gap" /> カラム <span className="tab-count">{table.columns.length}</span>
+          <i className="bi bi-columns-gap" /> 列 <span className="tab-count">{table.columns.length}</span>
+        </button>
+        <button className={tab === "constraints" ? "active" : ""} onClick={() => setTab("constraints")}>
+          <i className="bi bi-shield-check" /> 制約
         </button>
         <button className={tab === "indexes" ? "active" : ""} onClick={() => setTab("indexes")}>
           <i className="bi bi-lightning" /> インデックス <span className="tab-count">{table.indexes.length}</span>
         </button>
-        <button className={tab === "ddl" ? "active" : ""} onClick={() => setTab("ddl")}>
-          <i className="bi bi-code-square" /> DDL
+        <button className={tab === "triggers" ? "active" : ""} onClick={() => setTab("triggers")}>
+          <i className="bi bi-play-btn" /> トリガー
+        </button>
+        <button className={tab === "comment" ? "active" : ""} onClick={() => setTab("comment")}>
+          <i className="bi bi-chat-left-text" /> コメント
         </button>
       </div>
 
-      {/* Content */}
-      <div className="table-editor-body">
-        {tab === "columns" && (
-          <ColumnsTab table={table} update={update} allTables={allTables} />
-        )}
-        {tab === "indexes" && (
-          <IndexesTab table={table} update={update} />
-        )}
-        {tab === "ddl" && (
-          <DdlTab ddl={ddl} dialect={ddlDialect} onDialectChange={setDdlDialect} />
-        )}
+      {/* Content + DDL drawer */}
+      <div className="table-editor-content-area">
+        <div className="table-editor-body">
+          {tab === "columns" && (
+            <ColumnsTab table={table} update={update} allTables={allTables} />
+          )}
+          {tab === "constraints" && (
+            <PlaceholderTab
+              icon="bi-shield-check"
+              title="制約 (β-2 で実装予定)"
+              description="CHECK 制約・UNIQUE 制約等を一覧・編集します。"
+            />
+          )}
+          {tab === "indexes" && (
+            <IndexesTab table={table} update={update} />
+          )}
+          {tab === "triggers" && (
+            <PlaceholderTab
+              icon="bi-play-btn"
+              title="トリガー (β-4 で実装予定)"
+              description="BEFORE/AFTER INSERT/UPDATE/DELETE トリガーを一覧・編集します。"
+            />
+          )}
+          {tab === "comment" && (
+            <CommentTab table={table} update={update} />
+          )}
+        </div>
+
+        <DdlPreviewDrawer
+          ddl={ddl}
+          dialect={ddlDialect}
+          onDialectChange={setDdlDialect}
+          defaultOpen={ddlOpen}
+          key={`ddl-drawer-${ddlOpen}`}
+        />
       </div>
     </div>
   );
@@ -994,41 +1027,41 @@ function IndexesTab({
   );
 }
 
-// ── DDLタブ ───────────────────────────────────────────────────────────────────
+// ── プレースホルダータブ (β-2〜4 実装前の仮表示) ──────────────────────────────
 
-function DdlTab({
-  ddl, dialect, onDialectChange,
-}: {
-  ddl: string;
-  dialect: SqlDialect;
-  onDialectChange: (d: SqlDialect) => void;
-}) {
-  const [copied, setCopied] = useState(false);
-
-  const handleCopy = () => {
-    navigator.clipboard.writeText(ddl);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
-
+function PlaceholderTab({ icon, title, description }: { icon: string; title: string; description: string }) {
   return (
-    <div className="ddl-tab">
-      <div className="ddl-toolbar">
-        <select
-          value={dialect}
-          onChange={(e) => onDialectChange(e.target.value as SqlDialect)}
-          className="ddl-dialect-select"
-        >
-          {Object.entries(SQL_DIALECT_LABELS).map(([k, v]) => (
-            <option key={k} value={k}>{v}</option>
-          ))}
-        </select>
-        <button className="tbl-btn tbl-btn-ghost" onClick={handleCopy}>
-          <i className={`bi ${copied ? "bi-check-lg" : "bi-clipboard"}`} />
-          {copied ? "コピーしました" : "コピー"}
-        </button>
-      </div>
-      <pre className="ddl-preview"><code>{ddl}</code></pre>
+    <div className="placeholder-tab">
+      <i className={`bi ${icon} placeholder-tab-icon`} />
+      <p className="placeholder-tab-title">{title}</p>
+      <p className="placeholder-tab-desc">{description}</p>
+    </div>
+  );
+}
+
+// ── コメントタブ ──────────────────────────────────────────────────────────────
+
+function CommentTab({
+  table, update,
+}: {
+  table: TableDefinition;
+  update: (fn: (t: TableDefinition) => void) => void;
+}) {
+  return (
+    <div className="comment-tab">
+      <label className="tbl-field comment-tab-field">
+        <span>テーブルコメント</span>
+        <textarea
+          className="comment-tab-textarea"
+          value={table.comment ?? ""}
+          onChange={(e) => update((t) => { t.comment = e.target.value || undefined; })}
+          placeholder="テーブルの用途・概要を記載します（DDL の COMMENT ON TABLE に反映されます）"
+          rows={4}
+        />
+      </label>
+      <p className="comment-tab-hint">
+        <i className="bi bi-info-circle" /> PostgreSQL では <code>COMMENT ON TABLE {table.name} IS &#39;...&#39;;</code> として DDL に出力されます。
+      </p>
     </div>
   );
 }

--- a/designer/src/components/table/TableEditor.tsx
+++ b/designer/src/components/table/TableEditor.tsx
@@ -19,6 +19,7 @@ import { DataList, type DataListColumn } from "../common/DataList";
 import { SortBar } from "../common/SortBar";
 import { ListContextMenu, type ContextMenuItem } from "../common/ListContextMenu";
 import { DdlPreviewDrawer } from "./DdlPreviewDrawer";
+import { ConstraintsTab } from "./ConstraintsTab";
 import { generateUUID } from "../../utils/uuid";
 import { renumber } from "../../utils/listOrder";
 import "../../styles/table.css";
@@ -129,6 +130,9 @@ export function TableEditor() {
         </button>
         <button className={tab === "constraints" ? "active" : ""} onClick={() => setTab("constraints")}>
           <i className="bi bi-shield-check" /> 制約
+          {(table.constraints?.length ?? 0) > 0 && (
+            <span className="tab-count">{table.constraints!.length}</span>
+          )}
         </button>
         <button className={tab === "indexes" ? "active" : ""} onClick={() => setTab("indexes")}>
           <i className="bi bi-lightning" /> インデックス <span className="tab-count">{table.indexes.length}</span>
@@ -148,11 +152,7 @@ export function TableEditor() {
             <ColumnsTab table={table} update={update} allTables={allTables} />
           )}
           {tab === "constraints" && (
-            <PlaceholderTab
-              icon="bi-shield-check"
-              title="制約 (β-2 で実装予定)"
-              description="CHECK 制約・UNIQUE 制約等を一覧・編集します。"
-            />
+            <ConstraintsTab table={table} update={update} allTables={allTables} />
           )}
           {tab === "indexes" && (
             <IndexesTab table={table} update={update} />

--- a/designer/src/components/table/TableEditor.tsx
+++ b/designer/src/components/table/TableEditor.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import type { TableDefinition, TableColumn, TableIndex, SqlDialect, ColumnTemplate } from "../../types/table";
+import type { TableDefinition, TableColumn, SqlDialect, ColumnTemplate } from "../../types/table";
 import { DATA_TYPE_LABELS, COLUMN_TEMPLATES, DATA_TYPES_WITH_LENGTH, DATA_TYPES_WITH_SCALE, TABLE_CATEGORIES } from "../../types/table";
 import type { DataType } from "../../types/table";
-import { loadTable, saveTable, addColumn, removeColumn, addIndex, removeIndex } from "../../store/tableStore";
+import { loadTable, saveTable, addColumn, removeColumn } from "../../store/tableStore";
 import { listTables } from "../../store/tableStore";
 import { generateDdl, generateTableMarkdown } from "../../utils/ddlGenerator";
 import { mcpBridge } from "../../mcp/mcpBridge";
@@ -20,6 +20,7 @@ import { SortBar } from "../common/SortBar";
 import { ListContextMenu, type ContextMenuItem } from "../common/ListContextMenu";
 import { DdlPreviewDrawer } from "./DdlPreviewDrawer";
 import { ConstraintsTab } from "./ConstraintsTab";
+import { IndexesTab } from "./IndexesTab";
 import { generateUUID } from "../../utils/uuid";
 import { renumber } from "../../utils/listOrder";
 import "../../styles/table.css";
@@ -155,7 +156,7 @@ export function TableEditor() {
             <ConstraintsTab table={table} update={update} allTables={allTables} />
           )}
           {tab === "indexes" && (
-            <IndexesTab table={table} update={update} />
+            <IndexesTab key="indexes" table={table} update={update} />
           )}
           {tab === "triggers" && (
             <PlaceholderTab
@@ -938,96 +939,7 @@ function ForeignKeyEditor({
   );
 }
 
-// ── インデックスタブ ──────────────────────────────────────────────────────────
-
-function IndexesTab({
-  table, update,
-}: {
-  table: TableDefinition;
-  update: (fn: (t: TableDefinition) => void) => void;
-}) {
-  const handleAdd = () => {
-    update((t) => addIndex(t));
-  };
-
-  const handleRemove = (idxId: string) => {
-    update((t) => removeIndex(t, idxId));
-  };
-
-  const handleUpdate = (idxId: string, patch: Partial<TableIndex>) => {
-    update((t) => {
-      const idx = t.indexes.find((i) => i.id === idxId);
-      if (idx) Object.assign(idx, patch);
-    });
-  };
-
-  const toggleColumn = (idxId: string, colId: string) => {
-    update((t) => {
-      const idx = t.indexes.find((i) => i.id === idxId);
-      if (!idx) return;
-      if (idx.columns.includes(colId)) {
-        idx.columns = idx.columns.filter((c) => c !== colId);
-      } else {
-        idx.columns.push(colId);
-      }
-    });
-  };
-
-  return (
-    <div className="indexes-tab">
-      {table.indexes.length === 0 ? (
-        <div className="indexes-empty">
-          <p>インデックスがまだありません</p>
-        </div>
-      ) : (
-        <div className="indexes-list">
-          {table.indexes.map((idx) => (
-            <div key={idx.id} className="index-card">
-              <div className="index-card-header">
-                <input
-                  type="text"
-                  className="index-name-input"
-                  value={idx.name}
-                  onChange={(e) => handleUpdate(idx.id, { name: e.target.value })}
-                  placeholder="インデックス名"
-                />
-                <label className="column-flag-label">
-                  <input
-                    type="checkbox"
-                    checked={idx.unique}
-                    onChange={(e) => handleUpdate(idx.id, { unique: e.target.checked })}
-                  />
-                  UNIQUE
-                </label>
-                <button className="tbl-btn-icon danger" onClick={() => handleRemove(idx.id)} title="削除">
-                  <i className="bi bi-trash" />
-                </button>
-              </div>
-              <div className="index-columns">
-                <span className="index-columns-label">カラム:</span>
-                {table.columns.map((col) => (
-                  <label key={col.id} className={`index-col-chip${idx.columns.includes(col.id) ? " selected" : ""}`}>
-                    <input
-                      type="checkbox"
-                      checked={idx.columns.includes(col.id)}
-                      onChange={() => toggleColumn(idx.id, col.id)}
-                    />
-                    {col.name}
-                  </label>
-                ))}
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
-      <button className="tbl-btn tbl-btn-primary" onClick={handleAdd}>
-        <i className="bi bi-plus-lg" /> インデックス追加
-      </button>
-    </div>
-  );
-}
-
-// ── プレースホルダータブ (β-2〜4 実装前の仮表示) ──────────────────────────────
+// ── プレースホルダータブ (β-4 実装前の仮表示) ─────────────────────────────────
 
 function PlaceholderTab({ icon, title, description }: { icon: string; title: string; description: string }) {
   return (

--- a/designer/src/components/table/TableEditor.tsx
+++ b/designer/src/components/table/TableEditor.tsx
@@ -133,7 +133,7 @@ export function TableEditor() {
         <button className={tab === "constraints" ? "active" : ""} onClick={() => setTab("constraints")}>
           <i className="bi bi-shield-check" /> 制約
           {(table.constraints?.length ?? 0) > 0 && (
-            <span className="tab-count">{table.constraints!.length}</span>
+            <span className="tab-count">{table.constraints?.length}</span>
           )}
         </button>
         <button className={tab === "indexes" ? "active" : ""} onClick={() => setTab("indexes")}>
@@ -175,7 +175,6 @@ export function TableEditor() {
           dialect={ddlDialect}
           onDialectChange={setDdlDialect}
           defaultOpen={ddlOpen}
-          key={`ddl-drawer-${ddlOpen}`}
         />
       </div>
     </div>
@@ -939,17 +938,6 @@ function ForeignKeyEditor({
   );
 }
 
-// ── プレースホルダータブ (β-4 実装前の仮表示) ─────────────────────────────────
-
-function PlaceholderTab({ icon, title, description }: { icon: string; title: string; description: string }) {
-  return (
-    <div className="placeholder-tab">
-      <i className={`bi ${icon} placeholder-tab-icon`} />
-      <p className="placeholder-tab-title">{title}</p>
-      <p className="placeholder-tab-desc">{description}</p>
-    </div>
-  );
-}
 
 // ── コメントタブ ──────────────────────────────────────────────────────────────
 

--- a/designer/src/components/table/TriggersDefaultsTab.tsx
+++ b/designer/src/components/table/TriggersDefaultsTab.tsx
@@ -1,0 +1,482 @@
+import { useState } from "react";
+import type {
+  TableDefinition,
+  DefaultDefinition,
+  DefaultKind,
+  TriggerDefinition,
+  TriggerTiming,
+  TriggerEvent,
+} from "../../types/table";
+import { addDefault, removeDefault, addTrigger, removeTrigger } from "../../store/tableStore";
+
+// @conv.numbering.* の候補 (datalist 補完用)
+const CONVENTION_REF_SUGGESTIONS = [
+  "@conv.numbering.orderNumber",
+  "@conv.numbering.invoiceNumber",
+  "@conv.numbering.purchaseOrderNumber",
+  "@conv.numbering.customerCode",
+  "@conv.numbering.productCode",
+  "@conv.numbering.receiptNumber",
+  "@conv.numbering.shipmentNumber",
+];
+
+const DEFAULT_KIND_LABELS: Record<DefaultKind, string> = {
+  literal: "リテラル (例: 0, 'active')",
+  function: "関数 (例: NOW(), UUID())",
+  sequence: "シーケンス (nextval)",
+  conventionRef: "規約参照 (@conv.numbering.*)",
+};
+
+const TRIGGER_TIMINGS: TriggerTiming[] = ["BEFORE", "AFTER"];
+const TRIGGER_EVENTS: TriggerEvent[] = ["INSERT", "UPDATE", "DELETE"];
+
+interface Props {
+  table: TableDefinition;
+  update: (fn: (t: TableDefinition) => void) => void;
+}
+
+export function TriggersDefaultsTab({ table, update }: Props) {
+  const [editingDefaultCol, setEditingDefaultCol] = useState<string | null>(null);
+  const [editingTriggerId, setEditingTriggerId] = useState<string | null>(null);
+
+  const defaults = table.defaults ?? [];
+  const triggers = table.triggers ?? [];
+  const colNames = table.columns.map((c) => c.name);
+
+  // ── DEFAULT 値 ──────────────────────────────────────────────────────────
+
+  const handleAddDefault = () => {
+    const availableCols = colNames.filter((n) => !defaults.some((d) => d.column === n));
+    const col = availableCols[0] ?? colNames[0] ?? "";
+    if (!col) return;
+    const def: DefaultDefinition = { column: col, kind: "literal", value: "" };
+    update((t) => addDefault(t, def));
+    setEditingDefaultCol(col);
+  };
+
+  const handleDeleteDefault = (col: string) => {
+    update((t) => removeDefault(t, col));
+    if (editingDefaultCol === col) setEditingDefaultCol(null);
+  };
+
+  const handleUpdateDefault = (col: string, patch: Partial<DefaultDefinition>) => {
+    update((t) => {
+      const d = (t.defaults ?? []).find((x) => x.column === col);
+      if (d) Object.assign(d, patch);
+    });
+    // if column name changed, update editing key
+    if (patch.column && patch.column !== col) {
+      setEditingDefaultCol(patch.column);
+    }
+  };
+
+  // ── トリガー ─────────────────────────────────────────────────────────────
+
+  const handleAddTrigger = () => {
+    let newId = "";
+    update((t) => {
+      const trg = addTrigger(t);
+      newId = trg.id;
+    });
+    setTimeout(() => setEditingTriggerId(newId), 0);
+  };
+
+  const handleDeleteTrigger = (id: string) => {
+    update((t) => removeTrigger(t, id));
+    if (editingTriggerId === id) setEditingTriggerId(null);
+  };
+
+  const handleUpdateTrigger = (id: string, patch: Partial<TriggerDefinition>) => {
+    update((t) => {
+      const trg = (t.triggers ?? []).find((x) => x.id === id);
+      if (trg) Object.assign(trg, patch);
+    });
+  };
+
+  return (
+    <div className="triggers-defaults-tab">
+      {/* ── DEFAULT 値セクション ───────────────────────────────── */}
+      <div className="td-section">
+        <div className="td-section-header">
+          <span className="td-section-title">
+            <i className="bi bi-database-fill-gear" /> DEFAULT 値
+          </span>
+          <button
+            className="tbl-btn tbl-btn-primary tbl-btn-sm"
+            onClick={handleAddDefault}
+            disabled={colNames.length === 0}
+            title={colNames.length === 0 ? "列を先に追加してください" : undefined}
+          >
+            <i className="bi bi-plus-lg" /> 追加
+          </button>
+        </div>
+
+        {defaults.length === 0 ? (
+          <div className="td-empty">
+            <i className="bi bi-database-fill-gear td-empty-icon" />
+            <p>DEFAULT 値定義を追加すると <code>ALTER TABLE ... ALTER COLUMN ... SET DEFAULT</code> として DDL に出力されます。</p>
+            <p className="td-empty-hint">規約参照 (<code>@conv.numbering.*</code>) を選ぶと採番規約との連携を明示できます。</p>
+          </div>
+        ) : (
+          <div className="td-list">
+            {defaults.map((def) =>
+              editingDefaultCol === def.column ? (
+                <DefaultEditorCard
+                  key={def.column}
+                  def={def}
+                  colNames={colNames}
+                  usedCols={new Set(defaults.map((d) => d.column).filter((c) => c !== def.column))}
+                  onUpdate={(patch) => handleUpdateDefault(def.column, patch)}
+                  onClose={() => setEditingDefaultCol(null)}
+                  onDelete={() => handleDeleteDefault(def.column)}
+                />
+              ) : (
+                <DefaultRow
+                  key={def.column}
+                  def={def}
+                  onEdit={() => setEditingDefaultCol(def.column)}
+                  onDelete={() => handleDeleteDefault(def.column)}
+                />
+              ),
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* ── トリガーセクション ─────────────────────────────────── */}
+      <div className="td-section">
+        <div className="td-section-header">
+          <span className="td-section-title">
+            <i className="bi bi-play-btn-fill" /> トリガー
+          </span>
+          <button className="tbl-btn tbl-btn-primary tbl-btn-sm" onClick={handleAddTrigger}>
+            <i className="bi bi-plus-lg" /> 追加
+          </button>
+        </div>
+
+        {triggers.length === 0 ? (
+          <div className="td-empty">
+            <i className="bi bi-play-btn td-empty-icon" />
+            <p>トリガーを追加すると <code>CREATE TRIGGER</code> として DDL に出力されます。</p>
+          </div>
+        ) : (
+          <div className="td-list">
+            {triggers.map((trg) =>
+              editingTriggerId === trg.id ? (
+                <TriggerEditorCard
+                  key={trg.id}
+                  trg={trg}
+                  onUpdate={(patch) => handleUpdateTrigger(trg.id, patch)}
+                  onClose={() => setEditingTriggerId(null)}
+                  onDelete={() => handleDeleteTrigger(trg.id)}
+                />
+              ) : (
+                <TriggerRow
+                  key={trg.id}
+                  trg={trg}
+                  onEdit={() => setEditingTriggerId(trg.id)}
+                  onDelete={() => handleDeleteTrigger(trg.id)}
+                />
+              ),
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── DEFAULT 値 一覧行 ────────────────────────────────────────────────────────
+
+function DefaultRow({
+  def, onEdit, onDelete,
+}: {
+  def: DefaultDefinition;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <div className="td-row">
+      <div className="td-row-main">
+        <span className={`td-kind-badge td-kind-badge--${def.kind}`}>
+          {def.kind === "conventionRef" ? "規約参照" : def.kind}
+        </span>
+        <code className="td-row-col">{def.column}</code>
+        {def.description && <span className="td-row-desc">{def.description}</span>}
+      </div>
+      <div className="td-row-summary">
+        <code>{def.value || "(未設定)"}</code>
+      </div>
+      <div className="td-row-actions">
+        <button className="tbl-btn tbl-btn-ghost tbl-btn-sm" onClick={onEdit}>
+          <i className="bi bi-pencil" /> 編集
+        </button>
+        <button className="tbl-btn tbl-btn-ghost tbl-btn-sm danger" onClick={onDelete}>
+          <i className="bi bi-trash" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── DEFAULT 値 編集カード ─────────────────────────────────────────────────────
+
+function DefaultEditorCard({
+  def, colNames, usedCols, onUpdate, onClose, onDelete,
+}: {
+  def: DefaultDefinition;
+  colNames: string[];
+  usedCols: Set<string>;
+  onUpdate: (patch: Partial<DefaultDefinition>) => void;
+  onClose: () => void;
+  onDelete: () => void;
+}) {
+  const isConventionRef = def.kind === "conventionRef";
+
+  return (
+    <div className="td-editor-card">
+      <div className="td-editor-header">
+        <span className="td-editor-title">DEFAULT 値を編集</span>
+        <button className="tbl-btn-icon" onClick={onClose} title="閉じる">
+          <i className="bi bi-x-lg" />
+        </button>
+      </div>
+
+      <div className="td-editor-body">
+        <label className="td-editor-field">
+          <span>対象列</span>
+          <select
+            value={def.column}
+            onChange={(e) => onUpdate({ column: e.target.value })}
+          >
+            {colNames.map((n) => (
+              <option key={n} value={n} disabled={usedCols.has(n)}>
+                {n}{usedCols.has(n) ? " (使用中)" : ""}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <div className="td-editor-field">
+          <span>種別</span>
+          <div className="td-kind-radios">
+            {(["literal", "function", "sequence", "conventionRef"] as DefaultKind[]).map((k) => (
+              <label key={k} className="td-kind-radio">
+                <input
+                  type="radio"
+                  name={`default-kind-${def.column}`}
+                  value={k}
+                  checked={def.kind === k}
+                  onChange={() => onUpdate({ kind: k, value: k === "conventionRef" ? "@conv.numbering." : "" })}
+                />
+                {DEFAULT_KIND_LABELS[k]}
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <label className="td-editor-field">
+          <span>{isConventionRef ? "規約参照キー" : "値"}</span>
+          {isConventionRef ? (
+            <>
+              <input
+                type="text"
+                list="conv-numbering-list"
+                value={def.value}
+                onChange={(e) => onUpdate({ value: e.target.value })}
+                placeholder="@conv.numbering.orderNumber"
+                className="td-value-input"
+              />
+              <datalist id="conv-numbering-list">
+                {CONVENTION_REF_SUGGESTIONS.map((s) => (
+                  <option key={s} value={s} />
+                ))}
+              </datalist>
+              <span className="td-hint">
+                <i className="bi bi-info-circle" /> DDL では <code>DEFAULT NULL /* @conv.numbering.xxx */</code> として出力されます。採番の実装は sequence + trigger で行います。
+              </span>
+            </>
+          ) : (
+            <input
+              type="text"
+              value={def.value}
+              onChange={(e) => onUpdate({ value: e.target.value })}
+              placeholder={def.kind === "literal" ? "0 または 'active'" : def.kind === "sequence" ? "seq_name" : "NOW()"}
+              className="td-value-input"
+            />
+          )}
+        </label>
+
+        <label className="td-editor-field">
+          <span>説明 (任意)</span>
+          <input
+            type="text"
+            value={def.description ?? ""}
+            onChange={(e) => onUpdate({ description: e.target.value || undefined })}
+            placeholder="この DEFAULT 値の目的・理由"
+          />
+        </label>
+      </div>
+
+      <div className="td-editor-footer">
+        <button className="tbl-btn tbl-btn-ghost tbl-btn-sm danger" onClick={onDelete}>
+          <i className="bi bi-trash" /> 削除
+        </button>
+        <button className="tbl-btn tbl-btn-primary tbl-btn-sm" onClick={onClose}>
+          完了
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── トリガー 一覧行 ────────────────────────────────────────────────────────────
+
+function TriggerRow({
+  trg, onEdit, onDelete,
+}: {
+  trg: TriggerDefinition;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <div className="td-row">
+      <div className="td-row-main">
+        <span className="td-timing-badge">{trg.timing}</span>
+        <span className="td-events-badge">{trg.events.join(" | ")}</span>
+        <code className="td-row-col">{trg.id}</code>
+        {trg.description && <span className="td-row-desc">{trg.description}</span>}
+      </div>
+      {trg.body && (
+        <div className="td-row-summary">
+          <code className="td-body-preview">{trg.body.split("\n")[0]}{trg.body.includes("\n") ? "…" : ""}</code>
+        </div>
+      )}
+      <div className="td-row-actions">
+        <button className="tbl-btn tbl-btn-ghost tbl-btn-sm" onClick={onEdit}>
+          <i className="bi bi-pencil" /> 編集
+        </button>
+        <button className="tbl-btn tbl-btn-ghost tbl-btn-sm danger" onClick={onDelete}>
+          <i className="bi bi-trash" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── トリガー 編集カード ────────────────────────────────────────────────────────
+
+function TriggerEditorCard({
+  trg, onUpdate, onClose, onDelete,
+}: {
+  trg: TriggerDefinition;
+  onUpdate: (patch: Partial<TriggerDefinition>) => void;
+  onClose: () => void;
+  onDelete: () => void;
+}) {
+  const toggleEvent = (ev: TriggerEvent) => {
+    const next = trg.events.includes(ev)
+      ? trg.events.filter((e) => e !== ev)
+      : [...trg.events, ev];
+    if (next.length > 0) onUpdate({ events: next });
+  };
+
+  return (
+    <div className="td-editor-card">
+      <div className="td-editor-header">
+        <span className="td-editor-title">トリガーを編集</span>
+        <button className="tbl-btn-icon" onClick={onClose} title="閉じる">
+          <i className="bi bi-x-lg" />
+        </button>
+      </div>
+
+      <div className="td-editor-body">
+        <label className="td-editor-field">
+          <span>トリガー名</span>
+          <input
+            type="text"
+            value={trg.id}
+            onChange={(e) => onUpdate({ id: e.target.value })}
+            placeholder="trg_tablename_action"
+            className="td-trigger-name-input"
+          />
+        </label>
+
+        <div className="td-editor-field">
+          <span>タイミング</span>
+          <div className="td-timing-radios">
+            {TRIGGER_TIMINGS.map((t) => (
+              <label key={t} className="td-timing-radio">
+                <input
+                  type="radio"
+                  name={`timing-${trg.id}`}
+                  value={t}
+                  checked={trg.timing === t}
+                  onChange={() => onUpdate({ timing: t })}
+                />
+                {t}
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <div className="td-editor-field">
+          <span>イベント (複数選択可)</span>
+          <div className="td-events-checks">
+            {TRIGGER_EVENTS.map((ev) => (
+              <label key={ev} className="column-flag-label">
+                <input
+                  type="checkbox"
+                  checked={trg.events.includes(ev)}
+                  onChange={() => toggleEvent(ev)}
+                />
+                {ev}
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <label className="td-editor-field">
+          <span>WHEN 句 (省略可)</span>
+          <input
+            type="text"
+            value={trg.whenCondition ?? ""}
+            onChange={(e) => onUpdate({ whenCondition: e.target.value || undefined })}
+            placeholder="NEW.status = 'active'"
+            className="td-value-input"
+          />
+        </label>
+
+        <label className="td-editor-field">
+          <span>本体 (SQL / PL/pgSQL)</span>
+          <textarea
+            className="td-body-textarea"
+            value={trg.body}
+            onChange={(e) => onUpdate({ body: e.target.value })}
+            placeholder={"NEW.po_number := 'ORD-' || TO_CHAR(NOW(), 'YYYY') || '-' ||\n  LPAD(nextval('po_number_seq')::text, 4, '0');"}
+            rows={6}
+          />
+        </label>
+
+        <label className="td-editor-field">
+          <span>説明 (任意)</span>
+          <input
+            type="text"
+            value={trg.description ?? ""}
+            onChange={(e) => onUpdate({ description: e.target.value || undefined })}
+            placeholder="このトリガーの目的・処理内容"
+          />
+        </label>
+      </div>
+
+      <div className="td-editor-footer">
+        <button className="tbl-btn tbl-btn-ghost tbl-btn-sm danger" onClick={onDelete}>
+          <i className="bi bi-trash" /> 削除
+        </button>
+        <button className="tbl-btn tbl-btn-primary tbl-btn-sm" onClick={onClose}>
+          完了
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/designer/src/store/tableStore.ts
+++ b/designer/src/store/tableStore.ts
@@ -5,7 +5,7 @@
  * - wsBridge が接続済みの場合: サーバー側ファイルに保存（mcpBridge 経由）
  * - 未接続の場合: localStorage にフォールバック
  */
-import type { TableDefinition, TableMeta, TableColumn, IndexDefinition, ConstraintDefinition } from "../types/table";
+import type { TableDefinition, TableMeta, TableColumn, IndexDefinition, ConstraintDefinition, TriggerDefinition, DefaultDefinition } from "../types/table";
 import type { FlowProject } from "../types/flow";
 import { loadProject, saveProject } from "./flowStore";
 import { generateUUID } from "../utils/uuid";
@@ -188,6 +188,38 @@ export function addConstraint(
 /** 制約を削除 */
 export function removeConstraint(table: TableDefinition, constraintId: string): void {
   table.constraints = (table.constraints ?? []).filter((c) => c.id !== constraintId);
+}
+
+/** DEFAULT 値定義を追加 */
+export function addDefault(table: TableDefinition, def: DefaultDefinition): void {
+  table.defaults = [...(table.defaults ?? []), def];
+}
+
+/** DEFAULT 値定義を削除 */
+export function removeDefault(table: TableDefinition, column: string): void {
+  table.defaults = (table.defaults ?? []).filter((d) => d.column !== column);
+}
+
+/** トリガーを追加 */
+export function addTrigger(
+  table: TableDefinition,
+  partial?: Partial<TriggerDefinition>,
+): TriggerDefinition {
+  const t: TriggerDefinition = {
+    id: partial?.id ?? `trg_${table.name}_${(table.triggers ?? []).length + 1}`,
+    timing: partial?.timing ?? "BEFORE",
+    events: partial?.events ?? ["INSERT"],
+    whenCondition: partial?.whenCondition,
+    body: partial?.body ?? "",
+    description: partial?.description,
+  };
+  table.triggers = [...(table.triggers ?? []), t];
+  return t;
+}
+
+/** トリガーを削除 */
+export function removeTrigger(table: TableDefinition, triggerId: string): void {
+  table.triggers = (table.triggers ?? []).filter((t) => t.id !== triggerId);
 }
 
 /** テーブル一覧の並び順を変更する (project.tables の物理順) */

--- a/designer/src/store/tableStore.ts
+++ b/designer/src/store/tableStore.ts
@@ -5,7 +5,7 @@
  * - wsBridge が接続済みの場合: サーバー側ファイルに保存（mcpBridge 経由）
  * - 未接続の場合: localStorage にフォールバック
  */
-import type { TableDefinition, TableMeta, TableColumn, TableIndex, ConstraintDefinition } from "../types/table";
+import type { TableDefinition, TableMeta, TableColumn, IndexDefinition, ConstraintDefinition } from "../types/table";
 import type { FlowProject } from "../types/flow";
 import { loadProject, saveProject } from "./flowStore";
 import { generateUUID } from "../utils/uuid";
@@ -137,29 +137,33 @@ export function addColumn(
 
 /** カラムを削除 */
 export function removeColumn(table: TableDefinition, columnId: string): void {
+  const removedName = table.columns.find((c) => c.id === columnId)?.name;
   const idx = table.columns.findIndex((c) => c.id === columnId);
   if (idx >= 0) {
     table.columns.splice(idx, 1);
     table.columns = renumber(table.columns);
-    // インデックスからも参照を削除
-    for (const index of table.indexes) {
-      index.columns = index.columns.filter((cid) => cid !== columnId);
+    // インデックスからも参照を削除 (列名で照合)
+    if (removedName) {
+      for (const index of table.indexes) {
+        index.columns = index.columns.filter((ic) => ic.name !== removedName);
+      }
+      table.indexes = table.indexes.filter((idx) => idx.columns.length > 0);
     }
-    // 空になったインデックスを削除
-    table.indexes = table.indexes.filter((idx) => idx.columns.length > 0);
   }
 }
 
 /** インデックスを追加 */
 export function addIndex(
   table: TableDefinition,
-  partial?: Partial<TableIndex>,
-): TableIndex {
-  const idx: TableIndex = {
-    id: generateUUID(),
-    name: partial?.name ?? `idx_${table.name}_${table.indexes.length + 1}`,
+  partial?: Partial<IndexDefinition>,
+): IndexDefinition {
+  const idx: IndexDefinition = {
+    id: partial?.id ?? `idx_${table.name}_${table.indexes.length + 1}`,
     columns: partial?.columns ?? [],
     unique: partial?.unique ?? false,
+    method: partial?.method,
+    where: partial?.where,
+    description: partial?.description,
   };
   table.indexes.push(idx);
   return idx;

--- a/designer/src/store/tableStore.ts
+++ b/designer/src/store/tableStore.ts
@@ -5,7 +5,7 @@
  * - wsBridge が接続済みの場合: サーバー側ファイルに保存（mcpBridge 経由）
  * - 未接続の場合: localStorage にフォールバック
  */
-import type { TableDefinition, TableMeta, TableColumn, TableIndex } from "../types/table";
+import type { TableDefinition, TableMeta, TableColumn, TableIndex, ConstraintDefinition } from "../types/table";
 import type { FlowProject } from "../types/flow";
 import { loadProject, saveProject } from "./flowStore";
 import { generateUUID } from "../utils/uuid";
@@ -169,6 +169,21 @@ export function addIndex(
 export function removeIndex(table: TableDefinition, indexId: string): void {
   const idx = table.indexes.findIndex((i) => i.id === indexId);
   if (idx >= 0) table.indexes.splice(idx, 1);
+}
+
+/** 制約を追加 */
+export function addConstraint(
+  table: TableDefinition,
+  constraint: Omit<ConstraintDefinition, "id">,
+): ConstraintDefinition {
+  const c = { id: generateUUID(), ...constraint } as ConstraintDefinition;
+  table.constraints = [...(table.constraints ?? []), c];
+  return c;
+}
+
+/** 制約を削除 */
+export function removeConstraint(table: TableDefinition, constraintId: string): void {
+  table.constraints = (table.constraints ?? []).filter((c) => c.id !== constraintId);
 }
 
 /** テーブル一覧の並び順を変更する (project.tables の物理順) */

--- a/designer/src/store/tableStore.ts
+++ b/designer/src/store/tableStore.ts
@@ -54,7 +54,7 @@ export async function loadTable(tableId: string): Promise<TableDefinition | null
   raw.columns = renumber(raw.columns ?? []);
   // β-3 移行: 旧 TableIndex 形式 { name, columns: string[] } → IndexDefinition 形式
   raw.indexes = (raw.indexes ?? []).map((idx) => {
-    const i = idx as Record<string, unknown>;
+    const i = idx as unknown as Record<string, unknown>;
     if (typeof i.name === "string" && Array.isArray(i.columns) && (i.columns.length === 0 || typeof i.columns[0] === "string")) {
       return {
         id: i.name as string,

--- a/designer/src/store/tableStore.ts
+++ b/designer/src/store/tableStore.ts
@@ -52,6 +52,21 @@ export async function loadTable(tableId: string): Promise<TableDefinition | null
   if (!raw) return null;
   // docs/spec/list-common.md §3.10: 読み込み時に no を配列順で補完
   raw.columns = renumber(raw.columns ?? []);
+  // β-3 移行: 旧 TableIndex 形式 { name, columns: string[] } → IndexDefinition 形式
+  raw.indexes = (raw.indexes ?? []).map((idx) => {
+    const i = idx as Record<string, unknown>;
+    if (typeof i.name === "string" && Array.isArray(i.columns) && (i.columns.length === 0 || typeof i.columns[0] === "string")) {
+      return {
+        id: i.name as string,
+        columns: (i.columns as string[]).map((colId) => {
+          const col = raw.columns.find((c) => c.id === colId);
+          return { name: col ? col.name : colId };
+        }),
+        unique: (i.unique as boolean | undefined) ?? false,
+      } as IndexDefinition;
+    }
+    return idx;
+  });
   return raw;
 }
 
@@ -180,7 +195,8 @@ export function addConstraint(
   table: TableDefinition,
   constraint: Omit<ConstraintDefinition, "id">,
 ): ConstraintDefinition {
-  const c = { id: generateUUID(), ...constraint } as ConstraintDefinition;
+  const n = (table.constraints ?? []).length + 1;
+  const c = { id: `con_${table.name}_${n}`, ...constraint } as ConstraintDefinition;
   table.constraints = [...(table.constraints ?? []), c];
   return c;
 }

--- a/designer/src/styles/table.css
+++ b/designer/src/styles/table.css
@@ -1136,6 +1136,335 @@
   border-radius: 3px;
 }
 
+/* ── 制約タブ (β-2) ─────────────────────────────────────────────────────── */
+
+.constraints-tab {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+}
+
+.constraints-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.constraints-count {
+  font-size: 13px;
+  color: #888;
+}
+
+.constraints-add-wrap {
+  position: relative;
+}
+
+.constraints-add-menu {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 4px);
+  background: #222240;
+  border: 1px solid #444;
+  border-radius: 6px;
+  z-index: 50;
+  min-width: 160px;
+  box-shadow: 0 6px 20px rgba(0,0,0,0.5);
+  overflow: hidden;
+}
+
+.constraints-add-menu button {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 9px 14px;
+  background: transparent;
+  border: none;
+  color: #e0e0e0;
+  font-size: 13px;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.1s;
+}
+
+.constraints-add-menu button:hover {
+  background: rgba(255,255,255,0.07);
+}
+
+.constraints-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 40px 20px;
+  color: #666;
+  text-align: center;
+}
+
+.constraints-empty-icon {
+  font-size: 36px;
+  color: #444;
+}
+
+.constraints-empty p {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.6;
+  max-width: 480px;
+}
+
+.constraints-empty code {
+  font-family: "Consolas", "Monaco", monospace;
+  background: rgba(255,255,255,0.06);
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+
+.constraints-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* ── 制約行（折りたたみ） ─────────────────────────────────────────────────── */
+
+.constraint-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 14px;
+  background: #1e1e38;
+  border: 1px solid #333;
+  border-radius: 7px;
+  transition: border-color 0.12s;
+}
+
+.constraint-row:hover {
+  border-color: #555;
+}
+
+.constraint-row-main {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.constraint-kind-badge {
+  display: inline-block;
+  padding: 1px 7px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+
+.constraint-kind-badge--unique {
+  background: rgba(100, 180, 255, 0.15);
+  color: #64b4ff;
+  border: 1px solid rgba(100, 180, 255, 0.3);
+}
+
+.constraint-kind-badge--check {
+  background: rgba(255, 200, 80, 0.15);
+  color: #ffc850;
+  border: 1px solid rgba(255, 200, 80, 0.3);
+}
+
+.constraint-kind-badge--foreignKey {
+  background: rgba(130, 220, 160, 0.15);
+  color: #82dc9f;
+  border: 1px solid rgba(130, 220, 160, 0.3);
+}
+
+.constraint-id {
+  font-family: "Consolas", "Monaco", monospace;
+  font-size: 13px;
+  color: #ddd;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.constraint-desc-inline {
+  font-size: 12px;
+  color: #888;
+  flex-shrink: 0;
+}
+
+.constraint-row-summary {
+  font-size: 12px;
+  color: #999;
+  font-family: "Consolas", "Monaco", monospace;
+  padding-left: 2px;
+}
+
+.constraint-row-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 4px;
+  justify-content: flex-end;
+}
+
+/* ── 制約インライン編集カード ──────────────────────────────────────────────── */
+
+.constraint-editor-card {
+  background: #1a1a2e;
+  border: 1px solid #7c6bff;
+  border-radius: 8px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.constraint-editor-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.constraint-editor-id-wrap {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
+}
+
+.constraint-editor-label {
+  font-size: 12px;
+  color: #888;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.constraint-id-input {
+  flex: 1;
+  min-width: 0;
+  padding: 5px 8px;
+  background: #0d0d1a;
+  border: 1px solid #444;
+  border-radius: 5px;
+  color: #e0e0e0;
+  font-size: 13px;
+  font-family: "Consolas", "Monaco", monospace;
+  outline: none;
+}
+
+.constraint-id-input:focus {
+  border-color: #7c6bff;
+}
+
+.constraint-editor-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.constraint-editor-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.constraint-editor-field > span {
+  font-size: 12px;
+  color: #aaa;
+  font-weight: 500;
+}
+
+.constraint-editor-field select,
+.constraint-editor-field input[type="text"] {
+  padding: 6px 10px;
+  background: #0d0d1a;
+  border: 1px solid #444;
+  border-radius: 5px;
+  color: #e0e0e0;
+  font-size: 13px;
+  outline: none;
+  transition: border-color 0.12s;
+}
+
+.constraint-editor-field select:focus,
+.constraint-editor-field input[type="text"]:focus {
+  border-color: #7c6bff;
+}
+
+.constraint-expr-input {
+  font-family: "Consolas", "Monaco", monospace !important;
+}
+
+.constraint-col-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.constraint-col-chip {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 10px;
+  background: #222240;
+  border: 1px solid #444;
+  border-radius: 20px;
+  font-size: 12px;
+  color: #bbb;
+  cursor: pointer;
+  transition: all 0.1s;
+  user-select: none;
+}
+
+.constraint-col-chip input[type="checkbox"] {
+  display: none;
+}
+
+.constraint-col-chip.selected {
+  background: rgba(124, 107, 255, 0.2);
+  border-color: #7c6bff;
+  color: #c8bfff;
+}
+
+.constraint-col-chip:hover:not(.selected) {
+  border-color: #666;
+  color: #ddd;
+}
+
+.constraint-fk-actions-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.constraint-editor-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: 4px;
+  border-top: 1px solid #333;
+}
+
+/* ── 4K: 制約一覧 2 列グリッド ──────────────────────────────────────────── */
+
+@media (min-width: 3840px) {
+  .constraints-list {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+    align-items: start;
+  }
+
+  .constraint-editor-card {
+    grid-column: 1 / -1;
+  }
+}
+
 /* (旧 DDL タブは DdlPreviewDrawer に移行済み、クラス定義は互換のため残す) */
 .ddl-tab {
   display: flex;

--- a/designer/src/styles/table.css
+++ b/designer/src/styles/table.css
@@ -1136,6 +1136,327 @@
   border-radius: 3px;
 }
 
+/* ── トリガー + DEFAULT タブ (β-4) ───────────────────────────────────────── */
+
+.triggers-defaults-tab {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.td-section {
+  padding: 16px;
+  border-bottom: 1px solid #2a2a44;
+}
+
+.td-section:last-child {
+  border-bottom: none;
+}
+
+.td-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.td-section-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #ccc;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.td-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 24px 20px;
+  color: #666;
+  text-align: center;
+}
+
+.td-empty-icon {
+  font-size: 28px;
+  color: #444;
+}
+
+.td-empty p {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.6;
+  max-width: 520px;
+}
+
+.td-empty-hint {
+  font-size: 12px !important;
+  color: #555 !important;
+}
+
+.td-empty code {
+  font-family: "Consolas", "Monaco", monospace;
+  background: rgba(255,255,255,0.06);
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+
+.td-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+/* ── 一覧行 ──────────────────────────────────────────────────────────────── */
+
+.td-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 14px;
+  background: #1e1e38;
+  border: 1px solid #333;
+  border-radius: 7px;
+  transition: border-color 0.12s;
+}
+
+.td-row:hover {
+  border-color: #555;
+}
+
+.td-row-main {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.td-kind-badge {
+  display: inline-block;
+  padding: 1px 7px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.td-kind-badge--literal {
+  background: rgba(180, 200, 100, 0.15);
+  color: #b4c864;
+  border: 1px solid rgba(180, 200, 100, 0.3);
+}
+
+.td-kind-badge--function {
+  background: rgba(100, 200, 220, 0.15);
+  color: #64c8dc;
+  border: 1px solid rgba(100, 200, 220, 0.3);
+}
+
+.td-kind-badge--sequence {
+  background: rgba(200, 130, 255, 0.15);
+  color: #c882ff;
+  border: 1px solid rgba(200, 130, 255, 0.3);
+}
+
+.td-kind-badge--conventionRef {
+  background: rgba(255, 160, 80, 0.18);
+  color: #ffa050;
+  border: 1px solid rgba(255, 160, 80, 0.35);
+}
+
+.td-timing-badge {
+  display: inline-block;
+  padding: 1px 7px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 700;
+  background: rgba(124, 107, 255, 0.18);
+  color: #a99bff;
+  border: 1px solid rgba(124, 107, 255, 0.35);
+}
+
+.td-events-badge {
+  display: inline-block;
+  padding: 1px 7px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  background: rgba(100, 200, 180, 0.12);
+  color: #64c8b4;
+  border: 1px solid rgba(100, 200, 180, 0.3);
+}
+
+.td-row-col {
+  font-family: "Consolas", "Monaco", monospace;
+  font-size: 13px;
+  color: #ddd;
+  flex: 1;
+  min-width: 0;
+}
+
+.td-row-desc {
+  font-size: 12px;
+  color: #888;
+}
+
+.td-row-summary {
+  font-size: 12px;
+  color: #999;
+  font-family: "Consolas", "Monaco", monospace;
+}
+
+.td-body-preview {
+  opacity: 0.8;
+}
+
+.td-row-actions {
+  display: flex;
+  gap: 6px;
+  justify-content: flex-end;
+  margin-top: 4px;
+}
+
+/* ── 編集カード ──────────────────────────────────────────────────────────── */
+
+.td-editor-card {
+  background: #1a1a2e;
+  border: 1px solid #7c6bff;
+  border-radius: 8px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.td-editor-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.td-editor-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #a99bff;
+}
+
+.td-editor-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.td-editor-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.td-editor-field > span {
+  font-size: 12px;
+  color: #aaa;
+  font-weight: 500;
+}
+
+.td-editor-field select,
+.td-editor-field input[type="text"] {
+  padding: 6px 10px;
+  background: #0d0d1a;
+  border: 1px solid #444;
+  border-radius: 5px;
+  color: #e0e0e0;
+  font-size: 13px;
+  outline: none;
+  transition: border-color 0.12s;
+}
+
+.td-editor-field select:focus,
+.td-editor-field input[type="text"]:focus {
+  border-color: #7c6bff;
+}
+
+.td-value-input {
+  font-family: "Consolas", "Monaco", monospace !important;
+}
+
+.td-trigger-name-input {
+  font-family: "Consolas", "Monaco", monospace;
+}
+
+.td-kind-radios,
+.td-timing-radios,
+.td-events-checks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.td-kind-radio,
+.td-timing-radio {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: #ccc;
+  cursor: pointer;
+}
+
+.td-body-textarea {
+  background: #0d0d1a;
+  border: 1px solid #444;
+  border-radius: 5px;
+  color: #e0e0e0;
+  font-size: 13px;
+  font-family: "Consolas", "Monaco", monospace;
+  padding: 8px 10px;
+  resize: vertical;
+  outline: none;
+  line-height: 1.6;
+  transition: border-color 0.12s;
+}
+
+.td-body-textarea:focus {
+  border-color: #7c6bff;
+}
+
+.td-hint {
+  font-size: 12px;
+  color: #888;
+  line-height: 1.5;
+}
+
+.td-hint code {
+  font-family: "Consolas", "Monaco", monospace;
+  background: rgba(255,255,255,0.06);
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+
+.td-editor-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: 4px;
+  border-top: 1px solid #333;
+}
+
+/* ── 4K: 2 列グリッド ───────────────────────────────────────────────────── */
+
+@media (min-width: 3840px) {
+  .td-list {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+    align-items: start;
+  }
+
+  .td-editor-card {
+    grid-column: 1 / -1;
+  }
+}
+
 /* ── インデックスタブ (β-3) ─────────────────────────────────────────────── */
 
 .indexes-tab2 {

--- a/designer/src/styles/table.css
+++ b/designer/src/styles/table.css
@@ -583,6 +583,13 @@
 
 /* ── エディタ本体 ──────────────────────────────────────────────────────── */
 
+.table-editor-content-area {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
 .table-editor-body {
   flex: 1;
   overflow-y: auto;
@@ -951,6 +958,185 @@
 
 /* ── DDLタブ ───────────────────────────────────────────────────────────── */
 
+/* ── DDL プレビュードロワー ────────────────────────────────────────────── */
+
+.ddl-drawer {
+  background: #14142a;
+  border-top: 1px solid #333;
+  flex-shrink: 0;
+}
+
+.ddl-drawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 20px;
+  cursor: pointer;
+  user-select: none;
+  transition: background 0.12s;
+  min-height: 38px;
+}
+
+.ddl-drawer-header:hover {
+  background: rgba(255,255,255,0.03);
+}
+
+.ddl-drawer-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: #aaa;
+  font-weight: 500;
+}
+
+.ddl-drawer-chevron {
+  font-size: 11px;
+  color: #666;
+  transition: transform 0.15s;
+}
+
+.ddl-drawer--open .ddl-drawer-header {
+  border-bottom: 1px solid #2a2a45;
+}
+
+.ddl-drawer-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.ddl-drawer-body {
+  padding: 12px 20px 16px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+/* 4K (≥3840px): content-area を横並びに、ドロワーを右サイドパネル化 */
+@media (min-width: 3840px) {
+  .table-editor-content-area {
+    flex-direction: row;
+  }
+
+  .table-editor-body {
+    flex: 1;
+  }
+
+  .ddl-drawer {
+    width: 480px;
+    border-top: none;
+    border-left: 1px solid #333;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .ddl-drawer-header {
+    border-bottom: 1px solid #2a2a45;
+    cursor: default;
+  }
+
+  .ddl-drawer-header:hover {
+    background: transparent;
+  }
+
+  .ddl-drawer--open .ddl-drawer-header {
+    border-bottom: 1px solid #2a2a45;
+  }
+
+  .ddl-drawer-body {
+    flex: 1;
+    max-height: none;
+    overflow-y: auto;
+  }
+}
+
+/* ── プレースホルダータブ ───────────────────────────────────────────────── */
+
+.placeholder-tab {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 60px 20px;
+  color: #666;
+  text-align: center;
+}
+
+.placeholder-tab-icon {
+  font-size: 40px;
+  color: #444;
+}
+
+.placeholder-tab-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: #888;
+  margin: 0;
+}
+
+.placeholder-tab-desc {
+  font-size: 13px;
+  color: #666;
+  max-width: 400px;
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* ── コメントタブ ──────────────────────────────────────────────────────── */
+
+.comment-tab {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 700px;
+}
+
+.comment-tab-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.comment-tab-field > span {
+  font-size: 13px;
+  color: #aaa;
+  font-weight: 500;
+}
+
+.comment-tab-textarea {
+  background: #1a1a2e;
+  border: 1px solid #444;
+  border-radius: 6px;
+  color: #e0e0e0;
+  font-size: 13px;
+  padding: 10px 12px;
+  resize: vertical;
+  outline: none;
+  line-height: 1.6;
+  font-family: inherit;
+  transition: border-color 0.12s;
+}
+
+.comment-tab-textarea:focus {
+  border-color: #7c6bff;
+}
+
+.comment-tab-hint {
+  font-size: 12px;
+  color: #666;
+  margin: 0;
+  line-height: 1.5;
+}
+
+.comment-tab-hint code {
+  font-family: "Consolas", "Monaco", monospace;
+  background: rgba(255,255,255,0.06);
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+
+/* (旧 DDL タブは DdlPreviewDrawer に移行済み、クラス定義は互換のため残す) */
 .ddl-tab {
   display: flex;
   flex-direction: column;

--- a/designer/src/styles/table.css
+++ b/designer/src/styles/table.css
@@ -1136,6 +1136,305 @@
   border-radius: 3px;
 }
 
+/* ── インデックスタブ (β-3) ─────────────────────────────────────────────── */
+
+.indexes-tab2 {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+}
+
+.indexes-toolbar2 {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.indexes-count {
+  font-size: 13px;
+  color: #888;
+}
+
+.indexes-empty2 {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 40px 20px;
+  color: #666;
+  text-align: center;
+}
+
+.indexes-empty-icon {
+  font-size: 36px;
+  color: #444;
+}
+
+.indexes-empty2 p {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.6;
+  max-width: 480px;
+}
+
+.indexes-empty2 code {
+  font-family: "Consolas", "Monaco", monospace;
+  background: rgba(255,255,255,0.06);
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+
+.indexes-list2 {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.index-row2 {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 14px;
+  background: #1e1e38;
+  border: 1px solid #333;
+  border-radius: 7px;
+  transition: border-color 0.12s;
+}
+
+.index-row2:hover {
+  border-color: #555;
+}
+
+.index-row-main {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.index-unique-badge {
+  display: inline-block;
+  padding: 1px 7px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 700;
+  background: rgba(100, 180, 255, 0.15);
+  color: #64b4ff;
+  border: 1px solid rgba(100, 180, 255, 0.3);
+  white-space: nowrap;
+}
+
+.index-method-badge {
+  display: inline-block;
+  padding: 1px 7px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 700;
+  background: rgba(200, 160, 255, 0.15);
+  color: #c8a0ff;
+  border: 1px solid rgba(200, 160, 255, 0.3);
+}
+
+.index-row-id {
+  font-family: "Consolas", "Monaco", monospace;
+  font-size: 13px;
+  color: #ddd;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.index-row-desc {
+  font-size: 12px;
+  color: #888;
+}
+
+.index-row-summary {
+  display: flex;
+  gap: 16px;
+  font-size: 12px;
+  color: #999;
+  font-family: "Consolas", "Monaco", monospace;
+}
+
+.index-row-where {
+  color: #ffc850;
+}
+
+.index-row-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 4px;
+  justify-content: flex-end;
+}
+
+/* ── インデックス編集カード ────────────────────────────────────────────────── */
+
+.index-editor-card {
+  background: #1a1a2e;
+  border: 1px solid #7c6bff;
+  border-radius: 8px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.index-editor-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.index-editor-name-wrap {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
+}
+
+.index-editor-label {
+  font-size: 12px;
+  color: #888;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.index-name-input2 {
+  flex: 1;
+  min-width: 0;
+  padding: 5px 8px;
+  background: #0d0d1a;
+  border: 1px solid #444;
+  border-radius: 5px;
+  color: #e0e0e0;
+  font-size: 13px;
+  font-family: "Consolas", "Monaco", monospace;
+  outline: none;
+}
+
+.index-name-input2:focus {
+  border-color: #7c6bff;
+}
+
+.index-editor-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.index-editor-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.index-editor-field > span {
+  font-size: 12px;
+  color: #aaa;
+  font-weight: 500;
+}
+
+.index-editor-field select,
+.index-editor-field input[type="text"] {
+  padding: 6px 10px;
+  background: #0d0d1a;
+  border: 1px solid #444;
+  border-radius: 5px;
+  color: #e0e0e0;
+  font-size: 13px;
+  outline: none;
+  transition: border-color 0.12s;
+}
+
+.index-editor-field select:focus,
+.index-editor-field input[type="text"]:focus {
+  border-color: #7c6bff;
+}
+
+.index-where-input {
+  font-family: "Consolas", "Monaco", monospace !important;
+}
+
+.index-columns-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.index-col-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.index-col-select {
+  flex: 1;
+  padding: 5px 8px;
+  background: #0d0d1a;
+  border: 1px solid #444;
+  border-radius: 5px;
+  color: #e0e0e0;
+  font-size: 13px;
+  outline: none;
+}
+
+.index-col-select:focus {
+  border-color: #7c6bff;
+}
+
+.index-order-select {
+  width: 80px;
+  padding: 5px 8px;
+  background: #0d0d1a;
+  border: 1px solid #444;
+  border-radius: 5px;
+  color: #e0e0e0;
+  font-size: 13px;
+  outline: none;
+}
+
+.index-order-select:focus {
+  border-color: #7c6bff;
+}
+
+.index-method-select {
+  width: 120px;
+}
+
+.index-editor-flags {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.index-editor-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: 4px;
+  border-top: 1px solid #333;
+}
+
+/* ── 4K: インデックス一覧 2 列グリッド ──────────────────────────────────── */
+
+@media (min-width: 3840px) {
+  .indexes-list2 {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+    align-items: start;
+  }
+
+  .index-editor-card {
+    grid-column: 1 / -1;
+  }
+}
+
 /* ── 制約タブ (β-2) ─────────────────────────────────────────────────────── */
 
 .constraints-tab {

--- a/designer/src/types/table.ts
+++ b/designer/src/types/table.ts
@@ -85,6 +85,16 @@ export interface TableIndex {
   unique: boolean;
 }
 
+// ── β-2〜4 スロット型 (各 ISSUE で詳細定義) ──────────────────────────────
+
+/** CHECK 制約等の定義スロット (β-2 ISSUE で詳細化) */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ConstraintDefinition = Record<string, any>;
+
+/** トリガー定義スロット (β-4 ISSUE で詳細化) */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type TriggerDefinition = Record<string, any>;
+
 /** テーブル定義（完全データ） */
 export interface TableDefinition {
   id: string;
@@ -94,6 +104,12 @@ export interface TableDefinition {
   category?: string;
   columns: TableColumn[];
   indexes: TableIndex[];
+  /** テーブルコメント (β-1 追加) */
+  comment?: string;
+  /** 制約定義 (β-2 で中身を実装) */
+  constraints?: ConstraintDefinition[];
+  /** トリガー定義 (β-4 で中身を実装) */
+  triggers?: TriggerDefinition[];
   createdAt: string;
   updatedAt: string;
 }

--- a/designer/src/types/table.ts
+++ b/designer/src/types/table.ts
@@ -137,9 +137,30 @@ export interface ForeignKeyConstraint {
 
 export type ConstraintDefinition = UniqueConstraint | CheckConstraint | ForeignKeyConstraint;
 
-/** トリガー定義スロット (β-4 ISSUE で詳細化) */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type TriggerDefinition = Record<string, any>;
+// ── β-4 トリガー / DEFAULT 型 ────────────────────────────────────────────
+
+export type TriggerTiming = "BEFORE" | "AFTER";
+export type TriggerEvent = "INSERT" | "UPDATE" | "DELETE";
+
+/** トリガー定義 */
+export interface TriggerDefinition {
+  id: string;
+  timing: TriggerTiming;
+  events: TriggerEvent[];
+  whenCondition?: string;
+  body: string;
+  description?: string;
+}
+
+export type DefaultKind = "literal" | "function" | "sequence" | "conventionRef";
+
+/** 列 DEFAULT 値定義 */
+export interface DefaultDefinition {
+  column: string;
+  kind: DefaultKind;
+  value: string;
+  description?: string;
+}
 
 /** テーブル定義（完全データ） */
 export interface TableDefinition {
@@ -152,9 +173,11 @@ export interface TableDefinition {
   indexes: IndexDefinition[];
   /** テーブルコメント (β-1 追加) */
   comment?: string;
-  /** 制約定義 (β-2 で中身を実装) */
+  /** 制約定義 (β-2) */
   constraints?: ConstraintDefinition[];
-  /** トリガー定義 (β-4 で中身を実装) */
+  /** DEFAULT 値定義 (β-4) */
+  defaults?: DefaultDefinition[];
+  /** トリガー定義 (β-4) */
   triggers?: TriggerDefinition[];
   createdAt: string;
   updatedAt: string;

--- a/designer/src/types/table.ts
+++ b/designer/src/types/table.ts
@@ -128,6 +128,7 @@ export interface ForeignKeyConstraint {
   id: string;
   kind: "foreignKey";
   columns: string[];
+  /** テーブル名 (物理名) */
   referencedTable: string;
   referencedColumns: string[];
   onDelete?: FkAction;

--- a/designer/src/types/table.ts
+++ b/designer/src/types/table.ts
@@ -85,11 +85,39 @@ export interface TableIndex {
   unique: boolean;
 }
 
-// ── β-2〜4 スロット型 (各 ISSUE で詳細定義) ──────────────────────────────
+// ── β-2 制約型 ──────────────────────────────────────────────────────────
 
-/** CHECK 制約等の定義スロット (β-2 ISSUE で詳細化) */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type ConstraintDefinition = Record<string, any>;
+/** UNIQUE 制約 */
+export interface UniqueConstraint {
+  id: string;
+  kind: "unique";
+  columns: string[];
+  description?: string;
+}
+
+/** CHECK 制約 */
+export interface CheckConstraint {
+  id: string;
+  kind: "check";
+  expression: string;
+  description?: string;
+}
+
+export type FkAction = "CASCADE" | "SET NULL" | "SET DEFAULT" | "RESTRICT" | "NO ACTION";
+
+/** FOREIGN KEY 制約 */
+export interface ForeignKeyConstraint {
+  id: string;
+  kind: "foreignKey";
+  columns: string[];
+  referencedTable: string;
+  referencedColumns: string[];
+  onDelete?: FkAction;
+  onUpdate?: FkAction;
+  description?: string;
+}
+
+export type ConstraintDefinition = UniqueConstraint | CheckConstraint | ForeignKeyConstraint;
 
 /** トリガー定義スロット (β-4 ISSUE で詳細化) */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/designer/src/types/table.ts
+++ b/designer/src/types/table.ts
@@ -77,7 +77,25 @@ export interface TableColumn {
   comment?: string;
 }
 
+/** インデックス列 */
+export interface IndexColumn {
+  name: string;
+  order?: "asc" | "desc";
+}
+
+export type IndexMethod = "btree" | "hash" | "gin" | "gist";
+
 /** インデックス定義 */
+export interface IndexDefinition {
+  id: string;
+  columns: IndexColumn[];
+  unique?: boolean;
+  method?: IndexMethod;
+  where?: string;
+  description?: string;
+}
+
+/** @deprecated β-3 前の旧型。IndexDefinition を使用してください */
 export interface TableIndex {
   id: string;
   name: string;
@@ -131,7 +149,7 @@ export interface TableDefinition {
   description: string;
   category?: string;
   columns: TableColumn[];
-  indexes: TableIndex[];
+  indexes: IndexDefinition[];
   /** テーブルコメント (β-1 追加) */
   comment?: string;
   /** 制約定義 (β-2 で中身を実装) */

--- a/designer/src/utils/ddlGenerator.test.ts
+++ b/designer/src/utils/ddlGenerator.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import { generateDdl } from "./ddlGenerator";
+import type { TableDefinition } from "../types/table";
+
+function baseTable(overrides: Partial<TableDefinition> = {}): TableDefinition {
+  return {
+    id: "t1",
+    name: "orders",
+    logicalName: "受注",
+    description: "",
+    columns: [
+      {
+        id: "c1", no: 1, name: "id", logicalName: "ID",
+        dataType: "INTEGER", notNull: true, primaryKey: true, unique: false, autoIncrement: true,
+      },
+      {
+        id: "c2", no: 2, name: "amount", logicalName: "金額",
+        dataType: "DECIMAL", length: 12, scale: 2, notNull: true, primaryKey: false, unique: false,
+      },
+      {
+        id: "c3", no: 3, name: "supplier_id", logicalName: "仕入先ID",
+        dataType: "INTEGER", notNull: true, primaryKey: false, unique: false,
+      },
+      {
+        id: "c4", no: 4, name: "po_number", logicalName: "発注番号",
+        dataType: "VARCHAR", length: 50, notNull: true, primaryKey: false, unique: false,
+      },
+    ],
+    indexes: [],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("generateDdl — constraints (β-2)", () => {
+  it("UNIQUE 制約が ALTER TABLE ... ADD CONSTRAINT ... UNIQUE として出力される", () => {
+    const table = baseTable({
+      constraints: [
+        { id: "uq_po_number", kind: "unique", columns: ["po_number"] },
+      ],
+    });
+    const ddl = generateDdl(table, "postgresql");
+    expect(ddl).toContain("ALTER TABLE orders ADD CONSTRAINT uq_po_number UNIQUE (po_number);");
+  });
+
+  it("CHECK 制約が ALTER TABLE ... ADD CONSTRAINT ... CHECK として出力される", () => {
+    const table = baseTable({
+      constraints: [
+        { id: "chk_amount_positive", kind: "check", expression: "amount > 0" },
+      ],
+    });
+    const ddl = generateDdl(table, "postgresql");
+    expect(ddl).toContain("ALTER TABLE orders ADD CONSTRAINT chk_amount_positive CHECK (amount > 0);");
+  });
+
+  it("FOREIGN KEY 制約が ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY として出力される", () => {
+    const table = baseTable({
+      constraints: [
+        {
+          id: "fk_orders_supplier",
+          kind: "foreignKey",
+          columns: ["supplier_id"],
+          referencedTable: "suppliers",
+          referencedColumns: ["id"],
+          onDelete: "RESTRICT",
+        },
+      ],
+    });
+    const ddl = generateDdl(table, "postgresql");
+    expect(ddl).toContain("ALTER TABLE orders ADD CONSTRAINT fk_orders_supplier");
+    expect(ddl).toContain("FOREIGN KEY (supplier_id) REFERENCES suppliers(id)");
+    expect(ddl).toContain("ON DELETE RESTRICT");
+  });
+
+  it("FK に onUpdate が指定された場合は ON UPDATE も出力される", () => {
+    const table = baseTable({
+      constraints: [
+        {
+          id: "fk_cascade",
+          kind: "foreignKey",
+          columns: ["supplier_id"],
+          referencedTable: "suppliers",
+          referencedColumns: ["id"],
+          onDelete: "CASCADE",
+          onUpdate: "CASCADE",
+        },
+      ],
+    });
+    const ddl = generateDdl(table, "postgresql");
+    expect(ddl).toContain("ON DELETE CASCADE");
+    expect(ddl).toContain("ON UPDATE CASCADE");
+  });
+
+  it("FK に onDelete / onUpdate が未指定の場合は ON DELETE / ON UPDATE を出力しない", () => {
+    const table = baseTable({
+      constraints: [
+        {
+          id: "fk_bare",
+          kind: "foreignKey",
+          columns: ["supplier_id"],
+          referencedTable: "suppliers",
+          referencedColumns: ["id"],
+        },
+      ],
+    });
+    const ddl = generateDdl(table, "postgresql");
+    expect(ddl).not.toContain("ON DELETE");
+    expect(ddl).not.toContain("ON UPDATE");
+  });
+
+  it("constraints が未定義の場合は ALTER TABLE を出力しない", () => {
+    const table = baseTable();
+    const ddl = generateDdl(table, "postgresql");
+    expect(ddl).not.toContain("ALTER TABLE");
+  });
+
+  it("複数制約が順序通り出力される", () => {
+    const table = baseTable({
+      constraints: [
+        { id: "uq_po_number", kind: "unique", columns: ["po_number"] },
+        { id: "chk_amount", kind: "check", expression: "amount > 0" },
+      ],
+    });
+    const ddl = generateDdl(table, "postgresql");
+    const uqPos = ddl.indexOf("uq_po_number");
+    const chkPos = ddl.indexOf("chk_amount");
+    expect(uqPos).toBeGreaterThan(-1);
+    expect(chkPos).toBeGreaterThan(-1);
+    expect(uqPos).toBeLessThan(chkPos);
+  });
+
+  it("MySQL でも同じ ALTER TABLE 構文が出力される", () => {
+    const table = baseTable({
+      constraints: [
+        { id: "uq_po", kind: "unique", columns: ["po_number"] },
+      ],
+    });
+    const ddl = generateDdl(table, "mysql");
+    expect(ddl).toContain("ALTER TABLE orders ADD CONSTRAINT uq_po UNIQUE (po_number);");
+  });
+});

--- a/designer/src/utils/ddlGenerator.test.ts
+++ b/designer/src/utils/ddlGenerator.test.ts
@@ -246,3 +246,110 @@ describe("generateDdl — indexes (β-3)", () => {
     expect(ddl).not.toContain("CREATE INDEX");
   });
 });
+
+describe("generateDdl — defaults (β-4)", () => {
+  it("literal DEFAULT が ALTER TABLE SET DEFAULT として出力される", () => {
+    const table = baseTable({
+      defaults: [{ column: "amount", kind: "literal", value: "0" }],
+    });
+    const ddl = generateDdl(table, "postgresql");
+    expect(ddl).toContain("ALTER TABLE orders ALTER COLUMN amount SET DEFAULT 0;");
+  });
+
+  it("function DEFAULT が ALTER TABLE SET DEFAULT として出力される", () => {
+    const table = baseTable({
+      defaults: [{ column: "created_at", kind: "function", value: "NOW()" }],
+    });
+    const ddl = generateDdl(table, "postgresql");
+    expect(ddl).toContain("ALTER TABLE orders ALTER COLUMN created_at SET DEFAULT NOW();");
+  });
+
+  it("sequence DEFAULT が PostgreSQL で nextval() を使用する", () => {
+    const table = baseTable({
+      defaults: [{ column: "id", kind: "sequence", value: "orders_id_seq" }],
+    });
+    const ddl = generateDdl(table, "postgresql");
+    expect(ddl).toContain("SET DEFAULT nextval('orders_id_seq');");
+  });
+
+  it("conventionRef DEFAULT が DEFAULT NULL /* @conv.* */ として出力される", () => {
+    const table = baseTable({
+      defaults: [{ column: "po_number", kind: "conventionRef", value: "@conv.numbering.orderNumber" }],
+    });
+    const ddl = generateDdl(table, "postgresql");
+    expect(ddl).toContain("SET DEFAULT NULL /* @conv.numbering.orderNumber */;");
+  });
+
+  it("defaults が未定義の場合は ALTER TABLE ALTER COLUMN を出力しない", () => {
+    const table = baseTable();
+    const ddl = generateDdl(table, "postgresql");
+    expect(ddl).not.toContain("ALTER COLUMN");
+  });
+});
+
+describe("generateDdl — triggers (β-4)", () => {
+  it("PostgreSQL トリガーが CREATE FUNCTION + CREATE TRIGGER として出力される", () => {
+    const table = baseTable({
+      triggers: [{
+        id: "trg_po_number",
+        timing: "BEFORE",
+        events: ["INSERT"],
+        body: "NEW.po_number := 'ORD-001';",
+        description: "発注番号採番",
+      }],
+    });
+    const ddl = generateDdl(table, "postgresql");
+    expect(ddl).toContain("CREATE OR REPLACE FUNCTION trg_po_number_fn()");
+    expect(ddl).toContain("CREATE TRIGGER trg_po_number");
+    expect(ddl).toContain("BEFORE INSERT ON orders");
+    expect(ddl).toContain("FOR EACH ROW EXECUTE FUNCTION trg_po_number_fn();");
+  });
+
+  it("複数イベントが OR 区切りで出力される", () => {
+    const table = baseTable({
+      triggers: [{
+        id: "trg_audit",
+        timing: "AFTER",
+        events: ["INSERT", "UPDATE"],
+        body: "-- audit",
+      }],
+    });
+    const ddl = generateDdl(table, "postgresql");
+    expect(ddl).toContain("AFTER INSERT OR UPDATE ON orders");
+  });
+
+  it("WHEN 句が指定された場合は WHEN (条件) として出力される", () => {
+    const table = baseTable({
+      triggers: [{
+        id: "trg_cond",
+        timing: "BEFORE",
+        events: ["UPDATE"],
+        whenCondition: "NEW.status IS DISTINCT FROM OLD.status",
+        body: "-- status changed",
+      }],
+    });
+    const ddl = generateDdl(table, "postgresql");
+    expect(ddl).toContain("WHEN (NEW.status IS DISTINCT FROM OLD.status)");
+  });
+
+  it("MySQL ではシンプルな CREATE TRIGGER を出力する", () => {
+    const table = baseTable({
+      triggers: [{
+        id: "trg_simple",
+        timing: "BEFORE",
+        events: ["INSERT"],
+        body: "SET NEW.created_at = NOW();",
+      }],
+    });
+    const ddl = generateDdl(table, "mysql");
+    expect(ddl).toContain("CREATE TRIGGER trg_simple");
+    expect(ddl).toContain("BEFORE INSERT ON orders");
+    expect(ddl).not.toContain("CREATE OR REPLACE FUNCTION");
+  });
+
+  it("triggers が未定義の場合は CREATE TRIGGER を出力しない", () => {
+    const table = baseTable();
+    const ddl = generateDdl(table, "postgresql");
+    expect(ddl).not.toContain("CREATE TRIGGER");
+  });
+});

--- a/designer/src/utils/ddlGenerator.test.ts
+++ b/designer/src/utils/ddlGenerator.test.ts
@@ -140,3 +140,109 @@ describe("generateDdl — constraints (β-2)", () => {
     expect(ddl).toContain("ALTER TABLE orders ADD CONSTRAINT uq_po UNIQUE (po_number);");
   });
 });
+
+describe("generateDdl — indexes (β-3)", () => {
+  it("シンプルなインデックスが CREATE INDEX として出力される", () => {
+    const table = baseTable({
+      indexes: [
+        { id: "idx_orders_created_at", columns: [{ name: "created_at" }] },
+      ],
+    });
+    const ddl = generateDdl(table, "postgresql");
+    expect(ddl).toContain("CREATE INDEX idx_orders_created_at ON orders (created_at);");
+  });
+
+  it("UNIQUE インデックスが CREATE UNIQUE INDEX として出力される", () => {
+    const table = baseTable({
+      indexes: [
+        { id: "idx_uq_po_number", columns: [{ name: "po_number" }], unique: true },
+      ],
+    });
+    const ddl = generateDdl(table, "postgresql");
+    expect(ddl).toContain("CREATE UNIQUE INDEX idx_uq_po_number ON orders (po_number);");
+  });
+
+  it("複合インデックスがカンマ区切りで出力される", () => {
+    const table = baseTable({
+      indexes: [
+        {
+          id: "idx_supplier_status",
+          columns: [{ name: "supplier_id" }, { name: "amount" }],
+        },
+      ],
+    });
+    const ddl = generateDdl(table, "postgresql");
+    expect(ddl).toContain("(supplier_id, amount)");
+  });
+
+  it("DESC 列が DESC 付きで出力される", () => {
+    const table = baseTable({
+      indexes: [
+        { id: "idx_amount_desc", columns: [{ name: "amount", order: "desc" }] },
+      ],
+    });
+    const ddl = generateDdl(table, "postgresql");
+    expect(ddl).toContain("(amount DESC)");
+  });
+
+  it("ASC 列は何も付かない", () => {
+    const table = baseTable({
+      indexes: [
+        { id: "idx_amount_asc", columns: [{ name: "amount", order: "asc" }] },
+      ],
+    });
+    const ddl = generateDdl(table, "postgresql");
+    expect(ddl).toContain("(amount)");
+    expect(ddl).not.toContain("ASC");
+  });
+
+  it("WHERE 句が指定された場合は部分インデックスとして出力される", () => {
+    const table = baseTable({
+      indexes: [
+        {
+          id: "idx_partial",
+          columns: [{ name: "supplier_id" }],
+          where: "amount > 0",
+        },
+      ],
+    });
+    const ddl = generateDdl(table, "postgresql");
+    expect(ddl).toContain("WHERE amount > 0");
+  });
+
+  it("PostgreSQL + hash メソッドが USING HASH として出力される", () => {
+    const table = baseTable({
+      indexes: [
+        { id: "idx_hash", columns: [{ name: "po_number" }], method: "hash" },
+      ],
+    });
+    const ddl = generateDdl(table, "postgresql");
+    expect(ddl).toContain("USING HASH");
+  });
+
+  it("btree メソッドは USING 句を出力しない", () => {
+    const table = baseTable({
+      indexes: [
+        { id: "idx_btree", columns: [{ name: "amount" }], method: "btree" },
+      ],
+    });
+    const ddl = generateDdl(table, "postgresql");
+    expect(ddl).not.toContain("USING");
+  });
+
+  it("MySQL では USING を出力しない (btree 以外でも)", () => {
+    const table = baseTable({
+      indexes: [
+        { id: "idx_hash_mysql", columns: [{ name: "amount" }], method: "hash" },
+      ],
+    });
+    const ddl = generateDdl(table, "mysql");
+    expect(ddl).not.toContain("USING");
+  });
+
+  it("indexes が空の場合は CREATE INDEX を出力しない", () => {
+    const table = baseTable();
+    const ddl = generateDdl(table, "postgresql");
+    expect(ddl).not.toContain("CREATE INDEX");
+  });
+});

--- a/designer/src/utils/ddlGenerator.ts
+++ b/designer/src/utils/ddlGenerator.ts
@@ -3,7 +3,7 @@
  * テーブル定義から DDL (CREATE TABLE) を生成するユーティリティ
  * MySQL / PostgreSQL / Oracle / SQLite / 標準SQL に対応
  */
-import type { TableDefinition, SqlDialect, ConstraintDefinition, FkAction } from "../types/table";
+import type { TableDefinition, SqlDialect, ConstraintDefinition, FkAction, DefaultDefinition, TriggerDefinition } from "../types/table";
 
 export function generateDdl(table: TableDefinition, dialect: SqlDialect): string {
   const colDefs: string[] = [];
@@ -63,6 +63,16 @@ export function generateDdl(table: TableDefinition, dialect: SqlDialect): string
   // ALTER TABLE constraints (β-2)
   for (const c of table.constraints ?? []) {
     ddl += `\n\n${constraintToDdl(table.name, c, dialect)}`;
+  }
+
+  // DEFAULT 値定義 (β-4) — ALTER TABLE SET DEFAULT
+  for (const def of table.defaults ?? []) {
+    ddl += `\n\n${defaultToDdl(table.name, def, dialect)}`;
+  }
+
+  // トリガー定義 (β-4)
+  for (const trg of table.triggers ?? []) {
+    ddl += `\n\n${triggerToDdl(table.name, trg, dialect)}`;
   }
 
   // Comments for PostgreSQL / Oracle
@@ -200,6 +210,53 @@ function constraintToDdl(tableName: string, c: ConstraintDefinition, _dialect: S
 
 function fkActionSql(action: FkAction): string {
   return action;
+}
+
+function defaultToDdl(tableName: string, def: DefaultDefinition, dialect: SqlDialect): string {
+  let expr: string;
+  switch (def.kind) {
+    case "literal":
+    case "function":
+      expr = def.value;
+      break;
+    case "sequence":
+      expr = dialect === "postgresql"
+        ? `nextval('${def.value}')`
+        : def.value;
+      break;
+    case "conventionRef":
+      expr = `NULL /* ${def.value} */`;
+      break;
+  }
+  return `ALTER TABLE ${tableName} ALTER COLUMN ${def.column} SET DEFAULT ${expr};`;
+}
+
+function triggerToDdl(tableName: string, trg: TriggerDefinition, dialect: SqlDialect): string {
+  const events = trg.events.join(" OR ");
+  const when = trg.whenCondition ? `\n  WHEN (${trg.whenCondition})` : "";
+  if (dialect === "postgresql") {
+    const fnName = `${trg.id}_fn`;
+    return [
+      `CREATE OR REPLACE FUNCTION ${fnName}() RETURNS TRIGGER AS $$`,
+      `BEGIN`,
+      `  ${trg.body.split("\n").join("\n  ")}`,
+      `  RETURN NEW;`,
+      `END;`,
+      `$$ LANGUAGE plpgsql;`,
+      ``,
+      `CREATE TRIGGER ${trg.id}`,
+      `${trg.timing} ${events} ON ${tableName}${when}`,
+      `FOR EACH ROW EXECUTE FUNCTION ${fnName}();`,
+    ].join("\n");
+  }
+  return [
+    `CREATE TRIGGER ${trg.id}`,
+    `${trg.timing} ${events} ON ${tableName}${when}`,
+    `FOR EACH ROW`,
+    `BEGIN`,
+    `  ${trg.body.split("\n").join("\n  ")}`,
+    `END;`,
+  ].join("\n");
 }
 
 function autoIncrementType(dt: string, dialect: SqlDialect): string {

--- a/designer/src/utils/ddlGenerator.ts
+++ b/designer/src/utils/ddlGenerator.ts
@@ -47,12 +47,17 @@ export function generateDdl(table: TableDefinition, dialect: SqlDialect): string
 
   // Indexes
   for (const idx of table.indexes) {
-    const colNames = idx.columns.map((cid) => {
-      const c = table.columns.find((cc) => cc.id === cid);
-      return c ? c.name : cid;
-    });
+    const colList = idx.columns.map((ic) => {
+      const ord = ic.order === "desc" ? " DESC" : "";
+      return `${ic.name}${ord}`;
+    }).join(", ");
     const uniq = idx.unique ? "UNIQUE " : "";
-    ddl += `\n\nCREATE ${uniq}INDEX ${idx.name} ON ${table.name} (${colNames.join(", ")});`;
+    const method = idx.method && idx.method !== "btree" && dialect === "postgresql"
+      ? ` USING ${idx.method.toUpperCase()}`
+      : "";
+    let stmt = `CREATE ${uniq}INDEX ${idx.id} ON ${table.name}${method} (${colList})`;
+    if (idx.where) stmt += `\n  WHERE ${idx.where}`;
+    ddl += `\n\n${stmt};`;
   }
 
   // ALTER TABLE constraints (β-2)
@@ -109,15 +114,14 @@ export function generateTableMarkdown(table: TableDefinition): string {
   if (table.indexes.length > 0) {
     lines.push("", "**インデックス**", "");
     lines.push(
-      "| インデックス名 | カラム | ユニーク |",
-      "|-------------|--------|---------|",
+      "| インデックス名 | カラム | ユニーク | WHERE |",
+      "|-------------|--------|---------|-------|",
     );
     for (const idx of table.indexes) {
-      const colNames = idx.columns.map((cid) => {
-        const c = table.columns.find((cc) => cc.id === cid);
-        return c ? c.name : cid;
-      });
-      lines.push(`| ${idx.name} | ${colNames.join(", ")} | ${idx.unique ? "✓" : ""} |`);
+      const colList = idx.columns.map((ic) =>
+        `${ic.name}${ic.order === "desc" ? " DESC" : ""}`
+      ).join(", ");
+      lines.push(`| ${idx.id} | ${colList} | ${idx.unique ? "✓" : ""} | ${idx.where ?? ""} |`);
     }
   }
 

--- a/designer/src/utils/ddlGenerator.ts
+++ b/designer/src/utils/ddlGenerator.ts
@@ -3,7 +3,7 @@
  * テーブル定義から DDL (CREATE TABLE) を生成するユーティリティ
  * MySQL / PostgreSQL / Oracle / SQLite / 標準SQL に対応
  */
-import type { TableDefinition, SqlDialect, ConstraintDefinition, FkAction, DefaultDefinition, TriggerDefinition } from "../types/table";
+import type { TableDefinition, SqlDialect, ConstraintDefinition, DefaultDefinition, TriggerDefinition } from "../types/table";
 
 export function generateDdl(table: TableDefinition, dialect: SqlDialect): string {
   const colDefs: string[] = [];
@@ -201,15 +201,11 @@ function constraintToDdl(tableName: string, c: ConstraintDefinition, _dialect: S
       return `ALTER TABLE ${tableName} ADD CONSTRAINT ${c.id} CHECK (${c.expression});`;
     case "foreignKey": {
       let s = `ALTER TABLE ${tableName} ADD CONSTRAINT ${c.id}\n  FOREIGN KEY (${c.columns.join(", ")}) REFERENCES ${c.referencedTable}(${c.referencedColumns.join(", ")})`;
-      if (c.onDelete) s += `\n  ON DELETE ${fkActionSql(c.onDelete)}`;
-      if (c.onUpdate) s += `\n  ON UPDATE ${fkActionSql(c.onUpdate)}`;
+      if (c.onDelete) s += `\n  ON DELETE ${c.onDelete}`;
+      if (c.onUpdate) s += `\n  ON UPDATE ${c.onUpdate}`;
       return s + ";";
     }
   }
-}
-
-function fkActionSql(action: FkAction): string {
-  return action;
 }
 
 function defaultToDdl(tableName: string, def: DefaultDefinition, dialect: SqlDialect): string {
@@ -228,6 +224,9 @@ function defaultToDdl(tableName: string, def: DefaultDefinition, dialect: SqlDia
       expr = `NULL /* ${def.value} */`;
       break;
   }
+  if (dialect === "oracle") {
+    return `ALTER TABLE ${tableName} MODIFY (${def.column} DEFAULT ${expr});`;
+  }
   return `ALTER TABLE ${tableName} ALTER COLUMN ${def.column} SET DEFAULT ${expr};`;
 }
 
@@ -236,11 +235,14 @@ function triggerToDdl(tableName: string, trg: TriggerDefinition, dialect: SqlDia
   const when = trg.whenCondition ? `\n  WHEN (${trg.whenCondition})` : "";
   if (dialect === "postgresql") {
     const fnName = `${trg.id}_fn`;
+    const returnStmt = trg.events.length === 1 && trg.events[0] === "DELETE"
+      ? "RETURN OLD;"
+      : "RETURN NEW;";
     return [
       `CREATE OR REPLACE FUNCTION ${fnName}() RETURNS TRIGGER AS $$`,
       `BEGIN`,
       `  ${trg.body.split("\n").join("\n  ")}`,
-      `  RETURN NEW;`,
+      `  ${returnStmt}`,
       `END;`,
       `$$ LANGUAGE plpgsql;`,
       ``,

--- a/designer/src/utils/ddlGenerator.ts
+++ b/designer/src/utils/ddlGenerator.ts
@@ -3,7 +3,7 @@
  * テーブル定義から DDL (CREATE TABLE) を生成するユーティリティ
  * MySQL / PostgreSQL / Oracle / SQLite / 標準SQL に対応
  */
-import type { TableDefinition, SqlDialect } from "../types/table";
+import type { TableDefinition, SqlDialect, ConstraintDefinition, FkAction } from "../types/table";
 
 export function generateDdl(table: TableDefinition, dialect: SqlDialect): string {
   const colDefs: string[] = [];
@@ -53,6 +53,11 @@ export function generateDdl(table: TableDefinition, dialect: SqlDialect): string
     });
     const uniq = idx.unique ? "UNIQUE " : "";
     ddl += `\n\nCREATE ${uniq}INDEX ${idx.name} ON ${table.name} (${colNames.join(", ")});`;
+  }
+
+  // ALTER TABLE constraints (β-2)
+  for (const c of table.constraints ?? []) {
+    ddl += `\n\n${constraintToDdl(table.name, c, dialect)}`;
   }
 
   // Comments for PostgreSQL / Oracle
@@ -172,6 +177,25 @@ function mapDataType(dt: string, length?: number, scale?: number, dialect?: SqlD
       return "TEXT";
     default: return dt;
   }
+}
+
+function constraintToDdl(tableName: string, c: ConstraintDefinition, _dialect: SqlDialect): string {
+  switch (c.kind) {
+    case "unique":
+      return `ALTER TABLE ${tableName} ADD CONSTRAINT ${c.id} UNIQUE (${c.columns.join(", ")});`;
+    case "check":
+      return `ALTER TABLE ${tableName} ADD CONSTRAINT ${c.id} CHECK (${c.expression});`;
+    case "foreignKey": {
+      let s = `ALTER TABLE ${tableName} ADD CONSTRAINT ${c.id}\n  FOREIGN KEY (${c.columns.join(", ")}) REFERENCES ${c.referencedTable}(${c.referencedColumns.join(", ")})`;
+      if (c.onDelete) s += `\n  ON DELETE ${fkActionSql(c.onDelete)}`;
+      if (c.onUpdate) s += `\n  ON UPDATE ${fkActionSql(c.onUpdate)}`;
+      return s + ";";
+    }
+  }
+}
+
+function fkActionSql(action: FkAction): string {
+  return action;
 }
 
 function autoIncrementType(dt: string, dialect: SqlDialect): string {

--- a/designer/src/utils/ddlGenerator.ts
+++ b/designer/src/utils/ddlGenerator.ts
@@ -57,8 +57,9 @@ export function generateDdl(table: TableDefinition, dialect: SqlDialect): string
 
   // Comments for PostgreSQL / Oracle
   if (dialect === "postgresql" || dialect === "oracle") {
-    if (table.logicalName) {
-      ddl += `\n\nCOMMENT ON TABLE ${table.name} IS '${table.logicalName.replace(/'/g, "''")}';`;
+    const tableComment = table.comment || table.logicalName;
+    if (tableComment) {
+      ddl += `\n\nCOMMENT ON TABLE ${table.name} IS '${tableComment.replace(/'/g, "''")}';`;
     }
     for (const col of table.columns) {
       const cmt = col.comment || col.logicalName;

--- a/designer/src/utils/specExporter.ts
+++ b/designer/src/utils/specExporter.ts
@@ -228,12 +228,9 @@ function toSpecTable(t: TableDefinition): SpecTable {
       return col;
     }),
     indexes: t.indexes.map((idx) => ({
-      name: idx.name,
-      columns: idx.columns.map((cid) => {
-        const col = t.columns.find((cc) => cc.id === cid);
-        return col ? col.name : cid;
-      }),
-      unique: idx.unique,
+      name: idx.id,
+      columns: idx.columns.map((ic) => ic.name),
+      unique: idx.unique ?? false,
     })),
   };
 }


### PR DESCRIPTION
## 概要

テーブル定義エディタの β-1〜4 (Supabase 式インライン編集) を一括実装。

Closes #370
Closes #371
Closes #372
Closes #373

## 変更内容

### β-1: テーブル基本情報編集 (#370)
- テーブル名・論理名・カテゴリ・説明・コメントのインライン編集
- DdlPreviewDrawer: 右サイドパネルで DDL リアルタイムプレビュー
- DDL ダイアレクト切替 (MySQL / PostgreSQL / Oracle / SQLite / 標準SQL)

### β-2: 制約タブ (#371)
- `ConstraintsTab`: UNIQUE / CHECK / FOREIGN KEY の 3 種をインライン編集
- `ConstraintDefinition` 型を discriminated union に変更
- 制約 ID を `con_<table>_<N>` 形式で生成 (UUID は SQL 構文エラーになるため)
- DDL: `ALTER TABLE ADD CONSTRAINT` 形式で出力

### β-3: インデックスタブ (#372)
- `IndexesTab`: インデックス行 + 展開型インラインエディタ
- `IndexDefinition` 型を新設 (旧 `TableIndex` は deprecated)
- 列名・ASC/DESC・UNIQUE・アクセスメソッド・WHERE 句・説明
- DDL: `CREATE [UNIQUE] INDEX ... [USING METHOD] [(cols)] [WHERE ...]`
- `loadTable` で旧 `TableIndex` (columns: string[]) → `IndexDefinition` 移行
- MCP の DDL/export_spec も dual-format 対応

### β-4: トリガー/DEFAULT タブ (#373)
- `TriggersDefaultsTab`: DEFAULT 値定義 + トリガー定義の 2 セクション
- `DefaultDefinition`: literal / function / sequence / conventionRef の 4 種
- `TriggerDefinition`: timing × events × WHEN × body
- DDL: PostgreSQL = `CREATE FUNCTION + CREATE TRIGGER`; その他 = シンプル形式
- conventionRef は `NULL /* @conv.* */` としてコメント出力

## レビュー指摘対応

| # | 種別 | 内容 | 対応 |
|---|------|------|------|
| M-1 | Must | 旧 `TableIndex` → `IndexDefinition` 移行 | ✅ |
| M-2 | Must | MCP DDL で旧 string[] 列 ID 形式に dual-format 対応 | ✅ |
| M-3 | Must | 制約 ID を UUID → `con_<table>_<N>` 形式に変更 | ✅ |
| S-1 | Should | 不要な `PlaceholderTab` 関数を削除 | ✅ |
| S-2 | Should | `fkActionSql` ヘルパーを削除 | ✅ |
| S-3 | Should | DELETE 専用トリガーは `RETURN OLD` に修正 | ✅ |
| S-4 | Should | Oracle DEFAULT は `ALTER TABLE MODIFY ()` 構文に対応 | ✅ |
| S-5 | Should | `origin/main` に rebase | ✅ |
| S-3' | Should | MCP `generate_ddl` に制約・DEFAULT・トリガーの DDL 出力追加 | ✅ |
| N-1 | Nit | `DdlPreviewDrawer` の不要な `key` prop を削除 | ✅ |
| N-3 | Nit | `table.constraints!` 非 null アサーションを `?.` に変更 | ✅ |
| N-4 | Nit | `ForeignKeyConstraint.referencedTable` にコメント追加 | ✅ |

## テスト

- `ddlGenerator.test.ts`: 28 テスト (β-2 制約 8 / β-3 インデックス 10 / β-4 DEFAULT 5 / β-4 トリガー 5)
- 全 692 テスト pass / `tsc -b` pass / designer-mcp `tsc --noEmit` pass

## 目視確認項目 (ユーザー確認要)

- [ ] 制約タブ: UNIQUE / CHECK / FK の追加・編集・削除・DDL 出力
- [ ] インデックスタブ: インデックス追加・列設定・メソッド・WHERE 句
- [ ] トリガー/DEFAULT タブ: DEFAULT 値定義・トリガー定義・DDL 出力
- [ ] 旧データ (β-3 前のインデックス) のマイグレーション動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)