### PR TITLE
improve(skill): /create-flow Step 5 に validate:dogfood と validator 検証を統合 (#598)

### DIFF
--- a/.claude/skills/create-flow/SKILL.md
+++ b/.claude/skills/create-flow/SKILL.md
@@ -141,11 +141,15 @@ ProcessFlow JSON に含めるべき要素 (5/5 達成サンプル準拠):
 - 典型ミス: `SELECT id, status FROM table` で取得後、後続で `@row.quantity` を参照 → 実行時 undefined
 - 対処: SELECT 句に必要カラムを全列挙、または compute step で別途取得
 
+**Step 5.2 で `validate:dogfood` により機械的に検出される**
+
 ### Rule 10: `@conv.*` 参照の catalog 整合 (#486 で発覚)
 
 - フロー内で参照する全 `@conv.*` キーが `docs/sample-project/conventions/conventions-catalog.json` に存在することを確認
 - 典型ミス: ADR で `@conv.limit.maxDeliveryAttempts` を仕様化したが catalog 追加を忘れる → runtime で undefined 解決、condition が常に false
 - 対処: 新規 `@conv.*` キーを使うときは必ず catalog にも追加 (本 PR で追加するか、別 ISSUE で先行追加)
+
+**Step 5.2 で `validate:dogfood` により機械的に検出される**
 
 ### Rule 11: TX 内 branch return 後の制御 (#486 で発覚)
 
@@ -211,13 +215,51 @@ ProcessFlow JSON に含めるべき要素 (5/5 達成サンプル準拠):
 
 ## Step 5: 完成後の自己検証 (必須)
 
+### 5.1 構造検証
+
 ```bash
 cd designer
 npx vitest run src/schemas/extensions-samples.test.ts src/schemas/process-flow.schema.test.ts
 npm run build
 ```
 
-両 pass を確認したら、**強く推奨**:
+### 5.2 バリデータ横断検証 (Rule 9/10 の機械的検出)
+
+作成したフローを `docs/sample-project/process-flows/<flowId>.json` に配置した状態で:
+
+```bash
+cd designer
+npm run validate:dogfood
+```
+
+これにより以下を機械的に検出する:
+
+| バリデータ | 検出内容 | 対応 Rule |
+|---|---|---|
+| sqlColumnValidator | SQL 内で参照したカラムがテーブル定義に存在しない | Rule 9 |
+| conventionsValidator | `@conv.*` 参照が conventions-catalog.json 未登録 | Rule 10 |
+| referentialIntegrity | responseRef / errorCode / systemRef / compensatesFor の不整合 | Rule 5 / Rule 8 補強 |
+| identifierScope | 識別子スコープ違反 (root レベル) | Rule 1 補強 |
+
+**fail した場合の対処**:
+- `UNKNOWN_COLUMN` → SELECT 句を見直す or テーブル定義を更新
+- `UNKNOWN_CONV_LIMIT` 等 → `docs/sample-project/conventions/conventions-catalog.json` に追加 or 既存キーへ修正
+- 構造的に解消できない場合は ISSUE 起票して停止 (グローバル schema 変更は禁止 — Rule 15)
+
+### 5.3 単一フロー検証 (任意)
+
+`validate:dogfood` は `docs/sample-project/` 全件対象のため、作成中フロー 1 件のみを検証したい場合:
+
+```bash
+cd designer
+npx vitest run src/schemas/validateDogfood.test.ts -t "<flowId の一部>"
+```
+
+または `validateDogfood.test.ts` のパターンを参考にインライン実行 (詳細は同テストを参照)。
+
+### 5.4 /review-flow による最終検証
+
+5.1 / 5.2 が pass したら、**強く推奨**:
 
 ```
 /review-flow <flowId>
@@ -265,8 +307,9 @@ npm run build
 
 ### 検証結果
 - vitest: <pass/fail 件数>
-- npm run build: <成功/失敗>
-- /review-flow 自己実行: <実施済 Must-fix N 件 / 未実施>
+- build: <pass/fail>
+- validate:dogfood: <pass/fail 件数> (sqlColumnValidator / conventionsValidator / referentialIntegrity / identifierScope)
+- /review-flow: <Must-fix 件数 / Should-fix 件数>
 
 ### 推奨: 次の手順
 - /review-flow を未実施なら実施


### PR DESCRIPTION
## 関連

- Closes #598
- 親 #493
- 監査報告 PR #597
- 仕様: N/A (Skill 手順の改善。対応 ISSUE #598 の完了基準に準拠)

## 概要

`/create-flow` の完成後自己検証 Step 5 に `validate:dogfood` を組み込み、Rule 9/10 を含む validator 横断検証を作成フローの標準手順として明記しました。

## 主な変更

- Rule 9 / Rule 10 に `validate:dogfood` で機械的に検出される旨を追記
- Step 5 を 5.1-5.4 に分割し、構造検証、validator 横断検証、単一フロー検証、`/review-flow` 最終検証を明記
- Step 6 の出力フォーマットに build / validate:dogfood / `/review-flow` の結果欄を追加

## 仕様逐条突合 (自己申告)

- Rule 9 末尾への機械検出注記追加 → `.claude/skills/create-flow/SKILL.md:144` ✓
- Rule 10 末尾への機械検出注記追加 → `.claude/skills/create-flow/SKILL.md:152` ✓
- Step 5 見出し維持 → `.claude/skills/create-flow/SKILL.md:216` ✓
- Step 5.1 構造検証追加 → `.claude/skills/create-flow/SKILL.md:218` ✓
- Step 5.2 validator 横断検証追加 → `.claude/skills/create-flow/SKILL.md:226` ✓
- Step 5.3 単一フロー検証追加 → `.claude/skills/create-flow/SKILL.md:249` ✓
- Step 5.4 `/review-flow` 最終検証追加 → `.claude/skills/create-flow/SKILL.md:260` ✓
- Step 6 検証結果ブロック更新 → `.claude/skills/create-flow/SKILL.md:308` ✓
- build 結果欄追加 → `.claude/skills/create-flow/SKILL.md:310` ✓
- validate:dogfood 結果欄追加 → `.claude/skills/create-flow/SKILL.md:311` ✓
- `/review-flow` 結果欄更新 → `.claude/skills/create-flow/SKILL.md:312` ✓

## レビューで特に見てほしい箇所

- Step 5.2 の validator 名と検出内容の対応が現行実装・#598 の意図とずれていないか
- Step 5.3 の単一フロー検証案内が過剰に実装手順へ踏み込みすぎていないか

## テスト

- Vitest: N/A (Skill markdown のみ変更)
- Playwright: N/A (UI 変更なし)
- MCP E2E: N/A (MCP 実装変更なし)
- `git diff origin/main..HEAD -- schemas/`: pass (出力なし)
- `grep -nP [ｦ-ﾟ] .claude/skills/create-flow/SKILL.md`: pass (出力なし)

## UI 影響 / AI smoke test

- [ ] UI 影響あり (AI が chrome-devtools MCP / Playwright で smoke test 実施済み)
- [x] UI 影響なし (auto テスト pass のみ)

### UI 影響ありの場合、AI smoke test で確認した項目

N/A

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

- `schemas/*.json` と `designer/scripts/validate-dogfood.ts` は変更していません。
- 変更対象は `.claude/skills/create-flow/SKILL.md` の指定箇所のみです。