### PR TITLE
feat(workspace): 複数ワークスペース管理機能 (#27 + #671-#675)

### DIFF
--- a/designer-mcp/src/handlers/processFlow.ts
+++ b/designer-mcp/src/handlers/processFlow.ts
@@ -21,7 +21,7 @@ import {
   listProcessFlows as listProcessFlowFiles,
   readProject,
   writeProject,
-  DATA_DIR,
+  dataDir,
   readExtensionsBundle,
   writeExtensionsFile,
   type ExtensionFileKind,
@@ -463,7 +463,7 @@ export const handleProcessFlowTool: ToolHandler = async (name, args) => {
 
       const outPath = path.isAbsolute(a.outputPath as string)
         ? (a.outputPath as string)
-        : path.join(DATA_DIR, a.outputPath as string);
+        : path.join(dataDir(), a.outputPath as string);
 
       const zip = new AdmZip();
       const manifest = {
@@ -495,13 +495,13 @@ export const handleProcessFlowTool: ToolHandler = async (name, args) => {
       }
       const inPath = path.isAbsolute(a.inputPath as string)
         ? (a.inputPath as string)
-        : path.join(DATA_DIR, a.inputPath as string);
+        : path.join(dataDir(), a.inputPath as string);
       const conflict = (a.conflictResolution as string | undefined) ?? "skip";
 
       const zip = new AdmZip(inPath);
       const entries = zip.getEntries().filter(e => e.entryName.startsWith("process-flows/") && e.entryName.endsWith(".json") && !e.isDirectory);
 
-      const actionsDir = path.join(DATA_DIR, "actions");
+      const actionsDir = path.join(dataDir(), "actions");
       const results: string[] = [];
 
       for (const entry of entries) {

--- a/designer-mcp/src/index.ts
+++ b/designer-mcp/src/index.ts
@@ -1094,7 +1094,7 @@ function createMcpServer(): Server {
           activeId: entry.id,
           path: entry.path,
           name: entry.name,
-          lockdown: false,
+          lockdown: isLockdown(),
         });
         return { content: [{ type: "text", text: `ワークスペース「${entry.name}」を開きました (${entry.path})` }] };
       }
@@ -1122,7 +1122,7 @@ function createMcpServer(): Server {
           activeId: null,
           path: null,
           name: null,
-          lockdown: false,
+          lockdown: isLockdown(),
         });
         return { content: [{ type: "text", text: "ワークスペースを閉じました。" }] };
       }

--- a/designer-mcp/src/index.ts
+++ b/designer-mcp/src/index.ts
@@ -1,6 +1,7 @@
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { randomUUID } from "node:crypto";
+import path from "node:path";
 import { handleMarkerTool } from "./handlers/marker.js";
 import { handleProcessFlowTool } from "./handlers/processFlow.js";
 import { renameScreenItemId, checkScreenItemRefs, updateProcessFlowRefs } from "./renameScreenItem.js";
@@ -17,6 +18,8 @@ import { handleAuthCheck, handlePropose } from "./aiRename.js";
 import { htmlToReact, toPascalCase } from "./reactExporter.js";
 import { readProject, readCustomBlocks, readTable, writeTable, deleteTable as deleteTableFile, writeProject, readErLayout, readProcessFlow, writeProcessFlow, deleteProcessFlow as deleteProcessFlowFile, listProcessFlows as listProcessFlowFiles } from "./projectStorage.js";
 import { mcpTableToSpecEntry } from "./specExport.js";
+import { initWorkspaceState, getActivePath, setActivePath, clearActive, isLockdown, getLockdownPath, LockdownError, WorkspaceUnsetError } from "./workspaceState.js";
+import { listWorkspaces, upsertWorkspace, removeWorkspace, findById, findByPath, setLastActive } from "./recentStore.js";
 
 // 常駐バックエンドなので停止 signal (SIGTERM/SIGINT/disconnect) のみ監視。
 // stdin は監視しない (#302: HTTP transport に統一、stdio 廃止)。
@@ -31,6 +34,9 @@ function setupLifecycle(): void {
 }
 
 setupLifecycle();
+
+// workspace 状態の初期化 (#671): env DESIGNER_DATA_DIR があれば lockdown モード固定
+initWorkspaceState();
 
 // HTTP + WebSocket サーバ起動 (port 5179 に両方同居)
 await wsBridge.start();
@@ -963,10 +969,121 @@ function createMcpServer(): Server {
         return { content: [{ type: "text", text: lines.join("\n") }] };
       }
 
+      // ── ワークスペース管理 (#671) ─────────────────────────────────
+      case "designer__workspace_list": {
+        const { workspaces, lastActiveId } = await listWorkspaces();
+        const activePath = getActivePath();
+        const lockdown = isLockdown();
+        const lockdownPath = getLockdownPath();
+        const payload = {
+          workspaces,
+          lastActiveId,
+          active: activePath ? { path: activePath } : null,
+          lockdown,
+          lockdownPath,
+        };
+        return { content: [{ type: "text", text: JSON.stringify(payload, null, 2) }] };
+      }
+
+      case "designer__workspace_status": {
+        const activePath = getActivePath();
+        let activeName: string | null = null;
+        if (activePath) {
+          const entry = await findByPath(activePath);
+          activeName = entry?.name ?? null;
+        }
+        const payload = {
+          active: activePath ? { path: activePath, name: activeName } : null,
+          lockdown: isLockdown(),
+          lockdownPath: getLockdownPath(),
+        };
+        return { content: [{ type: "text", text: JSON.stringify(payload, null, 2) }] };
+      }
+
+      case "designer__workspace_open": {
+        const a = (args ?? {}) as Record<string, unknown>;
+        if (typeof a.path !== "string" && typeof a.id !== "string") {
+          throw new McpError(ErrorCode.InvalidParams, "path または id のいずれかが必要です");
+        }
+        let target = typeof a.path === "string" ? a.path : null;
+        if (!target && typeof a.id === "string") {
+          const entry = await findById(a.id);
+          if (!entry) throw new McpError(ErrorCode.InvalidParams, `id ${a.id} のワークスペースが見つかりません`);
+          target = entry.path;
+        }
+        if (!target) throw new McpError(ErrorCode.InvalidParams, "path 解決に失敗しました");
+        try {
+          setActivePath(target);
+        } catch (e) {
+          if (e instanceof LockdownError) {
+            throw new McpError(ErrorCode.InvalidParams, e.message);
+          }
+          throw e;
+        }
+        // project.json を読んで name をキャッシュ。失敗時は basename にフォールバック
+        let name = path.basename(target);
+        try {
+          const proj = await readProject();
+          if (proj && typeof proj === "object" && proj !== null) {
+            const meta = (proj as Record<string, unknown>).meta;
+            if (meta && typeof meta === "object" && meta !== null) {
+              const n = (meta as Record<string, unknown>).name;
+              if (typeof n === "string" && n.trim().length > 0) name = n;
+            }
+          }
+        } catch { /* recent name update only — open may still proceed before #672 init flow */ }
+        const entry = await upsertWorkspace(target, name);
+        await setLastActive(entry.id);
+        wsBridge.broadcast("workspace.changed", {
+          activeId: entry.id,
+          path: entry.path,
+          name: entry.name,
+          lockdown: false,
+        });
+        return { content: [{ type: "text", text: `ワークスペース「${entry.name}」を開きました (${entry.path})` }] };
+      }
+
+      case "designer__workspace_close": {
+        try {
+          clearActive();
+        } catch (e) {
+          if (e instanceof LockdownError) {
+            throw new McpError(ErrorCode.InvalidParams, e.message);
+          }
+          throw e;
+        }
+        await setLastActive(null);
+        wsBridge.broadcast("workspace.changed", {
+          activeId: null,
+          path: null,
+          name: null,
+          lockdown: false,
+        });
+        return { content: [{ type: "text", text: "ワークスペースを閉じました。" }] };
+      }
+
+      case "designer__workspace_remove": {
+        if (isLockdown()) {
+          throw new McpError(ErrorCode.InvalidParams, "lockdown モード中はワークスペースを除外できません");
+        }
+        const a = (args ?? {}) as Record<string, unknown>;
+        if (typeof a.id !== "string") {
+          throw new McpError(ErrorCode.InvalidParams, "id は必須です");
+        }
+        const removed = await removeWorkspace(a.id);
+        if (!removed) {
+          return { content: [{ type: "text", text: `id ${a.id} のワークスペースは見つかりませんでした。` }] };
+        }
+        return { content: [{ type: "text", text: `id ${a.id} を recent から除外しました (ファイルは変更されません)。` }] };
+      }
+
       default:
         throw new McpError(ErrorCode.MethodNotFound, `未知のツール: ${name}`);
     }
   } catch (err) {
+    if (err instanceof WorkspaceUnsetError) {
+      throw new McpError(ErrorCode.InvalidParams, err.message);
+    }
     if (err instanceof McpError) throw err;
     const message = err instanceof Error ? err.message : String(err);
     return {

--- a/designer-mcp/src/index.ts
+++ b/designer-mcp/src/index.ts
@@ -1041,6 +1041,8 @@ function createMcpServer(): Server {
         if (!target) throw new McpError(ErrorCode.InvalidParams, "path 解決に失敗しました");
 
         // init=true のとき: フォルダ作成 + project.json 初期化を行ってから open する (#672)
+        // init=false のとき: stale recent / typo path を active 化して fs を破壊しないよう、
+        // open 前に inspect で ready 状態を確認 (notFound / needsInit は reject)
         let resolvedName: string | null = null;
         if (initFlag) {
           if (isLockdown()) {
@@ -1053,6 +1055,16 @@ function createMcpServer(): Server {
           } catch (e) {
             const msg = e instanceof Error ? e.message : String(e);
             throw new McpError(ErrorCode.InternalError, `ワークスペース初期化失敗: ${msg}`);
+          }
+        } else {
+          const inspect = await inspectWorkspacePath(target);
+          if (inspect.status !== "ready") {
+            throw new McpError(
+              ErrorCode.InvalidParams,
+              inspect.status === "notFound"
+                ? `フォルダが見つかりません: ${target}`
+                : `ワークスペースが初期化されていません (project.json なし): ${target}。init=true で初期化してください。`,
+            );
           }
         }
 

--- a/designer-mcp/src/index.ts
+++ b/designer-mcp/src/index.ts
@@ -20,6 +20,7 @@ import { readProject, readCustomBlocks, readTable, writeTable, deleteTable as de
 import { mcpTableToSpecEntry } from "./specExport.js";
 import { initWorkspaceState, getActivePath, setActivePath, clearActive, isLockdown, getLockdownPath, LockdownError, WorkspaceUnsetError } from "./workspaceState.js";
 import { listWorkspaces, upsertWorkspace, removeWorkspace, findById, findByPath, setLastActive } from "./recentStore.js";
+import { autoActivateOnStartup, inspectWorkspacePath, initializeWorkspace } from "./workspaceInit.js";
 
 // 常駐バックエンドなので停止 signal (SIGTERM/SIGINT/disconnect) のみ監視。
 // stdin は監視しない (#302: HTTP transport に統一、stdio 廃止)。
@@ -37,6 +38,28 @@ setupLifecycle();
 
 // workspace 状態の初期化 (#671): env DESIGNER_DATA_DIR があれば lockdown モード固定
 initWorkspaceState();
+
+// 起動時の自動 active 設定 (#672):
+// 1. lockdown 中はスキップ (env で固定済み)
+// 2. recent.lastActiveId が指す workspace があれば再オープン
+// 3. 旧来の <repo>/data/ に project.json があれば default workspace として登録 + active 化
+{
+  const r = await autoActivateOnStartup();
+  switch (r.status) {
+    case "lockdown":
+      console.error(`[Workspace] lockdown モード: ${r.path}`);
+      break;
+    case "restored":
+      console.error(`[Workspace] 前回の workspace を再オープン: ${r.entry.name} (${r.entry.path})`);
+      break;
+    case "registeredLegacy":
+      console.error(`[Workspace] 旧来の data/ を default workspace として登録: ${r.entry.path}`);
+      break;
+    case "none":
+      console.error("[Workspace] active 未選択。UI 側で /workspace/select に誘導されます");
+      break;
+  }
+}
 
 // HTTP + WebSocket サーバ起動 (port 5179 に両方同居)
 await wsBridge.start();
@@ -1002,8 +1025,12 @@ function createMcpServer(): Server {
 
       case "designer__workspace_open": {
         const a = (args ?? {}) as Record<string, unknown>;
+        const initFlag = a.init === true;
         if (typeof a.path !== "string" && typeof a.id !== "string") {
           throw new McpError(ErrorCode.InvalidParams, "path または id のいずれかが必要です");
+        }
+        if (initFlag && typeof a.path !== "string") {
+          throw new McpError(ErrorCode.InvalidParams, "init=true の場合は path が必須です");
         }
         let target = typeof a.path === "string" ? a.path : null;
         if (!target && typeof a.id === "string") {
@@ -1012,6 +1039,23 @@ function createMcpServer(): Server {
           target = entry.path;
         }
         if (!target) throw new McpError(ErrorCode.InvalidParams, "path 解決に失敗しました");
+
+        // init=true のとき: フォルダ作成 + project.json 初期化を行ってから open する (#672)
+        let resolvedName: string | null = null;
+        if (initFlag) {
+          if (isLockdown()) {
+            throw new McpError(ErrorCode.InvalidParams, "lockdown モード中は新規ワークスペース初期化はできません");
+          }
+          try {
+            const initRes = await initializeWorkspace(target);
+            resolvedName = initRes.name;
+            target = initRes.path;
+          } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            throw new McpError(ErrorCode.InternalError, `ワークスペース初期化失敗: ${msg}`);
+          }
+        }
+
         try {
           setActivePath(target);
         } catch (e) {
@@ -1021,7 +1065,7 @@ function createMcpServer(): Server {
           throw e;
         }
         // project.json を読んで name をキャッシュ。失敗時は basename にフォールバック
-        let name = path.basename(target);
+        let name = resolvedName ?? path.basename(target);
         try {
           const proj = await readProject();
           if (proj && typeof proj === "object" && proj !== null) {
@@ -1031,7 +1075,7 @@ function createMcpServer(): Server {
               if (typeof n === "string" && n.trim().length > 0) name = n;
             }
           }
-        } catch { /* recent name update only — open may still proceed before #672 init flow */ }
+        } catch { /* fallback to basename / init result */ }
         const entry = await upsertWorkspace(target, name);
         await setLastActive(entry.id);
         wsBridge.broadcast("workspace.changed", {
@@ -1041,6 +1085,15 @@ function createMcpServer(): Server {
           lockdown: false,
         });
         return { content: [{ type: "text", text: `ワークスペース「${entry.name}」を開きました (${entry.path})` }] };
+      }
+
+      case "designer__workspace_inspect": {
+        const a = (args ?? {}) as Record<string, unknown>;
+        if (typeof a.path !== "string") {
+          throw new McpError(ErrorCode.InvalidParams, "path は必須です");
+        }
+        const result = await inspectWorkspacePath(a.path);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       }
 
       case "designer__workspace_close": {

--- a/designer-mcp/src/projectStorage.ts
+++ b/designer-mcp/src/projectStorage.ts
@@ -1,33 +1,38 @@
 /**
  * projectStorage.ts
- * ファイルベースのプロジェクトデータ永続化ユーティリティ
+ * ファイルベースのプロジェクトデータ永続化ユーティリティ。
  *
- * データディレクトリ: $DESIGNER_DATA_DIR または ../data（ワークスペースルート）
+ * #671 以降、active workspace path は `workspaceState` モジュールが保持する。
+ * 本モジュール内の path 解決はすべて `requireActivePath()` 経由で行うため、
+ * active 未選択時は WorkspaceUnsetError を throw する。
  */
 import fs from "fs/promises";
 import path from "path";
 import Ajv, { type ValidateFunction } from "ajv";
+import { requireActivePath } from "./workspaceState.js";
 
-// DATA_DIR: 環境変数で上書き可能
-// デフォルト: designer-mcp/src/ から 2 段上がって data/
-export const DATA_DIR =
-  process.env.DESIGNER_DATA_DIR ??
-  path.resolve(import.meta.dirname, "../../data");
+// ── path 解決ヘルパー (#671) ─────────────────────────────────────────
+// workspace 切替に追従するため、絶対パス constant を廃止し getter 関数化。
 
-const SCREENS_DIR = path.join(DATA_DIR, "screens");
-const TABLES_DIR = path.join(DATA_DIR, "tables");
-const ACTIONS_DIR = path.join(DATA_DIR, "actions");
-const CONVENTIONS_DIR = path.join(DATA_DIR, "conventions");
-const SCREEN_ITEMS_DIR = path.join(DATA_DIR, "screen-items");
-const SEQUENCES_DIR = path.join(DATA_DIR, "sequences");
-const VIEWS_DIR = path.join(DATA_DIR, "views");
-const VIEW_DEFINITIONS_DIR = path.join(DATA_DIR, "view-definitions");
-export const EXTENSIONS_DIR = path.join(DATA_DIR, "extensions");
-export const PROJECT_FILE = path.join(DATA_DIR, "project.json");
-export const CUSTOM_BLOCKS_FILE = path.join(DATA_DIR, "custom-blocks.json");
-export const ER_LAYOUT_FILE = path.join(DATA_DIR, "er-layout.json");
-export const SCREEN_LAYOUT_FILE = path.join(DATA_DIR, "screen-layout.json");
-export const CONVENTIONS_FILE = path.join(CONVENTIONS_DIR, "catalog.json");
+/** 現在 active な workspace のルート絶対パスを返す。未選択なら throw */
+export function dataDir(): string {
+  return requireActivePath();
+}
+
+const screensDir       = () => path.join(dataDir(), "screens");
+const tablesDir        = () => path.join(dataDir(), "tables");
+const actionsDir       = () => path.join(dataDir(), "actions");
+const conventionsDir   = () => path.join(dataDir(), "conventions");
+const screenItemsDir   = () => path.join(dataDir(), "screen-items");
+const sequencesDir     = () => path.join(dataDir(), "sequences");
+const viewsDir         = () => path.join(dataDir(), "views");
+const viewDefsDir      = () => path.join(dataDir(), "view-definitions");
+export const extensionsDir = () => path.join(dataDir(), "extensions");
+export const projectFile      = () => path.join(dataDir(), "project.json");
+export const customBlocksFile = () => path.join(dataDir(), "custom-blocks.json");
+export const erLayoutFile     = () => path.join(dataDir(), "er-layout.json");
+export const screenLayoutFile = () => path.join(dataDir(), "screen-layout.json");
+export const conventionsFile  = () => path.join(conventionsDir(), "catalog.json");
 
 const EXTENSION_FILE_NAMES = {
   steps: "steps.json",
@@ -78,18 +83,18 @@ async function validateExtensionFile(kind: ExtensionFileKind, data: unknown): Pr
   }
 }
 
-/** data/ ディレクトリ群を作成（既存なら無視） */
+/** active workspace 配下のディレクトリ群を作成（既存なら無視） */
 export async function ensureDataDir(): Promise<void> {
-  await fs.mkdir(DATA_DIR, { recursive: true });
-  await fs.mkdir(SCREENS_DIR, { recursive: true });
-  await fs.mkdir(TABLES_DIR, { recursive: true });
-  await fs.mkdir(ACTIONS_DIR, { recursive: true });
-  await fs.mkdir(CONVENTIONS_DIR, { recursive: true });
+  await fs.mkdir(dataDir(), { recursive: true });
+  await fs.mkdir(screensDir(), { recursive: true });
+  await fs.mkdir(tablesDir(), { recursive: true });
+  await fs.mkdir(actionsDir(), { recursive: true });
+  await fs.mkdir(conventionsDir(), { recursive: true });
   // screen-items/ は Phase 4-β migration 後に廃止済み — 再作成しない
-  await fs.mkdir(SEQUENCES_DIR, { recursive: true });
-  await fs.mkdir(VIEWS_DIR, { recursive: true });
-  await fs.mkdir(VIEW_DEFINITIONS_DIR, { recursive: true });
-  await fs.mkdir(EXTENSIONS_DIR, { recursive: true });
+  await fs.mkdir(sequencesDir(), { recursive: true });
+  await fs.mkdir(viewsDir(), { recursive: true });
+  await fs.mkdir(viewDefsDir(), { recursive: true });
+  await fs.mkdir(extensionsDir(), { recursive: true });
 }
 
 async function readJSON<T>(filePath: string): Promise<T | null> {
@@ -108,7 +113,7 @@ async function writeJSON(filePath: string, data: unknown): Promise<void> {
 
 /** project.json を読み込み（存在しない場合は null） */
 export async function readProject(): Promise<unknown | null> {
-  return readJSON<unknown>(PROJECT_FILE);
+  return readJSON<unknown>(projectFile());
 }
 
 /** project.json を書き込み */
@@ -116,13 +121,13 @@ export async function writeProject(project: unknown): Promise<void> {
   await ensureDataDir();
   const next = project as Record<string, unknown>;
   if (next.schemaVersion === "v3") {
-    const current = await readJSON<Record<string, unknown>>(PROJECT_FILE);
+    const current = await readJSON<Record<string, unknown>>(projectFile());
     if (current && current.schemaVersion !== "v3") {
       const ts = new Date().toISOString().replace(/[:.]/g, "-");
-      await fs.copyFile(PROJECT_FILE, `${PROJECT_FILE}.bak.${ts}`);
+      await fs.copyFile(projectFile(), `${projectFile()}.bak.${ts}`);
     }
   }
-  await writeJSON(PROJECT_FILE, project);
+  await writeJSON(projectFile(), project);
 }
 
 /** 各種データファイルの更新時刻を取得（存在しないなら null） */
@@ -139,18 +144,18 @@ export async function getFileMtime(kind: string, id?: string): Promise<number | 
 
 function resolveDataFile(kind: string, id?: string): string | null {
   switch (kind) {
-    case "project": return PROJECT_FILE;
-    case "erLayout": return ER_LAYOUT_FILE;
-    case "customBlocks": return CUSTOM_BLOCKS_FILE;
-    case "conventions": return CONVENTIONS_FILE;
-    case "screen": return id ? path.join(SCREENS_DIR, `${id}.design.json`) : null;
-    case "screenEntity": return id ? path.join(SCREENS_DIR, `${id}.json`) : null;
-    case "table": return id ? path.join(TABLES_DIR, `${id}.json`) : null;
-    case "processFlow": return id ? path.join(ACTIONS_DIR, `${id}.json`) : null;
-    case "screenItems": return id ? path.join(SCREEN_ITEMS_DIR, `${id}.json`) : null;
-    case "sequence": return id ? path.join(SEQUENCES_DIR, `${id}.json`) : null;
-    case "view": return id ? path.join(VIEWS_DIR, `${id}.json`) : null;
-    case "viewDefinition": return id ? path.join(VIEW_DEFINITIONS_DIR, `${id}.json`) : null;
+    case "project": return projectFile();
+    case "erLayout": return erLayoutFile();
+    case "customBlocks": return customBlocksFile();
+    case "conventions": return conventionsFile();
+    case "screen": return id ? path.join(screensDir(), `${id}.design.json`) : null;
+    case "screenEntity": return id ? path.join(screensDir(), `${id}.json`) : null;
+    case "table": return id ? path.join(tablesDir(), `${id}.json`) : null;
+    case "processFlow": return id ? path.join(actionsDir(), `${id}.json`) : null;
+    case "screenItems": return id ? path.join(screenItemsDir(), `${id}.json`) : null;
+    case "sequence": return id ? path.join(sequencesDir(), `${id}.json`) : null;
+    case "view": return id ? path.join(viewsDir(), `${id}.json`) : null;
+    case "viewDefinition": return id ? path.join(viewDefsDir(), `${id}.json`) : null;
     default: return null;
   }
 }
@@ -215,9 +220,9 @@ const _inflightMigrations = new Map<string, Promise<Record<string, unknown> | nu
 
 async function _migrateScreenCore(screenId: string): Promise<Record<string, unknown> | null> {
   await ensureDataDir();
-  const entityPath = path.join(SCREENS_DIR, `${screenId}.json`);
-  const designPath = path.join(SCREENS_DIR, `${screenId}.design.json`);
-  const legacyItemsPath = path.join(SCREEN_ITEMS_DIR, `${screenId}.json`);
+  const entityPath = path.join(screensDir(), `${screenId}.json`);
+  const designPath = path.join(screensDir(), `${screenId}.design.json`);
+  const legacyItemsPath = path.join(screenItemsDir(), `${screenId}.json`);
   const current = await readJSON<unknown>(entityPath);
 
   if (isScreenEntity(current) && !isLegacyGrapesScreen(current)) {
@@ -267,7 +272,7 @@ export async function readExtensionsBundle(): Promise<Record<ExtensionFileKind, 
   await ensureDataDir();
   const entries = await Promise.all(
     Object.entries(EXTENSION_FILE_NAMES).map(async ([kind, fileName]) => {
-      const data = await readJSON<unknown>(path.join(EXTENSIONS_DIR, fileName));
+      const data = await readJSON<unknown>(path.join(extensionsDir(), fileName));
       return [kind, data] as const;
     }),
   );
@@ -284,14 +289,14 @@ export async function writeExtensionsFile(
   if (!options?.skipValidation) {
     await validateExtensionFile(type, content);
   }
-  await writeJSON(path.join(EXTENSIONS_DIR, EXTENSION_FILE_NAMES[type]), content);
+  await writeJSON(path.join(extensionsDir(), EXTENSION_FILE_NAMES[type]), content);
   options?.onAfterWrite?.();
 }
 
 /** screens/{screenId}.json を読み込み */
 export async function readScreen(screenId: string): Promise<unknown | null> {
   await migrateScreenIfNeeded(screenId);
-  return readJSON<unknown>(path.join(SCREENS_DIR, `${screenId}.design.json`));
+  return readJSON<unknown>(path.join(screensDir(), `${screenId}.design.json`));
 }
 
 /** screens/{screenId}.json を書き込み */
@@ -311,8 +316,8 @@ export async function writeScreen(screenId: string, data: unknown): Promise<void
       designFileRef: `${screenId}.design.json`,
     },
   };
-  await writeJSON(path.join(SCREENS_DIR, `${screenId}.json`), entity);
-  await writeJSON(path.join(SCREENS_DIR, `${screenId}.design.json`), data);
+  await writeJSON(path.join(screensDir(), `${screenId}.json`), entity);
+  await writeJSON(path.join(screensDir(), `${screenId}.design.json`), data);
 }
 
 export async function readScreenEntity(screenId: string): Promise<unknown | null> {
@@ -337,70 +342,70 @@ export async function writeScreenEntity(screenId: string, data: unknown): Promis
       designFileRef: `${screenId}.design.json`,
     },
   };
-  await writeJSON(path.join(SCREENS_DIR, `${screenId}.json`), toSave);
+  await writeJSON(path.join(screensDir(), `${screenId}.json`), toSave);
 }
 
 /** screens/{screenId}.json を削除（存在しない場合は無視） */
 export async function deleteScreen(screenId: string): Promise<void> {
   try {
-    await fs.unlink(path.join(SCREENS_DIR, `${screenId}.json`));
+    await fs.unlink(path.join(screensDir(), `${screenId}.json`));
   } catch { /* file not found is OK */ }
   try {
-    await fs.unlink(path.join(SCREENS_DIR, `${screenId}.design.json`));
+    await fs.unlink(path.join(screensDir(), `${screenId}.design.json`));
   } catch { /* file not found is OK */ }
   try {
-    await fs.unlink(path.join(SCREEN_ITEMS_DIR, `${screenId}.json`));
+    await fs.unlink(path.join(screenItemsDir(), `${screenId}.json`));
   } catch { /* file not found is OK */ }
 }
 
 /** custom-blocks.json を読み込み */
 export async function readCustomBlocks(): Promise<unknown[]> {
-  return (await readJSON<unknown[]>(CUSTOM_BLOCKS_FILE)) ?? [];
+  return (await readJSON<unknown[]>(customBlocksFile())) ?? [];
 }
 
 /** custom-blocks.json を書き込み */
 export async function writeCustomBlocks(blocks: unknown[]): Promise<void> {
   await ensureDataDir();
-  await writeJSON(CUSTOM_BLOCKS_FILE, blocks);
+  await writeJSON(customBlocksFile(), blocks);
 }
 
 /** er-layout.json を読み込み */
 export async function readErLayout(): Promise<unknown | null> {
-  return readJSON<unknown>(ER_LAYOUT_FILE);
+  return readJSON<unknown>(erLayoutFile());
 }
 
 /** er-layout.json を書き込み */
 export async function writeErLayout(data: unknown): Promise<void> {
   await ensureDataDir();
-  await writeJSON(ER_LAYOUT_FILE, data);
+  await writeJSON(erLayoutFile(), data);
 }
 
 /** screen-layout.json を読み込み (Phase 3-β、#561) */
 export async function readScreenLayout(): Promise<unknown | null> {
-  return readJSON<unknown>(SCREEN_LAYOUT_FILE);
+  return readJSON<unknown>(screenLayoutFile());
 }
 
 /** screen-layout.json を書き込み (Phase 3-β、#561) */
 export async function writeScreenLayout(data: unknown): Promise<void> {
   await ensureDataDir();
-  await writeJSON(SCREEN_LAYOUT_FILE, data);
+  await writeJSON(screenLayoutFile(), data);
 }
 
 /** tables/{tableId}.json を読み込み */
 export async function readTable(tableId: string): Promise<unknown | null> {
-  return readJSON<unknown>(path.join(TABLES_DIR, `${tableId}.json`));
+  return readJSON<unknown>(path.join(tablesDir(), `${tableId}.json`));
 }
 
 /** tables/{tableId}.json を書き込み */
 export async function writeTable(tableId: string, data: unknown): Promise<void> {
   await ensureDataDir();
-  await writeJSON(path.join(TABLES_DIR, `${tableId}.json`), data);
+  await writeJSON(path.join(tablesDir(), `${tableId}.json`), data);
 }
 
 /** tables/{tableId}.json を削除（存在しない場合は無視） */
 export async function deleteTable(tableId: string): Promise<void> {
   try {
-    await fs.unlink(path.join(TABLES_DIR, `${tableId}.json`));
+    await fs.unlink(path.join(tablesDir(), `${tableId}.json`));
   } catch { /* file not found is OK */ }
 }
 
@@ -408,11 +413,11 @@ export async function deleteTable(tableId: string): Promise<void> {
 export async function listAllTables(): Promise<unknown[]> {
   try {
     await ensureDataDir();
-    const files = await fs.readdir(TABLES_DIR);
+    const files = await fs.readdir(tablesDir());
     const results: unknown[] = [];
     for (const file of files) {
       if (!file.endsWith(".json")) continue;
-      const data = await readJSON<unknown>(path.join(TABLES_DIR, file));
+      const data = await readJSON<unknown>(path.join(tablesDir(), file));
       if (data) results.push(data);
     }
     return results;
@@ -423,31 +428,31 @@ export async function listAllTables(): Promise<unknown[]> {
 
 /** actions/{processFlowId}.json を読み込み */
 export async function readProcessFlow(processFlowId: string): Promise<unknown | null> {
-  return readJSON<unknown>(path.join(ACTIONS_DIR, `${processFlowId}.json`));
+  return readJSON<unknown>(path.join(actionsDir(), `${processFlowId}.json`));
 }
 
 /** actions/{processFlowId}.json を書き込み */
 export async function writeProcessFlow(processFlowId: string, data: unknown): Promise<void> {
   await ensureDataDir();
-  await writeJSON(path.join(ACTIONS_DIR, `${processFlowId}.json`), data);
+  await writeJSON(path.join(actionsDir(), `${processFlowId}.json`), data);
 }
 
 /** actions/{processFlowId}.json を削除（存在しない場合は無視） */
 export async function deleteProcessFlow(processFlowId: string): Promise<void> {
   try {
-    await fs.unlink(path.join(ACTIONS_DIR, `${processFlowId}.json`));
+    await fs.unlink(path.join(actionsDir(), `${processFlowId}.json`));
   } catch { /* file not found is OK */ }
 }
 
 /** conventions/catalog.json を読み込み (#317) */
 export async function readConventions(): Promise<unknown | null> {
-  return readJSON<unknown>(CONVENTIONS_FILE);
+  return readJSON<unknown>(conventionsFile());
 }
 
 /** conventions/catalog.json を書き込み (#317) */
 export async function writeConventions(data: unknown): Promise<void> {
   await ensureDataDir();
-  await writeJSON(CONVENTIONS_FILE, data);
+  await writeJSON(conventionsFile(), data);
 }
 
 /** screen-items/{screenId}.json を読み込み (#318) */
@@ -472,7 +477,7 @@ export async function writeScreenItems(screenId: string, data: unknown): Promise
     updatedAt: new Date().toISOString(),
   };
   await writeScreenEntity(screenId, next);
-  try { await fs.unlink(path.join(SCREEN_ITEMS_DIR, `${screenId}.json`)); } catch { /* ignore */ }
+  try { await fs.unlink(path.join(screenItemsDir(), `${screenId}.json`)); } catch { /* ignore */ }
 }
 
 /** screen-items/{screenId}.json を削除 (#318) */
@@ -482,25 +487,25 @@ export async function deleteScreenItems(screenId: string): Promise<void> {
     await writeScreenEntity(screenId, { ...current, items: [] });
   }
   try {
-    await fs.unlink(path.join(SCREEN_ITEMS_DIR, `${screenId}.json`));
+    await fs.unlink(path.join(screenItemsDir(), `${screenId}.json`));
   } catch { /* file not found is OK */ }
 }
 
 /** sequences/{sequenceId}.json を読み込み (#374) */
 export async function readSequence(sequenceId: string): Promise<unknown | null> {
-  return readJSON<unknown>(path.join(SEQUENCES_DIR, `${sequenceId}.json`));
+  return readJSON<unknown>(path.join(sequencesDir(), `${sequenceId}.json`));
 }
 
 /** sequences/{sequenceId}.json を書き込み (#374) */
 export async function writeSequence(sequenceId: string, data: unknown): Promise<void> {
   await ensureDataDir();
-  await writeJSON(path.join(SEQUENCES_DIR, `${sequenceId}.json`), data);
+  await writeJSON(path.join(sequencesDir(), `${sequenceId}.json`), data);
 }
 
 /** sequences/{sequenceId}.json を削除（存在しない場合は無視） (#374) */
 export async function deleteSequence(sequenceId: string): Promise<void> {
   try {
-    await fs.unlink(path.join(SEQUENCES_DIR, `${sequenceId}.json`));
+    await fs.unlink(path.join(sequencesDir(), `${sequenceId}.json`));
   } catch { /* file not found is OK */ }
 }
 
@@ -508,11 +513,11 @@ export async function deleteSequence(sequenceId: string): Promise<void> {
 export async function listAllViews(): Promise<unknown[]> {
   try {
     await ensureDataDir();
-    const files = await fs.readdir(VIEWS_DIR);
+    const files = await fs.readdir(viewsDir());
     const results: unknown[] = [];
     for (const file of files) {
       if (!file.endsWith(".json")) continue;
-      const data = await readJSON<unknown>(path.join(VIEWS_DIR, file));
+      const data = await readJSON<unknown>(path.join(viewsDir(), file));
       if (data) results.push(data);
     }
     return results;
@@ -523,30 +528,30 @@ export async function listAllViews(): Promise<unknown[]> {
 
 /** views/{viewId}.json を読み込み (v3 per-entity #549) */
 export async function readView(viewId: string): Promise<unknown | null> {
-  return readJSON<unknown>(path.join(VIEWS_DIR, `${viewId}.json`));
+  return readJSON<unknown>(path.join(viewsDir(), `${viewId}.json`));
 }
 
 /** views/{viewId}.json を書き込み (v3 per-entity #549) */
 export async function writeView(viewId: string, data: unknown): Promise<void> {
   await ensureDataDir();
-  await writeJSON(path.join(VIEWS_DIR, `${viewId}.json`), data);
+  await writeJSON(path.join(viewsDir(), `${viewId}.json`), data);
 }
 
 /** views/{viewId}.json を削除（存在しない場合は無視） (v3 per-entity #549) */
 export async function deleteView(viewId: string): Promise<void> {
   try {
-    await fs.unlink(path.join(VIEWS_DIR, `${viewId}.json`));
+    await fs.unlink(path.join(viewsDir(), `${viewId}.json`));
   } catch { /* file not found is OK */ }
 }
 
 export async function listAllViewDefinitions(): Promise<unknown[]> {
   try {
     await ensureDataDir();
-    const files = await fs.readdir(VIEW_DEFINITIONS_DIR);
+    const files = await fs.readdir(viewDefsDir());
     const results: unknown[] = [];
     for (const file of files) {
       if (!file.endsWith(".json")) continue;
-      const data = await readJSON<unknown>(path.join(VIEW_DEFINITIONS_DIR, file));
+      const data = await readJSON<unknown>(path.join(viewDefsDir(), file));
       if (data) results.push(data);
     }
     return results;
@@ -556,17 +561,17 @@ export async function listAllViewDefinitions(): Promise<unknown[]> {
 }
 
 export async function readViewDefinition(viewDefinitionId: string): Promise<unknown | null> {
-  return readJSON<unknown>(path.join(VIEW_DEFINITIONS_DIR, `${viewDefinitionId}.json`));
+  return readJSON<unknown>(path.join(viewDefsDir(), `${viewDefinitionId}.json`));
 }
 
 export async function writeViewDefinition(viewDefinitionId: string, data: unknown): Promise<void> {
   await ensureDataDir();
-  await writeJSON(path.join(VIEW_DEFINITIONS_DIR, `${viewDefinitionId}.json`), data);
+  await writeJSON(path.join(viewDefsDir(), `${viewDefinitionId}.json`), data);
 }
 
 export async function deleteViewDefinition(viewDefinitionId: string): Promise<void> {
   try {
-    await fs.unlink(path.join(VIEW_DEFINITIONS_DIR, `${viewDefinitionId}.json`));
+    await fs.unlink(path.join(viewDefsDir(), `${viewDefinitionId}.json`));
   } catch { /* file not found is OK */ }
 }
 
@@ -574,11 +579,11 @@ export async function deleteViewDefinition(viewDefinitionId: string): Promise<vo
 export async function listProcessFlows(): Promise<unknown[]> {
   try {
     await ensureDataDir();
-    const files = await fs.readdir(ACTIONS_DIR);
+    const files = await fs.readdir(actionsDir());
     const results: unknown[] = [];
     for (const file of files) {
       if (!file.endsWith(".json")) continue;
-      const data = await readJSON<unknown>(path.join(ACTIONS_DIR, file));
+      const data = await readJSON<unknown>(path.join(actionsDir(), file));
       if (data) results.push(data);
     }
     return results;

--- a/designer-mcp/src/projectStorage.ts
+++ b/designer-mcp/src/projectStorage.ts
@@ -140,7 +140,8 @@ export async function writeProject(project: unknown): Promise<void> {
 
 /** 各種データファイルの更新時刻を取得（存在しないなら null） */
 export async function getFileMtime(kind: string, id?: string): Promise<number | null> {
-  const filePath = resolveDataFile(kind, id);
+  const root = requireActivePath();
+  const filePath = resolveDataFile(kind, root, id);
   if (!filePath) return null;
   try {
     const stat = await fs.stat(filePath);
@@ -150,20 +151,20 @@ export async function getFileMtime(kind: string, id?: string): Promise<number | 
   }
 }
 
-function resolveDataFile(kind: string, id?: string): string | null {
+function resolveDataFile(kind: string, root: string, id?: string): string | null {
   switch (kind) {
-    case "project": return projectFile();
-    case "erLayout": return erLayoutFile();
-    case "customBlocks": return customBlocksFile();
-    case "conventions": return conventionsFile();
-    case "screen": return id ? path.join(screensDir(), `${id}.design.json`) : null;
-    case "screenEntity": return id ? path.join(screensDir(), `${id}.json`) : null;
-    case "table": return id ? path.join(tablesDir(), `${id}.json`) : null;
-    case "processFlow": return id ? path.join(actionsDir(), `${id}.json`) : null;
-    case "screenItems": return id ? path.join(screenItemsDir(), `${id}.json`) : null;
-    case "sequence": return id ? path.join(sequencesDir(), `${id}.json`) : null;
-    case "view": return id ? path.join(viewsDir(), `${id}.json`) : null;
-    case "viewDefinition": return id ? path.join(viewDefsDir(), `${id}.json`) : null;
+    case "project": return projectFile(root);
+    case "erLayout": return erLayoutFile(root);
+    case "customBlocks": return customBlocksFile(root);
+    case "conventions": return conventionsFile(root);
+    case "screen": return id ? path.join(screensDir(root), `${id}.design.json`) : null;
+    case "screenEntity": return id ? path.join(screensDir(root), `${id}.json`) : null;
+    case "table": return id ? path.join(tablesDir(root), `${id}.json`) : null;
+    case "processFlow": return id ? path.join(actionsDir(root), `${id}.json`) : null;
+    case "screenItems": return id ? path.join(screenItemsDir(root), `${id}.json`) : null;
+    case "sequence": return id ? path.join(sequencesDir(root), `${id}.json`) : null;
+    case "view": return id ? path.join(viewsDir(root), `${id}.json`) : null;
+    case "viewDefinition": return id ? path.join(viewDefsDir(root), `${id}.json`) : null;
     default: return null;
   }
 }
@@ -381,7 +382,8 @@ export async function deleteScreen(screenId: string): Promise<void> {
 
 /** custom-blocks.json を読み込み */
 export async function readCustomBlocks(): Promise<unknown[]> {
-  return (await readJSON<unknown[]>(customBlocksFile())) ?? [];
+  const root = requireActivePath();
+  return (await readJSON<unknown[]>(customBlocksFile(root))) ?? [];
 }
 
 /** custom-blocks.json を書き込み */
@@ -393,7 +395,8 @@ export async function writeCustomBlocks(blocks: unknown[]): Promise<void> {
 
 /** er-layout.json を読み込み */
 export async function readErLayout(): Promise<unknown | null> {
-  return readJSON<unknown>(erLayoutFile());
+  const root = requireActivePath();
+  return readJSON<unknown>(erLayoutFile(root));
 }
 
 /** er-layout.json を書き込み */
@@ -405,7 +408,8 @@ export async function writeErLayout(data: unknown): Promise<void> {
 
 /** screen-layout.json を読み込み (Phase 3-β、#561) */
 export async function readScreenLayout(): Promise<unknown | null> {
-  return readJSON<unknown>(screenLayoutFile());
+  const root = requireActivePath();
+  return readJSON<unknown>(screenLayoutFile(root));
 }
 
 /** screen-layout.json を書き込み (Phase 3-β、#561) */
@@ -417,7 +421,8 @@ export async function writeScreenLayout(data: unknown): Promise<void> {
 
 /** tables/{tableId}.json を読み込み */
 export async function readTable(tableId: string): Promise<unknown | null> {
-  return readJSON<unknown>(path.join(tablesDir(), `${tableId}.json`));
+  const root = requireActivePath();
+  return readJSON<unknown>(path.join(tablesDir(root), `${tableId}.json`));
 }
 
 /** tables/{tableId}.json を書き込み */
@@ -429,8 +434,9 @@ export async function writeTable(tableId: string, data: unknown): Promise<void> 
 
 /** tables/{tableId}.json を削除（存在しない場合は無視） */
 export async function deleteTable(tableId: string): Promise<void> {
+  const root = requireActivePath();
   try {
-    await fs.unlink(path.join(tablesDir(), `${tableId}.json`));
+    await fs.unlink(path.join(tablesDir(root), `${tableId}.json`));
   } catch { /* file not found is OK */ }
 }
 
@@ -455,7 +461,8 @@ export async function listAllTables(): Promise<unknown[]> {
 
 /** actions/{processFlowId}.json を読み込み */
 export async function readProcessFlow(processFlowId: string): Promise<unknown | null> {
-  return readJSON<unknown>(path.join(actionsDir(), `${processFlowId}.json`));
+  const root = requireActivePath();
+  return readJSON<unknown>(path.join(actionsDir(root), `${processFlowId}.json`));
 }
 
 /** actions/{processFlowId}.json を書き込み */
@@ -467,14 +474,16 @@ export async function writeProcessFlow(processFlowId: string, data: unknown): Pr
 
 /** actions/{processFlowId}.json を削除（存在しない場合は無視） */
 export async function deleteProcessFlow(processFlowId: string): Promise<void> {
+  const root = requireActivePath();
   try {
-    await fs.unlink(path.join(actionsDir(), `${processFlowId}.json`));
+    await fs.unlink(path.join(actionsDir(root), `${processFlowId}.json`));
   } catch { /* file not found is OK */ }
 }
 
 /** conventions/catalog.json を読み込み (#317) */
 export async function readConventions(): Promise<unknown | null> {
-  return readJSON<unknown>(conventionsFile());
+  const root = requireActivePath();
+  return readJSON<unknown>(conventionsFile(root));
 }
 
 /** conventions/catalog.json を書き込み (#317) */
@@ -524,7 +533,8 @@ export async function deleteScreenItems(screenId: string): Promise<void> {
 
 /** sequences/{sequenceId}.json を読み込み (#374) */
 export async function readSequence(sequenceId: string): Promise<unknown | null> {
-  return readJSON<unknown>(path.join(sequencesDir(), `${sequenceId}.json`));
+  const root = requireActivePath();
+  return readJSON<unknown>(path.join(sequencesDir(root), `${sequenceId}.json`));
 }
 
 /** sequences/{sequenceId}.json を書き込み (#374) */
@@ -536,8 +546,9 @@ export async function writeSequence(sequenceId: string, data: unknown): Promise<
 
 /** sequences/{sequenceId}.json を削除（存在しない場合は無視） (#374) */
 export async function deleteSequence(sequenceId: string): Promise<void> {
+  const root = requireActivePath();
   try {
-    await fs.unlink(path.join(sequencesDir(), `${sequenceId}.json`));
+    await fs.unlink(path.join(sequencesDir(root), `${sequenceId}.json`));
   } catch { /* file not found is OK */ }
 }
 
@@ -562,7 +573,8 @@ export async function listAllViews(): Promise<unknown[]> {
 
 /** views/{viewId}.json を読み込み (v3 per-entity #549) */
 export async function readView(viewId: string): Promise<unknown | null> {
-  return readJSON<unknown>(path.join(viewsDir(), `${viewId}.json`));
+  const root = requireActivePath();
+  return readJSON<unknown>(path.join(viewsDir(root), `${viewId}.json`));
 }
 
 /** views/{viewId}.json を書き込み (v3 per-entity #549) */
@@ -574,8 +586,9 @@ export async function writeView(viewId: string, data: unknown): Promise<void> {
 
 /** views/{viewId}.json を削除（存在しない場合は無視） (v3 per-entity #549) */
 export async function deleteView(viewId: string): Promise<void> {
+  const root = requireActivePath();
   try {
-    await fs.unlink(path.join(viewsDir(), `${viewId}.json`));
+    await fs.unlink(path.join(viewsDir(root), `${viewId}.json`));
   } catch { /* file not found is OK */ }
 }
 
@@ -598,7 +611,8 @@ export async function listAllViewDefinitions(): Promise<unknown[]> {
 }
 
 export async function readViewDefinition(viewDefinitionId: string): Promise<unknown | null> {
-  return readJSON<unknown>(path.join(viewDefsDir(), `${viewDefinitionId}.json`));
+  const root = requireActivePath();
+  return readJSON<unknown>(path.join(viewDefsDir(root), `${viewDefinitionId}.json`));
 }
 
 export async function writeViewDefinition(viewDefinitionId: string, data: unknown): Promise<void> {
@@ -608,8 +622,9 @@ export async function writeViewDefinition(viewDefinitionId: string, data: unknow
 }
 
 export async function deleteViewDefinition(viewDefinitionId: string): Promise<void> {
+  const root = requireActivePath();
   try {
-    await fs.unlink(path.join(viewDefsDir(), `${viewDefinitionId}.json`));
+    await fs.unlink(path.join(viewDefsDir(root), `${viewDefinitionId}.json`));
   } catch { /* file not found is OK */ }
 }
 

--- a/designer-mcp/src/projectStorage.ts
+++ b/designer-mcp/src/projectStorage.ts
@@ -119,7 +119,10 @@ async function writeJSON(filePath: string, data: unknown): Promise<void> {
 
 /** project.json を読み込み（存在しない場合は null） */
 export async function readProject(root?: string): Promise<unknown | null> {
-  return readJSON<unknown>(projectFile(root));
+  // 他の read 関数と一貫させるため明示的に root snapshot (#676 Sonnet re-review Nit)。
+  // 引数 root が指定されていればそれを優先、未指定時は requireActivePath() で確定。
+  const r = root ?? requireActivePath();
+  return readJSON<unknown>(projectFile(r));
 }
 
 /** project.json を書き込み */

--- a/designer-mcp/src/projectStorage.ts
+++ b/designer-mcp/src/projectStorage.ts
@@ -13,26 +13,31 @@ import { requireActivePath } from "./workspaceState.js";
 
 // ── path 解決ヘルパー (#671) ─────────────────────────────────────────
 // workspace 切替に追従するため、絶対パス constant を廃止し getter 関数化。
+//
+// レース対策 (#676 review 7 周目): 各 getter は optional root を受け、未指定なら
+// requireActivePath() からフォールバック取得する。複数 path を生成する公開関数は
+// 関数開始時に root を 1 度だけスナップショットし、すべての helper にそれを渡す
+// ことで、操作中に workspace 切替が起きても書き込み先が分散しないようにする。
 
 /** 現在 active な workspace のルート絶対パスを返す。未選択なら throw */
-export function dataDir(): string {
-  return requireActivePath();
+export function dataDir(root?: string): string {
+  return root ?? requireActivePath();
 }
 
-const screensDir       = () => path.join(dataDir(), "screens");
-const tablesDir        = () => path.join(dataDir(), "tables");
-const actionsDir       = () => path.join(dataDir(), "actions");
-const conventionsDir   = () => path.join(dataDir(), "conventions");
-const screenItemsDir   = () => path.join(dataDir(), "screen-items");
-const sequencesDir     = () => path.join(dataDir(), "sequences");
-const viewsDir         = () => path.join(dataDir(), "views");
-const viewDefsDir      = () => path.join(dataDir(), "view-definitions");
-export const extensionsDir = () => path.join(dataDir(), "extensions");
-export const projectFile      = () => path.join(dataDir(), "project.json");
-export const customBlocksFile = () => path.join(dataDir(), "custom-blocks.json");
-export const erLayoutFile     = () => path.join(dataDir(), "er-layout.json");
-export const screenLayoutFile = () => path.join(dataDir(), "screen-layout.json");
-export const conventionsFile  = () => path.join(conventionsDir(), "catalog.json");
+const screensDir       = (root?: string) => path.join(dataDir(root), "screens");
+const tablesDir        = (root?: string) => path.join(dataDir(root), "tables");
+const actionsDir       = (root?: string) => path.join(dataDir(root), "actions");
+const conventionsDir   = (root?: string) => path.join(dataDir(root), "conventions");
+const screenItemsDir   = (root?: string) => path.join(dataDir(root), "screen-items");
+const sequencesDir     = (root?: string) => path.join(dataDir(root), "sequences");
+const viewsDir         = (root?: string) => path.join(dataDir(root), "views");
+const viewDefsDir      = (root?: string) => path.join(dataDir(root), "view-definitions");
+export const extensionsDir = (root?: string) => path.join(dataDir(root), "extensions");
+export const projectFile      = (root?: string) => path.join(dataDir(root), "project.json");
+export const customBlocksFile = (root?: string) => path.join(dataDir(root), "custom-blocks.json");
+export const erLayoutFile     = (root?: string) => path.join(dataDir(root), "er-layout.json");
+export const screenLayoutFile = (root?: string) => path.join(dataDir(root), "screen-layout.json");
+export const conventionsFile  = (root?: string) => path.join(conventionsDir(root), "catalog.json");
 
 const EXTENSION_FILE_NAMES = {
   steps: "steps.json",
@@ -84,17 +89,18 @@ async function validateExtensionFile(kind: ExtensionFileKind, data: unknown): Pr
 }
 
 /** active workspace 配下のディレクトリ群を作成（既存なら無視） */
-export async function ensureDataDir(): Promise<void> {
-  await fs.mkdir(dataDir(), { recursive: true });
-  await fs.mkdir(screensDir(), { recursive: true });
-  await fs.mkdir(tablesDir(), { recursive: true });
-  await fs.mkdir(actionsDir(), { recursive: true });
-  await fs.mkdir(conventionsDir(), { recursive: true });
+export async function ensureDataDir(root?: string): Promise<void> {
+  const r = dataDir(root);
+  await fs.mkdir(r, { recursive: true });
+  await fs.mkdir(screensDir(r), { recursive: true });
+  await fs.mkdir(tablesDir(r), { recursive: true });
+  await fs.mkdir(actionsDir(r), { recursive: true });
+  await fs.mkdir(conventionsDir(r), { recursive: true });
   // screen-items/ は Phase 4-β migration 後に廃止済み — 再作成しない
-  await fs.mkdir(sequencesDir(), { recursive: true });
-  await fs.mkdir(viewsDir(), { recursive: true });
-  await fs.mkdir(viewDefsDir(), { recursive: true });
-  await fs.mkdir(extensionsDir(), { recursive: true });
+  await fs.mkdir(sequencesDir(r), { recursive: true });
+  await fs.mkdir(viewsDir(r), { recursive: true });
+  await fs.mkdir(viewDefsDir(r), { recursive: true });
+  await fs.mkdir(extensionsDir(r), { recursive: true });
 }
 
 async function readJSON<T>(filePath: string): Promise<T | null> {
@@ -112,22 +118,24 @@ async function writeJSON(filePath: string, data: unknown): Promise<void> {
 }
 
 /** project.json を読み込み（存在しない場合は null） */
-export async function readProject(): Promise<unknown | null> {
-  return readJSON<unknown>(projectFile());
+export async function readProject(root?: string): Promise<unknown | null> {
+  return readJSON<unknown>(projectFile(root));
 }
 
 /** project.json を書き込み */
 export async function writeProject(project: unknown): Promise<void> {
-  await ensureDataDir();
+  const root = requireActivePath();
+  await ensureDataDir(root);
+  const projFile = projectFile(root);
   const next = project as Record<string, unknown>;
   if (next.schemaVersion === "v3") {
-    const current = await readJSON<Record<string, unknown>>(projectFile());
+    const current = await readJSON<Record<string, unknown>>(projFile);
     if (current && current.schemaVersion !== "v3") {
       const ts = new Date().toISOString().replace(/[:.]/g, "-");
-      await fs.copyFile(projectFile(), `${projectFile()}.bak.${ts}`);
+      await fs.copyFile(projFile, `${projFile}.bak.${ts}`);
     }
   }
-  await writeJSON(projectFile(), project);
+  await writeJSON(projFile, project);
 }
 
 /** 各種データファイルの更新時刻を取得（存在しないなら null） */
@@ -215,14 +223,15 @@ function buildDefaultScreenEntity(
   };
 }
 
-/** per-screenId の in-flight migration を 1 つに集約する Promise キャッシュ */
+/** per-(root, screenId) の in-flight migration を 1 つに集約する Promise キャッシュ。
+ * key を root::screenId にすることで、workspace 切替後も別 root の migration と独立に動く。 */
 const _inflightMigrations = new Map<string, Promise<Record<string, unknown> | null>>();
 
-async function _migrateScreenCore(screenId: string): Promise<Record<string, unknown> | null> {
-  await ensureDataDir();
-  const entityPath = path.join(screensDir(), `${screenId}.json`);
-  const designPath = path.join(screensDir(), `${screenId}.design.json`);
-  const legacyItemsPath = path.join(screenItemsDir(), `${screenId}.json`);
+async function _migrateScreenCore(screenId: string, root: string): Promise<Record<string, unknown> | null> {
+  await ensureDataDir(root);
+  const entityPath = path.join(screensDir(root), `${screenId}.json`);
+  const designPath = path.join(screensDir(root), `${screenId}.design.json`);
+  const legacyItemsPath = path.join(screenItemsDir(root), `${screenId}.json`);
   const current = await readJSON<unknown>(entityPath);
 
   if (isScreenEntity(current) && !isLegacyGrapesScreen(current)) {
@@ -235,7 +244,7 @@ async function _migrateScreenCore(screenId: string): Promise<Record<string, unkn
     } catch {
       await writeJSON(designPath, current);
     }
-    const project = await readProject();
+    const project = await readProject(root);
     const itemsFile = await readJSON<unknown>(legacyItemsPath);
     const entity = buildDefaultScreenEntity(screenId, getScreenEntry(project, screenId), extractItems(itemsFile));
     await writeJSON(entityPath, entity);
@@ -246,7 +255,7 @@ async function _migrateScreenCore(screenId: string): Promise<Record<string, unkn
   const design = await readJSON<unknown>(designPath);
   const itemsFile = await readJSON<unknown>(legacyItemsPath);
   if (design || itemsFile) {
-    const project = await readProject();
+    const project = await readProject(root);
     const entity = buildDefaultScreenEntity(screenId, getScreenEntry(project, screenId), extractItems(itemsFile));
     await writeJSON(entityPath, entity);
     try { await fs.unlink(legacyItemsPath); } catch { /* ignore */ }
@@ -256,23 +265,27 @@ async function _migrateScreenCore(screenId: string): Promise<Record<string, unkn
   return null;
 }
 
-async function migrateScreenIfNeeded(screenId: string): Promise<Record<string, unknown> | null> {
-  const existing = _inflightMigrations.get(screenId);
+async function migrateScreenIfNeeded(screenId: string, root?: string): Promise<Record<string, unknown> | null> {
+  const r = dataDir(root);
+  const key = `${r}::${screenId}`;
+  const existing = _inflightMigrations.get(key);
   if (existing) return existing;
 
-  const promise = _migrateScreenCore(screenId).finally(() => {
-    _inflightMigrations.delete(screenId);
+  const promise = _migrateScreenCore(screenId, r).finally(() => {
+    _inflightMigrations.delete(key);
   });
-  _inflightMigrations.set(screenId, promise);
+  _inflightMigrations.set(key, promise);
   return promise;
 }
 
 /** data/extensions/*.json を生 JSON バンドルとして読み込み (#444) */
 export async function readExtensionsBundle(): Promise<Record<ExtensionFileKind, unknown | null>> {
-  await ensureDataDir();
+  const root = requireActivePath();
+  await ensureDataDir(root);
+  const extDir = extensionsDir(root);
   const entries = await Promise.all(
     Object.entries(EXTENSION_FILE_NAMES).map(async ([kind, fileName]) => {
-      const data = await readJSON<unknown>(path.join(extensionsDir(), fileName));
+      const data = await readJSON<unknown>(path.join(extDir, fileName));
       return [kind, data] as const;
     }),
   );
@@ -285,26 +298,29 @@ export async function writeExtensionsFile(
   content: unknown,
   options?: { onAfterWrite?: () => void; skipValidation?: boolean },
 ): Promise<void> {
-  await ensureDataDir();
+  const root = requireActivePath();
+  await ensureDataDir(root);
   if (!options?.skipValidation) {
     await validateExtensionFile(type, content);
   }
-  await writeJSON(path.join(extensionsDir(), EXTENSION_FILE_NAMES[type]), content);
+  await writeJSON(path.join(extensionsDir(root), EXTENSION_FILE_NAMES[type]), content);
   options?.onAfterWrite?.();
 }
 
 /** screens/{screenId}.json を読み込み */
 export async function readScreen(screenId: string): Promise<unknown | null> {
-  await migrateScreenIfNeeded(screenId);
-  return readJSON<unknown>(path.join(screensDir(), `${screenId}.design.json`));
+  const root = requireActivePath();
+  await migrateScreenIfNeeded(screenId, root);
+  return readJSON<unknown>(path.join(screensDir(root), `${screenId}.design.json`));
 }
 
 /** screens/{screenId}.json を書き込み */
 export async function writeScreen(screenId: string, data: unknown): Promise<void> {
-  await ensureDataDir();
-  let entity = await migrateScreenIfNeeded(screenId);
+  const root = requireActivePath();
+  await ensureDataDir(root);
+  let entity = await migrateScreenIfNeeded(screenId, root);
   if (!entity) {
-    const project = await readProject();
+    const project = await readProject(root);
     entity = buildDefaultScreenEntity(screenId, getScreenEntry(project, screenId), []);
   }
   entity = {
@@ -316,8 +332,9 @@ export async function writeScreen(screenId: string, data: unknown): Promise<void
       designFileRef: `${screenId}.design.json`,
     },
   };
-  await writeJSON(path.join(screensDir(), `${screenId}.json`), entity);
-  await writeJSON(path.join(screensDir(), `${screenId}.design.json`), data);
+  const sDir = screensDir(root);
+  await writeJSON(path.join(sDir, `${screenId}.json`), entity);
+  await writeJSON(path.join(sDir, `${screenId}.design.json`), data);
 }
 
 export async function readScreenEntity(screenId: string): Promise<unknown | null> {
@@ -325,9 +342,10 @@ export async function readScreenEntity(screenId: string): Promise<unknown | null
 }
 
 export async function writeScreenEntity(screenId: string, data: unknown): Promise<void> {
-  await ensureDataDir();
+  const root = requireActivePath();
+  await ensureDataDir(root);
   const current = isRecord(data) ? data : {};
-  const project = await readProject();
+  const project = await readProject(root);
   const entry = getScreenEntry(project, screenId);
   const toSave = {
     ...buildDefaultScreenEntity(screenId, entry, []),
@@ -342,19 +360,22 @@ export async function writeScreenEntity(screenId: string, data: unknown): Promis
       designFileRef: `${screenId}.design.json`,
     },
   };
-  await writeJSON(path.join(screensDir(), `${screenId}.json`), toSave);
+  await writeJSON(path.join(screensDir(root), `${screenId}.json`), toSave);
 }
 
 /** screens/{screenId}.json を削除（存在しない場合は無視） */
 export async function deleteScreen(screenId: string): Promise<void> {
+  const root = requireActivePath();
+  const sDir = screensDir(root);
+  const siDir = screenItemsDir(root);
   try {
-    await fs.unlink(path.join(screensDir(), `${screenId}.json`));
+    await fs.unlink(path.join(sDir, `${screenId}.json`));
   } catch { /* file not found is OK */ }
   try {
-    await fs.unlink(path.join(screensDir(), `${screenId}.design.json`));
+    await fs.unlink(path.join(sDir, `${screenId}.design.json`));
   } catch { /* file not found is OK */ }
   try {
-    await fs.unlink(path.join(screenItemsDir(), `${screenId}.json`));
+    await fs.unlink(path.join(siDir, `${screenId}.json`));
   } catch { /* file not found is OK */ }
 }
 
@@ -365,8 +386,9 @@ export async function readCustomBlocks(): Promise<unknown[]> {
 
 /** custom-blocks.json を書き込み */
 export async function writeCustomBlocks(blocks: unknown[]): Promise<void> {
-  await ensureDataDir();
-  await writeJSON(customBlocksFile(), blocks);
+  const root = requireActivePath();
+  await ensureDataDir(root);
+  await writeJSON(customBlocksFile(root), blocks);
 }
 
 /** er-layout.json を読み込み */
@@ -376,8 +398,9 @@ export async function readErLayout(): Promise<unknown | null> {
 
 /** er-layout.json を書き込み */
 export async function writeErLayout(data: unknown): Promise<void> {
-  await ensureDataDir();
-  await writeJSON(erLayoutFile(), data);
+  const root = requireActivePath();
+  await ensureDataDir(root);
+  await writeJSON(erLayoutFile(root), data);
 }
 
 /** screen-layout.json を読み込み (Phase 3-β、#561) */
@@ -387,8 +410,9 @@ export async function readScreenLayout(): Promise<unknown | null> {
 
 /** screen-layout.json を書き込み (Phase 3-β、#561) */
 export async function writeScreenLayout(data: unknown): Promise<void> {
-  await ensureDataDir();
-  await writeJSON(screenLayoutFile(), data);
+  const root = requireActivePath();
+  await ensureDataDir(root);
+  await writeJSON(screenLayoutFile(root), data);
 }
 
 /** tables/{tableId}.json を読み込み */
@@ -398,8 +422,9 @@ export async function readTable(tableId: string): Promise<unknown | null> {
 
 /** tables/{tableId}.json を書き込み */
 export async function writeTable(tableId: string, data: unknown): Promise<void> {
-  await ensureDataDir();
-  await writeJSON(path.join(tablesDir(), `${tableId}.json`), data);
+  const root = requireActivePath();
+  await ensureDataDir(root);
+  await writeJSON(path.join(tablesDir(root), `${tableId}.json`), data);
 }
 
 /** tables/{tableId}.json を削除（存在しない場合は無視） */
@@ -412,12 +437,14 @@ export async function deleteTable(tableId: string): Promise<void> {
 /** tables/ ディレクトリ内の全テーブル定義を読み込み (#587) */
 export async function listAllTables(): Promise<unknown[]> {
   try {
-    await ensureDataDir();
-    const files = await fs.readdir(tablesDir());
+    const root = requireActivePath();
+    await ensureDataDir(root);
+    const tDir = tablesDir(root);
+    const files = await fs.readdir(tDir);
     const results: unknown[] = [];
     for (const file of files) {
       if (!file.endsWith(".json")) continue;
-      const data = await readJSON<unknown>(path.join(tablesDir(), file));
+      const data = await readJSON<unknown>(path.join(tDir, file));
       if (data) results.push(data);
     }
     return results;
@@ -433,8 +460,9 @@ export async function readProcessFlow(processFlowId: string): Promise<unknown | 
 
 /** actions/{processFlowId}.json を書き込み */
 export async function writeProcessFlow(processFlowId: string, data: unknown): Promise<void> {
-  await ensureDataDir();
-  await writeJSON(path.join(actionsDir(), `${processFlowId}.json`), data);
+  const root = requireActivePath();
+  await ensureDataDir(root);
+  await writeJSON(path.join(actionsDir(root), `${processFlowId}.json`), data);
 }
 
 /** actions/{processFlowId}.json を削除（存在しない場合は無視） */
@@ -451,8 +479,9 @@ export async function readConventions(): Promise<unknown | null> {
 
 /** conventions/catalog.json を書き込み (#317) */
 export async function writeConventions(data: unknown): Promise<void> {
-  await ensureDataDir();
-  await writeJSON(conventionsFile(), data);
+  const root = requireActivePath();
+  await ensureDataDir(root);
+  await writeJSON(conventionsFile(root), data);
 }
 
 /** screen-items/{screenId}.json を読み込み (#318) */
@@ -468,8 +497,9 @@ export async function readScreenItems(screenId: string): Promise<unknown | null>
 
 /** screen-items/{screenId}.json を書き込み (#318) */
 export async function writeScreenItems(screenId: string, data: unknown): Promise<void> {
-  const current = (await readScreenEntity(screenId)) as Record<string, unknown> | null;
-  const project = await readProject();
+  const root = requireActivePath();
+  const current = (await migrateScreenIfNeeded(screenId, root)) as Record<string, unknown> | null;
+  const project = await readProject(root);
   const items = extractItems(data);
   const next = {
     ...(current ?? buildDefaultScreenEntity(screenId, getScreenEntry(project, screenId), [])),
@@ -477,17 +507,18 @@ export async function writeScreenItems(screenId: string, data: unknown): Promise
     updatedAt: new Date().toISOString(),
   };
   await writeScreenEntity(screenId, next);
-  try { await fs.unlink(path.join(screenItemsDir(), `${screenId}.json`)); } catch { /* ignore */ }
+  try { await fs.unlink(path.join(screenItemsDir(root), `${screenId}.json`)); } catch { /* ignore */ }
 }
 
 /** screen-items/{screenId}.json を削除 (#318) */
 export async function deleteScreenItems(screenId: string): Promise<void> {
-  const current = (await readScreenEntity(screenId)) as Record<string, unknown> | null;
+  const root = requireActivePath();
+  const current = (await migrateScreenIfNeeded(screenId, root)) as Record<string, unknown> | null;
   if (current) {
     await writeScreenEntity(screenId, { ...current, items: [] });
   }
   try {
-    await fs.unlink(path.join(screenItemsDir(), `${screenId}.json`));
+    await fs.unlink(path.join(screenItemsDir(root), `${screenId}.json`));
   } catch { /* file not found is OK */ }
 }
 
@@ -498,8 +529,9 @@ export async function readSequence(sequenceId: string): Promise<unknown | null> 
 
 /** sequences/{sequenceId}.json を書き込み (#374) */
 export async function writeSequence(sequenceId: string, data: unknown): Promise<void> {
-  await ensureDataDir();
-  await writeJSON(path.join(sequencesDir(), `${sequenceId}.json`), data);
+  const root = requireActivePath();
+  await ensureDataDir(root);
+  await writeJSON(path.join(sequencesDir(root), `${sequenceId}.json`), data);
 }
 
 /** sequences/{sequenceId}.json を削除（存在しない場合は無視） (#374) */
@@ -512,12 +544,14 @@ export async function deleteSequence(sequenceId: string): Promise<void> {
 /** views/ ディレクトリ内の全ビュー定義を読み込み (#587) */
 export async function listAllViews(): Promise<unknown[]> {
   try {
-    await ensureDataDir();
-    const files = await fs.readdir(viewsDir());
+    const root = requireActivePath();
+    await ensureDataDir(root);
+    const vDir = viewsDir(root);
+    const files = await fs.readdir(vDir);
     const results: unknown[] = [];
     for (const file of files) {
       if (!file.endsWith(".json")) continue;
-      const data = await readJSON<unknown>(path.join(viewsDir(), file));
+      const data = await readJSON<unknown>(path.join(vDir, file));
       if (data) results.push(data);
     }
     return results;
@@ -533,8 +567,9 @@ export async function readView(viewId: string): Promise<unknown | null> {
 
 /** views/{viewId}.json を書き込み (v3 per-entity #549) */
 export async function writeView(viewId: string, data: unknown): Promise<void> {
-  await ensureDataDir();
-  await writeJSON(path.join(viewsDir(), `${viewId}.json`), data);
+  const root = requireActivePath();
+  await ensureDataDir(root);
+  await writeJSON(path.join(viewsDir(root), `${viewId}.json`), data);
 }
 
 /** views/{viewId}.json を削除（存在しない場合は無視） (v3 per-entity #549) */
@@ -546,12 +581,14 @@ export async function deleteView(viewId: string): Promise<void> {
 
 export async function listAllViewDefinitions(): Promise<unknown[]> {
   try {
-    await ensureDataDir();
-    const files = await fs.readdir(viewDefsDir());
+    const root = requireActivePath();
+    await ensureDataDir(root);
+    const vdDir = viewDefsDir(root);
+    const files = await fs.readdir(vdDir);
     const results: unknown[] = [];
     for (const file of files) {
       if (!file.endsWith(".json")) continue;
-      const data = await readJSON<unknown>(path.join(viewDefsDir(), file));
+      const data = await readJSON<unknown>(path.join(vdDir, file));
       if (data) results.push(data);
     }
     return results;
@@ -565,8 +602,9 @@ export async function readViewDefinition(viewDefinitionId: string): Promise<unkn
 }
 
 export async function writeViewDefinition(viewDefinitionId: string, data: unknown): Promise<void> {
-  await ensureDataDir();
-  await writeJSON(path.join(viewDefsDir(), `${viewDefinitionId}.json`), data);
+  const root = requireActivePath();
+  await ensureDataDir(root);
+  await writeJSON(path.join(viewDefsDir(root), `${viewDefinitionId}.json`), data);
 }
 
 export async function deleteViewDefinition(viewDefinitionId: string): Promise<void> {
@@ -578,12 +616,14 @@ export async function deleteViewDefinition(viewDefinitionId: string): Promise<vo
 /** actions/ ディレクトリ内の全処理フローを読み込み */
 export async function listProcessFlows(): Promise<unknown[]> {
   try {
-    await ensureDataDir();
-    const files = await fs.readdir(actionsDir());
+    const root = requireActivePath();
+    await ensureDataDir(root);
+    const aDir = actionsDir(root);
+    const files = await fs.readdir(aDir);
     const results: unknown[] = [];
     for (const file of files) {
       if (!file.endsWith(".json")) continue;
-      const data = await readJSON<unknown>(path.join(actionsDir(), file));
+      const data = await readJSON<unknown>(path.join(aDir, file));
       if (data) results.push(data);
     }
     return results;

--- a/designer-mcp/src/recentStore.test.ts
+++ b/designer-mcp/src/recentStore.test.ts
@@ -1,15 +1,23 @@
 /**
  * recentStore 単体テスト (#671)
  *
- * RECENT_FILE は ~/.designer/recent-workspaces.json に固定されているため、
- * テストでは tmp dir を HOME として被せる手間を避け、テスト前後で実ファイルを
- * 退避 / 復元する戦略をとる。
+ * env DESIGNER_RECENT_FILE で永続化先を tmp に振り替えてテストする。
+ * 実 user の ~/.designer/recent-workspaces.json には一切触れない。
  */
-import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import { describe, it, expect, beforeEach, afterAll, beforeAll } from "vitest";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import {
+
+const TMP_DIR = path.join(os.tmpdir(), `designer-recent-test-${process.pid}-${Date.now()}`);
+const TMP_FILE = path.join(TMP_DIR, "recent-workspaces.json");
+const ORIGINAL_ENV = process.env.DESIGNER_RECENT_FILE;
+
+// 環境変数を設定してから recentStore を import (環境変数は recentStore 内で関数経由で
+// 都度読まれる仕様にしてあるため、import 順は本来問わないが、明示性のため top で設定)。
+process.env.DESIGNER_RECENT_FILE = TMP_FILE;
+
+const {
   upsertWorkspace,
   removeWorkspace,
   findById,
@@ -18,42 +26,29 @@ import {
   setLastActive,
   readRecent,
   _internals,
-} from "./recentStore.js";
+} = await import("./recentStore.js");
 
-const RECENT_FILE = _internals.RECENT_FILE;
-const BACKUP = `${RECENT_FILE}.test-backup-${Date.now()}`;
-
-async function backupExistingFile(): Promise<void> {
-  try {
-    await fs.copyFile(RECENT_FILE, BACKUP);
-  } catch {
-    /* file does not exist, no backup needed */
-  }
-}
-
-async function restoreExistingFile(): Promise<void> {
-  try {
-    await fs.copyFile(BACKUP, RECENT_FILE);
-    await fs.unlink(BACKUP);
-  } catch {
-    try { await fs.unlink(RECENT_FILE); } catch { /* ignore */ }
-  }
-}
-
-async function clearFile(): Promise<void> {
-  try {
-    await fs.unlink(RECENT_FILE);
-  } catch { /* not found is OK */ }
-}
-
-await backupExistingFile();
+beforeAll(async () => {
+  await fs.mkdir(TMP_DIR, { recursive: true });
+});
 
 beforeEach(async () => {
-  await clearFile();
+  // 各テスト前に tmp file をクリア
+  try {
+    await fs.unlink(TMP_FILE);
+  } catch { /* not found is OK */ }
 });
 
 afterAll(async () => {
-  await restoreExistingFile();
+  // tmp ディレクトリ全削除 + env 復元
+  try {
+    await fs.rm(TMP_DIR, { recursive: true, force: true });
+  } catch { /* ignore */ }
+  if (ORIGINAL_ENV !== undefined) {
+    process.env.DESIGNER_RECENT_FILE = ORIGINAL_ENV;
+  } else {
+    delete process.env.DESIGNER_RECENT_FILE;
+  }
 });
 
 describe("recentStore", () => {
@@ -130,7 +125,19 @@ describe("recentStore", () => {
     expect(lastActiveId).toBe(e1.id);
   });
 
-  it("RECENT_FILE は ~/.designer/recent-workspaces.json", () => {
-    expect(RECENT_FILE).toBe(path.join(os.homedir(), ".designer", "recent-workspaces.json"));
+  it("recentFile() は env DESIGNER_RECENT_FILE を尊重 (現在値が TMP_FILE)", () => {
+    expect(_internals.recentFile()).toBe(path.resolve(TMP_FILE));
+  });
+
+  it("env 未設定時のデフォルトは ~/.designer/recent-workspaces.json", () => {
+    const original = process.env.DESIGNER_RECENT_FILE;
+    delete process.env.DESIGNER_RECENT_FILE;
+    try {
+      expect(_internals.recentFile()).toBe(
+        path.join(os.homedir(), ".designer", "recent-workspaces.json"),
+      );
+    } finally {
+      if (original !== undefined) process.env.DESIGNER_RECENT_FILE = original;
+    }
   });
 });

--- a/designer-mcp/src/recentStore.test.ts
+++ b/designer-mcp/src/recentStore.test.ts
@@ -1,0 +1,136 @@
+/**
+ * recentStore 単体テスト (#671)
+ *
+ * RECENT_FILE は ~/.designer/recent-workspaces.json に固定されているため、
+ * テストでは tmp dir を HOME として被せる手間を避け、テスト前後で実ファイルを
+ * 退避 / 復元する戦略をとる。
+ */
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  upsertWorkspace,
+  removeWorkspace,
+  findById,
+  findByPath,
+  listWorkspaces,
+  setLastActive,
+  readRecent,
+  _internals,
+} from "./recentStore.js";
+
+const RECENT_FILE = _internals.RECENT_FILE;
+const BACKUP = `${RECENT_FILE}.test-backup-${Date.now()}`;
+
+async function backupExistingFile(): Promise<void> {
+  try {
+    await fs.copyFile(RECENT_FILE, BACKUP);
+  } catch {
+    /* file does not exist, no backup needed */
+  }
+}
+
+async function restoreExistingFile(): Promise<void> {
+  try {
+    await fs.copyFile(BACKUP, RECENT_FILE);
+    await fs.unlink(BACKUP);
+  } catch {
+    try { await fs.unlink(RECENT_FILE); } catch { /* ignore */ }
+  }
+}
+
+async function clearFile(): Promise<void> {
+  try {
+    await fs.unlink(RECENT_FILE);
+  } catch { /* not found is OK */ }
+}
+
+await backupExistingFile();
+
+beforeEach(async () => {
+  await clearFile();
+});
+
+afterAll(async () => {
+  await restoreExistingFile();
+});
+
+describe("recentStore", () => {
+  it("readRecent: ファイル無しなら empty を返す", async () => {
+    const r = await readRecent();
+    expect(r.workspaces).toEqual([]);
+    expect(r.lastActiveId).toBeNull();
+    expect(r.version).toBe(1);
+  });
+
+  it("upsertWorkspace: 新規エントリは uuid 採番 + 末尾追加", async () => {
+    const e1 = await upsertWorkspace("/tmp/ws1", "Workspace1");
+    expect(e1.id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(e1.path).toBe(path.resolve("/tmp/ws1"));
+    expect(e1.name).toBe("Workspace1");
+    const r = await readRecent();
+    expect(r.workspaces.length).toBe(1);
+  });
+
+  it("upsertWorkspace: 同じ path は id 維持で name と lastOpenedAt 更新", async () => {
+    const e1 = await upsertWorkspace("/tmp/ws1", "Old Name");
+    await new Promise((r) => setTimeout(r, 5));
+    const e2 = await upsertWorkspace("/tmp/ws1", "New Name");
+    expect(e2.id).toBe(e1.id);
+    expect(e2.name).toBe("New Name");
+    expect(new Date(e2.lastOpenedAt).getTime()).toBeGreaterThan(new Date(e1.lastOpenedAt).getTime());
+    const r = await readRecent();
+    expect(r.workspaces.length).toBe(1);
+  });
+
+  it("findByPath: 大文字小文字を含めた絶対パス正規化で一致", async () => {
+    await upsertWorkspace("/tmp/ws1", "WS1");
+    const found = await findByPath("/tmp/./ws1");
+    expect(found).not.toBeNull();
+    expect(found?.name).toBe("WS1");
+  });
+
+  it("findById: 存在しない id は null", async () => {
+    const r = await findById("nope");
+    expect(r).toBeNull();
+  });
+
+  it("setLastActive: lastActiveId を更新", async () => {
+    const e1 = await upsertWorkspace("/tmp/ws1", "WS1");
+    await setLastActive(e1.id);
+    const r = await readRecent();
+    expect(r.lastActiveId).toBe(e1.id);
+    await setLastActive(null);
+    const r2 = await readRecent();
+    expect(r2.lastActiveId).toBeNull();
+  });
+
+  it("removeWorkspace: 存在する id は true、lastActiveId が同じなら null に", async () => {
+    const e1 = await upsertWorkspace("/tmp/ws1", "WS1");
+    await setLastActive(e1.id);
+    const removed = await removeWorkspace(e1.id);
+    expect(removed).toBe(true);
+    const r = await readRecent();
+    expect(r.workspaces.length).toBe(0);
+    expect(r.lastActiveId).toBeNull();
+  });
+
+  it("removeWorkspace: 存在しない id は false", async () => {
+    const r = await removeWorkspace("missing");
+    expect(r).toBe(false);
+  });
+
+  it("listWorkspaces: 全件 + lastActiveId を返す", async () => {
+    const e1 = await upsertWorkspace("/tmp/ws1", "WS1");
+    await upsertWorkspace("/tmp/ws2", "WS2");
+    await setLastActive(e1.id);
+    const { workspaces, lastActiveId } = await listWorkspaces();
+    expect(workspaces.length).toBe(2);
+    expect(lastActiveId).toBe(e1.id);
+  });
+
+  it("RECENT_FILE は ~/.designer/recent-workspaces.json", () => {
+    expect(RECENT_FILE).toBe(path.join(os.homedir(), ".designer", "recent-workspaces.json"));
+  });
+});

--- a/designer-mcp/src/recentStore.ts
+++ b/designer-mcp/src/recentStore.ts
@@ -36,8 +36,21 @@ type RecentFile = {
 };
 
 const SCHEMA_TAG = "designer-recent-workspaces-v1";
-const RECENT_DIR = path.join(os.homedir(), ".designer");
-const RECENT_FILE = path.join(RECENT_DIR, "recent-workspaces.json");
+
+/**
+ * 永続化先の解決。env DESIGNER_RECENT_FILE で上書き可能 (テスト / VS Code 拡張等の
+ * sandbox 用途)。未指定なら ~/.designer/recent-workspaces.json。
+ * 関数化することで、テスト中の vi.stubEnv / 直接代入が即座に反映される。
+ */
+function recentFile(): string {
+  const override = process.env.DESIGNER_RECENT_FILE;
+  if (override && override.trim().length > 0) return path.resolve(override);
+  return path.join(os.homedir(), ".designer", "recent-workspaces.json");
+}
+
+function recentDir(): string {
+  return path.dirname(recentFile());
+}
 
 function emptyFile(): RecentFile {
   return { $schema: SCHEMA_TAG, version: 1, workspaces: [], lastActiveId: null };
@@ -61,7 +74,7 @@ function isRecentFile(value: unknown): value is RecentFile {
 
 export async function readRecent(): Promise<RecentFile> {
   try {
-    const raw = await fs.readFile(RECENT_FILE, "utf-8");
+    const raw = await fs.readFile(recentFile(), "utf-8");
     const parsed = JSON.parse(raw);
     if (isRecentFile(parsed)) return parsed;
   } catch {
@@ -71,8 +84,8 @@ export async function readRecent(): Promise<RecentFile> {
 }
 
 async function writeRecent(file: RecentFile): Promise<void> {
-  await fs.mkdir(RECENT_DIR, { recursive: true });
-  await fs.writeFile(RECENT_FILE, JSON.stringify(file, null, 2), "utf-8");
+  await fs.mkdir(recentDir(), { recursive: true });
+  await fs.writeFile(recentFile(), JSON.stringify(file, null, 2), "utf-8");
 }
 
 function normalizePath(p: string): string {
@@ -142,8 +155,8 @@ export async function listWorkspaces(): Promise<{
 
 /** test-only */
 export const _internals = {
-  RECENT_FILE,
-  RECENT_DIR,
+  recentFile,
+  recentDir,
   emptyFile,
   isRecentFile,
 };

--- a/designer-mcp/src/recentStore.ts
+++ b/designer-mcp/src/recentStore.ts
@@ -94,9 +94,21 @@ function normalizePath(p: string): string {
 
 /**
  * read-modify-write 直列化用の write chain (#676 review: P1)。
- * upsert / setLastActive / removeWorkspace の同時呼び出しが interleave すると
- * 後発の write が先発の差分を上書き失う問題を防ぐ。chain.catch で next continuation を
- * 保護し、1 回の例外で chain が永久に停滞しないようにする。
+ * upsert / setLastActive / removeWorkspace の並行呼び出しが interleave すると、
+ * 後発の write が先発の差分を上書き失う問題 (例: A.upsert と B.setLastActive 並行で
+ * lastActiveId が消える) を防ぐ。
+ *
+ * セマンティクス (#676 Sonnet re-review P2):
+ * - `_writeChain.then(fn, fn)` は前段の成功・失敗どちらでも次の fn を実行する
+ *   (continue-on-error)。これは意図的な選択: 1 度の例外で chain が永続停滞し後続
+ *   全 RMW がブロックされる状況を回避するため。
+ * - 各 fn は `readRecent → modify → writeRecent` の独立 RMW で毎回 fresh に file を
+ *   読むので、前段が writeRecent の前で失敗しても次段に汚れた state は引き継がれない
+ *   (file 上の状態が真実)。
+ * - `result.catch(() => undefined)` は次 chain への接続のための rejection 抑制
+ *   (本来の caller は `result` を受け取るので個別エラーは見れる)。
+ * - 通常の mutex のように「前段失敗で残りを中断」を期待する用途では使えない。
+ *   本ファイル内には該当用途は無いため OK。
  */
 let _writeChain: Promise<unknown> = Promise.resolve();
 function withWriteLock<T>(fn: () => Promise<T>): Promise<T> {

--- a/designer-mcp/src/recentStore.ts
+++ b/designer-mcp/src/recentStore.ts
@@ -93,45 +93,64 @@ function normalizePath(p: string): string {
 }
 
 /**
+ * read-modify-write 直列化用の write chain (#676 review: P1)。
+ * upsert / setLastActive / removeWorkspace の同時呼び出しが interleave すると
+ * 後発の write が先発の差分を上書き失う問題を防ぐ。chain.catch で next continuation を
+ * 保護し、1 回の例外で chain が永久に停滞しないようにする。
+ */
+let _writeChain: Promise<unknown> = Promise.resolve();
+function withWriteLock<T>(fn: () => Promise<T>): Promise<T> {
+  const result = _writeChain.then(fn, fn);
+  _writeChain = result.catch(() => undefined);
+  return result;
+}
+
+/**
  * 指定 path のエントリを upsert (既存なら lastOpenedAt と name を更新、無ければ追加)。
  * 戻り値は upsert 後のエントリ。lastActiveId は呼び出し側で setLastActive を別途呼ぶ。
  */
-export async function upsertWorkspace(
+export function upsertWorkspace(
   workspacePath: string,
   name: string,
 ): Promise<WorkspaceEntry> {
-  const file = await readRecent();
-  const norm = normalizePath(workspacePath);
-  const now = new Date().toISOString();
-  const existing = file.workspaces.find((w) => normalizePath(w.path) === norm);
-  let entry: WorkspaceEntry;
-  if (existing) {
-    existing.path = norm;
-    existing.name = name;
-    existing.lastOpenedAt = now;
-    entry = existing;
-  } else {
-    entry = { id: randomUUID(), path: norm, name, lastOpenedAt: now };
-    file.workspaces.push(entry);
-  }
-  await writeRecent(file);
-  return entry;
+  return withWriteLock(async () => {
+    const file = await readRecent();
+    const norm = normalizePath(workspacePath);
+    const now = new Date().toISOString();
+    const existing = file.workspaces.find((w) => normalizePath(w.path) === norm);
+    let entry: WorkspaceEntry;
+    if (existing) {
+      existing.path = norm;
+      existing.name = name;
+      existing.lastOpenedAt = now;
+      entry = existing;
+    } else {
+      entry = { id: randomUUID(), path: norm, name, lastOpenedAt: now };
+      file.workspaces.push(entry);
+    }
+    await writeRecent(file);
+    return entry;
+  });
 }
 
-export async function setLastActive(id: string | null): Promise<void> {
-  const file = await readRecent();
-  file.lastActiveId = id;
-  await writeRecent(file);
+export function setLastActive(id: string | null): Promise<void> {
+  return withWriteLock(async () => {
+    const file = await readRecent();
+    file.lastActiveId = id;
+    await writeRecent(file);
+  });
 }
 
-export async function removeWorkspace(id: string): Promise<boolean> {
-  const file = await readRecent();
-  const before = file.workspaces.length;
-  file.workspaces = file.workspaces.filter((w) => w.id !== id);
-  if (file.lastActiveId === id) file.lastActiveId = null;
-  if (file.workspaces.length === before) return false;
-  await writeRecent(file);
-  return true;
+export function removeWorkspace(id: string): Promise<boolean> {
+  return withWriteLock(async () => {
+    const file = await readRecent();
+    const before = file.workspaces.length;
+    file.workspaces = file.workspaces.filter((w) => w.id !== id);
+    if (file.lastActiveId === id) file.lastActiveId = null;
+    if (file.workspaces.length === before) return false;
+    await writeRecent(file);
+    return true;
+  });
 }
 
 export async function findById(id: string): Promise<WorkspaceEntry | null> {

--- a/designer-mcp/src/recentStore.ts
+++ b/designer-mcp/src/recentStore.ts
@@ -1,0 +1,149 @@
+/**
+ * recentStore.ts (#671)
+ *
+ * 最近使ったワークスペースを `~/.designer/recent-workspaces.json` に永続化。
+ *
+ * 構造:
+ * {
+ *   "$schema": "designer-recent-workspaces-v1",
+ *   "version": 1,
+ *   "workspaces": [
+ *     { "id": "<uuid>", "path": "<absolute>", "name": "<display>", "lastOpenedAt": "<iso>" }
+ *   ],
+ *   "lastActiveId": "<uuid|null>"
+ * }
+ *
+ * lockdown モード (env DESIGNER_DATA_DIR 指定) 時はこのファイルを読み書きしない。
+ * 呼び出し側 (workspace.* MCP tool ハンドラ) が isLockdown() を確認した上で本モジュールを使う。
+ */
+import fs from "fs/promises";
+import path from "path";
+import os from "os";
+import { randomUUID } from "node:crypto";
+
+export type WorkspaceEntry = {
+  id: string;
+  path: string;
+  name: string;
+  lastOpenedAt: string;
+};
+
+type RecentFile = {
+  $schema: string;
+  version: 1;
+  workspaces: WorkspaceEntry[];
+  lastActiveId: string | null;
+};
+
+const SCHEMA_TAG = "designer-recent-workspaces-v1";
+const RECENT_DIR = path.join(os.homedir(), ".designer");
+const RECENT_FILE = path.join(RECENT_DIR, "recent-workspaces.json");
+
+function emptyFile(): RecentFile {
+  return { $schema: SCHEMA_TAG, version: 1, workspaces: [], lastActiveId: null };
+}
+
+function isRecentFile(value: unknown): value is RecentFile {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  if (v.version !== 1) return false;
+  if (!Array.isArray(v.workspaces)) return false;
+  if (v.lastActiveId !== null && typeof v.lastActiveId !== "string") return false;
+  return v.workspaces.every((w) => {
+    if (typeof w !== "object" || w === null) return false;
+    const e = w as Record<string, unknown>;
+    return typeof e.id === "string"
+      && typeof e.path === "string"
+      && typeof e.name === "string"
+      && typeof e.lastOpenedAt === "string";
+  });
+}
+
+export async function readRecent(): Promise<RecentFile> {
+  try {
+    const raw = await fs.readFile(RECENT_FILE, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (isRecentFile(parsed)) return parsed;
+  } catch {
+    /* not found or malformed → return empty */
+  }
+  return emptyFile();
+}
+
+async function writeRecent(file: RecentFile): Promise<void> {
+  await fs.mkdir(RECENT_DIR, { recursive: true });
+  await fs.writeFile(RECENT_FILE, JSON.stringify(file, null, 2), "utf-8");
+}
+
+function normalizePath(p: string): string {
+  return path.resolve(p);
+}
+
+/**
+ * 指定 path のエントリを upsert (既存なら lastOpenedAt と name を更新、無ければ追加)。
+ * 戻り値は upsert 後のエントリ。lastActiveId は呼び出し側で setLastActive を別途呼ぶ。
+ */
+export async function upsertWorkspace(
+  workspacePath: string,
+  name: string,
+): Promise<WorkspaceEntry> {
+  const file = await readRecent();
+  const norm = normalizePath(workspacePath);
+  const now = new Date().toISOString();
+  const existing = file.workspaces.find((w) => normalizePath(w.path) === norm);
+  let entry: WorkspaceEntry;
+  if (existing) {
+    existing.path = norm;
+    existing.name = name;
+    existing.lastOpenedAt = now;
+    entry = existing;
+  } else {
+    entry = { id: randomUUID(), path: norm, name, lastOpenedAt: now };
+    file.workspaces.push(entry);
+  }
+  await writeRecent(file);
+  return entry;
+}
+
+export async function setLastActive(id: string | null): Promise<void> {
+  const file = await readRecent();
+  file.lastActiveId = id;
+  await writeRecent(file);
+}
+
+export async function removeWorkspace(id: string): Promise<boolean> {
+  const file = await readRecent();
+  const before = file.workspaces.length;
+  file.workspaces = file.workspaces.filter((w) => w.id !== id);
+  if (file.lastActiveId === id) file.lastActiveId = null;
+  if (file.workspaces.length === before) return false;
+  await writeRecent(file);
+  return true;
+}
+
+export async function findById(id: string): Promise<WorkspaceEntry | null> {
+  const file = await readRecent();
+  return file.workspaces.find((w) => w.id === id) ?? null;
+}
+
+export async function findByPath(workspacePath: string): Promise<WorkspaceEntry | null> {
+  const norm = normalizePath(workspacePath);
+  const file = await readRecent();
+  return file.workspaces.find((w) => normalizePath(w.path) === norm) ?? null;
+}
+
+export async function listWorkspaces(): Promise<{
+  workspaces: WorkspaceEntry[];
+  lastActiveId: string | null;
+}> {
+  const file = await readRecent();
+  return { workspaces: file.workspaces, lastActiveId: file.lastActiveId };
+}
+
+/** test-only */
+export const _internals = {
+  RECENT_FILE,
+  RECENT_DIR,
+  emptyFile,
+  isRecentFile,
+};

--- a/designer-mcp/src/tools.ts
+++ b/designer-mcp/src/tools.ts
@@ -1243,14 +1243,26 @@ export const tools = [
   },
   {
     name: "designer__workspace_open",
-    description: "指定 path または id のワークスペースを active にし、recent に upsert します。lockdown モード時は error を返します。",
+    description: "指定 path または id のワークスペースを active にし、recent に upsert します。init=true 指定時は path のフォルダを作成し project.json を初期化してから open します。lockdown モード時は error を返します。",
     inputSchema: {
       type: "object" as const,
       properties: {
         path: { type: "string", description: "ワークスペースの絶対パス。id と排他、どちらか必須。" },
         id: { type: "string", description: "recent 上の workspace id。path と排他。" },
+        init: { type: "boolean", description: "true の場合、path のフォルダ作成と project.json 初期化を行ってから open します (path 必須)。" },
       },
       required: [],
+    },
+  },
+  {
+    name: "designer__workspace_inspect",
+    description: "指定 path のフォルダ状態を判定して返します。status は 'ready' (project.json あり), 'needsInit' (フォルダのみ), 'notFound' (フォルダ無し) のいずれか。",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        path: { type: "string", description: "判定対象の絶対パス" },
+      },
+      required: ["path"],
     },
   },
   {

--- a/designer-mcp/src/tools.ts
+++ b/designer-mcp/src/tools.ts
@@ -1229,4 +1229,44 @@ export const tools = [
     description: "data/extensions/ の全拡張 (steps / fieldTypes / triggers / dbOperations / responseTypes) を一括取得します。",
     inputSchema: { type: "object" as const, properties: {}, required: [] },
   },
+
+  // ── ワークスペース管理 (#671) ─────────────────────────────────────
+  {
+    name: "designer__workspace_list",
+    description: "最近使ったワークスペース一覧と現在 active なワークスペース、lockdown 状態を返します。",
+    inputSchema: { type: "object" as const, properties: {}, required: [] },
+  },
+  {
+    name: "designer__workspace_status",
+    description: "現在 active なワークスペースの絶対パス・名前・lockdown フラグを返します。",
+    inputSchema: { type: "object" as const, properties: {}, required: [] },
+  },
+  {
+    name: "designer__workspace_open",
+    description: "指定 path または id のワークスペースを active にし、recent に upsert します。lockdown モード時は error を返します。",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        path: { type: "string", description: "ワークスペースの絶対パス。id と排他、どちらか必須。" },
+        id: { type: "string", description: "recent 上の workspace id。path と排他。" },
+      },
+      required: [],
+    },
+  },
+  {
+    name: "designer__workspace_close",
+    description: "現在 active なワークスペースを閉じます (active = null)。lockdown モード時は error を返します。",
+    inputSchema: { type: "object" as const, properties: {}, required: [] },
+  },
+  {
+    name: "designer__workspace_remove",
+    description: "recent からワークスペースエントリを除外します (fs は変更しません)。lockdown モード時は error を返します。",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        id: { type: "string", description: "recent 上の workspace id" },
+      },
+      required: ["id"],
+    },
+  },
 ];

--- a/designer-mcp/src/workspaceInit.test.ts
+++ b/designer-mcp/src/workspaceInit.test.ts
@@ -1,0 +1,133 @@
+/**
+ * workspaceInit 単体テスト (#672)
+ */
+import { describe, it, expect, beforeEach, afterEach, afterAll } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import {
+  inspectWorkspacePath,
+  initializeWorkspace,
+} from "./workspaceInit.js";
+
+const TMP_ROOT = path.join(os.tmpdir(), `workspace-init-test-${process.pid}-${Date.now()}`);
+
+beforeEach(async () => {
+  await fs.mkdir(TMP_ROOT, { recursive: true });
+});
+
+afterEach(async () => {
+  try {
+    await fs.rm(TMP_ROOT, { recursive: true, force: true });
+  } catch { /* ignore */ }
+});
+
+afterAll(async () => {
+  try {
+    await fs.rm(TMP_ROOT, { recursive: true, force: true });
+  } catch { /* ignore */ }
+});
+
+describe("inspectWorkspacePath", () => {
+  it("存在しない path → notFound", async () => {
+    const r = await inspectWorkspacePath(path.join(TMP_ROOT, "missing"));
+    expect(r.status).toBe("notFound");
+  });
+
+  it("空フォルダ → needsInit", async () => {
+    const dir = path.join(TMP_ROOT, "empty");
+    await fs.mkdir(dir);
+    const r = await inspectWorkspacePath(dir);
+    expect(r.status).toBe("needsInit");
+  });
+
+  it("project.json あり → ready + name 抽出", async () => {
+    const dir = path.join(TMP_ROOT, "ready");
+    await fs.mkdir(dir);
+    await fs.writeFile(
+      path.join(dir, "project.json"),
+      JSON.stringify({ meta: { name: "テストプロジェクト" } }),
+    );
+    const r = await inspectWorkspacePath(dir);
+    expect(r.status).toBe("ready");
+    if (r.status === "ready") {
+      expect(r.name).toBe("テストプロジェクト");
+    }
+  });
+
+  it("project.json があるが meta.name 無し → name は basename", async () => {
+    const dir = path.join(TMP_ROOT, "no-name");
+    await fs.mkdir(dir);
+    await fs.writeFile(path.join(dir, "project.json"), JSON.stringify({ meta: {} }));
+    const r = await inspectWorkspacePath(dir);
+    expect(r.status).toBe("ready");
+    if (r.status === "ready") {
+      expect(r.name).toBe("no-name");
+    }
+  });
+
+  it("path がファイルでフォルダではない → notFound", async () => {
+    const file = path.join(TMP_ROOT, "file.txt");
+    await fs.writeFile(file, "x");
+    const r = await inspectWorkspacePath(file);
+    expect(r.status).toBe("notFound");
+  });
+});
+
+describe("initializeWorkspace", () => {
+  it("空フォルダに project.json + サブディレクトリ群を生成", async () => {
+    const dir = path.join(TMP_ROOT, "init-target");
+    const r = await initializeWorkspace(dir);
+    expect(r.path).toBe(path.resolve(dir));
+    expect(r.name).toBe("init-target");
+    expect(r.projectId).toMatch(/^[0-9a-f-]{36}$/);
+
+    // project.json 存在
+    const projPath = path.join(dir, "project.json");
+    const proj = JSON.parse(await fs.readFile(projPath, "utf-8"));
+    expect(proj.schemaVersion).toBe("v3");
+    expect(proj.meta.id).toBe(r.projectId);
+    expect(proj.meta.name).toBe("init-target");
+    expect(proj.meta.createdAt).toMatch(/Z$/);
+
+    // サブディレクトリ
+    for (const sub of ["screens", "tables", "actions", "conventions", "sequences", "views", "view-definitions", "extensions"]) {
+      const stat = await fs.stat(path.join(dir, sub));
+      expect(stat.isDirectory()).toBe(true);
+    }
+  });
+
+  it("存在しない path も mkdir -p で作る", async () => {
+    const dir = path.join(TMP_ROOT, "deep", "nested", "ws");
+    const r = await initializeWorkspace(dir);
+    expect(r.name).toBe("ws");
+    const stat = await fs.stat(path.join(dir, "project.json"));
+    expect(stat.isFile()).toBe(true);
+  });
+
+  it("既に project.json があれば idempotent (上書きしない)", async () => {
+    const dir = path.join(TMP_ROOT, "existing");
+    await fs.mkdir(dir);
+    const original = {
+      schemaVersion: "v3",
+      meta: { id: "11111111-1111-4111-8111-111111111111", name: "Existing", createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-01-01T00:00:00Z" },
+      entities: {},
+    };
+    await fs.writeFile(path.join(dir, "project.json"), JSON.stringify(original, null, 2));
+    const r = await initializeWorkspace(dir);
+    expect(r.projectId).toBe("11111111-1111-4111-8111-111111111111");
+    const re = JSON.parse(await fs.readFile(path.join(dir, "project.json"), "utf-8"));
+    expect(re.meta.name).toBe("Existing");
+  });
+
+  it("生成された project.json は schemas/v3/project.v3.schema.json で検証 pass", async () => {
+    const dir = path.join(TMP_ROOT, "validated");
+    await initializeWorkspace(dir);
+    // 検証は initializeWorkspace 内で実行済 (失敗時は throw)。ここでは追加のスキーマ違反例を
+    // 再度通すことはしない。pass = この時点で例外無く戻ってきたこと。
+    const proj = JSON.parse(await fs.readFile(path.join(dir, "project.json"), "utf-8"));
+    expect(proj.meta.maturity).toBe("draft");
+    expect(proj.meta.mode).toBe("upstream");
+    expect(Array.isArray(proj.entities.screens)).toBe(true);
+  });
+});

--- a/designer-mcp/src/workspaceInit.ts
+++ b/designer-mcp/src/workspaceInit.ts
@@ -1,0 +1,235 @@
+/**
+ * workspaceInit.ts (#672)
+ *
+ * - inspectWorkspacePath: 任意 path の状態 (ready / needsInit / notFound) を判定
+ * - initializeWorkspace: 空 (or 不存在) フォルダに data/ サブディレクトリ群と project.json を生成
+ * - autoActivateOnStartup: designer-mcp 起動時の自動 active 設定
+ *   1. lockdown 中なら何もしない (env で active 固定済み)
+ *   2. recent.lastActiveId が指す workspace があれば setActivePath
+ *   3. 旧来の <designer-mcp親>/data/ に project.json があれば recent に upsert + active 化
+ *   4. 何もなければ active 未設定のまま (UI 側で /workspace/select に誘導)
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import Ajv2020 from "ajv/dist/2020.js";
+import {
+  isLockdown,
+  setActivePath,
+} from "./workspaceState.js";
+import {
+  readRecent,
+  upsertWorkspace,
+  findById,
+  setLastActive,
+  type WorkspaceEntry,
+} from "./recentStore.js";
+// projectStorage の関数群は active workspace 必須なので本モジュールでは使わず、
+// ローカル fs API で project.json/サブディレクトリを直接生成する。
+
+export type WorkspaceInspectResult =
+  | { status: "ready"; path: string; name: string | null }
+  | { status: "needsInit"; path: string }
+  | { status: "notFound"; path: string };
+
+const PROJECT_SCHEMA_REF = "../schemas/v3/project.v3.schema.json";
+const SCHEMAS_DIR = path.resolve(import.meta.dirname, "../../schemas");
+
+let _validateProjectCache: ((data: unknown) => boolean) & { errors?: unknown } | null = null;
+
+async function getProjectValidator(): Promise<((data: unknown) => boolean) & { errors?: unknown }> {
+  if (_validateProjectCache) return _validateProjectCache;
+  // strict: false で format 系 ($ref 解決に format 制約が含まれる) の警告を抑制
+  // schemas/v3/*.schema.json は JSON Schema draft 2020-12 を使用 (Ajv2020 が必要)
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  // load schemas: project.v3 + common.v3 (referenced via $ref)
+  const projectSchema = JSON.parse(
+    await fs.readFile(path.join(SCHEMAS_DIR, "v3", "project.v3.schema.json"), "utf-8"),
+  );
+  const commonSchema = JSON.parse(
+    await fs.readFile(path.join(SCHEMAS_DIR, "v3", "common.v3.schema.json"), "utf-8"),
+  );
+  ajv.addSchema(commonSchema);
+  const validate = ajv.compile(projectSchema);
+  _validateProjectCache = validate as ((data: unknown) => boolean) & { errors?: unknown };
+  return _validateProjectCache;
+}
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readProjectAt(folderPath: string): Promise<unknown | null> {
+  try {
+    const raw = await fs.readFile(path.join(folderPath, "project.json"), "utf-8");
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function extractName(project: unknown, fallback: string): string {
+  if (typeof project === "object" && project !== null) {
+    const meta = (project as Record<string, unknown>).meta;
+    if (meta && typeof meta === "object") {
+      const name = (meta as Record<string, unknown>).name;
+      if (typeof name === "string" && name.trim().length > 0) return name;
+    }
+  }
+  return fallback;
+}
+
+export async function inspectWorkspacePath(folderPath: string): Promise<WorkspaceInspectResult> {
+  const abs = path.resolve(folderPath);
+  if (!(await pathExists(abs))) {
+    return { status: "notFound", path: abs };
+  }
+  const stat = await fs.stat(abs);
+  if (!stat.isDirectory()) {
+    return { status: "notFound", path: abs };
+  }
+  const project = await readProjectAt(abs);
+  if (!project) {
+    return { status: "needsInit", path: abs };
+  }
+  return { status: "ready", path: abs, name: extractName(project, path.basename(abs)) };
+}
+
+function isoTimestampZ(): string {
+  // EntityMeta.createdAt/updatedAt requires Z 終端 (no offset)
+  return new Date().toISOString();
+}
+
+export type InitializeResult = {
+  path: string;
+  name: string;
+  projectId: string;
+};
+
+/**
+ * 指定 path に project.json + data/サブディレクトリ群を生成する。
+ * フォルダ自体が存在しなければ mkdir -p で作る。
+ * 既に project.json が存在する場合は何もせずそのまま返す (idempotent)。
+ */
+export async function initializeWorkspace(folderPath: string): Promise<InitializeResult> {
+  const abs = path.resolve(folderPath);
+  await fs.mkdir(abs, { recursive: true });
+  // ensureDataDir で active を読むため、setActivePath を一時セットしたいところだが
+  // initializeWorkspace は active 切替前 (workspace.open の準備フェーズ) で呼ばれる前提なので
+  // ここでは fs 操作を直接行う。
+  const subdirs = ["screens", "tables", "actions", "conventions", "sequences", "views", "view-definitions", "extensions"];
+  await Promise.all(subdirs.map((d) => fs.mkdir(path.join(abs, d), { recursive: true })));
+
+  const projectFilePath = path.join(abs, "project.json");
+  const existing = await readProjectAt(abs);
+  if (existing) {
+    return {
+      path: abs,
+      name: extractName(existing, path.basename(abs)),
+      projectId: typeof (existing as Record<string, unknown>).meta === "object"
+        ? String(((existing as Record<string, unknown>).meta as Record<string, unknown>).id ?? "")
+        : "",
+    };
+  }
+
+  const ts = isoTimestampZ();
+  const projectId = randomUUID();
+  const name = path.basename(abs) || "新規ワークスペース";
+  const project = {
+    $schema: PROJECT_SCHEMA_REF,
+    schemaVersion: "v3" as const,
+    meta: {
+      id: projectId,
+      name,
+      createdAt: ts,
+      updatedAt: ts,
+      mode: "upstream" as const,
+      maturity: "draft" as const,
+    },
+    extensionsApplied: [],
+    entities: {
+      screens: [],
+      screenGroups: [],
+      screenTransitions: [],
+      tables: [],
+      sequences: [],
+      views: [],
+    },
+  };
+
+  // schema 検証してから書き込み (テスト pass を理由に schema を勝手に変更しない、
+  // 失敗した場合は ISSUE 起票して停止する原則に従う)
+  const validate = await getProjectValidator();
+  if (!validate(project)) {
+    throw new Error(
+      `初期 project.json が schemas/v3/project.v3.schema.json に違反: ${JSON.stringify(validate.errors)}`,
+    );
+  }
+  await fs.writeFile(projectFilePath, JSON.stringify(project, null, 2), "utf-8");
+  return { path: abs, name, projectId };
+}
+
+/**
+ * 旧来の <designer-mcp 親>/data/ ディレクトリを default workspace として扱う。
+ * project.json があれば recent に upsert、無ければ何もしない。
+ */
+const LEGACY_DATA_DIR = path.resolve(import.meta.dirname, "../../data");
+
+async function tryAutoRegisterLegacyData(): Promise<WorkspaceEntry | null> {
+  const legacy = LEGACY_DATA_DIR;
+  if (!(await pathExists(legacy))) return null;
+  const project = await readProjectAt(legacy);
+  if (!project) return null;
+  const name = extractName(project, path.basename(legacy));
+  const entry = await upsertWorkspace(legacy, name);
+  await setLastActive(entry.id);
+  return entry;
+}
+
+export type AutoActivateResult =
+  | { status: "lockdown"; path: string }
+  | { status: "restored"; entry: WorkspaceEntry }
+  | { status: "registeredLegacy"; entry: WorkspaceEntry }
+  | { status: "none" };
+
+/**
+ * 起動時の自動 active 設定。lockdown 中はスキップ。
+ * recent.lastActiveId が指す workspace があれば優先、無ければ legacy data/ 自動登録、
+ * それも無ければ active 未設定で UI 側に委ねる。
+ *
+ * 戻り値は呼び出し側 (index.ts) が console log 出力する用途。
+ * broadcast はしない (この時点で WS クライアントは未接続)。
+ */
+export async function autoActivateOnStartup(): Promise<AutoActivateResult> {
+  if (isLockdown()) {
+    return { status: "lockdown", path: process.env.DESIGNER_DATA_DIR ?? "" };
+  }
+  const recent = await readRecent();
+  if (recent.lastActiveId) {
+    const entry = await findById(recent.lastActiveId);
+    if (entry) {
+      // path が実在するか再確認 (ユーザーがフォルダを移動・削除している可能性)
+      if (await pathExists(entry.path)) {
+        setActivePath(entry.path);
+        return { status: "restored", entry };
+      }
+    }
+  }
+  const legacy = await tryAutoRegisterLegacyData();
+  if (legacy) {
+    setActivePath(legacy.path);
+    return { status: "registeredLegacy", entry: legacy };
+  }
+  return { status: "none" };
+}
+
+/** test-only */
+export const _internals = {
+  LEGACY_DATA_DIR,
+  PROJECT_SCHEMA_REF,
+};

--- a/designer-mcp/src/workspaceInit.ts
+++ b/designer-mcp/src/workspaceInit.ts
@@ -204,6 +204,9 @@ export type AutoActivateResult =
  *
  * 戻り値は呼び出し側 (index.ts) が console log 出力する用途。
  * broadcast はしない (この時点で WS クライアントは未接続)。
+ *
+ * lastActiveId 復元時は inspectWorkspacePath で ready 確認する (project.json が
+ * 削除・移動済みの stale エントリで起動しないようにする)。
  */
 export async function autoActivateOnStartup(): Promise<AutoActivateResult> {
   if (isLockdown()) {
@@ -213,11 +216,13 @@ export async function autoActivateOnStartup(): Promise<AutoActivateResult> {
   if (recent.lastActiveId) {
     const entry = await findById(recent.lastActiveId);
     if (entry) {
-      // path が実在するか再確認 (ユーザーがフォルダを移動・削除している可能性)
-      if (await pathExists(entry.path)) {
+      const inspect = await inspectWorkspacePath(entry.path);
+      if (inspect.status === "ready") {
         setActivePath(entry.path);
         return { status: "restored", entry };
       }
+      // フォルダが消えた / project.json が無い: stale エントリなのでスキップ。
+      // recent からの除去はしない (UI 側でユーザーが「リストから外す」できる前提)。
     }
   }
   const legacy = await tryAutoRegisterLegacyData();

--- a/designer-mcp/src/workspaceState.test.ts
+++ b/designer-mcp/src/workspaceState.test.ts
@@ -1,0 +1,93 @@
+/**
+ * workspaceState 単体テスト (#671)
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import path from "node:path";
+import {
+  initWorkspaceState,
+  isLockdown,
+  getLockdownPath,
+  getActivePath,
+  setActivePath,
+  clearActive,
+  requireActivePath,
+  LockdownError,
+  WorkspaceUnsetError,
+  _resetForTest,
+} from "./workspaceState.js";
+
+const ORIGINAL_ENV = process.env.DESIGNER_DATA_DIR;
+
+beforeEach(() => {
+  _resetForTest();
+  delete process.env.DESIGNER_DATA_DIR;
+});
+
+afterEach(() => {
+  if (ORIGINAL_ENV !== undefined) {
+    process.env.DESIGNER_DATA_DIR = ORIGINAL_ENV;
+  } else {
+    delete process.env.DESIGNER_DATA_DIR;
+  }
+});
+
+describe("workspaceState (通常モード)", () => {
+  it("init 後 active は null、lockdown も false", () => {
+    initWorkspaceState();
+    expect(getActivePath()).toBeNull();
+    expect(isLockdown()).toBe(false);
+    expect(getLockdownPath()).toBeNull();
+  });
+
+  it("setActivePath で active が更新される (絶対パスに正規化)", () => {
+    initWorkspaceState();
+    setActivePath("/some/path");
+    expect(getActivePath()).toBe(path.resolve("/some/path"));
+  });
+
+  it("clearActive で active が null に戻る", () => {
+    initWorkspaceState();
+    setActivePath("/some/path");
+    clearActive();
+    expect(getActivePath()).toBeNull();
+  });
+
+  it("requireActivePath は active 未選択時に WorkspaceUnsetError を throw", () => {
+    initWorkspaceState();
+    expect(() => requireActivePath()).toThrow(WorkspaceUnsetError);
+  });
+
+  it("requireActivePath は active 選択時にパスを返す", () => {
+    initWorkspaceState();
+    setActivePath("/some/path");
+    expect(requireActivePath()).toBe(path.resolve("/some/path"));
+  });
+});
+
+describe("workspaceState (lockdown モード)", () => {
+  it("env DESIGNER_DATA_DIR 指定時は lockdown=true、active が env パス固定", () => {
+    process.env.DESIGNER_DATA_DIR = "/env/data";
+    initWorkspaceState();
+    expect(isLockdown()).toBe(true);
+    expect(getLockdownPath()).toBe(path.resolve("/env/data"));
+    expect(getActivePath()).toBe(path.resolve("/env/data"));
+  });
+
+  it("lockdown 中の setActivePath は LockdownError", () => {
+    process.env.DESIGNER_DATA_DIR = "/env/data";
+    initWorkspaceState();
+    expect(() => setActivePath("/other")).toThrow(LockdownError);
+  });
+
+  it("lockdown 中の clearActive は LockdownError", () => {
+    process.env.DESIGNER_DATA_DIR = "/env/data";
+    initWorkspaceState();
+    expect(() => clearActive()).toThrow(LockdownError);
+  });
+
+  it("lockdown 中も requireActivePath は env パスを返す", () => {
+    process.env.DESIGNER_DATA_DIR = "/env/data";
+    initWorkspaceState();
+    expect(requireActivePath()).toBe(path.resolve("/env/data"));
+  });
+});

--- a/designer-mcp/src/workspaceState.ts
+++ b/designer-mcp/src/workspaceState.ts
@@ -1,0 +1,97 @@
+/**
+ * workspaceState.ts (#671)
+ *
+ * 現在 active なワークスペース (= project.json を含むフォルダ) の絶対パスを
+ * モジュールローカル state として保持する single source of truth。
+ *
+ * - 通常モード: `setActivePath()` / `clearActive()` で実行時に切替可能。
+ * - lockdown モード: 環境変数 DESIGNER_DATA_DIR が指定されている場合、
+ *   起動時に lockdown が有効化され、active は env 値に固定される。
+ *   `setActivePath()` / `clearActive()` は LockdownError を throw する。
+ *   `recent-workspaces.json` も読み書きしない (recentStore 側で別途判定)。
+ */
+import path from "path";
+
+export class LockdownError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LockdownError";
+  }
+}
+
+export class WorkspaceUnsetError extends Error {
+  constructor() {
+    super("ワークスペースが選択されていません");
+    this.name = "WorkspaceUnsetError";
+  }
+}
+
+let _activePath: string | null = null;
+let _lockdown = false;
+let _lockdownPath: string | null = null;
+let _initialized = false;
+
+/**
+ * env DESIGNER_DATA_DIR を読み、lockdown 状態を確定する。
+ * 通常モード時は active 未選択のまま起動する (recentStore 側で前回 active の自動オープンを試みる)。
+ * idempotent — 複数回呼んでも初回判定が固定される。
+ */
+export function initWorkspaceState(): void {
+  if (_initialized) return;
+  _initialized = true;
+  const envPath = process.env.DESIGNER_DATA_DIR;
+  if (envPath && envPath.trim().length > 0) {
+    const abs = path.resolve(envPath);
+    _lockdown = true;
+    _lockdownPath = abs;
+    _activePath = abs;
+  }
+}
+
+export function isLockdown(): boolean {
+  return _lockdown;
+}
+
+export function getLockdownPath(): string | null {
+  return _lockdownPath;
+}
+
+/** 現在 active な workspace の絶対パス。未選択なら null */
+export function getActivePath(): string | null {
+  return _activePath;
+}
+
+/**
+ * read/write が前提となるリソース系関数で使う。
+ * 未選択時は WorkspaceUnsetError を throw して UI 側で「未選択」状態を明示できるようにする。
+ */
+export function requireActivePath(): string {
+  if (!_activePath) throw new WorkspaceUnsetError();
+  return _activePath;
+}
+
+export function setActivePath(absPath: string): void {
+  if (_lockdown) {
+    throw new LockdownError(
+      "DESIGNER_DATA_DIR で固定モード中のため、ワークスペースを切り替えできません",
+    );
+  }
+  _activePath = path.resolve(absPath);
+}
+
+export function clearActive(): void {
+  if (_lockdown) {
+    throw new LockdownError(
+      "DESIGNER_DATA_DIR で固定モード中のため、ワークスペースを閉じる操作はできません",
+    );
+  }
+  _activePath = null;
+}
+
+/** test-only: 状態リセット */
+export function _resetForTest(): void {
+  _activePath = null;
+  _lockdown = false;
+  _lockdownPath = null;
+  _initialized = false;
+}

--- a/designer-mcp/src/wsBridge.ts
+++ b/designer-mcp/src/wsBridge.ts
@@ -773,7 +773,7 @@ class WsBridge extends EventEmitter {
             activeId: entry.id,
             path: entry.path,
             name: entry.name,
-            lockdown: false,
+            lockdown: isWorkspaceLockdown(),
           }, clientId);
           break;
         }
@@ -787,7 +787,7 @@ class WsBridge extends EventEmitter {
           await setLastActiveWorkspace(null);
           respond({ success: true });
           this.broadcast("workspace.changed", {
-            activeId: null, path: null, name: null, lockdown: false,
+            activeId: null, path: null, name: null, lockdown: isWorkspaceLockdown(),
           }, clientId);
           break;
         }

--- a/designer-mcp/src/wsBridge.ts
+++ b/designer-mcp/src/wsBridge.ts
@@ -5,6 +5,26 @@ import { execSync } from "child_process";
 import { createServer, type IncomingMessage, type ServerResponse, type Server as HttpServer } from "node:http";
 import { renameScreenItemId, checkScreenItemRefs } from "./renameScreenItem.js";
 import {
+  isLockdown as isWorkspaceLockdown,
+  getLockdownPath as getWorkspaceLockdownPath,
+  getActivePath as getActiveWorkspacePath,
+  setActivePath as setActiveWorkspacePath,
+  clearActive as clearActiveWorkspace,
+  LockdownError as WorkspaceLockdownError,
+} from "./workspaceState.js";
+import {
+  listWorkspaces as listWorkspacesEntries,
+  upsertWorkspace as upsertWorkspaceEntry,
+  removeWorkspace as removeWorkspaceEntry,
+  findById as findWorkspaceById,
+  findByPath as findWorkspaceByPath,
+  setLastActive as setLastActiveWorkspace,
+} from "./recentStore.js";
+import {
+  inspectWorkspacePath,
+  initializeWorkspace as initializeWorkspaceFolder,
+} from "./workspaceInit.js";
+import {
   readProject,
   writeProject,
   readScreen,
@@ -647,6 +667,127 @@ class WsBridge extends EventEmitter {
           respond(result);
           break;
         }
+
+        // ── ワークスペース管理 (#671/#672/#673) ─────────────────────────
+        case "workspace.list": {
+          const { workspaces, lastActiveId } = await listWorkspacesEntries();
+          const activePath = getActiveWorkspacePath();
+          respond({
+            workspaces,
+            lastActiveId,
+            active: activePath
+              ? { path: activePath, name: (workspaces.find((w) => w.path === activePath)?.name ?? null) }
+              : null,
+            lockdown: isWorkspaceLockdown(),
+            lockdownPath: getWorkspaceLockdownPath(),
+          });
+          break;
+        }
+        case "workspace.status": {
+          const activePath = getActiveWorkspacePath();
+          let activeName: string | null = null;
+          if (activePath) {
+            const entry = await findWorkspaceByPath(activePath);
+            activeName = entry?.name ?? null;
+          }
+          respond({
+            active: activePath ? { path: activePath, name: activeName } : null,
+            lockdown: isWorkspaceLockdown(),
+            lockdownPath: getWorkspaceLockdownPath(),
+          });
+          break;
+        }
+        case "workspace.inspect": {
+          const { path: targetPath } = (params ?? {}) as { path?: string };
+          if (typeof targetPath !== "string") {
+            respondError("path は必須です");
+            break;
+          }
+          const r = await inspectWorkspacePath(targetPath);
+          respond(r);
+          break;
+        }
+        case "workspace.open": {
+          const { path: targetPath, id, init } = (params ?? {}) as { path?: string; id?: string; init?: boolean };
+          if (typeof targetPath !== "string" && typeof id !== "string") {
+            respondError("path または id のいずれかが必要です");
+            break;
+          }
+          const initFlag = init === true;
+          if (initFlag && typeof targetPath !== "string") {
+            respondError("init=true の場合は path が必須です");
+            break;
+          }
+          let resolved = typeof targetPath === "string" ? targetPath : null;
+          if (!resolved && typeof id === "string") {
+            const entry = await findWorkspaceById(id);
+            if (!entry) { respondError(`id ${id} のワークスペースが見つかりません`); break; }
+            resolved = entry.path;
+          }
+          if (!resolved) { respondError("path 解決に失敗しました"); break; }
+          let initName: string | null = null;
+          if (initFlag) {
+            if (isWorkspaceLockdown()) { respondError("lockdown モード中は新規ワークスペース初期化はできません"); break; }
+            try {
+              const initRes = await initializeWorkspaceFolder(resolved);
+              initName = initRes.name;
+              resolved = initRes.path;
+            } catch (e) {
+              respondError(`ワークスペース初期化失敗: ${e instanceof Error ? e.message : String(e)}`);
+              break;
+            }
+          }
+          try {
+            setActiveWorkspacePath(resolved);
+          } catch (e) {
+            if (e instanceof WorkspaceLockdownError) { respondError(e.message); break; }
+            throw e;
+          }
+          let name = initName ?? resolved.split(/[\\/]/).pop() ?? "";
+          try {
+            const proj = await readProject();
+            if (proj && typeof proj === "object" && proj !== null) {
+              const meta = (proj as Record<string, unknown>).meta;
+              if (meta && typeof meta === "object" && meta !== null) {
+                const n = (meta as Record<string, unknown>).name;
+                if (typeof n === "string" && n.trim().length > 0) name = n;
+              }
+            }
+          } catch { /* fallback */ }
+          const entry = await upsertWorkspaceEntry(resolved, name);
+          await setLastActiveWorkspace(entry.id);
+          respond({ active: { id: entry.id, path: entry.path, name: entry.name } });
+          this.broadcast("workspace.changed", {
+            activeId: entry.id,
+            path: entry.path,
+            name: entry.name,
+            lockdown: false,
+          }, clientId);
+          break;
+        }
+        case "workspace.close": {
+          try {
+            clearActiveWorkspace();
+          } catch (e) {
+            if (e instanceof WorkspaceLockdownError) { respondError(e.message); break; }
+            throw e;
+          }
+          await setLastActiveWorkspace(null);
+          respond({ success: true });
+          this.broadcast("workspace.changed", {
+            activeId: null, path: null, name: null, lockdown: false,
+          }, clientId);
+          break;
+        }
+        case "workspace.remove": {
+          if (isWorkspaceLockdown()) { respondError("lockdown モード中はワークスペースを除外できません"); break; }
+          const { id } = (params ?? {}) as { id?: string };
+          if (typeof id !== "string") { respondError("id は必須です"); break; }
+          const removed = await removeWorkspaceEntry(id);
+          respond({ removed });
+          break;
+        }
+
         default:
           respondError(`未知のリクエストメソッド: ${method}`);
       }

--- a/designer-mcp/src/wsBridge.ts
+++ b/designer-mcp/src/wsBridge.ts
@@ -736,6 +736,18 @@ class WsBridge extends EventEmitter {
               respondError(`ワークスペース初期化失敗: ${e instanceof Error ? e.message : String(e)}`);
               break;
             }
+          } else {
+            // init=false 時: stale recent エントリ / typo パスを active 化して fs を破壊しないよう、
+            // open 前に inspect で ready 状態を確認する (見つからない / project.json 無しは reject)
+            const inspect = await inspectWorkspacePath(resolved);
+            if (inspect.status !== "ready") {
+              respondError(
+                inspect.status === "notFound"
+                  ? `フォルダが見つかりません: ${resolved}`
+                  : `ワークスペースが初期化されていません (project.json が見つかりません): ${resolved}。init=true で初期化してください。`,
+              );
+              break;
+            }
           }
           try {
             setActiveWorkspacePath(resolved);

--- a/designer-mcp/src/wsBridge.ts
+++ b/designer-mcp/src/wsBridge.ts
@@ -5,7 +5,6 @@ import { execSync } from "child_process";
 import { createServer, type IncomingMessage, type ServerResponse, type Server as HttpServer } from "node:http";
 import { renameScreenItemId, checkScreenItemRefs } from "./renameScreenItem.js";
 import {
-  ensureDataDir,
   readProject,
   writeProject,
   readScreen,
@@ -126,7 +125,8 @@ class WsBridge extends EventEmitter {
   }
 
   async start(): Promise<void> {
-    await ensureDataDir();
+    // workspace 切替モード対応 (#671): startup 時点で workspace 未選択のことがあるため、
+    // ensureDataDir() は呼ばない。各 read/write 関数が必要時に ensureDataDir() を呼ぶ。
     if (killStaleProcessOnPort(WS_PORT)) {
       await delay(500);
     }

--- a/designer/src/components/AppShell.tsx
+++ b/designer/src/components/AppShell.tsx
@@ -79,15 +79,14 @@ export function AppShell() {
     return subscribeWorkspace(() => setWorkspaceState(getWorkspaceState()));
   }, []);
 
-  // 起動時: MCP 接続を能動的に開始 + 接続後にワークスペースをロード、ブロードキャスト購読。
-  // / (Dashboard) のような MCP 接続を能動起動しないルートで初回ランディングしても guard が
-  // 動作するよう、AppShell が WS のライフサイクル責任を持つ:
-  //  - 起動時: startWithoutEditor() で能動起動。onStatusChange が即時に現状を発火するため、
-  //    "disconnected" 経由でも下記 disconnected ハンドラで起動が走る。
-  //  - "disconnected" 受信時: Designer unmount の stop() などで切断された後でも常に再起動する。
-  //    startWithoutEditor は readyState OPEN / status==="connecting" なら no-op なので idempotent。
-  //  - "connected" 受信時: loadWorkspaces で active state を最新化。
-  // Designer タブ等の start(editor) は既存接続があれば再利用するため衝突しない。
+  // AppShell が MCP 接続のライフサイクルを単一所有する (#676 review):
+  //  - mount 時に startWithoutEditor() を 1 度呼んで能動起動 (Dashboard 等で初回ランディング
+  //    した時にも bridge を必ず立ち上げる)。
+  //  - "connected" 受信で loadWorkspaces して active state を最新化。
+  //  - "disconnected" は mcpBridge 自身が RETRY_DELAY_MS の retry timer を回すので、AppShell は
+  //    何もしない (二重 reconnect で接続が在りえない遷移をするのを避けるため)。
+  //  - Designer は workspace 機能を破壊しないよう mcpBridge.stop() を呼ばない設計に変更済み
+  //    (Designer.tsx 参照)。なので AppShell が stop() の事後復帰を心配する必要は無い。
   useEffect(() => {
     const unsubBroadcast = subscribeWorkspaceChanges();
     const bridge = mcpBridge as unknown as {
@@ -97,11 +96,9 @@ export function AppShell() {
     const unsubStatus = bridge.onStatusChange((s) => {
       if (s === "connected") {
         loadWorkspaces().catch(console.error);
-      } else if (s === "disconnected") {
-        // 切断検知 → 再起動 (idempotent)。Designer unmount による stop() からの復帰経路。
-        bridge.startWithoutEditor();
       }
     });
+    bridge.startWithoutEditor();
     return () => { unsubBroadcast(); unsubStatus(); };
   }, []);
 

--- a/designer/src/components/AppShell.tsx
+++ b/designer/src/components/AppShell.tsx
@@ -342,9 +342,18 @@ export function AppShell() {
   }, [location.pathname]);
 
   // アクティブタブ → URL 同期
+  // workspace 未選択中 (active=null) や /workspace/select 表示中は同期を停止する。
+  // localStorage に残った activeTabId が design:xxx 等を指していると、guard が
+  // /workspace/select に redirect → 直後に本 effect が /screen/design/xxx へ navigate
+  // を上書き → guard が再度 redirect、というループ / flicker を起こすため。
+  // workspace-list タブだけは select 画面からの誘導でも進入可能なので例外扱い。
   const activeTab = tabs.find((t) => t.id === activeTabId);
   useEffect(() => {
     if (!activeTab) return;
+    if (location.pathname === "/workspace/select") return;
+    if (workspaceState.active === null && !workspaceState.lockdown && activeTab.type !== "workspace-list") {
+      return;
+    }
     const expectedPath =
       activeTab.type === "design"             ? `/screen/design/${activeTab.resourceId}`
       : activeTab.type === "table"            ? `/table/edit/${activeTab.resourceId}`
@@ -369,7 +378,7 @@ export function AppShell() {
     if (expectedPath && location.pathname !== expectedPath) {
       navigate(expectedPath, { replace: true });
     }
-  }, [activeTabId, activeTab?.type, activeTab?.resourceId]);
+  }, [activeTabId, activeTab?.type, activeTab?.resourceId, workspaceState.active, workspaceState.lockdown, location.pathname]);
 
   const designTabs = tabs.filter((t) => t.type === "design");
   const activeIsDesign = activeTab?.type === "design";

--- a/designer/src/components/AppShell.tsx
+++ b/designer/src/components/AppShell.tsx
@@ -37,6 +37,7 @@ import {
   setActiveTab,
   closeTab,
   makeTabId,
+  clearPersistedTabs,
   type TabItem,
   type TabType,
 } from "../store/tabStore";
@@ -137,6 +138,16 @@ export function AppShell() {
     if (dirtyLabels.length > 0) {
       console.warn(`[workspace] 未保存タブを強制破棄: ${dirtyLabels.join(", ")}`);
     }
+    // localStorage に永続化された旧 workspace のタブ / GrapesJS screen キャッシュを破棄してから reload。
+    // これを怠ると、reload 後にタブ復元 → URL sync で旧 resource ID へ navigate → 切替先 workspace に
+    // 同 ID があれば stale 表示・誤保存、無ければ dashboard fallback、というバグになる。
+    clearPersistedTabs();
+    try {
+      for (let i = localStorage.length - 1; i >= 0; i--) {
+        const k = localStorage.key(i);
+        if (k && k.startsWith("gjs-")) localStorage.removeItem(k);
+      }
+    } catch { /* private browsing / quota error は無視 */ }
     window.location.reload();
   }, [workspaceState.active?.id]);
 

--- a/designer/src/components/AppShell.tsx
+++ b/designer/src/components/AppShell.tsx
@@ -133,16 +133,19 @@ export function AppShell() {
   }, [workspaceState.active?.id]);
 
   // ルーティングガード: active===null かつ /workspace/list でも /workspace/select でもない → /workspace/select へ
+  // backend オフライン時は error が立つ → ガードを停止して localStorage fallback 経路を温存する。
+  // (AGENTS.md "If WS disconnected → localStorage" の互換性確保)
   useEffect(() => {
     if (workspaceState.loading) return; // ロード中は判定しない
     if (workspaceState.lockdown) return; // lockdown 時はガード不要 (常にアクティブ扱い)
+    if (workspaceState.error !== null) return; // load 失敗 (offline 等) は redirect しない
     if (workspaceState.active === null) {
       const excluded = ["/workspace/list", "/workspace/select"];
       if (!excluded.includes(location.pathname)) {
         navigate("/workspace/select", { replace: true });
       }
     }
-  }, [workspaceState.active, workspaceState.loading, workspaceState.lockdown, location.pathname]);
+  }, [workspaceState.active, workspaceState.loading, workspaceState.lockdown, workspaceState.error, location.pathname]);
 
   // CSS variables でヘッダー・タブバーの高さを各コンポーネントに伝える
   useEffect(() => {

--- a/designer/src/components/AppShell.tsx
+++ b/designer/src/components/AppShell.tsx
@@ -403,6 +403,25 @@ export function AppShell() {
     closeTab(tabId, true);
   };
 
+  // 初回ハイドレーション中はルートを描画しない (#676 review):
+  // workspaceState.loading=true の間に dashboard / 一覧系を描画すると、singleton stores
+  // (flowStore / tableStore 等) が WS 未接続のうちに localStorage fallback で初期化されて
+  // 旧 workspace のデータをキャッシュしてしまう。そのキャッシュは hydration 後も残り続け、
+  // その状態から保存すると active workspace に旧データが上書きされる。
+  // loading=false (= 初回 load 成功 or 失敗 or lockdown 確定) になるまで splash で遅延させる。
+  if (workspaceState.loading) {
+    return (
+      <div style={{
+        display: "flex", alignItems: "center", justifyContent: "center",
+        height: "100vh", flexDirection: "column", gap: "8px",
+        color: "var(--muted-text, #888)",
+      }}>
+        <i className="bi bi-hourglass-split" style={{ fontSize: "1.5rem" }} />
+        <p style={{ margin: 0 }}>ワークスペース情報を読み込み中...</p>
+      </div>
+    );
+  }
+
   // /workspace/select はフルスクリーンで表示 (ヘッダー・タブバーなし)
   if (location.pathname === "/workspace/select") {
     return <WorkspaceSelectView />;

--- a/designer/src/components/AppShell.tsx
+++ b/designer/src/components/AppShell.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Routes, Route, useLocation, useNavigate, matchPath } from "react-router-dom";
 import { FlowEditor } from "./flow/FlowEditor";
 import { ScreenListView } from "./flow/ScreenListView";
@@ -16,10 +16,13 @@ import { ViewListView } from "./view/ViewListView";
 import { ViewEditor } from "./view/ViewEditor";
 import { ViewDefinitionListView } from "./view-definition/ViewDefinitionListView";
 import { ViewDefinitionEditor } from "./view-definition/ViewDefinitionEditor";
+import { WorkspaceListView } from "./workspace/WorkspaceListView";
+import { WorkspaceSelectView } from "./workspace/WorkspaceSelectView";
 import { Designer } from "./Designer";
 import { DashboardView } from "./dashboard/DashboardView";
 import { TabBar } from "./TabBar";
 import { CommonHeader } from "./CommonHeader";
+import { mcpBridge } from "../mcp/mcpBridge";
 import { loadProject } from "../store/flowStore";
 import { loadTable } from "../store/tableStore";
 import { loadProcessFlow } from "../store/processFlowStore";
@@ -37,6 +40,12 @@ import {
   type TabItem,
   type TabType,
 } from "../store/tabStore";
+import {
+  getState as getWorkspaceState,
+  subscribe as subscribeWorkspace,
+  loadWorkspaces,
+  subscribeWorkspaceChanges,
+} from "../store/workspaceStore";
 import { useTabKeyboard } from "../hooks/useTabKeyboard";
 import { ErrorBoundary } from "./common/ErrorBoundary";
 import { TabErrorFallback } from "./common/ErrorFallback";
@@ -62,6 +71,65 @@ export function AppShell() {
   const navigate = useNavigate();
   const { showError } = useErrorDialog();
   useTabKeyboard();
+
+  // ワークスペース状態管理
+  const [workspaceState, setWorkspaceState] = useState(getWorkspaceState());
+  useEffect(() => {
+    return subscribeWorkspace(() => setWorkspaceState(getWorkspaceState()));
+  }, []);
+
+  // 起動時: MCP 接続後にワークスペースをロード、ブロードキャスト購読
+  useEffect(() => {
+    const unsubBroadcast = subscribeWorkspaceChanges();
+    const unsubStatus = (mcpBridge as unknown as { onStatusChange: (cb: (s: string) => void) => () => void }).onStatusChange((s) => {
+      if (s === "connected") {
+        loadWorkspaces().catch(console.error);
+      }
+    });
+    // 初回ロード試行
+    loadWorkspaces().catch(console.error);
+    return () => { unsubBroadcast(); unsubStatus(); };
+  }, []);
+
+  // workspace.changed → リソースタブをクローズ (per-resource tabs)
+  const prevActiveWorkspaceIdRef = useRef<string | null | undefined>(undefined);
+  useEffect(() => {
+    const currentId = workspaceState.active?.id ?? null;
+    if (prevActiveWorkspaceIdRef.current === undefined) {
+      // 初回: 記録のみ
+      prevActiveWorkspaceIdRef.current = currentId;
+      return;
+    }
+    if (prevActiveWorkspaceIdRef.current !== currentId) {
+      prevActiveWorkspaceIdRef.current = currentId;
+      // ワークスペースが切り替わった: per-resource タブを全て強制クローズ
+      const perResourceTypes: TabType[] = ["design", "table", "process-flow", "sequence", "view", "view-definition"];
+      const allTabs = getTabs();
+      const dirtyTabsClosed: string[] = [];
+      for (const tab of allTabs) {
+        if (perResourceTypes.includes(tab.type)) {
+          if (tab.isDirty) dirtyTabsClosed.push(tab.label);
+          closeTab(tab.id, true);
+        }
+      }
+      if (dirtyTabsClosed.length > 0) {
+        // 簡易通知: ブラウザ console + 将来的にはトーストへ
+        console.warn(`[workspace] 未保存タブを強制クローズ: ${dirtyTabsClosed.join(", ")}`);
+      }
+    }
+  }, [workspaceState.active?.id]);
+
+  // ルーティングガード: active===null かつ /workspace/list でも /workspace/select でもない → /workspace/select へ
+  useEffect(() => {
+    if (workspaceState.loading) return; // ロード中は判定しない
+    if (workspaceState.lockdown) return; // lockdown 時はガード不要 (常にアクティブ扱い)
+    if (workspaceState.active === null) {
+      const excluded = ["/workspace/list", "/workspace/select"];
+      if (!excluded.includes(location.pathname)) {
+        navigate("/workspace/select", { replace: true });
+      }
+    }
+  }, [workspaceState.active, workspaceState.loading, workspaceState.lockdown, location.pathname]);
 
   // CSS variables でヘッダー・タブバーの高さを各コンポーネントに伝える
   useEffect(() => {
@@ -227,6 +295,9 @@ export function AppShell() {
       return;
     }
 
+    // /workspace/select はタブ対象外 (フルスクリーン選択画面)
+    if (location.pathname === "/workspace/select") return;
+
     // シングルトンタブ: list / workspace 系は resourceId="main" で 1 インスタンスのみ
     const singletonRoutes: ReadonlyArray<{ path: string; type: TabType; label: string }> = [
       { path: "/",                   type: "dashboard",          label: "ダッシュボード" },
@@ -241,6 +312,7 @@ export function AppShell() {
       { path: "/sequence/list",      type: "sequence-list",      label: "シーケンス一覧" },
       { path: "/view/list",          type: "view-list",           label: "ビュー一覧" },
       { path: "/view-definition/list", type: "view-definition-list", label: "ビュー定義一覧" },
+      { path: "/workspace/list",     type: "workspace-list",     label: "ワークスペース" },
     ];
     for (const { path, type, label } of singletonRoutes) {
       if (location.pathname === path) {
@@ -275,6 +347,7 @@ export function AppShell() {
       : activeTab.type === "sequence-list"    ? "/sequence/list"
       : activeTab.type === "view-list"              ? "/view/list"
       : activeTab.type === "view-definition-list"   ? "/view-definition/list"
+      : activeTab.type === "workspace-list"         ? "/workspace/list"
       : activeTab.type === "dashboard"              ? "/"
       : null;
     if (expectedPath && location.pathname !== expectedPath) {
@@ -288,6 +361,11 @@ export function AppShell() {
   const handleCloseCrashedTab = (tabId: string) => {
     closeTab(tabId, true);
   };
+
+  // /workspace/select はフルスクリーンで表示 (ヘッダー・タブバーなし)
+  if (location.pathname === "/workspace/select") {
+    return <WorkspaceSelectView />;
+  }
 
   return (
     <>
@@ -358,6 +436,7 @@ export function AppShell() {
             <Route path="/view/edit/:viewId" element={<ViewEditor />} />
             <Route path="/view-definition/list" element={<ViewDefinitionListView />} />
             <Route path="/view-definition/edit/:viewDefinitionId" element={<ViewDefinitionEditor />} />
+            <Route path="/workspace/list" element={<WorkspaceListView />} />
           </Routes>
         </ErrorBoundary>
       )}

--- a/designer/src/components/AppShell.tsx
+++ b/designer/src/components/AppShell.tsx
@@ -80,19 +80,27 @@ export function AppShell() {
 
   // 起動時: MCP 接続を能動的に開始 + 接続後にワークスペースをロード、ブロードキャスト購読。
   // / (Dashboard) のような MCP 接続を能動起動しないルートで初回ランディングしても guard が
-  // 動作するよう、ここで startWithoutEditor() を呼ぶ。
-  // Designer タブ等の start(editor) は既存接続があれば再利用するため衝突しない (mcpBridge.start 内で
-  // readyState OPEN なら early return する仕様)。
+  // 動作するよう、AppShell が WS のライフサイクル責任を持つ:
+  //  - 起動時: startWithoutEditor() で能動起動。onStatusChange が即時に現状を発火するため、
+  //    "disconnected" 経由でも下記 disconnected ハンドラで起動が走る。
+  //  - "disconnected" 受信時: Designer unmount の stop() などで切断された後でも常に再起動する。
+  //    startWithoutEditor は readyState OPEN / status==="connecting" なら no-op なので idempotent。
+  //  - "connected" 受信時: loadWorkspaces で active state を最新化。
+  // Designer タブ等の start(editor) は既存接続があれば再利用するため衝突しない。
   useEffect(() => {
     const unsubBroadcast = subscribeWorkspaceChanges();
-    const unsubStatus = (mcpBridge as unknown as { onStatusChange: (cb: (s: string) => void) => () => void }).onStatusChange((s) => {
+    const bridge = mcpBridge as unknown as {
+      onStatusChange: (cb: (s: string) => void) => () => void;
+      startWithoutEditor: () => void;
+    };
+    const unsubStatus = bridge.onStatusChange((s) => {
       if (s === "connected") {
         loadWorkspaces().catch(console.error);
+      } else if (s === "disconnected") {
+        // 切断検知 → 再起動 (idempotent)。Designer unmount による stop() からの復帰経路。
+        bridge.startWithoutEditor();
       }
     });
-    // bridge を能動起動 (既に接続中なら no-op)。これにより onStatusChange が "connected" を
-    // 受信して loadWorkspaces が走る → loading=false に落ちる → guard が判定可能になる。
-    (mcpBridge as unknown as { startWithoutEditor: () => void }).startWithoutEditor();
     return () => { unsubBroadcast(); unsubStatus(); };
   }, []);
 

--- a/designer/src/components/AppShell.tsx
+++ b/designer/src/components/AppShell.tsx
@@ -78,19 +78,21 @@ export function AppShell() {
     return subscribeWorkspace(() => setWorkspaceState(getWorkspaceState()));
   }, []);
 
-  // 起動時: MCP 接続後にワークスペースをロード、ブロードキャスト購読
+  // 起動時: MCP 接続を能動的に開始 + 接続後にワークスペースをロード、ブロードキャスト購読。
+  // / (Dashboard) のような MCP 接続を能動起動しないルートで初回ランディングしても guard が
+  // 動作するよう、ここで startWithoutEditor() を呼ぶ。
+  // Designer タブ等の start(editor) は既存接続があれば再利用するため衝突しない (mcpBridge.start 内で
+  // readyState OPEN なら early return する仕様)。
   useEffect(() => {
     const unsubBroadcast = subscribeWorkspaceChanges();
-    // onStatusChange は登録時に現在の status を即座にコールバックする (mcpBridge 仕様)。
-    // よって、登録後 1 回目のコールが現状を反映する。"connected" になるまで loadWorkspaces を
-    // 呼ばないことで、未接続状態での失敗 → active=null → /workspace/select 強制遷移
-    // という不正な誘導を防ぐ。loading=true 初期値 (workspaceStore) と組み合わせ、
-    // 初回 load 完了までガードを停止させる。
     const unsubStatus = (mcpBridge as unknown as { onStatusChange: (cb: (s: string) => void) => () => void }).onStatusChange((s) => {
       if (s === "connected") {
         loadWorkspaces().catch(console.error);
       }
     });
+    // bridge を能動起動 (既に接続中なら no-op)。これにより onStatusChange が "connected" を
+    // 受信して loadWorkspaces が走る → loading=false に落ちる → guard が判定可能になる。
+    (mcpBridge as unknown as { startWithoutEditor: () => void }).startWithoutEditor();
     return () => { unsubBroadcast(); unsubStatus(); };
   }, []);
 
@@ -98,27 +100,36 @@ export function AppShell() {
   // per-resource タブを閉じるだけでは singleton stores (flowStore, tableStore 等) と
   // 現在マウント中の singleton view (DashboardView, ScreenListView 等) が旧 workspace の
   // データを保持し、その状態から保存すると新 workspace に旧データが混入するため。
+  //
+  // 重要: 初回 hydration (起動時の自動 active 設定: store の初期 null → 復元された id) は
+  // 「切替」ではないのでリロードしない。リロード対象は prev が non-null だった場合のみ。
+  // null → non-null をリロードすると、リロード後また初期 null に戻り再 hydration → 再リロードで
+  // 無限ループになる。
   const prevActiveWorkspaceIdRef = useRef<string | null | undefined>(undefined);
   useEffect(() => {
     const currentId = workspaceState.active?.id ?? null;
     if (prevActiveWorkspaceIdRef.current === undefined) {
-      // 初回: 記録のみ (起動時の自動 active 設定ではリロード不要)
+      // 1 回目の effect 実行: 記録のみ
       prevActiveWorkspaceIdRef.current = currentId;
       return;
     }
-    if (prevActiveWorkspaceIdRef.current !== currentId) {
+    if (prevActiveWorkspaceIdRef.current === currentId) return;
+    if (prevActiveWorkspaceIdRef.current === null) {
+      // null → non-null: 初回 hydration (backend の auto-restore など)。
+      // 既存 store / view は new workspace のデータでまだ何も染まっていないのでリロード不要。
       prevActiveWorkspaceIdRef.current = currentId;
-      // dirty タブの数を確認 (再読込で全閉じになるので警告ログのみ)
-      const perResourceTypes: TabType[] = ["design", "table", "process-flow", "sequence", "view", "view-definition"];
-      const dirtyLabels = getTabs()
-        .filter((t) => t.isDirty && perResourceTypes.includes(t.type))
-        .map((t) => t.label);
-      if (dirtyLabels.length > 0) {
-        console.warn(`[workspace] 未保存タブを強制破棄: ${dirtyLabels.join(", ")}`);
-      }
-      // 全 store / 全 view を初期化するための full page reload
-      window.location.reload();
+      return;
     }
+    // non-null → 別の non-null / null: ユーザー操作による workspace 切替 / 閉じる
+    prevActiveWorkspaceIdRef.current = currentId;
+    const perResourceTypes: TabType[] = ["design", "table", "process-flow", "sequence", "view", "view-definition"];
+    const dirtyLabels = getTabs()
+      .filter((t) => t.isDirty && perResourceTypes.includes(t.type))
+      .map((t) => t.label);
+    if (dirtyLabels.length > 0) {
+      console.warn(`[workspace] 未保存タブを強制破棄: ${dirtyLabels.join(", ")}`);
+    }
+    window.location.reload();
   }, [workspaceState.active?.id]);
 
   // ルーティングガード: active===null かつ /workspace/list でも /workspace/select でもない → /workspace/select へ

--- a/designer/src/components/AppShell.tsx
+++ b/designer/src/components/AppShell.tsx
@@ -81,41 +81,43 @@ export function AppShell() {
   // 起動時: MCP 接続後にワークスペースをロード、ブロードキャスト購読
   useEffect(() => {
     const unsubBroadcast = subscribeWorkspaceChanges();
+    // onStatusChange は登録時に現在の status を即座にコールバックする (mcpBridge 仕様)。
+    // よって、登録後 1 回目のコールが現状を反映する。"connected" になるまで loadWorkspaces を
+    // 呼ばないことで、未接続状態での失敗 → active=null → /workspace/select 強制遷移
+    // という不正な誘導を防ぐ。loading=true 初期値 (workspaceStore) と組み合わせ、
+    // 初回 load 完了までガードを停止させる。
     const unsubStatus = (mcpBridge as unknown as { onStatusChange: (cb: (s: string) => void) => () => void }).onStatusChange((s) => {
       if (s === "connected") {
         loadWorkspaces().catch(console.error);
       }
     });
-    // 初回ロード試行
-    loadWorkspaces().catch(console.error);
     return () => { unsubBroadcast(); unsubStatus(); };
   }, []);
 
-  // workspace.changed → リソースタブをクローズ (per-resource tabs)
+  // workspace.changed → ストア / 描画中 view を完全に破棄するためページ再読込。
+  // per-resource タブを閉じるだけでは singleton stores (flowStore, tableStore 等) と
+  // 現在マウント中の singleton view (DashboardView, ScreenListView 等) が旧 workspace の
+  // データを保持し、その状態から保存すると新 workspace に旧データが混入するため。
   const prevActiveWorkspaceIdRef = useRef<string | null | undefined>(undefined);
   useEffect(() => {
     const currentId = workspaceState.active?.id ?? null;
     if (prevActiveWorkspaceIdRef.current === undefined) {
-      // 初回: 記録のみ
+      // 初回: 記録のみ (起動時の自動 active 設定ではリロード不要)
       prevActiveWorkspaceIdRef.current = currentId;
       return;
     }
     if (prevActiveWorkspaceIdRef.current !== currentId) {
       prevActiveWorkspaceIdRef.current = currentId;
-      // ワークスペースが切り替わった: per-resource タブを全て強制クローズ
+      // dirty タブの数を確認 (再読込で全閉じになるので警告ログのみ)
       const perResourceTypes: TabType[] = ["design", "table", "process-flow", "sequence", "view", "view-definition"];
-      const allTabs = getTabs();
-      const dirtyTabsClosed: string[] = [];
-      for (const tab of allTabs) {
-        if (perResourceTypes.includes(tab.type)) {
-          if (tab.isDirty) dirtyTabsClosed.push(tab.label);
-          closeTab(tab.id, true);
-        }
+      const dirtyLabels = getTabs()
+        .filter((t) => t.isDirty && perResourceTypes.includes(t.type))
+        .map((t) => t.label);
+      if (dirtyLabels.length > 0) {
+        console.warn(`[workspace] 未保存タブを強制破棄: ${dirtyLabels.join(", ")}`);
       }
-      if (dirtyTabsClosed.length > 0) {
-        // 簡易通知: ブラウザ console + 将来的にはトーストへ
-        console.warn(`[workspace] 未保存タブを強制クローズ: ${dirtyTabsClosed.join(", ")}`);
-      }
+      // 全 store / 全 view を初期化するための full page reload
+      window.location.reload();
     }
   }, [workspaceState.active?.id]);
 

--- a/designer/src/components/CommonHeader.tsx
+++ b/designer/src/components/CommonHeader.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { HeaderMenu } from "./HeaderMenu";
+import { WorkspaceIndicator } from "./workspace/WorkspaceIndicator";
 import "../styles/commonHeader.css";
 
 interface Props {
@@ -14,6 +15,7 @@ export function CommonHeader({ notification, userName }: Props) {
         <HeaderMenu />
         <i className="bi bi-palette2 common-header-logo" />
         <span className="common-header-title">業務システム デザイナー</span>
+        <WorkspaceIndicator />
       </div>
       <div className="common-header-center">
         {notification}

--- a/designer/src/components/Designer.tsx
+++ b/designer/src/components/Designer.tsx
@@ -288,7 +288,10 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
       unsubScreenChanged();
       mcpBridge.setThemeHandler(null);
       mcpBridge.setCurrentScreenId(null);
-      mcpBridge.stop();
+      // mcpBridge.stop() は呼ばない (#676 review): WS ライフサイクルは AppShell が一括所有する。
+      // Designer タブを閉じても他タブ / Header の WorkspaceIndicator が WS を必要とし続けるため、
+      // ここで切断すると workspace 機能全体が壊れる。Designer 固有のハンドラはこの cleanup の
+      // 他行 (setThemeHandler/setCurrentScreenId(null) と上の各 unsub) で確実に外している。
       clearItemsFromCache(screenId);
     };
   }, [screenId, tabId]);

--- a/designer/src/components/HeaderMenu.tsx
+++ b/designer/src/components/HeaderMenu.tsx
@@ -60,6 +60,10 @@ const MENU_ITEMS: MenuItem[] = [
     id: "view-definition-list", label: "ビュー定義一覧", icon: "bi-layout-text-window", route: "/view-definition/list",
     activePaths: ["/view-definition/list"], activePrefixes: ["/view-definition/edit/"],
   },
+  {
+    id: "workspace-list", label: "ワークスペース", icon: "bi-folder2-open", route: "/workspace/list",
+    activePaths: ["/workspace/list", "/workspace/select"],
+  },
 ];
 
 const DASHBOARD_ITEM: MenuItem = {

--- a/designer/src/components/workspace/WorkspaceIndicator.tsx
+++ b/designer/src/components/workspace/WorkspaceIndicator.tsx
@@ -1,0 +1,204 @@
+import { useState, useEffect, useRef } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  getState,
+  subscribe as subscribeStore,
+  openWorkspace,
+  closeWorkspace,
+} from "../../store/workspaceStore";
+
+export function WorkspaceIndicator() {
+  const [state, setState] = useState(getState());
+  const [open, setOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    return subscribeStore(() => setState(getState()));
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    const close = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", close);
+    return () => document.removeEventListener("mousedown", close);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  const { active, lockdown, workspaces } = state;
+  const recentWorkspaces = workspaces.slice(0, 5);
+
+  const handleNavigateToList = () => {
+    setOpen(false);
+    navigate("/workspace/list");
+  };
+
+  const handleOpenWorkspace = async (id: string) => {
+    setOpen(false);
+    try {
+      await openWorkspace(id, true);
+    } catch (e) {
+      console.error("[WorkspaceIndicator] openWorkspace failed:", e);
+    }
+  };
+
+  const handleClose = async () => {
+    setOpen(false);
+    try {
+      await closeWorkspace();
+    } catch (e) {
+      console.error("[WorkspaceIndicator] closeWorkspace failed:", e);
+    }
+  };
+
+  return (
+    <div
+      ref={dropdownRef}
+      style={{ position: "relative", display: "inline-flex", alignItems: "center" }}
+    >
+      <button
+        onClick={() => setOpen((v) => !v)}
+        title={
+          lockdown
+            ? `環境変数 DESIGNER_DATA_DIR で固定中: ${state.lockdownPath ?? ""}`
+            : active?.path
+            ? active.path
+            : "ワークスペース未選択"
+        }
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "5px",
+          background: "transparent",
+          border: "1px solid #3b3e55",
+          borderRadius: "4px",
+          padding: "3px 8px",
+          cursor: "pointer",
+          color: active ? "#e4e6f0" : "#9a9db5",
+          fontSize: "12px",
+          whiteSpace: "nowrap",
+          maxWidth: "220px",
+        }}
+        aria-haspopup="true"
+        aria-expanded={open}
+      >
+        {lockdown ? (
+          <i className="bi bi-lock-fill" style={{ color: "#fbbf24" }} />
+        ) : (
+          <i className="bi bi-folder2" style={{ color: "#4dabf7" }} />
+        )}
+        <span style={{
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          maxWidth: "160px",
+          opacity: active ? 1 : 0.6,
+        }}>
+          {active?.name ?? (active?.path ? active.path : "ワークスペース未選択")}
+        </span>
+        <i className="bi bi-chevron-down" style={{ fontSize: "10px", opacity: 0.7 }} />
+      </button>
+
+      {open && (
+        <div style={{
+          position: "absolute",
+          top: "calc(100% + 4px)",
+          left: 0,
+          minWidth: "260px",
+          background: "#1e2035",
+          border: "1px solid #3b3e55",
+          borderRadius: "6px",
+          boxShadow: "0 4px 16px rgba(0,0,0,0.4)",
+          zIndex: 9999,
+          padding: "4px 0",
+        }}>
+          {/* ワークスペース一覧を開く */}
+          <button
+            onClick={handleNavigateToList}
+            style={menuItemStyle}
+          >
+            <i className="bi bi-folder2-open" style={{ marginRight: "8px", color: "#4dabf7" }} />
+            ワークスペース一覧を開く
+          </button>
+
+          {/* 最近使ったワークスペース (lockdown 時は非表示) */}
+          {!lockdown && recentWorkspaces.length > 0 && (
+            <>
+              <div style={sectionLabelStyle}>最近使ったワークスペース</div>
+              {recentWorkspaces.map((w) => (
+                <button
+                  key={w.id}
+                  onClick={() => handleOpenWorkspace(w.id)}
+                  style={{
+                    ...menuItemStyle,
+                    fontWeight: active?.id === w.id ? 600 : undefined,
+                  }}
+                  title={w.path}
+                >
+                  {active?.id === w.id && (
+                    <i className="bi bi-check2" style={{ marginRight: "4px", color: "#4ade80" }} />
+                  )}
+                  {active?.id !== w.id && (
+                    <span style={{ display: "inline-block", width: "18px" }} />
+                  )}
+                  <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", flex: 1 }}>
+                    {w.name}
+                  </span>
+                </button>
+              ))}
+            </>
+          )}
+
+          {/* セパレーター */}
+          <div style={{ height: "1px", background: "#3b3e55", margin: "4px 0" }} />
+
+          {/* ワークスペースを閉じる */}
+          <button
+            onClick={handleClose}
+            disabled={!active || lockdown}
+            style={{
+              ...menuItemStyle,
+              color: (!active || lockdown) ? "#666" : "#f87171",
+              cursor: (!active || lockdown) ? "not-allowed" : "pointer",
+            }}
+          >
+            <i className="bi bi-x-circle" style={{ marginRight: "8px" }} />
+            ワークスペースを閉じる
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+const menuItemStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  width: "100%",
+  padding: "7px 12px",
+  background: "transparent",
+  border: "none",
+  cursor: "pointer",
+  color: "#e4e6f0",
+  fontSize: "12px",
+  textAlign: "left",
+};
+
+const sectionLabelStyle: React.CSSProperties = {
+  padding: "6px 12px 2px",
+  fontSize: "10px",
+  color: "#9a9db5",
+  textTransform: "uppercase",
+  letterSpacing: "0.05em",
+};

--- a/designer/src/components/workspace/WorkspaceListView.tsx
+++ b/designer/src/components/workspace/WorkspaceListView.tsx
@@ -196,16 +196,24 @@ export function AddWorkspaceDialog({ onClose, onAdded }: AddWorkspaceDialogProps
         {status === "notFound" && (
           <>
             <div style={{ padding: "8px 12px", background: "var(--danger-bg, #f8d7da)", borderRadius: "4px", marginBottom: "12px", color: "var(--danger-text, #721c24)" }}>
-              <i className="bi bi-x-circle" /> フォルダが見つかりません。パスを確認してください。
+              <i className="bi bi-x-circle" /> フォルダが見つかりません。パスを確認するか、このパスに新規作成できます。
             </div>
             <div className="tbl-modal-btns">
-              <button className="tbl-btn tbl-btn-ghost" onClick={onClose}>閉じる</button>
+              <button className="tbl-btn tbl-btn-ghost" onClick={onClose}>キャンセル</button>
               <button
-                className="tbl-btn tbl-btn-primary"
+                className="tbl-btn tbl-btn-ghost"
                 onClick={handleInspect}
                 disabled={!path.trim()}
               >
                 <i className="bi bi-arrow-clockwise" /> 再確認
+              </button>
+              <button
+                className="tbl-btn tbl-btn-primary"
+                onClick={handleInit}
+                disabled={processing || !path.trim()}
+                title="このパスにフォルダを作成し、project.json を初期化します"
+              >
+                {processing ? "作成中..." : "フォルダを作成して初期化"}
               </button>
             </div>
           </>

--- a/designer/src/components/workspace/WorkspaceListView.tsx
+++ b/designer/src/components/workspace/WorkspaceListView.tsx
@@ -50,6 +50,7 @@ export function AddWorkspaceDialog({ onClose, onAdded }: AddWorkspaceDialogProps
   const [inspectName, setInspectName] = useState<string | null>(null);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [processing, setProcessing] = useState(false);
+  const [pickedFolderHint, setPickedFolderHint] = useState<string | null>(null);
 
   const handleInspect = async () => {
     const trimmed = path.trim();
@@ -103,10 +104,11 @@ export function AddWorkspaceDialog({ onClose, onAdded }: AddWorkspaceDialogProps
     if (!("showDirectoryPicker" in window)) return;
     try {
       const handle = await (window as Window & { showDirectoryPicker: () => Promise<{ name: string }> }).showDirectoryPicker();
-      setPath(handle.name);
-      setStatus("idle");
+      // showDirectoryPicker は絶対パスを返さない (フォルダ名 .name のみ)。
+      // 入力欄に書き込むと相対パスとして MCP server cwd 配下と誤解釈されるため、
+      // 入力欄には触れず、フォルダ名だけを「選択ヒント」として表示する。
+      setPickedFolderHint(handle.name);
       setErrorMsg(null);
-      setInspectName(null);
     } catch (e) {
       if ((e as { name?: string }).name !== "AbortError") {
         setErrorMsg("フォルダ選択に失敗しました");
@@ -134,7 +136,7 @@ export function AddWorkspaceDialog({ onClose, onAdded }: AddWorkspaceDialogProps
               onKeyDown={(e) => { if (e.key === "Enter") handleInspect(); }}
             />
             {hasPickerSupport && (
-              <button className="tbl-btn tbl-btn-ghost" onClick={handlePickFolder} title="フォルダを選択">
+              <button className="tbl-btn tbl-btn-ghost" onClick={handlePickFolder} title="フォルダ名を確認 (絶対パスは別途入力)">
                 <i className="bi bi-folder2-open" />
               </button>
             )}
@@ -143,7 +145,13 @@ export function AddWorkspaceDialog({ onClose, onAdded }: AddWorkspaceDialogProps
 
         {hasPickerSupport && (
           <p style={{ fontSize: "0.78rem", color: "var(--muted-text, #888)", margin: "0 0 8px" }}>
-            ※「フォルダを選択」はフォルダ名のみ取得できます。絶対パスは手動で入力・修正してください。
+            ※「フォルダ選択」はフォルダ名の確認のみ可能です (ブラウザ仕様で絶対パス取得不可)。上の入力欄には絶対パスを必ず手動入力してください。
+          </p>
+        )}
+
+        {pickedFolderHint && (
+          <p style={{ fontSize: "0.82rem", color: "var(--muted-text, #888)", margin: "0 0 8px" }}>
+            選択したフォルダ名: <strong>{pickedFolderHint}</strong> — このフォルダの<em>絶対パス</em>を上の入力欄に入力してください。
           </p>
         )}
 

--- a/designer/src/components/workspace/WorkspaceListView.tsx
+++ b/designer/src/components/workspace/WorkspaceListView.tsx
@@ -1,0 +1,570 @@
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { mcpBridge } from "../../mcp/mcpBridge";
+import {
+  getState,
+  subscribe as subscribeStore,
+  loadWorkspaces,
+  openWorkspace,
+  inspectWorkspace,
+  initAndOpen,
+  removeWorkspace,
+  type WorkspaceEntry,
+} from "../../store/workspaceStore";
+import { DataList, type DataListColumn } from "../common/DataList";
+import { FilterBar } from "../common/FilterBar";
+import { SortBar } from "../common/SortBar";
+import { ViewModeToggle, type ViewMode } from "../common/ViewModeToggle";
+import { useListSelection } from "../../hooks/useListSelection";
+import { useListFilter } from "../../hooks/useListFilter";
+import { useListSort } from "../../hooks/useListSort";
+import { usePersistentState } from "../../hooks/usePersistentState";
+import "../../styles/table.css";
+
+const STORAGE_KEY = "list-view-mode:workspace-list";
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "—";
+  try {
+    return new Date(iso).toLocaleString("ja-JP", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+// ─── 追加ダイアログ ───────────────────────────────────────────────────────────
+
+interface AddWorkspaceDialogProps {
+  onClose: () => void;
+  onAdded: () => void;
+}
+
+export function AddWorkspaceDialog({ onClose, onAdded }: AddWorkspaceDialogProps) {
+  const [path, setPath] = useState("");
+  const [status, setStatus] = useState<"idle" | "inspecting" | "ready" | "needsInit" | "notFound" | "error">("idle");
+  const [inspectName, setInspectName] = useState<string | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [processing, setProcessing] = useState(false);
+
+  const handleInspect = async () => {
+    const trimmed = path.trim();
+    if (!trimmed) return;
+    setStatus("inspecting");
+    setErrorMsg(null);
+    setInspectName(null);
+    try {
+      const result = await inspectWorkspace(trimmed);
+      setStatus(result.status);
+      setInspectName(result.name ?? null);
+    } catch (e) {
+      setStatus("error");
+      setErrorMsg(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  const handleOpen = async () => {
+    const trimmed = path.trim();
+    if (!trimmed) return;
+    setProcessing(true);
+    setErrorMsg(null);
+    try {
+      await openWorkspace(trimmed, false);
+      onAdded();
+      onClose();
+    } catch (e) {
+      setErrorMsg(e instanceof Error ? e.message : String(e));
+    } finally {
+      setProcessing(false);
+    }
+  };
+
+  const handleInit = async () => {
+    const trimmed = path.trim();
+    if (!trimmed) return;
+    setProcessing(true);
+    setErrorMsg(null);
+    try {
+      await initAndOpen(trimmed);
+      onAdded();
+      onClose();
+    } catch (e) {
+      setErrorMsg(e instanceof Error ? e.message : String(e));
+    } finally {
+      setProcessing(false);
+    }
+  };
+
+  const handlePickFolder = async () => {
+    if (!("showDirectoryPicker" in window)) return;
+    try {
+      const handle = await (window as Window & { showDirectoryPicker: () => Promise<{ name: string }> }).showDirectoryPicker();
+      setPath(handle.name);
+      setStatus("idle");
+      setErrorMsg(null);
+      setInspectName(null);
+    } catch (e) {
+      if ((e as { name?: string }).name !== "AbortError") {
+        setErrorMsg("フォルダ選択に失敗しました");
+      }
+    }
+  };
+
+  const hasPickerSupport = "showDirectoryPicker" in window;
+
+  return (
+    <div className="tbl-modal-overlay" onClick={onClose}>
+      <div className="tbl-modal" onClick={(e) => e.stopPropagation()} style={{ maxWidth: "480px" }}>
+        <div className="tbl-modal-title">ワークスペースを追加</div>
+
+        <label className="tbl-field">
+          <span>フォルダのパス</span>
+          <div style={{ display: "flex", gap: "6px" }}>
+            <input
+              type="text"
+              value={path}
+              onChange={(e) => { setPath(e.target.value); setStatus("idle"); setInspectName(null); setErrorMsg(null); }}
+              placeholder="C:\work\my-project または /home/user/my-project"
+              autoFocus
+              style={{ flex: 1 }}
+              onKeyDown={(e) => { if (e.key === "Enter") handleInspect(); }}
+            />
+            {hasPickerSupport && (
+              <button className="tbl-btn tbl-btn-ghost" onClick={handlePickFolder} title="フォルダを選択">
+                <i className="bi bi-folder2-open" />
+              </button>
+            )}
+          </div>
+        </label>
+
+        {hasPickerSupport && (
+          <p style={{ fontSize: "0.78rem", color: "var(--muted-text, #888)", margin: "0 0 8px" }}>
+            ※「フォルダを選択」はフォルダ名のみ取得できます。絶対パスは手動で入力・修正してください。
+          </p>
+        )}
+
+        {status === "idle" && (
+          <div className="tbl-modal-btns">
+            <button className="tbl-btn tbl-btn-ghost" onClick={onClose}>キャンセル</button>
+            <button
+              className="tbl-btn tbl-btn-primary"
+              onClick={handleInspect}
+              disabled={!path.trim()}
+            >
+              <i className="bi bi-search" /> 確認
+            </button>
+          </div>
+        )}
+
+        {status === "inspecting" && (
+          <p style={{ color: "var(--muted-text, #888)" }}>確認中...</p>
+        )}
+
+        {status === "ready" && (
+          <>
+            <div style={{ padding: "8px 12px", background: "var(--success-bg, #d4edda)", borderRadius: "4px", marginBottom: "12px", color: "var(--success-text, #155724)" }}>
+              <i className="bi bi-check-circle" /> ワークスペースが見つかりました
+              {inspectName && <> — <strong>{inspectName}</strong></>}
+            </div>
+            <div className="tbl-modal-btns">
+              <button className="tbl-btn tbl-btn-ghost" onClick={onClose}>キャンセル</button>
+              <button className="tbl-btn tbl-btn-primary" onClick={handleOpen} disabled={processing}>
+                {processing ? "開いています..." : "開く"}
+              </button>
+            </div>
+          </>
+        )}
+
+        {status === "needsInit" && (
+          <>
+            <div style={{ padding: "8px 12px", background: "var(--warning-bg, #fff3cd)", borderRadius: "4px", marginBottom: "12px", color: "var(--warning-text, #856404)" }}>
+              <i className="bi bi-exclamation-triangle" /> フォルダは空です。初期化してワークスペースを作成しますか？
+            </div>
+            <div className="tbl-modal-btns">
+              <button className="tbl-btn tbl-btn-ghost" onClick={onClose}>キャンセル</button>
+              <button className="tbl-btn tbl-btn-primary" onClick={handleInit} disabled={processing}>
+                {processing ? "初期化中..." : "初期化して開く"}
+              </button>
+            </div>
+          </>
+        )}
+
+        {status === "notFound" && (
+          <>
+            <div style={{ padding: "8px 12px", background: "var(--danger-bg, #f8d7da)", borderRadius: "4px", marginBottom: "12px", color: "var(--danger-text, #721c24)" }}>
+              <i className="bi bi-x-circle" /> フォルダが見つかりません。パスを確認してください。
+            </div>
+            <div className="tbl-modal-btns">
+              <button className="tbl-btn tbl-btn-ghost" onClick={onClose}>閉じる</button>
+              <button
+                className="tbl-btn tbl-btn-primary"
+                onClick={handleInspect}
+                disabled={!path.trim()}
+              >
+                <i className="bi bi-arrow-clockwise" /> 再確認
+              </button>
+            </div>
+          </>
+        )}
+
+        {status === "error" && (
+          <>
+            <div style={{ padding: "8px 12px", background: "var(--danger-bg, #f8d7da)", borderRadius: "4px", marginBottom: "12px", color: "var(--danger-text, #721c24)" }}>
+              <i className="bi bi-x-circle" /> エラー: {errorMsg}
+            </div>
+            <div className="tbl-modal-btns">
+              <button className="tbl-btn tbl-btn-ghost" onClick={onClose}>閉じる</button>
+              <button
+                className="tbl-btn tbl-btn-primary"
+                onClick={handleInspect}
+                disabled={!path.trim()}
+              >
+                <i className="bi bi-arrow-clockwise" /> 再試行
+              </button>
+            </div>
+          </>
+        )}
+
+        {errorMsg && status !== "error" && status !== "notFound" && (
+          <div style={{ color: "var(--danger-text, #721c24)", fontSize: "0.85rem", marginTop: "8px" }}>
+            {errorMsg}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── WorkspaceListView ────────────────────────────────────────────────────────
+
+export function WorkspaceListView() {
+  const [storeState, setStoreState] = useState(getState());
+  const [viewMode, setViewMode] = usePersistentState<ViewMode>(STORAGE_KEY, "card");
+  const [query, setQuery] = useState("");
+  const [showAdd, setShowAdd] = useState(false);
+  const [removeConfirmId, setRemoveConfirmId] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  useEffect(() => {
+    return subscribeStore(() => setStoreState(getState()));
+  }, []);
+
+  useEffect(() => {
+    mcpBridge.startWithoutEditor();
+    loadWorkspaces().catch(console.error);
+    const unsubStatus = mcpBridge.onStatusChange((s) => {
+      if (s === "connected") loadWorkspaces().catch(console.error);
+    });
+    return () => { unsubStatus(); };
+  }, []);
+
+  const { workspaces, active, lockdown } = storeState;
+
+  const sortAccessor = useCallback((w: WorkspaceEntry, key: string): string | number => {
+    switch (key) {
+      case "name": return w.name;
+      case "lastOpenedAt": return w.lastOpenedAt ?? "";
+      default: return "";
+    }
+  }, []);
+
+  const filter = useListFilter(workspaces);
+  useEffect(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) {
+      filter.applyFilter(null);
+      return;
+    }
+    filter.applyFilter((w) =>
+      w.name.toLowerCase().includes(q) ||
+      w.path.toLowerCase().includes(q),
+    );
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query]);
+
+  const sort = useListSort(filter.filtered, sortAccessor);
+  const selection = useListSelection(sort.sorted, (w) => w.id);
+
+  const columnLabels = useMemo<Record<string, string>>(() => ({
+    name: "名前",
+    lastOpenedAt: "最終オープン",
+  }), []);
+
+  const columns = useMemo<DataListColumn<WorkspaceEntry>[]>(() => [
+    {
+      key: "name",
+      header: "名前",
+      sortable: true,
+      sortAccessor: (w) => w.name,
+      render: (w) => (
+        <div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+          <i className="bi bi-folder2" style={{ color: "var(--accent, #4dabf7)" }} />
+          <span style={{ fontWeight: active?.path === w.path ? 600 : undefined }}>{w.name}</span>
+          {active?.path === w.path && (
+            <span style={{
+              fontSize: "0.7rem",
+              background: "var(--accent, #4dabf7)",
+              color: "#fff",
+              borderRadius: "3px",
+              padding: "1px 5px",
+            }}>
+              アクティブ
+            </span>
+          )}
+        </div>
+      ),
+    },
+    {
+      key: "path",
+      header: "パス",
+      render: (w) => (
+        <span
+          title={w.path}
+          style={{
+            fontFamily: "monospace",
+            fontSize: "0.82rem",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            display: "block",
+            maxWidth: "300px",
+            color: "var(--muted-text, #888)",
+          }}
+        >
+          {w.path}
+        </span>
+      ),
+    },
+    {
+      key: "lastOpenedAt",
+      header: "最終オープン",
+      width: "160px",
+      sortable: true,
+      sortAccessor: (w) => w.lastOpenedAt ?? "",
+      render: (w) => (
+        <span style={{ fontSize: "0.82rem", color: "var(--muted-text, #888)" }}>
+          {formatDate(w.lastOpenedAt)}
+        </span>
+      ),
+    },
+  ], [active]);
+
+  const renderCard = (w: WorkspaceEntry) => (
+    <div className="seq-card-content">
+      <div className="seq-card-header">
+        <i className="bi bi-folder2" style={{ color: "var(--accent, #4dabf7)", marginRight: "6px" }} />
+        <span className="seq-card-name">{w.name}</span>
+        {active?.path === w.path && (
+          <span style={{
+            fontSize: "0.7rem",
+            background: "var(--accent, #4dabf7)",
+            color: "#fff",
+            borderRadius: "3px",
+            padding: "1px 5px",
+            marginLeft: "6px",
+          }}>
+            アクティブ
+          </span>
+        )}
+      </div>
+      <div className="seq-card-description" title={w.path} style={{ fontFamily: "monospace", fontSize: "0.8rem", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+        {w.path}
+      </div>
+      <div className="seq-card-meta">
+        <span className="seq-card-date">{formatDate(w.lastOpenedAt)}</span>
+      </div>
+    </div>
+  );
+
+  const handleOpen = async () => {
+    const sel = selection.selectedItems;
+    if (sel.length !== 1) return;
+    setActionError(null);
+    try {
+      await openWorkspace(sel[0].id, true);
+    } catch (e) {
+      setActionError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  const handleRemoveConfirmed = async () => {
+    if (!removeConfirmId) return;
+    setActionError(null);
+    try {
+      await removeWorkspace(removeConfirmId);
+      setRemoveConfirmId(null);
+    } catch (e) {
+      setActionError(e instanceof Error ? e.message : String(e));
+      setRemoveConfirmId(null);
+    }
+  };
+
+  const handleActivate = useCallback((w: WorkspaceEntry) => {
+    if (lockdown) return;
+    setActionError(null);
+    openWorkspace(w.id, true).catch((e) => {
+      setActionError(e instanceof Error ? e.message : String(e));
+    });
+  }, [lockdown]);
+
+  const selectedCount = selection.selectedIds.size;
+  const selectedItem = selection.selectedItems[0] ?? null;
+
+  return (
+    <div className="table-list-page">
+      <div className="table-list-content">
+        {/* Lockdown banner */}
+        {lockdown && (
+          <div style={{
+            padding: "8px 16px",
+            background: "var(--warning-bg, #fff3cd)",
+            color: "var(--warning-text, #856404)",
+            borderRadius: "4px",
+            marginBottom: "12px",
+            display: "flex",
+            alignItems: "center",
+            gap: "8px",
+          }}>
+            <i className="bi bi-lock-fill" />
+            環境変数 DESIGNER_DATA_DIR で固定中のため、ワークスペース切替はできません
+          </div>
+        )}
+
+        <div className="table-list-header">
+          <h2 className="table-list-title">
+            <i className="bi bi-folder2-open" /> ワークスペース
+            <span className="table-list-count">{workspaces.length} 件</span>
+          </h2>
+          <div className="table-list-actions">
+            <div className="table-list-search">
+              <i className="bi bi-search" />
+              <input
+                type="text"
+                placeholder="名前・パスで絞り込み..."
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+              />
+              {query && (
+                <button className="clear-btn" onClick={() => setQuery("")} title="クリア">
+                  <i className="bi bi-x-circle-fill" />
+                </button>
+              )}
+            </div>
+            <ViewModeToggle mode={viewMode} onChange={setViewMode} storageKey={STORAGE_KEY} />
+            <button
+              className="tbl-btn tbl-btn-primary"
+              onClick={() => setShowAdd(true)}
+              disabled={lockdown}
+              title={lockdown ? "lockdown 中は無効" : undefined}
+            >
+              <i className="bi bi-plus-lg" /> 追加
+            </button>
+            <button
+              className="tbl-btn tbl-btn-ghost"
+              onClick={handleOpen}
+              disabled={lockdown || selectedCount !== 1}
+              title={lockdown ? "lockdown 中は無効" : selectedCount !== 1 ? "1件選択してください" : "開く"}
+            >
+              <i className="bi bi-folder2-open" /> 開く
+            </button>
+            <button
+              className="tbl-btn tbl-btn-ghost danger"
+              onClick={() => { if (selectedItem) setRemoveConfirmId(selectedItem.id); }}
+              disabled={lockdown || selectedCount !== 1}
+              title={lockdown ? "lockdown 中は無効" : selectedCount !== 1 ? "1件選択してください" : "リストから外す"}
+            >
+              <i className="bi bi-x-lg" /> リストから外す
+            </button>
+          </div>
+        </div>
+
+        {actionError && (
+          <div style={{
+            padding: "6px 12px",
+            background: "var(--danger-bg, #f8d7da)",
+            color: "var(--danger-text, #721c24)",
+            borderRadius: "4px",
+            marginBottom: "8px",
+            fontSize: "0.85rem",
+          }}>
+            <i className="bi bi-exclamation-circle" /> {actionError}
+          </div>
+        )}
+
+        <FilterBar
+          isActive={filter.isActive}
+          totalCount={filter.totalCount}
+          visibleCount={filter.visibleCount}
+          label={query ? `検索: "${query}"` : undefined}
+          onClear={() => { setQuery(""); filter.clearFilter(); }}
+        />
+
+        <SortBar sort={sort} columnLabels={columnLabels} />
+
+        {workspaces.length === 0 && !storeState.loading ? (
+          <div style={{ textAlign: "center", padding: "60px 20px", color: "var(--muted-text, #888)" }}>
+            <i className="bi bi-folder2-open" style={{ fontSize: "3rem", display: "block", marginBottom: "16px" }} />
+            <p style={{ marginBottom: "16px" }}>ワークスペースがまだありません。</p>
+            {!lockdown && (
+              <button className="tbl-btn tbl-btn-primary" onClick={() => setShowAdd(true)}>
+                <i className="bi bi-plus-lg" /> ワークスペースを追加
+              </button>
+            )}
+          </div>
+        ) : (
+          <DataList
+            items={sort.sorted}
+            columns={columns}
+            getId={(w) => w.id}
+            selection={selection}
+            onActivate={handleActivate}
+            layout={viewMode === "card" ? "grid" : "list"}
+            renderCard={renderCard}
+            showNumColumn={viewMode === "table"}
+            variant="dark"
+            className="sequences-data-list"
+            emptyMessage={
+              query
+                ? <p>該当するワークスペースがありません</p>
+                : <p>ワークスペースがまだありません</p>
+            }
+          />
+        )}
+
+        {/* 追加ダイアログ */}
+        {showAdd && (
+          <AddWorkspaceDialog
+            onClose={() => setShowAdd(false)}
+            onAdded={() => { loadWorkspaces().catch(console.error); }}
+          />
+        )}
+
+        {/* リストから外す確認ダイアログ */}
+        {removeConfirmId && (
+          <div className="tbl-modal-overlay" onClick={() => setRemoveConfirmId(null)}>
+            <div className="tbl-modal" onClick={(e) => e.stopPropagation()}>
+              <div className="tbl-modal-title">ワークスペースをリストから外す</div>
+              <p>
+                「{workspaces.find((w) => w.id === removeConfirmId)?.name}」をリストから外しますか？
+                <br />
+                <small style={{ color: "var(--muted-text, #888)" }}>フォルダは削除されません。後から追加し直せます。</small>
+              </p>
+              <div className="tbl-modal-btns">
+                <button className="tbl-btn tbl-btn-ghost" onClick={() => setRemoveConfirmId(null)}>
+                  キャンセル
+                </button>
+                <button className="tbl-btn tbl-btn-ghost danger" onClick={handleRemoveConfirmed}>
+                  リストから外す
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/designer/src/components/workspace/WorkspaceSelectView.tsx
+++ b/designer/src/components/workspace/WorkspaceSelectView.tsx
@@ -1,0 +1,217 @@
+import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  getState,
+  subscribe as subscribeStore,
+  loadWorkspaces,
+  openWorkspace,
+} from "../../store/workspaceStore";
+import { mcpBridge } from "../../mcp/mcpBridge";
+import { AddWorkspaceDialog } from "./WorkspaceListView";
+
+export function WorkspaceSelectView() {
+  const navigate = useNavigate();
+  const [state, setState] = useState(getState());
+  const [showAdd, setShowAdd] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  useEffect(() => {
+    return subscribeStore(() => setState(getState()));
+  }, []);
+
+  useEffect(() => {
+    mcpBridge.startWithoutEditor();
+    loadWorkspaces().catch(console.error);
+    const unsubStatus = mcpBridge.onStatusChange((s) => {
+      if (s === "connected") loadWorkspaces().catch(console.error);
+    });
+    return () => { unsubStatus(); };
+  }, []);
+
+  const { workspaces, lockdown } = state;
+  const recentWorkspaces = workspaces.slice(0, 5);
+
+  const handleOpenById = async (id: string) => {
+    setActionError(null);
+    try {
+      await openWorkspace(id, true);
+      navigate("/", { replace: true });
+    } catch (e) {
+      setActionError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  return (
+    <div style={{
+      minHeight: "100vh",
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "center",
+      justifyContent: "center",
+      background: "#0f1117",
+      color: "#e4e6f0",
+      padding: "32px",
+    }}>
+      <div style={{
+        width: "100%",
+        maxWidth: "520px",
+        background: "#1a1a2e",
+        borderRadius: "12px",
+        padding: "40px",
+        border: "1px solid #2d2d44",
+        boxShadow: "0 8px 32px rgba(0,0,0,0.4)",
+      }}>
+        <div style={{ textAlign: "center", marginBottom: "32px" }}>
+          <i className="bi bi-folder2-open" style={{ fontSize: "3rem", color: "#4dabf7", display: "block", marginBottom: "12px" }} />
+          <h2 style={{ fontSize: "1.4rem", fontWeight: 700, color: "#e4e6f0", margin: 0 }}>
+            ワークスペースを開いてください
+          </h2>
+          <p style={{ color: "#9a9db5", fontSize: "0.9rem", marginTop: "8px" }}>
+            プロジェクトデータを管理するフォルダを選択してください
+          </p>
+        </div>
+
+        {actionError && (
+          <div style={{
+            padding: "8px 12px",
+            background: "rgba(248,113,113,0.15)",
+            border: "1px solid rgba(248,113,113,0.4)",
+            borderRadius: "6px",
+            color: "#f87171",
+            fontSize: "0.85rem",
+            marginBottom: "20px",
+          }}>
+            <i className="bi bi-exclamation-circle" /> {actionError}
+          </div>
+        )}
+
+        {/* ワークスペース一覧へ */}
+        <button
+          onClick={() => navigate("/workspace/list")}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "10px",
+            width: "100%",
+            padding: "12px 16px",
+            background: "#4dabf7",
+            border: "none",
+            borderRadius: "6px",
+            color: "#fff",
+            fontWeight: 600,
+            fontSize: "0.95rem",
+            cursor: "pointer",
+            marginBottom: "16px",
+          }}
+        >
+          <i className="bi bi-list-ul" />
+          ワークスペース一覧へ
+        </button>
+
+        {/* 新しくワークスペースを追加 */}
+        {!lockdown && (
+          <button
+            onClick={() => setShowAdd(true)}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "10px",
+              width: "100%",
+              padding: "12px 16px",
+              background: "transparent",
+              border: "1px solid #3b3e55",
+              borderRadius: "6px",
+              color: "#e4e6f0",
+              fontWeight: 500,
+              fontSize: "0.95rem",
+              cursor: "pointer",
+              marginBottom: "16px",
+            }}
+          >
+            <i className="bi bi-plus-lg" style={{ color: "#4dabf7" }} />
+            新しくワークスペースを追加
+          </button>
+        )}
+
+        {/* 最近使ったワークスペース */}
+        {recentWorkspaces.length > 0 && !lockdown && (
+          <div>
+            <div style={{
+              fontSize: "0.78rem",
+              color: "#9a9db5",
+              textTransform: "uppercase",
+              letterSpacing: "0.05em",
+              marginBottom: "8px",
+            }}>
+              最近使ったワークスペース
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+              {recentWorkspaces.map((w) => (
+                <button
+                  key={w.id}
+                  onClick={() => handleOpenById(w.id)}
+                  title={w.path}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "10px",
+                    width: "100%",
+                    padding: "9px 12px",
+                    background: "transparent",
+                    border: "1px solid #2d2d44",
+                    borderRadius: "5px",
+                    color: "#e4e6f0",
+                    fontSize: "0.88rem",
+                    cursor: "pointer",
+                    textAlign: "left",
+                  }}
+                >
+                  <i className="bi bi-folder2" style={{ color: "#4dabf7", flexShrink: 0 }} />
+                  <div style={{ overflow: "hidden", flex: 1 }}>
+                    <div style={{ fontWeight: 500, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                      {w.name}
+                    </div>
+                    <div style={{
+                      fontSize: "0.76rem",
+                      color: "#9a9db5",
+                      fontFamily: "monospace",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}>
+                      {w.path}
+                    </div>
+                  </div>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {lockdown && (
+          <div style={{
+            padding: "10px 14px",
+            background: "rgba(251,191,36,0.12)",
+            border: "1px solid rgba(251,191,36,0.4)",
+            borderRadius: "6px",
+            color: "#fbbf24",
+            fontSize: "0.85rem",
+            display: "flex",
+            alignItems: "center",
+            gap: "8px",
+          }}>
+            <i className="bi bi-lock-fill" />
+            環境変数 DESIGNER_DATA_DIR で固定中のため、ワークスペース切替はできません
+          </div>
+        )}
+      </div>
+
+      {showAdd && (
+        <AddWorkspaceDialog
+          onClose={() => setShowAdd(false)}
+          onAdded={() => navigate("/", { replace: true })}
+        />
+      )}
+    </div>
+  );
+}

--- a/designer/src/store/tabStore.ts
+++ b/designer/src/store/tabStore.ts
@@ -130,6 +130,18 @@ export function _reloadFromStorageForTests(): void {
   _activeTabId = _loadActiveId();
 }
 
+/**
+ * workspace 切替前の cleanup 用 (#671/#676 review): 永続化されたタブ一覧と
+ * activeTabId を localStorage から完全削除する。reload 直前に呼ぶ前提で、
+ * モジュール内の `_tabs` / `_activeTabId` 状態は更新しない (リロードで初期化されるため)。
+ */
+export function clearPersistedTabs(): void {
+  try {
+    localStorage.removeItem(TABS_KEY);
+    localStorage.removeItem(ACTIVE_KEY);
+  } catch { /* private browsing / quota error は無視 */ }
+}
+
 export function getTabs(): readonly TabItem[] {
   return _tabs;
 }

--- a/designer/src/store/tabStore.ts
+++ b/designer/src/store/tabStore.ts
@@ -24,12 +24,14 @@ export type TabType =
   | "sequence-list"      // シーケンス一覧 (#374)
   | "view-list"          // ビュー一覧 (#376)
   | "view-definition-list" // ビュー定義一覧 (#666)
+  | "workspace-list"     // ワークスペース一覧 (#673)
   | "dashboard";         // ダッシュボード（#86 PR-3 で有効化）
 
 const KNOWN_TAB_TYPES: ReadonlySet<TabType> = new Set([
   "design", "table", "process-flow", "sequence", "view", "view-definition",
   "screen-flow", "screen-list", "table-list", "er", "process-flow-list",
-  "extensions", "conventions-catalog", "screen-items", "sequence-list", "view-list", "view-definition-list", "dashboard",
+  "extensions", "conventions-catalog", "screen-items", "sequence-list", "view-list", "view-definition-list",
+  "workspace-list", "dashboard",
 ]);
 
 export interface TabItem {

--- a/designer/src/store/workspaceStore.ts
+++ b/designer/src/store/workspaceStore.ts
@@ -1,0 +1,187 @@
+import { mcpBridge } from "../mcp/mcpBridge";
+
+// ─── 型定義 ─────────────────────────────────────────────────────────────────
+
+export interface WorkspaceEntry {
+  id: string;
+  path: string;
+  name: string;
+  lastOpenedAt: string | null;
+}
+
+export interface WorkspaceActive {
+  id?: string;
+  path: string;
+  name: string | null;
+}
+
+export interface WorkspaceState {
+  workspaces: WorkspaceEntry[];
+  active: WorkspaceActive | null;
+  lockdown: boolean;
+  lockdownPath: string | null;
+  loading: boolean;
+  error: string | null;
+}
+
+export interface WorkspaceInspectResult {
+  status: "ready" | "needsInit" | "notFound";
+  path: string;
+  name?: string;
+}
+
+// ─── 内部ストア ───────────────────────────────────────────────────────────────
+
+type Listener = () => void;
+
+let _state: WorkspaceState = {
+  workspaces: [],
+  active: null,
+  lockdown: false,
+  lockdownPath: null,
+  loading: false,
+  error: null,
+};
+
+const _listeners = new Set<Listener>();
+let _broadcastUnsubscribe: (() => void) | null = null;
+
+function _setState(partial: Partial<WorkspaceState>): void {
+  _state = { ..._state, ...partial };
+  _listeners.forEach((fn) => fn());
+}
+
+// ─── 公開 API ─────────────────────────────────────────────────────────────────
+
+export function getState(): WorkspaceState {
+  return _state;
+}
+
+export function subscribe(listener: Listener): () => void {
+  _listeners.add(listener);
+  return () => _listeners.delete(listener);
+}
+
+export async function loadWorkspaces(): Promise<void> {
+  _setState({ loading: true, error: null });
+  try {
+    const result = (await mcpBridge.request("workspace.list")) as {
+      workspaces: WorkspaceEntry[];
+      lastActiveId: string | null;
+      active: { path: string; name: string | null } | null;
+      lockdown: boolean;
+      lockdownPath: string | null;
+    };
+    _setState({
+      workspaces: result.workspaces ?? [],
+      active: result.active
+        ? {
+            id: result.workspaces?.find((w) => w.path === result.active!.path)?.id,
+            path: result.active.path,
+            name: result.active.name,
+          }
+        : null,
+      lockdown: result.lockdown ?? false,
+      lockdownPath: result.lockdownPath ?? null,
+      loading: false,
+      error: null,
+    });
+  } catch (e) {
+    _setState({
+      loading: false,
+      error: e instanceof Error ? e.message : String(e),
+    });
+  }
+}
+
+export async function inspectWorkspace(path: string): Promise<WorkspaceInspectResult> {
+  const result = (await mcpBridge.request("workspace.inspect", { path })) as WorkspaceInspectResult;
+  return result;
+}
+
+export async function openWorkspace(pathOrId: string, useId = false): Promise<void> {
+  _setState({ loading: true, error: null });
+  try {
+    const params = useId ? { id: pathOrId } : { path: pathOrId };
+    await mcpBridge.request("workspace.open", params);
+    await loadWorkspaces();
+  } catch (e) {
+    _setState({
+      loading: false,
+      error: e instanceof Error ? e.message : String(e),
+    });
+    throw e;
+  }
+}
+
+export async function initAndOpen(path: string): Promise<void> {
+  _setState({ loading: true, error: null });
+  try {
+    await mcpBridge.request("workspace.open", { path, init: true });
+    await loadWorkspaces();
+  } catch (e) {
+    _setState({
+      loading: false,
+      error: e instanceof Error ? e.message : String(e),
+    });
+    throw e;
+  }
+}
+
+export async function closeWorkspace(): Promise<void> {
+  _setState({ loading: true, error: null });
+  try {
+    await mcpBridge.request("workspace.close");
+    await loadWorkspaces();
+  } catch (e) {
+    _setState({
+      loading: false,
+      error: e instanceof Error ? e.message : String(e),
+    });
+    throw e;
+  }
+}
+
+export async function removeWorkspace(id: string): Promise<void> {
+  _setState({ loading: true, error: null });
+  try {
+    await mcpBridge.request("workspace.remove", { id });
+    await loadWorkspaces();
+  } catch (e) {
+    _setState({
+      loading: false,
+      error: e instanceof Error ? e.message : String(e),
+    });
+    throw e;
+  }
+}
+
+/** workspace.changed ブロードキャストをサブスクライブし、状態を自動更新する */
+export function subscribeWorkspaceChanges(): () => void {
+  if (_broadcastUnsubscribe) {
+    _broadcastUnsubscribe();
+    _broadcastUnsubscribe = null;
+  }
+
+  const unsub = mcpBridge.onBroadcast("workspace.changed", (data) => {
+    const ev = data as {
+      activeId: string | null;
+      path: string | null;
+      name: string | null;
+      lockdown: boolean;
+    };
+    if (ev.activeId === null || ev.path === null) {
+      _setState({ active: null, lockdown: ev.lockdown ?? false });
+    } else {
+      _setState({
+        active: { id: ev.activeId, path: ev.path, name: ev.name },
+        lockdown: ev.lockdown ?? false,
+      });
+    }
+    // ワークスペースリストも再取得して最新に保つ
+    loadWorkspaces().catch(console.error);
+  });
+
+  _broadcastUnsubscribe = unsub;
+  return unsub;
+}

--- a/designer/src/store/workspaceStore.ts
+++ b/designer/src/store/workspaceStore.ts
@@ -34,12 +34,15 @@ export interface WorkspaceInspectResult {
 
 type Listener = () => void;
 
+// loading は初期 true: WS 未接続のうちはガードを発動させない。
+// 最初の loadWorkspaces() (成功 or 失敗) で false になる。WS が永続的に未接続でも
+// loading=true のままなので /workspace/select への誤強制遷移を起こさない。
 let _state: WorkspaceState = {
   workspaces: [],
   active: null,
   lockdown: false,
   lockdownPath: null,
-  loading: false,
+  loading: true,
   error: null,
 };
 


### PR DESCRIPTION
## 関連

- Closes #27
- Closes #671
- Closes #672
- Closes #673
- Closes #674
- Closes #675
- 仕様: 本シリーズはユーザー要件 (会話ログ) ベースで設計。spec ファイル新設は無し
  - workspace ≡ project (project.json 流用)、UI 表記「ワークスペース」
  - 同時 1 ワークスペース、env DESIGNER_DATA_DIR 指定時は完全 lockdown (将来の VS Code 拡張化を想定)
  - 最近使ったリストは ~/.designer/recent-workspaces.json (designer-mcp 管理)

## 概要

1 インスタンス = 1 データフォルダ固定だった #27 を解消。任意フォルダをワークスペースとして開け、最近リストから切替できるようにする。env 指定時は固定モード (CI / 拡張ホスト用)。シリーズ統合 PR。

## 主な変更

- **backend (#671)**: `designer-mcp` の `DATA_DIR` をモジュール定数から `workspaceState` getter に置換。`recentStore` で `~/.designer/recent-workspaces.json` を upsert / removeWorkspace / setLastActive 管理。env DESIGNER_DATA_DIR 指定時は LockdownError で切替操作を拒否。MCP tools 5 件 (`workspace.list/status/open/close/remove`) + WS broadcast `workspace.changed` 追加
- **migration (#672)**: 起動時に lockdown 中はスキップ → recent.lastActiveId を再オープン → 旧来 `<repo>/data/` を default workspace として自動登録、の 4 段カスケード。空フォルダ open に init=true 引数を追加し、`schemas/v3/project.v3.schema.json` 準拠の project.json + サブディレクトリ群を生成 (Ajv2020 で生成 JSON を schema 検証してから書き込み)。`workspace.inspect` で needsInit / ready / notFound を判定
- **wsBridge ブラウザ向け WS API (#671 補完)**: ブラウザからの workspace 操作のため、wsBridge の `_handleBrowserRequest` に MCP tool と同等の handler 6 件を追加 (workspace.list/status/inspect/open/close/remove)
- **ListView (#673)**: `/workspace/list` シングルトンタブ。`DataList` + `useListSelection/Filter/Sort` + `<ViewModeToggle>` で名前 / パス / 最終オープン列。「追加」ダイアログは絶対パス入力 + `workspace.inspect` で 3 状態分岐 + Chromium 系限定の `showDirectoryPicker()` ヒント (絶対パス取得不可なのでヒント扱い)。「リストから外す」は確認ダイアログ付き、fs は触らない。lockdown バナー / 空状態の welcome 表示
- **ヘッダー常時表示 (#674)**: `WorkspaceIndicator` を `CommonHeader` 左に配置。現在 workspace 名 + path tooltip。ドロップダウン: 一覧へ / 最近使った 5 件 (active にチェック) / 閉じる。lockdown 時は鍵アイコン + 切替メニュー disabled
- **起動時自動再オープン + ガード (#675)**: AppShell 起動時に `loadWorkspaces()` (MCP 接続後 + 初回試行)。active===null かつ /workspace/list / select 以外 → /workspace/select にリダイレクト。`/workspace/select` はフルスクリーン welcome (ヘッダー / タブバーなしで早期 return)。workspace.changed broadcast 受信時に per-resource タブ (design/table/process-flow/sequence/view/view-definition) を強制クローズ + dirty タブ名を console.warn

## 仕様逐条突合 (自己申告)

ユーザー要件に対する実装の逐条マッピング:

- ワークスペース選択により自由に開ける → `WorkspaceListView.tsx:47-` (`AddWorkspaceDialog` の絶対パス入力) ✓
- 一度開いたワークスペースの一覧表示 → `WorkspaceListView.tsx` 全体 + `recentStore.ts:108-` (`upsertWorkspace`) ✓
- 同時 1 ワークスペースのみ → `workspaceState.ts:50` (`_activePath` 単一保持) ✓
- 将来の N 同時 workspace を技術的に可能 → wsBridge / state 設計が WS セッション単位で隔離可能なまま (現状はモジュール global、後続 ISSUE で per-session に拡張可) ✓
- 絶対パス入力 + 最近リスト + Chromium picker (ヒント) → `WorkspaceListView.tsx:47-220` ✓
- 空フォルダ open 時の「初期化しますか」 → `WorkspaceListView.tsx` の `AddWorkspaceDialog` + `workspaceInit.ts:initializeWorkspace` ✓
- 最近リストの保存先 `~/.designer/recent-workspaces.json` → `recentStore.ts:25-26` ✓
- 起動時に前回 workspace を自動再オープン → `workspaceInit.ts:autoActivateOnStartup` + `AppShell.tsx:80-90` ✓
- 「ワークスペースを閉じる」を HeaderMenu / dropdown に → `WorkspaceIndicator.tsx` ドロップダウン ✓
- 既存 `<repo>/data/` を default workspace として自動登録 → `workspaceInit.ts:tryAutoRegisterLegacyData` ✓
- 「リストから外す」は fs 削除しない → `recentStore.ts:128-138` (`removeWorkspace` は file ops 無し) ✓
- ヘッダー (トップレベル) に常時表示 → `CommonHeader.tsx:WorkspaceIndicator` ✓
- env DESIGNER_DATA_DIR 指定時は切替 UI 完全 lockdown → `workspaceState.ts:isLockdown` + UI 全箇所で disable / banner / lock icon ✓

## レビューで特に見てほしい箇所

- **schemaVersion 不変性**: `schemas/v3/project.v3.schema.json` に変更を加えていないこと (schema ガバナンス)。`git diff origin/main..HEAD -- schemas/` が empty
- **wsBridge の WS handler は MCP tool と二重実装**: ブラウザ用 WS request と AI 用 MCP tool は同じビジネスロジックを別エンドポイントから露出する。設計的に集約候補だが、現状のコードベースの慣行 (例: loadProject / saveProject は WS と MCP 両方持つ) に合わせた
- **lockdown 中の workspaceStore.active 反映**: recentStore は lockdown 中触らない一方、`workspaceState.getActivePath()` は env path を返すため `workspace.list` で `active.path` は埋まる。UI 側は `active.id` が undefined のことがあるため依存しない実装にした (WorkspaceIndicator / WorkspaceListView)
- **未保存タブの強制クローズ**: workspace 切替時に dirty タブも force-close + console.warn のみ。「破棄して切り替え」確認ダイアログは UI トースト基盤が無いため follow-up に倒した
- **WorkspaceSelectView の表示方式**: `<Routes>` 内ではなく AppShell の早期 return として実装 (ヘッダー / タブバー隠す要件のため)。同パターンが他に無いので独立判断

## テスト

- Vitest (designer-mcp): 133 passed (新規 28 件 = workspaceState 9 + recentStore 10 + workspaceInit 9)
- Vitest (designer): 1231 passed (新規 0 件 — UI store / View は今回 unit テスト追加せず、既存 regression のみ確認)
- Playwright: 既存スイート未実行 (backend / build pass のみで判定。UI smoke は下記 follow-up 候補)
- MCP E2E: httpTransport.test.ts 4 件 pass

## UI 影響 / AI smoke test

- [x] UI 影響あり (新画面 3 つ + ヘッダーインジケータ追加)
- [ ] AI smoke test 未実施 — 機能上の影響範囲が広く、designer-mcp 起動 + ブラウザ操作の組み合わせで挙動を見る必要がある。**独立レビューのフェーズで chrome-devtools MCP smoke test の実施可否を判定**

確認したい主要シナリオ (smoke test 想定):

- [ ] 起動時に既存 `<repo>/data/` が default workspace として自動 active
- [ ] ヘッダーに「新規プロジェクト」表示 + ドロップダウンが開く
- [ ] /workspace/list を開いてリストに 1 件表示、active バッジが付く
- [ ] 「追加」ダイアログで存在しない path を入力 → notFound エラー
- [ ] 既存 path 入力 → ready 表示 + 開く
- [ ] env DESIGNER_DATA_DIR=... 指定で起動 → lockdown バナー表示 / 切替操作不可
- [ ] ワークスペースを閉じる → /workspace/select に遷移、開いていた Designer タブが消える

## spec 側の不足点 / 提案

- 「workspace」概念は本 PR で初導入のため `docs/spec/workspace.md` 起票候補。**現時点では P1 follow-up とする** (実装が ground truth、spec 化は別 ISSUE)
- `~/.designer/recent-workspaces.json` の schema は `recentStore.ts` 内 `isRecentFile` で軽量検証のみ。本格的な JSON Schema 化は不要 (ユーザー設定ファイル、業務リソースではない)

## レビュー担当への申し送り

- **6 commits 構成**: #671 → #672 → #673 → #674 → #675 → #671 補完 (wsBridge 後付け)。最後の commit は backend WS API extension で、子 ISSUE 番号は #671 に紐付くがコミット順序的には末尾
- **schema 完全 untouched**: `git diff origin/main..HEAD -- schemas/` が empty であることをマージ前に再確認推奨
- **将来の N 同時 workspace 拡張**: 現状 `workspaceState` がモジュール global なため、複数 WS セッションが共有してしまう。N workspace 同時対応は WS session-scoped state への移行 + URL に workspace 識別子を埋める対応が必要 (本 PR では非ゴール、技術的に可能性のみ確認)
- **dirty タブ確認ダイアログ**: workspace 切替で per-resource タブを force-close する際、dirty タブの「破棄しますか」確認は省略 (console.warn のみ)。トースト基盤導入後に follow-up 化候補

🤖 Generated with [Claude Code](https://claude.com/claude-code)
