### PR TITLE
fix(workspace): /workspace/list 開く・ダブルクリックで navigate 漏れ修正 (#817)

### DIFF
--- a/designer/src/components/workspace/WorkspaceIndicator.tsx
+++ b/designer/src/components/workspace/WorkspaceIndicator.tsx
@@ -49,6 +49,7 @@ export function WorkspaceIndicator() {
     setOpen(false);
     try {
       await openWorkspace(id, true);
+      navigate("/", { replace: true });
     } catch (e) {
       console.error("[WorkspaceIndicator] openWorkspace failed:", e);
     }

--- a/designer/src/components/workspace/WorkspaceListView.test.tsx
+++ b/designer/src/components/workspace/WorkspaceListView.test.tsx
@@ -120,7 +120,7 @@ describe("WorkspaceListView navigation", () => {
 
     await waitFor(() => {
       expect(openWorkspaceMock).toHaveBeenCalledWith("ws-source", true);
-      expect(navigateMock).toHaveBeenCalledWith("/w/ws-target/", { replace: true });
+      expect(navigateMock).toHaveBeenCalledWith("/", { replace: true });
     });
   });
 
@@ -131,7 +131,7 @@ describe("WorkspaceListView navigation", () => {
 
     await waitFor(() => {
       expect(openWorkspaceMock).toHaveBeenCalledWith("ws-source", true);
-      expect(navigateMock).toHaveBeenCalledWith("/w/ws-target/", { replace: true });
+      expect(navigateMock).toHaveBeenCalledWith("/", { replace: true });
     });
   });
 });

--- a/designer/src/components/workspace/WorkspaceListView.test.tsx
+++ b/designer/src/components/workspace/WorkspaceListView.test.tsx
@@ -1,0 +1,137 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { WorkspaceEntry, WorkspaceState } from "../../store/workspaceStore";
+
+const navigateMock = vi.fn();
+const openWorkspaceMock = vi.fn();
+
+const workspace: WorkspaceEntry = {
+  id: "ws-source",
+  path: "workspaces/source",
+  name: "Source",
+  lastOpenedAt: null,
+};
+
+let state: WorkspaceState;
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => navigateMock,
+}));
+
+vi.mock("../../mcp/mcpBridge", () => ({
+  mcpBridge: {
+    onStatusChange: vi.fn(() => () => {}),
+  },
+}));
+
+vi.mock("../../store/workspaceStore", async () => {
+  const actual = await vi.importActual<typeof import("../../store/workspaceStore")>("../../store/workspaceStore");
+  return {
+    ...actual,
+    getState: vi.fn(() => state),
+    subscribe: vi.fn(() => () => {}),
+    loadWorkspaces: vi.fn(),
+    openWorkspace: openWorkspaceMock,
+    inspectWorkspace: vi.fn(),
+    initAndOpen: vi.fn(),
+    removeWorkspace: vi.fn(),
+  };
+});
+
+vi.mock("../common/DataList", () => ({
+  DataList: ({ items, onActivate }: { items: WorkspaceEntry[]; onActivate: (item: WorkspaceEntry) => void }) => (
+    <button type="button" data-testid="activate-workspace" onDoubleClick={() => onActivate(items[0])}>
+      activate
+    </button>
+  ),
+}));
+
+vi.mock("../common/FilterBar", () => ({
+  FilterBar: () => null,
+}));
+
+vi.mock("../common/SortBar", () => ({
+  SortBar: () => null,
+}));
+
+vi.mock("../common/ViewModeToggle", () => ({
+  ViewModeToggle: () => null,
+}));
+
+vi.mock("../../hooks/useListFilter", () => ({
+  useListFilter: (items: WorkspaceEntry[]) => ({
+    filtered: items,
+    isActive: false,
+    totalCount: items.length,
+    visibleCount: items.length,
+    applyFilter: vi.fn(),
+    clearFilter: vi.fn(),
+  }),
+}));
+
+vi.mock("../../hooks/useListSort", () => ({
+  useListSort: (items: WorkspaceEntry[]) => ({
+    sorted: items,
+    sortKeys: [],
+    toggleSort: vi.fn(),
+    getSortDirection: vi.fn(() => null),
+    getSortRank: vi.fn(() => null),
+  }),
+}));
+
+vi.mock("../../hooks/useListSelection", () => ({
+  useListSelection: () => ({
+    selectedItems: [workspace],
+    selectedIds: new Set([workspace.id]),
+    isSelected: vi.fn((id: string) => id === workspace.id),
+    handleRowClick: vi.fn(),
+    clearSelection: vi.fn(),
+    setSelectedIds: vi.fn(),
+  }),
+}));
+
+vi.mock("../../hooks/usePersistentState", () => ({
+  usePersistentState: () => ["card", vi.fn()],
+}));
+
+const { WorkspaceListView } = await import("./WorkspaceListView");
+
+beforeEach(() => {
+  navigateMock.mockReset();
+  openWorkspaceMock.mockReset();
+  openWorkspaceMock.mockResolvedValue("ws-target");
+  state = {
+    workspaces: [workspace],
+    active: null,
+    lockdown: false,
+    lockdownPath: null,
+    loading: false,
+    error: null,
+  };
+});
+
+describe("WorkspaceListView navigation", () => {
+  it("open button navigates to the opened workspace root", async () => {
+    const { container } = render(<WorkspaceListView />);
+
+    const openButton = container.querySelector<HTMLButtonElement>(".table-list-actions .tbl-btn-ghost:not(.danger)");
+    expect(openButton).not.toBeNull();
+    fireEvent.click(openButton!);
+
+    await waitFor(() => {
+      expect(openWorkspaceMock).toHaveBeenCalledWith("ws-source", true);
+      expect(navigateMock).toHaveBeenCalledWith("/w/ws-target/", { replace: true });
+    });
+  });
+
+  it("double-click activation navigates to the opened workspace root", async () => {
+    render(<WorkspaceListView />);
+
+    fireEvent.doubleClick(screen.getByTestId("activate-workspace"));
+
+    await waitFor(() => {
+      expect(openWorkspaceMock).toHaveBeenCalledWith("ws-source", true);
+      expect(navigateMock).toHaveBeenCalledWith("/w/ws-target/", { replace: true });
+    });
+  });
+});

