### PR TITLE
improve(validate): EMPTY_SCREEN_ITEMS を screen kind 別の条件付き発報に変更 (#723)

### DIFF
--- a/designer/scripts/validate-samples.ts
+++ b/designer/scripts/validate-samples.ts
@@ -250,7 +250,22 @@ function issue(
   return { validator, code, path, message, severity };
 }
 
-/** items 必須 kind 白リスト — 該当しない kind は warning 発報をスキップ */
+/**
+ * items 必須 kind 白リスト — 該当しない kind は warning 発報をスキップ。
+ *
+ * 各 kind の選定根拠 (schemas/v3/screen.v3.schema.json#/$defs/ScreenKind):
+ * - form: フォーム入力画面 — 必ず項目が必要
+ * - detail: 詳細表示 — 表示するフィールドが必要
+ * - search: 検索条件入力 — 検索条件項目が必要
+ * - confirm: 確認画面 — 確認する内容を表示する項目が必要 (modal と異なり画面遷移を伴う独立画面)
+ * - wizard: ステップ式入力 — 各ステップで項目が必要
+ *
+ * 除外理由:
+ * - dashboard / complete / error / login: 通常 items を持たない (固定表示やナビゲーションのみ)
+ * - list: items または viewDefinitionRefs どちらかで OK (ITEMS_OR_VIEW_DEF_KINDS で別扱い)
+ * - modal: 一般的に簡易ダイアログで items を持たないことが多い (持つ場合は kind: form 等で別画面化が望ましい)
+ * - other: 用途不明、判定不能のため安全側
+ */
 const ITEMS_REQUIRED_KINDS: ReadonlySet<string> = new Set([
   "form",
   "detail",
@@ -288,7 +303,9 @@ export function checkScreenItemsEmbedded(project: ProjectResources): ValidationI
     // 拡張 ScreenKind (<ns>:<name>) は判定不能 → warning スキップ (安全側)
     if (kind.includes(":")) continue;
 
-    // items 必須 kind にも viewDefinitionRefs 代替 kind にも該当しなければ warning スキップ
+    // items 必須 kind にも viewDefinitionRefs 代替 kind にも該当しなければ warning スキップ。
+    // kind が空文字列 (= undefined/null を "" に正規化した場合) もここで skip される —
+    // 種別不明の画面で false positive を出すより安全側に倒す意図。
     if (!ITEMS_REQUIRED_KINDS.has(kind) && !ITEMS_OR_VIEW_DEF_KINDS.has(kind)) {
       continue;
     }
@@ -310,7 +327,7 @@ export function checkScreenItemsEmbedded(project: ProjectResources): ValidationI
       code: "EMPTY_SCREEN_ITEMS",
       path: `screens/${id}.json`,
       message: isViewDefKind
-        ? `Screen.items が空です (kind=${kind})。viewDefinitionRefs も未定義のため UI で表示する内容がありません。\`items\` または \`viewDefinitionRefs\` を定義してください`
+        ? `Screen.items が空です (kind=${kind})。viewDefinitionRefs も空または未定義のため UI で表示する内容がありません。\`items\` または \`viewDefinitionRefs\` を定義してください`
         : `Screen.items が空です (kind=${kind || "<undefined>"})。runtime は別ファイル \`screen-items/${id}.json\` を読まないため UI で空フォームになります。\`screens/${id}.json#items\` 配列に画面項目を embed してください`,
     });
   }

--- a/designer/scripts/validate-samples.ts
+++ b/designer/scripts/validate-samples.ts
@@ -250,27 +250,69 @@ function issue(
   return { validator, code, path, message, severity };
 }
 
