### PR TITLE
fix(export): export_spec に β-2 制約・β-4 DEFAULT/トリガーを含める (#383)

### DIFF
--- a/designer-mcp/src/index.ts
+++ b/designer-mcp/src/index.ts
@@ -661,6 +661,9 @@ function createMcpServer(): Server {
                   unique: idx.unique,
                 };
               }),
+              ...((t.constraints as unknown[])?.length ? { constraints: t.constraints } : {}),
+              ...((t.defaults as unknown[])?.length ? { defaults: t.defaults } : {}),
+              ...((t.triggers as unknown[])?.length ? { triggers: t.triggers } : {}),
             };
           }),
           relations: [] as Array<Record<string, unknown>>,

--- a/designer-mcp/src/index.ts
+++ b/designer-mcp/src/index.ts
@@ -16,6 +16,7 @@ import { tools } from "./tools.js";
 import { handleAuthCheck, handlePropose } from "./aiRename.js";
 import { htmlToReact, toPascalCase } from "./reactExporter.js";
 import { readProject, readCustomBlocks, readTable, writeTable, deleteTable as deleteTableFile, writeProject, readErLayout, readActionGroup, writeActionGroup, deleteActionGroup as deleteActionGroupFile, listActionGroups as listActionGroupFiles } from "./projectStorage.js";
+import { mcpTableToSpecEntry } from "./specExport.js";
 
 // 常駐バックエンドなので停止 signal (SIGTERM/SIGINT/disconnect) のみ監視。
 // stdin は監視しない (#302: HTTP transport に統一、stdio 廃止)。
