### PR TITLE
improve(designer): DesignSubToolbar の useEditorOptional try/catch wrapper を Provider-aware ブリッジに置換 (#824)

### DIFF
--- a/designer/src/components/Designer.tsx
+++ b/designer/src/components/Designer.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { checkLegacyLocalStorage, executeRescue, clearLegacyLocalStorage } from "../grapes/legacyLocalStorageRescue";
 import { acknowledgeServerMtime } from "../utils/serverMtime";
-import { DesignSubToolbar } from "./design/DesignSubToolbar";
+import { DesignSubToolbar, DesignSubToolbarGrapesJSBridge } from "./design/DesignSubToolbar";
 import { ServerChangeBanner } from "./common/ServerChangeBanner";
 import { useErrorDialog } from "./common/ErrorDialogProvider";
 import { mcpBridge, type McpStatus } from "../mcp/mcpBridge";
@@ -637,6 +637,8 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
         </div>
       );
     }
+    // Puck 経路: <GjsEditor> ancestor が無いため editor は undefined 固定で props 渡し。
+    // GrapesJS 経路と異なり Provider-aware ブリッジは不要 (#824)。
     const puckSubToolbar = (
       <DesignSubToolbar
         panelMode={panelMode}
@@ -651,6 +653,7 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
         backLink={onBack ? { label: screenName ?? "画面デザイン", onClick: onBack } : undefined}
         screenId={screenId}
         isReadonly={isReadonly}
+        editor={undefined}
       />
     );
     const puckProps: PuckRenderEditorProps = {
@@ -686,8 +689,10 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
       </div>
     );
   }
