### PR TITLE
fix(designer): ナビゲーション破綻 + 無限ループ修正 (#793 子 7 検証で発覚)

### DIFF
--- a/designer/src/components/AppShell.tsx
+++ b/designer/src/components/AppShell.tsx
@@ -645,14 +645,6 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
   // /workspace/select に redirect → 直後に本 effect が /screen/design/xxx へ navigate
   // を上書き → guard が再度 redirect、というループ / flicker を起こすため。
   // workspace-list タブだけは select 画面からの誘導でも進入可能なので例外扱い。
-  //
-  // 追加 (2026-05-04): URL が singleton route (/w/<wsId>/, /screen/list, /table/list 等)
-  // の場合は本 effect で navigate しない。理由は URL → tab 同期 (上の useEffect) が
-  // singleton tab を setActiveTab する直前 (state 更新 batch 内) に本 effect が **古い
-  // activeTabId** で navigate を発火 → 古い per-resource タブの URL に上書き → 再度
-  // URL → tab 同期が singleton tab を開きにいく → ループ、というレース。
-  // singleton 路は URL → tab 同期が source of truth。本 effect は per-resource 路 (タブ
-  // クリックで開く design / table / action 等) に専念する。
   const activeTab = tabs.find((t) => t.id === activeTabId);
   useEffect(() => {
     if (!activeTab) return;
@@ -660,25 +652,8 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
     if (workspaceState.active === null && !workspaceState.lockdown && activeTab.type !== "workspace-list") {
       return;
     }
-    // singleton route 上での race を回避: URL が singleton であれば URL → tab 同期に委ねる
-    const wsPrefix = wsId ? `/w/${wsId}` : "";
-    const singletonRoutePaths = [
-      `${wsPrefix}/`,
-      `${wsPrefix}/screen/flow`,
-      `${wsPrefix}/screen/list`,
-      `${wsPrefix}/table/list`,
-      `${wsPrefix}/table/er`,
-      `${wsPrefix}/process-flow/list`,
-      `${wsPrefix}/extensions`,
-      `${wsPrefix}/conventions/catalog`,
-      `${wsPrefix}/sequence/list`,
-      `${wsPrefix}/view/list`,
-      `${wsPrefix}/view-definition/list`,
-      "/workspace/list",
-    ];
-    if (singletonRoutePaths.includes(location.pathname)) return;
     // /w/:wsId/* 規約のパスを生成。workspace-list は wsId なし
-    const wp = wsPrefix;
+    const wp = wsId ? `/w/${wsId}` : "";
     const expectedPath =
       activeTab.type === "design"             ? `${wp}/screen/design/${activeTab.resourceId}`
       : activeTab.type === "table"            ? `${wp}/table/edit/${activeTab.resourceId}`

--- a/designer/src/components/AppShell.tsx
+++ b/designer/src/components/AppShell.tsx
@@ -645,13 +645,6 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
   // /workspace/select に redirect → 直後に本 effect が /screen/design/xxx へ navigate
   // を上書き → guard が再度 redirect、というループ / flicker を起こすため。
   // workspace-list タブだけは select 画面からの誘導でも進入可能なので例外扱い。
-  //
-  // 重要: deps から `location.pathname` を意図的に除外している (2026-05-04 redirect loop fix)。
-  // 含めると、URL → tab 同期で setActiveTab → 次 render で本 effect が **古い state batch
-  // 内の activeTabId** で navigate を発火 → URL 変更 → URL → tab 再発火 → ループ。
-  // 本 effect は **「活動タブ変更時に URL を追随」** が役割で、URL 変更の追随は URL → tab
-  // 同期 (上の useEffect) が source of truth。pathname を読むのは現在値の比較用のみで、
-  // pathname 変更で再発火する必要は無い。
   const activeTab = tabs.find((t) => t.id === activeTabId);
   useEffect(() => {
     if (!activeTab) return;
@@ -687,9 +680,7 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
       const guard = checkRedirect(expectedPath);
       if (guard.allow) navigate(expectedPath, { replace: true });
     }
-  // location.pathname を deps から意図的に除外 (上のコメント参照)。lint disable で明示。
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeTabId, activeTab?.type, activeTab?.resourceId, workspaceState.active, workspaceState.lockdown, wsId]);
+  }, [activeTabId, activeTab?.type, activeTab?.resourceId, workspaceState.active, workspaceState.lockdown, location.pathname, wsId]);
 
   const designTabs = tabs.filter((t) => t.type === "design");
   const activeIsDesign = activeTab?.type === "design";
