### PR TITLE
improve(validator): sqlOrderValidator boundVars に暗黙宣言を取り込み (#654)

### DIFF
--- a/designer/src/schemas/sqlOrderValidator.test.ts
+++ b/designer/src/schemas/sqlOrderValidator.test.ts
@@ -488,6 +488,149 @@ describe("sqlOrderValidator boundVars implicit declarations (#654)", () => {
     );
     expect(target).toHaveLength(0);
   });
+
+  it("workflow.onRejected 内 outputBinding が後続 sibling step から参照可能", () => {
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-654-05",
+          name: "workflow onRejected",
+          trigger: "submit",
+          inputs: [],
+          steps: [
+            {
+              id: "step-workflow-01",
+              kind: "workflow",
+              description: "承認",
+              pattern: "approval-sequential",
+              approvers: [{ role: "manager" }],
+              onRejected: [
+                {
+                  id: "step-select-01",
+                  kind: "dbAccess",
+                  description: "却下済みレコード取得",
+                  tableId: "tbl-source",
+                  operation: "SELECT",
+                  sql: "SELECT id, name FROM source_items WHERE id = @inputs.id",
+                  outputBinding: { name: "rejectedRecord" },
+                },
+              ],
+            },
+            {
+              id: "step-insert-01",
+              kind: "dbAccess",
+              description: "監査ログ記録",
+              tableId: "tbl-audit-log",
+              operation: "INSERT",
+              sql: "INSERT INTO audit_log (payload) VALUES (@rejectedRecord)",
+            },
+          ],
+        },
+      ],
+    });
+
+    const issues = checkSqlOrder(flow, tables);
+    const target = issues.filter(
+      (i) => i.code === "NULL_NOT_ALLOWED_AT_INSERT" && i.message.includes("rejectedRecord"),
+    );
+    expect(target).toHaveLength(0);
+  });
+
+  it("workflow.onTimeout 内 outputBinding が後続 sibling step から参照可能", () => {
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-654-06",
+          name: "workflow onTimeout",
+          trigger: "submit",
+          inputs: [],
+          steps: [
+            {
+              id: "step-workflow-01",
+              kind: "workflow",
+              description: "承認",
+              pattern: "approval-sequential",
+              approvers: [{ role: "manager" }],
+              onTimeout: [
+                {
+                  id: "step-select-01",
+                  kind: "dbAccess",
+                  description: "期限切れレコード取得",
+                  tableId: "tbl-source",
+                  operation: "SELECT",
+                  sql: "SELECT id, name FROM source_items WHERE id = @inputs.id",
+                  outputBinding: { name: "timeoutRecord" },
+                },
+              ],
+            },
+            {
+              id: "step-insert-01",
+              kind: "dbAccess",
+              description: "監査ログ記録",
+              tableId: "tbl-audit-log",
+              operation: "INSERT",
+              sql: "INSERT INTO audit_log (payload) VALUES (@timeoutRecord)",
+            },
+          ],
+        },
+      ],
+    });
+
+    const issues = checkSqlOrder(flow, tables);
+    const target = issues.filter(
+      (i) => i.code === "NULL_NOT_ALLOWED_AT_INSERT" && i.message.includes("timeoutRecord"),
+    );
+    expect(target).toHaveLength(0);
+  });
+
+  it("validation.inlineBranch.ng 内 outputBinding が後続 sibling step から参照可能", () => {
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-654-07",
+          name: "validation inlineBranch ng",
+          trigger: "submit",
+          inputs: [],
+          steps: [
+            {
+              id: "step-validation-01",
+              kind: "validation",
+              description: "入力チェック",
+              rules: [],
+              inlineBranch: {
+                ok: [],
+                ng: [
+                  {
+                    id: "step-select-01",
+                    kind: "dbAccess",
+                    description: "検証NG項目取得",
+                    tableId: "tbl-source",
+                    operation: "SELECT",
+                    sql: "SELECT id, name FROM source_items WHERE id = @inputs.id",
+                    outputBinding: { name: "ngValidatedItem" },
+                  },
+                ],
+              },
+            },
+            {
+              id: "step-insert-01",
+              kind: "dbAccess",
+              description: "監査ログ記録",
+              tableId: "tbl-audit-log",
+              operation: "INSERT",
+              sql: "INSERT INTO audit_log (payload) VALUES (@ngValidatedItem)",
+            },
+          ],
+        },
+      ],
+    });
+
+    const issues = checkSqlOrder(flow, tables);
+    const target = issues.filter(
+      (i) => i.code === "NULL_NOT_ALLOWED_AT_INSERT" && i.message.includes("ngValidatedItem"),
+    );
+    expect(target).toHaveLength(0);
+  });
 });
 
 // ─── 観点 2: FK_REFERENCE_NOT_INSERTED ────────────────────────────────────

