### PR TITLE
feat(view-definition): UI 編集機能 — ListView + Editor + store + ルーティング (#666)

### DIFF
--- a/designer-mcp/src/projectStorage.ts
+++ b/designer-mcp/src/projectStorage.ts
@@ -21,6 +21,7 @@ const CONVENTIONS_DIR = path.join(DATA_DIR, "conventions");
 const SCREEN_ITEMS_DIR = path.join(DATA_DIR, "screen-items");
 const SEQUENCES_DIR = path.join(DATA_DIR, "sequences");
 const VIEWS_DIR = path.join(DATA_DIR, "views");
+const VIEW_DEFINITIONS_DIR = path.join(DATA_DIR, "view-definitions");
 export const EXTENSIONS_DIR = path.join(DATA_DIR, "extensions");
 export const PROJECT_FILE = path.join(DATA_DIR, "project.json");
 export const CUSTOM_BLOCKS_FILE = path.join(DATA_DIR, "custom-blocks.json");
@@ -87,6 +88,7 @@ export async function ensureDataDir(): Promise<void> {
   // screen-items/ は Phase 4-β migration 後に廃止済み — 再作成しない
   await fs.mkdir(SEQUENCES_DIR, { recursive: true });
   await fs.mkdir(VIEWS_DIR, { recursive: true });
+  await fs.mkdir(VIEW_DEFINITIONS_DIR, { recursive: true });
   await fs.mkdir(EXTENSIONS_DIR, { recursive: true });
 }
 
@@ -148,6 +150,7 @@ function resolveDataFile(kind: string, id?: string): string | null {
     case "screenItems": return id ? path.join(SCREEN_ITEMS_DIR, `${id}.json`) : null;
     case "sequence": return id ? path.join(SEQUENCES_DIR, `${id}.json`) : null;
     case "view": return id ? path.join(VIEWS_DIR, `${id}.json`) : null;
+    case "viewDefinition": return id ? path.join(VIEW_DEFINITIONS_DIR, `${id}.json`) : null;
     default: return null;
   }
 }
