### PR TITLE
improve(skill): /create-flow Rule 18 + testScenarios fixture バリエーション網羅指針 — Phase 2 M1 反省 (#608)

### DIFF
--- a/.claude/skills/create-flow/SKILL.md
+++ b/.claude/skills/create-flow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-flow
-description: ProcessFlow JSON を品質ガード付きで新規作成する。/review-flow の 10 観点 + 17 ルールを作成前 self-check として組み込み、既知パターンの再発を抑制 + グローバル schema 変更禁止 (#511) + 画面項目連携整合性 (#621)
+description: ProcessFlow JSON を品質ガード付きで新規作成する。/review-flow の 10 観点 + 18 ルールを作成前 self-check として組み込み、既知パターンの再発を抑制 + グローバル schema 変更禁止 (#511) + 画面項目連携整合性 (#621)
 argument-hint: <flowId> <業務概要> [namespace]
 disable-model-invocation: true
 ---
@@ -79,11 +79,21 @@ ProcessFlow JSON に含めるべき要素 (5/5 達成サンプル準拠):
 | `domainsCatalog` | ID 系・金額系等のドメイン型 (constraints 付き) |
 | `functionsCatalog` | 業務固有関数のシグネチャ (signature / returnType / examples) |
 | `actions[]` | 1-3 アクション。各 trigger / inputs / outputs / responses / steps |
-| `testScenarios` | 3 件以上 (happy path / validation error / 業務エッジケース) |
+| `testScenarios` | 3 件以上 (happy path / validation error / 業務エッジケース)、各 SELECT 対象テーブルについて行ありパターン + 行なしパターン (新規ユーザー / 初回利用) を網羅 (#608) |
 
 各セクション 0 件は許されない (eventsCatalog と decisions と testScenarios は特に必須)。
 
-## Step 3: 既知パターン回避 self-check (17 ルール、必須遵守)
+### testScenarios fixture バリエーション網羅 (#608)
+
+testScenarios 設計時に、各 `dbAccess SELECT` で使用するテーブルについて、以下のバリエーションを最低 1 件ずつ含める:
+
+- **テーブル行が存在するパターン** (典型的な happy-path)
+- **テーブル行が存在しないパターン** (新規ユーザー / 初回利用 / 第 1 回目の処理)
+- **テーブル行が境界条件にあるパターン** (累計が上限近傍 / 期限境界 / NULL 許容カラムが NULL の状態 等)
+
+`dbAccess INSERT` の前に他テーブル行の存在を前提とする場合、testScenarios で「前提行が無い場合の挙動」を必ず確認する。特に NOT NULL カラムへの INSERT で他テーブル参照を持つ場合は、その前提テーブル行が無い fixture を 1 件追加し、「初回」「新規」「リセット後初回」のキーワードを意図的に使う。
+
+## Step 3: 既知パターン回避 self-check (18 ルール、必須遵守)
 
 `/review-flow` で検出される既知パターンを**作成中**に避けること。各 step を書くたびに以下を確認:
 
@@ -224,6 +234,12 @@ UI 起点フロー (`type: "screen"` / `mode: "upstream"`) を作成するとき
 
 業務文脈の妥当性 (例えば「BenefitType の意味的妥当性」「画面選択肢の業務命名」) は引き続き AI 目視で `/review-flow` 観点 10 で扱う。
 
+### Rule 18: testScenarios fixture バリエーション網羅 (#608)
+
+- 各 `dbAccess SELECT` 対象テーブルについて、行ありパターン + 行なしパターン (新規ユーザー / 初回利用) を testScenarios で網羅する
+- NOT NULL カラムへの INSERT で他テーブル参照を持つ場合、前提行なしの fixture を必ず 1 件用意する
+- 典型ミス: happy-path で全前提を pre-seed、edge は 400/403 系の検証に偏り、初回ユーザーパスが抜ける
+
 ## Step 4: 拡張定義の使い方
 
 ### 既存 namespace を使う場合
@@ -348,6 +364,7 @@ npx vitest run src/schemas/validateDogfood.test.ts -t "<flowId の一部>"
 | 15. グローバル schema 変更禁止 | ✓ (`schemas/*.json` 未変更) / ❌ |
 | 16. 画面項目イベント連携整合 | ✓ / 該当なし (画面起点でない) / ❌ |
 | 17. 画面項目値レベル整合 | ✓ / 該当なし (画面起点でない) / ❌ (options / domainKey / 型 / pattern / range / length 不一致) |
+| 18. testScenarios fixture バリエーション網羅 | ✓ / 該当なし (DB 操作なし) / ❌ (行ありのみで行なしパターン未網羅) |
 
 ### 検証結果
 - vitest: <pass/fail 件数>
@@ -367,11 +384,11 @@ npx vitest run src/schemas/validateDogfood.test.ts -t "<flowId の一部>"
 - **拡張定義は実利用必須**: 定義のみで未使用は禁止 (spec §15.3)
 - **schema を尊重**: `type: "manufacturing:StepName"` のような未対応形式は使わない (`type: "other"` + outputSchema が正解)
 - **データファイル (`data/`) は触らない** (gitignore 対象)
-- **17 ルールすべて作成中に意識する**: 1 つでも無視するとレビューで detect される
+- **18 ルールすべて作成中に意識する**: 1 つでも無視するとレビューで detect される
 
 ## 注意事項
 
 - スキル肥大化を避けるため、spec 本文は転記しない (要約のみ)
 - 業務概要が短すぎて不明瞭な場合は、ユーザーに「もう少し詳しく」と聞き返すのも可
 - 既存サンプル (`dddddddd-0001-*` / `eeeeeeee-0001-*` / `ffffffff-0001-*` 等) は 5/5 達成済の良サンプル、構造を参考にする
-- `/issues` オーケストレーターから委譲される場合、briefing に「`/create-flow` の 17 ルールを遵守すること」が含まれているはず
+- `/issues` オーケストレーターから委譲される場合、briefing に「`/create-flow` の 18 ルールを遵守すること」が含まれているはず

--- a/.claude/skills/create-flow/SKILL.md
+++ b/.claude/skills/create-flow/SKILL.md
@@ -239,6 +239,7 @@ UI 起点フロー (`type: "screen"` / `mode: "upstream"`) を作成するとき
 - 各 `dbAccess SELECT` 対象テーブルについて、行ありパターン + 行なしパターン (新規ユーザー / 初回利用) を testScenarios で網羅する
 - NOT NULL カラムへの INSERT で他テーブル参照を持つ場合、前提行なしの fixture を必ず 1 件用意する
 - 典型ミス: happy-path で全前提を pre-seed、edge は 400/403 系の検証に偏り、初回ユーザーパスが抜ける
+- **補足**: 静的検出 `sqlOrderValidator` (#632) が導入されるまで本ルールが主要 catch 機構。導入後も「値レベル fixture 不足」など静的検出では届かない領域は本ルールで継続担保 (Step 5.2 validate:dogfood では機械検出されない、Step 3 self-check のみで担保)
 
 ## Step 4: 拡張定義の使い方
 
@@ -275,7 +276,7 @@ npx vitest run src/schemas/extensions-samples.test.ts src/schemas/process-flow.s
 npm run build
 ```
 
-### 5.2 バリデータ横断検証 (Rule 9 / 10 / 16 / 17 の機械的検出)
+### 5.2 バリデータ横断検証 (Rule 9 / 10 / 16 / 17 の機械的検出、Rule 18 は AI 目視)
 
 作成したフローを `docs/sample-project/process-flows/<flowId>.json` に配置した状態で:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Claude Code 向けの補足ガイダンス。
 
 - **`/issues <N>`** — ISSUE を 12 ルール Opus オーケストレーターワークフローで完遂 (`.claude/skills/issues/SKILL.md`)
 - **`/review-pr <N>`** — PR 独立レビュー (一般品質: spec / 命名 / テスト) (`.claude/skills/review-pr/SKILL.md`)
-- **`/create-flow <flowId> <業務概要> [namespace]`** — ProcessFlow JSON を品質ガード付きで作成 (`/review-flow` の 14 観点を作成前 self-check として組み込み、#486 検証で発覚した 6 件の追加 checklist を含む)。`/review-flow` と併用前提 (`.claude/skills/create-flow/SKILL.md`)
+- **`/create-flow <flowId> <業務概要> [namespace]`** — ProcessFlow JSON を品質ガード付きで作成 (`/review-flow` の 10 観点を作成前 self-check として組み込み、18 ルールの既知パターン回避 self-check を含む)。`/review-flow` と併用前提 (`.claude/skills/create-flow/SKILL.md`)
 - **`/review-flow <flowId>`** — ProcessFlow JSON 実行セマンティクス専門レビュー (変数ライフサイクル / TX / runIf / 補償 / event 双方向)。設計フェーズから使える (`.claude/skills/review-flow/SKILL.md`)
 - **`/review-issue <N>`** — ISSUE 単位の実装網羅性監査 (`.claude/skills/review-issue/SKILL.md`)
 - **`/test-strategy`** — テスト実装時の自動起動スキル (`.claude/skills/test-strategy/SKILL.md`)


### PR DESCRIPTION
## 関連

- Closes #608
- 仕様: docs/spec/phase2-evaluation-2026-04-30.md §フォローアップ ISSUE 起票案 (c) — Phase 2 #603 で発見された Must-fix M1 (welfare-benefit payments.beneficiary_id NOT NULL × INSERT 順序、初回受給者で NULL 違反) の反省を Skill に反映
- 仕様: docs/spec/phase3-evaluation-2026-04-30.md §「Validator では届かない領域」(γ) — testScenarios fixture バリエーション網羅は M1 / M2 の動的検出機構

## 概要

`/create-flow` Skill に **testScenarios fixture バリエーション網羅指針** を追加し、Phase 2 #603 で見逃された「初回ユーザー = 前提テーブル行なし」パターンの未網羅を構造的に防ぐ。Phase 4 着手前提整備 (Phase 3 評価レポート §Phase 4 移行判断 §条件 (β)) として位置付け。

## 主な変更

- `.claude/skills/create-flow/SKILL.md` 修正
- `CLAUDE.md` 修正 (`/create-flow` の説明乖離を整合)
- Step 2 必須セクション (testScenarios 行) に fixture バリエーション網羅要件を追記
- Step 2 に「testScenarios fixture バリエーション網羅」セクション新設 (3 バリエーション + NOT NULL × INSERT 順序の確認指針)
- Step 3 既知パターン回避 self-check を 17 ルール → **18 ルール** に拡張、Rule 18 (testScenarios fixture バリエーション網羅) 新設
- Rule 18 末尾に sqlOrderValidator (#632) との補完関係を 1 行明示 (静的検出 vs 動的検出の住み分け)
- Step 5.2 heading に「Rule 18 は AI 目視」追記 (機械検出対象外であることを伝える)
- self-check 表に Rule 18 行追加
- description / Step 3 heading / Step 6 / 末尾の「17 ルール」表記 4 箇所を「18 ルール」に置換 (残存 0)
- CLAUDE.md の `/create-flow` 説明 「14 観点 + 6 件の追加 checklist」 (#486 当時の値) → 「10 観点 + 18 ルール」に整合更新

## 仕様逐条突合 (自己申告、Codex 出力後 Opus 実測)

### #608 完了基準

- [x] §「完了基準」 `.claude/skills/create-flow/SKILL.md` Step 2 に fixture バリエーション網羅指針を追加 → SKILL.md:82 (testScenarios 行更新) + :86-94 (新セクション「testScenarios fixture バリエーション網羅 (#608)」) ✓
- [x] §「完了基準」 Step 3 (self-check) に Rule 18 を追加 (15 ルールから 16 ルールに拡張、ISSUE 本文の番号は古く実際は 17 → 18) → SKILL.md:96 (heading) + :237-242 (Rule 18 本文 + sqlOrderValidator 補足) ✓
- [x] §「完了基準」 Step 6 出力フォーマットの self-check 表に Rule 18 行を追加 → SKILL.md:368 (self-check 表) ✓

### #608 修正方針 (ISSUE 本文 §修正方針)

- [x] §「必須カバレッジ」 行ありパターン / 行なしパターン / 境界条件 → SKILL.md:88 以下 (3 バリエーション列挙) ✓
- [x] §「NOT NULL 制約と INSERT 順序の確認指針」 → SKILL.md:94 (NOT NULL × INSERT 順序の確認指針) ✓
- [x] §「Step 3 self-check に追加 Rule 16 (新規)」 → 実際は Rule 18 として実装 (Rule 16/17 は #619 / #631 で既使用済) ✓

### Sonnet 独立レビュー指摘の解消

- [x] S1 (Step 5.2 heading から Rule 18 が抜け落ち、機械検出対象外が伝わりにくい) → SKILL.md:279 heading に「Rule 18 は AI 目視」追記 ✓
- [x] N1 (Rule 18 に sqlOrderValidator (#632) との補完関係の明示なし) → SKILL.md:241-242 に補足 1 行追記、#632 導入後の継続活用も明記 ✓
- [x] S2 (CLAUDE.md の `/create-flow` 説明が「14 観点」「6 件」と旧記述、本 PR で巻き込み修正) → CLAUDE.md:25 を「10 観点 + 18 ルール」に整合更新 ✓

### スコープ整合

- [x] schema 変更なし → schemas/ 無変更 ✓
- [x] `/review-flow` (`.claude/skills/review-flow/SKILL.md`) は本 PR スコープ外 → 無変更 ✓

## レビューで特に見てほしい箇所

1. **CLAUDE.md 修正の妥当性** — Sonnet 1 回目レビューで「スコープ外だが同 PR でまとめて修正が望ましい」とされた S2 を本 PR に巻き込み修正。ルール表記の整合は本 ISSUE の趣旨と一致するため許容範囲と判断
2. **Rule 18 の sqlOrderValidator (#632) 関係表現** — 「導入されるまで主要 catch、導入後も値レベル fixture 不足は継続担保」の住み分け
3. **ルール番号統一の最終確認** — description / Step 3 heading / Step 6 / 末尾 / self-check 表すべて 18 で一貫しているか

## テスト

- Vitest: 該当なし (Skill ドキュメント + CLAUDE.md のみ)
- Playwright: 該当なし
- MCP E2E: 該当なし

## UI 影響 / AI smoke test

- [ ] UI 影響あり (AI が chrome-devtools MCP / Playwright で smoke test 実施済み)
- [x] UI 影響なし (auto テスト pass のみ)

ドキュメント変更のみ。実コード変更なし。

## spec 側の不足点 / 提案

N/A。Phase 2 評価レポート §フォローアップ (c) で既に提案された内容を実装。

## レビュー担当への申し送り

### Phase 4 前提整備 (位置付け)

Phase 3 評価レポート §Phase 4 移行判断 で「(β) #608 testScenarios fixture バリエーション網羅 → Phase 4 着手前に解消が望ましい」と整理済。本 PR で (β) を解消。

### sqlOrderValidator (#632) との関係

#632 は静的検出機構として将来導入予定 (設計者承認動線が必要)。本 PR の Rule 18 は #632 が導入されるまでの動的検出 fallback として機能する。#632 導入後も「validator では届かない値レベルパターン」の動的検出として継続活用される (Rule 18 末尾に明記)。

### 共通の盲点を疑ってほしい具体ポイント

- **Codex 出力の半角カナ混入**: memory `feedback_codex_japanese_string_mojibake.md` 既知。`grep -P '[ｦ-ﾟ]' .claude/skills/create-flow/SKILL.md CLAUDE.md` 実施済 (検出 0)
- **PR description 自己申告 file:line のズレ**: memory `feedback_pr_self_report_line_numbers.md` 既知。修正 commit `f931210` 後に Opus が grep で実測値再計算済

🤖 Generated with [Claude Code](https://claude.com/claude-code)

