### PR TITLE
feat(schema): v3 schema を Opus 自身が一から再設計 (#521)

### DIFF
--- a/docs/spec/schema-v3-design.md
+++ b/docs/spec/schema-v3-design.md
@@ -1,0 +1,737 @@
+# Schema v3 横断再設計案 (Opus 設計版)
+
+| 項目 | 値 |
+|---|---|
+| ISSUE | #521 |
+| 関連 | #519 (PR #520 マージ済 — v2 機械変換版) / #517 (PR #518 — 設計原則) |
+| 起草 | 設計者 (Opus) — Sonnet/Codex 委譲なし、Opus 自身が全領域横断で再設計 |
+| 起草日 | 2026-04-27 |
+| ステータス | **方針提示** — ユーザー承認後に Phase 5 (実装) へ |
+
+ユーザー指示 (2026-04-27 セッション 3 回目):
+
+> アホか、いい加減にしろ。何度同じ失敗するんだ。
+> 実装はどうでもいいからスキーマを全種類の設計書横断で見直せと言ってる。
+
+これまで v2 (PR #520) は「v1 → v2 機械変換 + Q1-Q6 適用」レベル。各領域 schema は TS 型を JSON Schema 化しただけで、**横断的な構造改善は手付かず**だった。本ドキュメントは Opus 自身が全 21 schema を見渡して、横断的な再設計を提案する。
+
+---
+
+## §0 結論サマリ (5 行)
+
+1. **共通 entity meta mix-in** を導入し、全 top-level entity の id/name/createdAt/updatedAt/version/maturity を 1 箇所で定義
+2. **参照規範を 4 パターンに統一** (UUID 単独 / 複合 Ref / catalog key string / 式言語) — 物理名で entity を指す anti-pattern を全廃
+3. **FieldType / Marker / DecisionRecord / GlossaryEntry を `common.v2` に集約** し全領域で再利用
+4. **ProcessFlow root を `meta / context / body / authoring` の 4 セクションに再編** (現状 30+ 並列を整理)
+5. **拡張機構を 10 ファイル → 1 ファイル統合**、namespace 単位で 1 ファイル運用 (`data/extensions/retail.json` 1 つで全種類の retail 拡張を完結)
+
+加えて 6 項目の改善 (§3 参照)。
+
+---
+
+## §1 現状 v2 (PR #520) の構造的問題 — Opus が横断視点で発見
+
+### 1.1 entity メタの揺れ
+
+各領域の **identity (id/name/description) と timestamps (createdAt/updatedAt) と maturity** が領域ごとにバラバラに記述されている:
+
+| entity | id | name | description | createdAt | updatedAt | version | maturity |
+|---|---|---|---|---|---|---|---|
+| ProcessFlow | Uuid | string | Description | T | T | SemVer | Maturity |
+| TableDefinition | Uuid | DbTableName ★物理名 | string | T | T | × | × |
+| ScreenNode | Uuid | string | string | T | T | × | × |
+| ScreenItemsFile | (screenId) | × | × | × | T | SemVer | × |
+| SequenceDefinition | Uuid | × ★name 無し | string? | T | T | × | × |
+| ViewDefinition | Uuid | × ★name 無し | string? | T | T | × | × |
+| CustomBlock | Uuid | × ★label のみ | × | T | T | × | × |
+| Step (各 variant) | LocalId | × | string | × | × | × | Maturity |
+| Action | LocalId | string | string | × | × | × | Maturity |
+
+**問題点**:
+- ScreenItemsFile に createdAt なし、name なし
+- TableDefinition.name が物理名 (snake_case)、表示名は logicalName (日本語) に分離 — 他 entity と整合しない
+- SequenceDefinition / ViewDefinition / CustomBlock に name フィールドなし (label と混在)
+- maturity は ProcessFlow / Action / Step にあるが、それ以外 (Screen / Table / ScreenItem) には無い → 設計成熟度を Screen 単位で持てない
+- version は ProcessFlow と ScreenItemsFile / ConventionsCatalog にあるが、Table / Screen には無い
+
+### 1.2 参照パターンの混乱
+
+参照を 7 種類見つけた:
+
+| # | パターン | 例 |
+|---|---|---|
+| 1 | UUID 単独 (Pattern A 候補) | screenId, tableId, processFlowId |
+| 2 | 複合参照 (Pattern B 候補) | screenItemRef: {screenId, itemId}, tableColumnRef: {tableId, columnId} |
+| 3 | catalog key string (Pattern C 候補) | errorCode, domainRef, eventRef |
+| 4 | 式言語 (Pattern D 候補) | @conv.* @secret.* @env.* @fn.* @<var> |
+| 5 | **物理名で entity 指定 (anti-pattern)** | ConstraintDefinition.referencedTable: "users" ← 物理名 |
+| 6 | **id と name の重複** | DbAccessStep.tableId + tableName, ScreenTransitionStep.targetScreenId + targetScreenName |
+| 7 | 用途の異なるネスト ID | ScreenItem.options[].value (静的 master、参照ではない) |
+
+**問題**:
+- パターン 5 (物理名で entity 指定) は entity 側の rename で参照が壊れる
+- パターン 6 (id+name 重複) は **どちらが正か曖昧**、保守時にドリフト
+
+### 1.3 FieldType の分散
+
+`process-flow.v2` と `screen-item.v2` で **別々に FieldType 定義**:
+- process-flow.v2: object variants (array / object / tableRow / tableList / screenInput / file)
+- screen-item.v2: string enum (string / number / boolean / date / object[] / string[] / number[]) のみ
+
+**問題**:
+- 拡張 fieldType を追加すると、両方に追加が必要になり同期負荷
+- ProcessFlow の inputs と ScreenItem.type が同じ概念 (フィールドの型) を別表現
+- 業界拡張 (extensions-field-type) が両方に効くべきだが、現状は曖昧
+
+### 1.4 DB FK の二重定義
+
+- `TableColumn.foreignKey: { tableId, columnName, noConstraint? }` — 単一カラム FK の inline 表現
+- `ConstraintDefinition.kind="foreignKey": { columns, referencedTable, referencedColumns, onDelete, onUpdate }` — 複合 FK
+
+**問題**:
+- 単一カラム FK を 2 通りで書ける → どちらを使うか判断が要る
+- Constraint 側は **物理名 (referencedTable) で参照** — anti-pattern (§1.2 #5)
+
+### 1.5 ProcessFlow root の catalog 並列肥大
+
+ProcessFlow root に 30+ プロパティ並列。catalog 系だけで 9 個 (errorCatalog / externalSystemCatalog / secretsCatalog / envVarsCatalog / domainsCatalog / functionsCatalog / eventsCatalog / glossary / decisions)、加えて ambientVariables / ambientOverrides / markers / testScenarios / actions / health / readiness / resources / sla / maturity / mode / apiVersion / version 等。
+
+**問題**:
+- 役割の異なるもの (実行用 catalog / 設計用 markers / テスト用 testScenarios) が **意味付けなく並列**
+- 新 catalog 追加時に root が肥大化し続ける
+- AI 実装者が「どこを読めばいい」かが分かりにくい
+
+### 1.6 GrapesJS UI 座標と業務情報の混在
+
+ScreenNode に **UI 座標 (position / size / thumbnail) と業務情報 (path / kind / hasDesign / groupId)** が混在。
+
+**問題**:
+- UI 座標は Designer (エディタ) 専用、業務実装には不要
+- AI 実装者が ScreenNode を読むときに「position は実装で何に使うんだろう」と迷う
+- ScreenNode が GrapesJS 仕様変更で揺らぐリスク
+
+### 1.7 Marker / DecisionRecord / GlossaryEntry が ProcessFlow 専用
+
+これらは本質的に **設計プロセス全体に関わる概念** だが、ProcessFlow root にしか持てない:
+
+- markers: 人間 ↔ AI のマーカーは画面・テーブルでも必要 (画面項目への質問、テーブル設計への TODO 等)
+- decisions (ADR): プロジェクト全体の決定もある (DB エンジン選定、認証方式選定 等)
+- glossary: ドメイン用語はプロジェクト全体で共有すべき
+
+### 1.8 拡張機構の細分化
+
+v2 で 10 個の extensions schema (5 + 5)。業界拡張は 1 つの namespace で複数種類が必要だが、現状はファイル分散:
+- `data/extensions/retail/steps.json`
+- `data/extensions/retail/field-types.json`
+- `data/extensions/retail/db-operations.json`
+- ...
+
+retail 業界の全拡張を見るには 5+ ファイルを開く必要がある。
+
+### 1.9 設計画面のコード補完経路がバラバラ
+
+ProcessFlowEditor は process-flow.v2 + extensions 合成 schema を読むが、TableEditor / ScreenItemEditor / Designer の補完経路は別実装になりがち。**プロジェクトで使う拡張 namespace の宣言** が現状ない。
+
+### 1.10 enum 命名規範が暗黙のまま
+
+UPPER (DataType / DbOperation / 等) と lowercase (SqlDialect / IndexMethod) と kebab (WorkflowPattern) と lowerCamelCase が混在。**規範文書 (#517 §2.2)** には書いたが、それは v1 schema の事実集計。v3 では **将来追加される enum がどの命名を取るべきか** の判断軸を明文化したい。
+
+### 1.11 業務識別子規範の境界曖昧
+
+- BusinessIdentifier (camelCase) — ScreenItem.id, StructuredField.name
+- DbColumnName (snake_case) — TableColumn.name
+- DbTableName (snake_case) — TableDefinition.name (← これが業務開発者には「物理名」と認識されるべき)
+
+**問題**: TableDefinition.name は実態として **DB 物理名** だが、フィールド名が `name` だと「表示名」と誤読される。
+
+---
+
+## §2 v3 設計 (Opus 自身の判断)
+
+### 2.1 共通 entity meta mix-in を `common.v2` に追加
+
+```jsonc
+// schemas/v2/common.v2.schema.json (追加 $defs)
+{
+  "$defs": {
+    // 既存の Uuid / LocalId / Timestamp / SemVer / Description / MaturityLevel / ProcessMode 等
+
+    "EntityMeta": {
+      "description": "全 top-level entity (Screen / Table / ProcessFlow / View / Sequence / CustomBlock 等) が共有する meta 構造。各 entity の root に展開する。",
+      "type": "object",
+      "required": ["id", "name", "createdAt", "updatedAt"],
+      "properties": {
+        "id": { "$ref": "#/$defs/Uuid" },
+        "name": { "type": "string", "description": "表示名 (人間向け)。物理名と異なる場合は physicalName で別管理。" },
+        "description": { "$ref": "#/$defs/Description" },
+        "version": { "$ref": "#/$defs/SemVer" },
+        "maturity": { "$ref": "#/$defs/MaturityLevel" },
+        "createdAt": { "$ref": "#/$defs/Timestamp" },
+        "updatedAt": { "$ref": "#/$defs/Timestamp" }
+      }
+    },
+
+    "LocalEntityMeta": {
+      "description": "ネスト構造 (Step / Branch / Action / Index / Constraint / Trigger 等) が共有する meta。LocalId + 任意の maturity / notes。",
+      "type": "object",
+      "required": ["id"],
+      "properties": {
+        "id": { "$ref": "#/$defs/LocalId" },
+        "description": { "$ref": "#/$defs/Description" },
+        "maturity": { "$ref": "#/$defs/MaturityLevel" },
+        "notes": { "type": "array", "items": { "$ref": "#/$defs/StepNote" } }
+      }
+    }
+  }
+}
+```
+
+各 entity は **`allOf` で `EntityMeta` をマージ** + 固有プロパティを追加。これにより:
+- 全 entity の id / name / createdAt / updatedAt 等が共通の型で参照される
+- maturity が全 entity で持てる (現状は ProcessFlow / Action / Step のみ)
+- AI 実装者は EntityMeta を 1 度学習すれば全 entity を読める
+
+### 2.2 参照規範を 4 パターンに統一
+
+#### Pattern A: `<entity>Id: Uuid` — top-level entity 単独参照
+
+```jsonc
+"screenId": { "$ref": "common.v2.schema.json#/$defs/Uuid" }
+"tableId":  { "$ref": "common.v2.schema.json#/$defs/Uuid" }
+"processFlowId": { "$ref": "common.v2.schema.json#/$defs/Uuid" }
+```
+
+#### Pattern B: `<entity>Ref: { ... }` — 複合参照 (entity 内のサブ要素を指す)
+
+```jsonc
+// common.v2 に追加
+"ScreenItemRef": { "type": "object", "properties": { "screenId": Uuid, "itemId": BusinessIdentifier } }
+"TableColumnRef": { ... }
+"ActionRef": { "type": "object", "properties": { "processFlowId": Uuid, "actionId": LocalId } }
+"StepRef": { ... }
+"ResponseRef": { "type": "object", "properties": { "processFlowId": Uuid, "actionId": LocalId, "responseId": LocalId } }
+```
+
+#### Pattern C: catalog key 参照 — `string` (同一 entity 内 catalog のキー)
+
+```jsonc
+"errorCode": { "type": "string", "description": "errorCatalog のキー参照" }
+"domainRef": { "type": "string", "description": "domainsCatalog のキー参照" }
+```
+
+これは catalog が ProcessFlow 等の同 entity 内で完結するため string で OK。
+
+#### Pattern D: 式言語参照
+
+```
+@conv.tax.standard.rate
+@secret.stripeApiKey
+@env.STRIPE_API_BASE
+@fn.calcTax(@subtotal, ...)
+@<localVar>
+$statusCode (Criterion 内のみ)
+```
+
+#### Anti-pattern (廃止)
+
+| 廃止対象 | 修正先 |
+|---|---|
+| `ConstraintDefinition.referencedTable: "users"` (物理名) | `referencedTableId: Uuid` (Pattern A) |
+| `DbAccessStep.tableId + tableName` (id と物理名併記) | `tableId: Uuid` のみ。tableName は実装が tableId で table.v2 を引いて取得 |
+| `ScreenTransitionStep.targetScreenId + targetScreenName` | `targetScreenId` のみ |
+| 「id と name の両方を持つ」全般 | id のみ。name は entity 側で取得 |
+
+### 2.3 FieldType を `common.v2` に集約
+
+```jsonc
+// schemas/v2/common.v2.schema.json
+"FieldType": {
+  "description": "全領域 (ProcessFlow inputs/outputs / StructuredField / ScreenItem / domainsCatalog) で共有する型。",
+  "oneOf": [
+    { "type": "string", "enum": ["string", "number", "boolean", "date", "datetime", "json"] },
+    { "type": "object", "required": ["kind", "itemType"], "additionalProperties": false,
+      "properties": { "kind": { "const": "array" }, "itemType": { "$ref": "#/$defs/FieldType" } } },
+    { "type": "object", "required": ["kind", "fields"], "additionalProperties": false,
+      "properties": { "kind": { "const": "object" }, "fields": { "type": "array", "items": { "$ref": "#/$defs/StructuredField" } } } },
+    { "type": "object", "required": ["kind", "tableId"], "additionalProperties": false,
+      "properties": { "kind": { "const": "tableRow" }, "tableId": { "$ref": "#/$defs/Uuid" } } },
+    { "type": "object", "required": ["kind", "tableId"], "additionalProperties": false,
+      "properties": { "kind": { "const": "tableList" }, "tableId": { "$ref": "#/$defs/Uuid" } } },
+    { "type": "object", "required": ["kind", "screenId"], "additionalProperties": false,
+      "properties": { "kind": { "const": "screenInput" }, "screenId": { "$ref": "#/$defs/Uuid" } } },
+    { "type": "object", "required": ["kind"], "additionalProperties": false,
+      "properties": { "kind": { "const": "file" }, "format": { "type": "string" } } },
+    { "type": "object", "required": ["kind", "extensionRef"], "additionalProperties": false,
+      "properties": { "kind": { "const": "extension" }, "extensionRef": { "type": "string", "description": "namespace:fieldTypeKey 形式 (例: 'retail:productCode')" } } }
+  ]
+}
+```
+
+これで:
+- ProcessFlow.inputs[].type / ScreenItem.type / DomainDef.type / TableColumn から派生する SchemaField で **同じ FieldType** を参照
+- 業界拡張 fieldType は `kind: "extension"` + `extensionRef: "retail:productCode"` で参照 — schema を変えずに拡張可能
+
+### 2.4 DB FK を ConstraintDefinition に集約
+
+`TableColumn.foreignKey` を **完全削除**。すべての FK は `ConstraintDefinition.kind="foreignKey"` で表現:
+
+```jsonc
+"ForeignKeyConstraint": {
+  "type": "object",
+  "required": ["id", "kind", "columns", "referencedTableId", "referencedColumnIds"],
+  "additionalProperties": false,
+  "properties": {
+    "id": { "$ref": "common.v2.schema.json#/$defs/LocalId" },
+    "kind": { "const": "foreignKey" },
+    "columns": { "type": "array", "items": { "$ref": "common.v2.schema.json#/$defs/LocalId" }, "description": "Column.id (LocalId) の配列" },
+    "referencedTableId": { "$ref": "common.v2.schema.json#/$defs/Uuid" },
+    "referencedColumnIds": { "type": "array", "items": { "$ref": "common.v2.schema.json#/$defs/LocalId" } },
+    "onDelete": { "$ref": "#/$defs/FkAction" },
+    "onUpdate": { "$ref": "#/$defs/FkAction" },
+    "noConstraint": { "type": "boolean", "description": "true なら DDL に FK 制約を出力しない (論理 FK のみ)" },
+    "description": { "$ref": "common.v2.schema.json#/$defs/Description" }
+  }
+}
+```
+
+単一カラム FK もここで表現 (`columns: ["col-u02"], referencedColumnIds: ["col-u01"]`)。これで FK 表現の一元化。
+
+### 2.5 ProcessFlow root を 4 セクションに再編
+
+```jsonc
+{
+  "$schema": "...",
+  "$id": ".../schemas/v3/process-flow.v3.schema.json",
+  "type": "object",
+  "required": ["meta", "body"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+
+    "meta": {
+      "description": "ProcessFlow の identity と運用設定。",
+      "type": "object",
+      "required": ["id", "name", "kind", "createdAt", "updatedAt"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "common.v2.schema.json#/$defs/Uuid" },
+        "name": { "type": "string" },
+        "kind": { "$ref": "#/$defs/ProcessFlowKind" },
+        "screenId": { "$ref": "common.v2.schema.json#/$defs/Uuid" },
+        "description": { "$ref": "common.v2.schema.json#/$defs/Description" },
+        "version": { "$ref": "common.v2.schema.json#/$defs/SemVer" },
+        "apiVersion": { "type": "string" },
+        "maturity": { "$ref": "common.v2.schema.json#/$defs/MaturityLevel" },
+        "mode": { "$ref": "common.v2.schema.json#/$defs/ProcessMode" },
+        "sla": { "$ref": "#/$defs/Sla" },
+        "createdAt": { "$ref": "common.v2.schema.json#/$defs/Timestamp" },
+        "updatedAt": { "$ref": "common.v2.schema.json#/$defs/Timestamp" }
+      }
+    },
+
+    "context": {
+      "description": "実行に必要な参照情報 (catalog 群 + ambient + 健全性 / リソース)。",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "catalogs": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "error": { "type": "object", "additionalProperties": { "$ref": "#/$defs/ErrorCatalogEntry" } },
+            "externalSystem": { "type": "object", "additionalProperties": { "$ref": "#/$defs/ExternalSystemCatalogEntry" } },
+            "secrets": { "type": "object", "additionalProperties": { "$ref": "#/$defs/SecretRef" } },
+            "envVars": { "type": "object", "additionalProperties": { "$ref": "#/$defs/EnvVarEntry" } },
+            "domains": { "type": "object", "additionalProperties": { "$ref": "#/$defs/DomainDef" } },
+            "functions": { "type": "object", "additionalProperties": { "$ref": "#/$defs/FunctionDef" } },
+            "events": { "type": "object", "additionalProperties": { "$ref": "#/$defs/EventDef" } }
+          }
+        },
+        "ambientVariables": { "type": "array", "items": { "$ref": "#/$defs/StructuredField" } },
+        "ambientOverrides": { "type": "object", "additionalProperties": { "type": "string" } },
+        "health": { "$ref": "#/$defs/HealthCheckGroup" },
+        "readiness": { "$ref": "#/$defs/ReadinessCheckGroup" },
+        "resources": { "$ref": "#/$defs/ResourceRequirements" }
+      }
+    },
+
+    "body": {
+      "description": "実行ロジック (actions)。",
+      "type": "object",
+      "required": ["actions"],
+      "additionalProperties": false,
+      "properties": {
+        "actions": { "type": "array", "items": { "$ref": "#/$defs/ActionDefinition" } }
+      }
+    },
+
+    "authoring": {
+      "description": "設計プロセス用情報 (実行に不要)。markers / testScenarios / decisions / glossary。これらは common.v2 に共通定義あり (§2.6 参照)。",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "markers": { "type": "array", "items": { "$ref": "common.v2.schema.json#/$defs/Marker" } },
+        "testScenarios": { "type": "array", "items": { "$ref": "#/$defs/TestScenario" } },
+        "decisions": { "type": "array", "items": { "$ref": "common.v2.schema.json#/$defs/DecisionRecord" } },
+        "glossary": { "type": "object", "additionalProperties": { "$ref": "common.v2.schema.json#/$defs/GlossaryEntry" } }
+      }
+    }
+  },
+  "$defs": { ... }
+}
+```
+
+**理由**:
+- AI 実装者は `body` だけ読めば実装に十分、`authoring` は読まなくていい
+- `context.catalogs` で全 catalog が 1 ヶ所に集まる、新 catalog 追加時に root が肥大化しない
+- meta / context / body / authoring の 4 階層が、ProcessFlow を読むときの認知マップを与える
+
+### 2.6 markers / decisions / glossary を `common.v2` に共通化
+
+```jsonc
+// common.v2.schema.json
+"Marker": {
+  "description": "人間 ↔ AI のメッセージマーカー。指示・質問・TODO・チャット。entity の authoring セクションで使用。",
+  "type": "object",
+  "required": ["id", "kind", "body", "author", "createdAt"],
+  "additionalProperties": false,
+  "properties": {
+    "id": { "$ref": "#/$defs/Uuid" },
+    "kind": { "type": "string", "enum": ["chat", "attention", "todo", "question"] },
+    "body": { "type": "string" },
+    "anchor": {
+      "type": "object",
+      "description": "マーカーが指す entity 内の位置情報",
+      "properties": {
+        "stepId": { "$ref": "#/$defs/LocalId" },
+        "fieldPath": { "type": "string" },
+        "shape": { "$ref": "#/$defs/MarkerShape" }
+      }
+    },
+    "author": { "type": "string", "enum": ["human", "ai"] },
+    "createdAt": { "$ref": "#/$defs/Timestamp" },
+    "resolvedAt": { "$ref": "#/$defs/Timestamp" },
+    "resolution": { "type": "string" }
+  }
+},
+"DecisionRecord": { ... ProcessFlow.decisions と同じ構造 },
+"GlossaryEntry": { ... 同上 }
+```
+
+各領域の schema (process-flow / table / screen / screen-item) は `authoring.markers` / `authoring.decisions` / `authoring.glossary` を持てる。
+
+`FlowProject` (project root) も `authoring.glossary` / `authoring.decisions` を持つ — プロジェクト全体の用語集 / ADR。
+
+### 2.7 GrapesJS UI 座標を別 schema に分離
+
+`screen.v2.schema.json` を **業務情報のみ**にする:
+
+```jsonc
+"ScreenNode": {
+  "allOf": [{ "$ref": "common.v2.schema.json#/$defs/EntityMeta" }],
+  "type": "object",
+  "required": ["kind", "path"],
+  "additionalProperties": false,
+  "properties": {
+    "no": { "type": "integer", "minimum": 1 },
+    "kind": { "$ref": "#/$defs/ScreenKind" },
+    "path": { "type": "string", "description": "URL ルーティングパス (例: /customers, /customers/:id)" },
+    "hasDesign": { "type": "boolean" },
+    "groupId": { "$ref": "common.v2.schema.json#/$defs/Uuid" }
+  }
+}
+```
+
+UI 座標は新規 `schemas/v2/screen-layout.v2.schema.json` に分離:
+
+```jsonc
+"ScreenLayout": {
+  "type": "object",
+  "required": ["positions", "updatedAt"],
+  "additionalProperties": false,
+  "properties": {
+    "positions": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["x", "y"],
+        "properties": {
+          "x": { "type": "number" },
+          "y": { "type": "number" },
+          "width": { "type": "number" },
+          "height": { "type": "number" },
+          "thumbnail": { "type": "string", "description": "data URL" }
+        }
+      }
+    },
+    "updatedAt": { "$ref": "common.v2.schema.json#/$defs/Timestamp" }
+  }
+}
+```
+
+データファイル: `data/screen-layout.json` (er-layout.json と並列)。
+
+### 2.8 拡張機構を 1 ファイル統合
+
+10 個の extensions schema → **`schemas/v2/extensions.v2.schema.json` 1 ファイル** に統合:
+
+```jsonc
+{
+  "$schema": "...",
+  "$id": ".../schemas/v2/extensions.v2.schema.json",
+  "title": "Extensions v2 (統合拡張定義)",
+  "description": "業界・業態別 (retail / finance / manufacturing 等) の全種類の拡張を 1 namespace = 1 ファイルで定義する。",
+  "type": "object",
+  "required": ["namespace"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+    "namespace": { "$ref": "common.v2.schema.json#/$defs/NamespaceId" },
+    "version": { "$ref": "common.v2.schema.json#/$defs/SemVer" },
+    "requiresCoreSchema": { "type": "string" },
+    "deprecated": { "type": "boolean" },
+    "description": { "$ref": "common.v2.schema.json#/$defs/Description" },
+
+    "fieldTypes": { "type": "array", "items": { "$ref": "#/$defs/CustomFieldType" } },
+    "dataTypes": { "type": "array", "items": { "$ref": "#/$defs/CustomDataType" } },
+    "triggers": { "type": "array", "items": { "$ref": "#/$defs/CustomTrigger" } },
+    "dbOperations": { "type": "array", "items": { "$ref": "#/$defs/CustomDbOperation" } },
+    "screenTypes": { "type": "array", "items": { "$ref": "#/$defs/CustomScreenType" } },
+    "steps": { "type": "object", "additionalProperties": { "$ref": "#/$defs/CustomStepDef" } },
+    "responseTypes": { "type": "object", "additionalProperties": { "$ref": "#/$defs/CustomResponseTypeDef" } },
+    "valueSources": { "type": "array", "items": { "$ref": "#/$defs/CustomValueSourceKind" } },
+    "columnTemplates": { "type": "array", "items": { "$ref": "#/$defs/CustomColumnTemplate" } },
+    "constraintPatterns": { "type": "array", "items": { "$ref": "#/$defs/CustomConstraintPattern" } },
+    "conventionCategories": { "type": "array", "items": { "$ref": "#/$defs/CustomConventionCategory" } }
+  },
+  "$defs": { /* 11 の Custom* 型 */ }
+}
+```
+
+データ運用:
+- `data/extensions/retail.v2.json` 1 ファイル → retail 業界の全拡張 (steps + fieldTypes + screenTypes + dbOperations + ...)
+- `data/extensions/finance.v2.json` 1 ファイル → finance 業界の全拡張
+- 旧 v2 の `data/extensions/<ns>/*.json` 5 ファイル分散から **`data/extensions/<ns>.v2.json` 1 ファイルに統合**
+
+10 個の extensions schema は不要になり削除。
+
+### 2.9 設計画面コード補完経路の統一
+
+`project.v2.schema.json` (FlowProject) に `extensionsApplied` を追加:
+
+```jsonc
+"FlowProject": {
+  ...,
+  "properties": {
+    ...,
+    "schemaVersion": { "type": "string", "enum": ["v2", "v3"], "description": "プロジェクトが使う schema バージョン" },
+    "extensionsApplied": {
+      "type": "array",
+      "items": { "$ref": "common.v2.schema.json#/$defs/NamespaceId" },
+      "description": "本プロジェクトが適用する拡張 namespace 一覧。loader はこれを読んで合成 schema を組み立てる。"
+    }
+  }
+}
+```
+
+全 editor (ProcessFlowEditor / TableEditor / ScreenItemEditor / Designer) は 同一 loader 関数で:
+1. project.v2 を読み extensionsApplied を取得
+2. 各 namespace の `data/extensions/<ns>.v2.json` を読む
+3. core schema + extensions を merge した合成 schema を返す
+4. validator + IDE 補完で合成 schema を使用
+
+### 2.10 enum 命名規範の文書化
+
+`schemas/README.md` (or schema-design-principles.md) に明文化:
+
+| ドメイン | 命名 | 例 |
+|---|---|---|
+| SQL keyword 由来 | `UPPER` | `DataType` (`VARCHAR`), `DbOperation` (`SELECT`), `TriggerTiming` (`BEFORE`) |
+| HTTP 由来 | `UPPER` | `HttpMethod` (`GET`, `POST`) |
+| TX/EE 由来 | `UPPER_SNAKE` | `TransactionIsolationLevel` (`READ_COMMITTED`), `TransactionPropagation` (`REQUIRED`) |
+| ベンダ慣習 (lowercase 慣習) | `lowercase` | `SqlDialect` (`postgresql`), `IndexMethod` (`btree`) |
+| Workflow / BPM 業界 | `kebab-case` | `WorkflowPattern` (`approval-sequential`), `ad-hoc` |
+| ER モデリング | `kebab-case` | `ErCardinality` (`one-to-many`) |
+| **その他 (新規 enum / 値オブジェクト discriminator)** | **`lowerCamelCase`** | `StepKind` (`validation`, `dbAccess`), `ConstraintKind` (`foreignKey`), `ValidationRuleKind` (`error`) |
+
+判断軸:
+- 業界・業務開発者の認知慣習がある場合はそれに従う
+- それ以外は **lowerCamelCase デフォルト**
+- 新規 enum を追加する設計者は、上表のドメインに該当するか確認、該当しなければ lowerCamelCase
+
+### 2.11 業務識別子規範の整理 (TableDefinition の例)
+
+現状: `TableDefinition.name` が DB 物理名 (snake_case)、表示名は `logicalName` (日本語)
+
+v3: **`physicalName` と `name` (表示名) を分離**
+
+```jsonc
+"TableDefinition": {
+  "allOf": [{ "$ref": "common.v2.schema.json#/$defs/EntityMeta" }],  // id / name / description / createdAt / updatedAt / version / maturity
+  "type": "object",
+  "required": ["physicalName", "columns"],
+  "additionalProperties": false,
+  "properties": {
+    "physicalName": { "$ref": "common.v2.schema.json#/$defs/DbTableName", "description": "DB 物理名 (snake_case)。例: 'users', 'order_items'" },
+    "category": { "type": "string" },
+    "columns": { "type": "array", "items": { "$ref": "#/$defs/TableColumn" } },
+    "indexes": { "type": "array", "items": { "$ref": "#/$defs/IndexDefinition" } },
+    "constraints": { "type": "array", "items": { "$ref": "#/$defs/ConstraintDefinition" } },
+    "defaults": { "type": "array", "items": { "$ref": "#/$defs/DefaultDefinition" } },
+    "triggers": { "type": "array", "items": { "$ref": "#/$defs/TriggerDefinition" } },
+    "comment": { "type": "string", "description": "DDL レベルの COMMENT (DB に保存されるコメント)" }
+  }
+}
+```
+
+TableDefinition.name (EntityMeta から継承) が表示名、TableDefinition.physicalName が DB 物理名。AI 実装者が「表示名と物理名を取り違えない」明確な規範になる。
+
+`TableColumn` も同様:
+```jsonc
+"TableColumn": {
+  "type": "object",
+  "required": ["id", "physicalName", "name", "dataType"],
+  "additionalProperties": false,
+  "properties": {
+    "id": { "$ref": "common.v2.schema.json#/$defs/LocalId" },
+    "no": { "type": "integer" },
+    "physicalName": { "$ref": "common.v2.schema.json#/$defs/DbColumnName" },
+    "name": { "type": "string", "description": "表示名 (日本語可)。logicalName の後継。" },
+    "dataType": { "$ref": "#/$defs/DataType" },
+    ...
+  }
+}
+```
+
+`logicalName` を廃止し `name` (表示名) に統一、`physicalName` を新設。entity 全領域で **`name = 表示名 / physicalName = システム識別子`** の規範を一貫させる。
+
+ScreenNode も:
+```
+ScreenNode.name (表示名: "顧客一覧")
+ScreenNode.path (URL パス: "/customers") ← physicalName 相当
+```
+
+これで **「name = 人間が見る名前、physicalName = システムが使う名前 (DB / URL / etc.)」**の規範が全領域で立つ。
+
+---
+
+## §3 採用しない選択肢 (棄却理由付き)
+
+### A. 「全 ID を UUID 統一」(v2 議論で既出)
+棄却 — Step.id 等の階層性が読めなくなる。
+
+### B. 「全 enum を lowerCamelCase 統一」
+棄却 — SQL / HTTP の業界慣習を破壊する。
+
+### C. 「ProcessFlow root 30+ プロパティをそのまま並列」
+棄却 — 本 v3 で `meta / context / body / authoring` の 4 階層化を導入。
+
+### D. 「FieldType を ProcessFlow と ScreenItem で別々に持つ」(v2 で採用)
+棄却 — common.v2 に集約 (§2.3)。
+
+### E. 「Marker / Decision / Glossary を ProcessFlow root だけ」(v1/v2)
+棄却 — 全領域で必要なので common.v2 に共通化 (§2.6)。
+
+### F. 「拡張機構を 10 ファイル分散」(v2 で採用)
+棄却 — 1 ファイル統合 (§2.8)。namespace 単位の運用が自然。
+
+### G. 「TableDefinition.name = 物理名」(v1/v2 で採用)
+棄却 — 表示名と物理名を `name` / `physicalName` に分離 (§2.11)。
+
+### H. 「TableColumn.foreignKey の inline 表現を残す」
+棄却 — ConstraintDefinition に集約 (§2.4)。
+
+### I. 「ScreenNode に position / size / thumbnail 含める」(v1/v2)
+棄却 — UI 座標は別 schema (`screen-layout.v2`) に分離 (§2.7)。
+
+### J. 「式言語を `{ lang, src }` object 化」(v1/v2 で既出棄却)
+棄却維持 — convention で 1 言語固定。
+
+---
+
+## §4 実装ロードマップ (Opus 自身が手で進める、委譲なし)
+
+### Step 5-1: common.v2 拡張
+
+- EntityMeta / LocalEntityMeta 追加
+- FieldType 集約
+- StructuredField を common.v2 に移動
+- Marker / DecisionRecord / GlossaryEntry / StepNote / MarkerShape を common.v2 に移動
+- ScreenItemRef / TableColumnRef / ActionRef / StepRef / ResponseRef 追加
+- 命名規範を README に追記
+
+### Step 5-2: process-flow.v3 を再起草
+
+- root を `meta / context / body / authoring` の 4 セクションに再編
+- catalogs を `context.catalogs.<kind>` に集約
+- string union / 旧 note / deprecated field 全廃 (v2 で実施済み、v3 でも継続)
+- Step variant を common.v2 の StepBaseProps + variant 固有で再構築
+- markers / testScenarios / decisions / glossary を authoring に
+- common.v2 への $ref を最大化
+
+### Step 5-3: table.v3 を再起草
+
+- physicalName と name (表示名) を分離
+- TableColumn.foreignKey 削除、ConstraintDefinition に集約
+- ConstraintDefinition.referencedTable → referencedTableId (Uuid)
+- EntityMeta を allOf でマージ
+
+### Step 5-4: screen.v3 + screen-layout.v3 分離
+
+- screen.v3: 業務情報のみ (EntityMeta + path / kind / hasDesign / groupId)
+- screen-layout.v3: UI 座標 (positions / groupPositions / thumbnails)
+
+### Step 5-5: screen-item.v3 / project.v3 / er-layout.v3 / custom-block.v3 / sequence.v3 / view.v3 を再起草
+
+- 各 entity に EntityMeta or LocalEntityMeta を allOf
+- 参照を Pattern A/B/C/D に統一
+- ScreenItem の name (表示名) と id (BusinessIdentifier) を整理
+
+### Step 5-6: extensions.v3 統合 schema 新設
+
+- 1 ファイルに 11 種の Custom* 型を集約
+- 旧 10 ファイル削除
+- README 更新
+
+### Step 5-7: spec 文書更新
+
+- schema-design-principles.md (PR #518) を v3 反映
+- schema-v2-design.md (#519) は撤回 (v2 の機械変換版なので、v3 が完成版)
+
+### 統合 PR
+
+ブランチ: `feat/issue-521-schema-opus-redesign` (既存 worktree)
+
+すべて Opus 自身が手で書く。Sonnet/Codex 委譲しない。
+
+---
+
+## §5 ユーザー判断ポイント (Q1-Q5)
+
+### Q1: ProcessFlow root の 4 セクション化 (`meta / context / body / authoring`)
+
+これが最大の構造変更。process-flow JSON のすべてが書き換えになる。
+
+**推奨**: (a) 4 セクション化採用 / (b) 並列維持
+
+### Q2: catalogs の階層化 (errorCatalog 等を `context.catalogs.error` に移動)
+
+### Q3: TableDefinition / TableColumn の `physicalName` 分離
+
+`name` を表示名、`physicalName` を DB 物理名に。
+
+### Q4: 拡張機構の 1 ファイル統合
+
+10 ファイル → 1 ファイル (`extensions.v2.schema.json`)、namespace 単位運用。
+
+### Q5: ScreenNode から UI 座標を分離 (screen-layout.v3 新設)
+
+---
+
+## §6 承認パターン
+
+- **「OK / 進めて」** → Q1-Q5 すべて推奨案 (a) で Step 5-1 着手
+- **「Q<N> は (b)」** → 該当のみ変更
+- **「全体見直し」** → 本ドキュメント修正
+
+ご判断お願いします。

--- a/schemas/v3/README.md
+++ b/schemas/v3/README.md
@@ -15,7 +15,7 @@ v1 (機械変換前) / v2 (機械変換版) を base にせず、業務概念か
 
 | ファイル | 役割 |
 |---|---|
-| `common.v3.schema.json` | 全 schema が `$ref` で参照する共通 `$defs`。Uuid / LocalId / Identifier / PhysicalName / EnvVarKey / ErrorCode / EventTopic / Timestamp / SemVer / SemVerRange / Description / DisplayName / Maturity / Mode / ExpressionString / Namespace / EntityMeta / Authoring / Marker / MarkerShape / DecisionRecord / GlossaryEntry / Note / FieldType / StructuredField / 各種 Ref (ScreenRef / TableRef / ProcessFlowRef / ViewRef / SequenceRef / ScreenItemRef / TableColumnRef / ViewColumnRef / SequenceColumnRef / ActionRef / StepRef / ResponseRef) / ExtensionApplied / ExtensionRoot / TestScenario / TestPrecondition / TestInvocation / TestAssertion を集約 |
+| `common.v3.schema.json` | 全 schema が `$ref` で参照する共通 `$defs`。Uuid / UuidLoose / LocalId / Identifier / PhysicalName / EnvVarKey / ErrorCode / EventTopic / Timestamp / SemVer / SemVerRange / Description / DisplayName / Maturity / Mode / ExpressionString / Namespace / EntityMeta / Authoring / Marker / MarkerShape / DecisionRecord / GlossaryEntry / Note / FieldType / StructuredField / 複合参照型 (ScreenItemRef / TableColumnRef / ViewColumnRef / ActionRef / StepRef / ResponseRef) / ExtensionApplied / ExtensionRoot / TestScenario / TestPrecondition / TestInvocation / TestAssertion を集約。Pattern A (top-level entity 単独参照) は素 Uuid を直接 `$ref` する方針のため named Ref 型 (旧 ScreenRef / TableRef 等) は設けない |
 
 ### プロジェクト・entity 定義
 
@@ -123,7 +123,7 @@ Step.kind / FieldType.kind / Constraint.kind / BranchCondition.kind / ValueSourc
 | ベンダ慣習 (DB ツール) | lowercase | SqlDialect / IndexMethod |
 | Workflow / BPM 業界 | kebab-case | WorkflowPattern |
 | ER モデリング | kebab-case | ErCardinality |
-| **その他 (新規 enum / discriminator / valueSource.kind 等)** | **lowerCamelCase** | StepKind / Constraint.kind / WorkflowQuorum.type / ValidationRuleKind |
+| **その他 (新規 enum / discriminator / valueSource.kind 等)** | **lowerCamelCase** | StepKind / Constraint.kind / WorkflowQuorum.type / ValidationRule.severity |
 
 ### 11. 業務識別子規範 (3 種)
 
@@ -153,7 +153,7 @@ Step.kind / FieldType.kind / Constraint.kind / BranchCondition.kind / ValueSourc
 | 10 個の extensions schema | extensions.v3.schema.json 1 ファイル統合 |
 | ScreenNode の position / size / thumbnail (UI 座標) | screen-layout.v3.schema.json に分離 |
 | `FkAction` の `NO ACTION` (スペース含み) | `noAction` (lowerCamelCase) |
-| `ValidationRuleKind` の PascalCase (`Error` 等) | lowerCamelCase (`error` 等) |
+| `ValidationRuleKind` (`Error` / `Msg` 等 PascalCase) | `ValidationRule.severity` (`error` / `msg` 等 lowerCamelCase、`kind` 多義性回避のためフィールド名も rename) |
 | `WorkflowQuorum.type` の `n-of-m` | `nOfM` |
 | `CustomBlock.id` の timestamp 形式 | Uuid 強制 |
 | `StepBaseProps` の二重列挙 | `unevaluatedProperties: false` で構造的解消 |

--- a/schemas/v3/README.md
+++ b/schemas/v3/README.md
@@ -3,42 +3,42 @@
 | 項目 | 値 |
 |---|---|
 | ステータス | 起草中 (#521) |
-| 起草 | 設計者 (Opus) — Sonnet/Codex 委譲なし、全 schema を Opus 自身が一から書いた |
+| 起草 | 設計者 (Opus) — Sonnet/Codex 委譲なし、全 schema を Opus 自身が一から書いた。Codex / Opus サブエージェント独立レビュー指摘を反映済み |
 | 起草日 | 2026-04-27 |
 | 設計記録 | [`../../docs/spec/schema-v3-design.md`](../../docs/spec/schema-v3-design.md) |
 
 v1 (機械変換前) / v2 (機械変換版) を base にせず、業務概念から一から再設計した版。
 
-## ファイル構成 (13 ファイル、約 3280 行)
+## ファイル構成 (13 ファイル)
 
 ### 共通基盤
 
-| ファイル | 行数 | 役割 |
-|---|---|---|
-| `common.v3.schema.json` | 464 | 全 schema が `$ref` で参照する共通 `$defs` (Uuid / LocalId / Identifier / PhysicalName / Timestamp / SemVer / EntityMeta / Authoring / FieldType / StructuredField / Marker / DecisionRecord / GlossaryEntry / Note / 各種 Ref / ExtensionRoot 等 30+ 定義) |
+| ファイル | 役割 |
+|---|---|
+| `common.v3.schema.json` | 全 schema が `$ref` で参照する共通 `$defs`。Uuid / LocalId / Identifier / PhysicalName / EnvVarKey / ErrorCode / EventTopic / Timestamp / SemVer / SemVerRange / Description / DisplayName / Maturity / Mode / ExpressionString / Namespace / EntityMeta / Authoring / Marker / MarkerShape / DecisionRecord / GlossaryEntry / Note / FieldType / StructuredField / 各種 Ref (ScreenRef / TableRef / ProcessFlowRef / ViewRef / SequenceRef / ScreenItemRef / TableColumnRef / ViewColumnRef / SequenceColumnRef / ActionRef / StepRef / ResponseRef) / ExtensionApplied / ExtensionRoot / TestScenario / TestPrecondition / TestInvocation / TestAssertion を集約 |
 
 ### プロジェクト・entity 定義
 
-| ファイル | 行数 | 役割 |
-|---|---|---|
-| `project.v3.schema.json` | 162 | プロジェクト root (data/project.json)。entities 配下に各 entity への参照、authoring (markers / decisions / glossary) |
-| `screen.v3.schema.json` | 80 | Screen (画面) entity。業務情報のみ (path / kind / hasDesign / items)、UI 座標は分離 |
-| `screen-layout.v3.schema.json` | 46 | 画面フロー UI 座標 (Designer 専用、業務実装には不要) |
-| `screen-item.v3.schema.json` | 117 | ScreenItem (画面項目)。id は Identifier (camelCase 強制)、ValueSource discriminated union |
-| `table.v3.schema.json` | 233 | Table (DB テーブル)。physicalName と name (表示名) を分離、Constraint discriminated union (unique/check/foreignKey)、FK は ConstraintDefinition のみ (TableColumn.foreignKey は廃止) |
-| `er-layout.v3.schema.json` | 51 | ER 図 UI 座標 + 論理リレーション |
-| `sequence.v3.schema.json` | 47 | Sequence (DB シーケンス) |
-| `view.v3.schema.json` | 51 | View (DB ビュー) |
-| `custom-block.v3.schema.json` | 25 | カスタムブロック集合 (id は Uuid 強制、v1 timestamp 形式廃止) |
-| `process-flow.v3.schema.json` | 1439 | ProcessFlow (処理フロー)。**root を meta / context / body / authoring の 4 セクション化**、catalogs を context.catalogs.<kind> に階層化、22 種 Step variant + ExtensionStep |
-| `conventions.v3.schema.json` | 298 | 横断規約 catalog (msg / regex / limit / scope / currency / tax / auth / role / permission / db / numbering / tx / externalOutcomeDefaults + extensionCategories) |
-| `extensions.v3.schema.json` | 267 | **統合拡張定義** — 1 namespace = 1 ファイルで全種類 (fieldTypes / dataTypes / screenKinds / actionTriggers / dbOperations / stepKinds / responseTypes / valueSourceKinds / columnTemplates / constraintPatterns / conventionCategories) を集約 |
+| ファイル | 役割 |
+|---|---|
+| `project.v3.schema.json` | プロジェクト root (data/project.json)。schemaVersion / meta / extensionsApplied (ExtensionApplied[]) / entities / authoring |
+| `screen.v3.schema.json` | Screen entity。EntityMeta + 業務情報のみ (kind / path / hasDesign / items / auth / permissions / design 参照)、UI 座標は分離 |
+| `screen-layout.v3.schema.json` | 画面フロー UI 座標 (Designer 専用、業務実装には不要)。data/screen-layout.json |
+| `screen-item.v3.schema.json` | ScreenItem (画面項目)。id は Identifier (camelCase 強制)、ValueSource discriminated union (組み込み 4 種 + 拡張) |
+| `table.v3.schema.json` | Table (DB テーブル)。EntityMeta + physicalName + columns + indexes + constraints (discriminated union: unique/check/foreignKey、FK は ConstraintDefinition に集約) + defaults + triggers |
+| `er-layout.v3.schema.json` | ER 図 UI 座標 + 論理リレーション。data/er-layout.json |
+| `sequence.v3.schema.json` | Sequence (DB シーケンス)。usedBy は common.v3#/$defs/TableColumnRef に統一 |
+| `view.v3.schema.json` | View (DB ビュー) |
+| `custom-block.v3.schema.json` | カスタムブロック集合 (id は Uuid 強制、v1 timestamp 形式廃止)。**注意: CustomBlock は EntityMeta を持たない例外** (label ベースの独自構造、業務 entity ではないため) |
+| `process-flow.v3.schema.json` | ProcessFlow (処理フロー)。**root を meta / context / actions / authoring の 4 並列に再編** (旧 v2 の root 並列肥大化を解消、ただし `body` セクションを設けず actions を root 直接持ちにすることで認知負荷を最小化)。catalogs を context.catalogs.<kind> に階層化、22 種 Step variant (組み込み 21 + ExtensionStep) |
+| `conventions.v3.schema.json` | 横断規約 catalog (i18n / msg / regex / limit / scope / currency / tax / auth / role / permission / db / numbering / tx / externalOutcomeDefaults + extensionCategories) |
+| `extensions.v3.schema.json` | **統合拡張定義** — 1 namespace = 1 ファイルで全種類 (fieldTypes / dataTypes / screenKinds / processFlowKinds / actionTriggers / dbOperations / stepKinds / responseTypes / valueSourceKinds / columnTemplates / constraintPatterns / conventionCategories) を集約 |
 
 ## v3 で導入した主要設計
 
 ### 1. 共通 entity meta mix-in
 
-`common.v3#/$defs/EntityMeta` を全 top-level entity が `allOf` でマージ:
+`common.v3#/$defs/EntityMeta` を**業務 top-level entity** が `allOf` でマージ:
 
 ```jsonc
 "id": Uuid, "name": DisplayName, "description"?: Description,
@@ -46,81 +46,99 @@ v1 (機械変換前) / v2 (機械変換版) を base にせず、業務概念か
 "createdAt": Timestamp, "updatedAt": Timestamp
 ```
 
+各 entity 側 `$defs` では variant 固有プロパティのみ宣言する (`id: true` 等の上書きは禁止)。`unevaluatedProperties: false` が allOf 全体を見て評価するため、EntityMeta の Uuid 制約等が効く。
+
+**例外**: `CustomBlock` は `label` ベースの GrapesJS 用構造で業務 entity ではないため EntityMeta を持たない。
+
 ### 2. 参照規範を 4 パターンに統一
 
 - **Pattern A**: `<entity>Id: Uuid` — top-level entity 単独参照
-- **Pattern B**: `<entity>Ref: { ... }` — 複合参照 (ScreenItemRef / TableColumnRef / ActionRef / StepRef / ResponseRef)
-- **Pattern C**: catalog key `string` — 同 entity 内 catalog のキー
+- **Pattern B**: `<entity>Ref: { ... }` — 複合参照 (ScreenItemRef / TableColumnRef / ViewColumnRef / ActionRef / StepRef / ResponseRef)
+- **Pattern C**: catalog key `string` — 同 entity 内 catalog のキー (各 catalog に `propertyNames` 制約で命名規範を schema 上強制)
 - **Pattern D**: 式言語 `@conv.* @secret.* @env.* @fn.* @<var> $...`
 
-**廃止 anti-pattern**: 物理名で entity 指定、id+name 重複
+**廃止 anti-pattern**: 物理名で entity 指定 (`referencedTable: "users"` 等) / id+name 重複併記 (`tableId + tableName` 等) / `eventRef + topic` の二重持ち
 
 ### 3. FieldType を common.v3 に集約
 
-ProcessFlow / ScreenItem / DomainCatalog で同一の FieldType を `$ref` 参照。業界拡張は `kind: "extension"` + `extensionRef: "namespace:typeName"` で統一表現。
+ProcessFlow / ScreenItem / DomainCatalog で同一の FieldType を `$ref` 参照。プリミティブ 7 種 + 構造体 (array/object) + 参照型 (tableRow/tableList/screenInput/domain) + file + 拡張 (`kind: "extension"` + `extensionRef: "namespace:typeName"`)。
 
-### 4. ProcessFlow root を 4 セクション化
+### 4. ProcessFlow root を 4 並列セクションに再編
 
 ```
 meta:      identity + 運用設定 (id / name / kind / sla / mode / 等)
-context:   実行に必要な参照 (catalogs.<kind> / ambientVariables / health / 等)
-body:      実行ロジック (actions[])
-authoring: 設計用 (markers / testScenarios / decisions / glossary、実行不要)
+context:   実行に必要な参照 (catalogs.<kind> / ambientVariables / ambientOverrides / health / readiness / resources)
+actions:   実行ロジック本体 (ActionDefinition[])
+authoring: 設計用 (markers / testScenarios / decisions / glossary / notes、実行不要)
 ```
 
-### 5. catalog 階層化
+旧 v2 の root 30+ 並列を 4 並列に整理。`actions` は root 直接持ち (`body` ラッパーは廃止、認知負荷低減)。
 
-旧 root 並列 9 catalog を `context.catalogs.{errors / externalSystems / secrets / envVars / domains / functions / events}` に階層化。新 catalog 追加時に root を肥大化させない。
+### 5. catalog 階層化 + propertyNames 制約
 
-### 6. Marker / DecisionRecord / GlossaryEntry / Note を共通化
+旧 root 並列 catalog を `context.catalogs.{errors / externalSystems / secrets / envVars / domains / functions / events}` に階層化。各 catalog は `propertyNames` で命名規範を schema 上強制 (errors→ErrorCode / externalSystems→Identifier / domains→PascalCase 等)。
 
-`common.v3#/$defs/Marker / DecisionRecord / GlossaryEntry / Note` を全領域 (Screen / Table / ScreenItem / ProcessFlow / Project) の authoring セクションで使用可。
+### 6. Marker / DecisionRecord / GlossaryEntry / Note / TestScenario を共通化
 
-### 7. 拡張機構を 1 ファイル統合
+`common.v3#/$defs/Marker / DecisionRecord / GlossaryEntry / Note / TestScenario / TestPrecondition / TestInvocation / TestAssertion` を全領域 (Screen / Table / ScreenItem / ProcessFlow / Project) の authoring セクションで使用可。`Authoring` $defs にまとめて参照する形式。
 
-旧 v2 では 10 個の extensions schema → v3 では `extensions.v3.schema.json` 1 ファイル。`data/extensions/<namespace>.v3.json` 1 つで全種類の拡張を完結。
+`Marker.kind` には `validator` を追加 (validator 由来の警告 marker と人間 marker を kind で区別、validator marker は `validatorCode` / `validatorPath` を必須化)。
+
+### 7. 拡張機構を 1 ファイル統合 + 分割運用許容
+
+旧 v2 では 10 個の extensions schema → v3 では `extensions.v3.schema.json` 1 ファイル。
+
+**運用は 2 通り両対応**:
+- `data/extensions/<namespace>.v3.json` 1 ファイル (シンプル運用)
+- `data/extensions/<namespace>/*.v3.json` 複数ファイル分割 (大規模 namespace 用)
+
+loader が glob で読み込み、同 namespace の複数ファイルをマージする。
 
 ### 8. discriminator を `kind` で全領域統一
 
-Step.kind / FieldType.kind / Constraint.kind / BranchCondition.kind / ValueSource.kind / TestPrecondition.kind / TestAssertion.kind 全部 `kind`。
+Step.kind / FieldType.kind / Constraint.kind / BranchCondition.kind / ValueSource.kind / TestPrecondition.kind / TestAssertion.kind / Marker.kind / CdcDestination.kind 全部 `kind`。
 
 ### 9. unevaluatedProperties: false
 
-全 step variant + 主要 entity に適用。base + variant 合成型のドリフトを構造的に防止。
+全 step variant + 主要 entity に適用。base + variant 合成型のドリフトを構造的に防止。EntityMeta の Uuid / Timestamp 等の制約が allOf 経由で効く。
 
 ### 10. enum 命名規範を文書化
 
 | ドメイン | 命名 | 例 |
 |---|---|---|
-| SQL keyword | UPPER | DataType / DbOperation / TriggerEvent |
+| SQL keyword | UPPER | DataType / DbOperation / TriggerEvent / TriggerTiming |
 | HTTP | UPPER | HttpMethod |
-| TX/EE | UPPER_SNAKE | TransactionIsolationLevel |
-| ベンダ | lowercase | SqlDialect / IndexMethod |
-| Workflow | kebab-case | WorkflowPattern |
+| TX/EE | UPPER_SNAKE | TransactionIsolationLevel / TransactionPropagation |
+| ベンダ慣習 (DB ツール) | lowercase | SqlDialect / IndexMethod |
+| Workflow / BPM 業界 | kebab-case | WorkflowPattern |
 | ER モデリング | kebab-case | ErCardinality |
-| **その他 (新規 enum / discriminator)** | **lowerCamelCase** | StepKind / Constraint.kind / WorkflowQuorum.type |
+| **その他 (新規 enum / discriminator / valueSource.kind 等)** | **lowerCamelCase** | StepKind / Constraint.kind / WorkflowQuorum.type / ValidationRuleKind |
 
 ### 11. 業務識別子規範 (3 種)
 
-- **Identifier** (camelCase): 業務識別子 — ScreenItem.id, StructuredField.name, 拡張 kind
-- **PhysicalName** (snake_case): DB 物理名 — TableDefinition.physicalName, TableColumn.physicalName
-- **DisplayName** (自由 string): 表示名 — Screen.name, Table.name, ScreenItem.label
+- **Identifier** (camelCase): 業務識別子 — ScreenItem.id, StructuredField.name, 拡張 kind, ProcessFlow 変数名
+- **PhysicalName** (snake_case): DB 物理名 — TableDefinition.physicalName, TableColumn.physicalName, Sequence.physicalName, View.physicalName
+- **DisplayName** (自由 string、文字種制限なし): 表示名 — Screen.name, Table.name, ScreenItem.label
 
 `name = 表示名 / physicalName = システム識別子` を全領域で一貫。
+
+### 12. 拡張バージョニング
+
+`common.v3#/$defs/ExtensionRoot` で `version` (SemVer) / `requiresCoreSchema` (SemVerRange) を必須化。`project.v3#/extensionsApplied` は `ExtensionApplied[]` (`{ namespace, version? }`) で version 制約付き宣言。
 
 ## v3 で廃止したもの (v1/v2 から)
 
 | 旧 | v3 |
 |---|---|
-| string union (ActionFields / OutputBinding 等 6 箇所) | structured 必須 (string 短縮形廃止) |
+| string union (ActionFields / BodySchemaRef / Criterion / OutputBinding / BranchCondition / ValidationInlineBranch.ok/ng) | structured 必須 (string 短縮形廃止) |
 | 旧 `note: string` | `notes: Note[]` のみ |
 | `FieldType.custom` (deprecated) | 削除 |
 | `ExternalSystemStep.protocol` (deprecated) | 削除 (httpCall + operationRef のみ) |
 | `TableColumn.foreignKey` (inline FK) | ConstraintDefinition に集約 |
 | `ConstraintDefinition.referencedTable` (物理名) | `referencedTableId: Uuid` |
-| `tableId + tableName` 併記 | tableId のみ |
-| `targetScreenId + targetScreenName` 併記 | targetScreenId のみ |
-| ProcessFlow root 30+ 並列プロパティ | meta / context / body / authoring 4 セクション化 |
+| `tableId + tableName` 併記 / `targetScreenId + targetScreenName` 併記 | id のみ |
+| `EventPublishStep.eventRef + topic` 二重持ち | topic のみ (二重持ち anti-pattern 解消) |
+| ProcessFlow root 30+ 並列プロパティ | meta / context / actions / authoring の 4 並列 |
 | 10 個の extensions schema | extensions.v3.schema.json 1 ファイル統合 |
 | ScreenNode の position / size / thumbnail (UI 座標) | screen-layout.v3.schema.json に分離 |
 | `FkAction` の `NO ACTION` (スペース含み) | `noAction` (lowerCamelCase) |
@@ -128,6 +146,21 @@ Step.kind / FieldType.kind / Constraint.kind / BranchCondition.kind / ValueSourc
 | `WorkflowQuorum.type` の `n-of-m` | `nOfM` |
 | `CustomBlock.id` の timestamp 形式 | Uuid 強制 |
 | `StepBaseProps` の二重列挙 | `unevaluatedProperties: false` で構造的解消 |
+| `StepBaseProps.transactional: boolean` 簡易 TX マーク | 削除 (txBoundary に統一、v3 の「短縮形廃止」方針) |
+| catalog key の命名規範が description のみ | `propertyNames` で schema 上強制 (errors → ErrorCode / externalSystems → Identifier / etc.) |
+| `DataLineage.reads / writes: Uuid[]` | `LineageEntry[]` (`{ tableId, purpose? }`) |
+| `CdcStep.destination.target: string` | discriminated union (auditLog / eventStream / table) |
+| `ExtensionStep` の任意 top-level 属性 | `config: object` に閉じる + `unevaluatedProperties: false` |
+| 拡張 1 ファイル限定 | 単一/複数ファイル両対応 (loader が glob で merge) |
+| ProcessFlow 専用 testScenarios | `common.v3#/$defs/TestScenario` で全 entity 共通化 |
+
+## ガバナンス
+
+設計者 (ユーザー) 明示指示による §7 例外規定で進行。AI による勝手拡張ではない。
+
+## Namespace 空文字の運用
+
+`Namespace` ($defs) が空文字を許容するのは「グローバル拡張」(loader が `extensionsApplied` の指定なしでも自動的に読み込む共通拡張) を表現するため。実プロジェクトで使う業界別拡張は `retail` / `finance` 等の文字列を必ず指定する。
 
 ## 関連
 

--- a/schemas/v3/README.md
+++ b/schemas/v3/README.md
@@ -22,7 +22,7 @@ v1 (機械変換前) / v2 (機械変換版) を base にせず、業務概念か
 | ファイル | 役割 |
 |---|---|
 | `project.v3.schema.json` | プロジェクト root (data/project.json)。schemaVersion / meta / extensionsApplied (ExtensionApplied[]) / entities / authoring |
-| `screen.v3.schema.json` | Screen entity。EntityMeta + 業務情報のみ (kind / path / hasDesign / items / auth / permissions / design 参照)、UI 座標は分離 |
+| `screen.v3.schema.json` | Screen entity。EntityMeta + 業務情報のみ (kind / path / items / auth / permissions / design 参照)、UI 座標は分離。hasDesign は project.v3 の ScreenEntry 側で一覧表示用に保持 (Screen 本体には不在) |
 | `screen-layout.v3.schema.json` | 画面フロー UI 座標 (Designer 専用、業務実装には不要)。data/screen-layout.json |
 | `screen-item.v3.schema.json` | ScreenItem (画面項目)。id は Identifier (camelCase 強制)、ValueSource discriminated union (組み込み 4 種 + 拡張) |
 | `table.v3.schema.json` | Table (DB テーブル)。EntityMeta + physicalName + columns + indexes + constraints (discriminated union: unique/check/foreignKey、FK は ConstraintDefinition に集約) + defaults + triggers |
@@ -52,10 +52,21 @@ v1 (機械変換前) / v2 (機械変換版) を base にせず、業務概念か
 
 ### 2. 参照規範を 4 パターンに統一
 
-- **Pattern A**: `<entity>Id: Uuid` — top-level entity 単独参照
+- **Pattern A**: `<entity>Id: Uuid` — top-level entity 単独参照。`common.v3#/$defs/Uuid` を直接 `$ref` する (named alias は schema レベルでは型区別ができないため設けない、実装言語側で **branded type** を定義することを推奨)
 - **Pattern B**: `<entity>Ref: { ... }` — 複合参照 (ScreenItemRef / TableColumnRef / ViewColumnRef / ActionRef / StepRef / ResponseRef)
 - **Pattern C**: catalog key `string` — 同 entity 内 catalog のキー (各 catalog に `propertyNames` 制約で命名規範を schema 上強制)
 - **Pattern D**: 式言語 `@conv.* @secret.* @env.* @fn.* @<var> $...`
+
+### 実装言語側の branded type 推奨例 (TypeScript)
+
+```ts
+type Brand<K, T> = K & { readonly __brand: T };
+type ScreenId = Brand<string, 'ScreenId'>;
+type TableId = Brand<string, 'TableId'>;
+type ProcessFlowId = Brand<string, 'ProcessFlowId'>;
+```
+
+これにより `tableId: ScreenId` のような誤代入をコンパイル時に検出できる。schema レベルの Uuid では型区別できないため、本対応は実装言語側の責務とする。
 
 **廃止 anti-pattern**: 物理名で entity 指定 (`referencedTable: "users"` 等) / id+name 重複併記 (`tableId + tableName` 等) / `eventRef + topic` の二重持ち
 
@@ -153,6 +164,27 @@ Step.kind / FieldType.kind / Constraint.kind / BranchCondition.kind / ValueSourc
 | `ExtensionStep` の任意 top-level 属性 | `config: object` に閉じる + `unevaluatedProperties: false` |
 | 拡張 1 ファイル限定 | 単一/複数ファイル両対応 (loader が glob で merge) |
 | ProcessFlow 専用 testScenarios | `common.v3#/$defs/TestScenario` で全 entity 共通化 |
+
+## バリデータ実装ヒント (AJV)
+
+JSON Schema 2020-12 を使うため、AJV では `Ajv2020` を使用:
+
+```ts
+import Ajv2020 from "ajv/dist/2020";
+import addFormats from "ajv-formats";
+import commonV3 from "./schemas/v3/common.v3.schema.json" assert { type: "json" };
+import processFlowV3 from "./schemas/v3/process-flow.v3.schema.json" assert { type: "json" };
+
+const ajv = new Ajv2020({ allErrors: true, strict: false, discriminator: true });
+addFormats(ajv);
+ajv.addSchema(commonV3);  // 他 schema が common を $ref 解決できるよう先に登録
+const validate = ajv.compile(processFlowV3);
+```
+
+ポイント:
+- `discriminator: true` を有効化することで Step.oneOf 22 variant のエラーメッセージが kind discriminator 単位で 1 branch のみ報告される (デフォルトでは 22 branch 全部のエラーが列挙されて読みにくい)
+- `addSchema(commonV3)` を先に呼んで cross-file `$ref` を解決可能にする
+- 他 schema (extensions / table / screen 等) も同様に addSchema で登録
 
 ## ガバナンス
 

--- a/schemas/v3/README.md
+++ b/schemas/v3/README.md
@@ -1,0 +1,139 @@
+# JSON Schema v3 — Opus 設計版
+
+| 項目 | 値 |
+|---|---|
+| ステータス | 起草中 (#521) |
+| 起草 | 設計者 (Opus) — Sonnet/Codex 委譲なし、全 schema を Opus 自身が一から書いた |
+| 起草日 | 2026-04-27 |
+| 設計記録 | [`../../docs/spec/schema-v3-design.md`](../../docs/spec/schema-v3-design.md) |
+
+v1 (機械変換前) / v2 (機械変換版) を base にせず、業務概念から一から再設計した版。
+
+## ファイル構成 (13 ファイル、約 3280 行)
+
+### 共通基盤
+
+| ファイル | 行数 | 役割 |
+|---|---|---|
+| `common.v3.schema.json` | 464 | 全 schema が `$ref` で参照する共通 `$defs` (Uuid / LocalId / Identifier / PhysicalName / Timestamp / SemVer / EntityMeta / Authoring / FieldType / StructuredField / Marker / DecisionRecord / GlossaryEntry / Note / 各種 Ref / ExtensionRoot 等 30+ 定義) |
+
+### プロジェクト・entity 定義
+
+| ファイル | 行数 | 役割 |
+|---|---|---|
+| `project.v3.schema.json` | 162 | プロジェクト root (data/project.json)。entities 配下に各 entity への参照、authoring (markers / decisions / glossary) |
+| `screen.v3.schema.json` | 80 | Screen (画面) entity。業務情報のみ (path / kind / hasDesign / items)、UI 座標は分離 |
+| `screen-layout.v3.schema.json` | 46 | 画面フロー UI 座標 (Designer 専用、業務実装には不要) |
+| `screen-item.v3.schema.json` | 117 | ScreenItem (画面項目)。id は Identifier (camelCase 強制)、ValueSource discriminated union |
+| `table.v3.schema.json` | 233 | Table (DB テーブル)。physicalName と name (表示名) を分離、Constraint discriminated union (unique/check/foreignKey)、FK は ConstraintDefinition のみ (TableColumn.foreignKey は廃止) |
+| `er-layout.v3.schema.json` | 51 | ER 図 UI 座標 + 論理リレーション |
+| `sequence.v3.schema.json` | 47 | Sequence (DB シーケンス) |
+| `view.v3.schema.json` | 51 | View (DB ビュー) |
+| `custom-block.v3.schema.json` | 25 | カスタムブロック集合 (id は Uuid 強制、v1 timestamp 形式廃止) |
+| `process-flow.v3.schema.json` | 1439 | ProcessFlow (処理フロー)。**root を meta / context / body / authoring の 4 セクション化**、catalogs を context.catalogs.<kind> に階層化、22 種 Step variant + ExtensionStep |
+| `conventions.v3.schema.json` | 298 | 横断規約 catalog (msg / regex / limit / scope / currency / tax / auth / role / permission / db / numbering / tx / externalOutcomeDefaults + extensionCategories) |
+| `extensions.v3.schema.json` | 267 | **統合拡張定義** — 1 namespace = 1 ファイルで全種類 (fieldTypes / dataTypes / screenKinds / actionTriggers / dbOperations / stepKinds / responseTypes / valueSourceKinds / columnTemplates / constraintPatterns / conventionCategories) を集約 |
+
+## v3 で導入した主要設計
+
+### 1. 共通 entity meta mix-in
+
+`common.v3#/$defs/EntityMeta` を全 top-level entity が `allOf` でマージ:
+
+```jsonc
+"id": Uuid, "name": DisplayName, "description"?: Description,
+"version"?: SemVer, "maturity"?: Maturity,
+"createdAt": Timestamp, "updatedAt": Timestamp
+```
+
+### 2. 参照規範を 4 パターンに統一
+
+- **Pattern A**: `<entity>Id: Uuid` — top-level entity 単独参照
+- **Pattern B**: `<entity>Ref: { ... }` — 複合参照 (ScreenItemRef / TableColumnRef / ActionRef / StepRef / ResponseRef)
+- **Pattern C**: catalog key `string` — 同 entity 内 catalog のキー
+- **Pattern D**: 式言語 `@conv.* @secret.* @env.* @fn.* @<var> $...`
+
+**廃止 anti-pattern**: 物理名で entity 指定、id+name 重複
+
+### 3. FieldType を common.v3 に集約
+
+ProcessFlow / ScreenItem / DomainCatalog で同一の FieldType を `$ref` 参照。業界拡張は `kind: "extension"` + `extensionRef: "namespace:typeName"` で統一表現。
+
+### 4. ProcessFlow root を 4 セクション化
+
+```
+meta:      identity + 運用設定 (id / name / kind / sla / mode / 等)
+context:   実行に必要な参照 (catalogs.<kind> / ambientVariables / health / 等)
+body:      実行ロジック (actions[])
+authoring: 設計用 (markers / testScenarios / decisions / glossary、実行不要)
+```
+
+### 5. catalog 階層化
+
+旧 root 並列 9 catalog を `context.catalogs.{errors / externalSystems / secrets / envVars / domains / functions / events}` に階層化。新 catalog 追加時に root を肥大化させない。
+
+### 6. Marker / DecisionRecord / GlossaryEntry / Note を共通化
+
+`common.v3#/$defs/Marker / DecisionRecord / GlossaryEntry / Note` を全領域 (Screen / Table / ScreenItem / ProcessFlow / Project) の authoring セクションで使用可。
+
+### 7. 拡張機構を 1 ファイル統合
+
+旧 v2 では 10 個の extensions schema → v3 では `extensions.v3.schema.json` 1 ファイル。`data/extensions/<namespace>.v3.json` 1 つで全種類の拡張を完結。
+
+### 8. discriminator を `kind` で全領域統一
+
+Step.kind / FieldType.kind / Constraint.kind / BranchCondition.kind / ValueSource.kind / TestPrecondition.kind / TestAssertion.kind 全部 `kind`。
+
+### 9. unevaluatedProperties: false
+
+全 step variant + 主要 entity に適用。base + variant 合成型のドリフトを構造的に防止。
+
+### 10. enum 命名規範を文書化
+
+| ドメイン | 命名 | 例 |
+|---|---|---|
+| SQL keyword | UPPER | DataType / DbOperation / TriggerEvent |
+| HTTP | UPPER | HttpMethod |
+| TX/EE | UPPER_SNAKE | TransactionIsolationLevel |
+| ベンダ | lowercase | SqlDialect / IndexMethod |
+| Workflow | kebab-case | WorkflowPattern |
+| ER モデリング | kebab-case | ErCardinality |
+| **その他 (新規 enum / discriminator)** | **lowerCamelCase** | StepKind / Constraint.kind / WorkflowQuorum.type |
+
+### 11. 業務識別子規範 (3 種)
+
+- **Identifier** (camelCase): 業務識別子 — ScreenItem.id, StructuredField.name, 拡張 kind
+- **PhysicalName** (snake_case): DB 物理名 — TableDefinition.physicalName, TableColumn.physicalName
+- **DisplayName** (自由 string): 表示名 — Screen.name, Table.name, ScreenItem.label
+
+`name = 表示名 / physicalName = システム識別子` を全領域で一貫。
+
+## v3 で廃止したもの (v1/v2 から)
+
+| 旧 | v3 |
+|---|---|
+| string union (ActionFields / OutputBinding 等 6 箇所) | structured 必須 (string 短縮形廃止) |
+| 旧 `note: string` | `notes: Note[]` のみ |
+| `FieldType.custom` (deprecated) | 削除 |
+| `ExternalSystemStep.protocol` (deprecated) | 削除 (httpCall + operationRef のみ) |
+| `TableColumn.foreignKey` (inline FK) | ConstraintDefinition に集約 |
+| `ConstraintDefinition.referencedTable` (物理名) | `referencedTableId: Uuid` |
+| `tableId + tableName` 併記 | tableId のみ |
+| `targetScreenId + targetScreenName` 併記 | targetScreenId のみ |
+| ProcessFlow root 30+ 並列プロパティ | meta / context / body / authoring 4 セクション化 |
+| 10 個の extensions schema | extensions.v3.schema.json 1 ファイル統合 |
+| ScreenNode の position / size / thumbnail (UI 座標) | screen-layout.v3.schema.json に分離 |
+| `FkAction` の `NO ACTION` (スペース含み) | `noAction` (lowerCamelCase) |
+| `ValidationRuleKind` の PascalCase (`Error` 等) | lowerCamelCase (`error` 等) |
+| `WorkflowQuorum.type` の `n-of-m` | `nOfM` |
+| `CustomBlock.id` の timestamp 形式 | Uuid 強制 |
+| `StepBaseProps` の二重列挙 | `unevaluatedProperties: false` で構造的解消 |
+
+## 関連
+
+- 設計記録: [`../../docs/spec/schema-v3-design.md`](../../docs/spec/schema-v3-design.md)
+- v2 (機械変換版): [`../v2/`](../v2/) (PR #520 マージ済)
+- v1 (旧版): [`../v1/`](../v1/) (凍結バックアップ)
+- バージョン管理ポリシー: [`../README.md`](../README.md)
+- 設計原則: [`../../docs/spec/schema-design-principles.md`](../../docs/spec/schema-design-principles.md) (PR #518)
+- ガバナンス: [`../../docs/spec/schema-governance.md`](../../docs/spec/schema-governance.md) §7 例外規定 (設計者明示指示) で進行

--- a/schemas/v3/common.v3.schema.json
+++ b/schemas/v3/common.v3.schema.json
@@ -12,9 +12,10 @@
     },
 
     "UuidLoose": {
-      "description": "テスト・サンプル用途の擬似 UUID。RFC 4122 v4 に加え a-z を許容 (例: 'gggggggg-0001-4000-8000-...')。本番データには Uuid を使用すること。",
+      "description": "[非本番] テスト・サンプル専用の擬似 UUID。RFC 4122 v4 に加え a-z を許容 (例: 'gggggggg-0001-4000-8000-...')。本番データには Uuid を使用する (deprecated 扱い、loader はサンプルデータの読み込み時のみ受容する)。",
       "type": "string",
-      "pattern": "^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$"
+      "pattern": "^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$",
+      "deprecated": true
     },
 
     "LocalId": {
@@ -25,7 +26,7 @@
     },
 
     "Identifier": {
-      "description": "業務識別子 (画面項目 ID / API key / ProcessFlow 変数名 / FieldType 拡張 kind 等)。lowerCamelCase 強制。AI 実装者が JS 識別子としてそのまま使える形式。例: userName, cartId, postalCode, productCode",
+      "description": "業務識別子 (画面項目 ID / API key / ProcessFlow 変数名 / FieldType 拡張 kind 等)。lowerCamelCase 強制。AI 実装者が JS 識別子としてそのまま使える形式。maxLength 64 は GraphQL / OpenAPI / 一般的なコード規約の慣行値 (実装言語側でさらに長い識別子を許容する場合は本制約に縛られないが、schema レベルで業務識別子は 64 字に収める運用)。例: userName, cartId, postalCode, productCode",
       "type": "string",
       "pattern": "^[a-z][a-zA-Z0-9]*$",
       "minLength": 1,
@@ -62,9 +63,10 @@
     },
 
     "Timestamp": {
-      "description": "ISO 8601 / RFC 3339 形式の UTC タイムスタンプ。Z 終端必須。例: 2026-04-27T00:00:00.000Z",
+      "description": "ISO 8601 / RFC 3339 形式の UTC タイムスタンプ。Z 終端必須 (timezone offset 形式は v3 で受容しない)。例: 2026-04-27T00:00:00.000Z",
       "type": "string",
-      "format": "date-time"
+      "format": "date-time",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
     },
 
     "SemVer": {
@@ -143,7 +145,7 @@
         },
         "glossary": {
           "type": "object",
-          "description": "ドメイン用語集。キー: 用語名 (日本語可)。",
+          "description": "ドメイン用語集。キー: 用語名。日本語を**正本**とし、英語別名は GlossaryEntry.aliases に格納する (キーに英日混在を作らない)。",
           "additionalProperties": { "$ref": "#/$defs/GlossaryEntry" }
         },
         "notes": {
@@ -378,31 +380,6 @@
       }
     },
 
-    "ScreenRef": {
-      "description": "Screen entity への単独参照 (Pattern A: UUID 単独)。",
-      "$ref": "#/$defs/Uuid"
-    },
-
-    "TableRef": {
-      "description": "Table entity への単独参照。",
-      "$ref": "#/$defs/Uuid"
-    },
-
-    "ProcessFlowRef": {
-      "description": "ProcessFlow entity への単独参照。",
-      "$ref": "#/$defs/Uuid"
-    },
-
-    "ViewRef": {
-      "description": "View entity への単独参照。",
-      "$ref": "#/$defs/Uuid"
-    },
-
-    "SequenceRef": {
-      "description": "Sequence entity への単独参照。",
-      "$ref": "#/$defs/Uuid"
-    },
-
     "ScreenItemRef": {
       "description": "Screen 内の画面項目への複合参照 (Pattern B)。screenId + itemId。",
       "type": "object",
@@ -433,17 +410,6 @@
       "properties": {
         "viewId": { "$ref": "#/$defs/Uuid" },
         "columnPhysicalName": { "$ref": "#/$defs/PhysicalName" }
-      }
-    },
-
-    "SequenceColumnRef": {
-      "description": "Sequence の利用先 Table カラムへの複合参照。",
-      "type": "object",
-      "required": ["tableId", "columnId"],
-      "additionalProperties": false,
-      "properties": {
-        "tableId": { "$ref": "#/$defs/Uuid" },
-        "columnId": { "$ref": "#/$defs/LocalId" }
       }
     },
 
@@ -566,7 +532,7 @@
           "additionalProperties": false,
           "properties": {
             "kind": { "const": "externalStub" },
-            "externalRef": { "type": "string", "description": "ProcessFlow.context.catalogs.externalSystems のキー。" },
+            "externalRef": { "$ref": "#/$defs/Identifier", "description": "ProcessFlow.context.catalogs.externalSystems のキー (Identifier / camelCase、ExternalSystemStep.systemRef と整合)。" },
             "responseMock": { "description": "外部 API のモックレスポンス (任意の値)。" }
           }
         },
@@ -593,12 +559,12 @@
     },
 
     "TestInvocation": {
-      "description": "テスト起動点。ProcessFlow.actions[].id 参照。",
+      "description": "テスト起動点。ProcessFlow.actions[].id 参照。Screen / Table の authoring から呼ぶ場合は processFlowId 必須 (どの ProcessFlow を起動するかが文脈に依存しないため)。同 ProcessFlow 内の authoring から呼ぶ場合は省略可。",
       "type": "object",
       "required": ["actionId", "input"],
       "additionalProperties": false,
       "properties": {
-        "processFlowId": { "$ref": "#/$defs/Uuid", "description": "省略時は同 ProcessFlow 内の actionId として解決。" },
+        "processFlowId": { "$ref": "#/$defs/Uuid", "description": "起動対象 ProcessFlow の Uuid。省略時は同 ProcessFlow 内の actionId として解決 (ProcessFlow.authoring.testScenarios 経由の場合)。" },
         "actionId": { "$ref": "#/$defs/LocalId" },
         "input": { "type": "object", "additionalProperties": true }
       }
@@ -644,7 +610,7 @@
           "additionalProperties": false,
           "properties": {
             "kind": { "const": "externalCall" },
-            "externalRef": { "type": "string" },
+            "externalRef": { "$ref": "#/$defs/Identifier", "description": "ProcessFlow.context.catalogs.externalSystems のキー (Identifier、ExternalSystemStep.systemRef と整合)。" },
             "method": { "type": "string" },
             "bodyMatch": { "type": "object", "additionalProperties": true }
           }

--- a/schemas/v3/common.v3.schema.json
+++ b/schemas/v3/common.v3.schema.json
@@ -2,19 +2,25 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/csilost2001/html-designer/main/schemas/v3/common.v3.schema.json",
   "title": "Common (v3 共通定義)",
-  "description": "全 v3 schema が参照する共通 $defs。業務システムの最小構成要素 (識別子・参照・メタ・型・マーカー・拡張入口) のみを集約する。各領域 schema は本ファイルを $ref で参照する。",
+  "description": "全 v3 schema が参照する共通 $defs。業務システムの最小構成要素 (識別子・参照・メタ・型・マーカー・テスト・拡張入口) を集約する。各領域 schema は本ファイルを $ref で参照する。",
   "$defs": {
 
     "Uuid": {
-      "description": "Top-level entity (Project / Screen / Table / ProcessFlow / View / Sequence / CustomBlock 等) の永続識別子。RFC 4122 UUID v4 を基本とするが a-z 拡張も許容 (擬似 UUID サンプル用)。",
+      "description": "Top-level entity (Project / Screen / Table / ProcessFlow / View / Sequence / CustomBlock 等) の永続識別子。RFC 4122 UUID v4 形式。",
+      "type": "string",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+    },
+
+    "UuidLoose": {
+      "description": "テスト・サンプル用途の擬似 UUID。RFC 4122 v4 に加え a-z を許容 (例: 'gggggggg-0001-4000-8000-...')。本番データには Uuid を使用すること。",
       "type": "string",
       "pattern": "^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$"
     },
 
     "LocalId": {
-      "description": "ネスト構造 (Step / Action / Branch / Column / Index / Constraint / Trigger / Note / TestScenario / Decision / Response / Marker 等) の識別子。kebab-case + 大文字 + 数字 / 階層を許容。例: step-01, step-13b-a-01, col-u01, idx-u01, act-001, br-03-a, ADR-001, 201-created, happy-path-order-confirm",
+      "description": "ネスト構造 (Step / Action / Branch / Column / Index / Constraint / Trigger / Note / TestScenario / Decision / Response / Marker 等) の識別子。kebab-case + 英大文字 + 数字 / 階層を許容。1 文字目から記号は不可、末尾も英数字のみ。例: step-01, step-13b-a-01, col-u01, idx-u01, act-001, br-03-a, ADR-001, 201-created, happy-path-order-confirm",
       "type": "string",
-      "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$",
+      "pattern": "^[A-Za-z0-9](?:[A-Za-z0-9_-]*[A-Za-z0-9])?$",
       "minLength": 1
     },
 
@@ -27,7 +33,7 @@
     },
 
     "PhysicalName": {
-      "description": "システム物理名 (DB テーブル名 / カラム名 / 環境変数 / 拡張 namespace 等)。snake_case 強制。例: login_id, password_hash, order_items, STRIPE_API_KEY (環境変数のみ大文字許容は別途 EnvVarKey で扱う)",
+      "description": "システム物理名 (DB テーブル名 / カラム名 / シーケンス名 等)。snake_case 強制。例: login_id, password_hash, order_items, seq_order_number",
       "type": "string",
       "pattern": "^[a-z][a-z0-9_]*$",
       "minLength": 1,
@@ -67,13 +73,19 @@
       "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
     },
 
+    "SemVerRange": {
+      "description": "SemVer 範囲式。npm semver 互換 (>=, ~, ^, x など)。例: '>=3.0.0', '~3.1', '^3.0.0', '3.x'",
+      "type": "string",
+      "minLength": 1
+    },
+
     "Description": {
       "description": "自由記述の説明文。Markdown 改行可。AI 実装者・業務開発者が読む人間向け補足情報。",
       "type": "string"
     },
 
     "DisplayName": {
-      "description": "人間向け表示名。多言語前提のため、文字種制限なし。物理名 (PhysicalName) とは別概念。例: '顧客一覧', 'ユーザー登録', '商品マスタ'",
+      "description": "人間向け表示名。多言語前提のため文字種制限なし。物理名 (PhysicalName) とは別概念。例: '顧客一覧', 'ユーザー登録', '商品マスタ'",
       "type": "string",
       "minLength": 1
     },
@@ -96,13 +108,13 @@
     },
 
     "Namespace": {
-      "description": "拡張機構 / 業界別定義の namespace 識別子。空文字はグローバル拡張。例: '', 'retail', 'finance', 'manufacturing'",
+      "description": "拡張機構 / 業界別定義の namespace 識別子。空文字はグローバル拡張 (組み込み拡張、project.json で extensionsApplied を指定しなくても loader が読み込む)。それ以外は業界・業態別 (例: 'retail', 'finance', 'manufacturing')。loader 運用は schemas/v3/README.md を参照。",
       "type": "string",
       "pattern": "^[a-z0-9_-]*$"
     },
 
     "EntityMeta": {
-      "description": "全 top-level entity (Project / Screen / Table / ProcessFlow / View / Sequence / CustomBlock 等) の共通 meta。各 entity root は本定義を allOf でマージし、固有プロパティを追加する。",
+      "description": "全 top-level entity (Project / Screen / Table / ProcessFlow / View / Sequence 等) の共通 meta。各 entity root は本定義を allOf でマージし、固有プロパティを追加する。CustomBlock のような特殊形式 entity は EntityMeta を採用しない (個別 schema で定義)。",
       "type": "object",
       "required": ["id", "name", "createdAt", "updatedAt"],
       "properties": {
@@ -117,7 +129,7 @@
     },
 
     "Authoring": {
-      "description": "設計プロセス用情報 (実行に不要)。各 entity は本定義を任意で持つ。markers (人間↔AI 対話) / decisions (ADR) / glossary (用語集) / testScenarios (テスト) を集約。",
+      "description": "設計プロセス用情報 (実行に不要)。各 entity は本定義を任意で持つ。markers (人間↔AI 対話) / decisions (ADR) / glossary (用語集) / notes / testScenarios を集約。Project / Screen / Table / ScreenItem / ProcessFlow 全領域で利用可。",
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -137,12 +149,17 @@
         "notes": {
           "type": "array",
           "items": { "$ref": "#/$defs/Note" }
+        },
+        "testScenarios": {
+          "type": "array",
+          "description": "Given-When-Then 形式のテストシナリオ。ProcessFlow / Screen / Table 等、対象 entity の文脈で AI 実装者がテストを生成するための入力。",
+          "items": { "$ref": "#/$defs/TestScenario" }
         }
       }
     },
 
     "Marker": {
-      "description": "人間↔AI のメッセージマーカー。指示・質問・TODO・チャット。entity の authoring セクションで使用。anchor で entity 内の位置 (step / field) を指す。",
+      "description": "人間↔AI のメッセージマーカー。指示・質問・TODO・チャット・validator 警告。entity の authoring セクションで使用。anchor で entity 内の位置 (step / field) を指す。",
       "type": "object",
       "required": ["id", "kind", "body", "author", "createdAt"],
       "additionalProperties": false,
@@ -150,8 +167,8 @@
         "id": { "$ref": "#/$defs/Uuid" },
         "kind": {
           "type": "string",
-          "enum": ["chat", "attention", "todo", "question"],
-          "description": "マーカー種別。"
+          "enum": ["chat", "attention", "todo", "question", "validator"],
+          "description": "マーカー種別。chat: 自由対話 / attention: 注意喚起 / todo: 未完了タスク / question: 質問 / validator: ツール由来の警告 (validatorCode/validatorPath 必須)。"
         },
         "body": { "type": "string", "description": "メッセージ本文。" },
         "anchor": {
@@ -168,9 +185,11 @@
         "createdAt": { "$ref": "#/$defs/Timestamp" },
         "resolvedAt": { "$ref": "#/$defs/Timestamp" },
         "resolution": { "type": "string", "description": "解決時の補足メッセージ。" },
-        "code": { "type": "string", "description": "validator 由来の警告コード (UNKNOWN_IDENTIFIER 等)。" },
-        "path": { "type": "string", "description": "validator 由来の JSON path。" }
-      }
+        "validatorCode": { "type": "string", "description": "kind='validator' 時の警告コード (UNKNOWN_IDENTIFIER 等)。" },
+        "validatorPath": { "type": "string", "description": "kind='validator' 時の対象 JSON path。" }
+      },
+      "if": { "properties": { "kind": { "const": "validator" } }, "required": ["kind"] },
+      "then": { "required": ["validatorCode", "validatorPath"] }
     },
 
     "MarkerShape": {
@@ -238,10 +257,10 @@
     },
 
     "FieldType": {
-      "description": "全領域 (StructuredField / ScreenItem / DomainDef / TableColumn 派生型) で共有するフィールド型。プリミティブ + 構造体 + 参照型 + 拡張入口。",
+      "description": "全領域 (StructuredField / ScreenItem / DomainEntry / TableColumn 派生型) で共有するフィールド型。プリミティブ + 構造体 + 参照型 + 拡張入口。",
       "oneOf": [
         {
-          "description": "プリミティブ型。",
+          "description": "プリミティブ型。'json' は任意の構造化データを表す (オブジェクト型を厳密表現したい場合は kind='object' + fields を使う)。",
           "type": "string",
           "enum": ["string", "number", "integer", "boolean", "date", "datetime", "json"]
         },
@@ -406,6 +425,28 @@
       }
     },
 
+    "ViewColumnRef": {
+      "description": "View 内のカラムへの複合参照。viewId + columnPhysicalName (View カラムは LocalId ではなく物理名で識別)。",
+      "type": "object",
+      "required": ["viewId", "columnPhysicalName"],
+      "additionalProperties": false,
+      "properties": {
+        "viewId": { "$ref": "#/$defs/Uuid" },
+        "columnPhysicalName": { "$ref": "#/$defs/PhysicalName" }
+      }
+    },
+
+    "SequenceColumnRef": {
+      "description": "Sequence の利用先 Table カラムへの複合参照。",
+      "type": "object",
+      "required": ["tableId", "columnId"],
+      "additionalProperties": false,
+      "properties": {
+        "tableId": { "$ref": "#/$defs/Uuid" },
+        "columnId": { "$ref": "#/$defs/LocalId" }
+      }
+    },
+
     "ActionRef": {
       "description": "ProcessFlow 内のアクションへの複合参照。",
       "type": "object",
@@ -441,16 +482,30 @@
       }
     },
 
-    "ExtensionRoot": {
-      "description": "拡張定義 root の共通プロパティ (extensions.v3.schema.json で allOf マージ)。namespace 単位 1 ファイルで全種類の拡張を集約する運用。",
+    "ExtensionApplied": {
+      "description": "プロジェクトが適用する拡張 namespace の宣言。namespace 名 + version 制約 (任意)。",
       "type": "object",
       "required": ["namespace"],
+      "additionalProperties": false,
+      "properties": {
+        "namespace": { "$ref": "#/$defs/Namespace" },
+        "version": {
+          "$ref": "#/$defs/SemVerRange",
+          "description": "拡張定義のバージョン制約 (例: '>=2.0.0')。loader が拡張定義の version と突合する。"
+        }
+      }
+    },
+
+    "ExtensionRoot": {
+      "description": "拡張定義 root の共通プロパティ (extensions.v3.schema.json で allOf マージ)。namespace 単位 1 ファイルで全種類の拡張を集約する運用 (data/extensions/<ns>.v3.json)。loader は data/extensions/<ns>/*.v3.json の分割運用も許容する (詳細: schemas/v3/README.md)。",
+      "type": "object",
+      "required": ["namespace", "version"],
       "properties": {
         "$schema": { "type": "string" },
         "namespace": { "$ref": "#/$defs/Namespace" },
-        "version": { "$ref": "#/$defs/SemVer" },
+        "version": { "$ref": "#/$defs/SemVer", "description": "拡張定義のバージョン (SemVer)。互換性追跡のため必須。" },
         "requiresCoreSchema": {
-          "type": "string",
+          "$ref": "#/$defs/SemVerRange",
           "description": "互換 core schema のバージョン範囲式。例: '>=3.0.0', '~3.1'"
         },
         "deprecated": {
@@ -459,6 +514,171 @@
         },
         "description": { "$ref": "#/$defs/Description" }
       }
+    },
+
+    "TestScenario": {
+      "description": "Given-When-Then 形式のテストシナリオ 1 件。ProcessFlow / Screen / Table 等の authoring セクションで使用。AI 実装者がテストコード生成の入力として読む。",
+      "type": "object",
+      "required": ["id", "name", "given", "when", "then"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "#/$defs/LocalId" },
+        "name": { "$ref": "#/$defs/DisplayName" },
+        "description": { "$ref": "#/$defs/Description" },
+        "given": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/TestPrecondition" }
+        },
+        "when": { "$ref": "#/$defs/TestInvocation" },
+        "then": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/TestAssertion" }
+        },
+        "tags": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+
+    "TestPrecondition": {
+      "description": "テスト前提条件。kind による discriminated union。",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["kind", "tableId", "rows"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "dbState" },
+            "tableId": { "$ref": "#/$defs/Uuid" },
+            "rows": { "type": "array", "items": { "type": "object", "additionalProperties": true } }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "context"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "sessionContext" },
+            "context": { "type": "object", "additionalProperties": true, "description": "ログインユーザー / 権限 / リクエスト ID 等の実行コンテキスト。" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "externalRef", "responseMock"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "externalStub" },
+            "externalRef": { "type": "string", "description": "ProcessFlow.context.catalogs.externalSystems のキー。" },
+            "responseMock": { "description": "外部 API のモックレスポンス (任意の値)。" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "now"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "clock" },
+            "now": { "$ref": "#/$defs/Timestamp" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "screenId", "items"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "screenInput" },
+            "screenId": { "$ref": "#/$defs/Uuid" },
+            "items": { "type": "object", "additionalProperties": true, "description": "画面項目 ID → 入力値のマップ。" }
+          }
+        }
+      ]
+    },
+
+    "TestInvocation": {
+      "description": "テスト起動点。ProcessFlow.actions[].id 参照。",
+      "type": "object",
+      "required": ["actionId", "input"],
+      "additionalProperties": false,
+      "properties": {
+        "processFlowId": { "$ref": "#/$defs/Uuid", "description": "省略時は同 ProcessFlow 内の actionId として解決。" },
+        "actionId": { "$ref": "#/$defs/LocalId" },
+        "input": { "type": "object", "additionalProperties": true }
+      }
+    },
+
+    "TestAssertion": {
+      "description": "テスト期待結果。kind による discriminated union。",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["kind", "expected"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "outcome" },
+            "expected": { "$ref": "#/$defs/LocalId", "description": "期待される Response.id。" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "tableId", "match"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "dbRow" },
+            "tableId": { "$ref": "#/$defs/Uuid" },
+            "match": { "type": "object", "additionalProperties": true },
+            "count": { "type": "integer", "minimum": 0 }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "path"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "output" },
+            "path": { "type": "string", "description": "JSON path (例: '$.status')" },
+            "equals": true,
+            "matches": { "type": "string", "format": "regex" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "externalRef"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "externalCall" },
+            "externalRef": { "type": "string" },
+            "method": { "type": "string" },
+            "bodyMatch": { "type": "object", "additionalProperties": true }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "action"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "auditLog" },
+            "action": { "type": "string" },
+            "result": { "type": "string", "enum": ["success", "failure"] }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "msgKey"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "errorMessage" },
+            "msgKey": { "type": "string", "description": "@conv.msg.<key>" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "screenId", "items"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "screenItemValue" },
+            "screenId": { "$ref": "#/$defs/Uuid" },
+            "items": { "type": "object", "additionalProperties": true, "description": "画面項目 ID → 期待表示値のマップ。" }
+          }
+        }
+      ]
     }
   }
 }

