### PR TITLE
perf(store): loadValidationMap を bulk fetch 化、N+1 を解消 (#587)

### DIFF
--- a/designer-mcp/src/projectStorage.ts
+++ b/designer-mcp/src/projectStorage.ts
@@ -401,6 +401,23 @@ export async function deleteTable(tableId: string): Promise<void> {
   } catch { /* file not found is OK */ }
 }
 
+/** tables/ ディレクトリ内の全テーブル定義を読み込み (#587) */
+export async function listAllTables(): Promise<unknown[]> {
+  try {
+    await ensureDataDir();
+    const files = await fs.readdir(TABLES_DIR);
+    const results: unknown[] = [];
+    for (const file of files) {
+      if (!file.endsWith(".json")) continue;
+      const data = await readJSON<unknown>(path.join(TABLES_DIR, file));
+      if (data) results.push(data);
+    }
+    return results;
+  } catch {
+    return [];
+  }
+}
+
 /** actions/{processFlowId}.json を読み込み */
 export async function readProcessFlow(processFlowId: string): Promise<unknown | null> {
   return readJSON<unknown>(path.join(ACTIONS_DIR, `${processFlowId}.json`));
@@ -482,6 +499,23 @@ export async function deleteSequence(sequenceId: string): Promise<void> {
   try {
     await fs.unlink(path.join(SEQUENCES_DIR, `${sequenceId}.json`));
   } catch { /* file not found is OK */ }
+}
+
+/** views/ ディレクトリ内の全ビュー定義を読み込み (#587) */
+export async function listAllViews(): Promise<unknown[]> {
+  try {
+    await ensureDataDir();
+    const files = await fs.readdir(VIEWS_DIR);
+    const results: unknown[] = [];
+    for (const file of files) {
+      if (!file.endsWith(".json")) continue;
+      const data = await readJSON<unknown>(path.join(VIEWS_DIR, file));
+      if (data) results.push(data);
+    }
+    return results;
+  } catch {
+    return [];
+  }
 }
 
 /** views/{viewId}.json を読み込み (v3 per-entity #549) */

--- a/designer-mcp/src/wsBridge.ts
+++ b/designer-mcp/src/wsBridge.ts
@@ -18,6 +18,7 @@ import {
   readTable,
   writeTable,
   deleteTable as deleteTableFile,
+  listAllTables,
   readErLayout,
   writeErLayout,
   readScreenLayout,
@@ -37,6 +38,7 @@ import {
   readView,
   writeView,
   deleteView as deleteViewFile,
+  listAllViews,
   getFileMtime,
   readExtensionsBundle,
   writeExtensionsFile,
@@ -427,6 +429,11 @@ class WsBridge extends EventEmitter {
           this.broadcast("tableChanged", { tableId, deleted: true }, clientId);
           break;
         }
+        case "listAllTables": {
+          const tablesData = await listAllTables();
+          respond(tablesData);
+          break;
+        }
         case "loadErLayout": {
           const layoutData = await readErLayout();
           respond(layoutData);
@@ -482,6 +489,11 @@ class WsBridge extends EventEmitter {
             updatedAt: ag.updatedAt,
           }));
           respond(metas);
+          break;
+        }
+        case "listAllViews": {
+          const viewsData = await listAllViews();
+          respond(viewsData);
           break;
         }
         case "loadConventions": {

--- a/designer/e2e/mcp/bulk-load.spec.ts
+++ b/designer/e2e/mcp/bulk-load.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from "@playwright/test";
+import * as net from "net";
+
+async function isMcpRunning(): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = new net.Socket();
+    socket.setTimeout(500);
+    socket.connect(5179, "127.0.0.1", () => { socket.destroy(); resolve(true); });
+    socket.on("error", () => resolve(false));
+    socket.on("timeout", () => resolve(false));
+  });
+}
+
+function sendBrowserRequest(method: string, params: unknown = {}): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket("ws://localhost:5179");
+    const clientId = `test-client-${Date.now()}`;
+    const reqId = `req-${Date.now()}`;
+
+    const timeout = setTimeout(() => {
+      ws.close();
+      reject(new Error(`Timeout waiting for response to ${method}`));
+    }, 10000);
+
+    ws.onopen = () => {
+      ws.send(JSON.stringify({ type: "register", clientId }));
+      ws.send(JSON.stringify({ type: "request", id: reqId, method, params }));
+    };
+
+    ws.onmessage = (event) => {
+      try {
+        const msg = JSON.parse(event.data as string);
+        if (msg.type === "response" && msg.id === reqId) {
+          clearTimeout(timeout);
+          ws.close();
+          if (msg.error) reject(new Error(msg.error));
+          else resolve(msg.result);
+        }
+      } catch { /* ignore unrelated messages */ }
+    };
+
+    ws.onerror = () => reject(new Error("WebSocket error"));
+  });
+}
+
+test.describe("wsBridge bulk load (#587)", () => {
+  test.beforeEach(async () => {
+    const running = await isMcpRunning();
+    if (!running) test.skip();
+  });
+
+  test("listAllTables は配列を返す", async () => {
+    const result = await sendBrowserRequest("listAllTables");
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  test("listAllViews は配列を返す", async () => {
+    const result = await sendBrowserRequest("listAllViews");
+    expect(Array.isArray(result)).toBe(true);
+  });
+});

--- a/designer/src/mcp/mcpBridge.ts
+++ b/designer/src/mcp/mcpBridge.ts
@@ -332,6 +332,7 @@ class McpBridgeImpl {
 
     const tableBackend: TableStorageBackend = {
       loadTable: (tableId) => this.request("loadTable", { tableId }),
+      listAllTables: () => this.request("listAllTables", {}) as Promise<unknown[]>,
       saveTable: (tableId, data) => this.request("saveTable", { tableId, data }).then(() => undefined),
       deleteTable: (tableId) => this.request("deleteTable", { tableId }).then(() => undefined),
     };
@@ -378,6 +379,7 @@ class McpBridgeImpl {
 
     const viewBackend: ViewStorageBackend = {
       loadView: (viewId) => this.request("loadView", { viewId }),
+      listAllViews: () => this.request("listAllViews", {}) as Promise<unknown[]>,
       saveView: (viewId, data) => this.request("saveView", { viewId, data }).then(() => undefined),
       deleteView: (viewId) => this.request("deleteView", { viewId }).then(() => undefined),
     };

--- a/designer/src/store/tableStore.bulkLoad.test.ts
+++ b/designer/src/store/tableStore.bulkLoad.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Project, ProjectId, Table, TableId, Timestamp } from "../types/v3";
+import { setFlowStorageBackend } from "./flowStore";
+import type { TableStorageBackend } from "./tableStore";
+import { loadTableValidationMap, setTableStorageBackend } from "./tableStore";
+
+const TS = "2026-04-29T00:00:00.000Z" as Timestamp;
+const TABLE_ID_1 = "11111111-1111-4111-8111-111111111111" as TableId;
+const TABLE_ID_2 = "22222222-2222-4222-8222-222222222222" as TableId;
+const ORPHAN_TABLE_ID = "33333333-3333-4333-8333-333333333333" as TableId;
+
+function table(id: TableId, name: string): Table {
+  return {
+    id,
+    name,
+    physicalName: name.toLowerCase(),
+    columns: [],
+    indexes: [],
+    createdAt: TS,
+    updatedAt: TS,
+  } as Table;
+}
+
+function project(tableIds: TableId[]): Project {
+  return {
+    schemaVersion: "v3",
+    meta: {
+      id: "00000000-0000-4000-8000-000000000001" as ProjectId,
+      name: "test",
+      createdAt: TS,
+      updatedAt: TS,
+      mode: "upstream",
+      maturity: "draft",
+    },
+    entities: {
+      tables: tableIds.map((id, index) => ({
+        id,
+        no: index + 1,
+        name: `table-${index + 1}`,
+        physicalName: `table_${index + 1}`,
+        updatedAt: TS,
+      })),
+    },
+  };
+}
+
+function setProject(tableIds: TableId[]): void {
+  setFlowStorageBackend({
+    loadProject: vi.fn().mockResolvedValue(project(tableIds)),
+    saveProject: vi.fn().mockResolvedValue(undefined),
+    deleteScreenData: vi.fn().mockResolvedValue(undefined),
+  });
+}
+
+describe("loadTableValidationMap bulk load (#587)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setFlowStorageBackend(null);
+    setTableStorageBackend(null);
+  });
+
+  it("backend が listAllTables を提供する場合は 1 回だけ呼び出す", async () => {
+    setProject([TABLE_ID_1, TABLE_ID_2]);
+    const listAllTables = vi.fn().mockResolvedValue([
+      table(TABLE_ID_1, "table_1"),
+      table(TABLE_ID_2, "table_2"),
+    ]);
+    const loadTable = vi.fn();
+    setTableStorageBackend({
+      loadTable,
+      listAllTables,
+      saveTable: vi.fn().mockResolvedValue(undefined),
+      deleteTable: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const validationMap = await loadTableValidationMap();
+
+    expect(listAllTables).toHaveBeenCalledTimes(1);
+    expect(loadTable).not.toHaveBeenCalled();
+    expect(validationMap.size).toBe(2);
+  });
+
+  it("backend が listAllTables を提供しない場合は id ごとの loadTable にフォールバックする", async () => {
+    setProject([TABLE_ID_1, TABLE_ID_2]);
+    const loadTable = vi.fn(async (id: TableId) => table(id, id === TABLE_ID_1 ? "table_1" : "table_2"));
+    setTableStorageBackend({
+      loadTable: loadTable as TableStorageBackend["loadTable"],
+      saveTable: vi.fn().mockResolvedValue(undefined),
+      deleteTable: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const validationMap = await loadTableValidationMap();
+
+    expect(loadTable).toHaveBeenCalledTimes(2);
+    expect(loadTable).toHaveBeenCalledWith(TABLE_ID_1);
+    expect(loadTable).toHaveBeenCalledWith(TABLE_ID_2);
+    expect(validationMap.size).toBe(2);
+  });
+
+  it("bulk 結果に project.json entry のない orphan が含まれていても validationMap から除外する", async () => {
+    setProject([TABLE_ID_1]);
+    setTableStorageBackend({
+      loadTable: vi.fn(),
+      listAllTables: vi.fn().mockResolvedValue([
+        table(TABLE_ID_1, "table_1"),
+        table(ORPHAN_TABLE_ID, "orphan"),
+      ]),
+      saveTable: vi.fn().mockResolvedValue(undefined),
+      deleteTable: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const validationMap = await loadTableValidationMap();
+
+    expect(validationMap.has(TABLE_ID_1)).toBe(true);
+    expect(validationMap.has(ORPHAN_TABLE_ID)).toBe(false);
+    expect(validationMap.size).toBe(1);
+  });
+});

--- a/designer/src/store/tableStore.ts
+++ b/designer/src/store/tableStore.ts
@@ -31,6 +31,7 @@ import { renumber, nextNo } from "../utils/listOrder";
 
 export interface TableStorageBackend {
   loadTable(tableId: string): Promise<unknown>;
+  listAllTables?(): Promise<unknown[]>;
   saveTable(tableId: string, data: unknown): Promise<void>;
   deleteTable(tableId: string): Promise<void>;
 }
@@ -75,7 +76,17 @@ export async function loadTable(tableId: string): Promise<Table | null> {
 
 export async function loadTableValidationMap(): Promise<Map<TableId, ValidationError[]>> {
   const entries = await listTables();
-  const tables = (await Promise.all(entries.map((entry) => loadTable(entry.id)))).filter((t): t is Table => t !== null);
+  const entryIds = new Set(entries.map((entry) => entry.id));
+
+  let tables: Table[];
+  if (_backend?.listAllTables) {
+    const all = (await _backend.listAllTables()) as Table[];
+    tables = all.filter((table) => entryIds.has(table.id));
+  } else {
+    tables = (await Promise.all(entries.map((entry) => loadTable(entry.id))))
+      .filter((t): t is Table => t !== null);
+  }
+
   const validationMap = new Map<TableId, ValidationError[]>();
 
   for (const table of tables) {

--- a/designer/src/store/viewStore.bulkLoad.test.ts
+++ b/designer/src/store/viewStore.bulkLoad.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Project, ProjectId, Timestamp, View, ViewId } from "../types/v3";
+import { setFlowStorageBackend } from "./flowStore";
+import type { ViewStorageBackend } from "./viewStore";
+import { loadViewValidationMap, setViewStorageBackend } from "./viewStore";
+
+const TS = "2026-04-29T00:00:00.000Z" as Timestamp;
+const VIEW_ID_1 = "11111111-1111-4111-8111-111111111111" as ViewId;
+const VIEW_ID_2 = "22222222-2222-4222-8222-222222222222" as ViewId;
+const ORPHAN_VIEW_ID = "33333333-3333-4333-8333-333333333333" as ViewId;
+
+function view(id: ViewId, name: string): View {
+  return {
+    id,
+    name,
+    physicalName: name.toLowerCase(),
+    selectStatement: "select 1",
+    outputColumns: [],
+    dependencies: [],
+    createdAt: TS,
+    updatedAt: TS,
+  } as View;
+}
+
+function project(viewIds: ViewId[]): Project {
+  return {
+    schemaVersion: "v3",
+    meta: {
+      id: "00000000-0000-4000-8000-000000000001" as ProjectId,
+      name: "test",
+      createdAt: TS,
+      updatedAt: TS,
+      mode: "upstream",
+      maturity: "draft",
+    },
+    entities: {
+      views: viewIds.map((id, index) => ({
+        id,
+        no: index + 1,
+        name: `view-${index + 1}`,
+        physicalName: `view_${index + 1}`,
+        updatedAt: TS,
+      })),
+    },
+  };
+}
+
+function setProject(viewIds: ViewId[]): void {
+  setFlowStorageBackend({
+    loadProject: vi.fn().mockResolvedValue(project(viewIds)),
+    saveProject: vi.fn().mockResolvedValue(undefined),
+    deleteScreenData: vi.fn().mockResolvedValue(undefined),
+  });
+}
+
+describe("loadViewValidationMap bulk load (#587)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setFlowStorageBackend(null);
+    setViewStorageBackend(null);
+  });
+
+  it("backend が listAllViews を提供する場合は 1 回だけ呼び出す", async () => {
+    setProject([VIEW_ID_1, VIEW_ID_2]);
+    const listAllViews = vi.fn().mockResolvedValue([
+      view(VIEW_ID_1, "view_1"),
+      view(VIEW_ID_2, "view_2"),
+    ]);
+    const loadView = vi.fn();
+    setViewStorageBackend({
+      loadView,
+      listAllViews,
+      saveView: vi.fn().mockResolvedValue(undefined),
+      deleteView: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const validationMap = await loadViewValidationMap();
+
+    expect(listAllViews).toHaveBeenCalledTimes(1);
+    expect(loadView).not.toHaveBeenCalled();
+    expect(validationMap.size).toBe(2);
+  });
+
+  it("backend が listAllViews を提供しない場合は id ごとの loadView にフォールバックする", async () => {
+    setProject([VIEW_ID_1, VIEW_ID_2]);
+    const loadView = vi.fn(async (id: ViewId) => view(id, id === VIEW_ID_1 ? "view_1" : "view_2"));
+    setViewStorageBackend({
+      loadView: loadView as ViewStorageBackend["loadView"],
+      saveView: vi.fn().mockResolvedValue(undefined),
+      deleteView: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const validationMap = await loadViewValidationMap();
+
+    expect(loadView).toHaveBeenCalledTimes(2);
+    expect(loadView).toHaveBeenCalledWith(VIEW_ID_1);
+    expect(loadView).toHaveBeenCalledWith(VIEW_ID_2);
+    expect(validationMap.size).toBe(2);
+  });
+
+  it("bulk 結果に project.json entry のない orphan が含まれていても validationMap から除外する", async () => {
+    setProject([VIEW_ID_1]);
+    setViewStorageBackend({
+      loadView: vi.fn(),
+      listAllViews: vi.fn().mockResolvedValue([
+        view(VIEW_ID_1, "view_1"),
+        view(ORPHAN_VIEW_ID, "orphan"),
+      ]),
+      saveView: vi.fn().mockResolvedValue(undefined),
+      deleteView: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const validationMap = await loadViewValidationMap();
+
+    expect(validationMap.has(VIEW_ID_1)).toBe(true);
+    expect(validationMap.has(ORPHAN_VIEW_ID)).toBe(false);
+    expect(validationMap.size).toBe(1);
+  });
+});

--- a/designer/src/store/viewStore.ts
+++ b/designer/src/store/viewStore.ts
@@ -9,6 +9,7 @@ import { renumber, nextNo } from "../utils/listOrder";
 
 export interface ViewStorageBackend {
   loadView(viewId: string): Promise<unknown>;
+  listAllViews?(): Promise<unknown[]>;
   saveView(viewId: string, data: unknown): Promise<void>;
   deleteView(viewId: string): Promise<void>;
 }
@@ -47,7 +48,17 @@ export async function loadView(viewId: string): Promise<View | null> {
 
 export async function loadViewValidationMap(): Promise<Map<ViewId, ValidationError[]>> {
   const entries = await listViews();
-  const views = (await Promise.all(entries.map((entry) => loadView(entry.id)))).filter((v): v is View => v !== null);
+  const entryIds = new Set(entries.map((entry) => entry.id));
+
+  let views: View[];
+  if (_backend?.listAllViews) {
+    const all = (await _backend.listAllViews()) as View[];
+    views = all.filter((view) => entryIds.has(view.id));
+  } else {
+    views = (await Promise.all(entries.map((entry) => loadView(entry.id))))
+      .filter((v): v is View => v !== null);
+  }
+
   const validationMap = new Map<ViewId, ValidationError[]>();
 
   for (const view of views) {

--- a/docs/spec/draft-state-policy.md
+++ b/docs/spec/draft-state-policy.md
@@ -106,7 +106,7 @@ load<Resource>ValidationMap(): Promise<Map<Id, ValidationError[]>>
 
 validation map は、リソース ID を key、`ValidationError[]` を value とする。UI はリソース一覧と validation map を突き合わせ、バッジ・CSS クラス・編集画面ヘッダーの状態を描画する。
 
-N+1 fetch を避けるため、`load<Resource>ValidationMap()` は必要な一覧をまとめて読み込む。個別リソースごとに追加 fetch する実装は #587 の対象リスクとして扱う。
+> **注**: `loadTableValidationMap()` / `loadViewValidationMap()` は backend が `listAllTables()` / `listAllViews()` を提供する場合 1 RPC で全件取得し、未提供時 (localStorage 等) は per-id にフォールバックする (#587 / PR #589 で実装)。bulk fetch 結果は project.json entries の ID で filter して orphan 互換性を維持する。
 
 ProcessFlow は既存の `aggregateValidation` を直接利用する。ProcessFlow 専用の validation 集約が既に存在するため、同じ判定を重複実装しない。
 


### PR DESCRIPTION
﻿## 関連

- Closes #587
- 仕様: docs/spec/draft-state-policy.md §5

## 概要

`loadTableValidationMap()` / `loadViewValidationMap()` の N+1 ロードを、backend が bulk fetch API を提供する場合は 1 RPC で全件取得する形に変更しました。旧 backend / localStorage 互換のため、bulk API が無い場合は従来の per-id load にフォールバックします。

## 主な変更

- designer-mcp に `listAllTables` / `listAllViews` を追加し、WS request で呼び出せるようにしました。
- frontend の `mcpBridge` が table/view storage backend に bulk method を渡すようにしました。
- table/view store の validation map 作成で bulk fetch を優先し、project entries に存在しない orphan は除外します。
- table/view store の bulk/fallback/orphan 互換テストと、WS bulk method の E2E smoke を追加しました。
- docs/spec/draft-state-policy.md §5 の N+1 注記を実装済み状態に更新しました。

## 仕様逐条突合 (自己申告)

- bulk endpoint: tables/views ディレクトリ全 JSON を読む `listAllTables` / `listAllViews` を追加 → designer-mcp/src/projectStorage.ts:405, designer-mcp/src/projectStorage.ts:505
- WS endpoint: `listAllTables` / `listAllViews` case を追加し配列を返す → designer-mcp/src/wsBridge.ts:432, designer-mcp/src/wsBridge.ts:494
- frontend bridge: table/view backend に `listAllTables` / `listAllViews` を公開 → designer/src/mcp/mcpBridge.ts:335, designer/src/mcp/mcpBridge.ts:382
- table store: optional backend method と bulk/fallback validation map を実装 → designer/src/store/tableStore.ts:34, designer/src/store/tableStore.ts:77, designer/src/store/tableStore.ts:82, designer/src/store/tableStore.ts:85
- view store: optional backend method と bulk/fallback validation map を実装 → designer/src/store/viewStore.ts:12, designer/src/store/viewStore.ts:49, designer/src/store/viewStore.ts:54, designer/src/store/viewStore.ts:57
- bulk path は 1 回だけ呼ばれることをテスト → designer/src/store/tableStore.bulkLoad.test.ts:62, designer/src/store/viewStore.bulkLoad.test.ts:63
- bulk method 未提供時は per-id load にフォールバックすることをテスト → designer/src/store/tableStore.bulkLoad.test.ts:83, designer/src/store/viewStore.bulkLoad.test.ts:84
- orphan filter 互換をテスト → designer/src/store/tableStore.bulkLoad.test.ts:99, designer/src/store/viewStore.bulkLoad.test.ts:100
- MCP E2E: `listAllTables` / `listAllViews` が配列を返すことを smoke test → designer/e2e/mcp/bulk-load.spec.ts:52, designer/e2e/mcp/bulk-load.spec.ts:57
- schema governance #511: `schemas/**/*.json` は変更なし → `git diff --cached -- schemas/` 出力なし
- [x] spec 整合: docs/spec/draft-state-policy.md §5 注記を本 PR 実装に合わせて更新 (Sonnet レビュー Should-fix #1 対応)

## レビューで特に見てほしい観点

- bulk API が project.json entries と実ファイルの不整合を増幅しないよう、entries の ID で filter している点。
- 旧 backend 互換として optional method + fallback にしている点。

## テスト

- Vitest: 55 件 (新規 6 件) - `cd designer && npx vitest run src/store/`
- Playwright: 0 件 (新規 0 件) - N/A
- MCP E2E: 新規 2 件 - `designer/e2e/mcp/bulk-load.spec.ts` を追加 (designer-mcp 起動時に `listAllTables` / `listAllViews` を検証)
- Build: `cd designer-mcp && npm run build` pass, `cd designer && npm run build` pass
- Mojibake scan: `git diff HEAD | grep -P '[ｦ-ﾟ]'` 該当なし; `grep -P '[ｦ-ﾟ]' docs/spec/draft-state-policy.md` 該当なし

## UI 影響 / AI smoke test

- [ ] UI 影響あり (AI が chrome-devtools MCP / Playwright で smoke test 実施済み)
- [x] UI 影響なし (auto test pass のみ)

### UI 影響ありの場合、AI smoke test で確認した項目

- [ ] N/A
- [ ] N/A
- [ ] N/A

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

Should-fix #1 は d33feb6 で対応済み。e2e helper 抽出は ISSUE #590 に分離。
