### PR TITLE
improve(designer): 画面複製時に Puck / GrapesJS の design data をコピー (#833)

### DIFF
--- a/designer/src/components/flow/FlowEditor.tsx
+++ b/designer/src/components/flow/FlowEditor.tsx
@@ -48,6 +48,7 @@ import {
   generateFlowMarkdown,
 } from "../../store/flowStore";
 import { buildDefaultScreen, loadScreenEntity, saveScreenEntity } from "../../store/screenStore";
+import { duplicateScreenDesignData } from "../../store/duplicateScreen";
 import { resolveEditorKind } from "../../utils/resolveEditorKind";
 import { resolveCssFramework } from "../../utils/resolveCssFramework";
 import { useUndoKeyboard } from "../../hooks/useUndoKeyboard";
@@ -485,6 +486,7 @@ function FlowEditorInner() {
       const dupEntity = await buildDefaultScreen(dup.id);
       dupEntity.design = { ...dupEntity.design, editorKind: srcEditorKind, cssFramework: srcCssFramework };
       await saveScreenEntity(dupEntity);
+      await duplicateScreenDesignData(screen.id, dup.id, srcEditorKind);
       setNodes((nds) => [...nds, {
         id: dup.id,
         type: "screenNode" as const,

--- a/designer/src/editor/puckIdRegeneration.test.ts
+++ b/designer/src/editor/puckIdRegeneration.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { Data } from "@measured/puck";
+
+const { mockGenerateUUID } = vi.hoisted(() => ({
+  mockGenerateUUID: vi.fn<() => string>(() => "uuid-default"),
+}));
+
+vi.mock("../utils/uuid", () => ({
+  generateUUID: mockGenerateUUID,
+}));
+
+import { regeneratePuckDataIds } from "./puckIdRegeneration";
+
+function puckData(data: unknown): Data {
+  return data as Data;
+}
+
+describe("regeneratePuckDataIds", () => {
+  beforeEach(() => {
+    let index = 0;
+    mockGenerateUUID.mockImplementation(() => `uuid-${++index}`);
+  });
+
+  it("content[] の props.id を新しい UUID に置換する", () => {
+    const data = puckData({
+      root: { props: {} },
+      content: [
+        { type: "Text", props: { id: "old-1", text: "A" } },
+        { type: "Button", props: { id: "old-2", label: "B" } },
+      ],
+    });
+
+    const result = regeneratePuckDataIds(data);
+
+    expect(result.content[0].props.id).toBe("uuid-1");
+    expect(result.content[1].props.id).toBe("uuid-2");
+    expect(result.content[0].props.id).not.toBe("old-1");
+    expect(result.content[1].props.id).not.toBe("old-2");
+    expect(result.content[0].props.id).not.toBe(result.content[1].props.id);
+  });
+
+  it("zones 内の props.id も置換する", () => {
+    const data = puckData({
+      root: { props: {} },
+      content: [],
+      zones: {
+        "main:zone": [
+          { type: "Card", props: { id: "zone-old-1" } },
+          { type: "Field", props: { id: "zone-old-2" } },
+        ],
+      },
+    });
+
+    const result = regeneratePuckDataIds(data);
+
+    expect(result.zones?.["main:zone"][0].props.id).toBe("uuid-1");
+    expect(result.zones?.["main:zone"][1].props.id).toBe("uuid-2");
+  });
+
+  it("同じ旧 ID は content と zones で同じ新 ID に対応する", () => {
+    const data = puckData({
+      root: { props: {} },
+      content: [{ type: "Text", props: { id: "shared-old" } }],
+      zones: {
+        aside: [{ type: "Text", props: { id: "shared-old" } }],
+      },
+    });
+
+    const result = regeneratePuckDataIds(data);
+
+    expect(result.content[0].props.id).toBe(result.zones?.aside[0].props.id);
+    expect(result.content[0].props.id).toBe("uuid-1");
+  });
+
+  it("id 以外の props を保持する", () => {
+    const nested = { level: "primary" };
+    const data = puckData({
+      root: { props: {} },
+      content: [
+        {
+          type: "Button",
+          props: { id: "old", label: "登録", variant: nested, disabled: false },
+        },
+      ],
+    });
+
+    const result = regeneratePuckDataIds(data);
+
+    expect(result.content[0].props).toMatchObject({
+      label: "登録",
+      variant: nested,
+      disabled: false,
+    });
+  });
+
+  it("入力 data を mutate しない", () => {
+    const data = puckData({
+      root: { props: {} },
+      content: [{ type: "Text", props: { id: "old", text: "before" } }],
+      zones: {
+        main: [{ type: "Field", props: { id: "zone-old" } }],
+      },
+    });
+
+    const result = regeneratePuckDataIds(data);
+
+    expect(result).not.toBe(data);
+    expect(result.content).not.toBe(data.content);
+    expect(result.content[0]).not.toBe(data.content[0]);
+    expect(data.content[0].props.id).toBe("old");
+    expect(data.zones?.main[0].props.id).toBe("zone-old");
+  });
+
+  it("空の data で例外を投げない", () => {
+    const data = puckData({ root: { props: {} }, content: [] });
+
+    expect(() => regeneratePuckDataIds(data)).not.toThrow();
+    expect(regeneratePuckDataIds(data).content).toEqual([]);
+  });
+});

--- a/designer/src/editor/puckIdRegeneration.test.ts
+++ b/designer/src/editor/puckIdRegeneration.test.ts
@@ -117,4 +117,27 @@ describe("regeneratePuckDataIds", () => {
     expect(() => regeneratePuckDataIds(data)).not.toThrow();
     expect(regeneratePuckDataIds(data).content).toEqual([]);
   });
+
+  it("props.id が undefined の component は id 生成しない", () => {
+    const data: Data = {
+      root: { props: {} },
+      content: [{ type: "Heading", props: {} }] as any, // id なし
+    };
+    const result = regeneratePuckDataIds(data);
+    expect((result.content[0] as any).props.id).toBeUndefined();
+  });
+
+  it("props.id が数値型等 string 以外でも content 直下なら UUID に置換される (regenerateItem は id キーを無条件置換)", () => {
+    // regenerateContent は regenerateItem を直接呼ぶため isComponentItem ガードを経由しない。
+    // regenerateItem は key === "id" を無条件で nextId() に渡すので、数値 id も UUID に置換される。
+    // (isComponentItem ガードは regenerateUnknown 経由のネスト検索にのみ使用される)
+    const data: Data = {
+      root: { props: {} },
+      content: [{ type: "Heading", props: { id: 123 as any } }] as any,
+    };
+    const result = regeneratePuckDataIds(data);
+    // 数値 id は UUID 文字列に置換される (string 型チェックは regenerateItem にはない)
+    expect(typeof (result.content[0] as any).props.id).toBe("string");
+    expect((result.content[0] as any).props.id).toBe("uuid-1");
+  });
 });

--- a/designer/src/editor/puckIdRegeneration.ts
+++ b/designer/src/editor/puckIdRegeneration.ts
@@ -1,0 +1,78 @@
+import type { Data } from "@measured/puck";
+import { generateUUID } from "../utils/uuid";
+
+type ComponentItem = {
+  type: string;
+  props: {
+    id: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+};
+
+function isComponentItem(value: unknown): value is ComponentItem {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    typeof (value as { type?: unknown }).type === "string" &&
+    typeof (value as { props?: { id?: unknown } }).props?.id === "string"
+  );
+}
+
+function nextId(oldId: string, idMap: Map<string, string>): string {
+  const existing = idMap.get(oldId);
+  if (existing) return existing;
+  const generated = generateUUID();
+  idMap.set(oldId, generated);
+  return generated;
+}
+
+function regenerateUnknown(value: unknown, idMap: Map<string, string>): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => regenerateUnknown(item, idMap));
+  }
+  if (isComponentItem(value)) {
+    return regenerateItem(value, idMap);
+  }
+  return value;
+}
+
+function regenerateItem(item: ComponentItem, idMap: Map<string, string>): ComponentItem {
+  const props = Object.fromEntries(
+    Object.entries(item.props).map(([key, value]) => [
+      key,
+      key === "id" ? nextId(value as string, idMap) : regenerateUnknown(value, idMap),
+    ]),
+  ) as ComponentItem["props"];
+
+  return {
+    ...item,
+    props,
+  };
+}
+
+function regenerateContent(
+  content: Data["content"],
+  idMap: Map<string, string>,
+): Data["content"] {
+  return content.map((item) => regenerateItem(item as ComponentItem, idMap)) as Data["content"];
+}
+
+export function regeneratePuckDataIds(data: Data): Data {
+  const idMap = new Map<string, string>();
+  const zones = data.zones
+    ? Object.fromEntries(
+      Object.entries(data.zones).map(([zoneId, content]) => [
+        zoneId,
+        regenerateContent(content, idMap),
+      ]),
+    )
+    : undefined;
+
+  return {
+    ...data,
+    content: regenerateContent(data.content, idMap),
+    ...(zones ? { zones } : {}),
+  };
+}