--- a/schemas/v3/common.v3.schema.json
+++ b/schemas/v3/common.v3.schema.json
@@ -1,0 +1,464 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/csilost2001/html-designer/main/schemas/v3/common.v3.schema.json",
+  "title": "Common (v3 共通定義)",
+  "description": "全 v3 schema が参照する共通 $defs。業務システムの最小構成要素 (識別子・参照・メタ・型・マーカー・拡張入口) のみを集約する。各領域 schema は本ファイルを $ref で参照する。",
+  "$defs": {
+
+    "Uuid": {
+      "description": "Top-level entity (Project / Screen / Table / ProcessFlow / View / Sequence / CustomBlock 等) の永続識別子。RFC 4122 UUID v4 を基本とするが a-z 拡張も許容 (擬似 UUID サンプル用)。",
+      "type": "string",
+      "pattern": "^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$"
+    },
+
+    "LocalId": {
+      "description": "ネスト構造 (Step / Action / Branch / Column / Index / Constraint / Trigger / Note / TestScenario / Decision / Response / Marker 等) の識別子。kebab-case + 大文字 + 数字 / 階層を許容。例: step-01, step-13b-a-01, col-u01, idx-u01, act-001, br-03-a, ADR-001, 201-created, happy-path-order-confirm",
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$",
+      "minLength": 1
+    },
+
+    "Identifier": {
+      "description": "業務識別子 (画面項目 ID / API key / ProcessFlow 変数名 / FieldType 拡張 kind 等)。lowerCamelCase 強制。AI 実装者が JS 識別子としてそのまま使える形式。例: userName, cartId, postalCode, productCode",
+      "type": "string",
+      "pattern": "^[a-z][a-zA-Z0-9]*$",
+      "minLength": 1,
+      "maxLength": 64
+    },
+
+    "PhysicalName": {
+      "description": "システム物理名 (DB テーブル名 / カラム名 / 環境変数 / 拡張 namespace 等)。snake_case 強制。例: login_id, password_hash, order_items, STRIPE_API_KEY (環境変数のみ大文字許容は別途 EnvVarKey で扱う)",
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_]*$",
+      "minLength": 1,
+      "maxLength": 63
+    },
+
+    "EnvVarKey": {
+      "description": "環境変数キー。OS / 12-factor 慣習に従い UPPER_SNAKE_CASE。例: STRIPE_API_BASE, MAX_RETRY_ATTEMPTS",
+      "type": "string",
+      "pattern": "^[A-Z][A-Z0-9_]*$",
+      "minLength": 1
+    },
+
+    "ErrorCode": {
+      "description": "エラーコード。HTTP / 業界慣習に従い UPPER_SNAKE。例: STOCK_SHORTAGE, INSUFFICIENT_INVENTORY",
+      "type": "string",
+      "pattern": "^[A-Z][A-Z0-9_]*$",
+      "minLength": 1
+    },
+
+    "EventTopic": {
+      "description": "イベント topic。dot.separated.lowercase (メッセージング業界慣習)。例: order.confirmed, invoice.issued",
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)*$",
+      "minLength": 1
+    },
+
+    "Timestamp": {
+      "description": "ISO 8601 / RFC 3339 形式の UTC タイムスタンプ。Z 終端必須。例: 2026-04-27T00:00:00.000Z",
+      "type": "string",
+      "format": "date-time"
+    },
+
+    "SemVer": {
+      "description": "Semantic Versioning 2.0 文字列。例: 1.0.0, 2.3.4-beta.1",
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+    },
+
+    "Description": {
+      "description": "自由記述の説明文。Markdown 改行可。AI 実装者・業務開発者が読む人間向け補足情報。",
+      "type": "string"
+    },
+
+    "DisplayName": {
+      "description": "人間向け表示名。多言語前提のため、文字種制限なし。物理名 (PhysicalName) とは別概念。例: '顧客一覧', 'ユーザー登録', '商品マスタ'",
+      "type": "string",
+      "minLength": 1
+    },
+
+    "Maturity": {
+      "description": "成熟度 3 値。draft = 下書き / provisional = 暫定 (想定残あり) / committed = 確定 (下流 AI に渡してよい)。entity / nested 構造の双方で使用可。",
+      "type": "string",
+      "enum": ["draft", "provisional", "committed"]
+    },
+
+    "Mode": {
+      "description": "ProcessFlow / Project の上流・下流モード。upstream = 人間が仕様を書く工程 / downstream = AI が読んで実装する工程。",
+      "type": "string",
+      "enum": ["upstream", "downstream"]
+    },
+
+    "ExpressionString": {
+      "description": "式言語 (js-subset) の文字列表現。文法は docs/spec/process-flow-expression-language.md を参照。@conv.* / @secret.* / @env.* / @fn.* / @<var> および Arazzo の $ 記法 (Criterion 内のみ) を許容。",
+      "type": "string"
+    },
+
+    "Namespace": {
+      "description": "拡張機構 / 業界別定義の namespace 識別子。空文字はグローバル拡張。例: '', 'retail', 'finance', 'manufacturing'",
+      "type": "string",
+      "pattern": "^[a-z0-9_-]*$"
+    },
+
+    "EntityMeta": {
+      "description": "全 top-level entity (Project / Screen / Table / ProcessFlow / View / Sequence / CustomBlock 等) の共通 meta。各 entity root は本定義を allOf でマージし、固有プロパティを追加する。",
+      "type": "object",
+      "required": ["id", "name", "createdAt", "updatedAt"],
+      "properties": {
+        "id": { "$ref": "#/$defs/Uuid" },
+        "name": { "$ref": "#/$defs/DisplayName", "description": "entity の表示名。物理名と異なる場合は entity 固有に physicalName を別途持つ。" },
+        "description": { "$ref": "#/$defs/Description" },
+        "version": { "$ref": "#/$defs/SemVer", "description": "entity 単独のリビジョン。" },
+        "maturity": { "$ref": "#/$defs/Maturity" },
+        "createdAt": { "$ref": "#/$defs/Timestamp" },
+        "updatedAt": { "$ref": "#/$defs/Timestamp" }
+      }
+    },
+
+    "Authoring": {
+      "description": "設計プロセス用情報 (実行に不要)。各 entity は本定義を任意で持つ。markers (人間↔AI 対話) / decisions (ADR) / glossary (用語集) / testScenarios (テスト) を集約。",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "markers": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Marker" }
+        },
+        "decisions": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/DecisionRecord" }
+        },
+        "glossary": {
+          "type": "object",
+          "description": "ドメイン用語集。キー: 用語名 (日本語可)。",
+          "additionalProperties": { "$ref": "#/$defs/GlossaryEntry" }
+        },
+        "notes": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Note" }
+        }
+      }
+    },
+
+    "Marker": {
+      "description": "人間↔AI のメッセージマーカー。指示・質問・TODO・チャット。entity の authoring セクションで使用。anchor で entity 内の位置 (step / field) を指す。",
+      "type": "object",
+      "required": ["id", "kind", "body", "author", "createdAt"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "#/$defs/Uuid" },
+        "kind": {
+          "type": "string",
+          "enum": ["chat", "attention", "todo", "question"],
+          "description": "マーカー種別。"
+        },
+        "body": { "type": "string", "description": "メッセージ本文。" },
+        "anchor": {
+          "type": "object",
+          "description": "マーカーが指す entity 内の位置。stepId / fieldPath / shape (DOM 描画用) を任意。",
+          "additionalProperties": false,
+          "properties": {
+            "stepId": { "$ref": "#/$defs/LocalId" },
+            "fieldPath": { "type": "string", "description": "JSON path 風 (例: '$.actions[0].steps[2].sql')" },
+            "shape": { "$ref": "#/$defs/MarkerShape" }
+          }
+        },
+        "author": { "type": "string", "enum": ["human", "ai"] },
+        "createdAt": { "$ref": "#/$defs/Timestamp" },
+        "resolvedAt": { "$ref": "#/$defs/Timestamp" },
+        "resolution": { "type": "string", "description": "解決時の補足メッセージ。" },
+        "code": { "type": "string", "description": "validator 由来の警告コード (UNKNOWN_IDENTIFIER 等)。" },
+        "path": { "type": "string", "description": "validator 由来の JSON path。" }
+      }
+    },
+
+    "MarkerShape": {
+      "description": "自由描画マーカーの形状。SVG path. anchor 指定時は entity の DOM bbox 相対 % 座標。",
+      "type": "object",
+      "required": ["kind", "d"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "type": "string", "enum": ["path"] },
+        "d": { "type": "string", "description": "SVG path d 属性 (0-100 % 座標)" },
+        "color": { "type": "string", "description": "描画色 (#ef4444 既定)" },
+        "strokeWidth": { "type": "number", "minimum": 0.1 }
+      }
+    },
+
+    "DecisionRecord": {
+      "description": "MADR 形式のアーキテクチャ決定記録。Project root / 各 entity authoring で使用可能。",
+      "type": "object",
+      "required": ["id", "title", "status", "context", "decision"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "#/$defs/LocalId", "description": "ADR-NNN 形式推奨。" },
+        "title": { "$ref": "#/$defs/DisplayName" },
+        "status": {
+          "type": "string",
+          "enum": ["proposed", "accepted", "deprecated", "superseded"]
+        },
+        "context": { "type": "string", "description": "決定の背景・問題の説明。" },
+        "decision": { "type": "string", "description": "採択した決定内容。" },
+        "consequences": { "type": "string", "description": "結果・影響・トレードオフ。" },
+        "date": { "type": "string", "description": "ISO date (YYYY-MM-DD)。" }
+      }
+    },
+
+    "GlossaryEntry": {
+      "description": "ドメイン用語集の 1 エントリ。キーは用語名 (日本語可)。",
+      "type": "object",
+      "required": ["definition"],
+      "additionalProperties": false,
+      "properties": {
+        "definition": { "type": "string", "description": "用語の定義。" },
+        "aliases": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "別名・略語のリスト。"
+        },
+        "domainRef": { "type": "string", "description": "ドメインモデルやテーブル等への参照文字列 (例: 'orders.order_number')。" }
+      }
+    },
+
+    "Note": {
+      "description": "Step / Action / Field レベルの付箋。意図・前提・TODO・将来検討・質問を構造化。",
+      "type": "object",
+      "required": ["id", "kind", "body", "createdAt"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "#/$defs/LocalId" },
+        "kind": {
+          "type": "string",
+          "enum": ["assumption", "prerequisite", "todo", "deferred", "question"]
+        },
+        "body": { "type": "string" },
+        "createdAt": { "$ref": "#/$defs/Timestamp" }
+      }
+    },
+
+    "FieldType": {
+      "description": "全領域 (StructuredField / ScreenItem / DomainDef / TableColumn 派生型) で共有するフィールド型。プリミティブ + 構造体 + 参照型 + 拡張入口。",
+      "oneOf": [
+        {
+          "description": "プリミティブ型。",
+          "type": "string",
+          "enum": ["string", "number", "integer", "boolean", "date", "datetime", "json"]
+        },
+        {
+          "description": "配列型。要素型を再帰的に表現。",
+          "type": "object",
+          "required": ["kind", "itemType"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "array" },
+            "itemType": { "$ref": "#/$defs/FieldType" }
+          }
+        },
+        {
+          "description": "オブジェクト型。fields[] で構造を表現。",
+          "type": "object",
+          "required": ["kind", "fields"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "object" },
+            "fields": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/StructuredField" }
+            }
+          }
+        },
+        {
+          "description": "テーブル 1 行型。",
+          "type": "object",
+          "required": ["kind", "tableId"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "tableRow" },
+            "tableId": { "$ref": "#/$defs/Uuid" }
+          }
+        },
+        {
+          "description": "テーブル配列型。",
+          "type": "object",
+          "required": ["kind", "tableId"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "tableList" },
+            "tableId": { "$ref": "#/$defs/Uuid" }
+          }
+        },
+        {
+          "description": "画面入力セット型。",
+          "type": "object",
+          "required": ["kind", "screenId"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "screenInput" },
+            "screenId": { "$ref": "#/$defs/Uuid" }
+          }
+        },
+        {
+          "description": "ドメイン参照型。domainsCatalog から型・制約・UI ヒントを継承する。",
+          "type": "object",
+          "required": ["kind", "domainKey"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "domain" },
+            "domainKey": { "type": "string", "description": "ProcessFlow.context.catalogs.domains のキー (PascalCase)。例: 'EmailAddress', 'Quantity'" }
+          }
+        },
+        {
+          "description": "ファイル型 (バッチ I/O 等)。format で CSV/ZIP 等を表現。",
+          "type": "object",
+          "required": ["kind"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "file" },
+            "format": { "type": "string", "description": "ファイル形式 (csv / tsv / zip / pdf 等)。" }
+          }
+        },
+        {
+          "description": "拡張型。業界別 namespace の fieldType 拡張を参照。",
+          "type": "object",
+          "required": ["kind", "extensionRef"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "extension" },
+            "extensionRef": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9_-]*:[a-z][a-zA-Z0-9]*$",
+              "description": "namespace:fieldTypeKey 形式。例: 'retail:productCode', 'finance:accountNumber'"
+            }
+          }
+        }
+      ]
+    },
+
+    "StructuredField": {
+      "description": "構造化フィールド定義。ProcessFlow.inputs/outputs / FieldType.object.fields 等で使用。識別子・型・必須・制約・参照を 1 単位で表現。",
+      "type": "object",
+      "required": ["name", "type"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "$ref": "#/$defs/Identifier", "description": "フィールド識別子 (camelCase)。" },
+        "label": { "$ref": "#/$defs/DisplayName" },
+        "type": { "$ref": "#/$defs/FieldType" },
+        "required": { "type": "boolean" },
+        "description": { "$ref": "#/$defs/Description" },
+        "format": {
+          "type": "string",
+          "description": "採番形式 / 正規表現 / 自由ヒント。@conv.numbering.* 参照可。"
+        },
+        "defaultValue": { "type": "string", "description": "既定値 (式可)。" },
+        "screenItemRef": { "$ref": "#/$defs/ScreenItemRef" },
+        "formula": {
+          "$ref": "#/$defs/ExpressionString",
+          "description": "派生属性の計算式。'= ' で始まる (例: '= @quantity * @unitPrice')。"
+        }
+      }
+    },
+
+    "ScreenRef": {
+      "description": "Screen entity への単独参照 (Pattern A: UUID 単独)。",
+      "$ref": "#/$defs/Uuid"
+    },
+
+    "TableRef": {
+      "description": "Table entity への単独参照。",
+      "$ref": "#/$defs/Uuid"
+    },
+
+    "ProcessFlowRef": {
+      "description": "ProcessFlow entity への単独参照。",
+      "$ref": "#/$defs/Uuid"
+    },
+
+    "ViewRef": {
+      "description": "View entity への単独参照。",
+      "$ref": "#/$defs/Uuid"
+    },
+
+    "SequenceRef": {
+      "description": "Sequence entity への単独参照。",
+      "$ref": "#/$defs/Uuid"
+    },
+
+    "ScreenItemRef": {
+      "description": "Screen 内の画面項目への複合参照 (Pattern B)。screenId + itemId。",
+      "type": "object",
+      "required": ["screenId", "itemId"],
+      "additionalProperties": false,
+      "properties": {
+        "screenId": { "$ref": "#/$defs/Uuid" },
+        "itemId": { "$ref": "#/$defs/Identifier" }
+      }
+    },
+
+    "TableColumnRef": {
+      "description": "Table 内のカラムへの複合参照。tableId + columnId (LocalId)。",
+      "type": "object",
+      "required": ["tableId", "columnId"],
+      "additionalProperties": false,
+      "properties": {
+        "tableId": { "$ref": "#/$defs/Uuid" },
+        "columnId": { "$ref": "#/$defs/LocalId" }
+      }
+    },
+
+    "ActionRef": {
+      "description": "ProcessFlow 内のアクションへの複合参照。",
+      "type": "object",
+      "required": ["processFlowId", "actionId"],
+      "additionalProperties": false,
+      "properties": {
+        "processFlowId": { "$ref": "#/$defs/Uuid" },
+        "actionId": { "$ref": "#/$defs/LocalId" }
+      }
+    },
+
+    "StepRef": {
+      "description": "ProcessFlow 内のステップへの複合参照。",
+      "type": "object",
+      "required": ["processFlowId", "actionId", "stepId"],
+      "additionalProperties": false,
+      "properties": {
+        "processFlowId": { "$ref": "#/$defs/Uuid" },
+        "actionId": { "$ref": "#/$defs/LocalId" },
+        "stepId": { "$ref": "#/$defs/LocalId" }
+      }
+    },
+
+    "ResponseRef": {
+      "description": "Action.responses[] への複合参照。",
+      "type": "object",
+      "required": ["processFlowId", "actionId", "responseId"],
+      "additionalProperties": false,
+      "properties": {
+        "processFlowId": { "$ref": "#/$defs/Uuid" },
+        "actionId": { "$ref": "#/$defs/LocalId" },
+        "responseId": { "$ref": "#/$defs/LocalId" }
+      }
+    },
+
+    "ExtensionRoot": {
+      "description": "拡張定義 root の共通プロパティ (extensions.v3.schema.json で allOf マージ)。namespace 単位 1 ファイルで全種類の拡張を集約する運用。",
+      "type": "object",
+      "required": ["namespace"],
+      "properties": {
+        "$schema": { "type": "string" },
+        "namespace": { "$ref": "#/$defs/Namespace" },
+        "version": { "$ref": "#/$defs/SemVer" },
+        "requiresCoreSchema": {
+          "type": "string",
+          "description": "互換 core schema のバージョン範囲式。例: '>=3.0.0', '~3.1'"
+        },
+        "deprecated": {
+          "type": "boolean",
+          "description": "true で本拡張全体を廃止予定とマーク。"
+        },
+        "description": { "$ref": "#/$defs/Description" }
+      }
+    }
+  }
+}

