### PR TITLE
fix: PR #379-#386 間の統合ギャップ修正 (β↔γ↔ε の store 連携 + tx.default) (#387)

### DIFF
--- a/designer/src/components/screen-items/ScreenItemsView.tsx
+++ b/designer/src/components/screen-items/ScreenItemsView.tsx
@@ -1141,7 +1141,7 @@ export function ScreenItemsView() {
               {tables.map((t) => <option key={t.id} value={t.name}>{t.logicalName}</option>)}
             </datalist>
             <datalist id="screen-items-view-list">
-              {views.map((v) => <option key={v.id} value={v.id} />)}
+              {views.map((v) => <option key={v.id} value={v.id}>{v.description}</option>)}
             </datalist>
           </div>
           </>

--- a/designer/src/components/screen-items/ScreenItemsView.tsx
+++ b/designer/src/components/screen-items/ScreenItemsView.tsx
@@ -30,6 +30,8 @@ import type { ActionGroupMeta } from "../../types/action";
 import type { TableMeta } from "../../types/table";
 import { listActionGroups } from "../../store/actionStore";
 import { listTables } from "../../store/tableStore";
+import { listViews } from "../../store/viewStore";
+import type { ViewMeta } from "../../types/view";
 import { ConvCompletionInput } from "../common/ConvCompletionInput";
 import { ScreenItemCandidatesModal } from "./ScreenItemCandidatesModal";
 import type { ExtractedCandidate } from "../../utils/screenItemExtractor";
@@ -175,11 +177,10 @@ function OutputFields({ item, idx, onUpdate, onCommit }: OutputFieldsProps) {
           {kind === "viewColumn" && (
             <>
               <label className="screen-items-detail-field" style={{ minWidth: "12em" }}>
-                <span className="screen-items-detail-label">
-                  ビュー名
-                  <span className="screen-items-todo-note" title="ビュー一覧は #376 で実装予定">※手動入力</span>
-                </span>
+                <span className="screen-items-detail-label">ビュー名</span>
                 <input
+                  type="text"
+                  list="screen-items-view-list"
                   className="form-control form-control-sm"
                   value={(item.valueFrom as Extract<ValueSource, { kind: "viewColumn" }>).viewName}
                   onChange={(e) => handleValueFromPatch({ viewName: e.target.value } as Partial<ValueSource>)}
@@ -242,6 +243,7 @@ export function ScreenItemsView() {
   const [expandedDetailRows, setExpandedDetailRows] = useState<Set<number>>(new Set());
   const [actionGroups, setActionGroups] = useState<ActionGroupMeta[]>([]);
   const [tables, setTables] = useState<TableMeta[]>([]);
+  const [views, setViews] = useState<ViewMeta[]>([]);
 
   /** ID フィールドのフォーカス時の値 (行インデックス → 元の値) */
   const idFocusVals = useRef<Map<number, string>>(new Map());
@@ -270,10 +272,11 @@ export function ScreenItemsView() {
     loadConventions().then(setConventions).catch(console.error);
   }, []);
 
-  // 処理フロー・テーブル一覧をロード (valueFrom datalist 用)
+  // 処理フロー・テーブル・ビュー一覧をロード (valueFrom datalist 用)
   useEffect(() => {
     listActionGroups().then(setActionGroups).catch(console.error);
     listTables().then(setTables).catch(console.error);
+    listViews().then(setViews).catch(console.error);
   }, []);
 
   // 画面一覧をロード (初回 + MCP 接続復帰時)
@@ -1136,6 +1139,9 @@ export function ScreenItemsView() {
             </datalist>
             <datalist id="screen-items-table-list">
               {tables.map((t) => <option key={t.id} value={t.name}>{t.logicalName}</option>)}
+            </datalist>
+            <datalist id="screen-items-view-list">
+              {views.map((v) => <option key={v.id} value={v.id} />)}
             </datalist>
           </div>
           </>

--- a/designer/src/components/table/TriggersDefaultsTab.tsx
+++ b/designer/src/components/table/TriggersDefaultsTab.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect, useMemo } from "react";
 import type {
   TableDefinition,
   DefaultDefinition,
@@ -8,17 +8,10 @@ import type {
   TriggerEvent,
 } from "../../types/table";
 import { addDefault, removeDefault, addTrigger, removeTrigger } from "../../store/tableStore";
-
-// @conv.numbering.* の候補 (datalist 補完用)
-const CONVENTION_REF_SUGGESTIONS = [
-  "@conv.numbering.orderNumber",
-  "@conv.numbering.invoiceNumber",
-  "@conv.numbering.purchaseOrderNumber",
-  "@conv.numbering.customerCode",
-  "@conv.numbering.productCode",
-  "@conv.numbering.receiptNumber",
-  "@conv.numbering.shipmentNumber",
-];
+import { listSequences } from "../../store/sequenceStore";
+import { loadConventions } from "../../store/conventionsStore";
+import type { SequenceMeta } from "../../types/sequence";
+import type { ConventionsCatalog } from "../../schemas/conventionsValidator";
 
 const DEFAULT_KIND_LABELS: Record<DefaultKind, string> = {
   literal: "リテラル (例: 0, 'active')",
@@ -38,6 +31,18 @@ interface Props {
 export function TriggersDefaultsTab({ table, update }: Props) {
   const [editingDefaultCol, setEditingDefaultCol] = useState<string | null>(null);
   const [editingTriggerId, setEditingTriggerId] = useState<string | null>(null);
+  const [sequences, setSequences] = useState<SequenceMeta[]>([]);
+  const [conventions, setConventions] = useState<ConventionsCatalog | null>(null);
+
+  useEffect(() => {
+    listSequences().then(setSequences).catch(console.error);
+    loadConventions().then(setConventions).catch(console.error);
+  }, []);
+
+  const numberingKeys = useMemo(() => {
+    if (!conventions?.numbering) return [];
+    return Object.keys(conventions.numbering).map((k) => `@conv.numbering.${k}`);
+  }, [conventions]);
 
   const defaults = table.defaults ?? [];
   const triggers = table.triggers ?? [];
@@ -126,6 +131,8 @@ export function TriggersDefaultsTab({ table, update }: Props) {
                   def={def}
                   colNames={colNames}
                   usedCols={new Set(defaults.map((d) => d.column).filter((c) => c !== def.column))}
+                  sequences={sequences}
+                  numberingKeys={numberingKeys}
                   onUpdate={(patch) => handleUpdateDefault(def.column, patch)}
                   onClose={() => setEditingDefaultCol(null)}
                   onDelete={() => handleDeleteDefault(def.column)}
@@ -222,11 +229,13 @@ function DefaultRow({
 // ── DEFAULT 値 編集カード ─────────────────────────────────────────────────────
 
 function DefaultEditorCard({
-  def, colNames, usedCols, onUpdate, onClose, onDelete,
+  def, colNames, usedCols, sequences, numberingKeys, onUpdate, onClose, onDelete,
 }: {
   def: DefaultDefinition;
   colNames: string[];
   usedCols: Set<string>;
+  sequences: SequenceMeta[];
+  numberingKeys: string[];
   onUpdate: (patch: Partial<DefaultDefinition>) => void;
   onClose: () => void;
   onDelete: () => void;
@@ -288,7 +297,7 @@ function DefaultEditorCard({
                 className="td-value-input"
               />
               <datalist id="conv-numbering-list">
-                {CONVENTION_REF_SUGGESTIONS.map((s) => (
+                {numberingKeys.map((s) => (
                   <option key={s} value={s} />
                 ))}
               </datalist>
@@ -297,13 +306,21 @@ function DefaultEditorCard({
               </span>
             </>
           ) : (
-            <input
-              type="text"
-              value={def.value}
-              onChange={(e) => onUpdate({ value: e.target.value })}
-              placeholder={def.kind === "literal" ? "0 または 'active'" : def.kind === "sequence" ? "seq_name" : "NOW()"}
-              className="td-value-input"
-            />
+            <>
+              <input
+                type="text"
+                list={def.kind === "sequence" ? "td-sequence-list" : undefined}
+                value={def.value}
+                onChange={(e) => onUpdate({ value: e.target.value })}
+                placeholder={def.kind === "literal" ? "0 または 'active'" : def.kind === "sequence" ? "seq_name" : "NOW()"}
+                className="td-value-input"
+              />
+              {def.kind === "sequence" && (
+                <datalist id="td-sequence-list">
+                  {sequences.map((s) => <option key={s.id} value={s.id} />)}
+                </datalist>
+              )}
+            </>
           )}
         </label>
 

--- a/designer/src/styles/screen-items.css
+++ b/designer/src/styles/screen-items.css
@@ -215,13 +215,6 @@
   align-items: flex-end;
   flex: 1;
 }
-.screen-items-todo-note {
-  margin-left: 4px;
-  font-size: 0.65rem;
-  font-weight: 400;
-  color: #94a3b8;
-  font-family: inherit;
-}
 
 /* 画面項目候補モーダル (#323) */
 .screen-item-candidates-overlay {


### PR DESCRIPTION
## 概要

Closes #387

2026-04-24 の Opus 横断レビューで発見した、マージ済み 7 PR (#379-#386) 間の統合ギャップ 4 件を修正。

---

## 変更内容

### Gap 1: β DEFAULT "sequence" kind ↔ γ sequenceStore 連携

**ファイル**: `designer/src/components/table/TriggersDefaultsTab.tsx`

- `TriggersDefaultsTab` で `listSequences()` を useEffect ロード
- sequence kind の input に `list="td-sequence-list"` を追加
- `<datalist id="td-sequence-list">` にγで登録したシーケンス一覧を表示

### Gap 2: β `CONVENTION_REF_SUGGESTIONS` hardcoded → catalog.json 動的読み込み

**ファイル**: `designer/src/components/table/TriggersDefaultsTab.tsx`

- `CONVENTION_REF_SUGGESTIONS` 定数を削除
- `loadConventions()` を useEffect ロード
- `useMemo` で `catalog.numbering` キーから `@conv.numbering.*` 候補を動的生成
- catalog に新規 numbering エントリを追加すると UI に即反映

### Gap 3: `catalog.json` tx.singleOperation に default フラグを追加

**ファイル**: `data/conventions/catalog.json` (gitignored・ランタイムデータ)

- `tx.singleOperation` に `"default": true` を追加
- `data/` は gitignored のためコミット対象外、適用済み

### Gap 4: ε valueFrom "viewColumn" ↔ δ viewStore 連携

**ファイル**: `designer/src/components/screen-items/ScreenItemsView.tsx`

- `listViews()` / `ViewMeta` を import
- `views` state を追加、既存 useEffect に `listViews()` を追加
- viewColumn kind の input に `list="screen-items-view-list"` を追加
- `<datalist id="screen-items-view-list">` にδで登録したビュー一覧を表示
- 「※手動入力」注記を削除

---

## テスト

- TypeScript: `npx tsc --noEmit` → エラーなし
- Vitest: 699 tests passed (46 files)

---

## 仕様逐条突合

| # | 受け入れ基準 | 対応箇所 |
|---|---|---|
| Gap1-1 | DEFAULT "sequence" kind に `list="..."` が設定される | `TriggersDefaultsTab.tsx:300` |
| Gap1-2 | `<datalist>` にγ登録シーケンスが表示される | `TriggersDefaultsTab.tsx:303` |
| Gap1-3 | 新規シーケンス登録で候補に反映 | useEffect + listSequences() |
| Gap1-4 | 既存データ破壊なし | 入力値の変更なし |
| Gap2-1 | `CONVENTION_REF_SUGGESTIONS` 定数が削除される | 削除済み |
| Gap2-2 | `loadConventions()` から動的生成 | `TriggersDefaultsTab.tsx:49-58` |
| Gap2-3 | catalog 追加で UI 反映 | useMemo(conventions) |
| Gap3-1 | `tx.singleOperation.default` が `true` | catalog.json 修正済み |
| Gap4-1 | viewColumn に `list="screen-items-view-list"` | `ScreenItemsView.tsx:183` |
| Gap4-2 | `<datalist>` にδ登録ビューが表示される | `ScreenItemsView.tsx:1141` |
| Gap4-3 | 「※手動入力」注記が削除される | 削除済み |
| Gap4-4 | 新規ビュー登録で候補に反映 | useEffect + listViews() |

---

## UI 確認項目 (目視必須)

1. テーブル定義 → DEFAULT 値追加 → kind "sequence" 選択 → γ登録シーケンスが候補に出るか
2. 同画面 → kind "規約参照" 選択 → 候補が catalog.json の numbering カテゴリと一致するか
3. 画面項目定義 → output の項目 → valueFrom "viewColumn" 選択 → δ登録ビューが候補に出るか

UI 影響あり → 別セッションで `/review-pr` + ユーザー目視確認後マージ

🤖 Generated with [Claude Code](https://claude.com/claude-code)