### PR TITLE
fix(designer): 接続失敗時の splash 永続を解消 — エラー画面 + 再試行ボタン + .gitignore 整理 (#795 C+D)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,11 @@ screenshots/
 
 # Claude Code local settings (skills/commands はチーム共有のため追跡対象)
 .claude/settings.local.json
+# Claude Code agent worktrees — 本来は C:/tmp/ 等プロジェクト外に置くべきだが
+# 誤配置時の VS Code git panel 汚染を防止 (memory feedback_worktree_placement_outside_project.md)
+.claude/worktrees/
+# Claude Code runtime artifacts (ScheduleWakeup の lock ファイル等)
+.claude/scheduled_tasks.lock
 
 # 一時出力 (例: /review-pr /review-issue が書き出すレビュー結果は tmp/review-cache/ 配下)
 tmp/

--- a/designer/src/components/AppShell.tsx
+++ b/designer/src/components/AppShell.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Routes, Route, useLocation, useNavigate, matchPath, useParams } from "react-router-dom";
 import { FlowEditor } from "./flow/FlowEditor";
 import { ScreenListView } from "./flow/ScreenListView";
@@ -110,7 +110,56 @@ function RedirectGuardBanner({ summary }: { summary: readonly string[] }) {
   );
 }
 
+// designer-mcp 接続失敗エラー画面 (#795-C)
+// splash で永遠に止まらず、サーバ未起動 / half-dead / network 障害を明示的に伝える
+function ConnectionFailedView({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div style={{
+      display: "flex", alignItems: "center", justifyContent: "center",
+      height: "100vh", flexDirection: "column", gap: "16px", padding: "24px",
+      color: "var(--muted-text, #ccc)",
+      backgroundColor: "var(--bg-color, #1a1a1a)",
+    }}>
+      <div style={{ fontSize: "3rem", color: "#dc3545" }}>
+        <i className="bi bi-plug-fill" />
+      </div>
+      <h2 style={{ margin: 0, fontSize: "1.25rem", color: "var(--text-color, #fff)" }}>
+        designer-mcp サーバに接続できません
+      </h2>
+      <div style={{
+        maxWidth: 480, fontSize: "0.875rem", lineHeight: 1.6,
+        color: "var(--muted-text, #aaa)", textAlign: "center",
+      }}>
+        <p style={{ marginTop: 0 }}>
+          designer-mcp サーバ (port 5179) が起動しているか確認してください。
+        </p>
+        <pre style={{
+          background: "rgba(255,255,255,0.05)", padding: "12px 16px", borderRadius: 6,
+          fontSize: "0.8125rem", textAlign: "left", margin: "12px auto",
+        }}>cd designer-mcp{"\n"}npm run dev</pre>
+        <p style={{ margin: "12px 0 0" }}>
+          すでに起動している場合は、port 5179 を別プロセスが握っている可能性があります。
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={onRetry}
+        style={{
+          padding: "8px 24px", fontSize: "0.9375rem",
+          background: "#0d6efd", color: "#fff", border: "none", borderRadius: 6,
+          cursor: "pointer", marginTop: 8,
+        }}
+      >
+        <i className="bi bi-arrow-clockwise" style={{ marginRight: 6 }} />
+        再試行
+      </button>
+    </div>
+  );
+}
+
 // ルートレベルの AppShell: /workspace/* と /w/:wsId/* に分岐
