### PR TITLE
feat(processflow): Tier C — Circuit Breaker/締め処理/CDC/Health/リソース要件 (#426)

### DIFF
--- a/designer/src/store/processFlowStore.ts
+++ b/designer/src/store/processFlowStore.ts
@@ -274,6 +274,16 @@ export function createDefaultStep(type: StepType): Step {
       return { ...base, type: "eventPublish", topic: "" };
     case "eventSubscribe":
       return { ...base, type: "eventSubscribe", topic: "" };
+    case "closing":
+      return { ...base, type: "closing", period: "monthly" };
+    case "cdc":
+      return {
+        ...base,
+        type: "cdc",
+        tables: [],
+        captureMode: "incremental",
+        destination: { type: "auditLog" },
+      };
     case "other":
       return { ...base, type: "other" };
   }

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -20,6 +20,8 @@ export type StepType =
   | "transactionScope" // 複数 DB 操作を 1 TX でまとめる meta-step (#415)
   | "eventPublish"     // イベント発行 (#423 B-1)
   | "eventSubscribe"   // イベント購読 (#423 B-1)
+  | "closing"          // 締め処理
+  | "cdc"              // CDC
   | "other";           // その他
 
 /** ステップ種別ラベル */
@@ -43,6 +45,8 @@ export const STEP_TYPE_LABELS: Record<StepType, string> = {
   transactionScope: "TX スコープ",
   eventPublish: "イベント発行",
   eventSubscribe: "イベント購読",
+  closing: "締め処理",
+  cdc: "CDC",
   other: "その他",
 };
 
@@ -67,6 +71,8 @@ export const STEP_TYPE_ICONS: Record<StepType, string> = {
   transactionScope: "bi-shield-fill",
   eventPublish: "bi-broadcast",
   eventSubscribe: "bi-broadcast-pin",
+  closing: "bi-calendar-check",
+  cdc: "bi-clock-history",
   other: "bi-three-dots",
 };
 
@@ -91,6 +97,8 @@ export const STEP_TYPE_COLORS: Record<StepType, string> = {
   transactionScope: "#dc2626",
   eventPublish: "#7c3aed",
   eventSubscribe: "#5b21b6",
+  closing: "#be185d",
+  cdc: "#0891b2",
   other: "#9ca3af",
 };
 
@@ -502,6 +510,17 @@ export interface RetryPolicy {
   initialDelayMs?: number;
 }
 
+export interface CircuitBreakerConfig {
+  failureThreshold: number;
+  timeout: number;
+  halfOpenMaxCalls?: number;
+}
+
+export interface BulkheadConfig {
+  maxConcurrent: number;
+  maxWait?: number;
+}
+
 /** 外部システムの認証方式 (#253 v1.2) */
 export type ExternalAuthKind = "bearer" | "basic" | "apiKey" | "oauth2" | "none";
 
@@ -602,6 +621,10 @@ export interface ExternalSystemStep extends StepBase {
   timeoutMs?: number;
   /** リトライ方針。未指定は「リトライなし」 */
   retryPolicy?: RetryPolicy;
+  /** Circuit breaker settings for this external call. */
+  circuitBreaker?: CircuitBreakerConfig;
+  /** Bulkhead settings for this external call. */
+  bulkhead?: BulkheadConfig;
   /** true なら TX 後・非同期 fire-and-forget。同期レスポンスを待たない */
   fireAndForget?: boolean;
   /**
@@ -900,6 +923,33 @@ export interface WorkflowStep extends StepBase {
   escalateTo?: WorkflowEscalateTo;
 }
 
+export type ClosingPeriod = "daily" | "monthly" | "quarterly" | "yearly" | "custom";
+
+export interface ClosingStep extends StepBase {
+  type: "closing";
+  period: ClosingPeriod;
+  customCron?: string;
+  cutoffAt?: string;
+  idempotencyKey?: string;
+  rollbackOnFailure?: boolean;
+}
+
+export type CdcCaptureMode = "full" | "incremental";
+
+export interface CdcDestination {
+  type: "auditLog" | "eventStream" | "table";
+  target?: string;
+}
+
+export interface CdcStep extends StepBase {
+  type: "cdc";
+  tables: string[];
+  captureMode: CdcCaptureMode;
+  destination: CdcDestination;
+  includeColumns?: string[];
+  excludeColumns?: string[];
+}
+
 /** TX 分離レベル (#415) */
 export type TransactionIsolationLevel =
   | "READ_COMMITTED"
@@ -1036,6 +1086,8 @@ export type Step =
   | TransactionScopeStep
   | EventPublishStep
   | EventSubscribeStep
+  | ClosingStep
+  | CdcStep
   | OtherStep;
 
 // ── アクション定義 ───────────────────────────────────────────────────────
@@ -1369,6 +1421,26 @@ export interface FunctionDef {
   examples?: string[];
 }
 
+export interface HealthCheck {
+  name: string;
+  type: "db" | "http" | "custom";
+  target?: string;
+  timeout?: number;
+}
+
+export interface ResourceRequirements {
+  cpu?: {
+    request?: string;
+    limit?: string;
+  };
+  memory?: {
+    request?: string;
+    limit?: string;
+  };
+  dbConnections?: number;
+  timeout?: number;
+}
+
 export interface ProcessFlow {
   id: string;
   name: string;
@@ -1385,6 +1457,9 @@ export interface ProcessFlow {
   maturity?: Maturity;
   /** SLA / Timeout declaration for this flow. */
   sla?: Sla;
+  health?: { checks: HealthCheck[] };
+  readiness?: { checks: HealthCheck[]; minimumPassCount?: number };
+  resources?: ResourceRequirements;
   /** 上流/下流モード。未指定は "upstream" として解釈 (docs/spec/process-flow-maturity.md §5) */
   mode?: ProcessFlowMode;
   /**

--- a/docs/sample-project/process-flows/cccccccc-0009-4000-8000-cccccccccccc.json
+++ b/docs/sample-project/process-flows/cccccccc-0009-4000-8000-cccccccccccc.json
@@ -1,0 +1,175 @@
+{
+  "id": "cccccccc-0009-4000-8000-cccccccccccc",
+  "name": "月次在庫締め処理",
+  "type": "scheduled",
+  "description": "倉庫別の当月在庫を確定し、外部倉庫 API と照合して、締め結果を監査ログへ連携する月次バッチフロー。",
+  "mode": "downstream",
+  "maturity": "committed",
+  "health": {
+    "checks": [
+      {
+        "name": "inventory-db",
+        "type": "db",
+        "target": "inventory",
+        "timeout": 3000
+      },
+      {
+        "name": "warehouse-api",
+        "type": "http",
+        "target": "https://warehouse.example.com/health",
+        "timeout": 5000
+      }
+    ]
+  },
+  "readiness": {
+    "checks": [
+      {
+        "name": "inventory-db-ready",
+        "type": "db",
+        "target": "inventory",
+        "timeout": 3000
+      },
+      {
+        "name": "warehouse-api-ready",
+        "type": "http",
+        "target": "https://warehouse.example.com/ready",
+        "timeout": 5000
+      }
+    ],
+    "minimumPassCount": 2
+  },
+  "resources": {
+    "cpu": {
+      "request": "500m",
+      "limit": "1"
+    },
+    "memory": {
+      "request": "512Mi",
+      "limit": "1Gi"
+    },
+    "dbConnections": 8,
+    "timeout": 900000
+  },
+  "actions": [
+    {
+      "id": "act-monthly-inventory-close",
+      "name": "月次在庫締め",
+      "trigger": "timer",
+      "description": "前月末時点の在庫を集計し、外部倉庫 API と照合したうえで締め結果を確定する。",
+      "maturity": "committed",
+      "inputs": [
+        {
+          "name": "targetMonth",
+          "label": "対象月",
+          "type": "string",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "name": "closedCount",
+          "label": "締め対象件数",
+          "type": "number"
+        }
+      ],
+      "steps": [
+        {
+          "id": "step-01-aggregate-inventory",
+          "type": "dbAccess",
+          "description": "対象月の倉庫別・商品別在庫残高を集計する。",
+          "maturity": "committed",
+          "tableName": "inventory_transactions",
+          "operation": "SELECT",
+          "sql": "SELECT warehouse_id, item_id, SUM(quantity) AS closing_quantity FROM inventory_transactions WHERE occurred_at < @targetMonthEnd GROUP BY warehouse_id, item_id",
+          "outputBinding": "inventorySummary"
+        },
+        {
+          "id": "step-02-sync-warehouse-api",
+          "type": "externalSystem",
+          "description": "外部倉庫システムへ月次締め前の在庫照合を依頼する。",
+          "maturity": "committed",
+          "systemName": "Warehouse API",
+          "httpCall": {
+            "method": "POST",
+            "path": "/api/monthly-inventory/reconcile",
+            "body": "{ month: @targetMonth, summary: @inventorySummary }"
+          },
+          "timeoutMs": 30000,
+          "retryPolicy": {
+            "maxAttempts": 3,
+            "backoff": "exponential",
+            "initialDelayMs": 1000
+          },
+          "circuitBreaker": {
+            "failureThreshold": 5,
+            "timeout": 60000,
+            "halfOpenMaxCalls": 2
+          },
+          "bulkhead": {
+            "maxConcurrent": 4,
+            "maxWait": 3000
+          },
+          "outcomes": {
+            "success": {
+              "action": "continue",
+              "description": "倉庫 API の照合が成功した場合は締め処理へ進む。"
+            },
+            "failure": {
+              "action": "abort",
+              "description": "照合に失敗した場合は締め確定を中止する。"
+            },
+            "timeout": {
+              "action": "abort",
+              "description": "タイムアウト時は翌営業日の再実行対象とする。"
+            }
+          },
+          "outputBinding": "warehouseReconcileResult"
+        },
+        {
+          "id": "step-03-closing",
+          "type": "closing",
+          "description": "対象月の在庫締めを確定し、二重実行を防止する。",
+          "maturity": "committed",
+          "period": "monthly",
+          "cutoffAt": "23:59:59",
+          "idempotencyKey": "inventory-close-@targetMonth",
+          "rollbackOnFailure": true,
+          "outputBinding": "closingResult"
+        },
+        {
+          "id": "step-04-save-closing-results",
+          "type": "dbAccess",
+          "description": "確定した月次在庫締め結果を保存する。",
+          "maturity": "committed",
+          "tableName": "inventory_closing_results",
+          "operation": "INSERT",
+          "sql": "INSERT INTO inventory_closing_results (closing_month, warehouse_id, item_id, closing_quantity) SELECT @targetMonth, warehouse_id, item_id, closing_quantity FROM @inventorySummary",
+          "outputBinding": "closedCount"
+        },
+        {
+          "id": "step-05-cdc",
+          "type": "cdc",
+          "description": "月次在庫締め結果の変更履歴を監査ログへ連携する。",
+          "maturity": "committed",
+          "tables": ["inventory_closing_results"],
+          "captureMode": "incremental",
+          "destination": {
+            "type": "auditLog",
+            "target": "inventory.monthlyClose"
+          },
+          "includeColumns": ["closing_month", "warehouse_id", "item_id", "closing_quantity"],
+          "excludeColumns": ["internal_note"]
+        },
+        {
+          "id": "step-06-return",
+          "type": "return",
+          "description": "月次在庫締めの完了結果を返却する。",
+          "maturity": "committed",
+          "bodyExpression": "{ closedCount: @closedCount }"
+        }
+      ]
+    }
+  ],
+  "createdAt": "2026-04-25T00:00:00.000Z",
+  "updatedAt": "2026-04-25T00:00:00.000Z"
+}

--- a/docs/sample-project/process-flows/cccccccc-0009-4000-8000-cccccccccccc.json
+++ b/docs/sample-project/process-flows/cccccccc-0009-4000-8000-cccccccccccc.json
@@ -63,6 +63,12 @@
           "label": "対象月",
           "type": "string",
           "required": true
+        },
+        {
+          "name": "targetMonthEnd",
+          "label": "対象月末日時",
+          "type": "string",
+          "required": true
         }
       ],
       "outputs": [

--- a/docs/sample-project/seed.mjs
+++ b/docs/sample-project/seed.mjs
@@ -29,6 +29,7 @@ const SEED_SCREEN_ITEMS_DIR = path.join(__dirname, "screen-items");
 // 新規追加した process flow は必須ファイルとして明示して seed 対象にする。古いファイルは省略可
 const REQUIRED_PROCESS_FLOW_FILES = [
   "cccccccc-0008-4000-8000-cccccccccccc.json",
+  "cccccccc-0009-4000-8000-cccccccccccc.json",
 ];
 
 fs.mkdirSync(SCREENS_DIR, { recursive: true });

--- a/docs/spec/process-flow-tier-c.md
+++ b/docs/spec/process-flow-tier-c.md
@@ -1,0 +1,106 @@
+# ProcessFlow Tier C 仕様
+
+関連 issue: #426
+
+本仕様は処理フロー JSON Schema の Tier C 拡張を定義する。一次成果物は `schemas/process-flow.schema.json` であり、TypeScript 型と UI 表示定義は派生物として追従する。
+
+## C-1 ExternalSystemStep の耐障害性設定
+
+`ExternalSystemStep` は外部システム呼び出し単位で circuit breaker と bulkhead を任意指定できる。
+
+```json
+{
+  "type": "externalSystem",
+  "circuitBreaker": {
+    "failureThreshold": 5,
+    "timeout": 60000,
+    "halfOpenMaxCalls": 2
+  },
+  "bulkhead": {
+    "maxConcurrent": 4,
+    "maxWait": 3000
+  }
+}
+```
+
+`circuitBreaker.failureThreshold` と `circuitBreaker.timeout` は必須。`halfOpenMaxCalls` は half-open 時に許可する試行数を表す。
+
+`bulkhead.maxConcurrent` は必須。`maxWait` は同時実行枠が空くまで待つ最大時間を表す。
+
+## C-2 ClosingStep
+
+`ClosingStep` は日次・月次・四半期・年次などの締め処理境界を表す。
+
+```json
+{
+  "id": "step-close",
+  "type": "closing",
+  "description": "月次在庫締めを確定する",
+  "period": "monthly",
+  "cutoffAt": "23:59:59",
+  "idempotencyKey": "inventory-close-@targetMonth",
+  "rollbackOnFailure": true
+}
+```
+
+`period` は `daily` / `monthly` / `quarterly` / `yearly` / `custom` のいずれか。`custom` を使う場合は `customCron` でスケジュール式を補足できる。
+
+## C-3 CdcStep
+
+`CdcStep` は対象テーブルの変更捕捉と、その出力先を宣言する。
+
+```json
+{
+  "id": "step-cdc",
+  "type": "cdc",
+  "description": "在庫締め結果の変更履歴を監査ログへ送る",
+  "tables": ["inventory_closing_results"],
+  "captureMode": "incremental",
+  "destination": {
+    "type": "auditLog",
+    "target": "inventory.monthlyClose"
+  },
+  "includeColumns": ["item_id", "closing_month", "closing_quantity"]
+}
+```
+
+`tables`、`captureMode`、`destination` は必須。`destination.type` は `auditLog` / `eventStream` / `table` のいずれか。
+
+## C-4 Health / Readiness
+
+`ProcessFlow` 直下に `health` と `readiness` を任意で定義できる。
+
+```json
+{
+  "health": {
+    "checks": [
+      { "name": "inventory-db", "type": "db", "target": "inventory" }
+    ]
+  },
+  "readiness": {
+    "checks": [
+      { "name": "warehouse-api", "type": "http", "target": "https://warehouse.example.com/health" }
+    ],
+    "minimumPassCount": 1
+  }
+}
+```
+
+`HealthCheck.type` は `db` / `http` / `custom` のいずれか。`readiness.minimumPassCount` は readiness 判定に必要な成功数を表す。
+
+## C-5 ResourceRequirements
+
+`ProcessFlow` 直下に `resources` を任意で定義できる。
+
+```json
+{
+  "resources": {
+    "cpu": { "request": "500m", "limit": "1" },
+    "memory": { "request": "512Mi", "limit": "1Gi" },
+    "dbConnections": 8,
+    "timeout": 900000
+  }
+}
+```
+
+`resources` は実装時の実行基盤向け目安であり、既存フローに対して後方互換の optional フィールドとして扱う。

--- a/schemas/process-flow.schema.json
+++ b/schemas/process-flow.schema.json
@@ -19,6 +19,9 @@
     "maturity": { "$ref": "#/$defs/Maturity" },
     "mode": { "$ref": "#/$defs/ProcessFlowMode" },
     "sla": { "$ref": "#/$defs/Sla" },
+    "health": { "$ref": "#/$defs/HealthCheckGroup" },
+    "readiness": { "$ref": "#/$defs/ReadinessCheckGroup" },
+    "resources": { "$ref": "#/$defs/ResourceRequirements" },
     "errorCatalog": {
       "description": "エラーコードカタログ (#253)。キーは errorCode (例: STOCK_SHORTAGE)。affectedRowsCheck.errorCode / BranchConditionVariant.errorCode から参照される",
       "type": "object",
@@ -318,6 +321,8 @@
         "transactionScope",
         "eventPublish",
         "eventSubscribe",
+        "closing",
+        "cdc",
         "other"
       ]
     },
@@ -460,6 +465,60 @@
         }
       ]
     },
+
+    "HealthCheck": {
+      "type": "object",
+      "required": ["name", "type"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "type": { "type": "string", "enum": ["db", "http", "custom"] },
+        "target": { "type": "string" },
+        "timeout": { "type": "number", "minimum": 0 }
+      }
+    },
+    "HealthCheckGroup": {
+      "type": "object",
+      "required": ["checks"],
+      "additionalProperties": false,
+      "properties": {
+        "checks": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/HealthCheck" }
+        }
+      }
+    },
+    "ReadinessCheckGroup": {
+      "type": "object",
+      "required": ["checks"],
+      "additionalProperties": false,
+      "properties": {
+        "checks": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/HealthCheck" }
+        },
+        "minimumPassCount": { "type": "number", "minimum": 0 }
+      }
+    },
+    "ResourceQuota": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "request": { "type": "string" },
+        "limit": { "type": "string" }
+      }
+    },
+    "ResourceRequirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "cpu": { "$ref": "#/$defs/ResourceQuota" },
+        "memory": { "$ref": "#/$defs/ResourceQuota" },
+        "dbConnections": { "type": "number", "minimum": 0 },
+        "timeout": { "type": "number", "minimum": 0 }
+      }
+    },
+
     "WorkflowPattern": {
       "type": "string",
       "enum": [
@@ -1092,6 +1151,8 @@
         { "$ref": "#/$defs/TransactionScopeStep" },
         { "$ref": "#/$defs/EventPublishStep" },
         { "$ref": "#/$defs/EventSubscribeStep" },
+        { "$ref": "#/$defs/ClosingStep" },
+        { "$ref": "#/$defs/CdcStep" },
         { "$ref": "#/$defs/OtherStep" }
       ]
     },
@@ -1106,6 +1167,25 @@
           "enum": ["fixed", "exponential"]
         },
         "initialDelayMs": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "CircuitBreakerConfig": {
+      "type": "object",
+      "required": ["failureThreshold", "timeout"],
+      "additionalProperties": false,
+      "properties": {
+        "failureThreshold": { "type": "number", "minimum": 0 },
+        "timeout": { "type": "number", "minimum": 0 },
+        "halfOpenMaxCalls": { "type": "number", "minimum": 0 }
+      }
+    },
+    "BulkheadConfig": {
+      "type": "object",
+      "required": ["maxConcurrent"],
+      "additionalProperties": false,
+      "properties": {
+        "maxConcurrent": { "type": "number", "minimum": 0 },
+        "maxWait": { "type": "number", "minimum": 0 }
       }
     },
     "ExternalAuthKind": {
@@ -1213,6 +1293,8 @@
             },
             "timeoutMs": { "type": "integer", "minimum": 0 },
             "retryPolicy": { "$ref": "#/$defs/RetryPolicy" },
+            "circuitBreaker": { "$ref": "#/$defs/CircuitBreakerConfig" },
+            "bulkhead": { "$ref": "#/$defs/BulkheadConfig" },
             "fireAndForget": { "type": "boolean" },
             "auth": { "$ref": "#/$defs/ExternalAuth" },
             "idempotencyKey": { "type": "string" },
@@ -1714,6 +1796,78 @@
       ]
     },
 
+    "ClosingPeriod": {
+      "type": "string",
+      "enum": ["daily", "monthly", "quarterly", "yearly", "custom"]
+    },
+    "ClosingStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "type", "description", "period"],
+          "additionalProperties": false,
+          "properties": {
+            "id": true, "description": true, "note": true, "notes": true,
+            "maturity": true, "runIf": true, "outputBinding": true,
+            "txBoundary": true, "transactional": true, "compensatesFor": true,
+            "externalChain": true, "subSteps": true, "requiredPermissions": true, "sla": true,
+            "type": { "const": "closing" },
+            "period": { "$ref": "#/$defs/ClosingPeriod" },
+            "customCron": { "type": "string" },
+            "cutoffAt": { "type": "string" },
+            "idempotencyKey": { "type": "string" },
+            "rollbackOnFailure": { "type": "boolean" }
+          }
+        }
+      ]
+    },
+
+    "CdcCaptureMode": {
+      "type": "string",
+      "enum": ["full", "incremental"]
+    },
+    "CdcDestination": {
+      "type": "object",
+      "required": ["type"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "type": "string", "enum": ["auditLog", "eventStream", "table"] },
+        "target": { "type": "string" }
+      }
+    },
+    "CdcStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "type", "description", "tables", "captureMode", "destination"],
+          "additionalProperties": false,
+          "properties": {
+            "id": true, "description": true, "note": true, "notes": true,
+            "maturity": true, "runIf": true, "outputBinding": true,
+            "txBoundary": true, "transactional": true, "compensatesFor": true,
+            "externalChain": true, "subSteps": true, "requiredPermissions": true, "sla": true,
+            "type": { "const": "cdc" },
+            "tables": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "captureMode": { "$ref": "#/$defs/CdcCaptureMode" },
+            "destination": { "$ref": "#/$defs/CdcDestination" },
+            "includeColumns": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "excludeColumns": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          }
+        }
+      ]
+    },
+
     "TransactionIsolationLevel": {
       "type": "string",
       "enum": ["READ_COMMITTED", "REPEATABLE_READ", "SERIALIZABLE"]
@@ -1786,6 +1940,8 @@
         { "$ref": "#/$defs/TransactionScopeStep" },
         { "$ref": "#/$defs/EventPublishStep" },
         { "$ref": "#/$defs/EventSubscribeStep" },
+        { "$ref": "#/$defs/ClosingStep" },
+        { "$ref": "#/$defs/CdcStep" },
         { "$ref": "#/$defs/OtherStep" }
       ]
     }


### PR DESCRIPTION
## 概要

#426 の実装。処理フロー仕様に Tier C 5 項目を追加。

Closes #426

## 変更内容

- C-1: ExternalSystemStep に circuitBreaker / bulkhead optional フィールド追加
- C-2: 新ステップタイプ ClosingStep (type: closing) — 締め処理パターン
- C-3: 新ステップタイプ CdcStep (type: cdc) — 変更履歴/CDC
- C-4: ProcessFlowRoot に health / readiness フィールド追加
- C-5: ProcessFlowRoot に resources フィールド追加

## テスト

- [ ] `cd designer && npm run build` pass
- [ ] `cd designer && npx vitest run src/schemas/process-flow.schema.test.ts` pass
- [ ] `cd designer && npx vitest run` pass

## 仕様逐条突合

- C-1 circuitBreaker: `schemas/process-flow.schema.json` ExternalSystemStep
- C-1 bulkhead: `schemas/process-flow.schema.json` ExternalSystemStep
- C-2 ClosingStep: StepType enum + $defs.ClosingStep
- C-3 CdcStep: StepType enum + $defs.CdcStep
- C-4 health/readiness: ProcessFlowRoot properties
- C-5 resources: ProcessFlowRoot properties
- サンプル cccccccc-0009 で全 C 項目をカバー