### PR TITLE
feat(schemas/process-flow): retail dogfood 改善 3 件 (#781, #782, #783)

### DIFF
--- a/designer/scripts/validate-samples.ts
+++ b/designer/scripts/validate-samples.ts
@@ -450,6 +450,55 @@ export async function runValidation(projectDirArg: string): Promise<ValidationSu
       issues.push(issue("processFlowAntipatternValidator", i.code, i.path, i.message, i.severity));
     }
 
+    // #781: outputBinding.transformations の field 重複チェック
+    if (Array.isArray(flow.actions)) {
+      for (let ai = 0; ai < flow.actions.length; ai++) {
+        const action = flow.actions[ai];
+        if (!Array.isArray(action.steps)) continue;
+        const checkTransformations = (steps: unknown[], basePath: string) => {
+          for (let si = 0; si < steps.length; si++) {
+            const step = steps[si] as Record<string, unknown>;
+            const path = `${basePath}[${si}]`;
+            const ob = step.outputBinding as Record<string, unknown> | undefined;
+            if (ob && Array.isArray(ob.transformations)) {
+              const seen = new Set<string>();
+              for (const t of ob.transformations as { field?: string }[]) {
+                if (t.field) {
+                  if (seen.has(t.field)) {
+                    issues.push(issue(
+                      "outputBindingTransformationsValidator",
+                      "DUPLICATE_TRANSFORMATION_FIELD",
+                      `${path}.outputBinding.transformations`,
+                      `field "${t.field}" が transformations に重複して定義されています。同一 field への変換は 1 件のみ許可されます。`,
+                    ));
+                  }
+                  seen.add(t.field);
+                }
+              }
+            }
+            // ネスト (branch / loop / transactionScope 等)
+            for (const nestedKey of ["steps", "elseBranch"]) {
+              if (nestedKey === "steps" && Array.isArray(step.steps)) {
+                checkTransformations(step.steps as unknown[], `${path}.steps`);
+              } else if (nestedKey === "elseBranch" && step.elseBranch) {
+                const eb = step.elseBranch as Record<string, unknown>;
+                if (Array.isArray(eb.steps)) checkTransformations(eb.steps as unknown[], `${path}.elseBranch.steps`);
+              }
+            }
+            if (Array.isArray(step.branches)) {
+              for (let bi = 0; bi < (step.branches as unknown[]).length; bi++) {
+                const branch = (step.branches as Record<string, unknown>[])[bi];
+                if (Array.isArray(branch.steps)) {
+                  checkTransformations(branch.steps as unknown[], `${path}.branches[${bi}].steps`);
+                }
+              }
+            }
+          }
+        };
+        checkTransformations(action.steps as unknown[], `actions[${ai}].steps`);
+      }
+    }
+
     return { filePath, displayName, projectId: project.projectId, issues };
   }
 
@@ -546,6 +595,7 @@ const validatorDisplayOrder = [
   "screenNavigationValidator",
   "runtimeContractValidator",
   "processFlowAntipatternValidator",
+  "outputBindingTransformationsValidator",
 ];
 
 export function printSummary(summary: ValidationSummary): void {

--- a/designer/scripts/validate-samples.ts
+++ b/designer/scripts/validate-samples.ts
@@ -493,6 +493,13 @@ export async function runValidation(projectDirArg: string): Promise<ValidationSu
                 }
               }
             }
+            // transactionScope の onCommit / onRollback 配下も走査 (#785 Nit)
+            if (Array.isArray(step.onCommit)) {
+              checkTransformations(step.onCommit as unknown[], `${path}.onCommit`);
+            }
+            if (Array.isArray(step.onRollback)) {
+              checkTransformations(step.onRollback as unknown[], `${path}.onRollback`);
+            }
           }
         };
         checkTransformations(action.steps as unknown[], `actions[${ai}].steps`);

--- a/designer/src/schemas/conventionsValidator.test.ts
+++ b/designer/src/schemas/conventionsValidator.test.ts
@@ -801,3 +801,90 @@ describe("#734 checkStep — validation rules[].minRef/maxRef/lengthRef 検査",
   });
 });
 
+describe("#783 context.catalogs.domains.constraints[].patternRef 検証", () => {
+  const catalog: ConventionsCatalog = {
+    version: "1.0.0",
+    regex: {
+      productCode: { pattern: "^P-[0-9]{4,6}$" },
+    },
+  };
+
+  it("domains.constraints[].patternRef に実在する @conv.regex.* を書くとエラーなし", () => {
+    const issues = checkConventionReferences(
+      makeGroup({
+        context: {
+          catalogs: {
+            domains: {
+              ProductCode: {
+                type: "string",
+                constraints: [
+                  { field: "productCode", type: "regex", patternRef: "@conv.regex.productCode", severity: "error" },
+                ],
+              },
+            },
+          },
+        },
+      } as Partial<ProcessFlow>),
+      catalog,
+    );
+    expect(issues).toHaveLength(0);
+  });
+
+  it("domains.constraints[].patternRef に存在しない @conv.regex.* を書くと UNKNOWN_CONV_REGEX 検出", () => {
+    const issues = checkConventionReferences(
+      makeGroup({
+        context: {
+          catalogs: {
+            domains: {
+              ProductCode: {
+                type: "string",
+                constraints: [
+                  { field: "productCode", type: "regex", patternRef: "@conv.regex.unknownKey", severity: "error" },
+                ],
+              },
+            },
+          },
+        },
+      } as Partial<ProcessFlow>),
+      catalog,
+    );
+    expect(issues).toHaveLength(1);
+    const hit = issues[0];
+    expect(hit.code).toBe("UNKNOWN_CONV_REGEX");
+    expect(hit.path).toBe("context.catalogs.domains.ProductCode.constraints[0].patternRef");
+  });
+
+  it("domains.constraints[].message に @conv.msg.* がある場合も検証される", () => {
+    const catalogWithMsg: ConventionsCatalog = {
+      version: "1.0.0",
+      regex: { productCode: { pattern: "^P-[0-9]{4,6}$" } },
+      msg: { required: { template: "必須です", params: [] } },
+    };
+    const issues = checkConventionReferences(
+      makeGroup({
+        context: {
+          catalogs: {
+            domains: {
+              ProductCode: {
+                type: "string",
+                constraints: [
+                  { field: "productCode", type: "regex", patternRef: "@conv.regex.productCode", severity: "error", message: "@conv.msg.unknownMsg" },
+                ],
+              },
+            },
+          },
+        },
+      } as Partial<ProcessFlow>),
+      catalogWithMsg,
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("UNKNOWN_CONV_MSG");
+    expect(issues[0].path).toBe("context.catalogs.domains.ProductCode.constraints[0].message");
+  });
+
+  it("domains が undefined の場合は検査スキップ (既存テスト不変)", () => {
+    const issues = checkConventionReferences(makeGroup({}), catalog);
+    expect(issues).toHaveLength(0);
+  });
+});
+

--- a/designer/src/schemas/conventionsValidator.test.ts
+++ b/designer/src/schemas/conventionsValidator.test.ts
@@ -886,5 +886,89 @@ describe("#783 context.catalogs.domains.constraints[].patternRef 検証", () => 
     const issues = checkConventionReferences(makeGroup({}), catalog);
     expect(issues).toHaveLength(0);
   });
