### PR TITLE
improve(designer): ListView の commit 関数を Store に移動 + loadValidationMap の Table 取得を一括化 (#668) (#669)

### DIFF
--- a/designer/src/components/sequence/SequenceListView.tsx
+++ b/designer/src/components/sequence/SequenceListView.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import type { Sequence, SequenceEntry, SequenceId, PhysicalName, DisplayName, Timestamp } from "../../types/v3";
-import { listSequences, createSequence, deleteSequence, loadSequence, saveSequence } from "../../store/sequenceStore";
+import { listSequences, createSequence, loadSequence, saveSequence, commitSequences } from "../../store/sequenceStore";
 import { generateUUID } from "../../utils/uuid";
-import { loadProject, saveProject } from "../../store/flowStore";
+import { loadProject } from "../../store/flowStore";
 import { mcpBridge } from "../../mcp/mcpBridge";
 import { makeTabId } from "../../store/tabStore";
 import { DataList, type DataListColumn } from "../common/DataList";
@@ -22,29 +22,6 @@ import { renumber } from "../../utils/listOrder";
 
 const STORAGE_KEY = "list-view-mode:sequence-list";
 const TAB_ID = makeTabId("sequence-list", "main");
-
-interface CommitSequencesDeps {
-  loadProject: typeof loadProject;
-  saveProject: typeof saveProject;
-  deleteSequence: typeof deleteSequence;
-}
-
-export async function commitSequences(
-  { itemsInOrder, deletedIds }: { itemsInOrder: SequenceEntry[]; deletedIds: string[] },
-  deps: CommitSequencesDeps = { loadProject, saveProject, deleteSequence },
-): Promise<void> {
-  const project = await deps.loadProject();
-  const deletedSet = new Set(deletedIds);
-  const orderMap = new Map(itemsInOrder.map((s, i) => [s.id, i]));
-  project.sequences = (project.sequences ?? [])
-    .filter((s) => !deletedSet.has(s.id))
-    .sort((a, b) => (orderMap.get(a.id) ?? Number.MAX_SAFE_INTEGER) - (orderMap.get(b.id) ?? Number.MAX_SAFE_INTEGER))
-    .map((s, i) => ({ ...s, no: i + 1 }));
-  await deps.saveProject(project);
-  for (const id of deletedIds) {
-    await deps.deleteSequence(id);
-  }
-}
 
 function formatDate(iso: string): string {
   try {

--- a/designer/src/components/table/TableListView.tsx
+++ b/designer/src/components/table/TableListView.tsx
@@ -2,8 +2,8 @@ import { useState, useEffect, useCallback, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import type { Table, TableEntry, TableId, PhysicalName, DisplayName, Timestamp } from "../../types/v3";
 import { type SqlDialect, SQL_DIALECT_LABELS } from "../../utils/ddlGenerator";
-import { listTables, createTable, deleteTable, loadTable, saveTable, loadTableValidationMap } from "../../store/tableStore";
-import { loadProject, saveProject } from "../../store/flowStore";
+import { listTables, createTable, loadTable, saveTable, loadTableValidationMap, commitTables } from "../../store/tableStore";
+import { loadProject } from "../../store/flowStore";
 import { generateAllDdl, generateAllTableMarkdown } from "../../utils/ddlGenerator";
 import { mcpBridge } from "../../mcp/mcpBridge";
 import { makeTabId } from "../../store/tabStore";
@@ -28,29 +28,6 @@ import "../../styles/table.css";
 
 const STORAGE_KEY = "list-view-mode:table-list";
 const TAB_ID = makeTabId("table-list", "main");
-
-interface CommitTablesDeps {
-  loadProject: typeof loadProject;
-  saveProject: typeof saveProject;
-  deleteTable: typeof deleteTable;
-}
-
-export async function commitTables(
-  { itemsInOrder, deletedIds }: { itemsInOrder: TableEntry[]; deletedIds: string[] },
-  deps: CommitTablesDeps = { loadProject, saveProject, deleteTable },
-): Promise<void> {
-  const project = await deps.loadProject();
-  const deletedSet = new Set(deletedIds);
-  const orderMap = new Map(itemsInOrder.map((t, i) => [t.id, i]));
-  project.tables = (project.tables ?? [])
-    .filter((t) => !deletedSet.has(t.id))
-    .sort((a, b) => (orderMap.get(a.id) ?? Number.MAX_SAFE_INTEGER) - (orderMap.get(b.id) ?? Number.MAX_SAFE_INTEGER))
-    .map((t, i) => ({ ...t, no: i + 1 }));
-  await deps.saveProject(project);
-  for (const id of deletedIds) {
-    await deps.deleteTable(id);
-  }
-}
 
 interface ValidationSummary {
   errors: number;

--- a/designer/src/components/view-definition/ViewDefinitionListView.tsx
+++ b/designer/src/components/view-definition/ViewDefinitionListView.tsx
@@ -12,13 +12,13 @@ import type {
 import {
   listViewDefinitions,
   createViewDefinition,
-  deleteViewDefinition,
   loadViewDefinition,
   saveViewDefinition,
   loadViewDefinitionValidationMap,
+  commitViewDefinitions,
 } from "../../store/viewDefinitionStore";
 import { listTables } from "../../store/tableStore";
-import { loadProject, saveProject } from "../../store/flowStore";
+import { loadProject } from "../../store/flowStore";
 import { generateUUID } from "../../utils/uuid";
 import { mcpBridge } from "../../mcp/mcpBridge";
 import { makeTabId, openTab } from "../../store/tabStore";
@@ -42,35 +42,6 @@ import "../../styles/table.css";
 
 const STORAGE_KEY = "list-view-mode:view-definition-list";
 const TAB_ID = makeTabId("view-definition-list", "main");
-
-interface CommitViewDefinitionsDeps {
-  loadProject: typeof loadProject;
-  saveProject: typeof saveProject;
-  deleteViewDefinition: typeof deleteViewDefinition;
-}
-
-export async function commitViewDefinitions(
-  { itemsInOrder, deletedIds }: { itemsInOrder: ViewDefinitionEntry[]; deletedIds: string[] },
-  deps: CommitViewDefinitionsDeps = { loadProject, saveProject, deleteViewDefinition },
-): Promise<void> {
-  const project = await deps.loadProject();
-  const deletedSet = new Set(deletedIds);
-  const orderMap = new Map(itemsInOrder.map((v, i) => [v.id, i]));
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const p = project as any;
-  p.viewDefinitions = (p.viewDefinitions ?? [])
-    .filter((v: ViewDefinitionEntry) => !deletedSet.has(String(v.id)))
-    .sort(
-      (a: ViewDefinitionEntry, b: ViewDefinitionEntry) =>
-        (orderMap.get(a.id) ?? Number.MAX_SAFE_INTEGER) -
-        (orderMap.get(b.id) ?? Number.MAX_SAFE_INTEGER),
-    )
-    .map((v: ViewDefinitionEntry, i: number) => ({ ...v, no: i + 1 }));
-  await deps.saveProject(p);
-  for (const id of deletedIds) {
-    await deps.deleteViewDefinition(id);
-  }
-}
 
 interface ValidationSummary {
   errors: number;

--- a/designer/src/components/view/ViewListView.tsx
+++ b/designer/src/components/view/ViewListView.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import type { View, ViewEntry, ViewId, PhysicalName, DisplayName, Timestamp } from "../../types/v3";
-import { listViews, createView, deleteView, loadView, saveView, loadViewValidationMap } from "../../store/viewStore";
-import { loadProject, saveProject } from "../../store/flowStore";
+import { listViews, createView, loadView, saveView, loadViewValidationMap, commitViews } from "../../store/viewStore";
+import { loadProject } from "../../store/flowStore";
 import { generateUUID } from "../../utils/uuid";
 import { mcpBridge } from "../../mcp/mcpBridge";
 import { makeTabId } from "../../store/tabStore";
@@ -25,29 +25,6 @@ import "../../styles/table.css";
 
 const STORAGE_KEY = "list-view-mode:view-list";
 const TAB_ID = makeTabId("view-list", "main");
-
-interface CommitViewsDeps {
-  loadProject: typeof loadProject;
-  saveProject: typeof saveProject;
-  deleteView: typeof deleteView;
-}
-
-export async function commitViews(
-  { itemsInOrder, deletedIds }: { itemsInOrder: ViewEntry[]; deletedIds: string[] },
-  deps: CommitViewsDeps = { loadProject, saveProject, deleteView },
-): Promise<void> {
-  const project = await deps.loadProject();
-  const deletedSet = new Set(deletedIds);
-  const orderMap = new Map(itemsInOrder.map((v, i) => [v.id, i]));
-  project.views = (project.views ?? [])
-    .filter((v) => !deletedSet.has(v.id))
-    .sort((a, b) => (orderMap.get(a.id) ?? Number.MAX_SAFE_INTEGER) - (orderMap.get(b.id) ?? Number.MAX_SAFE_INTEGER))
-    .map((v, i) => ({ ...v, no: i + 1 }));
-  await deps.saveProject(project);
-  for (const id of deletedIds) {
-    await deps.deleteView(id);
-  }
-}
 
 interface ValidationSummary {
   errors: number;

--- a/designer/src/store/sequenceStore.test.ts
+++ b/designer/src/store/sequenceStore.test.ts
@@ -1,11 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { commitSequences } from "../components/sequence/SequenceListView";
 import type { FlowProject } from "../types/flow";
 import type { SequenceEntry, SequenceId, Timestamp } from "../types/v3";
 import type { FlowStorageBackend } from "./flowStore";
 import { setFlowDraftMode, setFlowStorageBackend } from "./flowStore";
 import type { SequenceStorageBackend } from "./sequenceStore";
-import { deleteSequence, setSequenceStorageBackend } from "./sequenceStore";
+import { commitSequences, deleteSequence, setSequenceStorageBackend } from "./sequenceStore";
 
 const TS = "2026-04-29T00:00:00.000Z" as Timestamp;
 

--- a/designer/src/store/sequenceStore.ts
+++ b/designer/src/store/sequenceStore.ts
@@ -92,6 +92,29 @@ export async function deleteSequence(sequenceId: string): Promise<void> {
 
 }
 
+interface CommitSequencesDeps {
+  loadProject: typeof loadProject;
+  saveProject: typeof saveProject;
+  deleteSequence: typeof deleteSequence;
+}
+
+export async function commitSequences(
+  { itemsInOrder, deletedIds }: { itemsInOrder: SequenceEntry[]; deletedIds: string[] },
+  deps: CommitSequencesDeps = { loadProject, saveProject, deleteSequence },
+): Promise<void> {
+  const project = await deps.loadProject();
+  const deletedSet = new Set(deletedIds);
+  const orderMap = new Map(itemsInOrder.map((s, i) => [s.id, i]));
+  project.sequences = (project.sequences ?? [])
+    .filter((s) => !deletedSet.has(s.id))
+    .sort((a, b) => (orderMap.get(a.id) ?? Number.MAX_SAFE_INTEGER) - (orderMap.get(b.id) ?? Number.MAX_SAFE_INTEGER))
+    .map((s, i) => ({ ...s, no: i + 1 }));
+  await deps.saveProject(project);
+  for (const id of deletedIds) {
+    await deps.deleteSequence(id);
+  }
+}
+
 // ─── 内部 ────────────────────────────────────────────────────────────────
 
 async function syncSequenceMeta(sequence: Sequence): Promise<void> {

--- a/designer/src/store/tableStore.test.ts
+++ b/designer/src/store/tableStore.test.ts
@@ -1,11 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { commitTables } from "../components/table/TableListView";
 import type { FlowProject } from "../types/flow";
 import type { TableEntry, TableId, Timestamp } from "../types/v3";
 import type { FlowStorageBackend } from "./flowStore";
 import { setFlowDraftMode, setFlowStorageBackend } from "./flowStore";
 import type { TableStorageBackend } from "./tableStore";
-import { deleteTable, setTableStorageBackend } from "./tableStore";
+import { commitTables, deleteTable, setTableStorageBackend } from "./tableStore";
 
 const TS = "2026-04-29T00:00:00.000Z" as Timestamp;
 

--- a/designer/src/store/tableStore.ts
+++ b/designer/src/store/tableStore.ts
@@ -143,6 +143,29 @@ export async function deleteTable(tableId: string): Promise<void> {
   }
 }
 
+interface CommitTablesDeps {
+  loadProject: typeof loadProject;
+  saveProject: typeof saveProject;
+  deleteTable: typeof deleteTable;
+}
+
+export async function commitTables(
+  { itemsInOrder, deletedIds }: { itemsInOrder: TableEntry[]; deletedIds: string[] },
+  deps: CommitTablesDeps = { loadProject, saveProject, deleteTable },
+): Promise<void> {
+  const project = await deps.loadProject();
+  const deletedSet = new Set(deletedIds);
+  const orderMap = new Map(itemsInOrder.map((t, i) => [t.id, i]));
+  project.tables = (project.tables ?? [])
+    .filter((t) => !deletedSet.has(t.id))
+    .sort((a, b) => (orderMap.get(a.id) ?? Number.MAX_SAFE_INTEGER) - (orderMap.get(b.id) ?? Number.MAX_SAFE_INTEGER))
+    .map((t, i) => ({ ...t, no: i + 1 }));
+  await deps.saveProject(project);
+  for (const id of deletedIds) {
+    await deps.deleteTable(id);
+  }
+}
+
 // ─── カラム操作 (Table mutate ヘルパー) ──────────────────────────────────
 
 /** カラムを追加 (column.id は LocalId 形式で `col-NN` 採番) */

--- a/designer/src/store/tableStore.ts
+++ b/designer/src/store/tableStore.ts
@@ -74,19 +74,21 @@ export async function loadTable(tableId: string): Promise<Table | null> {
   return raw;
 }
 
-export async function loadTableValidationMap(): Promise<Map<TableId, ValidationError[]>> {
+export async function loadAllTables(): Promise<Table[]> {
   const entries = await listTables();
   const entryIds = new Set(entries.map((entry) => entry.id));
 
-  let tables: Table[];
   if (_backend?.listAllTables) {
     const all = (await _backend.listAllTables()) as Table[];
-    tables = all.filter((table) => entryIds.has(table.id));
-  } else {
-    tables = (await Promise.all(entries.map((entry) => loadTable(entry.id))))
-      .filter((t): t is Table => t !== null);
+    return all.filter((table) => entryIds.has(table.id));
   }
 
+  return (await Promise.all(entries.map((entry) => loadTable(entry.id))))
+    .filter((t): t is Table => t !== null);
+}
+
+export async function loadTableValidationMap(): Promise<Map<TableId, ValidationError[]>> {
+  const tables = await loadAllTables();
   const validationMap = new Map<TableId, ValidationError[]>();
 
   for (const table of tables) {

--- a/designer/src/store/viewDefinitionStore.test.ts
+++ b/designer/src/store/viewDefinitionStore.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { commitViewDefinitions } from "../components/view-definition/ViewDefinitionListView";
 import type { FlowProject } from "../types/flow";
 import type {
   DisplayName,
@@ -12,6 +11,7 @@ import type { FlowStorageBackend } from "./flowStore";
 import { setFlowDraftMode, setFlowStorageBackend } from "./flowStore";
 import type { ViewDefinitionStorageBackend as StoreViewDefinitionStorageBackend } from "./viewDefinitionStore";
 import {
+  commitViewDefinitions,
   createViewDefinition,
   deleteViewDefinition,
   setViewDefinitionStorageBackend,

--- a/designer/src/store/viewDefinitionStore.ts
+++ b/designer/src/store/viewDefinitionStore.ts
@@ -143,6 +143,33 @@ export async function deleteViewDefinition(viewDefinitionId: string): Promise<vo
   }
 }
 
+interface CommitViewDefinitionsDeps {
+  loadProject: typeof loadProject;
+  saveProject: typeof saveProject;
+  deleteViewDefinition: typeof deleteViewDefinition;
+}
+
+export async function commitViewDefinitions(
+  { itemsInOrder, deletedIds }: { itemsInOrder: ViewDefinitionEntry[]; deletedIds: string[] },
+  deps: CommitViewDefinitionsDeps = { loadProject, saveProject, deleteViewDefinition },
+): Promise<void> {
+  const project: ProjectWithViewDefinitions = await deps.loadProject();
+  const deletedSet = new Set(deletedIds);
+  const orderMap = new Map(itemsInOrder.map((v, i) => [v.id, i]));
+  project.viewDefinitions = (project.viewDefinitions ?? [])
+    .filter((v) => !deletedSet.has(String(v.id)))
+    .sort(
+      (a, b) =>
+        (orderMap.get(a.id) ?? Number.MAX_SAFE_INTEGER) -
+        (orderMap.get(b.id) ?? Number.MAX_SAFE_INTEGER),
+    )
+    .map((v, i) => ({ ...v, no: i + 1 }));
+  await deps.saveProject(project);
+  for (const id of deletedIds) {
+    await deps.deleteViewDefinition(id);
+  }
+}
+
 async function syncViewDefinitionMeta(vd: ViewDefinition): Promise<void> {
   const project: ProjectWithViewDefinitions = await loadProject();
   if (!project.viewDefinitions) project.viewDefinitions = [];

--- a/designer/src/store/viewDefinitionStore.ts
+++ b/designer/src/store/viewDefinitionStore.ts
@@ -1,6 +1,5 @@
 import type {
   DisplayName,
-  Table,
   TableId,
   Timestamp,
   ViewDefinition,
@@ -14,7 +13,7 @@ import {
   type ViewDefinitionIssue,
 } from "../schemas/viewDefinitionValidator";
 import { loadProject, saveProject } from "./flowStore";
-import { loadTable, listTables } from "./tableStore";
+import { loadAllTables } from "./tableStore";
 import { renumber, nextNo } from "../utils/listOrder";
 
 export interface ViewDefinitionStorageBackend {
@@ -79,9 +78,7 @@ export async function loadViewDefinitionValidationMap(): Promise<
       .filter((vd): vd is ViewDefinition => vd !== null);
   }
 
-  const tableEntries = await listTables();
-  const tables = (await Promise.all(tableEntries.map((entry) => loadTable(entry.id))))
-    .filter((table): table is Table => table !== null);
+  const tables = await loadAllTables();
 
   const issues = checkViewDefinitions(viewDefinitions, tables);
   const validationMap = new Map<ViewDefinitionId, ViewDefinitionIssue[]>();

--- a/designer/src/store/viewStore.test.ts
+++ b/designer/src/store/viewStore.test.ts
@@ -1,11 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { commitViews } from "../components/view/ViewListView";
 import type { FlowProject } from "../types/flow";
 import type { Timestamp, ViewEntry, ViewId } from "../types/v3";
 import type { FlowStorageBackend } from "./flowStore";
 import { setFlowDraftMode, setFlowStorageBackend } from "./flowStore";
 import type { ViewStorageBackend } from "./viewStore";
-import { deleteView, setViewStorageBackend } from "./viewStore";
+import { commitViews, deleteView, setViewStorageBackend } from "./viewStore";
 
 const TS = "2026-04-29T00:00:00.000Z" as Timestamp;
 

--- a/designer/src/store/viewStore.ts
+++ b/designer/src/store/viewStore.ts
@@ -115,6 +115,29 @@ export async function deleteView(viewId: string): Promise<void> {
 
 }
 
+interface CommitViewsDeps {
+  loadProject: typeof loadProject;
+  saveProject: typeof saveProject;
+  deleteView: typeof deleteView;
+}
+
+export async function commitViews(
+  { itemsInOrder, deletedIds }: { itemsInOrder: ViewEntry[]; deletedIds: string[] },
+  deps: CommitViewsDeps = { loadProject, saveProject, deleteView },
+): Promise<void> {
+  const project = await deps.loadProject();
+  const deletedSet = new Set(deletedIds);
+  const orderMap = new Map(itemsInOrder.map((v, i) => [v.id, i]));
+  project.views = (project.views ?? [])
+    .filter((v) => !deletedSet.has(v.id))
+    .sort((a, b) => (orderMap.get(a.id) ?? Number.MAX_SAFE_INTEGER) - (orderMap.get(b.id) ?? Number.MAX_SAFE_INTEGER))
+    .map((v, i) => ({ ...v, no: i + 1 }));
+  await deps.saveProject(project);
+  for (const id of deletedIds) {
+    await deps.deleteView(id);
+  }
+}
+
 // ─── 内部 ────────────────────────────────────────────────────────────────
 
 async function syncViewMeta(view: View): Promise<void> {


### PR DESCRIPTION
## 関連

Closes #668
Closes #669
- 仕様: docs/spec/draft-state-policy.md:109

## 概要

ListView から非コンポーネント export だった commit 関数を Store に移動し、Fast Refresh の only-export-components 対象を解消しました。あわせて Table 全件取得を loadAllTables() に切り出し、Table/ViewDefinition の validation map で共有しました。機能変更なしの refactor-only です。

## 主な変更

- View/Table/Sequence/ViewDefinition の commit 関数を各 Store に移動
- ListView 側は Store import に切り替え、TableListView の useCallback(commitTables, []) は維持
- loadAllTables() を tableStore に追加し、loadTableValidationMap と loadViewDefinitionValidationMap から利用
- commit 関数テストの import path を Store に更新

## 仕様逐条突合 (自己申告)

- #668 commitViews を Store に移動: designer/src/store/viewStore.ts:124 / designer/src/components/view/ViewListView.tsx:4
- #668 commitTables を Store に移動: designer/src/store/tableStore.ts:154 / designer/src/components/table/TableListView.tsx:5
- #668 TableListView の useCallback 維持: designer/src/components/table/TableListView.tsx:66
- #668 commitSequences を Store に移動: designer/src/store/sequenceStore.ts:101 / designer/src/components/sequence/SequenceListView.tsx:4
- #668 commitViewDefinitions を Store に移動: designer/src/store/viewDefinitionStore.ts:149 / designer/src/components/view-definition/ViewDefinitionListView.tsx:18
- #668 テスト import path 更新: designer/src/store/viewStore.test.ts:7 / designer/src/store/tableStore.test.ts:7 / designer/src/store/sequenceStore.test.ts:7 / designer/src/store/viewDefinitionStore.test.ts:14
- #669 loadAllTables 追加: designer/src/store/tableStore.ts:77
- #669 loadTableValidationMap の Table 取得を loadAllTables に置換: designer/src/store/tableStore.ts:91
- #669 loadViewDefinitionValidationMap の Table 取得を loadAllTables に置換: designer/src/store/viewDefinitionStore.ts:16 / designer/src/store/viewDefinitionStore.ts:81
- schema 変更禁止: git diff origin/main..HEAD -- schemas/ が空

## レビューで特に見てほしい箇所

- N/A (refactor-only。既存ロジックの移動と共通化のみ)

## テスト

- Vitest: 4 files / 9 tests passed - `npx vitest run src/store/viewStore.test.ts src/store/tableStore.test.ts src/store/sequenceStore.test.ts src/store/viewDefinitionStore.test.ts`
- Vitest: 3 files / 8 tests passed - `npx vitest run src/store/tableStore.bulkLoad.test.ts src/store/tableStore.test.ts src/store/viewDefinitionStore.test.ts`
- Build: passed - `npm run build`
- Lint: `npm run lint` は既存の unrelated error で失敗。ただし今回対象の 4 ListView の `react-refresh/only-export-components` error は出ておらず、残存の同 rule error は `designer/src/components/common/ErrorDialogProvider.tsx:83` のみ。

## UI 影響 / AI smoke test

- [x] UI 影響なし (refactor-only / auto test + build pass)
- [ ] UI 影響あり

### UI 影響ありの場合の確認項目

- N/A

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

N/A