### PR TITLE
fix(conventions): role.inherits の dangling 親 role 検出を追加 (#404)

### DIFF
--- a/designer/src/schemas/conventionsValidator.test.ts
+++ b/designer/src/schemas/conventionsValidator.test.ts
@@ -390,6 +390,21 @@ describe("checkConventionsCatalogIntegrity - RBAC", () => {
     expect(issues[0].code).toBe("UNKNOWN_CONV_ROLE_PERMISSION");
     expect(issues[0].path).toBe("role.orderOperator.permissions[1]");
   });
+
+  it("role.inherits の存在しない親 role 参照をエラーとして検出する", () => {
+    const catalog: ConventionsCatalog = {
+      version: "1.0.0",
+      role: {
+        orderApprover: { permissions: [], inherits: ["orderOperator"] },
+      },
+    };
+
+    const issues = checkConventionsCatalogIntegrity(catalog);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("UNKNOWN_CONV_ROLE_INHERITS");
+    expect(issues[0].path).toBe("role.orderApprover.inherits[0]");
+    expect(issues[0].value).toBe("orderOperator");
+  });
 });
 
 // ── checkScreenItemConventionReferences (#351) ────────────────────────────

--- a/designer/src/schemas/conventionsValidator.ts
+++ b/designer/src/schemas/conventionsValidator.ts
@@ -67,6 +67,7 @@ export interface ConventionIssue {
     | "UNKNOWN_CONV_CATEGORY"
     | "ROLE_INHERITS_CYCLE"
     | "UNKNOWN_CONV_ROLE_PERMISSION"
+    | "UNKNOWN_CONV_ROLE_INHERITS"
     | "INVALID_DEFAULT_LOCALE"
     | "UNKNOWN_MSG_LOCALE";
   value: string;
@@ -142,6 +143,7 @@ export function checkConventionsCatalogIntegrity(catalog: ConventionsCatalog | n
 
   const issues: ConventionIssue[] = [];
   checkRolePermissionReferences(catalog, issues);
+  checkRoleInheritsReferences(catalog, issues);
   checkRoleInheritanceCycles(catalog, issues);
   checkI18nCatalog(catalog, issues);
   return issues;
@@ -186,6 +188,23 @@ function checkRolePermissionReferences(catalog: ConventionsCatalog, issues: Conv
           code: "UNKNOWN_CONV_ROLE_PERMISSION",
           value: permissionKey,
           message: `role.${roleKey} が存在しない permission.${permissionKey} を参照しています`,
+        });
+      }
+    });
+  });
+}
+
+function checkRoleInheritsReferences(catalog: ConventionsCatalog, issues: ConventionIssue[]): void {
+  const roles = catalog.role ?? {};
+
+  Object.entries(roles).forEach(([roleKey, role]) => {
+    (role.inherits ?? []).forEach((parentKey, i) => {
+      if (!(parentKey in roles)) {
+        issues.push({
+          path: `role.${roleKey}.inherits[${i}]`,
+          code: "UNKNOWN_CONV_ROLE_INHERITS",
+          value: parentKey,
+          message: `role.${roleKey} が存在しない role.${parentKey} を参照しています`,
         });
       }
     });


### PR DESCRIPTION
## 関連

- Closes #404
- 仕様: GitHub Issue #404 受け入れ基準
  - role.foo.inherits = [nonExistentRole] で UNKNOWN_CONV_ROLE_INHERITS を発行する: designer/src/schemas/conventionsValidator.ts:197
  - 既存の循環参照テスト / dangling permission テストが回帰しない: designer/src/schemas/conventionsValidator.test.ts:364
  - 対象テストと full vitest が pass: 本 PR の「テスト」節

## 概要

role.inherits に存在しない親 role が指定された場合に conventionsValidator が silent ignore していたため、UNKNOWN_CONV_ROLE_INHERITS として ConventionIssue を発行する検査を追加しました。

## 主な変更

- RBAC カタログ整合性検査に role.inherits の dangling 親 role 検出を追加
- ConventionIssue の code union に UNKNOWN_CONV_ROLE_INHERITS を追加
- role.inherits の存在しない親 role 参照を検出する単体テストを追加

## 仕様逐条突合 (自己申告)

- Issue #404: IssueCode union に UNKNOWN_CONV_ROLE_INHERITS を追加 → designer/src/schemas/conventionsValidator.ts:70
- Issue #404: checkRoleInheritsReferences(catalog, issues) を追加し role.<roleKey>.inherits[<i>] に issue を出す → designer/src/schemas/conventionsValidator.ts:197
- Issue #404: checkRolePermissionReferences / checkRoleInheritanceCycles 付近の orchestrator から呼び出す → designer/src/schemas/conventionsValidator.ts:146
- Issue #404: RBAC describe 内に dangling inherits のテストを追加 → designer/src/schemas/conventionsValidator.test.ts:393

## レビューで特に見てほしい箇所

- UNKNOWN_CONV_ROLE_INHERITS の message / path / value が既存の UNKNOWN_CONV_ROLE_PERMISSION と同じ粒度になっているか
- dangling inherits と cycle 検出を別 issue として扱う順序で問題ないか

## テスト

- Vitest: 51 件 (新規 1 件) - `cd designer && npx vitest run src/schemas/conventionsValidator.test.ts`
- Vitest: 728 件 - `cd designer && npx vitest run`
- Build: pass - `cd designer && npm run build`
- Playwright: N/A (スキーマ validator のみの変更で UI 操作なし)
- MCP E2E: N/A (ファイル永続化 / MCP API 変更なし)

## UI 影響 / マージ保留フラグ

- [ ] UI 影響あり (マージ前にユーザー目視確認必須)
- [x] UI 影響なし (auto テスト pass でマージ可)

### UI 影響ありの場合の確認項目

- [ ] N/A: UI 変更なし
- [ ] N/A: 画面表示 / 保存挙動の変更なし
- [ ] N/A: 既存 UI の回帰確認対象なし

## spec 側の不足点 / 提案

N/A: Issue #404 の follow-up 実装で、仕様書・スキーマ・型ファイルはスコープ外です。

## レビュー担当への申し送り

変更対象は conventionsValidator の RBAC カタログ整合性検査のみです。既存の dangling permission 検出と同じ形で、親 role の存在チェックを cycle 検出前に追加しています。