### PR TITLE
improve(validator): actionValidation.ts を v3 化、aggregatedValidation の cast bridge 除去 (#637)

### DIFF
--- a/designer/src/utils/actionValidation.ts
+++ b/designer/src/utils/actionValidation.ts
@@ -1,4 +1,5 @@
-import type { ProcessFlow, Step } from "../types/action";
+import type { ProcessFlow, Step } from "../types/v3";
+import { isBuiltinStep } from "../schemas/stepGuards";
 
 export type ValidationSeverity = "error" | "warning";
 
@@ -14,8 +15,8 @@ export interface ValidationError {
 
 function collectAllIds(steps: Step[], ids: Set<string>): void {
   for (const step of steps) {
-    ids.add(step.id);
-    if (step.subSteps) collectAllIds(step.subSteps, ids);
+    ids.add(step.id as string);
+    if (!isBuiltinStep(step)) continue;
     if (step.kind === "branch") {
       for (const b of step.branches) collectAllIds(b.steps, ids);
       if (step.elseBranch) collectAllIds(step.elseBranch.steps, ids);
@@ -36,12 +37,13 @@ function validateSteps(
   allIds: Set<string>,
 ): void {
   for (const step of steps) {
+    if (!isBuiltinStep(step)) continue;
     switch (step.kind) {
       case "loopBreak":
       case "loopContinue":
         if (loopDepth === 0) {
           errors.push({
-            stepId: step.id,
+            stepId: step.id as string,
             severity: "error",
             message: step.kind === "loopBreak"
               ? "ループ終了 はループの中にのみ置けます"
@@ -51,23 +53,23 @@ function validateSteps(
         break;
       case "branch":
         if (step.branches.length === 0) {
-          errors.push({ stepId: step.id, severity: "error", message: "分岐が1つもありません" });
+          errors.push({ stepId: step.id as string, severity: "error", message: "分岐が1つもありません" });
         }
         for (const b of step.branches) validateSteps(b.steps, loopDepth, errors, allIds);
         if (step.elseBranch) validateSteps(step.elseBranch.steps, loopDepth, errors, allIds);
         break;
       case "loop":
         if (step.loopKind === "condition" && !step.conditionExpression) {
-          errors.push({ stepId: step.id, severity: "warning", message: "条件式が未入力です" });
+          errors.push({ stepId: step.id as string, severity: "warning", message: "条件式が未入力です" });
         }
         if (step.loopKind === "collection" && !step.collectionSource) {
-          errors.push({ stepId: step.id, severity: "warning", message: "コレクションが未入力です" });
+          errors.push({ stepId: step.id as string, severity: "warning", message: "コレクションが未入力です" });
         }
         validateSteps(step.steps, loopDepth + 1, errors, allIds);
         break;
       case "transactionScope":
         if (step.steps.length === 0) {
-          errors.push({ stepId: step.id, severity: "warning", message: "TX スコープに 1 つ以上のステップを配置してください" });
+          errors.push({ stepId: step.id as string, severity: "warning", message: "TX スコープに 1 つ以上のステップを配置してください" });
         }
         validateSteps(step.steps, loopDepth, errors, allIds);
         if (step.onCommit) validateSteps(step.onCommit, loopDepth, errors, allIds);
@@ -75,14 +77,11 @@ function validateSteps(
         break;
       case "jump":
         if (!step.jumpTo) {
-          errors.push({ stepId: step.id, severity: "warning", message: "ジャンプ先が未設定です" });
-        } else if (!allIds.has(step.jumpTo)) {
-          errors.push({ stepId: step.id, severity: "warning", message: "ジャンプ先が見つかりません" });
+          errors.push({ stepId: step.id as string, severity: "warning", message: "ジャンプ先が未設定です" });
+        } else if (!allIds.has(step.jumpTo as string)) {
+          errors.push({ stepId: step.id as string, severity: "warning", message: "ジャンプ先が見つかりません" });
         }
         break;
-    }
-    if (step.subSteps && step.subSteps.length > 0) {
-      validateSteps(step.subSteps, step.kind === "loop" ? loopDepth + 1 : loopDepth, errors, allIds);
     }
   }
 }

--- a/designer/src/utils/aggregatedValidation.test.ts
+++ b/designer/src/utils/aggregatedValidation.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { aggregateValidation } from "./aggregatedValidation";
-import type { ProcessFlow } from "../types/action";
+import type { ProcessFlow } from "../types/v3";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
@@ -45,7 +45,7 @@ describe("aggregateValidation — 統合テスト", () => {
     const errors = aggregateValidation(makeGroup({
       actions: [{
         id: "a1", name: "f", trigger: "click",
-        steps: [{ id: "s1", kind: "compute", description: "", expression: "@unknownX * 2", outputBinding: "r" }],
+        steps: [{ id: "s1", kind: "compute", description: "", expression: "@unknownX * 2", outputBinding: { name: "r" } }],
       }],
     }));
     const w = errors.find((e) => e.code === "UNKNOWN_IDENTIFIER");
@@ -61,7 +61,7 @@ describe("aggregateValidation — 統合テスト", () => {
         steps: [{
           id: "branch1", kind: "branch", description: "",
           branches: [{
-            id: "b1", code: "A", condition: "@flag",
+            id: "b1", code: "A", condition: { kind: "expression", expression: "@flag" },
             steps: [{ id: "inner-return", kind: "return", description: "", responseId: "missing" }],
           }],
         }],
@@ -80,7 +80,7 @@ describe("aggregateValidation — 統合テスト", () => {
           outcomes: {
             failure: {
               action: "continue",
-              sideEffects: [{ id: "se-unknown", kind: "compute", description: "", expression: "@unknownVar", outputBinding: "r" }],
+              sideEffects: [{ id: "se-unknown", kind: "compute", description: "", expression: "@unknownVar", outputBinding: { name: "r" } }],
             },
           },
         }],

--- a/designer/src/utils/aggregatedValidation.ts
+++ b/designer/src/utils/aggregatedValidation.ts
@@ -8,7 +8,6 @@
  * SQL 列検査 (要 TableDefinition) と conventions 検査 (要 conventions-catalog) は
  * 依存データが必要なため optional パラメータで受け取る。未指定時は skip。
  */
-import type { ProcessFlow as ProcessFlowV1 } from "../types/action";
 import type { ProcessFlow, Step } from "../types/v3";
 import { validateProcessFlow, type ValidationError } from "./actionValidation";
 import { checkReferentialIntegrity } from "../schemas/referentialIntegrity";
@@ -38,10 +37,7 @@ export function aggregateValidation(
   const errors: ValidationError[] = [];
 
   // 1. 既存の構造バリデータ (loopBreak スコープ、branch 空 等)
-  // actionValidation.ts は legacy v1 type 受けのため、v3 → v1 ブリッジ cast。
-  // 注意: v1 type は AnyRecord shim のため、v3 ↔ v1 の field 不整合を型レベルで catch できない
-  // (偽陰性リスク)。actionValidation の v3 化完了 (#637) まで本 cast は残置。
-  errors.push(...validateProcessFlow(group as unknown as ProcessFlowV1));
+  errors.push(...validateProcessFlow(group));
 
   // 2. 参照整合性 (responseId / errorCode / systemRef / typeRef / secretRef)
   for (const issue of checkReferentialIntegrity(group, options.extensions)) {


### PR DESCRIPTION
## 関連

- Closes #637
- 仕様: ISSUE #637 完了基準に準拠 (仕様 doc なし、ISSUE の完了基準が spec 相当)

## 概要

`aggregatedValidation.ts` (#636 で v3 化) が `actionValidation.ts` を呼ぶ際の `group as unknown as ProcessFlowV1` cast bridge を除去する。`actionValidation.ts` 自体を v3 型 (`../types/v3`) に切り替えることで、v3 ↔ v1 の field 不整合が型レベルで catch されない偽陰性リスクを解消する。

## 主な変更

- **actionValidation.ts v3 化**: import を `../types/action` (AnyRecord shim) から `../types/v3` に切替、`isBuiltinStep` guard を追加して ExtensionStep を early return。v1 fallback の `subSteps` 参照を全削除
- **aggregatedValidation.ts cast bridge 除去**: `group as unknown as ProcessFlowV1` を `group` に、`import type { ProcessFlow as ProcessFlowV1 }` を削除、偽陰性リスク注記コメント 3 行も除去
- **テスト fixture v3 化**: `outputBinding: "r"` → `{ name: "r" }`、`condition: "@flag"` → `{ kind: "expression", expression: "@flag" }`、import を `../types/v3` に切替

## 仕様逐条突合 (自己申告)

ISSUE #637 完了基準に対する逐条突合:

- `actionValidation.ts` から `@ts-nocheck` 除去 → 元々なし (確認済み)、v1 shim (AnyRecord) → v3 型推論有効に変更: `actionValidation.ts:1-2` ✓
- `actionValidation.ts` の import を `../types/v3` に切替: `actionValidation.ts:1` ✓
- `aggregatedValidation.ts` の cast bridge 除去 → `aggregatedValidation.ts:41` (旧 L44 cast → 直呼び) ✓
- `import { ProcessFlow as ProcessFlowV1 }` 削除 → `aggregatedValidation.ts:11` (削除済み) ✓
- tsc / vitest / validate:dogfood 全 pass → 以下テスト欄参照 ✓
- テスト fixture v3 化 → `aggregatedValidation.test.ts:48,64,83` ✓

## レビューで特に見てほしい箇所

- `collectAllIds` の `subSteps` 削除: v3 Step union には `subSteps` フィールドが存在しないため削除。v3 ネスト構造は `branch.steps` / `loop.steps` / `transactionScope.steps` で表現 — これらは既存 switch で正しく辿っている
- `isBuiltinStep(step)` による早期 continue: ExtensionStep は `kind: string` (namespace:Name 形式) のため union narrow が困難。PR #636 の stepGuards パターンを踏襲し、ExtensionStep は構造検査スキップとする設計
- `step.id as string` / `step.jumpTo as string` の brand cast: `LocalId` brand 型から `string` への cast は idiomatic パターン (PR #636 identifierScope.ts 参照)

## テスト

- Vitest: 8 件 (新規 0 件、変更 3 件) — aggregatedValidation.test.ts 全 pass
- Vitest: 447 件 — src/schemas/ 全 pass (regression なし)
- validate:dogfood: 18/18 pass (全 sample-project v3 流)
- Playwright: N/A (UI 変更なし)

## UI 影響 / AI smoke test

- [x] UI 影響なし (auto テスト pass のみ)

### UI 影響ありの場合、AI smoke test で確認した項目

N/A

## spec 側の不足点 / 提案

N/A — `actionValidation.ts` は spec ではなく ISSUE の完了基準に従う実装タスク。

## レビュー担当への申し送り

- 変更は 3 ファイルのみ (actionValidation.ts / aggregatedValidation.ts / aggregatedValidation.test.ts)、スコープは明確
- PR #636 (`9ca1a57`) の stepGuards パターンを同じく適用しているため、参考実装との整合性を確認されたい
- `collectAllIds` から `subSteps` を削除したことで、v1 時代に subSteps を使っていたフローの ID 収集が変わる可能性あるが、v3 schema に subSteps は存在しないため regression なし (v3 データには subSteps がそもそも含まれない)