### PR TITLE
feat(processflow): testScenarios (Given-When-Then) を ProcessFlow に追加 (#400)

### DIFF
--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -1071,9 +1071,39 @@ export interface ProcessFlow {
    * - Marker: AI への指示・一時的なコミュニケーション (解決後は resolvedAt で非表示)
    */
   markers?: Marker[];
+  testScenarios?: TestScenario[];
   createdAt: string;
   updatedAt: string;
 }
+
+export interface TestScenario {
+  id: string;
+  name: string;
+  description?: string;
+  given: TestPrecondition[];
+  when: TestInvocation;
+  then: TestAssertion[];
+  tags?: string[];
+}
+
+export type TestPrecondition =
+  | { kind: "dbState"; table: string; rows: Record<string, unknown>[] }
+  | { kind: "sessionContext"; context: Record<string, unknown> }
+  | { kind: "externalStub"; externalRef: string; responseMock: unknown }
+  | { kind: "clock"; now: string };
+
+export interface TestInvocation {
+  actionId: string;
+  input: Record<string, unknown>;
+}
+
+export type TestAssertion =
+  | { kind: "outcome"; expected: string }
+  | { kind: "dbRow"; table: string; match: Record<string, unknown>; count?: number }
+  | { kind: "output"; path: string; equals?: unknown; matches?: string }
+  | { kind: "externalCall"; externalRef: string; method?: string; bodyMatch?: Record<string, unknown> }
+  | { kind: "auditLog"; action: string; result?: "success" | "failure" }
+  | { kind: "errorMessage"; msgKey: string };
 
 /** project.json用メタデータ */
 export interface ProcessFlowMeta {

--- a/docs/sample-project/process-flows/cccccccc-0007-4000-8000-cccccccccccc.json
+++ b/docs/sample-project/process-flows/cccccccc-0007-4000-8000-cccccccccccc.json
@@ -485,6 +485,184 @@
     }
   ],
 
