### PR TITLE
improve(samples): retail 注文確定フロー (f81dd9e0) /review-flow 指摘解消 (#726)

### DIFF
--- a/samples/retail/actions/f81dd9e0-794c-4539-a2a5-9cbcc0a75899.json
+++ b/samples/retail/actions/f81dd9e0-794c-4539-a2a5-9cbcc0a75899.json
@@ -35,7 +35,7 @@
           "httpStatus": 422,
           "defaultMessage": "注文確定に失敗しました。",
           "responseId": "422-order-confirm-failed",
-          "description": "注文確定 TX 内で予期しないエラーが発生した場合。"
+          "description": "注文確定の catch-all エラーコード。TX inner からの直接 throw はなく、step-08b の persistedOrder == null ガード経由で発行される (ADR-005 参照)。orders.order_number UNIQUE 制約違反は ORDER_NUMBER_CONFLICT で個別 catch、それ以外の予期しない TX rollback はこのコードに集約される。"
         },
         "ORDER_NUMBER_CONFLICT": {
           "httpStatus": 422,
@@ -451,7 +451,7 @@
               },
               "steps": [
                 {
-                  "id": "step-07-c-01",
+                  "id": "step-07-b-01",
                   "kind": "return",
                   "description": "422 注文番号競合を返す。再試行で解消できる。",
                   "responseId": "422-order-confirm-failed",

--- a/samples/retail/actions/f81dd9e0-794c-4539-a2a5-9cbcc0a75899.json
+++ b/samples/retail/actions/f81dd9e0-794c-4539-a2a5-9cbcc0a75899.json
@@ -273,6 +273,7 @@
             "id": "br-03-else",
             "code": "B",
             "label": "カート明細あり",
+            "description": "カート明細あり — step-04 (totalAmount 計算) へ fallthrough。",
             "steps": []
           }
         },
@@ -302,7 +303,7 @@
           "isolationLevel": "READ_COMMITTED",
           "propagation": "REQUIRED",
           "timeoutMs": 10000,
-          "rollbackOn": ["STOCK_SHORTAGE", "ORDER_CONFIRM_FAILED", "ORDER_NUMBER_CONFLICT"],
+          "rollbackOn": ["STOCK_SHORTAGE", "ORDER_NUMBER_CONFLICT"],
           "steps": [
             {
               "id": "step-06-01",
@@ -440,27 +441,8 @@
               ]
             },
             {
-              "id": "br-07-fail",
-              "code": "B",
-              "label": "その他 TX エラー",
-              "condition": {
-                "kind": "tryCatch",
-                "errorCode": "ORDER_CONFIRM_FAILED",
-                "description": "在庫不足以外の TX 内エラー。"
-              },
-              "steps": [
-                {
-                  "id": "step-07-b-01",
-                  "kind": "return",
-                  "description": "422 注文確定失敗を返す。",
-                  "responseId": "422-order-confirm-failed",
-                  "bodyExpression": "{ code: 'ORDER_CONFIRM_FAILED', message: '注文確定に失敗しました。しばらく経ってから再試行してください。' }"
-                }
-              ]
-            },
-            {
               "id": "br-07-conflict",
-              "code": "C",
+              "code": "B",
               "label": "注文番号競合エラー",
               "condition": {
                 "kind": "tryCatch",
@@ -480,8 +462,9 @@
           ],
           "elseBranch": {
             "id": "br-07-else",
-            "code": "D",
+            "code": "C",
             "label": "TX 成功 — 後続処理へ",
+            "description": "TX 成功 — step-08 (persistedOrder 再取得) へ fallthrough。",
             "steps": []
           }
         },
@@ -525,6 +508,7 @@
             "id": "br-08b-else",
             "code": "B",
             "label": "persistedOrder あり — 後続へ",
+            "description": "persistedOrder あり — step-09 (eventPublish) / step-10 (return) へ fallthrough。",
             "steps": []
           }
         },
