### PR TITLE
improve(skill): /create-flow に新規 checklist 6 件追加 — 14 ルール体系へ拡張 (#490)

### DIFF
--- a/.claude/skills/create-flow/SKILL.md
+++ b/.claude/skills/create-flow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-flow
-description: ProcessFlow JSON を品質ガード付きで新規作成する。/review-flow の 8 観点を作成前 self-check として組み込み、既知パターンの再発を抑制する
+description: ProcessFlow JSON を品質ガード付きで新規作成する。/review-flow の 14 観点を作成前 self-check として組み込み、既知パターンの再発を抑制する
 argument-hint: <flowId> <業務概要> [namespace]
 disable-model-invocation: true
 ---
@@ -135,6 +135,44 @@ ProcessFlow JSON に含めるべき要素 (5/5 達成サンプル準拠):
 - `errorCatalog` に登録されたコードを使用
 - **死コード rollbackOn 禁止** (#458/#478 で頻発): TX 外 step が返すエラーコードを書かない
 
+### Rule 9: SQL SELECT カラム整合 (#486 で発覚)
+
+- 後続 step で `@bind.column` を参照するすべてのカラムが、対応する `dbAccess` step の SELECT 句に含まれているか確認
+- 典型ミス: `SELECT id, status FROM table` で取得後、後続で `@row.quantity` を参照 → 実行時 undefined
+- 対処: SELECT 句に必要カラムを全列挙、または compute step で別途取得
+
+### Rule 10: `@conv.*` 参照の catalog 整合 (#486 で発覚)
+
+- フロー内で参照する全 `@conv.*` キーが `docs/sample-project/conventions/conventions-catalog.json` に存在することを確認
+- 典型ミス: ADR で `@conv.limit.maxDeliveryAttempts` を仕様化したが catalog 追加を忘れる → runtime で undefined 解決、condition が常に false
+- 対処: 新規 `@conv.*` キーを使うときは必ず catalog にも追加 (本 PR で追加するか、別 ISSUE で先行追加)
+
+### Rule 11: TX 内 branch return 後の制御 (#486 で発覚)
+
+- Rule 4 (TX 外の branch fallthrough) の TX 内バージョン
+- TX inner で `branch` step を使い branch 内で return する場合、後続 inner step に fallthrough しないか明示確認
+- **推奨**: TX 内 branch を避け、`affectedRowsCheck.errorCode` で TX rollback を発火させる経路に統一
+- 典型ミス: `step-tx-02` の branch A で `return 422` した後、`step-tx-03` が implicit に実行されて二重処理 / undefined 参照
+
+### Rule 12: `affectedRowsCheck.operator` は `=` のみ受容 (schema 制約、#486 Opus 発見)
+
+- 利用可能な operator: `>` / `>=` / `=` / `<` / `<=`
+- **`==` は不可**、`!=` も不可
+- 典型ミス: `"operator": "==", "expected": 1` を書く → schema 違反
+
+### Rule 13: `affectedRowsCheck.expected` は integer リテラル必須 (schema 制約、#486 Opus 発見)
+
+- 整数リテラル (`1` / `0` 等) のみ受容
+- **式参照不可** (`@var` 不可)
+- 「N 行更新」を式で表現できないため、複数行 affected の検証が必要なら別の方法 (compute step で count → branch 等)
+
+### Rule 14: `OtherStep.outputSchema` 形式制約 (schema 制約、#486 Opus 発見)
+
+- `{field: "string"}` 形式のみ受容 (フィールド名 → 型名の単純マッピング)
+- **複雑な JSON Schema 不可**: nested object / required / additionalProperties / enum 等は使えない
+- 参考: 拡張定義 (`extensions/<namespace>/steps.json`) の `schema` フィールドは別物 (こちらは JSON Schema 完全対応)
+- 典型ミス: `"outputSchema": { "type": "object", "properties": {...}, "required": [...] }` を書く → schema 違反、Sonnet が #486 で実装中に修正
+
 ## Step 4: 拡張定義の使い方
 
 ### 既存 namespace を使う場合
@@ -201,11 +239,17 @@ npm run build
 | 1. 変数ライフサイクル | ✓ / ❌ (問題があれば詳細) |
 | 2. TransactionScope 内外整合 | ✓ / ❌ |
 | 3. runIf 連鎖の網羅性 | ✓ / ❌ |
-| 4. branch / elseBranch 到達性 | ✓ / ❌ |
+| 4. branch / elseBranch 到達性 (TX 外) | ✓ / ❌ |
 | 5. compensatesFor 参照健全性 | ✓ / 該当なし |
 | 6. eventsCatalog ⇄ eventPublish | ✓ / ❌ |
 | 7. 外部呼び出しと TX 位置関係 | ✓ / ❌ |
 | 8. rollbackOn 発火可能性 | ✓ / 該当なし |
+| 9. SQL SELECT カラム整合 | ✓ / ❌ (参照しているのに SELECT に無いカラム) |
+| 10. `@conv.*` 参照の catalog 整合 | ✓ / ❌ (catalog 未登録キーがあれば list) |
+| 11. TX 内 branch return 後制御 | ✓ / 該当なし (TX 内 branch を使っていない) |
+| 12. `affectedRowsCheck.operator` (`=` のみ) | ✓ / 該当なし |
+| 13. `affectedRowsCheck.expected` (integer リテラル) | ✓ / 該当なし |
+| 14. `OtherStep.outputSchema` 形式 | ✓ / 該当なし |
 
 ### 検証結果
 - vitest: <pass/fail 件数>
@@ -224,11 +268,11 @@ npm run build
 - **拡張定義は実利用必須**: 定義のみで未使用は禁止 (spec §15.3)
 - **schema を尊重**: `type: "manufacturing:StepName"` のような未対応形式は使わない (`type: "other"` + outputSchema が正解)
 - **データファイル (`data/`) は触らない** (gitignore 対象)
-- **8 ルールすべて作成中に意識する**: 1 つでも無視するとレビューで detect される
+- **14 ルールすべて作成中に意識する**: 1 つでも無視するとレビューで detect される
 
 ## 注意事項
 
 - スキル肥大化を避けるため、spec 本文は転記しない (要約のみ)
 - 業務概要が短すぎて不明瞭な場合は、ユーザーに「もう少し詳しく」と聞き返すのも可
-- 既存サンプル (`dddddddd-0001-*` / `eeeeeeee-0001-*` 等) は 5/5 達成済の良サンプル、構造を参考にする
-- `/issues` オーケストレーターから委譲される場合、briefing に「`/create-flow` の 8 ルールを遵守すること」が含まれているはず
+- 既存サンプル (`dddddddd-0001-*` / `eeeeeeee-0001-*` / `ffffffff-0001-*` 等) は 5/5 達成済の良サンプル、構造を参考にする
+- `/issues` オーケストレーターから委譲される場合、briefing に「`/create-flow` の 14 ルールを遵守すること」が含まれているはず

--- a/.claude/skills/issues/SKILL.md
+++ b/.claude/skills/issues/SKILL.md
@@ -86,11 +86,15 @@ briefing には以下を含める:
 - Step 2 で書いた設計手順
 - 作業ディレクトリ: `C:/tmp/wt-$ARGUMENTS`
 - PR 作成まで完了すること
-- **ProcessFlow JSON 作成を含む ISSUE では `/create-flow` の 8 ルール self-check を遵守する旨を明示**:
-  > 「フロー作成にあたり `.claude/skills/create-flow/SKILL.md` の Step 3 既知パターン回避 self-check 8 ルールを遵守すること:
-  > 1) TX 内 step が TX 外設定変数を前方参照しない、2) 外部呼び出しは TX 外、3) UPSERT 後の step すべてに同条件 runIf + no-op return、
+- **ProcessFlow JSON 作成を含む ISSUE では `/create-flow` の 14 ルール self-check を遵守する旨を明示**:
+  > 「フロー作成にあたり `.claude/skills/create-flow/SKILL.md` の Step 3 既知パターン回避 self-check 14 ルールを遵守すること:
+  > **基本 8 ルール**: 1) TX 内 step が TX 外設定変数を前方参照しない、2) 外部呼び出しは TX 外、3) UPSERT 後の step すべてに同条件 runIf + no-op return、
   > 4) branch return 後の共通 step に fallthrough しない、5) compensatesFor 対象 step が実在、6) eventsCatalog ⇄ eventPublish 双方向整合、
