### PR TITLE
fix(edit-session): #907 post-merge Codex review 4 round 解消 (#908)

### DIFF
--- a/frontend/src/components/Designer.tsx
+++ b/frontend/src/components/Designer.tsx
@@ -129,11 +129,14 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
   });
 
   // P2-2 fix (#907): URL ?session= から復元した initialEditSessionId を渡す (URL 招待 attach 復活)
+  // P2 fix (#908 round-5): editorKind 未解決中は session attach をスキップ (race 回避)。
+  // 初回 render で resourceType: "screen" のまま attach すると、後で "puck-data" に変わっても
+  // hook 内部 state は不整合のまま残る。resolved 後に正しい resourceType で attach する。
   const { editSession, mode, loading: sessionLoading, isDirtyForTab, actions: editActions, takeOver: editTakeOver, saveConflict, onSaveConflictOverwrite, onSaveConflictCancel } = useEditSession({
     resourceType: resolvedEditSessionResourceType,
     resourceId: screenId,
     sessionId,
-    editSessionId: initialDesignSessionId,
+    editSessionId: editorKindResolved ? initialDesignSessionId : undefined,
   });
 
   const isReadonly = mode.kind !== "editing";

--- a/frontend/src/components/Designer.tsx
+++ b/frontend/src/components/Designer.tsx
@@ -346,7 +346,9 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
           puckFlushRef.current();
           puckFlushRef.current = null;
         }
-        await editActions.save();
+        // P1 fix (#908): conflict 時は cleanup をスキップして clean 化を防ぐ。
+        const puckSaveResult = await editActions.save();
+        if (puckSaveResult.conflicted) return;
       } else {
         // GrapesJS 画面: 保留中の debounce timer があれば即時 flush してから EditSession.save
         if (draftUpdateTimer.current) {
@@ -357,7 +359,9 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
             await mcpBridge.request("editSession.update", { editSessionId: editSession.id, payload: data });
           }
         }
-        await editActions.save();
+        // P1 fix (#908): conflict 時は cleanup をスキップして clean 化を防ぐ。
+        const grapesJsSaveResult = await editActions.save();
+        if (grapesJsSaveResult.conflicted) return;
       }
       setIsDirtyState(false);
       isDirtyRef.current = false;

--- a/frontend/src/components/Designer.tsx
+++ b/frontend/src/components/Designer.tsx
@@ -112,15 +112,22 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
 
   // useEditSession — TableEditor:77 と同型
   const sessionId = mcpBridge.getSessionId();
+
+  // P1-A fix (#908): editorKind が "puck" の場合は resourceType を "puck-data" にする。
+  // editorKind 解決は非同期 (useEffect) のため、解決前は "screen" を仮置きし、
+  // 解決後に正しい type を反映する。
+  // useEditSession の resourceType が変わると EditSession が再初期化される (= 正しい挙動)。
+  const [resolvedEditSessionResourceType, setResolvedEditSessionResourceType] = useState<"screen" | "puck-data">("screen");
+
   // URL ?session= 同期 (spec §11.2) — initialEditSessionId を useEditSession に渡すため先に呼ぶ
   const { syncSessionToUrl, initialEditSessionId: initialDesignSessionId } = useSessionUrlSync({
-    resourceType: "screen",
+    resourceType: resolvedEditSessionResourceType,
     resourceId: screenId,
   });
 
   // P2-2 fix (#907): URL ?session= から復元した initialEditSessionId を渡す (URL 招待 attach 復活)
   const { editSession, mode, loading: sessionLoading, isDirtyForTab, actions: editActions, saveConflict, onSaveConflictOverwrite, onSaveConflictCancel } = useEditSession({
-    resourceType: "screen",
+    resourceType: resolvedEditSessionResourceType,
     resourceId: screenId,
     sessionId,
     editSessionId: initialDesignSessionId,
@@ -160,6 +167,7 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
   //   1. screen.design.* (画面個別指定)
   //   2. project.techStack.designer.* (project default)
   //   3. "bootstrap" / "grapesjs" (最終 default)
+  // P1-A fix (#908): editorKind が決まったら resolvedEditSessionResourceType を更新する。
   useEffect(() => {
     let cancelled = false;
     Promise.all([
@@ -172,6 +180,8 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
       cssFrameworkRef.current = fw;
       const ek = resolveEditorKind(screen.design, raw.techStack);
       setEditorKind(ek);
+      // P1-A: Puck 画面の editSession は "puck-data" branch を通すよう resourceType を更新する
+      setResolvedEditSessionResourceType(ek === "puck" ? "puck-data" : "screen");
     }).catch((e) => {
       console.warn("[Designer] cssFramework/editorKind resolve failed, using defaults", e);
     });

--- a/frontend/src/components/Designer.tsx
+++ b/frontend/src/components/Designer.tsx
@@ -116,8 +116,11 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
   // P1-A fix (#908): editorKind が "puck" の場合は resourceType を "puck-data" にする。
   // editorKind 解決は非同期 (useEffect) のため、解決前は "screen" を仮置きし、
   // 解決後に正しい type を反映する。
-  // useEditSession の resourceType が変わると EditSession が再初期化される (= 正しい挙動)。
+  // 注意: useEditSession の resourceType が変わっても hook 内部 state (editSession/myRole) は
+  // 自動リセットされない。startEditing は "編集開始" ボタン押下時に呼ばれるため、
+  // editorKind 解決完了フラグ (editorKindResolved) で未解決中の startEditing をガードする。
   const [resolvedEditSessionResourceType, setResolvedEditSessionResourceType] = useState<"screen" | "puck-data">("screen");
+  const [editorKindResolved, setEditorKindResolved] = useState(false);
 
   // URL ?session= 同期 (spec §11.2) — initialEditSessionId を useEditSession に渡すため先に呼ぶ
   const { syncSessionToUrl, initialEditSessionId: initialDesignSessionId } = useSessionUrlSync({
@@ -126,7 +129,7 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
   });
 
   // P2-2 fix (#907): URL ?session= から復元した initialEditSessionId を渡す (URL 招待 attach 復活)
-  const { editSession, mode, loading: sessionLoading, isDirtyForTab, actions: editActions, saveConflict, onSaveConflictOverwrite, onSaveConflictCancel } = useEditSession({
+  const { editSession, mode, loading: sessionLoading, isDirtyForTab, actions: editActions, takeOver: editTakeOver, saveConflict, onSaveConflictOverwrite, onSaveConflictCancel } = useEditSession({
     resourceType: resolvedEditSessionResourceType,
     resourceId: screenId,
     sessionId,
@@ -182,6 +185,7 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
       setEditorKind(ek);
       // P1-A: Puck 画面の editSession は "puck-data" branch を通すよう resourceType を更新する
       setResolvedEditSessionResourceType(ek === "puck" ? "puck-data" : "screen");
+      setEditorKindResolved(true);
     }).catch((e) => {
       console.warn("[Designer] cssFramework/editorKind resolve failed, using defaults", e);
     });
@@ -199,6 +203,17 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
     editorApiRef.current?.applyTheme(themeId, cssFrameworkRef.current);
   // cssFrameworkRef は ref なので依存配列不要
   }, []);
+
+  // editorKind 解決完了後のみ startEditing を許可するガードラップ
+  // editorKind 解決前に startEditing が呼ばれると誤った resourceType で EditSession が
+  // 作成される可能性があるため、解決まで待機する。
+  const handleStartEditing = useCallback(async () => {
+    if (!editorKindResolved) {
+      console.warn("[Designer] startEditing called before editorKind resolved, skipping");
+      return;
+    }
+    await editActions.startEditing();
+  }, [editorKindResolved, editActions]);
 
   // isReadonly の ref 版 (Puck onChange handler 等の closure からアクセスするため)
   const isReadonlyRef = useRef(isReadonly);
@@ -404,8 +419,8 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
 
   const handleResumeContinue = useCallback(async () => {
     setShowResumeDialog(false);
-    await editActions.startEditing();
-  }, [editActions]);
+    await handleStartEditing();
+  }, [handleStartEditing]);
 
   const handleResumeDiscard = useCallback(async () => {
     setShowResumeDialog(false);
@@ -569,7 +584,7 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
       {/* 編集モードツールバー */}
       <EditModeToolbar
         mode={mode}
-        onStartEditing={editActions.startEditing}
+        onStartEditing={handleStartEditing}
         onSave={handleSave}
         onDiscardClick={() => setShowDiscardDialog(true)}
         onForceReleaseClick={() => setShowForceReleaseDialog(true)}
@@ -671,8 +686,9 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
         editor={undefined}
         sessionMode={mode}
         sessionId={sessionId}
-        onStartEditing={editActions.startEditing}
+        onStartEditing={handleStartEditing}
         onViewerAttached={syncSessionToUrl}
+        onTakeOver={editTakeOver}
       />
     );
     const puckProps: PuckRenderEditorProps = {
@@ -686,7 +702,7 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
       onTogglePin: togglePin,
       onClosePanel: closePanel,
       screenId,
-      onStartEditing: editActions.startEditing,
+      onStartEditing: handleStartEditing,
       onChange: handlePuckChange,
       onReady: handlePuckReady,
       // Puck も EditorApi.reload() で再ロードできるよう reloadPayload を提供
@@ -726,8 +742,9 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
       isReadonly={isReadonly}
       sessionMode={mode}
       sessionId={sessionId}
-      onStartEditing={editActions.startEditing}
+      onStartEditing={handleStartEditing}
       onViewerAttached={syncSessionToUrl}
+      onTakeOver={editTakeOver}
     />
   );
   // GrapesJSRenderEditorProps で GrapesJS 固有 callback を型レベル required として渡す
@@ -743,7 +760,7 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
     onTogglePin: togglePin,
     onClosePanel: closePanel,
     screenId,
-    onStartEditing: editActions.startEditing,
+    onStartEditing: handleStartEditing,
     onChange: handleGrapesChange,
     onReady: handleGrapesReady,
     onServerChanged: handleGrapesServerChanged,

--- a/frontend/src/components/Designer.tsx
+++ b/frontend/src/components/Designer.tsx
@@ -191,6 +191,10 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
       setEditorKindResolved(true);
     }).catch((e) => {
       console.warn("[Designer] cssFramework/editorKind resolve failed, using defaults", e);
+      // P2 fix (#908 round-6): metadata load 失敗時も defaults でレンダリングするので resolved にする。
+      // 設定しないと editorKindResolved が永遠 false で handleStartEditing が silent no-op、
+      // fallback 経路で編集ボタンが効かなくなる。
+      if (!cancelled) setEditorKindResolved(true);
     });
     return () => { cancelled = true; };
   }, [screenId]);
@@ -351,7 +355,7 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
         }
         // P1 fix (#908): conflict 時は cleanup をスキップして clean 化を防ぐ。
         const puckSaveResult = await editActions.save();
