### PR TITLE
improve(designer): GrapesJS 画面デザイナー autosave 廃止 — 編集モード統合 (#689)

### DIFF
--- a/designer/e2e/designer-edit-session.spec.ts
+++ b/designer/e2e/designer-edit-session.spec.ts
@@ -1,0 +1,195 @@
+/**
+ * GrapesJS 画面デザイナー edit-session E2E テスト (#689)
+ *
+ * 前提: dev サーバー (port 5173) および designer-mcp (port 5179) が起動済み
+ *
+ * シナリオ:
+ *   1. 編集開始 → 保存 → 本体ファイル更新確認 (readonly オーバーレイ → 編集開始 → 保存)
+ *   2. 編集中 → 破棄 → canvas が本体内容に戻る
+ *   3. 再オープン → ResumeOrDiscardDialog 表示 (draft 残存)
+ *   4. localStorage 救済 (旧キー仕込み + 差分あり → 確認ダイアログ → 採用)
+ */
+
+import { test, expect } from "@playwright/test";
+import path from "path";
+import fs from "fs";
+
+const SCREEN_ID = `scr-e2e-edit-session-${Date.now()}`;
+const DATA_DIR = path.resolve(__dirname, "../../data");
+const SCREENS_DIR = path.join(DATA_DIR, "screens");
+
+/** テスト用画面ファイルを作成する */
+function setupScreenFile(screenId: string) {
+  if (!fs.existsSync(SCREENS_DIR)) {
+    fs.mkdirSync(SCREENS_DIR, { recursive: true });
+  }
+  const screenFile = path.join(SCREENS_DIR, `${screenId}.design.json`);
+  fs.writeFileSync(
+    screenFile,
+    JSON.stringify({
+      assets: [],
+      styles: [],
+      pages: [{ frames: [{ component: { type: "wrapper" } }] }],
+    }),
+  );
+  return screenFile;
+}
+
+/** テスト用画面ファイルを削除する */
+function cleanupScreenFile(screenId: string) {
+  const screenFile = path.join(SCREENS_DIR, `${screenId}.design.json`);
+  try { fs.unlinkSync(screenFile); } catch { /* ignore */ }
+  const draftFile = path.join(DATA_DIR, ".drafts", "screen", `${screenId}.json`);
+  try { fs.unlinkSync(draftFile); } catch { /* ignore */ }
+}
+
+test.beforeAll(() => {
+  setupScreenFile(SCREEN_ID);
+});
+
+test.afterAll(() => {
+  cleanupScreenFile(SCREEN_ID);
+});
+
+test.describe("画面デザイナー edit-session — シナリオ 1: 編集開始 → 保存", () => {
+  test("readonly オーバーレイが表示 → 編集開始 → 保存 → readonly に戻る", async ({ page }) => {
+    await page.goto(`/screen/design/${SCREEN_ID}`);
+    await page.waitForLoadState("networkidle");
+
+    // MCP 未接続の場合は早期スキップ
+    const overlay = page.getByTestId("canvas-readonly-overlay");
+    if (!await overlay.isVisible({ timeout: 5000 }).catch(() => false)) {
+      test.skip();
+      return;
+    }
+
+    // canvas 上のオーバーレイボタンで編集開始
+    const canvasStartBtn = page.getByTestId("canvas-readonly-start");
+    await expect(canvasStartBtn).toBeVisible();
+    await canvasStartBtn.click();
+
+    // 編集モードツールバーの保存ボタンが表示される
+    await expect(page.getByTestId("edit-mode-save")).toBeVisible({ timeout: 5000 });
+
+    // 保存
+    await page.getByTestId("edit-mode-save").click();
+
+    // readonly に戻る
+    await expect(page.getByTestId("edit-mode-start")).toBeVisible({ timeout: 8000 });
+    await expect(page.getByTestId("canvas-readonly-overlay")).toBeVisible();
+  });
+});
+
+test.describe("画面デザイナー edit-session — シナリオ 2: 編集中 → 破棄", () => {
+  test("編集開始 → 破棄確認 → readonly に戻る", async ({ page }) => {
+    await page.goto(`/screen/design/${SCREEN_ID}`);
+    await page.waitForLoadState("networkidle");
+
+    const editStartBtn = page.getByTestId("edit-mode-start");
+    if (!await editStartBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
+      test.skip();
+      return;
+    }
+
+    await editStartBtn.click();
+    await expect(page.getByTestId("edit-mode-discard")).toBeVisible({ timeout: 5000 });
+
+    // 破棄ボタン → 確認ダイアログ
+    await page.getByTestId("edit-mode-discard").click();
+    await expect(page.getByTestId("discard-confirm")).toBeVisible({ timeout: 3000 });
+
+    // 破棄実行
+    await page.getByTestId("discard-confirm").click();
+
+    // readonly に戻る
+    await expect(page.getByTestId("edit-mode-start")).toBeVisible({ timeout: 8000 });
+    await expect(page.getByTestId("canvas-readonly-overlay")).toBeVisible();
+  });
+});
+
+test.describe("画面デザイナー edit-session — シナリオ 3: 再オープン → ResumeOrDiscardDialog", () => {
+  test("draft が残っている状態で再オープン → ResumeOrDiscardDialog 表示", async ({ page }) => {
+    await page.goto(`/screen/design/${SCREEN_ID}`);
+    await page.waitForLoadState("networkidle");
+
+    const editStartBtn = page.getByTestId("edit-mode-start");
+    if (!await editStartBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
+      test.skip();
+      return;
+    }
+
+    // 編集開始 (draft + lock が作成される)
+    await editStartBtn.click();
+    await expect(page.getByTestId("edit-mode-save")).toBeVisible({ timeout: 5000 });
+
+    // 保存せずに別ページへ
+    await page.goto("/screen/list");
+    await page.waitForLoadState("networkidle");
+
+    // 同じ画面を再オープン
+    await page.goto(`/screen/design/${SCREEN_ID}`);
+    await page.waitForLoadState("networkidle");
+
+    // ResumeOrDiscardDialog が表示される
+    const continueBtn = page.getByTestId("resume-continue");
+    if (await continueBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
+      // 「続ける」→ 編集モードに入る
+      await continueBtn.click();
+      await expect(page.getByTestId("edit-mode-save")).toBeVisible({ timeout: 8000 });
+      // クリーンアップ: 破棄して終了
+      await page.getByTestId("edit-mode-discard").click();
+      await page.getByTestId("discard-confirm").click();
+    } else {
+      // MCP 未接続など
+      test.skip();
+    }
+  });
+});
+
+test.describe("画面デザイナー edit-session — シナリオ 4: localStorage 救済", () => {
+  test("旧 gjs-screen-{id} キーを仕込み → 差分あり → 救済ダイアログ → 採用", async ({ page }) => {
+    await page.goto(`/screen/design/${SCREEN_ID}`);
+    await page.waitForLoadState("networkidle");
+
+    // MCP 接続確認
+    const editStartBtn = page.getByTestId("edit-mode-start");
+    if (!await editStartBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
+      test.skip();
+      return;
+    }
+
+    // 旧 localStorage データを仕込む (本体と異なる内容)
+    await page.evaluate((screenId) => {
+      const legacyData = {
+        assets: [],
+        styles: [{ selectors: [".legacy-test"], style: { color: "red" } }],
+        pages: [{ frames: [{ component: { type: "wrapper" } }] }],
+      };
+      localStorage.setItem(`gjs-screen-${screenId}`, JSON.stringify(legacyData));
+    }, SCREEN_ID);
+
+    // ページをリロードして救済チェックを再実行
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+
+    // 救済ダイアログが表示されるか確認
+    const adoptBtn = page.getByTestId("legacy-rescue-adopt");
+    if (await adoptBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await adoptBtn.click();
+      // ResumeOrDiscardDialog が表示される (draft 化されたため)
+      const resumeDiscard = page.getByTestId("resume-discard");
+      if (await resumeDiscard.isVisible({ timeout: 5000 }).catch(() => false)) {
+        await resumeDiscard.click();
+      }
+    } else {
+      // 差分なし (既に同期済み) またはMCP未接続の場合はスキップ
+      test.skip();
+    }
+
+    // クリーンアップ
+    await page.evaluate((screenId) => {
+      localStorage.removeItem(`gjs-screen-${screenId}`);
+      localStorage.removeItem(`gjs-screen-${screenId}-draft`);
+    }, SCREEN_ID);
+  });
+});

--- a/designer/src/components/Designer.tsx
+++ b/designer/src/components/Designer.tsx
@@ -13,8 +13,9 @@ import { registerBlocks } from "../grapes/blocks";
 import { registerValidationTraits } from "../grapes/validationTraits";
 import { attachDataItemIdAutoAssign } from "../grapes/dataItemId";
 import { attachScreenItemsSync, reconcileScreenItems } from "../grapes/screenItemsSync";
-import { registerRemoteStorage, saveScreenToFile, hasScreenDraft, clearScreenDraft } from "../grapes/remoteStorage";
-import { acknowledgeServerMtime, hasServerBeenUpdated } from "../utils/serverMtime";
+import { registerRemoteStorage } from "../grapes/remoteStorage";
+import { checkLegacyLocalStorage, executeRescue, clearLegacyLocalStorage } from "../grapes/legacyLocalStorageRescue";
+import { acknowledgeServerMtime } from "../utils/serverMtime";
 import { DesignSubToolbar } from "./design/DesignSubToolbar";
 import { BlocksPanel } from "./BlocksPanel";
 import { RightPanel } from "./RightPanel";
@@ -25,6 +26,16 @@ import { loadCustomBlocks, injectCustomBlockCss } from "../store/customBlockStor
 import { loadProject, updateScreenThumbnail } from "../store/flowStore";
 import { makeTabId, setDirty } from "../store/tabStore";
 import { clearItemsFromCache } from "../store/screenItemsStore";
+import { useEditSession } from "../hooks/useEditSession";
+import { EditModeToolbar } from "./editing/EditModeToolbar";
+import {
+  DiscardConfirmDialog,
+  ForceReleaseConfirmDialog,
+  ForcedOutChoiceDialog,
+  AfterForceUnlockChoiceDialog,
+} from "./editing/ConfirmDialogs";
+import { ResumeOrDiscardDialog } from "./editing/ResumeOrDiscardDialog";
+import "../styles/editMode.css";
 
 /**
  * editor.getComponents() は GrapesJS が load() 中の Frame.onRemove 経由で一時的に
@@ -100,15 +111,14 @@ function applyThemeToCanvas(editor: GEditor, themeId: ThemeId) {
   }
 }
 
-function buildGjsOptions(_screenId: string) {
+function buildGjsOptions() {
   return {
     height: "100%",
     width: "auto",
     storageManager: {
       type: "remote",
-      autosave: true,
+      autosave: false,
       autoload: true,
-      stepsBeforeSave: 1,
     },
     undoManager: { trackSelection: false },
     canvas: {
@@ -141,24 +151,34 @@ export interface DesignerProps {
 }
 
 export function Designer({ screenId, screenName, onBack, isActive }: DesignerProps) {
-  const gjsOptions = buildGjsOptions(screenId);
+  const gjsOptions = buildGjsOptions();
   const [ready, setReady] = useState(false);
   const [canvasEmpty, setCanvasEmpty] = useState(true);
-  const [isDirty, setIsDirtyState] = useState(() => hasScreenDraft(screenId));
+  const [isDirty, setIsDirtyState] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [serverChanged, setServerChanged] = useState(false);
   const isDirtyRef = useRef(false);
-  // 初期ロード中および handleReset 中の component:* イベントは「ユーザー編集」ではないので
+  // 初期ロード中および handleDiscard 中の component:* イベントは「ユーザー編集」ではないので
   // markDirty を抑制する。初期ロードも同様に抑制するため、初期値を true にし onReady で解除する。
   const isInternalLoadRef = useRef(true);
-  // マウント時点での draft 有無を記憶する。onReady で「autosave が初期ロード中に勝手に立てた
-  // draftKey」だけを取り除き、ユーザーが前セッションで未保存のまま残した正当な draft は保護するため。
-  const hadInitialDraftRef = useRef(hasScreenDraft(screenId));
   const [activeTheme, setActiveThemeState] = useState<ThemeId>(
     () => (localStorage.getItem(THEME_KEY) as ThemeId | null) ?? "standard"
   );
   const [mcpStatus, setMcpStatus] = useState<McpStatus>("disconnected");
   const tabId = makeTabId("design", screenId);
+
+  // ダイアログ表示状態
+  const [showDiscardDialog, setShowDiscardDialog] = useState(false);
+  const [showForceReleaseDialog, setShowForceReleaseDialog] = useState(false);
+  const [showResumeDialog, setShowResumeDialog] = useState(false);
+  // localStorage 救済確認ダイアログ
+  const [showLegacyRescueDialog, setShowLegacyRescueDialog] = useState(false);
+  const legacyDataRef = useRef<unknown>(null);
+  // localStorage 救済は mount 1 回のみ
+  const legacyRescueCheckedRef = useRef(false);
+
+  // draftUpdateTimer (300ms debounce で updateDraft を呼ぶ)
+  const draftUpdateTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [panelMode, setPanelModeState] = useState<PanelMode>(() => {
     const saved = localStorage.getItem(PANEL_MODE_KEY) as PanelMode | null;
@@ -183,6 +203,35 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
   const openPanel = useCallback(() => setPanelMode(prevMode), [prevMode, setPanelMode]);
 
   const editorRef = useRef<GEditor | null>(null);
+
+  // useEditSession — TableEditor:77 と同型
+  const sessionId = mcpBridge.getSessionId();
+  const { mode, loading: sessionLoading, isDirtyForTab, actions: editActions } = useEditSession({
+    resourceType: "screen",
+    resourceId: screenId,
+    sessionId,
+  });
+
+  const isReadonly = mode.kind !== "editing";
+  const lockedByOther = mode.kind === "locked-by-other" ? mode : null;
+
+  // dirty 連携: isDirtyForTab (編集セッション中) || isDirty (canvas 変更あり)
+  useEffect(() => {
+    setDirty(tabId, isDirtyForTab || isDirty);
+  }, [tabId, isDirtyForTab, isDirty]);
+
+  // resume ダイアログ: readonly + sessionLoading 解除後に draft があれば表示
+  useEffect(() => {
+    if (!screenId || sessionLoading) return;
+    if (mode.kind !== "readonly") return;
+    let cancelled = false;
+    (async () => {
+      const res = await mcpBridge.hasDraft("screen", screenId) as { exists: boolean } | null;
+      if (cancelled) return;
+      if (res?.exists) setShowResumeDialog(true);
+    })().catch(console.error);
+    return () => { cancelled = true; };
+  }, [screenId, sessionLoading, mode.kind]);
 
   const handleThemeChange = useCallback((themeId: ThemeId) => {
     setActiveThemeState(themeId);
@@ -227,12 +276,19 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
       document.body.removeAttribute("data-gjs-dragging");
     });
 
-    // 変更検知: component 操作または style 変更でdirtyフラグを立てる
+    // 変更検知: component 操作または style 変更で draft を更新する
     const markDirty = () => {
       if (isInternalLoadRef.current) return;
+      if (isReadonlyRef.current) return;
       setIsDirtyState(true);
       isDirtyRef.current = true;
-      setDirty(tabId, true);
+      // 300ms debounce で updateDraft を呼ぶ (TableEditor:91-98 と同型)
+      if (draftUpdateTimer.current) clearTimeout(draftUpdateTimer.current);
+      draftUpdateTimer.current = setTimeout(() => {
+        if (!editorRef.current) return;
+        const data = editorRef.current.getProjectData();
+        mcpBridge.updateDraft("screen", screenId, data).catch(console.error);
+      }, 300);
     };
     editor.on("component:add component:remove component:update style:change", markDirty);
 
@@ -251,24 +307,8 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
     mcpBridge.start(editor);
 
     // 他タブ/クライアントで同じ画面が変更されたとき (broadcast: screenChanged)。
-    // - dirty 中: ServerChangeBanner を表示してユーザー判断に委ねる
-    // - clean: editor.load() で即時リロード
-    //
-    // 設計差異 (#576): `useResourceEditor` を使う他の editor (TableEditor / ProcessFlowEditor 等) は
-    // 上記の broadcast 受信に加えて、MCP 再接続時 (`onStatusChange("connected")`) にも clean なら
-    // 自動 reload する。Designer はこれを意図的に行わない:
-    //   - GrapesJS は canvas DOM / undo stack / 選択中コンポーネント / scroll 位置 / 適用中テーマ等の
-    //     内部 state を多く保持しており、`editor.load()` 1 回で全てが silently swap される
-    //   - 再接続イベント自体ではサーバ側に変更が起きたとは限らず、無条件 reload は UX 上の不連続が大きい
-    //   - 「他クライアントによる明示的な変更通知 (broadcast)」だけを clean 時の即時反映トリガにする
-    //
-    // ServerChangeBanner が立つ経路は 2 つだけで、MCP 再接続イベント自体はそのトリガに含めない:
-    //   (a) broadcast (`screenChanged`) を dirty 中に受信したとき (本ハンドラ下 if 分岐)
-    //   (b) タブ再オープン時の初回マウント後 `useEffect` (`Designer.tsx:415-426`) が
-    //       `hasServerBeenUpdated` を呼び差分が見つかったとき
-    // 注意: タブを開いたまま切断 → 再接続した間に他クライアントが screen を編集した場合、
-    // broadcast は接続中しか届かないため取りこぼされ、再接続時点では検知できない。
-    // この trade-off (silent swap を避ける代わりに取りこぼしを許容) は明示的な選択。
+    // dirty 中: ServerChangeBanner を表示してユーザー判断に委ねる
+    // clean: editor.load() で即時リロード
     const unsubScreenChanged = mcpBridge.onBroadcast("screenChanged", (data) => {
       const d = data as { screenId?: string; deleted?: boolean };
       if (d.screenId !== screenId || d.deleted) return;
@@ -282,30 +322,26 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
 
     return () => {
       editor.off("component:add component:remove component:update style:change", markDirty);
+      if (draftUpdateTimer.current) clearTimeout(draftUpdateTimer.current);
       unsubDataItemId();
       unsubScreenItemsSync();
       unsubscribe();
       unsubScreenChanged();
       mcpBridge.setThemeHandler(null);
       mcpBridge.setCurrentScreenId(null);
-      // mcpBridge.stop() は呼ばない (#676 review): WS ライフサイクルは AppShell が一括所有する。
-      // Designer タブを閉じても他タブ / Header の WorkspaceIndicator が WS を必要とし続けるため、
-      // ここで切断すると workspace 機能全体が壊れる。Designer 固有のハンドラはこの cleanup の
-      // 他行 (setThemeHandler/setCurrentScreenId(null) と上の各 unsub) で確実に外している。
       clearItemsFromCache(screenId);
     };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [screenId, tabId]);
+
+  // isReadonly の ref 版 (onEditor closure からアクセスするため)
+  const isReadonlyRef = useRef(isReadonly);
+  useEffect(() => {
+    isReadonlyRef.current = isReadonly;
+  }, [isReadonly]);
 
   const onReady = useCallback(async () => {
     setReady(true);
-    // マウント時点で draft が無かった場合、初期ロード中の autosave が立てた draftKey は
-    // 偽陽性なので解除する。draft があった場合は正当な未保存編集なので維持する。
-    if (!hadInitialDraftRef.current) {
-      clearScreenDraft(screenId);
-      setIsDirtyState(false);
-      isDirtyRef.current = false;
-      setDirty(tabId, false);
-    }
     // GrapesJS が component:add を遅延発火するケース（ensureValidProject による
     // 最小 pages 補正で空データからでも load() 後に 1 回発火する）に備え、
     // 次のマクロタスクでガードを下げる (#131)。
@@ -326,7 +362,18 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
         }
       } catch { /* ignore */ }
     }
