### PR TITLE
improve(spec): process-flow spec ガイドライン拡充 (#474)

### DIFF
--- a/docs/spec/process-flow-extensions.md
+++ b/docs/spec/process-flow-extensions.md
@@ -1074,3 +1074,62 @@ apiVersion?: string;                  // step 単位の override
 - 2026-04-24: `ProcessFlow.ambientOverrides` 追加 (#369)。§8.7 を新設。
 - 2026-04-25: P2+D 拡張 (#422)。§9 を新設。domainsCatalog / functionsCatalog / StructuredField.domainRef / StructuredField.formula / ValidationRule.kind / ScreenItem.computed を追加。
 - 2026-04-25: Tier-B (#423) 全 6 項目追加。§13 を新設 (B-1〜B-6)。
+- 2026-04-26: 拡張実装ガイドライン追記 (#474)。§15 を新設。
+
+## 15. 拡張実装ガイドライン (ドッグフード由来)
+
+シナリオ #2-#6 (PR #468-#472) 実装・レビュー時に判明した拡張定義の誤りパターン。拡張を新規追加・参照する前に確認すること。
+
+### §15.1 fieldType と domainsCatalog の使い分け
+
+| 区別 | 使い所 | 例 |
+|---|---|---|
+| **拡張 fieldType** (`{kind: "orderId"}`) | 業界固有の**型カテゴリ自体**を追加する場合。inputs/outputs の `type` フィールドで `kind` 形式で参照 | `{ "name": "orderId", "type": { "kind": "orderId" } }` |
+| **domainsCatalog** (`OrderId: {type: "string", constraints: ...}`) | ドメイン**制約付きの型エイリアス**を定義する場合。`constraints` (range / pattern 等) を持つ | `"domainRef": "OrderId"` |
+
+**使い分け基準**:
+- 制約が付くなら `domainsCatalog`
+- 純粋な型カテゴリ追加なら拡張 `fieldType`
+- 両方使う場合は `domainsCatalog` の `type` で fieldType kind を参照する形が自然
+
+```json
+// 拡張 fieldType 定義 (plugin extensions)
+{ "kind": "orderId", "label": "注文 ID", "baseType": "string" }
+
+// domainsCatalog で拡張 fieldType を参照
+"domainsCatalog": {
+  "OrderId": {
+    "type": { "kind": "orderId" },
+    "constraints": [{ "field": "orderId", "type": "regex", "pattern": "^ORD-\\d{4}-\\d{6}$" }]
+  }
+}
+```
+
+### §15.2 拡張 step の参照形式
+
+フロー JSON 内で拡張 step を参照する際の形式を統一する。
+
+- **正式形式**: `type: "namespace:StepName"` (例: `"securities:TradeMatchStep"`)
+- **過渡期許容**: `type: "other"` + `description` で明示する旧形式は後方互換として許容するが、**新規実装では namespace 修飾を推奨**
+- `process-flow.schema.json` の `Step` 定義は `type` のパターンとして `^[a-z][a-z0-9_-]*:[A-Z][A-Za-z0-9]*$` を許容する (allOf で `OtherStep` 互換)
+
+```json
+// 推奨 (namespace 修飾)
+{ "id": "step-match", "type": "securities:TradeMatchStep", "description": "約定マッチング" }
+
+// 許容 (過渡期・旧形式)
+{ "id": "step-match", "type": "other", "description": "securities:TradeMatchStep — 約定マッチング" }
+```
+
+### §15.3 拡張定義の実利用必須
+
+**「定義したが未使用」状態は禁止**。拡張定義 (`data/extensions/<namespace>/*.json`) を追加する際は、同 PR 内で対応するサンプルフロー JSON でその拡張を**実体使用すること**。
+
+- **理由**: 定義のみで未使用の拡張は、スキーマ整合検証の対象にならず、仕様ドリフトの温床になる
+- **例外**: 将来用として README に候補として記載する形は許容するが、継続的に未使用のままは避ける
+- **確認方法**: `/review-flow` の「拡張定義の実利用」観点 (SKILL.md への追記候補) で確認
+
+```
+# NG: 拡張定義を追加したが、サンプルフローで一度も type: "securities:TradeMatchStep" を使っていない
+# OK: 同一 PR で dddddddd-0007-*.json に type: "securities:TradeMatchStep" の step が存在する
+```

--- a/docs/spec/process-flow-runtime-conventions.md
+++ b/docs/spec/process-flow-runtime-conventions.md
@@ -415,3 +415,54 @@ Step-level の `requiredPermissions` は Action-level と AND 条件で評価す
 - [ ] `httpRoute.auth` のスキーム具体化は ambient 変数 + product-scope (§8)
 - [ ] ambient 前提 (TZ / 通貨 / 税率) は `data/conventions/catalog.json` の `default: true` エントリから取得 (§9.2)
 - [ ] フロー固有の ambient 例外は `ambientOverrides` を確認し、未記載なら catalog defaults をそのまま適用 (§9.3)
+
+## 13. 実装ガイドライン (ドッグフード由来)
+
+シナリオ #2-#6 (PR #468-#472) のレビューで繰り返し検出された実装ミスを以下にまとめる。チェックリスト §12 の補足として読むこと。
+
+### §13.1 内部スケジューラ起動の auth 表現
+
+グローバル定義スキーマで `action.httpRoute.auth` の enum は `["required", "optional", "none"]` の 3 値のみ。
+
+**内部スケジューラから呼ぶ API** (例: `marketOpen` トリガー、夜間バッチ) の auth は次のいずれかで表現する:
+
+| 方法 | 状況 | 例 |
+|---|---|---|
+| `auth: "required"` + `requiredPermissions: ["system"]` | 現行 workaround。内部スケジューラが system パーミッションを持つとして扱う | `"auth": "required", "requiredPermissions": ["system"]` |
+| `auth: "none"` | 完全に内部のみ・外部からアクセス不可と明示できる場合 | `"auth": "none"` |
+
+将来的に schema に `auth: "system"` 値を追加することを検討しているが (#474 とは別 ISSUE で起票)、現状は上記 workaround を使う。シナリオ #5 (#465) での実例を参照。
+
+### §13.2 ON CONFLICT DO NOTHING 時の outputBinding 振る舞い
+
+`INSERT ... ON CONFLICT DO NOTHING RETURNING ...` で衝突時 (no-op) の `outputBinding` 変数は **null か空オブジェクト** になる。
+
+**後続参照は null 安全表現を必須とする**:
+
+```json
+// 危険: ON CONFLICT DO NOTHING で衝突した場合 null deref
+{ "type": "compute", "expression": "@submissionRecord.submittedCount" }
+
+// 安全: null 安全アクセスまたは null 合体演算子を使う
+{ "type": "compute", "expression": "@submissionRecord?.submittedCount ?? @reportableTrades.length" }
+```
+
+シナリオ #5 での対策例: `@submissionRecord?.submittedCount ?? @reportableTrades.length` の形で null 安全表現を適用して解決。
+
+### §13.3 loop 0 件時の accumulate 初期化
+
+`outputBinding: { name: "total", operation: "accumulate", initialValue: 0 }` で loop が 0 件の場合、`@total` の値は**実装依存**になる。
+
+**安全な書き方**: loop の前に明示的初期化 step を置く。
+
+```json
+{ "id": "init-total", "type": "compute", "expression": "0", "outputBinding": "total" },
+{ "id": "the-loop", "type": "loop", "items": "@list", "steps": [
+  { "id": "accumulate", "type": "compute",
+    "expression": "@total + @item.amount", "outputBinding": "total" }
+]}
+```
+
+- `initialValue` を指定していても「loop 入口での初期化タイミング」は実装依存
+- loop 前の明示的 `compute` step で初期化することで、0 件パスでも `@total` が確実に定義済みになる
+- **検出パターン**: `/review-flow` 観点 1 (変数ライフサイクル) で「loop accumulate の 0 件パス」を確認 (シナリオ #4 で実例)

--- a/docs/spec/process-flow-transaction.md
+++ b/docs/spec/process-flow-transaction.md
@@ -164,3 +164,75 @@ TX が rollback された**後**に実行する step 列。任意・補償処理
 - 関連: `BranchConditionVariant.kind = "tryCatch"` (TX rollback エラー捕捉)
 - 関連: `compensatesFor` (Saga 補償の手動マーキング)
 - 業界フレームワーク: Power Platform Dataverse "Changeset", EF Core `TransactionScope`, Spring `@Transactional`
+
+## §8 実装ガイドライン (ドッグフード由来)
+
+シナリオ #2-#6 (PR #468-#472) の実装レビューで繰り返し検出された誤りパターンを以下にまとめる。新規フロー実装前に必読。
+
+### §8.1 TransactionScope 内外の変数アクセスパス
+
+`TransactionScopeStep` の inner step で `outputBinding` した変数を、TX 外の後続 step が参照する際のセマンティクス。
+
+- **TX 全体に `outputBinding: "txName"` を付けた場合**: 推奨は **inner 変数を直接参照** (`@innerVar`) する形。`@txName.innerVar` のネスト参照は spec で保証しない (シナリオ #3 で問題化)
+- **後続参照は TX commit が前提**: TX rollback 後は inner outputBinding 変数は未定義になりうる。後続 step に `runIf` ガード必須
+
+```json
+{ "id": "step-tx", "type": "transactionScope", "outputBinding": "txResult", "steps": [
+  { "id": "step-tx-insert", "type": "dbAccess", "operation": "INSERT", "outputBinding": "newRow" }
+]},
+{ "id": "step-after", "type": "eventPublish", "runIf": "@txResult.committed == true", "payload": "{ id: @newRow.id }" }
+```
+
+上の例では、TX commit 後の後続 step は `@newRow.id` (inner 変数直接参照) を使う。`@txResult.newRow.id` のようなネスト形式は避けること。
+
+### §8.2 外部呼び出しと TX の位置関係 (anti-pattern と例外)
+
+- **原則**: `externalSystem` step は `TransactionScopeStep` の inner に入れない (DB 接続長時間占有 / 外部障害で TX タイムアウト)
+- **例外ケース**: 補償処理が困難な場合 (例: 取引所への約定送信) でも、外部呼び出しは TX 外で行い `outcomes.failure: "compensate"` で逆操作を補償処理として記述する
+- **検出パターン**: TX inner step で `@外部呼び出しResult` を前方参照する誤りは `/review-flow` 観点 1 で検出 (シナリオ #1 で実例あり)
+
+推奨パターン:
+
+```json
+{ "id": "step-tx", "type": "transactionScope", "steps": [
+  { "id": "step-db-insert", "type": "dbAccess", "operation": "INSERT", "outputBinding": "newRow" }
+]},
+{ "id": "step-external", "type": "externalSystem", "runIf": "@txResult.committed == true",
+  "outcomes": { "failure": { "action": "compensate" } } }
+```
+
+### §8.3 TX rollback 時の制御フロー
+
+**TX rollback 発生後の後続 step** (TX の外側) は**明示的 `runIf` ガードが必要**。エンジン仕様で「自動 skip」は保証されない。
+
+推奨パターン:
+
+- TX に `outputBinding: "txResult"` を付与する
+- TX commit 経路の後続 step: `runIf: "@txResult.committed == true"`
+- TX rollback 経路のエラー返却 step: `runIf: "@txResult.committed == false"`
+
+```json
+{ "id": "step-tx", "type": "transactionScope", "outputBinding": "txResult", "steps": [ ... ] },
+{ "id": "step-success", "type": "return", "runIf": "@txResult.committed == true",
+  "responseRef": "201-success" },
+{ "id": "step-rollback-error", "type": "return", "runIf": "@txResult.committed == false",
+  "responseRef": "409-conflict" }
+```
+
+参考: シナリオ #6 (#473 で修正) では `runIf: "@creditTxResult.committed == false"` で 409 INVALID_STATE_TRANSITION を返す step を追加して解決。
+
+### §8.4 rollbackOn の発火可能性チェック
+
+**rollbackOn には TX inner step から実際に発生しうるエラーコードのみ列挙する。**
+
+- TX 外 step が返すエラーコード (例: `EXCHANGE_REJECTED` が `externalSystem` step 由来) を `rollbackOn` に書くと**死コード**になる
+- inner step の `affectedRowsCheck.errorCode` / `ValidationStep` が throw するコードのみが rollback トリガーになりえる
+- **検出パターン**: `/review-flow` 観点 8 で「rollbackOn の発火可能性」を体系チェック (シナリオ #1/#2/#3/#6 で実例)
+
+```jsonc
+// NG: externalSystem step の結果コードを rollbackOn に列挙 (TX 内に externalSystem がない場合)
+"rollbackOn": ["EXCHANGE_REJECTED", "STOCK_SHORTAGE"]
+
+// OK: TX inner の dbAccess が throw するコードのみ列挙
+"rollbackOn": ["STOCK_SHORTAGE"]
+```


### PR DESCRIPTION
## Summary

シナリオ #2-#6 (PR #468-#472) の `/review-flow` 検証で頻発した Codex 実装ミスの根本原因として spec ガイドライン不足が見えたため、3 つの spec ファイルにガイドラインを追記する。

- `process-flow-transaction.md` §8 を新設 (4 項目)
- `process-flow-extensions.md` §15 を新設 (3 項目)
- `process-flow-runtime-conventions.md` §13 を新設 (3 項目)

## 改訂内容

### `docs/spec/process-flow-transaction.md` (§8 新設)

| 節 | 内容 | file:line |
|---|---|---|
| §8.1 | TX 内外の変数アクセスパス — `@innerVar` 直接参照推奨、`@txName.innerVar` ネスト不保証 | process-flow-transaction.md:172 |
| §8.2 | 外部呼び出しと TX の位置関係 — externalSystem を TX inner に入れる anti-pattern 明示 | process-flow-transaction.md:192 |
| §8.3 | TX rollback 時の制御フロー — 後続 step の明示的 runIf ガード必須 | process-flow-transaction.md:210 |
| §8.4 | rollbackOn の発火可能性チェック — TX 外コード列挙は死コード | process-flow-transaction.md:232 |

### `docs/spec/process-flow-extensions.md` (§15 新設)

| 節 | 内容 | file:line |
|---|---|---|
| §15.1 | fieldType と domainsCatalog の使い分け — 制約あり→domainsCatalog、型カテゴリ追加→fieldType | process-flow-extensions.md:1095 |
| §15.2 | 拡張 step の参照形式統一 — `namespace:StepName` を正式形式に | process-flow-extensions.md:1122 |
| §15.3 | 拡張定義の実利用必須 — 定義のみ未使用状態を禁止 | process-flow-extensions.md:1140 |

### `docs/spec/process-flow-runtime-conventions.md` (§13 新設)

| 節 | 内容 | file:line |
|---|---|---|
| §13.1 | 内部スケジューラ起動の auth 表現 — `auth: "required"` + `requiredPermissions: ["system"]` workaround | process-flow-runtime-conventions.md:421 |
| §13.2 | ON CONFLICT DO NOTHING 時の outputBinding 振る舞い — null 安全表現必須 | process-flow-runtime-conventions.md:441 |
| §13.3 | loop 0 件時の accumulate 初期化 — loop 前の明示的 compute step で初期化 | process-flow-runtime-conventions.md:460 |

## Test plan

- [x] `npx vitest run src/schemas/extensions-samples.test.ts src/schemas/process-flow.schema.test.ts` — 209 テスト全 pass (spec 変更のみ、schema 変更なし)
- [x] `npm run build` — 成功 (TS チェック + Vite ビルド)
- [x] spec 文書のみ修正 — schema/サンプルフロー/拡張定義/データファイルは無変更

Closes #474