+/** items 必須 kind 白リスト — 該当しない kind は warning 発報をスキップ */
+const ITEMS_REQUIRED_KINDS: ReadonlySet<string> = new Set([
+  "form",
+  "detail",
+  "search",
+  "confirm",
+  "wizard",
+]);
+
+/** items 代替として viewDefinitionRefs を持てる kind */
+const ITEMS_OR_VIEW_DEF_KINDS: ReadonlySet<string> = new Set([
+  "list",
+]);
+
 /**
  * Check 1: Screen.items embed check (#714)
  *
  * - screens/<id>.json の items が空または未定義 → warning (EMPTY_SCREEN_ITEMS)
+ *   ただし kind に応じた条件付き発報 (#723):
+ *   - ITEMS_REQUIRED_KINDS (form/detail/search/confirm/wizard): items 空なら発報
+ *   - ITEMS_OR_VIEW_DEF_KINDS (list): items 空 かつ viewDefinitionRefs も空/未定義なら発報
+ *   - 拡張 kind (<ns>:<name>): 判定不能のため warning スキップ (安全側)
+ *   - その他の kind (dashboard/complete/error 等): warning スキップ
  * - screen-items/ ディレクトリに .json ファイルが存在 → error (LEGACY_SCREEN_ITEMS_DIR)
  */
 export function checkScreenItemsEmbedded(project: ProjectResources): ValidationIssue[] {
   const issues: ValidationIssue[] = [];
 
-  // Check 1a: items が空または未定義の screen
+  // Check 1a: items が空または未定義の screen (kind 別の条件付き発報 #723)
   for (const screen of project.screens) {
-    if (!screen.items || screen.items.length === 0) {
-      const id = screen.id ?? "unknown";
-      issues.push({
-        validator: "runtimeContractValidator",
-        severity: "warning",
-        code: "EMPTY_SCREEN_ITEMS",
-        path: `screens/${id}.json`,
-        message: `Screen.items が空です。runtime は別ファイル \`screen-items/${id}.json\` を読まないため UI で空フォームになります。\`screens/${id}.json#items\` 配列に画面項目を embed してください`,
-      });
+    if (screen.items && screen.items.length > 0) continue; // items あり → skip
+
+    const id = screen.id ?? "unknown";
+    const kind = typeof screen.kind === "string" ? screen.kind : "";
+
+    // 拡張 ScreenKind (<ns>:<name>) は判定不能 → warning スキップ (安全側)
+    if (kind.includes(":")) continue;
+
+    // items 必須 kind にも viewDefinitionRefs 代替 kind にも該当しなければ warning スキップ
+    if (!ITEMS_REQUIRED_KINDS.has(kind) && !ITEMS_OR_VIEW_DEF_KINDS.has(kind)) {
+      continue;
     }
+
+    // list 系で viewDefinitionRefs が 1+ 件あれば items 空でも OK
+    if (
+      ITEMS_OR_VIEW_DEF_KINDS.has(kind) &&
+      Array.isArray(screen.viewDefinitionRefs) &&
+      screen.viewDefinitionRefs.length > 0
+    ) {
+      continue;
+    }
+
+    // ここまで到達 → 真に items が必要なのに空
+    const isViewDefKind = ITEMS_OR_VIEW_DEF_KINDS.has(kind);
+    issues.push({
+      validator: "runtimeContractValidator",
+      severity: "warning",
+      code: "EMPTY_SCREEN_ITEMS",
+      path: `screens/${id}.json`,
+      message: isViewDefKind
+        ? `Screen.items が空です (kind=${kind})。viewDefinitionRefs も未定義のため UI で表示する内容がありません。\`items\` または \`viewDefinitionRefs\` を定義してください`
+        : `Screen.items が空です (kind=${kind || "<undefined>"})。runtime は別ファイル \`screen-items/${id}.json\` を読まないため UI で空フォームになります。\`screens/${id}.json#items\` 配列に画面項目を embed してください`,
+    });
   }
 
   // Check 1b: legacy screen-items/ ディレクトリが存在する場合

--- a/designer/src/schemas/validateSamplesRuntime.test.ts
+++ b/designer/src/schemas/validateSamplesRuntime.test.ts
@@ -212,3 +212,117 @@ describe("checkDesignFilePresence — designFileRef 未指定", () => {
     expect(missingIssues).toHaveLength(0);
   });
 });
