### PR TITLE
test(flow): useFlowProjectSync の cleanup / startWithoutEditor 呼び出しタイミング検証 (#580)

### DIFF
--- a/designer/src/hooks/useFlowProjectSync.test.ts
+++ b/designer/src/hooks/useFlowProjectSync.test.ts
@@ -49,9 +49,14 @@ async function emitStatus(status: string) {
   (m.mcpBridge as unknown as { _emitStatus: (s: string) => void })._emitStatus(status);
 }
 
-function setup(isDirtyRef = { current: false }) {
+function setup(
+  isDirtyRef = { current: false },
+  options: { navigate?: (path: string) => void } = {},
+) {
   const reload = vi.fn(async () => undefined);
-  const hook = renderHook(() => useFlowProjectSync({ reload, isDirtyRef }));
+  const hook = renderHook(() =>
+    useFlowProjectSync({ reload, isDirtyRef, navigate: options.navigate }),
+  );
   return { hook, reload, isDirtyRef };
 }
 
@@ -119,6 +124,7 @@ function createProject(): FlowProject {
 
 beforeEach(() => {
   localStorage.clear();
+  vi.clearAllMocks();
 });
 
 describe("broadcast received while dirty - shows banner, does not reload", () => {
@@ -208,5 +214,54 @@ describe("delete operations mark dirty via flowDraft saves", () => {
     });
 
     expect(isDirtyRef.current).toBe(true);
+  });
+});
+
+describe("cleanup behavior", () => {
+  it("startWithoutEditor is invoked exactly once per mount", async () => {
+    const { reload } = setup();
+    await waitForInitialLoad(reload);
+
+    const m = await import("../mcp/mcpBridge");
+    expect(m.mcpBridge.startWithoutEditor).toHaveBeenCalledTimes(1);
+  });
+
+  it("setFlowChangeHandler is reset to null on unmount", async () => {
+    const { hook, reload } = setup();
+    await waitForInitialLoad(reload);
+
+    const m = await import("../mcp/mcpBridge");
+    const setFlowChangeHandler = m.mcpBridge.setFlowChangeHandler as ReturnType<typeof vi.fn>;
+    expect(setFlowChangeHandler).toHaveBeenLastCalledWith(expect.any(Function));
+
+    hook.unmount();
+
+    expect(setFlowChangeHandler).toHaveBeenLastCalledWith(null);
+  });
+
+  it("setNavigateHandler is reset to null on unmount when navigate was provided", async () => {
+    const navigate = vi.fn();
+    const { hook, reload } = setup({ current: false }, { navigate });
+    await waitForInitialLoad(reload);
+
+    const m = await import("../mcp/mcpBridge");
+    const setNavigateHandler = m.mcpBridge.setNavigateHandler as ReturnType<typeof vi.fn>;
+    expect(setNavigateHandler).toHaveBeenLastCalledWith(expect.any(Function));
+
+    hook.unmount();
+
+    expect(setNavigateHandler).toHaveBeenLastCalledWith(null);
+  });
+
+  it("broadcast and status events after unmount do not trigger reload or banner", async () => {
+    const { hook, reload } = setup({ current: false });
+    await waitForInitialLoad(reload);
+
+    hook.unmount();
+
+    await act(async () => emitBroadcast("projectChanged", {}));
+    await act(async () => emitStatus("connected"));
+
+    expect(reload).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## 関連

- Closes #580
- 元 PR: #579 (#575)
- 元レビュー: Codex 独立レビュー Should-fix
- canonical 実装の cleanup 検証パターン: \`designer/src/hooks/useResourceEditor.test.ts\`

## 概要

PR #579 (#575) Codex 独立レビューで指摘された Should-fix の独立対応。\`useFlowProjectSync\` のテストでカバーできていなかった cleanup 経路と \`startWithoutEditor\` 呼び出しタイミングを検証する 4 ケースを追加する。

## 主な変更

\`designer/src/hooks/useFlowProjectSync.test.ts\` に新規 \`describe(\"cleanup behavior\")\` ブロックを追加:

- **startWithoutEditor がマウント時にちょうど 1 回呼ばれる** — 副作用の二重発火回避を担保
- **setFlowChangeHandler がアンマウント時に null で呼ばれる** — \`useFlowProjectSync.ts:80-81\` の cleanup を検証
- **setNavigateHandler が navigate 提供時、アンマウント時に null で呼ばれる** — 同上、navigate 経路の cleanup を独立に検証
- **アンマウント後の broadcast / status イベントが reload を発火しない** — \`unsubProject\` / \`unsubStatus\` による listener 解除経路を検証

支援変更:

- \`setup()\` に navigate optional パラメータを追加 (cleanup テスト用)
- \`beforeEach\` に \`vi.clearAllMocks()\` を追加 (mock 呼び出し回数を per-test でリセット)

## 仕様逐条突合 (自己申告)

ISSUE #580 受け入れ基準:

- 「\`unmount()\` 後に \`mcpBridge.setFlowChangeHandler\` / \`setNavigateHandler\` が \`null\` で呼ばれていることを assert」
  → \`useFlowProjectSync.test.ts\` の cleanup describe 内 2 ケースで検証済 ✓
- 「\`startWithoutEditor\` が hook マウント時にちょうど 1 回呼ばれることを assert」
  → cleanup describe の最初のケースで検証済 ✓
- 「(任意) onBroadcast / onStatusChange の cleanup が呼ばれた後、再度 broadcast/status 発火しても \`reload\` / \`serverChanged\` が動かないこと」
  → 4 ケース目で \`hook.unmount()\` 後の broadcast + status emit に対し \`reload\` が発火しないことを検証 ✓

## レビューで特に見てほしい箇所

- mock の \`vi.fn()\` インスタンスが factory 内で 1 度だけ生成され、テスト間で共有される構造のため、\`vi.clearAllMocks()\` を per-test で入れた。これによる既存 7 ケースへの影響無し (vitest 11 件全 pass)
- アンマウント後 \`reload\` が呼ばれないことの assert は、\`unsubProject\` / \`unsubStatus\` の解除と \`mounted = false\` フラグの両方で守られているが、テストとしてはどちらが効いて pass するかは区別していない (本ケースの目的は外形的 regression 検出)

## テスト

- Vitest: 11 件 (新規 4 件) — \`useFlowProjectSync\` の cleanup 経路 / \`startWithoutEditor\`
- Playwright: 0 件 (新規 0 件) — UI 挙動変更なし
- MCP E2E: 0 件 — 該当なし
- 既存テストへの影響: vitest 全 pass、tsc \`-b --noEmit\` clean

## UI 影響 / AI smoke test

- [ ] UI 影響あり
- [x] UI 影響なし (auto テスト pass のみ)

理由: テスト追加のみ。実装コード (\`useFlowProjectSync.ts\` / \`FlowEditor.tsx\` 等) には変更無し。

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

- 本 PR は #579 (#575) Codex 独立レビュー Should-fix の独立対応
- ISSUE #580 受け入れ基準を機械的に満たすシンプルなテスト追加 PR
- 既存 7 ケースの assertion を破壊していないことを vitest 全 pass で確認済

🤖 Generated with [Claude Code](https://claude.com/claude-code)