### PR TITLE
fix(backend): killStaleProcessOnPort をプラットフォーム分岐 (#846)

### DIFF
--- a/backend/src/wsBridge.ts
+++ b/backend/src/wsBridge.ts
@@ -105,6 +105,7 @@ function killStaleProcessOnPort(port: number): boolean {
     : killStaleProcessOnPortPosix(port);
 }
 
+/** Windows 経路: netstat + taskkill */
 function killStaleProcessOnPortWin32(port: number): boolean {
   try {
     const output = execSync(`netstat -ano -p tcp`, { encoding: "utf8", windowsHide: true });
@@ -139,17 +140,23 @@ function killStaleProcessOnPortWin32(port: number): boolean {
   }
 }
 
+/** POSIX 経路 (Linux / macOS / WSL2): lsof + kill -9 */
 function killStaleProcessOnPortPosix(port: number): boolean {
   // -sTCP:LISTEN は重要: これが無いと当該 port に接続中のクライアント PID も返り、
   // 無関係なプロセス (例: HTTP MCP client) を巻き添えで kill してしまう。
-  // 該当無しで非ゼロ exit、未インストールで ENOENT。いずれも検出不能 = stale 無し扱いで return false。
   let output: string;
   try {
     output = execSync(`lsof -ti tcp:${port} -sTCP:LISTEN`, {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
     });
-  } catch {
+  } catch (e) {
+    // execSync は shell 経由のため lsof 未導入は shell exit status 127、
+    // 該当プロセス無しは lsof 自身が exit 1。前者のみ warn で可視化する。
+    const status = (e as { status?: number }).status;
+    if (status === 127) {
+      console.warn(`[WsBridge] lsof not found; stale process kill on port ${port} skipped`);
+    }
     return false;
   }
 

--- a/backend/src/wsBridge.ts
+++ b/backend/src/wsBridge.ts
@@ -21,6 +21,7 @@ import {
   LockNotHeldError,
 } from "./lockManager.js";
 import { execSync } from "child_process";
+import { platform } from "node:os";
 import { createServer, type IncomingMessage, type ServerResponse, type Server as HttpServer } from "node:http";
 import { renameScreenItemId, checkScreenItemRefs } from "./renameScreenItem.js";
 import {
@@ -97,8 +98,14 @@ type BrowserRequest = { type: "request"; id: string; method: string; params?: un
 const WS_PORT = parseInt(process.env.DESIGNER_MCP_PORT ?? "5179", 10);
 const TIMEOUT_MS = 10000;
 
-/** ポートを占有している古い backend プロセスを強制終了 */
+/** ポートを占有している古い backend プロセスを強制終了 (#846: WSL2/Linux/macOS 対応) */
 function killStaleProcessOnPort(port: number): boolean {
+  return platform() === "win32"
+    ? killStaleProcessOnPortWin32(port)
+    : killStaleProcessOnPortPosix(port);
+}
+
+function killStaleProcessOnPortWin32(port: number): boolean {
   try {
     const output = execSync(`netstat -ano -p tcp`, { encoding: "utf8", windowsHide: true });
     const lines = output.split(/\r?\n/);
@@ -130,6 +137,40 @@ function killStaleProcessOnPort(port: number): boolean {
     console.error("[WsBridge] killStaleProcessOnPort error:", e);
     return false;
   }
+}
+
+function killStaleProcessOnPortPosix(port: number): boolean {
+  // -sTCP:LISTEN は重要: これが無いと当該 port に接続中のクライアント PID も返り、
+  // 無関係なプロセス (例: HTTP MCP client) を巻き添えで kill してしまう。
+  // 該当無しで非ゼロ exit、未インストールで ENOENT。いずれも検出不能 = stale 無し扱いで return false。
+  let output: string;
+  try {
+    output = execSync(`lsof -ti tcp:${port} -sTCP:LISTEN`, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    return false;
+  }
+
+  const ownPid = process.pid;
+  const pids = new Set<number>();
+  for (const token of output.split(/\s+/)) {
+    const pid = parseInt(token, 10);
+    if (Number.isFinite(pid) && pid > 0 && pid !== ownPid) pids.add(pid);
+  }
+
+  if (pids.size === 0) return false;
+
+  for (const pid of pids) {
+    console.error(`[WsBridge] Killing stale process PID=${pid} on port ${port}`);
+    try {
+      execSync(`kill -9 ${pid}`, { stdio: "ignore" });
+    } catch (e) {
+      console.error(`[WsBridge] Failed to kill PID=${pid}:`, e);
+    }
+  }
+  return true;
 }
 
 function delay(ms: number): Promise<void> {


### PR DESCRIPTION
## 関連

- Closes #846
- 仕様: N/A (Windows-only に書かれていた起動時 stale-kill の互換性バグ修正)

## 概要

`killStaleProcessOnPort` が Windows 専用 `netstat -ano -p tcp` を使っていたため、WSL2 / Linux で `netstat: not found` で失敗。EADDRINUSE 時の retry が機能しない問題を修正。

## 主な変更

- `backend/src/wsBridge.ts:101-106` — `killStaleProcessOnPort` を `platform()` で分岐するシンエントリに
- `backend/src/wsBridge.ts:108-141` — Windows 経路を `killStaleProcessOnPortWin32` に分離 (既存ロジック完全温存)
- `backend/src/wsBridge.ts:143-181` — POSIX (Linux / macOS / WSL2) 経路 `killStaleProcessOnPortPosix` を新設
  - `lsof -ti tcp:<port> -sTCP:LISTEN` で LISTEN 状態の PID のみ抽出
  - 自 PID 除外 / kill 失敗 warn 留めの既存挙動を踏襲
  - lsof 未導入 (shell exit 127) は warn で可視化、該当プロセス無し (lsof exit 1) は silent — Sonnet review S-1 反映

## 仕様逐条突合 (自己申告)

ISSUE 本文の検証 checklist に対する実装対応:

- 「Windows: 既存挙動が壊れていない」 → `wsBridge.ts:108-141` で旧ロジック完全温存 ✓
- 「WSL2 Ubuntu 24.04: lsof ベースで stale kill 動作」 → `wsBridge.ts:149` の `lsof -ti tcp:5179 -sTCP:LISTEN` で実機 PID 取得確認済 ✓
- 「初回起動時は warn 留め」 → `wsBridge.ts:153-161` で execSync 失敗を catch し `return false` ✓
- 「macOS: lsof ベースで動作」 → 実機なし、syntax は POSIX 共通 (issue 本文の方針通り)

## レビューで特に見てほしい箇所

**ISSUE 本文の修正案には無かったが、実機検証で発覚した重要な追加要件**:

`-sTCP:LISTEN` フラグを必ず付けないと、`lsof -ti tcp:5179` は当該ポートに**接続中のクライアント PID も**返してしまう。`wsBridge.ts:145-146` のコメントに記載した通り。実機で確認した出力:

```
$ lsof -i tcp:5179
node    33801 hidekatsu   29u  TCP *:5179 (LISTEN)               ← これだけ kill 対象
claude  12902 hidekatsu   53u  TCP localhost:58258->localhost:5179 (ESTABLISHED)  ← 巻き添え
claude  14059 hidekatsu   17u  TCP localhost:58244->localhost:5179 (ESTABLISHED)  ← 巻き添え
```

`-sTCP:LISTEN` 無しでこれを kill すると MCP HTTP client (claude code 自身など) を kill する事故になる。

## テスト

- Vitest: 0 件 (新規 0 件) — execSync ラッパーで unit test 費用対効果が低いため見送り
- Playwright: 0 件 — N/A
- MCP E2E: 0 件 — N/A

実機検証:
- `npm run build` (tsc) pass
- `lsof -ti tcp:5179 -sTCP:LISTEN` が現行 backend pid (1 件) を返すことを WSL2 で確認
- `lsof -ti tcp:9999 -sTCP:LISTEN` (空 port) が exit 1 で空 stdout を返し catch されることを確認
- shell の missing-command exit status が 127 であることを実機で確認

## UI 影響 / AI smoke test

- [ ] UI 影響あり
- [x] UI 影響なし (auto テスト pass のみ)

backend startup path の変更でブラウザ UI には影響なし。

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

- スコープ厳守: `wsBridge.ts` の `killStaleProcessOnPort` 周辺のみ。他の起動 path / EADDRINUSE retry ロジックは変更なし。
- macOS 実機検証は本 PR ではスコープ外 (ハードウェア無し)。POSIX 共通 syntax を採用しており動くはず。
- `lsof` 未導入環境への `ss -tlnp` フォールバックは入れていない (ISSUE 本文の方針通り)。Sonnet review S-1 を反映し、未導入時は warn で可視化。

## 独立レビュー履歴

- Sonnet (PR #848 / ISSUE #846) — Conditional → S-1 (lsof 未導入時の warn) / N-1 (PR 本文行ずれ) / N-2 (JSDoc) を本 PR で吸収済 (commit 511e9e8)