-  > 7) 外部呼び出しは TransactionScope inner にいない、8) rollbackOn は TX inner で発生するエラーコードのみ列挙 (死コード禁止)」
+  > 7) 外部呼び出しは TransactionScope inner にいない、8) rollbackOn は TX inner で発生するエラーコードのみ列挙 (死コード禁止)、
+  > **追加 6 ルール (#486 検証で発覚)**: 9) SQL SELECT カラム整合 (後続参照の全フィールドが SELECT 句に含まれること)、
+  > 10) `@conv.*` 参照は conventions-catalog.json 登録済キーのみ、11) TX 内 branch return 後の fallthrough も避ける、
+  > 12) `affectedRowsCheck.operator` は `=` のみ (`==` 不可)、13) `affectedRowsCheck.expected` は integer リテラル必須、
+  > 14) `OtherStep.outputSchema` は `{field: \"string\"}` 形式のみ」
 
 ### Codex が「プラン制限」エラー → 即 Sonnet フォールバック
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Claude Code 向けの補足ガイダンス。
 
 - **`/issues <N>`** — ISSUE を 12 ルール Opus オーケストレーターワークフローで完遂 (`.claude/skills/issues/SKILL.md`)
 - **`/review-pr <N>`** — PR 独立レビュー (一般品質: spec / 命名 / テスト) (`.claude/skills/review-pr/SKILL.md`)
