### PR TITLE
fix(schema-v3): R3-1/R3-2/R3-3 修正 (governance §7 設計者承認済) (#533)

### DIFF
--- a/designer/src/schemas/v3-variant-coverage.test.ts
+++ b/designer/src/schemas/v3-variant-coverage.test.ts
@@ -577,6 +577,42 @@ describe("v3 schema fix #533 R3-1: IdentifierPath で object field 参照 (#533)
     const ok = validateScreenItem(item);
     expect(ok).toBe(false);
   });
+
+  it("variableName='test_' (末尾 underscore) は reject (PR #534 N-1 で厳格化)", () => {
+    const item = {
+      id: "x",
+      label: "x",
+      type: "string",
+      direction: "output",
+      valueFrom: { kind: "flowVariable", variableName: "test_" },
+    };
+    const ok = validateScreenItem(item);
+    expect(ok).toBe(false);
+  });
+
+  it("variableName='user__name' (連続 underscore) は reject (PR #534 N-1 で厳格化)", () => {
+    const item = {
+      id: "x",
+      label: "x",
+      type: "string",
+      direction: "output",
+      valueFrom: { kind: "flowVariable", variableName: "user__name" },
+    };
+    const ok = validateScreenItem(item);
+    expect(ok).toBe(false);
+  });
+
+  it("variableName='user_id' (snake_case 1 セグメント) は pass", () => {
+    const item = {
+      id: "x",
+      label: "x",
+      type: "string",
+      direction: "output",
+      valueFrom: { kind: "flowVariable", variableName: "user_id" },
+    };
+    const ok = validateScreenItem(item);
+    expect(ok).toBe(true);
+  });
 });
 
 describe("v3 schema fix #533 R3-2: ClosingStep.cutoffAt pattern (#533)", () => {

--- a/designer/src/schemas/v3-variant-coverage.test.ts
+++ b/designer/src/schemas/v3-variant-coverage.test.ts
@@ -514,3 +514,143 @@ describe("v3 variant fixture coverage — Negative tests (discriminator 機能�
     expectFail(flow, "WorkflowQuorum nOfM requires n");
   });
 });