@@ -765,32 +756,28 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
           )}
         >
           <Routes>
-            {/* AppShellInner は親 Route /w/:wsId/* 配下にネストされている。
-                React Router v7 の標準形に従い、子 Route は **relative path** で書く。
-                以前は絶対 path (/w/:wsId/screen/list 等) を使っていたが v7 では match
-                しない (RenderedRoute に child fiber が生成されず Routes が null 描画) ため、
-                relative path + index に修正 (2026-05-04 redirect loop fix の裏で発見)。 */}
-            <Route index element={<DashboardView />} />
-            <Route path="screen/flow" element={<FlowEditor />} />
-            <Route path="screen/list" element={<ScreenListView />} />
+            {/* /w/:wsId/* 規約の絶対パス (location.pathname に対してマッチ) */}
+            <Route path="/w/:wsId/" element={<DashboardView />} />
+            <Route path="/w/:wsId/screen/flow" element={<FlowEditor />} />
+            <Route path="/w/:wsId/screen/list" element={<ScreenListView />} />
             {/* design は designTabs 経由で別レンダーされるが、
                  URL→タブ同期 effect の解決中に一瞬こちらのブランチが描画される。
                  以前は element={null} で真っ白だったのを ResourceLoading に置換 (#124) */}
-            <Route path="screen/design/:screenId" element={<ResourceLoading kind="screen" />} />
-            <Route path="table/list" element={<TableListView />} />
-            <Route path="table/edit/:tableId" element={<TableEditor />} />
-            <Route path="table/er" element={<ErDiagram />} />
-            <Route path="process-flow/list" element={<ProcessFlowListView />} />
-            <Route path="process-flow/edit/:processFlowId" element={<ProcessFlowEditor />} />
-            <Route path="extensions" element={<ExtensionsPanel />} />
-            <Route path="conventions/catalog" element={<ConventionsCatalogView />} />
-            <Route path="screen/items/:screenId" element={<ScreenItemsView />} />
-            <Route path="sequence/list" element={<SequenceListView />} />
-            <Route path="sequence/edit/:sequenceId" element={<SequenceEditor />} />
-            <Route path="view/list" element={<ViewListView />} />
-            <Route path="view/edit/:viewId" element={<ViewEditor />} />
-            <Route path="view-definition/list" element={<ViewDefinitionListView />} />
-            <Route path="view-definition/edit/:viewDefinitionId" element={<ViewDefinitionEditor />} />
+            <Route path="/w/:wsId/screen/design/:screenId" element={<ResourceLoading kind="screen" />} />
+            <Route path="/w/:wsId/table/list" element={<TableListView />} />
+            <Route path="/w/:wsId/table/edit/:tableId" element={<TableEditor />} />
+            <Route path="/w/:wsId/table/er" element={<ErDiagram />} />
+            <Route path="/w/:wsId/process-flow/list" element={<ProcessFlowListView />} />
+            <Route path="/w/:wsId/process-flow/edit/:processFlowId" element={<ProcessFlowEditor />} />
+            <Route path="/w/:wsId/extensions" element={<ExtensionsPanel />} />
+            <Route path="/w/:wsId/conventions/catalog" element={<ConventionsCatalogView />} />
+            <Route path="/w/:wsId/screen/items/:screenId" element={<ScreenItemsView />} />
+            <Route path="/w/:wsId/sequence/list" element={<SequenceListView />} />
+            <Route path="/w/:wsId/sequence/edit/:sequenceId" element={<SequenceEditor />} />
+            <Route path="/w/:wsId/view/list" element={<ViewListView />} />
+            <Route path="/w/:wsId/view/edit/:viewId" element={<ViewEditor />} />
+            <Route path="/w/:wsId/view-definition/list" element={<ViewDefinitionListView />} />
+            <Route path="/w/:wsId/view-definition/edit/:viewDefinitionId" element={<ViewDefinitionEditor />} />
           </Routes>
         </ErrorBoundary>
       )}

--- a/designer/src/components/AppShell.tsx
+++ b/designer/src/components/AppShell.tsx
@@ -645,6 +645,14 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
   // /workspace/select に redirect → 直後に本 effect が /screen/design/xxx へ navigate
   // を上書き → guard が再度 redirect、というループ / flicker を起こすため。
   // workspace-list タブだけは select 画面からの誘導でも進入可能なので例外扱い。
