### PR TITLE
feat(schema): 画面項目イベント + ProcessFlow.primaryInvoker 拡張 (#624)

### DIFF
--- a/designer/src/schemas/screen-item-events.schema.test.ts
+++ b/designer/src/schemas/screen-item-events.schema.test.ts
@@ -116,6 +116,42 @@ describe("ScreenItem.events[] (#624)", () => {
     };
     expect(validateScreenItem(item)).toBe(false);
   });
+
+  it("argumentMapping のキーが Identifier 形式 (lowerCamelCase) でないと fail", () => {
+    const item = {
+      id: "submitBtn",
+      label: "送信",
+      type: "string",
+      events: [
+        {
+          id: "click",
+          handlerFlowId: FLOW_UUID,
+          argumentMapping: {
+            "Invalid-Key": "@self.value",
+          },
+        },
+      ],
+    };
+    expect(validateScreenItem(item)).toBe(false);
+  });
+
+  it("argumentMapping の値が string (ExpressionString) でないと fail", () => {
+    const item = {
+      id: "submitBtn",
+      label: "送信",
+      type: "string",
+      events: [
+        {
+          id: "click",
+          handlerFlowId: FLOW_UUID,
+          argumentMapping: {
+            userId: 12345,
+          },
+        },
+      ],
+    };
+    expect(validateScreenItem(item)).toBe(false);
+  });
 });
 
 describe("ProcessFlow.meta.primaryInvoker (#624)", () => {
@@ -176,6 +212,22 @@ describe("ProcessFlow.meta.primaryInvoker (#624)", () => {
           itemId: "submitBtn",
           eventId: "click",
           unknownField: "rejected",
+        },
+      }),
+      actions: [],
+    };
+    expect(validateProcessFlow(flow)).toBe(false);
+  });
+
+  it("primaryInvoker.itemId が Identifier 形式 (lowerCamelCase) でないと fail", () => {
+    const flow = {
+      meta: makeMeta({
+        kind: "screen",
+        primaryInvoker: {
+          kind: "screen-item-event",
+          screenId: SCREEN_UUID,
+          itemId: "Submit-Btn",
+          eventId: "click",
         },
       }),
       actions: [],

--- a/designer/src/schemas/screen-item-events.schema.test.ts
+++ b/designer/src/schemas/screen-item-events.schema.test.ts
@@ -1,0 +1,185 @@
+/**
+ * ScreenItem.events[] + ProcessFlow.meta.primaryInvoker AJV 検証 (#624)
+ *
+ * 画面項目イベント (backward reference) と処理フロー primaryInvoker 任意宣言の
+ * schema 拡張に対する正常系・異常系・後方互換テスト。
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import Ajv2020, { type ValidateFunction } from "ajv/dist/2020";
+import addFormats from "ajv-formats";
+import { readFileSync } from "node:fs";
+import { resolve, join } from "node:path";
+
+const repoRoot = resolve(__dirname, "../../../");
+const v3Dir = resolve(repoRoot, "schemas/v3");
+
+function loadJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+let ajv: Ajv2020;
+let validateScreenItem: ValidateFunction;
+let validateProcessFlow: ValidateFunction;
+
+beforeAll(() => {
+  ajv = new Ajv2020({ allErrors: true, strict: false, discriminator: true });
+  addFormats(ajv);
+  ajv.addSchema(loadJson(join(v3Dir, "common.v3.schema.json")) as object);
+  validateScreenItem = ajv.compile(loadJson(join(v3Dir, "screen-item.v3.schema.json")) as object);
+  validateProcessFlow = ajv.compile(loadJson(join(v3Dir, "process-flow.v3.schema.json")) as object);
+});
+
+// RFC 4122 v4 UUID 形式 (3 ブロック目 "4xxx"、4 ブロック目 "[89ab]xxx") を満たすテスト用 UUID
+const FLOW_UUID = "11111111-1111-4111-8111-111111111111";
+const SCREEN_UUID = "22222222-2222-4222-8222-222222222222";
+
+function makeMeta(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: FLOW_UUID,
+    name: "test",
+    version: "1.0.0",
+    maturity: "draft",
+    createdAt: "2026-04-30T00:00:00.000Z",
+    updatedAt: "2026-04-30T00:00:00.000Z",
+    kind: "common",
+    ...overrides,
+  };
+}
+
+describe("ScreenItem.events[] (#624)", () => {
+  it("events 未指定の最小 ScreenItem が pass する (後方互換)", () => {
+    const item = { id: "submitBtn", label: "送信", type: "string" };
+    expect(validateScreenItem(item)).toBe(true);
+  });
+
+  it("handlerFlowId + argumentMapping を持つ正常系", () => {
+    const item = {
+      id: "submitBtn",
+      label: "送信",
+      type: "string",
+      events: [
+        {
+          id: "click",
+          label: "クリック時",
+          handlerFlowId: FLOW_UUID,
+          argumentMapping: {
+            userId: "@session.userId",
+            amount: "@self.amountInput.value",
+          },
+        },
+      ],
+    };
+    expect(validateScreenItem(item)).toBe(true);
+  });
+
+  it("複数の events (1 画面項目で複数イベント) が pass する", () => {
+    const item = {
+      id: "amountInput",
+      label: "金額",
+      type: "number",
+      events: [
+        { id: "change", handlerFlowId: FLOW_UUID },
+        { id: "blur", handlerFlowId: FLOW_UUID },
+      ],
+    };
+    expect(validateScreenItem(item)).toBe(true);
+  });
+
+  it("events.id を欠落させると fail", () => {
+    const item = {
+      id: "submitBtn",
+      label: "送信",
+      type: "string",
+      events: [{ handlerFlowId: FLOW_UUID }],
+    };
+    expect(validateScreenItem(item)).toBe(false);
+  });
+
+  it("events.handlerFlowId を欠落させると fail", () => {
+    const item = {
+      id: "submitBtn",
+      label: "送信",
+      type: "string",
+      events: [{ id: "click" }],
+    };
+    expect(validateScreenItem(item)).toBe(false);
+  });
+
+  it("events に未知のプロパティを含むと fail (additionalProperties: false)", () => {
+    const item = {
+      id: "submitBtn",
+      label: "送信",
+      type: "string",
+      events: [
+        { id: "click", handlerFlowId: FLOW_UUID, unknownField: "rejected" },
+      ],
+    };
+    expect(validateScreenItem(item)).toBe(false);
+  });
+});
+
+describe("ProcessFlow.meta.primaryInvoker (#624)", () => {
+  it("primaryInvoker 未指定の最小 ProcessFlow が pass する (後方互換)", () => {
+    const flow = { meta: makeMeta(), actions: [] };
+    expect(validateProcessFlow(flow)).toBe(true);
+  });
+
+  it("primaryInvoker (screen-item-event) を持つ正常系", () => {
+    const flow = {
+      meta: makeMeta({
+        kind: "screen",
+        primaryInvoker: {
+          kind: "screen-item-event",
+          screenId: SCREEN_UUID,
+          itemId: "submitBtn",
+          eventId: "click",
+        },
+      }),
+      actions: [],
+    };
+    expect(validateProcessFlow(flow)).toBe(true);
+  });
+
+  it("primaryInvoker.screenId を欠落させると fail", () => {
+    const flow = {
+      meta: makeMeta({
+        kind: "screen",
+        primaryInvoker: {
+          kind: "screen-item-event",
+          itemId: "submitBtn",
+          eventId: "click",
+        },
+      }),
+      actions: [],
+    };
+    expect(validateProcessFlow(flow)).toBe(false);
+  });
+
+  it("primaryInvoker.kind が未対応の値だと fail", () => {
+    const flow = {
+      meta: makeMeta({
+        kind: "screen",
+        primaryInvoker: { kind: "unknown-invoker" },
+      }),
+      actions: [],
+    };
+    expect(validateProcessFlow(flow)).toBe(false);
+  });
+
+  it("primaryInvoker に未知のトップレベルプロパティを含むと fail (additionalProperties: false)", () => {
+    const flow = {
+      meta: makeMeta({
+        kind: "screen",
+        primaryInvoker: {
+          kind: "screen-item-event",
+          screenId: SCREEN_UUID,
+          itemId: "submitBtn",
+          eventId: "click",
+          unknownField: "rejected",
+        },
+      }),
+      actions: [],
+    };
+    expect(validateProcessFlow(flow)).toBe(false);
+  });
+});

--- a/schemas/v3/process-flow.v3.schema.json
+++ b/schemas/v3/process-flow.v3.schema.json
@@ -48,9 +48,27 @@
         "screenId": { "$ref": "common.v3.schema.json#/$defs/Uuid", "description": "kind='screen' の場合に紐付く Screen の Uuid。" },
         "apiVersion": { "type": "string", "description": "ProcessFlow が公開する API のバージョン (例: 'v1', '2026-04-25')。" },
         "mode": { "$ref": "common.v3.schema.json#/$defs/Mode" },
-        "sla": { "$ref": "#/$defs/Sla" }
+        "sla": { "$ref": "#/$defs/Sla" },
+        "primaryInvoker": { "$ref": "#/$defs/PrimaryInvoker" }
       },
       "unevaluatedProperties": false
+    },
+
+    "PrimaryInvoker": {
+      "description": "本処理フローの主たる呼び出し元 (任意、#624)。designer 編集時の補完精度向上のためのメタ情報で、実行時には参照されない。副次的呼び出し (他画面 / batch / 他フロー) は宣言不要 — 画面項目側 events[].handlerFlowId のみで成立する。",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["kind", "screenId", "itemId", "eventId"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "screen-item-event", "description": "画面項目イベントから呼ばれる処理フロー。" },
+            "screenId": { "$ref": "common.v3.schema.json#/$defs/Uuid", "description": "主たる呼び出し元の画面 Uuid。" },
+            "itemId": { "$ref": "common.v3.schema.json#/$defs/Identifier", "description": "主たる呼び出し元の画面項目 id (Screen.items[].id)。" },
+            "eventId": { "type": "string", "description": "主たる呼び出し元のイベント id (ScreenItem.events[].id)。" }
+          }
+        }
+      ]
     },
 
     "ProcessFlowKind": {

--- a/schemas/v3/process-flow.v3.schema.json
+++ b/schemas/v3/process-flow.v3.schema.json
@@ -55,7 +55,7 @@
     },
 
     "PrimaryInvoker": {
-      "description": "本処理フローの主たる呼び出し元 (任意、#624)。designer 編集時の補完精度向上のためのメタ情報で、実行時には参照されない。副次的呼び出し (他画面 / batch / 他フロー) は宣言不要 — 画面項目側 events[].handlerFlowId のみで成立する。",
+      "description": "本処理フローの主たる呼び出し元 (任意、#624)。designer 編集時の補完精度向上のためのメタ情報で、実行時には参照されない。副次的呼び出し (他画面 / batch / 他フロー) は宣言不要 — 画面項目側 events[].handlerFlowId のみで成立する。現状は kind='screen-item-event' のみ対応 (1 要素 oneOf)。将来 'batch-trigger' / 'external-trigger' 等の variant を追加する際は AJV の discriminator キーワード採用を検討する。",
       "oneOf": [
         {
           "type": "object",

--- a/schemas/v3/screen-item.v3.schema.json
+++ b/schemas/v3/screen-item.v3.schema.json
@@ -65,7 +65,38 @@
           "$ref": "common.v3.schema.json#/$defs/ExpressionString",
           "description": "派生計算式 (= で始まる)。output 項目用。"
         },
+        "events": {
+          "type": "array",
+          "description": "本画面項目で発火するイベントと処理フロー連携 (#624)。backward reference により 1 処理フロー × N イベント (再利用) を自然に表現する。",
+          "items": { "$ref": "#/$defs/ScreenItemEvent" }
+        },
         "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      }
+    },
+
+    "ScreenItemEvent": {
+      "description": "画面項目イベント (#624)。発火時に handlerFlowId 指定の処理フローを呼び出し、argumentMapping で画面コンテキストを処理フロー inputs[] に変換する。",
+      "type": "object",
+      "required": ["id", "handlerFlowId"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "イベント ID (画面項目内ユニーク、例: 'click' / 'submit' / 'change' / 'blur')。"
+        },
+        "label": {
+          "$ref": "common.v3.schema.json#/$defs/DisplayName",
+          "description": "イベントの表示名 (designer UI 用)。"
+        },
+        "handlerFlowId": {
+          "$ref": "common.v3.schema.json#/$defs/Uuid",
+          "description": "発火時に実行する処理フローの ID (backward reference)。"
+        },
+        "argumentMapping": {
+          "type": "object",
+          "description": "画面コンテキストを処理フロー引数 (inputs[]) に変換するマッピング。キーは処理フロー側 inputs[].name、値は画面コンテキスト式 (@screen.* / @self.* / @session.* 等)。",
+          "additionalProperties": { "$ref": "common.v3.schema.json#/$defs/ExpressionString" }
+        }
       }
     },
 

--- a/schemas/v3/screen-item.v3.schema.json
+++ b/schemas/v3/screen-item.v3.schema.json
@@ -82,7 +82,7 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "イベント ID (画面項目内ユニーク、例: 'click' / 'submit' / 'change' / 'blur')。"
+          "description": "イベント ID (例: 'click' / 'submit' / 'change' / 'blur')。画面項目内ユニーク制約は validator 側 (#619) で担保 (JSON Schema 標準では配列内の特定プロパティ一意制約を表現できないため)。"
         },
         "label": {
           "$ref": "common.v3.schema.json#/$defs/DisplayName",
@@ -94,7 +94,8 @@
         },
         "argumentMapping": {
           "type": "object",
-          "description": "画面コンテキストを処理フロー引数 (inputs[]) に変換するマッピング。キーは処理フロー側 inputs[].name、値は画面コンテキスト式 (@screen.* / @self.* / @session.* 等)。",
+          "description": "画面コンテキストを処理フロー引数 (inputs[]) に変換するマッピング。キーは処理フロー側 inputs[].name (Identifier 形式: lowerCamelCase)、値は画面コンテキスト式 (@screen.* / @self.* / @session.* 等)。",
+          "propertyNames": { "$ref": "common.v3.schema.json#/$defs/Identifier" },
           "additionalProperties": { "$ref": "common.v3.schema.json#/$defs/ExpressionString" }
         }
       }


### PR DESCRIPTION
## 関連

- Closes #624
- 仕様: 設計判断履歴 #611 (Phase 3 メタ) コメント + #624 ISSUE 本文
- 関連: #619 Phase 3 子 1 (本 PR が前提)、#622 Phase 3 子 4 (ドッグフード)

## 概要

Phase 3 メタ #611 子 1 #619 (画面項目連携 validator) の前提となる schema 拡張。2026-04-30 ユーザー (設計者) との設計議論を経て確定した方針 (backward reference + 引数明示 + primaryInvoker 任意宣言) を schema レベルで実装。

## 設計判断 (#611 / #624 で議論済、ユーザー合意済)

### Backward reference + 引数明示

- 画面項目側 `events[].handlerFlowId` で処理フローを参照 (1 処理フロー × N イベントの再利用が自然)
- 画面項目側 `events[].argumentMapping` で画面コンテキストを処理フロー inputs[] にマッピング (純粋関数性維持)
- 処理フロー側は call sites を知らない (再利用可能なふるまいライブラリ)

### primaryInvoker 任意宣言

- 処理フロー側 `meta.primaryInvoker` で主呼び出し元を任意宣言
- designer 編集時の補完精度向上、副次呼び出し (他画面 / batch / 他フロー) は宣言不要
- 実行時には参照されないメタ情報

### `this` 的暗黙参照は不採用

- 静的検査困難 / batch 呼び出し非対応 / 純粋関数性失う
- 処理フロー内から画面値を直接参照するパターン (`@screen.<itemId>`) は導入しない

## 主な変更

### 1. `schemas/v3/screen-item.v3.schema.json`

- ScreenItem の properties に `events` 配列追加 (description / valueFrom / formula と同セクション)
- `$defs/ScreenItemEvent` 新設:
  - `id` (string、画面項目内ユニーク、required)
  - `label` (DisplayName、optional)
  - `handlerFlowId` (Uuid、required)
  - `argumentMapping` (object、key=処理フロー inputs[].name、value=式文字列、optional)
  - additionalProperties: false

### 2. `schemas/v3/process-flow.v3.schema.json`

- Meta の properties に `primaryInvoker` 追加 (任意フィールド)
- `$defs/PrimaryInvoker` 新設:
  - `kind: "screen-item-event"` (oneOf 構造、将来の拡張余地)
  - `screenId` (Uuid、required)
  - `itemId` (Identifier、required)
  - `eventId` (string、required)
  - additionalProperties: false

### 3. `designer/src/schemas/screen-item-events.schema.test.ts`

新規 AJV テストファイル、11 ケース:

- ScreenItem.events[] 6 ケース:
  - events 未指定 (後方互換) ✓
  - handlerFlowId + argumentMapping (正常系) ✓
  - 複数 events (1 画面項目 × 複数イベント) ✓
  - id 欠落 → fail
  - handlerFlowId 欠落 → fail
  - 未知プロパティ → fail (additionalProperties: false)
- ProcessFlow.meta.primaryInvoker 5 ケース:
  - primaryInvoker 未指定 (後方互換) ✓
  - screen-item-event 正常系 ✓
  - screenId 欠落 → fail
  - kind が未対応値 → fail
  - 未知プロパティ → fail

## 仕様逐条突合 (自己申告)

ISSUE #624 完了基準:

- [x] `screen-item.v3.schema.json` に `events[]` 追加 → schemas/v3/screen-item.v3.schema.json:68-72 ✓ + ScreenItemEvent $defs (line 77-102) ✓
- [x] `process-flow.v3.schema.json` の `meta` に `primaryInvoker` 任意フィールド追加 → schemas/v3/process-flow.v3.schema.json:52 ✓ + PrimaryInvoker $defs (line 57-72) ✓
- [x] AJV テスト追加 (events / primaryInvoker の正常系 + 異常系) → designer/src/schemas/screen-item-events.schema.test.ts (11 ケース) ✓
- [x] v3-samples.test.ts で既存サンプルが新 schema で AJV pass を維持 → vitest 全 25 files / 807 tests pass、regression なし ✓
- [x] 既存の v3 サンプルへの影響なし → events / primaryInvoker は optional 追加のみ、後方互換 ✓

スキーマガバナンス (AGENTS.md):

- [x] **本 PR は schemas/v3/*.json を変更している** が、設計者承認済 (#624 で詳細仕様を ISSUE 化、ユーザーから 2026-04-30 セッションで案 A 承認、実装は本 PR で実施) ✓
- [x] memory `feedback_schema_governance_strict.md` の「ISSUE 起票して作業停止 → 設計者承認待ち → 実装」のフロー遵守 ✓

## レビューで特に見てほしい箇所

1. **後方互換性**: events / primaryInvoker は optional 追加で、既存の v3 サンプル (7 プロジェクト / 14 process-flows / 多数 screen-items) すべてが新 schema 下でも AJV pass を維持していることを vitest で確認。
2. **設計仕様との整合**: schema 構造が #624 ISSUE 本文の仕様 (フィールド名 / required / additionalProperties / oneOf) と完全一致しているか。
3. **PrimaryInvoker の oneOf 構造**: 現状は `kind: "screen-item-event"` の 1 種のみだが、将来の拡張 (例: `batch-trigger` / `external-system-trigger`) に備えて oneOf 構造を採用。これが過剰設計でないか / 妥当か。
4. **argumentMapping の値型**: 画面コンテキスト式 (`@screen.* / @self.* / @session.*`) を表現するため `ExpressionString` を再利用。これで補完性 / 静的検査と互換するか。
5. **半角カナ混入**: 該当ファイル全件 grep で 0 件。

## テスト

- Vitest: 25 files / 807 tests pass (新規 11 件 — events / primaryInvoker 正常系 + 異常系)
- Playwright: N/A (UI 影響なし、schema 拡張のみ)
- AI smoke test: N/A (UI 影響なし)

## UI 影響 / AI smoke test

- [ ] UI 影響あり
- [x] UI 影響なし (schema 拡張のみ、実画面の変更なし)

## spec 側の不足点 / 提案

- spec 側 (`docs/spec/`) には別途 ISSUE で `events[]` と `primaryInvoker` の使い方ドキュメントを追加する余地あり。本 PR は schema レベルの拡張に絞り、ドキュメントは Phase 3 子 4 #622 ドッグフード作業時に実例と一緒に追加する想定 (本 PR スコープ外)。

## レビュー担当への申し送り

- 本 PR は **schema governance 設計者承認案件**。AI が schemas/v3/ を変更しているが、ユーザー (設計者) からの明示承認 (2026-04-30 設計議論) を経て実装している。レビューでは設計判断との整合のみ確認推奨。
- **#619 子 1 (画面項目連携 validator) の着手は本 PR マージ後**。PR マージ完了で Phase 3 メタ #611 の着手順序が次フェーズへ進む。
- 半角カナスキャン: 該当ファイル全件で `[ｦ-ﾟ]` 検出 0 件。
- PR 本文の自己申告 file:line は実測値で記載済 (実装直後の実 line 番号)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
