### PR TITLE
fix: PR #393 の漏れ修正 - CSS クラスリネーム + seed.mjs 定数修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,13 @@ screenshots/
 
 # 一時出力 (例: /review-pr /review-issue が書き出すレビュー結果は tmp/review-cache/ 配下)
 tmp/
+.tmp/
+
+# Codex CLI のプロジェクト固有設定 (ユーザー個人の sandbox 設定等、共有しない)
+.codex/
+
+# Playwright / vitest 等のテスト実行結果
+test-results/
 
 # Editor / OS
 .DS_Store

--- a/designer/e2e/action-list-marker-badge.spec.ts
+++ b/designer/e2e/action-list-marker-badge.spec.ts
@@ -78,9 +78,9 @@ async function setup(page: Page) {
     localStorage.removeItem("list-view-mode:process-flow-list");
   }, { project: dummyProject, fullMarkers: fullGroupWithMarkers, fullClean: fullGroupClean });
   await page.goto("/process-flow/list");
-  await expect(page.locator(".action-page")).toBeVisible();
+  await expect(page.locator(".process-flow-page")).toBeVisible();
   // マーカー集計は非同期バックグラウンド処理なので待つ
-  await expect(page.locator(".action-marker-badges").first()).toBeVisible({ timeout: 10000 });
+  await expect(page.locator(".process-flow-marker-badges").first()).toBeVisible({ timeout: 10000 });
 }
 
 test.describe("処理フロー一覧 マーカー件数バッジ (#261)", () => {
@@ -91,20 +91,20 @@ test.describe("処理フロー一覧 マーカー件数バッジ (#261)", () => 
     const cleanCard = page.locator(".data-list-card").filter({ hasText: "マーカーなし" });
 
     // todo 2 件
-    await expect(markerCard.locator(".action-marker-badge.kind-todo")).toContainText("2");
+    await expect(markerCard.locator(".process-flow-marker-badge.kind-todo")).toContainText("2");
     // question 1 件
-    await expect(markerCard.locator(".action-marker-badge.kind-question")).toContainText("1");
+    await expect(markerCard.locator(".process-flow-marker-badge.kind-question")).toContainText("1");
     // attention 1 件
-    await expect(markerCard.locator(".action-marker-badge.kind-attention")).toContainText("1");
+    await expect(markerCard.locator(".process-flow-marker-badge.kind-attention")).toContainText("1");
     // chat は 0 件なので表示されない
-    await expect(markerCard.locator(".action-marker-badge.kind-chat")).toHaveCount(0);
+    await expect(markerCard.locator(".process-flow-marker-badge.kind-chat")).toHaveCount(0);
 
     // resolved なマーカーはカウントされない (todo の総数が 2 であることで担保)
     // mk5 (resolved) を含めれば 3 になるはず
-    await expect(markerCard.locator(".action-marker-badge.kind-todo")).not.toContainText("3");
+    await expect(markerCard.locator(".process-flow-marker-badge.kind-todo")).not.toContainText("3");
 
     // マーカーなしグループには badges 自体が表示されない
-    await expect(cleanCard.locator(".action-marker-badges")).toHaveCount(0);
+    await expect(cleanCard.locator(".process-flow-marker-badges")).toHaveCount(0);
   });
 
   test("表ビューに マーカー 列が出て、badge が表示される", async ({ page }) => {
@@ -115,21 +115,21 @@ test.describe("処理フロー一覧 マーカー件数バッジ (#261)", () => 
     await expect(page.locator("thead th").filter({ hasText: "マーカー" })).toBeVisible();
 
     const markerRow = page.locator(".data-list-row").filter({ hasText: "マーカー入り" });
-    await expect(markerRow.locator(".action-marker-badge.kind-todo")).toContainText("2");
-    await expect(markerRow.locator(".action-marker-badge.kind-question")).toContainText("1");
+    await expect(markerRow.locator(".process-flow-marker-badge.kind-todo")).toContainText("2");
+    await expect(markerRow.locator(".process-flow-marker-badge.kind-question")).toContainText("1");
   });
 
   test("ヘッダ全体サマリにマーカー合計が表示される", async ({ page }) => {
     await setup(page);
     // 合計: todo 2 + question 1 + attention 1 = 4
-    const headerSummary = page.locator(".action-list-header").locator("span[title*='マーカー']");
+    const headerSummary = page.locator(".process-flow-list-header").locator("span[title*='マーカー']");
     await expect(headerSummary).toContainText("4");
   });
 
   test("「マーカーありのみ」フィルタで marker 入りの AG だけ表示", async ({ page }) => {
     await setup(page);
     // チェックボックス ON → marker 入りのみ残る (ag-clean は非表示)
-    await page.locator(".action-list-check-label").filter({ hasText: "マーカーあり" }).click();
+    await page.locator(".process-flow-list-check-label").filter({ hasText: "マーカーあり" }).click();
     await expect(page.locator(".data-list-card").filter({ hasText: "マーカー入り" })).toBeVisible();
     await expect(page.locator(".data-list-card").filter({ hasText: "マーカーなし" })).toHaveCount(0);
     // FilterBar にラベル表示

--- a/designer/e2e/action-list.spec.ts
+++ b/designer/e2e/action-list.spec.ts
@@ -54,7 +54,7 @@ async function setupActionList(page: Page) {
     localStorage.removeItem("list-view-mode:process-flow-list");
   }, { project: dummyProject, groups: dummyGroups });
   await page.goto("/process-flow/list");
-  await expect(page.locator(".action-page")).toBeVisible();
+  await expect(page.locator(".process-flow-page")).toBeVisible();
 }
 
 test.describe("処理フロー一覧", () => {

--- a/designer/e2e/catalog-panels.spec.ts
+++ b/designer/e2e/catalog-panels.spec.ts
@@ -30,7 +30,7 @@ async function setup(page: Page) {
     localStorage.removeItem("designer-active-tab");
   }, { project: dummyProject, group: dummyGroup });
   await page.goto(`/process-flow/edit/${groupId}`);
-  await expect(page.locator(".step-editor, .action-content").first()).toBeVisible({ timeout: 10000 });
+  await expect(page.locator(".step-editor, .process-flow-content").first()).toBeVisible({ timeout: 10000 });
 }
 
 test.describe("ProcessFlow カタログ編集パネル (#278)", () => {

--- a/designer/e2e/conv-completion.spec.ts
+++ b/designer/e2e/conv-completion.spec.ts
@@ -63,7 +63,7 @@ async function setup(page: Page) {
   }, { project: dummyProject, group: sampleGroup, catalog: sampleCatalog });
   await page.goto(`/process-flow/edit/${sampleGroup.id}`);
   // ProcessFlowEditor が表示されるまで待機
-  await expect(page.locator(".action-editor, [class*='action-editor']")).toBeVisible({ timeout: 10000 });
+  await expect(page.locator(".process-flow-editor, [class*='process-flow-editor']")).toBeVisible({ timeout: 10000 });
 }
 
 async function openComputeStep(page: Page) {

--- a/designer/e2e/drawing-anchor.spec.ts
+++ b/designer/e2e/drawing-anchor.spec.ts
@@ -88,7 +88,7 @@ async function setup(page: Page) {
     localStorage.removeItem("designer-active-tab");
   }, { project: dummyProject, group: dummyGroup });
   await page.goto(`/process-flow/edit/${groupId}`);
-  await expect(page.locator(".step-editor, .action-content").first()).toBeVisible({ timeout: 10000 });
+  await expect(page.locator(".step-editor, .process-flow-content").first()).toBeVisible({ timeout: 10000 });
 }
 
 test.describe("描画マーカー DOM anchor (#261)", () => {

--- a/designer/e2e/drawing-marker.spec.ts
+++ b/designer/e2e/drawing-marker.spec.ts
@@ -38,7 +38,7 @@ async function setup(page: Page) {
     localStorage.removeItem("designer-active-tab");
   }, { project: dummyProject, group: dummyGroup });
   await page.goto(`/process-flow/edit/${groupId}`);
-  await expect(page.locator(".step-editor, .action-content").first()).toBeVisible({ timeout: 10000 });
+  await expect(page.locator(".step-editor, .process-flow-content").first()).toBeVisible({ timeout: 10000 });
 }
 
 async function drawStroke(page: Page, x0: number, y0: number, dx: number, dy: number) {

--- a/designer/e2e/error-catalog-panel.spec.ts
+++ b/designer/e2e/error-catalog-panel.spec.ts
@@ -42,7 +42,7 @@ async function setup(page: Page) {
     localStorage.removeItem("designer-active-tab");
   }, { project: dummyProject, group: dummyGroup });
   await page.goto(`/process-flow/edit/${groupId}`);
-  await expect(page.locator(".step-editor, .action-content").first()).toBeVisible({ timeout: 10000 });
+  await expect(page.locator(".step-editor, .process-flow-content").first()).toBeVisible({ timeout: 10000 });
 }
 
 test.describe("errorCatalog 編集パネル (#278)", () => {

--- a/designer/e2e/list-ops.spec.ts
+++ b/designer/e2e/list-ops.spec.ts
@@ -35,7 +35,7 @@ async function setupList(page: Page) {
     localStorage.removeItem("list-view-mode:process-flow-list");
   }, { project, groups: listGroups });
   await page.goto("/process-flow/list");
-  await expect(page.locator(".action-page")).toBeVisible();
+  await expect(page.locator(".process-flow-page")).toBeVisible();
 }
 
 test.describe("ProcessFlowListView 操作 (#248)", () => {
@@ -80,7 +80,7 @@ test.describe("ProcessFlowListView 操作 (#248)", () => {
   test("成熟度サマリバーが total を表示する", async ({ page }) => {
     await setupList(page);
     // 全体: 1 committed / 1 provisional / 2 draft
-    const header = page.locator(".action-list-header");
+    const header = page.locator(".process-flow-list-header");
     // committed 1 / provisional 1 / draft 2
     await expect(header.getByText("全体:")).toBeVisible();
   });

--- a/designer/e2e/marker-ergonomics.spec.ts
+++ b/designer/e2e/marker-ergonomics.spec.ts
@@ -37,7 +37,7 @@ async function setupEditor(page: Page) {
     localStorage.removeItem("designer-active-tab");
   }, { project: dummyProject, group: dummyGroup });
   await page.goto(`/process-flow/edit/${groupId}`);
-  await expect(page.locator(".step-editor, .action-content").first()).toBeVisible({ timeout: 10000 });
+  await expect(page.locator(".step-editor, .process-flow-content").first()).toBeVisible({ timeout: 10000 });
 }
 
 async function setupDashboard(page: Page) {

--- a/designer/e2e/marker-panel.spec.ts
+++ b/designer/e2e/marker-panel.spec.ts
@@ -25,7 +25,7 @@ async function setup(page: Page) {
     localStorage.removeItem("designer-active-tab");
   }, { project: dummyProject, group: dummyGroup });
   await page.goto(`/process-flow/edit/${groupId}`);
-  await expect(page.locator(".step-editor, .action-content").first()).toBeVisible({ timeout: 10000 });
+  await expect(page.locator(".step-editor, .process-flow-content").first()).toBeVisible({ timeout: 10000 });
   // MarkerPanel は既定で折りたたみ (#261 anchor 対応): 明示的に展開する
   await page.locator(".marker-panel .catalog-panel-toggle").click();
   await expect(page.locator(".marker-panel .catalog-panel-body")).toBeVisible();

--- a/designer/e2e/maturity-notes.spec.ts
+++ b/designer/e2e/maturity-notes.spec.ts
@@ -78,9 +78,9 @@ async function setupEditor(page: Page) {
     localStorage.removeItem("designer-active-tab");
   }, { project: dummyProject, group: dummyGroup });
   await page.goto(`/process-flow/edit/${groupId}`);
-  await expect(page.locator(".action-editor")).toBeVisible({ timeout: 10000 }).catch(async () => {
+  await expect(page.locator(".process-flow-editor")).toBeVisible({ timeout: 10000 }).catch(async () => {
     // 別の top-level class を試す (フェイルセーフ)
-    await expect(page.locator(".step-editor, .action-content").first()).toBeVisible({ timeout: 5000 });
+    await expect(page.locator(".step-editor, .process-flow-content").first()).toBeVisible({ timeout: 5000 });
   });
 }
 
@@ -121,7 +121,7 @@ async function setupList(page: Page) {
     localStorage.removeItem("list-view-mode:process-flow-list");
   }, { project, groups: moreGroups });
   await page.goto("/process-flow/list");
-  await expect(page.locator(".action-page")).toBeVisible();
+  await expect(page.locator(".process-flow-page")).toBeVisible();
 }
 
 test.describe("成熟度バッジ (#185/#189)", () => {
@@ -202,6 +202,6 @@ test.describe("処理フロー一覧のカード成熟度 + フィルタ (#187/#
   test("プロジェクト全体サマリが表示される (#233)", async ({ page }) => {
     await setupList(page);
     // ヘッダに "全体:" ラベル
-    await expect(page.locator(".action-list-header").getByText("全体:")).toBeVisible();
+    await expect(page.locator(".process-flow-list-header").getByText("全体:")).toBeVisible();
   });
 });

--- a/designer/e2e/more-ui.spec.ts
+++ b/designer/e2e/more-ui.spec.ts
@@ -96,7 +96,7 @@ async function setupEditor(page: Page) {
     localStorage.removeItem("designer-active-tab");
   }, { project: dummyProject, group: dummyGroup });
   await page.goto(`/process-flow/edit/${groupId}`);
