### PR TITLE
feat(schemas/project): design.cssFramework field 追加 + TS 型同期 (#793 子 2)

### DIFF
--- a/designer/src/types/v3/project.ts
+++ b/designer/src/types/v3/project.ts
@@ -124,6 +124,22 @@ export interface ProjectMeta extends EntityMeta {
   mode?: Mode;
 }
 
+/**
+ * CSS フレームワーク選択 (#793)。
+ * project 作成時に固定し、途中切替は非サポート。
+ * - `"bootstrap"` — Bootstrap 5 を canvas iframe に読み込み (既存サンプル既定)。
+ * - `"tailwind"` — Tailwind ベースの theme CSS を canvas iframe に読み込み (semantic class を @apply で utility にマップ)。
+ *
+ * 詳細仕様: docs/spec/css-framework-switching.md
+ */
+export type CssFramework = "bootstrap" | "tailwind";
+
+/** プロジェクト全体のデザイン関連設定 (#793)。 */
+export interface ProjectDesign {
+  /** CSS フレームワーク選択。省略時は `"bootstrap"` 相当。 */
+  cssFramework?: CssFramework;
+}
+
 /** 業務システム 1 案件の root 定義。`data/project.json` に対応。 */
 export interface Project {
   $schema?: string;
@@ -138,4 +154,6 @@ export interface Project {
   entities?: ProjectEntities;
   /** プロジェクト全体の authoring 情報 (entity 横断で共有される ADR や用語集)。 */
   authoring?: Authoring;
+  /** プロジェクト全体のデザイン関連設定 (CSS フレームワーク選択等)。 */
+  design?: ProjectDesign;
 }

--- a/schemas/v3/project.v3.schema.json
+++ b/schemas/v3/project.v3.schema.json
@@ -52,6 +52,20 @@
     "authoring": {
       "$ref": "common.v3.schema.json#/$defs/Authoring",
       "description": "プロジェクト全体の authoring 情報 (markers / decisions / glossary)。entity 横断で共有される ADR や用語集はここに集約。"
+    },
+
+    "design": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "プロジェクト全体のデザイン関連設定 (#793 子 2)。CSS フレームワーク選択等。",
+      "properties": {
+        "cssFramework": {
+          "type": "string",
+          "enum": ["bootstrap", "tailwind"],
+          "default": "bootstrap",
+          "description": "画面デザイナー canvas + 最終実装で使用する CSS フレームワーク (#793)。project 作成時に固定し、途中切替は非サポート。'bootstrap' = Bootstrap 5 を canvas に読み込み (既存サンプル既定)。'tailwind' = Tailwind ベースの theme CSS を canvas に読み込み (semantic class を @apply で utility にマップ)。省略時は 'bootstrap' 相当。詳細仕様: docs/spec/css-framework-switching.md"
+        }
+      }
     }
   },
   "$defs": {


### PR DESCRIPTION
## 概要

ISSUE #793 子 2 — グローバル schema 変更 (\`schemas/v3/project.v3.schema.json\`) で \`design.cssFramework\` field を追加。子 5 (Designer.tsx 対応) / 子 6 (既存サンプル設定追加) で利用される。

## 設計者承認

- ISSUE #793 上で **2026-05-04 設計者承認済み** (本 PR は承認済 schema 変更の実装)
- 仕様書: \`docs/spec/css-framework-switching.md\` (子 1 で merged 済、PR #797)

## 変更内容

### schema 変更

\`schemas/v3/project.v3.schema.json:53-69\`:

\`\`\`json
"design": {
  "type": "object",
  "additionalProperties": false,
  "description": "プロジェクト全体のデザイン関連設定 (#793 子 2)。CSS フレームワーク選択等。",
  "properties": {
    "cssFramework": {
      "type": "string",
      "enum": ["bootstrap", "tailwind"],
      "default": "bootstrap",
      "description": "..."
    }
  }
}
\`\`\`

- 既存 project に対し **後方互換性あり** (省略時は \`"bootstrap"\` 相当扱い)
- リリース前なので backward compat は本来考慮不要だが、影響範囲を最小に保つ

### TS 型同期

\`designer/src/types/v3/project.ts\`:

- \`CssFramework\` 型 (\`"bootstrap" | "tailwind"\`)
- \`ProjectDesign\` interface
- \`Project\` interface に \`design?: ProjectDesign\` 追加

## 検証

- ✅ \`npm run build\`: pass (TypeScript check + Vite build)
- ✅ \`npm run test:unit\`: **1266 / 1266 pass**
- ✅ \`npm run validate:samples -- ../examples/retail\`: 6 / 6 flows passed (既存サンプル regression なし)
- ✅ 半角カナ混入なし

## 影響範囲

- 既存 3 サンプル (retail / realestate / english-learning) は \`design\` field 未指定 → schema valid (default 動作 \`"bootstrap"\`)
- 子 6 で各サンプルに \`design.cssFramework: "bootstrap"\` を明示追加予定

## 仕様逐条突合 (自己申告)

- design object 追加 (additionalProperties: false): \`schemas/v3/project.v3.schema.json:53-69\`
- cssFramework enum + default + description: \`schemas/v3/project.v3.schema.json:58-66\`
- CssFramework 型: \`designer/src/types/v3/project.ts:128-137\`
- ProjectDesign interface: \`designer/src/types/v3/project.ts:139-143\`
- Project.design field: \`designer/src/types/v3/project.ts:160\`

## スコープ外

- 子 3 (blocks.ts 書き換え)、子 4 (theme CSS 作成)、子 5 (Designer.tsx 対応)、子 6 (既存サンプル設定追加)、子 7 (dogfood) は別 PR

## Test plan

- [x] \`npm run build\` pass
- [x] \`npm run test:unit\` 1266/1266 pass
- [x] 既存 retail サンプル AJV pass
- [x] 半角カナ混入なし
- [x] schema governance #511 遵守 (設計者承認済み)

Closes part of #793

🤖 Generated with [Claude Code](https://claude.com/claude-code)