@@ -536,7 +520,7 @@
           "payload": "{ orderId: @persistedOrder.id, orderNumber: @persistedOrder.order_number, customerId: @persistedOrder.customer_id, totalAmount: @persistedOrder.total_amount }"
         },
         {
-          "id": "step-11",
+          "id": "step-10",
           "kind": "return",
           "description": "200 OK — 注文確定完了を返す。",
           "responseId": "200-ok",
@@ -581,6 +565,15 @@
         "context": "S-3 注文確定で支払方法 (credit_card / bank_transfer / cod) を受け取る必要がある。@conv.regex / @conv.limit で表現できないため、フロー内 ValidationRule (type='enum') で値域を強制する。",
         "decision": "ValidationRule の type='enum' + values: ['credit_card', 'bank_transfer', 'cod'] で受け付け、orders.payment_method (VARCHAR(30) NULL 許容) に保存する。NULL 許容は移行前注文 (paymentMethod 未指定) との互換のため。",
         "consequences": "DB 制約 (chk_orders_payment_method) と enum rule の両方で値域を担保する。新支払方法追加時は (1) cff4a398 paymentMethod options / (2) f81dd9e0 step-01 enum values / (3) orders.chk_orders_payment_method の 3 箇所同時更新が必要。",
+        "date": "2026-05-02"
+      },
+      {
+        "id": "ADR-005",
+        "title": "rollbackOn から ORDER_CONFIRM_FAILED を除外、catch-all は step-08b に集約",
+        "status": "accepted",
+        "context": "TX inner で ORDER_CONFIRM_FAILED を明示的に throw する step は存在せず、step-07.br-07-fail は dead branch だった (#726 /review-flow 検出)。",
+        "decision": "rollbackOn には実際に TX inner から throw されるエラーコード (STOCK_SHORTAGE / ORDER_NUMBER_CONFLICT) のみを列挙する。予期しない TX rollback (DB 制約違反等の汎用エラー) は step-08b の persistedOrder == null 検出で catch-all として 422-order-confirm-failed を返す。",
+        "consequences": "rollbackOn の意図 (= TX inner で throw される具体エラー) と実装が一致し、死コードがなくなる。汎用 catch-all は step-08b に集約され、ADR-002 の TX 後再取得設計と整合する。",
         "date": "2026-05-02"
       }
     ],


