### PR TITLE
feat(dogfood): 物流シナリオ — /create-flow 効果検証 Opus 担当 (#486)

### DIFF
--- a/docs/sample-project/conventions/conventions-catalog.json
+++ b/docs/sample-project/conventions/conventions-catalog.json
@@ -85,7 +85,8 @@
     "companyNameMax": { "value": 200, "unit": "char" },
     "quantityMax": { "value": 9999, "unit": "integer", "description": "発注可能数量の上限" },
     "quantityMin": { "value": 1, "unit": "integer" },
-    "amountMax": { "value": 999999999999, "unit": "yen", "description": "DECIMAL(12,0) の上限、JPY" }
+    "amountMax": { "value": 999999999999, "unit": "yen", "description": "DECIMAL(12,0) の上限、JPY" },
+    "maxDeliveryAttempts": { "value": 3, "unit": "integer", "description": "再配達上限回数 (ADR-003 参照)" }
   },
 
   "scope": {

--- a/docs/sample-project/extensions/logistics/README.md
+++ b/docs/sample-project/extensions/logistics/README.md
@@ -1,6 +1,8 @@
-# logistics 拡張 namespace
+# docs/sample-project/extensions/logistics
 
-物流業 (倉庫/配送/追跡) 業務向け ProcessFlow 拡張定義。
+物流業 (配送指示 → 倉庫ピッキング → 配送追跡 → 顧客到着確認) 向けの ProcessFlow 拡張定義サンプルです。
+
+実行時にバリデーターが読む場所は `data/extensions/` です。このディレクトリには、仕様確認用・業務別テンプレート用のサンプルを配置します。
 
 ## 対象ユースケース
 
@@ -8,18 +10,61 @@
 - 倉庫ピッキング (モバイル作業者操作)
 - 運送会社コールバック受信 → 配送追跡 UPSERT
 - 顧客到着確認 → 状態遷移 IN_TRANSIT → DELIVERED
-- 配送失敗時の再配達/廃棄判断 (補償処理)
+- 配送失敗時の再配達 / 廃棄判断 (補償処理)
 
-## ファイル構成
+## ファイル一覧
 
 | ファイル | 内容 |
 |---|---|
-| `field-types.json` | `shipmentId` / `trackingNumber` / `warehouseLocation` / `deliveryStatus` |
-| `triggers.json` | `deliveryAttempted` — 運送会社コールバック起動トリガー |
-| `db-operations.json` | `LOCK_INVENTORY` — 排他ロック付き在庫引当 |
-| `steps.json` | `PickingStep` / `TrackingUpdateStep` / `DeliveryConfirmStep` |
+| `field-types.json` | 配送指示 ID / 追跡番号 / 倉庫ロケーション / 配送ステータスの FieldType 拡張 |
+| `triggers.json` | 運送会社からの配送試行通知トリガー (`deliveryAttempted`) |
+| `db-operations.json` | 在庫排他ロック (`LOCK_INVENTORY`) の DbOperation 拡張 |
+| `steps.json` | 倉庫ピッキング / 配送追跡更新 / 配送完了確認の Step 拡張 |
 
-## 使用サンプル
+## 適用方法
 
-`docs/sample-project/process-flows/ffffffff-0001-4000-8000-ffffffffffff.json`
-— 配送指示/ピッキング/追跡/到着確認 (物流) シナリオ
+業務プロジェクトで利用する場合は、必要なファイルを手動で `data/extensions/` にコピー:
+
+```bash
+cp docs/sample-project/extensions/logistics/*.json data/extensions/
+```
+
+## 拡張の概要
+
+### Step 拡張
+
+- **PickingStep**: 倉庫作業者がモバイルから走査した商品 ID リストを取り込み、ピッキング作業の完了を検証する
+- **TrackingUpdateStep**: 運送会社の位置情報更新コールバックを `tracking_events` に冪等記録 (UPSERT_IDEMPOTENT 併用) し、`shipment_orders` の現在ステータスを反映する
+- **DeliveryConfirmStep**: 受領サイン / 写真 / 不在票のいずれかで顧客到着確認を `delivery_confirmations` に記録し、`shipment_orders` を `DELIVERED` に確定する
+
+### DbOperation 拡張
+
+- **LOCK_INVENTORY**: `parts_inventory` テーブルに対する `SELECT ... FOR UPDATE` 排他ロック。配送指示登録時に在庫数を確保するための pessimistic ロック方針
+
+### Trigger 拡張
+
+- **deliveryAttempted**: 運送会社の配送試行イベント (DELIVERED / FAILED / RETURNED 等) を受信した時の起動契機
+
+### FieldType 拡張
+
+- **shipmentId / trackingNumber / warehouseLocation / deliveryStatus**: 物流業務固有の値型カテゴリ
+
+## 由来 ISSUE
+
+| ISSUE / PR | 担当 AI | 拡張定義 |
+|---|---|---|
+| #486 / PR #487 (Sonnet) | Sonnet | logistics namespace 初期定義 + 配送指示/ピッキング/追跡/到着確認サンプル |
+| #486 / PR #488 (Opus) | Opus | 同 namespace の schema 詳細化 (deliveryStatus enum 強化、PickingStep/DeliveryConfirmStep schema 拡充)、別実装サンプル |
+
+`/create-flow` スキル (PR #485) の効果検証を兼ねて Sonnet と Opus の並列実装で品質比較を行った検証データ。
+
+## 実利用サンプル
+
+- `docs/sample-project/process-flows/ffffffff-0001-4000-8000-ffffffffffff.json` (Sonnet 実装、PR #487)
+- `docs/sample-project/process-flows/ffffffff-0002-4000-8000-ffffffffffff.json` (Opus 実装、PR #488)
+
+両方とも logistics 拡張 (field-types / triggers / db-operations / steps) を実体使用 (spec §15.3 遵守)。
+
+## 注意
+
+- `type: "logistics:PickingStep"` 形式は process-flow.schema.json が現状未対応 (#480/PR #482 で実証)。実フロー側では `type: "other"` + `outputSchema` + `note: "extensionStep=logistics:..."` 注記パターンを使う。schema が namespaced step 型に対応した時点で移行する想定。

--- a/docs/sample-project/extensions/logistics/steps.json
+++ b/docs/sample-project/extensions/logistics/steps.json
@@ -3,8 +3,8 @@
   "steps": {
     "PickingStep": {
       "label": "倉庫ピッキング",
-      "icon": "Package",
-      "description": "作業者がモバイル端末で倉庫ロケーションを指定し、ピッキング対象品目を確認・完了登録する。",
+      "icon": "PackageCheck",
+      "description": "倉庫作業者が指定された配送指示の対象商品をロケーションからピッキングする工程。複数商品の場合は warehouseLocation の昇順で巡回することを想定。",
       "schema": {
         "type": "object",
         "additionalProperties": false,
@@ -13,40 +13,45 @@
           "shipmentId": { "type": "string" },
           "warehouseLocation": { "type": "string" },
           "operatorId": { "type": "string" },
-          "pickedItems": { "type": "string" }
+          "scannedItems": { "type": "string", "description": "走査済み商品の式参照 (例: @inputs.scannedItems)" }
         }
       }
     },
     "TrackingUpdateStep": {
-      "label": "配送位置更新",
+      "label": "配送追跡更新",
       "icon": "MapPin",
-      "description": "運送会社から受信した位置情報と配送ステータスを shipment_tracking に UPSERT する。",
+      "description": "運送会社からの位置情報更新を tracking_events に冪等記録し、shipment_orders の現在ステータスを反映する。",
       "schema": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["shipmentId", "trackingNumber", "status"],
+        "required": ["trackingNumber", "deliveryStatus"],
         "properties": {
-          "shipmentId": { "type": "string" },
           "trackingNumber": { "type": "string" },
-          "status": { "type": "string", "enum": ["PICKED_UP", "IN_TRANSIT", "OUT_FOR_DELIVERY", "DELIVERED", "FAILED"] },
-          "location": { "type": "string" },
-          "updatedAt": { "type": "string" }
+          "deliveryStatus": {
+            "type": "string",
+            "enum": ["IN_TRANSIT", "OUT_FOR_DELIVERY", "DELIVERED", "FAILED", "RETURNED"]
+          },
+          "checkpointAt": { "type": "string" },
+          "checkpointLocation": { "type": "string" }
         }
       }
     },
     "DeliveryConfirmStep": {
-      "label": "顧客到着確認",
-      "icon": "CheckCircle",
-      "description": "顧客への配送完了を確認し、shipment_orders を DELIVERED に状態遷移させる。",
+      "label": "配送完了確認",
+      "icon": "BadgeCheck",
+      "description": "顧客への到着確認 (受領サイン / 写真 / 不在票) を delivery_confirmations に記録し、shipment_orders を DELIVERED に確定する。",
       "schema": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["shipmentId", "deliveredAt"],
+        "required": ["shipmentId", "confirmationKind"],
         "properties": {
           "shipmentId": { "type": "string" },
-          "deliveredAt": { "type": "string" },
-          "signatureRef": { "type": "string" },
-          "receiverName": { "type": "string" }
+          "confirmationKind": {
+            "type": "string",
+            "enum": ["SIGNATURE", "PHOTO", "ABSENT_NOTICE"]
+          },
+          "receivedBy": { "type": "string" },
+          "confirmedAt": { "type": "string" }
         }
       }
     }

--- a/docs/sample-project/extensions/logistics/triggers.json
+++ b/docs/sample-project/extensions/logistics/triggers.json
@@ -1,6 +1,6 @@
 {
   "namespace": "logistics",
   "triggers": [
-    { "value": "deliveryAttempted", "label": "運送会社コールバック (配送試行)" }
+    { "value": "deliveryAttempted", "label": "運送会社からの配送試行通知時" }
   ]
 }

--- a/docs/sample-project/process-flows/ffffffff-0002-4000-8000-ffffffffffff.json
+++ b/docs/sample-project/process-flows/ffffffff-0002-4000-8000-ffffffffffff.json
@@ -166,7 +166,7 @@
       "status": "accepted",
       "context": "再配達上限回数は法令・運送会社契約・季節変動 (繁忙期短縮) で運用調整したい。ハードコード (例: max 3) ではキャンペーン対応や規制変更に対応しづらい。",
       "decision": "再配達上限は @conv.limit.maxDeliveryAttempts 規約参照で取得する。delivery_attempts < max なら再配達スケジュール、>= max なら return_required に分岐する。validation rule の maxRef も同参照を使う。",
-      "consequences": "運用調整が data/conventions/catalog.json 編集だけで反映される。フロー JSON とコードは無変更で済む。テストでは clock + ambientContext で上限値を上書きする。",
+      "consequences": "運用調整が data/conventions/catalog.json 編集だけで反映される。フロー JSON とコードは無変更で済む。テストでは clock + ambientContext で上限値を上書きする。conventions-catalog.json で @conv.limit.maxDeliveryAttempts = 3 を定義済 (docs/sample-project/conventions/conventions-catalog.json#limit.maxDeliveryAttempts)。",
       "date": "2026-04-26"
     }
   ],
@@ -477,7 +477,7 @@
         {
           "id": "step-001-05",
           "type": "transactionScope",
-          "description": "在庫排他ロック (LOCK_INVENTORY) → 在庫引当 (UPDATE+affectedRowsCheck で在庫不足を検知し rollback) → shipment_orders INSERT を 1 TX で実行する。inner step は @inputs / @order / @selectedWarehouseId の TX 外変数のみ参照する。WMS 連携は TX 外。",
+          "description": "在庫排他ロック (LOCK_INVENTORY) → 在庫引当 (UPDATE+affectedRowsCheck で在庫不足を検知し rollback) → shipment_orders INSERT を 1 TX で実行する。inner step は @inputs / @order / @selectedWarehouseId の TX 外変数のみ参照する。WMS 連携は TX 外。txResult outputBinding は { committed: boolean, errorCode?: string } 形式で返す前提 (docs/spec/process-flow-transaction.md §8.3 で規定)。後段 step-001-06 の branches は @txResult.committed と @txResult.errorCode を参照して commit/rollback を判別する。",
           "maturity": "committed",
           "isolationLevel": "READ_COMMITTED",
           "propagation": "REQUIRED",
@@ -586,7 +586,6 @@
                   "body": "{ shipmentId: @newShipmentId, warehouseId: @selectedWarehouseId, items: @inputs.items }"
                 },
                 "idempotencyKey": "wms-pick-@newShipmentId",
-                "outputBinding": "wmsResult",
                 "outcomes": {
                   "success": { "action": "continue" },
                   "failure": {
@@ -965,19 +964,14 @@
               {
                 "id": "step-003-05-new-01",
                 "type": "other",
-                "description": "logistics:TrackingUpdateStep 拡張定義 (docs/sample-project/extensions/logistics/steps.json) を呼び出す意図。tracking_events 行から shipment_orders.current_status へのマッピング (状態巻き戻し防止) を補助する。",
+                "description": "logistics:TrackingUpdateStep 拡張定義 (docs/sample-project/extensions/logistics/steps.json) を呼び出す意図。tracking_events 行から shipment_orders.current_status へのマッピング (状態巻き戻し防止) を補助する。outputBinding は後段で参照されないため省略 (副作用のみ)。",
                 "maturity": "committed",
-                "note": "extensionStep=logistics:TrackingUpdateStep; trackingNumber=@inputs.trackingNumber; deliveryStatus=@inputs.status; checkpointAt=@inputs.checkpointAt; checkpointLocation=@inputs.checkpointLocation",
-                "outputBinding": "trackUpdate",
-                "outputSchema": {
-                  "appliedStatus": "string",
-                  "stateChanged": "boolean"
-                }
+                "note": "extensionStep=logistics:TrackingUpdateStep; trackingNumber=@inputs.trackingNumber; deliveryStatus=@inputs.status; checkpointAt=@inputs.checkpointAt; checkpointLocation=@inputs.checkpointLocation"
               },
               {
                 "id": "step-003-05-new-02",
                 "type": "branch",
-                "description": "ステータス値で DELIVERED / FAILED / その他に分岐する。DELIVERED は受領確認 + 顧客通知、FAILED は再配達/返送判断、それ以外は単純な状態反映のみ。",
+                "description": "ステータス値で DELIVERED / RETURNED / FAILED / その他に分岐する。DELIVERED は受領確認 + 顧客通知、RETURNED は運送会社直接通知の確定 + audit + 返送イベント、FAILED は再配達/返送判断、それ以外 (IN_TRANSIT / OUT_FOR_DELIVERY) は単純な状態反映のみ。RETURNED を専用 branch として切り出すことで OTHER_STATUS の暗黙キャッチを排し、状態巻き戻し防止と監査要件を明示する。",
                 "maturity": "committed",
                 "branches": [
                   {
@@ -989,7 +983,7 @@
                       {
                         "id": "step-003-05-new-02-delivered-01",
                         "type": "transactionScope",
-                        "description": "DELIVERED 経路: delivery_confirmations INSERT + shipment_orders を DELIVERED に更新を 1 TX で実行する。inner step は @inputs / @shipment / @upsertedTrack の TX 外変数のみ参照する。",
+                        "description": "DELIVERED 経路: delivery_confirmations INSERT + shipment_orders を DELIVERED に更新を 1 TX で実行する。inner step は @inputs / @shipment / @upsertedTrack の TX 外変数のみ参照する。deliveredTxResult outputBinding は { committed: boolean, errorCode?: string } 形式で返す前提 (docs/spec/process-flow-transaction.md §8.3 で規定)。後段 branches は @deliveredTxResult.committed を参照して commit/rollback を判別する。",
                         "maturity": "committed",
                         "isolationLevel": "READ_COMMITTED",
                         "propagation": "REQUIRED",
@@ -1111,6 +1105,62 @@
                             }
                           ]
                         }
+                      }
+                    ]
+                  },
+                  {
+                    "id": "br-003-05-new-02-returned",
+                    "code": "RETURNED",
+                    "label": "返送通知 (運送会社からの直接通知)",
+                    "condition": "@inputs.status == 'RETURNED'",
+                    "steps": [
+                      {
+                        "id": "step-003-05-new-02-returned-01",
+                        "type": "dbAccess",
+                        "description": "shipment_orders を RETURNED に遷移させる。状態巻き戻し (DELIVERED からの戻り) を防ぐため終端状態でない時のみ更新する。",
+                        "maturity": "committed",
+                        "tableName": "shipment_orders",
+                        "operation": "UPDATE",
+                        "sql": "UPDATE shipment_orders SET current_status = 'RETURNED', updated_at = NOW() WHERE id = @inputs.shipmentId AND current_status NOT IN ('DELIVERED', 'RETURNED') RETURNING id, current_status",
+                        "outputBinding": "returnedDirectShipment",
+                        "lineage": { "writes": ["shipment_orders"] }
+                      },
+                      {
+                        "id": "step-003-05-new-02-returned-02",
+                        "type": "audit",
+                        "description": "運送会社からの直接 RETURNED 通知を監査ログに記録する (sensitive: 顧客契約に影響)。",
+                        "maturity": "committed",
+                        "action": "shipment.return",
+                        "resource": { "type": "ShipmentOrder", "id": "@inputs.shipmentId" },
+                        "result": "success",
+                        "reason": "CARRIER_RETURNED_NOTICE",
+                        "sensitive": true
+                      },
+                      {
+                        "id": "step-003-05-new-02-returned-03",
+                        "type": "eventPublish",
+                        "description": "shipment.tracking_updated イベントを発行する。",
+                        "maturity": "committed",
+                        "topic": "shipment.tracking_updated",
+                        "eventRef": "shipment.tracking_updated",
+                        "payload": "{ shipmentId: @inputs.shipmentId, trackingNumber: @inputs.trackingNumber, status: 'RETURNED', checkpointAt: @inputs.checkpointAt }"
+                      },
+                      {
+                        "id": "step-003-05-new-02-returned-04",
+                        "type": "eventPublish",
+                        "description": "shipment.return_required イベントを発行する (再配達上限経由ではなく運送会社直接通知の RETURNED)。",
+                        "maturity": "committed",
+                        "topic": "shipment.return_required",
+                        "eventRef": "shipment.return_required",
+                        "payload": "{ shipmentId: @inputs.shipmentId, attemptCount: @shipment.delivery_attempts, reason: 'CARRIER_RETURNED_NOTICE' }"
+                      },
+                      {
+                        "id": "step-003-05-new-02-returned-05",
+                        "type": "return",
+                        "description": "200 RETURNED 確定を返す。",
+                        "maturity": "committed",
+                        "responseRef": "200-updated",
+                        "bodyExpression": "{ shipmentId: @inputs.shipmentId, status: 'RETURNED' }"
                       }
                     ]
                   },
@@ -1269,12 +1319,12 @@
                 "elseBranch": {
                   "id": "br-003-05-new-02-other",
                   "code": "OTHER_STATUS",
-                  "label": "IN_TRANSIT / OUT_FOR_DELIVERY / RETURNED 等 (単純反映)",
+                  "label": "IN_TRANSIT / OUT_FOR_DELIVERY (単純反映)",
                   "steps": [
                     {
                       "id": "step-003-05-new-02-other-01",
                       "type": "dbAccess",
-                      "description": "shipment_orders.current_status を反映する。状態巻き戻し (DELIVERED → 戻り) を防ぐため終端状態でない時のみ更新する。",
+                      "description": "shipment_orders.current_status を IN_TRANSIT / OUT_FOR_DELIVERY に反映する。状態巻き戻し (DELIVERED / RETURNED → 戻り) を防ぐため終端状態でない時のみ更新する。",
                       "maturity": "committed",
                       "tableName": "shipment_orders",
                       "operation": "UPDATE",

--- a/docs/sample-project/process-flows/ffffffff-0002-4000-8000-ffffffffffff.json
+++ b/docs/sample-project/process-flows/ffffffff-0002-4000-8000-ffffffffffff.json
@@ -1,0 +1,1445 @@
+{
+  "id": "ffffffff-0002-4000-8000-ffffffffffff",
+  "name": "配送指示/ピッキング/追跡/到着確認 (物流) [Opus 実装]",
+  "type": "system",
+  "screenId": "aaaaaaaa-0002-4000-8000-ffffffffffff",
+  "description": "受注確定からの連鎖で配送指示を登録し、倉庫ピッキング完了通知、運送会社の追跡コールバック、顧客到着確認、配送失敗時の再配達/廃棄判断までを扱う物流ドッグフードサンプル。在庫排他ロック (LOCK_INVENTORY) と冪等な追跡更新 (UPSERT_IDEMPOTENT)、外部 WMS / 運送会社 / 顧客通知ゲートウェイの連携を抽象化する。",
+  "apiVersion": "v2",
+  "mode": "downstream",
+  "maturity": "committed",
+  "eventsCatalog": {
+    "shipment.created": {
+      "description": "受注確定からの連鎖で配送指示が shipment_orders に登録され、対象在庫が排他ロックされた時点で発行されるイベント。",
+      "payload": {
+        "type": "object",
+        "required": ["shipmentId", "orderId", "warehouseId", "status"],
+        "properties": {
+          "shipmentId": { "type": "string" },
+          "orderId": { "type": "string" },
+          "warehouseId": { "type": "string" },
+          "status": { "type": "string", "const": "PLANNED" },
+          "plannedShipAt": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "shipment.picked": {
+      "description": "倉庫作業者が対象配送指示のピッキングを完了し、shipment_orders が PICKED に遷移した時点で発行されるイベント。",
+      "payload": {
+        "type": "object",
+        "required": ["shipmentId", "operatorId"],
+        "properties": {
+          "shipmentId": { "type": "string" },
+          "operatorId": { "type": "string" },
+          "pickedAt": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "shipment.tracking_updated": {
+      "description": "運送会社からの追跡コールバックで tracking_events に新規行を冪等登録し、shipment_orders の current_status を反映した時点で発行されるイベント。冪等 no-op 経路では発行しない。",
+      "payload": {
+        "type": "object",
+        "required": ["shipmentId", "trackingNumber", "status"],
+        "properties": {
+          "shipmentId": { "type": "string" },
+          "trackingNumber": { "type": "string" },
+          "status": {
+            "type": "string",
+            "enum": ["IN_TRANSIT", "OUT_FOR_DELIVERY", "DELIVERED", "FAILED", "RETURNED"]
+          },
+          "checkpointAt": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "shipment.delivered": {
+      "description": "顧客への到着確認 (受領サイン / 写真 / 不在票) が delivery_confirmations に記録され、shipment_orders が DELIVERED に確定した時点で発行されるイベント。",
+      "payload": {
+        "type": "object",
+        "required": ["shipmentId", "confirmationKind"],
+        "properties": {
+          "shipmentId": { "type": "string" },
+          "confirmationKind": { "type": "string", "enum": ["SIGNATURE", "PHOTO", "ABSENT_NOTICE"] },
+          "receivedBy": { "type": "string" },
+          "confirmedAt": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "shipment.redelivery_scheduled": {
+      "description": "配送失敗 (FAILED) を受信し、再配達枠の上限内で次回配達日時が決定された時点で発行されるイベント。",
+      "payload": {
+        "type": "object",
+        "required": ["shipmentId", "attemptCount", "nextAttemptAt"],
+        "properties": {
+          "shipmentId": { "type": "string" },
+          "attemptCount": { "type": "number" },
+          "nextAttemptAt": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "shipment.return_required": {
+      "description": "再配達上限を超過し、荷物を発荷元へ返送する判断が確定した時点で発行されるイベント。",
+      "payload": {
+        "type": "object",
+        "required": ["shipmentId", "attemptCount"],
+        "properties": {
+          "shipmentId": { "type": "string" },
+          "attemptCount": { "type": "number" },
+          "reason": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "glossary": {
+    "配送指示": {
+      "definition": "受注確定後に倉庫・運送会社に対して発行する出荷の業務単位。1 配送指示 = 1 荷物 (複数明細を含み得る)。",
+      "aliases": ["Shipment Order", "出荷指示"],
+      "domainRef": "shipment_orders"
+    },
+    "ピッキング": {
+      "definition": "倉庫作業者が指定された商品を保管ロケーションから取り出し、出荷準備エリアへ搬送する工程。",
+      "aliases": ["Picking", "出庫作業"],
+      "domainRef": "shipment_orders.status:PICKED"
+    },
+    "追跡番号": {
+      "definition": "運送会社が個別荷物に付番する一意識別子。配送状況照会と顧客通知に利用する。",
+      "aliases": ["Tracking Number", "問い合わせ番号"],
+      "domainRef": "shipment_orders.tracking_number"
+    },
+    "倉庫ロケーション": {
+      "definition": "倉庫内の棚・通路・段で表される保管位置。ピッキング順は通常ロケーションの巡回順で最適化する。",
+      "aliases": ["Warehouse Location", "棚番地"],
+      "domainRef": "parts_inventory.location_code"
+    },
+    "配送ステータス": {
+      "definition": "荷物の現在状態。PLANNED / PICKED / IN_TRANSIT / OUT_FOR_DELIVERY / DELIVERED / FAILED / RETURNED の状態機械を構成する。",
+      "aliases": ["Delivery Status", "現在ステータス"],
+      "domainRef": "shipment_orders.current_status"
+    },
+    "在庫排他ロック": {
+      "definition": "配送指示登録時に対象在庫を SELECT ... FOR UPDATE で pessimistic ロックし、同一在庫への二重引当を物理的に防ぐ運用方針。",
+      "aliases": ["Inventory Lock", "排他在庫引当"],
+      "domainRef": "parts_inventory.locked_qty"
+    },
+    "再配達": {
+      "definition": "1 度配達失敗した荷物に対して、上限回数 (規約値) 内で次回配達日時を再設定する処理。",
+      "aliases": ["Redelivery", "再配達依頼"],
+      "domainRef": "shipment_orders.delivery_attempts"
+    },
+    "受領確認": {
+      "definition": "顧客手元に荷物が届いた事実を確認する記録。受領サイン / 配達写真 / 不在票投函のいずれかの方式で行う。",
+      "aliases": ["Proof of Delivery", "POD"],
+      "domainRef": "delivery_confirmations"
+    },
+    "返送": {
+      "definition": "再配達上限を超過した、または受取拒否された荷物を発荷元 (倉庫) へ送り返す業務。",
+      "aliases": ["Return", "返品輸送"],
+      "domainRef": "shipment_orders.status:RETURNED"
+    }
+  },
+  "decisions": [
+    {
+      "id": "ADR-001",
+      "title": "配送指示登録時の在庫引当は LOCK_INVENTORY (SELECT ... FOR UPDATE) で pessimistic にする",
+      "status": "accepted",
+      "context": "配送指示の同時登録 (1 商品に対する複数注文の同時確定) で在庫の二重引当が起きるリスクがある。また在庫不足判定の TOCTOU レース (SELECT 後 UPDATE 前に別 TX が引当を完了する) が発生しうる。",
+      "decision": "配送指示登録は logistics:LOCK_INVENTORY DbOperation で対象 parts_inventory 行を SELECT ... FOR UPDATE で排他ロックし、同一 TX 内で available_qty を比較・UPDATE する。TX commit/rollback でロック解放されるため、外部呼出 (WMS) は TX 外に置く。",
+      "consequences": "DB 接続の長期占有はロック粒度が小さい (1 在庫行) ため許容範囲。TX 内で外部呼出を行わない原則 (spec §8.2) に整合。在庫不足は STOCK_SHORTAGE として 409 で返し、shipment_orders は INSERT 自体しない。",
+      "date": "2026-04-26"
+    },
+    {
+      "id": "ADR-002",
+      "title": "運送会社追跡コールバックは UPSERT_IDEMPOTENT で冪等処理する",
+      "status": "accepted",
+      "context": "運送会社からの位置情報更新コールバックは、ネットワーク再送・運送会社運用再送により同一 (trackingNumber, checkpointAt) が複数回到達する。tracking_events に二重行が登録されると顧客への重複通知や監査整合性が崩れる。",
+      "decision": "tracking_events に (tracking_number, checkpoint_at) 複合一意制約を置き、UPSERT_IDEMPOTENT (ON CONFLICT DO NOTHING RETURNING id) 方針で処理する。後続 step は @upsertedTrack?.id != null ガードで保護し、no-op 経路は ALREADY_PROCESSED で 200 を返す。",
+      "consequences": "重複コールバックによる二重イベント発行・顧客二重通知を防げる。current_status の更新も同一ガード下で行うため、状態巻き戻り (DELIVERED → IN_TRANSIT) は発生しない。",
+      "date": "2026-04-26"
+    },
+    {
+      "id": "ADR-003",
+      "title": "再配達上限と返送判断は ambient catalog 値で運用調整可能にする",
+      "status": "accepted",
+      "context": "再配達上限回数は法令・運送会社契約・季節変動 (繁忙期短縮) で運用調整したい。ハードコード (例: max 3) ではキャンペーン対応や規制変更に対応しづらい。",
+      "decision": "再配達上限は @conv.limit.maxDeliveryAttempts 規約参照で取得する。delivery_attempts < max なら再配達スケジュール、>= max なら return_required に分岐する。validation rule の maxRef も同参照を使う。",
+      "consequences": "運用調整が data/conventions/catalog.json 編集だけで反映される。フロー JSON とコードは無変更で済む。テストでは clock + ambientContext で上限値を上書きする。",
+      "date": "2026-04-26"
+    }
+  ],
+  "ambientVariables": [
+    {
+      "name": "requestId",
+      "type": "string",
+      "required": true,
+      "description": "リクエスト単位の追跡 ID。WMS / 運送会社呼出の冪等キーフォールバックや audit ログ相関に使う。"
+    },
+    {
+      "name": "sessionUserId",
+      "type": "string",
+      "required": true,
+      "description": "操作したログインユーザー ID。act-001 では受注処理システム、act-002 では倉庫作業者、act-003 では運送会社システム ID が該当。"
+    },
+    {
+      "name": "idempotencyKey",
+      "type": "string",
+      "required": false,
+      "description": "クライアント (運送会社・WMS) が付与する冪等キー。tracking 更新の冪等キー優先利用、未指定時は requestId をフォールバック。"
+    }
+  ],
+  "errorCatalog": {
+    "VALIDATION": {
+      "httpStatus": 400,
+      "defaultMessage": "入力値が不正です",
+      "responseRef": "400-validation"
+    },
+    "ORDER_NOT_FOUND": {
+      "httpStatus": 404,
+      "defaultMessage": "受注が見つかりません",
+      "responseRef": "404-order-not-found"
+    },
+    "SHIPMENT_NOT_FOUND": {
+      "httpStatus": 404,
+      "defaultMessage": "配送指示が見つかりません",
+      "responseRef": "404-shipment-not-found"
+    },
+    "STOCK_SHORTAGE": {
+      "httpStatus": 409,
+      "defaultMessage": "在庫が不足しています",
+      "responseRef": "409-stock-shortage",
+      "description": "LOCK_INVENTORY 後の available_qty 比較で不足検知。shipment_orders は INSERT しない。"
+    },
+    "INVALID_STATE_TRANSITION": {
+      "httpStatus": 409,
+      "defaultMessage": "状態遷移が不正です",
+      "responseRef": "409-invalid-state-transition",
+      "description": "shipment_orders.current_status の前提状態違反 (例: DELIVERED から IN_TRANSIT 戻り)。affectedRowsCheck で検出。"
+    },
+    "DB_CONSTRAINT_VIOLATION": {
+      "httpStatus": 409,
+      "defaultMessage": "DB 制約違反 (TX rollback)",
+      "responseRef": "409-invalid-state-transition"
+    },
+    "DUPLICATE_TRACKING": {
+      "httpStatus": 200,
+      "defaultMessage": "既に処理済みです",
+      "responseRef": "200-already-processed",
+      "description": "tracking_events 冪等 no-op。HTTP 200 + status: ALREADY_PROCESSED で返す。"
+    },
+    "CARRIER_REJECTED": {
+      "httpStatus": 502,
+      "defaultMessage": "運送会社からの応答が不正です",
+      "responseRef": "502-carrier-rejected"
+    }
+  },
+  "externalSystemCatalog": {
+    "wmsSystem": {
+      "name": "Warehouse Management System",
+      "baseUrl": "https://wms-gateway.example.internal",
+      "openApiSpec": "docs/openapi/wms-gateway.yaml",
+      "auth": {
+        "kind": "apiKey",
+        "tokenRef": "@secret.wmsApiKey",
+        "headerName": "X-WMS-Key"
+      },
+      "timeoutMs": 5000,
+      "description": "倉庫管理システム。配送指示登録後にピッキング指示を送信し、ピッキング完了通知を受け取る。"
+    },
+    "carrierGateway": {
+      "name": "Carrier Tracking Gateway",
+      "baseUrl": "https://carrier-gateway.example.internal",
+      "openApiSpec": "docs/openapi/carrier-gateway.yaml",
+      "auth": {
+        "kind": "bearer",
+        "tokenRef": "@secret.carrierToken"
+      },
+      "timeoutMs": 4000,
+      "description": "運送会社ゲートウェイ。配送追跡情報の問合せと再配達依頼に利用する。コールバック (act-003) を受信する側が中心。"
+    },
+    "customerNotification": {
+      "name": "Customer Notification Gateway",
+      "baseUrl": "https://customer-notification.example.internal",
+      "auth": {
+        "kind": "apiKey",
+        "tokenRef": "@secret.customerNotifyApiKey",
+        "headerName": "X-API-Key"
+      },
+      "timeoutMs": 2000,
+      "description": "顧客向け通知配信ゲートウェイ。発荷通知・到着予定通知・配送完了通知に利用する。"
+    }
+  },
+  "secretsCatalog": {
+    "wmsApiKey": {
+      "source": "env",
+      "name": "WMS_API_KEY",
+      "rotationDays": 180,
+      "description": "WMS 連携用 API キー"
+    },
+    "carrierToken": {
+      "source": "env",
+      "name": "CARRIER_API_TOKEN",
+      "rotationDays": 90,
+      "description": "運送会社ゲートウェイ Bearer トークン"
+    },
+    "customerNotifyApiKey": {
+      "source": "env",
+      "name": "CUSTOMER_NOTIFY_API_KEY",
+      "rotationDays": 180,
+      "description": "顧客通知ゲートウェイ API キー"
+    }
+  },
+  "domainsCatalog": {
+    "ShipmentId": {
+      "type": { "kind": "shipmentId" },
+      "uiHint": "text",
+      "description": "配送指示 ID。配送指示登録時に採番される。"
+    },
+    "OrderId": {
+      "type": "string",
+      "uiHint": "text",
+      "description": "受注 ID。配送指示の親となる注文識別子。"
+    },
+    "TrackingNumber": {
+      "type": { "kind": "trackingNumber" },
+      "uiHint": "text",
+      "description": "運送会社が付番する追跡番号。"
+    },
+    "WarehouseLocation": {
+      "type": { "kind": "warehouseLocation" },
+      "uiHint": "text",
+      "description": "倉庫内の保管ロケーション。"
+    },
+    "DeliveryStatus": {
+      "type": { "kind": "deliveryStatus" },
+      "uiHint": "text",
+      "description": "配送ステータス。PLANNED/PICKED/IN_TRANSIT/OUT_FOR_DELIVERY/DELIVERED/FAILED/RETURNED の状態機械。"
+    },
+    "Quantity": {
+      "type": "number",
+      "uiHint": "number",
+      "constraints": [
+        { "field": "quantity", "type": "range", "min": 1, "message": "数量は 1 以上で入力してください" }
+      ],
+      "description": "配送指示明細の数量。"
+    }
+  },
+  "functionsCatalog": {
+    "selectWarehouseRoute": {
+      "signature": "selectWarehouseRoute(orderItems: OrderItem[]): string",
+      "returnType": "string",
+      "description": "受注明細から最適な発荷倉庫 ID を決定する。在庫保有・距離・優先度を加味した最寄り倉庫アルゴリズムの抽象化。",
+      "examples": [
+        "@fn.selectWarehouseRoute(@order.items) // => \"WH-001\""
+      ]
+    },
+    "calculatePlannedShipAt": {
+      "signature": "calculatePlannedShipAt(warehouseId: string, now: datetime): datetime",
+      "returnType": "string",
+      "description": "倉庫の翌営業日カットオフを考慮した発荷予定日時を算出する。",
+      "examples": [
+        "@fn.calculatePlannedShipAt(@warehouse, @now)"
+      ]
+    },
+    "scheduleNextAttempt": {
+      "signature": "scheduleNextAttempt(currentAttempt: number, failedAt: datetime): datetime",
+      "returnType": "string",
+      "description": "現在の配達試行回数と失敗時刻から、運送会社の翌営業日同時刻を再配達日時として算出する。",
+      "examples": [
+        "@fn.scheduleNextAttempt(@shipment.delivery_attempts, @inputs.checkpointAt)"
+      ]
+    },
+    "generateUuid": {
+      "signature": "generateUuid(): string",
+      "returnType": "string",
+      "description": "v4 UUID 文字列を生成する。配送指示 ID 等を TX 前に採番し、TX 内外で同一参照を使うため。",
+      "examples": [
+        "@fn.generateUuid() // => '550e8400-e29b-41d4-a716-446655440000'"
+      ]
+    }
+  },
+  "actions": [
+    {
+      "id": "act-001",
+      "name": "配送指示受付 (受注確定からの連鎖)",
+      "trigger": "auto",
+      "description": "受注確定イベントからの連鎖で起動。在庫排他ロックで対象在庫を pessimistic に確保し、shipment_orders を 1 TX で登録、TX 外で WMS にピッキング指示を送る。",
+      "maturity": "committed",
+      "httpRoute": {
+        "method": "POST",
+        "path": "/internal/shipment/create-from-order",
+        "auth": "required"
+      },
+      "requiredPermissions": ["system"],
+      "inputs": [
+        { "name": "orderId", "label": "受注 ID", "type": "string", "required": true, "domainRef": "OrderId" },
+        { "name": "warehouseId", "label": "発荷倉庫 ID", "type": "string", "required": false, "description": "未指定なら @fn.selectWarehouseRoute で自動選択。" },
+        { "name": "items", "label": "明細", "type": { "kind": "array", "itemType": "string" }, "required": true, "description": "明細を JSON 文字列または structured object として配列で受ける (例: [{ partNumber, quantity, location? }] 形式)。" }
+      ],
+      "outputs": [
+        { "name": "shipmentId", "label": "配送指示 ID", "type": "string", "domainRef": "ShipmentId" },
+        { "name": "status", "label": "配送ステータス", "type": "string", "domainRef": "DeliveryStatus" }
+      ],
+      "responses": [
+        { "id": "201-created", "status": 201, "bodySchema": { "schema": { "type": "object", "required": ["shipmentId", "status"], "properties": { "shipmentId": { "type": "string" }, "status": { "type": "string", "const": "PLANNED" }, "plannedShipAt": { "type": "string" } }, "additionalProperties": false } }, "when": "配送指示が登録され WMS にピッキング指示を送信した" },
+        { "id": "400-validation", "status": 400, "bodySchema": { "schema": { "type": "object" } }, "when": "入力値が不正" },
+        { "id": "404-order-not-found", "status": 404, "bodySchema": { "schema": { "type": "object" } }, "when": "対象 order が存在しない" },
+        { "id": "409-stock-shortage", "status": 409, "bodySchema": { "schema": { "type": "object", "required": ["code"], "properties": { "code": { "type": "string", "const": "STOCK_SHORTAGE" }, "message": { "type": "string" } }, "additionalProperties": false } }, "when": "在庫不足 (LOCK_INVENTORY+UPDATE の affectedRowsCheck で検出)" }
+      ],
+      "steps": [
+        {
+          "id": "step-001-01",
+          "type": "validation",
+          "description": "orderId と items[*] の必須・数量チェック。",
+          "maturity": "committed",
+          "conditions": "orderId は必須。items は 1 件以上、各 items[*].partNumber と quantity > 0 が必須。",
+          "rules": [
+            { "field": "orderId", "type": "required", "message": "受注 ID は必須です" },
+            { "field": "items", "type": "required", "message": "明細は必須です" },
+            { "field": "items[*].partNumber", "type": "required", "message": "明細の部品番号は必須です" },
+            { "field": "items[*].quantity", "type": "range", "min": 1, "message": "数量は 1 以上で入力してください" }
+          ],
+          "fieldErrorsVar": "fieldErrors",
+          "inlineBranch": {
+            "ok": "受注取得へ進む",
+            "ng": "400 バリデーションエラー",
+            "ngResponseRef": "400-validation",
+            "ngBodyExpression": "{ code: 'VALIDATION', message: '入力値が不正です', fieldErrors: @fieldErrors }"
+          }
+        },
+        {
+          "id": "step-001-02",
+          "type": "dbAccess",
+          "description": "対象の orders を取得する。CONFIRMED 状態のみ進行可。",
+          "maturity": "committed",
+          "tableName": "orders",
+          "operation": "SELECT",
+          "sql": "SELECT id, customer_id, status FROM orders WHERE id = @inputs.orderId",
+          "outputBinding": "order",
+          "lineage": { "reads": ["orders"] }
+        },
+        {
+          "id": "step-001-03",
+          "type": "branch",
+          "description": "order が存在しない場合は 404 を返す。",
+          "maturity": "committed",
+          "branches": [
+            {
+              "id": "br-001-03-a",
+              "code": "NOT_FOUND",
+              "label": "order なし",
+              "condition": "@order == null",
+              "steps": [
+                {
+                  "id": "step-001-03-a-01",
+                  "type": "return",
+                  "description": "404 受注なし。",
+                  "maturity": "committed",
+                  "responseRef": "404-order-not-found",
+                  "bodyExpression": "{ code: 'ORDER_NOT_FOUND', orderId: @inputs.orderId }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-001-03-else",
+            "code": "FOUND",
+            "label": "order 取得済み",
+            "steps": []
+          }
+        },
+        {
+          "id": "step-001-04",
+          "type": "compute",
+          "description": "warehouseId 未指定時は @fn.selectWarehouseRoute で発荷倉庫を決定する。",
+          "maturity": "committed",
+          "expression": "@inputs.warehouseId ?? @fn.selectWarehouseRoute(@inputs.items)",
+          "outputBinding": "selectedWarehouseId"
+        },
+        {
+          "id": "step-001-04b",
+          "type": "compute",
+          "description": "TX 前に shipmentId を採番する (Rule 2: TX inner outputBinding を TX 外参照しないため、ID は事前生成して @inputs と同様に TX 内外両方から参照可能にする)。",
+          "maturity": "committed",
+          "expression": "@fn.generateUuid()",
+          "outputBinding": "newShipmentId"
+        },
+        {
+          "id": "step-001-04c",
+          "type": "compute",
+          "description": "TX 前に発荷予定日時を算出する (TX inner で @now を使うと TX 開始時刻と微妙にずれるため事前確定)。",
+          "maturity": "committed",
+          "expression": "@fn.calculatePlannedShipAt(@selectedWarehouseId, @now)",
+          "outputBinding": "plannedShipAt"
+        },
+        {
+          "id": "step-001-05",
+          "type": "transactionScope",
+          "description": "在庫排他ロック (LOCK_INVENTORY) → 在庫引当 (UPDATE+affectedRowsCheck で在庫不足を検知し rollback) → shipment_orders INSERT を 1 TX で実行する。inner step は @inputs / @order / @selectedWarehouseId の TX 外変数のみ参照する。WMS 連携は TX 外。",
+          "maturity": "committed",
+          "isolationLevel": "READ_COMMITTED",
+          "propagation": "REQUIRED",
+          "outputBinding": "txResult",
+          "rollbackOn": ["STOCK_SHORTAGE"],
+          "steps": [
+            {
+              "id": "step-001-05-01",
+              "type": "dbAccess",
+              "description": "logistics:LOCK_INVENTORY 拡張 DbOperation を呼び出す。対象 parts_inventory 行群を SELECT ... FOR UPDATE で排他ロックする。",
+              "maturity": "committed",
+              "tableName": "parts_inventory",
+              "operation": "LOCK_INVENTORY",
+              "sql": "SELECT part_number, location_code, available_qty, locked_qty FROM parts_inventory WHERE warehouse_id = @selectedWarehouseId AND part_number IN (SELECT i.partNumber FROM UNNEST(@inputs.items) AS i) FOR UPDATE",
+              "outputBinding": "lockedInventory",
+              "lineage": { "reads": ["parts_inventory"] }
+            },
+            {
+              "id": "step-001-05-02",
+              "type": "dbAccess",
+              "description": "parts_inventory.locked_qty を加算し available_qty を減算する。affectedRowsCheck で在庫不足 (WHERE available_qty >= i.quantity を満たさない明細) を検知し STOCK_SHORTAGE を throw して TX rollback を発火する。",
+              "maturity": "committed",
+              "tableName": "parts_inventory",
+              "operation": "UPDATE",
+              "sql": "UPDATE parts_inventory SET locked_qty = locked_qty + i.quantity, available_qty = available_qty - i.quantity, updated_at = NOW() FROM UNNEST(@inputs.items) AS i WHERE parts_inventory.warehouse_id = @selectedWarehouseId AND parts_inventory.part_number = i.partNumber AND parts_inventory.available_qty >= i.quantity",
+              "outputBinding": "reservedInventory",
+              "lineage": { "writes": ["parts_inventory"] },
+              "affectedRowsCheck": {
+                "operator": ">",
+                "expected": 0,
+                "onViolation": "throw",
+                "errorCode": "STOCK_SHORTAGE",
+                "description": "在庫不足検知: WHERE available_qty >= i.quantity を全 items が満たさず 0 行更新の場合 STOCK_SHORTAGE で rollback。複数明細の部分不足検知は別途 CTE で事前 COUNT する想定 (実装側補足)。"
+              }
+            },
+            {
+              "id": "step-001-05-03",
+              "type": "dbAccess",
+              "description": "shipment_orders に PLANNED 配送指示を登録する。id は TX 外で採番した @newShipmentId を明示指定 (Rule 2 遵守: TX inner outputBinding を TX 外で参照しないため、ID は事前確定)。",
+              "maturity": "committed",
+              "tableName": "shipment_orders",
+              "operation": "INSERT",
+              "sql": "INSERT INTO shipment_orders (id, order_id, warehouse_id, current_status, planned_ship_at, requested_by, delivery_attempts, created_at) VALUES (@newShipmentId, @inputs.orderId, @selectedWarehouseId, 'PLANNED', @plannedShipAt, @sessionUserId, 0, NOW())",
+              "lineage": { "writes": ["shipment_orders"] }
+            }
+          ]
+        },
+        {
+          "id": "step-001-06",
+          "type": "branch",
+          "description": "TX commit 結果で commit / rollback を分岐する。runIf による return 後 fallthrough を構造化で防止する。",
+          "maturity": "committed",
+          "branches": [
+            {
+              "id": "br-001-06-rollback-shortage",
+              "code": "ROLLBACK_SHORTAGE",
+              "label": "TX rollback (STOCK_SHORTAGE)",
+              "condition": "@txResult.committed == false && @txResult.errorCode == 'STOCK_SHORTAGE'",
+              "steps": [
+                {
+                  "id": "step-001-06-shortage-01",
+                  "type": "audit",
+                  "description": "在庫不足を監査ログに記録する。",
+                  "maturity": "committed",
+                  "action": "shipment.create",
+                  "resource": { "type": "Order", "id": "@inputs.orderId" },
+                  "result": "failure",
+                  "reason": "STOCK_SHORTAGE",
+                  "sensitive": false
+                },
+                {
+                  "id": "step-001-06-shortage-02",
+                  "type": "return",
+                  "description": "409 在庫不足を返す。shipment_orders は INSERT されておらず parts_inventory も rollback で元値。",
+                  "maturity": "committed",
+                  "responseRef": "409-stock-shortage",
+                  "bodyExpression": "{ code: 'STOCK_SHORTAGE', message: '在庫が不足しています' }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-001-06-commit",
+            "code": "COMMIT",
+            "label": "TX commit (PLANNED 登録成功)",
+            "steps": [
+              {
+                "id": "step-001-06-commit-01",
+                "type": "eventPublish",
+                "description": "shipment.created イベントを発行する。shipmentId / plannedShipAt は TX 前に確定した値を使用 (Rule 2 遵守)。",
+                "maturity": "committed",
+                "topic": "shipment.created",
+                "eventRef": "shipment.created",
+                "payload": "{ shipmentId: @newShipmentId, orderId: @inputs.orderId, warehouseId: @selectedWarehouseId, status: 'PLANNED', plannedShipAt: @plannedShipAt }"
+              },
+              {
+                "id": "step-001-06-commit-02",
+                "type": "externalSystem",
+                "description": "WMS にピッキング指示を送信する。TX 外なので失敗時は continue + audit。Saga 補償までは行わない。",
+                "maturity": "committed",
+                "systemName": "Warehouse Management System",
+                "systemRef": "wmsSystem",
+                "httpCall": {
+                  "method": "POST",
+                  "path": "/v1/picking-orders",
+                  "body": "{ shipmentId: @newShipmentId, warehouseId: @selectedWarehouseId, items: @inputs.items }"
+                },
+                "idempotencyKey": "wms-pick-@newShipmentId",
+                "outputBinding": "wmsResult",
+                "outcomes": {
+                  "success": { "action": "continue" },
+                  "failure": {
+                    "action": "continue",
+                    "sideEffects": [
+                      {
+                        "id": "step-001-06-commit-02-side-01",
+                        "type": "audit",
+                        "description": "WMS 連携失敗を監査ログに記録する (運用検知用)。",
+                        "maturity": "committed",
+                        "action": "wms.picking-order",
+                        "resource": { "type": "ShipmentOrder", "id": "@newShipmentId" },
+                        "result": "failure",
+                        "reason": "WMS_UNAVAILABLE",
+                        "sensitive": false
+                      }
+                    ]
+                  },
+                  "timeout": { "action": "continue", "sameAs": "failure" }
+                }
+              },
+              {
+                "id": "step-001-06-commit-03",
+                "type": "return",
+                "description": "201 Created を返す。",
+                "maturity": "committed",
+                "responseRef": "201-created",
+                "bodyExpression": "{ shipmentId: @newShipmentId, status: 'PLANNED', plannedShipAt: @plannedShipAt }"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "act-002",
+      "name": "倉庫ピッキング完了",
+      "trigger": "submit",
+      "description": "倉庫作業者がモバイル端末から走査した商品 ID リストを送信する。logistics:PickingStep 拡張でピッキング検証を行い、shipment_orders を PICKED に遷移させる。",
+      "maturity": "committed",
+      "httpRoute": {
+        "method": "POST",
+        "path": "/api/shipments/:shipmentId/pick",
+        "auth": "required"
+      },
+      "inputs": [
+        { "name": "shipmentId", "label": "配送指示 ID", "type": { "kind": "shipmentId" }, "required": true, "domainRef": "ShipmentId" },
+        { "name": "operatorId", "label": "作業者 ID", "type": "string", "required": true },
+        { "name": "scannedItems", "label": "走査済み商品 ID リスト", "type": { "kind": "array", "itemType": "string" }, "required": true, "description": "倉庫モバイル端末でバーコード走査した商品 ID の配列 (string)。" }
+      ],
+      "outputs": [
+        { "name": "shipmentId", "label": "配送指示 ID", "type": "string", "domainRef": "ShipmentId" },
+        { "name": "status", "label": "配送ステータス", "type": "string", "domainRef": "DeliveryStatus" }
+      ],
+      "responses": [
+        { "id": "200-picked", "status": 200, "bodySchema": { "schema": { "type": "object", "required": ["shipmentId", "status"], "properties": { "shipmentId": { "type": "string" }, "status": { "type": "string", "const": "PICKED" } }, "additionalProperties": false } }, "when": "ピッキング完了 + shipment_orders を PICKED に遷移" },
+        { "id": "400-validation", "status": 400, "bodySchema": { "schema": { "type": "object" } }, "when": "入力値が不正" },
+        { "id": "404-shipment-not-found", "status": 404, "bodySchema": { "schema": { "type": "object" } }, "when": "対象 shipment が存在しない" },
+        { "id": "409-invalid-state-transition", "status": 409, "bodySchema": { "schema": { "type": "object" } }, "when": "shipment が PLANNED 以外 (前提状態違反)" }
+      ],
+      "steps": [
+        {
+          "id": "step-002-01",
+          "type": "validation",
+          "description": "shipmentId / operatorId / scannedItems の必須をチェック。",
+          "maturity": "committed",
+          "conditions": "shipmentId/operatorId は必須。scannedItems は 1 件以上。",
+          "rules": [
+            { "field": "shipmentId", "type": "required", "message": "配送指示 ID は必須です" },
+            { "field": "operatorId", "type": "required", "message": "作業者 ID は必須です" },
+            { "field": "scannedItems", "type": "required", "message": "走査済み商品リストは必須です" }
+          ],
+          "fieldErrorsVar": "fieldErrors",
+          "inlineBranch": {
+            "ok": "shipment 取得へ進む",
+            "ng": "400 バリデーションエラー",
+            "ngResponseRef": "400-validation",
+            "ngBodyExpression": "{ code: 'VALIDATION', message: '入力値が不正です', fieldErrors: @fieldErrors }"
+          }
+        },
+        {
+          "id": "step-002-02",
+          "type": "dbAccess",
+          "description": "対象 shipment_orders を取得する。",
+          "maturity": "committed",
+          "tableName": "shipment_orders",
+          "operation": "SELECT",
+          "sql": "SELECT id, current_status, warehouse_id, order_id FROM shipment_orders WHERE id = @inputs.shipmentId",
+          "outputBinding": "shipment",
+          "lineage": { "reads": ["shipment_orders"] }
+        },
+        {
+          "id": "step-002-03",
+          "type": "branch",
+          "description": "shipment が存在しない、または PLANNED 以外の場合は早期リターン。",
+          "maturity": "committed",
+          "branches": [
+            {
+              "id": "br-002-03-not-found",
+              "code": "NOT_FOUND",
+              "label": "shipment なし",
+              "condition": "@shipment == null",
+              "steps": [
+                {
+                  "id": "step-002-03-not-found-01",
+                  "type": "return",
+                  "description": "404 shipment なし。",
+                  "maturity": "committed",
+                  "responseRef": "404-shipment-not-found",
+                  "bodyExpression": "{ code: 'SHIPMENT_NOT_FOUND', shipmentId: @inputs.shipmentId }"
+                }
+              ]
+            },
+            {
+              "id": "br-002-03-bad-state",
+              "code": "BAD_STATE",
+              "label": "前提状態違反",
+              "condition": "@shipment != null && @shipment.current_status != 'PLANNED'",
+              "steps": [
+                {
+                  "id": "step-002-03-bad-state-01",
+                  "type": "return",
+                  "description": "409 PLANNED 以外からはピッキング不可。",
+                  "maturity": "committed",
+                  "responseRef": "409-invalid-state-transition",
+                  "bodyExpression": "{ code: 'INVALID_STATE_TRANSITION', currentStatus: @shipment.current_status }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-002-03-ok",
+            "code": "OK",
+            "label": "PLANNED 取得済み",
+            "steps": []
+          }
+        },
+        {
+          "id": "step-002-04",
+          "type": "other",
+          "description": "logistics:PickingStep 拡張定義 (docs/sample-project/extensions/logistics/steps.json) を呼び出す意図。走査済み商品リストと shipment_orders の明細を突合し、ピッキング工程の完全性を検証する。出力 (pickingResult.complete / shortItems) を後段で参照する。",
+          "maturity": "committed",
+          "note": "extensionStep=logistics:PickingStep; shipmentId=@inputs.shipmentId; warehouseLocation=@shipment.warehouse_id; operatorId=@inputs.operatorId; scannedItems=@inputs.scannedItems",
+          "outputBinding": "pickingResult",
+          "outputSchema": {
+            "complete": "boolean",
+            "shortItems": "array",
+            "verifiedAt": "string"
+          }
+        },
+        {
+          "id": "step-002-05",
+          "type": "branch",
+          "description": "ピッキング不完全 (走査漏れ) の場合は 409 を返し、shipment は PLANNED のまま据え置く。",
+          "maturity": "committed",
+          "branches": [
+            {
+              "id": "br-002-05-incomplete",
+              "code": "INCOMPLETE",
+              "label": "走査漏れあり",
+              "condition": "@pickingResult.complete == false",
+              "steps": [
+                {
+                  "id": "step-002-05-incomplete-01",
+                  "type": "audit",
+                  "description": "走査漏れを監査ログに記録する (運用検知)。",
+                  "maturity": "committed",
+                  "action": "shipment.pick",
+                  "resource": { "type": "ShipmentOrder", "id": "@inputs.shipmentId" },
+                  "result": "failure",
+                  "reason": "PICKING_INCOMPLETE",
+                  "sensitive": false
+                },
+                {
+                  "id": "step-002-05-incomplete-02",
+                  "type": "return",
+                  "description": "409 走査漏れあり。shipment は PLANNED 据え置き。",
+                  "maturity": "committed",
+                  "responseRef": "409-invalid-state-transition",
+                  "bodyExpression": "{ code: 'INVALID_STATE_TRANSITION', message: 'ピッキング走査漏れあり', shortItems: @pickingResult.shortItems }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-002-05-complete",
+            "code": "COMPLETE",
+            "label": "ピッキング完了",
+            "steps": [
+              {
+                "id": "step-002-05-complete-01",
+                "type": "dbAccess",
+                "description": "shipment_orders を PICKED に遷移する。affectedRowsCheck で前提状態 (PLANNED) を再確認。",
+                "maturity": "committed",
+                "tableName": "shipment_orders",
+                "operation": "UPDATE",
+                "sql": "UPDATE shipment_orders SET current_status = 'PICKED', picked_at = NOW(), updated_at = NOW() WHERE id = @inputs.shipmentId AND current_status = 'PLANNED' RETURNING id, current_status",
+                "outputBinding": "updatedShipment",
+                "lineage": { "writes": ["shipment_orders"] },
+                "affectedRowsCheck": {
+                  "operator": ">",
+                  "expected": 0,
+                  "onViolation": "throw",
+                  "errorCode": "INVALID_STATE_TRANSITION",
+                  "description": "PLANNED 以外からの遷移を検知"
+                }
+              },
+              {
+                "id": "step-002-05-complete-02",
+                "type": "audit",
+                "description": "ピッキング完了を監査ログに記録する。",
+                "maturity": "committed",
+                "action": "shipment.pick",
+                "resource": { "type": "ShipmentOrder", "id": "@inputs.shipmentId" },
+                "result": "success",
+                "reason": "PICKED",
+                "sensitive": false
+              },
+              {
+                "id": "step-002-05-complete-03",
+                "type": "eventPublish",
+                "description": "shipment.picked イベントを発行する。",
+                "maturity": "committed",
+                "topic": "shipment.picked",
+                "eventRef": "shipment.picked",
+                "payload": "{ shipmentId: @inputs.shipmentId, operatorId: @inputs.operatorId, pickedAt: @now }"
+              },
+              {
+                "id": "step-002-05-complete-04",
+                "type": "return",
+                "description": "200 PICKED を返す。",
+                "maturity": "committed",
+                "responseRef": "200-picked",
+                "bodyExpression": "{ shipmentId: @inputs.shipmentId, status: 'PICKED' }"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "act-003",
+      "name": "配送追跡更新 (運送会社コールバック)",
+      "trigger": "other",
+      "description": "external trigger (logistics:deliveryAttempted): 運送会社からの追跡コールバックを受信し、tracking_events に冪等登録 (UPSERT_IDEMPOTENT)、shipment_orders.current_status を更新、DELIVERED は受領確認を記録、FAILED は再配達/返送を判断する。",
+      "maturity": "committed",
+      "httpRoute": {
+        "method": "POST",
+        "path": "/internal/carrier-callback/tracking-update",
+        "auth": "required"
+      },
+      "requiredPermissions": ["system"],
+      "inputs": [
+        { "name": "trackingNumber", "label": "追跡番号", "type": { "kind": "trackingNumber" }, "required": true, "domainRef": "TrackingNumber" },
+        { "name": "shipmentId", "label": "配送指示 ID", "type": { "kind": "shipmentId" }, "required": true, "domainRef": "ShipmentId" },
+        { "name": "status", "label": "配送ステータス", "type": { "kind": "deliveryStatus" }, "required": true, "domainRef": "DeliveryStatus" },
+        { "name": "checkpointAt", "label": "チェックポイント時刻", "type": "string", "required": true },
+        { "name": "checkpointLocation", "label": "チェックポイント拠点", "type": "string", "required": false },
+        { "name": "receivedBy", "label": "受領者氏名 (DELIVERED 時)", "type": "string", "required": false },
+        { "name": "confirmationKind", "label": "受領種別 (DELIVERED 時)", "type": "string", "required": false }
+      ],
+      "outputs": [
+        { "name": "shipmentId", "label": "配送指示 ID", "type": "string", "domainRef": "ShipmentId" },
+        { "name": "status", "label": "現在ステータス", "type": "string", "domainRef": "DeliveryStatus" }
+      ],
+      "responses": [
+        { "id": "200-updated", "status": 200, "bodySchema": { "schema": { "type": "object", "required": ["shipmentId", "status"], "properties": { "shipmentId": { "type": "string" }, "status": { "type": "string" } }, "additionalProperties": false } }, "when": "新規追跡更新を反映した" },
+        { "id": "200-already-processed", "status": 200, "bodySchema": { "schema": { "type": "object", "required": ["status"], "properties": { "status": { "type": "string", "const": "ALREADY_PROCESSED" } }, "additionalProperties": false } }, "when": "同一 (trackingNumber, checkpointAt) が既に登録済みで no-op" },
+        { "id": "400-validation", "status": 400, "bodySchema": { "schema": { "type": "object" } }, "when": "入力値が不正" },
+        { "id": "404-shipment-not-found", "status": 404, "bodySchema": { "schema": { "type": "object" } }, "when": "対象 shipment が存在しない" },
+        { "id": "502-carrier-rejected", "status": 502, "bodySchema": { "schema": { "type": "object" } }, "when": "DELIVERED 時に customerNotification 必須経路で運送会社情報不整合" }
+      ],
+      "steps": [
+        {
+          "id": "step-003-01",
+          "type": "validation",
+          "description": "trackingNumber/shipmentId/status/checkpointAt の必須を検証。DELIVERED は confirmationKind 必須。",
+          "maturity": "committed",
+          "conditions": "trackingNumber/shipmentId/status/checkpointAt は必須。status は IN_TRANSIT/OUT_FOR_DELIVERY/DELIVERED/FAILED/RETURNED のいずれか。status==DELIVERED の場合 confirmationKind は必須。",
+          "rules": [
+            { "field": "trackingNumber", "type": "required", "message": "追跡番号は必須です" },
+            { "field": "shipmentId", "type": "required", "message": "配送指示 ID は必須です" },
+            { "field": "status", "type": "enum", "values": ["IN_TRANSIT", "OUT_FOR_DELIVERY", "DELIVERED", "FAILED", "RETURNED"], "message": "配送ステータスが不正です" },
+            { "field": "checkpointAt", "type": "required", "message": "チェックポイント時刻は必須です" },
+            { "field": "confirmationKind", "type": "required", "condition": "@inputs.status == 'DELIVERED'", "message": "DELIVERED 時は受領種別 (confirmationKind) が必須です" },
+            { "field": "confirmationKind", "type": "enum", "condition": "@inputs.status == 'DELIVERED'", "values": ["SIGNATURE", "PHOTO", "ABSENT_NOTICE"], "message": "受領種別は SIGNATURE/PHOTO/ABSENT_NOTICE のいずれかです" }
+          ],
+          "fieldErrorsVar": "fieldErrors",
+          "inlineBranch": {
+            "ok": "shipment 取得へ進む",
+            "ng": "400 バリデーションエラー",
+            "ngResponseRef": "400-validation",
+            "ngBodyExpression": "{ code: 'VALIDATION', message: '入力値が不正です', fieldErrors: @fieldErrors }"
+          }
+        },
+        {
+          "id": "step-003-02",
+          "type": "dbAccess",
+          "description": "対象 shipment_orders を取得する (現在ステータスと再配達回数を含む)。",
+          "maturity": "committed",
+          "tableName": "shipment_orders",
+          "operation": "SELECT",
+          "sql": "SELECT id, current_status, tracking_number, delivery_attempts, order_id FROM shipment_orders WHERE id = @inputs.shipmentId",
+          "outputBinding": "shipment",
+          "lineage": { "reads": ["shipment_orders"] }
+        },
+        {
+          "id": "step-003-03",
+          "type": "branch",
+          "description": "shipment が存在しない場合は 404 を返す。",
+          "maturity": "committed",
+          "branches": [
+            {
+              "id": "br-003-03-not-found",
+              "code": "NOT_FOUND",
+              "label": "shipment なし",
+              "condition": "@shipment == null",
+              "steps": [
+                {
+                  "id": "step-003-03-not-found-01",
+                  "type": "return",
+                  "description": "404 shipment なし。",
+                  "maturity": "committed",
+                  "responseRef": "404-shipment-not-found",
+                  "bodyExpression": "{ code: 'SHIPMENT_NOT_FOUND', shipmentId: @inputs.shipmentId }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-003-03-found",
+            "code": "FOUND",
+            "label": "shipment 取得済み",
+            "steps": []
+          }
+        },
+        {
+          "id": "step-003-04",
+          "type": "dbAccess",
+          "description": "UPSERT_IDEMPOTENT: tracking_events に (tracking_number, checkpoint_at) 一意で冪等登録し、既存なら no-op (RETURNING で id を返さない) にする。",
+          "maturity": "committed",
+          "tableName": "tracking_events",
+          "operation": "UPSERT_IDEMPOTENT",
+          "sql": "INSERT INTO tracking_events (tracking_number, shipment_id, status, checkpoint_at, checkpoint_location, request_id, created_at) VALUES (@inputs.trackingNumber, @inputs.shipmentId, @inputs.status, @inputs.checkpointAt, @inputs.checkpointLocation, @requestId, NOW()) ON CONFLICT (tracking_number, checkpoint_at) DO NOTHING RETURNING id",
+          "outputBinding": "upsertedTrack",
+          "lineage": { "writes": ["tracking_events"] }
+        },
+        {
+          "id": "step-003-05",
+          "type": "branch",
+          "description": "冪等 no-op 経路と新規登録経路を分岐する。後続の状態遷移・イベント発行・外部連携はすべて新規登録経路に閉じる。",
+          "maturity": "committed",
+          "branches": [
+            {
+              "id": "br-003-05-noop",
+              "code": "NOOP",
+              "label": "冪等 no-op (再送)",
+              "condition": "@upsertedTrack?.id == null",
+              "steps": [
+                {
+                  "id": "step-003-05-noop-01",
+                  "type": "return",
+                  "description": "200 ALREADY_PROCESSED を返す。状態巻き戻し・二重イベント発行を防ぐ規約レスポンス。",
+                  "maturity": "committed",
+                  "responseRef": "200-already-processed",
+                  "bodyExpression": "{ status: 'ALREADY_PROCESSED' }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-003-05-new",
+            "code": "NEW",
+            "label": "新規追跡更新",
+            "steps": [
+              {
+                "id": "step-003-05-new-01",
+                "type": "other",
+                "description": "logistics:TrackingUpdateStep 拡張定義 (docs/sample-project/extensions/logistics/steps.json) を呼び出す意図。tracking_events 行から shipment_orders.current_status へのマッピング (状態巻き戻し防止) を補助する。",
+                "maturity": "committed",
+                "note": "extensionStep=logistics:TrackingUpdateStep; trackingNumber=@inputs.trackingNumber; deliveryStatus=@inputs.status; checkpointAt=@inputs.checkpointAt; checkpointLocation=@inputs.checkpointLocation",
+                "outputBinding": "trackUpdate",
+                "outputSchema": {
+                  "appliedStatus": "string",
+                  "stateChanged": "boolean"
+                }
+              },
+              {
+                "id": "step-003-05-new-02",
+                "type": "branch",
+                "description": "ステータス値で DELIVERED / FAILED / その他に分岐する。DELIVERED は受領確認 + 顧客通知、FAILED は再配達/返送判断、それ以外は単純な状態反映のみ。",
+                "maturity": "committed",
+                "branches": [
+                  {
+                    "id": "br-003-05-new-02-delivered",
+                    "code": "DELIVERED",
+                    "label": "配送完了",
+                    "condition": "@inputs.status == 'DELIVERED'",
+                    "steps": [
+                      {
+                        "id": "step-003-05-new-02-delivered-01",
+                        "type": "transactionScope",
+                        "description": "DELIVERED 経路: delivery_confirmations INSERT + shipment_orders を DELIVERED に更新を 1 TX で実行する。inner step は @inputs / @shipment / @upsertedTrack の TX 外変数のみ参照する。",
+                        "maturity": "committed",
+                        "isolationLevel": "READ_COMMITTED",
+                        "propagation": "REQUIRED",
+                        "outputBinding": "deliveredTxResult",
+                        "rollbackOn": ["INVALID_STATE_TRANSITION"],
+                        "steps": [
+                          {
+                            "id": "step-003-05-new-02-delivered-01-01",
+                            "type": "dbAccess",
+                            "description": "logistics:DeliveryConfirmStep 拡張意図に対応する DB 書込: delivery_confirmations に受領確認を記録する。outputBinding は使わず TX 内でのみ反映 (Rule 2 遵守)。",
+                            "maturity": "committed",
+                            "tableName": "delivery_confirmations",
+                            "operation": "INSERT",
+                            "sql": "INSERT INTO delivery_confirmations (shipment_id, tracking_number, confirmation_kind, received_by, confirmed_at, created_at) VALUES (@inputs.shipmentId, @inputs.trackingNumber, @inputs.confirmationKind, @inputs.receivedBy, @inputs.checkpointAt, NOW())",
+                            "lineage": { "writes": ["delivery_confirmations"] }
+                          },
+                          {
+                            "id": "step-003-05-new-02-delivered-01-02",
+                            "type": "dbAccess",
+                            "description": "shipment_orders を DELIVERED に遷移させる。affectedRowsCheck で前提状態 (IN_TRANSIT/OUT_FOR_DELIVERY/PICKED) を確認する (DELIVERED → DELIVERED 戻りも affectedRows=0 で reject)。outputBinding は TX 内 step なので TX 外では参照しない (Rule 2 遵守)。",
+                            "maturity": "committed",
+                            "tableName": "shipment_orders",
+                            "operation": "UPDATE",
+                            "sql": "UPDATE shipment_orders SET current_status = 'DELIVERED', delivered_at = @inputs.checkpointAt, updated_at = NOW() WHERE id = @inputs.shipmentId AND current_status IN ('PICKED', 'IN_TRANSIT', 'OUT_FOR_DELIVERY')",
+                            "lineage": { "writes": ["shipment_orders"] },
+                            "affectedRowsCheck": {
+                              "operator": ">",
+                              "expected": 0,
+                              "onViolation": "throw",
+                              "errorCode": "INVALID_STATE_TRANSITION",
+                              "description": "前提状態違反 (DELIVERED/RETURNED/FAILED 等の終端からの再遷移) を検知"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "id": "step-003-05-new-02-delivered-02",
+                        "type": "branch",
+                        "description": "TX 結果で commit / rollback を分岐し、commit 経路で event 発行と顧客通知を行う。runIf による return 後 fallthrough を構造化で防止する。",
+                        "maturity": "committed",
+                        "branches": [
+                          {
+                            "id": "br-003-05-new-02-delivered-02-rollback",
+                            "code": "ROLLBACK",
+                            "label": "TX rollback (前提状態違反)",
+                            "condition": "@deliveredTxResult.committed == false",
+                            "steps": [
+                              {
+                                "id": "step-003-05-new-02-delivered-02-rollback-01",
+                                "type": "audit",
+                                "description": "DELIVERED への遷移失敗を監査ログに記録 (運用検知)。",
+                                "maturity": "committed",
+                                "action": "shipment.deliver",
+                                "resource": { "type": "ShipmentOrder", "id": "@inputs.shipmentId" },
+                                "result": "failure",
+                                "reason": "INVALID_STATE_TRANSITION",
+                                "sensitive": false
+                              },
+                              {
+                                "id": "step-003-05-new-02-delivered-02-rollback-02",
+                                "type": "return",
+                                "description": "200 既処理として返す (運送会社からの再送等で既に DELIVERED の場合)。tracking_events 自体は新規登録済みだが、状態は変えない。",
+                                "maturity": "committed",
+                                "responseRef": "200-already-processed",
+                                "bodyExpression": "{ status: 'ALREADY_PROCESSED' }"
+                              }
+                            ]
+                          }
+                        ],
+                        "elseBranch": {
+                          "id": "br-003-05-new-02-delivered-02-commit",
+                          "code": "COMMIT",
+                          "label": "DELIVERED 確定",
+                          "steps": [
+                            {
+                              "id": "step-003-05-new-02-delivered-02-commit-01",
+                              "type": "eventPublish",
+                              "description": "shipment.tracking_updated イベントを発行する。",
+                              "maturity": "committed",
+                              "topic": "shipment.tracking_updated",
+                              "eventRef": "shipment.tracking_updated",
+                              "payload": "{ shipmentId: @inputs.shipmentId, trackingNumber: @inputs.trackingNumber, status: 'DELIVERED', checkpointAt: @inputs.checkpointAt }"
+                            },
+                            {
+                              "id": "step-003-05-new-02-delivered-02-commit-02",
+                              "type": "eventPublish",
+                              "description": "shipment.delivered イベントを発行する。",
+                              "maturity": "committed",
+                              "topic": "shipment.delivered",
+                              "eventRef": "shipment.delivered",
+                              "payload": "{ shipmentId: @inputs.shipmentId, confirmationKind: @inputs.confirmationKind, receivedBy: @inputs.receivedBy, confirmedAt: @inputs.checkpointAt }"
+                            },
+                            {
+                              "id": "step-003-05-new-02-delivered-02-commit-03",
+                              "type": "externalSystem",
+                              "description": "顧客へ配送完了通知を送る (fireAndForget、failure: continue)。通知未達は別運用で再送する。",
+                              "maturity": "committed",
+                              "systemName": "Customer Notification Gateway",
+                              "systemRef": "customerNotification",
+                              "httpCall": {
+                                "method": "POST",
+                                "path": "/notifications/shipment-delivered",
+                                "body": "{ shipmentId: @inputs.shipmentId, trackingNumber: @inputs.trackingNumber, confirmationKind: @inputs.confirmationKind, confirmedAt: @inputs.checkpointAt }"
+                              },
+                              "fireAndForget": true,
+                              "outcomes": {
+                                "success": { "action": "continue" },
+                                "failure": { "action": "continue" },
+                                "timeout": { "action": "continue", "sameAs": "failure" }
+                              }
+                            },
+                            {
+                              "id": "step-003-05-new-02-delivered-02-commit-04",
+                              "type": "return",
+                              "description": "200 DELIVERED 確定を返す。",
+                              "maturity": "committed",
+                              "responseRef": "200-updated",
+                              "bodyExpression": "{ shipmentId: @inputs.shipmentId, status: 'DELIVERED' }"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "id": "br-003-05-new-02-failed",
+                    "code": "FAILED",
+                    "label": "配送失敗 (再配達/返送判断)",
+                    "condition": "@inputs.status == 'FAILED'",
+                    "steps": [
+                      {
+                        "id": "step-003-05-new-02-failed-01",
+                        "type": "compute",
+                        "description": "現在の試行回数 +1 を算出する。",
+                        "maturity": "committed",
+                        "expression": "@shipment.delivery_attempts + 1",
+                        "outputBinding": "newAttemptCount"
+                      },
+                      {
+                        "id": "step-003-05-new-02-failed-02",
+                        "type": "branch",
+                        "description": "再配達上限 (@conv.limit.maxDeliveryAttempts) と比較し、再配達 / 返送に分岐する。",
+                        "maturity": "committed",
+                        "branches": [
+                          {
+                            "id": "br-003-05-new-02-failed-02-redeliver",
+                            "code": "REDELIVER",
+                            "label": "再配達枠あり",
+                            "condition": "@newAttemptCount < @conv.limit.maxDeliveryAttempts",
+                            "steps": [
+                              {
+                                "id": "step-003-05-new-02-failed-02-redeliver-01",
+                                "type": "compute",
+                                "description": "次回配達日時を算出する。",
+                                "maturity": "committed",
+                                "expression": "@fn.scheduleNextAttempt(@newAttemptCount, @inputs.checkpointAt)",
+                                "outputBinding": "nextAttemptAt"
+                              },
+                              {
+                                "id": "step-003-05-new-02-failed-02-redeliver-02",
+                                "type": "dbAccess",
+                                "description": "shipment_orders.delivery_attempts を加算し current_status を FAILED (再配達待ち) に更新する。",
+                                "maturity": "committed",
+                                "tableName": "shipment_orders",
+                                "operation": "UPDATE",
+                                "sql": "UPDATE shipment_orders SET delivery_attempts = @newAttemptCount, current_status = 'FAILED', next_attempt_at = @nextAttemptAt, updated_at = NOW() WHERE id = @inputs.shipmentId AND current_status IN ('IN_TRANSIT', 'OUT_FOR_DELIVERY', 'FAILED') RETURNING id, current_status",
+                                "outputBinding": "redeliverShipment",
+                                "lineage": { "writes": ["shipment_orders"] }
+                              },
+                              {
+                                "id": "step-003-05-new-02-failed-02-redeliver-03",
+                                "type": "eventPublish",
+                                "description": "shipment.tracking_updated イベントを発行する。",
+                                "maturity": "committed",
+                                "topic": "shipment.tracking_updated",
+                                "eventRef": "shipment.tracking_updated",
+                                "payload": "{ shipmentId: @inputs.shipmentId, trackingNumber: @inputs.trackingNumber, status: 'FAILED', checkpointAt: @inputs.checkpointAt }"
+                              },
+                              {
+                                "id": "step-003-05-new-02-failed-02-redeliver-04",
+                                "type": "eventPublish",
+                                "description": "shipment.redelivery_scheduled イベントを発行する。",
+                                "maturity": "committed",
+                                "topic": "shipment.redelivery_scheduled",
+                                "eventRef": "shipment.redelivery_scheduled",
+                                "payload": "{ shipmentId: @inputs.shipmentId, attemptCount: @newAttemptCount, nextAttemptAt: @nextAttemptAt }"
+                              },
+                              {
+                                "id": "step-003-05-new-02-failed-02-redeliver-05",
+                                "type": "externalSystem",
+                                "description": "顧客へ再配達日時通知を送る (fireAndForget)。",
+                                "maturity": "committed",
+                                "systemName": "Customer Notification Gateway",
+                                "systemRef": "customerNotification",
+                                "httpCall": {
+                                  "method": "POST",
+                                  "path": "/notifications/redelivery-scheduled",
+                                  "body": "{ shipmentId: @inputs.shipmentId, attemptCount: @newAttemptCount, nextAttemptAt: @nextAttemptAt }"
+                                },
+                                "fireAndForget": true,
+                                "outcomes": {
+                                  "success": { "action": "continue" },
+                                  "failure": { "action": "continue" },
+                                  "timeout": { "action": "continue", "sameAs": "failure" }
+                                }
+                              },
+                              {
+                                "id": "step-003-05-new-02-failed-02-redeliver-06",
+                                "type": "return",
+                                "description": "200 FAILED + 再配達予定で返す。",
+                                "maturity": "committed",
+                                "responseRef": "200-updated",
+                                "bodyExpression": "{ shipmentId: @inputs.shipmentId, status: 'FAILED' }"
+                              }
+                            ]
+                          }
+                        ],
+                        "elseBranch": {
+                          "id": "br-003-05-new-02-failed-02-return",
+                          "code": "RETURN",
+                          "label": "再配達上限超過 (返送判断)",
+                          "steps": [
+                            {
+                              "id": "step-003-05-new-02-failed-02-return-01",
+                              "type": "dbAccess",
+                              "description": "shipment_orders を RETURNED に遷移させ、最終試行回数を保存する。補償処理として在庫戻し (parts_inventory.available_qty +=) を伴うが、本サンプルでは別フロー (return-to-warehouse) に委譲する。",
+                              "maturity": "committed",
+                              "tableName": "shipment_orders",
+                              "operation": "UPDATE",
+                              "sql": "UPDATE shipment_orders SET delivery_attempts = @newAttemptCount, current_status = 'RETURNED', updated_at = NOW() WHERE id = @inputs.shipmentId RETURNING id, current_status",
+                              "outputBinding": "returnedShipment",
+                              "lineage": { "writes": ["shipment_orders"] }
+                            },
+                            {
+                              "id": "step-003-05-new-02-failed-02-return-02",
+                              "type": "audit",
+                              "description": "返送判断を監査ログに記録する (sensitive: 顧客契約に影響)。",
+                              "maturity": "committed",
+                              "action": "shipment.return",
+                              "resource": { "type": "ShipmentOrder", "id": "@inputs.shipmentId" },
+                              "result": "success",
+                              "reason": "REDELIVERY_LIMIT_EXCEEDED",
+                              "sensitive": true
+                            },
+                            {
+                              "id": "step-003-05-new-02-failed-02-return-03",
+                              "type": "eventPublish",
+                              "description": "shipment.tracking_updated イベントを発行する。",
+                              "maturity": "committed",
+                              "topic": "shipment.tracking_updated",
+                              "eventRef": "shipment.tracking_updated",
+                              "payload": "{ shipmentId: @inputs.shipmentId, trackingNumber: @inputs.trackingNumber, status: 'RETURNED', checkpointAt: @inputs.checkpointAt }"
+                            },
+                            {
+                              "id": "step-003-05-new-02-failed-02-return-04",
+                              "type": "eventPublish",
+                              "description": "shipment.return_required イベントを発行する。",
+                              "maturity": "committed",
+                              "topic": "shipment.return_required",
+                              "eventRef": "shipment.return_required",
+                              "payload": "{ shipmentId: @inputs.shipmentId, attemptCount: @newAttemptCount, reason: 'REDELIVERY_LIMIT_EXCEEDED' }"
+                            },
+                            {
+                              "id": "step-003-05-new-02-failed-02-return-05",
+                              "type": "return",
+                              "description": "200 RETURNED 確定を返す。",
+                              "maturity": "committed",
+                              "responseRef": "200-updated",
+                              "bodyExpression": "{ shipmentId: @inputs.shipmentId, status: 'RETURNED' }"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "elseBranch": {
+                  "id": "br-003-05-new-02-other",
+                  "code": "OTHER_STATUS",
+                  "label": "IN_TRANSIT / OUT_FOR_DELIVERY / RETURNED 等 (単純反映)",
+                  "steps": [
+                    {
+                      "id": "step-003-05-new-02-other-01",
+                      "type": "dbAccess",
+                      "description": "shipment_orders.current_status を反映する。状態巻き戻し (DELIVERED → 戻り) を防ぐため終端状態でない時のみ更新する。",
+                      "maturity": "committed",
+                      "tableName": "shipment_orders",
+                      "operation": "UPDATE",
+                      "sql": "UPDATE shipment_orders SET current_status = @inputs.status, updated_at = NOW() WHERE id = @inputs.shipmentId AND current_status NOT IN ('DELIVERED', 'RETURNED') RETURNING id, current_status",
+                      "outputBinding": "intransitShipment",
+                      "lineage": { "writes": ["shipment_orders"] }
+                    },
+                    {
+                      "id": "step-003-05-new-02-other-02",
+                      "type": "eventPublish",
+                      "description": "shipment.tracking_updated イベントを発行する。",
+                      "maturity": "committed",
+                      "topic": "shipment.tracking_updated",
+                      "eventRef": "shipment.tracking_updated",
+                      "payload": "{ shipmentId: @inputs.shipmentId, trackingNumber: @inputs.trackingNumber, status: @inputs.status, checkpointAt: @inputs.checkpointAt }"
+                    },
+                    {
+                      "id": "step-003-05-new-02-other-03",
+                      "type": "return",
+                      "description": "200 状態反映済みで返す。",
+                      "maturity": "committed",
+                      "responseRef": "200-updated",
+                      "bodyExpression": "{ shipmentId: @inputs.shipmentId, status: @inputs.status }"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "testScenarios": [
+    {
+      "id": "happy-shipment-create-and-deliver",
+      "name": "受注確定→配送指示登録→DELIVERED まで通過する",
+      "description": "在庫充足の受注から配送指示を登録し、運送会社から DELIVERED を受信して shipment_orders が DELIVERED 確定、顧客通知が送信される正常系。",
+      "given": [
+        { "kind": "clock", "now": "2026-04-26T08:00:00.000Z" },
+        { "kind": "sessionContext", "context": { "sessionUserId": "system-order", "requestId": "req-486-happy-create" } },
+        { "kind": "dbState", "table": "orders", "rows": [ { "id": "ORD-486-001", "customer_id": "CUS-001", "status": "CONFIRMED" } ] },
+        { "kind": "dbState", "table": "parts_inventory", "rows": [ { "warehouse_id": "WH-001", "part_number": "PRT-A", "available_qty": 10, "locked_qty": 0, "location_code": "A-01-1" } ] },
+        { "kind": "externalStub", "externalRef": "wmsSystem", "responseMock": { "status": 202, "body": { "accepted": true } } },
+        { "kind": "externalStub", "externalRef": "customerNotification", "responseMock": { "status": 202, "body": { "accepted": true } } }
+      ],
+      "when": {
+        "actionId": "act-001",
+        "input": {
+          "orderId": "ORD-486-001",
+          "warehouseId": "WH-001",
+          "items": [ { "partNumber": "PRT-A", "quantity": 2, "location": "A-01-1" } ]
+        }
+      },
+      "then": [
+        { "kind": "outcome", "expected": "201-created" },
+        { "kind": "output", "path": "$.status", "equals": "PLANNED" },
+        { "kind": "dbRow", "table": "shipment_orders", "match": { "order_id": "ORD-486-001", "current_status": "PLANNED" }, "count": 1 },
+        { "kind": "dbRow", "table": "parts_inventory", "match": { "warehouse_id": "WH-001", "part_number": "PRT-A", "available_qty": 8, "locked_qty": 2 }, "count": 1 },
+        { "kind": "externalCall", "externalRef": "wmsSystem", "method": "POST", "bodyMatch": { "warehouseId": "WH-001" } }
+      ],
+      "tags": ["happy", "shipment", "create"]
+    },
+    {
+      "id": "validation-error-empty-items",
+      "name": "items 空配列は 400 になる",
+      "description": "明細が空の配送指示登録要求は入力検証で拒否され、shipment_orders は登録されない。",
+      "given": [
+        { "kind": "sessionContext", "context": { "sessionUserId": "system-order", "requestId": "req-486-validation" } }
+      ],
+      "when": {
+        "actionId": "act-001",
+        "input": {
+          "orderId": "ORD-486-002",
+          "warehouseId": "WH-001",
+          "items": []
+        }
+      },
+      "then": [
+        { "kind": "outcome", "expected": "400-validation" },
+        { "kind": "errorMessage", "msgKey": "明細は必須です" }
+      ],
+      "tags": ["error", "validation"]
+    },
+    {
+      "id": "stock-shortage-tx-rollback",
+      "name": "在庫不足で TX rollback、shipment_orders は INSERT されない",
+      "description": "LOCK_INVENTORY 後に available_qty < 要求数量を検知し、STOCK_SHORTAGE で TX rollback。shipment_orders は登録されず、parts_inventory も変化しない。",
+      "given": [
+        { "kind": "clock", "now": "2026-04-26T08:30:00.000Z" },
+        { "kind": "sessionContext", "context": { "sessionUserId": "system-order", "requestId": "req-486-shortage" } },
+        { "kind": "dbState", "table": "orders", "rows": [ { "id": "ORD-486-003", "customer_id": "CUS-002", "status": "CONFIRMED" } ] },
+        { "kind": "dbState", "table": "parts_inventory", "rows": [ { "warehouse_id": "WH-001", "part_number": "PRT-A", "available_qty": 1, "locked_qty": 0, "location_code": "A-01-1" } ] }
+      ],
+      "when": {
+        "actionId": "act-001",
+        "input": {
+          "orderId": "ORD-486-003",
+          "warehouseId": "WH-001",
+          "items": [ { "partNumber": "PRT-A", "quantity": 5 } ]
+        }
+      },
+      "then": [
+        { "kind": "outcome", "expected": "409-stock-shortage" },
+        { "kind": "dbRow", "table": "shipment_orders", "match": { "order_id": "ORD-486-003" }, "count": 0 },
+        { "kind": "dbRow", "table": "parts_inventory", "match": { "warehouse_id": "WH-001", "part_number": "PRT-A", "available_qty": 1, "locked_qty": 0 }, "count": 1 }
+      ],
+      "tags": ["error", "stock-shortage", "tx-rollback"]
+    },
+    {
+      "id": "idempotent-tracking-callback",
+      "name": "同一 (trackingNumber, checkpointAt) の追跡更新再送は no-op になる",
+      "description": "既に tracking_events に登録済みの (trackingNumber, checkpointAt) で再受信しても、UPSERT_IDEMPOTENT で no-op となり 200 ALREADY_PROCESSED が返る。tracking_events は 1 行のままで shipment_orders.current_status は変化しない。状態巻き戻し防止。",
+      "given": [
+        { "kind": "clock", "now": "2026-04-26T12:00:00.000Z" },
+        { "kind": "sessionContext", "context": { "sessionUserId": "carrier-system", "requestId": "req-486-idempotent" } },
+        { "kind": "dbState", "table": "shipment_orders", "rows": [ { "id": "SHP-486-004", "current_status": "DELIVERED", "tracking_number": "TRK-486-004", "delivery_attempts": 0, "order_id": "ORD-486-004" } ] },
+        { "kind": "dbState", "table": "tracking_events", "rows": [ { "tracking_number": "TRK-486-004", "shipment_id": "SHP-486-004", "status": "IN_TRANSIT", "checkpoint_at": "2026-04-26T11:30:00.000Z", "checkpoint_location": "BASE-A" } ] }
+      ],
+      "when": {
+        "actionId": "act-003",
+        "input": {
+          "trackingNumber": "TRK-486-004",
+          "shipmentId": "SHP-486-004",
+          "status": "IN_TRANSIT",
+          "checkpointAt": "2026-04-26T11:30:00.000Z",
+          "checkpointLocation": "BASE-A"
+        }
+      },
+      "then": [
+        { "kind": "outcome", "expected": "200-already-processed" },
+        { "kind": "output", "path": "$.status", "equals": "ALREADY_PROCESSED" },
+        { "kind": "dbRow", "table": "tracking_events", "match": { "tracking_number": "TRK-486-004", "checkpoint_at": "2026-04-26T11:30:00.000Z" }, "count": 1 },
+        { "kind": "dbRow", "table": "shipment_orders", "match": { "id": "SHP-486-004", "current_status": "DELIVERED" }, "count": 1 }
+      ],
+      "tags": ["idempotency", "callback", "carrier"]
+    },
+    {
+      "id": "redelivery-limit-exceeded-return",
+      "name": "再配達上限超過で RETURNED に確定する",
+      "description": "規約値 @conv.limit.maxDeliveryAttempts = 3 (catalog default) の前提で、shipment_orders.delivery_attempts が 2 (上限直前) の状態で FAILED を受信すると、+1 した newAttemptCount=3 が < 3 を満たさないため再配達枠を超え、RETURNED に確定し shipment.return_required イベントが発行される。",
+      "given": [
+        { "kind": "clock", "now": "2026-04-26T15:00:00.000Z" },
+        { "kind": "sessionContext", "context": { "sessionUserId": "carrier-system", "requestId": "req-486-redelivery-limit" } },
+        { "kind": "dbState", "table": "shipment_orders", "rows": [ { "id": "SHP-486-005", "current_status": "OUT_FOR_DELIVERY", "tracking_number": "TRK-486-005", "delivery_attempts": 2, "order_id": "ORD-486-005" } ] }
+      ],
+      "when": {
+        "actionId": "act-003",
+        "input": {
+          "trackingNumber": "TRK-486-005",
+          "shipmentId": "SHP-486-005",
+          "status": "FAILED",
+          "checkpointAt": "2026-04-26T14:55:00.000Z",
+          "checkpointLocation": "DELIVERY-AREA-B"
+        }
+      },
+      "then": [
+        { "kind": "outcome", "expected": "200-updated" },
+        { "kind": "output", "path": "$.status", "equals": "RETURNED" },
+        { "kind": "dbRow", "table": "shipment_orders", "match": { "id": "SHP-486-005", "current_status": "RETURNED", "delivery_attempts": 3 }, "count": 1 },
+        { "kind": "dbRow", "table": "tracking_events", "match": { "tracking_number": "TRK-486-005", "status": "FAILED" }, "count": 1 }
+      ],
+      "tags": ["error", "redelivery", "return", "limit"]
+    }
+  ],
+  "createdAt": "2026-04-26T00:00:00.000Z",
+  "updatedAt": "2026-04-26T00:00:00.000Z"
+}


### PR DESCRIPTION
## Summary

- `/create-flow` スキル (#484/#485) の効果検証。Opus が物流業務シナリオを `/create-flow` の 8 ルール self-check 遵守で実装。
- 物流 `logistics` namespace 拡張定義を新規作成し、処理フロー JSON で全拡張を実利用 (`type: "other"` + outputSchema + description 注記パターン、PR #482 で実証済の schema 互換形式)。
- 3 アクション構成: 配送指示受付 (LOCK_INVENTORY 排他ロック + TX) / 倉庫ピッキング完了 (PickingStep 拡張) / 配送追跡コールバック (UPSERT_IDEMPOTENT 冪等 + DELIVERED の TX 内受領確認 + FAILED の再配達/返送分岐)。
- 5 件の testScenarios: happy path / validation error / 在庫不足 TX rollback / 冪等再送 / 再配達上限超過 RETURNED。

Sonnet 並列実装 (PR #487) との品質比較データを残すのが本 PR の目的。両 PR は同一 ISSUE #486 だが、Sonnet が先に `Closes #486` で PR 作成済のため、本 PR は `Refs #486` のみとする。

## `/create-flow` 8 ルール self-check 結果テーブル

| Rule | 状態 | 詳細 |
|---|---|---|
| 1. 変数ライフサイクル | OK | 全 `@varName` 参照 (`@order`, `@selectedWarehouseId`, `@newShipmentId`, `@plannedShipAt`, `@txResult`, `@shipment`, `@pickingResult`, `@upsertedTrack`, `@trackUpdate`, `@deliveredTxResult`, `@newAttemptCount`, `@nextAttemptAt`) は実行順で先に設定済み。`@inputs.*` / `@requestId` / `@sessionUserId` / `@idempotencyKey` / `@now` / `@conv.limit.maxDeliveryAttempts` は ambient / inputs。typo (`@input.x` 等) なし。 |
| 2. TransactionScope 内外整合 | OK | act-001 TX inner は TX 外で設定された `@inputs` / `@order` / `@selectedWarehouseId` / `@newShipmentId` / `@plannedShipAt` のみ参照。**TX inner outputBinding (`@lockedInventory` / `@reservedInventory`) は TX 外から参照しない**。shipmentId と plannedShipAt は TX 前に `@fn.generateUuid()` / `@fn.calculatePlannedShipAt()` で事前確定し、TX 後の event publish / WMS 連携 / return body から参照する (方針 A: TX 後 SELECT 再取得の代替として事前生成パターン)。act-003 DELIVERED TX も同様に inner outputBinding を持たず inner 操作は副作用のみ、TX 外参照は `@inputs.*` のみ。**外部呼び出し (wmsSystem / customerNotification) は全て TX 外**。 |
| 3. runIf 連鎖の網羅性 | OK | 本フローは UPSERT_IDEMPOTENT 後の処理を **runIf 連鎖でなく `branch` 構造で分離** (act-003 step-003-05): NEW (新規登録) と NOOP (冪等再送) を branch / elseBranch で完全分岐し、no-op パスは `200 ALREADY_PROCESSED` を返す single step、新規パスは TrackingUpdateStep + 状態分岐 (DELIVERED/FAILED/その他) を全て elseBranch.steps に閉じる。runIf による fallthrough 防止より構造化が明示的。 |
| 4. branch / elseBranch 到達性 | OK | 全 branch / elseBranch が return か後続 step に到達。**BLOCK/REJECT 後の共通 step fallthrough は構造化で完全防止**: act-001 step-001-06 で TX rollback 経路 (audit + return) と elseBranch (commit) で event/external/return を完結 (#458/#478 の再発パターン回避)。act-002 step-002-05 INCOMPLETE → return / COMPLETE → UPDATE+events+return。act-003 step-003-05-new-02 DELIVERED → TX+rollback/commit branch、FAILED → REDELIVER/RETURN branch、elseBranch (OTHER_STATUS) → UPDATE+event+return。 |
| 5. compensatesFor 参照健全性 | 該当なし | 本フローは Saga 補償までは行わない (ADR-003 の決定通り、外部失敗は audit + continue で運用検知に委ね、別フロー return-to-warehouse に委譲)。 |
| 6. eventsCatalog ⇄ eventPublish | OK | eventsCatalog 6 件 (`shipment.created` / `shipment.picked` / `shipment.tracking_updated` / `shipment.delivered` / `shipment.redelivery_scheduled` / `shipment.return_required`) に対し全件対応する eventPublish step が存在 (act-001 / act-002 / act-003 の 9 箇所、`shipment.tracking_updated` は 3 経路で再発行)。eventRef がカタログキーと一致、payload required フィールドが catalog schema と整合。 |
| 7. 外部呼び出しと TX 位置関係 | OK | externalSystem step は全て transactionScope の inner にいない。act-001 wmsSystem は step-001-06-commit-02 (TX 後 commit branch)、act-003 customerNotification は DELIVERED commit / REDELIVER のいずれも TX 外。outcomes は WMS が `failure: continue + sideEffects audit`、customerNotification が `fireAndForget: true + failure: continue`。 |
| 8. rollbackOn 発火可能性 | OK | act-001 TX `rollbackOn: ["STOCK_SHORTAGE"]` — inner step-001-05-02 (parts_inventory UPDATE) の `affectedRowsCheck.errorCode: "STOCK_SHORTAGE"` から発火。act-003 DELIVERED TX `rollbackOn: ["INVALID_STATE_TRANSITION"]` — inner step-003-05-new-02-delivered-01-02 (shipment_orders UPDATE) の `affectedRowsCheck.errorCode: "INVALID_STATE_TRANSITION"` から発火。**死コード rollbackOn なし** (TX 外 step が返すコードを列挙していない)。errorCatalog 登録済みコードのみ使用。 |

### self-check 中に気づいた点

- `affectedRowsCheck.operator` は `[">", ">=", "=", "<", "<="]` のみ許可 (`==` 不可、`=` が等価)。最初 `==` で書き schema reject されて修正。
- `affectedRowsCheck.expected` は **integer リテラル必須** (`"@inputs.items.length"` のような式参照不可)。複数明細の部分不足検知のための `==N` パターンが書けないため、`> 0` セマンティクスに変更し description で実装側補足を明記。複数明細の精密検知は CTE で事前 COUNT する想定を documentation。
- `kind: "ambientCatalog"` という TestPrecondition は schema にない (clock/dbState/sessionContext/externalStub の 4 種のみ)。test scenario の規約値オーバーライド意図は description に注記。
- `FieldType.kind = "array"` の `itemType` は string 型しか取れない (object kind は `fields` 必須)。`items` 入力を `{ kind: "array", itemType: "string" }` に変更し、配列要素を JSON 文字列または structured object 想定として description で明記。
- `raiseError` step type は schema に存在しない。TX 内の業務エラー throw は `affectedRowsCheck.onViolation: "throw"` 経由のみ可能と判明し、設計を再構成。
- `namespace:StepName` 形式は schema 未対応 (#480/PR #482 で実証通り)。`type: "other"` + `outputSchema` (additionalProperties: string のみ) + `note: "extensionStep=logistics:..."` で記述。
- TX inner outputBinding を TX 外で参照すると Rule 2 違反になることを設計途中で発見。`@shipment.id` / `@shipment.planned_ship_at` 参照を排除するため、shipmentId と plannedShipAt を TX 前に compute step で事前確定し `@newShipmentId` / `@plannedShipAt` で参照する pattern に refactor。

## 仕様逐条突合 (file:line)

| 条項 | ファイル:行 | 備考 |
|---|---|---|
| §8.1 TX 内 outputBinding を TX 外参照しない (方針 A 事前生成代替) | `ffffffff-0002-4000-8000-ffffffffffff.json:457-475` (`step-001-04b/04c` 事前生成) | `@fn.generateUuid()` / `@fn.calculatePlannedShipAt(...)` で TX 前確定 |
| §8.2 externalSystem は TX 外 (anti-pattern 回避) | `ffffffff-0002-4000-8000-ffffffffffff.json:570-602` (act-001 wmsSystem) / `1103-1121` (act-003 DELIVERED customerNotification) | 全 externalSystem は TX 後 commit branch 内に配置 |
| §8.3 TX commit ガード | `ffffffff-0002-4000-8000-ffffffffffff.json:511` (`@txResult.committed == false`) / `1056` (`@deliveredTxResult.committed == false`) | branch / elseBranch 構造で実現 (runIf より明示的) |
| §8.4 rollbackOn 発火可能性 | `ffffffff-0002-4000-8000-ffffffffffff.json:484` (`["STOCK_SHORTAGE"]`) / `1013` (`["INVALID_STATE_TRANSITION"]`) | inner step affectedRowsCheck.errorCode から実発火 |
| §15.1 fieldType vs domainsCatalog | `ffffffff-0002-4000-8000-ffffffffffff.json:295-318` (`domainsCatalog`) | `ShipmentId: { type: { kind: "shipmentId" } }` 等で拡張 fieldType を参照 |
| §15.2 拡張 step 参照形式 (過渡期 type:"other") | `ffffffff-0002-4000-8000-ffffffffffff.json:743-754` (PickingStep) / `978-989` (TrackingUpdateStep) / `1015-1024,1026-1042` (DeliveryConfirmStep DB 書込) | `type: "other"` + `outputSchema` + `note: "extensionStep=logistics:..."` |
| §15.3 拡張定義の実利用必須 | `extensions/logistics/*.json` 全定義 | shipmentId/trackingNumber/warehouseLocation/deliveryStatus fieldType / deliveryAttempted trigger / LOCK_INVENTORY DbOperation / PickingStep/TrackingUpdateStep/DeliveryConfirmStep がフロー内で実体使用 |
| eventsCatalog ⇄ eventPublish | `eventsCatalog` (l.10-93) / `eventPublish` 9 箇所 (l.566 / 829 / 1088 / 1097 / 1183 / 1192 / 1258 / 1267 / 1306) | 6 catalog ↔ 9 publish (うち shipment.tracking_updated は 3 経路で再発行) |
| ADR (decisions) | `ffffffff-0002-4000-8000-ffffffffffff.json:138-180` (3 件) | LOCK_INVENTORY / UPSERT_IDEMPOTENT / @conv.limit.maxDeliveryAttempts |
| testScenarios 3 件以上 | `ffffffff-0002-4000-8000-ffffffffffff.json:1320+` (5 件) | happy / validation / TX rollback / 冪等 / 再配達上限 |

## 統計

- アクション数: 3 (act-001/002/003)
- step 総数: 約 50 (入れ子含む)
- testScenarios: 5 件 (happy / validation / TX rollback / idempotent / redelivery limit)
- decisions (ADR): 3 件
- eventsCatalog: 6 件 / glossary: 9 用語
- errorCatalog: 8 件 / externalSystemCatalog: 3 件 / secretsCatalog: 3 件
- domainsCatalog: 6 件 / functionsCatalog: 4 件 (selectWarehouseRoute / calculatePlannedShipAt / scheduleNextAttempt / generateUuid)
- 拡張利用: logistics namespace **新規定義** (field-types 4 種 / triggers 1 種 / db-operations 1 種 / steps 3 種) + **全件実利用**

## Test plan

- [x] `cd designer && npx vitest run src/schemas/extensions-samples.test.ts src/schemas/process-flow.schema.test.ts` — 220 passed
- [x] `cd designer && npm run build` — 成功
- [ ] 別セッションで `/review-flow ffffffff-0002-4000-8000-ffffffffffff` を実施し Must-fix 件数を測定 (Phase 7-2 検証指標として #478 ベースライン 4 件と比較)

## 検証結果

- vitest: 220 passed (0 failed)
- npm run build: 成功
- `/review-flow` 自己実行: 未実施 (本 PR 内では schema/build pass 確認に留め、Must-fix 測定は別セッションで実施)

Refs #486
