### PR TITLE
feat(view): ビュー定義 一覧 + エディタ (#376)

### DIFF
--- a/designer-mcp/src/projectStorage.ts
+++ b/designer-mcp/src/projectStorage.ts
@@ -19,6 +19,7 @@ const ACTIONS_DIR = path.join(DATA_DIR, "actions");
 const CONVENTIONS_DIR = path.join(DATA_DIR, "conventions");
 const SCREEN_ITEMS_DIR = path.join(DATA_DIR, "screen-items");
 const SEQUENCES_DIR = path.join(DATA_DIR, "sequences");
+export const VIEWS_FILE = path.join(DATA_DIR, "views.json");
 export const PROJECT_FILE = path.join(DATA_DIR, "project.json");
 export const CUSTOM_BLOCKS_FILE = path.join(DATA_DIR, "custom-blocks.json");
 export const ER_LAYOUT_FILE = path.join(DATA_DIR, "er-layout.json");
@@ -83,6 +84,7 @@ function resolveDataFile(kind: string, id?: string): string | null {
     case "actionGroup": return id ? path.join(ACTIONS_DIR, `${id}.json`) : null;
     case "screenItems": return id ? path.join(SCREEN_ITEMS_DIR, `${id}.json`) : null;
     case "sequence": return id ? path.join(SEQUENCES_DIR, `${id}.json`) : null;
+    case "view": return VIEWS_FILE;
     default: return null;
   }
 }
@@ -208,6 +210,17 @@ export async function deleteSequence(sequenceId: string): Promise<void> {
   try {
     await fs.unlink(path.join(SEQUENCES_DIR, `${sequenceId}.json`));
   } catch { /* file not found is OK */ }
+}
+
+/** views.json を読み込み (#376) */
+export async function readViewsFile(): Promise<unknown | null> {
+  return readJSON<unknown>(VIEWS_FILE);
+}
+
+/** views.json を書き込み (#376) */
+export async function writeViewsFile(data: unknown): Promise<void> {
+  await ensureDataDir();
+  await writeJSON(VIEWS_FILE, data);
 }
 
 /** actions/ ディレクトリ内の全アクショングループを読み込み */