-  await expect(page.locator(".step-editor, .action-content").first()).toBeVisible({ timeout: 10000 });
+  await expect(page.locator(".step-editor, .process-flow-content").first()).toBeVisible({ timeout: 10000 });
 }
 
 async function setupDashboard(page: Page) {

--- a/designer/e2e/save-reset-action.spec.ts
+++ b/designer/e2e/save-reset-action.spec.ts
@@ -75,17 +75,17 @@ async function setupProcessFlowEditor(page: Page, draft: object | null = null) {
     },
   );
   await page.goto(`/process-flow/edit/${PROCESS_FLOW_ID}`);
-  await expect(page.locator(".action-page")).toBeVisible();
+  await expect(page.locator(".process-flow-page")).toBeVisible();
 }
 
 /** アクションを追加してアクティブにする（ステップ追加の前提条件） */
 async function addAction(page: Page, name: string) {
   // 「+」ボタン（アクション追加）をクリック
-  await page.locator(".action-tab-add").click();
-  await page.locator(".action-modal input.form-control").first().fill(name);
-  await page.locator(".action-modal button.btn-primary").click();
+  await page.locator(".process-flow-tab-add").click();
+  await page.locator(".process-flow-modal input.form-control").first().fill(name);
+  await page.locator(".process-flow-modal button.btn-primary").click();
   // モーダルが閉じるまで待つ
-  await expect(page.locator(".action-modal")).not.toBeVisible();
+  await expect(page.locator(".process-flow-modal")).not.toBeVisible();
 }
 
 // ─── テスト ────────────────────────────────────────────────────────────────

