### PR TITLE
fix(test): httpTransport afterAll を Linux/macOS 対応にして flaky 解消 (#905)

### DIFF
--- a/backend/src/httpTransport.test.ts
+++ b/backend/src/httpTransport.test.ts
@@ -124,16 +124,53 @@ describe("backend HTTP transport (#302)", () => {
   }, 30000);
 
   afterAll(async () => {
+    // shell:true で cmd.exe / sh 経由のため、server.kill("SIGTERM") は親 shell しか
+    // 殺さず孫の node.js が orphan になってポートを占有し続ける。
+    // OS 別に process tree を強制終了し、最後にポート占有プロセスを掃除する (#905 fix)。
+    const { execSync } = await import("node:child_process");
+
     if (server && server.pid) {
-      // Windows: shell:true で cmd.exe 経由の場合、process tree ごと強制終了する。
-      // server.kill("SIGTERM") は cmd.exe しか殺さず node.js が orphan になってポートを占有し続けるため
-      // taskkill /F /T で子孫まで含めてまとめて終了する (#700 R-2 test fix)
       try {
-        const { execSync } = await import("node:child_process");
-        execSync(`taskkill /F /T /PID ${server.pid}`, { stdio: "ignore" });
+        if (process.platform === "win32") {
+          execSync(`taskkill /F /T /PID ${server.pid}`, { stdio: "ignore" });
+        } else {
+          // Linux / macOS / WSL2: 自身 + 子孫を強制終了
+          try {
+            execSync(`pkill -9 -P ${server.pid}`, { stdio: "ignore" });
+          } catch { /* no children */ }
+          try {
+            execSync(`kill -9 ${server.pid}`, { stdio: "ignore" });
+          } catch { /* already exited */ }
+        }
       } catch { /* ignore — already exited */ }
     }
-    // Windows ではポート解放に時間がかかることがある
+
+    // 残存したポート占有プロセスを sweep する fallback (#905):
+    // shell:true 経由で起動した tsx 孫プロセスが上記 kill で取り切れなかった場合の
+    // 最後の砦。次回起動時の killStaleProcessOnPort が同じことをするが、ここで掃除して
+    // おくことで test 間の冪等性を担保する。
+    try {
+      if (process.platform === "win32") {
+        const out = execSync(`netstat -ano -p tcp | findstr LISTENING | findstr :${TEST_PORT}`, { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
+        const pids = new Set<string>();
+        for (const line of out.split(/\r?\n/)) {
+          const m = line.match(/\s(\d+)\s*$/);
+          if (m) pids.add(m[1]);
+        }
+        for (const pid of pids) {
+          try { execSync(`taskkill /F /PID ${pid}`, { stdio: "ignore" }); } catch { /* ignore */ }
+        }
+      } else {
+        const out = execSync(`lsof -ti tcp:${TEST_PORT} -sTCP:LISTEN`, { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+        for (const pid of out.split(/\s+/)) {
+          if (pid) {
+            try { execSync(`kill -9 ${pid}`, { stdio: "ignore" }); } catch { /* ignore */ }
+          }
+        }
+      }
+    } catch { /* lsof / netstat exit 1 = no listener: 正常 */ }
+
+    // ポート解放を待つ
     await delay(500);
     // #758: fixture workspace の cleanup
     if (tempFixtureDir) {


### PR DESCRIPTION
## Summary

ISSUE #905 — `httpTransport.test.ts > 2 WS クライアントが接続でき、各々が lockdown active workspace.status を返す` が origin/main で flaky だった原因を根本解消。

Closes #905

## 根本原因

\`afterAll\` の cleanup が \`taskkill /F /T /PID\` (Windows 専用) のみで、Linux/WSL2 では silent fail し、spawn した tsx server が orphan として port 5201 を占有し続けていた。次回テスト起動時に \`killStaleProcessOnPort\` が orphan を検出して kill するが、500ms delay と WS handshake の干渉で初回 WS roundtrip が 5s timeout 直近に張り付き flaky 化していた。

実証:
- orphan 残存状態: 5003ms で fail (WS roundtrip 中の register/request 応答が来ない)
- orphan 無し状態: 全 6 テスト 1.59s で pass

## 修正内容 (\`backend/src/httpTransport.test.ts\`)

### 1. process tree kill を OS 別に対応 (\`afterAll\` 前半)

- Windows: \`taskkill /F /T /PID\` (従来動作維持)
- Linux / macOS / WSL2: \`pkill -9 -P <pid>\` (子孫) + \`kill -9 <pid>\` (本体)

### 2. port sweep fallback (\`afterAll\` 後半)

shell:true 経由で起動した tsx 孫プロセスが上記 kill で取り切れなかった場合の最後の砦として、port 占有プロセスを \`lsof -ti tcp:<port>\` (POSIX) / \`netstat -ano\` (Windows) で検出して kill。test 間の冪等性を担保。

## 検証

- 単体実行 × 3 連続 pass、port 5201 リーク無し
- \`npm test\` 全 380 件 pass

## 仕様逐条突合

- platform 別 process tree kill: \`backend/src/httpTransport.test.ts:128-145\` ✓
- port sweep fallback: \`backend/src/httpTransport.test.ts:151-170\` ✓
- delay + fixture cleanup 既存ロジック維持: \`backend/src/httpTransport.test.ts:172-180\` ✓

## 影響範囲

- テストのみ (production code 変更なし)
- Windows / Linux / macOS / WSL2 全対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)