### PR TITLE
feat(designer-mcp): draft ファイル管理 — data/.drafts 配下 atomic CRUD (#685)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ data/
 !data/extensions/
 !data/extensions/**
 
+# 編集中 draft ファイル (個人の作業中間状態、git 管理対象外)
+data/.drafts/
+
 # Playwright test artifacts
 designer/test-results/
 designer/playwright-report/

--- a/designer-mcp/src/draftStore.test.ts
+++ b/designer-mcp/src/draftStore.test.ts
@@ -1,0 +1,212 @@
+/**
+ * draftStore 単体テスト (#685)
+ *
+ * env DESIGNER_DATA_DIR に tmp パスを設定して workspaceState の lockdown を利用。
+ * 実際のワークスペースには一切触れない。
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+const TMP_ROOT = path.join(os.tmpdir(), `draft-store-test-${process.pid}-${Date.now()}`);
+const ORIGINAL_ENV = process.env.DESIGNER_DATA_DIR;
+
+const {
+  createDraft,
+  readDraft,
+  updateDraft,
+  commitDraft,
+  discardDraft,
+  hasDraft,
+  listDrafts,
+} = await import("./draftStore.js");
+
+const { _resetForTest, setActivePath, initWorkspaceState } = await import("./workspaceState.js");
+
+async function ensureWorkspace(): Promise<void> {
+  await fs.mkdir(TMP_ROOT, { recursive: true });
+  try {
+    await fs.writeFile(path.join(TMP_ROOT, "project.json"), JSON.stringify({ name: "test" }), "utf-8");
+  } catch {
+    // ignore
+  }
+}
+
+beforeAll(async () => {
+  await ensureWorkspace();
+  _resetForTest();
+  setActivePath(TMP_ROOT);
+});
+
+beforeEach(async () => {
+  const draftsDir = path.join(TMP_ROOT, ".drafts");
+  try {
+    await fs.rm(draftsDir, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+});
+
+afterAll(async () => {
+  try {
+    await fs.rm(TMP_ROOT, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+  _resetForTest();
+  if (ORIGINAL_ENV !== undefined) {
+    process.env.DESIGNER_DATA_DIR = ORIGINAL_ENV;
+  } else {
+    delete process.env.DESIGNER_DATA_DIR;
+  }
+});
+
+describe("draftStore", () => {
+  describe("createDraft / readDraft / updateDraft", () => {
+    it("happy path: create (新規) → read → update → read", async () => {
+      const result = await createDraft("table", "tbl-001");
+      expect(result.created).toBe(true);
+
+      const initial = await readDraft("table", "tbl-001");
+      expect(initial).toEqual({});
+
+      await updateDraft("table", "tbl-001", { name: "users", columns: [] });
+      const updated = await readDraft("table", "tbl-001");
+      expect(updated).toMatchObject({ name: "users", columns: [] });
+    });
+
+    it("createDraft: 既に draft が存在する場合は created: false を返す", async () => {
+      await createDraft("table", "tbl-dup");
+      const second = await createDraft("table", "tbl-dup");
+      expect(second.created).toBe(false);
+    });
+
+    it("createDraft: 本体ファイルが存在すれば内容をコピーする", async () => {
+      const tablesDir = path.join(TMP_ROOT, "tables");
+      await fs.mkdir(tablesDir, { recursive: true });
+      await fs.writeFile(
+        path.join(tablesDir, "tbl-copy.json"),
+        JSON.stringify({ id: "tbl-copy", name: "existing" }),
+        "utf-8",
+      );
+
+      const r = await createDraft("table", "tbl-copy");
+      expect(r.created).toBe(true);
+      const draft = await readDraft("table", "tbl-copy");
+      expect(draft).toMatchObject({ name: "existing" });
+    });
+
+    it("readDraft: 存在しない draft は null を返す", async () => {
+      const d = await readDraft("table", "nonexistent");
+      expect(d).toBeNull();
+    });
+
+    it("updateDraft: draft が未存在でも書き込める (新規作成)", async () => {
+      await updateDraft("sequence", "seq-001", { steps: [1, 2, 3] });
+      const d = await readDraft("sequence", "seq-001");
+      expect(d).toMatchObject({ steps: [1, 2, 3] });
+    });
+  });
+
+  describe("commitDraft", () => {
+    it("table: draft を本体ファイルへ昇格し draft が消える", async () => {
+      await updateDraft("table", "tbl-commit", { id: "tbl-commit", name: "orders" });
+      const r = await commitDraft("table", "tbl-commit");
+      expect(r.committed).toBe(true);
+
+      const afterDraft = await readDraft("table", "tbl-commit");
+      expect(afterDraft).toBeNull();
+
+      const bodyPath = path.join(TMP_ROOT, "tables", "tbl-commit.json");
+      const body = JSON.parse(await fs.readFile(bodyPath, "utf-8"));
+      expect(body).toMatchObject({ name: "orders" });
+    });
+
+    it("process-flow: draft を actions/ 配下へ昇格する", async () => {
+      await updateDraft("process-flow", "flow-001", { id: "flow-001", steps: [] });
+      const r = await commitDraft("process-flow", "flow-001");
+      expect(r.committed).toBe(true);
+
+      const bodyPath = path.join(TMP_ROOT, "actions", "flow-001.json");
+      const body = JSON.parse(await fs.readFile(bodyPath, "utf-8"));
+      expect(body).toMatchObject({ id: "flow-001" });
+    });
+
+    it("convention: draft を conventions/catalog.json へ昇格する", async () => {
+      await updateDraft("convention", "catalog", { version: 1, rules: [] });
+      const r = await commitDraft("convention", "catalog");
+      expect(r.committed).toBe(true);
+
+      const bodyPath = path.join(TMP_ROOT, "conventions", "catalog.json");
+      const body = JSON.parse(await fs.readFile(bodyPath, "utf-8"));
+      expect(body).toMatchObject({ version: 1 });
+    });
+
+    it("commitDraft: draft が存在しない場合は committed: false を返す", async () => {
+      const r = await commitDraft("table", "no-such-draft");
+      expect(r.committed).toBe(false);
+    });
+  });
+
+  describe("discardDraft", () => {
+    it("create → discard → has=false", async () => {
+      await createDraft("sequence", "seq-discard");
+      const r = await discardDraft("sequence", "seq-discard");
+      expect(r.discarded).toBe(true);
+
+      const exists = await hasDraft("sequence", "seq-discard");
+      expect(exists).toBe(false);
+    });
+
+    it("discardDraft: 存在しない draft は discarded: false", async () => {
+      const r = await discardDraft("table", "ghost");
+      expect(r.discarded).toBe(false);
+    });
+  });
+
+  describe("hasDraft", () => {
+    it("draft 存在時は true、非存在時は false", async () => {
+      expect(await hasDraft("table", "hd-test")).toBe(false);
+      await createDraft("table", "hd-test");
+      expect(await hasDraft("table", "hd-test")).toBe(true);
+    });
+  });
+
+  describe("listDrafts", () => {
+    it("複数 type の draft を列挙できる", async () => {
+      await createDraft("table", "t1");
+      await createDraft("table", "t2");
+      await createDraft("sequence", "s1");
+
+      const items = await listDrafts();
+      expect(items.length).toBeGreaterThanOrEqual(3);
+
+      const types = items.map((i) => i.type);
+      expect(types).toContain("table");
+      expect(types).toContain("sequence");
+
+      for (const item of items) {
+        expect(typeof item.id).toBe("string");
+        expect(typeof item.mtimeMs).toBe("number");
+        expect(item.mtimeMs).toBeGreaterThan(0);
+      }
+    });
+
+    it(".drafts/ が存在しない場合は空配列を返す", async () => {
+      const items = await listDrafts();
+      expect(Array.isArray(items)).toBe(true);
+    });
+  });
+
+  describe("atomic write", () => {
+    it("連続 update でも最終値が正しく読める", async () => {
+      const updates = Array.from({ length: 10 }, (_, i) => ({ version: i }));
+      for (const payload of updates) {
+        await updateDraft("table", "atomic-test", payload);
+      }
+      const final = await readDraft("table", "atomic-test");
+      expect(final).toMatchObject({ version: 9 });
+    });
+  });
+});

--- a/designer-mcp/src/draftStore.test.ts
+++ b/designer-mcp/src/draftStore.test.ts
@@ -147,6 +147,11 @@ describe("draftStore", () => {
       const r = await commitDraft("table", "no-such-draft");
       expect(r.committed).toBe(false);
     });
+
+    it("screen-item: commitDraft は Error を throw する", async () => {
+      await updateDraft("screen-item", "si-001", { id: "si-001", label: "test" });
+      await expect(commitDraft("screen-item", "si-001")).rejects.toThrow(/screen-item/i);
+    });
   });
 
   describe("discardDraft", () => {

--- a/designer-mcp/src/draftStore.ts
+++ b/designer-mcp/src/draftStore.ts
@@ -1,0 +1,272 @@
+/**
+ * draftStore.ts (#685)
+ *
+ * data/.drafts/<resourceType>/<id>.json を edit-session の working copy として管理する。
+ * atomic write: tmp ファイルへ書き込み → fs.rename でアトミックに置換。
+ * commitDraft: draft を本体ファイルへ atomic に昇格し draft を削除する。
+ */
+import fs from "fs/promises";
+import path from "path";
+import { requireActivePath } from "./workspaceState.js";
+import {
+  writeScreen,
+  writeTable,
+  writeProcessFlow,
+  writeView,
+  writeViewDefinition,
+  writeSequence,
+  writeConventions,
+} from "./projectStorage.js";
+
+export type DraftResourceType =
+  | "screen"
+  | "table"
+  | "process-flow"
+  | "view"
+  | "view-definition"
+  | "screen-item"
+  | "sequence"
+  | "extension"
+  | "convention";
+
+const DRAFTS_SUBDIR = ".drafts";
+
+function draftsRoot(activeRoot: string): string {
+  return path.join(activeRoot, DRAFTS_SUBDIR);
+}
+
+function draftDir(activeRoot: string, type: DraftResourceType): string {
+  return path.join(draftsRoot(activeRoot), type);
+}
+
+function draftPath(activeRoot: string, type: DraftResourceType, id: string): string {
+  return path.join(draftDir(activeRoot, type), `${id}.json`);
+}
+
+async function ensureDraftDir(activeRoot: string, type: DraftResourceType): Promise<void> {
+  await fs.mkdir(draftDir(activeRoot, type), { recursive: true });
+}
+
+async function atomicWrite(targetPath: string, data: unknown): Promise<void> {
+  const tmp = `${targetPath}.tmp-${process.pid}-${Date.now()}`;
+  const json = JSON.stringify(data, null, 2);
+  await fs.writeFile(tmp, json, "utf-8");
+  await fs.rename(tmp, targetPath);
+}
+
+async function readJSON<T>(filePath: string): Promise<T | null> {
+  try {
+    const raw = await fs.readFile(filePath, "utf-8");
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+function canonicalBodyPath(activeRoot: string, type: DraftResourceType, id: string): string | null {
+  switch (type) {
+    case "screen":
+      return path.join(activeRoot, "screens", `${id}.design.json`);
+    case "table":
+      return path.join(activeRoot, "tables", `${id}.json`);
+    case "process-flow":
+      return path.join(activeRoot, "actions", `${id}.json`);
+    case "view":
+      return path.join(activeRoot, "views", `${id}.json`);
+    case "view-definition":
+      return path.join(activeRoot, "view-definitions", `${id}.json`);
+    case "screen-item":
+      return null;
+    case "sequence":
+      return path.join(activeRoot, "sequences", `${id}.json`);
+    case "extension":
+      return path.join(activeRoot, "extensions", `${id}.json`);
+    case "convention":
+      return path.join(activeRoot, "conventions", "catalog.json");
+    default:
+      return null;
+  }
+}
+
+/**
+ * 編集開始: 本体ファイルが存在すればコピー、存在しなければ空 draft を作成する。
+ * 既に draft が存在する場合は作成せず created: false を返す。
+ */
+export async function createDraft(
+  type: DraftResourceType,
+  id: string,
+): Promise<{ created: boolean }> {
+  const root = requireActivePath();
+  const dp = draftPath(root, type, id);
+
+  try {
+    await fs.access(dp);
+    return { created: false };
+  } catch {
+    // draft 未存在 → 作成する
+  }
+
+  await ensureDraftDir(root, type);
+
+  const bodyPath = canonicalBodyPath(root, type, id);
+  let initialContent: unknown = {};
+  if (bodyPath) {
+    const existing = await readJSON<unknown>(bodyPath);
+    if (existing !== null) {
+      initialContent = existing;
+    }
+  }
+
+  await atomicWrite(dp, initialContent);
+  return { created: true };
+}
+
+/** draft ファイルを読み込む。存在しない場合は null を返す。 */
+export async function readDraft(
+  type: DraftResourceType,
+  id: string,
+): Promise<unknown | null> {
+  const root = requireActivePath();
+  return readJSON<unknown>(draftPath(root, type, id));
+}
+
+/** draft ファイルを更新する (atomic write)。draft が存在しない場合も書き込む。 */
+export async function updateDraft(
+  type: DraftResourceType,
+  id: string,
+  payload: unknown,
+): Promise<void> {
+  const root = requireActivePath();
+  await ensureDraftDir(root, type);
+  await atomicWrite(draftPath(root, type, id), payload);
+}
+
+/**
+ * draft を本体ファイルへ atomic に昇格し、draft を削除する。
+ * draft が存在しない場合は committed: false を返す。
+ */
+export async function commitDraft(
+  type: DraftResourceType,
+  id: string,
+): Promise<{ committed: boolean }> {
+  const root = requireActivePath();
+  const dp = draftPath(root, type, id);
+  const payload = await readJSON<unknown>(dp);
+  if (payload === null) {
+    return { committed: false };
+  }
+
+  switch (type) {
+    case "screen":
+      await writeScreen(id, payload);
+      break;
+    case "table":
+      await writeTable(id, payload);
+      break;
+    case "process-flow":
+      await writeProcessFlow(id, payload);
+      break;
+    case "view":
+      await writeView(id, payload);
+      break;
+    case "view-definition":
+      await writeViewDefinition(id, payload);
+      break;
+    case "screen-item": {
+      const bodyPath = canonicalBodyPath(root, type, id);
+      if (!bodyPath) {
+        throw new Error("screen-item の本体パス解決に失敗しました (PR-7 で対応予定)");
+      }
+      await atomicWrite(bodyPath, payload);
+      break;
+    }
+    case "sequence":
+      await writeSequence(id, payload);
+      break;
+    case "extension":
+    case "convention": {
+      const bodyPath = canonicalBodyPath(root, type, id);
+      if (!bodyPath) {
+        throw new Error(`${type} の本体パス解決に失敗しました`);
+      }
+      await fs.mkdir(path.dirname(bodyPath), { recursive: true });
+      await atomicWrite(bodyPath, payload);
+      break;
+    }
+    default: {
+      const _exhaustive: never = type;
+      throw new Error(`未対応の resourceType: ${_exhaustive}`);
+    }
+  }
+
+  try {
+    await fs.unlink(dp);
+  } catch {
+    // draft 削除失敗は無視 (commit 自体は成功)
+  }
+
+  return { committed: true };
+}
+
+/** draft ファイルを削除する (本体には変更しない)。 */
+export async function discardDraft(
+  type: DraftResourceType,
+  id: string,
+): Promise<{ discarded: boolean }> {
+  const root = requireActivePath();
+  const dp = draftPath(root, type, id);
+  try {
+    await fs.unlink(dp);
+    return { discarded: true };
+  } catch {
+    return { discarded: false };
+  }
+}
+
+/** draft ファイルが存在するかを返す。 */
+export async function hasDraft(type: DraftResourceType, id: string): Promise<boolean> {
+  const root = requireActivePath();
+  try {
+    await fs.access(draftPath(root, type, id));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** 全 draft を列挙する。 */
+export async function listDrafts(): Promise<Array<{ type: DraftResourceType; id: string; mtimeMs: number }>> {
+  const root = requireActivePath();
+  const dr = draftsRoot(root);
+  const result: Array<{ type: DraftResourceType; id: string; mtimeMs: number }> = [];
+
+  let typeDirs: string[];
+  try {
+    typeDirs = await fs.readdir(dr);
+  } catch {
+    return result;
+  }
+
+  for (const typeDir of typeDirs) {
+    const type = typeDir as DraftResourceType;
+    const fullTypeDir = path.join(dr, typeDir);
+    let files: string[];
+    try {
+      files = await fs.readdir(fullTypeDir);
+    } catch {
+      continue;
+    }
+    for (const file of files) {
+      if (!file.endsWith(".json")) continue;
+      const id = file.slice(0, -5);
+      try {
+        const stat = await fs.stat(path.join(fullTypeDir, file));
+        result.push({ type, id, mtimeMs: stat.mtimeMs });
+      } catch {
+        // ファイルが消えた場合はスキップ
+      }
+    }
+  }
+
+  return result;
+}

--- a/designer-mcp/src/draftStore.ts
+++ b/designer-mcp/src/draftStore.ts
@@ -7,6 +7,7 @@
  */
 import fs from "fs/promises";
 import path from "path";
+import { randomBytes } from "node:crypto";
 import { requireActivePath } from "./workspaceState.js";
 import {
   writeScreen,
@@ -15,7 +16,6 @@ import {
   writeView,
   writeViewDefinition,
   writeSequence,
-  writeConventions,
 } from "./projectStorage.js";
 
 export type DraftResourceType =
@@ -48,10 +48,16 @@ async function ensureDraftDir(activeRoot: string, type: DraftResourceType): Prom
 }
 
 async function atomicWrite(targetPath: string, data: unknown): Promise<void> {
-  const tmp = `${targetPath}.tmp-${process.pid}-${Date.now()}`;
+  const rand = randomBytes(4).toString("hex");
+  const tmp = `${targetPath}.tmp-${process.pid}-${Date.now()}-${rand}`;
   const json = JSON.stringify(data, null, 2);
-  await fs.writeFile(tmp, json, "utf-8");
-  await fs.rename(tmp, targetPath);
+  try {
+    await fs.writeFile(tmp, json, "utf-8");
+    await fs.rename(tmp, targetPath);
+  } catch (err) {
+    await fs.unlink(tmp).catch(() => {});
+    throw err;
+  }
 }
 
 async function readJSON<T>(filePath: string): Promise<T | null> {

--- a/designer-mcp/src/httpTransport.test.ts
+++ b/designer-mcp/src/httpTransport.test.ts
@@ -88,7 +88,7 @@ describe("designer-mcp HTTP transport (#302)", () => {
     expect(res.body).toContain("designer-mcp");
   });
 
-  it("tools/list で 20 件以上のツールが返る (stateless なので initialize 直後に呼べる)", async () => {
+  it("tools/list で 20 件以上のツールが返り draft__* 6 種を含む", async () => {
     const res = await mcpCall("tools/list", undefined, { id: 2 });
     let parsed: { result?: { tools: { name: string }[] }; error?: unknown };
     const dataLine = res.body.split("\n").find((l) => l.startsWith("data: "));
@@ -106,6 +106,46 @@ describe("designer-mcp HTTP transport (#302)", () => {
     expect(names).toContain("designer__list_process_flows");
     expect(names).toContain("designer__list_markers");
     expect(names).toContain("designer__find_all_markers");
+    expect(names).toContain("draft__read");
+    expect(names).toContain("draft__update");
+    expect(names).toContain("draft__commit");
+    expect(names).toContain("draft__discard");
+    expect(names).toContain("draft__has");
+    expect(names).toContain("draft__list");
+  });
+
+  it("draft E2E: update → has=true → discard → has=false", async () => {
+    async function callTool(toolName: string, args: Record<string, unknown>) {
+      const res = await mcpCall("tools/call", undefined, {
+        id: Math.floor(Math.random() * 100000),
+        params: { name: toolName, arguments: args },
+      });
+      const dataLine = res.body.split("\n").find((l) => l.startsWith("data: "));
+      let parsed: { result?: { content: Array<{ type: string; text: string }> }; error?: unknown };
+      if (dataLine) {
+        parsed = JSON.parse(dataLine.slice(6));
+      } else {
+        parsed = JSON.parse(res.body);
+      }
+      if (parsed.error) throw new Error(`MCP error: ${JSON.stringify(parsed.error)}`);
+      const text = parsed.result?.content?.[0]?.text ?? "";
+      return JSON.parse(text);
+    }
+
+    await callTool("draft__update", {
+      type: "table",
+      id: "e2e-test-tbl",
+      payload: { name: "e2e_table", columns: [] },
+    });
+
+    const hasResult = await callTool("draft__has", { type: "table", id: "e2e-test-tbl" });
+    expect(hasResult.exists).toBe(true);
+
+    const discardResult = await callTool("draft__discard", { type: "table", id: "e2e-test-tbl" });
+    expect(discardResult.discarded).toBe(true);
+
+    const hasAfter = await callTool("draft__has", { type: "table", id: "e2e-test-tbl" });
+    expect(hasAfter.exists).toBe(false);
   });
 
   it("同一 port で WebSocket も受け付ける (ws:// upgrade)", async () => {

--- a/designer-mcp/src/index.ts
+++ b/designer-mcp/src/index.ts
@@ -17,6 +17,16 @@ import { tools } from "./tools.js";
 import { handleAuthCheck, handlePropose } from "./aiRename.js";
 import { htmlToReact, toPascalCase } from "./reactExporter.js";
 import { readProject, readCustomBlocks, readTable, writeTable, deleteTable as deleteTableFile, writeProject, readErLayout, readProcessFlow, writeProcessFlow, deleteProcessFlow as deleteProcessFlowFile, listProcessFlows as listProcessFlowFiles } from "./projectStorage.js";
+import {
+  createDraft,
+  readDraft,
+  updateDraft,
+  commitDraft,
+  discardDraft,
+  hasDraft,
+  listDrafts,
+  type DraftResourceType,
+} from "./draftStore.js";
 import { mcpTableToSpecEntry } from "./specExport.js";
 import { initWorkspaceState, getActivePath, setActivePath, clearActive, isLockdown, getLockdownPath, LockdownError, WorkspaceUnsetError } from "./workspaceState.js";
 import { listWorkspaces, upsertWorkspace, removeWorkspace, findById, findByPath, setLastActive } from "./recentStore.js";
@@ -1140,6 +1150,49 @@ function createMcpServer(): Server {
           return { content: [{ type: "text", text: `id ${a.id} のワークスペースは見つかりませんでした。` }] };
         }
         return { content: [{ type: "text", text: `id ${a.id} を recent から除外しました (ファイルは変更されません)。` }] };
+      }
+
+      // ── draft 管理 (#685) ─────────────────────────────────────────
+      case "draft__read": {
+        const a = argRecord as { type: DraftResourceType; id: string };
+        const payload = await readDraft(a.type, a.id);
+        return { content: [{ type: "text", text: JSON.stringify({ payload, exists: payload !== null }, null, 2) }] };
+      }
+
+      case "draft__update": {
+        const a = argRecord as { type: DraftResourceType; id: string; payload: unknown };
+        await updateDraft(a.type, a.id, a.payload);
+        wsBridge.broadcast("draft.changed", { type: a.type, id: a.id, op: "updated" });
+        return { content: [{ type: "text", text: JSON.stringify({ updated: true }) }] };
+      }
+
+      case "draft__commit": {
+        const a = argRecord as { type: DraftResourceType; id: string };
+        const r = await commitDraft(a.type, a.id);
+        if (r.committed) {
+          wsBridge.broadcast("draft.changed", { type: a.type, id: a.id, op: "committed" });
+        }
+        return { content: [{ type: "text", text: JSON.stringify(r) }] };
+      }
+
+      case "draft__discard": {
+        const a = argRecord as { type: DraftResourceType; id: string };
+        const r = await discardDraft(a.type, a.id);
+        if (r.discarded) {
+          wsBridge.broadcast("draft.changed", { type: a.type, id: a.id, op: "discarded" });
+        }
+        return { content: [{ type: "text", text: JSON.stringify(r) }] };
+      }
+
+      case "draft__has": {
+        const a = argRecord as { type: DraftResourceType; id: string };
+        const exists = await hasDraft(a.type, a.id);
+        return { content: [{ type: "text", text: JSON.stringify({ exists }) }] };
+      }
+
+      case "draft__list": {
+        const drafts = await listDrafts();
+        return { content: [{ type: "text", text: JSON.stringify({ drafts }, null, 2) }] };
       }
 
       default:

--- a/designer-mcp/src/tools.ts
+++ b/designer-mcp/src/tools.ts
@@ -1281,4 +1281,94 @@ export const tools = [
       required: ["id"],
     },
   },
+  {
+    name: "draft__read",
+    description: "draft ファイルを読み込みます。draft が存在しない場合は exists: false を返します。",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        type: {
+          type: "string",
+          enum: ["screen", "table", "process-flow", "view", "view-definition", "screen-item", "sequence", "extension", "convention"],
+          description: "リソース種別",
+        },
+        id: { type: "string", description: "リソース ID" },
+      },
+      required: ["type", "id"],
+    },
+  },
+  {
+    name: "draft__update",
+    description: "draft ファイルを更新します (atomic write)。draft が存在しない場合は新規作成します。",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        type: {
+          type: "string",
+          enum: ["screen", "table", "process-flow", "view", "view-definition", "screen-item", "sequence", "extension", "convention"],
+          description: "リソース種別",
+        },
+        id: { type: "string", description: "リソース ID" },
+        payload: { type: "object", description: "保存する内容" },
+      },
+      required: ["type", "id", "payload"],
+    },
+  },
+  {
+    name: "draft__commit",
+    description: "draft を本体ファイルへ atomic に昇格し、draft を削除します。draft が存在しない場合は committed: false を返します。",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        type: {
+          type: "string",
+          enum: ["screen", "table", "process-flow", "view", "view-definition", "screen-item", "sequence", "extension", "convention"],
+          description: "リソース種別",
+        },
+        id: { type: "string", description: "リソース ID" },
+      },
+      required: ["type", "id"],
+    },
+  },
+  {
+    name: "draft__discard",
+    description: "draft ファイルを削除します (本体ファイルは変更しません)。draft が存在しない場合は discarded: false を返します。",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        type: {
+          type: "string",
+          enum: ["screen", "table", "process-flow", "view", "view-definition", "screen-item", "sequence", "extension", "convention"],
+          description: "リソース種別",
+        },
+        id: { type: "string", description: "リソース ID" },
+      },
+      required: ["type", "id"],
+    },
+  },
+  {
+    name: "draft__has",
+    description: "draft ファイルが存在するかを返します。",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        type: {
+          type: "string",
+          enum: ["screen", "table", "process-flow", "view", "view-definition", "screen-item", "sequence", "extension", "convention"],
+          description: "リソース種別",
+        },
+        id: { type: "string", description: "リソース ID" },
+      },
+      required: ["type", "id"],
+    },
+  },
+  {
+    name: "draft__list",
+    description: "active workspace 配下の全 draft を列挙します。",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+      required: [],
+    },
+  },
 ];