+
+// ─── Case 9 以降: kind 別の条件付き発報 (#723) ────────────────────────────
+
+describe("checkScreenItemsEmbedded — kind=form items 空 → 発報", () => {
+  it("kind が 'form' かつ items 空のとき EMPTY_SCREEN_ITEMS warning が 1 件", () => {
+    const dir = makeTempProject();
+    const id = "11111111-0000-4000-8000-000000000001";
+    const screens = [makeScreen(id, { kind: "form", items: [] })];
+    const project = makeProject(dir, screens);
+    const issues = checkScreenItemsEmbedded(project);
+    const emptyIssues = issues.filter((i) => i.code === "EMPTY_SCREEN_ITEMS");
+    expect(emptyIssues).toHaveLength(1);
+    expect(emptyIssues[0].severity).toBe("warning");
+    expect(emptyIssues[0].message).toContain("kind=form");
+  });
+});
+
+describe("checkScreenItemsEmbedded — kind=dashboard items 空 → 発報なし", () => {
+  it("kind が 'dashboard' かつ items 空のとき EMPTY_SCREEN_ITEMS は出ない", () => {
+    const dir = makeTempProject();
+    const id = "22222222-0000-4000-8000-000000000001";
+    const screens = [makeScreen(id, { kind: "dashboard" as Screen["kind"], items: [] })];
+    const project = makeProject(dir, screens);
+    const issues = checkScreenItemsEmbedded(project);
+    const emptyIssues = issues.filter((i) => i.code === "EMPTY_SCREEN_ITEMS");
+    expect(emptyIssues).toHaveLength(0);
+  });
+});
+
+describe("checkScreenItemsEmbedded — kind=complete items 空 → 発報なし", () => {
+  it("kind が 'complete' かつ items 空のとき EMPTY_SCREEN_ITEMS は出ない", () => {
+    const dir = makeTempProject();
+    const id = "33333333-0000-4000-8000-000000000001";
+    const screens = [makeScreen(id, { kind: "complete" as Screen["kind"], items: [] })];
+    const project = makeProject(dir, screens);
+    const issues = checkScreenItemsEmbedded(project);
+    const emptyIssues = issues.filter((i) => i.code === "EMPTY_SCREEN_ITEMS");
+    expect(emptyIssues).toHaveLength(0);
+  });
+});
+
+describe("checkScreenItemsEmbedded — kind=list items 空 viewDefinitionRefs あり → 発報なし", () => {
+  it("kind が 'list' かつ items 空 かつ viewDefinitionRefs に UUID あり → EMPTY_SCREEN_ITEMS は出ない", () => {
+    const dir = makeTempProject();
+    const id = "44444444-0000-4000-8000-000000000001";
+    const screens = [makeScreen(id, {
+      kind: "list" as Screen["kind"],
+      items: [],
+      viewDefinitionRefs: ["44444444-0000-4000-8000-000000000099"] as Screen["viewDefinitionRefs"],
+    })];
+    const project = makeProject(dir, screens);
+    const issues = checkScreenItemsEmbedded(project);
+    const emptyIssues = issues.filter((i) => i.code === "EMPTY_SCREEN_ITEMS");
+    expect(emptyIssues).toHaveLength(0);
+  });
+});
+
+describe("checkScreenItemsEmbedded — kind=list items 空 viewDefinitionRefs 空配列 → 発報", () => {
+  it("kind が 'list' かつ items 空 かつ viewDefinitionRefs も空配列のとき EMPTY_SCREEN_ITEMS warning が 1 件", () => {
+    const dir = makeTempProject();
+    const id = "55555555-0000-4000-8000-000000000001";
+    const screens = [makeScreen(id, {
+      kind: "list" as Screen["kind"],
+      items: [],
+      viewDefinitionRefs: [] as Screen["viewDefinitionRefs"],
+    })];
+    const project = makeProject(dir, screens);
+    const issues = checkScreenItemsEmbedded(project);
+    const emptyIssues = issues.filter((i) => i.code === "EMPTY_SCREEN_ITEMS");
+    expect(emptyIssues).toHaveLength(1);
+    expect(emptyIssues[0].severity).toBe("warning");
+    expect(emptyIssues[0].message).toContain("viewDefinitionRefs");
+    expect(emptyIssues[0].message).toContain("kind=list");
+  });
+});
+
+describe("checkScreenItemsEmbedded — kind=list items 空 viewDefinitionRefs 未指定 → 発報", () => {
+  it("kind が 'list' かつ items 空 かつ viewDefinitionRefs 未指定のとき EMPTY_SCREEN_ITEMS warning が 1 件", () => {
+    const dir = makeTempProject();
+    const id = "66666666-0000-4000-8000-000000000001";
+    const screens = [makeScreen(id, { kind: "list" as Screen["kind"], items: [] })];
+    const project = makeProject(dir, screens);
+    const issues = checkScreenItemsEmbedded(project);
+    const emptyIssues = issues.filter((i) => i.code === "EMPTY_SCREEN_ITEMS");
+    expect(emptyIssues).toHaveLength(1);
+    expect(emptyIssues[0].severity).toBe("warning");
+  });
+});
+
+describe("checkScreenItemsEmbedded — kind=retail:storefront (拡張) items 空 → 発報なし", () => {
+  it("拡張 kind '<ns>:<name>' は判定不能のため EMPTY_SCREEN_ITEMS は出ない", () => {
+    const dir = makeTempProject();
+    const id = "77777777-0000-4000-8000-000000000001";
+    const screens = [makeScreen(id, { kind: "retail:storefront" as Screen["kind"], items: [] })];
+    const project = makeProject(dir, screens);
+    const issues = checkScreenItemsEmbedded(project);
+    const emptyIssues = issues.filter((i) => i.code === "EMPTY_SCREEN_ITEMS");
+    expect(emptyIssues).toHaveLength(0);
+  });
+});
+
+describe("checkScreenItemsEmbedded — kind=detail items 空 → 発報", () => {
+  it("kind が 'detail' かつ items 空のとき EMPTY_SCREEN_ITEMS warning が 1 件", () => {
+    const dir = makeTempProject();
+    const id = "88888888-0000-4000-8000-000000000001";
+    const screens = [makeScreen(id, { kind: "detail" as Screen["kind"], items: [] })];
+    const project = makeProject(dir, screens);
+    const issues = checkScreenItemsEmbedded(project);
+    const emptyIssues = issues.filter((i) => i.code === "EMPTY_SCREEN_ITEMS");
+    expect(emptyIssues).toHaveLength(1);
+    expect(emptyIssues[0].severity).toBe("warning");
+    expect(emptyIssues[0].message).toContain("kind=detail");
+  });
+});


