### PR TITLE
fix(framework): #856 follow-up — Codex post-merge review P2-1 / P2-2 解消

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1177,7 +1177,8 @@ function createMcpServer(sessionId: string): Server {
             throw new McpError(ErrorCode.InvalidParams, "lockdown モード中は新規ワークスペース初期化はできません");
           }
           try {
-            const initRes = await initializeWorkspace(target);
+            const dataDirArg = typeof a.dataDir === "string" ? a.dataDir : undefined;
+            const initRes = await initializeWorkspace(target, dataDirArg ? { dataDir: dataDirArg } : undefined);
             resolvedName = initRes.name;
             target = initRes.path;
           } catch (e) {

--- a/backend/src/workspaceInit.test.ts
+++ b/backend/src/workspaceInit.test.ts
@@ -262,6 +262,49 @@ describe("initializeWorkspace", () => {
       expect(r.name).toBe("roundtrip");
     }
   });
+
+  // Codex post-merge review P2-2: 既存 harmony.json が schema 違反なら init を中止
+  it("既存 harmony.json の dataDir が path traversal だと throw (workspace 外への作成事故防止)", async () => {
+    const dir = path.join(TMP_ROOT, "invalid-existing-traversal");
+    await fs.mkdir(dir, { recursive: true });
+    const broken = {
+      $schema: "../schemas/v3/harmony.v3.schema.json",
+      schemaVersion: "v3" as const,
+      dataDir: "../outside", // 仕様違反
+      meta: { id: "x", name: "x", maturity: "draft", mode: "upstream", createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+      entities: { screens: [], tables: [], processFlows: [], conventions: [], sequences: [], views: [], viewDefinitions: [] },
+    };
+    await fs.writeFile(path.join(dir, "harmony.json"), JSON.stringify(broken), "utf-8");
+    await expect(initializeWorkspace(dir)).rejects.toThrow(/schema 違反/);
+    // workspace 外にディレクトリが作られていないことを確認
+    const outside = path.join(TMP_ROOT, "outside");
+    await expect(fs.access(outside)).rejects.toThrow();
+  });
+
+  it("既存 harmony.json の dataDir が絶対パスだと throw", async () => {
+    const dir = path.join(TMP_ROOT, "invalid-existing-abs");
+    await fs.mkdir(dir, { recursive: true });
+    const broken = {
+      $schema: "../schemas/v3/harmony.v3.schema.json",
+      schemaVersion: "v3" as const,
+      dataDir: "/etc/passwd",
+      meta: { id: "y", name: "y", maturity: "draft", mode: "upstream", createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+      entities: { screens: [], tables: [], processFlows: [], conventions: [], sequences: [], views: [], viewDefinitions: [] },
+    };
+    await fs.writeFile(path.join(dir, "harmony.json"), JSON.stringify(broken), "utf-8");
+    await expect(initializeWorkspace(dir)).rejects.toThrow(/schema 違反/);
+  });
+
+  // opts.dataDir が反映されることの positive テスト (P2-1 関連: MCP からの dataDir 引数も同経路)
+  it("opts.dataDir で dataDir をオーバーライドできる", async () => {
+    const dir = path.join(TMP_ROOT, "custom-datadir");
+    const result = await initializeWorkspace(dir, { dataDir: "docs/spec" });
+    expect(result.dataDir).toBe("docs/spec");
+    const harmony = JSON.parse(await fs.readFile(path.join(dir, "harmony.json"), "utf-8"));
+    expect(harmony.dataDir).toBe("docs/spec");
+    // dataDir 配下にサブディレクトリが作られていること
+    await expect(fs.access(path.join(dir, "docs", "spec", "screens"))).resolves.toBeUndefined();
+  });
 });
 
 // ── lockdown mode (harmony.json から dataDir 解決) ──────────────────────────