+  //
+  // 追加 (2026-05-04): URL が singleton route (/w/<wsId>/, /screen/list, /table/list 等)
+  // の場合は本 effect で navigate しない。理由は URL → tab 同期 (上の useEffect) が
+  // singleton tab を setActiveTab する直前 (state 更新 batch 内) に本 effect が **古い
+  // activeTabId** で navigate を発火 → 古い per-resource タブの URL に上書き → 再度
+  // URL → tab 同期が singleton tab を開きにいく → ループ、というレース。
+  // singleton 路は URL → tab 同期が source of truth。本 effect は per-resource 路 (タブ
+  // クリックで開く design / table / action 等) に専念する。
   const activeTab = tabs.find((t) => t.id === activeTabId);
   useEffect(() => {
     if (!activeTab) return;
@@ -652,8 +660,25 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
     if (workspaceState.active === null && !workspaceState.lockdown && activeTab.type !== "workspace-list") {
       return;
     }
+    // singleton route 上での race を回避: URL が singleton であれば URL → tab 同期に委ねる
+    const wsPrefix = wsId ? `/w/${wsId}` : "";
+    const singletonRoutePaths = [
+      `${wsPrefix}/`,
+      `${wsPrefix}/screen/flow`,
+      `${wsPrefix}/screen/list`,
+      `${wsPrefix}/table/list`,
+      `${wsPrefix}/table/er`,
+      `${wsPrefix}/process-flow/list`,
+      `${wsPrefix}/extensions`,
+      `${wsPrefix}/conventions/catalog`,
+      `${wsPrefix}/sequence/list`,
+      `${wsPrefix}/view/list`,
+      `${wsPrefix}/view-definition/list`,
+      "/workspace/list",
+    ];
+    if (singletonRoutePaths.includes(location.pathname)) return;
     // /w/:wsId/* 規約のパスを生成。workspace-list は wsId なし
-    const wp = wsId ? `/w/${wsId}` : "";
+    const wp = wsPrefix;
     const expectedPath =
       activeTab.type === "design"             ? `${wp}/screen/design/${activeTab.resourceId}`
       : activeTab.type === "table"            ? `${wp}/table/edit/${activeTab.resourceId}`

--- a/designer/src/components/AppShell.tsx
+++ b/designer/src/components/AppShell.tsx
@@ -718,6 +718,12 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
       const guard = checkRedirect(expectedPath);
       if (guard.allow) navigate(expectedPath, { replace: true });
     }
+  // 意図的に deps を [activeTabId] のみに絞っている。activeTab / workspaceState
+  // / location.pathname / wsId / navigate を deps に含めると、URL→tab effect と
+  // 競合してリダイレクトループを起こす (本 effect の役割は「activeTab 変更を URL に
+  // 追随させる」だけで、それ以外の変化は URL→tab 側で吸収する設計)。
+  // 将来 deps 追加が必要になったら、必ず lastSyncedActiveTabIdRef による
+  // 「実際に activeTabId が変化した時だけ navigate」の不変条件を維持すること。
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeTabId]);
 

--- a/designer/src/components/AppShell.tsx
+++ b/designer/src/components/AppShell.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Routes, Route, useLocation, useNavigate, matchPath, useParams } from "react-router-dom";
+import { Routes, Route, useLocation, useNavigate, matchPath, useParams, Outlet } from "react-router-dom";
 import { FlowEditor } from "./flow/FlowEditor";
 import { ScreenListView } from "./flow/ScreenListView";
 import { TableListView } from "./table/TableListView";
@@ -68,15 +68,16 @@ function useTabs() {
   return { tabs, activeTabId };
 }
 