@@ -533,6 +536,37 @@ export async function writeView(viewId: string, data: unknown): Promise<void> {
 export async function deleteView(viewId: string): Promise<void> {
   try {
     await fs.unlink(path.join(VIEWS_DIR, `${viewId}.json`));
+  } catch { /* file not found is OK */ }
+}
+
+export async function listAllViewDefinitions(): Promise<unknown[]> {
+  try {
+    await ensureDataDir();
+    const files = await fs.readdir(VIEW_DEFINITIONS_DIR);
+    const results: unknown[] = [];
+    for (const file of files) {
+      if (!file.endsWith(".json")) continue;
+      const data = await readJSON<unknown>(path.join(VIEW_DEFINITIONS_DIR, file));
+      if (data) results.push(data);
+    }
+    return results;
+  } catch {
+    return [];
+  }
+}
+
+export async function readViewDefinition(viewDefinitionId: string): Promise<unknown | null> {
+  return readJSON<unknown>(path.join(VIEW_DEFINITIONS_DIR, `${viewDefinitionId}.json`));
+}
+
+export async function writeViewDefinition(viewDefinitionId: string, data: unknown): Promise<void> {
+  await ensureDataDir();
+  await writeJSON(path.join(VIEW_DEFINITIONS_DIR, `${viewDefinitionId}.json`), data);
+}
+
+export async function deleteViewDefinition(viewDefinitionId: string): Promise<void> {
+  try {
+    await fs.unlink(path.join(VIEW_DEFINITIONS_DIR, `${viewDefinitionId}.json`));
   } catch { /* file not found is OK */ }
 }
 

--- a/designer-mcp/src/wsBridge.ts
+++ b/designer-mcp/src/wsBridge.ts
@@ -39,6 +39,10 @@ import {
   writeView,
   deleteView as deleteViewFile,
   listAllViews,
+  readViewDefinition,
+  writeViewDefinition,
+  deleteViewDefinition as deleteViewDefinitionFile,
+  listAllViewDefinitions,
   getFileMtime,
   readExtensionsBundle,
   writeExtensionsFile,
@@ -496,6 +500,11 @@ class WsBridge extends EventEmitter {
           respond(viewsData);
           break;
         }
+        case "listAllViewDefinitions": {
+          const viewDefinitionsData = await listAllViewDefinitions();
+          respond(viewDefinitionsData);
+          break;
+        }
         case "loadConventions": {
           const catalog = await readConventions();
           respond(catalog);
@@ -566,6 +575,26 @@ class WsBridge extends EventEmitter {
           await deleteViewFile(viewId);
           respond({ success: true });
           this.broadcast("viewChanged", { viewId, deleted: true }, clientId);
+          break;
+        }
+        case "loadViewDefinition": {
+          const { viewDefinitionId } = (params ?? {}) as { viewDefinitionId: string };
+          const data = await readViewDefinition(viewDefinitionId);
+          respond(data);
+          break;
+        }
+        case "saveViewDefinition": {
+          const { viewDefinitionId, data } = (params ?? {}) as { viewDefinitionId: string; data: unknown };
+          await writeViewDefinition(viewDefinitionId, data);
+          respond({ success: true });
+          this.broadcast("viewDefinitionChanged", { viewDefinitionId }, clientId);
+          break;
+        }
+        case "deleteViewDefinition": {
+          const { viewDefinitionId } = (params ?? {}) as { viewDefinitionId: string };
+          await deleteViewDefinitionFile(viewDefinitionId);
+          respond({ success: true });
+          this.broadcast("viewDefinitionChanged", { viewDefinitionId, deleted: true }, clientId);
           break;
         }
         case "getFileMtime": {

--- a/designer/e2e/view-definition.spec.ts
+++ b/designer/e2e/view-definition.spec.ts
@@ -1,0 +1,103 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { test, expect, type Page } from "@playwright/test";
+
+const TABLE_ID = "eb574288-88f2-419f-ac5e-56a9948e8f46";
+const CREATED_NAME = "E2E 商品ビュー";
+const UPDATED_NAME = "E2E 商品ビュー 更新";
+
+const sampleTable = JSON.parse(
+  readFileSync(
+    resolve(process.cwd(), "../docs/sample-project-v3/retail/tables/eb574288-88f2-419f-ac5e-56a9948e8f46.json"),
+    "utf8",
+  ),
+);
+
+async function seedRetailTable(page: Page) {
+  const now = new Date().toISOString();
+  const tableEntry = {
+    id: TABLE_ID,
+    no: 1,
+    name: sampleTable.name,
+    physicalName: sampleTable.physicalName,
+    category: sampleTable.category,
+    columnCount: sampleTable.columns.length,
+    updatedAt: sampleTable.updatedAt,
+    maturity: sampleTable.maturity,
+  };
+  const project = {
+    $schema: "../schemas/v3/project.v3.schema.json",
+    schemaVersion: "v3",
+    meta: {
+      id: "00000000-0000-4000-8000-000000000001",
+      name: "view-definition-e2e",
+      createdAt: now,
+      updatedAt: now,
+      mode: "upstream",
+      maturity: "draft",
+    },
+    extensionsApplied: [],
+    entities: {
+      screens: [],
+      screenGroups: [],
+      screenTransitions: [],
+      tables: [tableEntry],
+      processFlows: [],
+      sequences: [],
+      views: [],
+    },
+  };
+
+  await page.addInitScript(
+    ({ project, table, tableId }) => {
+      localStorage.clear();
+      localStorage.setItem("v3-project", JSON.stringify(project));
+      localStorage.setItem(`v3-table-${tableId}`, JSON.stringify(table));
+      localStorage.removeItem("designer-open-tabs");
+      localStorage.removeItem("designer-active-tab");
+      localStorage.removeItem("list-view-mode:view-definition-list");
+    },
+    { project, table: sampleTable, tableId: TABLE_ID },
+  );
+}
+
+async function openViewDefinitionListFromHeader(page: Page) {
+  await page.goto("/");
+  await page.locator(".header-menu-btn").click();
+  await page.getByRole("menuitem", { name: "ビュー定義一覧" }).click();
+  await expect(page).toHaveURL(/\/view-definition\/list$/);
+  await expect(page.getByText("ビュー定義一覧").first()).toBeVisible();
+}
+
+test.describe("ビュー定義 E2E", () => {
+  test.beforeEach(async ({ page }) => {
+    await seedRetailTable(page);
+  });
+
+  test("ヘッダーから一覧画面に遷移できる", async ({ page }) => {
+    await openViewDefinitionListFromHeader(page);
+  });
+
+  test("新規追加 → 編集 → 保存 → 一覧反映", async ({ page }) => {
+    await openViewDefinitionListFromHeader(page);
+
+    await page.getByRole("button", { name: /ビュー定義追加/ }).click();
+    await expect(page.getByText("ビュー定義追加").first()).toBeVisible();
+    await page.getByLabel("表示名").fill(CREATED_NAME);
+    await page.getByLabel("viewer 種別").selectOption("list");
+    await page.getByLabel("ソーステーブル").selectOption(TABLE_ID);
+    await page.getByRole("button", { name: "作成して編集" }).click();
+
+    await expect(page).toHaveURL(/\/view-definition\/edit\//);
+    await expect(page.getByText("ビュー定義編集").first()).toBeVisible();
+
+    await page.getByLabel(/表示名/).fill(UPDATED_NAME);
+    await expect(page.getByRole("button", { name: /保存/ })).toBeEnabled();
+    await page.getByRole("button", { name: /保存/ }).click();
+    await expect(page.getByRole("button", { name: /保存/ })).toBeDisabled();
+
+    await page.getByTestId("editor-header-back").click();
+    await expect(page).toHaveURL(/\/view-definition\/list$/);
+    await expect(page.getByText(UPDATED_NAME).first()).toBeVisible();
+  });
+});

--- a/designer/src/components/AppShell.tsx
+++ b/designer/src/components/AppShell.tsx
@@ -14,6 +14,8 @@ import { SequenceListView } from "./sequence/SequenceListView";
 import { SequenceEditor } from "./sequence/SequenceEditor";
 import { ViewListView } from "./view/ViewListView";
 import { ViewEditor } from "./view/ViewEditor";
+import { ViewDefinitionListView } from "./view-definition/ViewDefinitionListView";
+import { ViewDefinitionEditor } from "./view-definition/ViewDefinitionEditor";
 import { Designer } from "./Designer";
 import { DashboardView } from "./dashboard/DashboardView";
 import { TabBar } from "./TabBar";
@@ -23,6 +25,7 @@ import { loadTable } from "../store/tableStore";
 import { loadProcessFlow } from "../store/processFlowStore";
 import { loadSequence } from "../store/sequenceStore";
 import { loadView } from "../store/viewStore";
+import { loadViewDefinition } from "../store/viewDefinitionStore";
 import {
   getTabs,
   getActiveTabId,
@@ -202,6 +205,28 @@ export function AppShell() {
       return;
     }
 
+    const viewDefinitionMatch = matchPath("/view-definition/edit/:viewDefinitionId", location.pathname);
+    if (viewDefinitionMatch?.params.viewDefinitionId) {
+      const viewDefinitionId = decodeURIComponent(viewDefinitionMatch.params.viewDefinitionId);
+      const tabId = makeTabId("view-definition", viewDefinitionId);
+      const existing = getTabs().find((t) => t.id === tabId);
+      if (existing) {
+        setActiveTab(tabId);
+      } else {
+        loadViewDefinition(viewDefinitionId).then((vd) => {
+          if (vd) {
+            openTab({ id: tabId, type: "view-definition", resourceId: viewDefinitionId, label: vd.name });
+          } else {
+            fallbackToDashboard("ビュー定義", viewDefinitionId);
+          }
+        }).catch((e) => {
+          recordError({ source: "manual", message: "loadViewDefinition 失敗", stack: e instanceof Error ? e.stack : undefined });
+          fallbackToDashboard("ビュー定義", viewDefinitionId);
+        });
+      }
+      return;
+    }
+
     // シングルトンタブ: list / workspace 系は resourceId="main" で 1 インスタンスのみ
     const singletonRoutes: ReadonlyArray<{ path: string; type: TabType; label: string }> = [
       { path: "/",                   type: "dashboard",          label: "ダッシュボード" },
@@ -215,6 +240,7 @@ export function AppShell() {
       { path: "/screen-items",       type: "screen-items",       label: "画面項目定義" },
       { path: "/sequence/list",      type: "sequence-list",      label: "シーケンス一覧" },
       { path: "/view/list",          type: "view-list",           label: "ビュー一覧" },
+      { path: "/view-definition/list", type: "view-definition-list", label: "ビュー定義一覧" },
     ];
     for (const { path, type, label } of singletonRoutes) {
       if (location.pathname === path) {
@@ -237,6 +263,7 @@ export function AppShell() {
       : activeTab.type === "action"           ? `/process-flow/edit/${activeTab.resourceId}`
       : activeTab.type === "sequence"         ? `/sequence/edit/${activeTab.resourceId}`
       : activeTab.type === "view"             ? `/view/edit/${activeTab.resourceId}`
+      : activeTab.type === "view-definition"  ? `/view-definition/edit/${activeTab.resourceId}`
       : activeTab.type === "screen-flow"      ? "/screen/flow"
       : activeTab.type === "screen-list"      ? "/screen/list"
       : activeTab.type === "table-list"       ? "/table/list"
@@ -246,8 +273,9 @@ export function AppShell() {
       : activeTab.type === "conventions-catalog" ? "/conventions/catalog"
       : activeTab.type === "screen-items"     ? "/screen-items"
       : activeTab.type === "sequence-list"    ? "/sequence/list"
-      : activeTab.type === "view-list"        ? "/view/list"
-      : activeTab.type === "dashboard"        ? "/"
+      : activeTab.type === "view-list"              ? "/view/list"
+      : activeTab.type === "view-definition-list"   ? "/view-definition/list"
+      : activeTab.type === "dashboard"              ? "/"
       : null;
     if (expectedPath && location.pathname !== expectedPath) {
       navigate(expectedPath, { replace: true });
@@ -328,6 +356,8 @@ export function AppShell() {
             <Route path="/sequence/edit/:sequenceId" element={<SequenceEditor />} />
             <Route path="/view/list" element={<ViewListView />} />
             <Route path="/view/edit/:viewId" element={<ViewEditor />} />
+            <Route path="/view-definition/list" element={<ViewDefinitionListView />} />
+            <Route path="/view-definition/edit/:viewDefinitionId" element={<ViewDefinitionEditor />} />
           </Routes>
         </ErrorBoundary>
       )}

--- a/designer/src/components/HeaderMenu.tsx
+++ b/designer/src/components/HeaderMenu.tsx
@@ -56,6 +56,10 @@ const MENU_ITEMS: MenuItem[] = [
     id: "view-list", label: "ビュー一覧", icon: "bi-eye", route: "/view/list",
     activePaths: ["/view/list"], activePrefixes: ["/view/edit/"],
   },
+  {
+    id: "view-definition-list", label: "ビュー定義一覧", icon: "bi-layout-text-window", route: "/view-definition/list",
+    activePaths: ["/view-definition/list"], activePrefixes: ["/view-definition/edit/"],
+  },
 ];
 
 const DASHBOARD_ITEM: MenuItem = {

--- a/designer/src/components/view-definition/ViewDefinitionEditor.tsx
+++ b/designer/src/components/view-definition/ViewDefinitionEditor.tsx
@@ -1,0 +1,1011 @@
+/**
+ * ViewDefinitionEditor — ビュー定義編集画面 (#666 S5)
+ *
+ * 5 セクション構成:
+ *  1. 基本情報 (id / name / physicalName / description / kind / sourceTableId)
+ *  2. columns 編集テーブル (TableEditor のカラム編集パターンを参考)
+ *  3. sortDefaults 編集テーブル
+ *  4. filterDefaults 編集テーブル
+ *  5. その他 (pageSize / groupBy)
+ *
+ * リアルタイム validator: checkViewDefinition() の結果を各フィールドの隣に inline 表示。
+ */
+
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import type {
+  ViewDefinition,
+  ViewColumn,
+  SortSpec,
+  FilterSpec,
+  FilterOperator,
+  BuiltinViewDefinitionKind,
+} from "../../types/v3/view-definition";
+import type { Table, TableEntry, Maturity, Identifier, FieldType, FieldTypePrimitive } from "../../types/v3";
+import type { TableId, LocalId } from "../../types/v3/common";
+import { loadViewDefinition, saveViewDefinition } from "../../store/viewDefinitionStore";
+import { listTables, loadTable } from "../../store/tableStore";
+import { mcpBridge } from "../../mcp/mcpBridge";
+import { useResourceEditor } from "../../hooks/useResourceEditor";
+import { useSaveShortcut } from "../../hooks/useSaveShortcut";
+import { EditorHeader, type EditorHeaderSaveReset, type EditorHeaderBackLink, type EditorHeaderUndoRedo } from "../common/EditorHeader";
+import { ServerChangeBanner } from "../common/ServerChangeBanner";
+import { MaturityBadge } from "../process-flow/MaturityBadge";
+import { ValidationBadge } from "../common/ValidationBadge";
+import { checkViewDefinition, type ViewDefinitionIssue, type TableDefinitionForView } from "../../schemas/viewDefinitionValidator";
+import "../../styles/table.css";
+
+// ─── FieldType primitives available for display ──────────────────────────────
+
+const FIELD_TYPE_OPTIONS: FieldTypePrimitive[] = [
+  "string", "integer", "number", "boolean", "date", "datetime", "json",
+];
+
+// ─── FilterOperator options ───────────────────────────────────────────────────
+
+const FILTER_OPERATORS: FilterOperator[] = [
+  "eq", "neq", "gt", "gte", "lt", "lte",
+  "contains", "startsWith", "in", "between",
+];
+
+// ─── BuiltinViewDefinitionKind labels ────────────────────────────────────────
+
+const KIND_LABELS: Record<BuiltinViewDefinitionKind, string> = {
+  list: "list — 一覧",
+  detail: "detail — 詳細",
+  kanban: "kanban — カンバン",
+  calendar: "calendar — カレンダー",
+};
+
+// ─── useTablesForValidator hook ───────────────────────────────────────────────
+
+function useTablesForValidator(): TableDefinitionForView[] {
+  const [tables, setTables] = useState<TableDefinitionForView[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const entries = await listTables();
+      const all = await Promise.all(entries.map((e: TableEntry) => loadTable(e.id)));
+      const valid = all.filter((t): t is Table => t !== null);
+      if (!cancelled) {
+        // Table is shape-compatible with TableDefinitionForView (id / name / physicalName / columns)
+        setTables(valid as unknown as TableDefinitionForView[]);
+      }
+    })().catch(console.error);
+    return () => { cancelled = true; };
+  }, []);
+  return tables;
+}
+
+// ─── TableOption ─────────────────────────────────────────────────────────────
+
+interface TableOption {
+  id: string;
+  name: string;
+  columns: Array<{ id: string; name: string; physicalName: string }>;
+}
+
+function useTableOptions(): TableOption[] {
+  const [options, setOptions] = useState<TableOption[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const entries = await listTables();
+      const tables = await Promise.all(entries.map((e: TableEntry) => loadTable(e.id)));
+      if (!cancelled) {
+        setOptions(
+          tables
+            .filter((t): t is Table => t !== null)
+            .map((t) => ({
+              id: t.id,
+              name: t.name ?? t.physicalName ?? t.id,
+              columns: (t.columns ?? []).map((c) => ({
+                id: c.id,
+                name: c.name ?? c.physicalName ?? c.id,
+                physicalName: c.physicalName ?? c.id,
+              })),
+            })),
+        );
+      }
+    })().catch(console.error);
+    return () => { cancelled = true; };
+  }, []);
+  return options;
+}
+
+// ─── Inline issue display helper ─────────────────────────────────────────────
+
+function IssueHints({ issues }: { issues: ViewDefinitionIssue[] }) {
+  if (issues.length === 0) return null;
+  return (
+    <div className="vd-editor-issue-hints">
+      {issues.map((iss, i) => (
+        <small
+          key={i}
+          className={`vd-editor-issue vd-editor-issue--${iss.severity}`}
+          title={iss.code}
+        >
+          <i className={`bi ${iss.severity === "error" ? "bi-x-circle-fill" : "bi-exclamation-triangle-fill"}`} />
+          {" "}{iss.message}
+        </small>
+      ))}
+    </div>
+  );
+}
+
+// ─── Main Component ───────────────────────────────────────────────────────────
+
+export function ViewDefinitionEditor() {
+  const { viewDefinitionId: rawId } = useParams<{ viewDefinitionId: string }>();
+  const viewDefinitionId = rawId ? decodeURIComponent(rawId) : rawId;
+  const navigate = useNavigate();
+
+  // テーブル選択 state (tableColumnRef 用カスケード)
+  // key: column index → 選択中のテーブル ID (cascade step 1)
+  const [colRefTableIds, setColRefTableIds] = useState<Record<number, string>>({});
+
+  // kind: 拡張参照モード (builtin 以外の場合は true で初期化)
+  const [kindExtMode, setKindExtMode] = useState(false);
+
+  const handleNotFound = useCallback(() => navigate("/view-definition/list"), [navigate]);
+
+  // onLoaded: viewDefinition 読み込み時に UI state を初期化 (useEffect の代わり)
+  const handleLoaded = useCallback((vd: ViewDefinition) => {
+    const builtin = ["list", "detail", "kanban", "calendar"];
+    setKindExtMode(!builtin.includes(vd.kind));
+    const nextIds: Record<number, string> = {};
+    (vd.columns ?? []).forEach((col, i) => {
+      nextIds[i] = (col.tableColumnRef?.tableId as string) || (vd.sourceTableId as string);
+    });
+    setColRefTableIds(nextIds);
+  }, []);
+
+  const {
+    state: viewDefinition,
+    isDirty, isSaving, serverChanged,
+    update, updateSilent, commit, handleSave, handleReset, dismissServerBanner,
+    undo, redo, canUndo, canRedo,
+  } = useResourceEditor<ViewDefinition>({
+    tabType: "view-definition",
+    mtimeKind: "viewDefinition",
+    draftKind: "view-definition",
+    id: viewDefinitionId,
+    load: loadViewDefinition,
+    save: saveViewDefinition,
+    broadcastName: "viewDefinitionChanged",
+    broadcastIdField: "viewDefinitionId",
+    onNotFound: handleNotFound,
+    onLoaded: handleLoaded,
+  });
+
+  useSaveShortcut(() => {
+    if (isDirty && !isSaving) handleSave();
+  });
+
+  useEffect(() => {
+    mcpBridge.startWithoutEditor();
+  }, [viewDefinitionId]);
+
+  // テーブル一覧 (validator 用 & tableColumnRef 選択用)
+  const tables = useTablesForValidator();
+  const tableOptions = useTableOptions();
+
+
+  // リアルタイム validator
+  const issues = useMemo<ViewDefinitionIssue[]>(() => {
+    if (!viewDefinition) return [];
+    return checkViewDefinition(viewDefinition, tables);
+  }, [viewDefinition, tables]);
+
+  const issuesByPath = useMemo<Map<string, ViewDefinitionIssue[]>>(() => {
+    const map = new Map<string, ViewDefinitionIssue[]>();
+    for (const issue of issues) {
+      const list = map.get(issue.path) ?? [];
+      list.push(issue);
+      map.set(issue.path, list);
+    }
+    return map;
+  }, [issues]);
+
+  // issue 集計
+  const errorCount = useMemo(() => issues.filter((i) => i.severity === "error").length, [issues]);
+  const warningCount = useMemo(() => issues.filter((i) => i.severity === "warning").length, [issues]);
+
+  // path ヘルパー
+  const vdId = viewDefinition?.id ?? "";
+
+  function colPath(ci: number, colName: string, field?: string): string {
+    const base = `ViewDefinition[${vdId}].columns[${ci}=${colName}]`;
+    return field ? `${base}.${field}` : base;
+  }
+
+  function sortPath(si: number, field?: string): string {
+    const base = `ViewDefinition[${vdId}].sortDefaults[${si}].columnName`;
+    return field ? `ViewDefinition[${vdId}].sortDefaults[${si}].${field}` : base;
+  }
+
+  function filterPath(fi: number, field: string): string {
+    return `ViewDefinition[${vdId}].filterDefaults[${fi}].${field}`;
+  }
+
+  function getIssues(path: string): ViewDefinitionIssue[] {
+    return issuesByPath.get(path) ?? [];
+  }
+
+  // ─── 読み込み中 ────────────────────────────────────────────────────────────
+  if (!viewDefinition) {
+    return (
+      <div className="table-editor-loading">
+        <i className="bi bi-hourglass-split" /> 読み込み中...
+      </div>
+    );
+  }
+
+  const columnNames = (viewDefinition.columns ?? []).map((c) => c.name as string);
+
+  // ─── columns 操作 ──────────────────────────────────────────────────────────
+
+  const addColumn = () => {
+    const newCol: ViewColumn = {
+      name: "" as Identifier,
+      tableColumnRef: {
+        tableId: viewDefinition.sourceTableId as TableId,
+        columnId: "" as LocalId,
+      },
+      type: "string" as FieldTypePrimitive,
+    };
+    update((d) => { d.columns = [...(d.columns ?? []), newCol]; });
+    setColRefTableIds((prev) => ({
+      ...prev,
+      [viewDefinition.columns.length]: viewDefinition.sourceTableId,
+    }));
+  };
+
+  const removeColumn = (ci: number) => {
+    update((d) => { d.columns = d.columns.filter((_, i) => i !== ci); });
+    setColRefTableIds((prev) => {
+      const next: Record<number, string> = {};
+      Object.entries(prev).forEach(([k, v]) => {
+        const idx = Number(k);
+        if (idx < ci) next[idx] = v;
+        else if (idx > ci) next[idx - 1] = v;
+      });
+      return next;
+    });
+  };
+
+  const moveColumn = (ci: number, direction: "up" | "down") => {
+    const cols = [...(viewDefinition.columns ?? [])];
+    const target = direction === "up" ? ci - 1 : ci + 1;
+    if (target < 0 || target >= cols.length) return;
+    update((d) => {
+      const tmp = d.columns[ci];
+      d.columns[ci] = d.columns[target];
+      d.columns[target] = tmp;
+    });
+    setColRefTableIds((prev) => {
+      const next = { ...prev };
+      const tmp = next[ci];
+      next[ci] = next[target] ?? "";
+      next[target] = tmp ?? "";
+      return next;
+    });
+  };
+
+  const updateColumn = <K extends keyof ViewColumn>(ci: number, field: K, value: ViewColumn[K]) => {
+    update((d) => {
+      d.columns[ci] = { ...d.columns[ci], [field]: value };
+    });
+  };
+
+  // tableColumnRef カスケード: テーブル選択
+  const setColRefTable = (ci: number, tableId: string) => {
+    setColRefTableIds((prev) => ({ ...prev, [ci]: tableId }));
+    update((d) => {
+      d.columns[ci] = {
+        ...d.columns[ci],
+        tableColumnRef: { tableId: tableId as TableId, columnId: "" as LocalId },
+      };
+    });
+  };
+
+  // tableColumnRef カスケード: カラム選択
+  const setColRefColumn = (ci: number, columnId: string) => {
+    const tableId = colRefTableIds[ci] ?? viewDefinition.sourceTableId;
+    update((d) => {
+      d.columns[ci] = {
+        ...d.columns[ci],
+        tableColumnRef: { tableId: tableId as TableId, columnId: columnId as LocalId },
+      };
+    });
+  };
+
+  // ─── sortDefaults 操作 ─────────────────────────────────────────────────────
+
+  const addSortSpec = () => {
+    const spec: SortSpec = { columnName: "" as Identifier, order: "asc" };
+    update((d) => { d.sortDefaults = [...(d.sortDefaults ?? []), spec]; });
+  };
+
+  const removeSortSpec = (si: number) => {
+    update((d) => { d.sortDefaults = (d.sortDefaults ?? []).filter((_, i) => i !== si); });
+  };
+
+  const updateSortSpec = <K extends keyof SortSpec>(si: number, field: K, value: SortSpec[K]) => {
+    update((d) => {
+      const specs = d.sortDefaults ?? [];
+      specs[si] = { ...specs[si], [field]: value };
+      d.sortDefaults = specs;
+    });
+  };
+
+  // ─── filterDefaults 操作 ───────────────────────────────────────────────────
+
+  const addFilterSpec = () => {
+    const spec: FilterSpec = { columnName: "" as Identifier, operator: "eq" };
+    update((d) => { d.filterDefaults = [...(d.filterDefaults ?? []), spec]; });
+  };
+
+  const removeFilterSpec = (fi: number) => {
+    update((d) => { d.filterDefaults = (d.filterDefaults ?? []).filter((_, i) => i !== fi); });
+  };
+
+  const updateFilterSpec = <K extends keyof FilterSpec>(fi: number, field: K, value: FilterSpec[K]) => {
+    update((d) => {
+      const specs = d.filterDefaults ?? [];
+      specs[fi] = { ...specs[fi], [field]: value };
+      d.filterDefaults = specs;
+    });
+  };
+
+  const isBuiltinKind = (k: string): k is BuiltinViewDefinitionKind =>
+    ["list", "detail", "kanban", "calendar"].includes(k);
+
+  // ─── render ───────────────────────────────────────────────────────────────
+
+  return (
+    <div className="table-editor-page">
+      {serverChanged && (
+        <ServerChangeBanner onReload={handleReset} onDismiss={dismissServerBanner} />
+      )}
+
+      <EditorHeader
+        title={
+          <>
+            <i className="bi bi-layout-text-window" /> ビュー定義編集:{" "}
+            <code>{viewDefinition.name || viewDefinition.id}</code>
+          </>
+        }
+        backLink={{
+          label: "ビュー定義一覧",
+          onClick: () => navigate("/view-definition/list"),
+        } satisfies EditorHeaderBackLink}
+        undoRedo={{
+          onUndo: undo,
+          onRedo: redo,
+          canUndo,
+          canRedo,
+        } satisfies EditorHeaderUndoRedo}
+        saveReset={{
+          isDirty,
+          isSaving,
+          onSave: handleSave,
+          onReset: handleReset,
+          resetConfirmMessage: "未保存の変更を破棄してサーバの状態に戻しますか？",
+        } satisfies EditorHeaderSaveReset}
+      />
+
+      {/* 検証サマリーバー */}
+      {(errorCount > 0 || warningCount > 0) && (
+        <div className="vd-editor-issue-bar">
+          {errorCount > 0 && (
+            <ValidationBadge severity="error" count={errorCount} />
+          )}
+          {warningCount > 0 && (
+            <ValidationBadge severity="warning" count={warningCount} />
+          )}
+          <span className="vd-editor-issue-bar-label">
+            検証問題が検出されました。下記の各フィールドを確認してください。
+          </span>
+        </div>
+      )}
+
+      <div className="seq-editor-body">
+        <div className="seq-editor-left-col">
+
+          {/* ───── Section 1: 基本情報 ────────────────────────────────────── */}
+          <section className="seq-editor-section">
+            <h3 className="seq-editor-section-title">基本情報</h3>
+            <div className="seq-editor-grid">
+
+              {/* ID (read-only) */}
+              <label className="tbl-field">
+                <span>ID</span>
+                <input
+                  type="text"
+                  value={viewDefinition.id}
+                  readOnly
+                  className="seq-readonly"
+                  title="ID は変更できません"
+                />
+              </label>
+
+              {/* 表示名 */}
+              <label className="tbl-field">
+                <span>表示名 <span className="vd-editor-required">*</span></span>
+                <input
+                  type="text"
+                  value={viewDefinition.name}
+                  onChange={(e) => updateSilent((d) => { d.name = e.target.value as ViewDefinition["name"]; })}
+                  onBlur={commit}
+                  placeholder="顧客一覧"
+                />
+              </label>
+
+              {/* 説明 */}
+              <label className="tbl-field">
+                <span>説明</span>
+                <textarea
+                  value={viewDefinition.description ?? ""}
+                  onChange={(e) => updateSilent((d) => {
+                    d.description = e.target.value || undefined;
+                  })}
+                  onBlur={commit}
+                  rows={2}
+                  placeholder="このビュー定義の用途を記述..."
+                />
+              </label>
+
+              {/* viewer 種別 */}
+              <div className="tbl-field">
+                <span>viewer 種別 <span className="vd-editor-required">*</span></span>
+                <div className="vd-editor-kind-row">
+                  {!kindExtMode ? (
+                    <select
+                      value={isBuiltinKind(viewDefinition.kind) ? viewDefinition.kind : "list"}
+                      onChange={(e) => update((d) => { d.kind = e.target.value; })}
+                    >
+                      {(Object.entries(KIND_LABELS) as [BuiltinViewDefinitionKind, string][]).map(([v, label]) => (
+                        <option key={v} value={v}>{label}</option>
+                      ))}
+                    </select>
+                  ) : (
+                    <input
+                      type="text"
+                      value={viewDefinition.kind}
+                      onChange={(e) => updateSilent((d) => { d.kind = e.target.value; })}
+                      onBlur={commit}
+                      placeholder="namespace:kindName (例: retail:storefront)"
+                    />
+                  )}
+                  <button
+                    type="button"
+                    className="tbl-btn tbl-btn-ghost tbl-btn-sm"
+                    onClick={() => {
+                      setKindExtMode((v) => !v);
+                      if (kindExtMode) {
+                        update((d) => { d.kind = "list"; });
+                      }
+                    }}
+                    title={kindExtMode ? "組み込み種別に戻す" : "拡張参照を入力"}
+                  >
+                    {kindExtMode ? "組み込みに戻す" : "拡張参照"}
+                  </button>
+                </div>
+              </div>
+
+              {/* ソーステーブル */}
+              <div className="tbl-field">
+                <span>ソーステーブル <span className="vd-editor-required">*</span></span>
+                <select
+                  value={viewDefinition.sourceTableId}
+                  onChange={(e) => update((d) => { d.sourceTableId = e.target.value as TableId; })}
+                  className={getIssues(`ViewDefinition[${vdId}].sourceTableId`).length > 0 ? "input-error" : undefined}
+                >
+                  <option value="">— テーブルを選択 —</option>
+                  {tableOptions.map((t) => (
+                    <option key={t.id} value={t.id}>{t.name}</option>
+                  ))}
+                </select>
+                <IssueHints issues={getIssues(`ViewDefinition[${vdId}].sourceTableId`)} />
+              </div>
+
+              {/* 成熟度 */}
+              <label className="tbl-field">
+                <span>成熟度</span>
+                <div className="vd-editor-maturity-row">
+                  <MaturityBadge
+                    maturity={viewDefinition.maturity}
+                    size="md"
+                    onChange={(m: Maturity) => update((d) => { d.maturity = m; })}
+                  />
+                  <span className="vd-editor-maturity-label">
+                    {viewDefinition.maturity ?? "draft"}
+                  </span>
+                </div>
+              </label>
+
+            </div>
+          </section>
+
+          {/* ───── Section 2: columns 編集 ────────────────────────────────── */}
+          <section className="seq-editor-section">
+            <h3 className="seq-editor-section-title">
+              カラム定義
+              <span className="vd-editor-col-count">
+                ({(viewDefinition.columns ?? []).length} 件)
+              </span>
+            </h3>
+
+            <div className="vd-editor-columns-table-wrap">
+              <table className="vd-editor-columns-table">
+                <thead>
+                  <tr>
+                    <th>name <span className="vd-editor-required">*</span></th>
+                    <th>参照テーブル</th>
+                    <th>参照カラム</th>
+                    <th>表示名</th>
+                    <th>type <span className="vd-editor-required">*</span></th>
+                    <th>書式</th>
+                    <th>幅</th>
+                    <th>align</th>
+                    <th title="ソート可能">sort</th>
+                    <th title="フィルタ可能">filter</th>
+                    <th>linkTo</th>
+                    <th>操作</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(viewDefinition.columns ?? []).map((col, ci) => {
+                    const colName = col.name as string;
+                    const refTableId = colRefTableIds[ci] ?? col.tableColumnRef?.tableId ?? viewDefinition.sourceTableId;
+                    const colOptions = tableOptions.find((t) => t.id === refTableId)?.columns ?? [];
+                    const basePath = colPath(ci, colName);
+                    const colIssues = [
+                      ...getIssues(basePath),
+                      ...getIssues(`${basePath}.tableColumnRef`),
+                      ...getIssues(`${basePath}.type`),
+                    ];
+
+                    return (
+                      <tr key={ci} className={colIssues.some((i) => i.severity === "error") ? "vd-col-row--error" : colIssues.some((i) => i.severity === "warning") ? "vd-col-row--warning" : undefined}>
+                        {/* name */}
+                        <td>
+                          <input
+                            type="text"
+                            value={col.name as string}
+                            onChange={(e) => updateSilent((d) => {
+                              d.columns[ci] = { ...d.columns[ci], name: e.target.value as Identifier };
+                            })}
+                            onBlur={commit}
+                            placeholder="columnName"
+                            className="vd-col-input-sm"
+                            title="camelCase 識別子"
+                          />
+                        </td>
+                        {/* 参照テーブル (cascade step 1) */}
+                        <td>
+                          <select
+                            value={refTableId}
+                            onChange={(e) => setColRefTable(ci, e.target.value)}
+                            className="vd-col-select"
+                          >
+                            <option value="">— テーブル —</option>
+                            {tableOptions.map((t) => (
+                              <option key={t.id} value={t.id}>{t.name}</option>
+                            ))}
+                          </select>
+                        </td>
+                        {/* 参照カラム (cascade step 2) */}
+                        <td>
+                          <select
+                            value={col.tableColumnRef?.columnId ?? ""}
+                            onChange={(e) => setColRefColumn(ci, e.target.value)}
+                            className="vd-col-select"
+                            disabled={!refTableId}
+                          >
+                            <option value="">— カラム —</option>
+                            {colOptions.map((c) => (
+                              <option key={c.id} value={c.id}>{c.name}</option>
+                            ))}
+                          </select>
+                        </td>
+                        {/* displayName */}
+                        <td>
+                          <input
+                            type="text"
+                            value={col.displayName ?? ""}
+                            onChange={(e) => updateSilent((d) => {
+                              d.columns[ci] = {
+                                ...d.columns[ci],
+                                displayName: (e.target.value || undefined) as ViewColumn["displayName"],
+                              };
+                            })}
+                            onBlur={commit}
+                            placeholder="表示名"
+                            className="vd-col-input-sm"
+                          />
+                        </td>
+                        {/* type */}
+                        <td>
+                          <select
+                            value={typeof col.type === "string" ? col.type : "string"}
+                            onChange={(e) => updateColumn(ci, "type", e.target.value as FieldType)}
+                            className="vd-col-select"
+                          >
+                            {FIELD_TYPE_OPTIONS.map((ft) => (
+                              <option key={ft} value={ft}>{ft}</option>
+                            ))}
+                          </select>
+                        </td>
+                        {/* displayFormat */}
+                        <td>
+                          <input
+                            type="text"
+                            value={col.displayFormat ?? ""}
+                            onChange={(e) => updateSilent((d) => {
+                              d.columns[ci] = { ...d.columns[ci], displayFormat: e.target.value || undefined };
+                            })}
+                            onBlur={commit}
+                            placeholder="#,##0"
+                            className="vd-col-input-xs"
+                          />
+                        </td>
+                        {/* width */}
+                        <td>
+                          <input
+                            type="text"
+                            value={col.width ?? ""}
+                            onChange={(e) => updateSilent((d) => {
+                              d.columns[ci] = { ...d.columns[ci], width: e.target.value || undefined };
+                            })}
+                            onBlur={commit}
+                            placeholder="120px"
+                            className="vd-col-input-xs"
+                          />
+                        </td>
+                        {/* align */}
+                        <td>
+                          <select
+                            value={col.align ?? ""}
+                            onChange={(e) => update((d) => {
+                              d.columns[ci] = {
+                                ...d.columns[ci],
+                                align: (e.target.value || undefined) as ViewColumn["align"],
+                              };
+                            })}
+                            className="vd-col-select-xs"
+                          >
+                            <option value="">—</option>
+                            <option value="left">left</option>
+                            <option value="center">center</option>
+                            <option value="right">right</option>
+                          </select>
+                        </td>
+                        {/* sortable */}
+                        <td className="vd-col-center">
+                          <input
+                            type="checkbox"
+                            checked={col.sortable ?? false}
+                            onChange={(e) => update((d) => {
+                              d.columns[ci] = { ...d.columns[ci], sortable: e.target.checked || undefined };
+                            })}
+                          />
+                        </td>
+                        {/* filterable */}
+                        <td className="vd-col-center">
+                          <input
+                            type="checkbox"
+                            checked={col.filterable ?? false}
+                            onChange={(e) => update((d) => {
+                              d.columns[ci] = { ...d.columns[ci], filterable: e.target.checked || undefined };
+                            })}
+                          />
+                        </td>
+                        {/* linkTo */}
+                        <td>
+                          <input
+                            type="text"
+                            value={col.linkTo ?? ""}
+                            onChange={(e) => updateSilent((d) => {
+                              d.columns[ci] = { ...d.columns[ci], linkTo: e.target.value || undefined };
+                            })}
+                            onBlur={commit}
+                            placeholder="/orders/:id"
+                            className="vd-col-input-sm"
+                          />
+                        </td>
+                        {/* 操作 */}
+                        <td className="vd-col-ops">
+                          <button
+                            type="button"
+                            className="tbl-btn-icon"
+                            onClick={() => moveColumn(ci, "up")}
+                            disabled={ci === 0}
+                            title="上に移動"
+                          >
+                            <i className="bi bi-arrow-up" />
+                          </button>
+                          <button
+                            type="button"
+                            className="tbl-btn-icon"
+                            onClick={() => moveColumn(ci, "down")}
+                            disabled={ci === (viewDefinition.columns?.length ?? 0) - 1}
+                            title="下に移動"
+                          >
+                            <i className="bi bi-arrow-down" />
+                          </button>
+                          <button
+                            type="button"
+                            className="tbl-btn-icon danger"
+                            onClick={() => removeColumn(ci)}
+                            title="削除"
+                          >
+                            <i className="bi bi-trash" />
+                          </button>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+
+            {/* 列ごとの issue 表示 */}
+            {(viewDefinition.columns ?? []).map((col, ci) => {
+              const colName = col.name as string;
+              const basePath = colPath(ci, colName);
+              const colIssues = [
+                ...getIssues(basePath),
+                ...getIssues(`${basePath}.tableColumnRef`),
+                ...getIssues(`${basePath}.type`),
+              ];
+              if (colIssues.length === 0) return null;
+              return (
+                <div key={ci} className="vd-editor-col-issues">
+                  <span className="vd-editor-col-issues-label">
+                    カラム {ci + 1} ({colName || "未設定"}):
+                  </span>
+                  <IssueHints issues={colIssues} />
+                </div>
+              );
+            })}
+
+            <button
+              type="button"
+              className="tbl-btn tbl-btn-ghost vd-editor-add-row-btn"
+              onClick={addColumn}
+            >
+              <i className="bi bi-plus-lg" /> カラム追加
+            </button>
+          </section>
+
+          {/* ───── Section 3: sortDefaults ────────────────────────────────── */}
+          <section className="seq-editor-section">
+            <h3 className="seq-editor-section-title">
+              既定ソート順
+              <span className="vd-editor-col-count">({(viewDefinition.sortDefaults ?? []).length} 件)</span>
+            </h3>
+
+            {(viewDefinition.sortDefaults ?? []).length > 0 && (
+              <table className="vd-editor-sub-table">
+                <thead>
+                  <tr>
+                    <th>カラム名</th>
+                    <th>順序</th>
+                    <th>操作</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(viewDefinition.sortDefaults ?? []).map((spec, si) => {
+                    const siIssues = getIssues(sortPath(si));
+                    return (
+                      <tr key={si} className={siIssues.some((i) => i.severity === "error") ? "vd-col-row--error" : undefined}>
+                        <td>
+                          <select
+                            value={spec.columnName as string}
+                            onChange={(e) => updateSortSpec(si, "columnName", e.target.value as Identifier)}
+                            className={siIssues.length > 0 ? "input-error" : undefined}
+                          >
+                            <option value="">— カラムを選択 —</option>
+                            {columnNames.map((cn) => (
+                              <option key={cn} value={cn}>{cn}</option>
+                            ))}
+                          </select>
+                          <IssueHints issues={siIssues} />
+                        </td>
+                        <td>
+                          <select
+                            value={spec.order}
+                            onChange={(e) => updateSortSpec(si, "order", e.target.value as "asc" | "desc")}
+                          >
+                            <option value="asc">asc (昇順)</option>
+                            <option value="desc">desc (降順)</option>
+                          </select>
+                        </td>
+                        <td>
+                          <button
+                            type="button"
+                            className="tbl-btn-icon danger"
+                            onClick={() => removeSortSpec(si)}
+                            title="削除"
+                          >
+                            <i className="bi bi-trash" />
+                          </button>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            )}
+
+            <button
+              type="button"
+              className="tbl-btn tbl-btn-ghost vd-editor-add-row-btn"
+              onClick={addSortSpec}
+            >
+              <i className="bi bi-plus-lg" /> ソート条件追加
+            </button>
+          </section>
+
+          {/* ───── Section 4: filterDefaults ─────────────────────────────── */}
+          <section className="seq-editor-section">
+            <h3 className="seq-editor-section-title">
+              初期フィルタ
+              <span className="vd-editor-col-count">({(viewDefinition.filterDefaults ?? []).length} 件)</span>
+            </h3>
+
+            {(viewDefinition.filterDefaults ?? []).length > 0 && (
+              <table className="vd-editor-sub-table">
+                <thead>
+                  <tr>
+                    <th>カラム名</th>
+                    <th>演算子</th>
+                    <th>値</th>
+                    <th>値 (式)</th>
+                    <th>操作</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(viewDefinition.filterDefaults ?? []).map((spec, fi) => {
+                    const colIssues = getIssues(filterPath(fi, "columnName"));
+                    const opIssues = getIssues(filterPath(fi, "operator"));
+                    return (
+                      <tr
+                        key={fi}
+                        className={
+                          [...colIssues, ...opIssues].some((i) => i.severity === "error")
+                            ? "vd-col-row--error"
+                            : [...colIssues, ...opIssues].some((i) => i.severity === "warning")
+                              ? "vd-col-row--warning"
+                              : undefined
+                        }
+                      >
+                        <td>
+                          <select
+                            value={spec.columnName as string}
+                            onChange={(e) => updateFilterSpec(fi, "columnName", e.target.value as Identifier)}
+                            className={colIssues.length > 0 ? "input-error" : undefined}
+                          >
+                            <option value="">— カラムを選択 —</option>
+                            {columnNames.map((cn) => (
+                              <option key={cn} value={cn}>{cn}</option>
+                            ))}
+                          </select>
+                          <IssueHints issues={colIssues} />
+                        </td>
+                        <td>
+                          <select
+                            value={spec.operator}
+                            onChange={(e) => updateFilterSpec(fi, "operator", e.target.value as FilterOperator)}
+                            className={opIssues.length > 0 ? "input-error" : undefined}
+                          >
+                            {FILTER_OPERATORS.map((op) => (
+                              <option key={op} value={op}>{op}</option>
+                            ))}
+                          </select>
+                          <IssueHints issues={opIssues} />
+                        </td>
+                        <td>
+                          <input
+                            type="text"
+                            value={typeof spec.value === "string" ? spec.value : spec.value != null ? String(spec.value) : ""}
+                            onChange={(e) => updateSilent((d) => {
+                              const specs = d.filterDefaults ?? [];
+                              specs[fi] = { ...specs[fi], value: e.target.value || undefined };
+                              d.filterDefaults = specs;
+                            })}
+                            onBlur={commit}
+                            placeholder="比較値"
+                            className="vd-col-input-sm"
+                          />
+                        </td>
+                        <td>
+                          <input
+                            type="text"
+                            value={spec.valueExpression ?? ""}
+                            onChange={(e) => updateSilent((d) => {
+                              const specs = d.filterDefaults ?? [];
+                              specs[fi] = { ...specs[fi], valueExpression: (e.target.value || undefined) as FilterSpec["valueExpression"] };
+                              d.filterDefaults = specs;
+                            })}
+                            onBlur={commit}
+                            placeholder="@conv.numbering.threshold"
+                            className="vd-col-input-sm"
+                          />
+                        </td>
+                        <td>
+                          <button
+                            type="button"
+                            className="tbl-btn-icon danger"
+                            onClick={() => removeFilterSpec(fi)}
+                            title="削除"
+                          >
+                            <i className="bi bi-trash" />
+                          </button>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            )}
+
+            <button
+              type="button"
+              className="tbl-btn tbl-btn-ghost vd-editor-add-row-btn"
+              onClick={addFilterSpec}
+            >
+              <i className="bi bi-plus-lg" /> フィルタ条件追加
+            </button>
+          </section>
+
+          {/* ───── Section 5: その他 ─────────────────────────────────────── */}
+          <section className="seq-editor-section">
+            <h3 className="seq-editor-section-title">その他</h3>
+            <div className="seq-editor-grid">
+
+              {/* pageSize */}
+              <label className="tbl-field">
+                <span>ページサイズ <small>(1..1000)</small></span>
+                <input
+                  type="number"
+                  value={viewDefinition.pageSize ?? ""}
+                  min={1}
+                  max={1000}
+                  onChange={(e) => {
+                    const v = e.target.value ? Number(e.target.value) : undefined;
+                    update((d) => { d.pageSize = v; });
+                  }}
+                  placeholder="20"
+                  className="vd-editor-number-input"
+                />
+              </label>
+
+              {/* groupBy */}
+              <div className="tbl-field">
+                <span>groupBy</span>
+                <select
+                  value={viewDefinition.groupBy ?? ""}
+                  onChange={(e) => update((d) => {
+                    d.groupBy = (e.target.value || undefined) as Identifier | undefined;
+                  })}
+                  className={getIssues(`ViewDefinition[${vdId}].groupBy`).length > 0 ? "input-error" : undefined}
+                >
+                  <option value="">— なし —</option>
+                  {columnNames.map((cn) => (
+                    <option key={cn} value={cn}>{cn}</option>
+                  ))}
+                </select>
+                <IssueHints issues={getIssues(`ViewDefinition[${vdId}].groupBy`)} />
+              </div>
+
+            </div>
+          </section>
+
+        </div>{/* seq-editor-left-col */}
+      </div>
+    </div>
+  );
+}

--- a/designer/src/components/view-definition/ViewDefinitionListView.tsx
+++ b/designer/src/components/view-definition/ViewDefinitionListView.tsx
@@ -1,0 +1,781 @@
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import type {
+  ViewDefinition,
+  ViewDefinitionEntry,
+  ViewDefinitionId,
+  ViewDefinitionKind,
+  DisplayName,
+  TableId,
+  Timestamp,
+} from "../../types/v3";
+import {
+  listViewDefinitions,
+  createViewDefinition,
+  deleteViewDefinition,
+  loadViewDefinition,
+  saveViewDefinition,
+  loadViewDefinitionValidationMap,
+} from "../../store/viewDefinitionStore";
+import { listTables } from "../../store/tableStore";
+import { loadProject, saveProject } from "../../store/flowStore";
+import { generateUUID } from "../../utils/uuid";
+import { mcpBridge } from "../../mcp/mcpBridge";
+import { makeTabId, openTab } from "../../store/tabStore";
+import { MaturityBadge } from "../process-flow/MaturityBadge";
+import { DataList, type DataListColumn } from "../common/DataList";
+import { FilterBar } from "../common/FilterBar";
+import { SortBar } from "../common/SortBar";
+import { ListContextMenu, type ContextMenuItem } from "../common/ListContextMenu";
+import { ViewModeToggle, type ViewMode } from "../common/ViewModeToggle";
+import { ValidationBadge } from "../common/ValidationBadge";
+import { useListSelection } from "../../hooks/useListSelection";
+import { useListClipboard } from "../../hooks/useListClipboard";
+import { useListKeyboard } from "../../hooks/useListKeyboard";
+import { useListFilter } from "../../hooks/useListFilter";
+import { useListSort } from "../../hooks/useListSort";
+import { useListEditor } from "../../hooks/useListEditor";
+import { usePersistentState } from "../../hooks/usePersistentState";
+import { renumber } from "../../utils/listOrder";
+import type { TableEntry } from "../../types/v3";
+import "../../styles/table.css";
+
+const STORAGE_KEY = "list-view-mode:view-definition-list";
+const TAB_ID = makeTabId("view-definition-list", "main");
+
+interface CommitViewDefinitionsDeps {
+  loadProject: typeof loadProject;
+  saveProject: typeof saveProject;
+  deleteViewDefinition: typeof deleteViewDefinition;
+}
+
+export async function commitViewDefinitions(
+  { itemsInOrder, deletedIds }: { itemsInOrder: ViewDefinitionEntry[]; deletedIds: string[] },
+  deps: CommitViewDefinitionsDeps = { loadProject, saveProject, deleteViewDefinition },
+): Promise<void> {
+  const project = await deps.loadProject();
+  const deletedSet = new Set(deletedIds);
+  const orderMap = new Map(itemsInOrder.map((v, i) => [v.id, i]));
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const p = project as any;
+  p.viewDefinitions = (p.viewDefinitions ?? [])
+    .filter((v: ViewDefinitionEntry) => !deletedSet.has(String(v.id)))
+    .sort(
+      (a: ViewDefinitionEntry, b: ViewDefinitionEntry) =>
+        (orderMap.get(a.id) ?? Number.MAX_SAFE_INTEGER) -
+        (orderMap.get(b.id) ?? Number.MAX_SAFE_INTEGER),
+    )
+    .map((v: ViewDefinitionEntry, i: number) => ({ ...v, no: i + 1 }));
+  await deps.saveProject(p);
+  for (const id of deletedIds) {
+    await deps.deleteViewDefinition(id);
+  }
+}
+
+interface ValidationSummary {
+  errors: number;
+  warnings: number;
+}
+
+const KIND_LABELS: Record<string, string> = {
+  list: "一覧",
+  detail: "詳細",
+  kanban: "カンバン",
+  calendar: "カレンダー",
+};
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString("ja-JP");
+  } catch {
+    return iso;
+  }
+}
+
+export function ViewDefinitionListView() {
+  const navigate = useNavigate();
+  const [query, setQuery] = useState("");
+  const [viewMode, setViewMode] = usePersistentState<ViewMode>(STORAGE_KEY, "card");
+  const [showAdd, setShowAdd] = useState(false);
+  const [addName, setAddName] = useState("");
+  const [addKind, setAddKind] = useState<ViewDefinitionKind>("list");
+  const [addSourceTableId, setAddSourceTableId] = useState("");
+  const [addDescription, setAddDescription] = useState("");
+  const [addNameError, setAddNameError] = useState("");
+  const [addSourceTableError, setAddSourceTableError] = useState("");
+  const [tableList, setTableList] = useState<TableEntry[]>([]);
+  const [tableNameMap, setTableNameMap] = useState<Map<string, string>>(new Map());
+  const [contextMenu, setContextMenu] = useState<{ x: number; y: number; items: ContextMenuItem[] } | null>(null);
+  const [validationMap, setValidationMap] = useState<Map<string, ValidationSummary>>(new Map());
+
+  // テーブル一覧を初期ロード
+  useEffect(() => {
+    listTables()
+      .then((tables) => {
+        setTableList(tables);
+        const map = new Map<string, string>();
+        for (const t of tables) {
+          map.set(t.id, t.name);
+        }
+        setTableNameMap(map);
+      })
+      .catch(console.error);
+  }, []);
+
+  const loadViewDefs = useCallback(async () => {
+    mcpBridge.startWithoutEditor();
+    await loadProject();
+    return await listViewDefinitions();
+  }, []);
+
+  const editor = useListEditor<ViewDefinitionEntry>({
+    getId: (v) => String(v.id),
+    load: loadViewDefs,
+    commit: commitViewDefinitions,
+    tabId: TAB_ID,
+    renumber,
+  });
+
+  useEffect(() => {
+    editor.reload();
+    const unsubStatus = mcpBridge.onStatusChange((s) => {
+      if (s === "connected" && !editor.isDirty) editor.reload();
+    });
+    const unsubVd = mcpBridge.onBroadcast("viewDefinitionChanged", () => {
+      if (!editor.isDirty) editor.reload();
+    });
+    const unsubProj = mcpBridge.onBroadcast("projectChanged", () => {
+      if (!editor.isDirty) editor.reload();
+    });
+    return () => { unsubStatus(); unsubVd(); unsubProj(); };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const allViewDefs = editor.items;
+
+  useEffect(() => {
+    if (allViewDefs.length === 0) {
+      setValidationMap(new Map());
+      return;
+    }
+    let cancelled = false;
+    loadViewDefinitionValidationMap()
+      .then((map) => {
+        if (cancelled) return;
+        const next = new Map<string, ValidationSummary>();
+        for (const [id, issues] of map) {
+          next.set(String(id), {
+            errors: issues.filter((e) => e.severity === "error").length,
+            warnings: issues.filter((e) => e.severity === "warning").length,
+          });
+        }
+        setValidationMap(next);
+      })
+      .catch(console.error);
+    return () => { cancelled = true; };
+  }, [allViewDefs]);
+
+  const getErrorPriority = useCallback((id: string): number => {
+    const v = validationMap.get(id);
+    if (!v) return 0;
+    if (v.errors > 0) return 2;
+    if (v.warnings > 0) return 1;
+    return 0;
+  }, [validationMap]);
+
+  const filter = useListFilter(allViewDefs);
+  useEffect(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) {
+      filter.applyFilter(null);
+      return;
+    }
+    filter.applyFilter((v) =>
+      v.name.toLowerCase().includes(q) ||
+      (v.kind ?? "").toLowerCase().includes(q) ||
+      (tableNameMap.get(String(v.sourceTableId ?? "")) ?? "").toLowerCase().includes(q),
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query, tableNameMap]);
+
+  const sortAccessor = useCallback((v: ViewDefinitionEntry, key: string): string | number => {
+    switch (key) {
+      case "name": return v.name;
+      case "kind": return v.kind ?? "";
+      case "sourceTableId": return tableNameMap.get(String(v.sourceTableId ?? "")) ?? "";
+      case "columnCount": return v.columnCount ?? 0;
+      case "updatedAt": return v.updatedAt;
+      default: return "";
+    }
+  }, [tableNameMap]);
+
+  const sort = useListSort(filter.filtered, sortAccessor);
+  const selection = useListSelection(sort.sorted, (v) => String(v.id));
+  const clipboard = useListClipboard<ViewDefinitionEntry>((v) => String(v.id));
+
+  const handleActivate = useCallback((v: ViewDefinitionEntry) => {
+    if (editor.isDeleted(String(v.id))) return;
+    navigate(`/view-definition/edit/${encodeURIComponent(String(v.id))}`);
+  }, [navigate, editor]);
+
+  const handleDelete = (items: ViewDefinitionEntry[]) => {
+    editor.markDeleted(items.map((v) => String(v.id)));
+  };
+
+  const handleDuplicate = async (items: ViewDefinitionEntry[]) => {
+    const newIds: string[] = [];
+    for (const m of items) {
+      const full = await loadViewDefinition(String(m.id));
+      if (!full) continue;
+      const ts = new Date().toISOString() as Timestamp;
+      const newId = generateUUID() as ViewDefinitionId;
+      const completed: ViewDefinition = {
+        ...full,
+        id: newId,
+        name: `${full.name} のコピー` as DisplayName,
+        createdAt: ts,
+        updatedAt: ts,
+      };
+      await saveViewDefinition(completed);
+      newIds.push(String(newId));
+    }
+    await editor.reload();
+    if (newIds.length > 0) selection.setSelectedIds(new Set<string>(newIds));
+  };
+
+  const handlePaste = async (insertIdx: number | null) => {
+    const mode = clipboard.clipboard.mode;
+    const clipItems = clipboard.clipboard.items;
+    if (!clipItems.length) return;
+
+    if (mode === "cut") {
+      const cutIds = new Set<string>(clipItems.map((c) => String(c.id)));
+      const selIds = selection.selectedIds;
+      const sameSet = selIds.size === cutIds.size && [...selIds].every((id) => cutIds.has(id));
+      if (sameSet) return;
+
+      clipboard.consume();
+      const moved = clipItems;
+      const pos0 = insertIdx ?? editor.items.length;
+      const removedBefore = editor.items.slice(0, pos0).filter((v) => cutIds.has(String(v.id))).length;
+      const remaining = editor.items.filter((v) => !cutIds.has(String(v.id)));
+      const pos = Math.min(remaining.length, pos0 - removedBefore);
+      editor.setItems(() => {
+        const next = [...remaining];
+        next.splice(pos, 0, ...moved);
+        return renumber(next);
+      });
+      selection.setSelectedIds(new Set<string>(moved.map((v) => String(v.id))));
+    } else {
+      await handleDuplicate(clipItems);
+      clipboard.consume();
+    }
+  };
+
+  const handleReorder = (fromIdx: number, toIdx: number) => {
+    const visible = sort.sorted;
+    const fromId = visible[fromIdx] ? String(visible[fromIdx].id) : undefined;
+    const toId = visible[toIdx] ? String(visible[toIdx].id) : undefined;
+    if (!fromId || !toId) return;
+    const realFrom = editor.items.findIndex((v) => String(v.id) === fromId);
+    const realTo = editor.items.findIndex((v) => String(v.id) === toId);
+    if (realFrom < 0 || realTo < 0) return;
+    editor.reorder(realFrom, realTo);
+  };
+
+  const moveBlock = (items: ViewDefinitionEntry[], direction: "up" | "down") => {
+    const ids = new Set(items.map((v) => String(v.id)));
+    const idxs = editor.items
+      .map((v, i) => (ids.has(String(v.id)) ? i : -1))
+      .filter((i) => i >= 0)
+      .sort((a, b) => a - b);
+    if (idxs.length === 0) return;
+    if (direction === "up") {
+      if (idxs[0] === 0) return;
+      editor.setItems((prev) => {
+        const next = [...prev];
+        const [moved] = next.splice(idxs[0] - 1, 1);
+        next.splice(idxs[idxs.length - 1], 0, moved);
+        return renumber(next);
+      });
+    } else {
+      if (idxs[idxs.length - 1] === editor.items.length - 1) return;
+      editor.setItems((prev) => {
+        const next = [...prev];
+        const [moved] = next.splice(idxs[idxs.length - 1] + 1, 1);
+        next.splice(idxs[0], 0, moved);
+        return renumber(next);
+      });
+    }
+  };
+
+  const sortActive = sort.sortKeys.length > 0;
+
+  const columnLabels = useMemo<Record<string, string>>(() => ({
+    name: "表示名",
+    kind: "種別",
+    sourceTableId: "ソーステーブル",
+    columnCount: "カラム数",
+    updatedAt: "更新日",
+  }), []);
+
+  const resetAddForm = () => {
+    setAddName("");
+    setAddKind("list");
+    setAddSourceTableId("");
+    setAddDescription("");
+    setAddNameError("");
+    setAddSourceTableError("");
+  };
+
+  const handleAdd = async () => {
+    const name = addName.trim();
+    const sourceTableId = addSourceTableId.trim();
+    let hasError = false;
+    if (!name) {
+      setAddNameError("表示名は必須です");
+      hasError = true;
+    }
+    if (!sourceTableId) {
+      setAddSourceTableError("ソーステーブルは必須です");
+      hasError = true;
+    }
+    if (hasError) return;
+
+    const vd = await createViewDefinition(
+      name as DisplayName,
+      addKind as ViewDefinitionKind,
+      sourceTableId as TableId,
+      addDescription.trim() || undefined,
+    );
+    setShowAdd(false);
+    resetAddForm();
+    openTab({
+      id: makeTabId("view-definition", String(vd.id)),
+      type: "view-definition",
+      resourceId: String(vd.id),
+      label: vd.name,
+    });
+    navigate(`/view-definition/edit/${encodeURIComponent(String(vd.id))}`);
+  };
+
+  const buildMenuItems = (target: ViewDefinitionEntry | null): ContextMenuItem[] => {
+    const hasSelection = selection.selectedIds.size > 0 || target !== null;
+    const pasteBlocked = sortActive || !clipboard.hasContent;
+    const pasteReason = sortActive ? "ソート中は無効 (ソート解除で利用可能)" : "クリップボードが空";
+    const sortReason = "ソート中は無効 (ソート解除で利用可能)";
+
+    if (target === null && selection.selectedIds.size === 0) {
+      return [
+        {
+          key: "new", label: "新規作成", icon: "bi-plus-lg",
+          disabled: sortActive, disabledReason: sortReason,
+          onClick: () => setShowAdd(true),
+        },
+      ];
+    }
+
+    const items = target && !selection.isSelected(String(target.id))
+      ? [target]
+      : selection.selectedItems;
+
+    return [
+      {
+        key: "new", label: "新規作成", icon: "bi-plus-lg",
+        disabled: sortActive, disabledReason: sortReason,
+        onClick: () => setShowAdd(true),
+      },
+      { key: "sep1", separator: true },
+      {
+        key: "copy", label: "コピー", icon: "bi-files", shortcut: "Ctrl+C",
+        disabled: !hasSelection,
+        onClick: () => { if (items.length > 0) clipboard.copy(items); },
+      },
+      {
+        key: "cut", label: "切り取り", icon: "bi-scissors", shortcut: "Ctrl+X",
+        disabled: !hasSelection,
+        onClick: () => { if (items.length > 0) clipboard.cut(items); },
+      },
+      {
+        key: "paste", label: "貼り付け", icon: "bi-clipboard", shortcut: "Ctrl+V",
+        disabled: pasteBlocked, disabledReason: pasteBlocked && sortActive ? sortReason : pasteReason,
+        onClick: () => {
+          const ids = Array.from(selection.selectedIds);
+          const allIds: string[] = editor.items.map((v) => String(v.id));
+          const insertIndex = ids.length > 0
+            ? Math.max(...ids.map((id) => allIds.indexOf(id))) + 1
+            : null;
+          handlePaste(insertIndex).catch(console.error);
+        },
+      },
+      { key: "sep2", separator: true },
+      {
+        key: "duplicate", label: "複製", icon: "bi-copy", shortcut: "Ctrl+D",
+        disabled: !hasSelection || sortActive,
+        disabledReason: sortActive ? sortReason : undefined,
+        onClick: () => { if (items.length > 0) handleDuplicate(items).catch(console.error); },
+      },
+      { key: "sep3", separator: true },
+      {
+        key: "delete", label: "削除", icon: "bi-trash", shortcut: "Delete",
+        disabled: !hasSelection, danger: true,
+        onClick: () => { if (items.length > 0) handleDelete(items); },
+      },
+    ];
+  };
+
+  const handleContextMenu = (e: React.MouseEvent, target: ViewDefinitionEntry | null) => {
+    setContextMenu({ x: e.clientX, y: e.clientY, items: buildMenuItems(target) });
+  };
+
+  const handleContextMenuKey = (first: ViewDefinitionEntry | null, rect: DOMRect | null) => {
+    if (first && !selection.isSelected(String(first.id))) {
+      selection.setSelectedIds(new Set<string>([String(first.id)]));
+    }
+    const x = rect ? rect.left : 100;
+    const y = rect ? rect.bottom : 100;
+    setContextMenu({ x, y, items: buildMenuItems(first) });
+  };
+
+  const handleRowDelete = (v: ViewDefinitionEntry) => {
+    handleDelete([v]);
+  };
+
+  useListKeyboard({
+    items: sort.sorted,
+    getId: (v) => String(v.id),
+    selection,
+    clipboard,
+    sort,
+    layout: viewMode === "card" ? "grid" : "list",
+    onActivate: handleActivate,
+    onDelete: handleDelete,
+    onDuplicate: (items) => { handleDuplicate(items).catch(console.error); },
+    onMoveUp: (items) => moveBlock(items, "up"),
+    onMoveDown: (items) => moveBlock(items, "down"),
+    onPaste: (idx) => { handlePaste(idx).catch(console.error); },
+    onContextMenuKey: handleContextMenuKey,
+  });
+
+  const handleSave = () => {
+    editor.save().catch(console.error);
+    selection.clearSelection();
+  };
+
+  const handleReset = () => {
+    if (!confirm("未保存の変更を破棄してサーバの状態に戻しますか？")) return;
+    editor.reset().catch(console.error);
+    selection.clearSelection();
+  };
+
+  const columns = useMemo<DataListColumn<ViewDefinitionEntry>[]>(() => [
+    {
+      key: "name",
+      header: "表示名",
+      sortable: true,
+      sortAccessor: (v) => v.name,
+      render: (v) => <span>{v.name}</span>,
+    },
+    {
+      key: "kind",
+      header: "種別",
+      width: "110px",
+      sortable: true,
+      sortAccessor: (v) => v.kind ?? "",
+      render: (v) => v.kind
+        ? (
+          <span className="vd-kind-badge">
+            {KIND_LABELS[v.kind] ?? v.kind}
+          </span>
+        )
+        : null,
+    },
+    {
+      key: "sourceTableId",
+      header: "ソーステーブル",
+      sortable: true,
+      sortAccessor: (v) => tableNameMap.get(String(v.sourceTableId ?? "")) ?? "",
+      render: (v) => {
+        const tblName = tableNameMap.get(String(v.sourceTableId ?? ""));
+        return tblName
+          ? <code className="seq-list-name-code">{tblName}</code>
+          : v.sourceTableId
+            ? <code className="seq-list-name-code vd-unknown-table">{String(v.sourceTableId)}</code>
+            : null;
+      },
+    },
+    {
+      key: "columnCount",
+      header: "カラム数",
+      width: "90px",
+      align: "center",
+      sortable: true,
+      sortAccessor: (v) => v.columnCount ?? 0,
+      render: (v) => <span>{v.columnCount ?? 0}</span>,
+    },
+    {
+      key: "maturity",
+      header: "成熟度",
+      width: "80px",
+      align: "center",
+      sortable: true,
+      sortAccessor: (v) => {
+        const order: Record<string, number> = { draft: 0, provisional: 1, committed: 2 };
+        return order[v.maturity ?? "draft"] ?? 0;
+      },
+      render: (v) => <MaturityBadge maturity={v.maturity} />,
+    },
+    {
+      key: "validation",
+      header: "検証",
+      width: "100px",
+      align: "center",
+      sortable: true,
+      sortAccessor: (v) => getErrorPriority(String(v.id)),
+      render: (v) => {
+        const validation = validationMap.get(String(v.id));
+        if (!validation) return null;
+        if (validation.errors > 0) {
+          return <ValidationBadge severity="error" count={validation.errors} />;
+        }
+        if (validation.warnings > 0) {
+          return <ValidationBadge severity="warning" count={validation.warnings} />;
+        }
+        return <i className="bi bi-check-lg view-validation-ok" title="問題なし" />;
+      },
+    },
+    {
+      key: "updatedAt",
+      header: "更新日",
+      width: "120px",
+      sortable: true,
+      sortAccessor: (v) => v.updatedAt,
+      render: (v) => <span className="seq-list-date">{formatDate(v.updatedAt)}</span>,
+    },
+  ], [getErrorPriority, validationMap, tableNameMap]);
+
+  const renderCard = (v: ViewDefinitionEntry) => {
+    const validation = validationMap.get(String(v.id));
+    const hasError = (validation?.errors ?? 0) > 0;
+    const hasWarning = (validation?.warnings ?? 0) > 0;
+    const tblName = tableNameMap.get(String(v.sourceTableId ?? ""));
+    return (
+      <div className={`seq-card-content${hasError ? " has-error" : hasWarning ? " has-warning" : ""}`}>
+        <div className="seq-card-header">
+          <MaturityBadge maturity={v.maturity} />
+          <span className="seq-card-name">{v.name}</span>
+          {v.kind && (
+            <span className="vd-kind-badge vd-kind-badge--card">
+              {KIND_LABELS[v.kind] ?? v.kind}
+            </span>
+          )}
+          {validation && (hasError || hasWarning) && (
+            <span className="view-validation-badges">
+              <ValidationBadge severity="error" count={validation.errors} />
+              <ValidationBadge severity="warning" count={validation.warnings} />
+            </span>
+          )}
+        </div>
+        {tblName && (
+          <div className="seq-card-description">
+            <i className="bi bi-table" /> <code>{tblName}</code>
+            {v.columnCount !== undefined && (
+              <span className="vd-col-count"> ({v.columnCount} 列)</span>
+            )}
+          </div>
+        )}
+        <div className="seq-card-meta">
+          <span className="seq-card-date">{formatDate(v.updatedAt)}</span>
+        </div>
+      </div>
+    );
+  };
+
+  const selectedCount = selection.selectedIds.size;
+  const deletedCount = editor.deletedIds.size;
+
+  return (
+    <div className="table-list-page">
+      <div className="table-list-content">
+        <div className="table-list-header">
+          <h2 className="table-list-title">
+            <i className="bi bi-layout-text-window" /> ビュー定義一覧
+            <span className="table-list-count">
+              {allViewDefs.length - deletedCount} 件{deletedCount > 0 ? ` (削除予定 ${deletedCount})` : ""}
+            </span>
+          </h2>
+          <div className="table-list-actions">
+            <div className="table-list-search">
+              <i className="bi bi-search" />
+              <input
+                type="text"
+                placeholder="表示名・種別・テーブル名で絞り込み..."
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+              />
+              {query && (
+                <button className="clear-btn" onClick={() => setQuery("")} title="クリア">
+                  <i className="bi bi-x-circle-fill" />
+                </button>
+              )}
+            </div>
+            <ViewModeToggle mode={viewMode} onChange={setViewMode} storageKey={STORAGE_KEY} />
+            <button
+              className="tbl-btn tbl-btn-primary"
+              onClick={() => setShowAdd(true)}
+              disabled={sortActive}
+              title={sortActive ? "ソート中は無効 (ソート解除で利用可能)" : undefined}
+            >
+              <i className="bi bi-plus-lg" /> ビュー定義追加
+            </button>
+            <button
+              className="tbl-btn tbl-btn-ghost danger"
+              onClick={() => handleDelete(selection.selectedItems)}
+              disabled={selectedCount === 0}
+              title="削除 (Delete)"
+            >
+              <i className="bi bi-trash" /> 削除{selectedCount > 0 ? ` (${selectedCount})` : ""}
+            </button>
+            <span className="tbl-saveline-sep" />
+            <button
+              className="tbl-btn tbl-btn-ghost"
+              data-testid="list-reset-btn"
+              onClick={handleReset}
+              disabled={!editor.isDirty || editor.isSaving}
+              title="変更を破棄"
+            >
+              <i className="bi bi-arrow-counterclockwise" /> リセット
+            </button>
+            <button
+              className="tbl-btn tbl-btn-primary"
+              data-testid="list-save-btn"
+              onClick={handleSave}
+              disabled={!editor.isDirty || editor.isSaving}
+              title="変更を保存"
+            >
+              <i className="bi bi-save" /> {editor.isSaving ? "保存中..." : "保存"}
+            </button>
+          </div>
+        </div>
+
+        <FilterBar
+          isActive={filter.isActive}
+          totalCount={filter.totalCount}
+          visibleCount={filter.visibleCount}
+          label={query ? `検索: "${query}"` : undefined}
+          onClear={() => { setQuery(""); filter.clearFilter(); }}
+        />
+
+        <SortBar sort={sort} columnLabels={columnLabels} />
+
+        <DataList
+          items={sort.sorted}
+          columns={columns}
+          getId={(v) => String(v.id)}
+          getNo={(v) => v.no}
+          onRowDelete={handleRowDelete}
+          onContextMenu={handleContextMenu}
+          selection={selection}
+          clipboard={clipboard}
+          sort={sort}
+          onActivate={handleActivate}
+          onReorder={handleReorder}
+          layout={viewMode === "card" ? "grid" : "list"}
+          renderCard={renderCard}
+          showNumColumn={viewMode === "table"}
+          variant="dark"
+          className="view-definitions-data-list"
+          isItemGhost={(id) => editor.isDeleted(id)}
+          emptyMessage={
+            query
+              ? <p>該当するビュー定義がありません</p>
+              : <p>ビュー定義がまだありません。「ビュー定義追加」から作成してください。</p>
+          }
+        />
+
+        {showAdd && (
+          <div
+            className="tbl-modal-overlay"
+            onClick={() => { setShowAdd(false); resetAddForm(); }}
+          >
+            <div className="tbl-modal" onClick={(e) => e.stopPropagation()}>
+              <div className="tbl-modal-title">ビュー定義追加</div>
+              <label className="tbl-field">
+                <span>表示名</span>
+                <input
+                  type="text"
+                  value={addName}
+                  onChange={(e) => { setAddName(e.target.value); setAddNameError(""); }}
+                  placeholder="顧客一覧"
+                  autoFocus
+                  className={addNameError ? "input-error" : undefined}
+                  onKeyDown={(e) => { if (e.key === "Enter") handleAdd(); }}
+                />
+                {addNameError && <span className="tbl-field-error">{addNameError}</span>}
+              </label>
+              <label className="tbl-field">
+                <span>viewer 種別</span>
+                <select
+                  value={addKind}
+                  onChange={(e) => setAddKind(e.target.value as ViewDefinitionKind)}
+                >
+                  <option value="list">list — 一覧</option>
+                  <option value="detail">detail — 詳細</option>
+                  <option value="kanban">kanban — カンバン</option>
+                  <option value="calendar">calendar — カレンダー</option>
+                </select>
+              </label>
+              <label className="tbl-field">
+                <span>ソーステーブル</span>
+                <select
+                  value={addSourceTableId}
+                  onChange={(e) => { setAddSourceTableId(e.target.value); setAddSourceTableError(""); }}
+                  className={addSourceTableError ? "input-error" : undefined}
+                >
+                  <option value="">— テーブルを選択 —</option>
+                  {tableList.map((t) => (
+                    <option key={t.id} value={t.id}>{t.name}</option>
+                  ))}
+                </select>
+                {addSourceTableError && <span className="tbl-field-error">{addSourceTableError}</span>}
+              </label>
+              <label className="tbl-field">
+                <span>説明 <small>(任意)</small></span>
+                <textarea
+                  value={addDescription}
+                  onChange={(e) => setAddDescription(e.target.value)}
+                  placeholder="このビュー定義の用途を記述..."
+                  rows={3}
+                />
+              </label>
+              <div className="tbl-modal-btns">
+                <button
+                  className="tbl-btn tbl-btn-ghost"
+                  onClick={() => { setShowAdd(false); resetAddForm(); }}
+                >
+                  キャンセル
+                </button>
+                <button
+                  className="tbl-btn tbl-btn-primary"
+                  onClick={handleAdd}
+                  disabled={!addName.trim() || !addSourceTableId.trim()}
+                >
+                  作成して編集
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {contextMenu && (
+          <ListContextMenu
+            x={contextMenu.x}
+            y={contextMenu.y}
+            items={contextMenu.items}
+            onClose={() => setContextMenu(null)}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/designer/src/mcp/mcpBridge.ts
+++ b/designer/src/mcp/mcpBridge.ts
@@ -71,6 +71,10 @@ import {
   setViewStorageBackend,
   type ViewStorageBackend,
 } from "../store/viewStore";
+import {
+  setViewDefinitionStorageBackend,
+  type ViewDefinitionStorageBackend,
+} from "../store/viewDefinitionStore";
 import type { RawExtensionsBundle } from "../schemas/loadExtensions";
 
 export type McpStatus = "disconnected" | "connecting" | "connected";
@@ -384,6 +388,14 @@ class McpBridgeImpl {
       deleteView: (viewId) => this.request("deleteView", { viewId }).then(() => undefined),
     };
     setViewStorageBackend(viewBackend);
+
+    const viewDefinitionBackend: ViewDefinitionStorageBackend = {
+      loadViewDefinition: (viewDefinitionId) => this.request("loadViewDefinition", { viewDefinitionId }),
+      listAllViewDefinitions: () => this.request("listAllViewDefinitions", {}) as Promise<unknown[]>,
+      saveViewDefinition: (viewDefinitionId, data) => this.request("saveViewDefinition", { viewDefinitionId, data }).then(() => undefined),
+      deleteViewDefinition: (viewDefinitionId) => this.request("deleteViewDefinition", { viewDefinitionId }).then(() => undefined),
+    };
+    setViewDefinitionStorageBackend(viewDefinitionBackend);
   }
 
   /** 切断時: localStorage フォールバックに戻す */
@@ -398,6 +410,7 @@ class McpBridgeImpl {
     setScreenStorageBackend(null);
     setSequenceStorageBackend(null);
     setViewStorageBackend(null);
+    setViewDefinitionStorageBackend(null);
   }
 
   // ── メッセージ受信 ─────────────────────────────────────────────────────

--- a/designer/src/store/tabStore.ts
+++ b/designer/src/store/tabStore.ts
@@ -11,6 +11,7 @@ export type TabType =
   | "process-flow"    // 処理フロー編集
   | "sequence"        // シーケンス編集 (#374)
   | "view"            // ビュー編集 (#376)
+  | "view-definition" // ビュー定義編集 (#666)
   // シングルトン（1 インスタンス固定。resourceId は "main" で統一）
   | "screen-flow"        // 画面フロー図
   | "screen-list"        // 画面一覧 (#133 Phase C)
@@ -22,12 +23,13 @@ export type TabType =
   | "screen-items"       // 画面項目定義 (#318 プロトタイプ)
   | "sequence-list"      // シーケンス一覧 (#374)
   | "view-list"          // ビュー一覧 (#376)
+  | "view-definition-list" // ビュー定義一覧 (#666)
   | "dashboard";         // ダッシュボード（#86 PR-3 で有効化）
 
 const KNOWN_TAB_TYPES: ReadonlySet<TabType> = new Set([
-  "design", "table", "process-flow", "sequence", "view",
+  "design", "table", "process-flow", "sequence", "view", "view-definition",
   "screen-flow", "screen-list", "table-list", "er", "process-flow-list",
-  "extensions", "conventions-catalog", "screen-items", "sequence-list", "view-list", "dashboard",
+  "extensions", "conventions-catalog", "screen-items", "sequence-list", "view-list", "view-definition-list", "dashboard",
 ]);
 
 export interface TabItem {

--- a/designer/src/store/viewDefinitionStore.test.ts
+++ b/designer/src/store/viewDefinitionStore.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { FlowProject } from "../types/flow";
+import type {
+  DisplayName,
+  TableId,
+  Timestamp,
+} from "../types/v3";
+import type { FlowStorageBackend } from "./flowStore";
+import { setFlowDraftMode, setFlowStorageBackend } from "./flowStore";
+import type { ViewDefinitionStorageBackend as StoreViewDefinitionStorageBackend } from "./viewDefinitionStore";
+import {
+  createViewDefinition,
+  deleteViewDefinition,
+  setViewDefinitionStorageBackend,
+} from "./viewDefinitionStore";
+
+const TS = "2026-04-29T00:00:00.000Z" as Timestamp;
+
+function emptyProject(): FlowProject {
+  return {
+    version: 1,
+    name: "test",
+    screens: [],
+    groups: [],
+    edges: [],
+    updatedAt: TS,
+  };
+}
+
+describe("viewDefinitionStore", () => {
+  beforeEach(() => {
+    setViewDefinitionStorageBackend(null);
+    setFlowStorageBackend(null);
+    setFlowDraftMode(false);
+    localStorage.clear();
+  });
+
+  it("deleteViewDefinition does not save project.json", async () => {
+    const saveProject = vi.fn().mockResolvedValue(undefined);
+    const flowBackend: FlowStorageBackend = {
+      loadProject: vi.fn().mockResolvedValue(emptyProject()),
+      saveProject,
+      deleteScreenData: vi.fn().mockResolvedValue(undefined),
+    };
+    const viewBackend: StoreViewDefinitionStorageBackend = {
+      loadViewDefinition: vi.fn().mockResolvedValue(null),
+      saveViewDefinition: vi.fn().mockResolvedValue(undefined),
+      deleteViewDefinition: vi.fn().mockResolvedValue(undefined),
+    };
+    setFlowStorageBackend(flowBackend);
+    setViewDefinitionStorageBackend(viewBackend);
+
+    await deleteViewDefinition("a");
+
+    expect(viewBackend.deleteViewDefinition).toHaveBeenCalledWith("a");
+    expect(saveProject).not.toHaveBeenCalled();
+  });
+
+  it("createViewDefinition initializes required fields", async () => {
+    const project = emptyProject();
+    const flowBackend: FlowStorageBackend = {
+      loadProject: vi.fn().mockResolvedValue(project),
+      saveProject: vi.fn().mockResolvedValue(undefined),
+      deleteScreenData: vi.fn().mockResolvedValue(undefined),
+    };
+    setFlowStorageBackend(flowBackend);
+
+    const vd = await createViewDefinition(
+      "受注一覧" as DisplayName,
+      "list",
+      "table-orders" as TableId,
+    );
+
+    expect(vd.id).toBeTruthy();
+    expect(vd.kind).toBe("list");
+    expect(vd.sourceTableId).toBe("table-orders");
+    expect(vd.columns).toEqual([]);
+  });
+});

--- a/designer/src/store/viewDefinitionStore.test.ts
+++ b/designer/src/store/viewDefinitionStore.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { commitViewDefinitions } from "../components/view-definition/ViewDefinitionListView";
 import type { FlowProject } from "../types/flow";
 import type {
   DisplayName,
   TableId,
   Timestamp,
+  ViewDefinitionEntry,
+  ViewDefinitionId,
 } from "../types/v3";
 import type { FlowStorageBackend } from "./flowStore";
 import { setFlowDraftMode, setFlowStorageBackend } from "./flowStore";
@@ -25,6 +28,30 @@ function emptyProject(): FlowProject {
     edges: [],
     updatedAt: TS,
   };
+}
+
+function viewDefinitionEntry(id: string, no: number): ViewDefinitionEntry {
+  return {
+    id: id as unknown as ViewDefinitionId,
+    no,
+    name: `vd ${id}`,
+    kind: "list",
+    sourceTableId: "tbl-1" as any,
+    columnCount: 0,
+    updatedAt: TS,
+  };
+}
+
+function projectWithViewDefinitions(viewDefinitions: ViewDefinitionEntry[]): FlowProject {
+  return {
+    version: 1,
+    name: "test",
+    screens: [],
+    groups: [],
+    edges: [],
+    viewDefinitions,
+    updatedAt: TS,
+  } as unknown as FlowProject;
 }
 
 describe("viewDefinitionStore", () => {
@@ -75,5 +102,29 @@ describe("viewDefinitionStore", () => {
     expect(vd.kind).toBe("list");
     expect(vd.sourceTableId).toBe("table-orders");
     expect(vd.columns).toEqual([]);
+  });
+
+  it("commitViewDefinitions saves project.json once regardless of deletedIds count", async () => {
+    const project = projectWithViewDefinitions([
+      viewDefinitionEntry("a", 1),
+      viewDefinitionEntry("b", 2),
+      viewDefinitionEntry("c", 3),
+    ]);
+    const loadProject = vi.fn().mockResolvedValue(project);
+    const saveProject = vi.fn().mockResolvedValue(undefined);
+    const deleteViewDefinition = vi.fn().mockResolvedValue(undefined);
+
+    await commitViewDefinitions({
+      itemsInOrder: [viewDefinitionEntry("c", 1), viewDefinitionEntry("a", 2)],
+      deletedIds: ["b", "missing"],
+    }, { loadProject, saveProject, deleteViewDefinition });
+
+    expect(saveProject).toHaveBeenCalledTimes(1);
+    expect(saveProject).toHaveBeenCalledWith(project);
+    expect(project.viewDefinitions?.map((vd) => vd.id)).toEqual(["c", "a"]);
+    expect(project.viewDefinitions?.map((vd) => vd.no)).toEqual([1, 2]);
+    expect(deleteViewDefinition).toHaveBeenCalledTimes(2);
+    expect(deleteViewDefinition).toHaveBeenNthCalledWith(1, "b");
+    expect(deleteViewDefinition).toHaveBeenNthCalledWith(2, "missing");
   });
 });

--- a/designer/src/store/viewDefinitionStore.ts
+++ b/designer/src/store/viewDefinitionStore.ts
@@ -1,0 +1,169 @@
+import type {
+  DisplayName,
+  Table,
+  TableId,
+  Timestamp,
+  ViewDefinition,
+  ViewDefinitionEntry,
+  ViewDefinitionId,
+  ViewDefinitionKind,
+} from "../types/v3";
+import { generateUUID } from "../utils/uuid";
+import {
+  checkViewDefinitions,
+  type ViewDefinitionIssue,
+} from "../schemas/viewDefinitionValidator";
+import { loadProject, saveProject } from "./flowStore";
+import { loadTable, listTables } from "./tableStore";
+import { renumber, nextNo } from "../utils/listOrder";
+
+export interface ViewDefinitionStorageBackend {
+  loadViewDefinition(viewDefinitionId: string): Promise<unknown>;
+  listAllViewDefinitions?(): Promise<unknown[]>;
+  saveViewDefinition(viewDefinitionId: string, data: unknown): Promise<void>;
+  deleteViewDefinition(viewDefinitionId: string): Promise<void>;
+}
+
+let _backend: ViewDefinitionStorageBackend | null = null;
+
+export function setViewDefinitionStorageBackend(b: ViewDefinitionStorageBackend | null): void {
+  _backend = b;
+}
+
+const VIEW_DEFINITION_PREFIX = "v3-view-definition-";
+
+const VIEW_DEFINITION_SCHEMA_REF = "../../schemas/v3/view-definition.v3.schema.json";
+
+function nowTs(): Timestamp {
+  return new Date().toISOString() as Timestamp;
+}
+
+// TODO(#666): Remove after ViewDefinitionId is no longer a nested brand over Uuid.
+function toViewDefinitionId(id: string): ViewDefinitionId {
+  return id as unknown as ViewDefinitionId;
+}
+
+// TODO(#666): Replace this local extension after FlowProject exposes viewDefinitions.
+type ProjectWithViewDefinitions = Awaited<ReturnType<typeof loadProject>> & {
+  viewDefinitions?: ViewDefinitionEntry[];
+};
+
+export async function listViewDefinitions(): Promise<ViewDefinitionEntry[]> {
+  const project: ProjectWithViewDefinitions = await loadProject();
+  return project.viewDefinitions ?? [];
+}
+
+export async function loadViewDefinition(
+  viewDefinitionId: string,
+): Promise<ViewDefinition | null> {
+  if (_backend) {
+    return (await _backend.loadViewDefinition(viewDefinitionId)) as ViewDefinition | null;
+  }
+  const s = localStorage.getItem(`${VIEW_DEFINITION_PREFIX}${viewDefinitionId}`);
+  if (!s) return null;
+  try { return JSON.parse(s) as ViewDefinition; } catch { return null; }
+}
+
+export async function loadViewDefinitionValidationMap(): Promise<
+  Map<ViewDefinitionId, ViewDefinitionIssue[]>
+> {
+  const entries = await listViewDefinitions();
+  const entryIds = new Set(entries.map((entry) => String(entry.id)));
+
+  let viewDefinitions: ViewDefinition[];
+  if (_backend?.listAllViewDefinitions) {
+    const all = (await _backend.listAllViewDefinitions()) as ViewDefinition[];
+    viewDefinitions = all.filter((vd) => entryIds.has(String(vd.id)));
+  } else {
+    viewDefinitions = (await Promise.all(entries.map((entry) => loadViewDefinition(String(entry.id)))))
+      .filter((vd): vd is ViewDefinition => vd !== null);
+  }
+
+  const tableEntries = await listTables();
+  const tables = (await Promise.all(tableEntries.map((entry) => loadTable(entry.id))))
+    .filter((table): table is Table => table !== null);
+
+  const issues = checkViewDefinitions(viewDefinitions, tables);
+  const validationMap = new Map<ViewDefinitionId, ViewDefinitionIssue[]>();
+
+  for (const vd of viewDefinitions) {
+    validationMap.set(toViewDefinitionId(String(vd.id)), []);
+  }
+  for (const issue of issues) {
+    const id = toViewDefinitionId(issue.viewDefinitionId);
+    validationMap.set(id, [...(validationMap.get(id) ?? []), issue]);
+  }
+
+  return validationMap;
+}
+
+export async function saveViewDefinition(vd: ViewDefinition): Promise<void> {
+  const toSave: ViewDefinition = {
+    ...vd,
+    $schema: VIEW_DEFINITION_SCHEMA_REF,
+    updatedAt: nowTs(),
+  };
+
+  if (_backend) {
+    await _backend.saveViewDefinition(toSave.id, toSave);
+  } else {
+    localStorage.setItem(`${VIEW_DEFINITION_PREFIX}${toSave.id}`, JSON.stringify(toSave));
+  }
+
+  await syncViewDefinitionMeta(toSave);
+}
+
+export async function createViewDefinition(
+  name: DisplayName,
+  kind: ViewDefinitionKind,
+  sourceTableId: TableId,
+  description?: string,
+): Promise<ViewDefinition> {
+  const ts = nowTs();
+  const viewDefinition: ViewDefinition = {
+    $schema: VIEW_DEFINITION_SCHEMA_REF,
+    id: generateUUID() as ViewDefinitionId,
+    name,
+    description,
+    kind,
+    sourceTableId,
+    columns: [],
+    createdAt: ts,
+    updatedAt: ts,
+  };
+  await saveViewDefinition(viewDefinition);
+  return viewDefinition;
+}
+
+export async function deleteViewDefinition(viewDefinitionId: string): Promise<void> {
+  if (_backend) {
+    await _backend.deleteViewDefinition(viewDefinitionId);
+  } else {
+    localStorage.removeItem(`${VIEW_DEFINITION_PREFIX}${viewDefinitionId}`);
+  }
+}
+
+async function syncViewDefinitionMeta(vd: ViewDefinition): Promise<void> {
+  const project: ProjectWithViewDefinitions = await loadProject();
+  if (!project.viewDefinitions) project.viewDefinitions = [];
+
+  const idx = project.viewDefinitions.findIndex((entry) => String(entry.id) === String(vd.id));
+  const meta: ViewDefinitionEntry = {
+    id: toViewDefinitionId(String(vd.id)),
+    no: idx >= 0 ? project.viewDefinitions[idx].no : nextNo(project.viewDefinitions),
+    name: vd.name,
+    kind: vd.kind,
+    sourceTableId: vd.sourceTableId,
+    columnCount: vd.columns?.length,
+    updatedAt: vd.updatedAt,
+    maturity: vd.maturity,
+  };
+
+  if (idx >= 0) {
+    project.viewDefinitions[idx] = meta;
+  } else {
+    project.viewDefinitions.push(meta);
+  }
+  project.viewDefinitions = renumber(project.viewDefinitions);
+  await saveProject(project);
+}

--- a/designer/src/utils/serverMtime.ts
+++ b/designer/src/utils/serverMtime.ts
@@ -7,7 +7,7 @@
  */
 import { mcpBridge } from "../mcp/mcpBridge";
 
-export type MtimeKind = "project" | "screen" | "screenEntity" | "table" | "processFlow" | "erLayout" | "customBlocks" | "conventions" | "screenItems" | "sequence" | "view";
+export type MtimeKind = "project" | "screen" | "screenEntity" | "table" | "processFlow" | "erLayout" | "customBlocks" | "conventions" | "screenItems" | "sequence" | "view" | "viewDefinition";
 
 const LAST_SEEN_PREFIX = "mtime-";
 


### PR DESCRIPTION
## 関連

- Closes #666
- 仕様: `docs/spec/list-common.md` (一覧 UI 共通仕様), `docs/spec/draft-state-policy.md` (schema 違反保存可 + maturity 表示)
- 派生元: `docs/spec/phase4-evaluation-2026-04-30.md` §Phase 5 候補
- 前提 PR: #656 (#649) — schema/validator/型 完成済 (re-use only)

## 概要

ViewDefinition (画面側の一覧 UI viewer 概念) の **UI 編集機能** を新設。Phase 4 子 1 (#649 / PR #656) で schema + 9 観点 validator + 型は完成していたが、業務設計者が JSON 直書きでしか編集できない状態だった。本 PR で `/view-definition/list` (一覧) + `/view-definition/edit/:viewDefinitionId` (編集) を追加し、ブラウザから CRUD 可能にする。既存の View (DB View) と完全並列の構造。

## 主な変更

- **store 層**: `viewDefinitionStore.ts` (S1) — list / load / validationMap / save / create / delete + StorageBackend interface
- **永続化**: `designer-mcp/projectStorage.ts` + `wsBridge.ts` + `designer/mcp/mcpBridge.ts` (S2) — `data/view-definitions/` per-entity ファイル + `viewDefinitionChanged` broadcast
- **ルーティング/タブ**: `tabStore.ts` の TabType に `"view-definition"` (multi) と `"view-definition-list"` (singleton) 追加 (S4)、`AppShell.tsx` に 2 ルート追加 + URL/タブ双方向同期 (S5)、`HeaderMenu.tsx` に「ビュー定義一覧」追加 (S5)
- **ListView**: `ViewDefinitionListView.tsx` — DataList + ViewModeToggle (card/table) + 標準 5 hooks 全接続 + 9 観点 validation 件数 badge + maturity badge (S4)
- **Editor**: `ViewDefinitionEditor.tsx` — 5 セクション (基本情報 / columns / sortDefaults / filterDefaults / pageSize+groupBy) + リアルタイム 9 観点 validator (inline + 集計バー) + maturity 循環切替 + Ctrl+S (S5)
- **`MtimeKind` union 拡張**: `serverMtime.ts` に `"viewDefinition"` 追加 (S5)
- **テスト**: vitest `viewDefinitionStore.test.ts` (S1) + Playwright E2E `view-definition.spec.ts` 2 tests (S6)

## 仕様逐条突合 (自己申告)

ISSUE #666 完了基準ベース。

### 完了基準 (a) `/view-definition/list` と `/view-definition/edit/:viewDefinitionId` が HeaderMenu から到達可能で動作

- HeaderMenu「ビュー定義一覧」エントリ → `designer/src/components/HeaderMenu.tsx:60-61` ✓
- AppShell URL→タブ同期 (edit) → `designer/src/components/AppShell.tsx:208-225` ✓
- AppShell singleton 登録 (list) → `designer/src/components/AppShell.tsx:243` ✓
- AppShell タブ→URL 同期 → `designer/src/components/AppShell.tsx:266`, `:277` ✓
- React Router Route 登録 → `designer/src/components/AppShell.tsx:359-360` ✓
- TabType 拡張 → `designer/src/store/tabStore.ts:14`, `:26`, `:30`, `:32` ✓

### 完了基準 (b) CRUD 全機能 (新規 / 編集 / 保存 / 複製 / 削除)

**store 層**:
- `listViewDefinitions` → `designer/src/store/viewDefinitionStore.ts:51-54` ✓
- `loadViewDefinition` → `viewDefinitionStore.ts:56-65` ✓
- `saveViewDefinition` → `viewDefinitionStore.ts:100-114` ✓
- `createViewDefinition` (name + kind + sourceTableId + description?) → `viewDefinitionStore.ts:116-136` ✓
- `deleteViewDefinition` → `viewDefinitionStore.ts:138-144` ✓
- `syncViewDefinitionMeta` (project.json メタ同期、`columnCount` 等) → `viewDefinitionStore.ts:146-169` ✓

**ListView 操作**:
- `commitViewDefinitions` (削除/並べ替え一括コミット) → `ViewDefinitionListView.tsx:52-72` ✓
- 新規追加モーダル (name / kind / sourceTableId / description) → `ViewDefinitionListView.tsx:345-...` ✓
- 標準 5 hooks: `useListFilter` (`:186`), `useListSort` (`:212`), `useListSelection` (`:213`), `useListClipboard` (`:214`), `useListKeyboard` (`:444`) ✓
- ViewModeToggle (card/table) → `ViewDefinitionListView.tsx:622` ✓

**Editor 操作**:
- `useResourceEditor<ViewDefinition>` 初期化 → `ViewDefinitionEditor.tsx:168-178` ✓
- `useSaveShortcut` (Ctrl+S) → `ViewDefinitionEditor.tsx:181-183` ✓
- 保存ボタン → `ViewDefinitionEditor.tsx:392` ✓
- maturity 循環切替 → `ViewDefinitionEditor.tsx:517-...` ✓
- 5 セクション (基本情報 / columns / sort / filter / pageSize+groupBy) — Editor 内 5 領域に分割実装 ✓

### 完了基準 (c) 9 観点 validator がリアルタイム警告表示 + ListView で件数 badge

- ListView 集計 (severity 別カウント) → `ViewDefinitionListView.tsx:162-173` (`loadViewDefinitionValidationMap` 呼び出し) ✓
- ListView card view validation badge → `ViewDefinitionListView.tsx:574-575` ✓
- ListView table view validation badge → `ViewDefinitionListView.tsx:539-542` ✓
- Editor リアルタイム validator → `ViewDefinitionEditor.tsx:197` (`checkViewDefinition` を `useMemo` で実行、`viewDefinition` / `tables` 変化で再計算) ✓
- store layer aggregation → `viewDefinitionStore.ts:67-98` (entry-id / issue 集計) ✓

### 完了基準 (d) retail + welfare-benefit に各 1-2 件の sample ViewDefinition JSON

PR #656 (#649) で paving JSON が **既に実データ充填済**。本 PR は再利用 (新規追加なし、変更なし)。

- retail: `docs/sample-project-v3/retail/view-definitions/f1a2b3c4-d5e6-4000-8000-f1a2b3c4d5e6.json` (商品一覧ビュー、5 columns + sortDefaults + filterDefaults + maturity=committed) ✓
- welfare-benefit: `docs/sample-project-v3/welfare-benefit/view-definitions/c7d8e9f0-a1b2-4000-8000-c7d8e9f0a1b2.json` (受給者一覧ビュー、5 columns + sortDefaults + filterDefaults) ✓

### 完了基準 (e) vitest / Playwright / AI smoke test 全 pass

- Vitest: 76 files / **1230 tests 全 pass** (S5 完了時点で確認) — 新規 `viewDefinitionStore.test.ts` 2 tests
- Playwright E2E: `designer/e2e/view-definition.spec.ts` **2 tests passed** (golden path: 一覧→新規→編集→保存→反映) — S6 で確認
- AI smoke: Playwright E2E が UI フルパスを通すため **smoke test 兼用**。chrome-devtools MCP は本 PR では未使用 (designer-mcp 接続が一時断のため Playwright で代替)

### 完了基準 (f) `git diff origin/main..HEAD -- schemas/` 空

- 確認済 ✓ (本 PR 全 commit 通じて `schemas/*.json` 変更ゼロ)

## レビューで特に見てほしい箇所

1. **`MtimeKind` 拡張 (`serverMtime.ts`)**: `"view"` と並列に `"viewDefinition"` (camelCase) を追加。命名は既存 View 系の規則に合わせた (kebab-case の TabType と異なる)。一貫性レビュー希望
2. **`ProjectWithViewDefinitions` ローカル拡張型** (`viewDefinitionStore.ts:47-49`): `loadProject` の戻り型に `viewDefinitions?` を追加するため localintersection で逃がした。本来は `FlowProject` 型本体に直接生やすべきだが、本 PR では既存型変更を回避 (TODO コメント付与済み)
3. **`toViewDefinitionId` cast** (`viewDefinitionStore.ts:42-44`): branded type の `as unknown as` cast。`String(entry.id)` 経由で正規化して再 brand。型階層の整理は別 ISSUE 候補
4. **commit メッセージ揺れ**: S2 commit (`2e325c6`) の prefix が `feat(view): ...` になっており他の `feat(view-definition): ...` と不一致。squash merge 時に PR title で吸収されるため実害なしだが要確認
5. **既存 View ファイル (`viewStore.ts` / `ViewListView.tsx` / `ViewEditor.tsx`)**: 1 行も変更なし。並列存在の意図 (DB View ↔ 画面 ViewDefinition は別概念) を保つ

## テスト

- Vitest: 1230 件全 pass (新規 2 件 — `viewDefinitionStore.test.ts`)
- Playwright: 2 件新規 — `e2e/view-definition.spec.ts` golden path
- MCP E2E: N/A (本 PR で MCP E2E 拡張なし、既存 wsBridge handler 追加のみ)

## UI 影響 / AI smoke test

- [x] UI 影響あり (Playwright E2E で smoke test 実施済み — 2 tests pass)
- [ ] UI 影響なし

### UI 影響ありの場合、AI smoke test で確認した項目

- [x] HeaderMenu「ビュー定義一覧」→ `/view-definition/list` 遷移が動作 — Playwright E2E で確認
- [x] 一覧 → 新規追加モーダル → Editor 遷移 → 保存 → 一覧反映 — Playwright E2E で確認
- [x] 既存 View (DB View) との並列表示が壊れていない (両者は別ルート / 別ストア / 別 broadcast) — 既存テスト 1230 件 pass
- [x] schema 変更ゼロ → AJV / dogfood test 全 pass

## spec 側の不足点 / 提案

N/A — ViewDefinition spec / schema は PR #656 で完成済、本 PR は UI 実装のみ。実装中に spec の曖昧さ・抜けは検出されなかった。

## レビュー担当への申し送り

- **段階別委譲ワークフロー**: Opus orchestrator → Codex (S1/S2/S6) + Sonnet (S4/S5) で段階分割。コミット 5 個 (`596621e` / `2e325c6` / `5e295ce` / `67519b3` / `c8b8737`)、squash 後の単一 commit を ISSUE 完了の単位とする。設計コメントは ISSUE #666 [comment](https://github.com/csilost2001/html-designer/issues/666#issuecomment-4352127235)
- **観点**: 既存 View (DB View) パターンとの 1 対 1 対応が成立しているか。drift があれば指摘希望
- **9 観点 validator のフィールド対応**: Editor の `issuesByPath` がどの path に正確にマッチしているかは validator 実装 (`viewDefinitionValidator.ts:97-295`) と Editor UI 側 path 文字列の整合性レビュー希望 (盲点候補)
- **localStorage fallback**: designer-mcp 未起動時に localStorage で動作するパターン。E2E は `reuseExistingServer: true` で同 dev server を共有、designer-mcp が起動していれば永続化、未起動なら localStorage で完結
- **memory 適用済み**: `feedback_schema_governance_strict.md` (schemas/ 変更ゼロ厳守)、`feedback_codex_japanese_string_mojibake.md` (半角カナ 0 件確認)、`feedback_codex_brief_concrete_pattern_reference.md` (Codex/Sonnet 委譲時に line range + ファイル指定)、`feedback_pr_self_report_line_numbers.md` (本 PR 本文 file:line は実装後 grep で実測)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
