### PR TITLE
feat(types): Phase 4-δ — ProcessFlow inner table 型を v3 vocabulary に統一 (#566 #558)

### DIFF
--- a/designer/src/components/process-flow/ProcessFlowEditor.tsx
+++ b/designer/src/components/process-flow/ProcessFlowEditor.tsx
@@ -152,7 +152,7 @@ export function ProcessFlowEditor() {
   const pickerResolveRef = useRef<((r: ScreenItemPickResult | null) => void) | null>(null);
   const [newActionName, setNewActionName] = useState("");
   const [newActionTrigger, setNewActionTrigger] = useState<ActionTrigger>("click");
-  const [tables, setTables] = useState<{ id: string; name: string; logicalName: string }[]>([]);
+  const [tables, setTables] = useState<{ id: string; physicalName: string; name: string }[]>([]);
   const [screens, setScreens] = useState<{ id: string; name: string }[]>([]);
   const [commonGroups, setCommonGroups] = useState<{ id: string; name: string }[]>([]);
   const [showTemplates, setShowTemplates] = useState(false);
@@ -184,7 +184,7 @@ export function ProcessFlowEditor() {
       setCommonGroups(agMetas.filter((a) => a.type === "common").map((a) => ({ id: a.id, name: a.name })));
     }).catch(console.error);
     listTables().then(async (metas) => {
-      setTables(metas.map((tm) => ({ id: tm.id, name: tm.physicalName ?? "", logicalName: tm.name })));
+      setTables(metas.map((tm) => ({ id: tm.id, physicalName: tm.physicalName ?? "", name: tm.name })));
       // SQL 列検査用に全テーブルの columns まで読む (#261 UI 統合)
       const defs = await Promise.all(
         metas.map(async (tm) => {

--- a/designer/src/components/process-flow/SortableStepCard.tsx
+++ b/designer/src/components/process-flow/SortableStepCard.tsx
@@ -10,7 +10,7 @@ interface SortableStepCardProps {
   index: number;
   label: string;
   allSteps: Step[];
-  tables: { id: string; name: string; logicalName: string }[];
+  tables: { id: string; physicalName: string; name: string }[];
   screens: { id: string; name: string }[];
   commonGroups: { id: string; name: string }[];
   onChange: (changes: Partial<Step>) => void;

--- a/designer/src/components/process-flow/StepCard.tsx
+++ b/designer/src/components/process-flow/StepCard.tsx
@@ -82,7 +82,7 @@ interface InlineStepListProps {
   steps: Step[];
   parentLabel: string;
   allSteps: Step[];
-  tables: { id: string; name: string; logicalName: string }[];
+  tables: { id: string; physicalName: string; name: string }[];
   screens: { id: string; name: string }[];
   commonGroups: { id: string; name: string }[];
   onChange: (steps: Step[]) => void;
@@ -200,7 +200,7 @@ interface StepCardProps {
   index: number;
   label: string;
   allSteps: Step[];
-  tables: { id: string; name: string; logicalName: string }[];
+  tables: { id: string; physicalName: string; name: string }[];
   screens: { id: string; name: string }[];
   commonGroups: { id: string; name: string }[];
   conventions?: import("../../schemas/conventionsValidator").ConventionsCatalog | null;
@@ -916,13 +916,13 @@ export function StepCard({
                     className="form-select form-select-sm"
                     value={step.tableName}
                     onChange={(e) => {
-                      const t = tables.find((t) => t.name === e.target.value);
+                      const t = tables.find((t) => t.physicalName === e.target.value);
                       onChange({ tableName: e.target.value, tableId: t?.id } as Partial<Step>);
                     }}
                   >
                     <option value="">（選択）</option>
                     {tables.map((t) => (
-                      <option key={t.id} value={t.name}>{t.name}（{t.logicalName}）</option>
+                      <option key={t.id} value={t.physicalName}>{t.name}（{t.physicalName}）</option>
                     ))}
                   </select>
                 </div>

--- a/designer/src/components/process-flow/TransactionScopeStepPanel.tsx
+++ b/designer/src/components/process-flow/TransactionScopeStepPanel.tsx
@@ -27,7 +27,7 @@ interface Props {
   group?: ProcessFlow | null;
   /** 子ステップ描画用 */
   allSteps: Step[];
-  tables: { id: string; name: string; logicalName: string }[];
+  tables: { id: string; physicalName: string; name: string }[];
   screens: { id: string; name: string }[];
   commonGroups: { id: string; name: string }[];
   validationErrors?: ValidationError[];
@@ -62,7 +62,7 @@ interface InlineStepListProps {
   steps: Step[];
   parentLabel: string;
   allSteps: Step[];
-  tables: { id: string; name: string; logicalName: string }[];
+  tables: { id: string; physicalName: string; name: string }[];
   screens: { id: string; name: string }[];
   commonGroups: { id: string; name: string }[];
   onChange: (steps: Step[]) => void;


### PR DESCRIPTION
## 概要

v3 移行 Phase 4-δ: ProcessFlow 系コンポーネントの v1 inner table 型 (`{id, name, logicalName}`) を v3 vocabulary (`{id, physicalName, name}`) に統一。Phase 1〜4 の v3 移行を完結。

Closes #566
Closes #558 (Phase 2 申し送りを統合解消)

## 主な変更 (4 ファイル、+9 / -9)

| ファイル | 変更 |
|---|---|
| `ProcessFlowEditor.tsx:155, 187` | `useState<{...}>` 型 + setTables の map で v1 逆転 (`name=physicalName / logicalName=name`) を解消、v3 そのまま (`physicalName / name`) に |
| `SortableStepCard.tsx:13` | props inline 型を v3 vocabulary に |
| `StepCard.tsx:85, 203, 919, 925` | InlineStepListProps / StepCardProps tables 型 v3 化、option value を `t.physicalName` に、find 条件 `t.physicalName === ...` に |
| `TransactionScopeStepPanel.tsx:30, 65` | Props / InlineStepListProps v3 化 |

## 仕様逐条突合

- ✅ `grep -rn "logicalName" designer/src/components/process-flow/` → **0 件**
- ✅ `grep -rn "name: string;.*logicalName" designer/src/` → **0 件** (process-flow 配下)
- ✅ option value を physicalName に維持 (sqlColumnValidator は physicalName で SQL 検証する規範を踏襲、memory `project_schema_v3_2026_04_27.md`)
- ⚠️ `specExporter.ts` に `logicalName` 文字列が 4 行残存 — Sonnet 判断では markdown 出力フォーマット文字列で inner type ではない。レビューで再評価依頼

## 検証

- `npx tsc --noEmit` ✅ pass
- `npx vitest run` ✅ 60 ファイル / 1007 test pass (Phase 4-γ 時点と同数維持)
- `npm run build` (designer + designer-mcp) ✅ pass
- `git diff origin/main..HEAD -- schemas/` 差分 0 (governance 通過)

## v3 移行 Phase 1〜4 完結 — 後続作業候補

- ✅ Phase 1-1.6: view + sequence 型レベル + V3 機能
- ✅ Phase 1.5: conventions UI
- ✅ Phase 2: table + er-layout (用語逆転完了)
- ✅ Phase 3-α: screenItem 型レベル
- ✅ Phase 3-β: Screen + ScreenLayout 分離
- ✅ Phase 4-α: data/project.json restructure
- ✅ Phase 4-β: ScreenItemsFile 廃止 → Screen.items inline
- ✅ Phase 4-γ: ProcessFlow + 22 step variant の type→kind discriminator
- ✅ Phase 4-δ (本 PR): ProcessFlow inner table 型を v3 vocabulary 統一

### 残作業 (別 ISSUE)

- **#570** (Phase 4-γ-cleanup): runtime compat shim 削除、UI を v3 vocabulary 直接書換
- **#551** (Phase 1.6 派生): commitViews / commitSequences の N+1 saveProject バッチ化
- **#552** (Phase 1.6 派生): dirty state データ消失ガード横断確認
- **#548** (Phase 1 派生): View.outputColumns minItems:1 vs 新規作成 UX 不整合
- **#555** (Phase 1.5 派生): role / permission カテゴリの UI タブ追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)