+const CONNECTION_TIMEOUT_MS = 5000; // designer-mcp 接続失敗エラー UI 表示までの待機時間 (#795-C)
+
 export function AppShell() {
   const location = useLocation();
   const navigate = useNavigate();
@@ -118,11 +167,29 @@ export function AppShell() {
   const [guardTripped, setGuardTripped] = useState<readonly string[] | null>(
     isRedirectGuardTripped() ? [] : null,
   );
+  // designer-mcp 接続失敗の可視化 (#795-C): N 秒以内に "connected" が来ない場合 true
+  const [connectionFailed, setConnectionFailed] = useState(false);
+  // 一度でも connected になったかを保持 (timer 内 closure 用)
+  const everConnectedRef = useRef(false);
+  // timeout timer の制御用 ref (retry 時に reset するため)
+  const failTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   useEffect(() => {
     return subscribeWorkspace(() => setWorkspaceState(getWorkspaceState()));
   }, []);
   useEffect(() => {
     return subscribeRedirectGuardTrip((summary) => setGuardTripped(summary));
+  }, []);
+
+  // 接続失敗 timer 起動 (mount 時 + retry 時)
+  const startConnectionTimeout = useCallback(() => {
+    if (failTimerRef.current !== null) clearTimeout(failTimerRef.current);
+    failTimerRef.current = setTimeout(() => {
+      if (!everConnectedRef.current) {
+        uiWarn("workspace", "connection-timeout", { ms: CONNECTION_TIMEOUT_MS });
+        setConnectionFailed(true);
+      }
+    }, CONNECTION_TIMEOUT_MS);
   }, []);
 
   // MCP 接続のライフサイクル単一所有 (元は AppShellInner にあったが、初期 / URL アクセス時には
@@ -132,6 +199,7 @@ export function AppShell() {
   //  - "connected" 受信で loadWorkspaces して active state を最新化 (loading=true → false)
   //  - "disconnected" は mcpBridge 自身が retry timer を回すので AppShell は何もしない
   //  - サーバ側物理ログへの定期 flush もここで設定 (#750 follow-up)
+  //  - 接続失敗 timeout (#795-C): N 秒以内に "connected" が来ない場合エラー UI に切替
   useEffect(() => {
     const unsubBroadcast = subscribeWorkspaceChanges();
     const bridge = mcpBridge as unknown as {
@@ -141,15 +209,35 @@ export function AppShell() {
     };
     const unsubStatus = bridge.onStatusChange((s) => {
       if (s === "connected") {
+        everConnectedRef.current = true;
+        setConnectionFailed(false);
+        if (failTimerRef.current !== null) {
+          clearTimeout(failTimerRef.current);
+          failTimerRef.current = null;
+        }
         loadWorkspaces().catch(console.error);
       }
     });
     bridge.startWithoutEditor();
+    startConnectionTimeout();
     const unsubFlush = setupServerLogFlush((entries) =>
       bridge.request("client.log.flush", { entries }),
     );
-    return () => { unsubBroadcast(); unsubStatus(); unsubFlush(); };
-  }, []);
+    return () => {
+      if (failTimerRef.current !== null) clearTimeout(failTimerRef.current);
+      unsubBroadcast();
+      unsubStatus();
+      unsubFlush();
+    };
+  }, [startConnectionTimeout]);
+
+  // 接続失敗時の手動 retry (#795-C エラー UI ボタン)
+  const handleRetryConnection = useCallback(() => {
+    uiInfo("workspace", "connection-retry-clicked");
+    setConnectionFailed(false);
+    startConnectionTimeout();
+    (mcpBridge as { startWithoutEditor: () => void }).startWithoutEditor();
+  }, [startConnectionTimeout]);
 
   // workspace が loading 完了後に URL を判定してリダイレクト
   useEffect(() => {
@@ -172,7 +260,11 @@ export function AppShell() {
   }, [workspaceState.loading, workspaceState.active?.id, workspaceState.lockdown, location.pathname]);
 
   // loading 中はスプラッシュ表示 (WorkspaceScopedShell に合わせて一貫性確保)
+  // ただし接続失敗 timeout 超過時はエラー UI に切替 (#795-C)
   if (workspaceState.loading) {
+    if (connectionFailed) {
+      return <ConnectionFailedView onRetry={handleRetryConnection} />;
+    }
     return (
       <div style={{
         display: "flex", alignItems: "center", justifyContent: "center",


### PR DESCRIPTION
## 概要

ISSUE #795 提案 C + D の同時実装。

- 提案 C: designer-mcp 接続失敗時に splash 永続せず、エラー画面 + 再試行ボタンを表示
- 提案 D: \`.claude/worktrees/\` 等の VS Code git panel 汚染を防止する .gitignore 追加

## 提案 C — 接続失敗 UI 可視化

### 背景

PR #794 で deadlock 自体は修正したが、designer-mcp 不在 / half-dead / network 障害時には依然として「ワークスペース情報を読み込み中...」splash で永続停止する。設計者が原因を特定できず、開発体験を直撃する。

### 実装

\`designer/src/components/AppShell.tsx\`:

- \`CONNECTION_TIMEOUT_MS = 5000\` 定数追加
- mount 時に \`startConnectionTimeout()\` で 5 秒 timer を起動
- \`status="connected"\` 受信時に timer clear + \`everConnectedRef.current = true\` + \`setConnectionFailed(false)\`
- 5 秒経過してもまだ未接続の場合 \`setConnectionFailed(true)\` で \`ConnectionFailedView\` に切替
- \`ConnectionFailedView\` (新規): サーバ未起動メッセージ + 起動コマンド表示 + 「再試行」ボタン
- 「再試行」: \`startConnectionTimeout()\` 再起動 + \`mcpBridge.startWithoutEditor()\` 再呼び出し
- mid-session の disconnect は \`mcpBridge\` 自身の retry timer に委ねる (画面切替なし)

### エラー画面の表示内容

\`\`\`
[plug-fill icon (赤)]

designer-mcp サーバに接続できません

designer-mcp サーバ (port 5179) が起動しているか確認してください。

  cd designer-mcp
  npm run dev

すでに起動している場合は、port 5179 を別プロセスが握っている可能性があります。

[ 再試行 ] (青ボタン)
\`\`\`

## 提案 D — .gitignore 整理

agent worktree 残骸 + Claude Code runtime artifacts を gitignore:

\`\`\`gitignore
# Claude Code agent worktrees — 本来は C:/tmp/ 等プロジェクト外に置くべきだが
# 誤配置時の VS Code git panel 汚染を防止 (memory feedback_worktree_placement_outside_project.md)
.claude/worktrees/
# Claude Code runtime artifacts (ScheduleWakeup の lock ファイル等)
.claude/scheduled_tasks.lock
\`\`\`

\`.claude/settings.json\` は team 共有可能性あり、untracked のまま個別判断。

## 検証

- ✅ \`npm run build\`: pass
- ✅ \`npm run test:unit\`: **1266 / 1266 pass**
- ✅ 半角カナ混入なし
- ✅ gitignore 適用後 \`git status\` から worktrees / lock が消失
- ⏳ ブラウザ smoke は user 確認 (Playwright MCP 切断中):
  - 正常: \`/\` アクセス → \`/workspace/select\` 遷移 (#794 と同じ動作維持)
  - 異常: designer-mcp 停止状態で \`/\` アクセス → 5 秒後にエラー画面、「再試行」ボタンで designer-mcp 起動後に正常画面復帰

## 仕様逐条突合 (自己申告)

- \`CONNECTION_TIMEOUT_MS\` 定数定義: \`designer/src/components/AppShell.tsx:160\`
- \`ConnectionFailedView\` コンポーネント: \`designer/src/components/AppShell.tsx:111-156\`
- \`connectionFailed\` state + \`everConnectedRef\` + \`failTimerRef\`: \`designer/src/components/AppShell.tsx:170-177\`
- \`startConnectionTimeout\` callback: \`designer/src/components/AppShell.tsx:186-194\`
- timer 起動 + status 監視 useEffect: \`designer/src/components/AppShell.tsx:204-228\`
- \`handleRetryConnection\` callback: \`designer/src/components/AppShell.tsx:231-236\`
- splash → エラー画面分岐: \`designer/src/components/AppShell.tsx:259-264\`
- .gitignore 追加: \`.gitignore:20-24\`

## スコープ外 (#795 残作業)

- 提案 A: designer-mcp の half-dead 状態回復 + health check
- 提案 B: \`npm run dev\` の port collision UX 改善

別 PR で着手予定。

## Test plan

- [x] \`npm run build\` pass
- [x] \`npm run test:unit\` 1266/1266 pass
- [x] 半角カナ混入なし
- [ ] (user 確認) ブラウザで designer-mcp 起動状態 → 正常遷移
- [ ] (user 確認) ブラウザで designer-mcp 停止状態 → 5 秒後エラー画面表示
- [ ] (user 確認) エラー画面の「再試行」ボタン → designer-mcp 起動後に成功

Closes part of #795

🤖 Generated with [Claude Code](https://claude.com/claude-code)