### PR TITLE
test(e2e): 画面遷移 smoke を追加 (#818)

### DIFF
--- a/designer-mcp/src/projectStorage.ts
+++ b/designer-mcp/src/projectStorage.ts
@@ -45,6 +45,7 @@ export function dataDir(root: string): string {
 const screensDir       = (root: string) => path.join(root, "screens");
 const tablesDir        = (root: string) => path.join(root, "tables");
 const actionsDir       = (root: string) => path.join(root, "actions");
+const processFlowsDir  = (root: string) => path.join(root, "process-flows");
 const conventionsDir   = (root: string) => path.join(root, "conventions");
 const screenItemsDir   = (root: string) => path.join(root, "screen-items");
 const sequencesDir     = (root: string) => path.join(root, "sequences");
@@ -138,8 +139,18 @@ async function readJSON<T>(filePath: string): Promise<T | null> {
   }
 }
 
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 async function writeJSON(filePath: string, data: unknown): Promise<void> {
   const json = JSON.stringify(data, null, 2);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
   await fs.writeFile(filePath, json, "utf-8");
 }
 
@@ -516,25 +527,40 @@ export async function listAllTables(root: string): Promise<unknown[]> {
   }
 }
 
-/** actions/{processFlowId}.json を読み込み */
-export async function readProcessFlow(processFlowId: string, root: string): Promise<unknown | null> {
-  const r = root;
-  return readJSON<unknown>(path.join(actionsDir(r), `${processFlowId}.json`));
+function processFlowFileCandidates(root: string, processFlowId: string): string[] {
+  return [
+    path.join(actionsDir(root), `${processFlowId}.json`),
+    path.join(processFlowsDir(root), `${processFlowId}.json`),
+  ];
 }
 
-/** actions/{processFlowId}.json を書き込み */
+/** actions/{processFlowId}.json または process-flows/{processFlowId}.json を読み込み */
+export async function readProcessFlow(processFlowId: string, root: string): Promise<unknown | null> {
+  const r = root;
+  for (const filePath of processFlowFileCandidates(r, processFlowId)) {
+    const data = await readJSON<unknown>(filePath);
+    if (data) return data;
+  }
+  return null;
+}
+
+/** 既存配置を優先して処理フローを書き込み */
 export async function writeProcessFlow(processFlowId: string, data: unknown, root: string): Promise<void> {
   const r = root;
   await ensureDataDir(r);
-  await writeJSON(path.join(actionsDir(r), `${processFlowId}.json`), data);
+  const [legacyPath, currentPath] = processFlowFileCandidates(r, processFlowId);
+  const targetPath = await fileExists(currentPath) ? currentPath : legacyPath;
+  await writeJSON(targetPath, data);
 }
 
-/** actions/{processFlowId}.json を削除（存在しない場合は無視） */
+/** actions/process-flows 両配置の処理フローを削除（存在しない場合は無視） */
 export async function deleteProcessFlow(processFlowId: string, root: string): Promise<void> {
   const r = root;
-  try {
-    await fs.unlink(path.join(actionsDir(r), `${processFlowId}.json`));
-  } catch { /* file not found is OK */ }
+  for (const filePath of processFlowFileCandidates(r, processFlowId)) {
+    try {
+      await fs.unlink(filePath);
+    } catch { /* file not found is OK */ }
+  }
 }
 
 /** conventions/catalog.json を読み込み (#317) */
@@ -685,20 +711,29 @@ export async function deleteViewDefinition(viewDefinitionId: string, root: strin
   } catch { /* file not found is OK */ }
 }
 