@@ -623,49 +624,7 @@ function createMcpServer(): Server {
         const spec: Record<string, unknown> = {
           projectName: specProject.name,
           generatedAt: new Date().toISOString(),
-          tables: specTables.map((t) => {
-            const cols = (t.columns ?? []) as Array<Record<string, unknown>>;
-            return {
-              name: t.name,
-              logicalName: t.logicalName,
-              description: t.description,
-              category: t.category,
-              columns: cols.map((c) => {
-                const col: Record<string, unknown> = {
-                  name: c.name, logicalName: c.logicalName, dataType: c.dataType,
-                  ...(c.length != null ? { length: c.length } : {}),
-                  ...(c.scale != null ? { scale: c.scale } : {}),
-                  notNull: c.notNull, primaryKey: c.primaryKey, unique: c.unique,
-                  ...(c.autoIncrement ? { autoIncrement: true } : {}),
-                  ...(c.defaultValue ? { defaultValue: c.defaultValue } : {}),
-                  ...(c.comment ? { comment: c.comment } : {}),
-                };
-                if (c.foreignKey) {
-                  const fk = c.foreignKey as { tableId: string; columnName: string; noConstraint?: boolean };
-                  col.reference = { table: fk.tableId, column: fk.columnName, type: fk.noConstraint ? "logical" : "physical" };
-                }
-                return col;
-              }),
-              indexes: ((t.indexes ?? []) as Array<Record<string, unknown>>).map((idx) => {
-                const rawCols = (idx.columns ?? []) as Array<string | { name?: string; order?: string }>;
-                const colNames = rawCols.map((c) => {
-                  if (typeof c === "string") {
-                    const col = cols.find((cc) => cc.id === c);
-                    return col ? col.name : c;
-                  }
-                  return (c as { name?: string }).name ?? "";
-                });
-                return {
-                  name: (idx.id ?? idx.name) as string,
-                  columns: colNames,
-                  unique: idx.unique,
-                };
-              }),
-              ...((t.constraints as unknown[])?.length ? { constraints: t.constraints } : {}),
-              ...((t.defaults as unknown[])?.length ? { defaults: t.defaults } : {}),
-              ...((t.triggers as unknown[])?.length ? { triggers: t.triggers } : {}),
-            };
-          }),
+          tables: specTables.map((t) => mcpTableToSpecEntry(t)),
           relations: [] as Array<Record<string, unknown>>,
           screens: ((specProject.screens ?? []) as Array<Record<string, unknown>>).map((s) => ({
             name: s.name, type: s.type, path: s.path, description: s.description, hasDesign: s.hasDesign,

--- a/designer-mcp/src/specExport.test.ts
+++ b/designer-mcp/src/specExport.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import { mcpTableToSpecEntry } from "./specExport.js";
+
+function makeRawTable(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "t1",
+    name: "orders",
+    logicalName: "注文",
+    description: "注文テーブル",
+    columns: [
+      { id: "c1", name: "id", logicalName: "ID", dataType: "INTEGER", notNull: true, primaryKey: true, unique: false, autoIncrement: true },
+      { id: "c2", name: "customer_id", logicalName: "顧客ID", dataType: "INTEGER", notNull: true, primaryKey: false, unique: false },
+    ],
+    indexes: [],
+    ...overrides,
+  };
+}
+
+describe("mcpTableToSpecEntry", () => {
+  it("基本フィールドが出力される", () => {
+    const result = mcpTableToSpecEntry(makeRawTable());
+    expect(result.name).toBe("orders");
+    expect(result.logicalName).toBe("注文");
+    expect((result.columns as unknown[]).length).toBe(2);
+  });
+
+  it("constraints/defaults/triggers が undefined のとき出力に含まれない", () => {
+    const result = mcpTableToSpecEntry(makeRawTable());
+    expect(result.constraints).toBeUndefined();
+    expect(result.defaults).toBeUndefined();
+    expect(result.triggers).toBeUndefined();
+  });
+
+  it("空配列のとき出力に含まれない", () => {
+    const result = mcpTableToSpecEntry(makeRawTable({ constraints: [], defaults: [], triggers: [] }));
+    expect(result.constraints).toBeUndefined();
+    expect(result.defaults).toBeUndefined();
+    expect(result.triggers).toBeUndefined();
+  });
+
+  it("UNIQUE 制約が出力に含まれる", () => {
+    const constraints = [{ id: "uq1", kind: "unique", columns: ["customer_id"], description: "一意制約" }];
+    const result = mcpTableToSpecEntry(makeRawTable({ constraints }));
+    expect(result.constraints).toEqual(constraints);
+  });
+
+  it("CHECK 制約が出力に含まれる", () => {
+    const constraints = [{ id: "ck1", kind: "check", expression: "amount > 0" }];
+    const result = mcpTableToSpecEntry(makeRawTable({ constraints }));
+    expect(result.constraints).toEqual(constraints);
+  });
+
+  it("FOREIGN KEY 制約が出力に含まれる", () => {
+    const constraints = [{
+      id: "fk1", kind: "foreignKey",
+      columns: ["customer_id"], referencedTable: "customers", referencedColumns: ["id"],
+      onDelete: "CASCADE",
+    }];
+    const result = mcpTableToSpecEntry(makeRawTable({ constraints }));
+    expect((result.constraints as typeof constraints)[0]).toMatchObject({ kind: "foreignKey", onDelete: "CASCADE" });
+  });
+
+  it("DEFAULT 定義が出力に含まれる", () => {
+    const defaults = [
+      { column: "created_at", kind: "function", value: "NOW()" },
+      { column: "status", kind: "literal", value: "'active'" },
+    ];
+    const result = mcpTableToSpecEntry(makeRawTable({ defaults }));
+    expect(result.defaults).toEqual(defaults);
+  });
+
+  it("トリガー定義が出力に含まれる", () => {
+    const triggers = [{
+      id: "tr1", timing: "BEFORE", events: ["INSERT", "UPDATE"],
+      body: "SET NEW.updated_at = NOW();",
+    }];
+    const result = mcpTableToSpecEntry(makeRawTable({ triggers }));
+    expect(result.triggers).toEqual(triggers);
+  });
+
+  it("constraints / defaults / triggers が混在しても全て出力される", () => {
+    const raw = makeRawTable({
+      constraints: [{ id: "uq1", kind: "unique", columns: ["customer_id"] }],
+      defaults: [{ column: "status", kind: "literal", value: "'active'" }],
+      triggers: [{ id: "tr1", timing: "AFTER", events: ["INSERT"], body: "..." }],
+    });
+    const result = mcpTableToSpecEntry(raw);
+    expect((result.constraints as unknown[]).length).toBe(1);
+    expect((result.defaults as unknown[]).length).toBe(1);
+    expect((result.triggers as unknown[]).length).toBe(1);
+  });
+
+  it("foreignKey 列が reference に変換される", () => {
+    const raw = makeRawTable({
+      columns: [{
+        id: "c1", name: "customer_id", logicalName: "顧客ID", dataType: "INTEGER",
+        notNull: true, primaryKey: false, unique: false,
+        foreignKey: { tableId: "customers", columnName: "id" },
+      }],
+    });
+    const result = mcpTableToSpecEntry(raw);
+    const col = (result.columns as Array<Record<string, unknown>>)[0];
+    expect(col.reference).toMatchObject({ table: "customers", column: "id", type: "physical" });
+  });
+});

--- a/designer-mcp/src/specExport.ts
+++ b/designer-mcp/src/specExport.ts
@@ -1,0 +1,48 @@
+/**
+ * export_spec ハンドラ用テーブル変換ユーティリティ。
+ * index.ts の MCP ハンドラから切り出し、単体テスト可能にする。
+ */
+
+export function mcpTableToSpecEntry(t: Record<string, unknown>): Record<string, unknown> {
+  const cols = (t.columns ?? []) as Array<Record<string, unknown>>;
+  return {
+    name: t.name,
+    logicalName: t.logicalName,
+    description: t.description,
+    category: t.category,
+    columns: cols.map((c) => {
+      const col: Record<string, unknown> = {
+        name: c.name, logicalName: c.logicalName, dataType: c.dataType,
+        ...(c.length != null ? { length: c.length } : {}),
+        ...(c.scale != null ? { scale: c.scale } : {}),
+        notNull: c.notNull, primaryKey: c.primaryKey, unique: c.unique,
+        ...(c.autoIncrement ? { autoIncrement: true } : {}),
+        ...(c.defaultValue ? { defaultValue: c.defaultValue } : {}),
+        ...(c.comment ? { comment: c.comment } : {}),
+      };
+      if (c.foreignKey) {
+        const fk = c.foreignKey as { tableId: string; columnName: string; noConstraint?: boolean };
+        col.reference = { table: fk.tableId, column: fk.columnName, type: fk.noConstraint ? "logical" : "physical" };
+      }
+      return col;
+    }),
+    indexes: ((t.indexes ?? []) as Array<Record<string, unknown>>).map((idx) => {
+      const rawCols = (idx.columns ?? []) as Array<string | { name?: string; order?: string }>;
+      const colNames = rawCols.map((c) => {
+        if (typeof c === "string") {
+          const col = cols.find((cc) => cc.id === c);
+          return col ? col.name : c;
+        }
+        return (c as { name?: string }).name ?? "";
+      });
+      return {
+        name: (idx.id ?? idx.name) as string,
+        columns: colNames,
+        unique: idx.unique,
+      };
+    }),
+    ...((t.constraints as unknown[])?.length ? { constraints: t.constraints } : {}),
+    ...((t.defaults as unknown[])?.length ? { defaults: t.defaults } : {}),
+    ...((t.triggers as unknown[])?.length ? { triggers: t.triggers } : {}),
+  };
+}

--- a/designer/src/utils/specExporter.test.ts
+++ b/designer/src/utils/specExporter.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import { generateSpecJson } from "./specExporter";
+import type { TableDefinition } from "../types/table";
+import type { FlowProject } from "../types/flow";
+import type { ErLayout } from "../types/table";
+
+const emptyProject: FlowProject = {
+  name: "テストプロジェクト",
+  screens: [],
+  edges: [],
+};
+
+const emptyErLayout: ErLayout = {
+  positions: {},
+  updatedAt: new Date().toISOString(),
+};
+
+function makeTable(overrides: Partial<TableDefinition> = {}): TableDefinition {
+  return {
+    id: "t1",
+    name: "orders",
+    logicalName: "注文",
+    description: "注文テーブル",
+    columns: [
+      {
+        id: "c1", no: 1, name: "id", logicalName: "ID",
+        dataType: "INTEGER", notNull: true, primaryKey: true, unique: false, autoIncrement: true,
+      },
+      {
+        id: "c2", no: 2, name: "customer_id", logicalName: "顧客ID",
+        dataType: "INTEGER", notNull: true, primaryKey: false, unique: false,
+      },
+    ],
+    indexes: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("generateSpecJson — SpecTable", () => {
+  it("constraints/defaults/triggers が空のとき出力に含まれない", () => {
+    const spec = generateSpecJson(emptyProject, [makeTable()], emptyErLayout);
+    const t = spec.tables[0];
+    expect(t.constraints).toBeUndefined();
+    expect(t.defaults).toBeUndefined();
+    expect(t.triggers).toBeUndefined();
+  });
+
+  it("UNIQUE 制約が出力に含まれる", () => {
+    const table = makeTable({
+      constraints: [
+        { id: "uq1", kind: "unique", columns: ["customer_id"], description: "顧客IDは一意" },
+      ],
+    });
+    const spec = generateSpecJson(emptyProject, [table], emptyErLayout);
+    const t = spec.tables[0];
+    expect(t.constraints).toHaveLength(1);
+    expect(t.constraints![0]).toMatchObject({ kind: "unique", columns: ["customer_id"] });
+  });
+
+  it("CHECK 制約が出力に含まれる", () => {
+    const table = makeTable({
+      constraints: [
+        { id: "ck1", kind: "check", expression: "amount > 0", description: "金額は正の値" },
+      ],
+    });
+    const spec = generateSpecJson(emptyProject, [table], emptyErLayout);
+    expect(spec.tables[0].constraints![0]).toMatchObject({ kind: "check", expression: "amount > 0" });
+  });
+
+  it("FOREIGN KEY 制約が出力に含まれる", () => {
+    const table = makeTable({
+      constraints: [
+        {
+          id: "fk1", kind: "foreignKey",
+          columns: ["customer_id"], referencedTable: "customers", referencedColumns: ["id"],
+          onDelete: "CASCADE",
+        },
+      ],
+    });
+    const spec = generateSpecJson(emptyProject, [table], emptyErLayout);
+    expect(spec.tables[0].constraints![0]).toMatchObject({
+      kind: "foreignKey", referencedTable: "customers", onDelete: "CASCADE",
+    });
+  });
+
+  it("DEFAULT 定義が出力に含まれる", () => {
+    const table = makeTable({
+      defaults: [
+        { column: "created_at", kind: "function", value: "NOW()", description: "作成日時自動設定" },
+        { column: "status", kind: "literal", value: "'active'" },
+      ],
+    });
+    const spec = generateSpecJson(emptyProject, [table], emptyErLayout);
+    const t = spec.tables[0];
+    expect(t.defaults).toHaveLength(2);
+    expect(t.defaults![0]).toMatchObject({ column: "created_at", kind: "function", value: "NOW()" });
+    expect(t.defaults![1]).toMatchObject({ column: "status", kind: "literal" });
+  });
+
+  it("トリガー定義が出力に含まれる", () => {
+    const table = makeTable({
+      triggers: [
+        {
+          id: "tr1", timing: "BEFORE", events: ["INSERT", "UPDATE"],
+          body: "SET NEW.updated_at = NOW();", description: "更新日時自動セット",
+        },
+      ],
+    });
+    const spec = generateSpecJson(emptyProject, [table], emptyErLayout);
+    const t = spec.tables[0];
+    expect(t.triggers).toHaveLength(1);
+    expect(t.triggers![0]).toMatchObject({ timing: "BEFORE", events: ["INSERT", "UPDATE"] });
+  });
+
+  it("constraints / defaults / triggers が混在しても全て出力される", () => {
+    const table = makeTable({
+      constraints: [{ id: "uq1", kind: "unique", columns: ["customer_id"] }],
+      defaults: [{ column: "status", kind: "literal", value: "'active'" }],
+      triggers: [{ id: "tr1", timing: "AFTER", events: ["INSERT"], body: "..." }],
+    });
+    const spec = generateSpecJson(emptyProject, [table], emptyErLayout);
+    const t = spec.tables[0];
+    expect(t.constraints).toHaveLength(1);
+    expect(t.defaults).toHaveLength(1);
+    expect(t.triggers).toHaveLength(1);
+  });
+});

--- a/designer/src/utils/specExporter.ts
+++ b/designer/src/utils/specExporter.ts
@@ -5,7 +5,7 @@
  * PG工程のAIが正確に解釈可能な構造化フォーマットで、
  * テーブル定義・リレーション（物理/論理）・画面情報を統合出力する。
  */
-import type { TableDefinition } from "../types/table";
+import type { TableDefinition, ConstraintDefinition, DefaultDefinition, TriggerDefinition } from "../types/table";
 import type { ErRelation, ErLayout } from "../types/table";
 import type { FlowProject } from "../types/flow";
 import type { ActionGroup, Step } from "../types/action";
@@ -39,6 +39,9 @@ export interface SpecTable {
   category?: string;
   columns: SpecColumn[];
   indexes: SpecIndex[];
+  constraints?: ConstraintDefinition[];
+  defaults?: DefaultDefinition[];
+  triggers?: TriggerDefinition[];
 }
 
 export interface SpecColumn {
@@ -232,6 +235,9 @@ function toSpecTable(t: TableDefinition): SpecTable {
       columns: idx.columns.map((ic) => ic.name),
       unique: idx.unique ?? false,
     })),
+    ...(t.constraints && t.constraints.length > 0 ? { constraints: t.constraints } : {}),
+    ...(t.defaults && t.defaults.length > 0 ? { defaults: t.defaults } : {}),
+    ...(t.triggers && t.triggers.length > 0 ? { triggers: t.triggers } : {}),
   };
 }
 


### PR DESCRIPTION
## 概要

Closes #383

PR #381 レビュー r3 の Should-fix S-1 対応。`export_spec` ツールの出力に β-2 制約・β-4 DEFAULT/トリガーが欠けていた問題を修正。

## 変更内容

- `designer/src/utils/specExporter.ts` — `SpecTable` インターフェースに `constraints?` / `defaults?` / `triggers?` フィールドを追加。`toSpecTable()` で 3 フィールドを出力。
- `designer-mcp/src/specExport.ts` — MCP ハンドラのテーブル変換ロジック (`mcpTableToSpecEntry`) を `index.ts` から切り出し。
- `designer-mcp/src/index.ts` — `export_spec` ハンドラで `mcpTableToSpecEntry` を呼ぶよう置き換え。
- `designer/src/utils/specExporter.test.ts` — 新規テスト (7 ケース): ブラウザ側 `generateSpecJson` の constraints/defaults/triggers 出力を検証。
- `designer-mcp/src/specExport.test.ts` — 新規テスト (10 ケース): MCP ハンドラの `mcpTableToSpecEntry` コードパスを直接カバー。

## 仕様逐条突合

| # | 受け入れ基準 | 対応箇所 |
|---|---|---|
| ✅ | `SpecTable` 型に `constraints` / `defaults` / `triggers` フィールドが追加される | `specExporter.ts:42-44` |
| ✅ | `toSpecTable()` が 3 フィールドを出力する | `specExporter.ts:238-240` |
| ✅ | MCP `export_spec` ツール経由で上記データが取得できる | `specExport.ts` (10 ケース Vitest カバー) |
| ✅ | 既存テストが全 pass (designer: 699, designer-mcp: 95) | CI |
| ✅ | TypeScript ビルドエラーなし | `npm run build` 確認済み (両プロジェクト) |

## テスト計画

- [x] `npx vitest run src/utils/specExporter.test.ts` — 7 ケース全 pass (designer)
- [x] `npx vitest run` (designer-mcp) — 95 ケース全 pass (specExport.test.ts 10 ケース含む)
- [x] `npx vitest run` (designer) — 699 ケース全 pass
- [x] `npm run build` (designer / designer-mcp) — TypeScript ビルドエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)