### PR DESCRIPTION
## 関連

- Closes #723
- 仕様: N/A (validate-samples.ts の validator ロジック変更。spec 側に kind 別 items 要否は未定義のため、実装が実質的な仕様として機能する)

## 概要

`checkScreenItemsEmbedded` (Check 1a) の `EMPTY_SCREEN_ITEMS` warning を、screen の `kind` 値に応じた条件付き発報に変更する。

従来はすべての screen で items 空なら一律 warning が出ていたため、`dashboard` / `complete` / `error` 等の items を持たない種別や、`list` 系で `viewDefinitionRefs` による viewer 参照を使う画面でも誤報が発生していた。kind 白リスト方式により、真に items が必要な `form` / `detail` / `search` / `confirm` / `wizard` のみで発報する。

## 主な変更

- **ITEMS_REQUIRED_KINDS 白リスト追加**: `form` / `detail` / `search` / `confirm` / `wizard` — items 空なら warning 発報
- **ITEMS_OR_VIEW_DEF_KINDS**: `list` — items 空 かつ `viewDefinitionRefs` も空/未定義なら warning 発報。viewDefinitionRefs に 1 件以上あれば skip
- **拡張 kind スキップ**: `<ns>:<name>` 形式 (`:` 含む) は判定不能のため安全側 (warning スキップ)
- **その他の kind スキップ**: `dashboard` / `complete` / `error` / `login` / `modal` / `other` 等は warning スキップ
- **メッセージ差別化**: list 系発報時は `viewDefinitionRefs` への言及を含む別文言。全ケースで `(kind=<kind>)` を含めて種別を明確化
- **ユニットテスト 8 ケース追加**: validateSamplesRuntime.test.ts (既存 9 ケース維持、合計 17 ケース)

