### PR TITLE
improve(skill): /review-flow に Step 0.5 機械的バリデータ実行を追加 (#599)

### DIFF
--- a/.claude/skills/review-flow/SKILL.md
+++ b/.claude/skills/review-flow/SKILL.md
@@ -111,9 +111,15 @@ npm run validate:dogfood
 
 監査根拠: `docs/spec/dogfood-2026-04-29-phase2-validator-audit.md` §3 / §4。
 
+### 終了コードの扱い
+
+- **exit 0**: 4 バリデータ全 pass → Step 1 へ進む
+- **exit 1**: 1 件以上の validator issue 検出 → Step 1 を中止せず、issue 内容を Step 2 のカバレッジ表に「validator 検出済」として記録して進む (実行セマンティクス観点が AI 目視のみで残るため)
+- **exit 2**: 引数異常 / ファイル不在 / JSON parse 失敗 → エラーメッセージを報告し AI 目視のみで Step 1 に進む
+
 ### バリデータが動かない場合
 
-- `--flow <path>` のファイルが存在しない / JSON parse 失敗 → エラーメッセージを報告し Step 1 に進む (AI 目視のみで継続)
+- `--flow <path>` のファイルが存在しない / JSON parse 失敗 (= exit 2) → エラーメッセージを報告し Step 1 に進む (AI 目視のみで継続)
 - `npm run validate:dogfood` 自体が失敗 (依存解決等) → 同上、Step 1 に進む
 - バリデータ未呼び出しは **Step 2 の「validator 検出済」欄を「未実行」と明記** (隠さない)
 

--- a/.claude/skills/review-flow/SKILL.md
+++ b/.claude/skills/review-flow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-flow
-description: ProcessFlow JSON の実行セマンティクスを専門レビュー (変数ライフサイクル / TX スコープ / runIf 連鎖 / 補償整合 / event 双方向)。設計フェーズから使える
+description: ProcessFlow JSON の実行セマンティクスを専門レビュー (変数ライフサイクル / TX スコープ / runIf 連鎖 / 補償整合 / event 双方向)。Step 0.5 で 4 バリデータを機械実行 (#599)、Step 1 で 8 観点を AI レビュー。設計フェーズから使える
 argument-hint: <flowId | path | --all | (空 = MCP アクティブタブ)>
 disable-model-invocation: true
 ---
@@ -59,6 +59,63 @@ maturity: <maturity>
 ```
 
 複数件なら一覧表示してから順次処理。
+
+## Step 0.5: 機械的バリデータ実行 (#599)
+
+Step 1 の AI 目視レビューに入る前に、実装済みの 4 バリデータ (`checkReferentialIntegrity` / `checkIdentifierScopes` / `checkSqlColumns` / `checkConventionReferences`) を CLI 経由で実行して、機械的に検出可能な参照整合・識別子スコープ・SQL カラム・@conv.* 参照の問題を先に拾う。
+
+### 実行コマンド
+
+対象フローのパス (Step 0 で resolve した絶対 / 相対パス) を `--flow` で渡す:
+
+```bash
+cd designer
+npm run validate:dogfood -- --flow <対象フローのパス>
+```
+
+`--all` モードや、Step 0 で複数件 resolve した場合は、`--flow` 引数を省略することでサンプル全件を一括検証できる:
+
+```bash
+cd designer
+npm run validate:dogfood
+```
+
+### 何が動くか (4 バリデータ)
+
+| バリデータ | 検出内容 | 入力 |
+|---|---|---|
+| `checkReferentialIntegrity` | responseRef / errorCode / systemRef / compensatesFor 等の不整合 | 常時動作 |
+| `checkIdentifierScopes` | 識別子スコープ違反 (root レベル `@var` 未宣言) | 常時動作 |
+| `checkSqlColumns` | SQL 内で参照したカラムがテーブル定義に存在しない | `docs/sample-project/tables/` 経由で自動ロード |
+| `checkConventionReferences` | `@conv.*` 参照が catalog 未登録 | `docs/sample-project/conventions/conventions-catalog.json` を自動ロード |
+
+### 結果の取り扱い
+
+- バリデータが検出した issue は **Step 1 のレビュー入力**として活用 (重複説明はしない)
+- 結果は Step 2 の「8 観点別カバレッジ」表に **「validator 検出済」** カラムとして記録
+- Must-fix 候補: `UNKNOWN_RESPONSE_REF` / `UNKNOWN_ERROR_CODE` / `UNKNOWN_IDENTIFIER` / `UNKNOWN_COLUMN` / `UNKNOWN_CONV_*` 等
+- 終了コード 1 (1 件以上 fail) でも Step 1 を中止せず実施する (実行セマンティクス観点が AI 目視のみで残るため)
+
+### 観点 ⇄ バリデータ対応表 (担当領域)
+
+| 観点 | バリデータでカバー | AI 目視のみ |
+|---|---|---|
+| 1. 変数ライフサイクル | identifierScope (root 識別子の未宣言) | TX 順序 / property path / 前方参照は AI |
+| 2. TX スコープ整合 | (なし) | AI |
+| 3. runIf 連鎖の網羅性 | (なし) | AI |
+| 4. branch / elseBranch 到達性 | (なし) | AI |
+| 5. compensatesFor 健全性 | referentialIntegrity (compensatesFor 対象の実在チェック) | 補償内容の妥当性は AI |
+| 6. eventsCatalog ⇄ eventPublish | (なし、referentialIntegrity 対象外) | AI |
+| 7. 外部呼び出しと TX 位置 | referentialIntegrity (systemRef 実在) | TX 内外の位置関係は AI |
+| 8. rollbackOn 発火可能性 | referentialIntegrity (UNKNOWN_ERROR_CODE) | TX inner からの実発火可能性は AI |
+
+監査根拠: `docs/spec/dogfood-2026-04-29-phase2-validator-audit.md` §3 / §4。
+
+### バリデータが動かない場合
+
+- `--flow <path>` のファイルが存在しない / JSON parse 失敗 → エラーメッセージを報告し Step 1 に進む (AI 目視のみで継続)
+- `npm run validate:dogfood` 自体が失敗 (依存解決等) → 同上、Step 1 に進む
+- バリデータ未呼び出しは **Step 2 の「validator 検出済」欄を「未実行」と明記** (隠さない)
 
 ## Step 1: 検証項目 (8 観点)
 
@@ -178,16 +235,20 @@ TransactionScope の `rollbackOn: [...]` で指定したエラーコードにつ
 
 ### 8 観点別カバレッジ
 
-| 観点 | 検出件数 | 状態 |
-|---|---|---|
-| 1. 変数ライフサイクル | M:0 / S:0 / N:0 | ✓ 問題なし / ❌ Must-fix あり |
-| 2. TransactionScope 内外整合 | ... | ... |
-| 3. runIf 連鎖の網羅性 | ... | ... |
-| 4. branch 到達性 | ... | ... |
-| 5. compensatesFor | ... | ... |
-| 6. eventsCatalog ⇄ eventPublish | ... | ... |
-| 7. 外部呼び出しと TX | ... | ... |
-| 8. rollbackOn 発火可能性 | ... | ... |
+`validator 検出済` 欄には Step 0.5 で動作したバリデータの issue 件数を、`AI 目視` 欄には Step 1 で AI が検出した件数 (validator 重複は除外) を記入する。
+
+| 観点 | validator 検出済 | AI 目視 (M / S / N) | 状態 |
+|---|---|---|---|
+| 1. 変数ライフサイクル | identifierScope: N 件 | M:0 / S:0 / N:0 | ✓ 問題なし / ❌ Must-fix あり |
+| 2. TransactionScope 内外整合 | (validator 対象外) | ... | ... |
+| 3. runIf 連鎖の網羅性 | (validator 対象外) | ... | ... |
+| 4. branch 到達性 | (validator 対象外) | ... | ... |
+| 5. compensatesFor | referentialIntegrity: N 件 | ... | ... |
+| 6. eventsCatalog ⇄ eventPublish | (validator 対象外) | ... | ... |
+| 7. 外部呼び出しと TX | referentialIntegrity (systemRef): N 件 | ... | ... |
+| 8. rollbackOn 発火可能性 | referentialIntegrity (UNKNOWN_ERROR_CODE): N 件 | ... | ... |
+
+Step 0.5 をスキップした場合は `validator 検出済` 列を全行 `未実行` と記載する。
 
 ---
 
@@ -203,8 +264,9 @@ TransactionScope の `rollbackOn: [...]` で指定したエラーコードにつ
 
 ### 検証方法
 
+- Step 0.5: `npm run validate:dogfood -- --flow <パス>` で 4 バリデータ実行
 - 対象ファイル全文読み込み: <パス>
-- 8 観点を順に手動で grep + ライフサイクル追跡
+- 8 観点を順に手動で grep + ライフサイクル追跡 (validator 検出済の問題は重複説明しない)
 - 必要に応じて `schemas/process-flow.schema.json` の TransactionScopeStep 定義も参照
 ```
 
@@ -222,7 +284,8 @@ TransactionScope の `rollbackOn: [...]` で指定したエラーコードにつ
 
 - **マージしない / push しない / PR コメントしない** (設計フェーズでも使える skill のため)
 - **対象 JSON ファイルを書き換えない** (レビュー専任、修正は別ワークフロー)
-- **検証は read-only** (フロー JSON の Read + schema/spec の Read のみ)
+- **検証は read-only** (フロー JSON の Read + schema/spec の Read + Step 0.5 の `npm run validate:dogfood --flow` 実行のみ)
+- **Step 0.5 は必ず試行する** (失敗時は「未実行」と明記して Step 1 に進める)
 - **8 観点すべて実施**。「省略」は禁止。該当ゼロ件でもその旨明記
 - **JSON Schema 検証は対象外** (vitest や ajv にやらせる責務)。あくまで実行時セマンティクスを見る
 - **MCP `designer-mcp` が起動していなくても動く** (引数なし時のみ MCP 利用、明示指定時は不要)

--- a/designer/scripts/validate-dogfood.ts
+++ b/designer/scripts/validate-dogfood.ts
@@ -7,14 +7,15 @@
  *
  * 使用法:
  *   cd designer && npm run validate:dogfood
+ *   cd designer && npm run validate:dogfood -- --flow <path>   # 単一フローのみ検証 (#599)
  *
  * 終了コード:
  *   0: 全件 pass
  *   1: 1 件以上 fail
  */
 
-import { readFileSync, readdirSync } from "node:fs";
-import { resolve, join, basename, relative } from "node:path";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { resolve, join, basename, relative, isAbsolute } from "node:path";
 import type { ProcessFlow } from "../src/types/action.js";
 import { checkSqlColumns, type TableDefinition } from "../src/schemas/sqlColumnValidator.js";
 import { checkConventionReferences, type ConventionsCatalog } from "../src/schemas/conventionsValidator.js";
@@ -165,7 +166,27 @@ function loadExtensions(): { extensions: LoadedExtensions; fileCount: number } {
   return { extensions: result.extensions, fileCount };
 }
 
-function loadFlows(): Array<{ filePath: string; displayName: string; flow: ProcessFlow }> {
+function loadFlows(explicitPath?: string): Array<{ filePath: string; displayName: string; flow: ProcessFlow }> {
+  if (explicitPath) {
+    const filePath = isAbsolute(explicitPath) ? explicitPath : resolve(process.cwd(), explicitPath);
+    let stat;
+    try {
+      stat = statSync(filePath);
+    } catch {
+      throw new Error(`--flow に指定されたファイルが見つかりません: ${filePath}`);
+    }
+    if (!stat.isFile()) {
+      throw new Error(`--flow に指定されたパスはファイルではありません: ${filePath}`);
+    }
+    const displayName = relative(repoRoot, filePath).replace(/\\/g, "/");
+    const raw = readFileSync(filePath, "utf-8");
+    return [{
+      filePath,
+      displayName,
+      flow: JSON.parse(raw) as ProcessFlow,
+    }];
+  }
+
   const files = readdirSync(flowsDir)
     .filter((f) => f.endsWith(".json"))
     .sort();
@@ -187,12 +208,14 @@ function loadFlows(): Array<{ filePath: string; displayName: string; flow: Proce
 /**
  * 全サンプルフローを 4 バリデータで検証し、サマリを返す。
  * CI / テストから直接呼び出せるようにエクスポートする。
+ *
+ * @param flowPath 指定時はこのパスのフローのみを対象とする (単一フロー検証、#599)
  */
-export async function runValidation(): Promise<ValidationSummary> {
+export async function runValidation(flowPath?: string): Promise<ValidationSummary> {
   const tables = loadTables();
   const conventions = loadConventions();
   const { extensions, fileCount: extensionFileCount } = loadExtensions();
-  const flows = loadFlows();
+  const flows = loadFlows(flowPath);
 
   const results: FlowValidationResult[] = [];
 
@@ -241,7 +264,7 @@ export async function runValidation(): Promise<ValidationSummary> {
 
 // ─── CLI 出力 ──────────────────────────────────────────────────────────────
 
-function printSummary(summary: ValidationSummary): void {
+function printSummary(summary: ValidationSummary, options: { singleFlow: boolean }): void {
   const conventionsExists = (() => {
     try {
       readFileSync(conventionsFile);
@@ -251,7 +274,7 @@ function printSummary(summary: ValidationSummary): void {
     }
   })();
 
-  console.log("🔍 ドッグフード検証スイート");
+  console.log(options.singleFlow ? "🔍 ドッグフード検証スイート (単一フロー)" : "🔍 ドッグフード検証スイート");
   console.log();
   console.log(
     `📂 サンプル数: ${summary.totalFlows} flows / ${summary.tableCount} tables` +
@@ -312,8 +335,32 @@ function printSummary(summary: ValidationSummary): void {
 
 // ─── エントリーポイント ────────────────────────────────────────────────────
 
+function parseArgs(argv: string[]): { flowPath?: string } {
+  const out: { flowPath?: string } = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--flow") {
+      const next = argv[i + 1];
+      if (!next) throw new Error("--flow にはファイルパスを指定してください");
+      out.flowPath = next;
+      i++;
+    } else if (arg.startsWith("--flow=")) {
+      out.flowPath = arg.slice("--flow=".length);
+    }
+  }
+  return out;
+}
+
 (async () => {
-  const summary = await runValidation();
-  printSummary(summary);
-  process.exit(summary.failedFlows > 0 ? 1 : 0);
+  let flowPath: string | undefined;
+  try {
+    ({ flowPath } = parseArgs(process.argv.slice(2)));
+    const summary = await runValidation(flowPath);
+    printSummary(summary, { singleFlow: Boolean(flowPath) });
+    process.exit(summary.failedFlows > 0 ? 1 : 0);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`❌ ${message}`);
+    process.exit(2);
+  }
 })();

--- a/designer/scripts/validate-dogfood.ts
+++ b/designer/scripts/validate-dogfood.ts
@@ -180,11 +180,14 @@ function loadFlows(explicitPath?: string): Array<{ filePath: string; displayName
     }
     const displayName = relative(repoRoot, filePath).replace(/\\/g, "/");
     const raw = readFileSync(filePath, "utf-8");
-    return [{
-      filePath,
-      displayName,
-      flow: JSON.parse(raw) as ProcessFlow,
-    }];
+    let flow: ProcessFlow;
+    try {
+      flow = JSON.parse(raw) as ProcessFlow;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`--flow の JSON parse に失敗しました: ${filePath} — ${message}`);
+    }
+    return [{ filePath, displayName, flow }];
   }
 
   const files = readdirSync(flowsDir)


### PR DESCRIPTION
## 関連

- Closes #599
- 親 ISSUE: #493 (Phase 2 メタ — 処理フロー + テーブル定義 + 業務規約 連携整合性検証) 子 4
- 監査根拠: `docs/spec/dogfood-2026-04-29-phase2-validator-audit.md` (#596 / PR #597) §3 / §4

## 概要

Phase 2 子 1 監査で判明した「`/review-flow` Skill の 8 観点はすべて AI 目視であり、実装済みの 4 バリデータ (`checkReferentialIntegrity` / `checkIdentifierScopes` / `checkSqlColumns` / `checkConventionReferences`) を呼んでいない」ギャップを解消する。Step 0 (引数解決) と Step 1 (8 観点 AI レビュー) の間に Step 0.5 を新設し、機械的に検出可能な参照整合・識別子スコープ・SQL カラム・@conv.* 参照の問題を先に拾う。

## 主な変更

- **`/review-flow` SKILL に Step 0.5 (機械的バリデータ実行) を新設** (`.claude/skills/review-flow/SKILL.md:63-138`)
  - 実行コマンド: `npm run validate:dogfood -- --flow <対象フローのパス>`
  - 4 バリデータの検出内容と入力ソースの説明 (line 83-90)
  - 結果の取り扱い (line 92-97)
  - 「観点 ⇄ バリデータ対応表」(line 99-110): 8 観点ごとに validator 担当領域と AI 目視のみの領域を分離
  - 終了コードの扱い (line 114-118): exit 0/1/2 と Step 1 への進み方を明示
  - 失敗時は「未実行」と明記して Step 1 に進める方針 (line 120-124)
- **Step 2 報告フォーマットの 8 観点別カバレッジ表に「validator 検出済」列を追加** (`.claude/skills/review-flow/SKILL.md:242-257`)
- **制約節**: 「Step 0.5 は必ず試行 / `validate:dogfood --flow` は read-only」を追加 (`.claude/skills/review-flow/SKILL.md:293-294`)
- **`designer/scripts/validate-dogfood.ts` に `--flow <path>` オプションを追加**
  - 単一フロー検証モード (任意パス対応 / 絶対・相対両対応)
  - 全件モードは引数なしで継続動作 (後方互換)
  - エラー時は exit code 2 + 一行メッセージ (Node ENOENT / JSON parse スタックを露出させない)

新スキル `/review-table-flow` は不要 (監査結論)。既存 `/review-flow` が ProcessFlow 単体レビューとして対象が同一のため、Skill 統合の方が実用的。

## 仕様逐条突合 (自己申告)

ISSUE #599 完了基準との対応:

- [x] `.claude/skills/review-flow/SKILL.md` に Step 0.5 (機械的バリデータ実行) が追加されている
  → SKILL.md:63-138 (Step 0.5 セクション全体: 概要 / 実行コマンド / 4 バリデータ説明 / 観点対応表 / 終了コード扱い / 失敗時挙動)
- [x] 観点ごとの「validator 検出済 vs AI 目視のみ」マッピング表が含まれている
  → SKILL.md:99-110 (観点 ⇄ バリデータ対応表 — 8 観点ごとに validator 担当領域と AI 目視のみを分離)
  → SKILL.md:242-257 (Step 2 報告フォーマット 8 観点別カバレッジ表に validator 検出済列を追加)
- [x] (任意) supporting script を `scripts/` に配置
  → `designer/scripts/validate-dogfood.ts` に `--flow <path>` 追加 (新規ファイルではなく既存スクリプト拡張で実現)

ISSUE 本文「改善案」の 6 ステップ対応:

- 1. 対象 flow JSON を読み込む → SKILL.md:69-74 のコマンドで `validate-dogfood.ts:182` が実行
- 2. checkReferentialIntegrity(flow) を実行 → SKILL.md:87 (常時動作)
- 3. checkIdentifierScopes(flow) を実行 → SKILL.md:88 (常時動作)
- 4. (テーブル定義が利用可能なら) checkSqlColumns → SKILL.md:89 (`docs/sample-project/tables/` 自動ロード)
- 5. (規約 catalog が利用可能なら) checkConventionReferences → SKILL.md:90 (`conventions-catalog.json` 自動ロード)
- 6. 結果を観点別カバレッジ表に「validator 検出済」として記録 → SKILL.md:242-257

## レビューで特に見てほしい箇所

- **`--flow <path>` の挙動**: 任意パス受け入れ (絶対 / 相対 / process.cwd 基準) で正しいか。Windows 上での path resolution を意図的に process.cwd() ベースにしている (npm run コマンド実行ディレクトリから相対指定できるよう)
- **エラー時 exit code 2**: 既存 vitest テスト (`validateDogfood.test.ts`) は引数なしの 0/1 のみを assert するため新挙動に影響しないことを確認済み
- **観点 ⇄ バリデータ対応表 (SKILL.md:99-110)**: 監査報告書 §3 / §4 と整合しているか。観点 1 の「TX 順序 / property path / 前方参照は AI」という分担が妥当か (identifierScope は root レベルの未宣言のみ検出、property path 追跡は別問題という監査結論を反映)

## テスト

- Vitest: 既存 394 件全 pass (新規追加なし)
  - 特に `src/schemas/validateDogfood.test.ts` 7 件は引数なし動作前提のテストで、`--flow` 追加後も全 pass を確認
- 手動動作確認:
  - `npm run validate:dogfood -- --flow ../docs/sample-project/process-flows/gggggggg-0001-...json` → exit 0, ✅ 全件検証 pass
  - `npm run validate:dogfood` (引数なし) → exit 0, 4 件全 pass
  - `npm run validate:dogfood -- --flow nonexistent.json` → exit 2, `❌ --flow に指定されたファイルが見つかりません: ...`
  - `npm run validate:dogfood -- --flow` (引数欠落) → exit 2, `❌ --flow にはファイルパスを指定してください`
  - `npm run validate:dogfood -- --flow broken.json` (壊れた JSON) → exit 2, `❌ --flow の JSON parse に失敗しました: ... — Expected ...`
- Playwright: N/A (Skill ドキュメント + CLI スクリプト変更のみ、UI 影響なし)
- MCP E2E: N/A

## UI 影響 / AI smoke test

- [ ] UI 影響あり (AI が chrome-devtools MCP / Playwright で smoke test 実施済み)
- [x] UI 影響なし (auto テスト pass のみ)

理由: 変更は `.claude/skills/review-flow/SKILL.md` (Skill ドキュメント) と `designer/scripts/validate-dogfood.ts` (CLI スクリプト) のみで、designer フロントエンド / MCP server には一切影響しない。

## spec 側の不足点 / 提案

N/A (本 PR は Skill 改善であり、spec 本体への影響なし)。なお `docs/spec/dogfood-2026-04-29-phase2-validator-audit.md` §5 の子 4 briefing 案そのものを本 PR で実装したため、監査と本 PR は完全に整合している。

## レビュー担当への申し送り

- 別スキル `/review-table-flow` を新設しないという結論は、ISSUE #599 本文と監査報告書 §5 の両方で明記されている。本 PR でも踏襲しているので、レビュー時に「テーブル整合観点を独立 Skill にすべきか」の議論はスコープ外
- `--flow` 引数のパス resolution は `process.cwd()` 基準だが、`cd designer && npm run validate:dogfood -- --flow ../docs/sample-project/...` という典型呼び出しを想定したもの。SKILL.md の例も同形式で統一済み
- Step 0.5 を新設した結果、既存の Step 1-3 のステップ番号は変更していない (Step 0.5 という小数点番号で挟む形)。これは既存ドキュメント参照や `/issues` オーケストレーターからの呼び出しを破壊しないため

## 独立レビュー反映 (commit bd6b8e6)

PR 作成後の独立レビューで指摘された Nit を即対応:

- **Nit 1 (JSON parse の try/catch 化)**: `validate-dogfood.ts:183-189` で `JSON.parse` を try/catch で包み、失敗時は exit 2 + 一行メッセージを返すよう修正
- **Nit 3 (exit 1/2 の区別を SKILL に明記)**: SKILL.md:114-118 に「終了コードの扱い」セクションを追加し、exit 0 / 1 / 2 それぞれの Step 1 への進み方を明示

(独立レビューで指摘された Should-fix 1 — PR description の自己申告 file:line ズレ — は本 description 更新で全て実測値に修正済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)