### PR TITLE
feat(dogfood): schema v3.0.2 を public-service で再検証 — Round 4 (#535)

### DIFF
--- a/designer/src/schemas/v3-samples.test.ts
+++ b/designer/src/schemas/v3-samples.test.ts
@@ -52,11 +52,12 @@ function listJsonRecursive(dir: string): string[] {
 }
 
 describe("schema v3 dogfood samples (#523 retail + #527 finance)", () => {
-  it("project.json (retail + finance + manufacturing) validates against project.v3.schema.json", () => {
+  it("project.json (retail + finance + manufacturing + public-service) validates against project.v3.schema.json", () => {
     const files = [
       join(samplesV3Dir, "project.json"),
       join(samplesV3Dir, "finance", "project.json"),
       join(samplesV3Dir, "manufacturing", "project.json"),
+      join(samplesV3Dir, "public-service", "project.json"),
     ];
     for (const file of files) {
       const data = loadJson(file);
@@ -70,6 +71,7 @@ describe("schema v3 dogfood samples (#523 retail + #527 finance)", () => {
       ...listJsonRecursive(join(samplesV3Dir, "tables")),
       ...listJsonRecursive(join(samplesV3Dir, "finance", "tables")),
       ...listJsonRecursive(join(samplesV3Dir, "manufacturing", "tables")),
+      ...listJsonRecursive(join(samplesV3Dir, "public-service", "tables")),
     ];
     expect(files.length).toBeGreaterThan(0);
     for (const file of files) {
@@ -84,6 +86,7 @@ describe("schema v3 dogfood samples (#523 retail + #527 finance)", () => {
       ...listJsonRecursive(join(samplesV3Dir, "screens")),
       ...listJsonRecursive(join(samplesV3Dir, "finance", "screens")),
       ...listJsonRecursive(join(samplesV3Dir, "manufacturing", "screens")),
+      ...listJsonRecursive(join(samplesV3Dir, "public-service", "screens")),
     ];
     expect(files.length).toBeGreaterThan(0);
     for (const file of files) {
@@ -98,6 +101,7 @@ describe("schema v3 dogfood samples (#523 retail + #527 finance)", () => {
       ...listJsonRecursive(join(samplesV3Dir, "process-flows")),
       ...listJsonRecursive(join(samplesV3Dir, "finance", "process-flows")),
       ...listJsonRecursive(join(samplesV3Dir, "manufacturing", "process-flows")),
+      ...listJsonRecursive(join(samplesV3Dir, "public-service", "process-flows")),
     ];
     expect(files.length).toBeGreaterThan(0);
     for (const file of files) {
@@ -137,6 +141,7 @@ describe("schema v3 dogfood samples (#523 retail + #527 finance)", () => {
       ...listJsonRecursive(join(samplesV3Dir, "extensions")),
       ...listJsonRecursive(join(samplesV3Dir, "finance", "extensions")),
       ...listJsonRecursive(join(samplesV3Dir, "manufacturing", "extensions")),
+      ...listJsonRecursive(join(samplesV3Dir, "public-service", "extensions")),
     ];
     expect(files.length).toBeGreaterThan(0);
     for (const file of files) {

--- a/docs/sample-project-v3/public-service/extensions/public.v3.json
+++ b/docs/sample-project-v3/public-service/extensions/public.v3.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "../../../../schemas/v3/extensions.v3.schema.json",
+  "namespace": "public-service",
+  "version": "1.0.0",
+  "requiresCoreSchema": ">=3.0.0",
+  "description": "公共サービス (建築確認申請等) namespace の v3 拡張定義。Round 4 dogfood 用。WorkflowPattern 多段連結 (acknowledge / review / sign-off / approval-veto / approval-sequential) を業務文脈で検証する。",
+  "fieldTypes": [
+    { "kind": "applicantCode", "label": "申請者コード", "baseType": "string", "description": "AP + 8 桁数字。" },
+    { "kind": "applicationNumber", "label": "申請番号", "baseType": "string", "description": "BC + YYYYMMDD + 連番8桁。" },
+    { "kind": "buildingUse", "label": "建物用途", "baseType": "string", "description": "residential / commercial / industrial / public 等。" }
+  ],
+  "actionTriggers": [
+    {
+      "value": "applicationSubmitted",
+      "label": "申請提出トリガー",
+      "description": "市民が申請画面で提出ボタンを押下した時に起動。"
+    },
+    {
+      "value": "publicNoticeExpired",
+      "label": "公示期間満了トリガー",
+      "description": "公示期間 (14 日) 満了時に cron で自動起動 (異議申立対応 stage に遷移)。"
+    }
+  ],
+  "stepKinds": {
+    "ApplicationStatusUpdateStep": {
+      "label": "申請ステータス更新",
+      "icon": "Workflow",
+      "description": "applications.status を WorkflowStep の遷移と同期して更新する。stage 遷移時に呼び出し、application_approvals に履歴 INSERT も内部で実施。",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "applicationId": { "type": "string" },
+          "newStatus": { "type": "string", "enum": ["received", "under_review", "under_public_notice", "objection_review", "final_decision", "approved", "rejected", "cancelled"] },
+          "stage": { "type": "string", "enum": ["received_acknowledge", "first_review", "public_notice", "objection_response", "final_decision"] }
+        },
+        "required": ["applicationId", "newStatus", "stage"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "responseTypes": {
+    "ApplicationResponse": {
+      "schema": {
+        "type": "object",
+        "required": ["applicationNumber", "status"],
+        "properties": {
+          "applicationNumber": { "type": "string" },
+          "status": { "type": "string" },
+          "publicNoticeStartAt": { "type": "string" },
+          "publicNoticeEndAt": { "type": "string" },
+          "decidedAt": { "type": "string" }
+        }
+      }
+    },
+    "ApiError": {
+      "schema": {
+        "type": "object",
+        "required": ["code", "message"],
+        "properties": {
+          "code": { "type": "string" },
+          "message": { "type": "string" }
+        }
+      }
+    }
+  },
+  "conventionCategories": [
+    {
+      "categoryName": "publicServiceLimit",
+      "label": "公共サービス限度値",
+      "description": "公示期間日数・添付ファイルサイズ上限・申請有効期限など。",
+      "entrySchema": {
+        "type": "object",
+        "required": ["value", "unit"],
+        "properties": {
+          "value": { "type": "number" },
+          "unit": { "type": "string", "enum": ["days", "bytes", "count"] },
+          "description": { "type": "string" }
+        }
+      }
+    }
+  ]
+}

--- a/docs/sample-project-v3/public-service/process-flows/1cd900ee-0d69-4e0a-a32b-bb329f9bc983.json
+++ b/docs/sample-project-v3/public-service/process-flows/1cd900ee-0d69-4e0a-a32b-bb329f9bc983.json
@@ -1,0 +1,467 @@
+{
+  "$schema": "../../../../schemas/v3/process-flow.v3.schema.json",
+  "meta": {
+    "id": "1cd900ee-0d69-4e0a-a32b-bb329f9bc983",
+    "name": "建築確認申請審査 (5 段 workflow)",
+    "description": "建築確認申請 (建築基準法) を 5 段階の WorkflowStep で審査する。受付 (acknowledge) → 一次審査 (review) → 公示期間 (sign-off, 14 日 deadline) → 異議申立対応 (approval-veto) → 最終決裁 (approval-sequential)。Round 4 で WorkflowPattern 4 種を業務文脈で実機検証する目的。",
+    "version": "1.0.0",
+    "maturity": "committed",
+    "createdAt": "2026-04-28T00:00:00.000Z",
+    "updatedAt": "2026-04-28T00:00:00.000Z",
+    "kind": "screen",
+    "screenId": "f9de5853-db95-4dc5-aefc-ca03b482cfd9",
+    "apiVersion": "v1",
+    "mode": "upstream"
+  },
+  "context": {
+    "catalogs": {
+      "errors": {
+        "VALIDATION": { "httpStatus": 400, "defaultMessage": "入力値が不正です", "responseId": "400-validation" },
+        "APPLICANT_NOT_FOUND": { "httpStatus": 404, "defaultMessage": "申請者が見つかりません", "responseId": "404-applicant-not-found" },
+        "REVIEW_REJECTED": { "httpStatus": 422, "defaultMessage": "一次審査で却下されました", "responseId": "422-review-rejected" },
+        "OBJECTION_REJECTED": { "httpStatus": 422, "defaultMessage": "異議申立により却下されました", "responseId": "422-objection-rejected" },
+        "FINAL_REJECTED": { "httpStatus": 422, "defaultMessage": "最終決裁で却下されました", "responseId": "422-final-rejected" },
+        "INTERNAL_ERROR": { "httpStatus": 500, "defaultMessage": "内部エラー", "responseId": "500-internal-error" }
+      },
+      "events": {
+        "public.application_received": {
+          "description": "申請受付完了時。担当者通知。",
+          "payload": { "type": "object", "required": ["applicationNumber"], "properties": { "applicationNumber": { "type": "string" } } }
+        },
+        "public.application_under_public_notice": {
+          "description": "公示期間に遷移時。市民向け公示掲示板に表示。",
+          "payload": { "type": "object", "required": ["applicationNumber", "publicNoticeStartAt", "publicNoticeEndAt"], "properties": { "applicationNumber": { "type": "string" }, "publicNoticeStartAt": { "type": "string" }, "publicNoticeEndAt": { "type": "string" } } }
+        },
+        "public.application_approved": {
+          "description": "最終決裁完了時。",
+          "payload": { "type": "object", "required": ["applicationNumber"], "properties": { "applicationNumber": { "type": "string" } } }
+        },
+        "public.application_rejected": {
+          "description": "却下時 (一次審査 / 異議申立 / 最終決裁のいずれか)。",
+          "payload": { "type": "object", "required": ["applicationNumber", "stage", "reason"], "properties": { "applicationNumber": { "type": "string" }, "stage": { "type": "string" }, "reason": { "type": "string" } } }
+        }
+      }
+    },
+    "ambientVariables": [
+      { "name": "requestId", "type": "string", "required": true },
+      { "name": "sessionUserId", "type": "string", "required": true }
+    ]
+  },
+  "actions": [
+    {
+      "id": "act-001",
+      "name": "建築確認申請の審査",
+      "trigger": "submit",
+      "description": "申請受付から最終決裁までを 1 ProcessFlow で連結。5 段階 workflow を順次実行、却下時は途中終了。",
+      "maturity": "committed",
+      "httpRoute": { "method": "POST", "path": "/api/public/building-applications", "auth": "required" },
+      "requiredPermissions": ["@conv.permission.application.submit"],
+      "inputs": [
+        { "name": "applicantCode", "label": "申請者コード", "type": "string", "required": true },
+        { "name": "siteAddress", "label": "建築地", "type": "string", "required": true },
+        { "name": "buildingUse", "label": "建物用途", "type": "string", "required": true },
+        { "name": "totalFloorAreaSqm", "label": "延床面積", "type": "number", "required": true }
+      ],
+      "outputs": [
+        { "name": "applicationNumber", "label": "申請番号", "type": "string" },
+        { "name": "status", "label": "ステータス", "type": "string" }
+      ],
+      "responses": [
+        { "id": "200-ok", "status": 200, "bodySchema": { "typeRef": "public-service:ApplicationResponse" }, "when": "申請受付完了 (審査は別フローで非同期)" },
+        { "id": "400-validation", "status": 400, "bodySchema": { "typeRef": "public-service:ApiError" } },
+        { "id": "404-applicant-not-found", "status": 404, "bodySchema": { "typeRef": "public-service:ApiError" } },
+        { "id": "422-review-rejected", "status": 422, "bodySchema": { "typeRef": "public-service:ApiError" } },
+        { "id": "422-objection-rejected", "status": 422, "bodySchema": { "typeRef": "public-service:ApiError" } },
+        { "id": "422-final-rejected", "status": 422, "bodySchema": { "typeRef": "public-service:ApiError" } },
+        { "id": "500-internal-error", "status": 500, "bodySchema": { "typeRef": "public-service:ApiError" } }
+      ],
+      "steps": [
+        {
+          "id": "step-01",
+          "kind": "validation",
+          "description": "入力検証",
+          "rules": [
+            { "field": "applicantCode", "type": "regex", "severity": "error", "pattern": "^AP[0-9]{8}$", "message": "@conv.msg.applicantCode.invalid" },
+            { "field": "totalFloorAreaSqm", "type": "range", "severity": "error", "min": 1, "message": "延床面積は 1㎡ 以上" }
+          ],
+          "fieldErrorsVar": "fieldErrors",
+          "inlineBranch": {
+            "ok": [], "ng": [],
+            "ngResponseId": "400-validation",
+            "ngBodyExpression": "{ code: 'VALIDATION', message: '入力値が不正です', fieldErrors: @fieldErrors }"
+          }
+        },
+        {
+          "id": "step-02",
+          "kind": "dbAccess",
+          "description": "申請者を applicants から取得",
+          "tableId": "5ebdcbd7-0a49-463d-af3b-226ba1e3e36c",
+          "operation": "SELECT",
+          "sql": "SELECT id, applicant_code, name FROM applicants WHERE applicant_code = @inputs.applicantCode",
+          "outputBinding": { "name": "applicant" },
+          "lineage": { "reads": [{ "tableId": "5ebdcbd7-0a49-463d-af3b-226ba1e3e36c", "purpose": "lookup" }] }
+        },
+        {
+          "id": "step-03",
+          "kind": "branch",
+          "description": "申請者なし → 404",
+          "branches": [
+            {
+              "id": "br-03-a", "code": "A", "label": "申請者なし",
+              "condition": { "kind": "expression", "expression": "@applicant == null" },
+              "steps": [
+                { "id": "step-03-a-01", "kind": "return", "description": "404", "responseId": "404-applicant-not-found", "bodyExpression": "{ code: 'APPLICANT_NOT_FOUND', message: '申請者が登録されていません' }" }
+              ]
+            }
+          ],
+          "elseBranch": { "id": "br-03-else", "code": "B", "label": "OK", "steps": [] }
+        },
+        {
+          "id": "step-04",
+          "kind": "dbAccess",
+          "description": "applications に INSERT (status='received'、application_number 自動採番)",
+          "tableId": "0e169ac3-e54e-46f5-b0e2-2e937f0944bb",
+          "operation": "INSERT",
+          "sql": "INSERT INTO applications (application_number, applicant_id, site_address, building_use, total_floor_area_sqm, status, submitted_at) VALUES (@conv.numbering.applicationNumber, @applicant.id, @inputs.siteAddress, @inputs.buildingUse, @inputs.totalFloorAreaSqm, 'received', CURRENT_TIMESTAMP) RETURNING id, application_number",
+          "outputBinding": { "name": "createdApplication" },
+          "lineage": { "writes": [{ "tableId": "0e169ac3-e54e-46f5-b0e2-2e937f0944bb", "purpose": "create" }] }
+        },
+        {
+          "id": "step-05",
+          "kind": "audit",
+          "description": "申請受付を監査ログ (個人情報処理のため sensitive=true)",
+          "action": "public.application.submit",
+          "resource": { "type": "application", "id": "@createdApplication.application_number" },
+          "result": "success",
+          "sensitive": true
+        },
+        {
+          "id": "step-06",
+          "kind": "eventPublish",
+          "topic": "public.application_received",
+          "description": "申請受付イベント発行",
+          "payload": "{ applicationNumber: @createdApplication.application_number }"
+        },
+        {
+          "id": "step-stage-1",
+          "kind": "workflow",
+          "description": "Stage 1 受付確認 (acknowledge): 受付担当者が申請を受領したことを記録、決定権なし",
+          "maturity": "committed",
+          "pattern": "acknowledge",
+          "approvers": [
+            { "role": "@conv.role.public.clerk", "label": "受付担当", "order": 1 }
+          ],
+          "onApproved": [
+            {
+              "id": "step-stage-1-app-01",
+              "kind": "dbAccess",
+              "description": "application_approvals に受付確認履歴を INSERT",
+              "tableId": "79cfcc11-ed1d-45f8-b76e-6cf7b1133d13",
+              "operation": "INSERT",
+              "sql": "INSERT INTO application_approvals (application_id, stage, decision, reviewer_user_id, reviewer_role) VALUES (@createdApplication.id, 'received_acknowledge', 'acknowledged', @sessionUserId, 'clerk')",
+              "lineage": { "writes": [{ "tableId": "79cfcc11-ed1d-45f8-b76e-6cf7b1133d13", "purpose": "create" }] }
+            },
+            {
+              "id": "step-stage-1-app-02",
+              "kind": "dbAccess",
+              "description": "applications.status = 'under_review'",
+              "tableId": "0e169ac3-e54e-46f5-b0e2-2e937f0944bb",
+              "operation": "UPDATE",
+              "sql": "UPDATE applications SET status = 'under_review', review_started_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE id = @createdApplication.id",
+              "lineage": { "writes": [{ "tableId": "0e169ac3-e54e-46f5-b0e2-2e937f0944bb", "purpose": "status-update" }] }
+            }
+          ]
+        },
+        {
+          "id": "step-stage-2",
+          "kind": "workflow",
+          "description": "Stage 2 一次審査 (review): 担当者が建築基準法・条例適合性を判断。却下なら return。",
+          "maturity": "committed",
+          "pattern": "review",
+          "approvers": [
+            { "role": "@conv.role.public.reviewer", "label": "審査担当", "order": 1 }
+          ],
+          "onApproved": [
+            {
+              "id": "step-stage-2-app-01",
+              "kind": "dbAccess",
+              "description": "application_approvals に一次審査履歴 (approved)",
+              "tableId": "79cfcc11-ed1d-45f8-b76e-6cf7b1133d13",
+              "operation": "INSERT",
+              "sql": "INSERT INTO application_approvals (application_id, stage, decision, reviewer_user_id, reviewer_role) VALUES (@createdApplication.id, 'first_review', 'approved', @sessionUserId, 'staff')"
+            },
+            {
+              "id": "step-stage-2-app-02",
+              "kind": "dbAccess",
+              "description": "applications.status = 'under_public_notice' + 公示開始/終了日時を設定 (14 日)",
+              "tableId": "0e169ac3-e54e-46f5-b0e2-2e937f0944bb",
+              "operation": "UPDATE",
+              "sql": "UPDATE applications SET status = 'under_public_notice', public_notice_start_at = CURRENT_TIMESTAMP, public_notice_end_at = CURRENT_TIMESTAMP + INTERVAL '14 days', updated_at = CURRENT_TIMESTAMP WHERE id = @createdApplication.id"
+            }
+          ],
+          "onRejected": [
+            {
+              "id": "step-stage-2-rej-01",
+              "kind": "dbAccess",
+              "description": "application_approvals に rejected 履歴",
+              "tableId": "79cfcc11-ed1d-45f8-b76e-6cf7b1133d13",
+              "operation": "INSERT",
+              "sql": "INSERT INTO application_approvals (application_id, stage, decision, reviewer_user_id, reviewer_role) VALUES (@createdApplication.id, 'first_review', 'rejected', @sessionUserId, 'staff')"
+            },
+            {
+              "id": "step-stage-2-rej-02",
+              "kind": "dbAccess",
+              "description": "applications.status = 'rejected'",
+              "tableId": "0e169ac3-e54e-46f5-b0e2-2e937f0944bb",
+              "operation": "UPDATE",
+              "sql": "UPDATE applications SET status = 'rejected', rejection_reason = '一次審査で建築基準不適合', decided_at = CURRENT_TIMESTAMP WHERE id = @createdApplication.id"
+            },
+            { "id": "step-stage-2-rej-03", "kind": "eventPublish", "topic": "public.application_rejected", "description": "却下イベント", "payload": "{ applicationNumber: @createdApplication.application_number, stage: 'first_review', reason: 'review' }" },
+            { "id": "step-stage-2-rej-04", "kind": "return", "description": "422 一次審査却下", "responseId": "422-review-rejected", "bodyExpression": "{ code: 'REVIEW_REJECTED', message: '一次審査で却下されました' }" }
+          ]
+        },
+        {
+          "id": "step-stage-3",
+          "kind": "workflow",
+          "description": "Stage 3 公示期間 (sign-off): 14 日間の法定公示。公示終了後に書記が sign-off で次段階へ。",
+          "maturity": "committed",
+          "pattern": "sign-off",
+          "approvers": [
+            { "role": "@conv.role.public.clerk", "label": "書記", "order": 1 }
+          ],
+          "deadlineExpression": "@createdApplication.public_notice_end_at",
+          "onApproved": [
+            {
+              "id": "step-stage-3-app-01",
+              "kind": "eventPublish",
+              "topic": "public.application_under_public_notice",
+              "description": "公示開始イベント (公示掲示板へ表示)",
+              "payload": "{ applicationNumber: @createdApplication.application_number, publicNoticeStartAt: @createdApplication.public_notice_start_at, publicNoticeEndAt: @createdApplication.public_notice_end_at }"
+            },
+            {
+              "id": "step-stage-3-app-02",
+              "kind": "dbAccess",
+              "description": "application_approvals に signed_off 履歴",
+              "tableId": "79cfcc11-ed1d-45f8-b76e-6cf7b1133d13",
+              "operation": "INSERT",
+              "sql": "INSERT INTO application_approvals (application_id, stage, decision, reviewer_user_id, reviewer_role) VALUES (@createdApplication.id, 'public_notice', 'signed_off', @sessionUserId, 'clerk')"
+            },
+            {
+              "id": "step-stage-3-app-03",
+              "kind": "dbAccess",
+              "description": "applications.status = 'objection_review'",
+              "tableId": "0e169ac3-e54e-46f5-b0e2-2e937f0944bb",
+              "operation": "UPDATE",
+              "sql": "UPDATE applications SET status = 'objection_review', updated_at = CURRENT_TIMESTAMP WHERE id = @createdApplication.id"
+            }
+          ]
+        },
+        {
+          "id": "step-stage-4",
+          "kind": "workflow",
+          "description": "Stage 4 異議申立対応 (approval-veto): 利害関係者 (近隣住民等) が異議を出せる。1 件でも veto なら却下。",
+          "maturity": "committed",
+          "pattern": "approval-veto",
+          "approvers": [
+            { "role": "@conv.role.public.neighbor", "label": "近隣住民代表", "order": 1 },
+            { "role": "@conv.role.public.environment", "label": "環境担当", "order": 2 }
+          ],
+          "onApproved": [
+            {
+              "id": "step-stage-4-app-01",
+              "kind": "dbAccess",
+              "description": "application_approvals に異議申立対応 approved 履歴",
+              "tableId": "79cfcc11-ed1d-45f8-b76e-6cf7b1133d13",
+              "operation": "INSERT",
+              "sql": "INSERT INTO application_approvals (application_id, stage, decision, reviewer_user_id, reviewer_role) VALUES (@createdApplication.id, 'objection_response', 'approved', @sessionUserId, 'staff')"
+            },
+            {
+              "id": "step-stage-4-app-02",
+              "kind": "dbAccess",
+              "description": "applications.status = 'final_decision'",
+              "tableId": "0e169ac3-e54e-46f5-b0e2-2e937f0944bb",
+              "operation": "UPDATE",
+              "sql": "UPDATE applications SET status = 'final_decision', updated_at = CURRENT_TIMESTAMP WHERE id = @createdApplication.id"
+            }
+          ],
+          "onRejected": [
+            {
+              "id": "step-stage-4-rej-01",
+              "kind": "dbAccess",
+              "description": "application_approvals に rejected 履歴",
+              "tableId": "79cfcc11-ed1d-45f8-b76e-6cf7b1133d13",
+              "operation": "INSERT",
+              "sql": "INSERT INTO application_approvals (application_id, stage, decision, reviewer_user_id, reviewer_role) VALUES (@createdApplication.id, 'objection_response', 'rejected', @sessionUserId, 'staff')"
+            },
+            {
+              "id": "step-stage-4-rej-02",
+              "kind": "dbAccess",
+              "description": "applications.status = 'rejected'",
+              "tableId": "0e169ac3-e54e-46f5-b0e2-2e937f0944bb",
+              "operation": "UPDATE",
+              "sql": "UPDATE applications SET status = 'rejected', rejection_reason = '異議申立により却下', decided_at = CURRENT_TIMESTAMP WHERE id = @createdApplication.id"
+            },
+            { "id": "step-stage-4-rej-03", "kind": "eventPublish", "topic": "public.application_rejected", "description": "却下イベント", "payload": "{ applicationNumber: @createdApplication.application_number, stage: 'objection_response', reason: 'veto' }" },
+            { "id": "step-stage-4-rej-04", "kind": "return", "description": "422 異議申立却下", "responseId": "422-objection-rejected", "bodyExpression": "{ code: 'OBJECTION_REJECTED', message: '異議申立により却下されました' }" }
+          ]
+        },
+        {
+          "id": "step-stage-5",
+          "kind": "workflow",
+          "description": "Stage 5 最終決裁 (approval-sequential): 担当→課長→部長 の 3 段承認。Round 1〜3 で実機使用済の再現性確認。",
+          "maturity": "committed",
+          "pattern": "approval-sequential",
+          "approvers": [
+            { "role": "@conv.role.public.staff", "label": "担当", "order": 1 },
+            { "role": "@conv.role.public.manager", "label": "課長", "order": 2 },
+            { "role": "@conv.role.public.director", "label": "部長", "order": 3 }
+          ],
+          "onApproved": [
+            {
+              "id": "step-stage-5-app-01",
+              "kind": "dbAccess",
+              "description": "applications.status = 'approved' + decided_at",
+              "tableId": "0e169ac3-e54e-46f5-b0e2-2e937f0944bb",
+              "operation": "UPDATE",
+              "sql": "UPDATE applications SET status = 'approved', decided_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE id = @createdApplication.id"
+            },
+            {
+              "id": "step-stage-5-app-02",
+              "kind": "dbAccess",
+              "description": "application_approvals に最終決裁 approved 履歴",
+              "tableId": "79cfcc11-ed1d-45f8-b76e-6cf7b1133d13",
+              "operation": "INSERT",
+              "sql": "INSERT INTO application_approvals (application_id, stage, decision, reviewer_user_id, reviewer_role) VALUES (@createdApplication.id, 'final_decision', 'approved', @sessionUserId, 'director')"
+            }
+          ],
+          "onRejected": [
+            {
+              "id": "step-stage-5-rej-01",
+              "kind": "dbAccess",
+              "description": "applications.status = 'rejected'",
+              "tableId": "0e169ac3-e54e-46f5-b0e2-2e937f0944bb",
+              "operation": "UPDATE",
+              "sql": "UPDATE applications SET status = 'rejected', rejection_reason = '最終決裁で却下', decided_at = CURRENT_TIMESTAMP WHERE id = @createdApplication.id"
+            },
+            { "id": "step-stage-5-rej-02", "kind": "eventPublish", "topic": "public.application_rejected", "description": "却下イベント", "payload": "{ applicationNumber: @createdApplication.application_number, stage: 'final_decision', reason: 'final' }" },
+            { "id": "step-stage-5-rej-03", "kind": "return", "description": "422 最終決裁却下", "responseId": "422-final-rejected", "bodyExpression": "{ code: 'FINAL_REJECTED', message: '最終決裁で却下されました' }" }
+          ]
+        },
+        {
+          "id": "step-99-audit",
+          "kind": "audit",
+          "description": "最終決裁完了の監査ログ (個人情報処理の重要操作)",
+          "action": "public.application.approve",
+          "resource": { "type": "application", "id": "@createdApplication.application_number" },
+          "result": "success",
+          "sensitive": true
+        },
+        {
+          "id": "step-99-event",
+          "kind": "eventPublish",
+          "topic": "public.application_approved",
+          "description": "最終承認イベント発行",
+          "payload": "{ applicationNumber: @createdApplication.application_number }"
+        },
+        {
+          "id": "step-99-return",
+          "kind": "return",
+          "description": "200 OK 申請完了",
+          "responseId": "200-ok",
+          "bodyExpression": "{ applicationNumber: @createdApplication.application_number, status: 'approved', decidedAt: @now }"
+        }
+      ]
+    }
+  ],
+  "authoring": {
+    "decisions": [
+      {
+        "id": "ADR-001",
+        "title": "5 段 workflow を 1 ProcessFlow 内で連結する",
+        "status": "accepted",
+        "context": "建築確認申請の 5 段審査を、(A) 1 ProcessFlow に WorkflowStep を 5 つ並べる か (B) 5 つの ProcessFlow に分割しイベント駆動で連携する かの選択。",
+        "decision": "本サンプルは (A) を採用。schema レベルで多段 WorkflowStep 連結が表現可能か実機検証することが目的。実運用では (B) の方が deadline 待ちで HTTP TX を切らずに済むため現実的だが、本ラウンドの dogfood 趣旨は schema 検証。",
+        "consequences": "1 ProcessFlow が肥大化 (15+ step + 5 workflow)。可読性は下がるが、各 stage 間のデータフローが見える利点あり。",
+        "date": "2026-04-28"
+      }
+    ],
+    "glossary": {
+      "公示期間": {
+        "definition": "建築基準法に定められた 14 日間の公衆閲覧期間。利害関係者がこの期間内に異議を申し立てられる。",
+        "aliases": ["Public Notice Period"]
+      },
+      "異議申立": {
+        "definition": "公示期間中に近隣住民や環境担当が建築計画に対して提出する反対意見。1 件でも認められれば申請は却下 (approval-veto)。",
+        "aliases": ["Objection"]
+      }
+    },
+    "testScenarios": [
+      {
+        "id": "happy-path-full-approval",
+        "name": "全 5 段階を承認、最終的に approved になる",
+        "given": [
+          { "kind": "sessionContext", "context": { "requestId": "req-001", "sessionUserId": "user-001" } },
+          {
+            "kind": "dbState",
+            "tableId": "5ebdcbd7-0a49-463d-af3b-226ba1e3e36c",
+            "rows": [{ "id": 1, "applicant_code": "AP00000001", "name": "山田建設", "is_corporate": true }]
+          }
+        ],
+        "when": {
+          "actionId": "act-001",
+          "input": {
+            "applicantCode": "AP00000001",
+            "siteAddress": "東京都新宿区西新宿 1-1-1",
+            "buildingUse": "commercial",
+            "totalFloorAreaSqm": 1500.5
+          }
+        },
+        "then": [
+          { "kind": "outcome", "expected": "200-ok" },
+          { "kind": "output", "path": "$.status", "equals": "approved" },
+          { "kind": "dbRow", "tableId": "0e169ac3-e54e-46f5-b0e2-2e937f0944bb", "match": { "status": "approved" }, "count": 1 },
+          { "kind": "dbRow", "tableId": "79cfcc11-ed1d-45f8-b76e-6cf7b1133d13", "match": { "application_id": 1 }, "count": 5 },
+          { "kind": "auditLog", "action": "public.application.submit", "result": "success" },
+          { "kind": "auditLog", "action": "public.application.approve", "result": "success" }
+        ],
+        "tags": ["happy", "5-stage-workflow"]
+      },
+      {
+        "id": "first-review-rejected",
+        "name": "一次審査で却下 → 422",
+        "given": [
+          { "kind": "sessionContext", "context": { "requestId": "req-002", "sessionUserId": "user-001" } },
+          { "kind": "dbState", "tableId": "5ebdcbd7-0a49-463d-af3b-226ba1e3e36c", "rows": [{ "id": 1, "applicant_code": "AP00000001", "name": "テスト" }] }
+        ],
+        "when": { "actionId": "act-001", "input": { "applicantCode": "AP00000001", "siteAddress": "違反建築地", "buildingUse": "industrial", "totalFloorAreaSqm": 500 } },
+        "then": [{ "kind": "outcome", "expected": "422-review-rejected" }],
+        "tags": ["error", "first-review"]
+      },
+      {
+        "id": "objection-veto",
+        "name": "異議申立で veto → 422",
+        "given": [
+          { "kind": "sessionContext", "context": { "requestId": "req-003", "sessionUserId": "user-001" } },
+          { "kind": "dbState", "tableId": "5ebdcbd7-0a49-463d-af3b-226ba1e3e36c", "rows": [{ "id": 1, "applicant_code": "AP00000001", "name": "テスト" }] }
+        ],
+        "when": { "actionId": "act-001", "input": { "applicantCode": "AP00000001", "siteAddress": "近隣異議地", "buildingUse": "commercial", "totalFloorAreaSqm": 800 } },
+        "then": [{ "kind": "outcome", "expected": "422-objection-rejected" }],
+        "tags": ["error", "objection-veto"]
+      }
+    ],
+    "notes": [
+      {
+        "id": "note-r4-01",
+        "kind": "assumption",
+        "body": "Round 4 dogfood (#535)。WorkflowPattern 4 種 (acknowledge / review / sign-off / approval-veto) を 1 ProcessFlow 内に連結することで業務文脈での schema 妥当性を実機検証する。Round 1〜3 で実機使用したのは approval-sequential のみ、本フローで残り 4 種をカバー。",
+        "createdAt": "2026-04-28T00:00:00.000Z"
+      },
+      {
+        "id": "note-r4-02",
+        "kind": "deferred",
+        "body": "approval-quorum / approval-escalation / approval-parallel / branch-merge / discussion / ad-hoc は依然 fixture のみで業務文脈未検証。本サンプルでは出番がないため後続 Round で再評価 (もしくは fixture 検証で容認)。",
+        "createdAt": "2026-04-28T00:00:00.000Z"
+      }
+    ]
+  }
+}

--- a/docs/sample-project-v3/public-service/process-flows/72fe2c92-ff7b-4de1-9a6a-ed0dd1216118.json
+++ b/docs/sample-project-v3/public-service/process-flows/72fe2c92-ff7b-4de1-9a6a-ed0dd1216118.json
@@ -1,0 +1,346 @@
+{
+  "$schema": "../../../../schemas/v3/process-flow.v3.schema.json",
+  "meta": {
+    "id": "72fe2c92-ff7b-4de1-9a6a-ed0dd1216118",
+    "name": "申請ステータス通知フロー",
+    "description": "申請者が自分の申請の現在ステータスを照会する参照系 API (GET /api/public/applications/{applicationNumber}/status)。入力検証 → DB 取得 → 本人確認 → 公示残日数計算 → 監査ログ → レスポンス の 7 ステップ構成。Round 4 dogfood (#535): 5 段 workflow の複合系 (Opus 作) と対比する、シンプルな参照系フローとして作成。",
+    "version": "1.0.0",
+    "maturity": "committed",
+    "createdAt": "2026-04-28T00:00:00.000Z",
+    "updatedAt": "2026-04-28T00:00:00.000Z",
+    "kind": "screen",
+    "apiVersion": "v1",
+    "mode": "upstream"
+  },
+  "context": {
+    "catalogs": {
+      "errors": {
+        "VALIDATION": { "httpStatus": 400, "defaultMessage": "入力値が不正です", "responseId": "400-validation" },
+        "APPLICATION_NOT_FOUND": { "httpStatus": 404, "defaultMessage": "申請が見つかりません", "responseId": "404-not-found" },
+        "FORBIDDEN": { "httpStatus": 403, "defaultMessage": "本人以外はアクセスできません", "responseId": "403-forbidden" },
+        "INTERNAL_ERROR": { "httpStatus": 500, "defaultMessage": "内部エラー", "responseId": "500-internal-error" }
+      },
+      "events": {
+        "public.application_status_queried": {
+          "description": "申請ステータス照会完了時 (監査・集計用)。",
+          "payload": {
+            "type": "object",
+            "required": ["applicationNumber", "queriedBy"],
+            "properties": {
+              "applicationNumber": { "type": "string" },
+              "queriedBy": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+    "ambientVariables": [
+      { "name": "requestId", "type": "string", "required": true },
+      { "name": "sessionUserId", "type": "string", "required": true }
+    ]
+  },
+  "actions": [
+    {
+      "id": "act-001",
+      "name": "申請ステータス照会",
+      "trigger": "load",
+      "description": "申請者が申請番号を指定して現在のステータスを照会する。本人確認済の場合のみ情報を返す。",
+      "maturity": "committed",
+      "httpRoute": { "method": "GET", "path": "/api/public/applications/{applicationNumber}/status", "auth": "required" },
+      "requiredPermissions": ["@conv.permission.application.view"],
+      "inputs": [
+        { "name": "applicationNumber", "label": "申請番号", "type": "string", "required": true }
+      ],
+      "outputs": [
+        { "name": "applicationNumber", "label": "申請番号", "type": "string" },
+        { "name": "status", "label": "ステータス", "type": "string" },
+        { "name": "statusMessage", "label": "ステータスメッセージ", "type": "string" },
+        { "name": "publicNoticeStartAt", "label": "公示開始日時", "type": "string" },
+        { "name": "publicNoticeEndAt", "label": "公示終了日時", "type": "string" },
+        { "name": "decidedAt", "label": "決裁日時", "type": "string" },
+        { "name": "remainingNoticeDays", "label": "残り公示日数", "type": "number" }
+      ],
+      "responses": [
+        { "id": "200-ok", "status": 200, "bodySchema": { "typeRef": "public-service:ApplicationResponse" }, "when": "照会成功" },
+        { "id": "400-validation", "status": 400, "bodySchema": { "typeRef": "public-service:ApiError" } },
+        { "id": "403-forbidden", "status": 403, "bodySchema": { "typeRef": "public-service:ApiError" } },
+        { "id": "404-not-found", "status": 404, "bodySchema": { "typeRef": "public-service:ApiError" } },
+        { "id": "500-internal-error", "status": 500, "bodySchema": { "typeRef": "public-service:ApiError" } }
+      ],
+      "steps": [
+        {
+          "id": "step-01",
+          "kind": "validation",
+          "description": "申請番号フォーマット検証 (BC + YYYYMMDD + 連番8桁)",
+          "rules": [
+            {
+              "field": "applicationNumber",
+              "type": "required",
+              "severity": "error",
+              "message": "申請番号は必須です"
+            },
+            {
+              "field": "applicationNumber",
+              "type": "regex",
+              "severity": "error",
+              "pattern": "^BC[0-9]{8}[0-9]{8}$",
+              "message": "申請番号のフォーマットが不正です (例: BC2026042700000001)"
+            }
+          ],
+          "fieldErrorsVar": "fieldErrors",
+          "inlineBranch": {
+            "ok": [],
+            "ng": [],
+            "ngResponseId": "400-validation",
+            "ngBodyExpression": "{ code: 'VALIDATION', message: '入力値が不正です', fieldErrors: @fieldErrors }"
+          }
+        },
+        {
+          "id": "step-02",
+          "kind": "dbAccess",
+          "description": "applications テーブルから申請番号で当該申請を取得",
+          "tableId": "0e169ac3-e54e-46f5-b0e2-2e937f0944bb",
+          "operation": "SELECT",
+          "sql": "SELECT id, application_number, applicant_id, status, public_notice_start_at, public_notice_end_at, decided_at FROM applications WHERE application_number = @inputs.applicationNumber",
+          "outputBinding": { "name": "application" },
+          "lineage": { "reads": [{ "tableId": "0e169ac3-e54e-46f5-b0e2-2e937f0944bb", "purpose": "lookup" }] }
+        },
+        {
+          "id": "step-03",
+          "kind": "branch",
+          "description": "申請が存在しない場合 → 404",
+          "branches": [
+            {
+              "id": "br-03-a",
+              "code": "A",
+              "label": "申請なし",
+              "condition": { "kind": "expression", "expression": "@application == null" },
+              "steps": [
+                {
+                  "id": "step-03-a-01",
+                  "kind": "return",
+                  "description": "404 Not Found",
+                  "responseId": "404-not-found",
+                  "bodyExpression": "{ code: 'APPLICATION_NOT_FOUND', message: '申請が見つかりません' }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": { "id": "br-03-else", "code": "B", "label": "申請あり", "steps": [] }
+        },
+        {
+          "id": "step-04",
+          "kind": "branch",
+          "description": "認証ユーザーが申請者本人かを検証。applicants テーブルの applicant_id が sessionUserId に対応するか確認。本人以外は 403。",
+          "branches": [
+            {
+              "id": "br-04-a",
+              "code": "A",
+              "label": "本人以外",
+              "condition": { "kind": "expression", "expression": "@application.applicant_id != @sessionUserId" },
+              "steps": [
+                {
+                  "id": "step-04-a-01",
+                  "kind": "return",
+                  "description": "403 Forbidden",
+                  "responseId": "403-forbidden",
+                  "bodyExpression": "{ code: 'FORBIDDEN', message: '本人以外はアクセスできません' }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": { "id": "br-04-else", "code": "B", "label": "本人確認OK", "steps": [] }
+        },
+        {
+          "id": "step-05",
+          "kind": "compute",
+          "description": "公示中 (status='under_public_notice') の場合に残り公示日数を計算。公示中でなければ null。",
+          "expression": "@application.status == 'under_public_notice' ? Math.ceil((@application.public_notice_end_at - @now) / 86400000) : null",
+          "outputBinding": { "name": "remainingNoticeDays" }
+        },
+        {
+          "id": "step-06",
+          "kind": "compute",
+          "description": "ステータスコードを人間向けメッセージに変換",
+          "expression": "{ received: '受付済み - 審査待ち', under_review: '一次審査中', under_public_notice: '公示期間中', objection_review: '異議申立審査中', final_decision: '最終決裁中', approved: '確認済み (承認)', rejected: '却下', cancelled: '取下済み' }[@application.status] ?? @application.status",
+          "outputBinding": { "name": "statusMessage" }
+        },
+        {
+          "id": "step-07",
+          "kind": "audit",
+          "description": "個人情報アクセスのため監査ログを記録 (sensitive=true)",
+          "action": "public.application.status_query",
+          "resource": {
+            "type": "application",
+            "id": "@application.application_number"
+          },
+          "result": "success",
+          "sensitive": true
+        },
+        {
+          "id": "step-08",
+          "kind": "return",
+          "description": "200 OK — 照会結果を返す。R3-1 fix: valueFrom.flowVariable.variableName でobject field 参照 (application.application_number 等) を活用。",
+          "responseId": "200-ok",
+          "bodyExpression": "{ applicationNumber: @application.application_number, status: @application.status, statusMessage: @statusMessage, publicNoticeStartAt: @application.public_notice_start_at, publicNoticeEndAt: @application.public_notice_end_at, decidedAt: @application.decided_at, remainingNoticeDays: @remainingNoticeDays }"
+        }
+      ]
+    }
+  ],
+  "authoring": {
+    "decisions": [
+      {
+        "id": "ADR-001",
+        "title": "本人確認は DB 結合ではなく applicant_id と sessionUserId の直接比較",
+        "status": "accepted",
+        "context": "申請者本人確認の方法として (A) applicants テーブルを JOIN して session ユーザーと照合する か (B) applications.applicant_id と @sessionUserId を直接比較する かを選択。",
+        "decision": "本フローでは (B) を採用。applicant_id が FK として sessionUserId (認証ユーザーの主キー) に対応している前提。実運用では applicants テーブルの外部キー構造に依存するが、参照系フローのシンプルさを優先。",
+        "consequences": "applicant_id が sessionUserId と同一形式で格納されている前提。認証基盤との整合は実装時に確認が必要。",
+        "date": "2026-04-28"
+      }
+    ],
+    "glossary": {
+      "残り公示日数": {
+        "definition": "公示中 (status=under_public_notice) の申請に対し、公示終了日時 (public_notice_end_at) から現在時刻 (@now) を引いた残余日数。小数は切り上げ (Math.ceil)。公示中でない場合は null を返す。",
+        "aliases": ["Remaining Notice Days"]
+      }
+    },
+    "testScenarios": [
+      {
+        "id": "happy-path-approved",
+        "name": "承認済み申請の照会",
+        "given": [
+          { "kind": "sessionContext", "context": { "requestId": "req-001", "sessionUserId": "user-001" } },
+          {
+            "kind": "dbState",
+            "tableId": "0e169ac3-e54e-46f5-b0e2-2e937f0944bb",
+            "rows": [
+              {
+                "id": 1,
+                "application_number": "BC2026042700000001",
+                "applicant_id": "user-001",
+                "status": "approved",
+                "public_notice_start_at": null,
+                "public_notice_end_at": null,
+                "decided_at": "2026-04-27T12:00:00.000Z"
+              }
+            ]
+          }
+        ],
+        "when": {
+          "actionId": "act-001",
+          "input": { "applicationNumber": "BC2026042700000001" }
+        },
+        "then": [
+          { "kind": "outcome", "expected": "200-ok" },
+          { "kind": "output", "path": "$.status", "equals": "approved" },
+          { "kind": "output", "path": "$.statusMessage", "equals": "確認済み (承認)" },
+          { "kind": "output", "path": "$.remainingNoticeDays", "equals": null },
+          { "kind": "auditLog", "action": "public.application.status_query", "result": "success" }
+        ],
+        "tags": ["happy", "approved"]
+      },
+      {
+        "id": "happy-path-under-public-notice",
+        "name": "公示中申請の照会 (残り日数あり)",
+        "given": [
+          { "kind": "sessionContext", "context": { "requestId": "req-002", "sessionUserId": "user-002" } },
+          {
+            "kind": "dbState",
+            "tableId": "0e169ac3-e54e-46f5-b0e2-2e937f0944bb",
+            "rows": [
+              {
+                "id": 2,
+                "application_number": "BC2026042700000002",
+                "applicant_id": "user-002",
+                "status": "under_public_notice",
+                "public_notice_start_at": "2026-04-20T00:00:00.000Z",
+                "public_notice_end_at": "2026-05-04T00:00:00.000Z",
+                "decided_at": null
+              }
+            ]
+          }
+        ],
+        "when": {
+          "actionId": "act-001",
+          "input": { "applicationNumber": "BC2026042700000002" }
+        },
+        "then": [
+          { "kind": "outcome", "expected": "200-ok" },
+          { "kind": "output", "path": "$.status", "equals": "under_public_notice" },
+          { "kind": "output", "path": "$.statusMessage", "equals": "公示期間中" }
+        ],
+        "tags": ["happy", "under-public-notice"]
+      },
+      {
+        "id": "not-found",
+        "name": "存在しない申請番号 → 404",
+        "given": [
+          { "kind": "sessionContext", "context": { "requestId": "req-003", "sessionUserId": "user-001" } },
+          { "kind": "dbState", "tableId": "0e169ac3-e54e-46f5-b0e2-2e937f0944bb", "rows": [] }
+        ],
+        "when": {
+          "actionId": "act-001",
+          "input": { "applicationNumber": "BC2026042799999999" }
+        },
+        "then": [{ "kind": "outcome", "expected": "404-not-found" }],
+        "tags": ["error", "not-found"]
+      },
+      {
+        "id": "forbidden",
+        "name": "他人の申請照会 → 403",
+        "given": [
+          { "kind": "sessionContext", "context": { "requestId": "req-004", "sessionUserId": "user-999" } },
+          {
+            "kind": "dbState",
+            "tableId": "0e169ac3-e54e-46f5-b0e2-2e937f0944bb",
+            "rows": [
+              {
+                "id": 1,
+                "application_number": "BC2026042700000001",
+                "applicant_id": "user-001",
+                "status": "approved",
+                "public_notice_start_at": null,
+                "public_notice_end_at": null,
+                "decided_at": "2026-04-27T12:00:00.000Z"
+              }
+            ]
+          }
+        ],
+        "when": {
+          "actionId": "act-001",
+          "input": { "applicationNumber": "BC2026042700000001" }
+        },
+        "then": [{ "kind": "outcome", "expected": "403-forbidden" }],
+        "tags": ["error", "forbidden"]
+      },
+      {
+        "id": "validation-error",
+        "name": "申請番号フォーマット不正 → 400",
+        "given": [
+          { "kind": "sessionContext", "context": { "requestId": "req-005", "sessionUserId": "user-001" } }
+        ],
+        "when": {
+          "actionId": "act-001",
+          "input": { "applicationNumber": "INVALID-FORMAT" }
+        },
+        "then": [{ "kind": "outcome", "expected": "400-validation" }],
+        "tags": ["error", "validation"]
+      }
+    ],
+    "notes": [
+      {
+        "id": "note-r4-sonnet-01",
+        "kind": "assumption",
+        "body": "Round 4 dogfood (#535) Sonnet 担当分。Opus 作の 5 段 workflow 連結フロー (1cd900ee) と対比する参照系フローとして設計。WorkflowPattern を使わず validation / dbAccess / branch / compute / audit / return の基本 6 step-kind のみで完結させることで、schema の網羅性検証とは別軸 (シンプル参照系の表現力) を検証する。R3-1 fix (variableName で IdentifierPath = object field 参照) を @application.application_number / @application.status 等の形式で実機使用。Opus 5 段フローを読んだ感想: WorkflowStep の onApproved / onRejected 内に DB INSERT / eventPublish を入れ子にする構造は意図が明確で読みやすいが、5 stage が 1 フローに並ぶと全体長が増大し可読性とトレードオフになる。実運用では ADR-001 にあるようにイベント駆動分割が現実的だと感じた。",
+        "createdAt": "2026-04-28T00:00:00.000Z"
+      },
+      {
+        "id": "note-r4-sonnet-02",
+        "kind": "deferred",
+        "body": "本フローでは eventPublish step を省略した (監査ログのみ記録)。実運用では public.application_status_queried イベントを catalog に登録し、集計・アクセス監視に利用することを検討。catalog.events には定義済みのため、eventPublish step の追加は容易。",
+        "createdAt": "2026-04-28T00:00:00.000Z"
+      }
+    ]
+  }
+}

--- a/docs/sample-project-v3/public-service/project.json
+++ b/docs/sample-project-v3/public-service/project.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "../../../schemas/v3/project.v3.schema.json",
+  "schemaVersion": "v3",
+  "meta": {
+    "id": "4954fa07-ee78-4c3e-8c2a-bf512d29ec6c",
+    "name": "v3 dogfood Round 4 — public-service (建築確認申請)",
+    "description": "PR #534 (#533 R3-1〜R3-3 fix) マージ後の v3.0.2 を新業界 (公共サービス) で再検証する Round 4 サンプル (#535)。Round 1〜3 で fixture では cover したが業務文脈で未検証だった WorkflowPattern 4 種 (acknowledge / review / sign-off / approval-veto) を 5 段連結フローで実機検証する。",
+    "version": "1.0.0",
+    "maturity": "draft",
+    "createdAt": "2026-04-28T00:00:00.000Z",
+    "updatedAt": "2026-04-28T00:00:00.000Z",
+    "mode": "upstream"
+  },
+  "extensionsApplied": [
+    { "namespace": "public-service", "version": ">=1.0.0" }
+  ],
+  "entities": {
+    "screens": [
+      {
+        "id": "f9de5853-db95-4dc5-aefc-ca03b482cfd9",
+        "no": 1,
+        "name": "建築確認申請",
+        "updatedAt": "2026-04-28T00:00:00.000Z",
+        "maturity": "committed",
+        "kind": "form",
+        "path": "/public/applications/building-confirmation/new",
+        "hasDesign": false
+      }
+    ],
+    "tables": [
+      { "id": "5ebdcbd7-0a49-463d-af3b-226ba1e3e36c", "no": 1, "name": "申請者", "updatedAt": "2026-04-28T00:00:00.000Z", "maturity": "committed", "physicalName": "applicants", "category": "マスタ", "columnCount": 10 },
+      { "id": "0e169ac3-e54e-46f5-b0e2-2e937f0944bb", "no": 2, "name": "建築確認申請", "updatedAt": "2026-04-28T00:00:00.000Z", "maturity": "committed", "physicalName": "applications", "category": "トランザクション", "columnCount": 16 },
+      { "id": "79cfcc11-ed1d-45f8-b76e-6cf7b1133d13", "no": 3, "name": "申請承認履歴", "updatedAt": "2026-04-28T00:00:00.000Z", "maturity": "committed", "physicalName": "application_approvals", "category": "ログ", "columnCount": 9 },
+      { "id": "61fe772b-ed5c-40bb-990c-c5d0aa84df59", "no": 4, "name": "添付資料", "updatedAt": "2026-04-28T00:00:00.000Z", "maturity": "committed", "physicalName": "attachments", "category": "トランザクション", "columnCount": 7 }
+    ],
+    "processFlows": [
+      {
+        "id": "1cd900ee-0d69-4e0a-a32b-bb329f9bc983",
+        "no": 1,
+        "name": "建築確認申請審査 (5 段 workflow)",
+        "updatedAt": "2026-04-28T00:00:00.000Z",
+        "maturity": "committed",
+        "kind": "screen",
+        "screenId": "f9de5853-db95-4dc5-aefc-ca03b482cfd9",
+        "actionCount": 1
+      },
+      {
+        "id": "72fe2c92-ff7b-4de1-9a6a-ed0dd1216118",
+        "no": 2,
+        "name": "申請ステータス通知",
+        "updatedAt": "2026-04-28T00:00:00.000Z",
+        "maturity": "committed",
+        "kind": "system",
+        "actionCount": 1
+      }
+    ]
+  }
+}

--- a/docs/sample-project-v3/public-service/screens/f9de5853-db95-4dc5-aefc-ca03b482cfd9.json
+++ b/docs/sample-project-v3/public-service/screens/f9de5853-db95-4dc5-aefc-ca03b482cfd9.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "../../../../schemas/v3/screen.v3.schema.json",
+  "id": "f9de5853-db95-4dc5-aefc-ca03b482cfd9",
+  "name": "建築確認申請",
+  "description": "市民が建築確認申請を提出する画面。建築地・用途・延床面積を入力。提出後は審査フローへ遷移。",
+  "version": "1.0.0",
+  "maturity": "committed",
+  "createdAt": "2026-04-28T00:00:00.000Z",
+  "updatedAt": "2026-04-28T00:00:00.000Z",
+  "kind": "form",
+  "path": "/public/applications/building-confirmation/new",
+  "auth": "required",
+  "items": [
+    {
+      "id": "applicantCode",
+      "label": "申請者コード",
+      "type": { "kind": "extension", "extensionRef": "public-service:applicantCode" },
+      "direction": "input",
+      "required": true
+    },
+    {
+      "id": "siteAddress",
+      "label": "建築地",
+      "type": "string",
+      "direction": "input",
+      "required": true,
+      "maxLength": 500
+    },
+    {
+      "id": "buildingUse",
+      "label": "建物用途",
+      "type": { "kind": "extension", "extensionRef": "public-service:buildingUse" },
+      "direction": "input",
+      "required": true,
+      "options": [
+        { "value": "residential", "label": "住宅" },
+        { "value": "commercial", "label": "商業" },
+        { "value": "industrial", "label": "工業" },
+        { "value": "public", "label": "公共" }
+      ]
+    },
+    {
+      "id": "totalFloorAreaSqm",
+      "label": "延床面積 (㎡)",
+      "type": "number",
+      "direction": "input",
+      "required": true,
+      "min": 1,
+      "step": 0.01
+    },
+    {
+      "id": "applicationNumber",
+      "label": "申請番号",
+      "type": "string",
+      "direction": "output",
+      "valueFrom": { "kind": "flowVariable", "variableName": "createdApplication.application_number" },
+      "helperText": "受付後に自動採番されます (#533 R3-1 fix で flowVariable + dot 形式が直接書けます)。"
+    },
+    {
+      "id": "publicNoticeEndAt",
+      "label": "公示終了予定日",
+      "type": "datetime",
+      "direction": "output",
+      "valueFrom": { "kind": "expression", "expression": "@createdApplication.public_notice_end_at" },
+      "helperText": "公示期間 14 日後の日時。",
+      "displayFormat": "YYYY/MM/DD"
+    }
+  ],
+  "design": { "designFileRef": "design.json" }
+}

--- a/docs/sample-project-v3/public-service/tables/0e169ac3-e54e-46f5-b0e2-2e937f0944bb.json
+++ b/docs/sample-project-v3/public-service/tables/0e169ac3-e54e-46f5-b0e2-2e937f0944bb.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "../../../../schemas/v3/table.v3.schema.json",
+  "id": "0e169ac3-e54e-46f5-b0e2-2e937f0944bb",
+  "name": "建築確認申請",
+  "description": "建築確認申請の本体。status は 5 段階の workflow を反映: received (受付) / under_review (一次審査) / under_public_notice (公示中) / objection_review (異議申立対応) / final_decision (最終決裁) / approved / rejected / cancelled。",
+  "version": "1.0.0",
+  "maturity": "committed",
+  "createdAt": "2026-04-28T00:00:00.000Z",
+  "updatedAt": "2026-04-28T00:00:00.000Z",
+  "physicalName": "applications",
+  "category": "トランザクション",
+  "comment": "申請履歴。status 遷移は WorkflowStep で管理。public_notice_start_at + public_notice_end_at で公示期間 14 日を保持。",
+  "columns": [
+    { "id": "col-app01", "no": 1, "physicalName": "id", "name": "申請ID", "dataType": "BIGINT", "notNull": true, "primaryKey": true, "autoIncrement": true },
+    { "id": "col-app02", "no": 2, "physicalName": "application_number", "name": "申請番号", "dataType": "VARCHAR", "length": 20, "notNull": true, "unique": true, "comment": "BC + YYYYMMDD + 連番8桁。" },
+    { "id": "col-app03", "no": 3, "physicalName": "applicant_id", "name": "申請者ID", "dataType": "BIGINT", "notNull": true },
+    { "id": "col-app04", "no": 4, "physicalName": "site_address", "name": "建築地", "dataType": "VARCHAR", "length": 500, "notNull": true },
+    { "id": "col-app05", "no": 5, "physicalName": "building_use", "name": "建物用途", "dataType": "VARCHAR", "length": 100, "notNull": true, "comment": "residential / commercial / industrial / public 等。" },
+    { "id": "col-app06", "no": 6, "physicalName": "total_floor_area_sqm", "name": "延床面積", "dataType": "DECIMAL", "length": 10, "scale": 2, "notNull": true, "comment": "平方メートル。" },
+    { "id": "col-app07", "no": 7, "physicalName": "status", "name": "ステータス", "dataType": "VARCHAR", "length": 30, "notNull": true, "comment": "received / under_review / under_public_notice / objection_review / final_decision / approved / rejected / cancelled" },
+    { "id": "col-app08", "no": 8, "physicalName": "submitted_at", "name": "受付日時", "dataType": "TIMESTAMP", "notNull": true },
+    { "id": "col-app09", "no": 9, "physicalName": "review_started_at", "name": "一次審査開始日時", "dataType": "TIMESTAMP" },
+    { "id": "col-app10", "no": 10, "physicalName": "public_notice_start_at", "name": "公示開始日時", "dataType": "TIMESTAMP" },
+    { "id": "col-app11", "no": 11, "physicalName": "public_notice_end_at", "name": "公示終了日時", "dataType": "TIMESTAMP", "comment": "公示開始 + 14 日 (法定期間)。" },
+    { "id": "col-app12", "no": 12, "physicalName": "objection_count", "name": "異議申立件数", "dataType": "INTEGER", "notNull": true, "defaultValue": "0" },
+    { "id": "col-app13", "no": 13, "physicalName": "decided_at", "name": "決裁日時", "dataType": "TIMESTAMP" },
+    { "id": "col-app14", "no": 14, "physicalName": "rejection_reason", "name": "却下理由", "dataType": "TEXT" },
+    { "id": "col-app15", "no": 15, "physicalName": "created_at", "name": "作成日時", "dataType": "TIMESTAMP", "notNull": true, "defaultValue": "CURRENT_TIMESTAMP" },
+    { "id": "col-app16", "no": 16, "physicalName": "updated_at", "name": "更新日時", "dataType": "TIMESTAMP", "notNull": true, "defaultValue": "CURRENT_TIMESTAMP" }
+  ],
+  "indexes": [
+    { "id": "idx-app01", "physicalName": "idx_applications_application_number", "columns": [{ "columnId": "col-app02" }], "unique": true },
+    { "id": "idx-app02", "physicalName": "idx_applications_status_submitted", "columns": [{ "columnId": "col-app07" }, { "columnId": "col-app08", "order": "desc" }] },
+    { "id": "idx-app03", "physicalName": "idx_applications_under_public_notice", "columns": [{ "columnId": "col-app11" }], "where": "status = 'under_public_notice'", "description": "公示期間中の申請を高速検索 (Partial Index)" }
+  ],
+  "constraints": [
+    {
+      "id": "fk-app01",
+      "kind": "foreignKey",
+      "physicalName": "fk_applications_applicant",
+      "columnIds": ["col-app03"],
+      "referencedTableId": "5ebdcbd7-0a49-463d-af3b-226ba1e3e36c",
+      "referencedColumnIds": ["col-ap01"],
+      "onDelete": "restrict",
+      "onUpdate": "cascade"
+    },
+    {
+      "id": "chk-app01",
+      "kind": "check",
+      "physicalName": "chk_applications_status_enum",
+      "expression": "status IN ('received', 'under_review', 'under_public_notice', 'objection_review', 'final_decision', 'approved', 'rejected', 'cancelled')"
+    },
+    {
+      "id": "chk-app02",
+      "kind": "check",
+      "physicalName": "chk_applications_floor_area_positive",
+      "expression": "total_floor_area_sqm > 0"
+    },
+    {
+      "id": "chk-app03",
+      "kind": "check",
+      "physicalName": "chk_applications_public_notice_period",
+      "expression": "public_notice_end_at IS NULL OR public_notice_end_at >= public_notice_start_at"
+    },
+    {
+      "id": "chk-app04",
+      "kind": "check",
+      "physicalName": "chk_applications_objection_nonnegative",
+      "expression": "objection_count >= 0"
+    }
+  ]
+}

--- a/docs/sample-project-v3/public-service/tables/5ebdcbd7-0a49-463d-af3b-226ba1e3e36c.json
+++ b/docs/sample-project-v3/public-service/tables/5ebdcbd7-0a49-463d-af3b-226ba1e3e36c.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "../../../../schemas/v3/table.v3.schema.json",
+  "id": "5ebdcbd7-0a49-463d-af3b-226ba1e3e36c",
+  "name": "申請者",
+  "description": "公共サービス申請の申請者情報。個人情報を含むため sensitive 扱い、AuditStep / Trigger で監査ログを必須とする。",
+  "version": "1.0.0",
+  "maturity": "committed",
+  "createdAt": "2026-04-28T00:00:00.000Z",
+  "updatedAt": "2026-04-28T00:00:00.000Z",
+  "physicalName": "applicants",
+  "category": "マスタ",
+  "comment": "申請者マスタ。住民票連携前提だが本サンプルでは独立保持。is_corporate=true で法人申請。",
+  "columns": [
+    { "id": "col-ap01", "no": 1, "physicalName": "id", "name": "申請者ID", "dataType": "BIGINT", "notNull": true, "primaryKey": true, "autoIncrement": true },
+    { "id": "col-ap02", "no": 2, "physicalName": "applicant_code", "name": "申請者コード", "dataType": "VARCHAR", "length": 20, "notNull": true, "unique": true, "comment": "AP + 8 桁数字。" },
+    { "id": "col-ap03", "no": 3, "physicalName": "name", "name": "氏名 (法人名)", "dataType": "VARCHAR", "length": 200, "notNull": true },
+    { "id": "col-ap04", "no": 4, "physicalName": "name_kana", "name": "氏名カナ", "dataType": "VARCHAR", "length": 400 },
+    { "id": "col-ap05", "no": 5, "physicalName": "is_corporate", "name": "法人フラグ", "dataType": "BOOLEAN", "notNull": true, "defaultValue": "false" },
+    { "id": "col-ap06", "no": 6, "physicalName": "address", "name": "住所", "dataType": "VARCHAR", "length": 500, "notNull": true, "comment": "個人情報、sensitive 扱い。" },
+    { "id": "col-ap07", "no": 7, "physicalName": "phone", "name": "電話番号", "dataType": "VARCHAR", "length": 20 },
+    { "id": "col-ap08", "no": 8, "physicalName": "email", "name": "メール", "dataType": "VARCHAR", "length": 255 },
+    { "id": "col-ap09", "no": 9, "physicalName": "created_at", "name": "作成日時", "dataType": "TIMESTAMP", "notNull": true, "defaultValue": "CURRENT_TIMESTAMP" },
+    { "id": "col-ap10", "no": 10, "physicalName": "updated_at", "name": "更新日時", "dataType": "TIMESTAMP", "notNull": true, "defaultValue": "CURRENT_TIMESTAMP" }
+  ],
+  "indexes": [
+    { "id": "idx-ap01", "physicalName": "idx_applicants_applicant_code", "columns": [{ "columnId": "col-ap02" }], "unique": true }
+  ],
+  "constraints": [
+    {
+      "id": "chk-ap01",
+      "kind": "check",
+      "physicalName": "chk_applicants_code_pattern",
+      "expression": "applicant_code ~ '^AP[0-9]{8}$'"
+    }
+  ]
+}

--- a/docs/sample-project-v3/public-service/tables/61fe772b-ed5c-40bb-990c-c5d0aa84df59.json
+++ b/docs/sample-project-v3/public-service/tables/61fe772b-ed5c-40bb-990c-c5d0aa84df59.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "../../../../schemas/v3/table.v3.schema.json",
+  "id": "61fe772b-ed5c-40bb-990c-c5d0aa84df59",
+  "name": "添付資料",
+  "description": "建築確認申請に添付される図面・計算書・申請書類。1 申請 = 多数添付。file_path はオブジェクトストレージへの URL。",
+  "version": "1.0.0",
+  "maturity": "committed",
+  "createdAt": "2026-04-28T00:00:00.000Z",
+  "updatedAt": "2026-04-28T00:00:00.000Z",
+  "physicalName": "attachments",
+  "category": "トランザクション",
+  "comment": "添付ファイル。kind で資料種別を分類。法令で定められた必須資料を一覧する用途。",
+  "columns": [
+    { "id": "col-at01", "no": 1, "physicalName": "id", "name": "添付ID", "dataType": "BIGINT", "notNull": true, "primaryKey": true, "autoIncrement": true },
+    { "id": "col-at02", "no": 2, "physicalName": "application_id", "name": "申請ID", "dataType": "BIGINT", "notNull": true },
+    { "id": "col-at03", "no": 3, "physicalName": "kind", "name": "資料種別", "dataType": "VARCHAR", "length": 50, "notNull": true, "comment": "blueprint (図面) / structural_calc (構造計算書) / energy_report (省エネ計算書) / declaration (申請書) / other" },
+    { "id": "col-at04", "no": 4, "physicalName": "file_name", "name": "ファイル名", "dataType": "VARCHAR", "length": 255, "notNull": true },
+    { "id": "col-at05", "no": 5, "physicalName": "file_path", "name": "ファイルパス", "dataType": "VARCHAR", "length": 500, "notNull": true, "comment": "オブジェクトストレージ URL (S3 / GCS 等)。" },
+    { "id": "col-at06", "no": 6, "physicalName": "file_size_bytes", "name": "ファイルサイズ", "dataType": "BIGINT", "notNull": true },
+    { "id": "col-at07", "no": 7, "physicalName": "uploaded_at", "name": "アップロード日時", "dataType": "TIMESTAMP", "notNull": true, "defaultValue": "CURRENT_TIMESTAMP" }
+  ],
+  "indexes": [
+    { "id": "idx-at01", "physicalName": "idx_attachments_application", "columns": [{ "columnId": "col-at02" }] }
+  ],
+  "constraints": [
+    {
+      "id": "fk-at01",
+      "kind": "foreignKey",
+      "physicalName": "fk_attachments_application",
+      "columnIds": ["col-at02"],
+      "referencedTableId": "0e169ac3-e54e-46f5-b0e2-2e937f0944bb",
+      "referencedColumnIds": ["col-app01"],
+      "onDelete": "cascade",
+      "onUpdate": "cascade"
+    },
+    {
+      "id": "chk-at01",
+      "kind": "check",
+      "physicalName": "chk_attachments_kind_enum",
+      "expression": "kind IN ('blueprint', 'structural_calc', 'energy_report', 'declaration', 'other')"
+    },
+    {
+      "id": "chk-at02",
+      "kind": "check",
+      "physicalName": "chk_attachments_file_size",
+      "expression": "file_size_bytes > 0"
+    }
+  ]
+}

--- a/docs/sample-project-v3/public-service/tables/79cfcc11-ed1d-45f8-b76e-6cf7b1133d13.json
+++ b/docs/sample-project-v3/public-service/tables/79cfcc11-ed1d-45f8-b76e-6cf7b1133d13.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "../../../../schemas/v3/table.v3.schema.json",
+  "id": "79cfcc11-ed1d-45f8-b76e-6cf7b1133d13",
+  "name": "申請承認履歴",
+  "description": "建築確認申請の各段階 (5 stages) の承認履歴。1 申請 = 5 行 (受付 / 一次審査 / 公示 / 異議申立対応 / 最終決裁)。",
+  "version": "1.0.0",
+  "maturity": "committed",
+  "createdAt": "2026-04-28T00:00:00.000Z",
+  "updatedAt": "2026-04-28T00:00:00.000Z",
+  "physicalName": "application_approvals",
+  "category": "ログ",
+  "comment": "WorkflowStep の各段階で 1 行 INSERT、stage で何段階目かを識別。",
+  "columns": [
+    { "id": "col-aa01", "no": 1, "physicalName": "id", "name": "承認ID", "dataType": "BIGINT", "notNull": true, "primaryKey": true, "autoIncrement": true },
+    { "id": "col-aa02", "no": 2, "physicalName": "application_id", "name": "申請ID", "dataType": "BIGINT", "notNull": true },
+    { "id": "col-aa03", "no": 3, "physicalName": "stage", "name": "段階", "dataType": "VARCHAR", "length": 30, "notNull": true, "comment": "received_acknowledge / first_review / public_notice / objection_response / final_decision" },
+    { "id": "col-aa04", "no": 4, "physicalName": "decision", "name": "判断", "dataType": "VARCHAR", "length": 20, "notNull": true, "comment": "approved / rejected / acknowledged (受付段階) / signed_off (公示段階)" },
+    { "id": "col-aa05", "no": 5, "physicalName": "reviewer_user_id", "name": "判断者ID", "dataType": "VARCHAR", "length": 50, "notNull": true },
+    { "id": "col-aa06", "no": 6, "physicalName": "reviewer_role", "name": "判断者役職", "dataType": "VARCHAR", "length": 30, "notNull": true, "comment": "staff (担当) / manager (課長) / director (部長) / clerk (書記)" },
+    { "id": "col-aa07", "no": 7, "physicalName": "decided_at", "name": "判断日時", "dataType": "TIMESTAMP", "notNull": true, "defaultValue": "CURRENT_TIMESTAMP" },
+    { "id": "col-aa08", "no": 8, "physicalName": "comment", "name": "コメント", "dataType": "TEXT" },
+    { "id": "col-aa09", "no": 9, "physicalName": "created_at", "name": "作成日時", "dataType": "TIMESTAMP", "notNull": true, "defaultValue": "CURRENT_TIMESTAMP" }
+  ],
+  "indexes": [
+    { "id": "idx-aa01", "physicalName": "idx_application_approvals_application_stage", "columns": [{ "columnId": "col-aa02" }, { "columnId": "col-aa03" }] }
+  ],
+  "constraints": [
+    {
+      "id": "fk-aa01",
+      "kind": "foreignKey",
+      "physicalName": "fk_application_approvals_application",
+      "columnIds": ["col-aa02"],
+      "referencedTableId": "0e169ac3-e54e-46f5-b0e2-2e937f0944bb",
+      "referencedColumnIds": ["col-app01"],
+      "onDelete": "cascade",
+      "onUpdate": "cascade"
+    },
+    {
+      "id": "chk-aa01",
+      "kind": "check",
+      "physicalName": "chk_application_approvals_stage_enum",
+      "expression": "stage IN ('received_acknowledge', 'first_review', 'public_notice', 'objection_response', 'final_decision')"
+    },
+    {
+      "id": "chk-aa02",
+      "kind": "check",
+      "physicalName": "chk_application_approvals_decision_enum",
+      "expression": "decision IN ('approved', 'rejected', 'acknowledged', 'signed_off')"
+    }
+  ]
+}

--- a/docs/spec/dogfood-2026-04-28-schema-v3-public-service.md
+++ b/docs/spec/dogfood-2026-04-28-schema-v3-public-service.md
@@ -1,0 +1,156 @@
+# Schema v3 Dogfood Round 4 評価レポート (#535, public-service)
+
+| 項目 | 値 |
+|---|---|
+| ISSUE | #535 (Round 4) |
+| 実施日 | 2026-04-28 |
+| 対象 | PR #534 (#533 R3-1〜R3-3 fix) マージ後の v3.0.2、Round 1〜3 で fixture のみで業務未検証だった WorkflowPattern 4 種 |
+| サンプル所在地 | `docs/sample-project-v3/public-service/` |
+| AJV 検証 | `designer/src/schemas/v3-samples.test.ts` (14) + `v3-variant-coverage.test.ts` (47) = **61 test 全 pass** |
+| 担当 | Opus (主、5 段 workflow フロー) + Sonnet (1 件: 申請ステータス通知) |
+
+---
+
+## 1. スコープ・成果物
+
+`docs/sample-project-v3/public-service/` に建築確認申請プロジェクト一式:
+
+| 種別 | ファイル | 件数 |
+|---|---|---|
+| Project | `project.json` | 1 |
+| Table | applicants / applications / application_approvals / attachments | 4 |
+| Screen | 建築確認申請 (`f9de5853-...json`) | 1 |
+| ProcessFlow (Opus) | 建築確認申請審査 5 段 workflow (`1cd900ee-...json`) | 1 |
+| ProcessFlow (Sonnet) | 申請ステータス通知 (`72fe2c92-...json`) | 1 |
+| Extension | `public.v3.json` | 1 |
+| **合計** | — | **9 ファイル** |
+
+---
+
+## 2. Round 4 で検証した WorkflowPattern 業務文脈
+
+Round 1〜3 で**実機サンプルで使用したのは `approval-sequential` のみ**。fixture では他 10 種を cover したが業務妥当性は未検証だった。本ラウンドで 5 段 workflow 連結フローを実機検証:
+
+| Stage | WorkflowPattern | 業務シナリオ | 結果 |
+|---|---|---|---|
+| 1. 受付 | `acknowledge` | 受付担当者が申請を受領、決定権なし、記録のみ | ✅ approver 1 名、決定権なしの semantics が schema 上自然 |
+| 2. 一次審査 | `review` | 担当者が建築基準法・条例適合性を判断、却下なら return | ✅ 単純承認/却下の表現として `approval-sequential` (1 名) との違いがやや曖昧、運用ガイドで補完推奨 |
+| 3. 公示期間 | `sign-off` | 14 日法定公示、deadline 必須、書記が公示終了後に sign-off | ✅ `deadlineExpression` で公示期限を表現可、deadline 経過時の挙動は v3 schema レベルでは明示なし (運用が onTimeout 等で補完) |
+| 4. 異議申立対応 | `approval-veto` | 利害関係者 (近隣住民代表 / 環境担当) が異議、1 件でも veto なら却下 | ✅ approvers[] が複数で、1 名の rejected が onRejected に流れる semantics は明確 |
+| 5. 最終決裁 | `approval-sequential` | 担当→課長→部長 3 段承認 (Round 1〜3 の再現性確認) | ✅ Round 1〜3 と同一動作を確認、互換性 OK |
+
+**所感**: 4 種の新 WorkflowPattern は schema 上自然に書けた。**Sonnet 報告**: 「`onApproved / onRejected` 内に dbAccess と eventPublish を入れ子にする構造の明確さが印象的、各 stage の承認/却下で何が起きるかが 1 箇所に凝縮」。
+
+ただし Sonnet 指摘あり: **5 WorkflowStep + 15+ 通常 step が 1 ProcessFlow に並ぶと認知負荷が高い** (後半 step の文脈変数追跡が困難)。これは ADR-001 で明示済 (本サンプルは schema 検証目的、実運用ではイベント駆動分割推奨)。
+
+---
+
+## 3. Round 1〜3 で導入した fix の実機効果
+
+| Fix | Round 4 での効果 |
+|---|---|
+| F-1 ($schema 属性) | 9 sample すべてに $schema 記述、IDE 補完が効く |
+| F-2 (StepBaseProps.lineage) | 5 段 workflow で lineage を 9 step に分散使用 (writes 多用) |
+| F-4 (discriminator) | BranchCondition / Constraint で focused エラー報告、新業界でも体感 |
+| **R3-1 (IdentifierPath)** | Sonnet 報告: 「**表現力が大きく向上**」、`application.application_number` / `application.status` 等の object field 参照が直接 flowVariable で書ける、以前 expression 切り出しが必要だった場面が型付きで書けるようになった |
+| R3-2 (cutoffAt pattern) | 本ラウンドでは出番なし (closing 不使用) |
+| R3-3 (scheduled+httpRoute) | 本ラウンドの 2 PF はどちらも httpRoute あり (kind=screen/system)、不整合チェックは `kind=scheduled` のフローでのみ効くため適用なし |
+
+---
+
+## 4. 3 分類別 件数集計 (Round 1〜4 比較)
+
+| 分類 | Round 1 (retail) | Round 2 (finance) | Round 3 (manufacturing) | Round 4 (public-service) |
+|---|---|---|---|---|
+| **フレームワーク** (schema 自体) | 4 件 (F-1〜F-4) | 0 件 | 3 件 (R3-1〜R3-3) | **0 件** ✨ |
+| **拡張定義** (extensions.v3) | 2 件 (容認 / v3.1 候補) | 0 件 | 0 件 | 0 件 |
+| **サンプル設計** (記述ミス系) | 2 件 | 0 件 | 0 件 | 0 件 |
+
+**Round 4 で新規 finding: 0 件** (Sonnet も Opus も)。
+
+---
+
+## 5. 依然未検証 WorkflowPattern (低優先度、容認可)
+
+Round 4 でカバーできなかった WorkflowPattern (fixture では検証済):
+
+- `approval-quorum` (majority / nOfM): 委員会等の合議制
+- `approval-escalation`: deadline 後の自動エスカレーション
+- `approval-parallel`: 並列承認
+- `branch-merge`: 並行 step の合流
+- `discussion`: 議論型 (決定なし)
+- `ad-hoc`: 即興型
+
+これら 6 種は fixture (構造的バリデーション) で正常動作を確認済。業務文脈での使用感は未確認だが、Round 4 までの実績で **schema が想定する semantics は十分明確** と判断 (各 pattern の必須プロパティ if/then 強制も discriminator + AJV で機能)。
+
+---
+
+## 6. v3.0 確定可否判定 (Round 4 結果反映)
+
+### 判定: **v3.0 確定可能、TS 同期着手推奨 ✅**
+
+根拠:
+- Round 4 で **新規 finding 0 件**、F-1〜F-4 + R3-1〜R3-3 の累計 7 件 fix 後 schema は実機で堅牢
+- 4 業界 (retail / finance / manufacturing / public-service) で計 41 sample (Round 1: 7 + R2: 9 + R3: 12 + R4: 9 + 4 layouts) を実機検証、**修正ループ 0 回 (Round 2 / 4) または 軽微 (Round 3)**
+- WorkflowPattern 11 種のうち **5 種は業務文脈実証済** (acknowledge/review/sign-off/approval-veto/approval-sequential)、**残り 6 種は fixture で構造検証済**
+- Sonnet 独立委譲が 4 ラウンド連続で迷いなく書けている = schema が「別 AI が独立に読める」品質に到達
+
+### 完成度評価 (改訂)
+
+- Round 1 後: 70-75% (β)
+- Round 2 後: 85-90% (RC 候補) → PR レビューで下方修正
+- Round 3 後: 80-85% (R3 finding 検出で後退)
+- **Round 4 後: 90-95% (TS 同期着手可能)**
+
+### 残存リスク (TS 同期で発覚する可能性)
+
+- v3.1 候補 #6 (拡張機構 object/array 不統一) は依然未対応 — TS 型同期時に表面化する可能性、breaking change で別 ISSUE
+- WorkflowPattern 6 種が業務文脈未検証 — TS 型同期は schema 構造のみ依存、実装層で issue が出る場合は別 ISSUE で対応
+- 業界 5 個目 (healthcare / 教育 / 物流 等) 未検証 — public-service と性質が異なる業界で R5-x が出る可能性は残る
+
+---
+
+## 7. 追加ラウンド要否の判断材料 (ユーザー相談用)
+
+memory `project_schema_v3_2026_04_27.md` の品質評価ゲート規定 (2026-04-28 ユーザー確認): **0 件でも総合評価、対応できる問題があれば追加ラウンド可**。
+
+### 追加ラウンドを「やる」根拠
+
+- 残 WorkflowPattern 6 種を業務文脈で押さえれば 95%+ の自信
+- 業界 5 個目 (healthcare / 教育) で発見される可能性は理論上残る
+- TS 同期着手前に schema を確実に固める方が下流リワーク回避
+
+### 追加ラウンドを「やらない」根拠
+
+- Round 4 で新規 0 件、収束を強く示唆 (Round 1: 4 → R2: 0 → R3: 3 → R4: 0、振動はあるが下限が下がってきている)
+- 残 WorkflowPattern 6 種は fixture で構造検証済 = AJV 構造的には問題なし、業務妥当性は実装層 (TS 型 / UI) で発覚しても schema 修正なしに対処可能
+- TS 同期は schema 変更を最小限にできる前提で進められる
+- 4 業界 41 sample は dogfood として十分豊富
+
+### 推奨
+
+**TS 同期着手を推奨**。Round 5 (例: healthcare) は **TS 同期と並行可能** (memory rule 通り、マージブロッカーではない)。TS 同期で schema 改善が必要と判明したら、その時点で R5 を起票して優先度判断する流れが実用的。
+
+---
+
+## 8. 後続 ISSUE 優先順位 (Round 4 後の確定版)
+
+| 優先度 | ISSUE | 状態 |
+|---|---|---|
+| **完了** | dogfood Round 1〜4 + F-1〜F-4 fix + R3-1〜R3-3 fix + variant fixture | ✅ |
+| **次着手** | **TS 型同期** (`designer/src/types/`) | 7 ファイル + zod 検討 |
+| **並行可** | sample 全件 v3 化 (残 retail 0003/0004 = 2 件) | TS 同期と並行 |
+| **並行可** | spec 文書 v3 反映 (`docs/spec/process-flow-*.md` 14 件) | TS 同期と並行 |
+| **TS 後** | validator 切替 (referentialIntegrity / sqlColumnValidator / loadExtensions / conventionsValidator) | TS 型に依存 |
+| **TS 後** | UI コンポーネント v3 同期 (30+ ファイル) | TS 型完成後 |
+| **オプション** | dogfood Round 5 (healthcare 等) | TS 同期で問題が出たら起票 |
+| **将来 (v3.1)** | 拡張機構 object/array 不統一吸収 | breaking change、別 ISSUE |
+
+---
+
+## 9. 結論
+
+- Round 4 で v3 schema の業務文脈妥当性が 4 業界 + 41 sample で実証、新規 finding 0 件
+- WorkflowPattern 5 種が業務実証済、残 6 種は fixture で構造実証済 = 実用上十分
+- **TS 同期着手可能と判断**。Round 5 は TS 同期と並行で機会を見て実施
+- 完成度 90-95%、残り 5-10% は TS 同期 + 業界 5 個目で詰める範囲


### PR DESCRIPTION
## 関連

- Closes #535
- 関連 PR: #524 (Round 1) / #528 (Round 2) / #530 (Round 3) / #532 (#531 fixture) / #534 (#533 R3 fix)
- 評価レポート: \`docs/spec/dogfood-2026-04-28-schema-v3-public-service.md\`

## 概要

dogfood Round 4 として **公共サービス (建築確認申請、5 段審査ワークフロー)** で v3 schema を再検証。Round 1〜3 で fixture では cover したが業務文脈で未検証だった **WorkflowPattern 4 種** (acknowledge / review / sign-off / approval-veto) を 5 段連結フローで実機検証。**新規 finding 0 件**、完成度 90-95% で **TS 同期着手可能** と判定。

## 主な変更

- public-service sample 9 件: Project / Tables 4 (applicants / applications / application_approvals / attachments) / Screen / Extension / 2 ProcessFlow
- **Opus 5 段 workflow 連結** (\`1cd900ee-...json\`): 受付→一次審査→公示→異議申立→最終決裁、**top-level 14 step (うち 5 WorkflowStep + 通常 9)、onApproved/onRejected 内 22 sub-step を含む合計 36 step**
- **Sonnet 申請ステータス通知** (\`72fe2c92-...json\`): シンプル参照系で対比、R3-1 fix の効果を実機確認
- AJV 検証拡張: public-service ディレクトリも読む、61 test 全 pass

## 検証結果

| 分類 | Round 1 | Round 2 | Round 3 | **Round 4** |
|---|---|---|---|---|
| フレームワーク | 4 件 (F-1〜F-4) | 0 件 | 3 件 (R3-1〜R3-3) | **0 件** ✨ |
| 拡張定義 | 2 件 | 0 件 | 0 件 | 0 件 |
| サンプル設計 | 2 件 | 0 件 | 0 件 | 0 件 |

**WorkflowPattern 業務文脈実機検証**: acknowledge / review / sign-off / approval-veto / approval-sequential の 5 種。残 6 種 (approval-quorum/escalation/parallel/branch-merge/discussion/ad-hoc) は fixture で構造検証済 (PR #532)。

## R3-1 fix の Round 4 実機効果

Sonnet 報告: **「表現力が大きく向上」**。\`application.application_number\` / \`application.status\` 等の object field 参照が \`flowVariable\` 形式で直接書ける。

## 完成度評価

- Round 1 後: 70-75% (β)
- Round 2 後: 85-90% (RC 候補)
- Round 3 後: 80-85% (R3 finding で後退)
- **Round 4 後: 90-95% (TS 同期着手可能)**

## 次の手 (推奨)

**TS 同期着手**。ただし Sonnet レビューで **Round 5 (healthcare / 物流) を直列先行推奨** の指摘あり (parallel/branch-merge semantics の業務文脈未検証)。本 PR マージ後にユーザー判断、TS 同期 vs Round 5 の優先順位を決定。

## レビュー観点

- 5 段 workflow 連結 (1 ProcessFlow に 5 WorkflowStep) の認知負荷が許容範囲か
- WorkflowPattern 各種の業務文脈での妥当性
- TS 同期着手判断の妥当性 / Round 5 を挟むべきか

## schema governance

本 PR は \`schemas/v3/\` を一切変更していない。サンプル + テスト拡張 + ドキュメントのみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)