### PR TITLE
fix(framework): redirect 無限ループ guard + UI 構造化ログでバグ追跡可能化

### DIFF
--- a/designer/src/components/AppShell.tsx
+++ b/designer/src/components/AppShell.tsx
@@ -53,7 +53,7 @@ import { TabErrorFallback } from "./common/ErrorFallback";
 import { ResourceLoading } from "./common/ResourceLoading";
 import { useErrorDialog } from "./common/ErrorDialogProvider";
 import { recordError } from "../utils/errorLog";
-import { checkRedirect } from "../utils/redirectGuard";
+import { checkRedirect, subscribeRedirectGuardTrip, isRedirectGuardTripped } from "../utils/redirectGuard";
 import { uiInfo, uiWarn } from "../utils/uiLog";
 
 function useTabs() {
@@ -82,13 +82,47 @@ function WorkspaceScopedShell() {
   return <AppShellInner wsId={wsId} />;
 }
 
+// redirectGuard が trip した時、画面全体に被せる赤バナー (#750 review S-2)。
+// silently block すると見かけ上「画面が固まった」状態でユーザーが原因を理解できない。
+function RedirectGuardBanner({ summary }: { summary: readonly string[] }) {
+  return (
+    <div style={{
+      position: "fixed", top: 0, left: 0, right: 0, zIndex: 9999,
+      background: "#b71c1c", color: "#fff",
+      padding: "12px 16px", fontSize: 13,
+      borderBottom: "2px solid #7f0000",
+      boxShadow: "0 2px 8px rgba(0,0,0,0.3)",
+    }}>
+      <strong><i className="bi bi-exclamation-octagon-fill" /> リダイレクトループ検出 — 遷移を停止しました</strong>
+      <div style={{ marginTop: 4, fontSize: 12, opacity: 0.9 }}>
+        サーバ保護のため、これ以降のページ遷移を全てブロックしています。
+        ブラウザを手動で再読み込み (F5) してください。
+      </div>
+      {summary.length > 0 && (
+        <details style={{ marginTop: 6, fontSize: 11, fontFamily: "monospace" }}>
+          <summary style={{ cursor: "pointer" }}>直近の遷移先 (バグ報告用)</summary>
+          <ol style={{ margin: "4px 0 0 16px", padding: 0 }}>
+            {summary.map((p, i) => (<li key={i}>{p}</li>))}
+          </ol>
+        </details>
+      )}
+    </div>
+  );
+}
+
 // ルートレベルの AppShell: /workspace/* と /w/:wsId/* に分岐
 export function AppShell() {
   const location = useLocation();
   const navigate = useNavigate();
   const [workspaceState, setWorkspaceState] = useState(getWorkspaceState());
+  const [guardTripped, setGuardTripped] = useState<readonly string[] | null>(
+    isRedirectGuardTripped() ? [] : null,
+  );
   useEffect(() => {
     return subscribeWorkspace(() => setWorkspaceState(getWorkspaceState()));
+  }, []);
+  useEffect(() => {
+    return subscribeRedirectGuardTrip((summary) => setGuardTripped(summary));
   }, []);
 
   // workspace が loading 完了後に URL を判定してリダイレクト
@@ -126,6 +160,8 @@ export function AppShell() {
   }
 
   return (
+    <>
+      {guardTripped !== null && <RedirectGuardBanner summary={guardTripped} />}
     <Routes>
       <Route path="/w/:wsId/*" element={<WorkspaceScopedRoutes />} />
       <Route path="/workspace/list" element={<WorkspaceListView />} />
@@ -143,6 +179,7 @@ export function AppShell() {
         </div>
       } />
     </Routes>
+    </>
   );
 }
 

--- a/designer/src/components/AppShell.tsx
+++ b/designer/src/components/AppShell.tsx
@@ -53,6 +53,8 @@ import { TabErrorFallback } from "./common/ErrorFallback";
 import { ResourceLoading } from "./common/ResourceLoading";
 import { useErrorDialog } from "./common/ErrorDialogProvider";
 import { recordError } from "../utils/errorLog";
+import { checkRedirect } from "../utils/redirectGuard";
+import { uiInfo, uiWarn } from "../utils/uiLog";
 
 function useTabs() {
   const [tabs, setTabs] = useState<readonly TabItem[]>(getTabs);
@@ -97,10 +99,15 @@ export function AppShell() {
     // /w/:wsId/* 配下は WorkspaceScopedShell が処理
     if (location.pathname.startsWith("/w/")) return;
     // それ以外 (/, /screen/flow 等の旧 URL) は active があれば /w/<id>/<元パス> に、なければ /workspace/select に
+    let target: string | null = null;
     if (workspaceState.active?.id) {
-      navigate(`/w/${workspaceState.active.id}${location.pathname === "/" ? "/" : location.pathname}`, { replace: true });
+      target = `/w/${workspaceState.active.id}${location.pathname === "/" ? "/" : location.pathname}`;
     } else if (!workspaceState.lockdown) {
-      navigate("/workspace/select", { replace: true });
+      target = "/workspace/select";
+    }
+    if (target) {
+      const guard = checkRedirect(target);
+      if (guard.allow) navigate(target, { replace: true });
     }
   }, [workspaceState.loading, workspaceState.active?.id, workspaceState.lockdown, location.pathname]);
 
@@ -175,6 +182,16 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
     return () => { unsubBroadcast(); unsubStatus(); };
   }, []);
 
