### PR TITLE
feat(schema): グローバルスキーマ先行追加 — FieldType file / ActionTrigger auto / DbOperation MERGE-LOCK 他 (#443)

### DIFF
--- a/designer/src/components/process-flow/StepCard.tsx
+++ b/designer/src/components/process-flow/StepCard.tsx
@@ -821,27 +821,39 @@ export function StepCard({
                   <div className="step-inline-branch">
                     <div className="step-branch-box ok">
                       <div className="step-branch-label">A: OK</div>
-                      <input
-                        className="form-control form-control-sm"
-                        value={step.inlineBranch.ok}
-                        onChange={(e) =>
-                          onChange({ inlineBranch: { ...step.inlineBranch!, ok: e.target.value } } as Partial<Step>)
-                        }
-                        placeholder="OK時の処理"
-                        onBlur={onCommit}
-                      />
+                      {typeof step.inlineBranch.ok === "string" ? (
+                        <input
+                          className="form-control form-control-sm"
+                          value={step.inlineBranch.ok}
+                          onChange={(e) =>
+                            onChange({ inlineBranch: { ...step.inlineBranch!, ok: e.target.value } } as Partial<Step>)
+                          }
+                          placeholder="OK時の処理"
+                          onBlur={onCommit}
+                        />
+                      ) : (
+                        <span className="form-control form-control-sm text-muted" style={{ cursor: "default" }}>
+                          ステップ {step.inlineBranch.ok.length} 件 (JSON編集)
+                        </span>
+                      )}
                     </div>
                     <div className="step-branch-box ng">
                       <div className="step-branch-label">B: NG</div>
-                      <input
-                        className="form-control form-control-sm"
-                        value={step.inlineBranch.ng}
-                        onChange={(e) =>
-                          onChange({ inlineBranch: { ...step.inlineBranch!, ng: e.target.value } } as Partial<Step>)
-                        }
-                        placeholder="NG時の処理"
-                        onBlur={onCommit}
-                      />
+                      {typeof step.inlineBranch.ng === "string" ? (
+                        <input
+                          className="form-control form-control-sm"
+                          value={step.inlineBranch.ng}
+                          onChange={(e) =>
+                            onChange({ inlineBranch: { ...step.inlineBranch!, ng: e.target.value } } as Partial<Step>)
+                          }
+                          placeholder="NG時の処理"
+                          onBlur={onCommit}
+                        />
+                      ) : (
+                        <span className="form-control form-control-sm text-muted" style={{ cursor: "default" }}>
+                          ステップ {step.inlineBranch.ng.length} 件 (JSON編集)
+                        </span>
+                      )}
                     </div>
                   </div>
                 )}

--- a/designer/src/schemas/process-flow.schema.test.ts
+++ b/designer/src/schemas/process-flow.schema.test.ts
@@ -2151,3 +2151,115 @@ describe("process-flow.schema.json — Tier-B eventsCatalog (#423)", () => {
     expect(validate({ ...base })).toBe(true);
   });
 });
