### PR TITLE
improve(schema): OtherStep.type に namespace:StepName 形式を受容 (spec ↔ schema 乖離解消) (#492)

### DIFF
--- a/.claude/skills/create-flow/SKILL.md
+++ b/.claude/skills/create-flow/SKILL.md
@@ -190,10 +190,10 @@ ProcessFlow JSON に含めるべき要素 (5/5 達成サンプル準拠):
 ### 重要原則 (`docs/spec/process-flow-extensions.md` §15)
 
 - **拡張定義の実利用必須** (§15.3): 定義した拡張は**同 PR 内**で実フローから実体使用する。「定義したが未使用」は禁止
-- **拡張 step の参照形式**:
-  - 現行 schema は `type: "other"` + `outputSchema` + description 注記の形式が安全
-  - `namespace:StepName` 形式は schema が未対応で reject される (#480 で実証、Opus が遭遇)
-  - spec §15.2 と schema の乖離は別 ISSUE で解消予定
+- **拡張 step の参照形式** (#492 / PR #494 で schema 改修済):
+  - **推奨**: `type: "namespace:StepName"` (例: `"securities:TradeMatchStep"`) — 現行 schema 受容済
+  - **後方互換**: `type: "other"` + `outputSchema` + description 注記の旧形式も引き続き valid
+  - 旧版の `/create-flow` SKILL では `type: "other"` workaround を強制していたが、#492 で解消
 - **fieldType vs domainsCatalog 使い分け** (§15.1):
   - 拡張 fieldType (`{kind: "orderId"}`): 業界固有の**型自体**を追加
   - domainsCatalog (`OrderId: {type: "string", constraints: ...}`): ドメイン**制約付き**の型エイリアス

--- a/designer/src/schemas/process-flow.schema.test.ts
+++ b/designer/src/schemas/process-flow.schema.test.ts
@@ -187,6 +187,49 @@ describe("process-flow.schema.json — docs/sample-project/process-flows/*.json"
   }
 });
 
+describe("process-flow.schema.json — OtherStep namespace:StepName 形式 (#492)", () => {
+  const makeFlow = (step: object) => ({
+    id: "a", name: "x", type: "screen", description: "",
+    actions: [{
+      id: "act-1", name: "test", trigger: "submit",
+      steps: [step],
+    }],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  });
+
+  it("namespace:StepName 形式 (manufacturing:TraceabilityStep) が valid", () => {
+    const ok = validate(makeFlow({
+      id: "step-1", type: "manufacturing:TraceabilityStep",
+      description: "ロット記録",
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("type: 'other' は引き続き valid (後方互換)", () => {
+    const ok = validate(makeFlow({
+      id: "step-1", type: "other", description: "汎用 step",
+    }));
+    if (!ok) throw new Error(JSON.stringify(validate.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("不正形式 (大文字始まり namespace) は invalid", () => {
+    expect(validate(makeFlow({
+      id: "step-1", type: "Manufacturing:Step",
+      description: "",
+    }))).toBe(false);
+  });
+
+  it("不正形式 (StepName が小文字始まり) は invalid", () => {
+    expect(validate(makeFlow({
+      id: "step-1", type: "manufacturing:step",
+      description: "",
+    }))).toBe(false);
+  });
+});
+
 describe("process-flow.schema.json — v1.1 拡張 (#253)", () => {
   const base = {
     id: "a", name: "x", type: "screen", description: "",

--- a/docs/spec/process-flow-extensions.md
+++ b/docs/spec/process-flow-extensions.md
@@ -1109,15 +1109,15 @@ apiVersion?: string;                  // step 単位の override
 
 フロー JSON 内で拡張 step を参照する際の形式を統一する。
 
-- **正式形式**: `type: "namespace:StepName"` (例: `"securities:TradeMatchStep"`)
-- **過渡期許容**: `type: "other"` + `description` で明示する旧形式は後方互換として許容するが、**新規実装では namespace 修飾を推奨**
-- `process-flow.schema.json` の `Step` 定義は `type` のパターンとして `^[a-z][a-z0-9_-]*:[A-Z][A-Za-z0-9]*$` を許容する (allOf で `OtherStep` 互換)
+- **正式形式 (推奨)**: `type: "namespace:StepName"` (例: `"securities:TradeMatchStep"`)
+- **後方互換**: `type: "other"` + `description` で明示する旧形式も引き続き受容
+- `process-flow.schema.json` の `OtherStep.type` は `oneOf` で `{const: "other"}` と pattern `^[a-z][a-z0-9_-]*:[A-Z][A-Za-z0-9]*$` の両方を受容する (#492 で対応、PR #494)
 
 ```json
-// 推奨 (namespace 修飾)
+// 推奨 (namespace 修飾、schema valid)
 { "id": "step-match", "type": "securities:TradeMatchStep", "description": "約定マッチング" }
 
-// 許容 (過渡期・旧形式)
+// 後方互換 (旧形式、schema valid)
 { "id": "step-match", "type": "other", "description": "securities:TradeMatchStep — 約定マッチング" }
 ```
 

--- a/schemas/process-flow.schema.json
+++ b/schemas/process-flow.schema.json
@@ -1834,7 +1834,12 @@
             "maturity": true, "runIf": true, "outputBinding": true,
             "txBoundary": true, "transactional": true, "compensatesFor": true,
             "externalChain": true, "subSteps": true, "requiredPermissions": true, "sla": true,
-            "type": { "const": "other" },
+            "type": {
+              "oneOf": [
+                { "const": "other" },
+                { "type": "string", "pattern": "^[a-z][a-z0-9_-]*:[A-Z][A-Za-z0-9]*$" }
+              ]
+            },
             "outputSchema": {
               "type": "object",
               "additionalProperties": { "type": "string" }


### PR DESCRIPTION
## Summary

spec §15.2 (PR #477) が `namespace:StepName` を「正式形式」と規定したが schema OtherStep が `const: "other"` のみ受容していた**構造的乖離**を解消。schema を `oneOf` 化し、両形式を受容。

## 解消する問題

- #480 で Opus が `type: "manufacturing:TraceabilityStep"` を直接使用 → schema invalid → 後修正
- #486 で /create-flow SKILL が `type: "other"` workaround を強制していた矛盾
- spec が「正式形式」と書いた形式が機能していなかった

## 改修内容

`schemas/process-flow.schema.json` の `OtherStep.type`:



## 仕様逐条突合

- [x] schema 改修 — `schemas/process-flow.schema.json:1834-1842`
- [x] テスト追加 4 件 — `designer/src/schemas/process-flow.schema.test.ts` 新規 describe ブロック
- [x] spec §15.2 を 「過渡期許容」→「後方互換」に表現変更 — `docs/spec/process-flow-extensions.md`
- [x] SKILL の `type: "other"` workaround 推奨記述を 「`namespace:StepName` 推奨」に更新 — `.claude/skills/create-flow/SKILL.md`

## Test plan

- [x] vitest 225 tests pass (前 221 + 新規 4)
  - namespace:StepName 形式が valid
  - type: 'other' が引き続き valid (後方互換)
  - 不正形式 (大文字始まり namespace) は invalid
  - 不正形式 (StepName が小文字始まり) は invalid
- [x] npm run build 成功
- [x] 既存全サンプル (cccccccc-* / dddddddd-* / eeeeeeee-* / ffffffff-*) が引き続き valid (regression なし)

## 後続課題

- /create-flow SKILL の Rule 14 (`OtherStep.outputSchema` 形式制約) は本 PR スコープ外。これは別の制約 (フィールド名→型名の単純マッピングのみ) で、JSON Schema 完全対応を求める場合は別途 schema 改修が必要

Closes #492

🤖 Generated with [Claude Code](https://claude.com/claude-code)