### PR TITLE
feat(schema): screen-item.v3 に Ref フィールド追加 + process-flow.v3 lengthRef (#734)

### DIFF
--- a/designer/scripts/validate-samples.ts
+++ b/designer/scripts/validate-samples.ts
@@ -24,6 +24,7 @@ import { checkScreenItemFieldTypeConsistency } from "../src/schemas/screenItemFi
 import { checkScreenItemRefKeyConsistency } from "../src/schemas/screenItemRefKeyValidator.js";
 import { checkViewDefinitions } from "../src/schemas/viewDefinitionValidator.js";
 import { checkScreenNavigation } from "../src/schemas/screenNavigationValidator.js";
+import { resolveScreenItemRefs } from "../src/schemas/screenItemRefResolver.js";
 import { loadExtensionsFromBundle, type ExtensionsBundle, type LoadedExtensions } from "../src/schemas/loadExtensions.js";
 import type { Screen } from "../src/types/v3/screen.js";
 import type { Conventions } from "../src/types/v3/conventions.js";
@@ -438,7 +439,14 @@ export async function runValidation(projectDirArg: string): Promise<ValidationSu
     projectIssues.push(issue("screenItemFlowValidator", i.code, i.path, i.message, i.severity));
   }
 
-  for (const i of checkScreenItemFieldTypeConsistency(flows.map((f) => f.flow), project.screens)) {
+  // #734: *Ref フィールドを plain 値に展開した版で screenItemFieldTypeValidator を実行
+  // (plain min/max/minLength/maxLength が undefined の場合のみ Ref を解決して補完)
+  const screensWithRefsResolved: Screen[] = project.screens.map((screen) => ({
+    ...screen,
+    items: (screen.items ?? []).map((item) => resolveScreenItemRefs(item, project.conventionsV3)),
+  }));
+
+  for (const i of checkScreenItemFieldTypeConsistency(flows.map((f) => f.flow), screensWithRefsResolved)) {
     projectIssues.push(issue("screenItemFieldTypeValidator", i.code, i.path, i.message, i.severity));
   }
 

--- a/designer/src/schemas/conventionsValidator.test.ts
+++ b/designer/src/schemas/conventionsValidator.test.ts
@@ -657,6 +657,73 @@ describe("#734 screen-item Ref フィールド検証", () => {
   });
 });
 
+describe("#734 checkStep — validation rules[].minRef/maxRef/lengthRef 検査", () => {
+  // checkConventionReferences 経由で checkStep 内の rules Ref フィールドを検査する
+  const catalog: ConventionsCatalog = {
+    version: "1.0.0",
+    limit: {
+      cartItemMaxQuantity: { value: 999, unit: "integer" },
+    },
+  };
+
+  it("rules[].lengthRef が未登録 → UNKNOWN_CONV_LIMIT 検出 (#734 review S-1)", () => {
+    const issues = checkConventionReferences(
+      makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [{
+            id: "s1", kind: "validation", description: "", conditions: "",
+            rules: [{ field: "x", type: "maxLength", message: "エラー", lengthRef: "@conv.limit.unknownKey" }],
+          }],
+        }],
+      }),
+      catalog,
+    );
+    expect(issues.length).toBeGreaterThanOrEqual(1);
+    const hit = issues.find((i) => i.path === "actions[0].steps[0].rules[0].lengthRef");
+    expect(hit).toBeDefined();
+    expect(hit?.code).toBe("UNKNOWN_CONV_LIMIT");
+  });
+
+  it("rules[].minRef が未登録 → UNKNOWN_CONV_LIMIT 検出 (#734 review S-1)", () => {
+    const issues = checkConventionReferences(
+      makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [{
+            id: "s1", kind: "validation", description: "", conditions: "",
+            rules: [{ field: "x", type: "min", message: "エラー", minRef: "@conv.limit.unknownKey" }],
+          }],
+        }],
+      }),
+      catalog,
+    );
+    expect(issues.length).toBeGreaterThanOrEqual(1);
+    const hit = issues.find((i) => i.path === "actions[0].steps[0].rules[0].minRef");
+    expect(hit).toBeDefined();
+    expect(hit?.code).toBe("UNKNOWN_CONV_LIMIT");
+  });
+
+  it("rules[].maxRef が未登録 → UNKNOWN_CONV_LIMIT 検出 (#734 review S-1)", () => {
+    const issues = checkConventionReferences(
+      makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [{
+            id: "s1", kind: "validation", description: "", conditions: "",
+            rules: [{ field: "x", type: "max", message: "エラー", maxRef: "@conv.limit.unknownKey" }],
+          }],
+        }],
+      }),
+      catalog,
+    );
+    expect(issues.length).toBeGreaterThanOrEqual(1);
+    const hit = issues.find((i) => i.path === "actions[0].steps[0].rules[0].maxRef");
+    expect(hit).toBeDefined();
+    expect(hit?.code).toBe("UNKNOWN_CONV_LIMIT");
+  });
+});
+
 describe("checkConventionReferences — サンプル (docs/sample-project/process-flows/*.json) 横断", () => {
   const catalog = loadCatalog();
   const files = readdirSync(samplesDir).filter((f) => f.endsWith(".json"));

--- a/designer/src/schemas/conventionsValidator.test.ts
+++ b/designer/src/schemas/conventionsValidator.test.ts
@@ -566,6 +566,97 @@ describe("checkScreenItemConventionReferences", () => {
   });
 });
 