-// ─── WorkspaceScopedRoutes ────────────────────────────────────────────────────
-// /w/:wsId/* 配下の全ルートをレンダリングするコンポーネント
-// AppShell から /w/:wsId/* ネストで呼ばれる。useParams() で :wsId を取得可能。
-function WorkspaceScopedRoutes() {
-  return <WorkspaceScopedShell />;
-}
-
-// AppShell の全ロジックを持つ内部コンポーネント
-// /w/:wsId/* 配下にネストされているので useParams() で wsId を取得できる
+// ─── WorkspaceScopedShell ─────────────────────────────────────────────────────
+// /w/:wsId 配下の親レイアウト。React Router v7 の **nested Routes**
+// (子要素を親 Route の children として宣言する形式) で使う。
+// 子 Route の element はここで <Outlet /> によりレンダされる。
+//
+// 履歴: 以前は AppShellInner 内部で descendant <Routes> を使っていたが、
+// React Router v7 では descendant <Routes> + <Route index> + 同階層の
+// relative-path siblings の組合せで index 側が常に勝つ挙動を踏み、
+// `/w/<id>/screen/flow` でも DashboardView が出続けるバグになっていた
+// (2026-05-04 dogfood 検証で発覚)。Outlet パターンに統一して解消。
 function WorkspaceScopedShell() {
   const { wsId } = useParams<{ wsId: string }>();
   return <AppShellInner wsId={wsId} />;
@@ -281,7 +282,36 @@ export function AppShell() {
     <>
       {guardTripped !== null && <RedirectGuardBanner summary={guardTripped} />}
     <Routes>
-      <Route path="/w/:wsId/*" element={<WorkspaceScopedRoutes />} />
+      {/* /w/:wsId 配下の全ルートを **nested Routes** で宣言。
+          React Router v7 ではこの書き方で初めて
+            - <Route index> は parent path に exactly match した時のみ発火
+            - 子 path は parent pathnameBase 配下で相対解決
+          が正しく動く。以前の descendant <Routes> + <Route path="/w/:wsId/*">
+          + <Route index> の組合せだと index 側が常に勝つバグがあった。
+          AppShellInner では <Outlet /> で子 element をレンダする。 */}
+      <Route path="/w/:wsId" element={<WorkspaceScopedShell />}>
+        <Route index element={<DashboardView />} />
+        <Route path="screen/flow" element={<FlowEditor />} />
+        <Route path="screen/list" element={<ScreenListView />} />
+        {/* design は designTabs 経由で別レンダーされるが、
+             URL→タブ同期 effect の解決中に一瞬こちらのブランチが描画される。
+             以前は element={null} で真っ白だったのを ResourceLoading に置換 (#124) */}
+        <Route path="screen/design/:screenId" element={<ResourceLoading kind="screen" />} />
+        <Route path="table/list" element={<TableListView />} />
+        <Route path="table/edit/:tableId" element={<TableEditor />} />
+        <Route path="table/er" element={<ErDiagram />} />
+        <Route path="process-flow/list" element={<ProcessFlowListView />} />
+        <Route path="process-flow/edit/:processFlowId" element={<ProcessFlowEditor />} />
+        <Route path="extensions" element={<ExtensionsPanel />} />
+        <Route path="conventions/catalog" element={<ConventionsCatalogView />} />
+        <Route path="screen/items/:screenId" element={<ScreenItemsView />} />
+        <Route path="sequence/list" element={<SequenceListView />} />
+        <Route path="sequence/edit/:sequenceId" element={<SequenceEditor />} />
+        <Route path="view/list" element={<ViewListView />} />
+        <Route path="view/edit/:viewId" element={<ViewEditor />} />
+        <Route path="view-definition/list" element={<ViewDefinitionListView />} />
+        <Route path="view-definition/edit/:viewDefinitionId" element={<ViewDefinitionEditor />} />
+      </Route>
       <Route path="/workspace/list" element={<WorkspaceListView />} />
       <Route path="/workspace/select" element={<WorkspaceSelectView />} />
       {/* 旧 URL (/, /screen/flow 等) にもスプラッシュで対応
@@ -646,12 +676,20 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
   // を上書き → guard が再度 redirect、というループ / flicker を起こすため。
   // workspace-list タブだけは select 画面からの誘導でも進入可能なので例外扱い。
   const activeTab = tabs.find((t) => t.id === activeTabId);
+  // 前回 sync 済 activeTabId を ref で保持。本当に activeTabId が変化した時だけ navigate する
+  // (StrictMode の二重 effect 実行 + workspaceState/ wsId などの spurious dep 変化に依る race を抑止)
+  const lastSyncedActiveTabIdRef = useRef<string>(activeTabId);
   useEffect(() => {
     if (!activeTab) return;
     if (location.pathname === "/workspace/select") return;
     if (workspaceState.active === null && !workspaceState.lockdown && activeTab.type !== "workspace-list") {
       return;
     }
+    // activeTabId が前回 sync 済の値と同じなら何もしない
+    if (lastSyncedActiveTabIdRef.current === activeTabId) {
+      return;
+    }
+    lastSyncedActiveTabIdRef.current = activeTabId;
     // /w/:wsId/* 規約のパスを生成。workspace-list は wsId なし
     const wp = wsId ? `/w/${wsId}` : "";
     const expectedPath =
@@ -680,7 +718,8 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
       const guard = checkRedirect(expectedPath);
       if (guard.allow) navigate(expectedPath, { replace: true });
     }
-  }, [activeTabId, activeTab?.type, activeTab?.resourceId, workspaceState.active, workspaceState.lockdown, location.pathname, wsId]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeTabId]);
 
   const designTabs = tabs.filter((t) => t.type === "design");
   const activeIsDesign = activeTab?.type === "design";
@@ -739,7 +778,9 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
         </div>
       ))}
 
-      {/* 非デザインコンテンツ: 通常ルーティング (/w/:wsId/* 相対パス) */}
+      {/* 非デザインコンテンツ: 子 Route の element を <Outlet /> でレンダ。
+          子 Route は外側 AppShell の <Route path="/w/:wsId"> の children として
+          宣言されている。 */}
       {!activeIsDesign && (
         <ErrorBoundary
           resetKey={activeTabId}
@@ -755,30 +796,7 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
             />
           )}
         >
-          <Routes>
-            {/* /w/:wsId/* 規約の絶対パス (location.pathname に対してマッチ) */}
-            <Route path="/w/:wsId/" element={<DashboardView />} />
-            <Route path="/w/:wsId/screen/flow" element={<FlowEditor />} />
-            <Route path="/w/:wsId/screen/list" element={<ScreenListView />} />
-            {/* design は designTabs 経由で別レンダーされるが、
-                 URL→タブ同期 effect の解決中に一瞬こちらのブランチが描画される。
-                 以前は element={null} で真っ白だったのを ResourceLoading に置換 (#124) */}
-            <Route path="/w/:wsId/screen/design/:screenId" element={<ResourceLoading kind="screen" />} />
-            <Route path="/w/:wsId/table/list" element={<TableListView />} />
-            <Route path="/w/:wsId/table/edit/:tableId" element={<TableEditor />} />
-            <Route path="/w/:wsId/table/er" element={<ErDiagram />} />
-            <Route path="/w/:wsId/process-flow/list" element={<ProcessFlowListView />} />
-            <Route path="/w/:wsId/process-flow/edit/:processFlowId" element={<ProcessFlowEditor />} />
-            <Route path="/w/:wsId/extensions" element={<ExtensionsPanel />} />
-            <Route path="/w/:wsId/conventions/catalog" element={<ConventionsCatalogView />} />
-            <Route path="/w/:wsId/screen/items/:screenId" element={<ScreenItemsView />} />
-            <Route path="/w/:wsId/sequence/list" element={<SequenceListView />} />
-            <Route path="/w/:wsId/sequence/edit/:sequenceId" element={<SequenceEditor />} />
-            <Route path="/w/:wsId/view/list" element={<ViewListView />} />
-            <Route path="/w/:wsId/view/edit/:viewId" element={<ViewEditor />} />
-            <Route path="/w/:wsId/view-definition/list" element={<ViewDefinitionListView />} />
-            <Route path="/w/:wsId/view-definition/edit/:viewDefinitionId" element={<ViewDefinitionEditor />} />
-          </Routes>
+          <Outlet />
         </ErrorBoundary>
       )}
     </>

