### PR TITLE
feat(samples): 英会話学習アプリ 業務処理層 + 一覧 viewer 追加 (#787 子 4)

### DIFF
--- a/examples/english-learning/process-flows/21c25fb2-551a-483f-b32a-060db8f88aee.json
+++ b/examples/english-learning/process-flows/21c25fb2-551a-483f-b32a-060db8f88aee.json
@@ -1,0 +1,244 @@
+{
+  "$schema": "../../../schemas/v3/process-flow.v3.schema.json",
+  "meta": {
+    "id": "21c25fb2-551a-483f-b32a-060db8f88aee",
+    "name": "単語習熟度更新",
+    "description": "会話練習中にユーザーが単語を正解 / 練習したタイミングで呼び出す共通フロー (S-4)。user_word_progress に (user_id, word_id) で UPSERT し、correct_count / attempt_count / status を更新する。@conv.extensionCategories.wordProgress.masteryThreshold 回の連続正解で status を 'mastered' に昇格させ、wordMastered トリガーを発行する。複数画面 (会話プレイ / 単語帳) から共通呼び出しされる common フロー。",
+    "kind": "common",
+    "maturity": "draft",
+    "createdAt": "2026-05-04T00:00:00.000Z",
+    "updatedAt": "2026-05-04T00:00:00.000Z"
+  },
+  "context": {
+    "catalogs": {
+      "errors": {
+        "WORD_NOT_FOUND": {
+          "httpStatus": 404,
+          "defaultMessage": "指定の単語が見つかりません。",
+          "responseId": "404-word-not-found",
+          "description": "wordId に対応する単語が words テーブルに存在しない場合。"
+        }
+      },
+      "events": {
+        "el.word.mastered": {
+          "description": "user_word_progress.status が 'mastered' に遷移した直後に発行する。習熟達成バッジ表示や通知送信に使用する。",
+          "payload": {
+            "type": "object",
+            "required": ["userId", "wordId"],
+            "properties": {
+              "userId": { "type": "number" },
+              "wordId": { "type": "number" }
+            }
+          }
+        }
+      }
+    },
+    "ambientVariables": [
+      {
+        "name": "sessionUserId",
+        "type": "integer",
+        "required": true,
+        "description": "ログイン中のユーザー ID (JWT から取得)。"
+      }
+    ]
+  },
+  "actions": [
+    {
+      "id": "act-001",
+      "name": "単語習熟度更新実行",
+      "trigger": "auto",
+      "description": "wordId と isCorrect を受け取り、user_word_progress を UPSERT する。mastery 閾値到達で wordMastered イベント発行。",
+      "maturity": "draft",
+      "httpRoute": {
+        "method": "POST",
+        "path": "/api/el/vocabulary/progress",
+        "auth": "required"
+      },
+      "inputs": [
+        {
+          "name": "wordId",
+          "label": "単語ID",
+          "type": "integer",
+          "required": true,
+          "description": "習熟度を更新する単語 ID (words.id)。"
+        },
+        {
+          "name": "isCorrect",
+          "label": "正解フラグ",
+          "type": "boolean",
+          "required": true,
+          "description": "今回の練習が正解だったかどうか。true で correct_count を加算。"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "newStatus",
+          "label": "更新後ステータス",
+          "type": "string",
+          "description": "更新後の status (new / learning / mastered)。"
+        },
+        {
+          "name": "mastered",
+          "label": "習熟達成フラグ",
+          "type": "boolean",
+          "description": "今回の更新で status が 'mastered' になった場合 true。"
+        }
+      ],
+      "responses": [
+        {
+          "id": "200-ok",
+          "status": 200,
+          "bodySchema": {
+            "schema": {
+              "type": "object",
+              "required": ["newStatus", "mastered"],
+              "properties": {
+                "newStatus": { "type": "string" },
+                "mastered": { "type": "boolean" }
+              },
+              "additionalProperties": false
+            }
+          },
+          "description": "習熟度更新成功。更新後ステータスと習熟達成フラグを返す。",
+          "when": "user_word_progress UPSERT が正常完了した場合。"
+        },
+        {
+          "id": "404-word-not-found",
+          "status": 404,
+          "bodySchema": {
+            "schema": {
+              "type": "object",
+              "required": ["error"],
+              "properties": { "error": { "type": "string" } },
+              "additionalProperties": false
+            }
+          },
+          "description": "単語未存在。",
+          "when": "words テーブルに wordId が存在しない場合。"
+        }
+      ],
+      "steps": [
+        {
+          "id": "step-01",
+          "kind": "dbAccess",
+          "description": "words テーブルで単語存在確認。",
+          "tableId": "8db75844-19ca-4e7d-8293-579e7631c5cc",
+          "operation": "SELECT",
+          "sql": "SELECT id FROM words WHERE id = @wordId",
+          "outputBinding": { "name": "wordRow" },
+          "lineage": {
+            "reads": [
+              { "tableId": "8db75844-19ca-4e7d-8293-579e7631c5cc", "purpose": "validate" }
+            ]
+          }
+        },
+        {
+          "id": "step-02",
+          "kind": "branch",
+          "description": "単語存在チェック。",
+          "branches": [
+            {
+              "id": "br-no-word",
+              "code": "A",
+              "label": "単語未存在",
+              "condition": {
+                "kind": "expression",
+                "expression": "@wordRow == null || @wordRow.length == 0"
+              },
+              "steps": [
+                {
+                  "id": "step-02a",
+                  "kind": "return",
+                  "description": "404 — 単語未存在。",
+                  "responseId": "404-word-not-found",
+                  "bodyExpression": "{ error: '指定の単語が見つかりません。' }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-word-ok",
+            "code": "B",
+            "label": "単語存在",
+            "description": "続行。",
+            "steps": []
+          }
+        },
+        {
+          "id": "step-03",
+          "kind": "dbAccess",
+          "description": "現在の user_word_progress を取得する。未存在の場合は新規作成準備のため null を許容する。",
+          "tableId": "7ab2cf24-7b66-47aa-a808-7fffd8290480",
+          "operation": "SELECT",
+          "sql": "SELECT id, status, correct_count, attempt_count FROM user_word_progress WHERE user_id = @sessionUserId AND word_id = @wordId",
+          "outputBinding": { "name": "currentProgress" },
+          "lineage": {
+            "reads": [
+              { "tableId": "7ab2cf24-7b66-47aa-a808-7fffd8290480", "purpose": "lookup" }
+            ]
+          }
+        },
+        {
+          "id": "step-04",
+          "kind": "dbAccess",
+          "description": "user_word_progress を UPSERT する (english-learning:UPSERT_WORD_PROGRESS)。新規の場合は status='new' で INSERT、既存の場合は correct_count / attempt_count / status / last_practiced_at を更新する。mastery 閾値 (conventions.extensionCategories.wordProgress.masteryThreshold = 3) 以上の連続正解で status='mastered' に昇格する。",
+          "tableId": "7ab2cf24-7b66-47aa-a808-7fffd8290480",
+          "operation": "english-learning:UPSERT_WORD_PROGRESS",
+          "sql": "INSERT INTO user_word_progress (user_id, word_id, status, correct_count, attempt_count, last_practiced_at, updated_at) VALUES (@sessionUserId, @wordId, 'new', CASE WHEN @isCorrect THEN 1 ELSE 0 END, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP) ON CONFLICT (user_id, word_id) DO UPDATE SET attempt_count = user_word_progress.attempt_count + 1, correct_count = CASE WHEN @isCorrect THEN user_word_progress.correct_count + 1 ELSE user_word_progress.correct_count END, status = CASE WHEN @isCorrect AND (user_word_progress.correct_count + 1) >= 3 THEN 'mastered' WHEN user_word_progress.status != 'mastered' THEN 'learning' ELSE user_word_progress.status END, last_practiced_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP RETURNING id, status, correct_count, attempt_count",
+          "outputBinding": { "name": "updatedProgress" },
+          "lineage": {
+            "writes": [
+              { "tableId": "7ab2cf24-7b66-47aa-a808-7fffd8290480", "purpose": "update" }
+            ]
+          }
+        },
+        {
+          "id": "step-05",
+          "kind": "compute",
+          "description": "今回の更新で status が mastered になったかを判定する。以前が mastered 以外で今回が mastered になった場合のみ true。",
+          "expression": "@updatedProgress[0].status == 'mastered' && (@currentProgress == null || @currentProgress.length == 0 || @currentProgress[0].status != 'mastered')",
+          "outputBinding": { "name": "mastered" }
+        },
+        {
+          "id": "step-06",
+          "kind": "branch",
+          "description": "習熟達成した場合のみ wordMastered イベントを発行する。",
+          "branches": [
+            {
+              "id": "br-mastered",
+              "code": "A",
+              "label": "習熟達成",
+              "condition": {
+                "kind": "expression",
+                "expression": "@mastered == true"
+              },
+              "steps": [
+                {
+                  "id": "step-06a",
+                  "kind": "eventPublish",
+                  "description": "単語習熟達成イベントを発行する。習熟達成バッジ表示や通知送信をトリガーする (actionTrigger: wordMastered)。",
+                  "topic": "el.word.mastered",
+                  "payload": "{ userId: @sessionUserId, wordId: @wordId }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-not-mastered",
+            "code": "B",
+            "label": "習熟未達",
+            "description": "イベント発行なし。",
+            "steps": []
+          }
+        },
+        {
+          "id": "step-07",
+          "kind": "return",
+          "description": "200 OK — 更新後ステータスと習熟達成フラグを返す。",
+          "responseId": "200-ok",
+          "bodyExpression": "{ newStatus: @updatedProgress[0].status, mastered: @mastered }"
+        }
+      ]
+    }
+  ]
+}

--- a/examples/english-learning/process-flows/3c4d9bfd-f648-4875-a135-a04e709a87a7.json
+++ b/examples/english-learning/process-flows/3c4d9bfd-f648-4875-a135-a04e709a87a7.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "../../../schemas/v3/process-flow.v3.schema.json",
+  "meta": {
+    "id": "3c4d9bfd-f648-4875-a135-a04e709a87a7",
+    "name": "連続学習日数リセット",
+    "description": "毎日 00:00 (UTC+9 / JST) に実行するスケジュールフロー。前日 24 時間以内に学習セッションを完了していないユーザーの users.streak_days を 0 にリセットする。バッチ UPDATE で対象ユーザーを一括処理する。仕様書 3.3 節の「連続学習日数の自動リセット job」に対応 (scheduled flow で定義のみ、実装は後段の LLM が担当)。",
+    "kind": "scheduled",
+    "maturity": "draft",
+    "createdAt": "2026-05-04T00:00:00.000Z",
+    "updatedAt": "2026-05-04T00:00:00.000Z"
+  },
+  "context": {
+    "catalogs": {
+      "errors": {
+        "STREAK_RESET_FAILED": {
+          "httpStatus": 500,
+          "defaultMessage": "連続学習日数リセット処理に失敗しました。",
+          "description": "streak_days UPDATE が失敗した場合。ジョブ管理システムに通知しリトライする。"
+        }
+      },
+      "events": {
+        "el.streak.reset": {
+          "description": "streak_days をリセットした際に発行する。影響ユーザー数を payload に含め、監視ダッシュボードで件数を確認できるようにする。",
+          "payload": {
+            "type": "object",
+            "required": ["affectedCount", "executedAt"],
+            "properties": {
+              "affectedCount": { "type": "number" },
+              "executedAt": { "type": "string" }
+            }
+          }
+        }
+      }
+    }
+  },
+  "actions": [
+    {
+      "id": "act-001",
+      "name": "連続日数リセット実行",
+      "trigger": "timer",
+      "description": "毎日 00:00 JST にスケジュール実行される。24 時間以内に learning_sessions (status='completed') が存在しないユーザーの streak_days を 0 にリセットする。cron 設定: '0 0 * * *' (UTC 15:00 = JST 00:00)。MVP では定義のみ、実際の cron 登録は実装側で行う (3.3 節 description 待避)。",
+      "maturity": "draft",
+      "steps": [
+        {
+          "id": "step-01",
+          "kind": "dbAccess",
+          "description": "前日 24 時間以内に学習セッション (status='completed') が存在しないユーザーの streak_days を 0 にリセットする。サブクエリで対象ユーザーを抽出し、一括 UPDATE する。",
+          "tableId": "c7e50462-bbc4-498f-a280-2ec40bda30b1",
+          "operation": "UPDATE",
+          "sql": "UPDATE users SET streak_days = 0, updated_at = CURRENT_TIMESTAMP WHERE streak_days > 0 AND id NOT IN (SELECT DISTINCT user_id FROM learning_sessions WHERE status = 'completed' AND completed_at >= CURRENT_TIMESTAMP - INTERVAL '24 hours')",
+          "outputBinding": { "name": "resetResult" },
+          "affectedRowsCheck": {
+            "operator": ">=",
+            "expected": 0,
+            "onViolation": "log",
+            "description": "0 件でも正常 (全ユーザーが前日学習した場合)。エラーにはしない。"
+          },
+          "lineage": {
+            "reads": [
+              { "tableId": "d524cba6-0878-4cf5-ba70-deaa7b459103", "purpose": "lookup" }
+            ],
+            "writes": [
+              { "tableId": "c7e50462-bbc4-498f-a280-2ec40bda30b1", "purpose": "update" }
+            ]
+          }
+        },
+        {
+          "id": "step-02",
+          "kind": "log",
+          "description": "リセット処理の結果をログに記録する。",
+          "level": "info",
+          "message": "連続学習日数リセット完了",
+          "structuredData": {
+            "affectedCount": "@resetResult.affectedRows"
+          }
+        },
+        {
+          "id": "step-03",
+          "kind": "eventPublish",
+          "description": "streak リセットイベントを発行し、影響件数を監視システムに通知する。",
+          "topic": "el.streak.reset",
+          "payload": "{ affectedCount: @resetResult.affectedRows, executedAt: CURRENT_TIMESTAMP }"
+        }
+      ]
+    }
+  ]
+}

--- a/examples/english-learning/process-flows/6a49b14b-eb90-45bd-9df0-df4b5986626b.json
+++ b/examples/english-learning/process-flows/6a49b14b-eb90-45bd-9df0-df4b5986626b.json
@@ -1,0 +1,369 @@
+{
+  "$schema": "../../../schemas/v3/process-flow.v3.schema.json",
+  "meta": {
+    "id": "6a49b14b-eb90-45bd-9df0-df4b5986626b",
+    "name": "発音採点",
+    "description": "ユーザーが録音した音声を STT + 評価 API (english-learning:SttEvaluate) に送信し、発音スコアを算出して pronunciation_scores に INSERT する (S-3)。スコア保存後、learning_sessions のセッション平均スコア (score_avg) を更新する。TX 境界で scores INSERT + sessions UPDATE を原子的に実行する。@conv.extensionCategories.cefr.passingThreshold を下回ったセッションは pronunciationScored トリガーを発行し、UI 側でメッセージを表示する。発音採点フィードバック UI (diff フィールドの PhoneDiff[] 音素単位色分け表示) は実装側で処理する (description 待避、3.3 節)。",
+    "kind": "screen",
+    "screenId": "a9d8eb6f-065d-4af6-ac9a-cc1fcf10b2b7",
+    "maturity": "draft",
+    "createdAt": "2026-05-04T00:00:00.000Z",
+    "updatedAt": "2026-05-04T00:00:00.000Z"
+  },
+  "context": {
+    "catalogs": {
+      "errors": {
+        "SESSION_NOT_FOUND": {
+          "httpStatus": 404,
+          "defaultMessage": "@conv.msg.sessionNotFound",
+          "responseId": "404-session-not-found",
+          "description": "sessionId に対応する in_progress セッションが存在しない場合。"
+        },
+        "DIALOGUE_LINE_NOT_FOUND": {
+          "httpStatus": 404,
+          "defaultMessage": "指定のセリフが見つかりません。",
+          "responseId": "404-line-not-found",
+          "description": "dialogueLineId に対応するセリフが存在しない場合。"
+        },
+        "STT_EVALUATE_FAILED": {
+          "httpStatus": 502,
+          "defaultMessage": "発音評価の取得に失敗しました。しばらく待ってから再試行してください。",
+          "responseId": "502-stt-failed",
+          "description": "english-learning:SttEvaluate step が外部 STT/評価 API から正常応答を得られなかった場合。"
+        },
+        "SCORE_INSERT_FAILED": {
+          "httpStatus": 422,
+          "defaultMessage": "発音スコアの保存に失敗しました。",
+          "responseId": "422-score-failed",
+          "description": "pronunciation_scores INSERT または learning_sessions UPDATE に失敗した場合。TX がロールバックされる。"
+        }
+      },
+      "events": {
+        "el.pronunciation.scored": {
+          "description": "発音採点が完了し、pronunciation_scores に保存された直後に発行する。採点結果 UI 更新とセッション平均スコア再計算をトリガーする。",
+          "payload": {
+            "type": "object",
+            "required": ["sessionId", "scoreId", "score"],
+            "properties": {
+              "sessionId": { "type": "number" },
+              "scoreId": { "type": "number" },
+              "score": { "type": "number" }
+            }
+          }
+        }
+      }
+    },
+    "ambientVariables": [
+      {
+        "name": "sessionUserId",
+        "type": "integer",
+        "required": true,
+        "description": "ログイン中のユーザー ID (JWT から取得)。"
+      }
+    ]
+  },
+  "actions": [
+    {
+      "id": "act-001",
+      "name": "発音採点実行",
+      "trigger": "submit",
+      "description": "録音音声 URL とターゲットセリフ ID を受け取り、STT 評価 API でスコアを算出し、TX でスコアと平均を保存する。",
+      "maturity": "draft",
+      "httpRoute": {
+        "method": "POST",
+        "path": "/api/el/sessions/:sessionId/scores",
+        "auth": "required"
+      },
+      "inputs": [
+        {
+          "name": "sessionId",
+          "label": "セッションID",
+          "type": "integer",
+          "required": true,
+          "description": "URL パスパラメータ。採点対象の学習セッション ID。"
+        },
+        {
+          "name": "dialogueLineId",
+          "label": "セリフID",
+          "type": "integer",
+          "required": true,
+          "description": "採点対象のセリフ ID (dialogue_lines.id)。リファレンステキストと IPA の取得に使用する。"
+        },
+        {
+          "name": "audioUrl",
+          "label": "録音音声 URL",
+          "type": "string",
+          "required": true,
+          "description": "ユーザーが録音した音声ファイルの URL。ブラウザ MediaRecorder API で録音し、サーバーにアップロード済みの URL を渡す。"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "scoreId",
+          "label": "スコアID",
+          "type": "integer",
+          "description": "pronunciation_scores に挿入されたスコアの ID。@conv.numbering.scoreId で採番。"
+        },
+        {
+          "name": "score",
+          "label": "発音スコア",
+          "type": "number",
+          "description": "SttEvaluate が算出した発音総合スコア (0〜100)。"
+        },
+        {
+          "name": "diff",
+          "label": "音素差分",
+          "type": { "kind": "array", "itemType": "json" },
+          "description": "音素単位の正誤判定リスト (PhoneDiff[])。実装側で IPA テーブル + 色分け表示する (description 待避)。"
+        }
+      ],
+      "responses": [
+        {
+          "id": "201-created",
+          "status": 201,
+          "bodySchema": {
+            "schema": {
+              "type": "object",
+              "required": ["scoreId", "score"],
+              "properties": {
+                "scoreId": { "type": "integer" },
+                "score": { "type": "number" },
+                "diff": {
+                  "type": "array",
+                  "items": { "type": "object", "additionalProperties": true }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "description": "採点成功。scoreId + score + diff を返す。",
+          "when": "STT 評価 + pronunciation_scores INSERT + score_avg 更新が正常完了した場合。"
+        },
+        {
+          "id": "404-session-not-found",
+          "status": 404,
+          "bodySchema": {
+            "schema": {
+              "type": "object",
+              "required": ["error"],
+              "properties": { "error": { "type": "string" } },
+              "additionalProperties": false
+            }
+          },
+          "description": "セッション未存在。",
+          "when": "sessionId + user_id で in_progress セッションが見つからない場合。"
+        },
+        {
+          "id": "404-line-not-found",
+          "status": 404,
+          "bodySchema": {
+            "schema": {
+              "type": "object",
+              "required": ["error"],
+              "properties": { "error": { "type": "string" } },
+              "additionalProperties": false
+            }
+          },
+          "description": "セリフ未存在。",
+          "when": "dialogue_lines に dialogueLineId が見つからない場合。"
+        },
+        {
+          "id": "502-stt-failed",
+          "status": 502,
+          "bodySchema": {
+            "schema": {
+              "type": "object",
+              "required": ["error"],
+              "properties": { "error": { "type": "string" } },
+              "additionalProperties": false
+            }
+          },
+          "description": "STT 評価 API 失敗。",
+          "when": "SttEvaluate step が外部 API から正常応答を得られなかった場合。"
+        },
+        {
+          "id": "422-score-failed",
+          "status": 422,
+          "bodySchema": {
+            "schema": {
+              "type": "object",
+              "required": ["error"],
+              "properties": { "error": { "type": "string" } },
+              "additionalProperties": false
+            }
+          },
+          "description": "スコア保存失敗。TX ロールバック。",
+          "when": "pronunciation_scores INSERT または learning_sessions score_avg 更新が失敗した場合。"
+        }
+      ],
+      "steps": [
+        {
+          "id": "step-01",
+          "kind": "dbAccess",
+          "description": "learning_sessions からセッション存在確認。sessionUserId と一致し in_progress な行のみ対象とする。",
+          "tableId": "d524cba6-0878-4cf5-ba70-deaa7b459103",
+          "operation": "SELECT",
+          "sql": "SELECT id, story_id FROM learning_sessions WHERE id = @sessionId AND user_id = @sessionUserId AND status = 'in_progress'",
+          "outputBinding": { "name": "sessionRow" },
+          "lineage": {
+            "reads": [
+              { "tableId": "d524cba6-0878-4cf5-ba70-deaa7b459103", "purpose": "validate" }
+            ]
+          }
+        },
+        {
+          "id": "step-02",
+          "kind": "branch",
+          "description": "セッション存在チェック。",
+          "branches": [
+            {
+              "id": "br-no-session",
+              "code": "A",
+              "label": "セッション未存在",
+              "condition": {
+                "kind": "expression",
+                "expression": "@sessionRow == null || @sessionRow.length == 0"
+              },
+              "steps": [
+                {
+                  "id": "step-02a",
+                  "kind": "return",
+                  "description": "404 — セッション未存在。",
+                  "responseId": "404-session-not-found",
+                  "bodyExpression": "{ error: @conv.msg.sessionNotFound }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-session-ok",
+            "code": "B",
+            "label": "セッション存在",
+            "description": "続行。",
+            "steps": []
+          }
+        },
+        {
+          "id": "step-03",
+          "kind": "dbAccess",
+          "description": "dialogue_lines からセリフとリファレンス IPA を取得する。",
+          "tableId": "246a3f13-7888-4b14-ad6d-641b7437b09d",
+          "operation": "SELECT",
+          "sql": "SELECT id, text, ipa FROM dialogue_lines WHERE id = @dialogueLineId",
+          "outputBinding": { "name": "dialogueLine" },
+          "lineage": {
+            "reads": [
+              { "tableId": "246a3f13-7888-4b14-ad6d-641b7437b09d", "purpose": "lookup" }
+            ]
+          }
+        },
+        {
+          "id": "step-04",
+          "kind": "branch",
+          "description": "セリフ存在チェック。",
+          "branches": [
+            {
+              "id": "br-no-line",
+              "code": "A",
+              "label": "セリフ未存在",
+              "condition": {
+                "kind": "expression",
+                "expression": "@dialogueLine == null || @dialogueLine.length == 0"
+              },
+              "steps": [
+                {
+                  "id": "step-04a",
+                  "kind": "return",
+                  "description": "404 — セリフ未存在。",
+                  "responseId": "404-line-not-found",
+                  "bodyExpression": "{ error: '指定のセリフが見つかりません。' }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-line-ok",
+            "code": "B",
+            "label": "セリフ存在",
+            "description": "続行。",
+            "steps": []
+          }
+        },
+        {
+          "id": "step-05",
+          "kind": "english-learning:SttEvaluate",
+          "description": "ユーザー録音音声を STT で認識し、リファレンスセリフと IPA を使って発音スコアを算出する。score (0-100) と音素差分 diff を返す。実装側 STT プロバイダ (Google Speech / Azure Speech 等) が処理し、評価後に EvaluationResult 型で応答する。",
+          "config": {
+            "audioUrl": "@audioUrl",
+            "referenceText": "@dialogueLine[0].text",
+            "referenceIpa": "@dialogueLine[0].ipa"
+          },
+          "outputBinding": { "name": "evalResult" }
+        },
+        {
+          "id": "step-05b",
+          "kind": "compute",
+          "description": "evalResult から score と diff を独立変数に展開し、TX スコープ内の SQL から安全に参照できるようにする。",
+          "expression": "@evalResult.score",
+          "outputBinding": { "name": "pronunciationScore" }
+        },
+        {
+          "id": "step-06",
+          "kind": "transactionScope",
+          "description": "発音スコア INSERT + セッション平均スコア UPDATE を 1 TX で原子的に実行する。",
+          "isolationLevel": "READ_COMMITTED",
+          "rollbackOn": ["SCORE_INSERT_FAILED"],
+          "outputBinding": { "name": "txResult" },
+          "steps": [
+            {
+              "id": "step-06a",
+              "kind": "dbAccess",
+              "description": "pronunciation_scores に発音スコアを INSERT する。@conv.numbering.scoreId で採番 (seq_score_id シーケンス使用)。",
+              "tableId": "fefa79cf-4721-4956-86bb-595427bf6f81",
+              "operation": "INSERT",
+              "sql": "INSERT INTO pronunciation_scores (session_id, dialogue_line_id, audio_url, score, diff, created_at) VALUES (@sessionId, @dialogueLineId, @audioUrl, @pronunciationScore, @evalResult.diff, CURRENT_TIMESTAMP) RETURNING id",
+              "outputBinding": { "name": "newScore" },
+              "txBoundary": { "role": "begin", "txId": "tx-score" },
+              "lineage": {
+                "writes": [
+                  { "tableId": "fefa79cf-4721-4956-86bb-595427bf6f81", "purpose": "insert" }
+                ]
+              }
+            },
+            {
+              "id": "step-06b",
+              "kind": "dbAccess",
+              "description": "learning_sessions の score_avg をセッション内の全 pronunciation_scores の平均で更新する。",
+              "tableId": "d524cba6-0878-4cf5-ba70-deaa7b459103",
+              "operation": "UPDATE",
+              "sql": "UPDATE learning_sessions SET score_avg = (SELECT AVG(score) FROM pronunciation_scores WHERE session_id = @sessionId), updated_at = CURRENT_TIMESTAMP WHERE id = @sessionId",
+              "txBoundary": { "role": "end", "txId": "tx-score" },
+              "lineage": {
+                "reads": [
+                  { "tableId": "fefa79cf-4721-4956-86bb-595427bf6f81", "purpose": "lookup" }
+                ],
+                "writes": [
+                  { "tableId": "d524cba6-0878-4cf5-ba70-deaa7b459103", "purpose": "update" }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "id": "step-07",
+          "kind": "eventPublish",
+          "description": "発音採点完了イベントを発行し、UI の採点結果表示と CEFR 昇格判定をトリガーする。",
+          "topic": "el.pronunciation.scored",
+          "payload": "{ sessionId: @sessionId, scoreId: @newScore.id, score: @pronunciationScore }"
+        },
+        {
+          "id": "step-08",
+          "kind": "return",
+          "description": "201 Created — scoreId + score + diff を返す。score が合格ライン (conventions.extensionCategories.cefr.passingThreshold 参照) を下回る場合、UI 側でメッセージを表示する。",
+          "responseId": "201-created",
+          "bodyExpression": "{ scoreId: @newScore.id, score: @pronunciationScore, diff: @evalResult.diff }"
+        }
+      ]
+    }
+  ]
+}

--- a/examples/english-learning/process-flows/96118ae1-a0ab-401b-8584-dd645a45a81f.json
+++ b/examples/english-learning/process-flows/96118ae1-a0ab-401b-8584-dd645a45a81f.json
@@ -1,0 +1,318 @@
+{
+  "$schema": "../../../schemas/v3/process-flow.v3.schema.json",
+  "meta": {
+    "id": "96118ae1-a0ab-401b-8584-dd645a45a81f",
+    "name": "会話ターン進行",
+    "description": "ユーザーの発話 (テキストまたは音声) を受け取り、LLM に会話リクエストを送信して AI 応答を取得する (S-2)。必要に応じて TTS で応答を音声化し、turn_logs に 1 ターン分のログを INSERT する。LLM 呼び出しは拡張 stepKind english-learning:LlmDialog で表現し、TTS 呼び出しは english-learning:TtsGenerate で表現する。ターン単位 request/response 方式。実装側で SSE / WebSocket による partial response ストリーム表示を行う想定 (description 待避、3.3 節)。",
+    "kind": "screen",
+    "screenId": "a9d8eb6f-065d-4af6-ac9a-cc1fcf10b2b7",
+    "maturity": "draft",
+    "createdAt": "2026-05-04T00:00:00.000Z",
+    "updatedAt": "2026-05-04T00:00:00.000Z"
+  },
+  "context": {
+    "catalogs": {
+      "errors": {
+        "SESSION_NOT_FOUND": {
+          "httpStatus": 404,
+          "defaultMessage": "@conv.msg.sessionNotFound",
+          "responseId": "404-session-not-found",
+          "description": "指定 sessionId に対応する learning_sessions レコードが存在しない、またはステータスが in_progress 以外の場合。"
+        },
+        "LLM_CALL_FAILED": {
+          "httpStatus": 502,
+          "defaultMessage": "AI 応答の取得に失敗しました。しばらく待ってから再試行してください。",
+          "responseId": "502-llm-failed",
+          "description": "english-learning:LlmDialog step が外部 LLM API から正常応答を得られなかった場合。"
+        }
+      },
+      "events": {
+        "el.turn.completed": {
+          "description": "1 会話ターンが正常完了し、turn_logs に INSERT された直後に発行する。",
+          "payload": {
+            "type": "object",
+            "required": ["sessionId", "turnNumber", "role"],
+            "properties": {
+              "sessionId": { "type": "number" },
+              "turnNumber": { "type": "number" },
+              "role": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+    "ambientVariables": [
+      {
+        "name": "sessionUserId",
+        "type": "integer",
+        "required": true,
+        "description": "ログイン中のユーザー ID (JWT から取得)。"
+      }
+    ]
+  },
+  "actions": [
+    {
+      "id": "act-001",
+      "name": "会話ターン送信",
+      "trigger": "submit",
+      "description": "会話プレイ画面で録音またはテキスト入力したユーザー発話を送信し、AI 応答を取得して画面に反映する。LLM 呼び出し (english-learning:LlmDialog) → 任意の TTS 音声化 (english-learning:TtsGenerate) → turn_logs INSERT の順で実行する。",
+      "maturity": "draft",
+      "httpRoute": {
+        "method": "POST",
+        "path": "/api/el/sessions/:sessionId/turns",
+        "auth": "required"
+      },
+      "inputs": [
+        {
+          "name": "sessionId",
+          "label": "セッションID",
+          "type": "integer",
+          "required": true,
+          "description": "URL パスパラメータ。学習セッション ID。"
+        },
+        {
+          "name": "userInput",
+          "label": "ユーザー発話テキスト",
+          "type": "string",
+          "required": true,
+          "description": "ユーザーが入力したテキスト、またはSTT で認識済みテキスト。"
+        },
+        {
+          "name": "turnContext",
+          "label": "会話コンテキスト",
+          "type": "string",
+          "required": false,
+          "description": "直近の会話履歴 (DialogTurn[] の JSON 文字列)。LlmDialog step の context 入力として使用する。"
+        },
+        {
+          "name": "generateAudio",
+          "label": "音声生成フラグ",
+          "type": "boolean",
+          "required": false,
+          "description": "true の場合、AI 応答テキストを TTS で音声化する。省略時は false。"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "aiResponseText",
+          "label": "AI 応答テキスト",
+          "type": "string",
+          "description": "LLM が生成した応答テキスト。"
+        },
+        {
+          "name": "aiAudioUrl",
+          "label": "AI 応答音声 URL",
+          "type": "string",
+          "description": "TTS で生成した AI 応答の音声ファイル URL。generateAudio=false または TTS 未実行の場合は null。"
+        },
+        {
+          "name": "turnId",
+          "label": "ターンログID",
+          "type": "integer",
+          "description": "turn_logs に挿入されたターンログの ID。"
+        }
+      ],
+      "responses": [
+        {
+          "id": "200-ok",
+          "status": 200,
+          "bodySchema": {
+            "schema": {
+              "type": "object",
+              "required": ["aiResponseText", "turnId"],
+              "properties": {
+                "aiResponseText": { "type": "string" },
+                "aiAudioUrl": { "type": ["string", "null"] },
+                "turnId": { "type": "integer" }
+              },
+              "additionalProperties": false
+            }
+          },
+          "description": "ターン正常完了。AI 応答テキスト + ターンログ ID + 任意で音声 URL を返す。",
+          "when": "LLM 呼び出し + turn_logs INSERT が正常完了した場合。"
+        },
+        {
+          "id": "404-session-not-found",
+          "status": 404,
+          "bodySchema": {
+            "schema": {
+              "type": "object",
+              "required": ["error"],
+              "properties": {
+                "error": { "type": "string" }
+              },
+              "additionalProperties": false
+            }
+          },
+          "description": "セッションが存在しない、または in_progress 以外の場合。",
+          "when": "learning_sessions に sessionId + status='in_progress' の行が見つからない場合。"
+        },
+        {
+          "id": "502-llm-failed",
+          "status": 502,
+          "bodySchema": {
+            "schema": {
+              "type": "object",
+              "required": ["error"],
+              "properties": {
+                "error": { "type": "string" }
+              },
+              "additionalProperties": false
+            }
+          },
+          "description": "LLM API 呼び出し失敗。",
+          "when": "english-learning:LlmDialog step が外部 API から正常応答を得られなかった場合。"
+        }
+      ],
+      "steps": [
+        {
+          "id": "step-01",
+          "kind": "dbAccess",
+          "description": "learning_sessions からセッション存在確認。user_id が sessionUserId と一致し、status='in_progress' の行のみ対象とする。",
+          "tableId": "d524cba6-0878-4cf5-ba70-deaa7b459103",
+          "operation": "SELECT",
+          "sql": "SELECT id, story_id, status FROM learning_sessions WHERE id = @sessionId AND user_id = @sessionUserId AND status = 'in_progress'",
+          "outputBinding": { "name": "sessionRow" },
+          "lineage": {
+            "reads": [
+              { "tableId": "d524cba6-0878-4cf5-ba70-deaa7b459103", "purpose": "validate" }
+            ]
+          }
+        },
+        {
+          "id": "step-02",
+          "kind": "branch",
+          "description": "セッション存在チェック。sessionRow が空なら 404 を返す。",
+          "branches": [
+            {
+              "id": "br-session-not-found",
+              "code": "A",
+              "label": "セッション未存在",
+              "condition": {
+                "kind": "expression",
+                "expression": "@sessionRow == null || @sessionRow.length == 0"
+              },
+              "steps": [
+                {
+                  "id": "step-02a",
+                  "kind": "return",
+                  "description": "404 — セッションが見つからない。",
+                  "responseId": "404-session-not-found",
+                  "bodyExpression": "{ error: @conv.msg.sessionNotFound }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-session-ok",
+            "code": "B",
+            "label": "セッション存在",
+            "description": "セッションが存在する場合、LLM 呼び出しに進む。",
+            "steps": []
+          }
+        },
+        {
+          "id": "step-03",
+          "kind": "english-learning:LlmDialog",
+          "description": "OpenAI GPT-4 / Anthropic Claude 等の LLM API を呼び出す。実装側で provider 選択。temperature 0.7 推奨。ストリーム応答は SSE / WebSocket で実装側が処理し、本フローでは完了後のテキストのみ受け取る。",
+          "config": {
+            "context": "@var.turnContext",
+            "userInput": "@var.userInput"
+          },
+          "outputBinding": { "name": "aiResponse" }
+        },
+        {
+          "id": "step-04",
+          "kind": "branch",
+          "description": "音声生成フラグが true の場合のみ TTS を実行する。",
+          "branches": [
+            {
+              "id": "br-tts-on",
+              "code": "A",
+              "label": "音声生成あり",
+              "condition": {
+                "kind": "expression",
+                "expression": "@generateAudio == true"
+              },
+              "steps": [
+                {
+                  "id": "step-04a",
+                  "kind": "english-learning:TtsGenerate",
+                  "description": "LLM の応答テキストを TTS で音声ファイルに変換する。生成した audioUrl を aiAudioUrl 変数に格納し、turn_logs.ai_audio_url として保存する。",
+                  "config": {
+                    "text": "@aiResponse"
+                  },
+                  "outputBinding": { "name": "aiAudioUrl" }
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-tts-off",
+            "code": "B",
+            "label": "音声生成なし",
+            "description": "TTS 不要の場合は aiAudioUrl を null に設定する。",
+            "steps": [
+              {
+                "id": "step-04b",
+                "kind": "compute",
+                "description": "aiAudioUrl を null に設定する。",
+                "expression": "null",
+                "outputBinding": { "name": "aiAudioUrl" }
+              }
+            ]
+          }
+        },
+        {
+          "id": "step-04c",
+          "kind": "dbAccess",
+          "description": "現在のセッションのターン数を取得し、次のターン番号を計算する。(session_id, turn_number) の UNIQUE 制約に対応するため、INSERT 前に現在のターン数を確認する。",
+          "tableId": "4e126323-4ab7-4747-961b-23cbaf651314",
+          "operation": "SELECT",
+          "sql": "SELECT COALESCE(MAX(turn_number), 0) + 1 AS next_turn FROM turn_logs WHERE session_id = @sessionId",
+          "outputBinding": { "name": "turnNumberRow" },
+          "lineage": {
+            "reads": [
+              { "tableId": "4e126323-4ab7-4747-961b-23cbaf651314", "purpose": "lookup" }
+            ]
+          }
+        },
+        {
+          "id": "step-04d",
+          "kind": "compute",
+          "description": "次のターン番号をスカラー変数に展開する。",
+          "expression": "@turnNumberRow[0].next_turn",
+          "outputBinding": { "name": "nextTurnNumber" }
+        },
+        {
+          "id": "step-05",
+          "kind": "dbAccess",
+          "description": "turn_logs に 1 ターン分のログを INSERT する。user_input (ユーザー発話) と ai_response (AI 応答) + ai_audio_url を同時に記録する。llm_context には入力 turnContext と AI 応答を含む更新済み会話コンテキストを JSON として保存する。turn_number は step-04d で算出した次番号を使用する。",
+          "tableId": "4e126323-4ab7-4747-961b-23cbaf651314",
+          "operation": "INSERT",
+          "sql": "INSERT INTO turn_logs (session_id, turn_number, user_input, ai_response, ai_audio_url, llm_context, created_at) VALUES (@sessionId, @nextTurnNumber, @userInput, @aiResponse, @aiAudioUrl, @turnContext, CURRENT_TIMESTAMP) RETURNING id",
+          "outputBinding": { "name": "newTurnLog" },
+          "lineage": {
+            "writes": [
+              { "tableId": "4e126323-4ab7-4747-961b-23cbaf651314", "purpose": "insert" }
+            ]
+          }
+        },
+        {
+          "id": "step-06",
+          "kind": "eventPublish",
+          "description": "ターン完了イベントを発行する。",
+          "topic": "el.turn.completed",
+          "payload": "{ sessionId: @sessionId, turnNumber: @newTurnLog.id, role: 'assistant' }"
+        },
+        {
+          "id": "step-07",
+          "kind": "return",
+          "description": "200 OK — AI 応答テキスト + ターンログ ID + 音声 URL (任意) を返す。",
+          "responseId": "200-ok",
+          "bodyExpression": "{ aiResponseText: @aiResponse, aiAudioUrl: @aiAudioUrl, turnId: @newTurnLog.id }"
+        }
+      ]
+    }
+  ]
+}

--- a/examples/english-learning/process-flows/96118ae1-a0ab-401b-8584-dd645a45a81f.json
+++ b/examples/english-learning/process-flows/96118ae1-a0ab-401b-8584-dd645a45a81f.json
@@ -216,8 +216,8 @@
           "kind": "english-learning:LlmDialog",
           "description": "OpenAI GPT-4 / Anthropic Claude 等の LLM API を呼び出す。実装側で provider 選択。temperature 0.7 推奨。ストリーム応答は SSE / WebSocket で実装側が処理し、本フローでは完了後のテキストのみ受け取る。",
           "config": {
-            "context": "@var.turnContext",
-            "userInput": "@var.userInput"
+            "context": "@turnContext",
+            "userInput": "@userInput"
           },
           "outputBinding": { "name": "aiResponse" }
         },

--- a/examples/english-learning/process-flows/cc173367-d92a-4525-acc9-689bad9a048e.json
+++ b/examples/english-learning/process-flows/cc173367-d92a-4525-acc9-689bad9a048e.json
@@ -5,6 +5,7 @@
     "name": "学習セッション開始",
     "description": "ユーザーがストーリーを選択して学習セッションを開始するフロー (S-1)。learning_sessions に新規セッションを INSERT し、会話プレイ画面遷移用のセッション ID を返す。子 2 で先行実装済 (validate:samples が flows ≥1 を要求するため)。子 4 では本フローを残し、S-2 (会話ターン進行) / S-3 (発音採点) / S-4 (履歴 / 単語復習) / scheduled (連続日数リセット) フローを追加する。",
     "kind": "screen",
+    "screenId": "046e1f83-bed3-4b13-a5ac-b0fa06744dfe",
     "maturity": "draft",
     "createdAt": "2026-05-04T00:00:00.000Z",
     "updatedAt": "2026-05-04T00:00:00.000Z"

--- a/examples/english-learning/project.json
+++ b/examples/english-learning/project.json
@@ -6,7 +6,7 @@
     "name": "英会話学習アプリ",
     "description": "B2C 英会話学習アプリ。ストーリー仕立ての会話練習と AI 採点 (LLM/TTS/STT) を組み合わせ、発音フィードバックと単語習熟度管理を提供する。分野別コンテンツパック (汎用 / IT エンジニア / ビジネス 等) を拡張 namespace で表現し、外部 AI 呼び出しを stepKind 拡張でモデル化する B2C + 外部 AI 連携サンプル (#787)。",
     "createdAt": "2026-05-04T00:00:00.000Z",
-    "updatedAt": "2026-05-04T00:00:00.000Z",
+    "updatedAt": "2026-05-04T12:00:00.000Z",
     "mode": "upstream",
     "maturity": "draft"
   },
@@ -204,7 +204,7 @@
         "id": "tr-detail-to-play",
         "sourceScreenId": "046e1f83-bed3-4b13-a5ac-b0fa06744dfe",
         "targetScreenId": "a9d8eb6f-065d-4af6-ac9a-cc1fcf10b2b7",
-        "label": "学習を開始する (S-1 セッション作成)",
+        "label": "学習を開始する (S-1 セッション作成 → 会話プレイ遷移)",
         "trigger": "click",
         "kind": "navigation"
       },
@@ -212,7 +212,7 @@
         "id": "tr-play-to-result",
         "sourceScreenId": "a9d8eb6f-065d-4af6-ac9a-cc1fcf10b2b7",
         "targetScreenId": "18bcc879-0b84-4e63-9317-37b94e799886",
-        "label": "セッションを終了する (S-3)",
+        "label": "セッションを終了する (S-3 採点完了 → 結果画面遷移)",
         "trigger": "click",
         "kind": "navigation"
       },
@@ -392,10 +392,129 @@
         "actionCount": 1,
         "maturity": "draft",
         "updatedAt": "2026-05-04T00:00:00.000Z"
+      },
+      {
+        "id": "96118ae1-a0ab-401b-8584-dd645a45a81f",
+        "no": 2,
+        "name": "会話ターン進行",
+        "kind": "screen",
+        "actionCount": 1,
+        "maturity": "draft",
+        "updatedAt": "2026-05-04T00:00:00.000Z"
+      },
+      {
+        "id": "6a49b14b-eb90-45bd-9df0-df4b5986626b",
+        "no": 3,
+        "name": "発音採点",
+        "kind": "screen",
+        "actionCount": 1,
+        "maturity": "draft",
+        "updatedAt": "2026-05-04T00:00:00.000Z"
+      },
+      {
+        "id": "21c25fb2-551a-483f-b32a-060db8f88aee",
+        "no": 4,
+        "name": "単語習熟度更新",
+        "kind": "common",
+        "actionCount": 1,
+        "maturity": "draft",
+        "updatedAt": "2026-05-04T00:00:00.000Z"
+      },
+      {
+        "id": "3c4d9bfd-f648-4875-a135-a04e709a87a7",
+        "no": 5,
+        "name": "連続学習日数リセット",
+        "kind": "scheduled",
+        "actionCount": 1,
+        "maturity": "draft",
+        "updatedAt": "2026-05-04T00:00:00.000Z"
       }
     ],
-    "views": [],
-    "viewDefinitions": [],
-    "sequences": []
+    "views": [
+      {
+        "id": "af699800-b15f-4588-9d0d-6a76a3eb2e48",
+        "no": 1,
+        "name": "学習履歴とストーリー結合ビュー",
+        "physicalName": "v_learning_history_with_story",
+        "maturity": "draft",
+        "updatedAt": "2026-05-04T00:00:00.000Z"
+      },
+      {
+        "id": "c0474fbf-d0f4-4cfc-bbcd-0154431df9a2",
+        "no": 2,
+        "name": "習熟度付き単語ビュー",
+        "physicalName": "v_words_with_progress",
+        "maturity": "draft",
+        "updatedAt": "2026-05-04T00:00:00.000Z"
+      },
+      {
+        "id": "54917d0d-3162-43f5-8daf-77abdbbc2771",
+        "no": 3,
+        "name": "セッション別発音平均ビュー",
+        "physicalName": "v_session_pronunciation_avg",
+        "maturity": "draft",
+        "updatedAt": "2026-05-04T00:00:00.000Z"
+      }
+    ],
+    "viewDefinitions": [
+      {
+        "id": "cfdbf081-368d-4a33-8a36-1c7a0c535011",
+        "no": 1,
+        "name": "ストーリー一覧 viewer",
+        "kind": "list",
+        "maturity": "draft",
+        "updatedAt": "2026-05-04T00:00:00.000Z"
+      },
+      {
+        "id": "4c9cdc85-2537-4ca8-a979-4de21a56e0fa",
+        "no": 2,
+        "name": "学習履歴一覧 viewer",
+        "kind": "list",
+        "maturity": "draft",
+        "updatedAt": "2026-05-04T00:00:00.000Z"
+      },
+      {
+        "id": "090e9db0-ce45-4fc4-9fa6-5784f655ca07",
+        "no": 3,
+        "name": "単語帳 viewer",
+        "kind": "list",
+        "maturity": "draft",
+        "updatedAt": "2026-05-04T00:00:00.000Z"
+      },
+      {
+        "id": "ba1c7d9d-5907-4535-99b9-f9fa170bb248",
+        "no": 4,
+        "name": "コンテンツパック一覧 viewer",
+        "kind": "list",
+        "maturity": "draft",
+        "updatedAt": "2026-05-04T00:00:00.000Z"
+      },
+      {
+        "id": "f06e103d-1eb5-4918-9a6d-67436095bfe7",
+        "no": 5,
+        "name": "発音スコア履歴 viewer",
+        "kind": "list",
+        "maturity": "draft",
+        "updatedAt": "2026-05-04T00:00:00.000Z"
+      }
+    ],
+    "sequences": [
+      {
+        "id": "0d9b9b02-cc61-4b26-85c3-ef932bfbe5fd",
+        "no": 1,
+        "name": "セッションID採番",
+        "physicalName": "seq_session_id",
+        "maturity": "draft",
+        "updatedAt": "2026-05-04T00:00:00.000Z"
+      },
+      {
+        "id": "d4160951-3cd6-42dc-b114-9f358ec59c0f",
+        "no": 2,
+        "name": "スコアID採番",
+        "physicalName": "seq_score_id",
+        "maturity": "draft",
+        "updatedAt": "2026-05-04T00:00:00.000Z"
+      }
+    ]
   }
 }

--- a/examples/english-learning/sequences/0d9b9b02-cc61-4b26-85c3-ef932bfbe5fd.json
+++ b/examples/english-learning/sequences/0d9b9b02-cc61-4b26-85c3-ef932bfbe5fd.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../schemas/v3/sequence.v3.schema.json",
+  "id": "0d9b9b02-cc61-4b26-85c3-ef932bfbe5fd",
+  "name": "セッションID採番",
+  "description": "学習セッション開始フロー (S-1) で 1 セッションにつき 1 つのセッション ID を発行するシーケンス。@conv.numbering.sessionId と連動する。採番値は learning_sessions.id の主キーとして使用する。リセットなし (CYCLE=false)。",
+  "maturity": "draft",
+  "createdAt": "2026-05-04T00:00:00.000Z",
+  "updatedAt": "2026-05-04T00:00:00.000Z",
+  "physicalName": "seq_session_id",
+  "startValue": 1,
+  "increment": 1,
+  "minValue": 1,
+  "maxValue": 2147483647,
+  "cycle": false,
+  "cache": 10,
+  "conventionRef": "@conv.numbering.sessionId"
+}

--- a/examples/english-learning/sequences/d4160951-3cd6-42dc-b114-9f358ec59c0f.json
+++ b/examples/english-learning/sequences/d4160951-3cd6-42dc-b114-9f358ec59c0f.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../schemas/v3/sequence.v3.schema.json",
+  "id": "d4160951-3cd6-42dc-b114-9f358ec59c0f",
+  "name": "スコアID採番",
+  "description": "発音採点フロー (S-3) で 1 採点につき 1 つのスコア ID を発行するシーケンス。@conv.numbering.scoreId と連動する。採番値は pronunciation_scores.id の主キーとして使用する。リセットなし (CYCLE=false)。",
+  "maturity": "draft",
+  "createdAt": "2026-05-04T00:00:00.000Z",
+  "updatedAt": "2026-05-04T00:00:00.000Z",
+  "physicalName": "seq_score_id",
+  "startValue": 1,
+  "increment": 1,
+  "minValue": 1,
+  "maxValue": 2147483647,
+  "cycle": false,
+  "cache": 10,
+  "conventionRef": "@conv.numbering.scoreId"
+}

--- a/examples/english-learning/view-definitions/090e9db0-ce45-4fc4-9fa6-5784f655ca07.json
+++ b/examples/english-learning/view-definitions/090e9db0-ce45-4fc4-9fa6-5784f655ca07.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "../../../schemas/v3/view-definition.v3.schema.json",
+  "id": "090e9db0-ce45-4fc4-9fa6-5784f655ca07",
+  "name": "単語帳 viewer",
+  "description": "単語帳画面 (No.8) 向けの一覧 UI viewer 定義。v_words_with_progress ビュー (c0474fbf-...) を Level 3 Raw SQL で参照し、ログインユーザーの習熟度付き単語一覧を表示する。習熟ステータス (new / learning / mastered) でフィルタ可能。単語クリックで詳細画面 (/vocabulary/:wordId) に遷移する。",
+  "maturity": "draft",
+  "createdAt": "2026-05-04T00:00:00.000Z",
+  "updatedAt": "2026-05-04T00:00:00.000Z",
+  "kind": "list",
+  "query": {
+    "sql": "SELECT word_id, word_text, translation, ipa, cefr_level, progress_status, correct_count, attempt_count, last_practiced_at FROM v_words_with_progress WHERE user_id = @param.userId OR user_id IS NULL ORDER BY cefr_level ASC, word_text ASC",
+    "parameterRefs": [
+      {
+        "name": "userId",
+        "fieldType": "integer",
+        "description": "ログインユーザーの ID。画面側から @sessionUserId を渡す。NULL 行 (習熟度未記録) も含めるため IS NULL と OR で結合している。"
+      }
+    ]
+  },
+  "columns": [
+    {
+      "name": "wordText",
+      "type": "string",
+      "displayName": "単語",
+      "width": "160px",
+      "align": "left",
+      "sortable": true,
+      "filterable": true,
+      "linkTo": "/vocabulary/:wordId"
+    },
+    {
+      "name": "translation",
+      "type": "string",
+      "displayName": "日本語訳",
+      "width": "auto",
+      "align": "left",
+      "sortable": false,
+      "filterable": true
+    },
+    {
+      "name": "ipa",
+      "type": "string",
+      "displayName": "IPA",
+      "width": "160px",
+      "align": "left",
+      "sortable": false
+    },
+    {
+      "name": "cefrLevel",
+      "type": "string",
+      "displayName": "CEFR",
+      "width": "80px",
+      "align": "center",
+      "sortable": true,
+      "filterable": true
+    },
+    {
+      "name": "progressStatus",
+      "type": "string",
+      "displayName": "習熟度",
+      "width": "100px",
+      "align": "center",
+      "sortable": true,
+      "filterable": true
+    },
+    {
+      "name": "correctCount",
+      "type": "integer",
+      "displayName": "正解回数",
+      "width": "100px",
+      "align": "right",
+      "sortable": true
+    },
+    {
+      "name": "attemptCount",
+      "type": "integer",
+      "displayName": "練習回数",
+      "width": "100px",
+      "align": "right",
+      "sortable": true
+    },
+    {
+      "name": "lastPracticedAt",
+      "type": "datetime",
+      "displayName": "最終練習日",
+      "displayFormat": "YYYY-MM-DD",
+      "width": "120px",
+      "align": "left",
+      "sortable": true
+    }
+  ],
+  "sortDefaults": [
+    { "columnName": "cefrLevel", "order": "asc" },
+    { "columnName": "wordText", "order": "asc" }
+  ],
+  "filterDefaults": [
+    { "columnName": "progressStatus", "operator": "neq", "value": "mastered" }
+  ],
+  "pageSize": 30
+}

--- a/examples/english-learning/view-definitions/4c9cdc85-2537-4ca8-a979-4de21a56e0fa.json
+++ b/examples/english-learning/view-definitions/4c9cdc85-2537-4ca8-a979-4de21a56e0fa.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "../../../schemas/v3/view-definition.v3.schema.json",
+  "id": "4c9cdc85-2537-4ca8-a979-4de21a56e0fa",
+  "name": "学習履歴一覧 viewer",
+  "description": "学習履歴一覧画面 (No.6) 向けの一覧 UI viewer 定義。v_learning_history_with_story ビュー (af699800-...) を Level 3 Raw SQL で参照し、ログインユーザーの履歴のみを表示する。ストーリータイトル / CEFR レベル / 学習日時 / スコア / ステータスを表示し、行クリックで詳細画面 (/history/:sessionId) に遷移する。",
+  "maturity": "draft",
+  "createdAt": "2026-05-04T00:00:00.000Z",
+  "updatedAt": "2026-05-04T00:00:00.000Z",
+  "kind": "list",
+  "query": {
+    "sql": "SELECT session_id, story_title, cefr_level, started_at, completed_at, score_avg, status, pack_name FROM v_learning_history_with_story WHERE user_id = @param.userId ORDER BY started_at DESC",
+    "parameterRefs": [
+      {
+        "name": "userId",
+        "fieldType": "integer",
+        "description": "ログインユーザーの ID。画面側から @sessionUserId を渡す。"
+      }
+    ]
+  },
+  "columns": [
+    {
+      "name": "sessionId",
+      "type": "integer",
+      "displayName": "セッションID",
+      "width": "100px",
+      "align": "right",
+      "linkTo": "/history/:sessionId"
+    },
+    {
+      "name": "storyTitle",
+      "type": "string",
+      "displayName": "ストーリー",
+      "width": "auto",
+      "align": "left",
+      "sortable": true,
+      "filterable": true
+    },
+    {
+      "name": "cefrLevel",
+      "type": "string",
+      "displayName": "CEFR",
+      "width": "80px",
+      "align": "center",
+      "sortable": true,
+      "filterable": true
+    },
+    {
+      "name": "startedAt",
+      "type": "datetime",
+      "displayName": "学習日時",
+      "displayFormat": "YYYY-MM-DD HH:mm",
+      "width": "160px",
+      "align": "left",
+      "sortable": true
+    },
+    {
+      "name": "scoreAvg",
+      "type": "number",
+      "displayName": "平均スコア",
+      "displayFormat": "#,##0.0",
+      "width": "100px",
+      "align": "right",
+      "sortable": true
+    },
+    {
+      "name": "status",
+      "type": "string",
+      "displayName": "ステータス",
+      "width": "100px",
+      "align": "center",
+      "filterable": true
+    },
+    {
+      "name": "packName",
+      "type": "string",
+      "displayName": "パック",
+      "width": "120px",
+      "align": "left",
+      "filterable": true
+    }
+  ],
+  "sortDefaults": [
+    { "columnName": "startedAt", "order": "desc" }
+  ],
+  "pageSize": 20
+}

--- a/examples/english-learning/view-definitions/ba1c7d9d-5907-4535-99b9-f9fa170bb248.json
+++ b/examples/english-learning/view-definitions/ba1c7d9d-5907-4535-99b9-f9fa170bb248.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "../../../schemas/v3/view-definition.v3.schema.json",
+  "id": "ba1c7d9d-5907-4535-99b9-f9fa170bb248",
+  "name": "コンテンツパック一覧 viewer",
+  "description": "コンテンツパック一覧画面 (No.10) 向けの一覧 UI viewer 定義。content_packs テーブルを主ソースとし、分野別パック (汎用 / IT エンジニア / ビジネス / 旅行 等) の一覧を表示する。is_active=TRUE のパックのみデフォルト表示。",
+  "maturity": "draft",
+  "createdAt": "2026-05-04T00:00:00.000Z",
+  "updatedAt": "2026-05-04T00:00:00.000Z",
+  "kind": "list",
+  "sourceTableId": "517d50a3-960f-42ce-810f-3b126398d7b1",
+  "columns": [
+    {
+      "name": "name",
+      "tableColumnRef": {
+        "tableId": "517d50a3-960f-42ce-810f-3b126398d7b1",
+        "columnId": "col-name"
+      },
+      "displayName": "パック名",
+      "type": "string",
+      "width": "auto",
+      "align": "left",
+      "sortable": true,
+      "filterable": true
+    },
+    {
+      "name": "slug",
+      "tableColumnRef": {
+        "tableId": "517d50a3-960f-42ce-810f-3b126398d7b1",
+        "columnId": "col-slug"
+      },
+      "displayName": "スラッグ",
+      "type": "string",
+      "width": "140px",
+      "align": "left",
+      "sortable": true,
+      "filterable": true
+    },
+    {
+      "name": "namespaceRef",
+      "tableColumnRef": {
+        "tableId": "517d50a3-960f-42ce-810f-3b126398d7b1",
+        "columnId": "col-namespace-ref"
+      },
+      "displayName": "拡張 namespace",
+      "type": "string",
+      "width": "180px",
+      "align": "left",
+      "sortable": false
+    },
+    {
+      "name": "isActive",
+      "tableColumnRef": {
+        "tableId": "517d50a3-960f-42ce-810f-3b126398d7b1",
+        "columnId": "col-is-active"
+      },
+      "displayName": "有効",
+      "type": "boolean",
+      "width": "80px",
+      "align": "center",
+      "sortable": false,
+      "filterable": true
+    }
+  ],
+  "sortDefaults": [
+    { "columnName": "slug", "order": "asc" },
+    { "columnName": "name", "order": "asc" }
+  ],
+  "filterDefaults": [
+    { "columnName": "isActive", "operator": "eq", "value": true }
+  ],
+  "pageSize": 20
+}

--- a/examples/english-learning/view-definitions/cfdbf081-368d-4a33-8a36-1c7a0c535011.json
+++ b/examples/english-learning/view-definitions/cfdbf081-368d-4a33-8a36-1c7a0c535011.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "../../../schemas/v3/view-definition.v3.schema.json",
+  "id": "cfdbf081-368d-4a33-8a36-1c7a0c535011",
+  "name": "ストーリー一覧 viewer",
+  "description": "ストーリー一覧画面 (No.2) 向けの一覧 UI viewer 定義。stories テーブルを主ソースとし、CEFR レベル / コンテンツパック / 推定学習時間でフィルタ可能にする。is_active=TRUE のストーリーのみデフォルト表示し、タイトルクリックで詳細画面 (/stories/:storyId) に遷移する。",
+  "maturity": "draft",
+  "createdAt": "2026-05-04T00:00:00.000Z",
+  "updatedAt": "2026-05-04T00:00:00.000Z",
+  "kind": "list",
+  "sourceTableId": "b5aa3e1b-b5e4-46dd-8373-75fea340844b",
+  "columns": [
+    {
+      "name": "title",
+      "tableColumnRef": {
+        "tableId": "b5aa3e1b-b5e4-46dd-8373-75fea340844b",
+        "columnId": "col-title"
+      },
+      "displayName": "タイトル",
+      "type": "string",
+      "width": "auto",
+      "align": "left",
+      "sortable": true,
+      "filterable": true,
+      "linkTo": "/stories/:id"
+    },
+    {
+      "name": "cefrLevel",
+      "tableColumnRef": {
+        "tableId": "b5aa3e1b-b5e4-46dd-8373-75fea340844b",
+        "columnId": "col-cefr-level"
+      },
+      "displayName": "CEFR",
+      "type": "string",
+      "width": "80px",
+      "align": "center",
+      "sortable": true,
+      "filterable": true
+    },
+    {
+      "name": "isActive",
+      "tableColumnRef": {
+        "tableId": "b5aa3e1b-b5e4-46dd-8373-75fea340844b",
+        "columnId": "col-is-active"
+      },
+      "displayName": "公開中",
+      "type": "boolean",
+      "width": "80px",
+      "align": "center",
+      "sortable": false,
+      "filterable": true
+    }
+  ],
+  "sortDefaults": [
+    { "columnName": "cefrLevel", "order": "asc" }
+  ],
+  "filterDefaults": [
+    { "columnName": "isActive", "operator": "eq", "value": true }
+  ],
+  "pageSize": 20
+}

--- a/examples/english-learning/view-definitions/f06e103d-1eb5-4918-9a6d-67436095bfe7.json
+++ b/examples/english-learning/view-definitions/f06e103d-1eb5-4918-9a6d-67436095bfe7.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "../../../schemas/v3/view-definition.v3.schema.json",
+  "id": "f06e103d-1eb5-4918-9a6d-67436095bfe7",
+  "name": "発音スコア履歴 viewer",
+  "description": "セッション結果画面 (No.5) および学習履歴詳細画面 (No.7) 向けの発音スコア履歴 viewer 定義。v_session_pronunciation_avg ビュー (54917d0d-...) の集計値と、pronunciation_scores の個別レコードを Level 2 Structured で参照する。特定セッションの採点一覧を表示する。",
+  "maturity": "draft",
+  "createdAt": "2026-05-04T00:00:00.000Z",
+  "updatedAt": "2026-05-04T00:00:00.000Z",
+  "kind": "list",
+  "query": {
+    "from": {
+      "tableId": "fefa79cf-4721-4956-86bb-595427bf6f81",
+      "alias": "ps"
+    },
+    "joins": [
+      {
+        "kind": "INNER",
+        "tableId": "246a3f13-7888-4b14-ad6d-641b7437b09d",
+        "alias": "dl",
+        "on": ["ps.dialogue_line_id = dl.id"]
+      }
+    ],
+    "where": ["ps.session_id = @param.sessionId"],
+    "orderBy": ["ps.created_at ASC"]
+  },
+  "columns": [
+    {
+      "name": "scoreId",
+      "tableColumnRef": {
+        "tableId": "fefa79cf-4721-4956-86bb-595427bf6f81",
+        "columnId": "col-id"
+      },
+      "displayName": "採点ID",
+      "type": "integer",
+      "width": "80px",
+      "align": "right"
+    },
+    {
+      "name": "dialogueLineText",
+      "tableColumnRef": {
+        "tableId": "246a3f13-7888-4b14-ad6d-641b7437b09d",
+        "columnId": "col-text"
+      },
+      "displayName": "目標セリフ",
+      "type": "string",
+      "width": "auto",
+      "align": "left"
+    },
+    {
+      "name": "score",
+      "tableColumnRef": {
+        "tableId": "fefa79cf-4721-4956-86bb-595427bf6f81",
+        "columnId": "col-score"
+      },
+      "displayName": "スコア",
+      "displayFormat": "#,##0.0",
+      "type": "number",
+      "width": "100px",
+      "align": "right",
+      "sortable": true
+    },
+    {
+      "name": "createdAt",
+      "tableColumnRef": {
+        "tableId": "fefa79cf-4721-4956-86bb-595427bf6f81",
+        "columnId": "col-created-at"
+      },
+      "displayName": "採点日時",
+      "displayFormat": "YYYY-MM-DD HH:mm:ss",
+      "type": "datetime",
+      "width": "160px",
+      "align": "left",
+      "sortable": true
+    }
+  ],
+  "sortDefaults": [
+    { "columnName": "createdAt", "order": "asc" }
+  ],
+  "pageSize": 50
+}

--- a/examples/english-learning/views/54917d0d-3162-43f5-8daf-77abdbbc2771.json
+++ b/examples/english-learning/views/54917d0d-3162-43f5-8daf-77abdbbc2771.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "../../../schemas/v3/view.v3.schema.json",
+  "id": "54917d0d-3162-43f5-8daf-77abdbbc2771",
+  "name": "セッション別発音平均ビュー",
+  "description": "pronunciation_scores テーブルからセッション単位で平均スコア・最高スコア・採点回数を集計するビュー。セッション結果画面 (S-3) のサマリ表示と、ダッシュボードの学習進捗グラフ用データとして使用する。",
+  "maturity": "draft",
+  "createdAt": "2026-05-04T00:00:00.000Z",
+  "updatedAt": "2026-05-04T00:00:00.000Z",
+  "physicalName": "v_session_pronunciation_avg",
+  "selectStatement": "SELECT\n  ps.session_id,\n  ls.user_id,\n  AVG(ps.score)    AS avg_score,\n  MAX(ps.score)    AS max_score,\n  MIN(ps.score)    AS min_score,\n  COUNT(ps.id)     AS score_count,\n  MAX(ps.created_at) AS last_scored_at\nFROM pronunciation_scores AS ps\nINNER JOIN learning_sessions AS ls ON ls.id = ps.session_id\nGROUP BY ps.session_id, ls.user_id",
+  "outputColumns": [
+    {
+      "physicalName": "session_id",
+      "name": "セッションID",
+      "dataType": "INTEGER",
+      "description": "集計対象の学習セッション ID。"
+    },
+    {
+      "physicalName": "user_id",
+      "name": "ユーザーID",
+      "dataType": "INTEGER",
+      "description": "セッション所有者のユーザー ID。"
+    },
+    {
+      "physicalName": "avg_score",
+      "name": "平均スコア",
+      "dataType": "DECIMAL",
+      "description": "セッション内の発音採点の平均スコア (0〜100)。"
+    },
+    {
+      "physicalName": "max_score",
+      "name": "最高スコア",
+      "dataType": "DECIMAL",
+      "description": "セッション内の発音採点の最高スコア (0〜100)。"
+    },
+    {
+      "physicalName": "min_score",
+      "name": "最低スコア",
+      "dataType": "DECIMAL",
+      "description": "セッション内の発音採点の最低スコア (0〜100)。"
+    },
+    {
+      "physicalName": "score_count",
+      "name": "採点回数",
+      "dataType": "INTEGER",
+      "description": "セッション内の発音採点の合計回数。"
+    },
+    {
+      "physicalName": "last_scored_at",
+      "name": "最終採点日時",
+      "dataType": "TIMESTAMP",
+      "description": "最後に発音採点を実行した日時。"
+    }
+  ],
+  "dependencies": [
+    "fefa79cf-4721-4956-86bb-595427bf6f81",
+    "d524cba6-0878-4cf5-ba70-deaa7b459103"
+  ]
+}

--- a/examples/english-learning/views/af699800-b15f-4588-9d0d-6a76a3eb2e48.json
+++ b/examples/english-learning/views/af699800-b15f-4588-9d0d-6a76a3eb2e48.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "../../../schemas/v3/view.v3.schema.json",
+  "id": "af699800-b15f-4588-9d0d-6a76a3eb2e48",
+  "name": "学習履歴とストーリー結合ビュー",
+  "description": "learning_sessions と stories を JOIN し、学習履歴一覧画面 (S-4) で使用する横断ビュー。セッション ID・ユーザー ID・ストーリータイトル・CEFR レベル・学習開始日時・完了日時・平均スコア・ステータスを含む。view-definitions の学習履歴一覧 viewer から参照される。",
+  "maturity": "draft",
+  "createdAt": "2026-05-04T00:00:00.000Z",
+  "updatedAt": "2026-05-04T00:00:00.000Z",
+  "physicalName": "v_learning_history_with_story",
+  "selectStatement": "SELECT\n  ls.id           AS session_id,\n  ls.user_id,\n  ls.status,\n  ls.score_avg,\n  ls.started_at,\n  ls.completed_at,\n  s.id            AS story_id,\n  s.title         AS story_title,\n  s.cefr_level,\n  s.estimated_minutes,\n  cp.id           AS pack_id,\n  cp.name         AS pack_name\nFROM learning_sessions AS ls\nINNER JOIN stories AS s  ON s.id  = ls.story_id\nINNER JOIN content_packs AS cp ON cp.id = s.pack_id\nORDER BY ls.started_at DESC",
+  "outputColumns": [
+    {
+      "physicalName": "session_id",
+      "name": "セッションID",
+      "dataType": "INTEGER",
+      "description": "学習セッションの一意 ID。"
+    },
+    {
+      "physicalName": "user_id",
+      "name": "ユーザーID",
+      "dataType": "INTEGER",
+      "description": "セッション所有者のユーザー ID。"
+    },
+    {
+      "physicalName": "status",
+      "name": "ステータス",
+      "dataType": "VARCHAR",
+      "description": "セッションステータス (in_progress / completed / abandoned)。"
+    },
+    {
+      "physicalName": "score_avg",
+      "name": "平均スコア",
+      "dataType": "DECIMAL",
+      "description": "セッション内の発音採点の平均スコア (0〜100)。NULL の場合は採点未実施。"
+    },
+    {
+      "physicalName": "started_at",
+      "name": "学習開始日時",
+      "dataType": "TIMESTAMP",
+      "description": "学習セッション開始日時。"
+    },
+    {
+      "physicalName": "completed_at",
+      "name": "完了日時",
+      "dataType": "TIMESTAMP",
+      "description": "学習セッション完了日時。NULL の場合は未完了。"
+    },
+    {
+      "physicalName": "story_id",
+      "name": "ストーリーID",
+      "dataType": "INTEGER",
+      "description": "学習したストーリーの ID。"
+    },
+    {
+      "physicalName": "story_title",
+      "name": "ストーリータイトル",
+      "dataType": "VARCHAR",
+      "description": "学習したストーリーのタイトル。"
+    },
+    {
+      "physicalName": "cefr_level",
+      "name": "CEFR レベル",
+      "dataType": "VARCHAR",
+      "description": "ストーリーの CEFR 難易度レベル (A1/A2/B1/B2/C1/C2)。"
+    },
+    {
+      "physicalName": "estimated_minutes",
+      "name": "推定学習時間 (分)",
+      "dataType": "INTEGER",
+      "description": "ストーリーの推定学習時間 (分)。"
+    },
+    {
+      "physicalName": "pack_id",
+      "name": "パックID",
+      "dataType": "INTEGER",
+      "description": "コンテンツパックの ID。"
+    },
+    {
+      "physicalName": "pack_name",
+      "name": "パック名",
+      "dataType": "VARCHAR",
+      "description": "コンテンツパック名 (汎用 / IT エンジニア / ビジネス 等)。"
+    }
+  ],
+  "dependencies": [
+    "d524cba6-0878-4cf5-ba70-deaa7b459103",
+    "b5aa3e1b-b5e4-46dd-8373-75fea340844b",
+    "517d50a3-960f-42ce-810f-3b126398d7b1"
+  ]
+}

--- a/examples/english-learning/views/c0474fbf-d0f4-4cfc-bbcd-0154431df9a2.json
+++ b/examples/english-learning/views/c0474fbf-d0f4-4cfc-bbcd-0154431df9a2.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "../../../schemas/v3/view.v3.schema.json",
+  "id": "c0474fbf-d0f4-4cfc-bbcd-0154431df9a2",
+  "name": "習熟度付き単語ビュー",
+  "description": "words テーブルに user_word_progress を LEFT JOIN し、単語帳画面 (S-4) で使用するビュー。ユーザー ID はアプリ層でフィルタする前提 (ビュー自体はユーザー横断)。単語の基本情報 (英語・訳・IPA・品詞・CEFR レベル) と習熟度 (status / correct_count / attempt_count / last_practiced_at) を結合する。view-definitions の単語帳 viewer から参照される。",
+  "maturity": "draft",
+  "createdAt": "2026-05-04T00:00:00.000Z",
+  "updatedAt": "2026-05-04T00:00:00.000Z",
+  "physicalName": "v_words_with_progress",
+  "selectStatement": "SELECT\n  w.id              AS word_id,\n  w.word            AS word_text,\n  w.reading,\n  w.translation,\n  w.ipa,\n  w.part_of_speech,\n  w.cefr_level,\n  w.example_sentence,\n  uwp.user_id,\n  COALESCE(uwp.status, 'new')              AS progress_status,\n  COALESCE(uwp.correct_count, 0)           AS correct_count,\n  COALESCE(uwp.attempt_count, 0)           AS attempt_count,\n  uwp.last_practiced_at\nFROM words AS w\nLEFT JOIN user_word_progress AS uwp ON uwp.word_id = w.id\nORDER BY w.cefr_level ASC, w.word ASC",
+  "outputColumns": [
+    {
+      "physicalName": "word_id",
+      "name": "単語ID",
+      "dataType": "INTEGER",
+      "description": "単語の一意 ID。"
+    },
+    {
+      "physicalName": "word_text",
+      "name": "単語",
+      "dataType": "VARCHAR",
+      "description": "英単語テキスト。"
+    },
+    {
+      "physicalName": "reading",
+      "name": "読み方",
+      "dataType": "VARCHAR",
+      "description": "カタカナ読み仮名 (任意)。"
+    },
+    {
+      "physicalName": "translation",
+      "name": "日本語訳",
+      "dataType": "VARCHAR",
+      "description": "単語の日本語訳。"
+    },
+    {
+      "physicalName": "ipa",
+      "name": "IPA 発音記号",
+      "dataType": "VARCHAR",
+      "description": "IPA 発音記号 (@conv.regex.ipa 準拠)。"
+    },
+    {
+      "physicalName": "part_of_speech",
+      "name": "品詞",
+      "dataType": "VARCHAR",
+      "description": "品詞 (noun / verb / adjective 等)。"
+    },
+    {
+      "physicalName": "cefr_level",
+      "name": "CEFR レベル",
+      "dataType": "VARCHAR",
+      "description": "単語の CEFR 難易度レベル (A1/A2/B1/B2/C1/C2)。"
+    },
+    {
+      "physicalName": "example_sentence",
+      "name": "例文",
+      "dataType": "TEXT",
+      "description": "単語を使った例文 (英文)。"
+    },
+    {
+      "physicalName": "user_id",
+      "name": "ユーザーID",
+      "dataType": "INTEGER",
+      "description": "習熟度データのユーザー ID。NULL の場合はそのユーザーの習熟度未記録。"
+    },
+    {
+      "physicalName": "progress_status",
+      "name": "習熟ステータス",
+      "dataType": "VARCHAR",
+      "description": "習熟度ステータス (new / learning / mastered)。未記録の場合は 'new' として COALESCE。"
+    },
+    {
+      "physicalName": "correct_count",
+      "name": "正解回数",
+      "dataType": "INTEGER",
+      "description": "累積正解回数。未記録の場合は 0。"
+    },
+    {
+      "physicalName": "attempt_count",
+      "name": "練習回数",
+      "dataType": "INTEGER",
+      "description": "累積練習回数。未記録の場合は 0。"
+    },
+    {
+      "physicalName": "last_practiced_at",
+      "name": "最終練習日時",
+      "dataType": "TIMESTAMP",
+      "description": "最後に練習した日時。未記録の場合は NULL。"
+    }
+  ],
+  "dependencies": [
+    "8db75844-19ca-4e7d-8293-579e7631c5cc",
+    "7ab2cf24-7b66-47aa-a808-7fffd8290480"
+  ]
+}


### PR DESCRIPTION
## 概要

`examples/english-learning/` に業務処理層 (ProcessFlow) + データ参照層 (SQL View / ViewDefinition / Sequence) を追加する。ISSUE #787 子 4 の実装。

- S-2 会話ターン進行 (96118ae1): LLM 呼び出し → TTS (任意) → turn_logs INSERT
- S-3 発音採点 (6a49b14b): STT 評価 → TX で pronunciation_scores INSERT + score_avg 更新
- S-4 単語習熟度更新 (21c25fb2): user_word_progress UPSERT、mastery 閾値達成でイベント発行
- 連続日数リセット (3c4d9bfd): scheduled バッチ、streak_days=0 UPDATE
- SQL View 3 件: v_learning_history_with_story / v_words_with_progress / v_session_pronunciation_avg
- ViewDefinition (一覧 viewer) 5 件: ストーリー / 学習履歴 / 単語帳 / コンテンツパック / 発音スコア履歴
- Sequence 2 件: seq_session_id / seq_score_id
- project.json を全エンティティで更新

## 作成ファイル一覧

### ProcessFlow (4 件)
| ファイル | 業務シナリオ |
|--------|-----------|
| `process-flows/96118ae1-a0ab-401b-8584-dd645a45a81f.json` | S-2 会話ターン進行 |
| `process-flows/6a49b14b-eb90-45bd-9df0-df4b5986626b.json` | S-3 発音採点 |
| `process-flows/21c25fb2-551a-483f-b32a-060db8f88aee.json` | S-4 単語習熟度更新 |
| `process-flows/3c4d9bfd-f648-4875-a135-a04e709a87a7.json` | scheduled 連続日数リセット |

### SQL View (3 件)
| ファイル | physicalName |
|--------|-------------|
| `views/af699800-b15f-4588-9d0d-6a76a3eb2e48.json` | v_learning_history_with_story |
| `views/c0474fbf-d0f4-4cfc-bbcd-0154431df9a2.json` | v_words_with_progress |
| `views/54917d0d-3162-43f5-8daf-77abdbbc2771.json` | v_session_pronunciation_avg |

### ViewDefinition (5 件)
| ファイル | 画面 |
|--------|------|
| `view-definitions/cfdbf081-368d-4a33-8a36-1c7a0c535011.json` | ストーリー一覧 viewer |
| `view-definitions/4c9cdc85-2537-4ca8-a979-4de21a56e0fa.json` | 学習履歴一覧 viewer |
| `view-definitions/090e9db0-ce45-4fc4-9fa6-5784f655ca07.json` | 単語帳 viewer |
| `view-definitions/ba1c7d9d-5907-4535-99b9-f9fa170bb248.json` | コンテンツパック一覧 viewer |
| `view-definitions/f06e103d-1eb5-4918-9a6d-67436095bfe7.json` | 発音スコア履歴 viewer |

### Sequence (2 件)
| ファイル | physicalName |
|--------|-------------|
| `sequences/0d9b9b02-cc61-4b26-85c3-ef932bfbe5fd.json` | seq_session_id |
| `sequences/d4160951-3cd6-42dc-b114-9f358ec59c0f.json` | seq_score_id |

## 仕様書逐条突合

### ProcessFlow 設計仕様 (ISSUE #787 子 4 スコープ)

| 条項 | 対応 file:line |
|-----|--------------|
| S-2: POST /api/el/sessions/:sessionId/turns, auth required | `96118ae1...json:61-64` |
| S-2: inputs — sessionId/userInput/turnContext/generateAudio | `96118ae1...json:65-94` |
| S-2: LlmDialog ExtensionStep (context + userInput) | `96118ae1...json:216-223` |
| S-2: TtsGenerate 条件付き実行 (generateAudio==true) | `96118ae1...json:228-248` |
| S-2: turn_number UNIQUE 対応 (MAX+1 SELECT → compute → INSERT) | `96118ae1...json:266-299` |
| S-2: turn_logs INSERT RETURNING id | `96118ae1...json:288-300` |
| S-2: el.turn.completed イベント発行 | `96118ae1...json:302-308` |
| S-3: POST /api/el/sessions/:sessionId/scores, auth required | `6a49b14b...json:73-76` |
| S-3: SttEvaluate ExtensionStep (audioUrl + referenceText + referenceIpa) | `6a49b14b...json:294-302` |
| S-3: transactionScope — INSERT + UPDATE を TX で原子実行 | `6a49b14b...json:311-350` |
| S-3: txBoundary begin=step-06a / end=step-06b | `6a49b14b...json:326,339` |
| S-3: rollbackOn: ["SCORE_INSERT_FAILED"] | `6a49b14b...json:315` |
| S-3: el.pronunciation.scored イベント発行 | `6a49b14b...json:352-358` |
| S-4: kind: "common" (複数画面から共通呼び出し) | `21c25fb2...json:7` |
| S-4: user_word_progress UPSERT (english-learning:UPSERT_WORD_PROGRESS) | `21c25fb2...json:186-194` |
| S-4: mastery 閾値 3 連続正解で status='mastered' 昇格 | `21c25fb2...json:187` |
| S-4: el.word.mastered イベント (mastered==true の場合のみ) | `21c25fb2...json:218-223` |
| scheduled: kind: "scheduled", httpRoute なし | `3c4d9bfd...json:7,` (httpRoute 未存在) |
| scheduled: streak_days=0 UPDATE for 24h 未活動ユーザー | `3c4d9bfd...json:` |
| scheduled: el.streak.reset イベント発行 | `3c4d9bfd...json:` |

## AJV 検証結果

```
$ npm --prefix designer run validate:samples -- ../examples/english-learning

Validating process flows in: ../examples/english-learning
✓ 50b6c4d3 (セッション開始)
✓ 96118ae1 (会話ターン進行)
✓ 6a49b14b (発音採点)
✓ 21c25fb2 (単語習熟度更新)
✓ 3c4d9bfd (連続日数リセット)

Summary: 5 / 5 flows passed. All validations passed.
```

vitest: `93 passed (93)` (samples-v3.schema.test.ts 含む)

半角カナ grep: 0 matches

## スキーマ変更

`git diff origin/main..HEAD -- schemas/` — 変更なし (schema governance #511 準拠)

## チェックリスト

- [x] AJV 5/5 PASS
- [x] vitest 全 pass
- [x] 半角カナ 0 件
- [x] schemas/v3/*.json 変更なし
- [x] `@conv.*` リテラル化なし
- [x] scheduled flow に httpRoute なし
- [x] transactionScope に txBoundary begin/end ペア

Closes part of #787