--- a/schemas/v3/conventions.v3.schema.json
+++ b/schemas/v3/conventions.v3.schema.json
@@ -1,0 +1,298 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/csilost2001/html-designer/main/schemas/v3/conventions.v3.schema.json",
+  "title": "Conventions (v3 横断規約カタログ)",
+  "description": "プロジェクト横断の規約カタログ。@conv.<category>.<key> で参照される。data/conventions/catalog.json に対応。標準 14 カテゴリ + 拡張 (extensions.v3 の conventionCategories で追加) を持つ。",
+  "type": "object",
+  "required": ["version"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+    "version": { "$ref": "common.v3.schema.json#/$defs/SemVer" },
+    "description": { "$ref": "common.v3.schema.json#/$defs/Description" },
+    "updatedAt": { "$ref": "common.v3.schema.json#/$defs/Timestamp" },
+
+    "i18n": { "$ref": "#/$defs/I18nConfig" },
+
+    "msg": {
+      "type": "object",
+      "description": "メッセージテンプレート (@conv.msg.<key>)。",
+      "additionalProperties": { "$ref": "#/$defs/MessageTemplate" }
+    },
+    "regex": {
+      "type": "object",
+      "description": "正規表現 (@conv.regex.<key>)。",
+      "additionalProperties": { "$ref": "#/$defs/RegexEntry" }
+    },
+    "limit": {
+      "type": "object",
+      "description": "境界値 (@conv.limit.<key>)。",
+      "additionalProperties": { "$ref": "#/$defs/LimitEntry" }
+    },
+    "scope": {
+      "type": "object",
+      "description": "業務スコープ (@conv.scope.<key>)。",
+      "additionalProperties": { "$ref": "#/$defs/ScopeEntry" }
+    },
+    "currency": {
+      "type": "object",
+      "description": "通貨 (@conv.currency.<key>)。",
+      "additionalProperties": { "$ref": "#/$defs/CurrencyEntry" }
+    },
+    "tax": {
+      "type": "object",
+      "description": "税率 (@conv.tax.<key>)。",
+      "additionalProperties": { "$ref": "#/$defs/TaxEntry" }
+    },
+    "auth": {
+      "type": "object",
+      "description": "認証 (@conv.auth.<key>)。",
+      "additionalProperties": { "$ref": "#/$defs/AuthEntry" }
+    },
+    "role": {
+      "type": "object",
+      "description": "役割 (@conv.role.<key>)。",
+      "additionalProperties": { "$ref": "#/$defs/RoleEntry" }
+    },
+    "permission": {
+      "type": "object",
+      "description": "権限 (@conv.permission.<key>)。",
+      "additionalProperties": { "$ref": "#/$defs/PermissionEntry" }
+    },
+    "db": {
+      "type": "object",
+      "description": "DB 規約 (@conv.db.<key>)。",
+      "additionalProperties": { "$ref": "#/$defs/DbEntry" }
+    },
+    "numbering": {
+      "type": "object",
+      "description": "採番規約 (@conv.numbering.<key>)。",
+      "additionalProperties": { "$ref": "#/$defs/NumberingEntry" }
+    },
+    "tx": {
+      "type": "object",
+      "description": "TX 方針 (@conv.tx.<key>)。",
+      "additionalProperties": { "$ref": "#/$defs/TxEntry" }
+    },
+    "externalOutcomeDefaults": {
+      "type": "object",
+      "description": "外部連携 outcome 規約 (@conv.externalOutcomeDefaults.<key>)。",
+      "additionalProperties": { "$ref": "#/$defs/ExternalOutcomeEntry" }
+    },
+    "extensionCategories": {
+      "type": "object",
+      "description": "拡張カテゴリ (extensions.v3 の conventionCategories で定義された業界規約)。@conv.<categoryName>.<key> で参照。",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": true
+      }
+    }
+  },
+
+  "$defs": {
+
+    "I18nConfig": {
+      "type": "object",
+      "required": ["supportedLocales", "defaultLocale"],
+      "additionalProperties": false,
+      "properties": {
+        "supportedLocales": {
+          "type": "array",
+          "items": { "type": "string", "description": "BCP 47 locale (例: 'ja-JP', 'en-US')。" }
+        },
+        "defaultLocale": { "type": "string" },
+        "dateFormat": { "type": "object", "additionalProperties": { "type": "string" } },
+        "timeFormat": { "type": "object", "additionalProperties": { "type": "string" } },
+        "currencyDisplay": { "type": "object", "additionalProperties": { "enum": ["symbol", "code", "name"] } },
+        "numberGrouping": { "type": "object", "additionalProperties": { "type": "boolean" } }
+      }
+    },
+
+    "MessageTemplate": {
+      "type": "object",
+      "required": ["template"],
+      "additionalProperties": false,
+      "properties": {
+        "template": { "type": "string", "description": "{placeholder} 記法。" },
+        "params": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "locales": {
+          "type": "object",
+          "additionalProperties": { "type": "string" },
+          "description": "locale 別の文言上書き。"
+        },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      }
+    },
+
+    "RegexEntry": {
+      "type": "object",
+      "required": ["pattern"],
+      "additionalProperties": false,
+      "properties": {
+        "pattern": { "type": "string", "description": "ECMAScript 互換正規表現 (スラッシュ囲みなし)。" },
+        "flags": { "type": "string" },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" },
+        "exampleValid": { "type": "array", "items": { "type": "string" } },
+        "exampleInvalid": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+
+    "LimitEntry": {
+      "type": "object",
+      "required": ["value"],
+      "additionalProperties": false,
+      "properties": {
+        "value": { "type": ["number", "integer"] },
+        "unit": { "type": "string", "description": "単位 (char / integer / yen / ms / days 等)。" },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      }
+    },
+
+    "DefaultableEntry": {
+      "description": "ambient default 機構を持つエントリの共通フィールド (scope / currency / tax / auth / db で使用)。",
+      "type": "object",
+      "properties": {
+        "default": {
+          "type": "boolean",
+          "description": "true でこのエントリが project-wide ambient default。同カテゴリ内で複数 default は未定義動作。"
+        }
+      }
+    },
+
+    "ScopeEntry": {
+      "allOf": [{ "$ref": "#/$defs/DefaultableEntry" }],
+      "type": "object",
+      "required": ["value"],
+      "properties": {
+        "value": { "type": "string" },
+        "default": true,
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      },
+      "unevaluatedProperties": false
+    },
+
+    "CurrencyEntry": {
+      "allOf": [{ "$ref": "#/$defs/DefaultableEntry" }],
+      "type": "object",
+      "required": ["code"],
+      "properties": {
+        "code": { "type": "string", "description": "ISO 4217 通貨コード (例: 'JPY')。" },
+        "subunit": { "type": "integer", "minimum": 0, "description": "小数点以下桁数。" },
+        "roundingMode": { "$ref": "#/$defs/RoundingMode" },
+        "default": true,
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      },
+      "unevaluatedProperties": false
+    },
+
+    "TaxEntry": {
+      "allOf": [{ "$ref": "#/$defs/DefaultableEntry" }],
+      "type": "object",
+      "required": ["kind", "rate"],
+      "properties": {
+        "kind": { "type": "string", "enum": ["inclusive", "exclusive"] },
+        "rate": { "type": "number", "minimum": 0, "maximum": 1 },
+        "roundingMode": { "$ref": "#/$defs/RoundingMode" },
+        "default": true,
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      },
+      "unevaluatedProperties": false
+    },
+
+    "AuthEntry": {
+      "allOf": [{ "$ref": "#/$defs/DefaultableEntry" }],
+      "type": "object",
+      "required": ["scheme"],
+      "properties": {
+        "scheme": { "type": "string", "description": "認証方式 (session-cookie / bearer-jwt / basic 等)。" },
+        "sessionStorage": { "type": "string" },
+        "passwordHash": { "type": "string" },
+        "default": true,
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      },
+      "unevaluatedProperties": false
+    },
+
+    "RoleEntry": {
+      "type": "object",
+      "required": ["permissions"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "$ref": "common.v3.schema.json#/$defs/DisplayName" },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" },
+        "permissions": {
+          "type": "array",
+          "items": { "type": "string", "description": "@conv.permission.<key> で参照されるキー。" }
+        },
+        "inherits": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+
+    "PermissionEntry": {
+      "type": "object",
+      "required": ["resource", "action"],
+      "additionalProperties": false,
+      "properties": {
+        "resource": { "type": "string" },
+        "action": { "type": "string" },
+        "scope": { "type": "string", "enum": ["all", "own", "department"] },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      }
+    },
+
+    "DbEntry": {
+      "allOf": [{ "$ref": "#/$defs/DefaultableEntry" }],
+      "type": "object",
+      "properties": {
+        "engine": { "type": "string", "description": "例: 'postgresql@14'" },
+        "namingConvention": { "type": "string", "description": "例: 'snake_case'" },
+        "timestampColumns": { "type": "array", "items": { "type": "string" } },
+        "logicalDeleteColumn": { "type": "string" },
+        "default": true,
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      },
+      "unevaluatedProperties": false
+    },
+
+    "NumberingEntry": {
+      "type": "object",
+      "required": ["format"],
+      "additionalProperties": false,
+      "properties": {
+        "format": { "type": "string", "description": "採番フォーマット (例: 'C-NNNN', 'ORD-YYYY-NNNN')。" },
+        "implementation": { "type": "string", "description": "実装方式 (例: 'PG sequence + DEFAULT')。" },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      }
+    },
+
+    "TxEntry": {
+      "type": "object",
+      "required": ["policy"],
+      "additionalProperties": false,
+      "properties": {
+        "policy": { "type": "string" },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      }
+    },
+
+    "ExternalOutcomeEntry": {
+      "type": "object",
+      "required": ["outcome", "action"],
+      "additionalProperties": false,
+      "properties": {
+        "outcome": { "type": "string", "enum": ["success", "failure", "timeout"] },
+        "action": { "type": "string", "enum": ["continue", "abort", "compensate"] },
+        "retry": { "type": "string", "enum": ["none", "fixed", "exponential"] },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      }
+    },
+
+    "RoundingMode": {
+      "type": "string",
+      "enum": ["floor", "ceil", "round"]
+    }
+  }
+}

--- a/schemas/v3/conventions.v3.schema.json
+++ b/schemas/v3/conventions.v3.schema.json
@@ -145,9 +145,16 @@
       "required": ["value"],
       "additionalProperties": false,
       "properties": {
-        "value": { "type": "number", "description": "境界値。整数のみが有効な場合は unit='integer' で示す。" },
+        "value": { "type": "number", "description": "境界値。unit='integer' のときは整数値必須 (if/then で強制)。" },
         "unit": { "type": "string", "description": "単位 (char / integer / yen / ms / days 等)。" },
         "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      },
+      "if": {
+        "properties": { "unit": { "const": "integer" } },
+        "required": ["unit"]
+      },
+      "then": {
+        "properties": { "value": { "type": "integer" } }
       }
     },
 

--- a/schemas/v3/conventions.v3.schema.json
+++ b/schemas/v3/conventions.v3.schema.json
@@ -145,7 +145,7 @@
       "required": ["value"],
       "additionalProperties": false,
       "properties": {
-        "value": { "type": ["number", "integer"] },
+        "value": { "type": "number", "description": "境界値。整数のみが有効な場合は unit='integer' で示す。" },
         "unit": { "type": "string", "description": "単位 (char / integer / yen / ms / days 等)。" },
         "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
       }

--- a/schemas/v3/custom-block.v3.schema.json
+++ b/schemas/v3/custom-block.v3.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/csilost2001/html-designer/main/schemas/v3/custom-block.v3.schema.json",
+  "title": "CustomBlock (v3 カスタムブロック集合)",
+  "description": "Designer (画面デザイナー) で再利用するカスタムブロックの集合。data/custom-blocks.json に対応。",
+  "type": "array",
+  "items": { "$ref": "#/$defs/CustomBlock" },
+  "$defs": {
+    "CustomBlock": {
+      "type": "object",
+      "required": ["id", "label", "category", "content", "shared", "createdAt", "updatedAt"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "common.v3.schema.json#/$defs/Uuid", "description": "ブロック識別子 (UUID 強制、v1 の timestamp 形式は廃止)。" },
+        "label": { "$ref": "common.v3.schema.json#/$defs/DisplayName" },
+        "category": { "type": "string", "description": "ブロックパレット上のカテゴリ名 (例: 'マイブロック', 'フォーム')。" },
+        "content": { "type": "string", "description": "GrapesJS が展開する HTML 文字列 (data-shared-block-id 属性付き推奨)。" },
+        "shared": { "type": "boolean", "description": "true で複数画面で共有 (data-shared-block-id で同期)。" },
+        "createdAt": { "$ref": "common.v3.schema.json#/$defs/Timestamp" },
+        "updatedAt": { "$ref": "common.v3.schema.json#/$defs/Timestamp" },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      }
+    }
+  }
+}