-/** actions/ ディレクトリ内の全処理フローを読み込み */
+/** actions/ と process-flows/ ディレクトリ内の全処理フローを読み込み */
 export async function listProcessFlows(root: string): Promise<unknown[]> {
   try {
     const r = root;
     await ensureDataDir(r);
-    const aDir = actionsDir(r);
-    const files = await fs.readdir(aDir);
-    const results: unknown[] = [];
-    for (const file of files) {
-      if (!file.endsWith(".json")) continue;
-      const data = await readJSON<unknown>(path.join(aDir, file));
-      if (data) results.push(data);
+    const byId = new Map<string, unknown>();
+    for (const dir of [processFlowsDir(r), actionsDir(r)]) {
+      let files: string[];
+      try {
+        files = await fs.readdir(dir);
+      } catch {
+        continue;
+      }
+      for (const file of files) {
+        if (!file.endsWith(".json")) continue;
+        const data = await readJSON<unknown>(path.join(dir, file));
+        if (!data || typeof data !== "object") continue;
+        const id = (data as { id?: unknown; meta?: { id?: unknown } }).id
+          ?? (data as { meta?: { id?: unknown } }).meta?.id;
+        byId.set(typeof id === "string" ? id : file.replace(/\.json$/, ""), data);
+      }
     }
-    return results;
+    return Array.from(byId.values());
   } catch {
     return [];
   }

--- a/designer/e2e/helpers/realWorkspace.ts
+++ b/designer/e2e/helpers/realWorkspace.ts
@@ -1,0 +1,36 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export interface RealWorkspaceFixture {
+  key: string;
+  sourcePath: string;
+  workspacePath: string;
+}
+
+const THIS_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(THIS_DIR, "../../..");
+const TMP_ROOT = path.join(REPO_ROOT, ".tmp", "e2e-workspaces");
+
+export function repoPath(...segments: string[]): string {
+  return path.join(REPO_ROOT, ...segments);
+}
+
+export function tempWorkspacePath(key: string): string {
+  return path.join(TMP_ROOT, key);
+}
+
+export async function copyExampleWorkspace(exampleName: string, key: string): Promise<RealWorkspaceFixture> {
+  const sourcePath = repoPath("examples", exampleName);
+  const workspacePath = tempWorkspacePath(key);
+  await fs.rm(workspacePath, { recursive: true, force: true });
+  await fs.mkdir(path.dirname(workspacePath), { recursive: true });
+  await fs.cp(sourcePath, workspacePath, { recursive: true });
+  return { key, sourcePath, workspacePath };
+}
+
+export async function cleanupRealWorkspaces(keys: string[]): Promise<void> {
+  await Promise.all(
+    keys.map((key) => fs.rm(tempWorkspacePath(key), { recursive: true, force: true })),
+  );
+}

--- a/designer/e2e/workspace-navigation-smoke.spec.ts
+++ b/designer/e2e/workspace-navigation-smoke.spec.ts
@@ -1,0 +1,168 @@
+/**
+ * designer-mcp backend (WebSocket bridge) 起動下で、実ワークスペースを使った
+ * 主要画面遷移の smoke test。#818
+ */
+import { test, expect, type Page } from "@playwright/test";
+import { isMcpRunning, sendBrowserRequest } from "./mcp/_helpers";
+import {
+  cleanupRealWorkspaces,
+  copyExampleWorkspace,
+  type RealWorkspaceFixture,
+} from "./helpers/realWorkspace";
+
+let mcpAvailable = false;
+let english: RealWorkspaceFixture;
+let retail: RealWorkspaceFixture;
+
+async function openAddWorkspaceDialog(page: Page): Promise<void> {
+  await page.locator("button").filter({ has: page.locator(".bi-plus-lg") }).first().click();
+  await expect(page.locator(".tbl-modal")).toBeVisible();
+}
+
+async function addWorkspaceFromSelect(page: Page, workspacePath: string): Promise<void> {
+  await page.goto("/workspace/select");
+  await openAddWorkspaceDialog(page);
+  await page.locator(".tbl-modal input[type='text']").fill(workspacePath);
+  await page.locator(".tbl-modal .tbl-btn-primary").click();
+  await expect(page.locator(".tbl-modal .tbl-btn-primary")).toBeEnabled();
+  await page.locator(".tbl-modal .tbl-btn-primary").click();
+  await expect(page).toHaveURL(/\/w\/[^/]+\/$/);
+  await expect(page.locator(".dashboard-view")).toBeVisible();
+}
+
+async function registerWorkspace(path: string): Promise<void> {
+  await sendBrowserRequest("workspace.open", { path });
+}
+
+async function goToWorkspaceList(page: Page): Promise<void> {
+  await page.goto("/workspace/list");
+  await expect(page).toHaveURL("/workspace/list");
+  await expect(page.getByTestId("data-list")).toBeVisible();
+}
+
+async function currentWorkspaceRoot(page: Page): Promise<string> {
+  const pathname = await page.evaluate(() => location.pathname);
+  const match = pathname.match(/^\/w\/[^/]+/);
+  if (!match) throw new Error(`workspace URL expected, got ${pathname}`);
+  return match[0];
+}
+
+async function openWorkspaceFromListByButton(page: Page, workspacePath: string): Promise<void> {
+  const card = page.locator("[data-row-id]", { hasText: workspacePath }).first();
+  await expect(card).toBeVisible();
+  await card.click();
+  await page.locator(".table-list-actions .tbl-btn").filter({ has: page.locator(".bi-folder2-open") }).last().click();
+  await expect(page).toHaveURL(/\/w\/[^/]+\/$/);
+  await expect(page.locator(".dashboard-view")).toBeVisible();
+}
+
+async function openWorkspaceFromListByDoubleClick(page: Page, workspacePath: string): Promise<void> {
+  const card = page.locator("[data-row-id]", { hasText: workspacePath }).first();
+  await expect(card).toBeVisible();
+  await card.dblclick();
+  await expect(page).toHaveURL(/\/w\/[^/]+\/$/);
+  await expect(page.locator(".dashboard-view")).toBeVisible();
+}
+
+async function openWorkspaceFromListByEnter(page: Page, workspacePath: string): Promise<void> {
+  const card = page.locator("[data-row-id]", { hasText: workspacePath }).first();
+  await expect(card).toBeVisible();
+  await card.click();
+  await expect(card).toHaveClass(/selected/);
+  await page.keyboard.press("Enter");
+  await expect(page).toHaveURL(/\/w\/[^/]+\/$/);
+  await expect(page.locator(".dashboard-view")).toBeVisible();
+}
+
+async function navigateFromHeader(page: Page, label: string, expectedUrl: RegExp, contentSelector: string): Promise<void> {
+  await page.locator(".header-menu-btn").click();
+  await page.locator(".header-menu-item").filter({ hasText: label }).click();
+  await expect(page).toHaveURL(expectedUrl);
+  await expect(page.locator(contentSelector)).toBeVisible();
+}
+
+async function openFirstResource(page: Page, listPath: string, editorUrl: RegExp, editorSelector: string): Promise<void> {
+  await page.goto(listPath);
+  await expect(page.getByTestId("data-list")).toBeVisible();
+  const item = page.locator("[data-row-id]").first();
+  await expect(item).toBeVisible();
+  await item.dblclick();
+  await expect(page).toHaveURL(editorUrl);
+  await expect(page.locator(editorSelector).first()).toBeVisible();
+  await expect(page.locator(".tabbar-tab.active")).toBeVisible();
+}
+
+test.describe("workspace navigation smoke with designer-mcp backend", () => {
+  test.beforeAll(async () => {
+    mcpAvailable = await isMcpRunning();
+    if (!mcpAvailable) return;
+    english = await copyExampleWorkspace("english-learning", "issue-818-english-learning");
+    retail = await copyExampleWorkspace("retail", "issue-818-retail");
+    await registerWorkspace(english.workspacePath);
+    await registerWorkspace(retail.workspacePath);
+  });
+
+  test.afterAll(async () => {
+    if (!mcpAvailable) return;
+    await cleanupRealWorkspaces(["issue-818-english-learning", "issue-818-retail"]);
+  });
+
+  test.beforeEach(async () => {
+    test.skip(!mcpAvailable, "designer-mcp backend (port 5179) is not running");
+  });
+
+  test("workspace/select から実ワークスペースを追加してダッシュボードへ遷移できる", async ({ page }) => {
+    await addWorkspaceFromSelect(page, english.workspacePath);
+  });
+
+  test("workspace/list から開くボタン・ダブルクリック・Enter で切り替えできる", async ({ page }) => {
+    await goToWorkspaceList(page);
+    await openWorkspaceFromListByButton(page, english.workspacePath);
+
+    await goToWorkspaceList(page);
+    await openWorkspaceFromListByDoubleClick(page, retail.workspacePath);
+
+    await goToWorkspaceList(page);
+    await openWorkspaceFromListByEnter(page, english.workspacePath);
+  });
+
+  test("HeaderMenu の主要項目から各 singleton 画面へ遷移できる", async ({ page }) => {
+    await addWorkspaceFromSelect(page, english.workspacePath);
+    const wsPrefix = /\/w\/[^/]+/;
+
+    await navigateFromHeader(page, "画面フロー", new RegExp(`${wsPrefix.source}/screen/flow$`), ".flow-root");
+    await navigateFromHeader(page, "画面一覧", new RegExp(`${wsPrefix.source}/screen/list$`), ".screen-list-page");
+    await navigateFromHeader(page, "テーブル一覧", new RegExp(`${wsPrefix.source}/table/list$`), ".table-list-page");
+    await navigateFromHeader(page, "ER図", new RegExp(`${wsPrefix.source}/table/er$`), ".er-diagram, .er-diagram-page, .er-page");
+    await navigateFromHeader(page, "処理フロー一覧", new RegExp(`${wsPrefix.source}/process-flow/list$`), ".process-flow-page");
+    await navigateFromHeader(page, "拡張管理", new RegExp(`${wsPrefix.source}/extensions$`), ".extensions-panel, .extensions-page");
+    await navigateFromHeader(page, "ダッシュボード", new RegExp(`${wsPrefix.source}/$`), ".dashboard-view");
+  });
+
+  test("一覧から画面・テーブル・処理フローの個別エディタを開ける", async ({ page }) => {
+    await addWorkspaceFromSelect(page, english.workspacePath);
+    const wsRoot = await currentWorkspaceRoot(page);
+    const wsPrefix = "/w/[^/]+";
+
+    await openFirstResource(
+      page,
+      `${wsRoot}/screen/list`,
+      new RegExp(`${wsPrefix}/screen/design/[^/]+$`),
+      ".designer-root, [data-testid='puck-editor-container']",
+    );
+
+    await openFirstResource(
+      page,
+      `${wsRoot}/table/list`,
+      new RegExp(`${wsPrefix}/table/edit/[^/]+$`),
+      ".table-editor-page",
+    );
+
+    await openFirstResource(
+      page,
+      `${wsRoot}/process-flow/list`,
+      new RegExp(`${wsPrefix}/process-flow/edit/[^/]+$`),
+      ".process-flow-page",
+    );
+  });
+});

--- a/designer/src/components/AppShell.tsx
+++ b/designer/src/components/AppShell.tsx
@@ -702,7 +702,7 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
     const expectedPath =
       activeTab.type === "design"             ? `${wp}/screen/design/${activeTab.resourceId}`
       : activeTab.type === "table"            ? `${wp}/table/edit/${activeTab.resourceId}`
-      : activeTab.type === "action"           ? `${wp}/process-flow/edit/${activeTab.resourceId}`
+      : activeTab.type === "process-flow"     ? `${wp}/process-flow/edit/${activeTab.resourceId}`
       : activeTab.type === "sequence"         ? `${wp}/sequence/edit/${activeTab.resourceId}`
       : activeTab.type === "view"             ? `${wp}/view/edit/${activeTab.resourceId}`
       : activeTab.type === "view-definition"  ? `${wp}/view-definition/edit/${activeTab.resourceId}`

--- a/designer/src/components/workspace/WorkspaceListView.tsx
+++ b/designer/src/components/workspace/WorkspaceListView.tsx
@@ -16,6 +16,7 @@ import { FilterBar } from "../common/FilterBar";
 import { SortBar } from "../common/SortBar";
 import { ViewModeToggle, type ViewMode } from "../common/ViewModeToggle";
 import { useListSelection } from "../../hooks/useListSelection";
+import { useListKeyboard } from "../../hooks/useListKeyboard";
 import { useListFilter } from "../../hooks/useListFilter";
 import { useListSort } from "../../hooks/useListSort";
 import { usePersistentState } from "../../hooks/usePersistentState";
@@ -458,6 +459,16 @@ export function WorkspaceListView() {
 
   const selectedCount = selection.selectedIds.size;
   const selectedItem = selection.selectedItems[0] ?? null;
+
+  useListKeyboard({
+    items: sort.sorted,
+    getId: (w) => w.id,
+    selection,
+    sort,
+    layout: viewMode === "card" ? "grid" : "list",
+    onActivate: handleActivate,
+    enabled: !lockdown,
+  });
 
   return (
     <div className="table-list-page">


### PR DESCRIPTION
## 関連

- Closes #818
- 仕様: Issue #818 本文「テスト対象シナリオ」
  - 1. ようこそ → ワークスペース追加 → ダッシュボード遷移
  - 2. ワークスペース一覧経由の切替
  - 3. ヘッダーメニュー全項目の遷移
  - 4. 個別リソースエディタへの遷移

## 概要

designer-mcp backend 起動下で、実ワークスペースを使った画面遷移 smoke E2E を追加します。#817 系の navigate 抜けを検出できるようにし、実サンプルの `process-flows/` 配置も backend から読めるようにします。

## 主な変更

- 実ワークスペース fixture: `examples/english-learning` / `examples/retail` を `.tmp/e2e-workspaces/` にコピーして Playwright で開く helper を追加
- Navigation smoke: ワークスペース追加、一覧からの開く/ダブルクリック/Enter、HeaderMenu、画面/テーブル/処理フロー個別エディタ遷移を検証
- ワークスペース一覧: 既存 `useListKeyboard` を接続し、選択行の Enter 起動を有効化
- URL/tab 同期: `process-flow` タブの active tab → URL 同期 typo を修正
- backend storage: 既存 `actions/` に加えて `process-flows/` 配下の処理フローを read/list/write/delete 対象に追加

## 仕様逐条突合 (自己申告)

- シナリオ 1: `/workspace/select` → 実 workspace path 入力 → `/w/<wsId>/` ダッシュボード着地 → `designer/e2e/workspace-navigation-smoke.spec.ts:22-30`, `designer/e2e/workspace-navigation-smoke.spec.ts:114-116` ✓
- シナリオ 2: workspace/list から「開く」ボタン → dashboard → `designer/e2e/workspace-navigation-smoke.spec.ts:50-56`, `designer/e2e/workspace-navigation-smoke.spec.ts:118-121` ✓
- シナリオ 2: workspace/list からダブルクリック → dashboard → `designer/e2e/workspace-navigation-smoke.spec.ts:59-64`, `designer/e2e/workspace-navigation-smoke.spec.ts:122-124` ✓
- シナリオ 2: workspace/list から Enter → dashboard → `designer/e2e/workspace-navigation-smoke.spec.ts:67-74`, `designer/src/components/workspace/WorkspaceListView.tsx:463-471` ✓
- シナリオ 3: HeaderMenu 主要項目の URL と root 表示確認 → `designer/e2e/workspace-navigation-smoke.spec.ts:77-81`, `designer/e2e/workspace-navigation-smoke.spec.ts:129-140` ✓
- シナリオ 4: 画面/テーブル/処理フロー一覧から個別エディタへ遷移し active tab を確認 → `designer/e2e/workspace-navigation-smoke.spec.ts:84-92`, `designer/e2e/workspace-navigation-smoke.spec.ts:142-167` ✓
- fixture workspace は examples 直編集を避け `.tmp/e2e-workspaces/` にコピー → `designer/e2e/helpers/realWorkspace.ts:11-35` ✓
- `process-flows/` 実サンプルを backend から read/list 可能 → `designer-mcp/src/projectStorage.ts:48`, `designer-mcp/src/projectStorage.ts:530-553`, `designer-mcp/src/projectStorage.ts:714-736` ✓
- process-flow editor の tab → URL 同期 → `designer/src/components/AppShell.tsx:702-705` ✓
- schema governance: `git diff -- schemas/` が空であることを確認 ✓

## レビューで特に見てほしい箇所

- `designer-mcp/src/projectStorage.ts`: `actions/` と `process-flows/` の共存時の優先順位。現実装は read/list は両方、write は既存 `process-flows/<id>.json` があればそこを優先し、なければ従来どおり `actions/` に書きます。
- `designer/e2e/workspace-navigation-smoke.spec.ts`: backend 未起動時は skip する設計。常時 CI 実行にする場合は designer-mcp の webServer 起動を別途検討してください。
- `designer/src/components/AppShell.tsx`: `TabType` には旧 `action` と現 `process-flow` が併存していますが、実際に openTab される process-flow editor は `process-flow` なので同期先を修正しています。

## テスト

- Vitest: N/A
- Playwright: 4 件 (新規 4 件) — `workspace-navigation-smoke.spec.ts`
- MCP E2E: WebSocket bridge 起動下の Playwright smoke。現行 5179 常駐 backend が旧コードの状態では 3/4 pass、`process-flows/` fallback を含む本ブランチ backend では `projectStorage` 直検証で read/list pass
- Build: `cd designer && npm run build` pass
- Build: `cd designer-mcp && npm run build` pass
- ESLint: 変更ファイル限定 `npx eslint e2e/workspace-navigation-smoke.spec.ts e2e/helpers/realWorkspace.ts src/components/workspace/WorkspaceListView.tsx src/components/AppShell.tsx` error なし (既存 AppShell warning のみ)
- 全体 lint: 既存違反多数で fail

## UI 影響 / AI smoke test

- [x] UI 影響あり (AI が chrome-devtools MCP / Playwright で smoke test 実施済み)
- [ ] UI 影響なし (auto テスト pass のみ)

### UI 影響ありの場合、AI smoke test で確認した項目

- [x] workspace/select: 実 workspace path 追加で dashboard に遷移 — Playwright で確認
- [x] workspace/list: 開くボタン・ダブルクリック・Enter の遷移 — Playwright で確認
- [x] HeaderMenu: 主要 singleton 画面の URL と root 表示 — Playwright で確認
- [x] 一覧 → 個別エディタ: 画面/テーブルは Playwright で確認、処理フローは旧 5179 backend のため Playwright 上では旧コード由来で失敗、本ブランチ backend の `projectStorage` 直検証で読み込み修正を確認
- [x] 保存直後の JSON が Git 差分で揺れない — `.tmp/e2e-workspaces/` を使用し git tracked examples は非変更
- [x] 既存機能のリグレッションなし — build pass

## spec 側の不足点 / 提案

- Issue #818 は `process-flows/` と backend の旧 `actions/` 呼称差までは明記していませんでした。実サンプルを使う smoke によって不整合が顕在化したため、本 PR 内で同根修正として吸収しています。
- dashboard widget 経由の遷移は「該当 UI が存在する場合」とされているため、本 PR では HeaderMenu と一覧起点の smoke に絞っています。

## レビュー担当への申し送り

- Claude Code からも通常の `cd designer && npm run test:e2e` で本 spec は実行対象になります。designer-mcp backend が未起動なら `test.skip`、起動中なら実行されます。
- 5179 に既存常駐 backend がいる環境では、その backend が本ブランチのコードで再起動されている必要があります。旧 backend のままだと `process-flows/` 読み込みだけ失敗します。
- PR 作成前に `git diff -- schemas/` が空であることを確認済みです。