+  // GrapesJS 経路: GrapesJSEditorPane の <WithEditor> 配下に render されるため、
+  // Provider-aware ブリッジが useEditorMaybe() を Rules-of-Hooks 準拠で呼んで forward する (#824)。
   const grapesSubToolbar = (
-    <DesignSubToolbar
+    <DesignSubToolbarGrapesJSBridge
       panelMode={panelMode}
       onOpenPanel={openPanel}
       activeTheme={activeTheme}

--- a/designer/src/components/design/DesignSubToolbar.test.tsx
+++ b/designer/src/components/design/DesignSubToolbar.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * DesignSubToolbar refactor 回帰テスト (#824)
+ *
+ * 目的:
+ *   - editor=undefined (Puck 経路) で crash しないこと
+ *   - editor=mock (GrapesJS 経路) で editor 由来の機能が動くこと
+ *   - DesignSubToolbarGrapesJSBridge が useEditorMaybe() を呼び editor を forward すること
+ *
+ * 旧実装 (`useEditorOptional` の try/catch wrapper) では Puck 経路は throw を吸収する
+ * 形で同等動作を実現していたが、Rules-of-Hooks anti-pattern だった。本テストは
+ * 「editor を props で受ける」に置換しても両経路で挙動同等であることを保証する。
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// mcpBridge / customBlockStore を全面モック (DesignSubToolbar の useEffect が呼ぶ副作用を遮断)
+vi.mock("../../mcp/mcpBridge", () => {
+  return {
+    mcpBridge: {
+      onBroadcast: vi.fn(() => () => {}),
+      onStatusChange: vi.fn(() => () => {}),
+      setThemeHandler: vi.fn(),
+      setCurrentScreenId: vi.fn(),
+      getClientId: vi.fn(() => "test-client"),
+      request: vi.fn(),
+      start: vi.fn(),
+    },
+  };
+});
+
+vi.mock("../../store/customBlockStore", () => {
+  return {
+    upsertCustomBlock: vi.fn(),
+  };
+});
+
+// AI rename auth-check の fetch を no-op に
+beforeEach(() => {
+  global.fetch = vi.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ authenticated: false }),
+    } as Response),
+  ) as unknown as typeof fetch;
+});
+
+import { DesignSubToolbar } from "./DesignSubToolbar";
+
+const baseProps = {
+  panelMode: "hidden" as const,
+  onOpenPanel: vi.fn(),
+  activeTheme: "standard" as const,
+  onThemeChange: vi.fn(),
+  mcpStatus: "disconnected" as const,
+  isReadonly: false,
+};
+
+describe("DesignSubToolbar — editor prop 化 refactor (#824)", () => {
+  it("editor=undefined (Puck 経路) — Provider 不在環境で crash せず render される", () => {
+    // 旧実装は <GjsEditor> ancestor 不在で useEditorMaybe が throw → useEditorOptional が catch
+    // 新実装は editor prop で受けるので Provider 不要、かつ try/catch 不要
+    expect(() => {
+      render(<DesignSubToolbar {...baseProps} editor={undefined} />);
+    }).not.toThrow();
+
+    // ヘッダ自体は描画される (EditorHeader 経由)
+    expect(screen.getByTestId("editor-header")).toBeInTheDocument();
+  });
+
+  it("editor=undefined — Undo/Redo の canUndo/canRedo は false (editor 由来 API 無効化)", () => {
+    render(<DesignSubToolbar {...baseProps} editor={undefined} />);
+    // EditorHeader が描画する Undo/Redo ボタン (canUndo=false / canRedo=false で disabled)
+    expect(screen.getByTestId("editor-header-undo")).toBeDisabled();
+    expect(screen.getByTestId("editor-header-redo")).toBeDisabled();
+  });
+
+  it("editor=mock (GrapesJS 経路) — UndoManager.hasUndo を呼んで結果を反映する", () => {
+    const hasUndo = vi.fn(() => true);
+    const hasRedo = vi.fn(() => false);
+    const mockEditor = {
+      UndoManager: { hasUndo, hasRedo, undo: vi.fn(), redo: vi.fn() },
+      Devices: { getSelected: vi.fn(() => ({ get: () => "desktop" })) },
+      getSelectedAll: vi.fn(() => []),
+      getSelected: vi.fn(() => null),
+      on: vi.fn(),
+      off: vi.fn(),
+      runCommand: vi.fn(),
+      setDevice: vi.fn(),
+      DomComponents: { clear: vi.fn() },
+      BlockManager: { add: vi.fn() },
+      getHtml: vi.fn(() => ""),
+      getCss: vi.fn(() => ""),
+      select: vi.fn(),
+    };
+
+    render(
+      <DesignSubToolbar
+        {...baseProps}
+        editor={mockEditor as unknown as Parameters<typeof DesignSubToolbar>[0]["editor"]}
+      />,
+    );
+
+    // useEffect 内で hasUndo / hasRedo が呼ばれた = editor prop が渡って effect で使われた
+    expect(hasUndo).toHaveBeenCalled();
+    expect(hasRedo).toHaveBeenCalled();
+    // canUndo=true なので Undo ボタンは enabled
+    expect(screen.getByTestId("editor-header-undo")).not.toBeDisabled();
+  });
+});
+
+describe("DesignSubToolbarGrapesJSBridge (#824)", () => {
+  it("useEditorMaybe() の戻り値を DesignSubToolbar の editor prop に forward する", async () => {
+    // useEditorMaybe を mock し、bridge が呼んで forward することを検証
+    const fakeEditor = {
+      UndoManager: { hasUndo: vi.fn(() => false), hasRedo: vi.fn(() => false), undo: vi.fn(), redo: vi.fn() },
+      Devices: { getSelected: vi.fn(() => ({ get: () => "desktop" })) },
+      getSelectedAll: vi.fn(() => []),
+      getSelected: vi.fn(() => null),
+      on: vi.fn(),
+      off: vi.fn(),
+      runCommand: vi.fn(),
+      setDevice: vi.fn(),
+    };
+    const useEditorMaybeMock = vi.fn(() => fakeEditor);
+
+    vi.doMock("@grapesjs/react", () => ({
+      useEditorMaybe: useEditorMaybeMock,
+    }));
+
+    // doMock 後に動的 import (キャッシュ済み module を mock 後の物に差し替え)
+    vi.resetModules();
+    const { DesignSubToolbarGrapesJSBridge } = await import("./DesignSubToolbar");
+
+    render(<DesignSubToolbarGrapesJSBridge {...baseProps} />);
+
+    // bridge が useEditorMaybe を呼んだ
+    expect(useEditorMaybeMock).toHaveBeenCalled();
+    // forward された結果 editor.UndoManager.hasUndo が DesignSubToolbar の useEffect で呼ばれた
+    expect(fakeEditor.UndoManager.hasUndo).toHaveBeenCalled();
+
+    vi.doUnmock("@grapesjs/react");
+  });
+});

--- a/designer/src/components/design/DesignSubToolbar.tsx
+++ b/designer/src/components/design/DesignSubToolbar.tsx
@@ -1,21 +1,6 @@
 import { useEffect, useState, useCallback, useRef } from "react";
 import type { Editor as GEditor } from "grapesjs";
 import { useEditorMaybe } from "@grapesjs/react";