### PR DESCRIPTION
<!-- 単独 PR (#726)、Closes 1 件 -->

## 関連

- Closes #726
- 検出元: PR #727 (#718 + #719) の `/review-flow` 結果
- 関連 follow-up:
  - #728 (S-2 retail screen の submit event 配置統一 — 本 PR スコープ外)
  - #729 (Nit-1 sqlOrderValidator の collectionItemName 未認識バグ — framework-side)
- 親メタ: #680 (samples 業界別整備)
- 仕様: schemas/v3/process-flow.v3.schema.json (Branch / ElseBranch / TransactionScope) — 仕様変更なし

## 概要

PR #727 マージ後の `/review-flow` で f81dd9e0 (注文確定フロー) に検出された 4 件の pre-existing 設計改善指摘のうち、業界横断の規約統一が必要な S-2 (#728) と framework 側修正が前提の Nit-1 (#729) を別 ISSUE に分離した残り、**M-1 / S-1 / N-1 の 3 件 + 独立レビューで追加検出した 1 + 2 件** を 1 ファイル修正で解消する。

## 主な変更 (samples/retail/actions/f81dd9e0-...json のみ)

### M-1: ORDER_CONFIRM_FAILED 死コード解消

- `step-06.rollbackOn` から `"ORDER_CONFIRM_FAILED"` を削除 (TX inner で実際に throw する step が無く dead code)
- `step-07.branches[]` から `br-07-fail` (code=B、ORDER_CONFIRM_FAILED catch) と `step-07-b-01` を削除
- branch code 再採番: `br-07-conflict` (code C → **B**)、elseBranch (code D → **C**)
- catch-all は既存 `step-08b` (TX 後 persistedOrder == null 検出) → `step-08b-a-01` (`422-order-confirm-failed`) に集約
- errors catalog の `ORDER_CONFIRM_FAILED` エントリは保持 (step-08b-a-01 が使用中)

### S-1: 空 elseBranch description 補完

- `step-03.elseBranch` (br-03-else): description 追加 — fallthrough 先 step-04 (totalAmount 計算) を明記
- `step-07.elseBranch` (br-07-else): description 追加 — fallthrough 先 step-08 (persistedOrder 再取得) を明記
- `step-08b.elseBranch` (br-08b-else): description 追加 — fallthrough 先 step-09 / step-10 を明記 (一貫性)

### N-1: step ID 連続化

- `step-11` → `step-10` に renumber (欠番解消)

### ADR-005 追加

`authoring.decisions` 末尾に「rollbackOn 削減 + catch-all を step-08b に集約」の設計根拠を記録。

### 独立レビュー検出指摘の解消

- **Should-fix (両レビュー一致)**: `step-07-c-01` → `step-07-b-01` rename (br-07-conflict 昇格に伴う命名一貫性回復)
- **Nit-2 (review-flow)**: errors catalog の `ORDER_CONFIRM_FAILED.description` を ADR-005 と整合する文言 (catch-all 専用、TX inner 直接 throw なし) に更新

### scope 外として ISSUE 化

- **S-2 (review-flow)**: submit event 配置パターン (cff4a398.shippingPostalCode に submit) を retail screen 横断で統一すべき → **#728** に分離 (cart 画面 c73fa05c も同パターンのため)
- **Nit-1 (review-flow)**: `step-06-03.outputBinding` 削除を試みたら sqlOrderValidator が `collectionItemName` をバインド変数として認識せず 6 件の error が新規発生 → **#729** に分離 (framework 側修正が必要)

## 仕様逐条突合 (自己申告)

### 受入基準 (改訂版 #726 本文)

- §「M-1: ORDER_CONFIRM_FAILED を rollbackOn から削除 + step-07 br-07-fail dead branch 削除」 → f81dd9e0-...json `actions[0].steps[5].rollbackOn` (2 要素のみ) + branches[] から `br-07-fail` 削除済み ✓
- §「S-1: step-03 / step-07 の空 elseBranch に description を追加」 → 3 箇所 (step-03 / step-07 / step-08b の elseBranch) に description 追加 ✓ (step-08b は一貫性のため追加、本来の受入基準は 2 箇所)
- §「N-1: step-11 → step-10 に renumber」 → `step-10` (return 200-ok) に rename、`step-11` の参照は file 全体に 0 件 (grep 確認) ✓
- §「validate:samples で 5/5 pass 維持、warnings 件数が増えないこと」 → 5/5 pass / errors 0 / warnings 19 (PR #727 同水準) ✓
- §「/review-flow f81dd9e0 再実行で M-1 / S-1 / N-1 が解消」 → /review-flow 再実行で旧指摘 3 件すべて ✓ 解消確認済 (新検出は Should-fix S-1 + Nit-2 を本 PR で同梱解消、Nit-1 は #729 に分離)

### scope 外指摘の追跡

- S-2 → #728 起票済み ✓
- Nit-1 → #729 起票済み ✓

## レビューで特に見てほしい箇所

- **branch code 再採番の一貫性**: `br-07-fail` (旧 B) 削除に伴い、`br-07-conflict` (C → B)、`br-07-else` (D → C) に詰めた。内部 step ID も `step-07-c-01` → `step-07-b-01` に同調 rename した
- **catch-all 集約の正当性**: ADR-005 に明記したとおり、TX inner の予期しない rollback 時は `step-08b` で `@persistedOrder == null` を検出して `422-order-confirm-failed` を返す既存パスが catch-all として機能。`br-07-fail` は dead branch だったため削除しても挙動に影響なし
- **errors catalog の ORDER_CONFIRM_FAILED 保持判断**: step-08b-a-01 が `responseId: "422-order-confirm-failed"` で使用しているため catalog エントリは保持。`description` のみ ADR-005 と整合する文言に更新
- **scope 分離の妥当性**: S-2 (cross-screen 規約) と Nit-1 (framework validator) を本 PR で扱わず別 ISSUE 化した判断 — 本 PR は f81dd9e0 単独で完結する閉じた変更に絞った

## テスト

- Vitest: 既存テストを破壊していない (JSON 1 ファイルの修正のみ、runtime 改変なし)
- Playwright: N/A (UI コンポーネント変更なし)
- MCP E2E: N/A
- validate:samples: **5 / 5 flows passed, errors 0, warnings 19** (#727 同水準維持)
- /review-flow: 旧指摘 M-1 / S-1 (旧 elseBranch) / N-1 解消確認済み、新 Should-fix S-1 + Nit-2 も本 PR で解消、Nit-1 は #729 に分離

## UI 影響 / AI smoke test

- [ ] UI 影響あり (AI が chrome-devtools MCP / Playwright で smoke test 実施済み)
- [x] UI 影響なし (auto テスト pass のみ)

理由: 本 PR は **JSON サンプル 1 ファイルの修正のみ** で designer フロントエンドのコード変更ゼロ。step ID rename / rollbackOn 配列要素削除 / branch object 削除 / description 追加は runtime 実装に影響を与えない (samples は data only)。

## spec 側の不足点 / 提案

N/A — 本 PR は既存スキーマの制約内で完結。ElseBranch.description / Branch.code 再採番は schema 許容範囲。

## レビュー担当への申し送り

別セッション Claude (`/review-pr 730` (or new PR 番号)) でレビューする際:

1. **schema ガバナンス遵守**: `gh pr diff <N> --name-only | grep -E "^schemas/"` 結果が空であることを確認
2. **branch 内部の step ID 整合**: re-letter 後の `br-07-stock` (A) / `br-07-conflict` (B) / `br-07-else` (C) と内部 step ID `step-07-a-01` / `step-07-b-01` の対応に矛盾がないか
3. **rollbackOn と branches の 1:1 対応**: rollbackOn = `["STOCK_SHORTAGE", "ORDER_NUMBER_CONFLICT"]` と step-07 branches (`br-07-stock` / `br-07-conflict`) の 1:1 対応
4. **catch-all 経路**: TX 内予期しないエラー → TX rollback (汎用) → step-08 で persistedOrder == null → step-08b → step-08b-a-01 で 422 を返す経路が機能することを ADR-005 と突合
5. **#728 / #729 の分離妥当性**: 本 PR で扱わない指摘が適切に follow-up ISSUE 化されているか確認
6. **memory 遵守**:
   - Codex 禁止 (2026-05-05 まで) — 全実装を Sonnet subagent で完遂
   - schema governance (#511) — schemas/*.json 不変
   - feedback_nit_must_resolve.md — Nit / Should-fix の対応 or 即起票を遵守 (放置せず)
