### PR TITLE
refactor(e2e): designer/e2e/mcp/ の WS テストヘルパーを共通化 (#590)

### DIFF
--- a/designer/e2e/mcp/_helpers.ts
+++ b/designer/e2e/mcp/_helpers.ts
@@ -1,0 +1,52 @@
+import * as net from "net";
+
+/**
+ * designer-mcp サーバが port 5179 で起動しているかを確認する。
+ * 起動していなければ test.skip() を呼び出す側で利用。
+ */
+export async function isMcpRunning(): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = new net.Socket();
+    socket.setTimeout(500);
+    socket.connect(5179, "127.0.0.1", () => { socket.destroy(); resolve(true); });
+    socket.on("error", () => resolve(false));
+    socket.on("timeout", () => resolve(false));
+  });
+}
+
+/**
+ * ブラウザ役として wsBridge (ws://localhost:5179) にリクエストを送るヘルパー。
+ * `register` (clientId) → `request` (method/params) の順でメッセージを送り、
+ * 同じ id の `response` が返るのを待つ。10 秒でタイムアウト。
+ */
+export function sendBrowserRequest(method: string, params: unknown = {}): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket("ws://localhost:5179");
+    const clientId = `test-client-${Date.now()}`;
+    const reqId = `req-${Date.now()}`;
+
+    const timeout = setTimeout(() => {
+      ws.close();
+      reject(new Error(`Timeout waiting for response to ${method}`));
+    }, 10000);
+
+    ws.onopen = () => {
+      ws.send(JSON.stringify({ type: "register", clientId }));
+      ws.send(JSON.stringify({ type: "request", id: reqId, method, params }));
+    };
+
+    ws.onmessage = (event) => {
+      try {
+        const msg = JSON.parse(event.data as string);
+        if (msg.type === "response" && msg.id === reqId) {
+          clearTimeout(timeout);
+          ws.close();
+          if (msg.error) reject(new Error(msg.error));
+          else resolve(msg.result);
+        }
+      } catch { /* 別メッセージは無視 */ }
+    };
+
+    ws.onerror = () => reject(new Error("WebSocket error"));
+  });
+}

--- a/designer/e2e/mcp/bulk-load.spec.ts
+++ b/designer/e2e/mcp/bulk-load.spec.ts
@@ -1,47 +1,5 @@
 import { test, expect } from "@playwright/test";
