### PR TITLE
improve(edit-session): #908 シリーズ post-merge follow-up 統合 PR (#909 / #911 / #912)

### DIFF
--- a/backend/src/wsBridge.ts
+++ b/backend/src/wsBridge.ts
@@ -1307,11 +1307,24 @@ class WsBridge extends EventEmitter {
         case "editSession.save": {
           const esWsId = wsId();
           if (!esWsId) { respondError("ワークスペースが選択されていません"); break; }
-          const { editSessionId: esSvId, force } = (params ?? {}) as { editSessionId: string; force?: boolean };
+          // P2 fix (#912): stage パラメータで 2 段階保存をサポート (FlowEditor 等、frontend が本体ファイル
+          // 書き込みを担う resource type 用)。
+          //   - stage 未指定 (default): 従来通り conflict check + saveHistory 記録 + 本体書き込み + broadcast
+          //   - stage: "checkOnly" : conflict check のみ。saveHistory / 本体書き込み / broadcast なし
+          //   - stage: "commit"    : conflict check skip。saveHistory 記録 + 本体書き込み + broadcast
+          // FlowEditor は checkOnly → frontend persistProject() → commit の順で呼ぶことで、
+          // persistProject 失敗時に saveHistory が record されない (整合性向上、recoverable)。
+          const { editSessionId: esSvId, force, stage } = (params ?? {}) as {
+            editSessionId: string;
+            force?: boolean;
+            stage?: "checkOnly" | "commit";
+          };
           const esStore = this.getOrCreateEditSessionStore(esWsId);
 
-          // spec §9.3 last-save-wins 衝突検出: force フラグなしの場合のみ
-          if (!force) {
+          // spec §9.3 last-save-wins 衝突検出:
+          //   - force フラグありの場合は skip (overwrite 確認後)
+          //   - stage: "commit" の場合は skip (checkOnly で事前チェック済み)
+          if (!force && stage !== "commit") {
             const allSessions = esStore.listByResource(
               esStore.getById(esSvId)?.resourceType ?? "process-flow",
               esStore.getById(esSvId)?.resourceId ?? "",
@@ -1337,6 +1350,12 @@ class WsBridge extends EventEmitter {
               });
               break;
             }
+          }
+
+          // stage: "checkOnly" は conflict check のみで終了 (saveHistory 記録 / 本体書き込み / broadcast なし)
+          if (stage === "checkOnly") {
+            respond({ ok: true });
+            break;
           }
 
           const saveEvent = await esStore.save(esSvId, clientId);

--- a/frontend/src/components/Designer.tsx
+++ b/frontend/src/components/Designer.tsx
@@ -336,6 +336,32 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
     }
   }, [isActive]);
 
