### PR TITLE
fix(types): EditSessionRowProps.onTakeOver 戻り型を Promise<void> に統一 (#910)

### DIFF
--- a/frontend/src/components/editing/EditSessionDropdown.tsx
+++ b/frontend/src/components/editing/EditSessionDropdown.tsx
@@ -89,7 +89,7 @@ interface EditSessionRowProps {
   session: EditSessionData;
   currentSessionId: string;
   onViewerAttach: (editSessionId: string) => void;
-  onTakeOver: (editSessionId: string) => void;
+  onTakeOver: (editSessionId: string) => Promise<void>;
   onDiscard: (editSessionId: string) => void;
 }
 


### PR DESCRIPTION
## Summary

ISSUE #910 — pre-existing 型不一致 Nit を解消。

`EditSessionRowProps.onTakeOver` の戻り型を `void` から `Promise<void>` に修正。`handleTakeOver` は async として実装されており、外部 Props (`EditSessionDropdownProps.onTakeOver`) も `Promise<void>` 戻りなので、内部 row コンポーネントの型定義のみが食い違っていた。

Closes #910

## 変更内容

- \`frontend/src/components/editing/EditSessionDropdown.tsx:92\` — \`onTakeOver: (editSessionId: string) => void\` → \`Promise<void>\`

## 検証

- \`npx tsc --noEmit\` (frontend): ✓ pass
- \`npx eslint src/components/editing/EditSessionDropdown.tsx\`: ✓ pass
- 実行時挙動は変わらない (型レベルのみの修正)

## 仕様逐条突合

- 戻り型統一: \`frontend/src/components/editing/EditSessionDropdown.tsx:92\` ✓

## 影響範囲

- 同 file 内のみ。caller (line 166: \`onClick={() => onTakeOver(session.id)}\`) は fire-and-forget で問題なし
- \`onDiscard\` も同様のパターンだが #910 のスコープ外のためそのまま維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)