--- a/designer/src/store/duplicateScreen.ts
+++ b/designer/src/store/duplicateScreen.ts
@@ -1,0 +1,22 @@
+import type { Data } from "@measured/puck";
+import { mcpBridge } from "../mcp/mcpBridge";
+import { regeneratePuckDataIds } from "../editor/puckIdRegeneration";
+import type { EditorKind } from "../utils/resolveEditorKind";
+
+export async function duplicateScreenDesignData(
+  srcScreenId: string,
+  dupScreenId: string,
+  editorKind: EditorKind,
+): Promise<void> {
+  if (editorKind === "puck") {
+    const src = await mcpBridge.loadPuckData(srcScreenId);
+    if (!src) return;
+    const regenerated = regeneratePuckDataIds(src as Data);
+    await mcpBridge.savePuckData(dupScreenId, regenerated);
+    return;
+  }
+
+  const src = await mcpBridge.request("loadScreen", { screenId: srcScreenId });
+  if (!src) return;
+  await mcpBridge.request("saveScreen", { screenId: dupScreenId, data: src });
+}

--- a/designer/src/store/screenStore.duplicate.test.ts
+++ b/designer/src/store/screenStore.duplicate.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Data } from "@measured/puck";
+
+const { mockGenerateUUID } = vi.hoisted(() => ({
+  mockGenerateUUID: vi.fn<() => string>(() => "uuid-default"),
+}));
+
+vi.mock("../utils/uuid", () => ({
+  generateUUID: mockGenerateUUID,
+}));
+
+vi.mock("../mcp/mcpBridge", () => ({
+  mcpBridge: {
+    loadPuckData: vi.fn(),
+    savePuckData: vi.fn(),
+    request: vi.fn(),
+  },
+}));
+
+import { mcpBridge } from "../mcp/mcpBridge";
+import { duplicateScreenDesignData } from "./duplicateScreen";
+
+const mockBridge = mcpBridge as {
+  loadPuckData: ReturnType<typeof vi.fn>;
+  savePuckData: ReturnType<typeof vi.fn>;
+  request: ReturnType<typeof vi.fn>;
+};
+
+function puckData(data: unknown): Data {
+  return data as Data;
+}
+
+describe("duplicateScreenDesignData", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGenerateUUID.mockReturnValue("regenerated-id");
+  });
+
+  it("puck は loadPuckData で読み、ID 再生成後に savePuckData へ保存する", async () => {
+    const src = puckData({
+      root: { props: {} },
+      content: [{ type: "Text", props: { id: "old-id", text: "hello" } }],
+    });
+    mockBridge.loadPuckData.mockResolvedValue(src);
+
+    await duplicateScreenDesignData("src-screen", "dup-screen", "puck");
+
+    expect(mockBridge.loadPuckData).toHaveBeenCalledWith("src-screen");
+    expect(mockBridge.savePuckData).toHaveBeenCalledTimes(1);
+    expect(mockBridge.savePuckData).toHaveBeenCalledWith("dup-screen", {
+      root: { props: {} },
+      content: [{ type: "Text", props: { id: "regenerated-id", text: "hello" } }],
+    });
+    expect(mockBridge.request).not.toHaveBeenCalled();
+  });
+
+  it("grapesjs は loadScreen で読み、saveScreen へ同じ data を保存する", async () => {
+    const src = {
+      assets: [],
+      pages: [{ frames: [{ component: { type: "wrapper" } }] }],
+      styles: [],
+    };
+    mockBridge.request.mockResolvedValueOnce(src).mockResolvedValueOnce({ success: true });
+
+    await duplicateScreenDesignData("src-screen", "dup-screen", "grapesjs");
+
+    expect(mockBridge.request).toHaveBeenNthCalledWith(1, "loadScreen", { screenId: "src-screen" });
+    expect(mockBridge.request).toHaveBeenNthCalledWith(2, "saveScreen", {
+      screenId: "dup-screen",
+      data: src,
+    });
+    expect(mockBridge.loadPuckData).not.toHaveBeenCalled();
+    expect(mockBridge.savePuckData).not.toHaveBeenCalled();
+  });
+
+  it("puck の load が null の場合は保存しない", async () => {
+    mockBridge.loadPuckData.mockResolvedValue(null);
+
+    await duplicateScreenDesignData("src-screen", "dup-screen", "puck");
+
+    expect(mockBridge.savePuckData).not.toHaveBeenCalled();
+  });
+
+  it("grapesjs の load が undefined の場合は保存しない", async () => {
+    mockBridge.request.mockResolvedValue(undefined);
+
+    await duplicateScreenDesignData("src-screen", "dup-screen", "grapesjs");
+
+    expect(mockBridge.request).toHaveBeenCalledTimes(1);
+    expect(mockBridge.request).toHaveBeenCalledWith("loadScreen", { screenId: "src-screen" });
+  });
+});