+
+// ─── #533 R3-1/R3-2/R3-3 schema fix の機能検証 ──────────────────────────
+
+import Ajv2020Default, { type ValidateFunction as VF2 } from "ajv/dist/2020";
+import addFormatsDefault from "ajv-formats";
+
+let validateScreenItem: VF2;
+
+beforeAll(() => {
+  const ajv2 = new Ajv2020Default({ allErrors: true, strict: false, discriminator: true });
+  addFormatsDefault(ajv2);
+  ajv2.addSchema(loadJson(join(v3Dir, "common.v3.schema.json")) as object);
+  validateScreenItem = ajv2.compile(loadJson(join(v3Dir, "screen-item.v3.schema.json")) as object);
+});
+
+describe("v3 schema fix #533 R3-1: IdentifierPath で object field 参照 (#533)", () => {
+  it("variableName='createdOrder.order_number' (ドット区切り) は pass する", () => {
+    const item = {
+      id: "orderNumber",
+      label: "指示番号",
+      type: "string",
+      direction: "output",
+      valueFrom: { kind: "flowVariable", variableName: "createdOrder.order_number" },
+    };
+    const ok = validateScreenItem(item);
+    expect(ok, ok ? "" : (validateScreenItem.errors ?? []).map((e) => e.message).join("\n")).toBe(true);
+  });
+
+  it("variableName='inventoryRows' (Identifier 単独) も依然 pass する", () => {
+    const item = {
+      id: "items",
+      label: "items",
+      type: "string",
+      direction: "output",
+      valueFrom: { kind: "flowVariable", variableName: "inventoryRows" },
+    };
+    const ok = validateScreenItem(item);
+    expect(ok).toBe(true);
+  });
+
+  it("variableName='Foo.bar' (大文字始まり) は依然 reject (IdentifierPath 規範: 各セグメント小文字始まり)", () => {
+    const item = {
+      id: "x",
+      label: "x",
+      type: "string",
+      direction: "output",
+      valueFrom: { kind: "flowVariable", variableName: "Foo.bar" },
+    };
+    const ok = validateScreenItem(item);
+    expect(ok).toBe(false);
+  });
+
+  it("variableName='response.data[0].name' (array index 含む) は reject (expression 形式を使う)", () => {
+    const item = {
+      id: "x",
+      label: "x",
+      type: "string",
+      direction: "output",
+      valueFrom: { kind: "flowVariable", variableName: "response.data[0].name" },
+    };
+    const ok = validateScreenItem(item);
+    expect(ok).toBe(false);
+  });
+});
+
+describe("v3 schema fix #533 R3-2: ClosingStep.cutoffAt pattern (#533)", () => {
+  function closingFlow(cutoffAt: string) {
+    return makeFlow([
+      {
+        id: "step-01",
+        kind: "closing",
+        description: "closing fixture",
+        period: "monthly",
+        cutoffAt,
+      },
+    ]);
+  }
+
+  it("cutoffAt='23:59:59' (HH:MM:SS) は pass", () => {
+    expectPass(closingFlow("23:59:59"), "cutoffAt HH:MM:SS");
+  });
+
+  it("cutoffAt='23:59' (HH:MM) も pass", () => {
+    expectPass(closingFlow("23:59"), "cutoffAt HH:MM");
+  });
+
+  it("cutoffAt='00:00:00' は pass", () => {
+    expectPass(closingFlow("00:00:00"), "cutoffAt min");
+  });
+
+  it("cutoffAt='99:99' は reject", () => {
+    expectFail(closingFlow("99:99"), "cutoffAt 99:99 should reject");
+  });
+
+  it("cutoffAt='25:00:00' (時 24+) は reject", () => {
+    expectFail(closingFlow("25:00:00"), "cutoffAt 25:00:00 should reject");
+  });
+});
+
+describe("v3 schema fix #533 R3-3: scheduled + httpRoute 不整合 reject (#533)", () => {
+  it("kind=scheduled + Action に httpRoute なし → pass", () => {
+    const flow = makeFlow(
+      [{ id: "step-01", kind: "log", description: "ok", level: "info", message: "ok" }],
+      { metaOverride: { kind: "scheduled" } },
+    );
+    expectPass(flow, "scheduled + no httpRoute");
+  });
+
+  it("kind=screen + Action に httpRoute あり → 従来通り pass", () => {
+    const flow = {
+      meta: { ...META_BASE, kind: "screen" },
+      actions: [
+        {
+          id: "act-001",
+          name: "fixture",
+          trigger: "submit",
+          httpRoute: { method: "POST", path: "/api/x" },
+          steps: [{ id: "step-01", kind: "log", description: "ok", level: "info", message: "ok" }],
+        },
+      ],
+    };
+    expectPass(flow, "screen + httpRoute should pass");
+  });
+
+  it("kind=scheduled + Action に httpRoute あり → reject (R3-3 if/then)", () => {
+    const flow = {
+      meta: { ...META_BASE, kind: "scheduled" },
+      actions: [
+        {
+          id: "act-001",
+          name: "fixture",
+          trigger: "auto",
+          httpRoute: { method: "POST", path: "/api/x" },
+          steps: [{ id: "step-01", kind: "log", description: "ok", level: "info", message: "ok" }],
+        },
+      ],
+    };
+    expectFail(flow, "scheduled + httpRoute should reject");
+  });
+});

--- a/docs/sample-project-v3/manufacturing/screens/67cf4447-cff1-4402-ac73-816cf4fe4ca2.json
+++ b/docs/sample-project-v3/manufacturing/screens/67cf4447-cff1-4402-ac73-816cf4fe4ca2.json
@@ -49,8 +49,8 @@
       "label": "指示番号",
       "type": "string",
       "direction": "output",
-      "valueFrom": { "kind": "expression", "expression": "@createdOrder.order_number" },
-      "helperText": "登録後に自動採番されます (createdOrder.order_number への field 参照は flowVariable.variableName が Identifier 制約のため expression 形式で記述、#529 Round 3 finding R3-1)。"
+      "valueFrom": { "kind": "flowVariable", "variableName": "createdOrder.order_number" },
+      "helperText": "登録後に自動採番されます (#533 R3-1 fix で valueFrom.flowVariable.variableName が IdentifierPath になり、createdOrder.order_number のような object field 参照が直接書けるようになった)。"
     },
     {
       "id": "estimatedComponentCount",

--- a/schemas/v3/common.v3.schema.json
+++ b/schemas/v3/common.v3.schema.json
@@ -41,6 +41,14 @@
       "maxLength": 63
     },
 