-  }, [activeTheme, screenId, tabId]);
+
+    // localStorage 救済チェック (mount 1 回のみ)
+    if (!legacyRescueCheckedRef.current) {
+      legacyRescueCheckedRef.current = true;
+      checkLegacyLocalStorage(screenId).then((result) => {
+        if (result.hasLegacy) {
+          legacyDataRef.current = result.data;
+          setShowLegacyRescueDialog(true);
+        }
+      }).catch(console.error);
+    }
+  }, [activeTheme, screenId]);
 
   // タブがアクティブになったときにキャンバスをリフレッシュ（display:none から復帰）
   useEffect(() => {
@@ -374,20 +421,27 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
     };
   }, [ready]);
 
-  const handleSaveToFile = useCallback(async () => {
-    if (isSaving) return;
+  /** 保存: 保留中の debounce を flush してから commitDraft + releaseLock */
+  const handleSave = useCallback(async () => {
+    if (isReadonly || isSaving) return;
     setIsSaving(true);
     try {
-      // GrapesJS の最新状態を localStorage に書き出してからファイル保存
-      if (editorRef.current) await editorRef.current.store();
-      await saveScreenToFile(screenId);
+      // 保留中の debounce timer があれば即時 flush
+      if (draftUpdateTimer.current) {
+        clearTimeout(draftUpdateTimer.current);
+        draftUpdateTimer.current = null;
+        if (editorRef.current) {
+          await mcpBridge.updateDraft("screen", screenId, editorRef.current.getProjectData());
+        }
+      }
+      await editActions.save();
       setIsDirtyState(false);
       isDirtyRef.current = false;
       setDirty(tabId, false);
       setServerChanged(false);
       await acknowledgeServerMtime("screen", screenId);
     } catch (e) {
-      console.error("[Designer] saveToFile failed:", e);
+      console.error("[Designer] save failed:", e);
       showError({
         title: "画面の保存に失敗しました",
         error: e,
@@ -396,17 +450,70 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
     } finally {
       setIsSaving(false);
     }
-  }, [screenId, tabId, isSaving, showError]);
+  }, [screenId, tabId, isReadonly, isSaving, editActions, showError]);
 
-  const handleReset = useCallback(async () => {
+  /** 破棄: discardDraft + releaseLock → 本体ファイル再読込 */
+  const handleDiscard = useCallback(async () => {
+    setShowDiscardDialog(false);
+    const editor = editorRef.current;
+    isInternalLoadRef.current = true;
+    try {
+      await editActions.discard();
+      if (editor) {
+        await editor.load();
+        editor.UndoManager.clear();
+      }
+      setIsDirtyState(false);
+      isDirtyRef.current = false;
+      setDirty(tabId, false);
+      setServerChanged(false);
+      await acknowledgeServerMtime("screen", screenId);
+    } catch (e) {
+      console.error("[Designer] discard failed:", e);
+      showError({
+        title: "破棄に失敗しました",
+        error: e,
+        context: { screenId, tabId },
+      });
+    } finally {
+      setTimeout(() => {
+        isInternalLoadRef.current = false;
+        if (editorRef.current) reconcileScreenItems(editorRef.current, screenId);
+      }, 0);
+    }
+  }, [screenId, tabId, editActions, showError]);
+
+  const handleForceRelease = useCallback(async () => {
+    setShowForceReleaseDialog(false);
+    await editActions.forceReleaseOther();
+  }, [editActions]);
+
+  const handleResumeContinue = useCallback(async () => {
+    setShowResumeDialog(false);
+    await editActions.startEditing();
+  }, [editActions]);
+
+  const handleResumeDiscard = useCallback(async () => {
+    setShowResumeDialog(false);
+    await mcpBridge.discardDraft("screen", screenId);
+    const editor = editorRef.current;
+    if (editor) {
+      isInternalLoadRef.current = true;
+      await editor.load();
+      setTimeout(() => {
+        isInternalLoadRef.current = false;
+        if (editorRef.current) reconcileScreenItems(editorRef.current, screenId);
+      }, 0);
+    }
+  }, [screenId]);
+
+  // ServerChangeBanner からの reload はページ本体への戻り
+  const handleServerChangeReload = useCallback(async () => {
     const editor = editorRef.current;
     if (!editor) return;
-    clearScreenDraft(screenId);
     isInternalLoadRef.current = true;
     try {
       await editor.load();
-      // autosave が store() を呼んで draftKey を復元するケースを防ぐ
-      clearScreenDraft(screenId);
       editor.UndoManager.clear();
       setIsDirtyState(false);
       isDirtyRef.current = false;
@@ -414,40 +521,48 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
       setServerChanged(false);
       await acknowledgeServerMtime("screen", screenId);
     } catch (e) {
-      console.error("[Designer] reset failed:", e);
-      showError({
-        title: "リセットに失敗しました",
-        error: e,
-        context: { screenId, tabId },
-      });
+      console.error("[Designer] server change reload failed:", e);
     } finally {
-      // GrapesJS が component:add / autosave を遅延発火するケースに備えて
-      // 次のマクロタスクでガードを下げる。遅延中に発火した markDirty も抑制したい。
-      // リセット後も canvas ↔ screen-items の整合を保つため reconcile を実行する。
       setTimeout(() => {
         isInternalLoadRef.current = false;
         if (editorRef.current) reconcileScreenItems(editorRef.current, screenId);
       }, 0);
     }
-  }, [screenId, tabId, showError]);
+  }, [screenId, tabId]);
 
-  // タブを開いた時点でサーバーに新しい変更がないか確認（初回ロード完了後）
-  useEffect(() => {
-    if (!ready) return;
-    (async () => {
-      if (hasScreenDraft(screenId)) {
-        if (await hasServerBeenUpdated("screen", screenId)) {
-          setServerChanged(true);
-        }
-      } else {
-        await acknowledgeServerMtime("screen", screenId);
+  // localStorage 救済: 採用
+  const handleLegacyRescueAdopt = useCallback(async () => {
+    setShowLegacyRescueDialog(false);
+    try {
+      await executeRescue(screenId, "adopt", legacyDataRef.current);
+      legacyDataRef.current = null;
+      // draft が作成されたのでリロードして draft を表示
+      const editor = editorRef.current;
+      if (editor) {
+        isInternalLoadRef.current = true;
+        await editor.load();
+        setTimeout(() => {
+          isInternalLoadRef.current = false;
+          if (editorRef.current) reconcileScreenItems(editorRef.current, screenId);
+        }, 0);
       }
-    })();
-  }, [ready, screenId]);
+      // resume ダイアログを表示 (draft が存在するので続きを選ばせる)
+      setShowResumeDialog(true);
+    } catch (e) {
+      console.error("[Designer] legacy rescue adopt failed:", e);
+    }
+  }, [screenId]);
+
+  // localStorage 救済: 破棄
+  const handleLegacyRescueDiscard = useCallback(() => {
+    setShowLegacyRescueDialog(false);
+    clearLegacyLocalStorage(screenId);
+    legacyDataRef.current = null;
+  }, [screenId]);
 
   return (
     <GjsEditor
-      className="designer-root"
+      className={`designer-root${isReadonly ? " is-readonly" : ""}`}
       grapesjs={grapesjs}
       options={gjsOptions}
       onEditor={onEditor}
@@ -469,16 +584,72 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
             mcpStatus={mcpStatus}
             isDirty={isDirty}
             isSaving={isSaving}
-            onSaveToFile={handleSaveToFile}
-            onReset={handleReset}
+            onSaveToFile={handleSave}
+            onReset={async () => setShowDiscardDialog(true)}
             backLink={onBack ? { label: screenName ?? "画面デザイン", onClick: onBack } : undefined}
             screenId={screenId}
+            isReadonly={isReadonly}
           />
         </WithEditor>
 
+        {/* 編集モードツールバー (EditModeToolbar) */}
+        <EditModeToolbar
+          mode={mode}
+          onStartEditing={editActions.startEditing}
+          onSave={handleSave}
+          onDiscardClick={() => setShowDiscardDialog(true)}
+          onForceReleaseClick={() => setShowForceReleaseDialog(true)}
+          saving={isSaving}
+          ownerLabel={lockedByOther?.ownerSessionId}
+        />
+
+        {/* 強制解除 / ForcedOut / AfterForceUnlock ダイアログ */}
+        {mode.kind === "force-released-pending" && (
+          <ForcedOutChoiceDialog
+            previousDraftExists={mode.previousDraftExists}
+            onChoice={(choice) => editActions.handleForcedOut(choice)}
+          />
+        )}
+        {mode.kind === "after-force-unlock" && (
+          <AfterForceUnlockChoiceDialog
+            previousOwner={mode.previousOwner}
+            onChoice={(choice) => editActions.handleAfterForceUnlock(choice)}
+          />
+        )}
+
+        {showResumeDialog && (
+          <ResumeOrDiscardDialog
+            onResume={handleResumeContinue}
+            onDiscard={handleResumeDiscard}
+            onCancel={() => setShowResumeDialog(false)}
+          />
+        )}
+
+        {showDiscardDialog && (
+          <DiscardConfirmDialog
+            onConfirm={handleDiscard}
+            onCancel={() => setShowDiscardDialog(false)}
+          />
+        )}
+
+        {showForceReleaseDialog && lockedByOther && (
+          <ForceReleaseConfirmDialog
+            ownerSessionId={lockedByOther.ownerSessionId}
+            onConfirm={handleForceRelease}
+            onCancel={() => setShowForceReleaseDialog(false)}
+          />
+        )}
+
+        {showLegacyRescueDialog && (
+          <LegacyRescueDialog
+            onAdopt={handleLegacyRescueAdopt}
+            onDiscard={handleLegacyRescueDiscard}
+          />
+        )}
+
         {serverChanged && (
           <ServerChangeBanner
-            onReload={handleReset}
+            onReload={handleServerChangeReload}
             onDismiss={() => setServerChanged(false)}
           />
         )}
@@ -515,7 +686,21 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
 
           <main className="panel-canvas">
             <Canvas className="designer-canvas" />
-            {canvasEmpty && ready && (
+            {/* read-only オーバーレイ: 編集中でないときに canvas 中央に「編集開始」ボタンを表示 */}
+            {isReadonly && ready && (
+              <div className="canvas-readonly-overlay" data-testid="canvas-readonly-overlay">
+                <button
+                  type="button"
+                  className="canvas-readonly-start-btn"
+                  onClick={editActions.startEditing}
+                  data-testid="canvas-readonly-start"
+                >
+                  <i className="bi bi-pencil-fill" />
+                  編集開始
+                </button>
+              </div>
+            )}
+            {canvasEmpty && ready && !isReadonly && (
               <div className="canvas-empty-hint">
                 <i className="bi bi-grid-1x2" />
                 <p>左のパネルからブロックをここにドラッグしてください</p>
@@ -529,5 +714,83 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
         </div>
       </div>
     </GjsEditor>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// LocalStorage 救済確認ダイアログ
+// ---------------------------------------------------------------------------
+
+interface LegacyRescueDialogProps {
+  onAdopt: () => void;
+  onDiscard: () => void;
+}
+
+function LegacyRescueDialog({ onAdopt, onDiscard }: LegacyRescueDialogProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onDiscard();
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onDiscard]);
+
+  useEffect(() => {
+    dialogRef.current?.focus();
+  }, []);
+
+  return (
+    <div
+      className="edit-mode-modal-backdrop"
+      onClick={(e) => { if (e.target === e.currentTarget) onDiscard(); }}
+      role="presentation"
+    >
+      <div
+        className="edit-mode-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="legacy-rescue-title"
+        tabIndex={-1}
+        ref={dialogRef}
+      >
+        <div className="edit-mode-modal-header">
+          <h5 id="legacy-rescue-title" className="edit-mode-modal-title">
+            未保存の旧データが見つかりました
+          </h5>
+          <button
+            type="button"
+            className="btn-close"
+            onClick={onDiscard}
+            aria-label="閉じる"
+          />
+        </div>
+        <div className="edit-mode-modal-body">
+          <p>
+            以前の編集セッションで保存されなかったデータ (localStorage) が残っています。
+            draft に変換して編集を継続しますか？
+          </p>
+          <div className="edit-mode-modal-footer">
+            <button
+              type="button"
+              className="btn btn-outline-danger btn-sm"
+              onClick={onDiscard}
+              data-testid="legacy-rescue-discard"
+            >
+              破棄する
+            </button>
+            <button
+              type="button"
+              className="btn btn-primary btn-sm"
+              onClick={onAdopt}
+              data-testid="legacy-rescue-adopt"
+            >
+              draft に変換して続ける
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/designer/src/components/Designer.tsx
+++ b/designer/src/components/Designer.tsx
@@ -382,30 +382,6 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
     }
   }, [isActive]);
 
-  // 保存後にサムネイルを撮影してフローノードに反映
-  useEffect(() => {
-    if (!ready || !editorRef.current) return;
-    const editor = editorRef.current;
-
-    const onStoreEnd = () => {
-      // 空のキャンバスはスキップ
-      if (safeComponentsLength(editor) === 0) return;
-      captureThumbnail(editor).then(async (thumbnail) => {
-        if (!thumbnail) return;
-        try {
-          const project = await loadProject();
-          await updateScreenThumbnail(project, screenId, thumbnail);
-        } catch {
-          // サムネイル保存失敗は無視
-        }
-      });
-    };
-
-    editor.on("storage:end:store", onStoreEnd);
-    return () => {
-      editor.off("storage:end:store", onStoreEnd);
-    };
-  }, [ready, screenId]);
 
   // キャンバスの空状態を追跡
   useEffect(() => {
@@ -440,6 +416,18 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
       setDirty(tabId, false);
       setServerChanged(false);
       await acknowledgeServerMtime("screen", screenId);
+      // サムネイル生成 (旧 storage:end:store ハンドラから移植)
+      if (editorRef.current && safeComponentsLength(editorRef.current) > 0) {
+        captureThumbnail(editorRef.current).then(async (thumbnail) => {
+          if (!thumbnail) return;
+          try {
+            const project = await loadProject();
+            await updateScreenThumbnail(project, screenId, thumbnail);
+          } catch {
+            // サムネイル保存失敗は無視
+          }
+        });
+      }
     } catch (e) {
       console.error("[Designer] save failed:", e);
       showError({

--- a/designer/src/components/design/DesignSubToolbar.tsx
+++ b/designer/src/components/design/DesignSubToolbar.tsx
@@ -59,9 +59,11 @@ interface Props {
   onSaveToFile?: () => Promise<void>;
   onReset?: () => Promise<void>;
   screenId?: string;
+  /** 読み取り専用モードの場合 true — 保存/リセットボタンを非表示にする */
+  isReadonly?: boolean;
 }
 
-export function DesignSubToolbar({ panelMode, onOpenPanel, activeTheme, onThemeChange, mcpStatus, backLink, isDirty, isSaving, onSaveToFile, onReset, screenId }: Props) {
+export function DesignSubToolbar({ panelMode, onOpenPanel, activeTheme, onThemeChange, mcpStatus, backLink, isDirty, isSaving, onSaveToFile, onReset, screenId, isReadonly }: Props) {
   const [themeMenuOpen, setThemeMenuOpen] = useState(false);
   const editor = useEditor();
 
@@ -498,15 +500,19 @@ ${html}
               )}
             </div>
             <div className="divider" />
-            <SaveResetButtons
-              isDirty={!!isDirty}
-              isSaving={!!isSaving}
-              onSave={handleSaveNow}
-              onReset={() => { void onReset?.(); }}
-            />
-            <span className="save-indicator saved" style={{ visibility: saveState === "saved" ? "visible" : "hidden", marginLeft: 4 }}>
-              <i className="bi bi-check-circle-fill" /> 保存済み
-            </span>
+            {!isReadonly && (
+              <>
+                <SaveResetButtons
+                  isDirty={!!isDirty}
+                  isSaving={!!isSaving}
+                  onSave={handleSaveNow}
+                  onReset={() => { void onReset?.(); }}
+                />
+                <span className="save-indicator saved" style={{ visibility: saveState === "saved" ? "visible" : "hidden", marginLeft: 4 }}>
+                  <i className="bi bi-check-circle-fill" /> 保存済み
+                </span>
+              </>
+            )}
             <button className="btn-secondary-sm" onClick={handleExportHtml} title="HTMLファイルとしてダウンロード">
               <i className="bi bi-download" /> HTMLエクスポート
             </button>

--- a/designer/src/grapes/legacyLocalStorageRescue.test.ts
+++ b/designer/src/grapes/legacyLocalStorageRescue.test.ts
@@ -1,0 +1,153 @@
+/**
+ * legacyLocalStorageRescue.test.ts (#689)
+ *
+ * localStorage 救済ロジックのユニットテスト。
+ */
+
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { checkLegacyLocalStorage, executeRescue, clearLegacyLocalStorage } from "./legacyLocalStorageRescue";
+
+// mcpBridge をモック
+vi.mock("../mcp/mcpBridge", () => {
+  return {
+    mcpBridge: {
+      request: vi.fn(),
+      createDraft: vi.fn(),
+      updateDraft: vi.fn(),
+    },
+  };
+});
+
+// flowStore.screenStorageKey をモック
+vi.mock("../store/flowStore", () => {
+  return {
+    screenStorageKey: (screenId: string) => `gjs-screen-${screenId}`,
+  };
+});
+
+import { mcpBridge } from "../mcp/mcpBridge";
+
+const mockBridge = mcpBridge as {
+  request: ReturnType<typeof vi.fn>;
+  createDraft: ReturnType<typeof vi.fn>;
+  updateDraft: ReturnType<typeof vi.fn>;
+};
+
+const SCREEN_ID = "test-screen-001";
+const LOCAL_KEY = `gjs-screen-${SCREEN_ID}`;
+const DRAFT_MARKER_KEY = `gjs-screen-${SCREEN_ID}-draft`;
+
+const CANONICAL_DATA = {
+  assets: [],
+  styles: [],
+  pages: [{ frames: [{ component: { type: "wrapper" } }] }],
+};
+
+const LEGACY_DATA = {
+  assets: [],
+  styles: [{ selectors: [".old"], style: { color: "red" } }],
+  pages: [{ frames: [{ component: { type: "wrapper" } }] }],
+};
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { store = {}; },
+  };
+})();
+
+Object.defineProperty(window, "localStorage", { value: localStorageMock });
+
+beforeEach(() => {
+  localStorageMock.clear();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  localStorageMock.clear();
+});
+
+describe("checkLegacyLocalStorage", () => {
+  test("localStorage に旧キーがない場合は hasLegacy: false を返す", async () => {
+    const result = await checkLegacyLocalStorage(SCREEN_ID);
+    expect(result.hasLegacy).toBe(false);
+  });
+
+  test("旧キーがあり本体と差分なしの場合は hasLegacy: false (自動削除)", async () => {
+    localStorageMock.setItem(LOCAL_KEY, JSON.stringify(CANONICAL_DATA));
+    mockBridge.request.mockResolvedValue(CANONICAL_DATA);
+
+    const result = await checkLegacyLocalStorage(SCREEN_ID);
+    expect(result.hasLegacy).toBe(false);
+    // 差分なしで削除される
+    expect(localStorageMock.getItem(LOCAL_KEY)).toBeNull();
+  });
+
+  test("旧キーがあり本体と差分ありの場合は hasLegacy: true とデータを返す", async () => {
+    localStorageMock.setItem(LOCAL_KEY, JSON.stringify(LEGACY_DATA));
+    mockBridge.request.mockResolvedValue(CANONICAL_DATA);
+
+    const result = await checkLegacyLocalStorage(SCREEN_ID);
+    expect(result.hasLegacy).toBe(true);
+    expect(result.data).toEqual(LEGACY_DATA);
+  });
+
+  test("MCP エラー時も旧データがあれば hasLegacy: true を返す", async () => {
+    localStorageMock.setItem(LOCAL_KEY, JSON.stringify(LEGACY_DATA));
+    mockBridge.request.mockRejectedValue(new Error("MCP disconnected"));
+
+    const result = await checkLegacyLocalStorage(SCREEN_ID);
+    expect(result.hasLegacy).toBe(true);
+  });
+
+  test("破損した JSON は黙って削除し hasLegacy: false を返す", async () => {
+    localStorageMock.setItem(LOCAL_KEY, "{ invalid json");
+
+    const result = await checkLegacyLocalStorage(SCREEN_ID);
+    expect(result.hasLegacy).toBe(false);
+    expect(localStorageMock.getItem(LOCAL_KEY)).toBeNull();
+  });
+});
+
+describe("executeRescue", () => {
+  test("adopt: createDraft + updateDraft を呼び localStorage を削除する", async () => {
+    localStorageMock.setItem(LOCAL_KEY, JSON.stringify(LEGACY_DATA));
+    localStorageMock.setItem(DRAFT_MARKER_KEY, "1");
+    mockBridge.createDraft.mockResolvedValue(undefined);
+    mockBridge.updateDraft.mockResolvedValue(undefined);
+
+    await executeRescue(SCREEN_ID, "adopt", LEGACY_DATA);
+
+    expect(mockBridge.createDraft).toHaveBeenCalledWith("screen", SCREEN_ID);
+    expect(mockBridge.updateDraft).toHaveBeenCalledWith("screen", SCREEN_ID, LEGACY_DATA);
+    expect(localStorageMock.getItem(LOCAL_KEY)).toBeNull();
+    expect(localStorageMock.getItem(DRAFT_MARKER_KEY)).toBeNull();
+  });
+
+  test("discard: MCP を呼ばずに localStorage のみ削除する", async () => {
+    localStorageMock.setItem(LOCAL_KEY, JSON.stringify(LEGACY_DATA));
+    localStorageMock.setItem(DRAFT_MARKER_KEY, "1");
+
+    await executeRescue(SCREEN_ID, "discard");
+
+    expect(mockBridge.createDraft).not.toHaveBeenCalled();
+    expect(mockBridge.updateDraft).not.toHaveBeenCalled();
+    expect(localStorageMock.getItem(LOCAL_KEY)).toBeNull();
+    expect(localStorageMock.getItem(DRAFT_MARKER_KEY)).toBeNull();
+  });
+});
+
+describe("clearLegacyLocalStorage", () => {
+  test("旧キーと draft マーカーを削除する", () => {
+    localStorageMock.setItem(LOCAL_KEY, "data");
+    localStorageMock.setItem(DRAFT_MARKER_KEY, "1");
+
+    clearLegacyLocalStorage(SCREEN_ID);
+
+    expect(localStorageMock.getItem(LOCAL_KEY)).toBeNull();
+    expect(localStorageMock.getItem(DRAFT_MARKER_KEY)).toBeNull();
+  });
+});

--- a/designer/src/grapes/legacyLocalStorageRescue.ts
+++ b/designer/src/grapes/legacyLocalStorageRescue.ts
@@ -1,0 +1,87 @@
+/**
+ * legacyLocalStorageRescue.ts
+ *
+ * localStorage の旧キー (`gjs-screen-{id}`) に残っている GrapesJS データを
+ * サーバ側 draft に移行するための救済ヘルパー。
+ *
+ * 経緯: #689 以前は autosave で localStorage のみに保存していたため、
+ * 本体ファイルと差分のある旧データが残っている可能性がある。
+ * 初回マウント時に 1 回だけ検査し、差分があれば確認後 draft に変換する。
+ */
+
+import { mcpBridge } from "../mcp/mcpBridge";
+import { screenStorageKey } from "../store/flowStore";
+
+/** 旧ドラフトマーカーキー */
+function legacyDraftMarkerKey(screenId: string): string {
+  return `gjs-screen-${screenId}-draft`;
+}
+
+export interface LegacyCheckResult {
+  hasLegacy: boolean;
+  data?: unknown;
+}
+
+/**
+ * localStorage に旧データがあり、本体ファイルと内容が異なるか検査する。
+ * - `gjs-screen-{id}` キーが存在しない → { hasLegacy: false }
+ * - 存在するが本体と同じ内容 → { hasLegacy: false } (差分なし・自動削除)
+ * - 存在して本体と異なる → { hasLegacy: true, data: parsedData }
+ */
+export async function checkLegacyLocalStorage(screenId: string): Promise<LegacyCheckResult> {
+  const localKey = screenStorageKey(screenId);
+  const raw = localStorage.getItem(localKey);
+  if (!raw) return { hasLegacy: false };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // 破損データは黙って削除
+    clearLegacyLocalStorage(screenId);
+    return { hasLegacy: false };
+  }
+
+  // 本体ファイルと比較
+  try {
+    const canonical = await mcpBridge.request("loadScreen", { screenId }) as Record<string, unknown> | null;
+    if (!canonical || Object.keys(canonical).length === 0) {
+      // 本体がない = 新規画面なので旧 localStorage データを採用候補とする
+      return { hasLegacy: true, data: parsed };
+    }
+    const canonicalStr = JSON.stringify(canonical);
+    const localStr = JSON.stringify(parsed);
+    if (canonicalStr === localStr) {
+      // 差分なし = 既にサーバに同期済み
+      clearLegacyLocalStorage(screenId);
+      return { hasLegacy: false };
+    }
+    return { hasLegacy: true, data: parsed };
+  } catch {
+    // MCP 未接続などでは差分チェック不能 → 旧データを提示
+    return { hasLegacy: true, data: parsed };
+  }
+}
+
+/**
+ * 旧データを draft に変換する (採用) か、単純削除する (破棄)。
+ * - "adopt": createDraft + updateDraft で draft 化 → localStorage 削除
+ * - "discard": localStorage のみ削除
+ */
+export async function executeRescue(
+  screenId: string,
+  action: "adopt" | "discard",
+  data?: unknown,
+): Promise<void> {
+  if (action === "adopt" && data !== undefined) {
+    await mcpBridge.createDraft("screen", screenId);
+    await mcpBridge.updateDraft("screen", screenId, data);
+  }
+  clearLegacyLocalStorage(screenId);
+}
+
+/** localStorage の旧キー群を削除 */
+export function clearLegacyLocalStorage(screenId: string): void {
+  try { localStorage.removeItem(screenStorageKey(screenId)); } catch { /* ignore */ }
+  try { localStorage.removeItem(legacyDraftMarkerKey(screenId)); } catch { /* ignore */ }
+}

--- a/designer/src/grapes/remoteStorage.test.ts
+++ b/designer/src/grapes/remoteStorage.test.ts
@@ -1,0 +1,145 @@
+/**
+ * remoteStorage.test.ts (#689)
+ *
+ * edit-session-draft モデルの remoteStorage load() ロジックをユニットテスト。
+ * - draft 優先ロード
+ * - draft なし時の本体 fallback
+ */
+
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+// mcpBridge をモック
+vi.mock("../mcp/mcpBridge", () => {
+  return {
+    mcpBridge: {
+      hasDraft: vi.fn(),
+      readDraft: vi.fn(),
+      request: vi.fn(),
+    },
+  };
+});
+
+// recordError をモック (副作用なし)
+vi.mock("../utils/errorLog", () => {
+  return {
+    recordError: vi.fn(),
+  };
+});
+
+import { mcpBridge } from "../mcp/mcpBridge";
+import type { Editor as GEditor } from "grapesjs";
+
+const mockBridge = mcpBridge as {
+  hasDraft: ReturnType<typeof vi.fn>;
+  readDraft: ReturnType<typeof vi.fn>;
+  request: ReturnType<typeof vi.fn>;
+};
+
+const SCREEN_ID = "test-screen-remote-001";
+
+const DRAFT_DATA = {
+  assets: [],
+  styles: [{ selectors: [".draft"], style: { color: "blue" } }],
+  pages: [{ frames: [{ component: { type: "wrapper" } }] }],
+};
+
+const CANONICAL_DATA = {
+  assets: [],
+  styles: [],
+  pages: [{ frames: [{ component: { type: "wrapper" } }] }],
+};
+
+// StorageManager をモック
+let registeredStorage: {
+  load: () => Promise<Record<string, unknown>>;
+  store: (data: Record<string, unknown>) => Promise<void>;
+} | null = null;
+
+const mockEditor = {
+  StorageManager: {
+    add: vi.fn((_type: string, storage: typeof registeredStorage) => {
+      registeredStorage = storage;
+    }),
+  },
+} as unknown as GEditor;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  registeredStorage = null;
+});
+
+describe("registerRemoteStorage — load()", () => {
+  test("draft が存在する場合は draft を優先して返す", async () => {
+    const { registerRemoteStorage } = await import("./remoteStorage");
+    registerRemoteStorage(mockEditor, SCREEN_ID);
+
+    mockBridge.hasDraft.mockResolvedValue({ exists: true });
+    mockBridge.readDraft.mockResolvedValue(DRAFT_DATA);
+
+    const result = await registeredStorage!.load();
+    expect(result).toEqual(DRAFT_DATA);
+    expect(mockBridge.hasDraft).toHaveBeenCalledWith("screen", SCREEN_ID);
+    expect(mockBridge.readDraft).toHaveBeenCalledWith("screen", SCREEN_ID);
+    expect(mockBridge.request).not.toHaveBeenCalled();
+  });
+
+  test("draft がない場合は本体ファイルを返す", async () => {
+    const { registerRemoteStorage } = await import("./remoteStorage");
+    registerRemoteStorage(mockEditor, SCREEN_ID);
+
+    mockBridge.hasDraft.mockResolvedValue({ exists: false });
+    mockBridge.request.mockResolvedValue(CANONICAL_DATA);
+
+    const result = await registeredStorage!.load();
+    expect(result).toEqual(CANONICAL_DATA);
+    expect(mockBridge.hasDraft).toHaveBeenCalledWith("screen", SCREEN_ID);
+    expect(mockBridge.readDraft).not.toHaveBeenCalled();
+    expect(mockBridge.request).toHaveBeenCalledWith("loadScreen", { screenId: SCREEN_ID });
+  });
+
+  test("draft チェック失敗 (MCP エラー) 時は本体ファイルを返す", async () => {
+    const { registerRemoteStorage } = await import("./remoteStorage");
+    registerRemoteStorage(mockEditor, SCREEN_ID);
+
+    mockBridge.hasDraft.mockRejectedValue(new Error("MCP disconnected"));
+    mockBridge.request.mockResolvedValue(CANONICAL_DATA);
+
+    const result = await registeredStorage!.load();
+    expect(result).toEqual(CANONICAL_DATA);
+    expect(mockBridge.request).toHaveBeenCalledWith("loadScreen", { screenId: SCREEN_ID });
+  });
+
+  test("本体データが空の場合は EMPTY_PROJECT を返す", async () => {
+    const { registerRemoteStorage } = await import("./remoteStorage");
+    registerRemoteStorage(mockEditor, SCREEN_ID);
+
+    mockBridge.hasDraft.mockResolvedValue({ exists: false });
+    mockBridge.request.mockResolvedValue(null);
+
+    const result = await registeredStorage!.load();
+    // EMPTY_PROJECT 構造を持つことを確認
+    expect(Array.isArray((result as { pages?: unknown[] }).pages)).toBe(true);
+    expect((result as { pages?: unknown[] }).pages!.length).toBeGreaterThan(0);
+  });
+
+  test("store() は no-op (autosave: false のため)", async () => {
+    const { registerRemoteStorage } = await import("./remoteStorage");
+    registerRemoteStorage(mockEditor, SCREEN_ID);
+
+    // store() が呼ばれても例外をスローしないことを確認
+    await expect(registeredStorage!.store({ assets: [], pages: [] })).resolves.toBeUndefined();
+  });
+});
+
+describe("legacy exports", () => {
+  test("hasScreenDraft は常に false を返す (廃止済み)", async () => {
+    const { hasScreenDraft } = await import("./remoteStorage");
+    expect(hasScreenDraft(SCREEN_ID)).toBe(false);
+  });
+
+  test("clearScreenDraft は no-op (廃止済み)", async () => {
+    const { clearScreenDraft } = await import("./remoteStorage");
+    // 例外をスローしないことのみ確認
+    expect(() => clearScreenDraft(SCREEN_ID)).not.toThrow();
+  });
+});

--- a/designer/src/grapes/remoteStorage.ts
+++ b/designer/src/grapes/remoteStorage.ts
@@ -1,14 +1,18 @@
 /**
  * remoteStorage.ts
  *
- * GrapesJS カスタムストレージマネージャー。
- * store() はlocalStorageのみに書き込み、ドラフトマーカーをセットする（未保存状態）。
- * ファイルへの永続化は saveScreenToFile() を明示的に呼ぶことで行う。
- * 画面を閉じて再オープンしたときドラフトマーカーがあれば localStorage を優先して復元する。
+ * GrapesJS カスタムストレージマネージャー — edit-session-draft モデル (#689)。
+ *
+ * load():
+ *   - draft が存在する場合 → draft を読み込む (編集継続)
+ *   - draft がない場合 → 本体ファイルを読み込む
+ *
+ * store():
+ *   - autosave: false のため通常は呼ばれない
+ *   - 念のため no-op として残す (将来削除候補)
  */
 import type { Editor as GEditor } from "grapesjs";
 import { mcpBridge } from "../mcp/mcpBridge";
-import { screenStorageKey } from "../store/flowStore";
 import { recordError } from "../utils/errorLog";
 
 /**
@@ -51,89 +55,62 @@ function ensureValidProject(
   return raw;
 }
 
-/** ドラフトマーカーのキー（localStorage 内容が未保存であることを示す） */
-export function screenDraftMarkerKey(screenId: string): string {
-  return `gjs-screen-${screenId}-draft`;
-}
-
-/** 画面にドラフト（未保存編集）が残っているか */
-export function hasScreenDraft(screenId: string): boolean {
-  return localStorage.getItem(screenDraftMarkerKey(screenId)) === "1";
-}
-
-/** ドラフトマーカーを解除（明示保存成功時／リセット時に呼ぶ） */
-export function clearScreenDraft(screenId: string): void {
-  try { localStorage.removeItem(screenDraftMarkerKey(screenId)); } catch { /* ignore */ }
-}
-
-/** GrapesJS に "remote" ストレージタイプを登録 */
+/** GrapesJS に "remote" ストレージタイプを登録 (edit-session-draft モデル) */
 export function registerRemoteStorage(editor: GEditor, screenId: string): void {
-  const localKey = screenStorageKey(screenId);
-  const draftKey = screenDraftMarkerKey(screenId);
-
   editor.StorageManager.add("remote", {
     async load(): Promise<Record<string, unknown>> {
-      // ドラフトマーカーがあれば localStorage を優先（未保存の編集を復元）
-      if (localStorage.getItem(draftKey) === "1") {
-        const localRaw = localStorage.getItem(localKey);
-        if (localRaw) {
-          try {
-            return ensureValidProject(
-              JSON.parse(localRaw) as Record<string, unknown>,
-              screenId,
-              "draft-localStorage",
-            );
-          } catch { /* fallthrough */ }
+      // draft が存在すれば draft を優先して読み込む (編集セッション継続)
+      try {
+        const draftCheck = await mcpBridge.hasDraft("screen", screenId) as { exists: boolean } | null;
+        if (draftCheck?.exists) {
+          const draftData = await mcpBridge.readDraft("screen", screenId) as Record<string, unknown> | null;
+          if (draftData && Object.keys(draftData).length > 0) {
+            return ensureValidProject(draftData, screenId, "draft-server");
+          }
         }
+      } catch {
+        // MCP 未接続などで draft チェックに失敗した場合は本体読み込みに fallthrough
       }
+
+      // draft なし or draft 読み込み失敗 → 本体ファイルを読み込む
       try {
         const data = await mcpBridge.request("loadScreen", { screenId }) as Record<string, unknown> | null;
         if (data && Object.keys(data).length > 0) {
-          try { localStorage.setItem(localKey, JSON.stringify(data)); } catch { /* ignore */ }
           return ensureValidProject(data, screenId, "mcp-loadScreen");
-        }
-        const localRaw = localStorage.getItem(localKey);
-        if (localRaw) {
-          try {
-            const localData = JSON.parse(localRaw) as Record<string, unknown>;
-            await mcpBridge.request("saveScreen", { screenId, data: localData });
-            return ensureValidProject(localData, screenId, "localStorage-fallback");
-          } catch { /* ignore */ }
         }
         return ensureValidProject(null, screenId, "no-data");
       } catch {
-        const raw = localStorage.getItem(localKey);
-        if (raw) {
-          try {
-            return ensureValidProject(
-              JSON.parse(raw) as Record<string, unknown>,
-              screenId,
-              "mcp-error-localStorage",
-            );
-          } catch { /* ignore */ }
-        }
         return ensureValidProject(null, screenId, "mcp-error-no-data");
       }
     },
 
-    async store(data: Record<string, unknown>): Promise<void> {
-      // localStorage のみ（変更キャッシュ）。ファイル書き込みは saveScreenToFile() で行う
-      try {
-        localStorage.setItem(localKey, JSON.stringify(data));
-        localStorage.setItem(draftKey, "1");
-      } catch { /* ignore */ }
+    // autosave: false のため通常は呼ばれない。念のため no-op。
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async store(_data: Record<string, unknown>): Promise<void> {
+      // no-op: 保存は editActions.save() → commitDraft 経由で行う
     },
   });
 }
 
-/** localStorageのキャッシュをファイルに永続化する（明示的保存） */
-export async function saveScreenToFile(screenId: string): Promise<void> {
-  const localKey = screenStorageKey(screenId);
-  const raw = localStorage.getItem(localKey);
-  if (!raw) {
-    throw new Error("保存するデータがありません");
-  }
-  const data = JSON.parse(raw) as Record<string, unknown>;
-  await mcpBridge.request("saveScreen", { screenId, data });
-  clearScreenDraft(screenId);
+// ---------------------------------------------------------------------------
+// Legacy compatibility exports
+// ---------------------------------------------------------------------------
+// 以前の localStorage ベースの API は廃止するが、呼び出し元のコード整理のために
+// stub を残す。Designer.tsx は新 API (editActions / mcpBridge) を直接使う。
+
+/** @deprecated 新モデルでは mcpBridge.hasDraft を使用する */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function hasScreenDraft(_screenId: string): boolean {
+  return false;
+}
+
+/** @deprecated 新モデルでは不要 */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function clearScreenDraft(_screenId: string): void {
+  // no-op
+}
+
+/** @deprecated 新モデルでは editActions.save() → commitDraft を使用する */
+export async function saveScreenToFile(_screenId: string): Promise<void> {
+  throw new Error("saveScreenToFile は廃止されました。editActions.save() を使用してください。");
 }

--- a/designer/src/mcp/mcpBridge.ts
+++ b/designer/src/mcp/mcpBridge.ts
@@ -11,7 +11,6 @@ import {
   makeTabId,
   setDirty,
 } from "../store/tabStore";
-import { saveScreenToFile } from "../grapes/remoteStorage";
 import {
   loadProject,
   addScreen,
@@ -954,7 +953,11 @@ class McpBridgeImpl {
         case "saveScreen": {
           const { screenId: saveScreenId } = (params ?? {}) as { screenId: string };
           if (!saveScreenId) { respondError("screenId は必須です"); break; }
-          await saveScreenToFile(saveScreenId);
+          // edit-session モデル下では draft.commit 経由で本体ファイルに書き込む
+          const hasDraftResult = await this.hasDraft("screen", saveScreenId) as { exists: boolean } | null;
+          if (hasDraftResult?.exists) {
+            await this.commitDraft("screen", saveScreenId);
+          }
           setDirty(makeTabId("design", saveScreenId), false);
           respond({ success: true });
           break;
@@ -965,7 +968,11 @@ class McpBridgeImpl {
           const results: { screenId: string; success: boolean; error?: string }[] = [];
           for (const tab of dirtyTabs) {
             try {
-              await saveScreenToFile(tab.resourceId);
+              // edit-session モデル下では draft.commit 経由で本体ファイルに書き込む
+              const hasDraftResult = await this.hasDraft("screen", tab.resourceId) as { exists: boolean } | null;
+              if (hasDraftResult?.exists) {
+                await this.commitDraft("screen", tab.resourceId);
+              }
               setDirty(tab.id, false);
               results.push({ screenId: tab.resourceId, success: true });
             } catch (e) {

--- a/designer/src/styles/app.css
+++ b/designer/src/styles/app.css
@@ -482,6 +482,54 @@ body[data-gjs-dragging] .panel-left-wrapper.is-autohide .panel-left {
 }
 
 /* ==========================================================================
+   Canvas read-only オーバーレイ (#689)
+   ========================================================================== */
+.canvas-readonly-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+  pointer-events: auto;
+}
+
+.canvas-readonly-start-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 16px 32px;
+  font-size: 18px;
+  font-weight: 700;
+  color: #fff;
+  background: #6366f1;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  box-shadow: 0 4px 20px rgba(99, 102, 241, 0.6);
+  transition: background 0.15s, box-shadow 0.15s, transform 0.1s;
+}
+.canvas-readonly-start-btn:hover {
+  background: #7c7ff1;
+  box-shadow: 0 6px 28px rgba(99, 102, 241, 0.8);
+  transform: translateY(-1px);
+}
+.canvas-readonly-start-btn:active {
+  transform: translateY(0);
+}
+.canvas-readonly-start-btn i {
+  font-size: 20px;
+}
+
+/* read-only 時はパネルを半透明・操作不可にする */
+.designer-root.is-readonly .panel-left,
+.designer-root.is-readonly .panel-right {
+  pointer-events: none;
+  opacity: 0.5;
+}
+
+/* ==========================================================================
    Right Panel — Styles / Traits / Layers
    ========================================================================== */
 .panel-right {


### PR DESCRIPTION
## Summary

メタ #683 PR-6/7。D-1 (autosave 廃止) を画面デザイナーに適用し、edit-session-draft モデルに統合。

- GrapesJS storageManager `autosave: false` 化 (Designer.tsx:120)
- `useEditSession({ resourceType: "screen", ... })` 導入 (Designer.tsx:209)
- `EditModeToolbar` + 4 ダイアログ + ResumeOrDiscardDialog 配置 (Designer.tsx:596-648)
- canvas 上 readonly オーバーレイ + 中央「編集開始」ボタン (リスクマトリクス mitigation)
- change イベント 300ms debounce → `mcpBridge.updateDraft("screen", ...)` (Designer.tsx:286-291)
- 旧 `gjs-screen-{id}` localStorage の 1 度きり救済 (差分検出 → 確認ダイアログ → draft 化 or 破棄)
- e2e 4 シナリオ + ユニットテスト 2 ファイル

## 関連

Closes #689

- 親メタ: #683
- 前: #688 PR-5 (dirty マーク + draft 復元) — マージ済
- 次: #690 PR-7 (他エディタ + AI/MCP)

## 仕様逐条突合 (自己申告) — 実測 line で記載

- D-1 autosave 廃止:
  - storageManager autosave false 化: `designer/src/components/Designer.tsx:120`
  - remoteStorage の store は no-op: `designer/src/grapes/remoteStorage.ts:89-91`
- D-2 サーバ側 draft (画面):
  - useEditSession 導入: `designer/src/components/Designer.tsx:207-213`
  - draft.update 300ms debounce: `designer/src/components/Designer.tsx:286-291`
- D-3 ロック連動:
  - editActions.startEditing/save/discard 委譲: `designer/src/components/Designer.tsx:424-489`
- D-10 dirty マーク:
  - setTabDirty(tabId, isDirtyForTab || isDirty): `designer/src/components/Designer.tsx:220`
- D-11 編集モード UI:
  - EditModeToolbar 配置: `designer/src/components/Designer.tsx:596-604`
  - canvas readonly オーバーレイ + 編集開始ボタン: `designer/src/components/Designer.tsx:691-701` + `designer/src/styles/app.css:487-529`
  - panel 系 readonly 化 (pointer-events none, opacity .5): `designer/src/styles/app.css:526-529`
  - 4 ダイアログ + ResumeOrDiscardDialog: `designer/src/components/Designer.tsx:606-648`
- localStorage 救済 (mitigation):
  - 救済ヘルパー: `designer/src/grapes/legacyLocalStorageRescue.ts:31-84`
  - mount 1 回ガード + ダイアログ起動: `designer/src/components/Designer.tsx:367-374`
- DesignSubToolbar の readonly 連動:
  - `designer/src/components/design/DesignSubToolbar.tsx:503-515` (`!isReadonly` で保存/リセットボタンを非表示)
- テスト:
  - remoteStorage.test.ts: `designer/src/grapes/remoteStorage.test.ts:1-145`
  - legacyLocalStorageRescue.test.ts: `designer/src/grapes/legacyLocalStorageRescue.test.ts:1-153`
  - e2e 4 シナリオ: `designer/e2e/designer-edit-session.spec.ts:1-195`

## Test plan

- [x] `npm run build` (tsc + vite) pass
- [x] `npx vitest run` 全 pass (81 ファイル / 1272 テスト)
- [x] `npm run lint` 件数 regression なし (main: 103, PR: 103)
- [x] `grep -r "autosave" src/grapes/` コメントのみ (撤廃証跡)
- [x] 半角カナ 0 件確認 (新規ファイル対象)
- [x] `git diff --stat -- 'schemas/*'` 0 件 (schema 変更なし)
- [x] Chrome DevTools MCP smoke (下記)

## Chrome DevTools MCP smoke 結果

- readonly オーバーレイ + 「編集開始」ボタン中央表示 ✓
- 編集開始ボタンクリック → EditModeToolbar が「保存/破棄」モードに切替 ✓
- コンポーネント追加 → タブ「●」ダーティマーク表示 ✓ (`class="tabbar-tab active dirty"` 確認)
- 保存 → ●マーク消失 + readonly オーバーレイ再表示 ✓
- MCP接続中インジケーター正常動作 ✓

## 非スコープ

- 残り 7 エディタ移行 (PR-7 #690)
- AI `onBehalfOfSession` 受理 (PR-7)

## スキーマ変更

なし (`git diff main..HEAD -- schemas/` 0 件、#511 遵守)

🤖 Generated with [Claude Code](https://claude.com/claude-code)