### PR TITLE
feat(validator): 画面項目イベント ↔ 処理フロー連携 validator 新設 (#619)

### DIFF
--- a/designer/scripts/validate-dogfood.ts
+++ b/designer/scripts/validate-dogfood.ts
@@ -25,7 +25,9 @@ import { checkSqlColumns, type TableDefinition } from "../src/schemas/sqlColumnV
 import { checkConventionReferences, type ConventionsCatalog } from "../src/schemas/conventionsValidator.js";
 import { checkReferentialIntegrity } from "../src/schemas/referentialIntegrity.js";
 import { checkIdentifierScopes } from "../src/schemas/identifierScope.js";
+import { checkScreenItemFlowConsistency } from "../src/schemas/screenItemFlowValidator.js";
 import { loadExtensionsFromBundle, type LoadedExtensions, type ExtensionsBundle } from "../src/schemas/loadExtensions.js";
+import type { Screen } from "../src/types/v3/screen.js";
 
 // ─── パス解決 ──────────────────────────────────────────────────────────────
 
@@ -43,6 +45,7 @@ interface ProjectResources {
   projectDir: string;         // プロジェクトディレクトリ絶対パス
   tables: TableDefinition[];
   conventions: ConventionsCatalog | null;
+  screens: Screen[];          // 画面定義 (#619、画面項目イベント連携検証用)
   flowsDir: string;           // process-flows/ の絶対パス
 }
 
@@ -56,14 +59,26 @@ interface FlowValidationResult {
   }>;
 }
 
+interface ProjectValidationResult {
+  projectId: string;
+  displayName: string;
+  issues: Array<{
+    validator: string;
+    severity: "error" | "warning";
+    message: string;
+  }>;
+}
+
 interface ValidationSummary {
   totalFlows: number;
   passedFlows: number;
   failedFlows: number;
   results: FlowValidationResult[];
+  projectResults: ProjectValidationResult[];
   projectCount: number;
   totalTableCount: number;
   totalConventionsCount: number;
+  totalScreenCount: number;
   extensionFileCount: number;
 }
 
@@ -88,6 +103,16 @@ function loadConventionsFromFile(filePath: string): ConventionsCatalog | null {
   }
 }
 
