### PR TITLE
feat(backend): MCP tool 経由で edit-session 操作可能にする (#906)

### DIFF
--- a/backend/src/httpTransport.test.ts
+++ b/backend/src/httpTransport.test.ts
@@ -211,8 +211,171 @@ describe("backend HTTP transport (#302)", () => {
     expect(res.body).toContain("harmony-mcp");
   });
 
-  // NOTE: draft__* / lock__* MCP tool E2E は #897 シリーズで legacy MCP tool が削除されたため除去。
-  // 新 protocol 用 editSession__* MCP tool 追加は #906 で別途対応。
+  // NOTE: draft__* / lock__* MCP tool E2E は #897 シリーズで legacy MCP tool が削除された。
+  // 後継として editSession__* MCP tool E2E を以下に追加 (#906)。
+
+  // ── editSession__* MCP tool E2E (#906) ──────────────────────────────────────
+  // MCP HTTP transport は stateless (sessionIdGenerator: undefined) のため request 毎に
+  // 新規 sessionId が発行され、editSession の participant 継続性が成立しない。
+  // そこで:
+  //   - HTTP MCP 経由テスト: tool dispatch (tools/list 登録 + params validation + 単発呼び出し)
+  //   - WS roundtrip テスト: lifecycle (create → update → list → fetch_payload → save → discard、stable clientId)
+  // 両方を組み合わせて、wsBridge.editSession* 公開 API (HTTP/WS 共有) を全経路で検証する。
+  describe("editSession__* MCP tools — HTTP dispatch (#906)", () => {
+    it("tools/list に editSession__* 10 件が登録されている", async () => {
+      const res = await mcpCall("tools/list", undefined, { id: 1, params: {} });
+      const body = res.body;
+      // SSE / JSON どちらでも parse できるように
+      let json: unknown;
+      if (body.includes("data:")) {
+        const dataLine = body.split(/\r?\n/).find((l) => l.startsWith("data:"));
+        json = JSON.parse(dataLine!.slice(5).trim());
+      } else {
+        json = JSON.parse(body);
+      }
+      const r = json as { result: { tools: Array<{ name: string }> } };
+      const editSessionTools = r.result.tools.filter((t) => t.name.startsWith("editSession__"));
+      expect(editSessionTools).toHaveLength(10);
+      const names = editSessionTools.map((t) => t.name).sort();
+      expect(names).toEqual([
+        "editSession__attach_as_view",
+        "editSession__create",
+        "editSession__detach",
+        "editSession__discard",
+        "editSession__fetch_payload",
+        "editSession__list",
+        "editSession__save",
+        "editSession__set_role",
+        "editSession__transfer_edit",
+        "editSession__update",
+      ]);
+    });
+  });
+
+  describe("editSession__* lifecycle — WS roundtrip (#906)", () => {
+    /**
+     * 同一 WS 接続で複数 request を同期的に投げて response を集める helper。
+     * stable clientId (= participant.sessionId) 前提のテストに使う。
+     */
+    async function wsLifecycle(
+      clientId: string,
+      requests: Array<{ id: string; method: string; params?: Record<string, unknown> }>,
+    ): Promise<Array<{ id: string; result?: unknown; error?: string }>> {
+      return new Promise((resolve, reject) => {
+        const ws = new WebSocket(WS_URL);
+        const responses: Array<{ id: string; result?: unknown; error?: string }> = [];
+        const timer = setTimeout(() => {
+          ws.close();
+          reject(new Error("WS lifecycle timeout"));
+        }, 10_000);
+
+        ws.once("open", () => {
+          ws.send(JSON.stringify({ type: "register", clientId }));
+          for (const req of requests) {
+            ws.send(JSON.stringify({ type: "request", ...req }));
+          }
+        });
+
+        ws.on("message", (data: Buffer) => {
+          const msg = JSON.parse(data.toString()) as Record<string, unknown>;
+          if (msg.type === "response" && typeof msg.id === "string") {
+            responses.push({ id: msg.id, result: msg.result, error: msg.error as string | undefined });
+            if (responses.length === requests.length) {
+              clearTimeout(timer);
+              ws.close();
+              resolve(responses);
+            }
+          }
+        });
+
+        ws.once("error", (e) => {
+          clearTimeout(timer);
+          reject(e);
+        });
+      });
+    }
+
+    it("editSession 1-6 step フロー: create → update → list → fetch_payload → save → discard", async () => {
+      const clientId = `lifecycle-test-${Date.now()}`;
+      const resourceType = "table";
+      const resourceId = `tbl-lifecycle-${Date.now()}`;
+
+      // step 1: create
+      const r1 = await wsLifecycle(clientId, [
+        { id: "create", method: "editSession.create", params: { resourceType, resourceId, displayLabel: "@vitest" } },
+      ]);
+      expect(r1[0].error).toBeUndefined();
+      const created = r1[0].result as { editSession: { id: string; sequence: number } };
+      expect(created.editSession.id).toMatch(/^es-/);
+      const editSessionId = created.editSession.id;
+
+      // step 2-6: update → list → fetch_payload → save → discard を同一 connection で連続実行
+      const r2 = await wsLifecycle(clientId, [
+        { id: "update", method: "editSession.update", params: { editSessionId, payload: { columns: [{ name: "id" }], dataDir: "harmony" } } },
+        { id: "list", method: "editSession.list", params: { resourceType, resourceId } },
+        { id: "fetch", method: "editSession.fetchPayload", params: { editSessionId } },
+        { id: "save", method: "editSession.save", params: { editSessionId } },
+        { id: "discard", method: "editSession.discard", params: { editSessionId } },
+      ]);
+
+      const byId = (id: string) => r2.find((r) => r.id === id);
+
+      // step 2: update
+      expect(byId("update")?.error).toBeUndefined();
+      expect((byId("update")?.result as { sequence: number }).sequence).toBe(1);
+
+      // step 3: list
+      const listed = byId("list")?.result as { sessions: Array<{ id: string; state: string }> };
+      expect(listed.sessions).toHaveLength(1);
+      expect(listed.sessions[0].id).toBe(editSessionId);
+
+      // step 4: fetch_payload
+      const fetched = byId("fetch")?.result as { payload: { columns: Array<{ name: string }> }; sequence: number };
+      expect(fetched.payload.columns[0].name).toBe("id");
+      expect(fetched.sequence).toBe(1);
+
+      // step 5: save
+      const saved = byId("save")?.result as { ok: boolean; saveEvent?: { sequence: number } };
+      expect(saved.ok).toBe(true);
+      expect(saved.saveEvent?.sequence).toBe(1);
+
+      // step 6: discard
+      expect(byId("discard")?.error).toBeUndefined();
+      expect((byId("discard")?.result as { discarded: boolean }).discarded).toBe(true);
+    });
+
+    it("editSession.save の 2 段階保存 (stage=checkOnly → stage=commit、#912 連携)", async () => {
+      const clientId = `stage-test-${Date.now()}`;
+      const r1 = await wsLifecycle(clientId, [
+        { id: "create", method: "editSession.create", params: { resourceType: "process-flow", resourceId: `pf-stage-${Date.now()}` } },
+      ]);
+      const editSessionId = (r1[0].result as { editSession: { id: string } }).editSession.id;
+
+      const r2 = await wsLifecycle(clientId, [
+        { id: "update", method: "editSession.update", params: { editSessionId, payload: { name: "stage-test" } } },
+        { id: "checkOnly", method: "editSession.save", params: { editSessionId, stage: "checkOnly" } },
+        { id: "commit", method: "editSession.save", params: { editSessionId, stage: "commit" } },
+      ]);
+
+      // checkOnly は saveEvent なし
+      const checkOnly = r2.find((r) => r.id === "checkOnly")?.result as { ok: boolean; saveEvent?: unknown };
+      expect(checkOnly.ok).toBe(true);
+      expect(checkOnly.saveEvent).toBeUndefined();
+
+      // commit は saveEvent あり (sequence=1)
+      const commit = r2.find((r) => r.id === "commit")?.result as { ok: boolean; saveEvent?: { sequence: number } };
+      expect(commit.ok).toBe(true);
+      expect(commit.saveEvent?.sequence).toBe(1);
+    });
+
+    it("editSession.fetchPayload: 存在しない editSessionId は error を返す", async () => {
+      const r = await wsLifecycle(`fp-not-found-${Date.now()}`, [
+        { id: "fetch", method: "editSession.fetchPayload", params: { editSessionId: "es-non-existent-zzz" } },
+      ]);
+      expect(r[0].error).toBeDefined();
+      expect(r[0].error).toContain("見つかりません");
+    });
+  });
 
   it("同一 port で WebSocket も受け付ける (ws:// upgrade)", async () => {
     const ws = new WebSocket(WS_URL);

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1263,6 +1263,127 @@ function createMcpServer(sessionId: string): Server {
       // draft__ / lock__ MCP tools 削除済 (Phase 6 #903)
       // editSession.* API の直接呼び出しが正規経路。
 
+      // ── EditSession MCP tools (#906) ────────────────────────────────────────
+      // wsBridge の editSession* 公開 API を adapter として呼ぶ。WS handler と同一実装を共有。
+
+      case "editSession__create": {
+        const a = argRecord;
+        if (typeof a.resourceType !== "string") {
+          throw new McpError(ErrorCode.InvalidParams, "resourceType は必須です");
+        }
+        if (typeof a.resourceId !== "string") {
+          throw new McpError(ErrorCode.InvalidParams, "resourceId は必須です");
+        }
+        const result = wsBridge.editSessionCreate(
+          sessionId,
+          a.resourceType as Parameters<typeof wsBridge.editSessionCreate>[1],
+          a.resourceId,
+          typeof a.displayLabel === "string" ? a.displayLabel : undefined,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "editSession__attach_as_view": {
+        const a = argRecord;
+        if (typeof a.editSessionId !== "string") {
+          throw new McpError(ErrorCode.InvalidParams, "editSessionId は必須です");
+        }
+        const result = wsBridge.editSessionAttachAsView(
+          sessionId,
+          a.editSessionId,
+          typeof a.displayLabel === "string" ? a.displayLabel : undefined,
+          typeof a.parentHumanSessionId === "string" ? a.parentHumanSessionId : undefined,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "editSession__detach": {
+        const a = argRecord;
+        if (typeof a.editSessionId !== "string") {
+          throw new McpError(ErrorCode.InvalidParams, "editSessionId は必須です");
+        }
+        const result = wsBridge.editSessionDetach(sessionId, a.editSessionId);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "editSession__set_role": {
+        const a = argRecord;
+        if (typeof a.editSessionId !== "string") {
+          throw new McpError(ErrorCode.InvalidParams, "editSessionId は必須です");
+        }
+        if (a.role !== "Edit" && a.role !== "View") {
+          throw new McpError(ErrorCode.InvalidParams, "role は \"Edit\" または \"View\" である必要があります");
+        }
+        const result = wsBridge.editSessionSetRole(sessionId, a.editSessionId, a.role);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "editSession__transfer_edit": {
+        const a = argRecord;
+        if (typeof a.editSessionId !== "string") {
+          throw new McpError(ErrorCode.InvalidParams, "editSessionId は必須です");
+        }
+        const result = wsBridge.editSessionTransferEdit(sessionId, a.editSessionId);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "editSession__update": {
+        const a = argRecord;
+        if (typeof a.editSessionId !== "string") {
+          throw new McpError(ErrorCode.InvalidParams, "editSessionId は必須です");
+        }
+        if (!("payload" in a)) {
+          throw new McpError(ErrorCode.InvalidParams, "payload は必須です");
+        }
+        const result = wsBridge.editSessionUpdate(sessionId, a.editSessionId, a.payload);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "editSession__save": {
+        const a = argRecord;
+        if (typeof a.editSessionId !== "string") {
+          throw new McpError(ErrorCode.InvalidParams, "editSessionId は必須です");
+        }
+        const stage = a.stage;
+        if (stage !== undefined && stage !== "checkOnly" && stage !== "commit") {
+          throw new McpError(ErrorCode.InvalidParams, "stage は \"checkOnly\" または \"commit\" である必要があります");
+        }
+        const result = await wsBridge.editSessionSave(sessionId, a.editSessionId, {
+          force: typeof a.force === "boolean" ? a.force : undefined,
+          stage,
+        });
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "editSession__discard": {
+        const a = argRecord;
+        if (typeof a.editSessionId !== "string") {
+          throw new McpError(ErrorCode.InvalidParams, "editSessionId は必須です");
+        }
+        const result = await wsBridge.editSessionDiscard(sessionId, a.editSessionId);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "editSession__list": {
+        const a = argRecord;
+        const result = wsBridge.editSessionList(sessionId, {
+          resourceType: typeof a.resourceType === "string"
+            ? (a.resourceType as Parameters<typeof wsBridge.editSessionList>[1] extends { resourceType?: infer R } ? R : never)
+            : undefined,
+          resourceId: typeof a.resourceId === "string" ? a.resourceId : undefined,
+        });
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "editSession__fetch_payload": {
+        const a = argRecord;
+        if (typeof a.editSessionId !== "string") {
+          throw new McpError(ErrorCode.InvalidParams, "editSessionId は必須です");
+        }
+        const result = wsBridge.editSessionFetchPayload(sessionId, a.editSessionId);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
       default:
         throw new McpError(ErrorCode.MethodNotFound, `未知のツール: ${name}`);
     }

--- a/backend/src/tools.ts
+++ b/backend/src/tools.ts
@@ -1387,4 +1387,163 @@ export const tools = [
   // 旧 draft__read / draft__update / draft__commit / draft__discard / draft__has / draft__list /
   // lock__acquire / lock__release / lock__forceRelease / lock__get / lock__list は Phase 6 (#903) で削除。
   // editSession.* API が正規経路。
+
+  // ── EditSession MCP tools (#906) ──────────────────────────────────────────────
+  // AI エージェント (MCP 経由) が edit-session を直接操作するための tool 群。
+  // 旧 draft__/lock__ の MCP tool 削除に伴う後継。実装は wsBridge の editSession* 公開 API
+  // を adapter として呼ぶ (WS handler と共有)。spec docs/spec/edit-session-protocol.md 準拠。
+  {
+    name: "editSession__create",
+    description:
+      "新規 EditSession を作成して initial Edit participant として登録します。" +
+      "指定 resource (画面 / テーブル / 処理フロー等) の編集セッションを開始する際に使います。",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        resourceType: {
+          type: "string",
+          enum: [
+            "screen", "puck-data", "table", "process-flow", "view", "view-definition",
+            "screen-item", "sequence", "extension", "convention", "flow",
+          ],
+          description: "編集対象 resource の種別",
+        },
+        resourceId: { type: "string", description: "編集対象 resource の ID (singleton resource は \"singleton\" 等)" },
+        displayLabel: { type: "string", description: "participant の表示名 (例: \"@alice\" / \"AI@bot\")。省略時は sessionId" },
+      },
+      required: ["resourceType", "resourceId"],
+    },
+  },
+  {
+    name: "editSession__attach_as_view",
+    description:
+      "既存 EditSession に View role で attach します。response に現在の payload + sequence が含まれます。" +
+      "別エージェントが編集中の resource を観察 / 引き継ぎ準備する際に使います。",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        editSessionId: { type: "string", description: "対象 EditSession の ID" },
+        displayLabel: { type: "string", description: "participant の表示名。省略時は sessionId" },
+        parentHumanSessionId: { type: "string", description: "AI participant の場合、指示元 human の sessionId" },
+      },
+      required: ["editSessionId"],
+    },
+  },
+  {
+    name: "editSession__detach",
+    description:
+      "EditSession から完全離脱します。Edit role の場合は事前に View に降格 (set_role) する必要があります。",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        editSessionId: { type: "string", description: "対象 EditSession の ID" },
+      },
+      required: ["editSessionId"],
+    },
+  },
+  {
+    name: "editSession__set_role",
+    description:
+      "自身の participant role を変更します。通常は take-over (transfer_edit) を使い、本 tool は限定的な role 変更用 (Edit → View 降格等)。",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        editSessionId: { type: "string", description: "対象 EditSession の ID" },
+        role: { type: "string", enum: ["Edit", "View"], description: "新しい role" },
+      },
+      required: ["editSessionId", "role"],
+    },
+  },
+  {
+    name: "editSession__transfer_edit",
+    description:
+      "Edit role を atomic に take-over します。caller が new Edit holder になり、現 Edit holder は View に降格します。" +
+      "事前に attach_as_view で View 参加していること (spec §7.2)。",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        editSessionId: { type: "string", description: "対象 EditSession の ID" },
+      },
+      required: ["editSessionId"],
+    },
+  },
+  {
+    name: "editSession__update",
+    description:
+      "EditSession の payload を更新し sequence を increment します。FS write はせず in-memory snapshot のみ更新 (Forward-Compat 原則)。" +
+      "AI が draft 編集を反映する際に使います。",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        editSessionId: { type: "string", description: "対象 EditSession の ID" },
+        payload: { description: "新しい payload (opaque、resourceType ごとに schema が異なる)" },
+      },
+      required: ["editSessionId", "payload"],
+    },
+  },
+  {
+    name: "editSession__save",
+    description:
+      "EditSession の現時点 payload を本体ファイルに確定保存します (saveHistory 記録 + broadcast 含む)。" +
+      "spec §9.3 last-save-wins: 衝突時は { ok: false, conflict } を返します。" +
+      "stage パラメータで 2 段階保存をサポート (checkOnly / commit)。",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        editSessionId: { type: "string", description: "対象 EditSession の ID" },
+        force: { type: "boolean", description: "true で衝突 check skip (overwrite 確認後)" },
+        stage: {
+          type: "string",
+          enum: ["checkOnly", "commit"],
+          description: "checkOnly = 衝突 check のみ / commit = saveHistory 記録 + broadcast (衝突 check skip)",
+        },
+      },
+      required: ["editSessionId"],
+    },
+  },
+  {
+    name: "editSession__discard",
+    description:
+      "EditSession を Active → Discarded に遷移させます。draft が破棄され retention 期間 (7日) 後に完全削除されます。",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        editSessionId: { type: "string", description: "対象 EditSession の ID" },
+      },
+      required: ["editSessionId"],
+    },
+  },
+  {
+    name: "editSession__list",
+    description:
+      "EditSession 一覧を取得します。resourceType + resourceId 指定で絞り込み、未指定で全件返却。",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        resourceType: {
+          type: "string",
+          enum: [
+            "screen", "puck-data", "table", "process-flow", "view", "view-definition",
+            "screen-item", "sequence", "extension", "convention", "flow",
+          ],
+          description: "絞り込み: resource 種別",
+        },
+        resourceId: { type: "string", description: "絞り込み: resource ID (resourceType と同時指定)" },
+      },
+      required: [],
+    },
+  },
+  {
+    name: "editSession__fetch_payload",
+    description:
+      "EditSession の現在の payload + sequence を取得します (broadcast 待ちなし)。" +
+      "別 session が attach した直後の initial fetch や、cross-session take-over 後の同期に使います。",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        editSessionId: { type: "string", description: "対象 EditSession の ID" },
+      },
+      required: ["editSessionId"],
+    },
+  },
 ];