--- a/designer/src/components/AppShell.tsx
+++ b/designer/src/components/AppShell.tsx
@@ -645,6 +645,13 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
   // /workspace/select に redirect → 直後に本 effect が /screen/design/xxx へ navigate
   // を上書き → guard が再度 redirect、というループ / flicker を起こすため。
   // workspace-list タブだけは select 画面からの誘導でも進入可能なので例外扱い。
+  //
+  // 重要: deps から `location.pathname` を意図的に除外している (2026-05-04 redirect loop fix)。
+  // 含めると、URL → tab 同期で setActiveTab → 次 render で本 effect が **古い state batch
+  // 内の activeTabId** で navigate を発火 → URL 変更 → URL → tab 再発火 → ループ。
+  // 本 effect は **「活動タブ変更時に URL を追随」** が役割で、URL 変更の追随は URL → tab
+  // 同期 (上の useEffect) が source of truth。pathname を読むのは現在値の比較用のみで、
+  // pathname 変更で再発火する必要は無い。
   const activeTab = tabs.find((t) => t.id === activeTabId);
   useEffect(() => {
     if (!activeTab) return;
@@ -680,7 +687,9 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
       const guard = checkRedirect(expectedPath);
       if (guard.allow) navigate(expectedPath, { replace: true });
     }
-  }, [activeTabId, activeTab?.type, activeTab?.resourceId, workspaceState.active, workspaceState.lockdown, location.pathname, wsId]);
+  // location.pathname を deps から意図的に除外 (上のコメント参照)。lint disable で明示。
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeTabId, activeTab?.type, activeTab?.resourceId, workspaceState.active, workspaceState.lockdown, wsId]);
 
   const designTabs = tabs.filter((t) => t.type === "design");
   const activeIsDesign = activeTab?.type === "design";
