### PR TITLE
fix(validator): identifierScope.walkSteps が WorkflowStep の result handler に recurse しない盲点を修正 (#606)

### DIFF
--- a/designer/src/schemas/identifierScope.test.ts
+++ b/designer/src/schemas/identifierScope.test.ts
@@ -315,3 +315,74 @@ describe("checkIdentifierScopes — サンプル (docs/sample-project/process-fl
     });
   }
 });
+describe("checkIdentifierScopes - WorkflowStep result handlers", () => {
+  it("onApproved detects undeclared identifiers", () => {
+    const issues = checkIdentifierScopes(makeGroup({
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "wf", kind: "workflow", description: "",
+          pattern: "approval-sequential", approvers: [],
+          onApproved: [
+            { id: "s1", kind: "compute", description: "", expression: "@undeclared + 1", outputBinding: "r" },
+          ],
+        }],
+      }],
+    }));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].identifier).toBe("undeclared");
+    expect(issues[0].code).toBe("UNKNOWN_IDENTIFIER");
+  });
+
+  it("onRejected can reference variables declared by prior steps", () => {
+    const issues = checkIdentifierScopes(makeGroup({
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [
+          { id: "s1", kind: "compute", description: "", expression: "'req-1'", outputBinding: "requestId" },
+          {
+            id: "wf", kind: "workflow", description: "",
+            pattern: "approval-sequential", approvers: [],
+            onRejected: [
+              { id: "s2", kind: "return", description: "", bodyExpression: "{ requestId: @requestId }" },
+            ],
+          },
+        ],
+      }],
+    }));
+    expect(issues).toHaveLength(0);
+  });
+
+  it("onApproved can reference the WorkflowStep outputBinding", () => {
+    const issues = checkIdentifierScopes(makeGroup({
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "wf", kind: "workflow", description: "",
+          pattern: "approval-sequential", approvers: [],
+          outputBinding: "workflowResult",
+          onApproved: [
+            { id: "s1", kind: "compute", description: "", expression: "@workflowResult.status", outputBinding: "status" },
+          ],
+        }],
+      }],
+    }));
+    expect(issues).toHaveLength(0);
+  });
+
+  it("onTimeout can reference builtins", () => {
+    const issues = checkIdentifierScopes(makeGroup({
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "wf", kind: "workflow", description: "",
+          pattern: "approval-sequential", approvers: [],
+          onTimeout: [
+            { id: "s1", kind: "compute", description: "", expression: "@now.toISOString() + @uuid", outputBinding: "timeoutId" },
+          ],
+        }],
+      }],
+    }));
+    expect(issues).toHaveLength(0);
+  });
+});

--- a/designer/src/schemas/identifierScope.test.ts
+++ b/designer/src/schemas/identifierScope.test.ts
@@ -315,8 +315,8 @@ describe("checkIdentifierScopes — サンプル (docs/sample-project/process-fl
     });
   }
 });
