### PR TITLE
bug(designer): project.json 保存破壊修正 + Puck canvas theme CSS 注入 (#835)

### DIFF
--- a/designer/src/editor/PuckBackend.tsx
+++ b/designer/src/editor/PuckBackend.tsx
@@ -22,6 +22,13 @@ import { Puck } from "@measured/puck";
 import type { Data, Config } from "@measured/puck";
 import "@measured/puck/puck.css";
 
+// Puck canvas はメイン app DOM 内に描画されるため、GrapesJS の canvas iframe と異なり
+// theme CSS をメイン document.head に直接注入する必要がある (#835)。
+const PUCK_THEME_URLS: Record<"bootstrap" | "tailwind", string> = {
+  bootstrap: new URL("../styles/themes/theme-bootstrap.css", import.meta.url).href,
+  tailwind: new URL("../styles/themes/theme-tailwind.css", import.meta.url).href,
+};
+
 import type {
   EditorApi,
   EditorBackend,
@@ -183,6 +190,22 @@ function PuckEditorPane({
   useEffect(() => {
     currentDataRef.current = currentData;
   }, [currentData]);
+
+  // theme CSS を document.head に注入する。GrapesJS は canvas iframe に注入するが、
+  // Puck はメイン app DOM 内に直接 render するためこちらで対応する (#835)。
+  useEffect(() => {
+    const ID = "puck-theme-css";
+    const existing = document.getElementById(ID);
+    if (existing) existing.remove();
+    const link = document.createElement("link");
+    link.id = ID;
+    link.rel = "stylesheet";
+    link.href = PUCK_THEME_URLS[cssFramework];
+    document.head.appendChild(link);
+    return () => {
+      link.remove();
+    };
+  }, [cssFramework]);
 
   const reloadCustomComponents = useCallback(async () => {
     try {

--- a/designer/src/editor/PuckBackend.tsx
+++ b/designer/src/editor/PuckBackend.tsx
@@ -193,6 +193,8 @@ function PuckEditorPane({
 
   // theme CSS を document.head に注入する。GrapesJS は canvas iframe に注入するが、
   // Puck はメイン app DOM 内に直接 render するためこちらで対応する (#835)。
+  // mount 中のみ <head> へ注入。主 app の Bootstrap chrome と一部 utility が global collision するが、
+  // unmount 時 cleanup で解消。完全 scoping は別 ISSUE。
   useEffect(() => {
     const ID = "puck-theme-css";
     const existing = document.getElementById(ID);

--- a/designer/src/store/flowStore.roundtrip.test.ts
+++ b/designer/src/store/flowStore.roundtrip.test.ts
@@ -5,10 +5,11 @@
  * saveProject 経路で失われないことを検証する。
  */
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import type { FlowStorageBackend } from "./flowStore";
+import type { FlowStorageBackend, LegacyFlowProject } from "./flowStore";
 import {
   composeFlowProject,
   decomposeFlowProject,
+  legacyToProject,
   setFlowStorageBackend,
   setFlowDraftMode,
   saveProject,
@@ -193,5 +194,26 @@ describe("saveProject round-trip preservation (backend mock)", () => {
     await saveProject(flow);
 
     expect(savedProject!.meta.id).toBe(PROJ_ID);
+  });
+});
+
+describe("legacyToProject UUID 発番 (#835 Should-fix 1)", () => {
+  it("ハードコード UUID ではなく generateUUID() で新採番される", () => {
+    const legacy: LegacyFlowProject = {
+      version: 1,
+      name: "レガシープロジェクト",
+      screens: [],
+      groups: [],
+      edges: [],
+      updatedAt: "2026-01-01T00:00:00.000Z" as import("../types/v3").Timestamp,
+    };
+    const project = legacyToProject(legacy);
+
+    // UUID v4 形式であること
+    expect(project.meta.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+    // ハードコード値ではないこと
+    expect(project.meta.id).not.toBe("00000000-0000-4000-8000-000000000001");
   });
 });

--- a/designer/src/store/flowStore.roundtrip.test.ts
+++ b/designer/src/store/flowStore.roundtrip.test.ts
@@ -1,0 +1,197 @@
+/**
+ * flowStore.roundtrip.test.ts — decomposeFlowProject round-trip preservation (#835)
+ *
+ * techStack / extensionsApplied / meta.id / meta.description / screen.html 等が
+ * saveProject 経路で失われないことを検証する。
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { FlowStorageBackend } from "./flowStore";
+import {
+  composeFlowProject,
+  decomposeFlowProject,
+  setFlowStorageBackend,
+  setFlowDraftMode,
+  saveProject,
+} from "./flowStore";
+import type { FlowProject } from "../types/flow";
+import type {
+  Project,
+  ProjectId,
+  ScreenId,
+  ScreenLayout,
+  Timestamp,
+} from "../types/v3";
+
+const TS = "2026-05-05T00:00:00.000Z" as Timestamp;
+const PROJ_ID = "5352b9ca-92d1-43c1-aed7-02a1fdbea85a" as ProjectId;
+const SCREEN_ID = "496e43f8-d243-48a1-b680-32d34d98cc2d" as ScreenId;
+
+/** techStack / extensionsApplied / description / 画面の追加フィールド html を持つリッチな Project */
+function mkRichProject(): Project {
+  return {
+    $schema: "../../schemas/v3/project.v3.schema.json",
+    schemaVersion: "v3",
+    meta: {
+      id: PROJ_ID,
+      name: "英会話学習アプリ (Tailwind 版)",
+      description: "テスト用説明文",
+      createdAt: TS,
+      updatedAt: TS,
+      mode: "upstream",
+      maturity: "draft",
+    },
+    extensionsApplied: [{ namespace: "english-learning", version: ">=1.0.0" }],
+    techStack: {
+      designer: { editorKind: "puck", cssFramework: "tailwind" },
+      backend: { language: "typescript", framework: "nestjs" },
+    },
+    entities: {
+      screens: [
+        {
+          id: SCREEN_ID,
+          no: 1,
+          name: "ダッシュボード",
+          kind: "dashboard",
+          path: "/",
+          hasDesign: false,
+          updatedAt: TS,
+          // 追加フィールド (schema 拡張等で将来追加されうるフィールドのシミュレーション)
+          maturity: "draft",
+        },
+      ],
+      screenGroups: [],
+      screenTransitions: [],
+    },
+  };
+}
+
+function mkLayout(): ScreenLayout {
+  return {
+    positions: {
+      [SCREEN_ID]: { x: 100, y: 150, width: 200, height: 100 },
+    },
+    transitions: {},
+    updatedAt: TS,
+  };
+}
+
+describe("decomposeFlowProject round-trip preservation (#835)", () => {
+  it("existingRaw を渡すと meta.id が保持される", () => {
+    const existing = mkRichProject();
+    const flow = composeFlowProject(existing, mkLayout());
+    const { project: decomposed } = decomposeFlowProject(flow, mkLayout(), existing);
+
+    expect(decomposed.meta.id).toBe(PROJ_ID);
+  });
+
+  it("existingRaw を渡すと techStack が保持される", () => {
+    const existing = mkRichProject();
+    const flow = composeFlowProject(existing, mkLayout());
+    const { project: decomposed } = decomposeFlowProject(flow, mkLayout(), existing);
+
+    expect(decomposed.techStack).toEqual(existing.techStack);
+  });
+
+  it("existingRaw を渡すと extensionsApplied が保持される", () => {
+    const existing = mkRichProject();
+    const flow = composeFlowProject(existing, mkLayout());
+    const { project: decomposed } = decomposeFlowProject(flow, mkLayout(), existing);
+
+    expect(decomposed.extensionsApplied).toEqual([
+      { namespace: "english-learning", version: ">=1.0.0" },
+    ]);
+  });
+
+  it("existingRaw を渡すと meta.description が保持される", () => {
+    const existing = mkRichProject();
+    const flow = composeFlowProject(existing, mkLayout());
+    const { project: decomposed } = decomposeFlowProject(flow, mkLayout(), existing);
+
+    expect((decomposed.meta as { description?: string }).description).toBe("テスト用説明文");
+  });
+
+  it("existingRaw を渡すと meta.createdAt が保持される", () => {
+    const existing = mkRichProject();
+    const flow = composeFlowProject(existing, mkLayout());
+    const { project: decomposed } = decomposeFlowProject(flow, mkLayout(), existing);
+
+    expect(decomposed.meta.createdAt).toBe(TS);
+  });
+
+  it("existingRaw を渡すと同 id 画面の追加フィールド (maturity) が保持される", () => {
+    const existing = mkRichProject();
+    const flow = composeFlowProject(existing, mkLayout());
+    const { project: decomposed } = decomposeFlowProject(flow, mkLayout(), existing);
+
+    const screen = decomposed.entities?.screens?.find((s) => s.id === SCREEN_ID);
+    expect((screen as { maturity?: string } | undefined)?.maturity).toBe("draft");
+  });
+
+  it("existingRaw なしだと meta.id は generateUUID() で新採番される", () => {
+    const existing = mkRichProject();
+    const flow = composeFlowProject(existing, mkLayout());
+    // existingRaw を渡さない
+    const { project: decomposed } = decomposeFlowProject(flow, mkLayout());
+
+    // UUID v4 形式であること
+    expect(decomposed.meta.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+    // ハードコード値ではないこと
+    expect(decomposed.meta.id).not.toBe("00000000-0000-4000-8000-000000000001");
+  });
+
+  it("existingRaw なしだと techStack は undefined になる", () => {
+    const existing = mkRichProject();
+    const flow = composeFlowProject(existing, mkLayout());
+    const { project: decomposed } = decomposeFlowProject(flow, mkLayout());
+
+    expect(decomposed.techStack).toBeUndefined();
+  });
+});
+
+describe("saveProject round-trip preservation (backend mock)", () => {
+  let savedProject: Project | null = null;
+  let backendProject: Project;
+
+  beforeEach(() => {
+    savedProject = null;
+    backendProject = mkRichProject();
+    setFlowDraftMode(false);
+
+    const backend: FlowStorageBackend = {
+      loadProject: vi.fn().mockImplementation(() => Promise.resolve(backendProject)),
+      saveProject: vi.fn().mockImplementation((p: unknown) => {
+        savedProject = p as Project;
+        backendProject = p as Project;
+        return Promise.resolve();
+      }),
+      deleteScreenData: vi.fn().mockResolvedValue(undefined),
+    };
+    setFlowStorageBackend(backend);
+  });
+
+  it("saveProject 後も techStack が保持される", async () => {
+    const flow: FlowProject = composeFlowProject(backendProject, mkLayout());
+    await saveProject(flow);
+
+    expect(savedProject).not.toBeNull();
+    expect(savedProject!.techStack).toEqual(backendProject.techStack);
+  });
+
+  it("saveProject 後も extensionsApplied が保持される", async () => {
+    const flow: FlowProject = composeFlowProject(backendProject, mkLayout());
+    await saveProject(flow);
+
+    expect(savedProject!.extensionsApplied).toEqual([
+      { namespace: "english-learning", version: ">=1.0.0" },
+    ]);
+  });
+
+  it("saveProject 後も meta.id が保持される", async () => {
+    const flow: FlowProject = composeFlowProject(backendProject, mkLayout());
+    await saveProject(flow);
+
+    expect(savedProject!.meta.id).toBe(PROJ_ID);
+  });
+});

--- a/designer/src/store/flowStore.roundtrip.test.ts
+++ b/designer/src/store/flowStore.roundtrip.test.ts
@@ -10,6 +10,7 @@ import {
   composeFlowProject,
   decomposeFlowProject,
   legacyToProject,
+  saveTechStack,
   setFlowStorageBackend,
   setFlowDraftMode,
   saveProject,
@@ -215,5 +216,40 @@ describe("legacyToProject UUID 発番 (#835 Should-fix 1)", () => {
     );
     // ハードコード値ではないこと
     expect(project.meta.id).not.toBe("00000000-0000-4000-8000-000000000001");
+  });
+});
+
+describe("saveTechStack AJV validation (#835 Should-fix 2)", () => {
+  it("不正な techStack を渡すと assertValidProject が例外を投げ saveProject は呼ばれない", async () => {
+    const richProject = mkRichProject();
+    setFlowDraftMode(false);
+    const backend: FlowStorageBackend = {
+      loadProject: vi.fn().mockResolvedValue(richProject),
+      saveProject: vi.fn().mockResolvedValue(undefined),
+      deleteScreenData: vi.fn().mockResolvedValue(undefined),
+    };
+    setFlowStorageBackend(backend);
+
+    // editorKind に enum 違反値を渡す → assertValidProject が throw する
+    const invalidTechStack = {
+      designer: { editorKind: "INVALID_EDITOR" as unknown as "grapesjs", cssFramework: "tailwind" as const },
+    };
+    await expect(saveTechStack(invalidTechStack)).rejects.toThrow(/schema validation failed/);
+    // validation で中断されるため saveProject は呼ばれない
+    expect(backend.saveProject).not.toHaveBeenCalled();
+  });
+
+  it("正常な techStack では saveProject が呼ばれる", async () => {
+    const richProject = mkRichProject();
+    setFlowDraftMode(false);
+    const backend: FlowStorageBackend = {
+      loadProject: vi.fn().mockResolvedValue(richProject),
+      saveProject: vi.fn().mockResolvedValue(undefined),
+      deleteScreenData: vi.fn().mockResolvedValue(undefined),
+    };
+    setFlowStorageBackend(backend);
+
+    await expect(saveTechStack({ designer: { editorKind: "puck", cssFramework: "tailwind" } })).resolves.not.toThrow();
+    expect(backend.saveProject).toHaveBeenCalledOnce();
   });
 });

--- a/designer/src/store/flowStore.roundtrip.test.ts
+++ b/designer/src/store/flowStore.roundtrip.test.ts
@@ -219,6 +219,116 @@ describe("legacyToProject UUID 発番 (#835 Should-fix 1)", () => {
   });
 });
 
+describe("decomposeFlowProject screen id mismatch (negative paths) (#836)", () => {
+  const OTHER_SCREEN_ID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee" as ScreenId;
+  const NEW_SCREEN_ID = "11111111-2222-4333-8444-555555555555" as ScreenId;
+
+  /** existingRaw に OTHER_SCREEN_ID 画面を追加した Project を返す */
+  function mkRichProjectWith2Screens(): Project {
+    const base = mkRichProject();
+    return {
+      ...base,
+      entities: {
+        ...base.entities,
+        screens: [
+          ...(base.entities?.screens ?? []),
+          {
+            id: OTHER_SCREEN_ID,
+            no: 2,
+            name: "追加既存画面",
+            kind: "list",
+            path: "/other",
+            hasDesign: false,
+            updatedAt: TS,
+            maturity: "committed",
+          } as (typeof base.entities.screens)[number],
+        ],
+      },
+    };
+  }
+
+  it("existingRaw にあるが FlowProject にない orphan screen は drop される (FlowProject が正本)", () => {
+    // existing: SCREEN_ID + OTHER_SCREEN_ID の 2 画面
+    const existing = mkRichProjectWith2Screens();
+    // FlowProject は SCREEN_ID のみ (OTHER_SCREEN_ID は除外)
+    const flow = composeFlowProject(mkRichProject(), mkLayout());
+
+    const { project: decomposed } = decomposeFlowProject(flow, mkLayout(), existing);
+
+    // OTHER_SCREEN_ID (existingRaw 側だけにある orphan) は drop される
+    const orphan = decomposed.entities?.screens?.find((s) => s.id === OTHER_SCREEN_ID);
+    expect(orphan).toBeUndefined();
+    // SCREEN_ID は保持される
+    const kept = decomposed.entities?.screens?.find((s) => s.id === SCREEN_ID);
+    expect(kept).toBeDefined();
+  });
+
+  it("FlowProject にあるが existingRaw にない new screen は追加される (existing フィールドなし)", () => {
+    const existing = mkRichProject(); // SCREEN_ID のみ
+    // FlowProject に NEW_SCREEN_ID を追加した Project を合成する
+    const existingWithNew: Project = {
+      ...existing,
+      entities: {
+        ...existing.entities,
+        screens: [
+          ...(existing.entities?.screens ?? []),
+          {
+            id: NEW_SCREEN_ID,
+            no: 2,
+            name: "追加画面",
+            kind: "form",
+            path: "/extra",
+            hasDesign: false,
+            updatedAt: TS,
+          },
+        ],
+      },
+    };
+    const flow = composeFlowProject(existingWithNew, {
+      positions: {
+        [SCREEN_ID]: { x: 100, y: 150, width: 200, height: 100 },
+        [NEW_SCREEN_ID]: { x: 300, y: 150, width: 200, height: 100 },
+      },
+      transitions: {},
+      updatedAt: TS,
+    });
+
+    // existingRaw には NEW_SCREEN_ID がない (SCREEN_ID だけの existing を渡す)
+    const { project: decomposed } = decomposeFlowProject(flow, mkLayout(), existing);
+
+    // NEW_SCREEN_ID は FlowProject にあるので追加される
+    const added = decomposed.entities?.screens?.find((s) => s.id === NEW_SCREEN_ID);
+    expect(added).toBeDefined();
+    expect(added?.name).toBe("追加画面");
+    // existing に該当 id がないので maturity 等の追加フィールドは引き継がれない
+    expect((added as { maturity?: string } | undefined)?.maturity).toBeUndefined();
+    // 既存の SCREEN_ID も保持される
+    const original = decomposed.entities?.screens?.find((s) => s.id === SCREEN_ID);
+    expect(original).toBeDefined();
+  });
+
+  it("共通 id の screen は existing の追加フィールド (maturity) が merge され FlowProject の name が優先される", () => {
+    const existing = mkRichProject();
+    const flow = composeFlowProject(existing, mkLayout());
+    // FlowProject の同 id 画面名を変更する
+    const flowModified: typeof flow = {
+      ...flow,
+      screens: flow.screens.map((s) =>
+        s.id === SCREEN_ID ? { ...s, name: "変更後の名前" } : s
+      ),
+    };
+
+    const { project: decomposed } = decomposeFlowProject(flowModified, mkLayout(), existing);
+
+    const merged = decomposed.entities?.screens?.find((s) => s.id === SCREEN_ID);
+    expect(merged).toBeDefined();
+    // FlowProject の新しい name が反映される
+    expect(merged?.name).toBe("変更後の名前");
+    // existing の追加フィールド (maturity) も保持される
+    expect((merged as { maturity?: string } | undefined)?.maturity).toBe("draft");
+  });
+});
+
 describe("saveTechStack AJV validation (#835 Should-fix 2)", () => {
   it("不正な techStack を渡すと assertValidProject が例外を投げ saveProject は呼ばれない", async () => {
     const richProject = mkRichProject();

--- a/designer/src/store/flowStore.ts
+++ b/designer/src/store/flowStore.ts
@@ -132,7 +132,7 @@ interface PersistedEdge {
   trigger: ScreenTransitionEntry["trigger"];
 }
 
-interface LegacyFlowProject {
+export interface LegacyFlowProject {
   version: 1;
   name: string;
   screens: PersistedScreen[];
@@ -426,12 +426,12 @@ function normalizeLegacyPersisted(raw: unknown): LegacyFlowProject {
   };
 }
 
-function legacyToProject(legacy: LegacyFlowProject): Project {
+export function legacyToProject(legacy: LegacyFlowProject): Project {
   return {
     $schema: PROJECT_SCHEMA_REF,
     schemaVersion: "v3",
     meta: {
-      id: "00000000-0000-4000-8000-000000000001" as ProjectId,
+      id: generateUUID() as ProjectId,
       name: legacy.name,
       createdAt: legacy.updatedAt,
       updatedAt: legacy.updatedAt,

--- a/designer/src/store/flowStore.ts
+++ b/designer/src/store/flowStore.ts
@@ -42,6 +42,7 @@ import {
   removePosition as layoutRemovePosition,
   removeTransitionLayout as layoutRemoveTransition,
 } from "./screenLayoutStore";
+import { assertValidProject } from "../utils/validateProject";
 
 // ─── ストレージバックエンド ──────────────────────────────────────────────
 
@@ -232,35 +233,68 @@ export function composeFlowProject(
   };
 }
 
-/** UI 合成型 FlowProject を Persisted (project.json) と ScreenLayout に分解。 */
+/**
+ * UI 合成型 FlowProject を Persisted (project.json) と ScreenLayout に分解。
+ *
+ * existingRaw を渡すことで、FlowProject に含まれないフィールド
+ * (techStack / extensionsApplied / meta.id / meta.description 等) を保持する。
+ * round-trip preservation (#835 バグ修正)。
+ */
 export function decomposeFlowProject(
   project: FlowProject,
   baseLayout: ScreenLayout,
+  existingRaw?: Project,
 ): { project: Project; layout: ScreenLayout } {
   const ts = project.updatedAt || nowTs();
   const persisted: Project = {
     $schema: PROJECT_SCHEMA_REF,
     schemaVersion: "v3",
     meta: {
-      id: ("00000000-0000-4000-8000-000000000001" as ProjectId),
+      // existingRaw.meta.id を保持。新規プロジェクト or existing なし時は generateUUID()
+      id: (existingRaw?.meta?.id ?? generateUUID()) as ProjectId,
       name: project.name,
-      createdAt: ts,
+      // existingRaw.meta.createdAt を保持。なければ現在時刻
+      createdAt: existingRaw?.meta?.createdAt ?? ts,
       updatedAt: ts,
-      mode: "upstream",
-      maturity: "draft",
+      mode: existingRaw?.meta?.mode ?? "upstream",
+      maturity: existingRaw?.meta?.maturity ?? "draft",
+      // description を保持
+      ...(existingRaw?.meta?.description !== undefined
+        ? { description: existingRaw.meta.description }
+        : {}),
     },
-    extensionsApplied: [],
+    // extensionsApplied を既存から保持。存在しない場合は空配列
+    extensionsApplied: existingRaw?.extensionsApplied ?? [],
+    // techStack を既存から保持。FlowProject には techStack がないため常に existing を使う
+    ...(existingRaw?.techStack !== undefined ? { techStack: existingRaw.techStack } : {}),
     entities: {
-      screens: project.screens.map((s) => ({
-        id: s.id,
-        no: s.no,
-        name: s.name,
-        kind: s.kind,
-        path: s.path,
-        hasDesign: s.hasDesign,
-        groupId: s.groupId,
-        updatedAt: s.updatedAt,
-      })),
+      screens: project.screens.map((s) => {
+        // existing 同 id 画面があれば、既存の不明フィールド (html 等) を保持してマージ
+        const existingScreen = existingRaw?.entities?.screens?.find((es) => es.id === s.id);
+        if (existingScreen) {
+          return {
+            ...existingScreen,
+            id: s.id,
+            no: s.no,
+            name: s.name,
+            kind: s.kind,
+            path: s.path,
+            hasDesign: s.hasDesign,
+            groupId: s.groupId,
+            updatedAt: s.updatedAt,
+          };
+        }
+        return {
+          id: s.id,
+          no: s.no,
+          name: s.name,
+          kind: s.kind,
+          path: s.path,
+          hasDesign: s.hasDesign,
+          groupId: s.groupId,
+          updatedAt: s.updatedAt,
+        };
+      }),
       screenGroups: project.groups.map((g) => ({
         id: g.id,
         name: g.name,
@@ -638,7 +672,11 @@ export async function saveTechStack(techStack: Project["techStack"]): Promise<vo
 
 async function persistFlowProject(project: FlowProject): Promise<void> {
   const baseLayout = await loadScreenLayout();
-  const { project: persisted, layout } = decomposeFlowProject(project, baseLayout);
+  // 既存 raw を読み込んで round-trip preservation に使う (#835)
+  const existingRaw = await loadRawProject().catch(() => undefined);
+  const { project: persisted, layout } = decomposeFlowProject(project, baseLayout, existingRaw);
+  // AJV validation: schema 違反があれば保存を中断し例外を投げる (#835)
+  assertValidProject(persisted);
   if (_backend) {
     await _backend.saveProject(persisted);
   } else {

--- a/designer/src/store/flowStore.ts
+++ b/designer/src/store/flowStore.ts
@@ -600,6 +600,8 @@ export async function loadProject(): Promise<FlowProject> {
     if (data) {
       const persisted = normalizePersisted(data);
       if (!((data as Record<string, unknown>).schemaVersion === "v3")) {
+        // AJV validation: schema 違反があれば migration 書き戻しを中断し例外を投げる (#836)
+        assertValidProject(persisted);
         await _backend.saveProject(persisted);
       }
       const layout = await loadScreenLayout();
@@ -615,6 +617,8 @@ export async function loadProject(): Promise<FlowProject> {
       // 次回ロード時に backend layout (空) で localStorage layout を上書きしてしまうため。
       const layout = await loadScreenLayout();
       try {
+        // AJV validation: schema 違反があれば localStorage→backend migration 書き戻しを中断し例外を投げる (#836)
+        assertValidProject(local);
         await _backend.saveProject(local);
         if (Object.keys(layout.positions).length > 0 || Object.keys(layout.transitions ?? {}).length > 0) {
           await saveScreenLayout(layout);

--- a/designer/src/store/flowStore.ts
+++ b/designer/src/store/flowStore.ts
@@ -660,6 +660,8 @@ export async function loadRawProject(): Promise<Project> {
 export async function saveTechStack(techStack: Project["techStack"]): Promise<void> {
   const raw = await loadRawProject();
   const patched: Project = { ...raw, techStack };
+  // AJV validation: schema 違反があれば保存を中断し例外を投げる (#835)
+  assertValidProject(patched);
   if (_backend) {
     await _backend.saveProject(patched);
   } else {

--- a/designer/src/utils/validateProject.test.ts
+++ b/designer/src/utils/validateProject.test.ts
@@ -1,0 +1,76 @@
+/**
+ * validateProject.test.ts — AJV バリデーション動作確認 (#835)
+ */
+import { describe, it, expect } from "vitest";
+import { validateProject, assertValidProject } from "./validateProject";
+import type { Project } from "../types/v3/project";
+import type { ProjectId, Timestamp } from "../types/v3";
+
+const TS = "2026-05-05T00:00:00.000Z" as Timestamp;
+const ID = "aaaabbbb-0000-4000-8000-000000000001" as ProjectId;
+
+function validProject(): Project {
+  return {
+    $schema: "../../schemas/v3/project.v3.schema.json",
+    schemaVersion: "v3",
+    meta: {
+      id: ID,
+      name: "テスト",
+      createdAt: TS,
+      updatedAt: TS,
+      mode: "upstream",
+      maturity: "draft",
+    },
+    extensionsApplied: [],
+    entities: {
+      screens: [],
+      screenGroups: [],
+      screenTransitions: [],
+    },
+  };
+}
+
+describe("validateProject", () => {
+  it("valid な Project は { valid: true, errors: [] } を返す", () => {
+    const r = validateProject(validProject());
+    expect(r.valid).toBe(true);
+    expect(r.errors).toHaveLength(0);
+  });
+
+  it("schemaVersion が欠けると invalid", () => {
+    const p = { ...validProject(), schemaVersion: undefined };
+    const r = validateProject(p);
+    expect(r.valid).toBe(false);
+    expect(r.errors.length).toBeGreaterThan(0);
+  });
+
+  it("meta.id が UUID でない形式なら invalid", () => {
+    const p: Project = {
+      ...validProject(),
+      meta: {
+        ...validProject().meta,
+        id: "not-a-uuid" as ProjectId,
+      },
+    };
+    const r = validateProject(p);
+    expect(r.valid).toBe(false);
+    expect(r.errors.some((e) => e.includes("id"))).toBe(true);
+  });
+
+  it("未知の追加プロパティがあると invalid (additionalProperties: false)", () => {
+    const p = { ...validProject(), unknownField: "forbidden" };
+    const r = validateProject(p);
+    expect(r.valid).toBe(false);
+  });
+});
+
+describe("assertValidProject", () => {
+  it("valid な Project で例外を投げない", () => {
+    expect(() => assertValidProject(validProject())).not.toThrow();
+  });
+
+  it("invalid な Project で Error を投げる", () => {
+    const bad = { schemaVersion: "v3" }; // meta が欠けている
+    expect(() => assertValidProject(bad)).toThrowError("[validateProject] schema validation failed");
+  });
+});

--- a/designer/src/utils/validateProject.ts
+++ b/designer/src/utils/validateProject.ts
@@ -1,0 +1,52 @@
+/**
+ * validateProject.ts — project.v3.schema.json に対する AJV バリデーション (#835)
+ *
+ * persistFlowProject の save 直前に呼び出し、schema 違反の silent strip を防止する。
+ * AJV は devDependencies 既存 (designer/package.json)。
+ *
+ * JSON import は resolveJsonModule: true + Vite の JSON plugin で解決される。
+ */
+
+import Ajv2020 from "ajv/dist/2020";
+import addFormats from "ajv-formats";
+import type { Project } from "../types/v3/project";
+import commonSchema from "../../../schemas/v3/common.v3.schema.json";
+import projectSchema from "../../../schemas/v3/project.v3.schema.json";
+
+let _validateFn: ReturnType<InstanceType<typeof Ajv2020>["compile"]> | null = null;
+
+function getValidateFn(): ReturnType<InstanceType<typeof Ajv2020>["compile"]> {
+  if (_validateFn) return _validateFn;
+  const ajv = new Ajv2020({ strict: false, allErrors: true });
+  addFormats(ajv);
+  // common schema を先に登録して $ref 解決できるようにする
+  ajv.addSchema(commonSchema as object);
+  _validateFn = ajv.compile(projectSchema as object);
+  return _validateFn;
+}
+
+export interface ProjectValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+export function validateProject(project: unknown): ProjectValidationResult {
+  const fn = getValidateFn();
+  const valid = fn(project) as boolean;
+  if (valid) return { valid: true, errors: [] };
+  return {
+    valid: false,
+    errors: (fn.errors ?? []).map(
+      (e) => `${e.instancePath || "/"} ${e.message ?? "?"}`,
+    ),
+  };
+}
+
+export function assertValidProject(project: unknown): asserts project is Project {
+  const r = validateProject(project);
+  if (!r.valid) {
+    throw new Error(
+      `[validateProject] schema validation failed:\n  ${r.errors.join("\n  ")}`,
+    );
+  }
+}

--- a/designer/tsconfig.app.json
+++ b/designer/tsconfig.app.json
@@ -11,6 +11,7 @@
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
+    "resolveJsonModule": true,
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
## 関連

- Closes #835
- 仕様: ISSUE #835 設計コメント (https://github.com/csilost2001/html-designer/issues/835#issuecomment-4380275800)
  - spec 別途存在しないため設計コメントを仕様として参照。

## 概要

`examples/english-learning-tailwind/` を designer に開いた際に発生する 2 件のバグを修正。独立レビュー (PR #836 — Sonnet/Opus/Codex 3 段) で検出された Should-fix 2 件と Must-fix 1 件を追加吸収。

**A. project.json 保存破壊**: `decomposeFlowProject` が新規 Project をハードコードで構築するため、画面追加等の mutation で `techStack` / `extensionsApplied` / `meta.description` / `meta.id` (常に `00000000-...` 上書き) が strip されていた。`existingRaw` ラウンドトリップ保持により修正。

**B. Puck canvas theme CSS 経路なし**: GrapesJS は canvas iframe に CSS を注入するが、Puck はメイン app DOM 内 render のため経路がなかった。`document.head` への動的 link 注入で修正。

**C. legacyToProject ハードコード UUID** (Sonnet Should-fix 1 吸収): v1→v3 migration 経路でも `00000000-...` がハードコードされていた。`generateUUID()` に置換。

**D. saveTechStack AJV 未経由** (Sonnet Should-fix 2 吸収): `saveTechStack` が `assertValidProject` を通らず直接 `saveProject` していた。`persistFlowProject` と同パターンで validation を追加。

**E. loadProject() migration 経路の AJV guard bypass** (Codex Must-fix 吸収): `loadProject()` 内の non-v3 normalize 書き戻し (L603) および localStorage→backend migration 書き戻し (L618) の 2 箇所が `_backend.saveProject()` を直接呼び `assertValidProject` を bypass していた。両箇所に guard を追加。

**F. Puck theme inject global collision コメント** (Codex Should-fix 1 吸収): mount 中のみ `<head>` へ注入し unmount 時 cleanup で解消するが、Bootstrap chrome と一部 utility が global collision することを non-obvious な制約として明示するコメントを追加。

**G. roundtrip negative path テスト追加** (Codex Should-fix 2 吸収): FlowProject と existingRaw の screen id 不一致の 3 ケース (orphan drop / new screen 追加 / 共通 id merge) を検証するテストを追加。

## 主な変更

- **decomposeFlowProject round-trip preservation**: `existingRaw?: Project` 引数を追加。`meta.id` / `meta.description` / `meta.createdAt` / `meta.mode` / `meta.maturity` / `extensionsApplied` / `techStack` / 同 id 画面の追加フィールドを保持。
- **assertValidProject 追加**: `persistFlowProject` / `saveTechStack` / `loadProject()` migration 2 箇所の save 直前で AJV 検証。
- **validateProject.ts 新設**: AJV 2020 + ajv-formats で project.v3.schema.json を検証するユーティリティ。
- **tsconfig.app.json**: `resolveJsonModule: true` 追加 (JSON static import を TypeScript に認識させる)。
- **PuckBackend.tsx**: `PuckEditorPane` に `cssFramework` 依存 `useEffect` を追加。global collision 制約コメントを追加。
- **legacyToProject**: ハードコード UUID を `generateUUID()` に置換。
- **flowStore.roundtrip.test.ts**: screen id mismatch negative path テスト 3 件追加。

## 仕様逐条突合 (自己申告)

ISSUE 受け入れ基準 5 項目:

- A-1: 画面追加後に `saveProject` しても `techStack` が保持される → `flowStore.ts:679` (existingRaw 取得) + `flowStore.ts:254-270` (preserve ロジック) ✓
- A-1: `meta.id` がハードコード上書きされない → `flowStore.ts:254` (`existingRaw?.meta?.id ?? generateUUID()`) ✓
- A-1: `extensionsApplied` が保持される → `flowStore.ts:267` (`existingRaw?.extensionsApplied ?? []`) ✓
- A-2: AJV 違反で save を中断する → `flowStore.ts:682` (`assertValidProject(persisted)`) + `utils/validateProject.ts:41` ✓
- B: Puck canvas に theme CSS が注入される → `PuckBackend.tsx:194-211` (useEffect + document.head.appendChild) ✓

Should-fix / Must-fix 追加分 (#836 Codex adversarial):

- C: `legacyToProject` UUID → `flowStore.ts:434` (`generateUUID() as ProjectId`) ✓
- D: `saveTechStack` AJV validation → `flowStore.ts:663-664` (`assertValidProject(patched)`) ✓
- E: `loadProject()` non-v3 書き戻し guard → `flowStore.ts:603` (`assertValidProject(persisted)`) ✓
- E: `loadProject()` localStorage migration 書き戻し guard → `flowStore.ts:618` (`assertValidProject(local)`) ✓
- F: Puck global collision コメント → `PuckBackend.tsx:196-197` ✓
- G: screen id mismatch テスト → `flowStore.roundtrip.test.ts:159-268` ✓

## レビューで特に見てほしい箇所

- `persistFlowProject` で `loadRawProject()` を追加で呼び出すため、save ごとに 1 回余分な file read が発生する。
- `assertValidProject` が throw した場合、save は中断されユーザーに Error が伝播する。draft-state policy との関係: preservation により schema 違反が生じるシナリオはほぼないが、将来 schema 変更時に影響が出る可能性あり。
- `document.head` への link inject は Puck editor が unmount されたタイミングで cleanup される (useEffect cleanup)。

## テスト

- Vitest: 1669 件 (新規 23 件) — flowStore.roundtrip.test.ts (17 件) / validateProject.test.ts (6 件)
- Playwright: N/A (今回は E2E なし)
- MCP E2E: N/A

## UI 影響 / AI smoke test

- [x] UI 影響あり (AI が chrome-devtools MCP / Playwright で smoke test 実施済み)

### UI 影響ありの場合、AI smoke test で確認した項目

- [ ] Puck editor での theme CSS 注入は実機確認していない (designer-mcp + browser が必要)
- [x] ビルド成功 (`npm run build` pass) ✓
- [x] Vitest 1669 件 pass ✓
- [x] samples-v3.schema.test.ts: 4 サンプル全件 AJV pass ✓
- [x] 既存 flowStore.test.ts のデータ消失ガードテストが引き続き pass ✓

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

- schema governance (#511): `schemas/*.json` は一切変更していない。
- `validateProject.ts` は AJV の singleton (モジュール変数) で validate function をキャッシュ。テスト間の干渉はない。

Closes #835