-import * as net from "net";
-
-async function isMcpRunning(): Promise<boolean> {
-  return new Promise((resolve) => {
-    const socket = new net.Socket();
-    socket.setTimeout(500);
-    socket.connect(5179, "127.0.0.1", () => { socket.destroy(); resolve(true); });
-    socket.on("error", () => resolve(false));
-    socket.on("timeout", () => resolve(false));
-  });
-}
-
-function sendBrowserRequest(method: string, params: unknown = {}): Promise<unknown> {
-  return new Promise((resolve, reject) => {
-    const ws = new WebSocket("ws://localhost:5179");
-    const clientId = `test-client-${Date.now()}`;
-    const reqId = `req-${Date.now()}`;
-
-    const timeout = setTimeout(() => {
-      ws.close();
-      reject(new Error(`Timeout waiting for response to ${method}`));
-    }, 10000);
-
-    ws.onopen = () => {
-      ws.send(JSON.stringify({ type: "register", clientId }));
-      ws.send(JSON.stringify({ type: "request", id: reqId, method, params }));
-    };
-
-    ws.onmessage = (event) => {
-      try {
-        const msg = JSON.parse(event.data as string);
-        if (msg.type === "response" && msg.id === reqId) {
-          clearTimeout(timeout);
-          ws.close();
-          if (msg.error) reject(new Error(msg.error));
-          else resolve(msg.result);
-        }
-      } catch { /* ignore unrelated messages */ }
-    };
-
-    ws.onerror = () => reject(new Error("WebSocket error"));
-  });
-}
+import { isMcpRunning, sendBrowserRequest } from "./_helpers";
 
 test.describe("wsBridge bulk load (#587)", () => {
   test.beforeEach(async () => {

--- a/designer/e2e/mcp/mcp-tools.spec.ts
+++ b/designer/e2e/mcp/mcp-tools.spec.ts
@@ -13,55 +13,10 @@
  */
 
 import { test, expect } from "@playwright/test";
-import * as net from "net";
 import * as path from "path";
 import * as fs from "fs";
+import { isMcpRunning, sendBrowserRequest } from "./_helpers";
 
-// MCP サーバーが起動していない場合はスキップ
-async function isMcpRunning(): Promise<boolean> {
-  return new Promise((resolve) => {
-    const socket = new net.Socket();
-    socket.setTimeout(500);
-    socket.connect(5179, "127.0.0.1", () => { socket.destroy(); resolve(true); });
-    socket.on("error", () => resolve(false));
-    socket.on("timeout", () => resolve(false));
-  });
-}
-
-/** ブラウザ役として wsBridge にリクエストを送るヘルパー */
-function sendBrowserRequest(method: string, params: unknown = {}): Promise<unknown> {
-  return new Promise((resolve, reject) => {
-    const ws = new WebSocket("ws://localhost:5179");
-    const clientId = `test-client-${Date.now()}`;
-    const reqId = `req-${Date.now()}`;
-
-    const timeout = setTimeout(() => {
-      ws.close();
-      reject(new Error(`Timeout waiting for response to ${method}`));
-    }, 10000);
-
-    ws.onopen = () => {
-      // ブラウザとして登録
-      ws.send(JSON.stringify({ type: "register", clientId }));
-      // リクエスト送信
-      ws.send(JSON.stringify({ type: "request", id: reqId, method, params }));
-    };
-
-    ws.onmessage = (event) => {
-      try {
-        const msg = JSON.parse(event.data as string);
-        if (msg.type === "response" && msg.id === reqId) {
-          clearTimeout(timeout);
-          ws.close();
-          if (msg.error) reject(new Error(msg.error));
-          else resolve(msg.result);
-        }
-      } catch { /* 別メッセージは無視 */ }
-    };
-
-    ws.onerror = () => reject(new Error("WebSocket error"));
-  });
-}
 
 // ─── テスト ─────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
﻿## 関連

- Closes #590
- 仕様: N/A

## 概要

PR #589 のレビューで指摘された `designer/e2e/mcp/` 配下の WS テストヘルパー重複を解消しました。`isMcpRunning` と `sendBrowserRequest` を `_helpers.ts` に抽出し、既存 2 spec は import に置き換えています。

## 主な変更

- `designer/e2e/mcp/_helpers.ts` を新規作成し、MCP 起動チェックと WebSocket RPC ヘルパーを集約。
- `mcp-tools.spec.ts` から同一 helper 実装を削除し、共通 helper import に変更。
- `bulk-load.spec.ts` から同一 helper 実装を削除し、共通 helper import に変更。
- Playwright 設定は `testDir: "./e2e"` のみで `testMatch` 拡張なしのため、`_helpers.ts` は spec として実行されないことを確認。

## 仕様逐条突合 (自己申告)

- [x] `designer/e2e/mcp/_helpers.ts` 新規作成 — `designer/e2e/mcp/_helpers.ts:1`
- [x] `mcp-tools.spec.ts` から重複 helper 削除 + import 置換 — `designer/e2e/mcp/mcp-tools.spec.ts:18`
- [x] `bulk-load.spec.ts` から重複 helper 削除 + import 置換 — `designer/e2e/mcp/bulk-load.spec.ts:2`
- [x] Playwright `testMatch` で `_helpers.ts` がテストとして実行されないことを確認 — `designer/playwright.config.ts:4`
- [x] tsc / vite build 0 errors — `cd designer && npm run build`

## レビューで特に見てほしい観点

- helper 抽出のみで、WebSocket の登録順序、timeout、response 判定、error handling が変わっていないこと。
- `_helpers.ts` が spec 命名ではないため Playwright の実行対象にならないこと。

## テスト

- Vitest: 0 件 (新規 0 件) - N/A
- Playwright: 0 件 (新規 0 件) - 実行なし。リファクタのみで、対象 E2E は designer-mcp 起動依存のため今回は build 確認に限定。
- MCP E2E: 0 件 - N/A
- Build: `cd designer && npm run build` pass (tsc / vite build 0 errors)

## UI 影響 / AI smoke test

- [ ] UI 影響あり (AI が chrome-devtools MCP / Playwright で smoke test 実施済み)
- [x] UI 影響なし (auto test pass のみ)

### UI 影響ありの場合、AI smoke test で確認した項目

- [ ] N/A
- [ ] N/A
- [ ] N/A

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

実装コード、schema、data は変更していません。変更範囲は `designer/e2e/mcp/` 配下のみです。
