### PR TITLE
feat(processflow): P1-3 TransactionScopeStep — 複数 DB 操作を 1 TX でまとめる meta-step (#415)

### DIFF
--- a/designer-mcp/src/processFlowEdits.test.ts
+++ b/designer-mcp/src/processFlowEdits.test.ts
@@ -46,6 +46,17 @@ function makeGroup(): ProcessFlowDoc {
             failure: { sideEffects: [{ id: "s5-se-1", type: "other", description: "logger" }] },
           },
         },
+        {
+          id: "s6",
+          type: "transactionScope",
+          description: "tx1",
+          steps: [
+            { id: "s6-tx-1", type: "dbAccess", description: "insert" },
+            { id: "s6-tx-2", type: "dbAccess", description: "update" },
+          ],
+          onCommit: [{ id: "s6-c-1", type: "log", description: "commit log" }],
+          onRollback: [{ id: "s6-r-1", type: "log", description: "rollback log" }],
+        },
       ],
     }],
   };
@@ -58,6 +69,12 @@ describe("findStep — ネスト全対応", () => {
   it("elseBranch 配下", () => expect(findStep(ag, "s3-e-1")?.type).toBe("other"));
   it("loop 配下", () => expect(findStep(ag, "s4-1")?.type).toBe("other"));
   it("sideEffects 配下", () => expect(findStep(ag, "s5-se-1")?.type).toBe("other"));
+  it("transactionScope.steps 配下 (#415)", () =>
+    expect(findStep(ag, "s6-tx-1")?.type).toBe("dbAccess"));
+  it("transactionScope.onCommit 配下 (#415)", () =>
+    expect(findStep(ag, "s6-c-1")?.type).toBe("log"));
+  it("transactionScope.onRollback 配下 (#415)", () =>
+    expect(findStep(ag, "s6-r-1")?.type).toBe("log"));
   it("未知 id は null", () => expect(findStep(ag, "nope")).toBeNull());
 });
 
@@ -72,6 +89,21 @@ describe("updateStep — patch 適用", () => {
     updateStep(ag, "s3-a-1", { description: "branch 内改訂" });
     expect(findStep(ag, "s3-a-1")?.description).toBe("branch 内改訂");
   });