--- a/designer/src/components/workspace/WorkspaceListView.tsx
+++ b/designer/src/components/workspace/WorkspaceListView.tsx
@@ -427,8 +427,8 @@ export function WorkspaceListView() {
     if (sel.length !== 1) return;
     setActionError(null);
     try {
-      const wsId = await openWorkspace(sel[0].id, true);
-      navigate(`/w/${wsId}/`, { replace: true });
+      await openWorkspace(sel[0].id, true);
+      navigate("/", { replace: true });
     } catch (e) {
       setActionError(e instanceof Error ? e.message : String(e));
     }
@@ -450,7 +450,7 @@ export function WorkspaceListView() {
     if (lockdown) return;
     setActionError(null);
     openWorkspace(w.id, true)
-      .then((wsId) => navigate(`/w/${wsId}/`, { replace: true }))
+      .then(() => navigate("/", { replace: true }))
       .catch((e) => {
         setActionError(e instanceof Error ? e.message : String(e));
       });

--- a/designer/src/components/workspace/WorkspaceListView.tsx
+++ b/designer/src/components/workspace/WorkspaceListView.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
 import { mcpBridge } from "../../mcp/mcpBridge";
 import {
   getState,
@@ -268,6 +269,7 @@ export function AddWorkspaceDialog({ onClose, onAdded }: AddWorkspaceDialogProps
 // ─── WorkspaceListView ────────────────────────────────────────────────────────
 
 export function WorkspaceListView() {
+  const navigate = useNavigate();
   const [storeState, setStoreState] = useState(getState());
   const [viewMode, setViewMode] = usePersistentState<ViewMode>(STORAGE_KEY, "card");
   const [query, setQuery] = useState("");
@@ -425,7 +427,8 @@ export function WorkspaceListView() {
     if (sel.length !== 1) return;
     setActionError(null);
     try {
-      await openWorkspace(sel[0].id, true);
+      const wsId = await openWorkspace(sel[0].id, true);
+      navigate(`/w/${wsId}/`, { replace: true });
     } catch (e) {
       setActionError(e instanceof Error ? e.message : String(e));
     }
@@ -446,10 +449,12 @@ export function WorkspaceListView() {
   const handleActivate = useCallback((w: WorkspaceEntry) => {
     if (lockdown) return;
     setActionError(null);
-    openWorkspace(w.id, true).catch((e) => {
-      setActionError(e instanceof Error ? e.message : String(e));
-    });
-  }, [lockdown]);
+    openWorkspace(w.id, true)
+      .then((wsId) => navigate(`/w/${wsId}/`, { replace: true }))
+      .catch((e) => {
+        setActionError(e instanceof Error ? e.message : String(e));
+      });
+  }, [lockdown, navigate]);
 
   const selectedCount = selection.selectedIds.size;
   const selectedItem = selection.selectedItems[0] ?? null;

--- a/designer/src/store/workspaceStore.ts
+++ b/designer/src/store/workspaceStore.ts
@@ -151,12 +151,17 @@ export async function inspectWorkspace(path: string): Promise<WorkspaceInspectRe
   return result;
 }
 
-export async function openWorkspace(pathOrId: string, useId = false): Promise<void> {
+export async function openWorkspace(pathOrId: string, useId = false): Promise<string> {
   _setState({ loading: true, error: null });
   try {
     const params = useId ? { id: pathOrId } : { path: pathOrId };
     await mcpBridge.request("workspace.open", params);
     await loadWorkspaces();
+    const wsId = _state.active?.id;
+    if (!wsId) {
+      throw new Error("active workspace id is missing after open");
+    }
+    return wsId;
   } catch (e) {
     _setState({
       loading: false,


### PR DESCRIPTION
﻿Closes #817

## 概要
- `openWorkspace()` が切替後の active workspace id を返すように変更
- `/workspace/list` の「開く」ボタンとダブルクリック/Enter activation で `/w/<wsId>/` へ遷移
- 2 経路の navigate 呼び出しをコンポーネントテストで固定

## 仕様逐条突合 (自己申告)
| 修正点 | 確認箇所 |
|---|---|
| `openWorkspace(id, persist)` の戻り値を `Promise<string>` に変更 | `designer/src/store/workspaceStore.ts:154` |
| active workspace 設定後に wsId を返す | `designer/src/store/workspaceStore.ts:164` |
| 「開く」ボタンで `openWorkspace` 後に `/w/<wsId>/` へ replace navigate | `designer/src/components/workspace/WorkspaceListView.tsx:430` / `designer/src/components/workspace/WorkspaceListView.tsx:431` |
| ダブルクリック/Enter activation で `openWorkspace` 後に `/w/<wsId>/` へ replace navigate | `designer/src/components/workspace/WorkspaceListView.tsx:452` / `designer/src/components/workspace/WorkspaceListView.tsx:453` |
| `handleOpen` の regression test | `designer/src/components/workspace/WorkspaceListView.test.tsx:114` |
| `handleActivate` の regression test | `designer/src/components/workspace/WorkspaceListView.test.tsx:127` |

## 検証
| コマンド | 結果 |
|---|---|
| `cd designer && npm run build` | PASS |
| `cd designer && npm test -- --run workspace` | 実行不可: `designer/package.json` に `test` script が無いため npm が `Missing script: test` で終了 |
| `cd designer && npm run test:unit -- --run workspace` | PASS: 4 files / 24 tests |
| `git grep '[ｦ-ﾟ]' -- '*.ts' '*.tsx'` | FAIL: 既存 TS/TSX に match あり。今回許可された 3 ファイル以外も含む既存エンコーディング問題のため、本 PR では未変更 |



---
## Should-fix 反映 (Sonnet レビュー対応)
- S-2: WorkspaceListView の navigate 先を `/w/${wsId}/` → `/` に変更 (WorkspaceSelectView と統一)
- S-1: WorkspaceIndicator も同根修正 — openWorkspace 後に navigate('/') を追加
