### PR TITLE
feat(extensions): GM50 想定の FieldType サンプル拡張定義 (#390)

### DIFF
--- a/designer/src/schemas/extensions-samples.test.ts
+++ b/designer/src/schemas/extensions-samples.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import Ajv2020 from "ajv/dist/2020";
+import { describe, it, expect, beforeAll } from "vitest";
+import Ajv2020, { type ValidateFunction } from "ajv/dist/2020";
 import addFormats from "ajv-formats";
 import { readFileSync, readdirSync } from "node:fs";
 import { resolve, join, basename } from "node:path";
@@ -11,10 +11,9 @@ const schemasDir = resolve(repoRoot, "schemas");
 /**
  * ファイル名 → スキーマ種別の対応
  * field-types.json → extensions-field-types.schema.json
+ * ※ .json 以外は呼び出し元でフィルタ済みのため常に string を返す
  */
-function schemaPathForSample(fileName: string): string | null {
-  // README.md など JSON 以外は除外
-  if (!fileName.endsWith(".json")) return null;
+function schemaPathForSample(fileName: string): string {
   const kind = basename(fileName, ".json"); // e.g. "field-types"
   return join(schemasDir, `extensions-${kind}.schema.json`);
 }
@@ -24,8 +23,15 @@ const sampleFiles = readdirSync(samplesDir)
   .map((f) => ({
     file: f,
     samplePath: join(samplesDir, f),
-    schemaPath: schemaPathForSample(f)!,
+    schemaPath: schemaPathForSample(f),
   }));
+
+let ajv: Ajv2020;
+
+beforeAll(() => {
+  ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+});
 
 describe("docs/sample-project/extensions — スキーマバリデーション", () => {
   it("検証対象のサンプルファイルが 1 件以上存在する", () => {
@@ -36,9 +42,7 @@ describe("docs/sample-project/extensions — スキーマバリデーション",
     const sample = JSON.parse(readFileSync(samplePath, "utf-8")) as unknown;
     const schema = JSON.parse(readFileSync(schemaPath, "utf-8")) as object;
 
-    const ajv = new Ajv2020({ allErrors: true, strict: false });
-    addFormats(ajv);
-    const validate = ajv.compile(schema);
+    const validate: ValidateFunction = ajv.compile(schema);
     const ok = validate(sample);
 
     if (!ok) {

--- a/designer/src/schemas/extensions-samples.test.ts
+++ b/designer/src/schemas/extensions-samples.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import Ajv2020 from "ajv/dist/2020";
+import addFormats from "ajv-formats";
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve, join, basename } from "node:path";
+
+const repoRoot = resolve(__dirname, "../../../");
+const samplesDir = resolve(repoRoot, "docs/sample-project/extensions");
+const schemasDir = resolve(repoRoot, "schemas");
+
+/**
+ * ファイル名 → スキーマ種別の対応
+ * field-types.json → extensions-field-types.schema.json
+ */
+function schemaPathForSample(fileName: string): string | null {
+  // README.md など JSON 以外は除外
+  if (!fileName.endsWith(".json")) return null;
+  const kind = basename(fileName, ".json"); // e.g. "field-types"
+  return join(schemasDir, `extensions-${kind}.schema.json`);
+}
+
+const sampleFiles = readdirSync(samplesDir)
+  .filter((f) => f.endsWith(".json"))
+  .map((f) => ({
+    file: f,
+    samplePath: join(samplesDir, f),
+    schemaPath: schemaPathForSample(f)!,
+  }));
+
+describe("docs/sample-project/extensions — スキーマバリデーション", () => {
+  it("検証対象のサンプルファイルが 1 件以上存在する", () => {
+    expect(sampleFiles.length).toBeGreaterThan(0);
+  });
+
+  it.each(sampleFiles)("$file が対応スキーマで valid", ({ file, samplePath, schemaPath }) => {
+    const sample = JSON.parse(readFileSync(samplePath, "utf-8")) as unknown;
+    const schema = JSON.parse(readFileSync(schemaPath, "utf-8")) as object;
+
+    const ajv = new Ajv2020({ allErrors: true, strict: false });
+    addFormats(ajv);
+    const validate = ajv.compile(schema);
+    const ok = validate(sample);
+
+    if (!ok) {
+      throw new Error(
+        `${file} failed schema validation:\n${JSON.stringify(validate.errors, null, 2)}`
+      );
+    }
+    expect(ok).toBe(true);
+  });
+});

--- a/docs/sample-project/extensions/README.md
+++ b/docs/sample-project/extensions/README.md
@@ -2,4 +2,23 @@
 
 プラグイン拡張定義のサンプル、テンプレートを置くディレクトリです。
 
-実行時にバリデーターが読む場所は `data/extensions/` です。このディレクトリには、仕様確認用や業界別テンプレート用のサンプルを配置します。GM50 用の具体的な拡張定義は後続 ISSUE で追加します。
+実行時にバリデーターが読む場所は `data/extensions/` です。このディレクトリには、仕様確認用や業界別テンプレート用のサンプルを配置します。
+
+## ファイル一覧
+
+| ファイル | 内容 |
+|---|---|
+| `response-types.json` | レスポンス型サンプル (汎用) |
+| `field-types.json` | GM50 想定の FieldType 拡張サンプル |
+
+## field-types.json について
+
+GM50 顧客向けプラグインを想定したサンプル拡張定義です。`csv` / `tsv` / `zip` / `view` の 4 種類を定義しています。
+
+顧客先での適用は、以下のように手動コピーしてください (本リポジトリでは実適用しません):
+
+```bash
+cp docs/sample-project/extensions/field-types.json data/extensions/
+```
+
+なお、`data/actions/gm50-*.json` 内の `"TBL"` 値をグローバルの `{kind: "tableRow"}` に正規化する作業は、リポジトリ外の作業です (顧客先の実 JSON を直接修正してください)。

--- a/docs/sample-project/extensions/field-types.json
+++ b/docs/sample-project/extensions/field-types.json
@@ -1,0 +1,9 @@
+{
+  "namespace": "gm50",
+  "fieldTypes": [
+    { "kind": "csv", "label": "CSV ファイル" },
+    { "kind": "tsv", "label": "TSV ファイル" },
+    { "kind": "zip", "label": "ZIP ファイル" },
+    { "kind": "view", "label": "DB ビュー" }
+  ]
+}


### PR DESCRIPTION
## 関連

- Closes #390
- 仕様: docs/spec/plugin-system.md §3 (拡張定義ファイルフォーマット)

## 概要

プラグインシステム (#444) 完成を受け、GM50 顧客向けプラグインを想定したサンプル FieldType 拡張定義 (`field-types.json`) を `docs/sample-project/extensions/` に追加する。  
サンプル拡張ファイルがスキーマで valid であることを保証するテストも併せて追加する。

## 主な変更

- `docs/sample-project/extensions/field-types.json` 新規: GM50 顧客向けの FieldType 拡張サンプル (`csv` / `tsv` / `zip` / `view`)
- `docs/sample-project/extensions/README.md` 更新: 「後続 ISSUE で追加」文言を実際の内容説明に書き換え、適用手順・スコープ外事項を追記
- `designer/src/schemas/extensions-samples.test.ts` 新規: `docs/sample-project/extensions/*.json` の全ファイルを対応 `extensions-*.schema.json` で AJV 検証する vitest テスト

## スコープ外

- `data/actions/gm50-*.json` の `"TBL"` → `{kind: "tableRow"}` 正規化: GM50 実ファイルはリポジトリ外 (顧客先にのみ存在) のため本 PR の対象外。顧客先での実 JSON 修正は別作業
- `docs/sample-project/extensions/{steps,triggers,db-operations}.json`: 本 ISSUE は FieldType 由来分のみ

## 仕様逐条突合 (自己申告)

- `schemas/extensions-field-types.schema.json` が要求する `namespace` + `fieldTypes[].kind` + `fieldTypes[].label` の 3 フィールド構造 → `docs/sample-project/extensions/field-types.json:1-9` ✓
- namespace パターン `^[a-z0-9_-]*$` に合致する値 `"gm50"` を使用 → `docs/sample-project/extensions/field-types.json:2` ✓
- 4 種別 (`csv`/`tsv`/`zip`/`view`) が GM50 固有として確定済み (#390 2026-04-26 設計コメント) → `docs/sample-project/extensions/field-types.json:3-8` ✓
- サンプルファイル全件の AJV 検証テスト追加 → `designer/src/schemas/extensions-samples.test.ts:1-55` ✓
- README の「後続 ISSUE で追加」文言を実際の内容説明に更新 → `docs/sample-project/extensions/README.md:5-24` ✓

## レビューで特に見てほしい箇所

- `extensions-samples.test.ts` のファイル名 → スキーマ種別のマッピング手法 (ファイル名ベース推定): 新規サンプルファイルが増えた際に自動検出されるため追加コスト不要。ただしファイル名が `extensions-{kind}.schema.json` のパターンに合致しない場合は要手動対応

## テスト

- Vitest: 3 件 (新規 3 件) — extensions-samples.test.ts (AJV スキーマ検証)
- Playwright: N/A
- MCP E2E: N/A

## 検証実施

```
cd C:/tmp/wt-390/designer && npx vitest run src/schemas/extensions-samples.test.ts
→ Test Files 1 passed (1) / Tests 3 passed (3) ✓

cd C:/tmp/wt-390/designer && npm run build
→ ✓ built in 2.85s ✓

cd C:/tmp/wt-390/designer && npm run lint
→ 新規追加ファイルにエラーなし。既存 45 problems は本 PR 前から存在するもので変化なし ✓
```

## UI 影響 / AI smoke test

- [x] UI 影響なし (auto テスト pass のみ)

### UI 影響ありの場合、AI smoke test で確認した項目

N/A (ドキュメント + テスト追加のみ。実行時動作に影響なし)

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

- 本 PR は純粋に「サンプル JSON ファイル + 検証テスト」追加のみ。UI・ローダー・型定義への影響はない
- `loadExtensions.ts` は `data/extensions/` のみ読むため、`docs/sample-project/extensions/` の追加は実行時動作に影響しない
- lint エラーは既存コードのものであり本 PR 変更とは無関係 (stash 前後で件数同一: 45 problems)