--- a/schemas/v3/er-layout.v3.schema.json
+++ b/schemas/v3/er-layout.v3.schema.json
@@ -11,6 +11,7 @@
     "positions": {
       "type": "object",
       "description": "Table の Uuid をキーとし、UI 座標を値とする。",
+      "propertyNames": { "$ref": "common.v3.schema.json#/$defs/Uuid" },
       "additionalProperties": {
         "type": "object",
         "required": ["x", "y"],

--- a/schemas/v3/er-layout.v3.schema.json
+++ b/schemas/v3/er-layout.v3.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/csilost2001/html-designer/main/schemas/v3/er-layout.v3.schema.json",
+  "title": "ErLayout (v3 ER 図 UI 座標)",
+  "description": "ER 図の UI 座標および論理リレーション (FK 未定義の概念リレーション) を集約。Designer (ER 図エディタ) 専用。data/er-layout.json に対応。",
+  "type": "object",
+  "required": ["positions", "updatedAt"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+    "positions": {
+      "type": "object",
+      "description": "Table の Uuid をキーとし、UI 座標を値とする。",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["x", "y"],
+        "additionalProperties": false,
+        "properties": {
+          "x": { "type": "number" },
+          "y": { "type": "number" }
+        }
+      }
+    },
+    "logicalRelations": {
+      "type": "array",
+      "description": "FK 未定義の論理リレーション (概念設計段階)。",
+      "items": { "$ref": "#/$defs/LogicalRelation" }
+    },
+    "updatedAt": { "$ref": "common.v3.schema.json#/$defs/Timestamp" }
+  },
+  "$defs": {
+    "LogicalRelation": {
+      "type": "object",
+      "required": ["id", "sourceTableId", "targetTableId", "cardinality"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
+        "sourceTableId": { "$ref": "common.v3.schema.json#/$defs/Uuid" },
+        "sourceColumnId": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
+        "targetTableId": { "$ref": "common.v3.schema.json#/$defs/Uuid" },
+        "targetColumnId": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
+        "cardinality": {
+          "type": "string",
+          "enum": ["one-to-one", "one-to-many", "many-to-many"],
+          "description": "ER モデリング業界慣習に従い kebab-case。"
+        },
+        "label": { "type": "string", "description": "リレーション説明 (例: '顧客は複数の注文を持つ')。" }
+      }
+    }
+  }
+}