-        if (puckSaveResult.conflicted) return;
+        if (puckSaveResult.conflicted || puckSaveResult.failed) return;
       } else {
         // GrapesJS 画面: 保留中の debounce timer があれば即時 flush してから EditSession.save
         if (draftUpdateTimer.current) {
@@ -364,7 +368,7 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
         }
         // P1 fix (#908): conflict 時は cleanup をスキップして clean 化を防ぐ。
         const grapesJsSaveResult = await editActions.save();
-        if (grapesJsSaveResult.conflicted) return;
+        if (grapesJsSaveResult.conflicted || grapesJsSaveResult.failed) return;
       }
       setIsDirtyState(false);
       isDirtyRef.current = false;

--- a/frontend/src/components/conventions/ConventionsCatalogView.tsx
+++ b/frontend/src/components/conventions/ConventionsCatalogView.tsx
@@ -183,10 +183,14 @@ export function ConventionsCatalogView() {
       await mcpBridge.request("editSession.update", { editSessionId: editSession.id, payload: catalogRef.current });
     }
     // P1-B fix (#908): conflict check (actions.save) を本体書き込みより先に実行する。
-    // editSession.save が conflict なしと判断してから backend が本体ファイルを書き込む。
     // P1 fix (#908): conflict 時は postSave をスキップして clean 化を防ぐ。
     const { conflicted } = await actions.save();
     if (conflicted) return;
+    // P1 fix (#908 round-5): convention は backend editSession.save で write skip されるため、
+    // ここで catalog 本体ファイル書き込みを実行する (Extensions と同パターン)。
+    if (catalogRef.current) {
+      await saveCatalog(catalogRef.current);
+    }
     await postSave();
   }, [isReadonly, isSaving, postSave, actions, editSession]);
 

--- a/frontend/src/components/conventions/ConventionsCatalogView.tsx
+++ b/frontend/src/components/conventions/ConventionsCatalogView.tsx
@@ -184,8 +184,9 @@ export function ConventionsCatalogView() {
     }
     // P1-B fix (#908): conflict check (actions.save) を本体書き込みより先に実行する。
     // editSession.save が conflict なしと判断してから backend が本体ファイルを書き込む。
-    // postSave は frontend dirty クリア + mtime ack のみ (ファイル書き込みなし)。
-    await actions.save();
+    // P1 fix (#908): conflict 時は postSave をスキップして clean 化を防ぐ。
+    const { conflicted } = await actions.save();
+    if (conflicted) return;
     await postSave();
   }, [isReadonly, isSaving, postSave, actions, editSession]);
 

--- a/frontend/src/components/conventions/ConventionsCatalogView.tsx
+++ b/frontend/src/components/conventions/ConventionsCatalogView.tsx
@@ -184,8 +184,8 @@ export function ConventionsCatalogView() {
     }
     // P1-B fix (#908): conflict check (actions.save) を本体書き込みより先に実行する。
     // P1 fix (#908): conflict 時は postSave をスキップして clean 化を防ぐ。
-    const { conflicted } = await actions.save();
-    if (conflicted) return;
+    const { conflicted, failed } = await actions.save();
+    if (conflicted || failed) return;
     // P1 fix (#908 round-5): convention は backend editSession.save で write skip されるため、
     // ここで catalog 本体ファイル書き込みを実行する (Extensions と同パターン)。
     if (catalogRef.current) {

--- a/frontend/src/components/conventions/ConventionsCatalogView.tsx
+++ b/frontend/src/components/conventions/ConventionsCatalogView.tsx
@@ -122,7 +122,8 @@ export function ConventionsCatalogView() {
     isDirty, isSaving, serverChanged,
     update, updateSilent, commit,
     undo, redo, canUndo, canRedo,
-    handleSave: resourceHandleSave, handleReset, dismissServerBanner,
+    handleReset, dismissServerBanner,
+    postSave,
     reload,
   } = useResourceEditor<ConventionsCatalog>({
     tabType: "conventions-catalog",
@@ -181,9 +182,12 @@ export function ConventionsCatalogView() {
     if (catalogRef.current && editSession?.id) {
       await mcpBridge.request("editSession.update", { editSessionId: editSession.id, payload: catalogRef.current });
     }
-    await resourceHandleSave();
+    // P1-B fix (#908): conflict check (actions.save) を本体書き込みより先に実行する。
+    // editSession.save が conflict なしと判断してから backend が本体ファイルを書き込む。
+    // postSave は frontend dirty クリア + mtime ack のみ (ファイル書き込みなし)。
     await actions.save();
-  }, [isReadonly, isSaving, resourceHandleSave, actions, editSession]);
+    await postSave();
+  }, [isReadonly, isSaving, postSave, actions, editSession]);
 
   const handleDiscard = useCallback(async () => {
     setShowDiscardDialog(false);

--- a/frontend/src/components/design/DesignSubToolbar.test.tsx
+++ b/frontend/src/components/design/DesignSubToolbar.test.tsx
@@ -142,3 +142,37 @@ describe("DesignSubToolbarGrapesJSBridge (#824)", () => {
     vi.doUnmock("@grapesjs/react");
   });
 });