+function loadScreensFromDir(dir: string): Screen[] {
+  if (!existsSync(dir)) return [];
+  try {
+    const files = readdirSync(dir).filter((f) => f.endsWith(".json"));
+    return files.map((f) => JSON.parse(readFileSync(join(dir, f), "utf-8")) as Screen);
+  } catch {
+    return [];
+  }
+}
+
 /**
  * v1 + v3 のサンプルプロジェクトを発見してリソース情報を返す。
  *
@@ -108,6 +133,7 @@ function discoverProjects(): ProjectResources[] {
       projectDir: samplesV1Dir,
       tables: loadTablesFromDir(join(samplesV1Dir, "tables")),
       conventions: loadConventionsFromFile(join(samplesV1Dir, "conventions/conventions-catalog.json")),
+      screens: loadScreensFromDir(join(samplesV1Dir, "screens")),
       flowsDir: join(samplesV1Dir, "process-flows"),
     });
   }
@@ -124,6 +150,7 @@ function discoverProjects(): ProjectResources[] {
         projectDir,
         tables: loadTablesFromDir(join(projectDir, "tables")),
         conventions: loadConventionsFromFile(join(projectDir, "conventions-catalog.v3.json")),
+        screens: loadScreensFromDir(join(projectDir, "screens")),
         flowsDir: join(projectDir, "process-flows"),
       });
     }
@@ -316,8 +343,10 @@ export async function runValidation(flowPath?: string): Promise<ValidationSummar
 
   const totalTableCount = projects.reduce((acc, p) => acc + p.tables.length, 0);
   const totalConventionsCount = projects.filter((p) => p.conventions !== null).length;
+  const totalScreenCount = projects.reduce((acc, p) => acc + p.screens.length, 0);
 
   const results: FlowValidationResult[] = [];
+  const projectResults: ProjectValidationResult[] = [];
 
   function validateOne(filePath: string, displayName: string, flow: ProcessFlow, project: ProjectResources): FlowValidationResult {
     const issues: FlowValidationResult["issues"] = [];
@@ -362,6 +391,22 @@ export async function runValidation(flowPath?: string): Promise<ValidationSummar
       for (const { filePath, displayName, flow } of flows) {
         results.push(validateOne(filePath, displayName, flow, project));
       }
+      // 5. 画面項目イベント ↔ 処理フロー連携検証 (per-project、#619)
+      const screenItemFlowIssues = checkScreenItemFlowConsistency(
+        flows.map((f) => f.flow),
+        project.screens,
+      );
+      if (screenItemFlowIssues.length > 0) {
+        projectResults.push({
+          projectId: project.projectId,
+          displayName: project.displayName,
+          issues: screenItemFlowIssues.map((i) => ({
+            validator: "screenItemFlowValidator",
+            severity: i.severity,
+            message: `[${i.code}] ${i.path}: ${i.message}`,
+          })),
+        });
+      }
     }
   }
 
@@ -373,9 +418,11 @@ export async function runValidation(flowPath?: string): Promise<ValidationSummar
     passedFlows,
     failedFlows,
     results,
+    projectResults,
     projectCount: projects.length,
     totalTableCount,
     totalConventionsCount,
+    totalScreenCount,
     extensionFileCount,
   };
 }
@@ -387,7 +434,7 @@ function printSummary(summary: ValidationSummary, options: { singleFlow: boolean
   console.log();
   console.log(
     `📂 プロジェクト数: ${summary.projectCount} / ${summary.totalFlows} flows / ${summary.totalTableCount} tables` +
-    ` / ${summary.totalConventionsCount} conventions catalogs / ${summary.extensionFileCount} extension files`,
+    ` / ${summary.totalScreenCount} screens / ${summary.totalConventionsCount} conventions catalogs / ${summary.extensionFileCount} extension files`,
   );
   console.log();
 
@@ -410,10 +457,28 @@ function printSummary(summary: ValidationSummary, options: { singleFlow: boolean
     }
   }
 
+  // project-level 検証結果 (#619 画面項目連携 validator)
+  if (summary.projectResults.length > 0) {
+    console.log();
+    console.log("📋 プロジェクトレベル検証 (画面項目イベント ↔ 処理フロー連携):");
+    for (const pr of summary.projectResults) {
+      console.log(`  ⚠️  ${pr.displayName}`);
+      for (const issue of pr.issues) {
+        const tag = issue.severity === "warning" ? "WARN" : "ERROR";
+        console.log(`     [${tag}] ${issue.message}`);
+      }
+    }
+  }
+
   console.log();
   console.log("━".repeat(57));
 
-  if (summary.failedFlows === 0) {
+  const projectLevelErrorCount = summary.projectResults.reduce(
+    (acc, pr) => acc + pr.issues.filter((i) => i.severity === "error").length,
+    0,
+  );
+
+  if (summary.failedFlows === 0 && projectLevelErrorCount === 0) {
     console.log(`Summary: ${summary.passedFlows} / ${summary.totalFlows} flows passed.`);
     console.log("━".repeat(57));
     console.log();
@@ -463,7 +528,11 @@ function parseArgs(argv: string[]): { flowPath?: string } {
     ({ flowPath } = parseArgs(process.argv.slice(2)));
     const summary = await runValidation(flowPath);
     printSummary(summary, { singleFlow: Boolean(flowPath) });
-    process.exit(summary.failedFlows > 0 ? 1 : 0);
+    const projectErrorCount = summary.projectResults.reduce(
+      (acc, pr) => acc + pr.issues.filter((i) => i.severity === "error").length,
+      0,
+    );
+    process.exit(summary.failedFlows > 0 || projectErrorCount > 0 ? 1 : 0);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error(`❌ ${message}`);

--- a/designer/src/schemas/screenItemFlowValidator.test.ts
+++ b/designer/src/schemas/screenItemFlowValidator.test.ts
@@ -1,0 +1,321 @@
+/**
+ * 画面項目イベント ↔ 処理フロー連携 validator テスト (#619)
+ */
+import { describe, it, expect } from "vitest";
+import { checkScreenItemFlowConsistency } from "./screenItemFlowValidator";
+
+const FLOW_ID_A = "11111111-1111-4111-8111-111111111111";
+const FLOW_ID_B = "11111111-1111-4111-8111-222222222222";
+const SCREEN_ID = "22222222-2222-4222-8222-222222222222";
+
+function makeFlow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    meta: {
+      id: FLOW_ID_A,
+      name: "test-flow",
+      kind: "screen",
+      createdAt: "2026-04-30T00:00:00.000Z",
+      updatedAt: "2026-04-30T00:00:00.000Z",
+      ...((overrides.meta as Record<string, unknown>) ?? {}),
+    },
+    actions: [
+      {
+        id: "act1",
+        name: "submit",
+        trigger: "click",
+        steps: [],
+        inputs: [{ name: "userId", type: "string", required: true }],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makeScreen(items: unknown[]): Record<string, unknown> {
+  return {
+    id: SCREEN_ID,
+    name: "test-screen",
+    kind: "form",
+    path: "/test",
+    createdAt: "2026-04-30T00:00:00.000Z",
+    updatedAt: "2026-04-30T00:00:00.000Z",
+    items,
+  };
+}
+
+describe("checkScreenItemFlowConsistency — UNKNOWN_HANDLER_FLOW", () => {
+  it("存在しない handlerFlowId を検出する", () => {
+    const flow = makeFlow();
+    const screen = makeScreen([
+      {
+        id: "submitBtn",
+        label: "送信",
+        type: "string",
+        events: [
+          { id: "click", handlerFlowId: "00000000-0000-4000-8000-000000000000" },
+        ],
+      },
+    ]);
+    const issues = checkScreenItemFlowConsistency([flow] as never, [screen] as never);
+    const errs = issues.filter((i) => i.code === "UNKNOWN_HANDLER_FLOW");
+    expect(errs).toHaveLength(1);
+  });
+
+  it("正しい handlerFlowId は検出しない", () => {
+    const flow = makeFlow();
+    const screen = makeScreen([
+      {
+        id: "submitBtn",
+        label: "送信",
+        type: "string",
+        events: [
+          {
+            id: "click",
+            handlerFlowId: FLOW_ID_A,
+            argumentMapping: { userId: "@session.userId" },
+          },
+        ],
+      },
+    ]);
+    const issues = checkScreenItemFlowConsistency([flow] as never, [screen] as never);
+    expect(issues).toHaveLength(0);
+  });
+});
+
+describe("checkScreenItemFlowConsistency — MISSING_REQUIRED_ARGUMENT", () => {
+  it("required input が argumentMapping に無いと検出する", () => {
+    const flow = makeFlow();
+    const screen = makeScreen([
+      {
+        id: "submitBtn",
+        label: "送信",
+        type: "string",
+        events: [
+          { id: "click", handlerFlowId: FLOW_ID_A, argumentMapping: {} },
+        ],
+      },
+    ]);
+    const issues = checkScreenItemFlowConsistency([flow] as never, [screen] as never);
+    const errs = issues.filter((i) => i.code === "MISSING_REQUIRED_ARGUMENT");
+    expect(errs).toHaveLength(1);
+    expect(errs[0].message).toContain("userId");
+  });
+
+  it("optional input が argumentMapping に無くても検出しない", () => {
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act1",
+          name: "submit",
+          trigger: "click",
+          steps: [],
+          inputs: [{ name: "userId", type: "string", required: false }],
+        },
+      ],
+    });
+    const screen = makeScreen([
+      {
+        id: "submitBtn",
+        label: "送信",
+        type: "string",
+        events: [{ id: "click", handlerFlowId: FLOW_ID_A }],
+      },
+    ]);
+    const issues = checkScreenItemFlowConsistency([flow] as never, [screen] as never);
+    const errs = issues.filter((i) => i.code === "MISSING_REQUIRED_ARGUMENT");
+    expect(errs).toHaveLength(0);
+  });
+});
+
+describe("checkScreenItemFlowConsistency — EXTRA_ARGUMENT", () => {
+  it("argumentMapping のキーが inputs に無いと検出する", () => {
+    const flow = makeFlow();
+    const screen = makeScreen([
+      {
+        id: "submitBtn",
+        label: "送信",
+        type: "string",
+        events: [
+          {
+            id: "click",
+            handlerFlowId: FLOW_ID_A,
+            argumentMapping: {
+              userId: "@session.userId",
+              extraField: "@self.x",
+            },
+          },
+        ],
+      },
+    ]);
+    const issues = checkScreenItemFlowConsistency([flow] as never, [screen] as never);
+    const errs = issues.filter((i) => i.code === "EXTRA_ARGUMENT");
+    expect(errs).toHaveLength(1);
+    expect(errs[0].message).toContain("extraField");
+  });
+});
+
+describe("checkScreenItemFlowConsistency — PRIMARY_INVOKER_MISMATCH", () => {
+  it("primaryInvoker.screenId が見つからないと検出する", () => {
+    const flow = makeFlow({
+      meta: {
+        id: FLOW_ID_A,
+        name: "f",
+        kind: "screen",
+        createdAt: "2026-04-30T00:00:00.000Z",
+        updatedAt: "2026-04-30T00:00:00.000Z",
+        primaryInvoker: {
+          kind: "screen-item-event",
+          screenId: "99999999-9999-4999-8999-999999999999",
+          itemId: "submitBtn",
+          eventId: "click",
+        },
+      },
+    });
+    const screen = makeScreen([]);
+    const issues = checkScreenItemFlowConsistency([flow] as never, [screen] as never);
+    const errs = issues.filter((i) => i.code === "PRIMARY_INVOKER_MISMATCH");
+    expect(errs).toHaveLength(1);
+  });
+
+  it("双方向整合: 該イベントの handlerFlowId と本 flow ID が一致しないと検出する", () => {
+    const flow = makeFlow({
+      meta: {
+        id: FLOW_ID_A,
+        name: "f",
+        kind: "screen",
+        createdAt: "2026-04-30T00:00:00.000Z",
+        updatedAt: "2026-04-30T00:00:00.000Z",
+        primaryInvoker: {
+          kind: "screen-item-event",
+          screenId: SCREEN_ID,
+          itemId: "submitBtn",
+          eventId: "click",
+        },
+      },
+    });
+    const otherFlow = { ...flow, meta: { ...flow.meta as object, id: FLOW_ID_B } };
+    const screen = makeScreen([
+      {
+        id: "submitBtn",
+        label: "送信",
+        type: "string",
+        events: [
+          // 該イベントは別フロー (B) を呼んでいる
+          { id: "click", handlerFlowId: FLOW_ID_B, argumentMapping: { userId: "@session.userId" } },
+        ],
+      },
+    ]);
+    const issues = checkScreenItemFlowConsistency([flow, otherFlow] as never, [screen] as never);
+    const errs = issues.filter((i) => i.code === "PRIMARY_INVOKER_MISMATCH");
+    expect(errs.length).toBeGreaterThanOrEqual(1);
+    expect(errs[0].message).toContain("双方向");
+  });
+
+  it("primaryInvoker と画面項目側 handlerFlowId が一致すれば検出しない", () => {
+    const flow = makeFlow({
+      meta: {
+        id: FLOW_ID_A,
+        name: "f",
+        kind: "screen",
+        createdAt: "2026-04-30T00:00:00.000Z",
+        updatedAt: "2026-04-30T00:00:00.000Z",
+        primaryInvoker: {
+          kind: "screen-item-event",
+          screenId: SCREEN_ID,
+          itemId: "submitBtn",
+          eventId: "click",
+        },
+      },
+    });
+    const screen = makeScreen([
+      {
+        id: "submitBtn",
+        label: "送信",
+        type: "string",
+        events: [
+          { id: "click", handlerFlowId: FLOW_ID_A, argumentMapping: { userId: "@session.userId" } },
+        ],
+      },
+    ]);
+    const issues = checkScreenItemFlowConsistency([flow] as never, [screen] as never);
+    const errs = issues.filter((i) => i.code === "PRIMARY_INVOKER_MISMATCH");
+    expect(errs).toHaveLength(0);
+  });
+});
+
+describe("checkScreenItemFlowConsistency — INCONSISTENT_ARGUMENT_CONTRACT", () => {
+  it("1 flow × 多イベントで argKey 集合が異なると warning", () => {
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act1",
+          name: "submit",
+          trigger: "click",
+          steps: [],
+          inputs: [
+            { name: "userId", type: "string", required: false },
+            { name: "amount", type: "number", required: false },
+          ],
+        },
+      ],
+    });
+    const screen = makeScreen([
+      {
+        id: "btn1",
+        label: "送信1",
+        type: "string",
+        events: [
+          { id: "click", handlerFlowId: FLOW_ID_A, argumentMapping: { userId: "@s.u" } },
+        ],
+      },
+      {
+        id: "btn2",
+        label: "送信2",
+        type: "string",
+        events: [
+          { id: "click", handlerFlowId: FLOW_ID_A, argumentMapping: { userId: "@s.u", amount: "@s.a" } },
+        ],
+      },
+    ]);
+    const issues = checkScreenItemFlowConsistency([flow] as never, [screen] as never);
+    const warns = issues.filter((i) => i.code === "INCONSISTENT_ARGUMENT_CONTRACT");
+    expect(warns.length).toBeGreaterThanOrEqual(1);
+    expect(warns[0].severity).toBe("warning");
+  });
+
+  it("1 flow × 多イベントで argKey 集合が同じなら warning なし", () => {
+    const flow = makeFlow();
+    const screen = makeScreen([
+      {
+        id: "btn1",
+        label: "1",
+        type: "string",
+        events: [{ id: "click", handlerFlowId: FLOW_ID_A, argumentMapping: { userId: "@s.u" } }],
+      },
+      {
+        id: "btn2",
+        label: "2",
+        type: "string",
+        events: [{ id: "click", handlerFlowId: FLOW_ID_A, argumentMapping: { userId: "@s.u" } }],
+      },
+    ]);
+    const issues = checkScreenItemFlowConsistency([flow] as never, [screen] as never);
+    const warns = issues.filter((i) => i.code === "INCONSISTENT_ARGUMENT_CONTRACT");
+    expect(warns).toHaveLength(0);
+  });
+});
+
+describe("checkScreenItemFlowConsistency — empty inputs", () => {
+  it("events が無い ScreenItem は検出ゼロ (後方互換)", () => {
+    const flow = makeFlow();
+    const screen = makeScreen([
+      { id: "submitBtn", label: "送信", type: "string" },
+    ]);
+    const issues = checkScreenItemFlowConsistency([flow] as never, [screen] as never);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("空 flows / 空 screens で検出ゼロ", () => {
+    expect(checkScreenItemFlowConsistency([], [])).toEqual([]);
+  });
+});

--- a/designer/src/schemas/screenItemFlowValidator.test.ts
+++ b/designer/src/schemas/screenItemFlowValidator.test.ts
@@ -305,6 +305,27 @@ describe("checkScreenItemFlowConsistency — INCONSISTENT_ARGUMENT_CONTRACT", ()
   });
 });
 