+    "IdentifierPath": {
+      "description": "識別子のドット区切りパス。object 型変数の特定 field を参照する箇所 (例: ScreenItem.valueFrom.flowVariable.variableName で 'createdOrder.order_number' のように object の field を指す) で使用。各セグメントは小文字始まり + 英数字 + underscore (camelCase 変数名と DB カラム名 snake_case の両方をカバー)。array index は非対応 (response.data[0].name 等は expression 形式を使う)。例: userId, createdOrder.order_number, response.data.items。#533 R3-1 で追加。",
+      "type": "string",
+      "pattern": "^[a-z][a-zA-Z0-9_]*(\\.[a-z][a-zA-Z0-9_]*)*$",
+      "minLength": 1,
+      "maxLength": 128
+    },
+
     "EnvVarKey": {
       "description": "環境変数キー。OS / 12-factor 慣習に従い UPPER_SNAKE_CASE。例: STRIPE_API_BASE, MAX_RETRY_ATTEMPTS",
       "type": "string",

--- a/schemas/v3/common.v3.schema.json
+++ b/schemas/v3/common.v3.schema.json
@@ -42,9 +42,9 @@
     },
 
     "IdentifierPath": {
-      "description": "識別子のドット区切りパス。object 型変数の特定 field を参照する箇所 (例: ScreenItem.valueFrom.flowVariable.variableName で 'createdOrder.order_number' のように object の field を指す) で使用。各セグメントは小文字始まり + 英数字 + underscore (camelCase 変数名と DB カラム名 snake_case の両方をカバー)。array index は非対応 (response.data[0].name 等は expression 形式を使う)。例: userId, createdOrder.order_number, response.data.items。#533 R3-1 で追加。",
+      "description": "識別子のドット区切りパス。object 型変数の特定 field を参照する箇所 (例: ScreenItem.valueFrom.flowVariable.variableName で 'createdOrder.order_number' のように object の field を指す) で使用。各セグメントは camelCase または snake_case (連続 underscore / 末尾 underscore は禁止、Identifier / PhysicalName と一貫)。array index は非対応 (response.data[0].name 等は expression 形式を使う)。例: userId, createdOrder.order_number, response.data.items。#533 R3-1 で追加。",
       "type": "string",
-      "pattern": "^[a-z][a-zA-Z0-9_]*(\\.[a-z][a-zA-Z0-9_]*)*$",
+      "pattern": "^[a-z][a-zA-Z0-9]*(_[a-zA-Z0-9]+)*(\\.[a-z][a-zA-Z0-9]*(_[a-zA-Z0-9]+)*)*$",
       "minLength": 1,
       "maxLength": 128
     },

--- a/schemas/v3/process-flow.v3.schema.json
+++ b/schemas/v3/process-flow.v3.schema.json
@@ -17,6 +17,24 @@
     },
     "authoring": { "$ref": "common.v3.schema.json#/$defs/Authoring" }
   },
+  "if": {
+    "properties": {
+      "meta": {
+        "type": "object",
+        "properties": { "kind": { "const": "scheduled" } },
+        "required": ["kind"]
+      }
+    },
+    "required": ["meta"]
+  },
+  "then": {
+    "description": "#533 R3-3: meta.kind='scheduled' のフローでは、cron 起動の定期実行であり HTTP ルートからは呼ばれないため、Action.httpRoute を禁止する。",
+    "properties": {
+      "actions": {
+        "items": { "not": { "required": ["httpRoute"] } }
+      }
+    }
+  },
 
   "$defs": {
 
@@ -1183,7 +1201,7 @@
             "kind": { "const": "closing" },
             "period": { "type": "string", "enum": ["daily", "monthly", "quarterly", "yearly", "custom"] },
             "customCron": { "type": "string" },
-            "cutoffAt": { "type": "string", "description": "締切時刻 (例: '23:59:59')。" },
+            "cutoffAt": { "type": "string", "pattern": "^([01][0-9]|2[0-3]):[0-5][0-9](:[0-5][0-9])?$", "description": "締切時刻 (HH:MM または HH:MM:SS、24 時間表記、timezone なし)。例: '23:59:59' / '23:59' / '00:00:00'。#533 R3-2 で pattern 追加 (\"99:99\" 等の不正値を reject)。format: \"time\" は ajv-formats では timezone 必須のため不採用。" },
             "idempotencyKey": { "$ref": "common.v3.schema.json#/$defs/ExpressionString" },
             "rollbackOnFailure": { "type": "boolean" }
           }

