### PR TITLE
fix(designer): / URL アクセス時の splash 永続デッドロック解消 — MCP 接続を outer AppShell に移動

### DIFF
--- a/designer/src/components/AppShell.tsx
+++ b/designer/src/components/AppShell.tsx
@@ -125,6 +125,32 @@ export function AppShell() {
     return subscribeRedirectGuardTrip((summary) => setGuardTripped(summary));
   }, []);
 
+  // MCP 接続のライフサイクル単一所有 (元は AppShellInner にあったが、初期 / URL アクセス時には
+  // AppShellInner がマウントされず splash で停滞するため外側 AppShell に移動。outer AppShell は
+  // root component なので app の生存期間中マウントされ続ける):
+  //  - mount 時に startWithoutEditor() を 1 度呼んで能動起動
+  //  - "connected" 受信で loadWorkspaces して active state を最新化 (loading=true → false)
+  //  - "disconnected" は mcpBridge 自身が retry timer を回すので AppShell は何もしない
+  //  - サーバ側物理ログへの定期 flush もここで設定 (#750 follow-up)
+  useEffect(() => {
+    const unsubBroadcast = subscribeWorkspaceChanges();
+    const bridge = mcpBridge as unknown as {
+      onStatusChange: (cb: (s: string) => void) => () => void;
+      startWithoutEditor: () => void;
+      request: (method: string, params?: unknown) => Promise<unknown>;
+    };
+    const unsubStatus = bridge.onStatusChange((s) => {
+      if (s === "connected") {
+        loadWorkspaces().catch(console.error);
+      }
+    });
+    bridge.startWithoutEditor();
+    const unsubFlush = setupServerLogFlush((entries) =>
+      bridge.request("client.log.flush", { entries }),
+    );
+    return () => { unsubBroadcast(); unsubStatus(); unsubFlush(); };
+  }, []);
+
   // workspace が loading 完了後に URL を判定してリダイレクト
   useEffect(() => {
     if (workspaceState.loading) return;
@@ -196,33 +222,9 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
     return subscribeWorkspace(() => setWorkspaceState(getWorkspaceState()));
   }, []);
 
