### PR TITLE
feat(validator): sqlOrderValidator 観点 4 — CASCADE_DELETE_OMITTED 検出 (#641)

### DIFF
--- a/.claude/skills/create-flow/SKILL.md
+++ b/.claude/skills/create-flow/SKILL.md
@@ -241,7 +241,7 @@ UI 起点フロー (`type: "screen"` / `mode: "upstream"`) を作成するとき
 - 典型ミス: happy-path で全前提を pre-seed、edge は 400/403 系の検証に偏り、初回ユーザーパスが抜ける
 - **補足**: 静的検出 `sqlOrderValidator` (#632) が導入されるまで本ルールが主要 catch 機構。導入後も「値レベル fixture 不足」など静的検出では届かない領域は本ルールで継続担保 (Step 5.2 validate:dogfood では機械検出されない、Step 3 self-check のみで担保)
 
-### Rule 19: DB 制約 × INSERT 操作順序 (#632 / #640)
+### Rule 19: DB 制約 × INSERT / DELETE 操作順序 (#632 / #640 / #641)
 
 - INSERT 文の VALUES で使う変数が INSERT 時点でバインド済みか確認 (NOT NULL カラムが対象)
   - 未バインド変数を NOT NULL カラムに入れている場合: 実行時 DB 制約違反 → Must-fix
@@ -257,6 +257,11 @@ UI 起点フロー (`type: "screen"` / `mode: "upstream"`) を作成するとき
     2. INSERT step 自身の `affectedRowsCheck.errorCode` が UNIQUE/DUPLICATE/CONFLICT/ALREADY_EXISTS 系
     3. action 内に `branch.condition.kind: "tryCatch"` で UNIQUE_VIOLATION 系エラーをキャッチする step がある
   - 対象: `Table.constraints[].kind: "unique"` の columnIds および `Column.unique: true`
+- 親テーブルへの DELETE 時、FK の onDelete が restrict / noAction (または未指定) の子テーブルが存在する場合: Must-fix (error) (#641)
+  - 同 action 内の前段に子テーブルへの DELETE step が必要
+  - onDelete = cascade: DB 側が子を自動削除 → 子 DELETE step 不要
+  - onDelete = setNull / setDefault: DB 側が子の FK カラムを NULL / DEFAULT に更新 → 子 DELETE step 不要
+  - onDelete = restrict / noAction (デフォルト): 子 DELETE step が前段になければ実行時 FK 制約違反
 
 **Step 5.2 で `validate:dogfood` の `sqlOrderValidator` により機械的に検出される**
 
@@ -265,6 +270,7 @@ UI 起点フロー (`type: "screen"` / `mode: "upstream"`) を作成するとき
 | `NULL_NOT_ALLOWED_AT_INSERT` | error | NOT NULL カラムへの NULL または未バインド変数 INSERT |
 | `FK_REFERENCE_NOT_INSERTED` | error | FK 参照先テーブルの先行 INSERT なし + FK カラム変数が未バインド |
 | `UNIQUE_CHECK_MISSING` | warning | UNIQUE カラムへの INSERT で事前重複チェックなし (#640) |
+| `CASCADE_DELETE_OMITTED` | error | FK onDelete=restrict/noAction の子テーブル行を先 DELETE せず親を DELETE (#641) |
 
 ### Rule 20: ViewDefinition 整合 (#649、Phase 4 子 1)
 

--- a/.claude/skills/review-flow/SKILL.md
+++ b/.claude/skills/review-flow/SKILL.md
@@ -97,7 +97,7 @@ npm run validate:dogfood
 
 - バリデータが検出した issue は **Step 1 のレビュー入力**として活用 (重複説明はしない)
 - 結果は Step 2 の「10 観点別カバレッジ」表に **「validator 検出済」** カラムとして記録
-- Must-fix 候補: `UNKNOWN_RESPONSE_REF` / `UNKNOWN_ERROR_CODE` / `UNKNOWN_IDENTIFIER` / `UNKNOWN_COLUMN` / `UNKNOWN_CONV_*` / `UNKNOWN_HANDLER_FLOW` / `MISSING_REQUIRED_ARGUMENT` / `EXTRA_ARGUMENT` / `PRIMARY_INVOKER_MISMATCH` / `DUPLICATE_EVENT_ID` / `NULL_NOT_ALLOWED_AT_INSERT` / `FK_REFERENCE_NOT_INSERTED` 等
+- Must-fix 候補: `UNKNOWN_RESPONSE_REF` / `UNKNOWN_ERROR_CODE` / `UNKNOWN_IDENTIFIER` / `UNKNOWN_COLUMN` / `UNKNOWN_CONV_*` / `UNKNOWN_HANDLER_FLOW` / `MISSING_REQUIRED_ARGUMENT` / `EXTRA_ARGUMENT` / `PRIMARY_INVOKER_MISMATCH` / `DUPLICATE_EVENT_ID` / `NULL_NOT_ALLOWED_AT_INSERT` / `FK_REFERENCE_NOT_INSERTED` / `CASCADE_DELETE_OMITTED` 等
 - Should-fix 候補 (warning): `INCONSISTENT_ARGUMENT_CONTRACT` (1 フローを呼ぶ複数イベント間で argumentMapping キー集合が異なる) / `UNIQUE_CHECK_MISSING` (UNIQUE カラムへの INSERT で事前重複チェックなし、#640)
 - 終了コード 1 (1 件以上 fail) でも Step 1 を中止せず実施する (実行セマンティクス観点が AI 目視のみで残るため)
 
@@ -115,7 +115,7 @@ npm run validate:dogfood
 | 8. rollbackOn 発火可能性 | referentialIntegrity (UNKNOWN_ERROR_CODE) | TX inner からの実発火可能性は AI |
 | 9. 画面項目イベント連携整合 | screenItemFlowValidator (handlerFlowId / argumentMapping / primaryInvoker / events[].id ユニーク) | 業務文脈での argumentMapping 値の妥当性 (UI 入力 → フロー入力の意味的整合) は AI |
 | 10. 画面項目値レベル整合 | screenItemFieldTypeValidator (options 包含 / domainKey / 型 / pattern / range / length) | 業務文脈の妥当性 (選択肢命名の業務適切性 / domain 設計妥当性) は AI |
-| 11. DB 制約 × INSERT 順序 (#632 / #640) | sqlOrderValidator (NULL_NOT_ALLOWED_AT_INSERT / FK_REFERENCE_NOT_INSERTED / UNIQUE_CHECK_MISSING) | 複雑な条件分岐での可能性の有無は AI / UNIQUE チェック抑止パターンの業務妥当性は AI |
+| 11. DB 制約 × INSERT / DELETE 順序 (#632 / #640 / #641) | sqlOrderValidator (NULL_NOT_ALLOWED_AT_INSERT / FK_REFERENCE_NOT_INSERTED / UNIQUE_CHECK_MISSING / CASCADE_DELETE_OMITTED) | 複雑な条件分岐での可能性の有無は AI / UNIQUE チェック抑止パターンの業務妥当性は AI / onDelete 設定が業務要件として適切かは AI |
 | 12. ViewDefinition 整合 (#649) | viewDefinitionValidator (UNKNOWN_SOURCE_TABLE / UNKNOWN_TABLE_COLUMN_REF / DUPLICATE_VIEW_COLUMN_NAME / UNKNOWN_SORT_COLUMN / UNKNOWN_FILTER_COLUMN / UNKNOWN_GROUP_BY_COLUMN) | sourceTableId ↔ dbAccess テーブルの業務的整合 / FIELD_TYPE_INCOMPATIBLE の業務妥当性は AI |
 
 監査根拠: `docs/spec/dogfood-2026-04-29-phase2-validator-audit.md` §3 / §4 + Phase 3 子 1 #619 (PR #626)。

--- a/designer/src/schemas/sqlOrderValidator.test.ts
+++ b/designer/src/schemas/sqlOrderValidator.test.ts
@@ -1047,3 +1047,287 @@ describe("観点 3: UNIQUE_CHECK_MISSING", () => {
     expect(target).toHaveLength(0);
   });
 });
+
+// ─── 観点 4: CASCADE_DELETE_OMITTED ───────────────────────────────────────
+
+describe("観点 4: CASCADE_DELETE_OMITTED", () => {
+  /**
+   * テーブル構成:
+   *   orders (親)
+   *   └─ order_items (子、orders.id を FK 参照)
+   *
+   * order_items の FK onDelete は各テストで変えて確認する。
+   */
+
+  function makeOrderTables(onDelete?: "cascade" | "setNull" | "setDefault" | "restrict" | "noAction") {
+    const orders = makeTable(
+      "tbl-orders-parent",
+      "orders",
+      [
+        { physicalName: "id", notNull: true, autoIncrement: true, primaryKey: true },
+        { physicalName: "status", notNull: true },
+      ],
+    );
+
+    // order_items の制約を直接組み立てる (makeTable は onDelete を受け取らない)
+    const orderItemsCols = [
+      { id: "col-oi-1", physicalName: "id", notNull: true, autoIncrement: true, primaryKey: true },
+      { id: "col-oi-2", physicalName: "order_id", notNull: true },
+      { id: "col-oi-3", physicalName: "quantity", notNull: true },
+    ];
+    const orderItems = {
+      id: "tbl-order-items",
+      physicalName: "order_items",
+      columns: orderItemsCols,
+      constraints: [
+        {
+          kind: "foreignKey" as const,
+          id: "fk-oi-orders",
+          columnIds: ["col-oi-2"], // order_id
+          referencedTableId: "tbl-orders-parent",
+          referencedColumnIds: ["col-orders-1"],
+          ...(onDelete !== undefined ? { onDelete } : {}),
+        },
+      ],
+    };
+
+    return [orders, orderItems];
+  }
+
+  it("検出: 子 onDelete=restrict、子 DELETE なしで親 DELETE → CASCADE_DELETE_OMITTED error", () => {
+    const tables = makeOrderTables("restrict");
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "注文削除",
+          trigger: "click",
+          inputs: [{ name: "orderId", type: "string", required: true }],
+          steps: [
+            {
+              id: "step-01",
+              kind: "dbAccess",
+              description: "注文を削除 (子テーブル DELETE なし)",
+              tableId: "tbl-orders-parent",
+              operation: "DELETE",
+              sql: "DELETE FROM orders WHERE id = @inputs.orderId",
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, tables);
+    const target = issues.filter((i) => i.code === "CASCADE_DELETE_OMITTED");
+    expect(target.length).toBeGreaterThanOrEqual(1);
+    expect(target.some((i) => i.message.includes("order_items"))).toBe(true);
+    expect(target[0].severity).toBe("error");
+  });
+
+  it("検出: 子 onDelete=noAction (デフォルト)、子 DELETE なしで親 DELETE → CASCADE_DELETE_OMITTED error", () => {
+    const tables = makeOrderTables("noAction");
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "注文削除",
+          trigger: "click",
+          inputs: [{ name: "orderId", type: "string", required: true }],
+          steps: [
+            {
+              id: "step-01",
+              kind: "dbAccess",
+              description: "注文を削除 (onDelete=noAction、子 DELETE なし)",
+              tableId: "tbl-orders-parent",
+              operation: "DELETE",
+              sql: "DELETE FROM orders WHERE id = @inputs.orderId",
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, tables);
+    const target = issues.filter((i) => i.code === "CASCADE_DELETE_OMITTED");
+    expect(target.length).toBeGreaterThanOrEqual(1);
+    expect(target.some((i) => i.message.includes("order_items"))).toBe(true);
+  });
+
+  it("検出: onDelete 未指定 (デフォルト noAction 扱い)、子 DELETE なしで親 DELETE → error", () => {
+    const tables = makeOrderTables(undefined); // onDelete 未指定 → noAction 相当
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "注文削除",
+          trigger: "click",
+          inputs: [{ name: "orderId", type: "string", required: true }],
+          steps: [
+            {
+              id: "step-01",
+              kind: "dbAccess",
+              description: "注文を削除 (onDelete 未指定)",
+              tableId: "tbl-orders-parent",
+              operation: "DELETE",
+              sql: "DELETE FROM orders WHERE id = @inputs.orderId",
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, tables);
+    const target = issues.filter((i) => i.code === "CASCADE_DELETE_OMITTED");
+    expect(target.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("false positive 抑止: 子 DELETE が前段にある場合 (onDelete=restrict) → 検出しない", () => {
+    const tables = makeOrderTables("restrict");
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "注文削除",
+          trigger: "click",
+          inputs: [{ name: "orderId", type: "string", required: true }],
+          steps: [
+            {
+              id: "step-01",
+              kind: "dbAccess",
+              description: "子テーブル (order_items) を先に DELETE",
+              tableId: "tbl-order-items",
+              operation: "DELETE",
+              sql: "DELETE FROM order_items WHERE order_id = @inputs.orderId",
+            },
+            {
+              id: "step-02",
+              kind: "dbAccess",
+              description: "親テーブル (orders) を DELETE",
+              tableId: "tbl-orders-parent",
+              operation: "DELETE",
+              sql: "DELETE FROM orders WHERE id = @inputs.orderId",
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, tables);
+    const target = issues.filter((i) => i.code === "CASCADE_DELETE_OMITTED");
+    expect(target).toHaveLength(0);
+  });
+
+  it("false positive 抑止: 子 onDelete=cascade → DB 側が処理するため検出しない", () => {
+    const tables = makeOrderTables("cascade");
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "注文削除",
+          trigger: "click",
+          inputs: [{ name: "orderId", type: "string", required: true }],
+          steps: [
+            {
+              id: "step-01",
+              kind: "dbAccess",
+              description: "注文を削除 (onDelete=cascade なので子は DB 側で自動削除)",
+              tableId: "tbl-orders-parent",
+              operation: "DELETE",
+              sql: "DELETE FROM orders WHERE id = @inputs.orderId",
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, tables);
+    const target = issues.filter((i) => i.code === "CASCADE_DELETE_OMITTED");
+    expect(target).toHaveLength(0);
+  });
+
+  it("false positive 抑止: 子 onDelete=setNull → DB 側が NULL 化するため検出しない", () => {
+    const tables = makeOrderTables("setNull");
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "注文削除",
+          trigger: "click",
+          inputs: [{ name: "orderId", type: "string", required: true }],
+          steps: [
+            {
+              id: "step-01",
+              kind: "dbAccess",
+              description: "注文を削除 (onDelete=setNull なので子の FK カラムは DB 側で NULL 化)",
+              tableId: "tbl-orders-parent",
+              operation: "DELETE",
+              sql: "DELETE FROM orders WHERE id = @inputs.orderId",
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, tables);
+    const target = issues.filter((i) => i.code === "CASCADE_DELETE_OMITTED");
+    expect(target).toHaveLength(0);
+  });
+
+  it("false positive 抑止: 子 onDelete=setDefault → DB 側が DEFAULT 値を設定するため検出しない", () => {
+    const tables = makeOrderTables("setDefault");
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "注文削除",
+          trigger: "click",
+          inputs: [{ name: "orderId", type: "string", required: true }],
+          steps: [
+            {
+              id: "step-01",
+              kind: "dbAccess",
+              description: "注文を削除 (onDelete=setDefault なので子の FK カラムは DB 側で DEFAULT 値)",
+              tableId: "tbl-orders-parent",
+              operation: "DELETE",
+              sql: "DELETE FROM orders WHERE id = @inputs.orderId",
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, tables);
+    const target = issues.filter((i) => i.code === "CASCADE_DELETE_OMITTED");
+    expect(target).toHaveLength(0);
+  });
+
+  it("正常系: FK を持つ子テーブルが存在しない (参照がない) 場合は issue なし", () => {
+    const tables = makeOrderTables("restrict");
+    // 親テーブルのみ使う (子テーブルが存在しても FK が orders を参照していない)
+    const standaloneTable = makeTable(
+      "tbl-standalone",
+      "standalone",
+      [
+        { physicalName: "id", notNull: true, autoIncrement: true, primaryKey: true },
+        { physicalName: "name", notNull: true },
+      ],
+    );
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "スタンドアロン削除",
+          trigger: "click",
+          inputs: [{ name: "id", type: "string", required: true }],
+          steps: [
+            {
+              id: "step-01",
+              kind: "dbAccess",
+              description: "FK 参照のないテーブルを削除",
+              tableId: "tbl-standalone",
+              operation: "DELETE",
+              sql: "DELETE FROM standalone WHERE id = @inputs.id",
+            },
+          ],
+        },
+      ],
+    });
+    // standalone テーブルへの FK を持つ子テーブルがないため issue なし
+    const issues = checkSqlOrder(flow, [standaloneTable, ...tables]);
+    const target = issues.filter((i) => i.code === "CASCADE_DELETE_OMITTED");
+    expect(target).toHaveLength(0);
+  });
+});

--- a/designer/src/schemas/sqlOrderValidator.ts
+++ b/designer/src/schemas/sqlOrderValidator.ts
@@ -1,5 +1,5 @@
 /**
- * DB 制約 × フロー操作順序の交差検査 (#632 MVP: 観点 1+2、#640 観点 3)。
+ * DB 制約 × フロー操作順序の交差検査 (#632 MVP: 観点 1+2、#640 観点 3、#641 観点 4)。
  *
  * 観点 1 (NULL_NOT_ALLOWED_AT_INSERT):
  *   INSERT 時点で NOT NULL カラムに対応する変数が未バインド
@@ -16,11 +16,17 @@
  *   - INSERT step 自身の affectedRowsCheck.errorCode が UNIQUE_VIOLATION 系
  *   - INSERT を含む branch step の condition.kind: "tryCatch" で UNIQUE_VIOLATION error
  *
+ * 観点 4 (CASCADE_DELETE_OMITTED):
+ *   親テーブルへの DELETE step を検出した際に、子テーブル (referencedTableId が親を指す FK を持つ)
+ *   の onDelete が restrict / noAction (または未指定) の場合、同 action 内の前段に
+ *   子テーブルへの DELETE step が存在しなければ実行時 FK 制約違反。
+ *   - onDelete = cascade / setNull / setDefault → DB 側が処理するため issue なし
+ *   - onDelete = restrict / noAction (default) → 子 DELETE が前段になければ error
+ *
  * 既存 sqlColumnValidator と同じ node-sql-parser v5 AST walker を再利用。
  * 変数バインド時系列追跡 + テーブル schema (notNull / foreignKey / unique) との交差解析
  * で実行時 DB 制約違反を構造的に検出する。
  *
- * 観点 4 (CASCADE_DELETE_OMITTED) → #641
  * 観点 5 (TX_CIRCULAR_DEPENDENCY) → #642
  */
 
@@ -40,11 +46,15 @@ export interface OrderTableColumn {
   defaultValue?: string;
 }
 
+/** FK onDelete アクション (table.v3.schema.json の FkAction enum)。 */
+export type FkAction = "cascade" | "setNull" | "setDefault" | "restrict" | "noAction";
+
 /** FK 制約 (validator 内部で必要な最小フィールド)。 */
 export interface OrderForeignKeyConstraint {
   kind: "foreignKey";
   columnIds: string[];
   referencedTableId: string;
+  onDelete?: FkAction;
 }
 
 /** UNIQUE 制約 (validator 内部で必要な最小フィールド)。 */
@@ -71,7 +81,7 @@ export interface OrderTableDefinition {
 
 export interface SqlOrderIssue {
   path: string;
-  code: "NULL_NOT_ALLOWED_AT_INSERT" | "FK_REFERENCE_NOT_INSERTED" | "UNIQUE_CHECK_MISSING" | "SQL_PARSE_ERROR";
+  code: "NULL_NOT_ALLOWED_AT_INSERT" | "FK_REFERENCE_NOT_INSERTED" | "UNIQUE_CHECK_MISSING" | "CASCADE_DELETE_OMITTED" | "SQL_PARSE_ERROR";
   severity?: "error" | "warning";
   message: string;
 }
@@ -96,6 +106,33 @@ function extractInsertTableName(ast: any): string | null {
   if (ast.type === "insert" && Array.isArray(ast.table)) {
     for (const t of ast.table) {
       if (t.table && typeof t.table === "string") return t.table.toLowerCase();
+    }
+  }
+  return null;
+}
+
+/**
+ * DELETE AST から対象テーブル名を取得 (lowercase)。
+ *
+ * node-sql-parser v5 PostgreSQL dialect での DELETE AST 構造:
+ *   - ast.from: Array<{ table: string, ... }>  (PostgreSQL DELETE FROM)
+ *   - ast.table: Array<{ table: string, ... }>  (一部 dialect フォールバック)
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function extractDeleteTableName(ast: any): string | null {
+  if (!ast || typeof ast !== "object") return null;
+  if (ast.type === "delete") {
+    // PostgreSQL: DELETE FROM table_name → ast.from
+    if (Array.isArray(ast.from)) {
+      for (const t of ast.from) {
+        if (t.table && typeof t.table === "string") return t.table.toLowerCase();
+      }
+    }
+    // フォールバック: ast.table
+    if (Array.isArray(ast.table)) {
+      for (const t of ast.table) {
+        if (t.table && typeof t.table === "string") return t.table.toLowerCase();
+      }
     }
   }
   return null;
@@ -237,6 +274,7 @@ interface TableMeta {
   fkConstraints: Array<{
     columnPhysicalNames: string[]; // FK 本テーブル側カラム物理名 (lowercase)
     referencedTableId: string;
+    onDelete?: FkAction;           // FK 違反時アクション (省略時は noAction 相当)
   }>;
   uniqueConstraints: Array<string[]>; // UNIQUE 制約ごとの physicalName (lowercase) 配列
   uniqueColumns: Set<string>;         // Column.unique: true のカラム (各カラム単体 UNIQUE)
@@ -293,6 +331,7 @@ function buildTableMeta(tables: OrderTableDefinition[]): Map<string, TableMeta> 
           fkConstraints.push({
             columnPhysicalNames,
             referencedTableId: fkCon.referencedTableId,
+            onDelete: fkCon.onDelete,
           });
         }
       } else if (con.kind === "unique") {
@@ -490,10 +529,11 @@ function hasTryCatchUniqueViolationInSteps(steps: Step[]): boolean {
 // ─── メイン検査ロジック ─────────────────────────────────────────────────────
 
 /**
- * action 内 INSERT step を順番に検査。
+ * action 内 INSERT / DELETE step を順番に検査。
  *
  * - boundVars: action.inputs の name + 各 step を順に実行した際に蓄積される outputBinding.name
  * - insertedTableIds: 先行 INSERT で書き込んだテーブルの id (FK 参照先確認用)
+ * - deletedTableIds: 先行 DELETE で削除したテーブルの id (観点 4 の子 DELETE 前段確認用)
  * - priorSelectWhereColumns: INSERT より前に見た SELECT の WHERE カラム集合 (観点 3 用)
  */
 function checkAction(
@@ -506,6 +546,8 @@ function checkAction(
 ): void {
   const boundVars = new Set<string>(initialBound);
   const insertedTableIds = new Set<string>();
+  // 観点 4: 先行 DELETE 済みテーブル id (physicalName lowercase → id の逆引きも兼ねる)
+  const deletedTableIds = new Set<string>();
   // 観点 3: INSERT より前に見た SELECT の WHERE カラム集合 (テーブル物理名 → カラム集合)
   const priorSelectWhereColumnsByTable = new Map<string, Set<string>>();
 
@@ -556,6 +598,60 @@ function checkAction(
         }
       } catch {
         // SELECT パース失敗は無視 (観点 3 の偽陽性抑止のため)
+      }
+    }
+
+    // dbAccess DELETE: 観点 4 (CASCADE_DELETE_OMITTED) の検査
+    if (step.kind === "dbAccess" && step.operation === "DELETE" && step.sql) {
+      const delSql = step.sql;
+      const delSubstituted = substituteAtVars(delSql);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let delAst: any;
+      try {
+        delAst = parser.astify(delSubstituted, { database: DIALECT });
+      } catch {
+        // DELETE パース失敗は観点 4 をスキップ
+        delAst = null;
+      }
+      if (delAst) {
+        const delRootNode = Array.isArray(delAst) ? delAst[0] : delAst;
+        const delTableName = extractDeleteTableName(delRootNode);
+        if (delTableName) {
+          const delMeta = tableMeta.get(delTableName);
+          if (delMeta) {
+            // ── 観点 4: CASCADE_DELETE_OMITTED ──────────────────────────────
+            // 親テーブルを DELETE しようとしている → 子テーブルを逆引きして確認
+            // 子テーブル = fkConstraints に referencedTableId === delMeta.id が含まれるテーブル
+            for (const childMeta of tableMeta.values()) {
+              for (const fk of childMeta.fkConstraints) {
+                if (fk.referencedTableId !== delMeta.id) continue;
+
+                // onDelete の確認: cascade / setNull / setDefault は DB 側が処理 → skip
+                const onDel = fk.onDelete ?? "noAction";
+                if (onDel === "cascade" || onDel === "setNull" || onDel === "setDefault") continue;
+
+                // restrict / noAction: 子テーブルへの前段 DELETE が必要
+                if (deletedTableIds.has(childMeta.id)) continue;
+
+                // 前段 DELETE なし → error
+                issues.push({
+                  path: `${path}.sql`,
+                  code: "CASCADE_DELETE_OMITTED",
+                  severity: "error",
+                  message: `テーブル "${delMeta.physicalName}" を DELETE する前に、FK (onDelete=${onDel}) で参照している子テーブル "${childMeta.physicalName}" の DELETE が必要です。子テーブル行を先に DELETE してから親テーブルを DELETE してください。`,
+                });
+              }
+            }
+
+            // この DELETE を記録 (後続の親テーブル DELETE の false positive 抑止用)
+            deletedTableIds.add(delMeta.id);
+          }
+        }
+        // step.tableId からも記録 (SQL が取得できない場合の補完)
+        if (step.tableId) {
+          const metaById = tableIdIndex.get(step.tableId);
+          if (metaById) deletedTableIds.add(metaById.id);
+        }
       }
     }
 


### PR DESCRIPTION
## 関連

- Closes #641
- 仕様: AGENTS.md §Testing Strategy / sqlOrderValidator (#632 系列)

## 概要

`sqlOrderValidator` に観点 4 (CASCADE_DELETE_OMITTED) を追加する。親テーブルへの DELETE step を検出した際に、FK の `onDelete` が `restrict` / `noAction` (または未指定) の子テーブルへの前段 DELETE が同 action 内に存在しない場合を `error` として検出する。`cascade` / `setNull` / `setDefault` は DB 側が処理するため issue を出さない。

## 主な変更

- `sqlOrderValidator.ts`: 観点 4 検出ロジック追加
  - `FkAction` 型エクスポート追加 (table.v3.schema.json の FkAction enum と同等)
  - `OrderForeignKeyConstraint` に `onDelete?: FkAction` を追加
  - `TableMeta.fkConstraints` に `onDelete` を収集するよう `buildTableMeta` を更新
  - `extractDeleteTableName()` ヘルパー関数追加 (DELETE AST からテーブル名抽出)
  - `checkAction()` 内に DELETE 検出 + 子テーブル逆引き + onDelete 分岐ロジック追加
  - `deletedTableIds: Set<string>` を walkStepsInOrder と共に追跡し前段 DELETE 確認
  - `SqlOrderIssue.code` union に `CASCADE_DELETE_OMITTED` 追加
- `sqlOrderValidator.test.ts`: 観点 4 テストケース 8 件追加
  - 検出 3 件: restrict / noAction / onDelete 未指定
  - false positive 抑止 5 件: 前段 DELETE あり / cascade / setNull / setDefault / FK なし
- `.claude/skills/create-flow/SKILL.md`: Rule 19 見出し・説明・テーブルに観点 4 追記
- `.claude/skills/review-flow/SKILL.md`: 観点 11 テーブル行・Must-fix リストに CASCADE_DELETE_OMITTED 追記

## 仕様逐条突合 (自己申告)

- 設計者承認済み判定ロジック (ISSUE #641 本文): `sqlOrderValidator.ts:578-630` ✓
  - 親 DELETE 検出: `extractDeleteTableName()` + `delMeta = tableMeta.get(delTableName)` (L583-594)
  - 子テーブル逆引き: `for childMeta of tableMeta.values() / fk.referencedTableId !== delMeta.id` (L597-599)
  - onDelete 分岐: `cascade / setNull / setDefault → continue` (L602-603)
  - restrict / noAction: `deletedTableIds.has(childMeta.id)` チェック (L606)
  - CASCADE_DELETE_OMITTED 発行: severity = error (L608-613)
- scope = 同 action / tx 内: `deletedTableIds` が `checkAction` ローカル変数であり action 間は引き継がない (L549) ✓
- schema 拡張なし: `git diff origin/main..HEAD -- schemas/` = 0 件 ✓

## レビューで特に見てほしい箇所

- `walkStepsInOrder` は branch / loop / transactionScope の内部も再帰的に走査する。DELETE が branch の片方のパスのみに存在する場合でも「前段 DELETE あり」と楽観的に判定する設計 (偽陽性抑止優先)。これは観点 1〜3 と同じ方針。
- DELETE SQL のパース失敗時は観点 4 をスキップする (SQL_PARSE_ERROR は発行しない)。これも既存観点の方針と一致。

## テスト

- Vitest: 558 件 (全 pass)、うち観点 4 新規 8 件
- Playwright: N/A (UI 影響なし)
- MCP E2E: N/A

## UI 影響 / AI smoke test

- [x] UI 影響なし

## spec 側の不足点

N/A — 本 ISSUE の設計者承認済み方針を ISSUE 本文から直接取得して実装した。

## dogfood 結果

validate:dogfood 19/19 流 pass。CASCADE_DELETE_OMITTED の true positive ゼロ (既存 dogfood に DELETE step が含まれるフローがないため)。false positive ゼロ確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)