### PR TITLE
feat(samples): 既存 3 サンプルに design.cssFramework: bootstrap 明示追加 (#793 子 6)

### DIFF
--- a/examples/english-learning/project.json
+++ b/examples/english-learning/project.json
@@ -13,6 +13,9 @@
   "extensionsApplied": [
     { "namespace": "english-learning", "version": ">=1.0.0" }
   ],
+  "design": {
+    "cssFramework": "bootstrap"
+  },
   "entities": {
     "screens": [
       {

--- a/examples/realestate/project.json
+++ b/examples/realestate/project.json
@@ -17,6 +17,9 @@
       "version": ">=1.0.0"
     }
   ],
+  "design": {
+    "cssFramework": "bootstrap"
+  },
   "entities": {
     "screens": [
       {

--- a/examples/retail/project.json
+++ b/examples/retail/project.json
@@ -13,6 +13,9 @@
   "extensionsApplied": [
     { "namespace": "retail", "version": ">=1.0.0" }
   ],
+  "design": {
+    "cssFramework": "bootstrap"
+  },
   "entities": {
     "screens": [
       {


### PR DESCRIPTION
## 概要

ISSUE #793 子 6 — 既存 3 サンプル (retail / realestate / english-learning) の \`project.json\` に \`design.cssFramework: "bootstrap"\` を明示追加。

## 背景

子 5 (#801) で \`Designer.tsx\` が \`project.design.cssFramework\` を読み込んで canvas iframe に対応 theme CSS を注入する実装が入った。schema default は \`"bootstrap"\` なので明示しなくても regression は無いが、**「明示的に bootstrap を選択している」ことが project.json で読み取れる** ようになる。

## 変更内容

3 サンプルそれぞれの \`extensionsApplied\` 直後に以下を追加:

\`\`\`json
"design": {
  "cssFramework": "bootstrap"
},
\`\`\`

## 検証

- ✅ AJV: retail 6/6, realestate 5/5 (元々 1 warning 既存、本変更と無関係), english-learning 5/5 全て pass
- ✅ \`npm run test:unit\`: **1266 / 1266 pass**
- ✅ 半角カナ混入なし

## 仕様逐条突合 (自己申告)

- retail: \`examples/retail/project.json:16-18\`
- realestate: \`examples/realestate/project.json:20-22\`
- english-learning: \`examples/english-learning/project.json:16-18\`

## スコープ外 (#793 残り)

- 子 7: dogfood + Tailwind sample 1 件視覚確認

## Test plan

- [x] AJV 全 sample pass
- [x] vitest 1266/1266 pass
- [x] 半角カナ混入なし

Closes part of #793

🤖 Generated with [Claude Code](https://claude.com/claude-code)