+
+  it("domains.constraints[].minRef に存在しない @conv.limit.* を書くと UNKNOWN_CONV_LIMIT 検出", () => {
+    const catalogWithLimit: ConventionsCatalog = {
+      version: "1.0.0",
+      limit: { quantityMin: { value: 1, unit: "integer" } },
+    };
+    const issues = checkConventionReferences(
+      makeGroup({
+        context: {
+          catalogs: {
+            domains: {
+              Quantity: {
+                type: "integer",
+                constraints: [
+                  { field: "quantity", type: "min", minRef: "@conv.limit.unknownMin", severity: "error" },
+                ],
+              },
+            },
+          },
+        },
+      } as Partial<ProcessFlow>),
+      catalogWithLimit,
+    );
+    expect(issues.length).toBeGreaterThanOrEqual(1);
+    const hit = issues.find((i) => i.path === "context.catalogs.domains.Quantity.constraints[0].minRef");
+    expect(hit).toBeDefined();
+    expect(hit?.code).toBe("UNKNOWN_CONV_LIMIT");
+  });
+
+  it("domains.constraints[].maxRef に存在しない @conv.limit.* を書くと UNKNOWN_CONV_LIMIT 検出", () => {
+    const catalogWithLimit: ConventionsCatalog = {
+      version: "1.0.0",
+      limit: { quantityMax: { value: 9999, unit: "integer" } },
+    };
+    const issues = checkConventionReferences(
+      makeGroup({
+        context: {
+          catalogs: {
+            domains: {
+              Quantity: {
+                type: "integer",
+                constraints: [
+                  { field: "quantity", type: "max", maxRef: "@conv.limit.unknownMax", severity: "error" },
+                ],
+              },
+            },
+          },
+        },
+      } as Partial<ProcessFlow>),
+      catalogWithLimit,
+    );
+    expect(issues.length).toBeGreaterThanOrEqual(1);
+    const hit = issues.find((i) => i.path === "context.catalogs.domains.Quantity.constraints[0].maxRef");
+    expect(hit).toBeDefined();
+    expect(hit?.code).toBe("UNKNOWN_CONV_LIMIT");
+  });
+
+  it("domains.constraints[].lengthRef に存在しない @conv.limit.* を書くと UNKNOWN_CONV_LIMIT 検出", () => {
+    const catalogWithLimit: ConventionsCatalog = {
+      version: "1.0.0",
+      limit: { nameMax: { value: 100, unit: "char" } },
+    };
+    const issues = checkConventionReferences(
+      makeGroup({
+        context: {
+          catalogs: {
+            domains: {
+              ProductName: {
+                type: "string",
+                constraints: [
+                  { field: "name", type: "maxLength", lengthRef: "@conv.limit.unknownLength", severity: "error" },
+                ],
+              },
+            },
+          },
+        },
+      } as Partial<ProcessFlow>),
+      catalogWithLimit,
+    );
+    expect(issues.length).toBeGreaterThanOrEqual(1);
+    const hit = issues.find((i) => i.path === "context.catalogs.domains.ProductName.constraints[0].lengthRef");
+    expect(hit).toBeDefined();
+    expect(hit?.code).toBe("UNKNOWN_CONV_LIMIT");
+  });
 });
 

--- a/designer/src/schemas/conventionsValidator.ts
+++ b/designer/src/schemas/conventionsValidator.ts
@@ -234,6 +234,22 @@ export function checkConventionReferences(
     walkStepsInAction(action, `actions[${ai}]`, catalog, issues);
   });
 
+  // context.catalogs.domains の constraints[].patternRef / *Ref を検査 (#783)
+  const domains = group.context?.catalogs?.domains;
+  if (domains) {
+    Object.entries(domains).forEach(([domainKey, entry]) => {
+      (entry.constraints ?? []).forEach((rule, ri) => {
+        const base = `context.catalogs.domains.${domainKey}.constraints[${ri}]`;
+        if (rule.patternRef) checkValue(rule.patternRef, `${base}.patternRef`, catalog, issues);
+        if (rule.minRef) checkValue(rule.minRef, `${base}.minRef`, catalog, issues);
+        if (rule.maxRef) checkValue(rule.maxRef, `${base}.maxRef`, catalog, issues);
+        if (rule.lengthRef) checkValue(rule.lengthRef, `${base}.lengthRef`, catalog, issues);
+        if (rule.condition) checkValue(rule.condition, `${base}.condition`, catalog, issues);
+        if (rule.message) checkValue(rule.message, `${base}.message`, catalog, issues);
+      });
+    });
+  }
+
   return issues;
 }
 

