### PR TITLE
improve(store): commitTables の N+1 saveProject を 1 回にバッチ化 + no 再採番 (#594)

### DIFF
--- a/designer/src/components/table/TableListView.tsx
+++ b/designer/src/components/table/TableListView.tsx
@@ -29,6 +29,29 @@ import "../../styles/table.css";
 const STORAGE_KEY = "list-view-mode:table-list";
 const TAB_ID = makeTabId("table-list", "main");
 
+interface CommitTablesDeps {
+  loadProject: typeof loadProject;
+  saveProject: typeof saveProject;
+  deleteTable: typeof deleteTable;
+}
+
+export async function commitTables(
+  { itemsInOrder, deletedIds }: { itemsInOrder: TableEntry[]; deletedIds: string[] },
+  deps: CommitTablesDeps = { loadProject, saveProject, deleteTable },
+): Promise<void> {
+  const project = await deps.loadProject();
+  const deletedSet = new Set(deletedIds);
+  const orderMap = new Map(itemsInOrder.map((t, i) => [t.id, i]));
+  project.tables = (project.tables ?? [])
+    .filter((t) => !deletedSet.has(t.id))
+    .sort((a, b) => (orderMap.get(a.id) ?? Number.MAX_SAFE_INTEGER) - (orderMap.get(b.id) ?? Number.MAX_SAFE_INTEGER))
+    .map((t, i) => ({ ...t, no: i + 1 }));
+  await deps.saveProject(project);
+  for (const id of deletedIds) {
+    await deps.deleteTable(id);
+  }
+}
+
 interface ValidationSummary {
   errors: number;
   warnings: number;
@@ -63,27 +86,12 @@ export function TableListView() {
     return await listTables();
   }, []);
 
-  const commitTables = useCallback(async ({ itemsInOrder, deletedIds }: { itemsInOrder: TableEntry[]; deletedIds: string[] }) => {
-    // 1. 削除対象を削除
-    for (const id of deletedIds) {
-      await deleteTable(id);
-    }
-    // 2. 並び順を project.tables に反映
-    const project = await loadProject();
-    if (project.tables) {
-      const deletedSet = new Set(deletedIds);
-      const orderMap = new Map(itemsInOrder.map((t, i) => [t.id, i]));
-      project.tables = project.tables
-        .filter((t) => !deletedSet.has(t.id))
-        .sort((a, b) => (orderMap.get(a.id) ?? 0) - (orderMap.get(b.id) ?? 0));
-      await saveProject(project);
-    }
-  }, []);
+  const commitTableChanges = useCallback(commitTables, []);
 
   const editor = useListEditor<TableEntry>({
     getId: (t) => t.id,
     load: loadTables,
-    commit: commitTables,
+    commit: commitTableChanges,
     tabId: TAB_ID,
     renumber,
   });

--- a/designer/src/store/tableStore.test.ts
+++ b/designer/src/store/tableStore.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { commitTables } from "../components/table/TableListView";
+import type { FlowProject } from "../types/flow";
+import type { TableEntry, TableId, Timestamp } from "../types/v3";
+import type { FlowStorageBackend } from "./flowStore";
+import { setFlowDraftMode, setFlowStorageBackend } from "./flowStore";
+import type { TableStorageBackend } from "./tableStore";
+import { deleteTable, setTableStorageBackend } from "./tableStore";
+
+const TS = "2026-04-29T00:00:00.000Z" as Timestamp;
+
+function tableEntry(id: string, no: number): TableEntry {
+  return {
+    id: id as TableId,
+    no,
+    name: `table ${id}`,
+    physicalName: `table_${id}`,
+    columnCount: 0,
+    updatedAt: TS,
+  };
+}
+
+function projectWithTables(tables: TableEntry[]): FlowProject {
+  return {
+    version: 1,
+    name: "test",
+    screens: [],
+    groups: [],
+    edges: [],
+    tables,
+    updatedAt: TS,
+  };
+}
+
+describe("tableStore delete/commit batching", () => {
+  beforeEach(() => {
+    setTableStorageBackend(null);
+    setFlowStorageBackend(null);
+    setFlowDraftMode(false);
+    localStorage.clear();
+  });
+
+  it("deleteTable does not save project.json", async () => {
+    const saveProject = vi.fn().mockResolvedValue(undefined);
+    const flowBackend: FlowStorageBackend = {
+      loadProject: vi.fn().mockResolvedValue(projectWithTables([tableEntry("a", 1)])),
+      saveProject,
+      deleteScreenData: vi.fn().mockResolvedValue(undefined),
+    };
+    const tableBackend: TableStorageBackend = {
+      loadTable: vi.fn().mockResolvedValue(null),
+      saveTable: vi.fn().mockResolvedValue(undefined),
+      deleteTable: vi.fn().mockResolvedValue(undefined),
+    };
+    setFlowStorageBackend(flowBackend);
+    setTableStorageBackend(tableBackend);
+
+    await deleteTable("a");
+
+    expect(tableBackend.deleteTable).toHaveBeenCalledWith("a");
+    expect(saveProject).not.toHaveBeenCalled();
+  });
+
+  it("commitTables saves project.json once regardless of deletedIds count", async () => {
+    const project = projectWithTables([tableEntry("a", 1), tableEntry("b", 2), tableEntry("c", 3)]);
+    const loadProject = vi.fn().mockResolvedValue(project);
+    const saveProject = vi.fn().mockResolvedValue(undefined);
+    const deleteTable = vi.fn().mockResolvedValue(undefined);
+
+    await commitTables({
+      itemsInOrder: [tableEntry("c", 1), tableEntry("a", 2)],
+      deletedIds: ["b", "missing"],
+    }, { loadProject, saveProject, deleteTable });
+
+    expect(saveProject).toHaveBeenCalledTimes(1);
+    expect(saveProject).toHaveBeenCalledWith(project);
+    expect(project.tables?.map((t) => t.id)).toEqual(["c", "a"]);
+    expect(project.tables?.map((t) => t.no)).toEqual([1, 2]);
+    expect(deleteTable).toHaveBeenCalledTimes(2);
+    expect(deleteTable).toHaveBeenNthCalledWith(1, "b");
+    expect(deleteTable).toHaveBeenNthCalledWith(2, "missing");
+  });
+});

--- a/designer/src/store/tableStore.ts
+++ b/designer/src/store/tableStore.ts
@@ -141,12 +141,6 @@ export async function deleteTable(tableId: string): Promise<void> {
   } else {
     localStorage.removeItem(`${TABLE_PREFIX}${tableId}`);
   }
-
-  const project = await loadProject();
-  if (project.tables) {
-    project.tables = renumber(project.tables.filter((t) => t.id !== tableId));
-    await saveProject(project);
-  }
 }
 
 // ─── カラム操作 (Table mutate ヘルパー) ──────────────────────────────────


