### PR TITLE
improve(store): commitViews / commitSequences の N+1 saveProject を 1 回にバッチ化 (#551)

### DIFF
--- a/designer/src/components/sequence/SequenceListView.tsx
+++ b/designer/src/components/sequence/SequenceListView.tsx
@@ -23,6 +23,28 @@ import { renumber } from "../../utils/listOrder";
 const STORAGE_KEY = "list-view-mode:sequence-list";
 const TAB_ID = makeTabId("sequence-list", "main");
 
+interface CommitSequencesDeps {
+  loadProject: typeof loadProject;
+  saveProject: typeof saveProject;
+  deleteSequence: typeof deleteSequence;
+}
+
+export async function commitSequences(
+  { itemsInOrder, deletedIds }: { itemsInOrder: SequenceEntry[]; deletedIds: string[] },
+  deps: CommitSequencesDeps = { loadProject, saveProject, deleteSequence },
+): Promise<void> {
+  const project = await deps.loadProject();
+  const deletedSet = new Set(deletedIds);
+  const orderMap = new Map(itemsInOrder.map((s, i) => [s.id, i]));
+  project.sequences = (project.sequences ?? [])
+    .filter((s) => !deletedSet.has(s.id))
+    .sort((a, b) => (orderMap.get(a.id) ?? Number.MAX_SAFE_INTEGER) - (orderMap.get(b.id) ?? Number.MAX_SAFE_INTEGER));
+  await deps.saveProject(project);
+  for (const id of deletedIds) {
+    await deps.deleteSequence(id);
+  }
+}
+
 function formatDate(iso: string): string {
   try {
     return new Date(iso).toLocaleDateString("ja-JP");
@@ -45,21 +67,6 @@ export function SequenceListView() {
     mcpBridge.startWithoutEditor();
     await loadProject();
     return await listSequences();
-  }, []);
-
-  const commitSequences = useCallback(async ({ itemsInOrder, deletedIds }: { itemsInOrder: SequenceEntry[]; deletedIds: string[] }) => {
-    for (const id of deletedIds) {
-      await deleteSequence(id);
-    }
-    const project = await loadProject();
-    if (project.sequences) {
-      const deletedSet = new Set(deletedIds);
-      const orderMap = new Map(itemsInOrder.map((s, i) => [s.id, i]));
-      project.sequences = project.sequences
-        .filter((s) => !deletedSet.has(s.id))
-        .sort((a, b) => (orderMap.get(a.id) ?? 0) - (orderMap.get(b.id) ?? 0));
-      await saveProject(project);
-    }
   }, []);
 
   const editor = useListEditor<SequenceEntry>({

--- a/designer/src/components/sequence/SequenceListView.tsx
+++ b/designer/src/components/sequence/SequenceListView.tsx
@@ -38,7 +38,8 @@ export async function commitSequences(
   const orderMap = new Map(itemsInOrder.map((s, i) => [s.id, i]));
   project.sequences = (project.sequences ?? [])
     .filter((s) => !deletedSet.has(s.id))
-    .sort((a, b) => (orderMap.get(a.id) ?? Number.MAX_SAFE_INTEGER) - (orderMap.get(b.id) ?? Number.MAX_SAFE_INTEGER));
+    .sort((a, b) => (orderMap.get(a.id) ?? Number.MAX_SAFE_INTEGER) - (orderMap.get(b.id) ?? Number.MAX_SAFE_INTEGER))
+    .map((s, i) => ({ ...s, no: i + 1 }));
   await deps.saveProject(project);
   for (const id of deletedIds) {
     await deps.deleteSequence(id);

--- a/designer/src/components/view/ViewListView.tsx
+++ b/designer/src/components/view/ViewListView.tsx
@@ -26,6 +26,28 @@ import "../../styles/table.css";
 const STORAGE_KEY = "list-view-mode:view-list";
 const TAB_ID = makeTabId("view-list", "main");
 
+interface CommitViewsDeps {
+  loadProject: typeof loadProject;
+  saveProject: typeof saveProject;
+  deleteView: typeof deleteView;
+}
+
+export async function commitViews(
+  { itemsInOrder, deletedIds }: { itemsInOrder: ViewEntry[]; deletedIds: string[] },
+  deps: CommitViewsDeps = { loadProject, saveProject, deleteView },
+): Promise<void> {
+  const project = await deps.loadProject();
+  const deletedSet = new Set(deletedIds);
+  const orderMap = new Map(itemsInOrder.map((v, i) => [v.id, i]));
+  project.views = (project.views ?? [])
+    .filter((v) => !deletedSet.has(v.id))
+    .sort((a, b) => (orderMap.get(a.id) ?? Number.MAX_SAFE_INTEGER) - (orderMap.get(b.id) ?? Number.MAX_SAFE_INTEGER));
+  await deps.saveProject(project);
+  for (const id of deletedIds) {
+    await deps.deleteView(id);
+  }
+}
+
 interface ValidationSummary {
   errors: number;
   warnings: number;
@@ -54,21 +76,6 @@ export function ViewListView() {
     mcpBridge.startWithoutEditor();
     await loadProject();
     return await listViews();
-  }, []);
-
-  const commitViews = useCallback(async ({ itemsInOrder, deletedIds }: { itemsInOrder: ViewEntry[]; deletedIds: string[] }) => {
-    for (const id of deletedIds) {
-      await deleteView(id);
-    }
-    const project = await loadProject();
-    if (project.views) {
-      const deletedSet = new Set(deletedIds);
-      const orderMap = new Map(itemsInOrder.map((v, i) => [v.id, i]));
-      project.views = project.views
-        .filter((v) => !deletedSet.has(v.id))
-        .sort((a, b) => (orderMap.get(a.id) ?? 0) - (orderMap.get(b.id) ?? 0));
-      await saveProject(project);
-    }
   }, []);
 
   const editor = useListEditor<ViewEntry>({

--- a/designer/src/components/view/ViewListView.tsx
+++ b/designer/src/components/view/ViewListView.tsx
@@ -41,7 +41,8 @@ export async function commitViews(
   const orderMap = new Map(itemsInOrder.map((v, i) => [v.id, i]));
   project.views = (project.views ?? [])
     .filter((v) => !deletedSet.has(v.id))
-    .sort((a, b) => (orderMap.get(a.id) ?? Number.MAX_SAFE_INTEGER) - (orderMap.get(b.id) ?? Number.MAX_SAFE_INTEGER));
+    .sort((a, b) => (orderMap.get(a.id) ?? Number.MAX_SAFE_INTEGER) - (orderMap.get(b.id) ?? Number.MAX_SAFE_INTEGER))
+    .map((v, i) => ({ ...v, no: i + 1 }));
   await deps.saveProject(project);
   for (const id of deletedIds) {
     await deps.deleteView(id);

--- a/designer/src/store/sequenceStore.test.ts
+++ b/designer/src/store/sequenceStore.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { commitSequences } from "../components/sequence/SequenceListView";
+import type { FlowProject } from "../types/flow";
+import type { SequenceEntry, SequenceId, Timestamp } from "../types/v3";
+import type { FlowStorageBackend } from "./flowStore";
+import { setFlowDraftMode, setFlowStorageBackend } from "./flowStore";
+import type { SequenceStorageBackend } from "./sequenceStore";
+import { deleteSequence, setSequenceStorageBackend } from "./sequenceStore";
+
+const TS = "2026-04-29T00:00:00.000Z" as Timestamp;
+
+function sequenceEntry(id: string, no: number): SequenceEntry {
+  return {
+    id: id as SequenceId,
+    no,
+    name: `sequence ${id}`,
+    physicalName: `sequence_${id}`,
+    updatedAt: TS,
+  };
+}
+
+function projectWithSequences(sequences: SequenceEntry[]): FlowProject {
+  return {
+    version: 1,
+    name: "test",
+    screens: [],
+    groups: [],
+    edges: [],
+    sequences,
+    updatedAt: TS,
+  };
+}
+
+describe("sequenceStore delete/commit batching", () => {
+  beforeEach(() => {
+    setSequenceStorageBackend(null);
+    setFlowStorageBackend(null);
+    setFlowDraftMode(false);
+    localStorage.clear();
+  });
+
+  it("deleteSequence does not save project.json", async () => {
+    const saveProject = vi.fn().mockResolvedValue(undefined);
+    const flowBackend: FlowStorageBackend = {
+      loadProject: vi.fn().mockResolvedValue(projectWithSequences([sequenceEntry("a", 1)])),
+      saveProject,
+      deleteScreenData: vi.fn().mockResolvedValue(undefined),
+    };
+    const sequenceBackend: SequenceStorageBackend = {
+      loadSequence: vi.fn().mockResolvedValue(null),
+      saveSequence: vi.fn().mockResolvedValue(undefined),
+      deleteSequence: vi.fn().mockResolvedValue(undefined),
+    };
+    setFlowStorageBackend(flowBackend);
+    setSequenceStorageBackend(sequenceBackend);
+
+    await deleteSequence("a");
+
+    expect(sequenceBackend.deleteSequence).toHaveBeenCalledWith("a");
+    expect(saveProject).not.toHaveBeenCalled();
+  });
+
+  it("commitSequences saves project.json once regardless of deletedIds count", async () => {
+    const project = projectWithSequences([sequenceEntry("a", 1), sequenceEntry("b", 2), sequenceEntry("c", 3)]);
+    const loadProject = vi.fn().mockResolvedValue(project);
+    const saveProject = vi.fn().mockResolvedValue(undefined);
+    const deleteSequence = vi.fn().mockResolvedValue(undefined);
+
+    await commitSequences({
+      itemsInOrder: [sequenceEntry("c", 1), sequenceEntry("a", 2)],
+      deletedIds: ["b", "missing"],
+    }, { loadProject, saveProject, deleteSequence });
+
+    expect(saveProject).toHaveBeenCalledTimes(1);
+    expect(saveProject).toHaveBeenCalledWith(project);
+    expect(project.sequences?.map((s) => s.id)).toEqual(["c", "a"]);
+    expect(deleteSequence).toHaveBeenCalledTimes(2);
+    expect(deleteSequence).toHaveBeenNthCalledWith(1, "b");
+    expect(deleteSequence).toHaveBeenNthCalledWith(2, "missing");
+  });
+});

--- a/designer/src/store/sequenceStore.test.ts
+++ b/designer/src/store/sequenceStore.test.ts
@@ -74,6 +74,7 @@ describe("sequenceStore delete/commit batching", () => {
     expect(saveProject).toHaveBeenCalledTimes(1);
     expect(saveProject).toHaveBeenCalledWith(project);
     expect(project.sequences?.map((s) => s.id)).toEqual(["c", "a"]);
+    expect(project.sequences?.map((s) => s.no)).toEqual([1, 2]);
     expect(deleteSequence).toHaveBeenCalledTimes(2);
     expect(deleteSequence).toHaveBeenNthCalledWith(1, "b");
     expect(deleteSequence).toHaveBeenNthCalledWith(2, "missing");

--- a/designer/src/store/sequenceStore.ts
+++ b/designer/src/store/sequenceStore.ts
@@ -90,11 +90,6 @@ export async function deleteSequence(sequenceId: string): Promise<void> {
     localStorage.removeItem(`${SEQUENCE_PREFIX}${sequenceId}`);
   }
 
-  const project = await loadProject();
-  if (project.sequences) {
-    project.sequences = renumber(project.sequences.filter((s) => s.id !== sequenceId));
-    await saveProject(project);
-  }
 }
 
 // ─── 内部 ────────────────────────────────────────────────────────────────

--- a/designer/src/store/viewStore.test.ts
+++ b/designer/src/store/viewStore.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { commitViews } from "../components/view/ViewListView";
+import type { FlowProject } from "../types/flow";
+import type { Timestamp, ViewEntry, ViewId } from "../types/v3";
+import type { FlowStorageBackend } from "./flowStore";
+import { setFlowDraftMode, setFlowStorageBackend } from "./flowStore";
+import type { ViewStorageBackend } from "./viewStore";
+import { deleteView, setViewStorageBackend } from "./viewStore";
+
+const TS = "2026-04-29T00:00:00.000Z" as Timestamp;
+
+function viewEntry(id: string, no: number): ViewEntry {
+  return {
+    id: id as ViewId,
+    no,
+    name: `view ${id}`,
+    physicalName: `view_${id}`,
+    updatedAt: TS,
+  };
+}
+
+function projectWithViews(views: ViewEntry[]): FlowProject {
+  return {
+    version: 1,
+    name: "test",
+    screens: [],
+    groups: [],
+    edges: [],
+    views,
+    updatedAt: TS,
+  };
+}
+
+describe("viewStore delete/commit batching", () => {
+  beforeEach(() => {
+    setViewStorageBackend(null);
+    setFlowStorageBackend(null);
+    setFlowDraftMode(false);
+    localStorage.clear();
+  });
+
+  it("deleteView does not save project.json", async () => {
+    const saveProject = vi.fn().mockResolvedValue(undefined);
+    const flowBackend: FlowStorageBackend = {
+      loadProject: vi.fn().mockResolvedValue(projectWithViews([viewEntry("a", 1)])),
+      saveProject,
+      deleteScreenData: vi.fn().mockResolvedValue(undefined),
+    };
+    const viewBackend: ViewStorageBackend = {
+      loadView: vi.fn().mockResolvedValue(null),
+      saveView: vi.fn().mockResolvedValue(undefined),
+      deleteView: vi.fn().mockResolvedValue(undefined),
+    };
+    setFlowStorageBackend(flowBackend);
+    setViewStorageBackend(viewBackend);
+
+    await deleteView("a");
+
+    expect(viewBackend.deleteView).toHaveBeenCalledWith("a");
+    expect(saveProject).not.toHaveBeenCalled();
+  });
+
+  it("commitViews saves project.json once regardless of deletedIds count", async () => {
+    const project = projectWithViews([viewEntry("a", 1), viewEntry("b", 2), viewEntry("c", 3)]);
+    const loadProject = vi.fn().mockResolvedValue(project);
+    const saveProject = vi.fn().mockResolvedValue(undefined);
+    const deleteView = vi.fn().mockResolvedValue(undefined);
+
+    await commitViews({
+      itemsInOrder: [viewEntry("c", 1), viewEntry("a", 2)],
+      deletedIds: ["b", "missing"],
+    }, { loadProject, saveProject, deleteView });
+
+    expect(saveProject).toHaveBeenCalledTimes(1);
+    expect(saveProject).toHaveBeenCalledWith(project);
+    expect(project.views?.map((v) => v.id)).toEqual(["c", "a"]);
+    expect(deleteView).toHaveBeenCalledTimes(2);
+    expect(deleteView).toHaveBeenNthCalledWith(1, "b");
+    expect(deleteView).toHaveBeenNthCalledWith(2, "missing");
+  });
+});

--- a/designer/src/store/viewStore.test.ts
+++ b/designer/src/store/viewStore.test.ts
@@ -74,6 +74,7 @@ describe("viewStore delete/commit batching", () => {
     expect(saveProject).toHaveBeenCalledTimes(1);
     expect(saveProject).toHaveBeenCalledWith(project);
     expect(project.views?.map((v) => v.id)).toEqual(["c", "a"]);
+    expect(project.views?.map((v) => v.no)).toEqual([1, 2]);
     expect(deleteView).toHaveBeenCalledTimes(2);
     expect(deleteView).toHaveBeenNthCalledWith(1, "b");
     expect(deleteView).toHaveBeenNthCalledWith(2, "missing");

--- a/designer/src/store/viewStore.ts
+++ b/designer/src/store/viewStore.ts
@@ -113,11 +113,6 @@ export async function deleteView(viewId: string): Promise<void> {
     localStorage.removeItem(`${VIEW_PREFIX}${viewId}`);
   }
 
-  const project = await loadProject();
-  if (project.views) {
-    project.views = renumber(project.views.filter((v) => v.id !== viewId));
-    await saveProject(project);
-  }
 }
 
 // ─── 内部 ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 関連

Closes #551

## 概要

commitViews / commitSequences の削除保存処理で発生していた N+1 回の saveProject を、project.json の先行更新 1 回に集約した。また旧実装で deleteView/deleteSequence 内で行っていた no 再採番を commitX 側で明示的に行うよう修正。

## 主な変更

- viewStore / sequenceStore: deleteView / deleteSequence を per-entity 削除のみに変更 (loadProject/saveProject ブロック削除)
- ViewListView / SequenceListView: project.json を先に filter + sort + renumber + saveProject し、その後 entity ファイル削除を実行 (1 回化)
- Vitest: deleteView/deleteSequence 単体で saveProject しないこと、commitViews/commitSequences で saveProject が 1 回だけ呼ばれること + no 連番正確性を追加検証

## 仕様逐条突合 (自己申告)

- Step 1: deleteView は per-entity 削除のみ: designer/src/store/viewStore.ts:109, :113
- Step 1: deleteSequence は per-entity 削除のみ: designer/src/store/sequenceStore.ts:86, :90
- Step 2: commitViews — filter+sort+renumber: designer/src/components/view/ViewListView.tsx:42-45
- Step 2: commitViews — saveProject 1 回: designer/src/components/view/ViewListView.tsx:46
- Step 2: commitViews — per-entity 削除: designer/src/components/view/ViewListView.tsx:47-49
- Step 2: commitSequences — filter+sort+renumber: designer/src/components/sequence/SequenceListView.tsx:39-42
- Step 2: commitSequences — saveProject 1 回: designer/src/components/sequence/SequenceListView.tsx:43
- Step 2: commitSequences — per-entity 削除: designer/src/components/sequence/SequenceListView.tsx:44-46
- Step 3: deleteView 単体で saveProject 0 回: designer/src/store/viewStore.test.ts
- Step 3: commitViews で saveProject 1 回 + no 連番: designer/src/store/viewStore.test.ts
- Step 3: deleteSequence 単体で saveProject 0 回: designer/src/store/sequenceStore.test.ts
- Step 3: commitSequences で saveProject 1 回 + no 連番: designer/src/store/sequenceStore.test.ts

## テスト

- npm run build: pass
- npx vitest run: 67 files / 1042 tests pass
- schema 変更: git diff origin/main..HEAD -- schemas/ 出力なし
- 半角カナ: grep ヒットゼロ