--- a/designer/src/schemas/sqlOrderValidator.test.ts
+++ b/designer/src/schemas/sqlOrderValidator.test.ts
@@ -306,6 +306,190 @@ describe("観点 1: NULL_NOT_ALLOWED_AT_INSERT", () => {
   });
 });
 
+describe("sqlOrderValidator boundVars implicit declarations (#654)", () => {
+  const tables: OrderTableDefinition[] = [
+    makeTable("tbl-validation-errors", "validation_errors", [
+      { physicalName: "id", notNull: true, autoIncrement: true, primaryKey: true },
+      { physicalName: "error_log", notNull: true },
+    ]),
+    makeTable("tbl-audit-log", "audit_log", [
+      { physicalName: "id", notNull: true, autoIncrement: true, primaryKey: true },
+      { physicalName: "payload", notNull: true },
+    ]),
+    makeTable("tbl-source", "source_items", [
+      { physicalName: "id", notNull: true, autoIncrement: true, primaryKey: true },
+      { physicalName: "name", notNull: true },
+    ]),
+  ];
+
+  it("ValidationStep.fieldErrorsVar 明示: @myErrors 参照 INSERT の false positive を出さない", () => {
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-654-01",
+          name: "fieldErrorsVar 明示",
+          trigger: "submit",
+          inputs: [],
+          steps: [
+            {
+              id: "step-validation-01",
+              kind: "validation",
+              description: "入力チェック",
+              rules: [],
+              fieldErrorsVar: "myErrors",
+            },
+            {
+              id: "step-insert-01",
+              kind: "dbAccess",
+              description: "エラー記録",
+              tableId: "tbl-validation-errors",
+              operation: "INSERT",
+              sql: "INSERT INTO validation_errors (error_log) VALUES (@myErrors)",
+            },
+          ],
+        },
+      ],
+    });
+
+    const issues = checkSqlOrder(flow, tables);
+    const target = issues.filter(
+      (i) => i.code === "NULL_NOT_ALLOWED_AT_INSERT" && i.message.includes("myErrors"),
+    );
+    expect(target).toHaveLength(0);
+  });
+
+  it("ValidationStep.fieldErrorsVar 省略: デフォルト fieldErrors を boundVars として扱う", () => {
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-654-02",
+          name: "fieldErrorsVar 省略",
+          trigger: "submit",
+          inputs: [],
+          steps: [
+            {
+              id: "step-validation-01",
+              kind: "validation",
+              description: "入力チェック",
+              rules: [],
+            },
+            {
+              id: "step-insert-01",
+              kind: "dbAccess",
+              description: "エラー記録",
+              tableId: "tbl-validation-errors",
+              operation: "INSERT",
+              sql: "INSERT INTO validation_errors (error_log) VALUES (@fieldErrors)",
+            },
+          ],
+        },
+      ],
+    });
+
+    const issues = checkSqlOrder(flow, tables);
+    const target = issues.filter(
+      (i) => i.code === "NULL_NOT_ALLOWED_AT_INSERT" && i.message.includes("fieldErrors"),
+    );
+    expect(target).toHaveLength(0);
+  });
+
+  it("workflow.onApproved 内 outputBinding は workflow step 後の sibling step から参照できる", () => {
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-654-03",
+          name: "workflow onApproved",
+          trigger: "submit",
+          inputs: [],
+          steps: [
+            {
+              id: "step-workflow-01",
+              kind: "workflow",
+              description: "承認",
+              pattern: "approval-sequential",
+              approvers: [{ role: "manager" }],
+              onApproved: [
+                {
+                  id: "step-select-01",
+                  kind: "dbAccess",
+                  description: "承認済みレコード取得",
+                  tableId: "tbl-source",
+                  operation: "SELECT",
+                  sql: "SELECT id, name FROM source_items WHERE id = @inputs.id",
+                  outputBinding: { name: "approvedRecord" },
+                },
+              ],
+            },
+            {
+              id: "step-insert-01",
+              kind: "dbAccess",
+              description: "監査ログ記録",
+              tableId: "tbl-audit-log",
+              operation: "INSERT",
+              sql: "INSERT INTO audit_log (payload) VALUES (@approvedRecord)",
+            },
+          ],
+        },
+      ],
+    });
+
+    const issues = checkSqlOrder(flow, tables);
+    const target = issues.filter(
+      (i) => i.code === "NULL_NOT_ALLOWED_AT_INSERT" && i.message.includes("approvedRecord"),
+    );
+    expect(target).toHaveLength(0);
+  });
+
+  it("validation.inlineBranch.ok 内 outputBinding は validation step 後の sibling step から参照できる", () => {
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-654-04",
+          name: "validation inlineBranch",
+          trigger: "submit",
+          inputs: [],
+          steps: [
+            {
+              id: "step-validation-01",
+              kind: "validation",
+              description: "入力チェック",
+              rules: [],
+              inlineBranch: {
+                ok: [
+                  {
+                    id: "step-select-01",
+                    kind: "dbAccess",
+                    description: "検証済み項目取得",
+                    tableId: "tbl-source",
+                    operation: "SELECT",
+                    sql: "SELECT id, name FROM source_items WHERE id = @inputs.id",
+                    outputBinding: { name: "validatedItem" },
+                  },
+                ],
+                ng: [],
+              },
+            },
+            {
+              id: "step-insert-01",
+              kind: "dbAccess",
+              description: "監査ログ記録",
+              tableId: "tbl-audit-log",
+              operation: "INSERT",
+              sql: "INSERT INTO audit_log (payload) VALUES (@validatedItem)",
+            },
+          ],
+        },
+      ],
+    });
+
+    const issues = checkSqlOrder(flow, tables);
+    const target = issues.filter(
+      (i) => i.code === "NULL_NOT_ALLOWED_AT_INSERT" && i.message.includes("validatedItem"),
+    );
+    expect(target).toHaveLength(0);
+  });
+});
+
 // ─── 観点 2: FK_REFERENCE_NOT_INSERTED ────────────────────────────────────
 
 describe("観点 2: FK_REFERENCE_NOT_INSERTED", () => {

--- a/designer/src/schemas/sqlOrderValidator.ts
+++ b/designer/src/schemas/sqlOrderValidator.ts
@@ -261,6 +261,15 @@ function walkStepsInOrder(
         if (spec?.sideEffects) walkStepsInOrder(spec.sideEffects, `${path}.outcomes.${k}.sideEffects`, visitor);
       });
     }