--- a/schemas/v3/screen-item.v3.schema.json
+++ b/schemas/v3/screen-item.v3.schema.json
@@ -79,7 +79,7 @@
           "properties": {
             "kind": { "const": "flowVariable" },
             "processFlowId": { "$ref": "common.v3.schema.json#/$defs/Uuid", "description": "省略時はカレント画面に紐付く ProcessFlow を解決する。" },
-            "variableName": { "$ref": "common.v3.schema.json#/$defs/Identifier" }
+            "variableName": { "$ref": "common.v3.schema.json#/$defs/IdentifierPath", "description": "ProcessFlow 変数名。Identifier 単独 (例: 'inventoryRows') または ドット区切りで object の field 参照 (例: 'createdOrder.order_number')。#533 R3-1 で IdentifierPath に変更し object field 参照を許容。" }
           }
         },
         {


### PR DESCRIPTION
## 関連

- Closes #533
- 関連: PR #530 (#529 Round 3) — 検出元、PR #532 (#531 fixture 拡充)
- governance §7 設計者承認: ユーザー「OK」 (2026-04-28)

## 概要

dogfood Round 3 (#529) で検出された 3 件のフレームワーク改善を v3.0.2 として fix。

## 主な変更

### R3-1: \`valueFrom.flowVariable.variableName\` を Identifier → IdentifierPath
- \`common.v3.schema.json\` に **\`IdentifierPath\`** ($defs) 追加: \`^[a-z][a-zA-Z0-9_]*(\.[a-z][a-zA-Z0-9_]*)*$\`
- \`screen-item.v3.schema.json\` の variableName を \`IdentifierPath\` 参照に変更
- \`createdOrder.order_number\` のような object field 参照が直接 flowVariable 形式で書ける
- 各セグメントは小文字始まり + 英数 + underscore (camelCase 変数 + DB カラム snake_case の両立)
- manufacturing 製造指示画面の workaround (expression 形式) を flowVariable 形式に戻す

### R3-2: \`ClosingStep.cutoffAt\` に pattern 追加
- \`process-flow.v3.schema.json\`: \`pattern: "^([01][0-9]|2[0-3]):[0-5][0-9](:[0-5][0-9])?$"\`
- HH:MM / HH:MM:SS (24 時間、timezone なし) を許容、\`"99:99"\` / \`"25:00:00"\` 等を reject
- format: "time" は ajv-formats が timezone 必須のため不採用 (締め時刻の意味と合わない)

### R3-3: scheduled + httpRoute 不整合の if/then 強制
- \`process-flow.v3.schema.json\` root に \`if/then\` 追加
- \`meta.kind="scheduled"\` のフローでは \`Action.httpRoute\` を禁止
- screen/batch/system/common/other は影響なし

## 仕様逐条突合

ISSUE #533 完了基準:

- [x] common.v3 に IdentifierPath 追加 — \`schemas/v3/common.v3.schema.json:51-57\` ✓
- [x] screen-item.v3 variableName を IdentifierPath 参照に変更 — \`schemas/v3/screen-item.v3.schema.json:84\` ✓
- [x] ClosingStep.cutoffAt に pattern — \`schemas/v3/process-flow.v3.schema.json:1185\` ✓
- [x] process-flow.v3 root に if/then — \`schemas/v3/process-flow.v3.schema.json:20-37\` ✓
- [x] manufacturing 製造指示画面 R3-1 workaround を戻す — \`docs/sample-project-v3/manufacturing/screens/67cf4447-...json:55-56\` ✓
- [x] 既存 46 test 継続 pass + 新規 12 test = **58 test green** ✓
- [x] memory 更新 (PR マージ後に R3-1/R3-2/R3-3 を fix 済とマーク)

## テスト

- Vitest: 58 件 (新規 12 件、既存 46 件)
  - v3-samples.test.ts: 14 (既存維持、Round 1〜3 全 sample は互換)
  - v3-variant-coverage.test.ts: 44 (32 既存 + 12 新規 R3 fix 検証)

\`\`\`
$ npx vitest run src/schemas/v3-samples.test.ts src/schemas/v3-variant-coverage.test.ts
 Test Files  2 passed (2)
      Tests  58 passed (58)
\`\`\`

## UI 影響 / AI smoke test

- [x] UI 影響なし (auto テスト pass のみ)

理由: schema 修正 + sample 1 件の workaround 解除 + テスト追加のみ。

## レビュー観点

- **R3-1 IdentifierPath の pattern が妥当か**: camelCase + snake_case 両立 / array index 非対応 (response.data[0].name 等は expression 形式) — array index 対応は別 ISSUE で v3.1 検討余地あり
- **R3-2 pattern vs format=time の判断**: ajv-formats の time が timezone 必須で締め時刻の意味と不一致のため pattern 採用、レビューで再評価可
- **R3-3 if/then 構文**: AJV 2020-12 で正常動作する確認は新規テストで実機検証済 (kind=scheduled+httpRoute reject)
- **互換性**: 既存 v3 sample 32 件 (Round 1〜3) は変更なしで pass、R3-1 fix で manufacturing 画面の workaround を解除 = 改善方向

## schema governance

本 PR は \`schemas/v3/\` を 3 ファイル変更 (common.v3 + screen-item.v3 + process-flow.v3)。governance §7 (設計者明示指示) で進行、ユーザー「OK」(2026-04-28) を commit message + 本 PR description + memory に記録。

🤖 Generated with [Claude Code](https://claude.com/claude-code)