--- a/designer-mcp/src/wsBridge.ts
+++ b/designer-mcp/src/wsBridge.ts
@@ -538,8 +538,14 @@ class WsBridge extends EventEmitter {
         case "reorderViews": {
           const { orderedIds } = (params ?? {}) as { orderedIds: string[] };
           const existing = (await readViewsFile()) as { version?: string; updatedAt?: string; views?: unknown[] } | null;
-          const viewsMap = new Map((existing?.views ?? []).map((v) => [(v as { id: string }).id, v]));
-          const reordered = orderedIds.map((id) => viewsMap.get(id)).filter(Boolean);
+          const existingViews = existing?.views ?? [];
+          const viewsMap = new Map(existingViews.map((v) => [(v as { id: string }).id, v]));
+          const knownIds = new Set(orderedIds);
+          const unknownViews = existingViews.filter((v) => !knownIds.has((v as { id: string }).id));
+          const reordered = [
+            ...orderedIds.map((id) => viewsMap.get(id)).filter(Boolean),
+            ...unknownViews,
+          ];
           await writeViewsFile({ version: "1.0.0", updatedAt: new Date().toISOString(), views: reordered });
           respond({ success: true });
           this.broadcast("viewChanged", { reordered: true }, clientId);

--- a/designer-mcp/src/wsBridge.ts
+++ b/designer-mcp/src/wsBridge.ts
@@ -30,6 +30,8 @@ import {
   readSequence,
   writeSequence,
   deleteSequence as deleteSequenceFile,
+  readViewsFile,
+  writeViewsFile,
   getFileMtime,
 } from "./projectStorage.js";
 
@@ -499,6 +501,38 @@ class WsBridge extends EventEmitter {
           await deleteSequenceFile(sequenceId);
           respond({ success: true });
           this.broadcast("sequenceChanged", { sequenceId, deleted: true }, clientId);
+          break;
+        }
+        case "loadViewsFile": {
+          const data = await readViewsFile();
+          respond(data);
+          break;
+        }
+        case "loadView": {
+          const { viewId } = (params ?? {}) as { viewId: string };
+          const file = (await readViewsFile()) as { views?: { id: string }[] } | null;
+          const view = file?.views?.find((v) => v.id === viewId) ?? null;
+          respond(view);
+          break;
+        }
+        case "saveView": {
+          const { viewId, data } = (params ?? {}) as { viewId: string; data: unknown };
+          const existing = (await readViewsFile()) as { version?: string; updatedAt?: string; views?: unknown[] } | null;
+          const views: unknown[] = existing?.views ? [...existing.views] : [];
+          const idx = views.findIndex((v) => (v as { id: string }).id === viewId);
+          if (idx >= 0) { views[idx] = data; } else { views.push(data); }
+          await writeViewsFile({ version: "1.0.0", updatedAt: new Date().toISOString(), views });
+          respond({ success: true });
+          this.broadcast("viewChanged", { viewId }, clientId);
+          break;
+        }
+        case "deleteView": {
+          const { viewId } = (params ?? {}) as { viewId: string };
+          const existing = (await readViewsFile()) as { version?: string; updatedAt?: string; views?: unknown[] } | null;
+          const views = (existing?.views ?? []).filter((v) => (v as { id: string }).id !== viewId);
+          await writeViewsFile({ version: "1.0.0", updatedAt: new Date().toISOString(), views });
+          respond({ success: true });
+          this.broadcast("viewChanged", { viewId, deleted: true }, clientId);
           break;
         }
         case "getFileMtime": {

--- a/designer-mcp/src/wsBridge.ts
+++ b/designer-mcp/src/wsBridge.ts
@@ -535,6 +535,16 @@ class WsBridge extends EventEmitter {
           this.broadcast("viewChanged", { viewId, deleted: true }, clientId);
           break;
         }
+        case "reorderViews": {
+          const { orderedIds } = (params ?? {}) as { orderedIds: string[] };
+          const existing = (await readViewsFile()) as { version?: string; updatedAt?: string; views?: unknown[] } | null;
+          const viewsMap = new Map((existing?.views ?? []).map((v) => [(v as { id: string }).id, v]));
+          const reordered = orderedIds.map((id) => viewsMap.get(id)).filter(Boolean);
+          await writeViewsFile({ version: "1.0.0", updatedAt: new Date().toISOString(), views: reordered });
+          respond({ success: true });
+          this.broadcast("viewChanged", { reordered: true }, clientId);
+          break;
+        }
         case "getFileMtime": {
           const { kind, id: fid } = (params ?? {}) as { kind: string; id?: string };
           const mtime = await getFileMtime(kind, fid);

--- a/designer/src/components/AppShell.tsx
+++ b/designer/src/components/AppShell.tsx
@@ -11,6 +11,8 @@ import { ConventionsCatalogView } from "./conventions/ConventionsCatalogView";
 import { ScreenItemsView } from "./screen-items/ScreenItemsView";
 import { SequenceListView } from "./sequence/SequenceListView";
 import { SequenceEditor } from "./sequence/SequenceEditor";
+import { ViewListView } from "./view/ViewListView";
+import { ViewEditor } from "./view/ViewEditor";
 import { Designer } from "./Designer";
 import { DashboardView } from "./dashboard/DashboardView";
 import { TabBar } from "./TabBar";
@@ -19,6 +21,7 @@ import { loadProject } from "../store/flowStore";
 import { loadTable } from "../store/tableStore";
 import { loadActionGroup } from "../store/actionStore";
 import { loadSequence } from "../store/sequenceStore";
+import { loadView } from "../store/viewStore";
 import {
   getTabs,
   getActiveTabId,
@@ -176,6 +179,28 @@ export function AppShell() {
       return;
     }
 
+    const viewMatch = matchPath("/view/edit/:viewId", location.pathname);
+    if (viewMatch?.params.viewId) {
+      const viewId = viewMatch.params.viewId;
+      const tabId = makeTabId("view", viewId);
+      const existing = getTabs().find((t) => t.id === tabId);
+      if (existing) {
+        setActiveTab(tabId);
+      } else {
+        loadView(viewId).then((v) => {
+          if (v) {
+            openTab({ id: tabId, type: "view", resourceId: viewId, label: v.id });
+          } else {
+            fallbackToDashboard("ビュー", viewId);
+          }
+        }).catch((e) => {
+          recordError({ source: "manual", message: "loadView 失敗", stack: e instanceof Error ? e.stack : undefined });
+          fallbackToDashboard("ビュー", viewId);
+        });
+      }
+      return;
+    }
+
     // シングルトンタブ: list / workspace 系は resourceId="main" で 1 インスタンスのみ
     const singletonRoutes: ReadonlyArray<{ path: string; type: TabType; label: string }> = [
       { path: "/",                   type: "dashboard",          label: "ダッシュボード" },
@@ -187,6 +212,7 @@ export function AppShell() {
       { path: "/conventions/catalog", type: "conventions-catalog", label: "規約カタログ" },
       { path: "/screen-items",       type: "screen-items",       label: "画面項目定義" },
       { path: "/sequence/list",      type: "sequence-list",      label: "シーケンス一覧" },
+      { path: "/view/list",          type: "view-list",           label: "ビュー一覧" },
     ];
     for (const { path, type, label } of singletonRoutes) {
       if (location.pathname === path) {
@@ -208,6 +234,7 @@ export function AppShell() {
       : activeTab.type === "table"            ? `/table/edit/${activeTab.resourceId}`
       : activeTab.type === "action"           ? `/process-flow/edit/${activeTab.resourceId}`
       : activeTab.type === "sequence"         ? `/sequence/edit/${activeTab.resourceId}`
+      : activeTab.type === "view"             ? `/view/edit/${activeTab.resourceId}`
       : activeTab.type === "screen-flow"      ? "/screen/flow"
       : activeTab.type === "screen-list"      ? "/screen/list"
       : activeTab.type === "table-list"       ? "/table/list"
@@ -216,6 +243,7 @@ export function AppShell() {
       : activeTab.type === "conventions-catalog" ? "/conventions/catalog"
       : activeTab.type === "screen-items"     ? "/screen-items"
       : activeTab.type === "sequence-list"    ? "/sequence/list"
+      : activeTab.type === "view-list"        ? "/view/list"
       : activeTab.type === "dashboard"        ? "/"
       : null;
     if (expectedPath && location.pathname !== expectedPath) {
@@ -294,6 +322,8 @@ export function AppShell() {
             <Route path="/screen-items" element={<ScreenItemsView />} />
             <Route path="/sequence/list" element={<SequenceListView />} />
             <Route path="/sequence/edit/:sequenceId" element={<SequenceEditor />} />
+            <Route path="/view/list" element={<ViewListView />} />
+            <Route path="/view/edit/:viewId" element={<ViewEditor />} />
           </Routes>
         </ErrorBoundary>
       )}

--- a/designer/src/components/HeaderMenu.tsx
+++ b/designer/src/components/HeaderMenu.tsx
@@ -48,6 +48,10 @@ const MENU_ITEMS: MenuItem[] = [
     id: "sequence-list", label: "シーケンス一覧", icon: "bi-arrow-repeat", route: "/sequence/list",
     activePaths: ["/sequence/list"], activePrefixes: ["/sequence/edit/"],
   },
+  {
+    id: "view-list", label: "ビュー一覧", icon: "bi-eye", route: "/view/list",
+    activePaths: ["/view/list"], activePrefixes: ["/view/edit/"],
+  },
 ];
 
 const DASHBOARD_ITEM: MenuItem = {

--- a/designer/src/components/view/ViewEditor.tsx
+++ b/designer/src/components/view/ViewEditor.tsx
@@ -1,0 +1,320 @@
+import { useState, useEffect, useCallback } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import type { ViewDefinition, ViewOutputColumn } from "../../types/view";
+import { loadView, saveView } from "../../store/viewStore";
+import { listTables } from "../../store/tableStore";
+import { mcpBridge } from "../../mcp/mcpBridge";
+import { useResourceEditor } from "../../hooks/useResourceEditor";
+import { useSaveShortcut } from "../../hooks/useSaveShortcut";
+import { EditorHeader, type EditorHeaderSaveReset, type EditorHeaderBackLink } from "../common/EditorHeader";
+import { ServerChangeBanner } from "../common/ServerChangeBanner";
+import { generateViewDdl } from "./generateViewDdl";
+
+export function ViewEditor() {
+  const { viewId: rawId } = useParams<{ viewId: string }>();
+  const viewId = rawId ? decodeURIComponent(rawId) : rawId;
+  const navigate = useNavigate();
+
+  const [ddlOpen, setDdlOpen] = useState(false);
+  const [tableIds, setTableIds] = useState<string[]>([]);
+  const [addDepInput, setAddDepInput] = useState("");
+  const [addColName, setAddColName] = useState("");
+  const [addColType, setAddColType] = useState("");
+  const [addColDesc, setAddColDesc] = useState("");
+  const [addingCol, setAddingCol] = useState(false);
+
+  const handleNotFound = useCallback(() => navigate("/view/list"), [navigate]);
+
+  const {
+    state: view,
+    isDirty, isSaving, serverChanged,
+    update, updateSilent, commit, handleSave, handleReset, dismissServerBanner,
+  } = useResourceEditor<ViewDefinition>({
+    tabType: "view",
+    mtimeKind: "view",
+    draftKind: "view",
+    id: viewId,
+    load: loadView,
+    save: saveView,
+    broadcastName: "viewChanged",
+    broadcastIdField: "viewId",
+    onNotFound: handleNotFound,
+  });
+
+  useSaveShortcut(() => {
+    if (isDirty && !isSaving) handleSave();
+  });
+
+  useEffect(() => {
+    mcpBridge.startWithoutEditor();
+    listTables().then((metas) => {
+      setTableIds(metas.map((m) => m.id));
+    });
+  }, [viewId]);
+
+  if (!view) {
+    return <div className="table-editor-loading"><i className="bi bi-hourglass-split" /> 読み込み中...</div>;
+  }
+
+  const ddl = generateViewDdl(view);
+
+  const addDependency = () => {
+    const dep = addDepInput.trim();
+    if (!dep) return;
+    if ((view.dependencies ?? []).includes(dep)) return;
+    update((prev) => ({ ...prev, dependencies: [...(prev.dependencies ?? []), dep] }));
+    setAddDepInput("");
+  };
+
+  const removeDependency = (dep: string) => {
+    update((prev) => ({
+      ...prev,
+      dependencies: (prev.dependencies ?? []).filter((d) => d !== dep),
+    }));
+  };
+
+  const addOutputColumn = () => {
+    if (!addColName.trim() || !addColType.trim()) return;
+    const col: ViewOutputColumn = {
+      name: addColName.trim(),
+      type: addColType.trim(),
+      description: addColDesc.trim() || undefined,
+    };
+    update((prev) => ({ ...prev, outputColumns: [...prev.outputColumns, col] }));
+    setAddColName("");
+    setAddColType("");
+    setAddColDesc("");
+    setAddingCol(false);
+  };
+
+  const removeOutputColumn = (idx: number) => {
+    update((prev) => ({
+      ...prev,
+      outputColumns: prev.outputColumns.filter((_, i) => i !== idx),
+    }));
+  };
+
+  const updateOutputColumn = (idx: number, field: keyof ViewOutputColumn, value: string) => {
+    update((prev) => ({
+      ...prev,
+      outputColumns: prev.outputColumns.map((c, i) =>
+        i === idx ? { ...c, [field]: value || undefined } : c,
+      ),
+    }));
+  };
+
+  return (
+    <div className="table-editor-page">
+      {serverChanged && (
+        <ServerChangeBanner onReload={handleReset} onDismiss={dismissServerBanner} />
+      )}
+      <EditorHeader
+        title={<><i className="bi bi-eye" /> ビュー編集: <code>{view.id}</code></>}
+        backLink={{
+          label: "ビュー一覧",
+          onClick: () => navigate("/view/list"),
+        } satisfies EditorHeaderBackLink}
+        saveReset={{
+          isDirty,
+          isSaving,
+          onSave: handleSave,
+          onReset: handleReset,
+        } satisfies EditorHeaderSaveReset}
+      />
+
+      <div className="seq-editor-body">
+        {/* 左カラム（基本設定・SELECT・依存テーブル・出力列） */}
+        <div className="seq-editor-left-col">
+
+          {/* 基本設定 */}
+          <section className="seq-editor-section">
+            <h3 className="seq-editor-section-title">基本設定</h3>
+            <div className="seq-editor-grid">
+              <label className="tbl-field">
+                <span>ビュー名</span>
+                <input
+                  type="text"
+                  value={view.id}
+                  readOnly
+                  className="seq-readonly"
+                  title="ビュー名は作成後変更できません"
+                />
+              </label>
+              <label className="tbl-field">
+                <span>説明</span>
+                <input
+                  type="text"
+                  value={view.description ?? ""}
+                  onChange={(e) => update((prev) => ({ ...prev, description: e.target.value }))}
+                  placeholder="顧客に最終購入日を結合した表示用ビュー"
+                />
+              </label>
+            </div>
+          </section>
+
+          {/* SELECT 文 */}
+          <section className="seq-editor-section">
+            <h3 className="seq-editor-section-title">SELECT 文</h3>
+            <textarea
+              className="view-editor-select-stmt"
+              value={view.selectStatement}
+              onChange={(e) => updateSilent((prev) => ({ ...prev, selectStatement: e.target.value }))}
+              onBlur={commit}
+              rows={10}
+              placeholder={`SELECT\n  c.customer_id,\n  c.customer_name,\n  MAX(o.created_at) AS last_order_at\nFROM customers c\nLEFT JOIN orders o ON c.customer_id = o.customer_id\nGROUP BY c.customer_id, c.customer_name`}
+              spellCheck={false}
+            />
+          </section>
+
+          {/* 依存テーブル */}
+          <section className="seq-editor-section">
+            <h3 className="seq-editor-section-title">依存テーブル</h3>
+            {(view.dependencies ?? []).length > 0 && (
+              <div className="seq-used-by-list">
+                {(view.dependencies ?? []).map((dep) => (
+                  <div key={dep} className="seq-used-by-row">
+                    <span className="seq-used-by-text">
+                      <i className="bi bi-table" /> {dep}
+                    </span>
+                    <button
+                      className="seq-used-by-del"
+                      onClick={() => removeDependency(dep)}
+                      title="削除"
+                    >
+                      <i className="bi bi-x" />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+            <div className="view-editor-dep-add">
+              <input
+                type="text"
+                list="dep-table-ids"
+                value={addDepInput}
+                onChange={(e) => setAddDepInput(e.target.value)}
+                placeholder="テーブル名を入力..."
+                onKeyDown={(e) => { if (e.key === "Enter") addDependency(); }}
+                className="view-editor-dep-input"
+              />
+              <datalist id="dep-table-ids">
+                {tableIds.map((id) => (
+                  <option key={id} value={id} />
+                ))}
+              </datalist>
+              <button
+                className="tbl-btn tbl-btn-ghost"
+                onClick={addDependency}
+                disabled={!addDepInput.trim()}
+              >
+                <i className="bi bi-plus-lg" /> 追加
+              </button>
+            </div>
+          </section>
+
+          {/* 出力列 */}
+          <section className="seq-editor-section">
+            <h3 className="seq-editor-section-title">
+              出力列
+              <button
+                className="tbl-btn tbl-btn-ghost view-editor-col-add-btn"
+                onClick={() => setAddingCol(true)}
+              >
+                <i className="bi bi-plus-lg" /> 追加
+              </button>
+            </h3>
+
+            {view.outputColumns.length > 0 && (
+              <div className="view-editor-col-list">
+                {view.outputColumns.map((col, i) => (
+                  <div key={i} className="view-editor-col-row">
+                    <input
+                      type="text"
+                      value={col.name}
+                      onChange={(e) => updateOutputColumn(i, "name", e.target.value)}
+                      placeholder="列名"
+                      className="view-editor-col-name"
+                    />
+                    <input
+                      type="text"
+                      value={col.type}
+                      onChange={(e) => updateOutputColumn(i, "type", e.target.value)}
+                      placeholder="型"
+                      className="view-editor-col-type"
+                    />
+                    <input
+                      type="text"
+                      value={col.description ?? ""}
+                      onChange={(e) => updateOutputColumn(i, "description", e.target.value)}
+                      placeholder="説明（省略可）"
+                      className="view-editor-col-desc"
+                    />
+                    <button
+                      className="seq-used-by-del"
+                      onClick={() => removeOutputColumn(i)}
+                      title="削除"
+                    >
+                      <i className="bi bi-x" />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {addingCol && (
+              <div className="view-editor-col-add-form">
+                <input
+                  type="text"
+                  value={addColName}
+                  onChange={(e) => setAddColName(e.target.value)}
+                  placeholder="列名 (例: customer_id)"
+                  autoFocus
+                />
+                <input
+                  type="text"
+                  value={addColType}
+                  onChange={(e) => setAddColType(e.target.value)}
+                  placeholder="型 (例: uuid, string, timestamp)"
+                />
+                <input
+                  type="text"
+                  value={addColDesc}
+                  onChange={(e) => setAddColDesc(e.target.value)}
+                  placeholder="説明（省略可）"
+                />
+                <button
+                  className="tbl-btn tbl-btn-primary"
+                  onClick={addOutputColumn}
+                  disabled={!addColName.trim() || !addColType.trim()}
+                >
+                  追加
+                </button>
+                <button
+                  className="tbl-btn tbl-btn-ghost"
+                  onClick={() => { setAddingCol(false); setAddColName(""); setAddColType(""); setAddColDesc(""); }}
+                >
+                  キャンセル
+                </button>
+              </div>
+            )}
+          </section>
+
+        </div>{/* seq-editor-left-col */}
+
+        {/* DDL プレビュー */}
+        <section className="seq-editor-section seq-editor-ddl-section">
+          <button
+            className="seq-ddl-toggle"
+            onClick={() => setDdlOpen((v) => !v)}
+          >
+            <i className={`bi bi-chevron-${ddlOpen ? "down" : "right"}`} />
+            DDL プレビュー (CREATE OR REPLACE VIEW)
+          </button>
+          {ddlOpen && (
+            <pre className="seq-ddl-preview">{ddl}</pre>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/designer/src/components/view/ViewListView.tsx
+++ b/designer/src/components/view/ViewListView.tsx
@@ -1,0 +1,545 @@
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import type { ViewMeta } from "../../types/view";
+import type { ViewDefinition } from "../../types/view";
+import { listViews, createView, deleteView, loadView, saveView } from "../../store/viewStore";
+import { mcpBridge } from "../../mcp/mcpBridge";
+import { makeTabId } from "../../store/tabStore";
+import { DataList, type DataListColumn } from "../common/DataList";
+import { FilterBar } from "../common/FilterBar";
+import { SortBar } from "../common/SortBar";
+import { ListContextMenu, type ContextMenuItem } from "../common/ListContextMenu";
+import { ViewModeToggle, type ViewMode } from "../common/ViewModeToggle";
+import { useListSelection } from "../../hooks/useListSelection";
+import { useListClipboard } from "../../hooks/useListClipboard";
+import { useListKeyboard } from "../../hooks/useListKeyboard";
+import { useListFilter } from "../../hooks/useListFilter";
+import { useListSort } from "../../hooks/useListSort";
+import { useListEditor } from "../../hooks/useListEditor";
+import { usePersistentState } from "../../hooks/usePersistentState";
+import { renumber } from "../../utils/listOrder";
+
+const STORAGE_KEY = "list-view-mode:view-list";
+const TAB_ID = makeTabId("view-list", "main");
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString("ja-JP");
+  } catch {
+    return iso;
+  }
+}
+
+export function ViewListView() {
+  const navigate = useNavigate();
+  const [query, setQuery] = useState("");
+  const [viewMode, setViewMode] = usePersistentState<ViewMode>(STORAGE_KEY, "card");
+  const [showAdd, setShowAdd] = useState(false);
+  const [addId, setAddId] = useState("");
+  const [addDescription, setAddDescription] = useState("");
+  const [contextMenu, setContextMenu] = useState<{ x: number; y: number; items: ContextMenuItem[] } | null>(null);
+
+  const loadViews = useCallback(async () => {
+    mcpBridge.startWithoutEditor();
+    return await listViews();
+  }, []);
+
+  const commitViews = useCallback(async ({ deletedIds }: { itemsInOrder: ViewMeta[]; deletedIds: string[] }) => {
+    for (const id of deletedIds) {
+      await deleteView(id);
+    }
+  }, []);
+
+  const editor = useListEditor<ViewMeta>({
+    getId: (v) => v.id,
+    load: loadViews,
+    commit: commitViews,
+    tabId: TAB_ID,
+    renumber,
+  });
+
+  useEffect(() => {
+    editor.reload();
+    const unsubStatus = mcpBridge.onStatusChange((s) => {
+      if (s === "connected" && !editor.isDirty) editor.reload();
+    });
+    const unsubView = mcpBridge.onBroadcast("viewChanged", () => {
+      if (!editor.isDirty) editor.reload();
+    });
+    return () => { unsubStatus(); unsubView(); };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const allViews = editor.items;
+
+  const filter = useListFilter(allViews);
+  useEffect(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) {
+      filter.applyFilter(null);
+      return;
+    }
+    filter.applyFilter((v) =>
+      v.id.toLowerCase().includes(q) ||
+      (v.description ?? "").toLowerCase().includes(q),
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query]);
+
+  const sortAccessor = useCallback((v: ViewMeta, key: string): string | number => {
+    switch (key) {
+      case "id": return v.id;
+      case "description": return v.description ?? "";
+      case "updatedAt": return v.updatedAt;
+      default: return "";
+    }
+  }, []);
+
+  const sort = useListSort(filter.filtered, sortAccessor);
+  const selection = useListSelection(sort.sorted, (v) => v.id);
+  const clipboard = useListClipboard<ViewMeta>((v) => v.id);
+
+  const handleActivate = useCallback((v: ViewMeta) => {
+    if (editor.isDeleted(v.id)) return;
+    navigate(`/view/edit/${encodeURIComponent(v.id)}`);
+  }, [navigate, editor]);
+
+  const handleDelete = (items: ViewMeta[]) => {
+    editor.markDeleted(items.map((v) => v.id));
+  };
+
+  const makeCopyId = (baseId: string, existingIds: Set<string>): string => {
+    let candidate = baseId + "_copy";
+    let n = 2;
+    while (existingIds.has(candidate)) {
+      candidate = `${baseId}_copy_${n}`;
+      n++;
+    }
+    return candidate;
+  };
+
+  const handleDuplicate = async (items: ViewMeta[]) => {
+    const newIds: string[] = [];
+    const existingIds = new Set(editor.items.map((v) => v.id));
+    for (const m of items) {
+      const full = await loadView(m.id);
+      if (!full) continue;
+      const newId = makeCopyId(m.id, existingIds);
+      existingIds.add(newId);
+      const dup: ViewDefinition = {
+        ...full,
+        id: newId,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+      await saveView(dup);
+      newIds.push(dup.id);
+    }
+    await editor.reload();
+    if (newIds.length > 0) selection.setSelectedIds(new Set(newIds));
+  };
+
+  const handlePaste = async (insertIdx: number | null) => {
+    const mode = clipboard.clipboard.mode;
+    const clipItems = clipboard.clipboard.items;
+    if (!clipItems.length) return;
+
+    if (mode === "cut") {
+      const cutIds = new Set(clipItems.map((c) => c.id));
+      const selIds = selection.selectedIds;
+      const sameSet = selIds.size === cutIds.size && [...selIds].every((id) => cutIds.has(id));
+      if (sameSet) return;
+
+      clipboard.consume();
+      const moved = clipItems;
+      const pos0 = insertIdx ?? editor.items.length;
+      const removedBefore = editor.items.slice(0, pos0).filter((v) => cutIds.has(v.id)).length;
+      const remaining = editor.items.filter((v) => !cutIds.has(v.id));
+      const pos = Math.min(remaining.length, pos0 - removedBefore);
+      editor.setItems(() => {
+        const next = [...remaining];
+        next.splice(pos, 0, ...moved);
+        return renumber(next);
+      });
+      selection.setSelectedIds(new Set(moved.map((v) => v.id)));
+    } else {
+      const newIds: string[] = [];
+      const existingIds = new Set(editor.items.map((v) => v.id));
+      for (const m of clipItems) {
+        const full = await loadView(m.id);
+        if (!full) continue;
+        const newId = makeCopyId(m.id, existingIds);
+        existingIds.add(newId);
+        const dup: ViewDefinition = {
+          ...full,
+          id: newId,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        };
+        await saveView(dup);
+        newIds.push(dup.id);
+      }
+      clipboard.consume();
+      await editor.reload();
+      selection.setSelectedIds(new Set(newIds));
+    }
+  };
+
+  const handleReorder = (fromIdx: number, toIdx: number) => {
+    const visible = sort.sorted;
+    const fromId = visible[fromIdx]?.id;
+    const toId = visible[toIdx]?.id;
+    if (!fromId || !toId) return;
+    const realFrom = editor.items.findIndex((v) => v.id === fromId);
+    const realTo = editor.items.findIndex((v) => v.id === toId);
+    if (realFrom < 0 || realTo < 0) return;
+    editor.reorder(realFrom, realTo);
+  };
+
+  const moveBlock = (items: ViewMeta[], direction: "up" | "down") => {
+    const ids = new Set(items.map((v) => v.id));
+    const idxs = editor.items
+      .map((v, i) => (ids.has(v.id) ? i : -1))
+      .filter((i) => i >= 0)
+      .sort((a, b) => a - b);
+    if (idxs.length === 0) return;
+    if (direction === "up") {
+      if (idxs[0] === 0) return;
+      editor.setItems((prev) => {
+        const next = [...prev];
+        const [moved] = next.splice(idxs[0] - 1, 1);
+        next.splice(idxs[idxs.length - 1], 0, moved);
+        return renumber(next);
+      });
+    } else {
+      if (idxs[idxs.length - 1] === editor.items.length - 1) return;
+      editor.setItems((prev) => {
+        const next = [...prev];
+        const [moved] = next.splice(idxs[idxs.length - 1] + 1, 1);
+        next.splice(idxs[0], 0, moved);
+        return renumber(next);
+      });
+    }
+  };
+
+  const sortActive = sort.sortKeys.length > 0;
+
+  const columnLabels = useMemo<Record<string, string>>(() => ({
+    id: "ビュー名",
+    description: "説明",
+    updatedAt: "更新日",
+  }), []);
+
+  const handleAdd = async () => {
+    const id = addId.trim();
+    if (!id) return;
+    const v = await createView(id, addDescription.trim() || undefined);
+    setShowAdd(false);
+    setAddId("");
+    setAddDescription("");
+    navigate(`/view/edit/${encodeURIComponent(v.id)}`);
+  };
+
+  const buildMenuItems = (target: ViewMeta | null): ContextMenuItem[] => {
+    const hasSelection = selection.selectedIds.size > 0 || target !== null;
+    const pasteBlocked = sortActive || !clipboard.hasContent;
+    const pasteReason = sortActive ? "ソート中は無効 (ソート解除で利用可能)" : "クリップボードが空";
+    const sortReason = "ソート中は無効 (ソート解除で利用可能)";
+
+    if (target === null && selection.selectedIds.size === 0) {
+      return [
+        {
+          key: "new", label: "新規作成", icon: "bi-plus-lg",
+          disabled: sortActive, disabledReason: sortReason,
+          onClick: () => setShowAdd(true),
+        },
+      ];
+    }
+
+    const items = target && !selection.isSelected(target.id)
+      ? [target]
+      : selection.selectedItems;
+
+    return [
+      {
+        key: "new", label: "新規作成", icon: "bi-plus-lg",
+        disabled: sortActive, disabledReason: sortReason,
+        onClick: () => setShowAdd(true),
+      },
+      { key: "sep1", separator: true },
+      {
+        key: "copy", label: "コピー", icon: "bi-files", shortcut: "Ctrl+C",
+        disabled: !hasSelection,
+        onClick: () => { if (items.length > 0) clipboard.copy(items); },
+      },
+      {
+        key: "cut", label: "切り取り", icon: "bi-scissors", shortcut: "Ctrl+X",
+        disabled: !hasSelection,
+        onClick: () => { if (items.length > 0) clipboard.cut(items); },
+      },
+      {
+        key: "paste", label: "貼り付け", icon: "bi-clipboard", shortcut: "Ctrl+V",
+        disabled: pasteBlocked, disabledReason: pasteBlocked && sortActive ? sortReason : pasteReason,
+        onClick: () => {
+          const ids = Array.from(selection.selectedIds);
+          const allIds = editor.items.map((v) => v.id);
+          const insertIndex = ids.length > 0
+            ? Math.max(...ids.map((id) => allIds.indexOf(id))) + 1
+            : null;
+          handlePaste(insertIndex).catch(console.error);
+        },
+      },
+      { key: "sep2", separator: true },
+      {
+        key: "duplicate", label: "複製", icon: "bi-copy", shortcut: "Ctrl+D",
+        disabled: !hasSelection || sortActive,
+        disabledReason: sortActive ? sortReason : undefined,
+        onClick: () => { if (items.length > 0) handleDuplicate(items).catch(console.error); },
+      },
+      { key: "sep3", separator: true },
+      {
+        key: "delete", label: "削除", icon: "bi-trash", shortcut: "Delete",
+        disabled: !hasSelection, danger: true,
+        onClick: () => { if (items.length > 0) handleDelete(items); },
+      },
+    ];
+  };
+
+  const handleContextMenu = (e: React.MouseEvent, target: ViewMeta | null) => {
+    setContextMenu({ x: e.clientX, y: e.clientY, items: buildMenuItems(target) });
+  };
+
+  const handleContextMenuKey = (first: ViewMeta | null, rect: DOMRect | null) => {
+    if (first && !selection.isSelected(first.id)) {
+      selection.setSelectedIds(new Set([first.id]));
+    }
+    const x = rect ? rect.left : 100;
+    const y = rect ? rect.bottom : 100;
+    setContextMenu({ x, y, items: buildMenuItems(first) });
+  };
+
+  const handleRowDelete = (v: ViewMeta) => {
+    handleDelete([v]);
+  };
+
+  useListKeyboard({
+    items: sort.sorted,
+    getId: (v) => v.id,
+    selection,
+    clipboard,
+    sort,
+    layout: viewMode === "card" ? "grid" : "list",
+    onActivate: handleActivate,
+    onDelete: handleDelete,
+    onDuplicate: (items) => { handleDuplicate(items).catch(console.error); },
+    onMoveUp: (items) => moveBlock(items, "up"),
+    onMoveDown: (items) => moveBlock(items, "down"),
+    onPaste: (idx) => { handlePaste(idx).catch(console.error); },
+    onContextMenuKey: handleContextMenuKey,
+  });
+
+  const handleSave = () => {
+    editor.save().catch(console.error);
+    selection.clearSelection();
+  };
+
+  const handleReset = () => {
+    if (!confirm("未保存の変更を破棄してサーバの状態に戻しますか？")) return;
+    editor.reset().catch(console.error);
+    selection.clearSelection();
+  };
+
+  const columns = useMemo<DataListColumn<ViewMeta>[]>(() => [
+    {
+      key: "id",
+      header: "ビュー名",
+      sortable: true,
+      sortAccessor: (v) => v.id,
+      render: (v) => <code className="seq-list-name-code">{v.id}</code>,
+    },
+    {
+      key: "description",
+      header: "説明",
+      sortable: true,
+      sortAccessor: (v) => v.description ?? "",
+      render: (v) => <span className="seq-list-description">{v.description ?? ""}</span>,
+    },
+    {
+      key: "updatedAt",
+      header: "更新日",
+      width: "120px",
+      sortable: true,
+      sortAccessor: (v) => v.updatedAt,
+      render: (v) => <span className="seq-list-date">{formatDate(v.updatedAt)}</span>,
+    },
+  ], []);
+
+  const renderCard = (v: ViewMeta) => (
+    <div className="seq-card-content">
+      <div className="seq-card-header">
+        <code className="seq-card-name">{v.id}</code>
+      </div>
+      {v.description && (
+        <div className="seq-card-description">{v.description}</div>
+      )}
+      <div className="seq-card-meta">
+        <span className="seq-card-date">{formatDate(v.updatedAt)}</span>
+      </div>
+    </div>
+  );
+
+  const selectedCount = selection.selectedIds.size;
+  const deletedCount = editor.deletedIds.size;
+
+  return (
+    <div className="table-list-page">
+      <div className="table-list-content">
+        <div className="table-list-header">
+          <h2 className="table-list-title">
+            <i className="bi bi-eye" /> ビュー定義
+            <span className="table-list-count">
+              {allViews.length - deletedCount} 件{deletedCount > 0 ? ` (削除予定 ${deletedCount})` : ""}
+            </span>
+          </h2>
+          <div className="table-list-actions">
+            <div className="table-list-search">
+              <i className="bi bi-search" />
+              <input
+                type="text"
+                placeholder="名前・説明で絞り込み..."
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+              />
+              {query && (
+                <button className="clear-btn" onClick={() => setQuery("")} title="クリア">
+                  <i className="bi bi-x-circle-fill" />
+                </button>
+              )}
+            </div>
+            <ViewModeToggle mode={viewMode} onChange={setViewMode} storageKey={STORAGE_KEY} />
+            <button
+              className="tbl-btn tbl-btn-primary"
+              onClick={() => setShowAdd(true)}
+              disabled={sortActive}
+              title={sortActive ? "ソート中は無効 (ソート解除で利用可能)" : undefined}
+            >
+              <i className="bi bi-plus-lg" /> ビュー追加
+            </button>
+            <button
+              className="tbl-btn tbl-btn-ghost danger"
+              onClick={() => handleDelete(selection.selectedItems)}
+              disabled={selectedCount === 0}
+              title="削除 (Delete)"
+            >
+              <i className="bi bi-trash" /> 削除{selectedCount > 0 ? ` (${selectedCount})` : ""}
+            </button>
+            <span className="tbl-saveline-sep" />
+            <button
+              className="tbl-btn tbl-btn-ghost"
+              data-testid="list-reset-btn"
+              onClick={handleReset}
+              disabled={!editor.isDirty || editor.isSaving}
+              title="変更を破棄"
+            >
+              <i className="bi bi-arrow-counterclockwise" /> リセット
+            </button>
+            <button
+              className="tbl-btn tbl-btn-primary"
+              data-testid="list-save-btn"
+              onClick={handleSave}
+              disabled={!editor.isDirty || editor.isSaving}
+              title="変更を保存"
+            >
+              <i className="bi bi-save" /> {editor.isSaving ? "保存中..." : "保存"}
+            </button>
+          </div>
+        </div>
+
+        <FilterBar
+          isActive={filter.isActive}
+          totalCount={filter.totalCount}
+          visibleCount={filter.visibleCount}
+          label={query ? `検索: "${query}"` : undefined}
+          onClear={() => { setQuery(""); filter.clearFilter(); }}
+        />
+
+        <SortBar sort={sort} columnLabels={columnLabels} />
+
+        <DataList
+          items={sort.sorted}
+          columns={columns}
+          getId={(v) => v.id}
+          getNo={(v) => v.no}
+          onRowDelete={handleRowDelete}
+          onContextMenu={handleContextMenu}
+          selection={selection}
+          clipboard={clipboard}
+          sort={sort}
+          onActivate={handleActivate}
+          onReorder={handleReorder}
+          layout={viewMode === "card" ? "grid" : "list"}
+          renderCard={renderCard}
+          showNumColumn={viewMode === "table"}
+          variant="dark"
+          className="views-data-list"
+          isItemGhost={(id) => editor.isDeleted(id)}
+          emptyMessage={
+            query
+              ? <p>該当するビュー定義がありません</p>
+              : <p>ビュー定義がまだありません。「ビュー追加」から作成してください。</p>
+          }
+        />
+
+        {showAdd && (
+          <div className="tbl-modal-overlay" onClick={() => setShowAdd(false)}>
+            <div className="tbl-modal" onClick={(e) => e.stopPropagation()}>
+              <div className="tbl-modal-title">ビュー追加</div>
+              <label className="tbl-field">
+                <span>ビュー名 <small>(snake_case、例: v_customer_with_last_order)</small></span>
+                <input
+                  type="text"
+                  value={addId}
+                  onChange={(e) => setAddId(e.target.value)}
+                  placeholder="v_customer_with_last_order"
+                  autoFocus
+                  onKeyDown={(e) => { if (e.key === "Enter") handleAdd(); }}
+                />
+              </label>
+              <label className="tbl-field">
+                <span>説明</span>
+                <input
+                  type="text"
+                  value={addDescription}
+                  onChange={(e) => setAddDescription(e.target.value)}
+                  placeholder="顧客に最終購入日を結合した表示用ビュー"
+                  onKeyDown={(e) => { if (e.key === "Enter") handleAdd(); }}
+                />
+              </label>
+              <div className="tbl-modal-btns">
+                <button className="tbl-btn tbl-btn-ghost" onClick={() => setShowAdd(false)}>
+                  キャンセル
+                </button>
+                <button
+                  className="tbl-btn tbl-btn-primary"
+                  onClick={handleAdd}
+                  disabled={!addId.trim()}
+                >
+                  作成して編集
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {contextMenu && (
+          <ListContextMenu
+            x={contextMenu.x}
+            y={contextMenu.y}
+            items={contextMenu.items}
+            onClose={() => setContextMenu(null)}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/designer/src/components/view/ViewListView.tsx
+++ b/designer/src/components/view/ViewListView.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import type { ViewMeta } from "../../types/view";
 import type { ViewDefinition } from "../../types/view";
-import { listViews, createView, deleteView, loadView, saveView } from "../../store/viewStore";
+import { listViews, createView, deleteView, loadView, saveView, reorderViews } from "../../store/viewStore";
 import { mcpBridge } from "../../mcp/mcpBridge";
 import { makeTabId } from "../../store/tabStore";
 import { DataList, type DataListColumn } from "../common/DataList";
@@ -37,6 +37,7 @@ export function ViewListView() {
   const [showAdd, setShowAdd] = useState(false);
   const [addId, setAddId] = useState("");
   const [addDescription, setAddDescription] = useState("");
+  const [addIdError, setAddIdError] = useState("");
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; items: ContextMenuItem[] } | null>(null);
 
   const loadViews = useCallback(async () => {
@@ -44,9 +45,13 @@ export function ViewListView() {
     return await listViews();
   }, []);
 
-  const commitViews = useCallback(async ({ deletedIds }: { itemsInOrder: ViewMeta[]; deletedIds: string[] }) => {
+  const commitViews = useCallback(async ({ itemsInOrder, deletedIds }: { itemsInOrder: ViewMeta[]; deletedIds: string[] }) => {
     for (const id of deletedIds) {
       await deleteView(id);
+    }
+    const remainingIds = itemsInOrder.filter((v) => !deletedIds.includes(v.id)).map((v) => v.id);
+    if (remainingIds.length > 0) {
+      await reorderViews(remainingIds);
     }
   }, []);
 
@@ -233,10 +238,15 @@ export function ViewListView() {
   const handleAdd = async () => {
     const id = addId.trim();
     if (!id) return;
+    if (editor.items.some((v) => v.id === id)) {
+      setAddIdError(`ビュー名 "${id}" は既に存在します`);
+      return;
+    }
     const v = await createView(id, addDescription.trim() || undefined);
     setShowAdd(false);
     setAddId("");
     setAddDescription("");
+    setAddIdError("");
     navigate(`/view/edit/${encodeURIComponent(v.id)}`);
   };
 
@@ -491,7 +501,7 @@ export function ViewListView() {
         />
 
         {showAdd && (
-          <div className="tbl-modal-overlay" onClick={() => setShowAdd(false)}>
+          <div className="tbl-modal-overlay" onClick={() => { setShowAdd(false); setAddIdError(""); }}>
             <div className="tbl-modal" onClick={(e) => e.stopPropagation()}>
               <div className="tbl-modal-title">ビュー追加</div>
               <label className="tbl-field">
@@ -499,11 +509,13 @@ export function ViewListView() {
                 <input
                   type="text"
                   value={addId}
-                  onChange={(e) => setAddId(e.target.value)}
+                  onChange={(e) => { setAddId(e.target.value); setAddIdError(""); }}
                   placeholder="v_customer_with_last_order"
                   autoFocus
+                  className={addIdError ? "input-error" : undefined}
                   onKeyDown={(e) => { if (e.key === "Enter") handleAdd(); }}
                 />
+                {addIdError && <span className="tbl-field-error">{addIdError}</span>}
               </label>
               <label className="tbl-field">
                 <span>説明</span>
@@ -516,7 +528,7 @@ export function ViewListView() {
                 />
               </label>
               <div className="tbl-modal-btns">
-                <button className="tbl-btn tbl-btn-ghost" onClick={() => setShowAdd(false)}>
+                <button className="tbl-btn tbl-btn-ghost" onClick={() => { setShowAdd(false); setAddIdError(""); }}>
                   キャンセル
                 </button>
                 <button

--- a/designer/src/components/view/generateViewDdl.ts
+++ b/designer/src/components/view/generateViewDdl.ts
@@ -1,0 +1,21 @@
+import type { ViewDefinition } from "../../types/view";
+
+export function generateViewDdl(view: ViewDefinition): string {
+  const lines: string[] = [];
+
+  lines.push(`CREATE OR REPLACE VIEW ${view.id} AS`);
+
+  if (view.selectStatement.trim()) {
+    lines.push(view.selectStatement);
+  } else {
+    lines.push("-- SELECT 文を入力してください");
+  }
+
+  lines[lines.length - 1] += ";";
+
+  if (view.description) {
+    lines.push(`\nCOMMENT ON VIEW ${view.id} IS '${view.description.replace(/'/g, "''")}';`);
+  }
+
+  return lines.join("\n");
+}

--- a/designer/src/components/view/generateViewDdl.ts
+++ b/designer/src/components/view/generateViewDdl.ts
@@ -11,7 +11,7 @@ export function generateViewDdl(view: ViewDefinition): string {
     lines.push("-- SELECT 文を入力してください");
   }
 
-  lines[lines.length - 1] += ";";
+  lines[lines.length - 1] = lines[lines.length - 1].trimEnd().replace(/;+$/, "") + ";";
 
   if (view.description) {
     lines.push(`\nCOMMENT ON VIEW ${view.id} IS '${view.description.replace(/'/g, "''")}';`);

--- a/designer/src/mcp/mcpBridge.ts
+++ b/designer/src/mcp/mcpBridge.ts
@@ -61,6 +61,10 @@ import {
   setSequenceStorageBackend,
   type SequenceStorageBackend,
 } from "../store/sequenceStore";
+import {
+  setViewStorageBackend,
+  type ViewStorageBackend,
+} from "../store/viewStore";
 
 export type McpStatus = "disconnected" | "connecting" | "connected";
 export type ThemeIdLike = "standard" | "card" | "compact" | "dark";
@@ -332,6 +336,14 @@ class McpBridgeImpl {
       deleteSequence: (sequenceId) => this.request("deleteSequence", { sequenceId }).then(() => undefined),
     };
     setSequenceStorageBackend(sequenceBackend);
+
+    const viewBackend: ViewStorageBackend = {
+      loadView: (viewId) => this.request("loadView", { viewId }),
+      saveView: (viewId, data) => this.request("saveView", { viewId, data }).then(() => undefined),
+      deleteView: (viewId) => this.request("deleteView", { viewId }).then(() => undefined),
+      loadViewsFile: () => this.request("loadViewsFile"),
+    };
+    setViewStorageBackend(viewBackend);
   }
 
   /** 切断時: localStorage フォールバックに戻す */
@@ -344,6 +356,7 @@ class McpBridgeImpl {
     setConventionsStorageBackend(null);
     setScreenItemsStorageBackend(null);
     setSequenceStorageBackend(null);
+    setViewStorageBackend(null);
   }
 
   // ── メッセージ受信 ─────────────────────────────────────────────────────

--- a/designer/src/mcp/mcpBridge.ts
+++ b/designer/src/mcp/mcpBridge.ts
@@ -342,6 +342,7 @@ class McpBridgeImpl {
       saveView: (viewId, data) => this.request("saveView", { viewId, data }).then(() => undefined),
       deleteView: (viewId) => this.request("deleteView", { viewId }).then(() => undefined),
       loadViewsFile: () => this.request("loadViewsFile"),
+      reorderViews: (orderedIds) => this.request("reorderViews", { orderedIds }).then(() => undefined),
     };
     setViewStorageBackend(viewBackend);
   }

--- a/designer/src/store/tabStore.ts
+++ b/designer/src/store/tabStore.ts
@@ -9,6 +9,7 @@ export type TabType =
   | "table"           // テーブル編集
   | "action"          // 処理フロー編集
   | "sequence"        // シーケンス編集 (#374)
+  | "view"            // ビュー編集 (#376)
   // シングルトン（1 インスタンス固定。resourceId は "main" で統一）
   | "screen-flow"        // 画面フロー図
   | "screen-list"        // 画面一覧 (#133 Phase C)
@@ -18,12 +19,13 @@ export type TabType =
   | "conventions-catalog" // 規約カタログ (#317)
   | "screen-items"       // 画面項目定義 (#318 プロトタイプ)
   | "sequence-list"      // シーケンス一覧 (#374)
+  | "view-list"          // ビュー一覧 (#376)
   | "dashboard";         // ダッシュボード（#86 PR-3 で有効化）
 
 const KNOWN_TAB_TYPES: ReadonlySet<TabType> = new Set([
-  "design", "table", "action", "sequence",
+  "design", "table", "action", "sequence", "view",
   "screen-flow", "screen-list", "table-list", "er", "process-flow-list",
-  "conventions-catalog", "screen-items", "sequence-list", "dashboard",
+  "conventions-catalog", "screen-items", "sequence-list", "view-list", "dashboard",
 ]);
 
 export interface TabItem {

--- a/designer/src/store/viewStore.ts
+++ b/designer/src/store/viewStore.ts
@@ -1,0 +1,129 @@
+import type { ViewDefinition, ViewMeta, ViewsFile } from "../types/view";
+import { renumber, nextNo } from "../utils/listOrder";
+
+// ─── ストレージバックエンド ──────────────────────────────────────────────
+
+export interface ViewStorageBackend {
+  loadView(viewId: string): Promise<unknown>;
+  saveView(viewId: string, data: unknown): Promise<void>;
+  deleteView(viewId: string): Promise<void>;
+  loadViewsFile(): Promise<unknown>;
+}
+
+let _backend: ViewStorageBackend | null = null;
+
+export function setViewStorageBackend(b: ViewStorageBackend | null): void {
+  _backend = b;
+}
+
+// ─── localStorage キー ───────────────────────────────────────────────────
+
+const LS_PREFIX = "view-";
+const LS_META_KEY = "views-meta";
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function makeEmptyFile(): ViewsFile {
+  return { version: "1.0.0", updatedAt: now(), views: [] };
+}
+
+// ─── 公開 API ────────────────────────────────────────────────────────────
+
+/** ビュー一覧を取得 */
+export async function listViews(): Promise<ViewMeta[]> {
+  if (_backend) {
+    const file = (await _backend.loadViewsFile()) as ViewsFile | null;
+    if (!file?.views) return [];
+    return file.views.map((v, i) => ({
+      id: v.id,
+      no: i + 1,
+      description: v.description,
+      updatedAt: v.updatedAt,
+    }));
+  }
+  const raw = localStorage.getItem(LS_META_KEY);
+  if (!raw) return [];
+  try { return JSON.parse(raw) as ViewMeta[]; } catch { return []; }
+}
+
+/** ビュー定義を読み込み */
+export async function loadView(viewId: string): Promise<ViewDefinition | null> {
+  const raw = await (async () => {
+    if (_backend) return (await _backend.loadView(viewId)) as ViewDefinition | null;
+    const s = localStorage.getItem(`${LS_PREFIX}${viewId}`);
+    if (!s) return null;
+    try { return JSON.parse(s) as ViewDefinition; } catch { return null; }
+  })();
+  return raw;
+}
+
+/** ビュー定義を保存 */
+export async function saveView(view: ViewDefinition): Promise<void> {
+  view.updatedAt = now();
+  if (_backend) {
+    await _backend.saveView(view.id, view);
+  } else {
+    localStorage.setItem(`${LS_PREFIX}${view.id}`, JSON.stringify(view));
+    await _syncLocalMeta(view);
+  }
+}
+
+/** ビューを新規作成 */
+export async function createView(id: string, description?: string): Promise<ViewDefinition> {
+  const ts = now();
+  const view: ViewDefinition = {
+    id,
+    selectStatement: "",
+    outputColumns: [],
+    dependencies: [],
+    description: description ?? "",
+    createdAt: ts,
+    updatedAt: ts,
+  };
+  await saveView(view);
+  return view;
+}
+
+/** ビューを削除 */
+export async function deleteView(viewId: string): Promise<void> {
+  if (_backend) {
+    await _backend.deleteView(viewId);
+  } else {
+    localStorage.removeItem(`${LS_PREFIX}${viewId}`);
+    const metas = await listViews();
+    const filtered = renumber(metas.filter((v) => v.id !== viewId));
+    localStorage.setItem(LS_META_KEY, JSON.stringify(filtered));
+  }
+}
+
+// ─── 内部 ────────────────────────────────────────────────────────────────
+
+async function _syncLocalMeta(view: ViewDefinition): Promise<void> {
+  const metas = await listViews();
+  const idx = metas.findIndex((v) => v.id === view.id);
+  const meta: ViewMeta = {
+    id: view.id,
+    no: idx >= 0 ? metas[idx].no : nextNo(metas),
+    description: view.description,
+    updatedAt: view.updatedAt,
+  };
+  if (idx >= 0) metas[idx] = meta;
+  else metas.push(meta);
+  localStorage.setItem(LS_META_KEY, JSON.stringify(renumber(metas)));
+}
+
+/** views.json の全内容をロード（MCP ツール用・エクスポート用） */
+export async function loadViewsFile(): Promise<ViewsFile> {
+  if (_backend) {
+    return ((await _backend.loadViewsFile()) as ViewsFile | null) ?? makeEmptyFile();
+  }
+  const metas = await listViews();
+  const views: ViewDefinition[] = [];
+  for (const m of metas) {
+    const v = await loadView(m.id);
+    if (v) views.push(v);
+  }
+  return { version: "1.0.0", updatedAt: now(), views };
+}

--- a/designer/src/store/viewStore.ts
+++ b/designer/src/store/viewStore.ts
@@ -8,6 +8,7 @@ export interface ViewStorageBackend {
   saveView(viewId: string, data: unknown): Promise<void>;
   deleteView(viewId: string): Promise<void>;
   loadViewsFile(): Promise<unknown>;
+  reorderViews(orderedIds: string[]): Promise<void>;
 }
 
 let _backend: ViewStorageBackend | null = null;
@@ -61,12 +62,12 @@ export async function loadView(viewId: string): Promise<ViewDefinition | null> {
 
 /** ビュー定義を保存 */
 export async function saveView(view: ViewDefinition): Promise<void> {
-  view.updatedAt = now();
+  const toSave = { ...view, updatedAt: now() };
   if (_backend) {
-    await _backend.saveView(view.id, view);
+    await _backend.saveView(toSave.id, toSave);
   } else {
-    localStorage.setItem(`${LS_PREFIX}${view.id}`, JSON.stringify(view));
-    await _syncLocalMeta(view);
+    localStorage.setItem(`${LS_PREFIX}${toSave.id}`, JSON.stringify(toSave));
+    await _syncLocalMeta(toSave);
   }
 }
 
@@ -84,6 +85,18 @@ export async function createView(id: string, description?: string): Promise<View
   };
   await saveView(view);
   return view;
+}
+
+/** ビューの並び順を永続化 */
+export async function reorderViews(orderedIds: string[]): Promise<void> {
+  if (_backend) {
+    await _backend.reorderViews(orderedIds);
+  } else {
+    const metas = await listViews();
+    const map = new Map(metas.map((m) => [m.id, m]));
+    const reordered = orderedIds.map((id) => map.get(id)).filter(Boolean) as ViewMeta[];
+    localStorage.setItem(LS_META_KEY, JSON.stringify(renumber(reordered)));
+  }
 }
 
 /** ビューを削除 */

--- a/designer/src/types/view.ts
+++ b/designer/src/types/view.ts
@@ -1,0 +1,34 @@
+/** ビュー出力列 */
+export interface ViewOutputColumn {
+  name: string;
+  type: string;
+  description?: string;
+}
+
+/** ビュー定義（完全データ） */
+export interface ViewDefinition {
+  id: string;
+  selectStatement: string;
+  outputColumns: ViewOutputColumn[];
+  dependencies?: string[];
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** ビューメタ情報（一覧用） */
+export interface ViewMeta {
+  id: string;
+  /** 物理順 (1..N 連番) */
+  no: number;
+  description?: string;
+  updatedAt: string;
+}
+
+/** views.json ファイル構造 */
+export interface ViewsFile {
+  $schema?: string;
+  version: string;
+  updatedAt: string;
+  views: ViewDefinition[];
+}

--- a/designer/src/utils/serverMtime.ts
+++ b/designer/src/utils/serverMtime.ts
@@ -7,7 +7,7 @@
  */
 import { mcpBridge } from "../mcp/mcpBridge";
 
-export type MtimeKind = "project" | "screen" | "table" | "actionGroup" | "erLayout" | "customBlocks" | "conventions" | "screenItems" | "sequence";
+export type MtimeKind = "project" | "screen" | "table" | "actionGroup" | "erLayout" | "customBlocks" | "conventions" | "screenItems" | "sequence" | "view";
 
 const LAST_SEEN_PREFIX = "mtime-";
 


### PR DESCRIPTION
Closes #376

## 概要

ビュー定義（SELECT 文ベース）の一覧画面とエディタを実装。

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `designer/src/types/view.ts` | ViewDefinition / ViewMeta / ViewsFile 型定義 |
| `designer/src/store/viewStore.ts` | CRUD ストア + reorderViews |
| `designer/src/components/view/ViewListView.tsx` | ビュー一覧画面 (DataList ベース) |
| `designer/src/components/view/ViewEditor.tsx` | ビューエディタ (SELECT 文・出力列・依存テーブル・DDL プレビュー) |
| `designer/src/components/view/generateViewDdl.ts` | DDL 生成 (CREATE OR REPLACE VIEW) |
| `designer/src/components/AppShell.tsx` | /view/list + /view/edit/:viewId ルート追加 |
| `designer/src/components/HeaderMenu.tsx` | ビュー一覧エントリ追加 |
| `designer/src/mcp/mcpBridge.ts` | ViewStorageBackend 登録 |
| `designer/src/store/tabStore.ts` | TabType: view / view-list 追加 |
| `designer/src/utils/serverMtime.ts` | MtimeKind: "view" 追加 |
| `designer-mcp/src/projectStorage.ts` | readViewsFile / writeViewsFile + resolveDataFile 対応 |
| `designer-mcp/src/wsBridge.ts` | loadViewsFile / loadView / saveView / deleteView / reorderViews ハンドラ |

## レビュー指摘対応 (97157a9)

| 種別 | 指摘 | 対応 |
|---|---|---|
| Must | D&D 並び替えが保存されない | `commitViews` で `reorderViews` 呼び出し、views.json に永続化 |
| Must | 重複 ID で既存ビューが上書き | `handleAdd` で重複チェック + エラーメッセージ表示 |
| Should | DDL セミコロン二重問題 | `trimEnd().replace(/;+$/, "") + ";"` で正規化 |
| Should | `saveView` の引数ミューテート | `{ ...view, updatedAt }` で immutable に変更 |

**Should: ストレージパス** — ISSUE は `data/db/views.json` だが実装は `data/views.json`。既存の tables/sequences/actions も `data/` 直下ディレクトリであり一貫性を優先した。

## 仕様逐条突合

- [x] HeaderMenu「ビュー一覧」から画面を開ける — `HeaderMenu.tsx:49-53`
- [x] 新規作成・編集・削除・一覧表示 — `ViewListView.tsx`, `ViewEditor.tsx` (重複チェック済み)
- [x] SELECT 文 (複数行) の編集・保存 — `ViewEditor.tsx:textarea`, `viewStore.saveView`
- [x] 出力列の name/type を手動追加・編集 — `ViewEditor.tsx` 出力列セクション
- [x] 依存テーブルを手動追加 (datalist で既存テーブル選択) — `ViewEditor.tsx` 依存テーブルセクション
- [x] DDL プレビュー連動 — `generateViewDdl.ts` (セミコロン二重修正済み), `ViewEditor.tsx`
- [x] 保存・リロード後もデータ維持 — `viewStore.ts` + `wsBridge.ts` (data/views.json)
- [x] 並び替え永続化 — `reorderViews` + wsBridge `reorderViews` ハンドラ
- [x] FHD / 4K 両対応 — `seq-editor-body` / `seq-editor-left-col` 既存レイアウト利用
- [x] TypeScript ビルドエラーなし — `tsc --noEmit` pass (97157a9)

## 動作確認

UI 影響あり → ユーザー目視確認後マージ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)