-- **`/create-flow <flowId> <業務概要> [namespace]`** — ProcessFlow JSON を品質ガード付きで作成 (`/review-flow` の 8 観点を作成前 self-check として組み込み)。`/review-flow` と併用前提 (`.claude/skills/create-flow/SKILL.md`)
+- **`/create-flow <flowId> <業務概要> [namespace]`** — ProcessFlow JSON を品質ガード付きで作成 (`/review-flow` の 14 観点を作成前 self-check として組み込み、#486 検証で発覚した 6 件の追加 checklist を含む)。`/review-flow` と併用前提 (`.claude/skills/create-flow/SKILL.md`)
 - **`/review-flow <flowId>`** — ProcessFlow JSON 実行セマンティクス専門レビュー (変数ライフサイクル / TX / runIf / 補償 / event 双方向)。設計フェーズから使える (`.claude/skills/review-flow/SKILL.md`)
 - **`/review-issue <N>`** — ISSUE 単位の実装網羅性監査 (`.claude/skills/review-issue/SKILL.md`)
 - **`/test-strategy`** — テスト実装時の自動起動スキル (`.claude/skills/test-strategy/SKILL.md`)


### PR DESCRIPTION
## Summary

#486 (物流業務、/create-flow 効果検証) で発覚した新規盲点を Step 3 既知パターン回避 self-check に追加。**8 ルール → 14 ルール** に拡張。

## 追加 6 ルール

- **Rule 9**: SQL SELECT カラム整合 (#486 Sonnet 検出 — 後続参照の全フィールドが SELECT 句に含まれること)
- **Rule 10**: `@conv.*` 参照の catalog 整合 (#486 Opus 検出 — conventions-catalog.json 登録済キーのみ)
- **Rule 11**: TX 内 branch return 後の制御 (#486 Sonnet 検出 — TX 外と同パターンが TX 内でも発生)
- **Rule 12**: `affectedRowsCheck.operator` は `=` のみ (#486 Opus 発見の schema 制約)
- **Rule 13**: `affectedRowsCheck.expected` は integer リテラル必須 (#486 Opus 発見)
- **Rule 14**: `OtherStep.outputSchema` は `{field: "string"}` 形式のみ (#486 Sonnet/Opus 共通)

## 仕様逐条突合 (自己申告)

- [x] `.claude/skills/create-flow/SKILL.md` Step 3 に Rule 9-14 追加 + 出力フォーマット表に該当行追加
- [x] frontmatter `description` を「14 観点」に更新
- [x] `.claude/skills/issues/SKILL.md` Step 4 briefing を 14 ルール対応に更新
- [x] `CLAUDE.md` Slash Commands セクションの `/create-flow` 説明を更新

## Test plan
- [x] vitest 221 tests pass
- [x] npm run build 成功

## 期待効果

次回ドッグフード (Phase 2 等) で初回 Must-fix 件数を更に削減 (1-2 件 → 0-1 件)。

Closes #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)