### PR TITLE
improve(validator): v1 型バリデータ群を v3 TS 型に同期 (#610)

### DIFF
--- a/designer/src/schemas/conventionsValidator.ts
+++ b/designer/src/schemas/conventionsValidator.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * @conv.msg.* / @conv.regex.* / @conv.limit.* 参照の検証 (#151-A / #261 残)。
  *
@@ -11,10 +10,9 @@ import type {
   ProcessFlow,
   Step,
   ActionDefinition,
-  ValidationStep,
-  LoopStep,
-} from "../types/action";
-import type { Conventions } from "../types/v3";
+  Conventions,
+} from "../types/v3";
+import { isBuiltinStep } from "./stepGuards";
 
 /**
  * 既存呼び出し側互換のため `ConventionsCatalog` 名で v3 `Conventions` を再エクスポート。
@@ -258,12 +256,13 @@ function walkSteps(
     const path = `${basePath}[${i}]`;
     checkStep(step, path, catalog, issues);
 
-    if ("subSteps" in step && step.subSteps) walkSteps(step.subSteps, `${path}.subSteps`, catalog, issues);
+    // 拡張 step は nested 走査スキップ (固有プロパティは config 内に閉じる仕様)
+    if (!isBuiltinStep(step)) return;
     if (step.kind === "branch") {
       step.branches.forEach((b, bi) => walkSteps(b.steps, `${path}.branches[${bi}].steps`, catalog, issues));
       if (step.elseBranch) walkSteps(step.elseBranch.steps, `${path}.elseBranch.steps`, catalog, issues);
     }
-    if (step.kind === "loop") walkSteps((step as LoopStep).steps, `${path}.steps`, catalog, issues);
+    if (step.kind === "loop") walkSteps(step.steps, `${path}.steps`, catalog, issues);
     if (step.kind === "transactionScope") {
       walkSteps(step.steps, `${path}.steps`, catalog, issues);
       if (step.onCommit) walkSteps(step.onCommit, `${path}.onCommit`, catalog, issues);
@@ -302,29 +301,31 @@ function checkValue(src: string, path: string, catalog: ConventionsCatalog, issu
 function checkStep(step: Step, path: string, catalog: ConventionsCatalog, issues: ConventionIssue[]): void {
   const texts: Array<{ src: string; field: string }> = [];
 
+  // StepBaseProps 共通フィールド: kind に関係なく全 step variant で検査 (拡張 step / v1 fixture も含む)
   if (step.description) texts.push({ src: step.description, field: "description" });
   if (step.runIf) texts.push({ src: step.runIf, field: "runIf" });
 
-  if (step.kind === "compute") texts.push({ src: step.expression, field: "expression" });
-  if (step.kind === "return" && step.bodyExpression) texts.push({ src: step.bodyExpression, field: "bodyExpression" });
-  if (step.kind === "validation") {
-    const vStep = step as ValidationStep;
-    if (vStep.conditions) texts.push({ src: vStep.conditions, field: "conditions" });
-    (vStep.rules ?? []).forEach((r, ri) => {
-      if (r.condition) texts.push({ src: r.condition, field: `rules[${ri}].condition` });
-      if (r.message) texts.push({ src: r.message, field: `rules[${ri}].message` });
-      if (r.pattern) texts.push({ src: r.pattern, field: `rules[${ri}].pattern` });
-    });
-    if (vStep.inlineBranch?.ngBodyExpression) {
-      texts.push({ src: vStep.inlineBranch.ngBodyExpression, field: "inlineBranch.ngBodyExpression" });
+  // kind 固有フィールドは組み込み step に絞る (拡張 step の固有 property は config 内に閉じる仕様)
+  if (isBuiltinStep(step)) {
+    if (step.kind === "compute") texts.push({ src: step.expression, field: "expression" });
+    if (step.kind === "return" && step.bodyExpression) texts.push({ src: step.bodyExpression, field: "bodyExpression" });
+    if (step.kind === "validation") {
+      if (step.conditions) texts.push({ src: step.conditions, field: "conditions" });
+      (step.rules ?? []).forEach((r, ri) => {
+        if (r.condition) texts.push({ src: r.condition, field: `rules[${ri}].condition` });
+        if (r.message) texts.push({ src: r.message, field: `rules[${ri}].message` });
+        if (r.pattern) texts.push({ src: r.pattern, field: `rules[${ri}].pattern` });
+      });
+      if (step.inlineBranch?.ngBodyExpression) {
+        texts.push({ src: step.inlineBranch.ngBodyExpression, field: "inlineBranch.ngBodyExpression" });
+      }
     }
-  }
-  if (step.kind === "dbAccess") {
-    if (step.sql) texts.push({ src: step.sql, field: "sql" });
-  }
-  if (step.kind === "externalSystem") {
-    if (step.protocol) texts.push({ src: step.protocol, field: "protocol" });
-    if (step.httpCall?.body) texts.push({ src: step.httpCall.body, field: "httpCall.body" });
+    if (step.kind === "dbAccess") {
+      if (step.sql) texts.push({ src: step.sql, field: "sql" });
+    }
+    if (step.kind === "externalSystem") {
+      if (step.httpCall?.body) texts.push({ src: step.httpCall.body, field: "httpCall.body" });
+    }
   }
 
   for (const { src, field } of texts) {

--- a/designer/src/schemas/identifierScope.test.ts
+++ b/designer/src/schemas/identifierScope.test.ts
@@ -82,8 +82,8 @@ describe("checkIdentifierScopes — outputBinding が後続ステップで参照
         id: "a1", name: "f", trigger: "click",
         inputs: [{ name: "x", type: "number" }],
         steps: [
-          { id: "s1", kind: "compute", description: "", expression: "@x * 2", outputBinding: "doubled" },
-          { id: "s2", kind: "compute", description: "", expression: "@doubled + 1", outputBinding: "r" },
+          { id: "s1", kind: "compute", description: "", expression: "@x * 2", outputBinding: { name: "doubled" } },
+          { id: "s2", kind: "compute", description: "", expression: "@doubled + 1", outputBinding: { name: "r" } },
         ],
       }],
     }));
@@ -94,11 +94,11 @@ describe("checkIdentifierScopes — outputBinding が後続ステップで参照
 describe("checkIdentifierScopes — ambient 変数", () => {
   it("ambientVariables で宣言されれば参照 OK", () => {
     const issues = checkIdentifierScopes(makeGroup({
-      ambientVariables: [{ name: "requestId", type: "string" }],
+      context: { ambientVariables: [{ name: "requestId", type: "string" }] },
       actions: [{
         id: "a1", name: "f", trigger: "click",
         steps: [
-          { id: "s1", kind: "externalSystem", description: "", systemName: "x",
+          { id: "s1", kind: "externalSystem", description: "", systemRef: "x",
             idempotencyKey: "key-@requestId" },
         ],
       }],
@@ -157,7 +157,7 @@ describe("checkIdentifierScopes — ValidationStep.fieldErrorsVar", () => {
           {
             id: "s1", kind: "validation", description: "", conditions: "",
             rules: [{ field: "x", type: "required" }],
-            inlineBranch: { ok: "ok", ng: "ng", ngBodyExpression: "{ errors: @fieldErrors }" },
+            inlineBranch: { ok: [], ng: [], ngBodyExpression: "{ errors: @fieldErrors }" },
           },
         ],
       }],
@@ -399,7 +399,7 @@ describe("checkIdentifierScopes — WorkflowStep result handlers", () => {
       actions: [{
         id: "a1", name: "f", trigger: "click",
         steps: [
-          { id: "s1", kind: "compute", description: "", expression: "'req-1'", outputBinding: "requestId" },
+          { id: "s1", kind: "compute", description: "", expression: "'req-1'", outputBinding: { name: "requestId" } },
           {
             id: "wf", kind: "workflow", description: "",
             pattern: "approval-sequential", approvers: [],
@@ -420,9 +420,9 @@ describe("checkIdentifierScopes — WorkflowStep result handlers", () => {
         steps: [{
           id: "wf", kind: "workflow", description: "",
           pattern: "approval-sequential", approvers: [],
-          outputBinding: "workflowResult",
+          outputBinding: { name: "workflowResult" },
           onApproved: [
-            { id: "s1", kind: "compute", description: "", expression: "@workflowResult.status", outputBinding: "status" },
+            { id: "s1", kind: "compute", description: "", expression: "@workflowResult.status", outputBinding: { name: "status" } },
           ],
         }],
       }],
@@ -493,7 +493,7 @@ describe("checkIdentifierScopes — ValidationStep inlineBranch", () => {
       actions: [{
         id: "a1", name: "f", trigger: "click",
         steps: [
-          { id: "s0", kind: "compute", description: "", expression: "'r'", outputBinding: "requestId" },
+          { id: "s0", kind: "compute", description: "", expression: "'r'", outputBinding: { name: "requestId" } },
           {
             id: "v1", kind: "validation", description: "",
             rules: [],
@@ -505,23 +505,6 @@ describe("checkIdentifierScopes — ValidationStep inlineBranch", () => {
             },
           },
         ],
-      }],
-    }));
-    expect(issues).toHaveLength(0);
-  });
-
-  it("inlineBranch が string (v1 旧形式) のときは walk を skip", () => {
-    const issues = checkIdentifierScopes(makeGroup({
-      actions: [{
-        id: "a1", name: "f", trigger: "click",
-        steps: [{
-          id: "v1", kind: "validation", description: "",
-          rules: [],
-          inlineBranch: {
-            ok: "次のステップへ進む",
-            ng: "400 入力値エラーを返す",
-          } as never,
-        }],
       }],
     }));
     expect(issues).toHaveLength(0);

--- a/designer/src/schemas/identifierScope.ts
+++ b/designer/src/schemas/identifierScope.ts
@@ -1,12 +1,11 @@
-// @ts-nocheck
 /**
  * 処理フロー @ 参照の識別子スコープ検証 (#261 残タスク)。
  *
  * 全ての @identifier が以下のいずれかに存在するかを検査:
  * - ActionDefinition.inputs[].name
  * - ActionDefinition.outputs[].name
- * - ProcessFlow.ambientVariables[].name
- * - 先行ステップの StepBase.outputBinding (string or object.name)
+ * - ProcessFlow.context.ambientVariables[].name
+ * - 先行ステップの StepBase.outputBinding.name
  * - LoopStep.collectionItemName (ループ配下のスコープのみ)
  * - ValidationStep.fieldErrorsVar の宣言
  * - BUILTIN_AMBIENTS (組み込み関数・グローバル識別子)
@@ -18,10 +17,9 @@ import type {
   ProcessFlow,
   Step,
   OutputBinding,
-  ValidationStep,
-  LoopStep,
   StructuredField,
-} from "../types/action";
+} from "../types/v3";
+import { isBuiltinStep } from "./stepGuards";
 
 export interface IdentifierIssue {
   path: string;
@@ -62,13 +60,11 @@ function extractIdentifiers(src: string): string[] {
 }
 
 function getBindingName(binding: OutputBinding | undefined): string | null {
-  if (!binding) return null;
-  if (typeof binding === "string") return binding;
-  return binding.name;
+  return binding?.name ?? null;
 }
 
 function fieldNames(fields: StructuredField[] | undefined): string[] {
-  return fields?.map((f) => f.name) ?? [];
+  return fields?.map((f) => f.name as string) ?? [];
 }
 
 /**
@@ -77,10 +73,7 @@ function fieldNames(fields: StructuredField[] | undefined): string[] {
  */
 export function checkIdentifierScopes(group: ProcessFlow): IdentifierIssue[] {
   const issues: IdentifierIssue[] = [];
-  // v1 (top-level ambientVariables) と v3 (context.ambientVariables) の両形式に対応
-  const ambientFields =
-    (group as { context?: { ambientVariables?: StructuredField[] } }).context?.ambientVariables
-    ?? group.ambientVariables;
+  const ambientFields = group.context?.ambientVariables;
   const ambientNames = new Set(fieldNames(ambientFields));
 
   group.actions.forEach((action, ai) => {
@@ -125,13 +118,16 @@ function walkSteps(
     const available = new Set<string>([...known, ...loopItems]);
     checkStep(step, path, available, issues);
 
-    // この step の outputBinding を known に追加 (後続ステップから参照可能に)
+    // outputBinding は StepBaseProps 共通フィールド。拡張 step も継承するため kind 関係なく known に追加
     const bindName = getBindingName(step.outputBinding);
     if (bindName) known.add(bindName);
+
+    // 以下は組み込み step variant 固有の処理 (拡張 step は config 内の固有プロパティを持つため除外)
+    if (!isBuiltinStep(step)) return;
+
     // ValidationStep の fieldErrorsVar も known に
     if (step.kind === "validation") {
-      const vStep = step as ValidationStep;
-      if (vStep.fieldErrorsVar) known.add(vStep.fieldErrorsVar);
+      if (step.fieldErrorsVar) known.add(step.fieldErrorsVar);
       else known.add("fieldErrors"); // 既定
     }
     // ReturnStep は新変数を作らない
@@ -140,9 +136,6 @@ function walkSteps(
     // outputBinding は親スコープからも参照可能とする -- accumulate/push を
     // ループ外で参照するパターンを許容するため、現時点では permissive)。
     // loopItems はループ配下のみ有効 (ループ外に leak させない)。
-    if ("subSteps" in step && step.subSteps) {
-      walkSteps(step.subSteps, `${path}.subSteps`, known, loopItems, issues);
-    }
     if (step.kind === "branch") {
       step.branches.forEach((b, bi) => {
         walkSteps(b.steps, `${path}.branches[${bi}].steps`, known, loopItems, issues);
@@ -152,11 +145,10 @@ function walkSteps(
       }
     }
     if (step.kind === "loop") {
-      const loopStep = step as LoopStep;
-      const childLoopItems = loopStep.collectionItemName
-        ? [...loopItems, loopStep.collectionItemName]
+      const childLoopItems = step.collectionItemName
+        ? [...loopItems, step.collectionItemName]
         : loopItems;
-      walkSteps(loopStep.steps, `${path}.steps`, known, childLoopItems, issues);
+      walkSteps(step.steps, `${path}.steps`, known, childLoopItems, issues);
     }
     if (step.kind === "transactionScope") {
       walkSteps(step.steps, `${path}.steps`, known, loopItems, issues);
@@ -172,13 +164,8 @@ function walkSteps(
       if (step.onTimeout) walkSteps(step.onTimeout, `${path}.onTimeout`, known, loopItems, issues);
     }
     if (step.kind === "validation" && step.inlineBranch) {
-      // v1 旧形式は string、v3 schema は array of Step。Array.isArray で skip。
-      if (Array.isArray(step.inlineBranch.ok)) {
-        walkSteps(step.inlineBranch.ok, `${path}.inlineBranch.ok`, known, loopItems, issues);
-      }
-      if (Array.isArray(step.inlineBranch.ng)) {
-        walkSteps(step.inlineBranch.ng, `${path}.inlineBranch.ng`, known, loopItems, issues);
-      }
+      walkSteps(step.inlineBranch.ok, `${path}.inlineBranch.ok`, known, loopItems, issues);
+      walkSteps(step.inlineBranch.ng, `${path}.inlineBranch.ng`, known, loopItems, issues);
     }
     if (step.kind === "externalSystem") {
       Object.entries(step.outcomes ?? {}).forEach(([k, spec]) => {
@@ -192,12 +179,13 @@ function walkSteps(
 
 /** 1 step の式フィールドを全走査、@ 識別子を known と突合 */
 function checkStep(step: Step, path: string, availableIn: Set<string>, issues: IdentifierIssue[]): void {
+  // 拡張 step の固有 property は config に閉じるため、組み込み step に絞って検査
+  if (!isBuiltinStep(step)) return;
   // ValidationStep は自分自身の rules[] 評価結果 fieldErrors を同じ step の ngBodyExpression
   // で使う (同時に可視) ので、available に足してから式チェック
   const available = new Set(availableIn);
   if (step.kind === "validation") {
-    const vStep = step as ValidationStep;
-    available.add(vStep.fieldErrorsVar ?? "fieldErrors");
+    available.add(step.fieldErrorsVar ?? "fieldErrors");
   }
 
   const expressions: Array<{ src: string; field: string }> = [];
@@ -222,8 +210,8 @@ function checkStep(step: Step, path: string, availableIn: Set<string>, issues: I
   }
   if (step.kind === "branch") {
     step.branches.forEach((b, bi) => {
-      if (typeof b.condition === "string") {
-        expressions.push({ src: b.condition, field: `branches[${bi}].condition` });
+      if (b.condition.kind === "expression") {
+        expressions.push({ src: b.condition.expression, field: `branches[${bi}].condition.expression` });
       }
     });
   }
@@ -237,7 +225,6 @@ function checkStep(step: Step, path: string, availableIn: Set<string>, issues: I
     if (step.fields) expressions.push({ src: step.fields, field: "fields" });
   }
   if (step.kind === "externalSystem") {
-    if (step.protocol) expressions.push({ src: step.protocol, field: "protocol" });
     if (step.idempotencyKey) expressions.push({ src: step.idempotencyKey, field: "idempotencyKey" });
     if (step.httpCall?.path) expressions.push({ src: step.httpCall.path, field: "httpCall.path" });
     if (step.httpCall?.body) expressions.push({ src: step.httpCall.body, field: "httpCall.body" });
@@ -247,11 +234,6 @@ function checkStep(step: Step, path: string, availableIn: Set<string>, issues: I
     Object.entries(step.headers ?? {}).forEach(([k, v]) => {
       expressions.push({ src: v, field: `headers.${k}` });
     });
-    Object.entries((step as { argumentMapping?: Record<string, string> }).argumentMapping ?? {}).forEach(
-      ([k, v]) => {
-        expressions.push({ src: v, field: `argumentMapping.${k}` });
-      },
-    );
   }
   if (step.kind === "commonProcess" && step.argumentMapping) {
     Object.entries(step.argumentMapping).forEach(([k, v]) => {
@@ -260,8 +242,9 @@ function checkStep(step: Step, path: string, availableIn: Set<string>, issues: I
   }
 
   // outputBinding.initialValue: 文字列式のみ識別子検査 (JSON 値なら skip)
-  if (typeof step.outputBinding === "object" && typeof step.outputBinding?.initialValue === "string" && step.outputBinding.initialValue) {
-    expressions.push({ src: step.outputBinding.initialValue, field: "outputBinding.initialValue" });
+  const initialValue = step.outputBinding?.initialValue;
+  if (typeof initialValue === "string" && initialValue) {
+    expressions.push({ src: initialValue, field: "outputBinding.initialValue" });
   }
 
   for (const { src, field } of expressions) {

--- a/designer/src/schemas/referentialIntegrity.test.ts
+++ b/designer/src/schemas/referentialIntegrity.test.ts
@@ -16,13 +16,13 @@ function makeGroup(partial: Partial<ProcessFlow>): ProcessFlow {
 }
 
 describe("checkReferentialIntegrity — responseRef", () => {
-  it("未定義 responseRef を検出", () => {
+  it("未定義 responseId を検出", () => {
     const issues = checkReferentialIntegrity(makeGroup({
       actions: [{
         id: "a1", name: "f", trigger: "click",
         responses: [{ id: "201-ok", status: 201 }],
         steps: [
-          { id: "s1", kind: "return", description: "", responseRef: "999-missing" },
+          { id: "s1", kind: "return", description: "", responseId: "999-missing" },
         ],
       }],
     }));
@@ -31,35 +31,35 @@ describe("checkReferentialIntegrity — responseRef", () => {
     expect(issues[0].value).toBe("999-missing");
   });
 
-  it("定義済み responseRef は問題なし", () => {
+  it("定義済み responseId は問題なし", () => {
     const issues = checkReferentialIntegrity(makeGroup({
       actions: [{
         id: "a1", name: "f", trigger: "click",
         responses: [{ id: "201-ok", status: 201 }],
-        steps: [{ id: "s1", kind: "return", description: "", responseRef: "201-ok" }],
+        steps: [{ id: "s1", kind: "return", description: "", responseId: "201-ok" }],
       }],
     }));
     expect(issues).toHaveLength(0);
   });
 
-  it("ValidationStep.inlineBranch.ngResponseRef も検査", () => {
+  it("ValidationStep.inlineBranch.ngResponseId も検査", () => {
     const issues = checkReferentialIntegrity(makeGroup({
       actions: [{
         id: "a1", name: "f", trigger: "click",
         responses: [],
         steps: [{
           id: "s1", kind: "validation", description: "", conditions: "",
-          inlineBranch: { ok: "ok", ng: "ng", ngResponseRef: "400-not-defined" },
+          inlineBranch: { ok: [], ng: [], ngResponseId: "400-not-defined" },
         }],
       }],
     }));
     expect(issues.some((i) => i.code === "UNKNOWN_RESPONSE_REF")).toBe(true);
   });
 
-  it("errorCatalog.responseRef も検査", () => {
+  it("errorCatalog.responseId も検査", () => {
     const issues = checkReferentialIntegrity(makeGroup({
       context: { catalogs: { errors: {
-        STOCK_SHORTAGE: { responseRef: "409-missing" },
+        STOCK_SHORTAGE: { responseId: "409-missing" },
       } } },
       actions: [{
         id: "a1", name: "f", trigger: "click",
@@ -128,7 +128,7 @@ describe("checkReferentialIntegrity — ネスト走査", () => {
         responses: [{ id: "200-ok", status: 200 }],
         steps: [{
           id: "lp", kind: "loop", description: "", loopKind: "count",
-          steps: [{ id: "ret", kind: "return", description: "", responseRef: "missing" }],
+          steps: [{ id: "ret", kind: "return", description: "", responseId: "missing" }],
         }],
       }],
     }));
@@ -147,7 +147,7 @@ describe("checkReferentialIntegrity — ネスト走査", () => {
             failure: {
               action: "continue",
               sideEffects: [
-                { id: "ret", kind: "return", description: "", responseRef: "missing" },
+                { id: "ret", kind: "return", description: "", responseId: "missing" },
               ],
             },
           },

--- a/designer/src/schemas/referentialIntegrity.ts
+++ b/designer/src/schemas/referentialIntegrity.ts
@@ -1,41 +1,42 @@
-// @ts-nocheck
 /**
- * 蜃ｦ逅・ヵ繝ｭ繝ｼ JSON 縺ｮ繧ｯ繝ｭ繧ｹ繝ｪ繝輔ぃ繝ｬ繝ｳ繧ｹ讀懆ｨｼ (#253)縲・
+ * 処理フロー JSON のクロスリファレンス検証 (#253)。
  *
- * JSON Schema 2020-12 縺ｧ縺ｯ cross-reference (蛻･繝輔ぅ繝ｼ繝ｫ繝峨↓蟄伜惠縺吶ｋ蛟､縺ｸ縺ｮ蜿ら・讀懆ｨｼ) 縺ｯ
- * $dynamicRef 繧帝ｧ・ｽｿ縺励※繧りｪｭ縺ｿ縺ｫ縺上￥縺ｪ繧九◆繧√√せ繧ｭ繝ｼ繝槫､悶・繝舌Μ繝・・繧ｿ縺ｨ縺励※螳溯｣・・
+ * JSON Schema 2020-12 では cross-reference (別フィールドに存在する値への参照検証) は
+ * $dynamicRef を駆使しても読みにくくなるため、スキーマ外のバリデータとして実装する。
  *
- * 讀懆ｨｼ縺吶ｋ隕冗ｴ・
- * 1. ReturnStep.responseRef 縺ｯ action.responses[].id 縺ｫ蟄伜惠縺吶ｋ縺薙→
- * 2. ValidationStep.inlineBranch.ngResponseRef 縺ｯ action.responses[].id 縺ｫ蟄伜惠縺吶ｋ縺薙→
- * 3. BranchConditionVariant.errorCode 縺ｯ context.catalogs.errors 縺ｮ繧ｭ繝ｼ縺ｫ蟄伜惠縺吶ｋ縺薙→
- *    (context.catalogs.errors 縺悟ｮ夂ｾｩ縺輔ｌ縺ｦ縺・ｋ蝣ｴ蜷医・縺ｿ)
- * 4. DbAccessStep.affectedRowsCheck.errorCode 繧ょ酔荳・
- * 5. ErrorCatalogEntry.responseRef 縺ｯ action.responses[].id 縺ｫ蟄伜惠縺吶ｋ縺薙→ (context.catalogs.errors 竊・responses)
+ * 検証する観点:
+ * 1. ReturnStep.responseId は action.responses[].id に存在すること
+ * 2. ValidationStep.inlineBranch.ngResponseId は action.responses[].id に存在すること
+ * 3. BranchConditionVariant.errorCode は context.catalogs.errors のキーに存在すること
+ *    (context.catalogs.errors が定義されている場合のみ)
+ * 4. DbAccessStep.affectedRowsCheck.errorCode も同上
+ * 5. ErrorCatalogEntry.responseId は action.responses[].id に存在すること
+ *    (context.catalogs.errors → responses の逆参照)
  */
-import type { ProcessFlow, Step } from "../types/action";
+import type { ProcessFlow, Step } from "../types/v3";
 import type { LoadedExtensions } from "./loadExtensions";
+import { isBuiltinStep } from "./stepGuards";
 
 export interface IntegrityIssue {
-  /** 繝峨ャ繝医ヱ繧ｹ (萓・ "actions[0].steps[2].responseRef") */
+  /** ドットパス (例: "actions[0].steps[2].responseRef") */
   path: string;
-  /** 蝠城｡後・隴伜挨蟄・*/
+  /** 問題の識別子 */
   code:
     | "UNKNOWN_RESPONSE_REF"
     | "UNKNOWN_ERROR_CODE"
     | "UNKNOWN_SYSTEM_REF"
     | "UNKNOWN_TYPE_REF"
     | "UNKNOWN_SECRET_REF";
-  /** 蜿ら・縺励ｈ縺・→縺励◆蛟､ */
+  /** 参照しようとした値 */
   value: string;
-  /** 繧ｨ繝ｩ繝ｼ繝｡繝・そ繝ｼ繧ｸ */
+  /** エラーメッセージ */
   message: string;
 }
 
-/** @secret.KEY 縺ｫ繝槭ャ繝・*/
+/** @secret.KEY にマッチ */
 const SECRET_RE = /@secret\.([a-zA-Z_][\w-]*)/g;
 
-/** ProcessFlow 蜈ｨ菴薙・繧ｯ繝ｭ繧ｹ繝ｪ繝輔ぃ繝ｬ繝ｳ繧ｹ讀懆ｨｼ縲らｩｺ驟榊・縺ｪ繧・OK */
+/** ProcessFlow 全体のクロスリファレンス検証。空配列なら OK */
 export function checkReferentialIntegrity(
   group: ProcessFlow,
   extensions?: LoadedExtensions,
@@ -50,7 +51,7 @@ export function checkReferentialIntegrity(
   const secretKeys = new Set(Object.keys(group.context?.catalogs?.secrets ?? {}));
   const hasSecretsCatalog = secretKeys.size > 0;
 
-  // context.catalogs.externalSystems.*.auth.tokenRef 蜀・・ @secret.* 蜿ら・繧呈､懈渊
+  // context.catalogs.externalSystems.*.auth.tokenRef 内の @secret.* 参照を検査
   if (hasSecretsCatalog) {
     Object.entries(group.context?.catalogs?.externalSystems ?? {}).forEach(([k, entry]) => {
       const tok = entry.auth?.tokenRef;
@@ -62,7 +63,7 @@ export function checkReferentialIntegrity(
               path: `context.catalogs.externalSystems.${k}.auth.tokenRef`,
               code: "UNKNOWN_SECRET_REF",
               value: `@secret.${m[1]}`,
-              message: `@secret.${m[1]} 縺・context.catalogs.secrets 縺ｫ蟄伜惠縺励∪縺帙ｓ`,
+              message: `@secret.${m[1]} が context.catalogs.secrets に存在しません`,
             });
           }
         }
@@ -71,34 +72,41 @@ export function checkReferentialIntegrity(
   }
 
   group.actions.forEach((action, ai) => {
-    const responseIds = new Set(
-      (action.responses ?? []).map((r) => r.id).filter((x): x is string => !!x),
+    // r.id は v3 で LocalId brand 型のため、Set<string> として比較するため cast
+    const responseIds = new Set<string>(
+      (action.responses ?? [])
+        .map((r) => r.id as string | undefined)
+        .filter((x): x is string => !!x),
     );
-    // bodySchema.typeRef 縺ｮ蜿ら・讀懈渊
+    // bodySchema.typeRef の参照検査 (v3 BodySchema discriminated union: { typeRef } | { schema })
     (action.responses ?? []).forEach((resp, ri) => {
-      if (resp.bodySchema && typeof resp.bodySchema === "object" && "typeRef" in resp.bodySchema && resp.bodySchema.typeRef) {
-        if (hasExtensions && !typeIds.has(resp.bodySchema.typeRef)) {
-          issues.push({
-            path: `actions[${ai}].responses[${ri}].bodySchema.typeRef`,
-            code: "UNKNOWN_TYPE_REF",
-            value: resp.bodySchema.typeRef,
-            message: `bodySchema.typeRef "${resp.bodySchema.typeRef}" 縺・グローバル extensions responseTypes 縺ｫ蟄伜惠縺励∪縺帙ｓ`,
-          });
-        }
+      const bs = resp.bodySchema;
+      const typeRef =
+        bs && typeof bs === "object" && "typeRef" in bs
+          ? (bs as { typeRef?: string }).typeRef
+          : undefined;
+      if (typeRef && hasExtensions && !typeIds.has(typeRef)) {
+        issues.push({
+          path: `actions[${ai}].responses[${ri}].bodySchema.typeRef`,
+          code: "UNKNOWN_TYPE_REF",
+          value: typeRef,
+          message: `bodySchema.typeRef "${typeRef}" がグローバル extensions responseTypes に存在しません`,
+        });
       }
     });
     walkSteps(action.steps ?? [], `actions[${ai}].steps`, (step, path) => {
       checkStep(step, path, responseIds, errorCodes, hasErrorCatalog, systemIds, hasSystemCatalog, issues, secretKeys, hasSecretsCatalog);
     });
 
-    // context.catalogs.errors -> responses 蜿ら・
+    // context.catalogs.errors -> responses 参照
     Object.entries(group.context?.catalogs?.errors ?? {}).forEach(([key, entry]) => {
-      if (entry.responseRef && !responseIds.has(entry.responseRef)) {
+      const ref = entry.responseId;
+      if (ref && !responseIds.has(ref)) {
         issues.push({
-          path: `context.catalogs.errors.${key}.responseRef (actions[${ai}])`,
+          path: `context.catalogs.errors.${key}.responseId (actions[${ai}])`,
           code: "UNKNOWN_RESPONSE_REF",
-          value: entry.responseRef,
-          message: `context.catalogs.errors.${key}.responseRef "${entry.responseRef}" 縺・action "${action.name}" 縺ｮ responses[].id 縺ｫ蟄伜惠縺励∪縺帙ｓ`,
+          value: ref,
+          message: `context.catalogs.errors.${key}.responseId "${ref}" が action "${action.name}" の responses[].id に存在しません`,
         });
       }
     });
@@ -115,10 +123,9 @@ function walkSteps(
   steps.forEach((step, i) => {
     const path = `${basePath}[${i}]`;
     visit(step, path);
-    // 繝阪せ繝医＠縺・steps 繧呈戟縺､ variant
-    if ("subSteps" in step && step.subSteps) {
-      walkSteps(step.subSteps, `${path}.subSteps`, visit);
-    }
+    // 拡張 step は nested 走査スキップ (固有プロパティは config 内に閉じる仕様)
+    if (!isBuiltinStep(step)) return;
+    // ネストした steps を持つ variant
     if (step.kind === "branch") {
       step.branches.forEach((b, bi) => {
         walkSteps(b.steps, `${path}.branches[${bi}].steps`, visit);
@@ -157,6 +164,8 @@ function checkStep(
   secretKeys?: Set<string>,
   hasSecretsCatalog?: boolean,
 ): void {
+  // 拡張 step の固有 property は config に閉じるため、組み込み step に絞って検査
+  if (!isBuiltinStep(step)) return;
   if (step.kind === "externalSystem" && step.systemRef && hasSystemCatalog) {
     // systemRef に @ を含む場合は動的式 (@identifier による切替) のためスキップ
     if (!step.systemRef.includes("@") && !systemIds.has(step.systemRef)) {
@@ -164,11 +173,11 @@ function checkStep(
         path: `${path}.systemRef`,
         code: "UNKNOWN_SYSTEM_REF",
         value: step.systemRef,
-        message: `ExternalSystemStep.systemRef "${step.systemRef}" 縺・context.catalogs.externalSystems 縺ｫ蟄伜惠縺励∪縺帙ｓ`,
+        message: `ExternalSystemStep.systemRef "${step.systemRef}" が context.catalogs.externalSystems に存在しません`,
       });
     }
   }
-  // step 蛛ｴ auth.tokenRef 縺ｮ @secret.* 蜿ら・繧呈､懈渊
+  // step 側 auth.tokenRef の @secret.* 参照を検査
   if (step.kind === "externalSystem" && step.auth?.tokenRef && hasSecretsCatalog && secretKeys) {
     const tok = step.auth.tokenRef;
     const re = /@secret\.([a-zA-Z_][\w-]*)/g;
@@ -179,27 +188,30 @@ function checkStep(
           path: `${path}.auth.tokenRef`,
           code: "UNKNOWN_SECRET_REF",
           value: `@secret.${m[1]}`,
-          message: `@secret.${m[1]} 縺・context.catalogs.secrets 縺ｫ蟄伜惠縺励∪縺帙ｓ`,
+          message: `@secret.${m[1]} が context.catalogs.secrets に存在しません`,
         });
       }
     }
   }
-  if (step.kind === "return" && step.responseRef && !responseIds.has(step.responseRef)) {
-    issues.push({
-      path: `${path}.responseRef`,
-      code: "UNKNOWN_RESPONSE_REF",
-      value: step.responseRef,
-      message: `ReturnStep.responseRef "${step.responseRef}" 縺・action.responses[].id 縺ｫ蟄伜惠縺励∪縺帙ｓ`,
-    });
-  }
-  if (step.kind === "validation" && step.inlineBranch?.ngResponseRef) {
-    const r = step.inlineBranch.ngResponseRef;
-    if (!responseIds.has(r)) {
+  if (step.kind === "return") {
+    const ref = step.responseId;
+    if (ref && !responseIds.has(ref)) {
       issues.push({
-        path: `${path}.inlineBranch.ngResponseRef`,
+        path: `${path}.responseId`,
         code: "UNKNOWN_RESPONSE_REF",
-        value: r,
-        message: `ValidationStep.inlineBranch.ngResponseRef "${r}" 縺・action.responses[].id 縺ｫ蟄伜惠縺励∪縺帙ｓ`,
+        value: ref,
+        message: `ReturnStep.responseId "${ref}" が action.responses[].id に存在しません`,
+      });
+    }
+  }
+  if (step.kind === "validation" && step.inlineBranch) {
+    const ref = step.inlineBranch.ngResponseId;
+    if (ref && !responseIds.has(ref)) {
+      issues.push({
+        path: `${path}.inlineBranch.ngResponseId`,
+        code: "UNKNOWN_RESPONSE_REF",
+        value: ref,
+        message: `ValidationStep.inlineBranch.ngResponseId "${ref}" が action.responses[].id に存在しません`,
       });
     }
   }
@@ -210,7 +222,7 @@ function checkStep(
         path: `${path}.affectedRowsCheck.errorCode`,
         code: "UNKNOWN_ERROR_CODE",
         value: e,
-        message: `DbAccessStep.affectedRowsCheck.errorCode "${e}" 縺・context.catalogs.errors 縺ｫ蟄伜惠縺励∪縺帙ｓ`,
+        message: `DbAccessStep.affectedRowsCheck.errorCode "${e}" が context.catalogs.errors に存在しません`,
       });
     }
   }
@@ -223,7 +235,7 @@ function checkStep(
             path: `${path}.branches[${bi}].condition.errorCode`,
             code: "UNKNOWN_ERROR_CODE",
             value: c.errorCode,
-            message: `BranchConditionVariant.errorCode "${c.errorCode}" 縺・context.catalogs.errors 縺ｫ蟄伜惠縺励∪縺帙ｓ`,
+            message: `BranchConditionVariant.errorCode "${c.errorCode}" が context.catalogs.errors に存在しません`,
           });
         }
       }
@@ -236,7 +248,7 @@ function checkStep(
           path: `${path}.rollbackOn[${ci}]`,
           code: "UNKNOWN_ERROR_CODE",
           value: code,
-          message: `TransactionScopeStep.rollbackOn[${ci}] "${code}" 縺・context.catalogs.errors 縺ｫ蟄伜惠縺励∪縺帙ｓ`,
+          message: `TransactionScopeStep.rollbackOn[${ci}] "${code}" が context.catalogs.errors に存在しません`,
         });
       }
     });

--- a/designer/src/schemas/screenItemFlowValidator.ts
+++ b/designer/src/schemas/screenItemFlowValidator.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * 画面項目イベント ↔ 処理フロー連携の整合検査 (#619、#624 schema 拡張前提)。
  *
@@ -19,9 +18,7 @@
  * (全 v3 sample で actions 数 = 1 のため)。複数 actions のケースは将来課題。
  */
 
-import type { ProcessFlow, StructuredField } from "../types/action";
-import type { Screen } from "../types/v3/screen";
-import type { ScreenItem, ScreenItemEvent } from "../types/v3/screen-item";
+import type { ProcessFlow, StructuredField, Screen, ScreenItem, ScreenItemEvent } from "../types/v3";
 
 export type ScreenItemFlowIssueCode =
   | "UNKNOWN_HANDLER_FLOW"
@@ -51,12 +48,11 @@ interface CallSite {
 }
 
 function getFlowId(flow: ProcessFlow): string | null {
-  // v1 (top-level id) と v3 (meta.id) の両形式に対応
-  return (flow as { id?: string }).id ?? flow.meta?.id ?? null;
+  return flow.meta?.id ?? null;
 }
 
 function getScreenId(screen: Screen): string | null {
-  return (screen as { id?: string }).id ?? (screen as { meta?: { id: string } }).meta?.id ?? null;
+  return (screen.id as string | undefined) ?? null;
 }
 
 function getPrimaryInputs(flow: ProcessFlow): StructuredField[] {
@@ -125,7 +121,8 @@ export function checkScreenItemFlowConsistency(
         // 1.2 引数 contract 整合
         const inputs = getPrimaryInputs(targetFlow);
         const argMapping = event.argumentMapping ?? {};
-        const inputNames = new Set(inputs.map((i) => i.name));
+        // StructuredField.name は v3 で Identifier brand 型のため、Set<string> として比較するため cast
+        const inputNames = new Set<string>(inputs.map((i) => i.name as string));
 
         // 必須引数欠落
         for (const input of inputs) {

--- a/designer/src/schemas/sqlColumnValidator.ts
+++ b/designer/src/schemas/sqlColumnValidator.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * DbAccessStep.sql 内の列名がテーブル定義に存在するかを検証 (#261 残)。
  *
@@ -11,7 +10,8 @@
  * node-sql-parser v5 ベース。複雑な CTE / window / サブクエリは best-effort。
  */
 import { Parser } from "node-sql-parser";
-import type { ProcessFlow, DbAccessStep, Step } from "../types/action";
+import type { ProcessFlow, DbAccessStep, Step } from "../types/v3";
+import { isBuiltinStep } from "./stepGuards";
 
 /** テーブル定義 (最小シェイプ、docs/sample-project/tables/*.json 形式) */
 export interface TableDefinition {
@@ -210,7 +210,7 @@ export function checkSqlColumns(
 
   group.actions.forEach((action, ai) => {
     walkSteps(action.steps ?? [], `actions[${ai}].steps`, (step, path) => {
-      if (step.kind === "dbAccess" && step.sql) {
+      if (isBuiltinStep(step) && step.kind === "dbAccess" && step.sql) {
         issues.push(...validateSql(step.sql, defsByName, `${path}.sql`));
       }
     });
@@ -223,7 +223,8 @@ function walkSteps(steps: Step[], basePath: string, visit: (s: Step, p: string) 
   steps.forEach((step, i) => {
     const path = `${basePath}[${i}]`;
     visit(step, path);
-    if ("subSteps" in step && step.subSteps) walkSteps(step.subSteps, `${path}.subSteps`, visit);
+    // 拡張 step は nested 走査スキップ (固有プロパティは config 内に閉じる仕様)
+    if (!isBuiltinStep(step)) return;
     if (step.kind === "branch") {
       step.branches.forEach((b, bi) => walkSteps(b.steps, `${path}.branches[${bi}].steps`, visit));
       if (step.elseBranch) walkSteps(step.elseBranch.steps, `${path}.elseBranch.steps`, visit);

--- a/designer/src/schemas/stepGuards.ts
+++ b/designer/src/schemas/stepGuards.ts
@@ -1,0 +1,44 @@
+/**
+ * Step union 型 guard helper。
+ *
+ * v3 schema の `Step` union は組み込み 21 variant + ExtensionStep の計 22 variant。
+ * ExtensionStep は `kind: string` (namespace:Name 形式) のため、構造的サブタイピング下で
+ * `Exclude<Step, ExtensionStep>` は never に潰れてしまう。
+ * 代わりに、組み込み kind の literal union を `Extract<Step, { kind: BuiltinStepKind }>` で
+ * 取り出して narrow する。
+ *
+ * 拡張 step の固有 property は config 内に閉じる仕様 (process-flow.v3.schema §extensionStep) のため、
+ * フレームワーク横断 validator は組み込み step に対してのみ structural な検査を行う。
+ */
+import type { Step } from "../types/v3";
+
+export const BUILTIN_STEP_KINDS = [
+  "validation",
+  "dbAccess",
+  "externalSystem",
+  "commonProcess",
+  "screenTransition",
+  "displayUpdate",
+  "branch",
+  "loop",
+  "loopBreak",
+  "loopContinue",
+  "jump",
+  "compute",
+  "return",
+  "log",
+  "audit",
+  "workflow",
+  "transactionScope",
+  "eventPublish",
+  "eventSubscribe",
+  "closing",
+  "cdc",
+] as const;
+
+export type BuiltinStepKind = typeof BUILTIN_STEP_KINDS[number];
+export type BuiltinStep = Extract<Step, { kind: BuiltinStepKind }>;
+
+export function isBuiltinStep(s: Step): s is BuiltinStep {
+  return (BUILTIN_STEP_KINDS as readonly string[]).includes(s.kind);
+}

--- a/designer/src/schemas/validateDogfood.test.ts
+++ b/designer/src/schemas/validateDogfood.test.ts
@@ -96,13 +96,13 @@ describe("dogfood バリデータ — checkConventionReferences", () => {
 });
 
 describe("dogfood バリデータ — checkReferentialIntegrity", () => {
-  it("未定義 responseRef を検出する", () => {
+  it("未定義 responseId を検出する", () => {
     const flow = makeFlow({
       actions: [{
         id: "act-1", name: "取得", trigger: "init",
         responses: [{ id: "200-ok", status: 200 }],
         steps: [
-          { id: "ret-1", kind: "return", description: "", responseRef: "404-not-defined" },
+          { id: "ret-1", kind: "return", description: "", responseId: "404-not-defined" },
         ],
       }],
     });

--- a/designer/src/utils/aggregatedValidation.test.ts
+++ b/designer/src/utils/aggregatedValidation.test.ts
@@ -31,7 +31,7 @@ describe("aggregateValidation — 統合テスト", () => {
       actions: [{
         id: "a1", name: "f", trigger: "click",
         responses: [{ id: "201", status: 201 }],
-        steps: [{ id: "s1", kind: "return", description: "", responseRef: "404-missing" }],
+        steps: [{ id: "s1", kind: "return", description: "", responseId: "404-missing" }],
       }],
     }));
     const w = errors.find((e) => e.code === "UNKNOWN_RESPONSE_REF");
@@ -62,7 +62,7 @@ describe("aggregateValidation — 統合テスト", () => {
           id: "branch1", kind: "branch", description: "",
           branches: [{
             id: "b1", code: "A", condition: "@flag",
-            steps: [{ id: "inner-return", kind: "return", description: "", responseRef: "missing" }],
+            steps: [{ id: "inner-return", kind: "return", description: "", responseId: "missing" }],
           }],
         }],
       }],

--- a/designer/src/utils/aggregatedValidation.ts
+++ b/designer/src/utils/aggregatedValidation.ts
@@ -39,7 +39,8 @@ export function aggregateValidation(
 
   // 1. 既存の構造バリデータ (loopBreak スコープ、branch 空 等)
   // actionValidation.ts は legacy v1 type 受けのため、v3 → v1 ブリッジ cast。
-  // actionValidation 自体の v3 化は別 ISSUE スコープ。
+  // 注意: v1 type は AnyRecord shim のため、v3 ↔ v1 の field 不整合を型レベルで catch できない
+  // (偽陰性リスク)。actionValidation の v3 化完了 (#637) まで本 cast は残置。
   errors.push(...validateProcessFlow(group as unknown as ProcessFlowV1));
 
   // 2. 参照整合性 (responseId / errorCode / systemRef / typeRef / secretRef)

--- a/designer/src/utils/aggregatedValidation.ts
+++ b/designer/src/utils/aggregatedValidation.ts
@@ -8,12 +8,14 @@
  * SQL 列検査 (要 TableDefinition) と conventions 検査 (要 conventions-catalog) は
  * 依存データが必要なため optional パラメータで受け取る。未指定時は skip。
  */
-import type { ProcessFlow, Step } from "../types/action";
+import type { ProcessFlow as ProcessFlowV1 } from "../types/action";
+import type { ProcessFlow, Step } from "../types/v3";
 import { validateProcessFlow, type ValidationError } from "./actionValidation";
 import { checkReferentialIntegrity } from "../schemas/referentialIntegrity";
 import { checkIdentifierScopes } from "../schemas/identifierScope";
 import { checkSqlColumns, type TableDefinition } from "../schemas/sqlColumnValidator";
 import { checkConventionReferences, type ConventionsCatalog } from "../schemas/conventionsValidator";
+import { isBuiltinStep } from "../schemas/stepGuards";
 import type { LoadedExtensions } from "../schemas/loadExtensions";
 
 export interface AggregatedValidationOptions {
@@ -36,9 +38,11 @@ export function aggregateValidation(
   const errors: ValidationError[] = [];
 
   // 1. 既存の構造バリデータ (loopBreak スコープ、branch 空 等)
-  errors.push(...validateProcessFlow(group));
+  // actionValidation.ts は legacy v1 type 受けのため、v3 → v1 ブリッジ cast。
+  // actionValidation 自体の v3 化は別 ISSUE スコープ。
+  errors.push(...validateProcessFlow(group as unknown as ProcessFlowV1));
 
-  // 2. 参照整合性 (responseRef / errorCode / systemRef / typeRef / secretRef)
+  // 2. 参照整合性 (responseId / errorCode / systemRef / typeRef / secretRef)
   for (const issue of checkReferentialIntegrity(group, options.extensions)) {
     errors.push({
       stepId: stepIdFromPath(issue.path, group) ?? "",
@@ -91,7 +95,7 @@ export function aggregateValidation(
 
 /**
  * JSON path ("actions[0].steps[2]..." 等) から該当 step の ID を解決。
- * 深くネストしたパス (branches / elseBranch / loop / subSteps / sideEffects) も辿る。
+ * 深くネストしたパス (branches / elseBranch / loop / transactionScope / sideEffects) も辿る。
  * 解決できない場合 (catalog レベルの issue 等) は null。
  */
 function stepIdFromPath(path: string, group: ProcessFlow): string | null {
@@ -107,44 +111,43 @@ function stepIdFromPath(path: string, group: ProcessFlow): string | null {
 
   // ネストしたセグメントを順次辿る
   // 例: ".branches[0].steps[1].outcomes.failure.sideEffects[0]"
-  const segmentRe = /^(?:\.branches\[(\d+)\]\.steps\[(\d+)\]|\.elseBranch\.steps\[(\d+)\]|\.subSteps\[(\d+)\]|\.steps\[(\d+)\]|\.outcomes\.(success|failure|timeout)\.sideEffects\[(\d+)\])/;
+  const segmentRe = /^(?:\.branches\[(\d+)\]\.steps\[(\d+)\]|\.elseBranch\.steps\[(\d+)\]|\.steps\[(\d+)\]|\.outcomes\.(success|failure|timeout)\.sideEffects\[(\d+)\])/;
 
   while (true) {
     const sm = rest.match(segmentRe);
     if (!sm) break;
     if (sm[1] !== undefined && sm[2] !== undefined) {
-      // branches[b].steps[s]
-      if (currentStep.kind !== "branch") return currentStep.id;
+      if (!isBuiltinStep(currentStep) || currentStep.kind !== "branch") return currentStep.id;
       const branch = currentStep.branches[+sm[1]];
       if (!branch) return currentStep.id;
       const next = branch.steps[+sm[2]];
       if (!next) return currentStep.id;
       currentStep = next;
     } else if (sm[3] !== undefined) {
-      if (currentStep.kind !== "branch" || !currentStep.elseBranch) return currentStep.id;
+      if (!isBuiltinStep(currentStep) || currentStep.kind !== "branch" || !currentStep.elseBranch) return currentStep.id;
       const next = currentStep.elseBranch.steps[+sm[3]];
       if (!next) return currentStep.id;
       currentStep = next;
     } else if (sm[4] !== undefined) {
-      if (!currentStep.subSteps) return currentStep.id;
-      const next = currentStep.subSteps[+sm[4]];
-      if (!next) return currentStep.id;
-      currentStep = next;
-    } else if (sm[5] !== undefined) {
-      if (currentStep.kind !== "loop") return currentStep.id;
-      const next = currentStep.steps[+sm[5]];
-      if (!next) return currentStep.id;
-      currentStep = next;
-    } else if (sm[6] !== undefined && sm[7] !== undefined) {
-      if (currentStep.kind !== "externalSystem") return currentStep.id;
-      const outcome = currentStep.outcomes?.[sm[6] as "success" | "failure" | "timeout"];
+      // .steps[N]: loop / transactionScope の nested steps
+      if (!isBuiltinStep(currentStep)) return currentStep.id;
+      if (currentStep.kind === "loop" || currentStep.kind === "transactionScope") {
+        const next = currentStep.steps[+sm[4]];
+        if (!next) return currentStep.id;
+        currentStep = next;
+      } else {
+        return currentStep.id;
+      }
+    } else if (sm[5] !== undefined && sm[6] !== undefined) {
+      if (!isBuiltinStep(currentStep) || currentStep.kind !== "externalSystem") return currentStep.id;
+      const outcome = currentStep.outcomes?.[sm[5] as "success" | "failure" | "timeout"];
       if (!outcome?.sideEffects) return currentStep.id;
-      const next = outcome.sideEffects[+sm[7]];
+      const next = outcome.sideEffects[+sm[6]];
       if (!next) return currentStep.id;
       currentStep = next;
     }
     rest = rest.slice(sm[0].length);
   }
 
-  return currentStep.id;
+  return currentStep.id as string;
 }


### PR DESCRIPTION
## 関連

- Closes #610
- 仕様: 本 PR は型同期のみのリファクタリングで spec 変更なし
- 関連 memory: `feedback_v3_no_legacy_carryover.md` / `feedback_no_backward_compat_pre_release.md`
- フォローアップ ISSUE (Sonnet 独立レビュー S-1 対応で起票):
  - #637 — `actionValidation.ts` の v3 化、aggregatedValidation の cast bridge 除去
  - #638 — `v3-types.test.ts` retail 3 件の path subdirectory 化追従 (#616 fallout)

## 概要

`designer/src/schemas/` 配下の validator 群が `@ts-nocheck` 付きで v1 型 (現状 `AnyRecord` shim) を import している状態を解消。`../types/v3` への切替で型推論を有効化し、ExtensionStep の構造的サブタイピング問題を共通 type guard で吸収。同時に referentialIntegrity の文字化けコメントを修正。

## 主な変更

- **5 validator の v3 移行**:
  - `identifierScope.ts` (designer/src/schemas/identifierScope.ts:16-21)
  - `referentialIntegrity.ts` (designer/src/schemas/referentialIntegrity.ts:16)
  - `sqlColumnValidator.ts` (designer/src/schemas/sqlColumnValidator.ts:13)
  - `conventionsValidator.ts` (designer/src/schemas/conventionsValidator.ts:9-14)
  - `screenItemFlowValidator.ts` (designer/src/schemas/screenItemFlowValidator.ts:21)
- **共通 type guard helper 新設**: `designer/src/schemas/stepGuards.ts`。ExtensionStep の `kind: string` (構造的サブタイピング) で `Exclude<Step, ExtensionStep>` が `never` に潰れる問題を `Extract<Step, { kind: BuiltinStepKind }>` 方式で解決
- **referentialIntegrity.ts の文字化け修正**: 冒頭〜本文の Shift-JIS 残骸 (`蜃ｦ逅・ヵ繝ｭ繝ｼ` 等) を正常な日本語に復元 (designer/src/schemas/referentialIntegrity.ts:1-15)
- **aggregatedValidation.ts を v3 化** (designer/src/utils/aggregatedValidation.ts:12): `actionValidation` への呼び出しは `as unknown as ProcessFlowV1` で局所ブリッジ、偽陰性リスクを注記 (#637 で v3 化予定)
- **v1 fallback の全削除**:
  - top-level `ambientVariables` → `context.ambientVariables` のみ
  - `string` 形式 outputBinding → `{ name: ... }` object のみ
  - `responseRef` / `ngResponseRef` → v3 `responseId` / `ngResponseId` のみ
  - `step.subSteps` (v1) → 削除 (v3 では各 variant が個別 nested steps)
  - `string` 形式 BranchCondition → v3 discriminated union のみ
  - `step.protocol` (v1 only) → 削除
- **テスト fixture の v3 化** (responseRef → responseId 等)
- **screenItemFlowValidator のスコープ吸収**: ISSUE #610 起票時には存在しなかった 5 番目 validator (#619 で追加) が同問題を持つため、新規 ISSUE 化せず本 PR に吸収

## 仕様逐条突合 (自己申告)

ISSUE #610 完了基準:

- ✅ 全 4 (+1) バリデータから `@ts-nocheck` を除去
  - identifierScope.ts:1 (除去確認、現在 line 1 はコメント開始)
  - referentialIntegrity.ts:1 (同)
  - sqlColumnValidator.ts:1 (同)
  - conventionsValidator.ts:1 (同)
  - screenItemFlowValidator.ts:1 (同、5 番目 validator スコープ吸収)
- ✅ v3 型 import に切替
  - identifierScope.ts:16-21 ProcessFlow / Step / OutputBinding / StructuredField を v3 から
  - referentialIntegrity.ts:16 ProcessFlow / Step を v3 から
  - sqlColumnValidator.ts:13 ProcessFlow / DbAccessStep / Step を v3 から
  - conventionsValidator.ts:9-14 ProcessFlow / Step / ActionDefinition / Conventions を v3 から
  - screenItemFlowValidator.ts:21 ProcessFlow / StructuredField / Screen / ScreenItem / ScreenItemEvent を v3 から
- ✅ tsc / vitest / validate:dogfood 全て pass (詳細は「テスト」節)
- ✅ type drift 発生時の再発防止: stepGuards.ts に `BUILTIN_STEP_KINDS` を集約、step variant 追加時は本配列を更新する運用 (designer/src/schemas/stepGuards.ts:15-37)

## レビューで特に見てほしい箇所

- **stepGuards.ts の設計判断**: `Extract<Step, { kind: BuiltinStepKind }>` 方式を採用した経緯を comment に明記したが、別案 (`s.kind.includes(":")` のみで判定) と比べて妥当か (designer/src/schemas/stepGuards.ts:42-44)
- **aggregatedValidation の cast bridge**: `validateProcessFlow(group as unknown as ProcessFlowV1)` (designer/src/utils/aggregatedValidation.ts:44)。actionValidation 自体の v3 化を本 PR に含めると過剰スコープのため局所 cast に留めた (#637 で v3 化予定)
- **v1 fallback 全削除の妥当性**: ISSUE 文には「v1 互換維持」とあるが、ユーザー指示「リリース前のため後方互換不要」「v3 は新規作成」(memory `feedback_v3_no_legacy_carryover.md` / `feedback_no_backward_compat_pre_release.md`) に従って削除した
- **referentialIntegrity の文字化け修正**: 元の意図を可能な限り復元したが、誤訳していないか念のため確認 (designer/src/schemas/referentialIntegrity.ts:1-15)

## テスト

- Vitest: src/schemas/ 全 447 件 pass (designer/ 全体 1097 件中 1094 件 pass、残り 3 件は #638 で起票済の既知 fallout で本 PR と無関係)
- Playwright: N/A (validator のリファクタのみ、UI 影響なし)
- MCP E2E: N/A
- npm run build (tsc + vite): pass
- npm run validate:dogfood: 18/18 全件 pass (regression なし)

## UI 影響 / AI smoke test

- [ ] UI 影響あり (AI が chrome-devtools MCP / Playwright で smoke test 実施済み)
- [x] UI 影響なし (auto テスト pass のみ)

### UI 影響ありの場合、AI smoke test で確認した項目

- N/A (validator 内部リファクタのみ、UI からの呼び出し signature は維持)
- N/A
- N/A

## spec 側の不足点 / 提案

別 ISSUE 起票済 (本 PR スコープ外、後続作業として):

1. **#638 — `src/types/v3/v3-types.test.ts` の retail 3 件 fail**: ENOENT (file not found)。Phase 3 #616 で retail を subdirectory 化したため path 不整合
2. **#637 — `actionValidation.ts` の v3 化**: aggregatedValidation で局所 cast bridge を使ったが、本来は actionValidation 自体も v3 化すべき

## レビュー担当への申し送り

- ISSUE 文には「v1 互換維持」とあるが、ユーザー指示でリリース前後方互換不要に方針変更。v1 fallback 全削除済み
- ISSUE 起票時 (2026-04-29) 後に追加された 5 番目 validator screenItemFlowValidator (#619 マージ済み) も同問題を持つため、新規 ISSUE 化せず本 PR に吸収。1 PR 完結を優先
- stepGuards.ts は 5 validator + aggregatedValidation の 6 ファイルから利用するため共通 helper として独立ファイル化 (DRY、新規ファイル正当化)
- referentialIntegrity の文字化けは過去の Shift-JIS 残骸で長期間放置されていたもの。同ファイル編集ついでに修正したため本 PR に含めた (`grep [ｦ-ﾟ] schemas/` で 0 件確認)
- Sonnet 独立レビュー (general-purpose subagent) で Approve、Must-fix なし。Should-fix S-1 (フォローアップ ISSUE 起票) は本コミットで #637 / #638 として起票済。Nit N-2 (cast bridge 偽陰性リスク注記) は ba054e2 で対応済。Nit N-1 (file:line ズレ) は本本文更新で修正
