### PR TITLE
improve(scripts): generate-dogfood.ts を per-project 構造に対応 (#617)

### DIFF
--- a/designer/scripts/generate-dogfood.ts
+++ b/designer/scripts/generate-dogfood.ts
@@ -23,9 +23,15 @@
  */
 
 import { mkdirSync, writeFileSync, existsSync, readFileSync } from "node:fs";
-import { resolve, join, dirname } from "node:path";
+import { resolve, join, dirname, relative as pathRelative } from "node:path";
 import { spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
+import {
+  defaultRepoRoot,
+  discoverProjects,
+  findProjectById,
+  type SampleProjectInfo,
+} from "./sample-projects.js";
 
 // ─── CLI 引数解析 ─────────────────────────────────────────────────────────────
 
@@ -34,9 +40,16 @@ type GenerateMode = "dummy" | "ai";
 interface CliOptions {
   industry: string;
   scenarios: string;
+  /** 出力先ディレクトリ。--project 指定時は省略可 (該当プロジェクトの projectDir を使う) */
   output: string;
   dryRun: boolean;
   mode: GenerateMode;
+  /**
+   * 既存サンプルプロジェクト ID (例: finance / retail / v1)。
+   * 指定すると output 未指定でもプロジェクトディレクトリへ追記書き込みする per-project mode に切り替わる。
+   * extension namespace も projectId に揃える。
+   */
+  projectId?: string;
 }
 
 function parseArgs(argv: string[]): CliOptions {
@@ -54,6 +67,9 @@ function parseArgs(argv: string[]): CliOptions {
         break;
       case "--output":
         opts.output = args[++i];
+        break;
+      case "--project":
+        opts.projectId = args[++i];
         break;
       case "--dry-run":
         opts.dryRun = true;
@@ -75,6 +91,8 @@ function parseArgs(argv: string[]): CliOptions {
           opts.scenarios = arg.slice("--scenarios=".length);
         } else if (arg.startsWith("--output=")) {
           opts.output = arg.slice("--output=".length);
+        } else if (arg.startsWith("--project=")) {
+          opts.projectId = arg.slice("--project=".length);
         } else if (arg.startsWith("--mode=")) {
           const modeVal = arg.slice("--mode=".length);
           if (modeVal !== "dummy" && modeVal !== "ai") {
@@ -88,15 +106,32 @@ function parseArgs(argv: string[]): CliOptions {
     }
   }
 
+  // --project 指定時: industry / output 未指定なら projectId から推論
+  if (opts.projectId && !opts.output) {
+    const project = findProjectById(opts.projectId);
+    if (!project) {
+      const available = discoverProjects()
+        .map((p) => p.projectId)
+        .join(", ");
+      console.error(`エラー: --project ${opts.projectId} に該当するサンプルプロジェクトが見つかりません`);
+      console.error(`  利用可能: ${available}`);
+      process.exit(1);
+    }
+    opts.output = project.projectDir;
+    if (!opts.industry) {
+      opts.industry = opts.projectId;
+    }
+  }
+
   if (!opts.industry) {
-    console.error("エラー: --industry が必要です");
+    console.error("エラー: --industry が必要です (または --project を指定してください)");
     process.exit(1);
   }
   if (!opts.scenarios) {
     opts.scenarios = `${opts.industry} 業務シナリオ`;
   }
   if (!opts.output) {
-    console.error("エラー: --output が必要です");
+    console.error("エラー: --output が必要です (または --project を指定してください)");
     process.exit(1);
   }
 
@@ -105,13 +140,77 @@ function parseArgs(argv: string[]): CliOptions {
 
 // ─── ディレクトリ準備 ─────────────────────────────────────────────────────────
 
-function prepareOutputDirs(outputDir: string, industry: string): void {
-  const dirs = [
+interface OutputLayout {
+  /** 既存サンプルプロジェクト情報 (新規 ad-hoc 出力時は null) */
+  project: SampleProjectInfo | null;
+  /** 出力ルート (project.projectDir または ad-hoc の output) */
+  outputDir: string;
+  /** flows 出力先ディレクトリ */
+  flowsDir: string;
+  /** tables 出力先ディレクトリ */
+  tablesDir: string;
+  /** extensions namespace ディレクトリ。v3 は <projectDir>/extensions、v1 / ad-hoc は <outputDir>/extensions/<safeId> */
+  extensionsDir: string;
+  /** extensions namespace ファイル名 (v3 のみ <ns>.v3.json、v1 / ad-hoc は field-types.json) */
+  extensionsFileName: string;
+  /** conventions catalog ファイルの絶対パス。v3 は conventions-catalog.v3.json、v1 / ad-hoc は conventions/conventions-catalog.json */
+  conventionsCatalogFile: string;
+}
+
+/**
+ * --project 指定時は既存サンプル構造に揃えた path を返す (per-project mode)。
+ * 未指定時は ad-hoc 出力 (新規 outputDir 直下に v1 互換 flat 構造) を返す。
+ */
+function resolveOutputLayout(opts: CliOptions, safeId: string): OutputLayout {
+  const outputDir = resolve(opts.output);
+
+  if (opts.projectId) {
+    const project = findProjectById(opts.projectId);
+    if (!project) {
+      throw new Error(`--project ${opts.projectId} に該当するサンプルプロジェクトが見つかりません`);
+    }
+    if (project.variant === "v3") {
+      return {
+        project,
+        outputDir: project.projectDir,
+        flowsDir: project.flowsDir,
+        tablesDir: project.tablesDir,
+        extensionsDir: project.extensionsDir,
+        extensionsFileName: `${safeId}.v3.json`,
+        conventionsCatalogFile: project.conventionsCatalogFile,
+      };
+    }
+    // v1
+    return {
+      project,
+      outputDir: project.projectDir,
+      flowsDir: project.flowsDir,
+      tablesDir: project.tablesDir,
+      extensionsDir: join(project.extensionsDir, safeId),
+      extensionsFileName: "field-types.json",
+      conventionsCatalogFile: project.conventionsCatalogFile,
+    };
+  }
+
+  // ad-hoc 出力 (v1 互換 flat 構造)
+  return {
+    project: null,
     outputDir,
-    join(outputDir, "process-flows"),
-    join(outputDir, "tables"),
-    join(outputDir, "extensions", industry),
-    join(outputDir, "conventions"),
+    flowsDir: join(outputDir, "process-flows"),
+    tablesDir: join(outputDir, "tables"),
+    extensionsDir: join(outputDir, "extensions", safeId),
+    extensionsFileName: "field-types.json",
+    conventionsCatalogFile: join(outputDir, "conventions", "conventions-catalog.json"),
+  };
+}
+
+function prepareOutputDirs(layout: OutputLayout): void {
+  const dirs = [
+    layout.outputDir,
+    layout.flowsDir,
+    layout.tablesDir,
+    layout.extensionsDir,
+    dirname(layout.conventionsCatalogFile),
   ];
   for (const dir of dirs) {
     mkdirSync(dir, { recursive: true });
@@ -423,12 +522,24 @@ function generateBriefingContent(opts: {
   safeId: string;
   scenarios: string;
   outputDir: string;
+  layout: OutputLayout;
 }): string {
-  const { industry, safeId, scenarios, outputDir } = opts;
+  const { industry, safeId, scenarios, outputDir, layout } = opts;
   const scenarioList = parseScenarios(scenarios);
   const scenarioBullets = scenarioList
     .map((s, i) => `${i + 1}. ${s}`)
     .join("\n");
+
+  // briefing 内のリソース path 表記は per-project layout に従う
+  const variant = layout.project?.variant ?? "ad-hoc";
+  const flowsRel = relativeFromOutput(outputDir, layout.flowsDir);
+  const tablesRel = relativeFromOutput(outputDir, layout.tablesDir);
+  const extensionsFileRel = relativeFromOutput(outputDir, join(layout.extensionsDir, layout.extensionsFileName));
+  const conventionsRel = relativeFromOutput(outputDir, layout.conventionsCatalogFile);
+  const fallbackConventionsSource = findFallbackConventionsSource();
+  const fallbackConventionsLabel = fallbackConventionsSource
+    ? relativeFromRepoRoot(fallbackConventionsSource)
+    : "(既存サンプルなし)";
 
   return `# 設計データ投入 briefing — ${industry}
 
@@ -439,7 +550,7 @@ function generateBriefingContent(opts: {
 
 ## 業界 namespace
 
-\`${safeId}\` (業界: \`${industry}\`)
+\`${safeId}\` (業界: \`${industry}\`、レイアウト: \`${variant}\`)
 
 ## 業務概要 (シナリオ群)
 
@@ -453,17 +564,18 @@ ${scenarioBullets}
 
 作業ディレクトリ: \`${outputDir}/\`
 
-### 1. 拡張定義 (\`extensions/${safeId}/*.json\`)
+### 1. 拡張定義 (\`${extensionsFileRel}\`)
 
 業界固有の拡張定義を作成:
-- \`field-types.json\`: 業界固有の型 (例: \`${safeId}Id\` / \`${safeId}Name\` など)
-- \`triggers.json\`: 業界固有トリガー (該当あれば)
-- \`db-operations.json\`: 業界固有 DB 操作 (該当あれば)
-- \`steps.json\`: 業界固有メタステップ (該当あれば)
+- field-types: 業界固有の型 (例: \`${safeId}Id\` / \`${safeId}Name\` など)
+- triggers: 業界固有トリガー (該当あれば)
+- db-operations: 業界固有 DB 操作 (該当あれば)
+- steps: 業界固有メタステップ (該当あれば)
 
-各ファイルの形式: \`{ namespace: "${safeId}", fieldTypes/triggers/dbOperations/steps: [...] }\`
+ファイル形式 (v1): \`{ namespace: "${safeId}", fieldTypes/triggers/dbOperations/steps: [...] }\` を種別ごとに別ファイルで出力
+ファイル形式 (v3): \`{ namespace: "${safeId}", fieldTypes/actionTriggers/dbOperations/stepKinds: [...] }\` を 1 ファイルに統合
 
-### 2. テーブル定義 (\`tables/<uuid>.json\`) × N テーブル
+### 2. テーブル定義 (\`${tablesRel}/<uuid>.json\`) × N テーブル
 
 シナリオ群から推論されるエンティティを正規化したテーブル定義。
 各テーブルに以下を含める:
@@ -471,12 +583,12 @@ ${scenarioBullets}
 - \`columns[]\`: id / name / logicalName / dataType / notNull / primaryKey / unique / (autoIncrement)
 - \`indexes[]\`
 
-### 3. conventions 拡張 (\`conventions/conventions-catalog.json\`)
+### 3. conventions 拡張 (\`${conventionsRel}\`)
 
-既存 catalog (\`docs/sample-project/conventions/conventions-catalog.json\`) をベースに
+既存 catalog (\`${fallbackConventionsLabel}\`) をベースに
 業界固有 \`@conv.limit.*\` / \`@conv.numbering.*\` 等を追加した版を出力。
 
-### 4. 処理フロー (\`process-flows/<uuid>.json\`) × ${scenarioList.length} シナリオ
+### 4. 処理フロー (\`${flowsRel}/<uuid>.json\`) × ${scenarioList.length} シナリオ
 
 各シナリオに対して 1 フロー生成:
 
@@ -511,10 +623,10 @@ ${scenarioList.map((s, i) => `- シナリオ ${i + 1}: ${s}`).join("\n")}
 
 ### 推奨手順
 
-1. まず \`docs/sample-project/extensions/${safeId}/\` が存在しない場合は新規 namespace として \`${outputDir}/extensions/${safeId}/\` に作成
+1. 出力ルート \`${outputDir}/\` のディレクトリ骨格は本スクリプトで作成済 (extensions / process-flows / tables / conventions)
 2. Sonnet/Opus サブエージェントを Spawn し、1 シナリオずつ並列実装可能
 3. 各サブエージェントは \`/create-flow\` SKILL の 14 ルールを遵守
-4. 生成物を \`docs/sample-project/\` に移動してから \`validate:dogfood\` で検証
+4. 生成物が \`docs/sample-project/\` (v1) または \`docs/sample-project-v3/<projectId>/\` (v3) 配下にあれば、そのまま \`validate:dogfood\` の per-project スキャン対象となる (#615 / #617)
 5. 検出された問題を 3 分類別 (フレームワーク / 拡張定義 / サンプル設計) に集計
 
 ### 検証コマンド
@@ -524,9 +636,8 @@ cd designer
 npm run validate:dogfood
 \`\`\`
 
-> 注意: 現状 validate:dogfood は \`docs/sample-project/\` を対象とするため、
-> 生成先が異なる場合は生成物を \`docs/sample-project/\` に移動してから実行してください。
-> 生成先を直接検証する対応は別 ISSUE で追跡中。
+> 注意: validate:dogfood は \`docs/sample-project/\` (v1) と \`docs/sample-project-v3/<projectId>/\` (v3) を per-project スキャンする (#615)。
+> 出力先が上記サンプルルート配下なら自動検出される。それ以外のディレクトリへ生成した場合はサンプルルート配下に移動してから再実行してください。
 
 ---
 
@@ -557,9 +668,24 @@ npm run validate:dogfood
 - 既存 5/5 達成サンプル: \`docs/legacy-sample-project/process-flows/cccccccc-0007-*.json\`
 - /create-flow SKILL: \`.claude/skills/create-flow/SKILL.md\`
 - spec: \`docs/spec/process-flow-*.md\`
-- 既存 conventions: \`docs/sample-project/conventions/conventions-catalog.json\`
-- 既存拡張サンプル: \`docs/sample-project/extensions/\`
+- 既存 conventions テンプレート: \`${fallbackConventionsLabel}\`
+- 既存サンプル一覧 (v1 / v3 全件): \`docs/sample-project/\` および \`docs/sample-project-v3/<projectId>/\`
 `;
+}
+
+// ─── ユーティリティ (briefing template 用) ───────────────────────────────────
+
+/**
+ * outputDir 起点で targetPath を相対化。Windows path 区切りも正規化する。
+ */
+function relativeFromOutput(outputDir: string, targetPath: string): string {
+  const rel = pathRelative(outputDir, targetPath);
+  return rel.replace(/\\/g, "/") || ".";
+}
+
+function relativeFromRepoRoot(targetPath: string): string {
+  const rel = pathRelative(defaultRepoRoot(), targetPath);
+  return rel.replace(/\\/g, "/") || ".";
 }
 
 // ─── ファイル書き込み ─────────────────────────────────────────────────────────
@@ -611,20 +737,23 @@ export function generate(opts: CliOptions): {
   extensionPath: string;
   conventionsPath: string;
 } {
-  const { industry, scenarios, output, dryRun } = opts;
+  const { industry, scenarios, dryRun } = opts;
   const safeId = toSafeId(industry);
-  const outputDir = resolve(output);
+  const layout = resolveOutputLayout(opts, safeId);
 
   console.log("🚀 generate-dogfood 開始 (dummy モード)");
   console.log(`  industry : ${industry}`);
   console.log(`  scenarios: ${scenarios}`);
-  console.log(`  output   : ${outputDir}`);
+  console.log(`  output   : ${layout.outputDir}`);
+  if (layout.project) {
+    console.log(`  project  : ${layout.project.projectId} (${layout.project.variant})`);
+  }
   console.log(`  dry-run  : ${dryRun}`);
   console.log();
 
   // 1. ディレクトリ準備
   if (!dryRun) {
-    prepareOutputDirs(outputDir, safeId);
+    prepareOutputDirs(layout);
     console.log("📁 出力ディレクトリを作成しました");
   } else {
     console.log("[dry-run] ディレクトリ作成をスキップ");
@@ -634,7 +763,7 @@ export function generate(opts: CliOptions): {
   // 2. テーブル生成
   const tableId = randomUUID();
   const tableName = `${safeId}_items`;
-  const tablePath = join(outputDir, "tables", `${tableId}.json`);
+  const tablePath = join(layout.tablesDir, `${tableId}.json`);
   const tableData = generateDummyTable({ id: tableId, industry, safeId });
 
   console.log("📊 テーブル定義を生成:");
@@ -642,7 +771,7 @@ export function generate(opts: CliOptions): {
 
   // 3. フロー生成
   const flowId = randomUUID();
-  const flowPath = join(outputDir, "process-flows", `${flowId}.json`);
+  const flowPath = join(layout.flowsDir, `${flowId}.json`);
   const flowData = generateDummyFlow({
     id: flowId,
     industry,
@@ -656,7 +785,7 @@ export function generate(opts: CliOptions): {
   writeJson(flowPath, flowData, dryRun);
 
   // 4. 拡張定義生成
-  const extensionPath = join(outputDir, "extensions", safeId, "field-types.json");
+  const extensionPath = join(layout.extensionsDir, layout.extensionsFileName);
   const extensionData = generateDummyFieldTypes({ industry, safeId });
 
   console.log("🔌 拡張定義を生成:");
@@ -666,17 +795,12 @@ export function generate(opts: CliOptions): {
   writeJson(extensionPath, extensionData, dryRun);
 
   // 5. 規約カタログ生成
-  // docs/sample-project/conventions/conventions-catalog.json があればベースとして使う
-  const designerDir = resolve(__dirname, "..");
-  const sampleConventionsFile = resolve(
-    designerDir,
-    "../docs/sample-project/conventions/conventions-catalog.json",
-  );
-  const conventionsPath = join(outputDir, "conventions", "conventions-catalog.json");
+  // 既存 catalog があればベースに業界固有 limit を追記、無ければ最小骨格を生成
+  const conventionsPath = layout.conventionsCatalogFile;
   const conventionsData = generateDummyConventions({
     industry,
     safeId,
-    sourceConventionsFile: sampleConventionsFile,
+    sourceConventionsFile: existsSync(conventionsPath) ? conventionsPath : findFallbackConventionsSource(),
   });
 
   console.log("📜 規約カタログを生成:");
@@ -690,6 +814,21 @@ export function generate(opts: CliOptions): {
   console.log(`  規約    : ${conventionsPath}`);
 
   return { flowId, tableId, flowPath, tablePath, extensionPath, conventionsPath };
+}
+
+/**
+ * 既存サンプルから convention catalog のテンプレートを探す。
+ * v1 → v3 の優先順で最初に見つかった catalog を返す。無ければ undefined。
+ */
+function findFallbackConventionsSource(): string | undefined {
+  const projects = discoverProjects();
+  for (const variant of ["v1", "v3"] as const) {
+    for (const p of projects) {
+      if (p.variant !== variant) continue;
+      if (existsSync(p.conventionsCatalogFile)) return p.conventionsCatalogFile;
+    }
+  }
+  return undefined;
 }
 
 // ─── エントリーポイント (AI モード) ──────────────────────────────────────────
@@ -707,14 +846,18 @@ export interface GenerateAiResult {
  * Anthropic API 直接呼び出しは Phase 4-1c 別 ISSUE で対応。
  */
 export function generateAi(opts: CliOptions): GenerateAiResult {
-  const { industry, scenarios, output, dryRun } = opts;
+  const { industry, scenarios, dryRun } = opts;
   const safeId = toSafeId(industry);
-  const outputDir = resolve(output);
+  const layout = resolveOutputLayout(opts, safeId);
+  const outputDir = layout.outputDir;
 
   console.log("🚀 generate-dogfood 開始 (AI モード)");
   console.log(`  industry : ${industry}`);
   console.log(`  scenarios: ${scenarios}`);
   console.log(`  output   : ${outputDir}`);
+  if (layout.project) {
+    console.log(`  project  : ${layout.project.projectId} (${layout.project.variant})`);
+  }
   console.log(`  dry-run  : ${dryRun}`);
   console.log();
 
@@ -728,20 +871,20 @@ export function generateAi(opts: CliOptions): GenerateAiResult {
     console.log("   生成予定ファイル:");
     console.log(`     ${briefingPath}`);
     console.log("   生成予定ディレクトリ:");
-    console.log(`     ${join(outputDir, "process-flows")}/`);
-    console.log(`     ${join(outputDir, "tables")}/`);
-    console.log(`     ${join(outputDir, "extensions", safeId)}/`);
-    console.log(`     ${join(outputDir, "conventions")}/`);
+    console.log(`     ${layout.flowsDir}/`);
+    console.log(`     ${layout.tablesDir}/`);
+    console.log(`     ${layout.extensionsDir}/`);
+    console.log(`     ${dirname(layout.conventionsCatalogFile)}/`);
     return { briefingPath, outputDir };
   }
 
   // 1. ディレクトリ骨格作成
-  prepareOutputDirs(outputDir, safeId);
+  prepareOutputDirs(layout);
   console.log("📁 出力ディレクトリを作成しました");
   console.log();
 
   // 2. briefing.md 生成
-  const content = generateBriefingContent({ industry, safeId, scenarios, outputDir });
+  const content = generateBriefingContent({ industry, safeId, scenarios, outputDir, layout });
   writeFileSync(briefingPath, content, "utf-8");
   console.log(`📝 briefing を生成: ${briefingPath}`);
   console.log();
@@ -759,7 +902,7 @@ export function generateAi(opts: CliOptions): GenerateAiResult {
   console.log("     1. 別セッションで Claude Code を起動 (claude コマンド)");
   console.log(`     2. _briefing.md を読み込む: Read ${briefingPath}`);
   console.log("     3. briefing の指示に従って ProcessFlow / テーブル / 拡張定義 / 規約を生成");
-  console.log("     4. 生成物を docs/sample-project/ に移動後 validate:dogfood で検証");
+  console.log("     4. 生成物が docs/sample-project/ または docs/sample-project-v3/<projectId>/ 配下なら、validate:dogfood で per-project 検証可能 (#615 / #617)");
   console.log();
   console.log("  ℹ️  AI モードでは validate:dogfood は実行しません (生成物がまだないため)");
 
@@ -779,10 +922,21 @@ if (opts.mode === "ai") {
 
   // dry-run でなければ validate:dogfood を実行
   if (!opts.dryRun) {
-    // validate:dogfood は docs/sample-project/ を見る。
-    // --output docs/sample-project/ 専用 (本格対応は別 ISSUE)
+    // validate:dogfood は docs/sample-project/ (v1) と docs/sample-project-v3/<projectId>/ (v3)
+    // を per-project スキャンする (#615 / #617)。
+    // 生成先がいずれかの配下なら自動検出される。それ以外なら検証はスキップして警告のみ表示。
     const designerDir = resolve(__dirname, "..");
-    runValidateDogfood(designerDir);
+    const repoRoot = resolve(designerDir, "..");
+    const isUnderSampleRoot =
+      result.flowPath.startsWith(resolve(repoRoot, "docs/sample-project")) ||
+      result.flowPath.startsWith(resolve(repoRoot, "docs/sample-project-v3"));
+    if (isUnderSampleRoot) {
+      runValidateDogfood(designerDir);
+    } else {
+      console.log();
+      console.log("ℹ️  生成先がサンプルルート (docs/sample-project / docs/sample-project-v3) 配下ではないため、");
+      console.log("   validate:dogfood は実行しませんでした。生成物をサンプルルート配下に移動して再実行してください。");
+    }
   } else {
     console.log();
     console.log("ℹ️  --dry-run モード: validate:dogfood はスキップしました");

--- a/designer/scripts/sample-projects.ts
+++ b/designer/scripts/sample-projects.ts
@@ -1,0 +1,136 @@
+/**
+ * サンプルプロジェクト発見モジュール (#617)
+ *
+ * docs/sample-project (v1 legacy) および docs/sample-project-v3/<project>/ 配下の
+ * 各サンプルプロジェクトを発見してプロジェクト識別子・ディレクトリ・
+ * リソース子ディレクトリパスをまとめて返す。
+ *
+ * 元実装は scripts/validate-dogfood.ts:126 にあった discoverProjects()。
+ * generate-dogfood.ts でも per-project 構造で出力先を解決するため、共通 module 化。
+ *
+ * spec: docs/spec/sample-project-structure.md
+ */
+
+import { existsSync, readdirSync } from "node:fs";
+import { resolve, join, relative } from "node:path";
+
+/**
+ * サンプルプロジェクト 1 件分の情報。
+ *
+ * v1 (flat) と v3 (per-project subdirectory) の両方を統一的に扱う。
+ */
+export interface SampleProjectInfo {
+  /** 識別子。v1 は "v1"、v3 は subdir 名 (finance / retail 等) */
+  projectId: string;
+  /** schema バージョン区分 */
+  variant: "v1" | "v3";
+  /** repoRoot からの相対パス (Windows path 区切りは正規化済み) */
+  displayName: string;
+  /** プロジェクトディレクトリの絶対パス */
+  projectDir: string;
+  /** tables ディレクトリの絶対パス (存在しなくても返す。loader 側で existsSync 必須) */
+  tablesDir: string;
+  /** screens ディレクトリの絶対パス (v1 では未配置の場合あり) */
+  screensDir: string;
+  /** process-flows ディレクトリの絶対パス */
+  flowsDir: string;
+  /** 規約カタログファイルの絶対パス (v1 / v3 で命名規則が異なる) */
+  conventionsCatalogFile: string;
+  /** extensions ディレクトリの絶対パス (v1 のみ flat 配置、v3 は per-project) */
+  extensionsDir: string;
+}
+
+export interface DiscoverProjectsOptions {
+  /** v1 を結果に含めるか (デフォルト true) */
+  includeV1?: boolean;
+  /** v3 を結果に含めるか (デフォルト true) */
+  includeV3?: boolean;
+}
+
+/**
+ * リポジトリルート (designer/.. = repoRoot) を解決する。
+ *
+ * scripts は CJS モード (scripts/package.json で "type": "commonjs") のため
+ * __dirname が使用可能。呼び出し元は import 後に repoRoot 引数で上書き可能。
+ */
+export function defaultRepoRoot(): string {
+  return resolve(__dirname, "../..");
+}
+
+/**
+ * v1 + v3 のサンプルプロジェクトを発見してリソース情報を返す。
+ *
+ * 発見規則:
+ *   - v1: docs/sample-project/ 直下に conventions/process-flows/tables のいずれか
+ *         (project.json を持たない legacy 構造)
+ *   - v3: docs/sample-project-v3/<subdir>/ に project.json があれば 1 project
+ *
+ * spec: docs/spec/sample-project-structure.md
+ */
+export function discoverProjects(
+  repoRoot: string = defaultRepoRoot(),
+  options: DiscoverProjectsOptions = {},
+): SampleProjectInfo[] {
+  const includeV1 = options.includeV1 !== false;
+  const includeV3 = options.includeV3 !== false;
+
+  const samplesV1Dir = resolve(repoRoot, "docs/sample-project");
+  const samplesV3Dir = resolve(repoRoot, "docs/sample-project-v3");
+
+  const projects: SampleProjectInfo[] = [];
+
+  if (includeV1) {
+    if (
+      existsSync(join(samplesV1Dir, "project.json")) ||
+      existsSync(join(samplesV1Dir, "process-flows")) ||
+      existsSync(join(samplesV1Dir, "conventions")) ||
+      existsSync(join(samplesV1Dir, "tables"))
+    ) {
+      projects.push({
+        projectId: "v1",
+        variant: "v1",
+        displayName: relative(repoRoot, samplesV1Dir).replace(/\\/g, "/"),
+        projectDir: samplesV1Dir,
+        tablesDir: join(samplesV1Dir, "tables"),
+        screensDir: join(samplesV1Dir, "screens"),
+        flowsDir: join(samplesV1Dir, "process-flows"),
+        conventionsCatalogFile: join(samplesV1Dir, "conventions/conventions-catalog.json"),
+        extensionsDir: join(samplesV1Dir, "extensions"),
+      });
+    }
+  }
+
+  if (includeV3 && existsSync(samplesV3Dir)) {
+    for (const entry of readdirSync(samplesV3Dir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const projectDir = join(samplesV3Dir, entry.name);
+      if (!existsSync(join(projectDir, "project.json"))) continue;
+      projects.push({
+        projectId: entry.name,
+        variant: "v3",
+        displayName: relative(repoRoot, projectDir).replace(/\\/g, "/"),
+        projectDir,
+        tablesDir: join(projectDir, "tables"),
+        screensDir: join(projectDir, "screens"),
+        flowsDir: join(projectDir, "process-flows"),
+        conventionsCatalogFile: join(projectDir, "conventions-catalog.v3.json"),
+        extensionsDir: join(projectDir, "extensions"),
+      });
+    }
+  }
+
+  return projects;
+}
+
+/**
+ * projectId (例: "finance" / "retail" / "v1") からプロジェクト情報を取得する。
+ * 見つからない場合は null。
+ */
+export function findProjectById(
+  projectId: string,
+  repoRoot: string = defaultRepoRoot(),
+  options: DiscoverProjectsOptions = {},
+): SampleProjectInfo | null {
+  const projects = discoverProjects(repoRoot, options);
+  return projects.find((p) => p.projectId === projectId) ?? null;
+}

--- a/designer/scripts/validate-dogfood.ts
+++ b/designer/scripts/validate-dogfood.ts
@@ -29,6 +29,7 @@ import { checkScreenItemFlowConsistency } from "../src/schemas/screenItemFlowVal
 import { checkScreenItemFieldTypeConsistency } from "../src/schemas/screenItemFieldTypeValidator.js";
 import { loadExtensionsFromBundle, type LoadedExtensions, type ExtensionsBundle } from "../src/schemas/loadExtensions.js";
 import type { Screen } from "../src/types/v3/screen.js";
+import { discoverProjects as discoverSampleProjects, type SampleProjectInfo } from "./sample-projects.js";
 
 // ─── パス解決 ──────────────────────────────────────────────────────────────
 
@@ -117,47 +118,22 @@ function loadScreensFromDir(dir: string): Screen[] {
 /**
  * v1 + v3 のサンプルプロジェクトを発見してリソース情報を返す。
  *
- * 発見規則:
- *   - v1: docs/sample-project/ (1 project、conventions は conventions/conventions-catalog.json、tables は tables/)
- *   - v3 per-project: docs/sample-project-v3/<subdir>/ に project.json があれば 1 project
+ * 発見ロジックは scripts/sample-projects.ts の discoverProjects() に共通化済 (#617)。
+ * ここでは validator 用に tables / conventions / screens を eager load する。
  *
  * spec: docs/spec/sample-project-structure.md
  */
 function discoverProjects(): ProjectResources[] {
-  const projects: ProjectResources[] = [];
-
-  // v1
-  if (existsSync(join(samplesV1Dir, "project.json")) || existsSync(join(samplesV1Dir, "process-flows"))) {
-    projects.push({
-      projectId: "v1",
-      displayName: relative(repoRoot, samplesV1Dir).replace(/\\/g, "/"),
-      projectDir: samplesV1Dir,
-      tables: loadTablesFromDir(join(samplesV1Dir, "tables")),
-      conventions: loadConventionsFromFile(join(samplesV1Dir, "conventions/conventions-catalog.json")),
-      screens: loadScreensFromDir(join(samplesV1Dir, "screens")),
-      flowsDir: join(samplesV1Dir, "process-flows"),
-    });
-  }
-
-  // v3 per-project (旧 v3-root 過渡期 fallback は #616 で retail/ に移動完了したため削除)
-  if (existsSync(samplesV3Dir)) {
-    for (const entry of readdirSync(samplesV3Dir, { withFileTypes: true })) {
-      if (!entry.isDirectory()) continue;
-      const projectDir = join(samplesV3Dir, entry.name);
-      if (!existsSync(join(projectDir, "project.json"))) continue;
-      projects.push({
-        projectId: entry.name,
-        displayName: relative(repoRoot, projectDir).replace(/\\/g, "/"),
-        projectDir,
-        tables: loadTablesFromDir(join(projectDir, "tables")),
-        conventions: loadConventionsFromFile(join(projectDir, "conventions-catalog.v3.json")),
-        screens: loadScreensFromDir(join(projectDir, "screens")),
-        flowsDir: join(projectDir, "process-flows"),
-      });
-    }
-  }
-
-  return projects;
+  const infos: SampleProjectInfo[] = discoverSampleProjects(repoRoot);
+  return infos.map((info) => ({
+    projectId: info.projectId,
+    displayName: info.displayName,
+    projectDir: info.projectDir,
+    tables: loadTablesFromDir(info.tablesDir),
+    conventions: loadConventionsFromFile(info.conventionsCatalogFile),
+    screens: loadScreensFromDir(info.screensDir),
+    flowsDir: info.flowsDir,
+  }));
 }
 
 /**

--- a/designer/src/schemas/generateDogfood.test.ts
+++ b/designer/src/schemas/generateDogfood.test.ts
@@ -438,3 +438,99 @@ describe("generate-dogfood --mode ai (AI 推論モード, #504)", () => {
     expect(output).toContain("--mode");
   });
 });
+
+describe("generate-dogfood --project オプション (per-project mode, #617)", () => {
+  it("--project v1 --mode ai --dry-run は v1 layout (flat) のパスをログ出力する", () => {
+    const scriptPath = resolve(repoRoot, "designer/scripts/generate-dogfood.ts");
+    const tsxPath = resolveTsxPath(repoRoot);
+
+    const result = spawnSync(
+      tsxPath,
+      [
+        scriptPath,
+        "--project", "v1",
+        "--mode", "ai",
+        "--dry-run",
+      ],
+      {
+        cwd: designerDir,
+        encoding: "utf-8",
+        shell: process.platform === "win32",
+        maxBuffer: 5 * 1024 * 1024,
+      },
+    );
+
+    // 終了コード 0
+    expect(result.status).toBe(0);
+    const output = result.stdout ?? "";
+
+    // dry-run なのでディレクトリ作成はスキップされる
+    expect(output).toContain("dry-run");
+
+    // v1 プロジェクト配下のパスが出力に含まれること (sample-project 配下; Windows では \ 区切りのため部分一致)
+    expect(output).toContain("sample-project");
+
+    // AI モードなので _briefing.md がログに出る
+    expect(output).toContain("_briefing.md");
+  });
+
+  it("--project finance --mode ai --dry-run は v3 layout (subdirectory) のパスをログ出力する", () => {
+    const scriptPath = resolve(repoRoot, "designer/scripts/generate-dogfood.ts");
+    const tsxPath = resolveTsxPath(repoRoot);
+
+    const result = spawnSync(
+      tsxPath,
+      [
+        scriptPath,
+        "--project", "finance",
+        "--mode", "ai",
+        "--dry-run",
+      ],
+      {
+        cwd: designerDir,
+        encoding: "utf-8",
+        shell: process.platform === "win32",
+        maxBuffer: 5 * 1024 * 1024,
+      },
+    );
+
+    // 終了コード 0
+    expect(result.status).toBe(0);
+    const output = result.stdout ?? "";
+
+    // v3 プロジェクト配下のパスが出力に含まれること (docs/sample-project-v3/finance 配下)
+    expect(output).toContain("sample-project-v3");
+    expect(output).toContain("finance");
+
+    // project 情報がログに出力される
+    expect(output).toContain("v3");
+
+    // AI モードなので _briefing.md がログに出る
+    expect(output).toContain("_briefing.md");
+  });
+
+  it("--project nonexistent は該当プロジェクト不在でエラー終了コード 1", () => {
+    const scriptPath = resolve(repoRoot, "designer/scripts/generate-dogfood.ts");
+    const tsxPath = resolveTsxPath(repoRoot);
+
+    const result = spawnSync(
+      tsxPath,
+      [
+        scriptPath,
+        "--project", "nonexistent-project-xyz",
+      ],
+      {
+        cwd: designerDir,
+        encoding: "utf-8",
+        shell: process.platform === "win32",
+        maxBuffer: 1 * 1024 * 1024,
+      },
+    );
+
+    expect(result.status).toBe(1);
+    const output = (result.stderr ?? "") + (result.stdout ?? "");
+    // エラーメッセージに --project と不在プロジェクト名が含まれること
+    expect(output).toContain("--project");
+    expect(output).toContain("nonexistent-project-xyz");
+  });
+});


### PR DESCRIPTION
## 関連

- Closes #617
- 仕様: docs/spec/sample-project-structure.md (サンプルプロジェクト per-project 完結原則)
- 関連 PR: #615 (validate-dogfood per-project 化、本 PR の前提)
- 関連 ISSUE: #607 (Phase 3 一連)

## 概要

`generate-dogfood.ts` の v1 専用 path ベタ書き 9 箇所を per-project 構造へ対応させ、`validate-dogfood.ts` の `discoverProjects()` を共通 module `designer/scripts/sample-projects.ts` に切り出した。これにより v1 (legacy flat) と v3 per-project 両方の出力先を同じ発見ロジックで解決でき、`--project <projectId>` 指定で既存サンプルプロジェクト (例: `finance` / `retail`) へ追記書き込みが可能になる。

## 主な変更

- 共通 module: `designer/scripts/sample-projects.ts` (新規) — `SampleProjectInfo` (variant: "v1" | "v3" 区分付き) / `discoverProjects` / `findProjectById` / `defaultRepoRoot` を export
- validator: `validate-dogfood.ts` の `discoverProjects()` 本体を共通 module 呼び出しに置換 (regression なし)
- generator: `generate-dogfood.ts` に `--project <projectId>` オプション追加。`resolveOutputLayout()` が v1/v3 variant を見て extensions 配置 (v1: `extensions/<ns>/field-types.json`, v3: `extensions/<ns>.v3.json`) と conventions catalog 配置 (v1: `conventions/conventions-catalog.json`, v3: `conventions-catalog.v3.json`) を自動切替
- briefing template: v1 ベタ書き 9 箇所を per-project layout 由来の相対 path に置換、AI モード推奨手順・参考資料も per-project スキャン (#615) 前提に更新
- dummy モード末尾: validate:dogfood 自動実行はサンプルルート (`docs/sample-project/` または `docs/sample-project-v3/<projectId>/`) 配下のみ

## 仕様逐条突合 (自己申告)

ISSUE #617 完了基準ベース:

- [x] **設計判断 (案 A) の合意** → 案 A (discoverProjects 共通化) 採用、ユーザー指示書通り
- [x] **generate-dogfood.ts v1 専用 path ベタ書き 9 箇所の解消**:
  - briefing 拡張定義セクション (旧 line 456-464) → `generate-dogfood.ts:567-577` (extensionsFileRel, layout-aware namespace 形式説明)
  - briefing テーブル定義セクション (旧 line 466-470) → `generate-dogfood.ts:578` (tablesRel)
  - briefing conventions セクション (旧 line 474-477) → `generate-dogfood.ts:586-590` (conventionsRel + fallbackConventionsLabel)
  - briefing 処理フローセクション (旧 line 479) → `generate-dogfood.ts:591` (flowsRel)
  - briefing 推奨手順 (旧 line 514/517) → `generate-dogfood.ts:628-631` (per-project スキャン前提に書き換え)
  - briefing 検証コマンド注釈 (旧 line 527-528) → `generate-dogfood.ts:639-641` (per-project 自動検出に修正)
  - briefing 参考資料 (旧 line 560-561) → `generate-dogfood.ts:671` (fallbackConventionsLabel + per-project 全件指示)
  - generate() 内 sourceConventionsFile (旧 line 669-674) → `generate-dogfood.ts:803` + `findFallbackConventionsSource()` 定義 `823-832` (v1→v3 順で発見)
  - generateAi() 案内 (旧 line 762) → `generate-dogfood.ts:905` (per-project 構造説明)
  - CLI 起点 validate:dogfood 自動実行コメント (旧 line 782-783) → `generate-dogfood.ts:925-937` (サンプルルート配下チェックに条件付け)
- [x] **vitest src/schemas/ 全件 pass** → 16 files / 458 tests pass (--project オプション動作テスト 3 件追加含む)
- [x] **generate-dogfood 実行で v1/v3 サンプル意図通り生成** → `--project finance --mode ai` で `docs/sample-project-v3/finance/` 配下に briefing 生成確認、`--project finance` の variant 表示 / extensions/finance.v3.json / conventions-catalog.v3.json path 表示を確認
- [x] **regression なし** → validate:dogfood 18 flows / 8 projects 全 pass
- [x] **schema 変更ゼロ** → `git diff origin/main..HEAD -- schemas/` 空

## レビューで特に見てほしい箇所

- `resolveOutputLayout()` (`generate-dogfood.ts:164-205`) の v1/v3 分岐: v3 では extensions が `extensions/<ns>.v3.json` (1 file 統合)、v1 は `extensions/<ns>/field-types.json` (種別ごと別 file) と命名規則が異なるため、briefing 説明文も両方記載 (`generate-dogfood.ts:567-577`)
- `findFallbackConventionsSource()` (`generate-dogfood.ts:823-832`) は generate 時の規約 catalog テンプレートを v1→v3 順で探す。出力先に既存 catalog があればそれをベース、無ければサンプルから取得、それも無ければ最小骨格にフォールバック (3 段階)
- 共通 module `sample-projects.ts` の `SampleProjectInfo.variant` フィールド: v1 は `"v1"`, v3 は `"v3"`。validate-dogfood では variant 未参照だが、generate-dogfood は extensions / conventions の path 規則を分岐するため必須

## テスト

- Vitest: 458 件 (新規 3) — --project v1/finance/nonexistent の per-project mode 動作テスト追加、schema test 全 pass、共通 module 切り出しに regression なし確認
- Playwright: N/A — scripts のみの変更
- MCP E2E: N/A
- 手動動作確認:
  - `npm run validate:dogfood` → 18 flows / 8 projects 全 pass (v1 + v3 finance/healthcare/logistics/manufacturing/public-service/retail/welfare-benefit)
  - `npm run generate:dogfood -- --project finance --mode ai --dry-run` → v3 layout 表示確認
  - `npm run generate:dogfood -- --project finance --scenarios "test scenario" --mode ai` → briefing 生成、per-project path 反映確認
  - `npm run generate:dogfood -- --industry test-industry --output /tmp/... --mode dummy --dry-run` → ad-hoc 出力 (legacy 互換) も動作

## UI 影響 / AI smoke test

- [ ] UI 影響あり
- [x] UI 影響なし (auto テスト pass のみ) — 開発スクリプトのみの変更、ランタイム UI への影響なし

## spec 側の不足点 / 提案

N/A — 既存 spec (`docs/spec/sample-project-structure.md`) の per-project 原則に沿った変更で、spec 修正は不要。

## レビュー担当への申し送り

- **schema governance**: グローバル schema (`schemas/`) は一切変更していない (`git diff origin/main..HEAD -- schemas/` 空)
- **文字化けスキャン済**: `git grep '[ｦ-ﾟ]' designer/scripts/{generate-dogfood.ts,validate-dogfood.ts,sample-projects.ts}` で 0 件
- **設計判断**: 案 A (discoverProjects 共通化) 採用。案 B (v3 別 script) は重複ロジック生成、案 C (deprecate) は v1 retire まだ早い、と判断
- **後方互換性**: `--output <dir>` 単独指定の旧 ad-hoc mode は引き続き動作 (CLI option `--project` は optional)。validate:dogfood 自動実行のみサンプルルート配下条件付けに変更
- **盲点候補**:
  - briefing 内の path 表記が outputDir 起点の相対 path になっている。AI orchestrator が読む際に混乱しないか
  - `resolveOutputLayout` で `--project` 未指定 + `--output` 指定時は ad-hoc mode (v1 互換 flat) になる。意図せず legacy 構造で生成される可能性あり、ただしこれは旧仕様維持のため意図通り

🤖 Generated with [Claude Code](https://claude.com/claude-code)