-
-/**
- * `useEditorMaybe` は内部で `useEditorInstance` を呼び、Provider が無い場合は throw する
- * (editor 自体は undefined を許容するが Provider 自体は必須)。Puck 経路では <GjsEditor>
- * ancestor が無いため Provider missing で crash する。本 wrapper は try/catch で
- * その throw を吸収し、Provider 不在時は undefined を返すことで Puck 経路でも安全に
- * DesignSubToolbar を render できるようにする (#815 follow-up)。
- */
-function useEditorOptional(): GEditor | undefined {
-  try {
-    return useEditorMaybe();
-  } catch {
-    return undefined;
-  }
-}
 import type { PanelMode, ThemeId } from "../Designer";
 import type { McpStatus } from "../../mcp/mcpBridge";
 import { mcpBridge } from "../../mcp/mcpBridge";
@@ -77,14 +62,17 @@ interface Props {
   screenId?: string;
   /** 読み取り専用モードの場合 true — 保存/リセットボタンを非表示にする */
   isReadonly?: boolean;
+  /**
+   * GrapesJS editor instance。GrapesJS 経路は `DesignSubToolbarGrapesJSBridge` 経由で
+   * `<WithEditor>` 配下の `useEditorMaybe()` から得た値を渡す。Puck 経路は undefined。
+   * editor が undefined の場合、GrapesJS 由来の機能 (Undo/Redo/Devices/runCommand 等) は
+   * 無効化される (button disabled / onClick noop)。
+   */
+  editor: GEditor | undefined;
 }
 
