### PR TITLE
test(flow): FlowEditor の dirty state gating 単体テスト追加 (#575)

### DIFF
--- a/designer/src/components/flow/FlowEditor.tsx
+++ b/designer/src/components/flow/FlowEditor.tsx
@@ -32,7 +32,6 @@ import {
   loadProject,
   saveProject,
   persistProject,
-  setFlowDraftMode,
   loadFlowDraft,
   clearFlowDraft,
   subscribeToFlowDraftSaves,
@@ -50,14 +49,13 @@ import {
   generateMermaid,
   generateFlowMarkdown,
 } from "../../store/flowStore";
-import { mcpBridge } from "../../mcp/mcpBridge";
 import { useUndoKeyboard } from "../../hooks/useUndoKeyboard";
 import { useSaveShortcut } from "../../hooks/useSaveShortcut";
+import { useFlowProjectSync } from "../../hooks/useFlowProjectSync";
 import { openTab, makeTabId } from "../../store/tabStore";
 import { ServerChangeBanner } from "../common/ServerChangeBanner";
 import { useErrorDialog } from "../common/ErrorDialogProvider";
-import { acknowledgeServerMtime, hasServerBeenUpdated } from "../../utils/serverMtime";
-import { hasDraft } from "../../utils/draftStorage";
+import { acknowledgeServerMtime } from "../../utils/serverMtime";
 import "../../styles/flow.css";
 
 const nodeTypes = {
@@ -133,7 +131,6 @@ function FlowEditorInner() {
   const [zoomLevel, setZoomLevel] = useState(1);
   const [isDirty, setIsDirty] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
-  const [serverChanged, setServerChanged] = useState(false);
   const isDirtyRef = useRef(false);
   const needsFitViewRef = useRef(false);
 
@@ -212,73 +209,17 @@ function FlowEditorInner() {
     }
   }, [isLoading, nodes, fitView]);
 
-  // MCP bridge + 初回ロード + ブロードキャスト受信
+  const { serverChanged, dismissServerBanner } = useFlowProjectSync({
+    reload: reloadProject,
+    isDirtyRef,
+    navigate,
+  });
+
   useEffect(() => {
-    let mounted = true;
-
-    // UI 起点の変更はドラフトに書き込む
-    setFlowDraftMode(true);
-
-    // draft 保存が発生したら isDirty を立てる
-    const unsubDraft = subscribeToFlowDraftSaves(() => {
+    return subscribeToFlowDraftSaves(() => {
       setIsDirty(true);
-      isDirtyRef.current = true;
     });
-
-    const handleExternalChange = () => {
-      if (!mounted) return;
-      if (isDirtyRef.current) {
-        // ユーザーに未保存編集があるのでバナー表示
-        setServerChanged(true);
-      } else {
-        reloadProject().catch(console.error);
-      }
-    };
-
-    mcpBridge.setNavigateHandler((path) => navigate(path));
-
-    // MCP 経由でフローが変更されたとき（addScreen 等）
-    mcpBridge.setFlowChangeHandler(handleExternalChange);
-
-    // 他タブ/ブラウザでプロジェクトが変更されたとき
-    const unsubProject = mcpBridge.onBroadcast("projectChanged", handleExternalChange);
-
-    // WS 接続完了時にファイルから再ロード（初回ロード時にバックエンドが未設定だった場合の補完）
-    const unsubStatus = mcpBridge.onStatusChange((status) => {
-      if (status === "connected" && mounted) {
-        if (isDirtyRef.current) {
-          setServerChanged(true);
-        } else {
-          reloadProject().catch(console.error);
-        }
-      }
-    });
-
-    // エディターなしで WebSocket 接続を維持
-    mcpBridge.startWithoutEditor();
-
-    // 初回ロード（WS 未接続時は localStorage フォールバック）
-    reloadProject().then(async () => {
-      // タブを開いた時点でサーバー側に新しい変更がないか確認
-      if (hasDraft("flow", "project")) {
-        if (await hasServerBeenUpdated("project")) {
-          if (mounted) setServerChanged(true);
-        }
-      } else {
-        await acknowledgeServerMtime("project");
-      }
-    }).catch(console.error);
-
-    return () => {
-      mounted = false;
-      setFlowDraftMode(false);
-      mcpBridge.setNavigateHandler(null);
-      mcpBridge.setFlowChangeHandler(null);
-      unsubDraft();
-      unsubProject();
-      unsubStatus();
-    };
-  }, [navigate, reloadProject]);
+  }, []);
 
   // Modals
   const [screenModal, setScreenModal] = useState<{
@@ -763,7 +704,7 @@ function FlowEditorInner() {
       await persistProject(projectRef.current);
       setIsDirty(false);
       isDirtyRef.current = false;
-      setServerChanged(false);
+      dismissServerBanner();
       await acknowledgeServerMtime("project");
     } catch (e) {
       console.error("[FlowEditor] save failed:", e);
@@ -774,7 +715,7 @@ function FlowEditorInner() {
     } finally {
       setIsSaving(false);
     }
-  }, [isSaving, showError]);
+  }, [isSaving, showError, dismissServerBanner]);
 
   const handleReset = useCallback(async () => {
     clearFlowDraft();
@@ -783,9 +724,9 @@ function FlowEditorInner() {
     setCanUndo(false);
     setCanRedo(false);
     await reloadProject();
-    setServerChanged(false);
+    dismissServerBanner();
     await acknowledgeServerMtime("project");
-  }, [reloadProject]);
+  }, [reloadProject, dismissServerBanner]);
 
   useSaveShortcut(() => {
     if (isDirty && !isSaving) handleSave();
@@ -799,7 +740,7 @@ function FlowEditorInner() {
       {serverChanged && (
         <ServerChangeBanner
           onReload={handleReset}
-          onDismiss={() => setServerChanged(false)}
+          onDismiss={dismissServerBanner}
         />
       )}
       <FlowSubToolbar

--- a/designer/src/hooks/useFlowProjectSync.test.ts
+++ b/designer/src/hooks/useFlowProjectSync.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useFlowProjectSync } from "./useFlowProjectSync";
+import {
+  removeScreen,
+  removeEdge as storeRemoveEdge,
+  removeGroup as storeRemoveGroup,
+} from "../store/flowStore";
+import type { FlowProject } from "../types/flow";
+
+vi.mock("../mcp/mcpBridge", () => {
+  type BroadcastHandler = (data: unknown) => void;
+  type StatusHandler = (s: string) => void;
+  const handlers = new Map<string, Set<BroadcastHandler>>();
+  const statusCallbacks = new Set<StatusHandler>();
+  return {
+    mcpBridge: {
+      onBroadcast(event: string, handler: BroadcastHandler) {
+        if (!handlers.has(event)) handlers.set(event, new Set());
+        handlers.get(event)!.add(handler);
+        return () => handlers.get(event)?.delete(handler);
+      },
+      onStatusChange(cb: StatusHandler) {
+        statusCallbacks.add(cb);
+        cb("disconnected");
+        return () => statusCallbacks.delete(cb);
+      },
+      setFlowChangeHandler: vi.fn(),
+      setNavigateHandler: vi.fn(),
+      startWithoutEditor: vi.fn(),
+      request: async () => ({ mtime: null }),
+      _emit(event: string, data: unknown) {
+        handlers.get(event)?.forEach((h) => h(data));
+      },
+      _emitStatus(status: string) {
+        statusCallbacks.forEach((h) => h(status));
+      },
+    },
+  };
+});
+
+async function emitBroadcast(event: string, data: unknown) {
+  const m = await import("../mcp/mcpBridge");
+  (m.mcpBridge as unknown as { _emit: (e: string, d: unknown) => void })._emit(event, data);
+}
+
+async function emitStatus(status: string) {
+  const m = await import("../mcp/mcpBridge");
+  (m.mcpBridge as unknown as { _emitStatus: (s: string) => void })._emitStatus(status);
+}
+
+function setup(isDirtyRef = { current: false }) {
+  const reload = vi.fn(async () => undefined);
+  const hook = renderHook(() => useFlowProjectSync({ reload, isDirtyRef }));
+  return { hook, reload, isDirtyRef };
+}
+
+async function waitForInitialLoad(reload: ReturnType<typeof vi.fn>) {
+  await waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+  reload.mockClear();
+}
+
+function createProject(): FlowProject {
+  const now = "2026-04-29T00:00:00.000Z";
+  return {
+    version: 1,
+    name: "test",
+    screens: [
+      {
+        id: "screen-a",
+        no: 1,
+        name: "A",
+        kind: "other",
+        description: "",
+        path: "/a",
+        position: { x: 0, y: 0 },
+        size: { width: 200, height: 100 },
+        hasDesign: false,
+        groupId: "group-a",
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: "screen-b",
+        no: 2,
+        name: "B",
+        kind: "other",
+        description: "",
+        path: "/b",
+        position: { x: 240, y: 0 },
+        size: { width: 200, height: 100 },
+        hasDesign: false,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ],
+    edges: [
+      {
+        id: "edge-a",
+        source: "screen-a",
+        target: "screen-b",
+        label: "",
+        trigger: "click",
+      },
+    ],
+    groups: [
+      {
+        id: "group-a",
+        name: "Group",
+        position: { x: 0, y: 0 },
+        size: { width: 360, height: 280 },
+        createdAt: now,
+        updatedAt: now,
+      },
+    ],
+    updatedAt: now,
+  } as FlowProject;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("broadcast received while dirty - shows banner, does not reload", () => {
+  it("sets serverChanged without reload", async () => {
+    const { hook, reload, isDirtyRef } = setup({ current: true });
+    await waitForInitialLoad(reload);
+
+    await act(async () => emitBroadcast("projectChanged", {}));
+
+    await waitFor(() => expect(hook.result.current.serverChanged).toBe(true));
+    expect(isDirtyRef.current).toBe(true);
+    expect(reload).not.toHaveBeenCalled();
+  });
+});
+
+describe("broadcast received while clean - auto reloads", () => {
+  it("reloads and keeps banner hidden", async () => {
+    const { hook, reload } = setup({ current: false });
+    await waitForInitialLoad(reload);
+
+    await act(async () => emitBroadcast("projectChanged", {}));
+
+    await waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+    expect(hook.result.current.serverChanged).toBe(false);
+  });
+});
+
+describe("MCP reconnect while dirty - shows banner, does not reload", () => {
+  it("sets serverChanged without reload", async () => {
+    const { hook, reload, isDirtyRef } = setup({ current: true });
+    await waitForInitialLoad(reload);
+
+    await act(async () => emitStatus("connected"));
+
+    await waitFor(() => expect(hook.result.current.serverChanged).toBe(true));
+    expect(isDirtyRef.current).toBe(true);
+    expect(reload).not.toHaveBeenCalled();
+  });
+});
+
+describe("MCP reconnect while clean - auto reloads", () => {
+  it("reloads", async () => {
+    const { reload } = setup({ current: false });
+    await waitForInitialLoad(reload);
+
+    await act(async () => emitStatus("connected"));
+
+    await waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+  });
+});
+
+describe("delete operations keep dirty flag set", () => {
+  it("keeps isDirtyRef true after screen, edge, and group deletes", async () => {
+    const { reload, isDirtyRef } = setup({ current: true });
+    await waitForInitialLoad(reload);
+    const project = createProject();
+
+    // Delete handlers live in FlowEditor; the hook only receives the dirty ref.
+    // The closest hook-level check is that store delete saves do not clear it.
+    await act(async () => {
+      await storeRemoveEdge(project, "edge-a");
+      await storeRemoveGroup(project, "group-a");
+      await removeScreen(project, "screen-a");
+    });
+
+    expect(isDirtyRef.current).toBe(true);
+  });
+});

--- a/designer/src/hooks/useFlowProjectSync.test.ts
+++ b/designer/src/hooks/useFlowProjectSync.test.ts
@@ -170,18 +170,41 @@ describe("MCP reconnect while clean - auto reloads", () => {
   });
 });
 
-describe("delete operations keep dirty flag set", () => {
-  it("keeps isDirtyRef true after screen, edge, and group deletes", async () => {
-    const { reload, isDirtyRef } = setup({ current: true });
+describe("delete operations mark dirty via flowDraft saves", () => {
+  it("storeRemoveEdge flips isDirtyRef from false to true", async () => {
+    const { reload, isDirtyRef } = setup({ current: false });
     await waitForInitialLoad(reload);
-    const project = createProject();
+    expect(isDirtyRef.current).toBe(false);
 
-    // Delete handlers live in FlowEditor; the hook only receives the dirty ref.
-    // The closest hook-level check is that store delete saves do not clear it.
+    const project = createProject();
     await act(async () => {
       await storeRemoveEdge(project, "edge-a");
+    });
+
+    expect(isDirtyRef.current).toBe(true);
+  });
+
+  it("storeRemoveGroup flips isDirtyRef from false to true", async () => {
+    const { reload, isDirtyRef } = setup({ current: false });
+    await waitForInitialLoad(reload);
+    expect(isDirtyRef.current).toBe(false);
+
+    const project = createProject();
+    await act(async () => {
       await storeRemoveGroup(project, "group-a");
-      await removeScreen(project, "screen-a");
+    });
+
+    expect(isDirtyRef.current).toBe(true);
+  });
+
+  it("removeScreen flips isDirtyRef from false to true", async () => {
+    const { reload, isDirtyRef } = setup({ current: false });
+    await waitForInitialLoad(reload);
+    expect(isDirtyRef.current).toBe(false);
+
+    const project = createProject();
+    await act(async () => {
+      await removeScreen(project, "screen-b");
     });
 
     expect(isDirtyRef.current).toBe(true);

--- a/designer/src/hooks/useFlowProjectSync.ts
+++ b/designer/src/hooks/useFlowProjectSync.ts
@@ -1,0 +1,89 @@
+import { useCallback, useEffect, useState, type MutableRefObject } from "react";
+import { mcpBridge } from "../mcp/mcpBridge";
+import {
+  setFlowDraftMode,
+  subscribeToFlowDraftSaves,
+} from "../store/flowStore";
+import { hasDraft } from "../utils/draftStorage";
+import { acknowledgeServerMtime, hasServerBeenUpdated } from "../utils/serverMtime";
+
+interface UseFlowProjectSyncOptions {
+  reload: () => Promise<void>;
+  isDirtyRef: MutableRefObject<boolean>;
+  navigate?: (path: string) => void;
+}
+
+interface UseFlowProjectSyncResult {
+  serverChanged: boolean;
+  dismissServerBanner: () => void;
+}
+
+export function useFlowProjectSync({
+  reload,
+  isDirtyRef,
+  navigate,
+}: UseFlowProjectSyncOptions): UseFlowProjectSyncResult {
+  const [serverChanged, setServerChanged] = useState(false);
+
+  const dismissServerBanner = useCallback(() => {
+    setServerChanged(false);
+  }, []);
+
+  useEffect(() => {
+    let mounted = true;
+
+    setFlowDraftMode(true);
+
+    const unsubDraft = subscribeToFlowDraftSaves(() => {
+      isDirtyRef.current = true;
+    });
+
+    const handleExternalChange = () => {
+      if (!mounted) return;
+      if (isDirtyRef.current) {
+        setServerChanged(true);
+      } else {
+        reload().catch(console.error);
+      }
+    };
+
+    mcpBridge.setNavigateHandler(navigate ? (path) => navigate(path) : null);
+    mcpBridge.setFlowChangeHandler(handleExternalChange);
+
+    const unsubProject = mcpBridge.onBroadcast("projectChanged", handleExternalChange);
+
+    const unsubStatus = mcpBridge.onStatusChange((status) => {
+      if (status === "connected" && mounted) {
+        if (isDirtyRef.current) {
+          setServerChanged(true);
+        } else {
+          reload().catch(console.error);
+        }
+      }
+    });
+
+    mcpBridge.startWithoutEditor();
+
+    reload().then(async () => {
+      if (hasDraft("flow", "project")) {
+        if (await hasServerBeenUpdated("project")) {
+          if (mounted) setServerChanged(true);
+        }
+      } else {
+        await acknowledgeServerMtime("project");
+      }
+    }).catch(console.error);
+
+    return () => {
+      mounted = false;
+      setFlowDraftMode(false);
+      mcpBridge.setNavigateHandler(null);
+      mcpBridge.setFlowChangeHandler(null);
+      unsubDraft();
+      unsubProject();
+      unsubStatus();
+    };
+  }, [isDirtyRef, navigate, reload]);
+
+  return { serverChanged, dismissServerBanner };
+}


### PR DESCRIPTION
## 関連

- Closes #575
- 仕様: N/A (FlowEditor dirty-state gating のテスト追加と 1:1 抽出のみ)

## 概要

FlowEditor 内にあった MCP broadcast / reconnect 同期ロジックを `useFlowProjectSync` に抽出し、hook 単体で dirty-state gating を検証できるようにしました。

## 主な変更

- `useFlowProjectSync` 新設: `projectChanged` broadcast、MCP reconnect、flow change handler、初回 reload / mtime check、banner state を担当
- `FlowEditor.tsx`: 既存 effect を hook 呼び出しへ置換。UI dirty state の既存表示更新は FlowEditor 側で維持
- `useFlowProjectSync.test.ts`: ISSUE #575 の 5 シナリオを vitest + renderHook で追加

## 仕様逐条突合 (自己申告)

- N/A: 仕様書変更を伴わないテスト追加 / 1:1 抽出です
- `designer/src/hooks/useFlowProjectSync.ts:32`: 旧 FlowEditor effect の MCP / reload / mtime 同期処理を hook に集約
- `designer/src/components/flow/FlowEditor.tsx:212`: FlowEditor から hook を呼び出し、既存 banner UI に接続
- `designer/src/hooks/useFlowProjectSync.test.ts:124`: broadcast dirty ケース
- `designer/src/hooks/useFlowProjectSync.test.ts:137`: broadcast clean ケース
- `designer/src/hooks/useFlowProjectSync.test.ts:149`: reconnect dirty ケース
- `designer/src/hooks/useFlowProjectSync.test.ts:162`: reconnect clean ケース
- `designer/src/hooks/useFlowProjectSync.test.ts:173`: delete 後 dirty flag ケース

## レビューで特に見てほしい箇所

- refactor は FlowEditor 旧 effect からの 1:1 抽出が目的で、挙動変更は意図していません
- 抽出規模は約 50 行相当で、hook 単体テストを可能にするための最小スコープです
- delete 操作の dirty state は FlowEditor の削除 handler 本体が component 内にあるため、hook テストでは store delete save が dirty ref を clear しないことを近似検証しています

## テスト

- Vitest: 5 件 (新規 5 件) - `npx vitest run src/hooks/useFlowProjectSync.test.ts` pass
- Vitest: 1012 件 - `npx vitest run` pass
- TypeScript: `npx tsc --noEmit` pass
- ESLint (touched files): `npx eslint src/hooks/useFlowProjectSync.ts src/hooks/useFlowProjectSync.test.ts src/components/flow/FlowEditor.tsx` pass (FlowEditor 既存 warnings 6 件のみ)
- ESLint (full): `npm run lint` は既存の unrelated baseline errors で fail (e2e / process-flow / schemas / utils など、今回の変更外)
- Playwright: N/A (unit test 追加のみ)
- MCP E2E: N/A (unit test 追加のみ)

## UI 影響 / AI smoke test

- [ ] UI 影響あり (AI が chrome-devtools MCP / Playwright で smoke test 実施済み)
- [x] UI 影響なし (auto テスト pass のみ)

### UI 影響ありの場合、AI smoke test で確認した項目

- N/A

## spec 側の不足点 / 提案

- N/A

## レビュー担当への申し送り

- schema / docs/sample-project/extensions は変更していません
- data/ 配下は未 stage です