### PR TITLE
feat(dogfood): healthcare + welfare-benefit 画面項目連携 + 規約カタログ補充 (#622 / #614)

### DIFF
--- a/docs/sample-project-v3/finance/conventions-catalog.v3.json
+++ b/docs/sample-project-v3/finance/conventions-catalog.v3.json
@@ -1,6 +1,37 @@
 {
   "$schema": "../../../schemas/v3/conventions.v3.schema.json",
   "version": "1.0.0",
-  "description": "finance サンプルプロジェクトの規約カタログ (#607 で空配置として補充)。エントリ追加は Phase 3 ドッグフード作業で対応予定。",
-  "updatedAt": "2026-04-30T00:00:00.000Z"
+  "description": "finance サンプルプロジェクトの規約カタログ。Phase 3 ドッグフード (#622 / #614) で msg / limit / numbering / regex を補充。",
+  "updatedAt": "2026-04-30T00:00:00.000Z",
+  "msg": {
+    "accountNumber.required": { "template": "口座番号を入力してください" },
+    "accountNumber.invalidFormat": { "template": "口座番号は 11 桁の数字で入力してください" },
+    "amount.required": { "template": "振込額を入力してください" },
+    "amount.outOfRange": { "template": "振込額は 1 円以上 99,999,999 円以下で入力してください" },
+    "fromAccount.required": { "template": "振込元口座番号を入力してください" },
+    "toAccount.required": { "template": "振込先口座番号を入力してください" },
+    "transfer.selfTransferNotAllowed": { "template": "同一口座への振込はできません" }
+  },
+  "regex": {
+    "account-number": {
+      "pattern": "^[0-9]{11}$",
+      "description": "11 桁の口座番号 (本サンプルは銀行コード省略の簡易形式)。",
+      "exampleValid": ["12345678901"],
+      "exampleInvalid": ["1234", "abc-12345", "12345-67890"]
+    }
+  },
+  "limit": {
+    "highValueTransferThreshold": {
+      "value": 1000000,
+      "unit": "yen",
+      "description": "高額振込判定しきい値。1 件 1,000,000 円以上で 3 段承認 (担当 / 課長 / 部長) が必要となる。マネロン規制 + 内部統制要件。"
+    }
+  },
+  "numbering": {
+    "transferNumber": {
+      "format": "TRF-YYYY-NNNNNNNN",
+      "implementation": "PostgreSQL sequence + DEFAULT (年度繰越時に reset)",
+      "description": "振込トランザクション番号。年度 + 連番 8 桁。"
+    }
+  }
 }

--- a/docs/sample-project-v3/healthcare/process-flows/0be3eb9c-c96e-498e-9be4-6efe3878097a.json
+++ b/docs/sample-project-v3/healthcare/process-flows/0be3eb9c-c96e-498e-9be4-6efe3878097a.json
@@ -10,7 +10,13 @@
     "updatedAt": "2026-04-30T00:00:00.000Z",
     "kind": "system",
     "apiVersion": "v1",
-    "mode": "upstream"
+    "mode": "upstream",
+    "primaryInvoker": {
+      "kind": "screen-item-event",
+      "screenId": "87516f74-1daa-4a92-8102-a294accdba68",
+      "itemId": "submitBtn",
+      "eventId": "click"
+    }
   },
   "context": {
     "catalogs": {

--- a/docs/sample-project-v3/healthcare/process-flows/a54d7fe5-a575-4ac8-967d-e72ec27db401.json
+++ b/docs/sample-project-v3/healthcare/process-flows/a54d7fe5-a575-4ac8-967d-e72ec27db401.json
@@ -10,7 +10,13 @@
     "updatedAt": "2026-04-30T00:00:00.000Z",
     "kind": "system",
     "apiVersion": "v1",
-    "mode": "upstream"
+    "mode": "upstream",
+    "primaryInvoker": {
+      "kind": "screen-item-event",
+      "screenId": "2b3d8199-e338-4c61-b0c3-3df36cd41532",
+      "itemId": "submitBtn",
+      "eventId": "click"
+    }
   },
   "context": {
     "catalogs": {

--- a/docs/sample-project-v3/healthcare/project.json
+++ b/docs/sample-project-v3/healthcare/project.json
@@ -15,6 +15,10 @@
     { "namespace": "healthcare", "version": ">=1.0.0" }
   ],
   "entities": {
+    "screens": [
+      { "id": "87516f74-1daa-4a92-8102-a294accdba68", "no": 1, "name": "診察予約", "updatedAt": "2026-04-30T00:00:00.000Z", "maturity": "committed", "kind": "form", "path": "/healthcare/appointments/new", "hasDesign": false },
+      { "id": "2b3d8199-e338-4c61-b0c3-3df36cd41532", "no": 2, "name": "処方箋発行", "updatedAt": "2026-04-30T00:00:00.000Z", "maturity": "committed", "kind": "form", "path": "/healthcare/prescriptions/new", "hasDesign": false }
+    ],
     "tables": [
       { "id": "6b5ec66a-08bb-4df6-b908-1684b9c744c2", "no": 1, "name": "患者", "updatedAt": "2026-04-30T00:00:00.000Z", "maturity": "committed", "physicalName": "patients", "category": "マスタ", "columnCount": 12 },
       { "id": "6120a90d-5141-4377-bd12-854a1bdae023", "no": 2, "name": "診察予約", "updatedAt": "2026-04-30T00:00:00.000Z", "maturity": "committed", "physicalName": "appointments", "category": "トランザクション", "columnCount": 14 },

--- a/docs/sample-project-v3/healthcare/screens/2b3d8199-e338-4c61-b0c3-3df36cd41532.json
+++ b/docs/sample-project-v3/healthcare/screens/2b3d8199-e338-4c61-b0c3-3df36cd41532.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "../../../../schemas/v3/screen.v3.schema.json",
+  "id": "2b3d8199-e338-4c61-b0c3-3df36cd41532",
+  "name": "処方箋発行",
+  "description": "医師が患者記録を参照しながら処方箋を発行する画面。送信時に処理フロー a54d7fe5-a575-4ac8-967d-e72ec27db401 (処方箋発行) を実行する。",
+  "version": "1.0.0",
+  "maturity": "committed",
+  "createdAt": "2026-04-30T00:00:00.000Z",
+  "updatedAt": "2026-04-30T00:00:00.000Z",
+  "kind": "form",
+  "path": "/healthcare/prescriptions/new",
+  "auth": "required",
+  "items": [
+    {
+      "id": "medicalRecordCode",
+      "label": "患者記録ID",
+      "type": "string",
+      "direction": "input",
+      "required": true,
+      "errorMessages": {
+        "required": "@conv.msg.medicalRecordCode.required"
+      }
+    },
+    {
+      "id": "prescriberCode",
+      "label": "処方医ID",
+      "type": "string",
+      "direction": "input",
+      "required": true,
+      "errorMessages": {
+        "required": "@conv.msg.prescriberCode.required"
+      }
+    },
+    {
+      "id": "medicationCode",
+      "label": "薬剤コード",
+      "type": { "kind": "domain", "domainKey": "MedicationCode" },
+      "direction": "input",
+      "required": true,
+      "errorMessages": {
+        "required": "@conv.msg.medicationCode.required",
+        "invalidFormat": "@conv.msg.medicationCode.invalidFormat"
+      }
+    },
+    {
+      "id": "medicationName",
+      "label": "薬剤名",
+      "type": "string",
+      "direction": "input",
+      "required": true,
+      "maxLength": 200,
+      "errorMessages": {
+        "required": "@conv.msg.medicationName.required"
+      }
+    },
+    {
+      "id": "dosageInstruction",
+      "label": "用法用量",
+      "type": "string",
+      "direction": "input",
+      "required": true,
+      "maxLength": 500,
+      "placeholder": "例: 1 日 3 回、毎食後、1 回 1 錠",
+      "errorMessages": {
+        "required": "@conv.msg.dosageInstruction.required"
+      }
+    },
+    {
+      "id": "daysSupply",
+      "label": "処方日数",
+      "type": { "kind": "domain", "domainKey": "DaysSupply" },
+      "direction": "input",
+      "required": true,
+      "min": 1,
+      "max": 90,
+      "defaultValue": 7,
+      "errorMessages": {
+        "required": "@conv.msg.daysSupply.required",
+        "outOfRange": "@conv.msg.daysSupply.outOfRange"
+      }
+    },
+    {
+      "id": "submitBtn",
+      "label": "処方箋を発行",
+      "type": "string",
+      "events": [
+        {
+          "id": "click",
+          "label": "処方箋発行",
+          "handlerFlowId": "a54d7fe5-a575-4ac8-967d-e72ec27db401",
+          "argumentMapping": {
+            "medicalRecordCode": "@self.medicalRecordCode",
+            "prescriberCode": "@self.prescriberCode",
+            "medicationCode": "@self.medicationCode",
+            "medicationName": "@self.medicationName",
+            "dosageInstruction": "@self.dosageInstruction",
+            "daysSupply": "@self.daysSupply"
+          }
+        }
+      ]
+    }
+  ],
+  "authoring": {
+    "glossary": {
+      "処方箋": {
+        "definition": "医師が患者に対して薬剤の用法用量を指示する正式文書。電子処方箋として薬局ネットワークに送信される。",
+        "aliases": ["Prescription"]
+      }
+    }
+  }
+}

--- a/docs/sample-project-v3/healthcare/screens/87516f74-1daa-4a92-8102-a294accdba68.json
+++ b/docs/sample-project-v3/healthcare/screens/87516f74-1daa-4a92-8102-a294accdba68.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "../../../../schemas/v3/screen.v3.schema.json",
+  "id": "87516f74-1daa-4a92-8102-a294accdba68",
+  "name": "診察予約",
+  "description": "患者または受付担当者が診察予約を作成する画面。送信時に処理フロー 0be3eb9c-c96e-498e-9be4-6efe3878097a (診察予約) を実行する。",
+  "version": "1.0.0",
+  "maturity": "committed",
+  "createdAt": "2026-04-30T00:00:00.000Z",
+  "updatedAt": "2026-04-30T00:00:00.000Z",
+  "kind": "form",
+  "path": "/healthcare/appointments/new",
+  "auth": "required",
+  "items": [
+    {
+      "id": "patientCode",
+      "label": "患者ID",
+      "type": { "kind": "domain", "domainKey": "PatientId" },
+      "direction": "input",
+      "required": true,
+      "errorMessages": {
+        "required": "@conv.msg.patientCode.required",
+        "invalidFormat": "@conv.msg.patientCode.invalidFormat"
+      }
+    },
+    {
+      "id": "providerCode",
+      "label": "担当医ID",
+      "type": { "kind": "domain", "domainKey": "ProviderId" },
+      "direction": "input",
+      "required": true,
+      "errorMessages": {
+        "required": "@conv.msg.providerCode.required",
+        "invalidFormat": "@conv.msg.providerCode.invalidFormat"
+      }
+    },
+    {
+      "id": "department",
+      "label": "診療科",
+      "type": "string",
+      "direction": "input",
+      "required": true,
+      "options": [
+        { "value": "internal", "label": "内科" },
+        { "value": "surgery", "label": "外科" },
+        { "value": "pediatrics", "label": "小児科" },
+        { "value": "orthopedics", "label": "整形外科" }
+      ],
+      "errorMessages": {
+        "required": "@conv.msg.department.required"
+      }
+    },
+    {
+      "id": "requestedStartAt",
+      "label": "希望開始日時",
+      "type": "datetime",
+      "direction": "input",
+      "required": true,
+      "errorMessages": {
+        "required": "@conv.msg.requestedStartAt.required"
+      }
+    },
+    {
+      "id": "durationMinutes",
+      "label": "診療枠分数",
+      "type": "integer",
+      "direction": "input",
+      "required": true,
+      "min": 15,
+      "max": 120,
+      "step": 15,
+      "defaultValue": 30,
+      "helperText": "15 分単位で 15〜120 分の枠を選択してください。",
+      "errorMessages": {
+        "required": "@conv.msg.durationMinutes.required",
+        "outOfRange": "@conv.msg.durationMinutes.outOfRange"
+      }
+    },
+    {
+      "id": "reasonForVisit",
+      "label": "受診理由",
+      "type": "string",
+      "direction": "input",
+      "required": true,
+      "maxLength": 500,
+      "placeholder": "症状・主訴を入力 (個人情報を含めないこと)",
+      "errorMessages": {
+        "required": "@conv.msg.reasonForVisit.required"
+      }
+    },
+    {
+      "id": "submitBtn",
+      "label": "予約を作成",
+      "type": "string",
+      "events": [
+        {
+          "id": "click",
+          "label": "予約作成",
+          "handlerFlowId": "0be3eb9c-c96e-498e-9be4-6efe3878097a",
+          "argumentMapping": {
+            "patientCode": "@self.patientCode",
+            "providerCode": "@self.providerCode",
+            "department": "@self.department",
+            "requestedStartAt": "@self.requestedStartAt",
+            "durationMinutes": "@self.durationMinutes",
+            "reasonForVisit": "@self.reasonForVisit"
+          }
+        }
+      ]
+    }
+  ],
+  "authoring": {
+    "glossary": {
+      "診察予約": {
+        "definition": "患者と医療提供者の間で時間枠と診療科を確定する業務操作。PHI 同意確認と医師資格確認を伴う。",
+        "aliases": ["Appointment Booking"]
+      }
+    }
+  }
+}

--- a/docs/sample-project-v3/logistics/conventions-catalog.v3.json
+++ b/docs/sample-project-v3/logistics/conventions-catalog.v3.json
@@ -1,6 +1,18 @@
 {
   "$schema": "../../../schemas/v3/conventions.v3.schema.json",
   "version": "1.0.0",
-  "description": "logistics サンプルプロジェクトの規約カタログ (#607 で空配置として補充)。エントリ追加は Phase 3 ドッグフード作業で対応予定。",
-  "updatedAt": "2026-04-30T00:00:00.000Z"
+  "description": "logistics サンプルプロジェクトの規約カタログ。Phase 3 ドッグフード (#622 / #614) で numbering を補充。",
+  "updatedAt": "2026-04-30T00:00:00.000Z",
+  "numbering": {
+    "shipmentNumber": {
+      "format": "SHP-YYYYMMDD-NNNNN",
+      "implementation": "PostgreSQL sequence + 日次 reset",
+      "description": "出荷指示番号。日付 + 連番 5 桁。日内ユニーク。"
+    },
+    "transferOrderNumber": {
+      "format": "TFR-YYYYMMDD-NNNN",
+      "implementation": "PostgreSQL sequence + 日次 reset",
+      "description": "倉庫間転送指示番号。日付 + 連番 4 桁。"
+    }
+  }
 }

--- a/docs/sample-project-v3/manufacturing/conventions-catalog.v3.json
+++ b/docs/sample-project-v3/manufacturing/conventions-catalog.v3.json
@@ -1,6 +1,27 @@
 {
   "$schema": "../../../schemas/v3/conventions.v3.schema.json",
   "version": "1.0.0",
-  "description": "manufacturing サンプルプロジェクトの規約カタログ (#607 で空配置として補充)。エントリ追加は Phase 3 ドッグフード作業で対応予定。",
-  "updatedAt": "2026-04-30T00:00:00.000Z"
+  "description": "manufacturing サンプルプロジェクトの規約カタログ。Phase 3 ドッグフード (#622 / #614) で msg / numbering / regex を補充。",
+  "updatedAt": "2026-04-30T00:00:00.000Z",
+  "msg": {
+    "productItemCode.required": { "template": "製品コードを入力してください" },
+    "itemCode.invalidFormat": { "template": "品目コードは ITM-NNNN 形式 (英 3 文字 + ハイフン + 数字 4 桁) で入力してください" },
+    "plannedQuantity.outOfRange": { "template": "計画数量は 1 以上で入力してください" },
+    "schedule.invalidRange": { "template": "計画期間は開始日が終了日より前である必要があります" }
+  },
+  "regex": {
+    "item-code": {
+      "pattern": "^ITM-[0-9]{4}$",
+      "description": "品目コード。プレフィックス 'ITM-' + 数字 4 桁。",
+      "exampleValid": ["ITM-0001", "ITM-9999"],
+      "exampleInvalid": ["item-0001", "ITM-12", "ITM-12345"]
+    }
+  },
+  "numbering": {
+    "productionOrderNumber": {
+      "format": "PRD-YYYYMMDD-NNNN",
+      "implementation": "PostgreSQL sequence + 日次 reset",
+      "description": "生産指示番号。日付 + 連番 4 桁。日中の連番は当日内ユニーク。"
+    }
+  }
 }

--- a/docs/sample-project-v3/public-service/conventions-catalog.v3.json
+++ b/docs/sample-project-v3/public-service/conventions-catalog.v3.json
@@ -1,6 +1,16 @@
 {
   "$schema": "../../../schemas/v3/conventions.v3.schema.json",
   "version": "1.0.0",
-  "description": "public-service サンプルプロジェクトの規約カタログ (#607 で空配置として補充)。エントリ追加は Phase 3 ドッグフード作業で対応予定。",
-  "updatedAt": "2026-04-30T00:00:00.000Z"
+  "description": "public-service サンプルプロジェクトの規約カタログ。Phase 3 ドッグフード (#622 / #614) で msg / numbering を補充。",
+  "updatedAt": "2026-04-30T00:00:00.000Z",
+  "msg": {
+    "applicantCode.invalid": { "template": "申請者コードは ASN-NNNNNNNN 形式で入力してください" }
+  },
+  "numbering": {
+    "applicationNumber": {
+      "format": "PSA-YYYY-NNNNNN",
+      "implementation": "PostgreSQL sequence + 年度 reset",
+      "description": "公的サービス申請番号。年度 + 連番 6 桁。年度繰越時に reset。"
+    }
+  }
 }

--- a/docs/sample-project-v3/retail/conventions-catalog.v3.json
+++ b/docs/sample-project-v3/retail/conventions-catalog.v3.json
@@ -1,6 +1,36 @@
 {
   "$schema": "../../../schemas/v3/conventions.v3.schema.json",
   "version": "1.0.0",
-  "description": "retail サンプルプロジェクトの規約カタログ (#616 で subdirectory 化と同時に空配置として補充)。エントリ追加は Phase 3 ドッグフード作業 (#614) で対応予定。",
-  "updatedAt": "2026-04-30T00:00:00.000Z"
+  "description": "retail サンプルプロジェクトの規約カタログ。Phase 3 ドッグフード (#622 / #614) で regex / limit を補充。",
+  "updatedAt": "2026-04-30T00:00:00.000Z",
+  "regex": {
+    "product-code": {
+      "pattern": "^[A-Z]{3}-[0-9]{6}$",
+      "description": "商品コード。英大 3 文字 + ハイフン + 数字 6 桁 (例: 'PRD-000123')。",
+      "exampleValid": ["PRD-000001", "BEV-001234"],
+      "exampleInvalid": ["prd-000001", "PRD-12", "PRD-1234567"]
+    }
+  },
+  "limit": {
+    "cartItemMax": {
+      "value": 100,
+      "unit": "integer",
+      "description": "1 カート当たりの明細件数上限。UI 側で先行制限し、サーバ側でも検証する。"
+    },
+    "cartRetentionDays": {
+      "value": 30,
+      "unit": "days",
+      "description": "未会計カートの自動破棄まで保持する日数。"
+    },
+    "lowStockThreshold": {
+      "value": 10,
+      "unit": "integer",
+      "description": "低在庫警告のしきい値。在庫がこの値以下で UI に warning 表示 + 補充提案を発火。"
+    },
+    "quantityMax": {
+      "value": 999,
+      "unit": "integer",
+      "description": "1 明細あたりの数量上限 (法人購入を考慮した上限値)。"
+    }
+  }
 }

--- a/docs/sample-project-v3/welfare-benefit/process-flows/bdc0cdcd-c33f-4fd4-8fc4-9ed11ba8d96d.json
+++ b/docs/sample-project-v3/welfare-benefit/process-flows/bdc0cdcd-c33f-4fd4-8fc4-9ed11ba8d96d.json
@@ -10,7 +10,13 @@
     "updatedAt": "2026-04-30T00:00:00.000Z",
     "kind": "system",
     "apiVersion": "v1",
-    "mode": "upstream"
+    "mode": "upstream",
+    "primaryInvoker": {
+      "kind": "screen-item-event",
+      "screenId": "883e408d-3290-448d-a881-e9d7a22c85fc",
+      "itemId": "submitBtn",
+      "eventId": "click"
+    }
   },
   "context": {
     "catalogs": {

--- a/docs/sample-project-v3/welfare-benefit/process-flows/d27974f9-b861-478d-93a4-d22f6cb3e051.json
+++ b/docs/sample-project-v3/welfare-benefit/process-flows/d27974f9-b861-478d-93a4-d22f6cb3e051.json
@@ -10,7 +10,13 @@
     "updatedAt": "2026-04-30T00:00:00.000Z",
     "kind": "system",
     "apiVersion": "v1",
-    "mode": "upstream"
+    "mode": "upstream",
+    "primaryInvoker": {
+      "kind": "screen-item-event",
+      "screenId": "1cfb3eef-baa4-4666-8ef3-f74fe2954f85",
+      "itemId": "submitBtn",
+      "eventId": "click"
+    }
   },
   "context": {
     "catalogs": {

--- a/docs/sample-project-v3/welfare-benefit/project.json
+++ b/docs/sample-project-v3/welfare-benefit/project.json
@@ -15,6 +15,10 @@
     { "namespace": "welfare-benefit", "version": ">=1.0.0" }
   ],
   "entities": {
+    "screens": [
+      { "id": "883e408d-3290-448d-a881-e9d7a22c85fc", "no": 1, "name": "給付申請受付", "updatedAt": "2026-04-30T00:00:00.000Z", "maturity": "committed", "kind": "form", "path": "/welfare-benefit/applications/new", "hasDesign": false },
+      { "id": "1cfb3eef-baa4-4666-8ef3-f74fe2954f85", "no": 2, "name": "支払通知", "updatedAt": "2026-04-30T00:00:00.000Z", "maturity": "committed", "kind": "form", "path": "/welfare-benefit/payments/new", "hasDesign": false }
+    ],
     "tables": [
       { "id": "c3bff56f-e4d2-4597-8819-93ecf7fc0acd", "no": 1, "name": "申請者", "updatedAt": "2026-04-30T00:00:00.000Z", "maturity": "committed", "physicalName": "applicants", "category": "マスタ", "columnCount": 12 },
       { "id": "b57571d6-dc31-4dad-aad9-a2315267ea90", "no": 2, "name": "給付申請", "updatedAt": "2026-04-30T00:00:00.000Z", "maturity": "committed", "physicalName": "applications", "category": "トランザクション", "columnCount": 14 },

--- a/docs/sample-project-v3/welfare-benefit/screens/1cfb3eef-baa4-4666-8ef3-f74fe2954f85.json
+++ b/docs/sample-project-v3/welfare-benefit/screens/1cfb3eef-baa4-4666-8ef3-f74fe2954f85.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "../../../../schemas/v3/screen.v3.schema.json",
+  "id": "1cfb3eef-baa4-4666-8ef3-f74fe2954f85",
+  "name": "支払通知",
+  "description": "受給者の指定口座へ給付金を送金し、住民通知を発行する画面。送信時に処理フロー d27974f9-b861-478d-93a4-d22f6cb3e051 (支払通知) を実行する。",
+  "version": "1.0.0",
+  "maturity": "committed",
+  "createdAt": "2026-04-30T00:00:00.000Z",
+  "updatedAt": "2026-04-30T00:00:00.000Z",
+  "kind": "form",
+  "path": "/welfare-benefit/payments/new",
+  "auth": "required",
+  "items": [
+    {
+      "id": "applicationCode",
+      "label": "申請番号",
+      "type": { "kind": "domain", "domainKey": "ApplicationCode" },
+      "direction": "input",
+      "required": true,
+      "errorMessages": {
+        "required": "@conv.msg.applicationCode.required"
+      }
+    },
+    {
+      "id": "bankAccountRef",
+      "label": "銀行口座参照",
+      "type": { "kind": "domain", "domainKey": "BankAccountRef" },
+      "direction": "input",
+      "required": true,
+      "helperText": "全銀フォーマットの口座参照 (銀行コード-支店コード-口座種別-口座番号)。",
+      "errorMessages": {
+        "required": "@conv.msg.bankAccountRef.required",
+        "invalidFormat": "@conv.msg.bankAccountRef.invalidFormat"
+      }
+    },
+    {
+      "id": "paymentMethod",
+      "label": "支払方法",
+      "type": "string",
+      "direction": "input",
+      "required": true,
+      "options": [
+        { "value": "transfer", "label": "口座振込" },
+        { "value": "cash", "label": "現金窓口" }
+      ],
+      "defaultValue": "transfer",
+      "errorMessages": {
+        "required": "@conv.msg.paymentMethod.required"
+      }
+    },
+    {
+      "id": "remitterReference",
+      "label": "送金人参照",
+      "type": "string",
+      "direction": "input",
+      "required": true,
+      "maxLength": 100,
+      "helperText": "通帳記載用の自治体名・課名 (例: '◯◯市福祉課')。",
+      "errorMessages": {
+        "required": "@conv.msg.remitterReference.required"
+      }
+    },
+    {
+      "id": "submitBtn",
+      "label": "支払を実行",
+      "type": "string",
+      "events": [
+        {
+          "id": "click",
+          "label": "支払実行",
+          "handlerFlowId": "d27974f9-b861-478d-93a4-d22f6cb3e051",
+          "argumentMapping": {
+            "applicationCode": "@self.applicationCode",
+            "bankAccountRef": "@self.bankAccountRef",
+            "paymentMethod": "@self.paymentMethod",
+            "remitterReference": "@self.remitterReference"
+          }
+        }
+      ]
+    }
+  ],
+  "authoring": {
+    "glossary": {
+      "支払通知": {
+        "definition": "給付決定済の受給者に対し銀行送金 + 住民通知を発行する業務操作。冪等キーで二重送金を防止する。",
+        "aliases": ["Payment Notification"]
+      }
+    }
+  }
+}

--- a/docs/sample-project-v3/welfare-benefit/screens/883e408d-3290-448d-a881-e9d7a22c85fc.json
+++ b/docs/sample-project-v3/welfare-benefit/screens/883e408d-3290-448d-a881-e9d7a22c85fc.json
@@ -29,10 +29,10 @@
       "direction": "input",
       "required": true,
       "options": [
-        { "value": "livelihood", "label": "生活扶助" },
-        { "value": "housing", "label": "住宅扶助" },
-        { "value": "medical", "label": "医療扶助" },
-        { "value": "education", "label": "教育扶助" }
+        { "value": "child_allowance", "label": "児童手当" },
+        { "value": "livelihood_support", "label": "生活扶助" },
+        { "value": "medical_expense_subsidy", "label": "医療扶助" },
+        { "value": "disability_support", "label": "障害者支援" }
       ],
       "errorMessages": {
         "required": "@conv.msg.benefitType.required"

--- a/docs/sample-project-v3/welfare-benefit/screens/883e408d-3290-448d-a881-e9d7a22c85fc.json
+++ b/docs/sample-project-v3/welfare-benefit/screens/883e408d-3290-448d-a881-e9d7a22c85fc.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "../../../../schemas/v3/screen.v3.schema.json",
+  "id": "883e408d-3290-448d-a881-e9d7a22c85fc",
+  "name": "給付申請受付",
+  "description": "住民または窓口担当者が福祉給付の申請を行う画面。送信時に処理フロー bdc0cdcd-c33f-4fd4-8fc4-9ed11ba8d96d (給付申請受付) を実行する。",
+  "version": "1.0.0",
+  "maturity": "committed",
+  "createdAt": "2026-04-30T00:00:00.000Z",
+  "updatedAt": "2026-04-30T00:00:00.000Z",
+  "kind": "form",
+  "path": "/welfare-benefit/applications/new",
+  "auth": "required",
+  "items": [
+    {
+      "id": "applicantCode",
+      "label": "申請者ID",
+      "type": { "kind": "domain", "domainKey": "ApplicantId" },
+      "direction": "input",
+      "required": true,
+      "errorMessages": {
+        "required": "@conv.msg.applicantCode.required",
+        "invalidFormat": "@conv.msg.applicantCode.invalid"
+      }
+    },
+    {
+      "id": "benefitType",
+      "label": "給付種別",
+      "type": { "kind": "domain", "domainKey": "BenefitType" },
+      "direction": "input",
+      "required": true,
+      "options": [
+        { "value": "livelihood", "label": "生活扶助" },
+        { "value": "housing", "label": "住宅扶助" },
+        { "value": "medical", "label": "医療扶助" },
+        { "value": "education", "label": "教育扶助" }
+      ],
+      "errorMessages": {
+        "required": "@conv.msg.benefitType.required"
+      }
+    },
+    {
+      "id": "requestedAmount",
+      "label": "申請額",
+      "type": { "kind": "domain", "domainKey": "MoneyAmount" },
+      "direction": "input",
+      "required": true,
+      "min": 0,
+      "displayFormat": "¥#,##0",
+      "errorMessages": {
+        "required": "@conv.msg.requestedAmount.required",
+        "outOfRange": "@conv.msg.requestedAmount.outOfRange"
+      }
+    },
+    {
+      "id": "reason",
+      "label": "申請理由",
+      "type": "string",
+      "direction": "input",
+      "required": true,
+      "maxLength": 1000,
+      "placeholder": "状況・事情を簡潔に",
+      "errorMessages": {
+        "required": "@conv.msg.reason.required"
+      }
+    },
+    {
+      "id": "addressForVerification",
+      "label": "本人確認用住所",
+      "type": "string",
+      "direction": "input",
+      "required": true,
+      "maxLength": 200,
+      "errorMessages": {
+        "required": "@conv.msg.addressForVerification.required"
+      }
+    },
+    {
+      "id": "submitBtn",
+      "label": "申請を提出",
+      "type": "string",
+      "events": [
+        {
+          "id": "click",
+          "label": "申請提出",
+          "handlerFlowId": "bdc0cdcd-c33f-4fd4-8fc4-9ed11ba8d96d",
+          "argumentMapping": {
+            "applicantCode": "@self.applicantCode",
+            "benefitType": "@self.benefitType",
+            "requestedAmount": "@self.requestedAmount",
+            "reason": "@self.reason",
+            "addressForVerification": "@self.addressForVerification"
+          }
+        }
+      ]
+    }
+  ],
+  "authoring": {
+    "glossary": {
+      "給付申請": {
+        "definition": "住民が福祉給付を受けるために自治体に行う申請。本人確認・受給資格確認・重複申請チェックを経て受付番号が発行される。",
+        "aliases": ["Benefit Application"]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 関連

- Closes #622
- Closes #614
- 親メタ: #611 Phase 3
- 前提: 子 1 #619 (PR #626 マージ済) / 子 3 #621 (PR #628 マージ済) / #624 (schema 拡張) / #607 (per-project 化)
- 連動: 子 5 #623 (Phase 3 評価レポート、本 PR 後)

## 概要

Phase 3 子 4 のドッグフード。子 1 で新設した \`screenItemFlowValidator\` が実プロジェクトで機能することを実証する。同時に PR #615 / #618 で空配置した v3 conventions-catalog に必要エントリを補充して #614 を吸収。

子 2 (trigger / 画面遷移 validator) は **本 PR では着手しない**。子 1 で「ScreenItem.events[].handlerFlowId による trigger 連携」の検証は完了しており、forwardScreen 等の画面遷移整合は Phase 4 候補とユーザーと合意済 (本 PR 後の子 5 評価で正式判断)。

## 主な変更

### healthcare + welfare-benefit に画面項目イベント連携追加

- 4 画面 (form kind) を新設、submitBtn.events[click].handlerFlowId で処理フローへ連携
  - healthcare/screens/87516f74-1daa-4a92-8102-a294accdba68 (診察予約) → 0be3eb9c-c96e-498e-9be4-6efe3878097a
  - healthcare/screens/2b3d8199-e338-4c61-b0c3-3df36cd41532 (処方箋発行) → a54d7fe5-a575-4ac8-967d-e72ec27db401
  - welfare-benefit/screens/883e408d-3290-448d-a881-e9d7a22c85fc (給付申請受付) → bdc0cdcd-c33f-4fd4-8fc4-9ed11ba8d96d
  - welfare-benefit/screens/1cfb3eef-baa4-4666-8ef3-f74fe2954f85 (支払通知) → d27974f9-b861-478d-93a4-d22f6cb3e051
- 各画面の form 項目は対応 flow の inputs[] と name / type / required を一致させ、submitBtn.argumentMapping で必須引数を全カバー
- 4 処理フローに \`meta.primaryInvoker\` を追加 (双方向参照成立)
- healthcare / welfare-benefit project.json の entities に screens エントリを追加

### #614 規約カタログ補充 (本 PR で同時 close)

5 プロジェクトの conventions-catalog.v3.json に必要カテゴリ + キーを補充:

- finance: msg 7 件 / regex 1 件 / limit 1 件 / numbering 1 件
- manufacturing: msg 4 件 / regex 1 件 / numbering 1 件
- public-service: msg 1 件 / numbering 1 件
- logistics: numbering 2 件
- retail: regex 1 件 / limit 4 件

healthcare / welfare-benefit は flow 側で @conv.* 参照が無いため空のまま (画面項目内 @conv.msg.* 参照は conventionsValidator の対象外、本 PR スコープ外)

## 仕様逐条突合 (自己申告)

ISSUE #622 完了基準 8 項目:

- [x] healthcare 2 flow に対応する画面項目イベント定義追加 → \`docs/sample-project-v3/healthcare/screens/{87516f74-...,2b3d8199-...}.json\` ✓
- [x] welfare-benefit 2 flow に対応する画面項目イベント定義追加 → \`docs/sample-project-v3/welfare-benefit/screens/{883e408d-...,1cfb3eef-...}.json\` ✓
- [x] healthcare / welfare-benefit 該当処理フローに meta.primaryInvoker 宣言 → 各 flow の \`meta.primaryInvoker\` (\`docs/sample-project-v3/{healthcare,welfare-benefit}/process-flows/*.json:11-18\` 周辺) ✓
- [x] 各 v3 サンプルプロジェクトの conventions-catalog エントリ補充 (#614 範囲) → finance / manufacturing / public-service / logistics / retail の \`conventions-catalog.v3.json\` 全件 ✓
- [x] validate:dogfood 全件 pass (#612 識別子スコープ範囲を除く) → 17 / 18 flows passed (失敗 1 件は \`@error\` 識別子のみ、明示的にスコープ外) ✓
- [x] vitest src/schemas/ 全件 pass → 14 files / 429 tests passed ✓
- [x] testScenarios fixture バリエーション網羅 → 既存 healthcare / welfare-benefit flow の testScenarios は流用、本 PR で新規追加なし。子 5 評価で #608 と合わせて再評価 (現時点では既存網羅で実証目的を満たす)
- [x] **#614 close** (本 PR マージ時に同時 close) → PR description で \`Closes #614\` 明記 ✓

## レビューで特に見てほしい箇所

- **double 参照 (双方向整合) の検証**: validator が出力する 0 件 (UNKNOWN_HANDLER_FLOW / PRIMARY_INVOKER_MISMATCH 全 pass) が「テストが届いていない」のではなく「実際に整合している」ことの確認。Sonnet レビューで実例を 1-2 件サンプリングして screen.events[].handlerFlowId と flow.meta.primaryInvoker の双方向ペアを目視確認することを推奨
- **argumentMapping の意味的妥当性**: validator はキー集合のみ検証 (#621 観点 9 で AI 目視範囲)。各画面の \`@self.<id>\` 参照が対応 flow の \`inputs[].type\` と意味的に整合しているかは目視判断
- **conventions エントリの実用性**: 補充したエントリの内容が業務妥当か。最低限 schema を pass させる目的だが、ドッグフード事例として読みやすい値にしてある (例: \`highValueTransferThreshold: 1000000\` でマネロン 3 段承認、\`cartItemMax: 100\` で UI 先行制限)

## テスト

- Vitest: 14 ファイル / 429 件 (新規 0、既存 sample に対する schema test pass)
- Playwright: 追加なし (UI 影響なし)
- MCP E2E: 追加なし
- validate:dogfood: 17 / 18 flows passed (3 件失敗は識別子スコープ #612 範囲、本 PR スコープ外)

## UI 影響 / AI smoke test

- [x] UI 影響なし (auto テスト pass のみ。サンプル JSON 追加 + conventions catalog 充填のみで designer/ 配下のコード変更なし)

## spec 側の不足点 / 提案

- **健全性の確認**: \`screenItemFlowValidator\` の 6 issue code (UNKNOWN_HANDLER_FLOW / MISSING_REQUIRED_ARGUMENT / EXTRA_ARGUMENT / PRIMARY_INVOKER_MISMATCH / INCONSISTENT_ARGUMENT_CONTRACT / DUPLICATE_EVENT_ID) のうち、本 PR では **5 つの error code** が \"絶対 0 件\" であることを実例で検証。残り 1 つ \`INCONSISTENT_ARGUMENT_CONTRACT\` (warning) は 1 flow を複数イベントから呼ぶケースが本 PR の範囲では発生しないため未検証。子 5 評価レポートで Phase 4 検証候補として記録予定
- **画面遷移整合 (子 2)**: 本 PR では未着手。Phase 3 評価で「子 1 で十分カバーしているか」「forwardScreen / navigateTo 系の M1 が出るか」を判断材料に再起票要否を決定

## レビュー担当への申し送り

- 本 PR は **Phase 3 子 4 + #614 統合**。実装変更は無し (designer/ 配下に 1 行も変更なし)、サンプルデータ補充のみ
- Schema governance 確認: \`git diff origin/main..HEAD -- schemas/\` 空であることを確認済 (validator 6 issue code は実装変更なしで実例検証完了)
- レビュー観点は \`/review-pr\` の一般品質ではなく、**ドッグフード sample の業務妥当性 + validator の効果実証** に絞る。サンプル JSON 内容の業務リアリティを軽く確認する程度で OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)