### PR TITLE
feat(dogfood): schema v3 を manufacturing で再検証 — R3-1/R3-2/R3-3 検出 (#529 Round 3)

### DIFF
--- a/designer/src/schemas/v3-samples.test.ts
+++ b/designer/src/schemas/v3-samples.test.ts
@@ -18,6 +18,9 @@ let validateScreen: ValidateFunction;
 let validateTable: ValidateFunction;
 let validateProcessFlow: ValidateFunction;
 let validateExtension: ValidateFunction;
+let validateSequence: ValidateFunction;
+let validateScreenLayout: ValidateFunction;
+let validateErLayout: ValidateFunction;
 
 beforeAll(() => {
   ajv = new Ajv2020({ allErrors: true, strict: false, discriminator: true });
@@ -29,6 +32,9 @@ beforeAll(() => {
   validateTable = ajv.compile(loadJson(join(v3Dir, "table.v3.schema.json")) as object);
   validateProcessFlow = ajv.compile(loadJson(join(v3Dir, "process-flow.v3.schema.json")) as object);
   validateExtension = ajv.compile(loadJson(join(v3Dir, "extensions.v3.schema.json")) as object);
+  validateSequence = ajv.compile(loadJson(join(v3Dir, "sequence.v3.schema.json")) as object);
+  validateScreenLayout = ajv.compile(loadJson(join(v3Dir, "screen-layout.v3.schema.json")) as object);
+  validateErLayout = ajv.compile(loadJson(join(v3Dir, "er-layout.v3.schema.json")) as object);
 });
 
 function dumpErrors(file: string, validate: ValidateFunction): string {
@@ -46,10 +52,11 @@ function listJsonRecursive(dir: string): string[] {
 }
 
 describe("schema v3 dogfood samples (#523 retail + #527 finance)", () => {
-  it("project.json (retail + finance) validates against project.v3.schema.json", () => {
+  it("project.json (retail + finance + manufacturing) validates against project.v3.schema.json", () => {
     const files = [
       join(samplesV3Dir, "project.json"),
       join(samplesV3Dir, "finance", "project.json"),
+      join(samplesV3Dir, "manufacturing", "project.json"),
     ];
     for (const file of files) {
       const data = loadJson(file);
@@ -59,10 +66,10 @@ describe("schema v3 dogfood samples (#523 retail + #527 finance)", () => {
   });
 
   it("table samples validate against table.v3.schema.json", () => {
-    // retail (top-level tables/) + finance (finance/tables/) を網羅
     const files = [
       ...listJsonRecursive(join(samplesV3Dir, "tables")),
       ...listJsonRecursive(join(samplesV3Dir, "finance", "tables")),
+      ...listJsonRecursive(join(samplesV3Dir, "manufacturing", "tables")),
     ];
     expect(files.length).toBeGreaterThan(0);
     for (const file of files) {
@@ -76,6 +83,7 @@ describe("schema v3 dogfood samples (#523 retail + #527 finance)", () => {
     const files = [
       ...listJsonRecursive(join(samplesV3Dir, "screens")),
       ...listJsonRecursive(join(samplesV3Dir, "finance", "screens")),
+      ...listJsonRecursive(join(samplesV3Dir, "manufacturing", "screens")),
     ];
     expect(files.length).toBeGreaterThan(0);
     for (const file of files) {
@@ -89,6 +97,7 @@ describe("schema v3 dogfood samples (#523 retail + #527 finance)", () => {
     const files = [
       ...listJsonRecursive(join(samplesV3Dir, "process-flows")),
       ...listJsonRecursive(join(samplesV3Dir, "finance", "process-flows")),
+      ...listJsonRecursive(join(samplesV3Dir, "manufacturing", "process-flows")),
     ];
     expect(files.length).toBeGreaterThan(0);
     for (const file of files) {
@@ -98,10 +107,36 @@ describe("schema v3 dogfood samples (#523 retail + #527 finance)", () => {
     }
   });
 
+  it("screen-layout sample validates against screen-layout.v3.schema.json (#529 R3)", () => {
+    const file = join(samplesV3Dir, "manufacturing", "layouts", "screen-layout.json");
+    const data = loadJson(file);
+    const ok = validateScreenLayout(data);
+    expect(ok, ok ? "" : dumpErrors(file, validateScreenLayout)).toBe(true);
+  });
+
+  it("er-layout sample validates against er-layout.v3.schema.json (#529 R3)", () => {
+    const file = join(samplesV3Dir, "manufacturing", "layouts", "er-layout.json");
+    const data = loadJson(file);
+    const ok = validateErLayout(data);
+    expect(ok, ok ? "" : dumpErrors(file, validateErLayout)).toBe(true);
+  });
+
+  it("sequence samples validate against sequence.v3.schema.json", () => {
+    const dir = join(samplesV3Dir, "manufacturing", "sequences");
+    const files = listJsonRecursive(dir);
+    expect(files.length).toBeGreaterThan(0);
+    for (const file of files) {
+      const data = loadJson(file);
+      const ok = validateSequence(data);
+      expect(ok, ok ? "" : dumpErrors(file, validateSequence)).toBe(true);
+    }
+  });
+
   it("extension samples validate against extensions.v3.schema.json", () => {
     const files = [
       ...listJsonRecursive(join(samplesV3Dir, "extensions")),
       ...listJsonRecursive(join(samplesV3Dir, "finance", "extensions")),
+      ...listJsonRecursive(join(samplesV3Dir, "manufacturing", "extensions")),
     ];
     expect(files.length).toBeGreaterThan(0);
     for (const file of files) {

--- a/docs/sample-project-v3/manufacturing/extensions/manufacturing.v3.json
+++ b/docs/sample-project-v3/manufacturing/extensions/manufacturing.v3.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "../../../../schemas/v3/extensions.v3.schema.json",
+  "namespace": "manufacturing",
+  "version": "1.0.0",
+  "requiresCoreSchema": ">=3.0.0",
+  "description": "製造業 (manufacturing) namespace の v3 拡張定義。BOM 展開・MRP・品質管理・設備保全の業務概念を集約。Round 1 (retail) / Round 2 (finance) と並ぶ第 3 業界。",
+  "fieldTypes": [
+    { "kind": "itemCode", "label": "品目コード", "baseType": "string", "description": "I + 9 桁数字。" },
+    { "kind": "productionOrderNumber", "label": "製造指示番号", "baseType": "string", "description": "PO-YYYYMMDD-NNNNNN。" },
+    { "kind": "lotNumber", "label": "ロット番号", "baseType": "string", "description": "L + YYYYMMDD + 3 桁連番。" },
+    { "kind": "bomQuantity", "label": "BOM数量", "baseType": "number", "description": "親 1 単位あたり所要数量、scrap_factor 適用前。" },
+    { "kind": "qualityGrade", "label": "品質等級", "baseType": "string", "description": "A / B / C / 不合格。" }
+  ],
+  "actionTriggers": [
+    {
+      "value": "productionOrderRequested",
+      "label": "製造指示依頼",
+      "description": "MRP / 計画担当者から製造指示作成リクエストが入った時。"
+    },
+    {
+      "value": "monthlyClosingScheduled",
+      "label": "月次締めスケジュール",
+      "description": "月末日 23:55 cron で自動起動 (ProcessFlow.meta.kind='scheduled' 連動)。"
+    }
+  ],
+  "dbOperations": [
+    {
+      "value": "BOM_EXPAND",
+      "label": "BOM 展開",
+      "description": "親品目から再帰的に子品目を展開し、所要量を集計する SELECT (CTE recursive)。"
+    },
+    {
+      "value": "INVENTORY_SNAPSHOT_INSERT",
+      "label": "在庫スナップショット作成",
+      "description": "現時点の inventory 全行を inventory_snapshots に bulk INSERT (月次締め用)。"
+    }
+  ],
+  "stepKinds": {
+    "BomExplodeStep": {
+      "label": "BOM 展開",
+      "icon": "Package",
+      "description": "親品目とその子品目を再帰的に展開し、所要量 (quantity_per_parent × 1+scrap_factor × 計画数) を集計する。",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "productItemId": { "type": "string", "description": "展開する親品目の id (Uuid)。" },
+          "plannedQuantity": { "type": "number" },
+          "maxDepth": { "type": "integer", "default": 10, "description": "再帰深さ上限 (循環参照防御)。" },
+          "outputBindingName": { "type": "string", "default": "bomComponents" }
+        },
+        "required": ["productItemId", "plannedQuantity"],
+        "additionalProperties": false
+      }
+    },
+    "QualityCheckStep": {
+      "label": "品質検査",
+      "icon": "ShieldCheck",
+      "description": "完成品ロットに対する抽出検査。不良数 / サンプル数で品質判定し quality_inspections に記録。",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "productionOrderId": { "type": "string" },
+          "samplePolicy": { "type": "string", "enum": ["fixed", "percent", "aql"], "description": "fixed=固定数 / percent=完成数の n% / aql=AQL 表に従う。" },
+          "sampleSize": { "type": "integer" }
+        },
+        "required": ["productionOrderId", "samplePolicy"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "responseTypes": {
+    "ProductionOrderResponse": {
+      "schema": {
+        "type": "object",
+        "required": ["orderNumber", "status", "componentCount"],
+        "properties": {
+          "orderNumber": { "type": "string" },
+          "status": { "type": "string" },
+          "componentCount": { "type": "integer" },
+          "scheduledStartAt": { "type": "string" }
+        }
+      }
+    },
+    "ClosingResponse": {
+      "schema": {
+        "type": "object",
+        "required": ["closingDate", "snapshotCount"],
+        "properties": {
+          "closingDate": { "type": "string" },
+          "snapshotCount": { "type": "integer" },
+          "totalValuation": { "type": "number" }
+        }
+      }
+    },
+    "ApiError": {
+      "schema": {
+        "type": "object",
+        "required": ["code", "message"],
+        "properties": {
+          "code": { "type": "string" },
+          "message": { "type": "string" }
+        }
+      }
+    }
+  },
+  "conventionCategories": [
+    {
+      "categoryName": "manufacturingLimit",
+      "label": "製造業限度値",
+      "description": "BOM 再帰深さ上限・1 ロット最大数・品質検査閾値など。",
+      "entrySchema": {
+        "type": "object",
+        "required": ["value", "unit"],
+        "properties": {
+          "value": { "type": "number" },
+          "unit": { "type": "string" },
+          "description": { "type": "string" }
+        }
+      }
+    }
+  ]
+}

--- a/docs/sample-project-v3/manufacturing/layouts/er-layout.json
+++ b/docs/sample-project-v3/manufacturing/layouts/er-layout.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "../../../../schemas/v3/er-layout.v3.schema.json",
+  "positions": {
+    "38d3788e-092b-4fc4-8b97-ca359981d987": { "x": 0, "y": 0 },
+    "67ec6e96-74fe-4c75-889f-ddb0bbbc577f": { "x": 400, "y": 200 },
+    "81f7dcd2-11ac-4929-8f82-a2f1ad809e68": { "x": 0, "y": 400 },
+    "b85f3668-a0f8-4a84-ae99-7424ffd7ef85": { "x": 800, "y": 0 },
+    "eb2b1bf1-270c-439c-b506-21e8b858983b": { "x": 400, "y": 600 }
+  },
+  "logicalRelations": [
+    {
+      "id": "lr-bom-self",
+      "sourceTableId": "67ec6e96-74fe-4c75-889f-ddb0bbbc577f",
+      "sourceColumnId": "col-bm02",
+      "targetTableId": "38d3788e-092b-4fc4-8b97-ca359981d987",
+      "targetColumnId": "col-it01",
+      "cardinality": "many-to-many",
+      "label": "BOM は items を多対多で参照 (parent + child)"
+    }
+  ],
+  "updatedAt": "2026-04-28T00:00:00.000Z"
+}

--- a/docs/sample-project-v3/manufacturing/layouts/screen-layout.json
+++ b/docs/sample-project-v3/manufacturing/layouts/screen-layout.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../../../../schemas/v3/screen-layout.v3.schema.json",
+  "positions": {
+    "67cf4447-cff1-4402-ac73-816cf4fe4ca2": {
+      "x": 100,
+      "y": 100,
+      "width": 320,
+      "height": 240
+    }
+  },
+  "updatedAt": "2026-04-28T00:00:00.000Z"
+}

--- a/docs/sample-project-v3/manufacturing/process-flows/8210362d-c149-4963-bc6e-9512fe18e465.json
+++ b/docs/sample-project-v3/manufacturing/process-flows/8210362d-c149-4963-bc6e-9512fe18e465.json
@@ -1,0 +1,351 @@
+{
+  "$schema": "../../../../schemas/v3/process-flow.v3.schema.json",
+  "meta": {
+    "id": "8210362d-c149-4963-bc6e-9512fe18e465",
+    "name": "製造指示生成 (製造業)",
+    "description": "製品コード + 計画数量 + スケジュールから、(1) 製品の存在検証、(2) BOM 展開 (LoopStep collection mode で BOM 行を反復、所要量集計)、(3) production_orders に INSERT (Sequence 採番)、(4) production_order_components (省略) に bulk INSERT を実施。",
+    "version": "1.0.0",
+    "maturity": "committed",
+    "createdAt": "2026-04-28T00:00:00.000Z",
+    "updatedAt": "2026-04-28T00:00:00.000Z",
+    "kind": "screen",
+    "screenId": "67cf4447-cff1-4402-ac73-816cf4fe4ca2",
+    "apiVersion": "v1",
+    "mode": "upstream",
+    "sla": {
+      "timeoutMs": 15000,
+      "onTimeout": "throw",
+      "errorCode": "PRODUCTION_ORDER_TIMEOUT"
+    }
+  },
+  "context": {
+    "catalogs": {
+      "errors": {
+        "VALIDATION": { "httpStatus": 400, "defaultMessage": "入力値が不正です", "responseId": "400-validation" },
+        "ITEM_NOT_FOUND": { "httpStatus": 404, "defaultMessage": "品目が見つかりません", "responseId": "404-item-not-found" },
+        "BOM_NOT_DEFINED": { "httpStatus": 422, "defaultMessage": "BOM が定義されていません", "responseId": "422-bom-not-defined" },
+        "BOM_RECURSION_LIMIT": { "httpStatus": 422, "defaultMessage": "BOM 再帰深さ上限超過 (循環参照の可能性)", "responseId": "422-bom-recursion" },
+        "PRODUCTION_ORDER_TIMEOUT": { "httpStatus": 504, "defaultMessage": "処理タイムアウト", "responseId": "504-timeout" },
+        "INTERNAL_ERROR": { "httpStatus": 500, "defaultMessage": "内部エラー", "responseId": "500-internal-error" }
+      },
+      "domains": {
+        "ItemCode": {
+          "type": "string",
+          "uiHint": "text",
+          "constraints": [
+            { "field": "itemCode", "type": "regex", "patternRef": "@conv.regex.item-code", "message": "品目コードは I + 9 桁数字" }
+          ]
+        }
+      },
+      "functions": {
+        "calculateRequiredQuantity": {
+          "signature": "calculateRequiredQuantity(quantityPerParent: number, scrapFactor: number, plannedQuantity: number): number",
+          "returnType": "number",
+          "description": "BOM の所要量計算: quantityPerParent × (1 + scrapFactor) × plannedQuantity",
+          "examples": [
+            "@fn.calculateRequiredQuantity(@bomRow.quantity_per_parent, @bomRow.scrap_factor, @inputs.plannedQuantity)"
+          ]
+        }
+      },
+      "events": {
+        "manufacturing.production_order_created": {
+          "description": "製造指示作成完了時。MRP / 在庫予約システムが消費。",
+          "payload": {
+            "type": "object",
+            "required": ["orderNumber", "productItemCode", "plannedQuantity"],
+            "properties": {
+              "orderNumber": { "type": "string" },
+              "productItemCode": { "type": "string" },
+              "plannedQuantity": { "type": "number" },
+              "componentCount": { "type": "integer" }
+            },
+            "additionalProperties": false
+          }
+        }
+      }
+    },
+    "ambientVariables": [
+      { "name": "requestId", "type": "string", "required": true },
+      { "name": "sessionUserId", "type": "string", "required": true }
+    ]
+  },
+  "actions": [
+    {
+      "id": "act-001",
+      "name": "製造指示生成",
+      "trigger": "submit",
+      "description": "BOM 展開 + 製造指示 INSERT + 部品所要量計算",
+      "maturity": "committed",
+      "httpRoute": { "method": "POST", "path": "/api/manufacturing/production-orders", "auth": "required" },
+      "requiredPermissions": ["@conv.permission.production.create"],
+      "inputs": [
+        { "name": "productItemCode", "label": "製品コード", "type": { "kind": "domain", "domainKey": "ItemCode" }, "required": true },
+        { "name": "plannedQuantity", "label": "計画数量", "type": "number", "required": true },
+        { "name": "scheduledStartAt", "label": "計画開始日時", "type": "datetime", "required": true },
+        { "name": "scheduledEndAt", "label": "計画完了日時", "type": "datetime", "required": true }
+      ],
+      "outputs": [
+        { "name": "orderNumber", "label": "指示番号", "type": "string" },
+        { "name": "componentCount", "label": "部品数", "type": "integer" }
+      ],
+      "responses": [
+        { "id": "200-ok", "status": 200, "bodySchema": { "typeRef": "manufacturing:ProductionOrderResponse" }, "when": "製造指示作成完了" },
+        { "id": "400-validation", "status": 400, "bodySchema": { "typeRef": "manufacturing:ApiError" }, "when": "入力値不正" },
+        { "id": "404-item-not-found", "status": 404, "bodySchema": { "typeRef": "manufacturing:ApiError" }, "when": "品目なし" },
+        { "id": "422-bom-not-defined", "status": 422, "bodySchema": { "typeRef": "manufacturing:ApiError" }, "when": "BOM 未定義" },
+        { "id": "422-bom-recursion", "status": 422, "bodySchema": { "typeRef": "manufacturing:ApiError" }, "when": "BOM 再帰深さ上限超過" },
+        { "id": "500-internal-error", "status": 500, "bodySchema": { "typeRef": "manufacturing:ApiError" }, "when": "予期しないエラー" },
+        { "id": "504-timeout", "status": 504, "bodySchema": { "typeRef": "manufacturing:ApiError" }, "when": "タイムアウト" }
+      ],
+      "steps": [
+        {
+          "id": "step-01",
+          "kind": "validation",
+          "description": "入力検証",
+          "conditions": "品目コード形式 + 数量 > 0 + 開始 ≤ 終了",
+          "rules": [
+            { "field": "productItemCode", "type": "required", "severity": "error", "message": "@conv.msg.productItemCode.required" },
+            { "field": "productItemCode", "type": "regex", "severity": "error", "patternRef": "@conv.regex.item-code", "message": "@conv.msg.itemCode.invalidFormat" },
+            { "field": "plannedQuantity", "type": "range", "severity": "error", "min": 1, "message": "@conv.msg.plannedQuantity.outOfRange" },
+            { "field": "scheduledEndAt", "type": "custom", "severity": "error", "condition": "@inputs.scheduledEndAt < @inputs.scheduledStartAt", "message": "@conv.msg.schedule.invalidRange" }
+          ],
+          "fieldErrorsVar": "fieldErrors",
+          "inlineBranch": {
+            "ok": [], "ng": [],
+            "ngResponseId": "400-validation",
+            "ngBodyExpression": "{ code: 'VALIDATION', message: '入力値が不正です', fieldErrors: @fieldErrors }"
+          }
+        },
+        {
+          "id": "step-02",
+          "kind": "dbAccess",
+          "description": "製品コードから items を取得 (kind='product' のみ)",
+          "tableId": "38d3788e-092b-4fc4-8b97-ca359981d987",
+          "operation": "SELECT",
+          "sql": "SELECT id, item_code, name, kind, unit, lead_time_days FROM items WHERE item_code = @inputs.productItemCode AND kind = 'product' AND is_active = true",
+          "outputBinding": { "name": "product" },
+          "lineage": {
+            "reads": [{ "tableId": "38d3788e-092b-4fc4-8b97-ca359981d987", "purpose": "lookup" }]
+          }
+        },
+        {
+          "id": "step-03",
+          "kind": "branch",
+          "description": "製品が見つからない or 非アクティブ → 404",
+          "branches": [
+            {
+              "id": "br-03-a", "code": "A", "label": "製品なし",
+              "condition": { "kind": "expression", "expression": "@product == null" },
+              "steps": [
+                {
+                  "id": "step-03-a-01",
+                  "kind": "return",
+                  "description": "404",
+                  "responseId": "404-item-not-found",
+                  "bodyExpression": "{ code: 'ITEM_NOT_FOUND', message: '製品コード ' + @inputs.productItemCode + ' が見つかりません' }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": { "id": "br-03-else", "code": "B", "label": "製品 OK", "steps": [] }
+        },
+        {
+          "id": "step-04",
+          "kind": "dbAccess",
+          "description": "BOM 1 階層分を取得 (本サンプルは 1 階層のみ、再帰展開は extensions step で実装想定)",
+          "tableId": "67ec6e96-74fe-4c75-889f-ddb0bbbc577f",
+          "operation": "SELECT",
+          "sql": "SELECT b.id, b.parent_item_id, b.child_item_id, b.quantity_per_parent, b.scrap_factor, c.item_code as child_item_code, c.name as child_name, c.unit as child_unit FROM boms b JOIN items c ON c.id = b.child_item_id WHERE b.parent_item_id = @product.id AND (b.valid_to IS NULL OR b.valid_to >= CURRENT_DATE)",
+          "outputBinding": { "name": "bomRows" },
+          "lineage": {
+            "reads": [
+              { "tableId": "67ec6e96-74fe-4c75-889f-ddb0bbbc577f", "purpose": "lookup" },
+              { "tableId": "38d3788e-092b-4fc4-8b97-ca359981d987", "purpose": "lookup" }
+            ]
+          }
+        },
+        {
+          "id": "step-05",
+          "kind": "branch",
+          "description": "BOM が 1 行も無い場合は 422",
+          "branches": [
+            {
+              "id": "br-05-a", "code": "A", "label": "BOM なし",
+              "condition": { "kind": "expression", "expression": "@bomRows == null || @bomRows.length == 0" },
+              "steps": [
+                {
+                  "id": "step-05-a-01",
+                  "kind": "return",
+                  "responseId": "422-bom-not-defined",
+                  "description": "422 BOM 未定義",
+                  "bodyExpression": "{ code: 'BOM_NOT_DEFINED', message: '製品 ' + @product.item_code + ' の BOM が未定義' }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": { "id": "br-05-else", "code": "B", "label": "BOM あり", "steps": [] }
+        },
+        {
+          "id": "step-06",
+          "kind": "loop",
+          "description": "**LoopStep collection mode** で BOM 行を反復、所要量を計算して bomComponents 配列に push",
+          "maturity": "committed",
+          "loopKind": "collection",
+          "collectionSource": "@bomRows",
+          "collectionItemName": "bomRow",
+          "outputBinding": {
+            "name": "bomComponents",
+            "operation": "push",
+            "initialValue": "[]"
+          },
+          "steps": [
+            {
+              "id": "step-06-01",
+              "kind": "compute",
+              "description": "現在の bomRow から所要量を計算",
+              "expression": "{ childItemId: @bomRow.child_item_id, childItemCode: @bomRow.child_item_code, requiredQuantity: @fn.calculateRequiredQuantity(@bomRow.quantity_per_parent, @bomRow.scrap_factor, @inputs.plannedQuantity), unit: @bomRow.child_unit }",
+              "outputBinding": {
+                "name": "bomComponents",
+                "operation": "push"
+              }
+            }
+          ]
+        },
+        {
+          "id": "step-07",
+          "kind": "dbAccess",
+          "description": "production_orders に INSERT (DB Sequence で order_number 自動採番)",
+          "tableId": "81f7dcd2-11ac-4929-8f82-a2f1ad809e68",
+          "operation": "INSERT",
+          "sql": "INSERT INTO production_orders (product_item_id, planned_quantity, status, scheduled_start_at, scheduled_end_at, created_by_user_id) VALUES (@product.id, @inputs.plannedQuantity, 'scheduled', @inputs.scheduledStartAt, @inputs.scheduledEndAt, @sessionUserId) RETURNING id, order_number, status",
+          "outputBinding": { "name": "createdOrder" },
+          "lineage": {
+            "writes": [{ "tableId": "81f7dcd2-11ac-4929-8f82-a2f1ad809e68", "purpose": "create" }]
+          }
+        },
+        {
+          "id": "step-08",
+          "kind": "audit",
+          "description": "製造指示作成を監査ログ",
+          "action": "manufacturing.production_order.create",
+          "resource": { "type": "production_order", "id": "@createdOrder.order_number" },
+          "result": "success"
+        },
+        {
+          "id": "step-09",
+          "kind": "eventPublish",
+          "topic": "manufacturing.production_order_created",
+          "description": "製造指示作成イベント発行",
+          "payload": "{ orderNumber: @createdOrder.order_number, productItemCode: @product.item_code, plannedQuantity: @inputs.plannedQuantity, componentCount: @bomComponents.length }"
+        },
+        {
+          "id": "step-10",
+          "kind": "return",
+          "description": "200 OK",
+          "responseId": "200-ok",
+          "bodyExpression": "{ orderNumber: @createdOrder.order_number, status: @createdOrder.status, componentCount: @bomComponents.length, scheduledStartAt: @inputs.scheduledStartAt }"
+        }
+      ]
+    }
+  ],
+  "authoring": {
+    "decisions": [
+      {
+        "id": "ADR-001",
+        "title": "BOM 展開は 1 階層のみ実装、深い階層は別 ProcessFlow に分離",
+        "status": "accepted",
+        "context": "製造業の BOM は 5〜10 階層になることもあるが、本 dogfood では schema 検証が目的のため 1 階層展開のみ実装。",
+        "decision": "step-04 で BOM の直下子のみ取得 → LoopStep で反復計算。再帰展開は extension step (manufacturing:BomExplodeStep) で別実装想定。",
+        "consequences": "本フローはサブアセンブリの所要量を再帰的に展開しない。完全な MRP 実装には ExtensionStep + 再帰 SQL (CTE) が必要。",
+        "date": "2026-04-28"
+      },
+      {
+        "id": "ADR-002",
+        "title": "production_orders.order_number は DB Sequence で採番",
+        "status": "accepted",
+        "context": "アプリ層採番 vs DB Sequence の選択。",
+        "decision": "DB Sequence (production_order_seq、conventionRef: @conv.numbering.productionOrderNumber) で採番。schema 上は table.defaults[].kind='sequence' で表現。",
+        "consequences": "重複なしを DB が保証。アプリ再起動でも連番継続。Sequence の採番ギャップは許容 (TX rollback で連番が飛ぶ)。",
+        "date": "2026-04-28"
+      }
+    ],
+    "glossary": {
+      "BOM": {
+        "definition": "Bill of Materials の略。製品 1 単位を作るのに必要な部品・材料の構成リスト。階層構造。",
+        "aliases": ["部品表", "Bill of Materials"]
+      },
+      "ロス率": {
+        "definition": "製造工程で発生する歩留り損失の割合。所要量 = quantity × (1 + scrap_factor) で計算。",
+        "aliases": ["scrap factor"]
+      }
+    },
+    "testScenarios": [
+      {
+        "id": "happy-path-bom-explosion",
+        "name": "製品 + BOM (3 部品) で製造指示が作成される",
+        "given": [
+          { "kind": "sessionContext", "context": { "requestId": "req-prod-001", "sessionUserId": "user-001" } },
+          {
+            "kind": "dbState",
+            "tableId": "38d3788e-092b-4fc4-8b97-ca359981d987",
+            "rows": [
+              { "id": 1, "item_code": "I000000001", "name": "完成品A", "kind": "product", "unit": "個", "is_active": true },
+              { "id": 2, "item_code": "I000000002", "name": "部品X", "kind": "part", "unit": "個", "is_active": true },
+              { "id": 3, "item_code": "I000000003", "name": "部品Y", "kind": "part", "unit": "個", "is_active": true },
+              { "id": 4, "item_code": "I000000004", "name": "部品Z", "kind": "part", "unit": "個", "is_active": true }
+            ]
+          },
+          {
+            "kind": "dbState",
+            "tableId": "67ec6e96-74fe-4c75-889f-ddb0bbbc577f",
+            "rows": [
+              { "id": 1, "parent_item_id": 1, "child_item_id": 2, "quantity_per_parent": 2, "scrap_factor": 0.05 },
+              { "id": 2, "parent_item_id": 1, "child_item_id": 3, "quantity_per_parent": 1, "scrap_factor": 0.0 },
+              { "id": 3, "parent_item_id": 1, "child_item_id": 4, "quantity_per_parent": 4, "scrap_factor": 0.10 }
+            ]
+          }
+        ],
+        "when": {
+          "actionId": "act-001",
+          "input": {
+            "productItemCode": "I000000001",
+            "plannedQuantity": 100,
+            "scheduledStartAt": "2026-05-01T09:00:00.000Z",
+            "scheduledEndAt": "2026-05-03T18:00:00.000Z"
+          }
+        },
+        "then": [
+          { "kind": "outcome", "expected": "200-ok" },
+          { "kind": "output", "path": "$.componentCount", "equals": 3 },
+          { "kind": "dbRow", "tableId": "81f7dcd2-11ac-4929-8f82-a2f1ad809e68", "match": { "product_item_id": 1, "planned_quantity": 100, "status": "scheduled" }, "count": 1 },
+          { "kind": "auditLog", "action": "manufacturing.production_order.create", "result": "success" }
+        ],
+        "tags": ["happy", "bom-explosion", "loop"]
+      },
+      {
+        "id": "bom-not-defined",
+        "name": "BOM が未定義の製品 → 422",
+        "given": [
+          { "kind": "sessionContext", "context": { "requestId": "req-prod-002", "sessionUserId": "user-001" } },
+          {
+            "kind": "dbState",
+            "tableId": "38d3788e-092b-4fc4-8b97-ca359981d987",
+            "rows": [{ "id": 1, "item_code": "I000000099", "name": "BOM 未定義品", "kind": "product", "is_active": true }]
+          },
+          { "kind": "dbState", "tableId": "67ec6e96-74fe-4c75-889f-ddb0bbbc577f", "rows": [] }
+        ],
+        "when": { "actionId": "act-001", "input": { "productItemCode": "I000000099", "plannedQuantity": 10, "scheduledStartAt": "2026-05-01T09:00:00.000Z", "scheduledEndAt": "2026-05-02T18:00:00.000Z" } },
+        "then": [{ "kind": "outcome", "expected": "422-bom-not-defined" }],
+        "tags": ["error", "bom"]
+      }
+    ],
+    "notes": [
+      {
+        "id": "note-v3-mfg-01",
+        "kind": "assumption",
+        "body": "Round 3 dogfood (#529)。Round 1/2 で未使用だった LoopStep (collection mode) / Sequence / DefaultDefinition (kind='sequence') / 自己参照 FK (boms) を実機検証。月次棚卸締めフロー (e3a68880-...json) で ClosingStep + CdcStep + meta.kind='scheduled' を検証する。",
+        "createdAt": "2026-04-28T00:00:00.000Z"
+      }
+    ]
+  }
+}

--- a/docs/sample-project-v3/manufacturing/process-flows/e3a68880-9648-4bdc-b787-b083784c1229.json
+++ b/docs/sample-project-v3/manufacturing/process-flows/e3a68880-9648-4bdc-b787-b083784c1229.json
@@ -1,0 +1,301 @@
+{
+  "$schema": "../../../../schemas/v3/process-flow.v3.schema.json",
+  "meta": {
+    "id": "e3a68880-9648-4bdc-b787-b083784c1229",
+    "name": "月次棚卸締め (製造業)",
+    "description": "月末 cron 起動の定期実行フロー。(1) 冪等チェック (当月スナップショット既存なら早期 return)、(2) CdcStep で inventory 変動を auditLog に capture、(3) ClosingStep で月次締め宣言、(4) inventory_snapshots への bulk INSERT、(5) 月次評価額集計、(6) 完了イベント発行。meta.kind='scheduled' / ClosingStep / CdcStep の Round 3 検証フロー。",
+    "version": "1.0.0",
+    "maturity": "committed",
+    "createdAt": "2026-04-28T00:00:00.000Z",
+    "updatedAt": "2026-04-28T00:00:00.000Z",
+    "kind": "scheduled",
+    "sla": {
+      "timeoutMs": 1800000,
+      "onTimeout": "throw",
+      "errorCode": "CLOSING_TIMEOUT"
+    }
+  },
+  "context": {
+    "catalogs": {
+      "errors": {
+        "CLOSING_TIMEOUT": {
+          "httpStatus": 504,
+          "defaultMessage": "月次棚卸締め処理タイムアウト (30 分超過)",
+          "description": "cron 起動フロー SLA 超過。前回実行を確認し、ロールバックが完了しているか調査すること。"
+        },
+        "ALREADY_CLOSED": {
+          "httpStatus": 409,
+          "defaultMessage": "当月分の棚卸締めは既に完了しています",
+          "description": "冪等チェックで既存スナップショットを検出した場合。再実行安全 (早期 return)。"
+        },
+        "INTERNAL_ERROR": {
+          "httpStatus": 500,
+          "defaultMessage": "月次棚卸締め内部エラー",
+          "description": "予期しないエラー。ClosingStep rollbackOnFailure=true により TX はロールバック済みのはず。"
+        }
+      },
+      "events": {
+        "manufacturing.monthly_closing_completed": {
+          "description": "月次棚卸締め完了イベント。会計システム・レポーティング基盤が消費。",
+          "payload": {
+            "type": "object",
+            "required": ["closingDate", "snapshotCount", "totalValuation"],
+            "properties": {
+              "closingDate": { "type": "string", "description": "締め対象月末日 (YYYY-MM-DD)。" },
+              "snapshotCount": { "type": "integer", "description": "作成したスナップショット行数 (= active 品目数)。" },
+              "totalValuation": { "type": "number", "description": "月次評価額合計 (円)。" }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "functions": {
+        "calcTotalValuation": {
+          "signature": "calcTotalValuation(snapshots: object[]): number",
+          "returnType": "number",
+          "description": "inventory_snapshots 行配列から評価額合計を集計: sum(quantity_on_hand × unit_cost)。",
+          "examples": [
+            "@fn.calcTotalValuation(@snapshots)"
+          ]
+        }
+      }
+    },
+    "ambientVariables": [
+      { "name": "cutoffDate", "type": "string", "required": true, "description": "月末締め日 (YYYY-MM-DD)。cron runner が注入する ambient context。例: '2026-04-30'。" },
+      { "name": "traceId", "type": "string", "required": true, "description": "分散トレーシング ID。" }
+    ]
+  },
+  "actions": [
+    {
+      "id": "act-001",
+      "name": "月次棚卸締め実行",
+      "trigger": "auto",
+      "description": "cron runner から自動起動。cutoffDate (月末日) を ambient から受け取り、締め処理全体を実行する。",
+      "maturity": "committed",
+      "steps": [
+        {
+          "id": "step-01",
+          "kind": "compute",
+          "description": "cutoffDate から当月識別キー (YYYY-MM) を算出し、冪等チェック用キーを生成する",
+          "expression": "@cutoffDate.substring(0, 7)",
+          "outputBinding": { "name": "closingMonth" }
+        },
+        {
+          "id": "step-02",
+          "kind": "dbAccess",
+          "description": "当月分の inventory_snapshots が既に存在するか確認 (冪等チェック)",
+          "tableId": "b85f3668-a0f8-4a84-ae99-7424ffd7ef85",
+          "operation": "SELECT",
+          "sql": "SELECT COUNT(*) AS cnt FROM inventory_snapshots WHERE closing_month = @closingMonth",
+          "outputBinding": { "name": "existingCheck" },
+          "lineage": {
+            "reads": [{ "tableId": "b85f3668-a0f8-4a84-ae99-7424ffd7ef85", "purpose": "lookup" }]
+          }
+        },
+        {
+          "id": "step-03",
+          "kind": "branch",
+          "description": "当月スナップショットが既存ならば冪等 early return (再実行安全)",
+          "branches": [
+            {
+              "id": "br-03-a",
+              "code": "A",
+              "label": "既存スナップショットあり",
+              "condition": { "kind": "expression", "expression": "@existingCheck.cnt > 0" },
+              "steps": [
+                {
+                  "id": "step-03-a-01",
+                  "kind": "log",
+                  "description": "冪等 early return をログ記録",
+                  "level": "info",
+                  "message": "月次棚卸締め @closingMonth は既に完了済み。処理をスキップします。"
+                },
+                {
+                  "id": "step-03-a-02",
+                  "kind": "return",
+                  "description": "already-closed early return (HTTP 409 相当だが cron なのでログのみ)",
+                  "responseId": "200-ok"
+                }
+              ]
+            }
+          ],
+          "elseBranch": { "id": "br-03-else", "code": "B", "label": "新規締め処理を継続", "steps": [] }
+        },
+        {
+          "id": "step-04",
+          "kind": "dbAccess",
+          "description": "全 active 品目 (is_active=true) の在庫情報を取得",
+          "tableId": "38d3788e-092b-4fc4-8b97-ca359981d987",
+          "operation": "SELECT",
+          "sql": "SELECT i.id AS item_id, i.item_code, i.name AS item_name, i.unit, COALESCE(inv.quantity_on_hand, 0) AS quantity_on_hand, COALESCE(inv.unit_cost, 0) AS unit_cost FROM items i LEFT JOIN inventory inv ON inv.item_id = i.id WHERE i.is_active = true ORDER BY i.item_code",
+          "outputBinding": { "name": "activeItems" },
+          "lineage": {
+            "reads": [
+              { "tableId": "38d3788e-092b-4fc4-8b97-ca359981d987", "purpose": "lookup" }
+            ]
+          }
+        },
+        {
+          "id": "step-05",
+          "kind": "cdc",
+          "description": "月次締め直前の inventory 状態変動を auditLog に capture (Round 3 CdcStep 検証)",
+          "tableIds": ["38d3788e-092b-4fc4-8b97-ca359981d987"],
+          "captureMode": "full",
+          "destination": {
+            "kind": "auditLog",
+            "auditAction": "inventory.monthlyClose"
+          },
+          "lineage": {
+            "reads": [{ "tableId": "38d3788e-092b-4fc4-8b97-ca359981d987", "purpose": "lookup" }]
+          }
+        },
+        {
+          "id": "step-06",
+          "kind": "closing",
+          "description": "月次棚卸締め宣言 (Round 3 ClosingStep 検証)。idempotencyKey で再実行安全、rollbackOnFailure=true でエラー時は TX ロールバック",
+          "period": "monthly",
+          "cutoffAt": "23:59:59",
+          "idempotencyKey": "@closingMonth",
+          "rollbackOnFailure": true
+        },
+        {
+          "id": "step-07",
+          "kind": "dbAccess",
+          "description": "inventory_snapshots に active 品目の在庫情報を bulk INSERT (INSERT INTO ... SELECT 1 文)",
+          "tableId": "b85f3668-a0f8-4a84-ae99-7424ffd7ef85",
+          "operation": "INSERT",
+          "sql": "INSERT INTO inventory_snapshots (item_id, item_code, item_name, unit, quantity_on_hand, unit_cost, closing_month, snapshot_at) SELECT i.id, i.item_code, i.name, i.unit, COALESCE(inv.quantity_on_hand, 0), COALESCE(inv.unit_cost, 0), @closingMonth, NOW() FROM items i LEFT JOIN inventory inv ON inv.item_id = i.id WHERE i.is_active = true RETURNING id, item_id, quantity_on_hand, unit_cost",
+          "outputBinding": { "name": "snapshots" },
+          "lineage": {
+            "reads": [{ "tableId": "38d3788e-092b-4fc4-8b97-ca359981d987", "purpose": "lookup" }],
+            "writes": [{ "tableId": "b85f3668-a0f8-4a84-ae99-7424ffd7ef85", "purpose": "create" }]
+          }
+        },
+        {
+          "id": "step-08",
+          "kind": "compute",
+          "description": "月次評価額合計を集計 (quantity_on_hand × unit_cost の総和)",
+          "expression": "@fn.calcTotalValuation(@snapshots)",
+          "outputBinding": { "name": "totalValuation" }
+        },
+        {
+          "id": "step-09",
+          "kind": "eventPublish",
+          "description": "月次棚卸締め完了イベントを発行。会計・レポーティング基盤が消費する。",
+          "topic": "manufacturing.monthly_closing_completed",
+          "payload": "{ closingDate: @cutoffDate, snapshotCount: @snapshots.length, totalValuation: @totalValuation }"
+        },
+        {
+          "id": "step-10",
+          "kind": "audit",
+          "description": "月次棚卸締め完了を監査ログに記録",
+          "action": "manufacturing.inventory.monthly_close",
+          "resource": { "type": "inventory_snapshot", "id": "@closingMonth" },
+          "result": "success"
+        },
+        {
+          "id": "step-11",
+          "kind": "return",
+          "description": "cron フロー正常完了 (HTTP route なし、200-ok は形式的 ID)",
+          "responseId": "200-ok"
+        }
+      ],
+      "responses": [
+        { "id": "200-ok", "status": 200, "when": "月次棚卸締め正常完了 (または already-closed 冪等 return)" }
+      ]
+    }
+  ],
+  "authoring": {
+    "decisions": [
+      {
+        "id": "ADR-001",
+        "title": "CdcStep を ClosingStep の直前に配置",
+        "status": "accepted",
+        "context": "締め処理中に在庫の変更が発生すると、スナップショットとの整合性が失われる。",
+        "decision": "ClosingStep (step-06) の直前に CdcStep (step-05) で full capture を実施し、締め前の最終状態を auditLog に記録する。captureMode='full' を選択したのは、増分ではなく月次全件の絶対量を記録する要件のため。",
+        "consequences": "全 active 品目分のログが auditLog に書き込まれるため、品目数が多い場合は書き込み量が大きい。品目数 10 万件超では incremental への変更を検討する。",
+        "date": "2026-04-28"
+      },
+      {
+        "id": "ADR-002",
+        "title": "scheduled フロー + meta.kind='scheduled' で HTTP route を持たない",
+        "status": "accepted",
+        "context": "月次締めは cron runner から自動起動するため、HTTP エンドポイントは不要。",
+        "decision": "ActionDefinition.httpRoute を省略し、trigger='auto' とする。cutoffDate は cron runner が ambient context として注入する。",
+        "consequences": "HTTP 経由での手動実行には別の wrapper が必要。緊急再実行は DB 直接操作 or cron 手動 trigger で対応。",
+        "date": "2026-04-28"
+      },
+      {
+        "id": "ADR-003",
+        "title": "冪等性を ClosingStep.idempotencyKey + 冪等チェック branch の 2 重で保証",
+        "status": "accepted",
+        "context": "cron は二重起動・失敗後リトライの可能性があるため再実行安全性が必要。",
+        "decision": "step-02/03 で inventory_snapshots 存在確認による early return (アプリ層冪等)、step-06 の ClosingStep.idempotencyKey='@closingMonth' によるフレームワーク層冪等の 2 重保護。",
+        "consequences": "どちらか一方が失敗しても他方が保護する。ただし early return が先行するため ClosingStep の idempotencyKey は「フレームワーク実装次第の二次保険」として機能。",
+        "date": "2026-04-28"
+      }
+    ],
+    "glossary": {
+      "棚卸締め": {
+        "definition": "月末時点の在庫数量・評価額を確定し、スナップショットとして記録する会計・在庫管理上の作業。締め後は当月分の在庫修正が禁止される。",
+        "aliases": ["月次締め", "inventory closing"]
+      },
+      "評価額": {
+        "definition": "在庫の金額換算値。quantity_on_hand × unit_cost で算出。移動平均法・先入先出法等の原価計算方式によって unit_cost の算出方法が異なる。",
+        "aliases": ["inventory valuation"]
+      }
+    },
+    "testScenarios": [
+      {
+        "id": "happy-path-closing",
+        "name": "active 品目 3 件で月次締めが正常完了する",
+        "given": [
+          { "kind": "sessionContext", "context": { "cutoffDate": "2026-04-30", "traceId": "trace-closing-001" } },
+          {
+            "kind": "dbState",
+            "tableId": "38d3788e-092b-4fc4-8b97-ca359981d987",
+            "rows": [
+              { "id": 1, "item_code": "I000000001", "name": "完成品A", "unit": "個", "is_active": true },
+              { "id": 2, "item_code": "I000000002", "name": "部品X", "unit": "個", "is_active": true },
+              { "id": 3, "item_code": "I000000003", "name": "原材料Y", "unit": "kg", "is_active": true }
+            ]
+          },
+          { "kind": "dbState", "tableId": "b85f3668-a0f8-4a84-ae99-7424ffd7ef85", "rows": [] }
+        ],
+        "when": { "actionId": "act-001", "input": {} },
+        "then": [
+          { "kind": "outcome", "expected": "200-ok" },
+          { "kind": "dbRow", "tableId": "b85f3668-a0f8-4a84-ae99-7424ffd7ef85", "match": { "closing_month": "2026-04" }, "count": 3 },
+          { "kind": "auditLog", "action": "manufacturing.inventory.monthly_close", "result": "success" }
+        ],
+        "tags": ["happy", "closing", "scheduled"]
+      },
+      {
+        "id": "idempotent-already-closed",
+        "name": "当月スナップショット既存 → early return で二重締めしない",
+        "given": [
+          { "kind": "sessionContext", "context": { "cutoffDate": "2026-04-30", "traceId": "trace-closing-002" } },
+          {
+            "kind": "dbState",
+            "tableId": "b85f3668-a0f8-4a84-ae99-7424ffd7ef85",
+            "rows": [{ "id": 1, "item_id": 1, "closing_month": "2026-04", "quantity_on_hand": 100, "unit_cost": 500 }]
+          }
+        ],
+        "when": { "actionId": "act-001", "input": {} },
+        "then": [
+          { "kind": "outcome", "expected": "200-ok" },
+          { "kind": "dbRow", "tableId": "b85f3668-a0f8-4a84-ae99-7424ffd7ef85", "match": { "closing_month": "2026-04" }, "count": 1 }
+        ],
+        "tags": ["idempotent", "closing", "scheduled"]
+      }
+    ],
+    "notes": [
+      {
+        "id": "note-r3-dogfood-01",
+        "kind": "assumption",
+        "body": "Round 3 dogfood (#529) — 月次棚卸締めフロー。ClosingStep (period='monthly', idempotencyKey, rollbackOnFailure) / CdcStep (captureMode='full', destination.kind='auditLog') / meta.kind='scheduled' の 3 要素を実機で初めて書いた感想: (1) ClosingStep は period + idempotencyKey の 2 プロパティで冪等制御が宣言できるのは直感的。cutoffAt の型が string (例: '23:59:59') なのは ISO 8601 time 形式を想定しているが、schema の description だけでは形式 (HH:MM:SS vs HH:MM) が不明なため ajv-formats の 'time' 制約があると嬉しい。(2) CdcStep の captureMode='full' は「締め前スナップショット」ユースケースにぴったりだが、'incremental' との使い分け基準 (増分期間の定義) が schema コメントに無いので運用者が迷う可能性あり。(3) meta.kind='scheduled' + trigger='auto' の組み合わせは自然。httpRoute を省略できるのは重要だが、「scheduled なら httpRoute 禁止」の schema 制約は無く、誤って両方書いてもバリデーション通過する点は注意 (既知 R3-1 とは別の軽微な事項)。",
+        "createdAt": "2026-04-28T00:00:00.000Z"
+      }
+    ]
+  }
+}

--- a/docs/sample-project-v3/manufacturing/project.json
+++ b/docs/sample-project-v3/manufacturing/project.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "../../../schemas/v3/project.v3.schema.json",
+  "schemaVersion": "v3",
+  "meta": {
+    "id": "19b4f1a7-b37b-4c1e-9735-5857f2caedf0",
+    "name": "v3 dogfood Round 3 — manufacturing",
+    "description": "Round 1 (retail) / Round 2 (finance) で未使用だった schema 要素 (CdcStep / ClosingStep / LoopStep / ScheduledStep / Sequence / TriggerDefinition / DefaultDefinition / 自己参照 FK) を製造業の業務文脈で網羅検証する dogfood Round 3 (#529)。",
+    "version": "1.0.0",
+    "maturity": "draft",
+    "createdAt": "2026-04-28T00:00:00.000Z",
+    "updatedAt": "2026-04-28T00:00:00.000Z",
+    "mode": "upstream"
+  },
+  "extensionsApplied": [
+    { "namespace": "manufacturing", "version": ">=1.0.0" }
+  ],
+  "entities": {
+    "screens": [
+      {
+        "id": "67cf4447-cff1-4402-ac73-816cf4fe4ca2",
+        "no": 1,
+        "name": "製造指示作成",
+        "updatedAt": "2026-04-28T00:00:00.000Z",
+        "maturity": "committed",
+        "kind": "form",
+        "path": "/manufacturing/production-orders/new",
+        "hasDesign": false
+      }
+    ],
+    "tables": [
+      {
+        "id": "38d3788e-092b-4fc4-8b97-ca359981d987",
+        "no": 1,
+        "name": "品目マスタ",
+        "updatedAt": "2026-04-28T00:00:00.000Z",
+        "maturity": "committed",
+        "physicalName": "items",
+        "category": "マスタ",
+        "columnCount": 11
+      },
+      {
+        "id": "67ec6e96-74fe-4c75-889f-ddb0bbbc577f",
+        "no": 2,
+        "name": "BOM (部品表)",
+        "updatedAt": "2026-04-28T00:00:00.000Z",
+        "maturity": "committed",
+        "physicalName": "boms",
+        "category": "マスタ",
+        "columnCount": 8
+      },
+      {
+        "id": "81f7dcd2-11ac-4929-8f82-a2f1ad809e68",
+        "no": 3,
+        "name": "製造指示",
+        "updatedAt": "2026-04-28T00:00:00.000Z",
+        "maturity": "committed",
+        "physicalName": "production_orders",
+        "category": "トランザクション",
+        "columnCount": 13
+      },
+      {
+        "id": "b85f3668-a0f8-4a84-ae99-7424ffd7ef85",
+        "no": 4,
+        "name": "在庫スナップショット",
+        "updatedAt": "2026-04-28T00:00:00.000Z",
+        "maturity": "committed",
+        "physicalName": "inventory_snapshots",
+        "category": "ログ",
+        "columnCount": 6
+      },
+      {
+        "id": "eb2b1bf1-270c-439c-b506-21e8b858983b",
+        "no": 5,
+        "name": "品質検査記録",
+        "updatedAt": "2026-04-28T00:00:00.000Z",
+        "maturity": "committed",
+        "physicalName": "quality_inspections",
+        "category": "ログ",
+        "columnCount": 8
+      }
+    ],
+    "sequences": [
+      {
+        "id": "28e5b81c-ee4d-4325-94c1-215021c56d44",
+        "no": 1,
+        "name": "製造指示番号採番",
+        "updatedAt": "2026-04-28T00:00:00.000Z",
+        "maturity": "committed",
+        "physicalName": "production_order_seq",
+        "conventionRef": "@conv.numbering.productionOrderNumber"
+      }
+    ],
+    "processFlows": [
+      {
+        "id": "8210362d-c149-4963-bc6e-9512fe18e465",
+        "no": 1,
+        "name": "製造指示生成",
+        "updatedAt": "2026-04-28T00:00:00.000Z",
+        "maturity": "committed",
+        "kind": "screen",
+        "screenId": "67cf4447-cff1-4402-ac73-816cf4fe4ca2",
+        "actionCount": 1
+      },
+      {
+        "id": "e3a68880-9648-4bdc-b787-b083784c1229",
+        "no": 2,
+        "name": "月次棚卸締め",
+        "updatedAt": "2026-04-28T00:00:00.000Z",
+        "maturity": "committed",
+        "kind": "scheduled",
+        "actionCount": 1
+      }
+    ]
+  }
+}

--- a/docs/sample-project-v3/manufacturing/screens/67cf4447-cff1-4402-ac73-816cf4fe4ca2.json
+++ b/docs/sample-project-v3/manufacturing/screens/67cf4447-cff1-4402-ac73-816cf4fe4ca2.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "../../../../schemas/v3/screen.v3.schema.json",
+  "id": "67cf4447-cff1-4402-ac73-816cf4fe4ca2",
+  "name": "製造指示作成",
+  "description": "工場担当者が製品ID + 計画数量 + 計画開始日を指定して製造指示を作成する画面。BOM 展開と所要部品リスト確認は処理フロー側で実施。",
+  "version": "1.0.0",
+  "maturity": "committed",
+  "createdAt": "2026-04-28T00:00:00.000Z",
+  "updatedAt": "2026-04-28T00:00:00.000Z",
+  "kind": "form",
+  "path": "/manufacturing/production-orders/new",
+  "auth": "required",
+  "items": [
+    {
+      "id": "productItemCode",
+      "label": "製品コード",
+      "type": { "kind": "extension", "extensionRef": "manufacturing:itemCode" },
+      "direction": "input",
+      "required": true,
+      "pattern": "@conv.regex.item-code",
+      "errorMessages": { "required": "@conv.msg.productItem.required", "invalidFormat": "@conv.msg.itemCode.invalidFormat" }
+    },
+    {
+      "id": "plannedQuantity",
+      "label": "計画数量",
+      "type": "number",
+      "direction": "input",
+      "required": true,
+      "min": 1,
+      "step": 1,
+      "errorMessages": { "required": "@conv.msg.plannedQuantity.required" }
+    },
+    {
+      "id": "scheduledStartAt",
+      "label": "計画開始日時",
+      "type": "datetime",
+      "direction": "input",
+      "required": true
+    },
+    {
+      "id": "scheduledEndAt",
+      "label": "計画完了日時",
+      "type": "datetime",
+      "direction": "input",
+      "required": true
+    },
+    {
+      "id": "orderNumber",
+      "label": "指示番号",
+      "type": "string",
+      "direction": "output",
+      "valueFrom": { "kind": "expression", "expression": "@createdOrder.order_number" },
+      "helperText": "登録後に自動採番されます (createdOrder.order_number への field 参照は flowVariable.variableName が Identifier 制約のため expression 形式で記述、#529 Round 3 finding R3-1)。"
+    },
+    {
+      "id": "estimatedComponentCount",
+      "label": "BOM 展開部品数",
+      "type": "integer",
+      "direction": "output",
+      "valueFrom": { "kind": "expression", "expression": "@bomComponents.length" },
+      "displayFormat": "#,##0"
+    }
+  ],
+  "design": { "designFileRef": "design.json" }
+}

--- a/docs/sample-project-v3/manufacturing/sequences/28e5b81c-ee4d-4325-94c1-215021c56d44.json
+++ b/docs/sample-project-v3/manufacturing/sequences/28e5b81c-ee4d-4325-94c1-215021c56d44.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "../../../../schemas/v3/sequence.v3.schema.json",
+  "id": "28e5b81c-ee4d-4325-94c1-215021c56d44",
+  "name": "製造指示番号採番",
+  "description": "production_orders.order_number の自動採番に使用する DB シーケンス。@conv.numbering.productionOrderNumber と連動。",
+  "version": "1.0.0",
+  "maturity": "committed",
+  "createdAt": "2026-04-28T00:00:00.000Z",
+  "updatedAt": "2026-04-28T00:00:00.000Z",
+  "physicalName": "production_order_seq",
+  "startValue": 1,
+  "increment": 1,
+  "minValue": 1,
+  "cache": 50,
+  "usedBy": [
+    {
+      "tableId": "81f7dcd2-11ac-4929-8f82-a2f1ad809e68",
+      "columnId": "col-po02"
+    }
+  ],
+  "conventionRef": "@conv.numbering.productionOrderNumber"
+}

--- a/docs/sample-project-v3/manufacturing/tables/38d3788e-092b-4fc4-8b97-ca359981d987.json
+++ b/docs/sample-project-v3/manufacturing/tables/38d3788e-092b-4fc4-8b97-ca359981d987.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "../../../../schemas/v3/table.v3.schema.json",
+  "id": "38d3788e-092b-4fc4-8b97-ca359981d987",
+  "name": "品目マスタ",
+  "description": "製品・部品・原材料を統一管理するテーブル。kind で 'product' (完成品) / 'subassembly' (中間品) / 'part' (購入部品) / 'material' (原材料) を識別。BOM (boms テーブル) で親子関係を構築。",
+  "version": "1.0.0",
+  "maturity": "committed",
+  "createdAt": "2026-04-28T00:00:00.000Z",
+  "updatedAt": "2026-04-28T00:00:00.000Z",
+  "physicalName": "items",
+  "category": "マスタ",
+  "comment": "品目マスタ。BOM 階層は self-reference せず boms テーブルで保持。default 値は DefaultDefinition で表現 (Round 1/2 未使用要素)。",
+  "columns": [
+    { "id": "col-it01", "no": 1, "physicalName": "id", "name": "品目ID", "dataType": "BIGINT", "notNull": true, "primaryKey": true, "autoIncrement": true },
+    { "id": "col-it02", "no": 2, "physicalName": "item_code", "name": "品目コード", "dataType": "VARCHAR", "length": 30, "notNull": true, "unique": true, "comment": "I + 9 桁数字。" },
+    { "id": "col-it03", "no": 3, "physicalName": "name", "name": "品目名", "dataType": "VARCHAR", "length": 200, "notNull": true },
+    { "id": "col-it04", "no": 4, "physicalName": "kind", "name": "種別", "dataType": "VARCHAR", "length": 20, "notNull": true, "comment": "product / subassembly / part / material。" },
+    { "id": "col-it05", "no": 5, "physicalName": "unit", "name": "単位", "dataType": "VARCHAR", "length": 10, "notNull": true, "comment": "個 / kg / m / L 等。" },
+    { "id": "col-it06", "no": 6, "physicalName": "standard_cost", "name": "標準原価", "dataType": "DECIMAL", "length": 12, "scale": 2, "notNull": true, "comment": "JPY、税抜。" },
+    { "id": "col-it07", "no": 7, "physicalName": "lead_time_days", "name": "リードタイム", "dataType": "INTEGER", "notNull": true, "comment": "日数。" },
+    { "id": "col-it08", "no": 8, "physicalName": "min_order_quantity", "name": "最小発注数", "dataType": "INTEGER", "notNull": true },
+    { "id": "col-it09", "no": 9, "physicalName": "is_active", "name": "アクティブ", "dataType": "BOOLEAN", "notNull": true },
+    { "id": "col-it10", "no": 10, "physicalName": "created_at", "name": "作成日時", "dataType": "TIMESTAMP", "notNull": true },
+    { "id": "col-it11", "no": 11, "physicalName": "updated_at", "name": "更新日時", "dataType": "TIMESTAMP", "notNull": true }
+  ],
+  "indexes": [
+    { "id": "idx-it01", "physicalName": "idx_items_item_code", "columns": [{ "columnId": "col-it02" }], "unique": true },
+    { "id": "idx-it02", "physicalName": "idx_items_kind_active", "columns": [{ "columnId": "col-it04" }, { "columnId": "col-it09" }] }
+  ],
+  "constraints": [
+    {
+      "id": "chk-it01",
+      "kind": "check",
+      "physicalName": "chk_items_kind_enum",
+      "expression": "kind IN ('product', 'subassembly', 'part', 'material')",
+      "description": "品目種別の許容値。"
+    },
+    {
+      "id": "chk-it02",
+      "kind": "check",
+      "physicalName": "chk_items_standard_cost_positive",
+      "expression": "standard_cost > 0 AND lead_time_days >= 0 AND min_order_quantity > 0",
+      "description": "標準原価・リードタイム・最小発注数の妥当性。"
+    },
+    {
+      "id": "chk-it03",
+      "kind": "check",
+      "physicalName": "chk_items_item_code_pattern",
+      "expression": "item_code ~ '^I[0-9]{9}$'",
+      "description": "品目コードは I + 9 桁数字。"
+    }
+  ],
+  "defaults": [
+    { "columnId": "col-it08", "kind": "literal", "value": "1", "description": "最小発注数の既定値は 1 (個別品)。" },
+    { "columnId": "col-it09", "kind": "literal", "value": "true", "description": "新規登録は active 既定。" },
+    { "columnId": "col-it10", "kind": "function", "value": "CURRENT_TIMESTAMP", "description": "作成日時自動セット。" },
+    { "columnId": "col-it11", "kind": "function", "value": "CURRENT_TIMESTAMP", "description": "更新日時自動セット (UPDATE 時はトリガー or アプリ層で更新)。" }
+  ]
+}

--- a/docs/sample-project-v3/manufacturing/tables/67ec6e96-74fe-4c75-889f-ddb0bbbc577f.json
+++ b/docs/sample-project-v3/manufacturing/tables/67ec6e96-74fe-4c75-889f-ddb0bbbc577f.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "../../../../schemas/v3/table.v3.schema.json",
+  "id": "67ec6e96-74fe-4c75-889f-ddb0bbbc577f",
+  "name": "BOM (部品表)",
+  "description": "親品目 → 子品目の構成関係を保持する。1 行 = 1 構成関係。階層は再帰展開で取得 (parent_item_id を辿る)。**Round 1/2 未使用の self-referencing FK パターン (items への 2 つの FK)** を実機検証。",
+  "version": "1.0.0",
+  "maturity": "committed",
+  "createdAt": "2026-04-28T00:00:00.000Z",
+  "updatedAt": "2026-04-28T00:00:00.000Z",
+  "physicalName": "boms",
+  "category": "マスタ",
+  "comment": "BOM。1 製品 = 多数の部品行。LoopStep collection mode で展開する。循環参照は CHECK 制約 (parent <> child) で防御 + アプリ層で再帰深さチェック。",
+  "columns": [
+    { "id": "col-bm01", "no": 1, "physicalName": "id", "name": "BOM行ID", "dataType": "BIGINT", "notNull": true, "primaryKey": true, "autoIncrement": true },
+    { "id": "col-bm02", "no": 2, "physicalName": "parent_item_id", "name": "親品目ID", "dataType": "BIGINT", "notNull": true, "comment": "items.id への FK (親側)。" },
+    { "id": "col-bm03", "no": 3, "physicalName": "child_item_id", "name": "子品目ID", "dataType": "BIGINT", "notNull": true, "comment": "items.id への FK (子側)。" },
+    { "id": "col-bm04", "no": 4, "physicalName": "quantity_per_parent", "name": "親 1 個あたり数量", "dataType": "DECIMAL", "length": 10, "scale": 4, "notNull": true, "comment": "親 1 単位生産に必要な子の数量。" },
+    { "id": "col-bm05", "no": 5, "physicalName": "scrap_factor", "name": "ロス率", "dataType": "DECIMAL", "length": 5, "scale": 4, "notNull": true, "comment": "0.0500 = 5% のロス想定 (実所要量 = 数量 × (1 + scrap_factor))。" },
+    { "id": "col-bm06", "no": 6, "physicalName": "valid_from", "name": "有効開始日", "dataType": "DATE", "notNull": true },
+    { "id": "col-bm07", "no": 7, "physicalName": "valid_to", "name": "有効終了日", "dataType": "DATE", "comment": "NULL = 無期限。" },
+    { "id": "col-bm08", "no": 8, "physicalName": "created_at", "name": "作成日時", "dataType": "TIMESTAMP", "notNull": true, "defaultValue": "CURRENT_TIMESTAMP" }
+  ],
+  "indexes": [
+    { "id": "idx-bm01", "physicalName": "idx_boms_parent", "columns": [{ "columnId": "col-bm02" }] },
+    { "id": "idx-bm02", "physicalName": "idx_boms_child", "columns": [{ "columnId": "col-bm03" }] },
+    { "id": "idx-bm03", "physicalName": "idx_boms_parent_active", "columns": [{ "columnId": "col-bm02" }], "where": "valid_to IS NULL", "description": "現在有効な BOM のみの Partial Index。" }
+  ],
+  "constraints": [
+    {
+      "id": "fk-bm01",
+      "kind": "foreignKey",
+      "physicalName": "fk_boms_parent_item",
+      "columnIds": ["col-bm02"],
+      "referencedTableId": "38d3788e-092b-4fc4-8b97-ca359981d987",
+      "referencedColumnIds": ["col-it01"],
+      "onDelete": "restrict",
+      "onUpdate": "cascade",
+      "description": "親品目への FK (1 つ目)。"
+    },
+    {
+      "id": "fk-bm02",
+      "kind": "foreignKey",
+      "physicalName": "fk_boms_child_item",
+      "columnIds": ["col-bm03"],
+      "referencedTableId": "38d3788e-092b-4fc4-8b97-ca359981d987",
+      "referencedColumnIds": ["col-it01"],
+      "onDelete": "restrict",
+      "onUpdate": "cascade",
+      "description": "子品目への FK (2 つ目、同 items テーブルを 2 重参照する self-reference 系構造)。"
+    },
+    {
+      "id": "uq-bm01",
+      "kind": "unique",
+      "physicalName": "uq_boms_parent_child_valid",
+      "columnIds": ["col-bm02", "col-bm03", "col-bm06"],
+      "description": "親 × 子 × 有効開始日で UNIQUE (履歴管理)。"
+    },
+    {
+      "id": "chk-bm01",
+      "kind": "check",
+      "physicalName": "chk_boms_parent_not_child",
+      "expression": "parent_item_id <> child_item_id",
+      "description": "自身を子にできない。"
+    },
+    {
+      "id": "chk-bm02",
+      "kind": "check",
+      "physicalName": "chk_boms_quantity_positive",
+      "expression": "quantity_per_parent > 0 AND scrap_factor >= 0 AND scrap_factor < 1",
+      "description": "数量は正、ロス率は 0〜100% 未満。"
+    },
+    {
+      "id": "chk-bm03",
+      "kind": "check",
+      "physicalName": "chk_boms_valid_period",
+      "expression": "valid_to IS NULL OR valid_to >= valid_from",
+      "description": "有効終了日は有効開始日以降。"
+    }
+  ]
+}

--- a/docs/sample-project-v3/manufacturing/tables/81f7dcd2-11ac-4929-8f82-a2f1ad809e68.json
+++ b/docs/sample-project-v3/manufacturing/tables/81f7dcd2-11ac-4929-8f82-a2f1ad809e68.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "../../../../schemas/v3/table.v3.schema.json",
+  "id": "81f7dcd2-11ac-4929-8f82-a2f1ad809e68",
+  "name": "製造指示",
+  "description": "製造現場への作業指示書 1 件。order_number は production_order_seq シーケンスで採番 (Sequence 連動)。BOM 展開結果の所要部品リストは production_order_components (本サンプル省略) で保持想定。",
+  "version": "1.0.0",
+  "maturity": "committed",
+  "createdAt": "2026-04-28T00:00:00.000Z",
+  "updatedAt": "2026-04-28T00:00:00.000Z",
+  "physicalName": "production_orders",
+  "category": "トランザクション",
+  "comment": "製造指示。order_number は DB Sequence で採番 (DefaultDefinition.kind='sequence' 使用)。",
+  "columns": [
+    { "id": "col-po01", "no": 1, "physicalName": "id", "name": "指示ID", "dataType": "BIGINT", "notNull": true, "primaryKey": true, "autoIncrement": true },
+    { "id": "col-po02", "no": 2, "physicalName": "order_number", "name": "指示番号", "dataType": "VARCHAR", "length": 20, "notNull": true, "unique": true, "comment": "production_order_seq シーケンスで採番。例: PO-20260428-000001" },
+    { "id": "col-po03", "no": 3, "physicalName": "product_item_id", "name": "製品ID", "dataType": "BIGINT", "notNull": true, "comment": "items.id (kind='product') への FK。" },
+    { "id": "col-po04", "no": 4, "physicalName": "planned_quantity", "name": "計画数量", "dataType": "DECIMAL", "length": 10, "scale": 4, "notNull": true },
+    { "id": "col-po05", "no": 5, "physicalName": "completed_quantity", "name": "完成数量", "dataType": "DECIMAL", "length": 10, "scale": 4, "notNull": true, "defaultValue": "0" },
+    { "id": "col-po06", "no": 6, "physicalName": "status", "name": "ステータス", "dataType": "VARCHAR", "length": 20, "notNull": true, "comment": "draft / scheduled / in_progress / completed / cancelled。" },
+    { "id": "col-po07", "no": 7, "physicalName": "scheduled_start_at", "name": "計画開始日時", "dataType": "TIMESTAMP", "notNull": true },
+    { "id": "col-po08", "no": 8, "physicalName": "scheduled_end_at", "name": "計画完了日時", "dataType": "TIMESTAMP", "notNull": true },
+    { "id": "col-po09", "no": 9, "physicalName": "actual_start_at", "name": "実績開始日時", "dataType": "TIMESTAMP" },
+    { "id": "col-po10", "no": 10, "physicalName": "actual_end_at", "name": "実績完了日時", "dataType": "TIMESTAMP" },
+    { "id": "col-po11", "no": 11, "physicalName": "created_by_user_id", "name": "作成者ID", "dataType": "VARCHAR", "length": 50, "notNull": true },
+    { "id": "col-po12", "no": 12, "physicalName": "created_at", "name": "作成日時", "dataType": "TIMESTAMP", "notNull": true, "defaultValue": "CURRENT_TIMESTAMP" },
+    { "id": "col-po13", "no": 13, "physicalName": "updated_at", "name": "更新日時", "dataType": "TIMESTAMP", "notNull": true, "defaultValue": "CURRENT_TIMESTAMP" }
+  ],
+  "indexes": [
+    { "id": "idx-po01", "physicalName": "idx_production_orders_order_number", "columns": [{ "columnId": "col-po02" }], "unique": true },
+    { "id": "idx-po02", "physicalName": "idx_production_orders_status_scheduled", "columns": [{ "columnId": "col-po06" }, { "columnId": "col-po07", "order": "asc" }] }
+  ],
+  "constraints": [
+    {
+      "id": "fk-po01",
+      "kind": "foreignKey",
+      "physicalName": "fk_production_orders_product_item",
+      "columnIds": ["col-po03"],
+      "referencedTableId": "38d3788e-092b-4fc4-8b97-ca359981d987",
+      "referencedColumnIds": ["col-it01"],
+      "onDelete": "restrict",
+      "onUpdate": "cascade"
+    },
+    {
+      "id": "chk-po01",
+      "kind": "check",
+      "physicalName": "chk_production_orders_status_enum",
+      "expression": "status IN ('draft', 'scheduled', 'in_progress', 'completed', 'cancelled')"
+    },
+    {
+      "id": "chk-po02",
+      "kind": "check",
+      "physicalName": "chk_production_orders_quantity_consistency",
+      "expression": "planned_quantity > 0 AND completed_quantity >= 0 AND completed_quantity <= planned_quantity"
+    },
+    {
+      "id": "chk-po03",
+      "kind": "check",
+      "physicalName": "chk_production_orders_schedule_consistency",
+      "expression": "scheduled_end_at >= scheduled_start_at"
+    }
+  ],
+  "defaults": [
+    {
+      "columnId": "col-po02",
+      "kind": "sequence",
+      "value": "production_order_seq",
+      "description": "DB Sequence (28e5b81c-...json) で自動採番。"
+    },
+    {
+      "columnId": "col-po05",
+      "kind": "literal",
+      "value": "0",
+      "description": "完成数量の初期値は 0。"
+    },
+    {
+      "columnId": "col-po06",
+      "kind": "literal",
+      "value": "'draft'",
+      "description": "新規作成時のステータスは draft。"
+    }
+  ]
+}

--- a/docs/sample-project-v3/manufacturing/tables/b85f3668-a0f8-4a84-ae99-7424ffd7ef85.json
+++ b/docs/sample-project-v3/manufacturing/tables/b85f3668-a0f8-4a84-ae99-7424ffd7ef85.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "../../../../schemas/v3/table.v3.schema.json",
+  "id": "b85f3668-a0f8-4a84-ae99-7424ffd7ef85",
+  "name": "在庫スナップショット",
+  "description": "月次棚卸締め (ClosingStep) で生成される、月末時点の在庫数量スナップショット。CdcStep の `destination.kind=auditLog` で監査ログにも同時送出する想定。",
+  "version": "1.0.0",
+  "maturity": "committed",
+  "createdAt": "2026-04-28T00:00:00.000Z",
+  "updatedAt": "2026-04-28T00:00:00.000Z",
+  "physicalName": "inventory_snapshots",
+  "category": "ログ",
+  "comment": "月次締め用スナップショット。snapshot_date + item_id で UNIQUE (1 月 1 行)。",
+  "columns": [
+    { "id": "col-is01", "no": 1, "physicalName": "id", "name": "スナップショットID", "dataType": "BIGINT", "notNull": true, "primaryKey": true, "autoIncrement": true },
+    { "id": "col-is02", "no": 2, "physicalName": "snapshot_date", "name": "スナップショット日", "dataType": "DATE", "notNull": true, "comment": "月末日 (例: 2026-04-30)。" },
+    { "id": "col-is03", "no": 3, "physicalName": "item_id", "name": "品目ID", "dataType": "BIGINT", "notNull": true },
+    { "id": "col-is04", "no": 4, "physicalName": "quantity", "name": "在庫数量", "dataType": "DECIMAL", "length": 12, "scale": 4, "notNull": true },
+    { "id": "col-is05", "no": 5, "physicalName": "unit_cost", "name": "単価", "dataType": "DECIMAL", "length": 12, "scale": 2, "notNull": true, "comment": "FIFO / 標準原価。月次評価額 = quantity × unit_cost。" },
+    { "id": "col-is06", "no": 6, "physicalName": "captured_at", "name": "取得日時", "dataType": "TIMESTAMP", "notNull": true, "defaultValue": "CURRENT_TIMESTAMP" }
+  ],
+  "indexes": [
+    { "id": "idx-is01", "physicalName": "idx_inventory_snapshots_date_item", "columns": [{ "columnId": "col-is02" }, { "columnId": "col-is03" }], "unique": true }
+  ],
+  "constraints": [
+    {
+      "id": "fk-is01",
+      "kind": "foreignKey",
+      "physicalName": "fk_inventory_snapshots_item",
+      "columnIds": ["col-is03"],
+      "referencedTableId": "38d3788e-092b-4fc4-8b97-ca359981d987",
+      "referencedColumnIds": ["col-it01"],
+      "onDelete": "restrict",
+      "onUpdate": "cascade"
+    },
+    {
+      "id": "uq-is01",
+      "kind": "unique",
+      "physicalName": "uq_inventory_snapshots_date_item",
+      "columnIds": ["col-is02", "col-is03"],
+      "description": "1 日 × 1 品目で 1 行 (再実行は冪等、idempotencyKey で制御)。"
+    },
+    {
+      "id": "chk-is01",
+      "kind": "check",
+      "physicalName": "chk_inventory_snapshots_quantity_nonnegative",
+      "expression": "quantity >= 0 AND unit_cost >= 0"
+    }
+  ]
+}

--- a/docs/sample-project-v3/manufacturing/tables/eb2b1bf1-270c-439c-b506-21e8b858983b.json
+++ b/docs/sample-project-v3/manufacturing/tables/eb2b1bf1-270c-439c-b506-21e8b858983b.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "../../../../schemas/v3/table.v3.schema.json",
+  "id": "eb2b1bf1-270c-439c-b506-21e8b858983b",
+  "name": "品質検査記録",
+  "description": "製造指示の完成品ロットに対する品質検査記録。**Round 1/2 未使用の TriggerDefinition** を使用 — INSERT/UPDATE 時に検査結果を品目マスタの quality_grade (集計列、本サンプルでは省略) に伝播するトリガーを宣言。",
+  "version": "1.0.0",
+  "maturity": "committed",
+  "createdAt": "2026-04-28T00:00:00.000Z",
+  "updatedAt": "2026-04-28T00:00:00.000Z",
+  "physicalName": "quality_inspections",
+  "category": "ログ",
+  "comment": "品質検査記録。production_order に対する QA、result/sample 数/欠陥数を保持。",
+  "columns": [
+    { "id": "col-qi01", "no": 1, "physicalName": "id", "name": "検査ID", "dataType": "BIGINT", "notNull": true, "primaryKey": true, "autoIncrement": true },
+    { "id": "col-qi02", "no": 2, "physicalName": "production_order_id", "name": "製造指示ID", "dataType": "BIGINT", "notNull": true },
+    { "id": "col-qi03", "no": 3, "physicalName": "inspector_user_id", "name": "検査者ID", "dataType": "VARCHAR", "length": 50, "notNull": true },
+    { "id": "col-qi04", "no": 4, "physicalName": "sample_size", "name": "検査サンプル数", "dataType": "INTEGER", "notNull": true },
+    { "id": "col-qi05", "no": 5, "physicalName": "defect_count", "name": "不良数", "dataType": "INTEGER", "notNull": true, "defaultValue": "0" },
+    { "id": "col-qi06", "no": 6, "physicalName": "result", "name": "判定", "dataType": "VARCHAR", "length": 20, "notNull": true, "comment": "pass / fail / pending_recheck。" },
+    { "id": "col-qi07", "no": 7, "physicalName": "inspected_at", "name": "検査日時", "dataType": "TIMESTAMP", "notNull": true, "defaultValue": "CURRENT_TIMESTAMP" },
+    { "id": "col-qi08", "no": 8, "physicalName": "comment", "name": "コメント", "dataType": "TEXT" }
+  ],
+  "indexes": [
+    { "id": "idx-qi01", "physicalName": "idx_quality_inspections_order", "columns": [{ "columnId": "col-qi02" }] },
+    { "id": "idx-qi02", "physicalName": "idx_quality_inspections_result", "columns": [{ "columnId": "col-qi06" }] }
+  ],
+  "constraints": [
+    {
+      "id": "fk-qi01",
+      "kind": "foreignKey",
+      "physicalName": "fk_quality_inspections_production_order",
+      "columnIds": ["col-qi02"],
+      "referencedTableId": "81f7dcd2-11ac-4929-8f82-a2f1ad809e68",
+      "referencedColumnIds": ["col-po01"],
+      "onDelete": "cascade",
+      "onUpdate": "cascade"
+    },
+    {
+      "id": "chk-qi01",
+      "kind": "check",
+      "physicalName": "chk_quality_inspections_result_enum",
+      "expression": "result IN ('pass', 'fail', 'pending_recheck')"
+    },
+    {
+      "id": "chk-qi02",
+      "kind": "check",
+      "physicalName": "chk_quality_inspections_count_consistency",
+      "expression": "sample_size > 0 AND defect_count >= 0 AND defect_count <= sample_size"
+    }
+  ],
+  "triggers": [
+    {
+      "id": "trg-qi01",
+      "physicalName": "trg_quality_inspections_audit_after_insert",
+      "timing": "AFTER",
+      "events": ["INSERT"],
+      "body": "INSERT INTO audit_logs (action, resource_type, resource_id, payload, created_at) VALUES ('quality.inspection.recorded', 'quality_inspection', NEW.id, jsonb_build_object('production_order_id', NEW.production_order_id, 'result', NEW.result, 'defect_count', NEW.defect_count, 'sample_size', NEW.sample_size), CURRENT_TIMESTAMP);",
+      "description": "AFTER INSERT で監査ログに自動記録 (PL/pgSQL、PostgreSQL 方言)。Trigger は schema 上 SQL 文字列で持つだけで loader / 実装は別途。"
+    },
+    {
+      "id": "trg-qi02",
+      "physicalName": "trg_quality_inspections_block_modify_passed",
+      "timing": "BEFORE",
+      "events": ["UPDATE", "DELETE"],
+      "whenCondition": "OLD.result = 'pass'",
+      "body": "RAISE EXCEPTION 'Cannot modify or delete a passed quality inspection record (audit immutability)';",
+      "description": "BEFORE UPDATE/DELETE で result='pass' の行は変更禁止 (監査用 immutable)。"
+    }
+  ]
+}

--- a/docs/spec/dogfood-2026-04-28-schema-v3-manufacturing.md
+++ b/docs/spec/dogfood-2026-04-28-schema-v3-manufacturing.md
@@ -163,6 +163,29 @@ R3-1〜R3-3 fix で 90-95%、Round 4 (manufacturing 以外の異質業界) で 0
 - **v3.0 確定判定は Round 2 から後退**、R3-1〜R3-3 を v3.0.2 として fix してから TS 同期推奨
 - 完成度: **80-85% (R3 fix 後に 90-95%、Round 4 で 95%+)**
 - **Round 3 をやって良かった** — Round 1/2 だけで TS 同期着手していたら R3-1 はまる所だった
-- 次の手: 新規 ISSUE で **R3-1/R3-2/R3-3 schema 修正** を起票、設計者承認 (governance §7) → fix → 0 件継続確認 → TS 同期へ
 
-「Round 3 をやってから A」という判断は正解だった。「Round 2 で 0 件 = 確定」と急ぐと R3-1 はまり所が TS 同期の途中で発覚し、TS 型を書き直すコストが発生していた。
+### PR #530 独立レビュー (Sonnet) で追加検出 — 依然多くの未使用 variant が残る
+
+Round 3 後でも以下は **0 use のまま**:
+
+- BranchCondition: `tryCatch` / `affectedRowsZero` / `externalOutcome` (3/4 未使用)
+- Step kind: `screenTransition` / `displayUpdate` / `eventSubscribe` / `jump` / `loopBreak` / `loopContinue` / `commonProcess` (7 件)
+- LoopKind: `count` / `condition` (2/3 未使用)
+- WorkflowPattern: 10/11 未使用 (`approval-sequential` のみ使用)
+- Context: `health` / `readiness` / `resources` 未使用
+- StepBaseProps: `txBoundary` / `compensatesFor` (Saga 系) 未使用
+- CdcDestination: `eventStream` / `table` (2/3 未使用)
+
+新業界 sample で全部カバーは過剰。**現実的な対応**:
+
+- **A: 未使用 variant の AJV fixture テスト拡充** — 業務文脈なしで構造的バリデーション網羅 (推奨、~1 日)
+- **B: Round 4 (新業界、例: healthcare)** で**意図的に未使用 variant を使う設計** — 1 業界で複数カバー
+- **推奨**: A 先 → 必要なら B
+
+### 次の手 (確定版)
+
+1. **R3-1/R3-2/R3-3 schema fix ISSUE 起票** (governance §7 設計者承認、別 ISSUE)
+2. **未使用 variant AJV fixture 拡充 ISSUE 起票** (案 A、別 ISSUE) — Round 4 やる前に構造的網羅性を上げる
+3. これらが完了したら TS 同期着手、または Round 4 を判断
+
+「Round 3 をやってから A」という判断は正解だった。Round 2 で確定判断していれば R3-1 は TS 同期途中で発覚した。Round 3 後の「未使用 variant fixture 拡充」が次の現実解。

--- a/docs/spec/dogfood-2026-04-28-schema-v3-manufacturing.md
+++ b/docs/spec/dogfood-2026-04-28-schema-v3-manufacturing.md
@@ -1,0 +1,168 @@
+# Schema v3 Dogfood Round 3 評価レポート (#529, manufacturing)
+
+| 項目 | 値 |
+|---|---|
+| ISSUE | #529 (Round 3) |
+| 実施日 | 2026-04-28 |
+| 対象 | PR #526 (#525) で F-1/F-2/F-4 fix 後の `schemas/v3/`、Round 1 (retail) + Round 2 (finance) で未使用要素の検証 |
+| サンプル所在地 | `docs/sample-project-v3/manufacturing/` |
+| AJV 検証 | `designer/src/schemas/v3-samples.test.ts` (14 tests, 全 pass) |
+| 担当 | Opus (主) + Sonnet (1 件: 月次棚卸締め) |
+| 前提 | Round 2 後「90-95% 完成度」と評価したが PR #528 レビューで「85-90% 妥当」に下方修正済 |
+
+---
+
+## 1. スコープ・成果物
+
+`docs/sample-project-v3/manufacturing/` に Round 1/2 未使用要素を網羅検証する第 3 業界 sample 一式:
+
+| 種別 | ファイル | 件数 | Round 1/2 未使用要素を含むか |
+|---|---|---|---|
+| Project | `project.json` | 1 | (なし) |
+| Sequence | `sequences/28e5b81c-...json` (production_order_seq) | 1 | ✅ **Sequence** (Round 1/2 未使用) |
+| Table | `tables/` (items/boms/production_orders/inventory_snapshots/quality_inspections) | 5 | ✅ **TriggerDefinition (BEFORE/AFTER)**、**DefaultDefinition (4 kind)**、**self-referencing FK 系**（boms→items × 2 FK）|
+| Screen | `screens/67cf4447-...json` (製造指示作成) | 1 | (なし) |
+| Layouts | `layouts/screen-layout.json` + `layouts/er-layout.json` | 2 | ✅ **screen-layout.v3** + **er-layout.v3** (Round 1/2 未使用) |
+| ProcessFlow (Opus) | `process-flows/8210362d-...json` (製造指示生成) | 1 | ✅ **LoopStep collection mode**、Sequence 連動 INSERT、DefaultDefinition |
+| ProcessFlow (Sonnet) | `process-flows/e3a68880-...json` (月次棚卸締め) | 1 | ✅ **`meta.kind="scheduled"`**、**ClosingStep**、**CdcStep + CdcDestination(auditLog)** |
+| Extension | `extensions/manufacturing.v3.json` | 1 | (なし、既存 stepKinds 機構と同じ) |
+| **合計** | — | **12** | **6 領域すべて未使用要素を含む** |
+
+検証: `npx vitest run src/schemas/v3-samples.test.ts` — 14 test 全 pass (project/tables/screens/process-flow/extension/sequence/screen-layout/er-layout の 8 schema 横断)。
+
+---
+
+## 2. Round 1/2 未使用 schema 要素の実機検証結果
+
+| 要素 | 使用箇所 | 結果 | 所感 |
+|---|---|---|---|
+| **`Sequence`** + `conventionRef` + `usedBy: TableColumnRef[]` | 製造指示番号採番 sequence | ✅ 自然に書ける、TableColumnRef で利用先カラムを宣言 | 採番運用と DB Sequence 連携が schema 上で表現可、loader 実装で `@conv.numbering.*` 解決すれば良い |
+| **`TriggerDefinition`** (BEFORE/AFTER + INSERT/UPDATE/DELETE/TRUNCATE + whenCondition) | quality_inspections (audit / immutable enforcement の 2 trigger) | ✅ trg-qi01 (AFTER INSERT 監査) + trg-qi02 (BEFORE UPDATE/DELETE で result='pass' を block) で Trigger 機構をフル活用 | PL/pgSQL 等の DB 方言依存 body は string で持つだけで loader は無関与、schema 役割は明確 |
+| **`DefaultDefinition`** (literal / function / sequence / convention の 4 kind) | items (4 default) + production_orders (3 default) | ✅ 4 kind すべて使用、kind="sequence" で production_order_seq 連動 | `Column.defaultValue` (string short) と `DefaultDefinition` の使い分けは schema 上両方許容 — どちらを正にするかは運用ガイド次第 |
+| **`LoopStep` collection mode** + `outputBinding.operation="push"` | 製造指示生成 step-06 (BOM 行を反復、bomComponents に push) | ✅ 反復処理を構造化表現可、initialValue で初期化、collectionItemName で内部変数 | 一発で書けた。LoopStep の 3 loopKind (count/condition/collection) のうち collection が dogfood で最も使う |
+| **`ClosingStep`** (period="monthly" + idempotencyKey + rollbackOnFailure) | 月次棚卸締め (Sonnet) | ✅ 直感的に書ける | Sonnet 報告: 「`cutoffAt` の format 制約欠如」を発見 → **R3-2** |
+| **`CdcStep`** + `CdcDestination.kind="auditLog"` | 月次棚卸締め (Sonnet)、inventory snapshot capture | ✅ tableIds + captureMode + destination の 3 必須要素を素直に書ける | Sonnet 報告: 「`captureMode: full / incremental` の使い分け基準が schema コメントにない」(運用ガイドで補完可、Should-fix ではない) |
+| **`meta.kind="scheduled"`** | 月次棚卸締め | ✅ HTTP route 省略 + `trigger="auto"` で cron フローを表現 | Sonnet 報告: 「`scheduled` の場合に `httpRoute` 禁止の schema 強制がない」→ **R3-3** |
+| **`screen-layout.v3`** | 製造指示画面の position | ✅ Designer 専用座標 schema が独立しており業務情報と分離 | Round 1/2 で省略していたのは正しかった (業務情報には不要) |
+| **`er-layout.v3`** + `LogicalRelation` (cardinality: many-to-many) | manufacturing/layouts/er-layout.json | ✅ 5 table の position + boms→items の many-to-many logicalRelation | self-referencing 系を logical 表現できる、ER 図エディタの入力 schema として十分 |
+| **self-referencing 系 FK** (boms→items × 2 FK: parent + child) | boms テーブル | ✅ 同 items テーブルへ 2 つの FK、CHECK 制約 (parent <> child) で自身を子にできない | schema レベルでは特別扱い不要、通常 FK の集合で表現可 |
+
+---
+
+## 3. 3 分類別 件数集計 (Round 1/2/3 比較)
+
+memory `feedback_dogfood_issue_classification.md` 準拠:
+
+| 分類 | Round 1 | Round 2 | Round 3 |
+|---|---|---|---|
+| **フレームワーク** (schema 自体の改善) | 4 件 (F-1/F-2/F-3/F-4) | 0 件 | **3 件 (R3-1 / R3-2 / R3-3)** ⚠️ |
+| **拡張定義** (extensions.v3 の改善) | 2 件 (容認 / v3.1 候補) | 0 件 | 0 件 |
+| **サンプル設計** (記述ミス系) | 2 件 (placeholder UUID / F-2 関連) | 0 件 | 0 件 |
+
+### Round 3 で検出された 3 件のフレームワーク改善
+
+#### R3-1: `valueFrom.flowVariable.variableName` の Identifier 制約による object field 参照不可
+
+- **現象**: 製造指示画面で `valueFrom: { kind: "flowVariable", variableName: "createdOrder.order_number" }` と書こうとしたが、`Identifier` ($defs/Identifier) のパターン `^[a-z][a-zA-Z0-9]*$` がドット非対応で AJV reject
+- **発見**: Opus が製造指示画面作成時に踏んだ。AJV エラーで気付き、`expression` 形式 (`{ kind: "expression", expression: "@createdOrder.order_number" }`) で workaround
+- **影響**: INSERT RETURNING で取得した object 変数の特定 field を screen に出すケース (頻出) で `flowVariable` 短縮形を使えない
+- **修正案 (要設計者承認)**:
+  - **案 A**: `variableName` の制約を `Identifier` から「Identifier (.field)*」のパターンに緩和 (`^[a-z][a-zA-Z0-9]*(\.[a-z][a-zA-Z0-9]*)*$`)
+  - **案 B**: `valueFrom.flowVariable` に optional `path` フィールドを追加 (`{ kind: "flowVariable", variableName: "createdOrder", path: "order_number" }`)
+  - **推奨**: 案 A (実装も loader 側で `.split('.')` するだけで済む、UI 側の変更も小さい)
+- **影響範囲**: schemas/v3/screen-item.v3.schema.json 1 ファイル
+
+#### R3-2: `ClosingStep.cutoffAt` の format 制約欠如
+
+- **現象**: Sonnet が月次棚卸締め作成時に `cutoffAt: "23:59:59"` と書いたが、`HH:MM` (例: "23:59") も同じく schema 上 valid。実装側で format ばらつきが発生する余地
+- **発見**: Sonnet が schema 検証時に「description には例 23:59:59 とあるが pattern/format が無い」と指摘
+- **影響**: ClosingStep 実装間で cutoffAt 解釈が分かれる (実害は小、operational guide で補完可)
+- **修正案**: `cutoffAt` に `pattern: "^\\d{2}:\\d{2}(:\\d{2})?$"` を追加、または `format: "time"` (ajv-formats が要登録)
+- **影響範囲**: schemas/v3/process-flow.v3.schema.json 1 ファイル
+- **重要度**: **Should-fix** (運用ガイドで補完可だが schema 側 fix が clean)
+
+#### R3-3: `meta.kind="scheduled"` + `Action.httpRoute` の不整合チェック欠如
+
+- **現象**: Sonnet が月次棚卸締め (kind="scheduled") を書いたが、誤って Action.httpRoute を書いてもバリデーション通過した
+- **発見**: Sonnet が「scheduled なら httpRoute 禁止の強制が無い」と指摘
+- **影響**: cron フローに HTTP route を書いてしまう実装ミスが schema で防げない
+- **修正案**:
+  ```jsonc
+  // process-flow.v3.schema.json root に if/then 追加
+  "if": { "properties": { "meta": { "properties": { "kind": { "const": "scheduled" } } } } },
+  "then": {
+    "properties": {
+      "actions": {
+        "items": { "properties": { "httpRoute": false } }
+      }
+    }
+  }
+  ```
+- **影響範囲**: schemas/v3/process-flow.v3.schema.json 1 ファイル
+- **重要度**: **Should-fix** (実害は実装時に気付くが、schema で構造的に防ぐ方が安全)
+
+---
+
+## 4. v3.0 確定可否判定 (Round 3 結果反映)
+
+### 判定: **v3.0 確定の前に R3-1/R3-2/R3-3 修正を推奨 (v3.0.2 として fix)**
+
+Round 2 後の判定「v3.0 確定可能 (RC 状態)」は **撤回**。Round 3 で 3 件のフレームワーク改善 (うち R3-1 は実用上のはまり所、R3-2/R3-3 は構造的検証強化) が見つかったため、TS 型同期着手前に v3.0.2 として fix することを強く推奨。
+
+### 理由
+
+- **TS 同期は schema を正として 7 ファイル + zod 設計の作業** = 後から R3-1 を fix すると TS 型を書き直し
+- R3-1 (`valueFrom.flowVariable.variableName`) は実機ではまったので fix 必須。R3-2/R3-3 は Should-fix だが TS 同期前なら fix のコストは低い
+- Round 3 で「Round 1/2 で**未使用だった schema 要素**」を初めて検証したため新規 finding が出るのは想定内 — 既知 limitation の確認、Round 4 (例: healthcare) で 0 件継続なら確定
+
+### 完成度評価 (改訂)
+
+- Round 1 後: 70-75% (β)
+- Round 2 後: 85-90% (RC 候補) ← PR #528 レビューで下方修正
+- **Round 3 後: 80-85% (R3-1/R3-2/R3-3 fix 後に 90-95% に到達)**
+
+R3-1〜R3-3 fix で 90-95%、Round 4 (manufacturing 以外の異質業界) で 0 件継続が見られたら 95% 以上 = TS 同期着手可能。
+
+---
+
+## 5. v3.1 候補 6 項目の Round 3 後の判定
+
+| # | 候補 | Round 1 | Round 2 | Round 3 | 最終 |
+|---|---|---|---|---|---|
+| 1 | ProcessFlow root 4 セクション化の認知負荷 | 容認 | 容認 | 容認 (LoopStep 含む製造指示生成も書きやすい) | **容認 (確定)** |
+| 2 | `context.health` / `readiness` / `resources` 位置 | 保留 | 保留 | 保留 (manufacturing でも未使用) | **保留 (容認)** |
+| 3 | 拡張機構 1 ファイル統合の限界 | 容認 | 容認 | 容認 (manufacturing.v3.json も <200 行) | **容認 (確定)** |
+| 4 | Step.oneOf 22 variant の AI/validator 認知負荷 | 容認 | 容認 | 容認 (LoopStep collection mode 一発で書けた) | **容認 (limitation 文書化済)** |
+| 5 | ValidationStep.conditions と rules の同居 | 容認 | 容認 | 容認 | **容認 (確定)** |
+| 6 | 拡張機構の object/array 不統一 | v3.1 候補 | v3.1 候補 | (manufacturing でも気にならず) | **v3.1 持ち越し (低優先度)** |
+
+---
+
+## 6. 後続 ISSUE 優先順位 (Round 3 結果反映)
+
+| 優先度 | ISSUE | 状態 |
+|---|---|---|
+| **完了** | dogfood Round 1 (retail) | #523 PR #524 |
+| **完了** | F-1/F-2/F-4 fix | #525 PR #526 |
+| **完了** | dogfood Round 2 (finance) | #527 PR #528 |
+| **完了** | dogfood Round 3 (manufacturing) | **本 PR** |
+| **次 (新規 ISSUE 起票)** | **R3-1/R3-2/R3-3 fix** (schema 修正、governance §7 設計者承認) | TS 同期前の必須前提 |
+| **その後** | TS 型同期 (`designer/src/types/`) | R3 fix 後 |
+| **オプション** | dogfood Round 4 (healthcare 等) | R3 fix 後 + TS 同期着手判断 |
+| **中** | sample 全件 v3 化 (残 retail 0003/0004) | TS 同期と並行可 |
+| **中** | validator 切替 (referentialIntegrity / sqlColumnValidator / loadExtensions / conventionsValidator) | TS 同期後 |
+| **中** | spec 文書 v3 反映 (`docs/spec/process-flow-*.md` 14 件) | 並行可 |
+| **低** | UI コンポーネント v3 同期 (30+ ファイル) | TS 同期完了後 |
+| **将来 (v3.1)** | 拡張機構 object/array 不統一吸収 | 低優先度 |
+
+---
+
+## 7. 結論
+
+- **Round 3 で 3 件のフレームワーク改善 (R3-1/R3-2/R3-3) を検出**、Round 1/2 で未使用だった schema 要素 (Sequence / TriggerDefinition / DefaultDefinition / LoopStep collection / ClosingStep / CdcStep / scheduled / screen-layout / er-layout / self-FK) を網羅検証
+- **v3.0 確定判定は Round 2 から後退**、R3-1〜R3-3 を v3.0.2 として fix してから TS 同期推奨
+- 完成度: **80-85% (R3 fix 後に 90-95%、Round 4 で 95%+)**
+- **Round 3 をやって良かった** — Round 1/2 だけで TS 同期着手していたら R3-1 はまる所だった
+- 次の手: 新規 ISSUE で **R3-1/R3-2/R3-3 schema 修正** を起票、設計者承認 (governance §7) → fix → 0 件継続確認 → TS 同期へ
+
+「Round 3 をやってから A」という判断は正解だった。「Round 2 で 0 件 = 確定」と急ぐと R3-1 はまり所が TS 同期の途中で発覚し、TS 型を書き直すコストが発生していた。


### PR DESCRIPTION
## 関連

- Closes #529
- 関連 PR: #524 (Round 1) / #526 (#525 F-1〜F-4 fix) / #528 (Round 2)
- 評価レポート: \`docs/spec/dogfood-2026-04-28-schema-v3-manufacturing.md\`

## 概要

dogfood Round 3 として manufacturing namespace で **Round 1/2 未使用要素を網羅検証**。新規 finding **3 件 (R3-1/R3-2/R3-3)** を検出。Round 2 後の「v3.0 確定 RC」判定は撤回し、TS 同期前に v3.0.2 として fix を推奨。

## 主な変更

- manufacturing sample 12 件: Project / Tables 5 (items / boms 自己参照 FK / production_orders / inventory_snapshots / quality_inspections Trigger 付き) / Screen / Sequence / 2 Layout (screen / er) / 2 ProcessFlow (Opus 製造指示生成 + Sonnet 月次棚卸締め) / Extension
- AJV 検証拡張: 12 → 14 test (sequence / screen-layout / er-layout 検証追加)
- 評価レポート 7 セクション

## 検証した Round 1/2 未使用要素 (10 種、全部書けた)

Sequence / TriggerDefinition / DefaultDefinition (4 kind) / LoopStep collection / ClosingStep / CdcStep / meta.kind="scheduled" / screen-layout.v3 / er-layout.v3 / self-referencing FK 系

## 検出した 3 件の finding (別 ISSUE で fix)

- **R3-1 (Opus)**: valueFrom.flowVariable.variableName が Identifier 制約で object field 参照不可
- **R3-2 (Sonnet)**: ClosingStep.cutoffAt の format 制約欠如
- **R3-3 (Sonnet)**: meta.kind="scheduled" + httpRoute の不整合チェック欠如

詳細・修正案はレポート §3 参照。

## 完了基準

- [x] manufacturing sample 12 件 ✓
- [x] AJV 検証 14 test 全 pass ✓
- [x] Round 1/2 未使用要素を全て少なくとも 1 箇所で使用 ✓
- [x] 評価レポート 7 セクション ✓
- [x] memory 反映 ✓

## v3.0 確定判定

**Round 2 後の判定 (RC) は撤回**、R3-1/R3-2/R3-3 fix 後に再判定。完成度 80-85% (R3 fix 後 90-95% 想定)。

## レビュー観点

- R3-1/R3-2/R3-3 の修正案が妥当か (governance §7 設計者承認待ち)
- 重量級フロー (LoopStep + Sequence 連動 INSERT) と scheduled フロー (ClosingStep + CdcStep) の業務的妥当性
- TriggerDefinition の SQL 文字列扱い (loader 無関与) が schema 設計として妥当か

## schema governance

本 PR は \`schemas/v3/\` を一切変更していない。サンプル + テスト + ドキュメントのみ。R3-1/R3-2/R3-3 の schema fix は別 ISSUE で起票予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)