-  // AppShell が MCP 接続のライフサイクルを単一所有する (#676 review):
-  //  - mount 時に startWithoutEditor() を 1 度呼んで能動起動 (Dashboard 等で初回ランディング
-  //    した時にも bridge を必ず立ち上げる)。
-  //  - "connected" 受信で loadWorkspaces して active state を最新化。
-  //  - "disconnected" は mcpBridge 自身が RETRY_DELAY_MS の retry timer を回すので、AppShell は
-  //    何もしない (二重 reconnect で接続が在りえない遷移をするのを避けるため)。
-  //  - Designer は workspace 機能を破壊しないよう mcpBridge.stop() を呼ばない設計に変更済み
-  //    (Designer.tsx 参照)。なので AppShell が stop() の事後復帰を心配する必要は無い。
-  useEffect(() => {
-    const unsubBroadcast = subscribeWorkspaceChanges();
-    const bridge = mcpBridge as unknown as {
-      onStatusChange: (cb: (s: string) => void) => () => void;
-      startWithoutEditor: () => void;
-      request: (method: string, params?: unknown) => Promise<unknown>;
-    };
-    const unsubStatus = bridge.onStatusChange((s) => {
-      if (s === "connected") {
-        loadWorkspaces().catch(console.error);
-      }
-    });
-    bridge.startWithoutEditor();
-    // サーバ側物理ログへの定期 flush (#750 follow-up): warn/error を designer-mcp/logs/ に永続化
-    const unsubFlush = setupServerLogFlush((entries) =>
-      bridge.request("client.log.flush", { entries }),
-    );
-    return () => { unsubBroadcast(); unsubStatus(); unsubFlush(); };
-  }, []);
+  // MCP 接続のライフサイクルは外側 AppShell が単一所有する (#676 review)。
+  // 初期 / URL アクセス時に AppShellInner はマウントされない (splash で外側が停滞するため)
+  // 経路で deadlock した regression 修正 — 外側 AppShell の useEffect に移動済。
 
   // workspace state 変化を log 化 (ループ追跡用)
   useEffect(() => {


### PR DESCRIPTION
## 症状

ローカルで `http://localhost:5173/` にアクセスすると「ワークスペース情報を読み込み中...」splash で永遠に止まり、designer が使えなくなる。`/w/:wsId/` 形式の直接 URL でも同じ問題。

## 再現

1. `npm run dev` で designer + designer-mcp 起動
2. ブラウザで `http://localhost:5173/` を開く
3. → 「ワークスペース情報を読み込み中...」が永続表示される (期待: `/workspace/select` への遷移)

## 原因 (deadlock)

`designer/src/components/AppShell.tsx` の構造:

\`\`\`
AppShell (outer)
├── workspaceState.loading = true (初期値、workspaceStore.ts:96)
├── splash 早期 return (line 148)
└── ※ MCP 接続ロジックなし

AppShellInner (inner)
└── useEffect (修正前 line 207-225)
    ├── mcpBridge.startWithoutEditor()
    └── status='connected' 受信時に loadWorkspaces()
\`\`\`

`/` 初期アクセスでの実行:

1. outer AppShell マウント、loading=true
2. splash 早期 return → Routes 未描画 → **AppShellInner 永遠にマウントされない**
3. AppShellInner 内の `startWithoutEditor()` が呼ばれず → WebSocket 接続なし
4. リダイレクト useEffect (line 130) も `if (loading) return;` でブロック
5. `loadWorkspaces()` が走らないので loading が永遠に true → splash 永続

### 実機検証 (Playwright で確認)

修正前:
- `__mcpBridge.ws`: `null` (一度も WebSocket 作成されず)
- `__mcpBridge.status`: \`'disconnected'\`
- `__uiLogDump()`: 空配列 (アプリログ 0 件)
- Network: localhost:5179 への接続 0 件

### コメントとコードの食い違い

修正前の AppShellInner line 199-202 のコメント:

\`\`\`typescript
// AppShell が MCP 接続のライフサイクルを単一所有する (#676 review):
//  - mount 時に startWithoutEditor() を 1 度呼んで能動起動 (Dashboard 等で初回ランディング
//    した時にも bridge を必ず立ち上げる)。
\`\`\`

「AppShell が単一所有」と明記しているが、実装は AppShellInner にある食い違い。マルチワークスペース対応 (#676) で AppShellInner を分離した際の regression と推測。

## 修正

useEffect (`startWithoutEditor` + `onStatusChange('connected') → loadWorkspaces` + `subscribeWorkspaceChanges` + `setupServerLogFlush`) を AppShellInner から outer AppShell に移動。

outer AppShell は root component なので app の生存期間中マウントされ続け、初期 / URL アクセス時にも MCP 接続が能動起動される。

## 検証 (修正後)

- ✅ Playwright で `/` アクセス → `/workspace/select` リダイレクト成功、WorkspaceSelectView 正常表示
- ✅ `__mcpBridge.status: 'connected'`, `ws.readyState: OPEN`
- ✅ `__uiLogDump().length: 200` (アプリログ正常記録)
- ✅ \`npm run build\`: pass (TypeScript check + Vite build)
- ✅ \`npm run test:unit\`: **1266 / 1266 pass**
- ✅ 半角カナ混入なし

## 仕様逐条突合 (自己申告)

- outer AppShell に MCP ライフサイクル useEffect 追加: `designer/src/components/AppShell.tsx:128-152`
- AppShellInner から重複 useEffect 削除: 修正前 line 207-225 削除済 (line 200 周辺のコメントも更新)
- 既存 import (`mcpBridge`, `loadWorkspaces`, `subscribeWorkspaceChanges`, `setupServerLogFlush`) 流用、新規 import 不要

## Test plan

- [x] `npm run build` pass
- [x] `npm run test:unit` 1266/1266 pass
- [x] Playwright で `/` アクセス → 正常 redirect 確認
- [x] Playwright で WebSocket 接続成立確認 (status='connected', ws.readyState=OPEN)
- [x] 半角カナ混入なし

## 関連

- 起票なし (本日の dogfood で発見、即時 fix)
- 関連改善 ISSUE は別途起票予定 (designer-mcp half-dead 状態回復、port collision UX、splash timeout 警告等)

🤖 Generated with [Claude Code](https://claude.com/claude-code)