--- a/designer/src/store/screenStore.duplicate.test.ts
+++ b/designer/src/store/screenStore.duplicate.test.ts
@@ -89,4 +89,30 @@ describe("duplicateScreenDesignData", () => {
     expect(mockBridge.request).toHaveBeenCalledTimes(1);
     expect(mockBridge.request).toHaveBeenCalledWith("loadScreen", { screenId: "src-screen" });
   });
+
+  it("grapesjs 経路で saveScreen は呼ばれるが savePuckData / loadPuckData は呼ばれない (entity.editorKind/cssFramework を Puck API で上書きしない)", async () => {
+    // wsBridge.ts の writeScreen は {screenId}.design.json と {screenId}.json (entity) を両方書く設計。
+    // ただし entity 書き込みは projectStorage.ts:377 のスプレッド `{ ...entity.design, designFileRef: ... }`
+    // 経由なので editorKind / cssFramework は保持される (pre-existing 設計に依存)。
+    // このテストでは GrapesJS 経路が Puck 専用 API (savePuckData) を呼ばないことを保証し、
+    // entity 上書き経路が mcpBridge.request("saveScreen") のみであることを trace 可能にする。
+    const src = {
+      assets: [],
+      pages: [{ frames: [{ component: { type: "wrapper" } }] }],
+      styles: [],
+    };
+    mockBridge.request.mockResolvedValueOnce(src).mockResolvedValueOnce({ success: true });
+
+    await duplicateScreenDesignData("src-screen", "dup-screen", "grapesjs");
+
+    // GrapesJS の保存は request("saveScreen") のみ — entity の editorKind/cssFramework は
+    // wsBridge 側のスプレッドで保持される (projectStorage.ts:377 参照)
+    expect(mockBridge.request).toHaveBeenNthCalledWith(2, "saveScreen", {
+      screenId: "dup-screen",
+      data: src,
+    });
+    // Puck 専用 API は呼ばれない (entity を Puck 経路で二重上書きしない)
+    expect(mockBridge.savePuckData).not.toHaveBeenCalled();
+    expect(mockBridge.loadPuckData).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## 関連

- Closes #833
- 仕様: docs/spec/multi-editor-puck.md §13.4 duplicate 時の継承記述

## 概要

画面フロー上で screen を複製したとき、screen entity だけでなく editor design data も複製するようにしました。Puck は component props.id を再生成して保存し、GrapesJS は既存 design JSON を複製先 screenId へ保存します。

## 主な変更

- Puck Data の content / zones を走査して props.id を再生成する helper を追加
- Puck / GrapesJS の design data 複製 service を追加
- FlowEditor の handleDuplicateNode で screen entity 保存後に design data コピーを実行
- ID 再生成、zones、idMap consistency、props 保持、immutability、empty data、Puck/GrapesJS/null guard の unit test を追加

## 仕様逐条突合 (自己申告)

- Puck 画面複製で puck-data.json を読み、複製先へ保存する: designer/src/store/duplicateScreen.ts:12 / designer/src/store/duplicateScreen.ts:15 ✓
- 内部 component ID を再生成し、旧 ID が同じ場合は同じ新 ID に対応する: designer/src/editor/puckIdRegeneration.ts:41 / designer/src/editor/puckIdRegeneration.test.ts:60 ✓
- zones 内の component ID も再生成する: designer/src/editor/puckIdRegeneration.ts:64 / designer/src/editor/puckIdRegeneration.test.ts:42 ✓
- GrapesJS 画面では loadScreen / saveScreen で design data をコピーする: designer/src/store/duplicateScreen.ts:19 / designer/src/store/duplicateScreen.ts:21 / designer/src/store/screenStore.duplicate.test.ts:57 ✓
- 複製操作時、saveScreenEntity(dupEntity) 後に design data コピーを呼ぶ: designer/src/components/flow/FlowEditor.tsx:488 / designer/src/components/flow/FlowEditor.tsx:489 ✓

## レビュー対応 (#833 review, commit 0993806)

**Should-fix: writeScreen 二重書き込みによる entity 破壊検出力強化**
- `screenStore.duplicate.test.ts` に GrapesJS 経路で `savePuckData`/`loadPuckData` が呼ばれないことを assert するテストを追加
- wsBridge の writeScreen が entity.json を書く際に `projectStorage.ts:377` のスプレッドで editorKind/cssFramework が保持される pre-existing 設計依存をテスト内コメントで trace 可能に

**Nit 2: props.id エッジケーステスト追加**
- `puckIdRegeneration.test.ts` に props.id が undefined の場合 (id 生成なし) のテストを追加
- props.id が数値型の場合、content 直下では `regenerateItem` が id キーを無条件置換するため UUID に置き換わる実装の実際の動作を確認するテストを追加 (isComponentItem ガードは regenerateUnknown 経由のネスト検索にのみ適用される点を明確化)

**Nit 1 (zones/content 順序)**: 機能上正しく実害ゼロのため skip

## レビューで特に見てほしい箇所

- Puck の props.id 再生成対象を content / zones と props 内 nested item に限定している点
- GrapesJS 側は既存 MCP command の loadScreen / saveScreen を使っている点
- screenStore.ts ではなく duplicateScreen.ts に分離し、mcpBridge との循環 import を避けている点

## テスト

- Vitest: 104 files / 1682 tests pass (新規 13 tests) - npm run test:unit
- Build: pass - npm run build
- Lint: pre-existing lint エラー 136 件は本 ISSUE と無関係 (`actionMigration.ts` 他)、新規追加 3 ファイルは個別 lint pass 済
- Playwright: N/A (unit/store logic の変更で、既存 UI 操作への組み込みは FlowEditor 呼び出し箇所で確認)
- MCP E2E: N/A (mcpBridge は mock unit test で呼び出し契約を確認)

## UI 影響 / AI smoke test

- [x] UI 影響あり (画面複製時の保存データが変わる)
- [ ] UI 影響なし (auto test pass のみ)

### UI 影響ありの場合、AI smoke test で確認した項目

- [x] handleDuplicateNode の saveScreenEntity 後に duplicateScreenDesignData が呼ばれることを code path で確認: designer/src/components/flow/FlowEditor.tsx:488 / designer/src/components/flow/FlowEditor.tsx:489
- [x] Puck/GrapesJS の保存 API 呼び出し契約を unit test で確認: designer/src/store/screenStore.duplicate.test.ts:39 / designer/src/store/screenStore.duplicate.test.ts:57
- [x] 既存回帰なし: npm run test:unit pass

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

N/A