### PR TITLE
feat(plugin): 動的フォーム生成 SchemaForm CustomStepPanel StepPanelSelector スタブ 446

### DIFF
--- a/designer/src/components/common/SchemaForm.test.tsx
+++ b/designer/src/components/common/SchemaForm.test.tsx
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { SchemaForm, type DynamicFormSchema } from "./SchemaForm";
+
+function renderForm(schema: DynamicFormSchema, value: unknown = {}, onChange = vi.fn()) {
+  render(<SchemaForm schema={schema} value={value} onChange={onChange} />);
+  return onChange;
+}
+
+describe("SchemaForm", () => {
+  it("string input is rendered and propagates changes", () => {
+    const onChange = renderForm({
+      type: "object",
+      properties: { name: { type: "string" } },
+    });
+
+    fireEvent.change(screen.getByLabelText("name"), { target: { value: "顧客登録" } });
+
+    expect(onChange).toHaveBeenLastCalledWith({ name: "顧客登録" });
+  });
+
+  it("number input uses type=number and converts to number", () => {
+    const onChange = renderForm({
+      type: "object",
+      properties: { amount: { type: "number" } },
+    });
+    const input = screen.getByLabelText("amount") as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: "12.5" } });
+
+    expect(input.type).toBe("number");
+    expect(onChange).toHaveBeenLastCalledWith({ amount: 12.5 });
+  });
+
+  it("integer input uses type=number and truncates decimal input", () => {
+    const onChange = renderForm({
+      type: "object",
+      properties: { count: { type: "integer" } },
+    });
+    const input = screen.getByLabelText("count") as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: "8.9" } });
+
+    expect(input.type).toBe("number");
+    expect(onChange).toHaveBeenLastCalledWith({ count: 8 });
+  });
+
+  it("boolean input renders a checkbox", () => {
+    const onChange = renderForm({
+      type: "object",
+      properties: { enabled: { type: "boolean" } },
+    });
+    const checkbox = screen.getByLabelText("enabled") as HTMLInputElement;
+
+    fireEvent.click(checkbox);
+
+    expect(checkbox.type).toBe("checkbox");
+    expect(onChange).toHaveBeenLastCalledWith({ enabled: true });
+  });
+
+  it("enum renders a select with matching options", () => {
+    const onChange = renderForm({
+      type: "object",
+      properties: { mode: { enum: ["AUTO", "MANUAL"] } },
+    });
+    const select = screen.getByLabelText("mode");
+
+    expect(within(select).getByRole("option", { name: "AUTO" })).toBeTruthy();
+    expect(within(select).getByRole("option", { name: "MANUAL" })).toBeTruthy();
+
+    fireEvent.change(select, { target: { value: "MANUAL" } });
+    expect(onChange).toHaveBeenLastCalledWith({ mode: "MANUAL" });
+  });
+
+  it("object properties render recursively and update parent values", () => {
+    const onChange = renderForm(
+      {
+        type: "object",
+        properties: {
+          config: {
+            type: "object",
+            properties: { path: { type: "string" } },
+          },
+        },
+      },
+      { config: { path: "old" } },
+    );
+
+    fireEvent.change(screen.getByLabelText("path"), { target: { value: "new" } });
+
+    expect(onChange).toHaveBeenLastCalledWith({ config: { path: "new" } });
+  });
+
+  it("array items render recursively and can be added and removed", () => {
+    const onChange = renderForm(
+      {
+        type: "object",
+        properties: {
+          tags: {
+            type: "array",
+            items: { type: "string", default: "new-tag" },
+          },
+        },
+      },
+      { tags: ["a"] },
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "追加" }));
+    expect(onChange).toHaveBeenLastCalledWith({ tags: ["a", "new-tag"] });
+
+    fireEvent.click(screen.getByRole("button", { name: "tags 1 を削除" }));
+    expect(onChange).toHaveBeenLastCalledWith({ tags: [] });
+  });
+
+  it("required fields show a required marker", () => {
+    renderForm({
+      type: "object",
+      required: ["name"],
+      properties: { name: { type: "string" } },
+    });
+
+    expect(screen.getByText("*")).toBeTruthy();
+    expect(screen.getByText("必須項目です")).toBeTruthy();
+  });
+
+  it("description is rendered as help text", () => {
+    renderForm({
+      type: "object",
+      properties: {
+        batchId: { type: "string", description: "バッチ定義 ID" },
+      },
+    });
+
+    expect(screen.getByText("バッチ定義 ID")).toBeTruthy();
+  });
+
+  it("default is applied on mount and shown as placeholder", async () => {
+    const onChange = renderForm({
+      type: "object",
+      properties: {
+        chunkSize: { type: "number", default: 100 },
+      },
+    });
+
+    expect(screen.getByLabelText("chunkSize")).toHaveAttribute("placeholder", "100");
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith({ chunkSize: 100 }));
+  });
+
+  it("nested object and array structures update the nested branch", () => {
+    const onChange = renderForm(
+      {
+        type: "object",
+        properties: {
+          job: {
+            type: "object",
+            properties: {
+              steps: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: { command: { type: "string" } },
+                },
+              },
+            },
+          },
+        },
+      },
+      { job: { steps: [{ command: "load" }] } },
+    );
+
+    fireEvent.change(screen.getByLabelText("command"), { target: { value: "save" } });
+
+    expect(onChange).toHaveBeenLastCalledWith({ job: { steps: [{ command: "save" }] } });
+  });
+});

