### PR TITLE
fix(designer): /workspace/list 無限ループ点滅修正 (PR #813 hotfix)

### DIFF
--- a/designer/src/components/workspace/WorkspaceListView.tsx
+++ b/designer/src/components/workspace/WorkspaceListView.tsx
@@ -280,10 +280,24 @@ export function WorkspaceListView() {
   }, []);
 
   useEffect(() => {
-    // E: startWithoutEditor() は AppShell が起動時に呼んでいるため、ここでは呼ばない (重複削除)
-    loadWorkspaces().catch(console.error);
+    // onStatusChange は登録時に現在ステータスで即時発火する (mcpBridge.ts の仕様)。
+    // 「既接続」状態での即時発火時に loadWorkspaces() を呼ぶと、AppShell が既に実施した
+    // load と 2 重になり loading=true → AppShell スプラッシュ → アンマウント → 再マウント
+    // → 再び即時発火 という無限ループを引き起こす (WorkspaceSelectView と同パターン、PR #813 ホットフィックス)。
+    //
+    // 対策: 初回即時発火 (prevStatus=null) で AppShell の load 完了済 (workspaces 取得済) の場合は skip。
+    // 再接続 (disconnected → connected) は常に reload。
+    let prevStatus: string | null = null;
     const unsubStatus = mcpBridge.onStatusChange((s) => {
-      if (s === "connected") loadWorkspaces().catch(console.error);
+      const isReconnect = prevStatus !== null && prevStatus !== "connected" && s === "connected";
+      prevStatus = s;
+      if (s !== "connected") return;
+      if (!isReconnect) {
+        const { loading, workspaces } = getState();
+        // AppShell が load 完了済 (loading=false かつ workspaces 取得済) なら skip して 2 重 load を防ぐ
+        if (!loading && workspaces.length > 0) return;
+      }
+      loadWorkspaces().catch(console.error);
     });
     return () => { unsubStatus(); };
   }, []);

--- a/designer/vite.config.ts
+++ b/designer/vite.config.ts
@@ -1,12 +1,31 @@
-import { defineConfig } from 'vite'
+import { defineConfig, type Plugin } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 // VITE_PORT: worktree 環境で別 port を使う場合に設定 (#703 R-5 D-2)
 const VITE_PORT = parseInt(process.env.VITE_PORT ?? "5173", 10);
 
+/**
+ * @measured/puck の dist/index.css は冒頭で `@import "https://rsms.me/inter/inter.css"` を呼び、
+ * モバイル / プロキシ / 外部 CDN 不通環境で永久 pending → ページ load 未完了 → カーソルが
+ * ロード中スピナー表示のまま (#813 hotfix、ユーザー報告)。CDN 依存は本フレームワーク本来の
+ * 設計外なので transform で削除する。Inter font はデフォルト font fallback で代替させる。
+ */
+function stripPuckCdnImport(): Plugin {
+  return {
+    name: 'strip-puck-cdn-import',
+    enforce: 'pre',
+    transform(code, id) {
+      if (id.includes('@measured/puck') && id.endsWith('.css')) {
+        return code.replace(/@import\s+["']https:\/\/rsms\.me\/inter\/inter\.css["']\s*;?\s*/g, '');
+      }
+      return null;
+    },
+  };
+}
+
 export default defineConfig({
-  plugins: [react()],
+  plugins: [stripPuckCdnImport(), react()],
   server: {
     port: VITE_PORT,
     strictPort: VITE_PORT === 5173, // 標準 port のみ strictPort (worktree は別 port で起動)


### PR DESCRIPTION
## 概要

PR #813 (#806 マルチエディタ対応) のホットフィックス。本 PR は **2 つの修正** を含む。

### 1. WorkspaceListView 二重 reload chain 解消 (主目的)

#### 症状

\`http://localhost:5173/workspace/list\` を開くと無限ループで点滅する。

#### 根本原因

\`designer/src/components/workspace/WorkspaceListView.tsx\` L283-287 (修正前) が WorkspaceSelectView と全く同じ二重 reload chain pattern を持っていた:

\`\`\`ts
useEffect(() => {
  loadWorkspaces().catch(console.error);                     // 直接呼出
  const unsubStatus = mcpBridge.onStatusChange((s) => {
    if (s === \"connected\") loadWorkspaces().catch(console.error);  // 即時発火でも呼出
  });
}, []);
\`\`\`

\`mcpBridge.onStatusChange\` 登録時の即時発火と直接呼出で 2 重 \`loadWorkspaces()\` → loading=true → AppShell スプラッシュ → unmount → 再マウント → 即時発火 → ループ。

PR #813 の Sonnet/Opus/Codex 3 段階レビューで \`onStatusChange\` 全 17 箇所網羅 grep が抜けていたための対象漏れ。

#### 修正

WorkspaceSelectView (PR #813 commit 90120c2) と同じ prevStatus tracker パターンを適用。

#### 検証

Playwright で \`/workspace/list\` を 5 秒観察:
- pathname 変化: 1 回のみ (初期化)
- console error: 0
- Maximum update depth: 0
- Vite error overlay: なし

### 2. \`@measured/puck\` 外部 CDN @import 除去 (副、予防的措置)

#### 経緯

別途報告された「カーソル横のロード中スピナー (砂時計)」の調査中に発見。\`@measured/puck/dist/index.css\` (= \`puck.css\`) 1 行目に:

\`\`\`css
@import \"https://rsms.me/inter/inter.css\";
\`\`\`

外部 CDN への request がモバイル / プロキシ環境で永久 pending 化し、\`document.readyState\` が \`complete\` にならない原因になりうる。

#### 真因の更新

ユーザー検証の結果、**今回のスピナー症状は OS レベルの問題** と判明 (再起動後もデスクトップ / VS Code でも発生していた)。**本 PR の vite.config.ts 修正は今回のスピナー症状の真因ではない**。

#### 保持判断

ただし \`@measured/puck\` が外部 CDN へ無条件接続する設計依存は **予防的に除去すべき** と判断:

- 将来 Puck 画面を **オフライン / 社内プロキシ / モバイルネットワーク** で開いた際に同様の事象を再発する可能性
- 外部 CDN 依存はフレームワーク本来の設計外 (CSP / セキュリティ規約上も望ましくない)
- transform 1 plugin で解決する低コスト対策

#### 修正

\`designer/vite.config.ts\` に \`stripPuckCdnImport\` plugin を追加し、\`@measured/puck\` の CSS から該当 \`@import\` を transform 時に削除。Inter font は OS / browser default fallback で代替。

## Test plan

- [x] \`npm run build\` (designer + designer-mcp) pass
- [x] Playwright で \`/workspace/list\` 点滅消失確認 (PASS)
- [x] Vite plugin transform 効果を Playwright で確認 (\`rsms.me\` への request が 0 件)
- [x] 既存 vitest pass (regression なし)

## 反省 / memory 追加

- \`feedback_three_stage_review_pattern.md\` に「**同 pattern bug を一箇所修正したら、リポジトリ全体で同 API/同構造の grep を必ず実施**」を追記候補 (本 PR で WorkspaceSelectView と同じ pattern を WorkspaceListView で見落としていた)
- \`feedback_new_dep_pr_clean_install_dogfood.md\` に「新規 npm 依存追加時は依存パッケージの CSS / 外部 CDN @import / 静的アセットも merge 前検査必須」を追記候補

🤖 Generated with [Claude Code](https://claude.com/claude-code)