--- a/designer-mcp/src/wsBridge.ts
+++ b/designer-mcp/src/wsBridge.ts
@@ -1,6 +1,16 @@
 import { WebSocketServer, WebSocket } from "ws";
 import { EventEmitter } from "events";
 import { randomUUID } from "crypto";
+import {
+  createDraft,
+  readDraft,
+  updateDraft,
+  commitDraft,
+  discardDraft,
+  hasDraft,
+  listDrafts,
+  type DraftResourceType,
+} from "./draftStore.js";
 import { execSync } from "child_process";
 import { createServer, type IncomingMessage, type ServerResponse, type Server as HttpServer } from "node:http";
 import { renameScreenItemId, checkScreenItemRefs } from "./renameScreenItem.js";
@@ -797,6 +807,59 @@ class WsBridge extends EventEmitter {
           if (typeof id !== "string") { respondError("id は必須です"); break; }
           const removed = await removeWorkspaceEntry(id);
           respond({ removed });
+          break;
+        }
+
+        // ── draft 管理 (#685) ─────────────────────────────────────────
+        case "draft.read": {
+          const { type: dt, id: did } = (params ?? {}) as { type: DraftResourceType; id: string };
+          const payload = await readDraft(dt, did);
+          respond({ payload, exists: payload !== null });
+          break;
+        }
+        case "draft.update": {
+          const { type: dt, id: did, payload: dp } = (params ?? {}) as { type: DraftResourceType; id: string; payload: unknown };
+          await updateDraft(dt, did, dp);
+          respond({ updated: true });
+          this.broadcast("draft.changed", { type: dt, id: did, op: "updated" }, clientId);
+          break;
+        }
+        case "draft.commit": {
+          const { type: dt, id: did } = (params ?? {}) as { type: DraftResourceType; id: string };
+          const r = await commitDraft(dt, did);
+          respond(r);
+          if (r.committed) {
+            this.broadcast("draft.changed", { type: dt, id: did, op: "committed" }, clientId);
+          }
+          break;
+        }
+        case "draft.discard": {
+          const { type: dt, id: did } = (params ?? {}) as { type: DraftResourceType; id: string };
+          const r = await discardDraft(dt, did);
+          respond(r);
+          if (r.discarded) {
+            this.broadcast("draft.changed", { type: dt, id: did, op: "discarded" }, clientId);
+          }
+          break;
+        }
+        case "draft.has": {
+          const { type: dt, id: did } = (params ?? {}) as { type: DraftResourceType; id: string };
+          const exists = await hasDraft(dt, did);
+          respond({ exists });
+          break;
+        }
+        case "draft.list": {
+          const drafts = await listDrafts();
+          respond({ drafts });
+          break;
+        }
+        case "draft.create": {
+          const { type: dt, id: did } = (params ?? {}) as { type: DraftResourceType; id: string };
+          const r = await createDraft(dt, did);
+          respond(r);
+          if (r.created) {
+            this.broadcast("draft.changed", { type: dt, id: did, op: "created" }, clientId);
+          }
           break;
         }
 


