### PR TITLE
improve(designer): puck-editor.spec.ts の waitForTimeout 8 箇所を proper wait に置換 (#839)

### DIFF
--- a/designer/e2e/puck-editor.spec.ts
+++ b/designer/e2e/puck-editor.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, errors as pwErrors } from "@playwright/test";
 import * as path from "path";
 
 import {
@@ -136,8 +136,15 @@ test.describe("GrapesJS と Puck の混在", () => {
     // GrapesJS 画面を開く (multi-workspace URL pattern #704)
     await page.goto(`/w/${FAKE_WS_ID}/screen/design/${GJS_SCREEN_ID}`);
     // GrapesJS canvas iframe (or fallback container) のレンダリングを待つ。
-    // MCP オフラインで GrapesJS が起動できないケースもあるため catch で許容
-    await page.locator("iframe, [class*='gjs-']").first().waitFor({ state: "visible", timeout: 10000 }).catch(() => {});
+    // MCP オフラインで GrapesJS が起動できないケースもあるため timeout のみ許容 (#841 N-1)。
+    // locator ambiguity 等の他種エラーは throw して test 失敗にする。
+    await page
+      .locator("iframe, [class*='gjs-']")
+      .first()
+      .waitFor({ state: "visible", timeout: 10000 })
+      .catch((e) => {
+        if (!(e instanceof pwErrors.TimeoutError)) throw e;
+      });
 
     // GrapesJS または適切なデザイナコンテナが表示されている
     const currentContent = await page.content();
@@ -158,6 +165,11 @@ test.describe("cssFramework 切替", () => {
 
     const puckEl = page.locator("[data-testid='puck-editor-container']");
     await expect(puckEl).toBeVisible({ timeout: 15000 });
+
+    // 非同期 console.error の flush を待つ (Playwright の page.on listener は非同期 dispatch のため
+    // toBeVisible 直後だと初期化フェーズ末尾の error event を取りこぼし得る、#841 S-1)。
+    // waitForTimeout(0) はマクロタスク 1 tick を yield する手法。
+    await page.waitForTimeout(0);
 
     // 致命的エラーがないことを確認 (Puck 初期化エラーを検出)
     const fatalErrors = errors.filter(
@@ -180,6 +192,9 @@ test.describe("cssFramework 切替", () => {
 
     const puckEl = page.locator("[data-testid='puck-editor-container']");
     await expect(puckEl).toBeVisible({ timeout: 15000 });
+
+    // 非同期 console.error の flush 待ち (#841 S-1、test 6a と同様)
+    await page.waitForTimeout(0);
 
     const fatalErrors = errors.filter(
       (e) => e.includes("Cannot read") || e.includes("is not a function"),

--- a/designer/e2e/puck-editor.spec.ts
+++ b/designer/e2e/puck-editor.spec.ts
@@ -33,9 +33,6 @@ test.describe("Puck エディタ基本動作", () => {
   test("2. Puck パレットに primitive コンポーネントが表示される", async ({ page }) => {
     await setupPuckScreen(page);
 
-    // Puck が初期化されるまで待機
-    await page.waitForTimeout(2000);
-
     // Puck のコンポーネントパレットが存在する
     // primitive の label (日本語 / 英語) がパレットに出ていることを確認
     const puckRoot = page.locator("[data-testid='puck-editor-container']");
@@ -50,9 +47,6 @@ test.describe("Puck エディタ基本動作", () => {
 
   test("3. Puck データが既に存在する画面では配置済みコンテンツが表示される", async ({ page }) => {
     await setupPuckScreen(page, { puckData: PUCK_DATA_WITH_HEADING });
-
-    // Puck デザイナが表示されるまで待機
-    await page.waitForTimeout(2000);
 
     // Puck がマウントされ、コンテンツを描画していることを確認
     // PuckBackend.renderEditor が出力する puck-editor-container (data-testid 安定セレクタ)
@@ -132,7 +126,6 @@ test.describe("GrapesJS と Puck の混在", () => {
 
     // Puck 画面を開く (multi-workspace URL pattern #704)
     await page.goto(`/w/${FAKE_WS_ID}/screen/design/${PUCK_SCREEN_ID}`);
-    await page.waitForTimeout(2000);
 
     // Puck デザイナが表示される
     // PuckBackend.renderEditor が出力する puck-editor-container (data-testid 安定セレクタ)
@@ -142,7 +135,9 @@ test.describe("GrapesJS と Puck の混在", () => {
 
     // GrapesJS 画面を開く (multi-workspace URL pattern #704)
     await page.goto(`/w/${FAKE_WS_ID}/screen/design/${GJS_SCREEN_ID}`);
-    await page.waitForTimeout(2000);
+    // GrapesJS canvas iframe (or fallback container) のレンダリングを待つ。
+    // MCP オフラインで GrapesJS が起動できないケースもあるため catch で許容
+    await page.locator("iframe, [class*='gjs-']").first().waitFor({ state: "visible", timeout: 10000 }).catch(() => {});
 
     // GrapesJS または適切なデザイナコンテナが表示されている
     const currentContent = await page.content();
@@ -153,17 +148,16 @@ test.describe("GrapesJS と Puck の混在", () => {
 
 test.describe("cssFramework 切替", () => {
   test("6a. cssFramework=bootstrap の Puck 画面が表示される", async ({ page }) => {
-    await setupPuckScreen(page, { cssFramework: "bootstrap" });
-
-    const puckEl = page.locator("[data-testid='puck-editor-container']");
-    await expect(puckEl).toBeVisible({ timeout: 15000 });
-
-    // エラーなく表示されていることを確認
+    // console listener は setupPuckScreen 前に登録 (Puck 初期化中エラーも捕捉するため #839)
     const errors: string[] = [];
     page.on("console", (msg) => {
       if (msg.type() === "error") errors.push(msg.text());
     });
-    await page.waitForTimeout(1000);
+
+    await setupPuckScreen(page, { cssFramework: "bootstrap" });
+
+    const puckEl = page.locator("[data-testid='puck-editor-container']");
+    await expect(puckEl).toBeVisible({ timeout: 15000 });
 
     // 致命的エラーがないことを確認 (Puck 初期化エラーを検出)
     const fatalErrors = errors.filter(
@@ -173,6 +167,12 @@ test.describe("cssFramework 切替", () => {
   });
 
   test("6b. cssFramework=tailwind の Puck 画面が表示される", async ({ page }) => {
+    // console listener は setupPuckScreen 前に登録 (Puck 初期化中エラーも捕捉するため #839)
+    const errors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error") errors.push(msg.text());
+    });
+
     await setupPuckScreen(page, {
       screenId: PUCK_TW_SCREEN_ID,
       cssFramework: "tailwind",
@@ -180,12 +180,6 @@ test.describe("cssFramework 切替", () => {
 
     const puckEl = page.locator("[data-testid='puck-editor-container']");
     await expect(puckEl).toBeVisible({ timeout: 15000 });
-
-    const errors: string[] = [];
-    page.on("console", (msg) => {
-      if (msg.type() === "error") errors.push(msg.text());
-    });
-    await page.waitForTimeout(1000);
 
     const fatalErrors = errors.filter(
       (e) => e.includes("Cannot read") || e.includes("is not a function"),
@@ -226,8 +220,7 @@ test.describe("スクリーンショット撮影 (視覚回帰検証用)", () =>
   test("screenshot: Puck × bootstrap 画面", async ({ page }) => {
     await setupPuckScreen(page, { puckData: PUCK_DATA_WITH_HEADING });
 
-    await page.waitForTimeout(2000);
-    await page.locator("[data-testid='puck-editor-container']").waitFor({ state: "visible", timeout: 10000 }).catch(() => {});
+    await page.locator("[data-testid='puck-editor-container']").waitFor({ state: "visible", timeout: 15000 }).catch(() => {});
 
     await page.screenshot({
       path: path.join("test-results", "puck-bootstrap.png"),
@@ -242,8 +235,7 @@ test.describe("スクリーンショット撮影 (視覚回帰検証用)", () =>
       puckData: PUCK_DATA_WITH_HEADING,
     });
 
-    await page.waitForTimeout(2000);
-    await page.locator("[data-testid='puck-editor-container']").waitFor({ state: "visible", timeout: 10000 }).catch(() => {});
+    await page.locator("[data-testid='puck-editor-container']").waitFor({ state: "visible", timeout: 15000 }).catch(() => {});
 
     await page.screenshot({
       path: path.join("test-results", "puck-tailwind.png"),


### PR DESCRIPTION
## Summary

| # | 箇所 | 種別 | 変更内容 |
|---:|---|---|---|
| 1 | L37 area | deleted | `toBeVisible` 直前の冗長な `waitForTimeout(2000)` とコメントを削除 |
| 2 | L55 area | deleted | `toBeVisible` 直前の冗長な `waitForTimeout(2000)` とコメントを削除 |
| 3 | L135 area | deleted | Puck 画面 `page.goto` 後の冗長な `waitForTimeout(2000)` を削除 |
| 4 | L145 area | replaced | GrapesJS 画面 `page.goto` 後を iframe / gjs container の visible wait に置換 |
| 5 | L166 area | moved/deleted | test 6a の console listener を `setupPuckScreen` 前へ移動し、後続 timeout を削除 |
| 6 | L188 area | moved/deleted | test 6b の console listener を `setupPuckScreen` 前へ移動し、後続 timeout を削除 |
| 7 | L229 area | deleted/replaced | screenshot bootstrap の timeout を削除し、container visible wait を 15000ms に統一 |
| 8 | L245 area | deleted/replaced | screenshot tailwind の timeout を削除し、container visible wait を 15000ms に統一 |

## 副次効果

test 6a/6b の console listener bug fix: Puck 初期化中エラー捕捉漏れを修正しました。`setupPuckScreen` 前に listener を登録するため、初期化中の致命的 console error も検出できます。

## Test plan

- `npx playwright test e2e/puck-editor.spec.ts e2e/puck-visual-regression.spec.ts --reporter=list` -> 12 passed

Closes #839