### PR DESCRIPTION
﻿## 関連

- Closes #594
- 仕様: docs/spec/list-common.md §3.10 / Issue #594 改善方針

## 概要

Table 一覧の保存時削除で、deletedIds 件数分 `deleteTable` が `saveProject` を呼び、最後に `commitTables` も保存する N+1 構造を解消しました。`deleteTable` は per-entity 削除のみにし、`commitTables` が project.tables の filter / sort / no 再採番をまとめて 1 回だけ保存します。

## 主な変更

- Table 一覧の commit 処理を `commitTables` として top-level export し、依存注入で単体テスト可能にしました: `designer/src/components/table/TableListView.tsx:38`
- `commitTables` で削除除外、表示順反映、`no` 連番再採番、`saveProject` 1 回、per-entity 削除の順に統一しました: `designer/src/components/table/TableListView.tsx:42`
- `deleteTable` から `loadProject` / `saveProject` による project.json 更新を削除しました: `designer/src/store/tableStore.ts:138`
- Table 用の delete / commit batching テストを追加しました: `designer/src/store/tableStore.test.ts:43`, `designer/src/store/tableStore.test.ts:64`

## 仕様逐条突合 (自己申告)

- Issue #594 改善方針 1: `tableStore.deleteTable` は per-entity 削除のみ -> `designer/src/store/tableStore.ts:138`
- Issue #594 改善方針 2: `commitTables` で filter + sort + no 再採番 + `saveProject` 1 回 -> `designer/src/components/table/TableListView.tsx:42`
- Issue #594 改善方針 2: `saveProject` 後に deletedIds の per-entity 削除を実行 -> `designer/src/components/table/TableListView.tsx:50`
- Issue #594 改善方針 3: `deleteTable` 単体で `saveProject` 0 回を検証 -> `designer/src/store/tableStore.test.ts:43`
- Issue #594 改善方針 3: `commitTables` で `saveProject` 1 回、順序、`no` 連番を検証 -> `designer/src/store/tableStore.test.ts:64`

## レビューで特に見てほしい箇所

- `commitTables` の保存順序が View 側の `commitViews` と同型になっているか
- `deleteTable` から project.json 更新を外した影響範囲が一覧 commit に閉じているか

## テスト

- Vitest: 1044 件 (新規 2 件) - `npx vitest run`
- Playwright: N/A - store/list commit の単体挙動変更のみ
- MCP E2E: N/A - WebSocket API 追加変更なし
- Build: `npm run build`
- Schema diff: `git diff origin/main..HEAD -- schemas/` 出力なし
- 半角カナ確認: `grep -nP "[ｦ-ﾟ]" designer/src/store/tableStore.ts designer/src/components/table/TableListView.tsx designer/src/store/tableStore.test.ts` ヒットなし

## UI 影響 / AI smoke test

- [ ] UI 影響あり (AI が chrome-devtools MCP / Playwright で smoke test 実施済み)
- [x] UI 影響なし (auto テスト pass のみ)

### UI 影響ありの場合、AI smoke test で確認した項目

- N/A

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

N/A
