### PR TITLE
feat(validator): sqlOrderValidator 観点 5 — TX_CIRCULAR_DEPENDENCY 検出 (#642)

### DIFF
--- a/.claude/skills/create-flow/SKILL.md
+++ b/.claude/skills/create-flow/SKILL.md
@@ -262,6 +262,12 @@ UI 起点フロー (`type: "screen"` / `mode: "upstream"`) を作成するとき
   - onDelete = cascade: DB 側が子を自動削除 → 子 DELETE step 不要
   - onDelete = setNull / setDefault: DB 側が子の FK カラムを NULL / DEFAULT に更新 → 子 DELETE step 不要
   - onDelete = restrict / noAction (デフォルト): 子 DELETE step が前段になければ実行時 FK 制約違反
+- `transactionScope` 内で双方向 FK 循環 (A→B かつ B→A) がある場合: Should-fix (warning) (#642)
+  - 同一 TX で INSERT/UPDATE されるテーブル群の FK 有向グラフを DFS で検査し、back-edge を検出
+  - 三角循環 (A→B→C→A) も検出
+  - TX 外の双方向 FK は対象外 (TX スコープ内のみ)
+  - DEFERRED constraint 検出は Phase 5 候補 (別 ISSUE)
+  - 対処: 挿入順序の見直し / DEFERRED FK / FK 一時無効化 のいずれかを設計者が判断
 
 **Step 5.2 で `validate:dogfood` の `sqlOrderValidator` により機械的に検出される**
 
@@ -271,6 +277,7 @@ UI 起点フロー (`type: "screen"` / `mode: "upstream"`) を作成するとき
 | `FK_REFERENCE_NOT_INSERTED` | error | FK 参照先テーブルの先行 INSERT なし + FK カラム変数が未バインド |
 | `UNIQUE_CHECK_MISSING` | warning | UNIQUE カラムへの INSERT で事前重複チェックなし (#640) |
 | `CASCADE_DELETE_OMITTED` | error | FK onDelete=restrict/noAction の子テーブル行を先 DELETE せず親を DELETE (#641) |
+| `TX_CIRCULAR_DEPENDENCY` | warning | transactionScope 内で INSERT/UPDATE テーブル間に双方向 FK 循環 (#642) |
 
 ### Rule 20: ViewDefinition 整合 (#649、Phase 4 子 1)
 

--- a/.claude/skills/review-flow/SKILL.md
+++ b/.claude/skills/review-flow/SKILL.md
@@ -98,7 +98,7 @@ npm run validate:dogfood
 - バリデータが検出した issue は **Step 1 のレビュー入力**として活用 (重複説明はしない)
 - 結果は Step 2 の「10 観点別カバレッジ」表に **「validator 検出済」** カラムとして記録
 - Must-fix 候補: `UNKNOWN_RESPONSE_REF` / `UNKNOWN_ERROR_CODE` / `UNKNOWN_IDENTIFIER` / `UNKNOWN_COLUMN` / `UNKNOWN_CONV_*` / `UNKNOWN_HANDLER_FLOW` / `MISSING_REQUIRED_ARGUMENT` / `EXTRA_ARGUMENT` / `PRIMARY_INVOKER_MISMATCH` / `DUPLICATE_EVENT_ID` / `NULL_NOT_ALLOWED_AT_INSERT` / `FK_REFERENCE_NOT_INSERTED` / `CASCADE_DELETE_OMITTED` 等
-- Should-fix 候補 (warning): `INCONSISTENT_ARGUMENT_CONTRACT` (1 フローを呼ぶ複数イベント間で argumentMapping キー集合が異なる) / `UNIQUE_CHECK_MISSING` (UNIQUE カラムへの INSERT で事前重複チェックなし、#640)
+- Should-fix 候補 (warning): `INCONSISTENT_ARGUMENT_CONTRACT` (1 フローを呼ぶ複数イベント間で argumentMapping キー集合が異なる) / `UNIQUE_CHECK_MISSING` (UNIQUE カラムへの INSERT で事前重複チェックなし、#640) / `TX_CIRCULAR_DEPENDENCY` (transactionScope 内で INSERT/UPDATE テーブル間に双方向 FK 循環、#642)
 - 終了コード 1 (1 件以上 fail) でも Step 1 を中止せず実施する (実行セマンティクス観点が AI 目視のみで残るため)
 
 ### 観点 ⇄ バリデータ対応表 (担当領域)
@@ -115,7 +115,7 @@ npm run validate:dogfood
 | 8. rollbackOn 発火可能性 | referentialIntegrity (UNKNOWN_ERROR_CODE) | TX inner からの実発火可能性は AI |
 | 9. 画面項目イベント連携整合 | screenItemFlowValidator (handlerFlowId / argumentMapping / primaryInvoker / events[].id ユニーク) | 業務文脈での argumentMapping 値の妥当性 (UI 入力 → フロー入力の意味的整合) は AI |
 | 10. 画面項目値レベル整合 | screenItemFieldTypeValidator (options 包含 / domainKey / 型 / pattern / range / length) | 業務文脈の妥当性 (選択肢命名の業務適切性 / domain 設計妥当性) は AI |
-| 11. DB 制約 × INSERT / DELETE 順序 (#632 / #640 / #641) | sqlOrderValidator (NULL_NOT_ALLOWED_AT_INSERT / FK_REFERENCE_NOT_INSERTED / UNIQUE_CHECK_MISSING / CASCADE_DELETE_OMITTED) | 複雑な条件分岐での可能性の有無は AI / UNIQUE チェック抑止パターンの業務妥当性は AI / onDelete 設定が業務要件として適切かは AI |
+| 11. DB 制約 × INSERT / DELETE 順序 (#632 / #640 / #641 / #642) | sqlOrderValidator (NULL_NOT_ALLOWED_AT_INSERT / FK_REFERENCE_NOT_INSERTED / UNIQUE_CHECK_MISSING / CASCADE_DELETE_OMITTED / TX_CIRCULAR_DEPENDENCY) | 複雑な条件分岐での可能性の有無は AI / UNIQUE チェック抑止パターンの業務妥当性は AI / onDelete 設定が業務要件として適切かは AI / TX 循環の DEFERRED 検出は Phase 5 候補 (別 ISSUE) |
 | 12. ViewDefinition 整合 (#649) | viewDefinitionValidator (UNKNOWN_SOURCE_TABLE / UNKNOWN_TABLE_COLUMN_REF / DUPLICATE_VIEW_COLUMN_NAME / UNKNOWN_SORT_COLUMN / UNKNOWN_FILTER_COLUMN / UNKNOWN_GROUP_BY_COLUMN) | sourceTableId ↔ dbAccess テーブルの業務的整合 / FIELD_TYPE_INCOMPATIBLE の業務妥当性は AI |
 
 監査根拠: `docs/spec/dogfood-2026-04-29-phase2-validator-audit.md` §3 / §4 + Phase 3 子 1 #619 (PR #626)。

--- a/designer/src/schemas/sqlOrderValidator.test.ts
+++ b/designer/src/schemas/sqlOrderValidator.test.ts
@@ -1331,3 +1331,458 @@ describe("観点 4: CASCADE_DELETE_OMITTED", () => {
     expect(target).toHaveLength(0);
   });
 });
+
+// ─── 観点 5: TX_CIRCULAR_DEPENDENCY ───────────────────────────────────────
+
+describe("観点 5: TX_CIRCULAR_DEPENDENCY", () => {
+  /**
+   * テーブル構成:
+   *   table_a: FK → table_b (a.b_id)
+   *   table_b: FK → table_a (b.a_id) ← 双方向循環
+   *   table_c: FK → table_b (c.b_id) (一方向のみ: a→b→c は DAG)
+   *
+   * 循環: a ⇄ b (table_a.b_id → table_b 、 table_b.a_id → table_a)
+   */
+
+  function makeCircularTables() {
+    // table_a: FK b_id → table_b
+    const tableA = {
+      id: "tbl-circ-a",
+      physicalName: "table_a",
+      columns: [
+        { id: "col-a-1", physicalName: "id", notNull: true, autoIncrement: true, primaryKey: true },
+        { id: "col-a-2", physicalName: "b_id", notNull: true },
+        { id: "col-a-3", physicalName: "name", notNull: true },
+      ],
+      constraints: [
+        {
+          kind: "foreignKey" as const,
+          id: "fk-a-b",
+          columnIds: ["col-a-2"],
+          referencedTableId: "tbl-circ-b",
+          referencedColumnIds: ["col-b-1"],
+        },
+      ],
+    };
+
+    // table_b: FK a_id → table_a (双方向)
+    const tableB = {
+      id: "tbl-circ-b",
+      physicalName: "table_b",
+      columns: [
+        { id: "col-b-1", physicalName: "id", notNull: true, autoIncrement: true, primaryKey: true },
+        { id: "col-b-2", physicalName: "a_id", notNull: true },
+        { id: "col-b-3", physicalName: "value", notNull: true },
+      ],
+      constraints: [
+        {
+          kind: "foreignKey" as const,
+          id: "fk-b-a",
+          columnIds: ["col-b-2"],
+          referencedTableId: "tbl-circ-a",
+          referencedColumnIds: ["col-a-1"],
+        },
+      ],
+    };
+
+    // table_c: FK b_id → table_b (一方向のみ)
+    const tableC = {
+      id: "tbl-circ-c",
+      physicalName: "table_c",
+      columns: [
+        { id: "col-c-1", physicalName: "id", notNull: true, autoIncrement: true, primaryKey: true },
+        { id: "col-c-2", physicalName: "b_id", notNull: true },
+        { id: "col-c-3", physicalName: "detail", notNull: true },
+      ],
+      constraints: [
+        {
+          kind: "foreignKey" as const,
+          id: "fk-c-b",
+          columnIds: ["col-c-2"],
+          referencedTableId: "tbl-circ-b",
+          referencedColumnIds: ["col-b-1"],
+        },
+      ],
+    };
+
+    return [tableA, tableB, tableC] as import("./sqlOrderValidator").OrderTableDefinition[];
+  }
+
+  it("検出: A↔B 直接双方向循環 — 同一 TX で両テーブルに INSERT", () => {
+    const tables = makeCircularTables();
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "循環 INSERT",
+          trigger: "submit",
+          inputs: [
+            { name: "bId", type: "string", required: true },
+            { name: "aId", type: "string", required: true },
+            { name: "nameVal", type: "string", required: true },
+            { name: "valueVal", type: "string", required: true },
+          ],
+          steps: [
+            {
+              id: "step-tx-01",
+              kind: "transactionScope",
+              description: "双方向 FK 循環 TX",
+              steps: [
+                {
+                  id: "step-01",
+                  kind: "dbAccess",
+                  description: "table_a INSERT",
+                  tableId: "tbl-circ-a",
+                  operation: "INSERT",
+                  sql: "INSERT INTO table_a (b_id, name) VALUES (@inputs.bId, @inputs.nameVal)",
+                },
+                {
+                  id: "step-02",
+                  kind: "dbAccess",
+                  description: "table_b INSERT (循環)",
+                  tableId: "tbl-circ-b",
+                  operation: "INSERT",
+                  sql: "INSERT INTO table_b (a_id, value) VALUES (@inputs.aId, @inputs.valueVal)",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, tables);
+    const target = issues.filter((i) => i.code === "TX_CIRCULAR_DEPENDENCY");
+    expect(target.length).toBeGreaterThanOrEqual(1);
+    expect(target[0].severity).toBe("warning");
+    // 循環パスに table_a と table_b が含まれること
+    expect(target.some((i) => i.message.includes("table_a") && i.message.includes("table_b"))).toBe(true);
+  });
+
+  it("検出: A→B→C→A 三角循環 — 同一 TX で 3 テーブルに INSERT", () => {
+    // table_c に table_a への FK を追加した三角循環テーブル群
+    const tableA2 = {
+      id: "tbl-tri-a",
+      physicalName: "tri_a",
+      columns: [
+        { id: "col-ta-1", physicalName: "id", notNull: true, autoIncrement: true, primaryKey: true },
+        { id: "col-ta-2", physicalName: "c_id", notNull: true }, // → tri_c (三角の一辺)
+      ],
+      constraints: [
+        {
+          kind: "foreignKey" as const,
+          id: "fk-ta-tc",
+          columnIds: ["col-ta-2"],
+          referencedTableId: "tbl-tri-c",
+          referencedColumnIds: ["col-tc-1"],
+        },
+      ],
+    };
+    const tableB2 = {
+      id: "tbl-tri-b",
+      physicalName: "tri_b",
+      columns: [
+        { id: "col-tb-1", physicalName: "id", notNull: true, autoIncrement: true, primaryKey: true },
+        { id: "col-tb-2", physicalName: "a_id", notNull: true }, // → tri_a
+      ],
+      constraints: [
+        {
+          kind: "foreignKey" as const,
+          id: "fk-tb-ta",
+          columnIds: ["col-tb-2"],
+          referencedTableId: "tbl-tri-a",
+          referencedColumnIds: ["col-ta-1"],
+        },
+      ],
+    };
+    const tableC2 = {
+      id: "tbl-tri-c",
+      physicalName: "tri_c",
+      columns: [
+        { id: "col-tc-1", physicalName: "id", notNull: true, autoIncrement: true, primaryKey: true },
+        { id: "col-tc-2", physicalName: "b_id", notNull: true }, // → tri_b
+      ],
+      constraints: [
+        {
+          kind: "foreignKey" as const,
+          id: "fk-tc-tb",
+          columnIds: ["col-tc-2"],
+          referencedTableId: "tbl-tri-b",
+          referencedColumnIds: ["col-tb-1"],
+        },
+      ],
+    };
+    const tables = [tableA2, tableB2, tableC2] as import("./sqlOrderValidator").OrderTableDefinition[];
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "三角循環 INSERT",
+          trigger: "submit",
+          inputs: [
+            { name: "aId", type: "string", required: true },
+            { name: "bId", type: "string", required: true },
+            { name: "cId", type: "string", required: true },
+          ],
+          steps: [
+            {
+              id: "step-tx-01",
+              kind: "transactionScope",
+              description: "A→B→C→A 三角循環 TX",
+              steps: [
+                {
+                  id: "step-01",
+                  kind: "dbAccess",
+                  description: "tri_a INSERT",
+                  tableId: "tbl-tri-a",
+                  operation: "INSERT",
+                  sql: "INSERT INTO tri_a (c_id) VALUES (@inputs.cId)",
+                },
+                {
+                  id: "step-02",
+                  kind: "dbAccess",
+                  description: "tri_b INSERT",
+                  tableId: "tbl-tri-b",
+                  operation: "INSERT",
+                  sql: "INSERT INTO tri_b (a_id) VALUES (@inputs.aId)",
+                },
+                {
+                  id: "step-03",
+                  kind: "dbAccess",
+                  description: "tri_c INSERT",
+                  tableId: "tbl-tri-c",
+                  operation: "INSERT",
+                  sql: "INSERT INTO tri_c (b_id) VALUES (@inputs.bId)",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, tables);
+    const target = issues.filter((i) => i.code === "TX_CIRCULAR_DEPENDENCY");
+    expect(target.length).toBeGreaterThanOrEqual(1);
+    expect(target[0].severity).toBe("warning");
+  });
+
+  it("false positive 抑止: TX scope 外での双方向 FK (TX なし) — issue 出さない", () => {
+    const tables = makeCircularTables();
+    // TX なし (直接 action steps に INSERT)
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "TX 外 INSERT",
+          trigger: "submit",
+          inputs: [
+            { name: "bId", type: "string", required: true },
+            { name: "aId", type: "string", required: true },
+            { name: "nameVal", type: "string", required: true },
+            { name: "valueVal", type: "string", required: true },
+          ],
+          steps: [
+            {
+              id: "step-01",
+              kind: "dbAccess",
+              description: "table_a INSERT (TX 外)",
+              tableId: "tbl-circ-a",
+              operation: "INSERT",
+              sql: "INSERT INTO table_a (b_id, name) VALUES (@inputs.bId, @inputs.nameVal)",
+            },
+            {
+              id: "step-02",
+              kind: "dbAccess",
+              description: "table_b INSERT (TX 外)",
+              tableId: "tbl-circ-b",
+              operation: "INSERT",
+              sql: "INSERT INTO table_b (a_id, value) VALUES (@inputs.aId, @inputs.valueVal)",
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, tables);
+    // TX_CIRCULAR_DEPENDENCY は transactionScope 内のみ → TX 外では issue なし
+    const target = issues.filter((i) => i.code === "TX_CIRCULAR_DEPENDENCY");
+    expect(target).toHaveLength(0);
+  });
+
+  it("false positive 抑止: 一方向 FK のみ (A→B、循環なし) — issue 出さない", () => {
+    const tables = makeCircularTables();
+    // table_a (a.b_id→table_b) と table_c (c.b_id→table_b): a→b、c→b の DAG (循環なし)
+    // table_b 自体を INSERT しない (table_a と table_c のみ)
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "一方向 FK TX",
+          trigger: "submit",
+          inputs: [
+            { name: "bId", type: "string", required: true },
+            { name: "nameVal", type: "string", required: true },
+            { name: "detailVal", type: "string", required: true },
+          ],
+          steps: [
+            {
+              id: "step-tx-01",
+              kind: "transactionScope",
+              description: "一方向 FK TX (a→b のみ、循環なし)",
+              steps: [
+                {
+                  // table_a だけを INSERT (b_id は既存 table_b 行を参照するため変数が bound 済と仮定)
+                  // ここでの目的は TX_CIRCULAR_DEPENDENCY が出ないことの確認
+                  id: "step-01",
+                  kind: "dbAccess",
+                  description: "table_a INSERT のみ",
+                  tableId: "tbl-circ-a",
+                  operation: "INSERT",
+                  sql: "INSERT INTO table_a (b_id, name) VALUES (@inputs.bId, @inputs.nameVal)",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, tables);
+    const target = issues.filter((i) => i.code === "TX_CIRCULAR_DEPENDENCY");
+    // 1 テーブルのみ INSERT なので循環不可 → issue なし
+    expect(target).toHaveLength(0);
+  });
+
+  it("false positive 抑止: 同一 TX で 1 テーブルのみ操作 — issue 出さない", () => {
+    const tables = makeCircularTables();
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "単独 TX",
+          trigger: "submit",
+          inputs: [{ name: "bId", type: "string", required: true }],
+          steps: [
+            {
+              id: "step-tx-01",
+              kind: "transactionScope",
+              description: "1 テーブルのみ",
+              steps: [
+                {
+                  id: "step-01",
+                  kind: "dbAccess",
+                  description: "table_a のみ INSERT",
+                  tableId: "tbl-circ-a",
+                  operation: "INSERT",
+                  sql: "INSERT INTO table_a (b_id, name) VALUES (@inputs.bId, 'test')",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, tables);
+    const target = issues.filter((i) => i.code === "TX_CIRCULAR_DEPENDENCY");
+    expect(target).toHaveLength(0);
+  });
+
+  it("false positive 抑止: 異なる TX スコープに分散 (各 TX に 1 テーブルのみ) — issue 出さない", () => {
+    const tables = makeCircularTables();
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "分散 TX",
+          trigger: "submit",
+          inputs: [
+            { name: "bId", type: "string", required: true },
+            { name: "aId", type: "string", required: true },
+            { name: "nameVal", type: "string", required: true },
+            { name: "valueVal", type: "string", required: true },
+          ],
+          steps: [
+            {
+              id: "step-tx-01",
+              kind: "transactionScope",
+              description: "TX 1: table_a のみ",
+              steps: [
+                {
+                  id: "step-01",
+                  kind: "dbAccess",
+                  description: "table_a INSERT",
+                  tableId: "tbl-circ-a",
+                  operation: "INSERT",
+                  sql: "INSERT INTO table_a (b_id, name) VALUES (@inputs.bId, @inputs.nameVal)",
+                },
+              ],
+            },
+            {
+              id: "step-tx-02",
+              kind: "transactionScope",
+              description: "TX 2: table_b のみ",
+              steps: [
+                {
+                  id: "step-02",
+                  kind: "dbAccess",
+                  description: "table_b INSERT",
+                  tableId: "tbl-circ-b",
+                  operation: "INSERT",
+                  sql: "INSERT INTO table_b (a_id, value) VALUES (@inputs.aId, @inputs.valueVal)",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, tables);
+    // 各 TX に 1 テーブルのみ → 各スコープ内での循環なし → issue なし
+    const target = issues.filter((i) => i.code === "TX_CIRCULAR_DEPENDENCY");
+    expect(target).toHaveLength(0);
+  });
+
+  it("正常系: UPDATE も TX 内で検出対象に含まれる (双方向 FK + UPDATE)", () => {
+    const tables = makeCircularTables();
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "UPDATE 循環",
+          trigger: "submit",
+          inputs: [
+            { name: "bId", type: "string", required: true },
+            { name: "aId", type: "string", required: true },
+          ],
+          steps: [
+            {
+              id: "step-tx-01",
+              kind: "transactionScope",
+              description: "UPDATE を含む双方向 FK 循環 TX",
+              steps: [
+                {
+                  id: "step-01",
+                  kind: "dbAccess",
+                  description: "table_a UPDATE (b_id を参照)",
+                  tableId: "tbl-circ-a",
+                  operation: "UPDATE",
+                  sql: "UPDATE table_a SET b_id = @inputs.bId WHERE id = 1",
+                },
+                {
+                  id: "step-02",
+                  kind: "dbAccess",
+                  description: "table_b UPDATE (a_id を参照)",
+                  tableId: "tbl-circ-b",
+                  operation: "UPDATE",
+                  sql: "UPDATE table_b SET a_id = @inputs.aId WHERE id = 1",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, tables);
+    const target = issues.filter((i) => i.code === "TX_CIRCULAR_DEPENDENCY");
+    // UPDATE も対象 → 双方向 FK 循環 → warning
+    expect(target.length).toBeGreaterThanOrEqual(1);
+    expect(target[0].severity).toBe("warning");
+  });
+});

--- a/designer/src/schemas/sqlOrderValidator.ts
+++ b/designer/src/schemas/sqlOrderValidator.ts
@@ -31,7 +31,7 @@
  */
 
 import { Parser } from "node-sql-parser";
-import type { ProcessFlow, Step } from "../types/v3";
+import type { ProcessFlow, Step, TransactionScopeStep } from "../types/v3";
 import { isBuiltinStep } from "./stepGuards";
 
 // ─── 入力型: テーブル定義 (v3 形式) ────────────────────────────────────────
@@ -81,7 +81,7 @@ export interface OrderTableDefinition {
 
 export interface SqlOrderIssue {
   path: string;
-  code: "NULL_NOT_ALLOWED_AT_INSERT" | "FK_REFERENCE_NOT_INSERTED" | "UNIQUE_CHECK_MISSING" | "CASCADE_DELETE_OMITTED" | "SQL_PARSE_ERROR";
+  code: "NULL_NOT_ALLOWED_AT_INSERT" | "FK_REFERENCE_NOT_INSERTED" | "UNIQUE_CHECK_MISSING" | "CASCADE_DELETE_OMITTED" | "TX_CIRCULAR_DEPENDENCY" | "SQL_PARSE_ERROR";
   severity?: "error" | "warning";
   message: string;
 }
@@ -526,6 +526,183 @@ function hasTryCatchUniqueViolationInSteps(steps: Step[]): boolean {
   return false;
 }
 
+// ─── 観点 5: TX_CIRCULAR_DEPENDENCY ────────────────────────────────────────
+
+/**
+ * INSERT/UPDATE 対象テーブルを transactionScope step 内の dbAccess step から収集する。
+ * - INSERT / UPDATE step の対象テーブル物理名 (lowercase) を返す
+ * - SQL をパースできない場合は step.tableId 経由でフォールバック
+ */
+function collectTxWriteTableNames(
+  txSteps: Step[],
+  tableMeta: Map<string, TableMeta>,
+  tableIdIndex: Map<string, TableMeta>,
+): string[] {
+  const result: string[] = [];
+
+  function walk(steps: Step[]): void {
+    for (const step of steps) {
+      if (!isBuiltinStep(step)) continue;
+
+      if (step.kind === "dbAccess" && (step.operation === "INSERT" || step.operation === "UPDATE") && step.sql) {
+        // SQL パースでテーブル名を取得
+        const substituted = substituteAtVars(step.sql);
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          let ast: any = parser.astify(substituted, { database: DIALECT });
+          ast = Array.isArray(ast) ? ast[0] : ast;
+          if (ast) {
+            let tableName: string | null = null;
+            if (ast.type === "insert") {
+              tableName = extractInsertTableName(ast);
+            } else if (ast.type === "update") {
+              // UPDATE AST: ast.table または ast.from
+              if (Array.isArray(ast.table)) {
+                for (const t of ast.table) {
+                  if (t.table && typeof t.table === "string") { tableName = t.table.toLowerCase(); break; }
+                }
+              }
+            }
+            if (tableName && tableMeta.has(tableName)) {
+              result.push(tableName);
+            }
+          }
+        } catch {
+          // パース失敗: step.tableId フォールバック
+        }
+        // step.tableId フォールバック (SQL パース失敗 or テーブル名が取れなかった場合)
+        if (step.tableId) {
+          const meta = tableIdIndex.get(step.tableId);
+          if (meta && !result.includes(meta.physicalName)) {
+            result.push(meta.physicalName);
+          }
+        }
+      }
+
+      // nested step の走査 (branch / loop / transactionScope 内は対象外 — TX スコープは本関数呼び出し元で制御)
+      if (step.kind === "branch") {
+        for (const branch of step.branches) walk(branch.steps);
+        if (step.elseBranch) walk(step.elseBranch.steps);
+      }
+      if (step.kind === "loop") walk(step.steps);
+      // 入れ子 TX は対象外 (outer TX のみで循環を見る)
+    }
+  }
+
+  walk(txSteps);
+  return result;
+}
+
+/**
+ * テーブル集合のサブグラフで有向 FK グラフを構築し、DFS で循環を検出する。
+ *
+ * グラフ: 各ノード = テーブル物理名 (lowercase)
+ *         エッジ A → B = テーブル A の FK が テーブル B を参照する
+ *
+ * @param tableNames   TX 内で INSERT/UPDATE されたテーブル物理名集合
+ * @param tableMeta    テーブルメタデータ (FK 情報含む)
+ * @param tableIdIndex id → TableMeta 逆引き
+ * @returns 循環パスの配列 (例: [["table_a", "table_b", "table_a"]])
+ */
+function detectFkCycles(
+  tableNames: string[],
+  tableMeta: Map<string, TableMeta>,
+  tableIdIndex: Map<string, TableMeta>,
+): string[][] {
+  const tableSet = new Set(tableNames);
+  const cycles: string[][] = [];
+
+  // 隣接リスト (A → [B, C, ...]) を tableSet 内のノードのみで構築
+  const adj = new Map<string, string[]>();
+  for (const name of tableSet) {
+    const meta = tableMeta.get(name);
+    if (!meta) continue;
+    const neighbors: string[] = [];
+    for (const fk of meta.fkConstraints) {
+      const refMeta = tableIdIndex.get(fk.referencedTableId);
+      if (refMeta && tableSet.has(refMeta.physicalName) && refMeta.physicalName !== name) {
+        neighbors.push(refMeta.physicalName);
+      }
+    }
+    adj.set(name, neighbors);
+  }
+
+  // DFS による back-edge (循環) 検出
+  const visited = new Set<string>();
+  const onStack = new Set<string>();
+  const stackPath: string[] = [];
+
+  function dfs(node: string): void {
+    visited.add(node);
+    onStack.add(node);
+    stackPath.push(node);
+
+    const neighbors = adj.get(node) ?? [];
+    for (const neighbor of neighbors) {
+      if (!visited.has(neighbor)) {
+        dfs(neighbor);
+      } else if (onStack.has(neighbor)) {
+        // back-edge 発見: 循環パスを抽出
+        const cycleStart = stackPath.indexOf(neighbor);
+        const cyclePath = [...stackPath.slice(cycleStart), neighbor];
+        // 重複しない循環のみ追加 (循環の正規化: 最小要素を先頭にした比較)
+        const cycleKey = cyclePath.join("→");
+        const alreadyExists = cycles.some((c) => c.join("→") === cycleKey);
+        if (!alreadyExists) {
+          cycles.push(cyclePath);
+        }
+      }
+    }
+
+    stackPath.pop();
+    onStack.delete(node);
+  }
+
+  for (const name of tableSet) {
+    if (!visited.has(name)) {
+      dfs(name);
+    }
+  }
+
+  return cycles;
+}
+
+/**
+ * 観点 5: TX_CIRCULAR_DEPENDENCY 検出。
+ *
+ * 同一 transactionScope 内で INSERT/UPDATE されるテーブル群の FK 有向グラフで循環を検出する。
+ * 循環 = テーブル A の FK が B を参照し、かつ B の FK が A を参照 (直接 or 間接) していて、
+ * 同一 TX 内で両方が書き込まれている状態。
+ *
+ * severity = warning (設計者目視確認で許容判断。DEFERRED は本 ISSUE スコープ外)
+ */
+function checkTxCircularDependency(
+  txStep: TransactionScopeStep,
+  txPath: string,
+  tableMeta: Map<string, TableMeta>,
+  tableIdIndex: Map<string, TableMeta>,
+  issues: SqlOrderIssue[],
+): void {
+  const txSteps = txStep.steps ?? [];
+  if (txSteps.length === 0) return;
+
+  // TX 内で INSERT/UPDATE されるテーブル物理名を収集
+  const writtenTableNames = collectTxWriteTableNames(txSteps, tableMeta, tableIdIndex);
+  if (writtenTableNames.length < 2) return; // 2 テーブル未満では循環不可
+
+  // FK グラフで循環検出
+  const cycles = detectFkCycles(writtenTableNames, tableMeta, tableIdIndex);
+
+  for (const cycle of cycles) {
+    issues.push({
+      path: `${txPath}`,
+      code: "TX_CIRCULAR_DEPENDENCY",
+      severity: "warning",
+      message: `transactionScope 内で双方向 FK 循環が検出されました: ${cycle.join(" → ")}。同一 TX で INSERT/UPDATE されるテーブル間に循環する FK 参照チェーンが存在します。DEFERRED 制約または挿入順序の見直し / FK 一時無効化を検討してください (設計者目視確認が必要です)。`,
+    });
+  }
+}
+
 // ─── メイン検査ロジック ─────────────────────────────────────────────────────
 
 /**
@@ -555,6 +732,12 @@ function checkAction(
   // (branch 内部は楽観的に両パスを走査してバインドを union する — 保守的な偽陽性抑止)
   walkStepsInOrder(steps, `actions[${actionIndex}].steps`, (step, path) => {
     if (!isBuiltinStep(step)) return;
+
+    // ── 観点 5: TX_CIRCULAR_DEPENDENCY ────────────────────────────────────
+    // transactionScope step を検出したら、そのスコープ内のテーブルで FK 循環を検査
+    if (step.kind === "transactionScope") {
+      checkTxCircularDependency(step as TransactionScopeStep, path, tableMeta, tableIdIndex, issues);
+    }
 
     // outputBinding を先に boundVars に追加 (同 step の sql でも使えるよう before/after は問わない)
     // 厳密には sql 評価後に bind されるが、偽陽性抑止のため同 step の binding も有効とする。


### PR DESCRIPTION
## 関連

Closes #642

仕様: 設計者承認済方針 (ISSUE #642 本文記載)
- 観点 4 (CASCADE_DELETE_OMITTED) の FK グラフ再利用
- DEFERRED 検出は本 ISSUE スコープ外 (Phase 5 候補)
- severity = warning (常に)
- scope = transactionScope 内のみ

## 概要

`sqlOrderValidator` (#632 MVP) の観点 5 として、同一 `transactionScope` 内で INSERT/UPDATE されるテーブル群の FK 有向グラフを DFS で走査し、back-edge (双方向 FK 循環) を検出する。A⇄B の直接循環および A→B→C→A の三角循環に対応。

## 主な変更

- `collectTxWriteTableNames` 関数: `transactionScope` step 内の `dbAccess INSERT/UPDATE` を再帰走査して書き込みテーブル物理名を収集
- `detectFkCycles` 関数: 観点 4 の `OrderForeignKeyConstraint` を再利用した隣接リスト構築 + DFS back-edge 検出でサイクルパスを抽出
- `checkTxCircularDependency` 関数: `transactionScope` step 単位で上記 2 関数を呼び出し、循環ごとに `TX_CIRCULAR_DEPENDENCY` warning issue を積む
- `checkAction` 関数に `transactionScope` step 検出時の呼び出しフック追加
- `/create-flow/SKILL.md` Rule 19 テーブルに `TX_CIRCULAR_DEPENDENCY` 行追加 + 本文箇条書き補足
- `/review-flow/SKILL.md` 観点 11 に `#642` 追記 / Should-fix 候補に `TX_CIRCULAR_DEPENDENCY` 追加

## 仕様逐条突合 (自己申告)

ISSUE #642 完了基準より:

- `sqlOrderValidator.ts` に TX_CIRCULAR_DEPENDENCY 検出ロジック追加
  → `sqlOrderValidator.ts:529-704` (collectTxWriteTableNames / detectFkCycles / checkTxCircularDependency 全関数)
  → `sqlOrderValidator.ts:736-739` (checkAction 内の呼び出しフック)
- vitest 7 ケース以上
  → `sqlOrderValidator.test.ts:1337-1788` (7 ケース: 検出 2 + false positive 抑止 4 + UPDATE 対象検出 1)
- `/review-flow` SKILL 観点追加
  → `.claude/skills/review-flow/SKILL.md:101` (Should-fix 候補に TX_CIRCULAR_DEPENDENCY 追記)
  → `.claude/skills/review-flow/SKILL.md:118` (観点 11 に #642 / TX_CIRCULAR_DEPENDENCY 追記)
- `/create-flow` SKILL Rule 19 更新
  → `.claude/skills/create-flow/SKILL.md:265-271` (TX_CIRCULAR_DEPENDENCY 箇条書き + テーブル行)
- schema 変更要否: 不要 (`SqlOrderIssue.code` union に `TX_CIRCULAR_DEPENDENCY` を追加のみ、`schemas/*.json` 変更ゼロ)
  → `git diff origin/main..HEAD -- schemas/` = 0 件確認済み

## レビューで特に見てほしい箇所

1. `detectFkCycles` の DFS: `tableSet` 内ノードのみで隣接リスト構築 → TX 外テーブルへの FK エッジをサブグラフから除外している (false positive 抑止の主機構)
2. `collectTxWriteTableNames` の入れ子 TX 非対応: 外側 TX 単位で循環を見るため、ネストした `transactionScope` の内部 step は対象外 (コメント L589)
3. 循環重複排除: `cycleKey = cyclePath.join("→")` による文字列一致のみ。同じ循環を異なる起点で DFS した場合の重複は現実的には発生しないが、正規化は行っていない

## テスト

- Vitest: 40 件 (新規 7 件) — sqlOrderValidator.test.ts 観点 5 (TX_CIRCULAR_DEPENDENCY)
  - 検出: A↔B 直接双方向循環 (L1411) / A→B→C→A 三角循環 (L1461)
  - false positive 抑止: TX 外は対象外 (L1568) / 一方向 FK のみ (L1610) / 1 テーブルのみ (L1653) / 異なる TX スコープに分散 (L1687)
  - 正常系: UPDATE も検出対象 (L1742)
- Playwright: N/A (validator ロジック変更のみ、UI 影響なし)
- MCP E2E: N/A

## UI 影響 / AI smoke test

- [x] UI 影響なし (auto テスト pass のみ)

### UI 影響ありの場合、AI smoke test で確認した項目

N/A

## spec 側の不足点 / 提案

- DEFERRED constraint 検出 (PostgreSQL `SET CONSTRAINTS DEFERRED` で双方向 FK を許容するケース) は本 ISSUE スコープ外。Phase 5 候補として ISSUE 分離済み (ISSUE #642 本文に注記)
- 入れ子 `transactionScope` のサポートは未対応 (実装コメントに記載)。実務上の頻度が低いため Phase 5 以降での検討を推奨

## レビュー担当への申し送り

- 観点 4 (CASCADE_DELETE_OMITTED, `sqlOrderValidator.ts:608-668`) との実装共通部分 (`OrderForeignKeyConstraint` 型・`tableIdIndex`) を確認してほしい
- DFS サイクル検出ロジック (`detectFkCycles`, L607-668) の back-edge 判定: `onStack.has(neighbor)` で `visited` ではなく `onStack` を使う理由が正しく実装されているか
- dogfood 全件 (19 flows) での TX_CIRCULAR_DEPENDENCY true positive はゼロ — 既存サンプルに循環 FK 設計なしのため正常 (false positive 抑止も同時に検証済み)