### PR TITLE
feat(processflow): LogStep/AuditStep 専用編集フォーム (#402)

### DIFF
--- a/designer/src/components/process-flow/AuditStepPanel.test.tsx
+++ b/designer/src/components/process-flow/AuditStepPanel.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { AuditStepPanel } from "./AuditStepPanel";
+import type { AuditStep } from "../../types/action";
+
+const baseStep: AuditStep = {
+  id: "test-step",
+  type: "audit",
+  description: "",
+  action: "order.create",
+  maturity: "draft",
+};
+
+describe("AuditStepPanel", () => {
+  // Must-fix #1 (PR #410 review): resource.type / resource.id の片方だけ入力時は
+  // schema 上 type=""/id="X" のような片側空 object になってしまうのを防ぐ
+  it("resource.type だけ入力すると resource は undefined のまま", () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <AuditStepPanel step={baseStep} onChange={onChange} />,
+    );
+    const typeInput = container.querySelector('[data-field-path="resource.type"] input') as HTMLInputElement;
+    fireEvent.change(typeInput, { target: { value: "Order" } });
+    expect(onChange).toHaveBeenLastCalledWith({ resource: undefined });
+  });
+
+  it("resource.id だけ入力すると resource は undefined のまま", () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <AuditStepPanel step={baseStep} onChange={onChange} />,
+    );
+    const idInput = container.querySelector('[data-field-path="resource.id"] input') as HTMLInputElement;
+    fireEvent.change(idInput, { target: { value: "@orderId" } });
+    expect(onChange).toHaveBeenLastCalledWith({ resource: undefined });
+  });
+
+  it("resource.type と resource.id 両方揃った時のみ resource が出力される", () => {
+    const onChange = vi.fn();
+    const stepWithType: AuditStep = { ...baseStep, resource: { type: "Order", id: "" } };
+    const { container } = render(
+      <AuditStepPanel step={stepWithType} onChange={onChange} />,
+    );
+    const idInput = container.querySelector('[data-field-path="resource.id"] input') as HTMLInputElement;
+    fireEvent.change(idInput, { target: { value: "@orderId" } });
+    expect(onChange).toHaveBeenLastCalledWith({ resource: { type: "Order", id: "@orderId" } });
+  });
+
+  it("両方入っている state から id を空にすると resource が undefined", () => {
+    const onChange = vi.fn();
+    const stepFull: AuditStep = { ...baseStep, resource: { type: "Order", id: "@orderId" } };
+    const { container } = render(
+      <AuditStepPanel step={stepFull} onChange={onChange} />,
+    );
+    const idInput = container.querySelector('[data-field-path="resource.id"] input') as HTMLInputElement;
+    fireEvent.change(idInput, { target: { value: "" } });
+    expect(onChange).toHaveBeenLastCalledWith({ resource: undefined });
+  });
+
+  it("空白のみ入力は trim されて空扱い", () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <AuditStepPanel step={baseStep} onChange={onChange} />,
+    );
+    const typeInput = container.querySelector('[data-field-path="resource.type"] input') as HTMLInputElement;
+    fireEvent.change(typeInput, { target: { value: "   " } });
+    expect(onChange).toHaveBeenLastCalledWith({ resource: undefined });
+  });
+});