+    if (step.kind === "workflow") {
+      if (step.onApproved) walkStepsInOrder(step.onApproved, `${path}.onApproved`, visitor);
+      if (step.onRejected) walkStepsInOrder(step.onRejected, `${path}.onRejected`, visitor);
+      if (step.onTimeout) walkStepsInOrder(step.onTimeout, `${path}.onTimeout`, visitor);
+    }
+    if (step.kind === "validation" && step.inlineBranch) {
+      walkStepsInOrder(step.inlineBranch.ok, `${path}.inlineBranch.ok`, visitor);
+      walkStepsInOrder(step.inlineBranch.ng, `${path}.inlineBranch.ng`, visitor);
+    }
   }
 }
 
@@ -743,6 +752,11 @@ function checkAction(
     // 厳密には sql 評価後に bind されるが、偽陽性抑止のため同 step の binding も有効とする。
     if (step.outputBinding?.name) {
       boundVars.add(step.outputBinding.name);
+    }
+    // ValidationStep.fieldErrorsVar も暗黙宣言として boundVars に取り込む
+    // (identifierScope.ts:129-132 と同ロジック、デフォルト名 "fieldErrors")
+    if (step.kind === "validation") {
+      boundVars.add(step.fieldErrorsVar ?? "fieldErrors");
     }
     if (step.kind === "compute" && step.outputBinding?.name) {
       boundVars.add(step.outputBinding.name);


### PR DESCRIPTION
## 関連
- Closes #654
- 起源: PR #647 (#632 sqlOrderValidator MVP) 独立レビュー Nit N-1
- 関連: #612 (identifierScope に @error 追加) と axis が近い

## 概要

`sqlOrderValidator` の boundVars 集計が `outputBinding.name` しか拾っていなかった件を `identifierScope.ts` と同ロジックで補完。validator 間ロジック差異を解消し、将来 fixture 拡充で workflow / validation.inlineBranch 配下にバインド変数が増えても false positive を防ぐ。

## コミット構成

1. `<sha-1>` — `walkStepsInOrder` に workflow.{onApproved,onRejected,onTimeout} と validation.inlineBranch.{ok,ng} の再帰追加 + visitor で ValidationStep.fieldErrorsVar (省略時 'fieldErrors') を boundVars に追加 + テスト 4 件追加
2. `681766b` — 独立レビュー Should-fix / Nit 2 解消: workflow.onRejected / onTimeout / validation.inlineBranch.ng のテスト 3 件追加

## 主な変更

`designer/src/schemas/sqlOrderValidator.ts`:
- `walkStepsInOrder` (line 237 付近) のネスト再帰先に `workflow.{onApproved,onRejected,onTimeout}` と `validation.inlineBranch.{ok,ng}` を追加 — 観点 1〜5 の検出網羅性も向上 (副次効果)
- `checkAction` visitor で `ValidationStep.fieldErrorsVar` (省略時 `"fieldErrors"`) を boundVars に追加 (`identifierScope.ts:129-132` と同ロジック)

`designer/src/schemas/sqlOrderValidator.test.ts`:
- 新規 7 ケース追加 (#654 describe block):
  - `ValidationStep.fieldErrorsVar` 明示指定 (`myErrors` 参照 INSERT) で false positive 出ない
  - `ValidationStep.fieldErrorsVar` 省略時 (デフォルト `fieldErrors`)
  - `workflow.onApproved` 内 outputBinding を後続 sibling step から参照
  - `workflow.onRejected` 同上
  - `workflow.onTimeout` 同上
  - `validation.inlineBranch.ok` 内 outputBinding 同上
  - `validation.inlineBranch.ng` 同上

## 仕様逐条突合 (自己申告)

ISSUE #654 完了基準:
- `sqlOrderValidator` boundVars に `ValidationStep.fieldErrorsVar` を取り込む → `checkAction` visitor 内 `step.kind === 'validation'` 分岐で対応 (sqlOrderValidator.ts:756-759 付近)
- `Workflow.outputBinding` 等の他の暗黙宣言検討 → `walkStepsInOrder` の workflow / inlineBranch 再帰追加 (sqlOrderValidator.ts:264-273 付近) で配下の outputBinding が自動的に boundVars に蓄積される
- サンプル fixture 追加 → #608 既にクローズ済 + 現状実害なしのため本 PR スコープ外 (validator ロジック単独で完結)

## テスト

- Vitest:
  - `sqlOrderValidator.test.ts` 全 47 件 pass (既存 40 + 新規 7)
- dogfood: `validate:dogfood` 19 / 19 flows passed (regression なし)
- `npm run build`: tsc + lint + build pass
- Playwright: N/A (UI 影響なし)

## UI 影響

- [x] UI 影響なし (validator 内部ロジックのみ)

## schema 変更チェック (#511)

- `schemas/*.json` 変更なし — `gh pr diff 664 --name-only | grep -E '^schemas/'` で空 ✓

## 独立レビュー

- 別セッション Sonnet による独立レビュー実施済 (https://github.com/csilost2001/html-designer/pull/664#issuecomment-4351566041)
- Must-fix 0 / Should-fix 1 / Nit 2 → Should-fix と Nit-2 (workflow.onRejected/onTimeout + inlineBranch.ng のテスト不足) は本 PR 内 (681766b) で解消済
- Nit-1 (既存コード line 750 付近の重複) は本 PR スコープ外 (元から存在する既存コード起因)
- 総合評価: マージ可

## spec 側の不足点 / 提案

N/A