### PR TITLE
test(specExporter): compute/other の detail 空回帰テスト追加 (#438)

### DIFF
--- a/designer/src/utils/specExporter.test.ts
+++ b/designer/src/utils/specExporter.test.ts
@@ -7,12 +7,14 @@ import type {
   AuditStep,
   CdcStep,
   ClosingStep,
+  ComputeStep,
   DbAccessStep,
   EventPublishStep,
   EventSubscribeStep,
   LogStep,
   LoopBreakStep,
   LoopContinueStep,
+  OtherStep,
   ProcessFlow,
   ReturnStep,
   Step,
@@ -454,6 +456,27 @@ describe("toSpecStep — step detail", () => {
       approvers: [{ role: "manager" }],
     } as WorkflowStep);
     expect(step.type).toBe("workflow");
+    expect(step.detail).toEqual({});
+  });
+
+  it("compute: detail は空オブジェクト", () => {
+    const step = getStep({
+      id: "comp1",
+      type: "compute",
+      description: "税額計算",
+      expression: "@subtotal * 0.10",
+    } as ComputeStep);
+    expect(step.type).toBe("compute");
+    expect(step.detail).toEqual({});
+  });
+
+  it("other: detail は空オブジェクト", () => {
+    const step = getStep({
+      id: "oth1",
+      type: "other",
+      description: "その他処理",
+    } as OtherStep);
+    expect(step.type).toBe("other");
     expect(step.detail).toEqual({});
   });
 });


### PR DESCRIPTION
## 関連

- Closes #438
- 仕様: N/A (テスト追加のみ。specExporter の既存実装 `compute`/`other` case が switch に存在しないことを回帰テストで明示する)

## 概要

`specExporter.ts` の `toSpecStep` switch に `compute` / `other` の case が存在しないため、これら 2 種別の `detail` は常に `{}` になる。
PR #437 で追加されたテスト群からこの 2 種別が漏れていたため、空回帰テストを追加して網羅する。

## 主な変更

- `specExporter.test.ts`: `compute` / `other` の `detail` が空オブジェクトであることを確認する回帰テスト 2 件を追加
- `specExporter.test.ts`: import に `ComputeStep` / `OtherStep` を追加

## 仕様逐条突合 (自己申告)

N/A — 本 PR はテストファイルのみの変更。specExporter.ts の実装には手を加えていない。

## レビューで特に見てほしい箇所

- `compute` / `other` 両ケースが `toSpecStep` の switch に実際に存在しないことを確認するテストとして成立しているか
- 新規テストが既存テストのスタイル (`as ComputeStep` / `as OtherStep` キャスト) と整合しているか

## テスト

- Vitest: 29 件 (新規 2 件) — specExporter.test.ts
- Playwright: N/A
- MCP E2E: N/A

## UI 影響 / AI smoke test

- [x] UI 影響なし (auto テスト pass のみ)

### UI 影響ありの場合、AI smoke test で確認した項目

N/A

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

テストファイルのみの変更。`compute`/`other` の `detail` が `{}` になることは既存実装の仕様 (フィールドなし or specExporter が詳細を不要と判断) であり、テストはその現状を回帰として固定するもの。実装側に手を入れるかどうかは別 ISSUE の判断とする。