### PR TITLE
feat(samples): 英会話学習アプリ 業務データ層追加 (#787 子 2)

### DIFF
--- a/docs/spec/examples-english-learning.md
+++ b/docs/spec/examples-english-learning.md
@@ -98,13 +98,15 @@ B2C 英会話学習アプリ (中規模、画面 ~11、テーブル ~10、処理
 
 ### 2.6 conventions catalog
 
-- `numbering.session-id` — 学習セッション ID 採番
-- `numbering.score-id` — 発音スコア ID 採番
+`schemas/v3/conventions.v3.schema.json` のプロパティ命名 (`numbering` / `regex` / `msg` / `limit` / `db` / `auth` / `tx` / `extensionCategories`) に準拠。各カテゴリ内のキーは camelCase。参照は `@conv.<category>.<key>`。
+
+- `numbering.sessionId` — 学習セッション ID 採番
+- `numbering.scoreId` — 発音スコア ID 採番
 - `regex.ipa` — IPA Unicode 範囲正規表現
-- `cefr.passing-threshold` — CEFR レベル昇格の発音スコア閾値 (例: 70 点)
-- `messages.session-not-found` — セッション未検出メッセージ
-- `messages.pronunciation-low` — 発音低評価メッセージ
-- `wordProgress.masteryThreshold` — 単語習熟判定回数 (例: 連続 3 回正解で mastered)
+- `extensionCategories.cefr.passingThreshold` — CEFR レベル昇格の発音スコア閾値 (例: 70 点)
+- `msg.sessionNotFound` — セッション未検出メッセージ
+- `msg.pronunciationLow` — 発音低評価メッセージ
+- `extensionCategories.wordProgress.masteryThreshold` — 単語習熟判定回数 (例: 連続 3 回正解で mastered)
 
 ## 3. 設計判断
 

--- a/examples/english-learning/README.md
+++ b/examples/english-learning/README.md
@@ -1,0 +1,111 @@
+# english-learning — 英会話学習アプリ
+
+B2C 英会話学習アプリの **完結 業務 workspace サンプル** (#787)。ストーリー仕立ての会話練習と AI 採点 (LLM/TTS/STT) を組み合わせたアプリを本フレームワークでモデル化する。retail (B2B 店舗系) と並列の **B2C + 外部 AI 連携サンプル**。
+
+## 業務シナリオ (4 種、画面・処理・データを連携)
+
+| シナリオ | 概要 | 関連画面 |
+|---|---|---|
+| S-1 学習セッション開始 | ストーリー一覧から選択 → セッション作成 → 会話プレイへ遷移。TTS で音源プリロード。 | ストーリー一覧 / 詳細 / 会話プレイ |
+| S-2 会話ターン進行 | ユーザー発話 → LLM 応答生成 → TTS 音声化 → 履歴保存。stepKind 拡張で外部 AI 表現。 | 会話プレイ |
+| S-3 発音採点 | 録音送信 → STT + 評価 API → スコア保存 → セッション結果表示。 | 会話プレイ → セッション結果 |
+| S-4 学習履歴 + 単語復習 | 履歴一覧 / 詳細表示、単語帳で習熟度別復習。タップで辞書詳細。 | 学習履歴 / 単語帳 / 単語詳細 |
+
+補助画面: ダッシュボード、コンテンツパック一覧、プロフィール / 設定。
+
+## ディレクトリ構成
+
+```
+examples/english-learning/
+├── project.json                          # workspace ルート定義 (v3 schema)
+├── README.md                             # 本ファイル
+├── tables/                               # テーブル定義 (10 件)
+│   ├── c7e50462-...  users
+│   ├── 517d50a3-...  content_packs
+│   ├── b5aa3e1b-...  stories
+│   ├── 992ac5db-...  scenes
+│   ├── 246a3f13-...  dialogue_lines
+│   ├── 8db75844-...  words
+│   ├── d524cba6-...  learning_sessions
+│   ├── 4e126323-...  turn_logs
+│   ├── fefa79cf-...  pronunciation_scores
+│   └── 7ab2cf24-...  user_word_progress
+├── extensions/
+│   └── english-learning.v3.json          # english-learning namespace 拡張定義
+├── conventions/
+│   └── catalog.json                      # 業務規約カタログ
+├── screens/                              # 画面定義 (子 3 で追加予定)
+├── process-flows/                        # 処理フロー定義 (子 4 で追加予定)
+├── view-definitions/                     # ViewDefinition (子 4 で追加予定)
+├── views/                                # SQL VIEW 定義 (子 4 で追加予定)
+└── sequences/                            # 採番シーケンス (子 4 で追加予定)
+```
+
+## 採用拡張 namespace
+
+- `english-learning` — fieldTypes / actionTriggers / dbOperations / stepKinds / responseTypes / screenKinds を v3 canonical combined format (`extensions/english-learning.v3.json`) に統合
+
+### stepKind 拡張の肝 (本サンプルの核心)
+
+| stepKind キー | 用途 | outputType |
+|---|---|---|
+| `LlmDialog` | LLM への会話リクエスト | `english-learning:dialogTurn` |
+| `TtsGenerate` | TTS 音声生成 | `english-learning:audioUrl` |
+| `SttEvaluate` | STT + 発音評価 | `english-learning:pronunciationScore` |
+
+外部 AI 呼び出しを `type: "other"` (汎用エスケープ) ではなく namespace 拡張で表現し、ProcessFlow viewer 上で他 step と同一抽象レベルで表示できることを実証する。
+
+## 開き方 (動作確認)
+
+`examples/english-learning/` は **git 管理の正本サンプル**。直接開くと編集が git 差分になるため、動作確認は **コピーして使う** ことを推奨します (デプロイ相当)。
+
+### 推奨: workspaces/english-learning/ にコピーして使う
+
+```bash
+# workspaces/english-learning/ ディレクトリを作成してコピー (Windows PowerShell の例)
+New-Item -ItemType Directory -Force -Path workspaces\english-learning
+Copy-Item -Recurse -Force examples\english-learning\* workspaces\english-learning\
+
+# designer-mcp / designer を起動
+cd designer-mcp && npm run dev   # 別ターミナル
+cd designer && npm run dev
+```
+
+`workspaces/` は gitignored なので自由に編集できます。
+
+> **注意**: `data/` への直接 deploy は禁止 (#753)。`data/` はデザイナー本体組み込み拡張定義 (`data/extensions/`) 専用です。
+
+### 直接開く (見るだけの動作確認)
+
+designer UI のヘッダー「ワークスペース」 → 「フォルダを追加」 → `examples/english-learning` の絶対パス を指定。**ただし編集して保存するとファイルが書き換わり git 差分が出ます (自己責任)**。
+
+## テスト fixture としての利用
+
+```bash
+# 固定 workspace で designer-mcp 起動 (lockdown モード)
+DESIGNER_DATA_DIR=examples/english-learning npm run dev:mcp
+```
+
+## 検証 (AJV)
+
+```bash
+cd designer && npm run validate:samples -- ../examples/english-learning
+```
+
+`examples/**/*.json` は schema 検証 test に組み込まれる。schema 進化時に english-learning サンプルが breakage したら CI で検出。
+
+## 実装シリーズ
+
+| 子 ISSUE | スコープ | branch |
+|---|---|---|
+| 子 1 | 本仕様書 (docs/spec/examples-english-learning.md) | `docs/issue-787-spec-english-learning` |
+| 子 2 (本 PR) | 業務データ層 — tables / extensions / conventions / project.json / README | `feat/issue-787-tables-conventions` |
+| 子 3 | UI 層上半分 — screens / screenTransitions | `feat/issue-787-screens` |
+| 子 4 | UI 層下半分 + 業務処理 — process-flows / view-definitions / sequences / views | `feat/issue-787-flows` |
+| 子 5 | dogfood 検証 — AJV + review-flow Must-fix ゼロ + smoke | `chore/issue-787-dogfood` |
+
+## 関連
+
+- 親メタ: #787
+- spec: [docs/spec/examples-english-learning.md](../../docs/spec/examples-english-learning.md)
+- 運用方針: memory `project_samples_strategy_2026_05_02.md`

--- a/examples/english-learning/conventions/catalog.json
+++ b/examples/english-learning/conventions/catalog.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "../../../schemas/v3/conventions.v3.schema.json",
+  "version": "1.0.0",
+  "description": "英会話学習アプリの横断規約カタログ。採番・正規表現・メッセージ・境界値・DB 規約・認証・TX 方針・拡張カテゴリ (CEFR 昇格判定 / 単語習熟) を集約する。",
+  "updatedAt": "2026-05-04T00:00:00.000Z",
+  "i18n": {
+    "supportedLocales": ["ja-JP", "en-US"],
+    "defaultLocale": "ja-JP",
+    "dateFormat": { "ja-JP": "YYYY/MM/DD", "en-US": "MM/DD/YYYY" },
+    "timeFormat": { "ja-JP": "HH:mm", "en-US": "h:mm a" }
+  },
+  "numbering": {
+    "sessionId": {
+      "format": "SES-YYYYMMDD-NNNNNN",
+      "implementation": "DB sequence (seq_session_id) + アプリ層で YYYYMMDD を開始日付に置換して採番。日次 6 桁ゼロ埋め。",
+      "description": "学習セッション ID の採番規約。YYYYMMDD は開始日 (現地時刻 UTC+9)、NNNNNN はシーケンス 6 桁ゼロ埋め。例: SES-20260504-000001。セッション開始 TX (S-1) 内で 1 TX に 1 番号を発行する。"
+    },
+    "scoreId": {
+      "format": "SCO-NNNNNNNN",
+      "implementation": "DB sequence (seq_score_id) + アプリ層で NNNNNNNN を 8 桁ゼロ埋めで採番。",
+      "description": "発音スコア ID の採番規約。SCO- プレフィックス + 8 桁シーケンス。例: SCO-00000001。採点 TX (S-3) 内で発行する。"
+    }
+  },
+  "regex": {
+    "ipa": {
+      "pattern": "^[\\u0020-\\u007E\\u00C0-\\u024F\\u0250-\\u02AF\\u1E00-\\u1EFF\\u02B0-\\u02FF]+$",
+      "description": "IPA (国際音声記号) 発音記号の正規表現。ASCII 印刷可能文字 + Latin Extended + IPA Extensions + Phonetic Extensions の範囲を許容する。",
+      "exampleValid": ["/kae.fi/", "/helo/", "/prn.si.e.n/"],
+      "exampleInvalid": ["", "12345"]
+    }
+  },
+  "msg": {
+    "sessionNotFound": {
+      "template": "セッション ID {sessionId} の学習セッションが見つかりません。",
+      "params": ["sessionId"],
+      "description": "セッション未検出メッセージ。S-2 / S-3 フローで学習セッションが見つからない場合に表示する。"
+    },
+    "pronunciationLow": {
+      "template": "発音スコア {score} 点でした。もう一度練習してみましょう！ (合格ライン: {threshold} 点)",
+      "params": ["score", "threshold"],
+      "description": "発音低評価メッセージ。SttEvaluate の score が @conv.extensionCategories.cefr.passingThreshold を下回った場合に表示する。"
+    },
+    "sessionCompleted": {
+      "template": "学習セッションを完了しました！平均発音スコア: {scoreAvg} 点",
+      "params": ["scoreAvg"],
+      "description": "セッション完了メッセージ (S-3 セッション結果画面で表示)。"
+    },
+    "wordMastered": {
+      "template": "「{word}」を習熟しました！",
+      "params": ["word"],
+      "description": "単語習熟達成メッセージ。user_word_progress.status が mastered に遷移した時に表示する。"
+    },
+    "streakUpdated": {
+      "template": "{streakDays} 日連続学習達成！",
+      "params": ["streakDays"],
+      "description": "連続学習日数更新メッセージ。sessionCompleted トリガーで streak_days が更新された場合に表示する。"
+    }
+  },
+  "limit": {
+    "maxTurnsPerSession": {
+      "value": 50,
+      "unit": "integer",
+      "description": "1 セッションあたりの最大会話ターン数。これを超えた場合はセッションを強制完了とする。"
+    },
+    "maxAudioLengthSeconds": {
+      "value": 30,
+      "unit": "integer",
+      "description": "1 発音採点あたりの録音最大長 (秒)。MediaRecorder API の maxRecordingLength として使用する。"
+    }
+  },
+  "auth": {
+    "bearerJwt": {
+      "scheme": "bearer-jwt",
+      "default": true,
+      "description": "JWT Bearer トークン認証。B2C アプリのためセッション Cookie ではなく JWT を使用。アクセストークン有効期限 1 時間、リフレッシュトークン 30 日。"
+    }
+  },
+  "db": {
+    "primary": {
+      "engine": "postgresql@15",
+      "namingConvention": "snake_case",
+      "timestampColumns": ["created_at", "updated_at"],
+      "default": true,
+      "description": "本サンプルの主 DB。PostgreSQL 15 を想定。全テーブルに created_at を付与し、更新があるテーブルには updated_at も付与する。"
+    }
+  },
+  "tx": {
+    "sessionStart": {
+      "policy": "学習セッション開始 (S-1) は単一 DB トランザクション内で learning_sessions INSERT → seq_session_id 採番 を実行する。セッション ID 払い出し失敗時はロールバック。",
+      "description": "セッション開始フローのトランザクション方針。"
+    },
+    "pronunciationScore": {
+      "policy": "発音採点 (S-3) は単一 DB トランザクション内で pronunciation_scores INSERT → learning_sessions.score_avg 更新 → user_word_progress UPSERT を実行する。いずれかで失敗した場合は全体をロールバックする。",
+      "description": "発音採点フローのトランザクション方針。スコア保存とセッション平均更新を原子的に実行する。"
+    }
+  },
+  "extensionCategories": {
+    "cefr": {
+      "passingThreshold": {
+        "value": 70,
+        "description": "CEFR レベル昇格の発音スコア閾値。SttEvaluate の score がこの値以上かつ連続 3 セッションで達成した場合に cefr_level を 1 段階昇格させる。"
+      }
+    },
+    "wordProgress": {
+      "masteryThreshold": {
+        "value": 3,
+        "description": "単語習熟判定の連続正解回数。user_word_progress.correct_count がこの値以上になった場合に status を mastered に更新する。不正解時は correct_count を 0 にリセット (status は learning に降格)。"
+      }
+    }
+  }
+}

--- a/examples/english-learning/extensions/english-learning.v3.json
+++ b/examples/english-learning/extensions/english-learning.v3.json
@@ -1,0 +1,265 @@
+{
+  "$schema": "../../../schemas/v3/extensions.v3.schema.json",
+  "namespace": "english-learning",
+  "version": "1.0.0",
+  "requiresCoreSchema": ">=3.0.0",
+  "description": "英会話学習アプリ向け v3 canonical 拡張定義。fieldTypes / actionTriggers / dbOperations / stepKinds / responseTypes / screenKinds を統合。外部 AI (LLM/TTS/STT) 呼び出しを stepKind 拡張で表現し、CEFR レベル / IPA / 発音スコア等の英語学習固有型を fieldType として定義する。",
+  "fieldTypes": [
+    {
+      "kind": "ipa",
+      "label": "IPA 発音記号",
+      "baseType": "string",
+      "constraints": [
+        { "type": "pattern", "value": "^[\\u0020-\\u007E\\u00C0-\\u024F\\u0250-\\u02AF\\u1E00-\\u1EFF\\u02B0-\\u02FF]+$" }
+      ],
+      "description": "IPA (国際音声記号) 発音記号型。@conv.regex.ipa 準拠。dialogue_lines.ipa / words.ipa で使用する。"
+    },
+    {
+      "kind": "cefrLevel",
+      "label": "CEFR レベル",
+      "baseType": "string",
+      "constraints": [
+        { "type": "pattern", "value": "^(A1|A2|B1|B2|C1|C2)$" }
+      ],
+      "description": "英語能力の CEFR (Common European Framework of Reference) レベル型。値域: A1/A2/B1/B2/C1/C2。users.cefr_level / stories.cefr_level / words.cefr_level で使用する。"
+    },
+    {
+      "kind": "audioUrl",
+      "label": "音声 URL",
+      "baseType": "string",
+      "constraints": [
+        { "type": "pattern", "value": "^https?://.+" },
+        { "type": "maxLength", "value": 500 }
+      ],
+      "description": "TTS 生成済みまたは既存音源の音声ファイル URL 型。dialogue_lines.audio_url / turn_logs.ai_audio_url / pronunciation_scores.audio_url で使用する。"
+    },
+    {
+      "kind": "pronunciationScore",
+      "label": "発音スコア",
+      "baseType": "number",
+      "constraints": [
+        { "type": "minimum", "value": 0 },
+        { "type": "maximum", "value": 100 }
+      ],
+      "description": "発音採点スコア (0〜100)。SttEvaluate step の出力 EvaluationResult.score に対応。@conv.extensionCategories.cefr.passingThreshold と比較して CEFR レベル昇格を判定する。"
+    },
+    {
+      "kind": "dialogTurn",
+      "label": "会話ターン",
+      "baseType": "json",
+      "description": "LLM 会話ターンの構造型。{ role: 'user' | 'assistant' | 'system', content: string } の配列として実装する。LlmDialog step の outputType として使用し、turn_logs.llm_context に保存される。"
+    }
+  ],
+  "actionTriggers": [
+    {
+      "value": "sessionCompleted",
+      "label": "学習セッション完了後",
+      "description": "学習セッションが正常完了 (status='completed') した直後に発火するトリガー。users.streak_days の更新 / users.cefr_level の評価 / 単語習熟度のバッチ更新等の後続処理を起動する。"
+    },
+    {
+      "value": "pronunciationScored",
+      "label": "発音採点完了後",
+      "description": "SttEvaluate step が完了して pronunciation_scores にスコアが保存された直後に発火するトリガー。採点結果の UI 表示更新 / セッション平均スコア再計算に使用する。"
+    },
+    {
+      "value": "wordMastered",
+      "label": "単語習熟達成時",
+      "description": "user_word_progress.status が 'learning' から 'mastered' に遷移した直後に発火するトリガー。習熟達成バッジ表示や通知送信に使用する。"
+    }
+  ],
+  "dbOperations": [
+    {
+      "value": "UPSERT_WORD_PROGRESS",
+      "label": "単語習熟度 UPSERT",
+      "description": "user_word_progress に (user_id, word_id) で UPSERT する。新規の場合は status='new' で INSERT、既存の場合は correct_count / attempt_count / status / last_practiced_at を更新する。update-word-progress 共通フロー (S-4) で使用する。"
+    },
+    {
+      "value": "INCREMENT_STREAK",
+      "label": "連続学習日数加算",
+      "description": "users.streak_days を 1 加算する。sessionCompleted トリガーで発火し、当日初回セッション完了時にのみ実行する。翌日まで連続していない場合は streak_days を 0 にリセット (scheduled flow で管理)。"
+    },
+    {
+      "value": "UPDATE_SESSION_STATUS",
+      "label": "セッションステータス更新",
+      "description": "learning_sessions.status を更新し、完了時に completed_at と score_avg を同時に設定する。start-session / progress-turn フローの終端で使用する。"
+    }
+  ],
+  "stepKinds": {
+    "LlmDialog": {
+      "label": "LLM 会話呼び出し",
+      "icon": "bi-chat-dots",
+      "description": "外部 LLM API (OpenAI GPT-4 / Anthropic Claude 等) に会話リクエストを送信する拡張 Step。context (会話履歴) と userInput を入力とし、AI 応答テキストを outputBinding に返す。S-2 progress-turn フローで使用する。provider 選択・temperature 等の詳細は実装層が決定する。",
+      "schema": {
+        "type": "object",
+        "required": ["context", "userInput"],
+        "properties": {
+          "context": {
+            "type": "string",
+            "description": "会話コンテキスト (DialogTurn[] の変数参照、例: @var.turnContext)"
+          },
+          "userInput": {
+            "type": "string",
+            "description": "ユーザーの最新発話テキスト (変数参照、例: @var.userInput)"
+          },
+          "systemPrompt": {
+            "type": "string",
+            "description": "システムプロンプト (省略時はデフォルト英会話学習プロンプト)"
+          },
+          "maxTokens": {
+            "type": "integer",
+            "description": "最大出力トークン数 (省略時は 500)"
+          }
+        },
+        "additionalProperties": false
+      },
+      "outputType": {
+        "kind": "extension",
+        "extensionRef": "english-learning:dialogTurn"
+      }
+    },
+    "TtsGenerate": {
+      "label": "TTS 音声生成",
+      "icon": "bi-volume-up",
+      "description": "テキストを音声ファイルに変換する拡張 Step (Text-to-Speech)。text を入力とし、生成した音声の audioUrl を outputBinding に返す。S-1 でストーリー音源プリロード、S-2 で AI 応答音声化に使用する。将来の wordTimings 出力でカラオケ字幕に対応予定 (MVP は audioUrl のみ)。",
+      "schema": {
+        "type": "object",
+        "required": ["text"],
+        "properties": {
+          "text": {
+            "type": "string",
+            "description": "音声化するテキスト (英文、変数参照可)"
+          },
+          "voice": {
+            "type": "string",
+            "description": "音声モデル識別子 (例: en-US-Standard-A / alloy 等、省略時はデフォルト)"
+          },
+          "speed": {
+            "type": "number",
+            "description": "音声速度 (0.5〜2.0、省略時は 1.0)"
+          }
+        },
+        "additionalProperties": false
+      },
+      "outputType": {
+        "kind": "extension",
+        "extensionRef": "english-learning:audioUrl"
+      }
+    },
+    "SttEvaluate": {
+      "label": "STT 発音評価",
+      "icon": "bi-mic",
+      "description": "ユーザーの録音音声を STT (Speech-to-Text) で認識し、リファレンス IPA テキストと比較して発音スコアを算出する拡張 Step。audioUrl とリファレンス IPA を入力とし、score (0-100) と音素差分 diff を outputBinding に返す。S-3 発音採点フローで使用する。",
+      "schema": {
+        "type": "object",
+        "required": ["audioUrl", "referenceText"],
+        "properties": {
+          "audioUrl": {
+            "type": "string",
+            "description": "評価対象の録音音声 URL (変数参照可)"
+          },
+          "referenceText": {
+            "type": "string",
+            "description": "目標セリフの英文テキスト (変数参照可)"
+          },
+          "referenceIpa": {
+            "type": "string",
+            "description": "目標セリフの IPA 発音記号 (任意。省略時は STT プロバイダが自動判定)"
+          }
+        },
+        "additionalProperties": false
+      },
+      "outputType": {
+        "kind": "extension",
+        "extensionRef": "english-learning:pronunciationScore"
+      }
+    }
+  },
+  "responseTypes": {
+    "DialogTurn": {
+      "description": "LLM 会話ターンレスポンス。LlmDialog step の outputBinding に格納される会話ターン構造。turn_logs.llm_context (JSON 配列) の 1 要素に対応する。",
+      "schema": {
+        "type": "object",
+        "required": ["role", "content"],
+        "properties": {
+          "role": {
+            "type": "string",
+            "enum": ["user", "assistant", "system"],
+            "description": "発話者ロール"
+          },
+          "content": {
+            "type": "string",
+            "description": "発話内容テキスト"
+          },
+          "audioUrl": {
+            "type": "string",
+            "description": "TTS 生成済み音声 URL (assistant ロールのみ、任意)"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "EvaluationResult": {
+      "description": "SttEvaluate step の発音評価レスポンス。score と音素単位差分 diff を返す。pronunciation_scores テーブルへの保存に使用する。",
+      "schema": {
+        "type": "object",
+        "required": ["score"],
+        "properties": {
+          "score": {
+            "type": "number",
+            "description": "発音総合スコア (0〜100)"
+          },
+          "transcription": {
+            "type": "string",
+            "description": "STT で認識したテキスト (比較用)"
+          },
+          "diff": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["phone", "correct"],
+              "properties": {
+                "phone": { "type": "string", "description": "音素 (IPA 記号)" },
+                "expected": { "type": "string", "description": "期待音素" },
+                "actual": { "type": "string", "description": "実際の音素" },
+                "correct": { "type": "boolean", "description": "正誤フラグ" }
+              },
+              "additionalProperties": false
+            },
+            "description": "音素単位の正誤判定リスト (PhoneDiff[])。実装側で IPA テーブル + 色分け表示する。"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "SessionSummary": {
+      "description": "学習セッション完了サマリレスポンス。セッション結果画面に表示する集計情報を返す。",
+      "schema": {
+        "type": "object",
+        "required": ["sessionId", "scoreAvg", "turnsCompleted"],
+        "properties": {
+          "sessionId": { "type": "integer", "description": "セッション ID" },
+          "scoreAvg": { "type": "number", "description": "平均発音スコア (0〜100)" },
+          "turnsCompleted": { "type": "integer", "description": "完了ターン数" },
+          "masteredWords": {
+            "type": "array",
+            "items": { "type": "integer" },
+            "description": "このセッションで mastered になった word_id 一覧"
+          },
+          "cefrLevelUp": {
+            "type": "boolean",
+            "description": "CEFR レベルが昇格した場合 true"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "screenKinds": [
+    {
+      "kind": "conversationPlayer",
+      "label": "会話プレイヤー",
+      "icon": "bi-play-circle",
+      "description": "英会話学習用の会話プレイ画面種別。セリフ字幕表示 / 録音ボタン / 会話履歴ペイン / 発音スコア表示を統合した B2C 学習 UX を提供する。Web Audio API 録音 / カラオケ字幕 (将来) / 単語タップ辞書は description 待避 (3.3 節参照)。"
+    }
+  ]
+}

--- a/examples/english-learning/process-flows/cc173367-d92a-4525-acc9-689bad9a048e.json
+++ b/examples/english-learning/process-flows/cc173367-d92a-4525-acc9-689bad9a048e.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "../../../schemas/v3/process-flow.v3.schema.json",
+  "meta": {
+    "id": "cc173367-d92a-4525-acc9-689bad9a048e",
+    "name": "学習セッション開始",
+    "description": "ユーザーがストーリーを選択して学習セッションを開始するフロー (S-1)。learning_sessions に新規セッションを INSERT し、会話プレイ画面遷移用のセッション ID を返す。子 4 で詳細実装予定 (現在は骨格のみ)。",
+    "kind": "screen",
+    "maturity": "draft",
+    "createdAt": "2026-05-04T00:00:00.000Z",
+    "updatedAt": "2026-05-04T00:00:00.000Z"
+  },
+  "context": {
+    "ambientVariables": [
+      {
+        "name": "sessionUserId",
+        "type": "integer",
+        "required": true,
+        "description": "ログイン中のユーザー ID (JWT から取得)。"
+      }
+    ]
+  },
+  "actions": [
+    {
+      "id": "act-001",
+      "name": "セッション開始",
+      "trigger": "submit",
+      "description": "ストーリー詳細画面の「学習開始」ボタン押下で発火。learning_sessions に新規レコードを INSERT し、採番したセッション ID と共に会話プレイ画面 (/learn/:sessionId) に遷移する。",
+      "maturity": "draft",
+      "httpRoute": {
+        "method": "POST",
+        "path": "/api/el/sessions",
+        "auth": "required"
+      },
+      "inputs": [
+        {
+          "name": "storyId",
+          "label": "ストーリーID",
+          "type": "integer",
+          "required": true,
+          "description": "学習対象ストーリー ID (stories.id)。"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "sessionId",
+          "label": "セッションID",
+          "type": "integer",
+          "description": "採番された学習セッション ID。会話プレイ画面の URL パラメータに使用する。"
+        }
+      ],
+      "responses": [
+        {
+          "id": "201-created",
+          "status": 201,
+          "bodySchema": {
+            "schema": {
+              "type": "object",
+              "required": ["sessionId"],
+              "properties": {
+                "sessionId": { "type": "integer" }
+              },
+              "additionalProperties": false
+            }
+          },
+          "description": "セッション作成成功。sessionId を返し、呼び出し元画面が /learn/:sessionId に遷移する。",
+          "when": "learning_sessions INSERT が正常完了した場合。"
+        }
+      ],
+      "steps": [
+        {
+          "id": "step-01",
+          "kind": "dbAccess",
+          "description": "stories テーブルからストーリー存在確認。is_active=TRUE のストーリーのみ学習開始可能。",
+          "tableId": "b5aa3e1b-b5e4-46dd-8373-75fea340844b",
+          "operation": "SELECT",
+          "sql": "SELECT id, title, cefr_level FROM stories WHERE id = @storyId AND is_active = TRUE",
+          "outputBinding": { "name": "storyRow" },
+          "lineage": {
+            "reads": [
+              { "tableId": "b5aa3e1b-b5e4-46dd-8373-75fea340844b", "purpose": "validate" }
+            ]
+          }
+        },
+        {
+          "id": "step-02",
+          "kind": "dbAccess",
+          "description": "learning_sessions に新規セッションを INSERT する。",
+          "tableId": "d524cba6-0878-4cf5-ba70-deaa7b459103",
+          "operation": "INSERT",
+          "sql": "INSERT INTO learning_sessions (user_id, story_id, status, started_at, updated_at) VALUES (@sessionUserId, @storyId, 'in_progress', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP) RETURNING id",
+          "outputBinding": { "name": "newSession" },
+          "lineage": {
+            "writes": [
+              { "tableId": "d524cba6-0878-4cf5-ba70-deaa7b459103", "purpose": "insert" }
+            ]
+          }
+        },
+        {
+          "id": "step-03",
+          "kind": "return",
+          "description": "201 Created — 新規セッション ID を返す。",
+          "responseId": "201-created",
+          "bodyExpression": "{ sessionId: @newSession.id }"
+        }
+      ]
+    }
+  ]
+}

--- a/examples/english-learning/process-flows/cc173367-d92a-4525-acc9-689bad9a048e.json
+++ b/examples/english-learning/process-flows/cc173367-d92a-4525-acc9-689bad9a048e.json
@@ -3,7 +3,7 @@
   "meta": {
     "id": "cc173367-d92a-4525-acc9-689bad9a048e",
     "name": "学習セッション開始",
-    "description": "ユーザーがストーリーを選択して学習セッションを開始するフロー (S-1)。learning_sessions に新規セッションを INSERT し、会話プレイ画面遷移用のセッション ID を返す。子 4 で詳細実装予定 (現在は骨格のみ)。",
+    "description": "ユーザーがストーリーを選択して学習セッションを開始するフロー (S-1)。learning_sessions に新規セッションを INSERT し、会話プレイ画面遷移用のセッション ID を返す。子 2 で先行実装済 (validate:samples が flows ≥1 を要求するため)。子 4 では本フローを残し、S-2 (会話ターン進行) / S-3 (発音採点) / S-4 (履歴 / 単語復習) / scheduled (連続日数リセット) フローを追加する。",
     "kind": "screen",
     "maturity": "draft",
     "createdAt": "2026-05-04T00:00:00.000Z",

--- a/examples/english-learning/project.json
+++ b/examples/english-learning/project.json
@@ -1,0 +1,137 @@
+{
+  "$schema": "../../schemas/v3/project.v3.schema.json",
+  "schemaVersion": "v3",
+  "meta": {
+    "id": "aa696474-b681-4400-aab7-b8e4eacea665",
+    "name": "英会話学習アプリ",
+    "description": "B2C 英会話学習アプリ。ストーリー仕立ての会話練習と AI 採点 (LLM/TTS/STT) を組み合わせ、発音フィードバックと単語習熟度管理を提供する。分野別コンテンツパック (汎用 / IT エンジニア / ビジネス 等) を拡張 namespace で表現し、外部 AI 呼び出しを stepKind 拡張でモデル化する B2C + 外部 AI 連携サンプル (#787)。",
+    "createdAt": "2026-05-04T00:00:00.000Z",
+    "updatedAt": "2026-05-04T00:00:00.000Z",
+    "mode": "upstream",
+    "maturity": "draft"
+  },
+  "extensionsApplied": [
+    { "namespace": "english-learning", "version": ">=1.0.0" }
+  ],
+  "entities": {
+    "screens": [],
+    "screenGroups": [],
+    "screenTransitions": [],
+    "tables": [
+      {
+        "id": "c7e50462-bbc4-498f-a280-2ec40bda30b1",
+        "no": 1,
+        "name": "ユーザー",
+        "physicalName": "users",
+        "category": "マスタ",
+        "columnCount": 9,
+        "maturity": "draft",
+        "updatedAt": "2026-05-04T00:00:00.000Z"
+      },
+      {
+        "id": "517d50a3-960f-42ce-810f-3b126398d7b1",
+        "no": 2,
+        "name": "コンテンツパック",
+        "physicalName": "content_packs",
+        "category": "マスタ",
+        "columnCount": 8,
+        "maturity": "draft",
+        "updatedAt": "2026-05-04T00:00:00.000Z"
+      },
+      {
+        "id": "b5aa3e1b-b5e4-46dd-8373-75fea340844b",
+        "no": 3,
+        "name": "ストーリー",
+        "physicalName": "stories",
+        "category": "マスタ",
+        "columnCount": 9,
+        "maturity": "draft",
+        "updatedAt": "2026-05-04T00:00:00.000Z"
+      },
+      {
+        "id": "992ac5db-54fa-4eb0-9509-66b3babbdef6",
+        "no": 4,
+        "name": "シーン",
+        "physicalName": "scenes",
+        "category": "マスタ",
+        "columnCount": 7,
+        "maturity": "draft",
+        "updatedAt": "2026-05-04T00:00:00.000Z"
+      },
+      {
+        "id": "246a3f13-7888-4b14-ad6d-641b7437b09d",
+        "no": 5,
+        "name": "セリフ",
+        "physicalName": "dialogue_lines",
+        "category": "マスタ",
+        "columnCount": 10,
+        "maturity": "draft",
+        "updatedAt": "2026-05-04T00:00:00.000Z"
+      },
+      {
+        "id": "8db75844-19ca-4e7d-8293-579e7631c5cc",
+        "no": 6,
+        "name": "単語",
+        "physicalName": "words",
+        "category": "マスタ",
+        "columnCount": 10,
+        "maturity": "draft",
+        "updatedAt": "2026-05-04T00:00:00.000Z"
+      },
+      {
+        "id": "d524cba6-0878-4cf5-ba70-deaa7b459103",
+        "no": 7,
+        "name": "学習セッション",
+        "physicalName": "learning_sessions",
+        "category": "トランザクション",
+        "columnCount": 8,
+        "maturity": "draft",
+        "updatedAt": "2026-05-04T00:00:00.000Z"
+      },
+      {
+        "id": "4e126323-4ab7-4747-961b-23cbaf651314",
+        "no": 8,
+        "name": "会話ターンログ",
+        "physicalName": "turn_logs",
+        "category": "トランザクション",
+        "columnCount": 8,
+        "maturity": "draft",
+        "updatedAt": "2026-05-04T00:00:00.000Z"
+      },
+      {
+        "id": "fefa79cf-4721-4956-86bb-595427bf6f81",
+        "no": 9,
+        "name": "発音スコア",
+        "physicalName": "pronunciation_scores",
+        "category": "トランザクション",
+        "columnCount": 8,
+        "maturity": "draft",
+        "updatedAt": "2026-05-04T00:00:00.000Z"
+      },
+      {
+        "id": "7ab2cf24-7b66-47aa-a808-7fffd8290480",
+        "no": 10,
+        "name": "単語習熟度",
+        "physicalName": "user_word_progress",
+        "category": "トランザクション",
+        "columnCount": 8,
+        "maturity": "draft",
+        "updatedAt": "2026-05-04T00:00:00.000Z"
+      }
+    ],
+    "processFlows": [
+      {
+        "id": "cc173367-d92a-4525-acc9-689bad9a048e",
+        "no": 1,
+        "name": "学習セッション開始",
+        "kind": "screen",
+        "actionCount": 1,
+        "maturity": "draft",
+        "updatedAt": "2026-05-04T00:00:00.000Z"
+      }
+    ],
+    "views": [],
+    "viewDefinitions": [],
+    "sequences": []
+  }
+}

--- a/examples/english-learning/tables/246a3f13-7888-4b14-ad6d-641b7437b09d.json
+++ b/examples/english-learning/tables/246a3f13-7888-4b14-ad6d-641b7437b09d.json
@@ -1,0 +1,146 @@
+{
+  "$schema": "../../../schemas/v3/table.v3.schema.json",
+  "id": "246a3f13-7888-4b14-ad6d-641b7437b09d",
+  "name": "セリフ",
+  "description": "シーン配下のセリフ行管理テーブル。英文テキスト / 日本語訳 / IPA 発音記号 / 想定音声 URL を保持する。会話プレイ画面でセリフ字幕表示と発音採点の基準として使用する。将来的に TTS 生成の wordTimings を使ったカラオケ字幕に対応する想定 (description 待避)。",
+  "maturity": "draft",
+  "createdAt": "2026-05-04T00:00:00.000Z",
+  "updatedAt": "2026-05-04T00:00:00.000Z",
+  "physicalName": "dialogue_lines",
+  "category": "マスタ",
+  "comment": "セリフテーブル。シーン内のセリフ行を管理する。",
+  "columns": [
+    {
+      "id": "col-id",
+      "no": 1,
+      "physicalName": "id",
+      "name": "セリフID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "primaryKey": true,
+      "autoIncrement": true,
+      "comment": "サロゲートキー (自動採番)"
+    },
+    {
+      "id": "col-scene-id",
+      "no": 2,
+      "physicalName": "scene_id",
+      "name": "シーンID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "comment": "所属シーン (scenes.id 参照)"
+    },
+    {
+      "id": "col-sort-order",
+      "no": 3,
+      "physicalName": "sort_order",
+      "name": "表示順",
+      "dataType": "INTEGER",
+      "notNull": true,
+      "defaultValue": "0",
+      "comment": "シーン内でのセリフ順 (昇順)"
+    },
+    {
+      "id": "col-speaker",
+      "no": 4,
+      "physicalName": "speaker",
+      "name": "話者",
+      "dataType": "VARCHAR",
+      "length": 50,
+      "notNull": true,
+      "comment": "話者識別子 (例: user / ai / narrator)"
+    },
+    {
+      "id": "col-text",
+      "no": 5,
+      "physicalName": "text",
+      "name": "英文テキスト",
+      "dataType": "TEXT",
+      "notNull": true,
+      "comment": "セリフの英語原文。会話プレイ画面で表示。セリフ内の単語をタップで /vocabulary/:wordId を modal 表示 (実装側 router で intercept)",
+      "description": "将来: TtsGenerate の wordTimings 出力を使い word-level カラオケ字幕を実現する。MVP は通常字幕のみ。"
+    },
+    {
+      "id": "col-translation",
+      "no": 6,
+      "physicalName": "translation",
+      "name": "日本語訳",
+      "dataType": "TEXT",
+      "notNull": false,
+      "comment": "セリフの日本語訳 (ヒント表示用)"
+    },
+    {
+      "id": "col-ipa",
+      "no": 7,
+      "physicalName": "ipa",
+      "name": "IPA 発音記号",
+      "dataType": "VARCHAR",
+      "length": 500,
+      "notNull": false,
+      "comment": "セリフ全体の IPA 発音記号。@conv.regex.ipa 準拠",
+      "description": "fieldType: english-learning:ipa。発音採点のリファレンスとして使用。"
+    },
+    {
+      "id": "col-audio-url",
+      "no": 8,
+      "physicalName": "audio_url",
+      "name": "想定音声 URL",
+      "dataType": "VARCHAR",
+      "length": 500,
+      "notNull": false,
+      "comment": "TTS 生成済みの音声ファイル URL。NULL の場合は on-demand TTS 生成 (TtsGenerate step) を実行する",
+      "description": "fieldType: english-learning:audioUrl。S-1 でストーリー詳細表示時に TtsGenerate でプリロードする想定。"
+    },
+    {
+      "id": "col-created-at",
+      "no": 9,
+      "physicalName": "created_at",
+      "name": "登録日時",
+      "dataType": "TIMESTAMP",
+      "notNull": true,
+      "defaultValue": "CURRENT_TIMESTAMP",
+      "comment": "レコード作成日時"
+    },
+    {
+      "id": "col-updated-at",
+      "no": 10,
+      "physicalName": "updated_at",
+      "name": "更新日時",
+      "dataType": "TIMESTAMP",
+      "notNull": true,
+      "defaultValue": "CURRENT_TIMESTAMP",
+      "comment": "最終更新日時"
+    }
+  ],
+  "constraints": [
+    {
+      "id": "fk-scene-id",
+      "kind": "foreignKey",
+      "physicalName": "fk_dialogue_lines_scene_id",
+      "columnIds": ["col-scene-id"],
+      "referencedTableId": "992ac5db-54fa-4eb0-9509-66b3babbdef6",
+      "referencedColumnIds": ["col-id"],
+      "onDelete": "cascade",
+      "description": "シーンが削除されたら配下のセリフも削除"
+    },
+    {
+      "id": "chk-speaker",
+      "kind": "check",
+      "physicalName": "chk_dialogue_lines_speaker",
+      "expression": "speaker IN ('user', 'ai', 'narrator')",
+      "description": "話者は user / ai / narrator の 3 種類"
+    }
+  ],
+  "indexes": [
+    {
+      "id": "idx-scene-id",
+      "physicalName": "idx_dialogue_lines_scene_id",
+      "columns": [
+        { "columnId": "col-scene-id", "order": "asc" },
+        { "columnId": "col-sort-order", "order": "asc" }
+      ],
+      "method": "btree",
+      "description": "シーン内セリフ一覧取得インデックス (順序保持)"
+    }
+  ]
+}

--- a/examples/english-learning/tables/4e126323-4ab7-4747-961b-23cbaf651314.json
+++ b/examples/english-learning/tables/4e126323-4ab7-4747-961b-23cbaf651314.json
@@ -1,0 +1,131 @@
+{
+  "$schema": "../../../schemas/v3/table.v3.schema.json",
+  "id": "4e126323-4ab7-4747-961b-23cbaf651314",
+  "name": "会話ターンログ",
+  "description": "学習セッション内の会話ターン (ユーザー発話 + AI 応答) のログテーブル。LLM 入力コンテキスト / ユーザー入力 / AI 応答 / TTS 音声 URL を JSON で保持する。S-2 会話ターン進行フローで LlmDialog + TtsGenerate step の出力を記録する。将来 SSE / WebSocket によるストリーム応答に対応する想定 (description 待避)。",
+  "maturity": "draft",
+  "createdAt": "2026-05-04T00:00:00.000Z",
+  "updatedAt": "2026-05-04T00:00:00.000Z",
+  "physicalName": "turn_logs",
+  "category": "トランザクション",
+  "comment": "会話ターンログテーブル。LLM 入出力の全履歴を保持する。",
+  "columns": [
+    {
+      "id": "col-id",
+      "no": 1,
+      "physicalName": "id",
+      "name": "ターンログID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "primaryKey": true,
+      "autoIncrement": true,
+      "comment": "サロゲートキー (自動採番)"
+    },
+    {
+      "id": "col-session-id",
+      "no": 2,
+      "physicalName": "session_id",
+      "name": "セッションID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "comment": "所属学習セッション (learning_sessions.id 参照)"
+    },
+    {
+      "id": "col-turn-number",
+      "no": 3,
+      "physicalName": "turn_number",
+      "name": "ターン番号",
+      "dataType": "INTEGER",
+      "notNull": true,
+      "comment": "セッション内のターン連番 (1 始まり)"
+    },
+    {
+      "id": "col-user-input",
+      "no": 4,
+      "physicalName": "user_input",
+      "name": "ユーザー入力",
+      "dataType": "TEXT",
+      "notNull": false,
+      "comment": "ユーザーが入力したテキスト (テキスト入力時)。音声入力時は STT 変換後テキスト",
+      "description": "ターン単位の request/response。実装側で SSE / WebSocket による partial response ストリーム表示を行う想定。"
+    },
+    {
+      "id": "col-llm-context",
+      "no": 5,
+      "physicalName": "llm_context",
+      "name": "LLM コンテキスト",
+      "dataType": "JSON",
+      "notNull": false,
+      "comment": "LlmDialog step の入力コンテキスト JSON (会話履歴 / システムプロンプト等を含む)",
+      "description": "DialogTurn[] 配列形式。english-learning:DialogTurn responseType の構造に準拠。"
+    },
+    {
+      "id": "col-ai-response",
+      "no": 6,
+      "physicalName": "ai_response",
+      "name": "AI 応答",
+      "dataType": "TEXT",
+      "notNull": false,
+      "comment": "LLM が生成した応答テキスト"
+    },
+    {
+      "id": "col-ai-audio-url",
+      "no": 7,
+      "physicalName": "ai_audio_url",
+      "name": "AI 応答音声 URL",
+      "dataType": "VARCHAR",
+      "length": 500,
+      "notNull": false,
+      "comment": "TtsGenerate step で生成した AI 応答音声の URL",
+      "description": "fieldType: english-learning:audioUrl。NULL の場合は TTS 未生成 (失敗 or 省略)。"
+    },
+    {
+      "id": "col-created-at",
+      "no": 8,
+      "physicalName": "created_at",
+      "name": "記録日時",
+      "dataType": "TIMESTAMP",
+      "notNull": true,
+      "defaultValue": "CURRENT_TIMESTAMP",
+      "comment": "ターンログ記録日時"
+    }
+  ],
+  "constraints": [
+    {
+      "id": "fk-session-id",
+      "kind": "foreignKey",
+      "physicalName": "fk_turn_logs_session_id",
+      "columnIds": ["col-session-id"],
+      "referencedTableId": "d524cba6-0878-4cf5-ba70-deaa7b459103",
+      "referencedColumnIds": ["col-id"],
+      "onDelete": "cascade",
+      "description": "セッションが削除されたらターンログも削除"
+    },
+    {
+      "id": "uq-session-turn",
+      "kind": "unique",
+      "physicalName": "uq_turn_logs_session_turn",
+      "columnIds": ["col-session-id", "col-turn-number"],
+      "description": "セッション内のターン番号一意制約"
+    },
+    {
+      "id": "chk-turn-number",
+      "kind": "check",
+      "physicalName": "chk_turn_logs_turn_number",
+      "expression": "turn_number >= 1",
+      "description": "ターン番号は 1 以上"
+    }
+  ],
+  "indexes": [
+    {
+      "id": "idx-session-id",
+      "physicalName": "idx_turn_logs_session_id",
+      "columns": [
+        { "columnId": "col-session-id", "order": "asc" },
+        { "columnId": "col-turn-number", "order": "asc" }
+      ],
+      "method": "btree",
+      "description": "セッション内ターン一覧取得インデックス (順序保持)"
+    }
+  ]
+}

--- a/examples/english-learning/tables/517d50a3-960f-42ce-810f-3b126398d7b1.json
+++ b/examples/english-learning/tables/517d50a3-960f-42ce-810f-3b126398d7b1.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "../../../schemas/v3/table.v3.schema.json",
+  "id": "517d50a3-960f-42ce-810f-3b126398d7b1",
+  "name": "コンテンツパック",
+  "description": "分野別学習コンテンツのパッケージ管理テーブル。汎用 / IT エンジニア / ビジネス / 旅行 等の分野ごとにパックを定義する。namespace_ref で english-learning 拡張に紐付けることで動的コンテンツ追加を表現する。",
+  "maturity": "draft",
+  "createdAt": "2026-05-04T00:00:00.000Z",
+  "updatedAt": "2026-05-04T00:00:00.000Z",
+  "physicalName": "content_packs",
+  "category": "マスタ",
+  "comment": "コンテンツパックマスタ。分野別の学習コンテンツをパッケージ化して管理する。",
+  "columns": [
+    {
+      "id": "col-id",
+      "no": 1,
+      "physicalName": "id",
+      "name": "パックID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "primaryKey": true,
+      "autoIncrement": true,
+      "comment": "サロゲートキー (自動採番)"
+    },
+    {
+      "id": "col-name",
+      "no": 2,
+      "physicalName": "name",
+      "name": "パック名",
+      "dataType": "VARCHAR",
+      "length": 200,
+      "notNull": true,
+      "comment": "パックの表示名 (例: 「IT エンジニア英語」「ビジネス英語」)"
+    },
+    {
+      "id": "col-slug",
+      "no": 3,
+      "physicalName": "slug",
+      "name": "スラッグ",
+      "dataType": "VARCHAR",
+      "length": 100,
+      "notNull": true,
+      "unique": true,
+      "comment": "URL / API 用識別子 (例: general, it-engineer, business)"
+    },
+    {
+      "id": "col-description",
+      "no": 4,
+      "physicalName": "description",
+      "name": "説明",
+      "dataType": "TEXT",
+      "notNull": false,
+      "comment": "パックの概要説明 (コンテンツパック一覧画面で表示)"
+    },
+    {
+      "id": "col-thumbnail-url",
+      "no": 5,
+      "physicalName": "thumbnail_url",
+      "name": "サムネイル URL",
+      "dataType": "VARCHAR",
+      "length": 500,
+      "notNull": false,
+      "comment": "一覧カード表示用サムネイル画像 URL"
+    },
+    {
+      "id": "col-namespace-ref",
+      "no": 6,
+      "physicalName": "namespace_ref",
+      "name": "拡張 namespace 参照",
+      "dataType": "VARCHAR",
+      "length": 200,
+      "notNull": false,
+      "comment": "拡張定義への参照 (例: english-learning)。動的コンテンツパックと拡張 namespace を紐付ける",
+      "description": "null の場合は汎用パック (拡張なし)。拡張パックの場合は namespace 識別子を格納し、拡張定義ファイルを動的ロードする際の参照キーとして使用する。"
+    },
+    {
+      "id": "col-is-active",
+      "no": 7,
+      "physicalName": "is_active",
+      "name": "公開中フラグ",
+      "dataType": "BOOLEAN",
+      "notNull": true,
+      "defaultValue": "TRUE",
+      "comment": "FALSE で非公開 (論理削除)"
+    },
+    {
+      "id": "col-created-at",
+      "no": 8,
+      "physicalName": "created_at",
+      "name": "登録日時",
+      "dataType": "TIMESTAMP",
+      "notNull": true,
+      "defaultValue": "CURRENT_TIMESTAMP",
+      "comment": "レコード作成日時"
+    }
+  ],
+  "constraints": [
+    {
+      "id": "uq-slug",
+      "kind": "unique",
+      "physicalName": "uq_content_packs_slug",
+      "columnIds": ["col-slug"],
+      "description": "スラッグの一意制約 (URL / API で一意識別するため)"
+    }
+  ],
+  "indexes": [
+    {
+      "id": "idx-slug",
+      "physicalName": "idx_content_packs_slug",
+      "columns": [{ "columnId": "col-slug", "order": "asc" }],
+      "unique": true,
+      "method": "btree",
+      "description": "スラッグ検索インデックス"
+    },
+    {
+      "id": "idx-is-active",
+      "physicalName": "idx_content_packs_is_active",
+      "columns": [{ "columnId": "col-is-active", "order": "asc" }],
+      "method": "btree",
+      "description": "公開中パック絞り込みインデックス"
+    }
+  ]
+}

--- a/examples/english-learning/tables/7ab2cf24-7b66-47aa-a808-7fffd8290480.json
+++ b/examples/english-learning/tables/7ab2cf24-7b66-47aa-a808-7fffd8290480.json
@@ -1,0 +1,160 @@
+{
+  "$schema": "../../../schemas/v3/table.v3.schema.json",
+  "id": "7ab2cf24-7b66-47aa-a808-7fffd8290480",
+  "name": "単語習熟度",
+  "description": "ユーザーと単語の習熟度管理テーブル。(user_id, word_id) を UNIQUE キーとし、status (new / learning / mastered) と correct_count / attempt_count で習熟度を管理する。@conv.extensionCategories.wordProgress.masteryThreshold (連続正解回数) を超えた時点で mastered に昇格する。",
+  "maturity": "draft",
+  "createdAt": "2026-05-04T00:00:00.000Z",
+  "updatedAt": "2026-05-04T00:00:00.000Z",
+  "physicalName": "user_word_progress",
+  "category": "トランザクション",
+  "comment": "単語習熟度テーブル。ユーザー × 単語の学習進捗を管理する。",
+  "columns": [
+    {
+      "id": "col-id",
+      "no": 1,
+      "physicalName": "id",
+      "name": "習熟度ID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "primaryKey": true,
+      "autoIncrement": true,
+      "comment": "サロゲートキー (自動採番)"
+    },
+    {
+      "id": "col-user-id",
+      "no": 2,
+      "physicalName": "user_id",
+      "name": "ユーザーID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "comment": "学習者 (users.id 参照)"
+    },
+    {
+      "id": "col-word-id",
+      "no": 3,
+      "physicalName": "word_id",
+      "name": "単語ID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "comment": "対象単語 (words.id 参照)"
+    },
+    {
+      "id": "col-status",
+      "no": 4,
+      "physicalName": "status",
+      "name": "習熟ステータス",
+      "dataType": "VARCHAR",
+      "length": 20,
+      "notNull": true,
+      "defaultValue": "'new'",
+      "comment": "習熟度 (new=未学習 / learning=学習中 / mastered=習熟済み)"
+    },
+    {
+      "id": "col-correct-count",
+      "no": 5,
+      "physicalName": "correct_count",
+      "name": "連続正解回数",
+      "dataType": "INTEGER",
+      "notNull": true,
+      "defaultValue": "0",
+      "comment": "現在の連続正解回数。@conv.extensionCategories.wordProgress.masteryThreshold 以上で mastered に昇格"
+    },
+    {
+      "id": "col-attempt-count",
+      "no": 6,
+      "physicalName": "attempt_count",
+      "name": "累計挑戦回数",
+      "dataType": "INTEGER",
+      "notNull": true,
+      "defaultValue": "0",
+      "comment": "累計挑戦回数 (降格トラッキング用)"
+    },
+    {
+      "id": "col-last-practiced-at",
+      "no": 7,
+      "physicalName": "last_practiced_at",
+      "name": "最終練習日時",
+      "dataType": "TIMESTAMP",
+      "notNull": false,
+      "comment": "最後に練習した日時。一定期間未使用で習熟度自動降格 job (scheduled flow) のトリガー",
+      "description": "将来: scheduled flow で一定期間 (例: 14 日) 練習がない場合に mastered → learning に降格する。MVP では定義のみで実装は後段。"
+    },
+    {
+      "id": "col-updated-at",
+      "no": 8,
+      "physicalName": "updated_at",
+      "name": "更新日時",
+      "dataType": "TIMESTAMP",
+      "notNull": true,
+      "defaultValue": "CURRENT_TIMESTAMP",
+      "comment": "最終更新日時"
+    }
+  ],
+  "constraints": [
+    {
+      "id": "uq-user-word",
+      "kind": "unique",
+      "physicalName": "uq_user_word_progress_user_word",
+      "columnIds": ["col-user-id", "col-word-id"],
+      "description": "ユーザー × 単語の UNIQUE 制約 (重複 UPSERT 用)"
+    },
+    {
+      "id": "fk-user-id",
+      "kind": "foreignKey",
+      "physicalName": "fk_user_word_progress_user_id",
+      "columnIds": ["col-user-id"],
+      "referencedTableId": "c7e50462-bbc4-498f-a280-2ec40bda30b1",
+      "referencedColumnIds": ["col-id"],
+      "onDelete": "cascade",
+      "description": "ユーザーが削除されたら習熟度も削除"
+    },
+    {
+      "id": "fk-word-id",
+      "kind": "foreignKey",
+      "physicalName": "fk_user_word_progress_word_id",
+      "columnIds": ["col-word-id"],
+      "referencedTableId": "8db75844-19ca-4e7d-8293-579e7631c5cc",
+      "referencedColumnIds": ["col-id"],
+      "onDelete": "cascade",
+      "description": "単語が削除されたら習熟度も削除"
+    },
+    {
+      "id": "chk-status",
+      "kind": "check",
+      "physicalName": "chk_user_word_progress_status",
+      "expression": "status IN ('new', 'learning', 'mastered')",
+      "description": "習熟ステータスの値域制約"
+    },
+    {
+      "id": "chk-correct-count",
+      "kind": "check",
+      "physicalName": "chk_user_word_progress_correct_count",
+      "expression": "correct_count >= 0",
+      "description": "連続正解回数は 0 以上"
+    }
+  ],
+  "indexes": [
+    {
+      "id": "idx-user-id",
+      "physicalName": "idx_user_word_progress_user_id",
+      "columns": [
+        { "columnId": "col-user-id", "order": "asc" },
+        { "columnId": "col-status", "order": "asc" }
+      ],
+      "method": "btree",
+      "description": "ユーザー × ステータス別習熟度一覧取得インデックス (単語帳画面)"
+    },
+    {
+      "id": "idx-user-word",
+      "physicalName": "idx_user_word_progress_user_word",
+      "columns": [
+        { "columnId": "col-user-id", "order": "asc" },
+        { "columnId": "col-word-id", "order": "asc" }
+      ],
+      "unique": true,
+      "method": "btree",
+      "description": "UPSERT 用複合ユニークインデックス"
+    }
+  ]
+}

--- a/examples/english-learning/tables/8db75844-19ca-4e7d-8293-579e7631c5cc.json
+++ b/examples/english-learning/tables/8db75844-19ca-4e7d-8293-579e7631c5cc.json
@@ -1,0 +1,156 @@
+{
+  "$schema": "../../../schemas/v3/table.v3.schema.json",
+  "id": "8db75844-19ca-4e7d-8293-579e7631c5cc",
+  "name": "単語",
+  "description": "学習コンテンツ内の英単語辞書テーブル。英語 / 品詞 / 日本語訳 / IPA / 例文 / CEFR レベルを保持する。単語帳画面・単語詳細画面で表示し、user_word_progress との結合で習熟度管理を行う。",
+  "maturity": "draft",
+  "createdAt": "2026-05-04T00:00:00.000Z",
+  "updatedAt": "2026-05-04T00:00:00.000Z",
+  "physicalName": "words",
+  "category": "マスタ",
+  "comment": "単語辞書テーブル。アプリ内で使用する英単語のマスタ情報を管理する。",
+  "columns": [
+    {
+      "id": "col-id",
+      "no": 1,
+      "physicalName": "id",
+      "name": "単語ID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "primaryKey": true,
+      "autoIncrement": true,
+      "comment": "サロゲートキー (自動採番)"
+    },
+    {
+      "id": "col-word",
+      "no": 2,
+      "physicalName": "word",
+      "name": "英単語",
+      "dataType": "VARCHAR",
+      "length": 100,
+      "notNull": true,
+      "unique": true,
+      "comment": "英単語 (小文字正規化済み、例: coffee)"
+    },
+    {
+      "id": "col-part-of-speech",
+      "no": 3,
+      "physicalName": "part_of_speech",
+      "name": "品詞",
+      "dataType": "VARCHAR",
+      "length": 30,
+      "notNull": true,
+      "comment": "品詞 (例: noun, verb, adjective, adverb, preposition)"
+    },
+    {
+      "id": "col-translation",
+      "no": 4,
+      "physicalName": "translation",
+      "name": "日本語訳",
+      "dataType": "VARCHAR",
+      "length": 200,
+      "notNull": true,
+      "comment": "代表的な日本語訳"
+    },
+    {
+      "id": "col-ipa",
+      "no": 5,
+      "physicalName": "ipa",
+      "name": "IPA 発音記号",
+      "dataType": "VARCHAR",
+      "length": 200,
+      "notNull": false,
+      "comment": "IPA 発音記号。@conv.regex.ipa 準拠",
+      "description": "fieldType: english-learning:ipa。単語詳細画面で発音確認用に表示する。"
+    },
+    {
+      "id": "col-example-sentence",
+      "no": 6,
+      "physicalName": "example_sentence",
+      "name": "例文",
+      "dataType": "TEXT",
+      "notNull": false,
+      "comment": "単語を使用した英語例文"
+    },
+    {
+      "id": "col-example-translation",
+      "no": 7,
+      "physicalName": "example_translation",
+      "name": "例文日本語訳",
+      "dataType": "TEXT",
+      "notNull": false,
+      "comment": "例文の日本語訳"
+    },
+    {
+      "id": "col-cefr-level",
+      "no": 8,
+      "physicalName": "cefr_level",
+      "name": "CEFR レベル",
+      "dataType": "VARCHAR",
+      "length": 2,
+      "notNull": true,
+      "comment": "この単語の難易度 (A1/A2/B1/B2/C1/C2)",
+      "description": "fieldType: english-learning:cefrLevel。単語帳でのレベル別フィルタに使用する。"
+    },
+    {
+      "id": "col-created-at",
+      "no": 9,
+      "physicalName": "created_at",
+      "name": "登録日時",
+      "dataType": "TIMESTAMP",
+      "notNull": true,
+      "defaultValue": "CURRENT_TIMESTAMP",
+      "comment": "レコード作成日時"
+    },
+    {
+      "id": "col-updated-at",
+      "no": 10,
+      "physicalName": "updated_at",
+      "name": "更新日時",
+      "dataType": "TIMESTAMP",
+      "notNull": true,
+      "defaultValue": "CURRENT_TIMESTAMP",
+      "comment": "最終更新日時"
+    }
+  ],
+  "constraints": [
+    {
+      "id": "uq-word",
+      "kind": "unique",
+      "physicalName": "uq_words_word",
+      "columnIds": ["col-word"],
+      "description": "英単語の一意制約 (小文字正規化済み)"
+    },
+    {
+      "id": "chk-cefr-level",
+      "kind": "check",
+      "physicalName": "chk_words_cefr_level",
+      "expression": "cefr_level IN ('A1', 'A2', 'B1', 'B2', 'C1', 'C2')",
+      "description": "CEFR レベルの値域制約"
+    },
+    {
+      "id": "chk-part-of-speech",
+      "kind": "check",
+      "physicalName": "chk_words_part_of_speech",
+      "expression": "part_of_speech IN ('noun', 'verb', 'adjective', 'adverb', 'preposition', 'conjunction', 'interjection', 'other')",
+      "description": "品詞の値域制約"
+    }
+  ],
+  "indexes": [
+    {
+      "id": "idx-word",
+      "physicalName": "idx_words_word",
+      "columns": [{ "columnId": "col-word", "order": "asc" }],
+      "unique": true,
+      "method": "btree",
+      "description": "単語検索インデックス"
+    },
+    {
+      "id": "idx-cefr-level",
+      "physicalName": "idx_words_cefr_level",
+      "columns": [{ "columnId": "col-cefr-level", "order": "asc" }],
+      "method": "btree",
+      "description": "レベル別フィルタリングインデックス"
+    }
+  ]
+}

--- a/examples/english-learning/tables/992ac5db-54fa-4eb0-9509-66b3babbdef6.json
+++ b/examples/english-learning/tables/992ac5db-54fa-4eb0-9509-66b3babbdef6.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "../../../schemas/v3/table.v3.schema.json",
+  "id": "992ac5db-54fa-4eb0-9509-66b3babbdef6",
+  "name": "シーン",
+  "description": "ストーリー配下の会話シーン管理テーブル。シーンはストーリー内の場面 (例: カフェでの注文、会議の挨拶) を表し、複数のセリフ (dialogue_lines) で構成される。sort_order で順序を保持する。",
+  "maturity": "draft",
+  "createdAt": "2026-05-04T00:00:00.000Z",
+  "updatedAt": "2026-05-04T00:00:00.000Z",
+  "physicalName": "scenes",
+  "category": "マスタ",
+  "comment": "シーンマスタ。ストーリー配下の会話場面単位。",
+  "columns": [
+    {
+      "id": "col-id",
+      "no": 1,
+      "physicalName": "id",
+      "name": "シーンID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "primaryKey": true,
+      "autoIncrement": true,
+      "comment": "サロゲートキー (自動採番)"
+    },
+    {
+      "id": "col-story-id",
+      "no": 2,
+      "physicalName": "story_id",
+      "name": "ストーリーID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "comment": "所属ストーリー (stories.id 参照)"
+    },
+    {
+      "id": "col-title",
+      "no": 3,
+      "physicalName": "title",
+      "name": "シーンタイトル",
+      "dataType": "VARCHAR",
+      "length": 200,
+      "notNull": true,
+      "comment": "シーンの表示タイトル (例: 「カフェで注文する」)"
+    },
+    {
+      "id": "col-description",
+      "no": 4,
+      "physicalName": "description",
+      "name": "シーン説明",
+      "dataType": "TEXT",
+      "notNull": false,
+      "comment": "シーンの背景説明 (会話プレイ画面で冒頭に表示)"
+    },
+    {
+      "id": "col-sort-order",
+      "no": 5,
+      "physicalName": "sort_order",
+      "name": "表示順",
+      "dataType": "INTEGER",
+      "notNull": true,
+      "defaultValue": "0",
+      "comment": "ストーリー内でのシーン表示順 (昇順)"
+    },
+    {
+      "id": "col-created-at",
+      "no": 6,
+      "physicalName": "created_at",
+      "name": "登録日時",
+      "dataType": "TIMESTAMP",
+      "notNull": true,
+      "defaultValue": "CURRENT_TIMESTAMP",
+      "comment": "レコード作成日時"
+    },
+    {
+      "id": "col-updated-at",
+      "no": 7,
+      "physicalName": "updated_at",
+      "name": "更新日時",
+      "dataType": "TIMESTAMP",
+      "notNull": true,
+      "defaultValue": "CURRENT_TIMESTAMP",
+      "comment": "最終更新日時"
+    }
+  ],
+  "constraints": [
+    {
+      "id": "fk-story-id",
+      "kind": "foreignKey",
+      "physicalName": "fk_scenes_story_id",
+      "columnIds": ["col-story-id"],
+      "referencedTableId": "b5aa3e1b-b5e4-46dd-8373-75fea340844b",
+      "referencedColumnIds": ["col-id"],
+      "onDelete": "cascade",
+      "description": "ストーリーが削除されたら配下のシーンも削除"
+    }
+  ],
+  "indexes": [
+    {
+      "id": "idx-story-id",
+      "physicalName": "idx_scenes_story_id",
+      "columns": [
+        { "columnId": "col-story-id", "order": "asc" },
+        { "columnId": "col-sort-order", "order": "asc" }
+      ],
+      "method": "btree",
+      "description": "ストーリー内シーン一覧取得インデックス (順序保持)"
+    }
+  ]
+}

--- a/examples/english-learning/tables/b5aa3e1b-b5e4-46dd-8373-75fea340844b.json
+++ b/examples/english-learning/tables/b5aa3e1b-b5e4-46dd-8373-75fea340844b.json
@@ -1,0 +1,142 @@
+{
+  "$schema": "../../../schemas/v3/table.v3.schema.json",
+  "id": "b5aa3e1b-b5e4-46dd-8373-75fea340844b",
+  "name": "ストーリー",
+  "description": "コンテンツパック配下の学習ストーリー管理テーブル。各ストーリーは CEFR レベルを持ち、複数シーンで構成される。ストーリー一覧 / 詳細画面で表示し、学習セッション開始のエントリポイントとなる。",
+  "maturity": "draft",
+  "createdAt": "2026-05-04T00:00:00.000Z",
+  "updatedAt": "2026-05-04T00:00:00.000Z",
+  "physicalName": "stories",
+  "category": "マスタ",
+  "comment": "ストーリーマスタ。コンテンツパック配下の学習コンテンツ単位。",
+  "columns": [
+    {
+      "id": "col-id",
+      "no": 1,
+      "physicalName": "id",
+      "name": "ストーリーID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "primaryKey": true,
+      "autoIncrement": true,
+      "comment": "サロゲートキー (自動採番)"
+    },
+    {
+      "id": "col-pack-id",
+      "no": 2,
+      "physicalName": "pack_id",
+      "name": "パックID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "comment": "所属コンテンツパック (content_packs.id 参照)"
+    },
+    {
+      "id": "col-title",
+      "no": 3,
+      "physicalName": "title",
+      "name": "タイトル",
+      "dataType": "VARCHAR",
+      "length": 200,
+      "notNull": true,
+      "comment": "ストーリーの表示タイトル"
+    },
+    {
+      "id": "col-description",
+      "no": 4,
+      "physicalName": "description",
+      "name": "あらすじ",
+      "dataType": "TEXT",
+      "notNull": false,
+      "comment": "ストーリーの概要説明 (ストーリー一覧カードで表示)"
+    },
+    {
+      "id": "col-cefr-level",
+      "no": 5,
+      "physicalName": "cefr_level",
+      "name": "CEFR レベル",
+      "dataType": "VARCHAR",
+      "length": 2,
+      "notNull": true,
+      "comment": "ストーリーの難易度 (A1/A2/B1/B2/C1/C2)",
+      "description": "fieldType: english-learning:cefrLevel。ユーザーの cefr_level と照合してレコメンド表示に使用する。"
+    },
+    {
+      "id": "col-thumbnail-url",
+      "no": 6,
+      "physicalName": "thumbnail_url",
+      "name": "サムネイル URL",
+      "dataType": "VARCHAR",
+      "length": 500,
+      "notNull": false,
+      "comment": "一覧カード表示用サムネイル画像 URL"
+    },
+    {
+      "id": "col-sort-order",
+      "no": 7,
+      "physicalName": "sort_order",
+      "name": "表示順",
+      "dataType": "INTEGER",
+      "notNull": true,
+      "defaultValue": "0",
+      "comment": "パック内での表示順 (昇順)。同一パック内でユニーク推奨"
+    },
+    {
+      "id": "col-is-active",
+      "no": 8,
+      "physicalName": "is_active",
+      "name": "公開中フラグ",
+      "dataType": "BOOLEAN",
+      "notNull": true,
+      "defaultValue": "TRUE",
+      "comment": "FALSE で非公開 (論理削除)"
+    },
+    {
+      "id": "col-created-at",
+      "no": 9,
+      "physicalName": "created_at",
+      "name": "登録日時",
+      "dataType": "TIMESTAMP",
+      "notNull": true,
+      "defaultValue": "CURRENT_TIMESTAMP",
+      "comment": "レコード作成日時"
+    }
+  ],
+  "constraints": [
+    {
+      "id": "fk-pack-id",
+      "kind": "foreignKey",
+      "physicalName": "fk_stories_pack_id",
+      "columnIds": ["col-pack-id"],
+      "referencedTableId": "517d50a3-960f-42ce-810f-3b126398d7b1",
+      "referencedColumnIds": ["col-id"],
+      "onDelete": "cascade",
+      "description": "パックが削除されたら配下のストーリーも削除"
+    },
+    {
+      "id": "chk-cefr-level",
+      "kind": "check",
+      "physicalName": "chk_stories_cefr_level",
+      "expression": "cefr_level IN ('A1', 'A2', 'B1', 'B2', 'C1', 'C2')",
+      "description": "CEFR レベルの値域制約"
+    }
+  ],
+  "indexes": [
+    {
+      "id": "idx-pack-id",
+      "physicalName": "idx_stories_pack_id",
+      "columns": [
+        { "columnId": "col-pack-id", "order": "asc" },
+        { "columnId": "col-sort-order", "order": "asc" }
+      ],
+      "method": "btree",
+      "description": "パック内ストーリー一覧取得インデックス"
+    },
+    {
+      "id": "idx-cefr-level",
+      "physicalName": "idx_stories_cefr_level",
+      "columns": [{ "columnId": "col-cefr-level", "order": "asc" }],
+      "method": "btree",
+      "description": "レベル別フィルタリングインデックス"
+    }
+  ]
+}

--- a/examples/english-learning/tables/c7e50462-bbc4-498f-a280-2ec40bda30b1.json
+++ b/examples/english-learning/tables/c7e50462-bbc4-498f-a280-2ec40bda30b1.json
@@ -1,0 +1,149 @@
+{
+  "$schema": "../../../schemas/v3/table.v3.schema.json",
+  "id": "c7e50462-bbc4-498f-a280-2ec40bda30b1",
+  "name": "ユーザー",
+  "description": "学習者アカウント管理テーブル。CEFR レベル (現在 / 目標) / 連続学習日数 / 興味分野リストを保持する。B2C ユーザーの認証情報と学習進捗サマリを一元管理する。",
+  "maturity": "draft",
+  "createdAt": "2026-05-04T00:00:00.000Z",
+  "updatedAt": "2026-05-04T00:00:00.000Z",
+  "physicalName": "users",
+  "category": "マスタ",
+  "comment": "学習者アカウントテーブル。email で一意識別する。",
+  "columns": [
+    {
+      "id": "col-id",
+      "no": 1,
+      "physicalName": "id",
+      "name": "ユーザーID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "primaryKey": true,
+      "autoIncrement": true,
+      "comment": "サロゲートキー (自動採番)"
+    },
+    {
+      "id": "col-email",
+      "no": 2,
+      "physicalName": "email",
+      "name": "メールアドレス",
+      "dataType": "VARCHAR",
+      "length": 255,
+      "notNull": true,
+      "unique": true,
+      "comment": "ログイン用メールアドレス (一意)"
+    },
+    {
+      "id": "col-display-name",
+      "no": 3,
+      "physicalName": "display_name",
+      "name": "表示名",
+      "dataType": "VARCHAR",
+      "length": 100,
+      "notNull": true,
+      "comment": "アプリ内表示名"
+    },
+    {
+      "id": "col-cefr-level",
+      "no": 4,
+      "physicalName": "cefr_level",
+      "name": "現在 CEFR レベル",
+      "dataType": "VARCHAR",
+      "length": 2,
+      "notNull": true,
+      "defaultValue": "'A1'",
+      "comment": "現在の英語レベル (A1/A2/B1/B2/C1/C2)。@conv.extensionCategories.cefr.passingThreshold で昇格判定",
+      "description": "fieldType: english-learning:cefrLevel。学習セッション完了時に発音スコアが閾値を超えた場合に自動更新する想定。"
+    },
+    {
+      "id": "col-target-cefr-level",
+      "no": 5,
+      "physicalName": "target_cefr_level",
+      "name": "目標 CEFR レベル",
+      "dataType": "VARCHAR",
+      "length": 2,
+      "notNull": false,
+      "comment": "学習者が設定した目標レベル (A1/A2/B1/B2/C1/C2)",
+      "description": "fieldType: english-learning:cefrLevel。プロフィール設定画面で変更可能。"
+    },
+    {
+      "id": "col-streak-days",
+      "no": 6,
+      "physicalName": "streak_days",
+      "name": "連続学習日数",
+      "dataType": "INTEGER",
+      "notNull": true,
+      "defaultValue": "0",
+      "comment": "連続して学習した日数。毎日 0:00 リセット job (scheduled flow) で管理 (子 4 で定義)"
+    },
+    {
+      "id": "col-interests",
+      "no": 7,
+      "physicalName": "interests",
+      "name": "興味分野",
+      "dataType": "JSON",
+      "notNull": false,
+      "comment": "興味分野の文字列配列 (例: [\"IT\", \"ビジネス\"])。コンテンツパック選択のレコメンドに使用",
+      "description": "JSON 配列で保持。UI では複数選択チェックボックスで表示する。"
+    },
+    {
+      "id": "col-created-at",
+      "no": 8,
+      "physicalName": "created_at",
+      "name": "登録日時",
+      "dataType": "TIMESTAMP",
+      "notNull": true,
+      "defaultValue": "CURRENT_TIMESTAMP",
+      "comment": "アカウント作成日時"
+    },
+    {
+      "id": "col-updated-at",
+      "no": 9,
+      "physicalName": "updated_at",
+      "name": "更新日時",
+      "dataType": "TIMESTAMP",
+      "notNull": true,
+      "defaultValue": "CURRENT_TIMESTAMP",
+      "comment": "最終更新日時"
+    }
+  ],
+  "constraints": [
+    {
+      "id": "uq-email",
+      "kind": "unique",
+      "physicalName": "uq_users_email",
+      "columnIds": ["col-email"],
+      "description": "メールアドレスの一意制約"
+    },
+    {
+      "id": "chk-cefr-level",
+      "kind": "check",
+      "physicalName": "chk_users_cefr_level",
+      "expression": "cefr_level IN ('A1', 'A2', 'B1', 'B2', 'C1', 'C2')",
+      "description": "CEFR レベルの値域制約"
+    },
+    {
+      "id": "chk-streak-days",
+      "kind": "check",
+      "physicalName": "chk_users_streak_days",
+      "expression": "streak_days >= 0",
+      "description": "連続学習日数は 0 以上"
+    }
+  ],
+  "indexes": [
+    {
+      "id": "idx-email",
+      "physicalName": "idx_users_email",
+      "columns": [{ "columnId": "col-email", "order": "asc" }],
+      "unique": true,
+      "method": "btree",
+      "description": "メールアドレス検索インデックス (ログイン認証用)"
+    },
+    {
+      "id": "idx-cefr-level",
+      "physicalName": "idx_users_cefr_level",
+      "columns": [{ "columnId": "col-cefr-level", "order": "asc" }],
+      "method": "btree",
+      "description": "レベル別ユーザー集計用インデックス"
+    }
+  ]
+}

--- a/examples/english-learning/tables/d524cba6-0878-4cf5-ba70-deaa7b459103.json
+++ b/examples/english-learning/tables/d524cba6-0878-4cf5-ba70-deaa7b459103.json
@@ -1,0 +1,157 @@
+{
+  "$schema": "../../../schemas/v3/table.v3.schema.json",
+  "id": "d524cba6-0878-4cf5-ba70-deaa7b459103",
+  "name": "学習セッション",
+  "description": "学習者がストーリーを開始するたびに作成されるセッション管理テーブル。(user_id, story_id, started_at) の組み合わせで識別する。status で進行中 / 完了 / 中断を管理し、学習履歴一覧の元データとなる。",
+  "maturity": "draft",
+  "createdAt": "2026-05-04T00:00:00.000Z",
+  "updatedAt": "2026-05-04T00:00:00.000Z",
+  "physicalName": "learning_sessions",
+  "category": "トランザクション",
+  "comment": "学習セッションテーブル。ストーリー学習 1 回分の開始〜完了を管理する。",
+  "columns": [
+    {
+      "id": "col-id",
+      "no": 1,
+      "physicalName": "id",
+      "name": "セッションID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "primaryKey": true,
+      "autoIncrement": true,
+      "comment": "サロゲートキー。@conv.numbering.sessionId で採番規約を定義"
+    },
+    {
+      "id": "col-user-id",
+      "no": 2,
+      "physicalName": "user_id",
+      "name": "ユーザーID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "comment": "学習者 (users.id 参照)"
+    },
+    {
+      "id": "col-story-id",
+      "no": 3,
+      "physicalName": "story_id",
+      "name": "ストーリーID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "comment": "学習対象ストーリー (stories.id 参照)"
+    },
+    {
+      "id": "col-status",
+      "no": 4,
+      "physicalName": "status",
+      "name": "ステータス",
+      "dataType": "VARCHAR",
+      "length": 20,
+      "notNull": true,
+      "defaultValue": "'in_progress'",
+      "comment": "セッション状態 (in_progress / completed / abandoned)"
+    },
+    {
+      "id": "col-score-avg",
+      "no": 5,
+      "physicalName": "score_avg",
+      "name": "平均発音スコア",
+      "dataType": "DECIMAL",
+      "length": 5,
+      "scale": 2,
+      "notNull": false,
+      "comment": "セッション完了時に集計した平均発音スコア (0.00〜100.00)",
+      "description": "セッション完了時に pronunciation_scores から集計して更新する。"
+    },
+    {
+      "id": "col-started-at",
+      "no": 6,
+      "physicalName": "started_at",
+      "name": "開始日時",
+      "dataType": "TIMESTAMP",
+      "notNull": true,
+      "defaultValue": "CURRENT_TIMESTAMP",
+      "comment": "セッション開始日時"
+    },
+    {
+      "id": "col-completed-at",
+      "no": 7,
+      "physicalName": "completed_at",
+      "name": "完了日時",
+      "dataType": "TIMESTAMP",
+      "notNull": false,
+      "comment": "セッション完了日時 (完了時に更新)"
+    },
+    {
+      "id": "col-updated-at",
+      "no": 8,
+      "physicalName": "updated_at",
+      "name": "更新日時",
+      "dataType": "TIMESTAMP",
+      "notNull": true,
+      "defaultValue": "CURRENT_TIMESTAMP",
+      "comment": "最終更新日時"
+    }
+  ],
+  "constraints": [
+    {
+      "id": "fk-user-id",
+      "kind": "foreignKey",
+      "physicalName": "fk_learning_sessions_user_id",
+      "columnIds": ["col-user-id"],
+      "referencedTableId": "c7e50462-bbc4-498f-a280-2ec40bda30b1",
+      "referencedColumnIds": ["col-id"],
+      "onDelete": "cascade",
+      "description": "ユーザーが削除されたら学習セッションも削除"
+    },
+    {
+      "id": "fk-story-id",
+      "kind": "foreignKey",
+      "physicalName": "fk_learning_sessions_story_id",
+      "columnIds": ["col-story-id"],
+      "referencedTableId": "b5aa3e1b-b5e4-46dd-8373-75fea340844b",
+      "referencedColumnIds": ["col-id"],
+      "onDelete": "restrict",
+      "description": "セッション履歴が存在するストーリーは削除不可 (論理削除で対応)"
+    },
+    {
+      "id": "chk-status",
+      "kind": "check",
+      "physicalName": "chk_learning_sessions_status",
+      "expression": "status IN ('in_progress', 'completed', 'abandoned')",
+      "description": "ステータスの値域制約"
+    },
+    {
+      "id": "chk-score-avg",
+      "kind": "check",
+      "physicalName": "chk_learning_sessions_score_avg",
+      "expression": "score_avg IS NULL OR (score_avg >= 0 AND score_avg <= 100)",
+      "description": "平均スコアは 0〜100 の範囲"
+    }
+  ],
+  "indexes": [
+    {
+      "id": "idx-user-id",
+      "physicalName": "idx_learning_sessions_user_id",
+      "columns": [
+        { "columnId": "col-user-id", "order": "asc" },
+        { "columnId": "col-started-at", "order": "desc" }
+      ],
+      "method": "btree",
+      "description": "ユーザーの学習履歴一覧取得インデックス"
+    },
+    {
+      "id": "idx-story-id",
+      "physicalName": "idx_learning_sessions_story_id",
+      "columns": [{ "columnId": "col-story-id", "order": "asc" }],
+      "method": "btree",
+      "description": "ストーリー別セッション集計インデックス"
+    },
+    {
+      "id": "idx-status",
+      "physicalName": "idx_learning_sessions_status",
+      "columns": [{ "columnId": "col-status", "order": "asc" }],
+      "method": "btree",
+      "description": "ステータス別フィルタリングインデックス"
+    }
+  ]
+}

--- a/examples/english-learning/tables/fefa79cf-4721-4956-86bb-595427bf6f81.json
+++ b/examples/english-learning/tables/fefa79cf-4721-4956-86bb-595427bf6f81.json
@@ -2,7 +2,7 @@
   "$schema": "../../../schemas/v3/table.v3.schema.json",
   "id": "fefa79cf-4721-4956-86bb-595427bf6f81",
   "name": "発音スコア",
-  "description": "学習セッション内でのセリフ発音採点結果テーブル。SttEvaluate step (S-3) の出力を保持する。score 0-100 + 音素単位の差分 JSON (diff) を記録し、セッション結果画面で色分け表示に使用する。",
+  "description": "学習セッション内でのセリフ発音採点結果テーブル。SttEvaluate step (S-3) の出力を保持する。score 0-100 + 音素単位の差分 JSON (diff) を記録し、セッション結果画面で色分け表示に使用する。**1 セッション × 1 セリフに対し複数回の採点を許容する** (再練習で再録音 → 再採点)。最新スコアの取得は ORDER BY scored_at DESC LIMIT 1 で行う。",
   "maturity": "draft",
   "createdAt": "2026-05-04T00:00:00.000Z",
   "updatedAt": "2026-05-04T00:00:00.000Z",

--- a/examples/english-learning/tables/fefa79cf-4721-4956-86bb-595427bf6f81.json
+++ b/examples/english-learning/tables/fefa79cf-4721-4956-86bb-595427bf6f81.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "../../../schemas/v3/table.v3.schema.json",
+  "id": "fefa79cf-4721-4956-86bb-595427bf6f81",
+  "name": "発音スコア",
+  "description": "学習セッション内でのセリフ発音採点結果テーブル。SttEvaluate step (S-3) の出力を保持する。score 0-100 + 音素単位の差分 JSON (diff) を記録し、セッション結果画面で色分け表示に使用する。",
+  "maturity": "draft",
+  "createdAt": "2026-05-04T00:00:00.000Z",
+  "updatedAt": "2026-05-04T00:00:00.000Z",
+  "physicalName": "pronunciation_scores",
+  "category": "トランザクション",
+  "comment": "発音スコアテーブル。セリフ × セッションの採点結果を管理する。",
+  "columns": [
+    {
+      "id": "col-id",
+      "no": 1,
+      "physicalName": "id",
+      "name": "スコアID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "primaryKey": true,
+      "autoIncrement": true,
+      "comment": "サロゲートキー。@conv.numbering.scoreId で採番規約を定義"
+    },
+    {
+      "id": "col-session-id",
+      "no": 2,
+      "physicalName": "session_id",
+      "name": "セッションID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "comment": "所属学習セッション (learning_sessions.id 参照)"
+    },
+    {
+      "id": "col-dialogue-line-id",
+      "no": 3,
+      "physicalName": "dialogue_line_id",
+      "name": "セリフID",
+      "dataType": "BIGINT",
+      "notNull": true,
+      "comment": "採点対象セリフ (dialogue_lines.id 参照)"
+    },
+    {
+      "id": "col-score",
+      "no": 4,
+      "physicalName": "score",
+      "name": "発音スコア",
+      "dataType": "DECIMAL",
+      "length": 5,
+      "scale": 2,
+      "notNull": true,
+      "comment": "発音採点スコア (0.00〜100.00)。@conv.extensionCategories.cefr.passingThreshold と比較",
+      "description": "fieldType: english-learning:pronunciationScore。SttEvaluate step の出力 EvaluationResult.score に対応する。"
+    },
+    {
+      "id": "col-diff",
+      "no": 5,
+      "physicalName": "diff",
+      "name": "音素差分",
+      "dataType": "JSON",
+      "notNull": false,
+      "comment": "音素単位の正誤判定リスト (PhoneDiff[])。実装側で IPA テーブル + 色分け表示",
+      "description": "PhoneDiff 構造: { phone: string, expected: string, actual: string, correct: boolean }[]. english-learning:EvaluationResult responseType の diff フィールドに対応する。"
+    },
+    {
+      "id": "col-audio-url",
+      "no": 6,
+      "physicalName": "audio_url",
+      "name": "録音音声 URL",
+      "dataType": "VARCHAR",
+      "length": 500,
+      "notNull": false,
+      "comment": "ユーザーが録音した音声ファイルの URL (STT 送信後に保存)",
+      "description": "fieldType: english-learning:audioUrl。ブラウザ MediaRecorder API で録音、終了後 audioUrl を SttEvaluate step に POST する。"
+    },
+    {
+      "id": "col-created-at",
+      "no": 7,
+      "physicalName": "created_at",
+      "name": "採点日時",
+      "dataType": "TIMESTAMP",
+      "notNull": true,
+      "defaultValue": "CURRENT_TIMESTAMP",
+      "comment": "採点実施日時"
+    },
+    {
+      "id": "col-updated-at",
+      "no": 8,
+      "physicalName": "updated_at",
+      "name": "更新日時",
+      "dataType": "TIMESTAMP",
+      "notNull": true,
+      "defaultValue": "CURRENT_TIMESTAMP",
+      "comment": "最終更新日時"
+    }
+  ],
+  "constraints": [
+    {
+      "id": "fk-session-id",
+      "kind": "foreignKey",
+      "physicalName": "fk_pronunciation_scores_session_id",
+      "columnIds": ["col-session-id"],
+      "referencedTableId": "d524cba6-0878-4cf5-ba70-deaa7b459103",
+      "referencedColumnIds": ["col-id"],
+      "onDelete": "cascade",
+      "description": "セッションが削除されたらスコアも削除"
+    },
+    {
+      "id": "fk-dialogue-line-id",
+      "kind": "foreignKey",
+      "physicalName": "fk_pronunciation_scores_dialogue_line_id",
+      "columnIds": ["col-dialogue-line-id"],
+      "referencedTableId": "246a3f13-7888-4b14-ad6d-641b7437b09d",
+      "referencedColumnIds": ["col-id"],
+      "onDelete": "restrict",
+      "description": "スコアが紐付くセリフは削除不可"
+    },
+    {
+      "id": "chk-score",
+      "kind": "check",
+      "physicalName": "chk_pronunciation_scores_score",
+      "expression": "score >= 0 AND score <= 100",
+      "description": "発音スコアは 0〜100 の範囲"
+    }
+  ],
+  "indexes": [
+    {
+      "id": "idx-session-id",
+      "physicalName": "idx_pronunciation_scores_session_id",
+      "columns": [{ "columnId": "col-session-id", "order": "asc" }],
+      "method": "btree",
+      "description": "セッション別スコア一覧取得インデックス"
+    },
+    {
+      "id": "idx-dialogue-line-id",
+      "physicalName": "idx_pronunciation_scores_dialogue_line_id",
+      "columns": [{ "columnId": "col-dialogue-line-id", "order": "asc" }],
+      "method": "btree",
+      "description": "セリフ別スコア集計インデックス"
+    }
+  ]
+}


### PR DESCRIPTION
## 関連

Closes part of #787
仕様: docs/spec/examples-english-learning.md §2.4 (テーブル一覧) / §2.5 (拡張 namespace) / §2.6 (conventions catalog)

## 概要

英会話学習アプリサンプル (#787) の子 2 スコープ。業務データ層 (テーブル 10 件 / 拡張 namespace / 規約カタログ / project.json 雛形 / README) を新規作成する。B2C + 外部 AI 連携系サンプルとして retail と並列配置する正本サンプル。

## 主な変更

- **テーブル定義 10 件** — マスタ 6 (users / content_packs / stories / scenes / dialogue_lines / words) + トランザクション 4 (learning_sessions / turn_logs / pronunciation_scores / user_word_progress)。FK / INDEX / CHECK 制約付き。
- **拡張 namespace `english-learning`** — fieldTypes (ipa / cefrLevel / audioUrl / pronunciationScore / dialogTurn) / stepKinds (LlmDialog / TtsGenerate / SttEvaluate) / responseTypes (DialogTurn / EvaluationResult / SessionSummary) / actionTriggers / dbOperations / screenKinds を v3 canonical combined format に統合
- **conventions/catalog.json** — 採番 2 規約 + regex.ipa + メッセージ 5 件 + 境界値 2 件 + 認証 / DB / TX 方針 + 拡張カテゴリ (CEFR 昇格閾値 / 単語習熟閾値)
- **project.json 雛形** — maturity=draft、extensionsApplied に english-learning を登録、tables[] 10 件一覧
- **process-flows/cc173367 (骨格)** — validate:samples の必須リソース要件を満たすための学習セッション開始フロー (子 4 で詳細実装予定)
- **README.md** — retail と同フォーマット

## 仕様逐条突合 (自己申告)

- §2.4 テーブル一覧 10 件
  - users → tables/c7e50462-bbc4-498f-a280-2ec40bda30b1.json: CEFR レベル / streak_days / interests (JSON 配列) ✓
  - content_packs → tables/517d50a3-960f-42ce-810f-3b126398d7b1.json: namespace_ref で拡張紐付け ✓
  - stories → tables/b5aa3e1b-b5e4-46dd-8373-75fea340844b.json: pack_id FK / cefr_level / sort_order ✓
  - scenes → tables/992ac5db-54fa-4eb0-9509-66b3babbdef6.json: story_id FK / sort_order ✓
  - dialogue_lines → tables/246a3f13-7888-4b14-ad6d-641b7437b09d.json: 英文+訳+IPA+audio_url / description 待避注記 ✓
  - words → tables/8db75844-19ca-4e7d-8293-579e7631c5cc.json: 品詞+訳+IPA+例文+cefr_level ✓
  - learning_sessions → tables/d524cba6-0878-4cf5-ba70-deaa7b459103.json: (user_id, story_id, started_at) / status / score_avg ✓
  - turn_logs → tables/4e126323-4ab7-4747-961b-23cbaf651314.json: LLM 入出力 JSON / ai_audio_url / description 待避注記 ✓
  - pronunciation_scores → tables/fefa79cf-4721-4956-86bb-595427bf6f81.json: score 0-100 / diff JSON / audio_url ✓
  - user_word_progress → tables/7ab2cf24-7b66-47aa-a808-7fffd8290480.json: (user_id, word_id) UNIQUE / status: new/learning/mastered ✓
- §2.5 fieldTypes — kinds camelCase: ipa/cefrLevel/audioUrl/pronunciationScore/dialogTurn → extensions/english-learning.v3.json:7-50 ✓
- §2.5 stepKinds — keys PascalCase 必須、CustomStepKind (label/icon/description/schema/outputType): LlmDialog/TtsGenerate/SttEvaluate → extensions/english-learning.v3.json:51-142 ✓
- §2.5 outputType は outputSchema ではなく outputType フィールド名 → extensions/english-learning.v3.json:109,130,141 ✓
- §2.5 screenKinds camelCase: conversationPlayer → extensions/english-learning.v3.json:173-180 ✓
- §2.5 responseTypes PascalCase keys: DialogTurn/EvaluationResult/SessionSummary → extensions/english-learning.v3.json:143-171 ✓
- §2.5 dbOperations UPPER_SNAKE_CASE: UPSERT_WORD_PROGRESS/INCREMENT_STREAK/UPDATE_SESSION_STATUS → extensions/english-learning.v3.json:37-58 ✓
- §2.5 actionTriggers camelCase: sessionCompleted/pronunciationScored/wordMastered → extensions/english-learning.v3.json:23-36 ✓
- §2.6 conventions 7 規約
  - numbering.session-id → conventions/catalog.json:14-22 (フォーマット: SES-YYYYMMDD-NNNNNN) ✓
  - numbering.score-id → conventions/catalog.json:23-30 (フォーマット: SCO-NNNNNNNN) ✓
  - regex.ipa → conventions/catalog.json:32-38 ✓
  - cefr.passing-threshold → conventions/catalog.json:83-88 (値: 70) ✓
  - messages.session-not-found → conventions/catalog.json:41-46 ✓
  - messages.pronunciation-low → conventions/catalog.json:47-53 ✓
  - wordProgress.masteryThreshold → conventions/catalog.json:89-95 (値: 3) ✓
- §3.1 ID 規約 — top-level entity は UUID v4 (crypto.randomUUID() 生成) / LocalId は kebab-case / 物理名は snake_case ✓
- §3.4 schemas/v3 変更なし ✓

## レビューで特に見てほしい箇所

1. **extensions の outputType フィールド** — schemas/v3/extensions.v3.schema.json の CustomStepKind は `outputType: FieldType` (common.v3 の $defs/FieldType を参照)。`{ kind: "extension", extensionRef: "english-learning:cefrLevel" }` 形式が FieldType スキーマに合っているか確認を推奨
2. **conventions の extensionCategories** — `conventions.v3.schema.json` の `extensionCategories` は `additionalProperties: { type: object, additionalProperties: true }` なので自由形式で問題ないはずだが、`validate:samples` で警告が出ないか確認
3. **ProcessFlow 骨格の step id 形式** — `step-01` 等の kebab-case を使用 (spec §3.1 に準拠)

## テスト

- Vitest: N/A (JSON ファイルのみ、実装コード変更なし)
- Playwright: N/A (UI 影響なし)
- MCP E2E: N/A
- AJV validate:samples: 1 / 1 flows passed / 13 validators pass

## UI 影響 / AI smoke test

- [x] UI 影響なし (auto テスト pass のみ)

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

- 子 2 のスコープは業務データ層のみ (画面/ProcessFlow 詳細は子 3/4)
- validate:samples 必須要件 (ProcessFlow 1 件以上) のためセッション開始フローの骨格を追加した。子 4 で詳細実装が入り上書きされる前提
- テーブル間の FK は `referencedTableId` に UUID を使用 (物理名直書きは廃止済み、table.v3.schema.json §ForeignKeyConstraint 準拠)
- 子 3 (screens) で参照するテーブル ID 一覧: users=c7e50462 / stories=b5aa3e1b / learning_sessions=d524cba6 / words=8db75844 / user_word_progress=7ab2cf24 / pronunciation_scores=fefa79cf