+  "testScenarios": [
+    {
+      "id": "happy-path-regular-invoice",
+      "name": "通常請求書を発行できる",
+      "description": "存在する顧客と商品を指定し、請求書登録、PDF 生成、メール通知まで完了して 201 を返す。",
+      "given": [
+        {
+          "kind": "sessionContext",
+          "context": {
+            "sessionUserId": 9001,
+            "requestId": "req-test-0007-happy"
+          }
+        },
+        {
+          "kind": "dbState",
+          "table": "customers",
+          "rows": [
+            {
+              "id": 101,
+              "name": "株式会社サンプル",
+              "email": "billing@example.com",
+              "is_deleted": false
+            }
+          ]
+        },
+        {
+          "kind": "dbState",
+          "table": "products",
+          "rows": [
+            { "id": 501, "name": "保守サポート", "unit_price": 100000, "is_deleted": false },
+            { "id": 502, "name": "初期設定", "unit_price": 50000, "is_deleted": false }
+          ]
+        },
+        {
+          "kind": "externalStub",
+          "externalRef": "pdfService",
+          "responseMock": {
+            "status": 200,
+            "body": { "pdfUrl": "s3://invoices/INV-2026-0001.pdf" }
+          }
+        },
+        {
+          "kind": "externalStub",
+          "externalRef": "sendgrid",
+          "responseMock": {
+            "status": 202,
+            "body": { "accepted": true }
+          }
+        }
+      ],
+      "when": {
+        "actionId": "act-001",
+        "input": {
+          "customerId": 101,
+          "items": [
+            { "productId": 501, "quantity": 2 },
+            { "productId": 502, "quantity": 1 }
+          ],
+          "paymentTermDays": 30
+        }
+      },
+      "then": [
+        { "kind": "outcome", "expected": "201-created" },
+        { "kind": "output", "path": "$.invoiceNumber", "matches": "^INV-2026-\\d{4}$" }
+      ],
+      "tags": ["happy", "invoice", "external"]
+    },
+    {
+      "id": "validation-error-empty-items",
+      "name": "請求明細なしはバリデーションエラー",
+      "description": "items が空配列の場合、入力バリデーションで 400 を返し、必須エラーメッセージキーを検証する。",
+      "given": [
+        {
+          "kind": "sessionContext",
+          "context": {
+            "sessionUserId": 9001,
+            "requestId": "req-test-0007-validation"
+          }
+        }
+      ],
+      "when": {
+        "actionId": "act-001",
+        "input": {
+          "customerId": 101,
+          "items": [],
+          "paymentTermDays": 30
+        }
+      },
+      "then": [
+        { "kind": "outcome", "expected": "400-validation" },
+        { "kind": "errorMessage", "msgKey": "@conv.msg.required" }
+      ],
+      "tags": ["error", "validation"]
+    },
+    {
+      "id": "db-state-invoice-row-created",
+      "name": "DB 状態に基づき請求書行が登録される",
+      "description": "顧客と商品が存在する状態から請求書を発行し、invoices と invoice_items の登録内容を検証する。",
+      "given": [
+        {
+          "kind": "clock",
+          "now": "2026-04-24T09:00:00.000Z"
+        },
+        {
+          "kind": "sessionContext",
+          "context": {
+            "sessionUserId": 9002,
+            "requestId": "req-test-0007-db"
+          }
+        },
+        {
+          "kind": "dbState",
+          "table": "customers",
+          "rows": [
+            {
+              "id": 202,
+              "name": "テスト商事",
+              "email": "accounting@example.com",
+              "is_deleted": false
+            }
+          ]
+        },
+        {
+          "kind": "dbState",
+          "table": "products",
+          "rows": [
+            { "id": 601, "name": "月額利用料", "unit_price": 30000, "is_deleted": false }
+          ]
+        },
+        {
+          "kind": "externalStub",
+          "externalRef": "pdfService",
+          "responseMock": {
+            "status": 200,
+            "body": { "pdfUrl": "s3://invoices/INV-2026-0002.pdf" }
+          }
+        }
+      ],
+      "when": {
+        "actionId": "act-001",
+        "input": {
+          "customerId": 202,
+          "items": [
+            { "productId": 601, "quantity": 3 }
+          ],
+          "paymentTermDays": 45
+        }
+      },
+      "then": [
+        {
+          "kind": "dbRow",
+          "table": "invoices",
+          "match": {
+            "customer_id": 202,
+            "subtotal": 90000,
+            "tax_amount": 9000,
+            "total_amount": 99000,
+            "payment_term_days": 45,
+            "issued_by": 9002
+          },
+          "count": 1
+        },
+        {
+          "kind": "dbRow",
+          "table": "invoice_items",
+          "match": {
+            "product_id": 601,
+            "quantity": 3,
+            "unit_price": 30000,
+            "line_amount": 90000
+          },
+          "count": 1
+        }
+      ],
+      "tags": ["db", "edge"]
+    }
+  ],
+
   "createdAt": "2026-04-24T00:00:00.000Z",
   "updatedAt": "2026-04-24T00:00:00.000Z"
 }

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -12,6 +12,7 @@
 | [process-flow-extensions.md](process-flow-extensions.md) | HTTP 契約 / TX / Saga / 外部 outcomes / ValidationRule / compute / return (Phase B) | #151 / #182 |
 | [process-flow-expression-language.md](process-flow-expression-language.md) | runIf / expression / bodyExpression の式言語 BNF (js-subset) | #253 |
 | [process-flow-runtime-conventions.md](process-flow-runtime-conventions.md) | SQL 式補間 / HTTP body シリアライズ / TX×throw×tryCatch / fireAndForget / sideEffects TX 境界等の実行時規約 | #261 |
+| [process-flow-testing.md](process-flow-testing.md) | 処理フローの Given-When-Then テストシナリオ (`testScenarios`) | #400 |
 | [screen-items.md](screen-items.md) | 画面項目定義 (フォーム系バリデーション 3 層のうち「画面」層) — **ドラフト v0.1** | #318 |
 
 **一次成果物**: JSON スキーマ [`schemas/process-flow.schema.json`](../../schemas/process-flow.schema.json) ([README](../../schemas/README.md))。仕様書と突合する機械可読版。

