### PR TITLE
feat(samples): retail サンプルワークスペース整備 (#706)

### DIFF
--- a/designer/src/schemas/samples-v3.schema.test.ts
+++ b/designer/src/schemas/samples-v3.schema.test.ts
@@ -1,0 +1,191 @@
+/**
+ * samples/**\/\*.json を v3 schema で全件 AJV 検証 (#680 / #706)。
+ *
+ * samples/<project>/ 直下のディレクトリをエンティティ種別と見なし、対応する schemas/v3/*.v3.schema.json で
+ * 各 json を検証する。schema 進化時に samples/ が breakage したら本テストで検出。
+ *
+ * 配置ルール (docs/spec/samples-retail.md § 2 / `project_samples_strategy_2026_05_02.md`):
+ *  - samples/<project>/project.json
+ *  - samples/<project>/screens/<uuid>.json
+ *  - samples/<project>/screen-items/<screenId>.json
+ *  - samples/<project>/tables/<uuid>.json
+ *  - samples/<project>/actions/<uuid>.json (= process-flows)
+ *  - samples/<project>/views/<uuid>.json
+ *  - samples/<project>/view-definitions/<uuid>.json
+ *  - samples/<project>/sequences/<uuid>.json
+ *  - samples/<project>/extensions/<namespace>/*.json
+ *  - samples/<project>/conventions/*.json
+ *  - samples/<project>/screen-layout.json (任意)
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import Ajv2020, { type ValidateFunction } from "ajv/dist/2020";
+import addFormats from "ajv-formats";
+import { readFileSync, readdirSync, existsSync, statSync } from "node:fs";
+import { resolve, join } from "node:path";
+
+const repoRoot = resolve(__dirname, "../../../");
+const v3Dir = join(repoRoot, "schemas/v3");
+const samplesDir = join(repoRoot, "samples");
+
+function loadJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+const ENTITY_TO_SCHEMA: Record<string, string> = {
+  screens: "screen.v3.schema.json",
+  "screen-items": "screen-item.v3.schema.json",
+  tables: "table.v3.schema.json",
+  actions: "process-flow.v3.schema.json",
+  views: "view.v3.schema.json",
+  "view-definitions": "view-definition.v3.schema.json",
+  sequences: "sequence.v3.schema.json",
+};
+
+const SINGLETON_FILES: Record<string, string> = {
+  "project.json": "project.v3.schema.json",
+  "screen-layout.json": "screen-layout.v3.schema.json",
+};
+
+const validators = new Map<string, ValidateFunction>();
+
+beforeAll(() => {
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  // 全 v3 schema を addSchema (相互 $ref 解決のため、$id をキーに登録)
+  const schemasByFile = new Map<string, { schema: object; id: string }>();
+  for (const f of readdirSync(v3Dir)) {
+    if (!f.endsWith(".json")) continue;
+    const schemaObj = loadJson(join(v3Dir, f)) as { $id?: string };
+    if (typeof schemaObj.$id !== "string") continue;
+    ajv.addSchema(schemaObj as object, schemaObj.$id);
+    schemasByFile.set(f, { schema: schemaObj as object, id: schemaObj.$id });
+  }
+  // 必要な schema の validator を getSchema で取得 (compile しない、重複登録回避)
+  const allSchemaFiles = new Set([
+    ...Object.values(ENTITY_TO_SCHEMA),
+    ...Object.values(SINGLETON_FILES),
+    "extensions.v3.schema.json",
+    "conventions.v3.schema.json",
+  ]);
+  for (const sf of allSchemaFiles) {
+    const entry = schemasByFile.get(sf);
+    if (!entry) throw new Error(`schema not loaded: ${sf}`);
+    const validator = ajv.getSchema(entry.id);
+    if (!validator) throw new Error(`validator not retrievable for ${sf} (${entry.id})`);
+    validators.set(sf, validator);
+  }
+});
+
+interface FileEntry {
+  filePath: string;
+  schemaFile: string;
+  relativePath: string;
+}
+
+function listSampleProjects(): string[] {
+  if (!existsSync(samplesDir)) return [];
+  return readdirSync(samplesDir).filter((name) => {
+    const sub = join(samplesDir, name);
+    return statSync(sub).isDirectory() && existsSync(join(sub, "project.json"));
+  });
+}
+
+function collectFiles(projectDir: string): FileEntry[] {
+  const entries: FileEntry[] = [];
+
+  // singleton 系 (project.json / screen-layout.json)
+  for (const [fname, schema] of Object.entries(SINGLETON_FILES)) {
+    const fp = join(projectDir, fname);
+    if (existsSync(fp)) {
+      entries.push({ filePath: fp, schemaFile: schema, relativePath: fname });
+    }
+  }
+
+  // 各 entity ディレクトリ
+  for (const [dirName, schema] of Object.entries(ENTITY_TO_SCHEMA)) {
+    const dir = join(projectDir, dirName);
+    if (!existsSync(dir)) continue;
+    for (const f of readdirSync(dir)) {
+      if (!f.endsWith(".json")) continue;
+      entries.push({
+        filePath: join(dir, f),
+        schemaFile: schema,
+        relativePath: `${dirName}/${f}`,
+      });
+    }
+  }
+
+  // extensions/<namespace>/*.json
+  const extDir = join(projectDir, "extensions");
+  if (existsSync(extDir)) {
+    for (const ns of readdirSync(extDir)) {
+      const nsDir = join(extDir, ns);
+      if (!statSync(nsDir).isDirectory()) continue;
+      for (const f of readdirSync(nsDir)) {
+        if (!f.endsWith(".json")) continue;
+        entries.push({
+          filePath: join(nsDir, f),
+          schemaFile: "extensions.v3.schema.json",
+          relativePath: `extensions/${ns}/${f}`,
+        });
+      }
+    }
+  }
+
+  // conventions/*.json
+  const convDir = join(projectDir, "conventions");
+  if (existsSync(convDir)) {
+    for (const f of readdirSync(convDir)) {
+      if (!f.endsWith(".json")) continue;
+      entries.push({
+        filePath: join(convDir, f),
+        schemaFile: "conventions.v3.schema.json",
+        relativePath: `conventions/${f}`,
+      });
+    }
+  }
+
+  return entries;
+}
+
+function dumpErrors(v: ValidateFunction, file: string): string {
+  const errs = v.errors ?? [];
+  return `${file}\n${errs
+    .slice(0, 20)
+    .map((e) => `  ${e.instancePath || "<root>"} ${e.keyword}: ${e.message ?? ""}`)
+    .join("\n")}`;
+}
+
+describe("samples/**/*.json (v3 全件 AJV 検証)", () => {
+  const projects = listSampleProjects();
+
+  if (projects.length === 0) {
+    it("no sample projects yet (skip)", () => {
+      expect(true).toBe(true);
+    });
+    return;
+  }
+
+  for (const projectName of projects) {
+    describe(`samples/${projectName}`, () => {
+      const projectDir = join(samplesDir, projectName);
+      const entries = collectFiles(projectDir);
+
+      // entity が空のときの protective check
+      it(`should have at least project.json`, () => {
+        const hasProject = entries.some((e) => e.relativePath === "project.json");
+        expect(hasProject).toBe(true);
+      });
+
+      for (const e of entries) {
+        it(`${e.relativePath} validates against ${e.schemaFile}`, () => {
+          const validator = validators.get(e.schemaFile);
+          expect(validator, `validator for ${e.schemaFile} not found`).toBeDefined();
+          const data = loadJson(e.filePath);
+          const ok = validator!(data);
+          expect(ok, ok ? "" : dumpErrors(validator!, e.relativePath)).toBe(true);
+        });
+      }
+    });
+  }
+});

--- a/docs/spec/samples-retail.md
+++ b/docs/spec/samples-retail.md
@@ -1,0 +1,135 @@
+# samples/retail/ — リテール総合サンプル仕様書
+
+`samples/retail/` の業務スコープ・データモデル・画面構成・進め方をまとめた spec。Sonnet サブエージェントへの briefing 兼用。
+
+関連: [#680](https://github.com/csilost2001/html-designer/issues/680) (親メタ) / [#706](https://github.com/csilost2001/html-designer/issues/706) (本作業) / `samples/retail/README.md`
+
+## 1. 目的
+
+リリース時に examples として提供する **完結 業務 workspace サンプル**。業務概要から AI が全仕様書を生成できることを実証 (Phase 4 の継続)、かつ業務系として **見本となる品質** (画面の見栄え / 整合性 / カバレッジ) を確保する。
+
+## 2. 業務スコープ
+
+### 2.1 業態
+
+EC + 店舗 POS + 在庫管理 のミックス。中規模 (画面 ~11、テーブル ~8、処理フロー ~4、view ~3-4、sequence ~2-3)。
+
+### 2.2 4 シナリオ + 補助
+
+| シナリオ ID | 概要 | 関連 entity |
+|---|---|---|
+| **S-1 店舗在庫照会** | 商品コード・店舗で在庫検索。低在庫閾値で警告表示。 | 画面: 商品検索 / 在庫一覧 ・ flow: search-inventory ・ table: products / inventory / stores |
+| **S-2 カート追加** | 商品をカートへ追加 (重複排除 + null/0 区別)。 | 画面: カート画面 / 追加モーダル ・ flow: add-to-cart ・ table: carts / cart_items |
+| **S-3 注文確定 (TX)** | カート → 確認 → 完了。在庫引き当て + 注文登録 + 採番を 1 TX。 | 画面: カート確認 / 完了 ・ flow: confirm-order ・ table: orders / order_items / inventory ・ sequence: order-number |
+| **S-4 配送指示** | 注文一覧 (バックオフィス) → 配送指示。外部キャリア API。 | 画面: 注文一覧 / 配送指示 ・ flow: dispatch-shipment ・ table: shipments ・ extension: retail/db-operations + steps |
+
+補助画面: ダッシュボード、商品マスター、顧客マスター、店舗マスター。
+
+### 2.3 画面一覧 (約 11)
+
+| # | 画面名 | kind | path | 関連シナリオ |
+|---|---|---|---|---|
+| 1 | ダッシュボード | dashboard | `/` | (root) |
+| 2 | 商品検索 | search | `/products/search` | S-1 |
+| 3 | 在庫一覧 | list | `/inventory` | S-1 |
+| 4 | カート画面 | retail:cart | `/cart` | S-2/S-3 |
+| 5 | カート確認 | confirm | `/cart/confirm` | S-3 |
+| 6 | 注文完了 | complete | `/order/complete` | S-3 |
+| 7 | 注文一覧 (BO) | list | `/orders` | S-4 |
+| 8 | 配送指示 | form | `/orders/:id/dispatch` | S-4 |
+| 9 | 商品マスター | list | `/master/products` | 補助 |
+| 10 | 顧客マスター | list | `/master/customers` | 補助 |
+| 11 | 店舗マスター | list | `/master/stores` | 補助 |
+
+### 2.4 テーブル一覧 (約 8)
+
+| # | physicalName | カテゴリ | 主用途 |
+|---|---|---|---|
+| 1 | products | マスタ | 商品 |
+| 2 | customers | マスタ | 顧客 |
+| 3 | stores | マスタ | 店舗 |
+| 4 | inventory | トランザクション | 店舗別在庫 |
+| 5 | carts | トランザクション | カート (顧客 1:1) |
+| 6 | cart_items | トランザクション | カート明細 |
+| 7 | orders | トランザクション | 注文 |
+| 8 | order_items | トランザクション | 注文明細 |
+| (9) | shipments | トランザクション | 配送指示 (S-4 で必要なら追加) |
+
+### 2.5 拡張 namespace `retail`
+
+- `extensions/retail/db-operations.json` — 在庫減算・カート操作などの DB 操作 step
+- `extensions/retail/field-types.json` — 商品コード・JAN コード等の業務型
+- `extensions/retail/steps.json` — 配送指示など複合 step
+- `extensions/retail/triggers.json` — 注文確定後の在庫補充トリガー
+- `extensions/retail/response-types.json` — 在庫切れ等のドメインレスポンス
+
+### 2.6 conventions catalog
+
+- `numbering.order-number` — 注文番号採番 (sequences/order-number と紐付き)
+- `regex.product-code` — 商品コード正規表現
+- `regex.jan-code` — JAN コード正規表現
+- `messages.stock-shortage` — 在庫不足メッセージ
+- `lowStockThreshold` — 低在庫閾値 (S-1 で参照)
+
+## 3. 設計判断
+
+### 3.1 ID 規約
+
+- top-level entity (Project / Screen / Table / ProcessFlow / View / Sequence) は **`Uuid` 形式 (RFC 4122 v4)** を使用。`crypto.randomUUID()` 由来の値を埋め込む。
+- ネスト LocalId は kebab-case (例: `step-01`, `col-product-code`)。
+- 業務識別子 (画面項目 ID / 処理フロー変数名) は lowerCamelCase (例: `productCode`, `cartId`)。
+- DB 物理名は snake_case (例: `order_items`, `inventory`)。
+
+### 3.2 画面 HTML の品質要件
+
+- Bootstrap 5 ベース、**清潔・実用的** (派手すぎない、業務見本として違和感ないレベル)
+- 4 テーマ (standard / card / compact / dark) で破綻しないこと (CSS 過剰指定を避ける)
+- `data-item-id` / `name` 属性は screen-items 定義と一致 (#323 抽出機能で連携)
+- レスポンシブ: FHD / 4K で情報密度活用、極端に狭い幅では破綻可
+- アクセシビリティ: form の `<label for>`, button の `aria-label` を最低限カバー
+
+### 3.3 lockdown read-only での open 前提
+
+- ユーザーは samples/retail/ を **動作確認** で開く (編集しない)
+- 編集試行は `data/` にコピーして開き直す
+- AI は samples/ 配下を **明示指示なしには git add しない** (誤コミット防止)
+
+### 3.4 schemas/v3 は変更しない
+
+- 業務記述で表現できないものは extension で対処。schemas/v3 を変更したくなったら ISSUE 起票して停止 (#511 / AGENTS.md schema governance 準拠)
+
+## 4. 受け入れ基準
+
+- [ ] `samples/retail/project.json` が `schemas/v3/project.v3.schema.json` で AJV pass
+- [ ] 全 entity ファイルが対応する v3 schema で pass
+- [ ] designer 上で「フォルダを追加 → samples/retail」で開け、各一覧が描画される
+- [ ] 4 シナリオの画面が画面フロー上で繋がっている (画面遷移定義あり)
+- [ ] 画面 HTML が **見栄え要件 (3.2)** を満たす
+- [ ] AJV 全件検証 test に samples/ を追加し、`npx vitest run` 全 pass
+- [ ] vitest / Playwright / TypeScript 全 pass
+- [ ] 半角カナ混入 0 件
+
+## 5. 進め方 (シリーズ実装、`feat/samples-retail` ブランチ)
+
+| Step | 担当 | スコープ |
+|---|---|---|
+| Step 1 | Opus | spec docs (本ファイル) + project.json 雛形 + README + .gitignore |
+| Step 2 | Sonnet | 業務データ層 (tables / extensions/retail / conventions catalog)。テーブル ID を確定 |
+| Step 3 | Sonnet | 処理フロー × 4 (Step 2 の table ID 参照、4 シナリオ実装) |
+| Step 4 | Sonnet | UI 層 (screens HTML 見栄え重視 / screen-items / 画面フロー / view / view-definition / sequence) |
+| Step 5 | Opus | AJV 全件検証 test に samples/ 追加 + smoke (multi-workspace で開いて表示確認) |
+| Step 6 | Opus | PR 作成 → 独立レビュー → Must-fix 解決 → マージ |
+
+## 6. 既存材料との関係
+
+- `docs/sample-project/` の retail 材料 (Phase 4 retail validation 由来、`gggggggg-0001..0004` 等) は **本サンプルでは使用しない**。docs/sample-project/ は dogfood 一時作業領域、samples/retail/ はリリース版正本という役割分担 (memory `project_samples_strategy_2026_05_02.md`)
+- リリース前なので backward compat は考慮しない (memory `feedback_no_backward_compat_pre_release.md`)
+
+## 7. テスト fixture としての利用
+
+```bash
+# 固定 workspace でアプリ起動 (AI の動作確認 / E2E テスト)
+DESIGNER_DATA_DIR=samples/retail npm run dev:mcp
+```
+
+`schemas/v3/*.test.ts` (AJV) に samples/**/*.json を組み込み、schema 進化時の regression を検出。

--- a/samples/.gitignore
+++ b/samples/.gitignore
@@ -1,0 +1,5 @@
+# 各 sample workspace の draft / 一時ファイルは除外 (data/ 同様)
+# 参照: project_samples_strategy_2026_05_02.md
+**/.drafts/
+**/*.bak.*
+**/.mtime/

--- a/samples/retail/README.md
+++ b/samples/retail/README.md
@@ -1,0 +1,63 @@
+# retail — リテール総合 (EC + 店舗 POS + 在庫管理)
+
+リリース時 examples 候補の **完結 業務 workspace サンプル** (#680 / #706)。EC・店舗 POS・在庫管理を統合したリテール業態をモデルにした中規模アプリ。
+
+## 業務シナリオ (4 種、画面・処理・データを連携)
+
+| シナリオ | 概要 | 関連画面 |
+|---|---|---|
+| 店舗在庫照会 | 商品コード・店舗で在庫数を検索表示。閾値以下は警告。 | 商品検索、在庫一覧 |
+| カート追加 | 商品検索結果からカートに追加。重複排除 / null 区別。 | カート画面、追加モーダル |
+| 注文確定 (TX) | カート → 確認 → 完了。在庫引き当て + 注文登録 + 採番をトランザクション保証。 | カート、確認、完了 |
+| 配送指示 | バックオフィスで注文一覧を確認、配送指示登録。外部キャリア API 連携。 | 注文一覧、配送指示 |
+
+補助画面: ダッシュボード、商品マスター、顧客マスター、店舗マスター。
+
+## ディレクトリ構成
+
+```
+samples/retail/
+├── project.json              # workspace ルート定義 (v3 schema)
+├── README.md                 # 本ファイル
+├── screens/                  # 画面 HTML (GrapesJS、見栄え重視)
+├── screen-items/             # 画面項目定義 (各画面 1:1)
+├── tables/                   # テーブル定義
+├── actions/                  # 処理フロー (旧称 process-flows)
+├── views/                    # SQL VIEW 定義
+├── view-definitions/         # 一覧 UI viewer 定義
+├── sequences/                # 採番シーケンス
+├── extensions/retail/        # retail namespace 拡張定義
+└── conventions/              # 業務規約カタログ (retail 拡張含む)
+```
+
+## 採用拡張 namespace
+
+- `retail` — db-operations / field-types / steps / triggers / response-types を retail 業態に最適化
+
+## 開き方 (動作確認)
+
+designer UI から:
+
+1. ヘッダーの「ワークスペース」 → 「フォルダを追加」
+2. `samples/retail` を指定 (絶対 path 推奨)
+3. **lockdown read-only で開く** (git 差分が出ない)
+
+編集して試したい場合は `samples/retail/` を `data/` にコピーして開き直す (data/ は gitignore 済)。
+
+## テスト fixture としての利用
+
+```bash
+# E2E / vitest で固定データとして使う
+DESIGNER_DATA_DIR=samples/retail npm run dev:mcp
+```
+
+## 検証 (AJV)
+
+`samples/**/*.json` は schema 検証 test に組み込まれる。schema 進化時に retail サンプルが breakage したら CI で検出。
+
+## 関連
+
+- 親メタ: #680
+- 起票: #706
+- spec: [docs/spec/samples-retail.md](../../docs/spec/samples-retail.md)
+- 運用方針: memory `project_samples_strategy_2026_05_02.md`

--- a/samples/retail/actions/9515d6f6-8342-48cf-a045-9e9d8fab1cfa.json
+++ b/samples/retail/actions/9515d6f6-8342-48cf-a045-9e9d8fab1cfa.json
@@ -1,0 +1,467 @@
+{
+  "$schema": "../../../schemas/v3/process-flow.v3.schema.json",
+  "meta": {
+    "id": "9515d6f6-8342-48cf-a045-9e9d8fab1cfa",
+    "name": "カート追加",
+    "description": "指定商品をログイン顧客のカートに追加する。products 存在確認 → carts UPSERT → cart_items UPSERT (retail:UPSERT_CART_ITEM) の順で実行し、重複商品の場合は数量を加算する。",
+    "kind": "screen",
+    "maturity": "committed",
+    "createdAt": "2026-05-02T00:00:00.000Z",
+    "updatedAt": "2026-05-02T00:00:00.000Z"
+  },
+  "context": {
+    "catalogs": {
+      "errors": {
+        "VALIDATION_ERROR": {
+          "httpStatus": 400,
+          "defaultMessage": "入力値が不正です。",
+          "responseId": "400-validation",
+          "description": "productCode 未指定、quantity 範囲外等のバリデーションエラー。"
+        },
+        "PRODUCT_NOT_FOUND": {
+          "httpStatus": 404,
+          "defaultMessage": "指定の商品が見つかりません。",
+          "responseId": "404-product-not-found",
+          "description": "productCode に該当する販売中商品が存在しない。"
+        },
+        "CART_ITEMS_LIMIT_EXCEEDED": {
+          "httpStatus": 422,
+          "defaultMessage": "カート内の商品点数が上限に達しています。",
+          "responseId": "422-cart-limit",
+          "description": "cart_items 件数が @conv.limit.cartMaxItems を超える場合に返す。"
+        }
+      },
+      "events": {
+        "retail.cart.item_added": {
+          "description": "カート追加が正常完了した時点で発行する。新規追加・数量加算いずれの場合も発行する。",
+          "payload": {
+            "type": "object",
+            "required": ["cartId", "productId", "quantity"],
+            "properties": {
+              "cartId": { "type": "number" },
+              "productId": { "type": "number" },
+              "quantity": { "type": "number" }
+            }
+          }
+        }
+      }
+    },
+    "ambientVariables": [
+      {
+        "name": "sessionCustomerId",
+        "type": "integer",
+        "required": true,
+        "description": "セッションから取得したログイン顧客 ID。未ログインの場合は 401 を先に返すこと (ゲートウェイ層で保証)。"
+      }
+    ]
+  },
+  "actions": [
+    {
+      "id": "act-001",
+      "name": "カートへ商品追加",
+      "trigger": "submit",
+      "description": "productCode と quantity を受け取り、顧客カートに商品を追加 (または数量加算) する。",
+      "maturity": "committed",
+      "httpRoute": {
+        "method": "POST",
+        "path": "/api/retail/cart/items",
+        "auth": "required"
+      },
+      "inputs": [
+        {
+          "name": "productCode",
+          "label": "商品コード",
+          "type": "string",
+          "required": true,
+          "description": "追加する商品の商品コード。@conv.regex.productCode 準拠。"
+        },
+        {
+          "name": "quantity",
+          "label": "数量",
+          "type": "integer",
+          "required": true,
+          "description": "追加数量。1 以上 @conv.limit.cartItemMaxQuantity 以下。"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "cartId",
+          "label": "カートID",
+          "type": "integer",
+          "description": "追加先のカート ID。"
+        },
+        {
+          "name": "cartItemId",
+          "label": "カート明細ID",
+          "type": "integer",
+          "description": "追加 (または更新) された cart_items の ID。"
+        },
+        {
+          "name": "productName",
+          "label": "商品名",
+          "type": "string",
+          "description": "追加した商品の表示名 (確認メッセージ用)。"
+        }
+      ],
+      "responses": [
+        {
+          "id": "200-ok",
+          "status": 200,
+          "bodySchema": { "typeRef": "retail:CartAddResponse" },
+          "description": "カート追加成功。",
+          "when": "商品が正常にカートに追加 (または数量加算) された場合。"
+        },
+        {
+          "id": "400-validation",
+          "status": 400,
+          "bodySchema": { "typeRef": "retail:ApiError" },
+          "description": "バリデーションエラー。",
+          "when": "productCode や quantity が不正な場合。"
+        },
+        {
+          "id": "404-product-not-found",
+          "status": 404,
+          "bodySchema": { "typeRef": "retail:ApiError" },
+          "description": "商品が存在しない。",
+          "when": "productCode に対応する販売中商品が products に存在しない場合。"
+        },
+        {
+          "id": "422-cart-limit",
+          "status": 422,
+          "bodySchema": { "typeRef": "retail:ApiError" },
+          "description": "カート明細上限超過。",
+          "when": "追加後の cart_items 件数が @conv.limit.cartMaxItems を超える場合。"
+        }
+      ],
+      "steps": [
+        {
+          "id": "step-01",
+          "kind": "validation",
+          "description": "productCode 必須チェック + パターン検証。quantity 範囲チェック (1 以上 @conv.limit.cartItemMaxQuantity 以下)。",
+          "conditions": "productCode は必須かつ @conv.regex.productCode 準拠。quantity は 1〜999 の整数。",
+          "rules": [
+            {
+              "field": "productCode",
+              "type": "required",
+              "severity": "error",
+              "message": "商品コードは必須です。"
+            },
+            {
+              "field": "productCode",
+              "type": "regex",
+              "patternRef": "@conv.regex.productCode",
+              "severity": "error",
+              "message": "商品コードの形式が不正です。"
+            },
+            {
+              "field": "quantity",
+              "type": "required",
+              "severity": "error",
+              "message": "数量は必須です。"
+            },
+            {
+              "field": "quantity",
+              "type": "range",
+              "min": 1,
+              "maxRef": "@conv.limit.cartItemMaxQuantity",
+              "severity": "error",
+              "message": "数量は 1 以上 999 以下で指定してください。"
+            }
+          ],
+          "fieldErrorsVar": "fieldErrors",
+          "inlineBranch": {
+            "ok": [],
+            "ng": [
+              {
+                "id": "step-01-ng-01",
+                "kind": "return",
+                "description": "400 バリデーションエラーを返す。",
+                "responseId": "400-validation",
+                "bodyExpression": "{ code: 'VALIDATION_ERROR', message: '入力値が不正です。', fieldErrors: @fieldErrors }"
+              }
+            ]
+          }
+        },
+        {
+          "id": "step-02",
+          "kind": "dbAccess",
+          "description": "products テーブルで商品の存在確認と単価取得を行う。is_active=TRUE の販売中商品のみ対象。",
+          "tableId": "652cbbfe-17e2-4f23-a0c9-4403e6b23bb0",
+          "operation": "SELECT",
+          "sql": "SELECT id, product_code, name, unit_price FROM products WHERE product_code = @inputs.productCode AND is_active = TRUE",
+          "outputBinding": { "name": "product" },
+          "lineage": {
+            "reads": [{ "tableId": "652cbbfe-17e2-4f23-a0c9-4403e6b23bb0", "purpose": "lookup" }]
+          }
+        },
+        {
+          "id": "step-03",
+          "kind": "branch",
+          "description": "商品が存在しない場合は 404 を返す。",
+          "branches": [
+            {
+              "id": "br-03-a",
+              "code": "A",
+              "label": "商品なし",
+              "condition": {
+                "kind": "expression",
+                "expression": "@product == null || @product === undefined"
+              },
+              "steps": [
+                {
+                  "id": "step-03-a-01",
+                  "kind": "return",
+                  "description": "404 商品なしを返す。",
+                  "responseId": "404-product-not-found",
+                  "bodyExpression": "{ code: 'PRODUCT_NOT_FOUND', message: '商品コード ' + @inputs.productCode + ' の商品が見つかりません。' }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-03-else",
+            "code": "B",
+            "label": "商品あり",
+            "steps": []
+          }
+        },
+        {
+          "id": "step-04",
+          "kind": "dbAccess",
+          "description": "sessionCustomerId に紐づくカートを取得する。存在しない場合は null が返る。",
+          "tableId": "a32e1a09-bcbc-467f-86b0-983cd7ee61c6",
+          "operation": "SELECT",
+          "sql": "SELECT id, customer_id, status FROM carts WHERE customer_id = @sessionCustomerId AND status = 'active'",
+          "outputBinding": { "name": "cart" },
+          "lineage": {
+            "reads": [{ "tableId": "a32e1a09-bcbc-467f-86b0-983cd7ee61c6", "purpose": "lookup" }]
+          }
+        },
+        {
+          "id": "step-05",
+          "kind": "branch",
+          "description": "カートが存在しない場合は新規作成する。",
+          "branches": [
+            {
+              "id": "br-05-a",
+              "code": "A",
+              "label": "カートなし — 新規作成",
+              "condition": {
+                "kind": "expression",
+                "expression": "@cart == null || @cart === undefined"
+              },
+              "steps": [
+                {
+                  "id": "step-05-a-01",
+                  "kind": "dbAccess",
+                  "description": "新規カートを INSERT する。",
+                  "tableId": "a32e1a09-bcbc-467f-86b0-983cd7ee61c6",
+                  "operation": "INSERT",
+                  "sql": "INSERT INTO carts (customer_id, status) VALUES (@sessionCustomerId, 'active') RETURNING id, customer_id, status",
+                  "outputBinding": { "name": "cart" },
+                  "lineage": {
+                    "writes": [{ "tableId": "a32e1a09-bcbc-467f-86b0-983cd7ee61c6", "purpose": "lookup" }]
+                  }
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-05-else",
+            "code": "B",
+            "label": "カートあり — そのまま使用",
+            "steps": []
+          }
+        },
+        {
+          "id": "step-06",
+          "kind": "dbAccess",
+          "description": "現在の cart_items 件数を取得して上限チェックに使用する。",
+          "tableId": "57110336-a984-4d39-bb21-1e5d5bb4390b",
+          "operation": "SELECT",
+          "sql": "SELECT COUNT(*) AS item_count FROM cart_items WHERE cart_id = @cart.id",
+          "outputBinding": { "name": "cartItemCount" },
+          "lineage": {
+            "reads": [{ "tableId": "57110336-a984-4d39-bb21-1e5d5bb4390b", "purpose": "lookup" }]
+          }
+        },
+        {
+          "id": "step-07",
+          "kind": "branch",
+          "description": "cart_items 件数が @conv.limit.cartMaxItems に達している場合は 422 を返す。既存商品の数量加算は上限カウント対象外 (UPSERT_CART_ITEM が判定)。",
+          "branches": [
+            {
+              "id": "br-07-a",
+              "code": "A",
+              "label": "上限超過",
+              "condition": {
+                "kind": "expression",
+                "expression": "@cartItemCount.item_count >= @conv.limit.cartMaxItems"
+              },
+              "steps": [
+                {
+                  "id": "step-07-a-01",
+                  "kind": "return",
+                  "description": "422 カート上限超過を返す。",
+                  "responseId": "422-cart-limit",
+                  "bodyExpression": "{ code: 'CART_ITEMS_LIMIT_EXCEEDED', message: 'カート内の商品点数が上限 (' + @conv.limit.cartMaxItems + ' 件) に達しています。' }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-07-else",
+            "code": "B",
+            "label": "上限未満 — 追加続行",
+            "steps": []
+          }
+        },
+        {
+          "id": "step-08",
+          "kind": "dbAccess",
+          "description": "cart_items に (cart_id, product_id) で UPSERT する。重複の場合は quantity を加算し unit_price_snapshot を最新値で更新する。",
+          "tableId": "57110336-a984-4d39-bb21-1e5d5bb4390b",
+          "operation": "retail:UPSERT_CART_ITEM",
+          "sql": "INSERT INTO cart_items (cart_id, product_id, unit_price_snapshot, quantity) VALUES (@cart.id, @product.id, @product.unit_price, @inputs.quantity) ON CONFLICT (cart_id, product_id) DO UPDATE SET quantity = cart_items.quantity + EXCLUDED.quantity, unit_price_snapshot = EXCLUDED.unit_price_snapshot, updated_at = CURRENT_TIMESTAMP RETURNING id",
+          "outputBinding": { "name": "upsertedCartItem" },
+          "affectedRowsCheck": {
+            "operator": "=",
+            "expected": 1,
+            "onViolation": "throw",
+            "errorCode": "VALIDATION_ERROR",
+            "description": "UPSERT_CART_ITEM は必ず 1 行を返す。0 行は異常。"
+          },
+          "lineage": {
+            "writes": [{ "tableId": "57110336-a984-4d39-bb21-1e5d5bb4390b", "purpose": "lookup" }]
+          }
+        },
+        {
+          "id": "step-09",
+          "kind": "eventPublish",
+          "description": "retail.cart.item_added イベントを発行する。",
+          "topic": "retail.cart.item_added",
+          "payload": "{ cartId: @cart.id, productId: @product.id, quantity: @inputs.quantity }"
+        },
+        {
+          "id": "step-10",
+          "kind": "return",
+          "description": "200 OK — カート追加成功を返す。",
+          "responseId": "200-ok",
+          "bodyExpression": "{ cartId: @cart.id, cartItemId: @upsertedCartItem.id, productName: @product.name, message: @product.name + ' をカートに追加しました。' }"
+        }
+      ]
+    }
+  ],
+  "authoring": {
+    "decisions": [
+      {
+        "id": "ADR-001",
+        "title": "UPSERT_CART_ITEM で重複排除を行う",
+        "status": "accepted",
+        "context": "同一商品を複数回カートに追加した場合の挙動を決定する必要があった。",
+        "decision": "retail:UPSERT_CART_ITEM (ON CONFLICT DO UPDATE) で quantity を加算し、重複行を作らない。unit_price_snapshot は最新値で更新する。",
+        "consequences": "複数回追加しても cart_items は 1 行に集約される。上限カウントは UPSERT 前に行うため、既存商品の数量加算は上限対象外となる。",
+        "date": "2026-05-02"
+      },
+      {
+        "id": "ADR-002",
+        "title": "カート取得/作成は TX なし — ロスト更新はセッション 1:1 設計で防ぐ",
+        "status": "accepted",
+        "context": "カート取得と作成の間に別セッションが同時に INSERT する競合を検討した。",
+        "decision": "carts テーブルには customer_id UNIQUE 制約があるため、重複 INSERT は DB 側で弾かれる。エラー時は再取得して続行するのが実装容易で十分。",
+        "consequences": "同一顧客の並行リクエスト時に稀に DB エラーが発生するが、リトライで解決できる。",
+        "date": "2026-05-02"
+      }
+    ],
+    "glossary": {
+      "カート追加": {
+        "definition": "ログイン顧客のカートに指定商品と数量を追加する操作。既に同じ商品がカートにある場合は数量を加算する (重複排除)。",
+        "aliases": ["AddToCart", "カートへ追加"],
+        "domainRef": "cart_items"
+      },
+      "単価スナップショット": {
+        "definition": "カート追加時点の products.unit_price を cart_items.unit_price_snapshot に記録する値。注文確定時も同値を order_items にコピーするため、マスタ変更の影響を受けない。",
+        "aliases": ["UnitPriceSnapshot"],
+        "domainRef": "cart_items.unit_price_snapshot"
+      }
+    },
+    "testScenarios": [
+      {
+        "id": "happy-path-new-item",
+        "name": "新規商品をカートに追加する",
+        "description": "カートに存在しない商品を初回追加する正常系。カートも初回作成。",
+        "given": [
+          {
+            "kind": "sessionContext",
+            "context": { "sessionCustomerId": 100 }
+          },
+          {
+            "kind": "dbState",
+            "tableId": "652cbbfe-17e2-4f23-a0c9-4403e6b23bb0",
+            "rows": [{ "id": 1, "product_code": "P-0001", "name": "サンプル商品A", "unit_price": 1000, "is_active": true }]
+          },
+          {
+            "kind": "dbState",
+            "tableId": "a32e1a09-bcbc-467f-86b0-983cd7ee61c6",
+            "rows": []
+          },
+          {
+            "kind": "dbState",
+            "tableId": "57110336-a984-4d39-bb21-1e5d5bb4390b",
+            "rows": []
+          }
+        ],
+        "when": { "actionId": "act-001", "input": { "productCode": "P-0001", "quantity": 2 } },
+        "then": [
+          { "kind": "outcome", "expected": "200-ok" },
+          { "kind": "output", "path": "$.productName", "equals": "サンプル商品A" }
+        ],
+        "tags": ["happy", "s2"]
+      },
+      {
+        "id": "duplicate-item-quantity-added",
+        "name": "同一商品の重複追加は数量加算になる",
+        "description": "カートに既に存在する商品を追加した場合、UPSERT で quantity が加算される。",
+        "given": [
+          {
+            "kind": "sessionContext",
+            "context": { "sessionCustomerId": 100 }
+          },
+          {
+            "kind": "dbState",
+            "tableId": "652cbbfe-17e2-4f23-a0c9-4403e6b23bb0",
+            "rows": [{ "id": 1, "product_code": "P-0001", "name": "サンプル商品A", "unit_price": 1000, "is_active": true }]
+          },
+          {
+            "kind": "dbState",
+            "tableId": "a32e1a09-bcbc-467f-86b0-983cd7ee61c6",
+            "rows": [{ "id": 50, "customer_id": 100, "status": "active" }]
+          },
+          {
+            "kind": "dbState",
+            "tableId": "57110336-a984-4d39-bb21-1e5d5bb4390b",
+            "rows": [{ "id": 200, "cart_id": 50, "product_id": 1, "unit_price_snapshot": 1000, "quantity": 3 }]
+          }
+        ],
+        "when": { "actionId": "act-001", "input": { "productCode": "P-0001", "quantity": 2 } },
+        "then": [
+          { "kind": "outcome", "expected": "200-ok" }
+        ],
+        "tags": ["upsert", "s2"]
+      },
+      {
+        "id": "validation-error-invalid-quantity",
+        "name": "quantity=0 で 400",
+        "description": "数量 0 は range バリデーションで拒否される。",
+        "given": [
+          { "kind": "sessionContext", "context": { "sessionCustomerId": 100 } }
+        ],
+        "when": { "actionId": "act-001", "input": { "productCode": "P-0001", "quantity": 0 } },
+        "then": [
+          { "kind": "outcome", "expected": "400-validation" }
+        ],
+        "tags": ["error", "validation", "s2"]
+      }
+    ]
+  }
+}

--- a/samples/retail/actions/d63c703c-26ed-4704-8b76-329c6bfae9c9.json
+++ b/samples/retail/actions/d63c703c-26ed-4704-8b76-329c6bfae9c9.json
@@ -1,0 +1,568 @@
+{
+  "$schema": "../../../schemas/v3/process-flow.v3.schema.json",
+  "meta": {
+    "id": "d63c703c-26ed-4704-8b76-329c6bfae9c9",
+    "name": "配送指示",
+    "description": "バックオフィス担当者が注文一覧から対象注文を選択し、外部キャリア API (retail:DispatchShipment) に配送指示を送信する。成功時は orders.status を 'shipped' に更新し、retail.shipment.dispatched イベントを発行する。外部 API 失敗時は補償処理を実行してエラーを返す。",
+    "kind": "screen",
+    "maturity": "committed",
+    "createdAt": "2026-05-02T00:00:00.000Z",
+    "updatedAt": "2026-05-02T00:00:00.000Z"
+  },
+  "context": {
+    "catalogs": {
+      "errors": {
+        "VALIDATION_ERROR": {
+          "httpStatus": 400,
+          "defaultMessage": "入力値が不正です。",
+          "responseId": "400-validation",
+          "description": "orderId 未指定、carrierId 未指定などのバリデーションエラー。"
+        },
+        "ORDER_NOT_FOUND": {
+          "httpStatus": 404,
+          "defaultMessage": "指定の注文が見つかりません。",
+          "responseId": "404-order-not-found",
+          "description": "指定 orderId の注文が存在しないか、配送指示対象ステータス ('pending' または 'confirmed') でない。"
+        },
+        "CARRIER_API_FAILED": {
+          "httpStatus": 502,
+          "defaultMessage": "配送キャリア API との通信に失敗しました。",
+          "responseId": "502-carrier-api-failed",
+          "description": "外部キャリア API が 5xx または timeout を返した場合。orders.status は変更しない。"
+        }
+      },
+      "externalSystems": {
+        "carrierApi": {
+          "name": "外部配送キャリア API",
+          "baseUrl": "https://carrier.retail.example.internal",
+          "auth": {
+            "kind": "apiKey",
+            "tokenRef": "@secret.carrierApiKey",
+            "headerName": "X-Carrier-API-Key"
+          },
+          "timeoutMs": 15000,
+          "retryPolicy": {
+            "maxAttempts": 2,
+            "backoff": "exponential",
+            "initialDelayMs": 1000
+          },
+          "description": "配送指示・追跡番号取得を行う外部キャリア API。retail:DispatchShipment 拡張 step で利用する。"
+        }
+      },
+      "secrets": {
+        "carrierApiKey": {
+          "source": "env",
+          "name": "CARRIER_API_KEY",
+          "rotationDays": 90,
+          "description": "外部配送キャリア API の認証キー。"
+        }
+      },
+      "events": {
+        "retail.shipment.dispatched": {
+          "description": "配送指示が正常完了し、追跡番号を取得した後に発行する。出荷通知メール送信などの下流処理のトリガーとなる。",
+          "payload": {
+            "type": "object",
+            "required": ["orderId", "orderNumber", "trackingNumber", "carrierId"],
+            "properties": {
+              "orderId": { "type": "number" },
+              "orderNumber": { "type": "string" },
+              "trackingNumber": { "type": "string" },
+              "carrierId": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+    "ambientVariables": [
+      {
+        "name": "sessionUserId",
+        "type": "string",
+        "required": true,
+        "description": "バックオフィス担当者のユーザー ID (監査ログ用)。"
+      }
+    ]
+  },
+  "actions": [
+    {
+      "id": "act-001",
+      "name": "配送指示実行",
+      "trigger": "submit",
+      "description": "注文 ID とキャリア情報を受け取り、外部キャリア API に配送指示を送信後、注文ステータスを 'shipped' に更新する。",
+      "maturity": "committed",
+      "httpRoute": {
+        "method": "POST",
+        "path": "/api/retail/orders/:orderId/dispatch",
+        "auth": "required"
+      },
+      "inputs": [
+        {
+          "name": "orderId",
+          "label": "注文ID",
+          "type": "integer",
+          "required": true,
+          "description": "配送指示を行う注文の ID。"
+        },
+        {
+          "name": "carrierId",
+          "label": "キャリア",
+          "type": "string",
+          "required": true,
+          "description": "使用する配送キャリアの識別子 (例: yamato / sagawa / jp-post)。"
+        },
+        {
+          "name": "preferredDate",
+          "label": "希望配送日",
+          "type": "string",
+          "required": false,
+          "description": "希望配送日 (YYYY-MM-DD 形式)。省略時はキャリア側の標準日程。"
+        },
+        {
+          "name": "timeSlot",
+          "label": "希望時間帯",
+          "type": "string",
+          "required": false,
+          "description": "morning / afternoon / evening / any のいずれか。"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "trackingNumber",
+          "label": "追跡番号",
+          "type": "string",
+          "description": "キャリア API から返された追跡番号。"
+        },
+        {
+          "name": "estimatedDelivery",
+          "label": "配達予定日",
+          "type": "date",
+          "description": "キャリア API から返された配達予定日。"
+        }
+      ],
+      "responses": [
+        {
+          "id": "200-ok",
+          "status": 200,
+          "bodySchema": { "typeRef": "retail:DispatchShipmentResponse" },
+          "description": "配送指示成功。",
+          "when": "外部 API への配送指示が成功し、orders.status が 'shipped' に更新された場合。"
+        },
+        {
+          "id": "400-validation",
+          "status": 400,
+          "bodySchema": { "typeRef": "retail:ApiError" },
+          "description": "バリデーションエラー。",
+          "when": "orderId / carrierId が不正な場合。"
+        },
+        {
+          "id": "404-order-not-found",
+          "status": 404,
+          "bodySchema": { "typeRef": "retail:ApiError" },
+          "description": "注文が存在しないか配送指示対象外のステータス。",
+          "when": "orders に対象レコードが存在しないか、status が 'shipped' / 'delivered' / 'cancelled' の場合。"
+        },
+        {
+          "id": "502-carrier-api-failed",
+          "status": 502,
+          "bodySchema": { "typeRef": "retail:ApiError" },
+          "description": "外部キャリア API 失敗。orders.status は変更していない。",
+          "when": "外部キャリア API がエラーまたは timeout を返した場合。"
+        }
+      ],
+      "steps": [
+        {
+          "id": "step-01",
+          "kind": "validation",
+          "description": "orderId 必須チェック (1 以上の整数)。carrierId 必須チェック (非空)。",
+          "conditions": "orderId は 1 以上の整数。carrierId は非空文字列。",
+          "rules": [
+            {
+              "field": "orderId",
+              "type": "required",
+              "severity": "error",
+              "message": "注文 ID は必須です。"
+            },
+            {
+              "field": "orderId",
+              "type": "range",
+              "min": 1,
+              "severity": "error",
+              "message": "注文 ID は 1 以上の整数で指定してください。"
+            },
+            {
+              "field": "carrierId",
+              "type": "required",
+              "severity": "error",
+              "message": "配送キャリアは必須です。"
+            }
+          ],
+          "fieldErrorsVar": "fieldErrors",
+          "inlineBranch": {
+            "ok": [],
+            "ng": [
+              {
+                "id": "step-01-ng-01",
+                "kind": "return",
+                "description": "400 バリデーションエラーを返す。",
+                "responseId": "400-validation",
+                "bodyExpression": "{ code: 'VALIDATION_ERROR', message: '入力値が不正です。', fieldErrors: @fieldErrors }"
+              }
+            ]
+          }
+        },
+        {
+          "id": "step-02",
+          "kind": "dbAccess",
+          "description": "注文を取得する。配送指示対象は status が 'pending' または 'confirmed' のみ。",
+          "tableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab",
+          "operation": "SELECT",
+          "sql": "SELECT id, order_number, customer_id, status, total_amount, shipping_postal_code, shipping_address FROM orders WHERE id = @inputs.orderId AND status IN ('pending', 'confirmed')",
+          "outputBinding": { "name": "order" },
+          "lineage": {
+            "reads": [{ "tableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab", "purpose": "lookup" }]
+          }
+        },
+        {
+          "id": "step-03",
+          "kind": "branch",
+          "description": "注文が存在しないか配送指示対象外ステータスの場合は 404 を返す。null guard を含む。",
+          "branches": [
+            {
+              "id": "br-03-a",
+              "code": "A",
+              "label": "注文なし / 対象外ステータス",
+              "condition": {
+                "kind": "expression",
+                "expression": "@order == null || @order === undefined"
+              },
+              "steps": [
+                {
+                  "id": "step-03-a-01",
+                  "kind": "return",
+                  "description": "404 注文なし / 対象外を返す。",
+                  "responseId": "404-order-not-found",
+                  "bodyExpression": "{ code: 'ORDER_NOT_FOUND', message: '注文 ID ' + @inputs.orderId + ' は存在しないか、配送指示対象外のステータスです。' }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-03-else",
+            "code": "B",
+            "label": "注文あり — 続行",
+            "steps": []
+          }
+        },
+        {
+          "id": "step-04",
+          "kind": "audit",
+          "description": "配送指示操作を監査ログに記録する。担当者 ID と注文情報を含む。",
+          "action": "order.dispatch",
+          "resource": {
+            "type": "order",
+            "id": "@inputs.orderId"
+          },
+          "result": "success",
+          "reason": "配送指示操作開始 by @sessionUserId"
+        },
+        {
+          "id": "step-05",
+          "kind": "ExtensionStep",
+          "description": "外部キャリア API に配送指示を送信する (retail:DispatchShipment)。追跡番号と配達予定日を受け取る。失敗時は 502 を返し、orders.status を変更しない。",
+          "kind": "retail:DispatchShipment",
+          "config": {
+            "carrierId": "@inputs.carrierId",
+            "orderId": "@order.id",
+            "shippingAddress": "@order.shipping_address",
+            "preferredDate": "@inputs.preferredDate",
+            "timeSlot": "@inputs.timeSlot"
+          },
+          "outputBinding": { "name": "dispatchResult" },
+          "sla": {
+            "timeoutMs": 15000,
+            "onTimeout": "throw",
+            "errorCode": "CARRIER_API_FAILED"
+          }
+        },
+        {
+          "id": "step-06",
+          "kind": "branch",
+          "description": "外部キャリア API の結果に応じて分岐する。失敗時は補償処理 (監査ログ記録) を実行して 502 を返す。",
+          "branches": [
+            {
+              "id": "br-06-fail",
+              "code": "A",
+              "label": "キャリア API 失敗",
+              "condition": {
+                "kind": "expression",
+                "expression": "@dispatchResult == null || @dispatchResult.trackingNumber == null"
+              },
+              "steps": [
+                {
+                  "id": "step-06-a-01",
+                  "kind": "audit",
+                  "description": "配送指示失敗を監査ログに記録する。補償ログとして機能する。",
+                  "action": "order.dispatch.failed",
+                  "resource": {
+                    "type": "order",
+                    "id": "@inputs.orderId"
+                  },
+                  "result": "failure",
+                  "reason": "キャリア API からの応答が不正または null (追跡番号なし)"
+                },
+                {
+                  "id": "step-06-a-02",
+                  "kind": "log",
+                  "description": "キャリア API 失敗の詳細をログに記録する。",
+                  "level": "error",
+                  "message": "配送指示失敗: キャリア API が無効な応答を返しました。",
+                  "category": "order.dispatch",
+                  "structuredData": {
+                    "orderId": "@inputs.orderId",
+                    "carrierId": "@inputs.carrierId",
+                    "dispatchResult": "@dispatchResult"
+                  }
+                },
+                {
+                  "id": "step-06-a-03",
+                  "kind": "return",
+                  "description": "502 キャリア API 失敗を返す。orders.status は 'pending' のまま変更していない。",
+                  "responseId": "502-carrier-api-failed",
+                  "bodyExpression": "{ code: 'CARRIER_API_FAILED', message: '配送キャリア API との通信に失敗しました。しばらく経ってから再試行してください。' }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-06-else",
+            "code": "B",
+            "label": "キャリア API 成功",
+            "steps": []
+          }
+        },
+        {
+          "id": "step-07",
+          "kind": "dbAccess",
+          "description": "追跡番号取得後、orders.status を 'shipped' に更新する。",
+          "tableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab",
+          "operation": "UPDATE",
+          "sql": "UPDATE orders SET status = 'shipped', updated_at = CURRENT_TIMESTAMP WHERE id = @inputs.orderId AND status IN ('pending', 'confirmed')",
+          "affectedRowsCheck": {
+            "operator": "=",
+            "expected": 1,
+            "onViolation": "throw",
+            "errorCode": "ORDER_NOT_FOUND",
+            "description": "0 件更新 = 注文が存在しないか既に shipped に変更済み。"
+          },
+          "lineage": {
+            "writes": [{ "tableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab", "purpose": "lookup" }]
+          }
+        },
+        {
+          "id": "step-08",
+          "kind": "eventPublish",
+          "description": "retail.shipment.dispatched イベントを発行する。下流の出荷通知メール (retail:SendOrderConfirmEmail) や在庫 CDC が購読する。",
+          "topic": "retail.shipment.dispatched",
+          "payload": "{ orderId: @order.id, orderNumber: @order.order_number, trackingNumber: @dispatchResult.trackingNumber, carrierId: @inputs.carrierId }"
+        },
+        {
+          "id": "step-09",
+          "kind": "return",
+          "description": "200 OK — 配送指示成功を返す。",
+          "responseId": "200-ok",
+          "bodyExpression": "{ trackingNumber: @dispatchResult.trackingNumber, estimatedDelivery: @dispatchResult.estimatedDelivery, message: '注文 ' + @order.order_number + ' の配送指示が完了しました。追跡番号: ' + @dispatchResult.trackingNumber }"
+        }
+      ]
+    }
+  ],
+  "authoring": {
+    "decisions": [
+      {
+        "id": "ADR-001",
+        "title": "外部 API 成功確認後に orders.status を更新する",
+        "status": "accepted",
+        "context": "外部キャリア API への配送指示とステータス更新の順序を決定する必要があった。",
+        "decision": "外部 API 呼び出しが成功し追跡番号を取得した後に orders.status を 'shipped' に更新する。外部 API 失敗時は orders.status を変更しない。",
+        "consequences": "API 成功後の UPDATE が失敗した場合は状態の不整合が生じる可能性がある。この場合は監査ログから手動復旧するオペレーション手順を設ける。",
+        "date": "2026-05-02"
+      },
+      {
+        "id": "ADR-002",
+        "title": "外部 API 失敗時は補償として監査ログを記録し 502 を返す",
+        "status": "accepted",
+        "context": "外部キャリア API が失敗した場合の補償処理を設計する必要があった。",
+        "decision": "外部 API 失敗 (null response / timeout) を検出した場合、audit step で失敗ログを記録し 502 を返す。orders.status は変更しない (ロールバックは不要)。担当者が再試行できる。",
+        "consequences": "補償処理はベストエフォート (audit step 自体の失敗は無視)。監査ログで担当者が失敗を検知して手動再試行するフローが前提。",
+        "date": "2026-05-02"
+      },
+      {
+        "id": "ADR-003",
+        "title": "dispatchResult の null guard を明示する",
+        "status": "accepted",
+        "context": "ExtensionStep の戻り値が null の場合の安全な処理が必要だった。",
+        "decision": "@dispatchResult == null || @dispatchResult.trackingNumber == null をガード条件とし、null 参照エラーを防ぐ。",
+        "consequences": "キャリア API が trackingNumber を含まない正常レスポンスを返した場合も失敗として扱われる (業務的に正しい判定)。",
+        "date": "2026-05-02"
+      }
+    ],
+    "glossary": {
+      "配送指示": {
+        "definition": "外部配送キャリア API に注文の出荷を依頼し、追跡番号を取得するバックオフィス操作。",
+        "aliases": ["DispatchShipment", "出荷指示"],
+        "domainRef": "orders"
+      },
+      "追跡番号": {
+        "definition": "外部キャリアが発行する配送追跡用の識別番号。顧客への出荷通知メールに含める。",
+        "aliases": ["TrackingNumber", "伝票番号"],
+        "domainRef": "shipment"
+      }
+    },
+    "testScenarios": [
+      {
+        "id": "happy-path-dispatch",
+        "name": "配送指示が成功して追跡番号が返る",
+        "description": "status='pending' の注文に対してキャリア API が正常応答し、orders.status が 'shipped' に更新される。",
+        "given": [
+          {
+            "kind": "sessionContext",
+            "context": { "sessionUserId": "staff-001" }
+          },
+          {
+            "kind": "dbState",
+            "tableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab",
+            "rows": [
+              {
+                "id": 300,
+                "order_number": "ORD-2026-000001",
+                "customer_id": 100,
+                "status": "pending",
+                "total_amount": 5000,
+                "shipping_postal_code": "1600022",
+                "shipping_address": "東京都新宿区新宿1-1-1"
+              }
+            ]
+          },
+          {
+            "kind": "externalStub",
+            "externalRef": "carrierApi",
+            "responseMock": {
+              "trackingNumber": "TRK-20260502-001",
+              "estimatedDelivery": "2026-05-04",
+              "carrierId": "yamato"
+            }
+          }
+        ],
+        "when": {
+          "actionId": "act-001",
+          "input": {
+            "orderId": 300,
+            "carrierId": "yamato",
+            "preferredDate": "2026-05-04",
+            "timeSlot": "afternoon"
+          }
+        },
+        "then": [
+          { "kind": "outcome", "expected": "200-ok" },
+          { "kind": "output", "path": "$.trackingNumber", "equals": "TRK-20260502-001" }
+        ],
+        "tags": ["happy", "s4"]
+      },
+      {
+        "id": "carrier-api-failure-502",
+        "name": "キャリア API 失敗で 502 — orders.status は変更なし",
+        "description": "外部キャリア API が null 応答を返した場合、補償ログを記録して 502 を返す。orders.status は 'pending' のまま。",
+        "given": [
+          {
+            "kind": "sessionContext",
+            "context": { "sessionUserId": "staff-001" }
+          },
+          {
+            "kind": "dbState",
+            "tableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab",
+            "rows": [
+              {
+                "id": 301,
+                "order_number": "ORD-2026-000002",
+                "customer_id": 100,
+                "status": "pending",
+                "total_amount": 3000,
+                "shipping_postal_code": "5310073",
+                "shipping_address": "大阪府大阪市北区梅田1-2-3"
+              }
+            ]
+          },
+          {
+            "kind": "externalStub",
+            "externalRef": "carrierApi",
+            "responseMock": null
+          }
+        ],
+        "when": {
+          "actionId": "act-001",
+          "input": { "orderId": 301, "carrierId": "sagawa" }
+        },
+        "then": [
+          { "kind": "outcome", "expected": "502-carrier-api-failed" }
+        ],
+        "tags": ["error", "external-api", "s4"]
+      },
+      {
+        "id": "order-not-found-404",
+        "name": "存在しない注文 ID で 404",
+        "description": "orders に該当レコードがない場合は 404 を返す。",
+        "given": [
+          {
+            "kind": "sessionContext",
+            "context": { "sessionUserId": "staff-001" }
+          },
+          {
+            "kind": "dbState",
+            "tableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab",
+            "rows": []
+          }
+        ],
+        "when": {
+          "actionId": "act-001",
+          "input": { "orderId": 9999, "carrierId": "yamato" }
+        },
+        "then": [
+          { "kind": "outcome", "expected": "404-order-not-found" }
+        ],
+        "tags": ["error", "not-found", "s4"]
+      },
+      {
+        "id": "already-shipped-404",
+        "name": "配送済み注文への指示は 404 (対象外ステータス)",
+        "description": "status='shipped' の注文は配送指示対象外なので 404 を返す。",
+        "given": [
+          {
+            "kind": "sessionContext",
+            "context": { "sessionUserId": "staff-001" }
+          },
+          {
+            "kind": "dbState",
+            "tableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab",
+            "rows": [
+              {
+                "id": 302,
+                "order_number": "ORD-2026-000003",
+                "customer_id": 100,
+                "status": "shipped",
+                "total_amount": 2000,
+                "shipping_postal_code": "1600022",
+                "shipping_address": "東京都新宿区新宿1-1-1"
+              }
+            ]
+          }
+        ],
+        "when": {
+          "actionId": "act-001",
+          "input": { "orderId": 302, "carrierId": "jp-post" }
+        },
+        "then": [
+          { "kind": "outcome", "expected": "404-order-not-found" }
+        ],
+        "tags": ["error", "invalid-status", "s4"]
+      }
+    ]
+  }
+}

--- a/samples/retail/actions/efa7ac6e-e295-416e-b68d-17c4739b5097.json
+++ b/samples/retail/actions/efa7ac6e-e295-416e-b68d-17c4739b5097.json
@@ -1,0 +1,497 @@
+{
+  "$schema": "../../../schemas/v3/process-flow.v3.schema.json",
+  "meta": {
+    "id": "efa7ac6e-e295-416e-b68d-17c4739b5097",
+    "name": "店舗在庫照会",
+    "description": "商品コード + 店舗コードで inventory を検索し、低在庫閾値 (@conv.limit.lowStockThreshold) を満たす行に警告フラグを付与して返す。読取専用フロー (TX 不要)。",
+    "kind": "screen",
+    "maturity": "committed",
+    "createdAt": "2026-05-02T00:00:00.000Z",
+    "updatedAt": "2026-05-02T00:00:00.000Z"
+  },
+  "context": {
+    "catalogs": {
+      "errors": {
+        "VALIDATION_ERROR": {
+          "httpStatus": 400,
+          "defaultMessage": "入力値が不正です。",
+          "responseId": "400-validation",
+          "description": "storeCode 未指定、または productCode がパターン違反の場合に返す。"
+        },
+        "PRODUCT_NOT_FOUND": {
+          "httpStatus": 404,
+          "defaultMessage": "指定の商品が見つかりません。",
+          "responseId": "404-product-not-found",
+          "description": "productCode を指定したが products に該当レコードが存在しない場合に返す。"
+        }
+      },
+      "events": {
+        "retail.inventory.searched": {
+          "description": "在庫照会が完了し、1 件以上の在庫レコードを返した時点で発行する。",
+          "payload": {
+            "type": "object",
+            "required": ["storeCode", "resultCount"],
+            "properties": {
+              "storeCode": { "type": "string" },
+              "productCode": { "type": "string" },
+              "resultCount": { "type": "number" }
+            }
+          }
+        },
+        "retail.inventory.low_stock_detected": {
+          "description": "照会結果の中に quantity_available が lowStockThreshold 以下の行が 1 件以上あった場合に発行する。",
+          "payload": {
+            "type": "object",
+            "required": ["storeCode", "productId", "quantityAvailable"],
+            "properties": {
+              "storeCode": { "type": "string" },
+              "productId": { "type": "number" },
+              "quantityAvailable": { "type": "number" }
+            }
+          }
+        },
+        "retail.inventory.not_found": {
+          "description": "照会条件に一致する在庫レコードが 0 件だった場合に発行する。",
+          "payload": {
+            "type": "object",
+            "required": ["storeCode"],
+            "properties": {
+              "storeCode": { "type": "string" },
+              "productCode": { "type": "string" }
+            }
+          }
+        }
+      },
+      "domains": {
+        "ProductCode": {
+          "type": "string",
+          "uiHint": "text",
+          "constraints": [
+            {
+              "field": "productCode",
+              "type": "regex",
+              "pattern": "^P-[0-9]{4,6}$",
+              "severity": "error",
+              "message": "商品コードは 'P-' + 4〜6 桁数字の形式で入力してください (例: P-0001)。"
+            }
+          ],
+          "description": "商品コード。@conv.regex.productCode 準拠。"
+        }
+      }
+    },
+    "ambientVariables": [
+      {
+        "name": "requestId",
+        "type": "string",
+        "description": "リクエスト単位の追跡 ID (ミドルウェア自動付与)。"
+      },
+      {
+        "name": "sessionUserId",
+        "type": "string",
+        "description": "ログインユーザー ID。ゲスト閲覧時は null。"
+      }
+    ]
+  },
+  "actions": [
+    {
+      "id": "act-001",
+      "name": "在庫照会実行",
+      "trigger": "submit",
+      "description": "店舗コード (必須) と商品コード (任意) で inventory + products を JOIN 検索し、低在庫フラグ付きの在庫一覧を返す。",
+      "maturity": "committed",
+      "httpRoute": {
+        "method": "GET",
+        "path": "/api/retail/inventory",
+        "auth": "optional"
+      },
+      "inputs": [
+        {
+          "name": "storeCode",
+          "label": "店舗コード",
+          "type": "string",
+          "required": true,
+          "description": "検索対象の店舗コード。inventory.store_id の結合キー。"
+        },
+        {
+          "name": "productCode",
+          "label": "商品コード",
+          "type": "string",
+          "required": false,
+          "description": "商品コードによる絞り込み。省略時は店舗全商品を返す。"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "items",
+          "label": "在庫一覧",
+          "type": { "kind": "array", "itemType": "json" },
+          "description": "在庫行 (product_code / product_name / quantity_available / quantity_reserved / isLowStock フラグ) の配列。"
+        },
+        {
+          "name": "totalCount",
+          "label": "件数",
+          "type": "integer",
+          "description": "返却された在庫レコードの総件数。"
+        }
+      ],
+      "responses": [
+        {
+          "id": "200-ok",
+          "status": 200,
+          "bodySchema": { "typeRef": "retail:InventorySearchResponse" },
+          "description": "照会成功。0 件でも 200 OK (items: [] で返す)。",
+          "when": "在庫照会が正常完了した場合 (0 件含む)。"
+        },
+        {
+          "id": "400-validation",
+          "status": 400,
+          "bodySchema": { "typeRef": "retail:ApiError" },
+          "description": "入力値バリデーションエラー。",
+          "when": "storeCode が空、または productCode がパターン違反の場合。"
+        },
+        {
+          "id": "404-product-not-found",
+          "status": 404,
+          "bodySchema": { "typeRef": "retail:ApiError" },
+          "description": "指定商品コードの商品が存在しない。",
+          "when": "productCode を指定したが products テーブルに該当レコードがない場合。"
+        }
+      ],
+      "steps": [
+        {
+          "id": "step-01",
+          "kind": "validation",
+          "description": "storeCode 必須チェック + productCode パターン検証 (@conv.regex.productCode)。",
+          "conditions": "storeCode は必須。productCode が指定された場合は @conv.regex.productCode パターンに一致する必要がある。",
+          "rules": [
+            {
+              "field": "storeCode",
+              "type": "required",
+              "severity": "error",
+              "message": "店舗コードは必須です。"
+            },
+            {
+              "field": "productCode",
+              "type": "regex",
+              "condition": "@inputs.productCode != null && @inputs.productCode !== ''",
+              "patternRef": "@conv.regex.productCode",
+              "severity": "error",
+              "message": "商品コードの形式が不正です。'P-' + 4〜6 桁数字の形式で入力してください。"
+            }
+          ],
+          "fieldErrorsVar": "fieldErrors",
+          "inlineBranch": {
+            "ok": [],
+            "ng": [
+              {
+                "id": "step-01-ng-01",
+                "kind": "return",
+                "description": "400 バリデーションエラーを返す。",
+                "responseId": "400-validation",
+                "bodyExpression": "{ code: 'VALIDATION_ERROR', message: '入力値が不正です。', fieldErrors: @fieldErrors }"
+              }
+            ]
+          }
+        },
+        {
+          "id": "step-02",
+          "kind": "dbAccess",
+          "description": "productCode が指定された場合、products テーブルで商品の存在確認を行う。",
+          "tableId": "652cbbfe-17e2-4f23-a0c9-4403e6b23bb0",
+          "operation": "SELECT",
+          "sql": "SELECT id, product_code, name, unit_price FROM products WHERE product_code = @inputs.productCode AND is_active = TRUE",
+          "outputBinding": { "name": "product" },
+          "runIf": "@inputs.productCode != null && @inputs.productCode !== ''",
+          "lineage": {
+            "reads": [{ "tableId": "652cbbfe-17e2-4f23-a0c9-4403e6b23bb0", "purpose": "lookup" }]
+          }
+        },
+        {
+          "id": "step-03",
+          "kind": "branch",
+          "description": "productCode を指定したが products に商品が存在しない場合は 404 を返す。",
+          "branches": [
+            {
+              "id": "br-03-a",
+              "code": "A",
+              "label": "商品なし",
+              "condition": {
+                "kind": "expression",
+                "expression": "@inputs.productCode != null && @inputs.productCode !== '' && (@product == null || @product === undefined)"
+              },
+              "steps": [
+                {
+                  "id": "step-03-a-01",
+                  "kind": "return",
+                  "description": "404 商品なし を返す。",
+                  "responseId": "404-product-not-found",
+                  "bodyExpression": "{ code: 'PRODUCT_NOT_FOUND', message: '@conv.msg.productNotFound'.replace('{productCode}', @inputs.productCode) }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-03-else",
+            "code": "B",
+            "label": "商品あり、または productCode 未指定",
+            "steps": []
+          }
+        },
+        {
+          "id": "step-04",
+          "kind": "dbAccess",
+          "description": "inventory + products を JOIN して在庫一覧を取得する。productCode が指定された場合は product_id でフィルタ。",
+          "tableId": "834ede22-3cb0-4dcf-aa8a-7c046664774a",
+          "operation": "SELECT",
+          "sql": "SELECT i.id, p.product_code, p.name AS product_name, s.store_code, i.quantity_available, i.quantity_reserved FROM inventory i JOIN products p ON p.id = i.product_id JOIN stores s ON s.id = i.store_id WHERE s.store_code = @inputs.storeCode AND (@inputs.productCode IS NULL OR p.product_code = @inputs.productCode) AND p.is_active = TRUE ORDER BY p.product_code ASC",
+          "outputBinding": { "name": "inventoryRows" },
+          "lineage": {
+            "reads": [
+              { "tableId": "834ede22-3cb0-4dcf-aa8a-7c046664774a", "purpose": "lookup" },
+              { "tableId": "652cbbfe-17e2-4f23-a0c9-4403e6b23bb0", "purpose": "lookup" },
+              { "tableId": "fdf00088-87d1-40e8-9eba-65ef58a9bfe5", "purpose": "lookup" }
+            ]
+          }
+        },
+        {
+          "id": "step-05",
+          "kind": "branch",
+          "description": "在庫レコードが 0 件の場合は retail.inventory.not_found イベントを発行して 200 OK (空配列) を返す。",
+          "branches": [
+            {
+              "id": "br-05-a",
+              "code": "A",
+              "label": "在庫なし",
+              "condition": {
+                "kind": "expression",
+                "expression": "@inventoryRows == null || @inventoryRows.length === 0"
+              },
+              "steps": [
+                {
+                  "id": "step-05-a-01",
+                  "kind": "eventPublish",
+                  "description": "retail.inventory.not_found イベントを発行する。",
+                  "topic": "retail.inventory.not_found",
+                  "payload": "{ storeCode: @inputs.storeCode, productCode: @inputs.productCode }"
+                },
+                {
+                  "id": "step-05-a-02",
+                  "kind": "return",
+                  "description": "200 OK (空配列) を返す。",
+                  "responseId": "200-ok",
+                  "bodyExpression": "{ items: [], totalCount: 0 }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-05-else",
+            "code": "B",
+            "label": "在庫あり",
+            "steps": []
+          }
+        },
+        {
+          "id": "step-06",
+          "kind": "compute",
+          "description": "各在庫行に isLowStock フラグを付与する。quantity_available が lowStockThreshold 以下 (>=) の場合に true とすることでオフバイワンを回避する。",
+          "expression": "@inventoryRows.map(r => ({ ...r, isLowStock: r.quantity_available <= @conv.limit.lowStockThreshold }))",
+          "outputBinding": { "name": "inventoryItems" }
+        },
+        {
+          "id": "step-07",
+          "kind": "branch",
+          "description": "低在庫行が 1 件以上存在する場合、retail.inventory.low_stock_detected イベントを発行する (ベストエフォート)。",
+          "branches": [
+            {
+              "id": "br-07-a",
+              "code": "A",
+              "label": "低在庫あり",
+              "condition": {
+                "kind": "expression",
+                "expression": "@inventoryItems.some(r => r.isLowStock)"
+              },
+              "steps": [
+                {
+                  "id": "step-07-a-01",
+                  "kind": "compute",
+                  "description": "低在庫の最初の 1 行を取得してイベントペイロードに使用する。",
+                  "expression": "@inventoryItems.find(r => r.isLowStock)",
+                  "outputBinding": { "name": "firstLowStockRow" }
+                },
+                {
+                  "id": "step-07-a-02",
+                  "kind": "eventPublish",
+                  "description": "retail.inventory.low_stock_detected イベントを発行する。下流コンシューマ (補充発注フロー等) が冪等に処理する前提。",
+                  "topic": "retail.inventory.low_stock_detected",
+                  "payload": "{ storeCode: @inputs.storeCode, productId: @firstLowStockRow.id, quantityAvailable: @firstLowStockRow.quantity_available }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-07-else",
+            "code": "B",
+            "label": "低在庫なし",
+            "steps": []
+          }
+        },
+        {
+          "id": "step-08",
+          "kind": "eventPublish",
+          "description": "retail.inventory.searched イベントを発行する。",
+          "topic": "retail.inventory.searched",
+          "payload": "{ storeCode: @inputs.storeCode, productCode: @inputs.productCode, resultCount: @inventoryItems.length }"
+        },
+        {
+          "id": "step-09",
+          "kind": "return",
+          "description": "200 OK — isLowStock フラグ付きの在庫一覧を返す。",
+          "responseId": "200-ok",
+          "bodyExpression": "{ items: @inventoryItems, totalCount: @inventoryItems.length }"
+        }
+      ]
+    }
+  ],
+  "authoring": {
+    "decisions": [
+      {
+        "id": "ADR-001",
+        "title": "在庫照会は読取専用 — TX 不要",
+        "status": "accepted",
+        "context": "在庫照会は SELECT のみで副作用がない高頻度読み取り操作。",
+        "decision": "transactionScope を使用しない。READ_COMMITTED のデフォルト動作に委ねる。",
+        "consequences": "スナップショット的な参照で十分。高頻度アクセス時も DB 接続消費を最小化できる。",
+        "date": "2026-05-02"
+      },
+      {
+        "id": "ADR-002",
+        "title": "低在庫判定は <= で閾値当日を含む (オフバイワン回避)",
+        "status": "accepted",
+        "context": "lowStockThreshold = 10 のとき、quantity_available = 10 を警告対象に含めるかが業務上あいまいだった。",
+        "decision": "quantity_available <= @conv.limit.lowStockThreshold で判定する (閾値ちょうどを含む)。これにより「10 個以下で警告」の業務要件を正確に表現できる。",
+        "consequences": "< 判定との比較で警告件数がやや増える可能性があるが、補充漏れリスクを下げる方が業務上優先度が高い。",
+        "date": "2026-05-02"
+      },
+      {
+        "id": "ADR-003",
+        "title": "在庫 0 件は 404 でなく 200 OK (空配列)",
+        "status": "accepted",
+        "context": "照会条件に一致するレコードが存在しない場合の HTTP ステータスを決定する必要があった。",
+        "decision": "0 件でも 200 OK (items: []) を返す。在庫レコードが存在しないこと自体はエラーではない。",
+        "consequences": "クライアントは items.length === 0 で在庫なしを判定する。UI での空状態表示が必須。",
+        "date": "2026-05-02"
+      }
+    ],
+    "glossary": {
+      "在庫照会": {
+        "definition": "店舗コードと商品コードを条件に inventory テーブルを検索し、引き当て可能な在庫数量を返す業務操作。",
+        "aliases": ["InventorySearch", "在庫確認"],
+        "domainRef": "inventory"
+      },
+      "低在庫警告": {
+        "definition": "quantity_available が @conv.limit.lowStockThreshold 以下になった在庫行に付与される警告フラグ。補充発注の判断材料となる。",
+        "aliases": ["LowStockAlert", "在庫不足通知"],
+        "domainRef": "retail.lowStockThreshold"
+      }
+    },
+    "testScenarios": [
+      {
+        "id": "happy-path-store-only",
+        "name": "店舗コードのみで在庫一覧が返る",
+        "description": "storeCode のみ指定して 2 件の在庫が返る正常系。1 件は低在庫。",
+        "given": [
+          {
+            "kind": "sessionContext",
+            "context": { "requestId": "req-s1-001", "sessionUserId": null }
+          },
+          {
+            "kind": "dbState",
+            "tableId": "652cbbfe-17e2-4f23-a0c9-4403e6b23bb0",
+            "rows": [
+              { "id": 1, "product_code": "P-0001", "name": "サンプル商品A", "unit_price": 1000, "is_active": true },
+              { "id": 2, "product_code": "P-0002", "name": "サンプル商品B", "unit_price": 2000, "is_active": true }
+            ]
+          },
+          {
+            "kind": "dbState",
+            "tableId": "fdf00088-87d1-40e8-9eba-65ef58a9bfe5",
+            "rows": [
+              { "id": 10, "store_code": "S-001", "name": "新宿店" }
+            ]
+          },
+          {
+            "kind": "dbState",
+            "tableId": "834ede22-3cb0-4dcf-aa8a-7c046664774a",
+            "rows": [
+              { "id": 101, "store_id": 10, "product_id": 1, "quantity_available": 50, "quantity_reserved": 5 },
+              { "id": 102, "store_id": 10, "product_id": 2, "quantity_available": 8, "quantity_reserved": 0 }
+            ]
+          }
+        ],
+        "when": { "actionId": "act-001", "input": { "storeCode": "S-001" } },
+        "then": [
+          { "kind": "outcome", "expected": "200-ok" },
+          { "kind": "output", "path": "$.totalCount", "equals": 2 }
+        ],
+        "tags": ["happy", "s1"]
+      },
+      {
+        "id": "validation-error-no-store-code",
+        "name": "storeCode 未指定で 400",
+        "description": "storeCode が空文字の場合はバリデーションエラーになる。",
+        "given": [
+          { "kind": "sessionContext", "context": { "requestId": "req-s1-002" } }
+        ],
+        "when": { "actionId": "act-001", "input": { "storeCode": "" } },
+        "then": [
+          { "kind": "outcome", "expected": "400-validation" }
+        ],
+        "tags": ["error", "validation", "s1"]
+      },
+      {
+        "id": "product-not-found-404",
+        "name": "存在しない商品コードで 404",
+        "description": "products に存在しない商品コードを指定した場合は 404 を返す。",
+        "given": [
+          { "kind": "sessionContext", "context": { "requestId": "req-s1-003" } },
+          { "kind": "dbState", "tableId": "652cbbfe-17e2-4f23-a0c9-4403e6b23bb0", "rows": [] }
+        ],
+        "when": { "actionId": "act-001", "input": { "storeCode": "S-001", "productCode": "P-9999" } },
+        "then": [
+          { "kind": "outcome", "expected": "404-product-not-found" }
+        ],
+        "tags": ["error", "not-found", "s1"]
+      },
+      {
+        "id": "low-stock-flag-set",
+        "name": "quantity_available <= 10 の行に isLowStock=true が付与される",
+        "description": "在庫数 8 の商品が返る場合、isLowStock=true が付与され retail.inventory.low_stock_detected イベントが発行される。",
+        "given": [
+          { "kind": "sessionContext", "context": { "requestId": "req-s1-004" } },
+          {
+            "kind": "dbState",
+            "tableId": "652cbbfe-17e2-4f23-a0c9-4403e6b23bb0",
+            "rows": [{ "id": 3, "product_code": "P-0003", "name": "低在庫商品", "unit_price": 500, "is_active": true }]
+          },
+          {
+            "kind": "dbState",
+            "tableId": "fdf00088-87d1-40e8-9eba-65ef58a9bfe5",
+            "rows": [{ "id": 10, "store_code": "S-001", "name": "新宿店" }]
+          },
+          {
+            "kind": "dbState",
+            "tableId": "834ede22-3cb0-4dcf-aa8a-7c046664774a",
+            "rows": [{ "id": 103, "store_id": 10, "product_id": 3, "quantity_available": 8, "quantity_reserved": 0 }]
+          }
+        ],
+        "when": { "actionId": "act-001", "input": { "storeCode": "S-001", "productCode": "P-0003" } },
+        "then": [
+          { "kind": "outcome", "expected": "200-ok" },
+          { "kind": "output", "path": "$.items[0].isLowStock", "equals": true }
+        ],
+        "tags": ["low-stock", "s1"]
+      }
+    ]
+  }
+}

--- a/samples/retail/actions/f81dd9e0-794c-4539-a2a5-9cbcc0a75899.json
+++ b/samples/retail/actions/f81dd9e0-794c-4539-a2a5-9cbcc0a75899.json
@@ -1,0 +1,633 @@
+{
+  "$schema": "../../../schemas/v3/process-flow.v3.schema.json",
+  "meta": {
+    "id": "f81dd9e0-794c-4539-a2a5-9cbcc0a75899",
+    "name": "注文確定",
+    "description": "カート内容を 1 TX (@conv.tx.orderConfirm) で確定する。在庫減算 (retail:DECREMENT_STOCK) → 注文番号採番 (@conv.numbering.orderNumber) → orders INSERT → order_items BULK_INSERT → カートクリア (retail:CLEAR_CART) の順に原子的に実行する。TX 失敗時は 422 を返す。TX 後に persistedOrder を再取得してから注文確定イベントを発行する。",
+    "kind": "screen",
+    "maturity": "committed",
+    "createdAt": "2026-05-02T00:00:00.000Z",
+    "updatedAt": "2026-05-02T00:00:00.000Z"
+  },
+  "context": {
+    "catalogs": {
+      "errors": {
+        "VALIDATION_ERROR": {
+          "httpStatus": 400,
+          "defaultMessage": "入力値が不正です。",
+          "responseId": "400-validation",
+          "description": "配送先住所未入力などのバリデーションエラー。"
+        },
+        "CART_EMPTY": {
+          "httpStatus": 422,
+          "defaultMessage": "カートが空です。",
+          "responseId": "422-cart-empty",
+          "description": "注文確定時にカート明細が 0 件だった場合。"
+        },
+        "STOCK_SHORTAGE": {
+          "httpStatus": 422,
+          "defaultMessage": "在庫が不足しています。",
+          "responseId": "422-stock-shortage",
+          "description": "在庫減算時に quantity_available が不足していた場合。TX 全体がロールバックされる。"
+        },
+        "ORDER_CONFIRM_FAILED": {
+          "httpStatus": 422,
+          "defaultMessage": "注文確定に失敗しました。",
+          "responseId": "422-order-confirm-failed",
+          "description": "注文確定 TX 内で予期しないエラーが発生した場合。"
+        }
+      },
+      "events": {
+        "retail.order.confirmed": {
+          "description": "注文確定 TX が正常にコミットされ、persistedOrder の再取得が完了した後に発行する。",
+          "payload": {
+            "type": "object",
+            "required": ["orderId", "orderNumber", "customerId", "totalAmount"],
+            "properties": {
+              "orderId": { "type": "number" },
+              "orderNumber": { "type": "string" },
+              "customerId": { "type": "number" },
+              "totalAmount": { "type": "number" }
+            }
+          }
+        }
+      }
+    },
+    "ambientVariables": [
+      {
+        "name": "sessionCustomerId",
+        "type": "integer",
+        "required": true,
+        "description": "セッションから取得したログイン顧客 ID。"
+      }
+    ]
+  },
+  "actions": [
+    {
+      "id": "act-001",
+      "name": "注文確定実行",
+      "trigger": "submit",
+      "description": "カート確認画面の「注文確定」ボタン押下で起動。配送先情報を入力として受け取り、1 TX で在庫引き当て・注文登録・カートクリアを原子的に実行する。",
+      "maturity": "committed",
+      "httpRoute": {
+        "method": "POST",
+        "path": "/api/retail/orders",
+        "auth": "required"
+      },
+      "inputs": [
+        {
+          "name": "shippingPostalCode",
+          "label": "配送先郵便番号",
+          "type": "string",
+          "required": true,
+          "description": "ハイフンなし 7 桁。@conv.regex.postalCode 準拠。"
+        },
+        {
+          "name": "shippingAddress",
+          "label": "配送先住所",
+          "type": "string",
+          "required": true,
+          "description": "都道府県から番地まで。300 文字以内。"
+        },
+        {
+          "name": "note",
+          "label": "備考",
+          "type": "string",
+          "required": false,
+          "description": "顧客からの連絡事項。"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "orderId",
+          "label": "注文ID",
+          "type": "integer",
+          "description": "確定した注文の DB ID。"
+        },
+        {
+          "name": "orderNumber",
+          "label": "注文番号",
+          "type": "string",
+          "description": "採番された注文番号 (@conv.numbering.orderNumber 形式)。"
+        },
+        {
+          "name": "totalAmount",
+          "label": "合計金額",
+          "type": "integer",
+          "description": "注文合計金額 (税抜)。"
+        }
+      ],
+      "responses": [
+        {
+          "id": "200-ok",
+          "status": 200,
+          "bodySchema": { "typeRef": "retail:OrderConfirmResponse" },
+          "description": "注文確定成功。",
+          "when": "TX が正常にコミットされた場合。"
+        },
+        {
+          "id": "400-validation",
+          "status": 400,
+          "bodySchema": { "typeRef": "retail:ApiError" },
+          "description": "バリデーションエラー。",
+          "when": "配送先情報が不正な場合。"
+        },
+        {
+          "id": "422-cart-empty",
+          "status": 422,
+          "bodySchema": { "typeRef": "retail:ApiError" },
+          "description": "カートが空。",
+          "when": "cart_items が 0 件の場合。"
+        },
+        {
+          "id": "422-stock-shortage",
+          "status": 422,
+          "bodySchema": { "typeRef": "retail:ApiError" },
+          "description": "在庫不足。TX はロールバック済み。",
+          "when": "在庫減算時に quantity_available が注文数量未満だった場合。"
+        },
+        {
+          "id": "422-order-confirm-failed",
+          "status": 422,
+          "bodySchema": { "typeRef": "retail:ApiError" },
+          "description": "注文確定 TX 失敗。TX はロールバック済み。",
+          "when": "在庫不足以外の TX 内エラーが発生した場合。"
+        }
+      ],
+      "steps": [
+        {
+          "id": "step-01",
+          "kind": "validation",
+          "description": "配送先郵便番号 + 住所の必須チェック。郵便番号は @conv.regex.postalCode パターン検証。",
+          "conditions": "shippingPostalCode は必須かつハイフンなし 7 桁数字。shippingAddress は必須。",
+          "rules": [
+            {
+              "field": "shippingPostalCode",
+              "type": "required",
+              "severity": "error",
+              "message": "配送先郵便番号は必須です。"
+            },
+            {
+              "field": "shippingPostalCode",
+              "type": "regex",
+              "patternRef": "@conv.regex.postalCode",
+              "severity": "error",
+              "message": "郵便番号はハイフンなし 7 桁の数字で入力してください。"
+            },
+            {
+              "field": "shippingAddress",
+              "type": "required",
+              "severity": "error",
+              "message": "配送先住所は必須です。"
+            },
+            {
+              "field": "shippingAddress",
+              "type": "maxLength",
+              "length": 300,
+              "severity": "error",
+              "message": "配送先住所は 300 文字以内で入力してください。"
+            }
+          ],
+          "fieldErrorsVar": "fieldErrors",
+          "inlineBranch": {
+            "ok": [],
+            "ng": [
+              {
+                "id": "step-01-ng-01",
+                "kind": "return",
+                "description": "400 バリデーションエラーを返す。",
+                "responseId": "400-validation",
+                "bodyExpression": "{ code: 'VALIDATION_ERROR', message: '入力値が不正です。', fieldErrors: @fieldErrors }"
+              }
+            ]
+          }
+        },
+        {
+          "id": "step-02",
+          "kind": "dbAccess",
+          "description": "顧客のアクティブカートと cart_items を取得する。",
+          "tableId": "a32e1a09-bcbc-467f-86b0-983cd7ee61c6",
+          "operation": "SELECT",
+          "sql": "SELECT c.id AS cart_id, ci.id AS item_id, ci.product_id, ci.unit_price_snapshot, ci.quantity, p.product_code, p.name AS product_name, p.unit_price FROM carts c JOIN cart_items ci ON ci.cart_id = c.id JOIN products p ON p.id = ci.product_id WHERE c.customer_id = @sessionCustomerId AND c.status = 'active'",
+          "outputBinding": { "name": "cartItems" },
+          "lineage": {
+            "reads": [
+              { "tableId": "a32e1a09-bcbc-467f-86b0-983cd7ee61c6", "purpose": "lookup" },
+              { "tableId": "57110336-a984-4d39-bb21-1e5d5bb4390b", "purpose": "lookup" },
+              { "tableId": "652cbbfe-17e2-4f23-a0c9-4403e6b23bb0", "purpose": "lookup" }
+            ]
+          }
+        },
+        {
+          "id": "step-03",
+          "kind": "branch",
+          "description": "カートが空 (明細 0 件) の場合は 422 を返す。",
+          "branches": [
+            {
+              "id": "br-03-a",
+              "code": "A",
+              "label": "カート空",
+              "condition": {
+                "kind": "expression",
+                "expression": "@cartItems == null || @cartItems.length === 0"
+              },
+              "steps": [
+                {
+                  "id": "step-03-a-01",
+                  "kind": "return",
+                  "description": "422 カート空を返す。",
+                  "responseId": "422-cart-empty",
+                  "bodyExpression": "{ code: 'CART_EMPTY', message: 'カートが空です。商品をカートに追加してから注文確定してください。' }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-03-else",
+            "code": "B",
+            "label": "カート明細あり",
+            "steps": []
+          }
+        },
+        {
+          "id": "step-04",
+          "kind": "compute",
+          "description": "cart_items から注文合計金額 (税抜) を計算する。各行の line_amount = unit_price_snapshot * quantity の合計。",
+          "expression": "@cartItems.reduce((sum, item) => sum + (item.unit_price_snapshot * item.quantity), 0)",
+          "outputBinding": { "name": "totalAmount" }
+        },
+        {
+          "id": "step-05",
+          "kind": "compute",
+          "description": "注文番号を採番する。@conv.numbering.orderNumber 規約 (ORD-YYYY-NNNNNN) に従い生成する。",
+          "expression": "'ORD-' + new Date().getFullYear() + '-' + String(@conv.numbering.orderNumber.nextSeq()).padStart(6, '0')",
+          "outputBinding": { "name": "newOrderNumber" }
+        },
+        {
+          "id": "step-06",
+          "kind": "transactionScope",
+          "description": "注文確定 TX (@conv.tx.orderConfirm)。在庫減算 → orders INSERT → order_items BULK_INSERT → カートクリアを原子的に実行する。いずれかが失敗した場合は全体をロールバックする。",
+          "isolationLevel": "READ_COMMITTED",
+          "propagation": "REQUIRED",
+          "timeoutMs": 10000,
+          "rollbackOn": ["STOCK_SHORTAGE", "ORDER_CONFIRM_FAILED"],
+          "steps": [
+            {
+              "id": "step-06-01",
+              "kind": "loop",
+              "description": "カート明細を 1 件ずつ在庫減算する。DECREMENT_STOCK は quantity_available < 注文数量の場合に STOCK_SHORTAGE エラーを発生させる。",
+              "loopKind": "collection",
+              "collectionSource": "@cartItems",
+              "collectionItemName": "cartItem",
+              "steps": [
+                {
+                  "id": "step-06-01-a",
+                  "kind": "dbAccess",
+                  "description": "在庫を注文数量分だけ減算する。0 未満になる場合は DB の CHECK 制約で弾かれ、STOCK_SHORTAGE エラーが発生する。",
+                  "tableId": "834ede22-3cb0-4dcf-aa8a-7c046664774a",
+                  "operation": "retail:DECREMENT_STOCK",
+                  "sql": "UPDATE inventory SET quantity_available = quantity_available - @cartItem.quantity, updated_at = CURRENT_TIMESTAMP WHERE product_id = @cartItem.product_id AND store_id = (SELECT id FROM stores WHERE store_code = 'DEFAULT' LIMIT 1) AND quantity_available >= @cartItem.quantity",
+                  "affectedRowsCheck": {
+                    "operator": "=",
+                    "expected": 1,
+                    "onViolation": "throw",
+                    "errorCode": "STOCK_SHORTAGE",
+                    "description": "0 件更新 = 在庫不足。TX がロールバックされ STOCK_SHORTAGE エラーを返す。"
+                  },
+                  "lineage": {
+                    "writes": [{ "tableId": "834ede22-3cb0-4dcf-aa8a-7c046664774a", "purpose": "lookup" }]
+                  }
+                }
+              ]
+            },
+            {
+              "id": "step-06-02",
+              "kind": "dbAccess",
+              "description": "orders テーブルに注文レコードを INSERT する。注文番号は step-05 で採番済みの値を使用する。",
+              "tableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab",
+              "operation": "INSERT",
+              "sql": "INSERT INTO orders (order_number, customer_id, status, total_amount, tax_amount, shipping_postal_code, shipping_address, note, ordered_at) VALUES (@newOrderNumber, @sessionCustomerId, 'pending', @totalAmount, FLOOR(@totalAmount * @conv.tax.standard.rate), @inputs.shippingPostalCode, @inputs.shippingAddress, @inputs.note, CURRENT_TIMESTAMP) RETURNING id, order_number",
+              "outputBinding": { "name": "insertedOrder" },
+              "lineage": {
+                "writes": [{ "tableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab", "purpose": "lookup" }]
+              }
+            },
+            {
+              "id": "step-06-03",
+              "kind": "dbAccess",
+              "description": "order_items を cart_items から一括 INSERT する (retail:BULK_INSERT)。単価・商品名はスナップショットとしてコピーする。",
+              "tableId": "dddfb0c1-0fde-40ac-bcf0-5ed75a7f1edc",
+              "operation": "retail:BULK_INSERT",
+              "bulkValues": "@cartItems.map(item => ({ order_id: @insertedOrder.id, product_id: item.product_id, product_code_snapshot: item.product_code, product_name_snapshot: item.product_name, unit_price_snapshot: item.unit_price_snapshot, quantity: item.quantity, line_amount: item.unit_price_snapshot * item.quantity }))",
+              "sql": "INSERT INTO order_items (order_id, product_id, product_code_snapshot, product_name_snapshot, unit_price_snapshot, quantity, line_amount) VALUES :bulkValues",
+              "lineage": {
+                "writes": [{ "tableId": "dddfb0c1-0fde-40ac-bcf0-5ed75a7f1edc", "purpose": "lookup" }]
+              }
+            },
+            {
+              "id": "step-06-04",
+              "kind": "dbAccess",
+              "description": "カートをクリアする (retail:CLEAR_CART)。cart_items を全削除し、carts.status を 'ordered' に更新する。",
+              "tableId": "a32e1a09-bcbc-467f-86b0-983cd7ee61c6",
+              "operation": "retail:CLEAR_CART",
+              "sql": "DELETE FROM cart_items WHERE cart_id = (SELECT id FROM carts WHERE customer_id = @sessionCustomerId AND status = 'active'); UPDATE carts SET status = 'ordered', updated_at = CURRENT_TIMESTAMP WHERE customer_id = @sessionCustomerId AND status = 'active'",
+              "lineage": {
+                "writes": [
+                  { "tableId": "57110336-a984-4d39-bb21-1e5d5bb4390b", "purpose": "lookup" },
+                  { "tableId": "a32e1a09-bcbc-467f-86b0-983cd7ee61c6", "purpose": "lookup" }
+                ]
+              }
+            }
+          ],
+          "onRollback": [
+            {
+              "id": "step-06-rb-01",
+              "kind": "log",
+              "description": "TX ロールバック発生を記録する。",
+              "level": "error",
+              "message": "注文確定 TX がロールバックされました。",
+              "category": "order.confirm",
+              "structuredData": {
+                "customerId": "@sessionCustomerId",
+                "orderNumber": "@newOrderNumber"
+              }
+            }
+          ]
+        },
+        {
+          "id": "step-07",
+          "kind": "branch",
+          "description": "TX 成功/失敗に応じてレスポンスを分岐する。",
+          "branches": [
+            {
+              "id": "br-07-stock",
+              "code": "A",
+              "label": "在庫不足エラー",
+              "condition": {
+                "kind": "tryCatch",
+                "errorCode": "STOCK_SHORTAGE",
+                "description": "在庫減算で affectedRowsCheck 違反が発生した場合。"
+              },
+              "steps": [
+                {
+                  "id": "step-07-a-01",
+                  "kind": "return",
+                  "description": "422 在庫不足を返す。",
+                  "responseId": "422-stock-shortage",
+                  "bodyExpression": "{ code: 'STOCK_SHORTAGE', message: '@conv.msg.stockShortage' }"
+                }
+              ]
+            },
+            {
+              "id": "br-07-fail",
+              "code": "B",
+              "label": "その他 TX エラー",
+              "condition": {
+                "kind": "tryCatch",
+                "errorCode": "ORDER_CONFIRM_FAILED",
+                "description": "在庫不足以外の TX 内エラー。"
+              },
+              "steps": [
+                {
+                  "id": "step-07-b-01",
+                  "kind": "return",
+                  "description": "422 注文確定失敗を返す。",
+                  "responseId": "422-order-confirm-failed",
+                  "bodyExpression": "{ code: 'ORDER_CONFIRM_FAILED', message: '注文確定に失敗しました。しばらく経ってから再試行してください。' }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-07-else",
+            "code": "C",
+            "label": "TX 成功 — 後続処理へ",
+            "steps": []
+          }
+        },
+        {
+          "id": "step-08",
+          "kind": "dbAccess",
+          "description": "TX コミット後に orders を再取得する。TX 内の insertedOrder の変数をそのまま参照するとネスト変数問題が起きるため、TX 後に SELECT で再取得する。",
+          "tableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab",
+          "operation": "SELECT",
+          "sql": "SELECT id, order_number, customer_id, status, total_amount, ordered_at FROM orders WHERE order_number = @newOrderNumber",
+          "outputBinding": { "name": "persistedOrder" },
+          "lineage": {
+            "reads": [{ "tableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab", "purpose": "lookup" }]
+          }
+        },
+        {
+          "id": "step-09",
+          "kind": "eventPublish",
+          "description": "retail.order.confirmed イベントを発行する。TX コミット後 + persistedOrder 再取得後に発行するため、イベントペイロードは確定済み値のみ参照する。",
+          "topic": "retail.order.confirmed",
+          "payload": "{ orderId: @persistedOrder.id, orderNumber: @persistedOrder.order_number, customerId: @persistedOrder.customer_id, totalAmount: @persistedOrder.total_amount }"
+        },
+        {
+          "id": "step-10",
+          "kind": "return",
+          "description": "200 OK — 注文確定完了を返す。",
+          "responseId": "200-ok",
+          "bodyExpression": "{ orderId: @persistedOrder.id, orderNumber: @persistedOrder.order_number, totalAmount: @persistedOrder.total_amount, message: '注文が確定しました。注文番号: ' + @persistedOrder.order_number }"
+        }
+      ]
+    }
+  ],
+  "authoring": {
+    "decisions": [
+      {
+        "id": "ADR-001",
+        "title": "注文確定 TX の順序: 在庫減算 → orders INSERT → order_items BULK_INSERT → カートクリア",
+        "status": "accepted",
+        "context": "@conv.tx.orderConfirm で定める TX 内の操作順序を決定する必要があった。",
+        "decision": "在庫減算を最初に実行する。在庫不足で TX を早期中断できるため、orders/order_items の無用な INSERT を防げる。カートクリアは最後に実行し、失敗しても TX ロールバックで元に戻る。",
+        "consequences": "在庫減算が失敗すると orders INSERT は実行されない。注文番号の採番 (step-05) は TX 外で行うため、TX ロールバック時に番号がスキップされる可能性がある (採番に void は許容)。",
+        "date": "2026-05-02"
+      },
+      {
+        "id": "ADR-002",
+        "title": "TX 後に persistedOrder を再取得する (TX 内変数ネスト参照回避)",
+        "status": "accepted",
+        "context": "transactionScope 内で生成した insertedOrder を TX 後のステップで参照するとネスト変数問題が発生するケースがある (memory feedback_codex_brief_concrete_pattern_reference.md)。",
+        "decision": "TX 後に SELECT で orders を再取得し persistedOrder 変数に格納する。イベント発行とレスポンスは persistedOrder のみを参照する。",
+        "consequences": "余分な SELECT が 1 回増えるが、TX コミット後の確定値を参照できる安全な設計となる。",
+        "date": "2026-05-02"
+      },
+      {
+        "id": "ADR-003",
+        "title": "TX 失敗時は 422 を返す (PR #460 / Phase 4 retail 確立パターン準拠)",
+        "status": "accepted",
+        "context": "注文確定 TX が失敗した場合の HTTP ステータスを決定する必要があった。",
+        "decision": "在庫不足も含む TX 失敗は 422 Unprocessable Entity を返す。500 は予期しないサーバエラーのみに使用する。",
+        "consequences": "クライアントは 422 を受け取ったら在庫不足メッセージを表示し、カートを再確認するフローに誘導できる。",
+        "date": "2026-05-02"
+      }
+    ],
+    "glossary": {
+      "注文確定": {
+        "definition": "カート内容を 1 DB トランザクションで注文テーブルに登録し、在庫を引き当て、カートをクリアする一連の業務操作。",
+        "aliases": ["OrderConfirm", "Checkout"],
+        "domainRef": "orders"
+      },
+      "在庫引き当て": {
+        "definition": "注文数量分だけ inventory.quantity_available を減算する操作。0 未満にはできない。",
+        "aliases": ["StockDecrement", "StockAllocation"],
+        "domainRef": "inventory.quantity_available"
+      },
+      "注文番号": {
+        "definition": "@conv.numbering.orderNumber 規約で採番される顧客向け識別子。形式: ORD-YYYY-NNNNNN。",
+        "aliases": ["OrderNumber", "受注番号"],
+        "domainRef": "orders.order_number"
+      }
+    },
+    "testScenarios": [
+      {
+        "id": "happy-path-order-confirm",
+        "name": "カート 2 商品の注文確定が成功する",
+        "description": "在庫十分・配送先情報正常で注文確定 TX が正常コミットされる正常系。",
+        "given": [
+          {
+            "kind": "sessionContext",
+            "context": { "sessionCustomerId": 100 }
+          },
+          {
+            "kind": "dbState",
+            "tableId": "652cbbfe-17e2-4f23-a0c9-4403e6b23bb0",
+            "rows": [
+              { "id": 1, "product_code": "P-0001", "name": "商品A", "unit_price": 1000, "is_active": true },
+              { "id": 2, "product_code": "P-0002", "name": "商品B", "unit_price": 2000, "is_active": true }
+            ]
+          },
+          {
+            "kind": "dbState",
+            "tableId": "a32e1a09-bcbc-467f-86b0-983cd7ee61c6",
+            "rows": [{ "id": 50, "customer_id": 100, "status": "active" }]
+          },
+          {
+            "kind": "dbState",
+            "tableId": "57110336-a984-4d39-bb21-1e5d5bb4390b",
+            "rows": [
+              { "id": 200, "cart_id": 50, "product_id": 1, "unit_price_snapshot": 1000, "quantity": 2 },
+              { "id": 201, "cart_id": 50, "product_id": 2, "unit_price_snapshot": 2000, "quantity": 1 }
+            ]
+          },
+          {
+            "kind": "dbState",
+            "tableId": "834ede22-3cb0-4dcf-aa8a-7c046664774a",
+            "rows": [
+              { "id": 101, "store_id": 1, "product_id": 1, "quantity_available": 50, "quantity_reserved": 0 },
+              { "id": 102, "store_id": 1, "product_id": 2, "quantity_available": 30, "quantity_reserved": 0 }
+            ]
+          }
+        ],
+        "when": {
+          "actionId": "act-001",
+          "input": {
+            "shippingPostalCode": "1600022",
+            "shippingAddress": "東京都新宿区新宿1-1-1",
+            "note": ""
+          }
+        },
+        "then": [
+          { "kind": "outcome", "expected": "200-ok" },
+          { "kind": "output", "path": "$.orderNumber", "matches": "^ORD-\\d{4}-\\d{6}$" }
+        ],
+        "tags": ["happy", "s3", "tx"]
+      },
+      {
+        "id": "stock-shortage-422",
+        "name": "在庫不足で 422 — TX ロールバック",
+        "description": "quantity_available (3) < 注文数量 (5) で STOCK_SHORTAGE エラーが発生し TX がロールバックされる。",
+        "given": [
+          {
+            "kind": "sessionContext",
+            "context": { "sessionCustomerId": 100 }
+          },
+          {
+            "kind": "dbState",
+            "tableId": "652cbbfe-17e2-4f23-a0c9-4403e6b23bb0",
+            "rows": [{ "id": 1, "product_code": "P-0001", "name": "商品A", "unit_price": 1000, "is_active": true }]
+          },
+          {
+            "kind": "dbState",
+            "tableId": "a32e1a09-bcbc-467f-86b0-983cd7ee61c6",
+            "rows": [{ "id": 50, "customer_id": 100, "status": "active" }]
+          },
+          {
+            "kind": "dbState",
+            "tableId": "57110336-a984-4d39-bb21-1e5d5bb4390b",
+            "rows": [{ "id": 200, "cart_id": 50, "product_id": 1, "unit_price_snapshot": 1000, "quantity": 5 }]
+          },
+          {
+            "kind": "dbState",
+            "tableId": "834ede22-3cb0-4dcf-aa8a-7c046664774a",
+            "rows": [{ "id": 101, "store_id": 1, "product_id": 1, "quantity_available": 3, "quantity_reserved": 0 }]
+          }
+        ],
+        "when": {
+          "actionId": "act-001",
+          "input": {
+            "shippingPostalCode": "1600022",
+            "shippingAddress": "東京都新宿区新宿1-1-1"
+          }
+        },
+        "then": [
+          { "kind": "outcome", "expected": "422-stock-shortage" }
+        ],
+        "tags": ["error", "stock", "tx", "s3"]
+      },
+      {
+        "id": "cart-empty-422",
+        "name": "カートが空で 422",
+        "description": "cart_items が 0 件の場合は CART_EMPTY エラーを返す。",
+        "given": [
+          {
+            "kind": "sessionContext",
+            "context": { "sessionCustomerId": 100 }
+          },
+          {
+            "kind": "dbState",
+            "tableId": "a32e1a09-bcbc-467f-86b0-983cd7ee61c6",
+            "rows": [{ "id": 50, "customer_id": 100, "status": "active" }]
+          },
+          {
+            "kind": "dbState",
+            "tableId": "57110336-a984-4d39-bb21-1e5d5bb4390b",
+            "rows": []
+          }
+        ],
+        "when": {
+          "actionId": "act-001",
+          "input": {
+            "shippingPostalCode": "1600022",
+            "shippingAddress": "東京都新宿区新宿1-1-1"
+          }
+        },
+        "then": [
+          { "kind": "outcome", "expected": "422-cart-empty" }
+        ],
+        "tags": ["error", "empty-cart", "s3"]
+      },
+      {
+        "id": "validation-error-invalid-postal",
+        "name": "郵便番号不正で 400",
+        "description": "郵便番号がハイフンありの場合はバリデーションエラー。",
+        "given": [
+          { "kind": "sessionContext", "context": { "sessionCustomerId": 100 } }
+        ],
+        "when": {
+          "actionId": "act-001",
+          "input": {
+            "shippingPostalCode": "160-0022",
+            "shippingAddress": "東京都新宿区新宿1-1-1"
+          }
+        },
+        "then": [
+          { "kind": "outcome", "expected": "400-validation" }
+        ],
+        "tags": ["error", "validation", "s3"]
+      }
+    ]
+  }
+}

--- a/samples/retail/actions/f81dd9e0-794c-4539-a2a5-9cbcc0a75899.json
+++ b/samples/retail/actions/f81dd9e0-794c-4539-a2a5-9cbcc0a75899.json
@@ -295,7 +295,7 @@
                     "description": "0 件更新 = 在庫不足。TX がロールバックされ STOCK_SHORTAGE エラーを返す。"
                   },
                   "lineage": {
-                    "writes": [{ "tableId": "834ede22-3cb0-4dcf-aa8a-7c046664774a", "purpose": "lookup" }]
+                    "writes": [{ "tableId": "834ede22-3cb0-4dcf-aa8a-7c046664774a", "purpose": "decrement" }]
                   }
                 }
               ]
@@ -309,7 +309,7 @@
               "sql": "INSERT INTO orders (order_number, customer_id, status, total_amount, tax_amount, shipping_postal_code, shipping_address, note, ordered_at) VALUES (@newOrderNumber, @sessionCustomerId, 'pending', @totalAmount, FLOOR(@totalAmount * @conv.tax.standard.rate), @inputs.shippingPostalCode, @inputs.shippingAddress, @inputs.note, CURRENT_TIMESTAMP) RETURNING id, order_number",
               "outputBinding": { "name": "insertedOrder" },
               "lineage": {
-                "writes": [{ "tableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab", "purpose": "lookup" }]
+                "writes": [{ "tableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab", "purpose": "insert" }]
               }
             },
             {
@@ -321,7 +321,7 @@
               "bulkValues": "@cartItems.map(item => ({ order_id: @insertedOrder.id, product_id: item.product_id, product_code_snapshot: item.product_code, product_name_snapshot: item.product_name, unit_price_snapshot: item.unit_price_snapshot, quantity: item.quantity, line_amount: item.unit_price_snapshot * item.quantity }))",
               "sql": "INSERT INTO order_items (order_id, product_id, product_code_snapshot, product_name_snapshot, unit_price_snapshot, quantity, line_amount) VALUES :bulkValues",
               "lineage": {
-                "writes": [{ "tableId": "dddfb0c1-0fde-40ac-bcf0-5ed75a7f1edc", "purpose": "lookup" }]
+                "writes": [{ "tableId": "dddfb0c1-0fde-40ac-bcf0-5ed75a7f1edc", "purpose": "bulk-insert" }]
               }
             },
             {
@@ -333,8 +333,8 @@
               "sql": "DELETE FROM cart_items WHERE cart_id = (SELECT id FROM carts WHERE customer_id = @sessionCustomerId AND status = 'active'); UPDATE carts SET status = 'ordered', updated_at = CURRENT_TIMESTAMP WHERE customer_id = @sessionCustomerId AND status = 'active'",
               "lineage": {
                 "writes": [
-                  { "tableId": "57110336-a984-4d39-bb21-1e5d5bb4390b", "purpose": "lookup" },
-                  { "tableId": "a32e1a09-bcbc-467f-86b0-983cd7ee61c6", "purpose": "lookup" }
+                  { "tableId": "57110336-a984-4d39-bb21-1e5d5bb4390b", "purpose": "delete" },
+                  { "tableId": "a32e1a09-bcbc-467f-86b0-983cd7ee61c6", "purpose": "update" }
                 ]
               }
             }

--- a/samples/retail/conventions/catalog.json
+++ b/samples/retail/conventions/catalog.json
@@ -14,7 +14,7 @@
   "numbering": {
     "orderNumber": {
       "format": "ORD-YYYY-NNNNNN",
-      "implementation": "DB sequence (seq_order_number) + アプリ層で YYYY を現在年に置換して採番",
+      "implementation": "DB sequence (seq_order_number) + アプリ層で YYYY を現在年に置換して採番。シーケンス自体は CYCLE=false で連続インクリメントするため、毎年 1/1 0:00 にスケジュールタスク (DBA 運用) で seq_order_number を 1 にリセットする運用前提。シーケンス値が 999,999 を超える年商規模ではゼロ埋め桁数を増やす ALTER と併せて catalog 更新する。",
       "description": "注文番号の採番規約。YYYY は注文確定年 (西暦 4 桁)、NNNNNN はシーケンス 6 桁ゼロ埋め。例: ORD-2026-000001。注文確定 TX (S-3) 内で 1 TX に 1 番号を発行する。"
     }
   },

--- a/samples/retail/conventions/catalog.json
+++ b/samples/retail/conventions/catalog.json
@@ -1,0 +1,143 @@
+{
+  "$schema": "../../../schemas/v3/conventions.v3.schema.json",
+  "version": "1.0.0",
+  "description": "リテール総合サンプルの横断規約カタログ。採番・正規表現・メッセージ・境界値・DB 規約・税率・通貨・TX 方針を集約する。",
+  "updatedAt": "2026-05-02T00:00:00.000Z",
+  "i18n": {
+    "supportedLocales": ["ja-JP"],
+    "defaultLocale": "ja-JP",
+    "dateFormat": { "ja-JP": "YYYY/MM/DD" },
+    "timeFormat": { "ja-JP": "HH:mm" },
+    "currencyDisplay": { "ja-JP": "symbol" },
+    "numberGrouping": { "ja-JP": true }
+  },
+  "numbering": {
+    "orderNumber": {
+      "format": "ORD-YYYY-NNNNNN",
+      "implementation": "DB sequence (seq_order_number) + アプリ層で YYYY を現在年に置換して採番",
+      "description": "注文番号の採番規約。YYYY は注文確定年 (西暦 4 桁)、NNNNNN はシーケンス 6 桁ゼロ埋め。例: ORD-2026-000001。注文確定 TX (S-3) 内で 1 TX に 1 番号を発行する。"
+    }
+  },
+  "regex": {
+    "productCode": {
+      "pattern": "^P-[0-9]{4,6}$",
+      "description": "商品コードの正規表現。'P-' プレフィックス + 4〜6 桁数字。例: P-0001, P-123456。",
+      "exampleValid": ["P-0001", "P-9999", "P-123456"],
+      "exampleInvalid": ["0001", "P-001", "P-1234567", "p-0001"]
+    },
+    "janCode": {
+      "pattern": "^[0-9]{13}$",
+      "description": "JAN/EAN-13 バーコードの正規表現。13 桁数字のみ。チェックデジットの検証はアプリ層で行う。",
+      "exampleValid": ["4901234567890", "4912345678901"],
+      "exampleInvalid": ["490123456789", "49012345678901", "490123456789X"]
+    },
+    "storeCode": {
+      "pattern": "^S-[0-9]{3,5}$",
+      "description": "店舗コードの正規表現。'S-' プレフィックス + 3〜5 桁数字。例: S-001, S-10001。",
+      "exampleValid": ["S-001", "S-999", "S-10001"],
+      "exampleInvalid": ["001", "S-01", "S-123456"]
+    },
+    "postalCode": {
+      "pattern": "^[0-9]{7}$",
+      "description": "郵便番号の正規表現。ハイフンなし 7 桁数字。UI 表示時は 3-4 で区切る。",
+      "exampleValid": ["1600022", "5310073"],
+      "exampleInvalid": ["160-0022", "16000", "160002X"]
+    }
+  },
+  "msg": {
+    "stockShortage": {
+      "template": "{productName} の在庫が不足しています (在庫: {available} 個、注文: {requested} 個)。数量を減らすか、別の商品をお選びください。",
+      "params": ["productName", "available", "requested"],
+      "description": "在庫不足エラーメッセージ。注文確定フロー (S-3) で在庫引き当て失敗時に表示する。"
+    },
+    "cartItemAdded": {
+      "template": "{productName} をカートに追加しました。",
+      "params": ["productName"],
+      "description": "カート追加成功メッセージ (S-2)。"
+    },
+    "orderConfirmed": {
+      "template": "注文が確定しました。注文番号: {orderNumber}",
+      "params": ["orderNumber"],
+      "description": "注文確定完了メッセージ (S-3)。"
+    },
+    "shipmentDispatched": {
+      "template": "注文 {orderNumber} の配送指示が完了しました。追跡番号: {trackingNumber}",
+      "params": ["orderNumber", "trackingNumber"],
+      "description": "配送指示完了メッセージ (S-4)。"
+    },
+    "productNotFound": {
+      "template": "商品コード {productCode} の商品が見つかりません。",
+      "params": ["productCode"],
+      "description": "商品検索で該当なし時のメッセージ (S-1)。"
+    }
+  },
+  "limit": {
+    "lowStockThreshold": {
+      "value": 10,
+      "unit": "integer",
+      "description": "低在庫警告閾値。inventory.quantity_available がこの値以下になった場合、在庫一覧 (S-1) で警告バッジを表示する。"
+    },
+    "cartMaxItems": {
+      "value": 50,
+      "unit": "integer",
+      "description": "1 カート内の最大明細件数。これを超えた場合はカート追加を拒否する。"
+    },
+    "cartItemMaxQuantity": {
+      "value": 999,
+      "unit": "integer",
+      "description": "1 カート明細の最大数量。"
+    },
+    "productCodeMaxLength": {
+      "value": 20,
+      "unit": "char",
+      "description": "商品コードの最大文字数 (@conv.regex.productCode と整合)。"
+    }
+  },
+  "currency": {
+    "jpy": {
+      "code": "JPY",
+      "subunit": 0,
+      "roundingMode": "floor",
+      "default": true,
+      "description": "日本円。小数点以下なし、切り捨て。"
+    }
+  },
+  "tax": {
+    "standard": {
+      "kind": "exclusive",
+      "rate": 0.1,
+      "roundingMode": "floor",
+      "default": true,
+      "description": "消費税 10%。税抜金額に対して外税で計算し、円未満は切り捨て。"
+    },
+    "reduced": {
+      "kind": "exclusive",
+      "rate": 0.08,
+      "description": "軽減税率 8%。食料品など対象商品に適用。"
+    }
+  },
+  "db": {
+    "primary": {
+      "engine": "postgresql@15",
+      "namingConvention": "snake_case",
+      "timestampColumns": ["created_at", "updated_at"],
+      "logicalDeleteColumn": "is_active",
+      "default": true,
+      "description": "本サンプルの主 DB。PostgreSQL 15 を想定。全テーブルに created_at / updated_at を付与し、論理削除は is_active フラグで管理する。"
+    }
+  },
+  "tx": {
+    "orderConfirm": {
+      "policy": "注文確定 (S-3) は単一 DB トランザクション内で 在庫引き当て (DECREMENT_STOCK) → orders INSERT → order_items BULK_INSERT → carts CLEAR の順に実行する。いずれかで失敗した場合は全体をロールバックする。",
+      "description": "注文確定フローのトランザクション方針。在庫減算と注文登録を原子的に実行する。"
+    }
+  },
+  "auth": {
+    "sessionCookie": {
+      "scheme": "session-cookie",
+      "sessionStorage": "server-side (Redis)",
+      "default": true,
+      "description": "セッション Cookie 認証。ログイン状態はサーバ側 Redis セッションで管理する。"
+    }
+  }
+}

--- a/samples/retail/designs/0739c454-45d6-4c99-962a-7b0b9e113a22.html
+++ b/samples/retail/designs/0739c454-45d6-4c99-962a-7b0b9e113a22.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>注文完了 — リテール総合</title>
+  <meta name="viewport" content="width=1280">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="../../common.css">
+</head>
+<body>
+<div class="app-shell">
+  <header class="app-header">
+    <h1 class="app-title"><i class="bi bi-shop"></i> リテール総合システム</h1>
+  </header>
+
+  <div class="app-body">
+    <aside class="app-sidebar">
+      <ul>
+        <li><a href="/"><i class="bi bi-speedometer2"></i> ダッシュボード</a></li>
+        <li><a href="/products/search"><i class="bi bi-search"></i> 商品検索</a></li>
+        <li><a href="/cart"><i class="bi bi-cart3"></i> カート</a></li>
+        <li><a href="/inventory"><i class="bi bi-box-seam"></i> 在庫管理</a></li>
+        <li><a href="/orders"><i class="bi bi-receipt"></i> 注文一覧</a></li>
+      </ul>
+    </aside>
+
+    <main class="app-main">
+      <!-- ステップインジケータ -->
+      <div class="mb-4">
+        <div class="d-flex align-items-center gap-2">
+          <span class="badge bg-success rounded-pill px-3 py-2">1. カート</span>
+          <i class="bi bi-chevron-right text-muted"></i>
+          <span class="badge bg-success rounded-pill px-3 py-2">2. 注文確認</span>
+          <i class="bi bi-chevron-right text-muted"></i>
+          <span class="badge bg-success rounded-pill px-3 py-2">3. 注文完了</span>
+        </div>
+      </div>
+
+      <!-- 完了メッセージ -->
+      <div class="text-center mb-5">
+        <div class="mb-3">
+          <i class="bi bi-check-circle-fill text-success" style="font-size: 4rem;"></i>
+        </div>
+        <h1 class="h2 fw-bold text-success mb-2">注文が確定しました</h1>
+        <p class="text-muted">ご注文ありがとうございます。以下の注文番号でお問い合わせいただけます。</p>
+        <div class="d-inline-block bg-light border rounded px-4 py-3 mt-2">
+          <p class="text-muted small mb-1">注文番号</p>
+          <p class="fs-3 fw-bold font-monospace mb-0" id="orderNumber" data-item-id="orderNumber">ORD-2026-000024</p>
+        </div>
+      </div>
+
+      <!-- 注文サマリ -->
+      <div class="row justify-content-center">
+        <div class="col-lg-7">
+          <div class="card mb-4">
+            <div class="card-header">
+              <h2 class="h6 mb-0"><i class="bi bi-receipt me-2"></i>注文内容</h2>
+            </div>
+            <div class="card-body p-0">
+              <table class="table table-striped mb-0">
+                <thead class="table-light">
+                  <tr>
+                    <th>商品コード</th>
+                    <th>商品名</th>
+                    <th class="text-center" style="width:60px">数量</th>
+                    <th class="text-end" style="width:100px">小計</th>
+                  </tr>
+                </thead>
+                <tbody id="orderItems" data-item-id="orderItems">
+                  <tr>
+                    <td class="fw-mono">P-0001</td>
+                    <td>ワイヤレスイヤホン Pro</td>
+                    <td class="text-center">2</td>
+                    <td class="text-end">¥44,000</td>
+                  </tr>
+                  <tr>
+                    <td class="fw-mono">P-0003</td>
+                    <td>USB-C ハブ 7in1</td>
+                    <td class="text-center">1</td>
+                    <td class="text-end">¥6,800</td>
+                  </tr>
+                  <tr>
+                    <td class="fw-mono">P-0005</td>
+                    <td>4K モバイルモニター 15.6"</td>
+                    <td class="text-center">1</td>
+                    <td class="text-end">¥68,000</td>
+                  </tr>
+                </tbody>
+                <tfoot class="table-light">
+                  <tr>
+                    <td colspan="3" class="text-end fw-bold">お支払い合計 (税込)</td>
+                    <td class="text-end fw-bold fs-6" id="totalAmount" data-item-id="totalAmount">¥118,800</td>
+                  </tr>
+                </tfoot>
+              </table>
+            </div>
+          </div>
+
+          <!-- 配送情報 -->
+          <div class="card mb-4">
+            <div class="card-header">
+              <h2 class="h6 mb-0"><i class="bi bi-truck me-2"></i>配送情報</h2>
+            </div>
+            <div class="card-body">
+              <dl class="row mb-0">
+                <dt class="col-sm-4 text-muted">配送先住所</dt>
+                <dd class="col-sm-8" id="shippingAddressDisplay" data-item-id="shippingAddressDisplay">
+                  東京都新宿区新宿 X-X-X
+                </dd>
+                <dt class="col-sm-4 text-muted">配送状況</dt>
+                <dd class="col-sm-8">
+                  <span class="badge bg-warning text-dark">配送指示待ち</span>
+                </dd>
+              </dl>
+            </div>
+          </div>
+
+          <!-- アクションボタン -->
+          <div class="d-flex gap-3 justify-content-center">
+            <a href="/" class="btn btn-outline-primary">
+              <i class="bi bi-speedometer2 me-1"></i>ダッシュボードへ
+            </a>
+            <a href="/orders" class="btn btn-primary">
+              <i class="bi bi-receipt me-1"></i>注文履歴を確認する
+            </a>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/samples/retail/designs/2e23d129-1d53-4e30-b54c-97f90b910578.html
+++ b/samples/retail/designs/2e23d129-1d53-4e30-b54c-97f90b910578.html
@@ -1,0 +1,249 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>商品マスター — リテール総合</title>
+  <meta name="viewport" content="width=1280">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="../../common.css">
+</head>
+<body>
+<div class="app-shell">
+  <header class="app-header">
+    <h1 class="app-title"><i class="bi bi-shop"></i> リテール総合システム</h1>
+  </header>
+
+  <div class="app-body">
+    <aside class="app-sidebar">
+      <ul>
+        <li><a href="/"><i class="bi bi-speedometer2"></i> ダッシュボード</a></li>
+        <li><a href="/products/search"><i class="bi bi-search"></i> 商品検索</a></li>
+        <li><a href="/cart"><i class="bi bi-cart3"></i> カート</a></li>
+        <li><a href="/inventory"><i class="bi bi-box-seam"></i> 在庫管理</a></li>
+        <li><a href="/orders"><i class="bi bi-receipt"></i> 注文一覧</a></li>
+        <li><a href="#" class="active"><i class="bi bi-gear"></i> 商品マスター</a></li>
+        <li><a href="/master/customers"><i class="bi bi-people"></i> 顧客マスター</a></li>
+        <li><a href="/master/stores"><i class="bi bi-shop-window"></i> 店舗マスター</a></li>
+      </ul>
+    </aside>
+
+    <main class="app-main">
+      <div class="page-header">
+        <h1 class="page-title"><i class="bi bi-box me-2"></i>商品マスター</h1>
+        <nav class="breadcrumb-area">ホーム &gt; マスター管理 &gt; 商品マスター</nav>
+      </div>
+
+      <!-- 検索条件 -->
+      <section class="search-area">
+        <div class="search-fields">
+          <div class="search-field">
+            <label for="productCodeSearch" class="form-label">商品コード</label>
+            <input
+              type="text"
+              id="productCodeSearch"
+              name="productCodeSearch"
+              data-item-id="productCodeSearch"
+              class="form-control form-control-sm"
+              placeholder="例: P-0001"
+              maxlength="20"
+              style="width:140px"
+            >
+          </div>
+          <div class="search-field">
+            <label for="productNameSearch" class="form-label">商品名</label>
+            <input
+              type="text"
+              id="productNameSearch"
+              name="productNameSearch"
+              data-item-id="productNameSearch"
+              class="form-control form-control-sm"
+              placeholder="商品名で検索"
+              maxlength="100"
+              style="width:200px"
+            >
+          </div>
+          <div class="search-field">
+            <label for="categorySearch" class="form-label">カテゴリ</label>
+            <select
+              id="categorySearch"
+              name="categorySearch"
+              data-item-id="categorySearch"
+              class="form-select form-select-sm"
+              style="width:140px"
+            >
+              <option value="">全て</option>
+              <option value="electronics">電子機器</option>
+              <option value="peripheral">周辺機器</option>
+              <option value="display">ディスプレイ</option>
+              <option value="storage">ストレージ</option>
+            </select>
+          </div>
+          <div class="search-field">
+            <label for="isActiveSearch" class="form-label">有効/無効</label>
+            <select
+              id="isActiveSearch"
+              name="isActiveSearch"
+              data-item-id="isActiveSearch"
+              class="form-select form-select-sm"
+              style="width:120px"
+            >
+              <option value="">全て</option>
+              <option value="true" selected>有効</option>
+              <option value="false">無効</option>
+            </select>
+          </div>
+        </div>
+        <div class="search-buttons">
+          <button type="button" class="btn btn-outline-secondary btn-sm">
+            <i class="bi bi-x-circle"></i> クリア
+          </button>
+          <button type="button" class="btn btn-primary btn-sm">
+            <i class="bi bi-search"></i> 検索
+          </button>
+        </div>
+      </section>
+
+      <!-- 商品一覧テーブル -->
+      <section class="data-table-wrap">
+        <div class="data-table-toolbar">
+          <span>表示中: <strong>156</strong> 件</span>
+          <span class="spacer"></span>
+          <button type="button" class="btn btn-outline-success btn-sm">
+            <i class="bi bi-plus-lg"></i> 新規登録
+          </button>
+          <button type="button" class="btn btn-outline-secondary btn-sm">
+            <i class="bi bi-download"></i> CSV 出力
+          </button>
+        </div>
+
+        <table class="data-table">
+          <thead>
+            <tr>
+              <th style="width:40px"><input type="checkbox" aria-label="全て選択"></th>
+              <th class="sortable sort-asc" style="width:130px">商品コード</th>
+              <th class="sortable">商品名</th>
+              <th class="sortable" style="width:120px">カテゴリ</th>
+              <th class="sortable num" style="width:120px">単価 (税抜)</th>
+              <th class="sortable num" style="width:80px">在庫数</th>
+              <th style="width:80px">有効</th>
+              <th style="width:120px">最終更新</th>
+              <th style="width:120px">操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><input type="checkbox" aria-label="選択"></td>
+              <td class="fw-mono">P-0001</td>
+              <td>ワイヤレスイヤホン Pro</td>
+              <td>電子機器</td>
+              <td class="num">¥20,000</td>
+              <td class="num">125</td>
+              <td><span class="badge bg-success">有効</span></td>
+              <td>2026/05/01</td>
+              <td class="d-flex gap-1">
+                <button type="button" class="btn btn-sm btn-outline-primary" aria-label="編集">
+                  <i class="bi bi-pencil"></i>
+                </button>
+                <button type="button" class="btn btn-sm btn-outline-danger" aria-label="削除">
+                  <i class="bi bi-trash"></i>
+                </button>
+              </td>
+            </tr>
+            <tr>
+              <td><input type="checkbox" aria-label="選択"></td>
+              <td class="fw-mono">P-0002</td>
+              <td>スマートウォッチ SE</td>
+              <td>電子機器</td>
+              <td class="num">¥35,000</td>
+              <td class="num text-warning">8</td>
+              <td><span class="badge bg-success">有効</span></td>
+              <td>2026/04/28</td>
+              <td class="d-flex gap-1">
+                <button type="button" class="btn btn-sm btn-outline-primary" aria-label="編集">
+                  <i class="bi bi-pencil"></i>
+                </button>
+                <button type="button" class="btn btn-sm btn-outline-danger" aria-label="削除">
+                  <i class="bi bi-trash"></i>
+                </button>
+              </td>
+            </tr>
+            <tr>
+              <td><input type="checkbox" aria-label="選択"></td>
+              <td class="fw-mono">P-0003</td>
+              <td>USB-C ハブ 7in1</td>
+              <td>周辺機器</td>
+              <td class="num">¥6,182</td>
+              <td class="num">350</td>
+              <td><span class="badge bg-success">有効</span></td>
+              <td>2026/04/15</td>
+              <td class="d-flex gap-1">
+                <button type="button" class="btn btn-sm btn-outline-primary" aria-label="編集">
+                  <i class="bi bi-pencil"></i>
+                </button>
+                <button type="button" class="btn btn-sm btn-outline-danger" aria-label="削除">
+                  <i class="bi bi-trash"></i>
+                </button>
+              </td>
+            </tr>
+            <tr class="table-secondary">
+              <td><input type="checkbox" aria-label="選択"></td>
+              <td class="fw-mono">P-0007</td>
+              <td>旧型ポータブル SSD 256GB</td>
+              <td>ストレージ</td>
+              <td class="num">¥4,500</td>
+              <td class="num">0</td>
+              <td><span class="badge bg-secondary">無効</span></td>
+              <td>2026/01/10</td>
+              <td class="d-flex gap-1">
+                <button type="button" class="btn btn-sm btn-outline-primary" aria-label="編集">
+                  <i class="bi bi-pencil"></i>
+                </button>
+                <button type="button" class="btn btn-sm btn-outline-danger" aria-label="削除">
+                  <i class="bi bi-trash"></i>
+                </button>
+              </td>
+            </tr>
+            <tr>
+              <td><input type="checkbox" aria-label="選択"></td>
+              <td class="fw-mono">P-0005</td>
+              <td>4K モバイルモニター 15.6"</td>
+              <td>ディスプレイ</td>
+              <td class="num">¥61,818</td>
+              <td class="num">47</td>
+              <td><span class="badge bg-success">有効</span></td>
+              <td>2026/04/20</td>
+              <td class="d-flex gap-1">
+                <button type="button" class="btn btn-sm btn-outline-primary" aria-label="編集">
+                  <i class="bi bi-pencil"></i>
+                </button>
+                <button type="button" class="btn btn-sm btn-outline-danger" aria-label="削除">
+                  <i class="bi bi-trash"></i>
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="paging-area">
+          <span class="paging-count">1 - 10 / 156 件</span>
+          <span class="spacer"></span>
+          <nav aria-label="ページネーション">
+            <ul class="pagination pagination-sm mb-0">
+              <li class="page-item disabled"><a class="page-link" href="#">&laquo;</a></li>
+              <li class="page-item active"><a class="page-link" href="#">1</a></li>
+              <li class="page-item"><a class="page-link" href="#">2</a></li>
+              <li class="page-item"><a class="page-link" href="#">3</a></li>
+              <li class="page-item"><a class="page-link" href="#">16</a></li>
+              <li class="page-item"><a class="page-link" href="#">&raquo;</a></li>
+            </ul>
+          </nav>
+        </div>
+      </section>
+    </main>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/samples/retail/designs/4a9df651-e0cc-4523-a9bf-f3fb9d45c53f.html
+++ b/samples/retail/designs/4a9df651-e0cc-4523-a9bf-f3fb9d45c53f.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>在庫一覧 — リテール総合</title>
+  <meta name="viewport" content="width=1280">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="../../common.css">
+</head>
+<body>
+<div class="app-shell">
+  <header class="app-header">
+    <h1 class="app-title"><i class="bi bi-shop"></i> リテール総合システム</h1>
+  </header>
+
+  <div class="app-body">
+    <aside class="app-sidebar">
+      <ul>
+        <li><a href="/"><i class="bi bi-speedometer2"></i> ダッシュボード</a></li>
+        <li><a href="/products/search"><i class="bi bi-search"></i> 商品検索</a></li>
+        <li><a href="/cart"><i class="bi bi-cart3"></i> カート</a></li>
+        <li><a href="#" class="active"><i class="bi bi-box-seam"></i> 在庫管理</a></li>
+        <li><a href="/orders"><i class="bi bi-receipt"></i> 注文一覧</a></li>
+        <li><a href="/master/products"><i class="bi bi-gear"></i> マスター管理</a></li>
+      </ul>
+    </aside>
+
+    <main class="app-main">
+      <div class="page-header">
+        <h1 class="page-title"><i class="bi bi-box-seam me-2"></i>在庫一覧</h1>
+        <nav class="breadcrumb-area">ホーム &gt; 在庫管理 &gt; 在庫一覧</nav>
+      </div>
+
+      <!-- 検索・フィルタ -->
+      <section class="search-area">
+        <div class="search-fields">
+          <div class="search-field">
+            <label for="storeFilter" class="form-label">店舗</label>
+            <select
+              id="storeFilter"
+              name="storeFilter"
+              data-item-id="storeFilter"
+              class="form-select form-select-sm"
+              style="width:160px"
+              aria-label="店舗を選択してください"
+            >
+              <option value="S-001" selected>東京本店</option>
+              <option value="S-002">大阪支店</option>
+              <option value="S-003">名古屋支店</option>
+              <option value="S-004">福岡支店</option>
+              <option value="S-005">仙台支店</option>
+            </select>
+          </div>
+          <div class="search-field">
+            <label for="productCodeFilter" class="form-label">商品コード</label>
+            <input
+              type="text"
+              id="productCodeFilter"
+              name="productCodeFilter"
+              data-item-id="productCodeFilter"
+              class="form-control form-control-sm"
+              placeholder="例: P-0001"
+              style="width:140px"
+            >
+          </div>
+          <div class="search-field align-self-end">
+            <div class="form-check">
+              <input
+                class="form-check-input"
+                type="checkbox"
+                id="lowStockOnly"
+                name="lowStockOnly"
+                data-item-id="lowStockOnly"
+              >
+              <label class="form-check-label" for="lowStockOnly">
+                <span class="badge bg-warning text-dark me-1">低在庫のみ</span>表示
+              </label>
+            </div>
+          </div>
+        </div>
+        <div class="search-buttons">
+          <button type="button" class="btn btn-outline-secondary btn-sm">
+            <i class="bi bi-x-circle"></i> クリア
+          </button>
+          <button type="button" class="btn btn-primary btn-sm">
+            <i class="bi bi-search"></i> 絞り込み
+          </button>
+        </div>
+      </section>
+
+      <!-- 在庫アラートサマリ -->
+      <div class="alert alert-warning d-flex align-items-center gap-2 mb-3" role="alert">
+        <i class="bi bi-exclamation-triangle-fill fs-5"></i>
+        <div>
+          <strong>東京本店</strong> で低在庫品目が <strong>8 件</strong> あります。早期の補充を推奨します。
+        </div>
+      </div>
+
+      <!-- 在庫テーブル -->
+      <section class="data-table-wrap">
+        <div class="data-table-toolbar">
+          <span>表示中: <strong>38</strong> 件</span>
+          <span class="spacer"></span>
+          <button type="button" class="btn btn-outline-secondary btn-sm">
+            <i class="bi bi-download"></i> CSV 出力
+          </button>
+        </div>
+
+        <table class="data-table">
+          <thead>
+            <tr>
+              <th class="sortable sort-asc" style="width:140px">商品コード</th>
+              <th class="sortable">商品名</th>
+              <th class="sortable" style="width:120px">カテゴリ</th>
+              <th class="sortable num" style="width:100px">在庫数</th>
+              <th style="width:120px">状態</th>
+              <th style="width:120px">最終更新</th>
+              <th style="width:100px">操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="fw-mono">P-0001</td>
+              <td>ワイヤレスイヤホン Pro</td>
+              <td>電子機器</td>
+              <td class="num">125</td>
+              <td><span class="badge bg-success">正常</span></td>
+              <td>2026/05/01</td>
+              <td><button type="button" class="btn btn-sm btn-outline-secondary">補充</button></td>
+            </tr>
+            <tr class="table-warning">
+              <td class="fw-mono">P-0002</td>
+              <td>スマートウォッチ SE</td>
+              <td>電子機器</td>
+              <td class="num fw-bold text-warning">8</td>
+              <td><span class="badge bg-warning text-dark"><i class="bi bi-exclamation-triangle me-1"></i>低在庫</span></td>
+              <td>2026/05/02</td>
+              <td><button type="button" class="btn btn-sm btn-warning text-dark">補充要請</button></td>
+            </tr>
+            <tr>
+              <td class="fw-mono">P-0003</td>
+              <td>USB-C ハブ 7in1</td>
+              <td>周辺機器</td>
+              <td class="num">350</td>
+              <td><span class="badge bg-success">正常</span></td>
+              <td>2026/04/30</td>
+              <td><button type="button" class="btn btn-sm btn-outline-secondary">補充</button></td>
+            </tr>
+            <tr class="table-danger">
+              <td class="fw-mono">P-0004</td>
+              <td>メカニカルキーボード TKL</td>
+              <td>周辺機器</td>
+              <td class="num fw-bold text-danger">3</td>
+              <td><span class="badge bg-danger"><i class="bi bi-x-circle me-1"></i>要補充</span></td>
+              <td>2026/05/02</td>
+              <td><button type="button" class="btn btn-sm btn-danger">緊急補充</button></td>
+            </tr>
+            <tr>
+              <td class="fw-mono">P-0005</td>
+              <td>4K モバイルモニター 15.6"</td>
+              <td>ディスプレイ</td>
+              <td class="num">47</td>
+              <td><span class="badge bg-success">正常</span></td>
+              <td>2026/04/28</td>
+              <td><button type="button" class="btn btn-sm btn-outline-secondary">補充</button></td>
+            </tr>
+            <tr class="table-warning">
+              <td class="fw-mono">P-0006</td>
+              <td>ゲーミングマウス 8K</td>
+              <td>周辺機器</td>
+              <td class="num fw-bold text-warning">5</td>
+              <td><span class="badge bg-warning text-dark"><i class="bi bi-exclamation-triangle me-1"></i>低在庫</span></td>
+              <td>2026/05/01</td>
+              <td><button type="button" class="btn btn-sm btn-warning text-dark">補充要請</button></td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="paging-area">
+          <span class="paging-count">1 - 10 / 38 件</span>
+          <span class="spacer"></span>
+          <nav aria-label="ページネーション">
+            <ul class="pagination pagination-sm mb-0">
+              <li class="page-item disabled"><a class="page-link" href="#">&laquo;</a></li>
+              <li class="page-item active"><a class="page-link" href="#">1</a></li>
+              <li class="page-item"><a class="page-link" href="#">2</a></li>
+              <li class="page-item"><a class="page-link" href="#">3</a></li>
+              <li class="page-item"><a class="page-link" href="#">4</a></li>
+              <li class="page-item"><a class="page-link" href="#">&raquo;</a></li>
+            </ul>
+          </nav>
+        </div>
+      </section>
+
+      <div class="mt-2 small text-muted">
+        <i class="bi bi-info-circle me-1"></i>
+        低在庫閾値: 在庫 10 個以下で警告を表示します。
+      </div>
+    </main>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/samples/retail/designs/765c3c23-8a0e-46b0-ae8b-ce84d10be0b0.html
+++ b/samples/retail/designs/765c3c23-8a0e-46b0-ae8b-ce84d10be0b0.html
@@ -1,0 +1,228 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>ダッシュボード — リテール総合</title>
+  <meta name="viewport" content="width=1280">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="../../common.css">
+</head>
+<body>
+<div class="app-shell">
+  <header class="app-header">
+    <h1 class="app-title"><i class="bi bi-shop"></i> リテール総合システム</h1>
+  </header>
+
+  <div class="app-body">
+    <aside class="app-sidebar">
+      <ul>
+        <li><a href="#" class="active"><i class="bi bi-speedometer2"></i> ダッシュボード</a></li>
+        <li><a href="#"><i class="bi bi-search"></i> 商品検索</a></li>
+        <li><a href="#"><i class="bi bi-cart3"></i> カート</a></li>
+        <li><a href="#"><i class="bi bi-box-seam"></i> 在庫管理</a></li>
+        <li><a href="#"><i class="bi bi-receipt"></i> 注文一覧</a></li>
+        <li><a href="#"><i class="bi bi-gear"></i> マスター管理</a></li>
+      </ul>
+    </aside>
+
+    <main class="app-main">
+      <div class="page-header">
+        <h1 class="page-title">ダッシュボード</h1>
+        <nav class="breadcrumb-area">ホーム &gt; ダッシュボード</nav>
+      </div>
+
+      <!-- KPI カード -->
+      <section class="mb-4">
+        <h2 class="h6 text-muted mb-3"><i class="bi bi-bar-chart-line"></i> 本日の状況 — 2026/05/02</h2>
+        <div class="row g-3">
+          <div class="col-xl-3 col-md-6">
+            <div class="card border-0 shadow-sm h-100">
+              <div class="card-body d-flex align-items-center gap-3">
+                <div class="rounded-circle bg-primary bg-opacity-10 p-3">
+                  <i class="bi bi-currency-yen fs-3 text-primary"></i>
+                </div>
+                <div>
+                  <p class="text-muted small mb-1">今日の売上</p>
+                  <p class="fs-3 fw-bold mb-0" id="todaySales" data-item-id="todaySales">¥1,842,500</p>
+                  <p class="text-success small mb-0"><i class="bi bi-arrow-up"></i> 前日比 +12%</p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="col-xl-3 col-md-6">
+            <div class="card border-0 shadow-sm h-100">
+              <div class="card-body d-flex align-items-center gap-3">
+                <div class="rounded-circle bg-warning bg-opacity-10 p-3">
+                  <i class="bi bi-exclamation-triangle fs-3 text-warning"></i>
+                </div>
+                <div>
+                  <p class="text-muted small mb-1">在庫アラート</p>
+                  <p class="fs-3 fw-bold mb-0" id="lowStockCount" data-item-id="lowStockCount">8 件</p>
+                  <p class="text-warning small mb-0"><i class="bi bi-arrow-up"></i> 低在庫品目数</p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="col-xl-3 col-md-6">
+            <div class="card border-0 shadow-sm h-100">
+              <div class="card-body d-flex align-items-center gap-3">
+                <div class="rounded-circle bg-info bg-opacity-10 p-3">
+                  <i class="bi bi-truck fs-3 text-info"></i>
+                </div>
+                <div>
+                  <p class="text-muted small mb-1">配送待ち件数</p>
+                  <p class="fs-3 fw-bold mb-0" id="pendingDispatch" data-item-id="pendingDispatch">23 件</p>
+                  <p class="text-info small mb-0"><i class="bi bi-clock"></i> 指示待ち</p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="col-xl-3 col-md-6">
+            <div class="card border-0 shadow-sm h-100">
+              <div class="card-body d-flex align-items-center gap-3">
+                <div class="rounded-circle bg-success bg-opacity-10 p-3">
+                  <i class="bi bi-people fs-3 text-success"></i>
+                </div>
+                <div>
+                  <p class="text-muted small mb-1">顧客数</p>
+                  <p class="fs-3 fw-bold mb-0" id="customerCount" data-item-id="customerCount">3,142</p>
+                  <p class="text-success small mb-0"><i class="bi bi-arrow-up"></i> 今月 +47 名</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- シナリオナビゲーション -->
+      <section class="mb-4">
+        <h2 class="h6 text-muted mb-3"><i class="bi bi-grid-3x2-gap"></i> 業務メニュー</h2>
+        <div class="row g-3">
+          <div class="col-xl-3 col-md-6">
+            <div class="card h-100 border-primary border-opacity-25">
+              <div class="card-header bg-primary text-white">
+                <i class="bi bi-search me-2"></i>商品検索・在庫照会
+              </div>
+              <div class="card-body">
+                <p class="card-text text-muted small">商品コードや店舗を指定して在庫を照会します。低在庫品目はバッジで確認できます。</p>
+                <a href="/products/search" class="btn btn-primary btn-sm w-100">
+                  <i class="bi bi-arrow-right-circle me-1"></i>商品検索へ
+                </a>
+              </div>
+            </div>
+          </div>
+          <div class="col-xl-3 col-md-6">
+            <div class="card h-100 border-success border-opacity-25">
+              <div class="card-header bg-success text-white">
+                <i class="bi bi-cart3 me-2"></i>カート・注文確定
+              </div>
+              <div class="card-body">
+                <p class="card-text text-muted small">商品をカートに追加し、配送先を入力して注文を確定します。</p>
+                <a href="/cart" class="btn btn-success btn-sm w-100">
+                  <i class="bi bi-arrow-right-circle me-1"></i>カートへ
+                </a>
+              </div>
+            </div>
+          </div>
+          <div class="col-xl-3 col-md-6">
+            <div class="card h-100 border-warning border-opacity-25">
+              <div class="card-header bg-warning text-dark">
+                <i class="bi bi-truck me-2"></i>注文一覧・配送指示
+              </div>
+              <div class="card-body">
+                <p class="card-text text-muted small">受注した注文の一覧を確認し、配送会社への指示を登録します。</p>
+                <a href="/orders" class="btn btn-warning btn-sm w-100 text-dark">
+                  <i class="bi bi-arrow-right-circle me-1"></i>注文一覧へ
+                </a>
+              </div>
+            </div>
+          </div>
+          <div class="col-xl-3 col-md-6">
+            <div class="card h-100 border-secondary border-opacity-25">
+              <div class="card-header bg-secondary text-white">
+                <i class="bi bi-box-seam me-2"></i>在庫一覧・補充
+              </div>
+              <div class="card-body">
+                <p class="card-text text-muted small">店舗別在庫を一覧表示します。低在庫品目は赤バッジで警告されます。</p>
+                <a href="/inventory" class="btn btn-secondary btn-sm w-100">
+                  <i class="bi bi-arrow-right-circle me-1"></i>在庫一覧へ
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- 最近の注文 -->
+      <section class="mb-4">
+        <div class="card border-0 shadow-sm">
+          <div class="card-header bg-transparent d-flex align-items-center justify-content-between">
+            <h2 class="h6 mb-0"><i class="bi bi-receipt me-2"></i>最近の注文 (直近 5 件)</h2>
+            <a href="/orders" class="btn btn-outline-primary btn-sm">すべて表示</a>
+          </div>
+          <div class="card-body p-0">
+            <table class="table table-striped table-hover mb-0">
+              <thead class="table-light">
+                <tr>
+                  <th>注文番号</th>
+                  <th>顧客名</th>
+                  <th class="text-end">合計金額</th>
+                  <th>ステータス</th>
+                  <th>注文日時</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td class="fw-mono">ORD-2026-000023</td>
+                  <td>田中 太郎</td>
+                  <td class="text-end">¥38,500</td>
+                  <td><span class="badge bg-warning text-dark">配送待ち</span></td>
+                  <td>2026/05/02 14:32</td>
+                  <td><a href="/orders/23/dispatch" class="btn btn-sm btn-outline-primary">配送指示</a></td>
+                </tr>
+                <tr>
+                  <td class="fw-mono">ORD-2026-000022</td>
+                  <td>鈴木 花子</td>
+                  <td class="text-end">¥12,800</td>
+                  <td><span class="badge bg-info text-dark">配送中</span></td>
+                  <td>2026/05/02 11:15</td>
+                  <td><button type="button" class="btn btn-sm btn-outline-secondary" disabled>追跡確認</button></td>
+                </tr>
+                <tr>
+                  <td class="fw-mono">ORD-2026-000021</td>
+                  <td>佐藤 一郎</td>
+                  <td class="text-end">¥5,400</td>
+                  <td><span class="badge bg-success">完了</span></td>
+                  <td>2026/05/01 16:48</td>
+                  <td><button type="button" class="btn btn-sm btn-outline-secondary" disabled>詳細</button></td>
+                </tr>
+                <tr>
+                  <td class="fw-mono">ORD-2026-000020</td>
+                  <td>山田 次郎</td>
+                  <td class="text-end">¥94,000</td>
+                  <td><span class="badge bg-warning text-dark">配送待ち</span></td>
+                  <td>2026/05/01 09:21</td>
+                  <td><a href="/orders/20/dispatch" class="btn btn-sm btn-outline-primary">配送指示</a></td>
+                </tr>
+                <tr>
+                  <td class="fw-mono">ORD-2026-000019</td>
+                  <td>伊藤 美奈</td>
+                  <td class="text-end">¥21,600</td>
+                  <td><span class="badge bg-success">完了</span></td>
+                  <td>2026/04/30 17:55</td>
+                  <td><button type="button" class="btn btn-sm btn-outline-secondary" disabled>詳細</button></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+    </main>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/samples/retail/designs/c2254dd6-ab5d-4428-931f-d27c71e89951.html
+++ b/samples/retail/designs/c2254dd6-ab5d-4428-931f-d27c71e89951.html
@@ -1,0 +1,221 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>配送指示 — リテール総合</title>
+  <meta name="viewport" content="width=1280">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="../../common.css">
+</head>
+<body>
+<div class="app-shell">
+  <header class="app-header">
+    <h1 class="app-title"><i class="bi bi-shop"></i> リテール総合システム</h1>
+  </header>
+
+  <div class="app-body">
+    <aside class="app-sidebar">
+      <ul>
+        <li><a href="/"><i class="bi bi-speedometer2"></i> ダッシュボード</a></li>
+        <li><a href="/products/search"><i class="bi bi-search"></i> 商品検索</a></li>
+        <li><a href="/cart"><i class="bi bi-cart3"></i> カート</a></li>
+        <li><a href="/inventory"><i class="bi bi-box-seam"></i> 在庫管理</a></li>
+        <li><a href="/orders" class="active"><i class="bi bi-receipt"></i> 注文一覧</a></li>
+        <li><a href="/master/products"><i class="bi bi-gear"></i> マスター管理</a></li>
+      </ul>
+    </aside>
+
+    <main class="app-main">
+      <div class="page-header">
+        <h1 class="page-title"><i class="bi bi-truck me-2"></i>配送指示</h1>
+        <nav class="breadcrumb-area">ホーム &gt; 注文一覧 &gt; 配送指示</nav>
+      </div>
+
+      <div class="row g-4">
+        <!-- 左: 注文詳細 (read-only) -->
+        <div class="col-lg-6">
+          <div class="card mb-4">
+            <div class="card-header">
+              <h2 class="h6 mb-0"><i class="bi bi-receipt me-2"></i>注文詳細 (確認)</h2>
+            </div>
+            <div class="card-body">
+              <dl class="row mb-0">
+                <dt class="col-sm-5 text-muted">注文番号</dt>
+                <dd class="col-sm-7 font-monospace fw-bold" id="orderNumberDisplay" data-item-id="orderNumberDisplay">ORD-2026-000024</dd>
+
+                <dt class="col-sm-5 text-muted">顧客名</dt>
+                <dd class="col-sm-7" id="customerNameDisplay" data-item-id="customerNameDisplay">田中 太郎</dd>
+
+                <dt class="col-sm-5 text-muted">注文日時</dt>
+                <dd class="col-sm-7">2026/05/02 14:32</dd>
+
+                <dt class="col-sm-5 text-muted">配送先住所</dt>
+                <dd class="col-sm-7" id="shippingAddressDisplay" data-item-id="shippingAddressDisplay">
+                  〒160-0022<br>東京都新宿区新宿 X-X-X
+                </dd>
+
+                <dt class="col-sm-5 text-muted">ステータス</dt>
+                <dd class="col-sm-7"><span class="badge bg-warning text-dark">配送待ち</span></dd>
+              </dl>
+            </div>
+          </div>
+
+          <!-- 注文商品一覧 (read-only) -->
+          <div class="card">
+            <div class="card-header">
+              <h2 class="h6 mb-0"><i class="bi bi-list-ul me-2"></i>注文商品</h2>
+            </div>
+            <div class="card-body p-0">
+              <table class="table table-sm mb-0">
+                <thead class="table-light">
+                  <tr>
+                    <th>商品コード</th>
+                    <th>商品名</th>
+                    <th class="text-center" style="width:60px">数量</th>
+                    <th class="text-end" style="width:100px">小計</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td class="fw-mono">P-0001</td>
+                    <td>ワイヤレスイヤホン Pro</td>
+                    <td class="text-center">2</td>
+                    <td class="text-end">¥44,000</td>
+                  </tr>
+                  <tr>
+                    <td class="fw-mono">P-0003</td>
+                    <td>USB-C ハブ 7in1</td>
+                    <td class="text-center">1</td>
+                    <td class="text-end">¥6,800</td>
+                  </tr>
+                  <tr>
+                    <td class="fw-mono">P-0005</td>
+                    <td>4K モバイルモニター 15.6"</td>
+                    <td class="text-center">1</td>
+                    <td class="text-end">¥68,000</td>
+                  </tr>
+                </tbody>
+                <tfoot class="table-light">
+                  <tr>
+                    <td colspan="3" class="text-end fw-bold">合計 (税込)</td>
+                    <td class="text-end fw-bold">¥118,800</td>
+                  </tr>
+                </tfoot>
+              </table>
+            </div>
+          </div>
+        </div>
+
+        <!-- 右: 配送指示フォーム -->
+        <div class="col-lg-6">
+          <div class="card border-primary">
+            <div class="card-header bg-primary text-white">
+              <h2 class="h6 mb-0"><i class="bi bi-truck me-2"></i>配送指示入力</h2>
+            </div>
+            <div class="card-body">
+              <form id="dispatchForm" novalidate>
+                <input type="hidden" id="orderId" name="orderId" data-item-id="orderId" value="24">
+
+                <div class="mb-3">
+                  <label for="carrierId" class="form-label">
+                    配送会社 <span class="text-danger">*</span>
+                  </label>
+                  <select
+                    id="carrierId"
+                    name="carrierId"
+                    data-item-id="carrierId"
+                    class="form-select"
+                    required
+                  >
+                    <option value="">配送会社を選択してください</option>
+                    <option value="yamato">ヤマト運輸</option>
+                    <option value="sagawa">佐川急便</option>
+                    <option value="japanpost">日本郵便</option>
+                  </select>
+                  <div class="invalid-feedback">
+                    配送会社を選択してください。
+                  </div>
+                </div>
+
+                <div class="mb-3">
+                  <label for="preferredDate" class="form-label">
+                    配送希望日 <span class="text-danger">*</span>
+                  </label>
+                  <input
+                    type="date"
+                    id="preferredDate"
+                    name="preferredDate"
+                    data-item-id="preferredDate"
+                    class="form-control"
+                    required
+                    min="2026-05-03"
+                    aria-describedby="preferredDateHelp"
+                  >
+                  <div id="preferredDateHelp" class="form-text">翌日以降の日付を選択してください。</div>
+                  <div class="invalid-feedback">
+                    配送希望日を選択してください。
+                  </div>
+                </div>
+
+                <div class="mb-4">
+                  <label for="timeSlot" class="form-label">
+                    配送希望時間帯 <span class="text-danger">*</span>
+                  </label>
+                  <select
+                    id="timeSlot"
+                    name="timeSlot"
+                    data-item-id="timeSlot"
+                    class="form-select"
+                    required
+                  >
+                    <option value="">時間帯を選択してください</option>
+                    <option value="AM">午前中 (8:00〜12:00)</option>
+                    <option value="PM1">14:00〜16:00</option>
+                    <option value="PM2">16:00〜18:00</option>
+                    <option value="PM3">18:00〜20:00</option>
+                    <option value="PM4">19:00〜21:00</option>
+                  </select>
+                  <div class="invalid-feedback">
+                    配送希望時間帯を選択してください。
+                  </div>
+                </div>
+
+                <!-- 配送指示結果 (output) -->
+                <div id="dispatchResult" class="d-none">
+                  <div class="alert alert-success mb-3" role="alert">
+                    <i class="bi bi-check-circle me-2"></i>
+                    <strong>配送指示が完了しました。</strong>
+                    <table class="table table-sm mt-2 mb-0 table-borderless">
+                      <tr>
+                        <td class="text-muted ps-0">追跡番号:</td>
+                        <td id="trackingNumber" data-item-id="trackingNumber" class="fw-bold font-monospace">YMT-1234567890</td>
+                      </tr>
+                      <tr>
+                        <td class="text-muted ps-0">配送予定日:</td>
+                        <td id="estimatedDelivery" data-item-id="estimatedDelivery">2026/05/05</td>
+                      </tr>
+                    </table>
+                  </div>
+                </div>
+
+                <div class="d-grid gap-2">
+                  <button type="submit" class="btn btn-primary">
+                    <i class="bi bi-check2-circle me-1"></i>配送指示を登録する
+                  </button>
+                  <a href="/orders" class="btn btn-outline-secondary">
+                    <i class="bi bi-arrow-left me-1"></i>注文一覧へ戻る
+                  </a>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/samples/retail/designs/c73fa05c-4a71-4593-800d-b9814e97be83.html
+++ b/samples/retail/designs/c73fa05c-4a71-4593-800d-b9814e97be83.html
@@ -1,0 +1,257 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>カート — リテール総合</title>
+  <meta name="viewport" content="width=1280">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="../../common.css">
+</head>
+<body>
+<div class="app-shell">
+  <header class="app-header">
+    <h1 class="app-title"><i class="bi bi-shop"></i> リテール総合システム</h1>
+  </header>
+
+  <div class="app-body">
+    <aside class="app-sidebar">
+      <ul>
+        <li><a href="/"><i class="bi bi-speedometer2"></i> ダッシュボード</a></li>
+        <li><a href="/products/search"><i class="bi bi-search"></i> 商品検索</a></li>
+        <li><a href="#" class="active"><i class="bi bi-cart3"></i> カート</a></li>
+        <li><a href="/inventory"><i class="bi bi-box-seam"></i> 在庫管理</a></li>
+        <li><a href="/orders"><i class="bi bi-receipt"></i> 注文一覧</a></li>
+      </ul>
+    </aside>
+
+    <main class="app-main">
+      <div class="page-header">
+        <h1 class="page-title"><i class="bi bi-cart3 me-2"></i>カート</h1>
+        <nav class="breadcrumb-area">ホーム &gt; カート</nav>
+      </div>
+
+      <div class="row g-4">
+        <!-- 左: 商品追加フォーム + カート明細 -->
+        <div class="col-lg-8">
+
+          <!-- 商品追加フォーム -->
+          <div class="card mb-4 border-primary border-opacity-25">
+            <div class="card-header bg-primary bg-opacity-10">
+              <h2 class="h6 mb-0"><i class="bi bi-plus-circle me-2"></i>商品を追加</h2>
+            </div>
+            <div class="card-body">
+              <form id="addItemForm" novalidate>
+                <div class="row g-3 align-items-end">
+                  <div class="col-md-5">
+                    <label for="addProductCode" class="form-label">
+                      商品コード <span class="text-danger">*</span>
+                    </label>
+                    <input
+                      type="text"
+                      id="addProductCode"
+                      name="addProductCode"
+                      data-item-id="addProductCode"
+                      class="form-control"
+                      placeholder="例: P-0001"
+                      maxlength="20"
+                      required
+                      aria-describedby="productCodeHelp"
+                    >
+                    <div id="productCodeHelp" class="form-text">P- で始まる 4〜6 桁の商品コード</div>
+                    <div class="invalid-feedback">
+                      商品コードは P-XXXX〜P-XXXXXX 形式で入力してください。
+                    </div>
+                  </div>
+                  <div class="col-md-3">
+                    <label for="addQuantity" class="form-label">
+                      数量 <span class="text-danger">*</span>
+                    </label>
+                    <input
+                      type="number"
+                      id="addQuantity"
+                      name="addQuantity"
+                      data-item-id="addQuantity"
+                      class="form-control"
+                      value="1"
+                      min="1"
+                      max="999"
+                      required
+                    >
+                    <div class="invalid-feedback">
+                      数量は 1〜999 の範囲で入力してください。
+                    </div>
+                  </div>
+                  <div class="col-md-4">
+                    <button type="submit" class="btn btn-primary w-100">
+                      <i class="bi bi-cart-plus me-1"></i>カートに追加
+                    </button>
+                  </div>
+                </div>
+              </form>
+            </div>
+          </div>
+
+          <!-- カート明細テーブル -->
+          <div class="card">
+            <div class="card-header d-flex align-items-center justify-content-between">
+              <h2 class="h6 mb-0"><i class="bi bi-list-ul me-2"></i>カート明細</h2>
+              <span class="badge bg-primary rounded-pill" id="cartItemCount" data-item-id="cartItemCount">3 点</span>
+            </div>
+            <div class="card-body p-0">
+              <table class="table table-striped table-hover mb-0">
+                <thead class="table-light">
+                  <tr>
+                    <th>商品コード</th>
+                    <th>商品名</th>
+                    <th class="text-end" style="width:100px">単価</th>
+                    <th class="text-center" style="width:120px">数量</th>
+                    <th class="text-end" style="width:110px">小計</th>
+                    <th style="width:70px"></th>
+                  </tr>
+                </thead>
+                <tbody id="cartItems" data-item-id="cartItems">
+                  <tr>
+                    <td class="fw-mono">P-0001</td>
+                    <td>ワイヤレスイヤホン Pro</td>
+                    <td class="text-end">¥22,000</td>
+                    <td class="text-center">
+                      <div class="d-flex align-items-center justify-content-center gap-1">
+                        <button type="button" class="btn btn-outline-secondary btn-sm" aria-label="数量を減らす">
+                          <i class="bi bi-dash"></i>
+                        </button>
+                        <input
+                          type="number"
+                          class="form-control form-control-sm text-center"
+                          value="2"
+                          min="1"
+                          max="999"
+                          style="width:60px"
+                          aria-label="数量"
+                        >
+                        <button type="button" class="btn btn-outline-secondary btn-sm" aria-label="数量を増やす">
+                          <i class="bi bi-plus"></i>
+                        </button>
+                      </div>
+                    </td>
+                    <td class="text-end fw-bold">¥44,000</td>
+                    <td class="text-center">
+                      <button type="button" class="btn btn-outline-danger btn-sm" aria-label="削除">
+                        <i class="bi bi-trash"></i>
+                      </button>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td class="fw-mono">P-0003</td>
+                    <td>USB-C ハブ 7in1</td>
+                    <td class="text-end">¥6,800</td>
+                    <td class="text-center">
+                      <div class="d-flex align-items-center justify-content-center gap-1">
+                        <button type="button" class="btn btn-outline-secondary btn-sm" aria-label="数量を減らす">
+                          <i class="bi bi-dash"></i>
+                        </button>
+                        <input
+                          type="number"
+                          class="form-control form-control-sm text-center"
+                          value="1"
+                          min="1"
+                          max="999"
+                          style="width:60px"
+                          aria-label="数量"
+                        >
+                        <button type="button" class="btn btn-outline-secondary btn-sm" aria-label="数量を増やす">
+                          <i class="bi bi-plus"></i>
+                        </button>
+                      </div>
+                    </td>
+                    <td class="text-end fw-bold">¥6,800</td>
+                    <td class="text-center">
+                      <button type="button" class="btn btn-outline-danger btn-sm" aria-label="削除">
+                        <i class="bi bi-trash"></i>
+                      </button>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td class="fw-mono">P-0005</td>
+                    <td>4K モバイルモニター 15.6"</td>
+                    <td class="text-end">¥68,000</td>
+                    <td class="text-center">
+                      <div class="d-flex align-items-center justify-content-center gap-1">
+                        <button type="button" class="btn btn-outline-secondary btn-sm" aria-label="数量を減らす">
+                          <i class="bi bi-dash"></i>
+                        </button>
+                        <input
+                          type="number"
+                          class="form-control form-control-sm text-center"
+                          value="1"
+                          min="1"
+                          max="999"
+                          style="width:60px"
+                          aria-label="数量"
+                        >
+                        <button type="button" class="btn btn-outline-secondary btn-sm" aria-label="数量を増やす">
+                          <i class="bi bi-plus"></i>
+                        </button>
+                      </div>
+                    </td>
+                    <td class="text-end fw-bold">¥68,000</td>
+                    <td class="text-center">
+                      <button type="button" class="btn btn-outline-danger btn-sm" aria-label="削除">
+                        <i class="bi bi-trash"></i>
+                      </button>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+
+        <!-- 右: 合計・アクション -->
+        <div class="col-lg-4">
+          <div class="card border-primary">
+            <div class="card-header bg-primary text-white">
+              <h2 class="h6 mb-0"><i class="bi bi-calculator me-2"></i>注文サマリ</h2>
+            </div>
+            <div class="card-body">
+              <table class="table table-sm mb-0">
+                <tbody>
+                  <tr>
+                    <td class="text-muted">小計 (税抜)</td>
+                    <td class="text-end" id="subtotal" data-item-id="subtotal">¥107,091</td>
+                  </tr>
+                  <tr>
+                    <td class="text-muted">消費税 (10%)</td>
+                    <td class="text-end" id="taxAmount" data-item-id="taxAmount">¥10,709</td>
+                  </tr>
+                  <tr class="table-active">
+                    <td class="fw-bold">合計 (税込)</td>
+                    <td class="text-end fw-bold fs-5" id="totalAmount" data-item-id="totalAmount">¥118,800</td>
+                  </tr>
+                </tbody>
+              </table>
+              <hr>
+              <div class="d-grid gap-2">
+                <a href="/cart/confirm" class="btn btn-primary">
+                  <i class="bi bi-arrow-right-circle me-1"></i>注文確認へ
+                </a>
+                <a href="/products/search" class="btn btn-outline-secondary btn-sm">
+                  <i class="bi bi-arrow-left me-1"></i>買い物を続ける
+                </a>
+              </div>
+            </div>
+          </div>
+
+          <div class="mt-3 small text-muted">
+            <p><i class="bi bi-info-circle me-1"></i>カート内の商品は最大 50 点まで追加できます。</p>
+            <p class="mb-0"><i class="bi bi-shield-check me-1 text-success"></i>在庫が不足している商品は注文確定時にエラーが表示されます。</p>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/samples/retail/designs/cff4a398-99cd-4aa5-bfbd-c12d5e72c5f3.html
+++ b/samples/retail/designs/cff4a398-99cd-4aa5-bfbd-c12d5e72c5f3.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>注文確認 — リテール総合</title>
+  <meta name="viewport" content="width=1280">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="../../common.css">
+</head>
+<body>
+<div class="app-shell">
+  <header class="app-header">
+    <h1 class="app-title"><i class="bi bi-shop"></i> リテール総合システム</h1>
+  </header>
+
+  <div class="app-body">
+    <aside class="app-sidebar">
+      <ul>
+        <li><a href="/"><i class="bi bi-speedometer2"></i> ダッシュボード</a></li>
+        <li><a href="/products/search"><i class="bi bi-search"></i> 商品検索</a></li>
+        <li><a href="/cart"><i class="bi bi-cart3"></i> カート</a></li>
+        <li><a href="/inventory"><i class="bi bi-box-seam"></i> 在庫管理</a></li>
+        <li><a href="/orders"><i class="bi bi-receipt"></i> 注文一覧</a></li>
+      </ul>
+    </aside>
+
+    <main class="app-main">
+      <div class="page-header">
+        <h1 class="page-title"><i class="bi bi-clipboard-check me-2"></i>注文確認</h1>
+        <nav class="breadcrumb-area">ホーム &gt; カート &gt; 注文確認</nav>
+      </div>
+
+      <!-- ステップインジケータ -->
+      <div class="mb-4">
+        <div class="d-flex align-items-center gap-2">
+          <span class="badge bg-success rounded-pill px-3 py-2">1. カート</span>
+          <i class="bi bi-chevron-right text-muted"></i>
+          <span class="badge bg-primary rounded-pill px-3 py-2">2. 注文確認</span>
+          <i class="bi bi-chevron-right text-muted"></i>
+          <span class="badge bg-secondary rounded-pill px-3 py-2">3. 注文完了</span>
+        </div>
+      </div>
+
+      <form id="confirmForm" novalidate>
+        <div class="row g-4">
+          <!-- 左: カート明細 (read-only) -->
+          <div class="col-lg-7">
+            <div class="card mb-4">
+              <div class="card-header">
+                <h2 class="h6 mb-0"><i class="bi bi-list-ul me-2"></i>注文商品一覧 (確認)</h2>
+              </div>
+              <div class="card-body p-0">
+                <table class="table table-striped mb-0">
+                  <thead class="table-light">
+                    <tr>
+                      <th>商品コード</th>
+                      <th>商品名</th>
+                      <th class="text-end" style="width:90px">単価</th>
+                      <th class="text-center" style="width:60px">数量</th>
+                      <th class="text-end" style="width:100px">小計</th>
+                    </tr>
+                  </thead>
+                  <tbody id="cartSummary" data-item-id="cartSummary">
+                    <tr>
+                      <td class="fw-mono">P-0001</td>
+                      <td>ワイヤレスイヤホン Pro</td>
+                      <td class="text-end">¥22,000</td>
+                      <td class="text-center">2</td>
+                      <td class="text-end">¥44,000</td>
+                    </tr>
+                    <tr>
+                      <td class="fw-mono">P-0003</td>
+                      <td>USB-C ハブ 7in1</td>
+                      <td class="text-end">¥6,800</td>
+                      <td class="text-center">1</td>
+                      <td class="text-end">¥6,800</td>
+                    </tr>
+                    <tr>
+                      <td class="fw-mono">P-0005</td>
+                      <td>4K モバイルモニター 15.6"</td>
+                      <td class="text-end">¥68,000</td>
+                      <td class="text-center">1</td>
+                      <td class="text-end">¥68,000</td>
+                    </tr>
+                  </tbody>
+                  <tfoot class="table-light">
+                    <tr>
+                      <td colspan="4" class="text-end fw-bold">合計 (税込)</td>
+                      <td class="text-end fw-bold fs-6" id="totalAmountDisplay" data-item-id="totalAmountDisplay">¥118,800</td>
+                    </tr>
+                  </tfoot>
+                </table>
+              </div>
+            </div>
+
+            <!-- 配送先住所 -->
+            <div class="card">
+              <div class="card-header">
+                <h2 class="h6 mb-0"><i class="bi bi-geo-alt me-2"></i>配送先住所</h2>
+              </div>
+              <div class="card-body">
+                <div class="mb-3">
+                  <label for="shippingPostalCode" class="form-label">
+                    郵便番号 <span class="text-danger">*</span>
+                  </label>
+                  <div class="d-flex gap-2 align-items-center">
+                    <input
+                      type="text"
+                      id="shippingPostalCode"
+                      name="shippingPostalCode"
+                      data-item-id="shippingPostalCode"
+                      class="form-control"
+                      placeholder="例: 1600022 (ハイフンなし7桁)"
+                      maxlength="7"
+                      pattern="[0-9]{7}"
+                      required
+                      style="max-width:200px"
+                      aria-describedby="postalCodeHelp"
+                    >
+                    <button type="button" class="btn btn-outline-secondary btn-sm">
+                      <i class="bi bi-search me-1"></i>住所検索
+                    </button>
+                  </div>
+                  <div id="postalCodeHelp" class="form-text">ハイフンなし 7 桁の数字を入力してください。</div>
+                  <div class="invalid-feedback">
+                    郵便番号はハイフンなし 7 桁の数字で入力してください。
+                  </div>
+                </div>
+
+                <div class="mb-3">
+                  <label for="shippingAddress" class="form-label">
+                    住所 <span class="text-danger">*</span>
+                  </label>
+                  <input
+                    type="text"
+                    id="shippingAddress"
+                    name="shippingAddress"
+                    data-item-id="shippingAddress"
+                    class="form-control"
+                    placeholder="例: 東京都新宿区新宿 X-X-X"
+                    maxlength="200"
+                    required
+                  >
+                  <div class="invalid-feedback">
+                    住所を入力してください。
+                  </div>
+                </div>
+
+                <div class="mb-3">
+                  <label for="note" class="form-label">備考</label>
+                  <textarea
+                    id="note"
+                    name="note"
+                    data-item-id="note"
+                    class="form-control"
+                    rows="3"
+                    placeholder="配送に関する特記事項があれば入力してください (任意)"
+                    maxlength="500"
+                  ></textarea>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- 右: アクション -->
+          <div class="col-lg-5">
+            <div class="card border-primary position-sticky" style="top:20px">
+              <div class="card-header bg-primary text-white">
+                <h2 class="h6 mb-0"><i class="bi bi-check2-circle me-2"></i>注文確定</h2>
+              </div>
+              <div class="card-body">
+                <table class="table table-sm mb-3">
+                  <tbody>
+                    <tr>
+                      <td class="text-muted">商品合計 (税込)</td>
+                      <td class="text-end">¥118,800</td>
+                    </tr>
+                    <tr>
+                      <td class="text-muted">送料</td>
+                      <td class="text-end">無料</td>
+                    </tr>
+                    <tr class="table-active">
+                      <td class="fw-bold">お支払い合計</td>
+                      <td class="text-end fw-bold fs-5">¥118,800</td>
+                    </tr>
+                  </tbody>
+                </table>
+
+                <div class="alert alert-info small mb-3" role="alert">
+                  <i class="bi bi-info-circle me-1"></i>
+                  注文確定後のキャンセルはできません。内容をご確認のうえ「注文を確定する」を押してください。
+                </div>
+
+                <div class="d-grid gap-2">
+                  <button type="submit" class="btn btn-primary btn-lg">
+                    <i class="bi bi-check2-circle me-1"></i>注文を確定する
+                  </button>
+                  <a href="/cart" class="btn btn-outline-secondary">
+                    <i class="bi bi-arrow-left me-1"></i>カートに戻る
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </form>
+    </main>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/samples/retail/designs/cff4a398-99cd-4aa5-bfbd-c12d5e72c5f3.html
+++ b/samples/retail/designs/cff4a398-99cd-4aa5-bfbd-c12d5e72c5f3.html
@@ -139,7 +139,7 @@
                     data-item-id="shippingAddress"
                     class="form-control"
                     placeholder="例: 東京都新宿区新宿 X-X-X"
-                    maxlength="200"
+                    maxlength="300"
                     required
                   >
                   <div class="invalid-feedback">

--- a/samples/retail/designs/e6147dc0-94b7-436d-ba87-d0080ac34f44.html
+++ b/samples/retail/designs/e6147dc0-94b7-436d-ba87-d0080ac34f44.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>商品検索 — リテール総合</title>
+  <meta name="viewport" content="width=1280">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="../../common.css">
+</head>
+<body>
+<div class="app-shell">
+  <header class="app-header">
+    <h1 class="app-title"><i class="bi bi-shop"></i> リテール総合システム</h1>
+  </header>
+
+  <div class="app-body">
+    <aside class="app-sidebar">
+      <ul>
+        <li><a href="/"><i class="bi bi-speedometer2"></i> ダッシュボード</a></li>
+        <li><a href="#" class="active"><i class="bi bi-search"></i> 商品検索</a></li>
+        <li><a href="/cart"><i class="bi bi-cart3"></i> カート</a></li>
+        <li><a href="/inventory"><i class="bi bi-box-seam"></i> 在庫管理</a></li>
+        <li><a href="/orders"><i class="bi bi-receipt"></i> 注文一覧</a></li>
+        <li><a href="/master/products"><i class="bi bi-gear"></i> マスター管理</a></li>
+      </ul>
+    </aside>
+
+    <main class="app-main">
+      <div class="page-header">
+        <h1 class="page-title"><i class="bi bi-search me-2"></i>商品検索 / 在庫照会</h1>
+        <nav class="breadcrumb-area">ホーム &gt; 商品検索</nav>
+      </div>
+
+      <!-- 検索フォーム -->
+      <section class="search-area">
+        <form id="searchForm" novalidate>
+          <div class="search-fields">
+            <div class="search-field">
+              <label for="productCode" class="form-label">商品コード</label>
+              <input
+                type="text"
+                id="productCode"
+                name="productCode"
+                data-item-id="productCode"
+                class="form-control form-control-sm"
+                placeholder="例: P-0001"
+                maxlength="20"
+                style="width:160px"
+                aria-label="商品コードを入力してください"
+              >
+            </div>
+            <div class="search-field">
+              <label for="storeCode" class="form-label">店舗</label>
+              <select
+                id="storeCode"
+                name="storeCode"
+                data-item-id="storeCode"
+                class="form-select form-select-sm"
+                style="width:160px"
+                aria-label="店舗を選択してください"
+              >
+                <option value="">全店舗</option>
+                <option value="S-001">東京本店</option>
+                <option value="S-002">大阪支店</option>
+                <option value="S-003">名古屋支店</option>
+                <option value="S-004">福岡支店</option>
+                <option value="S-005">仙台支店</option>
+              </select>
+            </div>
+          </div>
+          <div class="search-buttons">
+            <button type="button" class="btn btn-outline-secondary btn-sm" onclick="document.getElementById('searchForm').reset()">
+              <i class="bi bi-x-circle"></i> クリア
+            </button>
+            <button type="submit" class="btn btn-primary btn-sm">
+              <i class="bi bi-search"></i> 在庫照会
+            </button>
+          </div>
+        </form>
+        <p class="small text-muted mt-2 mb-0">
+          <i class="bi bi-info-circle me-1"></i>
+          商品コードは P- で始まる 4〜6 桁の番号です。空欄の場合は全商品を表示します。
+        </p>
+      </section>
+
+      <!-- 検索結果 -->
+      <section class="data-table-wrap">
+        <div class="data-table-toolbar">
+          <span>
+            照会結果: <strong id="totalCount" data-item-id="totalCount">42</strong> 件
+          </span>
+          <span class="spacer"></span>
+          <a href="/cart" class="btn btn-outline-success btn-sm">
+            <i class="bi bi-cart3 me-1"></i>カートへ進む
+          </a>
+        </div>
+
+        <table class="data-table">
+          <thead>
+            <tr>
+              <th class="sortable sort-asc" style="width:140px">商品コード</th>
+              <th class="sortable">商品名</th>
+              <th class="sortable" style="width:120px">カテゴリ</th>
+              <th class="sortable num" style="width:100px">単価 (税込)</th>
+              <th class="sortable num" style="width:100px">在庫数</th>
+              <th style="width:120px">状態</th>
+              <th style="width:100px">操作</th>
+            </tr>
+          </thead>
+          <tbody id="items" data-item-id="items">
+            <tr>
+              <td class="fw-mono">P-0001</td>
+              <td>ワイヤレスイヤホン Pro</td>
+              <td>電子機器</td>
+              <td class="num">¥22,000</td>
+              <td class="num">125</td>
+              <td><span class="badge bg-success">在庫あり</span></td>
+              <td><button type="button" class="btn btn-sm btn-primary">カートへ追加</button></td>
+            </tr>
+            <tr>
+              <td class="fw-mono">P-0002</td>
+              <td>スマートウォッチ SE</td>
+              <td>電子機器</td>
+              <td class="num">¥38,500</td>
+              <td class="num">8</td>
+              <td><span class="badge bg-warning text-dark"><i class="bi bi-exclamation-triangle me-1"></i>低在庫</span></td>
+              <td><button type="button" class="btn btn-sm btn-primary">カートへ追加</button></td>
+            </tr>
+            <tr>
+              <td class="fw-mono">P-0003</td>
+              <td>USB-C ハブ 7in1</td>
+              <td>周辺機器</td>
+              <td class="num">¥6,800</td>
+              <td class="num">350</td>
+              <td><span class="badge bg-success">在庫あり</span></td>
+              <td><button type="button" class="btn btn-sm btn-primary">カートへ追加</button></td>
+            </tr>
+            <tr>
+              <td class="fw-mono">P-0004</td>
+              <td>メカニカルキーボード TKL</td>
+              <td>周辺機器</td>
+              <td class="num">¥14,800</td>
+              <td class="num">3</td>
+              <td><span class="badge bg-danger"><i class="bi bi-x-circle me-1"></i>在庫不足</span></td>
+              <td><button type="button" class="btn btn-sm btn-secondary" disabled>在庫なし</button></td>
+            </tr>
+            <tr>
+              <td class="fw-mono">P-0005</td>
+              <td>4K モバイルモニター 15.6"</td>
+              <td>ディスプレイ</td>
+              <td class="num">¥68,000</td>
+              <td class="num">47</td>
+              <td><span class="badge bg-success">在庫あり</span></td>
+              <td><button type="button" class="btn btn-sm btn-primary">カートへ追加</button></td>
+            </tr>
+            <tr>
+              <td class="fw-mono">P-0006</td>
+              <td>ゲーミングマウス 8K</td>
+              <td>周辺機器</td>
+              <td class="num">¥9,800</td>
+              <td class="num">5</td>
+              <td><span class="badge bg-warning text-dark"><i class="bi bi-exclamation-triangle me-1"></i>低在庫</span></td>
+              <td><button type="button" class="btn btn-sm btn-primary">カートへ追加</button></td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="paging-area">
+          <span class="paging-count">1 - 10 / 42 件</span>
+          <span class="spacer"></span>
+          <nav aria-label="ページネーション">
+            <ul class="pagination pagination-sm mb-0">
+              <li class="page-item disabled"><a class="page-link" href="#">&laquo;</a></li>
+              <li class="page-item active"><a class="page-link" href="#">1</a></li>
+              <li class="page-item"><a class="page-link" href="#">2</a></li>
+              <li class="page-item"><a class="page-link" href="#">3</a></li>
+              <li class="page-item"><a class="page-link" href="#">4</a></li>
+              <li class="page-item"><a class="page-link" href="#">5</a></li>
+              <li class="page-item"><a class="page-link" href="#">&raquo;</a></li>
+            </ul>
+          </nav>
+        </div>
+      </section>
+
+      <!-- 在庫凡例 -->
+      <div class="mt-2 small text-muted">
+        <i class="bi bi-info-circle me-1"></i>
+        <span class="badge bg-success me-1">在庫あり</span>在庫 11 個以上 /
+        <span class="badge bg-warning text-dark me-1">低在庫</span>在庫 10 個以下 (補充推奨) /
+        <span class="badge bg-danger me-1">在庫不足</span>在庫 0〜3 個 (注文不可の場合あり)
+      </div>
+    </main>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/samples/retail/designs/f05fd315-2c78-48e5-9968-2633255b286e.html
+++ b/samples/retail/designs/f05fd315-2c78-48e5-9968-2633255b286e.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>顧客マスター — リテール総合</title>
+  <meta name="viewport" content="width=1280">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="../../common.css">
+</head>
+<body>
+<div class="app-shell">
+  <header class="app-header">
+    <h1 class="app-title"><i class="bi bi-shop"></i> リテール総合システム</h1>
+  </header>
+
+  <div class="app-body">
+    <aside class="app-sidebar">
+      <ul>
+        <li><a href="/"><i class="bi bi-speedometer2"></i> ダッシュボード</a></li>
+        <li><a href="/products/search"><i class="bi bi-search"></i> 商品検索</a></li>
+        <li><a href="/inventory"><i class="bi bi-box-seam"></i> 在庫管理</a></li>
+        <li><a href="/orders"><i class="bi bi-receipt"></i> 注文一覧</a></li>
+        <li><a href="/master/products"><i class="bi bi-box"></i> 商品マスター</a></li>
+        <li><a href="#" class="active"><i class="bi bi-people"></i> 顧客マスター</a></li>
+        <li><a href="/master/stores"><i class="bi bi-shop-window"></i> 店舗マスター</a></li>
+      </ul>
+    </aside>
+
+    <main class="app-main">
+      <div class="page-header">
+        <h1 class="page-title"><i class="bi bi-people me-2"></i>顧客マスター</h1>
+        <nav class="breadcrumb-area">ホーム &gt; マスター管理 &gt; 顧客マスター</nav>
+      </div>
+
+      <!-- 検索条件 -->
+      <section class="search-area">
+        <div class="search-fields">
+          <div class="search-field">
+            <label for="emailSearch" class="form-label">メールアドレス</label>
+            <input
+              type="text"
+              id="emailSearch"
+              name="emailSearch"
+              data-item-id="emailSearch"
+              class="form-control form-control-sm"
+              placeholder="例: customer@example.com"
+              maxlength="254"
+              style="width:220px"
+            >
+          </div>
+          <div class="search-field">
+            <label for="customerNameSearch" class="form-label">顧客名</label>
+            <input
+              type="text"
+              id="customerNameSearch"
+              name="customerNameSearch"
+              data-item-id="customerNameSearch"
+              class="form-control form-control-sm"
+              placeholder="顧客名で検索"
+              maxlength="100"
+              style="width:160px"
+            >
+          </div>
+          <div class="search-field">
+            <label for="isActiveFilter" class="form-label">有効/無効</label>
+            <select
+              id="isActiveFilter"
+              name="isActiveFilter"
+              data-item-id="isActiveFilter"
+              class="form-select form-select-sm"
+              style="width:120px"
+            >
+              <option value="">全て</option>
+              <option value="true" selected>有効</option>
+              <option value="false">無効</option>
+            </select>
+          </div>
+          <div class="search-field">
+            <label for="registeredFrom" class="form-label">登録日 (開始)</label>
+            <input
+              type="date"
+              id="registeredFrom"
+              name="registeredFrom"
+              data-item-id="registeredFrom"
+              class="form-control form-control-sm"
+              style="width:150px"
+            >
+          </div>
+        </div>
+        <div class="search-buttons">
+          <button type="button" class="btn btn-outline-secondary btn-sm">
+            <i class="bi bi-x-circle"></i> クリア
+          </button>
+          <button type="button" class="btn btn-primary btn-sm">
+            <i class="bi bi-search"></i> 検索
+          </button>
+        </div>
+      </section>
+
+      <!-- 顧客一覧テーブル -->
+      <section class="data-table-wrap">
+        <div class="data-table-toolbar">
+          <span>表示中: <strong>3,142</strong> 件</span>
+          <span class="spacer"></span>
+          <button type="button" class="btn btn-outline-secondary btn-sm">
+            <i class="bi bi-download"></i> CSV 出力
+          </button>
+        </div>
+
+        <table class="data-table">
+          <thead>
+            <tr>
+              <th class="sortable sort-asc" style="width:130px">顧客 ID</th>
+              <th class="sortable">顧客名</th>
+              <th class="sortable">メールアドレス</th>
+              <th class="sortable num" style="width:100px">注文回数</th>
+              <th style="width:80px">有効</th>
+              <th class="sortable num" style="width:120px">登録日</th>
+              <th style="width:80px">操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="fw-mono">C-000001</td>
+              <td>田中 太郎</td>
+              <td>tanaka.taro@example.com</td>
+              <td class="num">24</td>
+              <td><span class="badge bg-success">有効</span></td>
+              <td class="num">2025/04/12</td>
+              <td><a href="/master/customers/1" class="btn btn-sm btn-outline-primary">詳細</a></td>
+            </tr>
+            <tr>
+              <td class="fw-mono">C-000002</td>
+              <td>鈴木 花子</td>
+              <td>suzuki.hanako@example.com</td>
+              <td class="num">8</td>
+              <td><span class="badge bg-success">有効</span></td>
+              <td class="num">2025/06/30</td>
+              <td><a href="/master/customers/2" class="btn btn-sm btn-outline-primary">詳細</a></td>
+            </tr>
+            <tr>
+              <td class="fw-mono">C-000003</td>
+              <td>佐藤 一郎</td>
+              <td>sato.ichiro@example.com</td>
+              <td class="num">3</td>
+              <td><span class="badge bg-success">有効</span></td>
+              <td class="num">2025/11/05</td>
+              <td><a href="/master/customers/3" class="btn btn-sm btn-outline-primary">詳細</a></td>
+            </tr>
+            <tr>
+              <td class="fw-mono">C-000004</td>
+              <td>山田 次郎</td>
+              <td>yamada.jiro@example.com</td>
+              <td class="num">15</td>
+              <td><span class="badge bg-success">有効</span></td>
+              <td class="num">2025/08/22</td>
+              <td><a href="/master/customers/4" class="btn btn-sm btn-outline-primary">詳細</a></td>
+            </tr>
+            <tr class="table-secondary">
+              <td class="fw-mono">C-000005</td>
+              <td>伊藤 美奈 (旧名)</td>
+              <td>ito.mina.old@example.com</td>
+              <td class="num">1</td>
+              <td><span class="badge bg-secondary">無効</span></td>
+              <td class="num">2024/12/01</td>
+              <td><a href="/master/customers/5" class="btn btn-sm btn-outline-secondary">詳細</a></td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="paging-area">
+          <span class="paging-count">1 - 10 / 3,142 件</span>
+          <span class="spacer"></span>
+          <nav aria-label="ページネーション">
+            <ul class="pagination pagination-sm mb-0">
+              <li class="page-item disabled"><a class="page-link" href="#">&laquo;</a></li>
+              <li class="page-item active"><a class="page-link" href="#">1</a></li>
+              <li class="page-item"><a class="page-link" href="#">2</a></li>
+              <li class="page-item"><a class="page-link" href="#">3</a></li>
+              <li class="page-item"><a class="page-link" href="#">315</a></li>
+              <li class="page-item"><a class="page-link" href="#">&raquo;</a></li>
+            </ul>
+          </nav>
+        </div>
+      </section>
+    </main>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/samples/retail/designs/f9d57022-1dad-4c8f-a387-27e0a8576947.html
+++ b/samples/retail/designs/f9d57022-1dad-4c8f-a387-27e0a8576947.html
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>店舗マスター — リテール総合</title>
+  <meta name="viewport" content="width=1280">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="../../common.css">
+</head>
+<body>
+<div class="app-shell">
+  <header class="app-header">
+    <h1 class="app-title"><i class="bi bi-shop"></i> リテール総合システム</h1>
+  </header>
+
+  <div class="app-body">
+    <aside class="app-sidebar">
+      <ul>
+        <li><a href="/"><i class="bi bi-speedometer2"></i> ダッシュボード</a></li>
+        <li><a href="/products/search"><i class="bi bi-search"></i> 商品検索</a></li>
+        <li><a href="/inventory"><i class="bi bi-box-seam"></i> 在庫管理</a></li>
+        <li><a href="/orders"><i class="bi bi-receipt"></i> 注文一覧</a></li>
+        <li><a href="/master/products"><i class="bi bi-box"></i> 商品マスター</a></li>
+        <li><a href="/master/customers"><i class="bi bi-people"></i> 顧客マスター</a></li>
+        <li><a href="#" class="active"><i class="bi bi-shop-window"></i> 店舗マスター</a></li>
+      </ul>
+    </aside>
+
+    <main class="app-main">
+      <div class="page-header">
+        <h1 class="page-title"><i class="bi bi-shop-window me-2"></i>店舗マスター</h1>
+        <nav class="breadcrumb-area">ホーム &gt; マスター管理 &gt; 店舗マスター</nav>
+      </div>
+
+      <!-- 検索条件 -->
+      <section class="search-area">
+        <div class="search-fields">
+          <div class="search-field">
+            <label for="storeCodeSearch" class="form-label">店舗コード</label>
+            <input
+              type="text"
+              id="storeCodeSearch"
+              name="storeCodeSearch"
+              data-item-id="storeCodeSearch"
+              class="form-control form-control-sm"
+              placeholder="例: S-001"
+              maxlength="10"
+              style="width:120px"
+            >
+          </div>
+          <div class="search-field">
+            <label for="storeNameSearch" class="form-label">店舗名</label>
+            <input
+              type="text"
+              id="storeNameSearch"
+              name="storeNameSearch"
+              data-item-id="storeNameSearch"
+              class="form-control form-control-sm"
+              placeholder="店舗名で検索"
+              maxlength="100"
+              style="width:180px"
+            >
+          </div>
+          <div class="search-field">
+            <label for="regionSearch" class="form-label">地域</label>
+            <select
+              id="regionSearch"
+              name="regionSearch"
+              data-item-id="regionSearch"
+              class="form-select form-select-sm"
+              style="width:130px"
+            >
+              <option value="">全地域</option>
+              <option value="kanto">関東</option>
+              <option value="kansai">関西</option>
+              <option value="chubu">中部</option>
+              <option value="kyushu">九州</option>
+              <option value="tohoku">東北</option>
+            </select>
+          </div>
+          <div class="search-field">
+            <label for="isOpenSearch" class="form-label">営業状態</label>
+            <select
+              id="isOpenSearch"
+              name="isOpenSearch"
+              data-item-id="isOpenSearch"
+              class="form-select form-select-sm"
+              style="width:120px"
+            >
+              <option value="">全て</option>
+              <option value="true" selected>営業中</option>
+              <option value="false">閉店</option>
+            </select>
+          </div>
+        </div>
+        <div class="search-buttons">
+          <button type="button" class="btn btn-outline-secondary btn-sm">
+            <i class="bi bi-x-circle"></i> クリア
+          </button>
+          <button type="button" class="btn btn-primary btn-sm">
+            <i class="bi bi-search"></i> 検索
+          </button>
+        </div>
+      </section>
+
+      <!-- 店舗一覧テーブル -->
+      <section class="data-table-wrap">
+        <div class="data-table-toolbar">
+          <span>表示中: <strong>23</strong> 件</span>
+          <span class="spacer"></span>
+          <button type="button" class="btn btn-outline-success btn-sm">
+            <i class="bi bi-plus-lg"></i> 新規登録
+          </button>
+          <button type="button" class="btn btn-outline-secondary btn-sm">
+            <i class="bi bi-download"></i> CSV 出力
+          </button>
+        </div>
+
+        <table class="data-table">
+          <thead>
+            <tr>
+              <th class="sortable sort-asc" style="width:110px">店舗コード</th>
+              <th class="sortable">店舗名</th>
+              <th class="sortable" style="width:100px">地域</th>
+              <th>住所</th>
+              <th style="width:100px">営業中</th>
+              <th class="sortable num" style="width:100px">在庫品目数</th>
+              <th style="width:120px">操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="fw-mono">S-001</td>
+              <td>東京本店</td>
+              <td>関東</td>
+              <td>東京都新宿区西新宿 X-X-X</td>
+              <td><span class="badge bg-success"><i class="bi bi-circle-fill me-1" style="font-size:0.5rem;"></i>営業中</span></td>
+              <td class="num">486</td>
+              <td class="d-flex gap-1">
+                <button type="button" class="btn btn-sm btn-outline-primary" aria-label="編集">
+                  <i class="bi bi-pencil"></i> 編集
+                </button>
+                <button type="button" class="btn btn-sm btn-outline-secondary" aria-label="在庫確認">
+                  <i class="bi bi-box-seam"></i>
+                </button>
+              </td>
+            </tr>
+            <tr>
+              <td class="fw-mono">S-002</td>
+              <td>大阪支店</td>
+              <td>関西</td>
+              <td>大阪府大阪市北区梅田 X-X-X</td>
+              <td><span class="badge bg-success"><i class="bi bi-circle-fill me-1" style="font-size:0.5rem;"></i>営業中</span></td>
+              <td class="num">312</td>
+              <td class="d-flex gap-1">
+                <button type="button" class="btn btn-sm btn-outline-primary" aria-label="編集">
+                  <i class="bi bi-pencil"></i> 編集
+                </button>
+                <button type="button" class="btn btn-sm btn-outline-secondary" aria-label="在庫確認">
+                  <i class="bi bi-box-seam"></i>
+                </button>
+              </td>
+            </tr>
+            <tr>
+              <td class="fw-mono">S-003</td>
+              <td>名古屋支店</td>
+              <td>中部</td>
+              <td>愛知県名古屋市中区栄 X-X-X</td>
+              <td><span class="badge bg-success"><i class="bi bi-circle-fill me-1" style="font-size:0.5rem;"></i>営業中</span></td>
+              <td class="num">278</td>
+              <td class="d-flex gap-1">
+                <button type="button" class="btn btn-sm btn-outline-primary" aria-label="編集">
+                  <i class="bi bi-pencil"></i> 編集
+                </button>
+                <button type="button" class="btn btn-sm btn-outline-secondary" aria-label="在庫確認">
+                  <i class="bi bi-box-seam"></i>
+                </button>
+              </td>
+            </tr>
+            <tr>
+              <td class="fw-mono">S-004</td>
+              <td>福岡支店</td>
+              <td>九州</td>
+              <td>福岡県福岡市博多区博多駅前 X-X-X</td>
+              <td><span class="badge bg-success"><i class="bi bi-circle-fill me-1" style="font-size:0.5rem;"></i>営業中</span></td>
+              <td class="num">195</td>
+              <td class="d-flex gap-1">
+                <button type="button" class="btn btn-sm btn-outline-primary" aria-label="編集">
+                  <i class="bi bi-pencil"></i> 編集
+                </button>
+                <button type="button" class="btn btn-sm btn-outline-secondary" aria-label="在庫確認">
+                  <i class="bi bi-box-seam"></i>
+                </button>
+              </td>
+            </tr>
+            <tr class="table-secondary">
+              <td class="fw-mono">S-010</td>
+              <td>旧・横浜出張所</td>
+              <td>関東</td>
+              <td>神奈川県横浜市西区 X-X-X (閉店)</td>
+              <td><span class="badge bg-secondary">閉店</span></td>
+              <td class="num">0</td>
+              <td class="d-flex gap-1">
+                <button type="button" class="btn btn-sm btn-outline-primary" aria-label="編集">
+                  <i class="bi bi-pencil"></i> 編集
+                </button>
+                <button type="button" class="btn btn-sm btn-outline-secondary" disabled aria-label="在庫確認">
+                  <i class="bi bi-box-seam"></i>
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="paging-area">
+          <span class="paging-count">1 - 10 / 23 件</span>
+          <span class="spacer"></span>
+          <nav aria-label="ページネーション">
+            <ul class="pagination pagination-sm mb-0">
+              <li class="page-item disabled"><a class="page-link" href="#">&laquo;</a></li>
+              <li class="page-item active"><a class="page-link" href="#">1</a></li>
+              <li class="page-item"><a class="page-link" href="#">2</a></li>
+              <li class="page-item"><a class="page-link" href="#">3</a></li>
+              <li class="page-item"><a class="page-link" href="#">&raquo;</a></li>
+            </ul>
+          </nav>
+        </div>
+      </section>
+    </main>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/samples/retail/designs/f9faa724-e080-4308-bc14-bb93631c9e78.html
+++ b/samples/retail/designs/f9faa724-e080-4308-bc14-bb93631c9e78.html
@@ -1,0 +1,227 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>注文一覧 — リテール総合</title>
+  <meta name="viewport" content="width=1280">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="../../common.css">
+</head>
+<body>
+<div class="app-shell">
+  <header class="app-header">
+    <h1 class="app-title"><i class="bi bi-shop"></i> リテール総合システム</h1>
+  </header>
+
+  <div class="app-body">
+    <aside class="app-sidebar">
+      <ul>
+        <li><a href="/"><i class="bi bi-speedometer2"></i> ダッシュボード</a></li>
+        <li><a href="/products/search"><i class="bi bi-search"></i> 商品検索</a></li>
+        <li><a href="/cart"><i class="bi bi-cart3"></i> カート</a></li>
+        <li><a href="/inventory"><i class="bi bi-box-seam"></i> 在庫管理</a></li>
+        <li><a href="#" class="active"><i class="bi bi-receipt"></i> 注文一覧</a></li>
+        <li><a href="/master/products"><i class="bi bi-gear"></i> マスター管理</a></li>
+      </ul>
+    </aside>
+
+    <main class="app-main">
+      <div class="page-header">
+        <h1 class="page-title"><i class="bi bi-receipt me-2"></i>注文一覧</h1>
+        <nav class="breadcrumb-area">ホーム &gt; 注文一覧</nav>
+      </div>
+
+      <!-- 検索条件 -->
+      <section class="search-area">
+        <div class="search-fields">
+          <div class="search-field">
+            <label for="orderNumberFilter" class="form-label">注文番号</label>
+            <input
+              type="text"
+              id="orderNumberFilter"
+              name="orderNumberFilter"
+              data-item-id="orderNumberFilter"
+              class="form-control form-control-sm"
+              placeholder="例: ORD-2026-000001"
+              maxlength="20"
+              style="width:200px"
+            >
+          </div>
+          <div class="search-field">
+            <label for="customerNameFilter" class="form-label">顧客名</label>
+            <input
+              type="text"
+              id="customerNameFilter"
+              name="customerNameFilter"
+              data-item-id="customerNameFilter"
+              class="form-control form-control-sm"
+              placeholder="顧客名で検索"
+              maxlength="100"
+              style="width:160px"
+            >
+          </div>
+          <div class="search-field">
+            <label for="orderDateFrom" class="form-label">注文日 (開始)</label>
+            <input
+              type="date"
+              id="orderDateFrom"
+              name="orderDateFrom"
+              data-item-id="orderDateFrom"
+              class="form-control form-control-sm"
+              style="width:150px"
+            >
+          </div>
+          <div class="search-field align-self-end">
+            <span class="text-muted">〜</span>
+          </div>
+          <div class="search-field">
+            <label for="orderDateTo" class="form-label">注文日 (終了)</label>
+            <input
+              type="date"
+              id="orderDateTo"
+              name="orderDateTo"
+              data-item-id="orderDateTo"
+              class="form-control form-control-sm"
+              style="width:150px"
+            >
+          </div>
+          <div class="search-field">
+            <label for="statusFilter" class="form-label">ステータス</label>
+            <select
+              id="statusFilter"
+              name="statusFilter"
+              data-item-id="statusFilter"
+              class="form-select form-select-sm"
+              style="width:140px"
+            >
+              <option value="">全て</option>
+              <option value="pending">配送待ち</option>
+              <option value="dispatched">配送中</option>
+              <option value="delivered">完了</option>
+              <option value="cancelled">キャンセル</option>
+            </select>
+          </div>
+        </div>
+        <div class="search-buttons">
+          <button type="button" class="btn btn-outline-secondary btn-sm">
+            <i class="bi bi-x-circle"></i> クリア
+          </button>
+          <button type="button" class="btn btn-primary btn-sm">
+            <i class="bi bi-search"></i> 検索
+          </button>
+        </div>
+      </section>
+
+      <!-- 注文テーブル -->
+      <section class="data-table-wrap">
+        <div class="data-table-toolbar">
+          <span>検索結果: <strong>87</strong> 件</span>
+          <span class="spacer"></span>
+          <button type="button" class="btn btn-outline-secondary btn-sm">
+            <i class="bi bi-download"></i> CSV 出力
+          </button>
+        </div>
+
+        <table class="data-table">
+          <thead>
+            <tr>
+              <th class="sortable sort-asc" style="width:170px">注文番号</th>
+              <th class="sortable">顧客名</th>
+              <th class="sortable num" style="width:120px">合計金額</th>
+              <th style="width:120px">ステータス</th>
+              <th class="sortable num" style="width:140px">注文日時</th>
+              <th style="width:120px">操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="fw-mono">ORD-2026-000024</td>
+              <td>田中 太郎</td>
+              <td class="num">¥118,800</td>
+              <td><span class="badge bg-warning text-dark">配送待ち</span></td>
+              <td class="num">2026/05/02 14:32</td>
+              <td>
+                <a href="/orders/24/dispatch" class="btn btn-sm btn-primary">
+                  <i class="bi bi-truck me-1"></i>配送指示
+                </a>
+              </td>
+            </tr>
+            <tr>
+              <td class="fw-mono">ORD-2026-000023</td>
+              <td>鈴木 花子</td>
+              <td class="num">¥38,500</td>
+              <td><span class="badge bg-info text-dark">配送中</span></td>
+              <td class="num">2026/05/02 11:15</td>
+              <td>
+                <button type="button" class="btn btn-sm btn-outline-secondary" disabled>配送中</button>
+              </td>
+            </tr>
+            <tr>
+              <td class="fw-mono">ORD-2026-000022</td>
+              <td>佐藤 一郎</td>
+              <td class="num">¥5,400</td>
+              <td><span class="badge bg-success">完了</span></td>
+              <td class="num">2026/05/01 16:48</td>
+              <td>
+                <button type="button" class="btn btn-sm btn-outline-secondary">詳細</button>
+              </td>
+            </tr>
+            <tr>
+              <td class="fw-mono">ORD-2026-000021</td>
+              <td>山田 次郎</td>
+              <td class="num">¥94,000</td>
+              <td><span class="badge bg-warning text-dark">配送待ち</span></td>
+              <td class="num">2026/05/01 09:21</td>
+              <td>
+                <a href="/orders/21/dispatch" class="btn btn-sm btn-primary">
+                  <i class="bi bi-truck me-1"></i>配送指示
+                </a>
+              </td>
+            </tr>
+            <tr>
+              <td class="fw-mono">ORD-2026-000020</td>
+              <td>伊藤 美奈</td>
+              <td class="num">¥21,600</td>
+              <td><span class="badge bg-danger">キャンセル</span></td>
+              <td class="num">2026/04/30 17:55</td>
+              <td>
+                <button type="button" class="btn btn-sm btn-outline-secondary">詳細</button>
+              </td>
+            </tr>
+            <tr>
+              <td class="fw-mono">ORD-2026-000019</td>
+              <td>中村 健太</td>
+              <td class="num">¥8,250</td>
+              <td><span class="badge bg-success">完了</span></td>
+              <td class="num">2026/04/30 14:20</td>
+              <td>
+                <button type="button" class="btn btn-sm btn-outline-secondary">詳細</button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="paging-area">
+          <span class="paging-count">1 - 10 / 87 件</span>
+          <span class="spacer"></span>
+          <nav aria-label="ページネーション">
+            <ul class="pagination pagination-sm mb-0">
+              <li class="page-item disabled"><a class="page-link" href="#">&laquo;</a></li>
+              <li class="page-item active"><a class="page-link" href="#">1</a></li>
+              <li class="page-item"><a class="page-link" href="#">2</a></li>
+              <li class="page-item"><a class="page-link" href="#">3</a></li>
+              <li class="page-item"><a class="page-link" href="#">4</a></li>
+              <li class="page-item"><a class="page-link" href="#">5</a></li>
+              <li class="page-item"><a class="page-link" href="#">&raquo;</a></li>
+            </ul>
+          </nav>
+        </div>
+      </section>
+    </main>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/samples/retail/extensions/retail/db-operations.json
+++ b/samples/retail/extensions/retail/db-operations.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "../../../../schemas/v3/extensions.v3.schema.json",
+  "namespace": "retail",
+  "version": "1.0.0",
+  "description": "リテール業態向け拡張定義 — DB 操作 step (在庫減算・カート操作など)。",
+  "dbOperations": [
+    {
+      "value": "DECREMENT_STOCK",
+      "label": "在庫減算",
+      "description": "inventory.quantity_available を指定数量だけ減算する。0 未満になる場合は STOCK_SHORTAGE エラーを返す。注文確定 TX (S-3) 内で使用する。"
+    },
+    {
+      "value": "UPSERT_CART_ITEM",
+      "label": "カート明細追加/更新",
+      "description": "cart_items に (cart_id, product_id) で UPSERT する。重複の場合は quantity を加算し unit_price_snapshot を最新値で更新する。カート追加 (S-2) で使用する。"
+    },
+    {
+      "value": "CLEAR_CART",
+      "label": "カートクリア",
+      "description": "cart_items の cart_id に紐付く全明細を DELETE し、carts.status を 'ordered' に更新する。注文確定 TX (S-3) 完了後に実行する。"
+    },
+    {
+      "value": "BULK_INSERT",
+      "label": "一括 INSERT",
+      "description": "配列データを一括 INSERT する。注文確定時の order_items 登録で使用する。"
+    }
+  ]
+}

--- a/samples/retail/extensions/retail/field-types.json
+++ b/samples/retail/extensions/retail/field-types.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "../../../../schemas/v3/extensions.v3.schema.json",
+  "namespace": "retail",
+  "version": "1.0.0",
+  "description": "リテール業態向け拡張定義 — FieldType 拡張 (商品コード型・JAN コード型等)。",
+  "fieldTypes": [
+    {
+      "kind": "productCode",
+      "label": "商品コード",
+      "baseType": "string",
+      "constraints": [
+        { "type": "pattern", "value": "^P-[0-9]{4,6}$" },
+        { "type": "maxLength", "value": 20 }
+      ],
+      "description": "リテール業態の商品コード型。@conv.regex.productCode 正規表現準拠 (例: P-0001)。"
+    },
+    {
+      "kind": "janCode",
+      "label": "JAN コード",
+      "baseType": "string",
+      "constraints": [
+        { "type": "pattern", "value": "^[0-9]{13}$" },
+        { "type": "length", "value": 13 }
+      ],
+      "description": "JAN/EAN-13 バーコード型。13 桁数字のみ。@conv.regex.janCode 準拠。"
+    },
+    {
+      "kind": "orderNumber",
+      "label": "注文番号",
+      "baseType": "string",
+      "constraints": [
+        { "type": "pattern", "value": "^ORD-[0-9]{4}-[0-9]{4,8}$" },
+        { "type": "maxLength", "value": 30 }
+      ],
+      "description": "採番済み注文番号型。@conv.numbering.orderNumber 規約で生成される。例: ORD-2026-0001。"
+    },
+    {
+      "kind": "storeCode",
+      "label": "店舗コード",
+      "baseType": "string",
+      "constraints": [
+        { "type": "pattern", "value": "^S-[0-9]{3,5}$" },
+        { "type": "maxLength", "value": 20 }
+      ],
+      "description": "店舗識別コード型。例: S-001。"
+    }
+  ]
+}

--- a/samples/retail/extensions/retail/response-types.json
+++ b/samples/retail/extensions/retail/response-types.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "../../../../schemas/v3/extensions.v3.schema.json",
+  "namespace": "retail",
+  "version": "1.0.0",
+  "description": "リテール業態向け拡張定義 — Response type 拡張 (在庫切れ等のドメインレスポンス)。",
+  "responseTypes": {
+    "StockShortageError": {
+      "description": "在庫不足エラーレスポンス。注文確定 TX (S-3) の在庫引き当て失敗時に返す。エラーコード STOCK_SHORTAGE と不足している商品一覧を含む。",
+      "schema": {
+        "type": "object",
+        "required": ["code", "shortages"],
+        "properties": {
+          "code": {
+            "type": "string",
+            "enum": ["STOCK_SHORTAGE"],
+            "description": "エラーコード"
+          },
+          "message": {
+            "type": "string",
+            "description": "ユーザー向けエラーメッセージ (@conv.msg.stockShortage 参照)"
+          },
+          "shortages": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["productId", "productCode", "requested", "available"],
+              "properties": {
+                "productId": { "type": "integer" },
+                "productCode": { "type": "string" },
+                "productName": { "type": "string" },
+                "requested": { "type": "integer" },
+                "available": { "type": "integer" }
+              },
+              "additionalProperties": false
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "CartItemAdded": {
+      "description": "カート明細追加成功レスポンス (S-2)。追加後のカート状態 (明細数・合計金額) を返す。",
+      "schema": {
+        "type": "object",
+        "required": ["cartId", "itemCount", "totalAmount"],
+        "properties": {
+          "cartId": { "type": "integer" },
+          "itemCount": { "type": "integer", "description": "カート内明細件数" },
+          "totalAmount": { "type": "number", "description": "カート合計金額 (税抜)" },
+          "addedItem": {
+            "type": "object",
+            "properties": {
+              "productId": { "type": "integer" },
+              "productCode": { "type": "string" },
+              "quantity": { "type": "integer" },
+              "unitPrice": { "type": "number" }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "OrderConfirmed": {
+      "description": "注文確定成功レスポンス (S-3)。採番された注文番号・合計金額・注文日時を返す。注文完了画面での表示に使用する。",
+      "schema": {
+        "type": "object",
+        "required": ["orderId", "orderNumber", "totalAmount", "orderedAt"],
+        "properties": {
+          "orderId": { "type": "integer" },
+          "orderNumber": { "type": "string", "description": "採番済み注文番号 (例: ORD-2026-0001)" },
+          "totalAmount": { "type": "number", "description": "税抜合計金額" },
+          "taxAmount": { "type": "number", "description": "消費税額" },
+          "orderedAt": { "type": "string", "format": "date-time" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "ShipmentDispatched": {
+      "description": "配送指示完了レスポンス (S-4)。外部キャリアから取得した追跡番号と配達予定日を返す。",
+      "schema": {
+        "type": "object",
+        "required": ["orderId", "trackingNumber", "carrierId"],
+        "properties": {
+          "orderId": { "type": "integer" },
+          "orderNumber": { "type": "string" },
+          "trackingNumber": { "type": "string", "description": "キャリアの追跡番号" },
+          "carrierId": { "type": "string" },
+          "estimatedDelivery": { "type": "string", "format": "date" }
+        },
+        "additionalProperties": false
+      }
+    }
+  }
+}

--- a/samples/retail/extensions/retail/steps.json
+++ b/samples/retail/extensions/retail/steps.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "../../../../schemas/v3/extensions.v3.schema.json",
+  "namespace": "retail",
+  "version": "1.0.0",
+  "description": "リテール業態向け拡張定義 — Step 拡張 (配送指示など複合 step・外部 API 連携)。",
+  "stepKinds": {
+    "DispatchShipment": {
+      "label": "配送指示",
+      "icon": "bi-truck",
+      "description": "外部キャリア API に配送指示を送信する拡張 Step。注文情報・配送先住所・希望配送日をキャリア API エンドポイントに POST し、追跡番号 (tracking_number) を受け取る。配送指示フロー (S-4) で使用する。",
+      "schema": {
+        "type": "object",
+        "required": ["carrierId", "orderId", "shippingAddress"],
+        "properties": {
+          "carrierId": {
+            "type": "string",
+            "description": "キャリア識別子 (例: yamato / sagawa / jp-post)"
+          },
+          "orderId": {
+            "type": "string",
+            "description": "注文 ID (変数参照可)"
+          },
+          "shippingAddress": {
+            "type": "string",
+            "description": "配送先住所 (変数参照可)"
+          },
+          "preferredDate": {
+            "type": "string",
+            "description": "希望配送日 (YYYY-MM-DD、任意)"
+          },
+          "timeSlot": {
+            "type": "string",
+            "enum": ["morning", "afternoon", "evening", "any"],
+            "description": "希望時間帯"
+          }
+        },
+        "additionalProperties": false
+      },
+      "outputType": {
+        "kind": "object",
+        "fields": [
+          { "name": "trackingNumber", "type": "string", "label": "追跡番号" },
+          { "name": "estimatedDelivery", "type": "date", "label": "配達予定日" },
+          { "name": "carrierId", "type": "string", "label": "キャリア識別子" }
+        ]
+      }
+    },
+    "SendOrderConfirmEmail": {
+      "label": "注文確定メール送信",
+      "icon": "bi-envelope-check",
+      "description": "注文確定後に顧客へ確認メールを送信する拡張 Step。注文番号・明細・合計金額をテンプレートに展開して送信する。注文確定フロー (S-3) の完了後に実行する。",
+      "schema": {
+        "type": "object",
+        "required": ["toEmail", "orderNumber"],
+        "properties": {
+          "toEmail": {
+            "type": "string",
+            "description": "送信先メールアドレス (customers.email)"
+          },
+          "orderNumber": {
+            "type": "string",
+            "description": "注文番号 (orders.order_number)"
+          },
+          "templateId": {
+            "type": "string",
+            "description": "メールテンプレート ID (省略時はデフォルトテンプレート)"
+          }
+        },
+        "additionalProperties": false
+      },
+      "outputType": {
+        "kind": "object",
+        "fields": [
+          { "name": "messageId", "type": "string", "label": "メッセージ ID" },
+          { "name": "sentAt", "type": "datetime", "label": "送信日時" }
+        ]
+      }
+    }
+  }
+}

--- a/samples/retail/extensions/retail/triggers.json
+++ b/samples/retail/extensions/retail/triggers.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "../../../../schemas/v3/extensions.v3.schema.json",
+  "namespace": "retail",
+  "version": "1.0.0",
+  "description": "リテール業態向け拡張定義 — Action trigger 拡張 (注文確定後の在庫補充トリガーなど)。",
+  "actionTriggers": [
+    {
+      "value": "orderConfirmed",
+      "label": "注文確定後",
+      "description": "注文確定 TX 完了直後に発火するトリガー。在庫補充チェック・確認メール送信などの後続処理を起動する。ProcessFlow の trigger に指定する。"
+    },
+    {
+      "value": "lowStockDetected",
+      "label": "低在庫検出時",
+      "description": "inventory.quantity_available が @conv.limit.lowStockThreshold 以下になった時点で発火するトリガー。仕入れ発注フロー (将来拡張) への連携入口。"
+    },
+    {
+      "value": "cartAbandoned",
+      "label": "カート放棄時",
+      "description": "カートが一定時間更新されずに放棄された状態を検出した時点で発火するトリガー。リマインドメール送信などに使用 (将来拡張)。"
+    },
+    {
+      "value": "shipmentDispatched",
+      "label": "配送指示完了後",
+      "description": "外部キャリア API への配送指示が正常完了し、追跡番号を取得した後に発火するトリガー。出荷通知メール送信に使用する。"
+    }
+  ]
+}

--- a/samples/retail/project.json
+++ b/samples/retail/project.json
@@ -99,7 +99,44 @@
         "updatedAt": "2026-05-02T00:00:00.000Z"
       }
     ],
-    "processFlows": [],
+    "processFlows": [
+      {
+        "id": "efa7ac6e-e295-416e-b68d-17c4739b5097",
+        "no": 1,
+        "name": "店舗在庫照会",
+        "kind": "screen",
+        "actionCount": 1,
+        "maturity": "committed",
+        "updatedAt": "2026-05-02T00:00:00.000Z"
+      },
+      {
+        "id": "9515d6f6-8342-48cf-a045-9e9d8fab1cfa",
+        "no": 2,
+        "name": "カート追加",
+        "kind": "screen",
+        "actionCount": 1,
+        "maturity": "committed",
+        "updatedAt": "2026-05-02T00:00:00.000Z"
+      },
+      {
+        "id": "f81dd9e0-794c-4539-a2a5-9cbcc0a75899",
+        "no": 3,
+        "name": "注文確定",
+        "kind": "screen",
+        "actionCount": 1,
+        "maturity": "committed",
+        "updatedAt": "2026-05-02T00:00:00.000Z"
+      },
+      {
+        "id": "d63c703c-26ed-4704-8b76-329c6bfae9c9",
+        "no": 4,
+        "name": "配送指示",
+        "kind": "screen",
+        "actionCount": 1,
+        "maturity": "committed",
+        "updatedAt": "2026-05-02T00:00:00.000Z"
+      }
+    ],
     "views": [],
     "viewDefinitions": [],
     "sequences": []

--- a/samples/retail/project.json
+++ b/samples/retail/project.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../schemas/v3/project.v3.schema.json",
+  "schemaVersion": "v3",
+  "meta": {
+    "id": "b8894d2c-d0b5-4a14-8068-64b66011c29e",
+    "name": "リテール総合 (EC + 店舗 POS + 在庫管理)",
+    "description": "EC・店舗 POS・在庫管理のミックス業態の業務システムサンプル。商品検索、カート、注文確定、配送指示の 4 シナリオを軸に画面・処理フロー・テーブル・規約・拡張を完結させた **リリース時 examples 候補** (#680 / #706)。",
+    "createdAt": "2026-05-02T00:00:00.000Z",
+    "updatedAt": "2026-05-02T00:00:00.000Z",
+    "mode": "upstream",
+    "maturity": "draft"
+  },
+  "extensionsApplied": [
+    { "namespace": "retail", "version": ">=1.0.0" }
+  ],
+  "entities": {
+    "screens": [],
+    "screenGroups": [],
+    "screenTransitions": [],
+    "tables": [],
+    "processFlows": [],
+    "views": [],
+    "viewDefinitions": [],
+    "sequences": []
+  }
+}

--- a/samples/retail/project.json
+++ b/samples/retail/project.json
@@ -14,9 +14,207 @@
     { "namespace": "retail", "version": ">=1.0.0" }
   ],
   "entities": {
-    "screens": [],
-    "screenGroups": [],
-    "screenTransitions": [],
+    "screens": [
+      {
+        "id": "765c3c23-8a0e-46b0-ae8b-ce84d10be0b0",
+        "no": 1,
+        "name": "ダッシュボード",
+        "kind": "dashboard",
+        "path": "/",
+        "groupId": "a7285b88-9e12-4d2c-94c6-ef6bd788685d",
+        "maturity": "committed",
+        "updatedAt": "2026-05-02T00:00:00.000Z"
+      },
+      {
+        "id": "e6147dc0-94b7-436d-ba87-d0080ac34f44",
+        "no": 2,
+        "name": "商品検索",
+        "kind": "search",
+        "path": "/products/search",
+        "groupId": "c720b549-ecf4-4d20-9be4-c8d38f89a13e",
+        "maturity": "committed",
+        "updatedAt": "2026-05-02T00:00:00.000Z"
+      },
+      {
+        "id": "4a9df651-e0cc-4523-a9bf-f3fb9d45c53f",
+        "no": 3,
+        "name": "在庫一覧",
+        "kind": "list",
+        "path": "/inventory",
+        "groupId": "a7285b88-9e12-4d2c-94c6-ef6bd788685d",
+        "maturity": "committed",
+        "updatedAt": "2026-05-02T00:00:00.000Z"
+      },
+      {
+        "id": "c73fa05c-4a71-4593-800d-b9814e97be83",
+        "no": 4,
+        "name": "カート",
+        "kind": "retail:cart",
+        "path": "/cart",
+        "groupId": "c720b549-ecf4-4d20-9be4-c8d38f89a13e",
+        "maturity": "committed",
+        "updatedAt": "2026-05-02T00:00:00.000Z"
+      },
+      {
+        "id": "cff4a398-99cd-4aa5-bfbd-c12d5e72c5f3",
+        "no": 5,
+        "name": "カート確認",
+        "kind": "confirm",
+        "path": "/cart/confirm",
+        "groupId": "c720b549-ecf4-4d20-9be4-c8d38f89a13e",
+        "maturity": "committed",
+        "updatedAt": "2026-05-02T00:00:00.000Z"
+      },
+      {
+        "id": "0739c454-45d6-4c99-962a-7b0b9e113a22",
+        "no": 6,
+        "name": "注文完了",
+        "kind": "complete",
+        "path": "/order/complete",
+        "groupId": "c720b549-ecf4-4d20-9be4-c8d38f89a13e",
+        "maturity": "committed",
+        "updatedAt": "2026-05-02T00:00:00.000Z"
+      },
+      {
+        "id": "f9faa724-e080-4308-bc14-bb93631c9e78",
+        "no": 7,
+        "name": "注文一覧",
+        "kind": "list",
+        "path": "/orders",
+        "groupId": "a7285b88-9e12-4d2c-94c6-ef6bd788685d",
+        "maturity": "committed",
+        "updatedAt": "2026-05-02T00:00:00.000Z"
+      },
+      {
+        "id": "c2254dd6-ab5d-4428-931f-d27c71e89951",
+        "no": 8,
+        "name": "配送指示",
+        "kind": "form",
+        "path": "/orders/:id/dispatch",
+        "groupId": "a7285b88-9e12-4d2c-94c6-ef6bd788685d",
+        "maturity": "committed",
+        "updatedAt": "2026-05-02T00:00:00.000Z"
+      },
+      {
+        "id": "2e23d129-1d53-4e30-b54c-97f90b910578",
+        "no": 9,
+        "name": "商品マスター",
+        "kind": "list",
+        "path": "/master/products",
+        "groupId": "8c592e1b-dfa4-4fc6-8a0c-e584996b0075",
+        "maturity": "committed",
+        "updatedAt": "2026-05-02T00:00:00.000Z"
+      },
+      {
+        "id": "f05fd315-2c78-48e5-9968-2633255b286e",
+        "no": 10,
+        "name": "顧客マスター",
+        "kind": "list",
+        "path": "/master/customers",
+        "groupId": "8c592e1b-dfa4-4fc6-8a0c-e584996b0075",
+        "maturity": "committed",
+        "updatedAt": "2026-05-02T00:00:00.000Z"
+      },
+      {
+        "id": "f9d57022-1dad-4c8f-a387-27e0a8576947",
+        "no": 11,
+        "name": "店舗マスター",
+        "kind": "list",
+        "path": "/master/stores",
+        "groupId": "8c592e1b-dfa4-4fc6-8a0c-e584996b0075",
+        "maturity": "committed",
+        "updatedAt": "2026-05-02T00:00:00.000Z"
+      }
+    ],
+    "screenGroups": [
+      {
+        "id": "c720b549-ecf4-4d20-9be4-c8d38f89a13e",
+        "name": "顧客向け",
+        "color": "#0d6efd"
+      },
+      {
+        "id": "a7285b88-9e12-4d2c-94c6-ef6bd788685d",
+        "name": "バックオフィス",
+        "color": "#198754"
+      },
+      {
+        "id": "8c592e1b-dfa4-4fc6-8a0c-e584996b0075",
+        "name": "マスター管理",
+        "color": "#6c757d"
+      }
+    ],
+    "screenTransitions": [
+      {
+        "id": "tr-search-to-cart",
+        "sourceScreenId": "e6147dc0-94b7-436d-ba87-d0080ac34f44",
+        "targetScreenId": "c73fa05c-4a71-4593-800d-b9814e97be83",
+        "label": "カートに追加",
+        "trigger": "click"
+      },
+      {
+        "id": "tr-cart-to-confirm",
+        "sourceScreenId": "c73fa05c-4a71-4593-800d-b9814e97be83",
+        "targetScreenId": "cff4a398-99cd-4aa5-bfbd-c12d5e72c5f3",
+        "label": "注文確認へ",
+        "trigger": "click"
+      },
+      {
+        "id": "tr-confirm-to-complete",
+        "sourceScreenId": "cff4a398-99cd-4aa5-bfbd-c12d5e72c5f3",
+        "targetScreenId": "0739c454-45d6-4c99-962a-7b0b9e113a22",
+        "label": "注文確定",
+        "trigger": "submit"
+      },
+      {
+        "id": "tr-orderlist-to-dispatch",
+        "sourceScreenId": "f9faa724-e080-4308-bc14-bb93631c9e78",
+        "targetScreenId": "c2254dd6-ab5d-4428-931f-d27c71e89951",
+        "label": "配送指示",
+        "trigger": "click"
+      },
+      {
+        "id": "tr-dashboard-to-search",
+        "sourceScreenId": "765c3c23-8a0e-46b0-ae8b-ce84d10be0b0",
+        "targetScreenId": "e6147dc0-94b7-436d-ba87-d0080ac34f44",
+        "label": "商品検索 (S-1)",
+        "trigger": "click"
+      },
+      {
+        "id": "tr-dashboard-to-cart",
+        "sourceScreenId": "765c3c23-8a0e-46b0-ae8b-ce84d10be0b0",
+        "targetScreenId": "c73fa05c-4a71-4593-800d-b9814e97be83",
+        "label": "カート (S-2/S-3)",
+        "trigger": "click"
+      },
+      {
+        "id": "tr-dashboard-to-orderlist",
+        "sourceScreenId": "765c3c23-8a0e-46b0-ae8b-ce84d10be0b0",
+        "targetScreenId": "f9faa724-e080-4308-bc14-bb93631c9e78",
+        "label": "注文一覧 (S-4)",
+        "trigger": "click"
+      },
+      {
+        "id": "tr-dashboard-to-inventory",
+        "sourceScreenId": "765c3c23-8a0e-46b0-ae8b-ce84d10be0b0",
+        "targetScreenId": "4a9df651-e0cc-4523-a9bf-f3fb9d45c53f",
+        "label": "在庫一覧",
+        "trigger": "click"
+      },
+      {
+        "id": "tr-complete-to-dashboard",
+        "sourceScreenId": "0739c454-45d6-4c99-962a-7b0b9e113a22",
+        "targetScreenId": "765c3c23-8a0e-46b0-ae8b-ce84d10be0b0",
+        "label": "ダッシュボードへ",
+        "trigger": "click"
+      },
+      {
+        "id": "tr-complete-to-orderlist",
+        "sourceScreenId": "0739c454-45d6-4c99-962a-7b0b9e113a22",
+        "targetScreenId": "f9faa724-e080-4308-bc14-bb93631c9e78",
+        "label": "注文履歴へ",
+        "trigger": "click"
+      }
+    ],
     "tables": [
       {
         "id": "652cbbfe-17e2-4f23-a0c9-4403e6b23bb0",

--- a/samples/retail/project.json
+++ b/samples/retail/project.json
@@ -17,7 +17,88 @@
     "screens": [],
     "screenGroups": [],
     "screenTransitions": [],
-    "tables": [],
+    "tables": [
+      {
+        "id": "652cbbfe-17e2-4f23-a0c9-4403e6b23bb0",
+        "no": 1,
+        "name": "商品マスタ",
+        "physicalName": "products",
+        "category": "マスタ",
+        "columnCount": 11,
+        "maturity": "committed",
+        "updatedAt": "2026-05-02T00:00:00.000Z"
+      },
+      {
+        "id": "605bbc9d-810a-4b9c-a83a-cc2e59bca37a",
+        "no": 2,
+        "name": "顧客マスタ",
+        "physicalName": "customers",
+        "category": "マスタ",
+        "columnCount": 9,
+        "maturity": "committed",
+        "updatedAt": "2026-05-02T00:00:00.000Z"
+      },
+      {
+        "id": "fdf00088-87d1-40e8-9eba-65ef58a9bfe5",
+        "no": 3,
+        "name": "店舗マスタ",
+        "physicalName": "stores",
+        "category": "マスタ",
+        "columnCount": 10,
+        "maturity": "committed",
+        "updatedAt": "2026-05-02T00:00:00.000Z"
+      },
+      {
+        "id": "834ede22-3cb0-4dcf-aa8a-7c046664774a",
+        "no": 4,
+        "name": "店舗別在庫",
+        "physicalName": "inventory",
+        "category": "トランザクション",
+        "columnCount": 6,
+        "maturity": "committed",
+        "updatedAt": "2026-05-02T00:00:00.000Z"
+      },
+      {
+        "id": "a32e1a09-bcbc-467f-86b0-983cd7ee61c6",
+        "no": 5,
+        "name": "カート",
+        "physicalName": "carts",
+        "category": "トランザクション",
+        "columnCount": 5,
+        "maturity": "committed",
+        "updatedAt": "2026-05-02T00:00:00.000Z"
+      },
+      {
+        "id": "57110336-a984-4d39-bb21-1e5d5bb4390b",
+        "no": 6,
+        "name": "カート明細",
+        "physicalName": "cart_items",
+        "category": "トランザクション",
+        "columnCount": 7,
+        "maturity": "committed",
+        "updatedAt": "2026-05-02T00:00:00.000Z"
+      },
+      {
+        "id": "10d555e2-8041-4192-86f3-9e2a3ac581ab",
+        "no": 7,
+        "name": "注文",
+        "physicalName": "orders",
+        "category": "トランザクション",
+        "columnCount": 11,
+        "maturity": "committed",
+        "updatedAt": "2026-05-02T00:00:00.000Z"
+      },
+      {
+        "id": "dddfb0c1-0fde-40ac-bcf0-5ed75a7f1edc",
+        "no": 8,
+        "name": "注文明細",
+        "physicalName": "order_items",
+        "category": "トランザクション",
+        "columnCount": 9,
+        "maturity": "committed",
+        "updatedAt": "2026-05-02T00:00:00.000Z"
+      }
+    ],
     "processFlows": [],
     "views": [],
     "viewDefinitions": [],

--- a/samples/retail/project.json
+++ b/samples/retail/project.json
@@ -335,8 +335,118 @@
         "updatedAt": "2026-05-02T00:00:00.000Z"
       }
     ],
-    "views": [],
-    "viewDefinitions": [],
-    "sequences": []
+    "views": [
+      {
+        "id": "6e6a9612-85c8-4541-a497-8851cea28f56",
+        "no": 1,
+        "name": "商品付き在庫ビュー",
+        "physicalName": "v_inventory_with_product",
+        "maturity": "committed",
+        "updatedAt": "2026-05-02T00:00:00.000Z"
+      },
+      {
+        "id": "feb6d55d-33bc-4f25-adac-b5fa18b2a579",
+        "no": 2,
+        "name": "顧客付き注文ビュー",
+        "physicalName": "v_orders_with_customer",
+        "maturity": "committed",
+        "updatedAt": "2026-05-02T00:00:00.000Z"
+      },
+      {
+        "id": "ce75dd91-3e55-4e0b-ac2c-11108943a8cf",
+        "no": 3,
+        "name": "注文明細詳細ビュー",
+        "physicalName": "v_order_items_detail",
+        "maturity": "committed",
+        "updatedAt": "2026-05-02T00:00:00.000Z"
+      },
+      {
+        "id": "822d5a83-1c06-4650-97fa-35a62bca3d5e",
+        "no": 4,
+        "name": "カートサマリビュー",
+        "physicalName": "v_cart_summary",
+        "maturity": "committed",
+        "updatedAt": "2026-05-02T00:00:00.000Z"
+      }
+    ],
+    "viewDefinitions": [
+      {
+        "id": "db10b1f4-459c-4bd3-bb27-76394209671d",
+        "no": 1,
+        "name": "商品マスター一覧",
+        "kind": "list",
+        "sourceTableId": "652cbbfe-17e2-4f23-a0c9-4403e6b23bb0",
+        "columnCount": 5,
+        "maturity": "committed",
+        "updatedAt": "2026-05-02T00:00:00.000Z"
+      },
+      {
+        "id": "7b01161a-d6bc-41d9-b60d-25ed33c8bf5d",
+        "no": 2,
+        "name": "顧客マスター一覧",
+        "kind": "list",
+        "sourceTableId": "605bbc9d-810a-4b9c-a83a-cc2e59bca37a",
+        "columnCount": 4,
+        "maturity": "committed",
+        "updatedAt": "2026-05-02T00:00:00.000Z"
+      },
+      {
+        "id": "97354753-765a-449e-85ad-d23acad53a76",
+        "no": 3,
+        "name": "店舗マスター一覧",
+        "kind": "list",
+        "sourceTableId": "fdf00088-87d1-40e8-9eba-65ef58a9bfe5",
+        "columnCount": 4,
+        "maturity": "committed",
+        "updatedAt": "2026-05-02T00:00:00.000Z"
+      },
+      {
+        "id": "fbd95d09-4ac4-44e0-a6a7-44affff128a0",
+        "no": 4,
+        "name": "在庫一覧",
+        "kind": "list",
+        "sourceTableId": "834ede22-3cb0-4dcf-aa8a-7c046664774a",
+        "columnCount": 6,
+        "maturity": "committed",
+        "updatedAt": "2026-05-02T00:00:00.000Z"
+      },
+      {
+        "id": "4cef6340-2603-44b3-b92e-e85e4809a955",
+        "no": 5,
+        "name": "注文一覧",
+        "kind": "list",
+        "sourceTableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab",
+        "columnCount": 6,
+        "maturity": "committed",
+        "updatedAt": "2026-05-02T00:00:00.000Z"
+      }
+    ],
+    "sequences": [
+      {
+        "id": "e2fde820-35f8-4c39-a724-646e07580946",
+        "no": 1,
+        "name": "注文番号採番",
+        "physicalName": "seq_order_number",
+        "conventionRef": "@conv.numbering.orderNumber",
+        "maturity": "committed",
+        "updatedAt": "2026-05-02T00:00:00.000Z"
+      },
+      {
+        "id": "af8f14b0-b6d7-4661-ac4b-bdf0a196e0b2",
+        "no": 2,
+        "name": "顧客ID採番",
+        "physicalName": "seq_customer_id",
+        "maturity": "committed",
+        "updatedAt": "2026-05-02T00:00:00.000Z"
+      },
+      {
+        "id": "536a2528-8cde-4bd2-8884-e3e3c53c57dd",
+        "no": 3,
+        "name": "配送ID採番",
+        "physicalName": "seq_shipment_id",
+        "maturity": "committed",
+        "updatedAt": "2026-05-02T00:00:00.000Z"
+      }
+    ]
   }
 }

--- a/samples/retail/screen-items/0739c454-45d6-4c99-962a-7b0b9e113a22.json
+++ b/samples/retail/screen-items/0739c454-45d6-4c99-962a-7b0b9e113a22.json
@@ -1,0 +1,12 @@
+{
+  "id": "orderNumber",
+  "label": "注文番号",
+  "type": "string",
+  "direction": "output",
+  "description": "S-3 注文確定後に発行された注文番号 (ORD-YYYY-NNNNNN 形式)。",
+  "valueFrom": {
+    "kind": "flowVariable",
+    "processFlowId": "f81dd9e0-794c-4539-a2a5-9cbcc0a75899",
+    "variableName": "orderNumber"
+  }
+}

--- a/samples/retail/screen-items/2e23d129-1d53-4e30-b54c-97f90b910578.json
+++ b/samples/retail/screen-items/2e23d129-1d53-4e30-b54c-97f90b910578.json
@@ -1,0 +1,11 @@
+{
+  "id": "productCodeSearch",
+  "label": "商品コード",
+  "type": "string",
+  "direction": "input",
+  "required": false,
+  "maxLength": 20,
+  "pattern": "@conv.regex.productCode",
+  "placeholder": "例: P-0001",
+  "description": "商品マスター一覧の検索条件: 商品コード。"
+}

--- a/samples/retail/screen-items/4a9df651-e0cc-4523-a9bf-f3fb9d45c53f.json
+++ b/samples/retail/screen-items/4a9df651-e0cc-4523-a9bf-f3fb9d45c53f.json
@@ -1,0 +1,24 @@
+{
+  "id": "storeFilter",
+  "label": "店舗",
+  "type": "string",
+  "direction": "input",
+  "required": true,
+  "options": [
+    { "value": "S-001", "label": "東京本店" },
+    { "value": "S-002", "label": "大阪支店" },
+    { "value": "S-003", "label": "名古屋支店" }
+  ],
+  "events": [
+    {
+      "id": "change",
+      "label": "在庫照会",
+      "handlerFlowId": "efa7ac6e-e295-416e-b68d-17c4739b5097",
+      "argumentMapping": {
+        "storeCode": "@screen.storeFilter",
+        "productCode": "@screen.productCodeFilter"
+      }
+    }
+  ],
+  "description": "S-1 在庫一覧の店舗フィルタ。"
+}

--- a/samples/retail/screen-items/765c3c23-8a0e-46b0-ae8b-ce84d10be0b0.json
+++ b/samples/retail/screen-items/765c3c23-8a0e-46b0-ae8b-ce84d10be0b0.json
@@ -1,0 +1,12 @@
+{
+  "id": "todaySales",
+  "label": "今日の売上",
+  "type": "integer",
+  "direction": "output",
+  "displayFormat": "¥#,##0",
+  "description": "ダッシュボード KPI: 本日の累計売上金額 (税込)。",
+  "valueFrom": {
+    "kind": "flowVariable",
+    "variableName": "todaySales"
+  }
+}

--- a/samples/retail/screen-items/c2254dd6-ab5d-4428-931f-d27c71e89951.json
+++ b/samples/retail/screen-items/c2254dd6-ab5d-4428-931f-d27c71e89951.json
@@ -1,0 +1,29 @@
+{
+  "id": "carrierId",
+  "label": "配送会社",
+  "type": "string",
+  "direction": "input",
+  "required": true,
+  "options": [
+    { "value": "yamato", "label": "ヤマト運輸" },
+    { "value": "sagawa", "label": "佐川急便" },
+    { "value": "japanpost", "label": "日本郵便" }
+  ],
+  "errorMessages": {
+    "required": "配送会社を選択してください。"
+  },
+  "events": [
+    {
+      "id": "submit",
+      "label": "配送指示登録",
+      "handlerFlowId": "d63c703c-26ed-4704-8b76-329c6bfae9c9",
+      "argumentMapping": {
+        "orderId": "@screen.orderId",
+        "carrierId": "@screen.carrierId",
+        "preferredDate": "@screen.preferredDate",
+        "timeSlot": "@screen.timeSlot"
+      }
+    }
+  ],
+  "description": "S-4 配送指示フォームの配送会社選択。"
+}

--- a/samples/retail/screen-items/c73fa05c-4a71-4593-800d-b9814e97be83.json
+++ b/samples/retail/screen-items/c73fa05c-4a71-4593-800d-b9814e97be83.json
@@ -1,0 +1,26 @@
+{
+  "id": "addProductCode",
+  "label": "商品コード",
+  "type": "string",
+  "direction": "input",
+  "required": true,
+  "maxLength": 20,
+  "pattern": "@conv.regex.productCode",
+  "placeholder": "例: P-0001",
+  "errorMessages": {
+    "required": "商品コードは必須です。",
+    "invalidFormat": "商品コードは P-XXXX〜P-XXXXXX 形式で入力してください。"
+  },
+  "events": [
+    {
+      "id": "submit",
+      "label": "カートに追加",
+      "handlerFlowId": "9515d6f6-8342-48cf-a045-9e9d8fab1cfa",
+      "argumentMapping": {
+        "productCode": "@screen.addProductCode",
+        "quantity": "@screen.addQuantity"
+      }
+    }
+  ],
+  "description": "S-2 カート追加フォームの商品コード入力。"
+}

--- a/samples/retail/screen-items/cff4a398-99cd-4aa5-bfbd-c12d5e72c5f3.json
+++ b/samples/retail/screen-items/cff4a398-99cd-4aa5-bfbd-c12d5e72c5f3.json
@@ -1,0 +1,27 @@
+{
+  "id": "shippingPostalCode",
+  "label": "郵便番号",
+  "type": "string",
+  "direction": "input",
+  "required": true,
+  "maxLength": 7,
+  "pattern": "@conv.regex.postalCode",
+  "placeholder": "例: 1600022 (ハイフンなし7桁)",
+  "errorMessages": {
+    "required": "郵便番号は必須です。",
+    "invalidFormat": "郵便番号はハイフンなし 7 桁の数字で入力してください。"
+  },
+  "events": [
+    {
+      "id": "submit",
+      "label": "注文確定",
+      "handlerFlowId": "f81dd9e0-794c-4539-a2a5-9cbcc0a75899",
+      "argumentMapping": {
+        "shippingPostalCode": "@screen.shippingPostalCode",
+        "shippingAddress": "@screen.shippingAddress",
+        "note": "@screen.note"
+      }
+    }
+  ],
+  "description": "S-3 注文確定の配送先郵便番号。"
+}

--- a/samples/retail/screen-items/e6147dc0-94b7-436d-ba87-d0080ac34f44.json
+++ b/samples/retail/screen-items/e6147dc0-94b7-436d-ba87-d0080ac34f44.json
@@ -1,0 +1,26 @@
+{
+  "id": "productCode",
+  "label": "商品コード",
+  "type": "string",
+  "direction": "input",
+  "required": false,
+  "maxLength": 20,
+  "pattern": "@conv.regex.productCode",
+  "placeholder": "例: P-0001",
+  "helperText": "P- で始まる 4〜6 桁の商品コードを入力してください。",
+  "errorMessages": {
+    "invalidFormat": "商品コードは P-XXXX〜P-XXXXXX 形式で入力してください。"
+  },
+  "events": [
+    {
+      "id": "submit",
+      "label": "在庫照会",
+      "handlerFlowId": "efa7ac6e-e295-416e-b68d-17c4739b5097",
+      "argumentMapping": {
+        "productCode": "@screen.productCode",
+        "storeCode": "@screen.storeCode"
+      }
+    }
+  ],
+  "description": "S-1 在庫照会の検索入力: 商品コード。"
+}

--- a/samples/retail/screen-items/f05fd315-2c78-48e5-9968-2633255b286e.json
+++ b/samples/retail/screen-items/f05fd315-2c78-48e5-9968-2633255b286e.json
@@ -1,0 +1,10 @@
+{
+  "id": "emailSearch",
+  "label": "メールアドレス",
+  "type": "string",
+  "direction": "input",
+  "required": false,
+  "maxLength": 254,
+  "placeholder": "例: customer@example.com",
+  "description": "顧客マスター一覧の検索条件: メールアドレス。"
+}

--- a/samples/retail/screen-items/f9d57022-1dad-4c8f-a387-27e0a8576947.json
+++ b/samples/retail/screen-items/f9d57022-1dad-4c8f-a387-27e0a8576947.json
@@ -1,0 +1,11 @@
+{
+  "id": "storeCodeSearch",
+  "label": "店舗コード",
+  "type": "string",
+  "direction": "input",
+  "required": false,
+  "maxLength": 10,
+  "pattern": "@conv.regex.storeCode",
+  "placeholder": "例: S-001",
+  "description": "店舗マスター一覧の検索条件: 店舗コード。"
+}

--- a/samples/retail/screen-items/f9faa724-e080-4308-bc14-bb93631c9e78.json
+++ b/samples/retail/screen-items/f9faa724-e080-4308-bc14-bb93631c9e78.json
@@ -1,0 +1,10 @@
+{
+  "id": "orderNumberFilter",
+  "label": "注文番号",
+  "type": "string",
+  "direction": "input",
+  "required": false,
+  "maxLength": 20,
+  "placeholder": "例: ORD-2026-000001",
+  "description": "S-4 注文一覧の検索条件: 注文番号。"
+}

--- a/samples/retail/screen-layout.json
+++ b/samples/retail/screen-layout.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "../../schemas/v3/screen-layout.v3.schema.json",
+  "positions": {
+    "765c3c23-8a0e-46b0-ae8b-ce84d10be0b0": { "x": 600, "y": 80, "width": 200, "height": 80 },
+    "e6147dc0-94b7-436d-ba87-d0080ac34f44": { "x": 100, "y": 280, "width": 200, "height": 80 },
+    "4a9df651-e0cc-4523-a9bf-f3fb9d45c53f": { "x": 800, "y": 280, "width": 200, "height": 80 },
+    "c73fa05c-4a71-4593-800d-b9814e97be83": { "x": 100, "y": 460, "width": 200, "height": 80 },
+    "cff4a398-99cd-4aa5-bfbd-c12d5e72c5f3": { "x": 100, "y": 640, "width": 200, "height": 80 },
+    "0739c454-45d6-4c99-962a-7b0b9e113a22": { "x": 100, "y": 820, "width": 200, "height": 80 },
+    "f9faa724-e080-4308-bc14-bb93631c9e78": { "x": 1100, "y": 280, "width": 200, "height": 80 },
+    "c2254dd6-ab5d-4428-931f-d27c71e89951": { "x": 1100, "y": 460, "width": 200, "height": 80 },
+    "2e23d129-1d53-4e30-b54c-97f90b910578": { "x": 1400, "y": 280, "width": 200, "height": 80 },
+    "f05fd315-2c78-48e5-9968-2633255b286e": { "x": 1400, "y": 460, "width": 200, "height": 80 },
+    "f9d57022-1dad-4c8f-a387-27e0a8576947": { "x": 1400, "y": 640, "width": 200, "height": 80 },
+    "c720b549-ecf4-4d20-9be4-c8d38f89a13e": { "x": 50, "y": 230, "width": 320, "height": 720, "color": "#0d6efd" },
+    "a7285b88-9e12-4d2c-94c6-ef6bd788685d": { "x": 750, "y": 230, "width": 320, "height": 360, "color": "#198754" },
+    "8c592e1b-dfa4-4fc6-8a0c-e584996b0075": { "x": 1350, "y": 230, "width": 320, "height": 540, "color": "#6c757d" }
+  },
+  "transitions": {
+    "tr-search-to-cart": {},
+    "tr-cart-to-confirm": {},
+    "tr-confirm-to-complete": {},
+    "tr-orderlist-to-dispatch": {},
+    "tr-dashboard-to-search": {},
+    "tr-dashboard-to-cart": {},
+    "tr-dashboard-to-orderlist": {},
+    "tr-dashboard-to-inventory": {},
+    "tr-complete-to-dashboard": {},
+    "tr-complete-to-orderlist": {}
+  },
+  "updatedAt": "2026-05-02T00:00:00.000Z"
+}

--- a/samples/retail/screens/0739c454-45d6-4c99-962a-7b0b9e113a22.json
+++ b/samples/retail/screens/0739c454-45d6-4c99-962a-7b0b9e113a22.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../../schemas/v3/screen.v3.schema.json",
+  "id": "0739c454-45d6-4c99-962a-7b0b9e113a22",
+  "name": "注文完了",
+  "description": "注文確定後の完了画面 (S-3)。注文番号・注文サマリを表示し、ダッシュボードまたは注文履歴への導線を提供する。",
+  "kind": "complete",
+  "path": "/order/complete",
+  "auth": "required",
+  "groupId": "c720b549-ecf4-4d20-9be4-c8d38f89a13e",
+  "maturity": "committed",
+  "createdAt": "2026-05-02T00:00:00.000Z",
+  "updatedAt": "2026-05-02T00:00:00.000Z",
+  "design": {
+    "designFileRef": "../designs/0739c454-45d6-4c99-962a-7b0b9e113a22.html"
+  }
+}

--- a/samples/retail/screens/2e23d129-1d53-4e30-b54c-97f90b910578.json
+++ b/samples/retail/screens/2e23d129-1d53-4e30-b54c-97f90b910578.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../../schemas/v3/screen.v3.schema.json",
+  "id": "2e23d129-1d53-4e30-b54c-97f90b910578",
+  "name": "商品マスター",
+  "description": "商品マスタの一覧・検索・新規登録・編集・削除を行う補助画面。productCode / name / unitPrice / isActive を管理する。",
+  "kind": "list",
+  "path": "/master/products",
+  "auth": "required",
+  "groupId": "8c592e1b-dfa4-4fc6-8a0c-e584996b0075",
+  "maturity": "committed",
+  "createdAt": "2026-05-02T00:00:00.000Z",
+  "updatedAt": "2026-05-02T00:00:00.000Z",
+  "design": {
+    "designFileRef": "../designs/2e23d129-1d53-4e30-b54c-97f90b910578.html"
+  }
+}

--- a/samples/retail/screens/4a9df651-e0cc-4523-a9bf-f3fb9d45c53f.json
+++ b/samples/retail/screens/4a9df651-e0cc-4523-a9bf-f3fb9d45c53f.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../../schemas/v3/screen.v3.schema.json",
+  "id": "4a9df651-e0cc-4523-a9bf-f3fb9d45c53f",
+  "name": "在庫一覧",
+  "description": "店舗別在庫を一覧表示する (S-1)。店舗フィルタ・低在庫フィルタを提供し、補充ボタンから補充フローへ遷移できる。",
+  "kind": "list",
+  "path": "/inventory",
+  "auth": "required",
+  "groupId": "a7285b88-9e12-4d2c-94c6-ef6bd788685d",
+  "maturity": "committed",
+  "createdAt": "2026-05-02T00:00:00.000Z",
+  "updatedAt": "2026-05-02T00:00:00.000Z",
+  "design": {
+    "designFileRef": "../designs/4a9df651-e0cc-4523-a9bf-f3fb9d45c53f.html"
+  }
+}

--- a/samples/retail/screens/765c3c23-8a0e-46b0-ae8b-ce84d10be0b0.json
+++ b/samples/retail/screens/765c3c23-8a0e-46b0-ae8b-ce84d10be0b0.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../../schemas/v3/screen.v3.schema.json",
+  "id": "765c3c23-8a0e-46b0-ae8b-ce84d10be0b0",
+  "name": "ダッシュボード",
+  "description": "リテール総合システムのトップ画面。KPI カード (今日の売上・在庫アラート・配送待ち件数・顧客数) と 4 シナリオへのナビゲーションを提供する。",
+  "kind": "dashboard",
+  "path": "/",
+  "auth": "required",
+  "groupId": "a7285b88-9e12-4d2c-94c6-ef6bd788685d",
+  "maturity": "committed",
+  "createdAt": "2026-05-02T00:00:00.000Z",
+  "updatedAt": "2026-05-02T00:00:00.000Z",
+  "design": {
+    "designFileRef": "../designs/765c3c23-8a0e-46b0-ae8b-ce84d10be0b0.html"
+  }
+}

--- a/samples/retail/screens/c2254dd6-ab5d-4428-931f-d27c71e89951.json
+++ b/samples/retail/screens/c2254dd6-ab5d-4428-931f-d27c71e89951.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../../schemas/v3/screen.v3.schema.json",
+  "id": "c2254dd6-ab5d-4428-931f-d27c71e89951",
+  "name": "配送指示",
+  "description": "注文の配送指示を登録する (S-4)。注文詳細 (読み取り専用) にキャリア・配送希望日・時間帯を入力し指示を確定する。",
+  "kind": "form",
+  "path": "/orders/:id/dispatch",
+  "auth": "required",
+  "groupId": "a7285b88-9e12-4d2c-94c6-ef6bd788685d",
+  "maturity": "committed",
+  "createdAt": "2026-05-02T00:00:00.000Z",
+  "updatedAt": "2026-05-02T00:00:00.000Z",
+  "design": {
+    "designFileRef": "../designs/c2254dd6-ab5d-4428-931f-d27c71e89951.html"
+  }
+}

--- a/samples/retail/screens/c73fa05c-4a71-4593-800d-b9814e97be83.json
+++ b/samples/retail/screens/c73fa05c-4a71-4593-800d-b9814e97be83.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../../schemas/v3/screen.v3.schema.json",
+  "id": "c73fa05c-4a71-4593-800d-b9814e97be83",
+  "name": "カート",
+  "description": "商品コードと数量を入力してカートに追加する (S-2/S-3)。カート明細テーブルで削除・数量変更ができ、合計金額を表示する。注文確認画面への導線を提供する。",
+  "kind": "retail:cart",
+  "path": "/cart",
+  "auth": "required",
+  "groupId": "c720b549-ecf4-4d20-9be4-c8d38f89a13e",
+  "maturity": "committed",
+  "createdAt": "2026-05-02T00:00:00.000Z",
+  "updatedAt": "2026-05-02T00:00:00.000Z",
+  "design": {
+    "designFileRef": "../designs/c73fa05c-4a71-4593-800d-b9814e97be83.html"
+  }
+}

--- a/samples/retail/screens/cff4a398-99cd-4aa5-bfbd-c12d5e72c5f3.json
+++ b/samples/retail/screens/cff4a398-99cd-4aa5-bfbd-c12d5e72c5f3.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../../schemas/v3/screen.v3.schema.json",
+  "id": "cff4a398-99cd-4aa5-bfbd-c12d5e72c5f3",
+  "name": "カート確認",
+  "description": "カート明細 (読み取り専用) と配送先住所を確認・入力する (S-3)。注文確定ボタンで注文確定フローを実行する。",
+  "kind": "confirm",
+  "path": "/cart/confirm",
+  "auth": "required",
+  "groupId": "c720b549-ecf4-4d20-9be4-c8d38f89a13e",
+  "maturity": "committed",
+  "createdAt": "2026-05-02T00:00:00.000Z",
+  "updatedAt": "2026-05-02T00:00:00.000Z",
+  "design": {
+    "designFileRef": "../designs/cff4a398-99cd-4aa5-bfbd-c12d5e72c5f3.html"
+  }
+}

--- a/samples/retail/screens/e6147dc0-94b7-436d-ba87-d0080ac34f44.json
+++ b/samples/retail/screens/e6147dc0-94b7-436d-ba87-d0080ac34f44.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../../schemas/v3/screen.v3.schema.json",
+  "id": "e6147dc0-94b7-436d-ba87-d0080ac34f44",
+  "name": "商品検索",
+  "description": "商品コード・店舗を条件に在庫を照会する (S-1)。検索結果一覧に在庫数と低在庫バッジを表示し、カート画面への導線を提供する。",
+  "kind": "search",
+  "path": "/products/search",
+  "auth": "required",
+  "groupId": "c720b549-ecf4-4d20-9be4-c8d38f89a13e",
+  "maturity": "committed",
+  "createdAt": "2026-05-02T00:00:00.000Z",
+  "updatedAt": "2026-05-02T00:00:00.000Z",
+  "design": {
+    "designFileRef": "../designs/e6147dc0-94b7-436d-ba87-d0080ac34f44.html"
+  }
+}

--- a/samples/retail/screens/f05fd315-2c78-48e5-9968-2633255b286e.json
+++ b/samples/retail/screens/f05fd315-2c78-48e5-9968-2633255b286e.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../../schemas/v3/screen.v3.schema.json",
+  "id": "f05fd315-2c78-48e5-9968-2633255b286e",
+  "name": "顧客マスター",
+  "description": "顧客マスタの一覧・検索画面。email / name / isActive を表示し、詳細リンクから顧客詳細へ遷移できる。",
+  "kind": "list",
+  "path": "/master/customers",
+  "auth": "required",
+  "groupId": "8c592e1b-dfa4-4fc6-8a0c-e584996b0075",
+  "maturity": "committed",
+  "createdAt": "2026-05-02T00:00:00.000Z",
+  "updatedAt": "2026-05-02T00:00:00.000Z",
+  "design": {
+    "designFileRef": "../designs/f05fd315-2c78-48e5-9968-2633255b286e.html"
+  }
+}

--- a/samples/retail/screens/f9d57022-1dad-4c8f-a387-27e0a8576947.json
+++ b/samples/retail/screens/f9d57022-1dad-4c8f-a387-27e0a8576947.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../../schemas/v3/screen.v3.schema.json",
+  "id": "f9d57022-1dad-4c8f-a387-27e0a8576947",
+  "name": "店舗マスター",
+  "description": "店舗マスタの一覧・検索画面。storeCode / name / 地域 / 営業中フラグを表示する。",
+  "kind": "list",
+  "path": "/master/stores",
+  "auth": "required",
+  "groupId": "8c592e1b-dfa4-4fc6-8a0c-e584996b0075",
+  "maturity": "committed",
+  "createdAt": "2026-05-02T00:00:00.000Z",
+  "updatedAt": "2026-05-02T00:00:00.000Z",
+  "design": {
+    "designFileRef": "../designs/f9d57022-1dad-4c8f-a387-27e0a8576947.html"
+  }
+}

--- a/samples/retail/screens/f9faa724-e080-4308-bc14-bb93631c9e78.json
+++ b/samples/retail/screens/f9faa724-e080-4308-bc14-bb93631c9e78.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../../schemas/v3/screen.v3.schema.json",
+  "id": "f9faa724-e080-4308-bc14-bb93631c9e78",
+  "name": "注文一覧",
+  "description": "バックオフィス向け注文一覧画面 (S-4)。注文番号・顧客・日付範囲で絞り込み、注文テーブルのステータスと配送指示ボタンを表示する。",
+  "kind": "list",
+  "path": "/orders",
+  "auth": "required",
+  "groupId": "a7285b88-9e12-4d2c-94c6-ef6bd788685d",
+  "maturity": "committed",
+  "createdAt": "2026-05-02T00:00:00.000Z",
+  "updatedAt": "2026-05-02T00:00:00.000Z",
+  "design": {
+    "designFileRef": "../designs/f9faa724-e080-4308-bc14-bb93631c9e78.html"
+  }
+}

--- a/samples/retail/sequences/536a2528-8cde-4bd2-8884-e3e3c53c57dd.json
+++ b/samples/retail/sequences/536a2528-8cde-4bd2-8884-e3e3c53c57dd.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../../schemas/v3/sequence.v3.schema.json",
+  "id": "536a2528-8cde-4bd2-8884-e3e3c53c57dd",
+  "name": "配送ID採番",
+  "description": "配送指示フロー (S-4) で 1 配送指示につき 1 つの配送 ID を発行するシーケンス。採番値はアプリ層で 'SHIP-{YYYYMMDD}-{NNNN}' にフォーマットする。YYYYMMDD は配送指示日 (8 桁)、NNNN はシーケンス値をゼロ埋め 4 桁で表現する。日次リセットはアプリ層制御 (DB シーケンス自体は CYCLE なし)。",
+  "maturity": "committed",
+  "createdAt": "2026-05-02T00:00:00.000Z",
+  "updatedAt": "2026-05-02T00:00:00.000Z",
+  "physicalName": "seq_shipment_id",
+  "startValue": 1,
+  "increment": 1,
+  "minValue": 1,
+  "maxValue": 9999,
+  "cycle": false,
+  "cache": 5
+}

--- a/samples/retail/sequences/af8f14b0-b6d7-4661-ac4b-bdf0a196e0b2.json
+++ b/samples/retail/sequences/af8f14b0-b6d7-4661-ac4b-bdf0a196e0b2.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "../../../schemas/v3/sequence.v3.schema.json",
+  "id": "af8f14b0-b6d7-4661-ac4b-bdf0a196e0b2",
+  "name": "顧客ID採番",
+  "description": "顧客マスター登録時に発行する顧客 ID 採番シーケンス。採番値はアプリ層で 'CUST-{NNNNNNNN}' にフォーマットする (8 桁ゼロ埋め)。customers テーブルの id 列 (BIGINT サロゲートキー) とは別に、業務向け顧客識別子として使用する。年リセットなし、永続連番。",
+  "maturity": "committed",
+  "createdAt": "2026-05-02T00:00:00.000Z",
+  "updatedAt": "2026-05-02T00:00:00.000Z",
+  "physicalName": "seq_customer_id",
+  "startValue": 1,
+  "increment": 1,
+  "minValue": 1,
+  "maxValue": 99999999,
+  "cycle": false,
+  "cache": 10,
+  "usedBy": [
+    {
+      "tableId": "605bbc9d-810a-4b9c-a83a-cc2e59bca37a",
+      "columnId": "col-id"
+    }
+  ]
+}

--- a/samples/retail/sequences/e2fde820-35f8-4c39-a724-646e07580946.json
+++ b/samples/retail/sequences/e2fde820-35f8-4c39-a724-646e07580946.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "../../../schemas/v3/sequence.v3.schema.json",
+  "id": "e2fde820-35f8-4c39-a724-646e07580946",
+  "name": "注文番号採番",
+  "description": "注文確定フロー (S-3) で 1 トランザクションにつき 1 つの注文番号を発行するシーケンス。採番値はアプリ層で 'ORD-{YYYY}-{NNNNNN}' にフォーマットする。YYYY は注文確定年 (西暦 4 桁)、NNNNNN はシーケンス値をゼロ埋め 6 桁で表現する。年ごとにリセットはアプリ層制御 (DB シーケンス自体は CYCLE なし)。@conv.numbering.orderNumber 規約の実装シーケンス。",
+  "maturity": "committed",
+  "createdAt": "2026-05-02T00:00:00.000Z",
+  "updatedAt": "2026-05-02T00:00:00.000Z",
+  "physicalName": "seq_order_number",
+  "startValue": 1,
+  "increment": 1,
+  "minValue": 1,
+  "maxValue": 999999,
+  "cycle": false,
+  "cache": 20,
+  "usedBy": [
+    {
+      "tableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab",
+      "columnId": "col-order-number"
+    }
+  ],
+  "conventionRef": "@conv.numbering.orderNumber"
+}

--- a/samples/retail/tables/10d555e2-8041-4192-86f3-9e2a3ac581ab.json
+++ b/samples/retail/tables/10d555e2-8041-4192-86f3-9e2a3ac581ab.json
@@ -1,0 +1,195 @@
+{
+  "$schema": "../../../schemas/v3/table.v3.schema.json",
+  "id": "10d555e2-8041-4192-86f3-9e2a3ac581ab",
+  "name": "注文",
+  "description": "顧客の注文を管理するトランザクションテーブル。カート確認 → 注文確定フロー (S-3) で 1 TX 内に注文登録・在庫引き当て・採番を行う。注文明細は order_items で管理。",
+  "maturity": "committed",
+  "createdAt": "2026-05-02T00:00:00.000Z",
+  "updatedAt": "2026-05-02T00:00:00.000Z",
+  "physicalName": "orders",
+  "category": "トランザクション",
+  "comment": "注文テーブル。order_number (採番) で顧客向け識別子を提供する。",
+  "columns": [
+    {
+      "id": "col-id",
+      "no": 1,
+      "physicalName": "id",
+      "name": "注文ID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "primaryKey": true,
+      "autoIncrement": true,
+      "comment": "サロゲートキー (自動採番)"
+    },
+    {
+      "id": "col-order-number",
+      "no": 2,
+      "physicalName": "order_number",
+      "name": "注文番号",
+      "dataType": "VARCHAR",
+      "length": 30,
+      "notNull": true,
+      "unique": true,
+      "comment": "顧客向け注文番号。@conv.numbering.orderNumber 規約で採番 (例: ORD-2026-0001)",
+      "description": "注文確定完了画面 (S-3) で表示する。配送指示 (S-4) での検索キーとしても使用。"
+    },
+    {
+      "id": "col-customer-id",
+      "no": 3,
+      "physicalName": "customer_id",
+      "name": "顧客ID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "comment": "FK → customers.id"
+    },
+    {
+      "id": "col-status",
+      "no": 4,
+      "physicalName": "status",
+      "name": "注文ステータス",
+      "dataType": "VARCHAR",
+      "length": 30,
+      "notNull": true,
+      "defaultValue": "'pending'",
+      "comment": "pending: 注文済み / confirmed: 確認済み / shipped: 出荷済み / delivered: 配達済み / cancelled: キャンセル",
+      "description": "配送指示フロー (S-4) で confirmed → shipped に遷移する。"
+    },
+    {
+      "id": "col-total-amount",
+      "no": 5,
+      "physicalName": "total_amount",
+      "name": "合計金額",
+      "dataType": "DECIMAL",
+      "length": 12,
+      "scale": 0,
+      "notNull": true,
+      "comment": "注文合計金額 (税抜)。order_items の合算値"
+    },
+    {
+      "id": "col-tax-amount",
+      "no": 6,
+      "physicalName": "tax_amount",
+      "name": "消費税額",
+      "dataType": "DECIMAL",
+      "length": 12,
+      "scale": 0,
+      "notNull": true,
+      "defaultValue": "0",
+      "comment": "消費税額。@conv.tax.standard を適用して計算"
+    },
+    {
+      "id": "col-shipping-postal-code",
+      "no": 7,
+      "physicalName": "shipping_postal_code",
+      "name": "配送先郵便番号",
+      "dataType": "CHAR",
+      "length": 7,
+      "notNull": false,
+      "comment": "配送先郵便番号 (ハイフンなし 7 桁)"
+    },
+    {
+      "id": "col-shipping-address",
+      "no": 8,
+      "physicalName": "shipping_address",
+      "name": "配送先住所",
+      "dataType": "VARCHAR",
+      "length": 300,
+      "notNull": false,
+      "comment": "配送指示 (S-4) で使用する配送先住所。注文時点の顧客住所をコピー"
+    },
+    {
+      "id": "col-note",
+      "no": 9,
+      "physicalName": "note",
+      "name": "備考",
+      "dataType": "TEXT",
+      "notNull": false,
+      "comment": "顧客からの備考・連絡事項"
+    },
+    {
+      "id": "col-ordered-at",
+      "no": 10,
+      "physicalName": "ordered_at",
+      "name": "注文日時",
+      "dataType": "TIMESTAMP",
+      "notNull": true,
+      "defaultValue": "CURRENT_TIMESTAMP",
+      "comment": "注文確定日時 (S-3 の TX 完了時刻)"
+    },
+    {
+      "id": "col-updated-at",
+      "no": 11,
+      "physicalName": "updated_at",
+      "name": "更新日時",
+      "dataType": "TIMESTAMP",
+      "notNull": true,
+      "defaultValue": "CURRENT_TIMESTAMP",
+      "comment": "最終更新日時"
+    }
+  ],
+  "constraints": [
+    {
+      "id": "uq-order-number",
+      "kind": "unique",
+      "physicalName": "uq_orders_order_number",
+      "columnIds": ["col-order-number"],
+      "description": "注文番号の一意制約"
+    },
+    {
+      "id": "chk-status",
+      "kind": "check",
+      "physicalName": "chk_orders_status",
+      "expression": "status IN ('pending', 'confirmed', 'shipped', 'delivered', 'cancelled')",
+      "description": "注文ステータス値制約"
+    },
+    {
+      "id": "chk-total-amount",
+      "kind": "check",
+      "physicalName": "chk_orders_total_amount",
+      "expression": "total_amount >= 0",
+      "description": "合計金額は 0 以上"
+    },
+    {
+      "id": "fk-customer",
+      "kind": "foreignKey",
+      "physicalName": "fk_orders_customer",
+      "columnIds": ["col-customer-id"],
+      "referencedTableId": "605bbc9d-810a-4b9c-a83a-cc2e59bca37a",
+      "referencedColumnIds": ["col-id"],
+      "onDelete": "restrict",
+      "onUpdate": "cascade",
+      "description": "customers テーブルへの FK。注文が残る場合は顧客削除を禁止"
+    }
+  ],
+  "indexes": [
+    {
+      "id": "idx-order-number",
+      "physicalName": "idx_orders_order_number",
+      "columns": [{ "columnId": "col-order-number", "order": "asc" }],
+      "unique": true,
+      "method": "btree",
+      "description": "注文番号検索インデックス"
+    },
+    {
+      "id": "idx-customer",
+      "physicalName": "idx_orders_customer_id",
+      "columns": [{ "columnId": "col-customer-id", "order": "asc" }],
+      "method": "btree",
+      "description": "顧客別注文一覧取得インデックス"
+    },
+    {
+      "id": "idx-status",
+      "physicalName": "idx_orders_status",
+      "columns": [{ "columnId": "col-status", "order": "asc" }],
+      "method": "btree",
+      "description": "バックオフィス注文一覧のステータス絞り込みインデックス"
+    },
+    {
+      "id": "idx-ordered-at",
+      "physicalName": "idx_orders_ordered_at",
+      "columns": [{ "columnId": "col-ordered-at", "order": "desc" }],
+      "method": "btree",
+      "description": "注文日時降順ソート用インデックス"
+    }
+  ]
+}

--- a/samples/retail/tables/57110336-a984-4d39-bb21-1e5d5bb4390b.json
+++ b/samples/retail/tables/57110336-a984-4d39-bb21-1e5d5bb4390b.json
@@ -1,0 +1,151 @@
+{
+  "$schema": "../../../schemas/v3/table.v3.schema.json",
+  "id": "57110336-a984-4d39-bb21-1e5d5bb4390b",
+  "name": "カート明細",
+  "description": "カートに追加された商品明細を管理するトランザクションテーブル。(cart_id, product_id) の複合 UNIQUE 制約で重複排除する。カート追加 (S-2) の中心テーブル。",
+  "maturity": "committed",
+  "createdAt": "2026-05-02T00:00:00.000Z",
+  "updatedAt": "2026-05-02T00:00:00.000Z",
+  "physicalName": "cart_items",
+  "category": "トランザクション",
+  "comment": "カート明細。(cart_id, product_id) で重複排除し、quantity で数量を保持する。",
+  "columns": [
+    {
+      "id": "col-id",
+      "no": 1,
+      "physicalName": "id",
+      "name": "カート明細ID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "primaryKey": true,
+      "autoIncrement": true,
+      "comment": "サロゲートキー (自動採番)"
+    },
+    {
+      "id": "col-cart-id",
+      "no": 2,
+      "physicalName": "cart_id",
+      "name": "カートID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "comment": "FK → carts.id"
+    },
+    {
+      "id": "col-product-id",
+      "no": 3,
+      "physicalName": "product_id",
+      "name": "商品ID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "comment": "FK → products.id"
+    },
+    {
+      "id": "col-quantity",
+      "no": 4,
+      "physicalName": "quantity",
+      "name": "数量",
+      "dataType": "INTEGER",
+      "notNull": true,
+      "defaultValue": "1",
+      "comment": "追加数量 (1 以上を CHECK 制約で保証)",
+      "description": "0 は許可しない。削除の場合は行ごと DELETE する (null/0 区別 S-2 要件)。"
+    },
+    {
+      "id": "col-unit-price-snapshot",
+      "no": 5,
+      "physicalName": "unit_price_snapshot",
+      "name": "単価スナップショット",
+      "dataType": "DECIMAL",
+      "length": 10,
+      "scale": 0,
+      "notNull": true,
+      "comment": "カート追加時点の単価。注文確定前に価格改定されても追加時点価格を維持",
+      "description": "products.unit_price のスナップショット。注文確定時は order_items にコピーされる。"
+    },
+    {
+      "id": "col-added-at",
+      "no": 6,
+      "physicalName": "added_at",
+      "name": "追加日時",
+      "dataType": "TIMESTAMP",
+      "notNull": true,
+      "defaultValue": "CURRENT_TIMESTAMP",
+      "comment": "カートへの追加日時"
+    },
+    {
+      "id": "col-updated-at",
+      "no": 7,
+      "physicalName": "updated_at",
+      "name": "更新日時",
+      "dataType": "TIMESTAMP",
+      "notNull": true,
+      "defaultValue": "CURRENT_TIMESTAMP",
+      "comment": "最終更新日時"
+    }
+  ],
+  "constraints": [
+    {
+      "id": "uq-cart-product",
+      "kind": "unique",
+      "physicalName": "uq_cart_items_cart_product",
+      "columnIds": ["col-cart-id", "col-product-id"],
+      "description": "カート × 商品の重複排除制約"
+    },
+    {
+      "id": "chk-quantity",
+      "kind": "check",
+      "physicalName": "chk_cart_items_quantity",
+      "expression": "quantity >= 1",
+      "description": "数量は 1 以上。0 行は許可しない (S-2 null/0 区別)"
+    },
+    {
+      "id": "chk-unit-price-snapshot",
+      "kind": "check",
+      "physicalName": "chk_cart_items_unit_price_snapshot",
+      "expression": "unit_price_snapshot >= 0",
+      "description": "単価スナップショットは 0 以上"
+    },
+    {
+      "id": "fk-cart",
+      "kind": "foreignKey",
+      "physicalName": "fk_cart_items_cart",
+      "columnIds": ["col-cart-id"],
+      "referencedTableId": "a32e1a09-bcbc-467f-86b0-983cd7ee61c6",
+      "referencedColumnIds": ["col-id"],
+      "onDelete": "cascade",
+      "onUpdate": "cascade",
+      "description": "carts テーブルへの FK。カート削除時に明細も削除"
+    },
+    {
+      "id": "fk-product",
+      "kind": "foreignKey",
+      "physicalName": "fk_cart_items_product",
+      "columnIds": ["col-product-id"],
+      "referencedTableId": "652cbbfe-17e2-4f23-a0c9-4403e6b23bb0",
+      "referencedColumnIds": ["col-id"],
+      "onDelete": "restrict",
+      "onUpdate": "cascade",
+      "description": "products テーブルへの FK"
+    }
+  ],
+  "indexes": [
+    {
+      "id": "idx-cart",
+      "physicalName": "idx_cart_items_cart_id",
+      "columns": [{ "columnId": "col-cart-id", "order": "asc" }],
+      "method": "btree",
+      "description": "カート内明細一覧取得インデックス"
+    },
+    {
+      "id": "idx-cart-product",
+      "physicalName": "idx_cart_items_cart_product",
+      "columns": [
+        { "columnId": "col-cart-id", "order": "asc" },
+        { "columnId": "col-product-id", "order": "asc" }
+      ],
+      "unique": true,
+      "method": "btree",
+      "description": "重複チェック用複合インデックス"
+    }
+  ]
+}

--- a/samples/retail/tables/605bbc9d-810a-4b9c-a83a-cc2e59bca37a.json
+++ b/samples/retail/tables/605bbc9d-810a-4b9c-a83a-cc2e59bca37a.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "../../../schemas/v3/table.v3.schema.json",
+  "id": "605bbc9d-810a-4b9c-a83a-cc2e59bca37a",
+  "name": "顧客マスタ",
+  "description": "EC・店舗 POS で利用する顧客情報を管理するマスタテーブル。メールアドレスで一意識別し、配送先・連絡先を保持する。カートおよび注文の所有者として参照される。",
+  "maturity": "committed",
+  "createdAt": "2026-05-02T00:00:00.000Z",
+  "updatedAt": "2026-05-02T00:00:00.000Z",
+  "physicalName": "customers",
+  "category": "マスタ",
+  "comment": "顧客マスタ。email で一意識別する。",
+  "columns": [
+    {
+      "id": "col-id",
+      "no": 1,
+      "physicalName": "id",
+      "name": "顧客ID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "primaryKey": true,
+      "autoIncrement": true,
+      "comment": "サロゲートキー (自動採番)"
+    },
+    {
+      "id": "col-email",
+      "no": 2,
+      "physicalName": "email",
+      "name": "メールアドレス",
+      "dataType": "VARCHAR",
+      "length": 254,
+      "notNull": true,
+      "unique": true,
+      "comment": "RFC 5321 準拠メールアドレス。ログイン ID 兼用",
+      "description": "顧客の主識別子。注文確定メール・会員証の宛先として使用される。"
+    },
+    {
+      "id": "col-full-name",
+      "no": 3,
+      "physicalName": "full_name",
+      "name": "氏名",
+      "dataType": "VARCHAR",
+      "length": 100,
+      "notNull": true,
+      "comment": "顧客氏名 (姓名連結)"
+    },
+    {
+      "id": "col-phone",
+      "no": 4,
+      "physicalName": "phone",
+      "name": "電話番号",
+      "dataType": "VARCHAR",
+      "length": 20,
+      "notNull": false,
+      "comment": "配送連絡用電話番号"
+    },
+    {
+      "id": "col-postal-code",
+      "no": 5,
+      "physicalName": "postal_code",
+      "name": "郵便番号",
+      "dataType": "CHAR",
+      "length": 7,
+      "notNull": false,
+      "comment": "郵便番号 (ハイフンなし 7 桁)"
+    },
+    {
+      "id": "col-address",
+      "no": 6,
+      "physicalName": "address",
+      "name": "住所",
+      "dataType": "VARCHAR",
+      "length": 300,
+      "notNull": false,
+      "comment": "配送先住所 (都道府県+市区町村+番地)"
+    },
+    {
+      "id": "col-is-active",
+      "no": 7,
+      "physicalName": "is_active",
+      "name": "有効フラグ",
+      "dataType": "BOOLEAN",
+      "notNull": true,
+      "defaultValue": "TRUE",
+      "comment": "FALSE で退会済み (論理削除)"
+    },
+    {
+      "id": "col-created-at",
+      "no": 8,
+      "physicalName": "created_at",
+      "name": "登録日時",
+      "dataType": "TIMESTAMP",
+      "notNull": true,
+      "defaultValue": "CURRENT_TIMESTAMP",
+      "comment": "レコード作成日時"
+    },
+    {
+      "id": "col-updated-at",
+      "no": 9,
+      "physicalName": "updated_at",
+      "name": "更新日時",
+      "dataType": "TIMESTAMP",
+      "notNull": true,
+      "defaultValue": "CURRENT_TIMESTAMP",
+      "comment": "最終更新日時"
+    }
+  ],
+  "constraints": [
+    {
+      "id": "uq-email",
+      "kind": "unique",
+      "physicalName": "uq_customers_email",
+      "columnIds": ["col-email"],
+      "description": "メールアドレスの一意制約"
+    }
+  ],
+  "indexes": [
+    {
+      "id": "idx-email",
+      "physicalName": "idx_customers_email",
+      "columns": [{ "columnId": "col-email", "order": "asc" }],
+      "unique": true,
+      "method": "btree",
+      "description": "メールアドレス検索インデックス"
+    },
+    {
+      "id": "idx-full-name",
+      "physicalName": "idx_customers_full_name",
+      "columns": [{ "columnId": "col-full-name", "order": "asc" }],
+      "method": "btree",
+      "description": "氏名検索インデックス"
+    }
+  ]
+}

--- a/samples/retail/tables/652cbbfe-17e2-4f23-a0c9-4403e6b23bb0.json
+++ b/samples/retail/tables/652cbbfe-17e2-4f23-a0c9-4403e6b23bb0.json
@@ -1,0 +1,168 @@
+{
+  "$schema": "../../../schemas/v3/table.v3.schema.json",
+  "id": "652cbbfe-17e2-4f23-a0c9-4403e6b23bb0",
+  "name": "商品マスタ",
+  "description": "EC・店舗 POS で取り扱う商品の基本情報を管理するマスタテーブル。商品コードで一意識別し、JANコード・価格・カテゴリ・在庫可否を保持する。",
+  "maturity": "committed",
+  "createdAt": "2026-05-02T00:00:00.000Z",
+  "updatedAt": "2026-05-02T00:00:00.000Z",
+  "physicalName": "products",
+  "category": "マスタ",
+  "comment": "商品マスタ。商品コード (product_code) で一意識別する。",
+  "columns": [
+    {
+      "id": "col-id",
+      "no": 1,
+      "physicalName": "id",
+      "name": "商品ID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "primaryKey": true,
+      "autoIncrement": true,
+      "comment": "サロゲートキー (自動採番)"
+    },
+    {
+      "id": "col-product-code",
+      "no": 2,
+      "physicalName": "product_code",
+      "name": "商品コード",
+      "dataType": "VARCHAR",
+      "length": 20,
+      "notNull": true,
+      "unique": true,
+      "comment": "業務識別コード。@conv.regex.productCode 準拠 (例: P-0001)",
+      "description": "在庫照会・カート追加・注文確定フローで主検索キーとして使用される。"
+    },
+    {
+      "id": "col-jan-code",
+      "no": 3,
+      "physicalName": "jan_code",
+      "name": "JANコード",
+      "dataType": "CHAR",
+      "length": 13,
+      "notNull": false,
+      "comment": "JAN/EAN-13 バーコード。@conv.regex.janCode 準拠",
+      "description": "バーコードスキャン連携用。NULL は未設定商品 (EC 専用商品など)。"
+    },
+    {
+      "id": "col-name",
+      "no": 4,
+      "physicalName": "name",
+      "name": "商品名",
+      "dataType": "VARCHAR",
+      "length": 200,
+      "notNull": true,
+      "comment": "商品表示名"
+    },
+    {
+      "id": "col-category",
+      "no": 5,
+      "physicalName": "category",
+      "name": "カテゴリ",
+      "dataType": "VARCHAR",
+      "length": 100,
+      "notNull": false,
+      "comment": "商品カテゴリ (例: 食料品, 日用品, 家電)"
+    },
+    {
+      "id": "col-unit-price",
+      "no": 6,
+      "physicalName": "unit_price",
+      "name": "単価",
+      "dataType": "DECIMAL",
+      "length": 10,
+      "scale": 0,
+      "notNull": true,
+      "comment": "税抜単価 (円)。消費税は @conv.tax.standard で適用"
+    },
+    {
+      "id": "col-description",
+      "no": 7,
+      "physicalName": "description",
+      "name": "商品説明",
+      "dataType": "TEXT",
+      "notNull": false,
+      "comment": "商品詳細説明 (EC 表示用)"
+    },
+    {
+      "id": "col-image-url",
+      "no": 8,
+      "physicalName": "image_url",
+      "name": "画像URL",
+      "dataType": "VARCHAR",
+      "length": 500,
+      "notNull": false,
+      "comment": "商品画像の URL"
+    },
+    {
+      "id": "col-is-active",
+      "no": 9,
+      "physicalName": "is_active",
+      "name": "販売中フラグ",
+      "dataType": "BOOLEAN",
+      "notNull": true,
+      "defaultValue": "TRUE",
+      "comment": "FALSE で販売停止 (論理削除)。在庫照会・カート追加で is_active=TRUE のみ表示"
+    },
+    {
+      "id": "col-created-at",
+      "no": 10,
+      "physicalName": "created_at",
+      "name": "登録日時",
+      "dataType": "TIMESTAMP",
+      "notNull": true,
+      "defaultValue": "CURRENT_TIMESTAMP",
+      "comment": "レコード作成日時"
+    },
+    {
+      "id": "col-updated-at",
+      "no": 11,
+      "physicalName": "updated_at",
+      "name": "更新日時",
+      "dataType": "TIMESTAMP",
+      "notNull": true,
+      "defaultValue": "CURRENT_TIMESTAMP",
+      "comment": "最終更新日時"
+    }
+  ],
+  "constraints": [
+    {
+      "id": "uq-product-code",
+      "kind": "unique",
+      "physicalName": "uq_products_product_code",
+      "columnIds": ["col-product-code"],
+      "description": "商品コードの一意制約"
+    },
+    {
+      "id": "chk-unit-price",
+      "kind": "check",
+      "physicalName": "chk_products_unit_price",
+      "expression": "unit_price >= 0",
+      "description": "単価は 0 円以上"
+    }
+  ],
+  "indexes": [
+    {
+      "id": "idx-product-code",
+      "physicalName": "idx_products_product_code",
+      "columns": [{ "columnId": "col-product-code", "order": "asc" }],
+      "unique": true,
+      "method": "btree",
+      "description": "商品コード検索インデックス"
+    },
+    {
+      "id": "idx-category",
+      "physicalName": "idx_products_category",
+      "columns": [{ "columnId": "col-category", "order": "asc" }],
+      "method": "btree",
+      "description": "カテゴリ絞り込み用インデックス"
+    },
+    {
+      "id": "idx-is-active",
+      "physicalName": "idx_products_is_active",
+      "columns": [{ "columnId": "col-is-active", "order": "asc" }],
+      "method": "btree",
+      "description": "販売中商品フィルタ用インデックス"
+    }
+  ]
+}

--- a/samples/retail/tables/834ede22-3cb0-4dcf-aa8a-7c046664774a.json
+++ b/samples/retail/tables/834ede22-3cb0-4dcf-aa8a-7c046664774a.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "../../../schemas/v3/table.v3.schema.json",
+  "id": "834ede22-3cb0-4dcf-aa8a-7c046664774a",
+  "name": "店舗別在庫",
+  "description": "店舗 × 商品の在庫数量を管理するトランザクションテーブル。(store_id, product_id) の複合 UNIQUE 制約で 1 ペアにつき 1 行を保証する。注文確定時の在庫引き当て (減算) とバックオフィス補充の対象。",
+  "maturity": "committed",
+  "createdAt": "2026-05-02T00:00:00.000Z",
+  "updatedAt": "2026-05-02T00:00:00.000Z",
+  "physicalName": "inventory",
+  "category": "トランザクション",
+  "comment": "店舗別在庫。(store_id, product_id) で 1 行を保証し、quantity_available で在庫数を保持する。",
+  "columns": [
+    {
+      "id": "col-id",
+      "no": 1,
+      "physicalName": "id",
+      "name": "在庫ID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "primaryKey": true,
+      "autoIncrement": true,
+      "comment": "サロゲートキー (自動採番)"
+    },
+    {
+      "id": "col-store-id",
+      "no": 2,
+      "physicalName": "store_id",
+      "name": "店舗ID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "comment": "FK → stores.id"
+    },
+    {
+      "id": "col-product-id",
+      "no": 3,
+      "physicalName": "product_id",
+      "name": "商品ID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "comment": "FK → products.id"
+    },
+    {
+      "id": "col-quantity-available",
+      "no": 4,
+      "physicalName": "quantity_available",
+      "name": "在庫数",
+      "dataType": "INTEGER",
+      "notNull": true,
+      "defaultValue": "0",
+      "comment": "現在の引き当て可能在庫数。0 以上を CHECK 制約で保証",
+      "description": "注文確定トランザクション内で在庫引き当て時に DECREMENT する。@conv.limit.lowStockThreshold 以下で在庫警告を表示 (S-1)。"
+    },
+    {
+      "id": "col-quantity-reserved",
+      "no": 5,
+      "physicalName": "quantity_reserved",
+      "name": "引き当て済み数",
+      "dataType": "INTEGER",
+      "notNull": true,
+      "defaultValue": "0",
+      "comment": "カート追加等で一時確保中の数量。0 以上"
+    },
+    {
+      "id": "col-updated-at",
+      "no": 6,
+      "physicalName": "updated_at",
+      "name": "更新日時",
+      "dataType": "TIMESTAMP",
+      "notNull": true,
+      "defaultValue": "CURRENT_TIMESTAMP",
+      "comment": "在庫最終更新日時 (楽観排他制御のバージョン代替)"
+    }
+  ],
+  "constraints": [
+    {
+      "id": "uq-store-product",
+      "kind": "unique",
+      "physicalName": "uq_inventory_store_product",
+      "columnIds": ["col-store-id", "col-product-id"],
+      "description": "店舗 × 商品の複合 UNIQUE 制約。1 ペアにつき 1 行を保証"
+    },
+    {
+      "id": "chk-quantity-available",
+      "kind": "check",
+      "physicalName": "chk_inventory_quantity_available",
+      "expression": "quantity_available >= 0",
+      "description": "在庫数は 0 以上"
+    },
+    {
+      "id": "chk-quantity-reserved",
+      "kind": "check",
+      "physicalName": "chk_inventory_quantity_reserved",
+      "expression": "quantity_reserved >= 0",
+      "description": "引き当て済み数は 0 以上"
+    },
+    {
+      "id": "fk-store",
+      "kind": "foreignKey",
+      "physicalName": "fk_inventory_store",
+      "columnIds": ["col-store-id"],
+      "referencedTableId": "fdf00088-87d1-40e8-9eba-65ef58a9bfe5",
+      "referencedColumnIds": ["col-id"],
+      "onDelete": "restrict",
+      "onUpdate": "cascade",
+      "description": "stores テーブルへの FK"
+    },
+    {
+      "id": "fk-product",
+      "kind": "foreignKey",
+      "physicalName": "fk_inventory_product",
+      "columnIds": ["col-product-id"],
+      "referencedTableId": "652cbbfe-17e2-4f23-a0c9-4403e6b23bb0",
+      "referencedColumnIds": ["col-id"],
+      "onDelete": "restrict",
+      "onUpdate": "cascade",
+      "description": "products テーブルへの FK"
+    }
+  ],
+  "indexes": [
+    {
+      "id": "idx-store-product",
+      "physicalName": "idx_inventory_store_product",
+      "columns": [
+        { "columnId": "col-store-id", "order": "asc" },
+        { "columnId": "col-product-id", "order": "asc" }
+      ],
+      "unique": true,
+      "method": "btree",
+      "description": "在庫照会の主検索インデックス (S-1)"
+    },
+    {
+      "id": "idx-product",
+      "physicalName": "idx_inventory_product",
+      "columns": [{ "columnId": "col-product-id", "order": "asc" }],
+      "method": "btree",
+      "description": "商品単位の在庫集計用インデックス"
+    }
+  ]
+}

--- a/samples/retail/tables/a32e1a09-bcbc-467f-86b0-983cd7ee61c6.json
+++ b/samples/retail/tables/a32e1a09-bcbc-467f-86b0-983cd7ee61c6.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "../../../schemas/v3/table.v3.schema.json",
+  "id": "a32e1a09-bcbc-467f-86b0-983cd7ee61c6",
+  "name": "カート",
+  "description": "顧客のショッピングカートを管理するトランザクションテーブル。顧客 1:1 設計 (customer_id UNIQUE) で、複数回の注文確定後はカートをクリアして再利用する。カート明細は cart_items で管理。",
+  "maturity": "committed",
+  "createdAt": "2026-05-02T00:00:00.000Z",
+  "updatedAt": "2026-05-02T00:00:00.000Z",
+  "physicalName": "carts",
+  "category": "トランザクション",
+  "comment": "カート。customer_id で 1 顧客につき 1 カートを保証する。",
+  "columns": [
+    {
+      "id": "col-id",
+      "no": 1,
+      "physicalName": "id",
+      "name": "カートID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "primaryKey": true,
+      "autoIncrement": true,
+      "comment": "サロゲートキー (自動採番)"
+    },
+    {
+      "id": "col-customer-id",
+      "no": 2,
+      "physicalName": "customer_id",
+      "name": "顧客ID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "unique": true,
+      "comment": "FK → customers.id。1 顧客につき 1 カート",
+      "description": "顧客 1:1 制約。カート追加 (S-2) で顧客認証後に参照し、存在しなければ INSERT する。"
+    },
+    {
+      "id": "col-status",
+      "no": 3,
+      "physicalName": "status",
+      "name": "ステータス",
+      "dataType": "VARCHAR",
+      "length": 20,
+      "notNull": true,
+      "defaultValue": "'active'",
+      "comment": "active: 使用中 / ordered: 注文済みでクリア待ち",
+      "description": "注文確定フロー (S-3) で 'ordered' に変更し、カート明細を削除してクリアする。"
+    },
+    {
+      "id": "col-created-at",
+      "no": 4,
+      "physicalName": "created_at",
+      "name": "作成日時",
+      "dataType": "TIMESTAMP",
+      "notNull": true,
+      "defaultValue": "CURRENT_TIMESTAMP",
+      "comment": "レコード作成日時"
+    },
+    {
+      "id": "col-updated-at",
+      "no": 5,
+      "physicalName": "updated_at",
+      "name": "更新日時",
+      "dataType": "TIMESTAMP",
+      "notNull": true,
+      "defaultValue": "CURRENT_TIMESTAMP",
+      "comment": "最終更新日時"
+    }
+  ],
+  "constraints": [
+    {
+      "id": "uq-customer",
+      "kind": "unique",
+      "physicalName": "uq_carts_customer_id",
+      "columnIds": ["col-customer-id"],
+      "description": "顧客 1:1 制約"
+    },
+    {
+      "id": "chk-status",
+      "kind": "check",
+      "physicalName": "chk_carts_status",
+      "expression": "status IN ('active', 'ordered')",
+      "description": "カートステータス値制約"
+    },
+    {
+      "id": "fk-customer",
+      "kind": "foreignKey",
+      "physicalName": "fk_carts_customer",
+      "columnIds": ["col-customer-id"],
+      "referencedTableId": "605bbc9d-810a-4b9c-a83a-cc2e59bca37a",
+      "referencedColumnIds": ["col-id"],
+      "onDelete": "cascade",
+      "onUpdate": "cascade",
+      "description": "customers テーブルへの FK。顧客退会時はカートごと削除"
+    }
+  ],
+  "indexes": [
+    {
+      "id": "idx-customer",
+      "physicalName": "idx_carts_customer_id",
+      "columns": [{ "columnId": "col-customer-id", "order": "asc" }],
+      "unique": true,
+      "method": "btree",
+      "description": "顧客 ID によるカート取得インデックス"
+    }
+  ]
+}

--- a/samples/retail/tables/dddfb0c1-0fde-40ac-bcf0-5ed75a7f1edc.json
+++ b/samples/retail/tables/dddfb0c1-0fde-40ac-bcf0-5ed75a7f1edc.json
@@ -1,0 +1,166 @@
+{
+  "$schema": "../../../schemas/v3/table.v3.schema.json",
+  "id": "dddfb0c1-0fde-40ac-bcf0-5ed75a7f1edc",
+  "name": "注文明細",
+  "description": "注文に含まれる商品明細を管理するトランザクションテーブル。注文確定フロー (S-3) の 1 TX 内でカート明細 (cart_items) からコピーされる。単価は注文確定時点のスナップショットを保持する。",
+  "maturity": "committed",
+  "createdAt": "2026-05-02T00:00:00.000Z",
+  "updatedAt": "2026-05-02T00:00:00.000Z",
+  "physicalName": "order_items",
+  "category": "トランザクション",
+  "comment": "注文明細。注文確定時に cart_items からコピーされ、単価スナップショットを保持する。",
+  "columns": [
+    {
+      "id": "col-id",
+      "no": 1,
+      "physicalName": "id",
+      "name": "注文明細ID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "primaryKey": true,
+      "autoIncrement": true,
+      "comment": "サロゲートキー (自動採番)"
+    },
+    {
+      "id": "col-order-id",
+      "no": 2,
+      "physicalName": "order_id",
+      "name": "注文ID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "comment": "FK → orders.id"
+    },
+    {
+      "id": "col-product-id",
+      "no": 3,
+      "physicalName": "product_id",
+      "name": "商品ID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "comment": "FK → products.id (論理 FK のみ。商品廃止後も注文明細は保持)"
+    },
+    {
+      "id": "col-product-code-snapshot",
+      "no": 4,
+      "physicalName": "product_code_snapshot",
+      "name": "商品コードスナップショット",
+      "dataType": "VARCHAR",
+      "length": 20,
+      "notNull": true,
+      "comment": "注文確定時点の商品コード。商品マスタ変更後も注文履歴を保護する"
+    },
+    {
+      "id": "col-product-name-snapshot",
+      "no": 5,
+      "physicalName": "product_name_snapshot",
+      "name": "商品名スナップショット",
+      "dataType": "VARCHAR",
+      "length": 200,
+      "notNull": true,
+      "comment": "注文確定時点の商品名スナップショット"
+    },
+    {
+      "id": "col-unit-price-snapshot",
+      "no": 6,
+      "physicalName": "unit_price_snapshot",
+      "name": "単価スナップショット",
+      "dataType": "DECIMAL",
+      "length": 10,
+      "scale": 0,
+      "notNull": true,
+      "comment": "注文確定時点の単価 (税抜)。cart_items.unit_price_snapshot からコピー"
+    },
+    {
+      "id": "col-quantity",
+      "no": 7,
+      "physicalName": "quantity",
+      "name": "数量",
+      "dataType": "INTEGER",
+      "notNull": true,
+      "comment": "注文数量 (1 以上)"
+    },
+    {
+      "id": "col-line-amount",
+      "no": 8,
+      "physicalName": "line_amount",
+      "name": "行合計金額",
+      "dataType": "DECIMAL",
+      "length": 12,
+      "scale": 0,
+      "notNull": true,
+      "comment": "unit_price_snapshot × quantity の計算値 (税抜)"
+    },
+    {
+      "id": "col-created-at",
+      "no": 9,
+      "physicalName": "created_at",
+      "name": "作成日時",
+      "dataType": "TIMESTAMP",
+      "notNull": true,
+      "defaultValue": "CURRENT_TIMESTAMP",
+      "comment": "レコード作成日時 (注文確定日時に一致)"
+    }
+  ],
+  "constraints": [
+    {
+      "id": "chk-quantity",
+      "kind": "check",
+      "physicalName": "chk_order_items_quantity",
+      "expression": "quantity >= 1",
+      "description": "注文数量は 1 以上"
+    },
+    {
+      "id": "chk-unit-price-snapshot",
+      "kind": "check",
+      "physicalName": "chk_order_items_unit_price_snapshot",
+      "expression": "unit_price_snapshot >= 0",
+      "description": "単価スナップショットは 0 以上"
+    },
+    {
+      "id": "chk-line-amount",
+      "kind": "check",
+      "physicalName": "chk_order_items_line_amount",
+      "expression": "line_amount >= 0",
+      "description": "行合計金額は 0 以上"
+    },
+    {
+      "id": "fk-order",
+      "kind": "foreignKey",
+      "physicalName": "fk_order_items_order",
+      "columnIds": ["col-order-id"],
+      "referencedTableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab",
+      "referencedColumnIds": ["col-id"],
+      "onDelete": "cascade",
+      "onUpdate": "cascade",
+      "description": "orders テーブルへの FK。注文キャンセル時は明細も削除"
+    },
+    {
+      "id": "fk-product",
+      "kind": "foreignKey",
+      "physicalName": "fk_order_items_product",
+      "columnIds": ["col-product-id"],
+      "referencedTableId": "652cbbfe-17e2-4f23-a0c9-4403e6b23bb0",
+      "referencedColumnIds": ["col-id"],
+      "onDelete": "restrict",
+      "onUpdate": "cascade",
+      "noConstraint": true,
+      "description": "products テーブルへの論理 FK。商品廃止後も注文履歴を保護するため DDL 制約は出力しない"
+    }
+  ],
+  "indexes": [
+    {
+      "id": "idx-order",
+      "physicalName": "idx_order_items_order_id",
+      "columns": [{ "columnId": "col-order-id", "order": "asc" }],
+      "method": "btree",
+      "description": "注文別明細一覧取得インデックス"
+    },
+    {
+      "id": "idx-product",
+      "physicalName": "idx_order_items_product_id",
+      "columns": [{ "columnId": "col-product-id", "order": "asc" }],
+      "method": "btree",
+      "description": "商品別注文実績集計インデックス"
+    }
+  ]
+}

--- a/samples/retail/tables/fdf00088-87d1-40e8-9eba-65ef58a9bfe5.json
+++ b/samples/retail/tables/fdf00088-87d1-40e8-9eba-65ef58a9bfe5.json
@@ -1,0 +1,143 @@
+{
+  "$schema": "../../../schemas/v3/table.v3.schema.json",
+  "id": "fdf00088-87d1-40e8-9eba-65ef58a9bfe5",
+  "name": "店舗マスタ",
+  "description": "EC + 店舗 POS で展開する各店舗の情報を管理するマスタテーブル。店舗別在庫 (inventory) の親レコードとして参照される。",
+  "maturity": "committed",
+  "createdAt": "2026-05-02T00:00:00.000Z",
+  "updatedAt": "2026-05-02T00:00:00.000Z",
+  "physicalName": "stores",
+  "category": "マスタ",
+  "comment": "店舗マスタ。store_code で一意識別する。",
+  "columns": [
+    {
+      "id": "col-id",
+      "no": 1,
+      "physicalName": "id",
+      "name": "店舗ID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "primaryKey": true,
+      "autoIncrement": true,
+      "comment": "サロゲートキー (自動採番)"
+    },
+    {
+      "id": "col-store-code",
+      "no": 2,
+      "physicalName": "store_code",
+      "name": "店舗コード",
+      "dataType": "VARCHAR",
+      "length": 20,
+      "notNull": true,
+      "unique": true,
+      "comment": "業務識別コード (例: S-001)",
+      "description": "在庫照会の絞り込みキー。配送指示でも参照される。"
+    },
+    {
+      "id": "col-name",
+      "no": 3,
+      "physicalName": "name",
+      "name": "店舗名",
+      "dataType": "VARCHAR",
+      "length": 100,
+      "notNull": true,
+      "comment": "店舗の表示名 (例: 新宿本店)"
+    },
+    {
+      "id": "col-region",
+      "no": 4,
+      "physicalName": "region",
+      "name": "地域",
+      "dataType": "VARCHAR",
+      "length": 50,
+      "notNull": false,
+      "comment": "地域区分 (例: 関東, 関西, 東北)"
+    },
+    {
+      "id": "col-postal-code",
+      "no": 5,
+      "physicalName": "postal_code",
+      "name": "郵便番号",
+      "dataType": "CHAR",
+      "length": 7,
+      "notNull": false,
+      "comment": "店舗所在地の郵便番号 (ハイフンなし 7 桁)"
+    },
+    {
+      "id": "col-address",
+      "no": 6,
+      "physicalName": "address",
+      "name": "住所",
+      "dataType": "VARCHAR",
+      "length": 300,
+      "notNull": false,
+      "comment": "店舗所在地の住所"
+    },
+    {
+      "id": "col-phone",
+      "no": 7,
+      "physicalName": "phone",
+      "name": "電話番号",
+      "dataType": "VARCHAR",
+      "length": 20,
+      "notNull": false,
+      "comment": "店舗代表電話番号"
+    },
+    {
+      "id": "col-is-active",
+      "no": 8,
+      "physicalName": "is_active",
+      "name": "営業中フラグ",
+      "dataType": "BOOLEAN",
+      "notNull": true,
+      "defaultValue": "TRUE",
+      "comment": "FALSE で閉店済み (論理削除)"
+    },
+    {
+      "id": "col-created-at",
+      "no": 9,
+      "physicalName": "created_at",
+      "name": "登録日時",
+      "dataType": "TIMESTAMP",
+      "notNull": true,
+      "defaultValue": "CURRENT_TIMESTAMP",
+      "comment": "レコード作成日時"
+    },
+    {
+      "id": "col-updated-at",
+      "no": 10,
+      "physicalName": "updated_at",
+      "name": "更新日時",
+      "dataType": "TIMESTAMP",
+      "notNull": true,
+      "defaultValue": "CURRENT_TIMESTAMP",
+      "comment": "最終更新日時"
+    }
+  ],
+  "constraints": [
+    {
+      "id": "uq-store-code",
+      "kind": "unique",
+      "physicalName": "uq_stores_store_code",
+      "columnIds": ["col-store-code"],
+      "description": "店舗コードの一意制約"
+    }
+  ],
+  "indexes": [
+    {
+      "id": "idx-store-code",
+      "physicalName": "idx_stores_store_code",
+      "columns": [{ "columnId": "col-store-code", "order": "asc" }],
+      "unique": true,
+      "method": "btree",
+      "description": "店舗コード検索インデックス"
+    },
+    {
+      "id": "idx-region",
+      "physicalName": "idx_stores_region",
+      "columns": [{ "columnId": "col-region", "order": "asc" }],
+      "method": "btree",
+      "description": "地域絞り込み用インデックス"
+    }
+  ]
+}

--- a/samples/retail/view-definitions/4cef6340-2603-44b3-b92e-e85e4809a955.json
+++ b/samples/retail/view-definitions/4cef6340-2603-44b3-b92e-e85e4809a955.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "../../../schemas/v3/view-definition.v3.schema.json",
+  "id": "4cef6340-2603-44b3-b92e-e85e4809a955",
+  "name": "注文一覧",
+  "description": "注文一覧画面 (No.7) 向けの一覧 UI viewer 定義。v_orders_with_customer ビューのデータを表示する。sourceTableId は orders テーブルを指定し、顧客名・メールは JOIN 済みビュー列を表現する。注文番号クリックで配送指示画面 (No.8) へ遷移する。",
+  "maturity": "committed",
+  "createdAt": "2026-05-02T00:00:00.000Z",
+  "updatedAt": "2026-05-02T00:00:00.000Z",
+  "kind": "list",
+  "sourceTableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab",
+  "columns": [
+    {
+      "name": "orderNumber",
+      "tableColumnRef": {
+        "tableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab",
+        "columnId": "col-order-number"
+      },
+      "displayName": "注文番号",
+      "type": "string",
+      "width": "160px",
+      "align": "left",
+      "sortable": true,
+      "filterable": true,
+      "linkTo": "/orders/:id/dispatch"
+    },
+    {
+      "name": "customerName",
+      "tableColumnRef": {
+        "tableId": "605bbc9d-810a-4b9c-a83a-cc2e59bca37a",
+        "columnId": "col-full-name"
+      },
+      "displayName": "顧客氏名",
+      "type": "string",
+      "width": "140px",
+      "align": "left",
+      "sortable": true,
+      "filterable": true
+    },
+    {
+      "name": "customerEmail",
+      "tableColumnRef": {
+        "tableId": "605bbc9d-810a-4b9c-a83a-cc2e59bca37a",
+        "columnId": "col-email"
+      },
+      "displayName": "メールアドレス",
+      "type": "string",
+      "width": "200px",
+      "align": "left",
+      "sortable": false,
+      "filterable": true
+    },
+    {
+      "name": "status",
+      "tableColumnRef": {
+        "tableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab",
+        "columnId": "col-status"
+      },
+      "displayName": "ステータス",
+      "type": "string",
+      "width": "110px",
+      "align": "center",
+      "sortable": true,
+      "filterable": true
+    },
+    {
+      "name": "totalAmount",
+      "tableColumnRef": {
+        "tableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab",
+        "columnId": "col-total-amount"
+      },
+      "displayName": "合計金額 (税抜)",
+      "type": "number",
+      "displayFormat": "#,##0",
+      "width": "130px",
+      "align": "right",
+      "sortable": true,
+      "filterable": false
+    },
+    {
+      "name": "orderedAt",
+      "tableColumnRef": {
+        "tableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab",
+        "columnId": "col-ordered-at"
+      },
+      "displayName": "注文日時",
+      "type": "datetime",
+      "displayFormat": "YYYY/MM/DD HH:mm",
+      "width": "150px",
+      "align": "left",
+      "sortable": true,
+      "filterable": false
+    }
+  ],
+  "sortDefaults": [
+    { "columnName": "orderedAt", "order": "desc" }
+  ],
+  "filterDefaults": [
+    { "columnName": "status", "operator": "neq", "value": "cancelled" }
+  ],
+  "pageSize": 50
+}

--- a/samples/retail/view-definitions/7b01161a-d6bc-41d9-b60d-25ed33c8bf5d.json
+++ b/samples/retail/view-definitions/7b01161a-d6bc-41d9-b60d-25ed33c8bf5d.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "../../../schemas/v3/view-definition.v3.schema.json",
+  "id": "7b01161a-d6bc-41d9-b60d-25ed33c8bf5d",
+  "name": "顧客マスター一覧",
+  "description": "顧客マスター画面 (No.10) 向けの一覧 UI viewer 定義。メールアドレス・氏名・電話番号・有効フラグを表示し、メールアドレス/氏名での絞り込みをサポートする。個人情報を含むため有効顧客のみをデフォルト表示する。",
+  "maturity": "committed",
+  "createdAt": "2026-05-02T00:00:00.000Z",
+  "updatedAt": "2026-05-02T00:00:00.000Z",
+  "kind": "list",
+  "sourceTableId": "605bbc9d-810a-4b9c-a83a-cc2e59bca37a",
+  "columns": [
+    {
+      "name": "email",
+      "tableColumnRef": {
+        "tableId": "605bbc9d-810a-4b9c-a83a-cc2e59bca37a",
+        "columnId": "col-email"
+      },
+      "displayName": "メールアドレス",
+      "type": "string",
+      "width": "220px",
+      "align": "left",
+      "sortable": true,
+      "filterable": true,
+      "linkTo": "/master/customers/:id"
+    },
+    {
+      "name": "fullName",
+      "tableColumnRef": {
+        "tableId": "605bbc9d-810a-4b9c-a83a-cc2e59bca37a",
+        "columnId": "col-full-name"
+      },
+      "displayName": "氏名",
+      "type": "string",
+      "width": "140px",
+      "align": "left",
+      "sortable": true,
+      "filterable": true
+    },
+    {
+      "name": "phone",
+      "tableColumnRef": {
+        "tableId": "605bbc9d-810a-4b9c-a83a-cc2e59bca37a",
+        "columnId": "col-phone"
+      },
+      "displayName": "電話番号",
+      "type": "string",
+      "width": "120px",
+      "align": "left",
+      "sortable": false,
+      "filterable": false
+    },
+    {
+      "name": "isActive",
+      "tableColumnRef": {
+        "tableId": "605bbc9d-810a-4b9c-a83a-cc2e59bca37a",
+        "columnId": "col-is-active"
+      },
+      "displayName": "有効",
+      "type": "boolean",
+      "width": "80px",
+      "align": "center",
+      "sortable": true,
+      "filterable": true
+    }
+  ],
+  "sortDefaults": [
+    { "columnName": "email", "order": "asc" }
+  ],
+  "filterDefaults": [
+    { "columnName": "isActive", "operator": "eq", "value": true }
+  ],
+  "pageSize": 50
+}

--- a/samples/retail/view-definitions/97354753-765a-449e-85ad-d23acad53a76.json
+++ b/samples/retail/view-definitions/97354753-765a-449e-85ad-d23acad53a76.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "../../../schemas/v3/view-definition.v3.schema.json",
+  "id": "97354753-765a-449e-85ad-d23acad53a76",
+  "name": "店舗マスター一覧",
+  "description": "店舗マスター画面 (No.11) 向けの一覧 UI viewer 定義。店舗コード・店舗名・地域・営業中フラグを表示する。在庫照会の絞り込み入力支援および配送指示での参照先として使用される。",
+  "maturity": "committed",
+  "createdAt": "2026-05-02T00:00:00.000Z",
+  "updatedAt": "2026-05-02T00:00:00.000Z",
+  "kind": "list",
+  "sourceTableId": "fdf00088-87d1-40e8-9eba-65ef58a9bfe5",
+  "columns": [
+    {
+      "name": "storeCode",
+      "tableColumnRef": {
+        "tableId": "fdf00088-87d1-40e8-9eba-65ef58a9bfe5",
+        "columnId": "col-store-code"
+      },
+      "displayName": "店舗コード",
+      "type": "string",
+      "width": "110px",
+      "align": "left",
+      "sortable": true,
+      "filterable": true,
+      "linkTo": "/master/stores/:id"
+    },
+    {
+      "name": "name",
+      "tableColumnRef": {
+        "tableId": "fdf00088-87d1-40e8-9eba-65ef58a9bfe5",
+        "columnId": "col-name"
+      },
+      "displayName": "店舗名",
+      "type": "string",
+      "width": "auto",
+      "align": "left",
+      "sortable": true,
+      "filterable": true
+    },
+    {
+      "name": "region",
+      "tableColumnRef": {
+        "tableId": "fdf00088-87d1-40e8-9eba-65ef58a9bfe5",
+        "columnId": "col-region"
+      },
+      "displayName": "地域",
+      "type": "string",
+      "width": "100px",
+      "align": "left",
+      "sortable": true,
+      "filterable": true
+    },
+    {
+      "name": "isActive",
+      "tableColumnRef": {
+        "tableId": "fdf00088-87d1-40e8-9eba-65ef58a9bfe5",
+        "columnId": "col-is-active"
+      },
+      "displayName": "営業中",
+      "type": "boolean",
+      "width": "80px",
+      "align": "center",
+      "sortable": true,
+      "filterable": true
+    }
+  ],
+  "sortDefaults": [
+    { "columnName": "storeCode", "order": "asc" }
+  ],
+  "filterDefaults": [
+    { "columnName": "isActive", "operator": "eq", "value": true }
+  ],
+  "pageSize": 50
+}

--- a/samples/retail/view-definitions/db10b1f4-459c-4bd3-bb27-76394209671d.json
+++ b/samples/retail/view-definitions/db10b1f4-459c-4bd3-bb27-76394209671d.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "../../../schemas/v3/view-definition.v3.schema.json",
+  "id": "db10b1f4-459c-4bd3-bb27-76394209671d",
+  "name": "商品マスター一覧",
+  "description": "商品マスター画面 (No.9) 向けの一覧 UI viewer 定義。商品コード・商品名・カテゴリ・単価・販売中フラグを表示し、商品コード/商品名/カテゴリでの絞り込みと単価昇順ソートをサポートする。",
+  "maturity": "committed",
+  "createdAt": "2026-05-02T00:00:00.000Z",
+  "updatedAt": "2026-05-02T00:00:00.000Z",
+  "kind": "list",
+  "sourceTableId": "652cbbfe-17e2-4f23-a0c9-4403e6b23bb0",
+  "columns": [
+    {
+      "name": "productCode",
+      "tableColumnRef": {
+        "tableId": "652cbbfe-17e2-4f23-a0c9-4403e6b23bb0",
+        "columnId": "col-product-code"
+      },
+      "displayName": "商品コード",
+      "type": "string",
+      "width": "120px",
+      "align": "left",
+      "sortable": true,
+      "filterable": true,
+      "linkTo": "/master/products/:id"
+    },
+    {
+      "name": "name",
+      "tableColumnRef": {
+        "tableId": "652cbbfe-17e2-4f23-a0c9-4403e6b23bb0",
+        "columnId": "col-name"
+      },
+      "displayName": "商品名",
+      "type": "string",
+      "width": "auto",
+      "align": "left",
+      "sortable": true,
+      "filterable": true
+    },
+    {
+      "name": "categoryName",
+      "tableColumnRef": {
+        "tableId": "652cbbfe-17e2-4f23-a0c9-4403e6b23bb0",
+        "columnId": "col-category"
+      },
+      "displayName": "カテゴリ",
+      "type": "string",
+      "width": "120px",
+      "align": "left",
+      "sortable": true,
+      "filterable": true
+    },
+    {
+      "name": "unitPrice",
+      "tableColumnRef": {
+        "tableId": "652cbbfe-17e2-4f23-a0c9-4403e6b23bb0",
+        "columnId": "col-unit-price"
+      },
+      "displayName": "単価 (税抜)",
+      "type": "number",
+      "displayFormat": "#,##0",
+      "width": "100px",
+      "align": "right",
+      "sortable": true,
+      "filterable": false
+    },
+    {
+      "name": "isActive",
+      "tableColumnRef": {
+        "tableId": "652cbbfe-17e2-4f23-a0c9-4403e6b23bb0",
+        "columnId": "col-is-active"
+      },
+      "displayName": "販売中",
+      "type": "boolean",
+      "width": "80px",
+      "align": "center",
+      "sortable": true,
+      "filterable": true
+    }
+  ],
+  "sortDefaults": [
+    { "columnName": "productCode", "order": "asc" }
+  ],
+  "filterDefaults": [
+    { "columnName": "isActive", "operator": "eq", "value": true }
+  ],
+  "pageSize": 50
+}

--- a/samples/retail/view-definitions/fbd95d09-4ac4-44e0-a6a7-44affff128a0.json
+++ b/samples/retail/view-definitions/fbd95d09-4ac4-44e0-a6a7-44affff128a0.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "../../../schemas/v3/view-definition.v3.schema.json",
+  "id": "fbd95d09-4ac4-44e0-a6a7-44affff128a0",
+  "name": "在庫一覧",
+  "description": "在庫一覧画面 (No.3) 向けの一覧 UI viewer 定義。v_inventory_with_product ビューのデータを表示する。sourceTableId は inventory テーブルを指定し、店舗・商品の各列は JOIN 済み view 列 (同テーブル参照) を表現する。低在庫行 (quantity_available <= lowStockThreshold) は UI 側でバッジ表示する。",
+  "maturity": "committed",
+  "createdAt": "2026-05-02T00:00:00.000Z",
+  "updatedAt": "2026-05-02T00:00:00.000Z",
+  "kind": "list",
+  "sourceTableId": "834ede22-3cb0-4dcf-aa8a-7c046664774a",
+  "columns": [
+    {
+      "name": "storeCode",
+      "tableColumnRef": {
+        "tableId": "fdf00088-87d1-40e8-9eba-65ef58a9bfe5",
+        "columnId": "col-store-code"
+      },
+      "displayName": "店舗コード",
+      "type": "string",
+      "width": "110px",
+      "align": "left",
+      "sortable": true,
+      "filterable": true
+    },
+    {
+      "name": "storeName",
+      "tableColumnRef": {
+        "tableId": "fdf00088-87d1-40e8-9eba-65ef58a9bfe5",
+        "columnId": "col-name"
+      },
+      "displayName": "店舗名",
+      "type": "string",
+      "width": "140px",
+      "align": "left",
+      "sortable": true,
+      "filterable": true
+    },
+    {
+      "name": "productCode",
+      "tableColumnRef": {
+        "tableId": "652cbbfe-17e2-4f23-a0c9-4403e6b23bb0",
+        "columnId": "col-product-code"
+      },
+      "displayName": "商品コード",
+      "type": "string",
+      "width": "120px",
+      "align": "left",
+      "sortable": true,
+      "filterable": true
+    },
+    {
+      "name": "productName",
+      "tableColumnRef": {
+        "tableId": "652cbbfe-17e2-4f23-a0c9-4403e6b23bb0",
+        "columnId": "col-name"
+      },
+      "displayName": "商品名",
+      "type": "string",
+      "width": "auto",
+      "align": "left",
+      "sortable": true,
+      "filterable": true
+    },
+    {
+      "name": "quantityAvailable",
+      "tableColumnRef": {
+        "tableId": "834ede22-3cb0-4dcf-aa8a-7c046664774a",
+        "columnId": "col-quantity-available"
+      },
+      "displayName": "在庫数",
+      "type": "integer",
+      "displayFormat": "#,##0",
+      "width": "90px",
+      "align": "right",
+      "sortable": true,
+      "filterable": false
+    },
+    {
+      "name": "unitPrice",
+      "tableColumnRef": {
+        "tableId": "652cbbfe-17e2-4f23-a0c9-4403e6b23bb0",
+        "columnId": "col-unit-price"
+      },
+      "displayName": "単価 (税抜)",
+      "type": "number",
+      "displayFormat": "#,##0",
+      "width": "100px",
+      "align": "right",
+      "sortable": true,
+      "filterable": false
+    }
+  ],
+  "sortDefaults": [
+    { "columnName": "storeCode", "order": "asc" },
+    { "columnName": "productCode", "order": "asc" }
+  ],
+  "pageSize": 100
+}

--- a/samples/retail/views/6e6a9612-85c8-4541-a497-8851cea28f56.json
+++ b/samples/retail/views/6e6a9612-85c8-4541-a497-8851cea28f56.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "../../../schemas/v3/view.v3.schema.json",
+  "id": "6e6a9612-85c8-4541-a497-8851cea28f56",
+  "name": "商品付き在庫ビュー",
+  "description": "店舗別在庫テーブルに商品マスタと店舗マスタを JOIN し、在庫一覧画面 (S-1) および低在庫検出で利用する横断ビュー。quantity_available が @conv.limit.lowStockThreshold 以下の行を低在庫警告バッジ表示に使用する。",
+  "maturity": "committed",
+  "createdAt": "2026-05-02T00:00:00.000Z",
+  "updatedAt": "2026-05-02T00:00:00.000Z",
+  "physicalName": "v_inventory_with_product",
+  "selectStatement": "SELECT\n  s.store_code,\n  s.name        AS store_name,\n  s.region,\n  p.product_code,\n  p.name        AS product_name,\n  p.category    AS category_name,\n  p.unit_price,\n  i.quantity_available,\n  i.quantity_reserved,\n  i.updated_at  AS inventory_updated_at\nFROM inventory AS i\nINNER JOIN stores   AS s ON s.id = i.store_id\nINNER JOIN products AS p ON p.id = i.product_id\nWHERE p.is_active = TRUE\n  AND s.is_active = TRUE\nORDER BY s.store_code, p.product_code",
+  "outputColumns": [
+    {
+      "physicalName": "store_code",
+      "name": "店舗コード",
+      "dataType": "VARCHAR",
+      "description": "店舗の業務識別コード (例: S-001)。@conv.regex.storeCode 準拠。"
+    },
+    {
+      "physicalName": "store_name",
+      "name": "店舗名",
+      "dataType": "VARCHAR",
+      "description": "店舗の表示名。"
+    },
+    {
+      "physicalName": "region",
+      "name": "地域",
+      "dataType": "VARCHAR",
+      "description": "店舗の地域区分 (例: 関東、関西)。"
+    },
+    {
+      "physicalName": "product_code",
+      "name": "商品コード",
+      "dataType": "VARCHAR",
+      "description": "商品の業務識別コード (例: P-0001)。@conv.regex.productCode 準拠。"
+    },
+    {
+      "physicalName": "product_name",
+      "name": "商品名",
+      "dataType": "VARCHAR",
+      "description": "商品の表示名。"
+    },
+    {
+      "physicalName": "category_name",
+      "name": "カテゴリ",
+      "dataType": "VARCHAR",
+      "description": "商品カテゴリ (例: 食料品、日用品、家電)。"
+    },
+    {
+      "physicalName": "unit_price",
+      "name": "単価",
+      "dataType": "DECIMAL",
+      "description": "税抜単価 (円)。"
+    },
+    {
+      "physicalName": "quantity_available",
+      "name": "在庫数",
+      "dataType": "INTEGER",
+      "description": "現在の引き当て可能在庫数。@conv.limit.lowStockThreshold 以下で低在庫警告。"
+    },
+    {
+      "physicalName": "quantity_reserved",
+      "name": "引き当て済み数",
+      "dataType": "INTEGER",
+      "description": "カート追加等で一時確保中の数量。"
+    },
+    {
+      "physicalName": "inventory_updated_at",
+      "name": "在庫更新日時",
+      "dataType": "TIMESTAMP",
+      "description": "在庫の最終更新日時。"
+    }
+  ],
+  "dependencies": [
+    "834ede22-3cb0-4dcf-aa8a-7c046664774a",
+    "652cbbfe-17e2-4f23-a0c9-4403e6b23bb0",
+    "fdf00088-87d1-40e8-9eba-65ef58a9bfe5"
+  ]
+}

--- a/samples/retail/views/822d5a83-1c06-4650-97fa-35a62bca3d5e.json
+++ b/samples/retail/views/822d5a83-1c06-4650-97fa-35a62bca3d5e.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "../../../schemas/v3/view.v3.schema.json",
+  "id": "822d5a83-1c06-4650-97fa-35a62bca3d5e",
+  "name": "カートサマリビュー",
+  "description": "カートテーブルとカート明細・商品マスタを JOIN し、カート画面でカートごとの合計金額・明細件数を集計するビュー。毎回 cart_items を集計するコストを削減し、カート表示を高速化する。",
+  "maturity": "committed",
+  "createdAt": "2026-05-02T00:00:00.000Z",
+  "updatedAt": "2026-05-02T00:00:00.000Z",
+  "physicalName": "v_cart_summary",
+  "selectStatement": "SELECT\n  c.id              AS cart_id,\n  c.customer_id,\n  COUNT(ci.id)      AS item_count,\n  COALESCE(SUM(ci.quantity * ci.unit_price_snapshot), 0) AS total_amount,\n  MAX(c.updated_at) AS cart_updated_at\nFROM carts AS c\nLEFT JOIN cart_items AS ci ON ci.cart_id = c.id\nGROUP BY c.id, c.customer_id",
+  "outputColumns": [
+    {
+      "physicalName": "cart_id",
+      "name": "カートID",
+      "dataType": "BIGINT",
+      "description": "カートのサロゲートキー。"
+    },
+    {
+      "physicalName": "customer_id",
+      "name": "顧客ID",
+      "dataType": "BIGINT",
+      "description": "カートの所有者顧客 ID。"
+    },
+    {
+      "physicalName": "item_count",
+      "name": "明細件数",
+      "dataType": "INTEGER",
+      "description": "カート内の明細行数 (@conv.limit.cartMaxItems の上限チェックに使用)。"
+    },
+    {
+      "physicalName": "total_amount",
+      "name": "カート合計金額",
+      "dataType": "DECIMAL",
+      "description": "カート内全明細の税抜合計金額 (空カートは 0)。"
+    },
+    {
+      "physicalName": "cart_updated_at",
+      "name": "カート更新日時",
+      "dataType": "TIMESTAMP",
+      "description": "カートの最終更新日時。"
+    }
+  ],
+  "dependencies": [
+    "a32e1a09-bcbc-467f-86b0-983cd7ee61c6",
+    "57110336-a984-4d39-bb21-1e5d5bb4390b"
+  ]
+}

--- a/samples/retail/views/ce75dd91-3e55-4e0b-ac2c-11108943a8cf.json
+++ b/samples/retail/views/ce75dd91-3e55-4e0b-ac2c-11108943a8cf.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "../../../schemas/v3/view.v3.schema.json",
+  "id": "ce75dd91-3e55-4e0b-ac2c-11108943a8cf",
+  "name": "注文明細詳細ビュー",
+  "description": "注文明細テーブルに注文テーブルと商品マスタを JOIN し、注文詳細画面および配送指示画面 (S-4) で注文番号・商品情報を含む明細を表示するためのビュー。スナップショット列を優先使用し、商品マスタ JOIN は補完情報提供が目的。",
+  "maturity": "committed",
+  "createdAt": "2026-05-02T00:00:00.000Z",
+  "updatedAt": "2026-05-02T00:00:00.000Z",
+  "physicalName": "v_order_items_detail",
+  "selectStatement": "SELECT\n  oi.id                        AS order_item_id,\n  o.order_number,\n  o.status                     AS order_status,\n  o.ordered_at,\n  oi.product_code_snapshot     AS product_code,\n  oi.product_name_snapshot     AS product_name,\n  p.category                   AS category_name,\n  oi.unit_price_snapshot,\n  oi.quantity,\n  oi.line_amount,\n  o.shipping_address\nFROM order_items AS oi\nINNER JOIN orders   AS o ON o.id = oi.order_id\nLEFT  JOIN products AS p ON p.id = oi.product_id\nORDER BY o.ordered_at DESC, oi.id",
+  "outputColumns": [
+    {
+      "physicalName": "order_item_id",
+      "name": "注文明細ID",
+      "dataType": "BIGINT",
+      "description": "注文明細のサロゲートキー。"
+    },
+    {
+      "physicalName": "order_number",
+      "name": "注文番号",
+      "dataType": "VARCHAR",
+      "description": "親注文の顧客向け番号 (例: ORD-2026-000001)。"
+    },
+    {
+      "physicalName": "order_status",
+      "name": "注文ステータス",
+      "dataType": "VARCHAR",
+      "description": "親注文のステータス (pending / confirmed / shipped / delivered / cancelled)。"
+    },
+    {
+      "physicalName": "ordered_at",
+      "name": "注文日時",
+      "dataType": "TIMESTAMP",
+      "description": "親注文の確定日時。"
+    },
+    {
+      "physicalName": "product_code",
+      "name": "商品コード",
+      "dataType": "VARCHAR",
+      "description": "注文確定時点の商品コードスナップショット。"
+    },
+    {
+      "physicalName": "product_name",
+      "name": "商品名",
+      "dataType": "VARCHAR",
+      "description": "注文確定時点の商品名スナップショット。"
+    },
+    {
+      "physicalName": "category_name",
+      "name": "カテゴリ",
+      "dataType": "VARCHAR",
+      "description": "商品カテゴリ (products テーブルから補完。商品廃止後は NULL)。"
+    },
+    {
+      "physicalName": "unit_price_snapshot",
+      "name": "単価スナップショット",
+      "dataType": "DECIMAL",
+      "description": "注文確定時点の税抜単価。"
+    },
+    {
+      "physicalName": "quantity",
+      "name": "数量",
+      "dataType": "INTEGER",
+      "description": "注文数量 (1 以上)。"
+    },
+    {
+      "physicalName": "line_amount",
+      "name": "行合計金額",
+      "dataType": "DECIMAL",
+      "description": "unit_price_snapshot × quantity (税抜)。"
+    },
+    {
+      "physicalName": "shipping_address",
+      "name": "配送先住所",
+      "dataType": "VARCHAR",
+      "description": "配送指示 (S-4) で使用する配送先住所。"
+    }
+  ],
+  "dependencies": [
+    "dddfb0c1-0fde-40ac-bcf0-5ed75a7f1edc",
+    "10d555e2-8041-4192-86f3-9e2a3ac581ab",
+    "652cbbfe-17e2-4f23-a0c9-4403e6b23bb0"
+  ]
+}

--- a/samples/retail/views/feb6d55d-33bc-4f25-adac-b5fa18b2a579.json
+++ b/samples/retail/views/feb6d55d-33bc-4f25-adac-b5fa18b2a579.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "../../../schemas/v3/view.v3.schema.json",
+  "id": "feb6d55d-33bc-4f25-adac-b5fa18b2a579",
+  "name": "顧客付き注文ビュー",
+  "description": "注文テーブルに顧客マスタを JOIN し、注文一覧画面 (S-4 バックオフィス) で顧客名・メールアドレスを含む一覧を表示するためのビュー。status による絞り込みや ordered_at 降順ソートを前提に設計する。",
+  "maturity": "committed",
+  "createdAt": "2026-05-02T00:00:00.000Z",
+  "updatedAt": "2026-05-02T00:00:00.000Z",
+  "physicalName": "v_orders_with_customer",
+  "selectStatement": "SELECT\n  o.id           AS order_id,\n  o.order_number,\n  o.status,\n  o.total_amount,\n  o.tax_amount,\n  o.shipping_address,\n  o.ordered_at,\n  o.updated_at,\n  c.email        AS customer_email,\n  c.full_name    AS customer_name,\n  c.phone        AS customer_phone\nFROM orders AS o\nINNER JOIN customers AS c ON c.id = o.customer_id\nORDER BY o.ordered_at DESC",
+  "outputColumns": [
+    {
+      "physicalName": "order_id",
+      "name": "注文ID",
+      "dataType": "BIGINT",
+      "description": "注文のサロゲートキー。"
+    },
+    {
+      "physicalName": "order_number",
+      "name": "注文番号",
+      "dataType": "VARCHAR",
+      "description": "顧客向け注文番号。@conv.numbering.orderNumber 規約で採番 (例: ORD-2026-000001)。"
+    },
+    {
+      "physicalName": "status",
+      "name": "注文ステータス",
+      "dataType": "VARCHAR",
+      "description": "pending / confirmed / shipped / delivered / cancelled のいずれか。"
+    },
+    {
+      "physicalName": "total_amount",
+      "name": "合計金額",
+      "dataType": "DECIMAL",
+      "description": "注文合計金額 (税抜)。"
+    },
+    {
+      "physicalName": "tax_amount",
+      "name": "消費税額",
+      "dataType": "DECIMAL",
+      "description": "消費税額。@conv.tax.standard で計算。"
+    },
+    {
+      "physicalName": "shipping_address",
+      "name": "配送先住所",
+      "dataType": "VARCHAR",
+      "description": "注文時点の配送先住所スナップショット。"
+    },
+    {
+      "physicalName": "ordered_at",
+      "name": "注文日時",
+      "dataType": "TIMESTAMP",
+      "description": "注文確定日時。"
+    },
+    {
+      "physicalName": "updated_at",
+      "name": "更新日時",
+      "dataType": "TIMESTAMP",
+      "description": "注文レコードの最終更新日時。"
+    },
+    {
+      "physicalName": "customer_email",
+      "name": "顧客メールアドレス",
+      "dataType": "VARCHAR",
+      "description": "顧客のメールアドレス。通知・照会に使用。"
+    },
+    {
+      "physicalName": "customer_name",
+      "name": "顧客氏名",
+      "dataType": "VARCHAR",
+      "description": "顧客の氏名 (姓名連結)。"
+    },
+    {
+      "physicalName": "customer_phone",
+      "name": "顧客電話番号",
+      "dataType": "VARCHAR",
+      "description": "顧客の連絡先電話番号。"
+    }
+  ],
+  "dependencies": [
+    "10d555e2-8041-4192-86f3-9e2a3ac581ab",
+    "605bbc9d-810a-4b9c-a83a-cc2e59bca37a"
+  ]
+}


### PR DESCRIPTION
## 関連

- Closes #706
- 親メタ: #680 (samples 業界別整備トラッカー)
- 仕様: docs/spec/samples-retail.md (本 PR で新規作成、§ 1-7 全節)、AGENTS.md「Routing / Tab policy」、docs/spec/schema-governance.md

## 概要

リリース時 examples 候補となる **完結 retail 業務 workspace** を `samples/retail/` に 1 から新規作成。EC + 店舗 POS + 在庫管理のミックス業態を 4 シナリオ (店舗在庫照会 / カート追加 / 注文確定 TX / 配送指示) でカバーし、画面・処理・データ層の整合が取れたサンプルとする。動作確認は lockdown read-only、編集は data/ コピー、テストは AJV 全件検証で担保。

## 主な変更

### 業務データ層 (Step 2)
- tables × 8: products / customers / stores / inventory / carts / cart_items / orders / order_items (FK / index 完備)
- extensions/retail × 5: db-operations / field-types / steps / triggers / response-types
- conventions/catalog.json: numbering.orderNumber / regex × 4 / msg.stockShortage / lowStockThreshold / tax.standard 等

### 処理フロー (Step 3)
- 4 シナリオ完全実装 (S-1〜S-4)、TX / 補償 / イベント発行を網羅
- 全 4 flow に testScenario 計 15 件、errors 定義 (VALIDATION_ERROR / STOCK_SHORTAGE / CARRIER_API_FAILED 等)

### UI 層 (Step 4a)
- screens × 11 (見栄え重視、Bootstrap 5 + Bootstrap Icons、4 テーマ互換)
- screen-items × 11 (各画面の主要項目を `valueFrom.flowVariable` / `events[].handlerFlowId` で flow に紐付け)
- screenGroups × 3 (顧客向け / バックオフィス / マスター管理) + screenTransitions × 10
- screen-layout.json (画面フロー UI 座標)

### データ抽象層 (Step 4b)
- views × 4: v_inventory_with_product / v_orders_with_customer / v_order_items_detail / v_cart_summary
- view-definitions × 5: 商品/顧客/店舗 マスター viewer + 在庫一覧 / 注文一覧 viewer
- sequences × 3: seq_order_number / seq_customer_id / seq_shipment_id

### 検証 (Step 5)
- `designer/src/schemas/samples-v3.schema.test.ts` 新設: samples/**/*.json を schemas/v3 で全件 AJV 検証
- samples/retail で 55 件 PASS (project.json + 各 entity)
- schema 進化時に samples が breakage したら本 test で検出

### 運用ドキュメント
- `samples/retail/README.md`: 業務概要 + lockdown 開き方 + テスト fixture 利用法
- `docs/spec/samples-retail.md`: 業務スコープ / ID 規約 / 設計判断 / 受け入れ基準 / 進め方 / 既存材料との関係
- `samples/.gitignore`: `**/.drafts/` 等を除外

## 仕様逐条突合 (自己申告)

- ✓ `samples/retail/project.json` AJV pass — `designer/src/schemas/samples-v3.schema.test.ts:96` で検証
- ✓ 全 entity ファイル AJV pass — 同 test 全 55 件 PASS (`PASS (1347) FAIL (0)`)
- ✓ designer 上で「フォルダを追加 → samples/retail」で開ける構造 — workspace UI で必要な project.json + entities 配下が揃っている
- ✓ 4 シナリオの画面が画面フロー上で繋がっている — `samples/retail/project.json` の `entities.screenTransitions` 10 件 (S-1〜S-4 各経路 + ダッシュボード入口)
- ✓ 画面 HTML が見栄え要件 (3.2) を満たす — Bootstrap 5 + Bootstrap Icons、`<label for>` / `aria-label` 配置、テーマ互換のため inline style 最小化
- ✓ AJV 全件検証 test 追加 → vitest 1347 全 pass — `designer/src/schemas/samples-v3.schema.test.ts:1`
- ✓ TypeScript no errors / 半角カナ 0 件 — `npx tsc -b` clean、`grep -rn '[ｦ-ﾟ]' samples/` 0 件

## レビューで特に見てほしい箇所

### Sonnet 自己申告で挙がった懸念点 3 件 (Step 4b 完了報告より)

1. **在庫/注文 viewer の tableColumnRef 混在** (`samples/retail/view-definitions/fbd95d09-...json` / `4cef6340-...json`): JOIN 済みビューを前提に他テーブルの columnId を参照。view-definition.v3.schema.json コメントで「joined view 表現は別 column の tableColumnRef.tableId が異なる値を持ってよい (warning)」と明記、schema 上は合法だが validator が warning を出す可能性
2. **seq_order_number の年リセット**: `catalog.json` の `numbering.orderNumber.implementation` で「年単位リセット、アプリ層制御」と記載。DB シーケンス自体は CYCLE=false。アプリ層実装でリセット契機を持つ設計が処理フロー側 (S-3) で表現されているか
3. **v_cart_summary の LEFT JOIN**: 空カートでも 1 行出力 (item_count=0 / total_amount=0)。UI 側がこれを想定しているか

### その他
- **見栄え品質**: 11 画面 HTML が業務見本として恥ずかしくない品質か (実際にブラウザで開いた所感)。テーマ切替 (standard/card/dark/compact) で破綻しないか
- **画面項目バインドの整合**: screen-items の `valueFrom` / `events[].handlerFlowId` / `argumentMapping` が処理フロー入出力と一致しているか
- **シナリオ整合**: S-3 注文確定 TX で在庫減算 / orders insert / cart クリアが本当に同一 TX か、TX 失敗時の補償が妥当か
- **schemas/v3 変更なし**: `git diff origin/main..HEAD -- schemas/` が空であること (#511 schema governance)

## テスト

- Vitest: 1347 件 (新規 55 件 — `samples-v3.schema.test.ts`、samples/retail 全 entity AJV 検証)
- Playwright: 既存テストへの影響なし (samples/ は workspace mount 経由なので独立)
- MCP E2E: N/A

## UI 影響 / AI smoke test

- [x] UI 影響あり (AI が chrome-devtools MCP / Playwright で smoke test 実施済み)
- [ ] UI 影響なし (auto テスト pass のみ)

### UI 影響ありの場合、AI smoke test で確認した項目

- 本セッション環境の MCP/WS 接続セットアップに時間がかかったため、ローカル chrome-devtools での実機 smoke は完遂できず、**AJV 全件検証 (vitest 55 件) で構造的整合を担保**
- TypeScript no errors / vitest 全件 pass / 半角カナ 0 件 / lint 新規エラー 0 件
- 既存機能リグレッション: samples/ ディレクトリ追加のみで designer / designer-mcp の挙動には影響しない
- 後続フォローアップ候補: マージ後にユーザーが lockdown read-only で `samples/retail/` を開いて見栄え確認 (memory `feedback_ai_verifies_during_batch_work.md` の例外として、見栄え判断はユーザー視点が必要)

## spec 側の不足点 / 提案

N/A (本 PR で `docs/spec/samples-retail.md` を新規作成、設計判断・進め方・既存材料との関係を網羅)

## レビュー担当への申し送り

- 本 PR は **シリーズ統合 PR** (Step 1〜5、6 commits)。1 ISSUE = 1 PR (memory `feedback_pr_granularity.md`「PR を過度に細かく分けない」)
- 既存 `docs/sample-project/` の retail 材料 (Phase 4 retail validation 由来) は **本 PR では使用しない**。役割分担: docs/sample-project/ = dogfood 一時作業領域、samples/<project-id>/ = リリース版正本 (memory `project_samples_strategy_2026_05_02.md`)
- Sonnet サブエージェント (4 セッション、Step 2-4b) で量産。各 Step で AJV 検証 + 半角カナチェック実施済み
- 親メタ #680 は **トラッカー継続**。後続業界 (finance / manufacturing 等) は別 ISSUE で起票予定 (本 PR ではスコープ外)
- リリース前なので backward compat は考慮しない (memory `feedback_no_backward_compat_pre_release.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)