### PR TITLE
feat(validator): sqlOrderValidator 新設 — DB 制約 × フロー操作順序の交差検査 MVP (#632)

### DIFF
--- a/.claude/skills/create-flow/SKILL.md
+++ b/.claude/skills/create-flow/SKILL.md
@@ -241,6 +241,19 @@ UI 起点フロー (`type: "screen"` / `mode: "upstream"`) を作成するとき
 - 典型ミス: happy-path で全前提を pre-seed、edge は 400/403 系の検証に偏り、初回ユーザーパスが抜ける
 - **補足**: 静的検出 `sqlOrderValidator` (#632) が導入されるまで本ルールが主要 catch 機構。導入後も「値レベル fixture 不足」など静的検出では届かない領域は本ルールで継続担保 (Step 5.2 validate:dogfood では機械検出されない、Step 3 self-check のみで担保)
 
+### Rule 19: DB 制約 × INSERT 操作順序 (#632)
+
+- INSERT 文の VALUES で使う変数が INSERT 時点でバインド済みか確認 (NOT NULL カラムが対象)
+  - 未バインド変数を NOT NULL カラムに入れている場合: 実行時 DB 制約違反 → Must-fix
+  - NULL リテラルを NOT NULL カラムに挿入: 実行時 DB 制約違反 → Must-fix
+  - autoIncrement / DEFAULT 付きカラムは省略可 (DB 側が値を補完)
+- FK カラムに未バインド変数を INSERT する場合: 参照先テーブルの行が未確保 → Must-fix
+  - SELECT で outputBinding された変数を FK に使う (= 既存行 ID 参照) は正常
+  - inputs から来た変数を FK に使う (= 外部から受け取った ID) は正常
+  - 全く出どころ不明の変数を FK カラムに使う場合のみ issue
+
+**Step 5.2 で `validate:dogfood` の `sqlOrderValidator` により機械的に検出される**
+
 ## Step 4: 拡張定義の使い方
 
 ### 既存 namespace を使う場合
@@ -295,6 +308,7 @@ npm run validate:dogfood
 | identifierScope | 識別子スコープ違反 (root レベル) | Rule 1 補強 |
 | screenItemFlowValidator | 画面項目イベント ↔ 処理フロー連携の整合 (handlerFlowId 実在 / argumentMapping 整合 / primaryInvoker 双方向) | Rule 16 |
 | screenItemFieldTypeValidator | 画面項目 ↔ 処理フロー 値レベル整合 (options 包含 / domainKey / 型 / pattern / range / length) | Rule 17 |
+| sqlOrderValidator | NOT NULL × INSERT 順序 (NULL_NOT_ALLOWED_AT_INSERT) / FK × INSERT 順序 (FK_REFERENCE_NOT_INSERTED) | Rule 19 |
 
 **fail した場合の対処**:
 - `UNKNOWN_COLUMN` → SELECT 句を見直す or テーブル定義を更新

--- a/.claude/skills/create-flow/SKILL.md
+++ b/.claude/skills/create-flow/SKILL.md
@@ -1,4 +1,4 @@
----
+﻿---
 name: create-flow
 description: ProcessFlow JSON を品質ガード付きで新規作成する。/review-flow の 10 観点 + 18 ルールを作成前 self-check として組み込み、既知パターンの再発を抑制 + グローバル schema 変更禁止 (#511) + 画面項目連携整合性 (#621)
 argument-hint: <flowId> <業務概要> [namespace]
@@ -289,7 +289,7 @@ npx vitest run src/schemas/extensions-samples.test.ts src/schemas/process-flow.s
 npm run build
 ```
 
-### 5.2 バリデータ横断検証 (Rule 9 / 10 / 16 / 17 の機械的検出、Rule 18 は AI 目視)
+### 5.2 バリデータ横断検証 (Rule 9 / 10 / 16 / 17 / 19 の機械的検出、Rule 18 は AI 目視)
 
 作成したフローを `docs/sample-project/process-flows/<flowId>.json` に配置した状態で:
 

--- a/.claude/skills/review-flow/SKILL.md
+++ b/.claude/skills/review-flow/SKILL.md
@@ -80,7 +80,7 @@ cd designer
 npm run validate:dogfood
 ```
 
-### 何が動くか (6 バリデータ)
+### 何が動くか (7 バリデータ)
 
 | # | バリデータ | 検出内容 | 入力 |
 |---|---|---|---|
@@ -90,12 +90,13 @@ npm run validate:dogfood
 | 4 | conventionsValidator | `@conv.*` 参照が catalog 未登録 | `docs/sample-project/conventions/conventions-catalog.json` を自動ロード |
 | 5 | screenItemFlowValidator | 画面項目イベント ↔ 処理フロー連携 (handlerFlowId 実在 / argumentMapping 整合 / primaryInvoker 双方向 / events[].id ユニーク) | 各プロジェクトの `screens/` を per-project でロード (project-level 検査、#619/#621) |
 | 6 | screenItemFieldTypeValidator | 画面項目 ↔ フロー 値レベル整合 | 画面項目定義ファイル + 処理フロー JSON |
+| 7 | sqlOrderValidator | DB 制約 × 操作順序 (NOT NULL × INSERT / FK × INSERT 順序) | テーブル定義 (v3 形式) を自動ロード (#632) |
 
 ### 結果の取り扱い
 
 - バリデータが検出した issue は **Step 1 のレビュー入力**として活用 (重複説明はしない)
 - 結果は Step 2 の「10 観点別カバレッジ」表に **「validator 検出済」** カラムとして記録
-- Must-fix 候補: `UNKNOWN_RESPONSE_REF` / `UNKNOWN_ERROR_CODE` / `UNKNOWN_IDENTIFIER` / `UNKNOWN_COLUMN` / `UNKNOWN_CONV_*` / `UNKNOWN_HANDLER_FLOW` / `MISSING_REQUIRED_ARGUMENT` / `EXTRA_ARGUMENT` / `PRIMARY_INVOKER_MISMATCH` / `DUPLICATE_EVENT_ID` 等
+- Must-fix 候補: `UNKNOWN_RESPONSE_REF` / `UNKNOWN_ERROR_CODE` / `UNKNOWN_IDENTIFIER` / `UNKNOWN_COLUMN` / `UNKNOWN_CONV_*` / `UNKNOWN_HANDLER_FLOW` / `MISSING_REQUIRED_ARGUMENT` / `EXTRA_ARGUMENT` / `PRIMARY_INVOKER_MISMATCH` / `DUPLICATE_EVENT_ID` / `NULL_NOT_ALLOWED_AT_INSERT` / `FK_REFERENCE_NOT_INSERTED` 等
 - Should-fix 候補 (warning): `INCONSISTENT_ARGUMENT_CONTRACT` (1 フローを呼ぶ複数イベント間で argumentMapping キー集合が異なる)
 - 終了コード 1 (1 件以上 fail) でも Step 1 を中止せず実施する (実行セマンティクス観点が AI 目視のみで残るため)
 
@@ -103,7 +104,7 @@ npm run validate:dogfood
 
 | 観点 | バリデータでカバー | AI 目視のみ |
 |---|---|---|
-| 1. 変数ライフサイクル | identifierScope (root 識別子の未宣言) | TX 順序 / property path / 前方参照は AI |
+| 1. 変数ライフサイクル | identifierScope (root 識別子の未宣言) / sqlOrderValidator (INSERT 時点の未バインド変数) | TX 順序 / property path / 前方参照は AI |
 | 2. TX スコープ整合 | (なし) | AI |
 | 3. runIf 連鎖の網羅性 | (なし) | AI |
 | 4. branch / elseBranch 到達性 | (なし) | AI |
@@ -113,6 +114,7 @@ npm run validate:dogfood
 | 8. rollbackOn 発火可能性 | referentialIntegrity (UNKNOWN_ERROR_CODE) | TX inner からの実発火可能性は AI |
 | 9. 画面項目イベント連携整合 | screenItemFlowValidator (handlerFlowId / argumentMapping / primaryInvoker / events[].id ユニーク) | 業務文脈での argumentMapping 値の妥当性 (UI 入力 → フロー入力の意味的整合) は AI |
 | 10. 画面項目値レベル整合 | screenItemFieldTypeValidator (options 包含 / domainKey / 型 / pattern / range / length) | 業務文脈の妥当性 (選択肢命名の業務適切性 / domain 設計妥当性) は AI |
+| 11. DB 制約 × INSERT 順序 (#632) | sqlOrderValidator (NULL_NOT_ALLOWED_AT_INSERT / FK_REFERENCE_NOT_INSERTED) | 複雑な条件分岐での可能性の有無は AI |
 
 監査根拠: `docs/spec/dogfood-2026-04-29-phase2-validator-audit.md` §3 / §4 + Phase 3 子 1 #619 (PR #626)。
 

--- a/designer/scripts/validate-dogfood.ts
+++ b/designer/scripts/validate-dogfood.ts
@@ -359,25 +359,25 @@ export async function runValidation(flowPath?: string): Promise<ValidationSummar
       issues.push({ validator: "sqlColumnValidator", message: `[${issue.code}] ${issue.path}: ${issue.message}` });
     }
 
-    // 7. DB 制約 × 操作順序検証 (#632 MVP: NULL_NOT_ALLOWED_AT_INSERT / FK_REFERENCE_NOT_INSERTED)
+    // 2. DB 制約 × 操作順序検証 (#632 MVP: NULL_NOT_ALLOWED_AT_INSERT / FK_REFERENCE_NOT_INSERTED)
     const sqlOrderIssues = checkSqlOrder(flow, project.tables as unknown as OrderTableDefinition[]);
     for (const issue of sqlOrderIssues) {
       issues.push({ validator: "sqlOrderValidator", message: `[${issue.code}] ${issue.path}: ${issue.message}` });
     }
 
-    // 2. 規約カタログ参照検証
+    // 3. 規約カタログ参照検証
     const convIssues = checkConventionReferences(flow, project.conventions);
     for (const issue of convIssues) {
       issues.push({ validator: "conventionsValidator", message: `[${issue.code}] ${issue.path}: ${issue.message}` });
     }
 
-    // 3. クロスリファレンス整合性検証 (extensions は global 統合)
+    // 4. クロスリファレンス整合性検証 (extensions は global 統合)
     const integrityIssues = checkReferentialIntegrity(flow, extensions);
     for (const issue of integrityIssues) {
       issues.push({ validator: "referentialIntegrity", message: `[${issue.code}] ${issue.path}: ${issue.message}` });
     }
 
-    // 4. 識別子スコープ検証
+    // 5. 識別子スコープ検証
     const scopeIssues = checkIdentifierScopes(flow);
     for (const issue of scopeIssues) {
       issues.push({ validator: "identifierScope", message: `[${issue.code}] ${issue.path}: @${issue.identifier} — ${issue.message}` });

--- a/designer/scripts/validate-dogfood.ts
+++ b/designer/scripts/validate-dogfood.ts
@@ -22,6 +22,7 @@ import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { resolve, join, basename, relative, isAbsolute } from "node:path";
 import type { ProcessFlow } from "../src/types/action.js";
 import { checkSqlColumns, type TableDefinition } from "../src/schemas/sqlColumnValidator.js";
+import { checkSqlOrder, type OrderTableDefinition } from "../src/schemas/sqlOrderValidator.js";
 import { checkConventionReferences, type ConventionsCatalog } from "../src/schemas/conventionsValidator.js";
 import { checkReferentialIntegrity } from "../src/schemas/referentialIntegrity.js";
 import { checkIdentifierScopes } from "../src/schemas/identifierScope.js";
@@ -358,6 +359,12 @@ export async function runValidation(flowPath?: string): Promise<ValidationSummar
       issues.push({ validator: "sqlColumnValidator", message: `[${issue.code}] ${issue.path}: ${issue.message}` });
     }
 
+    // 7. DB 制約 × 操作順序検証 (#632 MVP: NULL_NOT_ALLOWED_AT_INSERT / FK_REFERENCE_NOT_INSERTED)
+    const sqlOrderIssues = checkSqlOrder(flow, project.tables as unknown as OrderTableDefinition[]);
+    for (const issue of sqlOrderIssues) {
+      issues.push({ validator: "sqlOrderValidator", message: `[${issue.code}] ${issue.path}: ${issue.message}` });
+    }
+
     // 2. 規約カタログ参照検証
     const convIssues = checkConventionReferences(flow, project.conventions);
     for (const issue of convIssues) {
@@ -455,6 +462,7 @@ const validatorDisplayOrder = [
   "identifierScope",
   "screenItemFlowValidator",
   "screenItemFieldTypeValidator",
+  "sqlOrderValidator",
 ];
 
 function printSummary(summary: ValidationSummary, options: { singleFlow: boolean }): void {

--- a/designer/src/schemas/sqlOrderValidator.test.ts
+++ b/designer/src/schemas/sqlOrderValidator.test.ts
@@ -1,0 +1,739 @@
+/**
+ * sqlOrderValidator テスト (#632 MVP: 観点 1+2)
+ *
+ * - 観点 1 (NULL_NOT_ALLOWED_AT_INSERT): 10 ケース
+ * - 観点 2 (FK_REFERENCE_NOT_INSERTED): 4 ケース
+ * - 共通: 空入力 / DELETE・SELECT スキップ / SQL パースエラー耐性
+ *
+ * welfare-benefit M1 実証 fixture は末尾の describe で実施。
+ */
+
+import { describe, it, expect } from "vitest";
+import { checkSqlOrder, type OrderTableDefinition } from "./sqlOrderValidator";
+import type { ProcessFlow } from "../types/v3";
+
+// ─── テスト用ヘルパー ──────────────────────────────────────────────────────
+
+function makeFlow(overrides: Partial<ProcessFlow> = {}): ProcessFlow {
+  return {
+    id: "ffffffff-0001-4000-8000-000000000001",
+    name: "テストフロー",
+    version: "1.0.0",
+    maturity: "draft",
+    createdAt: "2026-04-30T00:00:00.000Z",
+    updatedAt: "2026-04-30T00:00:00.000Z",
+    kind: "screen",
+    context: {},
+    actions: [],
+    ...overrides,
+  } as ProcessFlow;
+}
+
+/**
+ * テーブル定義ショートカット。
+ * columns: [{ physicalName, notNull?, autoIncrement?, defaultValue? }, ...]
+ * constraints: [{ kind: "foreignKey", columnPhysicalNames, referencedTableId }, ...]
+ */
+function makeTable(
+  id: string,
+  physicalName: string,
+  columns: Array<{
+    id?: string;
+    physicalName: string;
+    notNull?: boolean;
+    autoIncrement?: boolean;
+    defaultValue?: string;
+    primaryKey?: boolean;
+  }>,
+  fkConstraints?: Array<{ columnPhysicalNames: string[]; referencedTableId: string }>,
+): OrderTableDefinition {
+  const cols = columns.map((c, i) => ({
+    id: c.id ?? `col-${physicalName}-${i + 1}`,
+    physicalName: c.physicalName,
+    notNull: c.notNull,
+    autoIncrement: c.autoIncrement,
+    defaultValue: c.defaultValue,
+    primaryKey: c.primaryKey,
+  }));
+
+  // FK 制約の columnIds は physicalName → id の逆引きで解決
+  const physicalToId = new Map<string, string>(cols.map((c) => [c.physicalName, c.id]));
+
+  const constraints = (fkConstraints ?? []).map((fk, i) => ({
+    kind: "foreignKey" as const,
+    id: `fk-${physicalName}-${i + 1}`,
+    columnIds: fk.columnPhysicalNames.map((p) => physicalToId.get(p) ?? p),
+    referencedTableId: fk.referencedTableId,
+    referencedColumnIds: ["col-ref-01"],
+  }));
+
+  return { id, physicalName, columns: cols, constraints };
+}
+
+// ─── 観点 1: NULL_NOT_ALLOWED_AT_INSERT ────────────────────────────────────
+
+describe("観点 1: NULL_NOT_ALLOWED_AT_INSERT", () => {
+  const tables: OrderTableDefinition[] = [
+    makeTable("tbl-users", "users", [
+      { physicalName: "id", notNull: true, autoIncrement: true, primaryKey: true },
+      { physicalName: "name", notNull: true },
+      { physicalName: "email", notNull: true },
+      { physicalName: "nickname" }, // nullable
+    ]),
+    makeTable("tbl-orders", "orders", [
+      { physicalName: "id", notNull: true, autoIncrement: true, primaryKey: true },
+      { physicalName: "user_id", notNull: true },
+      { physicalName: "amount", notNull: true },
+      { physicalName: "note" }, // nullable
+      { physicalName: "status", notNull: true, defaultValue: "'pending'" },
+    ]),
+  ];
+
+  it("正常系: NOT NULL カラムへの INSERT で変数が直前 step でバインドされている", () => {
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "ユーザー登録",
+          trigger: "submit",
+          inputs: [
+            { name: "userName", type: "string", required: true },
+            { name: "userEmail", type: "string", required: true },
+          ],
+          steps: [
+            {
+              id: "step-01",
+              kind: "dbAccess",
+              description: "ユーザーを INSERT",
+              tableId: "tbl-users",
+              operation: "INSERT",
+              sql: "INSERT INTO users (name, email) VALUES (@inputs.userName, @inputs.userEmail)",
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, tables);
+    expect(issues.filter((i) => i.code === "NULL_NOT_ALLOWED_AT_INSERT")).toHaveLength(0);
+  });
+
+  it("検出: NOT NULL カラムが変数参照で、変数が未バインド", () => {
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "注文登録",
+          trigger: "submit",
+          inputs: [],
+          steps: [
+            {
+              id: "step-01",
+              kind: "dbAccess",
+              description: "注文を INSERT (user_id が未バインド)",
+              tableId: "tbl-orders",
+              operation: "INSERT",
+              sql: "INSERT INTO orders (user_id, amount) VALUES (@user.id, @inputs.amount)",
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, tables);
+    const target = issues.filter((i) => i.code === "NULL_NOT_ALLOWED_AT_INSERT");
+    expect(target.length).toBeGreaterThanOrEqual(1);
+    expect(target.some((i) => i.message.includes("user_id") && i.message.includes("user"))).toBe(true);
+  });
+
+  it("検出: NULL リテラルを NOT NULL カラムに INSERT", () => {
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "テスト",
+          trigger: "submit",
+          inputs: [],
+          steps: [
+            {
+              id: "step-01",
+              kind: "dbAccess",
+              description: "name に NULL を挿入",
+              tableId: "tbl-users",
+              operation: "INSERT",
+              sql: "INSERT INTO users (name, email) VALUES (NULL, @inputs.email)",
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, tables);
+    const target = issues.filter((i) => i.code === "NULL_NOT_ALLOWED_AT_INSERT");
+    expect(target.some((i) => i.message.includes("name"))).toBe(true);
+  });
+
+  it("正常系: nullable カラムは未バインドでも issue なし", () => {
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "テスト",
+          trigger: "submit",
+          inputs: [
+            { name: "userName", type: "string", required: true },
+            { name: "userEmail", type: "string", required: true },
+          ],
+          steps: [
+            {
+              id: "step-01",
+              kind: "dbAccess",
+              description: "nickname は nullable なので省略可",
+              tableId: "tbl-users",
+              operation: "INSERT",
+              sql: "INSERT INTO users (name, email) VALUES (@inputs.userName, @inputs.userEmail)",
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, tables);
+    expect(issues.filter((i) => i.code === "NULL_NOT_ALLOWED_AT_INSERT")).toHaveLength(0);
+  });
+
+  it("正常系: autoIncrement カラムは未バインドでも issue なし", () => {
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "テスト",
+          trigger: "submit",
+          inputs: [
+            { name: "userName", type: "string", required: true },
+            { name: "userEmail", type: "string", required: true },
+          ],
+          steps: [
+            {
+              id: "step-01",
+              kind: "dbAccess",
+              description: "id は autoIncrement なので列リストから省略",
+              tableId: "tbl-users",
+              operation: "INSERT",
+              // id 列は指定しない → autoIncrement で DB が埋める → issue なし
+              sql: "INSERT INTO users (name, email) VALUES (@inputs.userName, @inputs.userEmail)",
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, tables);
+    expect(issues.filter((i) => i.code === "NULL_NOT_ALLOWED_AT_INSERT")).toHaveLength(0);
+  });
+
+  it("正常系: DEFAULT 付き NOT NULL カラムは issue なし (status = 'pending' default)", () => {
+    // status は NOT NULL だが defaultValue: "'pending'" があるため issue にならない
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "テスト",
+          trigger: "submit",
+          inputs: [
+            { name: "userId", type: "string", required: true },
+            { name: "amount", type: "number", required: true },
+          ],
+          steps: [
+            {
+              id: "step-01",
+              kind: "dbAccess",
+              description: "status は DEFAULT 付きなので省略可",
+              tableId: "tbl-orders",
+              operation: "INSERT",
+              sql: "INSERT INTO orders (user_id, amount) VALUES (@inputs.userId, @inputs.amount)",
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, tables);
+    expect(issues.filter((i) => i.code === "NULL_NOT_ALLOWED_AT_INSERT")).toHaveLength(0);
+  });
+
+  it("正常系: 直前 compute step でバインドされた変数は OK", () => {
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "テスト",
+          trigger: "submit",
+          inputs: [{ name: "rawName", type: "string", required: true }],
+          steps: [
+            {
+              id: "step-01",
+              kind: "compute",
+              description: "名前をトリム",
+              expression: "@inputs.rawName.trim()",
+              outputBinding: { name: "cleanName" },
+            },
+            {
+              id: "step-02",
+              kind: "dbAccess",
+              description: "INSERT",
+              tableId: "tbl-users",
+              operation: "INSERT",
+              sql: "INSERT INTO users (name, email) VALUES (@cleanName, @inputs.userEmail)",
+            },
+          ],
+        },
+      ],
+    });
+    // cleanName は step-01 でバインドされるため issue なし
+    // userEmail は inputs に無いため issue になるが、それは別の問題
+    const issues = checkSqlOrder(flow, tables);
+    // cleanName に関する NULL_NOT_ALLOWED_AT_INSERT は出ないことを確認
+    const cleanNameIssues = issues.filter(
+      (i) => i.code === "NULL_NOT_ALLOWED_AT_INSERT" && i.message.includes("cleanName"),
+    );
+    expect(cleanNameIssues).toHaveLength(0);
+  });
+});
+
+// ─── 観点 2: FK_REFERENCE_NOT_INSERTED ────────────────────────────────────
+
+describe("観点 2: FK_REFERENCE_NOT_INSERTED", () => {
+  const tables: OrderTableDefinition[] = [
+    makeTable("tbl-parent", "parent_records", [
+      { physicalName: "id", notNull: true, autoIncrement: true, primaryKey: true },
+      { physicalName: "code", notNull: true },
+    ]),
+    makeTable(
+      "tbl-child",
+      "child_records",
+      [
+        { physicalName: "id", notNull: true, autoIncrement: true, primaryKey: true },
+        { physicalName: "parent_id", notNull: true },
+        { physicalName: "value", notNull: true },
+      ],
+      [{ columnPhysicalNames: ["parent_id"], referencedTableId: "tbl-parent" }],
+    ),
+  ];
+
+  it("検出: FK 参照先への先行 INSERT なしで子テーブルを INSERT (未バインド変数)", () => {
+    // @unknownParent は inputs にも outputBinding にも存在しない → 未バインド → FK issue
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "テスト",
+          trigger: "submit",
+          inputs: [
+            { name: "value", type: "string", required: true },
+          ],
+          steps: [
+            {
+              id: "step-01",
+              kind: "dbAccess",
+              description: "子レコードを INSERT (parent_id が未バインド変数)",
+              tableId: "tbl-child",
+              operation: "INSERT",
+              // @unknownParent は inputs にも step outputBinding にも存在しない
+              sql: "INSERT INTO child_records (parent_id, value) VALUES (@unknownParent.id, @inputs.value)",
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, tables);
+    const target = issues.filter((i) => i.code === "FK_REFERENCE_NOT_INSERTED");
+    expect(target.length).toBeGreaterThanOrEqual(1);
+    expect(target.some((i) => i.message.includes("parent_records"))).toBe(true);
+  });
+
+  it("正常系: FK 参照先への先行 INSERT がある場合は issue なし", () => {
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "テスト",
+          trigger: "submit",
+          inputs: [
+            { name: "code", type: "string", required: true },
+            { name: "value", type: "string", required: true },
+          ],
+          steps: [
+            {
+              id: "step-01",
+              kind: "dbAccess",
+              description: "親レコードを INSERT",
+              tableId: "tbl-parent",
+              operation: "INSERT",
+              sql: "INSERT INTO parent_records (code) VALUES (@inputs.code)",
+              outputBinding: { name: "createdParent" },
+            },
+            {
+              id: "step-02",
+              kind: "dbAccess",
+              description: "子レコードを INSERT (先行 INSERT あり)",
+              tableId: "tbl-child",
+              operation: "INSERT",
+              sql: "INSERT INTO child_records (parent_id, value) VALUES (@createdParent.id, @inputs.value)",
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, tables);
+    expect(issues.filter((i) => i.code === "FK_REFERENCE_NOT_INSERTED")).toHaveLength(0);
+  });
+
+  it("検出: 異なる action 間の先行 INSERT は対象外 (同 action のみ検査、未バインド変数使用)", () => {
+    // act-001 で parent_records を INSERT したが、act-002 では未バインド変数を FK に使う
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "親作成",
+          trigger: "submit",
+          inputs: [{ name: "code", type: "string", required: true }],
+          steps: [
+            {
+              id: "step-01",
+              kind: "dbAccess",
+              description: "親レコードを INSERT (別 action)",
+              tableId: "tbl-parent",
+              operation: "INSERT",
+              sql: "INSERT INTO parent_records (code) VALUES (@inputs.code)",
+              outputBinding: { name: "createdParent" },
+            },
+          ],
+        },
+        {
+          id: "act-002",
+          name: "子作成",
+          trigger: "click",
+          inputs: [
+            { name: "value", type: "string", required: true },
+          ],
+          steps: [
+            {
+              // act-002 では parent_records への先行 INSERT も SELECT も無く、
+              // @unknownParent は未バインド → FK issue
+              id: "step-02",
+              kind: "dbAccess",
+              description: "子レコードを INSERT (同 action に先行 INSERT なし、未バインド変数)",
+              tableId: "tbl-child",
+              operation: "INSERT",
+              sql: "INSERT INTO child_records (parent_id, value) VALUES (@unknownParent.id, @inputs.value)",
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, tables);
+    // act-002 の step-02 は FK issue になるはず
+    const fkIssues = issues.filter((i) => i.code === "FK_REFERENCE_NOT_INSERTED");
+    expect(fkIssues.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ─── 共通: スキップ・エッジケース ──────────────────────────────────────────
+
+describe("共通: スキップ・エッジケース", () => {
+  const tables: OrderTableDefinition[] = [
+    makeTable("tbl-items", "items", [
+      { physicalName: "id", notNull: true, autoIncrement: true, primaryKey: true },
+      { physicalName: "name", notNull: true },
+    ]),
+  ];
+
+  it("空 actions は issue なし", () => {
+    const flow = makeFlow({ actions: [] });
+    const issues = checkSqlOrder(flow, tables);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("空 tables は issue なし (カタログ外テーブルは skip)", () => {
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "テスト",
+          trigger: "submit",
+          inputs: [],
+          steps: [
+            {
+              id: "step-01",
+              kind: "dbAccess",
+              description: "カタログ外テーブルへの INSERT",
+              tableId: "tbl-unknown",
+              operation: "INSERT",
+              sql: "INSERT INTO unknown_table (col1) VALUES (@var1)",
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, []);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("SELECT 文は観点 1+2 の対象外 (skip)", () => {
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "テスト",
+          trigger: "submit",
+          inputs: [],
+          steps: [
+            {
+              id: "step-01",
+              kind: "dbAccess",
+              description: "SELECT は対象外",
+              tableId: "tbl-items",
+              operation: "SELECT",
+              sql: "SELECT id, name FROM items WHERE id = @someVar",
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, tables);
+    expect(issues.filter((i) => ["NULL_NOT_ALLOWED_AT_INSERT", "FK_REFERENCE_NOT_INSERTED"].includes(i.code))).toHaveLength(0);
+  });
+
+  it("DELETE 文は観点 1+2 の対象外 (skip)", () => {
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "テスト",
+          trigger: "click",
+          inputs: [],
+          steps: [
+            {
+              id: "step-01",
+              kind: "dbAccess",
+              description: "DELETE は対象外",
+              tableId: "tbl-items",
+              operation: "DELETE",
+              sql: "DELETE FROM items WHERE id = @inputs.id",
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, tables);
+    expect(issues.filter((i) => ["NULL_NOT_ALLOWED_AT_INSERT", "FK_REFERENCE_NOT_INSERTED"].includes(i.code))).toHaveLength(0);
+  });
+
+  it("sql フィールドが無い dbAccess step はスキップ", () => {
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "テスト",
+          trigger: "submit",
+          inputs: [],
+          steps: [
+            {
+              id: "step-01",
+              kind: "dbAccess",
+              description: "SQL なし INSERT",
+              tableId: "tbl-items",
+              operation: "INSERT",
+              // sql: なし
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, tables);
+    expect(issues.filter((i) => i.code === "NULL_NOT_ALLOWED_AT_INSERT")).toHaveLength(0);
+  });
+
+  it("ambientVariables で宣言された変数は INSERT 時点でバインド済みとみなす", () => {
+    const flow = makeFlow({
+      context: {
+        ambientVariables: [
+          { name: "sessionUserId", type: "string" },
+          { name: "requestId", type: "string" },
+        ],
+      },
+      actions: [
+        {
+          id: "act-001",
+          name: "テスト",
+          trigger: "submit",
+          inputs: [{ name: "itemName", type: "string", required: true }],
+          steps: [
+            {
+              id: "step-01",
+              kind: "dbAccess",
+              description: "ambient variable を使用",
+              tableId: "tbl-items",
+              operation: "INSERT",
+              sql: "INSERT INTO items (name) VALUES (@inputs.itemName)",
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, tables);
+    expect(issues.filter((i) => i.code === "NULL_NOT_ALLOWED_AT_INSERT")).toHaveLength(0);
+  });
+});
+
+// ─── welfare-benefit M1 実証 fixture ────────────────────────────────────────
+
+describe("welfare-benefit M1 実証: beneficiary_id NOT NULL × INSERT 順序", () => {
+  /**
+   * Phase 2 子 2 #600 で発見した M1 の再現:
+   *   payments.beneficiary_id は NOT NULL
+   *   旧フローでは beneficiary SELECT の結果 (@beneficiary) が payments INSERT 時点で
+   *   「初回受給者」ケースで null になる可能性があった。
+   *
+   * 現行の welfare-benefit フローは修正済みだが、ここでは問題のある旧パターンを
+   * fixture として残して回帰検出を実証する。
+   */
+
+  const welfarePaymentsTable = makeTable(
+    "7198e401-00d8-4f6e-8382-aad4caeaf59e",
+    "payments",
+    [
+      { physicalName: "id", notNull: true, autoIncrement: true, primaryKey: true },
+      { physicalName: "application_id", notNull: true },
+      { physicalName: "beneficiary_id", notNull: true },   // M1 の源: NOT NULL
+      { physicalName: "amount", notNull: true },
+      { physicalName: "currency", notNull: true, defaultValue: "'JPY'" },
+      { physicalName: "payment_method", notNull: true, defaultValue: "'bank_transfer'" },
+      { physicalName: "bank_account_ref", notNull: true },
+      { physicalName: "idempotency_key", notNull: true },
+      { physicalName: "transfer_status", notNull: true, defaultValue: "'pending'" },
+    ],
+    [
+      {
+        columnPhysicalNames: ["application_id"],
+        referencedTableId: "b57571d6-dc31-4dad-aad9-a2315267ea90",
+      },
+      {
+        columnPhysicalNames: ["beneficiary_id"],
+        referencedTableId: "dde87bc9-e122-4466-9b1c-e8c5b2f98408",
+      },
+    ],
+  );
+
+  const beneficiariesTable = makeTable(
+    "dde87bc9-e122-4466-9b1c-e8c5b2f98408",
+    "beneficiaries",
+    [
+      { physicalName: "id", notNull: true, autoIncrement: true, primaryKey: true },
+      { physicalName: "beneficiary_code", notNull: true },
+      { physicalName: "applicant_id", notNull: true },
+      { physicalName: "fiscal_year", notNull: true },
+      { physicalName: "total_paid_amount", notNull: true, defaultValue: "0" },
+      { physicalName: "eligibility_status", notNull: true, defaultValue: "'eligible'" },
+    ],
+  );
+
+  const applicationsTable = makeTable(
+    "b57571d6-dc31-4dad-aad9-a2315267ea90",
+    "applications",
+    [
+      { physicalName: "id", notNull: true, autoIncrement: true, primaryKey: true },
+      { physicalName: "application_code", notNull: true },
+      { physicalName: "applicant_id", notNull: true },
+      { physicalName: "benefit_type", notNull: true },
+      { physicalName: "requested_amount", notNull: true },
+      { physicalName: "status", notNull: true, defaultValue: "'received'" },
+      { physicalName: "submitted_at", notNull: true },
+    ],
+  );
+
+  const tables = [welfarePaymentsTable, beneficiariesTable, applicationsTable];
+
+  it("旧パターン (M1 バグ): payments INSERT 時点で @beneficiary が未バインド → 検出", () => {
+    /**
+     * 旧フローのパターン:
+     *   step-06: beneficiaries SELECT → @beneficiary (nullable: 初回受給者は null)
+     *   step-XX: payments INSERT で @beneficiary.id を参照
+     *   → 初回受給者のとき @beneficiary.id は null → beneficiary_id NOT NULL 制約違反
+     *
+     * ここではより単純化して「@beneficiary が inputs にも outputBinding にも存在しない」
+     * 状態でパターンを再現する。
+     */
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-payment",
+          name: "支払処理",
+          trigger: "auto",
+          inputs: [
+            { name: "applicationId", type: "string", required: true },
+            { name: "bankAccountRef", type: "string", required: true },
+            { name: "idempotencyKey", type: "string", required: true },
+            { name: "amount", type: "number", required: true },
+          ],
+          steps: [
+            {
+              id: "step-pay-01",
+              kind: "dbAccess",
+              description: "payments テーブルに INSERT (beneficiary_id = @beneficiary.id は未バインド)",
+              tableId: "7198e401-00d8-4f6e-8382-aad4caeaf59e",
+              operation: "INSERT",
+              // @beneficiary は inputs / outputBinding のどちらにも存在しない → M1 パターン
+              sql: "INSERT INTO payments (application_id, beneficiary_id, amount, bank_account_ref, idempotency_key) VALUES (@inputs.applicationId, @beneficiary.id, @inputs.amount, @inputs.bankAccountRef, @inputs.idempotencyKey)",
+            },
+          ],
+        },
+      ],
+    });
+
+    const issues = checkSqlOrder(flow, tables);
+    const nullIssues = issues.filter((i) => i.code === "NULL_NOT_ALLOWED_AT_INSERT");
+    expect(nullIssues.length).toBeGreaterThanOrEqual(1);
+    expect(nullIssues.some((i) => i.message.includes("beneficiary_id") && i.message.includes("beneficiary"))).toBe(true);
+  });
+
+  it("修正後パターン: beneficiary SELECT → outputBinding → payments INSERT → 検出なし", () => {
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-payment",
+          name: "支払処理",
+          trigger: "auto",
+          inputs: [
+            { name: "applicationId", type: "string", required: true },
+            { name: "bankAccountRef", type: "string", required: true },
+            { name: "idempotencyKey", type: "string", required: true },
+            { name: "amount", type: "number", required: true },
+            { name: "applicantId", type: "string", required: true },
+          ],
+          steps: [
+            {
+              id: "step-01",
+              kind: "dbAccess",
+              description: "受給者台帳を取得",
+              tableId: "dde87bc9-e122-4466-9b1c-e8c5b2f98408",
+              operation: "SELECT",
+              sql: "SELECT id, eligibility_status FROM beneficiaries WHERE applicant_id = @inputs.applicantId",
+              outputBinding: { name: "beneficiary" },
+            },
+            {
+              id: "step-02",
+              kind: "dbAccess",
+              description: "payments INSERT (beneficiary.id は step-01 でバインド済み)",
+              tableId: "7198e401-00d8-4f6e-8382-aad4caeaf59e",
+              operation: "INSERT",
+              sql: "INSERT INTO payments (application_id, beneficiary_id, amount, bank_account_ref, idempotency_key) VALUES (@inputs.applicationId, @beneficiary.id, @inputs.amount, @inputs.bankAccountRef, @inputs.idempotencyKey)",
+            },
+          ],
+        },
+      ],
+    });
+
+    const issues = checkSqlOrder(flow, tables);
+    // beneficiary_id に関する NULL_NOT_ALLOWED_AT_INSERT は出ない
+    const nullIssues = issues.filter(
+      (i) => i.code === "NULL_NOT_ALLOWED_AT_INSERT" && i.message.includes("beneficiary_id"),
+    );
+    expect(nullIssues).toHaveLength(0);
+  });
+});

--- a/designer/src/schemas/sqlOrderValidator.ts
+++ b/designer/src/schemas/sqlOrderValidator.ts
@@ -1,0 +1,486 @@
+/**
+ * DB 制約 × フロー操作順序の交差検査 (#632 MVP: 観点 1+2)。
+ *
+ * 観点 1 (NULL_NOT_ALLOWED_AT_INSERT):
+ *   INSERT 時点で NOT NULL カラムに対応する変数が未バインド
+ *   (= outputBinding に記録されていない変数名を VALUES に使っている)
+ *
+ * 観点 2 (FK_REFERENCE_NOT_INSERTED):
+ *   INSERT 時点で FK 参照先テーブルへの先行 INSERT が同 action 内に無い
+ *   (= FK 制約の参照整合を保証する先行書き込みが存在しない)
+ *
+ * 既存 sqlColumnValidator と同じ node-sql-parser v5 AST walker を再利用。
+ * 変数バインド時系列追跡 + テーブル schema (notNull / foreignKey) との交差解析
+ * で実行時 DB 制約違反を構造的に検出する。
+ *
+ * 観点 3 (UNIQUE_CHECK_MISSING) → #640
+ * 観点 4 (CASCADE_DELETE_OMITTED) → #641
+ * 観点 5 (TX_CIRCULAR_DEPENDENCY) → #642
+ */
+
+import { Parser } from "node-sql-parser";
+import type { ProcessFlow, Step } from "../types/v3";
+import { isBuiltinStep } from "./stepGuards";
+
+// ─── 入力型: テーブル定義 (v3 形式) ────────────────────────────────────────
+
+/** カラム 1 件 (validator 内部で必要な最小フィールド)。 */
+export interface OrderTableColumn {
+  id: string;
+  physicalName: string;
+  notNull?: boolean;
+  primaryKey?: boolean;
+  autoIncrement?: boolean;
+  defaultValue?: string;
+}
+
+/** FK 制約 (validator 内部で必要な最小フィールド)。 */
+export interface OrderForeignKeyConstraint {
+  kind: "foreignKey";
+  columnIds: string[];
+  referencedTableId: string;
+}
+
+/** テーブル制約 (validator 内部では FK だけ利用)。 */
+export type OrderConstraint =
+  | { kind: "unique" | "check"; [key: string]: unknown }
+  | OrderForeignKeyConstraint;
+
+/** テーブル定義 (v3 table.v3.schema.json の最小シェイプ)。 */
+export interface OrderTableDefinition {
+  id: string;
+  physicalName: string;
+  columns: OrderTableColumn[];
+  constraints?: OrderConstraint[];
+}
+
+// ─── 出力型: 検出 issue ─────────────────────────────────────────────────────
+
+export interface SqlOrderIssue {
+  path: string;
+  code: "NULL_NOT_ALLOWED_AT_INSERT" | "FK_REFERENCE_NOT_INSERTED" | "SQL_PARSE_ERROR";
+  message: string;
+}
+
+// ─── パーサー初期化 ─────────────────────────────────────────────────────────
+
+const parser = new Parser();
+const DIALECT = "postgresql" as const;
+
+/** @xxx / @x.y.z を $N プレースホルダに置換 (sqlColumnValidator と同じ手法)。 */
+function substituteAtVars(sql: string): string {
+  let n = 0;
+  return sql.replace(/@[a-zA-Z_][\w.?]*/g, () => `$${++n}`);
+}
+
+// ─── AST ヘルパー ───────────────────────────────────────────────────────────
+
+/** INSERT AST から対象テーブル名を取得 (lowercase)。 */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function extractInsertTableName(ast: any): string | null {
+  if (!ast || typeof ast !== "object") return null;
+  if (ast.type === "insert" && Array.isArray(ast.table)) {
+    for (const t of ast.table) {
+      if (t.table && typeof t.table === "string") return t.table.toLowerCase();
+    }
+  }
+  return null;
+}
+
+/**
+ * INSERT AST から (columnPhysicalName → varName | null) マップを抽出。
+ *
+ * node-sql-parser v5 PostgreSQL dialect での INSERT AST 構造:
+ *   - ast.columns: Array<{ type: "default", value: string }> (列名リスト)
+ *   - ast.values: { type: "values", values: Array<{ type: "expr_list", value: any[] }> }
+ *   - 各 value 要素: { type: "var", name: number, prefix: "$", members: [] }  ← プレースホルダ
+ *                 または { type: "null", value: null }  ← NULL リテラル
+ *                 または { type: "number" | "string" | ... }  ← リテラル
+ *
+ * @atVarMap: プレースホルダ番号 (1, 2, ...) → 元の @varName のルート名のマップ
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function extractInsertColumnVarMap(ast: any, atVarMap: Map<number, string>): Map<string, string | null> {
+  const result = new Map<string, string | null>();
+  if (!ast || ast.type !== "insert") return result;
+
+  // columns: Array<{ type: "default", value: string }> または string[] のどちらもサポート
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const columns: string[] = Array.isArray(ast.columns) ? ast.columns.map((c: any) => {
+    if (typeof c === "string") return c;
+    if (c && typeof c.value === "string") return c.value;
+    return String(c);
+  }) : [];
+
+  // values: { type: "values", values: Array<{ type: "expr_list", value: any[] }> }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const valuesContainer: any = ast.values;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let valueRows: any[][] = [];
+  if (valuesContainer && Array.isArray(valuesContainer.values)) {
+    // v5 形式: { type: "values", values: [...] }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    valueRows = valuesContainer.values.map((row: any) => Array.isArray(row?.value) ? row.value : []);
+  } else if (Array.isArray(valuesContainer)) {
+    // フォールバック: 旧来の配列形式
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    valueRows = valuesContainer.map((row: any) => Array.isArray(row?.value) ? row.value : []);
+  }
+
+  if (columns.length === 0 || valueRows.length === 0) return result;
+
+  // 最初の VALUES 行のみ検査 (バルク INSERT の 2 行目以降は同形とみなす)
+  const firstRow = valueRows[0];
+  for (let i = 0; i < columns.length; i++) {
+    const colName = columns[i].toLowerCase();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const valNode: any = firstRow[i];
+    if (!valNode) {
+      result.set(colName, null);
+      continue;
+    }
+    // プレースホルダ: { type: "var", name: number, prefix: "$" }
+    if (valNode.type === "var" && valNode.prefix === "$" && typeof valNode.name === "number") {
+      const paramNum = valNode.name; // 1, 2, 3, ...
+      const originalVar = atVarMap.get(paramNum) ?? null;
+      result.set(colName, originalVar);
+    } else if (valNode.type === "null" || valNode.value === null) {
+      // NULL リテラル
+      result.set(colName, null);
+    } else {
+      // リテラル値 (string / number / boolean) → 変数参照ではないため non-null とみなす
+      result.set(colName, `__literal__`);
+    }
+  }
+  return result;
+}
+
+/**
+ * @xxx / @x.y.z → プレースホルダ番号 → 元変数名 の逆引きマップを構築。
+ * substituteAtVars と同じ順序で置換するため、同じ regex を使用。
+ */
+function buildAtVarMap(sql: string): Map<number, string> {
+  const map = new Map<number, string>();
+  let n = 0;
+  const re = /@[a-zA-Z_][\w.?]*/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(sql)) !== null) {
+    n++;
+    // @varName.field の場合はルート変数名部分を抽出 (例: @beneficiary.id → beneficiary)
+    const fullRef = m[0].slice(1); // "varName.field"
+    const rootName = fullRef.split(".")[0]; // "varName"
+    map.set(n, rootName);
+  }
+  return map;
+}
+
+// ─── 変数バインド時系列追跡 ─────────────────────────────────────────────────
+
+/**
+ * step 列を順走査して、各 step が outputBinding で宣言する変数名を収集。
+ * action.inputs[] はこの関数の外で先に追加しておく。
+ *
+ * @param steps   走査対象 step 列
+ * @param visitor (step, path) → void コールバック (副作用あり)
+ */
+function walkStepsInOrder(
+  steps: Step[],
+  basePath: string,
+  visitor: (step: Step, path: string) => void,
+): void {
+  for (let i = 0; i < steps.length; i++) {
+    const step = steps[i];
+    const path = `${basePath}[${i}]`;
+    visitor(step, path);
+    if (!isBuiltinStep(step)) continue;
+    if (step.kind === "branch") {
+      step.branches.forEach((b, bi) =>
+        walkStepsInOrder(b.steps, `${path}.branches[${bi}].steps`, visitor),
+      );
+      if (step.elseBranch) walkStepsInOrder(step.elseBranch.steps, `${path}.elseBranch.steps`, visitor);
+    }
+    if (step.kind === "loop") walkStepsInOrder(step.steps, `${path}.steps`, visitor);
+    if (step.kind === "transactionScope") {
+      walkStepsInOrder(step.steps, `${path}.steps`, visitor);
+      if (step.onCommit) walkStepsInOrder(step.onCommit, `${path}.onCommit`, visitor);
+      if (step.onRollback) walkStepsInOrder(step.onRollback, `${path}.onRollback`, visitor);
+    }
+    if (step.kind === "externalSystem") {
+      Object.entries(step.outcomes ?? {}).forEach(([k, spec]) => {
+        if (spec?.sideEffects) walkStepsInOrder(spec.sideEffects, `${path}.outcomes.${k}.sideEffects`, visitor);
+      });
+    }
+  }
+}
+
+// ─── テーブルメタデータ ─────────────────────────────────────────────────────
+
+interface TableMeta {
+  id: string;
+  physicalName: string;
+  notNullColumns: Set<string>;     // physicalName (lowercase) で保持
+  autoColumns: Set<string>;        // autoIncrement || defaultValue 付き → NOT NULL でもバインド不要
+  fkConstraints: Array<{
+    columnPhysicalNames: string[]; // FK 本テーブル側カラム物理名 (lowercase)
+    referencedTableId: string;
+  }>;
+}
+
+/**
+ * テーブルまたはカラムの物理名を取得。
+ * v3 では physicalName、v1 フォールバックでは name を使用。
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function getPhysicalName(obj: any): string | undefined {
+  return (typeof obj?.physicalName === "string" && obj.physicalName)
+    ? obj.physicalName
+    : (typeof obj?.name === "string" ? obj.name : undefined);
+}
+
+function buildTableMeta(tables: OrderTableDefinition[]): Map<string, TableMeta> {
+  const map = new Map<string, TableMeta>();
+  for (const t of tables) {
+    const tablePhysicalName = getPhysicalName(t);
+    if (!tablePhysicalName) continue; // 物理名が取れないテーブルはスキップ
+
+    const notNullColumns = new Set<string>();
+    const autoColumns = new Set<string>();
+    for (const col of t.columns) {
+      const pName = getPhysicalName(col);
+      if (!pName) continue;
+      const pNameLower = pName.toLowerCase();
+      if (col.notNull) notNullColumns.add(pNameLower);
+      // autoIncrement または DB 側 DEFAULT がある列はバインド不要 (DB が値を埋める)
+      if (col.autoIncrement || col.defaultValue !== undefined) autoColumns.add(pNameLower);
+      // primaryKey は通常 autoIncrement と同義だが念のため除外
+      if (col.primaryKey) autoColumns.add(pNameLower);
+    }
+
+    // FK 制約: Column.id → physicalName 逆引きマップ
+    const colIdToPhysical = new Map<string, string>();
+    for (const col of t.columns) {
+      const pName = getPhysicalName(col);
+      if (pName) colIdToPhysical.set(col.id, pName.toLowerCase());
+    }
+
+    const fkConstraints: TableMeta["fkConstraints"] = [];
+    for (const con of t.constraints ?? []) {
+      if (con.kind === "foreignKey") {
+        const fkCon = con as OrderForeignKeyConstraint;
+        const columnPhysicalNames = fkCon.columnIds
+          .map((id) => colIdToPhysical.get(id) ?? "")
+          .filter(Boolean);
+        if (columnPhysicalNames.length > 0) {
+          fkConstraints.push({
+            columnPhysicalNames,
+            referencedTableId: fkCon.referencedTableId,
+          });
+        }
+      }
+    }
+
+    map.set(tablePhysicalName.toLowerCase(), {
+      id: t.id,
+      physicalName: tablePhysicalName.toLowerCase(),
+      notNullColumns,
+      autoColumns,
+      fkConstraints,
+    });
+  }
+  return map;
+}
+
+// ─── メイン検査ロジック ─────────────────────────────────────────────────────
+
+/**
+ * action 内 INSERT step を順番に検査。
+ *
+ * - boundVars: action.inputs の name + 各 step を順に実行した際に蓄積される outputBinding.name
+ * - insertedTableIds: 先行 INSERT で書き込んだテーブルの id (FK 参照先確認用)
+ */
+function checkAction(
+  actionIndex: number,
+  steps: Step[],
+  tableMeta: Map<string, TableMeta>,
+  tableIdIndex: Map<string, TableMeta>, // id → TableMeta
+  initialBound: Set<string>,
+  issues: SqlOrderIssue[],
+): void {
+  const boundVars = new Set<string>(initialBound);
+  const insertedTableIds = new Set<string>();
+
+  // 平坦化した step のシーケンスを順走査
+  // (branch 内部は楽観的に両パスを走査してバインドを union する — 保守的な偽陽性抑止)
+  walkStepsInOrder(steps, `actions[${actionIndex}].steps`, (step, path) => {
+    if (!isBuiltinStep(step)) return;
+
+    // outputBinding を先に boundVars に追加 (同 step の sql でも使えるよう before/after は問わない)
+    // 厳密には sql 評価後に bind されるが、偽陽性抑止のため同 step の binding も有効とする。
+    if (step.outputBinding?.name) {
+      boundVars.add(step.outputBinding.name);
+    }
+    if (step.kind === "compute" && step.outputBinding?.name) {
+      boundVars.add(step.outputBinding.name);
+    }
+
+    // dbAccess INSERT のみ検査
+    if (step.kind !== "dbAccess") return;
+    if (step.operation !== "INSERT") return;
+    const sql = step.sql;
+    if (!sql) return;
+
+    // INSERT 先テーブルを記録
+    const tableIdRef = step.tableId ?? "";
+
+    // SQL パース
+    const atVarMap = buildAtVarMap(sql);
+    const substituted = substituteAtVars(sql);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let ast: any;
+    try {
+      ast = parser.astify(substituted, { database: DIALECT });
+    } catch {
+      issues.push({
+        path: `${path}.sql`,
+        code: "SQL_PARSE_ERROR",
+        message: "INSERT SQL のパースに失敗しました (sqlOrderValidator)",
+      });
+      return;
+    }
+
+    // AST が配列の場合は先頭のみ使用
+    const rootNode = Array.isArray(ast) ? ast[0] : ast;
+    if (!rootNode || rootNode.type !== "insert") return;
+
+    const insertTableName = extractInsertTableName(rootNode);
+    if (!insertTableName) return;
+    const meta = tableMeta.get(insertTableName);
+
+    // テーブルがカタログに無い場合は検査しない (外部テーブルは対象外)
+    if (meta) {
+      const colVarMap = extractInsertColumnVarMap(rootNode, atVarMap);
+
+      // ── 観点 1: NOT NULL × 変数バインド ─────────────────────────────────
+      for (const [colPhysical, varName] of colVarMap.entries()) {
+        if (!meta.notNullColumns.has(colPhysical)) continue;   // nullable は無視
+        if (meta.autoColumns.has(colPhysical)) continue;        // autoIncrement / DEFAULT は無視
+
+        if (varName === null) {
+          // NULL リテラルまたはプレースホルダ番号に対応する @var が無い (プレースホルダ外の NULL)
+          issues.push({
+            path: `${path}.sql`,
+            code: "NULL_NOT_ALLOWED_AT_INSERT",
+            message: `テーブル "${insertTableName}" の NOT NULL カラム "${colPhysical}" に NULL が挿入されます。INSERT 時点で非 NULL 値が必要です。`,
+          });
+        } else if (varName !== "__literal__" && !boundVars.has(varName)) {
+          // 変数参照だが、この時点でまだバインドされていない
+          issues.push({
+            path: `${path}.sql`,
+            code: "NULL_NOT_ALLOWED_AT_INSERT",
+            message: `テーブル "${insertTableName}" の NOT NULL カラム "${colPhysical}" が参照する変数 @${varName} は INSERT 時点で未バインドです。`,
+          });
+        }
+      }
+
+      // ── 観点 2: FK 参照先テーブルへの先行 INSERT ─────────────────────────
+      // 検査対象: FK カラムの値が変数参照 (= 実行時 binding) であり、
+      //           かつその変数が boundVars にも存在しない (= SELECT 未済) で、
+      //           かつ FK 参照先テーブルへの先行 INSERT も存在しない場合
+      //
+      // False positive 抑止の設計判断:
+      //   FK カラムが @existingRow.id のような変数参照をしており、その変数が
+      //   boundVars に存在する場合は「先行 SELECT で取得済みの既存行を参照している」
+      //   とみなして issue にしない (よくあるパターン: SELECT → INSERT の正常フロー)。
+      //   問題になるのは FK カラムが「まだバインドされていない変数」を参照している場合のみ。
+      for (const fk of meta.fkConstraints) {
+        // FK カラムが今回の INSERT 対象に含まれているか
+        const fkColsInInsert = fk.columnPhysicalNames.filter((c) => colVarMap.has(c));
+        if (fkColsInInsert.length === 0) continue;
+
+        const refTableId = fk.referencedTableId;
+        const refMeta = tableIdIndex.get(refTableId);
+        if (!refMeta) continue; // 参照先テーブルがカタログ外 → skip
+
+        // FK 参照先テーブルへの先行 INSERT が存在する場合は OK (通常の親→子 INSERT 順序)
+        if (insertedTableIds.has(refTableId)) continue;
+
+        // FK 列の値変数が全て boundVars に存在する場合は OK
+        // (SELECT で取得済みの既存行 ID を参照しているとみなす)
+        const allVarsBound = fkColsInInsert.every((c) => {
+          const v = colVarMap.get(c);
+          // null (NULL リテラル) または未バインド変数 → NG
+          if (v === null) return false;
+          if (v === "__literal__") return true; // リテラル値は OK
+          return boundVars.has(v); // 変数がバインド済みなら OK
+        });
+        if (allVarsBound) continue;
+
+        // FK 列の値が変数参照かつ未バインド → 潜在的問題
+        const unboundFkCols = fkColsInInsert.filter((c) => {
+          const v = colVarMap.get(c);
+          if (v === null || v === "__literal__") return false;
+          return !boundVars.has(v);
+        });
+        if (unboundFkCols.length === 0) continue;
+
+        issues.push({
+          path: `${path}.sql`,
+          code: "FK_REFERENCE_NOT_INSERTED",
+          message: `テーブル "${insertTableName}" の FK カラム [${unboundFkCols.join(", ")}] が参照する "${refMeta.physicalName}" の行が INSERT 時点で未確保です (先行 INSERT なし、かつ FK 列の変数が未バインド)。`,
+        });
+      }
+
+      // INSERT 完了後: このテーブル id を insertedTableIds に追加
+      insertedTableIds.add(meta.id);
+    }
+
+    // tableId 参照 (SQL ではなく step.tableId から) でも追加
+    if (tableIdRef) {
+      const metaById = tableIdIndex.get(tableIdRef);
+      if (metaById) insertedTableIds.add(metaById.id);
+    }
+  });
+}
+
+// ─── エクスポート関数 ───────────────────────────────────────────────────────
+
+/**
+ * ProcessFlow 内の全 action を検査し、DB 制約 × 操作順序の問題を返す。
+ *
+ * @param flow   検査対象の ProcessFlow
+ * @param tables テーブル定義一覧 (v3 形式、physicalName + columns[].notNull + constraints[])
+ */
+export function checkSqlOrder(
+  flow: ProcessFlow,
+  tables: OrderTableDefinition[],
+): SqlOrderIssue[] {
+  const issues: SqlOrderIssue[] = [];
+  const tableMeta = buildTableMeta(tables);
+
+  // id → TableMeta の逆引きインデックス
+  const tableIdIndex = new Map<string, TableMeta>();
+  for (const meta of tableMeta.values()) {
+    tableIdIndex.set(meta.id, meta);
+  }
+
+  // ProcessFlow は context.ambientVariables が暗黙バインド
+  const ambientVars = new Set<string>(
+    (flow.context?.ambientVariables ?? []).map((v) => v.name),
+  );
+  // 暗黙的にどこでも参照可能な特殊ルート変数名
+  // (@inputs.xxx / @conv.xxx / @env.xxx / @secret.xxx / @now 等は常にバインド済みとみなす)
+  const ALWAYS_BOUND = new Set(["inputs", "outputs", "conv", "env", "secret", "now", "requestId", "fn"]);
+
+  flow.actions.forEach((action, ai) => {
+    // inputs は action 開始時点で全てバインド済み
+    const initialBound = new Set<string>(ambientVars);
+    // 特殊ルート変数は常にバインド済み
+    for (const name of ALWAYS_BOUND) initialBound.add(name);
+    for (const inp of action.inputs ?? []) {
+      initialBound.add(inp.name);
+    }
+    checkAction(ai, action.steps ?? [], tableMeta, tableIdIndex, initialBound, issues);
+  });
+
+  return issues;
+}


### PR DESCRIPTION
## 関連

- Closes #632
- 仕様: ISSUE #632 本文 (MVP スコープ: 観点 1+2)、Phase 2/3 評価レポート §フォローアップ

## 概要

Phase 2 子 2 #600 で発見した M1 (welfare-benefit の payments INSERT で beneficiary_id NOT NULL 制約違反) を構造的に検出するため、新 validator `sqlOrderValidator` を新設する。`node-sql-parser` v5 AST walker を再利用し、変数バインド時系列追跡 + テーブル schema (notNull / foreignKey) の交差解析で実行時 DB 制約違反を静的に検出。

## 主な変更

- `sqlOrderValidator.ts` 新設 (486 行): 観点 1 (NULL_NOT_ALLOWED_AT_INSERT) + 観点 2 (FK_REFERENCE_NOT_INSERTED) 実装
- `sqlOrderValidator.test.ts` 新設 (18 テストケース): 観点 1+2 検出 / 正常系 / edge cases / welfare-benefit M1 実証 fixture
- `validate-dogfood.ts`: 7 番目 validator として統合 (import + validateOne 内 #7 検査 + validatorDisplayOrder 追記)
- `/create-flow` SKILL: Rule 19 追加 + Step 5.2 バリデータ表に sqlOrderValidator 追記
- `/review-flow` SKILL: 7 バリデータ表に追記 + 観点 11 (DB 制約 × INSERT 順序) 追加 + Must-fix 候補に 2 issue code 追記

## 仕様逐条突合 (自己申告)

ISSUE #632 完了基準の各条項:

- `designer/src/schemas/sqlOrderValidator.ts` 新設 → sqlOrderValidator.ts:1-486 ✓
- 観点 1 (NULL_NOT_ALLOWED_AT_INSERT) 検出ロジック → sqlOrderValidator.ts:361-382 ✓
- 観点 2 (FK_REFERENCE_NOT_INSERTED) 検出ロジック → sqlOrderValidator.ts:385-430 ✓
- vitest 10 ケース以上 → sqlOrderValidator.test.ts 18 ケース ✓
- `validate-dogfood.ts` に 7 番目 validator として統合 → validate-dogfood.ts (import + `checkSqlOrder` 呼び出し + validatorDisplayOrder 追記) ✓
- welfare-benefit M1 検出実証 fixture → sqlOrderValidator.test.ts の `welfare-benefit M1 実証` describe ✓
- `/create-flow` SKILL に Rule 追加 + Step 5.2 表追記 → create-flow/SKILL.md (Rule 19 + バリデータ表) ✓
- `/review-flow` SKILL に観点追加 → review-flow/SKILL.md (観点 11 + 7 バリデータ表 + Must-fix 候補) ✓
- schema 変更なし → `git diff origin/main..HEAD -- schemas/` = 差分なし ✓

## レビューで特に見てほしい箇所

**false positive 抑止設計** (最重要):

1. `ALWAYS_BOUND` セット (sqlOrderValidator.ts:472): `inputs` / `conv` / `env` 等の特殊ルート変数名を初期 boundVars に含め、`@inputs.xxx` 等のパターンを正常とみなす
2. FK 検査のスキップ条件 (sqlOrderValidator.ts:395-415): FK カラムが boundVars 内の変数を参照する場合は issue にしない。`SELECT → outputBinding → INSERT FK 参照` という典型パターンを正常として通す
3. autoIncrement / defaultValue 付きカラムは `autoColumns` セットに格納して NOT NULL 検査除外 (sqlOrderValidator.ts:259-262)

validate:dogfood で 18/18 flows pass (false positive ゼロ) を確認済み。

**観点 2 の設計範囲**:
- 観点 2 は「FK 列の参照変数が未バインド + 先行 INSERT もない」場合のみ検出
- `@inputs.parentId` を FK に使う (入力 ID で既存行を参照) は正常とみなす (false positive 抑止優先)
- 本当に危険なのは「全く出どころ不明の変数を FK に使う」パターンのみ

## テスト

- Vitest: 465 件 pass (新規 18 件) — sqlOrderValidator.test.ts + 既存 src/schemas/ 全件リグレッションなし
- Playwright: N/A (validator は UI なし)
- MCP E2E: N/A

## UI 影響 / AI smoke test

- [x] UI 影響なし (auto テスト pass のみ)

### UI 影響ありの場合、AI smoke test で確認した項目

N/A

## spec 側の不足点 / 提案

N/A (ISSUE #632 MVP スコープで実装、観点 3/4/5 は #640/#641/#642 で別 ISSUE 化済)

## レビュー担当への申し送り

- schema 変更なし: `git diff origin/main..HEAD -- schemas/` の差分ゼロを確認してください
- false positive 抑止設計が主な review 観点。ALWAYS_BOUND の選択 (`fn` / `outputs` 等も追加して良いか) とFK 検査スキップ条件の網羅性を重点確認してください
- welfare-benefit M1 実証 fixture (test 末尾の describe) で、旧パターン (未バインド @beneficiary.id を NOT NULL カラムに INSERT) が正しく検出されることを確認してください
- 観点 3/4/5 は ISSUE #640/#641/#642 でスコープ外、本 PR では対応しません