--- a/docs/spec/process-flow-testing.md
+++ b/docs/spec/process-flow-testing.md
@@ -1,0 +1,144 @@
+# 処理フロー テストシナリオ仕様
+
+## 目的
+
+`testScenarios` は、処理フロー定義の中に Given-When-Then 形式のテストケースを同居させるための領域である。
+業務設計者が期待する振る舞いを、仕様書、実装指示、テスト観点として 1 つの `ProcessFlow` にまとめる。
+AI 実装者はこの配列を読み、単体テスト、結合テスト、E2E テストの下書きを自動生成できる。
+テストケースを別ファイルに分離しないことで、Action、outcome、DB 操作、外部システム参照とのずれを減らす。
+UI 表示は本仕様の対象外であり、まず JSON Schema と型定義で機械可読な形を固定する。
+
+## 配置
+
+`testScenarios` は `ProcessFlow` の直下に任意プロパティとして配置する。
+既存の処理フローは `testScenarios` を持たなくても valid でなければならない。
+新規または成熟度の高い処理フローでは、最低限のシナリオを記述することを推奨する。
+
+```json
+{
+  "id": "process-flow-id",
+  "actions": [],
+  "testScenarios": []
+}
+```
+
+## TestScenario
+
+各シナリオは 1 つの業務上の期待結果を表す。
+`id` はファイル内で一意な安定 ID とする。
+`name` は設計者と実装者が読む表示名とする。
+`description` は条件や狙いが名前だけで伝わらない場合に記述する。
+`given` は前提条件の配列である。
+`when` は起動する Action と入力値である。
+`then` は期待結果の配列である。
+`tags` は `happy`、`error`、`db`、`edge` など任意の分類に使う。
+
+## Given
+
+`given` にはテスト実行前に準備すべき状態を列挙する。
+複数の前提は配列順に読めるが、実行基盤は必要に応じて依存順に並べ替えてよい。
+前提条件は `kind` で種類を判別する。
+
+### dbState
+
+`dbState` はテスト DB に投入するテーブル行を表す。
+`table` は物理テーブル名または実装側が解決できる論理名とする。
+`rows` は投入する行オブジェクトの配列である。
+既存データを暗黙に期待せず、テストに必要な最小行を明示する。
+論理削除や有効期間など、分岐に影響する列も省略しない。
+
+### sessionContext
+
+`sessionContext` はログインユーザー、権限、リクエスト ID などの実行コンテキストを表す。
+`context` にはミドルウェアやフレームワークが通常注入する値を置く。
+`ambientVariables` と対応する値は、ここに記述すると実装テストが作りやすい。
+認可や監査に関わる値は、業務上の前提として明示する。
+
+### externalStub
+
+`externalStub` は外部 API や外部サービスのモック応答を表す。
+`externalRef` は `externalSystemCatalog` のキーを参照する。
+`responseMock` には HTTP ステータス、レスポンス body、例外相当の情報などを入れる。
+成功系だけでなく、タイムアウトや異常応答を表現する場合にも使う。
+
+### clock
+
+`clock` は実行時刻を固定するための前提である。
+`now` は ISO 8601 形式の文字列とする。
+締め日、期限日、採番、監査ログ時刻など、現在時刻で結果が変わる処理で使う。
+時刻を固定しないと再現性が落ちるシナリオでは必ず指定する。
+
+## When
+
+`when` はテスト対象の起動点を表す。
+`actionId` は同じ `ProcessFlow` 内の `actions[].id` を参照する。
+`input` は画面入力値、HTTP request body、またはバッチ起動パラメータに相当する。
+入力値には正常値だけでなく、未入力、境界値、不正値もそのまま記述する。
+AI 実装者は `actionId` からルート、ハンドラ、ユースケースの呼び出し先を特定する。
+
+## Then
+
+`then` には検証すべき期待結果を列挙する。
+1 つのシナリオに複数の assertion を置いてよい。
+主要 outcome と、副作用の DB 行や外部呼び出しを同時に確認する使い方を想定する。
+assertion は `kind` で種類を判別する。
+
+### outcome
+
+`outcome` は Action の結果が期待した outcome または response に一致することを検証する。
+`expected` には `responses[].id`、分岐 outcome、または実装側が解釈できる結果 ID を記述する。
+正常終了、バリデーションエラー、業務エラーの最初の確認点として使う。
+
+### dbRow
+
+`dbRow` は特定テーブルに期待する行が存在することを検証する。
+`table` は対象テーブル名である。
+`match` は一致条件または期待値の部分集合である。
+`count` を指定した場合は一致件数も検証する。
+INSERT、UPDATE、論理削除、履歴登録などの副作用確認に使う。
+
+### output
+
+`output` はレスポンス body や returnMapping の一部を検証する。
+`path` は JSON path など、実装側が解釈できる出力パスである。
+`equals` は完全一致の期待値である。
+`matches` は文字列や採番値を正規表現で検証する場合に使う。
+
+### externalCall
+
+`externalCall` は外部システムが期待どおり呼び出されたことを検証する。
+`externalRef` は `externalSystemCatalog` のキーを参照する。
+`method` は HTTP メソッドなどの呼び出し種別を表す。
+`bodyMatch` は送信 body の部分一致条件である。
+fire-and-forget の通知や、外部 API 連携の契約確認に使う。
+
+### auditLog
+
+`auditLog` は監査ログが記録されたことを検証する。
+`action` は監査上の操作名である。
+`result` は `success` または `failure` を指定できる。
+この assertion は #397 で追加された `AuditStep` と対応する。
+監査要件がある処理では、成功時だけでなく失敗時の記録も検討する。
+
+### errorMessage
+
+`errorMessage` はバリデーションや業務エラーのメッセージキーを検証する。
+`msgKey` は `@conv.msg.*` などの規約カタログ参照を想定する。
+文言そのものではなくキーを検証することで、多言語化や文言調整の影響を減らす。
+入力エラーのテストでは outcome と組み合わせて使う。
+
+## 最低シナリオ
+
+各 `ProcessFlow` には最低 3 件のシナリオを持たせることを推奨する。
+1 件目は happy path とし、主要な正常終了 outcome を確認する。
+2 件目は validation error とし、入力不備と `errorMessage` を確認する。
+3 件目は DB state dependency とし、`dbState` 前提と `dbRow` assertion を確認する。
+外部システム連携や監査要件が重要な場合は、`externalCall` や `auditLog` の追加シナリオを置く。
+
+## AI 実装者の責務
+
+AI 実装者は `testScenarios` を単なる説明文として扱わず、テスト生成の入力として扱う。
+`when.actionId` が存在しない場合は、実装前に仕様不整合として報告する。
+`given` のテーブル名や `externalRef` が参照先と合わない場合も同様に扱う。
+assertion の意味を満たすために必要なテスト基盤は、対象アプリの標準的な方法で用意する。
+シナリオが 3 件未満の成熟した処理フローでは、テスト観点不足として追加提案する。

