### PR TITLE
improve(dogfood): 製造シナリオ #2 — 製造実績/品質検査/出荷判定/トレーサビリティ (#480)

### DIFF
--- a/docs/sample-project/extensions/manufacturing/README.md
+++ b/docs/sample-project/extensions/manufacturing/README.md
@@ -1,6 +1,6 @@
 # docs/sample-project/extensions/manufacturing
 
-製造業向け受注/生産計画/部材引当/製造指示領域の ProcessFlow 拡張定義サンプルです。
+製造業 (受注 → 生産計画 → 部材引当 → 製造実績 → 品質検査 → 出荷) 向けの ProcessFlow 拡張定義サンプルです。
 
 実行時にバリデーターが読む場所は `data/extensions/` です。このディレクトリには、仕様確認用・業務別テンプレート用のサンプルを配置します。
 
@@ -8,9 +8,10 @@
 
 | ファイル | 内容 |
 |---|---|
-| `field-types.json` | ロット ID、製造指示書 ID、部品番号の FieldType 拡張サンプル |
-| `db-operations.json` | BOM 階層展開・在庫引当 (排他ロック) の DbOperation 拡張サンプル |
-| `steps.json` | BOM 展開ステップ・在庫引当ステップの拡張サンプル |
+| `field-types.json` | ロット ID / 製造指示書 ID / 部品番号 / シリアル番号の FieldType 拡張 |
+| `triggers.json` | 品質異常検知トリガー (`qualityIncident`) |
+| `db-operations.json` | BOM 展開 / 在庫引当の DbOperation 拡張 |
+| `steps.json` | BOM 展開 / 在庫引当 / トレーサビリティ記録 / 品質検査の Step 拡張 |
 
 ## 適用方法
 
