### PR TITLE
feat(server): designer-mcp 物理ログ + ブラウザ uiLog サーバ統合

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ Thumbs.db
 # Logs
 *.log
 npm-debug.log*
+logs/
 
 # Local env
 .env

--- a/designer-mcp/AGENTS.md
+++ b/designer-mcp/AGENTS.md
@@ -25,6 +25,32 @@ npm run build      # Compile to dist/
 
 **自動 spawn はしない** (URL mode): エージェント起動時に既存サーバが無いと MCP 不接続状態になるため、backend が上がっているか先に確認すること。
 
+## 物理ログ (#751)
+
+サーバ起動時に \`<projectRoot>/logs/designer-mcp-YYYY-MM-DD.log\` (UTF-8 / JSON Lines) を作成し、すべてのサーバ側ログ + ブラウザから flush された UI ログ (\`client-*\` カテゴリ) を統合書き込みする。
+
+### 環境変数
+
+| env | 効果 | デフォルト |
+|---|---|---|
+| `DESIGNER_MCP_LOG_LEVEL` | 物理ログの最小レベル (`debug` / `info` / `warn` / `error`) | `info` |
+| `DESIGNER_LOG_DIR` | 出力先ディレクトリ上書き (デフォルトは projectRoot/logs) | unset |
+
+### バグ報告フロー
+
+ユーザーから不具合報告を受ける際は、以下 2 点をセットで取得すると AI が後追い調査できる:
+
+1. **クライアント側**: ブラウザ DevTools コンソールで `__uiLogDump()` を実行 → JSON 出力をコピペ
+2. **サーバ側**: `logs/designer-mcp-YYYY-MM-DD.log` の末尾 100 行をコピペ
+
+両ログを ISO 時刻で突き合わせて、UI redirect → WS request → handler 例外 の因果連鎖を特定可能なレベルを目指している。
+
+### ログ保持
+
+- 起動時に 7 日以上前のログを自動削除 (retention rotation)
+- ログサイズ上限なし (1 日 1 ファイル運用前提)
+- gitignore 済 (`logs/`)
+
 ## Testing
 
 - MCP E2E: `../designer/e2e/mcp/**/*.spec.ts` — wsBridge ファイル操作（本サーバの起動が必要）

--- a/designer-mcp/src/index.ts
+++ b/designer-mcp/src/index.ts
@@ -41,17 +41,33 @@ import {
   LockNotHeldError,
 } from "./lockManager.js";
 import { resolveOnBehalfOfSession, logAuditIfDelegated } from "./onBehalfOfSession.js";
+import { initServerLog, shutdownServerLog, logInfo, logError, ingestClientLog } from "./serverLog.js";
+
+// 物理ログ初期化 (#750 follow-up): logs/ ディレクトリへ JSON Lines 形式で永続化
+// projectRoot = designer-mcp の親 (= repo root)。env DESIGNER_LOG_DIR で上書き可能。
+const projectRoot = process.env.DESIGNER_LOG_DIR ?? path.resolve(process.cwd(), "..");
+initServerLog(projectRoot);
 
 // 常駐バックエンドなので停止 signal (SIGTERM/SIGINT/disconnect) のみ監視。
 // stdin は監視しない (#302: HTTP transport に統一、stdio 廃止)。
 function setupLifecycle(): void {
   const exitHandler = (reason: string) => {
-    console.error(`[MCP] Exiting: ${reason}`);
+    logInfo("lifecycle", `Exiting: ${reason}`);
+    shutdownServerLog();
     process.exit(0);
   };
   process.on("SIGTERM", () => exitHandler("SIGTERM"));
   process.on("SIGINT", () => exitHandler("SIGINT"));
   process.on("disconnect", () => exitHandler("disconnected from parent"));
+  process.on("uncaughtException", (err) => {
+    logError("lifecycle", "uncaughtException", { error: err.message, stack: err.stack });
+  });
+  process.on("unhandledRejection", (reason) => {
+    logError("lifecycle", "unhandledRejection", {
+      reason: reason instanceof Error ? reason.message : String(reason),
+      stack: reason instanceof Error ? reason.stack : undefined,
+    });
+  });
 }
 
 setupLifecycle();
@@ -67,24 +83,37 @@ initWorkspaceState();
   const r = await autoActivateOnStartup();
   switch (r.status) {
     case "lockdown":
-      console.error(`[Workspace] lockdown モード: ${r.path}`);
+      logInfo("workspace", "lockdown モード", { path: r.path });
       break;
     case "restored":
-      console.error(`[Workspace] 前回の workspace を再オープン: ${r.entry.name} (${r.entry.path})`);
+      logInfo("workspace", "前回の workspace を再オープン", { name: r.entry.name, path: r.entry.path });
       break;
     case "registeredLegacy":
-      console.error(`[Workspace] 旧来の data/ を default workspace として登録: ${r.entry.path}`);
+      logInfo("workspace", "旧来の data/ を default workspace として登録", { path: r.entry.path });
       break;
     case "none":
-      console.error("[Workspace] active 未選択。UI 側で /workspace/select に誘導されます");
+      logInfo("workspace", "active 未選択 (UI 側で /workspace/select に誘導)");
       break;
   }
 }
 
 // HTTP + WebSocket サーバ起動 (port 5179 に両方同居)
 await wsBridge.start();
-wsBridge.on("connected", () => console.error("[MCP] Designer connected via WebSocket"));
-wsBridge.on("disconnected", () => console.error("[MCP] Designer disconnected"));
+wsBridge.on("connected", () => logInfo("ws-bridge", "Designer connected via WebSocket"));
+wsBridge.on("disconnected", () => logInfo("ws-bridge", "Designer disconnected"));
+
+// クライアント (ブラウザ uiLog) からログ flush を受け取るハンドラ (#750 follow-up)
+wsBridge.registerBrowserHandler("client.log.flush", async (params) => {
+  const entries = ((params as { entries?: unknown })?.entries ?? []) as Array<{
+    ts: number;
+    level: "debug" | "info" | "warn" | "error";
+    category: string;
+    msg: string;
+    ctx?: Record<string, unknown>;
+  }>;
+  if (!Array.isArray(entries)) return { count: 0 };
+  return ingestClientLog(entries);
+});
 
 // MCPサーバーのファクトリ (#302, #700 R-2): HTTP リクエスト毎に fresh な Server インスタンスを
 // 作成することで、複数クライアントが同時接続しても互いの initialize 状態と干渉しない

--- a/designer-mcp/src/serverLog.test.ts
+++ b/designer-mcp/src/serverLog.test.ts
@@ -1,0 +1,75 @@
+/**
+ * serverLog の単体テスト (#750 follow-up)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { initServerLog, log, ingestClientLog, shutdownServerLog } from "./serverLog.js";
+
+let tmpRoot = "";
+
+function readLatestLogFile(): string {
+  const logDir = path.join(tmpRoot, "logs");
+  if (!fs.existsSync(logDir)) return "";
+  const files = fs.readdirSync(logDir).filter((f) => f.endsWith(".log"));
+  if (files.length === 0) return "";
+  files.sort();
+  return fs.readFileSync(path.join(logDir, files[files.length - 1]), "utf-8");
+}
+
+describe("serverLog", () => {
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "designer-mcp-log-"));
+    initServerLog(tmpRoot);
+  });
+  afterEach(() => {
+    shutdownServerLog();
+    try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it("logs/ ディレクトリと日付別ファイルを作成し initialized エントリが書かれる", () => {
+    const out = readLatestLogFile();
+    expect(out).toContain('"category":"server-log"');
+    expect(out).toContain('"msg":"logger initialized"');
+  });
+
+  it("log() が JSON Lines 形式で書き込む", () => {
+    log("info", "test", "hello", { foo: "bar" });
+    const out = readLatestLogFile();
+    const lines = out.trim().split("\n");
+    const last = JSON.parse(lines[lines.length - 1]);
+    expect(last.level).toBe("info");
+    expect(last.category).toBe("test");
+    expect(last.msg).toBe("hello");
+    expect(last.ctx).toEqual({ foo: "bar" });
+    expect(last.ts).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("ingestClientLog はカテゴリに 'client-' プレフィックスを付ける", () => {
+    ingestClientLog([
+      { ts: Date.now(), level: "warn", category: "redirect", msg: "/foo", ctx: { recent: 5 } },
+    ]);
+    const out = readLatestLogFile();
+    expect(out).toContain('"category":"client-redirect"');
+    expect(out).toContain('"msg":"/foo"');
+  });
+
+  it("ingestClientLog は client_ts を ctx に含める", () => {
+    const clientTs = Date.UTC(2026, 0, 1, 12, 0, 0);
+    ingestClientLog([{ ts: clientTs, level: "info", category: "tabsync", msg: "tab open" }]);
+    const out = readLatestLogFile();
+    const lines = out.trim().split("\n");
+    const lastEntry = JSON.parse(lines[lines.length - 1]);
+    expect(lastEntry.ctx._clientTs).toMatch(/2026-01-01T12:00:00/);
+  });
+
+  it("count を返す", () => {
+    const r = ingestClientLog([
+      { ts: Date.now(), level: "info", category: "a", msg: "1" },
+      { ts: Date.now(), level: "warn", category: "b", msg: "2" },
+    ]);
+    expect(r.count).toBe(2);
+  });
+});

--- a/designer-mcp/src/serverLog.ts
+++ b/designer-mcp/src/serverLog.ts
@@ -1,0 +1,144 @@
+/**
+ * designer-mcp 物理ログ (ファイル) 出力 (#750 follow-up)
+ *
+ * 目的:
+ *  - ブラウザの uiLog は揮発・リフレッシュで消える → サーバ側で永続化
+ *  - 無限ループ系・WS エラー系・ハンドラ例外を後追い調査可能にする
+ *  - ブラウザから flush された log エントリも同ファイルに統合 (client_uilog)
+ *
+ * 出力先: <projectRoot>/logs/designer-mcp-YYYY-MM-DD.log (UTF-8 / 1 行 1 JSON)
+ *
+ * ローテーション: 日付別ファイル名で自動切替 (Date.now() 経由で即時切替)。
+ * 7 日分以上のログは自動削除 (起動時)。
+ *
+ * バグ報告フロー:
+ *   1. ユーザーがブラウザコンソールで __uiLogDump() 実行 → JSON を貼る
+ *   2. 別途 logs/ ディレクトリの最新ファイルを共有
+ *   3. AI 側はクライアント側 + サーバ側ログを突き合わせて root cause 特定
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+export interface LogEntry {
+  ts: string;       // ISO timestamp
+  level: LogLevel;
+  category: string; // e.g. "ws-bridge" / "workspace" / "handler" / "client-uilog"
+  msg: string;
+  ctx?: Record<string, unknown>;
+}
+
+const LEVEL_ORDER: Record<LogLevel, number> = { debug: 0, info: 1, warn: 2, error: 3 };
+const RETENTION_DAYS = 7;
+
+let _logDir: string | null = null;
+let _currentDate = "";
+let _minLevel: LogLevel = "info";
+
+/** logger 初期化。projectRoot は data/ の親ディレクトリ。 */
+export function initServerLog(projectRoot: string): void {
+  _logDir = path.join(projectRoot, "logs");
+  try {
+    fs.mkdirSync(_logDir, { recursive: true });
+  } catch (e) {
+    console.error(`[serverLog] Failed to create log dir ${_logDir}:`, e);
+    _logDir = null;
+    return;
+  }
+  _minLevel = (process.env.DESIGNER_MCP_LOG_LEVEL as LogLevel) ?? "info";
+  _rotateRetention();
+  // 起動 banner
+  log("info", "server-log", "logger initialized", { dir: _logDir, level: _minLevel });
+}
+
+function _rotateRetention(): void {
+  if (!_logDir) return;
+  try {
+    const files = fs.readdirSync(_logDir).filter((f) => f.startsWith("designer-mcp-") && f.endsWith(".log"));
+    const cutoff = Date.now() - RETENTION_DAYS * 86400_000;
+    for (const f of files) {
+      const m = f.match(/designer-mcp-(\d{4})-(\d{2})-(\d{2})\.log/);
+      if (!m) continue;
+      const fileDate = new Date(`${m[1]}-${m[2]}-${m[3]}T00:00:00Z`).getTime();
+      if (fileDate < cutoff) {
+        try { fs.unlinkSync(path.join(_logDir, f)); } catch { /* ignore */ }
+      }
+    }
+  } catch (e) {
+    console.error("[serverLog] retention rotation failed:", e);
+  }
+}
+
+function _todayFileName(): string {
+  const now = new Date();
+  const y = now.getUTCFullYear();
+  const m = String(now.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(now.getUTCDate()).padStart(2, "0");
+  return `designer-mcp-${y}-${m}-${d}.log`;
+}
+
+/** メイン log 出力関数。category は短い文字列推奨。 */
+export function log(
+  level: LogLevel,
+  category: string,
+  msg: string,
+  ctx?: Record<string, unknown>,
+): void {
+  if (LEVEL_ORDER[level] < LEVEL_ORDER[_minLevel]) return;
+  const entry: LogEntry = {
+    ts: new Date().toISOString(),
+    level,
+    category,
+    msg,
+    ctx,
+  };
+  // ファイル出力 — appendFileSync で確実に flush (テスト容易性 + クラッシュ時の log 保全)。
+  // 高頻度ログでもボトルネックにならない (server-side は秒間 100 件もない想定)。
+  if (_logDir) {
+    try {
+      const today = _todayFileName();
+      _currentDate = today;
+      fs.appendFileSync(path.join(_logDir, today), JSON.stringify(entry) + "\n", "utf-8");
+    } catch (e) {
+      console.error("[serverLog] write failed:", e);
+    }
+  }
+  // 重要度高は console にも出す (既存挙動互換 + 開発時の視認性)
+  if (level === "warn" || level === "error") {
+    const prefix = `[${entry.ts}][${category}]`;
+    if (level === "error") console.error(prefix, msg, ctx ?? "");
+    else console.warn(prefix, msg, ctx ?? "");
+  }
+}
+
+export const logDebug = (cat: string, msg: string, ctx?: Record<string, unknown>) => log("debug", cat, msg, ctx);
+export const logInfo = (cat: string, msg: string, ctx?: Record<string, unknown>) => log("info", cat, msg, ctx);
+export const logWarn = (cat: string, msg: string, ctx?: Record<string, unknown>) => log("warn", cat, msg, ctx);
+export const logError = (cat: string, msg: string, ctx?: Record<string, unknown>) => log("error", cat, msg, ctx);
+
+/**
+ * クライアント (ブラウザ) から ui-log エントリを受け取って物理ログに統合する。
+ * wsBridge の "client.log.flush" メソッドから呼ばれる想定。
+ */
+export function ingestClientLog(entries: ReadonlyArray<{
+  ts: number;
+  level: LogLevel;
+  category: string;
+  msg: string;
+  ctx?: Record<string, unknown>;
+}>): { count: number } {
+  for (const e of entries) {
+    log(e.level, `client-${e.category}`, e.msg, {
+      ...e.ctx,
+      _clientTs: new Date(e.ts).toISOString(),
+    });
+  }
+  return { count: entries.length };
+}
+
+/** プロセス終了時のクリーンアップ。appendFileSync 利用なので buffer flush は不要だが、API 互換のため残す。 */
+export function shutdownServerLog(): void {
+  _currentDate = "";
+}

--- a/designer-mcp/src/serverLog.ts
+++ b/designer-mcp/src/serverLog.ts
@@ -34,7 +34,6 @@ const LEVEL_ORDER: Record<LogLevel, number> = { debug: 0, info: 1, warn: 2, erro
 const RETENTION_DAYS = 7;
 
 let _logDir: string | null = null;
-let _currentDate = "";
 let _minLevel: LogLevel = "info";
 
 /** logger 初期化。projectRoot は data/ の親ディレクトリ。 */
@@ -96,11 +95,10 @@ export function log(
   };
   // ファイル出力 — appendFileSync で確実に flush (テスト容易性 + クラッシュ時の log 保全)。
   // 高頻度ログでもボトルネックにならない (server-side は秒間 100 件もない想定)。
+  // 日付ロールオーバーは _todayFileName() が UTC 日付ベースで毎回算出するので自動切替。
   if (_logDir) {
     try {
-      const today = _todayFileName();
-      _currentDate = today;
-      fs.appendFileSync(path.join(_logDir, today), JSON.stringify(entry) + "\n", "utf-8");
+      fs.appendFileSync(path.join(_logDir, _todayFileName()), JSON.stringify(entry) + "\n", "utf-8");
     } catch (e) {
       console.error("[serverLog] write failed:", e);
     }
@@ -138,7 +136,7 @@ export function ingestClientLog(entries: ReadonlyArray<{
   return { count: entries.length };
 }
 
-/** プロセス終了時のクリーンアップ。appendFileSync 利用なので buffer flush は不要だが、API 互換のため残す。 */
+/** プロセス終了時のクリーンアップ。appendFileSync 利用なので buffer flush は不要 (no-op、API 互換のみ)。 */
 export function shutdownServerLog(): void {
-  _currentDate = "";
+  /* no-op: appendFileSync で同期書き込み済 */
 }

--- a/designer-mcp/src/wsBridge.ts
+++ b/designer-mcp/src/wsBridge.ts
@@ -973,12 +973,32 @@ class WsBridge extends EventEmitter {
           break;
         }
 
-        default:
+        default: {
+          // 動的に登録されたハンドラ (#750 follow-up: client.log.flush 等)
+          const dynHandler = this._browserHandlers.get(method);
+          if (dynHandler) {
+            const result = await dynHandler(params, { clientId });
+            respond(result);
+            break;
+          }
           respondError(`未知のリクエストメソッド: ${method}`);
+        }
       }
     } catch (e) {
       respondError(e instanceof Error ? e.message : String(e));
     }
+  }
+
+  /** 動的にブラウザリクエストハンドラを登録する (#750 follow-up: client.log.flush 等)。 */
+  private _browserHandlers = new Map<
+    string,
+    (params: unknown, ctx: { clientId: string }) => Promise<unknown> | unknown
+  >();
+  registerBrowserHandler(
+    method: string,
+    handler: (params: unknown, ctx: { clientId: string }) => Promise<unknown> | unknown,
+  ): void {
+    this._browserHandlers.set(method, handler);
   }
 
   /**

--- a/designer/src/components/AppShell.tsx
+++ b/designer/src/components/AppShell.tsx
@@ -54,7 +54,7 @@ import { ResourceLoading } from "./common/ResourceLoading";
 import { useErrorDialog } from "./common/ErrorDialogProvider";
 import { recordError } from "../utils/errorLog";
 import { checkRedirect, subscribeRedirectGuardTrip, isRedirectGuardTripped } from "../utils/redirectGuard";
-import { uiInfo, uiWarn } from "../utils/uiLog";
+import { uiInfo, uiWarn, setupServerLogFlush } from "../utils/uiLog";
 
 function useTabs() {
   const [tabs, setTabs] = useState<readonly TabItem[]>(getTabs);
@@ -209,6 +209,7 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
     const bridge = mcpBridge as unknown as {
       onStatusChange: (cb: (s: string) => void) => () => void;
       startWithoutEditor: () => void;
+      request: (method: string, params?: unknown) => Promise<unknown>;
     };
     const unsubStatus = bridge.onStatusChange((s) => {
       if (s === "connected") {
@@ -216,7 +217,11 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
       }
     });
     bridge.startWithoutEditor();
-    return () => { unsubBroadcast(); unsubStatus(); };
+    // サーバ側物理ログへの定期 flush (#750 follow-up): warn/error を designer-mcp/logs/ に永続化
+    const unsubFlush = setupServerLogFlush((entries) =>
+      bridge.request("client.log.flush", { entries }),
+    );
+    return () => { unsubBroadcast(); unsubStatus(); unsubFlush(); };
   }, []);
 
   // workspace state 変化を log 化 (ループ追跡用)

--- a/designer/src/utils/uiLog.ts
+++ b/designer/src/utils/uiLog.ts
@@ -95,6 +95,8 @@ export function uiLog(
 ): void {
   pushRecent(category, msg, ctx);
   detectFlooding(category, msg);
+  // warn/error はサーバ flush キューにも入れる (#750 follow-up: 物理ログ統合)
+  _enqueueForFlush(category, msg, level, ctx);
   if (!shouldLog(level)) return;
   const prefix = `[${ts()}][${category}]`;
   // eslint-disable-next-line no-console
@@ -144,5 +146,49 @@ if (typeof window !== "undefined") {
   window.__uiLogDump = () => _recent.slice();
   window.__uiLogSetLevel = (l: UiLogLevel) => {
     try { localStorage.setItem("ui-log", l); } catch { /* private mode */ }
+  };
+}
+
+// ─── サーバ側物理ログへの定期 flush (#750 follow-up) ──────────────────────
+// warn / error レベルのイベントはブラウザリフレッシュで消えてしまうため
+// designer-mcp の logs/ に統合する。送信は非同期 + best-effort (失敗時は黙って破棄)。
+
+const _flushQueue: RecentEvent[] = [];
+
+function _enqueueForFlush(category: UiLogCategory, msg: string, level: UiLogLevel, ctx?: Record<string, unknown>): void {
+  if (level !== "warn" && level !== "error") return;
+  _flushQueue.push({ ts: Date.now(), category, msg, ctx });
+  // キューが大きくなりすぎないよう上限 (バックエンド disconnect 中の保護)
+  if (_flushQueue.length > 500) _flushQueue.splice(0, _flushQueue.length - 500);
+}
+
+/**
+ * サーバ側に flush する hook。mcpBridge が "client.log.flush" を呼べる前提で使う。
+ * mcpBridge.ts の startWithoutEditor() 直後に setupServerLogFlush() を呼ぶ。
+ *
+ * sendFn は mcpBridge.request("client.log.flush", { entries }) を期待。
+ */
+export function setupServerLogFlush(
+  sendFn: (entries: ReadonlyArray<RecentEvent>) => Promise<unknown>,
+  intervalMs = 5000,
+): () => void {
+  const flush = async () => {
+    if (_flushQueue.length === 0) return;
+    const batch = _flushQueue.splice(0, _flushQueue.length);
+    try {
+      await sendFn(batch);
+    } catch {
+      // 失敗時は console.error でも残しておく (server まで届かなかったが debug 可能)
+      // eslint-disable-next-line no-console
+      console.warn(`[uiLog] server flush failed (${batch.length} entries dropped)`);
+    }
+  };
+  const timer = setInterval(flush, intervalMs);
+  // ページ離脱時に同期送信 (sendBeacon は使えないので best-effort)
+  const onUnload = () => { void flush(); };
+  window.addEventListener("beforeunload", onUnload);
+  return () => {
+    clearInterval(timer);
+    window.removeEventListener("beforeunload", onUnload);
   };
 }

--- a/designer/src/utils/uiLog.ts
+++ b/designer/src/utils/uiLog.ts
@@ -168,6 +168,9 @@ function _enqueueForFlush(category: UiLogCategory, msg: string, level: UiLogLeve
  *
  * sendFn は mcpBridge.request("client.log.flush", { entries }) を期待。
  */
+let _lastFlushFailLogTs = 0;
+const FLUSH_FAIL_LOG_INTERVAL_MS = 30_000; // disconnect 中の console spam 防止
+
 export function setupServerLogFlush(
   sendFn: (entries: ReadonlyArray<RecentEvent>) => Promise<unknown>,
   intervalMs = 5000,
@@ -178,9 +181,17 @@ export function setupServerLogFlush(
     try {
       await sendFn(batch);
     } catch {
-      // 失敗時は console.error でも残しておく (server まで届かなかったが debug 可能)
-      // eslint-disable-next-line no-console
-      console.warn(`[uiLog] server flush failed (${batch.length} entries dropped)`);
+      // 失敗時はキューに戻す (transient disconnect のリトライ機会を残す)。
+      // ただし上限 (500) を超えないように先頭 (古いほう) から切り捨てる。
+      _flushQueue.unshift(...batch);
+      if (_flushQueue.length > 500) _flushQueue.splice(0, _flushQueue.length - 500);
+      // console.warn は disconnect ループ中に大量出力されるため rate-limit (30 秒)
+      const now = Date.now();
+      if (now - _lastFlushFailLogTs > FLUSH_FAIL_LOG_INTERVAL_MS) {
+        _lastFlushFailLogTs = now;
+        // eslint-disable-next-line no-console
+        console.warn(`[uiLog] server flush failed; ${_flushQueue.length} entries queued for retry`);
+      }
     }
   };
   const timer = setInterval(flush, intervalMs);


### PR DESCRIPTION
## 背景

#750 で UI 構造化ログを追加したが、ブラウザ console のみで揮発・リフレッシュで消える。「サーバー側にも物理ログ出してる?」とユーザーから指摘 → 永続化レイヤーを追加。

## 変更内容

### 1. designer-mcp/serverLog.ts (新設)

- 出力先: \`<projectRoot>/logs/designer-mcp-YYYY-MM-DD.log\` (JSON Lines)
- \`appendFileSync\` 利用でクラッシュ耐性 + テスト容易性
- 7 日以上前のログを起動時に自動削除
- env \`DESIGNER_MCP_LOG_LEVEL\` で minLevel 指定 (default \`info\`)
- env \`DESIGNER_LOG_DIR\` で出力先上書き可能

### 2. ブラウザ → サーバ ログ統合

- ブラウザ側で warn/error が発生したら 5 秒間隔で \`mcpBridge.request("client.log.flush", { entries })\` 送信
- サーバ側で \`client-\` prefix を付けて物理ログに統合 (例: \`[client-redirect]\`, \`[client-guard]\`)
- リフレッシュ前は \`beforeunload\` で best-effort flush

### 3. wsBridge 動的ハンドラ登録

- \`wsBridge.registerBrowserHandler(method, handler)\` 新設
- 将来の拡張 (telemetry / debug API 等) も同パターンで追加可能

### 4. lifecycle 強化

- \`uncaughtException\` / \`unhandledRejection\` を logError でファイル記録
- 起動 workspace 状態を logInfo に置換 (旧 console.error)

### 5. .gitignore に \`logs/\` 追加

## バグ報告フロー

| 段階 | ユーザー操作 | 出力 |
|---|---|---|
| 1. クライアント側 | コンソールで \`__uiLogDump()\` | 直近 1 秒の UI イベント JSON |
| 2. サーバ側 | \`logs/designer-mcp-YYYY-MM-DD.log\` 末尾 100 行 | WS リクエスト / handler 例外 / lifecycle |
| 3. AI 側 | 両ログを時刻で突き合わせ | client redirect → server WS request → handler exception の因果連鎖を特定 |

## テスト

- serverLog.test.ts: **5 ケース pass** (init / log / ingestClientLog / client_ts / count)
- vitest: **designer-mcp 223 / designer 1463 全 pass**
- tsc / build: clean

## 関連

- 前 PR: #750 (UI 構造化ログ + redirectGuard)
- ユーザー要求: 「サーバー側にも物理ログ出してる?」「ログだけで現象判別できるレベルが必要」

🤖 Generated with [Claude Code](https://claude.com/claude-code)