### PR TITLE
fix(validator): identifierScope に @error onRollback 専用 ambient を追加 — 修正方針 B (#612)

### DIFF
--- a/designer/src/schemas/identifierScope.test.ts
+++ b/designer/src/schemas/identifierScope.test.ts
@@ -333,6 +333,8 @@ describe("checkIdentifierScopes - TransactionScopeStep onRollback @error ambient
     expect(errorIssues[0].code).toBe("UNKNOWN_IDENTIFIER");
   });
 
+  // ケース C: walkSteps が onRollback 内の nested step (branch.condition / 内部 return.bodyExpression)
+  // にも onRollbackKnown を再帰継承することを確認
   it("inherits @error inside nested onRollback steps", () => {
     const issues = checkIdentifierScopes(makeGroup({
       actions: [{

--- a/designer/src/schemas/identifierScope.test.ts
+++ b/designer/src/schemas/identifierScope.test.ts
@@ -300,6 +300,64 @@ describe("checkIdentifierScopes — 組み込み関数 BUILTIN_AMBIENTS", () => 
   });
 });
 
+describe("checkIdentifierScopes - TransactionScopeStep onRollback @error ambient", () => {
+  it("allows @error inside transactionScope.onRollback", () => {
+    const issues = checkIdentifierScopes(makeGroup({
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "tx", kind: "transactionScope", description: "",
+          steps: [
+            { id: "s1", kind: "compute", description: "", expression: "1", outputBinding: "value" },
+          ],
+          onRollback: [
+            { id: "rb1", kind: "return", description: "", bodyExpression: "{ message: @error.message }" },
+          ],
+        }],
+      }],
+    }));
+    expect(issues.filter((i) => i.identifier === "error")).toHaveLength(0);
+  });
+
+  it("reports @error outside transactionScope.onRollback", () => {
+    const issues = checkIdentifierScopes(makeGroup({
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [
+          { id: "s1", kind: "return", description: "", bodyExpression: "{ message: @error.message }" },
+        ],
+      }],
+    }));
+    const errorIssues = issues.filter((i) => i.identifier === "error");
+    expect(errorIssues).toHaveLength(1);
+    expect(errorIssues[0].code).toBe("UNKNOWN_IDENTIFIER");
+  });
+
+  it("inherits @error inside nested onRollback steps", () => {
+    const issues = checkIdentifierScopes(makeGroup({
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "tx", kind: "transactionScope", description: "",
+          steps: [
+            { id: "s1", kind: "compute", description: "", expression: "1", outputBinding: "value" },
+          ],
+          onRollback: [{
+            id: "branch", kind: "branch", description: "",
+            branches: [{
+              condition: "@error.code == 'STOCK_SHORTAGE'",
+              steps: [
+                { id: "rb1", kind: "return", description: "", bodyExpression: "{ code: @error.code }" },
+              ],
+            }],
+          }],
+        }],
+      }],
+    }));
+    expect(issues.filter((i) => i.identifier === "error")).toHaveLength(0);
+  });
+});
+
 describe("checkIdentifierScopes — サンプル (docs/sample-project/process-flows/*.json)", () => {
   const files = readdirSync(samplesDir).filter((f) => f.endsWith(".json"));
   for (const f of files) {

--- a/designer/src/schemas/identifierScope.ts
+++ b/designer/src/schemas/identifierScope.ts
@@ -161,7 +161,10 @@ function walkSteps(
     if (step.kind === "transactionScope") {
       walkSteps(step.steps, `${path}.steps`, known, loopItems, issues);
       if (step.onCommit) walkSteps(step.onCommit, `${path}.onCommit`, known, loopItems, issues);
-      if (step.onRollback) walkSteps(step.onRollback, `${path}.onRollback`, known, loopItems, issues);
+      if (step.onRollback) {
+        const onRollbackKnown = new Set([...known, "error"]);
+        walkSteps(step.onRollback, `${path}.onRollback`, onRollbackKnown, loopItems, issues);
+      }
     }
     if (step.kind === "workflow") {
       if (step.onApproved) walkSteps(step.onApproved, `${path}.onApproved`, known, loopItems, issues);

--- a/docs/spec/process-flow-transaction.md
+++ b/docs/spec/process-flow-transaction.md
@@ -109,6 +109,12 @@ TX が rollback された**後**に実行する step 列。任意・補償処理
 
 `onRollback` の step は **TX の外** で実行されるため、ここでの失敗は元の rollback を撤回しない。
 
+#### `@error` ambient
+
+`onRollback[]` 内の step では、rollback の原因を表す暗黙変数 `@error` を参照できる。`@error` は `onRollback[]` 専用 ambient であり、`transactionScope.steps[]`、`onCommit[]`、transactionScope 外の root steps から参照した場合は `UNKNOWN_IDENTIFIER` として扱う。
+
+`@error` の型と具体的なフィールドは処理フローエンジン側で定義する。本バリデータは識別子 `error` がそのスコープで参照可能かだけを検証し、型検証は行わない。
+
 ## §3 既存 `StepBaseProps.txBoundary` との関係
 
 両者は **共存** する。役割は明確に分かれる:


### PR DESCRIPTION
## 関連

- Closes #612
- 仕様: 修正後追記 — docs/spec/process-flow-transaction.md:112-116 §「`@error` 暗黙変数 (onRollback 専用、#612)」
- 関連: Phase 3 子 0a #606 / PR #613 で発覚した既存 3 件誤検出
- 関連: Phase 3 評価レポート §フォローアップ (α) — Phase 4 前提整備として位置付け

## 概要

`identifierScope.ts` の `BUILTIN_AMBIENTS` に `error` が含まれず、`transactionScope.onRollback` 配下で `@error` を参照すると `UNKNOWN_IDENTIFIER` で誤検出される問題を、設計者確定方針 **候補 B (onRollback 専用スコープ)** で解消する。`@error` は onRollback 内のみ参照可能、外部からの参照は引き続き UNKNOWN_IDENTIFIER で検出される (ambient 漏洩なし、検査精度維持)。

## 主な変更

- `identifierScope.ts` の transactionScope ハンドリングで onRollback walk 時のみ `onRollbackKnown = new Set([...known, "error"])` を渡す
- `onCommit` / `onAbort` 等は従来の `known` を維持 (`@error` は onRollback 専用)
- `identifierScope.test.ts` に 3 ケース追加 (ケース A/B/C: onRollback 内 OK / 外で UNKNOWN_IDENTIFIER / nested 継承 OK)
- `docs/spec/process-flow-transaction.md` に `@error` 暗黙変数仕様セクションを追記

## 仕様逐条突合 (自己申告、Codex 出力後 Opus 実測)

### #612 完了基準

- [x] §「採用候補に応じた実装」 候補 B (onRollback 専用スコープ) → identifierScope.ts:161-167 (`onRollbackKnown` 専用 set) ✓
- [x] §「修正後 finance flow で UNKNOWN_IDENTIFIER 0 件」 → validate-dogfood 実行で finance flow `@error` 誤検出 3 件 → 0 件 ✓
- [x] §「identifierScope.test.ts に該当ケースのテスト追加」 → identifierScope.test.ts:303-360 (3 ケース、33 passed) ✓
- [x] §「仕様書に `@error` の暗黙変数仕様を明記」 → docs/spec/process-flow-transaction.md:112-116 (注: ISSUE 指定の `process-flow-execution-semantics.md` 不在のため最も近い既存 spec ファイルに追記) ✓

### スコープ整合

- [x] §「採用候補」 候補 B 採用 (候補 A: BUILTIN_AMBIENTS 全体追加は不採用 — onRollback 外の誤参照を検出できなくなるため) ✓
- [x] schema 変更なし → schemas/ 無変更 ✓

## レビューで特に見てほしい箇所

1. **候補 B 実装の正確性** — onRollback 専用スコープが他のハンドラ (onCommit / onAbort 等) に漏洩していないか
2. **テストケース C (nested onRollback) の継承** — `onRollback[0].onError` のような nested step でも `@error` がスコープに継承されているか
3. **spec 追記場所の妥当性** — `process-flow-execution-semantics.md` が存在しなかったため `process-flow-transaction.md` に追記。transactionScope 仕様の一部として配置するのが妥当か
4. **`@error` の値構造未指定** — フロー側 validator は識別子の有無のみ検証する設計判断

## テスト

- Vitest: 33 件 pass (新規 3 件 — identifierScope.test.ts に `@error` ケース A/B/C)
- Playwright: 該当なし (validator 単体)
- MCP E2E: 該当なし

## UI 影響 / AI smoke test

- [ ] UI 影響あり (AI が chrome-devtools MCP / Playwright で smoke test 実施済み)
- [x] UI 影響なし (auto テスト pass のみ)

## spec 側の不足点 / 提案

ISSUE 本文で指定された `docs/spec/process-flow-execution-semantics.md` が現状リポジトリに存在しないため、最も近い既存 spec `process-flow-transaction.md` に追記。将来 `process-flow-execution-semantics.md` が新設される場合、本セクションの再配置を検討する余地あり (本 PR スコープ外)。

## レビュー担当への申し送り

### 候補 A vs B vs C の判断経緯

- **候補 A (BUILTIN_AMBIENTS に追加)**: 不採用。`@error` がどこでも参照可能になり、onRollback 外での誤参照を検出できなくなる
- **候補 B (onRollback 専用スコープ)**: 採用。スコープ正確性を維持、minimal 実装
- **候補 C (schema で context.ambientVariables 推奨)**: 不採用。全サンプル更新が必要、暗黙性が失われる

### Phase 4 前提整備 (位置付け)

Phase 3 評価レポート §Phase 4 移行判断 で「(α) #612 → Phase 4 着手前に解消が望ましい」と整理済。本 PR で (α) を解消。

### 共通の盲点を疑ってほしい具体ポイント

- **Codex 出力の半角カナ混入**: memory `feedback_codex_japanese_string_mojibake.md` 既知。全変更ファイルで検出 0
- **PR description 自己申告 file:line のズレ**: memory `feedback_pr_self_report_line_numbers.md` 既知。Codex 完了報告後の自己申告値、独立レビューで再実測想定

🤖 Generated with [Claude Code](https://claude.com/claude-code)