--- a/schemas/v3/extensions.v3.schema.json
+++ b/schemas/v3/extensions.v3.schema.json
@@ -1,0 +1,267 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/csilost2001/html-designer/main/schemas/v3/extensions.v3.schema.json",
+  "title": "Extensions (v3 統合拡張定義)",
+  "description": "業界・業態別 (retail / finance / manufacturing 等) の全種類の拡張を 1 namespace = 1 ファイルで定義する。data/extensions/<namespace>.v3.json に対応。core schema は本拡張を loader で動的にマージして合成 schema を作る。",
+  "allOf": [
+    { "$ref": "common.v3.schema.json#/$defs/ExtensionRoot" },
+    {
+      "type": "object",
+      "properties": {
+        "fieldTypes": {
+          "type": "array",
+          "description": "FieldType の業界拡張。FieldType.kind='extension' で参照される。",
+          "items": { "$ref": "#/$defs/CustomFieldType" }
+        },
+        "dataTypes": {
+          "type": "array",
+          "description": "DataType (DB) の拡張。DataType の namespace:UPPER 形式で参照される。",
+          "items": { "$ref": "#/$defs/CustomDataType" }
+        },
+        "screenKinds": {
+          "type": "array",
+          "description": "ScreenKind の拡張。Screen.kind の namespace:kindName で参照される。",
+          "items": { "$ref": "#/$defs/CustomScreenKind" }
+        },
+        "actionTriggers": {
+          "type": "array",
+          "description": "Action.trigger の拡張。",
+          "items": { "$ref": "#/$defs/CustomActionTrigger" }
+        },
+        "dbOperations": {
+          "type": "array",
+          "description": "DbAccessStep.operation の拡張。",
+          "items": { "$ref": "#/$defs/CustomDbOperation" }
+        },
+        "stepKinds": {
+          "type": "object",
+          "description": "Step.kind の拡張定義。OtherStep の namespace:StepName で参照される。キー = StepName (PascalCase)。",
+          "additionalProperties": { "$ref": "#/$defs/CustomStepKind" }
+        },
+        "responseTypes": {
+          "type": "object",
+          "description": "Response 型の拡張。HttpResponseSpec.bodySchema={typeRef} で参照。キー = TypeName。",
+          "additionalProperties": { "$ref": "#/$defs/CustomResponseType" }
+        },
+        "valueSourceKinds": {
+          "type": "array",
+          "description": "ScreenItem.valueFrom.kind の拡張。",
+          "items": { "$ref": "#/$defs/CustomValueSourceKind" }
+        },
+        "columnTemplates": {
+          "type": "array",
+          "description": "Table.columns 用カラム雛形 (一括追加用)。",
+          "items": { "$ref": "#/$defs/CustomColumnTemplate" }
+        },
+        "constraintPatterns": {
+          "type": "array",
+          "description": "Table.constraints の典型パターン雛形。",
+          "items": { "$ref": "#/$defs/CustomConstraintPattern" }
+        },
+        "conventionCategories": {
+          "type": "array",
+          "description": "Conventions の業界拡張カテゴリ。@conv.<categoryName>.<key> で参照される。",
+          "items": { "$ref": "#/$defs/CustomConventionCategory" }
+        }
+      }
+    }
+  ],
+  "unevaluatedProperties": false,
+
+  "$defs": {
+
+    "CustomFieldType": {
+      "type": "object",
+      "required": ["kind", "label"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "$ref": "common.v3.schema.json#/$defs/Identifier", "description": "拡張 fieldType の識別子 (camelCase)。FieldType.kind='extension' + extensionRef='<ns>:<kind>' で参照。" },
+        "label": { "$ref": "common.v3.schema.json#/$defs/DisplayName" },
+        "baseType": {
+          "type": "string",
+          "enum": ["string", "number", "integer", "boolean", "date", "datetime", "json"],
+          "description": "底になるプリミティブ型 (実装の型 mapping ヒント)。"
+        },
+        "constraints": {
+          "type": "array",
+          "description": "拡張 fieldType に紐付く既定制約 (validation 等)。",
+          "items": { "type": "object", "additionalProperties": true }
+        },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      }
+    },
+
+    "CustomDataType": {
+      "type": "object",
+      "required": ["physicalKind", "label"],
+      "additionalProperties": false,
+      "properties": {
+        "physicalKind": {
+          "type": "string",
+          "pattern": "^[A-Z][A-Z0-9_]*$",
+          "description": "拡張 DataType (UPPER_SNAKE)。例: 'VARCHAR2', 'JSONB'。"
+        },
+        "label": { "$ref": "common.v3.schema.json#/$defs/DisplayName" },
+        "lengthRequired": { "type": "boolean" },
+        "scaleSupported": { "type": "boolean" },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      }
+    },
+
+    "CustomScreenKind": {
+      "type": "object",
+      "required": ["kind", "label"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "$ref": "common.v3.schema.json#/$defs/Identifier", "description": "拡張画面種別 (camelCase)。Screen.kind='<ns>:<kind>' で参照。" },
+        "label": { "$ref": "common.v3.schema.json#/$defs/DisplayName" },
+        "icon": { "type": "string", "description": "Bootstrap Icons クラス名 (例: 'bi-shop')。" },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      }
+    },
+
+    "CustomActionTrigger": {
+      "type": "object",
+      "required": ["value", "label"],
+      "additionalProperties": false,
+      "properties": {
+        "value": { "$ref": "common.v3.schema.json#/$defs/Identifier" },
+        "label": { "$ref": "common.v3.schema.json#/$defs/DisplayName" },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      }
+    },
+
+    "CustomDbOperation": {
+      "type": "object",
+      "required": ["value", "label"],
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "type": "string",
+          "pattern": "^[A-Z][A-Z0-9_]*$",
+          "description": "DbOperation 拡張 (UPPER_SNAKE)。例: 'UPSERT', 'TRUNCATE'。"
+        },
+        "label": { "$ref": "common.v3.schema.json#/$defs/DisplayName" },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      }
+    },
+
+    "CustomStepKind": {
+      "description": "拡張 Step 種別。OtherStep に namespace:StepName で参照される。schema フィールドで動的フォーム生成 (subset JSON Schema)。",
+      "type": "object",
+      "required": ["label", "icon", "description", "schema"],
+      "additionalProperties": false,
+      "properties": {
+        "label": { "$ref": "common.v3.schema.json#/$defs/DisplayName" },
+        "icon": { "type": "string", "description": "アイコン (Bootstrap Icons / Lucide 名)。" },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" },
+        "schema": { "$ref": "#/$defs/DynamicFormSchema" },
+        "outputType": { "$ref": "common.v3.schema.json#/$defs/FieldType", "description": "拡張 step の outputBinding 結果型 (型推論用)。" }
+      }
+    },
+
+    "CustomResponseType": {
+      "type": "object",
+      "required": ["schema"],
+      "additionalProperties": false,
+      "properties": {
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" },
+        "schema": {
+          "type": "object",
+          "description": "JSON Schema draft 2020-12 (response body 構造)。",
+          "additionalProperties": true
+        }
+      }
+    },
+
+    "CustomValueSourceKind": {
+      "type": "object",
+      "required": ["kind", "label"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "$ref": "common.v3.schema.json#/$defs/Identifier" },
+        "label": { "$ref": "common.v3.schema.json#/$defs/DisplayName" },
+        "schema": {
+          "type": "object",
+          "description": "ValueSource variant の追加プロパティ schema (動的フォーム生成用)。",
+          "additionalProperties": true
+        },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      }
+    },
+
+    "CustomColumnTemplate": {
+      "type": "object",
+      "required": ["id", "label", "category", "column"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
+        "label": { "$ref": "common.v3.schema.json#/$defs/DisplayName" },
+        "icon": { "type": "string" },
+        "category": { "type": "string" },
+        "column": {
+          "type": "object",
+          "description": "カラム雛形 (table.v3.schema.json#/$defs/Column の id/no を除いたサブセット)。",
+          "additionalProperties": true
+        },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      }
+    },
+
+    "CustomConstraintPattern": {
+      "type": "object",
+      "required": ["id", "label", "kind"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
+        "label": { "$ref": "common.v3.schema.json#/$defs/DisplayName" },
+        "kind": { "type": "string", "enum": ["unique", "check", "foreignKey"] },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" },
+        "template": {
+          "type": "object",
+          "description": "制約雛形の構造 (table.v3#/$defs/Constraint の subset)。",
+          "additionalProperties": true
+        }
+      }
+    },
+
+    "CustomConventionCategory": {
+      "type": "object",
+      "required": ["categoryName", "label", "entrySchema"],
+      "additionalProperties": false,
+      "properties": {
+        "categoryName": { "$ref": "common.v3.schema.json#/$defs/Identifier", "description": "@conv.<categoryName>.<key> の categoryName (camelCase)。" },
+        "label": { "$ref": "common.v3.schema.json#/$defs/DisplayName" },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" },
+        "entrySchema": {
+          "$ref": "#/$defs/DynamicFormSchema",
+          "description": "本カテゴリの 1 entry の動的フォーム schema (JSON Schema subset)。"
+        }
+      }
+    },
+
+    "DynamicFormSchema": {
+      "description": "拡張 schema 定義用の JSON Schema subset。動的フォーム生成 UI が対応する範囲のみ。",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "oneOf": [
+            { "enum": ["string", "number", "integer", "boolean", "object", "array"] },
+            { "type": "array", "items": { "enum": ["string", "number", "integer", "boolean", "object", "array"] } }
+          ]
+        },
+        "enum": { "type": "array" },
+        "properties": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/$defs/DynamicFormSchema" }
+        },
+        "items": { "$ref": "#/$defs/DynamicFormSchema" },
+        "required": { "type": "array", "items": { "type": "string" } },
+        "description": { "type": "string" },
+        "default": true,
+        "additionalProperties": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/schemas/v3/extensions.v3.schema.json
+++ b/schemas/v3/extensions.v3.schema.json
@@ -23,6 +23,11 @@
           "description": "ScreenKind の拡張。Screen.kind の namespace:kindName で参照される。",
           "items": { "$ref": "#/$defs/CustomScreenKind" }
         },
+        "processFlowKinds": {
+          "type": "array",
+          "description": "ProcessFlowKind の拡張。ProcessFlow.meta.kind の namespace:kindName で参照される。",
+          "items": { "$ref": "#/$defs/CustomProcessFlowKind" }
+        },
         "actionTriggers": {
           "type": "array",
           "description": "Action.trigger の拡張。",
@@ -35,12 +40,14 @@
         },
         "stepKinds": {
           "type": "object",
-          "description": "Step.kind の拡張定義。OtherStep の namespace:StepName で参照される。キー = StepName (PascalCase)。",
+          "description": "Step.kind の拡張定義。process-flow.v3 ExtensionStep の namespace:StepName で参照される。キー = StepName (PascalCase)。",
+          "propertyNames": { "type": "string", "pattern": "^[A-Z][A-Za-z0-9]*$" },
           "additionalProperties": { "$ref": "#/$defs/CustomStepKind" }
         },
         "responseTypes": {
           "type": "object",
-          "description": "Response 型の拡張。HttpResponseSpec.bodySchema={typeRef} で参照。キー = TypeName。",
+          "description": "Response 型の拡張。HttpResponseSpec.bodySchema={typeRef} で参照。キー = TypeName (PascalCase)。",
+          "propertyNames": { "type": "string", "pattern": "^[A-Z][A-Za-z0-9]*$" },
           "additionalProperties": { "$ref": "#/$defs/CustomResponseType" }
         },
         "valueSourceKinds": {
@@ -147,7 +154,7 @@
     },
 
     "CustomStepKind": {
-      "description": "拡張 Step 種別。OtherStep に namespace:StepName で参照される。schema フィールドで動的フォーム生成 (subset JSON Schema)。",
+      "description": "拡張 Step 種別。process-flow.v3 ExtensionStep に namespace:StepName で参照される。schema フィールドで動的フォーム生成 (subset JSON Schema)、ExtensionStep.config の構造を縛る。",
       "type": "object",
       "required": ["label", "icon", "description", "schema"],
       "additionalProperties": false,
@@ -155,8 +162,21 @@
         "label": { "$ref": "common.v3.schema.json#/$defs/DisplayName" },
         "icon": { "type": "string", "description": "アイコン (Bootstrap Icons / Lucide 名)。" },
         "description": { "$ref": "common.v3.schema.json#/$defs/Description" },
-        "schema": { "$ref": "#/$defs/DynamicFormSchema" },
+        "schema": { "$ref": "#/$defs/DynamicFormSchema", "description": "ExtensionStep.config の構造を縛る subset schema。" },
         "outputType": { "$ref": "common.v3.schema.json#/$defs/FieldType", "description": "拡張 step の outputBinding 結果型 (型推論用)。" }
+      }
+    },
+
+    "CustomProcessFlowKind": {
+      "description": "拡張 ProcessFlowKind。ProcessFlow.meta.kind の namespace:kindName で参照される。",
+      "type": "object",
+      "required": ["kind", "label"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "$ref": "common.v3.schema.json#/$defs/Identifier", "description": "拡張 ProcessFlowKind 識別子 (camelCase)。" },
+        "label": { "$ref": "common.v3.schema.json#/$defs/DisplayName" },
+        "icon": { "type": "string" },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
       }
     },
 
@@ -175,17 +195,14 @@
     },
 
     "CustomValueSourceKind": {
+      "description": "拡張 ValueSource。ScreenItem.valueFrom の namespace:kindName で参照される。schema は ValueSource.config の構造を縛る。",
       "type": "object",
-      "required": ["kind", "label"],
+      "required": ["kind", "label", "schema"],
       "additionalProperties": false,
       "properties": {
         "kind": { "$ref": "common.v3.schema.json#/$defs/Identifier" },
         "label": { "$ref": "common.v3.schema.json#/$defs/DisplayName" },
-        "schema": {
-          "type": "object",
-          "description": "ValueSource variant の追加プロパティ schema (動的フォーム生成用)。",
-          "additionalProperties": true
-        },
+        "schema": { "$ref": "#/$defs/DynamicFormSchema", "description": "ValueSource.config の構造を縛る subset schema。" },
         "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
       }
     },

