### PR TITLE
feat(validator): sqlOrderValidator 観点 3 — UNIQUE_CHECK_MISSING 検出 (#640)

### DIFF
--- a/.claude/skills/create-flow/SKILL.md
+++ b/.claude/skills/create-flow/SKILL.md
@@ -241,7 +241,7 @@ UI 起点フロー (`type: "screen"` / `mode: "upstream"`) を作成するとき
 - 典型ミス: happy-path で全前提を pre-seed、edge は 400/403 系の検証に偏り、初回ユーザーパスが抜ける
 - **補足**: 静的検出 `sqlOrderValidator` (#632) が導入されるまで本ルールが主要 catch 機構。導入後も「値レベル fixture 不足」など静的検出では届かない領域は本ルールで継続担保 (Step 5.2 validate:dogfood では機械検出されない、Step 3 self-check のみで担保)
 
-### Rule 19: DB 制約 × INSERT 操作順序 (#632)
+### Rule 19: DB 制約 × INSERT 操作順序 (#632 / #640)
 
 - INSERT 文の VALUES で使う変数が INSERT 時点でバインド済みか確認 (NOT NULL カラムが対象)
   - 未バインド変数を NOT NULL カラムに入れている場合: 実行時 DB 制約違反 → Must-fix
@@ -251,9 +251,20 @@ UI 起点フロー (`type: "screen"` / `mode: "upstream"`) を作成するとき
   - SELECT で outputBinding された変数を FK に使う (= 既存行 ID 参照) は正常
   - inputs から来た変数を FK に使う (= 外部から受け取った ID) は正常
   - 全く出どころ不明の変数を FK カラムに使う場合のみ issue
+- UNIQUE 制約のあるカラムへの INSERT で事前の重複チェックがない場合: Should-fix (warning) (#640)
+  - 以下のいずれかがあれば OK (検出しない):
+    1. INSERT 前に同テーブルへの SELECT WHERE で UNIQUE カラムを WHERE に含む (存在確認)
+    2. INSERT step 自身の `affectedRowsCheck.errorCode` が UNIQUE/DUPLICATE/CONFLICT/ALREADY_EXISTS 系
+    3. action 内に `branch.condition.kind: "tryCatch"` で UNIQUE_VIOLATION 系エラーをキャッチする step がある
+  - 対象: `Table.constraints[].kind: "unique"` の columnIds および `Column.unique: true`
 
 **Step 5.2 で `validate:dogfood` の `sqlOrderValidator` により機械的に検出される**
 
+| code | severity | 検出内容 |
+|---|---|---|
+| `NULL_NOT_ALLOWED_AT_INSERT` | error | NOT NULL カラムへの NULL または未バインド変数 INSERT |
+| `FK_REFERENCE_NOT_INSERTED` | error | FK 参照先テーブルの先行 INSERT なし + FK カラム変数が未バインド |
+| `UNIQUE_CHECK_MISSING` | warning | UNIQUE カラムへの INSERT で事前重複チェックなし (#640) |
 
 ### Rule 20: ViewDefinition 整合 (#649、Phase 4 子 1)
 

--- a/.claude/skills/review-flow/SKILL.md
+++ b/.claude/skills/review-flow/SKILL.md
@@ -98,7 +98,7 @@ npm run validate:dogfood
 - バリデータが検出した issue は **Step 1 のレビュー入力**として活用 (重複説明はしない)
 - 結果は Step 2 の「10 観点別カバレッジ」表に **「validator 検出済」** カラムとして記録
 - Must-fix 候補: `UNKNOWN_RESPONSE_REF` / `UNKNOWN_ERROR_CODE` / `UNKNOWN_IDENTIFIER` / `UNKNOWN_COLUMN` / `UNKNOWN_CONV_*` / `UNKNOWN_HANDLER_FLOW` / `MISSING_REQUIRED_ARGUMENT` / `EXTRA_ARGUMENT` / `PRIMARY_INVOKER_MISMATCH` / `DUPLICATE_EVENT_ID` / `NULL_NOT_ALLOWED_AT_INSERT` / `FK_REFERENCE_NOT_INSERTED` 等
-- Should-fix 候補 (warning): `INCONSISTENT_ARGUMENT_CONTRACT` (1 フローを呼ぶ複数イベント間で argumentMapping キー集合が異なる)
+- Should-fix 候補 (warning): `INCONSISTENT_ARGUMENT_CONTRACT` (1 フローを呼ぶ複数イベント間で argumentMapping キー集合が異なる) / `UNIQUE_CHECK_MISSING` (UNIQUE カラムへの INSERT で事前重複チェックなし、#640)
 - 終了コード 1 (1 件以上 fail) でも Step 1 を中止せず実施する (実行セマンティクス観点が AI 目視のみで残るため)
 
 ### 観点 ⇄ バリデータ対応表 (担当領域)
@@ -115,7 +115,7 @@ npm run validate:dogfood
 | 8. rollbackOn 発火可能性 | referentialIntegrity (UNKNOWN_ERROR_CODE) | TX inner からの実発火可能性は AI |
 | 9. 画面項目イベント連携整合 | screenItemFlowValidator (handlerFlowId / argumentMapping / primaryInvoker / events[].id ユニーク) | 業務文脈での argumentMapping 値の妥当性 (UI 入力 → フロー入力の意味的整合) は AI |
 | 10. 画面項目値レベル整合 | screenItemFieldTypeValidator (options 包含 / domainKey / 型 / pattern / range / length) | 業務文脈の妥当性 (選択肢命名の業務適切性 / domain 設計妥当性) は AI |
-| 11. DB 制約 × INSERT 順序 (#632) | sqlOrderValidator (NULL_NOT_ALLOWED_AT_INSERT / FK_REFERENCE_NOT_INSERTED) | 複雑な条件分岐での可能性の有無は AI |
+| 11. DB 制約 × INSERT 順序 (#632 / #640) | sqlOrderValidator (NULL_NOT_ALLOWED_AT_INSERT / FK_REFERENCE_NOT_INSERTED / UNIQUE_CHECK_MISSING) | 複雑な条件分岐での可能性の有無は AI / UNIQUE チェック抑止パターンの業務妥当性は AI |
 | 12. ViewDefinition 整合 (#649) | viewDefinitionValidator (UNKNOWN_SOURCE_TABLE / UNKNOWN_TABLE_COLUMN_REF / DUPLICATE_VIEW_COLUMN_NAME / UNKNOWN_SORT_COLUMN / UNKNOWN_FILTER_COLUMN / UNKNOWN_GROUP_BY_COLUMN) | sourceTableId ↔ dbAccess テーブルの業務的整合 / FIELD_TYPE_INCOMPATIBLE の業務妥当性は AI |
 
 監査根拠: `docs/spec/dogfood-2026-04-29-phase2-validator-audit.md` §3 / §4 + Phase 3 子 1 #619 (PR #626)。

--- a/designer/scripts/validate-dogfood.ts
+++ b/designer/scripts/validate-dogfood.ts
@@ -67,6 +67,7 @@ interface FlowValidationResult {
   projectId: string;
   issues: Array<{
     validator: string;
+    severity?: "error" | "warning";
     message: string;
   }>;
 }
@@ -377,10 +378,15 @@ export async function runValidation(flowPath?: string): Promise<ValidationSummar
       issues.push({ validator: "sqlColumnValidator", message: `[${issue.code}] ${issue.path}: ${issue.message}` });
     }
 
-    // 2. DB 制約 × 操作順序検証 (#632 MVP: NULL_NOT_ALLOWED_AT_INSERT / FK_REFERENCE_NOT_INSERTED)
+    // 2. DB 制約 × 操作順序検証 (#632 MVP: NULL_NOT_ALLOWED_AT_INSERT / FK_REFERENCE_NOT_INSERTED / #640 UNIQUE_CHECK_MISSING)
+    // severity: "warning" の issue は表示するが exit code には影響しない (draft-state policy 準拠)。
     const sqlOrderIssues = checkSqlOrder(flow, project.tables as unknown as OrderTableDefinition[]);
     for (const issue of sqlOrderIssues) {
-      issues.push({ validator: "sqlOrderValidator", message: `[${issue.code}] ${issue.path}: ${issue.message}` });
+      issues.push({
+        validator: "sqlOrderValidator",
+        severity: issue.severity ?? "error",
+        message: `[${issue.code}] ${issue.path}: ${issue.message}`,
+      });
     }
 
     // 3. 規約カタログ参照検証
@@ -497,8 +503,11 @@ export async function runValidation(flowPath?: string): Promise<ValidationSummar
     }
   }
 
-  const passedFlows = results.filter((r) => r.issues.length === 0).length;
-  const failedFlows = results.filter((r) => r.issues.length > 0).length;
+  // error issue が 1 件以上あるフローを失敗扱い (warning のみは pass 扱い)
+  const hasErrorIssues = (r: FlowValidationResult) =>
+    r.issues.some((i) => !i.severity || i.severity === "error");
+  const passedFlows = results.filter((r) => !hasErrorIssues(r)).length;
+  const failedFlows = results.filter((r) => hasErrorIssues(r)).length;
 
   return {
     totalFlows: results.length,
@@ -540,8 +549,16 @@ function printSummary(summary: ValidationSummary, options: { singleFlow: boolean
   console.log();
 
   for (const result of summary.results) {
-    if (result.issues.length === 0) {
+    const errorIssues = result.issues.filter((i) => !i.severity || i.severity === "error");
+    const warnIssues = result.issues.filter((i) => i.severity === "warning");
+    if (errorIssues.length === 0 && warnIssues.length === 0) {
       console.log(`✅ ${result.displayName} (${validatorDisplayOrder.length} validators pass)`);
+    } else if (errorIssues.length === 0 && warnIssues.length > 0) {
+      // warning のみ → pass 扱いだが警告表示
+      console.log(`⚠️  ${result.displayName} (${validatorDisplayOrder.length} validators pass, ${warnIssues.length} warning(s))`);
+      for (const issue of warnIssues) {
+        console.log(`   [WARN] ${issue.message}`);
+      }
     } else {
       console.log(`❌ ${result.displayName}`);
       const byValidator = new Map<string, string[]>();
@@ -587,14 +604,15 @@ function printSummary(summary: ValidationSummary, options: { singleFlow: boolean
   } else {
     const totalByValidator = new Map<string, number>();
     let totalIssues = 0;
-    for (const result of summary.results.filter((r) => r.issues.length > 0)) {
-      for (const issue of result.issues) {
+    // error issue のみをカウント (warning は pass 扱い)
+    for (const result of summary.results.filter((r) => r.issues.some((i) => !i.severity || i.severity === "error"))) {
+      for (const issue of result.issues.filter((i) => !i.severity || i.severity === "error")) {
         totalByValidator.set(issue.validator, (totalByValidator.get(issue.validator) ?? 0) + 1);
         totalIssues++;
       }
     }
     for (const pr of summary.projectResults) {
-      for (const issue of pr.issues) {
+      for (const issue of pr.issues.filter((i) => i.severity === "error")) {
         totalByValidator.set(issue.validator, (totalByValidator.get(issue.validator) ?? 0) + 1);
         totalIssues++;
       }

--- a/designer/src/schemas/sqlOrderValidator.test.ts
+++ b/designer/src/schemas/sqlOrderValidator.test.ts
@@ -31,8 +31,9 @@ function makeFlow(overrides: Partial<ProcessFlow> = {}): ProcessFlow {
 
 /**
  * テーブル定義ショートカット。
- * columns: [{ physicalName, notNull?, autoIncrement?, defaultValue? }, ...]
- * constraints: [{ kind: "foreignKey", columnPhysicalNames, referencedTableId }, ...]
+ * columns: [{ physicalName, notNull?, autoIncrement?, defaultValue?, unique? }, ...]
+ * fkConstraints: [{ columnPhysicalNames, referencedTableId }, ...]
+ * uniqueConstraints: [{ columnPhysicalNames }] — 複合 UNIQUE 制約
  */
 function makeTable(
   id: string,
@@ -44,8 +45,10 @@ function makeTable(
     autoIncrement?: boolean;
     defaultValue?: string;
     primaryKey?: boolean;
+    unique?: boolean;
   }>,
   fkConstraints?: Array<{ columnPhysicalNames: string[]; referencedTableId: string }>,
+  uniqueConstraints?: Array<{ columnPhysicalNames: string[] }>,
 ): OrderTableDefinition {
   const cols = columns.map((c, i) => ({
     id: c.id ?? `col-${physicalName}-${i + 1}`,
@@ -54,18 +57,26 @@ function makeTable(
     autoIncrement: c.autoIncrement,
     defaultValue: c.defaultValue,
     primaryKey: c.primaryKey,
+    unique: c.unique,
   }));
 
-  // FK 制約の columnIds は physicalName → id の逆引きで解決
+  // FK / UNIQUE 制約の columnIds は physicalName → id の逆引きで解決
   const physicalToId = new Map<string, string>(cols.map((c) => [c.physicalName, c.id]));
 
-  const constraints = (fkConstraints ?? []).map((fk, i) => ({
-    kind: "foreignKey" as const,
-    id: `fk-${physicalName}-${i + 1}`,
-    columnIds: fk.columnPhysicalNames.map((p) => physicalToId.get(p) ?? p),
-    referencedTableId: fk.referencedTableId,
-    referencedColumnIds: ["col-ref-01"],
-  }));
+  const constraints = [
+    ...(fkConstraints ?? []).map((fk, i) => ({
+      kind: "foreignKey" as const,
+      id: `fk-${physicalName}-${i + 1}`,
+      columnIds: fk.columnPhysicalNames.map((p) => physicalToId.get(p) ?? p),
+      referencedTableId: fk.referencedTableId,
+      referencedColumnIds: ["col-ref-01"],
+    })),
+    ...(uniqueConstraints ?? []).map((uq, i) => ({
+      kind: "unique" as const,
+      id: `uq-${physicalName}-${i + 1}`,
+      columnIds: uq.columnPhysicalNames.map((p) => physicalToId.get(p) ?? p),
+    })),
+  ];
 
   return { id, physicalName, columns: cols, constraints };
 }
@@ -735,5 +746,304 @@ describe("welfare-benefit M1 実証: beneficiary_id NOT NULL × INSERT 順序", 
       (i) => i.code === "NULL_NOT_ALLOWED_AT_INSERT" && i.message.includes("beneficiary_id"),
     );
     expect(nullIssues).toHaveLength(0);
+  });
+});
+
+// ─── 観点 3: UNIQUE_CHECK_MISSING ─────────────────────────────────────────
+
+describe("観点 3: UNIQUE_CHECK_MISSING", () => {
+  /**
+   * テーブル: users
+   *   - email: Column.unique: true (単体 UNIQUE)
+   *   - (transfer_id, approver_role): 複合 UNIQUE 制約 (transfer_approvals 相当)
+   */
+  const tableUsers = makeTable(
+    "tbl-users-uq",
+    "users",
+    [
+      { physicalName: "id", notNull: true, autoIncrement: true, primaryKey: true },
+      { physicalName: "email", notNull: true, unique: true },
+      { physicalName: "name", notNull: true },
+    ],
+  );
+
+  const tableApprovals = makeTable(
+    "tbl-approvals",
+    "transfer_approvals",
+    [
+      { physicalName: "id", notNull: true, autoIncrement: true, primaryKey: true },
+      { physicalName: "transfer_id", notNull: true },
+      { physicalName: "approver_role", notNull: true },
+      { physicalName: "decision", notNull: true },
+    ],
+    undefined, // FK なし
+    [{ columnPhysicalNames: ["transfer_id", "approver_role"] }], // 複合 UNIQUE 制約
+  );
+
+  it("検出: UNIQUE カラム (email) への INSERT で事前チェックなし", () => {
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "ユーザー登録",
+          trigger: "submit",
+          inputs: [
+            { name: "userEmail", type: "string", required: true },
+            { name: "userName", type: "string", required: true },
+          ],
+          steps: [
+            {
+              id: "step-01",
+              kind: "dbAccess",
+              description: "users INSERT (email UNIQUE チェックなし)",
+              tableId: "tbl-users-uq",
+              operation: "INSERT",
+              sql: "INSERT INTO users (email, name) VALUES (@inputs.userEmail, @inputs.userName)",
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, [tableUsers]);
+    const target = issues.filter((i) => i.code === "UNIQUE_CHECK_MISSING");
+    expect(target.length).toBeGreaterThanOrEqual(1);
+    expect(target.some((i) => i.message.includes("email"))).toBe(true);
+    expect(target[0].severity).toBe("warning");
+  });
+
+  it("検出: 複合 UNIQUE 制約 (transfer_id, approver_role) への INSERT で事前チェックなし", () => {
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "承認記録",
+          trigger: "submit",
+          inputs: [
+            { name: "transferId", type: "string", required: true },
+            { name: "approverRole", type: "string", required: true },
+            { name: "decision", type: "string", required: true },
+          ],
+          steps: [
+            {
+              id: "step-01",
+              kind: "dbAccess",
+              description: "transfer_approvals INSERT (重複チェックなし)",
+              tableId: "tbl-approvals",
+              operation: "INSERT",
+              sql: "INSERT INTO transfer_approvals (transfer_id, approver_role, decision) VALUES (@inputs.transferId, @inputs.approverRole, @inputs.decision)",
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, [tableApprovals]);
+    const target = issues.filter((i) => i.code === "UNIQUE_CHECK_MISSING");
+    expect(target.length).toBeGreaterThanOrEqual(1);
+    // 複合 UNIQUE のいずれかのカラムを含む旨のメッセージ
+    expect(target.some((i) => i.message.includes("transfer_id") || i.message.includes("approver_role"))).toBe(true);
+  });
+
+  it("false positive 抑止 (パターン 1): 先行 SELECT WHERE email で EXISTS チェック → 検出しない", () => {
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "ユーザー登録",
+          trigger: "submit",
+          inputs: [
+            { name: "userEmail", type: "string", required: true },
+            { name: "userName", type: "string", required: true },
+          ],
+          steps: [
+            {
+              id: "step-01",
+              kind: "dbAccess",
+              description: "email 重複確認 SELECT",
+              tableId: "tbl-users-uq",
+              operation: "SELECT",
+              sql: "SELECT id FROM users WHERE email = @inputs.userEmail",
+              outputBinding: { name: "existingUser" },
+            },
+            {
+              id: "step-02",
+              kind: "branch",
+              description: "既存ユーザーがいなければ INSERT",
+              branches: [
+                {
+                  condition: "@existingUser == null",
+                  steps: [
+                    {
+                      id: "step-03",
+                      kind: "dbAccess",
+                      description: "users INSERT",
+                      tableId: "tbl-users-uq",
+                      operation: "INSERT",
+                      sql: "INSERT INTO users (email, name) VALUES (@inputs.userEmail, @inputs.userName)",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, [tableUsers]);
+    const target = issues.filter((i) => i.code === "UNIQUE_CHECK_MISSING");
+    expect(target).toHaveLength(0);
+  });
+
+  it("false positive 抑止 (パターン 2): affectedRowsCheck.errorCode = DUPLICATE_ENTRY → 検出しない", () => {
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "ユーザー登録",
+          trigger: "submit",
+          inputs: [
+            { name: "userEmail", type: "string", required: true },
+            { name: "userName", type: "string", required: true },
+          ],
+          steps: [
+            {
+              id: "step-01",
+              kind: "dbAccess",
+              description: "users INSERT with UNIQUE violation errorCode",
+              tableId: "tbl-users-uq",
+              operation: "INSERT",
+              sql: "INSERT INTO users (email, name) VALUES (@inputs.userEmail, @inputs.userName)",
+              affectedRowsCheck: {
+                operator: "=",
+                expected: 1,
+                onViolation: "throw",
+                errorCode: "DUPLICATE_ENTRY",
+              },
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, [tableUsers]);
+    const target = issues.filter((i) => i.code === "UNIQUE_CHECK_MISSING");
+    expect(target).toHaveLength(0);
+  });
+
+  it("false positive 抑止 (パターン 2 変形): affectedRowsCheck.errorCode = UNIQUE_VIOLATION → 検出しない", () => {
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "ユーザー登録",
+          trigger: "submit",
+          inputs: [
+            { name: "userEmail", type: "string", required: true },
+            { name: "userName", type: "string", required: true },
+          ],
+          steps: [
+            {
+              id: "step-01",
+              kind: "dbAccess",
+              description: "users INSERT with UNIQUE_VIOLATION errorCode",
+              tableId: "tbl-users-uq",
+              operation: "INSERT",
+              sql: "INSERT INTO users (email, name) VALUES (@inputs.userEmail, @inputs.userName)",
+              affectedRowsCheck: {
+                operator: "=",
+                expected: 1,
+                onViolation: "throw",
+                errorCode: "UNIQUE_VIOLATION",
+              },
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, [tableUsers]);
+    const target = issues.filter((i) => i.code === "UNIQUE_CHECK_MISSING");
+    expect(target).toHaveLength(0);
+  });
+
+  it("false positive 抑止 (パターン 3): tryCatch branch で UNIQUE_VIOLATION をキャッチ → 検出しない", () => {
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "ユーザー登録",
+          trigger: "submit",
+          inputs: [
+            { name: "userEmail", type: "string", required: true },
+            { name: "userName", type: "string", required: true },
+          ],
+          steps: [
+            {
+              id: "step-01",
+              kind: "dbAccess",
+              description: "users INSERT",
+              tableId: "tbl-users-uq",
+              operation: "INSERT",
+              sql: "INSERT INTO users (email, name) VALUES (@inputs.userEmail, @inputs.userName)",
+            },
+            {
+              id: "step-02",
+              kind: "branch",
+              description: "tryCatch で UNIQUE_VIOLATION をキャッチ",
+              branches: [
+                {
+                  condition: {
+                    kind: "tryCatch",
+                    catchErrors: ["UNIQUE_VIOLATION"],
+                  },
+                  steps: [
+                    {
+                      id: "step-03",
+                      kind: "return",
+                      description: "重複エラーを返す",
+                      payload: { status: "DUPLICATE" },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, [tableUsers]);
+    const target = issues.filter((i) => i.code === "UNIQUE_CHECK_MISSING");
+    expect(target).toHaveLength(0);
+  });
+
+  it("正常系: UNIQUE 制約のないテーブルへの INSERT は検出しない", () => {
+    const tableNoUnique = makeTable(
+      "tbl-no-unique",
+      "orders",
+      [
+        { physicalName: "id", notNull: true, autoIncrement: true, primaryKey: true },
+        { physicalName: "amount", notNull: true },
+      ],
+    );
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "注文登録",
+          trigger: "submit",
+          inputs: [{ name: "amount", type: "number", required: true }],
+          steps: [
+            {
+              id: "step-01",
+              kind: "dbAccess",
+              description: "orders INSERT",
+              tableId: "tbl-no-unique",
+              operation: "INSERT",
+              sql: "INSERT INTO orders (amount) VALUES (@inputs.amount)",
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, [tableNoUnique]);
+    const target = issues.filter((i) => i.code === "UNIQUE_CHECK_MISSING");
+    expect(target).toHaveLength(0);
   });
 });

--- a/designer/src/schemas/sqlOrderValidator.ts
+++ b/designer/src/schemas/sqlOrderValidator.ts
@@ -1,5 +1,5 @@
 /**
- * DB 制約 × フロー操作順序の交差検査 (#632 MVP: 観点 1+2)。
+ * DB 制約 × フロー操作順序の交差検査 (#632 MVP: 観点 1+2、#640 観点 3)。
  *
  * 観点 1 (NULL_NOT_ALLOWED_AT_INSERT):
  *   INSERT 時点で NOT NULL カラムに対応する変数が未バインド
@@ -9,11 +9,17 @@
  *   INSERT 時点で FK 参照先テーブルへの先行 INSERT が同 action 内に無い
  *   (= FK 制約の参照整合を保証する先行書き込みが存在しない)
  *
+ * 観点 3 (UNIQUE_CHECK_MISSING):
+ *   INSERT 時点で UNIQUE 制約のあるカラムに対して事前の重複チェックがない
+ *   (= 以下のいずれかが INSERT 直前に存在しない場合 warning)
+ *   - SELECT WHERE <unique_col> = <value> + branch.condition で件数判定
+ *   - INSERT step 自身の affectedRowsCheck.errorCode が UNIQUE_VIOLATION 系
+ *   - INSERT を含む branch step の condition.kind: "tryCatch" で UNIQUE_VIOLATION error
+ *
  * 既存 sqlColumnValidator と同じ node-sql-parser v5 AST walker を再利用。
- * 変数バインド時系列追跡 + テーブル schema (notNull / foreignKey) との交差解析
+ * 変数バインド時系列追跡 + テーブル schema (notNull / foreignKey / unique) との交差解析
  * で実行時 DB 制約違反を構造的に検出する。
  *
- * 観点 3 (UNIQUE_CHECK_MISSING) → #640
  * 観点 4 (CASCADE_DELETE_OMITTED) → #641
  * 観点 5 (TX_CIRCULAR_DEPENDENCY) → #642
  */
@@ -41,9 +47,16 @@ export interface OrderForeignKeyConstraint {
   referencedTableId: string;
 }
 
-/** テーブル制約 (validator 内部では FK だけ利用)。 */
+/** UNIQUE 制約 (validator 内部で必要な最小フィールド)。 */
+export interface OrderUniqueConstraint {
+  kind: "unique";
+  columnIds: string[];
+}
+
+/** テーブル制約 (validator 内部では FK と UNIQUE を利用)。 */
 export type OrderConstraint =
-  | { kind: "unique" | "check"; [key: string]: unknown }
+  | OrderUniqueConstraint
+  | { kind: "check"; [key: string]: unknown }
   | OrderForeignKeyConstraint;
 
 /** テーブル定義 (v3 table.v3.schema.json の最小シェイプ)。 */
@@ -58,7 +71,8 @@ export interface OrderTableDefinition {
 
 export interface SqlOrderIssue {
   path: string;
-  code: "NULL_NOT_ALLOWED_AT_INSERT" | "FK_REFERENCE_NOT_INSERTED" | "SQL_PARSE_ERROR";
+  code: "NULL_NOT_ALLOWED_AT_INSERT" | "FK_REFERENCE_NOT_INSERTED" | "UNIQUE_CHECK_MISSING" | "SQL_PARSE_ERROR";
+  severity?: "error" | "warning";
   message: string;
 }
 
@@ -224,6 +238,8 @@ interface TableMeta {
     columnPhysicalNames: string[]; // FK 本テーブル側カラム物理名 (lowercase)
     referencedTableId: string;
   }>;
+  uniqueConstraints: Array<string[]>; // UNIQUE 制約ごとの physicalName (lowercase) 配列
+  uniqueColumns: Set<string>;         // Column.unique: true のカラム (各カラム単体 UNIQUE)
 }
 
 /**
@@ -264,6 +280,9 @@ function buildTableMeta(tables: OrderTableDefinition[]): Map<string, TableMeta> 
     }
 
     const fkConstraints: TableMeta["fkConstraints"] = [];
+    const uniqueConstraints: TableMeta["uniqueConstraints"] = [];
+    const uniqueColumns = new Set<string>();
+
     for (const con of t.constraints ?? []) {
       if (con.kind === "foreignKey") {
         const fkCon = con as OrderForeignKeyConstraint;
@@ -276,6 +295,24 @@ function buildTableMeta(tables: OrderTableDefinition[]): Map<string, TableMeta> 
             referencedTableId: fkCon.referencedTableId,
           });
         }
+      } else if (con.kind === "unique") {
+        // UNIQUE 制約 (複合含む): columnIds → physicalName に変換
+        const uqCon = con as OrderUniqueConstraint;
+        const columnPhysicalNames = uqCon.columnIds
+          .map((id) => colIdToPhysical.get(id) ?? "")
+          .filter(Boolean);
+        if (columnPhysicalNames.length > 0) {
+          uniqueConstraints.push(columnPhysicalNames);
+        }
+      }
+    }
+
+    // Column.unique: true も単体 UNIQUE として収集
+    for (const col of t.columns) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      if ((col as any).unique === true) {
+        const pName = getPhysicalName(col);
+        if (pName) uniqueColumns.add(pName.toLowerCase());
       }
     }
 
@@ -285,9 +322,169 @@ function buildTableMeta(tables: OrderTableDefinition[]): Map<string, TableMeta> 
       notNullColumns,
       autoColumns,
       fkConstraints,
+      uniqueConstraints,
+      uniqueColumns,
     });
   }
   return map;
+}
+
+// ─── 観点 3: UNIQUE_CHECK_MISSING ヘルパー ─────────────────────────────────
+
+/**
+ * UNIQUE_VIOLATION 系のエラーコード文字列かどうかを判定。
+ * 主要な命名パターンを網羅する。
+ */
+function isUniqueViolationErrorCode(code: string | undefined): boolean {
+  if (!code) return false;
+  const upper = code.toUpperCase();
+  return (
+    upper.includes("UNIQUE") ||
+    upper.includes("DUPLICATE") ||
+    upper.includes("ALREADY_EXISTS") ||
+    upper.includes("CONFLICT") ||
+    upper.includes("DUPLICATE_KEY") ||
+    upper.includes("DUPLICATE_ENTRY")
+  );
+}
+
+/**
+ * column_ref ノードからカラム名文字列を抽出する。
+ *
+ * node-sql-parser v5 PostgreSQL dialect では column が
+ * - 文字列 (v4 以前) または
+ * - { expr: { type: "default", value: "colName" } } オブジェクト (v5)
+ * のどちらかになる。両方に対応する。
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function extractColumnName(node: any): string | null {
+  if (!node || node.type !== "column_ref") return null;
+  const col = node.column;
+  if (typeof col === "string") return col.toLowerCase();
+  if (col && typeof col === "object") {
+    // v5 形式: { expr: { type: "default", value: "colName" } }
+    if (col.expr && typeof col.expr.value === "string") return col.expr.value.toLowerCase();
+    // フォールバック: value 直下
+    if (typeof col.value === "string") return col.value.toLowerCase();
+  }
+  return null;
+}
+
+/**
+ * SELECT SQL AST から WHERE 句で参照しているカラム物理名 (lowercase) を抽出する。
+ * シンプルな `WHERE col = @var` 形式および `AND` / `OR` 連結を対象とする。
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function extractWhereColumns(ast: any): Set<string> {
+  const cols = new Set<string>();
+  if (!ast || ast.type !== "select") return cols;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function walk(node: any): void {
+    if (!node || typeof node !== "object") return;
+    // binary expression: left/right
+    if (node.type === "binary_expr") {
+      const leftCol = extractColumnName(node.left);
+      if (leftCol) cols.add(leftCol);
+      const rightCol = extractColumnName(node.right);
+      if (rightCol) cols.add(rightCol);
+      walk(node.left);
+      walk(node.right);
+    }
+    // WHERE 直下
+    if (node.where) walk(node.where);
+  }
+
+  walk(ast);
+  return cols;
+}
+
+/**
+ * action 内の前段 step (INSERT step より前の index まで) を走査して、
+ * 以下のいずれかが存在するか確認する (UNIQUE_CHECK_MISSING の false positive 抑止):
+ *
+ * パターン 1: SELECT WHERE <unique_col> = <value> が存在する
+ *             (= SELECT で存在確認してから INSERT する正常フロー)
+ *
+ * walkStepsInOrder は INSERT 順に呼ばれるため、ここでは「これまでに見た SELECT step 列」を
+ * 引数で受け取る。
+ */
+function hasPriorSelectForUniqueColumns(
+  uniqueColPhysicalNames: string[], // UNIQUE 制約の全カラム物理名 (lowercase)
+  priorSelectWhereColumns: Set<string>, // INSERT より前に見た SELECT の WHERE カラム集合
+): boolean {
+  // UNIQUE 制約のいずれかのカラムが SELECT WHERE に含まれていれば OK
+  // (厳密には全カラムが含まれるべきだが、偽陽性抑止優先で any-match にする)
+  return uniqueColPhysicalNames.some((col) => priorSelectWhereColumns.has(col));
+}
+
+/**
+ * step の affectedRowsCheck.errorCode が UNIQUE_VIOLATION 系かどうかを確認する。
+ * パターン 2: INSERT step 自身の affectedRowsCheck でハンドリングしている。
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function hasAffectedRowsUniqueCheck(step: any): boolean {
+  return isUniqueViolationErrorCode(step?.affectedRowsCheck?.errorCode);
+}
+
+/**
+ * step がいずれかの branch / tryCatch 内に入っているかを確認するのではなく、
+ * INSERT step の親 branch step が tryCatch で UNIQUE_VIOLATION をハンドルしているかを確認する。
+ *
+ * 実装上の制約: walkStepsInOrder は step を個別に訪問するため、「親 branch を持つか」の
+ * 判定が複雑になる。ここでは代わりに「action 全体の step 列 (flat) に tryCatch で
+ * UNIQUE_VIOLATION 系のエラーをハンドルする branch step が存在するか」で代替する。
+ * (偽陽性抑止優先: tryCatch が存在すれば OK とみなす)
+ *
+ * パターン 3: branch step の condition.kind === "tryCatch" で UNIQUE_VIOLATION をキャッチ。
+ */
+function hasTryCatchUniqueViolationInSteps(steps: Step[]): boolean {
+  for (const step of steps) {
+    if (!isBuiltinStep(step)) continue;
+    if (step.kind === "branch") {
+      // branches の condition を確認
+      for (const branch of step.branches) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const cond = branch.condition as any;
+        if (
+          cond?.kind === "tryCatch" &&
+          Array.isArray(cond?.catchErrors) &&
+          cond.catchErrors.some((e: unknown) => {
+            if (typeof e === "string") return isUniqueViolationErrorCode(e);
+            if (e && typeof e === "object") {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const obj = e as any;
+              return isUniqueViolationErrorCode(obj.errorCode ?? obj.code ?? obj.kind ?? "");
+            }
+            return false;
+          })
+        ) {
+          return true;
+        }
+        // condition が文字列で UNIQUE_VIOLATION 系を含む場合
+        if (typeof branch.condition === "string" && isUniqueViolationErrorCode(branch.condition)) {
+          return true;
+        }
+      }
+      // elseBranch も含め再帰
+      if (step.elseBranch && hasTryCatchUniqueViolationInSteps(step.elseBranch.steps)) return true;
+      for (const branch of step.branches) {
+        if (hasTryCatchUniqueViolationInSteps(branch.steps)) return true;
+      }
+    }
+    if (step.kind === "loop" && hasTryCatchUniqueViolationInSteps(step.steps)) return true;
+    if (step.kind === "transactionScope") {
+      if (hasTryCatchUniqueViolationInSteps(step.steps)) return true;
+    }
+    if (step.kind === "externalSystem") {
+      for (const spec of Object.values(step.outcomes ?? {})) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const s = spec as any;
+        if (s?.sideEffects && hasTryCatchUniqueViolationInSteps(s.sideEffects)) return true;
+      }
+    }
+  }
+  return false;
 }
 
 // ─── メイン検査ロジック ─────────────────────────────────────────────────────
@@ -297,6 +494,7 @@ function buildTableMeta(tables: OrderTableDefinition[]): Map<string, TableMeta> 
  *
  * - boundVars: action.inputs の name + 各 step を順に実行した際に蓄積される outputBinding.name
  * - insertedTableIds: 先行 INSERT で書き込んだテーブルの id (FK 参照先確認用)
+ * - priorSelectWhereColumns: INSERT より前に見た SELECT の WHERE カラム集合 (観点 3 用)
  */
 function checkAction(
   actionIndex: number,
@@ -308,6 +506,8 @@ function checkAction(
 ): void {
   const boundVars = new Set<string>(initialBound);
   const insertedTableIds = new Set<string>();
+  // 観点 3: INSERT より前に見た SELECT の WHERE カラム集合 (テーブル物理名 → カラム集合)
+  const priorSelectWhereColumnsByTable = new Map<string, Set<string>>();
 
   // 平坦化した step のシーケンスを順走査
   // (branch 内部は楽観的に両パスを走査してバインドを union する — 保守的な偽陽性抑止)
@@ -321,6 +521,42 @@ function checkAction(
     }
     if (step.kind === "compute" && step.outputBinding?.name) {
       boundVars.add(step.outputBinding.name);
+    }
+
+    // dbAccess SELECT: WHERE カラムを収集 (観点 3 の false positive 抑止用)
+    if (step.kind === "dbAccess" && step.operation === "SELECT" && step.sql) {
+      const substitutedSel = substituteAtVars(step.sql);
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        let astSel: any = parser.astify(substitutedSel, { database: DIALECT });
+        astSel = Array.isArray(astSel) ? astSel[0] : astSel;
+        if (astSel && astSel.type === "select") {
+          // SELECT 対象テーブル名を抽出 (FROM 句)
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const fromTables: string[] = [];
+          if (Array.isArray(astSel.from)) {
+            for (const fromItem of astSel.from) {
+              if (fromItem?.table && typeof fromItem.table === "string") {
+                fromTables.push(fromItem.table.toLowerCase());
+              }
+            }
+          }
+          const whereColumns = extractWhereColumns(astSel);
+          for (const tbl of fromTables) {
+            const existing = priorSelectWhereColumnsByTable.get(tbl) ?? new Set<string>();
+            for (const col of whereColumns) existing.add(col);
+            priorSelectWhereColumnsByTable.set(tbl, existing);
+          }
+          // テーブルが特定できない場合は全テーブルに追加 (偽陽性抑止)
+          if (fromTables.length === 0 && whereColumns.size > 0) {
+            const fallback = priorSelectWhereColumnsByTable.get("__any__") ?? new Set<string>();
+            for (const col of whereColumns) fallback.add(col);
+            priorSelectWhereColumnsByTable.set("__any__", fallback);
+          }
+        }
+      } catch {
+        // SELECT パース失敗は無視 (観点 3 の偽陽性抑止のため)
+      }
     }
 
     // dbAccess INSERT のみ検査
@@ -427,6 +663,45 @@ function checkAction(
           path: `${path}.sql`,
           code: "FK_REFERENCE_NOT_INSERTED",
           message: `テーブル "${insertTableName}" の FK カラム [${unboundFkCols.join(", ")}] が参照する "${refMeta.physicalName}" の行が INSERT 時点で未確保です (先行 INSERT なし、かつ FK 列の変数が未バインド)。`,
+        });
+      }
+
+      // ── 観点 3: UNIQUE 制約 × 事前チェック有無 (warning) ───────────────────
+      // UNIQUE 制約のあるカラムが INSERT 対象に含まれる場合、
+      // 以下のいずれかが存在するか確認する:
+      //   パターン 1: 同テーブルへの先行 SELECT WHERE で UNIQUE カラムを参照している
+      //   パターン 2: INSERT step 自身の affectedRowsCheck.errorCode が UNIQUE_VIOLATION 系
+      //   パターン 3: action 全体の steps に tryCatch で UNIQUE_VIOLATION をキャッチする branch がある
+      const allUniqueConstraints: Array<{ cols: string[] }> = [
+        ...meta.uniqueConstraints.map((cols) => ({ cols })),
+        // Column.unique: true は単体 UNIQUE として扱う
+        ...[...meta.uniqueColumns].map((col) => ({ cols: [col] })),
+      ];
+
+      for (const uq of allUniqueConstraints) {
+        // INSERT 対象カラムとの交差
+        const uqColsInInsert = uq.cols.filter((c) => colVarMap.has(c));
+        if (uqColsInInsert.length === 0) continue;
+
+        // パターン 2: affectedRowsCheck.errorCode が UNIQUE_VIOLATION 系
+        if (hasAffectedRowsUniqueCheck(step)) continue;
+
+        // パターン 3: action 全体の steps に tryCatch で UNIQUE_VIOLATION をキャッチする branch
+        if (hasTryCatchUniqueViolationInSteps(steps)) continue;
+
+        // パターン 1: 同テーブルへの先行 SELECT WHERE でいずれかの UNIQUE カラムを参照
+        const tablePriorCols = priorSelectWhereColumnsByTable.get(insertTableName) ?? new Set<string>();
+        // __any__ (テーブル不明な SELECT のカラム) も加算
+        const anyPriorCols = priorSelectWhereColumnsByTable.get("__any__") ?? new Set<string>();
+        const mergedPriorCols = new Set<string>([...tablePriorCols, ...anyPriorCols]);
+        if (hasPriorSelectForUniqueColumns(uqColsInInsert, mergedPriorCols)) continue;
+
+        // どのパターンも満たさない → warning
+        issues.push({
+          path: `${path}.sql`,
+          code: "UNIQUE_CHECK_MISSING",
+          severity: "warning",
+          message: `テーブル "${insertTableName}" の UNIQUE カラム [${uqColsInInsert.join(", ")}] に対する事前の重複チェックがありません。INSERT 前に SELECT で存在確認するか、INSERT の affectedRowsCheck で UNIQUE VIOLATION をハンドルするか、tryCatch で UNIQUE_VIOLATION エラーをキャッチしてください。`,
         });
       }
 


### PR DESCRIPTION
## 関連

- Closes #640
- 仕様: docs/spec/dogfood-2026-04-29-phase2-validator-audit.md §3 / §4 (観点 11 DB 制約 × INSERT 順序)

## 概要

UNIQUE 制約のあるカラムへの INSERT に対して、事前の重複チェック有無を検査する観点 3 (UNIQUE_CHECK_MISSING) を sqlOrderValidator に実装。severity = warning (DB 側が最終防御する前提のグッドプラクティス指摘)。

## 主な変更

- **検出ロジック** (`designer/src/schemas/sqlOrderValidator.ts`):
  - `OrderUniqueConstraint` 型追加 + `TableMeta` に `uniqueConstraints` / `uniqueColumns` を追加
  - `buildTableMeta`: `constraints[].kind: "unique"` の columnIds を収集 + `Column.unique: true` を単体 UNIQUE として収集
  - `extractColumnName`: node-sql-parser v5 の column_ref ノードから列名を抽出 (v5 で `column.expr.value` 形式に変化)
  - `extractWhereColumns`: SELECT AST の WHERE 句からカラム名を抽出
  - `isUniqueViolationErrorCode`: UNIQUE/DUPLICATE/CONFLICT/ALREADY_EXISTS 系エラーコード判定
  - `hasAffectedRowsUniqueCheck` / `hasTryCatchUniqueViolationInSteps`: パターン 2/3 の false positive 抑止
  - `checkAction`: SELECT 時に priorSelectWhereColumnsByTable を更新 (パターン 1)、INSERT 時に 3 パターンで事前チェック有無を判定
  - `SqlOrderIssue` に `severity?: "error" | "warning"` を追加

- **dogfood 統合** (`designer/scripts/validate-dogfood.ts`):
  - severity: "warning" の issue は [WARN] 表示するが exit code に影響しない (draft-state policy 準拠)
  - FlowValidationResult に severity フィールド追加
  - passedFlows / failedFlows の計算を error issue のみ対象に修正
  - 出力: warning のみのフローは ⚠️ + "pass, N warning(s)" 表示

- **テスト追加** (`designer/src/schemas/sqlOrderValidator.test.ts`):
  - `makeTable` を `uniqueConstraints` パラメータ対応に拡張
  - 観点 3: 7 ケース追加 (検出 2 件 + false positive 抑止 5 件)
  - 合計 35 テスト (既存 28 + 新規 7)

- **Skill 統合**:
  - `create-flow/SKILL.md`: Rule 19 に UNIQUE_CHECK_MISSING 行と抑止パターン 3 条件を追記
  - `review-flow/SKILL.md`: 観点 11 テーブル・Should-fix 候補リストに UNIQUE_CHECK_MISSING を追記

## 仕様逐条突合 (自己申告)

設計者承認済み方針 (#640 ISSUE 本文) 各条項:

- 「重複チェックあり」判定パターン 1 (SELECT WHERE 件数判定) → `sqlOrderValidator.ts:checkAction` 内 priorSelectWhereColumnsByTable 収集ロジック + `hasPriorSelectForUniqueColumns` ✓
- 「重複チェックあり」判定パターン 2 (affectedRowsCheck.errorCode UNIQUE 系) → `hasAffectedRowsUniqueCheck` + `isUniqueViolationErrorCode` ✓
- 「重複チェックあり」判定パターン 3 (tryCatch UNIQUE_VIOLATION) → `hasTryCatchUniqueViolationInSteps` ✓
- severity = warning → `SqlOrderIssue.severity: "warning"` + dogfood での warning 分岐処理 ✓
- scope = 同 action 内 step 順序走査 → `checkAction` の `walkStepsInOrder` closure ✓

## レビューで特に見てほしい箇所

1. `extractColumnName` の v5 AST 対応: `column.expr.value` 形式への対応。デバッグで確認した実際の AST 構造に基づく
2. `hasTryCatchUniqueViolationInSteps` の検索スコープ: action 全体 steps を再帰探索 (INSERT の直接の親 branch のみでなく全体)。偽陽性抑止優先の設計
3. dogfood での既存 9 件の UNIQUE_CHECK_MISSING warning: これらは true positive (実際に事前チェックが欠けているサンプルフロー)。既存フロー修正は本 PR スコープ外

## テスト

- Vitest: 25 件 (新規 7 件) — sqlOrderValidator 観点 3 の検出・false positive 抑止
- Playwright: N/A (UI 影響なし)
- MCP E2E: N/A

## UI 影響 / AI smoke test

- [x] UI 影響なし (auto テスト pass のみ)

## spec 側の不足点 / 提案

N/A (設計者承認済み方針を ISSUE 本文から直接実装)

## レビュー担当への申し送り

- node-sql-parser v5 の `column_ref` AST 構造変化 (`column` が文字列でなくオブジェクト) を `extractColumnName` で吸収。既存 `sqlColumnValidator.ts` の同様の AST 処理パターンと比較してください
- dogfood で検出される 9 件の warning は既存サンプルの true positive であり、false positive ではありません
- `isUniqueViolationErrorCode` のキーワードリスト (UNIQUE/DUPLICATE/ALREADY_EXISTS/CONFLICT) が業務的に十分かを確認してください

## 補足: validate-dogfood.ts 改修について

観点 3 は warning severity のため、validate-dogfood.ts を severity-aware に改修 (warning は exit 0 を維持) し、dogfood で warning 検出時も CI 失敗としない設計とした。draft-state policy (#548 / #588) 準拠。
