### PR TITLE
feat(processflow): A-6 SLA / Timeout 宣言 — フロー / アクション / ステップの 3 レベル (#412)

### DIFF
--- a/designer/src/components/process-flow/ActionMetaTabBar.tsx
+++ b/designer/src/components/process-flow/ActionMetaTabBar.tsx
@@ -19,6 +19,7 @@ import { AmbientVariablesPanel } from "./AmbientVariablesPanel";
 import { SecretsCatalogPanel } from "./SecretsCatalogPanel";
 import { ExternalSystemCatalogPanel } from "./ExternalSystemCatalogPanel";
 import { TypeCatalogPanel } from "./TypeCatalogPanel";
+import { SlaPanel } from "./SlaPanel";
 
 type TabKey = "info" | "marker" | "error" | "ambient" | "secrets" | "external" | "type";
 
@@ -64,6 +65,11 @@ export function ActionMetaTabBar({ group, updateGroup, updateGroupSilent }: Prop
   const handleInfoChange = (field: string, value: string) => {
     updateGroupSilent((g) => {
       (g as unknown as Record<string, string>)[field] = value;
+    });
+  };
+  const handleSlaChange = (sla: ProcessFlow["sla"]) => {
+    updateGroupSilent((g) => {
+      g.sla = sla;
     });
   };
 
@@ -246,6 +252,11 @@ export function ActionMetaTabBar({ group, updateGroup, updateGroupSilent }: Prop
               </button>
             </div>
           </div>
+          <SlaPanel
+            label="フロー SLA / Timeout"
+            sla={group.sla}
+            onChange={handleSlaChange}
+          />
         </div>
       )}
       {active === "marker" && (

--- a/designer/src/components/process-flow/ProcessFlowEditor.tsx
+++ b/designer/src/components/process-flow/ProcessFlowEditor.tsx
@@ -57,6 +57,7 @@ import { SortableStepCard } from "./SortableStepCard";
 import { MaturityBadge } from "./MaturityBadge";
 import { ActionHttpContractPanel } from "./ActionHttpContractPanel";
 import { ActionMetaTabBar } from "./ActionMetaTabBar";
+import { SlaPanel } from "./SlaPanel";
 import { DrawingOverlay } from "./DrawingOverlay";
 import { StructuredFieldsEditor, type ScreenItemPickResult } from "./StructuredFieldsEditor";
 import { ScreenItemPickerModal } from "./ScreenItemPickerModal";
@@ -778,6 +779,17 @@ export function ProcessFlowEditor() {
                 updateGroupSilent((g) => {
                   const act = g.actions.find((a) => a.id === activeActionId);
                   if (act) Object.assign(act, patch);
+                });
+                commitGroup();
+              }}
+            />
+            <SlaPanel
+              label="アクション SLA / Timeout"
+              sla={activeAction.sla}
+              onChange={(sla) => {
+                updateGroupSilent((g) => {
+                  const act = g.actions.find((a) => a.id === activeActionId);
+                  if (act) act.sla = sla;
                 });
                 commitGroup();
               }}

--- a/designer/src/components/process-flow/SlaPanel.tsx
+++ b/designer/src/components/process-flow/SlaPanel.tsx
@@ -1,0 +1,105 @@
+import type { Sla, OnTimeout } from "../../types/action";
+
+interface Props {
+  sla?: Sla;
+  onChange: (sla: Sla | undefined) => void;
+  label?: string;
+}
+
+const ON_TIMEOUT_OPTIONS: Array<{ value: OnTimeout; label: string }> = [
+  { value: "throw", label: "throw (エラーにする)" },
+  { value: "continue", label: "continue (継続する)" },
+  { value: "compensate", label: "compensate (補償処理へ)" },
+  { value: "log", label: "log (記録のみ)" },
+];
+
+const compact = (next: Sla): Sla | undefined => {
+  const normalized: Sla = {};
+  if (next.timeoutMs !== undefined) normalized.timeoutMs = next.timeoutMs;
+  if (next.onTimeout) normalized.onTimeout = next.onTimeout;
+  if (next.warningThresholdMs !== undefined) normalized.warningThresholdMs = next.warningThresholdMs;
+  if (next.errorCode?.trim()) normalized.errorCode = next.errorCode.trim();
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+};
+
+const toNumber = (value: string): number | undefined => {
+  if (value === "") return undefined;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : undefined;
+};
+
+export function SlaPanel({ sla, onChange, label = "SLA / Timeout" }: Props) {
+  const patch = (partial: Partial<Sla>) => {
+    onChange(compact({ ...(sla ?? {}), ...partial }));
+  };
+
+  return (
+    <div className="sla-panel" style={{ margin: "8px 0", borderTop: "1px dashed #e2e8f0", paddingTop: 8 }}>
+      <div className="d-flex align-items-center gap-2 mb-2">
+        <span className="form-label small fw-semibold mb-0">
+          <i className="bi bi-stopwatch me-1" />
+          {label}
+        </span>
+        {sla && (
+          <button
+            type="button"
+            className="btn btn-sm btn-link text-danger p-0"
+            onClick={() => onChange(undefined)}
+            title="SLA を削除"
+          >
+            <i className="bi bi-x-circle" />
+          </button>
+        )}
+      </div>
+
+      <div className="row g-2 align-items-end">
+        <div className="col-sm-3" data-field-path="sla.timeoutMs">
+          <label className="form-label small mb-0">タイムアウト ms</label>
+          <input
+            type="number"
+            min={0}
+            className="form-control form-control-sm"
+            value={sla?.timeoutMs ?? ""}
+            onChange={(e) => patch({ timeoutMs: toNumber(e.target.value) })}
+            placeholder="2000"
+          />
+        </div>
+        <div className="col-sm-3" data-field-path="sla.onTimeout">
+          <label className="form-label small mb-0">タイムアウト時</label>
+          <select
+            className="form-select form-select-sm"
+            value={sla?.onTimeout ?? ""}
+            onChange={(e) => patch({ onTimeout: e.target.value ? (e.target.value as OnTimeout) : undefined })}
+          >
+            <option value="">未指定</option>
+            {ON_TIMEOUT_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </select>
+        </div>
+        <div className="col-sm-3" data-field-path="sla.warningThresholdMs">
+          <label className="form-label small mb-0">警告閾値 ms</label>
+          <input
+            type="number"
+            min={0}
+            className="form-control form-control-sm"
+            value={sla?.warningThresholdMs ?? ""}
+            onChange={(e) => patch({ warningThresholdMs: toNumber(e.target.value) })}
+            placeholder="1500"
+          />
+        </div>
+        <div className="col-sm-3" data-field-path="sla.errorCode">
+          <label className="form-label small mb-0">エラーコード</label>
+          <input
+            type="text"
+            className="form-control form-control-sm"
+            value={sla?.errorCode ?? ""}
+            onChange={(e) => patch({ errorCode: e.target.value || undefined })}
+            placeholder="TIMEOUT"
+            style={{ fontFamily: "monospace" }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/designer/src/components/process-flow/SlaPanel.tsx
+++ b/designer/src/components/process-flow/SlaPanel.tsx
@@ -18,6 +18,7 @@ const compact = (next: Sla): Sla | undefined => {
   if (next.timeoutMs !== undefined) normalized.timeoutMs = next.timeoutMs;
   if (next.onTimeout) normalized.onTimeout = next.onTimeout;
   if (next.warningThresholdMs !== undefined) normalized.warningThresholdMs = next.warningThresholdMs;
+  if (next.p95LatencyMs !== undefined) normalized.p95LatencyMs = next.p95LatencyMs;
   if (next.errorCode?.trim()) normalized.errorCode = next.errorCode.trim();
   return Object.keys(normalized).length > 0 ? normalized : undefined;
 };
@@ -86,6 +87,17 @@ export function SlaPanel({ sla, onChange, label = "SLA / Timeout" }: Props) {
             value={sla?.warningThresholdMs ?? ""}
             onChange={(e) => patch({ warningThresholdMs: toNumber(e.target.value) })}
             placeholder="1500"
+          />
+        </div>
+        <div className="col-sm-3" data-field-path="sla.p95LatencyMs">
+          <label className="form-label small mb-0">P95 レイテンシ ms</label>
+          <input
+            type="number"
+            min={0}
+            className="form-control form-control-sm"
+            value={sla?.p95LatencyMs ?? ""}
+            onChange={(e) => patch({ p95LatencyMs: toNumber(e.target.value) })}
+            placeholder="例: 500"
           />
         </div>
         <div className="col-sm-3" data-field-path="sla.errorCode">

--- a/designer/src/components/process-flow/StepAdvancedMetadataPanel.tsx
+++ b/designer/src/components/process-flow/StepAdvancedMetadataPanel.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import type { Step, TxBoundary, TxBoundaryRole, ExternalChain, ExternalChainPhase } from "../../types/action";
+import { SlaPanel } from "./SlaPanel";
 
 interface Props {
   step: Step;
@@ -15,7 +16,7 @@ const CHAIN_PHASES: ExternalChainPhase[] = ["authorize", "capture", "cancel", "o
  * 折りたたみ可能。未設定のステップでは「詳細メタ情報を追加」のボタンのみ表示。
  */
 export function StepAdvancedMetadataPanel({ step, onChange, onCommit }: Props) {
-  const hasAny = !!(step.txBoundary || step.compensatesFor || step.externalChain || step.transactional);
+  const hasAny = !!(step.txBoundary || step.compensatesFor || step.externalChain || step.transactional || step.sla);
   const [expanded, setExpanded] = useState(hasAny);
 
   const txB = step.txBoundary;
@@ -151,6 +152,19 @@ export function StepAdvancedMetadataPanel({ step, onChange, onCommit }: Props) {
           )}
         </div>
       </div>
+      <SlaPanel
+        label="ステップ SLA / Timeout"
+        sla={step.sla}
+        onChange={(sla) => {
+          onChange({ sla } as Partial<Step>);
+          onCommit?.();
+        }}
+      />
+      {step.type === "externalSystem" && (
+        <div className="text-muted small" style={{ marginTop: 4 }}>
+          ExternalSystemStep の旧 timeoutMs は後方互換用です。sla.timeoutMs が指定されている場合はそちらを優先します。
+        </div>
+      )}
     </div>
   );
 }

--- a/designer/src/schemas/process-flow.schema.test.ts
+++ b/designer/src/schemas/process-flow.schema.test.ts
@@ -1131,6 +1131,79 @@ describe("process-flow.schema.json — DbAccessStep.bulkValues + BranchStep.tryS
   });
 });
 
+describe("process-flow.schema.json — Sla 3 レベル + p95LatencyMs + 条件付き errorCode (#412)", () => {
+  const ts = {
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  };
+
+  it("3 レベル (Flow / Action / Step) すべてに sla を含む process-flow が valid", () => {
+    const ok = validate({
+      id: "a", name: "x", type: "screen", description: "",
+      sla: { timeoutMs: 30000, p95LatencyMs: 5000, warningThresholdMs: 20000, onTimeout: "log" },
+      actions: [{
+        id: "act-1", name: "submit", trigger: "submit",
+        sla: { timeoutMs: 5000, p95LatencyMs: 500, onTimeout: "throw", errorCode: "ACTION_TIMEOUT" },
+        steps: [{
+          id: "s1", type: "dbAccess", description: "",
+          tableName: "orders", operation: "SELECT",
+          sla: { timeoutMs: 1000, p95LatencyMs: 100, onTimeout: "compensate", errorCode: "DB_TIMEOUT" },
+        }],
+      }],
+      ...ts,
+    });
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("onTimeout: \"abort\" (enum 外) は reject", () => {
+    expect(validate({
+      id: "a", name: "x", type: "screen", description: "",
+      sla: { timeoutMs: 1000, onTimeout: "abort", errorCode: "X" },
+      actions: [],
+      ...ts,
+    })).toBe(false);
+  });
+
+  it("timeoutMs: -1 (minimum 違反) は reject", () => {
+    expect(validate({
+      id: "a", name: "x", type: "screen", description: "",
+      sla: { timeoutMs: -1 },
+      actions: [],
+      ...ts,
+    })).toBe(false);
+  });
+
+  it("onTimeout: \"throw\" で errorCode 無しは reject (条件付き必須)", () => {
+    expect(validate({
+      id: "a", name: "x", type: "screen", description: "",
+      sla: { timeoutMs: 1000, onTimeout: "throw" },
+      actions: [],
+      ...ts,
+    })).toBe(false);
+  });
+
+  it("onTimeout: \"compensate\" で errorCode 無しは reject (条件付き必須)", () => {
+    expect(validate({
+      id: "a", name: "x", type: "screen", description: "",
+      sla: { timeoutMs: 1000, onTimeout: "compensate" },
+      actions: [],
+      ...ts,
+    })).toBe(false);
+  });
+
+  it("onTimeout: \"log\" で errorCode 無しは accept (errorCode 不要)", () => {
+    const ok = validate({
+      id: "a", name: "x", type: "screen", description: "",
+      sla: { timeoutMs: 1000, onTimeout: "log" },
+      actions: [],
+      ...ts,
+    });
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+});
+
 describe("process-flow.schema.json — ambientOverrides (#369)", () => {
   const base = {
     id: "a", name: "x", type: "screen", description: "",

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -174,6 +174,8 @@ export interface Sla {
   onTimeout?: OnTimeout;
   errorCode?: string;
   warningThresholdMs?: number;
+  /** P95 レイテンシ目標 (ms)。超過時は監視 alert 対象 (#412) */
+  p95LatencyMs?: number;
 }
 
 // ── outputBinding の構造化 (docs/spec, #151 (B)) ──────────────────────────

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -167,6 +167,15 @@ export interface StepNote {
 /** 処理フローのモード (docs/spec/process-flow-maturity.md §5) */
 export type ProcessFlowMode = "upstream" | "downstream";
 
+export type OnTimeout = "throw" | "continue" | "compensate" | "log";
+
+export interface Sla {
+  timeoutMs?: number;
+  onTimeout?: OnTimeout;
+  errorCode?: string;
+  warningThresholdMs?: number;
+}
+
 // ── outputBinding の構造化 (docs/spec, #151 (B)) ──────────────────────────
 
 /**
@@ -231,6 +240,8 @@ export interface StepBase {
   notes?: StepNote[];
   /** 成熟度。未指定は "draft" として解釈 */
   maturity?: Maturity;
+  /** SLA / Timeout declaration for this step. */
+  sla?: Sla;
   /**
    * ステップの条件実行ガード (#178)。
    * 真偽式 (自由記述、例: "@paymentMethod == 'credit_card'") または @conv.* 参照。
@@ -513,7 +524,10 @@ export interface ExternalSystemStep extends StepBase {
    * 省略時は product-scope §11 の既定 (failure/timeout=abort、success=continue) を適用。
    */
   outcomes?: Partial<Record<ExternalCallOutcome, ExternalCallOutcomeSpec>>;
-  /** タイムアウト (ミリ秒)。未指定は product-scope §11 の既定 10000 */
+  /**
+   * タイムアウト (ミリ秒)。未指定は product-scope §11 の既定 10000
+   * @deprecated Use sla.timeoutMs instead
+   */
   timeoutMs?: number;
   /** リトライ方針。未指定は「リトライなし」 */
   retryPolicy?: RetryPolicy;
@@ -867,6 +881,8 @@ export interface ActionDefinition {
   outputs?: ActionFields;
   /** 成熟度。未指定は "draft" として解釈 */
   maturity?: Maturity;
+  /** SLA / Timeout declaration for this action. */
+  sla?: Sla;
   /** アクション起動に必要な permission key。@conv.permission.<key> と対応する。 */
   requiredPermissions?: string[];
   /**
@@ -1024,6 +1040,8 @@ export interface ProcessFlow {
   actions: ActionDefinition[];
   /** 成熟度。未指定は "draft" として解釈 (docs/spec/process-flow-maturity.md §3) */
   maturity?: Maturity;
+  /** SLA / Timeout declaration for this flow. */
+  sla?: Sla;
   /** 上流/下流モード。未指定は "upstream" として解釈 (docs/spec/process-flow-maturity.md §5) */
   mode?: ProcessFlowMode;
   /**

--- a/docs/sample-project/process-flows/cccccccc-0005-4000-8000-cccccccccccc.json
+++ b/docs/sample-project/process-flows/cccccccc-0005-4000-8000-cccccccccccc.json
@@ -6,6 +6,12 @@
   "description": "data/actions/cccccccc-0019 を v1.3 全機能 (errorCatalog / typeCatalog / externalSystemCatalog / httpCall / systemRef / FieldType.array+object / BodySchemaRef.typeRef / ExternalAuth / idempotencyKey / initialValue / BranchConditionVariant.affectedRowsZero) で migrate。地の文依存ゼロを目標とする正規サンプル。\n\n【前提スキーマ】items / inventory / orders / order_items / customers テーブル、Stripe Japan 2 段階決済 (authorize → capture)、SendGrid。\n【参照規約】docs/conventions/validation-rules.md / product-scope.md (ambient)。",
   "mode": "downstream",
   "maturity": "committed",
+  "sla": {
+    "timeoutMs": 30000,
+    "warningThresholdMs": 20000,
+    "onTimeout": "throw",
+    "errorCode": "TIMEOUT"
+  },
 
   "ambientVariables": [
     { "name": "requestId", "type": "string", "required": true, "description": "リクエスト毎に一意。冪等性キー生成やログ相関に使う。通常はリバプロ/ミドルウェア (X-Request-Id) から注入" },
@@ -37,6 +43,12 @@
       "defaultMessage": "決済に失敗しました",
       "responseRef": "402-payment-failed",
       "description": "Stripe authorize が failure/timeout"
+    },
+    "TIMEOUT": {
+      "httpStatus": 504,
+      "defaultMessage": "処理がタイムアウトしました",
+      "responseRef": "504-timeout",
+      "description": "SLA / Timeout 宣言から発生するタイムアウト"
     },
     "STOCK_SHORTAGE": {
       "httpStatus": 409,
@@ -116,6 +128,12 @@
       "name": "注文確定ボタン",
       "trigger": "submit",
       "maturity": "committed",
+      "sla": {
+        "timeoutMs": 10000,
+        "warningThresholdMs": 7000,
+        "onTimeout": "throw",
+        "errorCode": "TIMEOUT"
+      },
       "requiredPermissions": ["order.create"],
       "httpRoute": { "method": "POST", "path": "/api/orders", "auth": "required" },
       "responses": [
@@ -123,6 +141,7 @@
         { "id": "400-validation", "status": 400, "bodySchema": { "typeRef": "ApiError" }, "description": "バリデーション違反" },
         { "id": "404-not-found", "status": 404, "bodySchema": { "typeRef": "ApiError" }, "description": "顧客/商品が存在しない" },
         { "id": "402-payment-failed", "status": 402, "bodySchema": { "typeRef": "ApiError" }, "description": "決済拒否", "when": "@paymentAuth.status == 'failed'" },
+        { "id": "504-timeout", "status": 504, "bodySchema": { "typeRef": "ApiError" }, "description": "SLA タイムアウト" },
         { "id": "409-stock-shortage", "status": 409, "bodySchema": { "typeRef": "ApiError" }, "description": "在庫不足" }
       ],
       "inputs": [
@@ -154,6 +173,12 @@
           "id": "step-or2-001",
           "type": "validation",
           "maturity": "committed",
+          "sla": {
+            "timeoutMs": 5000,
+            "warningThresholdMs": 3500,
+            "onTimeout": "compensate",
+            "errorCode": "PAYMENT_FAILED"
+          },
           "description": "入力バリデーション",
           "conditions": "",
           "rules": [

--- a/docs/sample-project/process-flows/cccccccc-0007-4000-8000-cccccccccccc.json
+++ b/docs/sample-project/process-flows/cccccccc-0007-4000-8000-cccccccccccc.json
@@ -444,6 +444,7 @@
           "maturity": "committed",
           "systemName": "PDF Generation Service",
           "systemRef": "pdfService",
+          "timeoutMs": 30000,
           "httpCall": {
             "method": "POST",
             "path": "/generate/invoice",

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -10,6 +10,7 @@
 | [process-flow-maturity.md](process-flow-maturity.md) | 成熟度・付箋・上流/下流モード (Phase 1 基盤) | #151 / #152 |
 | [process-flow-variables.md](process-flow-variables.md) | 変数・入出力・outputBinding (Phase 1 基盤) | #151 / #152 |
 | [process-flow-extensions.md](process-flow-extensions.md) | HTTP 契約 / TX / Saga / 外部 outcomes / ValidationRule / compute / return (Phase B) | #151 / #182 |
+| [process-flow-sla.md](process-flow-sla.md) | SLA / Timeout 宣言 (ProcessFlow / ActionDefinition / StepBase) | #412 |
 | [process-flow-expression-language.md](process-flow-expression-language.md) | runIf / expression / bodyExpression の式言語 BNF (js-subset) | #253 |
 | [process-flow-runtime-conventions.md](process-flow-runtime-conventions.md) | SQL 式補間 / HTTP body シリアライズ / TX×throw×tryCatch / fireAndForget / sideEffects TX 境界等の実行時規約 | #261 |
 | [process-flow-testing.md](process-flow-testing.md) | 処理フローの Given-When-Then テストシナリオ (`testScenarios`) | #400 |

--- a/docs/spec/process-flow-sla.md
+++ b/docs/spec/process-flow-sla.md
@@ -1,0 +1,57 @@
+# ProcessFlow SLA / Timeout 仕様
+
+## 目的
+
+処理フロー定義に、性能・待ち時間・タイムアウト時の扱いを宣言するための `sla` を追加する。AI 実装者はこの情報を使い、タイムアウト設定、監視、ログ、補償処理、エラー応答を生成する。
+
+## 対象レベル
+
+`sla` は次の 3 レベルで指定できる。
+
+| レベル | 対象 | 用途 |
+|---|---|---|
+| ProcessFlow | フロー全体 | 画面操作やバッチ全体の上限時間、全体監視 |
+| ActionDefinition | アクション単位 | submit / click / timer など 1 アクション内の上限時間 |
+| StepBase | 任意ステップ | 外部 API、DB、計算、ログなど個別処理の上限時間 |
+
+より内側のレベルが指定されている場合は、実装時に内側の宣言を優先する。例: `StepBase.sla.timeoutMs` は `ActionDefinition.sla.timeoutMs` より具体的な制約として扱う。
+
+## Sla
+
+```ts
+interface Sla {
+  timeoutMs?: number;
+  onTimeout?: "throw" | "continue" | "compensate" | "log";
+  errorCode?: string;
+  warningThresholdMs?: number;
+}
+```
+
+### timeoutMs
+
+タイムアウトまでのミリ秒。ProcessFlow / ActionDefinition / StepBase のいずれでも同じ意味で、対象スコープの最大実行時間を示す。
+
+### onTimeout
+
+タイムアウト時の挙動。
+
+| 値 | 意味 |
+|---|---|
+| `throw` | エラーとして扱い、通常のエラー処理へ進める |
+| `continue` | タイムアウトを記録し、次の処理へ継続する |
+| `compensate` | 補償処理や Saga の戻し処理へ進める |
+| `log` | タイムアウトをログ・監視に残すが、業務フローは止めない |
+
+### errorCode
+
+`errorCatalog` のキーと連携するエラーコード。`onTimeout: "throw"` または `compensate` の場合、HTTP レスポンスや業務エラーへの変換に利用する。
+
+### warningThresholdMs
+
+タイムアウトより手前で警告を出す閾値。例: `timeoutMs: 2000`, `warningThresholdMs: 1500` の場合、1.5 秒を超えた処理を遅延警告として監視できる。
+
+## 後方互換
+
+既存の `ExternalSystemStep.timeoutMs` は deprecated として残す。新規定義では `StepBase.sla.timeoutMs` を使用する。
+
+外部システムステップで両方が指定された場合、`sla.timeoutMs` を優先する。旧データの読み込み・検証互換を維持するため、スキーマ上は `ExternalSystemStep.timeoutMs` も引き続き受け付ける。

--- a/docs/spec/process-flow-sla.md
+++ b/docs/spec/process-flow-sla.md
@@ -24,12 +24,21 @@ interface Sla {
   onTimeout?: "throw" | "continue" | "compensate" | "log";
   errorCode?: string;
   warningThresholdMs?: number;
+  p95LatencyMs?: number;
 }
 ```
 
 ### timeoutMs
 
 タイムアウトまでのミリ秒。ProcessFlow / ActionDefinition / StepBase のいずれでも同じ意味で、対象スコープの最大実行時間を示す。
+
+各レベルでの解釈:
+
+| レベル | 意味 |
+|---|---|
+| ProcessFlow | フロー全体 (全アクション + 全ステップ合計) の最大実行時間 |
+| ActionDefinition | アクション 1 回 (HTTP リクエスト 1 回など) の最大実行時間 |
+| StepBase | 個別ステップ (DB 1 クエリ、外部 API 1 呼出 など) の最大実行時間 |
 
 ### onTimeout
 
@@ -46,9 +55,47 @@ interface Sla {
 
 `errorCatalog` のキーと連携するエラーコード。`onTimeout: "throw"` または `compensate` の場合、HTTP レスポンスや業務エラーへの変換に利用する。
 
+**スキーマ制約 (#412)**: `onTimeout` が `throw` または `compensate` の場合、`errorCode` は必須 (JSON Schema の `if/then` で強制)。`continue` / `log` では `errorCode` は不要。
+
 ### warningThresholdMs
 
 タイムアウトより手前で警告を出す閾値。例: `timeoutMs: 2000`, `warningThresholdMs: 1500` の場合、1.5 秒を超えた処理を遅延警告として監視できる。
+
+### p95LatencyMs
+
+P95 レイテンシ目標 (ms)。SRE 監視・SLO 評価で「95% のリクエストが満たすべき応答時間」として使用する。`timeoutMs` (絶対上限) と異なり、超過しても処理は継続するが、観測値が継続的に超えた場合は監視 alert 対象。
+
+例: `timeoutMs: 5000`, `p95LatencyMs: 500` — 上限 5 秒 / SLO 目標 P95 < 500ms。
+
+## 設計判断
+
+### timeoutMs の 3 レベル統合 (採用)
+
+ISSUE #412 の当初案では、Flow / Action では `totalTimeoutMs`、Step では `timeoutMs` という別名を採用していたが、3 レベルすべてで `timeoutMs` に統一した。
+
+理由:
+
+- **シンプルな API**: フィールド名がレベルで変わらないため、AI 実装者が記憶しやすい
+- **JSON 型再利用**: 同一の `Sla` 型を 3 レベルで使い回せる (型定義 / バリデーション / UI / テストが一段集約)
+- **意味は文脈から自明**: 上述の通り、レベルに応じて「対象スコープの最大実行時間」と読み替えれば意味が一意に決まる
+- 「フロー全体の上限」「アクション 1 回の上限」「ステップ 1 つの上限」はネスト関係 (内側 ⊆ 外側) なので、別名にする実用的メリットが薄い
+
+トレードオフ: `totalTimeoutMs` という命名が持つ「全体合計」のニュアンスは失われるが、上の表で意味を明示することで補う。
+
+## 将来追加候補
+
+### errorBudget (SRE error budget)
+
+SRE プラクティスの「許容エラー率」(例: 99.9% SLO なら error budget = 0.1%) を Sla に追加することを検討中。
+
+```jsonc
+// 将来案
+"sla": {
+  "errorBudget": 0.001  // 許容エラー率 0.1%
+}
+```
+
+別 ISSUE で扱う予定。実装時には `monitoring.errorBudgetBurnRate` のような関連フィールドとセットで設計する。
 
 ## 後方互換
 

--- a/schemas/process-flow.schema.json
+++ b/schemas/process-flow.schema.json
@@ -83,8 +83,18 @@
         "timeoutMs": { "type": "number", "minimum": 0 },
         "onTimeout": { "$ref": "#/$defs/OnTimeout" },
         "errorCode": { "type": "string" },
-        "warningThresholdMs": { "type": "number", "minimum": 0 }
-      }
+        "warningThresholdMs": { "type": "number", "minimum": 0 },
+        "p95LatencyMs": {
+          "type": "number",
+          "minimum": 0,
+          "description": "P95 レイテンシ目標 (ms)。超過時は監視 alert 対象"
+        }
+      },
+      "if": {
+        "properties": { "onTimeout": { "enum": ["throw", "compensate"] } },
+        "required": ["onTimeout"]
+      },
+      "then": { "required": ["errorCode"] }
     },
     "Maturity": {
       "type": "string",

--- a/schemas/process-flow.schema.json
+++ b/schemas/process-flow.schema.json
@@ -14,6 +14,7 @@
     "description": { "type": "string" },
     "maturity": { "$ref": "#/$defs/Maturity" },
     "mode": { "$ref": "#/$defs/ProcessFlowMode" },
+    "sla": { "$ref": "#/$defs/Sla" },
     "errorCatalog": {
       "description": "エラーコードカタログ (#253)。キーは errorCode (例: STOCK_SHORTAGE)。affectedRowsCheck.errorCode / BranchConditionVariant.errorCode から参照される",
       "type": "object",
@@ -70,6 +71,20 @@
       "type": "string",
       "enum": ["upstream", "downstream"],
       "description": "上流/下流モード。未指定は upstream 相当"
+    },
+    "OnTimeout": {
+      "type": "string",
+      "enum": ["throw", "continue", "compensate", "log"]
+    },
+    "Sla": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "timeoutMs": { "type": "number", "minimum": 0 },
+        "onTimeout": { "$ref": "#/$defs/OnTimeout" },
+        "errorCode": { "type": "string" },
+        "warningThresholdMs": { "type": "number", "minimum": 0 }
+      }
     },
     "Maturity": {
       "type": "string",
@@ -502,6 +517,7 @@
         "inputs": { "$ref": "#/$defs/ActionFields" },
         "outputs": { "$ref": "#/$defs/ActionFields" },
         "maturity": { "$ref": "#/$defs/Maturity" },
+        "sla": { "$ref": "#/$defs/Sla" },
         "requiredPermissions": {
           "type": "array",
           "items": { "type": "string" }
@@ -593,6 +609,7 @@
           "items": { "$ref": "#/$defs/StepNote" }
         },
         "maturity": { "$ref": "#/$defs/Maturity" },
+        "sla": { "$ref": "#/$defs/Sla" },
         "runIf": { "type": "string" },
         "requiredPermissions": {
           "type": "array",
@@ -664,7 +681,7 @@
             "id": true, "description": true, "note": true, "notes": true,
             "maturity": true, "runIf": true, "outputBinding": true,
             "txBoundary": true, "transactional": true, "compensatesFor": true,
-            "externalChain": true, "subSteps": true, "requiredPermissions": true,
+            "externalChain": true, "subSteps": true, "requiredPermissions": true, "sla": true,
             "type": { "const": "validation" },
             "conditions": { "type": "string" },
             "rules": {
@@ -715,7 +732,7 @@
             "id": true, "description": true, "note": true, "notes": true,
             "maturity": true, "runIf": true, "outputBinding": true,
             "txBoundary": true, "transactional": true, "compensatesFor": true,
-            "externalChain": true, "subSteps": true, "requiredPermissions": true,
+            "externalChain": true, "subSteps": true, "requiredPermissions": true, "sla": true,
             "type": { "const": "dbAccess" },
             "tableName": { "type": "string" },
             "tableId": { "type": "string" },
@@ -849,7 +866,7 @@
             "id": true, "description": true, "note": true, "notes": true,
             "maturity": true, "runIf": true, "outputBinding": true,
             "txBoundary": true, "transactional": true, "compensatesFor": true,
-            "externalChain": true, "subSteps": true, "requiredPermissions": true,
+            "externalChain": true, "subSteps": true, "requiredPermissions": true, "sla": true,
             "type": { "const": "externalSystem" },
             "systemName": { "type": "string" },
             "systemRef": {
@@ -896,7 +913,7 @@
             "id": true, "description": true, "note": true, "notes": true,
             "maturity": true, "runIf": true, "outputBinding": true,
             "txBoundary": true, "transactional": true, "compensatesFor": true,
-            "externalChain": true, "subSteps": true, "requiredPermissions": true,
+            "externalChain": true, "subSteps": true, "requiredPermissions": true, "sla": true,
             "type": { "const": "commonProcess" },
             "refId": { "type": "string" },
             "refName": { "type": "string" },
@@ -920,7 +937,7 @@
             "id": true, "description": true, "note": true, "notes": true,
             "maturity": true, "runIf": true, "outputBinding": true,
             "txBoundary": true, "transactional": true, "compensatesFor": true,
-            "externalChain": true, "subSteps": true, "requiredPermissions": true,
+            "externalChain": true, "subSteps": true, "requiredPermissions": true, "sla": true,
             "type": { "const": "screenTransition" },
             "targetScreenId": { "type": "string" },
             "targetScreenName": { "type": "string" }
@@ -940,7 +957,7 @@
             "id": true, "description": true, "note": true, "notes": true,
             "maturity": true, "runIf": true, "outputBinding": true,
             "txBoundary": true, "transactional": true, "compensatesFor": true,
-            "externalChain": true, "subSteps": true, "requiredPermissions": true,
+            "externalChain": true, "subSteps": true, "requiredPermissions": true, "sla": true,
             "type": { "const": "displayUpdate" },
             "target": { "type": "string" }
           }
@@ -1035,7 +1052,7 @@
             "id": true, "description": true, "note": true, "notes": true,
             "maturity": true, "runIf": true, "outputBinding": true,
             "txBoundary": true, "transactional": true, "compensatesFor": true,
-            "externalChain": true, "subSteps": true, "requiredPermissions": true,
+            "externalChain": true, "subSteps": true, "requiredPermissions": true, "sla": true,
             "type": { "const": "branch" },
             "branches": {
               "type": "array",
@@ -1067,7 +1084,7 @@
             "id": true, "description": true, "note": true, "notes": true,
             "maturity": true, "runIf": true, "outputBinding": true,
             "txBoundary": true, "transactional": true, "compensatesFor": true,
-            "externalChain": true, "subSteps": true, "requiredPermissions": true,
+            "externalChain": true, "subSteps": true, "requiredPermissions": true, "sla": true,
             "type": { "const": "loop" },
             "loopKind": { "$ref": "#/$defs/LoopKind" },
             "countExpression": { "type": "string" },
@@ -1095,7 +1112,7 @@
             "id": true, "description": true, "note": true, "notes": true,
             "maturity": true, "runIf": true, "outputBinding": true,
             "txBoundary": true, "transactional": true, "compensatesFor": true,
-            "externalChain": true, "subSteps": true, "requiredPermissions": true,
+            "externalChain": true, "subSteps": true, "requiredPermissions": true, "sla": true,
             "type": { "const": "loopBreak" }
           }
         }
@@ -1112,7 +1129,7 @@
             "id": true, "description": true, "note": true, "notes": true,
             "maturity": true, "runIf": true, "outputBinding": true,
             "txBoundary": true, "transactional": true, "compensatesFor": true,
-            "externalChain": true, "subSteps": true, "requiredPermissions": true,
+            "externalChain": true, "subSteps": true, "requiredPermissions": true, "sla": true,
             "type": { "const": "loopContinue" }
           }
         }
@@ -1130,7 +1147,7 @@
             "id": true, "description": true, "note": true, "notes": true,
             "maturity": true, "runIf": true, "outputBinding": true,
             "txBoundary": true, "transactional": true, "compensatesFor": true,
-            "externalChain": true, "subSteps": true, "requiredPermissions": true,
+            "externalChain": true, "subSteps": true, "requiredPermissions": true, "sla": true,
             "type": { "const": "jump" },
             "jumpTo": { "type": "string" }
           }
@@ -1149,7 +1166,7 @@
             "id": true, "description": true, "note": true, "notes": true,
             "maturity": true, "runIf": true, "outputBinding": true,
             "txBoundary": true, "transactional": true, "compensatesFor": true,
-            "externalChain": true, "subSteps": true, "requiredPermissions": true,
+            "externalChain": true, "subSteps": true, "requiredPermissions": true, "sla": true,
             "type": { "const": "compute" },
             "expression": { "type": "string" }
           }
@@ -1168,7 +1185,7 @@
             "id": true, "description": true, "note": true, "notes": true,
             "maturity": true, "runIf": true, "outputBinding": true,
             "txBoundary": true, "transactional": true, "compensatesFor": true,
-            "externalChain": true, "subSteps": true, "requiredPermissions": true,
+            "externalChain": true, "subSteps": true, "requiredPermissions": true, "sla": true,
             "type": { "const": "return" },
             "responseRef": { "type": "string" },
             "bodyExpression": { "type": "string" }
@@ -1188,7 +1205,7 @@
             "id": true, "description": true, "note": true, "notes": true,
             "maturity": true, "runIf": true, "outputBinding": true,
             "txBoundary": true, "transactional": true, "compensatesFor": true,
-            "externalChain": true, "subSteps": true, "requiredPermissions": true,
+            "externalChain": true, "subSteps": true, "requiredPermissions": true, "sla": true,
             "type": { "const": "log" },
             "level": {
               "type": "string",
@@ -1225,7 +1242,7 @@
             "id": true, "description": true, "note": true, "notes": true,
             "maturity": true, "runIf": true, "outputBinding": true,
             "txBoundary": true, "transactional": true, "compensatesFor": true,
-            "externalChain": true, "subSteps": true, "requiredPermissions": true,
+            "externalChain": true, "subSteps": true, "requiredPermissions": true, "sla": true,
             "type": { "const": "audit" },
             "action": { "type": "string" },
             "resource": { "$ref": "#/$defs/AuditResource" },
@@ -1248,7 +1265,7 @@
             "id": true, "description": true, "note": true, "notes": true,
             "maturity": true, "runIf": true, "outputBinding": true,
             "txBoundary": true, "transactional": true, "compensatesFor": true,
-            "externalChain": true, "subSteps": true, "requiredPermissions": true,
+            "externalChain": true, "subSteps": true, "requiredPermissions": true, "sla": true,
             "type": { "const": "other" }
           }
         }


### PR DESCRIPTION
## 関連

- Closes #412
- 仕様: docs/spec/process-flow-sla.md

## 概要

SLA / Timeout 宣言を ProcessFlow / ActionDefinition / StepBase の 3 レベルで扱えるようにしました。スキーマ・TypeScript 型・サンプル・仕様書・編集 UI を同期し、既存の ExternalSystemStep.timeoutMs は後方互換用に残しています。

## 主な変更

- `Sla` / `OnTimeout` を JSON Schema と TypeScript 型に追加
- ProcessFlow / ActionDefinition / StepBase に `sla` を追加
- 全 Step variant で `sla` を受け付けるよう schema の `additionalProperties: false` 側も更新
- `SlaPanel` を追加し、フロー基本情報・アクション編集領域・ステップ詳細メタ情報から編集可能に変更
- サンプルに 3 レベルの SLA 例と、旧 `ExternalSystemStep.timeoutMs` 後方互換サンプルを追加
- `docs/spec/process-flow-sla.md` を追加し、docs/spec README からリンク

## 仕様逐条突合 (自己申告)

- `Sla.timeoutMs / onTimeout / errorCode / warningThresholdMs` 定義: `schemas/process-flow.schema.json:75`, `schemas/process-flow.schema.json:79`, `designer/src/types/action.ts:170`, `designer/src/types/action.ts:172`
- ProcessFlow / ActionDefinition / StepBase の 3 レベルに `sla` 追加: `schemas/process-flow.schema.json:17`, `schemas/process-flow.schema.json:520`, `schemas/process-flow.schema.json:612`, `designer/src/types/action.ts:244`, `designer/src/types/action.ts:885`, `designer/src/types/action.ts:1044`
- StepBase.sla を全 Step variant で許可: `schemas/process-flow.schema.json:684`, `schemas/process-flow.schema.json:735`, `schemas/process-flow.schema.json:869`, `schemas/process-flow.schema.json:916`, `schemas/process-flow.schema.json:940`, `schemas/process-flow.schema.json:960`, `schemas/process-flow.schema.json:1055`, `schemas/process-flow.schema.json:1087`, `schemas/process-flow.schema.json:1115`, `schemas/process-flow.schema.json:1132`, `schemas/process-flow.schema.json:1150`, `schemas/process-flow.schema.json:1169`, `schemas/process-flow.schema.json:1188`, `schemas/process-flow.schema.json:1208`, `schemas/process-flow.schema.json:1245`, `schemas/process-flow.schema.json:1268`
- `ExternalSystemStep.timeoutMs` 後方互換・deprecated: `schemas/process-flow.schema.json:891`, `designer/src/types/action.ts:529`, `docs/sample-project/process-flows/cccccccc-0007-4000-8000-cccccccccccc.json:447`
- サンプル 3 レベル SLA 例: `docs/sample-project/process-flows/cccccccc-0005-4000-8000-cccccccccccc.json:9`, `docs/sample-project/process-flows/cccccccc-0005-4000-8000-cccccccccccc.json:131`, `docs/sample-project/process-flows/cccccccc-0005-4000-8000-cccccccccccc.json:176`
- SLA 仕様書とリンク: `docs/spec/process-flow-sla.md:9`, `docs/spec/process-flow-sla.md:34`, `docs/spec/process-flow-sla.md:45`, `docs/spec/process-flow-sla.md:49`, `docs/spec/process-flow-sla.md:55`, `docs/spec/README.md:13`
- 共通 SLA パネルと AI マーカー用 data-field-path: `designer/src/components/process-flow/SlaPanel.tsx:31`, `designer/src/components/process-flow/SlaPanel.tsx:56`, `designer/src/components/process-flow/SlaPanel.tsx:67`, `designer/src/components/process-flow/SlaPanel.tsx:80`, `designer/src/components/process-flow/SlaPanel.tsx:91`
- ステップ詳細メタ情報への組み込みと旧 timeoutMs 優先関係表示: `designer/src/components/process-flow/StepAdvancedMetadataPanel.tsx:156`, `designer/src/components/process-flow/StepAdvancedMetadataPanel.tsx:165`
- フロー / アクション編集 UI への SLA 組み込み: `designer/src/components/process-flow/ActionMetaTabBar.tsx:256`, `designer/src/components/process-flow/ProcessFlowEditor.tsx:787`

## レビューで特に見てほしい箇所

- Step variant 側の `additionalProperties: false` と `sla: true` の網羅性
- `SlaPanel` の保存タイミングが既存メタデータ UI の操作感と合っているか
- 旧 `ExternalSystemStep.timeoutMs` と新 `sla.timeoutMs` の説明が十分か

## テスト

- Vitest: 94 件 - `cd designer && npx vitest run src/schemas/process-flow.schema.test.ts`
- Vitest: 737 件 - `cd designer && npx vitest run`
- Build: pass - `cd designer && npm run build`
- Playwright: N/A
- MCP E2E: N/A

## UI 影響 / マージ保留フラグ

- [x] UI 影響あり (マージ前にユーザー目視確認必須)
- [ ] UI 影響なし (auto テスト pass でマージ可)

### UI 影響ありの場合の確認項目

- [ ] フロー基本情報タブで SLA / Timeout を入力・削除できる
- [ ] アクション編集領域で SLA / Timeout を入力・削除できる
- [ ] ステップ詳細メタ情報で SLA / Timeout を入力・削除できる
- [ ] 外部システムステップで旧 timeoutMs との関係説明が表示される
- [ ] 保存後の JSON に `sla` が反映され、不要フィールドは空で残らない

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

UI は自動テストと build まで確認済みです。画面操作の目視確認は PR 上で別途実施してください。