--- a/designer/src/components/process-flow/AuditStepPanel.tsx
+++ b/designer/src/components/process-flow/AuditStepPanel.tsx
@@ -11,11 +11,14 @@ interface Props {
 
 export function AuditStepPanel({ step, onChange, onCommit, conventions }: Props) {
   const setResource = (patch: Partial<NonNullable<AuditStep["resource"]>>) => {
-    const next = { type: step.resource?.type ?? "", id: step.resource?.id ?? "", ...patch };
-    if (!next.type && !next.id) {
+    const type = (patch.type ?? step.resource?.type ?? "").trim();
+    const id = (patch.id ?? step.resource?.id ?? "").trim();
+    // 片方だけ入力された中間状態は schema 上 type=""/id="" の片側空 object となり
+    // AI 読み取り時に誤判定を招くため、両方揃うまで undefined とする
+    if (!type || !id) {
       onChange({ resource: undefined });
     } else {
-      onChange({ resource: next });
+      onChange({ resource: { type, id } });
     }
   };
 
@@ -117,6 +120,7 @@ export function AuditStepPanel({ step, onChange, onCommit, conventions }: Props)
               className="form-check-input"
               checked={!!step.sensitive}
               onChange={(e) => {
+                // false (default) は出力しない: JSON ノイズを減らすため省略形を採用
                 onChange({ sensitive: e.target.checked || undefined });
                 onCommit?.();
               }}

--- a/designer/src/components/process-flow/AuditStepPanel.tsx
+++ b/designer/src/components/process-flow/AuditStepPanel.tsx
@@ -1,0 +1,131 @@
+import type { AuditStep } from "../../types/action";
+import type { ConventionsCatalog } from "../../schemas/conventionsValidator";
+import { ConvCompletionInput } from "../common/ConvCompletionInput";
+
+interface Props {
+  step: AuditStep;
+  onChange: (patch: Partial<AuditStep>) => void;
+  onCommit?: () => void;
+  conventions?: ConventionsCatalog | null;
+}
+
+export function AuditStepPanel({ step, onChange, onCommit, conventions }: Props) {
+  const setResource = (patch: Partial<NonNullable<AuditStep["resource"]>>) => {
+    const next = { type: step.resource?.type ?? "", id: step.resource?.id ?? "", ...patch };
+    if (!next.type && !next.id) {
+      onChange({ resource: undefined });
+    } else {
+      onChange({ resource: next });
+    }
+  };
+
+  return (
+    <>
+      <div className="row g-2 mb-2" data-field-path="action">
+        <div className="col-12">
+          <label className="form-label">
+            <i className="bi bi-lightning-charge me-1" />
+            業務アクション (action) <span className="text-danger">*</span>
+          </label>
+          <input
+            type="text"
+            className="form-control form-control-sm"
+            value={step.action}
+            onChange={(e) => onChange({ action: e.target.value })}
+            onBlur={onCommit}
+            placeholder="例: order.create / user.passwordChange / invoice.approve"
+            style={{ fontFamily: "monospace" }}
+          />
+        </div>
+      </div>
+
+      <div className="row g-2 mb-2">
+        <div className="col-4" data-field-path="resource.type">
+          <label className="form-label">
+            <i className="bi bi-box me-1" />
+            対象リソース種別 (resource.type)
+          </label>
+          <input
+            type="text"
+            className="form-control form-control-sm"
+            value={step.resource?.type ?? ""}
+            onChange={(e) => setResource({ type: e.target.value })}
+            onBlur={onCommit}
+            placeholder="例: Order / User / Invoice"
+            style={{ fontFamily: "monospace" }}
+          />
+        </div>
+        <div className="col-8" data-field-path="resource.id">
+          <label className="form-label">
+            <i className="bi bi-fingerprint me-1" />
+            対象リソース ID (resource.id、式可)
+          </label>
+          <ConvCompletionInput
+            className="form-control form-control-sm"
+            value={step.resource?.id ?? ""}
+            onValueChange={(v) => setResource({ id: v })}
+            onCommit={onCommit}
+            conventions={conventions ?? null}
+            placeholder="例: @orderId"
+            style={{ fontFamily: "monospace" }}
+          />
+        </div>
+      </div>
+
+      <div className="row g-2 mb-2">
+        <div className="col-4" data-field-path="result">
+          <label className="form-label">
+            <i className="bi bi-check2-circle me-1" />
+            結果 (result)
+          </label>
+          <select
+            className="form-select form-select-sm"
+            value={step.result ?? ""}
+            onChange={(e) => {
+              const v = e.target.value;
+              onChange({ result: v ? (v as AuditStep["result"]) : undefined });
+              onCommit?.();
+            }}
+          >
+            <option value="">— (実装で自動判定)</option>
+            <option value="success">success (成功)</option>
+            <option value="failure">failure (失敗)</option>
+          </select>
+        </div>
+        <div className="col-8" data-field-path="reason">
+          <label className="form-label">
+            <i className="bi bi-chat-left-quote me-1" />
+            理由 (reason、任意・式可)
+          </label>
+          <ConvCompletionInput
+            className="form-control form-control-sm"
+            value={step.reason ?? ""}
+            onValueChange={(v) => onChange({ reason: v || undefined })}
+            onCommit={onCommit}
+            conventions={conventions ?? null}
+            placeholder="例: @rejectionReason"
+            style={{ fontFamily: "monospace" }}
+          />
+        </div>
+      </div>
+
+      <div className="row g-2 mb-2" data-field-path="sensitive">
+        <div className="col-12">
+          <label className="form-check-label small d-inline-flex align-items-center gap-2">
+            <input
+              type="checkbox"
+              className="form-check-input"
+              checked={!!step.sensitive}
+              onChange={(e) => {
+                onChange({ sensitive: e.target.checked || undefined });
+                onCommit?.();
+              }}
+            />
+            <i className="bi bi-shield-lock" />
+            機微データ (sensitive) — オンにすると値本体はマスクし key だけ記録
+          </label>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/designer/src/components/process-flow/LogStepPanel.test.tsx
+++ b/designer/src/components/process-flow/LogStepPanel.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { LogStepPanel } from "./LogStepPanel";
+import type { LogStep } from "../../types/action";
+
+const baseStep: LogStep = {
+  id: "test-step",
+  type: "log",
+  description: "",
+  level: "info",
+  message: "test",
+  maturity: "draft",
+};
+
+const getStructuredRows = (container: HTMLElement) => {
+  const wrap = container.querySelector('[data-field-path="structuredData"]');
+  return Array.from(wrap?.querySelectorAll<HTMLElement>(".d-flex.align-items-center.gap-1.mb-1") ?? []);
+};
+
+describe("LogStepPanel structuredData", () => {
+  // Must-fix #2 (PR #410 review): key を全消去しても entry と value が消失しない
+  it("既存 entry の key を全消去しても entry が消えず value が保持される", () => {
+    const onChange = vi.fn();
+    const stepWithData: LogStep = {
+      ...baseStep,
+      structuredData: { orderId: "@orderId" },
+    };
+    const { container, rerender } = render(
+      <LogStepPanel step={stepWithData} onChange={onChange} />,
+    );
+
+    const rows = getStructuredRows(container);
+    expect(rows).toHaveLength(1);
+
+    const keyInput = rows[0].querySelector("input") as HTMLInputElement;
+    fireEvent.change(keyInput, { target: { value: "" } });
+
+    expect(onChange).toHaveBeenLastCalledWith({ structuredData: undefined });
+
+    rerender(<LogStepPanel step={{ ...stepWithData, structuredData: undefined }} onChange={onChange} />);
+    const rowsAfter = getStructuredRows(container);
+    expect(rowsAfter).toHaveLength(1);
+    const valueInput = rowsAfter[0].querySelectorAll("input")[1] as HTMLInputElement;
+    expect(valueInput?.value).toBe("@orderId");
+  });
+
+  it("key を再入力すると normalize されて structuredData が再構築される", () => {
+    const onChange = vi.fn();
+    const stepWithData: LogStep = {
+      ...baseStep,
+      structuredData: { orderId: "@orderId" },
+    };
+    const { container, rerender } = render(
+      <LogStepPanel step={stepWithData} onChange={onChange} />,
+    );
+
+    const keyInput = getStructuredRows(container)[0].querySelector("input") as HTMLInputElement;
+    fireEvent.change(keyInput, { target: { value: "" } });
+    rerender(<LogStepPanel step={{ ...stepWithData, structuredData: undefined }} onChange={onChange} />);
+    fireEvent.change(getStructuredRows(container)[0].querySelector("input") as HTMLInputElement, {
+      target: { value: "customerId" },
+    });
+    expect(onChange).toHaveBeenLastCalledWith({ structuredData: { customerId: "@orderId" } });
+  });
+
+  // Should-fix #3 (PR #410 review): 重複 key は is-invalid で警告
+  it("同じ key を持つ 2 行があると両方に is-invalid が付与される", () => {
+    const onChange = vi.fn();
+    const stepWithData: LogStep = {
+      ...baseStep,
+      structuredData: { orderId: "@orderId" },
+    };
+    const { container } = render(
+      <LogStepPanel step={stepWithData} onChange={onChange} />,
+    );
+
+    const addBtn = container.querySelector("button.btn-outline-secondary") as HTMLButtonElement;
+    fireEvent.click(addBtn);
+
+    const rows = getStructuredRows(container);
+    expect(rows).toHaveLength(2);
+    const newKeyInput = rows[1].querySelector("input") as HTMLInputElement;
+    fireEvent.change(newKeyInput, { target: { value: "orderId" } });
+
+    const keyInputs = rows.map((r) => r.querySelector("input") as HTMLInputElement);
+    expect(keyInputs[0].className).toContain("is-invalid");
+    expect(keyInputs[1].className).toContain("is-invalid");
+  });
+
+  it("key 全消去 → 値編集 → key 再入力 で value が消えない (in-place edit)", () => {
+    const onChange = vi.fn();
+    const stepWithData: LogStep = {
+      ...baseStep,
+      structuredData: { orderId: "@orderId" },
+    };
+    const { container, rerender } = render(
+      <LogStepPanel step={stepWithData} onChange={onChange} />,
+    );
+
+    const keyInput = getStructuredRows(container)[0].querySelector("input") as HTMLInputElement;
+    fireEvent.change(keyInput, { target: { value: "" } });
+    rerender(<LogStepPanel step={{ ...stepWithData, structuredData: undefined }} onChange={onChange} />);
+
+    const valueInput = getStructuredRows(container)[0].querySelectorAll("input")[1] as HTMLInputElement;
+    fireEvent.change(valueInput, { target: { value: "@newValue" } });
+
+    fireEvent.change(getStructuredRows(container)[0].querySelector("input") as HTMLInputElement, {
+      target: { value: "customerId" },
+    });
+    expect(onChange).toHaveBeenLastCalledWith({ structuredData: { customerId: "@newValue" } });
+  });
+});

--- a/designer/src/components/process-flow/LogStepPanel.tsx
+++ b/designer/src/components/process-flow/LogStepPanel.tsx
@@ -1,0 +1,163 @@
+import type { LogStep } from "../../types/action";
+import type { ConventionsCatalog } from "../../schemas/conventionsValidator";
+import { ConvCompletionInput } from "../common/ConvCompletionInput";
+
+interface Props {
+  step: LogStep;
+  onChange: (patch: Partial<LogStep>) => void;
+  onCommit?: () => void;
+  conventions?: ConventionsCatalog | null;
+}
+
+const LOG_LEVELS: Array<{ value: LogStep["level"]; label: string }> = [
+  { value: "trace", label: "trace (詳細追跡)" },
+  { value: "debug", label: "debug (デバッグ)" },
+  { value: "info", label: "info (情報)" },
+  { value: "warn", label: "warn (警告)" },
+  { value: "error", label: "error (エラー)" },
+];
+
+export function LogStepPanel({ step, onChange, onCommit, conventions }: Props) {
+  const entries = Object.entries(step.structuredData ?? {});
+
+  const updateEntry = (idx: number, key: string, value: string) => {
+    const next = entries.slice();
+    next[idx] = [key, value];
+    const map: Record<string, string> = {};
+    for (const [k, v] of next) {
+      if (k.trim()) map[k.trim()] = v;
+    }
+    onChange({ structuredData: Object.keys(map).length > 0 ? map : undefined });
+  };
+
+  const removeEntry = (idx: number) => {
+    const next = entries.filter((_, i) => i !== idx);
+    const map: Record<string, string> = {};
+    for (const [k, v] of next) {
+      if (k.trim()) map[k.trim()] = v;
+    }
+    onChange({ structuredData: Object.keys(map).length > 0 ? map : undefined });
+    onCommit?.();
+  };
+
+  const addEntry = () => {
+    const map: Record<string, string> = { ...(step.structuredData ?? {}) };
+    let key = "key";
+    let i = 1;
+    while (key in map) key = `key${++i}`;
+    map[key] = "";
+    onChange({ structuredData: map });
+  };
+
+  return (
+    <>
+      <div className="row g-2 mb-2">
+        <div className="col-4" data-field-path="level">
+          <label className="form-label">
+            <i className="bi bi-bar-chart-steps me-1" />
+            ログレベル (level)
+          </label>
+          <select
+            className="form-select form-select-sm"
+            value={step.level}
+            onChange={(e) => {
+              onChange({ level: e.target.value as LogStep["level"] });
+              onCommit?.();
+            }}
+          >
+            {LOG_LEVELS.map((l) => (
+              <option key={l.value} value={l.value}>{l.label}</option>
+            ))}
+          </select>
+        </div>
+        <div className="col-8" data-field-path="category">
+          <label className="form-label">
+            <i className="bi bi-tag me-1" />
+            カテゴリ (category、任意)
+          </label>
+          <input
+            type="text"
+            className="form-control form-control-sm"
+            value={step.category ?? ""}
+            onChange={(e) => onChange({ category: e.target.value || undefined })}
+            onBlur={onCommit}
+            placeholder="例: order.lifecycle / payment.audit"
+          />
+        </div>
+      </div>
+
+      <div className="row g-2 mb-2" data-field-path="message">
+        <div className="col-12">
+          <label className="form-label">
+            <i className="bi bi-chat-left-text me-1" />
+            メッセージ (message)
+          </label>
+          <ConvCompletionInput
+            className="form-control form-control-sm"
+            value={step.message}
+            onValueChange={(v) => onChange({ message: v })}
+            onCommit={onCommit}
+            conventions={conventions ?? null}
+            placeholder={"例: 注文 @orderId 受付完了 (顧客 @customerId)"}
+            style={{ fontFamily: "monospace" }}
+          />
+        </div>
+      </div>
+
+      <div className="row g-2 mb-2" data-field-path="structuredData">
+        <div className="col-12">
+          <div className="d-flex align-items-center gap-2 mb-1">
+            <label className="form-label small mb-0">
+              <i className="bi bi-list-columns me-1" />
+              構造化データ (structuredData、key=式、任意)
+            </label>
+            <button
+              type="button"
+              className="btn btn-sm btn-outline-secondary py-0"
+              onClick={addEntry}
+              style={{ fontSize: "0.75rem" }}
+            >
+              <i className="bi bi-plus-lg" /> 項目を追加
+            </button>
+          </div>
+          {entries.length === 0 && (
+            <div className="text-muted" style={{ fontSize: "0.78rem" }}>
+              ログ集計・検索しやすいよう構造化値を残す場合に追加 (例: orderId / amount)
+            </div>
+          )}
+          {entries.map(([k, v], i) => (
+            <div key={i} className="d-flex align-items-center gap-1 mb-1">
+              <input
+                type="text"
+                className="form-control form-control-sm"
+                value={k}
+                onChange={(e) => updateEntry(i, e.target.value, v)}
+                onBlur={onCommit}
+                placeholder="key"
+                style={{ width: 160, fontFamily: "monospace", fontSize: "0.8rem" }}
+              />
+              <span className="text-muted">=</span>
+              <ConvCompletionInput
+                className="form-control form-control-sm"
+                value={v}
+                onValueChange={(nv) => updateEntry(i, k, nv)}
+                onCommit={onCommit}
+                conventions={conventions ?? null}
+                placeholder="例: @orderId / @subtotal + @tax"
+                style={{ fontFamily: "monospace", fontSize: "0.8rem", flex: 1 }}
+              />
+              <button
+                type="button"
+                className="btn btn-sm btn-link text-danger p-0"
+                onClick={() => removeEntry(i)}
+                title="項目を削除"
+              >
+                <i className="bi bi-x" />
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/designer/src/components/process-flow/LogStepPanel.tsx
+++ b/designer/src/components/process-flow/LogStepPanel.tsx
@@ -1,6 +1,8 @@
+import { useState, useEffect, useRef } from "react";
 import type { LogStep } from "../../types/action";
 import type { ConventionsCatalog } from "../../schemas/conventionsValidator";
 import { ConvCompletionInput } from "../common/ConvCompletionInput";
+import { generateUUID } from "../../utils/uuid";
 
 interface Props {
   step: LogStep;
@@ -17,36 +19,66 @@ const LOG_LEVELS: Array<{ value: LogStep["level"]; label: string }> = [
   { value: "error", label: "error (エラー)" },
 ];
 
-export function LogStepPanel({ step, onChange, onCommit, conventions }: Props) {
-  const entries = Object.entries(step.structuredData ?? {});
+type RawEntry = { id: string; key: string; value: string };
 
-  const updateEntry = (idx: number, key: string, value: string) => {
-    const next = entries.slice();
-    next[idx] = [key, value];
-    const map: Record<string, string> = {};
-    for (const [k, v] of next) {
-      if (k.trim()) map[k.trim()] = v;
-    }
-    onChange({ structuredData: Object.keys(map).length > 0 ? map : undefined });
+const toEntries = (sd: Record<string, string> | undefined): RawEntry[] =>
+  Object.entries(sd ?? {}).map(([key, value]) => ({ id: generateUUID(), key, value }));
+
+const normalize = (entries: RawEntry[]): Record<string, string> | undefined => {
+  // 空 key の行は出力しない (key 編集中の中間状態を保存に出さない)。
+  // 重複 key は後勝ち (UI 側で is-invalid 警告を出す)。
+  const map: Record<string, string> = {};
+  for (const e of entries) {
+    const k = e.key.trim();
+    if (k) map[k] = e.value;
+  }
+  return Object.keys(map).length > 0 ? map : undefined;
+};
+
+export function LogStepPanel({ step, onChange, onCommit, conventions }: Props) {
+  // 内部 state は raw entries (key="" の行も保持) で持つ。
+  // step.structuredData (props) には normalize 済の Record<string,string> が入る。
+  // → key を一旦全消去しても value が消えない / 重複 key を一時的に許容する。
+  const [entries, setEntries] = useState<RawEntry[]>(() => toEntries(step.structuredData));
+  // 直前に自分が onChange で送出した normalized 値を記録し、
+  // それ以外 (= 外部からの再描画 / undo 等) で props が変わった時のみ entries を再構築する。
+  const lastEmittedRef = useRef<Record<string, string> | undefined>(step.structuredData);
+
+  useEffect(() => {
+    if (step.structuredData === lastEmittedRef.current) return;
+    setEntries(toEntries(step.structuredData));
+    lastEmittedRef.current = step.structuredData;
+  }, [step.structuredData]);
+
+  const persist = (next: RawEntry[]) => {
+    setEntries(next);
+    const normalized = normalize(next);
+    lastEmittedRef.current = normalized;
+    onChange({ structuredData: normalized });
   };
 
-  const removeEntry = (idx: number) => {
-    const next = entries.filter((_, i) => i !== idx);
-    const map: Record<string, string> = {};
-    for (const [k, v] of next) {
-      if (k.trim()) map[k.trim()] = v;
-    }
-    onChange({ structuredData: Object.keys(map).length > 0 ? map : undefined });
+  const updateEntry = (id: string, patch: Partial<Omit<RawEntry, "id">>) => {
+    persist(entries.map((e) => (e.id === id ? { ...e, ...patch } : e)));
+  };
+
+  const removeEntry = (id: string) => {
+    persist(entries.filter((e) => e.id !== id));
     onCommit?.();
   };
 
   const addEntry = () => {
-    const map: Record<string, string> = { ...(step.structuredData ?? {}) };
-    let key = "key";
-    let i = 1;
-    while (key in map) key = `key${++i}`;
-    map[key] = "";
-    onChange({ structuredData: map });
+    persist([...entries, { id: generateUUID(), key: "", value: "" }]);
+  };
+
+  // 重複 key 検出 (空 key は除外)
+  const keyCounts = new Map<string, number>();
+  for (const e of entries) {
+    const k = e.key.trim();
+    if (k) keyCounts.set(k, (keyCounts.get(k) ?? 0) + 1);
+  }
+  const isDuplicateKey = (key: string) => {
+    const k = key.trim();
+    return !!k && (keyCounts.get(k) ?? 0) > 1;
   };
 
   return (
@@ -125,37 +157,41 @@ export function LogStepPanel({ step, onChange, onCommit, conventions }: Props) {
               ログ集計・検索しやすいよう構造化値を残す場合に追加 (例: orderId / amount)
             </div>
           )}
-          {entries.map(([k, v], i) => (
-            <div key={i} className="d-flex align-items-center gap-1 mb-1">
-              <input
-                type="text"
-                className="form-control form-control-sm"
-                value={k}
-                onChange={(e) => updateEntry(i, e.target.value, v)}
-                onBlur={onCommit}
-                placeholder="key"
-                style={{ width: 160, fontFamily: "monospace", fontSize: "0.8rem" }}
-              />
-              <span className="text-muted">=</span>
-              <ConvCompletionInput
-                className="form-control form-control-sm"
-                value={v}
-                onValueChange={(nv) => updateEntry(i, k, nv)}
-                onCommit={onCommit}
-                conventions={conventions ?? null}
-                placeholder="例: @orderId / @subtotal + @tax"
-                style={{ fontFamily: "monospace", fontSize: "0.8rem", flex: 1 }}
-              />
-              <button
-                type="button"
-                className="btn btn-sm btn-link text-danger p-0"
-                onClick={() => removeEntry(i)}
-                title="項目を削除"
-              >
-                <i className="bi bi-x" />
-              </button>
-            </div>
-          ))}
+          {entries.map((entry) => {
+            const dup = isDuplicateKey(entry.key);
+            return (
+              <div key={entry.id} className="d-flex align-items-center gap-1 mb-1">
+                <input
+                  type="text"
+                  className={`form-control form-control-sm${dup ? " is-invalid" : ""}`}
+                  value={entry.key}
+                  onChange={(e) => updateEntry(entry.id, { key: e.target.value })}
+                  onBlur={onCommit}
+                  placeholder="key"
+                  title={dup ? "重複している key (保存時に後勝ちで上書きされます)" : undefined}
+                  style={{ width: 160, fontFamily: "monospace", fontSize: "0.8rem" }}
+                />
+                <span className="text-muted">=</span>
+                <ConvCompletionInput
+                  className="form-control form-control-sm"
+                  value={entry.value}
+                  onValueChange={(nv) => updateEntry(entry.id, { value: nv })}
+                  onCommit={onCommit}
+                  conventions={conventions ?? null}
+                  placeholder="例: @orderId / @subtotal + @tax"
+                  style={{ fontFamily: "monospace", fontSize: "0.8rem", flex: 1 }}
+                />
+                <button
+                  type="button"
+                  className="btn btn-sm btn-link text-danger p-0"
+                  onClick={() => removeEntry(entry.id)}
+                  title="項目を削除"
+                >
+                  <i className="bi bi-x" />
+                </button>
+              </div>
+            );
+          })}
         </div>
       </div>
     </>

--- a/designer/src/components/process-flow/StepCard.tsx
+++ b/designer/src/components/process-flow/StepCard.tsx
@@ -27,6 +27,8 @@ import { ValidationRulesPanel } from "./ValidationRulesPanel";
 import { ConvCompletionInput } from "../common/ConvCompletionInput";
 import { ExternalOutcomesPanel } from "./ExternalOutcomesPanel";
 import { JumpTargetSelector } from "./JumpTargetSelector";
+import { LogStepPanel } from "./LogStepPanel";
+import { AuditStepPanel } from "./AuditStepPanel";
 
 const ALL_SUB_STEP_TYPES: StepType[] = [
   "validation", "dbAccess", "externalSystem", "commonProcess",
@@ -1575,6 +1577,26 @@ export function StepCard({
                   )}
                 </div>
               </div>
+            )}
+
+            {/* ── ログ出力 (#402) ──────────────────────────────── */}
+            {step.type === "log" && (
+              <LogStepPanel
+                step={step}
+                onChange={(patch) => onChange(patch as Partial<Step>)}
+                onCommit={onCommit}
+                conventions={conventions ?? null}
+              />
+            )}
+
+            {/* ── 監査ログ (#402) ──────────────────────────────── */}
+            {step.type === "audit" && (
+              <AuditStepPanel
+                step={step}
+                onChange={(patch) => onChange(patch as Partial<Step>)}
+                onCommit={onCommit}
+                conventions={conventions ?? null}
+              />
             )}
 
             {/* ── ジャンプ (Phase 5) ───────────────────────────── */}


### PR DESCRIPTION
## 概要

#401 で追加した `LogStep` / `AuditStep` の編集 UI を追加。汎用 JSON / 基本メタフィールドだけだったところに、他 StepType と同等の型安全な専用パネルを実装。

Closes #402

## 変更内容

### `designer/src/components/process-flow/LogStepPanel.tsx` (新規)
- `level` (trace/debug/info/warn/error) の dropdown
- `message` / `category` の入力 (`message` は `@conv` 補完対応)
- `structuredData` の `key=式` の動的編集 (key 行追加・削除、値は `@conv` 補完対応)

### `designer/src/components/process-flow/AuditStepPanel.tsx` (新規)
- `action` 必須入力
- `resource.type` / `resource.id` (`id` は式可・`@conv` 補完対応)
- `result` dropdown (`success` / `failure` / 未指定)
- `reason` 入力 (式可)
- `sensitive` checkbox

### `designer/src/components/process-flow/StepCard.tsx`
- `step.type === \"log\"` / `\"audit\"` の分岐を追加し、各 panel を render
- 既存パネルパターン (ValidationRulesPanel / ExternalOutcomesPanel 等) と同じ呼び出し規約

各フィールドに `data-field-path` を付与し、AI マーカー (#261) のフィールドピンポイント先になれるようにした。

## 仕様逐条突合

ISSUE #402 の受け入れ基準:

- [x] LogStepPanel が表示され `level` / `message` / `category` / `structuredData` を編集・保存できる — `LogStepPanel.tsx:1-156`
- [x] AuditStepPanel が表示され `action` / `resource` / `result` / `reason` / `sensitive` を編集・保存できる — `AuditStepPanel.tsx:1-128`
- [x] 保存後リロードしても入力値が維持される — chrome-devtools MCP で smoke test 実施済 (新規バッチフロー作成 → log/audit ステップ追加 → 各値入力 → 保存 → リロード → 全値復元を確認)
- [x] `cd designer && npm run build` pass
- [x] 既存 StepType の編集フォームに回帰なし — `StepCard.tsx` への変更は新分岐 22 行追加のみ、既存分岐は無編集

## 検証

```bash
cd designer && npm run build      # pass (tsc + Vite)
cd designer && npx vitest run     # pass (728/728)
```

UI smoke test (chrome-devtools MCP):
1. 新規バッチフロー \"log/audit panel smoke test\" 作成
2. \"ログ出力\" / \"監査ログ\" の各ステップを追加
3. LogStep に `level=warn` / `category=order.lifecycle` / `message=注文 @orderId 受付完了` / `structuredData={orderId: \"@orderId\"}` を入力
4. AuditStep に `action=order.create` / `resource={type: Order, id: @orderId}` / `result=success` / `sensitive=true` を入力
5. 保存 → JSON ファイル (`data/actions/595807a9-...json`) で構造確認
6. ページリロード → エディタ再オープン → ステップ展開 → 全値が復元されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
