### PR TITLE
improve(validate): printSummary に warning 件数集計と三分岐メッセージ追加 (#722)

### DIFF
--- a/designer/scripts/validate-samples.ts
+++ b/designer/scripts/validate-samples.ts
@@ -516,7 +516,7 @@ export function printSummary(summary: ValidationSummary): void {
   if (totalErrors === 0 && totalWarnings === 0) {
     console.log("All validations passed.");
   } else if (totalErrors === 0) {
-    console.log(`All errors resolved (${totalWarnings} warning${totalWarnings > 1 ? "s" : ""} remain):`);
+    console.log(`All errors resolved (${totalWarnings} warning${totalWarnings > 1 ? "s remain" : " remains"}):`);
     for (const validator of validatorDisplayOrder) {
       const w = totalWarnByValidator.get(validator) ?? 0;
       if (w > 0) console.log(`  - [${validator}] ${w} warning${w > 1 ? "s" : ""}`);

--- a/designer/scripts/validate-samples.ts
+++ b/designer/scripts/validate-samples.ts
@@ -67,7 +67,7 @@ interface ProjectValidationResult {
   issues: ValidationIssue[];
 }
 
-interface ValidationSummary {
+export interface ValidationSummary {
   totalFlows: number;
   passedFlows: number;
   failedFlows: number;
@@ -447,7 +447,7 @@ const validatorDisplayOrder = [
   "runtimeContractValidator",
 ];
 
-function printSummary(summary: ValidationSummary): void {
+export function printSummary(summary: ValidationSummary): void {
   console.log("samples dogfood validation");
   console.log();
   console.log(
@@ -491,28 +491,47 @@ function printSummary(summary: ValidationSummary): void {
   console.log();
   console.log("---------------------------------------------------------");
 
-  const totalByValidator = new Map<string, number>();
-  let totalIssues = 0;
+  const totalByValidator = new Map<string, number>();    // error
+  const totalWarnByValidator = new Map<string, number>(); // warning
+  let totalErrors = 0;
+  let totalWarnings = 0;
   for (const result of summary.results) {
-    for (const i of result.issues.filter((item) => item.severity === "error")) {
-      totalByValidator.set(i.validator, (totalByValidator.get(i.validator) ?? 0) + 1);
-      totalIssues++;
+    for (const i of result.issues) {
+      const map = i.severity === "warning" ? totalWarnByValidator : totalByValidator;
+      map.set(i.validator, (map.get(i.validator) ?? 0) + 1);
+      if (i.severity === "warning") totalWarnings++;
+      else totalErrors++;
     }
   }
   for (const pr of summary.projectResults) {
-    for (const i of pr.issues.filter((item) => item.severity === "error")) {
-      totalByValidator.set(i.validator, (totalByValidator.get(i.validator) ?? 0) + 1);
-      totalIssues++;
+    for (const i of pr.issues) {
+      const map = i.severity === "warning" ? totalWarnByValidator : totalByValidator;
+      map.set(i.validator, (map.get(i.validator) ?? 0) + 1);
+      if (i.severity === "warning") totalWarnings++;
+      else totalErrors++;
     }
   }
 
   console.log(`Summary: ${summary.passedFlows} / ${summary.totalFlows} flows passed.`);
-  if (totalIssues === 0) {
+  if (totalErrors === 0 && totalWarnings === 0) {
     console.log("All validations passed.");
-  } else {
-    console.log(`${summary.failedFlows} flow${summary.failedFlows > 1 ? "s" : ""} failed with ${totalIssues} issues:`);
+  } else if (totalErrors === 0) {
+    console.log(`All errors resolved (${totalWarnings} warning${totalWarnings > 1 ? "s" : ""} remain):`);
     for (const validator of validatorDisplayOrder) {
-      console.log(`  - [${validator}] ${totalByValidator.get(validator) ?? 0} issue(s)`);
+      const w = totalWarnByValidator.get(validator) ?? 0;
+      if (w > 0) console.log(`  - [${validator}] ${w} warning${w > 1 ? "s" : ""}`);
+    }
+  } else {
+    console.log(`${summary.failedFlows} flow${summary.failedFlows > 1 ? "s" : ""} failed with ${totalErrors} error${totalErrors > 1 ? "s" : ""}${totalWarnings > 0 ? ` and ${totalWarnings} warning${totalWarnings > 1 ? "s" : ""}` : ""}:`);
+    for (const validator of validatorDisplayOrder) {
+      const e = totalByValidator.get(validator) ?? 0;
+      const w = totalWarnByValidator.get(validator) ?? 0;
+      if (e > 0 || w > 0) {
+        const parts: string[] = [];
+        if (e > 0) parts.push(`${e} error${e > 1 ? "s" : ""}`);
+        if (w > 0) parts.push(`${w} warning${w > 1 ? "s" : ""}`);
+        console.log(`  - [${validator}] ${parts.join(", ")}`);
+      }
     }
   }
   console.log("---------------------------------------------------------");

--- a/designer/src/schemas/validateSamplesPrintSummary.test.ts
+++ b/designer/src/schemas/validateSamplesPrintSummary.test.ts
@@ -1,0 +1,290 @@
+/**
+ * validate-samples.ts printSummary のユニットテスト (#722)
+ *
+ * warning 存在時の誤誘導 "All validations passed." を修正した三分岐メッセージを検証する。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { printSummary, type ValidationSummary } from "../../scripts/validate-samples";
+
+// ─── テスト用ヘルパー ────────────────────────────────────────────────────────
+
+function makeSummary(overrides: Partial<ValidationSummary> = {}): ValidationSummary {
+  return {
+    totalFlows: 0,
+    passedFlows: 0,
+    failedFlows: 0,
+    results: [],
+    projectResults: [],
+    projectCount: 1,
+    totalTableCount: 0,
+    totalConventionsCount: 0,
+    totalScreenCount: 0,
+    totalViewDefinitionCount: 0,
+    extensionFileCount: 0,
+    ...overrides,
+  };
+}
+
+function makeIssue(
+  validator: string,
+  severity: "error" | "warning",
+  code = "TEST_CODE",
+  path = "test/path",
+  message = "テストメッセージ",
+) {
+  return { validator, severity, code, path, message };
+}
+
+// ─── テスト ──────────────────────────────────────────────────────────────────
+
+describe("printSummary — error = 0, warning = 0", () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it("error も warning もないとき 'All validations passed.' を出力する", () => {
+    const summary = makeSummary({ totalFlows: 3, passedFlows: 3, failedFlows: 0 });
+    printSummary(summary);
+    const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).toContain("All validations passed.");
+  });
+
+  it("error も warning もないとき 'All errors resolved' や 'failed' を出力しない", () => {
+    const summary = makeSummary({ totalFlows: 3, passedFlows: 3, failedFlows: 0 });
+    printSummary(summary);
+    const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).not.toContain("All errors resolved");
+    expect(output).not.toContain("failed");
+  });
+});
+
+describe("printSummary — error = 0, warning > 0", () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it("warning が 2 件 (異なる validator) のとき 'All errors resolved (2 warnings remain):' を出力する", () => {
+    const summary = makeSummary({
+      totalFlows: 2,
+      passedFlows: 2,
+      failedFlows: 0,
+      projectResults: [
+        {
+          projectId: "test",
+          displayName: "test",
+          issues: [
+            makeIssue("runtimeContractValidator", "warning", "EMPTY_SCREEN_ITEMS"),
+            makeIssue("sqlOrderValidator", "warning", "WARN_CODE"),
+          ],
+        },
+      ],
+    });
+    printSummary(summary);
+    const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).toContain("All errors resolved (2 warnings remain):");
+  });
+
+  it("warning が 2 件のとき per-validator 内訳を出力する", () => {
+    const summary = makeSummary({
+      totalFlows: 2,
+      passedFlows: 2,
+      failedFlows: 0,
+      projectResults: [
+        {
+          projectId: "test",
+          displayName: "test",
+          issues: [
+            makeIssue("runtimeContractValidator", "warning", "EMPTY_SCREEN_ITEMS"),
+            makeIssue("sqlOrderValidator", "warning", "WARN_CODE"),
+          ],
+        },
+      ],
+    });
+    printSummary(summary);
+    const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).toContain("[runtimeContractValidator] 1 warning");
+    expect(output).toContain("[sqlOrderValidator] 1 warning");
+  });
+
+  it("warning が 2 件のとき 'All validations passed.' を出力しない", () => {
+    const summary = makeSummary({
+      totalFlows: 2,
+      passedFlows: 2,
+      failedFlows: 0,
+      projectResults: [
+        {
+          projectId: "test",
+          displayName: "test",
+          issues: [
+            makeIssue("runtimeContractValidator", "warning", "EMPTY_SCREEN_ITEMS"),
+            makeIssue("sqlOrderValidator", "warning", "WARN_CODE"),
+          ],
+        },
+      ],
+    });
+    printSummary(summary);
+    const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).not.toContain("All validations passed.");
+  });
+
+  it("warning が 1 件のとき単数形 'warning remain' を出力する", () => {
+    const summary = makeSummary({
+      totalFlows: 1,
+      passedFlows: 1,
+      failedFlows: 0,
+      projectResults: [
+        {
+          projectId: "test",
+          displayName: "test",
+          issues: [
+            makeIssue("runtimeContractValidator", "warning", "EMPTY_SCREEN_ITEMS"),
+          ],
+        },
+      ],
+    });
+    printSummary(summary);
+    const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).toContain("All errors resolved (1 warning remain):");
+  });
+});
+
+describe("printSummary — error > 0, warning > 0", () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it("error = 1, warning = 1 のとき '1 flow failed with 1 error and 1 warning:' を出力する", () => {
+    const summary = makeSummary({
+      totalFlows: 1,
+      passedFlows: 0,
+      failedFlows: 1,
+      results: [
+        {
+          filePath: "/test/flow.json",
+          displayName: "test/flow.json",
+          projectId: "test",
+          issues: [makeIssue("sqlColumnValidator", "error", "COL_NOT_FOUND")],
+        },
+      ],
+      projectResults: [
+        {
+          projectId: "test",
+          displayName: "test",
+          issues: [makeIssue("runtimeContractValidator", "warning", "EMPTY_SCREEN_ITEMS")],
+        },
+      ],
+    });
+    printSummary(summary);
+    const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).toContain("1 flow failed with 1 error and 1 warning:");
+  });
+
+  it("error = 1, warning = 1 のとき per-validator 内訳を出力する", () => {
+    const summary = makeSummary({
+      totalFlows: 1,
+      passedFlows: 0,
+      failedFlows: 1,
+      results: [
+        {
+          filePath: "/test/flow.json",
+          displayName: "test/flow.json",
+          projectId: "test",
+          issues: [makeIssue("sqlColumnValidator", "error", "COL_NOT_FOUND")],
+        },
+      ],
+      projectResults: [
+        {
+          projectId: "test",
+          displayName: "test",
+          issues: [makeIssue("runtimeContractValidator", "warning", "EMPTY_SCREEN_ITEMS")],
+        },
+      ],
+    });
+    printSummary(summary);
+    const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).toContain("[sqlColumnValidator] 1 error");
+    expect(output).toContain("[runtimeContractValidator] 1 warning");
+  });
+
+  it("error = 1, warning = 1 のとき 'All validations passed.' を出力しない", () => {
+    const summary = makeSummary({
+      totalFlows: 1,
+      passedFlows: 0,
+      failedFlows: 1,
+      results: [
+        {
+          filePath: "/test/flow.json",
+          displayName: "test/flow.json",
+          projectId: "test",
+          issues: [makeIssue("sqlColumnValidator", "error", "COL_NOT_FOUND")],
+        },
+      ],
+      projectResults: [
+        {
+          projectId: "test",
+          displayName: "test",
+          issues: [makeIssue("runtimeContractValidator", "warning", "EMPTY_SCREEN_ITEMS")],
+        },
+      ],
+    });
+    printSummary(summary);
+    const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).not.toContain("All validations passed.");
+  });
+});
+
+describe("printSummary — error > 0, warning = 0", () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it("error = 2, warning = 0 のとき warning 言及なしで '2 flows failed with 2 errors:' を出力する", () => {
+    const summary = makeSummary({
+      totalFlows: 2,
+      passedFlows: 0,
+      failedFlows: 2,
+      results: [
+        {
+          filePath: "/test/flow1.json",
+          displayName: "test/flow1.json",
+          projectId: "test",
+          issues: [makeIssue("sqlColumnValidator", "error", "COL_NOT_FOUND")],
+        },
+        {
+          filePath: "/test/flow2.json",
+          displayName: "test/flow2.json",
+          projectId: "test",
+          issues: [makeIssue("conventionsValidator", "error", "REF_NOT_FOUND")],
+        },
+      ],
+    });
+    printSummary(summary);
+    const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).toContain("2 flows failed with 2 errors:");
+    expect(output).not.toContain("warning");
+  });
+});

--- a/designer/src/schemas/validateSamplesPrintSummary.test.ts
+++ b/designer/src/schemas/validateSamplesPrintSummary.test.ts
@@ -139,7 +139,7 @@ describe("printSummary — error = 0, warning > 0", () => {
     expect(output).not.toContain("All validations passed.");
   });
 
-  it("warning が 1 件のとき単数形 'warning remain' を出力する", () => {
+  it("warning が 1 件のとき単数形 'warning remains' を出力する", () => {
     const summary = makeSummary({
       totalFlows: 1,
       passedFlows: 1,
@@ -156,7 +156,7 @@ describe("printSummary — error = 0, warning > 0", () => {
     });
     printSummary(summary);
     const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
-    expect(output).toContain("All errors resolved (1 warning remain):");
+    expect(output).toContain("All errors resolved (1 warning remains):");
   });
 });
 


### PR DESCRIPTION
## 関連

- Closes #722
- 仕様: spec なし (validate-samples.ts はスクリプト内部の表示ロジック)

## 概要

`printSummary` の末尾集計メッセージが error 件数のみを見ており、warning が存在しても `All validations passed.` と表示していた。これはユーザーを誤誘導するため、三分岐メッセージに修正する。

## 主な変更

- **warning 件数集計追加**: `totalByValidator` (error) に加え `totalWarnByValidator` (warning) の Map と `totalErrors` / `totalWarnings` の 2 カウンタを追加 — `validate-samples.ts:494-513`
- **三分岐メッセージ実装**: `(errors=0 && warnings=0)` / `(errors=0 && warnings>0)` / `(errors>0)` の三分岐に変更 — `validate-samples.ts:516-537`
- **型と関数の export 化**: `ValidationSummary` interface と `printSummary` 関数を export — `validate-samples.ts:70`, `validate-samples.ts:450`
- **ユニットテスト新規追加**: `validateSamplesPrintSummary.test.ts` — 4 describe ブロック、10 ケース

## 仕様逐条突合 (自己申告)

仕様は ISSUE #722 コメント内の設計に従う:

- 分岐1: `totalErrors === 0 && totalWarnings === 0` → `All validations passed.` → `validate-samples.ts:516-517` ✓
- 分岐2: `totalErrors === 0 && totalWarnings > 0` → `All errors resolved (N warning(s) remain):` + per-validator 内訳 → `validate-samples.ts:518-522` ✓
- 分岐3: `totalErrors > 0` → `K flow(s) failed with M error(s)[ and N warning(s)]:` + per-validator error+warning 件数 → `validate-samples.ts:523-537` ✓
- exit code 設計は変更しない (`failedFlows > 0 || projectErrorCount > 0 ? 1 : 0`) → `validate-samples.ts:559` ✓ (変更なし)
- validator 群 (`*Validator.ts`) は触らない ✓

## レビューで特に見てほしい箇所

- warning が 0 件の error あり分岐で `and N warning(s)` の接尾が付かないこと (` and ${totalWarnings > 0 ? ...}`)
- per-validator 内訳は `e > 0 || w > 0` の場合のみ出力 (0 件のバリデータは表示しない) — `validate-samples.ts:527`
- retail 実行結果: warning = 19 件 (viewDefinitionValidator 7 + screenNavigationValidator 12) で exit 0、`All errors resolved (19 warnings remain):` 表示

## テスト

- Vitest: 19 件 (新規 10 件) — validateSamplesPrintSummary.test.ts (printSummary 三分岐) + validateSamplesRuntime.test.ts (既存 9 件 regression なし)
- Playwright: N/A
- MCP E2E: N/A

## UI 影響 / AI smoke test

- [x] UI 影響なし (auto テスト pass のみ)

### UI 影響ありの場合、AI smoke test で確認した項目

N/A

## spec 側の不足点 / 提案

N/A — スクリプト内部の表示ロジックのため spec は存在しない。ISSUE #722 コメントが設計仕様として機能している。

## レビュー担当への申し送り

- validate-samples.ts は `scripts/` 配下の CLI スクリプトで、`src/` のテストから import するため `export` が必要だった
- retail sample は warning = 19 件の状態で exit 0 を維持することを確認済み (warning は exit code に影響しない)
- 既存の lint エラー (93 errors, 16 warnings) は PR 作成前から存在するプロジェクト全体の問題であり、本 PR の変更ファイルには lint エラーなし