--- a/designer/src/types/v3/process-flow.ts
+++ b/designer/src/types/v3/process-flow.ts
@@ -737,6 +737,16 @@ export interface WorkflowStep extends StepBaseProps {
 
 // ─── TransactionScopeStep ──────────────────────────────────────────────
 
+/**
+ * TX スコープ step。`outputBinding` を指定すると TX 結果が以下の semantics で expose される:
+ *
+ * - TX commit 成功: `@<name>.committed === true`、`@<name>.error` は未定義
+ * - TX rollback (rollbackOn のエラー): `@<name>.committed === false`、`@<name>.error.code` = エラーコード、`@<name>.error.message` = 例外メッセージ
+ * - TX rollback (rollbackOn 外の汎用エラー): `@<name>.committed === false`、`@<name>.error.code === "UNHANDLED"`
+ *
+ * 後続 branch の `condition.kind: "expression"` で `@txResult.error.code === 'STOCK_SHORTAGE'` のように参照する。
+ * 参照: docs/spec/process-flow-transaction.md §8.5、ISSUE #782
+ */
 export interface TransactionScopeStep extends StepBaseProps {
   kind: "transactionScope";
   description: Description;

--- a/designer/src/types/v3/process-flow.ts
+++ b/designer/src/types/v3/process-flow.ts
@@ -329,6 +329,21 @@ export interface ActionDefinition {
 
 // ─── StepBaseProps (全 Step variant 共通) ──────────────────────────────
 
+/** outputBinding.transformations の 1 エントリ。SELECT 結果列の型変換指示。 */
+export interface OutputBindingTransformation {
+  /** 変換対象の column 名 (SELECT alias 名)。例: "itemCount"、"totalAmount"。 */
+  field: string;
+  /**
+   * 変換後の型。
+   * - integer: parseInt
+   * - float: parseFloat
+   * - boolean: truthy 判定
+   * - date: new Date
+   * - json: JSON.parse
+   */
+  type: "integer" | "float" | "boolean" | "date" | "json";
+}
+
 /** Step 結果の outputBinding (構造化のみ、v3 で string 短縮形廃止)。 */
 export interface OutputBinding {
   /** 結果変数名 (Identifier / camelCase)。 */
@@ -337,6 +352,12 @@ export interface OutputBinding {
   operation?: "assign" | "accumulate" | "push";
   /** accumulate / push 時の初期値。JSON 値 (例: 0, []) または式文字列。 */
   initialValue?: unknown;
+  /**
+   * 結果列の型変換指示。runtime が SELECT 結果を binding に格納する前に各 field の型を変換する。
+   * SQL 方言 (PG COUNT(*)→bigint→string、SUM(...)→decimal→string 等) を吸収する責務を
+   * フレームワーク側に持たせ、SQL を DB 中立に保つ。SQL 側に CAST(...) を書く必要がなくなる。
+   */
+  transformations?: OutputBindingTransformation[];
 }
 
 /** TX 境界宣言。txId 単位で begin/member/end を結合。 */

--- a/docs/spec/process-flow-transaction.md
+++ b/docs/spec/process-flow-transaction.md
@@ -149,7 +149,8 @@ TX が rollback された**後**に実行する step 列。任意・補償処理
 2. **`onCommit` / `onRollback` の独立性**: これらは TX の外で実行され、自身の失敗は元の TX 結果を覆さない
 3. **ネスト時の `REQUIRES_NEW`**: 親 TX が動いている時に `REQUIRES_NEW` の TransactionScopeStep に入ると、親 TX が一時停止して内側 TX が独立 commit/rollback する。内側 commit 後に親 TX が rollback しても、内側の commit は取り消されない
 4. **ネスト時の `NESTED`**: savepoint を使う。内側 rollback は親 TX の savepoint 復元、親 rollback は savepoint も含めて全 rollback
-5. **`tryCatch` Branch との組合せ**: TransactionScopeStep の外側で `kind: "tryCatch"` Branch を置けば、TX rollback で throw されたエラーを捕捉できる
+5. **`outputBinding` による TX 結果の expose**: `transactionScope` step に `outputBinding: { "name": "txResult" }` を指定すると、TX 外の後続 step が `@txResult.committed` (boolean) と `@txResult.error` (失敗時のみ) を参照できる。これにより TX 失敗エラーコードを後続 branch の `condition.kind: "expression"` で参照できる (§8.5 参照)
+6. **`tryCatch` Branch との組合せ**: `outputBinding` なし / `tryCatch` branch による捕捉は以前から可能 (下位互換)。新規フローでは §8.5 の `outputBinding` + `expression` パターンを推奨する
 
 ## §5 サンプル (v3)
 
@@ -247,3 +248,89 @@ TX が rollback された**後**に実行する step 列。任意・補償処理
 // OK: TX inner の dbAccess が throw するコードのみ列挙
 "rollbackOn": ["STOCK_SHORTAGE"]
 ```
+
+### §8.5 `outputBinding` による TX 結果の expose と expression branch パターン (#782)
+
+`transactionScope` step の `outputBinding` は `StepBaseProps` を通じて他の step と同様に使用できる。TX の場合は特別な semantics が追加される:
+
+| 状態 | `@<name>.committed` | `@<name>.error` |
+|---|---|---|
+| TX commit 成功 | `true` | `undefined` (参照時は null 扱い) |
+| TX rollback (rollbackOn のエラー) | `false` | `{ code: "<エラーコード>", message: "<例外メッセージ>" }` |
+| TX rollback (rollbackOn 外の汎用エラー) | `false` | `{ code: "UNHANDLED", message: "<例外メッセージ>" }` |
+
+この semantics により、TX 外の `branch` step の `condition.kind: "expression"` で具体的なエラーコードを参照できる:
+
+```json
+{
+  "id": "step-tx",
+  "kind": "transactionScope",
+  "outputBinding": { "name": "txResult" },
+  "rollbackOn": ["STOCK_SHORTAGE", "ORDER_NUMBER_CONFLICT"],
+  "steps": [ ... ]
+},
+{
+  "id": "step-error-branch",
+  "kind": "branch",
+  "description": "TX 失敗時のエラー分岐",
+  "branches": [
+    {
+      "id": "br-stock-shortage",
+      "code": "A",
+      "label": "在庫不足エラー",
+      "condition": {
+        "kind": "expression",
+        "expression": "@txResult.error.code === 'STOCK_SHORTAGE'"
+      },
+      "steps": [
+        { "id": "step-return-422", "kind": "return", "responseId": "422-stock-shortage" }
+      ]
+    },
+    {
+      "id": "br-conflict",
+      "code": "B",
+      "label": "番号競合エラー",
+      "condition": {
+        "kind": "expression",
+        "expression": "@txResult.error.code === 'ORDER_NUMBER_CONFLICT'"
+      },
+      "steps": [
+        { "id": "step-return-422b", "kind": "return", "responseId": "422-conflict" }
+      ]
+    },
+    {
+      "id": "br-unhandled",
+      "code": "C",
+      "label": "予期しない TX エラー (catch-all)",
+      "condition": {
+        "kind": "expression",
+        "expression": "@txResult.error.code === 'UNHANDLED'"
+      },
+      "steps": [
+        { "id": "step-return-500", "kind": "return", "responseId": "500-internal" }
+      ]
+    }
+  ],
+  "elseBranch": {
+    "id": "br-tx-success",
+    "code": "D",
+    "label": "TX 成功 — 後続処理へ",
+    "steps": []
+  }
+},
+{
+  "id": "step-after-tx",
+  "kind": "return",
+  "runIf": "@txResult.committed == true",
+  "responseId": "200-ok"
+}
+```
+
+**`tryCatch` branch との役割分離**:
+
+| 方式 | 用途 | 推奨度 |
+|---|---|---|
+| `condition.kind: "tryCatch"` | step 単位の throw catch (TX 外でも使用可、TX 内の catch は `NESTED` + `tryCatch` の組合せ) | 下位互換として継続利用可 |
+| `outputBinding` + `expression: "@<name>.error.code === ..."` | TX 全体の失敗後に TX 外 branch でエラーコード別分岐 | **新規フローで推奨** |
+
+**重要**: 両方を同じ TX に対して使用しないこと。`outputBinding` + `expression` パターンを採用したら、同一 TX の `tryCatch` branch は削除する。

--- a/docs/spec/process-flow-variables.md
+++ b/docs/spec/process-flow-variables.md
@@ -87,10 +87,16 @@ interface ActionDefinition {
 // v3 で string 短縮形廃止、object 形式に統一
 type OutputBindingOperation = "assign" | "accumulate" | "push";
 
+interface OutputBindingTransformation {
+  field: string;                                         // 変換対象 column 名 (SELECT alias 名)
+  type: "integer" | "float" | "boolean" | "date" | "json"; // 変換後の型
+}
+
 interface OutputBinding {
-  name: string;                       // Identifier (camelCase 強制)
-  operation?: OutputBindingOperation; // 既定 "assign"
-  initialValue?: string;              // accumulate: "0", push: "[]" 相当 (式可)
+  name: string;                            // Identifier (camelCase 強制)
+  operation?: OutputBindingOperation;      // 既定 "assign"
+  initialValue?: string;                   // accumulate: "0", push: "[]" 相当 (式可)
+  transformations?: OutputBindingTransformation[]; // SELECT 結果の型変換 (#781)
 }
 
 interface StepBaseProps {
@@ -102,6 +108,42 @@ operation の意味:
 - `assign` (既定): 上書き代入
 - `accumulate`: `+=` で数値累積 (例: 税額計算の積算)
 - `push`: 配列の末尾追加 (例: ループ内で enrichedItems を構築)
+
+#### transformations — DB 方言吸収 (#781)
+
+`transformations` は SQL の SELECT 結果を binding に格納する前に runtime が型変換するための宣言。**SQL 側に `CAST(...)` を書かずに DB 中立な SQL を保ちつつ**、PG 固有の型変換問題を吸収できる。
+
+| type | 変換処理 | 主なユースケース |
+|------|----------|----------------|
+| `integer` | `parseInt(value, 10)` | PG `COUNT(*)`→bigint→string |
+| `float` | `parseFloat(value)` | PG `SUM(amount)`→decimal→string |
+| `boolean` | truthy 判定 | PG `bool` 値→string "t"/"f" |
+| `date` | `new Date(value)` | ISO 日付文字列→Date オブジェクト |
+| `json` | `JSON.parse(value)` | JSON 文字列→オブジェクト |
+
+**AI 実装時のルール**:
+1. PG `COUNT(*)` / `SUM(...)` / `AVG(...)` 等の集約関数を使う `dbAccess` step は、後続で数値比較する場合 `transformations` で `integer` または `float` を宣言する
+2. SQL 側では `CAST(COUNT(*) AS INTEGER)` 等の DB 固有構文を**使わない** (`transformations` で吸収する)
+3. `field` には SELECT の alias 名を指定する (例: `"itemCount"`, `"totalAmount"`)
+
+**例 (retail カート追加フロー)**:
+
+```json
+{
+  "id": "step-09",
+  "kind": "dbAccess",
+  "operation": "SELECT",
+  "sql": "SELECT COUNT(*) AS \"itemCount\" FROM cart_items WHERE cart_id = @cart.id",
+  "outputBinding": {
+    "name": "cartItemCount",
+    "transformations": [
+      { "field": "itemCount", "type": "integer" }
+    ]
+  }
+}
+```
+
+後続の `@cartItemCount.itemCount >= @conv.limit.cartMaxItems` は数値比較として正しく評価される。
 
 対応ステップタイプ (v3):
 

--- a/docs/spec/process-flow-variables.md
+++ b/docs/spec/process-flow-variables.md
@@ -121,9 +121,13 @@ operation の意味:
 | `date` | `new Date(value)` | ISO 日付文字列→Date オブジェクト |
 | `json` | `JSON.parse(value)` | JSON 文字列→オブジェクト |
 
+**適用範囲**:
+- `transformations` は `dbAccess` step の `outputBinding` に対して適用される。
+- `transactionScope` の outputBinding (`txResult.committed` / `txResult.error`) には適用されない (txResult はフレームワークが型付きで expose するため変換不要)。
+
 **AI 実装時のルール**:
 1. PG `COUNT(*)` / `SUM(...)` / `AVG(...)` 等の集約関数を使う `dbAccess` step は、後続で数値比較する場合 `transformations` で `integer` または `float` を宣言する
-2. SQL 側では `CAST(COUNT(*) AS INTEGER)` 等の DB 固有構文を**使わない** (`transformations` で吸収する)
+2. SQL 側では PG 等の DB 固有の `CAST(COUNT(*) AS INTEGER)` 等の構文を書かず、`transformations` 経由で runtime に吸収させる (DB 中立な SQL を保つため)
 3. `field` には SELECT の alias 名を指定する (例: `"itemCount"`, `"totalAmount"`)
 
 **例 (retail カート追加フロー)**:

--- a/examples/retail/process-flows/267e94bf-0397-44b8-b665-d3c40c38935b.json
+++ b/examples/retail/process-flows/267e94bf-0397-44b8-b665-d3c40c38935b.json
@@ -79,7 +79,13 @@
           "tableId": "57110336-a984-4d39-bb21-1e5d5bb4390b",
           "operation": "SELECT",
           "sql": "SELECT COALESCE(COUNT(ci.id), 0) AS \"itemCount\", COALESCE(SUM(ci.unit_price_snapshot * ci.quantity), 0) AS \"totalAmount\" FROM carts c LEFT JOIN cart_items ci ON ci.cart_id = c.id WHERE c.customer_id = @sessionCustomerId AND c.status = 'active'",
-          "outputBinding": { "name": "summaryRows" },
+          "outputBinding": {
+            "name": "summaryRows",
+            "transformations": [
+              { "field": "itemCount", "type": "integer" },
+              { "field": "totalAmount", "type": "float" }
+            ]
+          },
           "lineage": {
             "reads": [
               { "tableId": "a32e1a09-bcbc-467f-86b0-983cd7ee61c6", "purpose": "lookup" },

--- a/examples/retail/process-flows/9515d6f6-8342-48cf-a045-9e9d8fab1cfa.json
+++ b/examples/retail/process-flows/9515d6f6-8342-48cf-a045-9e9d8fab1cfa.json
@@ -378,11 +378,16 @@
         {
           "id": "step-09",
           "kind": "dbAccess",
-          "description": "現在の cart_items 件数を取得して上限チェックに使用する。existingItem が null の場合 (新規追加) のみ意味を持つ。PostgreSQL COUNT(*) は bigint を返すため CAST AS INTEGER で integer 型に正規化し、step-10 の数値比較で文字列⇔数値の暗黙変換を排除する。",
+          "description": "現在の cart_items 件数を取得して上限チェックに使用する。existingItem が null の場合 (新規追加) のみ意味を持つ。outputBinding.transformations で itemCount を integer 型に正規化し、step-10 の数値比較で文字列⇔数値の暗黙変換を排除する (PG COUNT(*) bigint→string 方言を runtime が吸収)。",
           "tableId": "57110336-a984-4d39-bb21-1e5d5bb4390b",
           "operation": "SELECT",
-          "sql": "SELECT CAST(COUNT(*) AS INTEGER) AS \"itemCount\" FROM cart_items WHERE cart_id = @cart.id",
-          "outputBinding": { "name": "cartItemCount" },
+          "sql": "SELECT COUNT(*) AS \"itemCount\" FROM cart_items WHERE cart_id = @cart.id",
+          "outputBinding": {
+            "name": "cartItemCount",
+            "transformations": [
+              { "field": "itemCount", "type": "integer" }
+            ]
+          },
           "lineage": {
             "reads": [{ "tableId": "57110336-a984-4d39-bb21-1e5d5bb4390b", "purpose": "lookup" }]
           }

--- a/examples/retail/process-flows/a3659922-3932-4857-a906-26dd605254fe.json
+++ b/examples/retail/process-flows/a3659922-3932-4857-a906-26dd605254fe.json
@@ -66,7 +66,13 @@
           "tableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab",
           "operation": "SELECT",
           "sql": "SELECT COALESCE(SUM(total_amount + tax_amount), 0) AS \"todaySales\", COUNT(*) AS \"ordersToday\" FROM orders WHERE DATE(ordered_at) = CURRENT_DATE AND status != 'cancelled'",
-          "outputBinding": { "name": "ordersAgg" },
+          "outputBinding": {
+            "name": "ordersAgg",
+            "transformations": [
+              { "field": "todaySales", "type": "float" },
+              { "field": "ordersToday", "type": "integer" }
+            ]
+          },
           "lineage": {
             "reads": [{ "tableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab", "purpose": "lookup" }]
           }
@@ -78,7 +84,12 @@
           "tableId": "834ede22-3cb0-4dcf-aa8a-7c046664774a",
           "operation": "SELECT",
           "sql": "SELECT COUNT(*) AS \"lowStockCount\" FROM inventory WHERE quantity_available <= @conv.limit.lowStockThreshold",
-          "outputBinding": { "name": "lowStockAgg" },
+          "outputBinding": {
+            "name": "lowStockAgg",
+            "transformations": [
+              { "field": "lowStockCount", "type": "integer" }
+            ]
+          },
           "lineage": {
             "reads": [{ "tableId": "834ede22-3cb0-4dcf-aa8a-7c046664774a", "purpose": "lookup" }]
           }
@@ -90,7 +101,12 @@
           "tableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab",
           "operation": "SELECT",
           "sql": "SELECT COUNT(*) AS \"dispatchPending\" FROM orders WHERE status IN ('pending', 'confirmed')",
-          "outputBinding": { "name": "dispatchAgg" },
+          "outputBinding": {
+            "name": "dispatchAgg",
+            "transformations": [
+              { "field": "dispatchPending", "type": "integer" }
+            ]
+          },
           "lineage": {
             "reads": [{ "tableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab", "purpose": "lookup" }]
           }

--- a/examples/retail/process-flows/efa7ac6e-e295-416e-b68d-17c4739b5097.json
+++ b/examples/retail/process-flows/efa7ac6e-e295-416e-b68d-17c4739b5097.json
@@ -71,7 +71,7 @@
             {
               "field": "productCode",
               "type": "regex",
-              "pattern": "^P-[0-9]{4,6}$",
+              "patternRef": "@conv.regex.productCode",
               "severity": "error",
               "message": "商品コードは 'P-' + 4〜6 桁数字の形式で入力してください (例: P-0001)。"
             }

--- a/examples/retail/process-flows/f81dd9e0-794c-4539-a2a5-9cbcc0a75899.json
+++ b/examples/retail/process-flows/f81dd9e0-794c-4539-a2a5-9cbcc0a75899.json
@@ -307,11 +307,12 @@
         {
           "id": "step-06",
           "kind": "transactionScope",
-          "description": "注文確定 TX (@conv.tx.orderConfirm)。在庫減算 → orders INSERT → order_items loop INSERT → カートクリアを原子的に実行する。いずれかが失敗した場合は全体をロールバックする。",
+          "description": "注文確定 TX (@conv.tx.orderConfirm)。在庫減算 → orders INSERT → order_items loop INSERT → カートクリアを原子的に実行する。いずれかが失敗した場合は全体をロールバックする。TX 結果は @txResult に expose され、後続 step-07 が @txResult.error.code で分岐する (ADR-007)。",
           "isolationLevel": "READ_COMMITTED",
           "propagation": "REQUIRED",
           "timeoutMs": 10000,
           "rollbackOn": ["STOCK_SHORTAGE", "ORDER_NUMBER_CONFLICT"],
+          "outputBinding": { "name": "txResult" },
           "steps": [
             {
               "id": "step-06-01",
@@ -426,16 +427,15 @@
         {
           "id": "step-07",
           "kind": "branch",
-          "description": "TX 成功/失敗に応じてレスポンスを分岐する。",
+          "description": "TX 失敗時にエラーコード別レスポンスを返す。@txResult.error.code で STOCK_SHORTAGE / ORDER_NUMBER_CONFLICT を識別し、それ以外 (UNHANDLED) は 422-order-confirm-failed に集約する。TX 成功時は else 経路で step-08 へ fallthrough する (ADR-007)。",
           "branches": [
             {
               "id": "br-07-stock",
               "code": "A",
               "label": "在庫不足エラー",
               "condition": {
-                "kind": "tryCatch",
-                "errorCode": "STOCK_SHORTAGE",
-                "description": "在庫減算で affectedRowsCheck 違反が発生した場合。"
+                "kind": "expression",
+                "expression": "@txResult.error.code === 'STOCK_SHORTAGE'"
               },
               "steps": [
                 {
@@ -452,9 +452,8 @@
               "code": "B",
               "label": "注文番号競合エラー",
               "condition": {
-                "kind": "tryCatch",
-                "errorCode": "ORDER_NUMBER_CONFLICT",
-                "description": "orders.order_number UNIQUE 制約違反。TX はロールバック済み。"
+                "kind": "expression",
+                "expression": "@txResult.error.code === 'ORDER_NUMBER_CONFLICT'"
               },
               "steps": [
                 {
@@ -465,11 +464,29 @@
                   "bodyExpression": "{ code: 'ORDER_NUMBER_CONFLICT', message: '注文番号の採番で競合が発生しました。再度お試しください。' }"
                 }
               ]
+            },
+            {
+              "id": "br-07-unhandled",
+              "code": "C",
+              "label": "予期しない TX エラー (catch-all)",
+              "condition": {
+                "kind": "expression",
+                "expression": "@txResult.error.code === 'UNHANDLED'"
+              },
+              "steps": [
+                {
+                  "id": "step-07-c-01",
+                  "kind": "return",
+                  "description": "422 注文確定失敗を返す。rollbackOn 外の予期しない TX エラー (UNHANDLED) に対応する catch-all。",
+                  "responseId": "422-order-confirm-failed",
+                  "bodyExpression": "{ code: 'ORDER_CONFIRM_FAILED', message: '注文確定処理に失敗しました。しばらく経ってから再度お試しください。' }"
+                }
+              ]
             }
           ],
           "elseBranch": {
             "id": "br-07-else",
-            "code": "C",
+            "code": "D",
             "label": "TX 成功 — 後続処理へ",
             "description": "TX 成功 — step-08 (persistedOrder 再取得) へ fallthrough。",
             "steps": []
@@ -582,6 +599,15 @@
         "decision": "rollbackOn には実際に TX inner から throw されるエラーコード (STOCK_SHORTAGE / ORDER_NUMBER_CONFLICT) のみを列挙する。予期しない TX rollback (DB 制約違反等の汎用エラー) は step-08b の persistedOrder == null 検出で catch-all として 422-order-confirm-failed を返す。",
         "consequences": "rollbackOn の意図 (= TX inner で throw される具体エラー) と実装が一致し、死コードがなくなる。汎用 catch-all は step-08b に集約され、ADR-002 の TX 後再取得設計と整合する。",
         "date": "2026-05-02"
+      },
+      {
+        "id": "ADR-007",
+        "title": "step-07 の TX 失敗捕捉を tryCatch から outputBinding + expression パターンに migration (#782)",
+        "status": "accepted",
+        "context": "旧版 step-07 は condition.kind: 'tryCatch' で STOCK_SHORTAGE / ORDER_NUMBER_CONFLICT を個別 catch していた。この方式はフレームワーク contract が暗黙的で AI 実装ごとに独自パターンが発生する問題が ISSUE #782 で指摘された。",
+        "decision": "step-06 (transactionScope) に outputBinding: { name: 'txResult' } を追加し、TX 失敗後は @txResult.error.code で標準的に識別できるようにした。step-07 の各 branch を condition.kind: 'expression', expression: \"@txResult.error.code === 'STOCK_SHORTAGE'\" 形式に書き換えた。rollbackOn に列挙されていない予期しないエラーは @txResult.error.code === 'UNHANDLED' で catch-all する (br-07-unhandled 追加)。",
+        "consequences": "ADR-005 で定義した catch-all の役割が step-08b の persistedOrder == null ガード (TX 成功後の SELECT 失敗) と step-07.br-07-unhandled (TX 失敗の汎用 catch-all) に役割分離された。step-08b はそのまま存在し、TX 成功後の SELECT 失敗ガードとして機能する。txResult.error.code === 'UNHANDLED' はフレームワーク (runtime) が rollbackOn 外エラー発生時に自動付与するコードである。",
+        "date": "2026-05-04"
       },
       {
         "id": "ADR-006",

--- a/examples/retail/process-flows/f81dd9e0-794c-4539-a2a5-9cbcc0a75899.json
+++ b/examples/retail/process-flows/f81dd9e0-794c-4539-a2a5-9cbcc0a75899.json
@@ -427,7 +427,8 @@
         {
           "id": "step-07",
           "kind": "branch",
-          "description": "TX 失敗時にエラーコード別レスポンスを返す。@txResult.error.code で STOCK_SHORTAGE / ORDER_NUMBER_CONFLICT を識別し、それ以外 (UNHANDLED) は 422-order-confirm-failed に集約する。TX 成功時は else 経路で step-08 へ fallthrough する (ADR-007)。",
+          "runIf": "@txResult.committed == false",
+          "description": "TX 失敗時にエラーコード別レスポンスを返す (runIf ガード済: TX 失敗時のみ評価)。@txResult.error.code で STOCK_SHORTAGE / ORDER_NUMBER_CONFLICT を識別し、それ以外 (UNHANDLED) は 422-order-confirm-failed に集約する。TX 成功時は runIf ガードにより skip される (ADR-007、spec §8.3 準拠)。",
           "branches": [
             {
               "id": "br-07-stock",
@@ -495,7 +496,8 @@
         {
           "id": "step-08",
           "kind": "dbAccess",
-          "description": "TX コミット後に orders を再取得する。TX 内の insertedOrder の変数をそのまま参照するとネスト変数問題が起きるため、TX 後に SELECT で再取得する。",
+          "runIf": "@txResult.committed == true",
+          "description": "TX コミット後に orders を再取得する (runIf ガード済: TX commit 後にのみ実行)。TX 内の insertedOrder の変数をそのまま参照するとネスト変数問題が起きるため、TX 後に SELECT で再取得する (spec §8.3 準拠)。",
           "tableId": "10d555e2-8041-4192-86f3-9e2a3ac581ab",
           "operation": "SELECT",
           "sql": "SELECT id, order_number AS \"orderNumber\", customer_id AS \"customerId\", status, total_amount AS \"totalAmount\", ordered_at AS \"orderedAt\" FROM orders WHERE order_number = @newOrderNumber",
@@ -507,7 +509,8 @@
         {
           "id": "step-08b",
           "kind": "branch",
-          "description": "TX コミット後の orders 再取得で null の場合は内部エラーとして 422 を返す (TX コミット直後なので理論上は発生しないが安全ガード)。",
+          "runIf": "@txResult.committed == true",
+          "description": "TX コミット後の orders 再取得で null の場合は内部エラーとして 422 を返す (runIf ガード済: TX commit 後にのみ評価。TX コミット直後なので理論上は発生しないが安全ガード、spec §8.3 準拠)。",
           "branches": [
             {
               "id": "br-08b-a",
@@ -539,14 +542,16 @@
         {
           "id": "step-09",
           "kind": "eventPublish",
-          "description": "retail.order.confirmed イベントを発行する。TX コミット後 + persistedOrder 再取得後に発行するため、イベントペイロードは確定済み値のみ参照する。",
+          "runIf": "@txResult.committed == true",
+          "description": "retail.order.confirmed イベントを発行する (runIf ガード済: TX commit 後にのみ実行)。TX コミット後 + persistedOrder 再取得後に発行するため、イベントペイロードは確定済み値のみ参照する (spec §8.3 準拠)。",
           "topic": "retail.order.confirmed",
           "payload": "{ orderId: @persistedOrder.id, orderNumber: @persistedOrder.orderNumber, customerId: @persistedOrder.customerId, totalAmount: @persistedOrder.totalAmount }"
         },
         {
           "id": "step-10",
           "kind": "return",
-          "description": "200 OK — 注文確定完了を返す。",
+          "runIf": "@txResult.committed == true",
+          "description": "200 OK — 注文確定完了を返す (runIf ガード済: TX commit 後にのみ実行、spec §8.3 準拠)。",
           "responseId": "200-ok",
           "bodyExpression": "{ orderId: @persistedOrder.id, orderNumber: @persistedOrder.orderNumber, totalAmount: @persistedOrder.totalAmount, orderedAt: @persistedOrder.orderedAt, message: '注文が確定しました。注文番号: ' + @persistedOrder.orderNumber }"
         }

--- a/schemas/v3/process-flow.v3.schema.json
+++ b/schemas/v3/process-flow.v3.schema.json
@@ -410,6 +410,23 @@
         },
         "initialValue": {
           "description": "accumulate / push 時の初期値。JSON 値 (例: 0, []) または式文字列。"
+        },
+        "transformations": {
+          "type": "array",
+          "description": "結果列の型変換指示。runtime が SELECT 結果を binding に格納する前に各 field の型を変換する。SQL 方言 (PG COUNT(*)→bigint→string、SUM(...)→decimal→string 等) を吸収する責務をフレームワーク側に持たせ、SQL を DB 中立に保つ。SQL 側に CAST(...) を書く必要がなくなる。",
+          "items": {
+            "type": "object",
+            "required": ["field", "type"],
+            "additionalProperties": false,
+            "properties": {
+              "field": { "type": "string", "description": "変換対象の column 名 (SELECT alias 名)。例: \"itemCount\"、\"totalAmount\"。" },
+              "type": {
+                "type": "string",
+                "enum": ["integer", "float", "boolean", "date", "json"],
+                "description": "変換後の型。integer=parseInt / float=parseFloat / boolean=truthy 判定 / date=new Date / json=JSON.parse。"
+              }
+            }
+          }
         }
       }
     },

--- a/schemas/v3/process-flow.v3.schema.json
+++ b/schemas/v3/process-flow.v3.schema.json
@@ -1152,6 +1152,7 @@
     },
 
     "TransactionScopeStep": {
+      "description": "TX スコープ step。StepBaseProps.outputBinding を指定すると TX 結果を後続 step に expose する: commit 成功時は @<name>.committed=true / rollbackOn エラー時は @<name>.committed=false + @<name>.error={code,message} / rollbackOn 外の汎用エラー時は @<name>.error.code='UNHANDLED'。後続 branch で condition.kind='expression' + expression='@txResult.error.code===\"STOCK_SHORTAGE\"' のように参照する。詳細: docs/spec/process-flow-transaction.md §8.5 (#782)。",
       "allOf": [
         { "$ref": "#/$defs/StepBaseProps" },
         {
@@ -1164,7 +1165,8 @@
             "timeoutMs": { "type": "number", "minimum": 0 },
             "rollbackOn": {
               "type": "array",
-              "items": { "$ref": "common.v3.schema.json#/$defs/ErrorCode" }
+              "items": { "$ref": "common.v3.schema.json#/$defs/ErrorCode" },
+              "description": "TX rollback を引き起こすエラーコード集合。TX inner step から実際に throw されるコードのみを列挙する。列挙外のエラーが発生した場合は outputBinding の @<name>.error.code が 'UNHANDLED' になる。"
             },
             "steps": { "type": "array", "items": { "$ref": "#/$defs/Step" } },
             "onCommit": { "type": "array", "items": { "$ref": "#/$defs/Step" } },


### PR DESCRIPTION
## 関連

Closes #781
Closes #782
Closes #783

- 仕様:
  - `docs/spec/process-flow-variables.md` §3.2 (#781 transformations)
  - `docs/spec/process-flow-transaction.md` §4 規約 5+6 / §8.3 runIf ガード / §8.5 新設 (#782 TX expose)
  - `designer/src/schemas/conventionsValidator.ts` の domain 走査 (#783 patternRef)

## 概要

PR #780 retail dogfood (段階 4) で同根として起票された framework 提案 3 件を、AGENTS.md「ISSUE 起票の鉄則」鉄則 3 (同根は 1 ISSUE / 1 PR に統合) に **後追い** で統合した PR (memory `feedback_consolidate_related_proposals_into_one_issue.md`)。

調査の結果、3 件すべて schema 拡張案件として承認されたものの、実装で:

- **#783**: schema 変更 **不要** (既に `DomainEntry.constraints` は `ValidationRule` を参照しており `patternRef` 既定義)。validator + sample migration で完結
- **#782**: schema 変更は **description 追記のみ** (`StepBaseProps.outputBinding` を全 step が継承済み)。spec で TX 固有 expose semantics を明文化
- **#781**: 唯一の **本格的 schema 拡張** (`OutputBinding.transformations` 新設)

## 主な変更

### #781 — outputBinding.transformations による DB 方言吸収

- schema: `OutputBinding.transformations: [{field, type}]` 追加 (type: integer/float/boolean/date/json) — `schemas/v3/process-flow.v3.schema.json:414`
- TypeScript 型: `OutputBindingTransformation` interface 追加 — `designer/src/types/v3/process-flow.ts:333` / `:360`
- spec: `docs/spec/process-flow-variables.md` (interface / 各 type の semantics / AI 実装ルール / 例)
- sample migration (retail 全 4 file 5 step):
  - F3 (`9515d6f6-...json`) step-09: `CAST(COUNT(*) AS INTEGER)` を `COUNT(*)` に戻し `integer` 宣言
  - カート集計 (`267e94bf-...json`) step-01: itemCount/integer + totalAmount/float
  - ダッシュボード KPI (`a3659922-...json`) step-01: todaySales/float + ordersToday/integer / step-02: lowStockCount/integer / step-03: dispatchPending/integer
- validator: `designer/scripts/validate-samples.ts` — transformations 整合性チェック (TX `onCommit`/`onRollback` 配下も走査)

### #782 — transactionScope の TX 失敗 expose pattern

- schema: `TransactionScopeStep` description で TX outputBinding 固有 semantics (committed / error.code / UNHANDLED) を明文化 — `schemas/v3/process-flow.v3.schema.json:1171`
- spec §4 規約 5+6: `docs/spec/process-flow-transaction.md:152-153` (`outputBinding` 推奨 + `tryCatch` 並立)
- spec §8.5 新設: `docs/spec/process-flow-transaction.md:252` 以降 (expose 表 + 完全 JSON 例 + tryCatch との役割分離)
- sample migration (F6 `f81dd9e0-...json`):
  - step-06 に `outputBinding: { name: "txResult" }`
  - step-07 を `tryCatch` から `condition.kind: "expression"` ベース branch に書き換え、catch-all `UNHANDLED` 明示
  - **step-07/08/08b/09/10 すべてに spec §8.3 準拠の `runIf` ガードを追加** (TX rollback 後の自動 skip は保証されないため、明示的 `@txResult.committed == true` / `false` ガードを必須化)
  - ADR-007 追記
- 既存 `tryCatch` step は変更なし (並立、役割分離が方針)

### #783 — domain.constraints の patternRef 許容

- schema: **変更なし** (既に `ValidationRule` で許容済み)
- validator: `designer/src/schemas/conventionsValidator.ts:237-243` — domain 走査 (`constraints[].patternRef` / `*Ref`) 追加
- unit test: `designer/src/schemas/conventionsValidator.test.ts` (+170 行 / +7 tests、`patternRef`/`minRef`/`maxRef`/`lengthRef` 全カバー)
- sample migration (F1 `efa7ac6e-...json`): `domains.ProductCode.constraints[0]` を literal pattern → `patternRef: "@conv.regex.productCode"`

### レビュー対応 (commit `e5b0f3a`)

独立レビュー (PR コメント参照) の Must-fix / Should-fix / Nit を **同 PR で吸収** (memory `feedback_pr_scope_absorb_pre_existing.md`、ISSUE 純増回避):

- **Must-fix**: F6 step-07/08/08b/09/10 に runIf ガード追加 (spec §8.3 準拠、`@txResult.error` 参照の null-safe 化も同時解消)
- **Should-fix**: 残り retail flows (267e94bf / a3659922) の COUNT/SUM 4 step に transformations 追加 (ISSUE #781 全 retail 適用)
- **Nit**: spec で transformations の dbAccess 限定明記 / CAST 文言 DB 中立化 / validator が `onCommit`/`onRollback` 走査 / unit test に minRef/maxRef/lengthRef 追加

## 仕様逐条突合 (自己申告)

**#781**:
- 型変換指示を schema 上に追加 → `schemas/v3/process-flow.v3.schema.json:414` ✓
- AI 実装ルール (SQL CAST 不要、transformations で吸収) → `docs/spec/process-flow-variables.md` ✓
- retail 全集約 SQL の reverse migration → F3/カート集計/KPI 計 4 ファイル 5 step ✓
- TypeScript 型同期 → `designer/src/types/v3/process-flow.ts:333,360` ✓

**#782**:
- TX 失敗時の `txResult.error.code` expose semantics → `schemas/v3/process-flow.v3.schema.json:1171` description ✓
- catch-all (`UNHANDLED`) 標準パターン → `docs/spec/process-flow-transaction.md §8.5` ✓
- `tryCatch` step との役割分離 → `docs/spec/process-flow-transaction.md:152-153` + §8.5 末尾 ✓
- F6 sample が新パターン準拠 + spec §8.3 runIf ガード遵守 → `examples/retail/process-flows/f81dd9e0-...json` step-06,07,08,08b,09,10 ✓

**#783**:
- domain `constraints[].patternRef` の解決 → `designer/src/schemas/conventionsValidator.ts:237-243` ✓
- F1 sample が patternRef migration 済み → `examples/retail/process-flows/efa7ac6e-...json` line 71 ✓
- DRY 違反解消 (`@conv.regex.productCode` 1 箇所更新で同期) ✓

## レビューで特に見てほしい箇所

(初回独立レビュー実施済 — `gh pr view 785 --comments`、レビュー対応 commit `e5b0f3a` で全指摘対応済)

1. **#781 transformations の type 列挙**: 初期スコープ 5 種 (integer/float/boolean/date/json) で十分か
2. **#782 schema description のみで spec 詳細を doc に逃がした構成**: AI 読み取り時に schema → spec link が辿れるか
3. **#783 schema 変更ゼロでの解決**: `DomainEntry.constraints` が `ValidationRule[]` を継承していた事実を根拠に schema 変更を見送った判断
4. **F6 migration**: `tryCatch` から `expression` ベース branch + spec §8.3 準拠の runIf ガード一式

## テスト

- Vitest: 1226 件 (新規 +7 件、`conventionsValidator.test.ts` で patternRef/minRef/maxRef/lengthRef 全カバー)
- Playwright: N/A (UI 影響なし)
- MCP E2E: N/A (UI 影響なし)

検証コマンド:
- `cd designer && npm run validate:samples -- ../examples/retail` → **6/6 flows pass** (13 validators each)
- `cd designer && npm run test:unit` → **87 test files / 1226 tests all pass**
- `cd designer && npm run build` → 型エラーなし

## UI 影響 / AI smoke test

- [ ] UI 影響あり (AI が chrome-devtools MCP / Playwright で smoke test 実施済み)
- [x] UI 影響なし (auto テスト pass のみ)

schema / spec / sample / validator / TypeScript 型のみの変更。

## spec 側の不足点 / 提案

(レビュー対応 commit `e5b0f3a` で Nit 1-3 を吸収済。残る将来検討候補のみ記載)

1. `BranchCondition` の `expression` variant に `description` field がない (F6 migration 時に schema validation エラーで判明)。`label` で代替可能だが将来検討候補
2. `ValidationRule` で `type: "regex"` の場合に `pattern` または `patternRef` のいずれか一方を必須化する if/then 制約。現状どちらも未指定でも valid
3. `transformations.field` と SQL SELECT alias の整合性 best-effort チェックは未実装 (SQL パース難度高)

## レビュー担当への申し送り

- **3 ISSUE 統合 PR**: 同根の framework 提案を後追い統合。独立レビュー 1 round 実施済 → Must-fix / Should-fix / Nit 全件を commit `e5b0f3a` で同 PR 吸収
- **schema 変更は #781 のみ**: `OutputBinding.transformations` 追加。#782 は description 追記のみ、#783 は schema 変更ゼロ。governance memory `feedback_schema_governance_strict.md` の重みを保ち最小拡張で実装
- **PR #780 で入れた CAST workaround は解除**: F3 step-09 の `CAST(...)` は #781 transformations に置き換え、その他 retail flows (267e94bf / a3659922) も同根として transformations 追加で全網羅
- **F6 step-08b は維持**: ADR-005 由来の `@persistedOrder == null` ガードは TX 成功後の SELECT 失敗ガードとして引き続き存在、ADR-007 で役割分離を明記
- **F6 全 TX 後 step に runIf ガード**: spec §8.3 準拠で step-07/08/08b/09/10 に明示的 `runIf: "@txResult.committed == true|false"` を追加
- **Sonnet 委譲構成**: Opus がオーケストレーター、各 ISSUE を Sonnet に順次委譲 (並列なし、worktree なし、同一 main repo で `feat/process-flow-framework-improvements` ブランチに順次積む)。レビュー / レビュー対応も Sonnet サブエージェントで実施

🤖 Generated with [Claude Code](https://claude.com/claude-code)
