### PR TITLE
fix(test): v3-types.test.ts retail 3 件の path を subdirectory 構造 (#616) に追従 (#638)

### DIFF
--- a/designer/src/types/v3/v3-types.test.ts
+++ b/designer/src/types/v3/v3-types.test.ts
@@ -198,14 +198,14 @@ function loadJson<T>(path: string): T {
 
 describe("v3 TS 型 と sample-project-v3 JSON の compatibility (5 業界カバー)", () => {
   it("retail project.json を Project 型として parse できる", () => {
-    const project = loadJson<Project>(join(samplesV3Dir, "project.json"));
+    const project = loadJson<Project>(join(samplesV3Dir, "retail/project.json"));
     expect(project.schemaVersion).toBe("v3");
     expect(project.meta.name).toBeDefined();
   });
 
   it("retail 在庫照会フローを ProcessFlow 型として parse できる + Step narrow", () => {
     const flow = loadJson<ProcessFlow>(
-      join(samplesV3Dir, "process-flows/506c266f-cc46-4d6f-86df-3c71f515bfcc.json"),
+      join(samplesV3Dir, "retail/process-flows/506c266f-cc46-4d6f-86df-3c71f515bfcc.json"),
     );
     expect(flow.meta.kind).toBe("screen");
     const firstStep: Step = flow.actions[0].steps[0];
@@ -235,7 +235,7 @@ describe("v3 TS 型 と sample-project-v3 JSON の compatibility (5 業界カバ
 
   it("retail 店舗在庫照会画面を Screen 型として parse できる", () => {
     const screen = loadJson<Screen>(
-      join(samplesV3Dir, "screens/3f378ca7-ad6f-44ad-8ebc-ab17fb806c2c.json"),
+      join(samplesV3Dir, "retail/screens/3f378ca7-ad6f-44ad-8ebc-ab17fb806c2c.json"),
     );
     expect(screen.kind).toBe("search");
     expect(screen.path).toMatch(/\/inventory\//);


### PR DESCRIPTION
## 関連

- Closes #638
- 仕様: N/A (テスト path の単純修正、spec 条項なし)

## 概要

Phase 3 #616 (PR #618) で `docs/sample-project-v3/retail/` subdirectory 化した際に、`v3-types.test.ts` の retail 参照 3 件が旧 path のまま残っていた。ENOENT で fail していた retail 3 テストを修正する。

## 主な変更

- `v3-types.test.ts` retail 参照 3 件を `retail/` プレフィックス付き path に修正
  - `project.json` → `retail/project.json`
  - `process-flows/506c266f-...json` → `retail/process-flows/506c266f-...json`
  - `screens/3f378ca7-...json` → `retail/screens/3f378ca7-...json`

## 仕様逐条突合 (自己申告)

N/A — 既存テスト path のバグ修正のみ。schema / spec 条項への新たな対応なし。

## レビューで特に見てほしい箇所

- 他業界 (finance / healthcare / logistics / manufacturing / public-service / welfare-benefit) の path は既に `<industry>/` プレフィックス付きで正しく記述されており、今回修正対象外であることを確認済み。
- retail のみ 3 件が `retail/` なしの旧 path で残っていた。

## テスト

- Vitest: 18 件 pass (0 件新規、既存テストの pass 復旧) — `src/types/v3/v3-types.test.ts`
- Playwright: N/A
- MCP E2E: N/A

## UI 影響 / AI smoke test

- [x] UI 影響なし (auto テスト pass のみ)

### UI 影響ありの場合、AI smoke test で確認した項目

N/A

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

テスト path 3 行の修正のみ。ロジック変更なし。`npm run build` も tsc/vite ともに pass 済み。