## 仕様逐条突合 (自己申告)

ISSUE #723 コメント (設計仕様) に記載の各要件:

- 拡張 kind (`:` 含む) → skip → `validate-samples.ts:303-304` ✓
- ITEMS_REQUIRED_KINDS でも ITEMS_OR_VIEW_DEF_KINDS でもない → skip → `validate-samples.ts:309-311` ✓
- ITEMS_OR_VIEW_DEF_KINDS (list) + viewDefinitionRefs 1+ 件 → skip → `validate-samples.ts:314-320` ✓
- ここまで到達 → warning 発報 → `validate-samples.ts:322-332` ✓
- list 系メッセージは `items` または `viewDefinitionRefs` を言及 → `validate-samples.ts:329-330` ✓
- form 等メッセージは現状の「画面項目を embed してください」文言 → `validate-samples.ts:331` ✓
- メッセージに `(kind=${kind})` を含める → `validate-samples.ts:329-331` ✓
- Check 1b (LEGACY_SCREEN_ITEMS_DIR) は変更なし → `validate-samples.ts:335-353` ✓

## レビューで特に見てほしい箇所

- `kind: undefined` / 空文字のケース: `kind = typeof screen.kind === "string" ? screen.kind : ""` で空文字に正規化し、空文字は ITEMS_REQUIRED_KINDS にも ITEMS_OR_VIEW_DEF_KINDS にも含まれないため skip される。従来動作から変更あり (undefined kind では warning が出なくなる) — これは意図的。
- `list` 以外の viewDefinitionRefs を持つ kind (仮に `kanban` 等が拡張 kind で実装された場合): 拡張 kind は `:` 含みになるため skip される。skip されるのは安全側。

## テスト

- Vitest: 17 件 (新規 8 件) — `checkScreenItemsEmbedded` の kind 別発報ロジック
- Playwright: N/A (UI 影響なし)
- MCP E2E: N/A

## UI 影響 / AI smoke test

- [x] UI 影響なし (auto テスト pass のみ)

### UI 影響ありの場合、AI smoke test で確認した項目

N/A

## spec 側の不足点 / 提案

ISSUE #723 の設計コメントに記載の通り、`validator` が実質的な仕様として機能する。必要であれば `docs/spec/` に kind 別 items 要否を明文化する別 ISSUE を起票可能だが、本 PR スコープ外。

## レビュー担当への申し送り

- 既存テスト Case 2/3 (`items 空配列` / `items undefined`) は `makeScreen` のデフォルト `kind: "form"` を利用するため、新ロジックでも引き続き warning が出る。kind の明示的指定なしで pass する理由はここ。
- retail サンプルは全 11 screen に `items` が定義済みのため Check 1a は 0 件 (変化なし)。warning 19 件は viewDefinitionValidator + screenNavigationValidator 由来で本 PR と無関係。
- `viewDefinitionRefs` フィールドは `Screen` 型 (`src/types/v3/screen.ts:64`) に正式定義済みのため、型キャスト不要。
