### PR TITLE
feat(framework): ProcessFlow に AI step kind を追加 — aiCall / aiAgent + modelEndpoints (#935)

### DIFF
--- a/.claude/skills/create-flow/SKILL.md
+++ b/.claude/skills/create-flow/SKILL.md
@@ -75,9 +75,10 @@ ProcessFlow JSON に含めるべき要素 (5/5 達成サンプル準拠):
 | `ambientVariables` | requestId / sessionUserId 等の暗黙変数定義 |
 | `errorCatalog` | 5 件以上、key + httpStatus + defaultMessage + responseRef |
 | `externalSystemCatalog` | 連携する外部システム (auth / baseUrl / timeoutMs / openApiSpec 任意) |
+| `modelEndpointCatalog` | AI モデルエンドポイント (provider / model / auth / defaults / fallback) — `aiCall` / `aiAgent` step から参照 (#935) |
 | `secretsCatalog` | 各 API トークン (source / name / rotationDays) |
 | `domainsCatalog` | ID 系・金額系等のドメイン型 (constraints 付き) |
-| `functionsCatalog` | 業務固有関数のシグネチャ (signature / returnType / examples) |
+| `functionsCatalog` | 業務固有関数のシグネチャ (signature / returnType / examples) — `aiCall.tools[].functionRef` から tool として再利用可 |
 | `actions[]` | 1-3 アクション。各 trigger / inputs / outputs / responses / steps |
 | `testScenarios` | 3 件以上 (happy path / validation error / 業務エッジケース)、各 SELECT 対象テーブルについて行ありパターン + 行なしパターン (新規ユーザー / 初回利用) を網羅 (#608) |
 

--- a/.claude/skills/create-flow/SKILL.md
+++ b/.claude/skills/create-flow/SKILL.md
@@ -74,11 +74,11 @@ ProcessFlow JSON に含めるべき要素 (5/5 達成サンプル準拠):
 | `decisions` | ADR 形式 3 件以上 (id / title / status / context / decision / consequences / date) |
 | `ambientVariables` | requestId / sessionUserId 等の暗黙変数定義 |
 | `errorCatalog` | 5 件以上、key + httpStatus + defaultMessage + responseRef |
-| `externalSystemCatalog` | 連携する外部システム (auth / baseUrl / timeoutMs / openApiSpec 任意) |
-| `modelEndpointCatalog` | AI モデルエンドポイント (provider / model / auth / defaults / fallback) — `aiCall` / `aiAgent` step から参照 (#935) |
-| `secretsCatalog` | 各 API トークン (source / name / rotationDays) |
-| `domainsCatalog` | ID 系・金額系等のドメイン型 (constraints 付き) |
-| `functionsCatalog` | 業務固有関数のシグネチャ (signature / returnType / examples) — `aiCall.tools[].functionRef` から tool として再利用可 |
+| `externalSystemCatalog` (= `context.catalogs.externalSystems`) | 連携する外部システム (auth / baseUrl / timeoutMs / openApiSpec 任意) |
+| `modelEndpointCatalog` (= `context.catalogs.modelEndpoints`) | AI モデルエンドポイント (provider / model / auth / defaults / fallback) — `aiCall` / `aiAgent` step から `modelRef` で参照 (#935) |
+| `secretsCatalog` (= `context.catalogs.secrets`) | 各 API トークン (source / name / rotationDays) |
+| `domainsCatalog` (= `context.catalogs.domains`) | ID 系・金額系等のドメイン型 (constraints 付き) |
+| `functionsCatalog` (= `context.catalogs.functions`) | 業務固有関数のシグネチャ (signature / returnType / examples) — `aiCall.tools[].functionRef` から tool として再利用可 |
 | `actions[]` | 1-3 アクション。各 trigger / inputs / outputs / responses / steps |
 | `testScenarios` | 3 件以上 (happy path / validation error / 業務エッジケース)、各 SELECT 対象テーブルについて行ありパターン + 行なしパターン (新規ユーザー / 初回利用) を網羅 (#608) |
 

--- a/.claude/skills/generate-code/SKILL.md
+++ b/.claude/skills/generate-code/SKILL.md
@@ -169,6 +169,8 @@ ProcessFlow JSON を入力として、techStack に基づく backend code 雛形
 | `return` | `return ResponseEntity.<T>status(N).body(body)` | `throw new HttpException(body, status)` または `return response` |
 | `validation` | Bean Validation DTO + `@Valid` Controller 引数 | `class-validator` DTO デコレータ |
 | `log` | `log.error(message, structuredData)` | `this.logger.error(message, structuredData)` |
+| `aiCall` (#935) | `modelEndpoints.<modelRef>.provider` に従い SDK 切替 (anthropic-java-sdk / openai-java / langchain4j 等)。tools[] は `tool_use` block で渡す、responseFormat=structuredObject は JSON Schema 強制 | `modelEndpoints.<modelRef>.provider` に従い `@anthropic-ai/sdk` / `openai` / `langchain` 等切替。tools / structured output 同様 |
+| `aiAgent` (#935) | tool call loop を SDK / 自前実装で `maxIterations` 回まで実装 (anthropic agent SDK / openai assistants → responses 移行 / langchain Runnable / langgraph 等) | 同左、JS/TS SDK で実装 |
 | `other` | `// TODO: {{step.description}}` + outputSchema で型推定 (注: schema の `kind` に `other` は存在しない。extension step では `type: "other"` を使う別階層の概念であるため混同注意) | 同左 |
 
 ### affectedRowsCheck → 実装パターン

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -21,6 +21,7 @@
 | [process-flow-env-vars.md](process-flow-env-vars.md) | 環境変数カタログ (`envVarsCatalog`) — 環境別 (dev/staging/prod) の型付き設定値 | #414 |
 | [process-flow-secrets.md](process-flow-secrets.md) | Secrets カタログ (`secretsCatalog`) — 秘匿値メタデータ + 環境別参照式 | #261 / #414 |
 | [process-flow-transaction.md](process-flow-transaction.md) | `TransactionScopeStep` (複数 DB 操作を 1 TX でまとめる meta-step) と既存 `txBoundary` の関係 | #415 |
+| [process-flow-ai-step-kind.md](process-flow-ai-step-kind.md) | AI step kind (`aiCall` / `aiAgent`) と `modelEndpoints` catalog — provider 抽象 / tool use / structured output / vision input (業界標準形式準拠) | #935 |
 | [screen-items.md](screen-items.md) | 画面項目定義 (フォーム系バリデーション 3 層のうち「画面」層) — **ドラフト v0.1** | #318 |
 | [view-definition.md](view-definition.md) | ViewDefinition (画面 一覧 UI viewer) — 3 レベル DSL (Simple / Structured / Raw SQL) / items[] の direction:viewer 連携 / kind 別レイアウト / validator 11 観点 | #649 / #666 / #745 / #761 |
 | [plugin-system.md](plugin-system.md) | プラグインシステム — ソース変更なしにスキーマ・ステップ型・enum を拡張する仕組み | #390 |

--- a/docs/spec/process-flow-ai-step-kind.md
+++ b/docs/spec/process-flow-ai-step-kind.md
@@ -58,7 +58,7 @@ N=2 で表現方法が分裂しており、放置すると後続 sample (CRM / E
 - **provider** (enum): `anthropic` / `openai` / `google` / `aws-bedrock` / `ollama` / `azure-openai` または拡張 `namespace:provider` 形式
 - **model**: provider 固有のモデル ID
 - **endpoint**: API base URL (省略時は provider のデフォルト、Ollama / 自前 BYO endpoint で必須)
-- **auth**: `ExternalAuth` (kind: bearer / apiKey / oauth2 / iamRole / azureAd / none、tokenRef は `@secret.<key>` 参照)
+- **auth**: `ExternalAuth` (kind: bearer / basic / apiKey / oauth2 / iamRole / azureAd / none、tokenRef は `@secret.<key>` 参照)
 - **defaults**: temperature / maxTokens 等のデフォルト推論パラメータ (step 側 parameters で override)
 - **fallback**: プライマリ失敗時の fallback endpoint key (推奨: 別 provider)
 
@@ -115,12 +115,14 @@ N=2 で表現方法が分裂しており、放置すると後続 sample (CRM / E
 
 ### `AiResponseFormat`
 
-| kind | 説明 |
-|---|---|
-| `text` | デフォルト、自由テキスト |
-| `json` | free-form JSON、parse のみ (schema 制約なし) |
-| `structuredObject` + `schema` | JSON Schema 準拠の構造化出力 (Anthropic / OpenAI / Dify 共通) |
-| `streaming` | SSE / WebSocket、partial response |
+| kind | 追加 field | 説明 |
+|---|---|---|
+| `text` | (なし) | デフォルト、自由テキスト。`kind` 以外の field は不可 (`additionalProperties: false`) |
+| `json` | `description?` | free-form JSON、parse のみ (schema 制約なし) |
+| `structuredObject` | `schema` (必須) + `name?` | JSON Schema 準拠の構造化出力 (Anthropic / OpenAI / Dify 共通) |
+| `streaming` | `description?` | SSE / WebSocket、partial response |
+
+各 variant は schema で `additionalProperties: false`。`text` は `kind` のみ、他 variant も列挙された field 以外は不可。
 
 ## 使用例
 
@@ -259,6 +261,8 @@ env 切替の典型:
 - `examples/diary` の `externalSystem` step + `catalogs.externalSystems.claudeApi` を `aiCall` + `catalogs.modelEndpoints.<key>` に移行
 - `examples/english-learning` の `english-learning:LlmDialog` を `aiAgent` (multi-turn) に移行
 - `examples/english-learning/harmony/extensions/english-learning.v3.json` から `LlmDialog` stepKind 定義を削除 (`TtsGenerate` / `SttEvaluate` は当面残す)
+- `/generate-tests` skill の AI flow 検出ロジックを **`kind=aiCall|aiAgent`** に対応させる (現状 `kind=externalSystem` + `systemRef=claudeApi` 等の旧パターン検出のままだと、Phase 2 移行後の sample で AI flow が検出されず、生成テストが旧 fixture 期待のままになる)
+- `/generate-code` skill のテンプレート (`templates/backend/typescript-nestjs/` / `templates/backend/java-spring-boot/`) に `aiCall` / `aiAgent` step の SDK 切替コード生成ロジックを追加 (現状 `SKILL.md` の step kind table に方針記述のみで、テンプレート本体は未対応)
 
 ## 関連
 

--- a/docs/spec/process-flow-ai-step-kind.md
+++ b/docs/spec/process-flow-ai-step-kind.md
@@ -1,0 +1,269 @@
+# ProcessFlow AI Step Kind (#935)
+
+**初版: 2026-05-08**
+
+## 目的
+
+業務アプリにおける LLM / AI agent 呼び出しを ProcessFlow の **一級概念** として表現する。Anthropic / OpenAI / Google / AWS Bedrock / Ollama / Azure OpenAI の現代的 AI provider を、step 側に provider 直書きせず catalog 経由で抽象化する。tool use / structured output / vision input / agent loop を業界標準形式で扱う。
+
+## 背景
+
+ProcessFlow には従来 AI 呼び出し専用の step kind が無く、各 sample がアドホックに表現していた:
+
+| sample | 表現方法 | 限界 |
+|---|---|---|
+| `examples/diary` | `externalSystem` step + `catalogs.externalSystems.claudeApi` (Anthropic 固有) | provider 直書き、provider 切替は catalog 全体の書換必要、tool use / structured output が semantic に表現できない |
+| `examples/english-learning` | `english-learning:LlmDialog` namespace 拡張 stepKind (extensions/english-learning.v3.json) | namespace ごとに同じ概念を再発明、core 標準化されておらず、業界共通の tool / response_format 構造を持てない |
+
+N=2 で表現方法が分裂しており、放置すると後続 sample (CRM / EC / 製造業 etc.) が独自表現を作り、移行コストが指数的に増える。リリース前のため breaking change / migration コストが発生しないタイミングで core 標準化する (#935 設計者承認 2026-05-08)。
+
+## 業界共通パターン (採用根拠)
+
+公式 doc 調査結果 (Azure AI Foundry Prompt Flow / Dify Workflow / LangChain LCEL / OpenAI Responses / Anthropic Messages / AWS Bedrock Agents / Camunda BPMN AI Connectors) より:
+
+1. **modality 別分割は少数派** — ほぼ全プラットフォームが「LLM 呼び出し」を 1 概念で扱い、画像/音声は messages 内 content block か別 endpoint
+2. **single-shot vs agent loop の 2 分は普遍** — Camunda (Task vs Sub-process) / OpenAI (Responses vs Conversations) / LangGraph
+3. **provider 切替は connection / endpoint catalog 型** — 個別 step に provider 直書きせず参照キーで間接化
+4. **tool は array of `{name, description, parameters: JSON Schema}`** が事実上の標準
+5. **structured output は JSON Schema で response_format / schema として宣言**
+
+→ 上記 5 パターンに準拠した設計を採用する。
+
+## 採用設計
+
+### Step kinds (2 種類)
+
+| kind | 用途 | 業界対応 |
+|---|---|---|
+| `aiCall` | single-shot LLM 呼び出し (text + vision multimodal + tool use + structured output) | OpenAI Responses / Anthropic Messages / Camunda AI Agent Task |
+| `aiAgent` | multi-step agent loop (`maxIterations` 制御、tool call 連鎖) | LangGraph / Camunda AI Agent Sub-process / OpenAI Conversations |
+
+`aiCall` は tool 結果を後続 step (compute / dbAccess) で評価する用途、`aiAgent` は LLM 自身が tool 結果を見て次の tool を選ぶ自律 loop。tool が無い単発呼び出しは `aiCall` を使う。
+
+### catalog: `context.catalogs.modelEndpoints`
+
+```json
+"modelEndpoints": {
+  "summarizeModel": {
+    "provider": "anthropic",
+    "model": "claude-opus-4-7",
+    "endpoint": "https://api.anthropic.com",
+    "auth": { "kind": "bearer", "tokenRef": "@secret.anthropicApiKey" },
+    "defaults": { "temperature": 0.7, "maxTokens": 1024 },
+    "fallback": "summarizeModelFallback"
+  }
+}
+```
+
+- **provider** (enum): `anthropic` / `openai` / `google` / `aws-bedrock` / `ollama` / `azure-openai` または拡張 `namespace:provider` 形式
+- **model**: provider 固有のモデル ID
+- **endpoint**: API base URL (省略時は provider のデフォルト、Ollama / 自前 BYO endpoint で必須)
+- **auth**: `ExternalAuth` (kind: bearer / apiKey / oauth2 / iamRole / azureAd / none、tokenRef は `@secret.<key>` 参照)
+- **defaults**: temperature / maxTokens 等のデフォルト推論パラメータ (step 側 parameters で override)
+- **fallback**: プライマリ失敗時の fallback endpoint key (推奨: 別 provider)
+
+### `AiCallStep` の field
+
+| field | 型 | 必須 | 説明 |
+|---|---|---|---|
+| `kind` | `"aiCall"` | ✓ | const |
+| `modelRef` | Identifier | ✓ | `modelEndpoints` のキー参照 |
+| `messages` | `AiMessage[]` (minItems=1) | ✓ | system / user / assistant の role 別 |
+| `tools` | `AiToolRef[]` | | LLM に提供する tool 群 |
+| `toolChoice` | `auto` / `any` / `none` / `{name}` | | tool 選択戦略 |
+| `responseFormat` | `AiResponseFormat` | | text / json / structuredObject (JSON Schema) / streaming |
+| `parameters` | `AiInferenceParameters` | | modelEndpoint.defaults を override |
+| `outputBinding` | from `StepBaseProps` | | LLM 応答全体を変数に bind |
+| `outcomes` | `ExternalCallOutcomes` | | 失敗 / timeout 時の挙動 (既存パターン流用) |
+
+### `AiAgentStep` の field
+
+`AiCallStep` の上位互換。差分のみ:
+- `tools` が **必須** (`minItems=1`、tool なしなら `aiCall` を使う)
+- `maxIterations` (integer, default 10) で tool call ループ上限を指定
+
+### `AiMessage.content`
+
+`string` (シンプルテキスト) または content blocks 配列 (text / image)。Anthropic / OpenAI と整合。
+
+```json
+{ "role": "user", "content": "本文を要約してください: @inputs.body" }
+```
+
+```json
+{ "role": "user", "content": [
+  { "type": "text", "text": "この画像の alt を生成してください。" },
+  { "type": "image", "source": { "kind": "fileRef", "ref": "@inputs.photo" } }
+]}
+```
+
+`image.source` は 3 形式: `fileRef` (推奨、ScreenItem type=file / step output 参照) / `url` / `base64` (test fixture 等限定)。
+
+### `AiToolRef`
+
+```json
+{ "kind": "functionRef", "ref": "lookupGlossary" }
+```
+
+または
+
+```json
+{ "kind": "inline", "name": "suggestTag", "description": "...", "parameters": { ... JSON Schema ... } }
+```
+
+`functionRef` は `context.catalogs.functions` の既存 entry を再利用 (DRY)。`inline` はアドホック使用。
+
+### `AiResponseFormat`
+
+| kind | 説明 |
+|---|---|
+| `text` | デフォルト、自由テキスト |
+| `json` | free-form JSON、parse のみ (schema 制約なし) |
+| `structuredObject` + `schema` | JSON Schema 準拠の構造化出力 (Anthropic / OpenAI / Dify 共通) |
+| `streaming` | SSE / WebSocket、partial response |
+
+## 使用例
+
+### 1. シンプル要約 (text)
+
+```json
+{
+  "id": "step-summarize",
+  "kind": "aiCall",
+  "description": "本文を 3-5 文で要約する",
+  "modelRef": "summarizeModel",
+  "messages": [
+    { "role": "system", "content": "あなたは日本語要約の専門家です。" },
+    { "role": "user", "content": "@inputs.body" }
+  ],
+  "outputBinding": { "name": "summaryResponse" }
+}
+```
+
+### 2. structured output (タグ提案)
+
+```json
+{
+  "id": "step-suggest",
+  "kind": "aiCall",
+  "description": "本文からタグ候補を構造化出力する",
+  "modelRef": "tagSuggestModel",
+  "messages": [{ "role": "user", "content": "@inputs.body" }],
+  "responseFormat": {
+    "kind": "structuredObject",
+    "name": "TagSuggestResult",
+    "schema": {
+      "type": "object",
+      "properties": {
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+            },
+            "required": ["name", "confidence"]
+          }
+        }
+      },
+      "required": ["tags"]
+    }
+  },
+  "outputBinding": { "name": "tagsResponse" }
+}
+```
+
+### 3. vision input (画像 alt 生成)
+
+```json
+{
+  "id": "step-alt",
+  "kind": "aiCall",
+  "description": "写真の alt text を生成する",
+  "modelRef": "altTextModel",
+  "messages": [
+    { "role": "user", "content": [
+      { "type": "text", "text": "この画像の alt テキストを 40-100 字で生成してください。" },
+      { "type": "image", "source": { "kind": "fileRef", "ref": "@inputs.photo" } }
+    ] }
+  ],
+  "outputBinding": { "name": "altResponse" }
+}
+```
+
+### 4. agent loop (顧客サポート)
+
+```json
+{
+  "id": "step-agent",
+  "kind": "aiAgent",
+  "description": "顧客問い合わせを agent loop で解決する",
+  "modelRef": "supportAgent",
+  "messages": [
+    { "role": "system", "content": "あなたはサポートエージェントです。" },
+    { "role": "user", "content": "@inputs.query" }
+  ],
+  "tools": [
+    { "kind": "functionRef", "ref": "searchKnowledgeBase" },
+    { "kind": "functionRef", "ref": "createTicket" },
+    { "kind": "functionRef", "ref": "escalateToHuman" }
+  ],
+  "maxIterations": 5,
+  "outputBinding": { "name": "agentResult" }
+}
+```
+
+## provider 切替の運用
+
+`modelEndpoints` catalog で `provider` / `model` / `endpoint` / `auth` を **1 か所に集約** することで、provider 切替は catalog の編集だけで完結する。step 側は `modelRef` のキー参照のみで provider 非依存。
+
+env 切替の典型:
+
+```json
+"modelEndpoints": {
+  "summarizeModel": {
+    "provider": "anthropic",
+    "model": "claude-opus-4-7",
+    "auth": { "kind": "bearer", "tokenRef": "@secret.anthropicApiKey" }
+  }
+}
+```
+
+別環境では同 endpoint key を別 provider で再定義 (例: ローカル開発で Ollama に切替):
+
+```json
+"modelEndpoints": {
+  "summarizeModel": {
+    "provider": "ollama",
+    "model": "llama3.1:70b",
+    "endpoint": "http://localhost:11434",
+    "auth": { "kind": "none" }
+  }
+}
+```
+
+## ドメイン固有 AI 機能 (TTS / STT / Embedding / ImageGen) との関係
+
+本 spec は **LLM 呼び出し (text + vision + tool use)** の core 標準化に絞る。TTS (Text-to-Speech) / STT (Speech-to-Text) / Embedding / ImageGen は別 endpoint で別概念のため、当面は以下のいずれかで対応:
+
+1. **namespace 拡張 stepKind**: `examples/english-learning` の `english-learning:TtsGenerate` / `:SttEvaluate` のように、業界別の namespace 拡張で表現
+2. **将来 core 化**: 業務アプリ横断の汎用ニーズが見えた時点 (N=3+ で複数 sample が同じ概念を再発明している状況) で `aiTts` / `aiStt` / `aiEmbedding` / `aiImageGen` を core に追加する候補
+
+英語学習 sample の domain 固有 fieldType (`cefrLevel` / `ipa` / `audioUrl` / `pronunciationScore` / `dialogTurn`) は業務ドメイン固有のため namespace 拡張に残す (core 化対象外)。
+
+## 既存表現からの移行 (Phase 2、別 PR)
+
+本 spec を含む PR (Phase 1) は schema 改変 + spec + test fixture のみ。既存 sample (diary AI 4 flow + english-learning AI 3 flow) の `aiCall` / `aiAgent` への書き換えは **別セッションで Phase 2 として実施** する。Phase 2 完了時に:
+
+- `examples/diary` の `externalSystem` step + `catalogs.externalSystems.claudeApi` を `aiCall` + `catalogs.modelEndpoints.<key>` に移行
+- `examples/english-learning` の `english-learning:LlmDialog` を `aiAgent` (multi-turn) に移行
+- `examples/english-learning/harmony/extensions/english-learning.v3.json` から `LlmDialog` stepKind 定義を削除 (`TtsGenerate` / `SttEvaluate` は当面残す)
+
+## 関連
+
+- 起票元 ISSUE: #935 (本 spec)
+- supersede: #865 (examples/diary AI provider 抽象化、本 spec が正規解決策)
+- 連動: #867 (Codex App Server BYOS、Harmony 本体側 AI 統合 — 別レイヤー)
+- supersede memory: `project_phase2_modelEndpoint_rfc_2026_05_07.md` (RFC 起票方針 → 即実施に変更)
+- 上位 memory: `project_ai_step_kind_core_2026_05_08.md`

--- a/frontend/src/schemas/ai-step-kind.schema.test.ts
+++ b/frontend/src/schemas/ai-step-kind.schema.test.ts
@@ -1,0 +1,328 @@
+/**
+ * AI step kind (aiCall / aiAgent) と modelEndpoints catalog の core schema 動作証明 (#935)。
+ *
+ * examples/* には sample 移行 (Phase 2) 完了まで AI step kind 使用箇所が無いため、
+ * samples-v3.schema.test.ts では新 step kind が validator を通っているか検証できない。
+ * 本ファイルが「core schema が新 step kind を認識し、想定通り valid/invalid 判定する」を test fixture で証明する。
+ *
+ * 関連: project_ai_step_kind_core_2026_05_08.md
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import Ajv2020, { type ValidateFunction } from "ajv/dist/2020";
+import addFormats from "ajv-formats";
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve, join } from "node:path";
+
+const repoRoot = resolve(__dirname, "../../../");
+const v3Dir = join(repoRoot, "schemas/v3");
+
+function loadJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+let validateProcessFlow: ValidateFunction;
+
+beforeAll(() => {
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  for (const f of readdirSync(v3Dir)) {
+    if (!f.endsWith(".json")) continue;
+    const schemaObj = loadJson(join(v3Dir, f)) as { $id?: string };
+    if (typeof schemaObj.$id !== "string") continue;
+    ajv.addSchema(schemaObj as object, schemaObj.$id);
+  }
+  const v = ajv.getSchema(
+    "https://raw.githubusercontent.com/csilost2001/harmony/main/schemas/v3/process-flow.v3.schema.json"
+  );
+  if (!v) throw new Error("process-flow.v3.schema.json not loaded");
+  validateProcessFlow = v;
+});
+
+function dumpErrors(): string {
+  return (validateProcessFlow.errors ?? [])
+    .slice(0, 10)
+    .map((e) => `  ${e.instancePath || "<root>"} ${e.keyword}: ${e.message ?? ""}`)
+    .join("\n");
+}
+
+// 共通の minimal envelope (meta + actions skeleton)
+function envelope(action: object) {
+  return {
+    $schema: "../../../../schemas/v3/process-flow.v3.schema.json",
+    meta: {
+      id: "00000000-0000-4000-8000-000000000001",
+      name: "Test",
+      description: "test fixture for AI step kind",
+      kind: "common" as const,
+      maturity: "draft" as const,
+      createdAt: "2026-05-08T00:00:00.000Z",
+      updatedAt: "2026-05-08T00:00:00.000Z",
+    },
+    context: {
+      catalogs: {
+        secrets: {
+          anthropicApiKey: { source: "env", name: "ANTHROPIC_API_KEY" },
+          openaiApiKey: { source: "env", name: "OPENAI_API_KEY" },
+        },
+        modelEndpoints: {
+          summarizeModel: {
+            provider: "anthropic" as const,
+            model: "claude-opus-4-7",
+            auth: { kind: "bearer", tokenRef: "@secret.anthropicApiKey" },
+            defaults: { temperature: 0.7, maxTokens: 1024 },
+            fallback: "summarizeModelFallback",
+          },
+          summarizeModelFallback: {
+            provider: "openai" as const,
+            model: "gpt-4o",
+            auth: { kind: "bearer", tokenRef: "@secret.openaiApiKey" },
+          },
+          ollamaLocal: {
+            provider: "ollama" as const,
+            model: "llama3.1:70b",
+            endpoint: "http://localhost:11434",
+            auth: { kind: "none" },
+          },
+        },
+      },
+    },
+    actions: [action],
+  };
+}
+
+const baseAction = (steps: unknown[]) => ({
+  id: "act-001",
+  name: "Test action",
+  trigger: "submit" as const,
+  description: "test",
+  maturity: "draft" as const,
+  inputs: [],
+  outputs: [],
+  responses: [{ id: "200-ok", status: 200, description: "ok" }],
+  steps,
+});
+
+describe("AI step kind core schema (#935)", () => {
+  describe("aiCall — valid fixtures", () => {
+    it("basic text + tools + structuredObject response", () => {
+      const data = envelope(
+        baseAction([
+          {
+            id: "step-01",
+            kind: "aiCall",
+            description: "本文を 3-5 文で要約する",
+            modelRef: "summarizeModel",
+            messages: [
+              { role: "system", content: "あなたは日本語要約の専門家です。" },
+              { role: "user", content: "@inputs.body" },
+            ],
+            tools: [{ kind: "functionRef", ref: "lookupGlossary" }],
+            toolChoice: "auto",
+            responseFormat: {
+              kind: "structuredObject",
+              schema: {
+                type: "object",
+                properties: { summary: { type: "string" }, keywords: { type: "array" } },
+                required: ["summary"],
+              },
+              name: "SummarizeResult",
+            },
+            parameters: { temperature: 0.3, maxTokens: 512 },
+            outputBinding: { name: "aiResponse" },
+            outcomes: { failure: { action: "abort" } },
+          },
+        ])
+      );
+      const ok = validateProcessFlow(data);
+      expect(ok, ok ? "" : dumpErrors()).toBe(true);
+    });
+
+    it("vision input (image content block via fileRef)", () => {
+      const data = envelope(
+        baseAction([
+          {
+            id: "step-01",
+            kind: "aiCall",
+            description: "写真の alt text を生成する",
+            modelRef: "summarizeModel",
+            messages: [
+              {
+                role: "user",
+                content: [
+                  { type: "text", text: "この画像の alt テキストを日本語で 40-100 字で生成してください。" },
+                  { type: "image", source: { kind: "fileRef", ref: "@inputs.photo" } },
+                ],
+              },
+            ],
+            outputBinding: { name: "altResponse" },
+          },
+        ])
+      );
+      const ok = validateProcessFlow(data);
+      expect(ok, ok ? "" : dumpErrors()).toBe(true);
+    });
+
+    it("inline tool definition", () => {
+      const data = envelope(
+        baseAction([
+          {
+            id: "step-01",
+            kind: "aiCall",
+            description: "tag 提案",
+            modelRef: "summarizeModel",
+            messages: [{ role: "user", content: "@inputs.body" }],
+            tools: [
+              {
+                kind: "inline",
+                name: "suggestTag",
+                description: "本文からタグ候補を返す",
+                parameters: {
+                  type: "object",
+                  properties: { name: { type: "string" }, confidence: { type: "number" } },
+                  required: ["name", "confidence"],
+                },
+              },
+            ],
+            toolChoice: { name: "suggestTag" },
+            outputBinding: { name: "tagResponse" },
+          },
+        ])
+      );
+      const ok = validateProcessFlow(data);
+      expect(ok, ok ? "" : dumpErrors()).toBe(true);
+    });
+  });
+
+  describe("aiAgent — valid fixture", () => {
+    it("multi-step agent loop with tools and maxIterations", () => {
+      const data = envelope(
+        baseAction([
+          {
+            id: "step-01",
+            kind: "aiAgent",
+            description: "顧客問い合わせを agent loop で解決する",
+            modelRef: "summarizeModel",
+            messages: [
+              { role: "system", content: "あなたはサポートエージェントです。" },
+              { role: "user", content: "@inputs.query" },
+            ],
+            tools: [
+              { kind: "functionRef", ref: "searchDb" },
+              { kind: "functionRef", ref: "createTicket" },
+            ],
+            maxIterations: 5,
+            parameters: { temperature: 0.2 },
+            outputBinding: { name: "agentResult" },
+          },
+        ])
+      );
+      const ok = validateProcessFlow(data);
+      expect(ok, ok ? "" : dumpErrors()).toBe(true);
+    });
+  });
+
+  describe("modelEndpoints catalog — provider variants", () => {
+    it("all built-in providers + custom extension provider", () => {
+      const data = envelope(baseAction([]));
+      const me = (data.context.catalogs as Record<string, Record<string, unknown>>).modelEndpoints;
+      me.gpt = { provider: "openai", model: "gpt-4o", auth: { kind: "bearer", tokenRef: "@secret.openaiApiKey" } };
+      me.gemini = { provider: "google", model: "gemini-2.0-flash", auth: { kind: "apiKey", tokenRef: "@secret.openaiApiKey", headerName: "x-goog-api-key" } };
+      me.bedrock = { provider: "aws-bedrock", model: "amazon.nova-pro-v1:0", auth: { kind: "iamRole" } };
+      me.azure = { provider: "azure-openai", model: "gpt-4o", endpoint: "https://example.openai.azure.com", auth: { kind: "azureAd" } };
+      me.custom = { provider: "harmony:in-house-llm", model: "internal-v1", auth: { kind: "none" } };
+      const ok = validateProcessFlow(data);
+      expect(ok, ok ? "" : dumpErrors()).toBe(true);
+    });
+  });
+
+  describe("invalid fixtures — must be rejected", () => {
+    it("aiCall without modelRef", () => {
+      const data = envelope(
+        baseAction([
+          {
+            id: "step-01",
+            kind: "aiCall",
+            description: "no modelRef",
+            messages: [{ role: "user", content: "x" }],
+          },
+        ])
+      );
+      expect(validateProcessFlow(data)).toBe(false);
+    });
+
+    it("aiCall with empty messages array", () => {
+      const data = envelope(
+        baseAction([
+          {
+            id: "step-01",
+            kind: "aiCall",
+            description: "empty messages",
+            modelRef: "summarizeModel",
+            messages: [],
+          },
+        ])
+      );
+      expect(validateProcessFlow(data)).toBe(false);
+    });
+
+    it("aiAgent without tools (should use aiCall instead)", () => {
+      const data = envelope(
+        baseAction([
+          {
+            id: "step-01",
+            kind: "aiAgent",
+            description: "no tools",
+            modelRef: "summarizeModel",
+            messages: [{ role: "user", content: "x" }],
+          },
+        ])
+      );
+      expect(validateProcessFlow(data)).toBe(false);
+    });
+
+    it("modelEndpoint with unknown provider (not matching enum or extension pattern)", () => {
+      const data = envelope(baseAction([]));
+      const me = (data.context.catalogs as Record<string, Record<string, unknown>>).modelEndpoints;
+      me.bad = { provider: "InvalidProvider", model: "x" };
+      expect(validateProcessFlow(data)).toBe(false);
+    });
+
+    it("aiCall with structuredObject responseFormat missing schema", () => {
+      const data = envelope(
+        baseAction([
+          {
+            id: "step-01",
+            kind: "aiCall",
+            description: "x",
+            modelRef: "summarizeModel",
+            messages: [{ role: "user", content: "x" }],
+            responseFormat: { kind: "structuredObject" },
+          },
+        ])
+      );
+      expect(validateProcessFlow(data)).toBe(false);
+    });
+
+    it("aiCall with image content block but invalid source kind", () => {
+      const data = envelope(
+        baseAction([
+          {
+            id: "step-01",
+            kind: "aiCall",
+            description: "x",
+            modelRef: "summarizeModel",
+            messages: [
+              {
+                role: "user",
+                content: [
+                  { type: "image", source: { kind: "filepath", path: "/tmp/x.png" } },
+                ],
+              },
+            ],
+          },
+        ])
+      );
+      expect(validateProcessFlow(data)).toBe(false);
+    });
+  });
+});

--- a/frontend/src/schemas/ai-step-kind.schema.test.ts
+++ b/frontend/src/schemas/ai-step-kind.schema.test.ts
@@ -280,6 +280,22 @@ describe("AI step kind core schema (#935)", () => {
       expect(validateProcessFlow(data)).toBe(false);
     });
 
+    it("aiAgent with tools: [] (empty array, minItems=1 violation)", () => {
+      const data = envelope(
+        baseAction([
+          {
+            id: "step-01",
+            kind: "aiAgent",
+            description: "empty tools array",
+            modelRef: "summarizeModel",
+            messages: [{ role: "user", content: "x" }],
+            tools: [],
+          },
+        ])
+      );
+      expect(validateProcessFlow(data)).toBe(false);
+    });
+
     it("modelEndpoint with unknown provider (not matching enum or extension pattern)", () => {
       const data = envelope(baseAction([]));
       const me = (data.context.catalogs as Record<string, Record<string, unknown>>).modelEndpoints;

--- a/schemas/v3/process-flow.v3.schema.json
+++ b/schemas/v3/process-flow.v3.schema.json
@@ -165,6 +165,12 @@
           "description": "イベント pub/sub catalog。キー: EventTopic (dot.lowercase)。EventPublishStep.topic / EventSubscribeStep.topic から参照。",
           "propertyNames": { "$ref": "common.v3.schema.json#/$defs/EventTopic" },
           "additionalProperties": { "$ref": "#/$defs/EventEntry" }
+        },
+        "modelEndpoints": {
+          "type": "object",
+          "description": "AI モデルエンドポイント catalog。キー: endpointKey (lowerCamelCase)。AiCallStep / AiAgentStep の modelRef から参照する。provider / model / endpoint URL / 認証方式を 1 か所に集約し、step 側は参照キーのみ持つことで provider 切替を catalog 編集だけで完結させる (LangChain / Camunda / Azure Foundry 等の業界共通パターン)。",
+          "propertyNames": { "$ref": "common.v3.schema.json#/$defs/Identifier" },
+          "additionalProperties": { "$ref": "#/$defs/ModelEndpointEntry" }
         }
       }
     },
@@ -273,6 +279,52 @@
           "description": "ペイロードの JSON Schema (draft 2020-12)。",
           "additionalProperties": true
         }
+      }
+    },
+
+    "ModelEndpointEntry": {
+      "description": "AI モデルエンドポイント定義。1 エントリ = 1 provider+model+認証の組合せ。step 側は modelRef でキー参照することで provider 切替を catalog 編集に閉じ込める。",
+      "type": "object",
+      "required": ["provider", "model"],
+      "additionalProperties": false,
+      "properties": {
+        "provider": {
+          "oneOf": [
+            { "type": "string", "enum": ["anthropic", "openai", "google", "aws-bedrock", "ollama", "azure-openai"] },
+            { "type": "string", "pattern": "^[a-z][a-z0-9_-]*:[a-z][a-zA-Z0-9-]*$", "description": "拡張 provider (namespace:identifier)。組み込み 6 種で足りない場合の入口。" }
+          ],
+          "description": "AI provider 識別子。組み込み 6 種 (anthropic / openai / google / aws-bedrock / ollama / azure-openai) または拡張 (namespace:provider)。"
+        },
+        "model": {
+          "type": "string",
+          "description": "プロバイダー固有のモデル ID (例: 'claude-opus-4-7' / 'gpt-4o' / 'gemini-2.0-flash' / 'llama3.1:70b' / 'amazon.nova-pro-v1:0')。"
+        },
+        "endpoint": {
+          "type": "string",
+          "format": "uri",
+          "description": "API base URL。省略時は provider のデフォルト (anthropic=api.anthropic.com / openai=api.openai.com 等) を使用。Ollama / Azure OpenAI / 自前 BYO endpoint で必須。"
+        },
+        "auth": {
+          "$ref": "#/$defs/ExternalAuth",
+          "description": "認証方式。tokenRef は @secret.<key> 形式で参照。anthropic/openai は bearer/apiKey、azure-openai は azureAd、aws-bedrock は iamRole、ollama は none が典型。"
+        },
+        "defaults": {
+          "type": "object",
+          "description": "step 側で未指定時に適用するデフォルトパラメータ。step 側 parameters で override 可。",
+          "additionalProperties": false,
+          "properties": {
+            "temperature": { "type": "number", "minimum": 0, "maximum": 2 },
+            "maxTokens": { "type": "integer", "minimum": 1 },
+            "topP": { "type": "number", "minimum": 0, "maximum": 1 },
+            "topK": { "type": "integer", "minimum": 1 },
+            "stopSequences": { "type": "array", "items": { "type": "string" } }
+          }
+        },
+        "fallback": {
+          "$ref": "common.v3.schema.json#/$defs/Identifier",
+          "description": "プライマリ呼び出し失敗時の fallback endpoint key (modelEndpoints 内の別キー参照、推奨: 別 provider)。"
+        },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
       }
     },
 
@@ -467,14 +519,14 @@
       "required": ["kind"],
       "additionalProperties": false,
       "properties": {
-        "kind": { "type": "string", "enum": ["bearer", "basic", "apiKey", "oauth2", "none"] },
+        "kind": { "type": "string", "enum": ["bearer", "basic", "apiKey", "oauth2", "iamRole", "azureAd", "none"] },
         "tokenRef": { "type": "string", "description": "@secret.<key> 推奨 (旧 ENV: / SECRET: 形式は v3 廃止)。" },
         "headerName": { "type": "string" }
       }
     },
 
     "Step": {
-      "description": "Step union。kind プロパティで variant を識別。組み込み 21 variant + ExtensionStep の計 22 variant。ExtensionStep は kind にパターン (namespace:StepName) を取るため AJV `discriminator: true` の strict const 要件を満たさず、本 oneOf には discriminator keyword を付けない (#525 F-4 limitation)。Step.kind ミスマッチ時のエラー読みやすさは AJV `allErrors: true` + 上位 UI 側でフィルタ推奨。",
+      "description": "Step union。kind プロパティで variant を識別。組み込み 23 variant + ExtensionStep の計 24 variant。ExtensionStep は kind にパターン (namespace:StepName) を取るため AJV `discriminator: true` の strict const 要件を満たさず、本 oneOf には discriminator keyword を付けない (#525 F-4 limitation)。Step.kind ミスマッチ時のエラー読みやすさは AJV `allErrors: true` + 上位 UI 側でフィルタ推奨。",
       "oneOf": [
         { "$ref": "#/$defs/ValidationStep" },
         { "$ref": "#/$defs/DbAccessStep" },
@@ -497,6 +549,8 @@
         { "$ref": "#/$defs/EventSubscribeStep" },
         { "$ref": "#/$defs/ClosingStep" },
         { "$ref": "#/$defs/CdcStep" },
+        { "$ref": "#/$defs/AiCallStep" },
+        { "$ref": "#/$defs/AiAgentStep" },
         { "$ref": "#/$defs/ExtensionStep" }
       ]
     },
@@ -524,6 +578,8 @@
         { "$ref": "#/$defs/EventSubscribeStep" },
         { "$ref": "#/$defs/ClosingStep" },
         { "$ref": "#/$defs/CdcStep" },
+        { "$ref": "#/$defs/AiCallStep" },
+        { "$ref": "#/$defs/AiAgentStep" },
         { "$ref": "#/$defs/ExtensionStep" }
       ]
     },
@@ -797,6 +853,276 @@
         "maxConcurrent": { "type": "number", "minimum": 0 },
         "maxWait": { "type": "number", "minimum": 0 }
       }
+    },
+
+    "AiCallStep": {
+      "description": "single-shot LLM 呼び出し step (text / vision multimodal / tool use / structured output 込み)。OpenAI Responses / Anthropic Messages / Camunda AI Agent Task に対応。multi-step ループ (tool 結果に応じた次の判断) が必要な場合は AiAgentStep を使う。",
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "kind", "description", "modelRef", "messages"],
+          "properties": {
+            "kind": { "const": "aiCall" },
+            "modelRef": {
+              "$ref": "common.v3.schema.json#/$defs/Identifier",
+              "description": "context.catalogs.modelEndpoints のキー参照。"
+            },
+            "messages": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/$defs/AiMessage" },
+              "description": "LLM に送信する messages 配列。system / user / assistant の role 別に並べる。"
+            },
+            "tools": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/AiToolRef" },
+              "description": "LLM に提供する tool 群 (任意)。functionRef (catalogs.functions 参照) または inline 定義を並列許容。"
+            },
+            "toolChoice": { "$ref": "#/$defs/AiToolChoice" },
+            "responseFormat": { "$ref": "#/$defs/AiResponseFormat" },
+            "parameters": { "$ref": "#/$defs/AiInferenceParameters", "description": "modelEndpoint.defaults を override。同キーは本フィールド優先。" },
+            "outcomes": { "$ref": "#/$defs/ExternalCallOutcomes", "description": "失敗 / timeout 時の挙動。既存 ExternalSystemStep と同じ pattern を流用。" }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+
+    "AiAgentStep": {
+      "description": "multi-step agent loop step。tool call → 結果 → 次の tool 選択を maxIterations 回まで繰り返す。LangGraph / Camunda AI Agent Sub-process / OpenAI Conversations に対応。tool が無い single-shot 呼び出しは AiCallStep を使う。",
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "kind", "description", "modelRef", "messages", "tools"],
+          "properties": {
+            "kind": { "const": "aiAgent" },
+            "modelRef": { "$ref": "common.v3.schema.json#/$defs/Identifier" },
+            "messages": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/$defs/AiMessage" },
+              "description": "初期 messages。agent loop 開始時の context (system + user)。"
+            },
+            "tools": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/$defs/AiToolRef" },
+              "description": "agent が呼べる tool 群 (1 件以上必須、tool なしなら AiCallStep を使う)。"
+            },
+            "toolChoice": { "$ref": "#/$defs/AiToolChoice" },
+            "maxIterations": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 10,
+              "description": "tool call ループの最大反復回数。LLM が連続 tool 呼び出しに陥った場合の安全装置。"
+            },
+            "responseFormat": { "$ref": "#/$defs/AiResponseFormat", "description": "最終 assistant message の構造化指定。" },
+            "parameters": { "$ref": "#/$defs/AiInferenceParameters" },
+            "outcomes": { "$ref": "#/$defs/ExternalCallOutcomes" }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+
+    "AiMessage": {
+      "description": "LLM 入力メッセージ 1 件。Anthropic Messages / OpenAI Chat Completions の messages 構造に対応。content は string (シンプルテキスト) または array of content blocks (multimodal) を許容。",
+      "type": "object",
+      "required": ["role", "content"],
+      "additionalProperties": false,
+      "properties": {
+        "role": { "type": "string", "enum": ["system", "user", "assistant"] },
+        "content": {
+          "oneOf": [
+            { "type": "string", "description": "シンプルなテキスト content (式補間 @<var> 含む)。" },
+            {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/$defs/AiContentBlock" },
+              "description": "multimodal content blocks (text / image)。"
+            }
+          ]
+        },
+        "name": { "type": "string", "description": "tool 結果メッセージ等で使う name (任意)。" }
+      }
+    },
+
+    "AiContentBlock": {
+      "description": "LLM message の content block。text / image を sum type で表現。",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["type", "text"],
+          "additionalProperties": false,
+          "properties": {
+            "type": { "const": "text" },
+            "text": { "type": "string", "description": "プレーンテキスト (式補間 @<var> 含む)。" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["type", "source"],
+          "additionalProperties": false,
+          "properties": {
+            "type": { "const": "image" },
+            "source": { "$ref": "#/$defs/AiImageSource" }
+          }
+        }
+      ]
+    },
+
+    "AiImageSource": {
+      "description": "vision input の画像ソース。fileRef (ScreenItem type=file / step output 等の式参照) / url / base64 の 3 形式。",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["kind", "ref"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "fileRef" },
+            "ref": {
+              "$ref": "common.v3.schema.json#/$defs/ExpressionString",
+              "description": "ScreenItem (type=file) または step output 等の式参照 (例: '@inputs.photo' / '@uploaded.file')。"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "url"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "url" },
+            "url": { "type": "string", "format": "uri" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "data", "mediaType"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "base64" },
+            "mediaType": { "type": "string", "enum": ["image/jpeg", "image/png", "image/webp", "image/gif"] },
+            "data": { "type": "string", "description": "base64-encoded 画像データ (literal)。実用は fileRef 推奨、本形式は test fixture / 小規模アイコン等に限定。" }
+          }
+        }
+      ]
+    },
+
+    "AiToolRef": {
+      "description": "LLM に提供する tool 1 件。functionRef (context.catalogs.functions 参照、推奨) または inline 定義 (アドホック使用)。業界共通の {name, description, parameters: JSON Schema} 構造に対応。",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["kind", "ref"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "functionRef" },
+            "ref": {
+              "$ref": "common.v3.schema.json#/$defs/Identifier",
+              "description": "context.catalogs.functions のキー参照。tool の name / description / parameters は functions catalog から取得。"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "name", "description", "parameters"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "inline" },
+            "name": { "$ref": "#/$defs/AiName" },
+            "description": { "$ref": "common.v3.schema.json#/$defs/Description" },
+            "parameters": {
+              "type": "object",
+              "additionalProperties": true,
+              "description": "JSON Schema (draft 2020-12) で tool 引数を定義。OpenAI / Anthropic / Bedrock / Camunda 共通の業界標準形式。"
+            }
+          }
+        }
+      ]
+    },
+
+    "AiToolChoice": {
+      "description": "tool 選択戦略。auto=LLM が自動選択 (デフォルト) / any=必ず何らかの tool を呼ぶ / none=tool 呼ばない / {name}=指定 tool を強制。",
+      "oneOf": [
+        { "type": "string", "enum": ["auto", "any", "none"] },
+        {
+          "type": "object",
+          "required": ["name"],
+          "additionalProperties": false,
+          "properties": {
+            "name": { "$ref": "#/$defs/AiName", "description": "強制的に呼ぶ tool 名 (functionRef / inline.name と一致)。" }
+          }
+        }
+      ]
+    },
+
+    "AiResponseFormat": {
+      "description": "LLM 出力の format 指定。text (デフォルト、自由テキスト) / json (free-form JSON、parse のみ) / structuredObject (JSON Schema 準拠の構造化出力) / streaming (SSE / WebSocket、partial response 配信)。",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["kind"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "text" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "json" },
+            "description": { "type": "string", "description": "free-form JSON 出力 (schema 制約なし、parse のみ)。" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "schema"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "structuredObject" },
+            "schema": {
+              "type": "object",
+              "additionalProperties": true,
+              "description": "JSON Schema (draft 2020-12)。LLM が schema 準拠で構造化出力する (Anthropic / OpenAI / Dify 共通の業界標準形式)。"
+            },
+            "name": { "$ref": "#/$defs/AiName", "description": "schema 名 (provider 仕様の名称ヒント、optional)。OpenAI structured output / Anthropic tool 名と同形式。" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "streaming" },
+            "description": { "type": "string", "description": "SSE / WebSocket 等で partial response を流す。実装側で client streaming を処理。" }
+          }
+        }
+      ]
+    },
+
+    "AiInferenceParameters": {
+      "description": "LLM 推論パラメータ。modelEndpoint.defaults と AiCallStep.parameters の両方で使用。",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "temperature": { "type": "number", "minimum": 0, "maximum": 2 },
+        "maxTokens": { "type": "integer", "minimum": 1 },
+        "topP": { "type": "number", "minimum": 0, "maximum": 1 },
+        "topK": { "type": "integer", "minimum": 1 },
+        "stopSequences": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+
+    "AiName": {
+      "description": "AI tool / response schema 名。PascalCase / camelCase / snake_case / kebab-case を許容 (provider の慣例に合わせる)。OpenAI / Anthropic / Bedrock 共通の許容パターン。Identifier (lowerCamelCase 強制) より緩く設計。",
+      "type": "string",
+      "pattern": "^[a-zA-Z][a-zA-Z0-9_-]*$",
+      "minLength": 1,
+      "maxLength": 64
     },
 
     "CommonProcessStep": {


### PR DESCRIPTION
## 関連

Closes #935

仕様: [docs/spec/process-flow-ai-step-kind.md](docs/spec/process-flow-ai-step-kind.md) (本 PR で新規作成)

supersede 対象: #865 (examples/diary AI provider 抽象化) — 本 PR + Phase 2 が正規解決策。Phase 2 完了時に close 候補。

## 概要

業務アプリにおける LLM / AI agent 呼び出しを ProcessFlow の **一級概念** として表現する。Anthropic / OpenAI / Google / AWS Bedrock / Ollama / Azure OpenAI を、step 側に provider 直書きせず catalog 経由で抽象化。tool use / structured output / vision input / agent loop を業界標準形式 (OpenAI Responses / Anthropic Messages / Camunda BPMN AI Connectors / LangGraph 等) で扱う。

N=2 で表現分裂 (diary externalSystem vs english-learning namespace 拡張) している現状を、リリース前のコスト最小タイミングで core 標準化する (#935 設計者承認 2026-05-08、RFC 起票フェーズを明示的にスキップ)。

## 主な変更

### schema (`schemas/v3/process-flow.v3.schema.json`)

- step kind 追加: `aiCall` (single-shot LLM) / `aiAgent` (agent loop)
- catalog 追加: `context.catalogs.modelEndpoints` (provider / model / endpoint / auth / defaults / fallback)
- 補助型: `ModelEndpointEntry` / `AiMessage` / `AiContentBlock` / `AiImageSource` / `AiToolRef` / `AiToolChoice` / `AiResponseFormat` / `AiInferenceParameters` / `AiName`
- 既存 `ExternalAuth.kind` enum に `iamRole` (AWS Bedrock 用) / `azureAd` (Azure OpenAI 用) を追加
- Step union / NonReturnStep union に AiCallStep / AiAgentStep を追加 (組み込み 21→23 variant)

### spec 文書

- 新規: `docs/spec/process-flow-ai-step-kind.md` (業界調査結果 / 採用設計 / 詳細仕様 / 4 種の使用例 / provider 切替の運用 / TTS/STT/Embedding との関係 / 既存表現からの移行)
- 更新: `docs/spec/README.md` の spec 一覧に追加

### 動作証明 test

- 新規: `frontend/src/schemas/ai-step-kind.schema.test.ts` (11 件 pass)
  - valid fixtures: text+tools+structuredObject / vision input / inline tool / aiAgent multi-step / 全 6 provider variant
  - invalid fixtures: missing modelRef / empty messages / aiAgent without tools / unknown provider / structuredObject without schema / invalid image source kind

### skill

- `create-flow/SKILL.md`: catalog 一覧に `modelEndpointCatalog` を追加、`functionsCatalog` の説明に「`aiCall.tools[].functionRef` から再利用可」を追記
- `generate-code/SKILL.md`: step kind table に `aiCall` / `aiAgent` を追加 (provider 別 SDK 切替の方針記述)

## 仕様逐条突合 (自己申告)

設計判断 (docs/spec/process-flow-ai-step-kind.md の各節) との逐条突合:

- **§ Step kinds (aiCall + aiAgent の 2 種類)** → schema $defs `AiCallStep` (process-flow.v3.schema.json:858-890) + `AiAgentStep` (:892-928) ✓
- **§ catalog: modelEndpoints** → schema $defs `ModelEndpointEntry` (process-flow.v3.schema.json:286-326) + Catalogs.properties に追加 (:171-176) ✓
- **§ provider enum (built-in 6 + 拡張)** → ModelEndpointEntry.provider oneOf (:294-298) ✓
- **§ AiCallStep 必須 field (modelRef / messages)** → AiCallStep required: ["id", "kind", "description", "modelRef", "messages"] (:865) ✓
- **§ AiAgentStep 必須 field (modelRef / messages / tools)** → AiAgentStep required (:899) + tools minItems=1 (:909) ✓
- **§ messages.content (string or content blocks 配列)** → AiMessage.content oneOf (:937-948) ✓
- **§ vision input 3 形式 (fileRef / url / base64)** → AiImageSource oneOf (:976-1011) ✓
- **§ tools (functionRef / inline 並列)** → AiToolRef oneOf (:1013-1044) ✓
- **§ toolChoice (auto / any / none / {name})** → AiToolChoice (:1046-1059) ✓
- **§ responseFormat (text / json / structuredObject / streaming)** → AiResponseFormat oneOf (:1061-1105) ✓
- **§ AiName (緩い tool/schema 名の業界慣習)** → $defs `AiName` (:1116-1122) ✓
- **§ ExternalAuth.kind に iamRole / azureAd 追加** → ExternalAuth.kind enum (process-flow.v3.schema.json:470) ✓
- **§ Step union / NonReturnStep union** → :552-553 (Step) + :581-582 (NonReturn) ✓
- **§ Phase 2 で対応予定 (sample 移行 / generate-tests skill 拡張)** → spec § 既存表現からの移行で明記 ✓

## レビューで特に見てほしい箇所

- **業界共通パターンの採用妥当性**: docs/spec の § 業界共通パターン に列挙した 5 パターン (modality 別分割少数派 / single-shot vs agent loop / endpoint catalog / tool 構造 / structured output) のうち、Harmony schema での反映に不足や過剰がないか
- **AiName pattern (`^[a-zA-Z][a-zA-Z0-9_-]*$`) の妥当性**: 当初 Identifier (lowerCamelCase) を流用したが、OpenAI structured output の name 慣習が PascalCase 中心で test fixture が通らない事象が発生したため緩めた経緯あり。OpenAI / Anthropic / Bedrock の許容パターン (`a-zA-Z0-9_-`、最大 64) に合わせている
- **`ExternalAuth.kind` の enum 追加 (iamRole / azureAd)**: 既存表現を壊さない加算のみで、AWS Bedrock / Azure OpenAI 用に追加。既存 `bearer` / `apiKey` / `oauth2` で表現できない別認証方式が必要だったため
- **Phase 2 (sample 移行) を本 PR に含めない判断**: 設計者指示通り schema + spec + test fixture のみ。サンプル移行は別セッションが担当するため schema が壊れないよう test fixture で動作証明を担保
- **`functions` catalog の流用**: tool 定義は OpenAI / Anthropic / Bedrock 共通で `{name, description, parameters: JSON Schema}` 構造。既存 `context.catalogs.functions` がほぼ同じ構造のため、`AiToolRef.kind="functionRef"` で再利用 (DRY)。inline 定義も並列許容

## テスト

- Vitest: 1810 件 全 pass (新 `ai-step-kind.schema.test.ts` 11 件含む)
- validate:samples: 既存 sample (diary 17 / retail 6 / english-learning 5 / english-learning-tailwind 5) regression なし
- Playwright / MCP E2E: 設計データ (schema 改変 + spec) のみのため未実施 (UI 影響なし)

## UI 影響 / AI smoke test

- [ ] UI 影響あり (AI が chrome-devtools MCP / Playwright で smoke test 実施済み)
- [x] UI 影響なし (auto テスト pass のみ)

schema 改変 + spec 文書追加 + test fixture 追加で frontend ランタイムの表示や挙動には影響しない。validate:samples + Vitest で担保。

## spec 側の不足点 / 提案

- **TTS / STT / Embedding / ImageGen の core 化**: 本 PR では LLM 呼び出し (text + vision + tool use) のみ core 標準化。TTS / STT は english-learning の 1 件のみで N=1 状態のため当面 namespace 拡張に残す方針 (spec § ドメイン固有 AI 機能 で明記)。N=3+ で複数 sample が同概念を再発明している状況になったら core 化候補
- **provider fallback の実装責任**: schema 上は `modelEndpoint.fallback` で fallback endpoint key を指定可能だが、実際の fallback 実行 (primary 失敗 → secondary 試行) は generate-code 時の SDK 層で実装する。ProcessFlow runtime の責任分界点として spec で明示する余地あり (Phase 2 で詳細化検討)
- **streaming response の outputBinding**: `responseFormat.kind="streaming"` の場合、outputBinding が「最終結果」を指すのか「stream チャンネル」を指すのかは spec 未定義。OpenAI / Anthropic では SSE で chunks を送り、最終的に full response が組み立てられるが、UI 側で partial display する場合の binding 仕様は別途 spec 化が必要

## レビュー担当への申し送り

- **本 PR は schema 改変 PR**。schema governance ルールでは AI 単独実装禁止だが、設計者 (ユーザー) が 2026-05-08 に「世の中の一般的な定義方法を参考にあなたが設計して決めてください。これはもはやRFCではなく即実施するもの」と明示承認。memory `project_ai_step_kind_core_2026_05_08.md` に経緯記録
- **Phase 1 / Phase 2 分離**: 本 PR は Phase 1 (schema + spec + test fixture)。Phase 2 (既存 sample 移行) は別セッションが対応、PR description で明記
- **業界調査の根拠**: docs/spec § 業界共通パターン に列挙した 7 プラットフォーム (Azure Foundry / Dify / LangChain / OpenAI / Anthropic / Bedrock / Camunda) は WebSearch / WebFetch で公式 doc を確認。設計の overshoot / undershoot を疑ってほしい
- **後方互換性は不要 (リリース前)**: breaking change / migration ロジック / 後方互換シムは入れていない。既存表現 (externalSystem step / namespace 拡張 stepKind) は Phase 2 で書き換え予定
- **Sonnet が見落としそうな部分**: AJV 2020-12 の `unevaluatedProperties: false` と allOf / oneOf の評価相互作用 (実際本 PR でも一度 AiCallStep の test fixture が unevaluatedProperties エラーで fail した経緯あり、AiName 緩和で解決)。oneOf の各 candidate が部分マッチ → エラー大量出力 → 真の原因が埋もれるパターンに注意
