### PR TITLE
feat(processflow): P3-2/P3-3/P3-4 — Criterion 多様化 / Arazzo Export / Solution pack・unpack (#427)

### DIFF
--- a/designer-mcp/package-lock.json
+++ b/designer-mcp/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "adm-zip": "^0.5.17",
         "htmlparser2": "^12.0.0",
         "ws": "^8.20.0",
         "zod": "^3.23.8"
@@ -17,6 +18,7 @@
         "designer-mcp": "dist/index.js"
       },
       "devDependencies": {
+        "@types/adm-zip": "^0.5.8",
         "@types/node": "^20.0.0",
         "@types/ws": "^8.5.12",
         "tsx": "^4.19.0",
@@ -870,6 +872,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/adm-zip": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.8.tgz",
+      "integrity": "sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -1039,6 +1051,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/ajv": {

--- a/designer-mcp/package.json
+++ b/designer-mcp/package.json
@@ -14,11 +14,13 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "adm-zip": "^0.5.17",
     "htmlparser2": "^12.0.0",
     "ws": "^8.20.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@types/adm-zip": "^0.5.8",
     "@types/node": "^20.0.0",
     "@types/ws": "^8.5.12",
     "tsx": "^4.19.0",

--- a/designer-mcp/src/handlers/processFlow.ts
+++ b/designer-mcp/src/handlers/processFlow.ts
@@ -1,14 +1,18 @@
 /**
  * ProcessFlow / step / catalog 関連 MCP tool handler (#261)
  *
- * 対象 (14 ツール):
+ * 対象 (17 ツール):
  * - designer__list_process_flows / get_process_flow
  * - designer__add_process_flow / update_process_flow / delete_process_flow
  * - designer__add_action / add_step / update_step / remove_step / move_step
  * - designer__set_maturity / add_step_note
  * - designer__add_catalog_entry / remove_catalog_entry
+ * - designer__export_arazzo (#427 P3-3)
+ * - designer__solution_pack / solution_unpack (#427 P3-4)
  */
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+import path from "node:path";
+import AdmZip from "adm-zip";
 import {
   readProcessFlow,
   writeProcessFlow,
@@ -16,6 +20,7 @@ import {
   listProcessFlows as listProcessFlowFiles,
   readProject,
   writeProject,
+  DATA_DIR,
 } from "../projectStorage.js";
 import {
   updateStep as editUpdateStep,
@@ -275,7 +280,224 @@ export const handleProcessFlowTool: ToolHandler = async (name, args) => {
       return { content: [{ type: "text", text: `${a.catalog}.${a.key} を削除しました。` }] };
     }
 
+    case "designer__export_arazzo": {
+      if (typeof a.processFlowId !== "string") {
+        throw new McpError(ErrorCode.InvalidParams, "processFlowId は必須です");
+      }
+      const flow = await readProcessFlow(a.processFlowId) as Record<string, unknown> | null;
+      if (!flow) throw new McpError(ErrorCode.InvalidParams, `処理フロー ${a.processFlowId} が見つかりません`);
+
+      const fmt = (a.outputFormat as string | undefined) ?? "yaml";
+      const arazzo = buildArazzoDoc(flow);
+
+      let text: string;
+      if (fmt === "json") {
+        text = JSON.stringify(arazzo, null, 2);
+      } else {
+        text = toYaml(arazzo);
+      }
+      return { content: [{ type: "text", text }] };
+    }
+
+    case "designer__solution_pack": {
+      const ids = a.processFlowIds as string[] | undefined;
+      if (!Array.isArray(ids) || ids.length === 0) {
+        throw new McpError(ErrorCode.InvalidParams, "processFlowIds は 1 件以上の配列が必要です");
+      }
+      if (typeof a.publisherPrefix !== "string" || typeof a.version !== "string" || typeof a.outputPath !== "string") {
+        throw new McpError(ErrorCode.InvalidParams, "publisherPrefix, version, outputPath は必須です");
+      }
+
+      const outPath = path.isAbsolute(a.outputPath as string)
+        ? (a.outputPath as string)
+        : path.join(DATA_DIR, a.outputPath as string);
+
+      const zip = new AdmZip();
+      const manifest = {
+        publisher: a.publisherPrefix,
+        version: a.version,
+        processFlowIds: ids,
+        createdAt: new Date().toISOString(),
+      };
+      zip.addFile("manifest.json", Buffer.from(JSON.stringify(manifest, null, 2), "utf8"));
+
+      const missing: string[] = [];
+      for (const id of ids) {
+        const doc = await readProcessFlow(id);
+        if (!doc) { missing.push(id); continue; }
+        zip.addFile(`process-flows/${id}.json`, Buffer.from(JSON.stringify(doc, null, 2), "utf8"));
+      }
+      zip.writeZip(outPath);
+
+      const msg = missing.length > 0
+        ? `${outPath} に ${ids.length - missing.length} 件をパック。見つからない ID: ${missing.join(", ")}`
+        : `${outPath} に ${ids.length} 件をパックしました。`;
+      return { content: [{ type: "text", text: msg }] };
+    }
+
+    case "designer__solution_unpack": {
+      if (typeof a.inputPath !== "string") {
+        throw new McpError(ErrorCode.InvalidParams, "inputPath は必須です");
+      }
+      const inPath = path.isAbsolute(a.inputPath as string)
+        ? (a.inputPath as string)
+        : path.join(DATA_DIR, a.inputPath as string);
+      const conflict = (a.conflictResolution as string | undefined) ?? "skip";
+
+      const zip = new AdmZip(inPath);
+      const entries = zip.getEntries().filter(e => e.entryName.startsWith("process-flows/") && e.entryName.endsWith(".json") && !e.isDirectory);
+
+      const actionsDir = path.join(DATA_DIR, "actions");
+      const results: string[] = [];
+
+      for (const entry of entries) {
+        const raw = entry.getData().toString("utf8");
+        let doc: Record<string, unknown>;
+        try { doc = JSON.parse(raw); } catch { results.push(`SKIP (parse error): ${entry.entryName}`); continue; }
+
+        const id = doc.id as string | undefined;
+        if (!id) { results.push(`SKIP (no id): ${entry.entryName}`); continue; }
+
+        const destPath = path.join(actionsDir, `${id}.json`);
+        const { existsSync } = await import("node:fs");
+        const exists = existsSync(destPath);
+
+        if (exists && conflict === "skip") {
+          results.push(`SKIP (exists): ${id}`);
+          continue;
+        }
+
+        let writeId = id;
+        if (exists && conflict === "rename") {
+          const prefix = (a.publisherPrefix as string | undefined) ?? "imported";
+          writeId = `${prefix}_${id}`;
+          doc = { ...doc, id: writeId };
+        }
+
+        await writeProcessFlow(writeId, doc);
+        results.push(`OK: ${writeId}`);
+      }
+
+      return { content: [{ type: "text", text: `展開完了 (${results.length} 件):\n${results.join("\n")}` }] };
+    }
+
     default:
       return null;
   }
 };
+
+// ---- Arazzo export helpers ----
+
+interface ArazzoStep {
+  stepId: string;
+  operationId?: string;
+  operationPath?: string;
+  successCriteria?: unknown[];
+}
+
+interface ArazzoDoc {
+  arazzo: string;
+  info: { title: string; version: string };
+  sourceDescriptions: Array<{ name: string; url: string; type: string }>;
+  workflows: Array<{ workflowId: string; steps: ArazzoStep[] }>;
+}
+
+function collectExternalSteps(steps: unknown[]): Array<Record<string, unknown>> {
+  const result: Array<Record<string, unknown>> = [];
+  for (const step of steps) {
+    const s = step as Record<string, unknown>;
+    if (s.type === "externalSystem") result.push(s);
+    if (Array.isArray(s.steps)) result.push(...collectExternalSteps(s.steps as unknown[]));
+    if (Array.isArray(s.branches)) {
+      for (const b of s.branches as Array<{ steps?: unknown[] }>) {
+        if (Array.isArray(b.steps)) result.push(...collectExternalSteps(b.steps));
+      }
+    }
+    if (s.elseBranch && Array.isArray((s.elseBranch as { steps?: unknown[] }).steps)) {
+      result.push(...collectExternalSteps((s.elseBranch as { steps: unknown[] }).steps));
+    }
+    if (Array.isArray(s.subSteps)) result.push(...collectExternalSteps(s.subSteps as unknown[]));
+  }
+  return result;
+}
+
+function buildArazzoDoc(flow: Record<string, unknown>): ArazzoDoc {
+  const flowId = flow.id as string;
+  const flowName = flow.name as string ?? flowId;
+  const catalog = (flow.externalSystemCatalog ?? {}) as Record<string, Record<string, unknown>>;
+
+  const allSteps: Array<Record<string, unknown>> = [];
+  for (const action of (flow.actions ?? []) as Array<{ steps?: unknown[] }>) {
+    if (Array.isArray(action.steps)) allSteps.push(...collectExternalSteps(action.steps));
+  }
+
+  const seenSystems = new Map<string, string>();
+  for (const step of allSteps) {
+    const sysRef = step.systemRef as string | undefined;
+    const sysName = step.systemName as string | undefined;
+    const key = sysRef ?? sysName ?? "unknown";
+    if (!seenSystems.has(key)) {
+      const entry = sysRef ? catalog[sysRef] : undefined;
+      const url = (entry?.openApiSpec as string | undefined) ?? "#unknown";
+      seenSystems.set(key, url);
+    }
+  }
+
+  const sourceDescriptions = Array.from(seenSystems.entries()).map(([name, url]) => ({
+    name,
+    url,
+    type: "openapi",
+  }));
+
+  const arazzoSteps: ArazzoStep[] = allSteps.map(step => {
+    const s: ArazzoStep = { stepId: step.id as string };
+    if (step.operationId) s.operationId = step.operationId as string;
+    else if (step.operationRef) s.operationPath = step.operationRef as string;
+    else if (step.httpCall) {
+      const hc = step.httpCall as { method?: string; path?: string };
+      s.operationPath = `${hc.method ?? "POST"} ${hc.path ?? "/"}`;
+    }
+    if (Array.isArray(step.successCriteria) && step.successCriteria.length > 0) {
+      s.successCriteria = step.successCriteria;
+    }
+    return s;
+  });
+
+  return {
+    arazzo: "1.0.1",
+    info: { title: flowName, version: "1.0" },
+    sourceDescriptions,
+    workflows: [{ workflowId: flowId, steps: arazzoSteps }],
+  };
+}
+
+function toYaml(obj: unknown, indent = 0): string {
+  const pad = "  ".repeat(indent);
+  if (obj === null || obj === undefined) return "null";
+  if (typeof obj === "boolean") return obj ? "true" : "false";
+  if (typeof obj === "number") return String(obj);
+  if (typeof obj === "string") {
+    if (/[\n:#{}\[\],&*?|<>=!%@`]/.test(obj) || obj.trim() !== obj) {
+      return `"${obj.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+    }
+    return obj;
+  }
+  if (Array.isArray(obj)) {
+    if (obj.length === 0) return "[]";
+    return obj.map(item => `\n${pad}- ${toYaml(item, indent + 1).trimStart()}`).join("");
+  }
+  const entries = Object.entries(obj as Record<string, unknown>).filter(([, v]) => v !== undefined);
+  if (entries.length === 0) return "{}";
+  return entries
+    .map(([k, v]) => {
+      const valStr = toYaml(v, indent + 1);
+      if (typeof v === "object" && v !== null && !Array.isArray(v)) {
+        return `\n${pad}${k}:${valStr}`;
+      }
+      if (Array.isArray(v)) {
+        return `\n${pad}${k}:${valStr}`;
+      }
+      return `\n${pad}${k}: ${valStr}`;
+    })
+    .join("");
+}

--- a/designer-mcp/src/handlers/processFlow.ts
+++ b/designer-mcp/src/handlers/processFlow.ts
@@ -515,13 +515,10 @@ function toYaml(obj: unknown, indent = 0): string {
   return entries
     .map(([k, v]) => {
       const valStr = toYaml(v, indent + 1);
-      if (typeof v === "object" && v !== null && !Array.isArray(v)) {
-        return `\n${pad}${k}:${valStr}`;
-      }
-      if (Array.isArray(v)) {
-        return `\n${pad}${k}:${valStr}`;
-      }
-      return `\n${pad}${k}: ${valStr}`;
+      // non-empty objects/arrays: valStr starts with \n — omit space (key:\n  ...)
+      // empty or scalar: valStr does not start with \n — add space (key: value)
+      const sep = valStr.startsWith("\n") ? "" : " ";
+      return `\n${pad}${k}:${sep}${valStr}`;
     })
     .join("");
 }

--- a/designer-mcp/src/handlers/processFlow.ts
+++ b/designer-mcp/src/handlers/processFlow.ts
@@ -12,6 +12,7 @@
  */
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import path from "node:path";
+import fs from "node:fs";
 import AdmZip from "adm-zip";
 import {
   readProcessFlow,
@@ -294,7 +295,7 @@ export const handleProcessFlowTool: ToolHandler = async (name, args) => {
       if (fmt === "json") {
         text = JSON.stringify(arazzo, null, 2);
       } else {
-        text = toYaml(arazzo);
+        text = toYaml(arazzo).trimStart();
       }
       return { content: [{ type: "text", text }] };
     }
@@ -327,6 +328,7 @@ export const handleProcessFlowTool: ToolHandler = async (name, args) => {
         if (!doc) { missing.push(id); continue; }
         zip.addFile(`process-flows/${id}.json`, Buffer.from(JSON.stringify(doc, null, 2), "utf8"));
       }
+      fs.mkdirSync(path.dirname(outPath), { recursive: true });
       zip.writeZip(outPath);
 
       const msg = missing.length > 0
@@ -359,8 +361,7 @@ export const handleProcessFlowTool: ToolHandler = async (name, args) => {
         if (!id) { results.push(`SKIP (no id): ${entry.entryName}`); continue; }
 
         const destPath = path.join(actionsDir, `${id}.json`);
-        const { existsSync } = await import("node:fs");
-        const exists = existsSync(destPath);
+        const exists = fs.existsSync(destPath);
 
         if (exists && conflict === "skip") {
           results.push(`SKIP (exists): ${id}`);
@@ -402,21 +403,39 @@ interface ArazzoDoc {
   workflows: Array<{ workflowId: string; steps: ArazzoStep[] }>;
 }
 
+function collectNestedStepLists(s: Record<string, unknown>): Array<unknown[]> {
+  const lists: Array<unknown[]> = [];
+  const push = (v: unknown) => { if (Array.isArray(v)) lists.push(v as unknown[]); };
+  // branch / loop / transactionScope / workflow inner steps
+  push(s.steps);
+  push(s.subSteps);
+  push(s.onCommit);    // TransactionScopeStep
+  push(s.onRollback);  // TransactionScopeStep
+  push(s.onApproved);  // WorkflowStep
+  push(s.onRejected);  // WorkflowStep
+  push(s.onTimeout);   // WorkflowStep
+  // branches
+  if (Array.isArray(s.branches)) {
+    for (const b of s.branches as Array<{ steps?: unknown[] }>) push(b.steps);
+  }
+  if (s.elseBranch) push((s.elseBranch as { steps?: unknown[] }).steps);
+  // ExternalCallOutcomeSpec sideEffects
+  if (s.outcomes && typeof s.outcomes === "object") {
+    for (const oc of Object.values(s.outcomes as Record<string, { sideEffects?: unknown[] }>)) {
+      if (oc && Array.isArray(oc.sideEffects)) lists.push(oc.sideEffects);
+    }
+  }
+  return lists;
+}
+
 function collectExternalSteps(steps: unknown[]): Array<Record<string, unknown>> {
   const result: Array<Record<string, unknown>> = [];
   for (const step of steps) {
     const s = step as Record<string, unknown>;
     if (s.type === "externalSystem") result.push(s);
-    if (Array.isArray(s.steps)) result.push(...collectExternalSteps(s.steps as unknown[]));
-    if (Array.isArray(s.branches)) {
-      for (const b of s.branches as Array<{ steps?: unknown[] }>) {
-        if (Array.isArray(b.steps)) result.push(...collectExternalSteps(b.steps));
-      }
+    for (const nested of collectNestedStepLists(s)) {
+      result.push(...collectExternalSteps(nested));
     }
-    if (s.elseBranch && Array.isArray((s.elseBranch as { steps?: unknown[] }).steps)) {
-      result.push(...collectExternalSteps((s.elseBranch as { steps: unknown[] }).steps));
-    }
-    if (Array.isArray(s.subSteps)) result.push(...collectExternalSteps(s.subSteps as unknown[]));
   }
   return result;
 }
@@ -477,7 +496,12 @@ function toYaml(obj: unknown, indent = 0): string {
   if (typeof obj === "boolean") return obj ? "true" : "false";
   if (typeof obj === "number") return String(obj);
   if (typeof obj === "string") {
-    if (/[\n:#{}\[\],&*?|<>=!%@`]/.test(obj) || obj.trim() !== obj) {
+    const needsQuote =
+      /[\n:#{}\[\],&*?|<>=!%@`]/.test(obj) ||
+      obj.trim() !== obj ||
+      /^(true|false|null|~|yes|no|on|off)$/i.test(obj) ||
+      /^[-+]?(?:\d+\.?\d*|\.\d+)(?:[eE][-+]?\d+)?$/.test(obj);
+    if (needsQuote) {
       return `"${obj.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
     }
     return obj;

--- a/designer-mcp/src/tools.ts
+++ b/designer-mcp/src/tools.ts
@@ -1066,6 +1066,10 @@ export const tools = [
           enum: ["skip", "overwrite", "rename"],
           description: "ID 衝突時の解決方針。skip: 既存を維持 / overwrite: 上書き / rename: プレフィックス付きで保存。デフォルト: skip",
         },
+        publisherPrefix: {
+          type: "string",
+          description: "conflictResolution=rename 時に ID の先頭に付与するプレフィックス (例: myapp)。省略時は \"imported\"",
+        },
       },
       required: ["inputPath"],
     },

--- a/designer-mcp/src/tools.ts
+++ b/designer-mcp/src/tools.ts
@@ -996,4 +996,78 @@ export const tools = [
       required: ["processFlowId", "markerId"],
     },
   },
+
+  {
+    name: "designer__export_arazzo",
+    description:
+      "ProcessFlow 内の ExternalSystemStep を Arazzo 1.0 YAML / JSON として出力します。" +
+      "フロー中の外部 API 呼び出しを Arazzo ワークフロー形式にエクスポートし、OpenAPI ツールとの連携に利用できます。",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        processFlowId: {
+          type: "string",
+          description: "対象フロー ID",
+        },
+        outputFormat: {
+          type: "string",
+          enum: ["yaml", "json"],
+          description: "出力形式。デフォルト: yaml",
+        },
+      },
+      required: ["processFlowId"],
+    },
+  },
+
+  {
+    name: "designer__solution_pack",
+    description:
+      "指定した処理フロー群を solution ZIP ファイルにパッケージングします。" +
+      "プロジェクト間でフロー定義を配布・共有するための pack 機能 (Power Platform Solution 相当)。",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        processFlowIds: {
+          type: "array",
+          items: { type: "string" },
+          description: "ZIP に同梱するフロー ID の配列",
+        },
+        publisherPrefix: {
+          type: "string",
+          description: "プロジェクト識別子 (ID 衝突防止プレフィックス, 例: myapp)",
+        },
+        version: {
+          type: "string",
+          description: "バージョン文字列 (例: 1.0.0)",
+        },
+        outputPath: {
+          type: "string",
+          description: "出力先 .zip パス (絶対パスまたは data/ からの相対パス)",
+        },
+      },
+      required: ["processFlowIds", "publisherPrefix", "version", "outputPath"],
+    },
+  },
+
+  {
+    name: "designer__solution_unpack",
+    description:
+      "solution ZIP ファイルを展開し、フロー定義を data/actions/ に取り込みます。" +
+      "solution_pack で作成した ZIP を別プロジェクトで展開する unpack 機能。",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        inputPath: {
+          type: "string",
+          description: "展開する .zip パス (絶対パスまたは data/ からの相対パス)",
+        },
+        conflictResolution: {
+          type: "string",
+          enum: ["skip", "overwrite", "rename"],
+          description: "ID 衝突時の解決方針。skip: 既存を維持 / overwrite: 上書き / rename: プレフィックス付きで保存。デフォルト: skip",
+        },
+      },
+      required: ["inputPath"],
+    },
+  },
 ];

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -554,6 +554,23 @@ export interface ExternalHttpCall {
   body?: string;
 }
 
+/** Criterion の評価種別 (#427 P3-2 / Arazzo 由来) */
+export type CriterionType = "simple" | "regex" | "jsonpath" | "xpath";
+
+/**
+ * 型付き条件式 (#427 P3-2)。Arazzo 1.0 の successCriteria 互換。
+ * simple: "@status == 200", regex: "^[0-9]+$", jsonpath: "$.items[0].id", xpath: "//result/text()"
+ */
+export interface StructuredCriterion {
+  type: CriterionType;
+  expression: string;
+  /** jsonpath / xpath の評価対象 (例: "@responseBody") */
+  context?: string;
+}
+
+/** 成功判定条件 (#427 P3-2)。string (旧互換) または StructuredCriterion の union */
+export type Criterion = string | StructuredCriterion;
+
 /**
  * ProcessFlow.externalSystemCatalog エントリ (#261 v1.3)。
  * 同一外部システム (Stripe, SendGrid 等) を使う複数ステップで auth/baseUrl/timeoutMs/retryPolicy を集約し、
@@ -649,6 +666,8 @@ export interface ExternalSystemStep extends StepBase {
   apiVersion?: string;
   /** キャッシュヒント (#423 B-4)。GET 系 API レスポンスのキャッシュ設定 */
   cache?: CacheHint;
+  /** Arazzo 互換の成功判定条件 (#427 P3-2)。Arazzo Export で successCriteria フィールドにマッピングされる */
+  successCriteria?: Criterion[];
 }
 
 export interface CommonProcessStep extends StepBase {

--- a/docs/sample-project/process-flows/cccccccc-0010-4000-8000-cccccccccccc.json
+++ b/docs/sample-project/process-flows/cccccccc-0010-4000-8000-cccccccccccc.json
@@ -1,8 +1,8 @@
 {
-  "id": "cccccccc-0009-4000-8000-cccccccccccc",
+  "id": "cccccccc-0010-4000-8000-cccccccccccc",
   "name": "決済処理",
   "type": "screen",
-  "screenId": "aaaaaaaa-0009-4000-8000-aaaaaaaaaaaa",
+  "screenId": "aaaaaaaa-0010-4000-8000-aaaaaaaaaaaa",
   "description": "#427 P3-2 実証サンプル: StructuredCriterion (jsonpath / simple / regex) を使う外部 API 呼び出しと Arazzo 互換 successCriteria を示す。Stripe 決済 API との連携フロー。",
   "maturity": "draft",
 

--- a/docs/spec/process-flow-criterion.md
+++ b/docs/spec/process-flow-criterion.md
@@ -1,0 +1,59 @@
+# Criterion — 成功判定条件仕様 (#427 P3-2)
+
+`Criterion` は ExternalSystemStep の `successCriteria` フィールドで使う条件式型です。Arazzo 1.0 仕様の `successCriteria` に対応し、外部 API 呼び出しの成否をプログラム的に判定します。
+
+## 型定義
+
+```ts
+type CriterionType = "simple" | "regex" | "jsonpath" | "xpath";
+
+interface StructuredCriterion {
+  type: CriterionType;
+  expression: string;    // 評価式
+  context?: string;      // 評価対象 (jsonpath / xpath で必須)
+}
+
+type Criterion = string | StructuredCriterion;
+```
+
+後方互換性のため、既存の `string` 形式も引き続き valid です。
+
+## CriterionType 一覧
+
+| type       | expression 例                        | context 例          | 説明 |
+|------------|--------------------------------------|---------------------|------|
+| `simple`   | `@statusCode == 200`                 | `@statusCode`       | 単純比較式。ランタイムが変数を展開して評価 |
+| `regex`    | `^pi_`                               | `@responseBody.id`  | 正規表現マッチ。context に評価対象文字列を指定 |
+| `jsonpath` | `$.status`                           | `@responseBody`     | JSONPath 評価。context に JSON オブジェクトを指定 |
+| `xpath`    | `//result/status/text() = 'success'` | `@responseBody`     | XPath 評価。context に XML 文字列を指定 |
+
+## 利用場所
+
+`ExternalSystemStep.successCriteria?: Criterion[]`
+
+すべての条件が true の場合に「成功」と見なします (AND 結合)。
+
+```json
+{
+  "type": "externalSystem",
+  "id": "step-call-api",
+  "description": "外部 API を呼び出す",
+  "systemRef": "stripe",
+  "systemName": "Stripe",
+  "successCriteria": [
+    { "type": "simple",   "expression": "@statusCode == 200", "context": "@statusCode" },
+    { "type": "jsonpath", "expression": "$.status",           "context": "@responseBody" },
+    { "type": "regex",    "expression": "^pi_",               "context": "@responseBody.id" }
+  ]
+}
+```
+
+## Arazzo Export との連携
+
+`designer__export_arazzo` MCP ツールは `successCriteria` を Arazzo 1.0 ワークフローの同名フィールドにそのままマッピングします。`successCriteria` が未設定の場合はそのステップの `successCriteria` フィールドを省略します。
+
+## 設計判断
+
+- `string` 形式との union にすることで既存フロー定義を破壊せず移行可能 (旧データは再検証不要)
+- `context` を optional にすることで `simple` 型が `context` を省略できる (短縮記法)
+- AND 結合のみサポート — OR は複数 Branch による表現を推奨

--- a/schemas/process-flow.schema.json
+++ b/schemas/process-flow.schema.json
@@ -1130,6 +1130,36 @@
         "sameAs": { "$ref": "#/$defs/ExternalCallOutcome" }
       }
     },
+    "CriterionType": {
+      "description": "Criterion の評価種別 (#427 P3-2 / Arazzo 由来)",
+      "type": "string",
+      "enum": ["simple", "regex", "jsonpath", "xpath"]
+    },
+    "StructuredCriterion": {
+      "description": "型付き条件式 (#427 P3-2)。Arazzo 1.0 の successCriteria 互換",
+      "type": "object",
+      "required": ["type", "expression"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "$ref": "#/$defs/CriterionType" },
+        "expression": {
+          "type": "string",
+          "description": "評価式。simple: \"@status == 200\", regex: \"^[0-9]+$\", jsonpath: \"$.items[0].id\", xpath: \"//result/text()\""
+        },
+        "context": {
+          "type": "string",
+          "description": "jsonpath / xpath の評価対象 (例: \"@responseBody\", \"@statusCode\")"
+        }
+      }
+    },
+    "Criterion": {
+      "description": "成功判定条件 (#427 P3-2)。string (旧互換) または StructuredCriterion の union",
+      "oneOf": [
+        { "type": "string" },
+        { "$ref": "#/$defs/StructuredCriterion" }
+      ]
+    },
+
     "NonReturnStep": {
       "description": "sideEffects 配列で使える Step の制限サブセット。ReturnStep を除外 (#261)",
       "oneOf": [
@@ -1309,6 +1339,11 @@
             "cache": {
               "$ref": "#/$defs/CacheHint",
               "description": "キャッシュヒント (#423 B-4)。GET 系 API レスポンスのキャッシュ設定"
+            },
+            "successCriteria": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/Criterion" },
+              "description": "Arazzo 互換の成功判定条件 (#427 P3-2)。Arazzo Export で successCriteria フィールドにマッピングされる"
             }
           }
         }


### PR DESCRIPTION
## 概要

ISSUE #427 (P3-2/P3-3/P3-4 の 3 項目を 1 PR に束ねる) の実装。全て additive・破壊変更なし。

Closes #427

## 変更内容

### P3-2: Criterion 多様化 (Arazzo 由来)
- `schemas/process-flow.schema.json`: `CriterionType` / `StructuredCriterion` / `Criterion` 定義を追加
- `ExternalSystemStep` に `successCriteria?: Criterion[]` を追加 (Arazzo 互換フィールド)
- `designer/src/types/action.ts`: `CriterionType` / `StructuredCriterion` / `Criterion` 型を追加
- 既存 JSON は string 形式のまま valid (後方互換 oneOf)
- 新サンプル `cccccccc-0009` (決済処理) で `jsonpath` / `simple` / `regex` 各 criterion を実証
- `docs/spec/process-flow-criterion.md` 新規作成

### P3-3: Arazzo Export
- `designer-mcp/src/tools.ts`: `designer__export_arazzo` ツール定義追加
- `designer-mcp/src/handlers/processFlow.ts`: ハンドラ実装
  - フロー内の ExternalSystemStep を再帰収集 (branch/loop/transactionScope/workflow/sideEffects 含む)
  - `externalSystemCatalog` から `sourceDescriptions` を生成
  - `successCriteria` (P3-2) を Arazzo `successCriteria` にマッピング
  - YAML / JSON 両形式で出力 (`arazzo: "1.0.1"` 含む)
  - YAML シリアライザ: 先頭改行 trim、number-like 文字列のクォート対応

### P3-4: Solution unpack/pack
- `designer__solution_pack`: 指定フロー群を ZIP に梱包 (`manifest.json` + `process-flows/*.json`)、親ディレクトリ自動作成
- `designer__solution_unpack`: ZIP を `data/actions/` に展開、`skip` / `overwrite` / `rename` 衝突解決、`publisherPrefix` パラメータ追加
- `adm-zip` 依存追加 (pure JS)

## 仕様逐条突合

### P3-2 Criterion 多様化
- [x] `schemas/process-flow.schema.json` の `Criterion` が `oneOf: [string, StructuredCriterion]` → `schemas/process-flow.schema.json:1097-1101`
- [x] `StructuredCriterion.type` が `"simple" | "regex" | "jsonpath" | "xpath"` → `schemas/process-flow.schema.json:1075-1078`
- [x] `designer/src/types/action.ts` に `CriterionType` / `StructuredCriterion` → `designer/src/types/action.ts:539-553`
- [x] 既存 JSON サンプル後方互換 — 183 件 pass
- [x] `StructuredCriterion` 使用サンプル → `cccccccc-0009` (jsonpath / simple / regex 全 3 種)

### P3-3 Arazzo Export
- [x] `export_arazzo` ツール定義 → `designer-mcp/src/tools.ts:1001`
- [x] ExternalSystemStep から Arazzo 1.0 最小 YAML 出力 → `buildArazzoDoc` + `toYaml`
- [x] 出力 YAML が `arazzo: "1.0.1"` キーを含む → `buildArazzoDoc` 戻り値

### P3-4 Solution unpack/pack
- [x] `solution_pack` ツール定義・実装 → `designer-mcp/src/tools.ts:1023`
- [x] `solution_unpack` ツール定義・実装 → `designer-mcp/src/tools.ts:1053`
- [x] `conflictResolution` の skip/overwrite/rename 動作 → unpack ハンドラ 3 分岐

### テスト・ビルド
- [x] `cd designer && npx vitest run src/schemas/process-flow.schema.test.ts` → 183 件 pass
- [x] `cd designer && npm run build` → pass
- [x] `cd designer-mcp && npm run build` → pass
- [x] `cd designer && npx vitest run` → 839 件 pass

## レビュー指摘対応 (第 1 回レビュー後)
- [x] Must-fix: `solution_unpack` に `publisherPrefix` パラメータ追加
- [x] Should-fix: `toYaml` 先頭 `\n` を `trimStart()` 除去
- [x] Should-fix: number-like 文字列 (`1.0` 等) を YAML 引用符でクォート
- [x] Should-fix: `collectExternalSteps` で `onCommit`/`onRollback`/`onApproved`/`onRejected`/`onTimeout`/`sideEffects` を走査
- [x] Should-fix: `zip.writeZip` 前に親ディレクトリを `mkdirSync` で作成
- [x] Should-fix: `docs/spec/process-flow-criterion.md` を新規作成
- [x] Nit: `await import("node:fs")` を静的 import に変更

## テスト計画

- [x] Vitest スキーマテスト 183 件 pass
- [x] Vitest 全テスト 839 件 pass
- [x] designer-mcp TypeScript ビルド pass
- [x] designer TypeScript + Vite ビルド pass
- N/A Playwright (UI 変更なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)