+  // workspace state 変化を log 化 (ループ追跡用)
+  useEffect(() => {
+    uiInfo("workspace", "state-change", {
+      loading: workspaceState.loading,
+      activeId: workspaceState.active?.id ?? null,
+      lockdown: workspaceState.lockdown,
+      error: workspaceState.error,
+    });
+  }, [workspaceState.loading, workspaceState.active?.id, workspaceState.lockdown, workspaceState.error]);
+
   // workspace.changed → ストア / 描画中 view を完全に破棄するためページ再読込。
   // per-resource タブを閉じるだけでは singleton stores (flowStore, tableStore 等) と
   // 現在マウント中の singleton view (DashboardView, ScreenListView 等) が旧 workspace の
@@ -221,6 +238,13 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
     // workspace 切替: navigate で URL を /w/<新wsId>/ に更新してから reload。
     // store のリセットは reload が担う (store.resetForWorkspaceSwitch 未実装のため reload 方式を維持)。
     const targetPath = currentId ? `/w/${currentId}/` : "/workspace/select";
+    uiInfo("workspace", "switch-reload", { from: prevActiveWorkspaceIdRef.current, to: currentId, targetPath });
+    // 万一 workspace.changed broadcast が暴走した場合の保険: redirectGuard を通す
+    const guard = checkRedirect(targetPath);
+    if (!guard.allow) {
+      uiWarn("guard", "workspace switch reload を redirectGuard で抑止 (暴走防止)", { targetPath });
+      return;
+    }
     // location.href を直接書き換えることで URL 変更 + 完全リロードを一発で実現
     window.location.href = targetPath;
   }, [workspaceState.active?.id]);
@@ -237,18 +261,21 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
       // active なし → /workspace/select
       // /workspace/* パスは AppShell の上位 Route で処理済みのため、
       // ここは /w/:wsId/* 配下の場合のみ
-      navigate("/workspace/select", { replace: true });
+      const guard = checkRedirect("/workspace/select");
+      if (guard.allow) navigate("/workspace/select", { replace: true });
     } else if (wsId && wsId !== workspaceState.active.id) {
       // URL の :wsId が現在 active と異なる → workspace.open で同期
       const recentEntry = workspaceState.workspaces.find((w) => w.id === wsId);
       if (recentEntry) {
         mcpBridge.request("workspace.open", { id: wsId }).catch((err) => {
           console.error("[workspace] workspace.open from URL failed:", err);
-          navigate("/workspace/select", { replace: true });
+          const guard = checkRedirect("/workspace/select");
+          if (guard.allow) navigate("/workspace/select", { replace: true });
         });
       } else {
         // recent にない不正 wsId → /workspace/select
-        navigate("/workspace/select", { replace: true });
+        const guard = checkRedirect("/workspace/select");
+        if (guard.allow) navigate("/workspace/select", { replace: true });
       }
     }
   }, [workspaceState.active, workspaceState.active?.id, workspaceState.loading, workspaceState.lockdown, workspaceState.error, workspaceState.workspaces, wsId, location.pathname]);
