### PR TITLE
fix(dogfood): Phase 4-2 ラウンド 2 — retail 4 flow Must-fix 修正 (#506)

### DIFF
--- a/docs/sample-project/process-flows/gggggggg-0001-4000-8000-gggggggggggg.json
+++ b/docs/sample-project/process-flows/gggggggg-0001-4000-8000-gggggggggggg.json
@@ -9,7 +9,7 @@
   "maturity": "committed",
   "eventsCatalog": {
     "inventory.searched": {
-      "description": "在庫照会リクエストを受け付け、結果を返した時点で発行されるイベント。検索条件と件数をペイロードに含む。",
+      "description": "在庫照会リクエストを受け付け、結果を返した時点で発行されるイベント。在庫レコードが存在する場合に発行 (0 件の場合は inventory.notFound を発行)。検索条件と件数をペイロードに含む。",
       "payload": {
         "type": "object",
         "required": ["requestId", "storeCode", "resultCount"],
@@ -118,8 +118,8 @@
       "title": "在庫低下アラートイベントは照会時に発行する",
       "status": "accepted",
       "context": "在庫が低下しているかどうかをリアルタイムで検知するため、照会タイミングで判定する設計にする。",
-      "decision": "照会結果の available_quantity が @conv.limit.lowStockThreshold 未満の場合、retail.inventory_low_detected イベントを発行する。発行はベストエフォート (fireAndForget)。",
-      "consequences": "照会するたびにアラートが発行され重複する可能性がある。下流コンシューマは冪等に処理する必要がある。",
+      "decision": "照会結果の中で available_quantity が @conv.limit.lowStockThreshold 未満の最初の 1 件のみ通知する (@fn.isLowStock を使用した .find() の動作)。retail.inventory_low_detected イベントを発行する。発行はベストエフォート (fireAndForget)。",
+      "consequences": "照会するたびにアラートが発行され重複する可能性がある。下流コンシューマは冪等に処理する必要がある。複数の低在庫商品が存在しても通知は最初の 1 件のみ (全件通知が必要な場合は設計変更が必要)。",
       "date": "2026-04-26"
     },
     {
@@ -152,11 +152,6 @@
       "defaultMessage": "入力値が不正です",
       "responseRef": "400-validation"
     },
-    "STORE_NOT_FOUND": {
-      "httpStatus": 404,
-      "defaultMessage": "指定の店舗が見つかりません",
-      "responseRef": "404-store-not-found"
-    },
     "PRODUCT_NOT_FOUND": {
       "httpStatus": 404,
       "defaultMessage": "指定の商品が見つかりません",
@@ -166,11 +161,6 @@
       "httpStatus": 500,
       "defaultMessage": "内部エラーが発生しました",
       "responseRef": "500-internal-error"
-    },
-    "SEARCH_LIMIT_EXCEEDED": {
-      "httpStatus": 400,
-      "defaultMessage": "検索条件が多すぎます",
-      "responseRef": "400-search-limit-exceeded"
     }
   },
   "externalSystemCatalog": {
@@ -277,7 +267,7 @@
         {
           "name": "items",
           "label": "在庫一覧",
-          "type": "string"
+          "type": "object[]"
         },
         {
           "name": "totalCount",
@@ -299,12 +289,6 @@
           "when": "入力値が不正"
         },
         {
-          "id": "404-store-not-found",
-          "status": 404,
-          "bodySchema": { "typeRef": "ApiError" },
-          "when": "指定の店舗が存在しない"
-        },
-        {
           "id": "404-product-not-found",
           "status": 404,
           "bodySchema": { "typeRef": "ApiError" },
@@ -315,12 +299,6 @@
           "status": 500,
           "bodySchema": { "typeRef": "ApiError" },
           "when": "予期しないエラー"
-        },
-        {
-          "id": "400-search-limit-exceeded",
-          "status": 400,
-          "bodySchema": { "typeRef": "ApiError" },
-          "when": "検索条件が多すぎる"
         }
       ],
       "steps": [
@@ -340,7 +318,7 @@
               "field": "productCode",
               "type": "regex",
               "condition": "@inputs.productCode != null && @inputs.productCode != ''",
-              "pattern": "^[A-Z0-9]{3,20}$",
+              "patternRef": "@conv.regex.product-code",
               "message": "商品コードは英大文字・数字 3〜20 文字で入力してください"
             }
           ],
@@ -368,7 +346,8 @@
           "cache": {
             "ttlSeconds": 300,
             "key": "product-@inputs.productCode",
-            "invalidateOn": ["products.updated"]
+            "invalidateOn": ["products.updated"],
+            "note": "products.updated は商品マスタ更新フロー (cross-flow) が発行するイベント。キャッシュ無効化はフロー外依存であり、商品マスタ更新フローとの連携が前提となる。"
           }
         },
         {
@@ -381,7 +360,7 @@
               "id": "br-03-a",
               "code": "A",
               "label": "商品なし",
-              "condition": "@inputs.productCode != null && @inputs.productCode != '' && @product == null",
+              "condition": "@inputs.productCode != null && @inputs.productCode != '' && (@product == null || @product == undefined)",
               "steps": [
                 {
                   "id": "step-03-a-01",
@@ -465,7 +444,7 @@
           "type": "compute",
           "description": "在庫一覧の中で available_quantity < @conv.limit.lowStockThreshold の最初の行を抽出する。",
           "maturity": "committed",
-          "expression": "@inventoryRows.find(r => r.available_quantity < @conv.limit.lowStockThreshold)",
+          "expression": "@inventoryRows.find(r => @fn.isLowStock(r.available_quantity, @conv.limit.lowStockThreshold))",
           "outputBinding": "lowStockRow"
         },
         {

--- a/docs/sample-project/process-flows/gggggggg-0002-4000-8000-gggggggggggg.json
+++ b/docs/sample-project/process-flows/gggggggg-0002-4000-8000-gggggggggggg.json
@@ -79,7 +79,7 @@
     },
     "冪等 UPSERT": {
       "definition": "同一キー (cart_id + product_code) で何度実行しても結果が同じになる INSERT ... ON CONFLICT DO UPDATE 操作。retail:UPSERT_CART_ITEM で実現。",
-      "aliases": ["IdempotentUpsert", "冪等追加"],
+      "aliases": ["IdempotentUpsert", "冪等追加", "UPSERT_CART_ITEM"],
       "domainRef": "cart_items"
     },
     "カート有効期限": {
@@ -349,7 +349,12 @@
           "fieldErrorsVar": "fieldErrors",
           "inlineBranch": {
             "ok": "次のステップへ進む",
-            "ng": "400 入力値エラーを返す",
+            "ng": "cart.validation_failed イベント発行後に 400 入力値エラーを返す",
+            "ngEventPublish": {
+              "topic": "cart.validation_failed",
+              "eventRef": "cart.validation_failed",
+              "payload": "{ cartId: @inputs.cartId, errorCode: 'VALIDATION' }"
+            },
             "ngResponseRef": "400-validation",
             "ngBodyExpression": "{ code: 'VALIDATION', message: '入力値が不正です', fieldErrors: @fieldErrors }"
           }
@@ -485,7 +490,8 @@
                   "maturity": "committed",
                   "topic": "cart.inventory_insufficient",
                   "eventRef": "cart.inventory_insufficient",
-                  "payload": "{ cartId: @inputs.cartId, productCode: @inputs.productCode, requestedQty: @inputs.quantity, availableQty: @inventoryRow != null ? @inventoryRow.available_quantity : 0 }"
+                  "payload": "{ cartId: @inputs.cartId, productCode: @inputs.productCode, requestedQty: @inputs.quantity, availableQty: @inventoryRow != null ? @inventoryRow.available_quantity : -1 }",
+                  "note": "availableQty: -1 は在庫レコード未登録 (商品マスタにのみ存在し inventory レコードがない) を表す番兵値。0 は在庫ゼロと区別する。"
                 },
                 {
                   "id": "step-07-a-02",
@@ -518,16 +524,29 @@
           }
         },
         {
+          "id": "step-08b",
+          "type": "dbAccess",
+          "description": "同一 cart_id + product_code の既存明細を SELECT して @existingCartItem にバインドする。既存行があれば UPSERT は更新のみで件数増加なし。",
+          "maturity": "committed",
+          "tableName": "cart_items",
+          "operation": "SELECT",
+          "sql": "SELECT cart_id, product_code, quantity FROM cart_items WHERE cart_id = @inputs.cartId AND product_code = @inputs.productCode LIMIT 1",
+          "outputBinding": "existingCartItem",
+          "lineage": {
+            "reads": ["cart_items"]
+          }
+        },
+        {
           "id": "step-09",
           "type": "branch",
-          "description": "カート明細が上限 (@conv.limit.cartItemMax=50) 以上で、かつ新規商品の場合は 422 を返す。",
+          "description": "カート明細が上限 (@conv.limit.cartItemMax=50) 以上で、かつ新規商品 (existingCartItem == null) の場合は 422 を返す。既存商品の数量更新は上限チェック対象外。",
           "maturity": "committed",
           "branches": [
             {
               "id": "br-09-a",
               "code": "A",
-              "label": "カート上限超過",
-              "condition": "@cartItemCount.item_count >= @conv.limit.cartItemMax",
+              "label": "カート上限超過 (新規商品のみ)",
+              "condition": "@existingCartItem == null && @cartItemCount.item_count >= @conv.limit.cartItemMax",
               "steps": [
                 {
                   "id": "step-09-a-01",
@@ -544,18 +563,6 @@
             "code": "B",
             "label": "上限内",
             "steps": []
-          }
-        },
-        {
-          "id": "step-10",
-          "type": "retail:CartManageStep",
-          "description": "cart_items に (cart_id, product_code) 複合キーで UPSERT する。既存行があれば quantity を加算し、なければ INSERT する。",
-          "maturity": "committed",
-          "outputSchema": {
-            "cart_id": "string",
-            "product_code": "string",
-            "quantity": "number",
-            "unit_price": "number"
           }
         },
         {
@@ -597,7 +604,7 @@
           "description": "200 OK を返す。",
           "maturity": "committed",
           "responseRef": "200-ok",
-          "bodyExpression": "{ cartId: @inputs.cartId, status: 'ADDED', itemCount: @cartItemCount.item_count }",
+          "bodyExpression": "{ cartId: @inputs.cartId, status: 'ADDED', itemCount: @existingCartItem == null ? @cartItemCount.item_count + 1 : @cartItemCount.item_count }",
           "runIf": "@upsertedItem != null"
         },
         {
@@ -607,6 +614,7 @@
           "maturity": "committed",
           "responseRef": "200-ok",
           "bodyExpression": "{ cartId: @inputs.cartId, status: 'ALREADY_UPDATED', itemCount: @cartItemCount.item_count }",
+          "note": "no-op (upsertedItem == null) の場合も件数は変わらないので cartItemCount.item_count をそのまま返す。",
           "runIf": "@upsertedItem == null"
         }
       ]
@@ -736,6 +744,58 @@
         { "kind": "outcome", "expected": "422-cart-expired" }
       ],
       "tags": ["error", "cart-expired"]
+    },
+    {
+      "id": "idempotent-noop-same-item",
+      "name": "同一商品を再追加しても no-op で 200 が返る (冪等パス)",
+      "description": "既にカートに存在する商品を同じ数量で追加しようとした場合、UPSERT は no-op となり ALREADY_UPDATED ステータスで 200 OK を返す。",
+      "given": [
+        {
+          "kind": "sessionContext",
+          "context": { "sessionUserId": "user-001", "requestId": "req-cart-noop-001" }
+        },
+        {
+          "kind": "dbState",
+          "table": "carts",
+          "rows": [
+            { "id": "cart-abc123", "status": "ACTIVE", "expires_at": "2026-05-01T00:00:00.000Z" }
+          ]
+        },
+        {
+          "kind": "dbState",
+          "table": "products",
+          "rows": [
+            { "product_code": "PROD001", "name": "テスト商品", "unit_price": 1000, "is_active": true }
+          ]
+        },
+        {
+          "kind": "dbState",
+          "table": "inventory",
+          "rows": [
+            { "product_code": "PROD001", "store_code": "DEFAULT", "available_quantity": 100, "reserved_quantity": 0 }
+          ]
+        },
+        {
+          "kind": "dbState",
+          "table": "cart_items",
+          "rows": [
+            { "cart_id": "cart-abc123", "product_code": "PROD001", "quantity": 2, "unit_price": 1000 }
+          ]
+        }
+      ],
+      "when": {
+        "actionId": "act-001",
+        "input": {
+          "cartId": "cart-abc123",
+          "productCode": "PROD001",
+          "quantity": 2
+        }
+      },
+      "then": [
+        { "kind": "outcome", "expected": "200-ok" },
+        { "kind": "output", "path": "$.status", "equals": "ALREADY_UPDATED" }
+      ],
+      "tags": ["idempotent", "noop", "cart"]
     }
   ],
   "createdAt": "2026-04-26T00:00:00.000Z",