--- a/backend/src/workspaceInit.ts
+++ b/backend/src/workspaceInit.ts
@@ -167,13 +167,18 @@ export async function initializeWorkspace(
   await fs.mkdir(abs, { recursive: true });
 
   // harmony.json が既に存在すれば idempotent で返す
+  // ただし AJV 検証に通らない harmony.json は schema 違反 dataDir
+  // (../outside / 絶対パス等) で workspace 外にディレクトリ作成する事故を起こすため reject (Codex post-merge review P2-2)
   const harmonyResult = await readHarmonyAt(abs);
   if (harmonyResult !== null && "data" in harmonyResult) {
     const existing = harmonyResult.data;
-    const existingDataDir =
-      typeof (existing as Record<string, unknown>).dataDir === "string"
-        ? ((existing as Record<string, unknown>).dataDir as string)
-        : dataDirVal;
+    const validate = await getProjectValidator();
+    if (!validate(existing)) {
+      throw new Error(
+        `既存 harmony.json が schema 違反のため init を中止しました: ${path.join(abs, "harmony.json")}: ${JSON.stringify(validate.errors)}`,
+      );
+    }
+    const existingDataDir = (existing as Record<string, unknown>).dataDir as string;
     // dataDir 配下のサブディレクトリも念のため確認・作成 (idempotent)
     await ensureSubdirs(abs, existingDataDir);
     return {


### PR DESCRIPTION
## 関連

- 親 PR (post-merge): #856 (workspace folder 構造 root + dataDir 分離 + harmony.json rename)
- レビュー実施: Codex post-merge adversarial review (`codex review --commit 5d770b6`)
- 親メタ ISSUE: #849
- ISSUE 起票なし: PR #856 の post-merge follow-up small PR (memory `feedback_pr_scope_absorb_pre_existing.md` / 鉄則 0)

## 概要

Codex の post-merge 独立レビューが Sonnet stage 1 では見逃した **P2 重大バグ 2 件** を検出。fix-forward で本 PR に吸収。

## 主な変更

### P2-1: MCP `designer__workspace_open` の `dataDir` 引数非転送

- 場所: `backend/src/index.ts:1180-1184`
- 問題: `tools.ts:1354` で `dataDir` パラメータを公開しているが、handler は `initializeWorkspace(target)` を opts なしで呼んでいた。WS bridge 経由なら `dataDir` は反映されるが、MCP/AI クライアント経由では default `"harmony"` 固定になり挙動分岐
- 修正: `args.dataDir` を抽出して `initializeWorkspace(target, { dataDir })` に転送

### P2-2: 既存 harmony.json の dataDir 信用問題

- 場所: `backend/src/workspaceInit.ts:170-`
- 問題: `init=true` で既存 harmony.json がある場合の idempotent branch で、AJV 検証を skip して `dataDir` field をそのまま信用していた。`../outside` や `/etc/...` のような仕様違反 dataDir に対し `ensureSubdirs` が **workspace 外にディレクトリを作る事故** が成立可能
- 修正: read 直後に `getProjectValidator()` で AJV 検証、違反なら throw

### テスト追加

`backend/src/workspaceInit.test.ts` に 3 件:

- 既存 harmony.json の `dataDir: "../outside"` で throw + 外側ディレクトリ非作成検証
- 同 `dataDir: "/etc/passwd"` (絶対パス) で throw
- `opts.dataDir: "docs/spec"` override の positive case (P2-1 fix path 間接 cover)

## 仕様逐条突合

P2-1 / P2-2 各々:

- P2-1 → `backend/src/index.ts:1180-1184` で `dataDirArg = typeof a.dataDir === "string" ? a.dataDir : undefined` 抽出 + `initializeWorkspace(target, dataDirArg ? { dataDir: dataDirArg } : undefined)` ✓
- P2-2 → `backend/src/workspaceInit.ts:172-179` で `validate(existing)` 失敗時 throw ✓
- テスト → `workspaceInit.test.ts:267-310` 3 件追加、全 pass ✓

## テスト

- Vitest (backend): 316 pass / 1 pre-existing flaky (httpTransport WS timeout、PR #856 マージ前から無関係に存在)。新規 R-3 件すべて pass
- Playwright: N/A (UI 影響なし)
- MCP E2E: N/A (handler 修正の単体テストで担保)

実機検証:
- `cd backend && npm run build` (tsc) pass
- `cd backend && npm test` 316 pass / 1 flaky

## UI 影響 / AI smoke test

- [ ] UI 影響あり
- [x] UI 影響なし (handler 修正、unit test で担保)

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

- スコープ厳守: backend/src/index.ts (workspace_open handler 1 箇所) + backend/src/workspaceInit.ts (idempotent branch validation 追加) + workspaceInit.test.ts のみ
- PR #856 が schema governance 経由で承認・マージ済の前提。本 PR はその実装上の bug fix
- Codex 検出 → Opus が修正 → 本 PR で independent verification は省略 (Codex review 自体が stage 3 相当、修正後は単体テストで担保)