+
+describe("process-flow.schema.json — グローバルスキーマ先行追加 (#443)", () => {
+  const makeFlow = (action: object) => ({
+    id: "a", name: "x", type: "screen", description: "",
+    actions: [action],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  });
+  const baseStep = { id: "s1", type: "other", description: "" };
+
+  // 1. FieldType {kind: "file"}
+  it("FieldType {kind: file} accept", () => {
+    const ok = validate(makeFlow({
+      id: "act-1", name: "test", trigger: "submit",
+      inputs: [{ name: "uploadFile", type: { kind: "file" } }],
+      steps: [baseStep],
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("FieldType {kind: file, format: csv} accept", () => {
+    const ok = validate(makeFlow({
+      id: "act-1", name: "test", trigger: "submit",
+      inputs: [{ name: "csvFile", type: { kind: "file", format: "csv" } }],
+      steps: [baseStep],
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  // 2. ActionTrigger "auto"
+  it("ActionTrigger auto accept", () => {
+    const ok = validate(makeFlow({
+      id: "act-1", name: "batch", trigger: "auto",
+      steps: [baseStep],
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  // 3. DbOperation MERGE / LOCK
+  it("DbOperation MERGE accept", () => {
+    const ok = validate(makeFlow({
+      id: "act-1", name: "test", trigger: "submit",
+      steps: [{
+        id: "s1", type: "dbAccess", description: "",
+        operation: "MERGE",
+        tableName: "orders",
+      }],
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("DbOperation LOCK accept", () => {
+    const ok = validate(makeFlow({
+      id: "act-1", name: "test", trigger: "submit",
+      steps: [{
+        id: "s1", type: "dbAccess", description: "",
+        operation: "LOCK",
+        tableName: "orders",
+      }],
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  // 4. ValidationInlineBranch ok/ng as Step[]
+  it("ValidationInlineBranch ng as Step[] accept", () => {
+    const ok = validate(makeFlow({
+      id: "act-1", name: "test", trigger: "submit",
+      steps: [{
+        id: "s1", type: "validation", description: "",
+        conditions: "",
+        inlineBranch: {
+          ok: "続行",
+          ng: [{ id: "s-ng", type: "return", description: "NG return" }],
+        },
+      }],
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("ValidationInlineBranch ok/ng as string (後方互換) accept", () => {
+    const ok = validate(makeFlow({
+      id: "act-1", name: "test", trigger: "submit",
+      steps: [{
+        id: "s1", type: "validation", description: "",
+        conditions: "",
+        inlineBranch: { ok: "続行", ng: "エラー表示" },
+      }],
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  // 5. CommonProcessStep returnMapping
+  it("CommonProcessStep returnMapping accept", () => {
+    const ok = validate(makeFlow({
+      id: "act-1", name: "test", trigger: "submit",
+      steps: [{
+        id: "s1", type: "commonProcess", description: "",
+        refId: "common-batch-check",
+        returnMapping: { "処理結果": "0:正常終了, 1:異常終了" },
+      }],
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+});

--- a/designer/src/schemas/process-flow.schema.test.ts
+++ b/designer/src/schemas/process-flow.schema.test.ts
@@ -2236,6 +2236,22 @@ describe("process-flow.schema.json — グローバルスキーマ先行追加 (
     expect(ok).toBe(true);
   });
 
+  it("ValidationInlineBranch ok as Step[] accept", () => {
+    const ok = validate(makeFlow({
+      id: "act-1", name: "test", trigger: "submit",
+      steps: [{
+        id: "s1", type: "validation", description: "",
+        conditions: "",
+        inlineBranch: {
+          ok: [{ id: "s-ok", type: "return", description: "OK return" }],
+          ng: "エラー表示",
+        },
+      }],
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
   it("ValidationInlineBranch ok/ng as string (後方互換) accept", () => {
     const ok = validate(makeFlow({
       id: "act-1", name: "test", trigger: "submit",

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -1137,6 +1137,7 @@ export type FieldType =
   | { kind: "tableRow"; tableId: string }
   | { kind: "tableList"; tableId: string }
   | { kind: "screenInput"; screenId: string }
+  | { kind: "file"; format?: string }
   | { kind: "custom"; label: string };
 
 export interface StructuredField {

--- a/designer/src/types/action.ts
+++ b/designer/src/types/action.ts
@@ -103,13 +103,15 @@ export const STEP_TYPE_COLORS: Record<StepType, string> = {
 };
 
 /** DB操作種別 */
-export type DbOperation = "SELECT" | "INSERT" | "UPDATE" | "DELETE";
+export type DbOperation = "SELECT" | "INSERT" | "UPDATE" | "DELETE" | "MERGE" | "LOCK";
 
 export const DB_OPERATION_LABELS: Record<DbOperation, string> = {
   SELECT: "検索",
   INSERT: "登録",
   UPDATE: "更新",
   DELETE: "削除",
+  MERGE: "MERGE",
+  LOCK: "ロック",
 };
 
 /** ProcessFlowの種別 */
@@ -147,6 +149,7 @@ export type ActionTrigger =
   | "change"  // 値変更
   | "load"    // 画面読み込み
   | "timer"   // タイマー
+  | "auto"    // バッチ自動起動
   | "other";  // その他
 
 export const ACTION_TRIGGER_LABELS: Record<ActionTrigger, string> = {
@@ -156,6 +159,7 @@ export const ACTION_TRIGGER_LABELS: Record<ActionTrigger, string> = {
   change: "値変更",
   load: "画面読み込み",
   timer: "タイマー",
+  auto: "自動起動",
   other: "その他",
 };
 
@@ -375,8 +379,8 @@ export interface ValidationStep extends StepBase {
    */
   fieldErrorsVar?: string;
   inlineBranch?: {
-    ok: string;
-    ng: string;
+    ok: string | Step[];
+    ng: string | Step[];
     ngJumpTo?: string;
     /**
      * バリデーション NG 時に返却する HTTP レスポンス参照 (#180)。
@@ -680,6 +684,8 @@ export interface CommonProcessStep extends StepBase {
    * docs/spec/process-flow-variables.md §3.4
    */
   argumentMapping?: Record<string, string>;
+  /** 呼び先フローの戻り値名 → 説明のマッピング (例: {"処理結果": "0:正常終了, 1:異常終了"}) */
+  returnMapping?: Record<string, string>;
 }
 
 export interface ScreenTransitionStep extends StepBase {

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -20,6 +20,7 @@
 | [process-flow-secrets.md](process-flow-secrets.md) | Secrets カタログ (`secretsCatalog`) — 秘匿値メタデータ + 環境別参照式 | #261 / #414 |
 | [process-flow-transaction.md](process-flow-transaction.md) | `TransactionScopeStep` (複数 DB 操作を 1 TX でまとめる meta-step) と既存 `txBoundary` の関係 | #415 |
 | [screen-items.md](screen-items.md) | 画面項目定義 (フォーム系バリデーション 3 層のうち「画面」層) — **ドラフト v0.1** | #318 |
+| [plugin-system.md](plugin-system.md) | プラグインシステム — ソース変更なしにスキーマ・ステップ型・enum を拡張する仕組み | #390 |
 
 **一次成果物**: JSON スキーマ [`schemas/process-flow.schema.json`](../../schemas/process-flow.schema.json) ([README](../../schemas/README.md))。仕様書と突合する機械可読版。
 

--- a/docs/spec/plugin-system.md
+++ b/docs/spec/plugin-system.md
@@ -129,17 +129,18 @@ data/extensions/
   "namespace": "gm50",
   "fieldTypes": [
     {
-      "kind": "file",
-      "label": "ファイル",
-      "formatOptions": ["csv", "tsv", "zip", "pdf"]
-    },
-    {
       "kind": "view",
       "label": "ビュー"
+    },
+    {
+      "kind": "tbl",
+      "label": "テーブル参照 (旧TBL形式)"
     }
   ]
 }
 ```
+
+> **注意**: `{kind: "file"}` はグローバルスキーマ (#443) で追加済みのため、プラグインで定義する必要はない。
 
 - `kind`: FieldType の `kind` 値として登録される
 - `formatOptions`: 省略可。`format` サブフィールドの選択肢として UI に表示
@@ -151,16 +152,18 @@ data/extensions/
   "namespace": "gm50",
   "triggers": [
     {
-      "value": "auto",
-      "label": "自動起動"
-    },
-    {
       "value": "webhook",
       "label": "Webhook"
+    },
+    {
+      "value": "mq",
+      "label": "メッセージキュー"
     }
   ]
 }
 ```
+
+> **注意**: `"auto"` はグローバルスキーマ (#443) で追加済みのため、プラグインで定義する必要はない。
 
 ### db-operations.json — DbOperation 拡張
 

--- a/docs/spec/plugin-system.md
+++ b/docs/spec/plugin-system.md
@@ -1,0 +1,308 @@
+# プラグインシステム仕様
+
+処理フロースキーマをソース変更なしに拡張するための仕組み。業務アプリ開発者がプロジェクト固有の型・ステップ・操作を追加できる。
+
+**関連 ISSUE**: #390 (GM50 バッチ対応、本仕様の最初のユーザー)
+
+---
+
+## 設計原則
+
+### グローバルスキーマ vs プラグイン の判断基準
+
+| 区分 | 基準 | 例 |
+|---|---|---|
+| **グローバル** | どの業務プロジェクトでも合理的に必要になる | `"file"` FieldType、`"auto"` トリガー、`MERGE` DB 操作 |
+| **プラグイン** | 特定プロジェクト・業界・業態に固有 | GM50 の `"csv"` / `"ZIP"` / `"TBL"` 型 |
+
+**原則**: グローバルに入れるべきものはグローバルに。プラグインはソースを触らずに拡張できる手段であり、グローバル定義の代替ではない。
+
+### アーキテクチャ
+
+```
+グローバルスキーマ (schemas/process-flow.schema.json)
+  └─ 全プロジェクト共通の型・enum・ステップ定義
+
+プラグイン (data/extensions/*.json)
+  └─ プロジェクト固有の追加定義
+  └─ グローバルと重複した場合はプラグインが上書き (意図的な上書きとして扱う)
+
+バリデーター
+  └─ 検証のたびに extensions/ を動的読み込み → グローバルとマージして検証
+```
+
+---
+
+## ファイル構成
+
+```
+data/extensions/
+  steps.json          カスタムステップ型 (処理フローエディターのカード)
+  field-types.json    FieldType 拡張 (入出力フィールドの型)
+  triggers.json       ActionTrigger 拡張 (アクションの起動条件)
+  db-operations.json  DbOperation 拡張 (DB 操作の種別)
+  response-types.json レスポンス型定義 (typeCatalog の後継)
+```
+
+- 拡張種別ごとにファイルを分ける (異なる概念を同一ファイルに混在させない)
+- バリデーターはディレクトリ内の全ファイルを読み込んでマージする
+- ファイルが存在しない場合はその種別の拡張なしとして扱う (エラーにしない)
+
+### 将来の拡張
+
+- 外部パス設定: `project.json` に `extensionsPath` を追加し、`data/extensions/` 以外の場所を指定できるようにする (複数業務プロジェクトの並行管理に対応)
+- 複数プロジェクト対応: 外部パス指定により、各業務プロジェクトのリポジトリ内に拡張定義を置ける
+
+---
+
+## 名前空間
+
+プラグイン定義の各エントリには名前空間プレフィックスを付けられる。
+
+```json
+// steps.json
+{
+  "namespace": "gm50",
+  "steps": {
+    "BatchStep": { ... }
+  }
+}
+// → "gm50:BatchStep" として登録される
+```
+
+```json
+// namespace が空の場合
+{
+  "namespace": "",
+  "steps": {
+    "BatchStep": { ... }
+  }
+}
+// → "BatchStep" としてそのまま登録
+```
+
+**競合ルール**: 同一キーが複数のファイルで定義された場合、後から読み込まれたものが上書きする (ファイル名のアルファベット順)。名前空間を使うことで意図しない競合を避けることを推奨する。
+
+---
+
+## 各ファイルの仕様
+
+### steps.json — カスタムステップ型
+
+```json
+{
+  "namespace": "gm50",
+  "steps": {
+    "BatchProcessStep": {
+      "label": "バッチ処理",
+      "icon": "bi-gear",
+      "description": "大量データの一括処理ステップ",
+      "schema": {
+        "type": "object",
+        "required": ["batchId"],
+        "properties": {
+          "batchId": {
+            "type": "string",
+            "description": "バッチ定義 ID"
+          },
+          "chunkSize": {
+            "type": "number",
+            "description": "1 回の処理件数"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+- `label`: 処理フローエディターのカードパレットに表示される名称
+- `icon`: Bootstrap Icons のクラス名
+- `schema`: JSON Schema draft 2020-12 で記述。UI フォームはこの schema から動的生成される
+
+**UI への反映**: 定義されたカスタムステップはカードパレットの「カスタム」セクションに表示され、D&D でフローに追加できる。
+
+### field-types.json — FieldType 拡張
+
+```json
+{
+  "namespace": "gm50",
+  "fieldTypes": [
+    {
+      "kind": "file",
+      "label": "ファイル",
+      "formatOptions": ["csv", "tsv", "zip", "pdf"]
+    },
+    {
+      "kind": "view",
+      "label": "ビュー"
+    }
+  ]
+}
+```
+
+- `kind`: FieldType の `kind` 値として登録される
+- `formatOptions`: 省略可。`format` サブフィールドの選択肢として UI に表示
+
+### triggers.json — ActionTrigger 拡張
+
+```json
+{
+  "namespace": "gm50",
+  "triggers": [
+    {
+      "value": "auto",
+      "label": "自動起動"
+    },
+    {
+      "value": "webhook",
+      "label": "Webhook"
+    }
+  ]
+}
+```
+
+### db-operations.json — DbOperation 拡張
+
+```json
+{
+  "namespace": "gm50",
+  "dbOperations": [
+    { "value": "TRUNCATE", "label": "TRUNCATE" }
+  ]
+}
+```
+
+### response-types.json — レスポンス型定義 (typeCatalog 後継)
+
+```json
+{
+  "namespace": "",
+  "responseTypes": {
+    "ApiError": {
+      "description": "API エラーレスポンス",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "code": { "type": "string" },
+          "message": { "type": "string" }
+        }
+      }
+    }
+  }
+}
+```
+
+`HttpResponseSpec.bodySchema = { "typeRef": "ApiError" }` の解決先。`typeCatalog` (ProcessFlow 内部) を廃止しこちらに移行する。
+
+---
+
+## バリデーター設計
+
+- 処理フロー JSON の検証のたびに `data/extensions/` を読み込む (再起動不要)
+- 読み込み順: ファイル名アルファベット順
+- マージ戦略: 後から読み込んだエントリが同一キーを上書き
+- グローバルスキーマの enum にプラグインの値を追加した合成スキーマで検証する
+- extensions/ が存在しない・空の場合はグローバルスキーマのみで検証
+
+---
+
+## MCP ツール設計
+
+AI がプラグインを操作するための専用ツール。拡張種別ごとに分ける (誤操作防止)。
+
+| ツール名 | 操作 |
+|---|---|
+| `add_step_extension` | カスタムステップを追加・更新 |
+| `add_field_type_extension` | FieldType を追加 |
+| `add_trigger_extension` | ActionTrigger を追加 |
+| `add_db_operation_extension` | DbOperation を追加 |
+| `add_response_type_extension` | レスポンス型を追加 (旧 add_catalog_entry の後継) |
+| `remove_extension` | 任意の拡張エントリを削除 |
+| `list_extensions` | 現在の全拡張一覧を取得 |
+
+既存の `add_catalog_entry` / `remove_catalog_entry` は `add_response_type_extension` に置き換える。
+
+---
+
+## UI 設計
+
+### 拡張管理パネル
+
+処理フローエディターまたは設定画面に「拡張管理」パネルを追加。
+
+- 拡張種別ごとにタブ表示 (ステップ / フィールド型 / トリガー / DB 操作 / レスポンス型)
+- 各エントリの追加・編集・削除が可能
+- 編集後は即時反映 (バリデーター動的読み込みのため再起動不要)
+
+### カスタムステップの編集フォーム
+
+カスタムステップをフロー上に配置した後の編集 UI:
+
+- `steps.json` に定義された `schema` から **動的にフォームを生成**する
+- JSON Schema の各プロパティを入力フィールドに自動変換
+  - `type: "string"` → テキスト入力
+  - `type: "number"` → 数値入力
+  - `type: "boolean"` → チェックボックス
+  - `enum` → セレクトボックス
+  - `type: "object"` / `type: "array"` → ネストしたフォーム
+- **汎用 JSON テキストエリアは不可** (業務設計者が使えないため)
+
+### カードパレット
+
+標準ステップのカードに加え、「カスタム」セクションを設けてプラグイン定義のカードを表示。`label` と `icon` を使って表示。
+
+---
+
+## typeCatalog 移行
+
+現在 ProcessFlow JSON 内部にある `typeCatalog` フィールドは本仕様の `response-types.json` に移行する。
+
+**移行手順** (プラグインシステム実装時に同時実施):
+1. 既存の `typeCatalog` エントリを `data/extensions/response-types.json` に移動
+2. ProcessFlow JSON から `typeCatalog` フィールドを削除
+3. `TypeCatalogPanel` UI コンポーネントを拡張管理パネルの「レスポンス型」タブに統合
+4. MCP ツール `add_catalog_entry` / `remove_catalog_entry` を廃止し `add_response_type_extension` に置換
+
+---
+
+## AI 向けガイド (操作規約)
+
+AI が処理フロー設計中にプラグインを操作する際の判断規約。
+
+### 拡張を追加する前に確認すること
+
+1. **グローバルスキーマに既に存在しないか** — まず `list_extensions` とスキーマ定義を確認する
+2. **グローバルに入れるべきものではないか** — 「どの業務プロジェクトでも必要か」を問う。そうなら実装者に報告してグローバル追加を提案する
+3. **既存の拡張と名前が衝突しないか** — `list_extensions` で確認する。衝突する場合は名前空間を使う
+
+### カスタムステップを追加する際の schema の書き方
+
+- フィールドには必ず `description` を付ける (AI 実装者が読む)
+- `required` を明示する
+- `additionalProperties: false` を推奨 (意図しないフィールドの混入防止)
+
+### やってはいけないこと
+
+- グローバルスキーマで既にカバーされている概念をプラグインに重複定義する
+- `namespace` を省略する (空文字列でも明示する)
+- schema のない step を定義する
+
+---
+
+## #390 との関係
+
+#390 (GM50 バッチ処理フロー対応) は本プラグインシステムの最初のユーザー。
+
+**グローバルスキーマに追加 (本仕様とは別 ISSUE で先行実装)**:
+- `FieldType`: `{kind: "file"}` を追加
+- `ActionTrigger`: `"auto"` を追加
+- `DbOperation`: `"MERGE"`, `"LOCK"` を追加
+- `ValidationInlineBranch.ok/ng`: `string | Step[]` に拡張
+- `CommonProcessStep.returnMapping`: プロパティ追加
+
+**GM50 プラグインとして定義 (#390 本体で実装)**:
+- `field-types.json`: `"csv"`, `"tsv"`, `"zip"`, `"view"` 等の GM50 固有型
+- `"TBL"` → グローバルの `{kind: "tableRow"}` に正規化
+
+プラグインシステムインフラ完成後、#390 は「GM50 用拡張定義ファイルを作成する」チケットとして実行する。

--- a/schemas/process-flow.schema.json
+++ b/schemas/process-flow.schema.json
@@ -297,7 +297,7 @@
     },
     "ActionTrigger": {
       "type": "string",
-      "enum": ["click", "submit", "select", "change", "load", "timer", "other"]
+      "enum": ["click", "submit", "select", "change", "load", "timer", "auto", "other"]
     },
     "StepType": {
       "type": "string",
@@ -787,6 +787,16 @@
           }
         },
         {
+          "description": "ファイル型。バッチ処理の入出力ファイル等。format で CSV/ZIP 等の形式を表現。",
+          "type": "object",
+          "required": ["kind"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "file" },
+            "format": { "type": "string", "description": "ファイル形式 (例: csv, tsv, zip, pdf)" }
+          }
+        },
+        {
           "description": "DEPRECATED (#261 v1.3): 新規データは array / object / primitive を優先。label 文字列に型情報を自由記述するパターンは AI 実装者が構造パースを強いられるため非推奨。",
           "deprecated": true,
           "type": "object",
@@ -1013,8 +1023,18 @@
       "required": ["ok", "ng"],
       "additionalProperties": false,
       "properties": {
-        "ok": { "type": "string" },
-        "ng": { "type": "string" },
+        "ok": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "$ref": "#/$defs/Step" } }
+          ]
+        },
+        "ng": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "$ref": "#/$defs/Step" } }
+          ]
+        },
         "ngJumpTo": { "type": "string" },
         "ngResponseRef": { "type": "string" },
         "ngBodyExpression": { "type": "string" }
@@ -1050,7 +1070,7 @@
 
     "DbOperation": {
       "type": "string",
-      "enum": ["SELECT", "INSERT", "UPDATE", "DELETE"]
+      "enum": ["SELECT", "INSERT", "UPDATE", "DELETE", "MERGE", "LOCK"]
     },
     "AffectedRowsOperator": {
       "type": "string",
@@ -1366,6 +1386,11 @@
             "refId": { "type": "string" },
             "refName": { "type": "string" },
             "argumentMapping": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            },
+            "returnMapping": {
+              "description": "呼び先フローの戻り値名 → 説明のマッピング (例: {\"処理結果\": \"0:正常終了, 1:異常終了\"})",
               "type": "object",
               "additionalProperties": { "type": "string" }
             }


### PR DESCRIPTION
## 概要

#443 の実装。#390 (GM50 バッチ対応) で発見されたスキーマ不足 5 件のうちグローバルに追加すべきものを一括追加。

Closes #443

## 変更内容

| 変更 | 詳細 |
|---|---|
| `FieldType {kind: "file"}` | ファイル I/O 型。`format?: string` でCSV/ZIP等の形式を表現 |
| `ActionTrigger "auto"` | バッチ自動起動。`ACTION_TRIGGER_LABELS` に `自動起動` を追加 |
| `DbOperation "MERGE" / "LOCK"` | ANSI SQL 標準操作。`DB_OPERATION_LABELS` に追加 |
| `ValidationInlineBranch.ok/ng` | `string \| Step[]` に拡張。NG 時にステップ列を直接記述可能に |
| `CommonProcessStep.returnMapping` | `Record<string, string>` — 呼び先フローの戻り値マッピング |

## 新規ファイル

- `docs/spec/plugin-system.md` — プラグインシステム全体設計仕様 (#442 メタ ISSUE に対応)

## グローバル採用の判断基準

`docs/spec/plugin-system.md` に明記: 「どの業務プロジェクトでも合理的に必要になるか」をグローバル採用の基準とした。GM50 固有の値 (`"csv"` / `"TBL"` 等) は #390 にてプラグイン定義で対応。

## レビュー対応 (Must-fix 2件)

- `FieldType` TS 型に `{kind: "file"; format?: string}` を追加 (スキーマのみ追加でTS型が欠落していた)
- `StepCard`: `inlineBranch.ok/ng` が `Step[]` の場合はステップ件数を表示 (string の場合は従来通り入力欄)

## テスト計画

- [x] `npx vitest run src/schemas/process-flow.schema.test.ts` — 192/192 pass
- [x] `npx tsc --noEmit` — エラーなし
- [x] 新規テストケース 8 件追加 (各変更につき accept ケース)
- N/A Playwright (UI は読み取り専用表示の追加のみ)

## 仕様逐条突合

- [x] FieldType `{kind: "file"}` — スキーマ oneOf に追加、TS 型に追加、テスト追加
- [x] ActionTrigger `"auto"` — スキーマ enum に追加、TS 型・ラベルマップに追加、テスト追加
- [x] DbOperation `"MERGE"` / `"LOCK"` — スキーマ enum に追加、TS 型・ラベルマップに追加、テスト追加
- [x] `ValidationInlineBranch.ok/ng` — `oneOf[string, Step[]]` に変更、TS 型変更、StepCard UI 対応、後方互換テスト追加
- [x] `CommonProcessStep.returnMapping` — スキーマ・TS 型に追加、テスト追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)