+  it("transactionScope.steps 配下も更新 (#415)", () => {
+    const ag = makeGroup();
+    updateStep(ag, "s6-tx-2", { description: "TX 内改訂" });
+    expect(findStep(ag, "s6-tx-2")?.description).toBe("TX 内改訂");
+  });
+  it("transactionScope.onCommit 配下も更新 (#415)", () => {
+    const ag = makeGroup();
+    updateStep(ag, "s6-c-1", { description: "commit 内改訂" });
+    expect(findStep(ag, "s6-c-1")?.description).toBe("commit 内改訂");
+  });
+  it("transactionScope.onRollback 配下も更新 (#415)", () => {
+    const ag = makeGroup();
+    updateStep(ag, "s6-r-1", { description: "rollback 内改訂" });
+    expect(findStep(ag, "s6-r-1")?.description).toBe("rollback 内改訂");
+  });
   it("未知 id は throw", () => {
     const ag = makeGroup();
     expect(() => updateStep(ag, "nope", {})).toThrow();
@@ -82,7 +114,7 @@ describe("removeStep", () => {
   it("top-level 削除", () => {
     const ag = makeGroup();
     removeStep(ag, "s2");
-    expect(ag.actions[0].steps.length).toBe(4);
+    expect(ag.actions[0].steps.length).toBe(5);
     expect(findStep(ag, "s2")).toBeNull();
   });
   it("branch 配下を削除", () => {
@@ -90,6 +122,25 @@ describe("removeStep", () => {
     removeStep(ag, "s3-a-1");
     const s3 = findStep(ag, "s3");
     expect(s3?.branches?.[0].steps.length).toBe(0);
+  });
+  it("transactionScope.steps 配下を削除 (#415)", () => {
+    const ag = makeGroup();
+    removeStep(ag, "s6-tx-1");
+    const s6 = findStep(ag, "s6");
+    expect(s6?.steps?.length).toBe(1);
+    expect(findStep(ag, "s6-tx-1")).toBeNull();
+  });
+  it("transactionScope.onCommit 配下を削除 (#415)", () => {
+    const ag = makeGroup();
+    removeStep(ag, "s6-c-1");
+    const s6 = findStep(ag, "s6");
+    expect((s6?.onCommit ?? []).length).toBe(0);
+  });
+  it("transactionScope.onRollback 配下を削除 (#415)", () => {
+    const ag = makeGroup();
+    removeStep(ag, "s6-r-1");
+    const s6 = findStep(ag, "s6");
+    expect((s6?.onRollback ?? []).length).toBe(0);
   });
 });
 
@@ -105,6 +156,13 @@ describe("moveStep", () => {
     moveStep(ag, "s1", 999);
     const ids = ag.actions[0].steps.map((s) => s.id);
     expect(ids[ids.length - 1]).toBe("s1");
+  });
+  it("transactionScope.steps 内で並び替え (#415)", () => {
+    const ag = makeGroup();
+    moveStep(ag, "s6-tx-1", 1);
+    const s6 = findStep(ag, "s6");
+    const ids = (s6?.steps ?? []).map((s) => s.id);
+    expect(ids).toEqual(["s6-tx-2", "s6-tx-1"]);
   });
 });
 

--- a/designer-mcp/src/processFlowEdits.ts
+++ b/designer-mcp/src/processFlowEdits.ts
@@ -12,7 +12,9 @@ type Step = {
   subSteps?: Step[];
   branches?: Array<{ id: string; steps: Step[] }>;
   elseBranch?: { id: string; steps: Step[] };
-  steps?: Step[]; // loop body
+  steps?: Step[]; // loop body / transactionScope.steps
+  onCommit?: Step[]; // transactionScope: commit 成功後の追加処理
+  onRollback?: Step[]; // transactionScope: rollback 後の補償処理
   outcomes?: Record<string, { sideEffects?: Step[] } | undefined>;
   notes?: Array<{ id: string; type: string; body: string; createdAt: string }>;
   [k: string]: unknown;
@@ -65,6 +67,11 @@ function walkSteps(
     }
     if (s.elseBranch && walkSteps(s.elseBranch.steps, visit)) return true;
     if (s.type === "loop" && s.steps && walkSteps(s.steps, visit)) return true;
+    if (s.type === "transactionScope") {
+      if (s.steps && walkSteps(s.steps, visit)) return true;
+      if (s.onCommit && walkSteps(s.onCommit, visit)) return true;
+      if (s.onRollback && walkSteps(s.onRollback, visit)) return true;
+    }
     if (s.outcomes) {
       for (const oc of Object.values(s.outcomes)) {
         if (oc?.sideEffects && walkSteps(oc.sideEffects, visit)) return true;

--- a/designer/src/components/process-flow/ActionMetaTabBar.tsx
+++ b/designer/src/components/process-flow/ActionMetaTabBar.tsx
@@ -47,6 +47,11 @@ function countMaturity(group: ProcessFlow): {
         if (s.elseBranch) visit(s.elseBranch.steps);
       }
       if (s.type === "loop") visit(s.steps);
+      if (s.type === "transactionScope") {
+        visit(s.steps);
+        if (s.onCommit) visit(s.onCommit);
+        if (s.onRollback) visit(s.onRollback);
+      }
     }
   };
   for (const act of group.actions) visit(act.steps);

--- a/designer/src/components/process-flow/MarkerPanel.tsx
+++ b/designer/src/components/process-flow/MarkerPanel.tsx
@@ -24,6 +24,11 @@ function collectStepIds(group: ProcessFlow): Set<string> {
         if (s.elseBranch) visit(s.elseBranch.steps);
       }
       if (s.type === "loop") visit(s.steps);
+      if (s.type === "transactionScope") {
+        visit(s.steps);
+        if (s.onCommit) visit(s.onCommit);
+        if (s.onRollback) visit(s.onRollback);
+      }
       if (s.type === "externalSystem" && s.outcomes) {
         for (const oc of Object.values(s.outcomes)) {
           if (oc?.sideEffects) visit(oc.sideEffects);

--- a/designer/src/components/process-flow/ProcessFlowEditor.tsx
+++ b/designer/src/components/process-flow/ProcessFlowEditor.tsx
@@ -111,14 +111,14 @@ const ALL_STEP_TYPES: StepType[] = [
   "validation", "dbAccess", "externalSystem", "commonProcess",
   "screenTransition", "displayUpdate", "branch", "loop",
   "loopBreak", "loopContinue", "jump", "compute", "return", "other",
-  "log", "audit", "workflow",
+  "log", "audit", "workflow", "transactionScope",
 ];
 
 const ALL_SUB_STEP_TYPES: StepType[] = [
   "validation", "dbAccess", "externalSystem", "commonProcess",
   "screenTransition", "displayUpdate", "branch", "loop",
   "loopBreak", "loopContinue", "jump", "compute", "return", "other",
-  "log", "audit", "workflow",
+  "log", "audit", "workflow", "transactionScope",
 ];
 
 const ALL_TRIGGERS: ActionTrigger[] = ["click", "submit", "select", "change", "load", "timer", "other"];
@@ -934,6 +934,7 @@ export function ProcessFlowEditor() {
                           markerTooltip={markerTooltip}
                           markerKinds={markerKinds}
                           conventions={conventions}
+                          group={group}
                         />
                       </div>
                       );

--- a/designer/src/components/process-flow/SortableStepCard.tsx
+++ b/designer/src/components/process-flow/SortableStepCard.tsx
@@ -1,7 +1,7 @@
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { StepCard } from "./StepCard";
-import type { Step, StepType } from "../../types/action";
+import type { ProcessFlow, Step, StepType } from "../../types/action";
 import type { ValidationError } from "../../utils/actionValidation";
 import type { ConventionsCatalog } from "../../schemas/conventionsValidator";
 
@@ -33,6 +33,7 @@ interface SortableStepCardProps {
   markerTooltip?: string;
   markerKinds?: { todo: number; question: number; attention: number; chat: number };
   conventions?: ConventionsCatalog | null;
+  group?: ProcessFlow | null;
 }
 
 export function SortableStepCard({ step, ...props }: SortableStepCardProps) {

--- a/designer/src/components/process-flow/StepCard.tsx
+++ b/designer/src/components/process-flow/StepCard.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from "react";
 import type { DraggableAttributes, DraggableSyntheticListeners } from "@dnd-kit/core";
 import type {
   Branch,
+  ProcessFlow,
   Step,
   StepType,
   DbOperation,
@@ -31,12 +32,13 @@ import { JumpTargetSelector } from "./JumpTargetSelector";
 import { WorkflowStepPanel } from "./WorkflowStepPanel";
 import { LogStepPanel } from "./LogStepPanel";
 import { AuditStepPanel } from "./AuditStepPanel";
+import { TransactionScopeStepPanel } from "./TransactionScopeStepPanel";
 
 const ALL_SUB_STEP_TYPES: StepType[] = [
   "validation", "dbAccess", "externalSystem", "commonProcess",
   "screenTransition", "displayUpdate", "branch", "loop",
   "loopBreak", "loopContinue", "jump", "compute", "return", "other",
-  "log", "audit", "workflow",
+  "log", "audit", "workflow", "transactionScope",
 ];
 
 // ─── ヘルパーコンポーネント ──────────────────────────────────────────────────
@@ -86,6 +88,7 @@ interface InlineStepListProps {
   onNavigateCommon: (refId: string) => void;
   validationErrors?: ValidationError[];
   conventions?: import("../../schemas/conventionsValidator").ConventionsCatalog | null;
+  group?: ProcessFlow | null;
 }
 
 function InlineStepList({
@@ -100,6 +103,7 @@ function InlineStepList({
   onNavigateCommon,
   validationErrors,
   conventions,
+  group,
 }: InlineStepListProps) {
   const [showTypePicker, setShowTypePicker] = useState(false);
 
@@ -164,6 +168,7 @@ function InlineStepList({
             depth={1}
             validationErrors={validationErrors}
             conventions={conventions}
+            group={group}
           />
         </div>
       ))}
@@ -197,6 +202,8 @@ interface StepCardProps {
   screens: { id: string; name: string }[];
   commonGroups: { id: string; name: string }[];
   conventions?: import("../../schemas/conventionsValidator").ConventionsCatalog | null;
+  /** TX スコープ等で errorCatalog を参照するために必要 (#415) */
+  group?: ProcessFlow | null;
   onChange: (changes: Partial<Step>) => void;
   onCommit?: () => void;
   onMoveUp?: () => void;
@@ -241,6 +248,7 @@ export function StepCard({
   screens,
   commonGroups,
   conventions,
+  group,
   onChange,
   onCommit,
   onMoveUp,
@@ -307,6 +315,11 @@ export function StepCard({
       }
       case "workflow":
         return `${WORKFLOW_PATTERN_LABELS[step.pattern]} / 承認者 ${step.approvers.length}件${step.description ? ` - ${step.description}` : ""}`;
+      case "transactionScope": {
+        const n = step.steps.length;
+        const iso = step.isolationLevel ?? "READ_COMMITTED";
+        return `TX (${iso}, ${n} ステップ)${step.description ? ` - ${step.description}` : ""}`;
+      }
       default:
         return step.description || "その他";
     }
@@ -1459,6 +1472,7 @@ export function StepCard({
                             onNavigateCommon={onNavigateCommon}
                             validationErrors={validationErrors}
                             conventions={conventions}
+                            group={group}
                           />
                         </div>
                       )}
@@ -1512,6 +1526,7 @@ export function StepCard({
                             onNavigateCommon={onNavigateCommon}
                             validationErrors={validationErrors}
                             conventions={conventions}
+                            group={group}
                           />
                         </div>
                       )}
@@ -1646,6 +1661,7 @@ export function StepCard({
                         onNavigateCommon={onNavigateCommon}
                         validationErrors={validationErrors}
                         conventions={conventions}
+                        group={group}
                       />
                     </div>
                   )}
@@ -1670,6 +1686,23 @@ export function StepCard({
                 onChange={(patch) => onChange(patch as Partial<Step>)}
                 onCommit={onCommit}
                 conventions={conventions ?? null}
+              />
+            )}
+
+            {/* ── TX スコープ (#415) ────────────────────────────── */}
+            {step.type === "transactionScope" && (
+              <TransactionScopeStepPanel
+                step={step}
+                onChange={(patch) => onChange(patch as Partial<Step>)}
+                onCommit={onCommit}
+                group={group}
+                allSteps={allSteps}
+                tables={tables}
+                screens={screens}
+                commonGroups={commonGroups}
+                validationErrors={validationErrors}
+                conventions={conventions ?? null}
+                onNavigateCommon={onNavigateCommon}
               />
             )}
 
@@ -1782,6 +1815,8 @@ export function StepCard({
                 onOutdent={onOutdentSubStep ? () => onOutdentSubStep(sub.id) : undefined}
                 onOutdentSubStep={(subSubId) => handleOutdentFromSubSteps(sub.id, subSubId)}
                 validationErrors={validationErrors}
+                conventions={conventions}
+                group={group}
               />
             </div>
           ))}

--- a/designer/src/components/process-flow/TransactionScopeStepPanel.tsx
+++ b/designer/src/components/process-flow/TransactionScopeStepPanel.tsx
@@ -68,6 +68,8 @@ interface InlineStepListProps {
   onNavigateCommon: (refId: string) => void;
   validationErrors?: ValidationError[];
   conventions?: ConventionsCatalog | null;
+  /** ネストした transactionScope 等で errorCatalog を参照するために必要 (#415) */
+  group?: ProcessFlow | null;
 }
 
 function InlineStepList({
@@ -82,6 +84,7 @@ function InlineStepList({
   onNavigateCommon,
   validationErrors,
   conventions,
+  group,
 }: InlineStepListProps) {
   const [showTypePicker, setShowTypePicker] = useState(false);
 
@@ -146,6 +149,7 @@ function InlineStepList({
             depth={1}
             validationErrors={validationErrors}
             conventions={conventions}
+            group={group}
           />
         </div>
       ))}
@@ -335,6 +339,7 @@ export function TransactionScopeStepPanel({
             onNavigateCommon={onNavigateCommon}
             validationErrors={validationErrors}
             conventions={conventions}
+            group={group}
           />
         </div>
       </div>
@@ -372,6 +377,7 @@ export function TransactionScopeStepPanel({
               onNavigateCommon={onNavigateCommon}
               validationErrors={validationErrors}
               conventions={conventions}
+              group={group}
             />
           </div>
         )}
@@ -410,6 +416,7 @@ export function TransactionScopeStepPanel({
               onNavigateCommon={onNavigateCommon}
               validationErrors={validationErrors}
               conventions={conventions}
+              group={group}
             />
           </div>
         )}

--- a/designer/src/components/process-flow/TransactionScopeStepPanel.tsx
+++ b/designer/src/components/process-flow/TransactionScopeStepPanel.tsx
@@ -1,0 +1,419 @@
+import { useState } from "react";
+import type {
+  Step,
+  StepType,
+  TransactionScopeStep,
+  TransactionIsolationLevel,
+  TransactionPropagation,
+  ProcessFlow,
+} from "../../types/action";
+import {
+  STEP_TYPE_LABELS,
+  STEP_TYPE_ICONS,
+  STEP_TYPE_COLORS,
+} from "../../types/action";
+import type { ConventionsCatalog } from "../../schemas/conventionsValidator";
+import type { ValidationError } from "../../utils/actionValidation";
+import { createDefaultStep } from "../../store/processFlowStore";
+import { generateUUID } from "../../utils/uuid";
+import { StepCard } from "./StepCard";
+
+interface Props {
+  step: TransactionScopeStep;
+  onChange: (patch: Partial<TransactionScopeStep>) => void;
+  onCommit?: () => void;
+  /** errorCatalog (rollbackOn の候補取得用) */
+  group?: ProcessFlow | null;
+  /** 子ステップ描画用 */
+  allSteps: Step[];
+  tables: { id: string; name: string; logicalName: string }[];
+  screens: { id: string; name: string }[];
+  commonGroups: { id: string; name: string }[];
+  validationErrors?: ValidationError[];
+  conventions?: ConventionsCatalog | null;
+  onNavigateCommon: (refId: string) => void;
+}
+
+const ISOLATION_LEVELS: Array<{ value: TransactionIsolationLevel; label: string }> = [
+  { value: "READ_COMMITTED", label: "READ_COMMITTED (commit 済データのみ可視・既定)" },
+  { value: "REPEATABLE_READ", label: "REPEATABLE_READ (同 TX 内で同じ行は安定)" },
+  { value: "SERIALIZABLE", label: "SERIALIZABLE (直列実行と等価・最厳)" },
+];
+
+const PROPAGATIONS: Array<{ value: TransactionPropagation; label: string }> = [
+  { value: "REQUIRED", label: "REQUIRED (既存 TX に参加・既定)" },
+  { value: "REQUIRES_NEW", label: "REQUIRES_NEW (既存を一時停止して新規 TX)" },
+  { value: "NESTED", label: "NESTED (savepoint で部分 rollback 可)" },
+];
+
+// ─── サブステップ管理用の InlineStepList (TransactionScopeStep 用ローカル版) ──
+// StepCard 内の InlineStepList と同型だが、再利用の都合で本コンポーネント内に置く。
+
+const ALL_SUB_STEP_TYPES: StepType[] = [
+  "validation", "dbAccess", "externalSystem", "commonProcess",
+  "screenTransition", "displayUpdate", "branch", "loop",
+  "loopBreak", "loopContinue", "jump", "compute", "return", "other",
+  "log", "audit", "transactionScope",
+];
+
+interface InlineStepListProps {
+  steps: Step[];
+  parentLabel: string;
+  allSteps: Step[];
+  tables: { id: string; name: string; logicalName: string }[];
+  screens: { id: string; name: string }[];
+  commonGroups: { id: string; name: string }[];
+  onChange: (steps: Step[]) => void;
+  onCommit?: () => void;
+  onNavigateCommon: (refId: string) => void;
+  validationErrors?: ValidationError[];
+  conventions?: ConventionsCatalog | null;
+}
+
+function InlineStepList({
+  steps,
+  parentLabel,
+  allSteps,
+  tables,
+  screens,
+  commonGroups,
+  onChange,
+  onCommit,
+  onNavigateCommon,
+  validationErrors,
+  conventions,
+}: InlineStepListProps) {
+  const [showTypePicker, setShowTypePicker] = useState(false);
+
+  const addStep = (type: StepType) => {
+    const newStep = createDefaultStep(type);
+    onChange([...steps, newStep]);
+    onCommit?.();
+    setShowTypePicker(false);
+  };
+
+  return (
+    <div className="inline-step-list">
+      {steps.map((step, si) => (
+        <div key={step.id} className="mb-1">
+          <StepCard
+            step={step}
+            index={si}
+            label={`${parentLabel}-${si + 1}`}
+            allSteps={allSteps}
+            tables={tables}
+            screens={screens}
+            commonGroups={commonGroups}
+            onChange={(changes) => {
+              const arr = steps.slice();
+              arr[si] = { ...arr[si], ...changes } as Step;
+              onChange(arr);
+            }}
+            onCommit={onCommit}
+            onMoveUp={si > 0 ? () => {
+              const arr = steps.slice();
+              [arr[si - 1], arr[si]] = [arr[si], arr[si - 1]];
+              onChange(arr);
+              onCommit?.();
+            } : undefined}
+            onMoveDown={si < steps.length - 1 ? () => {
+              const arr = steps.slice();
+              [arr[si], arr[si + 1]] = [arr[si + 1], arr[si]];
+              onChange(arr);
+              onCommit?.();
+            } : undefined}
+            onDelete={() => {
+              onChange(steps.filter((s) => s.id !== step.id));
+              onCommit?.();
+            }}
+            onDuplicate={() => {
+              const clone = JSON.parse(JSON.stringify(step)) as Step;
+              clone.id = generateUUID();
+              const arr = steps.slice();
+              arr.splice(si + 1, 0, clone);
+              onChange(arr);
+              onCommit?.();
+            }}
+            onAddSubStep={(type) => {
+              const newSub = createDefaultStep(type);
+              const arr = steps.slice();
+              arr[si] = { ...arr[si], subSteps: [...(arr[si].subSteps ?? []), newSub] } as Step;
+              onChange(arr);
+              onCommit?.();
+            }}
+            onContextMenu={(e) => e.preventDefault()}
+            onNavigateCommon={onNavigateCommon}
+            depth={1}
+            validationErrors={validationErrors}
+            conventions={conventions}
+          />
+        </div>
+      ))}
+      <div className="inline-step-add">
+        <button className="inline-add-btn" onClick={() => setShowTypePicker(!showTypePicker)}>
+          <i className="bi bi-plus" /> ステップを追加
+        </button>
+        {showTypePicker && (
+          <div className="inline-type-picker">
+            {ALL_SUB_STEP_TYPES.map((t) => (
+              <button key={t} className="inline-type-btn" onClick={() => addStep(t)}>
+                <i className={`bi ${STEP_TYPE_ICONS[t]}`} style={{ color: STEP_TYPE_COLORS[t] }} />
+                {STEP_TYPE_LABELS[t]}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function TransactionScopeStepPanel({
+  step,
+  onChange,
+  onCommit,
+  group,
+  allSteps,
+  tables,
+  screens,
+  commonGroups,
+  validationErrors,
+  conventions,
+  onNavigateCommon,
+}: Props) {
+  const [onCommitOpen, setOnCommitOpen] = useState((step.onCommit ?? []).length > 0);
+  const [onRollbackOpen, setOnRollbackOpen] = useState((step.onRollback ?? []).length > 0);
+
+  // errorCatalog の key 候補
+  const errorCodes = Object.keys(group?.errorCatalog ?? {});
+  const selectedErrorCodes = new Set(step.rollbackOn ?? []);
+
+  const toggleRollbackCode = (code: string) => {
+    const next = new Set(selectedErrorCodes);
+    if (next.has(code)) next.delete(code);
+    else next.add(code);
+    const arr = Array.from(next);
+    onChange({ rollbackOn: arr.length > 0 ? arr : undefined });
+    onCommit?.();
+  };
+
+  return (
+    <>
+      <div className="row g-2 mb-2">
+        <div className="col-6" data-field-path="isolationLevel">
+          <label className="form-label">
+            <i className="bi bi-shield-lock me-1" />
+            分離レベル (isolationLevel)
+          </label>
+          <select
+            className="form-select form-select-sm"
+            value={step.isolationLevel ?? "READ_COMMITTED"}
+            onChange={(e) => {
+              onChange({ isolationLevel: e.target.value as TransactionIsolationLevel });
+              onCommit?.();
+            }}
+          >
+            {ISOLATION_LEVELS.map((l) => (
+              <option key={l.value} value={l.value}>{l.label}</option>
+            ))}
+          </select>
+        </div>
+        <div className="col-6" data-field-path="propagation">
+          <label className="form-label">
+            <i className="bi bi-arrow-repeat me-1" />
+            伝播モード (propagation)
+          </label>
+          <select
+            className="form-select form-select-sm"
+            value={step.propagation ?? "REQUIRED"}
+            onChange={(e) => {
+              onChange({ propagation: e.target.value as TransactionPropagation });
+              onCommit?.();
+            }}
+          >
+            {PROPAGATIONS.map((p) => (
+              <option key={p.value} value={p.value}>{p.label}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="row g-2 mb-2">
+        <div className="col-4" data-field-path="timeoutMs">
+          <label className="form-label">
+            <i className="bi bi-stopwatch me-1" />
+            タイムアウト (timeoutMs)
+          </label>
+          <div className="input-group input-group-sm">
+            <input
+              type="number"
+              className="form-control form-control-sm"
+              value={step.timeoutMs ?? ""}
+              onChange={(e) => {
+                const v = e.target.value;
+                onChange({ timeoutMs: v === "" ? undefined : Math.max(0, Number(v)) });
+              }}
+              onBlur={onCommit}
+              min={0}
+              placeholder="ms"
+            />
+            <span className="input-group-text">ms</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="row g-2 mb-2" data-field-path="rollbackOn">
+        <div className="col-12">
+          <label className="form-label">
+            <i className="bi bi-arrow-counterclockwise me-1" />
+            rollback トリガー (rollbackOn)
+            <span className="text-muted ms-1" style={{ fontSize: "0.75rem" }}>
+              — errorCatalog の key を選択。未選択は「すべての例外で rollback」
+            </span>
+          </label>
+          {errorCodes.length === 0 ? (
+            <div className="text-muted small">
+              ProcessFlow.errorCatalog にエントリがありません。errorCatalog タブで先に定義してください。
+            </div>
+          ) : (
+            <div className="d-flex flex-wrap gap-2">
+              {errorCodes.map((code) => {
+                const checked = selectedErrorCodes.has(code);
+                return (
+                  <label
+                    key={code}
+                    className="form-check-label small d-inline-flex align-items-center gap-1"
+                    style={{ cursor: "pointer" }}
+                  >
+                    <input
+                      type="checkbox"
+                      className="form-check-input"
+                      checked={checked}
+                      onChange={() => toggleRollbackCode(code)}
+                    />
+                    <code style={{ fontSize: "0.78rem" }}>{code}</code>
+                  </label>
+                );
+              })}
+            </div>
+          )}
+          {/* errorCatalog に無い不明な rollbackOn コードがあれば警告表示 */}
+          {(step.rollbackOn ?? [])
+            .filter((c) => !errorCodes.includes(c))
+            .map((c) => (
+              <div key={c} className="text-danger small mt-1">
+                <i className="bi bi-exclamation-triangle me-1" />
+                未知の errorCode: <code>{c}</code> (errorCatalog に追加してください)
+                <button
+                  type="button"
+                  className="btn btn-sm btn-link text-danger p-0 ms-2"
+                  onClick={() => toggleRollbackCode(c)}
+                  title="この rollbackOn から削除"
+                >
+                  <i className="bi bi-x" /> 削除
+                </button>
+              </div>
+            ))}
+        </div>
+      </div>
+
+      <div className="mb-2" data-field-path="steps">
+        <label className="form-label small">
+          <i className="bi bi-shield-fill me-1" style={{ color: "#dc2626" }} />
+          TX 内のステップ (steps) — atomic 単位で実行
+        </label>
+        <div className="border rounded p-2" style={{ background: "rgba(220, 38, 38, 0.04)" }}>
+          <InlineStepList
+            steps={step.steps}
+            parentLabel="TX"
+            allSteps={allSteps}
+            tables={tables}
+            screens={screens}
+            commonGroups={commonGroups}
+            onChange={(newSteps) => onChange({ steps: newSteps })}
+            onCommit={onCommit}
+            onNavigateCommon={onNavigateCommon}
+            validationErrors={validationErrors}
+            conventions={conventions}
+          />
+        </div>
+      </div>
+
+      {/* onCommit (折りたたみ) */}
+      <div className="mb-2" data-field-path="onCommit">
+        <button
+          type="button"
+          className="btn btn-link btn-sm p-0 d-flex align-items-center gap-1"
+          onClick={() => setOnCommitOpen(!onCommitOpen)}
+          style={{ fontSize: "0.85rem", textDecoration: "none" }}
+        >
+          <i className={`bi bi-chevron-${onCommitOpen ? "down" : "right"}`} />
+          <i className="bi bi-check2-circle" style={{ color: "#22c55e" }} />
+          onCommit (commit 成功後の追加処理、任意)
+          {(step.onCommit ?? []).length > 0 && (
+            <span className="badge bg-success ms-1" style={{ fontSize: "0.7rem" }}>
+              {(step.onCommit ?? []).length}
+            </span>
+          )}
+        </button>
+        {onCommitOpen && (
+          <div className="border rounded p-2 mt-1" style={{ background: "rgba(34, 197, 94, 0.04)" }}>
+            <InlineStepList
+              steps={step.onCommit ?? []}
+              parentLabel="C"
+              allSteps={allSteps}
+              tables={tables}
+              screens={screens}
+              commonGroups={commonGroups}
+              onChange={(newSteps) =>
+                onChange({ onCommit: newSteps.length > 0 ? newSteps : undefined })
+              }
+              onCommit={onCommit}
+              onNavigateCommon={onNavigateCommon}
+              validationErrors={validationErrors}
+              conventions={conventions}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* onRollback (折りたたみ) */}
+      <div className="mb-2" data-field-path="onRollback">
+        <button
+          type="button"
+          className="btn btn-link btn-sm p-0 d-flex align-items-center gap-1"
+          onClick={() => setOnRollbackOpen(!onRollbackOpen)}
+          style={{ fontSize: "0.85rem", textDecoration: "none" }}
+        >
+          <i className={`bi bi-chevron-${onRollbackOpen ? "down" : "right"}`} />
+          <i className="bi bi-arrow-counterclockwise" style={{ color: "#ef4444" }} />
+          onRollback (rollback 後の補償処理、任意)
+          {(step.onRollback ?? []).length > 0 && (
+            <span className="badge bg-danger ms-1" style={{ fontSize: "0.7rem" }}>
+              {(step.onRollback ?? []).length}
+            </span>
+          )}
+        </button>
+        {onRollbackOpen && (
+          <div className="border rounded p-2 mt-1" style={{ background: "rgba(239, 68, 68, 0.04)" }}>
+            <InlineStepList
+              steps={step.onRollback ?? []}
+              parentLabel="R"
+              allSteps={allSteps}
+              tables={tables}
+              screens={screens}
+              commonGroups={commonGroups}
+              onChange={(newSteps) =>
+                onChange({ onRollback: newSteps.length > 0 ? newSteps : undefined })
+              }
+              onCommit={onCommit}
+              onNavigateCommon={onNavigateCommon}
+              validationErrors={validationErrors}
+              conventions={conventions}
+            />
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/designer/src/schemas/conventionsValidator.ts
+++ b/designer/src/schemas/conventionsValidator.ts
@@ -290,6 +290,11 @@ function walkSteps(
       if (step.elseBranch) walkSteps(step.elseBranch.steps, `${path}.elseBranch.steps`, catalog, issues);
     }
     if (step.type === "loop") walkSteps((step as LoopStep).steps, `${path}.steps`, catalog, issues);
+    if (step.type === "transactionScope") {
+      walkSteps(step.steps, `${path}.steps`, catalog, issues);
+      if (step.onCommit) walkSteps(step.onCommit, `${path}.onCommit`, catalog, issues);
+      if (step.onRollback) walkSteps(step.onRollback, `${path}.onRollback`, catalog, issues);
+    }
     if (step.type === "externalSystem") {
       Object.entries(step.outcomes ?? {}).forEach(([k, spec]) => {
         if (spec?.sideEffects) walkSteps(spec.sideEffects, `${path}.outcomes.${k}.sideEffects`, catalog, issues);

--- a/designer/src/schemas/identifierScope.ts
+++ b/designer/src/schemas/identifierScope.ts
@@ -132,6 +132,11 @@ function walkSteps(
         : loopItems;
       walkSteps(loopStep.steps, `${path}.steps`, known, childLoopItems, issues);
     }
+    if (step.type === "transactionScope") {
+      walkSteps(step.steps, `${path}.steps`, known, loopItems, issues);
+      if (step.onCommit) walkSteps(step.onCommit, `${path}.onCommit`, known, loopItems, issues);
+      if (step.onRollback) walkSteps(step.onRollback, `${path}.onRollback`, known, loopItems, issues);
+    }
     if (step.type === "externalSystem") {
       Object.entries(step.outcomes ?? {}).forEach(([k, spec]) => {
         if (spec?.sideEffects) {

--- a/designer/src/schemas/process-flow.schema.test.ts
+++ b/designer/src/schemas/process-flow.schema.test.ts
@@ -1356,6 +1356,139 @@ describe("process-flow.schema.json — secretsCatalog.values (#414)", () => {
   });
 });
 
+describe("process-flow.schema.json — TransactionScopeStep (#415)", () => {
+  const makeFlow = (step: object) => ({
+    id: "a", name: "x", type: "screen", description: "",
+    actions: [{
+      id: "act-1", name: "test", trigger: "submit",
+      steps: [step],
+    }],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  });
+
+  const minimalTx = {
+    id: "tx-1",
+    type: "transactionScope",
+    description: "TX",
+    steps: [
+      { id: "s1", type: "dbAccess", description: "", tableName: "orders", operation: "INSERT" },
+    ],
+  };
+
+  it("最小構成 (id/type/description/steps) accept", () => {
+    const ok = validate(makeFlow(minimalTx));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("isolationLevel + propagation + timeoutMs + rollbackOn accept", () => {
+    const ok = validate(makeFlow({
+      ...minimalTx,
+      isolationLevel: "REPEATABLE_READ",
+      propagation: "REQUIRES_NEW",
+      timeoutMs: 5000,
+      rollbackOn: ["STOCK_SHORTAGE", "VALIDATION"],
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("isolationLevel enum 外は reject", () => {
+    expect(validate(makeFlow({
+      ...minimalTx,
+      isolationLevel: "READ_UNCOMMITTED",
+    }))).toBe(false);
+  });
+
+  it("propagation enum 外は reject", () => {
+    expect(validate(makeFlow({
+      ...minimalTx,
+      propagation: "MANDATORY",
+    }))).toBe(false);
+  });
+
+  it("timeoutMs 負数は reject", () => {
+    expect(validate(makeFlow({
+      ...minimalTx,
+      timeoutMs: -1,
+    }))).toBe(false);
+  });
+
+  it("steps 欠落は reject", () => {
+    expect(validate(makeFlow({
+      id: "tx-1", type: "transactionScope", description: "",
+    }))).toBe(false);
+  });
+
+  it("description 欠落は reject", () => {
+    expect(validate(makeFlow({
+      id: "tx-1", type: "transactionScope", steps: [],
+    }))).toBe(false);
+  });
+
+  it("onCommit / onRollback に Step を入れて accept", () => {
+    const ok = validate(makeFlow({
+      ...minimalTx,
+      onCommit: [
+        { id: "c1", type: "log", description: "", level: "info", message: "committed" },
+      ],
+      onRollback: [
+        { id: "r1", type: "log", description: "", level: "warn", message: "rolled back" },
+      ],
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("ネストした TransactionScopeStep accept", () => {
+    const ok = validate(makeFlow({
+      ...minimalTx,
+      steps: [
+        {
+          id: "tx-inner", type: "transactionScope", description: "ネスト",
+          propagation: "NESTED",
+          steps: [
+            { id: "s2", type: "dbAccess", description: "", tableName: "x", operation: "UPDATE" },
+          ],
+        },
+      ],
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("空 steps[] は schema 上 accept (UI 側の warning で対応)", () => {
+    expect(validate(makeFlow({
+      id: "tx-1", type: "transactionScope", description: "", steps: [],
+    }))).toBe(true);
+  });
+
+  it("rollbackOn の要素が string 以外なら reject", () => {
+    expect(validate(makeFlow({
+      ...minimalTx,
+      rollbackOn: [123],
+    }))).toBe(false);
+  });
+
+  it("未知フィールドは reject (additionalProperties: false)", () => {
+    expect(validate(makeFlow({
+      ...minimalTx,
+      unknownField: "x",
+    }))).toBe(false);
+  });
+
+  it("StepType enum に transactionScope が含まれる (StepBase + 親 step として使える)", () => {
+    // 親 step の subSteps に置けることの確認
+    const ok = validate(makeFlow({
+      id: "parent", type: "other", description: "",
+      subSteps: [{ ...minimalTx, id: "child-tx" }],
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+});
+
 describe("process-flow.schema.json — ambientOverrides (#369)", () => {
   const base = {
     id: "a", name: "x", type: "screen", description: "",

--- a/designer/src/schemas/referentialIntegrity.ts
+++ b/designer/src/schemas/referentialIntegrity.ts
@@ -125,6 +125,11 @@ function walkSteps(
     if (step.type === "loop") {
       walkSteps(step.steps, `${path}.steps`, visit);
     }
+    if (step.type === "transactionScope") {
+      walkSteps(step.steps, `${path}.steps`, visit);
+      if (step.onCommit) walkSteps(step.onCommit, `${path}.onCommit`, visit);
+      if (step.onRollback) walkSteps(step.onRollback, `${path}.onRollback`, visit);
+    }
     if (step.type === "externalSystem") {
       Object.entries(step.outcomes ?? {}).forEach(([k, spec]) => {
         if (spec?.sideEffects) {
@@ -213,6 +218,18 @@ function checkStep(
             message: `BranchConditionVariant.errorCode "${c.errorCode}" が ProcessFlow.errorCatalog に存在しません`,
           });
         }
+      }
+    });
+  }
+  if (step.type === "transactionScope" && step.rollbackOn && hasErrorCatalog) {
+    step.rollbackOn.forEach((code, ci) => {
+      if (!errorCodes.has(code)) {
+        issues.push({
+          path: `${path}.rollbackOn[${ci}]`,
+          code: "UNKNOWN_ERROR_CODE",
+          value: code,
+          message: `TransactionScopeStep.rollbackOn[${ci}] "${code}" が ProcessFlow.errorCatalog に存在しません`,
+        });
       }
     });
   }

--- a/designer/src/schemas/sqlColumnValidator.ts
+++ b/designer/src/schemas/sqlColumnValidator.ts
@@ -228,6 +228,11 @@ function walkSteps(steps: Step[], basePath: string, visit: (s: Step, p: string) 
       if (step.elseBranch) walkSteps(step.elseBranch.steps, `${path}.elseBranch.steps`, visit);
     }
     if (step.type === "loop") walkSteps(step.steps, `${path}.steps`, visit);
+    if (step.type === "transactionScope") {
+      walkSteps(step.steps, `${path}.steps`, visit);
+      if (step.onCommit) walkSteps(step.onCommit, `${path}.onCommit`, visit);
+      if (step.onRollback) walkSteps(step.onRollback, `${path}.onRollback`, visit);
+    }
     if (step.type === "externalSystem") {
       Object.entries(step.outcomes ?? {}).forEach(([k, spec]) => {
         if (spec?.sideEffects) walkSteps(spec.sideEffects, `${path}.outcomes.${k}.sideEffects`, visit);

--- a/designer/src/store/processFlowStore.ts
+++ b/designer/src/store/processFlowStore.ts
@@ -262,6 +262,14 @@ export function createDefaultStep(type: StepType): Step {
         approvers: [],
         quorum: { type: "any" },
       };
+    case "transactionScope":
+      return {
+        ...base,
+        type: "transactionScope",
+        isolationLevel: "READ_COMMITTED",
+        propagation: "REQUIRED",
+        steps: [],
+      };
     case "other":
       return { ...base, type: "other" };
   }
@@ -279,6 +287,11 @@ function countGroupNotes(group: ProcessFlow): number {
         if (s.elseBranch) visit(s.elseBranch.steps);
       }
       if (s.type === "loop") visit(s.steps);
+      if (s.type === "transactionScope") {
+        visit(s.steps);
+        if (s.onCommit) visit(s.onCommit);
+        if (s.onRollback) visit(s.onRollback);
+      }
     }
   };
   for (const a of group.actions) visit(a.steps);

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -16,7 +16,8 @@ export type StepType =
   | "compute"          // 計算式 / 変数代入 (#174)
   | "return"           // HTTP レスポンス返却 (#178)
   | "log" | "audit"    // アプリケーションログ / 監査ログ
-  | "workflow"         // 承認ワークフロー
+  | "workflow"         // 承認ワークフロー (#411)
+  | "transactionScope" // 複数 DB 操作を 1 TX でまとめる meta-step (#415)
   | "other";           // その他
 
 /** ステップ種別ラベル */
@@ -37,6 +38,7 @@ export const STEP_TYPE_LABELS: Record<StepType, string> = {
   log: "ログ出力",
   audit: "監査ログ",
   workflow: "承認ワークフロー",
+  transactionScope: "TX スコープ",
   other: "その他",
 };
 
@@ -58,6 +60,7 @@ export const STEP_TYPE_ICONS: Record<StepType, string> = {
   log: "bi-journal-text",
   audit: "bi-shield-check",
   workflow: "bi-people-fill",
+  transactionScope: "bi-shield-fill",
   other: "bi-three-dots",
 };
 
@@ -79,6 +82,7 @@ export const STEP_TYPE_COLORS: Record<StepType, string> = {
   log: "#64748b",
   audit: "#a855f7",
   workflow: "#0d9488",
+  transactionScope: "#dc2626",
   other: "#9ca3af",
 };
 
@@ -806,6 +810,7 @@ export const WORKFLOW_PATTERN_VALUES: readonly WorkflowPattern[] = [
   "discussion",
   "ad-hoc",
 ] as const;
+
 export interface WorkflowApprover {
   /** RBAC catalog role key */
   role: string;
@@ -837,6 +842,50 @@ export interface WorkflowStep extends StepBase {
   escalateTo?: WorkflowEscalateTo;
 }
 
+/** TX 分離レベル (#415) */
+export type TransactionIsolationLevel =
+  | "READ_COMMITTED"
+  | "REPEATABLE_READ"
+  | "SERIALIZABLE";
+
+/** TX 伝播モード (#415、Spring / EF Core 由来) */
+export type TransactionPropagation =
+  | "REQUIRED"     // 既存 TX に参加、無ければ新規開始 (既定)
+  | "REQUIRES_NEW" // 既存 TX を一時停止して新規 TX を開始
+  | "NESTED";      // 既存 TX 内に savepoint を作る
+
+/**
+ * 複数 DB 操作を 1 TX でまとめる meta-step (#415)。
+ * Power Platform Changeset / EF Core TransactionScope 由来。
+ *
+ * 既存 `StepBase.txBoundary` (begin/member/end) は単独ステップが TX 境界に属することを宣言する平坦
+ * モデルだが、本 step は「TX 範囲を構造的にネストして表現」する。複数 DbAccess を確実に同一 TX に
+ * くくるには TransactionScopeStep を用いる方が誤りが少ない。
+ *
+ * @see docs/spec/process-flow-transaction.md
+ */
+export interface TransactionScopeStep extends StepBase {
+  type: "transactionScope";
+  /** TX 分離レベル。既定 "READ_COMMITTED" */
+  isolationLevel?: TransactionIsolationLevel;
+  /** TX 伝播モード。既定 "REQUIRED" */
+  propagation?: TransactionPropagation;
+  /** TX タイムアウト (ms)。未指定はランタイム既定 */
+  timeoutMs?: number;
+  /**
+   * rollback を引き起こす errorCode の配列。ProcessFlow.errorCatalog のキー参照。
+   * 列挙されたコードが TX 内で throw された場合に rollback される。
+   * 未指定時は「すべての例外で rollback」(ランタイム既定)。
+   */
+  rollbackOn?: string[];
+  /** TX 内で実行する step 列。1 TX に含めたい DB / 外部呼出を順序通りに並べる */
+  steps: Step[];
+  /** TX commit 成功後に実行する step 列 (任意)。例: 通知送信、キャッシュ無効化 */
+  onCommit?: Step[];
+  /** TX rollback 後に実行する step 列 (任意・補償処理)。例: Stripe authorize の cancel、Slack 通知 */
+  onRollback?: Step[];
+}
+
 export type Step =
   | ValidationStep
   | DbAccessStep
@@ -854,6 +903,7 @@ export type Step =
   | LogStep
   | AuditStep
   | WorkflowStep
+  | TransactionScopeStep
   | OtherStep;
 
 // ── アクション定義 ───────────────────────────────────────────────────────

--- a/designer/src/utils/actionMigration.ts
+++ b/designer/src/utils/actionMigration.ts
@@ -141,6 +141,16 @@ function migrateStepInPlace(raw: unknown): Step {
     }
   } else if (step.type === "loop" && Array.isArray(step.steps)) {
     step.steps = (step.steps as unknown[]).map(migrateStepInPlace);
+  } else if (step.type === "transactionScope") {
+    if (Array.isArray(step.steps)) {
+      step.steps = (step.steps as unknown[]).map(migrateStepInPlace);
+    }
+    if (Array.isArray(step.onCommit)) {
+      step.onCommit = (step.onCommit as unknown[]).map(migrateStepInPlace);
+    }
+    if (Array.isArray(step.onRollback)) {
+      step.onRollback = (step.onRollback as unknown[]).map(migrateStepInPlace);
+    }
   }
 
   // #172: outcome.sideEffects 内のステップも再帰的にマイグレーション

--- a/designer/src/utils/actionUtils.ts
+++ b/designer/src/utils/actionUtils.ts
@@ -53,6 +53,11 @@ function walkSteps(steps: Step[], visit: (step: Step) => void): void {
       if (step.elseBranch) walkSteps(step.elseBranch.steps, visit);
     }
     if (step.type === "loop") walkSteps(step.steps, visit);
+    if (step.type === "transactionScope") {
+      walkSteps(step.steps, visit);
+      if (step.onCommit) walkSteps(step.onCommit, visit);
+      if (step.onRollback) walkSteps(step.onRollback, visit);
+    }
   }
 }
 

--- a/designer/src/utils/actionValidation.ts
+++ b/designer/src/utils/actionValidation.ts
@@ -21,6 +21,11 @@ function collectAllIds(steps: Step[], ids: Set<string>): void {
       if (step.elseBranch) collectAllIds(step.elseBranch.steps, ids);
     }
     if (step.type === "loop") collectAllIds(step.steps, ids);
+    if (step.type === "transactionScope") {
+      collectAllIds(step.steps, ids);
+      if (step.onCommit) collectAllIds(step.onCommit, ids);
+      if (step.onRollback) collectAllIds(step.onRollback, ids);
+    }
   }
 }
 
@@ -59,6 +64,14 @@ function validateSteps(
           errors.push({ stepId: step.id, severity: "warning", message: "コレクションが未入力です" });
         }
         validateSteps(step.steps, loopDepth + 1, errors, allIds);
+        break;
+      case "transactionScope":
+        if (step.steps.length === 0) {
+          errors.push({ stepId: step.id, severity: "warning", message: "TX スコープに 1 つ以上のステップを配置してください" });
+        }
+        validateSteps(step.steps, loopDepth, errors, allIds);
+        if (step.onCommit) validateSteps(step.onCommit, loopDepth, errors, allIds);
+        if (step.onRollback) validateSteps(step.onRollback, loopDepth, errors, allIds);
         break;
       case "jump":
         if (!step.jumpTo) {

--- a/designer/src/utils/specExporter.ts
+++ b/designer/src/utils/specExporter.ts
@@ -313,6 +313,15 @@ function toSpecStep(s: Step, index: number): SpecStep {
     case "jump":
       detail.jumpTo = s.jumpTo;
       break;
+    case "transactionScope":
+      if (s.isolationLevel) detail.isolationLevel = s.isolationLevel;
+      if (s.propagation) detail.propagation = s.propagation;
+      if (s.timeoutMs !== undefined) detail.timeoutMs = s.timeoutMs;
+      if (s.rollbackOn && s.rollbackOn.length > 0) detail.rollbackOn = s.rollbackOn;
+      detail.steps = s.steps;
+      if (s.onCommit) detail.onCommit = s.onCommit;
+      if (s.onRollback) detail.onRollback = s.onRollback;
+      break;
   }
   return {
     number: getStepLabel(index),

--- a/docs/sample-project/process-flows/cccccccc-0005-4000-8000-cccccccccccc.json
+++ b/docs/sample-project/process-flows/cccccccc-0005-4000-8000-cccccccccccc.json
@@ -543,8 +543,177 @@
           }
         }
       ]
+    },
+    {
+      "id": "act-orderreg-003",
+      "name": "注文確定ボタン (TX スコープ版・参考)",
+      "trigger": "submit",
+      "maturity": "draft",
+      "description": "act-orderreg-002 の TX 部分 (orders INSERT + order_items INSERT + inventory UPDATE) を TransactionScopeStep 1 つで宣言する参考実装 (#415)。v1.3 平坦 txBoundary との比較サンプルとして併存させる。",
+      "requiredPermissions": ["order.create"],
+      "responses": [
+        { "id": "201-success", "status": 201, "bodySchema": { "typeRef": "OrderRegisterResponse" }, "description": "登録成功" },
+        { "id": "400-validation", "status": 400, "bodySchema": { "typeRef": "ApiError" }, "description": "バリデーション違反" },
+        { "id": "404-not-found", "status": 404, "bodySchema": { "typeRef": "ApiError" }, "description": "顧客/商品が存在しない" },
+        { "id": "402-payment-failed", "status": 402, "bodySchema": { "typeRef": "ApiError" }, "description": "決済拒否" },
+        { "id": "409-stock-shortage", "status": 409, "bodySchema": { "typeRef": "ApiError" }, "description": "在庫不足 (TX rollback 起因)" }
+      ],
+      "inputs": [
+        { "name": "customerId", "label": "顧客ID", "type": "number", "required": true },
+        {
+          "name": "enrichedItems",
+          "label": "明細 (前段で構築済)",
+          "type": {
+            "kind": "array",
+            "itemType": {
+              "kind": "object",
+              "fields": [
+                { "name": "itemId", "type": "number", "required": true },
+                { "name": "name", "type": "string", "required": true },
+                { "name": "quantity", "type": "number", "required": true },
+                { "name": "unit_price", "type": "number", "required": true },
+                { "name": "subtotal", "type": "number", "required": true }
+              ]
+            }
+          }
+        },
+        { "name": "subtotal", "label": "小計", "type": "number", "required": true },
+        { "name": "taxAmount", "label": "税額", "type": "number", "required": true },
+        { "name": "totalAmount", "label": "合計", "type": "number", "required": true },
+        { "name": "paymentMethod", "label": "支払方法", "type": "string", "required": true },
+        { "name": "paymentAuth", "label": "Stripe authorize 結果", "type": { "kind": "object", "fields": [
+          { "name": "id", "type": "string" },
+          { "name": "status", "type": "string" }
+        ]}},
+        { "name": "orderNotes", "label": "備考", "type": "string", "required": false }
+      ],
+      "outputs": [
+        { "name": "orderId", "type": "number" },
+        { "name": "orderNumber", "type": "string" }
+      ],
+      "steps": [
+        {
+          "id": "step-or3-001",
+          "type": "transactionScope",
+          "maturity": "draft",
+          "description": "注文登録 + 在庫減算を 1 TX でまとめる (Power Platform Changeset 由来)",
+          "isolationLevel": "READ_COMMITTED",
+          "propagation": "REQUIRED",
+          "timeoutMs": 5000,
+          "rollbackOn": ["VALIDATION", "STOCK_SHORTAGE"],
+          "steps": [
+            {
+              "id": "step-or3-001-1",
+              "type": "dbAccess",
+              "maturity": "draft",
+              "description": "注文ヘッダ INSERT",
+              "tableName": "orders",
+              "tableId": "bbbbbbbb-0003-4000-8000-bbbbbbbbbbbb",
+              "operation": "INSERT",
+              "sql": "INSERT INTO orders (customer_id, order_date, subtotal, tax_amount, total_amount, payment_method, payment_id, status, notes) VALUES (@customerId, CURRENT_TIMESTAMP, @subtotal, @taxAmount, @totalAmount, @paymentMethod, @paymentAuth?.id, 'processing', @orderNotes) RETURNING id, order_number",
+              "outputBinding": "registeredOrder"
+            },
+            {
+              "id": "step-or3-001-2",
+              "type": "loop",
+              "maturity": "draft",
+              "description": "明細 INSERT",
+              "loopKind": "collection",
+              "collectionSource": "@enrichedItems",
+              "collectionItemName": "eitem",
+              "steps": [
+                {
+                  "id": "step-or3-001-2-1",
+                  "type": "dbAccess",
+                  "maturity": "draft",
+                  "description": "order_items INSERT",
+                  "tableName": "order_items",
+                  "tableId": "bbbbbbbb-0004-4000-8000-bbbbbbbbbbbb",
+                  "operation": "INSERT",
+                  "sql": "INSERT INTO order_items (order_id, item_name, quantity, unit_price, subtotal) VALUES (@registeredOrder.id, @eitem.name, @eitem.quantity, @eitem.unit_price, @eitem.subtotal)"
+                }
+              ]
+            },
+            {
+              "id": "step-or3-001-3",
+              "type": "loop",
+              "maturity": "draft",
+              "description": "在庫引当 (条件付き UPDATE)",
+              "loopKind": "collection",
+              "collectionSource": "@enrichedItems",
+              "collectionItemName": "eitem",
+              "steps": [
+                {
+                  "id": "step-or3-001-3-1",
+                  "type": "dbAccess",
+                  "maturity": "draft",
+                  "description": "stock 減算",
+                  "tableName": "inventory",
+                  "operation": "UPDATE",
+                  "sql": "UPDATE inventory SET stock = stock - @eitem.quantity, reserved = reserved + @eitem.quantity, updated_at = CURRENT_TIMESTAMP WHERE item_id = @eitem.itemId AND stock >= @eitem.quantity",
+                  "affectedRowsCheck": {
+                    "operator": ">",
+                    "expected": 0,
+                    "onViolation": "throw",
+                    "errorCode": "STOCK_SHORTAGE",
+                    "description": "並行引当による在庫切れ → TX ROLLBACK (rollbackOn により本 TX 全体を巻戻す)"
+                  }
+                }
+              ]
+            }
+          ],
+          "onCommit": [
+            {
+              "id": "step-or3-001-c1",
+              "type": "log",
+              "maturity": "draft",
+              "description": "TX commit 成功ログ",
+              "level": "info",
+              "message": "注文 @registeredOrder.order_number を確定 (顧客 @customerId)",
+              "category": "order.lifecycle",
+              "structuredData": {
+                "orderId": "@registeredOrder.id",
+                "totalAmount": "@totalAmount"
+              }
+            }
+          ],
+          "onRollback": [
+            {
+              "id": "step-or3-001-r1",
+              "type": "log",
+              "maturity": "draft",
+              "description": "TX rollback ログ",
+              "level": "warn",
+              "message": "注文 TX rollback (顧客 @customerId)",
+              "category": "order.lifecycle"
+            },
+            {
+              "id": "step-or3-001-r2",
+              "type": "externalSystem",
+              "maturity": "draft",
+              "description": "Stripe authorize cancel (rollback の補償)",
+              "runIf": "@paymentAuth != null",
+              "systemName": "Stripe Japan",
+              "systemRef": "stripe",
+              "httpCall": {
+                "method": "POST",
+                "path": "/v1/payment_intents/@paymentAuth.id/cancel"
+              },
+              "idempotencyKey": "cancel-@paymentAuth.id",
+              "externalChain": { "chainId": "stripe-pi-order-tx", "phase": "cancel" }
+            }
+          ]
+        },
+        {
+          "id": "step-or3-002",
+          "type": "return",
+          "maturity": "draft",
+          "description": "201 成功",
+          "bodyExpression": "{ orderId: @registeredOrder.id, orderNumber: @registeredOrder.order_number }"
+        }
+      ]
     }
   ],
   "createdAt": "2026-04-20T19:00:00.000Z",
-  "updatedAt": "2026-04-20T19:00:00.000Z"
+  "updatedAt": "2026-04-25T12:00:00.000Z"
 }

--- a/docs/sample-project/process-flows/cccccccc-0005-4000-8000-cccccccccccc.json
+++ b/docs/sample-project/process-flows/cccccccc-0005-4000-8000-cccccccccccc.json
@@ -556,7 +556,8 @@
         { "id": "400-validation", "status": 400, "bodySchema": { "typeRef": "ApiError" }, "description": "バリデーション違反" },
         { "id": "404-not-found", "status": 404, "bodySchema": { "typeRef": "ApiError" }, "description": "顧客/商品が存在しない" },
         { "id": "402-payment-failed", "status": 402, "bodySchema": { "typeRef": "ApiError" }, "description": "決済拒否" },
-        { "id": "409-stock-shortage", "status": 409, "bodySchema": { "typeRef": "ApiError" }, "description": "在庫不足 (TX rollback 起因)" }
+        { "id": "409-stock-shortage", "status": 409, "bodySchema": { "typeRef": "ApiError" }, "description": "在庫不足 (TX rollback 起因)" },
+        { "id": "504-timeout", "status": 504, "bodySchema": { "typeRef": "ApiError" }, "description": "SLA タイムアウト" }
       ],
       "inputs": [
         { "name": "customerId", "label": "顧客ID", "type": "number", "required": true },

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -18,6 +18,7 @@
 | [process-flow-workflow.md](process-flow-workflow.md) | WorkflowStep / WorkflowPattern (承認ワークフロー標準 11 パターン) | #411 |
 | [process-flow-env-vars.md](process-flow-env-vars.md) | 環境変数カタログ (`envVarsCatalog`) — 環境別 (dev/staging/prod) の型付き設定値 | #414 |
 | [process-flow-secrets.md](process-flow-secrets.md) | Secrets カタログ (`secretsCatalog`) — 秘匿値メタデータ + 環境別参照式 | #261 / #414 |
+| [process-flow-transaction.md](process-flow-transaction.md) | `TransactionScopeStep` (複数 DB 操作を 1 TX でまとめる meta-step) と既存 `txBoundary` の関係 | #415 |
 | [screen-items.md](screen-items.md) | 画面項目定義 (フォーム系バリデーション 3 層のうち「画面」層) — **ドラフト v0.1** | #318 |
 
 **一次成果物**: JSON スキーマ [`schemas/process-flow.schema.json`](../../schemas/process-flow.schema.json) ([README](../../schemas/README.md))。仕様書と突合する機械可読版。

--- a/docs/spec/process-flow-transaction.md
+++ b/docs/spec/process-flow-transaction.md
@@ -1,0 +1,166 @@
+# Process Flow — Transaction Scope (`TransactionScopeStep`)
+
+ISSUE: #415 / 親 #396 (Power Platform Changeset / EF Core TransactionScope 由来)
+
+複数 DB 操作を atomic な TX 単位でラップする meta-step。「注文登録 + 在庫減算」のように、一連の DB 書き込みを「全部成功するか、何も無かったかにする」のを宣言的に表現する。
+
+## §1 動機
+
+業務システムでは「複数の DB 操作を 1 TX でまとめる」が頻出。例:
+
+- 注文登録: `orders` INSERT + `order_items` INSERT + `inventory` UPDATE
+- 残高振替: `accounts` UPDATE × 2 (引落+入金)
+- ユーザー削除: 関連テーブル群の cascade UPDATE
+
+既存 `StepBase.txBoundary` は `{role: "begin"|"member"|"end", txId}` の平坦モデルで、同一 `txId` を持つ step 群が単一 TX を構成する。これは下位互換のため残すが、**範囲が構造ではなく ID 一致で表現される**ため、以下の問題がある:
+
+- step を移動・複製した時に `txId` の整合性が崩れやすい
+- `begin` から `end` までの範囲が一目で読みづらい
+- ネストが表現できない
+
+`TransactionScopeStep` は **TX の範囲を構造的にネストして表現**する。範囲は `steps[]` 配列で明示。AI / 実装側はこれを 1 まとまりで TX として扱う。
+
+## §2 スキーマ
+
+```jsonc
+{
+  "id": "tx-001",
+  "type": "transactionScope",
+  "description": "注文登録 + 在庫減算",
+  "isolationLevel": "READ_COMMITTED",      // optional・既定 "READ_COMMITTED"
+  "propagation": "REQUIRED",                // optional・既定 "REQUIRED"
+  "timeoutMs": 5000,                        // optional
+  "rollbackOn": ["VALIDATION", "STOCK_SHORTAGE"],  // optional
+  "steps": [ /* TX 内で実行する step 列 */ ],
+  "onCommit": [ /* commit 後の追加処理、optional */ ],
+  "onRollback": [ /* rollback 後の補償処理、optional */ ]
+}
+```
+
+`steps[]` 内には任意の Step を再帰的に置ける (LoopStep / BranchStep / 別の TransactionScopeStep もネスト可)。
+
+### §2.1 `isolationLevel`
+
+| 値 | 意味 |
+|---|---|
+| `READ_COMMITTED` (既定) | commit 済データのみ可視。phantom read / non-repeatable read を許容 |
+| `REPEATABLE_READ` | 同一 TX 内で同じ行を再読すると常に同じ結果 (phantom は許容) |
+| `SERIALIZABLE` | 直列実行と等価。phantom read も防止 (実装で blocking / abort のいずれか) |
+
+選定指針: 業務系 DB 書込は通常 `READ_COMMITTED` で十分。在庫引当・残高振替など **「同じ行を読んで条件付き書込」** をする TX は `REPEATABLE_READ` 以上 (または `affectedRowsCheck` による楽観ロックで補完) を推奨。
+
+### §2.2 `propagation`
+
+Spring `@Transactional` / EF Core `TransactionScopeOption` 由来。既存 TX が呼び出し側にある場合の挙動を制御:
+
+| 値 | 既存 TX が無い場合 | 既存 TX がある場合 |
+|---|---|---|
+| `REQUIRED` (既定) | 新規 TX 開始 | 既存 TX に参加 (内側の rollback は外側にも波及) |
+| `REQUIRES_NEW` | 新規 TX 開始 | 既存 TX を一時停止し、新規 TX を独立に開始/commit (内側の結果は外側に影響しない) |
+| `NESTED` | 新規 TX 開始 | 既存 TX 内で savepoint を作る (内側だけ部分 rollback 可能) |
+
+選定指針: 大半は `REQUIRED`。**監査ログ・通知記録など「呼び元 TX とは独立に必ず残したい」処理**は `REQUIRES_NEW`。**try-catch で部分 rollback したい**場合は `NESTED`。
+
+### §2.3 `timeoutMs`
+
+TX 全体のタイムアウト (ms)。経過後はランタイムが TX を rollback する。未指定はランタイム既定 (DB / フレームワークが決める)。
+
+### §2.4 `rollbackOn`
+
+rollback を引き起こす `errorCode` の配列。`ProcessFlow.errorCatalog` のキー参照。
+
+- 列挙されたコードが TX 内で throw された場合のみ rollback
+- 未指定時は **「すべての例外で rollback」** がランタイム既定 (Spring の `RuntimeException` 既定挙動と同じ)
+- `affectedRowsCheck.errorCode` (例: `STOCK_SHORTAGE`) を含めると、影響行数違反でも rollback できる
+
+例:
+
+```jsonc
+"rollbackOn": ["STOCK_SHORTAGE"]
+```
+
+→ `affectedRowsCheck.onViolation: "throw"` で `errorCode: "STOCK_SHORTAGE"` が投げられた時に TX 全体が rollback。それ以外の例外は実装側の例外伝播ルールに委ねる。
+
+### §2.5 `steps[]`
+
+TX 内で実行する step 列。順序通りに実行され、TX が始まってから commit / rollback の判定までを含む。
+
+- 任意の Step type を置ける (DbAccessStep / LoopStep / BranchStep / TransactionScopeStep ネスト可)
+- `ExternalSystemStep` を入れた場合の意味論は **実装依存** (DB TX に外部 HTTP は本質的に巻き込めない)。Saga 的に補償をかけるか、TX 外に出すのが基本
+
+### §2.6 `onCommit[]`
+
+TX が commit 成功した**後**に実行する step 列。任意。例:
+
+- 通知メール送信 (`ExternalSystemStep` with `fireAndForget: true`)
+- キャッシュ無効化
+- 監査ログ (`AuditStep`)
+
+`onCommit` の step は **TX の外** で実行されるため、ここでの失敗は元の TX を巻き戻さない (best-effort)。
+
+### §2.7 `onRollback[]`
+
+TX が rollback された**後**に実行する step 列。任意・補償処理 (Saga compensation) として使う:
+
+- Stripe `authorize` の `cancel` (DB rollback で予約取消したので決済も取消)
+- 運用通知 (Slack 等)
+- ログ記録 (`LogStep`)
+
+`onRollback` の step は **TX の外** で実行されるため、ここでの失敗は元の rollback を撤回しない。
+
+## §3 既存 `StepBase.txBoundary` との関係
+
+両者は **共存** する。役割は明確に分かれる:
+
+| | `StepBase.txBoundary` | `TransactionScopeStep` |
+|---|---|---|
+| モデル | 平坦 (`{role, txId}` で同一 `txId` の step 群が 1 TX) | 構造的 (`steps[]` 配列で範囲を表現) |
+| 表現 | 単独ステップが TX 境界の一部であることを宣言 | 複数ステップを 1 TX としてくくる meta-step |
+| ネスト | 不可 (txId 重複を禁止しない実装依存) | 可 (ネストは `propagation` で制御) |
+| `onCommit`/`onRollback` | 持たない | 持つ |
+| 移動・複製耐性 | 弱 (txId の同期が手動) | 強 (構造ごと移動) |
+| 既存サンプルでの位置 | `cccccccc-0005` の `step-or2-007 ~ 009` (begin/member/end で `tx-order-main` を構成) | 同じファイルの `act-orderreg-003` (新規追加・参考実装) |
+
+### §3.1 移行ガイダンス
+
+新規データは **`TransactionScopeStep` を優先** する。既存の平坦 `txBoundary` は当面残し、リファクタリング時に置き換える運用とする。
+
+平坦 → 構造化の機械変換は 1:1 でないことに注意:
+
+- 平坦の `begin/member/end` は range が連続でない (途中に TX 外 step が挟まる) ことを許容
+- `TransactionScopeStep.steps[]` は連続範囲のみ。挟まる TX 外処理は前後に出す必要あり
+
+### §3.2 同一 step 内での併用は禁止
+
+`TransactionScopeStep` 自身に `txBoundary` を付けたデータ (例: `transactionScope` の親 step が begin で、子の step が member) は **意味曖昧** のため使ってはいけない。`TransactionScopeStep` を使うなら、その内部 step には `txBoundary` を付けない (実装側は付いていても無視する)。
+
+## §4 ランタイム規約
+
+[`process-flow-runtime-conventions.md`](process-flow-runtime-conventions.md) を補足する形で、TX スコープに関するランタイム挙動:
+
+1. **commit タイミング**: `steps[]` の最後の step が成功で抜けた時点で commit。途中の throw は (rollbackOn にマッチすれば) rollback
+2. **`onCommit` / `onRollback` の独立性**: これらは TX の外で実行され、自身の失敗は元の TX 結果を覆さない
+3. **ネスト時の `REQUIRES_NEW`**: 親 TX が動いている時に `REQUIRES_NEW` の TransactionScopeStep に入ると、親 TX が一時停止して内側 TX が独立 commit/rollback する。内側 commit 後に親 TX が rollback しても、内側の commit は取り消されない
+4. **ネスト時の `NESTED`**: savepoint を使う。内側 rollback は親 TX の savepoint 復元、親 rollback は savepoint も含めて全 rollback
+5. **`tryCatch` Branch との組合せ**: TransactionScopeStep の外側で `kind: "tryCatch"` Branch を置けば、TX rollback で throw されたエラーを捕捉できる
+
+## §5 サンプル
+
+`docs/sample-project/process-flows/cccccccc-0005-...json` の `actions[1]` (`act-orderreg-003`) を参照。**注文登録 + 在庫減算** を `TransactionScopeStep` 1 つでくくった参考実装が含まれる。同ファイル `actions[0]` (`act-orderreg-002`) の平坦 `txBoundary` 版と比較して読むこと。
+
+## §6 UI
+
+`designer/src/components/process-flow/TransactionScopeStepPanel.tsx` で編集:
+
+- `isolationLevel` / `propagation` / `timeoutMs`: dropdown / number input
+- `rollbackOn`: `errorCatalog` のキーを multi-select (チェックボックス)
+- `steps[]`: 子 StepCard の InlineStepList で再帰編集
+- `onCommit[]` / `onRollback[]`: 折りたたみで InlineStepList
+
+## §7 関連参照
+
+- 親 ISSUE: #396 (処理フロー仕様拡張計画メタ)
+- 関連: `affectedRowsCheck` (`schemas/process-flow.schema.json` `DbAccessStep`)
+- 関連: `BranchConditionVariant.kind = "tryCatch"` (TX rollback エラー捕捉)
+- 関連: `compensatesFor` (Saga 補償の手動マーキング)
+- 業界フレームワーク: Power Platform Dataverse "Changeset", EF Core `TransactionScope`, Spring `@Transactional`

--- a/schemas/process-flow.schema.json
+++ b/schemas/process-flow.schema.json
@@ -286,6 +286,7 @@
         "log",
         "audit",
         "workflow",
+        "transactionScope",
         "other"
       ]
     },
@@ -850,6 +851,7 @@
         { "$ref": "#/$defs/LogStep" },
         { "$ref": "#/$defs/AuditStep" },
         { "$ref": "#/$defs/WorkflowStep" },
+        { "$ref": "#/$defs/TransactionScopeStep" },
         { "$ref": "#/$defs/OtherStep" }
       ]
     },
@@ -1464,6 +1466,56 @@
       ]
     },
 
+    "TransactionIsolationLevel": {
+      "type": "string",
+      "enum": ["READ_COMMITTED", "REPEATABLE_READ", "SERIALIZABLE"]
+    },
+    "TransactionPropagation": {
+      "type": "string",
+      "enum": ["REQUIRED", "REQUIRES_NEW", "NESTED"]
+    },
+    "TransactionScopeStep": {
+      "description": "複数 DB 操作を 1 TX でまとめる meta-step (#415)。Power Platform Changeset / EF Core TransactionScope 由来。steps[] が atomic 単位で実行される",
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "type", "description", "steps"],
+          "additionalProperties": false,
+          "properties": {
+            "id": true, "description": true, "note": true, "notes": true,
+            "maturity": true, "runIf": true, "outputBinding": true,
+            "txBoundary": true, "transactional": true, "compensatesFor": true,
+            "externalChain": true, "subSteps": true, "requiredPermissions": true,
+            "type": { "const": "transactionScope" },
+            "isolationLevel": { "$ref": "#/$defs/TransactionIsolationLevel" },
+            "propagation": { "$ref": "#/$defs/TransactionPropagation" },
+            "timeoutMs": { "type": "number", "minimum": 0 },
+            "rollbackOn": {
+              "description": "rollback を引き起こす errorCode の配列。ProcessFlow.errorCatalog のキー参照",
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "steps": {
+              "description": "TX 内で実行する step 列。1 TX に含めたい DB / 外部呼出を順序通りに並べる",
+              "type": "array",
+              "items": { "$ref": "#/$defs/Step" }
+            },
+            "onCommit": {
+              "description": "TX commit 成功後に実行する step 列 (任意)。例: 通知送信、キャッシュ無効化",
+              "type": "array",
+              "items": { "$ref": "#/$defs/Step" }
+            },
+            "onRollback": {
+              "description": "TX rollback 後に実行する step 列 (任意・補償処理)。例: Stripe authorize の cancel、Slack 通知",
+              "type": "array",
+              "items": { "$ref": "#/$defs/Step" }
+            }
+          }
+        }
+      ]
+    },
+
     "Step": {
       "description": "discriminator: type プロパティの値で variant を決定",
       "oneOf": [
@@ -1483,6 +1535,7 @@
         { "$ref": "#/$defs/LogStep" },
         { "$ref": "#/$defs/AuditStep" },
         { "$ref": "#/$defs/WorkflowStep" },
+        { "$ref": "#/$defs/TransactionScopeStep" },
         { "$ref": "#/$defs/OtherStep" }
       ]
     }


### PR DESCRIPTION
## 概要

複数 DB 操作を atomic な TX 単位でラップする meta-step `TransactionScopeStep` を導入 (Power Platform Changeset / EF Core TransactionScope 由来)。`StepBase.txBoundary` の平坦モデルに対し、TX 範囲を構造的にネストして表現する。

Closes #415

## 変更内容

### スキーマ・型 (4 層)

- `schemas/process-flow.schema.json`: `TransactionScopeStep` / `TransactionIsolationLevel` / `TransactionPropagation` 定義を追加 (schemas/process-flow.schema.json:241-260, :1257-1310)、`Step` union (:1325-1346) と `NonReturnStep` (:777-797) に追加
- `designer/src/types/action.ts`: `StepType` に `"transactionScope"` を追加 (action.ts:18)、`STEP_TYPE_LABELS/ICONS/COLORS` (:38, :58, :77)、`TransactionIsolationLevel` / `TransactionPropagation` / `TransactionScopeStep` interface を追加 (:758-803)、`Step` union に追加 (:822)
- `docs/sample-project/process-flows/cccccccc-0005-...json`: 新 action `act-orderreg-003` を追加し、`orders` INSERT + `order_items` INSERT + `inventory` UPDATE を `TransactionScopeStep` 1 つでまとめた参考実装 (rollbackOn=[VALIDATION,STOCK_SHORTAGE]、onCommit/onRollback も実装)
- `docs/spec/process-flow-transaction.md` 新規 + `docs/spec/README.md` にリンク追加

### 走査ロジック更新 (10 ファイル)

新 step type `transactionScope` の `steps[]` / `onCommit[]` / `onRollback[]` を再帰走査するよう修正:

- `designer/src/utils/actionUtils.ts:47-66` (walkSteps)
- `designer/src/utils/actionValidation.ts:15-30` (collectAllIds), `:62-72` (validateSteps - empty steps 警告)
- `designer/src/utils/actionMigration.ts:142-155` (migrateStepInPlace)
- `designer/src/utils/specExporter.ts:316-325` (export detail)
- `designer/src/store/processFlowStore.ts:265-285` (countGroupNotes)
- `designer/src/schemas/identifierScope.ts:135-139`
- `designer/src/schemas/referentialIntegrity.ts:127-132` + `:225-238` (rollbackOn → errorCatalog 参照検査 UNKNOWN_ERROR_CODE)
- `designer/src/schemas/sqlColumnValidator.ts:231-236`
- `designer/src/schemas/conventionsValidator.ts:293-298`
- `designer/src/components/process-flow/MarkerPanel.tsx:26-31` (collectStepIds)
- `designer/src/components/process-flow/ActionMetaTabBar.tsx:48-53` (notes/maturity 集計)

### Store

- `designer/src/store/processFlowStore.ts:257-264`: `createDefaultStep("transactionScope")` の case を追加 (`isolationLevel: "READ_COMMITTED"`, `propagation: "REQUIRED"`, `steps: []`)

### UI

- `designer/src/components/process-flow/TransactionScopeStepPanel.tsx` 新規:
  - isolationLevel dropdown (`data-field-path="isolationLevel"`)
  - propagation dropdown (`data-field-path="propagation"`)
  - timeoutMs number input (`data-field-path="timeoutMs"`)
  - rollbackOn — `errorCatalog` の key を multi-select チェックボックス (`data-field-path="rollbackOn"`)、未知 errorCode は警告表示
  - steps — InlineStepList で再帰編集 (`data-field-path="steps"`)
  - onCommit / onRollback — 折りたたみで InlineStepList、件数 badge 表示 (`data-field-path="onCommit"` / `onRollback"`)
- `designer/src/components/process-flow/StepCard.tsx`: type 分岐に `"transactionScope"` を追加して TransactionScopeStepPanel を render (:1602-1617)、サマリ `TX (READ_COMMITTED, N ステップ)` を追加 (:303-307)、`group` prop を Props に追加して全 InlineStepList / 子 StepCard に伝播 (:189-200, :164, :1391, :1442, :1576, :1696-1697)、`ALL_SUB_STEP_TYPES` に追加 (:38)
- `designer/src/components/process-flow/SortableStepCard.tsx`: `group` prop を SortableStepCardProps に追加 (rest spread で透過)
- `designer/src/components/process-flow/ProcessFlowEditor.tsx`: `ALL_STEP_TYPES` / `ALL_SUB_STEP_TYPES` に `"transactionScope"` を追加 (:113, :120)、SortableStepCard へ `group={group}` を渡す (:925)

### テスト追加

- `designer/src/schemas/process-flow.schema.test.ts`: TransactionScopeStep 単独の schema テスト 13 件を追加 (最小構成 / 全フィールド / enum 外 reject / 必須欠落 reject / ネスト / 空 steps OK / 未知フィールド reject / subSteps 内に置けるか 等)

## 仕様逐条突合 (自己申告)

ISSUE 受け入れ基準:

- [x] スキーマ + 型 + サンプル + spec の 4 層が同期: schemas/process-flow.schema.json:1257-1310 / designer/src/types/action.ts:758-803 / docs/sample-project/process-flows/cccccccc-0005-4000-8000-cccccccccccc.json:484-622 / docs/spec/process-flow-transaction.md
- [x] \`cd designer && npx vitest run src/schemas/process-flow.schema.test.ts\` pass: 107 tests passed (94 既存 + 13 新規)
- [x] \`cd designer && npm run build\` pass: tsc -b + vite build 共に成功
- [x] StepCard に TransactionScopeStep の専用編集フォームが追加され、編集・保存・リロードで値復元できる: designer/src/components/process-flow/StepCard.tsx:1602-1617 で TransactionScopeStepPanel を render、各フィールドは onChange/onCommit を経由して step に書き戻し
- [x] 既存 StepType の編集フォームに回帰なし: 750 vitest 全 pass
- [x] 既存 \`StepBase.txBoundary\` との関係が spec で明示されている: docs/spec/process-flow-transaction.md §3 (両者の比較表 + §3.1 移行ガイダンス + §3.2 同一 step 内併用禁止)

ISSUE スコープ:

- [x] 新規 \`TransactionScopeStep\` フィールド: isolationLevel/propagation/timeoutMs/rollbackOn/steps/onCommit/onRollback すべて schema と型に存在
- [x] StepType に \`"transactionScope"\` を追加 (schemas/process-flow.schema.json:259, designer/src/types/action.ts:18)
- [x] STEP_TYPE_LABELS = "TX スコープ" (action.ts:38)
- [x] STEP_TYPE_ICONS = "bi-shield-fill" (action.ts:58)
- [x] STEP_TYPE_COLORS = "#dc2626" (action.ts:77)
- [x] サンプルに 注文登録+在庫減算 を 1 TX でまとめた例 (cccccccc-0005-...json:541-622)
- [x] spec 新規 (docs/spec/process-flow-transaction.md) + docs/spec/README.md にリンク追加

## 検証

- \`cd designer && npx tsc -b\`: pass
- \`cd designer && npx vite build\`: pass (387 modules transformed)
- \`cd designer && npx vitest run src/schemas/process-flow.schema.test.ts\`: 107 tests pass (新サンプル含む全件 valid)
- \`cd designer && npx vitest run\`: 750 tests pass (1 ファイル分の参照整合性失敗を responses[] 追加で解消)

## ISSUE 設計から差異

なし。ISSUE 本文のフィールド名・型・必須/任意は全て遵守。サンプルは既存の `cccccccc-0005` ファイル内に新 action として追加 (既存 `act-orderreg-002` の平坦 txBoundary 版と並存させ、両者を比較できるようにした)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)