### PR TITLE
feat(workspace): WSL2 ホスト検出 + OS-aware パス入力 UX 改善 (#858)

### DIFF
--- a/backend/src/hostInfo.test.ts
+++ b/backend/src/hostInfo.test.ts
@@ -36,7 +36,7 @@ describe("getHostInfo", () => {
 
     it.runIf(isLinux)("WSL2 文字列を含む /proc/version → isWSL=true", async () => {
       vi.spyOn(fs, "readFile").mockResolvedValue(
-        "Linux version 5.15.90.1-microsoft-standard-WSL2 (oe-user@oe-host) ..." as unknown as Buffer,
+        "Linux version 5.15.90.1-microsoft-standard-WSL2 (oe-user@oe-host) ...",
       );
       const info = await getHostInfo();
       expect(info.isWSL).toBe(true);
@@ -44,7 +44,7 @@ describe("getHostInfo", () => {
 
     it.runIf(isLinux)("Microsoft 文字列 (WSL1 想定) → isWSL=true", async () => {
       vi.spyOn(fs, "readFile").mockResolvedValue(
-        "Linux version 4.4.0-19041-Microsoft (Microsoft@Microsoft.com) ..." as unknown as Buffer,
+        "Linux version 4.4.0-19041-Microsoft (Microsoft@Microsoft.com) ...",
       );
       const info = await getHostInfo();
       expect(info.isWSL).toBe(true);
@@ -52,7 +52,7 @@ describe("getHostInfo", () => {
 
     it.runIf(isLinux)("native Linux (Microsoft/WSL を含まない) → isWSL=false", async () => {
       vi.spyOn(fs, "readFile").mockResolvedValue(
-        "Linux version 5.15.0-91-generic (buildd@lcy02-amd64-009) ..." as unknown as Buffer,
+        "Linux version 5.15.0-91-generic (buildd@lcy02-amd64-009) ...",
       );
       const info = await getHostInfo();
       expect(info.isWSL).toBe(false);

--- a/backend/src/hostInfo.test.ts
+++ b/backend/src/hostInfo.test.ts
@@ -1,13 +1,18 @@
 /**
  * hostInfo 単体テスト (#858)
+ *
+ * /proc/version の文字列マッチで WSL 検出を行うので、fs.readFile を mock して
+ * 各バリエーション (WSL2 / WSL1 / native Linux / 読み込み失敗) を直接検証する。
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import os from "node:os";
+import fs from "node:fs/promises";
 import { getHostInfo, __resetHostInfoCacheForTest } from "./hostInfo.js";
 
 describe("getHostInfo", () => {
   beforeEach(() => {
     __resetHostInfoCacheForTest();
+    vi.restoreAllMocks();
   });
 
   it("platform / homeDir を返す", async () => {
@@ -17,18 +22,52 @@ describe("getHostInfo", () => {
     expect(typeof info.isWSL).toBe("boolean");
   });
 
-  it("Linux 以外 (win32 / darwin) では isWSL=false", async () => {
-    if (process.platform === "linux") {
-      // Linux 環境では実 /proc/version を読むので skip (動作環境に依存)
-      return;
-    }
-    const info = await getHostInfo();
-    expect(info.isWSL).toBe(false);
-  });
-
   it("結果がキャッシュされる (2 回目は同一インスタンス)", async () => {
     const a = await getHostInfo();
     const b = await getHostInfo();
     expect(b).toBe(a);
+  });
+
+  // ── WSL 検出ロジックの直接検証 (process.platform="linux" 想定の環境のみ) ─────
+  // /proc/version の内容を mock し、isWSL の判定が正しいかを文字列バリアント別に確認
+
+  describe("WSL 検出 (Linux ホストでの /proc/version マッチ)", () => {
+    const isLinux = process.platform === "linux";
+
+    it.runIf(isLinux)("WSL2 文字列を含む /proc/version → isWSL=true", async () => {
+      vi.spyOn(fs, "readFile").mockResolvedValue(
+        "Linux version 5.15.90.1-microsoft-standard-WSL2 (oe-user@oe-host) ..." as unknown as Buffer,
+      );
+      const info = await getHostInfo();
+      expect(info.isWSL).toBe(true);
+    });
+
+    it.runIf(isLinux)("Microsoft 文字列 (WSL1 想定) → isWSL=true", async () => {
+      vi.spyOn(fs, "readFile").mockResolvedValue(
+        "Linux version 4.4.0-19041-Microsoft (Microsoft@Microsoft.com) ..." as unknown as Buffer,
+      );
+      const info = await getHostInfo();
+      expect(info.isWSL).toBe(true);
+    });
+
+    it.runIf(isLinux)("native Linux (Microsoft/WSL を含まない) → isWSL=false", async () => {
+      vi.spyOn(fs, "readFile").mockResolvedValue(
+        "Linux version 5.15.0-91-generic (buildd@lcy02-amd64-009) ..." as unknown as Buffer,
+      );
+      const info = await getHostInfo();
+      expect(info.isWSL).toBe(false);
+    });
+
+    it.runIf(isLinux)("/proc/version 読み込み失敗 → isWSL=false (例外を伝播しない)", async () => {
+      vi.spyOn(fs, "readFile").mockRejectedValue(new Error("ENOENT"));
+      const info = await getHostInfo();
+      expect(info.isWSL).toBe(false);
+    });
+  });
+
+  it("Linux 以外 (win32 / darwin) では isWSL=false を即返す", async () => {
+    if (process.platform === "linux") return; // Linux 環境では skip
+    const info = await getHostInfo();
+    expect(info.isWSL).toBe(false);
   });
 });

--- a/backend/src/hostInfo.test.ts
+++ b/backend/src/hostInfo.test.ts
@@ -1,0 +1,34 @@
+/**
+ * hostInfo 単体テスト (#858)
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import os from "node:os";
+import { getHostInfo, __resetHostInfoCacheForTest } from "./hostInfo.js";
+
+describe("getHostInfo", () => {
+  beforeEach(() => {
+    __resetHostInfoCacheForTest();
+  });
+
+  it("platform / homeDir を返す", async () => {
+    const info = await getHostInfo();
+    expect(["linux", "win32", "darwin", "other"]).toContain(info.platform);
+    expect(info.homeDir).toBe(os.homedir());
+    expect(typeof info.isWSL).toBe("boolean");
+  });
+
+  it("Linux 以外 (win32 / darwin) では isWSL=false", async () => {
+    if (process.platform === "linux") {
+      // Linux 環境では実 /proc/version を読むので skip (動作環境に依存)
+      return;
+    }
+    const info = await getHostInfo();
+    expect(info.isWSL).toBe(false);
+  });
+
+  it("結果がキャッシュされる (2 回目は同一インスタンス)", async () => {
+    const a = await getHostInfo();
+    const b = await getHostInfo();
+    expect(b).toBe(a);
+  });
+});

--- a/backend/src/hostInfo.ts
+++ b/backend/src/hostInfo.ts
@@ -1,0 +1,54 @@
+/**
+ * hostInfo.ts (#858)
+ *
+ * Backend が動作しているホスト OS を判定し、ワークスペース選択画面の placeholder /
+ * パス入力ヒントを切り替えるための情報を提供する。
+ *
+ * - platform: process.platform を "linux" / "win32" / "darwin" / "other" に正規化
+ * - isWSL: /proc/version に "Microsoft" / "WSL" 文字列が含まれるか
+ * - homeDir: os.homedir() (frontend が user 名を埋め込んだプレースホルダを生成するのに使う)
+ *
+ * frontend は WSL 環境で「フォルダ参照」が Windows ファイルダイアログを出してしまい
+ * Linux パス (/home/<user>/...) に navigate できない問題に遭遇していた。本情報をもとに
+ * 入力欄の placeholder を切り替えることで、設計者が即座に正しいパス形式を入れられるようにする。
+ */
+import os from "node:os";
+import fs from "node:fs/promises";
+
+export interface HostInfo {
+  platform: "linux" | "win32" | "darwin" | "other";
+  isWSL: boolean;
+  homeDir: string;
+}
+
+let _cache: HostInfo | null = null;
+
+function normalizePlatform(p: NodeJS.Platform): HostInfo["platform"] {
+  if (p === "linux" || p === "win32" || p === "darwin") return p;
+  return "other";
+}
+
+async function detectWSL(): Promise<boolean> {
+  if (process.platform !== "linux") return false;
+  try {
+    const content = await fs.readFile("/proc/version", "utf-8");
+    return /Microsoft|WSL/i.test(content);
+  } catch {
+    return false;
+  }
+}
+
+export async function getHostInfo(): Promise<HostInfo> {
+  if (_cache) return _cache;
+  const isWSL = await detectWSL();
+  _cache = {
+    platform: normalizePlatform(process.platform),
+    isWSL,
+    homeDir: os.homedir(),
+  };
+  return _cache;
+}
+
+export function __resetHostInfoCacheForTest(): void {
+  _cache = null;
+}

--- a/backend/src/wsBridge.ts
+++ b/backend/src/wsBridge.ts
@@ -33,6 +33,7 @@ import {
   inspectWorkspacePath,
   initializeWorkspace as initializeWorkspaceFolder,
 } from "./workspaceInit.js";
+import { getHostInfo } from "./hostInfo.js";
 import {
   EditSessionStore,
   EditSessionNotFoundError,
@@ -1367,6 +1368,11 @@ class WsBridge extends EventEmitter {
           }
           const r = await inspectWorkspacePath(targetPath);
           respond(r);
+          break;
+        }
+        case "workspace.hostInfo": {
+          const info = await getHostInfo();
+          respond(info);
           break;
         }
         case "workspace.open": {

--- a/docs/spec/workspace.md
+++ b/docs/spec/workspace.md
@@ -145,7 +145,26 @@ workspace.inspect(path) → { status, path, name? }
 
 **実装**: `backend/src/workspaceInit.ts:87-101`
 
-### 3.6 init=true 時の初期化内容
+### 3.6 workspace.hostInfo
+
+```
+workspace.hostInfo() → { platform, isWSL, homeDir }
+```
+
+backend が動作しているホスト OS 情報を返す。`AddWorkspaceDialog` が path 入力欄の placeholder / WSL 検出ヒント表示に使う (#858)。
+
+| field | 型 | 内容 |
+|-------|----|------|
+| `platform` | `"linux" \| "win32" \| "darwin" \| "other"` | `process.platform` を 4 値に正規化 |
+| `isWSL` | `boolean` | `process.platform === "linux"` かつ `/proc/version` に `Microsoft` または `WSL` 文字列を含む場合 `true` (大文字小文字無視) |
+| `homeDir` | `string` | `os.homedir()` (placeholder の "/home/<user>/projects/my-app" 等を組み立てるのに使用) |
+
+- backend session 内でキャッシュされる (`/proc/version` を毎回読まない)
+- `inspectWorkspacePath` のような厳密判定ではなく**情報提供 API**。frontend は描画切替の hint として使うのみで、認可判断には使わない
+
+**実装**: `backend/src/hostInfo.ts:32-49` / `backend/src/wsBridge.ts:1373-1376`
+
+### 3.7 init=true 時の初期化内容
 
 `initializeWorkspace(path)` が実行する処理:
 

--- a/frontend/e2e/workspace-os-aware-input.spec.ts
+++ b/frontend/e2e/workspace-os-aware-input.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * workspace-os-aware-input.spec.ts (#858)
+ *
+ * AddWorkspaceDialog の WSL2 環境向け UX 改善を E2E で検証。
+ *
+ * カバー範囲:
+ *  - host info (workspace.hostInfo) で OS-aware placeholder が出る
+ *  - WSL2 環境 (本検証 host) では「WSL2 環境を検出しました」の専用ヒントが出る
+ *  - debounced auto-inspect: パス入力 400ms 後に status badge が描画される
+ *  - 「確認」ボタン (secondary) で即時検証も可能 (auto-inspect 待ち回避)
+ *  - recent dropdown: input フォーカス / 入力時に最近のワークスペースが表示される
+ *
+ * 前提: backend (port 5179) と frontend (port 5173) が稼働中
+ *       WSL2 環境で playwright を実行 → host info の isWSL=true がレスポンスされる
+ */
+import { test, expect, type Page } from "@playwright/test";
+
+async function setupClean(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.clear();
+    window.alert = () => {};
+    window.confirm = () => false;
+  });
+}
+
+async function openAddDialog(page: Page) {
+  await page.goto("/workspace/list");
+  const addBtn = page.locator("button", { hasText: "追加" }).first();
+  await addBtn.click();
+  await expect(page.locator(".tbl-modal")).toBeVisible();
+}
+
+test.describe("AddWorkspaceDialog — WSL2 / OS-aware UX (#858)", () => {
+  test("WSL2 環境では Linux 形式の絶対パスと専用ヒントが表示される", async ({ page }) => {
+    await setupClean(page);
+    await openAddDialog(page);
+
+    const input = page.getByTestId("workspace-path-input");
+    await expect(input).toBeVisible();
+
+    // host info から取得した homeDir 配下の例が placeholder に入る
+    const placeholder = await input.getAttribute("placeholder");
+    expect(placeholder).toMatch(/\/home\/[^/]+\/projects\/my-app/);
+    // 既存 #755 e2e と同様 workspaces/ 形式も placeholder に含まれること
+    expect(placeholder).toContain("workspaces/my-app");
+
+    // WSL 検出ヒント (本ホストは WSL2 想定)
+    await expect(page.locator(".tbl-modal").getByText(/WSL2 環境を検出しました/)).toBeVisible();
+  });
+
+  test("パス入力 → debounce 後に status badge が自動描画される", async ({ page }) => {
+    await setupClean(page);
+    await openAddDialog(page);
+
+    const input = page.getByTestId("workspace-path-input");
+    // 不存在パスを入れて status="notFound" を期待 (backend 接続 + inspect が走ることの確認)
+    await input.fill("/tmp/__definitely_not_a_workspace__");
+
+    // debounce 400ms + inspect で status badge が出る
+    const badge = page.getByTestId("workspace-status");
+    await expect(badge).toBeVisible({ timeout: 5000 });
+    await expect(badge).toHaveAttribute("data-status", /notFound|needsInit|invalid|error/);
+  });
+
+  test("「確認」ボタンで debounce 待ちせず即時検証できる (secondary action)", async ({ page }) => {
+    await setupClean(page);
+    await openAddDialog(page);
+
+    const input = page.getByTestId("workspace-path-input");
+    await input.fill("/tmp/__manual_inspect_target__");
+
+    // debounce 待たずに「確認」ボタン押下
+    const confirmBtn = page.locator(".tbl-modal button", { hasText: "確認" }).first();
+    await confirmBtn.click();
+
+    const badge = page.getByTestId("workspace-status");
+    await expect(badge).toBeVisible({ timeout: 5000 });
+  });
+
+  test("入力欄フォーカスで recent dropdown が表示される", async ({ page }) => {
+    await setupClean(page);
+    await page.goto("/workspace/list");
+
+    // recent を作るために最低 1 件 workspace を localStorage に登録できないので、
+    // backend recent から取得される。recent 0 件環境なら dropdown 自体が出ない (空配列)。
+    // dropdown 構造の存在検証のみここで行い、ダミーフォーカス → 表示有無を観測する。
+    const addBtn = page.locator("button", { hasText: "追加" }).first();
+    await addBtn.click();
+    await expect(page.locator(".tbl-modal")).toBeVisible();
+
+    const input = page.getByTestId("workspace-path-input");
+    await input.focus();
+
+    // recent が無い環境では listbox が空で出ないことのみ確認 (regression なし)
+    // recent 1 件以上ある実環境では listbox が visible
+    const listbox = page.locator("#workspace-recent-dropdown");
+    const isPresent = await listbox.count();
+    if (isPresent > 0) {
+      await expect(listbox).toBeVisible();
+      await expect(listbox.locator("li").first()).toBeVisible();
+    }
+    // どちらでも regression なし
+  });
+});

--- a/frontend/src/components/workspace/AddWorkspaceDialog.test.tsx
+++ b/frontend/src/components/workspace/AddWorkspaceDialog.test.tsx
@@ -174,7 +174,7 @@ describe("AddWorkspaceDialog (#858)", () => {
     expect(input.value).toBe("/home/user/projects/diary");
   });
 
-  it("入力中の文字列で recent エントリを prefix-match で絞り込む", async () => {
+  it("入力中の文字列で recent エントリを substring-match で絞り込む", async () => {
     getHostInfoMock.mockResolvedValue(makeHost());
     inspectWorkspaceMock.mockResolvedValue({ status: "notFound", path: "" } satisfies WorkspaceInspectResult);
 
@@ -187,5 +187,77 @@ describe("AddWorkspaceDialog (#858)", () => {
     expect(screen.getByText("Diary")).toBeTruthy();
     // Retail はマッチしないので非表示
     expect(screen.queryByText("Retail")).toBeNull();
+  });
+
+  it("Escape キーで recent dropdown が閉じる (input focus は維持) (SF-3)", async () => {
+    getHostInfoMock.mockResolvedValue(makeHost());
+    inspectWorkspaceMock.mockResolvedValue({ status: "notFound", path: "" } satisfies WorkspaceInspectResult);
+
+    render(<AddWorkspaceDialog onClose={() => {}} onAdded={() => {}} />);
+
+    const input = await screen.findByTestId("workspace-path-input");
+    fireEvent.focus(input);
+    expect(screen.queryByRole("listbox", { name: "最近使ったワークスペース" })).toBeTruthy();
+
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("listbox", { name: "最近使ったワークスペース" })).toBeNull();
+    });
+  });
+
+  it("Tab キーで recent dropdown が閉じる (SF-3)", async () => {
+    getHostInfoMock.mockResolvedValue(makeHost());
+    inspectWorkspaceMock.mockResolvedValue({ status: "notFound", path: "" } satisfies WorkspaceInspectResult);
+
+    render(<AddWorkspaceDialog onClose={() => {}} onAdded={() => {}} />);
+
+    const input = await screen.findByTestId("workspace-path-input");
+    fireEvent.focus(input);
+    expect(screen.queryByRole("listbox", { name: "最近使ったワークスペース" })).toBeTruthy();
+
+    fireEvent.keyDown(input, { key: "Tab" });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("listbox", { name: "最近使ったワークスペース" })).toBeNull();
+    });
+  });
+
+  it("入力を空に戻すと進行中 inspect の遅延結果で UI が上書きされない (MF-1 race fix)", async () => {
+    getHostInfoMock.mockResolvedValue(makeHost());
+    // 1 回目の inspect は遅延して resolve するよう細工
+    let resolveFirst: (v: WorkspaceInspectResult) => void = () => {};
+    const firstPromise = new Promise<WorkspaceInspectResult>((res) => { resolveFirst = res; });
+    inspectWorkspaceMock.mockReturnValueOnce(firstPromise);
+
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    render(<AddWorkspaceDialog onClose={() => {}} onAdded={() => {}} />);
+    const input = await screen.findByTestId("workspace-path-input");
+
+    // パスを入力 → debounce 完了 → inspectWorkspace が呼ばれて pending 状態
+    fireEvent.change(input, { target: { value: "/home/user/projects/diary" } });
+    await act(async () => { vi.advanceTimersByTime(400); });
+    await waitFor(() => {
+      expect(inspectWorkspaceMock).toHaveBeenCalledWith("/home/user/projects/diary");
+    });
+
+    // この時点で status="inspecting" バッジが描画されているはず
+    expect(screen.getByTestId("workspace-status").getAttribute("data-status")).toBe("inspecting");
+
+    // パスを空に戻す → 進行中の inspect は seq guard で破棄されるべき
+    fireEvent.change(input, { target: { value: "" } });
+    // 空入力で status badge は消える (idle)
+    await waitFor(() => {
+      expect(screen.queryByTestId("workspace-status")).toBeNull();
+    });
+
+    // 遅延していた 1 回目の inspect が後から resolve しても、
+    // status badge は再描画されない (seq guard で結果が破棄される)
+    resolveFirst({ status: "ready", path: "/home/user/projects/diary", name: "Diary" });
+    vi.useRealTimers();
+
+    // 100ms 待っても status badge は出ない
+    await new Promise((r) => setTimeout(r, 50));
+    expect(screen.queryByTestId("workspace-status")).toBeNull();
   });
 });

--- a/frontend/src/components/workspace/AddWorkspaceDialog.test.tsx
+++ b/frontend/src/components/workspace/AddWorkspaceDialog.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * AddWorkspaceDialog テスト (#858)
+ *
+ * - OS-aware placeholder (host info に応じて切り替え)
+ * - debounced auto-inspect (入力後 400ms で inspectWorkspace 自動呼び出し)
+ * - recent dropdown (focus / 入力時に表示、クリックで補完)
+ * - WSL 検出時に専用ヒント表示
+ */
+import { fireEvent, render, screen, waitFor, act } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { HostInfo, WorkspaceInspectResult } from "../../store/workspaceStore";
+
+// vi.mock factory は hoist されるので、内部で参照する mock は vi.hoisted で持ち上げる
+const mocks = vi.hoisted(() => {
+  const recentEntries = [
+    { id: "ws-1", path: "/home/user/projects/diary", name: "Diary", lastOpenedAt: null },
+    { id: "ws-2", path: "/home/user/projects/retail", name: "Retail", lastOpenedAt: null },
+  ];
+  const baseState = {
+    workspaces: recentEntries,
+    active: null,
+    lockdown: false,
+    lockdownPath: null,
+    loading: false,
+    error: null,
+  };
+  return {
+    inspectWorkspaceMock: vi.fn(),
+    getHostInfoMock: vi.fn(),
+    openWorkspaceMock: vi.fn(),
+    initAndOpenMock: vi.fn(),
+    recentEntries,
+    baseState,
+  };
+});
+
+const { inspectWorkspaceMock, getHostInfoMock, openWorkspaceMock, initAndOpenMock } = mocks;
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock("../../mcp/mcpBridge", () => ({
+  mcpBridge: {
+    onStatusChange: vi.fn(() => () => {}),
+  },
+}));
+
+vi.mock("../../store/workspaceStore", async () => {
+  const actual = await vi.importActual<typeof import("../../store/workspaceStore")>("../../store/workspaceStore");
+  return {
+    ...actual,
+    getState: vi.fn(() => mocks.baseState),
+    subscribe: vi.fn(() => () => {}),
+    loadWorkspaces: vi.fn(),
+    openWorkspace: mocks.openWorkspaceMock,
+    inspectWorkspace: mocks.inspectWorkspaceMock,
+    initAndOpen: mocks.initAndOpenMock,
+    removeWorkspace: vi.fn(),
+    getHostInfo: mocks.getHostInfoMock,
+  };
+});
+
+import { AddWorkspaceDialog } from "./WorkspaceListView";
+
+describe("AddWorkspaceDialog (#858)", () => {
+  beforeEach(() => {
+    inspectWorkspaceMock.mockReset();
+    getHostInfoMock.mockReset();
+    openWorkspaceMock.mockReset();
+    initAndOpenMock.mockReset();
+    vi.useRealTimers();
+  });
+
+  function makeHost(overrides: Partial<HostInfo> = {}): HostInfo {
+    return {
+      platform: "linux",
+      isWSL: false,
+      homeDir: "/home/user",
+      ...overrides,
+    };
+  }
+
+  it("placeholder に workspaces/ ヒントを含む (#755 e2e regression 防止)", async () => {
+    getHostInfoMock.mockResolvedValue(makeHost());
+    inspectWorkspaceMock.mockResolvedValue({ status: "notFound", path: "" } satisfies WorkspaceInspectResult);
+
+    render(<AddWorkspaceDialog onClose={() => {}} onAdded={() => {}} />);
+
+    const input = await screen.findByTestId("workspace-path-input");
+    const placeholder = input.getAttribute("placeholder") ?? "";
+    expect(placeholder).toContain("workspaces/my-app");
+  });
+
+  it("WSL 環境では Linux 形式の絶対パスと WSL 専用ヒントを表示する", async () => {
+    getHostInfoMock.mockResolvedValue(makeHost({ platform: "linux", isWSL: true, homeDir: "/home/wsluser" }));
+    inspectWorkspaceMock.mockResolvedValue({ status: "notFound", path: "" } satisfies WorkspaceInspectResult);
+
+    render(<AddWorkspaceDialog onClose={() => {}} onAdded={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/WSL2 環境を検出しました/)).toBeTruthy();
+    });
+    const input = screen.getByTestId("workspace-path-input");
+    const placeholder = input.getAttribute("placeholder") ?? "";
+    expect(placeholder).toContain("/home/wsluser/projects/my-app");
+  });
+
+  it("Windows ホストではバックスラッシュ形式の例を出す", async () => {
+    getHostInfoMock.mockResolvedValue(makeHost({ platform: "win32", isWSL: false, homeDir: "C:\\Users\\winuser" }));
+    inspectWorkspaceMock.mockResolvedValue({ status: "notFound", path: "" } satisfies WorkspaceInspectResult);
+
+    render(<AddWorkspaceDialog onClose={() => {}} onAdded={() => {}} />);
+
+    const input = await screen.findByTestId("workspace-path-input");
+    await waitFor(() => {
+      const placeholder = input.getAttribute("placeholder") ?? "";
+      expect(placeholder).toContain("C:\\Users\\winuser\\projects\\my-app");
+    });
+  });
+
+  it("入力後 400ms で inspectWorkspace が自動呼び出しされ、status バッジが描画される", async () => {
+    getHostInfoMock.mockResolvedValue(makeHost());
+    inspectWorkspaceMock.mockResolvedValue({ status: "ready", path: "/home/user/projects/diary", name: "Diary" } satisfies WorkspaceInspectResult);
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    render(<AddWorkspaceDialog onClose={() => {}} onAdded={() => {}} />);
+
+    const input = await screen.findByTestId("workspace-path-input");
+    fireEvent.change(input, { target: { value: "/home/user/projects/diary" } });
+
+    // debounce 期間中は呼び出されない
+    expect(inspectWorkspaceMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(400);
+    });
+
+    await waitFor(() => {
+      expect(inspectWorkspaceMock).toHaveBeenCalledWith("/home/user/projects/diary");
+    });
+
+    vi.useRealTimers();
+    await waitFor(() => {
+      const badge = screen.getByTestId("workspace-status");
+      expect(badge.getAttribute("data-status")).toBe("ready");
+    });
+  });
+
+  it("入力欄フォーカスで recent dropdown が出る", async () => {
+    getHostInfoMock.mockResolvedValue(makeHost());
+    inspectWorkspaceMock.mockResolvedValue({ status: "notFound", path: "" } satisfies WorkspaceInspectResult);
+
+    render(<AddWorkspaceDialog onClose={() => {}} onAdded={() => {}} />);
+
+    const input = await screen.findByTestId("workspace-path-input");
+    fireEvent.focus(input);
+
+    expect(screen.getByRole("listbox", { name: "最近使ったワークスペース" })).toBeTruthy();
+    expect(screen.getByText("Diary")).toBeTruthy();
+    expect(screen.getByText("Retail")).toBeTruthy();
+  });
+
+  it("recent dropdown のエントリをクリックすると入力欄に絶対パスが入る", async () => {
+    getHostInfoMock.mockResolvedValue(makeHost());
+    inspectWorkspaceMock.mockResolvedValue({ status: "ready", path: "/home/user/projects/diary", name: "Diary" } satisfies WorkspaceInspectResult);
+
+    render(<AddWorkspaceDialog onClose={() => {}} onAdded={() => {}} />);
+
+    const input = (await screen.findByTestId("workspace-path-input")) as HTMLInputElement;
+    fireEvent.focus(input);
+    fireEvent.click(screen.getByText("Diary"));
+
+    expect(input.value).toBe("/home/user/projects/diary");
+  });
+
+  it("入力中の文字列で recent エントリを prefix-match で絞り込む", async () => {
+    getHostInfoMock.mockResolvedValue(makeHost());
+    inspectWorkspaceMock.mockResolvedValue({ status: "notFound", path: "" } satisfies WorkspaceInspectResult);
+
+    render(<AddWorkspaceDialog onClose={() => {}} onAdded={() => {}} />);
+
+    const input = await screen.findByTestId("workspace-path-input");
+    fireEvent.change(input, { target: { value: "diary" } });
+
+    // dropdown は表示状態のまま (focus + 入力)
+    expect(screen.getByText("Diary")).toBeTruthy();
+    // Retail はマッチしないので非表示
+    expect(screen.queryByText("Retail")).toBeNull();
+  });
+});

--- a/frontend/src/components/workspace/WorkspaceListView.tsx
+++ b/frontend/src/components/workspace/WorkspaceListView.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef, useId } from "react";
 import { useNavigate } from "react-router-dom";
 import { mcpBridge } from "../../mcp/mcpBridge";
 import {
@@ -88,8 +88,10 @@ export function AddWorkspaceDialog({ onClose, onAdded }: AddWorkspaceDialogProps
   const debounceRef = useRef<number | null>(null);
   const inflightSeqRef = useRef(0);
   const inputRef = useRef<HTMLInputElement | null>(null);
+  // 同一画面に複数 dialog が同時表示される将来拡張に備え、global ID 衝突を避けて useId で一意化
+  const dropdownId = useId();
 
-  // recent workspace 一覧 (store から取得、prefix-match で suggest)
+  // recent workspace 一覧 (store から取得、substring-match で suggest)
   const recentWorkspaces = getState().workspaces;
 
   // host info を取得 (失敗は黙って null のまま、placeholder はフォールバックを使う)
@@ -134,10 +136,11 @@ export function AddWorkspaceDialog({ onClose, onAdded }: AddWorkspaceDialogProps
     if (debounceRef.current !== null) {
       window.clearTimeout(debounceRef.current);
     }
+    // path が変わった瞬間、進行中 inspect (旧 path 用) の遅延 response が
+    // 新 path の UI を上書きしないよう seq を bump して旧結果を破棄する。
+    // 空入力 / 非空入力切替 / 非空 → 非空切替 すべての race window をカバー。
+    inflightSeqRef.current++;
     if (!path.trim()) {
-      // 空入力に戻した瞬間、進行中 inspect の遅延 response が
-      // idle 状態を ready/notFound 等に上書きしないよう seq を bump して破棄する
-      inflightSeqRef.current++;
       setStatus("idle");
       setInspectName(null);
       setErrorMsg(null);
@@ -202,7 +205,11 @@ export function AddWorkspaceDialog({ onClose, onAdded }: AddWorkspaceDialogProps
     }
   };
 
-  const hasPickerSupport = typeof window !== "undefined" && "showDirectoryPicker" in window;
+  // WSL2 + Windows ブラウザ環境では showDirectoryPicker が Linux パスに到達できず実質使えないので、
+  // ヒント文と整合させてフォルダ参照ボタンを非表示にする (#858 / #919 Opus review nit)
+  const hasPickerSupport = typeof window !== "undefined"
+    && "showDirectoryPicker" in window
+    && !host?.isWSL;
   const placeholder = buildPlaceholder(host);
   const exampleAbs = buildOsAwareExamplePath(host);
 
@@ -222,7 +229,7 @@ export function AddWorkspaceDialog({ onClose, onAdded }: AddWorkspaceDialogProps
       const target = e.target as Node;
       if (inputRef.current && !inputRef.current.contains(target)) {
         // dropdown 内クリックは別途閉じる (handleSelectRecent)
-        const dropdown = document.getElementById("workspace-recent-dropdown");
+        const dropdown = document.getElementById(dropdownId);
         if (!dropdown || !dropdown.contains(target)) {
           setShowRecent(false);
         }
@@ -230,7 +237,7 @@ export function AddWorkspaceDialog({ onClose, onAdded }: AddWorkspaceDialogProps
     };
     document.addEventListener("mousedown", handler);
     return () => document.removeEventListener("mousedown", handler);
-  }, [showRecent]);
+  }, [showRecent, dropdownId]);
 
   const handleSelectRecent = (entry: WorkspaceEntry) => {
     setPath(entry.path);
@@ -285,7 +292,7 @@ export function AddWorkspaceDialog({ onClose, onAdded }: AddWorkspaceDialogProps
             )}
             {showRecent && filteredRecents.length > 0 && (
               <ul
-                id="workspace-recent-dropdown"
+                id={dropdownId}
                 role="listbox"
                 aria-label="最近使ったワークスペース"
                 style={{

--- a/frontend/src/components/workspace/WorkspaceListView.tsx
+++ b/frontend/src/components/workspace/WorkspaceListView.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { mcpBridge } from "../../mcp/mcpBridge";
 import {
@@ -9,7 +9,10 @@ import {
   inspectWorkspace,
   initAndOpen,
   removeWorkspace,
+  getHostInfo,
   type WorkspaceEntry,
+  type HostInfo,
+  type WorkspaceInspectResult,
 } from "../../store/workspaceStore";
 import { DataList, type DataListColumn } from "../common/DataList";
 import { FilterBar } from "../common/FilterBar";
@@ -46,38 +49,107 @@ interface AddWorkspaceDialogProps {
   onAdded: () => void;
 }
 
+type InspectStatus = "idle" | "inspecting" | "ready" | "needsInit" | "notFound" | "invalid" | "error";
+
+/**
+ * host info から OS 別の絶対パス例を生成 (#858)。
+ * placeholder と説明文の両方で使う。
+ *
+ * - WSL: `/home/<user>/projects/my-app` (Windows ファイルダイアログから到達不可、テキスト入力必須)
+ * - Linux native: `/home/<user>/projects/my-app`
+ * - macOS: `/Users/<user>/projects/my-app` (homeDir をそのまま使う)
+ * - Windows: `C:\\Users\\<user>\\projects\\my-app`
+ *
+ * homeDir 末尾の trailing separator を保持しないよう注意。
+ */
+function buildOsAwareExamplePath(host: HostInfo | null): string {
+  // host info 取得前のフォールバック
+  if (!host) return "workspaces/my-app";
+  const sep = host.platform === "win32" ? "\\" : "/";
+  const home = host.homeDir.replace(/[\\/]+$/, "");
+  return `${home}${sep}projects${sep}my-app`;
+}
+
+/** placeholder 用の短い例 (workspaces/ プレフィクスを必ず含むこと: #755 e2e regression 防止) */
+function buildPlaceholder(host: HostInfo | null): string {
+  const example = buildOsAwareExamplePath(host);
+  return `${example} または workspaces/my-app`;
+}
+
 export function AddWorkspaceDialog({ onClose, onAdded }: AddWorkspaceDialogProps) {
   const [path, setPath] = useState("");
-  const [status, setStatus] = useState<"idle" | "inspecting" | "ready" | "needsInit" | "notFound" | "invalid" | "error">("idle");
+  const [status, setStatus] = useState<InspectStatus>("idle");
   const [inspectName, setInspectName] = useState<string | null>(null);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [processing, setProcessing] = useState(false);
   const [pickedFolderHint, setPickedFolderHint] = useState<string | null>(null);
+  const [host, setHost] = useState<HostInfo | null>(null);
+  const [showRecent, setShowRecent] = useState(false);
+  const debounceRef = useRef<number | null>(null);
+  const inflightSeqRef = useRef(0);
+  const inputRef = useRef<HTMLInputElement | null>(null);
 
-  // デフォルトの新規作成推奨パス (サーバ側 workspaces/ ディレクトリ) をヒントとして表示するだけ。
-  // ブラウザの file picker では絶対パスを取得できないため、ここではプレースホルダ文字列のみ使用。
-  // 推奨パスは workspaces/<新規 wsId>/ (例: workspaces/my-project)
-  const defaultPathHint = "workspaces/my-project";
+  // recent workspace 一覧 (store から取得、prefix-match で suggest)
+  const recentWorkspaces = getState().workspaces;
 
-  const handleInspect = async () => {
-    const trimmed = path.trim();
-    if (!trimmed) return;
+  // host info を取得 (失敗は黙って null のまま、placeholder はフォールバックを使う)
+  useEffect(() => {
+    let cancelled = false;
+    getHostInfo()
+      .then((info) => { if (!cancelled) setHost(info); })
+      .catch(() => { /* 取得失敗 → null のまま */ });
+    return () => { cancelled = true; };
+  }, []);
+
+  // debounced auto-inspect: 入力が落ち着いてから 400ms で自動 inspect
+  // 競合した古い request の結果で UI を上書きしないよう seq でガード
+  const runInspect = useCallback(async (target: string) => {
+    const trimmed = target.trim();
+    if (!trimmed) {
+      setStatus("idle");
+      setInspectName(null);
+      setErrorMsg(null);
+      return;
+    }
+    const seq = ++inflightSeqRef.current;
     setStatus("inspecting");
     setErrorMsg(null);
     setInspectName(null);
     try {
-      const result = await inspectWorkspace(trimmed);
-      setStatus(result.status as typeof status);
+      const result: WorkspaceInspectResult = await inspectWorkspace(trimmed);
+      if (seq !== inflightSeqRef.current) return; // 古い結果は破棄
+      setStatus(result.status);
       setInspectName(result.name ?? null);
-      // invalid ステータスの場合は reason をエラーメッセージとして表示 (#852 R-3)
-      if (result.status === "invalid" && "reason" in result) {
-        setErrorMsg((result as { reason: string }).reason ?? null);
+      if (result.status === "invalid" && result.reason) {
+        setErrorMsg(result.reason);
       }
     } catch (e) {
+      if (seq !== inflightSeqRef.current) return;
       setStatus("error");
       setErrorMsg(e instanceof Error ? e.message : String(e));
     }
-  };
+  }, []);
+
+  useEffect(() => {
+    if (debounceRef.current !== null) {
+      window.clearTimeout(debounceRef.current);
+    }
+    if (!path.trim()) {
+      setStatus("idle");
+      setInspectName(null);
+      setErrorMsg(null);
+      return;
+    }
+    debounceRef.current = window.setTimeout(() => {
+      runInspect(path);
+    }, 400);
+    return () => {
+      if (debounceRef.current !== null) {
+        window.clearTimeout(debounceRef.current);
+        debounceRef.current = null;
+      }
+    };
+  }, [path, runInspect]);
 
   const handleOpen = async () => {
     const trimmed = path.trim();
@@ -127,41 +199,140 @@ export function AddWorkspaceDialog({ onClose, onAdded }: AddWorkspaceDialogProps
     }
   };
 
-  const hasPickerSupport = "showDirectoryPicker" in window;
+  const hasPickerSupport = typeof window !== "undefined" && "showDirectoryPicker" in window;
+  const placeholder = buildPlaceholder(host);
+  const exampleAbs = buildOsAwareExamplePath(host);
+
+  // recent dropdown: 入力中の文字列で path / name を絞り込み
+  const filteredRecents = useMemo(() => {
+    const q = path.trim().toLowerCase();
+    if (!q) return recentWorkspaces.slice(0, 5);
+    return recentWorkspaces
+      .filter((w) => w.path.toLowerCase().includes(q) || w.name.toLowerCase().includes(q))
+      .slice(0, 5);
+  }, [path, recentWorkspaces]);
+
+  // dropdown 外クリックで閉じる
+  useEffect(() => {
+    if (!showRecent) return;
+    const handler = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (inputRef.current && !inputRef.current.contains(target)) {
+        // dropdown 内クリックは別途閉じる (handleSelectRecent)
+        const dropdown = document.getElementById("workspace-recent-dropdown");
+        if (!dropdown || !dropdown.contains(target)) {
+          setShowRecent(false);
+        }
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [showRecent]);
+
+  const handleSelectRecent = (entry: WorkspaceEntry) => {
+    setPath(entry.path);
+    setShowRecent(false);
+    inputRef.current?.focus();
+  };
 
   return (
     <div className="tbl-modal-overlay" onClick={onClose}>
-      <div className="tbl-modal" onClick={(e) => e.stopPropagation()} style={{ maxWidth: "480px" }}>
+      <div className="tbl-modal" onClick={(e) => e.stopPropagation()} style={{ maxWidth: "520px" }}>
         <div className="tbl-modal-title">ワークスペースを追加</div>
 
         <label className="tbl-field">
-          <span>フォルダのパス</span>
-          <div style={{ display: "flex", gap: "6px" }}>
+          <span>フォルダの絶対パス</span>
+          <div style={{ display: "flex", gap: "6px", position: "relative" }}>
             <input
+              ref={inputRef}
               type="text"
               value={path}
-              onChange={(e) => { setPath(e.target.value); setStatus("idle"); setInspectName(null); setErrorMsg(null); }}
-              placeholder={`workspaces/my-project (例: C:\\repos\\my-app\\${defaultPathHint})`}
+              onChange={(e) => { setPath(e.target.value); setShowRecent(true); }}
+              onFocus={() => setShowRecent(true)}
+              placeholder={placeholder}
               autoFocus
-              style={{ flex: 1 }}
-              onKeyDown={(e) => { if (e.key === "Enter") handleInspect(); }}
+              spellCheck={false}
+              autoCapitalize="off"
+              autoCorrect="off"
+              style={{ flex: 1, fontFamily: "monospace" }}
+              data-testid="workspace-path-input"
             />
             {hasPickerSupport && (
-              <button className="tbl-btn tbl-btn-ghost" onClick={handlePickFolder} title="フォルダ名を確認 (絶対パスは別途入力)">
+              <button
+                type="button"
+                className="tbl-btn tbl-btn-ghost"
+                onClick={handlePickFolder}
+                title="フォルダ名を確認 (絶対パスは別途入力)"
+                tabIndex={-1}
+              >
                 <i className="bi bi-folder2-open" />
               </button>
+            )}
+            {showRecent && filteredRecents.length > 0 && (
+              <ul
+                id="workspace-recent-dropdown"
+                role="listbox"
+                aria-label="最近使ったワークスペース"
+                style={{
+                  position: "absolute",
+                  top: "100%",
+                  left: 0,
+                  right: hasPickerSupport ? "44px" : 0,
+                  marginTop: "2px",
+                  padding: 0,
+                  listStyle: "none",
+                  background: "var(--card-bg, #fff)",
+                  border: "1px solid var(--border, #ccc)",
+                  borderRadius: "4px",
+                  boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
+                  maxHeight: "200px",
+                  overflowY: "auto",
+                  zIndex: 10,
+                }}
+              >
+                {filteredRecents.map((w) => (
+                  <li key={w.id} role="option" aria-selected={false}>
+                    <button
+                      type="button"
+                      onClick={() => handleSelectRecent(w)}
+                      style={{
+                        display: "block",
+                        width: "100%",
+                        textAlign: "left",
+                        padding: "6px 10px",
+                        background: "transparent",
+                        border: "none",
+                        cursor: "pointer",
+                        fontFamily: "inherit",
+                      }}
+                    >
+                      <div style={{ fontWeight: 500, fontSize: "0.85rem" }}>{w.name}</div>
+                      <div style={{ fontFamily: "monospace", fontSize: "0.75rem", color: "var(--muted-text, #888)" }}>
+                        {w.path}
+                      </div>
+                    </button>
+                  </li>
+                ))}
+              </ul>
             )}
           </div>
         </label>
 
-        <p style={{ fontSize: "0.78rem", color: "var(--muted-text, #888)", margin: "0 0 8px" }}>
-          推奨: リポジトリ直下の <code>workspaces/</code> フォルダに新規作成してください (例: <code>workspaces/{defaultPathHint.split("/")[1]}</code>)。
-          任意の絶対パスも使用できます。
+        <p style={{ fontSize: "0.78rem", color: "var(--muted-text, #888)", margin: "0 0 6px" }}>
+          推奨: 絶対パスで指定 (例: <code style={{ fontFamily: "monospace" }}>{exampleAbs}</code>)。
+          リポジトリ直下の <code>workspaces/my-app</code> 形式の相対パスも使用できます。
         </p>
+
+        {host?.isWSL && (
+          <p style={{ fontSize: "0.78rem", color: "var(--muted-text, #888)", margin: "0 0 6px" }}>
+            <i className="bi bi-info-circle" /> WSL2 環境を検出しました。Windows ブラウザの「フォルダ参照」では Linux パス
+            (<code>/home/...</code>) に到達できないため、上の入力欄に手動で絶対パスを入力してください。
+          </p>
+        )}
 
         {hasPickerSupport && (
           <p style={{ fontSize: "0.78rem", color: "var(--muted-text, #888)", margin: "0 0 8px" }}>
-            ※「フォルダ選択」はフォルダ名の確認のみ可能です (ブラウザ仕様で絶対パス取得不可)。上の入力欄には絶対パスを必ず手動入力してください。
+            ※「フォルダ選択」ボタンはフォルダ名の確認のみ可能です (ブラウザ仕様で絶対パス取得不可)。
           </p>
         )}
 
@@ -171,116 +342,110 @@ export function AddWorkspaceDialog({ onClose, onAdded }: AddWorkspaceDialogProps
           </p>
         )}
 
-        {status === "idle" && (
-          <div className="tbl-modal-btns">
-            <button className="tbl-btn tbl-btn-ghost" onClick={onClose}>キャンセル</button>
-            <button
-              className="tbl-btn tbl-btn-primary"
-              onClick={handleInspect}
-              disabled={!path.trim()}
-            >
-              <i className="bi bi-search" /> 確認
-            </button>
+        {/* インライン状態表示 (debounced auto-inspect の結果) */}
+        {status === "inspecting" && (
+          <div
+            data-testid="workspace-status"
+            data-status="inspecting"
+            style={{ padding: "6px 10px", color: "var(--muted-text, #888)", fontSize: "0.85rem" }}
+          >
+            <i className="bi bi-hourglass-split" /> 確認中...
           </div>
         )}
 
-        {status === "inspecting" && (
-          <p style={{ color: "var(--muted-text, #888)" }}>確認中...</p>
-        )}
-
         {status === "ready" && (
-          <>
-            <div style={{ padding: "8px 12px", background: "var(--success-bg, #d4edda)", borderRadius: "4px", marginBottom: "12px", color: "var(--success-text, #155724)" }}>
-              <i className="bi bi-check-circle" /> ワークスペースが見つかりました
-              {inspectName && <> — <strong>{inspectName}</strong></>}
-            </div>
-            <div className="tbl-modal-btns">
-              <button className="tbl-btn tbl-btn-ghost" onClick={onClose}>キャンセル</button>
-              <button className="tbl-btn tbl-btn-primary" onClick={handleOpen} disabled={processing}>
-                {processing ? "開いています..." : "開く"}
-              </button>
-            </div>
-          </>
+          <div
+            data-testid="workspace-status"
+            data-status="ready"
+            style={{ padding: "8px 12px", background: "var(--success-bg, #d4edda)", borderRadius: "4px", marginBottom: "12px", color: "var(--success-text, #155724)" }}
+          >
+            <i className="bi bi-check-circle" /> ワークスペースが見つかりました
+            {inspectName && <> — <strong>{inspectName}</strong></>}
+          </div>
         )}
 
         {status === "needsInit" && (
-          <>
-            <div style={{ padding: "8px 12px", background: "var(--warning-bg, #fff3cd)", borderRadius: "4px", marginBottom: "12px", color: "var(--warning-text, #856404)" }}>
-              <i className="bi bi-exclamation-triangle" /> フォルダは空です。初期化してワークスペースを作成しますか？
-            </div>
-            <div className="tbl-modal-btns">
-              <button className="tbl-btn tbl-btn-ghost" onClick={onClose}>キャンセル</button>
-              <button className="tbl-btn tbl-btn-primary" onClick={handleInit} disabled={processing}>
-                {processing ? "初期化中..." : "初期化して開く"}
-              </button>
-            </div>
-          </>
+          <div
+            data-testid="workspace-status"
+            data-status="needsInit"
+            style={{ padding: "8px 12px", background: "var(--warning-bg, #fff3cd)", borderRadius: "4px", marginBottom: "12px", color: "var(--warning-text, #856404)" }}
+          >
+            <i className="bi bi-exclamation-triangle" /> フォルダは空です。初期化してワークスペースを作成しますか？
+          </div>
         )}
 
         {status === "notFound" && (
-          <>
-            <div style={{ padding: "8px 12px", background: "var(--danger-bg, #f8d7da)", borderRadius: "4px", marginBottom: "12px", color: "var(--danger-text, #721c24)" }}>
-              <i className="bi bi-x-circle" /> フォルダが見つかりません。パスを確認するか、このパスに新規作成できます。
-            </div>
-            <div className="tbl-modal-btns">
-              <button className="tbl-btn tbl-btn-ghost" onClick={onClose}>キャンセル</button>
-              <button
-                className="tbl-btn tbl-btn-ghost"
-                onClick={handleInspect}
-                disabled={!path.trim()}
-              >
-                <i className="bi bi-arrow-clockwise" /> 再確認
-              </button>
-              <button
-                className="tbl-btn tbl-btn-primary"
-                onClick={handleInit}
-                disabled={processing || !path.trim()}
-                title="このパスにフォルダを作成し、harmony.json を初期化します"
-              >
-                {processing ? "作成中..." : "フォルダを作成して初期化"}
-              </button>
-            </div>
-          </>
+          <div
+            data-testid="workspace-status"
+            data-status="notFound"
+            style={{ padding: "8px 12px", background: "var(--danger-bg, #f8d7da)", borderRadius: "4px", marginBottom: "12px", color: "var(--danger-text, #721c24)" }}
+          >
+            <i className="bi bi-x-circle" /> フォルダが見つかりません。パスを確認するか、このパスに新規作成できます。
+          </div>
         )}
 
         {status === "invalid" && (
-          <>
-            <div style={{ padding: "8px 12px", background: "var(--danger-bg, #f8d7da)", borderRadius: "4px", marginBottom: "12px", color: "var(--danger-text, #721c24)" }}>
-              <i className="bi bi-exclamation-circle" /> harmony.json が不正です。ファイルを修正するか、初期化し直してください。
-              {errorMsg && <div style={{ fontSize: "0.8rem", marginTop: "4px", opacity: 0.8 }}>{errorMsg}</div>}
-            </div>
-            <div className="tbl-modal-btns">
-              <button className="tbl-btn tbl-btn-ghost" onClick={onClose}>キャンセル</button>
-              <button
-                className="tbl-btn tbl-btn-primary"
-                onClick={handleInspect}
-                disabled={!path.trim()}
-              >
-                <i className="bi bi-arrow-clockwise" /> 再確認
-              </button>
-            </div>
-          </>
+          <div
+            data-testid="workspace-status"
+            data-status="invalid"
+            style={{ padding: "8px 12px", background: "var(--danger-bg, #f8d7da)", borderRadius: "4px", marginBottom: "12px", color: "var(--danger-text, #721c24)" }}
+          >
+            <i className="bi bi-exclamation-circle" /> harmony.json が不正です。ファイルを修正するか、初期化し直してください。
+            {errorMsg && <div style={{ fontSize: "0.8rem", marginTop: "4px", opacity: 0.8 }}>{errorMsg}</div>}
+          </div>
         )}
 
         {status === "error" && (
-          <>
-            <div style={{ padding: "8px 12px", background: "var(--danger-bg, #f8d7da)", borderRadius: "4px", marginBottom: "12px", color: "var(--danger-text, #721c24)" }}>
-              <i className="bi bi-x-circle" /> エラー: {errorMsg}
-            </div>
-            <div className="tbl-modal-btns">
-              <button className="tbl-btn tbl-btn-ghost" onClick={onClose}>閉じる</button>
-              <button
-                className="tbl-btn tbl-btn-primary"
-                onClick={handleInspect}
-                disabled={!path.trim()}
-              >
-                <i className="bi bi-arrow-clockwise" /> 再試行
-              </button>
-            </div>
-          </>
+          <div
+            data-testid="workspace-status"
+            data-status="error"
+            style={{ padding: "8px 12px", background: "var(--danger-bg, #f8d7da)", borderRadius: "4px", marginBottom: "12px", color: "var(--danger-text, #721c24)" }}
+          >
+            <i className="bi bi-x-circle" /> エラー: {errorMsg}
+          </div>
         )}
 
-        {errorMsg && status !== "error" && status !== "notFound" && (
+        {/* アクションボタン:
+            - debounced auto-inspect が走るため通常は「確認」を押す必要はないが、
+              即時再検証したい場合のために secondary 「確認」ボタンを常設する (#858 + #755 e2e regression 防止)
+            - status に応じて primary アクション (開く / 初期化 / 作成) を出す */}
+        <div className="tbl-modal-btns">
+          <button className="tbl-btn tbl-btn-ghost" onClick={onClose}>キャンセル</button>
+
+          <button
+            className="tbl-btn tbl-btn-ghost"
+            onClick={() => runInspect(path)}
+            disabled={!path.trim() || status === "inspecting"}
+            title="入力したパスの状態を即時確認します (通常は自動で実行)"
+          >
+            <i className="bi bi-search" /> 確認
+          </button>
+
+          {status === "ready" && (
+            <button className="tbl-btn tbl-btn-primary" onClick={handleOpen} disabled={processing}>
+              {processing ? "開いています..." : "開く"}
+            </button>
+          )}
+
+          {status === "needsInit" && (
+            <button className="tbl-btn tbl-btn-primary" onClick={handleInit} disabled={processing}>
+              {processing ? "初期化中..." : "初期化して開く"}
+            </button>
+          )}
+
+          {status === "notFound" && (
+            <button
+              className="tbl-btn tbl-btn-primary"
+              onClick={handleInit}
+              disabled={processing || !path.trim()}
+              title="このパスにフォルダを作成し、harmony.json を初期化します"
+            >
+              {processing ? "作成中..." : "フォルダを作成して初期化"}
+            </button>
+          )}
+        </div>
+
+        {errorMsg && status !== "error" && status !== "notFound" && status !== "invalid" && (
           <div style={{ color: "var(--danger-text, #721c24)", fontSize: "0.85rem", marginTop: "8px" }}>
             {errorMsg}
           </div>

--- a/frontend/src/components/workspace/WorkspaceListView.tsx
+++ b/frontend/src/components/workspace/WorkspaceListView.tsx
@@ -135,6 +135,9 @@ export function AddWorkspaceDialog({ onClose, onAdded }: AddWorkspaceDialogProps
       window.clearTimeout(debounceRef.current);
     }
     if (!path.trim()) {
+      // 空入力に戻した瞬間、進行中 inspect の遅延 response が
+      // idle 状態を ready/notFound 等に上書きしないよう seq を bump して破棄する
+      inflightSeqRef.current++;
       setStatus("idle");
       setInspectName(null);
       setErrorMsg(null);
@@ -249,6 +252,18 @@ export function AddWorkspaceDialog({ onClose, onAdded }: AddWorkspaceDialogProps
               value={path}
               onChange={(e) => { setPath(e.target.value); setShowRecent(true); }}
               onFocus={() => setShowRecent(true)}
+              onKeyDown={(e) => {
+                // Escape: dropdown を閉じる (input は focus に残す)
+                // Tab: dropdown を閉じてから次要素へ移動 (default 動作)
+                if (e.key === "Escape") {
+                  if (showRecent) {
+                    e.stopPropagation();
+                    setShowRecent(false);
+                  }
+                } else if (e.key === "Tab") {
+                  setShowRecent(false);
+                }
+              }}
               placeholder={placeholder}
               autoFocus
               spellCheck={false}

--- a/frontend/src/store/workspaceStore.ts
+++ b/frontend/src/store/workspaceStore.ts
@@ -32,6 +32,13 @@ export interface WorkspaceInspectResult {
   reason?: string;
 }
 
+/** backend ホスト OS 情報 (#858: WSL2 環境で placeholder を切り替えるため) */
+export interface HostInfo {
+  platform: "linux" | "win32" | "darwin" | "other";
+  isWSL: boolean;
+  homeDir: string;
+}
+
 // ─── 内部ストア ───────────────────────────────────────────────────────────────
 
 type Listener = () => void;
@@ -155,6 +162,34 @@ async function _doLoadWorkspaces(): Promise<void> {
 export async function inspectWorkspace(path: string): Promise<WorkspaceInspectResult> {
   const result = (await mcpBridge.request("workspace.inspect", { path })) as WorkspaceInspectResult;
   return result;
+}
+
+let _hostInfoCache: HostInfo | null = null;
+let _hostInfoInflight: Promise<HostInfo> | null = null;
+
+/**
+ * backend のホスト OS 情報を取得 (セッション内 1 回キャッシュ、#858)。
+ * WSL2 / macOS / Windows でパス入力欄の placeholder 文字列を切り替えるために使う。
+ */
+export async function getHostInfo(): Promise<HostInfo> {
+  if (_hostInfoCache) return _hostInfoCache;
+  if (_hostInfoInflight) return _hostInfoInflight;
+  _hostInfoInflight = (async () => {
+    try {
+      const info = (await mcpBridge.request("workspace.hostInfo")) as HostInfo;
+      _hostInfoCache = info;
+      return info;
+    } finally {
+      _hostInfoInflight = null;
+    }
+  })();
+  return _hostInfoInflight;
+}
+
+/** @internal テスト専用: hostInfo キャッシュをクリア */
+export function __resetHostInfoCacheForTest(): void {
+  _hostInfoCache = null;
+  _hostInfoInflight = null;
 }
 
 export async function openWorkspace(pathOrId: string, useId = false): Promise<string> {


### PR DESCRIPTION
## 関連

- Closes #858
- 仕様: docs/spec/workspace.md §3.1-3.2 (workspace 選択 UI、AddWorkspaceDialog の操作経路)
  - WSL2 環境で「フォルダ参照」ダイアログが Linux パスに到達できない UX 障害を解消
  - 既存 `inspectWorkspacePath` API を流用、新規エンドポイント `workspace.hostInfo` 1 件追加

## 概要

WSL2 環境では Windows ブラウザの「フォルダ参照」が Linux パス (`/home/<user>/...`) に navigate できず、設計者は入力欄に手でフルパスを書くしかなかった。テキスト入力欄を主役に押し上げ、host OS に応じた placeholder / debounced auto-inspect / recent dropdown を導入して、入力負荷を最小化した。

## 主な変更

- **backend ホスト検出**: `hostInfo.ts` 新設 (`process.platform` + `/proc/version` の WSL マーカー判定 + `os.homedir()`)、`workspace.hostInfo` WS ハンドラ追加
- **frontend store**: `getHostInfo()` (セッション 1 回キャッシュ) + `HostInfo` 型公開
- **AddWorkspaceDialog 改修**:
  - OS-aware placeholder: WSL/Linux は `/home/<user>/projects/my-app`、Windows は `C:\\Users\\<user>\\projects\\my-app`、macOS は `/Users/<user>/projects/my-app`。`workspaces/my-app` 形式も並記して #755 の e2e regression 防止
  - **WSL 検出時のヒント**: 「Windows ブラウザの『フォルダ参照』では Linux パスに到達できない」旨を明示
  - **debounced auto-inspect** (400ms): 「確認」ボタン押下不要で `workspace.inspect` が走り、status badge を inline 描画 (`data-testid="workspace-status"` + `data-status` 属性)
  - 「確認」ボタンを secondary action として残存 (即時検証経路を維持、既存 e2e の assertion を破壊しない)
  - **recent dropdown**: 入力欄 focus / 入力時に最近使ったワークスペースを prefix-match で表示、クリックで絶対パスを補完
  - 古い inspect 結果で UI を上書きしない seq guard
- **既存 e2e** `workspace-default-path.spec.ts` は **無改変** (確認ボタン押下経路を維持)

## 仕様逐条突合 (自己申告)

ISSUE #858 の検証項目:

- [x] Windows + WSL2 Edge/Chrome で `/home/<user>/projects/diary` を入力 → `status: ready` 表示 → open 成功
  - host info `isWSL=true` のとき WSL ヒント表示 → `WorkspaceListView.tsx:259-264` ✓
  - 入力 400ms 後に inspect 自動実行 → `WorkspaceListView.tsx:131-152` ✓
  - status=ready で「開く」ボタン → `WorkspaceListView.tsx:373-377` ✓
- [x] notFound / needsInit / invalid 各状態がリアルタイム表示
  - `WorkspaceListView.tsx:316-358` (4 status badges、`data-testid="workspace-status"`) ✓
- [x] recent dropdown が動作
  - filter ロジック → `WorkspaceListView.tsx:213-220` ✓
  - dropdown 描画 → `WorkspaceListView.tsx:267-290` ✓
  - クリックで補完 → `WorkspaceListView.tsx:240-244` ✓

ISSUE 修正案 A (テキスト入力欄を第一候補に格上げ):
- 入力欄 `autoFocus` + `flex: 1` + monospace + `data-testid` で primary 化 → `WorkspaceListView.tsx:228-241` ✓
- 「フォルダ参照」アイコンボタンは `tabIndex={-1}` で secondary 維持 → `WorkspaceListView.tsx:243-252` ✓

ISSUE 修正案 B (パス入力 UX 強化):
- リアルタイム validate (debounced inspect) → `WorkspaceListView.tsx:131-152` ✓
- recent から history dropdown → `WorkspaceListView.tsx:267-290` ✓
- ホスト OS 検出で placeholder 切替 → `WorkspaceListView.tsx:64-79` + `hostInfo.ts:32-42` ✓

(ISSUE 修正案 C — File System Access API 統合 — はスコープ外、別 ISSUE 案件として明記)

## レビューで特に見てほしい箇所

- **「確認」ボタンの去就**: 一度撤去しかけたが、debounce 待ちを回避したいケース + 既存 e2e の assertion 維持のため secondary action として残した。debounced auto-inspect とのダブルレーンになっているが UX として冗長ではないか
- **inspect 競合の seq guard**: `inflightSeqRef` で古い結果を破棄しているが、Promise キャンセルではないので abort 後も 1 つ無駄な fetch が走る。実害はないが意図通りか
- **recent dropdown の click-outside 判定**: `inputRef.current.contains` + `dropdown.contains` の二段で外部クリックを検知。Modal overlay クリックも transparent に通って onClose を発火させたいケースとの相性
- **placeholder / WSL ヒント文言**: WSL2 検出時の説明文が冗長すぎないか (i18n 観点ではないが日本語の長さ)

## テスト

- **Vitest (frontend)**: 9 件 (新規 7 件) — `AddWorkspaceDialog.test.tsx`
  - placeholder に `workspaces/my-app` (#755 regression)
  - WSL 環境で Linux 形式絶対パス + WSL ヒント
  - Windows ホストでバックスラッシュ形式
  - debounced auto-inspect 400ms + status badge
  - 入力欄 focus で recent dropdown
  - dropdown クリックで input 補完
  - prefix-match フィルタ
- **Vitest (backend)**: 3 件 (新規 3 件) — `hostInfo.test.ts`
  - platform / homeDir 取得
  - 非 Linux で isWSL=false
  - キャッシュ動作
- **Playwright (E2E)**: 8 件 (新規 4 件 + 既存 4 件無改変)
  - 新規 `workspace-os-aware-input.spec.ts`: WSL ヒント表示 / debounced auto-inspect / 確認ボタン即時検証 / recent dropdown
  - 既存 `workspace-default-path.spec.ts`: 無改変で全 pass

## UI 影響 / AI smoke test

- [x] UI 影響あり (AI が Playwright で smoke test 実施済み)
- [ ] UI 影響なし (auto テスト pass のみ)

### UI 影響ありの場合、AI smoke test で確認した項目

- [x] `AddWorkspaceDialog`: WSL2 ヒント文言 + OS-aware placeholder が正しく描画されていることをスクリーンショットで確認 (`.tmp/screenshots/858-dialog-empty.png`)
- [x] パス入力 → 800ms 後に「ワークスペースが見つかりました — 日記アプリ」緑 badge + 「開く」ボタンが出現することをスクリーンショットで確認 (`.tmp/screenshots/858-dialog-typed.png`)
- [x] backend `workspace.hostInfo` が `{platform: "linux", isWSL: true, homeDir: "/home/hidekatsu"}` を返すことを WS 直叩きで確認
- [x] 既存機能 (workspaces/ ヒント / キャンセル動作 / WorkspaceSelectView 経由のダイアログ起動) のリグレッションなし

## spec 側の不足点 / 提案

N/A (本 ISSUE スコープ内で完結。File System Access API 統合 (修正案 C) は ISSUE #858 で「別 ISSUE 案件」として明記済み)

## レビュー担当への申し送り

- 既存 `workspace-default-path.spec.ts` を無改変で維持しているため、新ダイアログでも「確認」ボタンが secondary に存在する。これを撤去して auto-inspect 一本化するか、両立させるかは UX 判断が分かれる箇所。今回は両立を選択 (理由: 既存 e2e regression 防止 + debounce 待ち回避操作の維持)
- WSL 検出は `/proc/version` の `Microsoft|WSL` 文字列マッチのみ。WSL1 環境は手元で再現できておらず、`/proc/version` の文字列が同じか未検証 (WSL1 / WSL2 ともに Microsoft マーカーは含まれる想定)
- recent dropdown は WorkspaceListView の `getState()` 結果をそのまま参照 (subscribe してないので、ダイアログ表示中の recent 変更は反映されない)。ダイアログは短時間で閉じる前提なので問題ないと判断