### PR TITLE
feat(samples): examples/diary follow-up シリーズ — 認証/写真/タグ/events (#861-#864)

### DIFF
--- a/examples/diary/README.md
+++ b/examples/diary/README.md
@@ -30,7 +30,7 @@ examples/diary/
 ├── README.md                    # 本ファイル
 └── harmony/
     ├── tables/                  # 5 テーブル (User / Post / Tag / PostTag / Photo)
-    ├── process-flows/           # 9 ProcessFlow (CRUD 5 + AI 4)
+    ├── process-flows/           # 17 ProcessFlow (CRUD 5 + AI 4 + 認証 3 + 写真 1 + タグ CRUD 4)
     ├── screens/                 # 5 screens (.json + .design.json)
     ├── conventions/
     │   └── catalog.json         # i18n / regex / limit / msg (メッセージ / 境界値 等)
@@ -40,9 +40,9 @@ examples/diary/
     └── extensions/
 ```
 
-## ProcessFlow 一覧 (9 件)
+## ProcessFlow 一覧 (17 件)
 
-### CRUD + 検索 (5 件、kind: screen)
+### 投稿 CRUD + 検索 (5 件)
 
 | ID | name | HTTP |
 |---|---|---|
@@ -60,6 +60,29 @@ examples/diary/
 | `a9b0c1d2-...` | AIタグ提案 | POST /api/ai/tag-suggest | title+body → tag 候補 |
 | `b0c1d2e3-...` | AI画像alt生成 | POST /api/ai/alt-text | photo URL → alt text |
 | `c1d2e3f4-...` | AI文章校正 | POST /api/ai/proofread | text + style → 校正結果 |
+
+### 認証 (3 件、#863)
+
+| ID | name | HTTP |
+|---|---|---|
+| `1ce956c5-...` | ログイン | POST /api/auth/login |
+| `9537764e-...` | トークン更新 | POST /api/auth/refresh |
+| `46436b69-...` | ログアウト | POST /api/auth/logout |
+
+### 写真 (1 件、#861)
+
+| ID | name | HTTP |
+|---|---|---|
+| `2fecbf99-...` | 写真アップロード | POST /api/upload (multipart/form-data) |
+
+### タグ CRUD (4 件、#862)
+
+| ID | name | HTTP |
+|---|---|---|
+| `803764e4-...` | タグ一覧取得 | GET /api/tags |
+| `46b99455-...` | タグ作成 | POST /api/tags |
+| `8cc24fea-...` | タグ更新 | PUT /api/tags/:id |
+| `305509f7-...` | タグ削除 | DELETE /api/tags/:id |
 
 ## screens 一覧 (5 件)
 
@@ -98,18 +121,18 @@ examples/diary/
 
 ## Known limitations (follow-up ISSUE)
 
-| 項目 | ISSUE |
-|---|---|
-| 写真アップロード ProcessFlow 未定義 (現状 URL 直入力モック) | #861 |
-| タグ CRUD 完全化 (update/delete ProcessFlow 不在) | #862 |
-| 認証フロー (login/refresh/logout) ProcessFlow として未明示 | #863 |
-| screen items の `events[]` 補完 — `/generate-code` 精度向上 | #864 |
-| AI provider 抽象化 (Ollama / OpenAI 切替対応) | #865 |
-| AI モデル / 環境値参照 (現状リテラル文字列で迂回) | #859 (framework 改善) |
+| 項目 | ISSUE | 状態 |
+|---|---|---|
+| 写真アップロード ProcessFlow 未定義 (現状 URL 直入力モック) | #861 | ✅ 解消 |
+| タグ CRUD 完全化 (update/delete ProcessFlow 不在) | #862 | ✅ 解消 |
+| 認証フロー (login/refresh/logout) ProcessFlow として未明示 | #863 | ✅ 解消 |
+| screen items の `events[]` 補完 — `/generate-code` 精度向上 | #864 | ✅ 解消 |
+| AI provider 抽象化 (Ollama / OpenAI 切替対応) | #865 | open |
+| AI モデル / 環境値参照 (現状リテラル文字列で迂回) | #859 | ✅ 解消 (PR #921) |
 
 ## 検証
 
 ```bash
 cd frontend && npx tsx scripts/validate-samples.ts ../examples/diary
-# → 1 / 9 flows / 5 tables / 5 screens / 1 conventions catalogs (All validations passed)
+# → 17 / 17 flows / 5 tables / 5 screens / 1 conventions catalogs (All validations passed)
 ```

--- a/examples/diary/harmony.json
+++ b/examples/diary/harmony.json
@@ -7,7 +7,7 @@
     "name": "日記アプリ",
     "description": "Harmony フレームワーク dogfood — 個人向け日記/ブログアプリ。投稿 (タイトル / 本文 / 写真ギャラリー / タグ) + AI assist (要約 / タグ提案 / 文章校正 / 画像 alt 自動生成) + 全文検索。techStack: NestJS + Next.js + Prisma + SQLite + Tailwind。",
     "createdAt": "2026-05-06T12:40:00.000Z",
-    "updatedAt": "2026-05-06T12:40:00.000Z",
+    "updatedAt": "2026-05-07T00:00:00.000Z",
     "mode": "upstream",
     "maturity": "draft"
   },
@@ -217,6 +217,78 @@
         "actionCount": 1,
         "maturity": "draft",
         "updatedAt": "2026-05-06T14:00:00.000Z"
+      },
+      {
+        "id": "1ce956c5-7aa9-47b5-bb38-ca392ad73518",
+        "no": 10,
+        "name": "ログイン",
+        "kind": "screen",
+        "actionCount": 1,
+        "maturity": "draft",
+        "updatedAt": "2026-05-07T00:00:00.000Z"
+      },
+      {
+        "id": "9537764e-3fe9-459d-8172-00d69a575c09",
+        "no": 11,
+        "name": "トークン更新",
+        "kind": "screen",
+        "actionCount": 1,
+        "maturity": "draft",
+        "updatedAt": "2026-05-07T00:00:00.000Z"
+      },
+      {
+        "id": "46436b69-99f2-48b3-a5fa-07bf9fcd1478",
+        "no": 12,
+        "name": "ログアウト",
+        "kind": "screen",
+        "actionCount": 1,
+        "maturity": "draft",
+        "updatedAt": "2026-05-07T00:00:00.000Z"
+      },
+      {
+        "id": "2fecbf99-6a4e-4c62-840c-59d96e48ecb6",
+        "no": 13,
+        "name": "写真アップロード",
+        "kind": "screen",
+        "actionCount": 1,
+        "maturity": "draft",
+        "updatedAt": "2026-05-07T00:00:00.000Z"
+      },
+      {
+        "id": "803764e4-c27d-47fd-b3d9-924c1fa28bd8",
+        "no": 14,
+        "name": "タグ一覧取得",
+        "kind": "screen",
+        "actionCount": 1,
+        "maturity": "draft",
+        "updatedAt": "2026-05-07T00:00:00.000Z"
+      },
+      {
+        "id": "46b99455-a011-4419-937f-a5ef8368e694",
+        "no": 15,
+        "name": "タグ作成",
+        "kind": "screen",
+        "actionCount": 1,
+        "maturity": "draft",
+        "updatedAt": "2026-05-07T00:00:00.000Z"
+      },
+      {
+        "id": "8cc24fea-f497-432b-8496-5d86dea1c98b",
+        "no": 16,
+        "name": "タグ更新",
+        "kind": "screen",
+        "actionCount": 1,
+        "maturity": "draft",
+        "updatedAt": "2026-05-07T00:00:00.000Z"
+      },
+      {
+        "id": "305509f7-d118-459a-8acb-18780e4fde68",
+        "no": 17,
+        "name": "タグ削除",
+        "kind": "screen",
+        "actionCount": 1,
+        "maturity": "draft",
+        "updatedAt": "2026-05-07T00:00:00.000Z"
       }
     ],
     "sequences": [],

--- a/examples/diary/harmony/process-flows/1ce956c5-7aa9-47b5-bb38-ca392ad73518.json
+++ b/examples/diary/harmony/process-flows/1ce956c5-7aa9-47b5-bb38-ca392ad73518.json
@@ -1,0 +1,300 @@
+{
+  "$schema": "../../../../schemas/v3/process-flow.v3.schema.json",
+  "meta": {
+    "id": "1ce956c5-7aa9-47b5-bb38-ca392ad73518",
+    "name": "ログイン",
+    "description": "username + password を受け取り、users テーブルで認証して JWT (access token + refresh token) を発行する処理フロー。1 ユーザー個人運用前提 + JWT stateless 認証。失敗ケース (ユーザー不在 / パスワード不一致) は同一の 401 INVALID_CREDENTIALS を返してユーザー列挙攻撃を防ぐ。",
+    "kind": "screen",
+    "maturity": "draft",
+    "createdAt": "2026-05-07T00:00:00.000Z",
+    "updatedAt": "2026-05-07T00:00:00.000Z"
+  },
+  "context": {
+    "catalogs": {
+      "errors": {
+        "VALIDATION_ERROR": {
+          "httpStatus": 400,
+          "defaultMessage": "入力値が不正です。",
+          "responseId": "400-validation",
+          "description": "username regex / password minLength 違反。"
+        },
+        "INVALID_CREDENTIALS": {
+          "httpStatus": 401,
+          "defaultMessage": "ユーザー名またはパスワードが正しくありません。",
+          "responseId": "401-unauthorized",
+          "description": "ユーザー不在 / パスワード不一致のどちらも同じ 401 を返す (ユーザー列挙攻撃対策)。"
+        }
+      },
+      "secrets": {
+        "jwtAccessSecret": {
+          "source": "env",
+          "name": "JWT_ACCESS_SECRET",
+          "description": "アクセストークン署名用キー (HS256)。"
+        },
+        "jwtRefreshSecret": {
+          "source": "env",
+          "name": "JWT_REFRESH_SECRET",
+          "description": "リフレッシュトークン署名用キー (HS256、access とは別キー)。"
+        }
+      },
+      "envVars": {
+        "JWT_ACCESS_TTL": {
+          "type": "string",
+          "default": "1h",
+          "description": "アクセストークンの有効期限 (zeit/ms 形式)。"
+        },
+        "JWT_REFRESH_TTL": {
+          "type": "string",
+          "default": "30d",
+          "description": "リフレッシュトークンの有効期限 (rememberMe=true 時)。false 時はアクセストークンと同等。"
+        }
+      }
+    }
+  },
+  "actions": [
+    {
+      "id": "act-001",
+      "name": "ログイン",
+      "trigger": "submit",
+      "description": "username + password を受け取り、users から passwordHash を取得 → bcrypt で照合 → 成功時に JWT (access + refresh) を発行して返す。",
+      "maturity": "draft",
+      "httpRoute": {
+        "method": "POST",
+        "path": "/api/auth/login",
+        "auth": "none"
+      },
+      "inputs": [
+        {
+          "name": "username",
+          "label": "ユーザー名",
+          "type": "string",
+          "required": true,
+          "description": "3-32 文字の英数字 + ハイフン/アンダースコア。"
+        },
+        {
+          "name": "password",
+          "label": "パスワード",
+          "type": "string",
+          "required": true,
+          "description": "8-128 文字。実装側で平文を受け取り bcrypt.compare で検証する。ログ出力 / 永続化は禁止。"
+        },
+        {
+          "name": "rememberMe",
+          "label": "ログイン状態を保持",
+          "type": "boolean",
+          "required": false,
+          "description": "true で refresh token TTL を JWT_REFRESH_TTL に拡張。false ならアクセストークンと同じ短期 TTL。"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "accessToken",
+          "label": "アクセストークン",
+          "type": "string",
+          "description": "短期 JWT。Authorization: Bearer ヘッダで使用。"
+        },
+        {
+          "name": "refreshToken",
+          "label": "リフレッシュトークン",
+          "type": "string",
+          "description": "長期 JWT。/api/auth/refresh で新 access token を取得する用途。"
+        },
+        {
+          "name": "user",
+          "label": "ログインユーザー",
+          "type": {
+            "kind": "object",
+            "fields": [
+              { "name": "id", "type": "integer", "required": true },
+              { "name": "username", "type": "string", "required": true },
+              { "name": "displayName", "type": "string" }
+            ]
+          },
+          "description": "ログインユーザーの ID + 表示用情報 (UI ヘッダ等に使用)。"
+        }
+      ],
+      "responses": [
+        {
+          "id": "200-ok",
+          "status": 200,
+          "description": "認証成功。",
+          "when": "username 一致 + password 検証成功した場合。"
+        },
+        {
+          "id": "400-validation",
+          "status": 400,
+          "description": "バリデーションエラー。",
+          "when": "username regex / password minLength 違反。"
+        },
+        {
+          "id": "401-unauthorized",
+          "status": 401,
+          "description": "認証失敗。",
+          "when": "ユーザー不在 / パスワード不一致。"
+        }
+      ],
+      "steps": [
+        {
+          "id": "step-01",
+          "kind": "validation",
+          "description": "username 形式チェック (regex)、password 必須 + minLength 8。",
+          "rules": [
+            {
+              "field": "username",
+              "type": "required",
+              "severity": "error",
+              "message": "ユーザー名を入力してください。"
+            },
+            {
+              "field": "username",
+              "type": "regex",
+              "patternRef": "@conv.regex.username",
+              "severity": "error",
+              "message": "@conv.msg.validation.username.format"
+            },
+            {
+              "field": "password",
+              "type": "required",
+              "severity": "error",
+              "message": "パスワードを入力してください。"
+            },
+            {
+              "field": "password",
+              "type": "minLength",
+              "length": 8,
+              "severity": "error",
+              "message": "パスワードは 8 文字以上で入力してください。"
+            }
+          ],
+          "inlineBranch": {
+            "ok": [],
+            "ng": [
+              {
+                "id": "step-01-ng-01",
+                "kind": "return",
+                "description": "400 バリデーションエラーを返す。",
+                "responseId": "400-validation",
+                "bodyExpression": "{ code: 'VALIDATION_ERROR', message: '入力値が不正です。', details: @fieldErrors }"
+              }
+            ]
+          }
+        },
+        {
+          "id": "step-02",
+          "kind": "dbAccess",
+          "description": "username で users を検索し、認証に必要な id / passwordHash + UI 表示用 displayName を取得する。",
+          "tableId": "695939b7-f3f7-473f-b0cf-a2ccfe5da8fa",
+          "operation": "SELECT",
+          "sql": "SELECT id AS \"userId\", username AS \"username\", display_name AS \"displayName\", password_hash AS \"passwordHash\" FROM users WHERE username = @inputs.username LIMIT 1",
+          "outputBinding": {
+            "name": "userRow"
+          },
+          "lineage": {
+            "reads": [
+              {
+                "tableId": "695939b7-f3f7-473f-b0cf-a2ccfe5da8fa",
+                "purpose": "auth-lookup"
+              }
+            ]
+          }
+        },
+        {
+          "id": "step-03",
+          "kind": "branch",
+          "description": "ユーザーが見つからない場合は 401 を返す (404 ではなく 401 で列挙攻撃対策)。",
+          "branches": [
+            {
+              "id": "br-03-a",
+              "code": "A",
+              "label": "ユーザー不在",
+              "condition": {
+                "kind": "expression",
+                "expression": "@userRow == null"
+              },
+              "steps": [
+                {
+                  "id": "step-03-a-01",
+                  "kind": "return",
+                  "description": "401 認証失敗を返す。",
+                  "responseId": "401-unauthorized",
+                  "bodyExpression": "{ code: 'INVALID_CREDENTIALS', message: 'ユーザー名またはパスワードが正しくありません。' }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-03-else",
+            "code": "B",
+            "label": "ユーザー存在",
+            "steps": []
+          }
+        },
+        {
+          "id": "step-04",
+          "kind": "compute",
+          "description": "bcrypt で入力パスワードと password_hash を比較する。実装は bcrypt.compare(plain, hash) を呼び、true/false を返す。",
+          "expression": "bcryptCompare(@inputs.password, @userRow.passwordHash)",
+          "outputBinding": {
+            "name": "passwordValid"
+          }
+        },
+        {
+          "id": "step-05",
+          "kind": "branch",
+          "description": "password 検証が失敗した場合は 401 を返す。",
+          "branches": [
+            {
+              "id": "br-05-a",
+              "code": "A",
+              "label": "password 不一致",
+              "condition": {
+                "kind": "expression",
+                "expression": "@passwordValid != true"
+              },
+              "steps": [
+                {
+                  "id": "step-05-a-01",
+                  "kind": "return",
+                  "description": "401 認証失敗を返す。",
+                  "responseId": "401-unauthorized",
+                  "bodyExpression": "{ code: 'INVALID_CREDENTIALS', message: 'ユーザー名またはパスワードが正しくありません。' }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-05-else",
+            "code": "B",
+            "label": "password 一致",
+            "steps": []
+          }
+        },
+        {
+          "id": "step-06",
+          "kind": "compute",
+          "description": "アクセストークンを発行する。HS256, payload: { sub: userId, type: 'access' }, ttl: @env.JWT_ACCESS_TTL。",
+          "expression": "jwtSign({ sub: @userRow.userId, type: 'access' }, @secret.jwtAccessSecret, { expiresIn: @env.JWT_ACCESS_TTL })",
+          "outputBinding": {
+            "name": "accessToken"
+          }
+        },
+        {
+          "id": "step-07",
+          "kind": "compute",
+          "description": "リフレッシュトークンを発行する。rememberMe=true なら長期 TTL (@env.JWT_REFRESH_TTL)、false なら短期 (@env.JWT_ACCESS_TTL)。",
+          "expression": "jwtSign({ sub: @userRow.userId, type: 'refresh' }, @secret.jwtRefreshSecret, { expiresIn: @inputs.rememberMe == true ? @env.JWT_REFRESH_TTL : @env.JWT_ACCESS_TTL })",
+          "outputBinding": {
+            "name": "refreshToken"
+          }
+        },
+        {
+          "id": "step-08",
+          "kind": "return",
+          "description": "200 認証成功 + access/refresh トークン + ユーザー基本情報を返す。",
+          "responseId": "200-ok",
+          "bodyExpression": "{ accessToken: @accessToken, refreshToken: @refreshToken, user: { id: @userRow.userId, username: @userRow.username, displayName: @userRow.displayName } }"
+        }
+      ]
+    }
+  ]
+}

--- a/examples/diary/harmony/process-flows/2fecbf99-6a4e-4c62-840c-59d96e48ecb6.json
+++ b/examples/diary/harmony/process-flows/2fecbf99-6a4e-4c62-840c-59d96e48ecb6.json
@@ -1,0 +1,325 @@
+{
+  "$schema": "../../../../schemas/v3/process-flow.v3.schema.json",
+  "meta": {
+    "id": "2fecbf99-6a4e-4c62-840c-59d96e48ecb6",
+    "name": "写真アップロード",
+    "description": "投稿に紐付く写真をアップロードする処理フロー。multipart/form-data で受け取り、ローカルファイルシステム (uploads/photos/) に保存 → サムネイル生成 → 寸法 + EXIF 抽出 → photos テーブル INSERT を 1 アップロード単位で実行する。photos.post_id は NOT NULL のため postId は必須 (post 作成後の upload を前提)。S3 / R2 互換ストレージへの切替は v2 で context.catalogs.externalSystems に photoStorage を登録して step-04 を externalSystem に置き換える。",
+    "kind": "screen",
+    "maturity": "draft",
+    "createdAt": "2026-05-07T00:00:00.000Z",
+    "updatedAt": "2026-05-07T00:00:00.000Z"
+  },
+  "context": {
+    "catalogs": {
+      "errors": {
+        "VALIDATION_ERROR": {
+          "httpStatus": 400,
+          "defaultMessage": "アップロード内容が不正です。",
+          "responseId": "400-validation",
+          "description": "postId / file 未指定、mimeType 非対応、ファイルサイズ超過のいずれか。"
+        },
+        "POST_NOT_FOUND": {
+          "httpStatus": 404,
+          "defaultMessage": "投稿が見つかりません。",
+          "responseId": "404-not-found",
+          "description": "指定 postId の投稿が存在しないか、ログインユーザーの投稿ではない。"
+        },
+        "STORAGE_ERROR": {
+          "httpStatus": 500,
+          "defaultMessage": "ファイル保存に失敗しました。",
+          "responseId": "500-internal",
+          "description": "ファイルシステム書き込み / サムネイル生成のいずれかが失敗した場合。"
+        },
+        "PHOTO_UPLOAD_FAILED": {
+          "httpStatus": 500,
+          "defaultMessage": "写真の登録に失敗しました。",
+          "responseId": "500-internal",
+          "description": "photos テーブルへの INSERT が想定外に 0 行を返した場合。"
+        }
+      },
+      "envVars": {
+        "PHOTO_UPLOAD_DIR": {
+          "type": "string",
+          "default": "uploads/photos",
+          "description": "ローカルストレージ時のアップロード先ディレクトリ (relative or absolute)。"
+        },
+        "PHOTO_THUMBNAIL_WIDTH": {
+          "type": "number",
+          "default": 400,
+          "description": "サムネイル生成時の幅 (px)。masonry レイアウトのカード幅に合わせる。"
+        }
+      }
+    },
+    "ambientVariables": [
+      {
+        "name": "sessionUserId",
+        "type": "integer",
+        "required": true,
+        "description": "アップロード実行ユーザー ID (JWT から抽出)。post 所有者確認に使用。"
+      }
+    ]
+  },
+  "actions": [
+    {
+      "id": "act-001",
+      "name": "写真アップロード",
+      "trigger": "submit",
+      "description": "multipart/form-data で file + postId を受け取り、ファイル保存 → サムネイル生成 → 寸法 / EXIF 抽出 → photos へ INSERT する。",
+      "maturity": "draft",
+      "httpRoute": {
+        "method": "POST",
+        "path": "/api/upload",
+        "auth": "required"
+      },
+      "inputs": [
+        {
+          "name": "postId",
+          "label": "投稿ID",
+          "type": "integer",
+          "required": true,
+          "description": "アップロード写真の関連先 post.id。photos.post_id は NOT NULL のため必須。"
+        },
+        {
+          "name": "file",
+          "label": "アップロードファイル",
+          "type": { "kind": "file", "format": "image/*" },
+          "required": true,
+          "description": "アップロード対象の画像ファイル。jpeg / png / webp / heic を許容。最大 @conv.limit.photoFileSize bytes。"
+        },
+        {
+          "name": "alt",
+          "label": "代替テキスト",
+          "type": "string",
+          "required": false,
+          "description": "手動指定の alt text (任意)。未指定時は AI 画像 alt 生成フローで後付け補完する。"
+        },
+        {
+          "name": "caption",
+          "label": "キャプション",
+          "type": "string",
+          "required": false,
+          "description": "写真キャプション (lightbox に表示)。"
+        },
+        {
+          "name": "orderIndex",
+          "label": "表示順",
+          "type": "integer",
+          "required": false,
+          "description": "ギャラリー内の並び順。未指定時は 0。"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "photo",
+          "label": "登録された写真",
+          "type": {
+            "kind": "object",
+            "fields": [
+              { "name": "id", "type": "integer", "required": true },
+              { "name": "postId", "type": "integer", "required": true },
+              { "name": "url", "type": "string", "required": true },
+              { "name": "thumbnailUrl", "type": "string" },
+              { "name": "width", "type": "integer" },
+              { "name": "height", "type": "integer" },
+              { "name": "bytes", "type": "integer" },
+              { "name": "mimeType", "type": "string" },
+              { "name": "orderIndex", "type": "integer" }
+            ]
+          },
+          "description": "INSERT された photos 行 (UI 側でギャラリーに追加するための情報)。"
+        }
+      ],
+      "responses": [
+        {
+          "id": "201-created",
+          "status": 201,
+          "description": "アップロード + photos 登録成功。",
+          "when": "ファイル保存・サムネイル生成・DB 登録が全て成功した場合。"
+        },
+        {
+          "id": "400-validation",
+          "status": 400,
+          "description": "バリデーションエラー。",
+          "when": "postId 未指定 / file 未指定 / mimeType 非対応 / ファイルサイズ超過。"
+        },
+        {
+          "id": "404-not-found",
+          "status": 404,
+          "description": "対象投稿が存在しない、または所有者でない。",
+          "when": "posts に postId が存在しないか、posts.user_id != sessionUserId。"
+        },
+        {
+          "id": "500-internal",
+          "status": 500,
+          "description": "ストレージ / DB エラー。",
+          "when": "ファイル保存失敗 or photos INSERT が 0 行を返した場合。"
+        }
+      ],
+      "steps": [
+        {
+          "id": "step-01",
+          "kind": "validation",
+          "description": "postId / file 必須、mimeType allowed (image/jpeg|png|webp|heic)、bytes <= conv.limit.photoFileSize。",
+          "rules": [
+            {
+              "field": "postId",
+              "type": "required",
+              "severity": "error",
+              "message": "postId を指定してください。"
+            },
+            {
+              "field": "file",
+              "type": "required",
+              "severity": "error",
+              "message": "アップロードファイルを指定してください。"
+            },
+            {
+              "field": "file.mimeType",
+              "type": "enum",
+              "values": ["image/jpeg", "image/png", "image/webp", "image/heic"],
+              "severity": "error",
+              "message": "対応していない画像形式です。jpeg / png / webp / heic を指定してください。"
+            },
+            {
+              "field": "file.bytes",
+              "type": "range",
+              "maxRef": "@conv.limit.photoFileSize",
+              "severity": "error",
+              "message": "@conv.msg.validation.photo.tooLarge"
+            }
+          ],
+          "inlineBranch": {
+            "ok": [],
+            "ng": [
+              {
+                "id": "step-01-ng-01",
+                "kind": "return",
+                "description": "400 バリデーションエラーを返す。",
+                "responseId": "400-validation",
+                "bodyExpression": "{ code: 'VALIDATION_ERROR', message: 'アップロード内容が不正です。', details: @fieldErrors }"
+              }
+            ]
+          }
+        },
+        {
+          "id": "step-02",
+          "kind": "dbAccess",
+          "description": "postId の投稿がログインユーザーのものか確認する (所有者チェック)。",
+          "tableId": "79d2c08c-7511-4d37-9051-e6f4587630e0",
+          "operation": "SELECT",
+          "sql": "SELECT id AS \"postId\", user_id AS \"userId\" FROM posts WHERE id = @inputs.postId AND user_id = @sessionUserId LIMIT 1",
+          "outputBinding": {
+            "name": "postRow"
+          },
+          "lineage": {
+            "reads": [
+              {
+                "tableId": "79d2c08c-7511-4d37-9051-e6f4587630e0",
+                "purpose": "ownership-check"
+              }
+            ]
+          }
+        },
+        {
+          "id": "step-03",
+          "kind": "branch",
+          "description": "投稿が見つからない / 所有者でない場合は 404 を返す。",
+          "branches": [
+            {
+              "id": "br-03-a",
+              "code": "A",
+              "label": "投稿不在/非所有",
+              "condition": {
+                "kind": "expression",
+                "expression": "@postRow == null"
+              },
+              "steps": [
+                {
+                  "id": "step-03-a-01",
+                  "kind": "return",
+                  "description": "404 投稿が見つかりませんを返す。",
+                  "responseId": "404-not-found",
+                  "bodyExpression": "{ code: 'POST_NOT_FOUND', message: '投稿が見つかりません。' }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-03-else",
+            "code": "B",
+            "label": "投稿存在",
+            "steps": []
+          }
+        },
+        {
+          "id": "step-04",
+          "kind": "compute",
+          "description": "ファイルをローカルストレージに保存する。実装は uuid v4 + 元拡張子のファイル名で @env.PHOTO_UPLOAD_DIR 配下に書き込み、公開 URL を返す。失敗時は STORAGE_ERROR を投げて 500 にする。",
+          "expression": "saveLocalFile(@inputs.file, { dir: @env.PHOTO_UPLOAD_DIR, filenameStrategy: 'uuid' })",
+          "outputBinding": {
+            "name": "saved"
+          }
+        },
+        {
+          "id": "step-05",
+          "kind": "compute",
+          "description": "サムネイルを生成する。sharp 等で @env.PHOTO_THUMBNAIL_WIDTH 幅にリサイズし、saved.dir 配下に <basename>_thumb.<ext> として保存。",
+          "expression": "generateThumbnail(@saved.absolutePath, { width: @env.PHOTO_THUMBNAIL_WIDTH, suffix: '_thumb' })",
+          "outputBinding": {
+            "name": "thumbnail"
+          }
+        },
+        {
+          "id": "step-06",
+          "kind": "compute",
+          "description": "画像の寸法 (width / height) を取得する。sharp 等で metadata から抽出。",
+          "expression": "extractImageDimensions(@saved.absolutePath)",
+          "outputBinding": {
+            "name": "dimensions"
+          }
+        },
+        {
+          "id": "step-07",
+          "kind": "compute",
+          "description": "EXIF メタデータを抽出する (撮影日時 / GPS / カメラ等)。exifr 等を使用。失敗時は null を返す実装で許容 (写真によっては EXIF が無いため)。",
+          "expression": "extractExif(@saved.absolutePath)",
+          "outputBinding": {
+            "name": "exifJson"
+          }
+        },
+        {
+          "id": "step-08",
+          "kind": "dbAccess",
+          "description": "photos テーブルに新規写真を INSERT する。order_index 未指定時は 0 (default)。",
+          "tableId": "d8fc5f8a-9cd2-4e46-9f3d-03c337ae0e9f",
+          "operation": "INSERT",
+          "sql": "INSERT INTO photos (post_id, url, thumbnail_url, alt, caption, order_index, width, height, bytes, mime_type, exif_json, created_at) VALUES (@inputs.postId, @saved.url, @thumbnail.url, @inputs.alt, @inputs.caption, COALESCE(@inputs.orderIndex, 0), @dimensions.width, @dimensions.height, @inputs.file.bytes, @inputs.file.mimeType, @exifJson, CURRENT_TIMESTAMP) RETURNING id AS \"photoId\"",
+          "outputBinding": {
+            "name": "newPhoto"
+          },
+          "affectedRowsCheck": {
+            "operator": "=",
+            "expected": 1,
+            "onViolation": "throw",
+            "errorCode": "PHOTO_UPLOAD_FAILED"
+          },
+          "lineage": {
+            "writes": [
+              {
+                "tableId": "d8fc5f8a-9cd2-4e46-9f3d-03c337ae0e9f",
+                "purpose": "insert"
+              }
+            ]
+          }
+        },
+        {
+          "id": "step-09",
+          "kind": "return",
+          "description": "201 作成成功 + 登録された写真情報を返す。",
+          "responseId": "201-created",
+          "bodyExpression": "{ photo: { id: @newPhoto.photoId, postId: @inputs.postId, url: @saved.url, thumbnailUrl: @thumbnail.url, width: @dimensions.width, height: @dimensions.height, bytes: @inputs.file.bytes, mimeType: @inputs.file.mimeType, orderIndex: COALESCE(@inputs.orderIndex, 0) } }"
+        }
+      ]
+    }
+  ]
+}

--- a/examples/diary/harmony/process-flows/305509f7-d118-459a-8acb-18780e4fde68.json
+++ b/examples/diary/harmony/process-flows/305509f7-d118-459a-8acb-18780e4fde68.json
@@ -1,0 +1,192 @@
+{
+  "$schema": "../../../../schemas/v3/process-flow.v3.schema.json",
+  "meta": {
+    "id": "305509f7-d118-459a-8acb-18780e4fde68",
+    "name": "タグ削除",
+    "description": "タグを削除する処理フロー。post_tags に参照が残っている場合は 409 で削除拒否し、UI から「N 件で使用中、削除不可」を表示できるようにする。cascade 削除はしない (既存投稿のタグが意図せず外れる事故を防ぐ、ユーザーが明示的に投稿側でタグを外してから再削除する想定)。",
+    "kind": "screen",
+    "maturity": "draft",
+    "createdAt": "2026-05-07T00:00:00.000Z",
+    "updatedAt": "2026-05-07T00:00:00.000Z"
+  },
+  "context": {
+    "catalogs": {
+      "errors": {
+        "VALIDATION_ERROR": {
+          "httpStatus": 400,
+          "defaultMessage": "タグ ID を指定してください。",
+          "responseId": "400-validation",
+          "description": "id 未指定。"
+        },
+        "TAG_NOT_FOUND": {
+          "httpStatus": 404,
+          "defaultMessage": "タグが見つかりません。",
+          "responseId": "404-not-found",
+          "description": "指定 id のタグが既に存在しない (DELETE が 0 行を返した場合)。"
+        },
+        "TAG_IN_USE": {
+          "httpStatus": 409,
+          "defaultMessage": "このタグは投稿で使用中のため削除できません。",
+          "responseId": "409-conflict",
+          "description": "post_tags に参照が残っている。usageCount を返してクライアントに表示させる。"
+        }
+      }
+    }
+  },
+  "actions": [
+    {
+      "id": "act-001",
+      "name": "タグ削除",
+      "trigger": "submit",
+      "description": "id を受け取り、post_tags への参照を確認した上で tags から DELETE する。参照ありなら 409 で拒否。",
+      "maturity": "draft",
+      "httpRoute": {
+        "method": "DELETE",
+        "path": "/api/tags/:id",
+        "auth": "required"
+      },
+      "inputs": [
+        {
+          "name": "id",
+          "label": "タグID",
+          "type": "integer",
+          "required": true,
+          "description": "削除対象タグの id (URL path から)。"
+        }
+      ],
+      "outputs": [],
+      "responses": [
+        {
+          "id": "204-no-content",
+          "status": 204,
+          "description": "削除成功 (本文なし)。",
+          "when": "post_tags に参照がなく、DELETE が 1 行を返した場合。"
+        },
+        {
+          "id": "400-validation",
+          "status": 400,
+          "description": "id 未指定。",
+          "when": "id が指定されていない。"
+        },
+        {
+          "id": "404-not-found",
+          "status": 404,
+          "description": "タグが見つからない。",
+          "when": "DELETE 実行時に 0 行が返った場合 (既に削除済)。"
+        },
+        {
+          "id": "409-conflict",
+          "status": 409,
+          "description": "使用中で削除拒否。",
+          "when": "post_tags にタグへの参照が残っている場合。"
+        }
+      ],
+      "steps": [
+        {
+          "id": "step-01",
+          "kind": "validation",
+          "description": "id 必須チェック。",
+          "rules": [
+            {
+              "field": "id",
+              "type": "required",
+              "severity": "error",
+              "message": "タグ ID を指定してください。"
+            }
+          ],
+          "inlineBranch": {
+            "ok": [],
+            "ng": [
+              {
+                "id": "step-01-ng-01",
+                "kind": "return",
+                "description": "400 バリデーションエラーを返す。",
+                "responseId": "400-validation",
+                "bodyExpression": "{ code: 'VALIDATION_ERROR', message: 'タグ ID を指定してください。' }"
+              }
+            ]
+          }
+        },
+        {
+          "id": "step-02",
+          "kind": "dbAccess",
+          "description": "post_tags 経由でタグの使用件数を集計する (使用中なら 409 で削除拒否)。",
+          "tableId": "1681eee2-39d9-4548-9044-5cedac68d41e",
+          "operation": "SELECT",
+          "sql": "SELECT COUNT(*) AS \"usageCount\" FROM post_tags WHERE tag_id = @inputs.id",
+          "outputBinding": {
+            "name": "usage"
+          },
+          "lineage": {
+            "reads": [
+              {
+                "tableId": "1681eee2-39d9-4548-9044-5cedac68d41e",
+                "purpose": "in-use-check"
+              }
+            ]
+          }
+        },
+        {
+          "id": "step-03",
+          "kind": "branch",
+          "description": "使用中なら 409 を返す (cascade 削除はしない)。",
+          "branches": [
+            {
+              "id": "br-03-a",
+              "code": "A",
+              "label": "使用中",
+              "condition": {
+                "kind": "expression",
+                "expression": "@usage.usageCount > 0"
+              },
+              "steps": [
+                {
+                  "id": "step-03-a-01",
+                  "kind": "return",
+                  "description": "409 削除拒否を返す。usageCount を payload に含めて UI で件数表示できるようにする。",
+                  "responseId": "409-conflict",
+                  "bodyExpression": "{ code: 'TAG_IN_USE', message: 'このタグは投稿で使用中のため削除できません。', usageCount: @usage.usageCount }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-03-else",
+            "code": "B",
+            "label": "未使用",
+            "steps": []
+          }
+        },
+        {
+          "id": "step-04",
+          "kind": "dbAccess",
+          "description": "tags から id を DELETE する。0 行 (既に削除済) なら 404 を返す。",
+          "tableId": "07439e21-0743-48ca-af9e-763e4be2d094",
+          "operation": "DELETE",
+          "sql": "DELETE FROM tags WHERE id = @inputs.id",
+          "affectedRowsCheck": {
+            "operator": "=",
+            "expected": 1,
+            "onViolation": "throw",
+            "errorCode": "TAG_NOT_FOUND",
+            "description": "0 行は既に削除済 (= 404)、複数行は schema 違反 (id PK のため発生しない想定)。"
+          },
+          "lineage": {
+            "writes": [
+              {
+                "tableId": "07439e21-0743-48ca-af9e-763e4be2d094",
+                "purpose": "delete"
+              }
+            ]
+          }
+        },
+        {
+          "id": "step-05",
+          "kind": "return",
+          "description": "204 No Content を返す。",
+          "responseId": "204-no-content"
+        }
+      ]
+    }
+  ]
+}

--- a/examples/diary/harmony/process-flows/46436b69-99f2-48b3-a5fa-07bf9fcd1478.json
+++ b/examples/diary/harmony/process-flows/46436b69-99f2-48b3-a5fa-07bf9fcd1478.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "../../../../schemas/v3/process-flow.v3.schema.json",
+  "meta": {
+    "id": "46436b69-99f2-48b3-a5fa-07bf9fcd1478",
+    "name": "ログアウト",
+    "description": "ログアウトを受け付ける処理フロー。JWT stateless 認証 + 1 ユーザー個人運用前提のため、サーバ側のトークン失効処理 (blacklist) は行わず、監査ログだけ残して 204 を返す。クライアントは access/refresh トークンを localStorage から破棄するだけで完了する。",
+    "kind": "screen",
+    "maturity": "draft",
+    "createdAt": "2026-05-07T00:00:00.000Z",
+    "updatedAt": "2026-05-07T00:00:00.000Z"
+  },
+  "context": {
+    "ambientVariables": [
+      {
+        "name": "sessionUserId",
+        "type": "integer",
+        "required": true,
+        "description": "ログアウトを実行するユーザー ID (JWT から抽出)。"
+      }
+    ]
+  },
+  "actions": [
+    {
+      "id": "act-001",
+      "name": "ログアウト",
+      "trigger": "submit",
+      "description": "監査ログを書き出して 204 を返す。クライアント側で localStorage の token を破棄する想定。",
+      "maturity": "draft",
+      "httpRoute": {
+        "method": "POST",
+        "path": "/api/auth/logout",
+        "auth": "required"
+      },
+      "inputs": [],
+      "outputs": [],
+      "responses": [
+        {
+          "id": "204-no-content",
+          "status": 204,
+          "description": "ログアウト処理完了 (本文なし)。",
+          "when": "認証済リクエストが届いた場合 (常に成功)。"
+        }
+      ],
+      "steps": [
+        {
+          "id": "step-01",
+          "kind": "audit",
+          "description": "ログアウトイベントを監査ログに記録する。",
+          "action": "auth.logout",
+          "resource": {
+            "type": "user",
+            "id": "@sessionUserId"
+          }
+        },
+        {
+          "id": "step-02",
+          "kind": "return",
+          "description": "204 No Content を返す。",
+          "responseId": "204-no-content"
+        }
+      ]
+    }
+  ]
+}

--- a/examples/diary/harmony/process-flows/46b99455-a011-4419-937f-a5ef8368e694.json
+++ b/examples/diary/harmony/process-flows/46b99455-a011-4419-937f-a5ef8368e694.json
@@ -1,0 +1,263 @@
+{
+  "$schema": "../../../../schemas/v3/process-flow.v3.schema.json",
+  "meta": {
+    "id": "46b99455-a011-4419-937f-a5ef8368e694",
+    "name": "タグ作成",
+    "description": "新規タグを作成する処理フロー。slug 未指定時は name から自動生成 (英小文字 + ハイフン)。name / slug の UNIQUE 制約違反は事前 SELECT で 409 を返す (投稿作成 flow と同じ pattern)。",
+    "kind": "screen",
+    "maturity": "draft",
+    "createdAt": "2026-05-07T00:00:00.000Z",
+    "updatedAt": "2026-05-07T00:00:00.000Z"
+  },
+  "context": {
+    "catalogs": {
+      "errors": {
+        "VALIDATION_ERROR": {
+          "httpStatus": 400,
+          "defaultMessage": "入力値が不正です。",
+          "responseId": "400-validation",
+          "description": "name 未入力 / 長さ超過 / slug regex 違反 / color hex 違反。"
+        },
+        "TAG_DUPLICATE": {
+          "httpStatus": 409,
+          "defaultMessage": "同名のタグが既に存在します。",
+          "responseId": "409-conflict",
+          "description": "name または slug が既存タグと重複した場合。"
+        },
+        "TAG_CREATE_FAILED": {
+          "httpStatus": 500,
+          "defaultMessage": "タグの作成に失敗しました。",
+          "responseId": "500-internal",
+          "description": "DB INSERT が想定外に 0 行を返した場合。"
+        }
+      }
+    }
+  },
+  "actions": [
+    {
+      "id": "act-001",
+      "name": "タグ作成",
+      "trigger": "submit",
+      "description": "name + 任意の slug / color / icon を受け取り、tags に新規 INSERT する。",
+      "maturity": "draft",
+      "httpRoute": {
+        "method": "POST",
+        "path": "/api/tags",
+        "auth": "required"
+      },
+      "inputs": [
+        {
+          "name": "name",
+          "label": "タグ名",
+          "type": "string",
+          "required": true,
+          "description": "タグ表示名 (例: '旅行', 'カフェ')。最大 64 文字。"
+        },
+        {
+          "name": "slug",
+          "label": "スラッグ",
+          "type": "string",
+          "required": false,
+          "description": "URL 用 slug。未指定時は name を lowercase + space→hyphen で自動生成する。"
+        },
+        {
+          "name": "color",
+          "label": "カラー",
+          "type": "string",
+          "required": false,
+          "description": "UI chip 色 (#RRGGBB)。未指定時は default '#6366f1'。"
+        },
+        {
+          "name": "icon",
+          "label": "アイコン名",
+          "type": "string",
+          "required": false,
+          "description": "Lucide / Heroicons のアイコン名 (任意)。"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "tag",
+          "label": "登録されたタグ",
+          "type": {
+            "kind": "object",
+            "fields": [
+              { "name": "id", "type": "integer", "required": true },
+              { "name": "name", "type": "string", "required": true },
+              { "name": "slug", "type": "string", "required": true },
+              { "name": "color", "type": "string" },
+              { "name": "icon", "type": "string" }
+            ]
+          }
+        }
+      ],
+      "responses": [
+        {
+          "id": "201-created",
+          "status": 201,
+          "description": "タグ作成成功。",
+          "when": "name + slug が一意で、INSERT が正常完了した場合。"
+        },
+        {
+          "id": "400-validation",
+          "status": 400,
+          "description": "バリデーションエラー。",
+          "when": "name 未入力 / 長さ超過 / slug regex 違反 / color hex 違反。"
+        },
+        {
+          "id": "409-conflict",
+          "status": 409,
+          "description": "同名タグ重複。",
+          "when": "tags.name または tags.slug の UNIQUE 制約違反。"
+        },
+        {
+          "id": "500-internal",
+          "status": 500,
+          "description": "内部エラー。",
+          "when": "DB INSERT が想定外に 0 行を返した場合。"
+        }
+      ],
+      "steps": [
+        {
+          "id": "step-01",
+          "kind": "validation",
+          "description": "name 必須 + 最大長、slug regex (指定時のみ)、color hex regex (指定時のみ)。",
+          "rules": [
+            {
+              "field": "name",
+              "type": "required",
+              "severity": "error",
+              "message": "タグ名を入力してください。"
+            },
+            {
+              "field": "name",
+              "type": "maxLength",
+              "length": 64,
+              "severity": "error",
+              "message": "タグ名は 64 文字以内で入力してください。"
+            },
+            {
+              "field": "slug",
+              "type": "regex",
+              "patternRef": "@conv.regex.tagSlug",
+              "condition": "@inputs.slug != null && @inputs.slug != ''",
+              "severity": "error",
+              "message": "スラッグは英小文字 + 数字 + ハイフンで指定してください (例: travel, ai-art)。"
+            },
+            {
+              "field": "color",
+              "type": "regex",
+              "patternRef": "@conv.regex.hexColor",
+              "condition": "@inputs.color != null && @inputs.color != ''",
+              "severity": "error",
+              "message": "カラーは #RRGGBB 形式 (CSS hex 6 桁) で指定してください。"
+            }
+          ],
+          "inlineBranch": {
+            "ok": [],
+            "ng": [
+              {
+                "id": "step-01-ng-01",
+                "kind": "return",
+                "description": "400 バリデーションエラーを返す。",
+                "responseId": "400-validation",
+                "bodyExpression": "{ code: 'VALIDATION_ERROR', message: '入力値が不正です。', details: @fieldErrors }"
+              }
+            ]
+          }
+        },
+        {
+          "id": "step-02",
+          "kind": "compute",
+          "description": "slug が未指定の場合は name から自動生成する (lowercase + space→hyphen)。指定時はそのまま採用。",
+          "expression": "@inputs.slug != null && @inputs.slug != '' ? @inputs.slug : LOWER(REPLACE(@inputs.name, ' ', '-'))",
+          "outputBinding": {
+            "name": "resolvedSlug"
+          }
+        },
+        {
+          "id": "step-03",
+          "kind": "dbAccess",
+          "description": "name または slug が既存タグと重複していないか SELECT で事前チェックする。",
+          "tableId": "07439e21-0743-48ca-af9e-763e4be2d094",
+          "operation": "SELECT",
+          "sql": "SELECT id AS \"tagId\" FROM tags WHERE name = @inputs.name OR slug = @resolvedSlug LIMIT 1",
+          "outputBinding": {
+            "name": "duplicateTag"
+          },
+          "lineage": {
+            "reads": [
+              {
+                "tableId": "07439e21-0743-48ca-af9e-763e4be2d094",
+                "purpose": "uniqueness-check"
+              }
+            ]
+          }
+        },
+        {
+          "id": "step-04",
+          "kind": "branch",
+          "description": "重複があれば 409 Conflict を返す。",
+          "branches": [
+            {
+              "id": "br-04-a",
+              "code": "A",
+              "label": "重複あり",
+              "condition": {
+                "kind": "expression",
+                "expression": "@duplicateTag != null"
+              },
+              "steps": [
+                {
+                  "id": "step-04-a-01",
+                  "kind": "return",
+                  "description": "409 同名タグ重複を返す。",
+                  "responseId": "409-conflict",
+                  "bodyExpression": "{ code: 'TAG_DUPLICATE', message: '同名のタグが既に存在します。' }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-04-else",
+            "code": "B",
+            "label": "重複なし",
+            "steps": []
+          }
+        },
+        {
+          "id": "step-05",
+          "kind": "dbAccess",
+          "description": "tags に新規タグを INSERT する。color 未指定時は default '#6366f1'。",
+          "tableId": "07439e21-0743-48ca-af9e-763e4be2d094",
+          "operation": "INSERT",
+          "sql": "INSERT INTO tags (name, slug, color, icon, usage_count, created_at, updated_at) VALUES (@inputs.name, @resolvedSlug, COALESCE(@inputs.color, '#6366f1'), @inputs.icon, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP) RETURNING id AS \"tagId\"",
+          "outputBinding": {
+            "name": "newTag"
+          },
+          "affectedRowsCheck": {
+            "operator": "=",
+            "expected": 1,
+            "onViolation": "throw",
+            "errorCode": "TAG_CREATE_FAILED"
+          },
+          "lineage": {
+            "writes": [
+              {
+                "tableId": "07439e21-0743-48ca-af9e-763e4be2d094",
+                "purpose": "insert"
+              }
+            ]
+          }
+        },
+        {
+          "id": "step-06",
+          "kind": "return",
+          "description": "201 作成成功 + 登録されたタグを返す。",
+          "responseId": "201-created",
+          "bodyExpression": "{ tag: { id: @newTag.tagId, name: @inputs.name, slug: @resolvedSlug, color: COALESCE(@inputs.color, '#6366f1'), icon: @inputs.icon } }"
+        }
+      ]
+    }
+  ]
+}

--- a/examples/diary/harmony/process-flows/803764e4-c27d-47fd-b3d9-924c1fa28bd8.json
+++ b/examples/diary/harmony/process-flows/803764e4-c27d-47fd-b3d9-924c1fa28bd8.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "../../../../schemas/v3/process-flow.v3.schema.json",
+  "meta": {
+    "id": "803764e4-c27d-47fd-b3d9-924c1fa28bd8",
+    "name": "タグ一覧取得",
+    "description": "タグマスタ全件を usage_count DESC で取得する処理フロー。タグの総件数は現実的に少ない (数十〜数百) ため、サーバ側では 1 種類の並び順 (タグクラウド表示用) のみ返し、別ソート (五十音 / 新着) は UI 側でクライアントサイド並び替えする方針 (#862 の v1 設計判断)。動的 ORDER BY は SQL injection 経路を増やすため避ける。",
+    "kind": "screen",
+    "maturity": "draft",
+    "createdAt": "2026-05-07T00:00:00.000Z",
+    "updatedAt": "2026-05-07T00:00:00.000Z"
+  },
+  "context": {
+    "catalogs": {
+      "errors": {}
+    }
+  },
+  "actions": [
+    {
+      "id": "act-001",
+      "name": "タグ一覧取得",
+      "trigger": "submit",
+      "description": "tags テーブル全件を usage_count DESC, name ASC で取得して返す。別ソートは UI 側でクライアントサイド並び替えする想定。",
+      "maturity": "draft",
+      "httpRoute": {
+        "method": "GET",
+        "path": "/api/tags",
+        "auth": "required"
+      },
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "tags",
+          "label": "タグ一覧",
+          "type": {
+            "kind": "tableList",
+            "tableId": "07439e21-0743-48ca-af9e-763e4be2d094"
+          },
+          "description": "tags 全行の配列。usage_count 降順 + name 昇順で並び替え済 (タグクラウド表示順)。"
+        }
+      ],
+      "responses": [
+        {
+          "id": "200-ok",
+          "status": 200,
+          "description": "取得成功。",
+          "when": "SELECT が正常完了した場合。"
+        }
+      ],
+      "steps": [
+        {
+          "id": "step-01",
+          "kind": "dbAccess",
+          "description": "tags 全件を usage_count DESC, name ASC で SELECT する。タグ件数は現実的に少ない (数十〜数百) ため pagination 不要。",
+          "tableId": "07439e21-0743-48ca-af9e-763e4be2d094",
+          "operation": "SELECT",
+          "sql": "SELECT id AS \"tagId\", name AS \"name\", slug AS \"slug\", color AS \"color\", icon AS \"icon\", usage_count AS \"usageCount\", created_at AS \"createdAt\", updated_at AS \"updatedAt\" FROM tags ORDER BY usage_count DESC, name ASC",
+          "outputBinding": {
+            "name": "tagRows"
+          },
+          "lineage": {
+            "reads": [
+              {
+                "tableId": "07439e21-0743-48ca-af9e-763e4be2d094",
+                "purpose": "list"
+              }
+            ]
+          }
+        },
+        {
+          "id": "step-02",
+          "kind": "return",
+          "description": "200 タグ一覧を返す。",
+          "responseId": "200-ok",
+          "bodyExpression": "{ tags: @tagRows }"
+        }
+      ]
+    }
+  ]
+}

--- a/examples/diary/harmony/process-flows/8cc24fea-f497-432b-8496-5d86dea1c98b.json
+++ b/examples/diary/harmony/process-flows/8cc24fea-f497-432b-8496-5d86dea1c98b.json
@@ -1,0 +1,350 @@
+{
+  "$schema": "../../../../schemas/v3/process-flow.v3.schema.json",
+  "meta": {
+    "id": "8cc24fea-f497-432b-8496-5d86dea1c98b",
+    "name": "タグ更新",
+    "description": "既存タグの属性 (name / slug / color / icon) を部分更新する処理フロー。指定されない field は既存値を維持する (COALESCE pattern)。name / slug の UNIQUE 制約は事前 SELECT で 409 を返す。",
+    "kind": "screen",
+    "maturity": "draft",
+    "createdAt": "2026-05-07T00:00:00.000Z",
+    "updatedAt": "2026-05-07T00:00:00.000Z"
+  },
+  "context": {
+    "catalogs": {
+      "errors": {
+        "VALIDATION_ERROR": {
+          "httpStatus": 400,
+          "defaultMessage": "入力値が不正です。",
+          "responseId": "400-validation",
+          "description": "id 未指定 / name 長さ超過 / slug regex 違反 / color hex 違反。"
+        },
+        "TAG_NOT_FOUND": {
+          "httpStatus": 404,
+          "defaultMessage": "タグが見つかりません。",
+          "responseId": "404-not-found",
+          "description": "指定 id のタグが存在しない。"
+        },
+        "TAG_DUPLICATE": {
+          "httpStatus": 409,
+          "defaultMessage": "同名のタグが既に存在します。",
+          "responseId": "409-conflict",
+          "description": "name または slug が他のタグと重複した場合。"
+        },
+        "TAG_UPDATE_FAILED": {
+          "httpStatus": 500,
+          "defaultMessage": "タグの更新に失敗しました。",
+          "responseId": "500-internal",
+          "description": "DB UPDATE が想定外に 0 行を返した場合 (= step-03 の存在確認後に削除された競合)。"
+        }
+      }
+    }
+  },
+  "actions": [
+    {
+      "id": "act-001",
+      "name": "タグ更新",
+      "trigger": "submit",
+      "description": "id を必須、name / slug / color / icon を任意で受け取り、指定された field のみを UPDATE する。",
+      "maturity": "draft",
+      "httpRoute": {
+        "method": "PUT",
+        "path": "/api/tags/:id",
+        "auth": "required"
+      },
+      "inputs": [
+        {
+          "name": "id",
+          "label": "タグID",
+          "type": "integer",
+          "required": true,
+          "description": "更新対象タグの id (URL path から)。"
+        },
+        {
+          "name": "name",
+          "label": "タグ名",
+          "type": "string",
+          "required": false,
+          "description": "新しいタグ名 (任意)。最大 64 文字。"
+        },
+        {
+          "name": "slug",
+          "label": "スラッグ",
+          "type": "string",
+          "required": false,
+          "description": "新しい slug (任意)。"
+        },
+        {
+          "name": "color",
+          "label": "カラー",
+          "type": "string",
+          "required": false,
+          "description": "新しい UI chip 色 (#RRGGBB)。"
+        },
+        {
+          "name": "icon",
+          "label": "アイコン名",
+          "type": "string",
+          "required": false,
+          "description": "新しいアイコン名。空文字を渡すと NULL に更新される。"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "tag",
+          "label": "更新されたタグ",
+          "type": {
+            "kind": "object",
+            "fields": [
+              { "name": "id", "type": "integer", "required": true },
+              { "name": "name", "type": "string", "required": true },
+              { "name": "slug", "type": "string", "required": true },
+              { "name": "color", "type": "string" },
+              { "name": "icon", "type": "string" }
+            ]
+          }
+        }
+      ],
+      "responses": [
+        {
+          "id": "200-ok",
+          "status": 200,
+          "description": "更新成功。",
+          "when": "対象タグが存在し、name/slug 重複がなく UPDATE が完了した場合。"
+        },
+        {
+          "id": "400-validation",
+          "status": 400,
+          "description": "バリデーションエラー。",
+          "when": "id 未指定 / name 長さ超過 / slug regex 違反 / color hex 違反。"
+        },
+        {
+          "id": "404-not-found",
+          "status": 404,
+          "description": "タグが見つからない。",
+          "when": "指定 id のタグが存在しない。"
+        },
+        {
+          "id": "409-conflict",
+          "status": 409,
+          "description": "同名タグ重複。",
+          "when": "name / slug が他のタグと重複した場合。"
+        },
+        {
+          "id": "500-internal",
+          "status": 500,
+          "description": "内部エラー。",
+          "when": "DB UPDATE が想定外に 0 行を返した場合。"
+        }
+      ],
+      "steps": [
+        {
+          "id": "step-01",
+          "kind": "validation",
+          "description": "id 必須、name 最大長 (指定時)、slug regex (指定時)、color hex regex (指定時)。",
+          "rules": [
+            {
+              "field": "id",
+              "type": "required",
+              "severity": "error",
+              "message": "タグ ID を指定してください。"
+            },
+            {
+              "field": "name",
+              "type": "maxLength",
+              "length": 64,
+              "condition": "@inputs.name != null",
+              "severity": "error",
+              "message": "タグ名は 64 文字以内で入力してください。"
+            },
+            {
+              "field": "slug",
+              "type": "regex",
+              "patternRef": "@conv.regex.tagSlug",
+              "condition": "@inputs.slug != null && @inputs.slug != ''",
+              "severity": "error",
+              "message": "スラッグは英小文字 + 数字 + ハイフンで指定してください。"
+            },
+            {
+              "field": "color",
+              "type": "regex",
+              "patternRef": "@conv.regex.hexColor",
+              "condition": "@inputs.color != null && @inputs.color != ''",
+              "severity": "error",
+              "message": "カラーは #RRGGBB 形式で指定してください。"
+            }
+          ],
+          "inlineBranch": {
+            "ok": [],
+            "ng": [
+              {
+                "id": "step-01-ng-01",
+                "kind": "return",
+                "description": "400 バリデーションエラーを返す。",
+                "responseId": "400-validation",
+                "bodyExpression": "{ code: 'VALIDATION_ERROR', message: '入力値が不正です。', details: @fieldErrors }"
+              }
+            ]
+          }
+        },
+        {
+          "id": "step-02",
+          "kind": "dbAccess",
+          "description": "対象タグの存在を SELECT で確認する。",
+          "tableId": "07439e21-0743-48ca-af9e-763e4be2d094",
+          "operation": "SELECT",
+          "sql": "SELECT id AS \"tagId\", name AS \"name\", slug AS \"slug\" FROM tags WHERE id = @inputs.id LIMIT 1",
+          "outputBinding": {
+            "name": "existingTag"
+          },
+          "lineage": {
+            "reads": [
+              {
+                "tableId": "07439e21-0743-48ca-af9e-763e4be2d094",
+                "purpose": "lookup"
+              }
+            ]
+          }
+        },
+        {
+          "id": "step-03",
+          "kind": "branch",
+          "description": "対象タグが存在しない場合は 404 を返す。",
+          "branches": [
+            {
+              "id": "br-03-a",
+              "code": "A",
+              "label": "タグ不在",
+              "condition": {
+                "kind": "expression",
+                "expression": "@existingTag == null"
+              },
+              "steps": [
+                {
+                  "id": "step-03-a-01",
+                  "kind": "return",
+                  "description": "404 タグが見つかりませんを返す。",
+                  "responseId": "404-not-found",
+                  "bodyExpression": "{ code: 'TAG_NOT_FOUND', message: 'タグが見つかりません。' }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-03-else",
+            "code": "B",
+            "label": "タグ存在",
+            "steps": []
+          }
+        },
+        {
+          "id": "step-04",
+          "kind": "compute",
+          "description": "更新後の name / slug を解決する (未指定なら既存値を維持)。重複チェック / UPDATE 双方で再利用する。",
+          "expression": "{ name: COALESCE(@inputs.name, @existingTag.name), slug: COALESCE(@inputs.slug, @existingTag.slug) }",
+          "outputBinding": {
+            "name": "resolved"
+          }
+        },
+        {
+          "id": "step-05",
+          "kind": "dbAccess",
+          "description": "他タグとの name / slug 重複を SELECT で確認する (自身は除外)。",
+          "tableId": "07439e21-0743-48ca-af9e-763e4be2d094",
+          "operation": "SELECT",
+          "sql": "SELECT id AS \"tagId\" FROM tags WHERE id != @inputs.id AND (name = @resolved.name OR slug = @resolved.slug) LIMIT 1",
+          "outputBinding": {
+            "name": "duplicateTag"
+          },
+          "lineage": {
+            "reads": [
+              {
+                "tableId": "07439e21-0743-48ca-af9e-763e4be2d094",
+                "purpose": "uniqueness-check"
+              }
+            ]
+          }
+        },
+        {
+          "id": "step-06",
+          "kind": "branch",
+          "description": "他タグと重複していたら 409 を返す。",
+          "branches": [
+            {
+              "id": "br-06-a",
+              "code": "A",
+              "label": "重複あり",
+              "condition": {
+                "kind": "expression",
+                "expression": "@duplicateTag != null"
+              },
+              "steps": [
+                {
+                  "id": "step-06-a-01",
+                  "kind": "return",
+                  "description": "409 重複を返す。",
+                  "responseId": "409-conflict",
+                  "bodyExpression": "{ code: 'TAG_DUPLICATE', message: '同名のタグが既に存在します。' }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-06-else",
+            "code": "B",
+            "label": "重複なし",
+            "steps": []
+          }
+        },
+        {
+          "id": "step-07",
+          "kind": "dbAccess",
+          "description": "tags を UPDATE する。指定されない field は既存値を維持。",
+          "tableId": "07439e21-0743-48ca-af9e-763e4be2d094",
+          "operation": "UPDATE",
+          "sql": "UPDATE tags SET name = @resolved.name, slug = @resolved.slug, color = COALESCE(@inputs.color, color), icon = COALESCE(@inputs.icon, icon), updated_at = CURRENT_TIMESTAMP WHERE id = @inputs.id",
+          "affectedRowsCheck": {
+            "operator": "=",
+            "expected": 1,
+            "onViolation": "throw",
+            "errorCode": "TAG_UPDATE_FAILED",
+            "description": "step-03 の存在確認後に削除された競合の場合 0 行になるため throw。"
+          },
+          "lineage": {
+            "writes": [
+              {
+                "tableId": "07439e21-0743-48ca-af9e-763e4be2d094",
+                "purpose": "update"
+              }
+            ]
+          }
+        },
+        {
+          "id": "step-08",
+          "kind": "dbAccess",
+          "description": "更新後の行を読み戻して返す。",
+          "tableId": "07439e21-0743-48ca-af9e-763e4be2d094",
+          "operation": "SELECT",
+          "sql": "SELECT id AS \"tagId\", name AS \"name\", slug AS \"slug\", color AS \"color\", icon AS \"icon\" FROM tags WHERE id = @inputs.id LIMIT 1",
+          "outputBinding": {
+            "name": "updatedTag"
+          },
+          "lineage": {
+            "reads": [
+              {
+                "tableId": "07439e21-0743-48ca-af9e-763e4be2d094",
+                "purpose": "lookup"
+              }
+            ]
+          }
+        },
+        {
+          "id": "step-09",
+          "kind": "return",
+          "description": "200 更新後のタグを返す。",
+          "responseId": "200-ok",
+          "bodyExpression": "{ tag: { id: @updatedTag.tagId, name: @updatedTag.name, slug: @updatedTag.slug, color: @updatedTag.color, icon: @updatedTag.icon } }"
+        }
+      ]
+    }
+  ]
+}

--- a/examples/diary/harmony/process-flows/9537764e-3fe9-459d-8172-00d69a575c09.json
+++ b/examples/diary/harmony/process-flows/9537764e-3fe9-459d-8172-00d69a575c09.json
@@ -1,0 +1,233 @@
+{
+  "$schema": "../../../../schemas/v3/process-flow.v3.schema.json",
+  "meta": {
+    "id": "9537764e-3fe9-459d-8172-00d69a575c09",
+    "name": "トークン更新",
+    "description": "リフレッシュトークンを受け取り、検証成功時に新しいアクセストークンを発行して返す処理フロー。リフレッシュトークン自体は再発行しない (rotation 戦略は v1 では non-rotating で簡素化、必要なら別 ISSUE で導入)。",
+    "kind": "screen",
+    "maturity": "draft",
+    "createdAt": "2026-05-07T00:00:00.000Z",
+    "updatedAt": "2026-05-07T00:00:00.000Z"
+  },
+  "context": {
+    "catalogs": {
+      "errors": {
+        "VALIDATION_ERROR": {
+          "httpStatus": 400,
+          "defaultMessage": "リフレッシュトークンが必要です。",
+          "responseId": "400-validation",
+          "description": "refreshToken 未指定。"
+        },
+        "INVALID_REFRESH_TOKEN": {
+          "httpStatus": 401,
+          "defaultMessage": "リフレッシュトークンが無効または期限切れです。再ログインしてください。",
+          "responseId": "401-unauthorized",
+          "description": "JWT 検証失敗 / 期限切れ / 対応ユーザー不在のいずれも同じ 401 を返す (列挙攻撃対策)。"
+        }
+      },
+      "secrets": {
+        "jwtAccessSecret": {
+          "source": "env",
+          "name": "JWT_ACCESS_SECRET",
+          "description": "アクセストークン署名用キー (HS256)。"
+        },
+        "jwtRefreshSecret": {
+          "source": "env",
+          "name": "JWT_REFRESH_SECRET",
+          "description": "リフレッシュトークン検証用キー (HS256)。"
+        }
+      },
+      "envVars": {
+        "JWT_ACCESS_TTL": {
+          "type": "string",
+          "default": "1h",
+          "description": "新規発行するアクセストークンの有効期限。"
+        }
+      }
+    }
+  },
+  "actions": [
+    {
+      "id": "act-001",
+      "name": "トークン更新",
+      "trigger": "submit",
+      "description": "リフレッシュトークンを検証し、ユーザー存在を確認した上で新しいアクセストークンを発行する。",
+      "maturity": "draft",
+      "httpRoute": {
+        "method": "POST",
+        "path": "/api/auth/refresh",
+        "auth": "none"
+      },
+      "inputs": [
+        {
+          "name": "refreshToken",
+          "label": "リフレッシュトークン",
+          "type": "string",
+          "required": true,
+          "description": "ログインフローで発行されたリフレッシュトークン。"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "accessToken",
+          "label": "アクセストークン",
+          "type": "string",
+          "description": "新規発行されたアクセストークン。"
+        }
+      ],
+      "responses": [
+        {
+          "id": "200-ok",
+          "status": 200,
+          "description": "更新成功。",
+          "when": "リフレッシュトークン検証成功 + 対応ユーザー存在。"
+        },
+        {
+          "id": "400-validation",
+          "status": 400,
+          "description": "リフレッシュトークンが指定されていない。",
+          "when": "refreshToken が未指定または空文字。"
+        },
+        {
+          "id": "401-unauthorized",
+          "status": 401,
+          "description": "リフレッシュトークン無効 / 期限切れ / ユーザー不在。",
+          "when": "jwtVerify が失敗、または対応するユーザーが users テーブルに存在しない。"
+        }
+      ],
+      "steps": [
+        {
+          "id": "step-01",
+          "kind": "validation",
+          "description": "refreshToken 必須チェック。",
+          "rules": [
+            {
+              "field": "refreshToken",
+              "type": "required",
+              "severity": "error",
+              "message": "リフレッシュトークンを指定してください。"
+            }
+          ],
+          "inlineBranch": {
+            "ok": [],
+            "ng": [
+              {
+                "id": "step-01-ng-01",
+                "kind": "return",
+                "description": "400 バリデーションエラーを返す。",
+                "responseId": "400-validation",
+                "bodyExpression": "{ code: 'VALIDATION_ERROR', message: 'リフレッシュトークンが必要です。' }"
+              }
+            ]
+          }
+        },
+        {
+          "id": "step-02",
+          "kind": "compute",
+          "description": "リフレッシュトークンを HS256 で検証する。期限切れ / 改竄 / 署名不一致の場合は null を返す実装。type='refresh' でない場合も null。",
+          "expression": "jwtVerify(@inputs.refreshToken, @secret.jwtRefreshSecret, { requireType: 'refresh' })",
+          "outputBinding": {
+            "name": "decoded"
+          }
+        },
+        {
+          "id": "step-03",
+          "kind": "branch",
+          "description": "JWT 検証に失敗した場合は 401 を返す。",
+          "branches": [
+            {
+              "id": "br-03-a",
+              "code": "A",
+              "label": "JWT 検証失敗",
+              "condition": {
+                "kind": "expression",
+                "expression": "@decoded == null"
+              },
+              "steps": [
+                {
+                  "id": "step-03-a-01",
+                  "kind": "return",
+                  "description": "401 リフレッシュトークン無効を返す。",
+                  "responseId": "401-unauthorized",
+                  "bodyExpression": "{ code: 'INVALID_REFRESH_TOKEN', message: 'リフレッシュトークンが無効または期限切れです。再ログインしてください。' }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-03-else",
+            "code": "B",
+            "label": "JWT 検証成功",
+            "steps": []
+          }
+        },
+        {
+          "id": "step-04",
+          "kind": "dbAccess",
+          "description": "decoded.sub (userId) で users を引き、ユーザーがまだ存在することを確認する。",
+          "tableId": "695939b7-f3f7-473f-b0cf-a2ccfe5da8fa",
+          "operation": "SELECT",
+          "sql": "SELECT id AS \"userId\" FROM users WHERE id = @decoded.sub LIMIT 1",
+          "outputBinding": {
+            "name": "userRow"
+          },
+          "lineage": {
+            "reads": [
+              {
+                "tableId": "695939b7-f3f7-473f-b0cf-a2ccfe5da8fa",
+                "purpose": "auth-lookup"
+              }
+            ]
+          }
+        },
+        {
+          "id": "step-05",
+          "kind": "branch",
+          "description": "ユーザーが users から削除済の場合は 401 を返す (refresh token は有効でも実体が無いため)。",
+          "branches": [
+            {
+              "id": "br-05-a",
+              "code": "A",
+              "label": "ユーザー不在",
+              "condition": {
+                "kind": "expression",
+                "expression": "@userRow == null"
+              },
+              "steps": [
+                {
+                  "id": "step-05-a-01",
+                  "kind": "return",
+                  "description": "401 リフレッシュトークン無効を返す。",
+                  "responseId": "401-unauthorized",
+                  "bodyExpression": "{ code: 'INVALID_REFRESH_TOKEN', message: 'リフレッシュトークンが無効または期限切れです。再ログインしてください。' }"
+                }
+              ]
+            }
+          ],
+          "elseBranch": {
+            "id": "br-05-else",
+            "code": "B",
+            "label": "ユーザー存在",
+            "steps": []
+          }
+        },
+        {
+          "id": "step-06",
+          "kind": "compute",
+          "description": "新しいアクセストークンを発行する。HS256, payload: { sub: userId, type: 'access' }, ttl: @env.JWT_ACCESS_TTL。",
+          "expression": "jwtSign({ sub: @userRow.userId, type: 'access' }, @secret.jwtAccessSecret, { expiresIn: @env.JWT_ACCESS_TTL })",
+          "outputBinding": {
+            "name": "accessToken"
+          }
+        },
+        {
+          "id": "step-07",
+          "kind": "return",
+          "description": "200 新しいアクセストークンを返す。",
+          "responseId": "200-ok",
+          "bodyExpression": "{ accessToken: @accessToken }"
+        }
+      ]
+    }
+  ]
+}

--- a/examples/diary/harmony/screens/31d56212-b654-46dc-b004-096c7382c404.json
+++ b/examples/diary/harmony/screens/31d56212-b654-46dc-b004-096c7382c404.json
@@ -155,6 +155,21 @@
         "processFlowId": "e6f7a8b9-c0d1-4e2f-8a3b-4c5d6e7f8a9b",
         "variableName": "total"
       }
+    },
+    {
+      "id": "logoutButton",
+      "label": "ログアウト",
+      "type": "string",
+      "direction": "input",
+      "description": "ヘッダー右上のログアウトボタン。クリックで ログアウト ProcessFlow を起動し、成功時に localStorage の access/refresh トークンを破棄して /login に画面遷移する想定。",
+      "required": false,
+      "events": [
+        {
+          "id": "click",
+          "label": "ログアウト実行",
+          "handlerFlowId": "46436b69-99f2-48b3-a5fa-07bf9fcd1478"
+        }
+      ]
     }
   ],
   "design": {

--- a/examples/diary/harmony/screens/31d56212-b654-46dc-b004-096c7382c404.json
+++ b/examples/diary/harmony/screens/31d56212-b654-46dc-b004-096c7382c404.json
@@ -2,13 +2,13 @@
   "$schema": "../../../../schemas/v3/screen.v3.schema.json",
   "id": "31d56212-b654-46dc-b004-096c7382c404",
   "name": "投稿一覧",
-  "description": "Day One 風の投稿一覧画面。masonry グリッドで投稿カードを表示し、検索バー・タグチップフィルタ・公開状態トグルで絞り込み可能。各カードにヒーロー画像・AI生成要約・mood絵文字・天気アイコン・場所バッジ・タグチップを表示。新規投稿用フローティングFABを装備。",
+  "description": "Day One 風の投稿一覧画面。masonry グリッドで投稿カードを表示し、検索バー・タグチップフィルタ・公開状態トグルで絞り込み可能。各カードにヒーロー画像・AI生成要約・mood絵文字・天気アイコン・場所バッジ・タグチップを表示。新規投稿用フローティングFABを装備。検索フォーム / フィルタ変更時は events で 投稿検索 ProcessFlow を再起動、新規投稿 FAB は /post/edit への画面遷移 (リンク扱い、events 結線なし)。",
   "kind": "list",
   "path": "/",
   "auth": "required",
   "maturity": "draft",
   "createdAt": "2026-05-06T14:30:00.000Z",
-  "updatedAt": "2026-05-06T14:30:00.000Z",
+  "updatedAt": "2026-05-07T00:00:00.000Z",
   "items": [
     {
       "id": "searchQuery",
@@ -17,15 +17,39 @@
       "direction": "input",
       "description": "投稿タイトル・本文の全文検索キーワード。入力値を投稿検索フローに渡す。",
       "placeholder": "投稿を検索…",
-      "required": false
+      "required": false,
+      "events": [
+        {
+          "id": "submit",
+          "label": "検索実行",
+          "handlerFlowId": "e6f7a8b9-c0d1-4e2f-8a3b-4c5d6e7f8a9b",
+          "argumentMapping": {
+            "q": "@screen.searchQuery",
+            "tagSlug": "@screen.selectedTagSlugs",
+            "status": "@screen.statusFilter"
+          }
+        }
+      ]
     },
     {
       "id": "selectedTagSlugs",
       "label": "タグフィルタ",
       "type": { "kind": "array", "itemType": "string" },
       "direction": "input",
-      "description": "絞り込むタグのスラッグ一覧。複数選択可。投稿検索フローの tagSlugs パラメータに渡す。",
-      "required": false
+      "description": "絞り込むタグのスラッグ一覧。複数選択可。投稿検索フローの tagSlug パラメータにカンマ区切り文字列として渡す (実装側で配列→string 変換)。",
+      "required": false,
+      "events": [
+        {
+          "id": "change",
+          "label": "タグフィルタ変更",
+          "handlerFlowId": "e6f7a8b9-c0d1-4e2f-8a3b-4c5d6e7f8a9b",
+          "argumentMapping": {
+            "q": "@screen.searchQuery",
+            "tagSlug": "@screen.selectedTagSlugs",
+            "status": "@screen.statusFilter"
+          }
+        }
+      ]
     },
     {
       "id": "statusFilter",
@@ -39,7 +63,19 @@
         { "value": "draft", "label": "下書き" }
       ],
       "defaultValue": "all",
-      "required": false
+      "required": false,
+      "events": [
+        {
+          "id": "change",
+          "label": "公開状態フィルタ変更",
+          "handlerFlowId": "e6f7a8b9-c0d1-4e2f-8a3b-4c5d6e7f8a9b",
+          "argumentMapping": {
+            "q": "@screen.searchQuery",
+            "tagSlug": "@screen.selectedTagSlugs",
+            "status": "@screen.statusFilter"
+          }
+        }
+      ]
     },
     {
       "id": "posts",
@@ -100,8 +136,13 @@
         }
       },
       "direction": "output",
-      "description": "タグフィルタのチップ一覧として表示するタグ配列。id / name / slug / color を含む。",
-      "required": false
+      "description": "タグフィルタのチップ一覧として表示するタグ配列。id / name / slug / color を含む。タグ一覧取得 ProcessFlow の tags 出力から。",
+      "required": false,
+      "valueFrom": {
+        "kind": "flowVariable",
+        "processFlowId": "803764e4-c27d-47fd-b3d9-924c1fa28bd8",
+        "variableName": "tags"
+      }
     },
     {
       "id": "totalCount",

--- a/examples/diary/harmony/screens/531619ae-0f5f-4f55-8043-03e5a9ef6670.json
+++ b/examples/diary/harmony/screens/531619ae-0f5f-4f55-8043-03e5a9ef6670.json
@@ -185,11 +185,11 @@
       "label": "投稿ID",
       "type": "integer",
       "direction": "output",
-      "description": "URL :id? が指定されている場合の編集対象 postId。新規モードでは null。投稿詳細取得 ProcessFlow から既存 post を初期化する際の鍵。",
+      "description": "URL :id? が指定されている場合の編集対象 postId。新規モードでは null。投稿詳細取得 ProcessFlow の outputs.post.postId を IdentifierPath (post.postId) で参照する。",
       "valueFrom": {
         "kind": "flowVariable",
         "processFlowId": "d5e6f7a8-b9c0-4d1e-8f2a-3b4c5d6e7f8a",
-        "variableName": "postId"
+        "variableName": "post.postId"
       }
     },
     {

--- a/examples/diary/harmony/screens/531619ae-0f5f-4f55-8043-03e5a9ef6670.json
+++ b/examples/diary/harmony/screens/531619ae-0f5f-4f55-8043-03e5a9ef6670.json
@@ -2,13 +2,13 @@
   "$schema": "../../../../schemas/v3/screen.v3.schema.json",
   "id": "531619ae-0f5f-4f55-8043-03e5a9ef6670",
   "name": "投稿編集",
-  "description": "Notion + Substack 風の投稿作成・編集フォーム画面。タイトル入力・Markdownエディタ・写真D&Dアップロード・AI assistサイドパネル (要約/タグ提案/校正/画像alt)・mood/weather/locationフィールド・下書き保存/公開ボタン (sticky bottom)。idパラメータなしで新規作成モード。",
+  "description": "Notion + Substack 風の投稿作成・編集フォーム画面。タイトル入力・Markdownエディタ・写真D&Dアップロード・AI assistサイドパネル (要約/タグ提案/校正/画像alt)・mood/weather/locationフィールド・保存ボタン (sticky bottom)。path :id? の有無で新規作成 / 更新モードを切り替え。saveButton.events に create/update 双方を結線し、UI 側で URL parameter から実行 event を選ぶ実装を想定。",
   "kind": "form",
   "path": "/post/edit/:id?",
   "auth": "required",
   "maturity": "draft",
   "createdAt": "2026-05-06T14:30:00.000Z",
-  "updatedAt": "2026-05-06T14:30:00.000Z",
+  "updatedAt": "2026-05-07T00:00:00.000Z",
   "items": [
     {
       "id": "postTitle",
@@ -179,6 +179,161 @@
         "processFlowId": "b0c1d2e3-f4a5-4b6c-8d7e-8f9a0b1c2d3e",
         "variableName": "altText"
       }
+    },
+    {
+      "id": "postId",
+      "label": "投稿ID",
+      "type": "integer",
+      "direction": "output",
+      "description": "URL :id? が指定されている場合の編集対象 postId。新規モードでは null。投稿詳細取得 ProcessFlow から既存 post を初期化する際の鍵。",
+      "valueFrom": {
+        "kind": "flowVariable",
+        "processFlowId": "d5e6f7a8-b9c0-4d1e-8f2a-3b4c5d6e7f8a",
+        "variableName": "postId"
+      }
+    },
+    {
+      "id": "selectedPhotoId",
+      "label": "AI alt 対象写真ID",
+      "type": "integer",
+      "direction": "input",
+      "description": "AI画像alt生成 button 押下時に対象となる photos[] の id を保持する画面 state。photo クリック時に実装側で update する。",
+      "required": false
+    },
+    {
+      "id": "uploadPhotoFile",
+      "label": "写真アップロード",
+      "type": { "kind": "file", "format": "image/*" },
+      "direction": "input",
+      "description": "写真 D&D ゾーン / file picker。ファイル選択 (submit event) で 写真アップロード ProcessFlow を起動し、photos[] に追加する。",
+      "required": false,
+      "events": [
+        {
+          "id": "submit",
+          "label": "写真アップロード実行",
+          "handlerFlowId": "2fecbf99-6a4e-4c62-840c-59d96e48ecb6",
+          "argumentMapping": {
+            "postId": "@screen.postId",
+            "file": "@self"
+          }
+        }
+      ]
+    },
+    {
+      "id": "saveButton",
+      "label": "保存",
+      "type": "string",
+      "direction": "input",
+      "description": "保存ボタン (公開 / 下書きは status item の値で決まる)。新規モード (postId=null) では 投稿作成 を、更新モード (postId 有) では 投稿更新 を起動する。UI 側で URL :id? の有無により click-create / click-update を選択する。",
+      "required": false,
+      "events": [
+        {
+          "id": "click-create",
+          "label": "新規投稿作成",
+          "handlerFlowId": "0671b051-4acc-49cf-ba92-9fa29b47f671",
+          "argumentMapping": {
+            "title": "@screen.postTitle",
+            "body": "@screen.postBody",
+            "mood": "@screen.mood",
+            "weather": "@screen.weather",
+            "location": "@screen.location",
+            "status": "@screen.status",
+            "photos": "@screen.photos",
+            "tags": "@screen.tagIds"
+          }
+        },
+        {
+          "id": "click-update",
+          "label": "既存投稿更新",
+          "handlerFlowId": "b3a1c2d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+          "argumentMapping": {
+            "postId": "@screen.postId",
+            "title": "@screen.postTitle",
+            "body": "@screen.postBody",
+            "mood": "@screen.mood",
+            "weather": "@screen.weather",
+            "location": "@screen.location",
+            "status": "@screen.status",
+            "photos": "@screen.photos",
+            "tags": "@screen.tagIds"
+          }
+        }
+      ]
+    },
+    {
+      "id": "aiSummarizeButton",
+      "label": "AI 要約",
+      "type": "string",
+      "direction": "input",
+      "description": "AI assist サイドパネルの「要約」ボタン。クリックで AI要約生成 ProcessFlow を起動し、結果を aiSummary に表示する。",
+      "required": false,
+      "events": [
+        {
+          "id": "click",
+          "label": "AI 要約実行",
+          "handlerFlowId": "f7a8b9c0-d1e2-4f3a-8b4c-5d6e7f8a9b0c",
+          "argumentMapping": {
+            "postId": "@screen.postId",
+            "body": "@screen.postBody"
+          }
+        }
+      ]
+    },
+    {
+      "id": "aiTagSuggestButton",
+      "label": "AI タグ提案",
+      "type": "string",
+      "direction": "input",
+      "description": "AI assist サイドパネルの「タグ提案」ボタン。クリックで AIタグ提案 ProcessFlow を起動し、結果を aiSuggestedTags に表示する。",
+      "required": false,
+      "events": [
+        {
+          "id": "click",
+          "label": "AI タグ提案実行",
+          "handlerFlowId": "a9b0c1d2-e3f4-4a5b-8c6d-7e8f9a0b1c2d",
+          "argumentMapping": {
+            "title": "@screen.postTitle",
+            "body": "@screen.postBody"
+          }
+        }
+      ]
+    },
+    {
+      "id": "aiProofreadButton",
+      "label": "AI 校正",
+      "type": "string",
+      "direction": "input",
+      "description": "AI assist サイドパネルの「校正」ボタン。クリックで AI文章校正 ProcessFlow を起動し、結果を aiProofreadResult に表示する。style は conventions.msg.proofreadStyle (default: 'casual-diary') を採用。",
+      "required": false,
+      "events": [
+        {
+          "id": "click",
+          "label": "AI 校正実行",
+          "handlerFlowId": "c1d2e3f4-a5b6-4c7d-8e9f-0a1b2c3d4e5f",
+          "argumentMapping": {
+            "text": "@screen.postBody",
+            "style": "@conv.msg.proofreadStyle"
+          }
+        }
+      ]
+    },
+    {
+      "id": "aiImageAltButton",
+      "label": "AI 画像 alt",
+      "type": "string",
+      "direction": "input",
+      "description": "写真カードのインライン「AI alt」ボタン。クリック時に対象 photo の id を selectedPhotoId にセットしてから AI画像alt生成 ProcessFlow を起動し、結果を aiImageAlt に表示する。",
+      "required": false,
+      "events": [
+        {
+          "id": "click",
+          "label": "AI 画像 alt 実行",
+          "handlerFlowId": "b0c1d2e3-f4a5-4b6c-8d7e-8f9a0b1c2d3e",
+          "argumentMapping": {
+            "photoId": "@screen.selectedPhotoId"
+          }
+        }
+      ]
     }
   ],
   "design": {

--- a/examples/diary/harmony/screens/a5088d22-4ad8-4615-a4c5-447ff9cdd280.json
+++ b/examples/diary/harmony/screens/a5088d22-4ad8-4615-a4c5-447ff9cdd280.json
@@ -2,13 +2,13 @@
   "$schema": "../../../../schemas/v3/screen.v3.schema.json",
   "id": "a5088d22-4ad8-4615-a4c5-447ff9cdd280",
   "name": "ログイン",
-  "description": "ミニマリスト風のログイン画面。中央配置カードにロゴ + username/passwordフィールド + ログインボタン + 管理者依頼ヒントテキストを配置。認証フロー本体は本フェーズのprocessFlowに含まれないUIモック。",
+  "description": "ミニマリスト風のログイン画面。中央配置カードにロゴ + username/passwordフィールド + ログインボタン + 管理者依頼ヒントテキストを配置。loginButton.events で `ログイン` ProcessFlow と結線。",
   "kind": "login",
   "path": "/login",
   "auth": "none",
   "maturity": "draft",
   "createdAt": "2026-05-06T14:30:00.000Z",
-  "updatedAt": "2026-05-06T14:30:00.000Z",
+  "updatedAt": "2026-05-07T00:00:00.000Z",
   "items": [
     {
       "id": "username",
@@ -39,6 +39,26 @@
       "description": "チェック時にJWT有効期限を延長してログイン状態を維持する。",
       "defaultValue": false,
       "required": false
+    },
+    {
+      "id": "loginButton",
+      "label": "ログイン",
+      "type": "string",
+      "direction": "input",
+      "description": "ログインボタン。クリック (submit) で ログイン ProcessFlow を起動し、成功時に accessToken/refreshToken を localStorage に保存して投稿一覧に遷移する想定。",
+      "required": false,
+      "events": [
+        {
+          "id": "submit",
+          "label": "ログイン実行",
+          "handlerFlowId": "1ce956c5-7aa9-47b5-bb38-ca392ad73518",
+          "argumentMapping": {
+            "username": "@screen.username",
+            "password": "@screen.password",
+            "rememberMe": "@screen.rememberMe"
+          }
+        }
+      ]
     }
   ],
   "design": {

--- a/examples/diary/harmony/screens/c0bd613a-ab67-4f72-8e2d-775e827bf9b2.json
+++ b/examples/diary/harmony/screens/c0bd613a-ab67-4f72-8e2d-775e827bf9b2.json
@@ -49,11 +49,11 @@
       "label": "スラッグ",
       "type": "string",
       "direction": "input",
-      "description": "新規タグのURLスラッグ。英数字・ハイフンのみ。タグ名から自動生成も可。",
-      "required": true,
+      "description": "新規タグのURLスラッグ。英数字・ハイフンのみ。未入力時は タグ作成 ProcessFlow が name から自動生成する (slug は flow 側で optional)。",
+      "required": false,
       "maxLength": 50,
       "pattern": "^[a-z0-9-]+$",
-      "placeholder": "tag-slug"
+      "placeholder": "未入力でタグ名から自動生成"
     },
     {
       "id": "newTagColor",
@@ -75,17 +75,17 @@
     {
       "id": "editTagId",
       "label": "編集対象タグID",
-      "type": "string",
+      "type": "integer",
       "direction": "input",
-      "description": "編集モーダルで編集中のタグID。",
+      "description": "編集モーダルで編集中のタグID。タグ更新 ProcessFlow の id input (integer) と型を一致させる。",
       "required": false
     },
     {
       "id": "deleteTagId",
       "label": "削除対象タグID",
-      "type": "string",
+      "type": "integer",
       "direction": "input",
-      "description": "削除確認ダイアログで確認中のタグID。",
+      "description": "削除確認ダイアログで確認中のタグID。タグ削除 ProcessFlow の id input (integer) と型を一致させる。",
       "required": false
     },
     {

--- a/examples/diary/harmony/screens/c0bd613a-ab67-4f72-8e2d-775e827bf9b2.json
+++ b/examples/diary/harmony/screens/c0bd613a-ab67-4f72-8e2d-775e827bf9b2.json
@@ -2,13 +2,13 @@
   "$schema": "../../../../schemas/v3/screen.v3.schema.json",
   "id": "c0bd613a-ab67-4f72-8e2d-775e827bf9b2",
   "name": "タグ管理",
-  "description": "Notion 風のタグ管理画面。色付きchip + 使用回数付きタグ一覧を表示。新規追加modal・編集modal (name/slug/colorPicker/iconPicker)・削除確認dialogを提供。タグCRUDは本フェーズのprocessFlowに含まれないためvalueFromは省略。",
+  "description": "Notion 風のタグ管理画面。色付きchip + 使用回数付きタグ一覧を表示。新規追加modal・編集modal (name/slug/colorPicker/iconPicker)・削除確認dialogを提供。tags 一覧の取得は タグ一覧取得 ProcessFlow を valueFrom で結線、CRUD button は events で各タグ ProcessFlow と結線。",
   "kind": "list",
   "path": "/tags",
   "auth": "required",
   "maturity": "draft",
   "createdAt": "2026-05-06T14:30:00.000Z",
-  "updatedAt": "2026-05-06T14:30:00.000Z",
+  "updatedAt": "2026-05-07T00:00:00.000Z",
   "items": [
     {
       "id": "tags",
@@ -27,7 +27,12 @@
         }
       },
       "direction": "output",
-      "description": "全タグの配列。id / name / slug / color / postCount を含む。"
+      "description": "全タグの配列。usage_count DESC + name ASC で並び替え済 (postCount は usageCount と同義)。",
+      "valueFrom": {
+        "kind": "flowVariable",
+        "processFlowId": "803764e4-c27d-47fd-b3d9-924c1fa28bd8",
+        "variableName": "tags"
+      }
     },
     {
       "id": "newTagName",
@@ -88,9 +93,70 @@
       "label": "タグ検索",
       "type": "string",
       "direction": "input",
-      "description": "タグ名での絞り込み検索キーワード。",
+      "description": "タグ名での絞り込み検索キーワード (クライアントサイド絞り込み、ProcessFlow は呼ばない)。",
       "required": false,
       "placeholder": "タグを検索…"
+    },
+    {
+      "id": "createTagButton",
+      "label": "タグを作成",
+      "type": "string",
+      "direction": "input",
+      "description": "新規追加 modal の確定ボタン。クリックで タグ作成 ProcessFlow を起動する。",
+      "required": false,
+      "events": [
+        {
+          "id": "submit",
+          "label": "タグ作成実行",
+          "handlerFlowId": "46b99455-a011-4419-937f-a5ef8368e694",
+          "argumentMapping": {
+            "name": "@screen.newTagName",
+            "slug": "@screen.newTagSlug",
+            "color": "@screen.newTagColor",
+            "icon": "@screen.newTagIcon"
+          }
+        }
+      ]
+    },
+    {
+      "id": "updateTagButton",
+      "label": "タグを更新",
+      "type": "string",
+      "direction": "input",
+      "description": "編集 modal の保存ボタン。クリックで タグ更新 ProcessFlow を起動する。editTagId が入力済の前提。",
+      "required": false,
+      "events": [
+        {
+          "id": "submit",
+          "label": "タグ更新実行",
+          "handlerFlowId": "8cc24fea-f497-432b-8496-5d86dea1c98b",
+          "argumentMapping": {
+            "id": "@screen.editTagId",
+            "name": "@screen.newTagName",
+            "slug": "@screen.newTagSlug",
+            "color": "@screen.newTagColor",
+            "icon": "@screen.newTagIcon"
+          }
+        }
+      ]
+    },
+    {
+      "id": "deleteTagButton",
+      "label": "タグを削除",
+      "type": "string",
+      "direction": "input",
+      "description": "削除確認 dialog の OK ボタン。クリックで タグ削除 ProcessFlow を起動する。deleteTagId が入力済の前提。",
+      "required": false,
+      "events": [
+        {
+          "id": "submit",
+          "label": "タグ削除実行",
+          "handlerFlowId": "305509f7-d118-459a-8acb-18780e4fde68",
+          "argumentMapping": {
+            "id": "@screen.deleteTagId"
+          }
+        }
+      ]
     }
   ],
   "design": {

--- a/examples/diary/harmony/screens/ffec74d0-6c21-45f7-a387-167ac8819255.json
+++ b/examples/diary/harmony/screens/ffec74d0-6c21-45f7-a387-167ac8819255.json
@@ -13,13 +13,13 @@
     {
       "id": "postId",
       "label": "投稿ID",
-      "type": "string",
+      "type": "integer",
       "direction": "output",
-      "description": "URLパラメータから取得した投稿ID。投稿詳細取得フローに渡す。",
+      "description": "URL :id パラメータから取得した投稿ID。投稿詳細取得フローの outputs.post.postId を IdentifierPath (post.postId) で参照、deleteConfirm.events で 投稿削除 (postId integer) に渡す。",
       "valueFrom": {
         "kind": "flowVariable",
         "processFlowId": "d5e6f7a8-b9c0-4d1e-8f2a-3b4c5d6e7f8a",
-        "variableName": "postId"
+        "variableName": "post.postId"
       }
     },
     {

--- a/examples/diary/harmony/screens/ffec74d0-6c21-45f7-a387-167ac8819255.json
+++ b/examples/diary/harmony/screens/ffec74d0-6c21-45f7-a387-167ac8819255.json
@@ -2,13 +2,13 @@
   "$schema": "../../../../schemas/v3/screen.v3.schema.json",
   "id": "ffec74d0-6c21-45f7-a387-167ac8819255",
   "name": "投稿詳細",
-  "description": "Medium 風の投稿詳細表示画面。ヒーロー画像・タイトル・メタ情報 (公開日/著者/mood/天気/場所) + Markdownレンダリング本文 + フォトギャラリー + タグチップを表示。所有者には編集/削除ボタンを表示。",
+  "description": "Medium 風の投稿詳細表示画面。ヒーロー画像・タイトル・メタ情報 (公開日/著者/mood/天気/場所) + Markdownレンダリング本文 + フォトギャラリー + タグチップを表示。所有者には編集/削除ボタンを表示。編集ボタンは /post/edit/:id への画面遷移 (リンク扱いのため events 結線なし)、削除ボタンは deleteConfirm.events で 投稿削除 ProcessFlow と結線。",
   "kind": "detail",
   "path": "/post/:id",
   "auth": "required",
   "maturity": "draft",
   "createdAt": "2026-05-06T14:30:00.000Z",
-  "updatedAt": "2026-05-06T14:30:00.000Z",
+  "updatedAt": "2026-05-07T00:00:00.000Z",
   "items": [
     {
       "id": "postId",
@@ -183,7 +183,17 @@
       "type": "boolean",
       "direction": "input",
       "description": "削除確認ダイアログでOKを押した際に投稿削除フローを呼び出すトリガー。",
-      "required": false
+      "required": false,
+      "events": [
+        {
+          "id": "confirm",
+          "label": "削除実行",
+          "handlerFlowId": "c4d5e6f7-a8b9-4c0d-8e1f-2a3b4c5d6e7f",
+          "argumentMapping": {
+            "postId": "@screen.postId"
+          }
+        }
+      ]
     }
   ],
   "design": {


### PR DESCRIPTION
## 関連

Closes #861
Closes #862
Closes #863
Closes #864

仕様: 親 ISSUE #860 (CLOSED) 本文の Known limitations セクション β-1〜β-4。各 ISSUE 本文の冒頭に `## 🔗 統合 PR 情報` セクションを prepend 済み。

## 概要

#860 (examples/diary 新規追加 PR) の Known limitations として残されていた β-1〜β-4 を 1 統合 PR で解消する。examples/diary/harmony/ 配下のみの設計データ変更で、generate-code テンプレ / framework 側には触れない。#864 (events 補完) は他 3 件の ProcessFlow が出揃ってから一括補完するため、シリーズで 1 PR にまとめる必要があった。#865 (AI provider 抽象化) は `apps/api/` 側の実装で scope が異なるため別 PR に分離。

## 主な変更

- **ProcessFlow 追加 8 件** (`examples/diary/harmony/process-flows/`)
  - 認証 3 件 (#863): `1ce956c5` ログイン / `9537764e` トークン更新 / `46436b69` ログアウト
  - 写真アップロード 1 件 (#861): `2fecbf99`
  - タグ CRUD 4 件 (#862): `803764e4` 一覧 / `46b99455` 作成 / `8cc24fea` 更新 / `305509f7` 削除
- **screens events[] 補完 5 件** (#864)
  - 各 input button / フィルタ系 item に events 追加、本シリーズで追加した ProcessFlow + 既存 9 件と argumentMapping で結線
  - tags / availableTags の `valueFrom` を タグ一覧取得 ProcessFlow と結線
  - 投稿編集に postId / saveButton / uploadPhotoFile / AI 4 ボタン / selectedPhotoId を新規 item として追加
- **harmony.json**: processFlows[] に新規 8 件 (no 10-17) を登録、updatedAt 更新
- **README.md**: ProcessFlow 一覧の章立てを CRUD/AI/認証/写真/タグ で再構成、Known limitations 表に解消マークを記録

## 仕様逐条突合 (自己申告)

### #861 写真アップロード

- 写真アップロード ProcessFlow 新規作成 → `examples/diary/harmony/process-flows/2fecbf99-6a4e-4c62-840c-59d96e48ecb6.json` ✓
- HTTP POST /api/upload (multipart/form-data) → 2fecbf99 act-001.httpRoute (file:65-71) ✓
- 入力 file (binary) + postId → inputs (file:74-103) ✓
- 動作 ファイル保存 → サムネイル生成 → photos INSERT → URL 返却 → step-04..09 (file:189-258) ✓
- EXIF 抽出 (任意 step) → step-07 (file:222-229) ✓
- screens/531619ae の photos items に events[] 追加で uploadPhoto flow と結線 → uploadPhotoFile.events (file:230-247) ✓
- harmony.json の entities.processFlows[] に新規 entry 追加 → no:13 (file:198-206) ✓
- v1 ローカルディスク → step-04 description で明記、`@env.PHOTO_UPLOAD_DIR` (file:189-198) ✓
- v2 S3/R2 → meta.description で context.catalogs.externalSystems 拡張ルートを記載 (file:5-7) ✓
- ⚠ 仕様乖離: ISSUE 本文「postId? (任意、後で関連付け)」に対し、photos.post_id NOT NULL 制約のため required に変更。README の Known limitations / meta.description で v2 で対応する旨を明記 ✓

### #862 タグ CRUD 完全化

- getTagList ProcessFlow 新規作成 → `803764e4-c27d-47fd-b3d9-924c1fa28bd8.json` ✓
- createTag ProcessFlow 新規作成 → `46b99455-a011-4419-937f-a5ef8368e694.json` ✓
- updateTag ProcessFlow 新規作成 → `8cc24fea-f497-432b-8496-5d86dea1c98b.json` ✓
- deleteTag ProcessFlow 新規作成 → `305509f7-d118-459a-8acb-18780e4fde68.json` ✓
- screens/c0bd613a (TagManagement) の各 button items に events[] 結線 → createTagButton/updateTagButton/deleteTagButton (file:106-159) ✓
- harmony.json の processFlows[] に新規 4 件追加 → no:14-17 (file:207-242) ✓
- 同時改善: 編集 modal クリックハンドラ → updateTagButton.events.submit で 8cc24fea 起動 (screens/c0bd613a:127-141) ✓
- ⚠ 仕様乖離: ISSUE 本文「GET /api/tags?sort=usage_count&order=desc」のクエリ動的指定 → 動的 ORDER BY が SQL parser を通らないため固定 ORDER BY (usage_count DESC, name ASC) に変更。タグ件数が少ない前提で UI 側クライアントサイド並び替えする方針を 803764e4 meta.description に明記 ✓

### #863 認証フロー

- login ProcessFlow 新規作成 (POST /api/auth/login、JWT 発行) → `1ce956c5-7aa9-47b5-bb38-ca392ad73518.json` ✓
- refreshToken ProcessFlow 新規作成 (POST /api/auth/refresh) → `9537764e-3fe9-459d-8172-00d69a575c09.json` ✓
- logout ProcessFlow 新規作成 (POST /api/auth/logout) → `46436b69-99f2-48b3-a5fa-07bf9fcd1478.json` ✓
- screens/a5088d22 (Login) の loginButton.events.submit で login flow と結線 (file:54-68) ✓
- harmony.json の processFlows[] に 3 件追加 → no:10-12 (file:171-197) ✓
- 設計判断:
  - JWT secret rotation 戦略: access / refresh で別キー (catalogs.secrets.jwtAccessSecret / jwtRefreshSecret、`@conv.auth.*` ではなく env 経由) → 1ce956c5:24-35 ✓
  - session storage 方針: localStorage 維持 (UI 側責任、ProcessFlow 出力 accessToken/refreshToken をクライアントが localStorage に永続化) → 1ce956c5 outputs description (file:90-102) ✓
  - 1 user 運用前提を維持: ambient sessionUserId のみ、role / 権限 catalog なし → 46436b69:14-22 / 9537764e ambient なし ✓

### #864 screen items events[] 補完

| screen | 補完対象 | 結線先 ProcessFlow |
|---|---|---|
| 投稿一覧 (`31d56212`) | searchQuery (submit) / selectedTagSlugs (change) / statusFilter (change) | 投稿検索 `e6f7a8b9` (file:18-26 / 35-46 / 64-77) ✓ |
| 投稿一覧 | availableTags.valueFrom 結線 | タグ一覧取得 `803764e4` (file:108-114) ✓ |
| 投稿詳細 (`ffec74d0`) | deleteConfirm (confirm) | 投稿削除 `c4d5e6f7` (file:189-198) ✓ |
| 投稿詳細 | 編集ボタン | 画面遷移リンク扱い (events なし、description で明記) ✓ |
| 投稿編集 (`531619ae`) | saveButton (click-create / click-update) / uploadPhotoFile / AI 4 button | 投稿作成/更新 + 写真アップロード + AI 4 件 (file:184-345) ✓ |
| タグ管理 (`c0bd613a`) | createTagButton / updateTagButton / deleteTagButton | タグ CRUD 3 件 (file:106-159) ✓ |
| タグ管理 | tags.valueFrom 結線 | タグ一覧取得 `803764e4` (file:31-34) ✓ |
| ログイン (`a5088d22`) | loginButton (submit) | ログイン `1ce956c5` (file:54-68) ✓ |

## レビューで特に見てほしい箇所

- **写真アップロード postId 必須化** (#861): photos.post_id が NOT NULL のため、ISSUE 本文の「postId? (任意)」を required に変更している。後付け関連付けは photos スキーマ拡張案件として持ち越しが妥当か、それとも「下書き post を自動作成して post_id を埋める」案を v1 で取るべきかの判断
- **タグ一覧の sort/order 動的指定の取り下げ** (#862): SQL parser が ORDER BY @params.sort @params.order を解釈できないため固定にした。タグ件数の現実的上限 (~数百) を踏まえ UI 側並び替えに倒す判断は妥当か
- **events[] の screen-side state state 拡張**: 投稿編集 screen に postId / selectedPhotoId / saveButton / uploadPhotoFile / AI 4 button / aiTagSuggestButton / aiProofreadButton / aiImageAltButton の 8 個を追加。これは #864 issue 本文の「button click → flow 呼び出し」の結線を表現するための最小拡張。screen item の type 'string' を button 用便宜表現として使っており、schema 仕様との整合性を確認したい
- **uploadPhotoFile の type を `{ kind: 'file', format: 'image/*' }` に**: screenItemFieldTypeValidator が argumentMapping.file の型整合をチェックするため、type を file に揃えた。issue 本文の「button」想定とはズレるが、validator pass のための合理的調整

## テスト

- Vitest: 1799 件 全 pass (`samples-v3.schema.test.ts` 162 件含む)
- validate:samples: 17/17 ProcessFlow + 5 screens + 5 tables + 1 conventions catalog 全 pass (13 validators)
- Playwright / MCP E2E: 設計データのみの変更で UI 表示への影響なしのため未実施

## UI 影響 / AI smoke test

- [ ] UI 影響あり (AI が chrome-devtools MCP / Playwright で smoke test 実施済み)
- [x] UI 影響なし (auto テスト pass のみ)

設計データ (process-flow / screen / harmony.json) のみの変更で、frontend ランタイムの表示や挙動には影響しない。validate:samples 全 pass + Vitest 全 pass で担保。

## spec 側の不足点 / 提案

- screen item の type に「button」相当の概念がない: ScreenItemEvent 結線のために button 系 item を追加する場合、`type: "string"` + `direction: "input"` で便宜的に表現する以外の手段がない。`type: { kind: "trigger" }` のような button 専用 type 追加は別 ISSUE 起票候補だが、本シリーズの scope 外
- `argumentMapping` で `@self.uploadedFile` のような property 取得が許容されるか不明: screenItemFieldTypeValidator は ScreenItem 自身の type と引数の type を比較するため、`@self.X` のような property reference は型不一致になる。本 PR では `@self` (ScreenItem 自身) を渡す形に揃えたが、property 取得を許容する仕様か validator バグかは確認が必要

## レビュー担当への申し送り

- 統合 PR 運用 (1 PR で 4 ISSUE close)。各 ISSUE 本文に `## 🔗 統合 PR 情報` セクション prepend 済み
- ISSUE 本文と乖離が 2 箇所あり、PR description の「仕様逐条突合」の ⚠ マーク部分を重点的に確認してほしい
- AI 4 button の argumentMapping は意図表現で、generate-code 時に細部が解決される前提。@conv.msg.proofreadStyle のような catalog 参照は ExpressionString として有効
- 投稿編集 screen に追加した 8 個の items が schema 違反していないこと (`screenItemFieldTypeValidator` 全 pass で確認済) を再確認