--- a/schemas/v3/process-flow.v3.schema.json
+++ b/schemas/v3/process-flow.v3.schema.json
@@ -1,0 +1,1439 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/csilost2001/html-designer/main/schemas/v3/process-flow.v3.schema.json",
+  "title": "ProcessFlow (v3 処理フロー定義)",
+  "description": "業務処理フロー entity 1 件分の正規定義。data/process-flows/<id>.json に対応。root を 4 セクション (meta / context / body / authoring) に再編し、catalog 群を context.catalogs.<kind> に階層化することで意味付けと拡張性を確保する。",
+  "type": "object",
+  "required": ["meta", "body"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+
+    "meta": { "$ref": "#/$defs/Meta" },
+    "context": { "$ref": "#/$defs/Context" },
+    "body": { "$ref": "#/$defs/Body" },
+    "authoring": {
+      "allOf": [{ "$ref": "common.v3.schema.json#/$defs/Authoring" }],
+      "type": "object",
+      "properties": {
+        "markers": true, "decisions": true, "glossary": true, "notes": true,
+        "testScenarios": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/TestScenario" }
+        }
+      },
+      "unevaluatedProperties": false
+    }
+  },
+
+  "$defs": {
+
+    "Meta": {
+      "description": "ProcessFlow の identity と運用設定。",
+      "allOf": [{ "$ref": "common.v3.schema.json#/$defs/EntityMeta" }],
+      "type": "object",
+      "required": ["kind"],
+      "properties": {
+        "id": true, "name": true, "description": true, "version": true,
+        "maturity": true, "createdAt": true, "updatedAt": true,
+        "kind": { "$ref": "#/$defs/ProcessFlowKind" },
+        "screenId": { "$ref": "common.v3.schema.json#/$defs/Uuid", "description": "kind='screen' の場合に紐付く Screen の Uuid。" },
+        "apiVersion": { "type": "string", "description": "ProcessFlow が公開する API のバージョン (例: 'v1', '2026-04-25')。" },
+        "mode": { "$ref": "common.v3.schema.json#/$defs/Mode" },
+        "sla": { "$ref": "#/$defs/Sla" }
+      },
+      "unevaluatedProperties": false
+    },
+
+    "ProcessFlowKind": {
+      "description": "ProcessFlow の種別。プリミティブ + 拡張参照。",
+      "oneOf": [
+        { "type": "string", "enum": ["screen", "batch", "scheduled", "system", "common", "other"] },
+        { "type": "string", "pattern": "^[a-z][a-z0-9_-]*:[a-z][a-zA-Z0-9]*$", "description": "拡張 ProcessFlowKind 参照 (namespace:kindName)。" }
+      ]
+    },
+
+    "Sla": {
+      "description": "SLA / Timeout 設定。ProcessFlow / Action / Step の 3 レベルで使用可。",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "timeoutMs": { "type": "number", "minimum": 0 },
+        "onTimeout": { "type": "string", "enum": ["throw", "continue", "compensate", "log"] },
+        "errorCode": { "$ref": "common.v3.schema.json#/$defs/ErrorCode" },
+        "warningThresholdMs": { "type": "number", "minimum": 0 },
+        "p95LatencyMs": { "type": "number", "minimum": 0 }
+      },
+      "if": {
+        "properties": { "onTimeout": { "enum": ["throw", "compensate"] } },
+        "required": ["onTimeout"]
+      },
+      "then": { "required": ["errorCode"] }
+    },
+
+    "Context": {
+      "description": "実行に必要な参照情報 (catalog 群 / ambient / 健全性 / リソース)。",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "catalogs": { "$ref": "#/$defs/Catalogs" },
+        "ambientVariables": {
+          "type": "array",
+          "items": { "$ref": "common.v3.schema.json#/$defs/StructuredField" },
+          "description": "ミドルウェア由来の自動注入変数 (@requestId / @traceId / @fieldErrors 等)。"
+        },
+        "ambientOverrides": {
+          "type": "object",
+          "additionalProperties": { "type": "string" },
+          "description": "規約カタログ defaults の本フロー固有 override。キー: カテゴリ名または 'カテゴリ.キー'。"
+        },
+        "health": { "$ref": "#/$defs/HealthCheckGroup" },
+        "readiness": { "$ref": "#/$defs/ReadinessCheckGroup" },
+        "resources": { "$ref": "#/$defs/ResourceRequirements" }
+      }
+    },
+
+    "Catalogs": {
+      "description": "ProcessFlow 内 catalog 群を階層化集約。新 catalog 追加時に root を肥大化させない。",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "errors": {
+          "type": "object",
+          "description": "エラーコード catalog。キー: ErrorCode (UPPER_SNAKE)。affectedRowsCheck.errorCode / Branch.condition.errorCode から参照。",
+          "additionalProperties": { "$ref": "#/$defs/ErrorCatalogEntry" }
+        },
+        "externalSystems": {
+          "type": "object",
+          "description": "外部システム catalog。キー: systemId (lowercase)。ExternalSystemStep.systemRef から参照。",
+          "additionalProperties": { "$ref": "#/$defs/ExternalSystemCatalogEntry" }
+        },
+        "secrets": {
+          "type": "object",
+          "description": "Secrets catalog。キー: secretKey (camelCase)。@secret.<key> で参照。",
+          "additionalProperties": { "$ref": "#/$defs/SecretEntry" }
+        },
+        "envVars": {
+          "type": "object",
+          "description": "環境変数 catalog。キー: EnvVarKey (UPPER_SNAKE)。@env.<KEY> で参照。",
+          "additionalProperties": { "$ref": "#/$defs/EnvVarEntry" }
+        },
+        "domains": {
+          "type": "object",
+          "description": "ドメイン型 catalog。キー: ドメイン名 (PascalCase)。FieldType.kind='domain' から参照。",
+          "additionalProperties": { "$ref": "#/$defs/DomainEntry" }
+        },
+        "functions": {
+          "type": "object",
+          "description": "組み込み関数 catalog。キー: 関数名 (camelCase)。@fn.<name>(...) で参照。",
+          "additionalProperties": { "$ref": "#/$defs/FunctionEntry" }
+        },
+        "events": {
+          "type": "object",
+          "description": "イベント pub/sub catalog。キー: EventTopic (dot.lowercase)。EventPublishStep / EventSubscribeStep の eventRef から参照。",
+          "additionalProperties": { "$ref": "#/$defs/EventEntry" }
+        }
+      }
+    },
+
+    "ErrorCatalogEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "httpStatus": { "type": "integer", "minimum": 100, "maximum": 599 },
+        "defaultMessage": { "type": "string" },
+        "responseId": { "$ref": "common.v3.schema.json#/$defs/LocalId", "description": "Action.responses[].id 参照。" },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      }
+    },
+
+    "ExternalSystemCatalogEntry": {
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "$ref": "common.v3.schema.json#/$defs/DisplayName" },
+        "baseUrl": { "type": "string" },
+        "openApiSpec": { "type": "string", "description": "OpenAPI spec への URL または相対パス。" },
+        "auth": { "$ref": "#/$defs/ExternalAuth" },
+        "timeoutMs": { "type": "integer", "minimum": 0 },
+        "retryPolicy": { "$ref": "#/$defs/RetryPolicy" },
+        "headers": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      }
+    },
+
+    "SecretEntry": {
+      "type": "object",
+      "required": ["source", "name"],
+      "additionalProperties": false,
+      "properties": {
+        "source": { "type": "string", "enum": ["env", "vault", "file"] },
+        "name": { "type": "string", "description": "source ごとの参照名 (env=環境変数名 / vault=path / file=パス)。" },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" },
+        "rotationDays": { "type": "integer", "minimum": 1 },
+        "lastRotatedAt": { "$ref": "common.v3.schema.json#/$defs/Timestamp" },
+        "values": {
+          "type": "object",
+          "additionalProperties": { "type": "string" },
+          "description": "環境別の参照式 (vault://... / env://... / k8s-secret://... / file://...)。実値は含まない。"
+        }
+      }
+    },
+
+    "EnvVarEntry": {
+      "type": "object",
+      "required": ["type"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "type": "string", "enum": ["string", "number", "boolean"] },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" },
+        "values": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "環境別の値 (キー: dev/staging/prod 等)。"
+        },
+        "default": { "description": "values で当該環境キーが未指定時の既定値。" }
+      }
+    },
+
+    "DomainEntry": {
+      "type": "object",
+      "required": ["type"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "$ref": "common.v3.schema.json#/$defs/FieldType" },
+        "constraints": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/ValidationRule" }
+        },
+        "uiHint": { "type": "string", "description": "UI 表示ヒント (例: 'email', 'tel', 'textarea')。" },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      }
+    },
+
+    "FunctionEntry": {
+      "type": "object",
+      "required": ["signature", "returnType", "description"],
+      "additionalProperties": false,
+      "properties": {
+        "signature": { "type": "string", "description": "関数シグネチャ (例: 'formatCurrency(amount: number, currency: string): string')。" },
+        "returnType": { "type": "string" },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" },
+        "examples": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+
+    "EventEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" },
+        "payload": {
+          "type": "object",
+          "description": "ペイロードの JSON Schema (draft 2020-12)。",
+          "additionalProperties": true
+        }
+      }
+    },
+
+    "Body": {
+      "description": "実行ロジック本体。ActionDefinition の配列。",
+      "type": "object",
+      "required": ["actions"],
+      "additionalProperties": false,
+      "properties": {
+        "actions": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/ActionDefinition" }
+        }
+      }
+    },
+
+    "ActionDefinition": {
+      "type": "object",
+      "required": ["id", "name", "trigger", "steps"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "common.v3.schema.json#/$defs/LocalId", "description": "Action ID (例: 'act-001')。" },
+        "name": { "$ref": "common.v3.schema.json#/$defs/DisplayName" },
+        "trigger": { "$ref": "#/$defs/ActionTrigger" },
+        "elementRef": { "type": "string", "description": "GrapesJS の DOM 要素 ID (画面側からの紐付け用)。" },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" },
+        "inputs": {
+          "type": "array",
+          "items": { "$ref": "common.v3.schema.json#/$defs/StructuredField" }
+        },
+        "outputs": {
+          "type": "array",
+          "items": { "$ref": "common.v3.schema.json#/$defs/StructuredField" }
+        },
+        "maturity": { "$ref": "common.v3.schema.json#/$defs/Maturity" },
+        "sla": { "$ref": "#/$defs/Sla" },
+        "requiredPermissions": {
+          "type": "array",
+          "items": { "type": "string", "description": "@conv.permission.<key> または permission キー名。" }
+        },
+        "httpRoute": { "$ref": "#/$defs/HttpRoute" },
+        "responses": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/HttpResponseSpec" }
+        },
+        "steps": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Step" }
+        }
+      }
+    },
+
+    "ActionTrigger": {
+      "oneOf": [
+        { "type": "string", "enum": ["click", "submit", "select", "change", "load", "timer", "auto", "other"] },
+        { "type": "string", "pattern": "^[a-z][a-z0-9_-]*:[a-z][a-zA-Z0-9]*$" }
+      ]
+    },
+
+    "HttpRoute": {
+      "type": "object",
+      "required": ["method", "path"],
+      "additionalProperties": false,
+      "properties": {
+        "method": { "type": "string", "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"] },
+        "path": { "type": "string", "description": "URL パターン。例: '/api/orders', '/api/orders/:id'" },
+        "auth": { "type": "string", "enum": ["required", "optional", "none"] }
+      }
+    },
+
+    "HttpResponseSpec": {
+      "type": "object",
+      "required": ["id", "status"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "common.v3.schema.json#/$defs/LocalId", "description": "Response ID (例: '201-created', '400-validation')。Step.responseId / errorCatalog.responseId から参照。" },
+        "status": { "type": "integer", "minimum": 100, "maximum": 599 },
+        "contentType": { "type": "string" },
+        "bodySchema": { "$ref": "#/$defs/BodySchema" },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" },
+        "when": { "type": "string", "description": "発生条件 (人間向け説明)。" }
+      }
+    },
+
+    "BodySchema": {
+      "description": "Response body の schema。typeRef (拡張 responseTypes 参照) または inline schema の oneOf。",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["typeRef"],
+          "additionalProperties": false,
+          "properties": {
+            "typeRef": { "type": "string", "description": "namespace:typeName または typeName 形式。extensions.v3.responseTypes から解決される。" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["schema"],
+          "additionalProperties": false,
+          "properties": {
+            "schema": { "type": "object", "additionalProperties": true, "description": "インライン JSON Schema。" }
+          }
+        }
+      ]
+    },
+
+    "StepBaseProps": {
+      "description": "全 Step variant 共通のプロパティ集合。各 variant は本定義を allOf でマージし、固有プロパティを追加 + unevaluatedProperties: false で閉じる。",
+      "type": "object",
+      "properties": {
+        "id": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" },
+        "notes": {
+          "type": "array",
+          "items": { "$ref": "common.v3.schema.json#/$defs/Note" }
+        },
+        "maturity": { "$ref": "common.v3.schema.json#/$defs/Maturity" },
+        "sla": { "$ref": "#/$defs/Sla" },
+        "runIf": { "$ref": "common.v3.schema.json#/$defs/ExpressionString", "description": "実行条件式。false なら本 step を skip。" },
+        "requiredPermissions": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "outputBinding": { "$ref": "#/$defs/OutputBinding" },
+        "txBoundary": { "$ref": "#/$defs/TxBoundary" },
+        "transactional": { "type": "boolean", "description": "簡易 TX マーク (txBoundary 不要時の boolean 短縮)。" },
+        "compensatesFor": { "$ref": "common.v3.schema.json#/$defs/LocalId", "description": "Saga 補償対象の Step.id 参照。" },
+        "externalChain": { "$ref": "#/$defs/ExternalChain" }
+      }
+    },
+
+    "OutputBinding": {
+      "description": "Step 結果の outputBinding (構造化のみ、v3 で string 短縮形は廃止)。",
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "$ref": "common.v3.schema.json#/$defs/Identifier", "description": "結果変数名 (camelCase)。" },
+        "operation": {
+          "type": "string",
+          "enum": ["assign", "accumulate", "push"],
+          "description": "代入方式。assign=上書き / accumulate=数値加算 / push=配列追加。既定: assign。"
+        },
+        "initialValue": {
+          "description": "accumulate / push 時の初期値。JSON 値 (例: 0, []) または式文字列。"
+        }
+      }
+    },
+
+    "TxBoundary": {
+      "type": "object",
+      "required": ["role", "txId"],
+      "additionalProperties": false,
+      "properties": {
+        "role": { "type": "string", "enum": ["begin", "member", "end"] },
+        "txId": { "$ref": "common.v3.schema.json#/$defs/LocalId" }
+      }
+    },
+
+    "ExternalChain": {
+      "type": "object",
+      "required": ["chainId", "phase"],
+      "additionalProperties": false,
+      "properties": {
+        "chainId": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
+        "phase": { "type": "string", "enum": ["authorize", "capture", "cancel", "other"] }
+      }
+    },
+
+    "RetryPolicy": {
+      "type": "object",
+      "required": ["maxAttempts"],
+      "additionalProperties": false,
+      "properties": {
+        "maxAttempts": { "type": "integer", "minimum": 1 },
+        "backoff": { "type": "string", "enum": ["fixed", "exponential"] },
+        "initialDelayMs": { "type": "integer", "minimum": 0 }
+      }
+    },
+
+    "ExternalAuth": {
+      "type": "object",
+      "required": ["kind"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "type": "string", "enum": ["bearer", "basic", "apiKey", "oauth2", "none"] },
+        "tokenRef": { "type": "string", "description": "@secret.<key> 推奨 (旧 ENV: / SECRET: 形式は v3 廃止)。" },
+        "headerName": { "type": "string" }
+      }
+    },
+
+    "Step": {
+      "description": "Step union。kind プロパティで variant を識別。22 種の組み込み variant + 拡張 (ExtensionStep)。",
+      "oneOf": [
+        { "$ref": "#/$defs/ValidationStep" },
+        { "$ref": "#/$defs/DbAccessStep" },
+        { "$ref": "#/$defs/ExternalSystemStep" },
+        { "$ref": "#/$defs/CommonProcessStep" },
+        { "$ref": "#/$defs/ScreenTransitionStep" },
+        { "$ref": "#/$defs/DisplayUpdateStep" },
+        { "$ref": "#/$defs/BranchStep" },
+        { "$ref": "#/$defs/LoopStep" },
+        { "$ref": "#/$defs/LoopBreakStep" },
+        { "$ref": "#/$defs/LoopContinueStep" },
+        { "$ref": "#/$defs/JumpStep" },
+        { "$ref": "#/$defs/ComputeStep" },
+        { "$ref": "#/$defs/ReturnStep" },
+        { "$ref": "#/$defs/LogStep" },
+        { "$ref": "#/$defs/AuditStep" },
+        { "$ref": "#/$defs/WorkflowStep" },
+        { "$ref": "#/$defs/TransactionScopeStep" },
+        { "$ref": "#/$defs/EventPublishStep" },
+        { "$ref": "#/$defs/EventSubscribeStep" },
+        { "$ref": "#/$defs/ClosingStep" },
+        { "$ref": "#/$defs/CdcStep" },
+        { "$ref": "#/$defs/ExtensionStep" }
+      ]
+    },
+
+    "NonReturnStep": {
+      "description": "Return を除く Step subset。ExternalCallOutcomeSpec.sideEffects 等で使用。",
+      "oneOf": [
+        { "$ref": "#/$defs/ValidationStep" },
+        { "$ref": "#/$defs/DbAccessStep" },
+        { "$ref": "#/$defs/ExternalSystemStep" },
+        { "$ref": "#/$defs/CommonProcessStep" },
+        { "$ref": "#/$defs/ScreenTransitionStep" },
+        { "$ref": "#/$defs/DisplayUpdateStep" },
+        { "$ref": "#/$defs/BranchStep" },
+        { "$ref": "#/$defs/LoopStep" },
+        { "$ref": "#/$defs/LoopBreakStep" },
+        { "$ref": "#/$defs/LoopContinueStep" },
+        { "$ref": "#/$defs/JumpStep" },
+        { "$ref": "#/$defs/ComputeStep" },
+        { "$ref": "#/$defs/LogStep" },
+        { "$ref": "#/$defs/AuditStep" },
+        { "$ref": "#/$defs/WorkflowStep" },
+        { "$ref": "#/$defs/TransactionScopeStep" },
+        { "$ref": "#/$defs/EventPublishStep" },
+        { "$ref": "#/$defs/EventSubscribeStep" },
+        { "$ref": "#/$defs/ClosingStep" },
+        { "$ref": "#/$defs/CdcStep" },
+        { "$ref": "#/$defs/ExtensionStep" }
+      ]
+    },
+
+    "ValidationStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "kind", "description"],
+          "properties": {
+            "kind": { "const": "validation" },
+            "conditions": { "type": "string", "description": "人間向けバリデーション概要。" },
+            "rules": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/ValidationRule" }
+            },
+            "fieldErrorsVar": { "$ref": "common.v3.schema.json#/$defs/Identifier", "description": "rules[] 結果格納変数名。既定: 'fieldErrors'。" },
+            "inlineBranch": { "$ref": "#/$defs/ValidationInlineBranch" }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+
+    "ValidationRule": {
+      "type": "object",
+      "required": ["field", "type"],
+      "additionalProperties": false,
+      "properties": {
+        "field": { "type": "string", "description": "対象フィールドパス (例: 'email', 'items[*].quantity')。" },
+        "type": { "type": "string", "enum": ["required", "regex", "maxLength", "minLength", "range", "enum", "custom"] },
+        "kind": {
+          "type": "string",
+          "enum": ["error", "msg", "noaccept", "default"],
+          "description": "違反時の振る舞い。"
+        },
+        "pattern": { "type": "string" },
+        "patternRef": { "type": "string", "description": "@conv.regex.<key> 参照。" },
+        "length": { "type": "integer", "minimum": 0 },
+        "min": { "type": "number" },
+        "max": { "type": "number" },
+        "minRef": { "type": "string", "description": "@conv.limit.<key> 参照 (min の代替)。" },
+        "maxRef": { "type": "string", "description": "@conv.limit.<key> 参照 (max の代替)。" },
+        "values": { "type": "array", "items": { "type": "string" } },
+        "condition": { "$ref": "common.v3.schema.json#/$defs/ExpressionString" },
+        "message": { "type": "string", "description": "違反メッセージ (@conv.msg.<key> 推奨)。" }
+      }
+    },
+
+    "ValidationInlineBranch": {
+      "type": "object",
+      "required": ["ok", "ng"],
+      "additionalProperties": false,
+      "properties": {
+        "ok": { "type": "array", "items": { "$ref": "#/$defs/Step" }, "description": "OK 時の後続 step 列。" },
+        "ng": { "type": "array", "items": { "$ref": "#/$defs/Step" }, "description": "NG 時の後続 step 列。" },
+        "ngJumpTo": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
+        "ngResponseId": { "$ref": "common.v3.schema.json#/$defs/LocalId", "description": "NG 時の Response.id 参照。" },
+        "ngBodyExpression": { "$ref": "common.v3.schema.json#/$defs/ExpressionString" },
+        "ngEventPublish": {
+          "type": "object",
+          "required": ["topic", "eventRef", "payload"],
+          "additionalProperties": false,
+          "properties": {
+            "topic": { "$ref": "common.v3.schema.json#/$defs/EventTopic" },
+            "eventRef": { "$ref": "common.v3.schema.json#/$defs/EventTopic" },
+            "payload": { "$ref": "common.v3.schema.json#/$defs/ExpressionString" }
+          }
+        }
+      }
+    },
+
+    "DbAccessStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "kind", "description", "tableId", "operation"],
+          "properties": {
+            "kind": { "const": "dbAccess" },
+            "tableId": { "$ref": "common.v3.schema.json#/$defs/Uuid", "description": "対象 Table の Uuid (物理名直書きは v3 廃止)。" },
+            "operation": { "$ref": "#/$defs/DbOperation" },
+            "fields": { "type": "string", "description": "対象フィールド (人間向け簡易表記)。" },
+            "sql": { "type": "string", "description": "完全 SQL 文 (式補間は @<var> / @conv.* / @env.* 等)。" },
+            "bulkValues": { "$ref": "common.v3.schema.json#/$defs/ExpressionString", "description": "一括 INSERT 時に VALUES に展開する配列変数の式。" },
+            "affectedRowsCheck": { "$ref": "#/$defs/AffectedRowsCheck" },
+            "lineage": { "$ref": "#/$defs/DataLineage" },
+            "cache": { "$ref": "#/$defs/CacheHint" }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+
+    "DbOperation": {
+      "oneOf": [
+        { "type": "string", "enum": ["SELECT", "INSERT", "UPDATE", "DELETE", "MERGE", "LOCK"] },
+        { "type": "string", "pattern": "^[a-z][a-z0-9_-]*:[A-Z][A-Z0-9_]*$", "description": "拡張 DbOperation (namespace:UPPER_SNAKE)。" }
+      ]
+    },
+
+    "AffectedRowsCheck": {
+      "type": "object",
+      "required": ["operator", "expected", "onViolation"],
+      "additionalProperties": false,
+      "properties": {
+        "operator": { "type": "string", "enum": [">", ">=", "=", "<", "<="] },
+        "expected": { "type": "integer", "minimum": 0 },
+        "onViolation": { "type": "string", "enum": ["throw", "abort", "log", "continue"] },
+        "errorCode": { "$ref": "common.v3.schema.json#/$defs/ErrorCode" },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      }
+    },
+
+    "DataLineage": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "reads": {
+          "type": "array",
+          "items": { "$ref": "common.v3.schema.json#/$defs/Uuid" },
+          "description": "読み取り対象 Table.id 一覧。"
+        },
+        "writes": {
+          "type": "array",
+          "items": { "$ref": "common.v3.schema.json#/$defs/Uuid" },
+          "description": "書き込み対象 Table.id 一覧。"
+        }
+      }
+    },
+
+    "CacheHint": {
+      "type": "object",
+      "required": ["ttlSeconds"],
+      "additionalProperties": false,
+      "properties": {
+        "ttlSeconds": { "type": "number", "minimum": 0 },
+        "key": { "$ref": "common.v3.schema.json#/$defs/ExpressionString" },
+        "invalidateOn": {
+          "type": "array",
+          "items": { "$ref": "common.v3.schema.json#/$defs/EventTopic" }
+        },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      }
+    },
+
+    "ExternalSystemStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "kind", "description", "systemRef"],
+          "properties": {
+            "kind": { "const": "externalSystem" },
+            "systemRef": { "type": "string", "description": "ProcessFlow.context.catalogs.externalSystems のキー参照。" },
+            "httpCall": { "$ref": "#/$defs/ExternalHttpCall" },
+            "operationRef": { "type": "string", "description": "OpenAPI operation 参照 (例: '/v1/payment_intents POST')。" },
+            "operationId": { "type": "string" },
+            "requestBodyRef": { "type": "string", "description": "OpenAPI request body schema への JSON Pointer。" },
+            "responseRef": { "type": "string" },
+            "outcomes": { "$ref": "#/$defs/ExternalCallOutcomes" },
+            "timeoutMs": { "type": "integer", "minimum": 0 },
+            "retryPolicy": { "$ref": "#/$defs/RetryPolicy" },
+            "circuitBreaker": { "$ref": "#/$defs/CircuitBreakerConfig" },
+            "bulkhead": { "$ref": "#/$defs/BulkheadConfig" },
+            "fireAndForget": { "type": "boolean" },
+            "auth": { "$ref": "#/$defs/ExternalAuth" },
+            "idempotencyKey": { "$ref": "common.v3.schema.json#/$defs/ExpressionString" },
+            "headers": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            },
+            "apiVersion": { "type": "string" },
+            "cache": { "$ref": "#/$defs/CacheHint" },
+            "successCriteria": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/Criterion" }
+            }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+
+    "ExternalHttpCall": {
+      "type": "object",
+      "required": ["method", "path"],
+      "additionalProperties": false,
+      "properties": {
+        "method": { "type": "string", "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"] },
+        "path": { "type": "string" },
+        "query": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "body": { "$ref": "common.v3.schema.json#/$defs/ExpressionString" }
+      }
+    },
+
+    "ExternalCallOutcomes": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "success": { "$ref": "#/$defs/ExternalCallOutcomeSpec" },
+        "failure": { "$ref": "#/$defs/ExternalCallOutcomeSpec" },
+        "timeout": { "$ref": "#/$defs/ExternalCallOutcomeSpec" }
+      }
+    },
+
+    "ExternalCallOutcomeSpec": {
+      "type": "object",
+      "required": ["action"],
+      "additionalProperties": false,
+      "properties": {
+        "action": { "type": "string", "enum": ["continue", "abort", "compensate"] },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" },
+        "jumpTo": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
+        "sideEffects": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/NonReturnStep" }
+        },
+        "sameAs": { "type": "string", "enum": ["success", "failure", "timeout"] }
+      }
+    },
+
+    "Criterion": {
+      "description": "Arazzo 互換の成功判定条件。",
+      "type": "object",
+      "required": ["type", "expression"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "type": "string", "enum": ["simple", "regex", "jsonpath", "xpath"] },
+        "expression": { "type": "string", "description": "Arazzo Runtime Expression ($ 記法) 推奨。" },
+        "context": { "type": "string" }
+      }
+    },
+
+    "CircuitBreakerConfig": {
+      "type": "object",
+      "required": ["failureThreshold", "timeout"],
+      "additionalProperties": false,
+      "properties": {
+        "failureThreshold": { "type": "number", "minimum": 0 },
+        "timeout": { "type": "number", "minimum": 0 },
+        "halfOpenMaxCalls": { "type": "number", "minimum": 0 }
+      }
+    },
+
+    "BulkheadConfig": {
+      "type": "object",
+      "required": ["maxConcurrent"],
+      "additionalProperties": false,
+      "properties": {
+        "maxConcurrent": { "type": "number", "minimum": 0 },
+        "maxWait": { "type": "number", "minimum": 0 }
+      }
+    },
+
+    "CommonProcessStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "kind", "description", "refId"],
+          "properties": {
+            "kind": { "const": "commonProcess" },
+            "refId": { "$ref": "common.v3.schema.json#/$defs/Uuid", "description": "呼び出し先 ProcessFlow の Uuid (kind='common' の他フロー)。" },
+            "argumentMapping": {
+              "type": "object",
+              "additionalProperties": { "$ref": "common.v3.schema.json#/$defs/ExpressionString" },
+              "description": "呼び先 inputs 名 → 引数式の対応。"
+            },
+            "returnMapping": {
+              "type": "object",
+              "additionalProperties": { "type": "string" },
+              "description": "呼び先 outputs 名 → 説明 / バインド先の対応。"
+            }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+
+    "ScreenTransitionStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "kind", "description", "targetScreenId"],
+          "properties": {
+            "kind": { "const": "screenTransition" },
+            "targetScreenId": { "$ref": "common.v3.schema.json#/$defs/Uuid" }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+
+    "DisplayUpdateStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "kind", "description", "target"],
+          "properties": {
+            "kind": { "const": "displayUpdate" },
+            "target": { "type": "string", "description": "更新対象 (式 / DOM / variable)。" }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+
+    "BranchStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "kind", "description", "branches"],
+          "properties": {
+            "kind": { "const": "branch" },
+            "branches": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/$defs/Branch" }
+            },
+            "elseBranch": { "$ref": "#/$defs/ElseBranch" },
+            "tryScope": {
+              "type": "array",
+              "items": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
+              "description": "tryCatch 分岐の try 範囲となる Step.id 列。"
+            }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+
+    "Branch": {
+      "type": "object",
+      "required": ["id", "code", "condition", "steps"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
+        "code": { "type": "string", "description": "1 文字大文字 (A/B/C...)。" },
+        "label": { "$ref": "common.v3.schema.json#/$defs/DisplayName" },
+        "condition": { "$ref": "#/$defs/BranchCondition" },
+        "steps": { "type": "array", "items": { "$ref": "#/$defs/Step" } }
+      }
+    },
+
+    "ElseBranch": {
+      "type": "object",
+      "required": ["id", "code", "steps"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
+        "code": { "type": "string" },
+        "label": { "$ref": "common.v3.schema.json#/$defs/DisplayName" },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" },
+        "steps": { "type": "array", "items": { "$ref": "#/$defs/Step" } }
+      }
+    },
+
+    "BranchCondition": {
+      "description": "分岐条件。kind による discriminated union (式 / tryCatch / affectedRowsZero / externalOutcome)。string 短縮形は v3 廃止。",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["kind", "expression"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "expression" },
+            "expression": { "$ref": "common.v3.schema.json#/$defs/ExpressionString" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "errorCode"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "tryCatch" },
+            "errorCode": { "$ref": "common.v3.schema.json#/$defs/ErrorCode" },
+            "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "affectedRowsZero" },
+            "stepId": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
+            "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "outcome"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "externalOutcome" },
+            "stepId": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
+            "outcome": { "type": "string", "enum": ["success", "failure", "timeout"] },
+            "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+          }
+        }
+      ]
+    },
+
+    "LoopStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "kind", "description", "loopKind", "steps"],
+          "properties": {
+            "kind": { "const": "loop" },
+            "loopKind": { "type": "string", "enum": ["count", "condition", "collection"] },
+            "countExpression": { "$ref": "common.v3.schema.json#/$defs/ExpressionString" },
+            "conditionMode": { "type": "string", "enum": ["continue", "exit"] },
+            "conditionExpression": { "$ref": "common.v3.schema.json#/$defs/ExpressionString" },
+            "collectionSource": { "$ref": "common.v3.schema.json#/$defs/ExpressionString" },
+            "collectionItemName": { "$ref": "common.v3.schema.json#/$defs/Identifier" },
+            "steps": { "type": "array", "items": { "$ref": "#/$defs/Step" } }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+
+    "LoopBreakStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "kind", "description"],
+          "properties": { "kind": { "const": "loopBreak" } }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+
+    "LoopContinueStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "kind", "description"],
+          "properties": { "kind": { "const": "loopContinue" } }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+
+    "JumpStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "kind", "description", "jumpTo"],
+          "properties": {
+            "kind": { "const": "jump" },
+            "jumpTo": { "$ref": "common.v3.schema.json#/$defs/LocalId" }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+
+    "ComputeStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "kind", "description", "expression"],
+          "properties": {
+            "kind": { "const": "compute" },
+            "expression": { "$ref": "common.v3.schema.json#/$defs/ExpressionString" }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+
+    "ReturnStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "kind", "description"],
+          "properties": {
+            "kind": { "const": "return" },
+            "responseId": { "$ref": "common.v3.schema.json#/$defs/LocalId", "description": "Action.responses[].id 参照。" },
+            "bodyExpression": { "$ref": "common.v3.schema.json#/$defs/ExpressionString" }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+
+    "LogStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "kind", "description", "level", "message"],
+          "properties": {
+            "kind": { "const": "log" },
+            "level": { "type": "string", "enum": ["trace", "debug", "info", "warn", "error"] },
+            "message": { "type": "string" },
+            "category": { "type": "string" },
+            "structuredData": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+
+    "AuditStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "kind", "description", "action"],
+          "properties": {
+            "kind": { "const": "audit" },
+            "action": { "type": "string", "description": "監査対象アクション (例: 'order.confirm')。" },
+            "resource": {
+              "type": "object",
+              "required": ["type", "id"],
+              "additionalProperties": false,
+              "properties": {
+                "type": { "type": "string" },
+                "id": { "type": "string" }
+              }
+            },
+            "result": { "type": "string", "enum": ["success", "failure"] },
+            "reason": { "type": "string" },
+            "sensitive": { "type": "boolean" }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+
+    "WorkflowStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "kind", "description", "pattern", "approvers"],
+          "properties": {
+            "kind": { "const": "workflow" },
+            "pattern": { "$ref": "#/$defs/WorkflowPattern" },
+            "approvers": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/WorkflowApprover" }
+            },
+            "quorum": { "$ref": "#/$defs/WorkflowQuorum" },
+            "onApproved": { "type": "array", "items": { "$ref": "#/$defs/Step" } },
+            "onRejected": { "type": "array", "items": { "$ref": "#/$defs/Step" } },
+            "onTimeout": { "type": "array", "items": { "$ref": "#/$defs/Step" } },
+            "deadlineExpression": { "$ref": "common.v3.schema.json#/$defs/ExpressionString" },
+            "escalateAfter": { "type": "string", "description": "ISO 8601 duration またはエスカレーション期間式。" },
+            "escalateTo": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "role": { "type": "string", "description": "@conv.role.<key>" },
+                "userExpression": { "$ref": "common.v3.schema.json#/$defs/ExpressionString" }
+              }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "pattern": { "const": "approval-escalation" } }, "required": ["pattern"] },
+          "then": { "required": ["escalateAfter", "escalateTo"] }
+        },
+        {
+          "if": { "properties": { "pattern": { "const": "approval-quorum" } }, "required": ["pattern"] },
+          "then": { "required": ["quorum"] }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+
+    "WorkflowPattern": {
+      "type": "string",
+      "enum": [
+        "approval-sequential", "approval-parallel", "approval-veto",
+        "approval-quorum", "approval-escalation", "review", "sign-off",
+        "acknowledge", "branch-merge", "discussion", "ad-hoc"
+      ]
+    },
+
+    "WorkflowApprover": {
+      "type": "object",
+      "required": ["role"],
+      "additionalProperties": false,
+      "properties": {
+        "role": { "type": "string", "description": "@conv.role.<key> 参照。" },
+        "label": { "$ref": "common.v3.schema.json#/$defs/DisplayName" },
+        "order": { "type": "integer", "minimum": 1 }
+      }
+    },
+
+    "WorkflowQuorum": {
+      "type": "object",
+      "required": ["type"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "type": "string", "enum": ["all", "any", "majority", "nOfM"] },
+        "n": { "type": "integer", "minimum": 1 }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "type": { "const": "nOfM" } }, "required": ["type"] },
+          "then": { "required": ["n"] }
+        }
+      ]
+    },
+
+    "TransactionScopeStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "kind", "description", "steps"],
+          "properties": {
+            "kind": { "const": "transactionScope" },
+            "isolationLevel": { "type": "string", "enum": ["READ_COMMITTED", "REPEATABLE_READ", "SERIALIZABLE"] },
+            "propagation": { "type": "string", "enum": ["REQUIRED", "REQUIRES_NEW", "NESTED"] },
+            "timeoutMs": { "type": "number", "minimum": 0 },
+            "rollbackOn": {
+              "type": "array",
+              "items": { "$ref": "common.v3.schema.json#/$defs/ErrorCode" }
+            },
+            "steps": { "type": "array", "items": { "$ref": "#/$defs/Step" } },
+            "onCommit": { "type": "array", "items": { "$ref": "#/$defs/Step" } },
+            "onRollback": { "type": "array", "items": { "$ref": "#/$defs/Step" } },
+            "outcomes": { "$ref": "#/$defs/ExternalCallOutcomes" }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+
+    "EventPublishStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "kind", "description", "topic"],
+          "properties": {
+            "kind": { "const": "eventPublish" },
+            "topic": { "$ref": "common.v3.schema.json#/$defs/EventTopic" },
+            "eventRef": { "$ref": "common.v3.schema.json#/$defs/EventTopic", "description": "context.catalogs.events のキー (= topic 名と一致が原則)。" },
+            "payload": { "$ref": "common.v3.schema.json#/$defs/ExpressionString" }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+
+    "EventSubscribeStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "kind", "description", "topic"],
+          "properties": {
+            "kind": { "const": "eventSubscribe" },
+            "topic": { "$ref": "common.v3.schema.json#/$defs/EventTopic" },
+            "eventRef": { "$ref": "common.v3.schema.json#/$defs/EventTopic" },
+            "filter": { "$ref": "common.v3.schema.json#/$defs/ExpressionString" }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+
+    "ClosingStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "kind", "description", "period"],
+          "properties": {
+            "kind": { "const": "closing" },
+            "period": { "type": "string", "enum": ["daily", "monthly", "quarterly", "yearly", "custom"] },
+            "customCron": { "type": "string" },
+            "cutoffAt": { "type": "string", "description": "締切時刻 (例: '23:59:59')。" },
+            "idempotencyKey": { "$ref": "common.v3.schema.json#/$defs/ExpressionString" },
+            "rollbackOnFailure": { "type": "boolean" }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+
+    "CdcStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "kind", "description", "tableIds", "captureMode", "destination"],
+          "properties": {
+            "kind": { "const": "cdc" },
+            "tableIds": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "common.v3.schema.json#/$defs/Uuid" },
+              "description": "対象 Table の Uuid 配列。"
+            },
+            "captureMode": { "type": "string", "enum": ["full", "incremental"] },
+            "destination": {
+              "type": "object",
+              "required": ["type"],
+              "additionalProperties": false,
+              "properties": {
+                "type": { "type": "string", "enum": ["auditLog", "eventStream", "table"] },
+                "target": { "type": "string" }
+              }
+            },
+            "includeColumnIds": {
+              "type": "array",
+              "items": { "$ref": "common.v3.schema.json#/$defs/LocalId" }
+            },
+            "excludeColumnIds": {
+              "type": "array",
+              "items": { "$ref": "common.v3.schema.json#/$defs/LocalId" }
+            }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+
+    "ExtensionStep": {
+      "description": "拡張 Step (extensions.v3.stepKinds で定義)。kind は namespace:StepName 形式。outputSchema は拡張定義側 schema で確認すること。",
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "kind", "description"],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9_-]*:[A-Z][A-Za-z0-9]*$",
+              "description": "拡張 step 識別子 (namespace:StepName)。例: 'retail:OrderConfirmStep'"
+            }
+          }
+        }
+      ],
+      "unevaluatedProperties": true
+    },
+
+    "TestScenario": {
+      "type": "object",
+      "required": ["id", "name", "given", "when", "then"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
+        "name": { "$ref": "common.v3.schema.json#/$defs/DisplayName" },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" },
+        "given": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/TestPrecondition" }
+        },
+        "when": { "$ref": "#/$defs/TestInvocation" },
+        "then": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/TestAssertion" }
+        },
+        "tags": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+
+    "TestPrecondition": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["kind", "tableId", "rows"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "dbState" },
+            "tableId": { "$ref": "common.v3.schema.json#/$defs/Uuid" },
+            "rows": { "type": "array", "items": { "type": "object", "additionalProperties": true } }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "context"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "sessionContext" },
+            "context": { "type": "object", "additionalProperties": true }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "externalRef", "responseMock"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "externalStub" },
+            "externalRef": { "type": "string" },
+            "responseMock": true
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "now"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "clock" },
+            "now": { "$ref": "common.v3.schema.json#/$defs/Timestamp" }
+          }
+        }
+      ]
+    },
+
+    "TestInvocation": {
+      "type": "object",
+      "required": ["actionId", "input"],
+      "additionalProperties": false,
+      "properties": {
+        "actionId": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
+        "input": { "type": "object", "additionalProperties": true }
+      }
+    },
+
+    "TestAssertion": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["kind", "expected"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "outcome" },
+            "expected": { "$ref": "common.v3.schema.json#/$defs/LocalId", "description": "期待される Response.id。" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "tableId", "match"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "dbRow" },
+            "tableId": { "$ref": "common.v3.schema.json#/$defs/Uuid" },
+            "match": { "type": "object", "additionalProperties": true },
+            "count": { "type": "integer", "minimum": 0 }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "path"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "output" },
+            "path": { "type": "string" },
+            "equals": true,
+            "matches": { "type": "string", "format": "regex" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "externalRef"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "externalCall" },
+            "externalRef": { "type": "string" },
+            "method": { "type": "string" },
+            "bodyMatch": { "type": "object", "additionalProperties": true }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "action"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "auditLog" },
+            "action": { "type": "string" },
+            "result": { "type": "string", "enum": ["success", "failure"] }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "msgKey"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "errorMessage" },
+            "msgKey": { "type": "string", "description": "@conv.msg.<key>" }
+          }
+        }
+      ]
+    },
+
+    "HealthCheckGroup": {
+      "type": "object",
+      "required": ["checks"],
+      "additionalProperties": false,
+      "properties": {
+        "checks": { "type": "array", "items": { "$ref": "#/$defs/HealthCheck" } }
+      }
+    },
+
+    "ReadinessCheckGroup": {
+      "type": "object",
+      "required": ["checks"],
+      "additionalProperties": false,
+      "properties": {
+        "checks": { "type": "array", "items": { "$ref": "#/$defs/HealthCheck" } },
+        "minimumPassCount": { "type": "number", "minimum": 0 }
+      }
+    },
+
+    "HealthCheck": {
+      "type": "object",
+      "required": ["name", "kind"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "$ref": "common.v3.schema.json#/$defs/DisplayName" },
+        "kind": { "type": "string", "enum": ["db", "http", "custom"] },
+        "target": { "type": "string" },
+        "timeout": { "type": "number", "minimum": 0 }
+      }
+    },
+
+    "ResourceRequirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "cpu": { "$ref": "#/$defs/ResourceQuota" },
+        "memory": { "$ref": "#/$defs/ResourceQuota" },
+        "dbConnections": { "type": "number", "minimum": 0 },
+        "timeout": { "type": "number", "minimum": 0 }
+      }
+    },
+
+    "ResourceQuota": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "request": { "type": "string" },
+        "limit": { "type": "string" }
+      }
+    }
+  }
+}

--- a/schemas/v3/process-flow.v3.schema.json
+++ b/schemas/v3/process-flow.v3.schema.json
@@ -2,28 +2,21 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/csilost2001/html-designer/main/schemas/v3/process-flow.v3.schema.json",
   "title": "ProcessFlow (v3 処理フロー定義)",
-  "description": "業務処理フロー entity 1 件分の正規定義。data/process-flows/<id>.json に対応。root を 4 セクション (meta / context / body / authoring) に再編し、catalog 群を context.catalogs.<kind> に階層化することで意味付けと拡張性を確保する。",
+  "description": "業務処理フロー entity 1 件分の正規定義。data/process-flows/<id>.json に対応。root を 4 セクション (meta / context / actions / authoring) に再編し、catalog 群を context.catalogs.<kind> に階層化することで意味付けと拡張性を確保する。actions は実行ロジック本体、authoring は実行不要 (markers / decisions / glossary / notes / testScenarios)。",
   "type": "object",
-  "required": ["meta", "body"],
+  "required": ["meta", "actions"],
   "additionalProperties": false,
   "properties": {
     "$schema": { "type": "string" },
-
     "meta": { "$ref": "#/$defs/Meta" },
     "context": { "$ref": "#/$defs/Context" },
-    "body": { "$ref": "#/$defs/Body" },
-    "authoring": {
-      "allOf": [{ "$ref": "common.v3.schema.json#/$defs/Authoring" }],
-      "type": "object",
-      "properties": {
-        "markers": true, "decisions": true, "glossary": true, "notes": true,
-        "testScenarios": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/TestScenario" }
-        }
-      },
-      "unevaluatedProperties": false
-    }
+    "actions": {
+      "type": "array",
+      "minItems": 0,
+      "items": { "$ref": "#/$defs/ActionDefinition" },
+      "description": "実行ロジック本体。0 件も許容 (ロード時の placeholder ProcessFlow 用)。"
+    },
+    "authoring": { "$ref": "common.v3.schema.json#/$defs/Authoring" }
   },
 
   "$defs": {
@@ -34,8 +27,6 @@
       "type": "object",
       "required": ["kind"],
       "properties": {
-        "id": true, "name": true, "description": true, "version": true,
-        "maturity": true, "createdAt": true, "updatedAt": true,
         "kind": { "$ref": "#/$defs/ProcessFlowKind" },
         "screenId": { "$ref": "common.v3.schema.json#/$defs/Uuid", "description": "kind='screen' の場合に紐付く Screen の Uuid。" },
         "apiVersion": { "type": "string", "description": "ProcessFlow が公開する API のバージョン (例: 'v1', '2026-04-25')。" },
@@ -94,43 +85,50 @@
     },
 
     "Catalogs": {
-      "description": "ProcessFlow 内 catalog 群を階層化集約。新 catalog 追加時に root を肥大化させない。",
+      "description": "ProcessFlow 内 catalog 群を階層化集約。新 catalog 追加時に root を肥大化させない。各 catalog のキー命名規範は propertyNames pattern で schema 上強制する。",
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "errors": {
           "type": "object",
           "description": "エラーコード catalog。キー: ErrorCode (UPPER_SNAKE)。affectedRowsCheck.errorCode / Branch.condition.errorCode から参照。",
+          "propertyNames": { "$ref": "common.v3.schema.json#/$defs/ErrorCode" },
           "additionalProperties": { "$ref": "#/$defs/ErrorCatalogEntry" }
         },
         "externalSystems": {
           "type": "object",
-          "description": "外部システム catalog。キー: systemId (lowercase)。ExternalSystemStep.systemRef から参照。",
+          "description": "外部システム catalog。キー: systemId (lowerCamelCase)。ExternalSystemStep.systemRef から参照。",
+          "propertyNames": { "$ref": "common.v3.schema.json#/$defs/Identifier" },
           "additionalProperties": { "$ref": "#/$defs/ExternalSystemCatalogEntry" }
         },
         "secrets": {
           "type": "object",
           "description": "Secrets catalog。キー: secretKey (camelCase)。@secret.<key> で参照。",
+          "propertyNames": { "$ref": "common.v3.schema.json#/$defs/Identifier" },
           "additionalProperties": { "$ref": "#/$defs/SecretEntry" }
         },
         "envVars": {
           "type": "object",
           "description": "環境変数 catalog。キー: EnvVarKey (UPPER_SNAKE)。@env.<KEY> で参照。",
+          "propertyNames": { "$ref": "common.v3.schema.json#/$defs/EnvVarKey" },
           "additionalProperties": { "$ref": "#/$defs/EnvVarEntry" }
         },
         "domains": {
           "type": "object",
           "description": "ドメイン型 catalog。キー: ドメイン名 (PascalCase)。FieldType.kind='domain' から参照。",
+          "propertyNames": { "type": "string", "pattern": "^[A-Z][A-Za-z0-9]*$" },
           "additionalProperties": { "$ref": "#/$defs/DomainEntry" }
         },
         "functions": {
           "type": "object",
           "description": "組み込み関数 catalog。キー: 関数名 (camelCase)。@fn.<name>(...) で参照。",
+          "propertyNames": { "$ref": "common.v3.schema.json#/$defs/Identifier" },
           "additionalProperties": { "$ref": "#/$defs/FunctionEntry" }
         },
         "events": {
           "type": "object",
-          "description": "イベント pub/sub catalog。キー: EventTopic (dot.lowercase)。EventPublishStep / EventSubscribeStep の eventRef から参照。",
+          "description": "イベント pub/sub catalog。キー: EventTopic (dot.lowercase)。EventPublishStep.topic / EventSubscribeStep.topic から参照。",
+          "propertyNames": { "$ref": "common.v3.schema.json#/$defs/EventTopic" },
           "additionalProperties": { "$ref": "#/$defs/EventEntry" }
         }
       }
@@ -243,19 +241,6 @@
       }
     },
 
