### PR TITLE
feat(phase4): ViewDefinition 一覧 UI viewer 概念新設 (#649)

### DIFF
--- a/.claude/skills/create-flow/SKILL.md
+++ b/.claude/skills/create-flow/SKILL.md
@@ -257,26 +257,26 @@ UI 起点フロー (`type: "screen"` / `mode: "upstream"`) を作成するとき
 
 ### Rule 20: ViewDefinition 整合 (#649、Phase 4 子 1)
 
-一覧系画面 ( /  等) のフローを作成するとき、同プロジェクト内の ViewDefinition との整合を確認する。 が以下を機械検出する。
+一覧系画面 (`list` / `search` 等) のフローを作成するとき、同プロジェクト内の ViewDefinition との整合を確認する。`viewDefinitionValidator` が以下を機械検出する。
 
 | code | severity | 検出内容 |
 |---|---|---|
-|  | error | ViewDefinition.sourceTableId が同プロジェクトのテーブルに実在しない |
-|  | error | ViewColumn.tableColumnRef が指す {tableId, columnId} が実在しない |
-|  | warning | tableColumnRef.tableId が sourceTableId と異なる (joined view 参照) |
-|  | error | ViewColumn.name が同 ViewDefinition 内で重複 |
-|  | warning | ViewColumn.type (FieldType) と DB Column.dataType が互換しない |
-|  | error | sortDefaults[].columnName が columns[].name に存在しない |
-|  | error | filterDefaults[].columnName が columns[].name に存在しない |
-|  | warning | filter operator が column type と不整合 (数値型に contains 等) |
-|  | error | groupBy が columns[].name に存在しない |
+| `UNKNOWN_SOURCE_TABLE` | error | ViewDefinition.sourceTableId が同プロジェクトのテーブルに実在しない |
+| `UNKNOWN_TABLE_COLUMN_REF` | error | ViewColumn.tableColumnRef が指す {tableId, columnId} が実在しない |
+| `COLUMN_REF_NOT_IN_SOURCE_TABLE` | warning | tableColumnRef.tableId が sourceTableId と異なる (joined view 参照) |
+| `DUPLICATE_VIEW_COLUMN_NAME` | error | ViewColumn.name が同 ViewDefinition 内で重複 |
+| `FIELD_TYPE_INCOMPATIBLE` | warning | ViewColumn.type (FieldType) と DB Column.dataType が互換しない |
+| `UNKNOWN_SORT_COLUMN` | error | sortDefaults[].columnName が columns[].name に存在しない |
+| `UNKNOWN_FILTER_COLUMN` | error | filterDefaults[].columnName が columns[].name に存在しない |
+| `FILTER_OPERATOR_TYPE_MISMATCH` | warning | filter operator が column type と不整合 (数値型に contains 等) |
+| `UNKNOWN_GROUP_BY_COLUMN` | error | groupBy が columns[].name に存在しない |
 
 フロー作成時のチェックポイント:
--  の対象テーブルが ViewDefinition.sourceTableId と一致しているか
+- `dbAccess` の対象テーブルが ViewDefinition.sourceTableId と一致しているか
 - ViewColumn.name で参照している列が実際に SELECT 句に含まれているか
 - Screen.viewDefinitionRefs[] が本フローで扱う ViewDefinition ID を正しく列挙しているか
 
-**Step 5.2 で  の  により機械的に検出される**
+**Step 5.2 で `validate:dogfood` の `viewDefinitionValidator` により機械的に検出される**
 
 ### Rule 22: 画面項目 refKey 横断整合 (#651、Phase 4 子 3)
 

--- a/.claude/skills/create-flow/SKILL.md
+++ b/.claude/skills/create-flow/SKILL.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: create-flow
 description: ProcessFlow JSON を品質ガード付きで新規作成する。/review-flow の 10 観点 + 18 ルールを作成前 self-check として組み込み、既知パターンの再発を抑制 + グローバル schema 変更禁止 (#511) + 画面項目連携整合性 (#621)
 argument-hint: <flowId> <業務概要> [namespace]
@@ -253,6 +253,30 @@ UI 起点フロー (`type: "screen"` / `mode: "upstream"`) を作成するとき
   - 全く出どころ不明の変数を FK カラムに使う場合のみ issue
 
 **Step 5.2 で `validate:dogfood` の `sqlOrderValidator` により機械的に検出される**
+
+
+### Rule 20: ViewDefinition 整合 (#649、Phase 4 子 1)
+
+一覧系画面 ( /  等) のフローを作成するとき、同プロジェクト内の ViewDefinition との整合を確認する。 が以下を機械検出する。
+
+| code | severity | 検出内容 |
+|---|---|---|
+|  | error | ViewDefinition.sourceTableId が同プロジェクトのテーブルに実在しない |
+|  | error | ViewColumn.tableColumnRef が指す {tableId, columnId} が実在しない |
+|  | warning | tableColumnRef.tableId が sourceTableId と異なる (joined view 参照) |
+|  | error | ViewColumn.name が同 ViewDefinition 内で重複 |
+|  | warning | ViewColumn.type (FieldType) と DB Column.dataType が互換しない |
+|  | error | sortDefaults[].columnName が columns[].name に存在しない |
+|  | error | filterDefaults[].columnName が columns[].name に存在しない |
+|  | warning | filter operator が column type と不整合 (数値型に contains 等) |
+|  | error | groupBy が columns[].name に存在しない |
+
+フロー作成時のチェックポイント:
+-  の対象テーブルが ViewDefinition.sourceTableId と一致しているか
+- ViewColumn.name で参照している列が実際に SELECT 句に含まれているか
+- Screen.viewDefinitionRefs[] が本フローで扱う ViewDefinition ID を正しく列挙しているか
+
+**Step 5.2 で  の  により機械的に検出される**
 
 ### Rule 22: 画面項目 refKey 横断整合 (#651、Phase 4 子 3)
 

--- a/.claude/skills/review-flow/SKILL.md
+++ b/.claude/skills/review-flow/SKILL.md
@@ -80,7 +80,7 @@ cd designer
 npm run validate:dogfood
 ```
 
-### 何が動くか (7 バリデータ)
+### 何が動くか (8 バリデータ)
 
 | # | バリデータ | 検出内容 | 入力 |
 |---|---|---|---|
@@ -91,6 +91,7 @@ npm run validate:dogfood
 | 5 | screenItemFlowValidator | 画面項目イベント ↔ 処理フロー連携 (handlerFlowId 実在 / argumentMapping 整合 / primaryInvoker 双方向 / events[].id ユニーク) | 各プロジェクトの `screens/` を per-project でロード (project-level 検査、#619/#621) |
 | 6 | screenItemFieldTypeValidator | 画面項目 ↔ フロー 値レベル整合 | 画面項目定義ファイル + 処理フロー JSON |
 | 7 | sqlOrderValidator | DB 制約 × 操作順序 (NOT NULL × INSERT / FK × INSERT 順序) | テーブル定義 (v3 形式) を自動ロード (#632) |
+| 8 | viewDefinitionValidator | ViewDefinition 整合 (sourceTableId 実在 / columnRef 実在 / 重複列名 / sort/filter/groupBy 列参照 / FieldType 互換) | 各プロジェクトの `view-definitions/` を per-project でロード (project-level 検査、#649) |
 
 ### 結果の取り扱い
 
@@ -115,13 +116,16 @@ npm run validate:dogfood
 | 9. 画面項目イベント連携整合 | screenItemFlowValidator (handlerFlowId / argumentMapping / primaryInvoker / events[].id ユニーク) | 業務文脈での argumentMapping 値の妥当性 (UI 入力 → フロー入力の意味的整合) は AI |
 | 10. 画面項目値レベル整合 | screenItemFieldTypeValidator (options 包含 / domainKey / 型 / pattern / range / length) | 業務文脈の妥当性 (選択肢命名の業務適切性 / domain 設計妥当性) は AI |
 | 11. DB 制約 × INSERT 順序 (#632) | sqlOrderValidator (NULL_NOT_ALLOWED_AT_INSERT / FK_REFERENCE_NOT_INSERTED) | 複雑な条件分岐での可能性の有無は AI |
+| 12. ViewDefinition 整合 (#649) | viewDefinitionValidator (UNKNOWN_SOURCE_TABLE / UNKNOWN_TABLE_COLUMN_REF / DUPLICATE_VIEW_COLUMN_NAME / UNKNOWN_SORT_COLUMN / UNKNOWN_FILTER_COLUMN / UNKNOWN_GROUP_BY_COLUMN) | sourceTableId ↔ dbAccess テーブルの業務的整合 / FIELD_TYPE_INCOMPATIBLE の業務妥当性は AI |
 
 監査根拠: `docs/spec/dogfood-2026-04-29-phase2-validator-audit.md` §3 / §4 + Phase 3 子 1 #619 (PR #626)。
 
 ### 終了コードの扱い
 
-- **exit 0**: 6 バリデータ全 pass → Step 1 へ進む
+- **exit 0**: 8 バリデータ全 pass → Step 1 へ進む
 - **exit 1**: 1 件以上の validator issue 検出 → Step 1 を中止せず、issue 内容を Step 2 のカバレッジ表に「validator 検出済」として記録して進む (実行セマンティクス観点が AI 目視のみで残るため)
+- **ViewDefinition 関連 Must-fix 候補**: `UNKNOWN_SOURCE_TABLE` / `UNKNOWN_TABLE_COLUMN_REF` / `DUPLICATE_VIEW_COLUMN_NAME` / `UNKNOWN_SORT_COLUMN` / `UNKNOWN_FILTER_COLUMN` / `UNKNOWN_GROUP_BY_COLUMN`
+- **ViewDefinition 関連 Should-fix (warning)**: `COLUMN_REF_NOT_IN_SOURCE_TABLE` / `FIELD_TYPE_INCOMPATIBLE` / `FILTER_OPERATOR_TYPE_MISMATCH`
 - **exit 2**: 引数異常 / ファイル不在 / JSON parse 失敗 → エラーメッセージを報告し AI 目視のみで Step 1 に進む
 
 ### バリデータが動かない場合
@@ -130,9 +134,10 @@ npm run validate:dogfood
 - `npm run validate:dogfood` 自体が失敗 (依存解決等) → 同上、Step 1 に進む
 - バリデータ未呼び出しは **Step 2 の「validator 検出済」欄を「未実行」と明記** (隠さない)
 
-## Step 1: 検証項目 (10 観点)
+## Step 1: 検証項目 (12 観点)
 
 各観点を **必ず実施**。「該当なし」の場合もその旨を明記する。
+観点 11 / 12 は機械検出が主 (Step 0.5) で AI 目視は業務文脈の妥当性のみ担当する。
 
 ### 1. 変数ライフサイクル (Variable Lifecycle)
 

--- a/designer/scripts/validate-dogfood.ts
+++ b/designer/scripts/validate-dogfood.ts
@@ -29,9 +29,11 @@ import { checkIdentifierScopes } from "../src/schemas/identifierScope.js";
 import { checkScreenItemFlowConsistency } from "../src/schemas/screenItemFlowValidator.js";
 import { checkScreenItemFieldTypeConsistency } from "../src/schemas/screenItemFieldTypeValidator.js";
 import { checkScreenItemRefKeyConsistency } from "../src/schemas/screenItemRefKeyValidator.js";
+import { checkViewDefinitions } from "../src/schemas/viewDefinitionValidator.js";
 import { loadExtensionsFromBundle, type LoadedExtensions, type ExtensionsBundle } from "../src/schemas/loadExtensions.js";
 import type { Screen } from "../src/types/v3/screen.js";
 import type { Conventions } from "../src/types/v3/conventions.js";
+import type { ViewDefinition } from "../src/types/v3/view-definition.js";
 import { discoverProjects as discoverSampleProjects, type SampleProjectInfo } from "./sample-projects.js";
 
 // ─── パス解決 ──────────────────────────────────────────────────────────────
@@ -52,6 +54,7 @@ interface ProjectResources {
   conventions: ConventionsCatalog | null;
   conventionsV3: Conventions | null;  // v3 型 conventions (refKey validator 用、#651)
   screens: Screen[];          // 画面定義 (#619、画面項目イベント連携検証用)
+  viewDefinitions: ViewDefinition[]; // ViewDefinition 一覧 (#649)
   flowsDir: string;           // process-flows/ の絶対パス
 }
 
@@ -85,6 +88,7 @@ interface ValidationSummary {
   totalTableCount: number;
   totalConventionsCount: number;
   totalScreenCount: number;
+  totalViewDefinitionCount: number;
   extensionFileCount: number;
 }
 
@@ -119,6 +123,16 @@ function loadScreensFromDir(dir: string): Screen[] {
   }
 }
 
+function loadViewDefinitionsFromDir(dir: string): ViewDefinition[] {
+  if (!existsSync(dir)) return [];
+  try {
+    const files = readdirSync(dir).filter((f) => f.endsWith(".json"));
+    return files.map((f) => JSON.parse(readFileSync(join(dir, f), "utf-8")) as ViewDefinition);
+  } catch {
+    return [];
+  }
+}
+
 /**
  * v1 + v3 のサンプルプロジェクトを発見してリソース情報を返す。
  *
@@ -139,6 +153,7 @@ function discoverProjects(): ProjectResources[] {
       conventions,
       conventionsV3: conventions as Conventions | null,
       screens: loadScreensFromDir(info.screensDir),
+      viewDefinitions: loadViewDefinitionsFromDir(join(info.projectDir, "view-definitions")),
       flowsDir: info.flowsDir,
     };
   });
@@ -329,6 +344,7 @@ export async function runValidation(flowPath?: string): Promise<ValidationSummar
   const totalTableCount = projects.reduce((acc, p) => acc + p.tables.length, 0);
   const totalConventionsCount = projects.filter((p) => p.conventions !== null).length;
   const totalScreenCount = projects.reduce((acc, p) => acc + p.screens.length, 0);
+  const totalViewDefinitionCount = projects.reduce((acc, p) => acc + p.viewDefinitions.length, 0);
 
   const results: FlowValidationResult[] = [];
   const projectResults: ProjectValidationResult[] = [];
@@ -422,6 +438,19 @@ export async function runValidation(flowPath?: string): Promise<ValidationSummar
         })),
       );
 
+      // 11. ViewDefinition 整合検証 (#649 Phase 4 子 1)
+      const viewDefinitionIssues = checkViewDefinitions(
+        project.viewDefinitions,
+        project.tables as unknown as import("../src/schemas/viewDefinitionValidator.js").TableDefinitionForView[],
+      );
+      projectIssues.push(
+        ...viewDefinitionIssues.map((i) => ({
+          validator: "viewDefinitionValidator",
+          severity: i.severity,
+          message: `[${i.code}] ${i.path}: ${i.message}`,
+        })),
+      );
+
       if (projectIssues.length > 0) {
         projectResults.push({
           projectId: project.projectId,
@@ -445,6 +474,7 @@ export async function runValidation(flowPath?: string): Promise<ValidationSummar
     totalTableCount,
     totalConventionsCount,
     totalScreenCount,
+    totalViewDefinitionCount,
     extensionFileCount,
   };
 }
@@ -460,6 +490,7 @@ const validatorDisplayOrder = [
   "screenItemFieldTypeValidator",
   "sqlOrderValidator",
   "screenItemRefKeyValidator",
+  "viewDefinitionValidator",
 ];
 
 function printSummary(summary: ValidationSummary, options: { singleFlow: boolean }): void {
@@ -467,7 +498,7 @@ function printSummary(summary: ValidationSummary, options: { singleFlow: boolean
   console.log();
   console.log(
     `📂 プロジェクト数: ${summary.projectCount} / ${summary.totalFlows} flows / ${summary.totalTableCount} tables` +
-    ` / ${summary.totalScreenCount} screens / ${summary.totalConventionsCount} conventions catalogs / ${summary.extensionFileCount} extension files`,
+    ` / ${summary.totalScreenCount} screens / ${summary.totalViewDefinitionCount} viewDefinitions / ${summary.totalConventionsCount} conventions catalogs / ${summary.extensionFileCount} extension files`,
   );
   console.log();
 

--- a/designer/src/schemas/v3-samples.test.ts
+++ b/designer/src/schemas/v3-samples.test.ts
@@ -21,6 +21,7 @@ let validateExtension: ValidateFunction;
 let validateSequence: ValidateFunction;
 let validateScreenLayout: ValidateFunction;
 let validateErLayout: ValidateFunction;
+let validateViewDefinition: ValidateFunction;
 
 beforeAll(() => {
   ajv = new Ajv2020({ allErrors: true, strict: false, discriminator: true });
@@ -35,6 +36,7 @@ beforeAll(() => {
   validateSequence = ajv.compile(loadJson(join(v3Dir, "sequence.v3.schema.json")) as object);
   validateScreenLayout = ajv.compile(loadJson(join(v3Dir, "screen-layout.v3.schema.json")) as object);
   validateErLayout = ajv.compile(loadJson(join(v3Dir, "er-layout.v3.schema.json")) as object);
+  validateViewDefinition = ajv.compile(loadJson(join(v3Dir, "view-definition.v3.schema.json")) as object);
 });
 
 function dumpErrors(file: string, validate: ValidateFunction): string {
@@ -94,6 +96,8 @@ describe("schema v3 dogfood samples (#523 retail + #527 finance)", () => {
       ...listJsonRecursive(join(samplesV3Dir, "manufacturing", "screens")),
       ...listJsonRecursive(join(samplesV3Dir, "public-service", "screens")),
       ...listJsonRecursive(join(samplesV3Dir, "logistics", "screens")),
+      ...listJsonRecursive(join(samplesV3Dir, "healthcare", "screens")),
+      ...listJsonRecursive(join(samplesV3Dir, "welfare-benefit", "screens")),
     ];
     expect(files.length).toBeGreaterThan(0);
     for (const file of files) {
@@ -356,6 +360,19 @@ describe("schema v3 dogfood samples (#523 retail + #527 finance)", () => {
       (e) => e.keyword === "discriminator" || (e.message ?? "").includes("discriminator"),
     );
     expect(discriminatorErr).toBeDefined();
+  });
+
+  it("view-definition samples validate against view-definition.v3.schema.json (#649)", () => {
+    const files = [
+      ...listJsonRecursive(join(samplesV3Dir, "retail", "view-definitions")),
+      ...listJsonRecursive(join(samplesV3Dir, "welfare-benefit", "view-definitions")),
+    ];
+    expect(files.length).toBeGreaterThan(0);
+    for (const file of files) {
+      const data = loadJson(file);
+      const ok = validateViewDefinition(data);
+      expect(ok, ok ? "" : dumpErrors(file, validateViewDefinition)).toBe(true);
+    }
   });
 
   it("F-4: Constraint (table.v3) の不正 kind は discriminator でエラー", () => {

--- a/designer/src/schemas/viewDefinitionValidator.test.ts
+++ b/designer/src/schemas/viewDefinitionValidator.test.ts
@@ -1,0 +1,427 @@
+/**
+ * ViewDefinition 整合検証テスト (#649)
+ *
+ * viewDefinitionValidator.ts の 9 観点を網羅:
+ * 1. UNKNOWN_SOURCE_TABLE
+ * 2. UNKNOWN_TABLE_COLUMN_REF
+ * 3. COLUMN_REF_NOT_IN_SOURCE_TABLE (warning)
+ * 4. DUPLICATE_VIEW_COLUMN_NAME
+ * 5. FIELD_TYPE_INCOMPATIBLE (warning)
+ * 6. UNKNOWN_SORT_COLUMN
+ * 7. UNKNOWN_FILTER_COLUMN
+ * 8. FILTER_OPERATOR_TYPE_MISMATCH (warning)
+ * 9. UNKNOWN_GROUP_BY_COLUMN
+ */
+import { describe, it, expect } from "vitest";
+import {
+  checkViewDefinition,
+  checkViewDefinitions,
+  type TableDefinitionForView,
+} from "./viewDefinitionValidator";
+import type { ViewDefinition } from "../types/v3/view-definition";
+
+// ─── テスト用ファクトリ ──────────────────────────────────────────────────────
+
+const TABLE_ID = "aaaaaaaa-0001-4000-8000-aaaaaaaaaaaa";
+const OTHER_TABLE_ID = "bbbbbbbb-0002-4000-8000-bbbbbbbbbbbb";
+
+const TABLES: TableDefinitionForView[] = [
+  {
+    id: TABLE_ID,
+    physicalName: "products",
+    name: "商品マスタ",
+    columns: [
+      { id: "col-p01", physicalName: "id", name: "商品ID", dataType: "INTEGER" },
+      { id: "col-p02", physicalName: "name", name: "商品名", dataType: "VARCHAR" },
+      { id: "col-p03", physicalName: "unit_price", name: "単価", dataType: "INTEGER" },
+      { id: "col-p04", physicalName: "category", name: "カテゴリ", dataType: "VARCHAR" },
+      { id: "col-p05", physicalName: "is_active", name: "販売フラグ", dataType: "BOOLEAN" },
+      { id: "col-p06", physicalName: "created_at", name: "作成日時", dataType: "TIMESTAMP" },
+    ],
+  },
+  {
+    id: OTHER_TABLE_ID,
+    physicalName: "inventory",
+    name: "在庫管理",
+    columns: [
+      { id: "col-i01", physicalName: "id", name: "在庫ID", dataType: "INTEGER" },
+      { id: "col-i02", physicalName: "product_code", name: "商品コード", dataType: "VARCHAR" },
+    ],
+  },
+];
+
+function makeViewDefinition(partial: Partial<ViewDefinition>): ViewDefinition {
+  return {
+    meta: {
+      id: "vvvvvvvv-0001-4000-8000-vvvvvvvvvvvv",
+      name: "商品一覧",
+      version: "1.0.0",
+      maturity: "draft",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+    },
+    kind: "list",
+    sourceTableId: TABLE_ID,
+    columns: [
+      {
+        name: "productId" as unknown as import("../types/v3/common").Identifier,
+        tableColumnRef: { tableId: TABLE_ID, columnId: "col-p01" },
+        type: "integer" as unknown as import("../types/v3/common").FieldType,
+        displayName: "商品ID" as unknown as import("../types/v3/common").DisplayName,
+        sortable: true,
+        filterable: true,
+      },
+      {
+        name: "productName" as unknown as import("../types/v3/common").Identifier,
+        tableColumnRef: { tableId: TABLE_ID, columnId: "col-p02" },
+        type: "string" as unknown as import("../types/v3/common").FieldType,
+        displayName: "商品名" as unknown as import("../types/v3/common").DisplayName,
+        sortable: true,
+        filterable: true,
+      },
+    ],
+    ...partial,
+  } as ViewDefinition;
+}
+
+// ─── 1. UNKNOWN_SOURCE_TABLE ─────────────────────────────────────────────────
+
+describe("viewDefinitionValidator — 1. UNKNOWN_SOURCE_TABLE", () => {
+  it("存在しない sourceTableId を検出する", () => {
+    const vd = makeViewDefinition({ sourceTableId: "00000000-dead-4000-8000-000000000000" });
+    const issues = checkViewDefinition(vd, TABLES);
+    expect(issues.some((i) => i.code === "UNKNOWN_SOURCE_TABLE")).toBe(true);
+    const issue = issues.find((i) => i.code === "UNKNOWN_SOURCE_TABLE");
+    expect(issue?.severity).toBe("error");
+  });
+
+  it("正しい sourceTableId は issue なし", () => {
+    const vd = makeViewDefinition({});
+    const issues = checkViewDefinition(vd, TABLES);
+    expect(issues.filter((i) => i.code === "UNKNOWN_SOURCE_TABLE")).toHaveLength(0);
+  });
+});
+
+// ─── 2. UNKNOWN_TABLE_COLUMN_REF ─────────────────────────────────────────────
+
+describe("viewDefinitionValidator — 2. UNKNOWN_TABLE_COLUMN_REF", () => {
+  it("存在しない columnId を検出する", () => {
+    const vd = makeViewDefinition({
+      columns: [
+        {
+          name: "productId" as unknown as import("../types/v3/common").Identifier,
+          tableColumnRef: { tableId: TABLE_ID, columnId: "col-nonexistent" },
+          type: "integer" as unknown as import("../types/v3/common").FieldType,
+        },
+      ],
+    });
+    const issues = checkViewDefinition(vd, TABLES);
+    expect(issues.some((i) => i.code === "UNKNOWN_TABLE_COLUMN_REF")).toBe(true);
+    expect(issues.find((i) => i.code === "UNKNOWN_TABLE_COLUMN_REF")?.severity).toBe("error");
+  });
+
+  it("存在しない tableId を検出する", () => {
+    const vd = makeViewDefinition({
+      columns: [
+        {
+          name: "col" as unknown as import("../types/v3/common").Identifier,
+          tableColumnRef: { tableId: "00000000-dead-4000-8000-000000000000", columnId: "col-p01" },
+          type: "integer" as unknown as import("../types/v3/common").FieldType,
+        },
+      ],
+    });
+    const issues = checkViewDefinition(vd, TABLES);
+    // COLUMN_REF_NOT_IN_SOURCE_TABLE (warning) も出るが UNKNOWN_TABLE_COLUMN_REF (error) も出る
+    expect(issues.some((i) => i.code === "UNKNOWN_TABLE_COLUMN_REF")).toBe(true);
+  });
+
+  it("正しい tableColumnRef は issue なし", () => {
+    const vd = makeViewDefinition({});
+    const issues = checkViewDefinition(vd, TABLES);
+    expect(issues.filter((i) => i.code === "UNKNOWN_TABLE_COLUMN_REF")).toHaveLength(0);
+  });
+});
+
+// ─── 3. COLUMN_REF_NOT_IN_SOURCE_TABLE ───────────────────────────────────────
+
+describe("viewDefinitionValidator — 3. COLUMN_REF_NOT_IN_SOURCE_TABLE", () => {
+  it("別テーブルの列参照を warning で検出する (joined view 許容)", () => {
+    const vd = makeViewDefinition({
+      columns: [
+        {
+          name: "inventoryId" as unknown as import("../types/v3/common").Identifier,
+          // 別テーブル (OTHER_TABLE_ID) の列参照 (joined view 想定)
+          tableColumnRef: { tableId: OTHER_TABLE_ID, columnId: "col-i01" },
+          type: "integer" as unknown as import("../types/v3/common").FieldType,
+        },
+      ],
+    });
+    const issues = checkViewDefinition(vd, TABLES);
+    expect(issues.some((i) => i.code === "COLUMN_REF_NOT_IN_SOURCE_TABLE")).toBe(true);
+    expect(issues.find((i) => i.code === "COLUMN_REF_NOT_IN_SOURCE_TABLE")?.severity).toBe("warning");
+  });
+
+  it("sourceTableId と一致するテーブル参照は warning なし", () => {
+    const vd = makeViewDefinition({});
+    const issues = checkViewDefinition(vd, TABLES);
+    expect(issues.filter((i) => i.code === "COLUMN_REF_NOT_IN_SOURCE_TABLE")).toHaveLength(0);
+  });
+});
+
+// ─── 4. DUPLICATE_VIEW_COLUMN_NAME ───────────────────────────────────────────
+
+describe("viewDefinitionValidator — 4. DUPLICATE_VIEW_COLUMN_NAME", () => {
+  it("同 name が 2 回出てくる場合を検出する", () => {
+    const vd = makeViewDefinition({
+      columns: [
+        {
+          name: "productId" as unknown as import("../types/v3/common").Identifier,
+          tableColumnRef: { tableId: TABLE_ID, columnId: "col-p01" },
+          type: "integer" as unknown as import("../types/v3/common").FieldType,
+        },
+        {
+          name: "productId" as unknown as import("../types/v3/common").Identifier, // duplicate
+          tableColumnRef: { tableId: TABLE_ID, columnId: "col-p02" },
+          type: "string" as unknown as import("../types/v3/common").FieldType,
+        },
+      ],
+    });
+    const issues = checkViewDefinition(vd, TABLES);
+    expect(issues.some((i) => i.code === "DUPLICATE_VIEW_COLUMN_NAME")).toBe(true);
+    expect(issues.find((i) => i.code === "DUPLICATE_VIEW_COLUMN_NAME")?.severity).toBe("error");
+  });
+
+  it("全 name がユニークなら issue なし", () => {
+    const vd = makeViewDefinition({});
+    const issues = checkViewDefinition(vd, TABLES);
+    expect(issues.filter((i) => i.code === "DUPLICATE_VIEW_COLUMN_NAME")).toHaveLength(0);
+  });
+});
+
+// ─── 5. FIELD_TYPE_INCOMPATIBLE ──────────────────────────────────────────────
+
+describe("viewDefinitionValidator — 5. FIELD_TYPE_INCOMPATIBLE", () => {
+  it("VARCHAR に boolean 型は warning 検出", () => {
+    const vd = makeViewDefinition({
+      columns: [
+        {
+          name: "productName" as unknown as import("../types/v3/common").Identifier,
+          tableColumnRef: { tableId: TABLE_ID, columnId: "col-p02" }, // VARCHAR
+          type: "boolean" as unknown as import("../types/v3/common").FieldType, // 不整合
+        },
+      ],
+    });
+    const issues = checkViewDefinition(vd, TABLES);
+    expect(issues.some((i) => i.code === "FIELD_TYPE_INCOMPATIBLE")).toBe(true);
+    expect(issues.find((i) => i.code === "FIELD_TYPE_INCOMPATIBLE")?.severity).toBe("warning");
+  });
+
+  it("INTEGER に integer 型は互換、warning なし", () => {
+    const vd = makeViewDefinition({
+      columns: [
+        {
+          name: "productId" as unknown as import("../types/v3/common").Identifier,
+          tableColumnRef: { tableId: TABLE_ID, columnId: "col-p01" }, // INTEGER
+          type: "integer" as unknown as import("../types/v3/common").FieldType,
+        },
+      ],
+    });
+    const issues = checkViewDefinition(vd, TABLES);
+    expect(issues.filter((i) => i.code === "FIELD_TYPE_INCOMPATIBLE")).toHaveLength(0);
+  });
+
+  it("TIMESTAMP に datetime は互換、warning なし", () => {
+    const vd = makeViewDefinition({
+      columns: [
+        {
+          name: "createdAt" as unknown as import("../types/v3/common").Identifier,
+          tableColumnRef: { tableId: TABLE_ID, columnId: "col-p06" }, // TIMESTAMP
+          type: "datetime" as unknown as import("../types/v3/common").FieldType,
+        },
+      ],
+    });
+    const issues = checkViewDefinition(vd, TABLES);
+    expect(issues.filter((i) => i.code === "FIELD_TYPE_INCOMPATIBLE")).toHaveLength(0);
+  });
+});
+
+// ─── 6. UNKNOWN_SORT_COLUMN ───────────────────────────────────────────────────
+
+describe("viewDefinitionValidator — 6. UNKNOWN_SORT_COLUMN", () => {
+  it("columns に存在しない columnName は error 検出", () => {
+    const vd = makeViewDefinition({
+      sortDefaults: [
+        { columnName: "nonexistentCol" as unknown as import("../types/v3/common").Identifier, order: "asc" },
+      ],
+    });
+    const issues = checkViewDefinition(vd, TABLES);
+    expect(issues.some((i) => i.code === "UNKNOWN_SORT_COLUMN")).toBe(true);
+    expect(issues.find((i) => i.code === "UNKNOWN_SORT_COLUMN")?.severity).toBe("error");
+  });
+
+  it("正しい columnName は issue なし", () => {
+    const vd = makeViewDefinition({
+      sortDefaults: [
+        { columnName: "productId" as unknown as import("../types/v3/common").Identifier, order: "desc" },
+      ],
+    });
+    const issues = checkViewDefinition(vd, TABLES);
+    expect(issues.filter((i) => i.code === "UNKNOWN_SORT_COLUMN")).toHaveLength(0);
+  });
+});
+
+// ─── 7. UNKNOWN_FILTER_COLUMN ────────────────────────────────────────────────
+
+describe("viewDefinitionValidator — 7. UNKNOWN_FILTER_COLUMN", () => {
+  it("columns に存在しない columnName は error 検出", () => {
+    const vd = makeViewDefinition({
+      filterDefaults: [
+        { columnName: "noSuchColumn" as unknown as import("../types/v3/common").Identifier, operator: "eq" },
+      ],
+    });
+    const issues = checkViewDefinition(vd, TABLES);
+    expect(issues.some((i) => i.code === "UNKNOWN_FILTER_COLUMN")).toBe(true);
+    expect(issues.find((i) => i.code === "UNKNOWN_FILTER_COLUMN")?.severity).toBe("error");
+  });
+
+  it("正しい columnName は issue なし", () => {
+    const vd = makeViewDefinition({
+      filterDefaults: [
+        { columnName: "productName" as unknown as import("../types/v3/common").Identifier, operator: "contains" },
+      ],
+    });
+    const issues = checkViewDefinition(vd, TABLES);
+    expect(issues.filter((i) => i.code === "UNKNOWN_FILTER_COLUMN")).toHaveLength(0);
+  });
+});
+
+// ─── 8. FILTER_OPERATOR_TYPE_MISMATCH ────────────────────────────────────────
+
+describe("viewDefinitionValidator — 8. FILTER_OPERATOR_TYPE_MISMATCH", () => {
+  it("string 型カラムに between は warning 検出", () => {
+    const vd = makeViewDefinition({
+      filterDefaults: [
+        {
+          columnName: "productName" as unknown as import("../types/v3/common").Identifier, // string
+          operator: "between",
+        },
+      ],
+    });
+    const issues = checkViewDefinition(vd, TABLES);
+    expect(issues.some((i) => i.code === "FILTER_OPERATOR_TYPE_MISMATCH")).toBe(true);
+    expect(issues.find((i) => i.code === "FILTER_OPERATOR_TYPE_MISMATCH")?.severity).toBe("warning");
+  });
+
+  it("integer 型カラムに contains は warning 検出", () => {
+    const vd = makeViewDefinition({
+      filterDefaults: [
+        {
+          columnName: "productId" as unknown as import("../types/v3/common").Identifier, // integer
+          operator: "contains",
+        },
+      ],
+    });
+    const issues = checkViewDefinition(vd, TABLES);
+    expect(issues.some((i) => i.code === "FILTER_OPERATOR_TYPE_MISMATCH")).toBe(true);
+  });
+
+  it("string 型カラムに contains は warning なし", () => {
+    const vd = makeViewDefinition({
+      filterDefaults: [
+        {
+          columnName: "productName" as unknown as import("../types/v3/common").Identifier, // string
+          operator: "contains",
+        },
+      ],
+    });
+    const issues = checkViewDefinition(vd, TABLES);
+    expect(issues.filter((i) => i.code === "FILTER_OPERATOR_TYPE_MISMATCH")).toHaveLength(0);
+  });
+});
+
+// ─── 9. UNKNOWN_GROUP_BY_COLUMN ──────────────────────────────────────────────
+
+describe("viewDefinitionValidator — 9. UNKNOWN_GROUP_BY_COLUMN", () => {
+  it("columns に存在しない groupBy は error 検出", () => {
+    const vd = makeViewDefinition({
+      groupBy: "missingColumn" as unknown as import("../types/v3/common").Identifier,
+    });
+    const issues = checkViewDefinition(vd, TABLES);
+    expect(issues.some((i) => i.code === "UNKNOWN_GROUP_BY_COLUMN")).toBe(true);
+    expect(issues.find((i) => i.code === "UNKNOWN_GROUP_BY_COLUMN")?.severity).toBe("error");
+  });
+
+  it("columns に存在する groupBy は issue なし", () => {
+    const vd = makeViewDefinition({
+      groupBy: "productId" as unknown as import("../types/v3/common").Identifier,
+    });
+    const issues = checkViewDefinition(vd, TABLES);
+    expect(issues.filter((i) => i.code === "UNKNOWN_GROUP_BY_COLUMN")).toHaveLength(0);
+  });
+});
+
+// ─── 正常系: 全 issue なし ────────────────────────────────────────────────────
+
+describe("viewDefinitionValidator — 正常系", () => {
+  it("完全に正しい ViewDefinition は issue なし", () => {
+    const vd = makeViewDefinition({
+      columns: [
+        {
+          name: "productId" as unknown as import("../types/v3/common").Identifier,
+          tableColumnRef: { tableId: TABLE_ID, columnId: "col-p01" },
+          type: "integer" as unknown as import("../types/v3/common").FieldType,
+          displayName: "商品ID" as unknown as import("../types/v3/common").DisplayName,
+          sortable: true,
+          filterable: true,
+          align: "right",
+        },
+        {
+          name: "productName" as unknown as import("../types/v3/common").Identifier,
+          tableColumnRef: { tableId: TABLE_ID, columnId: "col-p02" },
+          type: "string" as unknown as import("../types/v3/common").FieldType,
+          displayName: "商品名" as unknown as import("../types/v3/common").DisplayName,
+          sortable: true,
+          filterable: true,
+        },
+        {
+          name: "unitPrice" as unknown as import("../types/v3/common").Identifier,
+          tableColumnRef: { tableId: TABLE_ID, columnId: "col-p03" },
+          type: "integer" as unknown as import("../types/v3/common").FieldType,
+          displayName: "単価" as unknown as import("../types/v3/common").DisplayName,
+          sortable: true,
+          align: "right",
+          displayFormat: "#,##0",
+        },
+      ],
+      sortDefaults: [
+        { columnName: "unitPrice" as unknown as import("../types/v3/common").Identifier, order: "desc" },
+      ],
+      filterDefaults: [
+        { columnName: "productName" as unknown as import("../types/v3/common").Identifier, operator: "contains" },
+      ],
+    });
+    const issues = checkViewDefinition(vd, TABLES);
+    expect(issues).toHaveLength(0);
+  });
+});
+
+// ─── checkViewDefinitions (複数 ViewDefinition) ───────────────────────────────
+
+describe("checkViewDefinitions", () => {
+  it("複数 ViewDefinition を一括検証し各 issue を集約する", () => {
+    const vd1 = makeViewDefinition({ sourceTableId: "00000000-dead-4000-8000-000000000000" });
+    const vd2 = makeViewDefinition({
+      sortDefaults: [
+        { columnName: "noSuchCol" as unknown as import("../types/v3/common").Identifier, order: "asc" },
+      ],
+    });
+    const issues = checkViewDefinitions([vd1, vd2], TABLES);
+    expect(issues.some((i) => i.code === "UNKNOWN_SOURCE_TABLE")).toBe(true);
+    expect(issues.some((i) => i.code === "UNKNOWN_SORT_COLUMN")).toBe(true);
+  });
+
+  it("空配列は issue なし", () => {
+    const issues = checkViewDefinitions([], TABLES);
+    expect(issues).toHaveLength(0);
+  });
+});

--- a/designer/src/schemas/viewDefinitionValidator.ts
+++ b/designer/src/schemas/viewDefinitionValidator.ts
@@ -1,0 +1,311 @@
+/**
+ * ViewDefinition 整合検証 (#649、Phase 4 子 1)
+ *
+ * 検査観点 (9 件):
+ * 1. UNKNOWN_SOURCE_TABLE         — sourceTableId が同プロジェクト内に実在しない
+ * 2. UNKNOWN_TABLE_COLUMN_REF     — ViewColumn.tableColumnRef が実在しない
+ * 3. COLUMN_REF_NOT_IN_SOURCE_TABLE — tableColumnRef.tableId が sourceTableId と異なる (joined view、warning)
+ * 4. DUPLICATE_VIEW_COLUMN_NAME   — ViewColumn.name が同 ViewDefinition 内で重複
+ * 5. FIELD_TYPE_INCOMPATIBLE      — ViewColumn.type (FieldType) と DB Column.dataType が互換しない (warning)
+ * 6. UNKNOWN_SORT_COLUMN          — sortDefaults[].columnName が columns[].name に存在しない
+ * 7. UNKNOWN_FILTER_COLUMN        — filterDefaults[].columnName が columns[].name に存在しない
+ * 8. FILTER_OPERATOR_TYPE_MISMATCH — filter operator が column type と不整合 (warning)
+ * 9. UNKNOWN_GROUP_BY_COLUMN      — groupBy が columns[].name に存在しない
+ */
+
+import type { ViewDefinition, ViewColumn } from "../types/v3/view-definition";
+
+export type ViewDefinitionIssueCode =
+  | "UNKNOWN_SOURCE_TABLE"
+  | "UNKNOWN_TABLE_COLUMN_REF"
+  | "COLUMN_REF_NOT_IN_SOURCE_TABLE"
+  | "DUPLICATE_VIEW_COLUMN_NAME"
+  | "FIELD_TYPE_INCOMPATIBLE"
+  | "UNKNOWN_SORT_COLUMN"
+  | "UNKNOWN_FILTER_COLUMN"
+  | "FILTER_OPERATOR_TYPE_MISMATCH"
+  | "UNKNOWN_GROUP_BY_COLUMN";
+
+export interface ViewDefinitionIssue {
+  path: string;
+  code: ViewDefinitionIssueCode;
+  severity: "error" | "warning";
+  viewDefinitionId: string;
+  message: string;
+}
+
+/** テーブル定義の最小インターフェース (validate-dogfood からも利用) */
+export interface TableDefinitionForView {
+  id: string;
+  physicalName?: string;
+  name?: string;
+  columns?: Array<{
+    id: string;
+    physicalName?: string;
+    name?: string;
+    dataType?: string;
+  }>;
+}
+
+/** DB DataType → FieldType 互換マップ (ViewColumn.type と照合) */
+const DATATYPE_TO_FIELDTYPE_COMPATIBLE: Record<string, string[]> = {
+  INTEGER: ["integer", "number", "string"],
+  BIGINT: ["integer", "number", "string"],
+  SMALLINT: ["integer", "number", "string"],
+  DECIMAL: ["number", "string"],
+  NUMERIC: ["number", "string"],
+  FLOAT: ["number", "string"],
+  DOUBLE: ["number", "string"],
+  REAL: ["number", "string"],
+  VARCHAR: ["string"],
+  TEXT: ["string"],
+  CHAR: ["string"],
+  BOOLEAN: ["boolean", "string"],
+  DATE: ["date", "string"],
+  TIMESTAMP: ["datetime", "date", "string"],
+  DATETIME: ["datetime", "date", "string"],
+  JSON: ["json", "string"],
+  JSONB: ["json", "string"],
+  BINARY: ["string"],
+  BLOB: ["string"],
+};
+
+/** text 系 FieldType で between/in 等の数値系オペレータは不整合 */
+const TEXT_OPERATORS_ONLY = new Set(["contains", "startsWith"]);
+const NUMERIC_OPERATORS_ONLY = new Set(["between"]);
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function normalizeFieldType(type: unknown): string | null {
+  if (typeof type === "string") return type;
+  const rec = type as Record<string, unknown> | null;
+  if (rec && typeof rec.kind === "string") return rec.kind;
+  return null;
+}
+
+function getViewId(vd: ViewDefinition): string {
+  // ViewDefinition extends EntityMeta (flat), so id is at root
+  return vd.id ?? "<unknown>";
+}
+
+/**
+ * 単一 ViewDefinition を検証。
+ * tables は同プロジェクトのテーブル定義一覧。
+ */
+export function checkViewDefinition(
+  vd: ViewDefinition,
+  tables: TableDefinitionForView[],
+): ViewDefinitionIssue[] {
+  const issues: ViewDefinitionIssue[] = [];
+  const viewId = getViewId(vd);
+
+  // テーブル索引を事前構築
+  const tableById = new Map<string, TableDefinitionForView>();
+  for (const t of tables) {
+    if (t.id) tableById.set(t.id, t);
+  }
+
+  // ─── 1. UNKNOWN_SOURCE_TABLE ─────────────────────────────────────────────
+  const sourceTable = tableById.get(vd.sourceTableId);
+  if (!sourceTable) {
+    issues.push({
+      path: `ViewDefinition[${viewId}].sourceTableId`,
+      code: "UNKNOWN_SOURCE_TABLE",
+      severity: "error",
+      viewDefinitionId: viewId,
+      message: `sourceTableId '${vd.sourceTableId}' が同プロジェクト内のテーブルに存在しません。`,
+    });
+    // sourceTable が無ければ以降の column 検査は全て false positive になるためスキップ
+    // ただし columns 内の重複検査・sort/filter/groupBy 検査は継続する
+  }
+
+  // columns の name セットを構築 (後続 sort / filter / groupBy 検査用)
+  const columnNames = new Set<string>();
+
+  // ─── 4. DUPLICATE_VIEW_COLUMN_NAME (先にカウント) ─────────────────────
+  const columnNameCount = new Map<string, number>();
+  for (const col of vd.columns ?? []) {
+    const n = asString(col.name);
+    if (n) columnNameCount.set(n, (columnNameCount.get(n) ?? 0) + 1);
+  }
+
+  // ─── columns 個別検査 ────────────────────────────────────────────────────
+  (vd.columns ?? []).forEach((col: ViewColumn, ci: number) => {
+    const colName = asString(col.name) ?? `columns[${ci}]`;
+    const colPath = `ViewDefinition[${viewId}].columns[${ci}=${colName}]`;
+
+    // 4. DUPLICATE_VIEW_COLUMN_NAME
+    if ((columnNameCount.get(colName) ?? 0) > 1) {
+      // 初出 (first occurrence) のみ報告 (重複は 1 回のみ)
+      if (!columnNames.has(colName)) {
+        issues.push({
+          path: colPath,
+          code: "DUPLICATE_VIEW_COLUMN_NAME",
+          severity: "error",
+          viewDefinitionId: viewId,
+          message: `columns[].name '${colName}' が同 ViewDefinition 内で重複しています。`,
+        });
+      }
+    }
+    columnNames.add(colName);
+
+    const ref = col.tableColumnRef;
+    if (!ref) return;
+
+    const refTableId = asString(ref.tableId);
+    const refColumnId = asString(ref.columnId);
+
+    // 3. COLUMN_REF_NOT_IN_SOURCE_TABLE (warning: joined view は許容)
+    if (refTableId && refTableId !== vd.sourceTableId) {
+      issues.push({
+        path: `${colPath}.tableColumnRef`,
+        code: "COLUMN_REF_NOT_IN_SOURCE_TABLE",
+        severity: "warning",
+        viewDefinitionId: viewId,
+        message: `tableColumnRef.tableId '${refTableId}' が sourceTableId '${vd.sourceTableId}' と異なります (joined view 参照は warning)。`,
+      });
+    }
+
+    // 2. UNKNOWN_TABLE_COLUMN_REF
+    if (refTableId && refColumnId) {
+      const refTable = tableById.get(refTableId);
+      if (!refTable) {
+        issues.push({
+          path: `${colPath}.tableColumnRef`,
+          code: "UNKNOWN_TABLE_COLUMN_REF",
+          severity: "error",
+          viewDefinitionId: viewId,
+          message: `tableColumnRef.tableId '${refTableId}' が同プロジェクト内のテーブルに存在しません。`,
+        });
+      } else {
+        const refColumn = (refTable.columns ?? []).find((c) => c.id === refColumnId);
+        if (!refColumn) {
+          issues.push({
+            path: `${colPath}.tableColumnRef`,
+            code: "UNKNOWN_TABLE_COLUMN_REF",
+            severity: "error",
+            viewDefinitionId: viewId,
+            message: `tableColumnRef.columnId '${refColumnId}' がテーブル '${refTableId}' に存在しません。`,
+          });
+        } else {
+          // 5. FIELD_TYPE_INCOMPATIBLE (warning)
+          const dbType = asString(refColumn.dataType)?.toUpperCase();
+          const fieldType = normalizeFieldType(col.type);
+          if (dbType && fieldType) {
+            const compatible = DATATYPE_TO_FIELDTYPE_COMPATIBLE[dbType];
+            if (compatible && !compatible.includes(fieldType)) {
+              issues.push({
+                path: `${colPath}.type`,
+                code: "FIELD_TYPE_INCOMPATIBLE",
+                severity: "warning",
+                viewDefinitionId: viewId,
+                message: `ViewColumn.type '${fieldType}' と DB Column.dataType '${dbType}' が互換しません。互換 FieldType: ${compatible.join(", ")}。`,
+              });
+            }
+          }
+        }
+      }
+    }
+
+    // 8. FILTER_OPERATOR_TYPE_MISMATCH — columns 側で先に FieldType を記録
+    // (filterDefaults の検査で参照するため、columnNames セットで型も保持)
+  });
+
+  // columnNames.has() はコラム名の存在確認のみ。型情報は別途 map で保持
+  const columnFieldType = new Map<string, string | null>();
+  for (const col of vd.columns ?? []) {
+    const n = asString(col.name);
+    if (n) columnFieldType.set(n, normalizeFieldType(col.type));
+  }
+
+  // ─── 6. UNKNOWN_SORT_COLUMN ────────────────────────────────────────────────
+  (vd.sortDefaults ?? []).forEach((sortSpec, si) => {
+    const colName = asString(sortSpec.columnName);
+    if (colName && !columnNames.has(colName)) {
+      issues.push({
+        path: `ViewDefinition[${viewId}].sortDefaults[${si}].columnName`,
+        code: "UNKNOWN_SORT_COLUMN",
+        severity: "error",
+        viewDefinitionId: viewId,
+        message: `sortDefaults[${si}].columnName '${colName}' が columns[].name に存在しません。`,
+      });
+    }
+  });
+
+  // ─── 7. UNKNOWN_FILTER_COLUMN / 8. FILTER_OPERATOR_TYPE_MISMATCH ────────
+  (vd.filterDefaults ?? []).forEach((filterSpec, fi) => {
+    const colName = asString(filterSpec.columnName);
+    if (!colName) return;
+
+    if (!columnNames.has(colName)) {
+      issues.push({
+        path: `ViewDefinition[${viewId}].filterDefaults[${fi}].columnName`,
+        code: "UNKNOWN_FILTER_COLUMN",
+        severity: "error",
+        viewDefinitionId: viewId,
+        message: `filterDefaults[${fi}].columnName '${colName}' が columns[].name に存在しません。`,
+      });
+      return;
+    }
+
+    // 8. FILTER_OPERATOR_TYPE_MISMATCH
+    const operator = asString(filterSpec.operator);
+    const fieldType = columnFieldType.get(colName);
+    if (operator && fieldType) {
+      const isTextType = fieldType === "string";
+      const isNumericType = ["integer", "number", "date", "datetime"].includes(fieldType);
+
+      if (isTextType && NUMERIC_OPERATORS_ONLY.has(operator)) {
+        issues.push({
+          path: `ViewDefinition[${viewId}].filterDefaults[${fi}].operator`,
+          code: "FILTER_OPERATOR_TYPE_MISMATCH",
+          severity: "warning",
+          viewDefinitionId: viewId,
+          message: `filterDefaults[${fi}] operator '${operator}' は text 系 FieldType '${fieldType}' では不整合です。`,
+        });
+      }
+      if (isNumericType && TEXT_OPERATORS_ONLY.has(operator)) {
+        issues.push({
+          path: `ViewDefinition[${viewId}].filterDefaults[${fi}].operator`,
+          code: "FILTER_OPERATOR_TYPE_MISMATCH",
+          severity: "warning",
+          viewDefinitionId: viewId,
+          message: `filterDefaults[${fi}] operator '${operator}' は数値/日付系 FieldType '${fieldType}' では不整合です。`,
+        });
+      }
+    }
+  });
+
+  // ─── 9. UNKNOWN_GROUP_BY_COLUMN ───────────────────────────────────────────
+  if (vd.groupBy) {
+    const groupByName = asString(vd.groupBy);
+    if (groupByName && !columnNames.has(groupByName)) {
+      issues.push({
+        path: `ViewDefinition[${viewId}].groupBy`,
+        code: "UNKNOWN_GROUP_BY_COLUMN",
+        severity: "error",
+        viewDefinitionId: viewId,
+        message: `groupBy '${groupByName}' が columns[].name に存在しません。`,
+      });
+    }
+  }
+
+  return issues;
+}
+
+/**
+ * プロジェクト全体の ViewDefinition を検証。
+ * viewDefinitions は data/view-definitions/<id>.json 相当のオブジェクト配列。
+ */
+export function checkViewDefinitions(
+  viewDefinitions: ViewDefinition[],
+  tables: TableDefinitionForView[],
+): ViewDefinitionIssue[] {
+  const issues: ViewDefinitionIssue[] = [];
+  for (const vd of viewDefinitions ?? []) {
+    issues.push(...checkViewDefinition(vd, tables));
+  }
+  return issues;
+}

--- a/designer/src/types/v3/index.ts
+++ b/designer/src/types/v3/index.ts
@@ -33,6 +33,7 @@ export * from "./screen-layout";
 export * from "./table";
 export * from "./sequence";
 export * from "./view";
+export * from "./view-definition";
 export * from "./er-layout";
 
 // 処理フロー

--- a/designer/src/types/v3/project.ts
+++ b/designer/src/types/v3/project.ts
@@ -23,6 +23,7 @@ import type {
   Uuid,
   ViewId,
 } from "./common";
+import type { ViewDefinitionId } from "./view-definition";
 
 /** entities.* 配列要素の共通プロパティ。一覧 UI 表示用最小メタ。 */
 export interface EntryBase {
@@ -63,6 +64,16 @@ export interface ProcessFlowEntry extends EntryBase {
 export interface ViewEntry extends EntryBase {
   id: ViewId;
   physicalName?: PhysicalName;
+}
+
+/** ViewDefinition (画面 一覧 UI viewer) entry。schemas/v3/view-definition.v3.schema.json と対応。 */
+export interface ViewDefinitionEntry extends EntryBase {
+  id: ViewDefinitionId;
+  /** ViewDefinitionKind (list / detail / kanban / calendar、または `retail:storefront` 等の拡張参照)。 */
+  kind?: string;
+  /** ベースとなる source table の Uuid (一覧 UI 表示用)。 */
+  sourceTableId?: TableId;
+  columnCount?: number;
 }
 
 export interface SequenceEntry extends EntryBase {

--- a/designer/src/types/v3/project.ts
+++ b/designer/src/types/v3/project.ts
@@ -105,6 +105,7 @@ export interface ProjectEntities {
   tables?: TableEntry[];
   processFlows?: ProcessFlowEntry[];
   views?: ViewEntry[];
+  viewDefinitions?: ViewDefinitionEntry[];
   sequences?: SequenceEntry[];
   screenGroups?: ScreenGroupEntry[];
   screenTransitions?: ScreenTransitionEntry[];

--- a/designer/src/types/v3/screen.ts
+++ b/designer/src/types/v3/screen.ts
@@ -9,6 +9,7 @@
 
 import type { Authoring, EntityMeta, ScreenGroupId } from "./common";
 import type { ScreenItem } from "./screen-item";
+import type { ViewDefinitionId } from "./view-definition";
 
 /** 組み込み画面種別 (12 種)。 */
 export type BuiltinScreenKind =
@@ -59,5 +60,7 @@ export interface Screen extends EntityMeta {
   permissions?: string[];
   /** 画面デザイン (GrapesJS 生 HTML への参照)。 */
   design?: ScreenDesign;
+  /** 本画面が参照する ViewDefinition ID 一覧 (1:N)。 */
+  viewDefinitionRefs?: ViewDefinitionId[];
   authoring?: Authoring;
 }

--- a/designer/src/types/v3/view-definition.ts
+++ b/designer/src/types/v3/view-definition.ts
@@ -1,0 +1,103 @@
+/**
+ * v3 ViewDefinition 型定義 (`schemas/v3/view-definition.v3.schema.json` と 1:1 対応)
+ *
+ * - 画面側の一覧 UI viewer 設定 (list / detail / kanban / calendar 等)
+ * - DB View (view.ts) とは axis が異なる: viewer は画面コンポーネント内 render
+ * - Screen は viewDefinitionRefs[] で 1:N 参照する
+ *
+ * 参考: schemas/v3/view-definition.v3.schema.json
+ */
+
+import type {
+  Authoring,
+  Brand,
+  DisplayName,
+  EntityMeta,
+  ExpressionString,
+  FieldType,
+  Identifier,
+  TableColumnRef,
+  TableId,
+  Uuid,
+} from "./common";
+
+/** ViewDefinition の永続識別子 (branded UUID)。 */
+export type ViewDefinitionId = Brand<Uuid, "ViewDefinitionId">;
+
+/** 組み込み viewer 種別 (4 種)。 */
+export type BuiltinViewDefinitionKind = "list" | "detail" | "kanban" | "calendar";
+
+/**
+ * viewer 種別。組み込み + 拡張参照 (`namespace:kindName`)。
+ * 例: `retail:storefront`
+ */
+export type ViewDefinitionKind = BuiltinViewDefinitionKind | string;
+
+/** ソート 1 列。columnName は ViewColumn.name を参照。 */
+export interface SortSpec {
+  columnName: Identifier;
+  order: "asc" | "desc";
+}
+
+/** フィルタの比較演算子。 */
+export type FilterOperator =
+  | "eq"
+  | "neq"
+  | "gt"
+  | "gte"
+  | "lt"
+  | "lte"
+  | "contains"
+  | "startsWith"
+  | "in"
+  | "between";
+
+/** フィルタ 1 件。columnName は ViewColumn.name を参照。 */
+export interface FilterSpec {
+  columnName: Identifier;
+  operator: FilterOperator;
+  /** 比較リテラル (operator に応じて型が変わる)。 */
+  value?: unknown;
+  /** 比較値を式で渡す場合 (例: `@conv.numbering.lowStockThreshold`)。 */
+  valueExpression?: ExpressionString;
+}
+
+/** viewer 1 列。table カラムへの複合参照 + 画面表示型 (FieldType)。 */
+export interface ViewColumn {
+  /** 列識別子 (camelCase)。同 ViewDefinition 内で一意。 */
+  name: Identifier;
+  /** 参照する table カラム (Pattern B)。 */
+  tableColumnRef: TableColumnRef;
+  displayName?: DisplayName;
+  /** 画面表示型 (FieldType)。Column.dataType (DB 型) と互換であること (validator が検査)。 */
+  type: FieldType;
+  /** 表示書式。例: `'#,##0'`, `'YYYY-MM-DD'`。 */
+  displayFormat?: string;
+  /** 列幅 (CSS 表記、例: `'120px'`, `'1fr'`)。 */
+  width?: string;
+  align?: "left" | "center" | "right";
+  sortable?: boolean;
+  filterable?: boolean;
+  /** 列表示条件式。 */
+  visibleWhen?: ExpressionString;
+  /** セル click で navigate する path (例: `'/orders/:id'`)。 */
+  linkTo?: string;
+}
+
+/** ViewDefinition entity 本体。 */
+export interface ViewDefinition extends EntityMeta {
+  $schema?: string;
+  kind: ViewDefinitionKind;
+  /** viewer の主要ソーステーブル。1 ViewDefinition = 1 ベース table。 */
+  sourceTableId: TableId;
+  columns: ViewColumn[];
+  /** 既定ソート順 (複数列対応)。 */
+  sortDefaults?: SortSpec[];
+  /** 初期フィルタ条件。 */
+  filterDefaults?: FilterSpec[];
+  /** ページング初期件数 (1..1000)。 */
+  pageSize?: number;
+  /** kanban / グルーピング表示時の集約キー。columns[].name を参照。 */
+  groupBy?: Identifier;
+  authoring?: Authoring;
+}

--- a/docs/sample-project-v3/retail/project.json
+++ b/docs/sample-project-v3/retail/project.json
@@ -28,6 +28,28 @@
         "kind": "search",
         "path": "/retail/inventory/search",
         "hasDesign": false
+      },
+      {
+        "id": "a1b2c3d4-e5f6-4000-8000-a1b2c3d4e5f6",
+        "no": 2,
+        "name": "商品一覧",
+        "updatedAt": "2026-04-30T00:00:00.000Z",
+        "maturity": "committed",
+        "kind": "list",
+        "path": "/retail/products",
+        "hasDesign": false
+      }
+    ],
+    "viewDefinitions": [
+      {
+        "id": "f1a2b3c4-d5e6-4000-8000-f1a2b3c4d5e6",
+        "no": 1,
+        "name": "商品一覧ビュー",
+        "updatedAt": "2026-04-30T00:00:00.000Z",
+        "maturity": "committed",
+        "kind": "list",
+        "sourceTableId": "eb574288-88f2-419f-ac5e-56a9948e8f46",
+        "columnCount": 5
       }
     ],
     "tables": [

--- a/docs/sample-project-v3/retail/screens/a1b2c3d4-e5f6-4000-8000-a1b2c3d4e5f6.json
+++ b/docs/sample-project-v3/retail/screens/a1b2c3d4-e5f6-4000-8000-a1b2c3d4e5f6.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../../schemas/v3/screen.v3.schema.json",
+  "id": "a1b2c3d4-e5f6-4000-8000-a1b2c3d4e5f6",
+  "name": "商品一覧",
+  "description": "商品マスタの一覧を表示する画面。カテゴリによるフィルタと商品名のキーワード検索をサポートする。",
+  "version": "1.0.0",
+  "maturity": "committed",
+  "createdAt": "2026-04-30T00:00:00.000Z",
+  "updatedAt": "2026-04-30T00:00:00.000Z",
+  "kind": "list",
+  "path": "/retail/products",
+  "auth": "optional",
+  "viewDefinitionRefs": [
+    "f1a2b3c4-d5e6-4000-8000-f1a2b3c4d5e6"
+  ],
+  "authoring": {
+    "notes": [
+      {
+        "id": "note-screen-prod-01",
+        "kind": "assumption",
+        "body": "商品一覧は未認証でも参照可能 (在庫照会の前段)。認証必須への変更は将来の要件で検討。",
+        "createdAt": "2026-04-30T00:00:00.000Z"
+      }
+    ]
+  }
+}

--- a/docs/sample-project-v3/retail/view-definitions/f1a2b3c4-d5e6-4000-8000-f1a2b3c4d5e6.json
+++ b/docs/sample-project-v3/retail/view-definitions/f1a2b3c4-d5e6-4000-8000-f1a2b3c4d5e6.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "../../../../schemas/v3/view-definition.v3.schema.json",
+  "id": "f1a2b3c4-d5e6-4000-8000-f1a2b3c4d5e6",
+  "name": "商品一覧ビュー",
+  "description": "商品マスタを一覧表示する ViewDefinition。カテゴリフィルタと商品コードソートをデフォルト設定。",
+  "version": "1.0.0",
+  "maturity": "committed",
+  "createdAt": "2026-04-30T00:00:00.000Z",
+  "updatedAt": "2026-04-30T00:00:00.000Z",
+  "kind": "list",
+  "sourceTableId": "eb574288-88f2-419f-ac5e-56a9948e8f46",
+  "columns": [
+    {
+      "name": "productCode",
+      "tableColumnRef": { "tableId": "eb574288-88f2-419f-ac5e-56a9948e8f46", "columnId": "col-p02" },
+      "displayName": "商品コード",
+      "type": "string",
+      "width": "120px",
+      "align": "left",
+      "sortable": true,
+      "filterable": false,
+      "linkTo": "/retail/products/:productCode"
+    },
+    {
+      "name": "productName",
+      "tableColumnRef": { "tableId": "eb574288-88f2-419f-ac5e-56a9948e8f46", "columnId": "col-p03" },
+      "displayName": "商品名",
+      "type": "string",
+      "width": "1fr",
+      "align": "left",
+      "sortable": true,
+      "filterable": true
+    },
+    {
+      "name": "category",
+      "tableColumnRef": { "tableId": "eb574288-88f2-419f-ac5e-56a9948e8f46", "columnId": "col-p04" },
+      "displayName": "カテゴリ",
+      "type": "string",
+      "width": "150px",
+      "align": "left",
+      "sortable": true,
+      "filterable": true
+    },
+    {
+      "name": "unitPrice",
+      "tableColumnRef": { "tableId": "eb574288-88f2-419f-ac5e-56a9948e8f46", "columnId": "col-p05" },
+      "displayName": "単価(税抜)",
+      "type": "integer",
+      "width": "100px",
+      "align": "right",
+      "sortable": true,
+      "filterable": false,
+      "displayFormat": "#,##0"
+    },
+    {
+      "name": "isActive",
+      "tableColumnRef": { "tableId": "eb574288-88f2-419f-ac5e-56a9948e8f46", "columnId": "col-p07" },
+      "displayName": "販売フラグ",
+      "type": "boolean",
+      "width": "80px",
+      "align": "center",
+      "sortable": false,
+      "filterable": true
+    }
+  ],
+  "sortDefaults": [
+    { "columnName": "productCode", "order": "asc" }
+  ],
+  "filterDefaults": [
+    { "columnName": "isActive", "operator": "eq", "value": true }
+  ],
+  "pageSize": 50,
+  "authoring": {
+    "notes": [
+      {
+        "id": "note-vd-retail-01",
+        "kind": "assumption",
+        "body": "商品コードはリンク付き (詳細画面 /retail/products/:productCode へ遷移)。初期フィルタは販売フラグ=true のみ表示。非販売商品を表示するにはフィルタ解除が必要。",
+        "createdAt": "2026-04-30T00:00:00.000Z"
+      }
+    ]
+  }
+}

--- a/docs/sample-project-v3/welfare-benefit/project.json
+++ b/docs/sample-project-v3/welfare-benefit/project.json
@@ -17,7 +17,20 @@
   "entities": {
     "screens": [
       { "id": "883e408d-3290-448d-a881-e9d7a22c85fc", "no": 1, "name": "給付申請受付", "updatedAt": "2026-04-30T00:00:00.000Z", "maturity": "committed", "kind": "form", "path": "/welfare-benefit/applications/new", "hasDesign": false },
-      { "id": "1cfb3eef-baa4-4666-8ef3-f74fe2954f85", "no": 2, "name": "支払通知", "updatedAt": "2026-04-30T00:00:00.000Z", "maturity": "committed", "kind": "form", "path": "/welfare-benefit/payments/new", "hasDesign": false }
+      { "id": "1cfb3eef-baa4-4666-8ef3-f74fe2954f85", "no": 2, "name": "支払通知", "updatedAt": "2026-04-30T00:00:00.000Z", "maturity": "committed", "kind": "form", "path": "/welfare-benefit/payments/new", "hasDesign": false },
+      { "id": "e2d3f4a5-b6c7-4000-8000-e2d3f4a5b6c7", "no": 3, "name": "受給者一覧", "updatedAt": "2026-04-30T00:00:00.000Z", "maturity": "committed", "kind": "list", "path": "/welfare-benefit/beneficiaries", "hasDesign": false }
+    ],
+    "viewDefinitions": [
+      {
+        "id": "c7d8e9f0-a1b2-4000-8000-c7d8e9f0a1b2",
+        "no": 1,
+        "name": "受給者一覧ビュー",
+        "updatedAt": "2026-04-30T00:00:00.000Z",
+        "maturity": "committed",
+        "kind": "list",
+        "sourceTableId": "dde87bc9-e122-4466-9b1c-e8c5b2f98408",
+        "columnCount": 5
+      }
     ],
     "tables": [
       { "id": "c3bff56f-e4d2-4597-8819-93ecf7fc0acd", "no": 1, "name": "申請者", "updatedAt": "2026-04-30T00:00:00.000Z", "maturity": "committed", "physicalName": "applicants", "category": "マスタ", "columnCount": 12 },

--- a/docs/sample-project-v3/welfare-benefit/screens/e2d3f4a5-b6c7-4000-8000-e2d3f4a5b6c7.json
+++ b/docs/sample-project-v3/welfare-benefit/screens/e2d3f4a5-b6c7-4000-8000-e2d3f4a5b6c7.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../../schemas/v3/screen.v3.schema.json",
+  "id": "e2d3f4a5-b6c7-4000-8000-e2d3f4a5b6c7",
+  "name": "受給者一覧",
+  "description": "受給者台帳の一覧を表示する画面。受給資格状態によるフィルタと受給者IDの検索をサポートする。",
+  "version": "1.0.0",
+  "maturity": "committed",
+  "createdAt": "2026-04-30T00:00:00.000Z",
+  "updatedAt": "2026-04-30T00:00:00.000Z",
+  "kind": "list",
+  "path": "/welfare-benefit/beneficiaries",
+  "auth": "required",
+  "viewDefinitionRefs": [
+    "c7d8e9f0-a1b2-4000-8000-c7d8e9f0a1b2"
+  ],
+  "authoring": {
+    "notes": [
+      {
+        "id": "note-screen-bnf-01",
+        "kind": "assumption",
+        "body": "受給者台帳には個人情報 (PII) が含まれるため認証必須。ロールベースアクセス制御は別途権限管理で実施する。",
+        "createdAt": "2026-04-30T00:00:00.000Z"
+      }
+    ]
+  }
+}

--- a/docs/sample-project-v3/welfare-benefit/view-definitions/c7d8e9f0-a1b2-4000-8000-c7d8e9f0a1b2.json
+++ b/docs/sample-project-v3/welfare-benefit/view-definitions/c7d8e9f0-a1b2-4000-8000-c7d8e9f0a1b2.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "../../../../schemas/v3/view-definition.v3.schema.json",
+  "id": "c7d8e9f0-a1b2-4000-8000-c7d8e9f0a1b2",
+  "name": "受給者一覧ビュー",
+  "description": "受給者台帳を一覧表示する ViewDefinition。受給資格状態フィルタと年間累計支払額降順ソートをデフォルト設定。",
+  "version": "1.0.0",
+  "maturity": "committed",
+  "createdAt": "2026-04-30T00:00:00.000Z",
+  "updatedAt": "2026-04-30T00:00:00.000Z",
+  "kind": "list",
+  "sourceTableId": "dde87bc9-e122-4466-9b1c-e8c5b2f98408",
+  "columns": [
+    {
+      "name": "beneficiaryCode",
+      "tableColumnRef": { "tableId": "dde87bc9-e122-4466-9b1c-e8c5b2f98408", "columnId": "col-bnf02" },
+      "displayName": "受給者ID",
+      "type": "string",
+      "width": "140px",
+      "align": "left",
+      "sortable": true,
+      "filterable": true,
+      "linkTo": "/welfare-benefit/beneficiaries/:beneficiaryCode"
+    },
+    {
+      "name": "fiscalYear",
+      "tableColumnRef": { "tableId": "dde87bc9-e122-4466-9b1c-e8c5b2f98408", "columnId": "col-bnf04" },
+      "displayName": "会計年度",
+      "type": "integer",
+      "width": "100px",
+      "align": "center",
+      "sortable": true,
+      "filterable": true
+    },
+    {
+      "name": "totalPaidAmount",
+      "tableColumnRef": { "tableId": "dde87bc9-e122-4466-9b1c-e8c5b2f98408", "columnId": "col-bnf05" },
+      "displayName": "年間累計支払額",
+      "type": "number",
+      "width": "150px",
+      "align": "right",
+      "sortable": true,
+      "filterable": false,
+      "displayFormat": "#,##0"
+    },
+    {
+      "name": "eligibilityStatus",
+      "tableColumnRef": { "tableId": "dde87bc9-e122-4466-9b1c-e8c5b2f98408", "columnId": "col-bnf07" },
+      "displayName": "受給資格状態",
+      "type": "string",
+      "width": "130px",
+      "align": "center",
+      "sortable": true,
+      "filterable": true
+    },
+    {
+      "name": "lastPaidAt",
+      "tableColumnRef": { "tableId": "dde87bc9-e122-4466-9b1c-e8c5b2f98408", "columnId": "col-bnf06" },
+      "displayName": "最終支払日時",
+      "type": "datetime",
+      "width": "160px",
+      "align": "left",
+      "sortable": true,
+      "filterable": false,
+      "displayFormat": "YYYY-MM-DD HH:mm"
+    }
+  ],
+  "sortDefaults": [
+    { "columnName": "totalPaidAmount", "order": "desc" }
+  ],
+  "filterDefaults": [
+    { "columnName": "eligibilityStatus", "operator": "eq", "value": "eligible" }
+  ],
+  "pageSize": 30,
+  "authoring": {
+    "notes": [
+      {
+        "id": "note-vd-bnf-01",
+        "kind": "assumption",
+        "body": "初期フィルタは受給資格状態=eligible のみ表示。資格停止受給者を含む全件表示はフィルタ解除で実施。年間累計支払額は降順で、限度額近傍の案件を先頭に表示する設計。",
+        "createdAt": "2026-04-30T00:00:00.000Z"
+      }
+    ]
+  }
+}

--- a/schemas/v3/project.v3.schema.json
+++ b/schemas/v3/project.v3.schema.json
@@ -42,6 +42,7 @@
         "tables":  { "type": "array", "items": { "$ref": "#/$defs/TableEntry" } },
         "processFlows": { "type": "array", "items": { "$ref": "#/$defs/ProcessFlowEntry" } },
         "views": { "type": "array", "items": { "$ref": "#/$defs/ViewEntry" } },
+        "viewDefinitions": { "type": "array", "items": { "$ref": "#/$defs/ViewDefinitionEntry" } },
         "sequences": { "type": "array", "items": { "$ref": "#/$defs/SequenceEntry" } },
         "screenGroups": { "type": "array", "items": { "$ref": "#/$defs/ScreenGroupEntry" } },
         "screenTransitions": { "type": "array", "items": { "$ref": "#/$defs/ScreenTransitionEntry" } }
@@ -108,6 +109,18 @@
       "type": "object",
       "properties": {
         "physicalName": { "$ref": "common.v3.schema.json#/$defs/PhysicalName" }
+      },
+      "unevaluatedProperties": false
+    },
+
+    "ViewDefinitionEntry": {
+      "description": "ViewDefinition (画面 一覧 UI viewer) entry。schemas/v3/view-definition.v3.schema.json と対応。",
+      "allOf": [{ "$ref": "#/$defs/EntryBase" }],
+      "type": "object",
+      "properties": {
+        "kind": { "type": "string", "description": "ViewDefinitionKind (list / detail / kanban / calendar、または 'retail:storefront' 等の拡張参照)。" },
+        "sourceTableId": { "$ref": "common.v3.schema.json#/$defs/Uuid", "description": "ベースとなる source table の Uuid (一覧 UI 表示用)。" },
+        "columnCount": { "type": "integer", "minimum": 0 }
       },
       "unevaluatedProperties": false
     },

--- a/schemas/v3/screen.v3.schema.json
+++ b/schemas/v3/screen.v3.schema.json
@@ -36,6 +36,11 @@
           "items": { "type": "string" },
           "description": "本画面表示に必要な permission キー (@conv.permission.<key>)。"
         },
+        "viewDefinitionRefs": {
+          "type": "array",
+          "description": "本画面が表示する一覧 UI viewer (ViewDefinition) の参照一覧 (1:N)。kind='list' / 'kanban' / 'calendar' 等の画面で複数 viewer をタブ等で切り替える場合に複数指定。schemas/v3/view-definition.v3.schema.json と対応。",
+          "items": { "$ref": "common.v3.schema.json#/$defs/Uuid" }
+        },
         "design": {
           "$ref": "#/$defs/ScreenDesign",
           "description": "画面デザイン (GrapesJS 生 HTML への参照)。本フレームワークの schema 範囲外、外部参照のみ。"

--- a/schemas/v3/view-definition.v3.schema.json
+++ b/schemas/v3/view-definition.v3.schema.json
@@ -1,0 +1,143 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/csilost2001/html-designer/main/schemas/v3/view-definition.v3.schema.json",
+  "title": "ViewDefinition (v3 画面 一覧 UI viewer)",
+  "description": "画面側の一覧 UI viewer 設定 (list / detail / kanban / calendar 等)。DB の SELECT 文を保持する View (view.v3.schema.json) とは axis が異なる。1 viewer = 1 source table、列は画面表示型 (FieldType) で表現。Screen は viewDefinitionRefs[] で 1:N 参照する。",
+  "type": "object",
+  "$ref": "#/$defs/ViewDefinition",
+  "$defs": {
+    "ViewDefinition": {
+      "description": "ViewDefinition entity 本体。EntityMeta + viewer 種別 + source table + columns + sort/filter defaults + authoring。",
+      "allOf": [
+        { "$ref": "common.v3.schema.json#/$defs/EntityMeta" }
+      ],
+      "type": "object",
+      "required": ["kind", "sourceTableId", "columns"],
+      "properties": {
+        "$schema": { "type": "string", "description": "instance JSON が参照する schema 文書への URL/相対パス。" },
+        "kind": { "$ref": "#/$defs/ViewDefinitionKind" },
+        "sourceTableId": {
+          "$ref": "common.v3.schema.json#/$defs/Uuid",
+          "description": "viewer の主要ソーステーブル。1 ViewDefinition = 1 ベース table。joined view を表現する場合は別 column の tableColumnRef.tableId が異なる値を持ってよい (warning)。"
+        },
+        "columns": {
+          "type": "array",
+          "minItems": 1,
+          "description": "viewer に表示する列定義。表示順は配列順。",
+          "items": { "$ref": "#/$defs/ViewColumn" }
+        },
+        "sortDefaults": {
+          "type": "array",
+          "description": "既定ソート順 (複数列対応)。columnName は columns[].name を参照。",
+          "items": { "$ref": "#/$defs/SortSpec" }
+        },
+        "filterDefaults": {
+          "type": "array",
+          "description": "初期フィルタ条件。columnName は columns[].name を参照。",
+          "items": { "$ref": "#/$defs/FilterSpec" }
+        },
+        "pageSize": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000,
+          "description": "ページング初期件数。"
+        },
+        "groupBy": {
+          "$ref": "common.v3.schema.json#/$defs/Identifier",
+          "description": "kanban / グルーピング表示時の集約キー。columns[].name を参照。"
+        },
+        "authoring": { "$ref": "common.v3.schema.json#/$defs/Authoring" }
+      },
+      "unevaluatedProperties": false
+    },
+
+    "ViewDefinitionKind": {
+      "description": "viewer 種別。組み込み 4 種 (list / detail / kanban / calendar) + 拡張参照 (namespace:kindName)。",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["list", "detail", "kanban", "calendar"]
+        },
+        {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_-]*:[a-z][a-zA-Z0-9]*$",
+          "description": "拡張 ViewDefinitionKind 参照。namespace:kindName 形式 (例: 'retail:storefront')。"
+        }
+      ]
+    },
+
+    "ViewColumn": {
+      "description": "viewer 1 列の定義。table カラムへの複合参照 + 画面表示型 (FieldType)。",
+      "type": "object",
+      "required": ["name", "tableColumnRef", "type"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "$ref": "common.v3.schema.json#/$defs/Identifier",
+          "description": "列識別子 (camelCase)。同 ViewDefinition 内で一意。sortDefaults / filterDefaults / groupBy が参照する。"
+        },
+        "tableColumnRef": {
+          "$ref": "common.v3.schema.json#/$defs/TableColumnRef",
+          "description": "参照する table カラム (Pattern B)。tableId は通常 sourceTableId と一致。"
+        },
+        "displayName": { "$ref": "common.v3.schema.json#/$defs/DisplayName" },
+        "type": {
+          "$ref": "common.v3.schema.json#/$defs/FieldType",
+          "description": "画面表示型 (FieldType)。Column.dataType (DB 型) と互換であること (validator が検査)。"
+        },
+        "displayFormat": {
+          "type": "string",
+          "description": "表示書式。例: '#,##0' (整数 3 桁区切り) / 'YYYY-MM-DD' (日付)。"
+        },
+        "width": {
+          "type": "string",
+          "description": "列幅 (CSS 表記、例: '120px' / '1fr' / 'auto')。"
+        },
+        "align": {
+          "enum": ["left", "center", "right"]
+        },
+        "sortable": { "type": "boolean" },
+        "filterable": { "type": "boolean" },
+        "visibleWhen": {
+          "$ref": "common.v3.schema.json#/$defs/ExpressionString",
+          "description": "列表示条件式。"
+        },
+        "linkTo": {
+          "type": "string",
+          "description": "セル click で navigate する path (例: '/orders/:id')。:colon 形式で同行値を埋め込み。"
+        }
+      }
+    },
+
+    "SortSpec": {
+      "description": "ソート 1 列。columnName は ViewColumn.name を参照。",
+      "type": "object",
+      "required": ["columnName", "order"],
+      "additionalProperties": false,
+      "properties": {
+        "columnName": { "$ref": "common.v3.schema.json#/$defs/Identifier" },
+        "order": { "enum": ["asc", "desc"] }
+      }
+    },
+
+    "FilterSpec": {
+      "description": "フィルタ 1 件。columnName は ViewColumn.name を参照。value (リテラル) または valueExpression (式) のいずれか。",
+      "type": "object",
+      "required": ["columnName", "operator"],
+      "additionalProperties": false,
+      "properties": {
+        "columnName": { "$ref": "common.v3.schema.json#/$defs/Identifier" },
+        "operator": {
+          "enum": ["eq", "neq", "gt", "gte", "lt", "lte", "contains", "startsWith", "in", "between"]
+        },
+        "value": {
+          "description": "比較リテラル値。operator に応じて型が変わる (in: array / between: [min, max] / contains-startsWith: string)。"
+        },
+        "valueExpression": {
+          "$ref": "common.v3.schema.json#/$defs/ExpressionString",
+          "description": "比較値を式で渡したい場合 (例: '@conv.numbering.lowStockThreshold')。"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 関連

Closes #649
仕様: ISSUE #649 Opus 設計計画 (gh issue view 649 --comments 参照)

## 概要

Phase 4 子 1 として、画面側の一覧 UI viewer 設定概念 `ViewDefinition` を新設する。DB の SELECT 文を保持する既存 `View` (view.v3.schema.json) とは別概念 (axis が異なる)。Screen は `viewDefinitionRefs[]` で 1:N 参照する設計を採用。

## 主な変更

- **新規 schema**: `schemas/v3/view-definition.v3.schema.json` 新設 (kind / sourceTableId / columns / sortDefaults / filterDefaults / pageSize / groupBy)
- **schema 拡張**: `project.v3.schema.json` に `viewDefinitions[]` エントリ追加、`screen.v3.schema.json` に `Screen.viewDefinitionRefs[]` 追加
- **型定義**: `designer/src/types/v3/view-definition.ts` 新設 (ViewDefinition / ViewColumn / SortSpec / FilterSpec / ViewDefinitionId)
- **validator 新設 (8 件目)**: `viewDefinitionValidator.ts` — 9 観点 (UNKNOWN_SOURCE_TABLE / UNKNOWN_TABLE_COLUMN_REF / COLUMN_REF_NOT_IN_SOURCE_TABLE / DUPLICATE_VIEW_COLUMN_NAME / FIELD_TYPE_INCOMPATIBLE / UNKNOWN_SORT_COLUMN / UNKNOWN_FILTER_COLUMN / FILTER_OPERATOR_TYPE_MISMATCH / UNKNOWN_GROUP_BY_COLUMN)
- **validate-dogfood 統合**: project-level 7 番目 validator として統合 (18/18 flows pass、2 viewDefinitions 検出)
- **paving サンプル 2 業界**: retail 商品一覧 (商品マスタ 5 列 / list-kind) + welfare-benefit 受給者一覧 (受給者台帳 5 列 / list-kind / eligibilityStatus フィルタ)
- **Skill 統合**: `/create-flow` Rule 20、`/review-flow` 観点 12 として viewDefinitionValidator を組込 (8 バリデータ / 12 観点に更新)

## 仕様逐条突合 (自己申告)

ISSUE #649 設計判断の採用確認:

- (a) Screen.viewDefinitionRefs[] 1:N 方式 → `schemas/v3/screen.v3.schema.json`:39-44 ✓
- (b) UI 見出し分離 / 独立 schema → `schemas/v3/view-definition.v3.schema.json`:1-143 ✓
- (c) paving 2 業界先行 (retail + welfare-benefit) → `docs/sample-project-v3/retail/view-definitions/` + `welfare-benefit/view-definitions/` ✓
- (d) schema + validator + サンプル先行 (UI は別 ISSUE) → UI コンポーネント変更なし ✓

validator 9 観点:
1. `UNKNOWN_SOURCE_TABLE` → viewDefinitionValidator.ts:95-106 ✓
2. `UNKNOWN_TABLE_COLUMN_REF` → viewDefinitionValidator.ts:139-161 ✓
3. `COLUMN_REF_NOT_IN_SOURCE_TABLE` → viewDefinitionValidator.ts:127-136 ✓
4. `DUPLICATE_VIEW_COLUMN_NAME` → viewDefinitionValidator.ts:111-122 ✓
5. `FIELD_TYPE_INCOMPATIBLE` → viewDefinitionValidator.ts:163-175 ✓
6. `UNKNOWN_SORT_COLUMN` → viewDefinitionValidator.ts:184-192 ✓
7. `UNKNOWN_FILTER_COLUMN` → viewDefinitionValidator.ts:195-210 ✓
8. `FILTER_OPERATOR_TYPE_MISMATCH` → viewDefinitionValidator.ts:212-228 ✓
9. `UNKNOWN_GROUP_BY_COLUMN` → viewDefinitionValidator.ts:232-241 ✓

## レビューで特に見てほしい箇所

- `FIELD_TYPE_INCOMPATIBLE` の互換マトリクス (`DATATYPE_TO_FIELDTYPE_COMPATIBLE` マップ、viewDefinitionValidator.ts:44-72) — DataType → FieldType の対応が業務的に妥当か
- `FILTER_OPERATOR_TYPE_MISMATCH` の判定ロジック — text 型に `between` / 数値型に `contains` の検出は適切か、他の不整合パターンの見落としがないか
- welfare-benefit 受給者一覧の `totalPaidAmount` カラムが DECIMAL → `number` 型マッピング — DECIMAL の互換 FieldType 設定が正しいか

## テスト

- Vitest: 24 件 (新規 24 件) — viewDefinitionValidator.test.ts (9 観点 × 正常系/異常系)
- Vitest: 493 件 pass (src/schemas/ 全件) — v3-samples.test.ts に ViewDefinition schema 検証追加
- validate:dogfood: 18/18 flows pass、2 viewDefinitions 検出 (regression なし)
- Playwright: N/A (UI 変更なし)

## UI 影響 / AI smoke test

- [x] UI 影響なし (auto テスト pass のみ)

UI 編集画面 (ViewDefinitionEditor / ViewDefinitionListView) は別 ISSUE スコープ外のため本 PR に含まない。

## spec 側の不足点 / 提案

N/A — schema / validator / サンプルの仕様は ISSUE #649 Opus 設計計画で全て確定済み。

## レビュー担当への申し送り

- **他 2 子 (#650 / #651) と並列実装中**: 本 PR は単独でマージ可能だが、Phase 4 メタ #648 の全子マージ後に main rebase を推奨
- **UI は後続 ISSUE**: ViewDefinitionListView / ViewDefinitionEditor / store は本 PR 対象外。ViewDefinition JSON の編集は現状手動のみ
- **schema ガバナンス**: 新設 `view-definition.v3.schema.json` は ISSUE #649 Opus 設計で承認済み。`project.v3.schema.json` と `screen.v3.schema.json` への追加も同計画内

🤖 Generated with [Claude Code](https://claude.com/claude-code)