@@ -756,28 +765,32 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
           )}
         >
           <Routes>
-            {/* /w/:wsId/* 規約の絶対パス (location.pathname に対してマッチ) */}
-            <Route path="/w/:wsId/" element={<DashboardView />} />
-            <Route path="/w/:wsId/screen/flow" element={<FlowEditor />} />
-            <Route path="/w/:wsId/screen/list" element={<ScreenListView />} />
+            {/* AppShellInner は親 Route /w/:wsId/* 配下にネストされている。
+                React Router v7 の標準形に従い、子 Route は **relative path** で書く。
+                以前は絶対 path (/w/:wsId/screen/list 等) を使っていたが v7 では match
+                しない (RenderedRoute に child fiber が生成されず Routes が null 描画) ため、
+                relative path + index に修正 (2026-05-04 redirect loop fix の裏で発見)。 */}
+            <Route index element={<DashboardView />} />
+            <Route path="screen/flow" element={<FlowEditor />} />
+            <Route path="screen/list" element={<ScreenListView />} />
             {/* design は designTabs 経由で別レンダーされるが、
                  URL→タブ同期 effect の解決中に一瞬こちらのブランチが描画される。
                  以前は element={null} で真っ白だったのを ResourceLoading に置換 (#124) */}
-            <Route path="/w/:wsId/screen/design/:screenId" element={<ResourceLoading kind="screen" />} />
-            <Route path="/w/:wsId/table/list" element={<TableListView />} />
-            <Route path="/w/:wsId/table/edit/:tableId" element={<TableEditor />} />
-            <Route path="/w/:wsId/table/er" element={<ErDiagram />} />
-            <Route path="/w/:wsId/process-flow/list" element={<ProcessFlowListView />} />
-            <Route path="/w/:wsId/process-flow/edit/:processFlowId" element={<ProcessFlowEditor />} />
-            <Route path="/w/:wsId/extensions" element={<ExtensionsPanel />} />
-            <Route path="/w/:wsId/conventions/catalog" element={<ConventionsCatalogView />} />
-            <Route path="/w/:wsId/screen/items/:screenId" element={<ScreenItemsView />} />
-            <Route path="/w/:wsId/sequence/list" element={<SequenceListView />} />
-            <Route path="/w/:wsId/sequence/edit/:sequenceId" element={<SequenceEditor />} />
-            <Route path="/w/:wsId/view/list" element={<ViewListView />} />
-            <Route path="/w/:wsId/view/edit/:viewId" element={<ViewEditor />} />
-            <Route path="/w/:wsId/view-definition/list" element={<ViewDefinitionListView />} />
-            <Route path="/w/:wsId/view-definition/edit/:viewDefinitionId" element={<ViewDefinitionEditor />} />
+            <Route path="screen/design/:screenId" element={<ResourceLoading kind="screen" />} />
+            <Route path="table/list" element={<TableListView />} />
+            <Route path="table/edit/:tableId" element={<TableEditor />} />
+            <Route path="table/er" element={<ErDiagram />} />
+            <Route path="process-flow/list" element={<ProcessFlowListView />} />
+            <Route path="process-flow/edit/:processFlowId" element={<ProcessFlowEditor />} />
+            <Route path="extensions" element={<ExtensionsPanel />} />
+            <Route path="conventions/catalog" element={<ConventionsCatalogView />} />
+            <Route path="screen/items/:screenId" element={<ScreenItemsView />} />
+            <Route path="sequence/list" element={<SequenceListView />} />
+            <Route path="sequence/edit/:sequenceId" element={<SequenceEditor />} />
+            <Route path="view/list" element={<ViewListView />} />
+            <Route path="view/edit/:viewId" element={<ViewEditor />} />
+            <Route path="view-definition/list" element={<ViewDefinitionListView />} />
+            <Route path="view-definition/edit/:viewDefinitionId" element={<ViewDefinitionEditor />} />
           </Routes>
         </ErrorBoundary>
       )}