--- a/docs/sample-project/process-flows/gggggggg-0003-4000-8000-gggggggggggg.json
+++ b/docs/sample-project/process-flows/gggggggg-0003-4000-8000-gggggggggggg.json
@@ -134,6 +134,15 @@
       "date": "2026-04-26"
     },
     {
+      "id": "ADR-004",
+      "title": "branch の elseBranch は fallthrough で後続ステップに継続する",
+      "status": "accepted",
+      "context": "branch ステップで条件が全 branches に一致しない場合の動作を明示する必要がある。",
+      "decision": "elseBranch に steps: [] の場合、後続のステップ (同一 action 内の次の step) に自動的に制御が移る (fallthrough)。return ステップがない限り処理は継続される。",
+      "consequences": "elseBranch が空の場合に意図しない fallthrough が発生するリスクを排除するため、各 branch の意図を description で明示する。",
+      "date": "2026-04-26"
+    },
+    {
       "id": "ADR-003",
       "title": "消費税計算は compute step で行い、税率は @conv.tax.standard.rate を参照する",
       "status": "accepted",
@@ -222,6 +231,14 @@
     }
   },
   "functionsCatalog": {
+    "generateUUID": {
+      "signature": "generateUUID(): string",
+      "returnType": "string",
+      "description": "UUID v4 を生成する。注文 ID 採番に使用する。",
+      "examples": [
+        "@fn.generateUUID()"
+      ]
+    },
     "calcTax": {
       "signature": "calcTax(subtotal: number, rate: number): number",
       "returnType": "number",
@@ -530,22 +547,10 @@
         {
           "id": "step-11",
           "type": "compute",
-          "description": "注文 ID を採番する (UUID v4)。",
+          "description": "注文 ID を採番する (UUID v4)。@fn.generateUUID を使用する。",
           "maturity": "committed",
-          "expression": "generateUUID()",
+          "expression": "@fn.generateUUID()",
           "outputBinding": "newOrderId"
-        },
-        {
-          "id": "step-12",
-          "type": "retail:OrderConfirmStep",
-          "description": "注文確定ステップ (retail 拡張)。orders INSERT / order_items INSERT / inventory DECREMENT を TX で処理することを明示する。",
-          "maturity": "committed",
-          "outputSchema": {
-            "orderId": "string",
-            "customerId": "string",
-            "totalAmount": "number",
-            "taxAmount": "number"
-          }
         },
         {
           "id": "step-13",
@@ -574,19 +579,14 @@
               "maturity": "committed",
               "tableName": "order_items",
               "operation": "INSERT",
-              "sql": "INSERT INTO order_items (order_id, product_code, product_name, quantity, unit_price, subtotal, created_at) SELECT @newOrder.id, ci.product_code, p.name, ci.quantity, ci.unit_price, ci.quantity * ci.unit_price, NOW() FROM cart_items ci JOIN products p ON p.product_code = ci.product_code WHERE ci.cart_id = @inputs.cartId",
+              "sql": "INSERT INTO order_items (order_id, product_code, product_name, quantity, unit_price, subtotal, created_at) SELECT @newOrderId, ci.product_code, p.name, ci.quantity, ci.unit_price, ci.quantity * ci.unit_price, NOW() FROM cart_items ci JOIN products p ON p.product_code = ci.product_code WHERE ci.cart_id = @inputs.cartId",
               "lineage": { "writes": ["order_items"] }
             },
             {
               "id": "step-13-03",
               "type": "retail:InventoryReserveStep",
-              "description": "在庫引当 (retail 拡張)。inventory.available_quantity を各商品の注文数量分デクリメントする。在庫不足の場合は affectedRows = 0 で TX をロールバックする。",
-              "maturity": "committed",
-              "outputSchema": {
-                "productCode": "string",
-                "quantity": "number",
-                "orderId": "string"
-              }
+              "description": "在庫引当 (retail 拡張)。前処理フックとして在庫引当の retail セマンティクスを明示する。実際の引当 UPDATE は step-13-04 で行う。",
+              "maturity": "committed"
             },
             {
               "id": "step-13-04",
@@ -608,6 +608,56 @@
           ]
         },
         {
+          "id": "step-13b",
+          "type": "branch",
+          "description": "TX 失敗 (在庫不足 rollback 等) を検出する。newOrder.id が null の場合は TX が失敗している。",
+          "maturity": "committed",
+          "branches": [
+            {
+              "id": "br-13b-a",
+              "code": "A",
+              "label": "TX 失敗",
+              "condition": "@newOrder == null || @newOrder.id == null",
+              "steps": [
+                {
+                  "id": "step-13b-a-01",
+                  "type": "eventPublish",
+                  "description": "order.confirm_failed イベントを発行する。",
+                  "maturity": "committed",
+                  "topic": "order.confirm_failed",
+                  "eventRef": "order.confirm_failed",
+                  "payload": "{ cartId: @inputs.cartId, customerId: @inputs.customerId, errorCode: 'INSUFFICIENT_INVENTORY' }"
+                },
+                {
+                  "id": "step-13b-a-02",
+                  "type": "return",
+                  "description": "422 在庫不足で TX ロールバック",
+                  "responseRef": "422-insufficient-inventory",
+                  "bodyExpression": "{ code: 'INSUFFICIENT_INVENTORY', message: '在庫が不足しています' }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-13b-else",
+            "code": "B",
+            "label": "TX 成功",
+            "description": "TX コミット済み。以降のステップを続行する。",
+            "steps": []
+          }
+        },
+        {
+          "id": "step-13c",
+          "type": "dbAccess",
+          "description": "TX コミット後に orders テーブルから確定済み注文を再 SELECT する。TX inner outputBinding (@newOrder) のネスト参照を避け、TX 外の確定値を取得する (#460 の修正パターン踏襲)。",
+          "maturity": "committed",
+          "tableName": "orders",
+          "operation": "SELECT",
+          "sql": "SELECT id, order_number, total_amount FROM orders WHERE id = @newOrderId",
+          "outputBinding": "persistedOrder",
+          "lineage": { "reads": ["orders"] }
+        },
+        {
           "id": "step-14",
           "type": "dbAccess",
           "description": "carts のステータスを CHECKED_OUT に更新する (TX 外)。",
@@ -615,7 +665,8 @@
           "tableName": "carts",
           "operation": "UPDATE",
           "sql": "UPDATE carts SET status = 'CHECKED_OUT', updated_at = NOW() WHERE id = @inputs.cartId",
-          "lineage": { "writes": ["carts"] }
+          "lineage": { "writes": ["carts"] },
+          "runIf": "@persistedOrder != null"
         },
         {
           "id": "step-15",
@@ -624,16 +675,18 @@
           "maturity": "committed",
           "topic": "retail.order_tax_calculated",
           "eventRef": "retail.order_tax_calculated",
-          "payload": "{ orderId: @newOrder.id, subtotal: @subtotal, taxAmount: @taxAmount, totalAmount: @totalAmount }"
+          "payload": "{ orderId: @persistedOrder.id, subtotal: @subtotal, taxAmount: @taxAmount, totalAmount: @totalAmount }",
+          "runIf": "@persistedOrder != null"
         },
         {
           "id": "step-16",
           "type": "eventPublish",
-          "description": "order.inventory_reserved イベントを発行する。",
+          "description": "order.inventory_reserved イベントを発行する。reservedItems は TX 後 SELECT の @inventoryUpdate を参照する。",
           "maturity": "committed",
           "topic": "order.inventory_reserved",
           "eventRef": "order.inventory_reserved",
-          "payload": "{ orderId: @newOrder.id, reservedItems: @cartItems }"
+          "payload": "{ orderId: @persistedOrder.id, reservedItems: @inventoryUpdate }",
+          "runIf": "@persistedOrder != null"
         },
         {
           "id": "step-17",
@@ -642,7 +695,8 @@
           "maturity": "committed",
           "topic": "order.confirmed",
           "eventRef": "order.confirmed",
-          "payload": "{ orderId: @newOrder.id, orderNumber: @newOrder.order_number, customerId: @inputs.customerId, totalAmount: @totalAmount, taxAmount: @taxAmount }"
+          "payload": "{ orderId: @persistedOrder.id, orderNumber: @persistedOrder.order_number, customerId: @inputs.customerId, totalAmount: @totalAmount, taxAmount: @taxAmount }",
+          "runIf": "@persistedOrder != null"
         },
         {
           "id": "step-18",
@@ -650,7 +704,8 @@
           "description": "201 Created を返す。",
           "maturity": "committed",
           "responseRef": "201-created",
-          "bodyExpression": "{ orderId: @newOrder.id, orderNumber: @newOrder.order_number, status: 'CONFIRMED', totalAmount: @totalAmount, taxAmount: @taxAmount }"
+          "bodyExpression": "{ orderId: @persistedOrder.id, orderNumber: @persistedOrder.order_number, status: 'CONFIRMED', totalAmount: @totalAmount, taxAmount: @taxAmount }",
+          "runIf": "@persistedOrder != null"
         }
       ]
     }

--- a/docs/sample-project/process-flows/gggggggg-0004-4000-8000-gggggggggggg.json
+++ b/docs/sample-project/process-flows/gggggggg-0004-4000-8000-gggggggggggg.json
@@ -86,7 +86,7 @@
       "domainRef": "retail.maxDeliveryAttempts"
     },
     "配送ステータス": {
-      "definition": "shipments.status の値。PENDING / DISPATCHED / IN_TRANSIT / DELIVERED / FAILED のいずれか。",
+      "definition": "shipments.status の値。PENDING / DISPATCHED / IN_TRANSIT / DELIVERED / FAILED のいずれか。existingShipment.id は shipments.id (PK, UUID v4) で、order_id に対して 1:1 制約 (UNIQUE INDEX)。",
       "aliases": ["ShipmentStatus"],
       "domainRef": "shipments.status"
     },
@@ -123,6 +123,15 @@
       "context": "物流会社 API は外部システムのため TX 内に含められない。試行回数の上限管理が必要。",
       "decision": "外部 API は TX 外で呼び出す。失敗時は delivery_attempt_count を +1 し、@conv.limit.maxDeliveryAttempts (3) 超過時は FAILED ステータスに更新してアラートイベントを発行する。",
       "consequences": "最大 3 回試行後に FAILED になる。4 回目以降は manual 対応が必要。",
+      "date": "2026-04-26"
+    },
+    {
+      "id": "ADR-004",
+      "title": "step-12/13 (DB 更新 2 件) は TX なしでべき等リトライを保証する",
+      "status": "accepted",
+      "context": "step-12 (shipments DISPATCHED 更新) と step-13 (orders SHIPPED 更新) を TransactionScope に入れるかどうか。",
+      "decision": "両ステップは独立した UPDATE であり、いずれかが失敗しても再試行でべき等に収束する。TX は使用しない。step-12 の shipmentId をべき等キーとして利用し、再試行時に同じ値で UPDATE することで副作用が発生しない。",
+      "consequences": "step-12 成功後 step-13 失敗のパターンでは orders が CONFIRMED のまま残るが、再試行時に step-12 はノーオペレーション (同値 UPDATE)、step-13 は冪等に SHIPPED に更新される。",
       "date": "2026-04-26"
     },
     {
@@ -191,7 +200,16 @@
         "headerName": "X-API-Key"
       },
       "timeoutMs": 5000,
