### PR TITLE
fix: PR #394 の漏れ修正 - TSX className 56 箇所を process-flow-* に統一

### DIFF
--- a/designer/src/components/process-flow/ProcessFlowEditor.tsx
+++ b/designer/src/components/process-flow/ProcessFlowEditor.tsx
@@ -568,7 +568,7 @@ export function ProcessFlowEditor() {
   };
 
   return (
-    <div className="action-page" onClick={() => closeContextMenu()} style={{ position: "relative" }}>
+    <div className="process-flow-page" onClick={() => closeContextMenu()} style={{ position: "relative" }}>
       <TableSubToolbar />
 
       {serverChanged && (
@@ -577,7 +577,7 @@ export function ProcessFlowEditor() {
 
       <EditorHeader
         title={
-          <div className="action-editor-breadcrumb">
+          <div className="process-flow-editor-breadcrumb">
             <Link to="/process-flow/list">処理フロー一覧</Link>
             <span className="mx-2">/</span>
             <span className="fw-semibold text-dark">{group.name}</span>
@@ -631,11 +631,11 @@ export function ProcessFlowEditor() {
 
       {/* 警告詳細パネル (#261 UI 統合) */}
       {showWarningsPanel && validationErrors.filter((e) => e.severity === "warning").length > 0 && (
-        <div className="action-validation-panel">
-          <div className="action-validation-panel-header">
+        <div className="process-flow-validation-panel">
+          <div className="process-flow-validation-panel-header">
             <i className="bi bi-exclamation-triangle-fill" /> 警告 ({validationErrors.filter((e) => e.severity === "warning").length} 件)
             <button
-              className="btn btn-sm btn-link action-validation-panel-bulk-ai"
+              className="btn btn-sm btn-link process-flow-validation-panel-bulk-ai"
               onClick={() => {
                 // 全警告をまとめて marker 化 (既に起票済のものは skip)
                 if (!group) return;
@@ -676,7 +676,7 @@ export function ProcessFlowEditor() {
               <i className="bi bi-x-lg" />
             </button>
           </div>
-          <ul className="action-validation-panel-list">
+          <ul className="process-flow-validation-panel-list">
             {validationErrors
               .filter((e) => e.severity === "warning")
               .map((e, i) => {
@@ -727,11 +727,11 @@ export function ProcessFlowEditor() {
       />
 
       {/* アクションタブ */}
-      <div className="action-tabs">
+      <div className="process-flow-tabs">
         {group.actions.map((act) => (
           <div key={act.id} className="d-flex align-items-center">
             <button
-              className={`action-tab ${activeActionId === act.id ? "active" : ""}`}
+              className={`process-flow-tab ${activeActionId === act.id ? "active" : ""}`}
               onClick={() => setActiveActionId(act.id)}
             >
               <MaturityBadge
@@ -757,7 +757,7 @@ export function ProcessFlowEditor() {
           </div>
         ))}
         <button
-          className="action-tab-add"
+          className="process-flow-tab-add"
           onClick={() => setShowAddAction(true)}
           title="アクション追加"
         >
@@ -766,7 +766,7 @@ export function ProcessFlowEditor() {
       </div>
 
       {/* ステップエディタ */}
-      <div className="action-content">
+      <div className="process-flow-content">
         {activeAction ? (
           <div className="step-editor">
             {/* HTTP 契約 */}
@@ -781,8 +781,8 @@ export function ProcessFlowEditor() {
               }}
             />
             {/* I/O パネル */}
-            <div className="action-io-panel">
-              <div className="action-io-field">
+            <div className="process-flow-io-panel">
+              <div className="process-flow-io-field">
                 <StructuredFieldsEditor
                   label="入力データ"
                   fields={activeAction.inputs}
@@ -797,7 +797,7 @@ export function ProcessFlowEditor() {
                   onPickScreenItem={handlePickScreenItem}
                 />
               </div>
-              <div className="action-io-field">
+              <div className="process-flow-io-field">
                 <StructuredFieldsEditor
                   label="出力データ"
                   fields={activeAction.outputs}
@@ -998,8 +998,8 @@ export function ProcessFlowEditor() {
 
       {/* アクション追加モーダル */}
       {showAddAction && (
-        <div className="action-modal-overlay" onClick={() => setShowAddAction(false)}>
-          <div className="action-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="process-flow-modal-overlay" onClick={() => setShowAddAction(false)}>
+          <div className="process-flow-modal" onClick={(e) => e.stopPropagation()}>
             <h6>アクション追加</h6>
             <div className="form-group">
               <label className="form-label">アクション名 *</label>
@@ -1023,7 +1023,7 @@ export function ProcessFlowEditor() {
                 ))}
               </select>
             </div>
-            <div className="action-modal-footer">
+            <div className="process-flow-modal-footer">
               <button className="btn btn-outline-secondary btn-sm" onClick={() => setShowAddAction(false)}>
                 キャンセル
               </button>

--- a/designer/src/components/process-flow/ProcessFlowListView.tsx
+++ b/designer/src/components/process-flow/ProcessFlowListView.tsx
@@ -493,12 +493,12 @@ export function ProcessFlowListView() {
       .map((b) => `${b.label}: ${m[b.kind]}`)
       .join(" / ");
     return (
-      <span className="action-marker-badges" title={`AI 依頼マーカー ${m.total} 件 (${tooltip})`}>
+      <span className="process-flow-marker-badges" title={`AI 依頼マーカー ${m.total} 件 (${tooltip})`}>
         {MARKER_BADGE_META.map((b) => {
           const count = m[b.kind];
           if (count === 0) return null;
           return (
-            <span key={b.kind} className={`action-marker-badge kind-${b.kind}`}>
+            <span key={b.kind} className={`process-flow-marker-badge kind-${b.kind}`}>
               <i className={`bi ${b.icon}`} />
               {count}
             </span>
@@ -514,7 +514,7 @@ export function ProcessFlowListView() {
       header: "名前",
       sortable: true,
       sortAccessor: (g) => g.name,
-      render: (g) => <span className="action-list-name">{g.name}</span>,
+      render: (g) => <span className="process-flow-list-name">{g.name}</span>,
     },
     {
       key: "type",
@@ -589,7 +589,7 @@ export function ProcessFlowListView() {
         if (!v) return null;
         if (v.errors > 0) return <span className="validation-badge error"><i className="bi bi-x-circle-fill" />{v.errors}</span>;
         if (v.warnings > 0) return <span className="validation-badge warning"><i className="bi bi-exclamation-triangle-fill" />{v.warnings}</span>;
-        return <i className="bi bi-check-lg action-validation-ok" title="問題なし" />;
+        return <i className="bi bi-check-lg process-flow-validation-ok" title="問題なし" />;
       },
     },
   ], [validationMap, getErrorPriority, markerMap]);
@@ -599,22 +599,22 @@ export function ProcessFlowListView() {
     const hasError = (v?.errors ?? 0) > 0;
     const hasWarning = (v?.warnings ?? 0) > 0;
     return (
-      <div className={`action-card-content${hasError ? " has-error" : hasWarning ? " has-warning" : ""}`}>
-        <div className="action-card-head">
+      <div className={`process-flow-card-content${hasError ? " has-error" : hasWarning ? " has-warning" : ""}`}>
+        <div className="process-flow-card-head">
           <span className={`process-flow-type-badge ${g.type}`}>
             <i className={`${PROCESS_FLOW_TYPE_ICONS[g.type as ProcessFlowType] ?? "bi-three-dots"} me-1`} />
             {PROCESS_FLOW_TYPE_LABELS[g.type as ProcessFlowType] ?? g.type}
           </span>
           <MaturityBadge maturity={g.maturity} />
-          <span className="action-card-name">{g.name}</span>
+          <span className="process-flow-card-name">{g.name}</span>
           {v && (hasError || hasWarning) && (
-            <span className="action-validation-badges">
+            <span className="process-flow-validation-badges">
               {hasError && <span className="validation-badge error"><i className="bi bi-x-circle-fill" />{v.errors}</span>}
               {hasWarning && <span className="validation-badge warning"><i className="bi bi-exclamation-triangle-fill" />{v.warnings}</span>}
             </span>
           )}
         </div>
-        <div className="action-card-meta">
+        <div className="process-flow-card-meta">
           <span><i className="bi bi-lightning me-1" />アクション: {g.actionCount}件</span>
           {g.screenId && <span><i className="bi bi-display me-1" />画面紐付き</span>}
           {(g.notesCount ?? 0) > 0 && (
@@ -637,14 +637,14 @@ export function ProcessFlowListView() {
   const deletedCount = editor.deletedIds.size;
 
   return (
-    <div className="action-page">
+    <div className="process-flow-page">
       <TableSubToolbar />
 
-      <div className="action-content">
-        <div className="action-list-header">
+      <div className="process-flow-content">
+        <div className="process-flow-list-header">
           <h5>
             <i className="bi bi-diagram-3 me-2" />処理フロー定義
-            {deletedCount > 0 && <span className="action-list-deleted-count"> (削除予定 {deletedCount})</span>}
+            {deletedCount > 0 && <span className="process-flow-list-deleted-count"> (削除予定 {deletedCount})</span>}
           </h5>
           {(() => {
             const summary = { draft: 0, provisional: 0, committed: 0, notes: 0 };
@@ -693,7 +693,7 @@ export function ProcessFlowListView() {
               </div>
             );
           })()}
-          <div className="action-list-header-right">
+          <div className="process-flow-list-header-right">
             <ViewModeToggle mode={viewMode} onChange={setViewMode} storageKey={STORAGE_KEY} />
             <button
               className="btn btn-primary btn-sm"
@@ -711,7 +711,7 @@ export function ProcessFlowListView() {
             >
               <i className="bi bi-trash" /> 削除{selection.selectedIds.size > 0 ? ` (${selection.selectedIds.size})` : ""}
             </button>
-            <span className="action-saveline-sep" />
+            <span className="process-flow-saveline-sep" />
             <button
               className="btn btn-outline-secondary btn-sm"
               data-testid="list-reset-btn"
@@ -734,7 +734,7 @@ export function ProcessFlowListView() {
         </div>
 
         {/* フィルタバー */}
-        <div className="action-list-filters">
+        <div className="process-flow-list-filters">
           <button
             className={`btn btn-sm ${filterType === "all" ? "btn-primary" : "btn-outline-secondary"}`}
             onClick={() => setFilterType("all")}
@@ -755,9 +755,9 @@ export function ProcessFlowListView() {
             );
           })}
 
-          <div className="action-list-filter-sep" />
+          <div className="process-flow-list-filter-sep" />
 
-          <label className="action-list-check-label">
+          <label className="process-flow-list-check-label">
             <input
               type="checkbox"
               checked={filterErrorsOnly}
@@ -766,7 +766,7 @@ export function ProcessFlowListView() {
             エラーありのみ
           </label>
 
-          <label className="action-list-check-label">
+          <label className="process-flow-list-check-label">
             <input
               type="checkbox"
               checked={filterMarkersOnly}
@@ -775,9 +775,9 @@ export function ProcessFlowListView() {
             <i className="bi bi-robot" /> マーカーありのみ
           </label>
 
-          <div className="action-list-filter-sep" />
+          <div className="process-flow-list-filter-sep" />
 
-          <label className="action-list-check-label" style={{ display: "flex", alignItems: "center", gap: 4 }}>
+          <label className="process-flow-list-check-label" style={{ display: "flex", alignItems: "center", gap: 4 }}>
             成熟度:
             <select
               className="form-select form-select-sm"
@@ -825,7 +825,7 @@ export function ProcessFlowListView() {
           layout={viewMode === "card" ? "grid" : "list"}
           renderCard={renderCard}
           showNumColumn={viewMode === "table"}
-          className="action-data-list"
+          className="process-flow-data-list"
           isItemGhost={(id) => editor.isDeleted(id)}
           emptyMessage={
             groups.length === 0
@@ -837,8 +837,8 @@ export function ProcessFlowListView() {
 
       {/* 新規作成モーダル */}
       {showAdd && (
-        <div className="action-modal-overlay" onClick={() => setShowAdd(false)}>
-          <div className="action-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="process-flow-modal-overlay" onClick={() => setShowAdd(false)}>
+          <div className="process-flow-modal" onClick={(e) => e.stopPropagation()}>
             <h6>処理フロー定義の新規作成</h6>
             <div className="form-group">
               <label className="form-label">名前 *</label>
@@ -887,7 +887,7 @@ export function ProcessFlowListView() {
                 placeholder="処理フローの概要"
               />
             </div>
-            <div className="action-modal-footer">
+            <div className="process-flow-modal-footer">
               <button className="btn btn-outline-secondary btn-sm" onClick={() => setShowAdd(false)}>
                 キャンセル
               </button>


### PR DESCRIPTION
## 概要

PR #394 で CSS 定義側 (`processFlow.css`) と e2e selector は `.process-flow-*` にリネーム済みだったが、**TSX 内の `className=\"action-*\"` が全く書き換えられておらず 56 箇所残存** していた。

結果として **CSS と TSX が不整合で ProcessFlow 画面のスタイルが完全に当たらない状態** だった。vitest / tsc は通過、Playwright E2E 未実行のため回帰検知できず。

## 根本原因

PR #394 の verification rg パターンが `\.action-*` (ドット付き CSS selector) のみで、TSX の `className=\"action-*\"` (ドットなし文字列) を漏らしていた。Codex plugin の task 検証も同じ不十分なパターンを使ったため検出できず。

## 修正内容

`designer/src/components/process-flow/` 下の 2 ファイル (ProcessFlowEditor.tsx + ProcessFlowListView.tsx) で className を機械的に置換 (56 箇所):

| 旧 className | 新 className |
|---|---|
| action-page | process-flow-page |
| action-content | process-flow-content |
| action-editor-breadcrumb | process-flow-editor-breadcrumb |
| action-validation-panel{,-header,-list,-bulk-ai} | process-flow-validation-panel* |
| action-validation-{ok,badges} | process-flow-validation-* |
| action-tabs / action-tab / action-tab-add | process-flow-tab* |
| action-io-{panel,field} | process-flow-io-* |
| action-modal{,-overlay,-footer} | process-flow-modal* |
| action-marker-{badges,badge} | process-flow-marker-* |
| action-list-{header,name,deleted-count,header-right,check-label,filter-sep,filters} | process-flow-list-* |
| action-card-{content,head,name,meta} | process-flow-card-* |
| action-saveline-sep | process-flow-saveline-sep |
| action-data-list | process-flow-data-list |

## 検証

- \`npx tsc --noEmit\`: exit 0
- \`npx vitest run\`: 46 files / 704 tests **all pass**
- \`grep 'className=[^>]*\baction-' designer/src/components/process-flow\`: **残存 0**
- CSS 定義と TSX 使用側の整合: 3 サンプル class (process-flow-page / process-flow-validation-panel-bulk-ai / process-flow-marker-badge) で確認済み

## 教訓 (以降の運用)

CSS リネーム時は **3 つの形態を全部** チェックする必要あり:

1. CSS 定義側 (ドット付き selector): \`rg '\.action-<word>'\`
2. **TSX 使用側 (ドットなし文字列)**: \`rg 'className=[^>]*\baction-<word>'\` ← **今回これが漏れていた**
3. E2E selector (ドット付きで Playwright 参照): \`rg '\.action-<word>' designer/e2e\`

本件を教訓として memory (`project_framework_research_2026_04_25.md` 等) に記録予定。

Refs #392 #393 #394