--- a/designer/src/hooks/useWorkspacePath.ts
+++ b/designer/src/hooks/useWorkspacePath.ts
@@ -10,6 +10,7 @@
  *   // → /w/<active-wsId>/screen/list
  */
 
+import { useCallback } from "react";
 import { useParams } from "react-router-dom";
 
 interface UseWorkspacePathResult {
@@ -22,12 +23,17 @@ interface UseWorkspacePathResult {
 export function useWorkspacePath(): UseWorkspacePathResult {
   const { wsId } = useParams<{ wsId: string }>();
 
-  function wsPath(suffix: string): string {
+  // wsId が同じである限り wsPath の関数 ref を安定化する。
+  // これを useCallback しないと、本フックを使うコンポーネントで
+  // wsPath を deps に持つ useMemo / useCallback / useEffect が
+  // 毎レンダー再評価され、setState 系を内側で叩いていると
+  // 無限ループ ("Maximum update depth exceeded") を起こす
+  // (UnsavedDraftsPanel で実際に発生していた、2026-05-04 修正)。
+  const wsPath = useCallback((suffix: string): string => {
     if (!wsId) return suffix;
-    // suffix が "/" で始まる場合は /w/<wsId><suffix>、始まらない場合も同様
     const normalizedSuffix = suffix.startsWith("/") ? suffix : `/${suffix}`;
     return `/w/${wsId}${normalizedSuffix}`;
-  }
+  }, [wsId]);
 
   return { wsPath, wsId };
 }


### PR DESCRIPTION
## Summary

`#793 子 7` (英会話学習アプリ Tailwind 版) を Playwright で dogfood していた際に発覚した、main の重大な regression を修正。

- **inner `<Routes>` + descendant pattern で `<Route index>` が常勝するバグ**: URL が `/screen/flow` でも DashboardView が描画されていた (fiber inspection で確認済) → outer AppShell の `<Route path=\"/w/:wsId\">` 配下に nested children + `<Outlet />` の v7 標準形に refactor。
- **`useWorkspacePath()` の `wsPath` が毎レンダー新 ref**: `UnsavedDraftsPanel` がこの ref を `useCallback` の dep に入れていたため `Maximum update depth exceeded` を 1 マウント当り 200+ 回出力。React 更新サイクルが壊れて (1) 起動時の `/` ⇄ `/workspace/select` 点滅、(2) menu navigate 後に `useEffect([location.pathname])` が発火せず画面が切替らない、を併発していた。`useCallback([wsId])` で wsPath を memo 化。

## 経緯

- `5ebc5d7` で 1 度暫定修正を入れたが破壊が増えたため `ba69760` で revert 済 (origin はクリーンな revert 状態だった)。
- 本 PR は revert 後にあらためて根本原因を 2 つ特定し、両方を一発で修正したもの。

## Test plan

ローカル Playwright + chrome-devtools MCP で以下を実機確認 (全フロー中 `Maximum update depth exceeded` の発生件数: **0**):

- [x] クリーン localStorage で `/` 起動 → ダッシュボード正常描画、redirect 1 回のみで点滅なし
- [x] `/` → 画面フロー menu → FlowEditor + 14 nodes 描画
- [x] `/screen/flow` → ダッシュボード tab click → DashboardView 復帰
- [x] ダッシュボード → 処理フロー一覧 menu → ProcessFlowListView (本 PR 修正前は URL のみ変わり中身が DashboardView のまま)
- [x] 画面一覧 / ER 図 / 規約カタログ menu → 各 view 描画
- [x] タブクリック → メニュークリック を交互に複数回 → 全て正常切替
- [x] `npm run build` (tsc + vite) green
- [x] `npx eslint src/components/AppShell.tsx src/hooks/useWorkspacePath.ts` 0 errors (warnings は pre-existing)

## Closes

なし — 単独 PR。`#793` 子 7 dogfood の余波として発覚した main 上の regression であり、新規 ISSUE 起票は AGENTS.md 「ISSUE 起票の鉄則」に従い回避し本 PR description で trace を残す。

🤖 Generated with [Claude Code](https://claude.com/claude-code)