### PR TITLE
feat(ui): ViewDefinitionEditor を 3 レベル DSL 編集対応に拡張 (#748)

### DIFF
--- a/designer/src/components/view-definition/ViewDefinitionEditor.tsx
+++ b/designer/src/components/view-definition/ViewDefinitionEditor.tsx
@@ -1,12 +1,14 @@
 /**
- * ViewDefinitionEditor — ビュー定義編集画面 (#666 S5)
+ * ViewDefinitionEditor — ビュー定義編集画面 (#666 S5 / #748 で 3 レベル DSL 編集対応)
  *
- * 5 セクション構成:
- *  1. 基本情報 (id / name / physicalName / description / kind / sourceTableId)
- *  2. columns 編集テーブル (TableEditor のカラム編集パターンを参考)
- *  3. sortDefaults 編集テーブル
- *  4. filterDefaults 編集テーブル
- *  5. その他 (pageSize / groupBy)
+ * 6 セクション構成:
+ *  1. 基本情報 (id / name / description / kind / Level 切替 / maturity)
+ *  2. Query — Level 1 (sourceTableId) / Level 2 (Structured: from + joins + where/...) /
+ *             Level 3 (Raw SQL: sql + parameterRefs)
+ *  3. columns 編集テーブル (Level に応じて tableColumnRef 列を切替)
+ *  4. sortDefaults 編集テーブル
+ *  5. filterDefaults 編集テーブル
+ *  6. その他 (pageSize / groupBy)
  *
  * リアルタイム validator: checkViewDefinition() の結果を各フィールドの隣に inline 表示。
  */
@@ -21,6 +23,10 @@ import type {
   FilterSpec,
   FilterOperator,
   BuiltinViewDefinitionKind,
+  ViewQueryStructured,
+  ViewQueryRawSql,
+  ViewQueryJoin,
+  ViewQueryParameterRef,
 } from "../../types/v3/view-definition";
 import type { Table, TableEntry, Maturity, Identifier, FieldType, FieldTypePrimitive } from "../../types/v3";
 import type { TableId, LocalId } from "../../types/v3/common";
@@ -67,6 +73,23 @@ const KIND_LABELS: Record<BuiltinViewDefinitionKind, string> = {
   detail: "detail — 詳細",
   kanban: "kanban — カンバン",
   calendar: "calendar — カレンダー",
+};
+
+// ─── Level 検出 + 切替ヘルパー (#748、3 レベル DSL UI 対応) ───────────────
+// テスト容易性のため別 module に切り出し済み (viewDefinitionLevels.ts)。
+import {
+  detectLevel,
+  migrateToLevel,
+  suggestAlias,
+  type ViewLevel,
+} from "./viewDefinitionLevels";
+
+const JOIN_KIND_OPTIONS: ViewQueryJoin["kind"][] = ["INNER", "LEFT", "RIGHT", "FULL"];
+
+const LEVEL_LABELS: Record<ViewLevel, string> = {
+  1: "Level 1 — Simple (1 テーブル)",
+  2: "Level 2 — Structured (joins + where)",
+  3: "Level 3 — Raw SQL (CTE / window 等)",
 };
 
 // ─── useTablesForValidator hook ───────────────────────────────────────────────
@@ -293,6 +316,37 @@ export function ViewDefinitionEditor() {
   const tableOptions = useTableOptions();
 
 
+  // 現在の Level (#748)
+  const currentLevel: ViewLevel = useMemo<ViewLevel>(() => {
+    return viewDefinition ? detectLevel(viewDefinition) : 1;
+  }, [viewDefinition]);
+
+  // Level 2 で利用可能なテーブル + alias 一覧 (columns の tableColumnRef 選択肢生成用)
+  // 各 entry = { tableId, alias, label } を返す。Level 1/3 では空配列 (UI 側で別経路を使う)。
+  const inScopeTables = useMemo<Array<{ tableId: string; alias: string; label: string; tableName: string }>>(() => {
+    if (!viewDefinition || currentLevel !== 2) return [];
+    const sq = viewDefinition.query as ViewQueryStructured | undefined;
+    if (!sq?.from) return [];
+    const out: Array<{ tableId: string; alias: string; label: string; tableName: string }> = [];
+    const fromTblName = tableOptions.find((t) => t.id === (sq.from.tableId as string))?.name ?? sq.from.tableId;
+    out.push({
+      tableId: sq.from.tableId as string,
+      alias: sq.from.alias,
+      label: `${sq.from.alias}: ${fromTblName}`,
+      tableName: fromTblName,
+    });
+    for (const j of sq.joins ?? []) {
+      const tName = tableOptions.find((t) => t.id === (j.tableId as string))?.name ?? (j.tableId as string);
+      out.push({
+        tableId: j.tableId as string,
+        alias: j.alias,
+        label: `${j.alias}: ${tName} (${j.kind} JOIN)`,
+        tableName: tName,
+      });
+    }
+    return out;
+  }, [viewDefinition, currentLevel, tableOptions]);
+
   // リアルタイム validator
   const issues = useMemo<ViewDefinitionIssue[]>(() => {
     if (!viewDefinition) return [];
@@ -348,19 +402,36 @@ export function ViewDefinitionEditor() {
   // ─── columns 操作 ──────────────────────────────────────────────────────────
 
   const addColumn = () => {
-    const newCol: ViewColumn = {
-      name: "" as Identifier,
-      tableColumnRef: {
-        // Level 1 想定: sourceTableId が undefined のときは空文字で初期化 (#745)。
-        tableId: ((viewDefinition.sourceTableId as string | undefined) ?? "") as TableId,
-        columnId: "" as LocalId,
-      },
-      type: "string" as FieldTypePrimitive,
-    };
+    // Level 別の初期 tableColumnRef:
+    //  Level 1: sourceTableId
+    //  Level 2: query.from.tableId (最初の in-scope テーブル)
+    //  Level 3: tableColumnRef は不要 (省略)
+    let initialTableId = "";
+    if (currentLevel === 1) {
+      initialTableId = (viewDefinition.sourceTableId as string | undefined) ?? "";
+    } else if (currentLevel === 2) {
+      const sq = viewDefinition.query as ViewQueryStructured | undefined;
+      initialTableId = (sq?.from?.tableId as string | undefined) ?? "";
+    }
+
+    const newCol: ViewColumn =
+      currentLevel === 3
+        ? {
+            name: "" as Identifier,
+            type: "string" as FieldTypePrimitive,
+          }
+        : {
+            name: "" as Identifier,
+            tableColumnRef: {
+              tableId: initialTableId as TableId,
+              columnId: "" as LocalId,
+            },
+            type: "string" as FieldTypePrimitive,
+          };
     updateWithDraft((d) => { d.columns = [...(d.columns ?? []), newCol]; });
     setColRefTableIds((prev) => ({
       ...prev,
-      [viewDefinition.columns.length]: (viewDefinition.sourceTableId as string | undefined) ?? "",
+      [viewDefinition.columns.length]: initialTableId,
     }));
   };
 
@@ -651,21 +722,35 @@ export function ViewDefinitionEditor() {
                 </div>
               </div>
 
-              {/* ソーステーブル */}
+              {/* Level 切替 (#748、3 レベル DSL) */}
               <div className="tbl-field">
-                <span>ソーステーブル <span className="vd-editor-required">*</span></span>
-                <select
-                  value={viewDefinition.sourceTableId}
-                  onChange={(e) => updateWithDraft((d) => { d.sourceTableId = e.target.value as TableId; })}
-                  className={getIssues(`ViewDefinition[${vdId}].sourceTableId`).length > 0 ? "input-error" : undefined}
-                  disabled={isReadonly}
-                >
-                  <option value="">— テーブルを選択 —</option>
-                  {tableOptions.map((t) => (
-                    <option key={t.id} value={t.id}>{t.name}</option>
+                <span>クエリ Level <span className="vd-editor-required">*</span></span>
+                <div className="vd-editor-level-row">
+                  {([1, 2, 3] as ViewLevel[]).map((lv) => (
+                    <label key={lv} className="vd-editor-level-radio" title={LEVEL_LABELS[lv]}>
+                      <input
+                        type="radio"
+                        name="vd-level"
+                        checked={currentLevel === lv}
+                        onChange={() => {
+                          if (currentLevel === lv || isReadonly) return;
+                          const tableName = (id: string) =>
+                            tableOptions.find((t) => t.id === id)?.name;
+                          updateWithDraft((d) => {
+                            const migrated = migrateToLevel(d, lv, tableName);
+                            d.sourceTableId = migrated.sourceTableId;
+                            d.query = migrated.query;
+                          });
+                        }}
+                        disabled={isReadonly}
+                      />
+                      {" "}{LEVEL_LABELS[lv]}
+                    </label>
                   ))}
-                </select>
-                <IssueHints issues={getIssues(`ViewDefinition[${vdId}].sourceTableId`)} />
+                </div>
+                <small className="vd-editor-level-hint">
+                  Level 切替時は <code>sourceTableId</code> と <code>query</code> が排他的に書き換わります (既存の columns / sort / filter は維持)。
+                </small>
               </div>
 
               {/* 成熟度 */}
@@ -686,7 +771,372 @@ export function ViewDefinitionEditor() {
             </div>
           </section>
 
-          {/* ───── Section 2: columns 編集 ────────────────────────────────── */}
+          {/* ───── Section 2: Query (Level 別) (#748) ──────────────────────── */}
+          <section className="seq-editor-section">
+            <h3 className="seq-editor-section-title">
+              クエリ <small className="vd-editor-level-tag">{LEVEL_LABELS[currentLevel]}</small>
+            </h3>
+
+            {currentLevel === 1 && (
+              <div className="seq-editor-grid">
+                <div className="tbl-field">
+                  <span>ソーステーブル <span className="vd-editor-required">*</span></span>
+                  <select
+                    value={(viewDefinition.sourceTableId as string | undefined) ?? ""}
+                    onChange={(e) => updateWithDraft((d) => { d.sourceTableId = e.target.value as TableId; })}
+                    className={getIssues(`ViewDefinition[${vdId}].sourceTableId`).length > 0 ? "input-error" : undefined}
+                    disabled={isReadonly}
+                  >
+                    <option value="">— テーブルを選択 —</option>
+                    {tableOptions.map((t) => (
+                      <option key={t.id} value={t.id}>{t.name}</option>
+                    ))}
+                  </select>
+                  <IssueHints issues={getIssues(`ViewDefinition[${vdId}].sourceTableId`)} />
+                </div>
+              </div>
+            )}
+
+            {currentLevel === 2 && (() => {
+              const sq = (viewDefinition.query as ViewQueryStructured | undefined) ?? {
+                from: { tableId: "" as TableId, alias: "a" },
+              };
+              const fromIssuePath = `ViewDefinition[${vdId}].query.from.tableId`;
+              return (
+                <div className="vd-query-structured">
+                  {/* FROM */}
+                  <div className="vd-query-row">
+                    <span className="vd-query-label">FROM</span>
+                    <select
+                      value={(sq.from?.tableId as string | undefined) ?? ""}
+                      onChange={(e) => updateWithDraft((d) => {
+                        const cur = (d.query as ViewQueryStructured | undefined) ?? { from: { tableId: "" as TableId, alias: "a" } };
+                        d.query = { ...cur, from: { ...cur.from, tableId: e.target.value as TableId } };
+                      })}
+                      className={getIssues(fromIssuePath).length > 0 ? "input-error" : undefined}
+                      disabled={isReadonly}
+                    >
+                      <option value="">— テーブル —</option>
+                      {tableOptions.map((t) => (
+                        <option key={t.id} value={t.id}>{t.name}</option>
+                      ))}
+                    </select>
+                    <span className="vd-query-as">AS</span>
+                    <input
+                      type="text"
+                      value={sq.from?.alias ?? ""}
+                      onChange={(e) => updateSilentWithDraft((d) => {
+                        const cur = (d.query as ViewQueryStructured | undefined) ?? { from: { tableId: "" as TableId, alias: "" } };
+                        d.query = { ...cur, from: { ...cur.from, alias: e.target.value } };
+                      })}
+                      onBlur={() => { if (!isReadonly) commit(); }}
+                      placeholder="alias"
+                      className="vd-query-alias-input"
+                      pattern="^[a-z][a-z0-9_]*$"
+                      title="snake_case (^[a-z][a-z0-9_]*$)"
+                      disabled={isReadonly}
+                    />
+                  </div>
+                  <IssueHints issues={getIssues(fromIssuePath)} />
+
+                  {/* JOINS */}
+                  <div className="vd-query-block">
+                    <div className="vd-query-block-title">JOINS</div>
+                    {(sq.joins ?? []).map((j, ji) => {
+                      const joinIssuePath = `ViewDefinition[${vdId}].query.joins[${ji}].tableId`;
+                      const aliasIssuePath = `ViewDefinition[${vdId}].query.joins[${ji}].alias`;
+                      return (
+                        <div key={ji} className="vd-query-join-row">
+                          <select
+                            value={j.kind}
+                            onChange={(e) => updateWithDraft((d) => {
+                              const cur = d.query as ViewQueryStructured;
+                              const joins = [...(cur.joins ?? [])];
+                              joins[ji] = { ...joins[ji], kind: e.target.value as ViewQueryJoin["kind"] };
+                              d.query = { ...cur, joins };
+                            })}
+                            disabled={isReadonly}
+                          >
+                            {JOIN_KIND_OPTIONS.map((k) => (
+                              <option key={k} value={k}>{k}</option>
+                            ))}
+                          </select>
+                          <span className="vd-query-as">JOIN</span>
+                          <select
+                            value={(j.tableId as string | undefined) ?? ""}
+                            onChange={(e) => updateWithDraft((d) => {
+                              const cur = d.query as ViewQueryStructured;
+                              const joins = [...(cur.joins ?? [])];
+                              joins[ji] = { ...joins[ji], tableId: e.target.value as TableId };
+                              d.query = { ...cur, joins };
+                            })}
+                            className={getIssues(joinIssuePath).length > 0 ? "input-error" : undefined}
+                            disabled={isReadonly}
+                          >
+                            <option value="">— テーブル —</option>
+                            {tableOptions.map((t) => (
+                              <option key={t.id} value={t.id}>{t.name}</option>
+                            ))}
+                          </select>
+                          <span className="vd-query-as">AS</span>
+                          <input
+                            type="text"
+                            value={j.alias}
+                            onChange={(e) => updateSilentWithDraft((d) => {
+                              const cur = d.query as ViewQueryStructured;
+                              const joins = [...(cur.joins ?? [])];
+                              joins[ji] = { ...joins[ji], alias: e.target.value };
+                              d.query = { ...cur, joins };
+                            })}
+                            onBlur={() => { if (!isReadonly) commit(); }}
+                            placeholder="alias"
+                            className={`vd-query-alias-input${getIssues(aliasIssuePath).length > 0 ? " input-error" : ""}`}
+                            disabled={isReadonly}
+                          />
+                          <span className="vd-query-as">ON</span>
+                          <div className="vd-query-on-list">
+                            {j.on.map((cond, oi) => (
+                              <input
+                                key={oi}
+                                type="text"
+                                value={cond}
+                                onChange={(e) => updateSilentWithDraft((d) => {
+                                  const cur = d.query as ViewQueryStructured;
+                                  const joins = [...(cur.joins ?? [])];
+                                  const on = [...(joins[ji].on ?? [])];
+                                  on[oi] = e.target.value;
+                                  joins[ji] = { ...joins[ji], on };
+                                  d.query = { ...cur, joins };
+                                })}
+                                onBlur={() => { if (!isReadonly) commit(); }}
+                                placeholder="o.customer_id = c.id"
+                                className="vd-query-fragment-input"
+                                disabled={isReadonly}
+                              />
+                            ))}
+                            <button
+                              type="button"
+                              className="tbl-btn-icon"
+                              onClick={() => updateWithDraft((d) => {
+                                const cur = d.query as ViewQueryStructured;
+                                const joins = [...(cur.joins ?? [])];
+                                const on = [...(joins[ji].on ?? []), ""];
+                                joins[ji] = { ...joins[ji], on };
+                                d.query = { ...cur, joins };
+                              })}
+                              disabled={isReadonly}
+                              title="ON 条件追加 (AND 結合)"
+                            >
+                              <i className="bi bi-plus-lg" />
+                            </button>
+                          </div>
+                          <button
+                            type="button"
+                            className="tbl-btn-icon danger"
+                            onClick={() => updateWithDraft((d) => {
+                              const cur = d.query as ViewQueryStructured;
+                              const joins = (cur.joins ?? []).filter((_, i) => i !== ji);
+                              d.query = { ...cur, joins: joins.length ? joins : undefined };
+                            })}
+                            disabled={isReadonly}
+                            title="JOIN 削除"
+                          >
+                            <i className="bi bi-trash" />
+                          </button>
+                          <IssueHints issues={[...getIssues(joinIssuePath), ...getIssues(aliasIssuePath)]} />
+                        </div>
+                      );
+                    })}
+                    <button
+                      type="button"
+                      className="tbl-btn tbl-btn-ghost"
+                      onClick={() => updateWithDraft((d) => {
+                        const cur = (d.query as ViewQueryStructured | undefined) ?? { from: { tableId: "" as TableId, alias: "a" } };
+                        const usedAliases = new Set<string>([cur.from?.alias ?? ""]);
+                        (cur.joins ?? []).forEach((j) => usedAliases.add(j.alias));
+                        const newJoin: ViewQueryJoin = {
+                          kind: "INNER",
+                          tableId: "" as TableId,
+                          alias: suggestAlias(undefined, usedAliases),
+                          on: [""],
+                        };
+                        d.query = { ...cur, joins: [...(cur.joins ?? []), newJoin] };
+                      })}
+                      disabled={isReadonly}
+                    >
+                      <i className="bi bi-plus-lg" /> JOIN 追加
+                    </button>
+                  </div>
+
+                  {/* WHERE / GROUP BY / HAVING / ORDER BY */}
+                  {(["where", "groupBy", "having", "orderBy"] as const).map((kw) => {
+                    const items = (sq[kw] ?? []) as string[];
+                    const labelMap = {
+                      where: ["WHERE", "AND 結合される条件式 (例: \"o.status = 'active'\")"],
+                      groupBy: ["GROUP BY", "GROUP BY 列式 (例: \"o.customer_id\")"],
+                      having: ["HAVING", "AND 結合される HAVING 条件 (例: \"COUNT(*) > 10\")"],
+                      orderBy: ["ORDER BY", "ORDER BY 式 (例: \"o.created_at DESC\")"],
+                    } as const;
+                    const [label, hint] = labelMap[kw];
+                    return (
+                      <div key={kw} className="vd-query-block">
+                        <div className="vd-query-block-title" title={hint}>{label}</div>
+                        {items.map((cond, idx) => (
+                          <div key={idx} className="vd-query-fragment-row">
+                            <input
+                              type="text"
+                              value={cond}
+                              onChange={(e) => updateSilentWithDraft((d) => {
+                                const cur = d.query as ViewQueryStructured;
+                                const arr = [...((cur[kw] as string[] | undefined) ?? [])];
+                                arr[idx] = e.target.value;
+                                d.query = { ...cur, [kw]: arr };
+                              })}
+                              onBlur={() => { if (!isReadonly) commit(); }}
+                              placeholder={hint}
+                              className="vd-query-fragment-input vd-query-fragment-input--full"
+                              disabled={isReadonly}
+                            />
+                            <button
+                              type="button"
+                              className="tbl-btn-icon danger"
+                              onClick={() => updateWithDraft((d) => {
+                                const cur = d.query as ViewQueryStructured;
+                                const arr = ((cur[kw] as string[] | undefined) ?? []).filter((_, i) => i !== idx);
+                                d.query = { ...cur, [kw]: arr.length ? arr : undefined };
+                              })}
+                              disabled={isReadonly}
+                              title="削除"
+                            >
+                              <i className="bi bi-trash" />
+                            </button>
+                          </div>
+                        ))}
+                        <button
+                          type="button"
+                          className="tbl-btn tbl-btn-ghost tbl-btn-sm"
+                          onClick={() => updateWithDraft((d) => {
+                            const cur = d.query as ViewQueryStructured;
+                            const arr = [...((cur[kw] as string[] | undefined) ?? []), ""];
+                            d.query = { ...cur, [kw]: arr };
+                          })}
+                          disabled={isReadonly}
+                        >
+                          <i className="bi bi-plus-lg" /> {label} 追加
+                        </button>
+                      </div>
+                    );
+                  })}
+                </div>
+              );
+            })()}
+
+            {currentLevel === 3 && (() => {
+              const rq = (viewDefinition.query as ViewQueryRawSql | undefined) ?? { sql: "", parameterRefs: [] };
+              return (
+                <div className="vd-query-rawsql">
+                  <div className="vd-query-block">
+                    <div className="vd-query-block-title">SQL</div>
+                    <textarea
+                      value={rq.sql ?? ""}
+                      onChange={(e) => updateSilentWithDraft((d) => {
+                        const cur = (d.query as ViewQueryRawSql | undefined) ?? { sql: "", parameterRefs: [] };
+                        d.query = { ...cur, sql: e.target.value };
+                      })}
+                      onBlur={() => { if (!isReadonly) commit(); }}
+                      placeholder={"WITH ranked AS (\n  SELECT id, name, ROW_NUMBER() OVER (PARTITION BY category ORDER BY price DESC) AS rn FROM products\n)\nSELECT * FROM ranked WHERE rn <= @param.topN"}
+                      rows={12}
+                      className="vd-query-sql-textarea"
+                      disabled={isReadonly}
+                    />
+                    <small className="vd-editor-level-hint">
+                      式補間は ProcessFlow と同じく <code>@&lt;var&gt;</code> / <code>@conv.*</code> / <code>@env.*</code> / <code>@param.&lt;name&gt;</code>。
+                    </small>
+                  </div>
+
+                  <div className="vd-query-block">
+                    <div className="vd-query-block-title">parameterRefs</div>
+                    {(rq.parameterRefs ?? []).map((p, pi) => (
+                      <div key={pi} className="vd-query-fragment-row">
+                        <input
+                          type="text"
+                          value={p.name as string}
+                          onChange={(e) => updateSilentWithDraft((d) => {
+                            const cur = d.query as ViewQueryRawSql;
+                            const params = [...(cur.parameterRefs ?? [])];
+                            params[pi] = { ...params[pi], name: e.target.value as Identifier };
+                            d.query = { ...cur, parameterRefs: params };
+                          })}
+                          onBlur={() => { if (!isReadonly) commit(); }}
+                          placeholder="paramName"
+                          className="vd-query-fragment-input"
+                          disabled={isReadonly}
+                        />
+                        <select
+                          value={typeof p.fieldType === "string" ? p.fieldType : "string"}
+                          onChange={(e) => updateWithDraft((d) => {
+                            const cur = d.query as ViewQueryRawSql;
+                            const params = [...(cur.parameterRefs ?? [])];
+                            params[pi] = { ...params[pi], fieldType: e.target.value as FieldType };
+                            d.query = { ...cur, parameterRefs: params };
+                          })}
+                          disabled={isReadonly}
+                        >
+                          {FIELD_TYPE_OPTIONS.map((ft) => (
+                            <option key={ft} value={ft}>{ft}</option>
+                          ))}
+                        </select>
+                        <input
+                          type="text"
+                          value={p.description ?? ""}
+                          onChange={(e) => updateSilentWithDraft((d) => {
+                            const cur = d.query as ViewQueryRawSql;
+                            const params = [...(cur.parameterRefs ?? [])];
+                            params[pi] = { ...params[pi], description: e.target.value || undefined };
+                            d.query = { ...cur, parameterRefs: params };
+                          })}
+                          onBlur={() => { if (!isReadonly) commit(); }}
+                          placeholder="description (任意)"
+                          className="vd-query-fragment-input vd-query-fragment-input--full"
+                          disabled={isReadonly}
+                        />
+                        <button
+                          type="button"
+                          className="tbl-btn-icon danger"
+                          onClick={() => updateWithDraft((d) => {
+                            const cur = d.query as ViewQueryRawSql;
+                            const params = (cur.parameterRefs ?? []).filter((_, i) => i !== pi);
+                            d.query = { ...cur, parameterRefs: params.length ? params : undefined };
+                          })}
+                          disabled={isReadonly}
+                          title="削除"
+                        >
+                          <i className="bi bi-trash" />
+                        </button>
+                      </div>
+                    ))}
+                    <button
+                      type="button"
+                      className="tbl-btn tbl-btn-ghost tbl-btn-sm"
+                      onClick={() => updateWithDraft((d) => {
+                        const cur = (d.query as ViewQueryRawSql | undefined) ?? { sql: "" };
+                        const newParam: ViewQueryParameterRef = {
+                          name: "" as Identifier,
+                          fieldType: "string" as FieldType,
+                        };
+                        d.query = { ...cur, parameterRefs: [...(cur.parameterRefs ?? []), newParam] };
+                      })}
+                      disabled={isReadonly}
+                    >
+                      <i className="bi bi-plus-lg" /> parameterRef 追加
+                    </button>
+                  </div>
+                </div>
+              );
+            })()}
+          </section>
+
+          {/* ───── Section 3: columns 編集 ────────────────────────────────── */}
           <section className="seq-editor-section">
             <h3 className="seq-editor-section-title">
               カラム定義
@@ -700,8 +1150,14 @@ export function ViewDefinitionEditor() {
                 <thead>
                   <tr>
                     <th>name <span className="vd-editor-required">*</span></th>
-                    <th>参照テーブル</th>
-                    <th>参照カラム</th>
+                    {currentLevel !== 3 && (
+                      <>
+                        <th title={currentLevel === 2 ? "from / joins[] のテーブルから選択" : "参照テーブル"}>
+                          {currentLevel === 2 ? "alias.テーブル" : "参照テーブル"}
+                        </th>
+                        <th>参照カラム</th>
+                      </>
+                    )}
                     <th>表示名</th>
                     <th>type <span className="vd-editor-required">*</span></th>
                     <th>書式</th>
@@ -742,34 +1198,44 @@ export function ViewDefinitionEditor() {
                             disabled={isReadonly}
                           />
                         </td>
-                        {/* 参照テーブル (cascade step 1) */}
-                        <td>
-                          <select
-                            value={refTableId}
-                            onChange={(e) => setColRefTable(ci, e.target.value)}
-                            className="vd-col-select"
-                            disabled={isReadonly}
-                          >
-                            <option value="">— テーブル —</option>
-                            {tableOptions.map((t) => (
-                              <option key={t.id} value={t.id}>{t.name}</option>
-                            ))}
-                          </select>
-                        </td>
-                        {/* 参照カラム (cascade step 2) */}
-                        <td>
-                          <select
-                            value={col.tableColumnRef?.columnId ?? ""}
-                            onChange={(e) => setColRefColumn(ci, e.target.value)}
-                            className="vd-col-select"
-                            disabled={!refTableId || isReadonly}
-                          >
-                            <option value="">— カラム —</option>
-                            {colOptions.map((c) => (
-                              <option key={c.id} value={c.id}>{c.name}</option>
-                            ))}
-                          </select>
-                        </td>
+                        {currentLevel !== 3 && (
+                          <>
+                            {/* 参照テーブル (cascade step 1) — Level 2 では in-scope alias リスト */}
+                            <td>
+                              <select
+                                value={refTableId ?? ""}
+                                onChange={(e) => setColRefTable(ci, e.target.value)}
+                                className="vd-col-select"
+                                disabled={isReadonly}
+                              >
+                                <option value="">— テーブル —</option>
+                                {currentLevel === 2
+                                  ? inScopeTables.map((s) => (
+                                      <option key={`${s.alias}-${s.tableId}`} value={s.tableId}>
+                                        {s.label}
+                                      </option>
+                                    ))
+                                  : tableOptions.map((t) => (
+                                      <option key={t.id} value={t.id}>{t.name}</option>
+                                    ))}
+                              </select>
+                            </td>
+                            {/* 参照カラム (cascade step 2) */}
+                            <td>
+                              <select
+                                value={col.tableColumnRef?.columnId ?? ""}
+                                onChange={(e) => setColRefColumn(ci, e.target.value)}
+                                className="vd-col-select"
+                                disabled={!refTableId || isReadonly}
+                              >
+                                <option value="">— カラム —</option>
+                                {colOptions.map((c) => (
+                                  <option key={c.id} value={c.id}>{c.name}</option>
+                                ))}
+                              </select>
+                            </td>
+                          </>
+                        )}
                         {/* displayName */}
                         <td>
                           <input

--- a/designer/src/components/view-definition/ViewDefinitionEditor.tsx
+++ b/designer/src/components/view-definition/ViewDefinitionEditor.tsx
@@ -194,11 +194,17 @@ export function ViewDefinitionEditor() {
     const builtin = ["list", "detail", "kanban", "calendar"];
     setKindExtMode(!builtin.includes(vd.kind));
     const nextIds: Record<number, string> = {};
-    // Level 2/3 (#745): tableColumnRef が無いか sourceTableId 不在のケースは空文字で埋める
-    // (UI Editor は現状 Level 1 編集のみ対応、Level 2/3 は別 PR で UI 拡張)
+    // Level 別 fallback (#748):
+    //  L1: sourceTableId / L2: query.from.tableId / L3: tableColumnRef は省略可なので空
+    const lv = detectLevel(vd);
+    const fallbackTableId =
+      lv === 1
+        ? ((vd.sourceTableId as string | undefined) ?? "")
+        : lv === 2
+          ? (((vd.query as ViewQueryStructured | undefined)?.from?.tableId as string | undefined) ?? "")
+          : "";
     (vd.columns ?? []).forEach((col, i) => {
-      nextIds[i] =
-        (col.tableColumnRef?.tableId as string | undefined) ?? (vd.sourceTableId as string | undefined) ?? "";
+      nextIds[i] = (col.tableColumnRef?.tableId as string | undefined) ?? fallbackTableId;
     });
     setColRefTableIds(nextIds);
   }, []);
@@ -483,9 +489,17 @@ export function ViewDefinitionEditor() {
     });
   };
 
-  // tableColumnRef カスケード: カラム選択
+  // tableColumnRef カスケード: カラム選択 (Level 別フォールバック)
+  // Level 1: sourceTableId / Level 2: query.from.tableId / Level 3: 既存値そのまま
   const setColRefColumn = (ci: number, columnId: string) => {
-    const tableId = colRefTableIds[ci] ?? viewDefinition.sourceTableId;
+    const fallbackTableId =
+      currentLevel === 1
+        ? (viewDefinition.sourceTableId as string | undefined)
+        : currentLevel === 2
+          ? ((viewDefinition.query as ViewQueryStructured | undefined)?.from?.tableId as string | undefined)
+          : undefined;
+    const existing = viewDefinition.columns[ci]?.tableColumnRef?.tableId as string | undefined;
+    const tableId = colRefTableIds[ci] || existing || fallbackTableId || "";
     updateWithDraft((d) => {
       d.columns[ci] = {
         ...d.columns[ci],

--- a/designer/src/components/view-definition/viewDefinitionLevels.test.ts
+++ b/designer/src/components/view-definition/viewDefinitionLevels.test.ts
@@ -1,0 +1,138 @@
+/**
+ * viewDefinitionLevels — Level 検出 + 切替の単体テスト (#748)
+ */
+
+import { describe, it, expect } from "vitest";
+import { detectLevel, suggestAlias, migrateToLevel } from "./viewDefinitionLevels";
+import type { ViewDefinition } from "../../types/v3/view-definition";
+
+const TBL_A = "aaaaaaaa-0001-4000-8000-aaaaaaaaaaaa";
+const TBL_B = "bbbbbbbb-0002-4000-8000-bbbbbbbbbbbb";
+
+function baseVd(partial: Partial<ViewDefinition> = {}): ViewDefinition {
+  return {
+    id: "vvvvvvvv-0001-4000-8000-vvvvvvvvvvvv",
+    name: "test view",
+    version: "1.0.0",
+    maturity: "draft",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    kind: "list",
+    columns: [],
+    ...partial,
+  } as unknown as ViewDefinition;
+}
+
+const tableNameMap: Record<string, string> = {
+  [TBL_A]: "orders",
+  [TBL_B]: "customers",
+};
+const tableName = (id: string) => tableNameMap[id];
+
+describe("detectLevel", () => {
+  it("sourceTableId だけなら Level 1", () => {
+    expect(detectLevel(baseVd({ sourceTableId: TBL_A } as Partial<ViewDefinition>))).toBe(1);
+  });
+
+  it("sourceTableId も query も無くても Level 1 (デフォルト)", () => {
+    expect(detectLevel(baseVd())).toBe(1);
+  });
+
+  it("query.from があれば Level 2", () => {
+    const vd = baseVd({ query: { from: { tableId: TBL_A as never, alias: "o" } } } as Partial<ViewDefinition>);
+    expect(detectLevel(vd)).toBe(2);
+  });
+
+  it("query.sql があれば Level 3", () => {
+    const vd = baseVd({ query: { sql: "SELECT 1", parameterRefs: [] } } as Partial<ViewDefinition>);
+    expect(detectLevel(vd)).toBe(3);
+  });
+});
+
+describe("suggestAlias", () => {
+  it("テーブル名先頭文字を返す (未使用なら)", () => {
+    expect(suggestAlias("orders", new Set())).toBe("o");
+    expect(suggestAlias("customers", new Set())).toBe("c");
+  });
+
+  it("衝突時は数字 suffix を付ける", () => {
+    expect(suggestAlias("orders", new Set(["o"]))).toBe("o2");
+    expect(suggestAlias("orders", new Set(["o", "o2"]))).toBe("o3");
+  });
+
+  it("非英字始まりは t にフォールバック", () => {
+    expect(suggestAlias("123_table", new Set())).toBe("t");
+  });
+
+  it("undefined / 空文字は t", () => {
+    expect(suggestAlias(undefined, new Set())).toBe("t");
+    expect(suggestAlias("", new Set())).toBe("t");
+  });
+});
+
+describe("migrateToLevel", () => {
+  it("Level 1 → Level 2: sourceTableId を query.from に変換、alias 自動推定", () => {
+    const vd = baseVd({ sourceTableId: TBL_A } as Partial<ViewDefinition>);
+    const next = migrateToLevel(vd, 2, tableName);
+    expect(detectLevel(next)).toBe(2);
+    expect(next.sourceTableId).toBeUndefined();
+    expect((next.query as { from: { tableId: string; alias: string } }).from.tableId).toBe(TBL_A);
+    expect((next.query as { from: { tableId: string; alias: string } }).from.alias).toBe("o"); // orders → o
+  });
+
+  it("Level 1 → Level 3: query.sql 雛形を生成、sourceTableId 解除", () => {
+    const vd = baseVd({ sourceTableId: TBL_A } as Partial<ViewDefinition>);
+    const next = migrateToLevel(vd, 3, tableName);
+    expect(detectLevel(next)).toBe(3);
+    expect(next.sourceTableId).toBeUndefined();
+    expect((next.query as { sql: string }).sql).toBe("");
+  });
+
+  it("Level 2 → Level 1: query.from.tableId を sourceTableId に変換", () => {
+    const vd = baseVd({
+      query: { from: { tableId: TBL_A as never, alias: "o" }, joins: [] },
+    } as Partial<ViewDefinition>);
+    const next = migrateToLevel(vd, 1, tableName);
+    expect(detectLevel(next)).toBe(1);
+    expect(next.query).toBeUndefined();
+    expect(next.sourceTableId).toBe(TBL_A);
+  });
+
+  it("Level 3 → Level 1: columns[0].tableColumnRef.tableId を sourceTableId に転用 (フォールバック)", () => {
+    const vd = baseVd({
+      query: { sql: "SELECT * FROM ...", parameterRefs: [] },
+      columns: [
+        {
+          name: "x" as never,
+          type: "string" as never,
+          tableColumnRef: { tableId: TBL_B, columnId: "col-1" },
+        },
+      ],
+    } as Partial<ViewDefinition>);
+    const next = migrateToLevel(vd, 1, tableName);
+    expect(detectLevel(next)).toBe(1);
+    expect(next.sourceTableId).toBe(TBL_B);
+    expect(next.query).toBeUndefined();
+  });
+
+  it("同じ Level への migrate は同オブジェクトを返す (no-op)", () => {
+    const vd = baseVd({ sourceTableId: TBL_A } as Partial<ViewDefinition>);
+    expect(migrateToLevel(vd, 1, tableName)).toBe(vd);
+  });
+
+  it("既存の columns / sortDefaults / filterDefaults は維持", () => {
+    const cols = [
+      { name: "x" as never, type: "string" as never, tableColumnRef: { tableId: TBL_A, columnId: "c1" } },
+    ];
+    const vd = baseVd({
+      sourceTableId: TBL_A,
+      columns: cols,
+      sortDefaults: [{ columnName: "x" as never, order: "asc" }],
+      filterDefaults: [{ columnName: "x" as never, operator: "eq", value: "v" }],
+    } as Partial<ViewDefinition>);
+    const next = migrateToLevel(vd, 2, tableName);
+    expect(next.columns).toEqual(cols);
+    expect(next.sortDefaults).toEqual(vd.sortDefaults);
+    expect(next.filterDefaults).toEqual(vd.filterDefaults);
+  });
+});

--- a/designer/src/components/view-definition/viewDefinitionLevels.ts
+++ b/designer/src/components/view-definition/viewDefinitionLevels.ts
@@ -1,0 +1,93 @@
+/**
+ * ViewDefinition 3 レベル DSL のレベル検出 + 切替ヘルパー (#748)
+ *
+ * Level 1 (Simple)     — sourceTableId
+ * Level 2 (Structured) — query.from + joins + where/groupBy/having/orderBy
+ * Level 3 (Raw SQL)    — query.sql + parameterRefs
+ *
+ * sourceTableId と query は schema レベルで oneOf により排他。
+ */
+
+import type {
+  ViewDefinition,
+  ViewQueryStructured,
+  ViewQueryRawSql,
+} from "../../types/v3/view-definition";
+import type { TableId } from "../../types/v3/common";
+
+export type ViewLevel = 1 | 2 | 3;
+
+/** ViewDefinition の現在の Level を判定する。
+ *  query.sql があれば 3、query.from があれば 2、それ以外 (sourceTableId 想定) は 1。 */
+export function detectLevel(vd: ViewDefinition): ViewLevel {
+  const q = vd.query;
+  if (q && "sql" in q && typeof (q as ViewQueryRawSql).sql === "string") return 3;
+  if (q && "from" in q && (q as ViewQueryStructured).from) return 2;
+  return 1;
+}
+
+/** 既に存在する alias を避けて、テーブル名から alias 候補を生成する。
+ *  ベースは英小文字 1 文字 (テーブル名先頭) で、衝突時は数字 suffix。 */
+export function suggestAlias(tableName: string | undefined, used: Set<string>): string {
+  const base = (tableName ?? "t")
+    .toLowerCase()
+    .replace(/[^a-z0-9_]/g, "_")
+    .replace(/^_+/, "");
+  const first = base.match(/^[a-z]/) ? base[0] : "t";
+  if (!used.has(first)) return first;
+  let i = 2;
+  while (used.has(`${first}${i}`)) i++;
+  return `${first}${i}`;
+}
+
+/**
+ * Level 切替時に schema oneOf を満たすよう sourceTableId / query を排他書き換え。
+ *
+ * 既存の columns / sortDefaults / filterDefaults / pageSize / groupBy は維持する。
+ * 切替候補テーブル ID:
+ *  - target=1 (Simple): query.from.tableId (L2 from) → columns[0].tableColumnRef.tableId (L3 from) → 旧 sourceTableId
+ *  - target=2 (Structured): sourceTableId (L1) → columns[0].tableColumnRef.tableId (L3) → 空
+ *  - target=3 (Raw SQL): 空の SQL + parameterRefs[]
+ *
+ * tableName は alias 推定用 (target=2 のときのみ使う)。
+ */
+export function migrateToLevel(
+  vd: ViewDefinition,
+  target: ViewLevel,
+  tableName: (id: string) => string | undefined,
+): ViewDefinition {
+  const cur = detectLevel(vd);
+  if (cur === target) return vd;
+
+  const next: ViewDefinition = { ...vd };
+  next.sourceTableId = undefined;
+  next.query = undefined;
+
+  if (target === 1) {
+    let sid: string | undefined;
+    if (cur === 2) {
+      const sq = vd.query as ViewQueryStructured | undefined;
+      sid = sq?.from?.tableId as string | undefined;
+    } else if (cur === 3) {
+      sid = vd.columns?.[0]?.tableColumnRef?.tableId as string | undefined;
+    } else {
+      sid = vd.sourceTableId as string | undefined;
+    }
+    next.sourceTableId = (sid ?? "") as TableId;
+  } else if (target === 2) {
+    let fromTableId: string | undefined;
+    if (cur === 1) fromTableId = vd.sourceTableId as string | undefined;
+    else if (cur === 3) fromTableId = vd.columns?.[0]?.tableColumnRef?.tableId as string | undefined;
+    const alias = suggestAlias(fromTableId ? tableName(fromTableId) : undefined, new Set());
+    next.query = {
+      from: { tableId: (fromTableId ?? "") as TableId, alias },
+    } satisfies ViewQueryStructured;
+  } else {
+    next.query = {
+      sql: "",
+      parameterRefs: [],
+    } satisfies ViewQueryRawSql;
+  }
+
+  return next;
+}

--- a/designer/src/styles/table.css
+++ b/designer/src/styles/table.css
@@ -2385,3 +2385,135 @@
     max-width: 900px;
   }
 }
+
+/* ─── ViewDefinition Editor: 3 レベル DSL UI (#748) ─────────────────────── */
+
+.vd-editor-level-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 6px 8px;
+  background: #111;
+  border: 1px solid #333;
+  border-radius: 4px;
+}
+.vd-editor-level-radio {
+  font-size: 12px;
+  color: #ccc;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+}
+.vd-editor-level-radio input[type="radio"] {
+  margin: 0;
+}
+.vd-editor-level-hint {
+  display: block;
+  font-size: 11px;
+  color: #888;
+  margin-top: 4px;
+}
+.vd-editor-level-hint code {
+  background: #222;
+  padding: 1px 4px;
+  border-radius: 3px;
+  color: #aaa;
+}
+.vd-editor-level-tag {
+  font-size: 11px;
+  font-weight: 400;
+  text-transform: none;
+  color: #6da9ff;
+  margin-left: 8px;
+  letter-spacing: 0;
+}
+
+.vd-query-structured,
+.vd-query-rawsql {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.vd-query-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.vd-query-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: #6da9ff;
+  min-width: 60px;
+}
+.vd-query-as {
+  font-size: 11px;
+  color: #888;
+  font-weight: 600;
+}
+.vd-query-block {
+  background: #111;
+  border: 1px solid #2a2a3a;
+  border-radius: 4px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.vd-query-block-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: #6da9ff;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 4px;
+}
+.vd-query-join-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  padding: 6px;
+  background: #15151f;
+  border: 1px solid #2a2a3a;
+  border-radius: 4px;
+}
+.vd-query-on-list {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex: 1;
+  flex-wrap: wrap;
+}
+.vd-query-fragment-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.vd-query-fragment-input {
+  flex: 1;
+  min-width: 200px;
+  font-family: ui-monospace, "Cascadia Code", "Source Code Pro", monospace;
+  font-size: 12px;
+}
+.vd-query-fragment-input--full {
+  width: 100%;
+}
+.vd-query-alias-input {
+  width: 80px;
+  font-family: ui-monospace, "Cascadia Code", monospace;
+  font-size: 12px;
+}
+.vd-query-sql-textarea {
+  width: 100%;
+  font-family: ui-monospace, "Cascadia Code", "Source Code Pro", monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  background: #0a0a14;
+  color: #d8d8d8;
+  border: 1px solid #2a2a3a;
+  border-radius: 4px;
+  padding: 8px;
+  resize: vertical;
+}


### PR DESCRIPTION
Closes #748

## Summary

#745 (PR #747) で ViewDefinition の 3 レベル DSL 化を schema/validator/sample で完了したが、UI Editor は Level 1 のみで、retail Level 2/3 サンプル (3 件) が JSON 直接編集前提だった。本 PR で Editor を 3 レベル全対応にし、機能としての完成度を担保する。

## UI 構造

### Level 切替 (基本情報セクション)

```
クエリ Level *
  ◯ Level 1 — Simple (1 テーブル)
  ◉ Level 2 — Structured (joins + where)
  ◯ Level 3 — Raw SQL (CTE / window 等)
```

### 新セクション「クエリ」

Level 別に出し分け:

**Level 1 (Simple)**: 既存 \`sourceTableId\` select を移設

**Level 2 (Structured)**:
- FROM: テーブル select + AS alias 入力
- JOINS: kind (INNER/LEFT/RIGHT/FULL) + テーブル + alias + ON 条件式 (AND 結合複数)
- WHERE / GROUP BY / HAVING / ORDER BY: SQL fragment 文字列の追加・削除

**Level 3 (Raw SQL)**:
- SQL textarea (等幅、12 行、暗背景)
- parameterRefs: name + fieldType + description

### columns テーブル

- Level 2: \`tableColumnRef\` のテーブル列を **from + joins[] alias 一覧** に絞る (例: \`o: 注文 / c: 顧客 / inv: 在庫 (LEFT JOIN)\`)
- Level 3: \`tableColumnRef\` 列を非表示 (name + type + 表示属性のみ、SQL 結果を信頼)

## Level 切替ロジック

\`viewDefinitionLevels.ts\` に抽出 (テスト容易性 + 再利用性):

| from / to | 動作 |
|---|---|
| L1 → L2 | sourceTableId → query.from.tableId、alias は \`suggestAlias()\` で自動推定 (orders → o) |
| L1 → L3 | sourceTableId 解除、query = { sql: "", parameterRefs: [] } |
| L2 → L1 | query.from.tableId → sourceTableId、joins[] / where 等は破棄 |
| L2 → L3 | query 全置換 |
| L3 → L1 | columns[0].tableColumnRef.tableId をフォールバック sourceTableId に |
| L3 → L2 | 同上を query.from.tableId に |

切替時に schema oneOf (\`sourceTableId XOR query\`) を満たす排他書き換え。**既存の columns / sortDefaults / filterDefaults / pageSize / groupBy は維持** する。

## 受入基準 (#748)

- [x] Level 1 / 2 / 3 切替可能 (radio)
- [x] Level 2: from / joins / where / groupBy / having / orderBy 編集 UI
- [x] Level 2: columns の tableColumnRef が from + joins[] から選択可能
- [x] Level 3: SQL textarea + parameterRefs 編集 UI
- [x] Level 3: columns 編集で tableColumnRef 非表示
- [x] Level 切替時の schema oneOf 整合
- [x] retail Level 2 サンプル 2 件 / Level 3 サンプル 1 件を Editor で開ける (実機 smoke test は次節)

## 仕様逐条突合 (自己申告)

| 項目 | 実装 | 場所 |
|---|---|---|
| detectLevel / migrateToLevel / suggestAlias 抽出 | ✅ | \`viewDefinitionLevels.ts\` |
| Level 切替 UI (radio) | ✅ | \`ViewDefinitionEditor.tsx\` 基本情報セクション末尾 |
| Query セクション (Level 1: sourceTableId 移設) | ✅ | \`ViewDefinitionEditor.tsx\` 新 Section 2 (\`currentLevel === 1\`) |
| Query セクション (Level 2: Structured) | ✅ | \`ViewDefinitionEditor.tsx\` 新 Section 2 (\`currentLevel === 2\`) |
| Query セクション (Level 3: Raw SQL) | ✅ | \`ViewDefinitionEditor.tsx\` 新 Section 2 (\`currentLevel === 3\`) |
| columns table の Level 2 alias 表示 | ✅ | \`ViewDefinitionEditor.tsx\` columns thead/td 条件分岐 |
| columns table の Level 3 ref 非表示 | ✅ | \`ViewDefinitionEditor.tsx\` columns thead/td 条件分岐 |
| addColumn() の Level 別初期 ref | ✅ | \`ViewDefinitionEditor.tsx\` (L1: sourceTableId / L2: from.tableId / L3: ref 省略) |
| inScopeTables memo (Level 2 用) | ✅ | \`ViewDefinitionEditor.tsx\` useMemo |
| CSS (Level radio / Query block / SQL textarea) | ✅ | \`table.css\` 末尾 |
| Level 別 viewDefinitionLevels テスト 14 ケース | ✅ | \`viewDefinitionLevels.test.ts\` |

## テスト

- vitest: **1454 passed / 0 failed** (新規 14 ケースの migrationヘルパー含む)
- tsc: clean
- build: success
- ESLint: 既存のみ

### 実機 smoke test 注記

ローカル環境でブラウザ smoke test を試みたが、\`workspaceState.loading=true\` 状態が解消せず Editor が描画される段階に到達できなかった (designer-mcp の \`workspace.list\` 応答が無く、AppShell スプラッシュで停滞)。これは pre-existing インフラ問題と推察 (本 PR の変更箇所外、ViewDefinitionEditor.tsx / viewDefinitionLevels.ts / styles のみ)。**code-level 静的レビューでの確認を独立レビュアーに依頼**。tsc / build / unit test pass で React tree のコンパイル整合は担保。

## scope 外

- viewDefinitionStore.createViewDefinition() の Level 2/3 対応 (現状 sourceTableId 必須シグネチャ) — 新規作成からは Level 1 で開始 → Level 切替 UI でアップグレード可
- AJV inline 検証の Level 2/3 message 翻訳 — validator はメッセージ提供済 (#745) で UI に IssueHints 通常表示

## 関連

- 親 dogfood: #709 retail 品質保証
- 元 ISSUE: #748 (本 PR で close)
- 前提 ISSUE: #745 (PR #747) — schema / validator / sample 完了
- D5 設計判断記録: PR #747 description

## Test plan

- [x] vitest 全件 pass (1454/1454)
- [x] viewDefinitionLevels 単体テスト 14 ケース pass
- [x] tsc / build clean
- [ ] 実機 smoke test: Level 1 → 2 → 3 切替、retail 4cef6340 / fbd95d09 / 37a3af9a を Editor で目視確認 (ローカル環境問題で未完、独立レビューで code 検証 + マージ後の実機検証で補完)

🤖 Generated with [Claude Code](https://claude.com/claude-code)