-export function DesignSubToolbar({ panelMode, onOpenPanel, activeTheme, onThemeChange, mcpStatus, backLink, isDirty, isSaving, onSaveToFile, onReset, screenId, isReadonly }: Props) {
+export function DesignSubToolbar({ panelMode, onOpenPanel, activeTheme, onThemeChange, mcpStatus, backLink, isDirty, isSaving, onSaveToFile, onReset, screenId, isReadonly, editor }: Props) {
   const [themeMenuOpen, setThemeMenuOpen] = useState(false);
-  // Puck 経路では <GjsEditor> context が存在しないため、Provider missing throw を吸収する
-  // wrapper を使用する。editor が undefined の場合、GrapesJS 由来の機能 (Undo/Redo/Devices/
-  // runCommand 等) は無効化される。
-  const editor = useEditorOptional();
 
   // ── AI 命名 (#337) ───────────────────────────────────────────────────────
   const [aiRenameAuthOk, setAiRenameAuthOk] = useState<boolean | null>(null);
@@ -715,4 +703,24 @@ function ShortcutsHelp({ onClose }: { onClose: () => void }) {
       </div>
     </div>
   );
+}
+
+// ---------------------------------------------------------------------------
+// GrapesJS 専用ブリッジ — Provider-aware に useEditorMaybe() を呼んで forward する
+// ---------------------------------------------------------------------------
+
+/**
+ * `DesignSubToolbarGrapesJSBridge` は GrapesJS 経路 (`<GjsEditor>` 配下) で
+ * `useEditorMaybe()` を Rules-of-Hooks に従って正規呼び出しし、得られた `editor` を
+ * `<DesignSubToolbar>` に props として forward する Provider-aware ブリッジ。
+ *
+ * Puck 経路 (`<GjsEditor>` ancestor 無し) は本ブリッジを **使わず**、Designer.tsx が
+ * 直接 `<DesignSubToolbar editor={undefined} ... />` を render する。これにより
+ * 旧実装の `try/catch` で hook 呼び出しを包む anti-pattern を解消する (#824)。
+ */
+type GrapesJSBridgeProps = Omit<Props, "editor">;
+
+export function DesignSubToolbarGrapesJSBridge(props: GrapesJSBridgeProps) {
+  const editor = useEditorMaybe();
+  return <DesignSubToolbar {...props} editor={editor} />;
 }

--- a/designer/src/editor/GrapesJSBackend.tsx
+++ b/designer/src/editor/GrapesJSBackend.tsx
@@ -5,8 +5,10 @@
  * #806 子 3 / #815 (interface 真の等価性) で完全実装に格上げ。
  *
  * 設計方針:
- * - <GjsEditor> + Canvas + BlocksPanel + RightPanel + DesignSubToolbar (WithEditor 経由)
+ * - <GjsEditor> + Canvas + BlocksPanel + RightPanel + DesignSubToolbarGrapesJSBridge (WithEditor 配下)
  *   をラップした完全なエディタペイン (GrapesJSEditorPane) を ReactNode として返す。
+ *   #824: SubToolbar は editor prop で受ける形に refactor 済 — bridge component が WithEditor 配下で
+ *   useEditorMaybe() を呼んで forward する (旧 try/catch wrapper anti-pattern を解消)。
  * - Designer.tsx は editorKind に関わらず backend.renderEditor(props) を render するだけになり、
  *   <GjsEditor> 直接マウントを廃止する。
  * - editor lifecycle (registerBlocks / registerValidationTraits / mcpBridge.start /
@@ -485,6 +487,10 @@ function GrapesJSEditorPane(props: GrapesJSEditorPaneProps) {
       }
     >
       <div className="designer-layout">
+        {/* WithEditor は editor 初期化完了まで children render を遅延する gate コンポーネント
+            (PropsWithChildren、render prop ではない)。EditorInstanceProvider 自体は <GjsEditor>
+            が提供するため、subToolbarSlot 内の DesignSubToolbarGrapesJSBridge が呼ぶ
+            useEditorMaybe() は GjsEditor の context から editor を取得できる (#824)。 */}
         <WithEditor>{subToolbarSlot}</WithEditor>
 
         {dialogsSlot}


### PR DESCRIPTION
## 関連

- Closes #824
- 起源: PR #823 (#815 follow-up) の Codex 独立レビュー Should-fix
- 仕様: docs/spec 側に該当節なし (React anti-pattern の解消)

## 概要

`DesignSubToolbar` 冒頭の `useEditorOptional` は React hook を `try/catch` でラップする anti-pattern (Rules-of-Hooks / React Compiler 敵対形状) で、Puck 経路で `<GjsEditor>` Provider が不在のため `useEditorMaybe()` が throw する事象を吸収していた。本 PR はこれを「`DesignSubToolbar` は editor を props で受け取り、GrapesJS 経路だけ Provider-aware ブリッジが `useEditorMaybe()` を正規呼び出しする」設計に置換し、anti-pattern を正攻法で解消する。挙動変更なし。

## 主な変更

- **`DesignSubToolbar` Props**: `editor: GEditor | undefined` を必須 prop として追加 (`DesignSubToolbar.tsx:71`)。`useEditorOptional` 関数および `useEditorMaybe` 直接呼び出しを撤去
- **`DesignSubToolbarGrapesJSBridge` 新設**: GrapesJS 経路専用の Provider-aware ブリッジ (`DesignSubToolbar.tsx:721-726`)。`<WithEditor>` 配下で `useEditorMaybe()` を Rules-of-Hooks 準拠で呼び、得られた editor を `DesignSubToolbar` に forward
- **Designer.tsx (Puck 経路)**: `<DesignSubToolbar editor={undefined} ... />` で直接 render (`Designer.tsx:656`)。Provider 不在環境でも安全
- **Designer.tsx (GrapesJS 経路)**: `<DesignSubToolbarGrapesJSBridge ... />` を使用 (`Designer.tsx:695`)。`GrapesJSEditorPane` の `<WithEditor>` 配下に置かれるため `useEditorMaybe()` は throw しない
- **`GrapesJSBackend.tsx`**: ファイルヘッダーコメントを `DesignSubToolbarGrapesJSBridge` に更新、`<WithEditor>` が gate (Provider ではない) である旨をコメントで明示
- **テスト**: `DesignSubToolbar.test.tsx` 新規 4 ケース — editor=undefined / editor=mock / bridge forward を検証

## 仕様逐条突合 (自己申告)

ISSUE #824 の Option A (推奨) 各要件:

- ☑ `useEditorOptional` 撤去 → `DesignSubToolbar.tsx` 冒頭の関数定義 (旧 line 12-18) が完全消滅 (`grep -rn "useEditorOptional" src/` → 0 件)
- ☑ `editor` を props で受け取る → `DesignSubToolbar.tsx:71` `editor: GEditor | undefined` 必須 prop
- ☑ Provider-aware 子コンポーネント切り出し → `DesignSubToolbar.tsx:721-726` `DesignSubToolbarGrapesJSBridge`
- ☑ `editor?.X` の null-safe 参照: #815 で対応済 (本 PR では既存形を維持)
- ☑ Rules-of-Hooks (ESLint) 準拠 → `npx eslint` `No issues found` 実測
- ☑ TypeScript clean → `npx tsc --noEmit` `No errors found` 実測

ISSUE #824 のテスト戦略要件:

- ☑ Vitest: editor=undefined / editor=mock の 2 系統 → `DesignSubToolbar.test.tsx` で 4 ケース実装
- ☑ Vitest 全件 pass → 1611 件 全 pass (新規 4 件) 実測
- ☑ Playwright: 既存 `puck-editor.spec.ts` 等の維持 → 構造変更のみ・既存テスト未変更

## レビューで特に見てほしい箇所

1. **設計判断: bridge を別 component に切り出した** — ISSUE 本文の Option A の具体例は parent 側で `WithEditor` + `React.cloneElement` を使う形だったが、本 PR は **代替形** として「Provider-aware ブリッジを別 component に切り出す」を採用。`cloneElement` を避け、TypeScript で型安全な props 渡しになる
2. **bridge の置き場所**: `DesignSubToolbarGrapesJSBridge` を `DesignSubToolbar.tsx` 同ファイル末尾に置いた。同心円的な責務 (DesignSubToolbar の GrapesJS 専用 wrapper) で 2 ファイル化は過剰と判断
3. **failure mode の変化**: 旧実装は Provider 不在で silent に undefined 返し、新実装は bridge を Provider 外で render すると `useEditorMaybe()` が loud に throw する。debugging が容易になる方向だが、想定外経路で誤用したら crash する点は許容
4. **`editor` を required prop にした**: optional `editor?:` ではなく `editor: GEditor | undefined` 必須にし、TypeScript で渡し漏れを防ぐ形にした

## テスト

- Vitest: 1611 件 全 pass (新規 **4 件**, `DesignSubToolbar.test.tsx`)
  - editor=undefined で crash せず render
  - editor=undefined で Undo/Redo ボタン disabled
  - editor=mock で `UndoManager.hasUndo()` が呼ばれて反映
  - `DesignSubToolbarGrapesJSBridge` が `useEditorMaybe()` を呼んで forward
- Playwright: 既存 `puck-editor.spec.ts` (Puck 経路で DesignSubToolbar が editor 不在時に crash しないこと) でカバー済 — 本 PR で新規 E2E 追加なし
- TypeScript: `npx tsc --noEmit` → No errors found
- ESLint: `npx eslint` (changed files) → No issues found
- Vite build: 成功

## UI 影響 / AI smoke test

- [x] UI 影響なし (auto テスト pass のみ — 構造リファクタで挙動変更なし)
- [ ] UI 影響あり

挙動変更が無いため AI smoke test 省略。Puck / GrapesJS 両経路の動作は既存 e2e + 本 PR で追加した Vitest 4 ケースがカバー。

## spec 側の不足点 / 提案

N/A — spec 影響なし。`docs/spec/multi-editor-puck.md` は本実装の具体名を記載していないため更新不要。

## レビュー担当への申し送り

- **#826 別セッションが進行中**: `feat/issue-826-project-tech-stack` は同じ `Designer.tsx` の `cssFramework` / `editorKind` resolve 周辺 (line 52, 146-160 付近) を触る。本 PR が触るのは line 4 (import) / line 656 / line 695 でレンジ重複なし — マージ順は問わず conflict-free
- **既知 limitation**: `useEditorMaybe()` の Provider 必須挙動 (no Provider → throw) は @grapesjs/react v2.0.0 の実装依存。将来の lib 更新で挙動が変わる可能性は本 PR の責務外
- **anti-pattern 解消の根拠**: React 公式 Rules-of-Hooks (https://react.dev/reference/rules/rules-of-hooks) の "Don't call Hooks inside conditions or loops" に try/catch も該当する一般理解。React Compiler / `react-hooks/rules-of-hooks` ESLint rule の将来 error 化リスクも消去
- **独立レビュー (#828) フォローアップ反映済み**: Should-fix #1 (Vitest 追加) → 4 ケース追加。Nit #1 (WithEditor の gate 役割コメント) → `GrapesJSBackend.tsx:489-493` で明示。Nit #2 (`GrapesJSBackend.tsx:8` 旧名称) → 更新済。Nit #3 (line 番号ズレ) → 本 description で実測値に修正。Should-fix #2 (bridge 配置) → 同ファイル末尾配置を「同心円的責務で 2 ファイル化は過剰」と PR description で根拠明示

🤖 Generated with [Claude Code](https://claude.com/claude-code)