@@ -268,6 +295,7 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
   // また袋小路に入るため、URL 自体も / に書き換える。
   const fallbackToDashboard = (kind: string, id: string) => {
     const msg = `URL が指すリソース (${kind}: ${id}) が見つかりません。ダッシュボードへフォールバック。`;
+    uiWarn("urlsync", "resource not found → fallback", { kind, id, pathname: location.pathname });
     recordError({
       source: "manual",
       message: msg,
@@ -280,12 +308,14 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
       skipLogRecord: true, // 直前に recordError 済み
     });
     const dashPath = wsId ? `/w/${wsId}/` : "/";
-    navigate(dashPath, { replace: true });
+    const guard = checkRedirect(dashPath);
+    if (guard.allow) navigate(dashPath, { replace: true });
   };
 
   // URL → タブ同期（ブラウザの直接ナビゲーション / mcpBridge.navigateScreen）
   // /w/:wsId/* 配下で使用するため、全 matchPath を /w/:wsId/... 規約に更新
   useEffect(() => {
+    uiInfo("urlsync", "pathname change", { pathname: location.pathname });
     const designMatch = matchPath("/w/:wsId/screen/design/:screenId", location.pathname);
     if (designMatch?.params.screenId) {
       const screenId = designMatch.params.screenId;
@@ -510,7 +540,9 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
       : activeTab.type === "dashboard"              ? `${wp}/`
       : null;
     if (expectedPath && location.pathname !== expectedPath) {
-      navigate(expectedPath, { replace: true });
+      uiInfo("tabsync", "active-tab → URL", { from: location.pathname, to: expectedPath, tabType: activeTab.type, tabId: activeTab.id });
+      const guard = checkRedirect(expectedPath);
+      if (guard.allow) navigate(expectedPath, { replace: true });
     }
   }, [activeTabId, activeTab?.type, activeTab?.resourceId, workspaceState.active, workspaceState.lockdown, location.pathname, wsId]);
 

--- a/designer/src/components/process-flow/ProcessFlowEditor.tsx
+++ b/designer/src/components/process-flow/ProcessFlowEditor.tsx
@@ -186,7 +186,7 @@ export function ProcessFlowEditor() {
   const [showForceReleaseDialog, setShowForceReleaseDialog] = useState(false);
   const [showResumeDialog, setShowResumeDialog] = useState(false);
 
-  const handleNotFound = useCallback(() => navigate(wsPath("/process-flow/list")), [navigate, wsPath]);
+  const handleNotFound = useCallback(() => navigate(wsPath("/process-flow/list"), { replace: true }), [navigate, wsPath]);
 
   const handleLoaded = useCallback((g: ProcessFlow) => {
     setActiveActionId((cur) => cur ?? (g.actions.length > 0 ? g.actions[0].id : null));

--- a/designer/src/components/sequence/SequenceEditor.tsx
+++ b/designer/src/components/sequence/SequenceEditor.tsx
@@ -47,7 +47,7 @@ export function SequenceEditor() {
   const [showForceReleaseDialog, setShowForceReleaseDialog] = useState(false);
   const [showResumeDialog, setShowResumeDialog] = useState(false);
 
-  const handleNotFound = useCallback(() => navigate(wsPath("/sequence/list")), [navigate, wsPath]);
+  const handleNotFound = useCallback(() => navigate(wsPath("/sequence/list"), { replace: true }), [navigate, wsPath]);
 
   const sessionId = mcpBridge.getSessionId();
 

--- a/designer/src/components/table/TableEditor.tsx
+++ b/designer/src/components/table/TableEditor.tsx
@@ -54,7 +54,7 @@ export function TableEditor() {
   const [showForceReleaseDialog, setShowForceReleaseDialog] = useState(false);
   const [showResumeDialog, setShowResumeDialog] = useState(false);
 
-  const handleNotFound = useCallback(() => navigate(wsPath("/table/list")), [navigate, wsPath]);
+  const handleNotFound = useCallback(() => navigate(wsPath("/table/list"), { replace: true }), [navigate, wsPath]);
 
   const sessionId = mcpBridge.getSessionId();
 

--- a/designer/src/components/view-definition/ViewDefinitionEditor.tsx
+++ b/designer/src/components/view-definition/ViewDefinitionEditor.tsx
@@ -187,7 +187,7 @@ export function ViewDefinitionEditor() {
   const [showForceReleaseDialog, setShowForceReleaseDialog] = useState(false);
   const [showResumeDialog, setShowResumeDialog] = useState(false);
 
-  const handleNotFound = useCallback(() => navigate(wsPath("/view-definition/list")), [navigate, wsPath]);
+  const handleNotFound = useCallback(() => navigate(wsPath("/view-definition/list"), { replace: true }), [navigate, wsPath]);
 
   // onLoaded: viewDefinition 読み込み時に UI state を初期化 (useEffect の代わり)
   const handleLoaded = useCallback((vd: ViewDefinition) => {

--- a/designer/src/components/view/ViewEditor.tsx
+++ b/designer/src/components/view/ViewEditor.tsx
@@ -46,7 +46,7 @@ export function ViewEditor() {
   const [showForceReleaseDialog, setShowForceReleaseDialog] = useState(false);
   const [showResumeDialog, setShowResumeDialog] = useState(false);
 
-  const handleNotFound = useCallback(() => navigate(wsPath("/view/list")), [navigate, wsPath]);
+  const handleNotFound = useCallback(() => navigate(wsPath("/view/list"), { replace: true }), [navigate, wsPath]);
 
   const sessionId = mcpBridge.getSessionId();
 

--- a/designer/src/store/tabStore.ts
+++ b/designer/src/store/tabStore.ts
@@ -1,4 +1,5 @@
 import { recordError } from "../utils/errorLog";
+import { uiInfo } from "../utils/uiLog";
 
 const TABS_KEY = "designer-open-tabs";
 const ACTIVE_KEY = "designer-active-tab";
@@ -162,6 +163,7 @@ export function subscribe(listener: Listener): () => void {
 
 export function openTab(item: Omit<TabItem, "isDirty" | "isPinned">): void {
   const existing = _tabs.find((t) => t.id === item.id);
+  uiInfo("tabsync", existing ? "tab re-activate" : "tab open", { id: item.id, type: item.type, resourceId: item.resourceId });
   if (existing) {
     _tabs = _tabs.map((t) => (t.id === item.id ? { ...t, label: item.label } : t));
     _activeTabId = item.id;
@@ -179,6 +181,7 @@ export function closeTab(id: string, force = false): boolean {
   if (!tab) return true;
   if (tab.isDirty && !force) return false;
 
+  uiInfo("tabsync", "tab close", { id, type: tab.type, force, isDirty: tab.isDirty });
   const idx = _tabs.findIndex((t) => t.id === id);
   const newTabs = _tabs.filter((t) => t.id !== id);
   _tabs = newTabs;
@@ -193,6 +196,7 @@ export function closeTab(id: string, force = false): boolean {
 
 export function setActiveTab(id: string): void {
   if (_activeTabId === id) return;
+  uiInfo("tabsync", "setActiveTab", { from: _activeTabId, to: id });
   _activeTabId = id;
   _persist();
   _notify();

--- a/designer/src/store/workspaceStore.ts
+++ b/designer/src/store/workspaceStore.ts
@@ -34,6 +34,8 @@ export interface WorkspaceInspectResult {
 
 type Listener = () => void;
 
+import { uiInfo, uiWarn } from "../utils/uiLog";
+
 // loading は初期 true: WS 未接続のうちはガードを発動させない。
 // 最初の loadWorkspaces() (成功 or 失敗) で false になる。WS が永続的に未接続でも
 // loading=true のままなので /workspace/select への誤強制遷移を起こさない。
@@ -106,6 +108,7 @@ export async function loadWorkspaces(): Promise<void> {
 }
 
 async function _doLoadWorkspaces(): Promise<void> {
+  uiInfo("workspace", "loadWorkspaces start");
   _setState({ loading: true, error: null });
   try {
     const result = (await mcpBridge.request("workspace.list")) as {
@@ -115,6 +118,11 @@ async function _doLoadWorkspaces(): Promise<void> {
       lockdown: boolean;
       lockdownPath: string | null;
     };
+    uiInfo("workspace", "loadWorkspaces success", {
+      count: result.workspaces?.length ?? 0,
+      activePath: result.active?.path ?? null,
+      lockdown: result.lockdown,
+    });
     _setState({
       workspaces: result.workspaces ?? [],
       active: result.active
@@ -130,6 +138,7 @@ async function _doLoadWorkspaces(): Promise<void> {
       error: null,
     });
   } catch (e) {
+    uiWarn("workspace", "loadWorkspaces failed", { error: e instanceof Error ? e.message : String(e) });
     _setState({
       loading: false,
       error: e instanceof Error ? e.message : String(e),
@@ -219,8 +228,15 @@ export function subscribeWorkspaceChanges(): () => void {
     // - 自分の active が null の場合 → hydration broadcast として受信 (初回 active 設定)
     // - 自分の active が非 null かつ ev.path が一致しない場合 → 別 workspace のブロードキャストを無視
     const currentActive = _state.active;
+    uiInfo("ws-broadcast", "workspace.changed received", {
+      currentActiveId: currentActive?.id ?? null,
+      evActiveId: ev.activeId,
+      evPath: ev.path,
+      lockdown: ev.lockdown,
+    });
     if (currentActive !== null && ev.path !== null && currentActive.path !== ev.path) {
       // 別 workspace の workspace.changed broadcast → ignore
+      uiInfo("ws-broadcast", "ignored (path mismatch)", { current: currentActive.path, ev: ev.path });
       return;
     }
 

--- a/designer/src/utils/redirectGuard.test.ts
+++ b/designer/src/utils/redirectGuard.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import { checkRedirect, isRedirectGuardTripped, resetRedirectGuard } from "./redirectGuard";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  checkRedirect,
+  isRedirectGuardTripped,
+  resetRedirectGuard,
+  subscribeRedirectGuardTrip,
+  getLastTripSummary,
+} from "./redirectGuard";
 
 describe("redirectGuard", () => {
   beforeEach(() => resetRedirectGuard());
@@ -52,5 +58,30 @@ describe("redirectGuard", () => {
     expect(isRedirectGuardTripped()).toBe(false);
     const r = checkRedirect("/after-reset");
     expect(r.allow).toBe(true);
+  });
+
+  it("trip 時に subscribeRedirectGuardTrip listener へ summary が渡される", () => {
+    const cb = vi.fn();
+    const unsub = subscribeRedirectGuardTrip(cb);
+    for (let i = 0; i < 21; i++) checkRedirect(`/p${i}`);
+    expect(cb).toHaveBeenCalledTimes(1);
+    const summary = cb.mock.calls[0][0] as string[];
+    expect(summary.length).toBeLessThanOrEqual(10);
+    expect(summary[summary.length - 1]).toBe("/p20");
+    unsub();
+  });
+
+  it("既に trip 済の状態で subscribe すると即時通知される", () => {
+    for (let i = 0; i < 25; i++) checkRedirect(`/p${i}`);
+    const cb = vi.fn();
+    subscribeRedirectGuardTrip(cb);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("getLastTripSummary() が最後の trip 時の path 列を返す", () => {
+    expect(getLastTripSummary()).toEqual([]);
+    for (let i = 0; i < 21; i++) checkRedirect(`/path${i}`);
+    expect(getLastTripSummary().length).toBeGreaterThan(0);
+    expect(getLastTripSummary()[getLastTripSummary().length - 1]).toBe("/path20");
   });
 });

--- a/designer/src/utils/redirectGuard.test.ts
+++ b/designer/src/utils/redirectGuard.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { checkRedirect, isRedirectGuardTripped, resetRedirectGuard } from "./redirectGuard";
+
+describe("redirectGuard", () => {
+  beforeEach(() => resetRedirectGuard());
+
+  it("通常使用 (1 navigation) は allow=true", () => {
+    const r = checkRedirect("/foo");
+    expect(r.allow).toBe(true);
+    expect(r.tripped).toBe(false);
+    expect(r.recentCount).toBe(1);
+  });
+
+  it("MAX_REDIRECTS (20) 以下なら全て allow", () => {
+    for (let i = 0; i < 20; i++) {
+      const r = checkRedirect(`/p${i}`);
+      expect(r.allow).toBe(true);
+      expect(r.tripped).toBe(false);
+    }
+  });
+
+  it("MAX_REDIRECTS を超えると trip して block", () => {
+    for (let i = 0; i < 20; i++) checkRedirect(`/p${i}`);
+    const r21 = checkRedirect("/p21");
+    expect(r21.allow).toBe(false);
+    expect(r21.tripped).toBe(true);
+    expect(isRedirectGuardTripped()).toBe(true);
+  });
+
+  it("trip 後は以降の navigation を全て block", () => {
+    for (let i = 0; i < 25; i++) checkRedirect(`/p${i}`);
+    const r = checkRedirect("/extra");
+    expect(r.allow).toBe(false);
+    expect(r.tripped).toBe(false); // 既に trip 済 (今回が初 trip ではない)
+  });
+
+  it("WINDOW_MS 以上の間隔があれば古いイベントは廃棄", async () => {
+    // 19 件積む
+    for (let i = 0; i < 19; i++) checkRedirect(`/p${i}`);
+    // 2 秒経過させる
+    await new Promise((r) => setTimeout(r, 2100));
+    // 古い 19 件は廃棄、新規 1 件のみ
+    const r = checkRedirect("/fresh");
+    expect(r.allow).toBe(true);
+    expect(r.recentCount).toBe(1);
+  });
+
+  it("resetRedirectGuard() で完全リセット", () => {
+    for (let i = 0; i < 25; i++) checkRedirect(`/p${i}`);
+    expect(isRedirectGuardTripped()).toBe(true);
+    resetRedirectGuard();
+    expect(isRedirectGuardTripped()).toBe(false);
+    const r = checkRedirect("/after-reset");
+    expect(r.allow).toBe(true);
+  });
+});

--- a/designer/src/utils/redirectGuard.ts
+++ b/designer/src/utils/redirectGuard.ts
@@ -19,6 +19,18 @@ const MAX_REDIRECTS = 20;
 
 let recent: RedirectEvent[] = [];
 let tripped = false;
+let lastTripSummary: string[] = [];
+
+type TripListener = (summary: string[]) => void;
+const tripListeners = new Set<TripListener>();
+
+/** trip 発生時に呼ばれるコールバックを登録する。React 側でモーダル表示等に使う。 */
+export function subscribeRedirectGuardTrip(cb: TripListener): () => void {
+  tripListeners.add(cb);
+  // 既に trip 済なら即時通知 (購読タイミング後勝ち)
+  if (tripped) cb(lastTripSummary);
+  return () => { tripListeners.delete(cb); };
+}
 
 export interface GuardResult {
   /** redirect を許可してよいか */
@@ -47,10 +59,15 @@ export function checkRedirect(path: string): GuardResult {
   if (recent.length > MAX_REDIRECTS) {
     tripped = true;
     const summary = recent.map((e) => e.path).slice(-10);
+    lastTripSummary = summary;
     uiLog("error", "guard", "redirect storm detected — blocking further navigation", {
       count: recent.length,
       windowMs: WINDOW_MS,
       lastPaths: summary,
+    });
+    // listener 通知 (UI モーダル表示等)
+    tripListeners.forEach((cb) => {
+      try { cb(summary); } catch (e) { console.error("[redirectGuard] listener threw:", e); }
     });
     return { allow: false, tripped: true, recentCount: recent.length };
   }
@@ -68,4 +85,10 @@ export function isRedirectGuardTripped(): boolean {
 export function resetRedirectGuard(): void {
   recent = [];
   tripped = false;
+  lastTripSummary = [];
+}
+
+/** 直近 trip の path 列 (バナー表示用) */
+export function getLastTripSummary(): readonly string[] {
+  return lastTripSummary;
 }

--- a/designer/src/utils/redirectGuard.ts
+++ b/designer/src/utils/redirectGuard.ts
@@ -1,0 +1,71 @@
+/**
+ * Redirect 無限ループ防止 circuit breaker (#748 follow-up)
+ *
+ * AppShell の useEffect 群 (URL → タブ / タブ → URL / workspace ガード / fallbackToDashboard)
+ * 同士が想定外の状況で navigate を撃ち合うと、無限ループ → backend RPC storm になる。
+ * 全ての navigate 経路でこの guard を通し、短時間に閾値超のリダイレクトを検出したら
+ * 強制停止する (= バグの早期発覚 + サーバ保護)。
+ */
+
+import { uiLog } from "./uiLog";
+
+interface RedirectEvent {
+  ts: number;
+  path: string;
+}
+
+const WINDOW_MS = 2000;
+const MAX_REDIRECTS = 20;
+
+let recent: RedirectEvent[] = [];
+let tripped = false;
+
+export interface GuardResult {
+  /** redirect を許可してよいか */
+  allow: boolean;
+  /** circuit breaker が今回 trip したか (= 直前で許容、本回が初回 block) */
+  tripped: boolean;
+  /** 最近 window 内の redirect 件数 */
+  recentCount: number;
+}
+
+/**
+ * navigate を撃つ前に呼び出す。allow=false の時は navigate を skip すること。
+ *
+ * @param path 遷移先パス (デバッグ表示用)
+ */
+export function checkRedirect(path: string): GuardResult {
+  const now = Date.now();
+  // 古いイベントを削除
+  recent = recent.filter((e) => now - e.ts < WINDOW_MS);
+  recent.push({ ts: now, path });
+
+  if (tripped) {
+    return { allow: false, tripped: false, recentCount: recent.length };
+  }
+
+  if (recent.length > MAX_REDIRECTS) {
+    tripped = true;
+    const summary = recent.map((e) => e.path).slice(-10);
+    uiLog("error", "guard", "redirect storm detected — blocking further navigation", {
+      count: recent.length,
+      windowMs: WINDOW_MS,
+      lastPaths: summary,
+    });
+    return { allow: false, tripped: true, recentCount: recent.length };
+  }
+
+  uiLog("debug", "redirect", path, { recent: recent.length });
+  return { allow: true, tripped: false, recentCount: recent.length };
+}
+
+/** circuit breaker の現在状態 (UI からエラー表示用) */
+export function isRedirectGuardTripped(): boolean {
+  return tripped;
+}
+
+/** 主にテスト用: state をリセット */
+export function resetRedirectGuard(): void {
+  recent = [];
+  tripped = false;
+}

--- a/designer/src/utils/uiLog.ts
+++ b/designer/src/utils/uiLog.ts
@@ -32,6 +32,8 @@ interface RecentEvent {
   ts: number;
   category: UiLogCategory;
   msg: string;
+  /** uiLog() の第 4 引数 ctx を保持。バグ報告時に `__uiLogDump()` で取り出して原因特定に使う。 */
+  ctx?: Record<string, unknown>;
 }
 
 const LEVEL_ORDER: Record<UiLogLevel, number> = {
@@ -60,9 +62,9 @@ function ts(): string {
   return new Date().toISOString().slice(11, 23); // HH:mm:ss.sss
 }
 
-function pushRecent(category: UiLogCategory, msg: string): void {
+function pushRecent(category: UiLogCategory, msg: string, ctx?: Record<string, unknown>): void {
   const now = Date.now();
-  _recent.push({ ts: now, category, msg });
+  _recent.push({ ts: now, category, msg, ctx });
   // ウィンドウ外を捨てる + 上限超過分をトリム
   _recent = _recent.filter((e) => now - e.ts < RECENT_WINDOW_MS);
   if (_recent.length > RECENT_MAX) _recent = _recent.slice(-RECENT_MAX);
@@ -91,7 +93,7 @@ export function uiLog(
   msg: string,
   ctx?: Record<string, unknown>,
 ): void {
-  pushRecent(category, msg);
+  pushRecent(category, msg, ctx);
   detectFlooding(category, msg);
   if (!shouldLog(level)) return;
   const prefix = `[${ts()}][${category}]`;

--- a/designer/src/utils/uiLog.ts
+++ b/designer/src/utils/uiLog.ts
@@ -1,0 +1,146 @@
+/**
+ * UI フレームワークレイヤーの構造化ログ (#748 follow-up、redirect-loop 調査用)
+ *
+ * 目的:
+ *  - navigate / tab open-close / URL sync / workspace state transition / resource load
+ *    のイベントを共通フォーマットで console に出力し、無限ループ系バグの追跡を容易にする
+ *  - 同一カテゴリの異常頻度 (例: 同 path navigate × 5+ in 1s) をフレームワーク側で
+ *    自動検出して console.warn する
+ *
+ * 出力例:
+ *   [13:42:18.345][redirect] /w/A/view-definition/edit/X { from: "/w/A/" }
+ *   [13:42:18.351][urlsync] view-definition tab open { id: "X", label: "注文一覧" }
+ *   [13:42:18.402][load] viewDefinition X → null { hasFallback: true }
+ *
+ * 環境変数 / localStorage で出力レベルを制御:
+ *   localStorage.setItem("ui-log", "debug")  // 全出力
+ *   localStorage.setItem("ui-log", "warn")   // 警告以上のみ (デフォルト)
+ *   localStorage.setItem("ui-log", "off")    // 完全停止
+ */
+
+export type UiLogLevel = "debug" | "info" | "warn" | "error" | "off";
+export type UiLogCategory =
+  | "redirect"
+  | "urlsync"
+  | "tabsync"
+  | "workspace"
+  | "load"
+  | "ws-broadcast"
+  | "guard";
+
+interface RecentEvent {
+  ts: number;
+  category: UiLogCategory;
+  msg: string;
+}
+
+const LEVEL_ORDER: Record<UiLogLevel, number> = {
+  debug: 0, info: 1, warn: 2, error: 3, off: 4,
+};
+
+let _recent: RecentEvent[] = [];
+const RECENT_WINDOW_MS = 1000;
+const RECENT_MAX = 200; // メモリ抑制
+
+function getLevel(): UiLogLevel {
+  try {
+    const v = localStorage.getItem("ui-log");
+    if (v === "debug" || v === "info" || v === "warn" || v === "error" || v === "off") return v;
+  } catch { /* SSR / private mode */ }
+  // 開発環境では debug (ログだけで現象判別できるレベル)、本番では warn
+  return import.meta.env?.DEV ? "debug" : "warn";
+}
+
+function shouldLog(level: UiLogLevel): boolean {
+  const cur = getLevel();
+  return LEVEL_ORDER[level] >= LEVEL_ORDER[cur];
+}
+
+function ts(): string {
+  return new Date().toISOString().slice(11, 23); // HH:mm:ss.sss
+}
+
+function pushRecent(category: UiLogCategory, msg: string): void {
+  const now = Date.now();
+  _recent.push({ ts: now, category, msg });
+  // ウィンドウ外を捨てる + 上限超過分をトリム
+  _recent = _recent.filter((e) => now - e.ts < RECENT_WINDOW_MS);
+  if (_recent.length > RECENT_MAX) _recent = _recent.slice(-RECENT_MAX);
+}
+
+/** 1 秒間に同 (category, msg) が threshold 回超えたら warn を出す。 */
+function detectFlooding(category: UiLogCategory, msg: string): boolean {
+  const now = Date.now();
+  const sameCount = _recent.filter(
+    (e) => now - e.ts < RECENT_WINDOW_MS && e.category === category && e.msg === msg,
+  ).length;
+  // 同 (category, msg) が 5 回超: 多分ループ
+  if (sameCount >= 5 && sameCount % 5 === 0) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[${ts()}][ui-log][flood] ${category}/${msg.slice(0, 60)} が 1 秒に ${sameCount} 回発生しています。loop 疑い。`,
+    );
+    return true;
+  }
+  return false;
+}
+
+export function uiLog(
+  level: UiLogLevel,
+  category: UiLogCategory,
+  msg: string,
+  ctx?: Record<string, unknown>,
+): void {
+  pushRecent(category, msg);
+  detectFlooding(category, msg);
+  if (!shouldLog(level)) return;
+  const prefix = `[${ts()}][${category}]`;
+  // eslint-disable-next-line no-console
+  const out =
+    level === "error" ? console.error
+    : level === "warn" ? console.warn
+    : level === "info" ? console.info
+    : console.debug;
+  if (ctx) out(prefix, msg, ctx);
+  else out(prefix, msg);
+}
+
+// 便利な短縮
+export const uiDebug = (cat: UiLogCategory, msg: string, ctx?: Record<string, unknown>) =>
+  uiLog("debug", cat, msg, ctx);
+export const uiInfo = (cat: UiLogCategory, msg: string, ctx?: Record<string, unknown>) =>
+  uiLog("info", cat, msg, ctx);
+export const uiWarn = (cat: UiLogCategory, msg: string, ctx?: Record<string, unknown>) =>
+  uiLog("warn", cat, msg, ctx);
+export const uiError = (cat: UiLogCategory, msg: string, ctx?: Record<string, unknown>) =>
+  uiLog("error", cat, msg, ctx);
+
+/** 主にテスト用 */
+export function _resetUiLog(): void { _recent = []; }
+export function _getRecent(): readonly RecentEvent[] { return _recent.slice(); }
+
+/**
+ * ブラウザコンソールから呼び出してバグ報告に貼り付けやすくするための窓口。
+ * 例: `__uiLogDump()` をコンソールで実行 → 直近 1 秒の全イベントが返る。
+ *
+ * バグ報告時のテンプレ:
+ *   1. 不具合の現象を文章で説明
+ *   2. ブラウザコンソールで `__uiLogDump()` を実行し結果を貼る
+ *   3. URL バーの値を貼る
+ *
+ * これだけで AI 側はリダイレクトループ / 重複 load / state 競合を判別できる前提で
+ * カテゴリ・メッセージ・コンテキストを設計している。
+ */
+declare global {
+  interface Window {
+    __uiLogDump?: () => readonly RecentEvent[];
+    __uiLogSetLevel?: (l: UiLogLevel) => void;
+  }
+}
+
+if (typeof window !== "undefined") {
+  window.__uiLogDump = () => _recent.slice();
+  window.__uiLogSetLevel = (l: UiLogLevel) => {
+    try { localStorage.setItem("ui-log", l); } catch { /* private mode */ }
+  };
+}


### PR DESCRIPTION
## 背景

#748 マージ後のスモーク中、ユーザー観測で「注文一覧 ↔ ダッシュボードが交互に切替表示される」点滅を報告。原因がループでもテストアーティファクトでも、**無限リダイレクトはサーバ RPC storm を起こす致命的欠陥**。フレームワーク層で防衛線と診断ログを整備する。

## 変更内容

### 1. \`handleNotFound\` 系を \`{ replace: true }\` に統一

| ファイル | 修正前 | 修正後 |
|---|---|---|
| ViewDefinitionEditor.tsx | \`navigate(...)\` | \`navigate(..., { replace: true })\` |
| SequenceEditor.tsx | 同上 | 同上 |
| ViewEditor.tsx | 同上 | 同上 |
| TableEditor.tsx | 同上 | 同上 |
| ProcessFlowEditor.tsx | 同上 | 同上 |

戻るボタンで not-found URL に再突入 → 再 RPC のループ穴を閉塞。

### 2. redirectGuard circuit breaker

\`designer/src/utils/redirectGuard.ts\` 新設:
- 2 秒以内に 20 回超のリダイレクトで **trip → 以降の navigate を全 block**
- AppShell の全 navigate 呼出を \`checkRedirect()\` 経由に統一
- \`window.location.href = ...\` (workspace-switch 完全リロード) も guard 経由
- 6 ケース単体テスト

### 3. UI 構造化ログ

\`designer/src/utils/uiLog.ts\` 新設:
- カテゴリ: \`[redirect]\` / \`[urlsync]\` / \`[tabsync]\` / \`[workspace]\` / \`[load]\` / \`[ws-broadcast]\` / \`[guard]\`
- 1 秒に同 (category, msg) が 5 回超で自動 \`[flood]\` warn → ループ疑い早期検出
- 開発時 \`debug\` / 本番 \`warn\` がデフォルト、\`localStorage.setItem("ui-log", "off")\` で停止
- **\`window.__uiLogDump()\`** をグローバル公開 — バグ報告時にユーザーがコンソールで実行 → 直近 1 秒の全イベント JSON を取得 → AI に貼るだけで原因特定可能なレベル

### 4. ログ埋め込み箇所

AppShell:
- workspaceState transition (loading / active / lockdown / error)
- pathname change (URL → tab sync)
- active-tab → URL sync の navigate
- workspace switch reload
- resource not found → fallback

workspaceStore:
- loadWorkspaces start / success / failure
- workspace.changed broadcast 受信 + per-session フィルタ判定

tabStore:
- tab open / re-activate / close / setActiveTab

## バグ報告フロー (期待効果)

```
[user] 「画面が点滅する」
↓
[user 操作] ブラウザコンソールで __uiLogDump() を実行
↓
[出力例]
[
  { ts: 1731..., category: "redirect", msg: "/w/A/" },
  { ts: 1731..., category: "tabsync", msg: "active-tab → URL" },
  { ts: 1731..., category: "redirect", msg: "/w/A/view-definition/edit/X" },
  ...
]
↓
[AI] ログだけでループ経路と原因を特定 → 修正
```

## テスト

- vitest: **1460 passed** (新規 6 + 既存 1454)
- tsc / eslint / build: clean

## 関連

- 前 PR: #749 (#748 ViewDefinition Editor Level 2/3)
- ユーザー報告: 「無限ループ・無限リダイレクトは厳禁、サーバが落ちるのでは」「ログだけで現象判別できるレベルが必要」

## Test plan

- [x] vitest 全件 pass (1460/1460)
- [x] redirectGuard 6 ケース pass
- [x] tsc / build clean
- [ ] 実機: \`__uiLogDump()\` が console から呼べる確認 (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)