### PR TITLE
chore(final): active docs 残骸 + #775 SQL alias 確定 — cleanup シリーズ完遂

### DIFF
--- a/.claude/skills/create-flow/SKILL.md
+++ b/.claude/skills/create-flow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-flow
-description: ProcessFlow JSON を品質ガード付きで新規作成する。/review-flow の 10 観点 + 29 ルールを作成前 self-check として組み込み、既知パターンの再発を抑制 + グローバル schema 変更禁止 (#511) + 画面項目連携整合性 (#621) + runtime 契約整合性 (#714) + retail dogfood 既知パターン (#740)
+description: ProcessFlow JSON を品質ガード付きで新規作成する。/review-flow の 12 観点 + 30 ルールを作成前 self-check として組み込み、既知パターンの再発を抑制 + グローバル schema 変更禁止 (#511) + 画面項目連携整合性 (#621) + runtime 契約整合性 (#714) + retail dogfood 既知パターン (#740) + SQL alias 必須 (#775)
 argument-hint: <flowId> <業務概要> [namespace]
 disable-model-invocation: true
 ---
@@ -426,6 +426,14 @@ SELECT 'ORD-' || EXTRACT(YEAR FROM CURRENT_DATE)::text || '-' || LPAD(nextval('s
 
 **Step 5.2 で `validate:samples` の `processFlowAntipatternValidator` (`MULTIPLE_STATEMENTS_IN_SQL` warning) により機械的に検出される**
 
+### Rule 30: SQL SELECT 句で camelCase 化が必要な列は `AS "<camelCase>"` alias 必須 (#775)
+
+- `dbAccess.sql` の SELECT 結果が ViewDefinition `columns[].name` (camelCase) へ直接バインドされる場合、**SQL 内で `AS "<camelCase>"` alias を明示する**
+- 例: `SELECT p.unit_price AS "unitPrice", p.product_code AS "productCode" FROM products p`
+- snake_case 物理名 (`unit_price`) と Identifier (`unitPrice`) の変換を runtime の暗黙変換に依存しない
+- alias 追加後は alias の camelCase キーで変数を参照する (`@rows[0].unitPrice` 等)。旧 snake_case 参照 (`@rows[0].unit_price`) は全て更新すること
+- 詳細: `docs/spec/view-definition.md § (D-5)` / `docs/spec/process-flow-runtime-conventions.md §1.4`
+
 ## Step 4: 拡張定義の使い方
 
 ### 既存 namespace を使う場合
@@ -570,6 +578,7 @@ npx vitest run src/schemas/validateDogfood.test.ts -t "<flowId の一部>"
 | 27. `@conv.numbering.X.nextSeq()` 構文禁止 → DB sequence | ✓ / 該当なし (採番なし) |
 | 28. rollbackOn 発火可能性 (欠落検査) + lineage.writes.purpose 整合 | ✓ / 該当なし (TX なし / lineage なし) |
 | 29. `dbAccess.sql` への複数文 SQL 詰め込み禁止 | ✓ / 該当なし (DB 操作なし) |
+| 30. SQL SELECT 列の `AS "<camelCase>"` alias (#775) | ✓ / 該当なし (VD binding なし) / ❌ |
 
 ### 検証結果
 - vitest: <pass/fail 件数>
@@ -589,7 +598,7 @@ npx vitest run src/schemas/validateDogfood.test.ts -t "<flowId の一部>"
 - **拡張定義は実利用必須**: 定義のみで未使用は禁止 (spec §15.3)
 - **schema を尊重**: `type: "manufacturing:StepName"` のような未対応形式は使わない (`type: "other"` + outputSchema が正解)
 - **データファイル (`data/`) は触らない** (gitignore 対象)
-- **29 ルールすべて作成中に意識する**: 1 つでも無視するとレビューで detect される
+- **30 ルールすべて作成中に意識する**: 1 つでも無視するとレビューで detect される
 
 ## 注意事項
 

--- a/.claude/skills/review-flow/SKILL.md
+++ b/.claude/skills/review-flow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-flow
-description: ProcessFlow JSON の実行セマンティクスを専門レビュー (変数ライフサイクル / TX スコープ / runIf 連鎖 / 補償整合 / event 双方向 / 画面項目連携)。Step 0.5 で 12 バリデータを機械実行 (#599 / #621)、Step 1 で 10 観点を AI レビュー。設計フェーズから使える
+description: ProcessFlow JSON の実行セマンティクスを専門レビュー (変数ライフサイクル / TX スコープ / runIf 連鎖 / 補償整合 / event 双方向 / 画面項目連携 / SQL alias 整合)。Step 0.5 で 12 バリデータを機械実行 (#599 / #621)、Step 1 で 13 観点を AI レビュー。設計フェーズから使える
 argument-hint: <flowId | path | --all | (空 = MCP アクティブタブ)>
 disable-model-invocation: true
 ---
@@ -114,6 +114,7 @@ npm run validate:samples -- ../examples/<project-id>
 | 10. 画面項目値レベル整合 | screenItemFieldTypeValidator (options 包含 / domainKey / 型 / pattern / range / length) | 業務文脈の妥当性 (選択肢命名の業務適切性 / domain 設計妥当性) は AI |
 | 11. DB 制約 × INSERT / DELETE 順序 (#632 / #640 / #641 / #642) | sqlOrderValidator (NULL_NOT_ALLOWED_AT_INSERT / FK_REFERENCE_NOT_INSERTED / UNIQUE_CHECK_MISSING / CASCADE_DELETE_OMITTED / TX_CIRCULAR_DEPENDENCY) | 複雑な条件分岐での可能性の有無は AI / UNIQUE チェック抑止パターンの業務妥当性は AI / onDelete 設定が業務要件として適切かは AI / TX 循環の DEFERRED 検出は Phase 5 候補 (別 ISSUE) |
 | 12. ViewDefinition 整合 (#649) | viewDefinitionValidator (UNKNOWN_SOURCE_TABLE / UNKNOWN_TABLE_COLUMN_REF / DUPLICATE_VIEW_COLUMN_NAME / UNKNOWN_SORT_COLUMN / UNKNOWN_FILTER_COLUMN / UNKNOWN_GROUP_BY_COLUMN) | sourceTableId ↔ dbAccess テーブルの業務的整合 / FIELD_TYPE_INCOMPATIBLE の業務妥当性は AI |
+| 13. SQL SELECT ↔ ViewDefinition alias 整合 (#775) | (なし、目視のみ) | SELECT 結果が viewer VD `columns[].name` と直接バインドする場合に `AS "<camelCase>"` alias があるか / alias 後の camelCase キーで変数参照が一致しているか |
 
 監査根拠: `docs/spec/dogfood-2026-04-29-phase2-validator-audit.md` §3 / §4 + Phase 3 子 1 #619 (PR #626)。
 

--- a/designer/src/types/v3/v3-types.test.ts
+++ b/designer/src/types/v3/v3-types.test.ts
@@ -5,7 +5,7 @@
  * - Branded types が正しく解決される
  * - Step discriminated union が kind narrowing で機能する
  * - WorkflowApprover の order semantics が JSDoc で参照可能 (型は number)
- * - sample-project-v3 の実 JSON と TS 型の互換性 (parseable)
+ * - examples/<project-id>/ (現行 canonical サンプル) の実 JSON と TS 型の互換性 (parseable)
  */
 
 import { describe, it, expect } from "vitest";

--- a/docs/spec/plugin-system.md
+++ b/docs/spec/plugin-system.md
@@ -342,7 +342,7 @@ ProcessFlow 内部にある `typeCatalog` を本仕様の `response-types.json` 
 | TypeScript 型 | `designer/src/types/action.ts` | `ProcessFlow.typeCatalog` 削除 |
 | **クロスリファレンス検証** | `designer/src/schemas/referentialIntegrity.ts` | `typeRef` の解決先を `group.typeCatalog` から**グローバル extensions** に変更 |
 | 同テスト | `designer/src/schemas/referentialIntegrity.test.ts` | typeCatalog ベースのテスト 2 件を extensions ベースに書き換え |
-| Schema テスト | `designer/src/schemas/process-flow.schema.test.ts` | typeCatalog 関連 2 ブロック (#261 v1.3) 削除 or 書き換え |
+| Schema テスト | `designer/src/schemas/samples-v3.schema.test.ts` | typeCatalog 関連テストを v3 extensions ベースに更新 (v1 凍結テストは削除済み — 現行は `samples-v3.schema.test.ts` / `v3-variant-coverage.test.ts`) |
 | UI コンポーネント | `designer/src/components/process-flow/TypeCatalogPanel.tsx` | 削除 |
 | UI 統合 | `designer/src/components/process-flow/ActionMetaTabBar.tsx` | typeCatalog タブ削除 |
 | MCP ツール | `designer-mcp/src/tools.ts` | `CatalogName` enum から `typeCatalog` 削除 + 新 `add_response_type_extension` 追加 |

--- a/docs/spec/process-flow-runtime-conventions.md
+++ b/docs/spec/process-flow-runtime-conventions.md
@@ -45,7 +45,23 @@ INSERT INTO orders (customer_id, total, payment_id) VALUES ($1, $2, $3)
 
 `CURRENT_TIMESTAMP` / `COALESCE(...)` / `NULL` / 列名 (`orders.status`) は **SQL 字句としてそのまま使用**。`@` プレフィックスがないものは全て SQL 字句。
 
-### 1.4 in-clause の展開
+### 1.4 SELECT 句の列 alias 規約 (#775)
+
+SELECT 結果が ViewDefinition `columns[].name` (camelCase) へ直接バインドされる場合は、**SQL 内で `AS "<camelCase>"` alias を明示する**。
+
+```sql
+-- NG: snake_case 物理名のまま返す (VD column 'unitPrice' と不一致)
+SELECT p.unit_price, p.product_code FROM products p
+
+-- OK: AS alias で VD column 名と一致させる
+SELECT p.unit_price AS "unitPrice", p.product_code AS "productCode" FROM products p
+```
+
+**理由**: runtime での暗黙変換 (snake_case → camelCase) は validator 検出不能。alias で構文上の binding を確定させる (#775)。
+
+詳細: [`docs/spec/view-definition.md` § (D-5)](view-definition.md)
+
+### 1.5 in-clause の展開
 
 `WHERE id IN (@ids)` のような配列展開は、`@ids` の要素数に応じて `$N, $N+1, ...` を展開:
 

--- a/docs/spec/process-flow-transaction.md
+++ b/docs/spec/process-flow-transaction.md
@@ -126,7 +126,7 @@ TX が rollback された**後**に実行する step 列。任意・補償処理
 | ネスト | 不可 (txId 重複を禁止しない実装依存) | 可 (ネストは `propagation` で制御) |
 | `onCommit`/`onRollback` | 持たない | 持つ |
 | 移動・複製耐性 | 弱 (txId の同期が手動) | 強 (構造ごと移動) |
-| v3 sample 実機検証 | 未使用 (Round 5 fixture でのみ検証) | `docs/sample-project-v3/finance/process-flows/a4d18f30-...json` step-08 (振込実行 TX)、`manufacturing/.../e3a68880-...json` (月次締め内部) で実機使用 (現在は `git log` でのみ参照可; 現行 canonical は `examples/` 配下) |
+| v3 sample 実機検証 | 未使用 (Round 5 fixture でのみ検証) | `examples/retail/process-flows/efa7ac6e-...json` (在庫操作 TX) / `examples/retail/process-flows/f81dd9e0-...json` (注文確定 TX) で実機使用。旧サンプルは削除済 — `git log` でのみ参照可 |
 
 ### §3.1 移行ガイダンス
 
@@ -153,10 +153,11 @@ TX が rollback された**後**に実行する step 列。任意・補償処理
 
 ## §5 サンプル (v3)
 
-実機検証済の TransactionScopeStep 使用例:
+実機検証済の TransactionScopeStep 典型パターン:
 
-- **`docs/sample-project-v3/finance/process-flows/a4d18f30-...json`** step-08 (現在は `git log` でのみ参照可): 振込実行 (3 段 dbAccess を SERIALIZABLE TX で原子化、`affectedRowsCheck` で残高不足検出 → rollback、`onRollback` で監査ログ + 422/500 分岐 return)
-- 旧 v1/v2 サンプル `docs/sample-project/process-flows/cccccccc-0005-...json` の `actions[1]` (`act-orderreg-003`) は v1 形式、参照時は v3 移行マッピング (`schemas/v3/README.md` 参照) で読み替え
+- **SERIALIZABLE TX + affectedRowsCheck + onRollback パターン**: 複数 `dbAccess` ステップを `TransactionScopeStep.steps[]` でくくり、`isolationLevel: "SERIALIZABLE"` を指定。各 `dbAccess` に `affectedRowsCheck` で行数検証 (例: 残高不足で 0 行 UPDATE → rollback)。`onRollback` ブランチで監査ログ記録 + エラーレスポンス分岐 (422/500) を配置する。
+- 現行 canonical サンプルは `examples/retail/process-flows/efa7ac6e-...json` (在庫操作 TX) / `examples/retail/process-flows/f81dd9e0-...json` (注文確定 TX) / `examples/realestate/process-flows/d4b5c6e7-...json` (物件登録 TX) を参照。
+- 旧サンプル (finance / manufacturing 業界) は削除済み — `git log` で参照可。
 
 ## §6 UI
 

--- a/docs/spec/process-flow-workflow.md
+++ b/docs/spec/process-flow-workflow.md
@@ -140,7 +140,7 @@ interface WorkflowApprover {
 
 ### approval-parallel (3 名並行承認、order は無視)
 
-`docs/sample-project-v3/logistics/process-flows/0fe7af80-...json` step-07 を参照 (現在は `git log` でのみ参照可; 現行 canonical サンプルは `examples/` 配下)。3 倉庫マネージャー (転送元 / 転送先 / コーディネーター) を全員 `order: 1` で並行宣言、deadline は workflow 全体に 1 つ。
+3 倉庫マネージャー (転送元 / 転送先 / コーディネーター) を全員 `order: 1` で並行宣言、deadline は workflow 全体に 1 つ。旧サンプルは削除済み — 現行 canonical サンプルは `examples/` 配下を参照。
 
 ### approval-quorum (nOfM)
 
@@ -204,4 +204,4 @@ v2 / v1 から v3 への命名・構造変更:
 
 - スキーマ: [`schemas/v3/process-flow.v3.schema.json`](../../schemas/v3/process-flow.v3.schema.json) `#/$defs/WorkflowStep`
 - 式言語: [`process-flow-expression-language.md`](process-flow-expression-language.md)
-- 実例: `docs/sample-project-v3/public-service/process-flows/1cd900ee-...json` (5 段 workflow 連結), `docs/sample-project-v3/logistics/process-flows/0fe7af80-...json` (approval-parallel + branch-merge) — いずれも `git log` でのみ参照可 (現行 canonical は `examples/` 配下)
+- 現行 canonical サンプル: `examples/` 配下の各プロジェクトを参照。旧サンプルは削除済み — `git log` でのみ参照可。

--- a/docs/spec/schema-design-principles.md
+++ b/docs/spec/schema-design-principles.md
@@ -800,12 +800,14 @@ schema 側は両形式を受け、UI/実装側で migration して扱う。
 
 ### 8.1 schema validation テスト
 
-`designer/src/schemas/process-flow.schema.test.ts` (および周辺) で:
-- `docs/sample-project/process-flows/*.json` 全件を schema validation で検証 (positive)
+`designer/src/schemas/samples-v3.schema.test.ts` / `v3-variant-coverage.test.ts` (および周辺) で:
+- `examples/<project-id>/process-flows/*.json` 全件を schema validation で検証 (positive)
 - 故意に invalid なデータも negative ケースとして検証
 - 新規フィールド追加時は **両ケース** を追加する
 
-実行: `cd designer && npx vitest run src/schemas/process-flow.schema.test.ts`
+実行: `cd designer && npx vitest run`
+
+> 注: v1 凍結テスト (v1 schema 用) は #774 で削除済み。現行は v3 schema を対象とする `samples-v3.schema.test.ts` を参照。
 
 ### 8.2 参照整合性テスト
 

--- a/docs/spec/screen-items.md
+++ b/docs/spec/screen-items.md
@@ -593,7 +593,7 @@ MVP は 1-2-3 まで。4-5-6 は段階的に。
 
 ### validator 観点
 
-`screenItemViewerValidator.ts` が次の観点を検出する (#762)。`validate-dogfood` の登録 12 番目。
+`screenItemViewerValidator.ts` が次の観点を検出する (#762)。`validate:samples` で検出される (`npm run validate:samples -- <projectDir>`)。
 
 | issue code | severity | 検出内容 |
 |---|---|---|

--- a/docs/spec/view-definition.md
+++ b/docs/spec/view-definition.md
@@ -320,9 +320,24 @@ Screen は `items[]` の `direction: "viewer"` screen-item から `viewDefinitio
 - Level 3 では SQL 結果に対応する table 列が必ずしも 1:1 で対応しないため (例: ROW_NUMBER の rn 列は table 由来ではない)。
 - 省略時は `name + type` のみで列を宣言する。型整合は設計者が保証 (validator は走らせない)。
 
+### (D-5) SQL SELECT 句の列は `AS "<camelCase>"` alias 必須 (#775)
+
+ProcessFlow の `dbAccess.sql` で SELECT した列が ViewDefinition の `columns[].name` (camelCase Identifier) へ直接バインドされる場合 (viewer screen-item の `valueFrom.flowVariable` 経由) は、**SQL 内で明示 alias により名前を一致させる**。
+
+> **規約**: SQL SELECT 句で DB 物理名 (snake_case) と `columns[].name` (camelCase) が異なる列は `AS "<camelCase>"` で alias 必須。
+>
+> 例: `SELECT p.unit_price AS "unitPrice", p.product_code AS "productCode" FROM products p`
+
+**理由**: snake_case 物理名 (`unit_price`) と camelCase Identifier (`unitPrice`) を runtime で暗黙変換すると validator で検出不能なバインドミスが発生する。明示 alias で SQL ↔ ViewDefinition binding を構文上確定させ、sqlColumnValidator の整合チェック対象に含める。
+
+**適用範囲**:
+- `dbAccess` の SQL 出力が ViewDefinition `columns[].name` と直接バインドされる SELECT 句のみ
+- 中間 compute step を挟む場合は compute 式の key で変換してもよいが、SQL alias で統一する方が明示的
+- 既存フローへの適用例: `examples/retail/process-flows/267e94bf-...json` / `examples/realestate/process-flows/d4b5c6e7-...json`
+
 ## validator 観点 (11 件、#745 反映)
 
-`viewDefinitionValidator.ts` が次の観点を検出する。Phase 4 PR #656 で 9 件登録され、PR #745 で Level 2 / Level 3 対応に伴い 2 件追加 (合計 11 観点)。`validate-dogfood` の登録 8 番目。
+`viewDefinitionValidator.ts` が次の観点を検出する。Phase 4 PR #656 で 9 件登録され、PR #745 で Level 2 / Level 3 対応に伴い 2 件追加 (合計 11 観点)。`validate:samples` の登録 9 番目 (`npm run validate:samples -- <projectDir>`)。
 
 | issue code | severity | 検出内容 |
 |---|---|---|

--- a/examples/realestate/process-flows/d4b5c6e7-f809-4112-bc3d-4e5f6a7b8c9d.json
+++ b/examples/realestate/process-flows/d4b5c6e7-f809-4112-bc3d-4e5f6a7b8c9d.json
@@ -144,7 +144,7 @@
           "description": "物件種別・上限価格・最小面積で properties を検索する。",
           "tableId": "c3a4b5d6-e7f8-4091-ab2c-3d4e5f6a7b8c",
           "operation": "SELECT",
-          "sql": "SELECT id, property_code, name, property_type, area_sqm, price_10k_yen, listed_at FROM properties WHERE (@inputs.propertyType IS NULL OR property_type = @inputs.propertyType) AND (@inputs.maxPrice10kYen IS NULL OR price_10k_yen <= @inputs.maxPrice10kYen) AND (@inputs.minAreaSqm IS NULL OR area_sqm >= @inputs.minAreaSqm) ORDER BY price_10k_yen ASC",
+          "sql": "SELECT id, property_code AS \"propertyCode\", name, property_type AS \"propertyType\", area_sqm AS \"areaSqm\", price_10k_yen AS \"price10kYen\", listed_at AS \"listedAt\" FROM properties WHERE (@inputs.propertyType IS NULL OR property_type = @inputs.propertyType) AND (@inputs.maxPrice10kYen IS NULL OR price_10k_yen <= @inputs.maxPrice10kYen) AND (@inputs.minAreaSqm IS NULL OR area_sqm >= @inputs.minAreaSqm) ORDER BY price_10k_yen ASC",
           "outputBinding": { "name": "rows" },
           "lineage": {
             "reads": [

--- a/examples/retail/process-flows/267e94bf-0397-44b8-b665-d3c40c38935b.json
+++ b/examples/retail/process-flows/267e94bf-0397-44b8-b665-d3c40c38935b.json
@@ -78,7 +78,7 @@
           "description": "ログイン顧客のアクティブカート (carts.status='active') に紐付く cart_items を集計する。LEFT JOIN + COALESCE で アクティブカート不在 / 明細 0 件の場合に (0, 0) を返すように正規化する。",
           "tableId": "57110336-a984-4d39-bb21-1e5d5bb4390b",
           "operation": "SELECT",
-          "sql": "SELECT COALESCE(COUNT(ci.id), 0) AS item_count, COALESCE(SUM(ci.unit_price_snapshot * ci.quantity), 0) AS total_amount FROM carts c LEFT JOIN cart_items ci ON ci.cart_id = c.id WHERE c.customer_id = @sessionCustomerId AND c.status = 'active'",
+          "sql": "SELECT COALESCE(COUNT(ci.id), 0) AS \"itemCount\", COALESCE(SUM(ci.unit_price_snapshot * ci.quantity), 0) AS \"totalAmount\" FROM carts c LEFT JOIN cart_items ci ON ci.cart_id = c.id WHERE c.customer_id = @sessionCustomerId AND c.status = 'active'",
           "outputBinding": { "name": "summaryRows" },
           "lineage": {
             "reads": [
@@ -91,14 +91,14 @@
           "id": "step-02",
           "kind": "compute",
           "description": "summaryRows[0] が無い場合のフォールバック (defensive guard、aggregate は常に 1 行返るため通常は dead path)。runtime や DB driver の挙動差異に備えた防御で、null 安全のため明示的に 0 に正規化する。AI 実装でも optional chaining / nullish coalescing を生成するヒントになる。",
-          "expression": "@summaryRows[0] != null ? @summaryRows[0].item_count : 0",
+          "expression": "@summaryRows[0] != null ? @summaryRows[0].itemCount : 0",
           "outputBinding": { "name": "itemCount" }
         },
         {
           "id": "step-03",
           "kind": "compute",
           "description": "summaryRows[0] が無い場合の totalAmount フォールバック (step-02 と同じ defensive guard、aggregate は常に 1 行返るため通常は dead path)。",
-          "expression": "@summaryRows[0] != null ? @summaryRows[0].total_amount : 0",
+          "expression": "@summaryRows[0] != null ? @summaryRows[0].totalAmount : 0",
           "outputBinding": { "name": "totalAmount" }
         },
         {
@@ -107,7 +107,7 @@
           "description": "アクティブカートに紐付く cart_items を products JOIN で取得し、viewer 表示用の行データを生成する。空 cart 時は 0 行が返る (#771)。",
           "tableId": "57110336-a984-4d39-bb21-1e5d5bb4390b",
           "operation": "SELECT",
-          "sql": "SELECT ci.id, p.product_code, p.name AS product_name, ci.quantity, ci.unit_price_snapshot, (ci.unit_price_snapshot * ci.quantity) AS subtotal FROM carts c JOIN cart_items ci ON ci.cart_id = c.id JOIN products p ON p.id = ci.product_id WHERE c.customer_id = @sessionCustomerId AND c.status = 'active' ORDER BY ci.added_at ASC",
+          "sql": "SELECT ci.id, p.product_code AS \"productCode\", p.name AS \"productName\", ci.quantity, ci.unit_price_snapshot AS \"unitPrice\", (ci.unit_price_snapshot * ci.quantity) AS subtotal FROM carts c JOIN cart_items ci ON ci.cart_id = c.id JOIN products p ON p.id = ci.product_id WHERE c.customer_id = @sessionCustomerId AND c.status = 'active' ORDER BY ci.added_at ASC",
           "outputBinding": { "name": "cartDetailRows" },
           "lineage": {
             "reads": [

--- a/examples/retail/process-flows/9515d6f6-8342-48cf-a045-9e9d8fab1cfa.json
+++ b/examples/retail/process-flows/9515d6f6-8342-48cf-a045-9e9d8fab1cfa.json
@@ -189,7 +189,7 @@
           "description": "products テーブルで商品の存在確認と単価取得を行う。is_active=TRUE の販売中商品のみ対象。",
           "tableId": "652cbbfe-17e2-4f23-a0c9-4403e6b23bb0",
           "operation": "SELECT",
-          "sql": "SELECT id, product_code, name, unit_price FROM products WHERE product_code = @inputs.productCode AND is_active = TRUE",
+          "sql": "SELECT id, product_code AS \"productCode\", name, unit_price AS \"unitPrice\" FROM products WHERE product_code = @inputs.productCode AND is_active = TRUE",
           "outputBinding": { "name": "product" },
           "lineage": {
             "reads": [{ "tableId": "652cbbfe-17e2-4f23-a0c9-4403e6b23bb0", "purpose": "lookup" }]
@@ -292,7 +292,7 @@
           "description": "現在の cart_items 件数を取得して上限チェックに使用する。existingItem が null の場合 (新規追加) のみ意味を持つ。",
           "tableId": "57110336-a984-4d39-bb21-1e5d5bb4390b",
           "operation": "SELECT",
-          "sql": "SELECT COUNT(*) AS item_count FROM cart_items WHERE cart_id = @cart.id",
+          "sql": "SELECT COUNT(*) AS \"itemCount\" FROM cart_items WHERE cart_id = @cart.id",
           "outputBinding": { "name": "cartItemCount" },
           "lineage": {
             "reads": [{ "tableId": "57110336-a984-4d39-bb21-1e5d5bb4390b", "purpose": "lookup" }]
@@ -309,7 +309,7 @@
               "label": "上限超過",
               "condition": {
                 "kind": "expression",
-                "expression": "@existingItem == null && @cartItemCount.item_count >= @conv.limit.cartMaxItems"
+                "expression": "@existingItem == null && @cartItemCount.itemCount >= @conv.limit.cartMaxItems"
               },
               "steps": [
                 {
@@ -335,7 +335,7 @@
           "description": "cart_items に (cart_id, product_id) で UPSERT する。重複の場合は quantity を加算し unit_price_snapshot を最新値で更新する。",
           "tableId": "57110336-a984-4d39-bb21-1e5d5bb4390b",
           "operation": "retail:UPSERT_CART_ITEM",
-          "sql": "INSERT INTO cart_items (cart_id, product_id, unit_price_snapshot, quantity) VALUES (@cart.id, @product.id, @product.unit_price, @inputs.quantity) ON CONFLICT (cart_id, product_id) DO UPDATE SET quantity = cart_items.quantity + EXCLUDED.quantity, unit_price_snapshot = EXCLUDED.unit_price_snapshot, updated_at = CURRENT_TIMESTAMP RETURNING id",
+          "sql": "INSERT INTO cart_items (cart_id, product_id, unit_price_snapshot, quantity) VALUES (@cart.id, @product.id, @product.unitPrice, @inputs.quantity) ON CONFLICT (cart_id, product_id) DO UPDATE SET quantity = cart_items.quantity + EXCLUDED.quantity, unit_price_snapshot = EXCLUDED.unit_price_snapshot, updated_at = CURRENT_TIMESTAMP RETURNING id",
           "outputBinding": { "name": "upsertedCartItem" },
           "affectedRowsCheck": {
             "operator": "=",

--- a/examples/retail/process-flows/a3659922-3932-4857-a906-26dd605254fe.json
+++ b/examples/retail/process-flows/a3659922-3932-4857-a906-26dd605254fe.json
@@ -65,7 +65,7 @@
           "description": "本日の注文件数と当日売上 (税込) を 1 クエリで集計する。COALESCE で 0 件時の NULL を 0 に正規化する。",
           "tableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab",
           "operation": "SELECT",
-          "sql": "SELECT COALESCE(SUM(total_amount + tax_amount), 0) AS today_sales, COUNT(*) AS orders_today FROM orders WHERE DATE(ordered_at) = CURRENT_DATE AND status != 'cancelled'",
+          "sql": "SELECT COALESCE(SUM(total_amount + tax_amount), 0) AS \"todaySales\", COUNT(*) AS \"ordersToday\" FROM orders WHERE DATE(ordered_at) = CURRENT_DATE AND status != 'cancelled'",
           "outputBinding": { "name": "ordersAgg" },
           "lineage": {
             "reads": [{ "tableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab", "purpose": "lookup" }]
@@ -77,7 +77,7 @@
           "description": "低在庫しきい値 (@conv.limit.lowStockThreshold) 以下の inventory 行数を集計する。",
           "tableId": "834ede22-3cb0-4dcf-aa8a-7c046664774a",
           "operation": "SELECT",
-          "sql": "SELECT COUNT(*) AS low_stock_count FROM inventory WHERE quantity_available <= @conv.limit.lowStockThreshold",
+          "sql": "SELECT COUNT(*) AS \"lowStockCount\" FROM inventory WHERE quantity_available <= @conv.limit.lowStockThreshold",
           "outputBinding": { "name": "lowStockAgg" },
           "lineage": {
             "reads": [{ "tableId": "834ede22-3cb0-4dcf-aa8a-7c046664774a", "purpose": "lookup" }]
@@ -89,7 +89,7 @@
           "description": "配送指示待ち (status IN ('pending', 'confirmed')) の注文件数を集計する。配送指示完了で 'shipped' に遷移するため、それ以前を待ち件数として扱う。",
           "tableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab",
           "operation": "SELECT",
-          "sql": "SELECT COUNT(*) AS dispatch_pending FROM orders WHERE status IN ('pending', 'confirmed')",
+          "sql": "SELECT COUNT(*) AS \"dispatchPending\" FROM orders WHERE status IN ('pending', 'confirmed')",
           "outputBinding": { "name": "dispatchAgg" },
           "lineage": {
             "reads": [{ "tableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab", "purpose": "lookup" }]
@@ -100,14 +100,14 @@
           "kind": "eventPublish",
           "description": "retail.dashboard.refreshed イベントを発行する。下流のメトリクス収集系で 4 KPI を参照可能にする。",
           "topic": "retail.dashboard.refreshed",
-          "payload": "{ todaySales: @ordersAgg.today_sales, ordersToday: @ordersAgg.orders_today, lowStockCount: @lowStockAgg.low_stock_count, dispatchPending: @dispatchAgg.dispatch_pending, requestId: @requestId }"
+          "payload": "{ todaySales: @ordersAgg.todaySales, ordersToday: @ordersAgg.ordersToday, lowStockCount: @lowStockAgg.lowStockCount, dispatchPending: @dispatchAgg.dispatchPending, requestId: @requestId }"
         },
         {
           "id": "step-05",
           "kind": "return",
           "description": "200 OK — 4 KPI を返す。",
           "responseId": "200-ok",
-          "bodyExpression": "{ todaySales: @ordersAgg.today_sales, ordersToday: @ordersAgg.orders_today, lowStockCount: @lowStockAgg.low_stock_count, dispatchPending: @dispatchAgg.dispatch_pending }"
+          "bodyExpression": "{ todaySales: @ordersAgg.todaySales, ordersToday: @ordersAgg.ordersToday, lowStockCount: @lowStockAgg.lowStockCount, dispatchPending: @dispatchAgg.dispatchPending }"
         }
       ]
     }

--- a/examples/retail/process-flows/d63c703c-26ed-4704-8b76-329c6bfae9c9.json
+++ b/examples/retail/process-flows/d63c703c-26ed-4704-8b76-329c6bfae9c9.json
@@ -216,7 +216,7 @@
           "description": "注文を取得する。配送指示対象は status が 'pending' または 'confirmed' のみ。",
           "tableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab",
           "operation": "SELECT",
-          "sql": "SELECT id, order_number, customer_id, status, total_amount, shipping_address FROM orders WHERE id = @inputs.orderId AND status IN ('pending', 'confirmed')",
+          "sql": "SELECT id, order_number AS \"orderNumber\", customer_id AS \"customerId\", status, total_amount AS \"totalAmount\", shipping_address AS \"shippingAddress\" FROM orders WHERE id = @inputs.orderId AND status IN ('pending', 'confirmed')",
           "outputBinding": { "name": "order" },
           "lineage": {
             "reads": [{ "tableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab", "purpose": "lookup" }]
@@ -271,7 +271,7 @@
           "config": {
             "carrierId": "@inputs.carrierId",
             "orderId": "@order.id",
-            "shippingAddress": "@order.shipping_address",
+            "shippingAddress": "@order.shippingAddress",
             "preferredDate": "@inputs.preferredDate",
             "timeSlot": "@inputs.timeSlot"
           },
@@ -361,14 +361,14 @@
           "kind": "eventPublish",
           "description": "retail.shipment.dispatched イベントを発行する。下流の出荷通知メール (retail:SendOrderConfirmEmail) や在庫 CDC が購読する。",
           "topic": "retail.shipment.dispatched",
-          "payload": "{ orderId: @order.id, orderNumber: @order.order_number, trackingNumber: @dispatchResult.trackingNumber, carrierId: @inputs.carrierId }"
+          "payload": "{ orderId: @order.id, orderNumber: @order.orderNumber, trackingNumber: @dispatchResult.trackingNumber, carrierId: @inputs.carrierId }"
         },
         {
           "id": "step-10",
           "kind": "return",
           "description": "200 OK — 配送指示成功を返す。",
           "responseId": "200-ok",
-          "bodyExpression": "{ orderId: @order.id, orderNumber: @order.order_number, trackingNumber: @dispatchResult.trackingNumber, carrierId: @inputs.carrierId, estimatedDelivery: @dispatchResult.estimatedDelivery }"
+          "bodyExpression": "{ orderId: @order.id, orderNumber: @order.orderNumber, trackingNumber: @dispatchResult.trackingNumber, carrierId: @inputs.carrierId, estimatedDelivery: @dispatchResult.estimatedDelivery }"
         }
       ]
     }

--- a/examples/retail/process-flows/efa7ac6e-e295-416e-b68d-17c4739b5097.json
+++ b/examples/retail/process-flows/efa7ac6e-e295-416e-b68d-17c4739b5097.json
@@ -250,7 +250,7 @@
           "description": "inventory + products を JOIN して在庫一覧を取得する。productCode が指定された場合は product_id でフィルタ。",
           "tableId": "834ede22-3cb0-4dcf-aa8a-7c046664774a",
           "operation": "SELECT",
-          "sql": "SELECT i.id, p.id AS product_id, p.product_code, p.name AS product_name, p.unit_price, s.id AS store_id, s.store_code, s.name AS store_name, i.quantity_available, i.quantity_reserved FROM inventory i JOIN products p ON p.id = i.product_id JOIN stores s ON s.id = i.store_id WHERE s.store_code = @inputs.storeCode AND (@inputs.productCode IS NULL OR p.product_code = @inputs.productCode) AND p.is_active = TRUE AND s.is_active = TRUE ORDER BY p.product_code ASC",
+          "sql": "SELECT i.id, p.id AS \"productId\", p.product_code AS \"productCode\", p.name AS \"productName\", p.unit_price AS \"unitPrice\", s.id AS \"storeId\", s.store_code AS \"storeCode\", s.name AS \"storeName\", i.quantity_available AS \"quantityAvailable\", i.quantity_reserved AS \"quantityReserved\" FROM inventory i JOIN products p ON p.id = i.product_id JOIN stores s ON s.id = i.store_id WHERE s.store_code = @inputs.storeCode AND (@inputs.productCode IS NULL OR p.product_code = @inputs.productCode) AND p.is_active = TRUE AND s.is_active = TRUE ORDER BY p.product_code ASC",
           "outputBinding": { "name": "inventoryRows" },
           "lineage": {
             "reads": [
@@ -301,8 +301,8 @@
         {
           "id": "step-06",
           "kind": "compute",
-          "description": "各在庫行に isLowStock フラグを付与する。quantity_available が lowStockThreshold 以下 (>=) の場合に true とすることでオフバイワンを回避する。",
-          "expression": "@inventoryRows.map(r => ({ id: r.id, productId: r.product_id, productCode: r.product_code, productName: r.product_name, unitPrice: r.unit_price, storeId: r.store_id, storeCode: r.store_code, storeName: r.store_name, quantityAvailable: r.quantity_available, quantityReserved: r.quantity_reserved, isLowStock: r.quantity_available <= @conv.limit.lowStockThreshold }))",
+          "description": "各在庫行に isLowStock フラグを付与する。SQL で AS alias 済のため camelCase キーを直接参照する。quantityAvailable が lowStockThreshold 以下の場合に true とすることでオフバイワンを回避する。",
+          "expression": "@inventoryRows.map(r => ({ ...r, isLowStock: r.quantityAvailable <= @conv.limit.lowStockThreshold }))",
           "outputBinding": { "name": "inventoryItems" }
         },
         {
@@ -331,7 +331,7 @@
                   "kind": "eventPublish",
                   "description": "retail.inventory.low_stock_detected イベントを発行する。下流コンシューマ (補充発注フロー等) が冪等に処理する前提。",
                   "topic": "retail.inventory.low_stock_detected",
-                  "payload": "{ storeCode: @inputs.storeCode, productId: @firstLowStockRow.id, quantityAvailable: @firstLowStockRow.quantity_available }"
+                  "payload": "{ storeCode: @inputs.storeCode, productId: @firstLowStockRow.id, quantityAvailable: @firstLowStockRow.quantityAvailable }"
                 }
               ]
             }

--- a/examples/retail/process-flows/f81dd9e0-794c-4539-a2a5-9cbcc0a75899.json
+++ b/examples/retail/process-flows/f81dd9e0-794c-4539-a2a5-9cbcc0a75899.json
@@ -235,7 +235,7 @@
           "description": "顧客のアクティブカートと cart_items を取得する。",
           "tableId": "a32e1a09-bcbc-467f-86b0-983cd7ee61c6",
           "operation": "SELECT",
-          "sql": "SELECT c.id AS cart_id, ci.id AS item_id, ci.product_id, ci.unit_price_snapshot, ci.quantity, p.product_code, p.name AS product_name, p.unit_price FROM carts c JOIN cart_items ci ON ci.cart_id = c.id JOIN products p ON p.id = ci.product_id WHERE c.customer_id = @sessionCustomerId AND c.status = 'active'",
+          "sql": "SELECT c.id AS \"cartId\", ci.id AS \"itemId\", ci.product_id AS \"productId\", ci.unit_price_snapshot AS \"unitPriceSnapshot\", ci.quantity, p.product_code AS \"productCode\", p.name AS \"productName\", p.unit_price AS \"unitPrice\" FROM carts c JOIN cart_items ci ON ci.cart_id = c.id JOIN products p ON p.id = ci.product_id WHERE c.customer_id = @sessionCustomerId AND c.status = 'active'",
           "outputBinding": { "name": "cartItems" },
           "lineage": {
             "reads": [
@@ -281,7 +281,7 @@
           "id": "step-04",
           "kind": "compute",
           "description": "cart_items から注文合計金額 (税抜) を計算する。各行の line_amount = unit_price_snapshot * quantity の合計。",
-          "expression": "@cartItems.reduce((sum, item) => sum + (item.unit_price_snapshot * item.quantity), 0)",
+          "expression": "@cartItems.reduce((sum, item) => sum + (item.unitPriceSnapshot * item.quantity), 0)",
           "outputBinding": { "name": "totalAmount" }
         },
         {
@@ -326,7 +326,7 @@
                   "description": "在庫を注文数量分だけ減算する。0 未満になる場合は DB の CHECK 制約で弾かれ、STOCK_SHORTAGE エラーが発生する。",
                   "tableId": "834ede22-3cb0-4dcf-aa8a-7c046664774a",
                   "operation": "retail:DECREMENT_STOCK",
-                  "sql": "UPDATE inventory SET quantity_available = quantity_available - @cartItem.quantity, updated_at = CURRENT_TIMESTAMP WHERE product_id = @cartItem.product_id AND store_id = (SELECT id FROM stores WHERE store_code = 'DEFAULT' LIMIT 1) AND quantity_available >= @cartItem.quantity",
+                  "sql": "UPDATE inventory SET quantity_available = quantity_available - @cartItem.quantity, updated_at = CURRENT_TIMESTAMP WHERE product_id = @cartItem.productId AND store_id = (SELECT id FROM stores WHERE store_code = 'DEFAULT' LIMIT 1) AND quantity_available >= @cartItem.quantity",
                   "affectedRowsCheck": {
                     "operator": "=",
                     "expected": 1,
@@ -373,7 +373,7 @@
                   "description": "order_items に 1 行 INSERT する。order_id は step-06-02 で取得した insertedOrder.id を使用する。",
                   "tableId": "dddfb0c1-0fde-40ac-bcf0-5ed75a7f1edc",
                   "operation": "INSERT",
-                  "sql": "INSERT INTO order_items (order_id, product_id, product_code_snapshot, product_name_snapshot, unit_price_snapshot, quantity, line_amount) VALUES (@insertedOrder.id, @cartItem.product_id, @cartItem.product_code, @cartItem.product_name, @cartItem.unit_price_snapshot, @cartItem.quantity, @cartItem.unit_price_snapshot * @cartItem.quantity)",
+                  "sql": "INSERT INTO order_items (order_id, product_id, product_code_snapshot, product_name_snapshot, unit_price_snapshot, quantity, line_amount) VALUES (@insertedOrder.id, @cartItem.productId, @cartItem.productCode, @cartItem.productName, @cartItem.unitPriceSnapshot, @cartItem.quantity, @cartItem.unitPriceSnapshot * @cartItem.quantity)",
                   "lineage": {
                     "writes": [{ "tableId": "dddfb0c1-0fde-40ac-bcf0-5ed75a7f1edc", "purpose": "insert" }]
                   }
@@ -480,7 +480,7 @@
           "description": "TX コミット後に orders を再取得する。TX 内の insertedOrder の変数をそのまま参照するとネスト変数問題が起きるため、TX 後に SELECT で再取得する。",
           "tableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab",
           "operation": "SELECT",
-          "sql": "SELECT id, order_number, customer_id, status, total_amount, ordered_at FROM orders WHERE order_number = @newOrderNumber",
+          "sql": "SELECT id, order_number AS \"orderNumber\", customer_id AS \"customerId\", status, total_amount AS \"totalAmount\", ordered_at AS \"orderedAt\" FROM orders WHERE order_number = @newOrderNumber",
           "outputBinding": { "name": "persistedOrder" },
           "lineage": {
             "reads": [{ "tableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab", "purpose": "lookup" }]
@@ -523,14 +523,14 @@
           "kind": "eventPublish",
           "description": "retail.order.confirmed イベントを発行する。TX コミット後 + persistedOrder 再取得後に発行するため、イベントペイロードは確定済み値のみ参照する。",
           "topic": "retail.order.confirmed",
-          "payload": "{ orderId: @persistedOrder.id, orderNumber: @persistedOrder.order_number, customerId: @persistedOrder.customer_id, totalAmount: @persistedOrder.total_amount }"
+          "payload": "{ orderId: @persistedOrder.id, orderNumber: @persistedOrder.orderNumber, customerId: @persistedOrder.customerId, totalAmount: @persistedOrder.totalAmount }"
         },
         {
           "id": "step-10",
           "kind": "return",
           "description": "200 OK — 注文確定完了を返す。",
           "responseId": "200-ok",
-          "bodyExpression": "{ orderId: @persistedOrder.id, orderNumber: @persistedOrder.order_number, totalAmount: @persistedOrder.total_amount, orderedAt: @persistedOrder.ordered_at, message: '注文が確定しました。注文番号: ' + @persistedOrder.order_number }"
+          "bodyExpression": "{ orderId: @persistedOrder.id, orderNumber: @persistedOrder.orderNumber, totalAmount: @persistedOrder.totalAmount, orderedAt: @persistedOrder.orderedAt, message: '注文が確定しました。注文番号: ' + @persistedOrder.orderNumber }"
         }
       ]
     }


### PR DESCRIPTION
## 関連

Closes #775
Continuation of #774 / #777 / #778 cleanup series

- 仕様: docs/spec/view-definition.md §(D-5) (新規追加)
- 仕様: docs/spec/process-flow-runtime-conventions.md §1.4 (新規追加)
- スキル: .claude/skills/create-flow/SKILL.md Rule 30
- スキル: .claude/skills/review-flow/SKILL.md 観点 13

## 概要

cleanup シリーズ (#774/#777/#778) で行ったメイン削除後も active spec docs に残っていた旧 `validate-dogfood` / `sample-project-v3` 参照を最新に追従し、#775 で確定した SQL SELECT AS alias 規約をサンプル全件に適用する。

## 主な変更

### (A) Active spec docs 残骸クリーンアップ (A-1〜A-7)
- screen-items.md:596: `validate-dogfood` → `validate:samples` (A-1)
- view-definition.md:340: `validate-dogfood` → `validate:samples` 登録 9 番目に訂正 (A-2)
- plugin-system.md:345: 削除済み `process-flow.schema.test.ts` → `samples-v3.schema.test.ts` (A-3)
- process-flow-transaction.md §5: 削除済みサンプル参照 → 現行 canonical 参照 + 概念説明化 (A-4)
- process-flow-workflow.md:143,207: 削除済み sample-project-v3 参照 → 抽象化 (A-5)
- schema-design-principles.md §8.1: `process-flow.schema.test.ts` 参照 → `samples-v3.schema.test.ts` + vitest に更新 (A-6)
- v3-types.test.ts:8: コメント内 `sample-project-v3` → `examples/<project-id>/` (A-7)

### (B) #775 確定: SQL SELECT AS alias 必須化
- view-definition.md (D-5) に規約を新設 (view-definition.md:323)
- process-flow-runtime-conventions.md §1.4 に規約追記 (process-flow-runtime-conventions.md:48)

### (C) サンプル全 SQL に AS alias 適用
- 267e94bf: itemCount/totalAmount alias + compute refs 更新、productCode/productName/unitPrice alias
- efa7ac6e: 在庫 JOIN SQL 全カラム alias + step-06 compute を `...spread + isLowStock` に簡略化
- a3659922: KPI 集計列 todaySales/ordersToday/lowStockCount/dispatchPending alias + refs 更新
- 9515d6f6: productCode/unitPrice alias + itemCount alias + refs 更新
- d63c703c: orderNumber/customerId/totalAmount/shippingAddress alias + refs 更新
- f81dd9e0: cartItems 全カラム camelCase alias + persistedOrder SQL alias + refs 更新
- d4b5c6e7 (realestate): propertyCode/propertyType/areaSqm/price10kYen/listedAt alias

### (D) スキル更新
- create-flow SKILL.md: Rule 30 追加 + self-check 表更新 (SKILL.md:429-437, SKILL.md:581)
- review-flow SKILL.md: 観点 13 追加 (SKILL.md 観点表)

### (E) #776 close
- `gh issue close 776` 実施済み (parking lot ISSUE 整理)

## 仕様逐条突合 (自己申告)

- A-1 screen-items.md validate-dogfood → validate:samples → docs/spec/screen-items.md:596 ✓
- A-2 view-definition.md validate-dogfood → validate:samples 登録 9 番目 → docs/spec/view-definition.md:340 ✓
- A-3 plugin-system.md process-flow.schema.test.ts → samples-v3.schema.test.ts → docs/spec/plugin-system.md:345 ✓
- A-4 process-flow-transaction.md §5 抽象化 → docs/spec/process-flow-transaction.md:154-160 ✓
- A-5 process-flow-workflow.md 旧参照削除 → docs/spec/process-flow-workflow.md:143, 207 ✓
- A-6 schema-design-principles.md §8.1 更新 → docs/spec/schema-design-principles.md:801-811 ✓
- A-7 v3-types.test.ts コメント更新 → designer/src/types/v3/v3-types.test.ts:8 ✓
- (D-5) SQL alias 規約 → docs/spec/view-definition.md:323-341 ✓
- §1.4 runtime conventions SQL alias → docs/spec/process-flow-runtime-conventions.md:48-66 ✓
- Rule 30 create-flow → .claude/skills/create-flow/SKILL.md:429-437, 581 ✓
- 観点 13 review-flow → .claude/skills/review-flow/SKILL.md 観点表 ✓
- validate:samples retail 6/6 pass ✓
- validate:samples realestate 1/1 pass ✓
- vitest 1219/1219 pass ✓
- build (tsc + vite) pass ✓

## レビューで特に見てほしい箇所

1. efa7ac6e step-06 の簡略化: SQL alias 追加に伴い map() の手動変換を `{ ...r, isLowStock: r.quantityAvailable <= ... }` に変更。isLowStock 計算が `r.quantityAvailable` (camelCase) を参照するよう更新済み。
2. f81dd9e0 step-02 の cartItems SQL: cart_id/item_id/product_name 等が全て camelCase alias に変更。loop 変数 `cartItem` から参照する SQL 内の `@cartItem.productId` 等も追従更新済み。
3. view-definition.md (D-5) と runtime-conventions §1.4 の二重定義を意図的にした (前者は VD spec、後者は runtime spec として別概念軸から記述)。

## テスト

- Vitest: 1219 件 (新規 0 件) — 既存テスト全 pass
- Playwright: N/A (UI 変更なし)
- MCP E2E: N/A

## UI 影響 / AI smoke test

- [x] UI 影響なし (auto テスト pass のみ)

### UI 影響ありの場合、AI smoke test で確認した項目

N/A (docs + JSON サンプルのみの変更)

## spec 側の不足点 / 提案

N/A — (D-5) / §1.4 として今 PR で規約追加済み。

## レビュー担当への申し送り

- 今 PR の核心は「SQL alias の追加が下流の変数参照と整合しているか」。各ファイルで alias 追加 → 旧 snake_case 参照 → 新 camelCase 参照への一貫した更新が重要。
- efa7ac6e のみ step-06 のロジック変更あり (spread operator使用)。意味は等価だがリグレッションに注意。
- sample-project-structure.md の廃止パス表 (lines 55-57) に `sample-project-v3` / `legacy-sample-project` の記述が残るが、これは「廃止パス一覧」テーブルとして正規の doc であり変更対象外と判断。