+describe("checkScreenItemFlowConsistency — DUPLICATE_EVENT_ID", () => {
+  it("画面項目内で event.id が重複すると検出する", () => {
+    const flow = makeFlow();
+    const screen = makeScreen([
+      {
+        id: "submitBtn",
+        label: "送信",
+        type: "string",
+        events: [
+          { id: "click", handlerFlowId: FLOW_ID_A, argumentMapping: { userId: "@s.u" } },
+          { id: "click", handlerFlowId: FLOW_ID_A, argumentMapping: { userId: "@s.u" } },
+        ],
+      },
+    ]);
+    const issues = checkScreenItemFlowConsistency([flow] as never, [screen] as never);
+    const errs = issues.filter((i) => i.code === "DUPLICATE_EVENT_ID");
+    expect(errs).toHaveLength(1);
+    expect(errs[0].message).toContain("'click'");
+  });
+});
+
 describe("checkScreenItemFlowConsistency — empty inputs", () => {
   it("events が無い ScreenItem は検出ゼロ (後方互換)", () => {
     const flow = makeFlow();

--- a/designer/src/schemas/screenItemFlowValidator.ts
+++ b/designer/src/schemas/screenItemFlowValidator.ts
@@ -28,8 +28,16 @@ export type ScreenItemFlowIssueCode =
   | "MISSING_REQUIRED_ARGUMENT"
   | "EXTRA_ARGUMENT"
   | "PRIMARY_INVOKER_MISMATCH"
-  | "INCONSISTENT_ARGUMENT_CONTRACT";
+  | "INCONSISTENT_ARGUMENT_CONTRACT"
+  | "DUPLICATE_EVENT_ID";
 
+/**
+ * 本 validator は他 4 validator (sqlColumnValidator / conventionsValidator /
+ * referentialIntegrity / identifierScope) と異なり severity を持つ最初の validator。
+ * INCONSISTENT_ARGUMENT_CONTRACT が「設計上問題ない場合もある」 (異なるユースケースで
+ * 意図的に異なる引数集合を渡したい) 性質のため warning とする。他観点はすべて error。
+ * 将来他 validator に warning 観点が追加される際は本パターンに揃える。
+ */
 export interface ScreenItemFlowIssue {
   path: string;
   code: ScreenItemFlowIssueCode;
@@ -82,6 +90,22 @@ export function checkScreenItemFlowConsistency(
 
     items.forEach((item: ScreenItem, ii) => {
       const events = item.events ?? [];
+
+      // events[].id 重複検査 (画面項目内ユニーク制約、JSON Schema 標準では表現不能のため validator で担保)
+      const eventIdCounts = new Map<string, number>();
+      for (const event of events) {
+        eventIdCounts.set(event.id, (eventIdCounts.get(event.id) ?? 0) + 1);
+      }
+      for (const [eid, count] of eventIdCounts) {
+        if (count > 1) {
+          issues.push({
+            path: `${screenLabel}.items[${ii}=${item.id}]`,
+            code: "DUPLICATE_EVENT_ID",
+            severity: "error",
+            message: `event ID '${eid}' が画面項目内で ${count} 回出現しています (画面項目内ユニーク制約違反)。`,
+          });
+        }
+      }
 
       events.forEach((event: ScreenItemEvent, ei) => {
         const path = `${screenLabel}.items[${ii}=${item.id}].events[${ei}=${event.id}]`;
@@ -188,6 +212,11 @@ export function checkScreenItemFlowConsistency(
   });
 
   // 3. 多重定義検出 (warning)
+  // 比較は sites[0] を基点とする単純実装。3+ サイトある場合 sites[0] と sites[2] が同一でも
+  // sites[1] が異なれば sites[1] のみ検出される (全ペア比較ではない)。実用上 1 flow を呼ぶ
+  // 全 site は同一引数集合であるべきなので sites[0] 基点で十分。将来全ペア比較が必要なら拡張。
+  // また UNKNOWN_HANDLER_FLOW で early return した event は collect されないため、エラー event
+  // は多重定義の比較基点にならない (多重定義検出はエラー event を含まないクリーン collect で実施)。
   for (const [flowId, sites] of flowToCallSites) {
     if (sites.length <= 1) continue;
     const baseKeys = sites[0].argKeys;

--- a/designer/src/schemas/screenItemFlowValidator.ts
+++ b/designer/src/schemas/screenItemFlowValidator.ts
@@ -1,0 +1,210 @@
+// @ts-nocheck
+/**
+ * 画面項目イベント ↔ 処理フロー連携の整合検査 (#619、#624 schema 拡張前提)。
+ *
+ * 検査観点:
+ * 1. UNKNOWN_HANDLER_FLOW         — ScreenItem.events[].handlerFlowId が指す
+ *                                   ProcessFlow が同プロジェクト内に実在するか
+ * 2. MISSING_REQUIRED_ARGUMENT    — ProcessFlow の required input が
+ *                                   argumentMapping で渡されているか
+ * 3. EXTRA_ARGUMENT               — argumentMapping のキーが ProcessFlow inputs[]
+ *                                   に存在しないものを参照していないか
+ * 4. PRIMARY_INVOKER_MISMATCH     — ProcessFlow.meta.primaryInvoker (宣言時)
+ *                                   が指す ScreenItem イベントが、画面項目側でも
+ *                                   handlerFlowId: <本フロー> で逆参照されているか
+ * 5. INCONSISTENT_ARGUMENT_CONTRACT — 1 ProcessFlow が複数イベントから呼ばれる
+ *                                     場合の argumentMapping キー集合の整合 (warning)
+ *
+ * 「ProcessFlow の inputs[]」は現状 actions[0].inputs[] を primary とする
+ * (全 v3 sample で actions 数 = 1 のため)。複数 actions のケースは将来課題。
+ */
+
+import type { ProcessFlow, StructuredField } from "../types/action";
+import type { Screen } from "../types/v3/screen";
+import type { ScreenItem, ScreenItemEvent } from "../types/v3/screen-item";
+
+export type ScreenItemFlowIssueCode =
+  | "UNKNOWN_HANDLER_FLOW"
+  | "MISSING_REQUIRED_ARGUMENT"
+  | "EXTRA_ARGUMENT"
+  | "PRIMARY_INVOKER_MISMATCH"
+  | "INCONSISTENT_ARGUMENT_CONTRACT";
+
+export interface ScreenItemFlowIssue {
+  path: string;
+  code: ScreenItemFlowIssueCode;
+  severity: "error" | "warning";
+  message: string;
+}
+
+interface CallSite {
+  path: string;
+  argKeys: Set<string>;
+}
+
+function getFlowId(flow: ProcessFlow): string | null {
+  // v1 (top-level id) と v3 (meta.id) の両形式に対応
+  return (flow as { id?: string }).id ?? flow.meta?.id ?? null;
+}
+
+function getScreenId(screen: Screen): string | null {
+  return (screen as { id?: string }).id ?? (screen as { meta?: { id: string } }).meta?.id ?? null;
+}
+
+function getPrimaryInputs(flow: ProcessFlow): StructuredField[] {
+  // 全 v3 sample で actions 数 = 1。actions[0].inputs[] を primary inputs とする。
+  return flow.actions?.[0]?.inputs ?? [];
+}
+
+/**
+ * 全プロジェクトの ProcessFlow と Screen を入力に、画面項目イベントと処理フロー
+ * 連携の整合を検証。空配列なら問題なし。
+ */
+export function checkScreenItemFlowConsistency(
+  flows: ProcessFlow[],
+  screens: Screen[],
+): ScreenItemFlowIssue[] {
+  const issues: ScreenItemFlowIssue[] = [];
+
+  // ProcessFlow を id 索引に
+  const flowById = new Map<string, ProcessFlow>();
+  for (const flow of flows) {
+    const id = getFlowId(flow);
+    if (id) flowById.set(id, flow);
+  }
+
+  // 1. ScreenItem.events[] 検査 + 多重定義検出のための collect
+  const flowToCallSites = new Map<string, CallSite[]>();
+
+  screens.forEach((screen, si) => {
+    const screenLabel = getScreenId(screen) ?? `screens[${si}]`;
+    const items = screen.items ?? [];
+
+    items.forEach((item: ScreenItem, ii) => {
+      const events = item.events ?? [];
+
+      events.forEach((event: ScreenItemEvent, ei) => {
+        const path = `${screenLabel}.items[${ii}=${item.id}].events[${ei}=${event.id}]`;
+
+        // 1.1 handlerFlowId 実在検査
+        const targetFlow = flowById.get(event.handlerFlowId);
+        if (!targetFlow) {
+          issues.push({
+            path,
+            code: "UNKNOWN_HANDLER_FLOW",
+            severity: "error",
+            message: `handlerFlowId '${event.handlerFlowId}' が指す処理フローが見つかりません。`,
+          });
+          return;
+        }
+
+        // 1.2 引数 contract 整合
+        const inputs = getPrimaryInputs(targetFlow);
+        const argMapping = event.argumentMapping ?? {};
+        const inputNames = new Set(inputs.map((i) => i.name));
+
+        // 必須引数欠落
+        for (const input of inputs) {
+          if (input.required && !(input.name in argMapping)) {
+            issues.push({
+              path,
+              code: "MISSING_REQUIRED_ARGUMENT",
+              severity: "error",
+              message: `argumentMapping に処理フローの必須引数 '${input.name}' が欠落しています。`,
+            });
+          }
+        }
+
+        // 余剰引数
+        for (const argKey of Object.keys(argMapping)) {
+          if (!inputNames.has(argKey)) {
+            issues.push({
+              path: `${path}.argumentMapping.${argKey}`,
+              code: "EXTRA_ARGUMENT",
+              severity: "error",
+              message: `argumentMapping のキー '${argKey}' が処理フロー inputs[] に存在しません。`,
+            });
+          }
+        }
+
+        // 多重定義検出のために collect
+        const sites = flowToCallSites.get(event.handlerFlowId) ?? [];
+        sites.push({ path, argKeys: new Set(Object.keys(argMapping)) });
+        flowToCallSites.set(event.handlerFlowId, sites);
+      });
+    });
+  });
+
+  // 2. ProcessFlow.meta.primaryInvoker 双方向整合検査
+  flows.forEach((flow, fi) => {
+    const flowId = getFlowId(flow);
+    const primaryInvoker = flow.meta?.primaryInvoker;
+    if (!primaryInvoker || !flowId) return;
+    if (primaryInvoker.kind !== "screen-item-event") return;
+
+    const path = `flows[${fi}=${flowId}].meta.primaryInvoker`;
+
+    const screen = screens.find((s) => getScreenId(s) === primaryInvoker.screenId);
+    if (!screen) {
+      issues.push({
+        path,
+        code: "PRIMARY_INVOKER_MISMATCH",
+        severity: "error",
+        message: `primaryInvoker.screenId '${primaryInvoker.screenId}' が指す画面が見つかりません。`,
+      });
+      return;
+    }
+
+    const item = screen.items?.find((i) => i.id === primaryInvoker.itemId);
+    if (!item) {
+      issues.push({
+        path,
+        code: "PRIMARY_INVOKER_MISMATCH",
+        severity: "error",
+        message: `primaryInvoker.itemId '${primaryInvoker.itemId}' が画面 '${primaryInvoker.screenId}' に存在しません。`,
+      });
+      return;
+    }
+
+    const event = item.events?.find((e) => e.id === primaryInvoker.eventId);
+    if (!event) {
+      issues.push({
+        path,
+        code: "PRIMARY_INVOKER_MISMATCH",
+        severity: "error",
+        message: `primaryInvoker.eventId '${primaryInvoker.eventId}' が画面項目 '${primaryInvoker.itemId}' に存在しません。`,
+      });
+      return;
+    }
+
+    if (event.handlerFlowId !== flowId) {
+      issues.push({
+        path,
+        code: "PRIMARY_INVOKER_MISMATCH",
+        severity: "error",
+        message: `primaryInvoker が指す画面項目イベントの handlerFlowId は '${event.handlerFlowId}' で、本フロー ID '${flowId}' と一致しません (双方向整合)。`,
+      });
+    }
+  });
+
+  // 3. 多重定義検出 (warning)
+  for (const [flowId, sites] of flowToCallSites) {
+    if (sites.length <= 1) continue;
+    const baseKeys = sites[0].argKeys;
+    for (let i = 1; i < sites.length; i++) {
+      const keys = sites[i].argKeys;
+      const sameSize = keys.size === baseKeys.size;
+      const sameKeys = sameSize && [...keys].every((k) => baseKeys.has(k));
+      if (!sameKeys) {
+        issues.push({
+          path: sites[i].path,
+          code: "INCONSISTENT_ARGUMENT_CONTRACT",
+          severity: "warning",
+          message: `処理フロー '${flowId}' を呼ぶ複数イベント間で argumentMapping のキー集合が異なります。最初の site '${sites[0].path}' と整合確認を推奨。`,
+        });
+      }
+    }
+  }
+
+  return issues;
+}

--- a/designer/src/types/v3/process-flow.ts
+++ b/designer/src/types/v3/process-flow.ts
@@ -74,7 +74,21 @@ export interface ProcessFlowMeta {
   apiVersion?: string;
   mode?: Mode;
   sla?: Sla;
+  /** 主たる呼び出し元 (#624、任意、designer 補完精度向上用)。 */
+  primaryInvoker?: PrimaryInvoker;
 }
+
+/**
+ * 処理フローの主たる呼び出し元 (#624)。任意メタ情報、実行時には参照されない。
+ * 副次的呼び出し (他画面 / batch / 他フロー) は宣言不要 — 画面項目側 events[].handlerFlowId
+ * のみで成立する。現状は kind='screen-item-event' のみ対応 (将来拡張余地あり)。
+ */
+export type PrimaryInvoker = {
+  kind: "screen-item-event";
+  screenId: ScreenId;
+  itemId: string;
+  eventId: string;
+};
 
 // ─── Context (catalogs / ambientVariables / health / readiness / resources) ──
 

--- a/designer/src/types/v3/screen-item.ts
+++ b/designer/src/types/v3/screen-item.ts
@@ -20,6 +20,25 @@ import type {
   ViewColumnRef,
 } from "./common";
 
+/**
+ * 画面項目イベント (#624) — 発火時に handlerFlowId 指定の処理フローを呼び出し、
+ * argumentMapping で画面コンテキストを処理フロー inputs[] に変換する。
+ * 1 処理フロー × N イベント (再利用) を自然に表現する backward reference。
+ */
+export interface ScreenItemEvent {
+  /** イベント ID (例: `click` / `submit` / `change` / `blur`)。画面項目内ユニーク (validator 担保)。 */
+  id: string;
+  label?: DisplayName;
+  /** 発火時に実行する処理フローの ID (backward reference)。 */
+  handlerFlowId: ProcessFlowId;
+  /**
+   * 画面コンテキストを処理フロー引数 (inputs[]) に変換するマッピング。
+   * キーは処理フロー側 inputs[].name (Identifier 形式)、値は画面コンテキスト式
+   * (`@screen.* / @self.* / @session.*` 等)。
+   */
+  argumentMapping?: Record<Identifier, ExpressionString>;
+}
+
 /** ScreenItem.options 1 件。 */
 export interface ScreenItemOption {
   value: string;
@@ -92,5 +111,7 @@ export interface ScreenItem {
   valueFrom?: ValueSource;
   /** 派生計算式 (= で始まる)。output 項目用。 */
   formula?: ExpressionString;
+  /** 本画面項目で発火するイベントと処理フロー連携 (#624)。 */
+  events?: ScreenItemEvent[];
   description?: Description;
 }


### PR DESCRIPTION
## 関連

- Closes #619
- 仕様: 設計判断履歴 #611 (Phase 3 メタ) + #624 (schema 拡張、PR #625 マージ済) + 本 ISSUE 本文
- 前提: #624 schema 拡張完了 (PR #625)
- 連動: 子 3 #621 (Skill 統合) / 子 4 #622 (ドッグフード)

## 概要

#624 で確立した schema 拡張 (ScreenItem.events[] + ProcessFlow.meta.primaryInvoker) に基づき、画面項目イベントと処理フロー連携の整合検査 validator を新設、validate-dogfood に統合。Phase 3 メタ #611 子 1 の本実装。

## 主な変更

### 1. validator 新設

- \`designer/src/schemas/screenItemFlowValidator.ts\` (新規、validator 本体)
  - \`checkScreenItemFlowConsistency(flows, screens)\` (line 63-)
  - 5 種の検査観点 (UNKNOWN_HANDLER_FLOW / MISSING_REQUIRED_ARGUMENT / EXTRA_ARGUMENT / PRIMARY_INVOKER_MISMATCH / INCONSISTENT_ARGUMENT_CONTRACT)
- \`designer/src/schemas/screenItemFlowValidator.test.ts\` (新規、12 ケース)
  - 各 issue code の検出テスト + events 未指定 (既存 sample が依然動作) + 空入力

### 2. TS 型同期 (本 PR で必要な最小範囲)

- \`designer/src/types/v3/screen-item.ts\`: \`ScreenItemEvent\` 型 + \`ScreenItem.events?\` フィールド追加
- \`designer/src/types/v3/process-flow.ts\`: \`PrimaryInvoker\` 型 + \`ProcessFlowMeta.primaryInvoker?\` フィールド追加
- 全 v3 TS 型同期は別 ISSUE #610 範囲 (本 PR では validator が型で動くための最小拡張のみ)

### 3. validate-dogfood 統合

- \`designer/scripts/validate-dogfood.ts\`:
  - \`ProjectResources\` に \`screens: Screen[]\` 追加
  - \`loadScreensFromDir(dir)\` 新設 (per-project screens/ ディレクトリスキャン)
  - \`runValidation\` 内で **per-project に新 validator を 5 番目として実行** (flows + screens を渡す)
  - \`ProjectValidationResult\` 型 + \`projectResults\` サマリー追加
  - 画面項目連携 issue は project-level セクションとして表示 (per-flow とは別軸)
  - exit code: per-flow fail OR project-level error が 1 件以上で 1

## 仕様逐条突合 (自己申告)

ISSUE #619 完了基準:

- [x] **#624 (schema 拡張) マージ済** → PR #625 マージ済 ✓
- [⚠] **既存サンプル参照状況の調査** → 既存 v3 sample に events[]/primaryInvoker は未登録 (新機能領域)。子 4 #622 ドッグフード時に実 sample で参照実態を蓄積予定
- [x] **validator 実装 + 単体テスト** → screenItemFlowValidator.ts (line 63-) + 12 ケース ✓ (うち 1 ケースは PRIMARY_INVOKER_MISMATCH の双方向不整合検出)
- [x] **validate-dogfood への統合** → per-project loop 内で 5 番目 validator として実行 (validate-dogfood.ts:328-348 付近) ✓
- [x] **vitest src/schemas/ 全件 pass** → 14 files / 428 tests pass ✓
- [x] **validate:dogfood 既存検出範囲を維持 (regression なし)** → 既存 22 件検出 (#614 / #612 範囲) を維持、画面項目連携 issue 0 件 (events/primaryInvoker 未登録のため正常) ✓

スキーマガバナンス (AGENTS.md):

- [x] \`schemas/v3/*.json\` 変更なし (#624 で完了済) ✓
- [x] 設計者承認済の方針に基づく実装 ✓

## レビューで特に見てほしい箇所

1. **5 種検査観点の網羅性**: ISSUE #619 完了基準に列挙された観点 (handlerFlowId 整合 / 引数 contract 整合 / primaryInvoker 双方向 / 多重定義) を 5 つの code に分解。網羅は十分か、追加すべき観点はないか。
2. **PRIMARY_INVOKER_MISMATCH の細粒度**: 4 段階で検査 (画面不在 / 項目不在 / イベント不在 / handlerFlowId 不一致)。それぞれの message が利用者にとって分かりやすいか。
3. **多重定義の判定 (INCONSISTENT_ARGUMENT_CONTRACT)**: argumentMapping のキー集合のみ比較し、値式 (ExpressionString) の比較は行わない。これで十分な warning 機能か。
4. **validator の入力モデル (per-project)**: flows + screens を一括で受け取り、per-project loop 外で実行するのではなく per-project 単位に集約。これが #607 で確立した per-project 構造と整合しているか。
5. **TS 型 (#610) との関係**: 本 PR で screen-item.ts / process-flow.ts に最小拡張を入れたが、全 v3 TS 型同期は #610 範囲。本 PR の範囲限定が妥当か。
6. **後方互換性**: 既存 v3 sample (events/primaryInvoker 未登録) で validate:dogfood の検出件数が変わらない (= regression なし) ことを実機実行で確認済。

## テスト

- Vitest: 14 files / 428 tests pass (新規 12 件 — screenItemFlowValidator.test.ts)
- Playwright: N/A (UI 影響なし、validator ロジックのみ)
- CLI: \`npm run validate:dogfood\` 実行 → 8 projects / 18 flows / 37 tables / 5 screens / 22 issues (既存範囲、project-level issues 0)

## UI 影響 / AI smoke test

- [ ] UI 影響あり
- [x] UI 影響なし (validator ロジック追加 + CLI ツール拡張のみ)

## spec 側の不足点 / 提案

- 画面項目連携の使い方ガイド (\`docs/spec/screen-items.md\` か新規) は本 PR スコープ外、子 4 #622 ドッグフードで実例追加と同時に作成想定
- Skill 統合 (\`/create-flow\` Step 5 + \`/review-flow\` Step 0.5 への組み込み) は子 3 #621 で対応

## レビュー担当への申し送り

- 本 PR は **Phase 3 メタ #611 子 1**。マージで Phase 3 の中核 validator が成立、子 3 (Skill 統合) → 子 4 (ドッグフード + #614 統合) → 子 5 (評価レポート) へ進行可能。
- 同根盲点探索: validate-dogfood の他 4 validator (sqlColumn / conventions / referentialIntegrity / identifierScope) が per-flow なのに対し、screenItemFlow は per-project。これは画面項目イベントが「flow ではなく screen に属する」性質上、per-project が自然 (画面間の整合は project スコープ)。
- 半角カナスキャン: 該当ファイル全件で \`[ｦ-ﾟ]\` 検出 0 件。
- PR 本文の自己申告 line 番号: ts:63 (checkScreenItemFlowConsistency) / test:46/85/130/157/246/308 (各 describe) は実測値。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
