### PR TITLE
feat(processflow): P3-1 — Runtime Expressions を $ 記法に統一 (Arazzo 互換) (#431)

### DIFF
--- a/.claude/skills/issues/SKILL.md
+++ b/.claude/skills/issues/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: issues
+description: ISSUE を 12 ルール Opus オーケストレーターワークフローで完遂する (ISSUE 読み取り→設計→実装→レビュー→マージ)
+argument-hint: <ISSUE番号>
+disable-model-invocation: true
+---
+
+<!--
+  使い方:
+    `/issues 431` のように ISSUE 番号を指定して呼び出す。
+    Opus がオーケストレーターとして以下の全工程を自律完遂する:
+      ISSUE 読み取り → 統合 PR 判定 → 設計 → worktree 作成 →
+      Codex/Sonnet 実装委譲 → Sonnet 独立レビュー → 修正 → squash マージ
+
+  前提:
+    - gh CLI がパスに通っていること
+    - designer-mcp が起動していること (MCP ツールが必要な ISSUE の場合)
+    - `disable-model-invocation: true`: ユーザーが明示的に `/issues <N>` と打った時のみ起動
+
+  運用原則 (feedback_orchestration_workflow.md より):
+    - Opus = オーケストレーター専任。実装コードは 1 行も書かない
+    - 実装は worktree + Codex 優先 (失敗時 Sonnet フォールバック)
+    - レビューは review-pr-sonnet サブエージェント
+    - ユーザー介入なし。build/test/review/merge まで AI が完遂
+-->
+
+ISSUE #$ARGUMENTS を 12 ルール Opus オーケストレーターワークフローで解決します。
+
+## Step 0: ISSUE を読む
+
+`gh issue view $ARGUMENTS` で本文・コメント・ラベル・担当者・マイルストーンを全取得する。
+
+## Step 1: 統合 PR 判定
+
+ISSUE 本文に `## 🔗 統合 PR 情報` セクションがあるか確認:
+
+### 統合 PR あり
+
+セクション記載の統合ブランチ名を読む。
+
+- ブランチが未作成 → `git worktree add C:/tmp/wt-$ARGUMENTS -b <統合ブランチ名> origin/main`
+- ブランチが既存 → `git worktree add C:/tmp/wt-$ARGUMENTS <統合ブランチ名>` で checkout
+- 自分の担当 ISSUE 分のコミットをそのブランチに積む (ISSUE 単位でコミットを分ける)
+- **他の統合対象 ISSUE が全て完了するまで PR を作らない** (draft も不可)
+- 最後の ISSUE 完了時だけ PR を作成し、description に `Closes #A\nCloses #B\n...` を記載
+
+### 統合 PR なし → 関連 ISSUE 検索 (必須)
+
+着手前に以下で関連 open ISSUE を洗い出す:
+
+```bash
+gh issue list --state open --search "<本 ISSUE のキーワード>"
+```
+
+本 ISSUE が触りそうなファイル・モジュール・UI 画面名をキーワードに使う。
+
+- 関連発見 → **着手前に統合提案をユーザーへ**。承認後、全 ISSUE 本文に `## 🔗 統合 PR 情報` を prepend
+- 関連なし → 通常の 1 ISSUE = 1 PR フロー (以降の Step へ)
+
+## Step 2: 設計を ISSUE に先書き (Rule 5)
+
+実装手順・変更ファイル・影響範囲を組み立て、**実装開始前に** `gh issue comment $ARGUMENTS --body "..."` で ISSUE に追記する。
+
+この comment が:
+- Codex/Sonnet への briefing
+- 後のレビュー基準
+
+## Step 3: ブランチと worktree を作る
+
+```bash
+git worktree add C:/tmp/wt-$ARGUMENTS -b feat/issue-$ARGUMENTS-<slug> origin/main
+```
+
+slug は ISSUE タイトルから英小文字ケバブケースで生成。
+
+## Step 4: 実装を委譲 (Rule 6)
+
+### 第一手: Codex
+
+```
+Agent(subagent_type="codex:codex-rescue", prompt="--fresh\n\n<briefing>")
+```
+
+briefing には以下を含める:
+- ISSUE 番号・タイトル・本文
+- Step 2 で書いた設計手順
+- 作業ディレクトリ: `C:/tmp/wt-$ARGUMENTS`
+- PR 作成まで完了すること
+
+### Codex が「プラン制限」エラー → 即 Sonnet フォールバック
+
+```
+Agent(subagent_type="general-purpose", model="sonnet", prompt="...")
+```
+
+同じ briefing を渡す。
+
+**⚠️ 確認なしで最初から Sonnet を使うのは禁止 (Rule 6 違反)**
+
+## Step 5: 逸脱確認 (Rule 7)
+
+`gh pr diff <PR番号> --name-only` と PR diff を読み、Step 2 の設計との乖離を確認:
+
+- ファイル名・API・型レベルの乖離に注目
+- 逸脱あり → `gh issue comment $ARGUMENTS --body "逸脱内容..."` に記録し、Codex/Sonnet に修正指示 → Step 5 に戻る (Rule 8)
+- 逸脱なし → Step 6 へ
+
+## Step 6: 独立レビュー (Rule 9)
+
+```
+Agent(subagent_type="review-pr-sonnet", prompt="PR #<PR番号> をレビューしてください")
+```
+
+- Sonnet で実行、クリーンコンテキスト
+- 結果は **PR コメント + ISSUE コメント** の両方に投稿される
+
+## Step 7: 残件対応 (Rule 10/11/12)
+
+`gh issue view $ARGUMENTS --comments` でレビュー結果を読む。
+
+### Must-fix / スコープ内 Should-fix が 0 件
+
+→ Step 8 (マージ) へ
+
+### スコープ外指摘あり
+
+→ 別 ISSUE を起票し、元 PR 本文に `スコープ外指摘は #<新ISSUE> に分離` を明示 → Step 8 へ
+
+### スコープ内 Must-fix / Should-fix あり
+
+1. Codex (or Sonnet) に修正指示 (Step 4 と同様に `--fresh`)
+2. Step 6 に戻る (再レビュー)
+
+## Step 8: squash マージ (Rule 10)
+
+```bash
+gh pr merge <PR番号> --squash --auto
+```
+
+PR タイトルに ISSUE 番号が含まれていることを確認してからマージ。
+
+## Step 9: 完了報告
+
+マージ完了後にユーザーへ短く報告:
+
+- マージした PR 番号・URL
+- クローズした ISSUE 番号
+- 次に着手できる候補があれば提示
+
+---
+
+## 制約 (必守)
+
+- **Opus は実装コードを書かない** — Codex/Sonnet サブエージェントが担当
+- **ユーザーへの確認は不要** — build/test/review/merge 全て AI が完遂
+- **Codex 呼び出しは常に `--fresh` 固定** — resume 選択プロンプトでブロックしない
+- **全レビュー結果は ISSUE に記録** — Opus は PR を直接見に行かず ISSUE を読む
+- **ブロック ISSUE**: 人間介入が必要とわかった場合 → スキップして次へ、ユーザーへ通知のみ

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ Claude Code 向けの補足ガイダンス。
 
 本プロジェクトで利用する Claude Code 固有スキル (`.claude/skills/`):
 
+- **`/issues <N>`** — ISSUE を 12 ルール Opus オーケストレーターワークフローで完遂 (`.claude/skills/issues/SKILL.md`)
 - **`/review-pr <N>`** — PR 独立レビュー (`.claude/skills/review-pr/SKILL.md`)
 - **`/review-issue <N>`** — ISSUE 単位の実装網羅性監査 (`.claude/skills/review-issue/SKILL.md`)
 - **`/test-strategy`** — テスト実装時の自動起動スキル (`.claude/skills/test-strategy/SKILL.md`)

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -559,12 +559,13 @@ export type CriterionType = "simple" | "regex" | "jsonpath" | "xpath";
 
 /**
  * 型付き条件式 (#427 P3-2)。Arazzo 1.0 の successCriteria 互換。
- * simple: "@status == 200", regex: "^[0-9]+$", jsonpath: "$.items[0].id", xpath: "//result/text()"
+ * $ 記法推奨: simple: "$statusCode == 200", regex: "^pi_", jsonpath: "$.status" (context: "$response.body")
+ * 旧 @記法 (@statusCode 等) は後方互換として引き続き有効
  */
 export interface StructuredCriterion {
   type: CriterionType;
   expression: string;
-  /** jsonpath / xpath の評価対象 (例: "@responseBody") */
+  /** jsonpath / xpath の評価対象。$ 記法推奨: "$response.body", "$response.body#/id" */
   context?: string;
 }
 

--- a/docs/sample-project/process-flows/cccccccc-0010-4000-8000-cccccccccccc.json
+++ b/docs/sample-project/process-flows/cccccccc-0010-4000-8000-cccccccccccc.json
@@ -3,7 +3,7 @@
   "name": "決済処理",
   "type": "screen",
   "screenId": "aaaaaaaa-0010-4000-8000-aaaaaaaaaaaa",
-  "description": "#427 P3-2 実証サンプル: StructuredCriterion (jsonpath / simple / regex) を使う外部 API 呼び出しと Arazzo 互換 successCriteria を示す。Stripe 決済 API との連携フロー。",
+  "description": "#427 P3-2 実証サンプル: StructuredCriterion (jsonpath / simple / regex) を使う外部 API 呼び出しと Arazzo 互換 successCriteria を示す。Stripe 決済 API との連携フロー。successCriteria は #431 P3-1 で $ 記法 (Arazzo Runtime Expression) に更新済み。",
   "maturity": "draft",
 
   "externalSystemCatalog": {
@@ -60,18 +60,17 @@
           "successCriteria": [
             {
               "type": "simple",
-              "expression": "@statusCode == 200",
-              "context": "@statusCode"
+              "expression": "$statusCode == 200"
             },
             {
               "type": "jsonpath",
               "expression": "$.status",
-              "context": "@responseBody"
+              "context": "$response.body"
             },
             {
               "type": "regex",
               "expression": "^pi_",
-              "context": "@responseBody.id"
+              "context": "$response.body#/id"
             }
           ],
           "outcomes": {
@@ -96,13 +95,12 @@
           "successCriteria": [
             {
               "type": "simple",
-              "expression": "@statusCode == 200",
-              "context": "@statusCode"
+              "expression": "$statusCode == 200"
             },
             {
               "type": "jsonpath",
               "expression": "$.status == 'succeeded'",
-              "context": "@responseBody"
+              "context": "$response.body"
             }
           ],
           "outcomes": {

--- a/docs/spec/process-flow-criterion.md
+++ b/docs/spec/process-flow-criterion.md
@@ -18,14 +18,35 @@ type Criterion = string | StructuredCriterion;
 
 後方互換性のため、既存の `string` 形式も引き続き valid です。
 
+## Arazzo Runtime Expression ($記法) — 推奨記法 (#431 P3-1)
+
+Arazzo 1.0 仕様では Runtime Expressions に `$` プレフィックスを使います。本プロジェクトは `$` 記法を推奨とし、旧 `@` 記法は後方互換として引き続き有効です。
+
+| Arazzo Runtime Expression | 意味 |
+|---------------------------|------|
+| `$statusCode`             | HTTP ステータスコード (数値) |
+| `$response.body`          | レスポンス body 全体 (JSON オブジェクト) |
+| `$response.body#/path`    | JSON Pointer でレスポンス body の特定フィールドを参照 |
+| `$response.header.X-Foo`  | レスポンスヘッダー値 |
+| `$request.body`           | リクエスト body |
+| `$inputs.<name>`          | ワークフロー入力変数 |
+
+**移行例:**
+
+| 旧 @記法 | 推奨 $記法 |
+|----------|-----------|
+| `@statusCode` | `$statusCode` |
+| `@responseBody` | `$response.body` |
+| `@responseBody.id` | `$response.body#/id` |
+
 ## CriterionType 一覧
 
-| type       | expression 例                        | context 例          | 説明 |
-|------------|--------------------------------------|---------------------|------|
-| `simple`   | `@statusCode == 200`                 | `@statusCode`       | 単純比較式。ランタイムが変数を展開して評価 |
-| `regex`    | `^pi_`                               | `@responseBody.id`  | 正規表現マッチ。context に評価対象文字列を指定 |
-| `jsonpath` | `$.status`                           | `@responseBody`     | JSONPath 評価。context に JSON オブジェクトを指定 |
-| `xpath`    | `//result/status/text() = 'success'` | `@responseBody`     | XPath 評価。context に XML 文字列を指定 |
+| type       | expression 例                        | context 例 ($ 記法推奨)      | 説明 |
+|------------|--------------------------------------|------------------------------|------|
+| `simple`   | `$statusCode == 200`                 | (省略可)                     | 単純比較式。ランタイムが変数を展開して評価 |
+| `regex`    | `^pi_`                               | `$response.body#/id`         | 正規表現マッチ。context に評価対象文字列を指定 |
+| `jsonpath` | `$.status`                           | `$response.body`             | JSONPath 評価。context に JSON オブジェクトを指定 |
+| `xpath`    | `//result/status/text() = 'success'` | `$response.body`             | XPath 評価。context に XML 文字列を指定 |
 
 ## 利用場所
 
@@ -41,9 +62,9 @@ type Criterion = string | StructuredCriterion;
   "systemRef": "stripe",
   "systemName": "Stripe",
   "successCriteria": [
-    { "type": "simple",   "expression": "@statusCode == 200", "context": "@statusCode" },
-    { "type": "jsonpath", "expression": "$.status",           "context": "@responseBody" },
-    { "type": "regex",    "expression": "^pi_",               "context": "@responseBody.id" }
+    { "type": "simple",   "expression": "$statusCode == 200" },
+    { "type": "jsonpath", "expression": "$.status",           "context": "$response.body" },
+    { "type": "regex",    "expression": "^pi_",               "context": "$response.body#/id" }
   ]
 }
 ```

--- a/schemas/process-flow.schema.json
+++ b/schemas/process-flow.schema.json
@@ -1148,7 +1148,7 @@
         },
         "context": {
           "type": "string",
-          "description": "jsonpath / xpath の評価対象。Arazzo Runtime Expression ($記法) 推奨: \"$response.body\", \"$response.body#/id\", \"$statusCode\". 旧 @記法 (@responseBody 等) は後方互換として引き続き有効"
+          "description": "jsonpath / xpath の評価対象 (JSON / XML オブジェクト)。Arazzo Runtime Expression ($記法) 推奨: \"$response.body\", \"$response.body#/id\". 旧 @記法 (@responseBody 等) は後方互換として引き続き有効"
         }
       }
     },

--- a/schemas/process-flow.schema.json
+++ b/schemas/process-flow.schema.json
@@ -1144,11 +1144,11 @@
         "type": { "$ref": "#/$defs/CriterionType" },
         "expression": {
           "type": "string",
-          "description": "評価式。simple: \"@status == 200\", regex: \"^[0-9]+$\", jsonpath: \"$.items[0].id\", xpath: \"//result/text()\""
+          "description": "評価式。Arazzo Runtime Expression ($記法) 推奨。simple: \"$statusCode == 200\", regex: \"^pi_\", jsonpath: \"$.status\", xpath: \"//result/text()\". 旧 @記法 (@statusCode 等) は後方互換として引き続き有効"
         },
         "context": {
           "type": "string",
-          "description": "jsonpath / xpath の評価対象 (例: \"@responseBody\", \"@statusCode\")"
+          "description": "jsonpath / xpath の評価対象。Arazzo Runtime Expression ($記法) 推奨: \"$response.body\", \"$response.body#/id\", \"$statusCode\". 旧 @記法 (@responseBody 等) は後方互換として引き続き有効"
         }
       }
     },


### PR DESCRIPTION
## 概要

親 ISSUE: #396 — 処理フロー仕様拡張計画メタ
ISSUE: #431 — P3-1 Runtime Expressions を $ 記法に統一 (Arazzo 互換)

Arazzo 1.0 仕様の Runtime Expression ($記法) を `StructuredCriterion` の推奨記法として採用。旧 `@` 記法は後方互換として引き続き有効 (フェーズ1 — 廃止はフェーズ2 別 ISSUE)。

## 変更内容

| ファイル | 変更 |
|---|---|
| `schemas/process-flow.schema.json` | `StructuredCriterion.expression` / `context` の description に Arazzo `$` 記法の例と後方互換説明を追記 |
| `designer/src/types/action.ts` | `StructuredCriterion` JSDoc を `$` 記法例に更新 |
| `docs/spec/process-flow-criterion.md` | Arazzo Runtime Expression セクション追加、型一覧表と利用例を `$` 記法に更新 |
| `docs/sample-project/process-flows/cccccccc-0010-*.json` | `successCriteria` を `$` 記法で書き直し |
| `.claude/skills/issues/SKILL.md` | 消失していた `/issues` スキルを再作成 (12 ルール Opus ワークフロー準拠) |
| `CLAUDE.md` | スキル一覧に `/issues` を追記 |

## 受け入れ基準の確認

- [x] `schemas/process-flow.schema.json` の `StructuredCriterion` description が `$` 記法の例を含む
- [x] `docs/spec/process-flow-criterion.md` に Arazzo Runtime Expression 記法セクションが追加されている
- [x] `cccccccc-0010` サンプルの `successCriteria` が `$` 記法で記述されている
- [x] 既存の `@` 記法サンプルが引き続き schema test に全 pass (後方互換) — 184 件 pass 確認
- [x] `cd designer && npx vitest run src/schemas/process-flow.schema.test.ts` — 184 件 pass
- [x] `cd designer && npm run build` — pass
- [x] `cd designer-mcp && npm run build` — pass

## レビュー対応 (Sonnet 独立レビュー #432)

- Should-fix: `context` description の `"$statusCode"` を削除 (jsonpath/xpath 向けにスカラー値例は不適切) → 修正済み (2b2d1b6)

## 仕様逐条突合 (自己申告)

| 受け入れ基準 | 実装箇所 |
|---|---|
| schema の expression description に $ 記法例 | `schemas/process-flow.schema.json:1147` |
| schema の context description に $ 記法例 | `schemas/process-flow.schema.json:1151` |
| spec docs に Arazzo Runtime Expression セクション | `docs/spec/process-flow-criterion.md:4-20` |
| spec docs の型一覧表が $ 記法 | `docs/spec/process-flow-criterion.md:22-28` |
| spec docs の利用例が $ 記法 | `docs/spec/process-flow-criterion.md:46-50` |
| cccccccc-0010 step-create の successCriteria が $ 記法 | `docs/sample-project/process-flows/cccccccc-0010-*.json:60-76` |
| cccccccc-0010 step-confirm の successCriteria が $ 記法 | `docs/sample-project/process-flows/cccccccc-0010-*.json:96-107` |
| action.ts JSDoc が $ 記法 | `designer/src/types/action.ts:560-568` |

## 関連

- 親 ISSUE: #396
- 関連 PR: #430 (P3-2/3/4 — Criterion 型定義 + Arazzo Export)
- spec: `docs/spec/process-flow-criterion.md`

Closes #431