### PR TITLE
fix(conventions): default?: boolean を TS 型へ同期 (#406)

### DIFF
--- a/designer/src/types/conventions.ts
+++ b/designer/src/types/conventions.ts
@@ -17,6 +17,8 @@ export interface MessageTemplate {
 export interface ScopeEntry {
   value: string;
   description?: string;
+  /** true = このエントリが project-wide ambient default (#369) */
+  default?: boolean;
 }
 
 export interface CurrencyEntry {
@@ -24,6 +26,8 @@ export interface CurrencyEntry {
   subunit?: number;
   roundingMode?: "floor" | "ceil" | "round";
   description?: string;
+  /** true = このエントリが project-wide ambient default (#369) */
+  default?: boolean;
 }
 
 export interface TaxEntry {
@@ -31,6 +35,8 @@ export interface TaxEntry {
   rate: number;
   roundingMode?: "floor" | "ceil" | "round";
   description?: string;
+  /** true = このエントリが project-wide ambient default (#369) */
+  default?: boolean;
 }
 
 export interface AuthEntry {
@@ -38,6 +44,8 @@ export interface AuthEntry {
   sessionStorage?: string;
   passwordHash?: string;
   description?: string;
+  /** true = このエントリが project-wide ambient default (#369) */
+  default?: boolean;
 }
 
 export interface RoleEntry {
@@ -60,6 +68,8 @@ export interface DbEntry {
   timestampColumns?: string[];
   logicalDeleteColumn?: string;
   description?: string;
+  /** true = このエントリが project-wide ambient default (#369) */
+  default?: boolean;
 }
 
 export interface NumberingEntry {


### PR DESCRIPTION
Closes #406

## 関連

- Closes #406
- 仕様: N/A

## 概要

schemas/conventions.schema.json では #369 の ambient default 用に定義済みだった default?: boolean を、対応する TypeScript 型へ同期します。
ScopeEntry / CurrencyEntry / TaxEntry / AuthEntry / DbEntry の 5 interface の schema/type 不整合を解消します。

## 主な変更

- conventions 型: ScopeEntry / CurrencyEntry / TaxEntry / AuthEntry / DbEntry に default?: boolean を追加
- コメント: schema 側の説明に合わせて project-wide ambient default (#369) であることを明記

## 仕様逐条突合 (自己申告)

- Issue #406 受け入れ基準: 5 interface すべてに default?: boolean を追加 → designer/src/types/conventions.ts:19,28,37,46,70 ✓
- Issue #406 受け入れ基準: description コメント付き → designer/src/types/conventions.ts:18,27,36,45,69 ✓
- Issue #406 受け入れ基準: build pass → npm run build ✓
- Issue #406 受け入れ基準: Vitest full suite pass → npx vitest run ✓
- Issue #406 受け入れ基準: default?: boolean 件数が 5 → rg -n 'default\?:\s*boolean' designer/src/types/conventions.ts | wc -l = 5 ✓

## レビューで特に見てほしい箇所

N/A

## テスト

- Vitest: 727 件 (新規 0 件) — full suite
- Playwright: N/A
- MCP E2E: N/A
- Build: npm run build pass
- 残存チェック: rg -n 'default\?:\s*boolean' designer/src/types/conventions.ts | wc -l → 5

## UI 影響 / マージ保留フラグ

- [ ] UI 影響あり (マージ前にユーザー目視確認必須)
- [x] UI 影響なし (auto テスト pass でマージ可)

### UI 影響ありの場合、確認項目

- [ ] N/A
- [ ] N/A
- [ ] N/A

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

変更対象は designer/src/types/conventions.ts のみです。schema 側は既に #369 で default が存在しているため、本 PR では型同期のみ行っています。