### PR TITLE
fix(validator): sqlOrderValidator で loop step の collectionItemName を boundVars 登録 (#729)

### DIFF
--- a/designer/src/schemas/sqlOrderValidator.test.ts
+++ b/designer/src/schemas/sqlOrderValidator.test.ts
@@ -2113,3 +2113,186 @@ describe("観点 5: TX_CIRCULAR_DEPENDENCY", () => {
     expect(target[0].severity).toBe("warning");
   });
 });
+
+// ─── 観点 1+2: loop step の collectionItemName を boundVars 登録 (#729) ──────
+
+describe("loop step collectionItemName boundVars 登録 (#729)", () => {
+  const tables: OrderTableDefinition[] = [
+    makeTable("tbl-orders", "orders", [
+      { physicalName: "id", notNull: true, autoIncrement: true, primaryKey: true },
+      { physicalName: "user_id", notNull: true },
+    ]),
+    makeTable(
+      "tbl-order-items",
+      "order_items",
+      [
+        { physicalName: "id", notNull: true, autoIncrement: true, primaryKey: true },
+        { physicalName: "order_id", notNull: true },
+        { physicalName: "product_id", notNull: true },
+      ],
+      [{ columnPhysicalNames: ["order_id"], referencedTableId: "tbl-orders" }],
+    ),
+  ];
+
+  it("ケース 1: ループ inner INSERT で @<itemName>.<field> 参照 → false positive なし", () => {
+    // collectionItemName = "item" をループ内 INSERT で参照
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "注文登録",
+          trigger: "submit",
+          inputs: [
+            { name: "cartItems", type: "string", required: true },
+            { name: "newOrder", type: "string", required: true },
+          ],
+          steps: [
+            {
+              id: "step-01",
+              kind: "dbAccess",
+              description: "orders に INSERT",
+              tableId: "tbl-orders",
+              operation: "INSERT",
+              sql: "INSERT INTO orders (user_id) VALUES (@newOrder.user_id)",
+            },
+            {
+              id: "step-loop",
+              kind: "loop",
+              description: "カートアイテムをループ",
+              loopKind: "collection",
+              collectionSource: "@cartItems",
+              collectionItemName: "item",
+              steps: [
+                {
+                  id: "step-loop-a",
+                  kind: "dbAccess",
+                  description: "order_items に INSERT",
+                  tableId: "tbl-order-items",
+                  operation: "INSERT",
+                  // @item.product_id は collectionItemName "item" 由来 → boundVars 登録済みのはず
+                  sql: "INSERT INTO order_items (order_id, product_id) VALUES (@newOrder.id, @item.product_id)",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, tables);
+    const target = issues.filter(
+      (i) => i.code === "NULL_NOT_ALLOWED_AT_INSERT" || i.code === "FK_REFERENCE_NOT_INSERTED",
+    );
+    // @item.product_id は loop collectionItemName により boundVars 登録済み → false positive 発生しない
+    const falsePositive = target.filter((i) => i.message.includes("item"));
+    expect(falsePositive).toHaveLength(0);
+  });
+
+  it("ケース 2: ループ外で @<itemName>.<field> を参照 → scope leak しない (false positive が出る)", () => {
+    // ループ外では "item" は boundVars にない → NOT NULL カラムへの参照は検出されるべき
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "注文登録",
+          trigger: "submit",
+          inputs: [
+            { name: "cartItems", type: "string", required: true },
+          ],
+          steps: [
+            {
+              id: "step-loop",
+              kind: "loop",
+              description: "カートアイテムをループ (中身は何もしない)",
+              loopKind: "collection",
+              collectionSource: "@cartItems",
+              collectionItemName: "item",
+              steps: [
+                {
+                  id: "step-loop-noop",
+                  kind: "compute",
+                  description: "何もしない compute",
+                  expression: "1",
+                },
+              ],
+            },
+            {
+              id: "step-after-loop",
+              kind: "dbAccess",
+              description: "ループ外で @item.product_id を参照 → 未バインド",
+              tableId: "tbl-order-items",
+              operation: "INSERT",
+              // ループ外なので "item" は boundVars にない → NULL_NOT_ALLOWED_AT_INSERT 発生するべき
+              sql: "INSERT INTO order_items (order_id, product_id) VALUES (@inputs.orderId, @item.product_id)",
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, tables);
+    const target = issues.filter((i) => i.code === "NULL_NOT_ALLOWED_AT_INSERT");
+    // @item.product_id はループ外で未バインド → 検出される
+    expect(target.some((i) => i.message.includes("item"))).toBe(true);
+  });
+
+  it("ケース 3: ネスト loop で同名 collectionItemName — 内側終了後も外側スコープが壊れない", () => {
+    // 外側 loop = "x", 内側 loop = "x" → 内側終了後も外側では "x" が有効であること
+    const flow = makeFlow({
+      actions: [
+        {
+          id: "act-001",
+          name: "ネストループテスト",
+          trigger: "submit",
+          inputs: [
+            { name: "outerList", type: "string", required: true },
+            { name: "innerList", type: "string", required: true },
+          ],
+          steps: [
+            {
+              id: "step-outer",
+              kind: "loop",
+              description: "外側ループ",
+              loopKind: "collection",
+              collectionSource: "@outerList",
+              collectionItemName: "x",
+              steps: [
+                {
+                  id: "step-inner",
+                  kind: "loop",
+                  description: "内側ループ (同名 x)",
+                  loopKind: "collection",
+                  collectionSource: "@innerList",
+                  collectionItemName: "x",
+                  steps: [
+                    {
+                      id: "step-inner-noop",
+                      kind: "compute",
+                      description: "何もしない",
+                      expression: "1",
+                    },
+                  ],
+                },
+                // 内側ループ終了後も外側 "x" は有効 → INSERT で @x.product_id が boundVars にある
+                {
+                  id: "step-after-inner",
+                  kind: "dbAccess",
+                  description: "内側ループ後の INSERT — 外側 @x は有効のまま",
+                  tableId: "tbl-order-items",
+                  operation: "INSERT",
+                  sql: "INSERT INTO order_items (order_id, product_id) VALUES (@inputs.orderId, @x.product_id)",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    const issues = checkSqlOrder(flow, tables);
+    const target = issues.filter(
+      (i) =>
+        (i.code === "NULL_NOT_ALLOWED_AT_INSERT" || i.code === "FK_REFERENCE_NOT_INSERTED") &&
+        i.message.includes("x"),
+    );
+    // 外側ループ内 (@x は外側スコープで有効) → false positive なし
+    expect(target).toHaveLength(0);
+  });
+});

--- a/designer/src/schemas/sqlOrderValidator.test.ts
+++ b/designer/src/schemas/sqlOrderValidator.test.ts
@@ -2218,11 +2218,12 @@ describe("loop step collectionItemName boundVars 登録 (#729)", () => {
             {
               id: "step-after-loop",
               kind: "dbAccess",
-              description: "ループ外で @item.product_id を参照 → 未バインド",
+              description: "ループ外で @item.order_id / @item.product_id を参照 → 未バインド",
               tableId: "tbl-order-items",
               operation: "INSERT",
               // ループ外なので "item" は boundVars にない → NULL_NOT_ALLOWED_AT_INSERT 発生するべき
-              sql: "INSERT INTO order_items (order_id, product_id) VALUES (@inputs.orderId, @item.product_id)",
+              // (@inputs は ALWAYS_BOUND のため除外し、@item.* のみで scope leak 検証を明確化)
+              sql: "INSERT INTO order_items (order_id, product_id) VALUES (@item.order_id, @item.product_id)",
             },
           ],
         },

--- a/designer/src/schemas/sqlOrderValidator.ts
+++ b/designer/src/schemas/sqlOrderValidator.ts
@@ -252,10 +252,9 @@ function walkStepsInOrder(
       if (step.elseBranch) walkStepsInOrder(step.elseBranch.steps, `${path}.elseBranch.steps`, visitor, loopHooks);
     }
     if (step.kind === "loop") {
-      const loopStep = step as LoopStep;
-      if (loopHooks) loopHooks.onEnter(loopStep);
+      if (loopHooks) loopHooks.onEnter(step);
       walkStepsInOrder(step.steps, `${path}.steps`, visitor, loopHooks);
-      if (loopHooks) loopHooks.onExit(loopStep);
+      if (loopHooks) loopHooks.onExit(step);
     }
     if (step.kind === "transactionScope") {
       walkStepsInOrder(step.steps, `${path}.steps`, visitor, loopHooks);

--- a/designer/src/schemas/sqlOrderValidator.ts
+++ b/designer/src/schemas/sqlOrderValidator.ts
@@ -31,7 +31,7 @@
  */
 
 import { Parser } from "node-sql-parser";
-import type { ProcessFlow, Step, TransactionScopeStep } from "../types/v3";
+import type { ProcessFlow, LoopStep, Step, TransactionScopeStep } from "../types/v3";
 import { isBuiltinStep } from "./stepGuards";
 
 // ─── 入力型: テーブル定義 (v3 形式) ────────────────────────────────────────
@@ -238,6 +238,7 @@ function walkStepsInOrder(
   steps: Step[],
   basePath: string,
   visitor: (step: Step, path: string) => void,
+  loopHooks?: { onEnter: (loop: LoopStep) => void; onExit: (loop: LoopStep) => void },
 ): void {
   for (let i = 0; i < steps.length; i++) {
     const step = steps[i];
@@ -246,29 +247,34 @@ function walkStepsInOrder(
     if (!isBuiltinStep(step)) continue;
     if (step.kind === "branch") {
       step.branches.forEach((b, bi) =>
-        walkStepsInOrder(b.steps, `${path}.branches[${bi}].steps`, visitor),
+        walkStepsInOrder(b.steps, `${path}.branches[${bi}].steps`, visitor, loopHooks),
       );
-      if (step.elseBranch) walkStepsInOrder(step.elseBranch.steps, `${path}.elseBranch.steps`, visitor);
+      if (step.elseBranch) walkStepsInOrder(step.elseBranch.steps, `${path}.elseBranch.steps`, visitor, loopHooks);
     }
-    if (step.kind === "loop") walkStepsInOrder(step.steps, `${path}.steps`, visitor);
+    if (step.kind === "loop") {
+      const loopStep = step as LoopStep;
+      if (loopHooks) loopHooks.onEnter(loopStep);
+      walkStepsInOrder(step.steps, `${path}.steps`, visitor, loopHooks);
+      if (loopHooks) loopHooks.onExit(loopStep);
+    }
     if (step.kind === "transactionScope") {
-      walkStepsInOrder(step.steps, `${path}.steps`, visitor);
-      if (step.onCommit) walkStepsInOrder(step.onCommit, `${path}.onCommit`, visitor);
-      if (step.onRollback) walkStepsInOrder(step.onRollback, `${path}.onRollback`, visitor);
+      walkStepsInOrder(step.steps, `${path}.steps`, visitor, loopHooks);
+      if (step.onCommit) walkStepsInOrder(step.onCommit, `${path}.onCommit`, visitor, loopHooks);
+      if (step.onRollback) walkStepsInOrder(step.onRollback, `${path}.onRollback`, visitor, loopHooks);
     }
     if (step.kind === "externalSystem") {
       Object.entries(step.outcomes ?? {}).forEach(([k, spec]) => {
-        if (spec?.sideEffects) walkStepsInOrder(spec.sideEffects, `${path}.outcomes.${k}.sideEffects`, visitor);
+        if (spec?.sideEffects) walkStepsInOrder(spec.sideEffects, `${path}.outcomes.${k}.sideEffects`, visitor, loopHooks);
       });
     }
     if (step.kind === "workflow") {
-      if (step.onApproved) walkStepsInOrder(step.onApproved, `${path}.onApproved`, visitor);
-      if (step.onRejected) walkStepsInOrder(step.onRejected, `${path}.onRejected`, visitor);
-      if (step.onTimeout) walkStepsInOrder(step.onTimeout, `${path}.onTimeout`, visitor);
+      if (step.onApproved) walkStepsInOrder(step.onApproved, `${path}.onApproved`, visitor, loopHooks);
+      if (step.onRejected) walkStepsInOrder(step.onRejected, `${path}.onRejected`, visitor, loopHooks);
+      if (step.onTimeout) walkStepsInOrder(step.onTimeout, `${path}.onTimeout`, visitor, loopHooks);
     }
     if (step.kind === "validation" && step.inlineBranch) {
-      walkStepsInOrder(step.inlineBranch.ok, `${path}.inlineBranch.ok`, visitor);
-      walkStepsInOrder(step.inlineBranch.ng, `${path}.inlineBranch.ng`, visitor);
+      walkStepsInOrder(step.inlineBranch.ok, `${path}.inlineBranch.ok`, visitor, loopHooks);
+      walkStepsInOrder(step.inlineBranch.ng, `${path}.inlineBranch.ng`, visitor, loopHooks);
     }
   }
 }
@@ -736,6 +742,10 @@ function checkAction(
   const deletedTableIds = new Set<string>();
   // 観点 3: INSERT より前に見た SELECT の WHERE カラム集合 (テーブル物理名 → カラム集合)
   const priorSelectWhereColumnsByTable = new Map<string, Set<string>>();
+  // loop step の collectionItemName を scope 管理するスタック
+  // push: ループ開始時に name を登録 (既存なら null を push してスコープ変更なし)
+  // pop: ループ終了時に登録した name を boundVars から削除
+  const loopScopeStack: Array<string | null> = [];
 
   // 平坦化した step のシーケンスを順走査
   // (branch 内部は楽観的に両パスを走査してバインドを union する — 保守的な偽陽性抑止)
@@ -1007,6 +1017,21 @@ function checkAction(
       const metaById = tableIdIndex.get(tableIdRef);
       if (metaById) insertedTableIds.add(metaById.id);
     }
+  }, {
+    onEnter: (loop) => {
+      const name = loop.collectionItemName;
+      if (name && !boundVars.has(name)) {
+        boundVars.add(name);
+        loopScopeStack.push(name);
+      } else {
+        // 既に boundVars に存在する (ネスト同名ループ等) → 追加しない
+        loopScopeStack.push(null);
+      }
+    },
+    onExit: () => {
+      const popped = loopScopeStack.pop();
+      if (popped) boundVars.delete(popped);
+    },
   });
 }
 

--- a/samples/retail/actions/f81dd9e0-794c-4539-a2a5-9cbcc0a75899.json
+++ b/samples/retail/actions/f81dd9e0-794c-4539-a2a5-9cbcc0a75899.json
@@ -366,7 +366,6 @@
               "loopKind": "collection",
               "collectionSource": "@cartItems",
               "collectionItemName": "cartItem",
-              "outputBinding": { "name": "cartItem" },
               "steps": [
                 {
                   "id": "step-06-03-a",


### PR DESCRIPTION
## Summary

- `walkStepsInOrder` に `loopHooks` (`onEnter`/`onExit`) を追加し、`checkAction` 側で `loopScopeStack` を使った push/pop により、ループ内 SQL の `@<itemName>.<field>` 参照が boundVars 既知として処理されるようにした
- retail サンプル `f81dd9e0` step-06-03 の シャドウイング workaround `outputBinding: { name: "cartItem" }` を削除
- vitest テストに collectionItemName 解析ケース 3 件を追加

## 仕様逐条突合 (自己申告)

- [x] `sqlOrderValidator` がループ step の `collectionItemName` を boundVars に登録する — `designer/src/schemas/sqlOrderValidator.ts:241` (loopHooks シグネチャ) / `748` (loopScopeStack 宣言) / `1021` (onEnter 実装)
- [x] ループ inner SQL の `@<itemName>.<field>` 参照が boundVars 既知として処理 — `designer/src/schemas/sqlOrderValidator.ts:256` (onEnter 呼び出し)
- [x] retail サンプルから シャドウイング workaround 削除 — `samples/retail/actions/f81dd9e0-794c-4539-a2a5-9cbcc0a75899.json:368` (collectionItemName のみ残存、outputBinding 削除済み)
- [x] `npm run validate:samples` 0 errors — Test plan 参照
- [x] vitest テスト追加 — `designer/src/schemas/sqlOrderValidator.test.ts:2119` から 3 ケース

## Test plan

- [x] npm run lint — pass (0 errors、既存 warnings のみ)
- [x] npm run build — pass
- [x] npx vitest run src/schemas/sqlOrderValidator.test.ts — pass (50 tests、新規 3 ケース含む)
- [x] npm run validate:samples -- ../samples/retail — 0 errors (warnings 19 件は既存)

Closes #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)