--- a/schemas/process-flow.schema.json
+++ b/schemas/process-flow.schema.json
@@ -49,6 +49,10 @@
       "type": "array",
       "items": { "$ref": "#/$defs/Marker" }
     },
+    "testScenarios": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/TestScenario" }
+    },
     "actions": {
       "type": "array",
       "items": { "$ref": "#/$defs/ActionDefinition" }
@@ -71,6 +75,163 @@
       "type": "string",
       "enum": ["draft", "provisional", "committed"],
       "description": "成熟度 3 値。未指定は draft 相当"
+    },
+    "TestScenario": {
+      "type": "object",
+      "required": ["id", "name", "given", "when", "then"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string" },
+        "name": { "type": "string" },
+        "description": { "type": "string" },
+        "given": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/TestPrecondition" }
+        },
+        "when": { "$ref": "#/$defs/TestInvocation" },
+        "then": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/TestAssertion" }
+        },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "TestPrecondition": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["kind", "table", "rows"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "dbState" },
+            "table": { "type": "string" },
+            "rows": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "context"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "sessionContext" },
+            "context": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "externalRef", "responseMock"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "externalStub" },
+            "externalRef": { "type": "string" },
+            "responseMock": true
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "now"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "clock" },
+            "now": { "type": "string" }
+          }
+        }
+      ]
+    },
+    "TestInvocation": {
+      "type": "object",
+      "required": ["actionId", "input"],
+      "additionalProperties": false,
+      "properties": {
+        "actionId": { "type": "string" },
+        "input": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    },
+    "TestAssertion": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["kind", "expected"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "outcome" },
+            "expected": { "type": "string" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "table", "match"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "dbRow" },
+            "table": { "type": "string" },
+            "match": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "count": { "type": "number" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "path"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "output" },
+            "path": { "type": "string" },
+            "equals": true,
+            "matches": { "type": "string" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "externalRef"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "externalCall" },
+            "externalRef": { "type": "string" },
+            "method": { "type": "string" },
+            "bodyMatch": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "action"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "auditLog" },
+            "action": { "type": "string" },
+            "result": { "type": "string", "enum": ["success", "failure"] }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "msgKey"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "errorMessage" },
+            "msgKey": { "type": "string" }
+          }
+        }
+      ]
     },
     "ActionTrigger": {
       "type": "string",

--- a/schemas/process-flow.schema.json
+++ b/schemas/process-flow.schema.json
@@ -145,7 +145,7 @@
           "additionalProperties": false,
           "properties": {
             "kind": { "const": "clock" },
-            "now": { "type": "string" }
+            "now": { "type": "string", "format": "date-time" }
           }
         }
       ]
