### PR TITLE
feat(processflow): closing/cdc ステップを UI パネル・エクスポーターに追加 (#429)

### DIFF
--- a/designer/src/components/process-flow/ProcessFlowEditor.tsx
+++ b/designer/src/components/process-flow/ProcessFlowEditor.tsx
@@ -112,6 +112,7 @@ const ALL_STEP_TYPES: StepType[] = [
   "screenTransition", "displayUpdate", "branch", "loop",
   "loopBreak", "loopContinue", "jump", "compute", "return", "other",
   "log", "audit", "workflow", "transactionScope",
+  "eventPublish", "eventSubscribe", "closing", "cdc",
 ];
 
 const ALL_SUB_STEP_TYPES: StepType[] = [
@@ -119,6 +120,7 @@ const ALL_SUB_STEP_TYPES: StepType[] = [
   "screenTransition", "displayUpdate", "branch", "loop",
   "loopBreak", "loopContinue", "jump", "compute", "return", "other",
   "log", "audit", "workflow", "transactionScope",
+  "eventPublish", "eventSubscribe", "closing", "cdc",
 ];
 
 const ALL_TRIGGERS: ActionTrigger[] = ["click", "submit", "select", "change", "load", "timer", "other"];

--- a/designer/src/components/process-flow/StepCard.tsx
+++ b/designer/src/components/process-flow/StepCard.tsx
@@ -39,6 +39,7 @@ const ALL_SUB_STEP_TYPES: StepType[] = [
   "screenTransition", "displayUpdate", "branch", "loop",
   "loopBreak", "loopContinue", "jump", "compute", "return", "other",
   "log", "audit", "workflow", "transactionScope",
+  "eventPublish", "eventSubscribe", "closing", "cdc",
 ];
 
 // ─── ヘルパーコンポーネント ──────────────────────────────────────────────────

--- a/designer/src/components/process-flow/TransactionScopeStepPanel.tsx
+++ b/designer/src/components/process-flow/TransactionScopeStepPanel.tsx
@@ -54,6 +54,7 @@ const ALL_SUB_STEP_TYPES: StepType[] = [
   "screenTransition", "displayUpdate", "branch", "loop",
   "loopBreak", "loopContinue", "jump", "compute", "return", "other",
   "log", "audit", "transactionScope",
+  "eventPublish", "eventSubscribe", "closing", "cdc",
 ];
 
 interface InlineStepListProps {

--- a/designer/src/utils/specExporter.ts
+++ b/designer/src/utils/specExporter.ts
@@ -322,6 +322,20 @@ function toSpecStep(s: Step, index: number): SpecStep {
       if (s.onCommit) detail.onCommit = s.onCommit;
       if (s.onRollback) detail.onRollback = s.onRollback;
       break;
+    case "closing":
+      detail.period = s.period;
+      if (s.customCron) detail.customCron = s.customCron;
+      if (s.cutoffAt) detail.cutoffAt = s.cutoffAt;
+      if (s.idempotencyKey) detail.idempotencyKey = s.idempotencyKey;
+      if (s.rollbackOnFailure !== undefined) detail.rollbackOnFailure = s.rollbackOnFailure;
+      break;
+    case "cdc":
+      detail.tables = s.tables;
+      detail.captureMode = s.captureMode;
+      detail.destination = s.destination;
+      if (s.includeColumns && s.includeColumns.length > 0) detail.includeColumns = s.includeColumns;
+      if (s.excludeColumns && s.excludeColumns.length > 0) detail.excludeColumns = s.excludeColumns;
+      break;
   }
   return {
     number: getStepLabel(index),

--- a/designer/src/utils/specExporter.ts
+++ b/designer/src/utils/specExporter.ts
@@ -336,6 +336,16 @@ function toSpecStep(s: Step, index: number): SpecStep {
       if (s.includeColumns && s.includeColumns.length > 0) detail.includeColumns = s.includeColumns;
       if (s.excludeColumns && s.excludeColumns.length > 0) detail.excludeColumns = s.excludeColumns;
       break;
+    case "eventPublish":
+      detail.topic = s.topic;
+      if (s.eventRef) detail.eventRef = s.eventRef;
+      if (s.payload) detail.payload = s.payload;
+      break;
+    case "eventSubscribe":
+      detail.topic = s.topic;
+      if (s.eventRef) detail.eventRef = s.eventRef;
+      if (s.filter) detail.filter = s.filter;
+      break;
   }
   return {
     number: getStepLabel(index),


### PR DESCRIPTION
## 概要

ISSUE #429: closing/cdc ステップを UI パネル・エクスポーターに追加 (follow-up #426)

PR #428 でスキーマ・型レベルに追加済みの `closing` / `cdc` ステップを UI の型配列と specExporter に追加。

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `ProcessFlowEditor.tsx` | `ALL_STEP_TYPES` / `ALL_SUB_STEP_TYPES` に `"eventPublish"`, `"eventSubscribe"`, `"closing"`, `"cdc"` を追加 |
| `StepCard.tsx` | `ALL_SUB_STEP_TYPES` に同上追加 (ISSUE 記載の StepAdvancedMetadataPanel.tsx は誤り。実対象は StepCard.tsx) |
| `TransactionScopeStepPanel.tsx` | `ALL_SUB_STEP_TYPES` に同上追加 |
| `specExporter.ts` | `toSpecStep` switch に `closing` / `cdc` / `eventPublish` / `eventSubscribe` の case を追加 |

## レビュー対応

- Should-fix 1: eventPublish/eventSubscribe の specExporter case を追加 (e750ef4)
- Should-fix 2: specExporter テスト不足 → 別 ISSUE #434 として起票

## 受け入れ基準

- [x] UI から closing/cdc ステップが選択可能になる (`ALL_STEP_TYPES` / `ALL_SUB_STEP_TYPES` 追加)
- [x] specExporter で closing/cdc の固有フィールドが detail に含まれる
- [x] `npm run build` pass
- [x] `npx vitest run` 844 件 pass

## 仕様逐条突合

| 項目 | 実装箇所 |
|---|---|
| ProcessFlowEditor ALL_STEP_TYPES | `ProcessFlowEditor.tsx:115` |
| ProcessFlowEditor ALL_SUB_STEP_TYPES | `ProcessFlowEditor.tsx:123` |
| StepCard ALL_SUB_STEP_TYPES | `StepCard.tsx:42` |
| TransactionScopeStepPanel ALL_SUB_STEP_TYPES | `TransactionScopeStepPanel.tsx:58` |
| specExporter closing case (period/customCron/cutoffAt/idempotencyKey/rollbackOnFailure) | `specExporter.ts:325-331` |
| specExporter cdc case (tables/captureMode/destination/include/excludeColumns) | `specExporter.ts:332-338` |
| specExporter eventPublish case (topic/eventRef/payload) | `specExporter.ts:339-343` |
| specExporter eventSubscribe case (topic/eventRef/filter) | `specExporter.ts:344-348` |

## 関連

- スコープ外指摘は #434 に分離 (specExporter テストカバレッジ)

Closes #429