+  /**
+   * P1 fix (#912): editSession.save 成功後 (通常 save と overwrite 両方) で共通に呼ぶ cleanup。
+   * 通常 save: editActions.save() が conflict / failed でない場合に呼ぶ
+   * overwrite: SaveConflictDialog の onOverwrite 内で onSaveConflictOverwrite() 後に呼ぶ
+   */
+  const commitAfterSave = useCallback(async () => {
+    setIsDirtyState(false);
+    isDirtyRef.current = false;
+    setDirty(tabId, false);
+    setServerChanged(false);
+    await acknowledgeServerMtime("screen", screenId);
+    // サムネイル生成 (GrapesJS のみ — Puck は API.captureThumbnail() が null を返す)
+    const api = editorApiRef.current;
+    if (api && !api.isCanvasEmpty()) {
+      api.captureThumbnail().then(async (thumbnail) => {
+        if (!thumbnail) return;
+        try {
+          const project = await loadProject();
+          await updateScreenThumbnail(project, screenId, thumbnail);
+        } catch {
+          // サムネイル保存失敗は無視
+        }
+      });
+    }
+  }, [screenId, tabId]);
+
   /** 保存: 保留中の debounce を flush してから editSession.save */
   const handleSave = useCallback(async () => {
     if (isReadonly || isSaving) return;
@@ -370,24 +396,7 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
         const grapesJsSaveResult = await editActions.save();
         if (grapesJsSaveResult.conflicted || grapesJsSaveResult.failed) return;
       }
-      setIsDirtyState(false);
-      isDirtyRef.current = false;
-      setDirty(tabId, false);
-      setServerChanged(false);
-      await acknowledgeServerMtime("screen", screenId);
-      // サムネイル生成 (GrapesJS のみ — Puck は API.captureThumbnail() が null を返す)
-      const api = editorApiRef.current;
-      if (api && !api.isCanvasEmpty()) {
-        api.captureThumbnail().then(async (thumbnail) => {
-          if (!thumbnail) return;
-          try {
-            const project = await loadProject();
-            await updateScreenThumbnail(project, screenId, thumbnail);
-          } catch {
-            // サムネイル保存失敗は無視
-          }
-        });
-      }
+      await commitAfterSave();
     } catch (e) {
       console.error("[Designer] save failed:", e);
       showError({
@@ -398,7 +407,7 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
     } finally {
       setIsSaving(false);
     }
-  }, [screenId, tabId, isReadonly, isSaving, editorKind, editActions, showError, editSession]);
+  }, [screenId, tabId, isReadonly, isSaving, editorKind, editActions, showError, editSession, commitAfterSave]);
 
   /** 破棄: discardDraft + releaseLock → 本体ファイル再読込 */
   const handleDiscard = useCallback(async () => {
@@ -650,7 +659,14 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
       {saveConflict && (
         <SaveConflictDialog
           conflict={saveConflict}
-          onOverwrite={() => { void onSaveConflictOverwrite(); }}
+          onOverwrite={async () => {
+            try {
+              await onSaveConflictOverwrite();
+              await commitAfterSave();
+            } catch (e) {
+              console.error("[Designer] save overwrite failed:", e);
+            }
+          }}
           onCancel={onSaveConflictCancel}
         />
       )}

--- a/frontend/src/components/conventions/ConventionsCatalogView.tsx
+++ b/frontend/src/components/conventions/ConventionsCatalogView.tsx
@@ -21,6 +21,7 @@ import {
   AfterForceUnlockChoiceDialog,
 } from "../editing/ConfirmDialogs";
 import { ResumeOrDiscardDialog } from "../editing/ResumeOrDiscardDialog";
+import { SaveConflictDialog } from "../editing/SaveConflictDialog";
 import { setDirty as setTabDirty, makeTabId } from "../../store/tabStore";
 import {
   loadConventions,
@@ -135,7 +136,7 @@ export function ConventionsCatalogView() {
     broadcastName: "conventionsChanged",
   });
 
-  const { editSession, mode, loading: sessionLoading, isDirtyForTab, actions } = useEditSession({
+  const { editSession, mode, loading: sessionLoading, isDirtyForTab, actions, saveConflict, onSaveConflictOverwrite, onSaveConflictCancel } = useEditSession({
     resourceType: "convention",
     resourceId: "singleton",
     sessionId,
@@ -378,6 +379,26 @@ export function ConventionsCatalogView() {
           ownerSessionId={lockedByOther.ownerSessionId}
           onConfirm={handleForceRelease}
           onCancel={() => setShowForceReleaseDialog(false)}
+        />
+      )}
+
+      {saveConflict && (
+        <SaveConflictDialog
+          conflict={saveConflict}
+          onOverwrite={async () => {
+            // P1 派生 fix (#911): backend force save 後に本体ファイル書き込み + cleanup を実行する。
+            // convention は backend editSession.save で write skip されるため、ここで saveCatalog を呼ぶ。
+            try {
+              await onSaveConflictOverwrite();
+              if (catalogRef.current) {
+                await saveCatalog(catalogRef.current);
+              }
+              await postSave();
+            } catch (e) {
+              console.error("[ConventionsCatalogView] save overwrite failed:", e);
+            }
+          }}
+          onCancel={onSaveConflictCancel}
         />
       )}
 

--- a/frontend/src/components/extensions/ExtensionsPanel.tsx
+++ b/frontend/src/components/extensions/ExtensionsPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { mcpBridge } from "../../mcp/mcpBridge";
 import { loadExtensionsFromBundle, type RawExtensionsBundle } from "../../schemas/loadExtensions";
@@ -16,6 +16,7 @@ import {
   AfterForceUnlockChoiceDialog,
 } from "../editing/ConfirmDialogs";
 import { ResumeOrDiscardDialog } from "../editing/ResumeOrDiscardDialog";
+import { SaveConflictDialog } from "../editing/SaveConflictDialog";
 import { setDirty as setTabDirty, makeTabId } from "../../store/tabStore";
 import "../../styles/editMode.css";
 
@@ -56,13 +57,20 @@ export function ExtensionsPanel() {
 
   const sessionId = mcpBridge.getSessionId();
 
-  const { mode, loading: sessionLoading, isDirtyForTab, actions } = useEditSession({
+  const { mode, loading: sessionLoading, isDirtyForTab, actions, saveConflict, onSaveConflictOverwrite, onSaveConflictCancel } = useEditSession({
     resourceType: "extension",
     resourceId: active,
     sessionId,
   });
 
   const isReadonly = mode.kind !== "editing";
+
+  /**
+   * P1 派生 fix (#911): handleSave は kind / content を引数で受けるため、
+   * SaveConflictDialog の onOverwrite が body 書き込みを再実行できるよう、最後の save 試行時の引数を保持する。
+   * conflict ダイアログ表示中は新たな save が起きないため ref で 1 件だけ保持すれば十分。
+   */
+  const lastSaveArgsRef = useRef<{ kind: ExtensionKind; content: unknown } | null>(null);
 
   const load = useCallback(async (forceReload = false) => {
     setLoading(true);
@@ -118,6 +126,8 @@ export function ExtensionsPanel() {
 
   const handleSave = useCallback(async (kind: ExtensionKind, content: unknown) => {
     if (isReadonly) return;
+    // P1 派生 fix (#911): SaveConflictDialog の onOverwrite が再現できるよう引数を ref に保持。
+    lastSaveArgsRef.current = { kind, content };
     setSaving(true);
     setMessage(null);
     try {
@@ -209,6 +219,32 @@ export function ExtensionsPanel() {
           onResume={() => { void handleResumeContinue(); }}
           onDiscard={() => { void handleResumeDiscard(); }}
           onCancel={() => setShowResumeDialog(false)}
+        />
+      )}
+
+      {saveConflict && (
+        <SaveConflictDialog
+          conflict={saveConflict}
+          onOverwrite={async () => {
+            // P1 派生 fix (#911): backend force save 後に extension package 本体を書き込み + cleanup を実行する。
+            // extension は backend editSession.save で write skip されるため、ここで saveExtensionPackage を呼ぶ。
+            const args = lastSaveArgsRef.current;
+            setSaving(true);
+            try {
+              await onSaveConflictOverwrite();
+              if (args) {
+                await mcpBridge.request("saveExtensionPackage", { type: args.kind, content: args.content });
+                setMessage("保存しました。");
+                await load(true);
+              }
+            } catch (e) {
+              console.error("[ExtensionsPanel] save overwrite failed:", e);
+              setMessage(e instanceof Error ? e.message : String(e));
+            } finally {
+              setSaving(false);
+            }
+          }}
+          onCancel={onSaveConflictCancel}
         />
       )}
 

--- a/frontend/src/components/flow/FlowEditor.tsx
+++ b/frontend/src/components/flow/FlowEditor.tsx
@@ -1081,16 +1081,19 @@ function FlowEditorInner() {
             // P2 fix (#912): flow は backend editSession.save で write skip されるため、
             // 上書き確認後に frontend で persistProject() を先に実行し、saveCommit() で saveHistory を記録する。
             // (persist 失敗時に saveHistory が先行記録される問題を解消)
+            // Should-fix (#916 review): projectRef.current が null なら persist 不能 — dialog を閉じて状態リセット。
+            if (!projectRef.current) {
+              onSaveConflictCancel();
+              return;
+            }
             try {
-              if (projectRef.current) {
-                await persistProject(projectRef.current);
-                const commitResult = await saveCommit();
-                if (commitResult.failed) return;
-                setIsDirty(false);
-                isDirtyRef.current = false;
-                dismissServerBanner();
-                await acknowledgeServerMtime("project");
-              }
+              await persistProject(projectRef.current);
+              const commitResult = await saveCommit();
+              if (commitResult.failed) return;
+              setIsDirty(false);
+              isDirtyRef.current = false;
+              dismissServerBanner();
+              await acknowledgeServerMtime("project");
             } catch (e) {
               console.error("[FlowEditor] save overwrite failed:", e);
             }

--- a/frontend/src/components/flow/FlowEditor.tsx
+++ b/frontend/src/components/flow/FlowEditor.tsx
@@ -162,7 +162,7 @@ function FlowEditorInner() {
   });
 
   // P2-2 fix (#907): URL ?session= から復元した initialEditSessionId を渡す (URL 招待 attach 復活)
-  const { editSession, mode, loading: sessionLoading, isDirtyForTab, actions, saveConflict, onSaveConflictOverwrite, onSaveConflictCancel } = useEditSession({
+  const { editSession, mode, loading: sessionLoading, isDirtyForTab, actions, saveCheckConflict, saveCommit, saveConflict, onSaveConflictCancel } = useEditSession({
     resourceType: "flow",
     resourceId: "singleton",
     sessionId,
@@ -782,10 +782,14 @@ function FlowEditorInner() {
     }
     setIsSaving(true);
     try {
-      // P1 fix (#908): conflict 時は cleanup をスキップして clean 化を防ぐ。
-      const { conflicted, failed } = await actions.save();
-      if (conflicted || failed) return;
+      // P2 fix (#912): 2 段階保存。flow は backend editSession.save で本体書き込みを skip し、
+      // 代わりに frontend persistProject() が harmony.json + screen-layout.json を書く設計のため、
+      // saveHistory 記録が persist 失敗時に先行記録される問題を解消するため checkOnly → persist → commit の順で実行する。
+      const checkResult = await saveCheckConflict();
+      if (checkResult.conflicted || checkResult.failed) return;
       await persistProject(projectRef.current);
+      const commitResult = await saveCommit();
+      if (commitResult.failed) return;
       setIsDirty(false);
       isDirtyRef.current = false;
       dismissServerBanner();
@@ -799,7 +803,7 @@ function FlowEditorInner() {
     } finally {
       setIsSaving(false);
     }
-  }, [isSaving, isReadonly, actions, showError, dismissServerBanner, editSession]);
+  }, [isSaving, isReadonly, saveCheckConflict, saveCommit, showError, dismissServerBanner, editSession]);
 
   const handleDiscard = useCallback(async () => {
     setShowDiscardDialog(false);
@@ -1074,12 +1078,14 @@ function FlowEditorInner() {
         <SaveConflictDialog
           conflict={saveConflict}
           onOverwrite={async () => {
-            // P1 fix (#908 round-6): backend editSession.save は flow を write skip するため、
-            // 上書き確認後に frontend で persistProject による本体書き込みを実行する。
+            // P2 fix (#912): flow は backend editSession.save で write skip されるため、
+            // 上書き確認後に frontend で persistProject() を先に実行し、saveCommit() で saveHistory を記録する。
+            // (persist 失敗時に saveHistory が先行記録される問題を解消)
             try {
-              await onSaveConflictOverwrite();
               if (projectRef.current) {
                 await persistProject(projectRef.current);
+                const commitResult = await saveCommit();
+                if (commitResult.failed) return;
                 setIsDirty(false);
                 isDirtyRef.current = false;
                 dismissServerBanner();

--- a/frontend/src/components/process-flow/ProcessFlowEditor.tsx
+++ b/frontend/src/components/process-flow/ProcessFlowEditor.tsx
@@ -764,7 +764,14 @@ export function ProcessFlowEditor() {
       {saveConflict && (
         <SaveConflictDialog
           conflict={saveConflict}
-          onOverwrite={() => { void onSaveConflictOverwrite(); }}
+          onOverwrite={async () => {
+            try {
+              await onSaveConflictOverwrite();
+              await hookPostSave();
+            } catch (e) {
+              console.error("[ProcessFlowEditor] save overwrite failed:", e);
+            }
+          }}
           onCancel={onSaveConflictCancel}
         />
       )}

--- a/frontend/src/components/screen-items/ScreenItemsView.tsx
+++ b/frontend/src/components/screen-items/ScreenItemsView.tsx
@@ -1517,7 +1517,14 @@ export function ScreenItemsView() {
       {saveConflict && (
         <SaveConflictDialog
           conflict={saveConflict}
-          onOverwrite={() => { void onSaveConflictOverwrite(); }}
+          onOverwrite={async () => {
+            try {
+              await onSaveConflictOverwrite();
+              await postSave();
+            } catch (e) {
+              console.error("[ScreenItemsView] save overwrite failed:", e);
+            }
+          }}
           onCancel={onSaveConflictCancel}
         />
       )}

--- a/frontend/src/components/sequence/SequenceEditor.tsx
+++ b/frontend/src/components/sequence/SequenceEditor.tsx
@@ -284,7 +284,14 @@ export function SequenceEditor() {
       {saveConflict && (
         <SaveConflictDialog
           conflict={saveConflict}
-          onOverwrite={() => { void onSaveConflictOverwrite(); }}
+          onOverwrite={async () => {
+            try {
+              await onSaveConflictOverwrite();
+              await postSave();
+            } catch (e) {
+              console.error("[SequenceEditor] save overwrite failed:", e);
+            }
+          }}
           onCancel={onSaveConflictCancel}
         />
       )}

--- a/frontend/src/components/table/TableEditor.tsx
+++ b/frontend/src/components/table/TableEditor.tsx
@@ -250,7 +250,14 @@ export function TableEditor() {
       {saveConflict && (
         <SaveConflictDialog
           conflict={saveConflict}
-          onOverwrite={() => { void onSaveConflictOverwrite(); }}
+          onOverwrite={async () => {
+            try {
+              await onSaveConflictOverwrite();
+              await postSave();
+            } catch (e) {
+              console.error("[TableEditor] save overwrite failed:", e);
+            }
+          }}
           onCancel={onSaveConflictCancel}
         />
       )}

--- a/frontend/src/components/view-definition/ViewDefinitionEditor.tsx
+++ b/frontend/src/components/view-definition/ViewDefinitionEditor.tsx
@@ -634,7 +634,14 @@ export function ViewDefinitionEditor() {
       {saveConflict && (
         <SaveConflictDialog
           conflict={saveConflict}
-          onOverwrite={() => { void onSaveConflictOverwrite(); }}
+          onOverwrite={async () => {
+            try {
+              await onSaveConflictOverwrite();
+              await postSave();
+            } catch (e) {
+              console.error("[ViewDefinitionEditor] save overwrite failed:", e);
+            }
+          }}
           onCancel={onSaveConflictCancel}
         />
       )}

--- a/frontend/src/components/view/ViewEditor.tsx
+++ b/frontend/src/components/view/ViewEditor.tsx
@@ -288,7 +288,14 @@ export function ViewEditor() {
       {saveConflict && (
         <SaveConflictDialog
           conflict={saveConflict}
-          onOverwrite={() => { void onSaveConflictOverwrite(); }}
+          onOverwrite={async () => {
+            try {
+              await onSaveConflictOverwrite();
+              await postSave();
+            } catch (e) {
+              console.error("[ViewEditor] save overwrite failed:", e);
+            }
+          }}
           onCancel={onSaveConflictCancel}
         />
       )}

--- a/frontend/src/hooks/useEditSession.test.ts
+++ b/frontend/src/hooks/useEditSession.test.ts
@@ -851,7 +851,114 @@ describe("useEditSession Phase 7 追加: broadcast 反映の網羅 (spec §14 / 
   });
 });
 
-// ── #909 fix: cross-session takeOver(targetId) で payload を同期する ──
+// ── #909 / #912 fix: saveCheckConflict / saveCommit / cross-session takeOver payload 同期 ──
+
+describe("useEditSession #912 fix: 2 段階保存 (saveCheckConflict / saveCommit)", () => {
+  it("saveCheckConflict: stage='checkOnly' で editSession.save を呼び conflicted=false を返す", async () => {
+    (mcpBridge.request as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      editSession: MOCK_EDIT_SESSION,
+    });
+
+    const { result } = renderHook(() => useEditSession(NEW_OPTS));
+    await act(async () => { await result.current.startEditing(); });
+
+    // checkOnly stage の応答 (ok: true、saveEvent なし)
+    (mcpBridge.request as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ ok: true });
+
+    let checkResult: { conflicted: boolean; failed?: boolean } | undefined;
+    await act(async () => {
+      checkResult = await result.current.saveCheckConflict();
+    });
+
+    expect(checkResult).toEqual({ conflicted: false });
+    expect(mcpBridge.request).toHaveBeenCalledWith("editSession.save", {
+      editSessionId: "es-test-001",
+      stage: "checkOnly",
+    });
+  });
+
+  it("saveCheckConflict: conflict 応答時に saveConflict をセットして conflicted=true を返す", async () => {
+    (mcpBridge.request as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      editSession: MOCK_EDIT_SESSION,
+    });
+
+    const { result } = renderHook(() => useEditSession(NEW_OPTS));
+    await act(async () => { await result.current.startEditing(); });
+
+    const conflictInfo = {
+      editSessionId: "es-other-001",
+      savedBy: "session-bob",
+      savedAt: new Date().toISOString(),
+      displayLabel: "@bob",
+    };
+    (mcpBridge.request as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      conflict: { other: conflictInfo },
+    });
+
+    let checkResult: { conflicted: boolean; failed?: boolean } | undefined;
+    await act(async () => {
+      checkResult = await result.current.saveCheckConflict();
+    });
+
+    expect(checkResult).toEqual({ conflicted: true });
+    expect(result.current.saveConflict).toEqual(conflictInfo);
+  });
+
+  it("saveCommit: stage='commit' で editSession.save を呼び saveConflict をクリアする", async () => {
+    (mcpBridge.request as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      editSession: MOCK_EDIT_SESSION,
+    });
+
+    const { result } = renderHook(() => useEditSession(NEW_OPTS));
+    await act(async () => { await result.current.startEditing(); });
+
+    // 先に conflict を発生させて saveConflict をセット
+    (mcpBridge.request as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      conflict: { other: { editSessionId: "es-other-001", savedBy: "x", savedAt: "y", displayLabel: "z" } },
+    });
+    await act(async () => { await result.current.save(); });
+    expect(result.current.saveConflict).not.toBeNull();
+
+    // commit 応答
+    (mcpBridge.request as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      saveEvent: { savedBy: SESSION_ID, savedAt: new Date().toISOString(), sequence: 2 },
+    });
+
+    let commitResult: { failed?: boolean } | undefined;
+    await act(async () => {
+      commitResult = await result.current.saveCommit();
+    });
+
+    expect(commitResult).toEqual({});
+    expect(mcpBridge.request).toHaveBeenCalledWith("editSession.save", {
+      editSessionId: "es-test-001",
+      stage: "commit",
+    });
+    // saveConflict がクリアされること (overwrite path 経由対応)
+    expect(result.current.saveConflict).toBeNull();
+  });
+
+  it("saveCommit: backend reject 時 { failed: true } を返す", async () => {
+    (mcpBridge.request as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      editSession: MOCK_EDIT_SESSION,
+    });
+
+    const { result } = renderHook(() => useEditSession(NEW_OPTS));
+    await act(async () => { await result.current.startEditing(); });
+
+    (mcpBridge.request as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("network error"));
+
+    let commitResult: { failed?: boolean } | undefined;
+    await act(async () => {
+      commitResult = await result.current.saveCommit();
+    });
+
+    expect(commitResult).toEqual({ failed: true });
+  });
+});
 
 describe("useEditSession #909 fix: cross-session takeOver(targetId) で payload を同期する", () => {
   it("cross-session takeOver: target session の payload + sequence を fetchPayload で取得して state に反映", async () => {

--- a/frontend/src/hooks/useEditSession.test.ts
+++ b/frontend/src/hooks/useEditSession.test.ts
@@ -850,3 +850,83 @@ describe("useEditSession Phase 7 追加: broadcast 反映の網羅 (spec §14 / 
     expect(result.current.myRole).toBe("Edit");
   });
 });
+
+// ── #909 fix: cross-session takeOver(targetId) で payload を同期する ──
+
+describe("useEditSession #909 fix: cross-session takeOver(targetId) で payload を同期する", () => {
+  it("cross-session takeOver: target session の payload + sequence を fetchPayload で取得して state に反映", async () => {
+    // startEditing で current session を作る (id=es-test-001)
+    (mcpBridge.request as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      editSession: MOCK_EDIT_SESSION,
+    });
+
+    const { result } = renderHook(() => useEditSession(NEW_OPTS));
+    await act(async () => { await result.current.startEditing(); });
+
+    expect(result.current.payload).toEqual({ data: "initial" });
+    expect(result.current.editSession?.id).toBe("es-test-001");
+
+    // 別 session (es-target-002) を takeOver する
+    // 1. transferEdit response
+    (mcpBridge.request as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      from: { sessionId: "session-other", role: "View" },
+      to: { sessionId: SESSION_ID, role: "Edit" },
+    });
+    // 2. fetchPayload response (cross-session 検知時に呼ばれる)
+    (mcpBridge.request as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      payload: { data: "target-payload" },
+      sequence: 42,
+    });
+    // 3. refreshEditSessionState: editSession.list response
+    (mcpBridge.request as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      sessions: [{ ...MOCK_EDIT_SESSION, id: "es-target-002", payload: { data: "target-payload" }, sequence: 42 }],
+    });
+
+    await act(async () => {
+      await result.current.takeOver("es-target-002");
+    });
+
+    // fetchPayload が target session に対して呼ばれたことを確認
+    expect(mcpBridge.request).toHaveBeenCalledWith("editSession.fetchPayload", {
+      editSessionId: "es-target-002",
+    });
+    // payload が target session のものに切り替わったこと
+    expect(result.current.payload).toEqual({ data: "target-payload" });
+    // myRole が Edit になったこと
+    expect(result.current.myRole).toBe("Edit");
+    // editSession state が target session に切り替わったこと
+    expect(result.current.editSession?.id).toBe("es-target-002");
+  });
+
+  it("same-session takeOver: 同じ session への take-over は fetchPayload を呼ばない", async () => {
+    // attach で View 状態を作る (id=es-test-001)
+    (mcpBridge.request as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      participant: { sessionId: SESSION_ID, role: "View" },
+      payload: { data: "view-payload" },
+      sequence: 5,
+    });
+    (mcpBridge.request as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      sessions: [MOCK_EDIT_SESSION_WITH_VIEW],
+    });
+
+    const { result } = renderHook(() => useEditSession(NEW_OPTS));
+    await act(async () => { await result.current.attach("es-test-001"); });
+
+    // takeOver(targetId) で同じ session を指定
+    (mcpBridge.request as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      from: { sessionId: "session-editor", role: "View" },
+      to: { sessionId: SESSION_ID, role: "Edit" },
+    });
+    (mcpBridge.request as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      sessions: [MOCK_EDIT_SESSION],
+    });
+
+    await act(async () => {
+      await result.current.takeOver("es-test-001");
+    });
+
+    // fetchPayload は呼ばれていない (同 session は broadcast 経由で payload 同期済み)
+    expect(mcpBridge.request).not.toHaveBeenCalledWith("editSession.fetchPayload", expect.anything());
+    expect(result.current.myRole).toBe("Edit");
+  });
+});

--- a/frontend/src/hooks/useEditSession.ts
+++ b/frontend/src/hooks/useEditSession.ts
@@ -517,6 +517,11 @@ export function useEditSession(opts: UseEditSessionOptions): UseEditSessionResul
   /**
    * P2 fix (#912): 2 段階保存の前段 — conflict check のみ。
    * 衝突検出時は saveConflict state にセットして { conflicted: true } を返す。
+   *
+   * 注意: hook の `loading` 状態はトグルしない (#916 review Should-fix)。
+   * 本メソッドは saveCheckConflict → persistProject → saveCommit の 3 段で必ずペア使用される
+   * 設計のため、独立してローディング状態を上書きすると persistProject 中に sessionLoading=false に
+   * 落ちる「チカチカ」が発生する。caller (FlowEditor) が独自の `isSaving` で 3 段全体をラップする。
    */
   const saveCheckConflict = useCallback(async (): Promise<{ conflicted: boolean; failed?: boolean }> => {
     setError(null);
@@ -525,7 +530,6 @@ export function useEditSession(opts: UseEditSessionOptions): UseEditSessionResul
       setError(new Error("EditSession がアクティブでありません"));
       return { conflicted: false };
     }
-    setLoading(true);
     try {
       const res = await mcpBridge.request("editSession.save", {
         editSessionId: es.id,
@@ -539,14 +543,14 @@ export function useEditSession(opts: UseEditSessionOptions): UseEditSessionResul
     } catch (e) {
       setError(e instanceof Error ? e : new Error(String(e)));
       return { conflicted: false, failed: true };
-    } finally {
-      setLoading(false);
     }
   }, []);
 
   /**
    * P2 fix (#912): 2 段階保存の後段 — saveHistory 記録 + broadcast。conflict check skip。
    * checkOnly 後の本体書き込み成功後に呼ぶ。
+   *
+   * 注意: hook の `loading` 状態はトグルしない (saveCheckConflict と同理由、#916 review Should-fix)。
    */
   const saveCommit = useCallback(async (): Promise<{ failed?: boolean }> => {
     setError(null);
@@ -555,7 +559,6 @@ export function useEditSession(opts: UseEditSessionOptions): UseEditSessionResul
       setError(new Error("EditSession がアクティブでありません"));
       return { failed: true };
     }
-    setLoading(true);
     try {
       await mcpBridge.request("editSession.save", {
         editSessionId: es.id,
@@ -567,8 +570,6 @@ export function useEditSession(opts: UseEditSessionOptions): UseEditSessionResul
     } catch (e) {
       setError(e instanceof Error ? e : new Error(String(e)));
       return { failed: true };
-    } finally {
-      setLoading(false);
     }
   }, []);
 

--- a/frontend/src/hooks/useEditSession.ts
+++ b/frontend/src/hooks/useEditSession.ts
@@ -379,6 +379,10 @@ export function useEditSession(opts: UseEditSessionOptions): UseEditSessionResul
    * P2 fix (#908): targetEditSessionId を指定すると、hook の current editSession とは
    * 別の session に対して transferEdit を実行できる (EditSessionDropdown で選択した session)。
    * 未指定時は hook の current editSession に対して実行する (従来動作)。
+   *
+   * Should-fix (#909): cross-session take-over (target が hook の current session と異なる) 時は、
+   * hook の payload / sequence / lastSeqRef を target session のものに切り替える。
+   * 切替えないと editor が古い session の payload を表示し続ける。
    */
   const takeOver = useCallback(async (targetEditSessionId?: string) => {
     setError(null);
@@ -397,6 +401,19 @@ export function useEditSession(opts: UseEditSessionOptions): UseEditSessionResul
         toSessionId: "", // server 側が clientId を使うため空で良い (handler 実装上、fromSessionId は clientId から自動判定)
       });
       setMyRole("Edit");
+
+      // Should-fix (#909): cross-session take-over 時は target session の payload + sequence を fetch して
+      // hook の state を target session のものに切り替える。同 session 内の take-over は broadcast 経由で
+      // payload が同期済みなので fetch 不要。
+      const isCrossSession = !es || es.id !== editSessionId;
+      if (isCrossSession) {
+        const fetchResult = await mcpBridge.request("editSession.fetchPayload", {
+          editSessionId,
+        }) as { payload: unknown; sequence: number };
+        setPayload(fetchResult.payload);
+        lastSeqRef.current = fetchResult.sequence ?? 0;
+      }
+
       await refreshEditSessionState(editSessionId);
     } catch (e) {
       setError(e instanceof Error ? e : new Error(String(e)));

--- a/frontend/src/hooks/useEditSession.ts
+++ b/frontend/src/hooks/useEditSession.ts
@@ -103,6 +103,18 @@ export interface UseEditSessionResult {
    * 呼び出し元は conflicted === true なら postSave / cleanup をスキップすること。
    */
   save(): Promise<{ conflicted: boolean; failed?: boolean }>;
+  /**
+   * P2 fix (#912): 2 段階保存の前段。conflict check のみを実行し、saveHistory 記録 / broadcast はしない。
+   * frontend が本体ファイル書き込みを担う resource (FlowEditor 等) が、persistProject 失敗時に
+   * saveHistory が先行記録される問題を解消するために使う。
+   */
+  saveCheckConflict(): Promise<{ conflicted: boolean; failed?: boolean }>;
+  /**
+   * P2 fix (#912): 2 段階保存の後段。conflict check skip、saveHistory 記録 + broadcast。
+   * checkOnly → 本体ファイル書き込み (frontend) → commit の順で使う。
+   * commit 失敗は { failed: true } で signal される。
+   */
+  saveCommit(): Promise<{ failed?: boolean }>;
   discard(): Promise<void>;
   detach(): Promise<void>;
   /**
@@ -502,6 +514,64 @@ export function useEditSession(opts: UseEditSessionOptions): UseEditSessionResul
     }
   }, []);
 
+  /**
+   * P2 fix (#912): 2 段階保存の前段 — conflict check のみ。
+   * 衝突検出時は saveConflict state にセットして { conflicted: true } を返す。
+   */
+  const saveCheckConflict = useCallback(async (): Promise<{ conflicted: boolean; failed?: boolean }> => {
+    setError(null);
+    const es = editSessionRef.current;
+    if (!es) {
+      setError(new Error("EditSession がアクティブでありません"));
+      return { conflicted: false };
+    }
+    setLoading(true);
+    try {
+      const res = await mcpBridge.request("editSession.save", {
+        editSessionId: es.id,
+        stage: "checkOnly",
+      }) as { ok?: boolean; conflict?: { other: SaveConflictInfo } } | undefined;
+      if (res && res.ok === false && res.conflict) {
+        setSaveConflict(res.conflict.other);
+        return { conflicted: true };
+      }
+      return { conflicted: false };
+    } catch (e) {
+      setError(e instanceof Error ? e : new Error(String(e)));
+      return { conflicted: false, failed: true };
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  /**
+   * P2 fix (#912): 2 段階保存の後段 — saveHistory 記録 + broadcast。conflict check skip。
+   * checkOnly 後の本体書き込み成功後に呼ぶ。
+   */
+  const saveCommit = useCallback(async (): Promise<{ failed?: boolean }> => {
+    setError(null);
+    const es = editSessionRef.current;
+    if (!es) {
+      setError(new Error("EditSession がアクティブでありません"));
+      return { failed: true };
+    }
+    setLoading(true);
+    try {
+      await mcpBridge.request("editSession.save", {
+        editSessionId: es.id,
+        stage: "commit",
+      });
+      // saveConflict は overwrite path 経由の場合に残っている可能性があるため明示的にクリア。
+      setSaveConflict(null);
+      return {};
+    } catch (e) {
+      setError(e instanceof Error ? e : new Error(String(e)));
+      return { failed: true };
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
   // ── discard ───────────────────────────────────────────────────────────────────
 
   const discard = useCallback(async () => {
@@ -606,6 +676,8 @@ export function useEditSession(opts: UseEditSessionOptions): UseEditSessionResul
     takeOver,
     releaseEdit,
     save,
+    saveCheckConflict,
+    saveCommit,
     discard,
     detach,
     mode,


### PR DESCRIPTION
## 関連

Closes #911
Closes #909
Closes #912

統合 PR: 3 ISSUE は #908 シリーズ post-merge follow-up で、いずれも `useEditSession` / SaveConflictDialog / overwrite path 周辺を触る同根のため 1 PR に統合 (個別 PR は review コスト純増)。各 ISSUE 本文冒頭に `## 🔗 統合 PR 情報` セクションを追加済み。

仕様: `docs/spec/edit-session-protocol.md` §9.3 (last-save-wins 衝突) / §15.2 (UseEditSessionResult)

## 概要

#908 シリーズ post-merge で Codex / Opus 各 round が検出した 3 件の recoverable correctness issue を解消する。いずれもデータ損失ではないが UX 不整合 (dirty flag 残存 / silent failure / payload 未同期 / saveHistory 順序不整合) を引き起こしていた。

## 主な変更

### #911 — Conventions / Extensions に SaveConflictDialog 統合

- `ConventionsCatalogView.tsx` / `ExtensionsPanel.tsx` の両 editor は SaveConflictDialog 自体が未統合だったため、conflict 発生時に silent failure (UI 無反応) になっていた
- FlowEditor 同パターンで SaveConflictDialog を配置、overwrite path で本体ファイル書き込み + cleanup を実行
- ExtensionsPanel は `handleSave(kind, content)` 引数を保持するため `lastSaveArgsRef` を追加

### #912 P1 — overwrite 後の postSave 不在を全 editor で解消

- `actions.save()` が `{ conflicted: true }` を返した場合、SaveConflictDialog 経由の overwrite で `onSaveConflictOverwrite()` のみ呼ばれ、各 editor の `postSave()` が呼ばれず dirty flag / draft / tab dirty state が残存
- 全 editor (`Table` / `Sequence` / `View` / `ViewDefinition` / `ScreenItems` / `ProcessFlow` / `Designer`) の `<SaveConflictDialog onOverwrite={...}>` を inline wrapper に変更し、`onSaveConflictOverwrite()` 後に `postSave()` を呼ぶ
- Designer は `postSave` 関数が存在しないため `commitAfterSave` helper を抽出し、通常 save / overwrite save の両 path で共通化

### #909 — takeOver(targetEditSessionId) のクロスセッション payload 同期

- `useEditSession.takeOver(targetId)` で別 session を引き継ぐ場合 (EditSessionDropdown 経由)、hook の `editSession` state / `payload` / `lastSeqRef` が古いまま remained されていた
- target が hook の current session と異なる cross-session 検知時に `editSession.fetchPayload` を呼んで state を target session のものに切り替える

### #912 P2 — flow saveHistory 順序を 2 段階保存で解消

- backend `editSession.save` は flow type を write skip (frontend `persistProject` 担当) するが、saveHistory 記録は server で実行されるため、`persistProject` 失敗時に server 側に save 成功 record が残り、他 active session との整合性が崩れていた
- `editSession.save` に `stage` パラメータを追加: `"checkOnly"` (conflict check のみ) / `"commit"` (saveHistory 記録 + broadcast) / 未指定 (atomic、既存非 flow 用)
- `useEditSession` に `saveCheckConflict()` / `saveCommit()` を追加 (FlowEditor 専用 2 段階 API)
- FlowEditor `handleSave` を `saveCheckConflict → persistProject → saveCommit` の順に変更、overwrite path も `persistProject → saveCommit` に変更
- 既存非 flow editor の保存パス・既存 force=true overwrite は不変 (既存テスト 380 件 pass)

## 仕様逐条突合 (自己申告)

- §9.3 (a) save 試行で衝突検出時 `{ ok: false, conflict: { other } }` を返す (既存) → `backend/src/wsBridge.ts:1326-1340` ✓
- §9.3 (a-2) `stage: "commit"` 指定時は conflict check skip (P2 拡張) → `backend/src/wsBridge.ts:1316-1318` ✓
- §9.3 (b) `force: true` で衝突 skip し上書き (既存) → `backend/src/wsBridge.ts:1316` (`!force && stage !== "commit"`) ✓
- §9.3 (c) editor は SaveConflictDialog で `onOverwrite` / `onCancel` を提示する → 全 editor (`Table:250-262` / `Sequence:284-296` / `View:288-300` / `ViewDefinition:634-646` / `ScreenItems:1517-1529` / `ProcessFlow:764-776` / `Designer:650-663` / `Flow:1077-1099` / `Conventions:384-401` / `Extensions:213-241`) ✓
- §9.3 (d) overwrite 後は本体ファイル書き込み + postSave (P1 P2 同時解消) → 全 editor の inline wrapper ✓
- §15.2 `UseEditSessionResult.takeOver(targetEditSessionId?)` cross-session payload 同期 → `useEditSession.ts:402-417` ✓
- §15.2 `UseEditSessionResult.saveCheckConflict()` (新規 P2 fix) → `useEditSession.ts:519-544` ✓
- §15.2 `UseEditSessionResult.saveCommit()` (新規 P2 fix) → `useEditSession.ts:550-574` ✓

## レビューで特に見てほしい箇所

1. **2 段階保存の race condition**: `saveCheckConflict` → `persistProject` → `saveCommit` の間で別 session が save した場合、`saveCommit` は conflict check skip のため pre-checked 結果に基づいて last-save-wins で commit する。ここは spec §9.3 last-save-wins 通りの挙動と認識しているが、レビューで再確認したい
2. **stage パラメータの後方互換**: 既存非 flow editor は引き続き `actions.save()` (stage 未指定) を使う。backend 既存挙動は完全に保たれる (vitest 380/380 + 28/28 pass で確認)
3. **Designer commitAfterSave helper 抽出**: 通常 save と overwrite で同一 cleanup を共通化したが、Puck / GrapesJS どちらの editorKind でも共通化されていることを再確認したい
4. **#911 ExtensionsPanel `lastSaveArgsRef`**: タブ切替で active が変わる前に conflict ダイアログが出るパターンは想定外なので、ref で 1 件だけ保持で十分と判断した。レビューで spec 解釈の妥当性を確認したい

## テスト

- **Vitest**: 28 件 (新規 6 件) — `useEditSession.test.ts`
  - 新規 #912: saveCheckConflict ok / conflict、saveCommit success / reject (4 件)
  - 新規 #909: cross-session takeOver で fetchPayload 呼び出し / same-session で fetchPayload skip (2 件)
- **Backend Vitest**: 380 件全 pass (既存、stage param 拡張で regression なし)
- **Playwright**: 既存 / 新規 e2e は本 PR スコープ外 (UI 表示パターンは既存 SaveConflictDialog と同等で UI smoke は Designer 統合済み画面で確認)
- **frontend 全体 vitest**: 1764 件 pass / 11 件 fail (= 全件 #895 既知 pre-existing、`examples/diary/harmony/*.json` AJV 検証失敗、本 PR と無関係)

## UI 影響 / AI smoke test

- [ ] UI 影響あり — SaveConflictDialog の出現条件は変更なし、overwrite クリック後の挙動が postSave 経由で dirty マーク消失するように改善 (Conventions / Extensions では新規に dialog 表示自体が機能するように)
- [x] AI smoke test 未実施 — concurrent save の conflict ダイアログを再現するには 2 ブラウザタブで同 resource を同時編集する必要があり、自動 smoke は困難。代わりに vitest で onOverwrite path の hook 配線を確認

### 確認した項目

- [x] vitest 28 件全 pass (saveCheckConflict / saveCommit / cross-session takeOver の hook 配線確認)
- [x] backend vitest 380 件全 pass (stage param 拡張で既存 conflict check / saveHistory / broadcast 経路に regression なし)
- [x] frontend tsc + vite build 成功 (型エラー / consumer 配線エラーなし)
- [x] backend tsc build 成功

## spec 側の不足点 / 提案

`docs/spec/edit-session-protocol.md` §9.3 で 2 段階保存 (stage パラメータ) の記述追加が望ましい。frontend 担当 write の resource (現状 flow のみ) における saveHistory 順序保証が現 spec では不明瞭。本 PR ではコードコメントで補足したが、spec 反映は別 ISSUE で起票するのが適切と判断 (本 PR scope 外、別ファイル変更を最小化するため) — レビューで spec 反映方針について判断を求めたい。

## レビュー担当への申し送り

- 4 commit に分割: #911 → #912 P1 → #909 → #912 P2 の順 (各 ISSUE が独立 commit、PR description で全 Closes 列挙)
- 統合 PR 規約に従い改行区切り `Closes #N` (前述 GitHub 仕様通り、`Closes #A, #B, #C` だと先頭しか自動 close されない)
- 独立レビューは本 PR 単位で 1 回 (個別 ISSUE では実行しない)