@@ -184,7 +184,7 @@
               "type": "object",
               "additionalProperties": true
             },
-            "count": { "type": "number" }
+            "count": { "type": "integer", "minimum": 0 }
           }
         },
         {
@@ -195,7 +195,7 @@
             "kind": { "const": "output" },
             "path": { "type": "string" },
             "equals": true,
-            "matches": { "type": "string" }
+            "matches": { "type": "string", "format": "regex" }
           }
         },
         {


### PR DESCRIPTION
## 関連

- Closes #400
- 仕様: `docs/spec/process-flow-testing.md` (本 PR で新設) — TestScenario / TestPrecondition / TestInvocation / TestAssertion の意味と AI 自動テスト生成の責務を定義
- 親 meta: #396 (処理フロー仕様の拡張計画)
- 関連: #397 (A-1 LogStep/AuditStep) — `auditLog` assertion kind が連動

## 概要

ProcessFlow に Given-When-Then 形式の `testScenarios?: TestScenario[]` を追加し、仕様 + 実装指示 + テストケースを 1 ファイルに co-locate できるようにする。これにより AI が ProcessFlow JSON から自動でテストケースを生成・実装できる粒度に到達する (5/5 ドッグフード後の次段階)。

## 主な変更

- **TypeScript types** (`designer/src/types/action.ts`): `ProcessFlow.testScenarios?: TestScenario[]` を optional 追加。`TestScenario` / `TestPrecondition` (discriminated union 4 kind) / `TestInvocation` / `TestAssertion` (discriminated union 6 kind) を export
- **JSON Schema** (`schemas/process-flow.schema.json`): `ProcessFlow.testScenarios` + `$defs/TestScenario` / `$defs/TestPrecondition` (oneOf 4 variant) / `$defs/TestInvocation` / `$defs/TestAssertion` (oneOf 6 variant)
- **Spec** (`docs/spec/process-flow-testing.md` 新規): 各 kind の意味・使い分け・AI 生成責務を 144 行で明文化。`docs/spec/README.md` にリンク追加
- **Sample** (`docs/sample-project/process-flows/cccccccc-0007-*.json`): 3 シナリオ追加 — happy path / validation error / DB state dependency
- **Schema 入力制約強化** (フォローアップコミット): `clock.now` を `format: date-time`、`dbRow.count` を非負整数、`output.matches` を `format: regex` に絞り、不正値を schema レベルで reject

## 仕様逐条突合 (自己申告)

ISSUE #400 受け入れ基準を file:line で個別検証:

- [x] `schemas/process-flow.schema.json` の `ProcessFlow` に `testScenarios` (optional, array) → process-flow.schema.json の ProcessFlow 定義 ✓
- [x] `$defs/TestScenario` / `TestPrecondition` / `TestInvocation` / `TestAssertion` 定義済 → process-flow.schema.json の `$defs` ブロック ✓
- [x] `TestAssertion` が `kind` discriminator で oneOf 6 variant — outcome / dbRow / output / externalCall / auditLog / errorMessage の各 required フィールドを正しく強制 → process-flow.schema.json:165-220 ✓
- [x] `TestPrecondition` が `kind` discriminator で oneOf 4 variant — dbState / sessionContext / externalStub / clock → process-flow.schema.json (TestPrecondition $defs) ✓
- [x] `designer/src/types/action.ts` に `TestScenario` / `TestPrecondition` / `TestInvocation` / `TestAssertion` がエクスポート、`ProcessFlow` に `testScenarios?` 追加 → action.ts (新規 4 type + ProcessFlow 拡張) ✓
- [x] `docs/spec/process-flow-testing.md` 新規作成、各 kind の検証意味・AI 生成責務 (最低 3 シナリオ推奨)・auditLog と #397 の連動を明文化 → process-flow-testing.md (144 行) ✓
- [x] `docs/spec/README.md` に新 spec へのリンク追加 ✓
- [x] `cccccccc-0007` に testScenarios 3 件以上 (happy / error / DB) → cccccccc-0007 の `testScenarios` 配列 ✓
- [x] 既存サンプル (testScenarios 無し) が schema valid (下位互換) — 既存 7 件 (0001-0006, 0008) は testScenarios 不在で従来通り valid ✓
- [x] `cd designer && npx vitest run src/schemas/process-flow.schema.test.ts` 全 pass — 94 tests pass ✓
- [x] `cd designer && npm run build` pass ✓
- [x] 残存チェック (rg) 全 pass ✓

## レビューで特に見てほしい箇所

- **discriminated union の oneOf 構造**: `TestPrecondition` / `TestAssertion` の各 variant で `kind: { "const": "<name>" }` を fixed して `additionalProperties: false` で厳格化。不正な kind や未定義フィールドは schema reject される。漏れがないか確認
- **auditLog assertion の AuditStep 連動**: #397 で merge 済の `audit` step type と整合した参照構造になっているか (実 runtime 検証は本 PR スコープ外)
- **Schema 入力制約強化** (フォローアップコミット d25fa70): clock.now の format: date-time / dbRow.count の non-negative integer / output.matches の format: regex を追加。既存サンプルへの影響なしを確認

## テスト

- Vitest: 727 件 — `cd designer && npx vitest run`
- Schema test: 94 件 (新規 3 サンプル / 既存 8 サンプル iterative validation) — `cd designer && npx vitest run src/schemas/process-flow.schema.test.ts`
- Build: pass — `cd designer && npm run build`
- Playwright: N/A — UI 操作変更なし
- MCP E2E: N/A — MCP API 変更なし

## UI 影響 / マージ保留フラグ

- [ ] UI 影響あり (マージ前にユーザー目視確認必須)
- [x] UI 影響なし (auto テスト pass でマージ可)

スキーマ / 型 / spec / サンプルの追加のみ。testScenario の編集 UI / runtime 実装 / テスト自動生成は本 PR スコープ外 (将来別 ISSUE 候補)。

## spec 側の不足点 / 提案

N/A — 本 PR で `process-flow-testing.md` を新規作成済。

## レビュー担当への申し送り

A-1 (#397) / A-2 (#398) / A-3 (#399) と並んで Tier A 4 項目シリーズの最終 PR。本 PR は testScenarios のスキーマ・型・サンプル・spec のみで、UI / runtime / テスト自動生成は範囲外。AI 実装者が ProcessFlow JSON から「これこれの input でこの outcome / DB 状態が期待される」を読み取れる粒度になっているか、3 シナリオサンプルと spec doc でレビュー希望。

特に:
- `auditLog` assertion が #397 AuditStep と意味的に整合するか
- `dbRow.match` の subset match / `output.path` の path syntax が spec で曖昧でないか
- 既存 cccccccc-0007 の actions / steps が破壊変更されていないこと

## 修正履歴

- `86836a5` 主実装 (Codex)
- `d25fa70` Codex 独立レビュー指摘対応: schema 入力制約強化 (clock.now: date-time / dbRow.count: non-negative int / output.matches: regex format) (Opus)

## スコープ外 (別 ISSUE 化候補)

本 PR はスキーマ層完結。以下は将来別 ISSUE で扱う:
- testScenario 編集 UI (ProcessFlowEditor 拡張)
- testScenario runtime 実行エンジン (実テストランナー)
- AI 自動テスト生成 (Claude Code / Codex で testScenarios → vitest コード生成)