-      "description": "ヤマト運輸の配送依頼 API。追跡番号・配送予定日を返す。"
+      "description": "ヤマト運輸の配送依頼 API。追跡番号・配送予定日を返す。",
+      "responseSchema": {
+        "type": "object",
+        "required": ["success", "trackingNumber", "estimatedDeliveryDate"],
+        "properties": {
+          "success": { "type": "boolean", "description": "配送依頼の成否" },
+          "trackingNumber": { "type": "string", "description": "ヤマト運輸が発行する追跡番号" },
+          "estimatedDeliveryDate": { "type": "string", "description": "配送予定日 (ISO 8601 date 形式)" }
+        }
+      }
     },
     "carrierApiSagawa": {
       "name": "佐川急便 API",
@@ -202,7 +220,16 @@
         "headerName": "X-API-Key"
       },
       "timeoutMs": 5000,
-      "description": "佐川急便の配送依頼 API。追跡番号・配送予定日を返す。"
+      "description": "佐川急便の配送依頼 API。追跡番号・配送予定日を返す。",
+      "responseSchema": {
+        "type": "object",
+        "required": ["success", "trackingNumber", "estimatedDeliveryDate"],
+        "properties": {
+          "success": { "type": "boolean", "description": "配送依頼の成否" },
+          "trackingNumber": { "type": "string", "description": "佐川急便が発行する追跡番号" },
+          "estimatedDeliveryDate": { "type": "string", "description": "配送予定日 (ISO 8601 date 形式)" }
+        }
+      }
     }
   },
   "secretsCatalog": {
@@ -457,8 +484,18 @@
               "id": "br-05-b",
               "code": "B",
               "label": "試行上限超過",
-              "condition": "@existingShipment != null && @existingShipment.delivery_attempt_count >= @conv.limit.maxDeliveryAttempts",
+              "condition": "@existingShipment != null && @existingShipment.delivery_attempt_count > @conv.limit.maxDeliveryAttempts",
               "steps": [
+                {
+                  "id": "step-05-b-00",
+                  "type": "dbAccess",
+                  "description": "配送指示を FAILED ステータスに更新する。試行上限超過を永続化する。",
+                  "maturity": "committed",
+                  "tableName": "shipments",
+                  "operation": "UPDATE",
+                  "sql": "UPDATE shipments SET status = 'FAILED', updated_at = NOW() WHERE id = @existingShipment.id",
+                  "lineage": { "writes": ["shipments"] }
+                },
                 {
                   "id": "step-05-b-01",
                   "type": "eventPublish",
@@ -490,7 +527,7 @@
           "type": "compute",
           "description": "配送指示 ID を採番する。既存 shipment があれば再利用、なければ新規生成。",
           "maturity": "committed",
-          "expression": "@existingShipment != null ? @existingShipment.id : generateUUID()",
+          "expression": "@existingShipment?.id != null ? @existingShipment.id : @fn.generateShipmentId()",
           "outputBinding": "shipmentId"
         },
         {
@@ -511,18 +548,6 @@
           "sql": "INSERT INTO shipments (id, order_id, carrier_code, status, delivery_attempt_count, created_at, updated_at) VALUES (@shipmentId, @inputs.orderId, @selectedCarrier, 'PENDING', 1, NOW(), NOW()) ON CONFLICT (id) DO UPDATE SET carrier_code = @selectedCarrier, delivery_attempt_count = shipments.delivery_attempt_count + 1, status = 'PENDING', updated_at = NOW() RETURNING id, delivery_attempt_count",
           "outputBinding": "upsertedShipment",
           "lineage": { "writes": ["shipments"] }
-        },
-        {
-          "id": "step-09",
-          "type": "retail:ShipmentDispatchStep",
-          "description": "配送指示ステップ (retail 拡張)。物流会社 API への配送依頼送信を明示する。",
-          "maturity": "committed",
-          "outputSchema": {
-            "orderId": "string",
-            "shipmentId": "string",
-            "carrierCode": "string",
-            "trackingNumber": "string"
-          }
         },
         {
           "id": "step-10",
@@ -555,7 +580,7 @@
               "id": "br-11-a",
               "code": "A",
               "label": "API 失敗",
-              "condition": "@carrierResult.success == false",
+              "condition": "@carrierResult == null || @carrierResult.success != true",
               "steps": [
                 {
                   "id": "step-11-a-01",
@@ -564,7 +589,17 @@
                   "maturity": "committed",
                   "topic": "shipment.dispatch_failed",
                   "eventRef": "shipment.dispatch_failed",
-                  "payload": "{ orderId: @inputs.orderId, errorCode: 'CARRIER_API_FAILED', retryCount: @upsertedShipment.delivery_attempt_count }"
+                  "payload": "{ orderId: @inputs.orderId, errorCode: 'CARRIER_API_FAILED', retryCount: @upsertedShipment.delivery_attempt_count }",
+                  "compensatesFor": "step-08"
+                },
+                {
+                  "id": "step-11-a-01b",
+                  "type": "eventPublish",
+                  "description": "shipment.carrier_notified イベントを success: false で発行する (catalog 整合)。",
+                  "maturity": "committed",
+                  "topic": "shipment.carrier_notified",
+                  "eventRef": "shipment.carrier_notified",
+                  "payload": "{ shipmentId: @shipmentId, orderId: @inputs.orderId, carrierCode: @selectedCarrier, success: false }"
                 },
                 {
                   "id": "step-11-a-02",

--- a/schemas/process-flow.schema.json
+++ b/schemas/process-flow.schema.json
@@ -334,6 +334,10 @@
           "type": "array",
           "items": { "type": "string" },
           "description": "このキャッシュを無効化するイベント名またはトピック名のリスト"
+        },
+        "note": {
+          "type": "string",
+          "description": "キャッシュ設定に関する補足説明。cross-flow 依存や運用上の注意事項を記述する"
         }
       }
     },
@@ -719,7 +723,7 @@
 
     "FieldType": {
       "oneOf": [
-        { "type": "string", "enum": ["string", "number", "boolean", "date"] },
+        { "type": "string", "enum": ["string", "number", "boolean", "date", "object[]", "string[]", "number[]"] },
         {
           "description": "配列型。itemType で要素型を再帰的に表現。例: Array<{itemId, quantity}>",
           "type": "object",
@@ -983,6 +987,10 @@
           "description": "GeneXus 由来の動作種別 (#422 P2-3)。type とは別概念。省略時はランタイム既定 (通常 Error 相当)"
         },
         "pattern": { "type": "string" },
+        "patternRef": {
+          "type": "string",
+          "description": "type=regex 時のパターンを @conv.regex.* 参照で指定するバリアント (リテラル pattern の代替)。例: '@conv.regex.product-code'"
+        },
         "length": { "type": "integer", "minimum": 0 },
         "min": { "type": "number" },
         "max": { "type": "number" },
@@ -1021,7 +1029,18 @@
         },
         "ngJumpTo": { "type": "string" },
         "ngResponseRef": { "type": "string" },
-        "ngBodyExpression": { "type": "string" }
+        "ngBodyExpression": { "type": "string" },
+        "ngEventPublish": {
+          "type": "object",
+          "description": "ng 時に eventPublish を実行してから ngResponseRef を返す。",
+          "required": ["topic", "eventRef", "payload"],
+          "additionalProperties": false,
+          "properties": {
+            "topic": { "type": "string" },
+            "eventRef": { "type": "string" },
+            "payload": { "type": "string" }
+          }
+        }
       }
     },
     "ValidationStep": {
@@ -1273,7 +1292,12 @@
           "type": "object",
           "additionalProperties": { "type": "string" }
         },
-        "description": { "type": "string" }
+        "description": { "type": "string" },
+        "responseSchema": {
+          "type": "object",
+          "description": "外部システム API のレスポンス JSON スキーマ (参考定義)。required / properties を記述する。",
+          "additionalProperties": true
+        }
       }
     },
     "ExternalSystemStep": {
@@ -1491,6 +1515,7 @@
         "id": { "type": "string" },
         "code": { "type": "string" },
         "label": { "type": "string" },
+        "description": { "type": "string" },
         "condition": { "$ref": "#/$defs/BranchCondition" },
         "steps": {
           "type": "array",


### PR DESCRIPTION
## Summary

- retail 4 フロー (gggggggg-0001〜0004) の Must-fix 13 件 / Should-fix 16 件 / Nit 11 件 (計 40 件) を修正
- `schemas/process-flow.schema.json` に不足フィールドを 6 件追加 (スキーマ拡張)
- `validate:dogfood` 4/4 全 pass、vitest 901/901 全 pass、build 成功

## 修正内容

### gggggggg-0001 (店舗在庫照会)
- **M2**: step-01 rules の productCode pattern を `patternRef: "@conv.regex.product-code"` に統一
- **S1**: step-03 condition に `|| @product == undefined` を追加 (null safety)
- **S2**: `inventory.searched` の description を「在庫レコードが存在する場合に発行」に修正
- **S3**: ADR-002 に「最初の 1 件のみ通知 (.find() 動作確定)」を明記
- **S4**: errorCatalog から `STORE_NOT_FOUND` / `SEARCH_LIMIT_EXCEEDED` を削除、対応 responses も削除
- **N1**: `act-001.outputs[0].type` を `"object[]"` に修正
- **N2**: step-06 expression を `@fn.isLowStock(...)` に変更
- **N3**: step-02 cache に `note` フィールドで cross-flow 依存を明記

### gggggggg-0002 (カート追加)
- **M1**: step-10 (`retail:CartManageStep`) を削除 (step-11 UPSERT との二重実行排除)
- **M2**: step-08b (existingCartItem SELECT) を追加、step-09 condition に既存商品除外 (`@existingCartItem == null &&`) を追加
- **M3**: step-07-a-01 の `availableQty` を `-1` 番兵値に変更 (0 = 在庫ゼロ との区別)
- **S1**: step-13 の `itemCount` を `@existingCartItem == null ? count + 1 : count` で最新値化
- **S4**: step-01 inlineBranch に `ngEventPublish` で `cart.validation_failed` 発行を追加
- **N2**: glossary `冪等 UPSERT` の aliases に `UPSERT_CART_ITEM` 追加
- **N3**: testScenarios に idempotent (no-op) パスのケースを追加

### gggggggg-0003 (注文確定 TX) — 既知パターン再発修正
- **S1**: step-12 (`retail:OrderConfirmStep`) を削除 (TX との責務重複解消)
- **M3**: step-13-02 の `@newOrder.id` を `@newOrderId` に統一
- **N2**: step-13-03 の outputSchema を削除 (前処理フックを明示)
- **M1/M2/M4**: step-11 を `@fn.generateUUID()` に変更、TX 直後に step-13b (TX 失敗 branch) + step-13c (persistedOrder SELECT) を追加、step-14〜18 に `runIf: "@persistedOrder != null"` 追加、`@newOrder.*` 参照を `@persistedOrder.*` に変更
- **S2**: step-16 の `reservedItems` を `@inventoryUpdate` 参照に変更
- **S3**: ADR-004 を追加して elseBranch fallthrough 動作を明記
- **generateUUID** を functionsCatalog に追加

### gggggggg-0004 (配送指示)
- **M1**: step-09 (`retail:ShipmentDispatchStep`) を削除 (step-10 externalSystem との責務重複解消)
- **M2**: step-11 br-11-a condition を `@carrierResult == null || @carrierResult.success != true` に変更
- **M3/S4**: step-06 expression を `@existingShipment?.id != null ? @existingShipment.id : @fn.generateShipmentId()` に変更
- **M4**: step-05-b condition を `>= → >` に変更 (オフバイワン解消)
- **S1**: step-11-a に `shipment.carrier_notified` (success: false) eventPublish 追加
- **S2**: step-05-b に shipments FAILED UPDATE step (step-05-b-00) を追加
- **S3**: glossary 「配送ステータス」に shipments.id PK 制約注記
- **S5**: externalSystemCatalog の Yamato/Sagawa に `responseSchema` を追加
- **N1**: step-11-a-01 に `compensatesFor: "step-08"` 追加
- **N2/N3**: ADR-004 で step-12/13 べき等リトライ方針を明記

### schemas/process-flow.schema.json (スキーマ拡張)
- `ValidationRule.patternRef` 追加 (`@conv.regex.*` 参照用)
- `ValidationInlineBranch.ngEventPublish` 追加
- `FieldType` に `"object[]"`, `"string[]"`, `"number[]"` 追加
- `ExternalSystemCatalogEntry.responseSchema` 追加
- `CacheHint.note` 追加
- `ElseBranch.description` 追加

## Test plan

- [x] `cd designer && npx tsx scripts/validate-dogfood.ts` → 4/4 全 pass
- [x] `cd designer && npx vitest run` → 901/901 全 pass (regression なし)
- [x] `cd designer && npm run build` → success

Refs #506