--- a/designer/e2e/schema-ui.spec.ts
+++ b/designer/e2e/schema-ui.spec.ts
@@ -93,7 +93,7 @@ async function setupEditor(page: Page) {
     localStorage.removeItem("designer-active-tab");
   }, { project: dummyProject, group: dummyGroup });
   await page.goto(`/process-flow/edit/${groupId}`);
-  await expect(page.locator(".step-editor, .action-content").first()).toBeVisible({ timeout: 10000 });
+  await expect(page.locator(".step-editor, .process-flow-content").first()).toBeVisible({ timeout: 10000 });
 }
 
 async function expandStep(page: Page, index: number) {
@@ -137,7 +137,7 @@ test.describe("アクション HTTP 契約編集 (#206)", () => {
     await setupEditor(page);
     // HTTP 契約パネルを開く
     await page.getByRole("button", { name: /HTTP 契約/ }).click();
-    const panel = page.locator(".action-http-contract-panel");
+    const panel = page.locator(".process-flow-http-contract-panel");
     await expect(panel).toBeVisible();
     // Method
     await panel.locator("select").first().selectOption("POST");

--- a/designer/e2e/step-advanced.spec.ts
+++ b/designer/e2e/step-advanced.spec.ts
@@ -65,7 +65,7 @@ async function setupEditor(page: Page) {
     localStorage.removeItem("designer-active-tab");
   }, { project: dummyProject, group: dummyGroup });
   await page.goto(`/process-flow/edit/${groupId}`);
-  await expect(page.locator(".step-editor, .action-content").first()).toBeVisible({ timeout: 10000 });
+  await expect(page.locator(".step-editor, .process-flow-content").first()).toBeVisible({ timeout: 10000 });
 }
 
 test.describe("ステップ追加 (条件分岐 / ループ) (#248)", () => {

--- a/designer/e2e/step-marker-badge.spec.ts
+++ b/designer/e2e/step-marker-badge.spec.ts
@@ -43,7 +43,7 @@ async function setup(page: Page) {
     localStorage.removeItem("designer-active-tab");
   }, { project: dummyProject, group: dummyGroup });
   await page.goto(`/process-flow/edit/${groupId}`);
-  await expect(page.locator(".step-editor, .action-content").first()).toBeVisible({ timeout: 10000 });
+  await expect(page.locator(".step-editor, .process-flow-content").first()).toBeVisible({ timeout: 10000 });
 }
 
 test.describe("step marker badge (#261)", () => {

--- a/designer/e2e/step-ops.spec.ts
+++ b/designer/e2e/step-ops.spec.ts
@@ -77,7 +77,7 @@ async function setupEditor(page: Page) {
     localStorage.removeItem("designer-active-tab");
   }, { project: dummyProject, group: dummyGroup });
   await page.goto(`/process-flow/edit/${groupId}`);
-  await expect(page.locator(".step-editor, .action-content").first()).toBeVisible({ timeout: 10000 });
+  await expect(page.locator(".step-editor, .process-flow-content").first()).toBeVisible({ timeout: 10000 });
 }
 
 test.describe("ステップツールバーから追加 (#246)", () => {

--- a/designer/e2e/stepcard-marker-kind-badge.spec.ts
+++ b/designer/e2e/stepcard-marker-kind-badge.spec.ts
@@ -44,7 +44,7 @@ async function setup(page: Page) {
     localStorage.removeItem("designer-active-tab");
   }, { project: dummyProject, group: dummyGroup });
   await page.goto(`/process-flow/edit/${groupId}`);
-  await expect(page.locator(".step-editor, .action-content").first()).toBeVisible({ timeout: 10000 });
+  await expect(page.locator(".step-editor, .process-flow-content").first()).toBeVisible({ timeout: 10000 });
 }
 
 test.describe("StepCard kind 別マーカーバッジ (#261)", () => {

--- a/designer/e2e/validation-sql-conv-panel.spec.ts
+++ b/designer/e2e/validation-sql-conv-panel.spec.ts
@@ -83,7 +83,7 @@ async function setupEditor(page: Page) {
     localStorage.removeItem("designer-active-tab");
   }, { project, group, tableDef, groupId, tableId });
   await page.goto(`/process-flow/edit/${groupId}`);
-  await expect(page.locator(".step-editor, .action-content").first()).toBeVisible({ timeout: 10000 });
+  await expect(page.locator(".step-editor, .process-flow-content").first()).toBeVisible({ timeout: 10000 });
 }
 
 test.describe("SQL 列検査 + 規約参照 の UI 統合 (#261)", () => {
@@ -94,7 +94,7 @@ test.describe("SQL 列検査 + 規約参照 の UI 統合 (#261)", () => {
     const badge = page.locator(".validation-badge.warning");
     await expect(badge).toBeVisible();
     await badge.click();
-    const panel = page.locator(".action-validation-panel");
+    const panel = page.locator(".process-flow-validation-panel");
     await expect(panel).toBeVisible();
     await expect(panel).toContainText("UNKNOWN_COLUMN");
     await expect(panel).toContainText("nonexistent_col");
@@ -104,7 +104,7 @@ test.describe("SQL 列検査 + 規約参照 の UI 統合 (#261)", () => {
     await setupEditor(page);
     await page.waitForTimeout(500);
     await page.locator(".validation-badge.warning").click();
-    const panel = page.locator(".action-validation-panel");
+    const panel = page.locator(".process-flow-validation-panel");
     await expect(panel).toContainText("UNKNOWN_CONV_MSG");
     await expect(panel).toContainText("thisDoesNotExist");
   });

--- a/designer/e2e/validation-warnings-panel.spec.ts
+++ b/designer/e2e/validation-warnings-panel.spec.ts
@@ -78,7 +78,7 @@ async function setupEditor(page: Page) {
     localStorage.removeItem("designer-active-tab");
   }, { project: dummyProject, group: dummyGroup });
   await page.goto(`/process-flow/edit/${groupId}`);
-  await expect(page.locator(".step-editor, .action-content").first()).toBeVisible({ timeout: 10000 });
+  await expect(page.locator(".step-editor, .process-flow-content").first()).toBeVisible({ timeout: 10000 });
 }
 
 test.describe("警告パネル UI 配線 (#261 UI 統合)", () => {
@@ -92,7 +92,7 @@ test.describe("警告パネル UI 配線 (#261 UI 統合)", () => {
 
   test("バッジクリックで詳細パネルが開く", async ({ page }) => {
     await setupEditor(page);
-    const panel = page.locator(".action-validation-panel");
+    const panel = page.locator(".process-flow-validation-panel");
     await expect(panel).toHaveCount(0);
 
     await page.locator(".validation-badge.warning").click();
@@ -103,7 +103,7 @@ test.describe("警告パネル UI 配線 (#261 UI 統合)", () => {
     await setupEditor(page);
     await page.locator(".validation-badge.warning").click();
 
-    const panel = page.locator(".action-validation-panel");
+    const panel = page.locator(".process-flow-validation-panel");
     await expect(panel).toBeVisible();
     await expect(panel).toContainText("UNKNOWN_IDENTIFIER");
     await expect(panel).toContainText("UNKNOWN_RESPONSE_REF");
@@ -120,10 +120,10 @@ test.describe("警告パネル UI 配線 (#261 UI 統合)", () => {
   test("閉じるボタンでパネルが閉じる", async ({ page }) => {
     await setupEditor(page);
     await page.locator(".validation-badge.warning").click();
-    await expect(page.locator(".action-validation-panel")).toBeVisible();
+    await expect(page.locator(".process-flow-validation-panel")).toBeVisible();
 
     // ヘッダには「全て AI に依頼」ボタンもあるため title="閉じる" で指定
-    await page.locator('.action-validation-panel-header button[title="閉じる"]').click();
-    await expect(page.locator(".action-validation-panel")).toHaveCount(0);
+    await page.locator('.process-flow-validation-panel-header button[title="閉じる"]').click();
+    await expect(page.locator(".process-flow-validation-panel")).toHaveCount(0);
   });
 });

--- a/designer/e2e/warning-to-marker.spec.ts
+++ b/designer/e2e/warning-to-marker.spec.ts
@@ -33,7 +33,7 @@ async function setup(page: Page) {
     localStorage.removeItem("designer-active-tab");
   }, { project: dummyProject, group: dummyGroup });
   await page.goto(`/process-flow/edit/${groupId}`);
-  await expect(page.locator(".step-editor, .action-content").first()).toBeVisible({ timeout: 10000 });
+  await expect(page.locator(".step-editor, .process-flow-content").first()).toBeVisible({ timeout: 10000 });
 }
 
 test.describe("警告 → Marker 起票 (#261)", () => {
@@ -41,12 +41,12 @@ test.describe("警告 → Marker 起票 (#261)", () => {
     await setup(page);
     // 警告バッジが出ていること
     await page.locator(".validation-badge.warning").click();
-    const panel = page.locator(".action-validation-panel");
+    const panel = page.locator(".process-flow-validation-panel");
     await expect(panel).toBeVisible();
 
     // UNKNOWN_IDENTIFIER 警告の行で AI に依頼
     await page.evaluate(() => {
-      const btn = document.querySelector(".action-validation-panel .validation-ask-ai-btn");
+      const btn = document.querySelector(".process-flow-validation-panel .validation-ask-ai-btn");
       btn?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, view: window }));
     });
 
@@ -69,7 +69,7 @@ test.describe("警告 → Marker 起票 (#261)", () => {
     await page.locator(".validation-badge.warning").click();
     page.on("dialog", (d) => d.accept());
     await page.evaluate(() => {
-      document.querySelector(".action-validation-panel-bulk-ai")?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, view: window }));
+      document.querySelector(".process-flow-validation-panel-bulk-ai")?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, view: window }));
     });
     // MarkerPanel 展開
     await page.locator(".marker-panel .catalog-panel-toggle").click();
@@ -82,7 +82,7 @@ test.describe("警告 → Marker 起票 (#261)", () => {
     await setup(page);
     await page.locator(".validation-badge.warning").click();
     await page.evaluate(() => {
-      document.querySelector(".action-validation-panel .validation-ask-ai-btn")?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, view: window }));
+      document.querySelector(".process-flow-validation-panel .validation-ask-ai-btn")?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, view: window }));
     });
 
     // パネルを閉じて開き直し、disabled のまま

--- a/designer/src/components/process-flow/DrawingOverlay.tsx
+++ b/designer/src/components/process-flow/DrawingOverlay.tsx
@@ -96,9 +96,9 @@ function AnchoredMarker({
     const ro = new ResizeObserver(measure);
     ro.observe(document.body);
     const mo = new MutationObserver(measure);
-    // .action-page 全体を観察 (.action-editor-info の MarkerPanel 展開も含む)。
+    // .process-flow-page 全体を観察 (.process-flow-editor-info の MarkerPanel 展開も含む)。
     // attributeFilter で style/class 変化のみに絞り、入力文字列の変更などノイズを避ける。
-    const scope = document.querySelector(".action-page") ?? document.body;
+    const scope = document.querySelector(".process-flow-page") ?? document.body;
     mo.observe(scope, { childList: true, subtree: true, attributes: true, attributeFilter: ["style", "class"] });
     window.addEventListener("scroll", measure, true);
     window.addEventListener("resize", measure);

--- a/designer/src/components/process-flow/ProcessFlowEditor.tsx
+++ b/designer/src/components/process-flow/ProcessFlowEditor.tsx
@@ -62,7 +62,7 @@ import { StructuredFieldsEditor, type ScreenItemPickResult } from "./StructuredF
 import { ScreenItemPickerModal } from "./ScreenItemPickerModal";
 import { EditorHeader } from "../common/EditorHeader";
 import { ServerChangeBanner } from "../common/ServerChangeBanner";
-import "../../styles/action.css";
+import "../../styles/processFlow.css";
 
 /** ツールバーのドラッグ可能なステップ種別ボタン */
 function ToolbarStepButton({ type, onClick }: { type: StepType; onClick: () => void }) {

--- a/designer/src/components/process-flow/ProcessFlowListView.tsx
+++ b/designer/src/components/process-flow/ProcessFlowListView.tsx
@@ -33,7 +33,7 @@ import { useListEditor } from "../../hooks/useListEditor";
 import { usePersistentState } from "../../hooks/usePersistentState";
 import { generateUUID } from "../../utils/uuid";
 import { renumber } from "../../utils/listOrder";
-import "../../styles/action.css";
+import "../../styles/processFlow.css";
 
 const ALL_TYPES: ProcessFlowType[] = ["screen", "batch", "scheduled", "system", "common", "other"];
 const STORAGE_KEY = "list-view-mode:process-flow-list";

--- a/designer/src/styles/processFlow.css
+++ b/designer/src/styles/processFlow.css
@@ -1,6 +1,6 @@
 /* ─── 処理フロー定義 共通 ─────────────────────────────────────────── */
 
-.action-page {
+.process-flow-page {
   height: calc(100vh - var(--common-header-h, 0px) - var(--tabbar-h, 0px));
   display: flex;
   flex-direction: column;
@@ -8,7 +8,7 @@
   background: #f8f9fa;
 }
 
-.action-content {
+.process-flow-content {
   flex: 1;
   overflow-y: auto;
   /* #309 フォローアップ: 情報密度優先。4K で余白過多にならないよう縦 8px / 横 14px */
@@ -17,36 +17,36 @@
 
 /* ─── 処理フロー一覧 ─────────────────────────────────────────────── */
 
-.action-list-header {
+.process-flow-list-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
   margin-bottom: 16px;
 }
 
-.action-list-header h5 {
+.process-flow-list-header h5 {
   margin: 0;
   font-weight: 700;
 }
 
-.action-list-filters {
+.process-flow-list-filters {
   display: flex;
   gap: 8px;
   margin-bottom: 16px;
   flex-wrap: wrap;
 }
 
-.action-list-filters .btn {
+.process-flow-list-filters .btn {
   font-size: 0.82rem;
   padding: 4px 12px;
 }
 
-.action-list-filters .btn.active {
+.process-flow-list-filters .btn.active {
   font-weight: 600;
 }
 
 /* ─── ProcessFlowListView ヘッダ右側 ───────────────────────────────────── */
-.action-list-header-right {
+.process-flow-list-header-right {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -70,19 +70,19 @@
 .process-flow-type-badge.other { background: #f1f5f9; color: #475569; }
 
 /* ─── DataList カード内コンテンツ ────────────────────────────────── */
-.action-card-content {
+.process-flow-card-content {
   display: flex;
   flex-direction: column;
   gap: 6px;
 }
 
-.action-card-head {
+.process-flow-card-head {
   display: flex;
   align-items: center;
   gap: 8px;
 }
 
-.action-card-name {
+.process-flow-card-name {
   font-weight: 600;
   font-size: 0.95rem;
   flex: 1 1 auto;
@@ -91,38 +91,38 @@
   white-space: nowrap;
 }
 
-.action-card-meta {
+.process-flow-card-meta {
   font-size: 0.8rem;
   color: #64748b;
   display: flex;
   gap: 12px;
 }
 
-.action-list-name {
+.process-flow-list-name {
   font-weight: 600;
 }
 
-.action-validation-ok {
+.process-flow-validation-ok {
   color: #10b981;
 }
 
 /* エラー/警告状態のカード装飾 (:has() で外側を着色) */
-.action-data-list .data-list-card:has(.action-card-content.has-error) {
+.process-flow-data-list .data-list-card:has(.process-flow-card-content.has-error) {
   background: #fff5f5;
   border-color: #fecaca;
 }
-.action-data-list .data-list-card:has(.action-card-content.has-error):hover {
+.process-flow-data-list .data-list-card:has(.process-flow-card-content.has-error):hover {
   border-color: #f87171;
 }
-.action-data-list .data-list-card:has(.action-card-content.has-warning:not(.has-error)) {
+.process-flow-data-list .data-list-card:has(.process-flow-card-content.has-warning:not(.has-error)) {
   background: #fffbeb;
   border-color: #fde68a;
 }
-.action-data-list .data-list-card:has(.action-card-content.has-warning:not(.has-error)):hover {
+.process-flow-data-list .data-list-card:has(.process-flow-card-content.has-warning:not(.has-error)):hover {
   border-color: #fbbf24;
 }
 
-.action-validation-badges {
+.process-flow-validation-badges {
   display: flex;
   gap: 4px;
   margin-left: auto;
@@ -130,13 +130,13 @@
 }
 
 /* ─── 処理フロー一覧 マーカー件数バッジ (#261) ──────────────────────── */
-.action-marker-badges {
+.process-flow-marker-badges {
   display: inline-flex;
   gap: 3px;
   align-items: center;
   flex-wrap: wrap;
 }
-.action-marker-badge {
+.process-flow-marker-badge {
   display: inline-flex;
   align-items: center;
   gap: 3px;
@@ -146,22 +146,22 @@
   font-weight: 600;
   line-height: 1.3;
 }
-.action-marker-badge i {
+.process-flow-marker-badge i {
   font-size: 0.7rem;
 }
-.action-marker-badge.kind-todo { background: #d1fae5; color: #065f46; }
-.action-marker-badge.kind-question { background: #ede9fe; color: #5b21b6; }
-.action-marker-badge.kind-attention { background: #fef3c7; color: #92400e; }
-.action-marker-badge.kind-chat { background: #dbeafe; color: #1e40af; }
+.process-flow-marker-badge.kind-todo { background: #d1fae5; color: #065f46; }
+.process-flow-marker-badge.kind-question { background: #ede9fe; color: #5b21b6; }
+.process-flow-marker-badge.kind-attention { background: #fef3c7; color: #92400e; }
+.process-flow-marker-badge.kind-chat { background: #dbeafe; color: #1e40af; }
 
-.action-list-filter-sep {
+.process-flow-list-filter-sep {
   width: 1px;
   background: #e2e8f0;
   margin: 0 4px;
   align-self: stretch;
 }
 
-.action-list-check-label {
+.process-flow-list-check-label {
   display: flex;
   align-items: center;
   gap: 6px;
@@ -173,23 +173,23 @@
 
 /* ─── 処理フロー編集 ─────────────────────────────────────────────── */
 
-.action-editor-breadcrumb {
+.process-flow-editor-breadcrumb {
   font-size: 0.85rem;
   color: #64748b;
 }
 
-.action-editor-breadcrumb a {
+.process-flow-editor-breadcrumb a {
   color: #6366f1;
   text-decoration: none;
 }
 
-.action-editor-breadcrumb a:hover {
+.process-flow-editor-breadcrumb a:hover {
   text-decoration: underline;
 }
 
 /* ─── アクションタブ ──────────────────────────────────────────────── */
 
-.action-tabs {
+.process-flow-tabs {
   display: flex;
   gap: 0;
   border-bottom: 2px solid #e2e8f0;
@@ -198,7 +198,7 @@
   overflow-x: auto;
 }
 
-.action-tab {
+.process-flow-tab {
   padding: 10px 16px;
   font-size: 0.85rem;
   font-weight: 500;
@@ -212,17 +212,17 @@
   transition: color 0.15s, border-color 0.15s;
 }
 
-.action-tab:hover {
+.process-flow-tab:hover {
   color: #334155;
 }
 
-.action-tab.active {
+.process-flow-tab.active {
   color: #6366f1;
   border-bottom-color: #6366f1;
   font-weight: 600;
 }
 
-.action-tab-add {
+.process-flow-tab-add {
   padding: 10px 12px;
   font-size: 0.85rem;
   color: #94a3b8;
@@ -232,13 +232,13 @@
   margin-bottom: -2px;
 }
 
-.action-tab-add:hover {
+.process-flow-tab-add:hover {
   color: #6366f1;
 }
 
 /* ─── I/O パネル ─────────────────────────────────────────────────── */
 
-.action-io-panel {
+.process-flow-io-panel {
   /* #310: 上下 2 段 (1fr) を既定に。以前は 1fr 1fr で左右分割していたが、
      表形式モードで幅が狭く折り返して縦積みに見えていたため、全幅を確保。
      #310 フォローアップ: 高解像度では左右 2 列に戻す (下の media query 参照)。 */
@@ -255,20 +255,20 @@
    table-layout: fixed + col-*: 11em+9em+7em+... の合計 ≒ 400px 以上あれば折り返し
    なく 1 項目 1 行が収まる。1600px / 2 ≒ 780px > 400px で十分余裕がある。 */
 @media (min-width: 1600px) {
-  .action-io-panel {
+  .process-flow-io-panel {
     grid-template-columns: 1fr 1fr;
     gap: 16px;
   }
 }
 
-.action-io-field .form-label {
+.process-flow-io-field .form-label {
   font-size: 0.78rem;
   font-weight: 600;
   color: #64748b;
   margin-bottom: 4px;
 }
 
-.action-io-textarea {
+.process-flow-io-textarea {
   font-size: 0.82rem;
   min-height: 32px;
   resize: vertical;
@@ -363,7 +363,7 @@
 
 .step-editor {
   /* #313: max-width 800px を撤去し viewport 幅を活かす。padding は親の
-     .action-content が担当するので 0。4K でもパネル幅を有効利用する。 */
+     .process-flow-content が担当するので 0。4K でもパネル幅を有効利用する。 */
   padding: 0;
 }
 
@@ -812,7 +812,7 @@
 
 /* ─── モーダル ────────────────────────────────────────────────────── */
 
-.action-modal-overlay {
+.process-flow-modal-overlay {
   position: fixed;
   top: 0;
   left: 0;
@@ -825,7 +825,7 @@
   z-index: 1000;
 }
 
-.action-modal {
+.process-flow-modal {
   background: #fff;
   border-radius: 12px;
   padding: 24px;
@@ -834,22 +834,22 @@
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15);
 }
 
-.action-modal h6 {
+.process-flow-modal h6 {
   font-weight: 700;
   margin-bottom: 16px;
 }
 
-.action-modal .form-group {
+.process-flow-modal .form-group {
   margin-bottom: 12px;
 }
 
-.action-modal .form-label {
+.process-flow-modal .form-label {
   font-size: 0.82rem;
   font-weight: 600;
   margin-bottom: 4px;
 }
 
-.action-modal-footer {
+.process-flow-modal-footer {
   display: flex;
   justify-content: flex-end;
   gap: 8px;
@@ -1305,14 +1305,14 @@
 }
 
 /* 警告詳細パネル (#261 UI 統合) */
-.action-validation-panel {
+.process-flow-validation-panel {
   margin: 4px 16px 8px;
   border: 1px solid #fde68a;
   border-radius: 8px;
   background: #fffbeb;
   overflow: hidden;
 }
-.action-validation-panel-header {
+.process-flow-validation-panel-header {
   display: flex;
   align-items: center;
   gap: 6px;
@@ -1323,14 +1323,14 @@
   background: #fef3c7;
   border-bottom: 1px solid #fde68a;
 }
-.action-validation-panel-list {
+.process-flow-validation-panel-list {
   list-style: none;
   margin: 0;
   padding: 4px 12px;
   max-height: 240px;
   overflow-y: auto;
 }
-.action-validation-panel-list li {
+.process-flow-validation-panel-list li {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
@@ -1338,14 +1338,14 @@
   font-size: 0.8rem;
   border-bottom: 1px dashed #fde68a;
 }
-.action-validation-panel-list li:last-child { border-bottom: none; }
+.process-flow-validation-panel-list li:last-child { border-bottom: none; }
 
-.action-validation-panel-bulk-ai {
+.process-flow-validation-panel-bulk-ai {
   margin-left: auto;
   color: #1e40af;
   font-weight: 600;
 }
-.action-validation-panel-bulk-ai:hover {
+.process-flow-validation-panel-bulk-ai:hover {
   background: #dbeafe;
   color: #1e3a8a;
 }
@@ -1464,7 +1464,7 @@
 /* ─── メタタブバー (#309) ─────────────────────────────────────────
    ProcessFlowEditor 上部の基本情報 + 6 カタログを 1 行のタブバーに集約し、
    排他的に 1 つだけ body を全幅で展開する。 */
-.action-meta-tabbar {
+.process-flow-meta-tabbar {
   padding: 3px 14px;
   background: #fff;
   border-bottom: 1px solid #e2e8f0;
@@ -1472,46 +1472,46 @@
   flex-direction: column;
   gap: 2px;
 }
-.action-meta-tabs {
+.process-flow-meta-tabs {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
   gap: 3px;
   row-gap: 3px;
 }
-.action-meta-tabs .catalog-panel {
+.process-flow-meta-tabs .catalog-panel {
   margin: 0;
   flex: 0 0 auto;
 }
-.action-meta-tabs .catalog-panel-toggle {
+.process-flow-meta-tabs .catalog-panel-toggle {
   width: auto;
   padding: 2px 8px;
   font-size: 0.76rem;
 }
 /* アクティブ (展開中) のパネルを強調: chevron-down アイコンの存在で判定 (:has) */
-.action-meta-tabs .catalog-panel:has(.bi-chevron-down) {
+.process-flow-meta-tabs .catalog-panel:has(.bi-chevron-down) {
   background: #dbeafe;
   border-color: #60a5fa;
 }
-.action-meta-tabs .catalog-panel:has(.bi-chevron-down) .catalog-panel-toggle {
+.process-flow-meta-tabs .catalog-panel:has(.bi-chevron-down) .catalog-panel-toggle {
   color: #1e40af;
 }
-.action-meta-tabbar-spacer {
+.process-flow-meta-tabbar-spacer {
   flex: 1 1 auto;
 }
-.action-meta-tabbar-inline {
+.process-flow-meta-tabbar-inline {
   display: flex;
   align-items: center;
   gap: 8px;
   font-size: 0.78rem;
   padding: 0 4px;
 }
-.action-meta-maturity-label {
+.process-flow-meta-maturity-label {
   font-weight: 600;
   color: #475569;
   font-size: 0.75rem;
 }
-.action-meta-progress {
+.process-flow-meta-progress {
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -1520,7 +1520,7 @@
   background: #f8fafc;
   border: 1px solid #e2e8f0;
 }
-.action-meta-body {
+.process-flow-meta-body {
   padding: 6px 10px;
   background: #f8fafc;
   border: 1px solid #cbd5e1;
@@ -1528,17 +1528,17 @@
   max-height: 50vh;
   overflow-y: auto;
 }
-.action-meta-body.action-meta-info-body {
+.process-flow-meta-body.process-flow-meta-info-body {
   padding: 8px 10px;
 }
 /* メタタブバー配下の body は外枠はタブバーが提供するので、
    各 Panel の border は解除して内側 padding のみにする */
-.action-meta-body > .catalog-panel {
+.process-flow-meta-body > .catalog-panel {
   margin: 0;
   border: none;
   background: transparent;
 }
-.action-meta-body > .catalog-panel > .catalog-panel-body {
+.process-flow-meta-body > .catalog-panel > .catalog-panel-body {
   max-height: none;
   padding: 0;
   border-top: none;
@@ -1548,7 +1548,7 @@
   border-top: 1px solid #e2e8f0;
   /* 長くなった panel (MarkerPanel に marker が大量 等) が上部領域を押し広げて
      下のステップ領域を viewport 外に押し出すのを防ぐ。各 panel 個別に内部スクロール。
-     #309 タブバー化以降は .action-meta-body 内で overrideされる (max-height: none)。 */
+     #309 タブバー化以降は .process-flow-meta-body 内で overrideされる (max-height: none)。 */
   max-height: 40vh;
   overflow-y: auto;
 }

--- a/docs/sample-project/seed.mjs
+++ b/docs/sample-project/seed.mjs
@@ -18,10 +18,10 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DATA_DIR = path.resolve(__dirname, "../../data");
 const SCREENS_DIR = path.join(DATA_DIR, "screens");
 const TABLES_DIR = path.join(DATA_DIR, "tables");
-const ACTIONS_DIR = path.join(DATA_DIR, "actions");
+const PROCESS_FLOWS_DIR = path.join(DATA_DIR, "process-flows");
 const SEED_SCREENS_DIR = path.join(__dirname, "screens");
 const SEED_TABLES_DIR = path.join(__dirname, "tables");
-const SEED_ACTIONS_DIR = path.join(__dirname, "actions");
+const SEED_PROCESS_FLOWS_DIR = path.join(__dirname, "process-flows");
 const CONVENTIONS_DIR = path.join(DATA_DIR, "conventions");
 const SEED_CONVENTIONS_DIR = path.join(__dirname, "conventions");
 const SCREEN_ITEMS_DIR = path.join(DATA_DIR, "screen-items");
@@ -29,7 +29,7 @@ const SEED_SCREEN_ITEMS_DIR = path.join(__dirname, "screen-items");
 
 fs.mkdirSync(SCREENS_DIR, { recursive: true });
 fs.mkdirSync(TABLES_DIR, { recursive: true });
-fs.mkdirSync(ACTIONS_DIR, { recursive: true });
+fs.mkdirSync(PROCESS_FLOWS_DIR, { recursive: true });
 fs.mkdirSync(CONVENTIONS_DIR, { recursive: true });
 fs.mkdirSync(SEED_SCREENS_DIR, { recursive: true });
 fs.mkdirSync(SCREEN_ITEMS_DIR, { recursive: true });
@@ -1120,12 +1120,12 @@ if (fs.existsSync(SEED_TABLES_DIR)) {
 
 // ── 処理フロー定義データをコピー ──────────────────────────────────────────
 let actionCount = 0;
-if (fs.existsSync(SEED_ACTIONS_DIR)) {
-  const actionFiles = fs.readdirSync(SEED_ACTIONS_DIR).filter((f) => f.endsWith(".json"));
+if (fs.existsSync(SEED_PROCESS_FLOWS_DIR)) {
+  const actionFiles = fs.readdirSync(SEED_PROCESS_FLOWS_DIR).filter((f) => f.endsWith(".json"));
   for (const file of actionFiles) {
     fs.copyFileSync(
-      path.join(SEED_ACTIONS_DIR, file),
-      path.join(ACTIONS_DIR, file),
+      path.join(SEED_PROCESS_FLOWS_DIR, file),
+      path.join(PROCESS_FLOWS_DIR, file),
     );
     actionCount++;
     console.log(`[action ${actionCount}/${actionFiles.length}] ${file.replace(".json", "")}`);


### PR DESCRIPTION
## 概要

PR #393 でリネームした CSS ファイル・seed.mjs 定数に対して、参照側のクラス名置換が漏れていた箇所を修正。

## 修正内容

| 種別 | 修正件数 |
|------|---------|
| CSS クラス定義 `.action-*` → `.process-flow-*` (processFlow.css) | 約 70 箇所 |
| Playwright セレクタ (e2e spec 21 ファイル) | 約 60 箇所 |
| DrawingOverlay.tsx querySelector セレクタ | 2 箇所 |
| seed.mjs 定数名 (`ACTIONS_DIR`/`SEED_ACTIONS_DIR`) | 4 箇所 |
| .gitignore (`.codex/` / `.tmp/` / `test-results/` 追加) | - |

## 検証結果

- `tsc --noEmit`: exit 0 ✅
- `vitest run`: 46 files, 704 tests 全 pass ✅
- 旧クラス名残存チェック (`grep .action-page/.action-editor-/...`): 0 matches ✅

## 除外した変更

- TypeScript 識別子 (`ActionDefinition`, `ActionTrigger` 等) は変更していない
- `block-action-btns` 等の ProcessFlow 無関係クラスは変更していない

Refs #392