### PR TITLE
improve(validator): conventionsValidator.checkStep で rules[].patternRef を検査対象に追加 (#737)

### DIFF
--- a/designer/src/schemas/conventionsValidator.test.ts
+++ b/designer/src/schemas/conventionsValidator.test.ts
@@ -664,6 +664,7 @@ describe("#734 checkStep — validation rules[].minRef/maxRef/lengthRef 検査",
     limit: {
       cartItemMaxQuantity: { value: 999, unit: "integer" },
     },
+    regex: {},
   };
 
   it("rules[].lengthRef が未登録 → UNKNOWN_CONV_LIMIT 検出 (#734 review S-1)", () => {
@@ -721,6 +722,25 @@ describe("#734 checkStep — validation rules[].minRef/maxRef/lengthRef 検査",
     const hit = issues.find((i) => i.path === "actions[0].steps[0].rules[0].maxRef");
     expect(hit).toBeDefined();
     expect(hit?.code).toBe("UNKNOWN_CONV_LIMIT");
+  });
+
+  it("rules[].patternRef が未登録 → UNKNOWN_CONV_REGEX 検出", () => {
+    const issues = checkConventionReferences(
+      makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [{
+            id: "s1", kind: "validation", description: "", conditions: "",
+            rules: [{ field: "x", type: "pattern", message: "エラー", patternRef: "@conv.regex.unknownKey" }],
+          }],
+        }],
+      }),
+      catalog,
+    );
+    expect(issues.length).toBeGreaterThanOrEqual(1);
+    const hit = issues.find((i) => i.path === "actions[0].steps[0].rules[0].patternRef");
+    expect(hit).toBeDefined();
+    expect(hit?.code).toBe("UNKNOWN_CONV_REGEX");
   });
 });
 

--- a/designer/src/schemas/conventionsValidator.ts
+++ b/designer/src/schemas/conventionsValidator.ts
@@ -318,6 +318,7 @@ function checkStep(step: Step, path: string, catalog: ConventionsCatalog, issues
         if (r.minRef) texts.push({ src: r.minRef, field: `rules[${ri}].minRef` });
         if (r.maxRef) texts.push({ src: r.maxRef, field: `rules[${ri}].maxRef` });
         if (r.lengthRef) texts.push({ src: r.lengthRef, field: `rules[${ri}].lengthRef` });
+        if (r.patternRef) texts.push({ src: r.patternRef, field: `rules[${ri}].patternRef` });
       });
       if (step.inlineBranch?.ngBodyExpression) {
         texts.push({ src: step.inlineBranch.ngBodyExpression, field: "inlineBranch.ngBodyExpression" });


### PR DESCRIPTION
## 関連

- Closes #737
- 仕様: N/A (validator 内部実装、spec 定義なし)

## 概要

PR #735 (#734) の独立レビューで検出された pre-existing gap を解消する。
`checkStep` 内の `rules[]` Ref フィールド検査で `patternRef` のみが `minRef / maxRef / lengthRef` と非対称な状態だった。
`@conv.regex.<key>` の未登録参照を validator が検出できない状態を修正する。

## 主な変更

- validator 拡張: `conventionsValidator.ts` の `checkStep` 内 `rules[]` forEach に `r.patternRef` の検査 1 行を追加 (`conventionsValidator.ts:321`)
- テスト追加: `conventionsValidator.test.ts` の `#734 checkStep — validation rules[].minRef/maxRef/lengthRef 検査` describe に `patternRef` 未登録 → `UNKNOWN_CONV_REGEX` 検出テスト 1 件を追加

## 仕様逐条突合 (自己申告)

ISSUE #737 受入基準との照合:

- [x] `conventionsValidator.ts` の `checkStep` 内 `forEach` に `r.patternRef` 検査 1 行追加 → `conventionsValidator.ts:321` ✓
- [x] `conventionsValidator.test.ts` に `patternRef` 未登録 → `UNKNOWN_CONV_REGEX` 検出テスト追加 (1 件) → `conventionsValidator.test.ts:726-743` ✓
- [x] `cd designer && npx vitest run` で全 pass (1394 tests) ✓
- [x] `npm run validate:samples -- ../samples/retail` で 5/5 pass、errors 0 ✓

## レビューで特に見てほしい箇所

- カタログに `regex: {}` を追加したこと: describe block のカタログが `limit` のみだったため `resolveCategory(catalog, "regex")` が null を返し `UNKNOWN_CONV_CATEGORY` になっていた。`regex: {}` を追加してカテゴリを認識させ、未知 key に対して `UNKNOWN_CONV_REGEX` を返す正常経路に乗せた。

## テスト

- Vitest: 1394 件 (新規 1 件) — `#737 rules[].patternRef が未登録 → UNKNOWN_CONV_REGEX 検出`
- Playwright: N/A (validator のみ変更)
- MCP E2E: N/A

## UI 影響 / AI smoke test

- [x] UI 影響なし (auto テスト pass のみ)

### UI 影響ありの場合、AI smoke test で確認した項目

N/A

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

規模小 (validator 1 行 + テスト 1 件) のため independent review 省略 (Opus orchestrator 判断)。