-describe("checkIdentifierScopes - WorkflowStep result handlers", () => {
-  it("onApproved detects undeclared identifiers", () => {
+describe("checkIdentifierScopes — WorkflowStep result handlers", () => {
+  it("onApproved 内で未宣言識別子を UNKNOWN_IDENTIFIER として検出する", () => {
     const issues = checkIdentifierScopes(makeGroup({
       actions: [{
         id: "a1", name: "f", trigger: "click",
@@ -334,7 +334,7 @@ describe("checkIdentifierScopes - WorkflowStep result handlers", () => {
     expect(issues[0].code).toBe("UNKNOWN_IDENTIFIER");
   });
 
-  it("onRejected can reference variables declared by prior steps", () => {
+  it("onRejected 内で先行 step の outputBinding を参照可能", () => {
     const issues = checkIdentifierScopes(makeGroup({
       actions: [{
         id: "a1", name: "f", trigger: "click",
@@ -353,7 +353,7 @@ describe("checkIdentifierScopes - WorkflowStep result handlers", () => {
     expect(issues).toHaveLength(0);
   });
 
-  it("onApproved can reference the WorkflowStep outputBinding", () => {
+  it("onApproved 内で WorkflowStep 自身の outputBinding を参照可能", () => {
     const issues = checkIdentifierScopes(makeGroup({
       actions: [{
         id: "a1", name: "f", trigger: "click",
@@ -370,7 +370,7 @@ describe("checkIdentifierScopes - WorkflowStep result handlers", () => {
     expect(issues).toHaveLength(0);
   });
 
-  it("onTimeout can reference builtins", () => {
+  it("onTimeout 内で BUILTIN (@now / @uuid) を参照可能", () => {
     const issues = checkIdentifierScopes(makeGroup({
       actions: [{
         id: "a1", name: "f", trigger: "click",
@@ -380,6 +380,87 @@ describe("checkIdentifierScopes - WorkflowStep result handlers", () => {
           onTimeout: [
             { id: "s1", kind: "compute", description: "", expression: "@now.toISOString() + @uuid", outputBinding: "timeoutId" },
           ],
+        }],
+      }],
+    }));
+    expect(issues).toHaveLength(0);
+  });
+});
+
+describe("checkIdentifierScopes — ValidationStep inlineBranch", () => {
+  it("inlineBranch.ok 内で未宣言識別子を UNKNOWN_IDENTIFIER として検出する", () => {
+    const issues = checkIdentifierScopes(makeGroup({
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "v1", kind: "validation", description: "",
+          rules: [],
+          inlineBranch: {
+            ok: [
+              { id: "s1", kind: "compute", description: "", expression: "@undeclared + 1", outputBinding: "r" },
+            ],
+            ng: [],
+          },
+        }],
+      }],
+    }));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].identifier).toBe("undeclared");
+    expect(issues[0].code).toBe("UNKNOWN_IDENTIFIER");
+  });
+
+  it("inlineBranch.ng 内で fieldErrors を参照可能 (validation step の暗黙宣言)", () => {
+    const issues = checkIdentifierScopes(makeGroup({
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "v1", kind: "validation", description: "",
+          rules: [],
+          inlineBranch: {
+            ok: [],
+            ng: [
+              { id: "s1", kind: "return", description: "", bodyExpression: "{ errors: @fieldErrors }" },
+            ],
+          },
+        }],
+      }],
+    }));
+    expect(issues).toHaveLength(0);
+  });
+
+  it("inlineBranch.ok 内で先行 step の outputBinding を参照可能", () => {
+    const issues = checkIdentifierScopes(makeGroup({
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [
+          { id: "s0", kind: "compute", description: "", expression: "'r'", outputBinding: "requestId" },
+          {
+            id: "v1", kind: "validation", description: "",
+            rules: [],
+            inlineBranch: {
+              ok: [
+                { id: "s1", kind: "return", description: "", bodyExpression: "{ requestId: @requestId }" },
+              ],
+              ng: [],
+            },
+          },
+        ],
+      }],
+    }));
+    expect(issues).toHaveLength(0);
+  });
+
+  it("inlineBranch が string (v1 旧形式) のときは walk を skip", () => {
+    const issues = checkIdentifierScopes(makeGroup({
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "v1", kind: "validation", description: "",
+          rules: [],
+          inlineBranch: {
+            ok: "次のステップへ進む",
+            ng: "400 入力値エラーを返す",
+          } as never,
         }],
       }],
     }));

--- a/designer/src/schemas/identifierScope.ts
+++ b/designer/src/schemas/identifierScope.ts
@@ -168,6 +168,15 @@ function walkSteps(
       if (step.onRejected) walkSteps(step.onRejected, `${path}.onRejected`, known, loopItems, issues);
       if (step.onTimeout) walkSteps(step.onTimeout, `${path}.onTimeout`, known, loopItems, issues);
     }
+    if (step.kind === "validation" && step.inlineBranch) {
+      // v1 旧形式は string、v3 schema は array of Step。Array.isArray で skip。
+      if (Array.isArray(step.inlineBranch.ok)) {
+        walkSteps(step.inlineBranch.ok, `${path}.inlineBranch.ok`, known, loopItems, issues);
+      }
+      if (Array.isArray(step.inlineBranch.ng)) {
+        walkSteps(step.inlineBranch.ng, `${path}.inlineBranch.ng`, known, loopItems, issues);
+      }
+    }
     if (step.kind === "externalSystem") {
       Object.entries(step.outcomes ?? {}).forEach(([k, spec]) => {
         if (spec?.sideEffects) {

--- a/designer/src/schemas/identifierScope.ts
+++ b/designer/src/schemas/identifierScope.ts
@@ -163,6 +163,11 @@ function walkSteps(
       if (step.onCommit) walkSteps(step.onCommit, `${path}.onCommit`, known, loopItems, issues);
       if (step.onRollback) walkSteps(step.onRollback, `${path}.onRollback`, known, loopItems, issues);
     }
+    if (step.kind === "workflow") {
+      if (step.onApproved) walkSteps(step.onApproved, `${path}.onApproved`, known, loopItems, issues);
+      if (step.onRejected) walkSteps(step.onRejected, `${path}.onRejected`, known, loopItems, issues);
+      if (step.onTimeout) walkSteps(step.onTimeout, `${path}.onTimeout`, known, loopItems, issues);
+    }
     if (step.kind === "externalSystem") {
       Object.entries(step.outcomes ?? {}).forEach(([k, spec]) => {
         if (spec?.sideEffects) {


### PR DESCRIPTION
## 関連

- Closes #606
- 仕様: `schemas/v3/process-flow.v3.schema.json`
  - §WorkflowStep (lines 1058-1097) — `onApproved` / `onRejected` / `onTimeout` の 3 result handler 配列が array of Step として定義
  - §ValidationInlineBranch (lines 542-563) — `ok` / `ng` が array of Step として定義 (Should-fix で追加対応)
- 関連: Phase 3 メタ #611 (子 0a として組み込み)
- 副次発見: #612 (修正前から既存していた finance flow `@error` 検出、別 ISSUE 化)

## 概要

`identifierScope.ts` の `walkSteps` が以下 2 種類の **Step 配列** を recurse しないため、配下の `@var` 参照が識別子スコープ検査をすり抜けていた:

1. WorkflowStep の result handler 配列 (`onApproved` / `onRejected` / `onTimeout`) — Phase 2 子 2 PR #603 で発覚
2. ValidationStep の `inlineBranch.ok` / `inlineBranch.ng` 配列 — 本 PR の独立レビューで同根盲点として発覚

両者を Phase 3 着手前必須の前提整備として一括修正。

## 主な変更

- **walkSteps WorkflowStep 分岐追加**: `step.kind === "workflow"` 時に `onApproved` / `onRejected` / `onTimeout` 配下を recurse
- **walkSteps ValidationInlineBranch 分岐追加**: `step.kind === "validation"` かつ `inlineBranch` 存在時に `ok` / `ng` 配下を recurse。v1 旧形式 (string) は `Array.isArray` ガードで skip
- **テストケース追加 8 件**: WorkflowStep 4 ケース (検出 / 先行 step 参照 / 自身の outputBinding / BUILTIN) + ValidationInlineBranch 4 ケース (検出 / fieldErrors 参照 / 先行 step 参照 / v1 string skip)
- **既存テストの揺れ修正**: describe ハイフンを em dash に統一、it 説明を日本語化 (独立レビュー Nit 1, 2 対応)

## 仕様逐条突合 (自己申告)

ISSUE #606 完了基準:

- [x] `identifierScope.ts` `walkSteps` に WorkflowStep 分岐を追加 → designer/src/schemas/identifierScope.ts:166-170 ✓
- [x] `identifierScope.ts` `walkSteps` に ValidationInlineBranch 分岐を追加 (Should-fix 対応) → designer/src/schemas/identifierScope.ts:171-179 ✓
- [x] `identifierScope.test.ts` に WorkflowStep 配下の参照検査テストケースを追加 → designer/src/schemas/identifierScope.test.ts:318-388 ✓ (4 ケース)
- [x] `identifierScope.test.ts` に ValidationInlineBranch 配下の参照検査テストケースを追加 → designer/src/schemas/identifierScope.test.ts:390-469 ✓ (4 ケース)
- [x] 既存 v3 サンプル全件で validate:dogfood pass → v1 サンプル `npm run validate:dogfood` 4/4 pass ✓ / v3 サンプルは validate:dogfood が v3 未対応 (#607 範囲) のため ad-hoc スクリプトで identifierScope 単体を 14 v3 flow 全件に適用、**両修正による新規検出 0 件**を確認 ✓ / 副次的に logistics の偽陽性 2 件が解消、finance の `@error` 既存検出 3 件は #612 として別 ISSUE 化
- [x] vitest src/schemas/ 全件 pass → 12 files / 402 tests pass ✓ (新規 8 件)

スキーマガバナンス (AGENTS.md):

- [x] `schemas/v3/*.json` 変更なし ✓
- [x] WorkflowStep の handler は v3 schema 定義 (`onApproved` / `onRejected` / `onTimeout` の 3 つ) のみを対象 ✓
- [x] ValidationInlineBranch の Step 配列は v3 schema 定義 (`ok` / `ng`) のみを対象 ✓
- [x] schema にない handler を勝手に追加しない原則を遵守 ✓

## レビューで特に見てほしい箇所

1. **ValidationInlineBranch の Array.isArray ガード**: v3 schema は `ok` / `ng` を array of Step と定義するが、v1 旧形式サンプル (`docs/sample-project/process-flows/gggggggg-000{1,2,3,4}-*.json`) では string で記述されている。修正で `Array.isArray` ガードを入れて v1 string を skip する設計とした。これは v1 サンプルが将来 v3 化されるまでの一時的処置で、v3 化されれば自動的に walk 対象になる。
2. **スコープ伝播**: 既存 `transactionScope.onCommit` / `onRollback` / `branch` / `loop` と同じ permissive 伝播 (known は親と共有、loopItems は親から引き継ぎ)。WorkflowStep / ValidationInlineBranch ともに新規 loopItem は追加しない。
3. **fieldErrors の伝播**: ValidationInlineBranch を walk する時点で walkSteps の `step.kind === "validation"` 処理 (line 132-136) により `known.add("fieldErrors")` が既に実行されているため、`ok` / `ng` 配下から `@fieldErrors` 参照可能 (テスト 6 番目で確認)。
4. **副次的影響 (要レビュー)**: WorkflowStep recurse 修正前は logistics flow の `@createdShipment` 2 件が UNKNOWN_IDENTIFIER として誤検出されていた (handler 内 declare の outputBinding が known に追加されていなかったため)。修正後は正しく解決される (修正による偽陽性解消)。
5. **finance flow `@error` 3 件は本 PR スコープ外**: 修正前後で同一の既存検出。`transactionScope.onRollback` 内の暗黙変数 `@error` の扱いは設計判断含むため #612 として別 ISSUE 起票済。

## テスト

- Vitest: 12 files / 402 tests pass (新規 8 件 — WorkflowStep 4 + ValidationInlineBranch 4)
- Playwright: N/A (UI 影響なし、validator ロジックのみ)
- MCP E2E: N/A

## UI 影響 / AI smoke test

- [ ] UI 影響あり (AI が chrome-devtools MCP / Playwright で smoke test 実施済み)
- [x] UI 影響なし (auto テスト pass のみ)

## spec 側の不足点 / 提案

- ISSUE #606 本文に `onAcknowledged` / `onCancelled` も列挙されていたが、v3 schema には未定義。仕様書 (`docs/spec/process-flow-execution-semantics.md` 等) でも WorkflowStep の handler 一覧が `onApproved` / `onRejected` / `onTimeout` の 3 つに統一されているか要確認 (本 PR スコープ外、Phase 3 子 1-2 で再点検候補)。
- finance flow の `@error` 暗黙変数の扱い: 仕様書に明記が無く #612 で別途設計者承認動線を立ち上げ。
- v1 サンプル (gggggggg-000{1,2,3,4}) の `inlineBranch.ok` / `ng` は string 記述で v3 schema 違反。v3 化タイミングで全て array of Step に書き換える必要がある (本 PR スコープ外、別途 v3 移行の課題)。

## レビュー担当への申し送り

- 本 PR は **Phase 3 メタ #611 子 0a** に該当する前提整備 PR。Phase 3 着手前に #607 (子 0b) と本 PR の両方をマージする必要がある。
- 修正は既存 `transactionScope` 分岐の直後に対称的に挿入する形で、**最小差分・既存パターン踏襲** を意識。スコープ伝播ロジックの再設計は行っていない。
- 独立レビュー (1 回目、commit 31c49bb) で Should-fix 1 件 (ValidationInlineBranch.ok/ng の同根盲点) と Nit 2 件 (em dash / 日本語化) が指摘されたため、commit d22458f で本 PR に統合対応。同根盲点を別 PR に分割すると Phase 3 着手前に再度同種修正が必要となるため、PR granularity 観点から本 PR 内で完結。
- `@error` の検出 (#612) は本 PR と独立。Phase 3 並走 ISSUE。
- 半角カナスキャン: identifierScope.ts / identifierScope.test.ts ともに検出なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
