### PR TITLE
feat(screen-items): 出力項目に displayFormat / valueFrom を追加 (#377)

### DIFF
--- a/designer/src/components/screen-items/ScreenItemsView.tsx
+++ b/designer/src/components/screen-items/ScreenItemsView.tsx
@@ -63,13 +63,11 @@ const VALUE_SOURCE_KINDS = [
 type OutputFieldsProps = {
   item: ScreenItem;
   idx: number;
-  actionGroups: ActionGroupMeta[];
-  tables: TableMeta[];
   onUpdate: (idx: number, patch: Partial<ScreenItem>) => void;
   onCommit: () => void;
 };
 
-function OutputFields({ item, idx, actionGroups, tables, onUpdate, onCommit }: OutputFieldsProps) {
+function OutputFields({ item, idx, onUpdate, onCommit }: OutputFieldsProps) {
   const kind = item.valueFrom?.kind ?? "";
 
   const handleKindChange = (newKind: string) => {
@@ -78,9 +76,9 @@ function OutputFields({ item, idx, actionGroups, tables, onUpdate, onCommit }: O
     } else if (newKind === "flowVariable") {
       onUpdate(idx, { valueFrom: { kind: "flowVariable", variableName: "" } });
     } else if (newKind === "tableColumn") {
-      onUpdate(idx, { valueFrom: { kind: "tableColumn", tableId: "", columnName: "" } });
+      onUpdate(idx, { valueFrom: { kind: "tableColumn", tableName: "", columnName: "" } });
     } else if (newKind === "viewColumn") {
-      onUpdate(idx, { valueFrom: { kind: "viewColumn", viewId: "", columnName: "" } });
+      onUpdate(idx, { valueFrom: { kind: "viewColumn", viewName: "", columnName: "" } });
     } else if (newKind === "expression") {
       onUpdate(idx, { valueFrom: { kind: "expression", expression: "" } });
     }
@@ -151,13 +149,13 @@ function OutputFields({ item, idx, actionGroups, tables, onUpdate, onCommit }: O
           {kind === "tableColumn" && (
             <>
               <label className="screen-items-detail-field" style={{ minWidth: "12em" }}>
-                <span className="screen-items-detail-label">テーブル</span>
+                <span className="screen-items-detail-label">テーブル名</span>
                 <input
                   type="text"
                   list="screen-items-table-list"
                   className="form-control form-control-sm"
-                  value={(item.valueFrom as Extract<ValueSource, { kind: "tableColumn" }>).tableId}
-                  onChange={(e) => handleValueFromPatch({ tableId: e.target.value } as Partial<ValueSource>)}
+                  value={(item.valueFrom as Extract<ValueSource, { kind: "tableColumn" }>).tableName}
+                  onChange={(e) => handleValueFromPatch({ tableName: e.target.value } as Partial<ValueSource>)}
                   onBlur={onCommit}
                   placeholder="users"
                 />
@@ -177,11 +175,14 @@ function OutputFields({ item, idx, actionGroups, tables, onUpdate, onCommit }: O
           {kind === "viewColumn" && (
             <>
               <label className="screen-items-detail-field" style={{ minWidth: "12em" }}>
-                <span className="screen-items-detail-label">ビュー</span>
+                <span className="screen-items-detail-label">
+                  ビュー名
+                  <span className="screen-items-todo-note" title="ビュー一覧は #376 で実装予定">※手動入力</span>
+                </span>
                 <input
                   className="form-control form-control-sm"
-                  value={(item.valueFrom as Extract<ValueSource, { kind: "viewColumn" }>).viewId}
-                  onChange={(e) => handleValueFromPatch({ viewId: e.target.value } as Partial<ValueSource>)}
+                  value={(item.valueFrom as Extract<ValueSource, { kind: "viewColumn" }>).viewName}
+                  onChange={(e) => handleValueFromPatch({ viewName: e.target.value } as Partial<ValueSource>)}
                   onBlur={onCommit}
                   placeholder="v_customer_summary"
                 />
@@ -212,15 +213,6 @@ function OutputFields({ item, idx, actionGroups, tables, onUpdate, onCommit }: O
           )}
         </div>
       </div>
-      <datalist id="screen-items-display-format-list">
-        {DISPLAY_FORMAT_PRESETS.map((f) => <option key={f} value={f} />)}
-      </datalist>
-      <datalist id="screen-items-action-group-list">
-        {actionGroups.map((ag) => <option key={ag.id} value={ag.id}>{ag.name}</option>)}
-      </datalist>
-      <datalist id="screen-items-table-list">
-        {tables.map((t) => <option key={t.id} value={t.name}>{t.logicalName}</option>)}
-      </datalist>
     </div>
   );
 }
@@ -1073,8 +1065,6 @@ export function ScreenItemsView() {
                           <OutputFields
                             item={item}
                             idx={i}
-                            actionGroups={actionGroups}
-                            tables={tables}
                             onUpdate={handleUpdateItem}
                             onCommit={commit}
                           />
@@ -1137,6 +1127,15 @@ export function ScreenItemsView() {
             </div>
             <datalist id="screen-items-type-list">
               {PRIMITIVE_TYPES.map((t) => <option key={t} value={t} />)}
+            </datalist>
+            <datalist id="screen-items-display-format-list">
+              {DISPLAY_FORMAT_PRESETS.map((f) => <option key={f} value={f} />)}
+            </datalist>
+            <datalist id="screen-items-action-group-list">
+              {actionGroups.map((ag) => <option key={ag.id} value={ag.id}>{ag.name}</option>)}
+            </datalist>
+            <datalist id="screen-items-table-list">
+              {tables.map((t) => <option key={t.id} value={t.name}>{t.logicalName}</option>)}
             </datalist>
           </div>
           </>

--- a/designer/src/components/screen-items/ScreenItemsView.tsx
+++ b/designer/src/components/screen-items/ScreenItemsView.tsx
@@ -24,8 +24,12 @@ import { loadConventions } from "../../store/conventionsStore";
 import { checkScreenItemConventionReferences } from "../../schemas/conventionsValidator";
 import type { ConventionsCatalog, ConventionIssue } from "../../schemas/conventionsValidator";
 import { mcpBridge } from "../../mcp/mcpBridge";
-import type { ScreenItem, ScreenItemsFile } from "../../types/screenItem";
+import type { ScreenItem, ScreenItemsFile, ValueSource } from "../../types/screenItem";
 import type { FieldType } from "../../types/action";
+import type { ActionGroupMeta } from "../../types/action";
+import type { TableMeta } from "../../types/table";
+import { listActionGroups } from "../../store/actionStore";
+import { listTables } from "../../store/tableStore";
 import { ConvCompletionInput } from "../common/ConvCompletionInput";
 import { ScreenItemCandidatesModal } from "./ScreenItemCandidatesModal";
 import type { ExtractedCandidate } from "../../utils/screenItemExtractor";
@@ -34,6 +38,192 @@ import "../../styles/screen-items.css";
 
 const PRIMITIVE_TYPES: Array<"string" | "number" | "boolean" | "date"> =
   ["string", "number", "boolean", "date"];
+
+const DISPLAY_FORMAT_PRESETS = [
+  "YYYY/MM/DD",
+  "YYYY-MM-DD",
+  "YYYY年MM月DD日",
+  "YYYY/MM/DD HH:mm:ss",
+  "#,##0",
+  "0.00",
+  "#,##0.00",
+  "¥#,##0",
+  "$#,##0.00",
+  "0%",
+  "0.00%",
+];
+
+const VALUE_SOURCE_KINDS = [
+  { value: "flowVariable", label: "処理フロー変数" },
+  { value: "tableColumn", label: "テーブル列" },
+  { value: "viewColumn", label: "ビュー列" },
+  { value: "expression", label: "計算式" },
+] as const;
+
+type OutputFieldsProps = {
+  item: ScreenItem;
+  idx: number;
+  actionGroups: ActionGroupMeta[];
+  tables: TableMeta[];
+  onUpdate: (idx: number, patch: Partial<ScreenItem>) => void;
+  onCommit: () => void;
+};
+
+function OutputFields({ item, idx, actionGroups, tables, onUpdate, onCommit }: OutputFieldsProps) {
+  const kind = item.valueFrom?.kind ?? "";
+
+  const handleKindChange = (newKind: string) => {
+    if (!newKind) {
+      onUpdate(idx, { valueFrom: undefined });
+    } else if (newKind === "flowVariable") {
+      onUpdate(idx, { valueFrom: { kind: "flowVariable", variableName: "" } });
+    } else if (newKind === "tableColumn") {
+      onUpdate(idx, { valueFrom: { kind: "tableColumn", tableId: "", columnName: "" } });
+    } else if (newKind === "viewColumn") {
+      onUpdate(idx, { valueFrom: { kind: "viewColumn", viewId: "", columnName: "" } });
+    } else if (newKind === "expression") {
+      onUpdate(idx, { valueFrom: { kind: "expression", expression: "" } });
+    }
+    onCommit();
+  };
+
+  const handleValueFromPatch = (patch: Partial<ValueSource>) => {
+    if (!item.valueFrom) return;
+    onUpdate(idx, { valueFrom: { ...item.valueFrom, ...patch } as ValueSource });
+  };
+
+  return (
+    <div className="screen-items-output-section">
+      <div className="screen-items-output-title">出力設定</div>
+      <div className="screen-items-output-fields">
+        <label className="screen-items-detail-field" style={{ minWidth: "14em", maxWidth: "20em" }}>
+          <span className="screen-items-detail-label">表示フォーマット</span>
+          <input
+            type="text"
+            list="screen-items-display-format-list"
+            className="form-control form-control-sm"
+            value={item.displayFormat ?? ""}
+            onChange={(e) => onUpdate(idx, { displayFormat: e.target.value || undefined })}
+            onBlur={onCommit}
+            placeholder="YYYY/MM/DD"
+          />
+        </label>
+        <div className="screen-items-valuefrom">
+          <label className="screen-items-detail-field" style={{ minWidth: "10em", maxWidth: "14em" }}>
+            <span className="screen-items-detail-label">バインド元 (種別)</span>
+            <select
+              className="form-select form-select-sm"
+              value={kind}
+              onChange={(e) => handleKindChange(e.target.value)}
+            >
+              <option value="">— 未設定 —</option>
+              {VALUE_SOURCE_KINDS.map((k) => (
+                <option key={k.value} value={k.value}>{k.label}</option>
+              ))}
+            </select>
+          </label>
+          {kind === "flowVariable" && (
+            <>
+              <label className="screen-items-detail-field" style={{ minWidth: "12em" }}>
+                <span className="screen-items-detail-label">処理フロー</span>
+                <input
+                  type="text"
+                  list="screen-items-action-group-list"
+                  className="form-control form-control-sm"
+                  value={(item.valueFrom as Extract<ValueSource, { kind: "flowVariable" }>).actionGroupId ?? ""}
+                  onChange={(e) => handleValueFromPatch({ actionGroupId: e.target.value || undefined } as Partial<ValueSource>)}
+                  onBlur={onCommit}
+                  placeholder="省略可"
+                />
+              </label>
+              <label className="screen-items-detail-field" style={{ minWidth: "12em" }}>
+                <span className="screen-items-detail-label">変数名</span>
+                <input
+                  className="form-control form-control-sm"
+                  value={(item.valueFrom as Extract<ValueSource, { kind: "flowVariable" }>).variableName}
+                  onChange={(e) => handleValueFromPatch({ variableName: e.target.value } as Partial<ValueSource>)}
+                  onBlur={onCommit}
+                  placeholder="result"
+                />
+              </label>
+            </>
+          )}
+          {kind === "tableColumn" && (
+            <>
+              <label className="screen-items-detail-field" style={{ minWidth: "12em" }}>
+                <span className="screen-items-detail-label">テーブル</span>
+                <input
+                  type="text"
+                  list="screen-items-table-list"
+                  className="form-control form-control-sm"
+                  value={(item.valueFrom as Extract<ValueSource, { kind: "tableColumn" }>).tableId}
+                  onChange={(e) => handleValueFromPatch({ tableId: e.target.value } as Partial<ValueSource>)}
+                  onBlur={onCommit}
+                  placeholder="users"
+                />
+              </label>
+              <label className="screen-items-detail-field" style={{ minWidth: "12em" }}>
+                <span className="screen-items-detail-label">列名</span>
+                <input
+                  className="form-control form-control-sm"
+                  value={(item.valueFrom as Extract<ValueSource, { kind: "tableColumn" }>).columnName}
+                  onChange={(e) => handleValueFromPatch({ columnName: e.target.value } as Partial<ValueSource>)}
+                  onBlur={onCommit}
+                  placeholder="created_at"
+                />
+              </label>
+            </>
+          )}
+          {kind === "viewColumn" && (
+            <>
+              <label className="screen-items-detail-field" style={{ minWidth: "12em" }}>
+                <span className="screen-items-detail-label">ビュー</span>
+                <input
+                  className="form-control form-control-sm"
+                  value={(item.valueFrom as Extract<ValueSource, { kind: "viewColumn" }>).viewId}
+                  onChange={(e) => handleValueFromPatch({ viewId: e.target.value } as Partial<ValueSource>)}
+                  onBlur={onCommit}
+                  placeholder="v_customer_summary"
+                />
+              </label>
+              <label className="screen-items-detail-field" style={{ minWidth: "12em" }}>
+                <span className="screen-items-detail-label">列名</span>
+                <input
+                  className="form-control form-control-sm"
+                  value={(item.valueFrom as Extract<ValueSource, { kind: "viewColumn" }>).columnName}
+                  onChange={(e) => handleValueFromPatch({ columnName: e.target.value } as Partial<ValueSource>)}
+                  onBlur={onCommit}
+                  placeholder="last_order_at"
+                />
+              </label>
+            </>
+          )}
+          {kind === "expression" && (
+            <label className="screen-items-detail-field" style={{ minWidth: "18em", flex: 2 }}>
+              <span className="screen-items-detail-label">計算式</span>
+              <input
+                className="form-control form-control-sm"
+                value={(item.valueFrom as Extract<ValueSource, { kind: "expression" }>).expression}
+                onChange={(e) => handleValueFromPatch({ expression: e.target.value } as Partial<ValueSource>)}
+                onBlur={onCommit}
+                placeholder="@inputs.price * @inputs.qty"
+              />
+            </label>
+          )}
+        </div>
+      </div>
+      <datalist id="screen-items-display-format-list">
+        {DISPLAY_FORMAT_PRESETS.map((f) => <option key={f} value={f} />)}
+      </datalist>
+      <datalist id="screen-items-action-group-list">
+        {actionGroups.map((ag) => <option key={ag.id} value={ag.id}>{ag.name}</option>)}
+      </datalist>
+      <datalist id="screen-items-table-list">
+        {tables.map((t) => <option key={t.id} value={t.name}>{t.logicalName}</option>)}
+      </datalist>
+    </div>
+  );
+}
 
 const JS_IDENTIFIER_RE = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/;
 
@@ -58,6 +248,8 @@ export function ScreenItemsView() {
   const [lintIssues, setLintIssues] = useState<ConventionIssue[]>([]);
   const [expandedErrorRows, setExpandedErrorRows] = useState<Set<number>>(new Set());
   const [expandedDetailRows, setExpandedDetailRows] = useState<Set<number>>(new Set());
+  const [actionGroups, setActionGroups] = useState<ActionGroupMeta[]>([]);
+  const [tables, setTables] = useState<TableMeta[]>([]);
 
   /** ID フィールドのフォーカス時の値 (行インデックス → 元の値) */
   const idFocusVals = useRef<Map<number, string>>(new Map());
@@ -84,6 +276,12 @@ export function ScreenItemsView() {
   // 規約カタログをロード (初回のみ)
   useEffect(() => {
     loadConventions().then(setConventions).catch(console.error);
+  }, []);
+
+  // 処理フロー・テーブル一覧をロード (valueFrom datalist 用)
+  useEffect(() => {
+    listActionGroups().then(setActionGroups).catch(console.error);
+    listTables().then(setTables).catch(console.error);
   }, []);
 
   // 画面一覧をロード (初回 + MCP 接続復帰時)
@@ -871,6 +1069,16 @@ export function ScreenItemsView() {
                             />
                           </label>
                         </div>
+                        {item.direction === "output" && (
+                          <OutputFields
+                            item={item}
+                            idx={i}
+                            actionGroups={actionGroups}
+                            tables={tables}
+                            onUpdate={handleUpdateItem}
+                            onCommit={commit}
+                          />
+                        )}
                       </td>
                     </tr>
                   )}

--- a/designer/src/styles/screen-items.css
+++ b/designer/src/styles/screen-items.css
@@ -188,6 +188,34 @@
   font-family: ui-monospace, SFMono-Regular, monospace;
 }
 
+/* 出力項目専用フィールド (#377) */
+.screen-items-output-section {
+  width: 100%;
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px dashed #bfdbfe;
+}
+.screen-items-output-title {
+  font-size: 0.68rem;
+  font-weight: 700;
+  color: #1d4ed8;
+  margin-bottom: 6px;
+  letter-spacing: 0.03em;
+}
+.screen-items-output-fields {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: flex-end;
+}
+.screen-items-valuefrom {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: flex-end;
+  flex: 1;
+}
+
 /* 画面項目候補モーダル (#323) */
 .screen-item-candidates-overlay {
   position: fixed;

--- a/designer/src/styles/screen-items.css
+++ b/designer/src/styles/screen-items.css
@@ -215,6 +215,13 @@
   align-items: flex-end;
   flex: 1;
 }
+.screen-items-todo-note {
+  margin-left: 4px;
+  font-size: 0.65rem;
+  font-weight: 400;
+  color: #94a3b8;
+  font-family: inherit;
+}
 
 /* 画面項目候補モーダル (#323) */
 .screen-item-candidates-overlay {

--- a/designer/src/types/screenItem.ts
+++ b/designer/src/types/screenItem.ts
@@ -1,5 +1,5 @@
 /**
- * 画面項目定義 (#318 / docs/spec/screen-items.md v0.1 相当)。
+ * 画面項目定義 (#318 / docs/spec/screen-items.md v1.1 相当)。
  *
  * 画面 (GrapesJS) のフォーム要素に紐付けるバリデーション・ラベル・表示制御を
  * 宣言的に保持する。処理フローの inputs から screenItemRef で参照される想定。
@@ -7,6 +7,16 @@
  * ファイル配置: data/screen-items/{screenId}.json (1 画面 = 1 ファイル)
  */
 import type { FieldType } from "./action";
+
+/**
+ * 出力項目 (direction="output") のバインド元 (#377)。
+ * 処理フロー変数 / テーブル列 / ビュー列 / 計算式 の 4 種別。
+ */
+export type ValueSource =
+  | { kind: "flowVariable"; actionGroupId?: string; variableName: string }
+  | { kind: "tableColumn"; tableId: string; columnName: string }
+  | { kind: "viewColumn"; viewId: string; columnName: string }
+  | { kind: "expression"; expression: string };
 
 export interface ScreenItemSelectOption {
   value: string;
@@ -65,6 +75,12 @@ export interface ScreenItem {
   // ─── 画面上での役割 ─────────────────────────────────────────────
   /** "input": フォーム入力 (デフォルト) / "output": データ表示 */
   direction?: "input" | "output";
+
+  // ─── 出力項目専用 (direction="output" のみ) ──────────────────────
+  /** 表示書式 (例: "YYYY/MM/DD", "¥#,##0", "0.00%") */
+  displayFormat?: string;
+  /** バインド元 — どのデータを表示するか (#377) */
+  valueFrom?: ValueSource;
 
   // ─── 備考 ──────────────────────────────────────────────────────
   description?: string;

--- a/designer/src/types/screenItem.ts
+++ b/designer/src/types/screenItem.ts
@@ -14,8 +14,8 @@ import type { FieldType } from "./action";
  */
 export type ValueSource =
   | { kind: "flowVariable"; actionGroupId?: string; variableName: string }
-  | { kind: "tableColumn"; tableId: string; columnName: string }
-  | { kind: "viewColumn"; viewId: string; columnName: string }
+  | { kind: "tableColumn"; tableName: string; columnName: string }
+  | { kind: "viewColumn"; viewName: string; columnName: string }
   | { kind: "expression"; expression: string };
 
 export interface ScreenItemSelectOption {

--- a/docs/spec/screen-items.md
+++ b/docs/spec/screen-items.md
@@ -1,9 +1,10 @@
 # 画面項目定義 (Screen Items)
 
-**ステータス**: v1.0 (凍結)
+**ステータス**: v1.1 (凍結)
 **策定開始**: 2026-04-22
-**凍結日**: 2026-04-23
-**関連 issue**: #318 #354
+**凍結日 v1.0**: 2026-04-23
+**更新 v1.1**: 2026-04-24 — 出力項目の `displayFormat` / `valueFrom` 追加 (#377)
+**関連 issue**: #318 #354 #377
 
 本書は画面項目定義 (画面 UI のフォーム項目に宣言的にバリデーション・ラベル・表示制御を紐付ける設計書) の仕様を定める。
 
@@ -86,9 +87,22 @@ interface ScreenItem {
   enabledWhen?: string;
   /** 画面上での役割 (デフォルト: "input") */
   direction?: "input" | "output";
+  /** 表示書式 (direction="output" 専用, 例: "YYYY/MM/DD", "¥#,##0") — #377 */
+  displayFormat?: string;
+  /** バインド元 (direction="output" 専用) — #377 */
+  valueFrom?: ValueSource;
   /** 備考 */
   description?: string;
 }
+
+/**
+ * 出力項目のバインド元 (4 種別) — #377
+ */
+type ValueSource =
+  | { kind: "flowVariable"; actionGroupId?: string; variableName: string }
+  | { kind: "tableColumn"; tableId: string; columnName: string }
+  | { kind: "viewColumn"; viewId: string; columnName: string }
+  | { kind: "expression"; expression: string };
 
 interface ScreenItemsFile {
   $schema?: string;
@@ -374,6 +388,9 @@ MVP は 1-2-3 まで。4-5-6 は段階的に。
 ### (A) データモデル
 - **A-1**: 独立ファイル方式 (`data/screen-items/{screenId}.json`) を採用
 - **A-2**: `ScreenItem` スキーマは上記の通り。`direction?: "input" | "output"` を追加 (#359 連動)
+- **A-3 (v1.1)**: `displayFormat?: string` / `valueFrom?: ValueSource` を追加 (#377)。`direction="output"` のときのみ使用。
+  - `displayFormat`: 自由記述 + datalist 補完 (日付 / 数値 / 金額 / パーセント プリセット)
+  - `valueFrom`: `flowVariable` / `tableColumn` / `viewColumn` / `expression` の 4 種別。入力項目 (`direction="input"` または未設定) ではエディタに表示されない
 - `name` は廃止、`id` が業務識別子を兼ねる (#330)
 
 ### (B) 処理フローとの関係

--- a/docs/spec/screen-items.md
+++ b/docs/spec/screen-items.md
@@ -100,8 +100,8 @@ interface ScreenItem {
  */
 type ValueSource =
   | { kind: "flowVariable"; actionGroupId?: string; variableName: string }
-  | { kind: "tableColumn"; tableId: string; columnName: string }
-  | { kind: "viewColumn"; viewId: string; columnName: string }
+  | { kind: "tableColumn"; tableName: string; columnName: string }   // tableName は物理名
+  | { kind: "viewColumn"; viewName: string; columnName: string }     // viewName は物理名
   | { kind: "expression"; expression: string };
 
 interface ScreenItemsFile {


### PR DESCRIPTION
Closes #377

## 概要

PR #363 で追加した `direction: "output"` の出力項目に、表示フォーマットとバインド元を設定できるようにする。

## 変更内容

### 型定義 (`designer/src/types/screenItem.ts`)
- `ValueSource` 型を新規追加 (4 種別: flowVariable / tableColumn / viewColumn / expression)
  - テーブル列は `tableName: string` (物理名)、ビュー列は `viewName: string` (物理名)
- `ScreenItem` に `displayFormat?: string` / `valueFrom?: ValueSource` フィールドを追加

### UI (`designer/src/components/screen-items/ScreenItemsView.tsx`)
- `OutputFields` コンポーネントを新設 (props は item / idx / onUpdate / onCommit のみ)
- 詳細展開行 (スライダーアイコン) で `direction=output` のときのみ「出力設定」セクションを表示
  - 表示フォーマット: datalist 補完 (日付/数値/金額/パーセント 11 プリセット) + 自由入力
  - バインド元: 種別 select → 種別ごとのフィールド
    - flowVariable: 処理フロー名 (datalist) + 変数名
    - tableColumn: テーブル名 (datalist) + 列名
    - viewColumn: ビュー名 (手動入力、「※手動入力」注記あり) + 列名
    - expression: 計算式テキスト
- datalist 3つ (displayFormat / actionGroup / table) は `ScreenItemsView` 直下に 1 つずつ配置 (重複 ID 排除)
- 処理フロー一覧・テーブル一覧を datalist として読み込み補完

### スタイル (`designer/src/styles/screen-items.css`)
- 出力設定セクション用スタイル追加 (青点線ボーダーで入力/出力フィールドを視覚的に区切り)
- `screen-items-todo-note` スタイル追加 (viewColumn の未実装注記)

### 仕様書 (`docs/spec/screen-items.md`)
- v1.0 → v1.1 に更新
- `displayFormat` / `valueFrom` / `ValueSource` を仕様に追記
- 決定事項に A-3 (v1.1) として追記

## 仕様逐条突合

| 条項 | 対応箇所 |
|------|---------|
| `displayFormat?: string` 追加 | `screenItem.ts:80-81` |
| `valueFrom?: ValueSource` 追加 | `screenItem.ts:82-83` |
| `ValueSource` 4 種別定義 | `screenItem.ts:15-19` |
| datalist 補完 + 自由入力 | `ScreenItemsView.tsx` `DISPLAY_FORMAT_PRESETS` + `input[list]` |
| valueFrom 4 種別 UI | `OutputFields` コンポーネント、kind select + 種別ごと分岐 |
| datalist で既存データ補完 (flowVariable/tableColumn) | `listActionGroups` / `listTables` ロード + datalist (親コンポーネント) |
| viewColumn の datalist 補完 | ビュー一覧 (#376) 未実装のため手動入力 + 「※手動入力」注記で明示 |
| direction=input では非表示 | `{item.direction === "output" && <OutputFields ...>}` |
| 保存・リロード後も維持 | useResourceEditor + screenItemsStore の既存保存フロー |
| spec 追記 | `docs/spec/screen-items.md` v1.1 |
| TypeScript ビルドエラーなし | `npm run build` 通過 |

## テスト

- TypeScript ビルド: ✅ pass
- UI 目視確認: ユーザーによる確認が必要 (CLAUDE.md 規約)

🤖 Generated with [Claude Code](https://claude.com/claude-code)