--- a/backend/src/wsBridge.ts
+++ b/backend/src/wsBridge.ts
@@ -255,11 +255,13 @@ class WsBridge extends EventEmitter {
   // WS 経由は WebSocket clientId、MCP 経由は MCP sessionId をそのまま渡す
   // (workspaceContextManager は両 namespace を統一管理する、#700 R-2)。
 
-  /** sessionId から active workspace path (wsId) を解決する。未選択時は throw。 */
+  /**
+   * sessionId から active workspace path (wsId) を解決する。未選択時は WorkspaceUnsetError を throw。
+   * #917 review M-1: plain Error だと index.ts の catch ブロックで McpError(InvalidParams) に
+   * 変換されず汎用 isError に落ちるため、他 workspace 依存 MCP tool と同じ requireActivePath を使う。
+   */
   private _resolveActiveWsId(sessionId: string): string {
-    const wsId = workspaceContextManager.getActivePath(sessionId);
-    if (!wsId) throw new Error("ワークスペースが選択されていません");
-    return wsId;
+    return workspaceContextManager.requireActivePath(sessionId);
   }
 
   /** spec §5 step 1: 新規 EditSession を作成し initial Edit participant として登録 + broadcast */
@@ -352,10 +354,18 @@ class WsBridge extends EventEmitter {
     const wsId = this._resolveActiveWsId(sessionId);
     const store = this.getOrCreateEditSessionStore(wsId);
     const targetSession = store.getById(editSessionId);
-    const fromSessionId = targetSession
-      ? (Array.from(targetSession.participants.values()).find((p) => p.role === "Edit")?.sessionId ?? sessionId)
-      : sessionId;
-    const result = store.transferEdit(fromSessionId, sessionId, editSessionId);
+    if (!targetSession) {
+      throw new EditSessionNotFoundError(editSessionId);
+    }
+    // #917 review S-2: editor 不在時に caller fallback すると "from は Edit role ではない" と
+    // 不明瞭なエラーが返るため、editor 不在を明示的に検出してより正確なエラーを throw する。
+    const editor = Array.from(targetSession.participants.values()).find((p) => p.role === "Edit");
+    if (!editor) {
+      throw new EditSessionStateError(
+        `EditSession ${editSessionId} に Edit role の participant が存在しないため take-over できません`,
+      );
+    }
+    const result = store.transferEdit(editor.sessionId, sessionId, editSessionId);
     this.broadcast({
       wsId,
       event: "editSession.roleChanged",
@@ -590,11 +600,20 @@ class WsBridge extends EventEmitter {
         try {
           const results = await store.cleanupExpired(now, 2 /* ttlDays */, 7 /* retentionDays */);
           for (const { editSession, action } of results) {
+            // #917 review S-1: spec §12.4 / §14.1 準拠の broadcast event 名に修正
+            //   - "discarded" (TTL 経過 Active → Discarded): editSession.discarded (reason: "ttl")
+            //   - "deleted" (retention 経過 Discarded → 完全削除): editSession.expired
             if (action === "discarded") {
               this.broadcast({
                 wsId,
+                event: "editSession.discarded",
+                data: { editSessionId: editSession.id, reason: "ttl" as const },
+              });
+            } else if (action === "deleted") {
+              this.broadcast({
+                wsId,
                 event: "editSession.expired",
-                data: { editSessionId: editSession.id, reason: "ttl" },
+                data: { editSessionId: editSession.id },
               });
             }
           }

--- a/backend/src/wsBridge.ts
+++ b/backend/src/wsBridge.ts
@@ -40,6 +40,8 @@ import {
   EditSessionPermissionError,
   EditSessionParticipantError,
   type DraftResourceType as EditSessionResourceType,
+  type ParticipantInfo as EditSessionParticipantInfo,
+  type SaveEvent as EditSessionSaveEvent,
 } from "./editSessionStore.js";
 import {
   readProject,
@@ -246,6 +248,304 @@ class WsBridge extends EventEmitter {
       this.editSessionStores.set(wsId, store);
     }
     return store;
+  }
+
+  // ── EditSession public API (#906, MCP tool + WS handler 共有) ─────────────────
+  // sessionId は workspace 解決 + actor (participant.sessionId) として使われる。
+  // WS 経由は WebSocket clientId、MCP 経由は MCP sessionId をそのまま渡す
+  // (workspaceContextManager は両 namespace を統一管理する、#700 R-2)。
+
+  /** sessionId から active workspace path (wsId) を解決する。未選択時は throw。 */
+  private _resolveActiveWsId(sessionId: string): string {
+    const wsId = workspaceContextManager.getActivePath(sessionId);
+    if (!wsId) throw new Error("ワークスペースが選択されていません");
+    return wsId;
+  }
+
+  /** spec §5 step 1: 新規 EditSession を作成し initial Edit participant として登録 + broadcast */
+  editSessionCreate(
+    sessionId: string,
+    resourceType: EditSessionResourceType,
+    resourceId: string,
+    displayLabel?: string,
+    parentHumanSessionId?: string,
+  ): { editSession: unknown } {
+    const wsId = this._resolveActiveWsId(sessionId);
+    const store = this.getOrCreateEditSessionStore(wsId);
+    const session = store.create(
+      sessionId,
+      resourceType,
+      resourceId,
+      displayLabel ?? sessionId,
+      parentHumanSessionId !== undefined ? { parentHumanSessionId } : undefined,
+    );
+    const serialized = _serializeEditSession(session);
+    this.broadcast({ wsId, event: "editSession.created", data: { editSession: serialized } });
+    return { editSession: serialized };
+  }
+
+  /** spec §5 step 2: View role で attach + initial payload fetch + broadcast */
+  editSessionAttachAsView(
+    sessionId: string,
+    editSessionId: string,
+    displayLabel?: string,
+    parentHumanSessionId?: string,
+  ): { participant: EditSessionParticipantInfo; payload: unknown; sequence: number } {
+    const wsId = this._resolveActiveWsId(sessionId);
+    const store = this.getOrCreateEditSessionStore(wsId);
+    const participant = store.attachAsView(
+      editSessionId,
+      sessionId,
+      displayLabel ?? sessionId,
+      parentHumanSessionId,
+    );
+    const fetchResult = store.fetchCurrentPayload(editSessionId);
+    this.broadcast({
+      wsId,
+      event: "editSession.attached",
+      data: { editSessionId, participant },
+    });
+    return {
+      participant,
+      payload: fetchResult?.payload ?? null,
+      sequence: fetchResult?.sequence ?? 0,
+    };
+  }
+
+  /** participant detach + broadcast (Edit role は事前に View 降格必要) */
+  editSessionDetach(sessionId: string, editSessionId: string): { detached: true } {
+    const wsId = this._resolveActiveWsId(sessionId);
+    const store = this.getOrCreateEditSessionStore(wsId);
+    store.detach(editSessionId, sessionId);
+    this.broadcast({
+      wsId,
+      event: "editSession.detached",
+      data: { editSessionId, sessionId },
+    });
+    return { detached: true };
+  }
+
+  /** participant role 変更 + broadcast (通常は transferEdit を使う) */
+  editSessionSetRole(
+    sessionId: string,
+    editSessionId: string,
+    newRole: "Edit" | "View",
+  ): { participant: EditSessionParticipantInfo } {
+    const wsId = this._resolveActiveWsId(sessionId);
+    const store = this.getOrCreateEditSessionStore(wsId);
+    const session = store.get(editSessionId);
+    const oldRole = session?.participants.get(sessionId)?.role ?? null;
+    const updatedParticipant = store.setRole(editSessionId, sessionId, newRole);
+    this.broadcast({
+      wsId,
+      event: "editSession.roleChanged",
+      data: { editSessionId, sessionId, oldRole, newRole },
+    });
+    return { participant: updatedParticipant };
+  }
+
+  /** spec §7: take-over (caller = new Edit holder)。fromSessionId は participants から自動検索 */
+  editSessionTransferEdit(
+    sessionId: string,
+    editSessionId: string,
+  ): { from: EditSessionParticipantInfo; to: EditSessionParticipantInfo } {
+    const wsId = this._resolveActiveWsId(sessionId);
+    const store = this.getOrCreateEditSessionStore(wsId);
+    const targetSession = store.getById(editSessionId);
+    const fromSessionId = targetSession
+      ? (Array.from(targetSession.participants.values()).find((p) => p.role === "Edit")?.sessionId ?? sessionId)
+      : sessionId;
+    const result = store.transferEdit(fromSessionId, sessionId, editSessionId);
+    this.broadcast({
+      wsId,
+      event: "editSession.roleChanged",
+      data: {
+        editSessionId,
+        sessionId,
+        oldRole: "View" as const,
+        newRole: "Edit" as const,
+        op: "transferred",
+        transferTo: sessionId,
+      },
+    });
+    return result;
+  }
+
+  /** spec §13.2 update: payload を更新 + broadcast (FS write なし、Forward-Compat 原則 ④) */
+  editSessionUpdate(
+    sessionId: string,
+    editSessionId: string,
+    payload: unknown,
+  ): { sequence: number } {
+    const wsId = this._resolveActiveWsId(sessionId);
+    const store = this.getOrCreateEditSessionStore(wsId);
+    const { sequence } = store.update(editSessionId, payload, sessionId);
+    this.broadcast({
+      wsId,
+      event: "editSession.update",
+      data: { editSessionId, sequence, payload, senderSessionId: sessionId },
+    });
+    return { sequence };
+  }
+
+  /**
+   * spec §5 step 5 / §8: 確定保存。stage パラメータで 2 段階保存をサポート (#912)。
+   *   - stage 未指定: conflict check + saveHistory + 本体書き込み + broadcast
+   *   - stage: "checkOnly": conflict check のみ
+   *   - stage: "commit": conflict check skip、saveHistory + 本体書き込み + broadcast
+   * 衝突時は { ok: false, conflict } を return value で signal (throw しない)。
+   */
+  async editSessionSave(
+    sessionId: string,
+    editSessionId: string,
+    opts?: { force?: boolean; stage?: "checkOnly" | "commit" },
+  ): Promise<
+    | { ok: true; saveEvent?: EditSessionSaveEvent }
+    | { ok: false; conflict: { other: { editSessionId: string; savedBy: string; savedAt: string; displayLabel: string } } }
+  > {
+    const wsId = this._resolveActiveWsId(sessionId);
+    const store = this.getOrCreateEditSessionStore(wsId);
+    const force = opts?.force === true;
+    const stage = opts?.stage;
+
+    // spec §9.3 last-save-wins 衝突検出
+    if (!force && stage !== "commit") {
+      const targetSession = store.getById(editSessionId);
+      const allSessions = store.listByResource(
+        targetSession?.resourceType ?? "process-flow",
+        targetSession?.resourceId ?? "",
+      );
+      const conflicting = allSessions.find(
+        (s) => s.id !== editSessionId && s.state === "Active" && s.saveHistory.length > 0,
+      );
+      if (conflicting) {
+        const lastSave = conflicting.saveHistory[conflicting.saveHistory.length - 1];
+        const otherParticipants = Array.from(conflicting.participants.values());
+        const editor = otherParticipants.find((p) => p.role === "Edit") ?? otherParticipants[0];
+        return {
+          ok: false,
+          conflict: {
+            other: {
+              editSessionId: conflicting.id,
+              savedBy: lastSave.savedBy,
+              savedAt: lastSave.savedAt,
+              displayLabel: editor?.displayLabel ?? lastSave.savedBy,
+            },
+          },
+        };
+      }
+    }
+
+    // stage: "checkOnly" は conflict check のみで終了
+    if (stage === "checkOnly") {
+      return { ok: true };
+    }
+
+    const saveEvent = await store.save(editSessionId, sessionId);
+
+    // 本体 resource file へ atomic write (P1-1, #907 regression 解消)
+    const session = store.getById(editSessionId);
+    if (session && session.payload !== null && session.payload !== undefined) {
+      const root = resolveRoot(sessionId);
+      const type = session.resourceType;
+      const resId = session.resourceId;
+      const payload = session.payload;
+      try {
+        switch (type) {
+          case "screen":
+            await writeScreen(resId, payload, root);
+            break;
+          case "puck-data":
+            await writePuckData(resId, payload, root);
+            break;
+          case "table":
+            await writeTable(resId, payload, root);
+            break;
+          case "process-flow":
+            await writeProcessFlow(resId, payload, root);
+            break;
+          case "view":
+            await writeView(resId, payload, root);
+            break;
+          case "view-definition":
+            await writeViewDefinition(resId, payload, root);
+            break;
+          case "screen-item": {
+            const siPayload = payload as { screenId?: string } | null;
+            const siScreenId = siPayload && typeof siPayload.screenId === "string" && siPayload.screenId
+              ? siPayload.screenId
+              : resId;
+            await writeScreenItems(siScreenId, payload, root);
+            break;
+          }
+          case "sequence":
+            await writeSequence(resId, payload, root);
+            break;
+          case "flow":
+          case "extension":
+          case "convention":
+            // flow は frontend persistProject() が書き込む / extension/convention は専用 MCP tool 経由のため skip
+            break;
+          default:
+            break;
+        }
+      } catch (writeErr) {
+        console.error(`[editSession.save] resource file 書き込み失敗 (type=${type}, id=${resId}):`, writeErr);
+        // 書き込み失敗でも saveHistory / broadcast は続行 (可用性優先)
+      }
+    }
+
+    this.broadcast({
+      wsId,
+      event: "editSession.saved",
+      data: {
+        editSessionId,
+        savedBy: saveEvent.savedBy,
+        savedAt: saveEvent.savedAt,
+        sequence: saveEvent.sequence,
+      },
+    });
+    return { ok: true, saveEvent };
+  }
+
+  /** spec §5 step 6a: Active → Discarded + broadcast */
+  async editSessionDiscard(sessionId: string, editSessionId: string): Promise<{ discarded: true }> {
+    const wsId = this._resolveActiveWsId(sessionId);
+    const store = this.getOrCreateEditSessionStore(wsId);
+    await store.discard(editSessionId, "manual");
+    this.broadcast({
+      wsId,
+      event: "editSession.discarded",
+      data: { editSessionId, reason: "manual" as const },
+    });
+    return { discarded: true };
+  }
+
+  /** EditSession 一覧を返す (filter なしで全件、resourceType+resourceId 指定で絞り込み) */
+  editSessionList(
+    sessionId: string,
+    filter?: { resourceType?: EditSessionResourceType; resourceId?: string },
+  ): { sessions: unknown[] } {
+    const wsId = this._resolveActiveWsId(sessionId);
+    const store = this.getOrCreateEditSessionStore(wsId);
+    const sessions = filter?.resourceType && filter?.resourceId
+      ? store.listByResource(filter.resourceType, filter.resourceId)
+      : store.listAll();
+    return { sessions: sessions.map(_serializeEditSession) };
+  }
+
+  /** spec §13.3: 現在の payload + sequence を取得 (broadcast 待ちなし) */
+  editSessionFetchPayload(
+    sessionId: string,
+    editSessionId: string,
+  ): { payload: unknown; sequence: number } {
+    const wsId = this._resolveActiveWsId(sessionId);
+    const store = this.getOrCreateEditSessionStore(wsId);
+    const result = store.fetchCurrentPayload(editSessionId);
+    if (!result) {
+      throw new EditSessionNotFoundError(editSessionId);
+    }
+    return result;
   }
 
   /** MCP コマンドを送る先: 最後に接続した有効なクライアント */
@@ -1143,8 +1443,7 @@ class WsBridge extends EventEmitter {
         // 旧 lock.* / draft.* handler は変更しない (Phase 4 で adapter 化、Phase 6 で削除)。
 
         case "editSession.create": {
-          const esWsId = wsId();
-          if (!esWsId) { respondError("ワークスペースが選択されていません"); break; }
+          // #906: 公開 API editSessionCreate を adapter として呼ぶ (MCP tool と共有)
           const {
             resourceType: esRt,
             resourceId: esRid,
@@ -1154,25 +1453,17 @@ class WsBridge extends EventEmitter {
             resourceId: string;
             displayLabel?: string;
           };
-          const esStore = this.getOrCreateEditSessionStore(esWsId);
-          const esSession = esStore.create(
-            clientId,
-            esRt,
-            esRid,
-            esLabel ?? clientId,
-          );
-          respond({ editSession: _serializeEditSession(esSession) });
-          this.broadcast({
-            wsId: esWsId,
-            event: "editSession.created",
-            data: { editSession: _serializeEditSession(esSession) },
-          });
+          try {
+            const result = this.editSessionCreate(clientId, esRt, esRid, esLabel);
+            respond(result);
+          } catch (e) {
+            respondError(e instanceof Error ? e.message : String(e));
+          }
           break;
         }
 
         case "editSession.attachAsView": {
-          const esWsId = wsId();
-          if (!esWsId) { respondError("ワークスペースが選択されていません"); break; }
+          // #906: 公開 API editSessionAttachAsView を adapter として呼ぶ
           const {
             editSessionId: esAvId,
             displayLabel: esAvLabel,
@@ -1182,305 +1473,123 @@ class WsBridge extends EventEmitter {
             displayLabel?: string;
             parentHumanSessionId?: string;
           };
-          const esStore = this.getOrCreateEditSessionStore(esWsId);
-          const participant = esStore.attachAsView(
-            esAvId,
-            clientId,
-            esAvLabel ?? clientId,
-            esAvParent,
-          );
-          const fetchResult = esStore.fetchCurrentPayload(esAvId);
-          respond({
-            participant,
-            payload: fetchResult?.payload ?? null,
-            sequence: fetchResult?.sequence ?? 0,
-          });
-          this.broadcast({
-            wsId: esWsId,
-            event: "editSession.attached",
-            data: { editSessionId: esAvId, participant },
-          });
+          try {
+            const result = this.editSessionAttachAsView(clientId, esAvId, esAvLabel, esAvParent);
+            respond(result);
+          } catch (e) {
+            respondError(e instanceof Error ? e.message : String(e));
+          }
           break;
         }
 
         case "editSession.detach": {
-          const esWsId = wsId();
-          if (!esWsId) { respondError("ワークスペースが選択されていません"); break; }
+          // #906: 公開 API editSessionDetach を adapter として呼ぶ
           const { editSessionId: esDtId } = (params ?? {}) as { editSessionId: string };
-          const esStore = this.getOrCreateEditSessionStore(esWsId);
-          esStore.detach(esDtId, clientId);
-          respond({ detached: true });
-          this.broadcast({
-            wsId: esWsId,
-            event: "editSession.detached",
-            data: { editSessionId: esDtId, sessionId: clientId },
-          });
+          try {
+            const result = this.editSessionDetach(clientId, esDtId);
+            respond(result);
+          } catch (e) {
+            respondError(e instanceof Error ? e.message : String(e));
+          }
           break;
         }
 
         case "editSession.setRole": {
-          const esWsId = wsId();
-          if (!esWsId) { respondError("ワークスペースが選択されていません"); break; }
+          // #906: 公開 API editSessionSetRole を adapter として呼ぶ
           const {
             editSessionId: esRoleId,
             role: esNewRole,
           } = (params ?? {}) as { editSessionId: string; role: "Edit" | "View" };
-          const esStore = this.getOrCreateEditSessionStore(esWsId);
-          const esRoleSession = esStore.get(esRoleId);
-          const oldRole = esRoleSession?.participants.get(clientId)?.role ?? null;
-          const updatedParticipant = esStore.setRole(esRoleId, clientId, esNewRole);
-          respond({ participant: updatedParticipant });
-          this.broadcast({
-            wsId: esWsId,
-            event: "editSession.roleChanged",
-            data: {
-              editSessionId: esRoleId,
-              sessionId: clientId,
-              oldRole,
-              newRole: esNewRole,
-            },
-          });
+          try {
+            const result = this.editSessionSetRole(clientId, esRoleId, esNewRole);
+            respond(result);
+          } catch (e) {
+            respondError(e instanceof Error ? e.message : String(e));
+          }
           break;
         }
 
         case "editSession.transferEdit": {
-          const esWsId = wsId();
-          if (!esWsId) { respondError("ワークスペースが選択されていません"); break; }
-          const {
-            editSessionId: esTrId,
-          } = (params ?? {}) as { editSessionId: string; toSessionId?: string };
-          const esStore = this.getOrCreateEditSessionStore(esWsId);
-
-          // P2-1: caller (clientId) は take-over を実行する viewer (= toSessionId)。
-          // fromSessionId (現 Edit holder) は EditSession の participants から自動検索する (#907 regression 解消)。
-          const esTrSession = esStore.getById(esTrId);
-          const esTrFromSessionId = esTrSession
-            ? (Array.from(esTrSession.participants.values()).find((p) => p.role === "Edit")?.sessionId ?? clientId)
-            : clientId;
-
-          const { from: esTrFrom, to: esTrNew } = esStore.transferEdit(
-            esTrFromSessionId,
-            clientId,  // caller = take-over 実行者 = new Edit holder
-            esTrId,
-          );
-          respond({ from: esTrFrom, to: esTrNew });
-          this.broadcast({
-            wsId: esWsId,
-            event: "editSession.roleChanged",
-            data: {
-              editSessionId: esTrId,
-              sessionId: clientId,  // clientId = take-over 実行者 = new Edit holder
-              oldRole: "View" as const,
-              newRole: "Edit" as const,
-              op: "transferred",
-              transferTo: clientId,
-            },
-          });
+          // #906: 公開 API editSessionTransferEdit を adapter として呼ぶ
+          // (caller = take-over 実行者 = new Edit holder; fromSessionId は participants から自動検索)
+          const { editSessionId: esTrId } = (params ?? {}) as { editSessionId: string; toSessionId?: string };
+          try {
+            const result = this.editSessionTransferEdit(clientId, esTrId);
+            respond(result);
+          } catch (e) {
+            respondError(e instanceof Error ? e.message : String(e));
+          }
           break;
         }
 
         case "editSession.update": {
           // opaque envelope: payload は server で解釈しない (Forward-Compat 原則 ①)
-          const esWsId = wsId();
-          if (!esWsId) { respondError("ワークスペースが選択されていません"); break; }
+          // #906: 公開 API editSessionUpdate を adapter として呼ぶ
           const {
             editSessionId: esUpId,
             payload: esUpPayload,
           } = (params ?? {}) as { editSessionId: string; payload: unknown };
-          const esStore = this.getOrCreateEditSessionStore(esWsId);
-          const { sequence: esSeq } = esStore.update(esUpId, esUpPayload, clientId);
-          respond({ sequence: esSeq });
-          // senderSessionId 付きで全員に broadcast (excludeClientId 不要 = 全員受信)
-          this.broadcast({
-            wsId: esWsId,
-            event: "editSession.update",
-            data: {
-              editSessionId: esUpId,
-              sequence: esSeq,
-              payload: esUpPayload, // opaque: そのまま透過
-              senderSessionId: clientId,
-            },
-          });
+          try {
+            const result = this.editSessionUpdate(clientId, esUpId, esUpPayload);
+            respond(result);
+          } catch (e) {
+            respondError(e instanceof Error ? e.message : String(e));
+          }
           break;
         }
 
         case "editSession.save": {
-          const esWsId = wsId();
-          if (!esWsId) { respondError("ワークスペースが選択されていません"); break; }
-          // P2 fix (#912): stage パラメータで 2 段階保存をサポート (FlowEditor 等、frontend が本体ファイル
-          // 書き込みを担う resource type 用)。
-          //   - stage 未指定 (default): 従来通り conflict check + saveHistory 記録 + 本体書き込み + broadcast
-          //   - stage: "checkOnly" : conflict check のみ。saveHistory / 本体書き込み / broadcast なし
-          //   - stage: "commit"    : conflict check skip。saveHistory 記録 + 本体書き込み + broadcast
-          // FlowEditor は checkOnly → frontend persistProject() → commit の順で呼ぶことで、
-          // persistProject 失敗時に saveHistory が record されない (整合性向上、recoverable)。
+          // #906: 公開 API editSessionSave を adapter として呼ぶ (#912 stage パラメータ含む)
           const { editSessionId: esSvId, force, stage } = (params ?? {}) as {
             editSessionId: string;
             force?: boolean;
             stage?: "checkOnly" | "commit";
           };
-          const esStore = this.getOrCreateEditSessionStore(esWsId);
-
-          // spec §9.3 last-save-wins 衝突検出:
-          //   - force フラグありの場合は skip (overwrite 確認後)
-          //   - stage: "commit" の場合は skip (checkOnly で事前チェック済み)
-          if (!force && stage !== "commit") {
-            const allSessions = esStore.listByResource(
-              esStore.getById(esSvId)?.resourceType ?? "process-flow",
-              esStore.getById(esSvId)?.resourceId ?? "",
-            );
-            // 自分以外の active EditSession が既に save 済みかチェック
-            const conflicting = allSessions.find(
-              (s) => s.id !== esSvId && s.state === "Active" && s.saveHistory.length > 0,
-            );
-            if (conflicting) {
-              const lastSave = conflicting.saveHistory[conflicting.saveHistory.length - 1];
-              const otherParticipants = Array.from(conflicting.participants.values());
-              const editor = otherParticipants.find((p) => p.role === "Edit") ?? otherParticipants[0];
-              respond({
-                ok: false,
-                conflict: {
-                  other: {
-                    editSessionId: conflicting.id,
-                    savedBy: lastSave.savedBy,
-                    savedAt: lastSave.savedAt,
-                    displayLabel: editor?.displayLabel ?? lastSave.savedBy,
-                  },
-                },
-              });
-              break;
-            }
+          try {
+            const result = await this.editSessionSave(clientId, esSvId, { force, stage });
+            respond(result);
+          } catch (e) {
+            respondError(e instanceof Error ? e.message : String(e));
           }
-
-          // stage: "checkOnly" は conflict check のみで終了 (saveHistory 記録 / 本体書き込み / broadcast なし)
-          if (stage === "checkOnly") {
-            respond({ ok: true });
-            break;
-          }
-
-          const saveEvent = await esStore.save(esSvId, clientId);
-
-          // P1-1: 本体 resource file へ atomic write (#907 regression 解消)
-          // editSession.save は saveHistory 記録に加え、in-memory payload を本体ファイルに書き込む。
-          // payload が null (まだ editSession.update が 1 度も呼ばれていない) の場合はスキップ。
-          const esSvSession = esStore.getById(esSvId);
-          if (esSvSession && esSvSession.payload !== null && esSvSession.payload !== undefined) {
-            const esSvRoot = resolveRoot(clientId);
-            const esSvType = esSvSession.resourceType;
-            const esSvResId = esSvSession.resourceId;
-            const esSvPayload = esSvSession.payload;
-            try {
-              switch (esSvType) {
-                case "screen":
-                  await writeScreen(esSvResId, esSvPayload, esSvRoot);
-                  break;
-                case "puck-data":
-                  await writePuckData(esSvResId, esSvPayload, esSvRoot);
-                  break;
-                case "table":
-                  await writeTable(esSvResId, esSvPayload, esSvRoot);
-                  break;
-                case "process-flow":
-                  await writeProcessFlow(esSvResId, esSvPayload, esSvRoot);
-                  break;
-                case "view":
-                  await writeView(esSvResId, esSvPayload, esSvRoot);
-                  break;
-                case "view-definition":
-                  await writeViewDefinition(esSvResId, esSvPayload, esSvRoot);
-                  break;
-                case "screen-item": {
-                  // screen-item payload は { screenId, items, ... } 形式
-                  const siPayload = esSvPayload as { screenId?: string } | null;
-                  const siScreenId = siPayload && typeof siPayload.screenId === "string" && siPayload.screenId
-                    ? siPayload.screenId
-                    : esSvResId;
-                  await writeScreenItems(siScreenId, esSvPayload, esSvRoot);
-                  break;
-                }
-                case "sequence":
-                  await writeSequence(esSvResId, esSvPayload, esSvRoot);
-                  break;
-                case "flow":
-                  // flow (画面フロー) は FlowEditor が persistProject() で harmony.json + screen-layout.json を
-                  // 既に書き込んでいるため、ここでは二重書き込みを避けスキップ。
-                  // editSession.save はサーバ側 saveHistory 記録のみ担う。
-                  break;
-                case "extension":
-                case "convention":
-                  // extension / convention は専用 MCP tool handler が書き込むため、ここではスキップ。
-                  break;
-                default:
-                  // 未対応 type は無視 (schema 拡張時に追加)
-                  break;
-              }
-            } catch (esSvWriteErr) {
-              console.error(`[editSession.save] resource file 書き込み失敗 (type=${esSvType}, id=${esSvResId}):`, esSvWriteErr);
-              // 書き込み失敗でも saveHistory / broadcast は続行 (可用性優先)
-            }
-          }
-
-          respond({ ok: true, saveEvent });
-          this.broadcast({
-            wsId: esWsId,
-            event: "editSession.saved",
-            data: {
-              editSessionId: esSvId,
-              savedBy: saveEvent.savedBy,
-              savedAt: saveEvent.savedAt,
-              sequence: saveEvent.sequence,
-            },
-          });
           break;
         }
 
         case "editSession.discard": {
-          const esWsId = wsId();
-          if (!esWsId) { respondError("ワークスペースが選択されていません"); break; }
+          // #906: 公開 API editSessionDiscard を adapter として呼ぶ
           const { editSessionId: esDiscId } = (params ?? {}) as { editSessionId: string };
-          const esStore = this.getOrCreateEditSessionStore(esWsId);
-          await esStore.discard(esDiscId, "manual");
-          respond({ discarded: true });
-          this.broadcast({
-            wsId: esWsId,
-            event: "editSession.discarded",
-            data: { editSessionId: esDiscId, reason: "manual" as const },
-          });
+          try {
+            const result = await this.editSessionDiscard(clientId, esDiscId);
+            respond(result);
+          } catch (e) {
+            respondError(e instanceof Error ? e.message : String(e));
+          }
           break;
         }
 
         case "editSession.list": {
-          const esWsId = wsId();
-          if (!esWsId) { respondError("ワークスペースが選択されていません"); break; }
+          // #906: 公開 API editSessionList を adapter として呼ぶ
           const {
             resourceType: esLstRt,
             resourceId: esLstRid,
           } = (params ?? {}) as { resourceType?: EditSessionResourceType; resourceId?: string };
-          const esStore = this.getOrCreateEditSessionStore(esWsId);
-          let sessions;
-          if (esLstRt && esLstRid) {
-            sessions = esStore.listByResource(esLstRt, esLstRid);
-          } else {
-            // filter なし: 全 EditSession を返す (store の private map を公開するため list all)
-            sessions = esStore.listAll();
+          try {
+            const result = this.editSessionList(clientId, { resourceType: esLstRt, resourceId: esLstRid });
+            respond(result);
+          } catch (e) {
+            respondError(e instanceof Error ? e.message : String(e));
           }
-          respond({ sessions: sessions.map(_serializeEditSession) });
-          // broadcast なし (response only)
           break;
         }
 
         case "editSession.fetchPayload": {
-          const esWsId = wsId();
-          if (!esWsId) { respondError("ワークスペースが選択されていません"); break; }
+          // #906: 公開 API editSessionFetchPayload を adapter として呼ぶ
           const { editSessionId: esFpId } = (params ?? {}) as { editSessionId: string };
-          const esStore = this.getOrCreateEditSessionStore(esWsId);
-          const fetchPayloadResult = esStore.fetchCurrentPayload(esFpId);
-          if (!fetchPayloadResult) {
-            respondError(`EditSession ${esFpId} が見つかりません`);
-            break;
+          try {
+            const result = this.editSessionFetchPayload(clientId, esFpId);
+            respond(result);
+          } catch (e) {
+            respondError(e instanceof Error ? e.message : String(e));
           }
-          respond({ payload: fetchPayloadResult.payload, sequence: fetchPayloadResult.sequence });
-          // broadcast なし (response only)
           break;
         }
 


### PR DESCRIPTION
## 関連

Closes #906

仕様: `docs/spec/edit-session-protocol.md` (全節)。本 PR は MCP tool 形式での adapter を提供し、既存仕様自体は変更なし。

## 概要

#897 / #903 で legacy `draft__*` / `lock__*` MCP tools を削除した後、新 protocol 用 `editSession__*` MCP tool が未定義で、AI エージェントが MCP 経由で edit-session を直接操作できなかった (browser-side WS 経由のみ動作) 問題を解消する。

## 主な変更

### wsBridge.ts: 公開 API 10 メソッド追加 (WS handler と MCP tool で共有)

10 メソッド (`editSessionCreate` / `editSessionAttachAsView` / `editSessionDetach` / `editSessionSetRole` / `editSessionTransferEdit` / `editSessionUpdate` / `editSessionSave` (#912 stage パラメータ含む) / `editSessionDiscard` / `editSessionList` / `editSessionFetchPayload`) を WsBridge クラスに追加。

各メソッドは `sessionId` (WS clientId / MCP sessionId 統一) を引数に取り、`workspaceContextManager` で wsId 解決 + `EditSessionStore` 操作 + broadcast を内部で実施。

**WS case handlers は本公開 API を adapter として呼ぶ形にリファクタリング** (300+ 行 → 100 行)。同一ロジックが WS 経路 / MCP 経路で共有される。

### tools.ts / index.ts: 10 個の MCP tool 定義 + dispatch handler

`editSession__create` / `editSession__attach_as_view` / `editSession__detach` / `editSession__set_role` / `editSession__transfer_edit` / `editSession__update` / `editSession__save` / `editSession__discard` / `editSession__list` / `editSession__fetch_payload`。

各 tool は `wsBridge` の対応公開 API を呼ぶ adapter 実装。

### httpTransport.test.ts: editSession E2E 4 ケース追加

- HTTP MCP dispatch: `tools/list` に 10 件登録確認
- WS roundtrip lifecycle: create → update → list → fetch_payload → save → discard
- WS roundtrip 2 段階保存: stage=checkOnly → stage=commit (#912 連携)
- WS roundtrip error path: 存在しない `editSessionId` で fetchPayload

**HTTP MCP transport は stateless** (`sessionIdGenerator: undefined`) のため request 毎に sessionId が変わり participant 継続性が成立しない。lifecycle 検証は stable clientId を持つ WS roundtrip で実施 (公開 API は HTTP/WS 共有のため両経路で `wsBridge.editSession*` が exercise される)。

## 仕様逐条突合 (自己申告)

- spec §5 step 1 (create): `wsBridge.ts:editSessionCreate` (sessionId を initial Edit participant) ✓
- spec §5 step 2 (attach_as_view + initial fetchPayload): `wsBridge.ts:editSessionAttachAsView` (response に payload + sequence 同梱) ✓
- spec §5 step 5 / §8 (save): `wsBridge.ts:editSessionSave` (saveHistory + 本体書き込み + broadcast、stage 分岐は #912 通り) ✓
- spec §5 step 6a (discard): `wsBridge.ts:editSessionDiscard` (Active → Discarded) ✓
- spec §6.2 (Edit role 直接 detach 禁止): `editSessionStore.ts:detach` でガード、テスト `editSession__set_role: Edit → View 降格 + 自身の detach を許可する` で確認 ✓
- spec §7 (transferEdit): `wsBridge.ts:editSessionTransferEdit` (caller = new Edit holder、fromSessionId 自動検索 #907 仕様) ✓
- spec §9.3 (last-save-wins): `wsBridge.ts:editSessionSave` (force / stage="commit" で skip) ✓
- spec §13.2 (update — FS write なし): `wsBridge.ts:editSessionUpdate` (snapshot only) ✓
- spec §13.3 (fetchPayload): `wsBridge.ts:editSessionFetchPayload` ✓
- spec §14.x (broadcast): 各 method で `this.broadcast({ wsId, event, data })` を呼び出し ✓

## レビューで特に見てほしい箇所

1. **WS case handler のリファクタ**: 旧 case 本体 (300+ 行) を public API 呼び出し (10〜15 行) に置換した。挙動完全互換が backend 380 既存テスト全 pass で確認できているが、broadcast / respond の形 (data 構造) が壊れていないか目視レビューを希望。
2. **MCP HTTP stateless 制約と lifecycle テスト分離**: HTTP では participant 継続性が成立しないため lifecycle テストを WS roundtrip に分離した。妥当性を確認したい。
3. **editSessionFetchPayload の error path**: store 側で `EditSessionNotFoundError` を throw するように変更したか確認。元の WS handler は `respondError(\`EditSession ${id} が見つかりません\`)` だったが、public API では throw ベースに統一。WS case の `try/catch` で同等のエラーメッセージが返ることをテストで確認済み。

## テスト

- **Backend Vitest**: 384 件 (新規 4 件) — `httpTransport.test.ts` editSession E2E
- **Frontend Vitest**: 28 件 pass (既存、影響なし)
- **frontend tsc + vite build**: 成功
- **backend tsc**: 成功

## UI 影響 / AI smoke test

- [x] UI 影響なし — backend のみの変更、frontend は既存 WS 経路で動作 (WS handler は同一公開 API を呼ぶ形にリファクタしたが、外部 protocol は完全互換)
- [x] auto テスト pass のみ (UI smoke 不要)

## spec 側の不足点 / 提案

特になし。本 PR は spec 準拠の MCP tool 追加のみで、spec 自体は無変更。

## レビュー担当への申し送り

- 1 commit (`68ae770`): refactor + 新規 tool + E2E test を 1 件にまとめた (リファクタと新規追加が密結合のため分割不可)
- 起点 ISSUE は単独。シリーズ統合 PR ではない
- HTTP transport stateless (`sessionIdGenerator: undefined`) は既存設計判断、本 PR で変更しない (memory + AGENTS.md scope 厳守)
