### PR TITLE
feat(designer): Designer.tsx canvas 2 軸 theme ロード対応 (#793 子 5)

### DIFF
--- a/designer/src/components/Designer.tsx
+++ b/designer/src/components/Designer.tsx
@@ -23,8 +23,9 @@ import { ServerChangeBanner } from "./common/ServerChangeBanner";
 import { useErrorDialog } from "./common/ErrorDialogProvider";
 import { mcpBridge, type McpStatus } from "../mcp/mcpBridge";
 import { loadCustomBlocks, injectCustomBlockCss } from "../store/customBlockStore";
-import { loadProject, updateScreenThumbnail } from "../store/flowStore";
+import { loadProject, loadRawProject, updateScreenThumbnail } from "../store/flowStore";
 import { makeTabId, setDirty } from "../store/tabStore";
+import type { CssFramework } from "../types/v3/project";
 import { clearItemsFromCache } from "../store/screenItemsStore";
 import { useEditSession } from "../hooks/useEditSession";
 import { EditModeToolbar } from "./editing/EditModeToolbar";
@@ -85,26 +86,62 @@ const THEME_KEY = "designer-theme";
 export type PanelMode = "pinned" | "autohide" | "hidden";
 export type ThemeId = "standard" | "card" | "compact" | "dark";
 
-const THEME_URLS: Record<ThemeId, string | null> = {
+/**
+ * CSS framework 軸 (#793 子 5)。
+ * project.design.cssFramework に応じて canvas iframe に読み込む framework CSS。
+ * - bootstrap: Bootstrap 5 + common.css (theme-bootstrap.css)
+ * - tailwind: Tailwind utility-first @apply theme (theme-tailwind.css)
+ */
+const FRAMEWORK_URLS: Record<CssFramework, string> = {
+  bootstrap: new URL("../styles/themes/theme-bootstrap.css", import.meta.url).href,
+  tailwind: new URL("../styles/themes/theme-tailwind.css", import.meta.url).href,
+};
+
+/**
+ * variant 軸 (従来の THEME_URLS を rename)。
+ * standard は framework デフォルトの見た目そのまま (上書きなし)。
+ */
+const VARIANT_URLS: Record<ThemeId, string | null> = {
   standard: null,
   card: new URL("../styles/theme-card.css", import.meta.url).href,
   compact: new URL("../styles/theme-compact.css", import.meta.url).href,
   dark: new URL("../styles/theme-dark.css", import.meta.url).href,
 };
 
-function applyThemeToCanvas(editor: GEditor, themeId: ThemeId) {
+/**
+ * canvas iframe に framework × variant の 2 軸 CSS を注入する (#793 子 5)。
+ *
+ * 注入順:
+ *   1. dz-framework-css  ← FRAMEWORK_URLS[framework] (Bootstrap または Tailwind theme)
+ *   2. dz-variant-override ← VARIANT_URLS[variant] (card/compact/dark の上書き、standard は省略)
+ *
+ * MVP 制約: tailwind framework は standard variant のみサポート。
+ * card/compact/dark × tailwind は仕様書 7.3 節で future work と明記。
+ */
+function applyThemeToCanvas(editor: GEditor, variant: ThemeId, framework: CssFramework) {
   try {
     const canvasDoc = editor.Canvas.getDocument();
     if (!canvasDoc) return;
-    const existing = canvasDoc.getElementById("dz-theme-override");
-    if (existing) existing.remove();
-    const url = THEME_URLS[themeId];
-    if (url) {
-      const link = canvasDoc.createElement("link");
-      link.id = "dz-theme-override";
-      link.rel = "stylesheet";
-      link.href = url;
-      canvasDoc.head.appendChild(link);
+
+    // 1. framework CSS (bootstrap or tailwind)
+    const existingFw = canvasDoc.getElementById("dz-framework-css");
+    if (existingFw) existingFw.remove();
+    const fwLink = canvasDoc.createElement("link");
+    fwLink.id = "dz-framework-css";
+    fwLink.rel = "stylesheet";
+    fwLink.href = FRAMEWORK_URLS[framework];
+    canvasDoc.head.appendChild(fwLink);
+
+    // 2. variant CSS (standard は省略 = framework 既定の見た目)
+    const existingVariant = canvasDoc.getElementById("dz-variant-override");
+    if (existingVariant) existingVariant.remove();
+    const variantUrl = VARIANT_URLS[variant];
+    if (variantUrl) {
+      const variantLink = canvasDoc.createElement("link");
+      variantLink.id = "dz-variant-override";
+      variantLink.rel = "stylesheet";
+      variantLink.href = variantUrl;
+      canvasDoc.head.appendChild(variantLink);
     }
   } catch {
     // canvas not ready
@@ -164,6 +201,9 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
   const [activeTheme, setActiveThemeState] = useState<ThemeId>(
     () => (localStorage.getItem(THEME_KEY) as ThemeId | null) ?? "standard"
   );
+  // project.design.cssFramework (#793 子 5): 省略時は "bootstrap" (schema default と一致)
+  const [cssFramework, setCssFramework] = useState<CssFramework>("bootstrap");
+  const cssFrameworkRef = useRef<CssFramework>("bootstrap");
   const [mcpStatus, setMcpStatus] = useState<McpStatus>("disconnected");
   const tabId = makeTabId("design", screenId);
 
@@ -233,12 +273,36 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
     return () => { cancelled = true; };
   }, [screenId, sessionLoading, mode.kind]);
 
+  // cssFramework をプロジェクトから読み込む (mount 時 1 回)。
+  // design.cssFramework は FlowProject には含まれないため loadRawProject() で取得する (#793 子 5)。
+  useEffect(() => {
+    let cancelled = false;
+    loadRawProject().then((raw) => {
+      if (cancelled) return;
+      const fw = raw.design?.cssFramework ?? "bootstrap";
+      setCssFramework(fw);
+      cssFrameworkRef.current = fw;
+    }).catch((e) => {
+      console.warn("[Designer] loadRawProject failed, using default cssFramework 'bootstrap'", e);
+    });
+    return () => { cancelled = true; };
+  // screenId に依存しない: framework はプロジェクト単位で固定 (途中切替非サポート)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // cssFrameworkRef を cssFramework state と同期 (onReady closure から参照するため)
+  useEffect(() => {
+    cssFrameworkRef.current = cssFramework;
+  }, [cssFramework]);
+
   const handleThemeChange = useCallback((themeId: ThemeId) => {
     setActiveThemeState(themeId);
     localStorage.setItem(THEME_KEY, themeId);
     if (editorRef.current) {
-      applyThemeToCanvas(editorRef.current, themeId);
+      applyThemeToCanvas(editorRef.current, themeId, cssFrameworkRef.current);
     }
+  // cssFrameworkRef は ref なので依存配列不要
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleThemeChangeRef = useRef(handleThemeChange);
@@ -351,9 +415,9 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
       if (editorRef.current) reconcileScreenItems(editorRef.current, screenId);
     }, 0);
     if (editorRef.current) {
-      if (activeTheme !== "standard") {
-        applyThemeToCanvas(editorRef.current, activeTheme);
-      }
+      // framework × variant の 2 軸 CSS を注入 (#793 子 5)。
+      // standard variant でも framework CSS は常に注入する (bootstrap/tailwind の選択を canvas に反映)。
+      applyThemeToCanvas(editorRef.current, activeTheme, cssFrameworkRef.current);
       // カスタムブロックの CSS をキャンバスに注入
       try {
         const customBlocks = await loadCustomBlocks();

--- a/designer/src/store/flowStore.ts
+++ b/designer/src/store/flowStore.ts
@@ -602,6 +602,23 @@ export async function loadProject(): Promise<FlowProject> {
   })();
 }
 
+/**
+ * プロジェクトの生 Project 定義を読み込む (design.cssFramework 等の参照用)。
+ * FlowProject へ合成する loadProject() とは異なり、project.json の raw shape を返す。
+ * design field は FlowProject には含まれないため、本関数で取得する (#793 子 5)。
+ */
+export async function loadRawProject(): Promise<Project> {
+  if (_backend) {
+    const data = await _backend.loadProject();
+    if (data) {
+      return normalizePersisted(data);
+    }
+  }
+  const local = loadPersistedFromLocalStorage();
+  if (local) return local;
+  return normalizePersisted({});
+}
+
 async function persistFlowProject(project: FlowProject): Promise<void> {
   const baseLayout = await loadScreenLayout();
   const { project: persisted, layout } = decomposeFlowProject(project, baseLayout);


### PR DESCRIPTION
## 概要

ISSUE #793 子 5 — `Designer.tsx` の theme ロード機構を `project.design.cssFramework` 対応に拡張。仕様書 `docs/spec/css-framework-switching.md` の 2.5 節・7.3 節に準拠。

## 変更内容

### `designer/src/components/Designer.tsx`

- `THEME_URLS` → `VARIANT_URLS` に rename (用途を明確化、null 維持)
- `FRAMEWORK_URLS` 定数を新規追加 (bootstrap/tailwind の 2 エントリ)
- `applyThemeToCanvas(editor, themeId)` → `applyThemeToCanvas(editor, variant, framework)` に拡張:
  - canvas iframe head に `dz-framework-css` (framework CSS) を注入
  - `dz-variant-override` (variant CSS、standard は省略) を後続注入
  - 旧 `dz-theme-override` id を廃止 → `dz-variant-override` に統一
- `cssFramework` state + `cssFrameworkRef` を追加 (デフォルト `"bootstrap"`)
- mount 時 `loadRawProject()` で `project.design?.cssFramework` を読み込み、state/ref に反映
- `onReady` で standard variant でも framework CSS を常に注入 (2 軸構造)
- `handleThemeChange` (variant 変更) が framework を維持して再注入

### `designer/src/store/flowStore.ts`

- `loadRawProject()` を新規 export:
  - `FlowProject` (UI 合成型) には `design` が含まれないため、raw `Project` を返す専用関数が必要
  - `_backend` → localStorage フォールバック → 空 Project の順で解決

## スコープ外 (別 PR)

- 子 6: 既存 sample に `cssFramework: "bootstrap"` 追加
- 子 7: E2E dogfood + 視覚確認
- tailwind × card/compact/dark variant 対応 (仕様書 7.3 節 future work)

## 仕様逐条突合

| 仕様条項 | 確認 |
|----------|------|
| 2.5節: `FRAMEWORK_URLS` 定数追加 | `Designer.tsx:95-98` |
| 2.5節: `VARIANT_URLS` (旧 THEME_URLS rename) | `Designer.tsx:104-109` |
| 2.5節: `applyThemeToCanvas` 2 引数化 | `Designer.tsx:121` |
| 2.5節: `dz-framework-css` 注入 (1 番目) | `Designer.tsx:127-133` |
| 2.5節: `dz-variant-override` 注入 (2 番目、null なら省略) | `Designer.tsx:136-145` |
| 2.5節: `project.design.cssFramework` 読み込み | `Designer.tsx:278-291` |
| 2.5節: 省略時デフォルト `"bootstrap"` | `Designer.tsx:282` |
| 7.3節: MVP は tailwind × standard のみ (variant 非対応は future work) | コード上制約なし、仕様書参照で明記 |

## 検証結果

- TypeScript build: 0 エラー (`npm --prefix designer run build`)
- vitest: 1266 / 1266 tests passed (`npm --prefix designer run test:unit -- --run`)
- AJV validate:samples (retail): 6 / 6 flows passed
- 半角カナ grep: 0 件

## 子 6 / 子 7 への前提情報

既存 sample (retail / realestate / english-learning) は `design.cssFramework` 未指定のため、`loadRawProject()` で `undefined` → デフォルト `"bootstrap"` として動作。視覚的には既存と同じ Bootstrap 見た目になる。

子 6 で `"cssFramework": "bootstrap"` を明示追加すれば schema validation でも明確になる。子 7 で `"tailwind"` を持つ新規 sample を作成し、Tailwind theme が適用されることを視覚確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)