-    "Body": {
-      "description": "実行ロジック本体。ActionDefinition の配列。",
-      "type": "object",
-      "required": ["actions"],
-      "additionalProperties": false,
-      "properties": {
-        "actions": {
-          "type": "array",
-          "minItems": 1,
-          "items": { "$ref": "#/$defs/ActionDefinition" }
-        }
-      }
-    },
 
     "ActionDefinition": {
       "type": "object",
@@ -365,8 +350,7 @@
           "items": { "type": "string" }
         },
         "outputBinding": { "$ref": "#/$defs/OutputBinding" },
-        "txBoundary": { "$ref": "#/$defs/TxBoundary" },
-        "transactional": { "type": "boolean", "description": "簡易 TX マーク (txBoundary 不要時の boolean 短縮)。" },
+        "txBoundary": { "$ref": "#/$defs/TxBoundary", "description": "TX 境界宣言。txId 単位で begin/member/end を結合。簡易フラグの transactional は v3 で廃止 (txBoundary に統一)。" },
         "compensatesFor": { "$ref": "common.v3.schema.json#/$defs/LocalId", "description": "Saga 補償対象の Step.id 参照。" },
         "externalChain": { "$ref": "#/$defs/ExternalChain" }
       }
@@ -599,19 +583,32 @@
     },
 
     "DataLineage": {
+      "description": "DbAccessStep のデータ系譜。reads/writes の各エントリは目的 (purpose) を持てる (CDC / 監査 / 影響範囲分析用)。",
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "reads": {
           "type": "array",
-          "items": { "$ref": "common.v3.schema.json#/$defs/Uuid" },
-          "description": "読み取り対象 Table.id 一覧。"
+          "items": { "$ref": "#/$defs/LineageEntry" },
+          "description": "読み取り対象 Table の参照 + 目的。"
         },
         "writes": {
           "type": "array",
-          "items": { "$ref": "common.v3.schema.json#/$defs/Uuid" },
-          "description": "書き込み対象 Table.id 一覧。"
+          "items": { "$ref": "#/$defs/LineageEntry" },
+          "description": "書き込み対象 Table の参照 + 目的。"
         }
+      }
+    },
+
+    "LineageEntry": {
+      "description": "DataLineage の 1 エントリ。tableId 必須 + purpose 任意。",
+      "type": "object",
+      "required": ["tableId"],
+      "additionalProperties": false,
+      "properties": {
+        "tableId": { "$ref": "common.v3.schema.json#/$defs/Uuid" },
+        "purpose": { "type": "string", "description": "読み取り/書き込みの目的 (例: 'lookup', 'lock', 'audit', 'snapshot', 'soft-delete')。" },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
       }
     },
 
@@ -638,7 +635,10 @@
           "required": ["id", "kind", "description", "systemRef"],
           "properties": {
             "kind": { "const": "externalSystem" },
-            "systemRef": { "type": "string", "description": "ProcessFlow.context.catalogs.externalSystems のキー参照。" },
+            "systemRef": {
+              "$ref": "common.v3.schema.json#/$defs/Identifier",
+              "description": "ProcessFlow.context.catalogs.externalSystems のキー参照 (Identifier / camelCase)。"
+            },
             "httpCall": { "$ref": "#/$defs/ExternalHttpCall" },
             "operationRef": { "type": "string", "description": "OpenAPI operation 参照 (例: '/v1/payment_intents POST')。" },
             "operationId": { "type": "string" },
@@ -828,7 +828,7 @@
       "additionalProperties": false,
       "properties": {
         "id": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
-        "code": { "type": "string", "description": "1 文字大文字 (A/B/C...)。" },
+        "code": { "type": "string", "pattern": "^[A-Z]$", "description": "1 文字大文字 (A/B/C...)。" },
         "label": { "$ref": "common.v3.schema.json#/$defs/DisplayName" },
         "condition": { "$ref": "#/$defs/BranchCondition" },
         "steps": { "type": "array", "items": { "$ref": "#/$defs/Step" } }
@@ -841,7 +841,7 @@
       "additionalProperties": false,
       "properties": {
         "id": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
-        "code": { "type": "string" },
+        "code": { "type": "string", "pattern": "^[A-Z]$", "description": "1 文字大文字 (A/B/C...、通常 'X' 等の最終枠を使用)。" },
         "label": { "$ref": "common.v3.schema.json#/$defs/DisplayName" },
         "description": { "$ref": "common.v3.schema.json#/$defs/Description" },
         "steps": { "type": "array", "items": { "$ref": "#/$defs/Step" } }
@@ -1136,6 +1136,7 @@
     },
 
     "EventPublishStep": {
+      "description": "イベント発行 step。topic は context.catalogs.events のキーと一致する (eventRef 二重持ちは v3 廃止)。",
       "allOf": [
         { "$ref": "#/$defs/StepBaseProps" },
         {
@@ -1143,8 +1144,7 @@
           "required": ["id", "kind", "description", "topic"],
           "properties": {
             "kind": { "const": "eventPublish" },
-            "topic": { "$ref": "common.v3.schema.json#/$defs/EventTopic" },
-            "eventRef": { "$ref": "common.v3.schema.json#/$defs/EventTopic", "description": "context.catalogs.events のキー (= topic 名と一致が原則)。" },
+            "topic": { "$ref": "common.v3.schema.json#/$defs/EventTopic", "description": "発行先 topic。同時に context.catalogs.events のキーとして登録されている必要がある。" },
             "payload": { "$ref": "common.v3.schema.json#/$defs/ExpressionString" }
           }
         }
@@ -1153,6 +1153,7 @@
     },
 
     "EventSubscribeStep": {
+      "description": "イベント購読 step。topic は context.catalogs.events のキーと一致 (eventRef 二重持ちは v3 廃止)。",
       "allOf": [
         { "$ref": "#/$defs/StepBaseProps" },
         {
@@ -1160,8 +1161,7 @@
           "required": ["id", "kind", "description", "topic"],
           "properties": {
             "kind": { "const": "eventSubscribe" },
-            "topic": { "$ref": "common.v3.schema.json#/$defs/EventTopic" },
-            "eventRef": { "$ref": "common.v3.schema.json#/$defs/EventTopic" },
+            "topic": { "$ref": "common.v3.schema.json#/$defs/EventTopic", "description": "購読 topic。同時に context.catalogs.events のキーとして登録されている必要がある。" },
             "filter": { "$ref": "common.v3.schema.json#/$defs/ExpressionString" }
           }
         }
@@ -1203,15 +1203,7 @@
               "description": "対象 Table の Uuid 配列。"
             },
             "captureMode": { "type": "string", "enum": ["full", "incremental"] },
-            "destination": {
-              "type": "object",
-              "required": ["type"],
-              "additionalProperties": false,
-              "properties": {
-                "type": { "type": "string", "enum": ["auditLog", "eventStream", "table"] },
-                "target": { "type": "string" }
-              }
-            },
+            "destination": { "$ref": "#/$defs/CdcDestination" },
             "includeColumnIds": {
               "type": "array",
               "items": { "$ref": "common.v3.schema.json#/$defs/LocalId" }
@@ -1226,8 +1218,41 @@
       "unevaluatedProperties": false
     },
 
+    "CdcDestination": {
+      "description": "CDC 出力先。kind による discriminated union (auditLog / eventStream / table)。",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["kind", "auditAction"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "auditLog" },
+            "auditAction": { "type": "string", "description": "監査ログのアクション名 (例: 'inventory.monthlyClose')。" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "topic"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "eventStream" },
+            "topic": { "$ref": "common.v3.schema.json#/$defs/EventTopic" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "tableId"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "table" },
+            "tableId": { "$ref": "common.v3.schema.json#/$defs/Uuid" }
+          }
+        }
+      ]
+    },
+
     "ExtensionStep": {
-      "description": "拡張 Step (extensions.v3.stepKinds で定義)。kind は namespace:StepName 形式。outputSchema は拡張定義側 schema で確認すること。",
+      "description": "拡張 Step (extensions.v3.stepKinds で定義)。kind は namespace:StepName 形式。固有プロパティは config object に閉じる (loader が拡張定義側 schema で config を検証)。",
       "allOf": [
         { "$ref": "#/$defs/StepBaseProps" },
         {
@@ -1238,151 +1263,16 @@
               "type": "string",
               "pattern": "^[a-z][a-z0-9_-]*:[A-Z][A-Za-z0-9]*$",
               "description": "拡張 step 識別子 (namespace:StepName)。例: 'retail:OrderConfirmStep'"
+            },
+            "config": {
+              "type": "object",
+              "additionalProperties": true,
+              "description": "拡張 step 固有設定。loader が extensions.v3.stepKinds[<kind>].schema (DynamicFormSchema) で構造を検証する。core schema 上は任意 object。"
             }
           }
         }
       ],
-      "unevaluatedProperties": true
-    },
-
-    "TestScenario": {
-      "type": "object",
-      "required": ["id", "name", "given", "when", "then"],
-      "additionalProperties": false,
-      "properties": {
-        "id": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
-        "name": { "$ref": "common.v3.schema.json#/$defs/DisplayName" },
-        "description": { "$ref": "common.v3.schema.json#/$defs/Description" },
-        "given": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/TestPrecondition" }
-        },
-        "when": { "$ref": "#/$defs/TestInvocation" },
-        "then": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/TestAssertion" }
-        },
-        "tags": { "type": "array", "items": { "type": "string" } }
-      }
-    },
-
-    "TestPrecondition": {
-      "oneOf": [
-        {
-          "type": "object",
-          "required": ["kind", "tableId", "rows"],
-          "additionalProperties": false,
-          "properties": {
-            "kind": { "const": "dbState" },
-            "tableId": { "$ref": "common.v3.schema.json#/$defs/Uuid" },
-            "rows": { "type": "array", "items": { "type": "object", "additionalProperties": true } }
-          }
-        },
-        {
-          "type": "object",
-          "required": ["kind", "context"],
-          "additionalProperties": false,
-          "properties": {
-            "kind": { "const": "sessionContext" },
-            "context": { "type": "object", "additionalProperties": true }
-          }
-        },
-        {
-          "type": "object",
-          "required": ["kind", "externalRef", "responseMock"],
-          "additionalProperties": false,
-          "properties": {
-            "kind": { "const": "externalStub" },
-            "externalRef": { "type": "string" },
-            "responseMock": true
-          }
-        },
-        {
-          "type": "object",
-          "required": ["kind", "now"],
-          "additionalProperties": false,
-          "properties": {
-            "kind": { "const": "clock" },
-            "now": { "$ref": "common.v3.schema.json#/$defs/Timestamp" }
-          }
-        }
-      ]
-    },
-
-    "TestInvocation": {
-      "type": "object",
-      "required": ["actionId", "input"],
-      "additionalProperties": false,
-      "properties": {
-        "actionId": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
-        "input": { "type": "object", "additionalProperties": true }
-      }
-    },
-
-    "TestAssertion": {
-      "oneOf": [
-        {
-          "type": "object",
-          "required": ["kind", "expected"],
-          "additionalProperties": false,
-          "properties": {
-            "kind": { "const": "outcome" },
-            "expected": { "$ref": "common.v3.schema.json#/$defs/LocalId", "description": "期待される Response.id。" }
-          }
-        },
-        {
-          "type": "object",
-          "required": ["kind", "tableId", "match"],
-          "additionalProperties": false,
-          "properties": {
-            "kind": { "const": "dbRow" },
-            "tableId": { "$ref": "common.v3.schema.json#/$defs/Uuid" },
-            "match": { "type": "object", "additionalProperties": true },
-            "count": { "type": "integer", "minimum": 0 }
-          }
-        },
-        {
-          "type": "object",
-          "required": ["kind", "path"],
-          "additionalProperties": false,
-          "properties": {
-            "kind": { "const": "output" },
-            "path": { "type": "string" },
-            "equals": true,
-            "matches": { "type": "string", "format": "regex" }
-          }
-        },
-        {
-          "type": "object",
-          "required": ["kind", "externalRef"],
-          "additionalProperties": false,
-          "properties": {
-            "kind": { "const": "externalCall" },
-            "externalRef": { "type": "string" },
-            "method": { "type": "string" },
-            "bodyMatch": { "type": "object", "additionalProperties": true }
-          }
-        },
-        {
-          "type": "object",
-          "required": ["kind", "action"],
-          "additionalProperties": false,
-          "properties": {
-            "kind": { "const": "auditLog" },
-            "action": { "type": "string" },
-            "result": { "type": "string", "enum": ["success", "failure"] }
-          }
-        },
-        {
-          "type": "object",
-          "required": ["kind", "msgKey"],
-          "additionalProperties": false,
-          "properties": {
-            "kind": { "const": "errorMessage" },
-            "msgKey": { "type": "string", "description": "@conv.msg.<key>" }
-          }
-        }
-      ]
+      "unevaluatedProperties": false
     },
 
     "HealthCheckGroup": {

--- a/schemas/v3/process-flow.v3.schema.json
+++ b/schemas/v3/process-flow.v3.schema.json
@@ -12,9 +12,8 @@
     "context": { "$ref": "#/$defs/Context" },
     "actions": {
       "type": "array",
-      "minItems": 0,
       "items": { "$ref": "#/$defs/ActionDefinition" },
-      "description": "実行ロジック本体。0 件も許容 (ロード時の placeholder ProcessFlow 用)。"
+      "description": "実行ロジック本体。0 件も許容 (ロード時の placeholder ProcessFlow 用、minItems は JSON Schema デフォルト 0)。"
     },
     "authoring": { "$ref": "common.v3.schema.json#/$defs/Authoring" }
   },
@@ -318,7 +317,11 @@
           "required": ["typeRef"],
           "additionalProperties": false,
           "properties": {
-            "typeRef": { "type": "string", "description": "namespace:typeName または typeName 形式。extensions.v3.responseTypes から解決される。" }
+            "typeRef": {
+              "type": "string",
+              "pattern": "^(?:[a-z][a-z0-9_-]*:)?[A-Z][A-Za-z0-9]*$",
+              "description": "namespace:TypeName または TypeName (PascalCase) 形式。extensions.v3.responseTypes から解決される。"
+            }
           }
         },
         {
@@ -417,7 +420,7 @@
     },
 
     "Step": {
-      "description": "Step union。kind プロパティで variant を識別。22 種の組み込み variant + 拡張 (ExtensionStep)。",
+      "description": "Step union。kind プロパティで variant を識別。組み込み 21 variant + ExtensionStep の計 22 variant。",
       "oneOf": [
         { "$ref": "#/$defs/ValidationStep" },
         { "$ref": "#/$defs/DbAccessStep" },
@@ -499,10 +502,10 @@
       "properties": {
         "field": { "type": "string", "description": "対象フィールドパス (例: 'email', 'items[*].quantity')。" },
         "type": { "type": "string", "enum": ["required", "regex", "maxLength", "minLength", "range", "enum", "custom"] },
-        "kind": {
+        "severity": {
           "type": "string",
           "enum": ["error", "msg", "noaccept", "default"],
-          "description": "違反時の振る舞い。"
+          "description": "違反時の振る舞い。error: エラー表示しブロック / msg: メッセージのみ表示続行可 / noaccept: 値を受け付けない / default: 既定値設定。Step.kind 等の discriminator とは別概念のため severity と命名 (旧 kind から rename)。"
         },
         "pattern": { "type": "string" },
         "patternRef": { "type": "string", "description": "@conv.regex.<key> 参照。" },
@@ -529,11 +532,11 @@
         "ngBodyExpression": { "$ref": "common.v3.schema.json#/$defs/ExpressionString" },
         "ngEventPublish": {
           "type": "object",
-          "required": ["topic", "eventRef", "payload"],
+          "description": "NG 時に eventPublish を実行してから ngResponseId を返す。topic は context.catalogs.events のキーと一致する (eventRef 二重持ちは v3 廃止、EventPublishStep と整合)。",
+          "required": ["topic", "payload"],
           "additionalProperties": false,
           "properties": {
             "topic": { "$ref": "common.v3.schema.json#/$defs/EventTopic" },
-            "eventRef": { "$ref": "common.v3.schema.json#/$defs/EventTopic" },
             "payload": { "$ref": "common.v3.schema.json#/$defs/ExpressionString" }
           }
         }
@@ -1204,13 +1207,15 @@
             },
             "captureMode": { "type": "string", "enum": ["full", "incremental"] },
             "destination": { "$ref": "#/$defs/CdcDestination" },
-            "includeColumnIds": {
+            "includeColumns": {
               "type": "array",
-              "items": { "$ref": "common.v3.schema.json#/$defs/LocalId" }
+              "items": { "$ref": "common.v3.schema.json#/$defs/TableColumnRef" },
+              "description": "captureMode 適用対象カラム (TableColumnRef で tableId+columnId を明示、複数テーブル間で columnId が衝突しない)。"
             },
-            "excludeColumnIds": {
+            "excludeColumns": {
               "type": "array",
-              "items": { "$ref": "common.v3.schema.json#/$defs/LocalId" }
+              "items": { "$ref": "common.v3.schema.json#/$defs/TableColumnRef" },
+              "description": "captureMode から除外するカラム。"
             }
           }
         }

--- a/schemas/v3/project.v3.schema.json
+++ b/schemas/v3/project.v3.schema.json
@@ -23,8 +23,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "id": true, "name": true, "description": true, "version": true,
-        "maturity": true, "createdAt": true, "updatedAt": true,
         "mode": { "$ref": "common.v3.schema.json#/$defs/Mode", "description": "プロジェクト全体の上流/下流モード。" }
       },
       "unevaluatedProperties": false
@@ -32,8 +30,8 @@
 
     "extensionsApplied": {
       "type": "array",
-      "items": { "$ref": "common.v3.schema.json#/$defs/Namespace" },
-      "description": "本プロジェクトが適用する拡張 namespace 一覧 (例: ['retail'])。loader は data/extensions/<ns>.v3.json を読み core schema と合成する。"
+      "items": { "$ref": "common.v3.schema.json#/$defs/ExtensionApplied" },
+      "description": "本プロジェクトが適用する拡張 namespace 一覧 (version 制約付き object)。例: [{ namespace: 'retail', version: '>=2.0.0' }]。loader は data/extensions/<ns>.v3.json (または data/extensions/<ns>/*.v3.json 分割) を読み、version 制約と突合の上で core schema と合成する。"
     },
 
     "entities": {
@@ -75,8 +73,7 @@
       "allOf": [{ "$ref": "#/$defs/EntryBase" }],
       "type": "object",
       "properties": {
-        "id": true, "no": true, "name": true, "updatedAt": true, "maturity": true,
-        "kind": { "type": "string", "description": "ScreenKind 文字列 (login/dashboard/list/detail/form 等、または 'extension:retail:storefront' 等の拡張参照)。" },
+        "kind": { "type": "string", "description": "ScreenKind 文字列 (login/dashboard/list/detail/form 等、または 'retail:storefront' 等の拡張参照)。" },
         "path": { "type": "string", "description": "URL ルーティングパス。" },
         "groupId": { "$ref": "common.v3.schema.json#/$defs/Uuid" },
         "hasDesign": { "type": "boolean" }
@@ -88,7 +85,6 @@
       "allOf": [{ "$ref": "#/$defs/EntryBase" }],
       "type": "object",
       "properties": {
-        "id": true, "no": true, "name": true, "updatedAt": true, "maturity": true,
         "physicalName": { "$ref": "common.v3.schema.json#/$defs/PhysicalName" },
         "category": { "type": "string", "description": "テーブルカテゴリ (例: 'マスタ', 'トランザクション', '中間テーブル', 'ログ' 等)。" },
         "columnCount": { "type": "integer", "minimum": 0 }
@@ -100,8 +96,7 @@
       "allOf": [{ "$ref": "#/$defs/EntryBase" }],
       "type": "object",
       "properties": {
-        "id": true, "no": true, "name": true, "updatedAt": true, "maturity": true,
-        "kind": { "type": "string", "description": "ProcessFlowKind (screen/batch/scheduled/system/common/other)。" },
+        "kind": { "type": "string", "description": "ProcessFlowKind (screen/batch/scheduled/system/common/other、または 'retail:posTransaction' 等の拡張参照)。" },
         "screenId": { "$ref": "common.v3.schema.json#/$defs/Uuid", "description": "screen kind の場合の関連画面 ID。" },
         "actionCount": { "type": "integer", "minimum": 0 },
         "notesCount": { "type": "integer", "minimum": 0 }
@@ -113,7 +108,6 @@
       "allOf": [{ "$ref": "#/$defs/EntryBase" }],
       "type": "object",
       "properties": {
-        "id": true, "no": true, "name": true, "updatedAt": true, "maturity": true,
         "physicalName": { "$ref": "common.v3.schema.json#/$defs/PhysicalName" }
       },
       "unevaluatedProperties": false
@@ -123,7 +117,6 @@
       "allOf": [{ "$ref": "#/$defs/EntryBase" }],
       "type": "object",
       "properties": {
-        "id": true, "no": true, "name": true, "updatedAt": true, "maturity": true,
         "physicalName": { "$ref": "common.v3.schema.json#/$defs/PhysicalName" },
         "conventionRef": { "type": "string", "description": "@conv.numbering.<key> 形式の参照。" }
       },

--- a/schemas/v3/project.v3.schema.json
+++ b/schemas/v3/project.v3.schema.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/csilost2001/html-designer/main/schemas/v3/project.v3.schema.json",
+  "title": "Project (v3 プロジェクト root)",
+  "description": "業務システム 1 案件の root 定義。data/project.json に対応。プロジェクト全体のメタ・参照する entity 一覧 (各 entity は別ファイル) を集約する。各 entity の中身は別 schema 参照。",
+  "type": "object",
+  "required": ["meta", "schemaVersion"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+
+    "schemaVersion": {
+      "type": "string",
+      "enum": ["v3"],
+      "description": "本プロジェクトが使う schema バージョン。loader は本値で schemas/v3/ を選択する。"
+    },
+
+    "meta": {
+      "description": "プロジェクト identity と運用設定。",
+      "allOf": [
+        { "$ref": "common.v3.schema.json#/$defs/EntityMeta" }
+      ],
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": true, "name": true, "description": true, "version": true,
+        "maturity": true, "createdAt": true, "updatedAt": true,
+        "mode": { "$ref": "common.v3.schema.json#/$defs/Mode", "description": "プロジェクト全体の上流/下流モード。" }
+      },
+      "unevaluatedProperties": false
+    },
+
+    "extensionsApplied": {
+      "type": "array",
+      "items": { "$ref": "common.v3.schema.json#/$defs/Namespace" },
+      "description": "本プロジェクトが適用する拡張 namespace 一覧 (例: ['retail'])。loader は data/extensions/<ns>.v3.json を読み core schema と合成する。"
+    },
+
+    "entities": {
+      "description": "プロジェクトが保持する各 entity への参照一覧。各 entity の本体は別ファイル (data/screens/<id>.json 等) に格納される。本セクションは entity の存在と表示用メタ (一覧 UI で使う) を集約する。",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "screens": { "type": "array", "items": { "$ref": "#/$defs/ScreenEntry" } },
+        "tables":  { "type": "array", "items": { "$ref": "#/$defs/TableEntry" } },
+        "processFlows": { "type": "array", "items": { "$ref": "#/$defs/ProcessFlowEntry" } },
+        "views": { "type": "array", "items": { "$ref": "#/$defs/ViewEntry" } },
+        "sequences": { "type": "array", "items": { "$ref": "#/$defs/SequenceEntry" } },
+        "screenGroups": { "type": "array", "items": { "$ref": "#/$defs/ScreenGroupEntry" } },
+        "screenTransitions": { "type": "array", "items": { "$ref": "#/$defs/ScreenTransitionEntry" } }
+      }
+    },
+
+    "authoring": {
+      "$ref": "common.v3.schema.json#/$defs/Authoring",
+      "description": "プロジェクト全体の authoring 情報 (markers / decisions / glossary)。entity 横断で共有される ADR や用語集はここに集約。"
+    }
+  },
+  "$defs": {
+
+    "EntryBase": {
+      "description": "entities.* 配列要素の共通プロパティ。一覧 UI が表示する最小メタ。",
+      "type": "object",
+      "required": ["id", "no", "name", "updatedAt"],
+      "properties": {
+        "id": { "$ref": "common.v3.schema.json#/$defs/Uuid" },
+        "no": { "type": "integer", "minimum": 1, "description": "物理順 (1..N)。一覧の並び替え永続化に使用。" },
+        "name": { "$ref": "common.v3.schema.json#/$defs/DisplayName" },
+        "updatedAt": { "$ref": "common.v3.schema.json#/$defs/Timestamp" },
+        "maturity": { "$ref": "common.v3.schema.json#/$defs/Maturity" }
+      }
+    },
+
+    "ScreenEntry": {
+      "allOf": [{ "$ref": "#/$defs/EntryBase" }],
+      "type": "object",
+      "properties": {
+        "id": true, "no": true, "name": true, "updatedAt": true, "maturity": true,
+        "kind": { "type": "string", "description": "ScreenKind 文字列 (login/dashboard/list/detail/form 等、または 'extension:retail:storefront' 等の拡張参照)。" },
+        "path": { "type": "string", "description": "URL ルーティングパス。" },
+        "groupId": { "$ref": "common.v3.schema.json#/$defs/Uuid" },
+        "hasDesign": { "type": "boolean" }
+      },
+      "unevaluatedProperties": false
+    },
+
+    "TableEntry": {
+      "allOf": [{ "$ref": "#/$defs/EntryBase" }],
+      "type": "object",
+      "properties": {
+        "id": true, "no": true, "name": true, "updatedAt": true, "maturity": true,
+        "physicalName": { "$ref": "common.v3.schema.json#/$defs/PhysicalName" },
+        "category": { "type": "string", "description": "テーブルカテゴリ (例: 'マスタ', 'トランザクション', '中間テーブル', 'ログ' 等)。" },
+        "columnCount": { "type": "integer", "minimum": 0 }
+      },
+      "unevaluatedProperties": false
+    },
+
+    "ProcessFlowEntry": {
+      "allOf": [{ "$ref": "#/$defs/EntryBase" }],
+      "type": "object",
+      "properties": {
+        "id": true, "no": true, "name": true, "updatedAt": true, "maturity": true,
+        "kind": { "type": "string", "description": "ProcessFlowKind (screen/batch/scheduled/system/common/other)。" },
+        "screenId": { "$ref": "common.v3.schema.json#/$defs/Uuid", "description": "screen kind の場合の関連画面 ID。" },
+        "actionCount": { "type": "integer", "minimum": 0 },
+        "notesCount": { "type": "integer", "minimum": 0 }
+      },
+      "unevaluatedProperties": false
+    },
+
+    "ViewEntry": {
+      "allOf": [{ "$ref": "#/$defs/EntryBase" }],
+      "type": "object",
+      "properties": {
+        "id": true, "no": true, "name": true, "updatedAt": true, "maturity": true,
+        "physicalName": { "$ref": "common.v3.schema.json#/$defs/PhysicalName" }
+      },
+      "unevaluatedProperties": false
+    },
+
+    "SequenceEntry": {
+      "allOf": [{ "$ref": "#/$defs/EntryBase" }],
+      "type": "object",
+      "properties": {
+        "id": true, "no": true, "name": true, "updatedAt": true, "maturity": true,
+        "physicalName": { "$ref": "common.v3.schema.json#/$defs/PhysicalName" },
+        "conventionRef": { "type": "string", "description": "@conv.numbering.<key> 形式の参照。" }
+      },
+      "unevaluatedProperties": false
+    },
+
+    "ScreenGroupEntry": {
+      "type": "object",
+      "required": ["id", "name"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "common.v3.schema.json#/$defs/Uuid" },
+        "name": { "$ref": "common.v3.schema.json#/$defs/DisplayName" },
+        "color": { "type": "string", "description": "UI 表示色 (#RRGGBB)。" }
+      }
+    },
+
+    "ScreenTransitionEntry": {
+      "description": "画面間の遷移定義。source / target は ScreenEntry.id を指す。UI 座標は screen-layout に分離。",
+      "type": "object",
+      "required": ["id", "sourceScreenId", "targetScreenId", "trigger"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
+        "sourceScreenId": { "$ref": "common.v3.schema.json#/$defs/Uuid" },
+        "targetScreenId": { "$ref": "common.v3.schema.json#/$defs/Uuid" },
+        "label": { "$ref": "common.v3.schema.json#/$defs/DisplayName" },
+        "trigger": {
+          "type": "string",
+          "enum": ["click", "submit", "select", "cancel", "auto", "back", "other"],
+          "description": "遷移トリガー種別。"
+        }
+      }
+    }
+  }
+}

--- a/schemas/v3/project.v3.schema.json
+++ b/schemas/v3/project.v3.schema.json
@@ -21,7 +21,6 @@
         { "$ref": "common.v3.schema.json#/$defs/EntityMeta" }
       ],
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "mode": { "$ref": "common.v3.schema.json#/$defs/Mode", "description": "プロジェクト全体の上流/下流モード。" }
       },

--- a/schemas/v3/screen-item.v3.schema.json
+++ b/schemas/v3/screen-item.v3.schema.json
@@ -70,7 +70,7 @@
     },
 
     "ValueSource": {
-      "description": "output 項目のバインド元。discriminated union (kind)。",
+      "description": "output 項目のバインド元。discriminated union (kind)。組み込み 4 種 + 拡張 (extensions.v3.valueSourceKinds で定義)。tableColumn / viewColumn は common.v3 の Ref 型を流用。",
       "oneOf": [
         {
           "type": "object",
@@ -84,22 +84,20 @@
         },
         {
           "type": "object",
-          "required": ["kind", "tableId", "columnId"],
+          "required": ["kind", "ref"],
           "additionalProperties": false,
           "properties": {
             "kind": { "const": "tableColumn" },
-            "tableId": { "$ref": "common.v3.schema.json#/$defs/Uuid" },
-            "columnId": { "$ref": "common.v3.schema.json#/$defs/LocalId" }
+            "ref": { "$ref": "common.v3.schema.json#/$defs/TableColumnRef" }
           }
         },
         {
           "type": "object",
-          "required": ["kind", "viewId", "columnPhysicalName"],
+          "required": ["kind", "ref"],
           "additionalProperties": false,
           "properties": {
             "kind": { "const": "viewColumn" },
-            "viewId": { "$ref": "common.v3.schema.json#/$defs/Uuid" },
-            "columnPhysicalName": { "$ref": "common.v3.schema.json#/$defs/PhysicalName" }
+            "ref": { "$ref": "common.v3.schema.json#/$defs/ViewColumnRef" }
           }
         },
         {
@@ -109,6 +107,24 @@
           "properties": {
             "kind": { "const": "expression" },
             "expression": { "$ref": "common.v3.schema.json#/$defs/ExpressionString" }
+          }
+        },
+        {
+          "description": "拡張 ValueSource。kind は namespace:identifier 形式。固有プロパティは config object に閉じる (loader が extensions.v3.valueSourceKinds[<kind>].schema で検証)。",
+          "type": "object",
+          "required": ["kind"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9_-]*:[a-z][a-zA-Z0-9]*$",
+              "description": "namespace:kindName 形式 (例: 'retail:cartCalculation')"
+            },
+            "config": {
+              "type": "object",
+              "additionalProperties": true,
+              "description": "拡張固有設定。loader が extensions.v3.valueSourceKinds[<kind>].schema で構造を検証。"
+            }
           }
         }
       ]