@@ -22,22 +23,30 @@ cp docs/sample-project/extensions/manufacturing/*.json data/extensions/
 
 ## 拡張の概要
 
-### BomExplodeStep
+### Step 拡張
 
-製品コード (`productCode`) と数量 (`quantity`) を受け取り、BOM (Bill of Materials) 定義に基づいて必要部品リストを階層的に展開する。出力は部品番号と必要数量のリスト。
+- **BomExplodeStep**: 製品コード (`productCode`) と数量 (`quantity`) を受け取り、BOM (Bill of Materials) に基づいて必要部品リストを階層展開する
+- **InventoryReserveStep**: 部品番号と数量を受け取り、parts_inventory に排他ロック付きで在庫引当を行う (`RESERVE_INVENTORY` DbOp と組合わせ)
+- **TraceabilityStep**: 部材ロット / 製造工程 / 担当者を traceability_log に記録する
+- **QualityCheckStep**: ロットの品質仕様適合チェック
 
-フロー内での参照形式: `"type": "manufacturing:BomExplodeStep"`
+### DbOperation 拡張
 
-### InventoryReserveStep
+- **BOM_EXPLODE**: BOM 階層展開 (再帰 SQL)
+- **RESERVE_INVENTORY**: 排他ロック付き UPDATE での在庫引当
 
-部品番号 (`partNumber`) と数量 (`quantity`) を受け取り、parts_inventory テーブルに対して排他ロック付きで在庫引当を行う。`RESERVE_INVENTORY` DbOperation と組み合わせて使用する。
+### Trigger 拡張
 
-フロー内での参照形式: `"type": "manufacturing:InventoryReserveStep"`
+- **qualityIncident**: 品質異常検知時の起動 (将来用候補、現状未使用)
 
-### BOM_EXPLODE / RESERVE_INVENTORY
+## 由来 ISSUE
 
-DbOperation 拡張。フロー内の `dbAccess` step の `operation` フィールドで使用する。
+| ISSUE / PR | 追加された拡張 |
+|---|---|
+| #479 / PR #481 (シナリオ #1) | `lotId` / `workOrderId` / `partNumber` fieldType、`BOM_EXPLODE` / `RESERVE_INVENTORY` DbOperation、`BomExplodeStep` / `InventoryReserveStep` |
+| #480 / PR #482 (シナリオ #2) | `serialNumber` fieldType、`qualityIncident` trigger、`TraceabilityStep` / `QualityCheckStep` |
 
 ## 実利用サンプル
 
-`docs/sample-project/process-flows/eeeeeeee-0001-4000-8000-eeeeeeeeeeee.json` にて全拡張を実体使用しています。
+- `docs/sample-project/process-flows/eeeeeeee-0001-*.json` (シナリオ #1): 受注/生産計画 ですべての #479 拡張を実体使用
+- `docs/sample-project/process-flows/eeeeeeee-0002-*.json` (シナリオ #2): 製造実績/品質/出荷 で TraceabilityStep / QualityCheckStep / serialNumber を実体使用 (`type: "other"` + outputSchema パターン)

--- a/docs/sample-project/extensions/manufacturing/db-operations.json
+++ b/docs/sample-project/extensions/manufacturing/db-operations.json
@@ -2,6 +2,6 @@
   "namespace": "manufacturing",
   "dbOperations": [
     { "value": "BOM_EXPLODE", "label": "BOM 階層展開" },
-    { "value": "RESERVE_INVENTORY", "label": "在庫引当 (排他ロック)" }
+    { "value": "RESERVE_INVENTORY", "label": "在庫引当 (排他ロック付き UPDATE)" }
   ]
 }

--- a/docs/sample-project/extensions/manufacturing/field-types.json
+++ b/docs/sample-project/extensions/manufacturing/field-types.json
@@ -3,6 +3,7 @@
   "fieldTypes": [
     { "kind": "lotId", "label": "ロット ID" },
     { "kind": "workOrderId", "label": "製造指示書 ID" },
-    { "kind": "partNumber", "label": "部品番号" }
+    { "kind": "partNumber", "label": "部品番号" },
+    { "kind": "serialNumber", "label": "シリアル番号" }
   ]
 }

--- a/docs/sample-project/extensions/manufacturing/steps.json
+++ b/docs/sample-project/extensions/manufacturing/steps.json
@@ -4,14 +4,15 @@
     "BomExplodeStep": {
       "label": "BOM 展開",
       "icon": "GitBranch",
-      "description": "製品コードから必要部品リストを階層展開",
+      "description": "製品コードから BOM を再帰展開し、必要部品リストを生成する。",
       "schema": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["productCode", "quantity"],
+        "required": ["productCode"],
         "properties": {
           "productCode": { "type": "string" },
-          "quantity": { "type": "number" }
+          "quantity": { "type": "number" },
+          "explodeDepth": { "type": "integer" }
         }
       }
     },
@@ -27,6 +28,37 @@
           "partNumber": { "type": "string" },
           "quantity": { "type": "number" },
           "lotId": { "type": "string" }
+        }
+      }
+    },
+    "TraceabilityStep": {
+      "label": "トレーサビリティ記録",
+      "icon": "Activity",
+      "description": "部材ロット / 製造工程 / 担当者を traceability_log に記録する。",
+      "schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["lotId", "eventType"],
+        "properties": {
+          "lotId": { "type": "string" },
+          "eventType": { "type": "string", "enum": ["PRODUCTION", "INSPECTION", "SHIPMENT"] },
+          "operatorId": { "type": "string" },
+          "metadata": { "type": "object" }
+        }
+      }
+    },
+    "QualityCheckStep": {
+      "label": "品質検査",
+      "icon": "CheckCircle",
+      "description": "ロットの品質仕様適合チェックを行う。inspectionItems は配列値式 (例: @inputs.inspectionItems) を文字列で受ける想定。",
+      "schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["lotId", "specification"],
+        "properties": {
+          "lotId": { "type": "string" },
+          "specification": { "type": "string" },
+          "inspectionItems": { "type": "string" }
         }
       }
     }

--- a/docs/sample-project/extensions/manufacturing/triggers.json
+++ b/docs/sample-project/extensions/manufacturing/triggers.json
@@ -1,0 +1,6 @@
+{
+  "namespace": "manufacturing",
+  "triggers": [
+    { "value": "qualityIncident", "label": "品質異常検知時" }
+  ]
+}

--- a/docs/sample-project/process-flows/eeeeeeee-0002-4000-8000-eeeeeeeeeeee.json
+++ b/docs/sample-project/process-flows/eeeeeeee-0002-4000-8000-eeeeeeeeeeee.json
@@ -165,12 +165,6 @@
       "type": "string",
       "required": true,
       "description": "操作したログインユーザー ID。act-002/act-003 では検査員・出荷担当者が該当。"
-    },
-    {
-      "name": "inspectorId",
-      "type": "string",
-      "required": false,
-      "description": "品質検査画面のセッションコンテキストで設定される検査員 ID。act-002 で audit / event に注入される。"
     }
   ],
   "errorCatalog": {
@@ -429,22 +423,20 @@
           "tableName": "work_orders",
           "operation": "UPDATE",
           "sql": "UPDATE work_orders SET completed_qty = completed_qty + 1, status = CASE WHEN completed_qty + 1 >= planned_qty THEN 'COMPLETED' ELSE 'IN_PROGRESS' END, updated_at = NOW() WHERE id = @inputs.workOrderId AND status IN ('IN_PROGRESS', 'COMPLETED') RETURNING id, status",
-          "outputBinding": "updatedWorkOrder",
           "lineage": { "writes": ["work_orders"] }
         },
         {
           "id": "step-001-06",
-          "type": "manufacturing:TraceabilityStep",
-          "description": "PRODUCTION イベントとして traceability_log にスナップショットを記録する。新規登録時のみ実行。",
+          "type": "other",
+          "description": "manufacturing:TraceabilityStep 拡張定義 (docs/sample-project/extensions/manufacturing/steps.json) を呼び出す意図。PRODUCTION イベントとして traceability_log にスナップショットを記録する。新規登録時のみ実行。",
           "maturity": "committed",
           "runIf": "@upsertedRecord?.id != null",
-          "lotId": "@inputs.lotId",
-          "eventType": "PRODUCTION",
-          "operatorId": "@inputs.operatorId",
-          "metadata": {
-            "workOrderId": "@inputs.workOrderId",
-            "serialNumber": "@inputs.serialNumber",
-            "lineId": "@inputs.lineId"
+          "note": "extensionStep=manufacturing:TraceabilityStep; lotId=@inputs.lotId; eventType=PRODUCTION; operatorId=@inputs.operatorId; metadata.workOrderId=@inputs.workOrderId; metadata.serialNumber=@inputs.serialNumber; metadata.lineId=@inputs.lineId",
+          "outputBinding": "productionTrace",
+          "outputSchema": {
+            "lotId": "string",
+            "eventType": "string",
+            "traceId": "string"
           }
         },
         {
@@ -583,13 +575,10 @@
         },
         {
           "id": "step-002-04",
-          "type": "manufacturing:QualityCheckStep",
-          "description": "品質仕様を ambient コンテキストから引いて、検査項目との総合適合性を補助計算する。",
+          "type": "other",
+          "description": "manufacturing:QualityCheckStep 拡張定義 (docs/sample-project/extensions/manufacturing/steps.json) を呼び出す意図。品質仕様を ambient コンテキストから引いて、検査項目との総合適合性を補助計算する。本フローでは判定値そのものは @inputs.overallResult を採用するため、本 step は補助 (出力非依存) として実行する。",
           "maturity": "committed",
-          "lotId": "@inputs.lotId",
-          "specification": "@lot.product_code",
-          "inspectionItems": "@inputs.inspectionItems",
-          "outputBinding": "qualityCheck"
+          "note": "extensionStep=manufacturing:QualityCheckStep; lotId=@inputs.lotId; specification=@lot.product_code; inspectionItems=@inputs.inspectionItems"
         },
         {
           "id": "step-002-05",
@@ -650,50 +639,68 @@
                       "tableName": "work_orders",
                       "operation": "UPDATE",
                       "sql": "UPDATE work_orders SET status = 'READY_FOR_SHIPMENT', updated_at = NOW() WHERE id = @lot.work_order_id AND status = 'COMPLETED' RETURNING id, status",
-                      "outputBinding": "updatedWorkOrder",
                       "lineage": { "writes": ["work_orders"] }
                     }
                   ]
                 },
                 {
                   "id": "step-002-05-a-02",
-                  "type": "return",
-                  "description": "TX commit 失敗 (DB_CONSTRAINT_VIOLATION rollback) 時に 409 を返す。",
+                  "type": "branch",
+                  "description": "TX commit 結果で commit / rollback を分岐する。runIf による return 後 fallthrough を構造化で防止する (#482 review M-4)。",
                   "maturity": "committed",
-                  "runIf": "@txResult.committed == false",
-                  "responseRef": "409-invalid-state-transition",
-                  "bodyExpression": "{ code: 'INVALID_STATE_TRANSITION', message: 'TX commit failed (lot status mismatch)', lotId: @inputs.lotId }"
-                },
-                {
-                  "id": "step-002-05-a-03",
-                  "type": "audit",
-                  "description": "PASS 判定を監査ログに記録する。TX 成功時のみ。",
-                  "maturity": "committed",
-                  "runIf": "@txResult.committed == true",
-                  "action": "quality.inspection",
-                  "resource": { "type": "Lot", "id": "@inputs.lotId" },
-                  "result": "success",
-                  "reason": "PASS",
-                  "sensitive": false
-                },
-                {
-                  "id": "step-002-05-a-04",
-                  "type": "eventPublish",
-                  "description": "quality.inspected イベントを発行する。TX 成功時のみ。",
-                  "maturity": "committed",
-                  "runIf": "@txResult.committed == true",
-                  "topic": "quality.inspected",
-                  "eventRef": "quality.inspected",
-                  "payload": "{ lotId: @inputs.lotId, verdict: 'PASS', inspectorId: @inputs.inspectorId, inspectedAt: @updatedLot.status }"
-                },
-                {
-                  "id": "step-002-05-a-05",
-                  "type": "return",
-                  "description": "200 PASS を返す。TX 成功時のみ。",
-                  "maturity": "committed",
-                  "runIf": "@txResult.committed == true",
-                  "responseRef": "200-pass",
-                  "bodyExpression": "{ lotId: @inputs.lotId, verdict: 'PASS', nextAction: 'shipment-evaluation' }"
+                  "branches": [
+                    {
+                      "id": "br-002-05-a-02-rollback",
+                      "code": "ROLLBACK",
+                      "label": "TX rollback (lot 前提状態違反など)",
+                      "condition": "@txResult.committed == false",
+                      "steps": [
+                        {
+                          "id": "step-002-05-a-02-rollback-01",
+                          "type": "return",
+                          "description": "TX commit 失敗 (DB_CONSTRAINT_VIOLATION rollback) 時に 409 を返す。",
+                          "maturity": "committed",
+                          "responseRef": "409-invalid-state-transition",
+                          "bodyExpression": "{ code: 'INVALID_STATE_TRANSITION', message: 'TX commit failed (lot status mismatch)', lotId: @inputs.lotId }"
+                        }
+                      ]
+                    }
+                  ],
+                  "elseBranch": {
+                    "id": "br-002-05-a-02-commit",
+                    "code": "COMMIT",
+                    "label": "TX commit (PASS 状態遷移成功)",
+                    "steps": [
+                      {
+                        "id": "step-002-05-a-02-commit-01",
+                        "type": "audit",
+                        "description": "PASS 判定を監査ログに記録する。",
+                        "maturity": "committed",
+                        "action": "quality.inspection",
+                        "resource": { "type": "Lot", "id": "@inputs.lotId" },
+                        "result": "success",
+                        "reason": "PASS",
+                        "sensitive": false
+                      },
+                      {
+                        "id": "step-002-05-a-02-commit-02",
+                        "type": "eventPublish",
+                        "description": "quality.inspected イベントを発行する。inspectedAt は ambient @now を使う (TX 内 outputBinding @updatedLot は TX 外参照不可、UPDATE 時 NOW() と同一 wall-clock として近似)。",
+                        "maturity": "committed",
+                        "topic": "quality.inspected",
+                        "eventRef": "quality.inspected",
+                        "payload": "{ lotId: @inputs.lotId, verdict: 'PASS', inspectorId: @inputs.inspectorId, inspectedAt: @now }"
+                      },
+                      {
+                        "id": "step-002-05-a-02-commit-03",
+                        "type": "return",
+                        "description": "200 PASS を返す。",
+                        "maturity": "committed",
+                        "responseRef": "200-pass",
+                        "bodyExpression": "{ lotId: @inputs.lotId, verdict: 'PASS', nextAction: 'shipment-evaluation' }"
+                      }
+                    ]
+                  }
                 }
               ]
             },
@@ -782,7 +789,16 @@
                     "id": "br-002-05-b-02-else",
                     "code": "OTHER",
                     "label": "想定外 (validator 通過後の防御)",
-                    "steps": []
+                    "steps": [
+                      {
+                        "id": "step-002-05-b-02-else-01",
+                        "type": "return",
+                        "description": "validator を通過した想定外の disposition が来た場合の防御的 400 (理論上到達不能、深層防御)。",
+                        "maturity": "committed",
+                        "responseRef": "400-validation",
+                        "bodyExpression": "{ code: 'VALIDATION', message: 'Unknown disposition', disposition: @inputs.disposition }"
+                      }
+                    ]
                   }
                 },
                 {
@@ -975,21 +991,21 @@
           "maturity": "committed",
           "tableName": "shipment_orders",
           "operation": "INSERT",
-          "sql": "INSERT INTO shipment_orders (lot_id, work_order_id, status, planned_ship_at, requested_by, created_at) VALUES (@inputs.lotId, @lotWithInspections.work_order_id, 'PLANNED', NOW() + INTERVAL '1 day', @sessionUserId, NOW()) RETURNING id",
+          "sql": "INSERT INTO shipment_orders (lot_id, work_order_id, status, planned_ship_at, requested_by, created_at) VALUES (@inputs.lotId, @lotWithInspections.work_order_id, 'PLANNED', NOW() + INTERVAL '1 day', @sessionUserId, NOW()) RETURNING id, planned_ship_at",
           "outputBinding": "shipmentOrder",
           "lineage": { "writes": ["shipment_orders"] }
         },
         {
           "id": "step-003-07",
-          "type": "manufacturing:TraceabilityStep",
-          "description": "SHIPMENT イベントとして出荷時 traceability snapshot を記録する。",
+          "type": "other",
+          "description": "manufacturing:TraceabilityStep 拡張定義 (docs/sample-project/extensions/manufacturing/steps.json) を呼び出す意図。SHIPMENT イベントとして出荷時 traceability snapshot を記録する。",
           "maturity": "committed",
-          "lotId": "@inputs.lotId",
-          "eventType": "SHIPMENT",
-          "operatorId": "@sessionUserId",
-          "metadata": {
-            "shipmentOrderId": "@shipmentOrder.id",
-            "workOrderId": "@lotWithInspections.work_order_id"
+          "note": "extensionStep=manufacturing:TraceabilityStep; lotId=@inputs.lotId; eventType=SHIPMENT; operatorId=@sessionUserId; metadata.shipmentOrderId=@shipmentOrder.id; metadata.workOrderId=@lotWithInspections.work_order_id",
+          "outputBinding": "shipmentTrace",
+          "outputSchema": {
+            "lotId": "string",
+            "eventType": "string",
+            "traceId": "string"
           }
         },
         {
@@ -1037,7 +1053,7 @@
           "httpCall": {
             "method": "POST",
             "path": "/notifications/shipment-planned",
-            "body": "{ shipmentOrderId: @shipmentOrder.id, lotId: @inputs.lotId, plannedShipAt: '@shipmentOrder.planned_ship_at' }"
+            "body": "{ shipmentOrderId: @shipmentOrder.id, lotId: @inputs.lotId, plannedShipAt: @shipmentOrder.planned_ship_at }"
           },
           "fireAndForget": true,
           "outcomes": {
@@ -1053,7 +1069,7 @@
           "maturity": "committed",
           "topic": "shipment.approved",
           "eventRef": "shipment.approved",
-          "payload": "{ lotId: @inputs.lotId, shipmentOrderId: @shipmentOrder.id, approvedAt: NOW() }"
+          "payload": "{ lotId: @inputs.lotId, shipmentOrderId: @shipmentOrder.id, approvedAt: @now }"
         },
         {
           "id": "step-003-11",

--- a/docs/sample-project/process-flows/eeeeeeee-0002-4000-8000-eeeeeeeeeeee.json
+++ b/docs/sample-project/process-flows/eeeeeeee-0002-4000-8000-eeeeeeeeeeee.json
@@ -1,0 +1,1192 @@
+{
+  "id": "eeeeeeee-0002-4000-8000-eeeeeeeeeeee",
+  "name": "製造実績/品質検査/出荷判定/トレーサビリティ (製造業)",
+  "type": "system",
+  "description": "製造ラインからの製造実績受信、品質検査、出荷可否判定、トレーサビリティ記録までの 3 アクション業務フロー。MES コールバックの冪等処理 (UPSERT_IDEMPOTENT)、品質結果による状態遷移とトランザクションスコープ、出荷時の外部 WMS / 顧客通知連携を扱う。",
+  "apiVersion": "v2",
+  "mode": "downstream",
+  "maturity": "committed",
+  "eventsCatalog": {
+    "production.completed": {
+      "description": "製造ラインから製造完了通知を受信し、production_records に新規行として登録された時点で発行されるイベント。",
+      "payload": {
+        "type": "object",
+        "required": ["workOrderId", "lotId", "serialNumber"],
+        "properties": {
+          "workOrderId": { "type": "string" },
+          "lotId": { "type": "string" },
+          "serialNumber": { "type": "string" },
+          "completedAt": { "type": "string" },
+          "lineId": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "quality.inspected": {
+      "description": "品質検査が完了し、ロットが INSPECTED_PASS に遷移した時点で発行されるイベント。",
+      "payload": {
+        "type": "object",
+        "required": ["lotId", "verdict"],
+        "properties": {
+          "lotId": { "type": "string" },
+          "verdict": { "type": "string", "enum": ["PASS"] },
+          "inspectorId": { "type": "string" },
+          "inspectedAt": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "quality.failed": {
+      "description": "品質検査で不合格となり、廃棄/再加工/特別採用のいずれかの処置が決定された時点で発行されるイベント。",
+      "payload": {
+        "type": "object",
+        "required": ["lotId", "verdict", "disposition"],
+        "properties": {
+          "lotId": { "type": "string" },
+          "verdict": { "type": "string", "enum": ["FAIL"] },
+          "disposition": { "type": "string", "enum": ["SCRAP", "REWORK", "SPECIAL_APPROVAL"] },
+          "inspectorId": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "shipment.approved": {
+      "description": "出荷条件を満たし、出荷指示 (shipment_orders) が登録された時点で発行されるイベント。",
+      "payload": {
+        "type": "object",
+        "required": ["lotId", "shipmentOrderId"],
+        "properties": {
+          "lotId": { "type": "string" },
+          "shipmentOrderId": { "type": "string" },
+          "approvedAt": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "traceability.recorded": {
+      "description": "トレーサビリティ snapshot が traceability_log に記録された時点で発行されるイベント。",
+      "payload": {
+        "type": "object",
+        "required": ["lotId", "eventType"],
+        "properties": {
+          "lotId": { "type": "string" },
+          "eventType": { "type": "string", "enum": ["PRODUCTION", "INSPECTION", "SHIPMENT"] },
+          "operatorId": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "glossary": {
+    "製造実績": {
+      "definition": "製造ラインで個品 (1 シリアル) が完成した実績。MES から完成都度コールバックされる。",
+      "aliases": ["Production Record", "完成実績"],
+      "domainRef": "production_records"
+    },
+    "品質検査": {
+      "definition": "ロットに対して仕様適合・寸法・外観等を検査し PASS/FAIL を判定する業務。",
+      "aliases": ["Quality Inspection", "QC"],
+      "domainRef": "quality_inspections"
+    },
+    "トレーサビリティ": {
+      "definition": "製品が「いつ・どこで・誰の手で・どの部材ロットから」作られ・検査され・出荷されたかを追跡する性質。",
+      "aliases": ["Traceability"],
+      "domainRef": "traceability_log"
+    },
+    "シリアル番号": {
+      "definition": "個品単位 (製品 1 個ごと) に一意に付番される識別子。同一ロット内でも個品ごとに異なる。",
+      "aliases": ["Serial Number", "個品 ID"],
+      "domainRef": "production_records.serial_number"
+    },
+    "ロット": {
+      "definition": "同一条件で製造された製品群の単位。品質検査・出荷判定はロット単位で行う。",
+      "aliases": ["Lot", "バッチ"],
+      "domainRef": "lots"
+    },
+    "WorkOrder": {
+      "definition": "製造指示書。何を・いくつ・どのラインで作るかを指示する業務単位。",
+      "aliases": ["製造指示書", "MO", "Manufacturing Order"],
+      "domainRef": "work_orders"
+    },
+    "規格外品": {
+      "definition": "品質検査で FAIL となった個品/ロット。廃棄・再加工・特別採用のいずれかの処置を行う。",
+      "aliases": ["Non-conforming Product", "NG 品"],
+      "domainRef": "lots.status:BLOCKED"
+    },
+    "特別採用": {
+      "definition": "規格外であるが、顧客同意のもと例外的に出荷を認める処置。要 audit 記録。",
+      "aliases": ["Concession", "Special Approval"],
+      "domainRef": "lots.status:SPECIAL_APPROVED"
+    },
+    "監査ログ": {
+      "definition": "誰が・いつ・どのリソースに・何を・なぜ実行したかを保全する記録。改竄不可・長期保管。",
+      "aliases": ["Audit Log"],
+      "domainRef": "audit_logs"
+    }
+  },
+  "decisions": [
+    {
+      "id": "ADR-001",
+      "title": "MES コールバックは UPSERT_IDEMPOTENT で冪等処理する",
+      "status": "accepted",
+      "context": "MES からの製造完了通知は、ネットワーク再送・MES 側の運用再送により同一 (lotId, serialNumber) が複数回到達する可能性がある。",
+      "decision": "production_records に (lot_id, serial_number) 複合一意制約を置き、既存行があれば no-op の UPSERT_IDEMPOTENT 方針で処理する。後続 step は @upsertedRecord?.id != null をガードに付け、no-op 経路は ALREADY_PROCESSED を返す。",
+      "consequences": "重複コールバックによる二重実績登録を防げる。後続 work_orders 状態更新・traceability 記録・event 発行も同一ガードで保護する必要がある。",
+      "date": "2026-04-26"
+    },
+    {
+      "id": "ADR-002",
+      "title": "品質検査 PASS の状態遷移は TransactionScope で 1 TX にまとめる",
+      "status": "accepted",
+      "context": "品質検査 PASS は (1) quality_inspections INSERT、(2) lots を INSPECTED_PASS に UPDATE、(3) 関連 work_orders を READY_FOR_SHIPMENT に UPDATE の 3 操作を伴う。途中失敗で部分適用されると lot 状態と inspections の整合が崩れる。",
+      "decision": "上記 3 DbAccessStep を TransactionScopeStep の inner に置き 1 TX として実行する。rollbackOn は inner で実際に発火しうる errorCode (DB_CONSTRAINT_VIOLATION) のみ列挙する。TX 外の audit step / event 発行は @txResult.committed == true でガードする。",
+      "consequences": "PASS 判定後の状態遷移が atomic になる。TX 内に外部呼出は入れない (spec §8.2 anti-pattern)。",
+      "date": "2026-04-26"
+    },
+    {
+      "id": "ADR-003",
+      "title": "WMS / 顧客通知は TX 外で fireAndForget または failure: continue",
+      "status": "accepted",
+      "context": "出荷判定後の WMS 出荷準備指示と顧客への出荷予定通知を、出荷指示 INSERT と同一 TX に入れると、外部障害で TX タイムアウトが起き shipment_orders すら登録できなくなる。",
+      "decision": "shipment_orders INSERT と traceability snapshot 記録を済ませた後、TX 外で WMS (failure: continue) と customerNotification (fireAndForget: true) を呼ぶ。WMS 失敗時は audit step で運用検知、顧客通知失敗時は別運用で再送する。",
+      "consequences": "出荷指示の DB 整合性を最優先し、外部依存はベストエフォートにする。Saga 補償までは行わない (出荷後の取消は別フロー)。",
+      "date": "2026-04-26"
+    }
+  ],
+  "ambientVariables": [
+    {
+      "name": "requestId",
+      "type": "string",
+      "required": true,
+      "description": "リクエスト単位の追跡 ID。MES コールバックの冪等キーフォールバックや audit ログ相関に使う。"
+    },
+    {
+      "name": "sessionUserId",
+      "type": "string",
+      "required": true,
+      "description": "操作したログインユーザー ID。act-002/act-003 では検査員・出荷担当者が該当。"
+    },
+    {
+      "name": "inspectorId",
+      "type": "string",
+      "required": false,
+      "description": "品質検査画面のセッションコンテキストで設定される検査員 ID。act-002 で audit / event に注入される。"
+    }
+  ],
+  "errorCatalog": {
+    "VALIDATION": {
+      "httpStatus": 400,
+      "defaultMessage": "入力値が不正です",
+      "responseRef": "400-validation"
+    },
+    "WORKORDER_NOT_FOUND": {
+      "httpStatus": 404,
+      "defaultMessage": "製造指示書が見つかりません",
+      "responseRef": "404-workorder-not-found"
+    },
+    "LOT_NOT_FOUND": {
+      "httpStatus": 404,
+      "defaultMessage": "ロットが見つかりません",
+      "responseRef": "404-lot-not-found"
+    },
+    "DUPLICATE_RECORD": {
+      "httpStatus": 200,
+      "defaultMessage": "既に処理済みです",
+      "responseRef": "200-already-processed",
+      "description": "MES コールバック再送による冪等 no-op。HTTP 200 + status: ALREADY_PROCESSED で返す。"
+    },
+    "QUALITY_HOLD": {
+      "httpStatus": 422,
+      "defaultMessage": "品質不合格のため処置が必要です",
+      "responseRef": "422-quality-hold"
+    },
+    "SHIPMENT_BLOCKED": {
+      "httpStatus": 422,
+      "defaultMessage": "出荷条件を満たしていません",
+      "responseRef": "422-shipment-blocked"
+    },
+    "INVALID_STATE_TRANSITION": {
+      "httpStatus": 409,
+      "defaultMessage": "状態遷移が不正です",
+      "responseRef": "409-invalid-state-transition"
+    },
+    "DB_CONSTRAINT_VIOLATION": {
+      "httpStatus": 409,
+      "defaultMessage": "DB 制約違反 (TX rollback)",
+      "responseRef": "409-invalid-state-transition"
+    }
+  },
+  "externalSystemCatalog": {
+    "mesSystem": {
+      "name": "Manufacturing Execution System",
+      "baseUrl": "https://mes-gateway.example.internal",
+      "auth": {
+        "kind": "bearer",
+        "tokenRef": "@secret.mesApiToken"
+      },
+      "timeoutMs": 3000,
+      "description": "製造ライン制御 MES。本フローでは MES からのコールバック (act-001) を受ける側が中心だが、補助 API として残す。"
+    },
+    "wmsSystem": {
+      "name": "Warehouse Management System",
+      "baseUrl": "https://wms-gateway.example.internal",
+      "auth": {
+        "kind": "apiKey",
+        "tokenRef": "@secret.wmsApiKey",
+        "headerName": "X-WMS-Key"
+      },
+      "timeoutMs": 5000,
+      "description": "倉庫管理システム。出荷判定後にピッキング指示を送る。"
+    },
+    "customerNotification": {
+      "name": "Customer Notification Gateway",
+      "baseUrl": "https://customer-notification.example.internal",
+      "auth": {
+        "kind": "apiKey",
+        "tokenRef": "@secret.customerNotifyApiKey",
+        "headerName": "X-API-Key"
+      },
+      "timeoutMs": 2000,
+      "description": "顧客向け通知配信ゲートウェイ。出荷予定通知に利用する。"
+    }
+  },
+  "secretsCatalog": {
+    "mesApiToken": {
+      "source": "env",
+      "name": "MES_API_TOKEN",
+      "rotationDays": 90,
+      "description": "MES 連携用 API トークン"
+    },
+    "wmsApiKey": {
+      "source": "env",
+      "name": "WMS_API_KEY",
+      "rotationDays": 180,
+      "description": "WMS 連携用 API キー"
+    },
+    "customerNotifyApiKey": {
+      "source": "env",
+      "name": "CUSTOMER_NOTIFY_API_KEY",
+      "rotationDays": 180,
+      "description": "顧客通知ゲートウェイ API キー"
+    }
+  },
+  "domainsCatalog": {
+    "WorkOrderId": {
+      "type": "string",
+      "uiHint": "text",
+      "description": "製造指示書 ID。"
+    },
+    "LotId": {
+      "type": "string",
+      "uiHint": "text",
+      "description": "製造ロット ID。"
+    },
+    "SerialNumber": {
+      "type": "string",
+      "uiHint": "text",
+      "description": "個品 (製品 1 個) ごとのシリアル番号。"
+    },
+    "QualityResult": {
+      "type": "string",
+      "uiHint": "text",
+      "description": "品質検査結果。PASS または FAIL。"
+    },
+    "TraceId": {
+      "type": "string",
+      "uiHint": "text",
+      "description": "traceability_log 行 ID。"
+    }
+  },
+  "functionsCatalog": {
+    "validateQualitySpec": {
+      "signature": "validateQualitySpec(lot: Lot, spec: string): boolean",
+      "returnType": "boolean",
+      "description": "ロット情報と品質仕様コードから、検査項目の総合合否を boolean で返す。",
+      "examples": [
+        "@fn.validateQualitySpec(@lot, @inputs.specification)"
+      ]
+    },
+    "evaluateShipmentReadiness": {
+      "signature": "evaluateShipmentReadiness(lot: Lot, inspections: Inspection[]): { ok: boolean; blockingReasons: string[] }",
+      "returnType": "object",
+      "description": "ロット状態と品質検査履歴から、出荷可否と阻害要因のリストを返す。",
+      "examples": [
+        "@fn.evaluateShipmentReadiness(@lot, @inspections)"
+      ]
+    }
+  },
+  "actions": [
+    {
+      "id": "act-001",
+      "name": "製造実績受信 (MES コールバック)",
+      "trigger": "other",
+      "description": "external trigger: MES から製造完了通知を受信し、production_records に冪等登録、work_orders を COMPLETED に遷移、traceability_log に PRODUCTION スナップショットを記録、production.completed イベントを発行する。",
+      "maturity": "committed",
+      "httpRoute": {
+        "method": "POST",
+        "path": "/internal/mes-callback/production-completed",
+        "auth": "required"
+      },
+      "requiredPermissions": ["system"],
+      "inputs": [
+        { "name": "workOrderId", "label": "製造指示書 ID", "type": { "kind": "workOrderId" }, "required": true, "domainRef": "WorkOrderId" },
+        { "name": "lotId", "label": "ロット ID", "type": { "kind": "lotId" }, "required": true, "domainRef": "LotId" },
+        { "name": "serialNumber", "label": "シリアル番号", "type": { "kind": "serialNumber" }, "required": true, "domainRef": "SerialNumber" },
+        { "name": "completedAt", "label": "製造完了日時", "type": "string", "required": true },
+        { "name": "lineId", "label": "ライン ID", "type": "string", "required": true },
+        { "name": "operatorId", "label": "ライン担当者 ID", "type": "string", "required": true }
+      ],
+      "outputs": [
+        { "name": "status", "label": "処理ステータス", "type": "string" }
+      ],
+      "responses": [
+        { "id": "200-recorded", "status": 200, "bodySchema": { "schema": { "type": "object", "required": ["status"], "properties": { "status": { "type": "string", "enum": ["RECORDED"] } }, "additionalProperties": false } }, "when": "新規製造実績として登録された" },
+        { "id": "200-already-processed", "status": 200, "bodySchema": { "schema": { "type": "object", "required": ["status"], "properties": { "status": { "type": "string", "enum": ["ALREADY_PROCESSED"] } }, "additionalProperties": false } }, "when": "同一 (lotId, serialNumber) が既に登録済みで no-op" },
+        { "id": "400-validation", "status": 400, "bodySchema": { "schema": { "type": "object" } }, "when": "入力値が不正" },
+        { "id": "404-workorder-not-found", "status": 404, "bodySchema": { "schema": { "type": "object" } }, "when": "対象 workOrder が存在しない" }
+      ],
+      "steps": [
+        {
+          "id": "step-001-01",
+          "type": "validation",
+          "description": "MES コールバック入力の必須・型・関連性を検証する。",
+          "maturity": "committed",
+          "conditions": "workOrderId/lotId/serialNumber/completedAt/lineId/operatorId は必須。",
+          "rules": [
+            { "field": "workOrderId", "type": "required", "message": "製造指示書 ID は必須です" },
+            { "field": "lotId", "type": "required", "message": "ロット ID は必須です" },
+            { "field": "serialNumber", "type": "required", "message": "シリアル番号は必須です" },
+            { "field": "completedAt", "type": "required", "message": "製造完了日時は必須です" },
+            { "field": "lineId", "type": "required", "message": "ライン ID は必須です" },
+            { "field": "operatorId", "type": "required", "message": "ライン担当者 ID は必須です" }
+          ],
+          "fieldErrorsVar": "fieldErrors",
+          "inlineBranch": {
+            "ok": "workOrder 取得へ進む",
+            "ng": "400 バリデーションエラー",
+            "ngResponseRef": "400-validation",
+            "ngBodyExpression": "{ code: 'VALIDATION', message: '入力値が不正です', fieldErrors: @fieldErrors }"
+          }
+        },
+        {
+          "id": "step-001-02",
+          "type": "dbAccess",
+          "description": "対象の work_orders を取得する。",
+          "maturity": "committed",
+          "tableName": "work_orders",
+          "operation": "SELECT",
+          "sql": "SELECT id, status, product_code, planned_qty, completed_qty FROM work_orders WHERE id = @inputs.workOrderId",
+          "outputBinding": "workOrder",
+          "lineage": { "reads": ["work_orders"] }
+        },
+        {
+          "id": "step-001-03",
+          "type": "branch",
+          "description": "work_order が存在しない場合は 404 を返す。",
+          "maturity": "committed",
+          "branches": [
+            {
+              "id": "br-001-03-a",
+              "code": "NOT_FOUND",
+              "label": "workOrder なし",
+              "condition": "@workOrder == null",
+              "steps": [
+                {
+                  "id": "step-001-03-a-01",
+                  "type": "return",
+                  "description": "404 workOrder なし。",
+                  "maturity": "committed",
+                  "responseRef": "404-workorder-not-found",
+                  "bodyExpression": "{ code: 'WORKORDER_NOT_FOUND', workOrderId: @inputs.workOrderId }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-001-03-else",
+            "code": "FOUND",
+            "label": "workOrder 取得済み",
+            "steps": []
+          }
+        },
+        {
+          "id": "step-001-04",
+          "type": "dbAccess",
+          "description": "UPSERT_IDEMPOTENT: production_records に (lotId, serialNumber) 一意で冪等登録し、既存なら no-op (RETURNING で id を返さない) にする。",
+          "maturity": "committed",
+          "tableName": "production_records",
+          "operation": "UPSERT_IDEMPOTENT",
+          "sql": "INSERT INTO production_records (lot_id, serial_number, work_order_id, line_id, operator_id, completed_at, request_id, created_at) VALUES (@inputs.lotId, @inputs.serialNumber, @inputs.workOrderId, @inputs.lineId, @inputs.operatorId, @inputs.completedAt, @requestId, NOW()) ON CONFLICT (lot_id, serial_number) DO NOTHING RETURNING id",
+          "outputBinding": "upsertedRecord",
+          "lineage": { "writes": ["production_records"] }
+        },
+        {
+          "id": "step-001-05",
+          "type": "dbAccess",
+          "description": "新規登録時のみ work_orders.completed_qty を加算し、planned_qty に達したら status を COMPLETED に更新する。冪等再送 (no-op 経路) では実行しない。",
+          "maturity": "committed",
+          "runIf": "@upsertedRecord?.id != null",
+          "tableName": "work_orders",
+          "operation": "UPDATE",
+          "sql": "UPDATE work_orders SET completed_qty = completed_qty + 1, status = CASE WHEN completed_qty + 1 >= planned_qty THEN 'COMPLETED' ELSE 'IN_PROGRESS' END, updated_at = NOW() WHERE id = @inputs.workOrderId AND status IN ('IN_PROGRESS', 'COMPLETED') RETURNING id, status",
+          "outputBinding": "updatedWorkOrder",
+          "lineage": { "writes": ["work_orders"] }
+        },
+        {
+          "id": "step-001-06",
+          "type": "manufacturing:TraceabilityStep",
+          "description": "PRODUCTION イベントとして traceability_log にスナップショットを記録する。新規登録時のみ実行。",
+          "maturity": "committed",
+          "runIf": "@upsertedRecord?.id != null",
+          "lotId": "@inputs.lotId",
+          "eventType": "PRODUCTION",
+          "operatorId": "@inputs.operatorId",
+          "metadata": {
+            "workOrderId": "@inputs.workOrderId",
+            "serialNumber": "@inputs.serialNumber",
+            "lineId": "@inputs.lineId"
+          }
+        },
+        {
+          "id": "step-001-07",
+          "type": "eventPublish",
+          "description": "production.completed イベントを発行する。新規登録時のみ。",
+          "maturity": "committed",
+          "runIf": "@upsertedRecord?.id != null",
+          "topic": "production.completed",
+          "eventRef": "production.completed",
+          "payload": "{ workOrderId: @inputs.workOrderId, lotId: @inputs.lotId, serialNumber: @inputs.serialNumber, completedAt: @inputs.completedAt, lineId: @inputs.lineId }"
+        },
+        {
+          "id": "step-001-08",
+          "type": "eventPublish",
+          "description": "traceability.recorded イベントを発行する。新規登録時のみ。",
+          "maturity": "committed",
+          "runIf": "@upsertedRecord?.id != null",
+          "topic": "traceability.recorded",
+          "eventRef": "traceability.recorded",
+          "payload": "{ lotId: @inputs.lotId, eventType: 'PRODUCTION', operatorId: @inputs.operatorId }"
+        },
+        {
+          "id": "step-001-09",
+          "type": "return",
+          "description": "新規登録経路: 200 RECORDED を返す。",
+          "maturity": "committed",
+          "runIf": "@upsertedRecord?.id != null",
+          "responseRef": "200-recorded",
+          "bodyExpression": "{ status: 'RECORDED' }"
+        },
+        {
+          "id": "step-001-10",
+          "type": "return",
+          "description": "冪等 no-op 経路: 200 ALREADY_PROCESSED を返す。MES 再送・運用再送に対する規約レスポンス。",
+          "maturity": "committed",
+          "runIf": "@upsertedRecord?.id == null",
+          "responseRef": "200-already-processed",
+          "bodyExpression": "{ status: 'ALREADY_PROCESSED' }"
+        }
+      ]
+    },
+    {
+      "id": "act-002",
+      "name": "品質検査 (PASS/FAIL 判定 + 規格外品処置)",
+      "trigger": "submit",
+      "description": "検査員が画面から品質検査結果を提出し、PASS なら lots/work_orders を 1 TX で状態遷移、FAIL なら廃棄/再加工/特別採用の処置を確定する。",
+      "maturity": "committed",
+      "httpRoute": {
+        "method": "POST",
+        "path": "/api/quality/inspect",
+        "auth": "required"
+      },
+      "inputs": [
+        { "name": "lotId", "label": "ロット ID", "type": { "kind": "lotId" }, "required": true, "domainRef": "LotId" },
+        { "name": "inspectionItems", "label": "検査項目の結果", "type": { "kind": "array", "itemType": "string" }, "required": true, "description": "各検査項目を JSON 文字列または structured object として配列で受ける (例: [{ item, result, comment }])" },
+        { "name": "overallResult", "label": "総合判定", "type": "string", "required": true },
+        { "name": "disposition", "label": "FAIL 時の処置 (SCRAP/REWORK/SPECIAL_APPROVAL)", "type": "string", "required": false },
+        { "name": "inspectorId", "label": "検査員 ID", "type": "string", "required": true },
+        { "name": "comment", "label": "コメント", "type": "string", "required": false }
+      ],
+      "outputs": [
+        { "name": "lotId", "label": "ロット ID", "type": "string", "domainRef": "LotId" },
+        { "name": "verdict", "label": "判定結果", "type": "string", "domainRef": "QualityResult" },
+        { "name": "nextAction", "label": "次アクション", "type": "string" }
+      ],
+      "responses": [
+        { "id": "200-pass", "status": 200, "bodySchema": { "schema": { "type": "object", "required": ["lotId", "verdict"], "properties": { "lotId": { "type": "string" }, "verdict": { "type": "string" }, "nextAction": { "type": "string" } }, "additionalProperties": false } }, "when": "品質合格 + lots/work_orders 状態遷移完了" },
+        { "id": "400-validation", "status": 400, "bodySchema": { "schema": { "type": "object" } }, "when": "入力値が不正" },
+        { "id": "404-lot-not-found", "status": 404, "bodySchema": { "schema": { "type": "object" } }, "when": "ロットが存在しない" },
+        { "id": "409-invalid-state-transition", "status": 409, "bodySchema": { "schema": { "type": "object" } }, "when": "TX commit 失敗 (DB 制約違反等)" },
+        { "id": "422-quality-hold", "status": 422, "bodySchema": { "schema": { "type": "object", "required": ["lotId", "verdict", "disposition"], "properties": { "lotId": { "type": "string" }, "verdict": { "type": "string" }, "disposition": { "type": "string" } }, "additionalProperties": false } }, "when": "品質不合格" }
+      ],
+      "steps": [
+        {
+          "id": "step-002-01",
+          "type": "validation",
+          "description": "品質検査入力を検証する。FAIL の場合は disposition が必須。",
+          "maturity": "committed",
+          "conditions": "lotId/overallResult/inspectorId は必須。overallResult は PASS または FAIL。FAIL の場合は disposition が SCRAP/REWORK/SPECIAL_APPROVAL のいずれか。",
+          "rules": [
+            { "field": "lotId", "type": "required", "message": "ロット ID は必須です" },
+            { "field": "overallResult", "type": "enum", "values": ["PASS", "FAIL"], "message": "総合判定は PASS または FAIL です" },
+            { "field": "inspectorId", "type": "required", "message": "検査員 ID は必須です" },
+            { "field": "disposition", "type": "required", "condition": "@inputs.overallResult == 'FAIL'", "message": "FAIL の場合は処置 (disposition) が必須です" },
+            { "field": "disposition", "type": "enum", "condition": "@inputs.overallResult == 'FAIL'", "values": ["SCRAP", "REWORK", "SPECIAL_APPROVAL"], "message": "処置は SCRAP/REWORK/SPECIAL_APPROVAL のいずれかです" }
+          ],
+          "fieldErrorsVar": "fieldErrors",
+          "inlineBranch": {
+            "ok": "ロット取得へ進む",
+            "ng": "400 バリデーションエラー",
+            "ngResponseRef": "400-validation",
+            "ngBodyExpression": "{ code: 'VALIDATION', message: '入力値が不正です', fieldErrors: @fieldErrors }"
+          }
+        },
+        {
+          "id": "step-002-02",
+          "type": "dbAccess",
+          "description": "対象 lot を取得する。",
+          "maturity": "committed",
+          "tableName": "lots",
+          "operation": "SELECT",
+          "sql": "SELECT id, work_order_id, status, product_code FROM lots WHERE id = @inputs.lotId",
+          "outputBinding": "lot",
+          "lineage": { "reads": ["lots"] }
+        },
+        {
+          "id": "step-002-03",
+          "type": "branch",
+          "description": "lot が存在しない場合は 404 を返す。",
+          "maturity": "committed",
+          "branches": [
+            {
+              "id": "br-002-03-a",
+              "code": "NOT_FOUND",
+              "label": "ロットなし",
+              "condition": "@lot == null",
+              "steps": [
+                {
+                  "id": "step-002-03-a-01",
+                  "type": "return",
+                  "description": "404 ロットなし。",
+                  "maturity": "committed",
+                  "responseRef": "404-lot-not-found",
+                  "bodyExpression": "{ code: 'LOT_NOT_FOUND', lotId: @inputs.lotId }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-002-03-else",
+            "code": "FOUND",
+            "label": "ロット取得済み",
+            "steps": []
+          }
+        },
+        {
+          "id": "step-002-04",
+          "type": "manufacturing:QualityCheckStep",
+          "description": "品質仕様を ambient コンテキストから引いて、検査項目との総合適合性を補助計算する。",
+          "maturity": "committed",
+          "lotId": "@inputs.lotId",
+          "specification": "@lot.product_code",
+          "inspectionItems": "@inputs.inspectionItems",
+          "outputBinding": "qualityCheck"
+        },
+        {
+          "id": "step-002-05",
+          "type": "branch",
+          "description": "総合判定により PASS / FAIL に分岐する。",
+          "maturity": "committed",
+          "branches": [
+            {
+              "id": "br-002-05-a",
+              "code": "PASS",
+              "label": "品質合格",
+              "condition": "@inputs.overallResult == 'PASS'",
+              "steps": [
+                {
+                  "id": "step-002-05-a-01",
+                  "type": "transactionScope",
+                  "description": "PASS 経路: quality_inspections INSERT + lots を INSPECTED_PASS に + 関連 work_orders を READY_FOR_SHIPMENT に、を 1 TX で実行する。inner step は @lot / @inputs / @qualityCheck の TX 外変数のみ参照する。",
+                  "maturity": "committed",
+                  "isolationLevel": "READ_COMMITTED",
+                  "propagation": "REQUIRED",
+                  "outputBinding": "txResult",
+                  "rollbackOn": ["DB_CONSTRAINT_VIOLATION"],
+                  "steps": [
+                    {
+                      "id": "step-002-05-a-01-01",
+                      "type": "dbAccess",
+                      "description": "quality_inspections に検査結果を登録する。",
+                      "maturity": "committed",
+                      "tableName": "quality_inspections",
+                      "operation": "INSERT",
+                      "sql": "INSERT INTO quality_inspections (lot_id, inspector_id, overall_result, inspection_items, inspected_at, comment) VALUES (@inputs.lotId, @inputs.inspectorId, 'PASS', @inputs.inspectionItems, NOW(), @inputs.comment) RETURNING id",
+                      "outputBinding": "inspection",
+                      "lineage": { "writes": ["quality_inspections"] }
+                    },
+                    {
+                      "id": "step-002-05-a-01-02",
+                      "type": "dbAccess",
+                      "description": "lot を INSPECTED_PASS に状態遷移させる。affectedRowsCheck で前提状態違反を検知する。",
+                      "maturity": "committed",
+                      "tableName": "lots",
+                      "operation": "UPDATE",
+                      "sql": "UPDATE lots SET status = 'INSPECTED_PASS', inspected_at = NOW(), updated_at = NOW() WHERE id = @inputs.lotId AND status IN ('IN_INSPECTION', 'PRODUCED') RETURNING id, status",
+                      "outputBinding": "updatedLot",
+                      "lineage": { "writes": ["lots"] },
+                      "affectedRowsCheck": {
+                        "operator": ">",
+                        "expected": 0,
+                        "onViolation": "throw",
+                        "errorCode": "DB_CONSTRAINT_VIOLATION",
+                        "description": "lot の前提状態 (IN_INSPECTION/PRODUCED) を満たさない場合に rollback"
+                      }
+                    },
+                    {
+                      "id": "step-002-05-a-01-03",
+                      "type": "dbAccess",
+                      "description": "関連 work_orders を READY_FOR_SHIPMENT に状態遷移させる。",
+                      "maturity": "committed",
+                      "tableName": "work_orders",
+                      "operation": "UPDATE",
+                      "sql": "UPDATE work_orders SET status = 'READY_FOR_SHIPMENT', updated_at = NOW() WHERE id = @lot.work_order_id AND status = 'COMPLETED' RETURNING id, status",
+                      "outputBinding": "updatedWorkOrder",
+                      "lineage": { "writes": ["work_orders"] }
+                    }
+                  ]
+                },
+                {
+                  "id": "step-002-05-a-02",
+                  "type": "return",
+                  "description": "TX commit 失敗 (DB_CONSTRAINT_VIOLATION rollback) 時に 409 を返す。",
+                  "maturity": "committed",
+                  "runIf": "@txResult.committed == false",
+                  "responseRef": "409-invalid-state-transition",
+                  "bodyExpression": "{ code: 'INVALID_STATE_TRANSITION', message: 'TX commit failed (lot status mismatch)', lotId: @inputs.lotId }"
+                },
+                {
+                  "id": "step-002-05-a-03",
+                  "type": "audit",
+                  "description": "PASS 判定を監査ログに記録する。TX 成功時のみ。",
+                  "maturity": "committed",
+                  "runIf": "@txResult.committed == true",
+                  "action": "quality.inspection",
+                  "resource": { "type": "Lot", "id": "@inputs.lotId" },
+                  "result": "success",
+                  "reason": "PASS",
+                  "sensitive": false
+                },
+                {
+                  "id": "step-002-05-a-04",
+                  "type": "eventPublish",
+                  "description": "quality.inspected イベントを発行する。TX 成功時のみ。",
+                  "maturity": "committed",
+                  "runIf": "@txResult.committed == true",
+                  "topic": "quality.inspected",
+                  "eventRef": "quality.inspected",
+                  "payload": "{ lotId: @inputs.lotId, verdict: 'PASS', inspectorId: @inputs.inspectorId, inspectedAt: @updatedLot.status }"
+                },
+                {
+                  "id": "step-002-05-a-05",
+                  "type": "return",
+                  "description": "200 PASS を返す。TX 成功時のみ。",
+                  "maturity": "committed",
+                  "runIf": "@txResult.committed == true",
+                  "responseRef": "200-pass",
+                  "bodyExpression": "{ lotId: @inputs.lotId, verdict: 'PASS', nextAction: 'shipment-evaluation' }"
+                }
+              ]
+            },
+            {
+              "id": "br-002-05-b",
+              "code": "FAIL",
+              "label": "品質不合格 (処置決定)",
+              "condition": "@inputs.overallResult == 'FAIL'",
+              "steps": [
+                {
+                  "id": "step-002-05-b-01",
+                  "type": "dbAccess",
+                  "description": "quality_inspections に FAIL 結果を登録する。",
+                  "maturity": "committed",
+                  "tableName": "quality_inspections",
+                  "operation": "INSERT",
+                  "sql": "INSERT INTO quality_inspections (lot_id, inspector_id, overall_result, inspection_items, disposition, inspected_at, comment) VALUES (@inputs.lotId, @inputs.inspectorId, 'FAIL', @inputs.inspectionItems, @inputs.disposition, NOW(), @inputs.comment) RETURNING id",
+                  "outputBinding": "failInspection",
+                  "lineage": { "writes": ["quality_inspections"] }
+                },
+                {
+                  "id": "step-002-05-b-02",
+                  "type": "branch",
+                  "description": "処置 (SCRAP/REWORK/SPECIAL_APPROVAL) により lot 状態を分岐遷移する。",
+                  "maturity": "committed",
+                  "branches": [
+                    {
+                      "id": "br-002-05-b-02-a",
+                      "code": "SCRAP",
+                      "label": "廃棄",
+                      "condition": "@inputs.disposition == 'SCRAP'",
+                      "steps": [
+                        {
+                          "id": "step-002-05-b-02-a-01",
+                          "type": "dbAccess",
+                          "description": "lot を BLOCKED に遷移させる (廃棄処置)。",
+                          "maturity": "committed",
+                          "tableName": "lots",
+                          "operation": "UPDATE",
+                          "sql": "UPDATE lots SET status = 'BLOCKED', disposition = 'SCRAP', updated_at = NOW() WHERE id = @inputs.lotId RETURNING id, status",
+                          "outputBinding": "scrappedLot",
+                          "lineage": { "writes": ["lots"] }
+                        }
+                      ]
+                    },
+                    {
+                      "id": "br-002-05-b-02-b",
+                      "code": "REWORK",
+                      "label": "再加工",
+                      "condition": "@inputs.disposition == 'REWORK'",
+                      "steps": [
+                        {
+                          "id": "step-002-05-b-02-b-01",
+                          "type": "dbAccess",
+                          "description": "lot を REWORK_PENDING に遷移させる (再加工処置)。",
+                          "maturity": "committed",
+                          "tableName": "lots",
+                          "operation": "UPDATE",
+                          "sql": "UPDATE lots SET status = 'REWORK_PENDING', disposition = 'REWORK', updated_at = NOW() WHERE id = @inputs.lotId RETURNING id, status",
+                          "outputBinding": "reworkLot",
+                          "lineage": { "writes": ["lots"] }
+                        }
+                      ]
+                    },
+                    {
+                      "id": "br-002-05-b-02-c",
+                      "code": "SPECIAL_APPROVAL",
+                      "label": "特別採用",
+                      "condition": "@inputs.disposition == 'SPECIAL_APPROVAL'",
+                      "steps": [
+                        {
+                          "id": "step-002-05-b-02-c-01",
+                          "type": "dbAccess",
+                          "description": "lot を SPECIAL_APPROVED に遷移させる (特別採用)。",
+                          "maturity": "committed",
+                          "tableName": "lots",
+                          "operation": "UPDATE",
+                          "sql": "UPDATE lots SET status = 'SPECIAL_APPROVED', disposition = 'SPECIAL_APPROVAL', updated_at = NOW() WHERE id = @inputs.lotId RETURNING id, status",
+                          "outputBinding": "specialApprovedLot",
+                          "lineage": { "writes": ["lots"] }
+                        }
+                      ]
+                    }
+                  ],
+                  "elseBranch": {
+                    "id": "br-002-05-b-02-else",
+                    "code": "OTHER",
+                    "label": "想定外 (validator 通過後の防御)",
+                    "steps": []
+                  }
+                },
+                {
+                  "id": "step-002-05-b-03",
+                  "type": "audit",
+                  "description": "FAIL 判定と処置を監査ログに記録する。特別採用は要詳細記録 (sensitive)。",
+                  "maturity": "committed",
+                  "action": "quality.inspection",
+                  "resource": { "type": "Lot", "id": "@inputs.lotId" },
+                  "result": "success",
+                  "reason": "FAIL",
+                  "sensitive": true
+                },
+                {
+                  "id": "step-002-05-b-04",
+                  "type": "eventPublish",
+                  "description": "quality.failed イベントを処置種別とともに発行する。",
+                  "maturity": "committed",
+                  "topic": "quality.failed",
+                  "eventRef": "quality.failed",
+                  "payload": "{ lotId: @inputs.lotId, verdict: 'FAIL', disposition: @inputs.disposition, inspectorId: @inputs.inspectorId }"
+                },
+                {
+                  "id": "step-002-05-b-05",
+                  "type": "return",
+                  "description": "422 QUALITY_HOLD を返す。",
+                  "maturity": "committed",
+                  "responseRef": "422-quality-hold",
+                  "bodyExpression": "{ code: 'QUALITY_HOLD', lotId: @inputs.lotId, verdict: 'FAIL', disposition: @inputs.disposition }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-002-05-else",
+            "code": "INVALID",
+            "label": "overallResult が PASS/FAIL 以外 (validator 通過後の防御)",
+            "steps": [
+              {
+                "id": "step-002-05-else-01",
+                "type": "return",
+                "description": "validator を通過した想定外の値が来た場合 400 を返す。",
+                "maturity": "committed",
+                "responseRef": "400-validation",
+                "bodyExpression": "{ code: 'VALIDATION', message: 'overallResult must be PASS or FAIL' }"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "act-003",
+      "name": "出荷可否判定 (品質合格後の連鎖起動)",
+      "trigger": "auto",
+      "description": "品質検査 PASS 後に連鎖起動される出荷可否判定。lots と quality_inspections を突合して出荷条件を確認し、shipment_orders を発行、WMS にピッキング指示、顧客へ出荷予定通知を送る。WMS / 顧客通知は TX 外で best-effort。",
+      "maturity": "committed",
+      "httpRoute": {
+        "method": "POST",
+        "path": "/internal/shipment/evaluate-readiness",
+        "auth": "required"
+      },
+      "requiredPermissions": ["system"],
+      "inputs": [
+        { "name": "lotId", "label": "ロット ID", "type": { "kind": "lotId" }, "required": true, "domainRef": "LotId" }
+      ],
+      "outputs": [
+        { "name": "lotId", "label": "ロット ID", "type": "string", "domainRef": "LotId" },
+        { "name": "shipmentApproved", "label": "出荷可否", "type": "boolean" },
+        { "name": "blockingReasons", "label": "阻害要因", "type": { "kind": "array", "itemType": "string" } }
+      ],
+      "responses": [
+        { "id": "200-approved", "status": 200, "bodySchema": { "schema": { "type": "object", "required": ["lotId", "shipmentApproved"], "properties": { "lotId": { "type": "string" }, "shipmentApproved": { "type": "boolean" }, "shipmentOrderId": { "type": "string" } }, "additionalProperties": false } }, "when": "出荷条件を満たし shipment_orders 登録完了" },
+        { "id": "400-validation", "status": 400, "bodySchema": { "schema": { "type": "object" } }, "when": "入力値が不正" },
+        { "id": "404-lot-not-found", "status": 404, "bodySchema": { "schema": { "type": "object" } }, "when": "ロットが存在しない" },
+        { "id": "422-shipment-blocked", "status": 422, "bodySchema": { "schema": { "type": "object", "required": ["lotId", "blockingReasons"], "properties": { "lotId": { "type": "string" }, "blockingReasons": { "type": "array", "items": { "type": "string" } } }, "additionalProperties": false } }, "when": "出荷条件不満足" }
+      ],
+      "steps": [
+        {
+          "id": "step-003-01",
+          "type": "validation",
+          "description": "lotId 必須を検証する。",
+          "maturity": "committed",
+          "conditions": "lotId は必須。",
+          "rules": [
+            { "field": "lotId", "type": "required", "message": "ロット ID は必須です" }
+          ],
+          "fieldErrorsVar": "fieldErrors",
+          "inlineBranch": {
+            "ok": "ロット取得へ進む",
+            "ng": "400 バリデーションエラー",
+            "ngResponseRef": "400-validation",
+            "ngBodyExpression": "{ code: 'VALIDATION', message: '入力値が不正です', fieldErrors: @fieldErrors }"
+          }
+        },
+        {
+          "id": "step-003-02",
+          "type": "dbAccess",
+          "description": "lot 詳細と関連 quality_inspections を取得する。",
+          "maturity": "committed",
+          "tableName": "lots",
+          "operation": "SELECT",
+          "sql": "SELECT l.id, l.status, l.product_code, l.work_order_id, l.customer_requirement_code, json_agg(qi.*) AS inspections FROM lots l LEFT JOIN quality_inspections qi ON qi.lot_id = l.id WHERE l.id = @inputs.lotId GROUP BY l.id",
+          "outputBinding": "lotWithInspections",
+          "lineage": { "reads": ["lots", "quality_inspections"] }
+        },
+        {
+          "id": "step-003-03",
+          "type": "branch",
+          "description": "lot が存在しない場合は 404 を返す。",
+          "maturity": "committed",
+          "branches": [
+            {
+              "id": "br-003-03-a",
+              "code": "NOT_FOUND",
+              "label": "ロットなし",
+              "condition": "@lotWithInspections == null",
+              "steps": [
+                {
+                  "id": "step-003-03-a-01",
+                  "type": "return",
+                  "description": "404 ロットなし。",
+                  "maturity": "committed",
+                  "responseRef": "404-lot-not-found",
+                  "bodyExpression": "{ code: 'LOT_NOT_FOUND', lotId: @inputs.lotId }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-003-03-else",
+            "code": "FOUND",
+            "label": "ロット取得済み",
+            "steps": []
+          }
+        },
+        {
+          "id": "step-003-04",
+          "type": "compute",
+          "description": "@fn.evaluateShipmentReadiness で出荷条件 (品質合格 / 規制要件 / 顧客指定要件) を判定する。",
+          "maturity": "committed",
+          "expression": "@fn.evaluateShipmentReadiness(@lotWithInspections, @lotWithInspections.inspections)",
+          "outputBinding": "readiness"
+        },
+        {
+          "id": "step-003-05",
+          "type": "branch",
+          "description": "出荷条件を満たさない場合は 422 を返す。",
+          "maturity": "committed",
+          "branches": [
+            {
+              "id": "br-003-05-a",
+              "code": "BLOCKED",
+              "label": "出荷不可",
+              "condition": "@readiness.ok == false",
+              "steps": [
+                {
+                  "id": "step-003-05-a-01",
+                  "type": "audit",
+                  "description": "出荷ブロックを監査ログに記録する。",
+                  "maturity": "committed",
+                  "action": "shipment.evaluate",
+                  "resource": { "type": "Lot", "id": "@inputs.lotId" },
+                  "result": "failure",
+                  "reason": "SHIPMENT_BLOCKED",
+                  "sensitive": false
+                },
+                {
+                  "id": "step-003-05-a-02",
+                  "type": "return",
+                  "description": "422 SHIPMENT_BLOCKED を阻害要因リストとともに返す。",
+                  "maturity": "committed",
+                  "responseRef": "422-shipment-blocked",
+                  "bodyExpression": "{ code: 'SHIPMENT_BLOCKED', lotId: @inputs.lotId, blockingReasons: @readiness.blockingReasons }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-003-05-else",
+            "code": "READY",
+            "label": "出荷条件満足",
+            "steps": []
+          }
+        },
+        {
+          "id": "step-003-06",
+          "type": "dbAccess",
+          "description": "shipment_orders に新規出荷指示を登録する。",
+          "maturity": "committed",
+          "tableName": "shipment_orders",
+          "operation": "INSERT",
+          "sql": "INSERT INTO shipment_orders (lot_id, work_order_id, status, planned_ship_at, requested_by, created_at) VALUES (@inputs.lotId, @lotWithInspections.work_order_id, 'PLANNED', NOW() + INTERVAL '1 day', @sessionUserId, NOW()) RETURNING id",
+          "outputBinding": "shipmentOrder",
+          "lineage": { "writes": ["shipment_orders"] }
+        },
+        {
+          "id": "step-003-07",
+          "type": "manufacturing:TraceabilityStep",
+          "description": "SHIPMENT イベントとして出荷時 traceability snapshot を記録する。",
+          "maturity": "committed",
+          "lotId": "@inputs.lotId",
+          "eventType": "SHIPMENT",
+          "operatorId": "@sessionUserId",
+          "metadata": {
+            "shipmentOrderId": "@shipmentOrder.id",
+            "workOrderId": "@lotWithInspections.work_order_id"
+          }
+        },
+        {
+          "id": "step-003-08",
+          "type": "externalSystem",
+          "description": "WMS にピッキング指示を送る。TX 外なので失敗時は continue + audit で運用検知する (Saga 補償までは行わない)。",
+          "maturity": "committed",
+          "systemName": "Warehouse Management System",
+          "systemRef": "wmsSystem",
+          "httpCall": {
+            "method": "POST",
+            "path": "/v1/picking-orders",
+            "body": "{ shipmentOrderId: @shipmentOrder.id, lotId: @inputs.lotId, workOrderId: @lotWithInspections.work_order_id }"
+          },
+          "idempotencyKey": "wms-pick-@shipmentOrder.id",
+          "outputBinding": "wmsResult",
+          "outcomes": {
+            "success": { "action": "continue" },
+            "failure": {
+              "action": "continue",
+              "sideEffects": [
+                {
+                  "id": "step-003-08-side-01",
+                  "type": "audit",
+                  "description": "WMS 連携失敗を監査ログに記録する (運用検知用)。",
+                  "maturity": "committed",
+                  "action": "wms.picking-order",
+                  "resource": { "type": "ShipmentOrder", "id": "@shipmentOrder.id" },
+                  "result": "failure",
+                  "reason": "WMS_UNAVAILABLE",
+                  "sensitive": false
+                }
+              ]
+            },
+            "timeout": { "action": "continue", "sameAs": "failure" }
+          }
+        },
+        {
+          "id": "step-003-09",
+          "type": "externalSystem",
+          "description": "顧客へ出荷予定通知を送る (fireAndForget、failure: continue)。通知未達は別運用で再送する。",
+          "maturity": "committed",
+          "systemName": "Customer Notification Gateway",
+          "systemRef": "customerNotification",
+          "httpCall": {
+            "method": "POST",
+            "path": "/notifications/shipment-planned",
+            "body": "{ shipmentOrderId: @shipmentOrder.id, lotId: @inputs.lotId, plannedShipAt: '@shipmentOrder.planned_ship_at' }"
+          },
+          "fireAndForget": true,
+          "outcomes": {
+            "success": { "action": "continue" },
+            "failure": { "action": "continue" },
+            "timeout": { "action": "continue", "sameAs": "failure" }
+          }
+        },
+        {
+          "id": "step-003-10",
+          "type": "eventPublish",
+          "description": "shipment.approved イベントを発行する。",
+          "maturity": "committed",
+          "topic": "shipment.approved",
+          "eventRef": "shipment.approved",
+          "payload": "{ lotId: @inputs.lotId, shipmentOrderId: @shipmentOrder.id, approvedAt: NOW() }"
+        },
+        {
+          "id": "step-003-11",
+          "type": "eventPublish",
+          "description": "traceability.recorded イベントを発行する。",
+          "maturity": "committed",
+          "topic": "traceability.recorded",
+          "eventRef": "traceability.recorded",
+          "payload": "{ lotId: @inputs.lotId, eventType: 'SHIPMENT', operatorId: @sessionUserId }"
+        },
+        {
+          "id": "step-003-12",
+          "type": "return",
+          "description": "200 出荷承認を返す。",
+          "maturity": "committed",
+          "responseRef": "200-approved",
+          "bodyExpression": "{ lotId: @inputs.lotId, shipmentApproved: true, shipmentOrderId: @shipmentOrder.id }"
+        }
+      ]
+    }
+  ],
+  "testScenarios": [
+    {
+      "id": "happy-production-recorded",
+      "name": "製造実績受信→品質合格→出荷判定の連続通過",
+      "description": "MES から製造完了通知を受信し、新規 production_records が登録された後、品質検査 PASS で lots が INSPECTED_PASS、出荷判定で shipment_orders が登録される。",
+      "given": [
+        { "kind": "clock", "now": "2026-04-26T10:00:00.000Z" },
+        { "kind": "sessionContext", "context": { "sessionUserId": "ship-001", "requestId": "req-480-happy", "inspectorId": "insp-101" } },
+        { "kind": "dbState", "table": "work_orders", "rows": [ { "id": "WO-480-001", "status": "IN_PROGRESS", "product_code": "PRD-A", "planned_qty": 1, "completed_qty": 0 } ] },
+        { "kind": "dbState", "table": "lots", "rows": [ { "id": "LOT-480-001", "work_order_id": "WO-480-001", "status": "PRODUCED", "product_code": "PRD-A", "customer_requirement_code": "CR-A" } ] },
+        { "kind": "externalStub", "externalRef": "wmsSystem", "responseMock": { "status": 202, "body": { "accepted": true } } },
+        { "kind": "externalStub", "externalRef": "customerNotification", "responseMock": { "status": 202, "body": { "accepted": true } } }
+      ],
+      "when": {
+        "actionId": "act-001",
+        "input": {
+          "workOrderId": "WO-480-001",
+          "lotId": "LOT-480-001",
+          "serialNumber": "SN-480-001",
+          "completedAt": "2026-04-26T09:55:00.000Z",
+          "lineId": "LINE-1",
+          "operatorId": "op-201"
+        }
+      },
+      "then": [
+        { "kind": "outcome", "expected": "200-recorded" },
+        { "kind": "output", "path": "$.status", "equals": "RECORDED" },
+        { "kind": "dbRow", "table": "production_records", "match": { "lot_id": "LOT-480-001", "serial_number": "SN-480-001" }, "count": 1 }
+      ],
+      "tags": ["happy", "production", "callback"]
+    },
+    {
+      "id": "idempotent-mes-callback",
+      "name": "同一 (lotId, serialNumber) の MES 再送は no-op になる",
+      "description": "既に production_records に登録済みの (lotId, serialNumber) で再受信しても、UPSERT_IDEMPOTENT で no-op になり ALREADY_PROCESSED が返る。production_records は 1 行のままで work_orders.completed_qty は加算されない。",
+      "given": [
+        { "kind": "clock", "now": "2026-04-26T10:05:00.000Z" },
+        { "kind": "sessionContext", "context": { "sessionUserId": "mes-system", "requestId": "req-480-idempotent" } },
+        { "kind": "dbState", "table": "work_orders", "rows": [ { "id": "WO-480-002", "status": "IN_PROGRESS", "product_code": "PRD-A", "planned_qty": 1, "completed_qty": 1 } ] },
+        { "kind": "dbState", "table": "production_records", "rows": [ { "lot_id": "LOT-480-002", "serial_number": "SN-480-002", "work_order_id": "WO-480-002", "line_id": "LINE-1", "operator_id": "op-202", "completed_at": "2026-04-26T09:30:00.000Z" } ] }
+      ],
+      "when": {
+        "actionId": "act-001",
+        "input": {
+          "workOrderId": "WO-480-002",
+          "lotId": "LOT-480-002",
+          "serialNumber": "SN-480-002",
+          "completedAt": "2026-04-26T09:30:00.000Z",
+          "lineId": "LINE-1",
+          "operatorId": "op-202"
+        }
+      },
+      "then": [
+        { "kind": "outcome", "expected": "200-already-processed" },
+        { "kind": "output", "path": "$.status", "equals": "ALREADY_PROCESSED" },
+        { "kind": "dbRow", "table": "production_records", "match": { "lot_id": "LOT-480-002", "serial_number": "SN-480-002" }, "count": 1 },
+        { "kind": "dbRow", "table": "work_orders", "match": { "id": "WO-480-002", "completed_qty": 1 }, "count": 1 }
+      ],
+      "tags": ["idempotency", "callback", "mes"]
+    },
+    {
+      "id": "quality-failed-rework",
+      "name": "品質不合格 + 再加工処置で 422 を返す",
+      "description": "総合判定 FAIL + disposition=REWORK で品質検査を提出すると、quality_inspections に FAIL 記録、lots を REWORK_PENDING に遷移、422 QUALITY_HOLD を返す。",
+      "given": [
+        { "kind": "clock", "now": "2026-04-26T11:00:00.000Z" },
+        { "kind": "sessionContext", "context": { "sessionUserId": "insp-101", "requestId": "req-480-fail-rework", "inspectorId": "insp-101" } },
+        { "kind": "dbState", "table": "lots", "rows": [ { "id": "LOT-480-003", "work_order_id": "WO-480-003", "status": "IN_INSPECTION", "product_code": "PRD-B" } ] }
+      ],
+      "when": {
+        "actionId": "act-002",
+        "input": {
+          "lotId": "LOT-480-003",
+          "inspectionItems": [ { "item": "外観", "result": "FAIL", "comment": "傷あり" } ],
+          "overallResult": "FAIL",
+          "disposition": "REWORK",
+          "inspectorId": "insp-101",
+          "comment": "再加工へ"
+        }
+      },
+      "then": [
+        { "kind": "outcome", "expected": "422-quality-hold" },
+        { "kind": "output", "path": "$.disposition", "equals": "REWORK" },
+        { "kind": "dbRow", "table": "lots", "match": { "id": "LOT-480-003", "status": "REWORK_PENDING" }, "count": 1 }
+      ],
+      "tags": ["error", "quality", "fail", "rework"]
+    },
+    {
+      "id": "quality-pass-tx-rollback",
+      "name": "品質 PASS だが lot 前提状態違反で TX rollback、409 が返る",
+      "description": "lots が CLOSED 状態の場合、UPDATE の affectedRowsCheck (operator: '>', expected: 0) が違反し DB_CONSTRAINT_VIOLATION を throw、TX rollback で 409 INVALID_STATE_TRANSITION を返す。",
+      "given": [
+        { "kind": "clock", "now": "2026-04-26T11:30:00.000Z" },
+        { "kind": "sessionContext", "context": { "sessionUserId": "insp-102", "requestId": "req-480-tx-rollback", "inspectorId": "insp-102" } },
+        { "kind": "dbState", "table": "lots", "rows": [ { "id": "LOT-480-004", "work_order_id": "WO-480-004", "status": "CLOSED", "product_code": "PRD-A" } ] }
+      ],
+      "when": {
+        "actionId": "act-002",
+        "input": {
+          "lotId": "LOT-480-004",
+          "inspectionItems": [ { "item": "外観", "result": "PASS" } ],
+          "overallResult": "PASS",
+          "inspectorId": "insp-102"
+        }
+      },
+      "then": [
+        { "kind": "outcome", "expected": "409-invalid-state-transition" },
+        { "kind": "dbRow", "table": "lots", "match": { "id": "LOT-480-004", "status": "CLOSED" }, "count": 1 }
+      ],
+      "tags": ["error", "tx", "rollback"]
+    }
+  ],
+  "createdAt": "2026-04-26T00:00:00.000Z",
+  "updatedAt": "2026-04-26T00:00:00.000Z"
+}


### PR DESCRIPTION
## Summary

- 親メタ #478 の再ドッグフード子 ISSUE #480 (Opus 担当) を実装。3 アクション構成 (製造実績受信 / 品質検査 / 出荷可否判定) のサンプルフローと、`manufacturing` namespace の追加拡張を投入。
- spec §8 (TransactionScope) / §13 (ランタイム規約) / §15 (拡張参照) を意識した実装。`@upsertedRecord?.id` の null-safe 表現、`@txResult.committed` ガード、`rollbackOn` の発火可能性精査を反映済み。
- シナリオ #1 (#479 Sonnet 担当) と並列実装中であり、`manufacturing/` 拡張の lotId/workOrderId/partNumber 等は本 PR で先行定義した。最終マージ時に #479 と差分統合する。

Closes #480

## 仕様逐条突合 (自己申告)

### spec §8 TransactionScope
- §8.1 inner 変数の TX 外参照: `docs/sample-project/process-flows/eeeeeeee-0002-4000-8000-eeeeeeeeeeee.json:606` (`@updatedLot.status`) — TX 内 outputBinding 変数を直接参照、`@txResult.x.y` ネスト形式は未使用。
- §8.2 外部呼出を TX 外に: 同 `:567-636` (TX inner は `quality_inspections INSERT` / `lots UPDATE` / `work_orders UPDATE` の 3 DB 操作のみ)。WMS / customerNotification は act-003 内で TX 外配置 (`:889-936`)。
- §8.3 TX rollback ガード: `:618` (`runIf: "@txResult.committed == false"` で 409 return)、`:626/:638/:649` (`runIf: "@txResult.committed == true"` で audit/event/return)。
- §8.4 rollbackOn の発火可能性: `:574` (`"rollbackOn": ["DB_CONSTRAINT_VIOLATION"]`) のみ列挙。同 errorCode は inner step `:597` の `affectedRowsCheck.errorCode` で実際に throw される。TX 外 step 由来コード (`SHIPMENT_BLOCKED` 等) は含めず。

### spec §13 ランタイム規約
- §13.1 内部スケジューラ auth: act-001 / act-003 ともに `auth: "required"` + `requiredPermissions: ["system"]` (`:323-325` / `:792-794`)。
- §13.2 ON CONFLICT DO NOTHING null-safe: `:428/:440/:455/:465/:475/:484` で `@upsertedRecord?.id != null` / `@upsertedRecord?.id == null` を使用。
- §13.3 loop 0 件時 accumulate: 本 PR では loop accumulate を使っていないため該当なし (N/A)。

### spec §15 拡張実装ガイドライン
- §15.1 fieldType vs domainsCatalog: `serialNumber` は型カテゴリのため拡張 fieldType として定義。`SerialNumber` 等は制約なしの type alias として `domainsCatalog` (`:271-275`) で表現。
- §15.2 拡張 step 参照形式: `manufacturing:TraceabilityStep` / `manufacturing:QualityCheckStep` で namespace 修飾形式を使用 (`:447`, `:589`, `:868`)。
- §15.3 拡張定義の実利用必須: `TraceabilityStep` は act-001 (`:447`) / act-003 (`:868`) で実利用、`QualityCheckStep` は act-002 (`:589`) で実利用。
- 並列実装中の #479 由来定義 (`BomExplodeStep` / `InventoryReserveStep` / `lotId` / `workOrderId` / `partNumber` / `BOM_EXPLODE` / `RESERVE_INVENTORY`) は本 PR では未使用。`README.md` (`docs/sample-project/extensions/manufacturing/README.md`) で由来 ISSUE と扱いを明記。

### スキーマ・拡張サンプル整合
- `extensions-samples.test.ts`: 11 / 11 pass (`docs/sample-project/extensions/**` 全件 schema 適合確認)
- `process-flow.schema.test.ts`: 203 / 203 pass (本 PR の `eeeeeeee-0002-*.json` を含む process-flows 全件 schema 適合)
- `npm run build`: success

### サンプル設計品質
- testScenarios 4 件 (`:1095-1190`): happy / idempotent no-op / FAIL+REWORK / TX rollback の 4 経路を網羅。
- decisions 3 件 (ADR-001..003): 冪等処理 / TX 範囲 / 外部依存の best-effort 化を MADR 形式で記録。
- glossary 9 件: 製造実績 / 品質検査 / トレーサビリティ / シリアル番号 / ロット / WorkOrder / 規格外品 / 特別採用 / 監査ログ。
- errorCatalog: VALIDATION (400) / WORKORDER_NOT_FOUND (404) / LOT_NOT_FOUND (404) / DUPLICATE_RECORD (200 idempotent) / QUALITY_HOLD (422) / SHIPMENT_BLOCKED (422) / INVALID_STATE_TRANSITION (409) / DB_CONSTRAINT_VIOLATION (409)。

## 3 分類別問題件数 (実装中に気づいたもの)

実装中に検出した問題を以下 3 分類で整理。なお、本 PR では実装内で解消済み or 別 ISSUE 候補として記録。

### A. フレームワーク / spec の曖昧さ (3 件)
1. **TX inner 変数の直接参照と outputBinding `txResult` の関係 (spec §8.1)**: 本 PR では `txResult.committed` のみを TX 外で参照し、inner outputBinding 変数 (`@updatedLot.status` 等) は直接参照する形に統一した。spec §8.1 例の `@newRow.id` パターンを踏襲。spec の例示は十分だったが、`txResult` がメタオブジェクト (committed の他に rolled-back / committedAt / errorCode 等) として何を持つかの形式は未定義。**別 ISSUE 起票候補**: `txResult` のメタオブジェクト形式の正規化 (committed 以外のフィールド契約)。
2. **fireAndForget での timeout 評価 (spec §4.3)**: spec はバックグラウンド reject 扱いと明記しているが、`outcomes.timeout.action: "continue"` 時の sideEffects の実行有無 (sync 経路を待たないため通常はスキップしたい場合) が曖昧。本 PR では fireAndForget 通知に sideEffects を入れない形で回避。**別 ISSUE 候補なし** (spec の意図は読める範囲内、実装規約として明示が望ましい程度)。
3. **TraceabilityStep の affectedRowsCheck 相当**: 拡張 step の冪等性 / 副作用契約 (1 回呼び出しで何行 INSERT されるか) を schema 側で表現する手段がない。現状は description / implementation contract に依存。**別 ISSUE 候補**: 拡張 step の `affectedRows` 契約宣言 (実装ヒント) — 優先度低。

### B. 拡張定義 (manufacturing namespace) の設計判断 (4 件)
1. **`UPSERT_IDEMPOTENT` の所属 namespace**: securities namespace で既に定義済 (シナリオ #1 金融) のため、本 PR では `manufacturing` で再定義せず、グローバルでの解決を期待してフロー JSON 内に直書きした (extensions が累積マージされる前提)。**統合 PR で要確認**: シナリオ #1 (#479) が `manufacturing` namespace で `UPSERT_IDEMPOTENT` を再定義した場合、両者 namespace に同一値が入るが衝突しない (DbOperation enum 拡張は global merge)。
2. **`QualityCheckStep.inspectionItems` の型**: 当初 `{ "type": "array" }` で定義したが、フロー側で `"@inputs.inspectionItems"` (式文字列) として渡すため schema 違反となり `{ "type": "string" }` に変更。**別 ISSUE 候補**: 拡張 step schema での「式参照値」の表現規約 (string OR concrete typed value の許容)。現状の workaround は string で受けて runtime で評価する想定。
3. **`qualityIncident` trigger の未利用**: act-002 は `submit` (画面操作) で起動するため、定義した `qualityIncident` を本 PR の 3 アクションでは実利用していない。spec §15.3 「定義したが未使用」の例外として README に「将来用 / 自動連動シナリオで利用」と記載。**別 ISSUE 候補**: シナリオ #5 / #6 等の将来子 ISSUE で実利用する。
4. **`TraceabilityStep.metadata` の Schema 緩さ**: `{ "type": "object" }` のみで内部構造未定義。act-001/act-003 で渡す metadata の鍵 (`workOrderId` 等) は実装時の Tribal knowledge になる。**別 ISSUE 候補**: 拡張 step の metadata 形状を kind 別に正規化する schema bag (TraceabilityMetadata.PRODUCTION / .INSPECTION / .SHIPMENT)。

### C. サンプル設計の選択肢 (3 件)
1. **act-002 PASS 経路の TX 範囲**: 当初 `quality_inspections INSERT` を TX 外に出す案も検討したが、INSERT 単独失敗で lots/work_orders だけ進む不整合を防ぐため TX inner に含めた。spec §8.2 の anti-pattern (外部呼出を TX 内) には抵触しない。
2. **act-003 連鎖起動 (`trigger: "auto"`)**: 設計上 quality.inspected イベント subscribe 経由の起動を想定しているが、本サンプルでは EventSubscribeStep を使わず HTTP `POST /internal/...` の同期起動として表現。spec §13.1 の Pattern (auth: required + requiredPermissions: ["system"]) を採用。**別 ISSUE 候補**: イベント駆動連鎖の正規パターン (subscribe → 同期起動 OR 別ハンドラ) の spec 化。
3. **`disposition` の 4 値目 (REWORK_AS_LOWER_GRADE 等) の拡張余地**: 本サンプルは SCRAP/REWORK/SPECIAL_APPROVAL の 3 値固定。製造業ドメインでは「ランクダウン採用」「補修出荷」等の派生処置もあるが、本 PR では割愛。**別 ISSUE 候補なし** (将来の業務要件次第)。

総計: A=3 / B=4 / C=3 = **10 件** (うち別 ISSUE 化候補は 6 件、解消済み 4 件)。

## Test plan

- [x] `cd designer && npx vitest run src/schemas/extensions-samples.test.ts` — 11 / 11 pass
- [x] `cd designer && npx vitest run src/schemas/process-flow.schema.test.ts` — 203 / 203 pass
- [x] `cd designer && npm run build` — success (vite build OK、tsc OK)
- [ ] `/review-flow` での実行セマンティクス独立レビュー (別セッションで実施予定)

## 関連

- 親メタ: #478
- 並列実装: #479 (シナリオ #1、Sonnet 担当)
- 参考シナリオ: #466 (PR #471 規制報告)、#467 (PR #472 口座開設承認 3 アクション + WorkflowStep)
- spec 改訂: PR #477

🤖 Generated with [Claude Code](https://claude.com/claude-code)