### PR TITLE
fix(dogfood): retail-0004 試行上限オフバイワン修正 — Phase 4-2 ラウンド 3 (#506)

### DIFF
--- a/docs/sample-project/process-flows/gggggggg-0004-4000-8000-gggggggggggg.json
+++ b/docs/sample-project/process-flows/gggggggg-0004-4000-8000-gggggggggggg.json
@@ -484,7 +484,7 @@
               "id": "br-05-b",
               "code": "B",
               "label": "試行上限超過",
-              "condition": "@existingShipment != null && @existingShipment.delivery_attempt_count > @conv.limit.maxDeliveryAttempts",
+              "condition": "@existingShipment != null && @existingShipment.delivery_attempt_count >= @conv.limit.maxDeliveryAttempts",
               "steps": [
                 {
                   "id": "step-05-b-00",


### PR DESCRIPTION
## Summary

Phase 4-2 ラウンド 4 (再 review-flow) で gggggggg-0004 に Must-fix 1 件残存を検出、修正。

### 問題
ラウンド 2 修正で `> @conv.limit.maxDeliveryAttempts` (strict greater) としたが、testScenario `max-attempts-exceeded` (delivery_attempt_count: 3) が 422 を期待する仕様と矛盾。`3 > 3` は false なので br-05-b が発動せず 4 回目試行が走ってしまう。

### 修正
`>` を `>=` に変更。意図 = 「3 回試行済みで上限到達 → 4 回目を拒否」が正しく機能する。

## Test plan
- [x] validate:dogfood 4/4 全 pass
- [x] vitest 全 pass

Refs #506 (Phase 4-2 改善ループ最終ラウンド)

🤖 Generated with [Claude Code](https://claude.com/claude-code)