### PR TITLE
test(specExporter): return/log/audit/workflow/loopBreak/loopContinue の detail 空回帰テスト追加 (#436)

### DIFF
--- a/designer/src/utils/specExporter.test.ts
+++ b/designer/src/utils/specExporter.test.ts
@@ -4,14 +4,20 @@ import type { TableDefinition } from "../types/table";
 import type { FlowProject } from "../types/flow";
 import type { ErLayout } from "../types/table";
 import type {
+  AuditStep,
   CdcStep,
   ClosingStep,
   DbAccessStep,
   EventPublishStep,
   EventSubscribeStep,
+  LogStep,
+  LoopBreakStep,
+  LoopContinueStep,
   ProcessFlow,
+  ReturnStep,
   Step,
   ValidationStep,
+  WorkflowStep,
 } from "../types/action";
 
 function makeFlow(steps: Step[]): ProcessFlow {
@@ -384,5 +390,70 @@ describe("toSpecStep — step detail", () => {
 
     expect(withoutFilter.detail.topic).toBe("order.created");
     expect(withoutFilter.detail).not.toHaveProperty("filter");
+  });
+
+  it("loopBreak: detail は空オブジェクト", () => {
+    const step = getStep({
+      id: "lb1",
+      type: "loopBreak",
+      description: "ループ脱出",
+    } as LoopBreakStep);
+    expect(step.type).toBe("loopBreak");
+    expect(step.detail).toEqual({});
+  });
+
+  it("loopContinue: detail は空オブジェクト", () => {
+    const step = getStep({
+      id: "lc1",
+      type: "loopContinue",
+      description: "ループ継続",
+    } as LoopContinueStep);
+    expect(step.type).toBe("loopContinue");
+    expect(step.detail).toEqual({});
+  });
+
+  it("return: detail は空オブジェクト", () => {
+    const step = getStep({
+      id: "r1",
+      type: "return",
+      description: "レスポンス返却",
+    } as ReturnStep);
+    expect(step.type).toBe("return");
+    expect(step.detail).toEqual({});
+  });
+
+  it("log: detail は空オブジェクト", () => {
+    const step = getStep({
+      id: "l1",
+      type: "log",
+      description: "ログ記録",
+      level: "info",
+      message: "処理完了",
+    } as LogStep);
+    expect(step.type).toBe("log");
+    expect(step.detail).toEqual({});
+  });
+
+  it("audit: detail は空オブジェクト", () => {
+    const step = getStep({
+      id: "au1",
+      type: "audit",
+      description: "監査ログ",
+      action: "order.create",
+    } as AuditStep);
+    expect(step.type).toBe("audit");
+    expect(step.detail).toEqual({});
+  });
+
+  it("workflow: detail は空オブジェクト", () => {
+    const step = getStep({
+      id: "wf1",
+      type: "workflow",
+      description: "承認フロー",
+      pattern: "approval-sequential",
+      approvers: [{ role: "manager" }],
+    } as WorkflowStep);
+    expect(step.type).toBe("workflow");
+    expect(step.detail).toEqual({});
   });
 });


### PR DESCRIPTION
## 関連

- Closes #436
- 仕様: N/A (テスト追加のみ、実装変更なし)

## 概要

`specExporter.ts` の `toSpecStep` で `detail` が常に `{}` になる 6 種別 (`loopBreak` / `loopContinue` / `return` / `log` / `audit` / `workflow`) に対して、PR #435 で漏れていた回帰テストを追加する。これにより、将来これらの型に `detail` の組み立てロジックが誤って追加・削除された場合に検出できるようになる。

## 主な変更

- `specExporter.test.ts`: 6 種別の `detail` 空オブジェクト回帰テストを追加 (各 `type` フィールドと `detail: {}` を検証)
- `specExporter.test.ts`: import に `AuditStep` / `LogStep` / `LoopBreakStep` / `LoopContinueStep` / `ReturnStep` / `WorkflowStep` を追加

## 仕様逐条突合 (自己申告)

本 PR はテストのみの変更であり、対応する仕様書の条項は存在しない。

- `loopBreak` / `loopContinue`: `toSpecStep` の switch に case はあるが body なし → `detail: {}` を確認 → specExporter.test.ts:391-403, 405-416
- `return` / `log` / `audit` / `workflow`: `toSpecStep` の switch に case が存在しない → `detail: {}` を確認 → specExporter.test.ts:418-428, 430-441, 443-453, 455-466

## レビューで特に見てほしい箇所

- `LogStep` / `AuditStep` / `WorkflowStep` のフィクスチャに必須フィールド (`level`/`message`, `action`, `pattern`/`approvers`) を含めているが、これらは `detail` に現れないことを意図的に確認している点
- `WorkflowStep` の `approvers` に `{ role: "manager" }` を使用 — 型制約を満たす最小値として妥当か確認

## テスト

- Vitest: 27 件 (新規 6 件) — `specExporter.ts` / `toSpecStep`
- Playwright: N/A
- MCP E2E: N/A

## UI 影響 / AI smoke test

- [x] UI 影響なし (auto テスト pass のみ)

### UI 影響ありの場合、AI smoke test で確認した項目

N/A

## spec 側の不足点 / 提案

N/A — テストのみの変更。

## レビュー担当への申し送り

- テストファイル (`specExporter.test.ts`) のみ変更。実装コードは一切変更なし
- 6 種別とも「detail が空オブジェクトであること」を回帰として固定するのが目的
- `WorkflowStep` の `approvers` 配列要素の型 (`{ role: string }`) が実際の型定義と合致しているか確認推奨