### PR TITLE
improve(dev): 開発環境 robustness 4 件 — designer-mcp /health + AppShell 接続失敗 UI + port pre-check + .gitignore (#795)

### DIFF
--- a/designer-mcp/src/httpTransport.test.ts
+++ b/designer-mcp/src/httpTransport.test.ts
@@ -148,6 +148,17 @@ describe("designer-mcp HTTP transport (#302)", () => {
     expect(j).toMatchObject({ status: "ok", service: "designer-mcp", port: TEST_PORT });
   });
 
+  it("GET /health で half-dead 検知フィールドを含む health JSON が返る (#795-A)", async () => {
+    const r = await fetch(`http://localhost:${TEST_PORT}/health`);
+    expect(r.ok).toBe(true);
+    const j = await r.json() as { status: string; lastWsMessageAt: number | null; wsConnections: number; uptimeMs: number };
+    expect(j.status).toBe("ok");
+    expect(Object.prototype.hasOwnProperty.call(j, "lastWsMessageAt")).toBe(true);
+    expect(typeof j.wsConnections).toBe("number");
+    expect(typeof j.uptimeMs).toBe("number");
+    expect(j.uptimeMs).toBeGreaterThan(0);
+  });
+
   it("POST /mcp initialize で protocolVersion が返る (stateless)", async () => {
     const res = await mcpCall("initialize", undefined, {
       id: 1,

--- a/designer-mcp/src/wsBridge.ts
+++ b/designer-mcp/src/wsBridge.ts
@@ -152,6 +152,10 @@ class WsBridge extends EventEmitter {
     string,
     { resolve: (r: unknown) => void; reject: (e: Error) => void; timer: NodeJS.Timeout }
   >();
+  /** 最後に WebSocket メッセージを受信した時刻 (ms)。half-dead 検知用 (#795-A) */
+  private lastMessageAt: number | null = null;
+  /** プロセス起動時刻 (ms) */
+  private readonly startedAt: number = Date.now();
 
   get isConnected(): boolean {
     return this.clients.size > 0;
@@ -161,6 +165,20 @@ class WsBridge extends EventEmitter {
   isActiveSession(sessionId: string): boolean {
     const ws = this.clients.get(sessionId);
     return ws !== undefined && ws.readyState === WebSocket.OPEN;
+  }
+
+  /**
+   * サーバ生存情報を返す (#795-A: half-dead 検知 + /health endpoint 用)。
+   * - lastWsMessageAt: 最後に WebSocket メッセージを受信したエポック ms (null = まだ受信なし)
+   * - wsConnections: 現在の接続ブラウザ数
+   * - uptimeMs: プロセス起動からの経過 ms
+   */
+  getHealth(): { lastWsMessageAt: number | null; wsConnections: number; uptimeMs: number } {
+    return {
+      lastWsMessageAt: this.lastMessageAt,
+      wsConnections: this.clients.size,
+      uptimeMs: Date.now() - this.startedAt,
+    };
   }
 
   /** MCP コマンドを送る先: 最後に接続した有効なクライアント */
@@ -244,10 +262,18 @@ class WsBridge extends EventEmitter {
         return;
       }
     }
-    // Simple health check endpoint
+    // Health check endpoint (#795-A): half-dead 検知情報を含む
     if (url === "/" || url === "/health") {
+      const health = this.getHealth();
       res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ status: "ok", service: "designer-mcp", port: WS_PORT }));
+      res.end(JSON.stringify({
+        status: "ok",
+        service: "designer-mcp",
+        port: WS_PORT,
+        lastWsMessageAt: health.lastWsMessageAt,
+        wsConnections: health.wsConnections,
+        uptimeMs: health.uptimeMs,
+      }));
       return;
     }
     res.writeHead(404, { "Content-Type": "text/plain" });
@@ -268,6 +294,7 @@ class WsBridge extends EventEmitter {
       if (this.clients.size === 1) this.emit("connected");
 
       ws.on("message", (data: Buffer) => {
+        this.lastMessageAt = Date.now();
         let msg: Record<string, unknown>;
         try {
           msg = JSON.parse(data.toString()) as Record<string, unknown>;

--- a/designer/src/components/AppShell.tsx
+++ b/designer/src/components/AppShell.tsx
@@ -182,13 +182,14 @@ export function AppShell() {
     return subscribeRedirectGuardTrip((summary) => setGuardTripped(summary));
   }, []);
 
-  // 接続失敗 timer 起動 (mount 時 + retry 時)
+  // 接続失敗 timer 起動 (mount 時 + retry 時)。タイムアウト時は mcpBridge.markFailed() を呼んで
+  // status="failed" に遷移 → onStatusChange で connectionFailed=true を立てる (#795-C)
   const startConnectionTimeout = useCallback(() => {
     if (failTimerRef.current !== null) clearTimeout(failTimerRef.current);
     failTimerRef.current = setTimeout(() => {
       if (!everConnectedRef.current) {
         uiWarn("workspace", "connection-timeout", { ms: CONNECTION_TIMEOUT_MS });
-        setConnectionFailed(true);
+        (mcpBridge as { markFailed: () => void }).markFailed();
       }
     }, CONNECTION_TIMEOUT_MS);
   }, []);
@@ -198,9 +199,9 @@ export function AppShell() {
   // root component なので app の生存期間中マウントされ続ける):
   //  - mount 時に startWithoutEditor() を 1 度呼んで能動起動
   //  - "connected" 受信で loadWorkspaces して active state を最新化 (loading=true → false)
+  //  - "failed" 受信でエラー UI に切替 (タイムアウト経路) (#795-C)
   //  - "disconnected" は mcpBridge 自身が retry timer を回すので AppShell は何もしない
   //  - サーバ側物理ログへの定期 flush もここで設定 (#750 follow-up)
-  //  - 接続失敗 timeout (#795-C): N 秒以内に "connected" が来ない場合エラー UI に切替
   useEffect(() => {
     const unsubBroadcast = subscribeWorkspaceChanges();
     const bridge = mcpBridge as unknown as {
@@ -217,6 +218,8 @@ export function AppShell() {
           failTimerRef.current = null;
         }
         loadWorkspaces().catch(console.error);
+      } else if (s === "failed") {
+        setConnectionFailed(true);
       }
     });
     bridge.startWithoutEditor();
@@ -235,6 +238,7 @@ export function AppShell() {
   // 接続失敗時の手動 retry (#795-C エラー UI ボタン)
   const handleRetryConnection = useCallback(() => {
     uiInfo("workspace", "connection-retry-clicked");
+    everConnectedRef.current = false;
     setConnectionFailed(false);
     startConnectionTimeout();
     (mcpBridge as { startWithoutEditor: () => void }).startWithoutEditor();

--- a/designer/src/mcp/mcpBridge.status.test.ts
+++ b/designer/src/mcp/mcpBridge.status.test.ts
@@ -1,0 +1,153 @@
+/**
+ * mcpBridge status 状態遷移ユニットテスト (#795-C)
+ *
+ * McpStatus 型の状態遷移ロジック (connecting / connected / failed) と
+ * markFailed() / startWithoutEditor() の振る舞いを検証する。
+ *
+ * mcpBridge.ts は html2canvas / GrapesJS 等の重い依存を持つため、
+ * それらをモックした上でモジュールを動的インポートしてテストする。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ── 重い依存をモック ────────────────────────────────────────────────────────
+
+vi.mock("html2canvas", () => ({ default: vi.fn() }));
+vi.mock("grapesjs", () => ({ default: {} }));
+vi.mock("../utils/uuid", () => ({ generateUUID: () => "test-uuid-" + Math.random().toString(36).slice(2) }));
+
+// store 系も最小モック (mcpBridge.ts の import 側がエラーにならないように)
+vi.mock("../store/flowStore", () => ({ loadProject: vi.fn(), addScreen: vi.fn(), updateScreen: vi.fn(), updateScreenThumbnail: vi.fn(), removeScreen: vi.fn(), addEdge: vi.fn(), removeEdge: vi.fn(), generateMermaid: vi.fn(), setFlowStorageBackend: vi.fn() }));
+vi.mock("../store/customBlockStore", () => ({ loadCustomBlocks: vi.fn(), upsertCustomBlock: vi.fn(), deleteCustomBlock: vi.fn(), injectCustomBlockCss: vi.fn(), setCustomBlocksBackend: vi.fn() }));
+vi.mock("../store/puckComponentsStore", () => ({ setPuckComponentsBackend: vi.fn() }));
+vi.mock("../store/tableStore", () => ({ setTableStorageBackend: vi.fn(), loadTable: vi.fn() }));
+vi.mock("../store/erLayoutStore", () => ({ setErLayoutStorageBackend: vi.fn() }));
+vi.mock("../store/screenLayoutStore", () => ({ setScreenLayoutStorageBackend: vi.fn() }));
+vi.mock("../store/processFlowStore", () => ({ setProcessFlowStorageBackend: vi.fn() }));
+vi.mock("../store/conventionsStore", () => ({ setConventionsStorageBackend: vi.fn() }));
+vi.mock("../store/screenItemsStore", () => ({ loadScreenItems: vi.fn(), setItemsInCache: vi.fn() }));
+vi.mock("../store/screenStore", () => ({ setScreenStorageBackend: vi.fn() }));
+vi.mock("../store/sequenceStore", () => ({ setSequenceStorageBackend: vi.fn() }));
+vi.mock("../store/viewStore", () => ({ setViewStorageBackend: vi.fn() }));
+vi.mock("../store/viewDefinitionStore", () => ({ setViewDefinitionStorageBackend: vi.fn() }));
+vi.mock("../store/tabStore", () => ({ openTab: vi.fn(), closeTab: vi.fn(), setActiveTab: vi.fn(), getTabs: vi.fn(() => []), getActiveTabId: vi.fn(() => null), makeTabId: vi.fn((type: string, id: string) => `${type}:${id}`), setDirty: vi.fn() }));
+
+// ── FakeWebSocket ──────────────────────────────────────────────────────────
+
+class FakeWebSocket extends EventTarget {
+  static OPEN = 1;
+  static CONNECTING = 0;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  readyState: number = FakeWebSocket.CONNECTING;
+
+  constructor(_url: string) {
+    super();
+  }
+
+  send(_data: string): void {}
+
+  close(): void {
+    this.readyState = FakeWebSocket.CLOSED;
+  }
+}
+
+// ── グローバル WebSocket スタブ ────────────────────────────────────────────
+
+const originalWebSocket = globalThis.WebSocket;
+
+beforeEach(() => {
+  // @ts-expect-error test stub
+  globalThis.WebSocket = FakeWebSocket;
+
+  if (!("location" in globalThis)) {
+    Object.defineProperty(globalThis, "location", {
+      value: { hostname: "localhost" },
+      writable: true,
+      configurable: true,
+    });
+  }
+});
+
+afterEach(() => {
+  globalThis.WebSocket = originalWebSocket;
+  vi.resetModules();
+});
+
+// ── ヘルパー: フレッシュな mcpBridge インスタンスを取得 ─────────────────────
+
+async function getFreshBridge() {
+  const { mcpBridge } = await import("./mcpBridge.ts");
+  return mcpBridge;
+}
+
+// ── テスト ─────────────────────────────────────────────────────────────────
+
+describe("McpStatus 状態遷移ロジック (#795-C)", () => {
+  it("McpStatus 型は connecting / connected / failed / disconnected の 4 状態を持つ", async () => {
+    // 型レベルの確認: import して型が存在することを検証
+    const mod = await import("./mcpBridge.ts");
+    expect(typeof mod.mcpBridge.getStatus).toBe("function");
+    // 初期状態は disconnected
+    expect(mod.mcpBridge.getStatus()).toBe("disconnected");
+  });
+
+  it("startWithoutEditor() を呼ぶと connecting になる", async () => {
+    const bridge = await getFreshBridge();
+    const statuses: string[] = [];
+    bridge.onStatusChange((s) => statuses.push(s));
+
+    bridge.startWithoutEditor();
+
+    expect(bridge.getStatus()).toBe("connecting");
+    expect(statuses).toContain("connecting");
+  });
+
+  it("markFailed() を呼ぶと failed になる", async () => {
+    const bridge = await getFreshBridge();
+    const received: string[] = [];
+    bridge.onStatusChange((s) => received.push(s));
+
+    bridge.startWithoutEditor(); // connecting
+    bridge.markFailed();
+
+    expect(bridge.getStatus()).toBe("failed");
+    expect(received).toContain("failed");
+  });
+
+  it("failed 状態から startWithoutEditor() を再呼び出しすると connecting になる (リトライ)", async () => {
+    const bridge = await getFreshBridge();
+
+    bridge.startWithoutEditor(); // connecting
+    bridge.markFailed();         // failed
+    expect(bridge.getStatus()).toBe("failed");
+
+    bridge.startWithoutEditor(); // retry → connecting
+    expect(bridge.getStatus()).toBe("connecting");
+  });
+
+  it("connectAttempts がインクリメントされる", async () => {
+    const bridge = await getFreshBridge();
+    const b = bridge as unknown as { connectAttempts: number };
+    expect(b.connectAttempts).toBe(0);
+
+    bridge.startWithoutEditor();
+    expect(b.connectAttempts).toBe(1);
+
+    bridge.markFailed();
+    bridge.startWithoutEditor();
+    expect(b.connectAttempts).toBe(2);
+  });
+
+  it("connecting 中に startWithoutEditor() を再呼び出しすると no-op (重複接続防止)", async () => {
+    const bridge = await getFreshBridge();
+    const b = bridge as unknown as { connectAttempts: number };
+
+    bridge.startWithoutEditor();
+    const countAfterFirst = b.connectAttempts;
+
+    bridge.startWithoutEditor(); // no-op
+    expect(b.connectAttempts).toBe(countAfterFirst);
+    expect(bridge.getStatus()).toBe("connecting");
+  });
+});

--- a/designer/src/mcp/mcpBridge.status.test.ts
+++ b/designer/src/mcp/mcpBridge.status.test.ts
@@ -128,26 +128,23 @@ describe("McpStatus 状態遷移ロジック (#795-C)", () => {
 
   it("connectAttempts がインクリメントされる", async () => {
     const bridge = await getFreshBridge();
-    const b = bridge as unknown as { connectAttempts: number };
-    expect(b.connectAttempts).toBe(0);
+    expect(bridge.getConnectAttempts()).toBe(0);
 
     bridge.startWithoutEditor();
-    expect(b.connectAttempts).toBe(1);
+    expect(bridge.getConnectAttempts()).toBe(1);
 
     bridge.markFailed();
     bridge.startWithoutEditor();
-    expect(b.connectAttempts).toBe(2);
+    expect(bridge.getConnectAttempts()).toBe(2);
   });
 
   it("connecting 中に startWithoutEditor() を再呼び出しすると no-op (重複接続防止)", async () => {
     const bridge = await getFreshBridge();
-    const b = bridge as unknown as { connectAttempts: number };
-
     bridge.startWithoutEditor();
-    const countAfterFirst = b.connectAttempts;
+    const countAfterFirst = bridge.getConnectAttempts();
 
     bridge.startWithoutEditor(); // no-op
-    expect(b.connectAttempts).toBe(countAfterFirst);
+    expect(bridge.getConnectAttempts()).toBe(countAfterFirst);
     expect(bridge.getStatus()).toBe("connecting");
   });
 });

--- a/designer/src/mcp/mcpBridge.ts
+++ b/designer/src/mcp/mcpBridge.ts
@@ -123,8 +123,8 @@ class McpBridgeImpl {
   private broadcastHandlers = new Map<string, Set<BroadcastHandler>>();
   private retryTimer: ReturnType<typeof setTimeout> | null = null;
   private stopped = false;
-  /** 接続試行カウンタ (status 遷移テスト用に外部から参照可能) */
-  connectAttempts = 0;
+  /** 接続試行カウンタ */
+  private connectAttempts = 0;
 
   /** ブラウザセッション固有の一意 ID（再接続でも不変） */
   private readonly clientId = generateUUID();
@@ -173,6 +173,10 @@ class McpBridgeImpl {
 
   getStatus(): McpStatus {
     return this.status;
+  }
+
+  getConnectAttempts(): number {
+    return this.connectAttempts;
   }
 
   /** ブロードキャストイベントのサブスクライブ */

--- a/designer/src/mcp/mcpBridge.ts
+++ b/designer/src/mcp/mcpBridge.ts
@@ -80,7 +80,7 @@ import {
 } from "../store/viewDefinitionStore";
 import type { RawExtensionsBundle } from "../schemas/loadExtensions";
 
-export type McpStatus = "disconnected" | "connecting" | "connected";
+export type McpStatus = "disconnected" | "connecting" | "connected" | "failed";
 export type ThemeIdLike = "standard" | "card" | "compact" | "dark";
 
 type StatusCallback = (s: McpStatus) => void;
@@ -123,6 +123,8 @@ class McpBridgeImpl {
   private broadcastHandlers = new Map<string, Set<BroadcastHandler>>();
   private retryTimer: ReturnType<typeof setTimeout> | null = null;
   private stopped = false;
+  /** 接続試行カウンタ (status 遷移テスト用に外部から参照可能) */
+  connectAttempts = 0;
 
   /** ブラウザセッション固有の一意 ID（再接続でも不変） */
   private readonly clientId = generateUUID();
@@ -220,13 +222,31 @@ class McpBridgeImpl {
     this._connect();
   }
 
-  /** フロー画面用: エディターなしで WebSocket 接続のみ起動 */
+  /** フロー画面用: エディターなしで WebSocket 接続のみ起動。"failed" 状態からのリトライも可 */
   startWithoutEditor(): void {
     if (this.ws && this.ws.readyState === WebSocket.OPEN) return;
-    if (this.status === "connecting") return;
+    // "failed" 状態のリトライ: 残っている接続試行中の ws を破棄してから再接続
+    if (this.status === "failed") {
+      if (this.ws) {
+        try { this.ws.close(); } catch { /* ignore */ }
+        this.ws = null;
+      }
+    } else if (this.status === "connecting") {
+      return;
+    }
     this.stopped = false;
     console.log("[mcpBridge] starting without editor (flow mode)...");
     this._connect();
+  }
+
+  /**
+   * AppShell が接続タイムアウトを検出した際に呼び出す (#795-C)。
+   * "connecting" → "failed" に遷移し、UI にエラー画面切替を通知する。
+   * retry は startWithoutEditor() の再呼び出しで行う。
+   */
+  markFailed(): void {
+    console.log("[mcpBridge] marking as failed (connection timeout)");
+    this._setStatus("failed");
   }
 
   stop(): void {
@@ -276,8 +296,9 @@ class McpBridgeImpl {
 
   private _connect(): void {
     if (this.stopped) return;
+    this.connectAttempts++;
     this._setStatus("connecting");
-    console.log("[mcpBridge] connecting to", WS_URL);
+    console.log("[mcpBridge] connecting to", WS_URL, `(attempt ${this.connectAttempts})`);
 
     const ws = new WebSocket(WS_URL);
     this.ws = ws;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "業務システム デザイナー ワークスペース（designer + designer-mcp）",
   "scripts": {
     "install:all": "npm install --prefix designer && npm install --prefix designer-mcp",
-    "dev": "concurrently -n designer,mcp -c cyan,magenta --kill-others-on-fail \"npm --prefix designer run dev\" \"npm --prefix designer-mcp run dev\"",
+    "dev": "node scripts/check-ports.mjs && concurrently -n designer,mcp -c cyan,magenta --kill-others-on-fail \"npm --prefix designer run dev\" \"npm --prefix designer-mcp run dev\"",
     "build": "concurrently -n designer,mcp -c cyan,magenta \"npm --prefix designer run build\" \"npm --prefix designer-mcp run build\"",
     "test:unit": "npm --prefix designer run test:unit",
     "test:e2e": "npm --prefix designer run test:e2e",

--- a/scripts/check-ports.mjs
+++ b/scripts/check-ports.mjs
@@ -29,7 +29,7 @@ function isPortInUse(port) {
     server.once("listening", () => {
       server.close(() => resolve(false));
     });
-    server.listen(port, "127.0.0.1");
+    server.listen(port, "0.0.0.0");
   });
 }
 

--- a/scripts/check-ports.mjs
+++ b/scripts/check-ports.mjs
@@ -1,0 +1,48 @@
+/**
+ * scripts/check-ports.mjs (#795-B)
+ *
+ * `npm run dev` 前置チェック: 5173 / 5179 が既に LISTENING の場合、
+ * 明示エラーメッセージで exit code 1 で終了する。
+ *
+ * LISTENING でなければ exit 0 (正常起動に進む)。
+ */
+
+import { createServer } from "node:net";
+
+const PORTS = [5173, 5179];
+
+/**
+ * 指定 port が LISTENING 中かを probe する。
+ * - EADDRINUSE: 既に使用中 → true
+ * - その他 / 成功: 未使用 → false
+ */
+function isPortInUse(port) {
+  return new Promise((resolve) => {
+    const server = createServer();
+    server.once("error", (err) => {
+      if (err.code === "EADDRINUSE") {
+        resolve(true);
+      } else {
+        resolve(false);
+      }
+    });
+    server.once("listening", () => {
+      server.close(() => resolve(false));
+    });
+    server.listen(port, "127.0.0.1");
+  });
+}
+
+const results = await Promise.all(PORTS.map(async (port) => ({ port, inUse: await isPortInUse(port) })));
+const occupied = results.filter((r) => r.inUse);
+
+if (occupied.length > 0) {
+  for (const { port } of occupied) {
+    console.error(
+      `\x1b[31m[check-ports]\x1b[0m Port ${port} はすでに使用中です。` +
+      ` 起動済みのプロセスを確認してください (例: 前回の \`npm run dev\` が残っている)。` +
+      ` 終了させてから再実行してください。`,
+    );
+  }
+  process.exit(1);
+}


### PR DESCRIPTION
﻿Closes #795

## 概要

PR #794 の dogfood 過程で発見した開発環境 robustness 改善 4 件を実装。

## 提案 C (最優先): WebSocket 接続失敗 UI 可視化

- `designer/src/mcp/mcpBridge.ts:83` — `McpStatus` に `"failed"` 追加
- `designer/src/mcp/mcpBridge.ts:127` — `connectAttempts` フィールド追加
- `designer/src/mcp/mcpBridge.ts:225-250` — `startWithoutEditor()` が `"failed"` からリトライ可能に修正、`markFailed()` メソッド追加
- `designer/src/mcp/mcpBridge.ts:299` — `_connect()` で `connectAttempts` インクリメント
- `designer/src/components/AppShell.tsx:185-195` — タイムアウト時に `markFailed()` 呼び出しで status 経由遷移
- `designer/src/components/AppShell.tsx:220-223` — `"failed"` status 受信で `connectionFailed=true`
- `designer/src/components/AppShell.tsx:239-243` — retry 時に `everConnectedRef` をリセット
- `designer/src/mcp/mcpBridge.status.test.ts` — 状態遷移 Vitest 5 件

## 提案 A: designer-mcp half-dead 検知 + /health endpoint 拡張

- `designer-mcp/src/wsBridge.ts:155-158` — `lastMessageAt` / `startedAt` フィールド追加
- `designer-mcp/src/wsBridge.ts:163-183` — `getHealth()` メソッド追加
- `designer-mcp/src/wsBridge.ts:267-276` — `/health` レスポンスに `lastWsMessageAt` / `wsConnections` / `uptimeMs` 追加
- `designer-mcp/src/wsBridge.ts:297` — ws メッセージ受信時に `lastMessageAt` 記録
- `designer-mcp/src/httpTransport.test.ts` — `/health` フィールド検証テスト追加 (1 件)

自動再起動は Phase 2 候補として PR description に記録 (本 ISSUE スコープ外)。

## 提案 B: port collision UX 改善

- `scripts/check-ports.mjs` — port 5173 / 5179 probe、`EADDRINUSE` なら明示エラー exit code 1
- `package.json:8` — `dev` script に `node scripts/check-ports.mjs &&` を前置

## 提案 D: .gitignore 追加

既に `main` に含まれていることを確認 (`.claude/worktrees/` / `.claude/scheduled_tasks.lock`)。本 PR でのコミットは不要。

## Test plan

- [x] `cd designer && npm run build` — tsc + Vite build pass
- [x] `cd designer-mcp && npm run build` — tsc pass
- [x] `cd designer && npm run test:unit` — 94 passed (3 pre-existing failures: ResizeObserver jsdom 環境制限)
- [x] `cd designer-mcp && npm test` — 14 passed (httpTransport /health フィールド検証含む)
- [x] `node scripts/check-ports.mjs` — exit 0 (5173/5179 空き時)
- [x] 半角カナチェック: 新規ファイル全て OK

## mcpBridge retry 動作について

markFailed() 後も mcpBridge 内部の ws retry loop は継続し、designer-mcp 起動後は自動で status=connected に回復する。エラー画面の再試行ボタンは即時再接続用、自動回復経路はバックグラウンドで継続。

## 将来課題 (Phase 2 候補)

- designer-mcp の自動 graceful restart (ws 受信 watchdog)
- disconnect 後の連続 retry 失敗検知 → 永続エラー UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
