### PR TITLE
fix(test): httpTransport.test.ts の pre-existing 2 件 fail 解消 (#758)

### DIFF
--- a/designer-mcp/src/httpTransport.test.ts
+++ b/designer-mcp/src/httpTransport.test.ts
@@ -295,14 +295,15 @@ describe("designer-mcp HTTP transport (#302)", () => {
      * シナリオ:
      * 1. client-A が接続・登録
      * 2. client-B が接続・登録
-     * 3. client-A に workspace.status を送る → active: null (未選択)
-     * 4. client-B に workspace.status を送る → active: null (未選択)
-     * 5. 2 session が独立した context として登録されている (WorkspaceContextManager 経由で確認)
+     * 3. client-A に workspace.status を送る → lockdown active (DESIGNER_DATA_DIR で固定)
+     * 4. client-B に workspace.status を送る → lockdown active (同上)
+     * 5. 2 session が独立した WS connection として接続でき、各々 status 応答を返せる
      *
-     * Note: workspace.open は実際のフォルダが必要なため E2E では open を試みず、
-     * status の応答形式と WS connection の独立性を検証する。
+     * Note (#758 lockdown 化以降): 本 server は DESIGNER_DATA_DIR で lockdown 起動するため
+     * 全 session が同一 lockdown active を共有する (per-session active 独立性は lockdown 解除時の挙動)。
+     * 本テストは「2 WS connection が独立して回答できる + lockdown active path が正しい」までを担保。
      */
-    it("2 WS クライアントが接続でき、各々が独立した workspace.status を返す", async () => {
+    it("2 WS クライアントが接続でき、各々が lockdown active workspace.status を返す", async () => {
       const clientAId = `test-client-A-${Date.now()}`;
       const clientBId = `test-client-B-${Date.now()}`;
 
@@ -346,19 +347,22 @@ describe("designer-mcp HTTP transport (#302)", () => {
       // client-A: workspace.status
       const statusA = await wsRoundtrip(clientAId, "workspace.status");
       expect(statusA.error).toBeUndefined();
-      const resultA = statusA.result as { active: unknown; lockdown: boolean };
+      const resultA = statusA.result as { active: { path: string } | null; lockdown: boolean };
       // #758: DESIGNER_DATA_DIR で lockdown 固定起動するため lockdown: true
       expect(resultA).toMatchObject({ lockdown: true });
-      // active は lockdown パスが固定される
-      expect(resultA).toHaveProperty("active");
+      // active.path が tempFixtureDir (lockdown env で固定) と一致することを実値検証
+      expect(resultA.active).not.toBeNull();
+      expect(resultA.active?.path).toBe(tempFixtureDir);
 
       // client-B: workspace.status
       const statusB = await wsRoundtrip(clientBId, "workspace.status");
       expect(statusB.error).toBeUndefined();
-      const resultB = statusB.result as { active: unknown; lockdown: boolean };
+      const resultB = statusB.result as { active: { path: string } | null; lockdown: boolean };
       // #758: DESIGNER_DATA_DIR で lockdown 固定起動するため lockdown: true
       expect(resultB).toMatchObject({ lockdown: true });
-      expect(resultB).toHaveProperty("active");
+      // 全 session が同一 lockdown active を共有することを実値で確認
+      expect(resultB.active).not.toBeNull();
+      expect(resultB.active?.path).toBe(tempFixtureDir);
     });
   });
 

--- a/designer-mcp/src/httpTransport.test.ts
+++ b/designer-mcp/src/httpTransport.test.ts
@@ -8,11 +8,18 @@
  * - WebSocket も同一 port で待機している (ws:// で接続できる)
  *
  * テストは 5200 番台の port を使用 (本番 5179 と衝突しないため)。
+ *
+ * #758: draft__* / lock__* ツールは active workspace を要求するため、
+ * spawn 時に DESIGNER_DATA_DIR=<tmpDir> を渡して lockdown モード固定で起動する。
  */
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { spawn, type ChildProcess } from "node:child_process";
 import { WebSocket } from "ws";
 import { setTimeout as delay } from "node:timers/promises";
+import os from "node:os";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
 
 const TEST_PORT = 5201;
 const MCP_URL = `http://localhost:${TEST_PORT}/mcp`;
@@ -20,6 +27,49 @@ const HEALTH_URL = `http://localhost:${TEST_PORT}/`;
 const WS_URL = `ws://localhost:${TEST_PORT}/`;
 
 let server: ChildProcess | null = null;
+let tempFixtureDir: string | null = null;
+
+/**
+ * テスト用 fixture workspace を os.tmpdir() 配下に作成する (#758)。
+ * schemas/v3/project.v3.schema.json 準拠の最小 project.json を生成する。
+ */
+async function createFixtureWorkspace(): Promise<string> {
+  const tmpDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), "designer-mcp-httpTransport-test-"),
+  );
+
+  // workspaceInit.ts:initializeWorkspace と同形式のサブディレクトリ群を作成
+  const subdirs = ["screens", "tables", "actions", "conventions", "sequences", "views", "view-definitions", "extensions"];
+  await Promise.all(subdirs.map((d) => fs.mkdir(path.join(tmpDir, d), { recursive: true })));
+
+  // 最小 project.json (schemas/v3/project.v3.schema.json 準拠)
+  const ts = new Date().toISOString();
+  const projectId = randomUUID();
+  const name = "httpTransport-test-fixture";
+  const project = {
+    $schema: "../schemas/v3/project.v3.schema.json",
+    schemaVersion: "v3",
+    meta: {
+      id: projectId,
+      name,
+      createdAt: ts,
+      updatedAt: ts,
+      mode: "upstream",
+      maturity: "draft",
+    },
+    extensionsApplied: [],
+    entities: {
+      screens: [],
+      screenGroups: [],
+      screenTransitions: [],
+      tables: [],
+      sequences: [],
+      views: [],
+    },
+  };
+  await fs.writeFile(path.join(tmpDir, "project.json"), JSON.stringify(project, null, 2), "utf-8");
+  return tmpDir;
+}
 
 async function waitForReady(timeoutMs = 10000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
@@ -49,9 +99,18 @@ async function mcpCall(method: string, sessionId?: string, body: Record<string, 
 
 describe("designer-mcp HTTP transport (#302)", () => {
   beforeAll(async () => {
+    // #758: lockdown モード fixture workspace を作成し DESIGNER_DATA_DIR で渡す。
+    // draft__* / lock__* ツールは active workspace を要求するため、
+    // lockdown 固定で起動することで per-session active state の問題を回避する。
+    tempFixtureDir = await createFixtureWorkspace();
+
     server = spawn("npx", ["tsx", "src/index.ts"], {
       cwd: __dirname + "/..", // designer-mcp/ dir
-      env: { ...process.env, DESIGNER_MCP_PORT: String(TEST_PORT) },
+      env: {
+        ...process.env,
+        DESIGNER_MCP_PORT: String(TEST_PORT),
+        DESIGNER_DATA_DIR: tempFixtureDir,
+      },
       stdio: ["ignore", "pipe", "pipe"],
       shell: true,
     });
@@ -74,6 +133,13 @@ describe("designer-mcp HTTP transport (#302)", () => {
     }
     // Windows ではポート解放に時間がかかることがある
     await delay(500);
+    // #758: fixture workspace の cleanup
+    if (tempFixtureDir) {
+      try {
+        await fs.rm(tempFixtureDir, { recursive: true, force: true });
+      } catch { /* ignore — OS が後で GC する */ }
+      tempFixtureDir = null;
+    }
   }, 10000);
   it("GET / で health JSON が返る", async () => {
     const r = await fetch(HEALTH_URL);
@@ -281,26 +347,27 @@ describe("designer-mcp HTTP transport (#302)", () => {
       const statusA = await wsRoundtrip(clientAId, "workspace.status");
       expect(statusA.error).toBeUndefined();
       const resultA = statusA.result as { active: unknown; lockdown: boolean };
-      expect(resultA).toMatchObject({ lockdown: false });
-      // active は null (未選択) または object (server 起動時の自動 active 化により設定済みの場合)
+      // #758: DESIGNER_DATA_DIR で lockdown 固定起動するため lockdown: true
+      expect(resultA).toMatchObject({ lockdown: true });
+      // active は lockdown パスが固定される
       expect(resultA).toHaveProperty("active");
 
       // client-B: workspace.status
       const statusB = await wsRoundtrip(clientBId, "workspace.status");
       expect(statusB.error).toBeUndefined();
       const resultB = statusB.result as { active: unknown; lockdown: boolean };
-      expect(resultB).toMatchObject({ lockdown: false });
+      // #758: DESIGNER_DATA_DIR で lockdown 固定起動するため lockdown: true
+      expect(resultB).toMatchObject({ lockdown: true });
       expect(resultB).toHaveProperty("active");
     });
   });
 
   describe("WorkspaceContextManager lockdown (WS 経路)", () => {
     /**
-     * lockdown モードでサーバが起動している場合、workspace.status で lockdown: true が返る。
-     * ただしこのテストは通常モードのサーバで実行されるため、lockdown: false を検証する。
-     * lockdown E2E は環境変数が必要なため別テストファイルで行う。
+     * DESIGNER_DATA_DIR を渡して lockdown モードでサーバが起動している場合、
+     * workspace.status で lockdown: true が返ることを確認する (#758)。
      */
-    it("通常起動時は lockdown: false が返る", async () => {
+    it("DESIGNER_DATA_DIR 指定時は lockdown: true が返る", async () => {
       async function wsRoundtrip(clientId: string, method: string): Promise<unknown> {
         return new Promise<unknown>((resolve, reject) => {
           const ws = new WebSocket(WS_URL);
@@ -323,7 +390,8 @@ describe("designer-mcp HTTP transport (#302)", () => {
       }
 
       const result = await wsRoundtrip(`lockdown-test-${Date.now()}`, "workspace.status") as { lockdown: boolean };
-      expect(result.lockdown).toBe(false);
+      // #758: DESIGNER_DATA_DIR で lockdown 固定起動するため lockdown: true
+      expect(result.lockdown).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## 関連

Closes #758

- 起源: PR #704 (v2 multi-workspace 統合、commit 4e42f05) — per-session active state 化以降、本テストの 2 件が pre-existing fail
- 検出: PR #757 (#753 統合 PR) の vitest 全件 run で 230/2 fail として捕捉、本件無関係として #758 独立起票
- 仕様: docs/spec/workspace.md §4 (lockdown モード = env DESIGNER_DATA_DIR で active 固定)

## 概要

`designer-mcp/src/httpTransport.test.ts` で `draft E2E` / `lock E2E` の 2 件が pre-existing fail。エラーは「ワークスペースが選択されていません」(MCP -32603)。

v2 multi-workspace 統合 (#704 / #700) で active state が per-session 化されたが、本テストの server spawn 時にどの workspace も active 化されておらず、`draft__*` / `lock__*` MCP tools が active workspace を要求するため reject された。pre-existing fail として PR #757 まで残存していた。

## 修正内容 (commit d1fc66d)

server spawn 時に **`DESIGNER_DATA_DIR=<temp-fixture-dir>` env を渡して lockdown モード固定** で起動 (workspace.md §4 仕様):

1. `beforeAll` 最初で `os.mkdtemp` により `os.tmpdir()/designer-mcp-httpTransport-test-XXXXXX/` を生成
2. 中身として最小有効 `project.json` (schemaVersion v3 / mode upstream / maturity draft / extensionsApplied [] / entities 空) + 必須サブディレクトリ (`screens/` `tables/` `actions/` `conventions/` `sequences/` `views/` `view-definitions/` `extensions/`) を配置
3. `spawn` の env に `DESIGNER_DATA_DIR: tempFixtureDir` を追加
4. `afterAll` 最後で `fs.rm(tempDir, { recursive: true, force: true })` で cleanup

副次変更: per-session WS テスト (L350, L358) の lockdown 期待値を `false` → `true` に追従修正 (server が lockdown モードで起動するため事実に合わせた)。

### 採用しなかった代替案

- 実 sample (`examples/retail/`) を fixture 流用 → test 毎に書き換わって git 差分が出る、CI 不安定化
- `workspace.open` を test 内で行う → per-session active で複数 test 跨ぎ維持されないため各 test に setup 必要、冗長
- describe 内 setup 共通化 → 既存 6 pass tests (health / initialize / tools/list / WebSocket) は active workspace 不要、spawn level lockdown 一括が最小変更

## 仕様逐条突合 (自己申告)

- ISSUE #758 受け入れ基準: 2 件 fail → 8/8 pass ✓
- workspace.md §4.1 lockdown 有効化条件: env `DESIGNER_DATA_DIR` 非空文字 → spawn env で `tempFixtureDir` 設定 ✓
- workspace.md §4.2 lockdown 時 active 操作: lockdown 中は env 値が active 固定なので MCP tools が active workspace 取得可 ✓
- regression 0: `npx vitest run src/httpTransport.test.ts` → 8 pass ✓ (既存 6 pass + 2 件解消)
- temp dir cleanup: `afterAll` で `fs.rm(..., { recursive: true, force: true })` 実装済 ✓

## レビューで特に見てほしい箇所

1. **temp fixture project.json の構造**: workspaceInit.ts の `initializeWorkspace()` が生成する形と整合しているか (schema v3 / meta / entities の最小構造)
2. **副次変更 (lockdown 期待値の per-session WS テスト)**: lockdown true への変更が他 test ロジックに影響しないか (lockdown true でも既存 8 pass 全部通ることは確認済)
3. **temp dir 命名衝突**: `os.mkdtemp` は安全 (XXXXXX で衝突回避) だが、CI 並行実行で同時起動した場合の挙動

## テスト

- Vitest: `designer-mcp/src/httpTransport.test.ts` 8/8 pass (元 2 fail 解消、既存 6 pass 維持)
- TypeScript: `npx tsc --noEmit` エラーなし
- 文字化け: `grep -P "[ｦ-ﾟ]"` 0 件
- temp dir cleanup: afterAll で実行 (テスト後 `os.tmpdir()` 配下に残骸 0 件)

## UI 影響 / AI smoke test

- [ ] UI 影響あり
- [x] UI 影響なし (test ファイルのみ変更)

## spec 側の不足点 / 提案

なし

## レビュー担当への申し送り

- 本 PR は #753 アーキテクチャ整理 wave の最後の cleanup (#704 v2 起源の pre-existing fail 解消)
- ユーザーから「全部このイシューでやれ。じゃないと問題解決できないだろ。全く無関係な別問題ならイシュー切れ」(2026-05-03) の指示で、本件は #759 (path 取り残し) と切り分けて独立 ISSUE 化、本 PR で完遂

## レビュー履歴

| 周 | 日時 | レビュアー | 結果 | 対応 |
|---|---|---|---|---|
| 1 | 2026-05-03 | Sonnet 4.6 (独立) | Must-fix 0 / Should-fix 2 / Nit 2 / マージ可 | Round 2 で Should-fix 2 件同 PR 吸収 |
| 2 | (進行中) | Sonnet 4.6 (focused) | — | Round 2 修正適切性確認のみ |
