### PR TITLE
improve(dogfood): 金融シナリオ #2 — ポジション計算/リスクチェック (#463)

### DIFF
--- a/docs/sample-project/extensions/securities/field-types.json
+++ b/docs/sample-project/extensions/securities/field-types.json
@@ -4,6 +4,8 @@
     { "kind": "orderId", "label": "注文 ID" },
     { "kind": "accountId", "label": "口座 ID" },
     { "kind": "tradeId", "label": "約定 ID" },
-    { "kind": "securityCode", "label": "銘柄コード" }
+    { "kind": "securityCode", "label": "銘柄コード" },
+    { "kind": "position", "label": "ポジション (BUY/SELL/数量)" },
+    { "kind": "pnl", "label": "損益" }
   ]
 }

--- a/docs/sample-project/extensions/securities/steps.json
+++ b/docs/sample-project/extensions/securities/steps.json
@@ -4,7 +4,7 @@
     "TradeMatchStep": {
       "label": "約定照合",
       "icon": "git-compare",
-      "description": "取引所から受信した約定 ID と注文 ID を照合し、約定数量・約定価格を処理します。",
+      "description": "取引所から受信した約定 ID と注文 ID を照合し、約定数量と約定価格を処理します。",
       "schema": {
         "type": "object",
         "properties": {
@@ -15,6 +15,23 @@
         },
         "required": ["tradeId", "orderId", "executedQty"],
         "additionalProperties": false
+      }
+    },
+    "PositionUpdateStep": {
+      "label": "ポジション更新",
+      "icon": "TrendingUp",
+      "description": "口座 × 銘柄単位でポジションを再計算 (UPSERT)",
+      "schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["accountId", "securityCode", "executedQty", "side"],
+        "properties": {
+          "accountId": { "type": "string" },
+          "securityCode": { "type": "string" },
+          "executedQty": { "type": "number" },
+          "executedPrice": { "type": "number" },
+          "side": { "type": "string", "enum": ["BUY", "SELL"] }
+        }
       }
     }
   }

