### PR TITLE
test(schema-v3): 未使用 variant 27 件 + negative 5 件 AJV fixture 拡充 (#531)

### DIFF
--- a/designer/src/schemas/v3-variant-coverage.test.ts
+++ b/designer/src/schemas/v3-variant-coverage.test.ts
@@ -265,7 +265,7 @@ describe("v3 variant fixture coverage — LoopKind (#531)", () => {
   });
 });
 
-describe("v3 variant fixture coverage — WorkflowPattern 10 種 (#531)", () => {
+describe("v3 variant fixture coverage — WorkflowPattern 11 種 + quorum 2 variants (#531)", () => {
   const APPROVERS = [
     { role: "@conv.role.staff", label: "担当", order: 1 },
     { role: "@conv.role.manager", label: "課長", order: 2 },

--- a/designer/src/schemas/v3-variant-coverage.test.ts
+++ b/designer/src/schemas/v3-variant-coverage.test.ts
@@ -1,0 +1,516 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import Ajv2020, { type ValidateFunction } from "ajv/dist/2020";
+import addFormats from "ajv-formats";
+import { readFileSync } from "node:fs";
+import { resolve, join } from "node:path";
+
+const repoRoot = resolve(__dirname, "../../../");
+const v3Dir = resolve(repoRoot, "schemas/v3");
+
+function loadJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+let validateProcessFlow: ValidateFunction;
+
+beforeAll(() => {
+  const ajv = new Ajv2020({ allErrors: true, strict: false, discriminator: true });
+  addFormats(ajv);
+  ajv.addSchema(loadJson(join(v3Dir, "common.v3.schema.json")) as object);
+  ajv.addSchema(loadJson(join(v3Dir, "screen-item.v3.schema.json")) as object);
+  validateProcessFlow = ajv.compile(loadJson(join(v3Dir, "process-flow.v3.schema.json")) as object);
+});
+
+const META_BASE = {
+  id: "11111111-1111-4111-8111-111111111111",
+  name: "fixture flow",
+  createdAt: "2026-04-28T00:00:00.000Z",
+  updatedAt: "2026-04-28T00:00:00.000Z",
+  kind: "screen",
+};
+
+function makeFlow(steps: unknown[], opts?: { contextOverride?: object; metaOverride?: object }): unknown {
+  return {
+    meta: { ...META_BASE, ...(opts?.metaOverride ?? {}) },
+    ...(opts?.contextOverride ? { context: opts.contextOverride } : {}),
+    actions: [
+      {
+        id: "act-001",
+        name: "fixture",
+        trigger: "submit",
+        steps,
+      },
+    ],
+  };
+}
+
+function dump(validate: ValidateFunction): string {
+  return (validate.errors ?? [])
+    .map((e) => `${e.instancePath || "<root>"} ${e.keyword}: ${e.message ?? ""}`)
+    .join("\n");
+}
+
+function expectPass(flow: unknown, hint: string) {
+  const ok = validateProcessFlow(flow);
+  expect(ok, ok ? "" : `${hint}\n${dump(validateProcessFlow)}`).toBe(true);
+}
+
+function expectFail(flow: unknown, hint: string) {
+  const ok = validateProcessFlow(flow);
+  expect(ok, ok ? `${hint} should have failed` : "").toBe(false);
+}
+
+describe("v3 variant fixture coverage — BranchCondition (#531)", () => {
+  it("kind=tryCatch with errorCode", () => {
+    const flow = makeFlow([
+      {
+        id: "step-01",
+        kind: "branch",
+        description: "tryCatch fixture",
+        branches: [
+          {
+            id: "br-a",
+            code: "A",
+            condition: { kind: "tryCatch", errorCode: "STOCK_SHORTAGE" },
+            steps: [],
+          },
+        ],
+      },
+    ]);
+    expectPass(flow, "BranchCondition tryCatch");
+  });
+
+  it("kind=affectedRowsZero with stepId", () => {
+    const flow = makeFlow([
+      {
+        id: "step-01",
+        kind: "branch",
+        description: "affectedRowsZero fixture",
+        branches: [
+          {
+            id: "br-a",
+            code: "A",
+            condition: { kind: "affectedRowsZero", stepId: "step-prev" },
+            steps: [],
+          },
+        ],
+      },
+    ]);
+    expectPass(flow, "BranchCondition affectedRowsZero");
+  });
+
+  it("kind=externalOutcome with outcome", () => {
+    const flow = makeFlow([
+      {
+        id: "step-01",
+        kind: "branch",
+        description: "externalOutcome fixture",
+        branches: [
+          {
+            id: "br-a",
+            code: "A",
+            condition: {
+              kind: "externalOutcome",
+              stepId: "step-ext",
+              outcome: "failure",
+            },
+            steps: [],
+          },
+        ],
+      },
+    ]);
+    expectPass(flow, "BranchCondition externalOutcome");
+  });
+});
+
+describe("v3 variant fixture coverage — Step kinds (#531)", () => {
+  it("kind=screenTransition", () => {
+    const flow = makeFlow([
+      {
+        id: "step-01",
+        kind: "screenTransition",
+        description: "screen transition fixture",
+        targetScreenId: "22222222-2222-4222-8222-222222222222",
+      },
+    ]);
+    expectPass(flow, "ScreenTransitionStep");
+  });
+
+  it("kind=displayUpdate", () => {
+    const flow = makeFlow([
+      {
+        id: "step-01",
+        kind: "displayUpdate",
+        description: "display update fixture",
+        target: "$.dashboardWidget",
+      },
+    ]);
+    expectPass(flow, "DisplayUpdateStep");
+  });
+
+  it("kind=eventSubscribe with topic + filter", () => {
+    const flow = makeFlow([
+      {
+        id: "step-01",
+        kind: "eventSubscribe",
+        description: "event subscribe fixture",
+        topic: "order.confirmed",
+        filter: "@payload.amount > 1000",
+      },
+    ]);
+    expectPass(flow, "EventSubscribeStep");
+  });
+
+  it("kind=jump with jumpTo", () => {
+    const flow = makeFlow([
+      {
+        id: "step-01",
+        kind: "jump",
+        description: "jump fixture",
+        jumpTo: "step-99",
+      },
+    ]);
+    expectPass(flow, "JumpStep");
+  });
+
+  it("kind=loopBreak inside LoopStep", () => {
+    const flow = makeFlow([
+      {
+        id: "step-01",
+        kind: "loop",
+        description: "loop with break",
+        loopKind: "collection",
+        collectionSource: "@items",
+        collectionItemName: "item",
+        steps: [
+          {
+            id: "step-01-01",
+            kind: "loopBreak",
+            description: "break fixture",
+          },
+        ],
+      },
+    ]);
+    expectPass(flow, "LoopBreakStep");
+  });
+
+  it("kind=loopContinue inside LoopStep", () => {
+    const flow = makeFlow([
+      {
+        id: "step-01",
+        kind: "loop",
+        description: "loop with continue",
+        loopKind: "collection",
+        collectionSource: "@items",
+        collectionItemName: "item",
+        steps: [
+          {
+            id: "step-01-01",
+            kind: "loopContinue",
+            description: "continue fixture",
+          },
+        ],
+      },
+    ]);
+    expectPass(flow, "LoopContinueStep");
+  });
+
+  it("kind=commonProcess with refId + argumentMapping + returnMapping", () => {
+    const flow = makeFlow([
+      {
+        id: "step-01",
+        kind: "commonProcess",
+        description: "common process fixture",
+        refId: "33333333-3333-4333-8333-333333333333",
+        argumentMapping: { customerId: "@inputs.customerId" },
+        returnMapping: { customerProfile: "顧客プロファイル" },
+      },
+    ]);
+    expectPass(flow, "CommonProcessStep");
+  });
+});
+
+describe("v3 variant fixture coverage — LoopKind (#531)", () => {
+  it("loopKind=count with countExpression", () => {
+    const flow = makeFlow([
+      {
+        id: "step-01",
+        kind: "loop",
+        description: "count loop fixture",
+        loopKind: "count",
+        countExpression: "@inputs.retryMax",
+        steps: [
+          { id: "step-01-01", kind: "log", description: "tick", level: "info", message: "iteration" },
+        ],
+      },
+    ]);
+    expectPass(flow, "LoopStep count mode");
+  });
+
+  it("loopKind=condition with conditionExpression + conditionMode=continue", () => {
+    const flow = makeFlow([
+      {
+        id: "step-01",
+        kind: "loop",
+        description: "condition loop fixture",
+        loopKind: "condition",
+        conditionMode: "continue",
+        conditionExpression: "@hasMore == true",
+        steps: [
+          { id: "step-01-01", kind: "log", description: "tick", level: "info", message: "iteration" },
+        ],
+      },
+    ]);
+    expectPass(flow, "LoopStep condition mode");
+  });
+});
+
+describe("v3 variant fixture coverage — WorkflowPattern 10 種 (#531)", () => {
+  const APPROVERS = [
+    { role: "@conv.role.staff", label: "担当", order: 1 },
+    { role: "@conv.role.manager", label: "課長", order: 2 },
+  ];
+
+  function workflowFlow(extra: object) {
+    return makeFlow([
+      {
+        id: "step-01",
+        kind: "workflow",
+        description: "workflow fixture",
+        approvers: APPROVERS,
+        ...extra,
+      },
+    ]);
+  }
+
+  it("pattern=review", () => {
+    expectPass(workflowFlow({ pattern: "review" }), "WorkflowPattern review");
+  });
+
+  it("pattern=approval-parallel", () => {
+    expectPass(workflowFlow({ pattern: "approval-parallel" }), "WorkflowPattern approval-parallel");
+  });
+
+  it("pattern=approval-veto", () => {
+    expectPass(workflowFlow({ pattern: "approval-veto" }), "WorkflowPattern approval-veto");
+  });
+
+  it("pattern=approval-quorum with quorum.type=majority", () => {
+    expectPass(
+      workflowFlow({ pattern: "approval-quorum", quorum: { type: "majority" } }),
+      "WorkflowPattern approval-quorum majority",
+    );
+  });
+
+  it("pattern=approval-quorum with quorum.type=nOfM + n", () => {
+    expectPass(
+      workflowFlow({ pattern: "approval-quorum", quorum: { type: "nOfM", n: 2 } }),
+      "WorkflowPattern approval-quorum nOfM",
+    );
+  });
+
+  it("pattern=approval-escalation with escalateAfter + escalateTo", () => {
+    expectPass(
+      workflowFlow({
+        pattern: "approval-escalation",
+        escalateAfter: "PT24H",
+        escalateTo: { role: "@conv.role.director" },
+      }),
+      "WorkflowPattern approval-escalation",
+    );
+  });
+
+  it("pattern=sign-off", () => {
+    expectPass(workflowFlow({ pattern: "sign-off" }), "WorkflowPattern sign-off");
+  });
+
+  it("pattern=acknowledge", () => {
+    expectPass(workflowFlow({ pattern: "acknowledge" }), "WorkflowPattern acknowledge");
+  });
+
+  it("pattern=branch-merge", () => {
+    expectPass(workflowFlow({ pattern: "branch-merge" }), "WorkflowPattern branch-merge");
+  });
+
+  it("pattern=discussion", () => {
+    expectPass(workflowFlow({ pattern: "discussion" }), "WorkflowPattern discussion");
+  });
+
+  it("pattern=ad-hoc", () => {
+    expectPass(workflowFlow({ pattern: "ad-hoc" }), "WorkflowPattern ad-hoc");
+  });
+});
+
+describe("v3 variant fixture coverage — Context (#531)", () => {
+  it("context.health + readiness + resources を全部使う", () => {
+    const flow = makeFlow(
+      [{ id: "step-01", kind: "log", description: "min", level: "info", message: "ok" }],
+      {
+        contextOverride: {
+          health: {
+            checks: [
+              { name: "db ping", kind: "db", target: "primary", timeout: 1000 },
+              { name: "external api", kind: "http", target: "https://api.example.com/health", timeout: 3000 },
+            ],
+          },
+          readiness: {
+            checks: [{ name: "warm cache", kind: "custom", target: "@fn.isCacheWarm()" }],
+            minimumPassCount: 1,
+          },
+          resources: {
+            cpu: { request: "100m", limit: "500m" },
+            memory: { request: "256Mi", limit: "1Gi" },
+            dbConnections: 10,
+            timeout: 30,
+          },
+        },
+      },
+    );
+    expectPass(flow, "Context health/readiness/resources");
+  });
+});
+
+describe("v3 variant fixture coverage — Saga (txBoundary + compensatesFor) (#531)", () => {
+  it("txBoundary.role=begin/member/end + compensatesFor", () => {
+    const flow = makeFlow([
+      {
+        id: "step-01",
+        kind: "log",
+        description: "saga begin",
+        level: "info",
+        message: "begin tx",
+        txBoundary: { role: "begin", txId: "tx-saga-001" },
+      },
+      {
+        id: "step-02",
+        kind: "log",
+        description: "saga member",
+        level: "info",
+        message: "do work",
+        txBoundary: { role: "member", txId: "tx-saga-001" },
+      },
+      {
+        id: "step-03",
+        kind: "log",
+        description: "saga compensation for step-02",
+        level: "warn",
+        message: "compensate",
+        compensatesFor: "step-02",
+      },
+      {
+        id: "step-04",
+        kind: "log",
+        description: "saga end",
+        level: "info",
+        message: "end tx",
+        txBoundary: { role: "end", txId: "tx-saga-001" },
+      },
+    ]);
+    expectPass(flow, "Saga txBoundary + compensatesFor");
+  });
+});
+
+describe("v3 variant fixture coverage — CdcDestination 2 種 (#531)", () => {
+  it("destination.kind=eventStream with topic", () => {
+    const flow = makeFlow([
+      {
+        id: "step-01",
+        kind: "cdc",
+        description: "CDC to event stream",
+        tableIds: ["44444444-4444-4444-8444-444444444444"],
+        captureMode: "incremental",
+        destination: { kind: "eventStream", topic: "inventory.changed" },
+      },
+    ]);
+    expectPass(flow, "CdcDestination eventStream");
+  });
+
+  it("destination.kind=table with tableId", () => {
+    const flow = makeFlow([
+      {
+        id: "step-01",
+        kind: "cdc",
+        description: "CDC to table",
+        tableIds: ["44444444-4444-4444-8444-444444444444"],
+        captureMode: "full",
+        destination: { kind: "table", tableId: "55555555-5555-4555-8555-555555555555" },
+      },
+    ]);
+    expectPass(flow, "CdcDestination table");
+  });
+});
+
+describe("v3 variant fixture coverage — Negative tests (discriminator 機能確認) (#531)", () => {
+  it("WorkflowPattern=approval-quorum で quorum 欠如 → reject", () => {
+    const flow = makeFlow([
+      {
+        id: "step-01",
+        kind: "workflow",
+        description: "missing quorum",
+        pattern: "approval-quorum",
+        approvers: [{ role: "@conv.role.x" }],
+      },
+    ]);
+    expectFail(flow, "approval-quorum requires quorum");
+  });
+
+  it("WorkflowPattern=approval-escalation で escalateAfter/escalateTo 欠如 → reject", () => {
+    const flow = makeFlow([
+      {
+        id: "step-01",
+        kind: "workflow",
+        description: "missing escalation fields",
+        pattern: "approval-escalation",
+        approvers: [{ role: "@conv.role.x" }],
+      },
+    ]);
+    expectFail(flow, "approval-escalation requires escalateAfter+escalateTo");
+  });
+
+  it("BranchCondition kind=tryCatch で errorCode 欠如 → reject", () => {
+    const flow = makeFlow([
+      {
+        id: "step-01",
+        kind: "branch",
+        description: "tryCatch missing errorCode",
+        branches: [
+          {
+            id: "br-a",
+            code: "A",
+            condition: { kind: "tryCatch" },
+            steps: [],
+          },
+        ],
+      },
+    ]);
+    expectFail(flow, "tryCatch requires errorCode");
+  });
+
+  it("CdcDestination kind=eventStream で topic 欠如 → reject", () => {
+    const flow = makeFlow([
+      {
+        id: "step-01",
+        kind: "cdc",
+        description: "eventStream missing topic",
+        tableIds: ["44444444-4444-4444-8444-444444444444"],
+        captureMode: "incremental",
+        destination: { kind: "eventStream" },
+      },
+    ]);
+    expectFail(flow, "eventStream requires topic");
+  });
+
+  it("WorkflowQuorum.type=nOfM で n 欠如 → reject", () => {
+    const flow = makeFlow([
+      {
+        id: "step-01",
+        kind: "workflow",
+        description: "nOfM missing n",
+        pattern: "approval-quorum",
+        approvers: [{ role: "@conv.role.x" }],
+        quorum: { type: "nOfM" },
+      },
+    ]);
+    expectFail(flow, "WorkflowQuorum nOfM requires n");
+  });
+});


### PR DESCRIPTION
## 関連

- Closes #531
- 関連 PR: #530 (#529 Round 3) — 未使用 variant 指摘元 (Sonnet 独立レビュー)
- memory: \`project_schema_v3_2026_04_27.md\` の品質評価ゲートに沿う

## 概要

PR #530 Sonnet レビューで指摘された **依然 27 variant が dogfood 未使用** に対応。新業界 sample (Round 4) ではなく AJV 構造的バリデーションで機械網羅する案を採用 (低コスト・広カバー)。

## 主な変更

\`designer/src/schemas/v3-variant-coverage.test.ts\` を新規追加、**32 test 全 pass** (正常系 27 + 異常系 5)。

### 正常系 27 fixture

| カテゴリ | Variant | テスト件数 |
|---|---|---|
| BranchCondition | tryCatch / affectedRowsZero / externalOutcome | 3 |
| Step kind | screenTransition / displayUpdate / eventSubscribe / jump / loopBreak / loopContinue / commonProcess | 7 |
| LoopKind | count / condition | 2 |
| WorkflowPattern | review / approval-parallel / approval-veto / approval-quorum (majority) / approval-quorum (nOfM) / approval-escalation / sign-off / acknowledge / branch-merge / discussion / ad-hoc | 11 |
| Context | health + readiness + resources (1 fixture に集約) | 1 |
| Saga | txBoundary (begin/member/end) + compensatesFor | 1 |
| CdcDestination | eventStream + table | 2 |

### 異常系 5 fixture (discriminator / if-then 機能確認)

- approval-quorum で quorum 欠如 → reject ✓
- approval-escalation で escalateAfter+escalateTo 欠如 → reject ✓ (process-flow.v3 の if/then 構文が機能)
- BranchCondition tryCatch で errorCode 欠如 → reject ✓ (#525 F-4 discriminator 効果)
- CdcDestination eventStream で topic 欠如 → reject ✓ (#525 F-4 discriminator 効果)
- WorkflowQuorum nOfM で n 欠如 → reject ✓ (allOf if/then 構文)

## 完了基準

- [x] \`v3-variant-coverage.test.ts\` 新規ファイル ✓
- [x] 全 27 variant を最低 1 fixture で正常系 validate ✓
- [x] 主要 variant に negative test 5 件 ✓
- [x] 既存 \`v3-samples.test.ts\` 14 test と並行 pass (合計 46 test green) ✓
- [x] memory 「fixture でカバー済」に更新 ✓

## 検証

```bash
$ npx vitest run src/schemas/v3-samples.test.ts src/schemas/v3-variant-coverage.test.ts
 Test Files  2 passed (2)
      Tests  46 passed (46)
```

## レビュー観点

- 各 variant の最小有効 fixture 設計が妥当か (過剰でも不足でもないか)
- WorkflowPattern 11 種の各必須プロパティ表現が schema 通りか (特に approval-quorum / approval-escalation の if/then が正しく動くか)
- Negative test 5 件が discriminator + if/then の主要動作を網羅しているか

## schema governance

本 PR は \`schemas/v3/\` を一切変更していない。テストファイル新規追加のみ。

## 次の手

本 PR マージ後、**R3-1/R3-2/R3-3 schema fix ISSUE 起票** (governance §7 設計者承認済) → schema 修正 → Round 4 → 品質評価ゲート → TS 同期着手判断。

🤖 Generated with [Claude Code](https://claude.com/claude-code)