### PR TITLE
feat(processflow): P1-1 ExternalSystemStep を OpenAPI $ref 参照に (#413)

### DIFF
--- a/designer/src/components/process-flow/ExternalSystemCatalogPanel.tsx
+++ b/designer/src/components/process-flow/ExternalSystemCatalogPanel.tsx
@@ -13,6 +13,10 @@ interface Props {
 }
 
 const AUTH_KINDS: ExternalAuthKind[] = ["bearer", "basic", "apiKey", "oauth2", "none"];
+const trimToUndefined = (value: string) => {
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+};
 
 export function ExternalSystemCatalogPanel({ group, onChange, expanded: expandedProp, onExpandedChange, render = "full" }: Props) {
   const [expandedState, setExpandedState] = useState(false);
@@ -102,6 +106,16 @@ export function ExternalSystemCatalogPanel({ group, onChange, expanded: expanded
                       value={e.baseUrl ?? ""}
                       onChange={(ev) => updateEntry(k, { baseUrl: ev.target.value || undefined })}
                       placeholder="https://api.stripe.com"
+                    />
+                  </label>
+                  <label className="catalog-wide" data-field-path="openApiSpec">
+                    openApiSpec
+                    <input
+                      className="form-control form-control-sm"
+                      data-field-path="openApiSpec"
+                      value={e.openApiSpec ?? ""}
+                      onChange={(ev) => updateEntry(k, { openApiSpec: trimToUndefined(ev.target.value) })}
+                      placeholder="https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json"
                     />
                   </label>
                   <label>

--- a/designer/src/components/process-flow/StepCard.tsx
+++ b/designer/src/components/process-flow/StepCard.tsx
@@ -225,6 +225,10 @@ interface StepCardProps {
 }
 
 const DB_OPS: DbOperation[] = ["SELECT", "INSERT", "UPDATE", "DELETE"];
+const trimToUndefined = (value: string) => {
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+};
 
 export function StepCard({
   step,
@@ -1022,6 +1026,58 @@ export function StepCard({
                       onChange={(e) => onChange({ protocol: e.target.value } as Partial<Step>)}
                       onBlur={onCommit}
                       placeholder="REST / SOAP / gRPC"
+                    />
+                  </div>
+                </div>
+                <div className="row g-2 mb-2">
+                  <div className="col-6" data-field-path="operationRef">
+                    <label className="form-label">operationRef</label>
+                    <input
+                      className="form-control form-control-sm"
+                      data-field-path="operationRef"
+                      value={step.operationRef ?? ""}
+                      onChange={(e) => onChange({ operationRef: trimToUndefined(e.target.value) } as Partial<Step>)}
+                      onBlur={onCommit}
+                      placeholder="/v1/payment_intents POST"
+                      style={{ fontFamily: "monospace" }}
+                    />
+                  </div>
+                  <div className="col-6" data-field-path="operationId">
+                    <label className="form-label">operationId</label>
+                    <input
+                      className="form-control form-control-sm"
+                      data-field-path="operationId"
+                      value={step.operationId ?? ""}
+                      onChange={(e) => onChange({ operationId: trimToUndefined(e.target.value) } as Partial<Step>)}
+                      onBlur={onCommit}
+                      placeholder="PostPaymentIntents"
+                      style={{ fontFamily: "monospace" }}
+                    />
+                  </div>
+                </div>
+                <div className="row g-2 mb-2">
+                  <div className="col-6" data-field-path="requestBodyRef">
+                    <label className="form-label">requestBodyRef</label>
+                    <input
+                      className="form-control form-control-sm"
+                      data-field-path="requestBodyRef"
+                      value={step.requestBodyRef ?? ""}
+                      onChange={(e) => onChange({ requestBodyRef: trimToUndefined(e.target.value) } as Partial<Step>)}
+                      onBlur={onCommit}
+                      placeholder="#/components/schemas/PaymentIntentCreateParams"
+                      style={{ fontFamily: "monospace" }}
+                    />
+                  </div>
+                  <div className="col-6" data-field-path="responseRef">
+                    <label className="form-label">responseRef</label>
+                    <input
+                      className="form-control form-control-sm"
+                      data-field-path="responseRef"
+                      value={step.responseRef ?? ""}
+                      onChange={(e) => onChange({ responseRef: trimToUndefined(e.target.value) } as Partial<Step>)}
+                      onBlur={onCommit}
+                      placeholder="#/components/responses/200/content/application~1json/schema"
+                      style={{ fontFamily: "monospace" }}
                     />
                   </div>
                 </div>

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -473,6 +473,8 @@ export interface ExternalSystemCatalogEntry {
   name: string;
   /** HTTP ベース URL (例: "https://api.stripe.com") */
   baseUrl?: string;
+  /** OpenAPI specification URL or relative path (#413) */
+  openApiSpec?: string;
   /** 既定認証 (step 側の auth が優先) */
   auth?: ExternalAuth;
   /** 既定タイムアウト (ms) */
@@ -508,6 +510,14 @@ export interface ExternalSystemStep extends StepBase {
    * method / path / query / body に分解、path は式補間可。
    */
   httpCall?: ExternalHttpCall;
+  /** OpenAPI operation reference. operationRef takes precedence over httpCall when both are present. */
+  operationRef?: string;
+  /** OpenAPI operationId. */
+  operationId?: string;
+  /** JSON Pointer / $ref to request body schema. */
+  requestBodyRef?: string;
+  /** JSON Pointer / $ref to response schema. */
+  responseRef?: string;
   /**
    * 各 outcome (success / failure / timeout) のハンドリング定義。
    * 省略時は product-scope §11 の既定 (failure/timeout=abort、success=continue) を適用。

--- a/docs/sample-project/process-flows/cccccccc-0005-4000-8000-cccccccccccc.json
+++ b/docs/sample-project/process-flows/cccccccc-0005-4000-8000-cccccccccccc.json
@@ -92,6 +92,7 @@
     "stripe": {
       "name": "Stripe Japan",
       "baseUrl": "https://api.stripe.com",
+      "openApiSpec": "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json",
       "auth": { "kind": "bearer", "tokenRef": "@secret.stripeApiKey" },
       "timeoutMs": 10000,
       "retryPolicy": { "maxAttempts": 3, "backoff": "exponential", "initialDelayMs": 500 },
@@ -260,6 +261,10 @@
           "runIf": "@paymentMethod == 'credit_card'",
           "systemName": "Stripe Japan",
           "systemRef": "stripe",
+          "operationRef": "/v1/payment_intents POST",
+          "operationId": "PostPaymentIntents",
+          "requestBodyRef": "#/components/schemas/PaymentIntentCreateParams",
+          "responseRef": "#/components/schemas/payment_intent",
           "httpCall": {
             "method": "POST",
             "path": "/v1/payment_intents",
@@ -367,6 +372,8 @@
                   "runIf": "@paymentAuth != null",
                   "systemName": "Stripe Japan",
                   "systemRef": "stripe",
+                  "operationRef": "/v1/payment_intents/{intent}/cancel POST",
+                  "operationId": "PostPaymentIntentsIntentCancel",
                   "httpCall": {
                     "method": "POST",
                     "path": "/v1/payment_intents/@paymentAuth.id/cancel"
@@ -410,6 +417,8 @@
                 "runIf": "@paymentMethod == 'credit_card'",
                 "systemName": "Stripe Japan",
                 "systemRef": "stripe",
+                "operationRef": "/v1/payment_intents/{intent}/capture POST",
+                "operationId": "PostPaymentIntentsIntentCapture",
                 "httpCall": {
                   "method": "POST",
                   "path": "/v1/payment_intents/@paymentAuth.id/capture"

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -12,6 +12,7 @@
 | [process-flow-extensions.md](process-flow-extensions.md) | HTTP 契約 / TX / Saga / 外部 outcomes / ValidationRule / compute / return (Phase B) | #151 / #182 |
 | [process-flow-expression-language.md](process-flow-expression-language.md) | runIf / expression / bodyExpression の式言語 BNF (js-subset) | #253 |
 | [process-flow-runtime-conventions.md](process-flow-runtime-conventions.md) | SQL 式補間 / HTTP body シリアライズ / TX×throw×tryCatch / fireAndForget / sideEffects TX 境界等の実行時規約 | #261 |
+| [process-flow-external-system.md](process-flow-external-system.md) | ExternalSystemStep の OpenAPI operation 参照 (`openApiSpec` / `operationRef`) | #413 |
 | [process-flow-testing.md](process-flow-testing.md) | 処理フローの Given-When-Then テストシナリオ (`testScenarios`) | #400 |
 | [screen-items.md](screen-items.md) | 画面項目定義 (フォーム系バリデーション 3 層のうち「画面」層) — **ドラフト v0.1** | #318 |
 

--- a/docs/spec/process-flow-external-system.md
+++ b/docs/spec/process-flow-external-system.md
@@ -1,0 +1,78 @@
+# ProcessFlow ExternalSystemStep OpenAPI 参照 (#413)
+
+## 目的
+
+`ExternalSystemStep` は外部 API 呼び出しを表す。AI 実装者が `systemName` や `httpCall.path` から API 仕様を推測しなくて済むよう、`externalSystemCatalog` から OpenAPI 仕様書へリンクし、各 step から OpenAPI operation を直接参照する。
+
+## externalSystemCatalog.openApiSpec
+
+`ProcessFlow.externalSystemCatalog.<systemRef>.openApiSpec` は、その外部システムの OpenAPI 仕様書を指す任意フィールド。
+
+- 型: `string`
+- 値: URL またはリポジトリ内の相対 path
+- 例: `https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json`
+
+AI 実装時は `systemRef` でカタログ entry を引き、`baseUrl` / `auth` / `headers` と合わせて `openApiSpec` を読む。Stripe や SendGrid のように公開 OpenAPI があるサービスでは、operation、request body、response schema を仕様書から確定できる。
+
+## operationRef と operationId
+
+`ExternalSystemStep` には OpenAPI operation を特定するための任意フィールドを置ける。
+
+- `operationRef`: OpenAPI `$ref` 風の参照。例: `/v1/payment_intents POST`、または full URI fragment
+- `operationId`: OpenAPI `operationId`
+- `requestBodyRef`: request body schema への JSON Pointer / `$ref`
+- `responseRef`: response schema への JSON Pointer / `$ref`
+
+選択ロジック:
+
+1. `operationRef` があれば最優先で使う。
+2. `operationRef` がなく `operationId` があれば、OpenAPI 仕様内の `operationId` で検索する。
+3. どちらもなければ従来どおり `httpCall.method` / `httpCall.path` から呼び出し先を解釈する。
+
+`operationRef` と `operationId` は併記できる。併記時は `operationRef` を正とし、`operationId` は人間向け・検索補助の別名として扱う。両者が OpenAPI 仕様上で別 operation を指す場合、実装者またはバリデータは警告を出す。
+
+## httpCall との優先順位
+
+`httpCall` は後方互換のため引き続き有効。`operationRef` と `httpCall` は同じ呼び出し先を表し得るため、両方ある場合は `operationRef` を優先する。
+
+推奨:
+
+- 新規データは `operationRef` または `operationId` を追加する。
+- 既存の `httpCall` は当面残し、実装環境が OpenAPI 参照を解決できない場合の fallback とする。
+- `operationRef` と `httpCall.method/path` が矛盾する場合は警告する。
+
+## 例
+
+Stripe Payment Intent 作成:
+
+```json
+{
+  "type": "externalSystem",
+  "systemName": "Stripe Japan",
+  "systemRef": "stripe",
+  "operationRef": "/v1/payment_intents POST",
+  "operationId": "PostPaymentIntents",
+  "requestBodyRef": "#/components/schemas/PaymentIntentCreateParams",
+  "responseRef": "#/components/schemas/payment_intent",
+  "httpCall": {
+    "method": "POST",
+    "path": "/v1/payment_intents"
+  }
+}
+```
+
+SendGrid mail send:
+
+```json
+{
+  "type": "externalSystem",
+  "systemName": "SendGrid",
+  "systemRef": "sendgrid",
+  "operationRef": "/v3/mail/send POST",
+  "operationId": "mail.send",
+  "httpCall": {
+    "method": "POST",
+    "path": "/v3/mail/send"
+  }
+}
+```

--- a/schemas/process-flow.schema.json
+++ b/schemas/process-flow.schema.json
@@ -828,6 +828,10 @@
       "properties": {
         "name": { "type": "string" },
         "baseUrl": { "type": "string" },
+        "openApiSpec": {
+          "type": "string",
+          "description": "OpenAPI specification URL or relative path (#413)"
+        },
         "auth": { "$ref": "#/$defs/ExternalAuth" },
         "timeoutMs": { "type": "integer", "minimum": 0 },
         "retryPolicy": { "$ref": "#/$defs/RetryPolicy" },
@@ -862,6 +866,22 @@
               "description": "DEPRECATED (#261): httpCall への移行推奨"
             },
             "httpCall": { "$ref": "#/$defs/ExternalHttpCall" },
+            "operationRef": {
+              "type": "string",
+              "description": "OpenAPI operation reference. When httpCall is also present, operationRef takes precedence (#413)."
+            },
+            "operationId": {
+              "type": "string",
+              "description": "OpenAPI operationId (#413)"
+            },
+            "requestBodyRef": {
+              "type": "string",
+              "description": "JSON Pointer / $ref to request body schema (#413)"
+            },
+            "responseRef": {
+              "type": "string",
+              "description": "JSON Pointer / $ref to response schema (#413)"
+            },
             "outcomes": {
               "type": "object",
               "additionalProperties": false,


### PR DESCRIPTION
## 関連

- Closes #413
- 仕様: docs/spec/process-flow-external-system.md

## 概要

ExternalSystemStep から OpenAPI operation を直接参照できるようにし、外部システムカタログに OpenAPI 仕様書 URL/path を持てるようにしました。既存 httpCall は後方互換として残し、operationRef がある場合は operationRef を優先する仕様を追加しています。

## 主な変更

- JSON Schema: externalSystemCatalog entry に openApiSpec、ExternalSystemStep に operationRef / operationId / requestBodyRef / responseRef を追加
- TypeScript 型: schema と同名・同 optionality のフィールドを追加
- サンプル: Stripe sample に openApiSpec と Stripe Payment Intent の operation 参照例を追加
- Spec: OpenAPI 参照仕様を新規作成し、docs/spec/README.md からリンク
- UI: ExternalSystemStep 編集欄と externalSystemCatalog 編集欄に新フィールドを追加

## 仕様逐条突合 (自己申告)

- externalSystemCatalog の各 systemRef に openApiSpec を追加: schemas/process-flow.schema.json:831, designer/src/types/action.ts:477, docs/sample-project/process-flows/cccccccc-0005-4000-8000-cccccccccccc.json:95
- ExternalSystemStep.operationRef を追加: schemas/process-flow.schema.json:869, designer/src/types/action.ts:514, designer/src/components/process-flow/StepCard.tsx:1033
- ExternalSystemStep.operationId を追加: schemas/process-flow.schema.json:873, designer/src/types/action.ts:516, designer/src/components/process-flow/StepCard.tsx:1045
- ExternalSystemStep.requestBodyRef を追加: schemas/process-flow.schema.json:877, designer/src/types/action.ts:518, designer/src/components/process-flow/StepCard.tsx:1059
- ExternalSystemStep.responseRef を追加: schemas/process-flow.schema.json:881, designer/src/types/action.ts:520, designer/src/components/process-flow/StepCard.tsx:1071
- operationRef と operationId は併記可、operationRef 優先、矛盾時は警告: docs/spec/process-flow-external-system.md:28, docs/spec/process-flow-external-system.md:32
- httpCall との併用時は operationRef 優先、httpCall は fallback: docs/spec/process-flow-external-system.md:36, docs/spec/process-flow-external-system.md:40
- 既存サンプルの Stripe 連携を更新し、新規サンプルは追加しない: docs/sample-project/process-flows/cccccccc-0005-4000-8000-cccccccccccc.json:264, docs/sample-project/process-flows/cccccccc-0005-4000-8000-cccccccccccc.json:375, docs/sample-project/process-flows/cccccccc-0005-4000-8000-cccccccccccc.json:420
- docs/spec/process-flow-external-system.md を作成し README からリンク: docs/spec/process-flow-external-system.md:1, docs/spec/README.md:15
- UI から openApiSpec / operationRef を編集・保存できる: designer/src/components/process-flow/ExternalSystemCatalogPanel.tsx:111, designer/src/components/process-flow/StepCard.tsx:1033

## レビューで特に見てほしい箇所

- operationRef と operationId 併記時の扱いを validation error ではなく spec 上の警告としている点
- openApiSpec を URL 固定ではなく、issue 本文どおり URL または相対 path の string としている点

## テスト

- Vitest: 737 件 pass (全体) — npx vitest run
- Vitest: 94 件 pass (schema) — npx vitest run src/schemas/process-flow.schema.test.ts
- Build: pass — npm run build
- Playwright: N/A
- MCP E2E: N/A

## UI 影響 / マージ保護フラグ

- [x] UI 影響あり (マージ前にユーザー目視確認必要)
- [ ] UI 影響なし (auto テスト pass でマージ可)

### UI 影響ありの場合の確認項目

- [ ] ProcessFlowEditor で ExternalSystemStep を開き、operationRef / operationId / requestBodyRef / responseRef を入力できる
- [ ] externalSystemCatalog で openApiSpec を入力できる
- [ ] 保存後の JSON に入力値が残る

## spec 側の不足点 / 提案

- JSON Schema では「警告」を表現できないため、operationRef と operationId の矛盾警告は spec 記述に留めています。将来、独自 validator 側で警告実装するとよいです。

## レビュー担当者への申し送り

- issue 本文が openApiSpec を「URL or 相対 path」としているため、schema は format: uri を付けず string にしています。