### PR TITLE
improve(designer): TechStackView 右ペイン未設定時 placeholder 表示 — #826 follow-up

### DIFF
--- a/designer/src/components/project/TechStackView.tsx
+++ b/designer/src/components/project/TechStackView.tsx
@@ -334,15 +334,18 @@ function DeploymentPanel({
 
 function SummarySection({ label, lines }: { label: string; lines: string[] }) {
   const nonEmpty = lines.filter(Boolean);
-  if (nonEmpty.length === 0) return null;
   return (
     <div style={{ marginBottom: 14 }}>
       <div style={{ fontSize: 11, color: "#777", textTransform: "uppercase" as const, letterSpacing: 1, marginBottom: 4 }}>
         {label}
       </div>
-      {nonEmpty.map((line, i) => (
-        <div key={i} style={{ fontSize: 12, color: "#ccc" }}>{line}</div>
-      ))}
+      {nonEmpty.length === 0 ? (
+        <div style={{ fontSize: 12, color: "#666", fontStyle: "italic" }}>(未設定)</div>
+      ) : (
+        nonEmpty.map((line, i) => (
+          <div key={i} style={{ fontSize: 12, color: "#ccc" }}>{line}</div>
+        ))
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

PR #829 (#826) の Sonnet 独立レビュー Nit として記録された UX 改善。`TechStackView` の右ペイン (`SummarySection`) が空の lines のときラベルごと非表示になっていたため、初期状態でほぼ空のサマリペインに見えていた問題を修正。

## 起票せずに直接 PR にした理由 (新鉄則 1 準拠)

- 1 ファイル / 1 関数 / 7 行の小修正
- AGENTS.md 鉄則 1: 本 PR (#829) はマージ済 → follow-up small PR で吸収。ISSUE 化せず、放置もしない (鉄則 0 準拠)

## 変更

```diff
-  if (nonEmpty.length === 0) return null;
   return (
     <div style={{ marginBottom: 14 }}>
       <div style={{ ...label styling... }}>{label}</div>
-      {nonEmpty.map((line, i) => (
-        <div key={i} style={{ fontSize: 12, color: "#ccc" }}>{line}</div>
-      ))}
+      {nonEmpty.length === 0 ? (
+        <div style={{ fontSize: 12, color: "#666", fontStyle: "italic" }}>(未設定)</div>
+      ) : (
+        nonEmpty.map((line, i) => (
+          <div key={i} style={{ fontSize: 12, color: "#ccc" }}>{line}</div>
+        ))
+      )}
     </div>
   );
```

## Test plan

- [x] `npm run build`: success
- [x] lint clean
- [ ] **dev server 実機 smoke は未実施** — `/project/tech-stack` 開いて初期状態 (techStack 全カテゴリ未設定) で右ペインに「(未設定)」が表示されることを確認推奨

## 関連

- 起源: PR #829 (#826) Sonnet 独立レビュー Nit
- 整合: 既存 PR #829 で導入された TechStackView 右ペイン構造の改善

🤖 Generated with [Claude Code](https://claude.com/claude-code)