### PR DESCRIPTION
## Summary

メタ #683 PR-2/7。`data/.drafts/<resourceType>/<id>.json` を edit-session の working copy として管理する backend 機構を実装。

- atomic CRUD (tmp + rename パターン)
- 9 resourceType サポート (screen / table / process-flow / view / view-definition / screen-item / sequence / extension / convention)
- MCP tool 6 種追加 (`draft__read` / `draft__update` / `draft__commit` / `draft__discard` / `draft__has` / `draft__list`)
- wsBridge に browser request ハンドラ (`draft.read` / `draft.update` / `draft.commit` / `draft.discard` / `draft.has` / `draft.list` / `draft.create`) + `draft.changed` broadcast
- `data/.drafts/` を `.gitignore` に追加 (D-6)

lock 管理は PR-3 (#686)、`onBehalfOfSession` は PR-7 (#690) で別途。

## 関連

Closes #685

- 親メタ: #683
- 前: #684 PR-1 (spec) — マージ済
- 次: #686 PR-3 (lock manager) — 本 PR マージ後着手

## 仕様逐条突合 (自己申告)

- draftStore.ts エントリポイント: designer-mcp/src/draftStore.ts:1
- DraftResourceType enum: designer-mcp/src/draftStore.ts:21
- atomic write helper: designer-mcp/src/draftStore.ts:50
- resourceType → 本体 path mapping (canonicalBodyPath): designer-mcp/src/draftStore.ts:72
- createDraft: designer-mcp/src/draftStore.ts:101
- readDraft: designer-mcp/src/draftStore.ts:131
- updateDraft: designer-mcp/src/draftStore.ts:140
- commitDraft: designer-mcp/src/draftStore.ts:154
- discardDraft: designer-mcp/src/draftStore.ts:218
- hasDraft: designer-mcp/src/draftStore.ts:233
- listDrafts: designer-mcp/src/draftStore.ts:244
- MCP tool 6 種 inputSchema: designer-mcp/src/tools.ts:1285-1377
- wsBridge draft.* ハンドラ追加箇所: designer-mcp/src/wsBridge.ts:814
- draft.changed broadcast: designer-mcp/src/wsBridge.ts:824 / 832 / 841 / 861
- index.ts CallToolRequest dispatcher 追加箇所: designer-mcp/src/index.ts:1156
- httpTransport.test.ts tools 件数更新 + draft 名チェック: designer-mcp/src/httpTransport.test.ts:109
- httpTransport.test.ts E2E 追加: designer-mcp/src/httpTransport.test.ts:117
- .gitignore data/.drafts/: .gitignore:52

## Test plan

- [x] `npm run build` (designer-mcp tsc) pass
- [x] `npx vitest run src/draftStore.test.ts` pass (16 件)
- [x] `npx vitest run src/httpTransport.test.ts` pass (5 件)
- [x] 半角カナ 0 件確認

## 実装メモ

- `screen-item` は Phase 4-β migration により `screen-items/` ディレクトリが廃止済み (`projectStorage.ts:99` コメント参照)。`commitDraft` は `canonicalBodyPath` が null を返すため明示的エラーを返す (PR-7 で対応予定)
- `extension` / `convention` の commit は projectStorage の write 関数が汎用でないため直接 atomicWrite を使用 (broadcast は wsBridge 経由で行われないため非推奨扱い、PR-7 で改善)
- `screen` の commit は `writeScreen` を呼ぶ (GrapesJS デザイン JSON を `screens/<id>.design.json` へ書く既存パス)

## 非スコープ

- lock 管理 (PR-3 #686)
- `onBehalfOfSession` (PR-7 #690)
- frontend UI (PR-4 以降)

🤖 Generated with [Claude Code](https://claude.com/claude-code)