+describe("#734 screen-item Ref フィールド検証", () => {
+  // catalog に limit.cartItemMaxQuantity (value: 999) が存在することを前提とする inline catalog
+  const catalog: ConventionsCatalog = {
+    version: "1.0.0",
+    limit: {
+      cartItemMaxQuantity: { value: 999, unit: "integer" },
+      productCodeMaxLength: { value: 20, unit: "char" },
+    },
+  };
+
+  it("items[].maxRef が @conv.limit.<key> として参照存在検査 — 有効 key → pass", () => {
+    const file = makeScreenItemsDocument({
+      items: [{ id: id("qty"), label: "数量", type: "integer", maxRef: "@conv.limit.cartItemMaxQuantity" }],
+    });
+    const issues = checkScreenItemConventionReferences(file, catalog);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("items[].maxRef に未登録 key → UNKNOWN_CONV_LIMIT 検出", () => {
+    const file = makeScreenItemsDocument({
+      items: [{ id: id("qty"), label: "数量", type: "integer", maxRef: "@conv.limit.noSuchKey" }],
+    });
+    const issues = checkScreenItemConventionReferences(file, catalog);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("UNKNOWN_CONV_LIMIT");
+    expect(issues[0].path).toBe("items[0].maxRef");
+  });
+
+  it("items[].minRef が @conv.limit.<key> として参照存在検査 — 有効 key → pass", () => {
+    const file = makeScreenItemsDocument({
+      items: [{ id: id("qty"), label: "数量", type: "integer", minRef: "@conv.limit.cartItemMaxQuantity" }],
+    });
+    const issues = checkScreenItemConventionReferences(file, catalog);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("items[].minRef に未登録 key → UNKNOWN_CONV_LIMIT 検出", () => {
+    const file = makeScreenItemsDocument({
+      items: [{ id: id("qty"), label: "数量", type: "integer", minRef: "@conv.limit.noSuchKey" }],
+    });
+    const issues = checkScreenItemConventionReferences(file, catalog);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("UNKNOWN_CONV_LIMIT");
+    expect(issues[0].path).toBe("items[0].minRef");
+  });
+
+  it("items[].maxLengthRef が @conv.limit.<key> として参照存在検査 — 有効 key → pass", () => {
+    const file = makeScreenItemsDocument({
+      items: [{ id: id("code"), label: "コード", type: "string", maxLengthRef: "@conv.limit.productCodeMaxLength" }],
+    });
+    const issues = checkScreenItemConventionReferences(file, catalog);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("items[].maxLengthRef に未登録 key → UNKNOWN_CONV_LIMIT 検出", () => {
+    const file = makeScreenItemsDocument({
+      items: [{ id: id("code"), label: "コード", type: "string", maxLengthRef: "@conv.limit.noSuchKey" }],
+    });
+    const issues = checkScreenItemConventionReferences(file, catalog);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("UNKNOWN_CONV_LIMIT");
+    expect(issues[0].path).toBe("items[0].maxLengthRef");
+  });
+
+  it("items[].minLengthRef が @conv.limit.<key> として参照存在検査 — 有効 key → pass", () => {
+    const file = makeScreenItemsDocument({
+      items: [{ id: id("code"), label: "コード", type: "string", minLengthRef: "@conv.limit.cartItemMaxQuantity" }],
+    });
+    const issues = checkScreenItemConventionReferences(file, catalog);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("items[].minLengthRef に未登録 key → UNKNOWN_CONV_LIMIT 検出", () => {
+    const file = makeScreenItemsDocument({
+      items: [{ id: id("code"), label: "コード", type: "string", minLengthRef: "@conv.limit.noSuchKey" }],
+    });
+    const issues = checkScreenItemConventionReferences(file, catalog);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("UNKNOWN_CONV_LIMIT");
+    expect(issues[0].path).toBe("items[0].minLengthRef");
+  });
+
+  it("Ref フィールドが文字列でない場合 (undefined) は検査スキップ", () => {
+    const file = makeScreenItemsDocument({
+      items: [{ id: id("qty"), label: "数量", type: "integer" }],
+    });
+    const issues = checkScreenItemConventionReferences(file, catalog);
+    expect(issues).toHaveLength(0);
+  });
+});
+
 describe("checkConventionReferences — サンプル (docs/sample-project/process-flows/*.json) 横断", () => {
   const catalog = loadCatalog();
   const files = readdirSync(samplesDir).filter((f) => f.endsWith(".json"));

--- a/designer/src/schemas/conventionsValidator.ts
+++ b/designer/src/schemas/conventionsValidator.ts
@@ -315,6 +315,9 @@ function checkStep(step: Step, path: string, catalog: ConventionsCatalog, issues
         if (r.condition) texts.push({ src: r.condition, field: `rules[${ri}].condition` });
         if (r.message) texts.push({ src: r.message, field: `rules[${ri}].message` });
         if (r.pattern) texts.push({ src: r.pattern, field: `rules[${ri}].pattern` });
+        if (r.minRef) texts.push({ src: r.minRef, field: `rules[${ri}].minRef` });
+        if (r.maxRef) texts.push({ src: r.maxRef, field: `rules[${ri}].maxRef` });
+        if (r.lengthRef) texts.push({ src: r.lengthRef, field: `rules[${ri}].lengthRef` });
       });
       if (step.inlineBranch?.ngBodyExpression) {
         texts.push({ src: step.inlineBranch.ngBodyExpression, field: "inlineBranch.ngBodyExpression" });
@@ -350,6 +353,11 @@ export function checkScreenItemConventionReferences(
         if (val) checkValue(val, `items[${i}].errorMessages.${key}`, catalog, issues);
       });
     }
+    // #734: *Ref フィールドの @conv.limit.<key> 参照存在を検査
+    if (item.minLengthRef) checkValue(item.minLengthRef, `items[${i}].minLengthRef`, catalog, issues);
+    if (item.maxLengthRef) checkValue(item.maxLengthRef, `items[${i}].maxLengthRef`, catalog, issues);
+    if (item.minRef) checkValue(item.minRef, `items[${i}].minRef`, catalog, issues);
+    if (item.maxRef) checkValue(item.maxRef, `items[${i}].maxRef`, catalog, issues);
   });
 
   return issues;

--- a/designer/src/schemas/process-flow.schema.test.ts
+++ b/designer/src/schemas/process-flow.schema.test.ts
@@ -2465,3 +2465,68 @@ describe("process-flow.schema.json — extensions 合成 (#444)", () => {
     expect(ok).toBe(true);
   });
 });
+
+// ── v3 schema テスト (#734) ────────────────────────────────────────────────
+
+describe("process-flow.v3.schema.json — ValidationRule.lengthRef (#734)", () => {
+  let validateV3: ValidateFunction;
+
+  beforeAll(() => {
+    const v3Dir = resolve(repoRoot, "schemas/v3");
+    const localAjv = new Ajv2020({ allErrors: true, strict: false });
+    addFormats(localAjv);
+    // common.v3 と screen-item.v3 を addSchema して $ref 解決
+    localAjv.addSchema(
+      JSON.parse(readFileSync(resolve(v3Dir, "common.v3.schema.json"), "utf-8")) as object,
+    );
+    localAjv.addSchema(
+      JSON.parse(readFileSync(resolve(v3Dir, "screen-item.v3.schema.json"), "utf-8")) as object,
+    );
+    validateV3 = localAjv.compile(
+      JSON.parse(readFileSync(resolve(v3Dir, "process-flow.v3.schema.json"), "utf-8")) as object,
+    );
+  });
+
+  /** v3 ProcessFlow の最小有効フィクスチャ */
+  const baseV3Meta = () => ({
+    id: "aaaaaaaa-0000-4000-8000-000000000001",
+    name: "テストフロー",
+    kind: "screen",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  });
+
+  /** ValidationStep 1 件を含む v3 ProcessFlow フィクスチャ */
+  const makeV3WithValidationRules = (rules: unknown[]) => ({
+    $schema: "../../../schemas/v3/process-flow.v3.schema.json",
+    meta: baseV3Meta(),
+    actions: [{
+      id: "act-001",
+      name: "テスト",
+      trigger: "submit",
+      description: "テスト用アクション",
+      steps: [{
+        id: "s-001",
+        kind: "validation",
+        description: "入力バリデーション",
+        rules,
+      }],
+    }],
+  });
+
+  it("ValidationRule.lengthRef accept — @conv.limit 参照文字列 (length と併用)", () => {
+    const ok = validateV3(makeV3WithValidationRules([
+      { field: "productCode", type: "maxLength", length: 20, lengthRef: "@conv.limit.productCodeMaxLength" },
+    ]));
+    if (!ok) throw new Error(JSON.stringify(validateV3.errors));
+    expect(ok).toBe(true);
+  });
+
+  it("ValidationRule.lengthRef のみ (length 省略) も accept", () => {
+    const ok = validateV3(makeV3WithValidationRules([
+      { field: "productCode", type: "maxLength", lengthRef: "@conv.limit.productCodeMaxLength" },
+    ]));
+    if (!ok) throw new Error(JSON.stringify(validateV3.errors));
+    expect(ok).toBe(true);
+  });
+});

--- a/designer/src/schemas/screenItemRefResolver.test.ts
+++ b/designer/src/schemas/screenItemRefResolver.test.ts
@@ -1,0 +1,142 @@
+/**
+ * screenItemRefResolver のユニットテスト (#734)
+ */
+import { describe, it, expect } from "vitest";
+import { resolveScreenItemRefs } from "./screenItemRefResolver";
+import type { ScreenItem } from "../types/v3/screen-item";
+import type { Conventions } from "../types/v3/conventions";
+
+function makeItem(partial: Partial<ScreenItem>): ScreenItem {
+  return {
+    id: "f1" as ScreenItem["id"],
+    label: "フィールド",
+    type: "integer",
+    ...partial,
+  };
+}
+
+function makeCatalog(limitEntries: Record<string, number>): Conventions {
+  const limit: Record<string, { value: number }> = {};
+  for (const [key, value] of Object.entries(limitEntries)) {
+    limit[key] = { value };
+  }
+  return { version: "1.0.0", limit } as Conventions;
+}
+
+describe("resolveScreenItemRefs (#734)", () => {
+  describe("maxRef → max 解決", () => {
+    it("maxRef が @conv.limit.<key> で catalog に存在する場合、max に値を展開する", () => {
+      const item = makeItem({ maxRef: "@conv.limit.cartItemMaxQuantity" });
+      const catalog = makeCatalog({ cartItemMaxQuantity: 999 });
+      const result = resolveScreenItemRefs(item, catalog);
+      expect(result.max).toBe(999);
+    });
+
+    it("max が既に存在する場合は plain 優先 (maxRef は無視)", () => {
+      const item = makeItem({ max: 500, maxRef: "@conv.limit.cartItemMaxQuantity" });
+      const catalog = makeCatalog({ cartItemMaxQuantity: 999 });
+      const result = resolveScreenItemRefs(item, catalog);
+      expect(result.max).toBe(500);
+    });
+
+    it("maxRef が catalog に未登録の場合は max を展開しない", () => {
+      const item = makeItem({ maxRef: "@conv.limit.unknownKey" });
+      const catalog = makeCatalog({ cartItemMaxQuantity: 999 });
+      const result = resolveScreenItemRefs(item, catalog);
+      expect(result.max).toBeUndefined();
+    });
+
+    it("maxRef が @conv.limit.* 形式でない場合は max を展開しない", () => {
+      const item = makeItem({ maxRef: "@conv.regex.somePattern" });
+      const catalog = makeCatalog({ somePattern: 999 });
+      const result = resolveScreenItemRefs(item, catalog);
+      expect(result.max).toBeUndefined();
+    });
+  });
+
+  describe("minRef → min 解決", () => {
+    it("minRef が @conv.limit.<key> で catalog に存在する場合、min に値を展開する", () => {
+      const item = makeItem({ minRef: "@conv.limit.orderMinAmount" });
+      const catalog = makeCatalog({ orderMinAmount: 1 });
+      const result = resolveScreenItemRefs(item, catalog);
+      expect(result.min).toBe(1);
+    });
+
+    it("min が既に存在する場合は plain 優先", () => {
+      const item = makeItem({ min: 10, minRef: "@conv.limit.orderMinAmount" });
+      const catalog = makeCatalog({ orderMinAmount: 1 });
+      const result = resolveScreenItemRefs(item, catalog);
+      expect(result.min).toBe(10);
+    });
+
+    it("minRef が未登録の場合は min を展開しない", () => {
+      const item = makeItem({ minRef: "@conv.limit.noSuchKey" });
+      const catalog = makeCatalog({ orderMinAmount: 1 });
+      const result = resolveScreenItemRefs(item, catalog);
+      expect(result.min).toBeUndefined();
+    });
+  });
+
+  describe("maxLengthRef → maxLength 解決", () => {
+    it("maxLengthRef が catalog に存在する場合、maxLength に値を展開する", () => {
+      const item = makeItem({ type: "string", maxLengthRef: "@conv.limit.productCodeMaxLength" });
+      const catalog = makeCatalog({ productCodeMaxLength: 20 });
+      const result = resolveScreenItemRefs(item, catalog);
+      expect(result.maxLength).toBe(20);
+    });
+
+    it("maxLength が既に存在する場合は plain 優先", () => {
+      const item = makeItem({ type: "string", maxLength: 10, maxLengthRef: "@conv.limit.productCodeMaxLength" });
+      const catalog = makeCatalog({ productCodeMaxLength: 20 });
+      const result = resolveScreenItemRefs(item, catalog);
+      expect(result.maxLength).toBe(10);
+    });
+
+    it("maxLengthRef が未登録の場合は maxLength を展開しない", () => {
+      const item = makeItem({ type: "string", maxLengthRef: "@conv.limit.noSuchKey" });
+      const catalog = makeCatalog({ productCodeMaxLength: 20 });
+      const result = resolveScreenItemRefs(item, catalog);
+      expect(result.maxLength).toBeUndefined();
+    });
+  });
+
+  describe("minLengthRef → minLength 解決", () => {
+    it("minLengthRef が catalog に存在する場合、minLength に値を展開する", () => {
+      const item = makeItem({ type: "string", minLengthRef: "@conv.limit.productCodeMinLength" });
+      const catalog = makeCatalog({ productCodeMinLength: 4 });
+      const result = resolveScreenItemRefs(item, catalog);
+      expect(result.minLength).toBe(4);
+    });
+
+    it("minLength が既に存在する場合は plain 優先", () => {
+      const item = makeItem({ type: "string", minLength: 2, minLengthRef: "@conv.limit.productCodeMinLength" });
+      const catalog = makeCatalog({ productCodeMinLength: 4 });
+      const result = resolveScreenItemRefs(item, catalog);
+      expect(result.minLength).toBe(2);
+    });
+  });
+
+  describe("conventions が null の場合", () => {
+    it("conventions null は shallow copy のみ返す (Ref フィールドは展開しない)", () => {
+      const item = makeItem({ maxRef: "@conv.limit.cartItemMaxQuantity" });
+      const result = resolveScreenItemRefs(item, null);
+      expect(result.max).toBeUndefined();
+      expect(result.maxRef).toBe("@conv.limit.cartItemMaxQuantity");
+    });
+
+    it("conventions null でも元オブジェクトとは別インスタンス", () => {
+      const item = makeItem({ maxRef: "@conv.limit.cartItemMaxQuantity" });
+      const result = resolveScreenItemRefs(item, null);
+      expect(result).not.toBe(item);
+    });
+  });
+
+  describe("元オブジェクト不変性", () => {
+    it("resolveScreenItemRefs は元の ScreenItem を変更しない", () => {
+      const item = makeItem({ maxRef: "@conv.limit.cartItemMaxQuantity" });
+      const catalog = makeCatalog({ cartItemMaxQuantity: 999 });
+      resolveScreenItemRefs(item, catalog);
+      expect((item as Record<string, unknown>).max).toBeUndefined();
+    });
+  });
+});

--- a/designer/src/schemas/screenItemRefResolver.ts
+++ b/designer/src/schemas/screenItemRefResolver.ts
@@ -1,0 +1,62 @@
+/**
+ * screen-item Ref フィールド resolver (#734)
+ *
+ * `*Ref` フィールド (`minLengthRef` / `maxLengthRef` / `minRef` / `maxRef`) を
+ * Conventions catalog の `limit.<key>.value` (number) に解決し、
+ * 対応する plain フィールド (`minLength` / `maxLength` / `min` / `max`) に展開した
+ * ScreenItem を返す純粋関数。
+ *
+ * - plain フィールドが既にある場合は plain 優先 (Ref は無視)。
+ * - conventions が null の場合は shallow copy のみ返す。
+ * - 未登録 Ref・regex 非一致 Ref の場合は対応フィールドを埋めない (undefined のまま)。
+ *   参照存在の検査は conventionsValidator.checkScreenItemConventionReferences が担当。
+ */
+
+import type { ScreenItem } from "../types/v3/screen-item";
+import type { Conventions } from "../types/v3/conventions";
+
+/** `@conv.limit.<key>` 形式にマッチする正規表現 */
+const LIMIT_REF_RE = /^@conv\.limit\.([a-zA-Z_][\w-]*(?:\.[a-zA-Z_][\w-]*)*)$/;
+
+/**
+ * `@conv.limit.<key>` 参照文字列から catalog 値 (number) を解決する。
+ * - ref が undefined/空 → undefined
+ * - conventions が null → undefined
+ * - regex 非一致 → undefined
+ * - catalog に key が無い → undefined
+ * - value が number でない → undefined
+ */
+function resolveLimitRef(ref: string | undefined, conventions: Conventions | null): number | undefined {
+  if (!ref || !conventions) return undefined;
+  const m = LIMIT_REF_RE.exec(ref);
+  if (!m) return undefined;
+  const entry = conventions.limit?.[m[1]];
+  return typeof entry?.value === "number" ? entry.value : undefined;
+}
+
+/**
+ * ScreenItem 1 件の `*Ref` フィールドを解決して展開した新 ScreenItem を返す。
+ * 元オブジェクトは変更しない (shallow copy)。
+ */
+export function resolveScreenItemRefs(item: ScreenItem, conventions: Conventions | null): ScreenItem {
+  const resolved: ScreenItem = { ...item };
+
+  if (resolved.minLength === undefined) {
+    const v = resolveLimitRef(item.minLengthRef, conventions);
+    if (v !== undefined) resolved.minLength = v;
+  }
+  if (resolved.maxLength === undefined) {
+    const v = resolveLimitRef(item.maxLengthRef, conventions);
+    if (v !== undefined) resolved.maxLength = v;
+  }
+  if (resolved.min === undefined) {
+    const v = resolveLimitRef(item.minRef, conventions);
+    if (v !== undefined) resolved.min = v;
+  }
+  if (resolved.max === undefined) {
+    const v = resolveLimitRef(item.maxRef, conventions);
+    if (v !== undefined) resolved.max = v;
+  }
+
+  return resolved;
+}

--- a/designer/src/types/v3/process-flow.ts
+++ b/designer/src/types/v3/process-flow.ts
@@ -173,6 +173,8 @@ export interface ValidationRule {
   minRef?: string;
   /** `@conv.limit.<key>` 参照。 */
   maxRef?: string;
+  /** `@conv.limit.<key>` 参照 (length の代替)。loader 段階で integer 値に展開される。 */
+  lengthRef?: string;
   values?: string[];
   condition?: ExpressionString;
   /** 違反メッセージ (`@conv.msg.<key>` 推奨)。 */

--- a/designer/src/types/v3/screen-item.ts
+++ b/designer/src/types/v3/screen-item.ts
@@ -99,6 +99,14 @@ export interface ScreenItem {
   maxLength?: number;
   min?: number;
   max?: number;
+  /** `@conv.limit.<key>` 参照 (minLength の代替)。loader 段階で integer 値に展開される。 */
+  minLengthRef?: string;
+  /** `@conv.limit.<key>` 参照 (maxLength の代替)。loader 段階で integer 値に展開される。 */
+  maxLengthRef?: string;
+  /** `@conv.limit.<key>` 参照 (min の代替)。loader 段階で number 値に展開される。 */
+  minRef?: string;
+  /** `@conv.limit.<key>` 参照 (max の代替)。loader 段階で number 値に展開される。 */
+  maxRef?: string;
   step?: number;
   /** 正規表現または `@conv.regex.<key>` 参照。 */
   pattern?: string;

--- a/samples/retail/actions/d63c703c-26ed-4704-8b76-329c6bfae9c9.json
+++ b/samples/retail/actions/d63c703c-26ed-4704-8b76-329c6bfae9c9.json
@@ -256,13 +256,12 @@
         {
           "id": "step-04",
           "kind": "audit",
-          "description": "配送指示操作を監査ログに記録する。担当者 ID と注文情報を含む。操作開始段階なので result は pending。",
+          "description": "配送指示操作を監査ログに記録する。担当者 ID と注文情報を含む。result は省略 (操作完了前のため確定値なし)。",
           "action": "order.dispatch",
           "resource": {
             "type": "order",
             "id": "@inputs.orderId"
           },
-          "result": "pending",
           "reason": "配送指示操作開始 by @sessionUserId"
         },
         {
@@ -280,8 +279,7 @@
           "sla": {
             "timeoutMs": 15000,
             "onTimeout": "throw",
-            "errorCode": "CARRIER_API_FAILED",
-            "responseId": "502-carrier-api-failed"
+            "errorCode": "CARRIER_API_FAILED"
           }
         },
         {

--- a/samples/retail/actions/f81dd9e0-794c-4539-a2a5-9cbcc0a75899.json
+++ b/samples/retail/actions/f81dd9e0-794c-4539-a2a5-9cbcc0a75899.json
@@ -291,10 +291,17 @@
           "tableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab",
           "operation": "SELECT",
           "sql": "SELECT 'ORD-' || EXTRACT(YEAR FROM CURRENT_DATE)::text || '-' || LPAD(nextval('seq_order_number')::text, 6, '0') AS order_number",
-          "outputBinding": { "name": "newOrderNumber", "path": "[0].order_number" },
+          "outputBinding": { "name": "newOrderNumberRows" },
           "lineage": {
             "reads": [{ "tableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab", "purpose": "lookup" }]
           }
+        },
+        {
+          "id": "step-05a",
+          "kind": "compute",
+          "description": "newOrderNumberRows[0].order_number を newOrderNumber に展開する (dbAccess は配列で返るため)。",
+          "expression": "@newOrderNumberRows[0].order_number",
+          "outputBinding": { "name": "newOrderNumber" }
         },
         {
           "id": "step-06",

--- a/samples/retail/screens/c73fa05c-4a71-4593-800d-b9814e97be83.json
+++ b/samples/retail/screens/c73fa05c-4a71-4593-800d-b9814e97be83.json
@@ -33,12 +33,12 @@
       "direction": "input",
       "required": true,
       "min": 1,
-      "max": 999,
+      "maxRef": "@conv.limit.cartItemMaxQuantity",
       "errorMessages": {
         "required": "数量は必須です。",
         "outOfRange": "数量は 1〜999 の範囲で入力してください。"
       },
-      "description": "S-2 カート追加フォームの数量入力。max=999 は @conv.limit.cartItemMaxQuantity 準拠 (schema 上 max は number 必須のため数値展開)。"
+      "description": "S-2 カート追加フォームの数量入力。maxRef で @conv.limit.cartItemMaxQuantity (999) を参照 (#734)。"
     },
     {
       "id": "cartItemCount",

--- a/schemas/v3/process-flow.v3.schema.json
+++ b/schemas/v3/process-flow.v3.schema.json
@@ -551,6 +551,7 @@
         "max": { "type": "number" },
         "minRef": { "type": "string", "description": "@conv.limit.<key> 参照 (min の代替)。" },
         "maxRef": { "type": "string", "description": "@conv.limit.<key> 参照 (max の代替)。" },
+        "lengthRef": { "type": "string", "description": "@conv.limit.<key> 参照 (length の代替)。loader が integer 値に展開する。" },
         "values": { "type": "array", "items": { "type": "string" } },
         "condition": { "$ref": "common.v3.schema.json#/$defs/ExpressionString" },
         "message": { "type": "string", "description": "違反メッセージ (@conv.msg.<key> 推奨)。" }

--- a/schemas/v3/screen-item.v3.schema.json
+++ b/schemas/v3/screen-item.v3.schema.json
@@ -32,6 +32,10 @@
         "maxLength": { "type": "integer", "minimum": 0 },
         "min": { "type": "number" },
         "max": { "type": "number" },
+        "minLengthRef": { "type": "string", "description": "@conv.limit.<key> 参照 (minLength の代替)。loader が integer 値に展開する。" },
+        "maxLengthRef": { "type": "string", "description": "@conv.limit.<key> 参照 (maxLength の代替)。loader が integer 値に展開する。" },
+        "minRef": { "type": "string", "description": "@conv.limit.<key> 参照 (min の代替)。loader が number 値に展開する。" },
+        "maxRef": { "type": "string", "description": "@conv.limit.<key> 参照 (max の代替)。loader が number 値に展開する。" },
         "step": { "type": "number" },
         "pattern": { "type": "string", "description": "正規表現または @conv.regex.<key> 参照。" },
         "options": {


### PR DESCRIPTION
## 関連

- Closes #734
- 仕様: ISSUE #734 本文 + 設計コメント (#734#issuecomment-4363660540)
- 設計者承認: ISSUE #734 本文「案 C 採用 (2026-05-02)」

## 概要

画面項目定義 (`screen-item.v3`) に 4 つの Ref フィールド (`minLengthRef` / `maxLengthRef` / `minRef` / `maxRef`) を追加し、処理フロー (`process-flow.v3`) の ValidationRule に `lengthRef` を追加する。これにより `@conv.limit.<key>` 参照で規約カタログの数値を間接参照でき、マジックナンバーの排除と変更一元管理が実現できる。

## 主な変更

- **Layer 1 — schema**: `schemas/v3/screen-item.v3.schema.json` に 4 フィールド、`schemas/v3/process-flow.v3.schema.json` ValidationRule に `lengthRef` 追加
- **Layer 2 — TS 型**: `designer/src/types/v3/screen-item.ts` ScreenItem interface に 4 フィールド、`designer/src/types/v3/process-flow.ts` ValidationRule に `lengthRef` 追加
- **Layer 3 — conventionsValidator**: `checkScreenItemConventionReferences` で `minLengthRef / maxLengthRef / minRef / maxRef` の `@conv.limit.<key>` 参照存在検査を追加。`checkStep` の `validation` ブロックで `rules[].minRef / maxRef / lengthRef` も検査対象化
- **Layer 4 — resolver**: `designer/src/schemas/screenItemRefResolver.ts` 新規作成。`resolveScreenItemRefs(item, conventions)` が `@conv.limit.<key>` を catalog 値 (number) に解決し plain フィールドに展開する pure helper。validate-samples.ts の `checkScreenItemFieldTypeConsistency` 呼び出し前に適用
- **Layer 5 — tests**: `screenItemRefResolver.test.ts` (15 件新規)、`conventionsValidator.test.ts` (#734 screen-item ブロック 8 件 + checkStep ブロック 3 件 = 11 件追加)、`process-flow.schema.test.ts` (v3 ValidationRule.lengthRef 2 件追加)
- **Layer 6 — サンプル**: `samples/retail/screens/c73fa05c-...json` の `addQuantity.max: 999` を `maxRef: "@conv.limit.cartItemMaxQuantity"` に置換 (catalog 確認: `value === 999` 一致)
- **Layer 7 — 吸収修正 (samples-v3 AJV fail 2 件 → 0 件)**:
  - `d63c703c` step-04: `audit.result: "pending"` は schema enum 外 (success/failure のみ) → 削除 + description 整合
  - `d63c703c` step-05: `sla.responseId` は Sla schema 外 (`additionalProperties: false`) → 削除
  - `f81dd9e0` step-05: `outputBinding.path` は OutputBinding schema 外 → `outputBinding.name=newOrderNumberRows` に変更し compute step-05a で配列展開

## 仕様逐条突合 (自己申告)

ISSUE #734 の受入基準に対する実装箇所:

- schema 5 フィールド追加 (screen-item 4 + process-flow 1)
  - `schemas/v3/screen-item.v3.schema.json:35-38` (`minLengthRef / maxLengthRef / minRef / maxRef`)
  - `schemas/v3/process-flow.v3.schema.json:554` (`lengthRef`)
- TS 型 5 フィールド追加
  - `designer/src/types/v3/screen-item.ts:102-109` (4 フィールド)
  - `designer/src/types/v3/process-flow.ts:177` (`lengthRef`)
- conventionsValidator が新 4 Ref フィールドの参照存在を検査
  - `designer/src/schemas/conventionsValidator.ts:357-360` (checkScreenItemConventionReferences 内)
  - `designer/src/schemas/conventionsValidator.ts:318-320` (checkStep 内 rules[].minRef/maxRef/lengthRef)
- screenItemRefResolver.ts 新規 + validate-samples で適用
  - `designer/src/schemas/screenItemRefResolver.ts` (全体)
  - `designer/scripts/validate-samples.ts:444-449` (screensWithRefsResolved 生成と適用)
- vitest 既存破壊なし、新規テスト追加
  - `designer/src/schemas/screenItemRefResolver.test.ts` (15 件)
  - `designer/src/schemas/conventionsValidator.test.ts:569-658` (#734 screen-item ブロック 8 件)
  - `designer/src/schemas/conventionsValidator.test.ts:660-725` (#734 checkStep ブロック 3 件 — review S-1 対応)
  - `designer/src/schemas/process-flow.schema.test.ts:2468-2529` (v3 lengthRef ブロック)
- validate:samples で retail 5/5 pass、errors 0、warnings 増えない
  - 実行結果: `5 / 5 flows passed. All errors resolved (19 warnings remain)` (warnings は既存)
- samples-v3.schema.test.ts: 吸収修正前 2 件 fail → 0 件 (全 45 件 pass)
- retail サンプルで Ref 形式の使用例 1 箇所
  - `samples/retail/screens/c73fa05c-4a71-4593-800d-b9814e97be83.json:36` (`maxRef: "@conv.limit.cartItemMaxQuantity"`)
- schema 変更は上記 5 フィールドのみ
  - `git diff HEAD schemas/` で確認: 5 フィールドのみの差分

## レビューで特に見てほしい箇所

- `screenItemRefResolver.ts` の plain 優先ロジック — `min/max/minLength/maxLength` が `undefined` のときのみ Ref 解決するため、両方記述した場合は plain が勝つ (briefing 仕様通り)。ただし「Ref と plain の混在記述」は意味的に曖昧なので、将来 conventionsValidator で warning 化する候補
- `checkStep` に `r.minRef / r.maxRef / r.lengthRef` を追加したことで、`process-flow.v3` の ValidationRule で Ref フィールドを使った場合も conventionsValidator がキャッチする。ただし `validate-samples.ts` 内の `checkConventionReferences` 経由で流れるため、screen-item と同じ `@conv.limit` 実装で正しく動作する
- 吸収修正 (Layer 7) により `samples-v3.schema.test.ts` の 2 件 fail を本 PR で解消 (`d63c703c` audit.result + sla.responseId、`f81dd9e0` outputBinding.path)

## テスト

- Vitest: 1393 件 (新規 28 件) — screenItemRefResolver / conventionsValidator #734 ブロック / process-flow.v3.schema.json lengthRef (吸収修正後: samples-v3 2 fail → 0) / checkStep rules Ref テスト 3 件 (review S-1)
- Playwright: N/A (UI 変更なし)
- MCP E2E: N/A

## UI 影響 / AI smoke test

- [x] UI 影響なし (auto テスト pass のみ)

### UI 影響ありの場合、AI smoke test で確認した項目

N/A

## spec 側の不足点 / 提案

- process-flow.v3 の ValidationRule に既存 `minRef / maxRef` があったが、`lengthRef` は存在しなかった。今回 5 フィールド目として追加 (ISSUE スコープ内の設計者承認済み変更)。
- `resolveScreenItemRefs` 相当の resolver が process-flow.v3 側には未実装。validate-samples.ts で screen-item 側のみ適用し、process-flow 側は conventionsValidator で文字列としての参照存在検査のみ。将来の後続 ISSUE 候補として PR description に明記 (Opus briefing 設計メモと同じ判断)。

## レビュー担当への申し送り

- 本 ISSUE は設計者承認済みの schema 改修 (#511 schema governance 対象)。`schemas/v3/` の変更は 5 フィールドのみで超過なし
- `checkScreenItemConventionReferences` は validate-samples.ts に未統合 (ScreenItemsView の UI 専用)。Ref フィールドの参照存在はこの PR では validate-samples 経由では検査されない点を確認してほしい (briefing の Layer 3/4 の役割分担通り)
- retail サンプル変更後の AJV 検証: `samples-v3.schema.test.ts` で c73fa05c が pass していることを確認済み (maxRef フィールドが additionalProperties: false を通過)