+
+// ── onTakeOver prop 伝播 (#908 P2 Must-fix) ──────────────────────────────────
+
+/**
+ * P2 fix (#908): DesignSubToolbar の Props に onTakeOver が追加され、
+ * EditSessionDropdown に渡されることを確認する回帰テスト。
+ *
+ * EditSessionDropdown の実際の take-over 動作は EditSessionDropdown.test.tsx で検証済み。
+ * 本テストは onTakeOver prop が Props 型に存在し、コンポーネントが crash せず
+ * render できることを保証するスモークテスト。
+ */
+describe("DesignSubToolbar — onTakeOver prop (#908 P2 fix)", () => {
+  it("onTakeOver prop を渡しても crash しない", () => {
+    const onTakeOver = vi.fn(async () => { /* ok */ });
+    expect(() => {
+      render(
+        <DesignSubToolbar
+          {...baseProps}
+          editor={undefined}
+          onTakeOver={onTakeOver}
+        />,
+      );
+    }).not.toThrow();
+    expect(screen.getByTestId("editor-header")).toBeInTheDocument();
+  });
+
+  it("onTakeOver を省略しても crash しない (optional prop)", () => {
+    // onTakeOver が省略された場合も EditSessionDropdown 内部 fallback が動く
+    expect(() => {
+      render(<DesignSubToolbar {...baseProps} editor={undefined} />);
+    }).not.toThrow();
+    expect(screen.getByTestId("editor-header")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/design/DesignSubToolbar.tsx
+++ b/frontend/src/components/design/DesignSubToolbar.tsx
@@ -79,9 +79,15 @@ interface Props {
   onStartEditing?: () => void;
   /** (#902 Phase 5) viewer として EditSession に attach した後の callback (URL 同期用) */
   onViewerAttached?: (editSessionId: string) => void;
+  /**
+   * P2 fix (#908): take-over callback — useEditSession.takeOver() を呼ぶ。
+   * 省略時は EditSessionDropdown が内部 fallback を使う (myRole 即時更新なし)。
+   * myRole の即時反映には onTakeOver の指定が必須。
+   */
+  onTakeOver?: () => Promise<void>;
 }
 
-export function DesignSubToolbar({ panelMode, onOpenPanel, activeTheme, onThemeChange, mcpStatus, backLink, isDirty, isSaving, onSaveToFile, onReset, screenId, isReadonly, editor, sessionMode, sessionId, onStartEditing, onViewerAttached }: Props) {
+export function DesignSubToolbar({ panelMode, onOpenPanel, activeTheme, onThemeChange, mcpStatus, backLink, isDirty, isSaving, onSaveToFile, onReset, screenId, isReadonly, editor, sessionMode, sessionId, onStartEditing, onViewerAttached, onTakeOver }: Props) {
   const [themeMenuOpen, setThemeMenuOpen] = useState(false);
 
   // ── AI 命名 (#337) ───────────────────────────────────────────────────────
@@ -498,6 +504,7 @@ ${html}
                 currentSessionId={sessionId}
                 onStartEditing={onStartEditing}
                 onViewerAttached={onViewerAttached}
+                onTakeOver={onTakeOver}
               />
             )}
             <div className="theme-selector">

--- a/frontend/src/components/design/DesignSubToolbar.tsx
+++ b/frontend/src/components/design/DesignSubToolbar.tsx
@@ -80,11 +80,12 @@ interface Props {
   /** (#902 Phase 5) viewer として EditSession に attach した後の callback (URL 同期用) */
   onViewerAttached?: (editSessionId: string) => void;
   /**
-   * P2 fix (#908): take-over callback — useEditSession.takeOver() を呼ぶ。
+   * P2 fix (#908): take-over callback — useEditSession.takeOver(editSessionId) を呼ぶ。
+   * editSessionId には選択した EditSession の ID が渡される。
    * 省略時は EditSessionDropdown が内部 fallback を使う (myRole 即時更新なし)。
    * myRole の即時反映には onTakeOver の指定が必須。
    */
-  onTakeOver?: () => Promise<void>;
+  onTakeOver?: (editSessionId: string) => Promise<void>;
 }
 
 export function DesignSubToolbar({ panelMode, onOpenPanel, activeTheme, onThemeChange, mcpStatus, backLink, isDirty, isSaving, onSaveToFile, onReset, screenId, isReadonly, editor, sessionMode, sessionId, onStartEditing, onViewerAttached, onTakeOver }: Props) {

--- a/frontend/src/components/editing/EditSessionDropdown.test.tsx
+++ b/frontend/src/components/editing/EditSessionDropdown.test.tsx
@@ -360,8 +360,9 @@ describe("EditSessionDropdown", () => {
     fireEvent.click(screen.getByTestId("esd-takeover-btn-es-takeover-p2"));
 
     await waitFor(() => {
-      // onTakeOver が呼ばれること (useEditSession.takeOver() 経由)
+      // onTakeOver が選択した editSessionId を引数として呼ばれること (P2 fix #908)
       expect(onTakeOver).toHaveBeenCalledTimes(1);
+      expect(onTakeOver).toHaveBeenCalledWith("es-takeover-p2");
       // editSession.transferEdit を直接呼んでいないこと
       expect(mockRequest).not.toHaveBeenCalledWith("editSession.transferEdit", expect.anything());
     });

--- a/frontend/src/components/editing/EditSessionDropdown.test.tsx
+++ b/frontend/src/components/editing/EditSessionDropdown.test.tsx
@@ -315,4 +315,103 @@ describe("EditSessionDropdown", () => {
       expect(screen.getByTestId("esd-discard-btn-es-discard-test")).toBeTruthy();
     });
   });
+
+  // ── P2 fix (#908): take-over で onTakeOver が呼ばれる ───────────────────────
+
+  it("#908 P2: [↪ 引継] クリックで onTakeOver callback が呼ばれ myRole が即時更新できる", async () => {
+    // session-self が View participant として参加している
+    mockRequest.mockResolvedValue({
+      sessions: [
+        makeEditSession({
+          id: "es-takeover-p2",
+          participants: {
+            "session-alice": {
+              sessionId: "session-alice",
+              role: "Edit",
+              joinedAt: new Date().toISOString(),
+              lastActivityAt: new Date().toISOString(),
+              displayLabel: "@alice",
+            },
+            "session-self": {
+              sessionId: "session-self",
+              role: "View",
+              joinedAt: new Date().toISOString(),
+              lastActivityAt: new Date().toISOString(),
+              displayLabel: "@self",
+            },
+          },
+        }),
+      ],
+    });
+
+    const onTakeOver = vi.fn().mockResolvedValue(undefined);
+    // window.confirm を自動承認
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    render(
+      <EditSessionDropdown
+        {...defaultProps}
+        onTakeOver={onTakeOver}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("esd-toggle-btn"));
+
+    await waitFor(() => screen.getByTestId("esd-takeover-btn-es-takeover-p2"));
+    fireEvent.click(screen.getByTestId("esd-takeover-btn-es-takeover-p2"));
+
+    await waitFor(() => {
+      // onTakeOver が呼ばれること (useEditSession.takeOver() 経由)
+      expect(onTakeOver).toHaveBeenCalledTimes(1);
+      // editSession.transferEdit を直接呼んでいないこと
+      expect(mockRequest).not.toHaveBeenCalledWith("editSession.transferEdit", expect.anything());
+    });
+
+    vi.restoreAllMocks();
+  });
+
+  it("#908 P2: onTakeOver が未指定の場合は editSession.transferEdit を fallback で直接呼ぶ", async () => {
+    mockRequest
+      .mockResolvedValueOnce({
+        sessions: [
+          makeEditSession({
+            id: "es-fallback-p2",
+            participants: {
+              "session-alice": {
+                sessionId: "session-alice",
+                role: "Edit",
+                joinedAt: new Date().toISOString(),
+                lastActivityAt: new Date().toISOString(),
+                displayLabel: "@alice",
+              },
+              "session-self": {
+                sessionId: "session-self",
+                role: "View",
+                joinedAt: new Date().toISOString(),
+                lastActivityAt: new Date().toISOString(),
+                displayLabel: "@self",
+              },
+            },
+          }),
+        ],
+      })
+      .mockResolvedValue({ ok: true }); // transferEdit mock
+
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    render(<EditSessionDropdown {...defaultProps} />); // onTakeOver 未指定
+    fireEvent.click(screen.getByTestId("esd-toggle-btn"));
+
+    await waitFor(() => screen.getByTestId("esd-takeover-btn-es-fallback-p2"));
+    fireEvent.click(screen.getByTestId("esd-takeover-btn-es-fallback-p2"));
+
+    await waitFor(() => {
+      // fallback: editSession.transferEdit が直接呼ばれること
+      expect(mockRequest).toHaveBeenCalledWith("editSession.transferEdit", expect.objectContaining({
+        editSessionId: "es-fallback-p2",
+        toSessionId: "session-self",
+      }));
+    });
+
+    vi.restoreAllMocks();
+  });
 });

--- a/frontend/src/components/editing/EditSessionDropdown.tsx
+++ b/frontend/src/components/editing/EditSessionDropdown.tsx
@@ -31,11 +31,12 @@ export interface EditSessionDropdownProps {
   /** 新規 draft 作成 (startEditing 相当) */
   onStartEditing?: () => void;
   /**
-   * P2 fix (#908): take-over callback — useEditSession.takeOver() を呼ぶ。
+   * P2 fix (#908): take-over callback — useEditSession.takeOver(editSessionId) を呼ぶ。
+   * editSessionId には選択した EditSession の ID が渡される。
    * 省略時は内部で mcpBridge.request("editSession.transferEdit") を直接呼ぶ (非推奨 fallback)。
    * myRole の即時反映には onTakeOver の指定が必須。
    */
-  onTakeOver?: () => Promise<void>;
+  onTakeOver?: (editSessionId: string) => Promise<void>;
 }
 
 // ── 相対時間 ─────────────────────────────────────────────────────────────────
@@ -282,8 +283,9 @@ export function EditSessionDropdown({
       if (!confirmed) return;
       try {
         if (onTakeOver) {
-          // P2 fix (#908): useEditSession.takeOver() 経由で実行し myRole を即時更新する
-          await onTakeOver();
+          // P2 fix (#908): useEditSession.takeOver(editSessionId) 経由で実行し、
+          // 選択した session に対して take-over を実行する。myRole も即時更新される。
+          await onTakeOver(editSessionId);
         } else {
           // fallback: onTakeOver が指定されていない場合は直接 transferEdit を呼ぶ
           // (myRole は broadcast 経由でのみ更新されるため遅延する可能性あり)

--- a/frontend/src/components/editing/EditSessionDropdown.tsx
+++ b/frontend/src/components/editing/EditSessionDropdown.tsx
@@ -30,6 +30,12 @@ export interface EditSessionDropdownProps {
   onViewerAttached?: (editSessionId: string) => void;
   /** 新規 draft 作成 (startEditing 相当) */
   onStartEditing?: () => void;
+  /**
+   * P2 fix (#908): take-over callback — useEditSession.takeOver() を呼ぶ。
+   * 省略時は内部で mcpBridge.request("editSession.transferEdit") を直接呼ぶ (非推奨 fallback)。
+   * myRole の即時反映には onTakeOver の指定が必須。
+   */
+  onTakeOver?: () => Promise<void>;
 }
 
 // ── 相対時間 ─────────────────────────────────────────────────────────────────
@@ -190,6 +196,7 @@ export function EditSessionDropdown({
   currentSessionId,
   onViewerAttached,
   onStartEditing,
+  onTakeOver,
 }: EditSessionDropdownProps) {
   const [open, setOpen] = useState(false);
   const [sessions, setSessions] = useState<EditSessionData[]>([]);
@@ -274,16 +281,23 @@ export function EditSessionDropdown({
       );
       if (!confirmed) return;
       try {
-        await mcpBridge.request("editSession.transferEdit", {
-          editSessionId,
-          toSessionId: currentSessionId,
-        });
+        if (onTakeOver) {
+          // P2 fix (#908): useEditSession.takeOver() 経由で実行し myRole を即時更新する
+          await onTakeOver();
+        } else {
+          // fallback: onTakeOver が指定されていない場合は直接 transferEdit を呼ぶ
+          // (myRole は broadcast 経由でのみ更新されるため遅延する可能性あり)
+          await mcpBridge.request("editSession.transferEdit", {
+            editSessionId,
+            toSessionId: currentSessionId,
+          });
+        }
         setOpen(false);
       } catch (e) {
-        console.error("[EditSessionDropdown] transferEdit failed:", e);
+        console.error("[EditSessionDropdown] transferEdit/takeOver failed:", e);
       }
     },
-    [sessions, currentSessionId],
+    [sessions, currentSessionId, onTakeOver],
   );
 
   // ── [× 破棄] — discard ────────────────────────────────────────────────────

--- a/frontend/src/components/extensions/ExtensionsPanel.tsx
+++ b/frontend/src/components/extensions/ExtensionsPanel.tsx
@@ -123,8 +123,8 @@ export function ExtensionsPanel() {
     try {
       // P1 fix (#908 Opus round-3): conflict check を本体書き込み前に実行
       // actions.save() は conflict 時 { conflicted: true } を返す (postSave / 本体書き込みをスキップして dialog 経由で対処)
-      const { conflicted } = await actions.save();
-      if (conflicted) return;
+      const { conflicted, failed } = await actions.save();
+      if (conflicted || failed) return;
       await mcpBridge.request("saveExtensionPackage", { type: kind, content });
       setMessage("保存しました。");
       await load(true);

--- a/frontend/src/components/extensions/ExtensionsPanel.tsx
+++ b/frontend/src/components/extensions/ExtensionsPanel.tsx
@@ -121,8 +121,11 @@ export function ExtensionsPanel() {
     setSaving(true);
     setMessage(null);
     try {
+      // P1 fix (#908 Opus round-3): conflict check を本体書き込み前に実行
+      // actions.save() は conflict 時 { conflicted: true } を返す (postSave / 本体書き込みをスキップして dialog 経由で対処)
+      const { conflicted } = await actions.save();
+      if (conflicted) return;
       await mcpBridge.request("saveExtensionPackage", { type: kind, content });
-      await actions.save();
       setMessage("保存しました。");
       await load(true);
     } catch (e) {

--- a/frontend/src/components/flow/FlowEditor.tsx
+++ b/frontend/src/components/flow/FlowEditor.tsx
@@ -782,8 +782,10 @@ function FlowEditorInner() {
     }
     setIsSaving(true);
     try {
-      await persistProject(projectRef.current);
+      // P1-B fix (#908): conflict check (actions.save) を本体書き込みより先に実行する。
+      // editSession.save が conflict なしと判断してから persistProject でファイルを書き込む。
       await actions.save();
+      await persistProject(projectRef.current);
       setIsDirty(false);
       isDirtyRef.current = false;
       dismissServerBanner();

--- a/frontend/src/components/flow/FlowEditor.tsx
+++ b/frontend/src/components/flow/FlowEditor.tsx
@@ -783,8 +783,8 @@ function FlowEditorInner() {
     setIsSaving(true);
     try {
       // P1 fix (#908): conflict 時は cleanup をスキップして clean 化を防ぐ。
-      const { conflicted } = await actions.save();
-      if (conflicted) return;
+      const { conflicted, failed } = await actions.save();
+      if (conflicted || failed) return;
       await persistProject(projectRef.current);
       setIsDirty(false);
       isDirtyRef.current = false;
@@ -1073,7 +1073,22 @@ function FlowEditorInner() {
       {saveConflict && (
         <SaveConflictDialog
           conflict={saveConflict}
-          onOverwrite={() => { void onSaveConflictOverwrite(); }}
+          onOverwrite={async () => {
+            // P1 fix (#908 round-6): backend editSession.save は flow を write skip するため、
+            // 上書き確認後に frontend で persistProject による本体書き込みを実行する。
+            try {
+              await onSaveConflictOverwrite();
+              if (projectRef.current) {
+                await persistProject(projectRef.current);
+                setIsDirty(false);
+                isDirtyRef.current = false;
+                dismissServerBanner();
+                await acknowledgeServerMtime("project");
+              }
+            } catch (e) {
+              console.error("[FlowEditor] save overwrite failed:", e);
+            }
+          }}
           onCancel={onSaveConflictCancel}
         />
       )}

--- a/frontend/src/components/flow/FlowEditor.tsx
+++ b/frontend/src/components/flow/FlowEditor.tsx
@@ -782,9 +782,9 @@ function FlowEditorInner() {
     }
     setIsSaving(true);
     try {
-      // P1-B fix (#908): conflict check (actions.save) を本体書き込みより先に実行する。
-      // editSession.save が conflict なしと判断してから persistProject でファイルを書き込む。
-      await actions.save();
+      // P1 fix (#908): conflict 時は cleanup をスキップして clean 化を防ぐ。
+      const { conflicted } = await actions.save();
+      if (conflicted) return;
       await persistProject(projectRef.current);
       setIsDirty(false);
       isDirtyRef.current = false;

--- a/frontend/src/components/process-flow/ProcessFlowEditor.tsx
+++ b/frontend/src/components/process-flow/ProcessFlowEditor.tsx
@@ -333,11 +333,19 @@ export function ProcessFlowEditor() {
   // 保存時にバリデーションをチェック（blocking なエラーがあれば中断）
   const handleSave = useCallback(async () => {
     if (!group || isReadonly || hasBlockingErrors(aggregateValidation(group, { tables: tableDefs, conventions, extensions }))) return;
+    // P1 fix (#908 round-5): debounce 中の draft を flush して即送信、その後 conflict check
+    if (draftUpdateTimer.current) {
+      clearTimeout(draftUpdateTimer.current);
+      draftUpdateTimer.current = null;
+    }
+    if (groupRef.current && editSession?.id) {
+      await mcpBridge.request("editSession.update", { editSessionId: editSession.id, payload: groupRef.current });
+    }
     // P1 fix (#908): conflict 時は hookPostSave をスキップして clean 化を防ぐ。
     const { conflicted } = await editActions.save();
     if (conflicted) return;
     await hookPostSave();
-  }, [group, isReadonly, hookPostSave, tableDefs, conventions, extensions, editActions]);
+  }, [group, isReadonly, hookPostSave, tableDefs, conventions, extensions, editActions, editSession]);
 
   // D&D: PointerSensor に移動距離閾値を設定（クリックとドラッグを区別）
   const sensors = useSensors(

--- a/frontend/src/components/process-flow/ProcessFlowEditor.tsx
+++ b/frontend/src/components/process-flow/ProcessFlowEditor.tsx
@@ -342,8 +342,8 @@ export function ProcessFlowEditor() {
       await mcpBridge.request("editSession.update", { editSessionId: editSession.id, payload: groupRef.current });
     }
     // P1 fix (#908): conflict 時は hookPostSave をスキップして clean 化を防ぐ。
-    const { conflicted } = await editActions.save();
-    if (conflicted) return;
+    const { conflicted, failed } = await editActions.save();
+    if (conflicted || failed) return;
     await hookPostSave();
   }, [group, isReadonly, hookPostSave, tableDefs, conventions, extensions, editActions, editSession]);
 

--- a/frontend/src/components/process-flow/ProcessFlowEditor.tsx
+++ b/frontend/src/components/process-flow/ProcessFlowEditor.tsx
@@ -333,8 +333,9 @@ export function ProcessFlowEditor() {
   // 保存時にバリデーションをチェック（blocking なエラーがあれば中断）
   const handleSave = useCallback(async () => {
     if (!group || isReadonly || hasBlockingErrors(aggregateValidation(group, { tables: tableDefs, conventions, extensions }))) return;
-    // P1-B fix (#908): conflict check (editActions.save) を本体書き込みより先に実行する。
-    await editActions.save();
+    // P1 fix (#908): conflict 時は hookPostSave をスキップして clean 化を防ぐ。
+    const { conflicted } = await editActions.save();
+    if (conflicted) return;
     await hookPostSave();
   }, [group, isReadonly, hookPostSave, tableDefs, conventions, extensions, editActions]);
 

--- a/frontend/src/components/process-flow/ProcessFlowEditor.tsx
+++ b/frontend/src/components/process-flow/ProcessFlowEditor.tsx
@@ -233,7 +233,7 @@ export function ProcessFlowEditor() {
     updateSilent: updateGroupSilent,
     commit: commitGroup,
     undo, redo, canUndo, canRedo,
-    handleSave: hookHandleSave,
+    postSave: hookPostSave,
     handleReset, dismissServerBanner,
   } = useResourceEditor<ProcessFlow>({
     tabType: "process-flow",
@@ -257,7 +257,7 @@ export function ProcessFlowEditor() {
   });
 
   // P2-2 fix (#907): URL ?session= から復元した initialEditSessionId を渡す (URL 招待 attach 復活)
-  const { editSession, mode, loading: sessionLoading, isDirtyForTab, actions: editActions, saveConflict, onSaveConflictOverwrite, onSaveConflictCancel } = useEditSession({
+  const { editSession, mode, loading: sessionLoading, isDirtyForTab, actions: editActions, takeOver: editTakeOver, saveConflict, onSaveConflictOverwrite, onSaveConflictCancel } = useEditSession({
     resourceType: "process-flow",
     resourceId: processFlowId ?? "",
     sessionId,
@@ -333,9 +333,10 @@ export function ProcessFlowEditor() {
   // 保存時にバリデーションをチェック（blocking なエラーがあれば中断）
   const handleSave = useCallback(async () => {
     if (!group || isReadonly || hasBlockingErrors(aggregateValidation(group, { tables: tableDefs, conventions, extensions }))) return;
-    await hookHandleSave();
+    // P1-B fix (#908): conflict check (editActions.save) を本体書き込みより先に実行する。
     await editActions.save();
-  }, [group, isReadonly, hookHandleSave, tableDefs, conventions, extensions, editActions]);
+    await hookPostSave();
+  }, [group, isReadonly, hookPostSave, tableDefs, conventions, extensions, editActions]);
 
   // D&D: PointerSensor に移動距離閾値を設定（クリックとドラッグを区別）
   const sensors = useSensors(
@@ -789,6 +790,7 @@ export function ProcessFlowEditor() {
               currentSessionId={sessionId}
               onStartEditing={() => { void editActions.startEditing(); }}
               onViewerAttached={syncSessionToUrl}
+              onTakeOver={editTakeOver}
             />
             <button
               type="button"

--- a/frontend/src/components/screen-items/ScreenItemsView.tsx
+++ b/frontend/src/components/screen-items/ScreenItemsView.tsx
@@ -507,8 +507,8 @@ export function ScreenItemsView() {
       await mcpBridge.request("editSession.update", { editSessionId: editSession.id, payload: fileRef.current });
     }
     // P1 fix (#908): conflict 時は postSave をスキップして clean 化を防ぐ。
-    const { conflicted } = await actions.save();
-    if (conflicted) return;
+    const { conflicted, failed } = await actions.save();
+    if (conflicted || failed) return;
     await postSave();
   }, [isReadonly, isSaving, actions, postSave, screenId, editSession]);
 

--- a/frontend/src/components/screen-items/ScreenItemsView.tsx
+++ b/frontend/src/components/screen-items/ScreenItemsView.tsx
@@ -506,8 +506,9 @@ export function ScreenItemsView() {
     if (screenId && fileRef.current && editSession?.id) {
       await mcpBridge.request("editSession.update", { editSessionId: editSession.id, payload: fileRef.current });
     }
-    // P1-B fix (#908): conflict check (actions.save) を本体書き込みより先に実行する。
-    await actions.save();
+    // P1 fix (#908): conflict 時は postSave をスキップして clean 化を防ぐ。
+    const { conflicted } = await actions.save();
+    if (conflicted) return;
     await postSave();
   }, [isReadonly, isSaving, actions, postSave, screenId, editSession]);
 

--- a/frontend/src/components/screen-items/ScreenItemsView.tsx
+++ b/frontend/src/components/screen-items/ScreenItemsView.tsx
@@ -437,7 +437,7 @@ export function ScreenItemsView() {
     isDirty, isSaving, serverChanged,
     update, updateSilent, commit,
     undo, redo, canUndo, canRedo,
-    handleSave: resourceHandleSave, handleReset, dismissServerBanner,
+    postSave, handleReset, dismissServerBanner,
     reload,
   } = useResourceEditor<ScreenItemsDocument>({
     tabType: "screen-items",
@@ -458,7 +458,7 @@ export function ScreenItemsView() {
   });
 
   // P2-2 fix (#907): URL ?session= から復元した initialEditSessionId を渡す (URL 招待 attach 復活)
-  const { editSession, mode, loading: sessionLoading, isDirtyForTab, actions, saveConflict, onSaveConflictOverwrite, onSaveConflictCancel } = useEditSession({
+  const { editSession, mode, loading: sessionLoading, isDirtyForTab, actions, takeOver, saveConflict, onSaveConflictOverwrite, onSaveConflictCancel } = useEditSession({
     resourceType: "screen-item",
     resourceId: screenId ?? "",
     sessionId,
@@ -506,9 +506,10 @@ export function ScreenItemsView() {
     if (screenId && fileRef.current && editSession?.id) {
       await mcpBridge.request("editSession.update", { editSessionId: editSession.id, payload: fileRef.current });
     }
-    await resourceHandleSave();
+    // P1-B fix (#908): conflict check (actions.save) を本体書き込みより先に実行する。
     await actions.save();
-  }, [isReadonly, isSaving, resourceHandleSave, actions, screenId, editSession]);
+    await postSave();
+  }, [isReadonly, isSaving, actions, postSave, screenId, editSession]);
 
   const handleDiscard = useCallback(async () => {
     setShowDiscardDialog(false);
@@ -988,6 +989,7 @@ export function ScreenItemsView() {
             currentSessionId={sessionId}
             onStartEditing={() => { void actions.startEditing(); }}
             onViewerAttached={syncSessionToUrl}
+            onTakeOver={takeOver}
           />
         }
         saveReset={isReadonly ? undefined : { isDirty, isSaving, onSave: handleSave, onReset: () => setShowDiscardDialog(true) }}

--- a/frontend/src/components/sequence/SequenceEditor.tsx
+++ b/frontend/src/components/sequence/SequenceEditor.tsx
@@ -106,11 +106,19 @@ export function SequenceEditor() {
 
   const handleSave = useCallback(async () => {
     if (isReadonly || isSaving) return;
+    // P1 fix (#908 round-5): debounce 中の draft を flush して即送信、その後 conflict check
+    if (draftUpdateTimer.current) {
+      clearTimeout(draftUpdateTimer.current);
+      draftUpdateTimer.current = null;
+    }
+    if (seqRef.current && editSession?.id) {
+      await mcpBridge.request("editSession.update", { editSessionId: editSession.id, payload: seqRef.current });
+    }
     // P1 fix (#908): conflict 時は postSave をスキップして clean 化を防ぐ。
     const { conflicted } = await actions.save();
     if (conflicted) return;
     await postSave();
-  }, [isReadonly, isSaving, actions, postSave]);
+  }, [isReadonly, isSaving, actions, postSave, editSession]);
 
   const handleDiscard = useCallback(async () => {
     setShowDiscardDialog(false);

--- a/frontend/src/components/sequence/SequenceEditor.tsx
+++ b/frontend/src/components/sequence/SequenceEditor.tsx
@@ -57,7 +57,7 @@ export function SequenceEditor() {
   const {
     state: seq,
     isDirty, isSaving, serverChanged,
-    update, handleSave: resourceHandleSave, handleReset, dismissServerBanner,
+    update, postSave, handleReset, dismissServerBanner,
     reload,
   } = useResourceEditor<Sequence>({
     tabType: "sequence",
@@ -78,7 +78,7 @@ export function SequenceEditor() {
   });
 
   // P2-2 fix (#907): URL ?session= から復元した initialEditSessionId を渡す (URL 招待 attach 復活)
-  const { editSession, mode, loading: sessionLoading, isDirtyForTab, actions, saveConflict, onSaveConflictOverwrite, onSaveConflictCancel } = useEditSession({
+  const { editSession, mode, loading: sessionLoading, isDirtyForTab, actions, takeOver, saveConflict, onSaveConflictOverwrite, onSaveConflictCancel } = useEditSession({
     resourceType: "sequence",
     resourceId: sequenceId ?? "",
     sessionId,
@@ -106,9 +106,10 @@ export function SequenceEditor() {
 
   const handleSave = useCallback(async () => {
     if (isReadonly || isSaving) return;
-    await resourceHandleSave();
+    // P1-B fix (#908): conflict check (actions.save) を本体書き込みより先に実行する。
     await actions.save();
-  }, [isReadonly, isSaving, resourceHandleSave, actions]);
+    await postSave();
+  }, [isReadonly, isSaving, actions, postSave]);
 
   const handleDiscard = useCallback(async () => {
     setShowDiscardDialog(false);
@@ -293,6 +294,7 @@ export function SequenceEditor() {
             currentSessionId={sessionId}
             onStartEditing={() => { void actions.startEditing(); }}
             onViewerAttached={syncSessionToUrl}
+            onTakeOver={takeOver}
           />
         }
         saveReset={isReadonly ? undefined : {

--- a/frontend/src/components/sequence/SequenceEditor.tsx
+++ b/frontend/src/components/sequence/SequenceEditor.tsx
@@ -115,8 +115,8 @@ export function SequenceEditor() {
       await mcpBridge.request("editSession.update", { editSessionId: editSession.id, payload: seqRef.current });
     }
     // P1 fix (#908): conflict 時は postSave をスキップして clean 化を防ぐ。
-    const { conflicted } = await actions.save();
-    if (conflicted) return;
+    const { conflicted, failed } = await actions.save();
+    if (conflicted || failed) return;
     await postSave();
   }, [isReadonly, isSaving, actions, postSave, editSession]);
 

--- a/frontend/src/components/sequence/SequenceEditor.tsx
+++ b/frontend/src/components/sequence/SequenceEditor.tsx
@@ -106,8 +106,9 @@ export function SequenceEditor() {
 
   const handleSave = useCallback(async () => {
     if (isReadonly || isSaving) return;
-    // P1-B fix (#908): conflict check (actions.save) を本体書き込みより先に実行する。
-    await actions.save();
+    // P1 fix (#908): conflict 時は postSave をスキップして clean 化を防ぐ。
+    const { conflicted } = await actions.save();
+    if (conflicted) return;
     await postSave();
   }, [isReadonly, isSaving, actions, postSave]);
 

--- a/frontend/src/components/table/TableEditor.tsx
+++ b/frontend/src/components/table/TableEditor.tsx
@@ -114,12 +114,19 @@ export function TableEditor() {
 
   const handleSave = useCallback(async () => {
     if (isReadonly || isSaving) return;
+    // P1 fix (#908 round-5): debounce 中の draft を flush して即送信、その後 conflict check
+    if (draftUpdateTimer.current) {
+      clearTimeout(draftUpdateTimer.current);
+      draftUpdateTimer.current = null;
+    }
+    if (tableRef.current && editSession?.id) {
+      await mcpBridge.request("editSession.update", { editSessionId: editSession.id, payload: tableRef.current });
+    }
     // P1 fix (#908): conflict 時は postSave をスキップして clean 化を防ぐ。
-    // actions.save() が { conflicted: true } を返した場合は SaveConflictDialog 経由で対処する。
     const { conflicted } = await actions.save();
     if (conflicted) return;
     await postSave();
-  }, [isReadonly, isSaving, actions, postSave]);
+  }, [isReadonly, isSaving, actions, postSave, editSession]);
 
   const handleDiscard = useCallback(async () => {
     setShowDiscardDialog(false);

--- a/frontend/src/components/table/TableEditor.tsx
+++ b/frontend/src/components/table/TableEditor.tsx
@@ -123,8 +123,8 @@ export function TableEditor() {
       await mcpBridge.request("editSession.update", { editSessionId: editSession.id, payload: tableRef.current });
     }
     // P1 fix (#908): conflict 時は postSave をスキップして clean 化を防ぐ。
-    const { conflicted } = await actions.save();
-    if (conflicted) return;
+    const { conflicted, failed } = await actions.save();
+    if (conflicted || failed) return;
     await postSave();
   }, [isReadonly, isSaving, actions, postSave, editSession]);
 

--- a/frontend/src/components/table/TableEditor.tsx
+++ b/frontend/src/components/table/TableEditor.tsx
@@ -65,7 +65,7 @@ export function TableEditor() {
     state: table,
     isDirty, isSaving, serverChanged,
     update, undo, redo, canUndo, canRedo,
-    handleSave: resourceHandleSave, handleReset, dismissServerBanner,
+    postSave, handleReset, dismissServerBanner,
     reload,
   } = useResourceEditor<Table>({
     tabType: "table",
@@ -86,7 +86,7 @@ export function TableEditor() {
   });
 
   // P2-2 fix (#907): URL ?session= から復元した initialEditSessionId を渡す (URL 招待 attach 復活)
-  const { editSession, mode, loading: sessionLoading, isDirtyForTab, actions, saveConflict, onSaveConflictOverwrite, onSaveConflictCancel } = useEditSession({
+  const { editSession, mode, loading: sessionLoading, isDirtyForTab, actions, takeOver, saveConflict, onSaveConflictOverwrite, onSaveConflictCancel } = useEditSession({
     resourceType: "table",
     resourceId: tableId ?? "",
     sessionId,
@@ -114,9 +114,12 @@ export function TableEditor() {
 
   const handleSave = useCallback(async () => {
     if (isReadonly || isSaving) return;
-    await resourceHandleSave();
+    // P1-B fix (#908): conflict check (actions.save) を本体書き込みより先に実行する。
+    // editSession.save が conflict なしと判断してから backend が本体ファイルを書き込む。
+    // postSave は frontend dirty クリア + mtime ack のみ (ファイル書き込みなし)。
     await actions.save();
-  }, [isReadonly, isSaving, resourceHandleSave, actions]);
+    await postSave();
+  }, [isReadonly, isSaving, actions, postSave]);
 
   const handleDiscard = useCallback(async () => {
     setShowDiscardDialog(false);
@@ -281,6 +284,7 @@ export function TableEditor() {
               currentSessionId={sessionId}
               onStartEditing={() => { void actions.startEditing(); }}
               onViewerAttached={syncSessionToUrl}
+              onTakeOver={takeOver}
             />
             <button
               className="editor-header-undo-btn"

--- a/frontend/src/components/table/TableEditor.tsx
+++ b/frontend/src/components/table/TableEditor.tsx
@@ -114,10 +114,10 @@ export function TableEditor() {
 
   const handleSave = useCallback(async () => {
     if (isReadonly || isSaving) return;
-    // P1-B fix (#908): conflict check (actions.save) を本体書き込みより先に実行する。
-    // editSession.save が conflict なしと判断してから backend が本体ファイルを書き込む。
-    // postSave は frontend dirty クリア + mtime ack のみ (ファイル書き込みなし)。
-    await actions.save();
+    // P1 fix (#908): conflict 時は postSave をスキップして clean 化を防ぐ。
+    // actions.save() が { conflicted: true } を返した場合は SaveConflictDialog 経由で対処する。
+    const { conflicted } = await actions.save();
+    if (conflicted) return;
     await postSave();
   }, [isReadonly, isSaving, actions, postSave]);
 

--- a/frontend/src/components/view-definition/ViewDefinitionEditor.tsx
+++ b/frontend/src/components/view-definition/ViewDefinitionEditor.tsx
@@ -280,11 +280,19 @@ export function ViewDefinitionEditor() {
 
   const handleSave = useCallback(async () => {
     if (isReadonly || isSaving) return;
+    // P1 fix (#908 round-5): debounce 中の draft を flush して即送信、その後 conflict check
+    if (draftUpdateTimer.current) {
+      clearTimeout(draftUpdateTimer.current);
+      draftUpdateTimer.current = null;
+    }
+    if (viewDefRef.current && editSession?.id) {
+      await mcpBridge.request("editSession.update", { editSessionId: editSession.id, payload: viewDefRef.current });
+    }
     // P1 fix (#908): conflict 時は postSave をスキップして clean 化を防ぐ。
     const { conflicted } = await actions.save();
     if (conflicted) return;
     await postSave();
-  }, [isReadonly, isSaving, actions, postSave]);
+  }, [isReadonly, isSaving, actions, postSave, editSession]);
 
   const handleDiscard = useCallback(async () => {
     setShowDiscardDialog(false);

--- a/frontend/src/components/view-definition/ViewDefinitionEditor.tsx
+++ b/frontend/src/components/view-definition/ViewDefinitionEditor.tsx
@@ -280,8 +280,9 @@ export function ViewDefinitionEditor() {
 
   const handleSave = useCallback(async () => {
     if (isReadonly || isSaving) return;
-    // P1-B fix (#908): conflict check (actions.save) を本体書き込みより先に実行する。
-    await actions.save();
+    // P1 fix (#908): conflict 時は postSave をスキップして clean 化を防ぐ。
+    const { conflicted } = await actions.save();
+    if (conflicted) return;
     await postSave();
   }, [isReadonly, isSaving, actions, postSave]);
 

--- a/frontend/src/components/view-definition/ViewDefinitionEditor.tsx
+++ b/frontend/src/components/view-definition/ViewDefinitionEditor.tsx
@@ -217,7 +217,7 @@ export function ViewDefinitionEditor() {
   const {
     state: viewDefinition,
     isDirty, isSaving, serverChanged,
-    update, updateSilent, commit, handleSave: resourceHandleSave, handleReset, dismissServerBanner,
+    update, updateSilent, commit, postSave, handleReset, dismissServerBanner,
     undo, redo, canUndo, canRedo,
     reload,
   } = useResourceEditor<ViewDefinition>({
@@ -240,7 +240,7 @@ export function ViewDefinitionEditor() {
   });
 
   // P2-2 fix (#907): URL ?session= から復元した initialEditSessionId を渡す (URL 招待 attach 復活)
-  const { editSession, mode, loading: sessionLoading, isDirtyForTab, actions, saveConflict, onSaveConflictOverwrite, onSaveConflictCancel } = useEditSession({
+  const { editSession, mode, loading: sessionLoading, isDirtyForTab, actions, takeOver, saveConflict, onSaveConflictOverwrite, onSaveConflictCancel } = useEditSession({
     resourceType: "view-definition",
     resourceId: viewDefinitionId ?? "",
     sessionId,
@@ -280,9 +280,10 @@ export function ViewDefinitionEditor() {
 
   const handleSave = useCallback(async () => {
     if (isReadonly || isSaving) return;
-    await resourceHandleSave();
+    // P1-B fix (#908): conflict check (actions.save) を本体書き込みより先に実行する。
     await actions.save();
-  }, [isReadonly, isSaving, resourceHandleSave, actions]);
+    await postSave();
+  }, [isReadonly, isSaving, actions, postSave]);
 
   const handleDiscard = useCallback(async () => {
     setShowDiscardDialog(false);
@@ -654,6 +655,7 @@ export function ViewDefinitionEditor() {
             currentSessionId={sessionId}
             onStartEditing={() => { void actions.startEditing(); }}
             onViewerAttached={syncSessionToUrl}
+            onTakeOver={takeOver}
           />
         }
         saveReset={isReadonly ? undefined : {

--- a/frontend/src/components/view-definition/ViewDefinitionEditor.tsx
+++ b/frontend/src/components/view-definition/ViewDefinitionEditor.tsx
@@ -289,8 +289,8 @@ export function ViewDefinitionEditor() {
       await mcpBridge.request("editSession.update", { editSessionId: editSession.id, payload: viewDefRef.current });
     }
     // P1 fix (#908): conflict 時は postSave をスキップして clean 化を防ぐ。
-    const { conflicted } = await actions.save();
-    if (conflicted) return;
+    const { conflicted, failed } = await actions.save();
+    if (conflicted || failed) return;
     await postSave();
   }, [isReadonly, isSaving, actions, postSave, editSession]);
 

--- a/frontend/src/components/view/ViewEditor.tsx
+++ b/frontend/src/components/view/ViewEditor.tsx
@@ -104,11 +104,19 @@ export function ViewEditor() {
 
   const handleSave = useCallback(async () => {
     if (isReadonly || isSaving) return;
+    // P1 fix (#908 round-5): debounce 中の draft を flush して即送信、その後 conflict check
+    if (draftUpdateTimer.current) {
+      clearTimeout(draftUpdateTimer.current);
+      draftUpdateTimer.current = null;
+    }
+    if (viewRef.current && editSession?.id) {
+      await mcpBridge.request("editSession.update", { editSessionId: editSession.id, payload: viewRef.current });
+    }
     // P1 fix (#908): conflict 時は postSave をスキップして clean 化を防ぐ。
     const { conflicted } = await actions.save();
     if (conflicted) return;
     await postSave();
-  }, [isReadonly, isSaving, actions, postSave]);
+  }, [isReadonly, isSaving, actions, postSave, editSession]);
 
   const handleDiscard = useCallback(async () => {
     setShowDiscardDialog(false);

--- a/frontend/src/components/view/ViewEditor.tsx
+++ b/frontend/src/components/view/ViewEditor.tsx
@@ -104,8 +104,9 @@ export function ViewEditor() {
 
   const handleSave = useCallback(async () => {
     if (isReadonly || isSaving) return;
-    // P1-B fix (#908): conflict check (actions.save) を本体書き込みより先に実行する。
-    await actions.save();
+    // P1 fix (#908): conflict 時は postSave をスキップして clean 化を防ぐ。
+    const { conflicted } = await actions.save();
+    if (conflicted) return;
     await postSave();
   }, [isReadonly, isSaving, actions, postSave]);
 

--- a/frontend/src/components/view/ViewEditor.tsx
+++ b/frontend/src/components/view/ViewEditor.tsx
@@ -113,8 +113,8 @@ export function ViewEditor() {
       await mcpBridge.request("editSession.update", { editSessionId: editSession.id, payload: viewRef.current });
     }
     // P1 fix (#908): conflict 時は postSave をスキップして clean 化を防ぐ。
-    const { conflicted } = await actions.save();
-    if (conflicted) return;
+    const { conflicted, failed } = await actions.save();
+    if (conflicted || failed) return;
     await postSave();
   }, [isReadonly, isSaving, actions, postSave, editSession]);
 

--- a/frontend/src/components/view/ViewEditor.tsx
+++ b/frontend/src/components/view/ViewEditor.tsx
@@ -55,7 +55,7 @@ export function ViewEditor() {
   const {
     state: view,
     isDirty, isSaving, serverChanged,
-    update, updateSilent, commit, handleSave: resourceHandleSave, handleReset, dismissServerBanner,
+    update, updateSilent, commit, postSave, handleReset, dismissServerBanner,
     reload,
   } = useResourceEditor<View>({
     tabType: "view",
@@ -104,9 +104,10 @@ export function ViewEditor() {
 
   const handleSave = useCallback(async () => {
     if (isReadonly || isSaving) return;
-    await resourceHandleSave();
+    // P1-B fix (#908): conflict check (actions.save) を本体書き込みより先に実行する。
     await actions.save();
-  }, [isReadonly, isSaving, resourceHandleSave, actions]);
+    await postSave();
+  }, [isReadonly, isSaving, actions, postSave]);
 
   const handleDiscard = useCallback(async () => {
     setShowDiscardDialog(false);

--- a/frontend/src/hooks/useEditSession.test.ts
+++ b/frontend/src/hooks/useEditSession.test.ts
@@ -187,6 +187,79 @@ describe("useEditSession (新 API, spec §15.2)", () => {
     expect(result.current.myRole).toBe("Edit");
   });
 
+  // ── P2 fix (#908): takeOver(targetEditSessionId) — 指定した session に take-over ──
+
+  it("P2 (#908): takeOver(targetEditSessionId) — 指定した editSessionId で transferEdit を呼ぶ", async () => {
+    // startEditing で Edit 状態の session を作る (hook の current)
+    (mcpBridge.request as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      editSession: MOCK_EDIT_SESSION,
+    });
+
+    const { result } = renderHook(() => useEditSession(NEW_OPTS));
+
+    await act(async () => {
+      await result.current.startEditing();
+    });
+
+    // 別 session (es-other-001) を takeOver する
+    (mcpBridge.request as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      from: { sessionId: "session-editor", role: "View" },
+      to: { sessionId: SESSION_ID, role: "Edit" },
+    });
+    // refreshEditSessionState
+    (mcpBridge.request as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      sessions: [{ ...MOCK_EDIT_SESSION, id: "es-other-001" }],
+    });
+
+    await act(async () => {
+      await result.current.takeOver("es-other-001");
+    });
+
+    // P2 fix: 指定した editSessionId で transferEdit が呼ばれること
+    expect(mcpBridge.request).toHaveBeenCalledWith("editSession.transferEdit", expect.objectContaining({
+      editSessionId: "es-other-001",
+    }));
+    // myRole が Edit になること
+    expect(result.current.myRole).toBe("Edit");
+  });
+
+  it("P2 (#908): takeOver() 引数なし — hook の current editSession に対して transferEdit を呼ぶ", async () => {
+    // attach して View 状態を作る
+    (mcpBridge.request as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      participant: { sessionId: SESSION_ID, role: "View" },
+      payload: null,
+      sequence: 0,
+    });
+    (mcpBridge.request as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      sessions: [MOCK_EDIT_SESSION],
+    });
+
+    const { result } = renderHook(() => useEditSession(NEW_OPTS));
+
+    await act(async () => {
+      await result.current.attach("es-test-001");
+    });
+
+    // takeOver() — 引数なし → hook の current session
+    (mcpBridge.request as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      from: { sessionId: "session-editor", role: "View" },
+      to: { sessionId: SESSION_ID, role: "Edit" },
+    });
+    (mcpBridge.request as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      sessions: [MOCK_EDIT_SESSION],
+    });
+
+    await act(async () => {
+      await result.current.takeOver();
+    });
+
+    // 引数なし時は hook の current editSession (es-test-001) に対して transferEdit
+    expect(mcpBridge.request).toHaveBeenCalledWith("editSession.transferEdit", expect.objectContaining({
+      editSessionId: "es-test-001",
+    }));
+    expect(result.current.myRole).toBe("Edit");
+  });
+
   // ── ケース 4: releaseEdit → setRole("View") 呼び出し、myRole が Edit → View ──
 
   it("4. releaseEdit: editSession.setRole(View) を呼び myRole が View になる", async () => {
@@ -541,6 +614,70 @@ describe("useEditSession spec §9.3 last-save-wins 衝突解決", () => {
       editSessionId: "es-test-001",
       force: true,
     });
+  });
+
+  // ── P1 fix (#908): save が conflict 時に { conflicted: true } を返すことを確認 ──
+
+  it("P1 (#908): save が conflict 応答を受けた場合 { conflicted: true } を返す", async () => {
+    // startEditing
+    (mcpBridge.request as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      editSession: MOCK_EDIT_SESSION,
+    });
+
+    const { result } = renderHook(() => useEditSession(NEW_OPTS));
+
+    await act(async () => {
+      await result.current.startEditing();
+    });
+
+    // save 応答で conflict を返す
+    (mcpBridge.request as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      conflict: { other: {
+        editSessionId: "es-other-001",
+        savedBy: "session-bob",
+        savedAt: new Date().toISOString(),
+        displayLabel: "@bob",
+      }},
+    });
+
+    let saveResult: { conflicted: boolean } | undefined;
+    await act(async () => {
+      saveResult = await result.current.save();
+    });
+
+    // P1 fix: { conflicted: true } が返ること
+    expect(saveResult).toEqual({ conflicted: true });
+    // saveConflict がセットされていること (ダイアログ表示用)
+    expect(result.current.saveConflict).not.toBeNull();
+  });
+
+  it("P1 (#908): save が成功した場合 { conflicted: false } を返す", async () => {
+    // startEditing
+    (mcpBridge.request as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      editSession: MOCK_EDIT_SESSION,
+    });
+
+    const { result } = renderHook(() => useEditSession(NEW_OPTS));
+
+    await act(async () => {
+      await result.current.startEditing();
+    });
+
+    // save 成功
+    (mcpBridge.request as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      saveEvent: { savedBy: SESSION_ID, savedAt: new Date().toISOString(), sequence: 2 },
+    });
+    (mcpBridge.request as ReturnType<typeof vi.fn>).mockResolvedValue({ sessions: [MOCK_EDIT_SESSION] });
+
+    let saveResult: { conflicted: boolean } | undefined;
+    await act(async () => {
+      saveResult = await result.current.save();
+    });
+
+    // 成功時は { conflicted: false }
+    expect(saveResult).toEqual({ conflicted: false });
+    expect(result.current.saveConflict).toBeNull();
   });
 
   it("onSaveConflictCancel: saveConflict をクリアして save 中止", async () => {

--- a/frontend/src/hooks/useEditSession.ts
+++ b/frontend/src/hooks/useEditSession.ts
@@ -102,7 +102,7 @@ export interface UseEditSessionResult {
    * P1 fix (#908): conflict 時は { conflicted: true } を返す。
    * 呼び出し元は conflicted === true なら postSave / cleanup をスキップすること。
    */
-  save(): Promise<{ conflicted: boolean }>;
+  save(): Promise<{ conflicted: boolean; failed?: boolean }>;
   discard(): Promise<void>;
   detach(): Promise<void>;
   /**
@@ -150,7 +150,7 @@ export interface EditSessionActions {
    * P1 fix (#908): conflict 時は { conflicted: true } を返す。
    * 呼び出し元は conflicted === true なら postSave / cleanup をスキップすること。
    */
-  save(): Promise<{ conflicted: boolean }>;
+  save(): Promise<{ conflicted: boolean; failed?: boolean }>;
   discard(): Promise<void>;
   /** 旧 lock model の強制解除。新 API では editSession.detach に相当 (forced=true 相当) */
   forceReleaseOther(): Promise<void>;
@@ -454,7 +454,7 @@ export function useEditSession(opts: UseEditSessionOptions): UseEditSessionResul
     }
   }, []);
 
-  const save = useCallback(async (): Promise<{ conflicted: boolean }> => {
+  const save = useCallback(async (): Promise<{ conflicted: boolean; failed?: boolean }> => {
     setError(null);
     const es = editSessionRef.current;
     if (!es) {
@@ -475,8 +475,11 @@ export function useEditSession(opts: UseEditSessionOptions): UseEditSessionResul
       // saveHistory は broadcast editSession.saved で refreshEditSessionState が呼ばれる
       return { conflicted: false };
     } catch (e) {
+      // P2 fix (#908 round-6): backend reject (transient failure) を caller に signal で伝播。
+      // throw だと React onClick の async handler で unhandled rejection になるため、
+      // 戻り値の failed フラグで明示。caller は (conflicted || failed) なら postSave skip。
       setError(e instanceof Error ? e : new Error(String(e)));
-      return { conflicted: false };
+      return { conflicted: false, failed: true };
     } finally {
       setLoading(false);
     }

--- a/frontend/src/hooks/useEditSession.ts
+++ b/frontend/src/hooks/useEditSession.ts
@@ -90,9 +90,19 @@ export interface UseEditSessionResult {
   error: Error | null;
   startEditing(): Promise<void>;
   attach(editSessionId: string): Promise<void>;
-  takeOver(): Promise<void>;
+  /**
+   * View → Edit に昇格 (atomic、prevEditor は View に降格)。
+   * P2 fix (#908): targetEditSessionId を指定すると、hook の current editSession とは
+   * 別の session に対して transferEdit を実行できる (EditSessionDropdown で選択した session)。
+   * 未指定時は hook の current editSession に対して実行する。
+   */
+  takeOver(targetEditSessionId?: string): Promise<void>;
   releaseEdit(): Promise<void>;
-  save(): Promise<void>;
+  /**
+   * P1 fix (#908): conflict 時は { conflicted: true } を返す。
+   * 呼び出し元は conflicted === true なら postSave / cleanup をスキップすること。
+   */
+  save(): Promise<{ conflicted: boolean }>;
   discard(): Promise<void>;
   detach(): Promise<void>;
   /**
@@ -136,7 +146,11 @@ export type EditMode =
  */
 export interface EditSessionActions {
   startEditing(): Promise<void>;
-  save(): Promise<void>;
+  /**
+   * P1 fix (#908): conflict 時は { conflicted: true } を返す。
+   * 呼び出し元は conflicted === true なら postSave / cleanup をスキップすること。
+   */
+  save(): Promise<{ conflicted: boolean }>;
   discard(): Promise<void>;
   /** 旧 lock model の強制解除。新 API では editSession.detach に相当 (forced=true 相当) */
   forceReleaseOther(): Promise<void>;
@@ -361,22 +375,29 @@ export function useEditSession(opts: UseEditSessionOptions): UseEditSessionResul
 
   // ── takeOver ─────────────────────────────────────────────────────────────────
 
-  const takeOver = useCallback(async () => {
+  /**
+   * P2 fix (#908): targetEditSessionId を指定すると、hook の current editSession とは
+   * 別の session に対して transferEdit を実行できる (EditSessionDropdown で選択した session)。
+   * 未指定時は hook の current editSession に対して実行する (従来動作)。
+   */
+  const takeOver = useCallback(async (targetEditSessionId?: string) => {
     setError(null);
     const es = editSessionRef.current;
-    if (!es) {
+    const editSessionId = targetEditSessionId ?? es?.id;
+    if (!editSessionId) {
       setError(new Error("EditSession がアクティブでありません"));
       return;
     }
     setLoading(true);
     try {
       // transferEdit: 現在の Edit participant から自分 (View) へ atomic に移譲
+      // P2 fix (#908): targetEditSessionId 指定時はそれに作用する
       await mcpBridge.request("editSession.transferEdit", {
-        editSessionId: es.id,
+        editSessionId,
         toSessionId: "", // server 側が clientId を使うため空で良い (handler 実装上、fromSessionId は clientId から自動判定)
       });
       setMyRole("Edit");
-      await refreshEditSessionState(es.id);
+      await refreshEditSessionState(editSessionId);
     } catch (e) {
       setError(e instanceof Error ? e : new Error(String(e)));
     } finally {
@@ -433,12 +454,12 @@ export function useEditSession(opts: UseEditSessionOptions): UseEditSessionResul
     }
   }, []);
 
-  const save = useCallback(async () => {
+  const save = useCallback(async (): Promise<{ conflicted: boolean }> => {
     setError(null);
     const es = editSessionRef.current;
     if (!es) {
       setError(new Error("EditSession がアクティブでありません"));
-      return;
+      return { conflicted: false };
     }
     setLoading(true);
     try {
@@ -446,13 +467,16 @@ export function useEditSession(opts: UseEditSessionOptions): UseEditSessionResul
         editSessionId: es.id,
       }) as { ok?: boolean; conflict?: { other: SaveConflictInfo }; saveEvent?: unknown } | undefined;
       // spec §9.3: 衝突検出 — backend が { ok: false, conflict: { other: ... } } を返した場合
+      // P1 fix (#908): conflict 時は { conflicted: true } を返し、呼び出し元が postSave をスキップできるようにする
       if (res && res.ok === false && res.conflict) {
         setSaveConflict(res.conflict.other);
-        return;
+        return { conflicted: true };
       }
       // saveHistory は broadcast editSession.saved で refreshEditSessionState が呼ばれる
+      return { conflicted: false };
     } catch (e) {
       setError(e instanceof Error ? e : new Error(String(e)));
+      return { conflicted: false };
     } finally {
       setLoading(false);
     }

--- a/frontend/src/hooks/useResourceEditor.test.ts
+++ b/frontend/src/hooks/useResourceEditor.test.ts
@@ -261,6 +261,36 @@ describe("useResourceEditor: broadcast", () => {
   });
 });
 
+// ── P1-B 順序回帰: actions.save (conflict check) → postSave (dirty クリア) (#908) ──────
+
+describe("useResourceEditor: P1-B save 順序回帰 (#908)", () => {
+  it("conflict check が postSave より先に呼ばれれば postSave は書き込みを行わない", async () => {
+    // 旧実装では resourceHandleSave (= save関数) → actions.save の順だったため
+    // conflict があっても既にファイルが書き込まれていた。
+    // 修正後は actions.save (conflict check) → postSave (dirty クリアのみ) の順。
+    // このテストは postSave が save 関数を一切呼ばないことを確認する。
+    const callOrder: string[] = [];
+    const save = vi.fn(async () => { callOrder.push("save"); });
+    const { hook } = setup({ save });
+    await waitFor(() => expect(hook.result.current.state).not.toBeNull());
+    act(() => hook.result.current.update((d) => { d.name = "edited"; }));
+
+    // actions.save (conflict check) が先に完了したと仮定して postSave を呼ぶ
+    await act(async () => {
+      callOrder.push("conflict-check");
+      await hook.result.current.postSave();
+      callOrder.push("post-save-done");
+    });
+
+    // save 関数 (ファイル書き込み相当) は呼ばれない
+    expect(save).not.toHaveBeenCalled();
+    // conflict-check → post-save-done の順で完了
+    expect(callOrder).toEqual(["conflict-check", "post-save-done"]);
+    // dirty クリア完了
+    expect(hook.result.current.isDirty).toBe(false);
+  });
+});
+
 // ── postSave (#908 P1-B fix) ─────────────────────────────────────────────────
 
 describe("useResourceEditor: postSave (#908 P1-B fix)", () => {

--- a/frontend/src/hooks/useResourceEditor.test.ts
+++ b/frontend/src/hooks/useResourceEditor.test.ts
@@ -260,3 +260,50 @@ describe("useResourceEditor: broadcast", () => {
     expect(hook.result.current.serverChanged).toBe(false);
   });
 });
+
+// ── postSave (#908 P1-B fix) ─────────────────────────────────────────────────
+
+describe("useResourceEditor: postSave (#908 P1-B fix)", () => {
+  it("postSave: save 関数を呼ばずに isDirty=false・draft 削除・タブ clean になる", async () => {
+    const save = vi.fn(async () => { /* ok */ });
+    const { hook } = setup({ save });
+    await waitFor(() => expect(hook.result.current.state).not.toBeNull());
+    act(() => hook.result.current.update((d) => { d.name = "changed"; }));
+    expect(hook.result.current.isDirty).toBe(true);
+
+    // postSave は save() を呼ばない (editSession.save が backend 側で書き込みを担う)
+    await act(async () => { await hook.result.current.postSave(); });
+
+    expect(save).not.toHaveBeenCalled(); // save 関数は呼ばれない
+    expect(hook.result.current.isDirty).toBe(false);
+    expect(hasDraft("table", "abc")).toBe(false);
+    expect(getTabs().find((t) => t.id === makeTabId("table", "abc"))?.isDirty).toBe(false);
+  });
+
+  it("postSave: isSaving は true → false と変化する", async () => {
+    const { hook } = setup();
+    await waitFor(() => expect(hook.result.current.state).not.toBeNull());
+    act(() => hook.result.current.update((d) => { d.name = "changed"; }));
+
+    // postSave 後は isSaving が false に戻る
+    await act(async () => { await hook.result.current.postSave(); });
+    expect(hook.result.current.isSaving).toBe(false);
+  });
+
+  it("postSave: handleSave との違い — handleSave は save() を呼ぶが postSave は呼ばない", async () => {
+    const save = vi.fn(async () => { /* ok */ });
+    const { hook } = setup({ save });
+    await waitFor(() => expect(hook.result.current.state).not.toBeNull());
+    act(() => hook.result.current.update((d) => { d.name = "v1"; }));
+
+    // handleSave は save() を呼ぶ
+    await act(async () => { await hook.result.current.handleSave(); });
+    expect(save).toHaveBeenCalledTimes(1);
+
+    // postSave は save() を呼ばない
+    act(() => hook.result.current.update((d) => { d.name = "v2"; }));
+    await act(async () => { await hook.result.current.postSave(); });
+    expect(save).toHaveBeenCalledTimes(1); // 変わらず 1 回のまま
+    expect(hook.result.current.isDirty).toBe(false);
+  });
+});

--- a/frontend/src/hooks/useResourceEditor.ts
+++ b/frontend/src/hooks/useResourceEditor.ts
@@ -68,6 +68,13 @@ export interface UseResourceEditorResult<T> {
 
   /** 保存実行（clean 化 + mtime ack）*/
   handleSave: () => Promise<void>;
+  /**
+   * P1-B fix (#908): conflict check 後の後処理のみ実行（ファイル書き込みなし）。
+   * editSession.save がファイル書き込みを担う場合に使う。
+   * markClean() + acknowledgeServerMtime() + setServerChanged(false) + setIsSaving 管理を行う。
+   * 呼び出し側は事前に editSession.update (debounce flush) と actions.save() (conflict check) を完了させること。
+   */
+  postSave: () => Promise<void>;
   /** リセット実行（draft 破棄 + backend 再ロード + undo クリア）*/
   handleReset: () => Promise<void>;
   /** バナーのみ閉じる（state は変えない）*/
@@ -189,6 +196,26 @@ export function useResourceEditor<T>(opts: UseResourceEditorOptions<T>): UseReso
     }
   }, [state, id, save, markClean, mtimeKind]);
 
+  /**
+   * P1-B fix (#908): ファイル書き込みなしで後処理のみ実行。
+   * editSession.save (conflict check + backend 書き込み) の後に呼ぶ。
+   * - markClean(): draft クリア + isDirty → false + tabDirty → false
+   * - acknowledgeServerMtime(): mtime を記録
+   * - setServerChanged(false): サーバ変更バナーを閉じる
+   * - isSaving の管理: setIsSaving(true/false) でラップ
+   */
+  const postSave = useCallback(async () => {
+    if (!id) return;
+    setIsSaving(true);
+    try {
+      markClean();
+      await acknowledgeServerMtime(mtimeKind, id);
+      setServerChanged(false);
+    } finally {
+      setIsSaving(false);
+    }
+  }, [id, markClean, mtimeKind]);
+
   const handleReset = useCallback(async () => {
     if (!id) return;
     clearDraft(draftKind, id);
@@ -305,6 +332,7 @@ export function useResourceEditor<T>(opts: UseResourceEditorOptions<T>): UseReso
     canUndo,
     canRedo,
     handleSave,
+    postSave,
     handleReset,
     dismissServerBanner,
     reload,


### PR DESCRIPTION
## 関連

Closes #908

派生 follow-up ISSUE (本 PR では trace のみ、対応は次 round):
- #909 takeOver(targetEditSessionId) クロスセッション payload 同期 (Should-fix)
- #910 EditSessionRowProps.onTakeOver 戻り型不一致 (Nit, pre-existing)
- #911 Conventions/Extensions SaveConflictDialog 統合 (Codex round-6 P1 派生)
- #912 overwrite 後 postSave 不在 + flow saveHistory 順序 (Codex round-7 P2)

仕様: `docs/spec/edit-session-protocol.md` (PR #896 マージ済) §9.3 last-save-wins / §13 永続化 / §11 URL 招待

## 概要

PR #907 (#897 シリーズ) squash merge 後の Codex post-merge re-review で **重大な silent functional regression を発見**。本シリーズの目的「旧 API 完全削除 + 新 protocol 純粋化」を達成するため frontend 13 files / 58 callsites の legacy mcpBridge 直呼びを refactor したが、**永続化ロジック / conflict 保護 / take-over UI / debounce flush 等の subtle bug が 4 round に渡り検出**された。Sonnet 4.6 サブエージェントが修正のたびに新 bug を混入させる問題に対し、ユーザー判断で Opus 直接 fix に切替えて収束。

## 主な変更

### Round 1 (Codex post-merge 3 件解消、Sonnet 4.6 / commit a2de7ee)
- `editSession.save` で本体 resource file 書き込み復活 (8 resource type 別 path、Phase 6 で漏れた永続化)
- Designer.tsx Puck flush 順序修正 (update 送信後に pendingPayload clear)
- transferEdit handler 内で fromSessionId 自動検索 (caller clientId 誤渡し修正)
- 8 editor で initialEditSessionId を useEditSession に渡し (URL 招待 attach 復活)

### Round 2 (Opus 検出 3 件解消、Sonnet 4.6 / commit a3de4b2)
- ConventionsCatalogView の P1-B 漏れ修正 (Sonnet 1 が 11 callsite 中 1 漏れ)
- FlowEditor persistProject 順序逆転修正 (conflict check 先行)
- Designer + DesignSubToolbar onTakeOver 実装 (myRole 即時更新)
- Designer editorKindResolved guard (Puck/GrapesJS race 解消)

### Round 3 (Codex 検出 2 件解消、Sonnet 4.6 / commit 0fac22f)
- `useEditSession.save` 戻り値で conflict signal、各 editor で conflict 時 postSave skip
- `useEditSession.takeOver(targetEditSessionId)` + EditSessionDropdown.onTakeOver(editSessionId) signature 拡張

### Round 4 (Opus 検出 1 件解消、Opus 直接 / commit b96d867)
- ExtensionsPanel save 順序 + conflict skip 漏れ修正 (Sonnet 3 grep audit 抜け)

### Round 5 (Codex 検出 3 件解消、Opus 直接 / commit 4687a33)
- 5 editor の debounce flush 追加 (Table/ProcessFlow/Sequence/View/ViewDefinition、handleSave で pending timer flush + 即送信)
- Convention catalog 本体書き込み復活 (backend editSession.save の convention branch は write skip 設計)
- Designer Puck URL attach race を editorKindResolved gate で解消

### Round 6 (Codex 検出 3 件解消、Opus 直接 + Sonnet テンプレ / commits f737676 + 単発 Edit)
- useEditSession.save の reject 時 `{ failed: true }` signal、9 editor + Designer 11 callsite で `if (conflicted || failed) return;` パターン展開
- Designer fallback で setEditorKindResolved(true) を catch block に追加 (永遠 false 防止)
- FlowEditor SaveConflictDialog onOverwrite を inline wrapper で persistProject も呼ぶように

### Round 7 (Codex 検出 P2 × 2 → 別 ISSUE #912 で trace)
- P1 = 0 件 → 収束、マージ可能と判定

## 仕様逐条突合 (自己申告)

- ☑ §9.3 conflict 保護: 全 9 editor で `actions.save()` 戻り値の `conflicted | failed` チェック
  - `frontend/src/components/table/TableEditor.tsx:126-127` / `view/ViewEditor.tsx:116-117` / `sequence/SequenceEditor.tsx:118-119` / `view-definition/ViewDefinitionEditor.tsx:292-293` / `screen-items/ScreenItemsView.tsx:510-511` / `process-flow/ProcessFlowEditor.tsx:345-346` / `flow/FlowEditor.tsx:786-787` / `conventions/ConventionsCatalogView.tsx:187-188` / `extensions/ExtensionsPanel.tsx:126-127`
- ☑ §13 永続化: backend `editSession.save` で 6 resource type の本体書き込み (`backend/src/wsBridge.ts:1354-1401`) + frontend で flow / convention の補助書き込み
- ☑ §11 URL 招待: 8 editor で `editSessionId: initialXxxSessionId` propagation
- ☑ §7 take-over: `editSessionStore.transferEdit` の fromSessionId 自動検索 (`backend/src/wsBridge.ts:1254-1260`) + dropdown `onTakeOver(editSessionId)` (`frontend/src/components/editing/EditSessionDropdown.tsx:288`)
- ☑ debounce flush: 5 editor の handleSave で pending timer flush + 即送信
- ☑ Forward-Compat: opaque envelope / lock 2 層化 / presence 独立 / snapshot only 維持

## レビューで特に見てほしい箇所

1. **Sonnet 4.6 vs Opus 直接 fix の品質差** — Sonnet が修正のたびに新 bug 混入、Opus 直接で収束。memory `feedback_role_division_opus_sonnet_codex.md` の「Sonnet=テンプレ充填」を超えた設計判断ありの修正で品質落ちる教訓
2. **`useEditSession.save` の戻り値 `{ conflicted, failed }` signal 方式** — throw だと React onClick 内 unhandled rejection、return signal で各 editor の最小修正
3. **debounce flush パターン** — 編集即 save シナリオで古い payload 送信 race の解消、5 editor 同パターン
4. **永続化責任分割** — backend writeXXX (Table/ProcessFlow/View/ViewDefinition/ScreenItems/Sequence) + frontend persistProject (flow) / saveCatalog (convention) / saveExtensionPackage (extension) のハイブリッド構造、Codex round-7 P2 (#912) で改善余地

## テスト

- **Vitest backend**: 379 pass / 1 fail (#905 pre-existing flaky `2 WS lockdown`)
- **Vitest frontend**: 1758+ pass / 11 fail (#895 pre-existing diary AJV)
- **Playwright e2e**: 既存 `frontend/e2e/edit-session/` 4 spec 影響なし (実機実行は CI で)
- **MCP E2E**: 旧 `draft__*` / `lock__*` 削除済 (#906 で新 `editSession__*` MCP tools 追加 trace 済)

## UI 影響 / AI smoke test

- [x] UI 影響あり (8 editor の handleSave 変更、SaveConflictDialog 統合、URL invitation 復活)
- [ ] AI smoke test (chrome-devtools MCP / Playwright) 実施済み

### 補足

- vitest (frontend RTL) で UI コンポーネント動作は確認 (useEditSession / EditSessionDropdown / Designer / TableEditor 等)
- フル UI smoke test は WSL2 制約で本セッション内不能、CI (Ubuntu) で確認推奨

## spec 側の不足点 / 提案

- `editSession.save` の resource type 別 write 経路 (backend で writable / frontend で writable) の統一化が課題 → #912 で trace
- overwrite 後の postSave 統一 (現状各 editor 個別 wrapper) → #911 + #912 で trace

## レビュー担当への申し送り

- **post-merge fix 専用 PR**、元 PR #907 の deeply hidden bugs を 7 round で網羅
- 規模: 6 commit + 1 minor edit = 7 commit、20+ files 変更
- pre-existing #905 (httpTransport) / #895 (diary) は本シリーズ無関係
- 派生 follow-up は #909 / #910 / #911 / #912 で trace 済
- **Sonnet 4.6 サブエージェントが修正のたびに subtle bug を混入させる問題** が学習事項、memory 反映候補

🤖 Generated with [Claude Code](https://claude.com/claude-code)