### PR TITLE
feat(processflow): Tier-B — イベント pub/sub・データ系譜・用語集・キャッシュ・ADR・API バージョニング (#423)

### DIFF
--- a/designer/src/schemas/process-flow.schema.test.ts
+++ b/designer/src/schemas/process-flow.schema.test.ts
@@ -1521,6 +1521,213 @@ describe("process-flow.schema.json — ambientOverrides (#369)", () => {
   });
 });
 
+// ── Tier-B (#423) ────────────────────────────────────────────────────────────
+
+describe("process-flow.schema.json — Tier-B B-1 EventPublishStep / EventSubscribeStep (#423)", () => {
+  const makeFlow = (step: object) => ({
+    id: "a", name: "x", type: "screen", description: "",
+    actions: [{
+      id: "act-1", name: "test", trigger: "submit",
+      steps: [step],
+    }],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  });
+
+  it("EventPublishStep 最小構成 (id/type/description/topic) accept", () => {
+    const ok = validate(makeFlow({
+      id: "ep-1", type: "eventPublish", description: "イベント発行",
+      topic: "order.created",
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("EventPublishStep フル構成 (topic/eventRef/payload) accept", () => {
+    const ok = validate(makeFlow({
+      id: "ep-1", type: "eventPublish", description: "イベント発行",
+      topic: "order.created",
+      eventRef: "order.created",
+      payload: "{ orderId: @orderId, total: @totalAmount }",
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("EventPublishStep topic 欠落は reject", () => {
+    expect(validate(makeFlow({
+      id: "ep-1", type: "eventPublish", description: "イベント発行",
+    }))).toBe(false);
+  });
+
+  it("EventSubscribeStep 最小構成 (id/type/description/topic) accept", () => {
+    const ok = validate(makeFlow({
+      id: "es-1", type: "eventSubscribe", description: "イベント購読",
+      topic: "payment.confirmed",
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("EventSubscribeStep フル構成 (topic/eventRef/filter) accept", () => {
+    const ok = validate(makeFlow({
+      id: "es-1", type: "eventSubscribe", description: "イベント購読",
+      topic: "payment.confirmed",
+      eventRef: "payment.confirmed",
+      filter: "@event.orderId == @orderId",
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("EventSubscribeStep topic 欠落は reject", () => {
+    expect(validate(makeFlow({
+      id: "es-1", type: "eventSubscribe", description: "イベント購読",
+    }))).toBe(false);
+  });
+
+  it("EventPublishStep / EventSubscribeStep の未知フィールドは reject (additionalProperties: false)", () => {
+    expect(validate(makeFlow({
+      id: "ep-1", type: "eventPublish", description: "", topic: "t",
+      unknownField: "x",
+    }))).toBe(false);
+  });
+});
+
+describe("process-flow.schema.json — Tier-B B-2 DbAccessStep.lineage (#423)", () => {
+  const makeFlow = (step: object) => ({
+    id: "a", name: "x", type: "screen", description: "",
+    actions: [{ id: "act-1", name: "test", trigger: "submit", steps: [step] }],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  });
+
+  it("DbAccessStep.lineage (reads + writes) accept", () => {
+    const ok = validate(makeFlow({
+      id: "db-1", type: "dbAccess", description: "",
+      tableName: "orders", operation: "INSERT",
+      lineage: { reads: ["customers", "products"], writes: ["orders", "order_items"] },
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("DbAccessStep.lineage reads のみ accept", () => {
+    const ok = validate(makeFlow({
+      id: "db-1", type: "dbAccess", description: "",
+      tableName: "customers", operation: "SELECT",
+      lineage: { reads: ["customers"] },
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("DbAccessStep.lineage 省略 accept (optional)", () => {
+    const ok = validate(makeFlow({
+      id: "db-1", type: "dbAccess", description: "",
+      tableName: "x", operation: "SELECT",
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+});
+
+describe("process-flow.schema.json — Tier-B B-4 CacheHint (#423)", () => {
+  const makeFlow = (step: object) => ({
+    id: "a", name: "x", type: "screen", description: "",
+    actions: [{ id: "act-1", name: "test", trigger: "submit", steps: [step] }],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  });
+
+  it("DbAccessStep.cache (ttlSeconds + key + invalidateOn) accept", () => {
+    const ok = validate(makeFlow({
+      id: "db-1", type: "dbAccess", description: "",
+      tableName: "customers", operation: "SELECT",
+      cache: { ttlSeconds: 300, key: "customer-@id", invalidateOn: ["customer.updated"] },
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("DbAccessStep.cache 最小構成 (ttlSeconds のみ) accept", () => {
+    const ok = validate(makeFlow({
+      id: "db-1", type: "dbAccess", description: "",
+      tableName: "x", operation: "SELECT",
+      cache: { ttlSeconds: 60 },
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("DbAccessStep.cache ttlSeconds 欠落は reject", () => {
+    expect(validate(makeFlow({
+      id: "db-1", type: "dbAccess", description: "",
+      tableName: "x", operation: "SELECT",
+      cache: { key: "x" },
+    }))).toBe(false);
+  });
+
+  it("ExternalSystemStep.cache accept", () => {
+    const ok = validate(makeFlow({
+      id: "ext-1", type: "externalSystem", description: "",
+      systemName: "PriceAPI",
+      cache: { ttlSeconds: 600, key: "price-@productId" },
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("ExternalSystemStep.cache 省略 accept (optional)", () => {
+    const ok = validate(makeFlow({
+      id: "ext-1", type: "externalSystem", description: "",
+      systemName: "PriceAPI",
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+});
+
+describe("process-flow.schema.json — Tier-B B-6 apiVersion (#423)", () => {
+  const base = {
+    id: "a", name: "x", type: "screen", description: "",
+    actions: [],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  };
+  const makeFlow = (step: object) => ({
+    ...base,
+    actions: [{ id: "act-1", name: "test", trigger: "submit", steps: [step] }],
+  });
+
+  it("ProcessFlow.apiVersion accept", () => {
+    const ok = validate({ ...base, apiVersion: "v1" });
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("ProcessFlow.apiVersion 省略 accept (optional)", () => {
+    expect(validate({ ...base })).toBe(true);
+  });
+
+  it("ExternalSystemStep.apiVersion accept", () => {
+    const ok = validate(makeFlow({
+      id: "ext-1", type: "externalSystem", description: "",
+      systemName: "NewAPI", apiVersion: "v2",
+      httpCall: { method: "GET", path: "/v2/resource" },
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("ExternalSystemStep.apiVersion 省略 accept (optional)", () => {
+    expect(validate(makeFlow({
+      id: "ext-1", type: "externalSystem", description: "",
+      systemName: "API",
+    }))).toBe(true);
+  });
+});
+
 describe("process-flow.schema.json — domainsCatalog (#422 P2-1)", () => {
   const base = {
     id: "a", name: "x", type: "screen", description: "",
@@ -1793,5 +2000,154 @@ describe("process-flow.schema.json — ValidationRule.kind (#422 P2-3)", () => {
 
   it("kind 省略 accept (optional)", () => {
     expect(validate(makeValidation({ field: "qty", type: "required" }))).toBe(true);
+  });
+});
+
+describe("process-flow.schema.json — Tier-B B-3 glossary (#423)", () => {
+  const base = {
+    id: "a", name: "x", type: "screen", description: "",
+    actions: [],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  };
+
+  it("glossary フル構成 (definition + aliases + domainRef) accept", () => {
+    const ok = validate({
+      ...base,
+      glossary: {
+        "小計": {
+          definition: "税抜きの請求合計金額",
+          aliases: ["subtotal"],
+          domainRef: "invoices.subtotal",
+        },
+      },
+    });
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("glossary definition のみ accept (aliases/domainRef は optional)", () => {
+    const ok = validate({
+      ...base,
+      glossary: { "請求書": { definition: "顧客への代金請求書類" } },
+    });
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("glossary definition 欠落は reject", () => {
+    expect(validate({
+      ...base,
+      glossary: { "用語": { aliases: ["alias"] } },
+    })).toBe(false);
+  });
+
+  it("glossary 省略 accept (optional)", () => {
+    expect(validate({ ...base })).toBe(true);
+  });
+});
+
+describe("process-flow.schema.json — Tier-B B-5 decisions / DecisionRecord (#423)", () => {
+  const base = {
+    id: "a", name: "x", type: "screen", description: "",
+    actions: [],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  };
+
+  const minimalDecision = {
+    id: "ADR-001",
+    title: "採番は DB トリガーで行う",
+    status: "accepted",
+    context: "アプリ層での並行採番は衝突リスクあり",
+    decision: "PostgreSQL BEFORE INSERT トリガー + sequence を使用",
+  };
+
+  it("decisions 最小構成 accept", () => {
+    const ok = validate({ ...base, decisions: [minimalDecision] });
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("decisions フル構成 (consequences + date) accept", () => {
+    const ok = validate({
+      ...base,
+      decisions: [{
+        ...minimalDecision,
+        consequences: "DDL にトリガー定義が必要",
+        date: "2026-04-25",
+      }],
+    });
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("decisions status enum 全値 accept", () => {
+    for (const status of ["proposed", "accepted", "deprecated", "superseded"] as const) {
+      const ok = validate({ ...base, decisions: [{ ...minimalDecision, status }] });
+      if (!ok) throw new Error(`status=${status}: ${JSON.stringify(validate.errors)}`);
+      expect(ok).toBe(true);
+    }
+  });
+
+  it("decisions status enum 外は reject", () => {
+    expect(validate({
+      ...base,
+      decisions: [{ ...minimalDecision, status: "approved" }],
+    })).toBe(false);
+  });
+
+  it("decisions 必須フィールド (id) 欠落は reject", () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { id: _id, ...noId } = minimalDecision;
+    expect(validate({ ...base, decisions: [noId] })).toBe(false);
+  });
+
+  it("decisions 省略 accept (optional)", () => {
+    expect(validate({ ...base })).toBe(true);
+  });
+
+  it("decisions 空配列 accept", () => {
+    expect(validate({ ...base, decisions: [] })).toBe(true);
+  });
+});
+
+describe("process-flow.schema.json — Tier-B eventsCatalog (#423)", () => {
+  const base = {
+    id: "a", name: "x", type: "screen", description: "",
+    actions: [],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  };
+
+  it("eventsCatalog フル構成 (description + payload) accept", () => {
+    const ok = validate({
+      ...base,
+      eventsCatalog: {
+        "order.created": {
+          description: "注文作成完了イベント",
+          payload: {
+            type: "object",
+            required: ["orderId"],
+            properties: { orderId: { type: "integer" } },
+          },
+        },
+      },
+    });
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("eventsCatalog 空エントリ (全フィールド省略) accept", () => {
+    const ok = validate({
+      ...base,
+      eventsCatalog: { "order.created": {} },
+    });
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("eventsCatalog 省略 accept (optional)", () => {
+    expect(validate({ ...base })).toBe(true);
   });
 });

--- a/designer/src/store/processFlowStore.ts
+++ b/designer/src/store/processFlowStore.ts
@@ -270,6 +270,10 @@ export function createDefaultStep(type: StepType): Step {
         propagation: "REQUIRED",
         steps: [],
       };
+    case "eventPublish":
+      return { ...base, type: "eventPublish", topic: "" };
+    case "eventSubscribe":
+      return { ...base, type: "eventSubscribe", topic: "" };
     case "other":
       return { ...base, type: "other" };
   }

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -18,6 +18,8 @@ export type StepType =
   | "log" | "audit"    // アプリケーションログ / 監査ログ
   | "workflow"         // 承認ワークフロー (#411)
   | "transactionScope" // 複数 DB 操作を 1 TX でまとめる meta-step (#415)
+  | "eventPublish"     // イベント発行 (#423 B-1)
+  | "eventSubscribe"   // イベント購読 (#423 B-1)
   | "other";           // その他
 
 /** ステップ種別ラベル */
@@ -39,6 +41,8 @@ export const STEP_TYPE_LABELS: Record<StepType, string> = {
   audit: "監査ログ",
   workflow: "承認ワークフロー",
   transactionScope: "TX スコープ",
+  eventPublish: "イベント発行",
+  eventSubscribe: "イベント購読",
   other: "その他",
 };
 
@@ -61,6 +65,8 @@ export const STEP_TYPE_ICONS: Record<StepType, string> = {
   audit: "bi-shield-check",
   workflow: "bi-people-fill",
   transactionScope: "bi-shield-fill",
+  eventPublish: "bi-broadcast",
+  eventSubscribe: "bi-broadcast-pin",
   other: "bi-three-dots",
 };
 
@@ -83,6 +89,8 @@ export const STEP_TYPE_COLORS: Record<StepType, string> = {
   audit: "#a855f7",
   workflow: "#0d9488",
   transactionScope: "#dc2626",
+  eventPublish: "#7c3aed",
+  eventSubscribe: "#5b21b6",
   other: "#9ca3af",
 };
 
@@ -397,6 +405,30 @@ export interface AffectedRowsCheck {
   description?: string;
 }
 
+/**
+ * キャッシュヒント (#423 B-4)。
+ * GET 系クエリ / API レスポンスのキャッシュ可否・TTL・無効化条件を宣言する。
+ */
+export interface CacheHint {
+  /** キャッシュ有効期間 (秒) */
+  ttlSeconds: number;
+  /** キャッシュキー式。省略時はランタイムが自動生成 */
+  key?: string;
+  /** このキャッシュを無効化するイベント名またはトピック名のリスト */
+  invalidateOn?: string[];
+}
+
+/**
+ * データ系譜 (#423 B-2)。
+ * DbAccessStep がどのテーブルを読み書きするかを宣言的に記述する。
+ */
+export interface DataLineage {
+  /** 読み取るテーブル名の一覧 */
+  reads?: string[];
+  /** 書き込むテーブル名の一覧 */
+  writes?: string[];
+}
+
 export interface DbAccessStep extends StepBase {
   type: "dbAccess";
   tableName: string;
@@ -423,6 +455,10 @@ export interface DbAccessStep extends StepBase {
    * SELECT / INSERT では通常不要。
    */
   affectedRowsCheck?: AffectedRowsCheck;
+  /** データ系譜 (#423 B-2)。このステップが読み書きするテーブルを宣言する */
+  lineage?: DataLineage;
+  /** キャッシュヒント (#423 B-4)。SELECT 系クエリのキャッシュ設定 */
+  cache?: CacheHint;
 }
 
 // ── 外部システム呼出の outcome / タイムアウト / リトライ (docs/spec, #151 (B)) ──
@@ -583,6 +619,13 @@ export interface ExternalSystemStep extends StepBase {
    * auth / idempotencyKey で表現できない任意ヘッダを設定する場合に使用。
    */
   headers?: Record<string, string>;
+  /**
+   * API バージョン override (#423 B-6)。
+   * ProcessFlow.apiVersion より優先。外部 API のバージョンを step 単位で指定する場合に使用。
+   */
+  apiVersion?: string;
+  /** キャッシュヒント (#423 B-4)。GET 系 API レスポンスのキャッシュ設定 */
+  cache?: CacheHint;
 }
 
 export interface CommonProcessStep extends StepBase {
@@ -901,6 +944,78 @@ export interface TransactionScopeStep extends StepBase {
   onRollback?: Step[];
 }
 
+/**
+ * イベント定義 (#423 B-1)。ProcessFlow.eventsCatalog の 1 エントリ。
+ */
+export interface EventDef {
+  /** 補足説明 */
+  description?: string;
+  /** ペイロードの JSON Schema (draft 2020-12) */
+  payload?: Record<string, unknown>;
+}
+
+/**
+ * イベント発行ステップ (#423 B-1)。
+ * 指定トピックにイベントをパブリッシュする。
+ */
+export interface EventPublishStep extends StepBase {
+  type: "eventPublish";
+  /** パブリッシュ先のトピック名 */
+  topic: string;
+  /** ProcessFlow.eventsCatalog のキー参照 */
+  eventRef?: string;
+  /** 送信ペイロードの式 (例: "{ orderId: @orderId }") */
+  payload?: string;
+}
+
+/**
+ * イベント購読ステップ (#423 B-1)。
+ * 指定トピックのイベントをサブスクライブし待機する。
+ */
+export interface EventSubscribeStep extends StepBase {
+  type: "eventSubscribe";
+  /** サブスクライブするトピック名 */
+  topic: string;
+  /** ProcessFlow.eventsCatalog のキー参照 */
+  eventRef?: string;
+  /** 受信フィルター条件の式 (例: "@event.type == \"OrderPlaced\"") */
+  filter?: string;
+}
+
+/**
+ * ビジネス用語集の 1 エントリ (#423 B-3)。
+ */
+export interface GlossaryEntry {
+  /** 用語の定義 */
+  definition: string;
+  /** 別名・略語のリスト */
+  aliases?: string[];
+  /** ドメインモデルやテーブル等への参照文字列 */
+  domainRef?: string;
+}
+
+/** ADR ステータス (#423 B-5) */
+export type DecisionStatus = "proposed" | "accepted" | "deprecated" | "superseded";
+
+/**
+ * ADR / 設計判断ログの 1 エントリ (#423 B-5)。
+ * MADR 形式を参考にした軽量 ADR。
+ */
+export interface DecisionRecord {
+  /** 例: "ADR-001" */
+  id: string;
+  title: string;
+  status: DecisionStatus;
+  /** 決定の背景・問題の説明 */
+  context: string;
+  /** 採択した決定内容 */
+  decision: string;
+  /** 結果・影響・トレードオフ (任意) */
+  consequences?: string;
+  /** ISO date (例: "2026-04-25") */
+  date?: string;
+}
+
 export type Step =
   | ValidationStep
   | DbAccessStep
@@ -919,6 +1034,8 @@ export type Step =
   | AuditStep
   | WorkflowStep
   | TransactionScopeStep
+  | EventPublishStep
+  | EventSubscribeStep
   | OtherStep;
 
 // ── アクション定義 ───────────────────────────────────────────────────────
@@ -1258,6 +1375,11 @@ export interface ProcessFlow {
   type: ProcessFlowType;
   screenId?: string;
   description: string;
+  /**
+   * API バージョン識別子 (#423 B-6)。
+   * 例: "v1", "2026-04-25"。ExternalSystemStep.apiVersion で step 単位の override が可能。
+   */
+  apiVersion?: string;
   actions: ActionDefinition[];
   /** 成熟度。未指定は "draft" として解釈 (docs/spec/process-flow-maturity.md §3) */
   maturity?: Maturity;
@@ -1319,6 +1441,21 @@ export interface ProcessFlow {
    * `@fn.<name>` 参照形式で式から呼び出される。
    */
   functionsCatalog?: Record<string, FunctionDef>;
+  /**
+   * イベント pub/sub カタログ (#423 B-1)。キー: トピック名。
+   * EventPublishStep / EventSubscribeStep の eventRef から参照される。
+   */
+  eventsCatalog?: Record<string, EventDef>;
+  /**
+   * ビジネス用語集 (#423 B-3)。キー: 用語名。
+   * ドメイン固有語・略語の定義と別名を集約する。AI 実装者がドメイン語義を解釈するための参照情報。
+   */
+  glossary?: Record<string, GlossaryEntry>;
+  /**
+   * ADR / 設計判断ログ (#423 B-5)。
+   * アーキテクチャ上の決定とその根拠・影響を記録する。
+   */
+  decisions?: DecisionRecord[];
   /**
    * マーカー (#261 リアルタイム編集ワークフロー)。
    * 人間が designer 画面で付けたコメント・質問・TODO・チャットメッセージを保持。

--- a/docs/sample-project/process-flows/cccccccc-0007-4000-8000-cccccccccccc.json
+++ b/docs/sample-project/process-flows/cccccccc-0007-4000-8000-cccccccccccc.json
@@ -3,9 +3,65 @@
   "name": "請求書発行画面",
   "type": "screen",
   "screenId": "aaaaaaaa-0007-4000-8000-aaaaaaaaaaaa",
-  "description": "2026-04-24 5/5 再ドッグフード: 顧客向け売上請求書を発行し PDF 生成 + メール通知を行う。前回 0006 サンプルの残ギャップ (@conv.numbering.* / @conv.currency.jpy subunit / @conv.scope.timezone ambient) を構造化フィールドで完全解消する実証サンプル。",
+  "description": "2026-04-24 5/5 再ドッグフード: 顧客向け売上請求書を発行し PDF 生成 + メール通知を行う。前回 0006 サンプルの残ギャップ (@conv.numbering.* / @conv.currency.jpy subunit / @conv.scope.timezone ambient) を構造化フィールドで完全解消する実証サンプル。Tier-B (#423) 追加: eventsCatalog / glossary / decisions / apiVersion を実証。",
+  "apiVersion": "v2",
   "mode": "downstream",
   "maturity": "committed",
+
+  "eventsCatalog": {
+    "invoice.issued": {
+      "description": "請求書発行完了イベント。PDF 生成・メール送信完了後に発行される",
+      "payload": {
+        "type": "object",
+        "required": ["invoiceId", "invoiceNumber", "customerId", "totalAmount"],
+        "properties": {
+          "invoiceId": { "type": "integer" },
+          "invoiceNumber": { "type": "string" },
+          "customerId": { "type": "integer" },
+          "totalAmount": { "type": "integer" }
+        }
+      }
+    }
+  },
+
+  "glossary": {
+    "請求書": {
+      "definition": "顧客に対して発行する代金請求のための書類。invoice_number (INV-YYYY-NNNN 形式) で識別される",
+      "aliases": ["インボイス", "Invoice"],
+      "domainRef": "invoices"
+    },
+    "明細": {
+      "definition": "請求書に含まれる商品・サービスの行単位の詳細。単価 × 数量 = 行金額",
+      "aliases": ["請求明細", "invoice line item"],
+      "domainRef": "invoice_items"
+    },
+    "小計": {
+      "definition": "税抜きの請求合計金額。Σ(単価 × 数量)",
+      "aliases": ["subtotal"],
+      "domainRef": "invoices.subtotal"
+    }
+  },
+
+  "decisions": [
+    {
+      "id": "ADR-001",
+      "title": "請求書番号の採番は DB トリガーで行う",
+      "status": "accepted",
+      "context": "請求書番号 (INV-YYYY-NNNN) は採番の一意性・欠番防止が必要。アプリ層での採番は並行アクセス時に衝突リスクがある",
+      "decision": "PostgreSQL の BEFORE INSERT トリガー + sequence で自動採番する。アプリ層は INSERT 後 RETURNING invoice_number で取得する",
+      "consequences": "DB トリガーへの依存が生じるが、一意性・欠番防止は DB 層で保証できる。マイグレーション時はトリガー定義も DDL に含める必要がある",
+      "date": "2026-04-25"
+    },
+    {
+      "id": "ADR-002",
+      "title": "メール送信は fireAndForget で非同期化する",
+      "status": "accepted",
+      "context": "メール送信失敗で請求書発行がロールバックされると UX が悪化する。メール再送は別の運用フローで対応可能",
+      "decision": "SendGrid 呼出を fireAndForget: true にし、failure/timeout を continue にする。請求書 DB 登録・PDF 生成が成功した時点でユーザーに完了を伝える",
+      "consequences": "メール未着ケースは SendGrid ダッシュボードで検知・再送が必要。請求書発行の信頼性は向上する",
+      "date": "2026-04-25"
+    }
+  ],
 
   "ambientVariables": [
     {
@@ -323,7 +379,9 @@
           "tableName": "customers",
           "operation": "SELECT",
           "sql": "SELECT id, name, email FROM customers WHERE id = @inputs.customerId AND is_deleted = false",
-          "outputBinding": "customer"
+          "outputBinding": "customer",
+          "lineage": { "reads": ["customers"] },
+          "cache": { "ttlSeconds": 300, "key": "customer-@inputs.customerId", "invalidateOn": ["customer.updated"] }
         },
 
         {
@@ -473,7 +531,8 @@
           "operation": "INSERT",
           "sql": "INSERT INTO invoices (customer_id, subtotal, tax_amount, total_amount, payment_term_days, issued_by, created_at, updated_at) VALUES (@inputs.customerId, @subtotal, @taxAmount, @subtotal + @taxAmount, @inputs.paymentTermDays, @sessionUserId, NOW(), NOW()) RETURNING id, invoice_number",
           "txBoundary": { "role": "begin", "txId": "tx-invoice-register" },
-          "outputBinding": "newInvoice"
+          "outputBinding": "newInvoice",
+          "lineage": { "writes": ["invoices"] }
         },
 
         {
@@ -496,6 +555,7 @@
           "systemName": "PDF Generation Service",
           "systemRef": "pdfService",
           "timeoutMs": 30000,
+          "apiVersion": "v2",
           "httpCall": {
             "method": "POST",
             "path": "/generate/invoice",
@@ -527,6 +587,16 @@
 
         {
           "id": "step-12",
+          "type": "eventPublish",
+          "description": "請求書発行完了イベントを発行 (他サービスへの通知用)",
+          "maturity": "committed",
+          "topic": "invoice.issued",
+          "eventRef": "invoice.issued",
+          "payload": "{ invoiceId: @newInvoice.id, invoiceNumber: @newInvoice.invoice_number, customerId: @inputs.customerId, totalAmount: @subtotal + @taxAmount }"
+        },
+
+        {
+          "id": "step-13",
           "type": "return",
           "description": "201 Created — 請求書発行完了",
           "maturity": "committed",

--- a/docs/spec/process-flow-extensions.md
+++ b/docs/spec/process-flow-extensions.md
@@ -840,10 +840,232 @@ PR: #422
 - `docs/conventions/validation-rules.md` / `product-scope.md` — 横断規約 (placeholder)
 - `designer/src/types/action.ts` — 型定義の正 (実装とドキュメントの整合性はこちらが優先)
 
-## 13. 変更履歴
+## 13. Tier-B 拡張 (#423)
+
+Issue: #396 (Tier B) / #423 (実装)  
+策定日: 2026-04-25
+
+### 13.1 イベント pub/sub (B-1)
+
+非同期メッセージング・イベント駆動アーキテクチャのための宣言サポート。
+
+#### ProcessFlow.eventsCatalog
+
+```ts
+interface EventDef {
+  description?: string;
+  payload?: object;  // JSON Schema draft 2020-12
+}
+
+// ProcessFlow に追加
+eventsCatalog?: Record<string, EventDef>;  // キー: トピック名
+```
+
+#### EventPublishStep (type: "eventPublish")
+
+```ts
+interface EventPublishStep extends StepBase {
+  type: "eventPublish";
+  topic: string;                  // パブリッシュ先トピック名 (required)
+  eventRef?: string;              // eventsCatalog のキー参照
+  payload?: string;               // 送信ペイロードの式
+}
+```
+
+#### EventSubscribeStep (type: "eventSubscribe")
+
+```ts
+interface EventSubscribeStep extends StepBase {
+  type: "eventSubscribe";
+  topic: string;                  // サブスクライブするトピック名 (required)
+  eventRef?: string;              // eventsCatalog のキー参照
+  filter?: string;                // 受信フィルター条件の式
+}
+```
+
+用例:
+
+```json
+"eventsCatalog": {
+  "invoice.issued": {
+    "description": "請求書発行完了イベント",
+    "payload": {
+      "type": "object",
+      "required": ["invoiceId", "invoiceNumber"],
+      "properties": {
+        "invoiceId": { "type": "integer" },
+        "invoiceNumber": { "type": "string" }
+      }
+    }
+  }
+},
+"steps": [
+  {
+    "id": "step-evt",
+    "type": "eventPublish",
+    "description": "請求書発行完了イベントを発行",
+    "topic": "invoice.issued",
+    "eventRef": "invoice.issued",
+    "payload": "{ invoiceId: @newInvoice.id, invoiceNumber: @newInvoice.invoice_number }"
+  }
+]
+```
+
+### 13.2 データ系譜 (B-2)
+
+`DbAccessStep` がどのテーブルを読み書きするかを宣言的に記述する。データリネージ分析・影響範囲特定に使用。
+
+```ts
+interface DataLineage {
+  reads?: string[];    // 読み取るテーブル名一覧
+  writes?: string[];   // 書き込むテーブル名一覧
+}
+
+// DbAccessStep に追加
+lineage?: DataLineage;
+```
+
+用例:
+
+```json
+{
+  "type": "dbAccess",
+  "tableName": "invoices",
+  "operation": "INSERT",
+  "lineage": { "writes": ["invoices"] }
+}
+```
+
+### 13.3 ビジネス用語集 (B-3)
+
+ドメイン固有語・略語を 1 箇所に集約し、AI 実装者がドメイン語義を誤解なく解釈できるよう支援する。
+
+```ts
+interface GlossaryEntry {
+  definition: string;        // 用語の定義 (required)
+  aliases?: string[];        // 別名・略語のリスト
+  domainRef?: string;        // テーブル名等への参照文字列
+}
+
+// ProcessFlow に追加
+glossary?: Record<string, GlossaryEntry>;  // キー: 用語名
+```
+
+用例:
+
+```json
+"glossary": {
+  "小計": {
+    "definition": "税抜きの請求合計金額。Σ(単価 × 数量)",
+    "aliases": ["subtotal"],
+    "domainRef": "invoices.subtotal"
+  }
+}
+```
+
+### 13.4 キャッシュヒント (B-4)
+
+GET 系クエリ / API レスポンスのキャッシュ設定を宣言。`DbAccessStep` (SELECT) と `ExternalSystemStep` (GET 系) に付与可能。
+
+```ts
+interface CacheHint {
+  ttlSeconds: number;           // キャッシュ有効期間 (秒, required)
+  key?: string;                 // キャッシュキー式 (省略時はランタイム自動生成)
+  invalidateOn?: string[];      // 無効化トリガーのイベント名/トピック名
+}
+
+// DbAccessStep に追加
+cache?: CacheHint;
+
+// ExternalSystemStep に追加
+cache?: CacheHint;
+```
+
+用例:
+
+```json
+{
+  "type": "dbAccess",
+  "tableName": "customers",
+  "operation": "SELECT",
+  "cache": {
+    "ttlSeconds": 300,
+    "key": "customer-@inputs.customerId",
+    "invalidateOn": ["customer.updated"]
+  }
+}
+```
+
+### 13.5 ADR / 設計判断ログ (B-5)
+
+アーキテクチャ上の決定とその根拠・影響を MADR 形式で記録する。AI 実装者が設計意図を理解するための参照情報。
+
+```ts
+type DecisionStatus = "proposed" | "accepted" | "deprecated" | "superseded";
+
+interface DecisionRecord {
+  id: string;                    // 例: "ADR-001" (required)
+  title: string;                 // (required)
+  status: DecisionStatus;        // (required)
+  context: string;               // 決定の背景・問題の説明 (required)
+  decision: string;              // 採択した決定内容 (required)
+  consequences?: string;         // 結果・影響・トレードオフ
+  date?: string;                 // ISO date (例: "2026-04-25")
+}
+
+// ProcessFlow に追加
+decisions?: DecisionRecord[];
+```
+
+用例:
+
+```json
+"decisions": [
+  {
+    "id": "ADR-001",
+    "title": "請求書番号の採番は DB トリガーで行う",
+    "status": "accepted",
+    "context": "アプリ層での採番は並行アクセス時に衝突リスクがある",
+    "decision": "PostgreSQL BEFORE INSERT トリガー + sequence で自動採番する",
+    "consequences": "DDL にトリガー定義が必要",
+    "date": "2026-04-25"
+  }
+]
+```
+
+### 13.6 API バージョニング (B-6)
+
+ProcessFlow レベルと ExternalSystemStep レベルの 2 層で API バージョンを宣言できる。step 単位の `apiVersion` が優先 (override)。
+
+```ts
+// ProcessFlow に追加
+apiVersion?: string;                  // フロー全体のデフォルト API バージョン
+
+// ExternalSystemStep に追加
+apiVersion?: string;                  // step 単位の override
+```
+
+用例:
+
+```json
+{
+  "apiVersion": "v1",
+  "actions": [{
+    "steps": [{
+      "type": "externalSystem",
+      "systemName": "新規 API",
+      "apiVersion": "v2",
+      "httpCall": { "method": "POST", "path": "/v2/resource" }
+    }]
+  }]
+}
+```
+
+## 14. 変更履歴
 
 - 2026-04-20: 初版。#155〜#181 の全 PR をカバー。
 - 2026-04-24: `StructuredField.format`, `ValidationRule.minRef/maxRef` 追加 (#367 / #253 v1.3)。§5.1・§8.6 を更新。
 - 2026-04-24: `DbAccessStep.bulkValues`, `BranchStep.tryScope` 追加 (#368 / #253)。§4.3・§7.2 を新設。
 - 2026-04-24: `ProcessFlow.ambientOverrides` 追加 (#369)。§8.7 を新設。
 - 2026-04-25: P2+D 拡張 (#422)。§9 を新設。domainsCatalog / functionsCatalog / StructuredField.domainRef / StructuredField.formula / ValidationRule.kind / ScreenItem.computed を追加。
+- 2026-04-25: Tier-B (#423) 全 6 項目追加。§13 を新設 (B-1〜B-6)。

--- a/schemas/process-flow.schema.json
+++ b/schemas/process-flow.schema.json
@@ -12,6 +12,10 @@
     "type": { "$ref": "#/$defs/ProcessFlowType" },
     "screenId": { "type": "string" },
     "description": { "type": "string" },
+    "apiVersion": {
+      "description": "API バージョン識別子 (#423 B-6)。例: \"v1\", \"2026-04-25\"",
+      "type": "string"
+    },
     "maturity": { "$ref": "#/$defs/Maturity" },
     "mode": { "$ref": "#/$defs/ProcessFlowMode" },
     "sla": { "$ref": "#/$defs/Sla" },
@@ -59,6 +63,21 @@
       "description": "組み込み関数カタログ (#422 P2-5 / Wagby 由来)。キー: 関数名 (例: \"formatCurrency\", \"calcAge\")。@fn.* 参照形式で式から呼び出される",
       "type": "object",
       "additionalProperties": { "$ref": "#/$defs/FunctionDef" }
+    },
+    "eventsCatalog": {
+      "description": "イベント pub/sub カタログ (#423 B-1)。キー: トピック名。EventPublishStep / EventSubscribeStep から参照される",
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/EventDef" }
+    },
+    "glossary": {
+      "description": "ビジネス用語集 (#423 B-3)。キー: 用語名。ドメイン固有語・略語の定義と別名を集約する",
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/GlossaryEntry" }
+    },
+    "decisions": {
+      "description": "ADR / 設計判断ログ (#423 B-5)。アーキテクチャ上の決定とその根拠・影響を記録する",
+      "type": "array",
+      "items": { "$ref": "#/$defs/DecisionRecord" }
     },
     "markers": {
       "description": "マーカー (#261)。人間が designer で付けた指示・質問・TODO・チャット。AI が読み取り resolvedAt で解決",
@@ -297,7 +316,148 @@
         "audit",
         "workflow",
         "transactionScope",
+        "eventPublish",
+        "eventSubscribe",
         "other"
+      ]
+    },
+
+    "CacheHint": {
+      "description": "キャッシュヒント (#423 B-4)。GET 系クエリのキャッシュ可否・TTL・無効化条件を宣言する",
+      "type": "object",
+      "required": ["ttlSeconds"],
+      "additionalProperties": false,
+      "properties": {
+        "ttlSeconds": { "type": "number", "minimum": 0, "description": "キャッシュ有効期間 (秒)" },
+        "key": { "type": "string", "description": "キャッシュキー式。省略時はランタイムが自動生成" },
+        "invalidateOn": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "このキャッシュを無効化するイベント名またはトピック名のリスト"
+        }
+      }
+    },
+
+    "DataLineage": {
+      "description": "データ系譜 (#423 B-2)。DbAccessStep がどのテーブルを読み書きするかを宣言的に記述する",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "reads": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "読み取るテーブル名の一覧"
+        },
+        "writes": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "書き込むテーブル名の一覧"
+        }
+      }
+    },
+
+    "EventDef": {
+      "description": "イベント定義 (#423 B-1)。ProcessFlow.eventsCatalog の 1 エントリ",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "description": { "type": "string" },
+        "payload": {
+          "type": "object",
+          "description": "ペイロードの JSON Schema (draft 2020-12)"
+        }
+      }
+    },
+
+    "GlossaryEntry": {
+      "description": "ビジネス用語集の 1 エントリ (#423 B-3)",
+      "type": "object",
+      "required": ["definition"],
+      "additionalProperties": false,
+      "properties": {
+        "definition": { "type": "string", "description": "用語の定義" },
+        "aliases": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "別名・略語のリスト"
+        },
+        "domainRef": {
+          "type": "string",
+          "description": "ドメインモデルやテーブル等への参照文字列"
+        }
+      }
+    },
+
+    "DecisionRecord": {
+      "description": "ADR / 設計判断ログの 1 エントリ (#423 B-5)。MADR 形式を参考にした軽量 ADR",
+      "type": "object",
+      "required": ["id", "title", "status", "context", "decision"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "description": "例: ADR-001" },
+        "title": { "type": "string" },
+        "status": {
+          "type": "string",
+          "enum": ["proposed", "accepted", "deprecated", "superseded"]
+        },
+        "context": { "type": "string", "description": "決定の背景・問題の説明" },
+        "decision": { "type": "string", "description": "採択した決定内容" },
+        "consequences": { "type": "string", "description": "結果・影響・トレードオフ" },
+        "date": { "type": "string", "description": "ISO date (例: 2026-04-25)" }
+      }
+    },
+
+    "EventPublishStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "type", "description", "topic"],
+          "additionalProperties": false,
+          "properties": {
+            "id": true, "description": true, "note": true, "notes": true,
+            "maturity": true, "runIf": true, "outputBinding": true,
+            "txBoundary": true, "transactional": true, "compensatesFor": true,
+            "externalChain": true, "subSteps": true, "requiredPermissions": true, "sla": true,
+            "type": { "const": "eventPublish" },
+            "topic": { "type": "string", "description": "パブリッシュ先のトピック名" },
+            "eventRef": {
+              "type": "string",
+              "description": "ProcessFlow.eventsCatalog のキー参照"
+            },
+            "payload": {
+              "type": "string",
+              "description": "送信ペイロードの式 (例: '{ orderId: @orderId }')"
+            }
+          }
+        }
+      ]
+    },
+
+    "EventSubscribeStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "type", "description", "topic"],
+          "additionalProperties": false,
+          "properties": {
+            "id": true, "description": true, "note": true, "notes": true,
+            "maturity": true, "runIf": true, "outputBinding": true,
+            "txBoundary": true, "transactional": true, "compensatesFor": true,
+            "externalChain": true, "subSteps": true, "requiredPermissions": true, "sla": true,
+            "type": { "const": "eventSubscribe" },
+            "topic": { "type": "string", "description": "サブスクライブするトピック名" },
+            "eventRef": {
+              "type": "string",
+              "description": "ProcessFlow.eventsCatalog のキー参照"
+            },
+            "filter": {
+              "type": "string",
+              "description": "受信フィルター条件の式 (例: '@event.type == \"OrderPlaced\"')"
+            }
+          }
+        }
       ]
     },
     "WorkflowPattern": {
@@ -874,7 +1034,15 @@
               "type": "string",
               "description": "一括 INSERT 時に VALUES 句へ展開する配列変数の参照 (例: \"@poItemValues\")。配列の各要素がレコードとして INSERT される (#253)"
             },
-            "affectedRowsCheck": { "$ref": "#/$defs/AffectedRowsCheck" }
+            "affectedRowsCheck": { "$ref": "#/$defs/AffectedRowsCheck" },
+            "lineage": {
+              "$ref": "#/$defs/DataLineage",
+              "description": "データ系譜 (#423 B-2)。このステップが読み書きするテーブルを宣言する"
+            },
+            "cache": {
+              "$ref": "#/$defs/CacheHint",
+              "description": "キャッシュヒント (#423 B-4)。SELECT 系クエリのキャッシュ設定"
+            }
           }
         }
       ]
@@ -922,6 +1090,8 @@
         { "$ref": "#/$defs/AuditStep" },
         { "$ref": "#/$defs/WorkflowStep" },
         { "$ref": "#/$defs/TransactionScopeStep" },
+        { "$ref": "#/$defs/EventPublishStep" },
+        { "$ref": "#/$defs/EventSubscribeStep" },
         { "$ref": "#/$defs/OtherStep" }
       ]
     },
@@ -1049,6 +1219,14 @@
             "headers": {
               "type": "object",
               "additionalProperties": { "type": "string" }
+            },
+            "apiVersion": {
+              "type": "string",
+              "description": "API バージョン override (#423 B-6)。ProcessFlow.apiVersion より優先"
+            },
+            "cache": {
+              "$ref": "#/$defs/CacheHint",
+              "description": "キャッシュヒント (#423 B-4)。GET 系 API レスポンスのキャッシュ設定"
             }
           }
         }
@@ -1606,6 +1784,8 @@
         { "$ref": "#/$defs/AuditStep" },
         { "$ref": "#/$defs/WorkflowStep" },
         { "$ref": "#/$defs/TransactionScopeStep" },
+        { "$ref": "#/$defs/EventPublishStep" },
+        { "$ref": "#/$defs/EventSubscribeStep" },
         { "$ref": "#/$defs/OtherStep" }
       ]
     }


### PR DESCRIPTION
## 概要

#396 の Tier B 全 6 項目を実装。

## 変更内容

### B-1 イベント pub/sub
- `ProcessFlow.eventsCatalog: Record<string, EventDef>` を追加
- `EventPublishStep` / `EventSubscribeStep` 新ステップ型追加
- `StepType` enum / LABELS / ICONS / COLORS に対応エントリ追加
- `processFlowStore.createDefaultStep` に両型のデフォルト生成を追加

### B-2 データ系譜 (Data Lineage)
- `DbAccessStep.lineage?: DataLineage` を追加 (`reads?`, `writes?` テーブル名配列)

### B-3 ビジネス用語集
- `ProcessFlow.glossary: Record<string, GlossaryEntry>` を追加

### B-4 キャッシュヒント
- `DbAccessStep.cache?: CacheHint` / `ExternalSystemStep.cache?: CacheHint` を追加
- `CacheHint`: `{ ttlSeconds, key?, invalidateOn? }`

### B-5 ADR / 設計判断ログ
- `ProcessFlow.decisions: DecisionRecord[]` を追加
- `DecisionRecord`: MADR 形式準拠 `{ id, title, status, context, decision, consequences?, date? }`

### B-6 API バージョニング
- `ProcessFlow.apiVersion?: string` / `ExternalSystemStep.apiVersion?: string` を追加

## サンプルフロー更新 (cccccccc-0007)
- `apiVersion: "v2"` / `eventsCatalog` / `glossary` / `decisions` をトップレベルに追加
- `EventPublishStep` (step-12) を追加
- `DbAccessStep.lineage` / `cache` / `ExternalSystemStep.apiVersion` を追加

## テスト計画

- [x] vite build pass
- [x] vitest pass (process-flow.schema.test.ts — 159 tests)
- [x] lint pass
- [x] 新規 Tier-B テストケース pass (B-1〜B-6 全カバー)

Closes #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)