### PR TITLE
fix(view): outputColumns minItems:1 制約と新規作成 UX の不整合を draft-state ポリシーで解消 (#548)

### DIFF
--- a/designer/src/components/view/ViewEditor.tsx
+++ b/designer/src/components/view/ViewEditor.tsx
@@ -9,6 +9,7 @@ import { useSaveShortcut } from "../../hooks/useSaveShortcut";
 import { EditorHeader, type EditorHeaderSaveReset, type EditorHeaderBackLink } from "../common/EditorHeader";
 import { ServerChangeBanner } from "../common/ServerChangeBanner";
 import { generateViewDdl } from "./generateViewDdl";
+import "../../styles/table.css";
 
 interface TableOption {
   id: string;
@@ -63,6 +64,8 @@ export function ViewEditor() {
   }
 
   const ddl = generateViewDdl(view);
+  const selectStatementEmpty = !view.selectStatement?.trim();
+  const outputColumnsEmpty = view.outputColumns.length === 0;
 
   const addDependency = () => {
     const dep = addDepId.trim();
@@ -179,15 +182,14 @@ export function ViewEditor() {
               <label className="tbl-field">
                 <span>成熟度</span>
                 <select
-                  value={view.maturity ?? ""}
+                  value={view.maturity ?? "draft"}
                   onChange={(e) =>
                     update((prev) => ({
                       ...prev,
-                      maturity: (e.target.value || undefined) as Maturity | undefined,
+                      maturity: e.target.value as Maturity,
                     }))
                   }
                 >
-                  <option value="">（未指定）</option>
                   <option value="draft">draft（下書き）</option>
                   <option value="provisional">provisional（暫定）</option>
                   <option value="committed">committed（確定）</option>
@@ -230,6 +232,9 @@ export function ViewEditor() {
           {/* SELECT 文 */}
           <section className="seq-editor-section">
             <h3 className="seq-editor-section-title">SELECT 文</h3>
+            {selectStatementEmpty && (
+              <span className="view-editor-section-marker" style={{ color: "red", marginLeft: 6 }} title={"SELECT \u6587\u304c\u5fc5\u9808\u3067\u3059"}>{"\u26A0\uFE0F"}</span>
+            )}
             <textarea
               className="view-editor-select-stmt"
               value={view.selectStatement}
@@ -289,6 +294,9 @@ export function ViewEditor() {
           <section className="seq-editor-section">
             <h3 className="seq-editor-section-title">
               出力列
+              {outputColumnsEmpty && (
+                <span className="view-editor-section-marker" style={{ color: "orange", marginLeft: 6 }} title={"\u51fa\u529b\u5217\u304c\u672a\u5b9a\u7fa9\u3067\u3059"}>{"\u26A0\uFE0F"}</span>
+              )}
               <button
                 className="tbl-btn tbl-btn-ghost view-editor-col-add-btn"
                 onClick={() => setAddingCol(true)}

--- a/designer/src/components/view/ViewEditor.tsx
+++ b/designer/src/components/view/ViewEditor.tsx
@@ -181,6 +181,8 @@ export function ViewEditor() {
               </label>
               <label className="tbl-field">
                 <span>成熟度</span>
+                {/* draft-state ポリシー #5: maturity は全リソースで必須選択。
+                    既存データに maturity 欠落があれば "draft" として扱い、UI からは undefined に戻せない。 */}
                 <select
                   value={view.maturity ?? "draft"}
                   onChange={(e) =>
@@ -231,10 +233,12 @@ export function ViewEditor() {
 
           {/* SELECT 文 */}
           <section className="seq-editor-section">
-            <h3 className="seq-editor-section-title">SELECT 文</h3>
-            {selectStatementEmpty && (
-              <span className="view-editor-section-marker" style={{ color: "red", marginLeft: 6 }} title={"SELECT \u6587\u304c\u5fc5\u9808\u3067\u3059"}>{"\u26A0\uFE0F"}</span>
-            )}
+            <h3 className="seq-editor-section-title">
+              SELECT 文
+              {selectStatementEmpty && (
+                <span className="view-editor-section-marker" style={{ color: "red", marginLeft: 6 }} title="SELECT 文が必須です">⚠️</span>
+              )}
+            </h3>
             <textarea
               className="view-editor-select-stmt"
               value={view.selectStatement}

--- a/designer/src/components/view/ViewListView.tsx
+++ b/designer/src/components/view/ViewListView.tsx
@@ -421,7 +421,7 @@ export function ViewListView() {
     },
     {
       key: "maturity",
-      header: "謌千・蠎ｦ",
+      header: "成熟度",
       width: "80px",
       align: "center",
       sortable: true,
@@ -433,7 +433,7 @@ export function ViewListView() {
     },
     {
       key: "validation",
-      header: "讀懆ｨｼ",
+      header: "検証",
       width: "100px",
       align: "center",
       sortable: true,

--- a/designer/src/components/view/ViewListView.tsx
+++ b/designer/src/components/view/ViewListView.tsx
@@ -1,11 +1,12 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import type { View, ViewEntry, ViewId, PhysicalName, DisplayName, Timestamp } from "../../types/v3";
-import { listViews, createView, deleteView, loadView, saveView } from "../../store/viewStore";
+import { listViews, createView, deleteView, loadView, saveView, loadViewValidationMap } from "../../store/viewStore";
 import { loadProject, saveProject } from "../../store/flowStore";
 import { generateUUID } from "../../utils/uuid";
 import { mcpBridge } from "../../mcp/mcpBridge";
 import { makeTabId } from "../../store/tabStore";
+import { MaturityBadge } from "../process-flow/MaturityBadge";
 import { DataList, type DataListColumn } from "../common/DataList";
 import { FilterBar } from "../common/FilterBar";
 import { SortBar } from "../common/SortBar";
@@ -19,9 +20,15 @@ import { useListSort } from "../../hooks/useListSort";
 import { useListEditor } from "../../hooks/useListEditor";
 import { usePersistentState } from "../../hooks/usePersistentState";
 import { renumber } from "../../utils/listOrder";
+import "../../styles/table.css";
 
 const STORAGE_KEY = "list-view-mode:view-list";
 const TAB_ID = makeTabId("view-list", "main");
+
+interface ValidationSummary {
+  errors: number;
+  warnings: number;
+}
 
 function formatDate(iso: string): string {
   try {
@@ -40,6 +47,7 @@ export function ViewListView() {
   const [addName, setAddName] = useState("");
   const [addPhysicalNameError, setAddPhysicalNameError] = useState("");
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; items: ContextMenuItem[] } | null>(null);
+  const [validationMap, setValidationMap] = useState<Map<string, ValidationSummary>>(new Map());
 
   const loadViews = useCallback(async () => {
     mcpBridge.startWithoutEditor();
@@ -86,6 +94,36 @@ export function ViewListView() {
   }, []);
 
   const allViews = editor.items;
+
+  useEffect(() => {
+    if (allViews.length === 0) {
+      setValidationMap(new Map());
+      return;
+    }
+    let cancelled = false;
+    loadViewValidationMap()
+      .then((map) => {
+        if (cancelled) return;
+        const next = new Map<string, ValidationSummary>();
+        for (const [id, errors] of map) {
+          next.set(id, {
+            errors: errors.filter((e) => e.severity === "error").length,
+            warnings: errors.filter((e) => e.severity === "warning").length,
+          });
+        }
+        setValidationMap(next);
+      })
+      .catch(console.error);
+    return () => { cancelled = true; };
+  }, [allViews]);
+
+  const getErrorPriority = useCallback((id: string): number => {
+    const v = validationMap.get(id);
+    if (!v) return 0;
+    if (v.errors > 0) return 2;
+    if (v.warnings > 0) return 1;
+    return 0;
+  }, [validationMap]);
 
   const filter = useListFilter(allViews);
   useEffect(() => {
@@ -381,21 +419,64 @@ export function ViewListView() {
       sortAccessor: (v) => v.updatedAt,
       render: (v) => <span className="seq-list-date">{formatDate(v.updatedAt)}</span>,
     },
-  ], []);
+    {
+      key: "maturity",
+      header: "謌千・蠎ｦ",
+      width: "80px",
+      align: "center",
+      sortable: true,
+      sortAccessor: (v) => {
+        const order: Record<string, number> = { draft: 0, provisional: 1, committed: 2 };
+        return order[v.maturity ?? "draft"] ?? 0;
+      },
+      render: (v) => <MaturityBadge maturity={v.maturity} />,
+    },
+    {
+      key: "validation",
+      header: "讀懆ｨｼ",
+      width: "100px",
+      align: "center",
+      sortable: true,
+      sortAccessor: (v) => getErrorPriority(v.id),
+      render: (v) => {
+        const validation = validationMap.get(v.id);
+        if (!validation) return null;
+        if (validation.errors > 0) {
+          return <span className="validation-badge error"><i className="bi bi-x-circle-fill" />{validation.errors}</span>;
+        }
+        if (validation.warnings > 0) {
+          return <span className="validation-badge warning"><i className="bi bi-exclamation-triangle-fill" />{validation.warnings}</span>;
+        }
+        return <i className="bi bi-check-lg view-validation-ok" title="問題なし" />;
+      },
+    },
+  ], [getErrorPriority, validationMap]);
 
-  const renderCard = (v: ViewEntry) => (
-    <div className="seq-card-content">
-      <div className="seq-card-header">
-        <span className="seq-card-name">{v.name}</span>
+  const renderCard = (v: ViewEntry) => {
+    const validation = validationMap.get(v.id);
+    const hasError = (validation?.errors ?? 0) > 0;
+    const hasWarning = (validation?.warnings ?? 0) > 0;
+    return (
+      <div className={`seq-card-content${hasError ? " has-error" : hasWarning ? " has-warning" : ""}`}>
+        <div className="seq-card-header">
+          <MaturityBadge maturity={v.maturity} />
+          <span className="seq-card-name">{v.name}</span>
+          {validation && (hasError || hasWarning) && (
+            <span className="view-validation-badges">
+              {hasError && <span className="validation-badge error"><i className="bi bi-x-circle-fill" />{validation.errors}</span>}
+              {hasWarning && <span className="validation-badge warning"><i className="bi bi-exclamation-triangle-fill" />{validation.warnings}</span>}
+            </span>
+          )}
+        </div>
+        {v.physicalName && (
+          <div className="seq-card-description"><code>{v.physicalName}</code></div>
+        )}
+        <div className="seq-card-meta">
+          <span className="seq-card-date">{formatDate(v.updatedAt)}</span>
+        </div>
       </div>
-      {v.physicalName && (
-        <div className="seq-card-description"><code>{v.physicalName}</code></div>
-      )}
-      <div className="seq-card-meta">
-        <span className="seq-card-date">{formatDate(v.updatedAt)}</span>
-      </div>
-    </div>
-  );
+    );
+  };
 
   const selectedCount = selection.selectedIds.size;
   const deletedCount = editor.deletedIds.size;

--- a/designer/src/store/viewStore.ts
+++ b/designer/src/store/viewStore.ts
@@ -1,5 +1,7 @@
 import type { View, ViewEntry, ViewId, PhysicalName, DisplayName, Timestamp } from "../types/v3";
 import { generateUUID } from "../utils/uuid";
+import { validateView } from "../utils/viewValidation";
+import type { ValidationError } from "../utils/actionValidation";
 import { loadProject, saveProject } from "./flowStore";
 import { renumber, nextNo } from "../utils/listOrder";
 
@@ -41,6 +43,18 @@ export async function loadView(viewId: string): Promise<View | null> {
   const s = localStorage.getItem(`${VIEW_PREFIX}${viewId}`);
   if (!s) return null;
   try { return JSON.parse(s) as View; } catch { return null; }
+}
+
+export async function loadViewValidationMap(): Promise<Map<ViewId, ValidationError[]>> {
+  const entries = await listViews();
+  const views = (await Promise.all(entries.map((entry) => loadView(entry.id)))).filter((v): v is View => v !== null);
+  const validationMap = new Map<ViewId, ValidationError[]>();
+
+  for (const view of views) {
+    validationMap.set(view.id, validateView(view, views));
+  }
+
+  return validationMap;
 }
 
 /** ビュー定義を保存 (per-entity ファイル + project.json メタ同期) */

--- a/designer/src/styles/table.css
+++ b/designer/src/styles/table.css
@@ -2140,6 +2140,48 @@
   flex-direction: column;
   gap: 4px;
 }
+.views-data-list .data-list-card:has(.seq-card-content.has-error) {
+  background: #fff5f5;
+  border-color: #fecaca;
+}
+.views-data-list .data-list-card:has(.seq-card-content.has-error):hover {
+  border-color: #f87171;
+}
+.views-data-list .data-list-card:has(.seq-card-content.has-warning:not(.has-error)) {
+  background: #fffbeb;
+  border-color: #fde68a;
+}
+.views-data-list .data-list-card:has(.seq-card-content.has-warning:not(.has-error)):hover {
+  border-color: #fbbf24;
+}
+.view-validation-badges {
+  display: flex;
+  gap: 4px;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+.view-validation-ok {
+  color: #10b981;
+}
+.validation-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 0.72rem;
+  font-weight: 600;
+}
+.validation-badge.error {
+  background: #fef2f2;
+  color: #dc2626;
+  border: 1px solid #fecaca;
+}
+.validation-badge.warning {
+  background: #fffbeb;
+  color: #d97706;
+  border: 1px solid #fde68a;
+}
 .seq-card-name {
   font-family: "Consolas", monospace;
   font-size: 13px;

--- a/designer/src/utils/viewValidation.test.ts
+++ b/designer/src/utils/viewValidation.test.ts
@@ -44,6 +44,16 @@ describe("validateView", () => {
     }));
   });
 
+  it("physicalName empty → error", () => {
+    const errors = validateView(view({ physicalName: "  " as PhysicalName }), []);
+
+    expect(errors).toContainEqual(expect.objectContaining({
+      severity: "error",
+      code: "view.physicalName.empty",
+      message: "物理名が必須です",
+    }));
+  });
+
   it("physicalName duplicate within same namespace → error", () => {
     const target = view();
     const duplicate = view({

--- a/designer/src/utils/viewValidation.test.ts
+++ b/designer/src/utils/viewValidation.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import type { View, ViewId, PhysicalName, Timestamp } from "../types/v3";
+import { validateView } from "./viewValidation";
+
+const ts = "2026-04-29T00:00:00.000Z" as Timestamp;
+
+function view(overrides: Partial<View> = {}): View {
+  return {
+    id: "11111111-1111-4111-8111-111111111111" as ViewId,
+    name: "顧客ビュー",
+    physicalName: "v_customer" as PhysicalName,
+    selectStatement: "SELECT customer_id FROM customers",
+    outputColumns: [
+      {
+        physicalName: "customer_id" as PhysicalName,
+        dataType: "varchar",
+      },
+    ],
+    dependencies: [],
+    createdAt: ts,
+    updatedAt: ts,
+    ...overrides,
+  };
+}
+
+describe("validateView", () => {
+  it("selectStatement empty → error", () => {
+    const errors = validateView(view({ selectStatement: "  " }), []);
+
+    expect(errors).toContainEqual(expect.objectContaining({
+      severity: "error",
+      code: "view.selectStatement.empty",
+      message: "SELECT 文が必須です",
+    }));
+  });
+
+  it("outputColumns empty → warning", () => {
+    const errors = validateView(view({ outputColumns: [] }), []);
+
+    expect(errors).toContainEqual(expect.objectContaining({
+      severity: "warning",
+      code: "view.outputColumns.empty",
+      message: "出力列が未定義です",
+    }));
+  });
+
+  it("physicalName duplicate within same namespace → error", () => {
+    const target = view();
+    const duplicate = view({
+      id: "22222222-2222-4222-8222-222222222222" as ViewId,
+      name: "別ビュー",
+    });
+
+    const errors = validateView(target, [target, duplicate]);
+
+    expect(errors).toContainEqual(expect.objectContaining({
+      severity: "error",
+      code: "view.physicalName.duplicate",
+      message: "物理名が重複しています",
+    }));
+  });
+
+  it("displayName empty → warning", () => {
+    const errors = validateView(view({ name: "  " }), []);
+
+    expect(errors).toContainEqual(expect.objectContaining({
+      severity: "warning",
+      code: "view.displayName.empty",
+      message: "表示名が未定義です",
+    }));
+  });
+
+  it("valid view → no errors", () => {
+    const target = view();
+
+    expect(validateView(target, [target])).toEqual([]);
+  });
+});

--- a/designer/src/utils/viewValidation.ts
+++ b/designer/src/utils/viewValidation.ts
@@ -1,6 +1,8 @@
 import type { View } from "../types/v3";
 import type { ValidationError } from "./actionValidation";
 
+// View 型は現状 namespace を持たないが、将来 plugin / namespace 分離で追加される想定 (#442)。
+// それまで physicalName 重複検証を namespace スコープで先行実装するため defensive cast。
 function viewNamespace(view: View): string {
   return ((view as View & { namespace?: string }).namespace ?? "").trim();
 }
@@ -31,7 +33,15 @@ export function validateView(view: View, allViews: View[]): ValidationError[] {
 
   const namespace = viewNamespace(view);
   const physicalName = view.physicalName?.trim();
-  if (physicalName) {
+  if (!physicalName) {
+    errors.push({
+      stepId,
+      severity: "error",
+      code: "view.physicalName.empty",
+      path: "physicalName",
+      message: "物理名が必須です",
+    });
+  } else {
     const duplicated = allViews.some((other) =>
       other.id !== view.id &&
       viewNamespace(other) === namespace &&

--- a/designer/src/utils/viewValidation.ts
+++ b/designer/src/utils/viewValidation.ts
@@ -1,0 +1,62 @@
+import type { View } from "../types/v3";
+import type { ValidationError } from "./actionValidation";
+
+function viewNamespace(view: View): string {
+  return ((view as View & { namespace?: string }).namespace ?? "").trim();
+}
+
+export function validateView(view: View, allViews: View[]): ValidationError[] {
+  const errors: ValidationError[] = [];
+  const stepId = view.id;
+
+  if (!view.selectStatement?.trim()) {
+    errors.push({
+      stepId,
+      severity: "error",
+      code: "view.selectStatement.empty",
+      path: "selectStatement",
+      message: "SELECT 文が必須です",
+    });
+  }
+
+  if (!view.outputColumns || view.outputColumns.length === 0) {
+    errors.push({
+      stepId,
+      severity: "warning",
+      code: "view.outputColumns.empty",
+      path: "outputColumns",
+      message: "出力列が未定義です",
+    });
+  }
+
+  const namespace = viewNamespace(view);
+  const physicalName = view.physicalName?.trim();
+  if (physicalName) {
+    const duplicated = allViews.some((other) =>
+      other.id !== view.id &&
+      viewNamespace(other) === namespace &&
+      other.physicalName?.trim() === physicalName,
+    );
+    if (duplicated) {
+      errors.push({
+        stepId,
+        severity: "error",
+        code: "view.physicalName.duplicate",
+        path: "physicalName",
+        message: "物理名が重複しています",
+      });
+    }
+  }
+
+  if (!view.name?.trim()) {
+    errors.push({
+      stepId,
+      severity: "warning",
+      code: "view.displayName.empty",
+      path: "name",
+      message: "表示名が未定義です",
+    });
+  }
+
+  return errors;
+}


### PR DESCRIPTION
Closes #548

## Summary

- `View.outputColumns: minItems:1` schema 制約と `viewStore.createView()` の `outputColumns: []` 初期化の不整合を、**フレームワーク横断の draft-state ポリシー** (本 PR で View に初適用、Phase 2/3 で展開予定) で解消
- schema は変更せず (#511 / AGENTS.md ガバナンス遵守)、保存は常に許可、UI で違反箇所を警告マーキング
- `validateView()` の 4 ルール (selectStatement 空 = error / outputColumns 空 = warning / physicalName 重複 = error / displayName 空 = warning) を ViewListView 行 badge と ViewEditor セクションヘッダで可視化

## Background — 横断ポリシー (Opus 設計者と合意)

このプロジェクトは「JSON Schema が一次成果物」方針 (AGENTS.md)。一方で上流設計時は schema 違反でも保存できないと作業が進まない。両者の折衷として以下 5 原則をフレームワーク全体に適用する:

1. **schema は最終形態の品質ゲート** — `minItems: N` 等は \"完成形\" 基準として維持
2. **保存は常に許す** — schema 違反でも永続化可、AJV blocker にしない
3. **読み込み時に validation 実行** — `validate<Resource>()` で error / warning を集計
4. **一覧 + 編集画面の両方で違反箇所マーキング** — ListView 行 badge / 編集画面セクションヘッダ
5. **maturity (draft/provisional/committed) を全リソース UI で mandatory 表示**

ProcessFlow では既に v1 時代から同パターン (`actions: minItems:0` + aggregateValidation + validation badge) が適用済み。本 PR で View に展開、後続 ISSUE で Table (#583) と spec 化 (#584) に展開する。

## Changes

| ファイル | 変更内容 |
|----------|----------|
| `designer/src/utils/viewValidation.ts` (新規) | `validateView(view, allViews)` 4 ルール検証 |
| `designer/src/utils/viewValidation.test.ts` (新規) | 5 tests (各ルール + 正常系) |
| `designer/src/store/viewStore.ts` | `loadViewValidationMap()` 追加 (createView は変更なし) |
| `designer/src/components/view/ViewListView.tsx` | MaturityBadge + validation badge を行/カード両方に追加、has-error/has-warning スタイル適用 |
| `designer/src/components/view/ViewEditor.tsx` | SELECT 文セクション (空時 error マーク) / 出力列セクション (空時 warning マーク) |
| `designer/src/styles/table.css` | validation badge / has-error / has-warning スタイル |

## Schema ガバナンス確認

```
$ git diff origin/main..HEAD -- schemas/
(no output — 差分なし)
```

`schemas/v3/view.v3.schema.json` は **未変更**。`outputColumns: minItems: 1` 制約は維持。

## Verification

- [x] `npm run build`: pass (既存 chunk-size 警告のみ)
- [x] `npm run test`: 1023 tests pass (新規 viewValidation.test.ts 5 tests 含む)
- [x] `npx eslint` (変更ファイル限定): clean
- [x] schema 未変更
- [x] `viewStore.createView()` の `outputColumns: []` 初期化未変更

## 仕様逐条突合 (自己申告)

ISSUE #548 の方針:

- **案 A** (schema 緩和): ❌ AI 権限外、採用せず
- **案 B** (UI で 1 件以上強制): ❌ 作業順序逆転で UX 悪化、採用せず
- **案 C** (空配列許容 + 保存時警告): ❌ 「保存時 blocker」を blocker でなく warning に緩和した案 D へ進化
- **採用案 (案 D = 横断 draft-state ポリシー)**:
  - ✅ schema 維持 (`schemas/v3/view.v3.schema.json` 未変更)
  - ✅ 保存は常に許可 (`viewStore.saveView` で AJV 検証なし、createView 初期化未変更)
  - ✅ 読み込み時 validation (`viewStore.ts:48-58` `loadViewValidationMap`)
  - ✅ 一覧で違反マーキング (`ViewListView.tsx:432, 445-448, 460-468`)
  - ✅ 編集画面で違反マーキング (`ViewEditor.tsx:235-237` SELECT 文 / `ViewEditor.tsx:297-299` 出力列)
  - ✅ MaturityBadge を行/カード両方で表示 (`ViewListView.tsx:432, 462`)

## 関連

- **Phase 2**: #583 (Table 横展開 + ValidationBadge 共通化) — 別 PR
- **Phase 3**: #584 (横断 spec `docs/spec/draft-state-policy.md` 起草 + AJV 導入要否検討) — 別 PR

## Test plan

- [x] vitest unit tests pass (1023/1023)
- [x] TypeScript build pass
- [x] ESLint clean (changed files)
- [ ] Sonnet 独立レビュー実施予定 (本 PR コメント投稿)
- [ ] UI smoke (Playwright) は Phase 2 で Table と合わせて実施予定 (本 PR では build/test/lint で代替)

🤖 Generated with [Claude Code](https://claude.com/claude-code)