--- a/schemas/v3/screen-item.v3.schema.json
+++ b/schemas/v3/screen-item.v3.schema.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/csilost2001/html-designer/main/schemas/v3/screen-item.v3.schema.json",
+  "title": "ScreenItem (v3 画面項目定義)",
+  "description": "画面項目 1 件の正規定義。screen.v3.schema.json#/$defs/Screen.items[] から参照される。フォーム入力項目 (direction='input') と表示項目 (direction='output') の双方を表現。",
+  "type": "object",
+  "$ref": "#/$defs/ScreenItem",
+  "$defs": {
+
+    "ScreenItem": {
+      "description": "画面項目 1 件。識別子 (Identifier) は画面内で一意、AI 実装で API key / 変数名としてそのまま使用可能。",
+      "type": "object",
+      "required": ["id", "label", "type"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "common.v3.schema.json#/$defs/Identifier", "description": "画面項目識別子 (camelCase 強制、JS 識別子に直接使用可)。" },
+        "label": { "$ref": "common.v3.schema.json#/$defs/DisplayName" },
+        "type": { "$ref": "common.v3.schema.json#/$defs/FieldType" },
+        "direction": {
+          "type": "string",
+          "enum": ["input", "output"],
+          "description": "input = フォーム入力項目 (既定) / output = 表示専用項目。"
+        },
+        "required": { "type": "boolean" },
+        "readonly": { "type": "boolean" },
+        "disabled": { "type": "boolean" },
+        "minLength": { "type": "integer", "minimum": 0 },
+        "maxLength": { "type": "integer", "minimum": 0 },
+        "min": { "type": "number" },
+        "max": { "type": "number" },
+        "step": { "type": "number" },
+        "pattern": { "type": "string", "description": "正規表現または @conv.regex.<key> 参照。" },
+        "options": {
+          "type": "array",
+          "description": "選択肢 (select / radio / checkbox 用)。静的マスタ。",
+          "items": {
+            "type": "object",
+            "required": ["value", "label"],
+            "additionalProperties": false,
+            "properties": {
+              "value": { "type": "string" },
+              "label": { "$ref": "common.v3.schema.json#/$defs/DisplayName" }
+            }
+          }
+        },
+        "defaultValue": {
+          "description": "既定値。型に応じた primitive または式文字列 (formula で代用も可)。",
+          "type": ["string", "number", "boolean", "null"]
+        },
+        "placeholder": { "type": "string" },
+        "helperText": { "type": "string" },
+        "errorMessages": {
+          "type": "object",
+          "description": "バリデーション NG 時のメッセージ。@conv.msg.<key> 参照推奨。キーは required / minLength / maxLength / invalidFormat / outOfRange / 任意のカスタムコード。",
+          "additionalProperties": { "type": "string" }
+        },
+        "visibleWhen": { "$ref": "common.v3.schema.json#/$defs/ExpressionString", "description": "表示条件式。" },
+        "enabledWhen": { "$ref": "common.v3.schema.json#/$defs/ExpressionString", "description": "活性条件式。" },
+        "displayFormat": {
+          "type": "string",
+          "description": "表示書式 (output 専用)。例: 'YYYY/MM/DD', '¥#,##0', '0.00%'"
+        },
+        "valueFrom": { "$ref": "#/$defs/ValueSource" },
+        "formula": {
+          "$ref": "common.v3.schema.json#/$defs/ExpressionString",
+          "description": "派生計算式 (= で始まる)。output 項目用。"
+        },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      }
+    },
+
+    "ValueSource": {
+      "description": "output 項目のバインド元。discriminated union (kind)。",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["kind", "variableName"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "flowVariable" },
+            "processFlowId": { "$ref": "common.v3.schema.json#/$defs/Uuid", "description": "省略時はカレント画面に紐付く ProcessFlow を解決する。" },
+            "variableName": { "$ref": "common.v3.schema.json#/$defs/Identifier" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "tableId", "columnId"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "tableColumn" },
+            "tableId": { "$ref": "common.v3.schema.json#/$defs/Uuid" },
+            "columnId": { "$ref": "common.v3.schema.json#/$defs/LocalId" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "viewId", "columnPhysicalName"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "viewColumn" },
+            "viewId": { "$ref": "common.v3.schema.json#/$defs/Uuid" },
+            "columnPhysicalName": { "$ref": "common.v3.schema.json#/$defs/PhysicalName" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "expression"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "expression" },
+            "expression": { "$ref": "common.v3.schema.json#/$defs/ExpressionString" }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/schemas/v3/screen-layout.v3.schema.json
+++ b/schemas/v3/screen-layout.v3.schema.json
@@ -11,11 +11,13 @@
     "positions": {
       "type": "object",
       "description": "Screen / ScreenGroup の UUID をキーとし、UI 座標を値とする。",
+      "propertyNames": { "$ref": "common.v3.schema.json#/$defs/Uuid" },
       "additionalProperties": { "$ref": "#/$defs/Position" }
     },
     "transitions": {
       "type": "object",
       "description": "ScreenTransition の LocalId をキーとし、UI 座標 (handle 位置等) を値とする。",
+      "propertyNames": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
       "additionalProperties": { "$ref": "#/$defs/TransitionLayout" }
     },
     "updatedAt": { "$ref": "common.v3.schema.json#/$defs/Timestamp" }

--- a/schemas/v3/screen-layout.v3.schema.json
+++ b/schemas/v3/screen-layout.v3.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/csilost2001/html-designer/main/schemas/v3/screen-layout.v3.schema.json",
+  "title": "ScreenLayout (v3 画面フロー UI 座標)",
+  "description": "画面フロー図 (ReactFlow キャンバス) 上の各画面・グループ・遷移の UI 座標を集約する。Designer (画面フローエディタ) 専用、業務実装には不要。data/screen-layout.json に対応。",
+  "type": "object",
+  "required": ["positions", "updatedAt"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+    "positions": {
+      "type": "object",
+      "description": "Screen / ScreenGroup の UUID をキーとし、UI 座標を値とする。",
+      "additionalProperties": { "$ref": "#/$defs/Position" }
+    },
+    "transitions": {
+      "type": "object",
+      "description": "ScreenTransition の LocalId をキーとし、UI 座標 (handle 位置等) を値とする。",
+      "additionalProperties": { "$ref": "#/$defs/TransitionLayout" }
+    },
+    "updatedAt": { "$ref": "common.v3.schema.json#/$defs/Timestamp" }
+  },
+  "$defs": {
+    "Position": {
+      "type": "object",
+      "required": ["x", "y"],
+      "additionalProperties": false,
+      "properties": {
+        "x": { "type": "number" },
+        "y": { "type": "number" },
+        "width": { "type": "number", "minimum": 0 },
+        "height": { "type": "number", "minimum": 0 },
+        "thumbnail": { "type": "string", "description": "data:image/... の base64 サムネイル。" },
+        "color": { "type": "string", "description": "ScreenGroup の表示色 (#RRGGBB)。" }
+      }
+    },
+    "TransitionLayout": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "sourceHandle": { "type": "string" },
+        "targetHandle": { "type": "string" }
+      }
+    }
+  }
+}

--- a/schemas/v3/screen.v3.schema.json
+++ b/schemas/v3/screen.v3.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/csilost2001/html-designer/main/schemas/v3/screen.v3.schema.json",
+  "title": "Screen (v3 画面定義)",
+  "description": "画面 entity 1 件分の正規定義。業務情報のみを保持し、UI 座標 (position / size / thumbnail) は schemas/v3/screen-layout.v3.schema.json に分離する。GrapesJS の生 HTML データは本 schema の対象外 (data/screens/<id>.html 等で別管理)。",
+  "type": "object",
+  "$ref": "#/$defs/Screen",
+  "$defs": {
+    "Screen": {
+      "description": "画面 entity 本体。EntityMeta + 業務情報 + 画面項目集合 (本ファイル内に embed) + authoring。",
+      "allOf": [
+        { "$ref": "common.v3.schema.json#/$defs/EntityMeta" }
+      ],
+      "type": "object",
+      "required": ["kind", "path"],
+      "properties": {
+        "id": true, "name": true, "description": true, "version": true,
+        "maturity": true, "createdAt": true, "updatedAt": true,
+        "kind": { "$ref": "#/$defs/ScreenKind" },
+        "path": { "type": "string", "description": "URL ルーティングパス。例: '/customers', '/customers/:id', '/orders/new'" },
+        "auth": {
+          "type": "string",
+          "enum": ["required", "optional", "none"],
+          "description": "本画面アクセスに必要な認証要件。未指定は required 相当。"
+        },
+        "groupId": {
+          "$ref": "common.v3.schema.json#/$defs/Uuid",
+          "description": "所属画面グループ ID (project.v3.entities.screenGroups[].id 参照)。"
+        },
+        "items": {
+          "type": "array",
+          "items": { "$ref": "screen-item.v3.schema.json#/$defs/ScreenItem" },
+          "description": "画面項目定義一覧 (フォーム要素・表示要素)。"
+        },
+        "permissions": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "本画面表示に必要な permission キー (@conv.permission.<key>)。"
+        },
+        "design": {
+          "$ref": "#/$defs/ScreenDesign",
+          "description": "画面デザイン (GrapesJS 生 HTML への参照)。本フレームワークの schema 範囲外、外部参照のみ。"
+        },
+        "authoring": { "$ref": "common.v3.schema.json#/$defs/Authoring" }
+      },
+      "unevaluatedProperties": false
+    },
+
+    "ScreenKind": {
+      "description": "画面種別。プリミティブ enum (組み込み 12 種) + 拡張参照。",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["login", "dashboard", "list", "detail", "form", "search", "confirm", "complete", "error", "modal", "wizard", "other"]
+        },
+        {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_-]*:[a-z][a-zA-Z0-9]*$",
+          "description": "拡張 ScreenKind 参照。namespace:kindName 形式 (例: 'retail:storefront')。"
+        }
+      ]
+    },
+
+    "ScreenDesign": {
+      "description": "画面デザイン (GrapesJS) の参照情報。生 HTML/CSS/component tree は別ファイル (data/screens/<id>.design.json) で管理し、本 schema は参照のみ持つ。",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "designFileRef": {
+          "type": "string",
+          "description": "デザインファイルへの相対パス (例: 'design.json')。"
+        },
+        "thumbnailRef": {
+          "type": "string",
+          "description": "サムネイル画像への相対パス または data URL。"
+        }
+      }
+    }
+  }
+}

--- a/schemas/v3/screen.v3.schema.json
+++ b/schemas/v3/screen.v3.schema.json
@@ -14,8 +14,6 @@
       "type": "object",
       "required": ["kind", "path"],
       "properties": {
-        "id": true, "name": true, "description": true, "version": true,
-        "maturity": true, "createdAt": true, "updatedAt": true,
         "kind": { "$ref": "#/$defs/ScreenKind" },
         "path": { "type": "string", "description": "URL ルーティングパス。例: '/customers', '/customers/:id', '/orders/new'" },
         "auth": {

--- a/schemas/v3/sequence.v3.schema.json
+++ b/schemas/v3/sequence.v3.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/csilost2001/html-designer/main/schemas/v3/sequence.v3.schema.json",
+  "title": "Sequence (v3 シーケンス定義)",
+  "description": "DB シーケンス 1 件の定義。data/sequences/<id>.json に対応。@conv.numbering.<key> から参照される。",
+  "type": "object",
+  "$ref": "#/$defs/Sequence",
+  "$defs": {
+    "Sequence": {
+      "allOf": [
+        { "$ref": "common.v3.schema.json#/$defs/EntityMeta" }
+      ],
+      "type": "object",
+      "required": ["physicalName"],
+      "properties": {
+        "id": true, "name": true, "description": true, "version": true,
+        "maturity": true, "createdAt": true, "updatedAt": true,
+        "physicalName": { "$ref": "common.v3.schema.json#/$defs/PhysicalName", "description": "シーケンス物理名 (例: 'seq_order_number')。" },
+        "startValue": { "type": "integer" },
+        "increment": { "type": "integer" },
+        "minValue": { "type": "integer" },
+        "maxValue": { "type": "integer" },
+        "cycle": { "type": "boolean", "description": "true で max 到達後 min に巡回。" },
+        "cache": { "type": "integer", "minimum": 1, "description": "キャッシュサイズ。" },
+        "usedBy": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["tableId", "columnId"],
+            "additionalProperties": false,
+            "properties": {
+              "tableId": { "$ref": "common.v3.schema.json#/$defs/Uuid" },
+              "columnId": { "$ref": "common.v3.schema.json#/$defs/LocalId" }
+            }
+          },
+          "description": "本シーケンスを利用するテーブルカラム参照。"
+        },
+        "conventionRef": {
+          "type": "string",
+          "description": "@conv.numbering.<key> 形式の参照。本シーケンスがどの採番規約を実装するかを示す。"
+        },
+        "authoring": { "$ref": "common.v3.schema.json#/$defs/Authoring" }
+      },
+      "unevaluatedProperties": false
+    }
+  }
+}

--- a/schemas/v3/sequence.v3.schema.json
+++ b/schemas/v3/sequence.v3.schema.json
@@ -13,8 +13,6 @@
       "type": "object",
       "required": ["physicalName"],
       "properties": {
-        "id": true, "name": true, "description": true, "version": true,
-        "maturity": true, "createdAt": true, "updatedAt": true,
         "physicalName": { "$ref": "common.v3.schema.json#/$defs/PhysicalName", "description": "シーケンス物理名 (例: 'seq_order_number')。" },
         "startValue": { "type": "integer" },
         "increment": { "type": "integer" },
@@ -24,16 +22,8 @@
         "cache": { "type": "integer", "minimum": 1, "description": "キャッシュサイズ。" },
         "usedBy": {
           "type": "array",
-          "items": {
-            "type": "object",
-            "required": ["tableId", "columnId"],
-            "additionalProperties": false,
-            "properties": {
-              "tableId": { "$ref": "common.v3.schema.json#/$defs/Uuid" },
-              "columnId": { "$ref": "common.v3.schema.json#/$defs/LocalId" }
-            }
-          },
-          "description": "本シーケンスを利用するテーブルカラム参照。"
+          "items": { "$ref": "common.v3.schema.json#/$defs/TableColumnRef" },
+          "description": "本シーケンスを利用するテーブルカラム参照。common.v3 の TableColumnRef に統一 (Pattern B 複合参照)。"
         },
         "conventionRef": {
           "type": "string",

--- a/schemas/v3/table.v3.schema.json
+++ b/schemas/v3/table.v3.schema.json
@@ -1,0 +1,233 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/csilost2001/html-designer/main/schemas/v3/table.v3.schema.json",
+  "title": "Table (v3 テーブル定義)",
+  "description": "テーブル entity 1 件分の正規定義。EntityMeta + 物理名 + カラム + 制約 + インデックス + DEFAULT + トリガー + コメント + authoring。FK は ConstraintDefinition に集約 (TableColumn に inline foreignKey は持たない)。",
+  "type": "object",
+  "$ref": "#/$defs/Table",
+  "$defs": {
+
+    "Table": {
+      "allOf": [
+        { "$ref": "common.v3.schema.json#/$defs/EntityMeta" }
+      ],
+      "type": "object",
+      "required": ["physicalName", "columns"],
+      "properties": {
+        "id": true, "name": true, "description": true, "version": true,
+        "maturity": true, "createdAt": true, "updatedAt": true,
+        "physicalName": { "$ref": "common.v3.schema.json#/$defs/PhysicalName", "description": "DB 物理名 (snake_case)。例: 'users', 'order_items'" },
+        "category": { "type": "string", "description": "テーブルカテゴリ (例: 'マスタ', 'トランザクション', '中間テーブル', 'ログ', '設定', 'その他')。" },
+        "comment": { "type": "string", "description": "DDL レベルのテーブルコメント (DB に COMMENT として出力)。" },
+        "columns": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/Column" }
+        },
+        "indexes": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Index" }
+        },
+        "constraints": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Constraint" }
+        },
+        "defaults": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/DefaultDefinition" }
+        },
+        "triggers": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/TriggerDefinition" }
+        },
+        "authoring": { "$ref": "common.v3.schema.json#/$defs/Authoring" }
+      },
+      "unevaluatedProperties": false
+    },
+
+    "Column": {
+      "description": "カラム 1 件。physicalName (snake_case) と name (表示名、自由) を分離。",
+      "type": "object",
+      "required": ["id", "physicalName", "name", "dataType"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
+        "no": { "type": "integer", "minimum": 1, "description": "物理順 (1..N)。" },
+        "physicalName": { "$ref": "common.v3.schema.json#/$defs/PhysicalName" },
+        "name": { "$ref": "common.v3.schema.json#/$defs/DisplayName", "description": "表示名 (例: 'ユーザーID', 'ログインID')。" },
+        "dataType": { "$ref": "#/$defs/DataType" },
+        "length": { "type": "integer", "minimum": 0, "description": "VARCHAR / CHAR / DECIMAL の長さ。" },
+        "scale": { "type": "integer", "minimum": 0, "description": "DECIMAL のスケール (小数桁)。" },
+        "notNull": { "type": "boolean" },
+        "primaryKey": { "type": "boolean" },
+        "unique": { "type": "boolean" },
+        "autoIncrement": { "type": "boolean" },
+        "defaultValue": { "type": "string", "description": "DDL DEFAULT 句に出す値 (リテラル / 関数式)。" },
+        "comment": { "type": "string", "description": "DDL カラムコメント。" },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      }
+    },
+
+    "DataType": {
+      "description": "DB データ型。SQL 業界慣習に従い UPPER。プリミティブ enum + 拡張参照。",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["VARCHAR", "CHAR", "TEXT", "INTEGER", "BIGINT", "SMALLINT", "DECIMAL", "FLOAT", "BOOLEAN", "DATE", "TIME", "TIMESTAMP", "BLOB", "JSON"]
+        },
+        {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_-]*:[A-Z][A-Z0-9_]*$",
+          "description": "拡張 DataType 参照。namespace:DATA_TYPE 形式 (例: 'oracle:VARCHAR2', 'postgres:JSONB')。"
+        }
+      ]
+    },
+
+    "Index": {
+      "type": "object",
+      "required": ["id", "physicalName", "columns"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
+        "physicalName": { "$ref": "common.v3.schema.json#/$defs/PhysicalName", "description": "インデックス物理名 (例: 'idx_users_email')。" },
+        "columns": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": ["columnId"],
+            "additionalProperties": false,
+            "properties": {
+              "columnId": { "$ref": "common.v3.schema.json#/$defs/LocalId", "description": "Column.id (LocalId) を参照。" },
+              "order": { "type": "string", "enum": ["asc", "desc"] }
+            }
+          }
+        },
+        "unique": { "type": "boolean" },
+        "method": {
+          "type": "string",
+          "enum": ["btree", "hash", "gin", "gist"],
+          "description": "インデックスアルゴリズム。"
+        },
+        "where": { "type": "string", "description": "Partial Index の WHERE 句。" },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      }
+    },
+
+    "Constraint": {
+      "description": "テーブル制約。kind による discriminated union (unique / check / foreignKey)。",
+      "oneOf": [
+        { "$ref": "#/$defs/UniqueConstraint" },
+        { "$ref": "#/$defs/CheckConstraint" },
+        { "$ref": "#/$defs/ForeignKeyConstraint" }
+      ]
+    },
+
+    "UniqueConstraint": {
+      "type": "object",
+      "required": ["id", "kind", "columnIds"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
+        "kind": { "const": "unique" },
+        "physicalName": { "$ref": "common.v3.schema.json#/$defs/PhysicalName" },
+        "columnIds": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "common.v3.schema.json#/$defs/LocalId" }
+        },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      }
+    },
+
+    "CheckConstraint": {
+      "type": "object",
+      "required": ["id", "kind", "expression"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
+        "kind": { "const": "check" },
+        "physicalName": { "$ref": "common.v3.schema.json#/$defs/PhysicalName" },
+        "expression": { "type": "string", "description": "SQL CHECK 式 (例: 'price > 0', 'status IN (\\'active\\', \\'inactive\\')')。" },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      }
+    },
+
+    "ForeignKeyConstraint": {
+      "description": "外部キー制約。単一カラム / 複合カラムを統一表現。referencedTableId は Uuid (物理名直書きは廃止)。",
+      "type": "object",
+      "required": ["id", "kind", "columnIds", "referencedTableId", "referencedColumnIds"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
+        "kind": { "const": "foreignKey" },
+        "physicalName": { "$ref": "common.v3.schema.json#/$defs/PhysicalName" },
+        "columnIds": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
+          "description": "本テーブルの Column.id 配列。"
+        },
+        "referencedTableId": { "$ref": "common.v3.schema.json#/$defs/Uuid", "description": "参照先 Table の Uuid。" },
+        "referencedColumnIds": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
+          "description": "参照先 Column.id 配列。"
+        },
+        "onDelete": { "$ref": "#/$defs/FkAction" },
+        "onUpdate": { "$ref": "#/$defs/FkAction" },
+        "noConstraint": {
+          "type": "boolean",
+          "description": "true なら DDL に FK 制約を出力しない (論理 FK のみ、ER 図表示用)。"
+        },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      }
+    },
+
+    "FkAction": {
+      "description": "FK 違反時のアクション。lowerCamelCase 統一 (v1 の 'NO ACTION' / 'SET NULL' のスペース含み廃止)。",
+      "type": "string",
+      "enum": ["cascade", "setNull", "setDefault", "restrict", "noAction"]
+    },
+
+    "DefaultDefinition": {
+      "description": "カラム DEFAULT 値の構造化定義。Column.defaultValue の代替として使用可。",
+      "type": "object",
+      "required": ["columnId", "kind", "value"],
+      "additionalProperties": false,
+      "properties": {
+        "columnId": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
+        "kind": {
+          "type": "string",
+          "enum": ["literal", "function", "sequence", "convention"],
+          "description": "literal=リテラル / function=DB 関数 (NOW() 等) / sequence=シーケンス参照 / convention=@conv.numbering.<key> 参照。"
+        },
+        "value": { "type": "string" },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      }
+    },
+
+    "TriggerDefinition": {
+      "type": "object",
+      "required": ["id", "physicalName", "timing", "events", "body"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
+        "physicalName": { "$ref": "common.v3.schema.json#/$defs/PhysicalName" },
+        "timing": {
+          "type": "string",
+          "enum": ["BEFORE", "AFTER", "INSTEAD_OF"]
+        },
+        "events": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "enum": ["INSERT", "UPDATE", "DELETE", "TRUNCATE"] }
+        },
+        "whenCondition": { "type": "string", "description": "WHEN 句 (省略可)。" },
+        "body": { "type": "string", "description": "トリガー本体 (PL/pgSQL 等の DB 方言依存)。" },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      }
+    }
+  }
+}

--- a/schemas/v3/table.v3.schema.json
+++ b/schemas/v3/table.v3.schema.json
@@ -14,8 +14,6 @@
       "type": "object",
       "required": ["physicalName", "columns"],
       "properties": {
-        "id": true, "name": true, "description": true, "version": true,
-        "maturity": true, "createdAt": true, "updatedAt": true,
         "physicalName": { "$ref": "common.v3.schema.json#/$defs/PhysicalName", "description": "DB 物理名 (snake_case)。例: 'users', 'order_items'" },
         "category": { "type": "string", "description": "テーブルカテゴリ (例: 'マスタ', 'トランザクション', '中間テーブル', 'ログ', '設定', 'その他')。" },
         "comment": { "type": "string", "description": "DDL レベルのテーブルコメント (DB に COMMENT として出力)。" },

--- a/schemas/v3/view.v3.schema.json
+++ b/schemas/v3/view.v3.schema.json
@@ -13,8 +13,6 @@
       "type": "object",
       "required": ["physicalName", "selectStatement", "outputColumns"],
       "properties": {
-        "id": true, "name": true, "description": true, "version": true,
-        "maturity": true, "createdAt": true, "updatedAt": true,
         "physicalName": { "$ref": "common.v3.schema.json#/$defs/PhysicalName", "description": "ビュー物理名。" },
         "selectStatement": { "type": "string", "description": "ビューを定義する SELECT 文 (DB 方言依存)。" },
         "outputColumns": {

--- a/schemas/v3/view.v3.schema.json
+++ b/schemas/v3/view.v3.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/csilost2001/html-designer/main/schemas/v3/view.v3.schema.json",
+  "title": "View (v3 ビュー定義)",
+  "description": "DB ビュー 1 件の定義。data/views/<id>.json に対応。SELECT 文 + 出力カラム定義 + 依存テーブル/ビュー。",
+  "type": "object",
+  "$ref": "#/$defs/View",
+  "$defs": {
+    "View": {
+      "allOf": [
+        { "$ref": "common.v3.schema.json#/$defs/EntityMeta" }
+      ],
+      "type": "object",
+      "required": ["physicalName", "selectStatement", "outputColumns"],
+      "properties": {
+        "id": true, "name": true, "description": true, "version": true,
+        "maturity": true, "createdAt": true, "updatedAt": true,
+        "physicalName": { "$ref": "common.v3.schema.json#/$defs/PhysicalName", "description": "ビュー物理名。" },
+        "selectStatement": { "type": "string", "description": "ビューを定義する SELECT 文 (DB 方言依存)。" },
+        "outputColumns": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/OutputColumn" }
+        },
+        "dependencies": {
+          "type": "array",
+          "description": "依存する Table / View entity の Uuid 一覧。",
+          "items": { "$ref": "common.v3.schema.json#/$defs/Uuid" }
+        },
+        "materialized": {
+          "type": "boolean",
+          "description": "true でマテリアライズドビュー。"
+        },
+        "authoring": { "$ref": "common.v3.schema.json#/$defs/Authoring" }
+      },
+      "unevaluatedProperties": false
+    },
+
+    "OutputColumn": {
+      "type": "object",
+      "required": ["physicalName", "dataType"],
+      "additionalProperties": false,
+      "properties": {
+        "physicalName": { "$ref": "common.v3.schema.json#/$defs/PhysicalName" },
+        "name": { "$ref": "common.v3.schema.json#/$defs/DisplayName" },
+        "dataType": { "$ref": "table.v3.schema.json#/$defs/DataType" },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 関連

- Closes #521
- 派生元: #519 (PR #520 マージ済 — v2 機械変換版)
- 設計原則: #517 (PR #518 マージ済)
- 設計記録: `docs/spec/schema-v3-design.md` (commit 47653cc、本 PR 同梱)

## 概要

ユーザー指示「実装はどうでもいい、スキーマを全種類の設計書横断で見直せ」「既存の焼き直しは要らん、一から作れ」に対応した v3 schema 群。

**v1 / v2 を base にせず、業務概念から一から書いた**。Sonnet/Codex には一切委譲していない。

## 範囲 (schema only)

| 領域 | スコープ |
|---|---|
| schemas/v3/ 13 ファイル新規 | ✅ 本 PR |
| 設計記録 (schema-v3-design.md) | ✅ 本 PR |
| TS 型同期 / sample 移行 / validator 切替 / UI 同期 | ❌ 別 PR (実装は本件スコープ外) |

## 新規 schemas/v3/ ファイル (13 件、約 3280 行)

| ファイル | 行数 | 役割 |
|---|---|---|
| common.v3.schema.json | 464 | 共通基盤 (\$defs 30+) — Uuid / LocalId / Identifier / PhysicalName / EntityMeta / Authoring / FieldType / StructuredField / Marker / DecisionRecord / GlossaryEntry / Note / 各種 Ref / ExtensionRoot 等 |
| project.v3.schema.json | 162 | プロジェクト root |
| screen.v3.schema.json | 80 | 画面 (業務情報のみ、UI 座標は別 schema) |
| screen-layout.v3.schema.json | 46 | 画面フロー UI 座標 (Designer 専用) |
| screen-item.v3.schema.json | 117 | 画面項目 (id は Identifier 強制) |
| table.v3.schema.json | 233 | テーブル (physicalName と name 分離、Constraint discriminated union) |
| er-layout.v3.schema.json | 51 | ER 図 UI 座標 + 論理リレーション |
| sequence.v3.schema.json | 47 | DB シーケンス |
| view.v3.schema.json | 51 | DB ビュー |
| custom-block.v3.schema.json | 25 | カスタムブロック (id を Uuid 強制) |
| process-flow.v3.schema.json | **1439** | **処理フロー — root を meta / context / body / authoring の 4 セクション化、catalogs を context.catalogs.<kind> に階層化、22 種 Step variant + ExtensionStep** |
| conventions.v3.schema.json | 298 | 横断規約 catalog |
| extensions.v3.schema.json | 267 | **統合拡張定義** — 1 namespace = 1 ファイルで全種類 (fieldTypes / dataTypes / screenKinds / actionTriggers / dbOperations / stepKinds / responseTypes / valueSourceKinds / columnTemplates / constraintPatterns / conventionCategories) を集約 |
| README.md | (一覧) | v3 構造ガイド |

## v3 横断的設計判断 (Opus が一から下した 11 件)

1. **EntityMeta mix-in** を common.v3 に集約 — 全 top-level entity の id/name/createdAt/updatedAt/version/maturity を 1 箇所で定義
2. **参照規範 4 パターン統一** (UUID 単独 / 複合 Ref / catalog key / 式言語) — anti-pattern (物理名で entity 指定 / id+name 重複) を全廃
3. **FieldType を common.v3 に集約** — ProcessFlow と ScreenItem で別定義していたものを統一、業界拡張は \`kind: 'extension'\` で表現
4. **TableColumn.foreignKey 削除** → ConstraintDefinition に集約、referencedTable を referencedTableId (Uuid)
5. **ProcessFlow root を 4 セクション化** (meta / context / body / authoring) — 30+ 並列プロパティを意味付け、catalogs を context.catalogs.<kind> に階層化
6. **screen.v3 と screen-layout.v3 分離** — UI 座標と業務情報を分離 (AI 実装者が UI 座標を読まなくて済む)
7. **Marker / DecisionRecord / GlossaryEntry / Note を common.v3 共通化** — ProcessFlow 専用から全領域共通化、各 entity の authoring セクションで使用可
8. **拡張機構を 1 ファイル統合** (extensions.v3.schema.json) — \`data/extensions/<namespace>.v3.json\` 1 ファイル運用 (旧 v2 では 10 ファイル分散)
9. **project.v3 に extensionsApplied** — 全 editor が同一 loader で合成 schema
10. **enum 命名規範を文書化** (UPPER 維持系 / lowerCamelCase 統一系)
11. **TableDefinition / TableColumn の name (表示名) と physicalName (DB 物理名) 分離** — 3 種の業務識別子規範 (Identifier / PhysicalName / DisplayName) を全領域で一貫

## 廃止 (v1/v2 から、ユーザー承認済み破壊的変更)

- string union 6 箇所 → structured 必須
- 旧 \`note: string\` → \`notes: Note[]\`
- \`FieldType.custom\` (deprecated) 削除
- \`ExternalSystemStep.protocol\` (deprecated) 削除
- \`TableColumn.foreignKey\` inline 表現削除
- \`ConstraintDefinition.referencedTable\` (物理名) → \`referencedTableId\` (Uuid)
- \`tableId + tableName\` 併記廃止 (id のみ)
- ProcessFlow root 並列プロパティ → 4 セクション化
- 10 個の extensions schema → 1 ファイル統合
- ScreenNode UI 座標 → 別 schema
- \`FkAction\` の \"NO ACTION\" → \"noAction\"
- \`ValidationRuleKind\` の \"Error\" → \"error\"
- \`WorkflowQuorum.type\` の \"n-of-m\" → \"nOfM\"
- \`CustomBlock.id\` の timestamp 形式 → Uuid 強制
- StepBaseProps 二重列挙 → \`unevaluatedProperties: false\` で構造的解消

## 検証

- 全 13 ファイル valid JSON
- 文字化けゼロ (Python regex で \`\?{3,}\` 検出ゼロ)
- v1/v2 既存ファイル変更なし

## ガバナンス

設計者 (ユーザー) 明示指示による §7 例外規定で進行。AI による勝手拡張ではない。

## レビュー観点

1. **横断的整合性** — common.v3 への \$ref が各領域 schema で正しく使われているか
2. **参照パターン 4 種** が一貫適用されているか
3. **ProcessFlow root 4 セクション化** が業務概念を素直に表現できているか
4. **拡張機構 1 ファイル統合** が namespace 運用と整合するか
5. **FieldType / Marker / DecisionRecord 等の共通化** が正しく行われたか

## 別 ISSUE 候補 (本 PR マージ後)

- TS 型同期 (designer/src/types/ を v3 に揃える)
- sample 4 件を v3 化 (data/process-flows/, data/screens/ 等)
- validator 切替 (referentialIntegrity / sqlColumnValidator / loadExtensions / conventionsValidator)
- UI コンポーネント v3 同期
- spec 文書 14 件の v3 反映

これらは本 PR スコープ外、実装フェーズで段階的に対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)