--- a/docs/sample-project/process-flows/dddddddd-0002-4000-8000-dddddddddddd.json
+++ b/docs/sample-project/process-flows/dddddddd-0002-4000-8000-dddddddddddd.json
@@ -1,0 +1,789 @@
+{
+  "id": "dddddddd-0002-4000-8000-dddddddddddd",
+  "name": "ポジション計算/リスクチェック (証券)",
+  "type": "system",
+  "description": "証券約定後のポジション再計算、損益算出、CircuitBreaker 判定、および取引前リスクチェックを扱う金融ドッグフード用サンプル。",
+  "apiVersion": "v2",
+  "mode": "downstream",
+  "maturity": "committed",
+  "eventsCatalog": {
+    "position.updated": {
+      "description": "口座 × 銘柄単位のポジション更新が完了した時点で発行されるイベント。",
+      "payload": {
+        "type": "object",
+        "required": ["positionId", "accountId", "securityCode", "quantity", "pnl"],
+        "properties": {
+          "positionId": { "type": "string" },
+          "accountId": { "type": "string" },
+          "securityCode": { "type": "string" },
+          "quantity": { "type": "number" },
+          "pnl": { "type": "number" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "risk.threshold.breached": {
+      "description": "与信使用率、VaR、または集中リスクの閾値を超過した時点で発行されるイベント。",
+      "payload": {
+        "type": "object",
+        "required": ["riskCheckId", "accountId", "threshold", "actual"],
+        "properties": {
+          "riskCheckId": { "type": "string" },
+          "accountId": { "type": "string" },
+          "threshold": { "type": "number" },
+          "actual": { "type": "number" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "circuit.broken": {
+      "description": "短時間損失閾値により CircuitBreaker が発動した時点で発行されるイベント。",
+      "payload": {
+        "type": "object",
+        "required": ["accountId", "recentLoss", "windowMinutes"],
+        "properties": {
+          "accountId": { "type": "string" },
+          "recentLoss": { "type": "number" },
+          "windowMinutes": { "type": "number" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "risk.check.completed": {
+      "description": "取引前リスクチェックが ALLOW / WATCH / BLOCK の判定を返した時点で発行されるイベント。",
+      "payload": {
+        "type": "object",
+        "required": ["riskCheckId", "accountId", "verdict"],
+        "properties": {
+          "riskCheckId": { "type": "string" },
+          "accountId": { "type": "string" },
+          "verdict": { "type": "string", "enum": ["ALLOW", "WATCH", "BLOCK"] }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "glossary": {
+    "ポジション": {
+      "definition": "口座が保有する銘柄別の建玉。売買区分、数量、平均取得単価、評価損益を含む。",
+      "aliases": ["Position", "建玉"],
+      "domainRef": "Position"
+    },
+    "VaR": {
+      "definition": "一定信頼水準で想定される最大損失額。日次バッチはヒストリカル法、リアルタイム判定は parametric VaR を用いる。",
+      "aliases": ["Value at Risk"],
+      "domainRef": "VaR"
+    },
+    "与信使用率": {
+      "definition": "現在エクスポージャと推定 VaR の合計を与信限度額で除した比率。",
+      "aliases": ["Credit usage ratio"],
+      "domainRef": "credit_limits.usage_ratio"
+    },
+    "集中リスク": {
+      "definition": "特定銘柄、セクター、または市場にポジションが偏ることで損失が拡大するリスク。",
+      "aliases": ["Concentration risk"],
+      "domainRef": "risk_limits.concentration"
+    },
+    "循環ブレーカー": {
+      "definition": "5分間累積損失が閾値を超過した場合に新規ポジション更新や注文許可を一時停止する制御。",
+      "aliases": ["CircuitBreaker", "サーキットブレーカー"],
+      "domainRef": "risk_controls.circuit_breaker"
+    },
+    "SLA": {
+      "definition": "リスクチェックが業務上許容される応答時間内に完了することを保証するサービスレベル。",
+      "aliases": ["Service Level Agreement"],
+      "domainRef": "risk_sla"
+    },
+    "マージン": {
+      "definition": "ポジション保有や注文執行に必要な証拠金。リスクチェックでは利用可能額と比較する。",
+      "aliases": ["証拠金", "Margin"],
+      "domainRef": "margin_accounts"
+    }
+  },
+  "decisions": [
+    {
+      "id": "ADR-001",
+      "title": "ポジション計算は trades 確定時の連鎖起動",
+      "status": "accepted",
+      "context": "注文受付時点では約定数量と約定価格が確定しておらず、ポジションや平均取得単価を正しく更新できない。",
+      "decision": "tradeId が確定して trades に登録された通知を起点に、内部 API /internal/risk/position-update を連鎖起動する。",
+      "consequences": "約定訂正や再送に備えて accountId × securityCode の UPSERT と tradeId 冪等性を実装側で担保する。",
+      "date": "2026-04-26"
+    },
+    {
+      "id": "ADR-002",
+      "title": "VaR はヒストリカル法250営業日、リアルタイムはparametric VaR",
+      "status": "accepted",
+      "context": "日次リスク集計では過去実績に基づく精度を優先できるが、取引前判定では低遅延応答が必要になる。",
+      "decision": "日次 VaR は250営業日のヒストリカル法で算出し、取引前チェックのリアルタイム推定は parametric VaR で近似する。",
+      "consequences": "リアルタイム判定は保守的な係数を使い、日次バッチとの差分は risk_check_log で検証する。",
+      "date": "2026-04-26"
+    },
+    {
+      "id": "ADR-003",
+      "title": "CircuitBreaker は5分間損失閾値超過で発動",
+      "status": "accepted",
+      "context": "短時間の急激な損失拡大は通常の与信チェックだけでは抑止が遅れる可能性がある。",
+      "decision": "口座別の直近5分累積損失が閾値を超えた場合、CircuitBreaker を発動して 503 CIRCUIT_BROKEN を返す。",
+      "consequences": "復旧は運用ポリシーまたはリスク管理者の解除に委ね、発動時は audit と circuit.broken イベントを残す。",
+      "date": "2026-04-26"
+    }
+  ],
+  "ambientVariables": [
+    {
+      "name": "requestId",
+      "type": "string",
+      "required": true,
+      "description": "リクエスト追跡 ID。API、イベント、監査ログを横断して相関させる。"
+    },
+    {
+      "name": "marketDate",
+      "type": "string",
+      "required": true,
+      "description": "市場営業日。ポジション評価とリスクチェックの評価基準日。"
+    },
+    {
+      "name": "riskCheckId",
+      "type": "string",
+      "required": false,
+      "description": "取引前リスクチェック単位の識別子。未指定時はミドルウェアで採番する。"
+    }
+  ],
+  "errorCatalog": {
+    "VALIDATION": {
+      "httpStatus": 400,
+      "defaultMessage": "入力値が不正です",
+      "responseRef": "400-validation"
+    },
+    "POSITION_NOT_FOUND": {
+      "httpStatus": 404,
+      "defaultMessage": "ポジションが見つかりません",
+      "responseRef": "404-position-not-found"
+    },
+    "RISK_THRESHOLD_BREACHED": {
+      "httpStatus": 422,
+      "defaultMessage": "リスク閾値を超過しています",
+      "responseRef": "422-risk-threshold-breached"
+    },
+    "CIRCUIT_BROKEN": {
+      "httpStatus": 503,
+      "defaultMessage": "CircuitBreaker が発動中です",
+      "responseRef": "503-circuit-broken"
+    },
+    "SLA_EXCEEDED": {
+      "httpStatus": 504,
+      "defaultMessage": "リスクチェックの SLA を超過しました",
+      "responseRef": "504-sla-exceeded"
+    }
+  },
+  "externalSystemCatalog": {
+    "marketDataService": {
+      "name": "Market Data Service",
+      "baseUrl": "https://market-data.example.internal",
+      "auth": { "kind": "bearer", "tokenRef": "@secret.marketDataApiToken" },
+      "timeoutMs": 1000,
+      "description": "現在値、終値、ボラティリティ、250営業日ヒストリカル価格を提供する市場データサービス。"
+    },
+    "riskEngine": {
+      "name": "Risk Engine",
+      "baseUrl": "https://risk-engine.example.internal",
+      "auth": { "kind": "bearer", "tokenRef": "@secret.riskEngineApiToken" },
+      "timeoutMs": 2000,
+      "description": "VaR、集中リスク、与信使用率、CircuitBreaker 状態を計算・保持するリスクエンジン。"
+    }
+  },
+  "secretsCatalog": {
+    "marketDataApiToken": {
+      "source": "env",
+      "name": "MARKET_DATA_API_TOKEN",
+      "rotationDays": 90,
+      "description": "marketDataService 接続用 API token"
+    },
+    "riskEngineApiToken": {
+      "source": "env",
+      "name": "RISK_ENGINE_API_TOKEN",
+      "rotationDays": 90,
+      "description": "riskEngine 接続用 API token"
+    }
+  },
+  "domainsCatalog": {
+    "PositionId": {
+      "type": "string",
+      "uiHint": "text",
+      "description": "ポジション ID。accountId × securityCode の論理一意キーから導出する。"
+    },
+    "Position": {
+      "type": { "kind": "position" },
+      "description": "口座 × 銘柄単位の保有数量、平均取得単価、時価、損益を表す。"
+    },
+    "Pnl": {
+      "type": { "kind": "pnl" },
+      "description": "評価損益または実現損益。"
+    },
+    "VaR": {
+      "type": "number",
+      "uiHint": "number",
+      "description": "Value at Risk。通貨単位の推定最大損失額。"
+    },
+    "Quantity": {
+      "type": "number",
+      "uiHint": "number",
+      "constraints": [
+        { "field": "quantity", "type": "range", "min": 1, "message": "数量は 1 以上で入力してください" }
+      ],
+      "description": "注文数量または約定数量。"
+    },
+    "Price": {
+      "type": "number",
+      "uiHint": "number",
+      "constraints": [
+        { "field": "price", "type": "range", "min": 0, "message": "価格は 0 以上で入力してください" }
+      ],
+      "description": "注文価格、約定価格、または現在値。"
+    },
+    "AccountId": {
+      "type": "string",
+      "uiHint": "text",
+      "description": "証券口座 ID。"
+    }
+  },
+  "functionsCatalog": {
+    "calcPnl": {
+      "signature": "calcPnl(position: Position, currentPrice: number): number",
+      "returnType": "number",
+      "description": "ポジションの平均取得単価と現在値から評価損益を算出する。",
+      "examples": ["@fn.calcPnl(@position, @currentPrice)"]
+    },
+    "calcVaR": {
+      "signature": "calcVaR(positions: Position[], confidence: number): number",
+      "returnType": "number",
+      "description": "ポジション集合と信頼水準から VaR を算出する。",
+      "examples": ["@fn.calcVaR(@projectedPositions, 0.99)"]
+    },
+    "checkCircuitBreaker": {
+      "signature": "checkCircuitBreaker(account: Account, lossThreshold: number): boolean",
+      "returnType": "boolean",
+      "description": "口座別の損失閾値に対して CircuitBreaker 発動要否を判定する。",
+      "examples": ["@fn.checkCircuitBreaker(@account, @recentLoss)"]
+    }
+  },
+  "actions": [
+    {
+      "id": "act-001",
+      "name": "約定通知連鎖ポジション更新",
+      "trigger": "other",
+      "description": "約定確定通知を起点に口座 × 銘柄単位のポジションを更新し、PnL と CircuitBreaker を判定する。",
+      "maturity": "committed",
+      "httpRoute": {
+        "method": "POST",
+        "path": "/internal/risk/position-update",
+        "auth": "required"
+      },
+      "inputs": [
+        { "name": "orderId", "label": "注文 ID", "type": "string", "required": true },
+        { "name": "tradeId", "label": "約定 ID", "type": "string", "required": true },
+        { "name": "accountId", "label": "口座 ID", "type": "string", "required": true, "domainRef": "AccountId" },
+        { "name": "securityCode", "label": "銘柄コード", "type": "string", "required": true },
+        { "name": "executedQty", "label": "約定数量", "type": "number", "required": true, "domainRef": "Quantity" },
+        { "name": "executedPrice", "label": "約定価格", "type": "number", "required": true, "domainRef": "Price" },
+        { "name": "side", "label": "売買区分", "type": "string", "required": true }
+      ],
+      "outputs": [
+        { "name": "positionId", "label": "ポジション ID", "type": "string", "domainRef": "PositionId" },
+        { "name": "status", "label": "ステータス", "type": "string" }
+      ],
+      "responses": [
+        {
+          "id": "200-ok",
+          "status": 200,
+          "bodySchema": {
+            "schema": {
+              "type": "object",
+              "required": ["positionId", "status"],
+              "properties": {
+                "positionId": { "type": "string" },
+                "status": { "type": "string", "enum": ["UPDATED", "CIRCUIT_BROKEN"] }
+              },
+              "additionalProperties": false
+            }
+          },
+          "when": "ポジション更新とリスク判定が完了した場合"
+        },
+        {
+          "id": "422-risk-threshold-breached",
+          "status": 422,
+          "bodySchema": { "typeRef": "ApiError" },
+          "when": "リスク閾値超過を検出した場合"
+        },
+        {
+          "id": "503-circuit-broken",
+          "status": 503,
+          "bodySchema": { "typeRef": "ApiError" },
+          "when": "CircuitBreaker が発動した場合"
+        }
+      ],
+      "steps": [
+        {
+          "id": "step-001",
+          "type": "validation",
+          "description": "orderId/tradeId/accountId/securityCode/executedQty/executedPrice/side を検証する。",
+          "maturity": "committed",
+          "conditions": "必須項目、executedQty > 0、executedPrice >= 0、side は BUY/SELL。",
+          "rules": [
+            { "field": "orderId", "type": "required", "message": "注文 ID は必須です" },
+            { "field": "tradeId", "type": "required", "message": "約定 ID は必須です" },
+            { "field": "accountId", "type": "required", "message": "口座 ID は必須です" },
+            { "field": "securityCode", "type": "required", "message": "銘柄コードは必須です" },
+            { "field": "executedQty", "type": "range", "min": 1, "message": "約定数量は 1 以上です" },
+            { "field": "executedPrice", "type": "range", "min": 0, "message": "約定価格は 0 以上です" },
+            { "field": "side", "type": "enum", "values": ["BUY", "SELL"], "message": "売買区分は BUY/SELL です" }
+          ]
+        },
+        {
+          "id": "step-002",
+          "type": "transactionScope",
+          "description": "ポジション UPSERT と平均取得単価更新を同一トランザクションで実行する。",
+          "maturity": "committed",
+          "isolationLevel": "READ_COMMITTED",
+          "propagation": "REQUIRED",
+          "rollbackOn": ["VALIDATION", "SLA_EXCEEDED"],
+          "steps": [
+            {
+              "id": "step-002-01",
+              "type": "other",
+              "description": "PositionUpdateStep: positions を accountId × securityCode の一意キーで UPSERT する。inputs の値だけを参照する。",
+              "maturity": "committed",
+              "note": "extensionStep=securities:PositionUpdateStep; accountId=@inputs.accountId; securityCode=@inputs.securityCode; executedQty=@inputs.executedQty; executedPrice=@inputs.executedPrice; side=@inputs.side",
+              "outputBinding": "position"
+            },
+            {
+              "id": "step-002-02",
+              "type": "dbAccess",
+              "description": "約定数量と約定価格から保有数量、平均取得単価、positionId を更新する。inputs と同一 TX 内の @position のみ参照する。",
+              "maturity": "committed",
+              "tableName": "positions",
+              "operation": "UPDATE",
+              "sql": "UPDATE positions SET quantity = CASE WHEN @inputs.side = 'BUY' THEN quantity + @inputs.executedQty ELSE quantity - @inputs.executedQty END, average_cost = CASE WHEN @inputs.side = 'BUY' THEN ((quantity * average_cost) + (@inputs.executedQty * @inputs.executedPrice)) / NULLIF(quantity + @inputs.executedQty, 0) ELSE average_cost END, updated_at = NOW() WHERE id = @position.position_id RETURNING id AS position_id, quantity, average_cost",
+              "outputBinding": "position",
+              "lineage": { "writes": ["positions"] }
+            }
+          ]
+        },
+        {
+          "id": "step-003",
+          "type": "externalSystem",
+          "description": "marketDataService から現在値を取得する。",
+          "maturity": "committed",
+          "systemName": "Market Data Service",
+          "systemRef": "marketDataService",
+          "httpCall": {
+            "method": "GET",
+            "path": "/prices/@inputs.securityCode/current"
+          },
+          "outputBinding": "currentPrice"
+        },
+        {
+          "id": "step-004",
+          "type": "compute",
+          "description": "更新済みポジションと現在値から評価損益を計算する。",
+          "maturity": "committed",
+          "expression": "@fn.calcPnl(@position, @currentPrice)",
+          "outputBinding": "pnl"
+        },
+        {
+          "id": "step-005",
+          "type": "dbAccess",
+          "description": "直近5分間の累積損失を取得する。",
+          "maturity": "committed",
+          "tableName": "pnl_snapshots",
+          "operation": "SELECT",
+          "sql": "SELECT COALESCE(SUM(loss_amount), 0) AS recent_loss FROM pnl_snapshots WHERE account_id = @inputs.accountId AND created_at >= NOW() - INTERVAL '5 minutes'",
+          "outputBinding": "recentLoss",
+          "lineage": { "reads": ["pnl_snapshots"] }
+        },
+        {
+          "id": "step-006",
+          "type": "dbAccess",
+          "description": "CircuitBreaker 判定用に口座リスク設定を取得する。",
+          "maturity": "committed",
+          "tableName": "accounts",
+          "operation": "SELECT",
+          "sql": "SELECT id, loss_threshold, circuit_breaker_enabled FROM accounts WHERE id = @inputs.accountId",
+          "outputBinding": "account",
+          "lineage": { "reads": ["accounts"] }
+        },
+        {
+          "id": "step-007",
+          "type": "compute",
+          "description": "CircuitBreaker 発動要否を判定する。",
+          "maturity": "committed",
+          "expression": "@fn.checkCircuitBreaker(@account, @recentLoss)",
+          "outputBinding": "circuitBroken"
+        },
+        {
+          "id": "step-008",
+          "type": "branch",
+          "description": "CircuitBreaker が発動した場合は監査ログと 503 応答を返す。",
+          "maturity": "committed",
+          "branches": [
+            {
+              "id": "br-007-a",
+              "code": "A",
+              "label": "CircuitBreaker 発動",
+              "condition": "@circuitBroken == true",
+              "steps": [
+                {
+                  "id": "step-008-a-01",
+                  "type": "audit",
+                  "description": "CircuitBreaker 発動を監査ログに記録する。",
+                  "maturity": "committed",
+                  "action": "risk.circuit_breaker",
+                  "resource": { "type": "Account", "id": "@inputs.accountId" },
+                  "result": "failure",
+                  "reason": "recentLoss threshold breached"
+                },
+                {
+                  "id": "step-008-a-02",
+                  "type": "eventPublish",
+                  "description": "circuit.broken イベントを発行する。",
+                  "maturity": "committed",
+                  "topic": "circuit.broken",
+                  "eventRef": "circuit.broken",
+                  "payload": "{ accountId: @inputs.accountId, recentLoss: @recentLoss, windowMinutes: 5 }"
+                },
+                {
+                  "id": "step-008-a-03",
+                  "type": "return",
+                  "description": "503 CIRCUIT_BROKEN を返す。",
+                  "maturity": "committed",
+                  "responseRef": "503-circuit-broken",
+                  "bodyExpression": "{ code: 'CIRCUIT_BROKEN', message: 'CircuitBreaker が発動中です', positionId: @position.position_id, status: 'CIRCUIT_BROKEN' }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-007-else",
+            "code": "B",
+            "label": "通常継続",
+            "steps": []
+          }
+        },
+        {
+          "id": "step-009",
+          "type": "eventPublish",
+          "description": "position.updated イベントを発行する。",
+          "maturity": "committed",
+          "topic": "position.updated",
+          "eventRef": "position.updated",
+          "payload": "{ positionId: @position.position_id, accountId: @inputs.accountId, securityCode: @inputs.securityCode, quantity: @position.quantity, pnl: @pnl }"
+        },
+        {
+          "id": "step-010",
+          "type": "return",
+          "description": "200 OK を返す。",
+          "maturity": "committed",
+          "responseRef": "200-ok",
+          "bodyExpression": "{ positionId: @position.position_id, status: 'UPDATED' }"
+        }
+      ]
+    },
+    {
+      "id": "act-002",
+      "name": "取引前リスクチェック",
+      "trigger": "submit",
+      "description": "注文前に予定ポジション、VaR、与信使用率を評価し ALLOW / WATCH / BLOCK を返す。",
+      "maturity": "committed",
+      "httpRoute": {
+        "method": "POST",
+        "path": "/api/risk/pre-trade-check",
+        "auth": "required"
+      },
+      "inputs": [
+        { "name": "accountId", "label": "口座 ID", "type": "string", "required": true, "domainRef": "AccountId" },
+        { "name": "securityCode", "label": "銘柄コード", "type": "string", "required": true },
+        { "name": "side", "label": "売買区分", "type": "string", "required": true },
+        { "name": "quantity", "label": "数量", "type": "number", "required": true, "domainRef": "Quantity" },
+        { "name": "price", "label": "価格", "type": "number", "required": true, "domainRef": "Price" }
+      ],
+      "outputs": [
+        { "name": "riskCheckId", "label": "リスクチェック ID", "type": "string" },
+        { "name": "verdict", "label": "判定", "type": "string" },
+        { "name": "message", "label": "メッセージ", "type": "string" }
+      ],
+      "responses": [
+        {
+          "id": "200-ok",
+          "status": 200,
+          "bodySchema": {
+            "schema": {
+              "type": "object",
+              "required": ["riskCheckId", "verdict", "message"],
+              "properties": {
+                "riskCheckId": { "type": "string" },
+                "verdict": { "type": "string", "enum": ["ALLOW", "WATCH", "BLOCK"] },
+                "message": { "type": "string" }
+              },
+              "additionalProperties": false
+            }
+          },
+          "when": "ALLOW または WATCH 判定の場合"
+        },
+        {
+          "id": "422-risk-threshold-breached",
+          "status": 422,
+          "bodySchema": { "typeRef": "ApiError" },
+          "when": "BLOCK 判定の場合"
+        }
+      ],
+      "steps": [
+        {
+          "id": "step-101",
+          "type": "validation",
+          "description": "accountId/securityCode/side/quantity/price を検証する。",
+          "maturity": "committed",
+          "conditions": "必須項目、quantity > 0、price >= 0、side は BUY/SELL。",
+          "rules": [
+            { "field": "accountId", "type": "required", "message": "口座 ID は必須です" },
+            { "field": "securityCode", "type": "required", "message": "銘柄コードは必須です" },
+            { "field": "side", "type": "enum", "values": ["BUY", "SELL"], "message": "売買区分は BUY/SELL です" },
+            { "field": "quantity", "type": "range", "min": 1, "message": "数量は 1 以上です" },
+            { "field": "price", "type": "range", "min": 0, "message": "価格は 0 以上です" }
+          ]
+        },
+        {
+          "id": "step-102",
+          "type": "dbAccess",
+          "description": "現在ポジションを取得する。",
+          "maturity": "committed",
+          "tableName": "positions",
+          "operation": "SELECT",
+          "sql": "SELECT * FROM positions WHERE account_id = @inputs.accountId AND security_code = @inputs.securityCode",
+          "outputBinding": "currentPosition",
+          "lineage": { "reads": ["positions"] }
+        },
+        {
+          "id": "step-103",
+          "type": "compute",
+          "description": "予定注文を反映した projected VaR を計算する。",
+          "maturity": "committed",
+          "expression": "@fn.calcVaR([@currentPosition, { accountId: @inputs.accountId, securityCode: @inputs.securityCode, side: @inputs.side, quantity: @inputs.quantity, price: @inputs.price }], 0.99)",
+          "outputBinding": "var"
+        },
+        {
+          "id": "step-104",
+          "type": "dbAccess",
+          "description": "与信限度額と現在エクスポージャを取得する。",
+          "maturity": "committed",
+          "tableName": "credit_limits",
+          "operation": "SELECT",
+          "sql": "SELECT credit_limit, current_exposure FROM credit_limits WHERE account_id = @inputs.accountId",
+          "outputBinding": "credit",
+          "lineage": { "reads": ["credit_limits"] }
+        },
+        {
+          "id": "step-105",
+          "type": "compute",
+          "description": "与信使用率を計算する。",
+          "maturity": "committed",
+          "expression": "(@var + @credit.current_exposure) / @credit.credit_limit",
+          "outputBinding": "usage"
+        },
+        {
+          "id": "step-106",
+          "type": "branch",
+          "description": "与信使用率により BLOCK / WATCH / ALLOW を判定する。",
+          "maturity": "committed",
+          "branches": [
+            {
+              "id": "br-106-a",
+              "code": "BLOCK",
+              "label": "95% 超過",
+              "condition": "@usage > 0.95",
+              "steps": [
+                {
+                  "id": "step-106-a-01",
+                  "type": "dbAccess",
+                  "description": "BLOCK 判定を risk_check_log に記録する。",
+                  "maturity": "committed",
+                  "tableName": "risk_check_log",
+                  "operation": "INSERT",
+                  "sql": "INSERT INTO risk_check_log (risk_check_id, account_id, security_code, verdict, usage_ratio, created_at) VALUES (@riskCheckId, @inputs.accountId, @inputs.securityCode, 'BLOCK', @usage, NOW())",
+                  "lineage": { "writes": ["risk_check_log"] }
+                },
+                {
+                  "id": "step-106-a-02",
+                  "type": "eventPublish",
+                  "description": "risk.threshold.breached イベントを発行する。",
+                  "maturity": "committed",
+                  "topic": "risk.threshold.breached",
+                  "eventRef": "risk.threshold.breached",
+                  "payload": "{ riskCheckId: @riskCheckId, accountId: @inputs.accountId, threshold: 0.95, actual: @usage }"
+                },
+                {
+                  "id": "step-106-a-03",
+                  "type": "eventPublish",
+                  "description": "risk.check.completed イベントを BLOCK 判定で発行する。",
+                  "maturity": "committed",
+                  "topic": "risk.check.completed",
+                  "eventRef": "risk.check.completed",
+                  "payload": "{ riskCheckId: @riskCheckId, accountId: @inputs.accountId, verdict: 'BLOCK' }"
+                },
+                {
+                  "id": "step-106-a-04",
+                  "type": "return",
+                  "description": "422 RISK_THRESHOLD_BREACHED を返す。",
+                  "maturity": "committed",
+                  "responseRef": "422-risk-threshold-breached",
+                  "bodyExpression": "{ riskCheckId: @riskCheckId, verdict: 'BLOCK', message: '与信使用率が 95% を超過しています' }"
+                }
+              ]
+            },
+            {
+              "id": "br-106-b",
+              "code": "WATCH",
+              "label": "80% 超過",
+              "condition": "@usage > 0.80",
+              "steps": [
+                {
+                  "id": "step-106-b-01",
+                  "type": "compute",
+                  "description": "WATCH 判定メッセージを設定する。",
+                  "maturity": "committed",
+                  "expression": "{ verdict: 'WATCH', message: '与信使用率が 80% を超過しています' }",
+                  "outputBinding": "riskVerdict"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-106-else",
+            "code": "ALLOW",
+            "label": "80% 以下",
+            "steps": [
+              {
+                "id": "step-106-c-01",
+                "type": "compute",
+                "description": "ALLOW 判定メッセージを設定する。",
+                "maturity": "committed",
+                "expression": "{ verdict: 'ALLOW', message: 'リスク閾値内です' }",
+                "outputBinding": "riskVerdict"
+              }
+            ]
+          }
+        },
+        {
+          "id": "step-107",
+          "type": "dbAccess",
+          "description": "リスクチェック結果を risk_check_log に監査登録する。",
+          "maturity": "committed",
+          "tableName": "risk_check_log",
+          "operation": "INSERT",
+          "sql": "INSERT INTO risk_check_log (risk_check_id, account_id, security_code, verdict, usage_ratio, created_at) VALUES (@riskCheckId, @inputs.accountId, @inputs.securityCode, @riskVerdict.verdict, @usage, NOW())",
+          "lineage": { "writes": ["risk_check_log"] }
+        },
+        {
+          "id": "step-108",
+          "type": "eventPublish",
+          "description": "risk.check.completed イベントを発行する。",
+          "maturity": "committed",
+          "topic": "risk.check.completed",
+          "eventRef": "risk.check.completed",
+          "payload": "{ riskCheckId: @riskCheckId, accountId: @inputs.accountId, verdict: @riskVerdict.verdict }"
+        },
+        {
+          "id": "step-109",
+          "type": "return",
+          "description": "200 OK と判定結果を返す。",
+          "maturity": "committed",
+          "responseRef": "200-ok",
+          "bodyExpression": "{ riskCheckId: @riskCheckId, verdict: @riskVerdict.verdict, message: @riskVerdict.message }"
+        }
+      ]
+    }
+  ],
+  "testScenarios": [
+    {
+      "id": "happy-position-update",
+      "name": "通常約定でポジション更新と PnL 計算が成功する",
+      "given": [
+        { "kind": "clock", "now": "2026-04-26T09:00:00.000Z" },
+        { "kind": "sessionContext", "context": { "requestId": "req-463-happy", "marketDate": "2026-04-26", "riskCheckId": "RISK-463-001" } },
+        { "kind": "dbState", "table": "positions", "rows": [{ "position_id": "POS-001", "account_id": "ACC-001", "security_code": "7203", "quantity": 100, "average_cost": 3000 }] },
+        { "kind": "dbState", "table": "pnl_snapshots", "rows": [] },
+        { "kind": "externalStub", "externalRef": "marketDataService", "responseMock": { "status": 200, "body": { "price": 3100 } } }
+      ],
+      "when": {
+        "actionId": "act-001",
+        "input": {
+          "orderId": "ORD-463-001",
+          "tradeId": "TRD-463-001",
+          "accountId": "ACC-001",
+          "securityCode": "7203",
+          "executedQty": 100,
+          "executedPrice": 3000,
+          "side": "BUY"
+        }
+      },
+      "then": [
+        { "kind": "outcome", "expected": "200-ok" },
+        { "kind": "output", "path": "$.status", "equals": "UPDATED" },
+        { "kind": "dbRow", "table": "positions", "match": { "account_id": "ACC-001", "security_code": "7203" }, "count": 1 }
+      ],
+      "tags": ["happy", "position", "pnl"]
+    },
+    {
+      "id": "circuit-broken-on-loss-threshold",
+      "name": "累積損失が閾値を超え CircuitBreaker 503 になる",
+      "given": [
+        { "kind": "clock", "now": "2026-04-26T09:05:00.000Z" },
+        { "kind": "sessionContext", "context": { "requestId": "req-463-circuit", "marketDate": "2026-04-26" } },
+        { "kind": "dbState", "table": "pnl_snapshots", "rows": [{ "account_id": "ACC-002", "loss_amount": 1500000, "created_at": "2026-04-26T09:04:00.000Z" }] }
+      ],
+      "when": {
+        "actionId": "act-001",
+        "input": {
+          "orderId": "ORD-463-002",
+          "tradeId": "TRD-463-002",
+          "accountId": "ACC-002",
+          "securityCode": "6758",
+          "executedQty": 100,
+          "executedPrice": 12000,
+          "side": "SELL"
+        }
+      },
+      "then": [
+        { "kind": "outcome", "expected": "503-circuit-broken" },
+        { "kind": "auditLog", "action": "risk.circuit_breaker", "result": "failure" }
+      ],
+      "tags": ["risk", "circuit-breaker", "error"]
+    },
+    {
+      "id": "pre-trade-check-block",
+      "name": "VaR 超過で BLOCK 判定になる",
+      "given": [
+        { "kind": "sessionContext", "context": { "requestId": "req-463-block", "marketDate": "2026-04-26", "riskCheckId": "RISK-463-003" } },
+        { "kind": "dbState", "table": "positions", "rows": [{ "position_id": "POS-003", "account_id": "ACC-003", "security_code": "9984", "quantity": 1000, "average_cost": 8000 }] },
+        { "kind": "dbState", "table": "credit_limits", "rows": [{ "account_id": "ACC-003", "credit_limit": 10000000, "current_exposure": 9200000 }] }
+      ],
+      "when": {
+        "actionId": "act-002",
+        "input": {
+          "accountId": "ACC-003",
+          "securityCode": "9984",
+          "side": "BUY",
+          "quantity": 500,
+          "price": 9000
+        }
+      },
+      "then": [
+        { "kind": "outcome", "expected": "422-risk-threshold-breached" },
+        { "kind": "output", "path": "$.verdict", "equals": "BLOCK" },
+        { "kind": "dbRow", "table": "risk_check_log", "match": { "account_id": "ACC-003", "verdict": "BLOCK" }, "count": 1 }
+      ],
+      "tags": ["risk", "var", "block"]
+    }
+  ],
+  "createdAt": "2026-04-26T00:00:00.000Z",
+  "updatedAt": "2026-04-26T00:00:00.000Z"
+}

--- a/docs/sample-project/process-flows/dddddddd-0002-4000-8000-dddddddddddd.json
+++ b/docs/sample-project/process-flows/dddddddd-0002-4000-8000-dddddddddddd.json
@@ -23,7 +23,7 @@
       }
     },
     "risk.threshold.breached": {
-      "description": "与信使用率、VaR、または集中リスクの閾値を超過した時点で発行されるイベント。",
+      "description": "BLOCK 判定時のみ発行。与信使用率、VaR、または集中リスクの閾値を超過した時点で発行されるイベント。",
       "payload": {
         "type": "object",
         "required": ["riskCheckId", "accountId", "threshold", "actual"],
@@ -145,7 +145,7 @@
     {
       "name": "riskCheckId",
       "type": "string",
-      "required": false,
+      "required": true,
       "description": "取引前リスクチェック単位の識別子。未指定時はミドルウェアで採番する。"
     }
   ],
@@ -261,9 +261,9 @@
       "examples": ["@fn.calcVaR(@projectedPositions, 0.99)"]
     },
     "checkCircuitBreaker": {
-      "signature": "checkCircuitBreaker(account: Account, lossThreshold: number): boolean",
+      "signature": "checkCircuitBreaker(account: Account, recentLoss: number): boolean",
       "returnType": "boolean",
-      "description": "口座別の損失閾値に対して CircuitBreaker 発動要否を判定する。",
+      "description": "口座別の損失閾値に対して CircuitBreaker 発動要否を判定する。内部で account.loss_threshold と比較。",
       "examples": ["@fn.checkCircuitBreaker(@account, @recentLoss)"]
     }
   },
@@ -346,7 +346,10 @@
           "maturity": "committed",
           "isolationLevel": "READ_COMMITTED",
           "propagation": "REQUIRED",
-          "rollbackOn": ["VALIDATION", "SLA_EXCEEDED"],
+          "rollbackOn": ["VALIDATION"],
+          "outcomes": {
+            "failure": { "action": "abort" }
+          },
           "steps": [
             {
               "id": "step-002-01",
@@ -354,7 +357,13 @@
               "description": "PositionUpdateStep: positions を accountId × securityCode の一意キーで UPSERT する。inputs の値だけを参照する。",
               "maturity": "committed",
               "note": "extensionStep=securities:PositionUpdateStep; accountId=@inputs.accountId; securityCode=@inputs.securityCode; executedQty=@inputs.executedQty; executedPrice=@inputs.executedPrice; side=@inputs.side",
-              "outputBinding": "position"
+              "outputBinding": "position",
+              "outputSchema": {
+                "position_id": "string",
+                "security_code": "string",
+                "current_qty": "number",
+                "average_cost": "number"
+              }
             },
             {
               "id": "step-002-02",
@@ -677,6 +686,7 @@
           "type": "dbAccess",
           "description": "リスクチェック結果を risk_check_log に監査登録する。",
           "maturity": "committed",
+          "runIf": "@riskVerdict != null",
           "tableName": "risk_check_log",
           "operation": "INSERT",
           "sql": "INSERT INTO risk_check_log (risk_check_id, account_id, security_code, verdict, usage_ratio, created_at) VALUES (@riskCheckId, @inputs.accountId, @inputs.securityCode, @riskVerdict.verdict, @usage, NOW())",
@@ -687,6 +697,7 @@
           "type": "eventPublish",
           "description": "risk.check.completed イベントを発行する。",
           "maturity": "committed",
+          "runIf": "@riskVerdict != null",
           "topic": "risk.check.completed",
           "eventRef": "risk.check.completed",
           "payload": "{ riskCheckId: @riskCheckId, accountId: @inputs.accountId, verdict: @riskVerdict.verdict }"
@@ -696,6 +707,7 @@
           "type": "return",
           "description": "200 OK と判定結果を返す。",
           "maturity": "committed",
+          "runIf": "@riskVerdict != null",
           "responseRef": "200-ok",
           "bodyExpression": "{ riskCheckId: @riskCheckId, verdict: @riskVerdict.verdict, message: @riskVerdict.message }"
         }
@@ -738,6 +750,7 @@
       "given": [
         { "kind": "clock", "now": "2026-04-26T09:05:00.000Z" },
         { "kind": "sessionContext", "context": { "requestId": "req-463-circuit", "marketDate": "2026-04-26" } },
+        { "kind": "dbState", "table": "accounts", "rows": [{ "id": "ACC-002", "loss_threshold": 1000000, "circuit_breaker_enabled": true }] },
         { "kind": "dbState", "table": "pnl_snapshots", "rows": [{ "account_id": "ACC-002", "loss_amount": 1500000, "created_at": "2026-04-26T09:04:00.000Z" }] }
       ],
       "when": {

--- a/schemas/process-flow.schema.json
+++ b/schemas/process-flow.schema.json
@@ -1834,7 +1834,11 @@
             "maturity": true, "runIf": true, "outputBinding": true,
             "txBoundary": true, "transactional": true, "compensatesFor": true,
             "externalChain": true, "subSteps": true, "requiredPermissions": true, "sla": true,
-            "type": { "const": "other" }
+            "type": { "const": "other" },
+            "outputSchema": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            }
           }
         }
       ]
@@ -1956,6 +1960,15 @@
               "description": "TX rollback 後に実行する step 列 (任意・補償処理)。例: Stripe authorize の cancel、Slack 通知",
               "type": "array",
               "items": { "$ref": "#/$defs/Step" }
+            },
+            "outcomes": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "success": { "$ref": "#/$defs/ExternalCallOutcomeSpec" },
+                "failure": { "$ref": "#/$defs/ExternalCallOutcomeSpec" },
+                "timeout": { "$ref": "#/$defs/ExternalCallOutcomeSpec" }
+              }
             }
           }
         }


### PR DESCRIPTION
## Summary
- securities extension namespace に `position` / `pnl` fieldType と `PositionUpdateStep` を追加
- 金融シナリオ #2「ポジション計算/リスクチェック (証券)」の Process Flow JSON を追加
- 約定通知連鎖ポジション更新、CircuitBreaker 判定、取引前リスクチェック、3件の testScenarios を定義

## 仕様逐条突合 (自己申告)
- Deliverable 1: Process Flow JSON 作成: `docs/sample-project/process-flows/dddddddd-0002-4000-8000-dddddddddddd.json:1`
- id/name/type/apiVersion/mode/maturity: `docs/sample-project/process-flows/dddddddd-0002-4000-8000-dddddddddddd.json:2`
- eventsCatalog: `docs/sample-project/process-flows/dddddddd-0002-4000-8000-dddddddddddd.json:9`
- glossary 7 terms: `docs/sample-project/process-flows/dddddddd-0002-4000-8000-dddddddddddd.json:66`
- decisions ADR-001..003: `docs/sample-project/process-flows/dddddddd-0002-4000-8000-dddddddddddd.json:103`
- ambientVariables: `docs/sample-project/process-flows/dddddddd-0002-4000-8000-dddddddddddd.json:132`
- errorCatalog: `docs/sample-project/process-flows/dddddddd-0002-4000-8000-dddddddddddd.json:152`
- externalSystemCatalog: `docs/sample-project/process-flows/dddddddd-0002-4000-8000-dddddddddddd.json:179`
- secretsCatalog: `docs/sample-project/process-flows/dddddddd-0002-4000-8000-dddddddddddd.json:195`
- domainsCatalog: `docs/sample-project/process-flows/dddddddd-0002-4000-8000-dddddddddddd.json:209`
- functionsCatalog: `docs/sample-project/process-flows/dddddddd-0002-4000-8000-dddddddddddd.json:250`
- act-001 約定通知連鎖ポジション更新: `docs/sample-project/process-flows/dddddddd-0002-4000-8000-dddddddddddd.json:272`
- act-001 transactionScope inner steps: `docs/sample-project/process-flows/dddddddd-0002-4000-8000-dddddddddddd.json:344`
- act-001 PositionUpdateStep extension reference: `docs/sample-project/process-flows/dddddddd-0002-4000-8000-dddddddddddd.json:354`
- act-001 PnL / recent loss / CircuitBreaker / event / return: `docs/sample-project/process-flows/dddddddd-0002-4000-8000-dddddddddddd.json:386`
- act-002 取引前リスクチェック: `docs/sample-project/process-flows/dddddddd-0002-4000-8000-dddddddddddd.json:492`
- act-002 3-way risk branch and audit/event/return: `docs/sample-project/process-flows/dddddddd-0002-4000-8000-dddddddddddd.json:587`
- testScenarios 3件: `docs/sample-project/process-flows/dddddddd-0002-4000-8000-dddddddddddd.json:705`
- Deliverable 2 fieldTypes 追加: `docs/sample-project/extensions/securities/field-types.json:8`
- Deliverable 2 PositionUpdateStep 定義: `docs/sample-project/extensions/securities/steps.json:20`

## Test plan
- `cd designer && npx vitest run src/schemas/extensions-samples.test.ts src/schemas/process-flow.schema.test.ts` (205 passed)
- `cd designer && npm run build` (passed)

Closes #463