--- a/designer/src/components/common/SchemaForm.test.tsx
+++ b/designer/src/components/common/SchemaForm.test.tsx
@@ -72,6 +72,22 @@ describe("SchemaForm", () => {
     expect(onChange).toHaveBeenLastCalledWith({ mode: "MANUAL" });
   });
 
+  it("enum placeholder is disabled and selecting a value does not emit undefined", () => {
+    const onChange = renderForm({
+      type: "object",
+      properties: { mode: { enum: ["AUTO", "MANUAL"] } },
+    });
+    const select = screen.getByLabelText("mode");
+    const placeholder = within(select).getByRole("option", { name: "選択してください" }) as HTMLOptionElement;
+
+    expect(placeholder.disabled).toBe(true);
+    expect(placeholder.value).toBe("");
+
+    fireEvent.change(select, { target: { value: "AUTO" } });
+    expect(onChange).toHaveBeenLastCalledWith({ mode: "AUTO" });
+    expect(onChange).not.toHaveBeenCalledWith({ mode: undefined });
+  });
+
   it("object properties render recursively and update parent values", () => {
     const onChange = renderForm(
       {
@@ -89,6 +105,37 @@ describe("SchemaForm", () => {
     fireEvent.change(screen.getByLabelText("path"), { target: { value: "new" } });
 
     expect(onChange).toHaveBeenLastCalledWith({ config: { path: "new" } });
+  });
+
+  it("nested objects with same-named properties do not reuse DOM ids", () => {
+    const { container } = render(
+      <SchemaForm
+        schema={{
+          type: "object",
+          properties: {
+            source: {
+              type: "object",
+              properties: { name: { type: "string" } },
+            },
+            target: {
+              type: "object",
+              properties: { name: { type: "string" } },
+            },
+          },
+        }}
+        value={{ source: { name: "from" }, target: { name: "to" } }}
+        onChange={vi.fn()}
+      />,
+    );
+
+    const labels = Array.from(container.querySelectorAll("label")).filter((label) => label.textContent === "name");
+    const fieldIds = labels.map((label) => label.htmlFor);
+
+    expect(labels).toHaveLength(2);
+    expect(new Set(fieldIds).size).toBe(2);
+    fieldIds.forEach((fieldId) => {
+      expect(container.ownerDocument.getElementById(fieldId)).toBeInstanceOf(HTMLInputElement);
+    });
   });
 
   it("array items render recursively and can be added and removed", () => {

--- a/designer/src/components/common/SchemaForm.tsx
+++ b/designer/src/components/common/SchemaForm.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo } from "react";
+import * as React from "react";
+import { useEffect } from "react";
 
 type SchemaPrimitive = string | number | boolean | null;
 
@@ -28,13 +29,15 @@ export function SchemaForm({
   required = false,
   fieldName,
 }: SchemaFormProps) {
+  const reactId = React.useId();
+
   useEffect(() => {
     if (value === undefined && Object.prototype.hasOwnProperty.call(schema, "default")) {
       onChange(schema.default);
     }
   }, [onChange, schema, value]);
 
-  const fieldId = useMemo(() => `schema-form-${fieldName ?? "root"}-${stableId(fieldName ?? "root")}`, [fieldName]);
+  const fieldId = `${reactId}-${fieldName ?? "root"}`;
   const invalid = required && isEmptyValue(value);
 
   if (schema.enum) {
@@ -44,9 +47,15 @@ export function SchemaForm({
           id={fieldId}
           className={`form-select form-select-sm${invalid ? " is-invalid" : ""}`}
           value={valueToInputValue(value)}
-          onChange={(e) => onChange(schema.enum?.find((item) => valueToInputValue(item) === e.target.value))}
+          defaultValue=""
+          onChange={(e) => {
+            const next = schema.enum?.find((item) => valueToInputValue(item) === e.target.value);
+            if (next !== undefined) onChange(next);
+          }}
         >
-          <option value="">選択してください</option>
+          <option value="" disabled>
+            選択してください
+          </option>
           {schema.enum.map((item) => (
             <option key={valueToInputValue(item)} value={valueToInputValue(item)}>
               {String(item)}
@@ -234,12 +243,4 @@ function isEmptyValue(value: unknown): boolean {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function stableId(value: string): string {
-  let hash = 0;
-  for (let i = 0; i < value.length; i += 1) {
-    hash = (hash * 31 + value.charCodeAt(i)) >>> 0;
-  }
-  return hash.toString(36);
 }

--- a/designer/src/components/common/SchemaForm.tsx
+++ b/designer/src/components/common/SchemaForm.tsx
@@ -1,0 +1,245 @@
+import { useEffect, useMemo } from "react";
+
+type SchemaPrimitive = string | number | boolean | null;
+
+export interface DynamicFormSchema {
+  type?: "string" | "number" | "integer" | "boolean" | "object" | "array";
+  enum?: SchemaPrimitive[];
+  properties?: Record<string, DynamicFormSchema>;
+  items?: DynamicFormSchema;
+  required?: string[];
+  description?: string;
+  default?: unknown;
+  additionalProperties?: boolean;
+}
+
+export interface SchemaFormProps {
+  schema: DynamicFormSchema;
+  value: unknown;
+  onChange: (next: unknown) => void;
+  required?: boolean;
+  fieldName?: string;
+}
+
+export function SchemaForm({
+  schema,
+  value,
+  onChange,
+  required = false,
+  fieldName,
+}: SchemaFormProps) {
+  useEffect(() => {
+    if (value === undefined && Object.prototype.hasOwnProperty.call(schema, "default")) {
+      onChange(schema.default);
+    }
+  }, [onChange, schema, value]);
+
+  const fieldId = useMemo(() => `schema-form-${fieldName ?? "root"}-${stableId(fieldName ?? "root")}`, [fieldName]);
+  const invalid = required && isEmptyValue(value);
+
+  if (schema.enum) {
+    return (
+      <FieldFrame fieldName={fieldName} fieldId={fieldId} schema={schema} required={required} invalid={invalid}>
+        <select
+          id={fieldId}
+          className={`form-select form-select-sm${invalid ? " is-invalid" : ""}`}
+          value={valueToInputValue(value)}
+          onChange={(e) => onChange(schema.enum?.find((item) => valueToInputValue(item) === e.target.value))}
+        >
+          <option value="">選択してください</option>
+          {schema.enum.map((item) => (
+            <option key={valueToInputValue(item)} value={valueToInputValue(item)}>
+              {String(item)}
+            </option>
+          ))}
+        </select>
+      </FieldFrame>
+    );
+  }
+
+  if (schema.type === "string") {
+    return (
+      <FieldFrame fieldName={fieldName} fieldId={fieldId} schema={schema} required={required} invalid={invalid}>
+        <input
+          id={fieldId}
+          type="text"
+          className={`form-control form-control-sm${invalid ? " is-invalid" : ""}`}
+          value={typeof value === "string" ? value : ""}
+          placeholder={placeholderFor(schema)}
+          onChange={(e) => onChange(e.target.value)}
+        />
+      </FieldFrame>
+    );
+  }
+
+  if (schema.type === "number" || schema.type === "integer") {
+    return (
+      <FieldFrame fieldName={fieldName} fieldId={fieldId} schema={schema} required={required} invalid={invalid}>
+        <input
+          id={fieldId}
+          type="number"
+          step={schema.type === "integer" ? 1 : "any"}
+          className={`form-control form-control-sm${invalid ? " is-invalid" : ""}`}
+          value={typeof value === "number" ? String(value) : ""}
+          placeholder={placeholderFor(schema)}
+          onChange={(e) => {
+            const next = e.target.value === "" ? undefined : Number(e.target.value);
+            onChange(schema.type === "integer" && typeof next === "number" ? Math.trunc(next) : next);
+          }}
+        />
+      </FieldFrame>
+    );
+  }
+
+  if (schema.type === "boolean") {
+    return (
+      <FieldFrame fieldName={fieldName} fieldId={fieldId} schema={schema} required={required} invalid={invalid}>
+        <div className="form-check">
+          <input
+            id={fieldId}
+            type="checkbox"
+            className="form-check-input"
+            checked={value === true}
+            onChange={(e) => onChange(e.target.checked)}
+          />
+        </div>
+      </FieldFrame>
+    );
+  }
+
+  if (schema.type === "object") {
+    const current = isRecord(value) ? value : {};
+    const properties = schema.properties ?? {};
+    const requiredFields = new Set(schema.required ?? []);
+
+    return (
+      <fieldset className={fieldName ? "border rounded p-2 mb-2" : ""}>
+        {fieldName ? (
+          <legend className="float-none w-auto px-1 fs-6 mb-1">
+            {fieldName}
+            {required ? <span className="text-danger ms-1">*</span> : null}
+          </legend>
+        ) : null}
+        {schema.description ? <small className="form-text text-muted d-block mb-2">{schema.description}</small> : null}
+        {Object.entries(properties).map(([key, childSchema]) => (
+          <SchemaForm
+            key={key}
+            schema={childSchema}
+            value={current[key]}
+            required={requiredFields.has(key)}
+            fieldName={key}
+            onChange={(next) => {
+              const updated = { ...current };
+              if (next === undefined) {
+                delete updated[key];
+              } else {
+                updated[key] = next;
+              }
+              onChange(updated);
+            }}
+          />
+        ))}
+      </fieldset>
+    );
+  }
+
+  if (schema.type === "array") {
+    const items = Array.isArray(value) ? value : [];
+    const itemSchema = schema.items ?? { type: "string" };
+
+    return (
+      <FieldFrame fieldName={fieldName} fieldId={fieldId} schema={schema} required={required} invalid={invalid}>
+        <div className="d-flex flex-column gap-2">
+          {items.map((item, index) => (
+            <div key={index} className="d-flex gap-2 align-items-start">
+              <div className="flex-grow-1">
+                <SchemaForm
+                  schema={itemSchema}
+                  value={item}
+                  fieldName={`${fieldName ?? "item"} ${index + 1}`}
+                  onChange={(next) => onChange(items.map((current, i) => (i === index ? next : current)))}
+                />
+              </div>
+              <button
+                type="button"
+                className="btn btn-outline-danger btn-sm"
+                aria-label={`${fieldName ?? "項目"} ${index + 1} を削除`}
+                onClick={() => onChange(items.filter((_, i) => i !== index))}
+              >
+                削除
+              </button>
+            </div>
+          ))}
+          <button
+            type="button"
+            className="btn btn-outline-primary btn-sm align-self-start"
+            onClick={() => onChange([...items, defaultForSchema(itemSchema)])}
+          >
+            追加
+          </button>
+        </div>
+      </FieldFrame>
+    );
+  }
+
+  return <div className="alert alert-warning py-2 mb-2">未対応スキーマ</div>;
+}
+
+interface FieldFrameProps {
+  children: React.ReactNode;
+  fieldName?: string;
+  fieldId: string;
+  schema: DynamicFormSchema;
+  required: boolean;
+  invalid: boolean;
+}
+
+function FieldFrame({ children, fieldName, fieldId, schema, required, invalid }: FieldFrameProps) {
+  return (
+    <div className="mb-2" data-field-name={fieldName}>
+      {fieldName ? (
+        <label htmlFor={fieldId} className="form-label mb-1">
+          {fieldName}
+          {required ? <span className="text-danger ms-1">*</span> : null}
+        </label>
+      ) : null}
+      {children}
+      {schema.description ? <small className="form-text text-muted">{schema.description}</small> : null}
+      {invalid ? <div className="invalid-feedback d-block">必須項目です</div> : null}
+    </div>
+  );
+}
+
+function defaultForSchema(schema: DynamicFormSchema): unknown {
+  if (Object.prototype.hasOwnProperty.call(schema, "default")) return schema.default;
+  if (schema.enum?.length) return schema.enum[0];
+  if (schema.type === "object") return {};
+  if (schema.type === "array") return [];
+  if (schema.type === "boolean") return false;
+  if (schema.type === "number" || schema.type === "integer") return 0;
+  return "";
+}
+
+function placeholderFor(schema: DynamicFormSchema): string | undefined {
+  return Object.prototype.hasOwnProperty.call(schema, "default") ? String(schema.default) : undefined;
+}
+
+function valueToInputValue(value: unknown): string {
+  return value == null ? "" : String(value);
+}
+
+function isEmptyValue(value: unknown): boolean {
+  return value === undefined || value === null || value === "";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stableId(value: string): string {
+  let hash = 0;
+  for (let i = 0; i < value.length; i += 1) {
+    hash = (hash * 31 + value.charCodeAt(i)) >>> 0;
+  }
+  return hash.toString(36);
+}

--- a/designer/src/components/common/SchemaForm.tsx
+++ b/designer/src/components/common/SchemaForm.tsx
@@ -47,7 +47,6 @@ export function SchemaForm({
           id={fieldId}
           className={`form-select form-select-sm${invalid ? " is-invalid" : ""}`}
           value={valueToInputValue(value)}
-          defaultValue=""
           onChange={(e) => {
             const next = schema.enum?.find((item) => valueToInputValue(item) === e.target.value);
             if (next !== undefined) onChange(next);

--- a/designer/src/components/process-flow/CustomStepPanel.test.tsx
+++ b/designer/src/components/process-flow/CustomStepPanel.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { CustomStepPanel } from "./CustomStepPanel";
+
+const bridgeMock = vi.hoisted(() => {
+  let extensionHandler: (() => void) | null = null;
+  return {
+    getExtensions: vi.fn(),
+    onExtensionsChanged: vi.fn((handler: () => void) => {
+      extensionHandler = handler;
+      return vi.fn();
+    }),
+    emitExtensionsChanged: () => extensionHandler?.(),
+  };
+});
+
+vi.mock("../../mcp/mcpBridge", () => ({
+  mcpBridge: bridgeMock,
+}));
+
+const bundleWithSchema = {
+  steps: {
+    namespace: "gm50",
+    steps: {
+      BatchStep: {
+        label: "バッチ処理",
+        icon: "bi-gear",
+        description: "バッチ処理ステップ",
+        schema: {
+          type: "object",
+          properties: {
+            batchId: { type: "string", description: "バッチ ID" },
+          },
+        },
+      },
+    },
+  },
+};
+
+describe("CustomStepPanel", () => {
+  beforeEach(() => {
+    bridgeMock.getExtensions.mockReset();
+    bridgeMock.onExtensionsChanged.mockClear();
+  });
+
+  it("renders loading first and then renders SchemaForm", async () => {
+    bridgeMock.getExtensions.mockResolvedValue(bundleWithSchema);
+
+    render(<CustomStepPanel customStepType="gm50:BatchStep" value={{}} onChange={vi.fn()} />);
+
+    expect(screen.getByText("カスタムステップ定義を読み込み中...")).toBeTruthy();
+    await waitFor(() => expect(screen.getByLabelText("batchId")).toBeTruthy());
+  });
+
+  it("shows an error when custom step definition is not found", async () => {
+    bridgeMock.getExtensions.mockResolvedValue(bundleWithSchema);
+
+    render(<CustomStepPanel customStepType="gm50:UnknownStep" value={{}} onChange={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('カスタムステップ "gm50:UnknownStep" の定義が見つかりません')).toBeTruthy();
+    });
+  });
+
+  it("re-fetches schema when extensionsChanged is broadcast", async () => {
+    bridgeMock.getExtensions
+      .mockResolvedValueOnce(bundleWithSchema)
+      .mockResolvedValueOnce({
+        steps: {
+          namespace: "gm50",
+          steps: {
+            BatchStep: {
+              label: "バッチ処理",
+              icon: "bi-gear",
+              description: "バッチ処理ステップ",
+              schema: {
+                type: "object",
+                properties: {
+                  retryCount: { type: "integer", description: "リトライ回数" },
+                },
+              },
+            },
+          },
+        },
+      });
+
+    render(<CustomStepPanel customStepType="gm50:BatchStep" value={{}} onChange={vi.fn()} />);
+    await waitFor(() => expect(screen.getByLabelText("batchId")).toBeTruthy());
+
+    bridgeMock.emitExtensionsChanged();
+
+    await waitFor(() => expect(screen.getByLabelText("retryCount")).toBeTruthy());
+    expect(bridgeMock.getExtensions).toHaveBeenLastCalledWith(true);
+  });
+});

--- a/designer/src/components/process-flow/CustomStepPanel.tsx
+++ b/designer/src/components/process-flow/CustomStepPanel.tsx
@@ -1,0 +1,77 @@
+import { useCallback, useEffect, useState } from "react";
+import { mcpBridge } from "../../mcp/mcpBridge";
+import { loadExtensionsFromBundle } from "../../schemas/loadExtensions";
+import { SchemaForm, type DynamicFormSchema } from "../common/SchemaForm";
+
+interface LoadState {
+  loading: boolean;
+  schema: DynamicFormSchema | null;
+  error: string | null;
+}
+
+export interface CustomStepPanelProps {
+  customStepType: string;
+  value: unknown;
+  onChange: (next: unknown) => void;
+}
+
+export function CustomStepPanel({ customStepType, value, onChange }: CustomStepPanelProps) {
+  const [state, setState] = useState<LoadState>({
+    loading: true,
+    schema: null,
+    error: null,
+  });
+
+  const reload = useCallback(async (forceReload = false) => {
+    try {
+      const bundle = await mcpBridge.getExtensions(forceReload);
+      const result = loadExtensionsFromBundle(bundle);
+      const schema = result.extensions.steps[customStepType]?.schema as DynamicFormSchema | undefined;
+
+      if (!schema) {
+        setState({
+          loading: false,
+          schema: null,
+          error: `カスタムステップ "${customStepType}" の定義が見つかりません`,
+        });
+        return;
+      }
+
+      setState({ loading: false, schema, error: null });
+    } catch (e) {
+      setState({
+        loading: false,
+        schema: null,
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }, [customStepType]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      void reload(false);
+    }, 0);
+    const unsubscribe = mcpBridge.onExtensionsChanged(() => {
+      setState((current) => ({ ...current, loading: true, error: null }));
+      void reload(true);
+    });
+    return () => {
+      window.clearTimeout(timer);
+      unsubscribe();
+    };
+  }, [reload]);
+
+  if (state.loading) {
+    return <div className="text-muted small">カスタムステップ定義を読み込み中...</div>;
+  }
+
+  if (state.error) {
+    return <div className="alert alert-danger py-2 mb-2">{state.error}</div>;
+  }
+
+  if (!state.schema) {
+    return <div className="alert alert-warning py-2 mb-2">未対応スキーマ</div>;
+  }
+
+  return <SchemaForm schema={state.schema} value={value} onChange={onChange} />;
+}

--- a/designer/src/components/process-flow/CustomStepPanel.tsx
+++ b/designer/src/components/process-flow/CustomStepPanel.tsx
@@ -26,7 +26,7 @@ export function CustomStepPanel({ customStepType, value, onChange }: CustomStepP
     try {
       const bundle = await mcpBridge.getExtensions(forceReload);
       const result = loadExtensionsFromBundle(bundle);
-      const schema = result.extensions.steps[customStepType]?.schema as DynamicFormSchema | undefined;
+      const schema = result.extensions.steps[customStepType]?.schema;
 
       if (!schema) {
         setState({

--- a/designer/src/components/process-flow/StepPanelSelector.tsx
+++ b/designer/src/components/process-flow/StepPanelSelector.tsx
@@ -1,0 +1,18 @@
+import type { Step } from "../../types/action";
+
+export interface StepPanelSelectorProps {
+  step: Step;
+  onChange: (step: Step) => void;
+}
+
+/**
+ * Future integration point for custom step panels.
+ *
+ * The current ProcessFlow Step union does not include a "custom" step type.
+ * StepCard integration is intentionally deferred to a separate issue that can
+ * update the ProcessFlow schema and action types together.
+ */
+export function StepPanelSelector(props: StepPanelSelectorProps): null {
+  void props;
+  return null;
+}

--- a/designer/src/schemas/loadExtensions.ts
+++ b/designer/src/schemas/loadExtensions.ts
@@ -1,12 +1,14 @@
 /// <reference types="node" />
 
+import type { DynamicFormSchema } from "../components/common/SchemaForm";
+
 export type ExtensionFileType = "steps" | "fieldTypes" | "triggers" | "dbOperations" | "responseTypes";
 
 export interface StepDef {
   label: string;
   icon: string;
   description: string;
-  schema: Record<string, unknown>;
+  schema: DynamicFormSchema;
 }
 
 export interface FieldTypeDef {
@@ -383,7 +385,7 @@ function validateStepDef(key: string, raw: unknown, errors: ExtensionLoadIssue[]
     label: raw.label,
     icon: raw.icon,
     description: raw.description,
-    schema: raw.schema,
+    schema: raw.schema as DynamicFormSchema,
   };
 }
 


### PR DESCRIPTION
## 関連

Closes #446
- 仕様: docs/spec/plugin-system.md 動的フォーム生成スコープ

## 概要

プラグイン定義の JSON Schema サブセットから編集フォームを生成する SchemaForm と、mcpBridge の extensions 取得結果からカスタムステップ schema を引いて表示する CustomStepPanel を追加しました。StepPanelSelector は将来の StepCard 統合ポイントとして null を返すスタブに留めています。

## 主な変更

- SchemaForm: string / number / integer / boolean / enum / object / array を再帰描画し、required / description / default を反映
- CustomStepPanel: mcpBridge.getExtensions() と loadExtensionsFromBundle() で namespaced custom step schema を解決し、loading / error / broadcast 再取得を処理
- StepPanelSelector: Step 型に custom が入る別 ISSUE までの統合ポイントを JSDoc 付きで追加
- Vitest: SchemaForm 11 ケース、CustomStepPanel 3 ケースを追加

## 仕様逐条突合 (自己申告)

- A SchemaForm 新規作成: designer/src/components/common/SchemaForm.tsx:5 DynamicFormSchema を定義
- A SchemaForm props: designer/src/components/common/SchemaForm.tsx:16 schema / value / onChange / required / fieldName を定義
- A string 対応: designer/src/components/common/SchemaForm.tsx:60 input type=text を描画
- A number / integer 対応: designer/src/components/common/SchemaForm.tsx:75 input type=number と整数変換を実装
- A boolean 対応: designer/src/components/common/SchemaForm.tsx:94 checkbox を描画
- A enum 対応: designer/src/components/common/SchemaForm.tsx:40 select と options を描画
- A object + properties 対応: designer/src/components/common/SchemaForm.tsx:110 properties を再帰描画
- A array + items 対応: designer/src/components/common/SchemaForm.tsx:146 items を再帰描画し追加/削除を実装
- A required 対応: designer/src/components/common/SchemaForm.tsx:38 必須判定、designer/src/components/common/SchemaForm.tsx:203 必須マーク表示
- A description 対応: designer/src/components/common/SchemaForm.tsx:207 help text 表示
- A default 対応: designer/src/components/common/SchemaForm.tsx:31 mount 時適用、designer/src/components/common/SchemaForm.tsx:223 placeholder 反映
- B SchemaForm tests: designer/src/components/common/SchemaForm.test.tsx:8 から 11 ケースで各型、nested object、array、required、description、default、onChange を検証
- C CustomStepPanel props: designer/src/components/process-flow/CustomStepPanel.tsx:12 customStepType / value / onChange を定義
- C schema lookup: designer/src/components/process-flow/CustomStepPanel.tsx:25 mcpBridge.getExtensions と loadExtensionsFromBundle で再取得
- C loading / error / SchemaForm 表示: designer/src/components/process-flow/CustomStepPanel.tsx:64 loading、designer/src/components/process-flow/CustomStepPanel.tsx:68 error、designer/src/components/process-flow/CustomStepPanel.tsx:76 SchemaForm 表示
- C broadcast re-fetch: designer/src/components/process-flow/CustomStepPanel.tsx:54 onExtensionsChanged 購読、designer/src/components/process-flow/CustomStepPanel.tsx:56 force reload
- D CustomStepPanel tests: designer/src/components/process-flow/CustomStepPanel.test.tsx:40 から loading-to-render / not-found error / broadcast re-fetch を検証
- E StepPanelSelector stub: designer/src/components/process-flow/StepPanelSelector.tsx:3 props 定義、designer/src/components/process-flow/StepPanelSelector.tsx:8 JSDoc、designer/src/components/process-flow/StepPanelSelector.tsx:15 null return

## レビューで特に見てほしい箇所

- SchemaForm の default 適用タイミングと、object child の onChange が親 object を組み立てる挙動
- CustomStepPanel が RawExtensionsBundle を直接読まず、loadExtensionsFromBundle の namespaced key 解決に寄せている点
- StepPanelSelector を StepCard に接続していないことが本 ISSUE のスコープと一致しているか

## テスト

- Vitest: 14 件 (新規 14 件) — SchemaForm 11 件、CustomStepPanel 3 件
- Playwright: N/A — custom step 配置 UI / StepCard 統合が別 ISSUE のため
- MCP E2E: N/A — 本 PR は mcpBridge の既存 getExtensions/onExtensionsChanged を mock した単体検証のみ

実行コマンド:
- cd designer && npm run build
- cd designer && npx vitest run src/components/common/SchemaForm.test.tsx src/components/process-flow/CustomStepPanel.test.tsx
- cd designer && npx eslint src/components/common/SchemaForm.tsx src/components/common/SchemaForm.test.tsx src/components/process-flow/CustomStepPanel.tsx src/components/process-flow/CustomStepPanel.test.tsx src/components/process-flow/StepPanelSelector.tsx

## UI 影響 / AI smoke test

- [ ] UI 影響あり (AI が chrome-devtools MCP / Playwright で smoke test 実施済み)
- [x] UI 影響なし (auto テスト pass のみ)

### UI 影響ありの場合、AI smoke test で確認した項目

N/A — 新規コンポーネント単体のみで、StepCard への組み込みや配置 UI は未実装です。

## spec 側の不足点 / 提案

N/A — 本 PR では docs/spec/plugin-system.md は変更せず、ISSUE #446 と Opus 設計コメントのスコープに限定しています。

## レビュー担当への申し送り

## 既知の制限

- 本 PR では SchemaForm + CustomStepPanel + StepPanelSelector の 3 コンポーネントを単独で構築しています。
- StepCard.tsx への組み込み、ProcessFlow JSON Schema への custom step 種別追加、designer/src/types/action.ts への custom Step 型追加は別 ISSUE に委ねます。
- E2E (Playwright) は未実施です。custom step 配置 UI が未整備のため、単体テストで検証しています。

## メモ

- main には既存の ESLint エラーが 34 件あります。本 PR 追加分は、5 新規ファイルを対象にした npx eslint で exit 0 を確認済みです。
- npm install 実行時に npm audit の moderate vulnerability 3 件が報告されましたが、依存更新は本 ISSUE のスコープ外です。

## スコープ外 / 触っていないファイル

- schemas/process-flow.schema.json は未変更
- designer/src/types/action.ts は未変更
- designer/src/components/process-flow/StepCard.tsx は未変更
- designer/eslint.config.js は未変更
- docs/spec/plugin-system.md は未変更