### PR TITLE
feat(samples): AI step kind Phase 2-A — diary + english-learning を aiCall/modelEndpoints に移行 (#865)

### DIFF
--- a/docs/spec/examples-english-learning.md
+++ b/docs/spec/examples-english-learning.md
@@ -26,7 +26,7 @@ B2C 英会話学習アプリ (中規模、画面 ~11、テーブル ~10、処理
 | シナリオ ID | 概要 | 関連 entity |
 |---|---|---|
 | **S-1 学習セッション開始** | ストーリー一覧から選択 → セッション作成 → 会話プレイ画面遷移。ストーリー詳細表示時に必要なら `TtsGenerate` でセリフ音源を事前生成。 | 画面: ストーリー一覧 / 詳細 / 会話プレイ ・ flow: start-session ・ table: stories / scenes / learning_sessions / sequences: session-id ・ extension: (任意) `english-learning:TtsGenerate` |
-| **S-2 会話ターン進行** | ユーザー発話 (テキスト or 音声) → LLM 応答生成 → 応答 TTS 音声化 → 履歴保存。**外部 LLM/TTS 呼び出しを stepKind 拡張で表現**。 | 画面: 会話プレイ ・ flow: progress-turn ・ table: turn_logs ・ extension: `english-learning:LlmDialog` + `english-learning:TtsGenerate` stepKind |
+| **S-2 会話ターン進行** | ユーザー発話 (テキスト or 音声) → LLM 応答生成 → 応答 TTS 音声化 → 履歴保存。**LLM 呼び出しは core stepKind `aiCall` + `modelEndpoints` catalog**、**TTS 呼び出しは namespace 拡張 stepKind `english-learning:TtsGenerate`** で表現する (#865 で 2026-05-08 移行)。 | 画面: 会話プレイ ・ flow: progress-turn ・ table: turn_logs ・ catalog: `modelEndpoints.dialogModel` ・ extension: `english-learning:TtsGenerate` stepKind |
 | **S-3 発音採点** | ユーザーが目標セリフを録音送信 → STT + 評価 API → スコア保存 → 画面表示。**外部 STT 呼び出しを stepKind 拡張で表現**。 | 画面: 会話プレイ → セッション結果 ・ flow: evaluate-pronunciation ・ table: pronunciation_scores ・ extension: `english-learning:SttEvaluate` stepKind |
 | **S-4 学習履歴閲覧 + 単語復習** | 学習履歴一覧 / 詳細表示、単語帳で習熟度別に復習。タップで辞書詳細。 | 画面: 学習履歴 / 単語帳 / 単語詳細 ・ flow: update-word-progress (common) ・ table: user_word_progress / words |
 
@@ -76,17 +76,16 @@ B2C 英会話学習アプリ (中規模、画面 ~11、テーブル ~10、処理
 | `audioUrl` | string | `english-learning:audioUrl` | 音声ファイル URL (TTS 生成 or 既存音源) |
 | `pronunciationScore` | number | `english-learning:pronunciationScore` | 発音スコア 0-100 |
 
-**stepKinds** (`object`、**キーは PascalCase 必須** — `^[A-Z][A-Za-z0-9]*$`、ProcessFlow ステップ拡張、**本サンプルの肝**):
+**stepKinds** (`object`、**キーは PascalCase 必須** — `^[A-Z][A-Za-z0-9]*$`、ProcessFlow ステップ拡張):
 
 | キー (PascalCase) | ProcessFlow.kind 参照 | 用途 |
 |---|---|---|
-| `LlmDialog` | `english-learning:LlmDialog` | LLM への会話リクエスト |
 | `TtsGenerate` | `english-learning:TtsGenerate` | TTS 音声生成 (S-1 でストーリー音源プリロード、S-2 で AI 応答音声化に使用) |
 | `SttEvaluate` | `english-learning:SttEvaluate` | STT + 発音評価 |
 
-各 stepKind の構造は `CustomStepKind` (`label` / `icon` / `description` / `schema` / `outputType`) に準拠。**`schema`** は `ExtensionStep.config` の入力構造を縛る subset JSON Schema (動的フォーム生成用)、**`outputType`** は `outputBinding` 結果の `FieldType` (型推論用)。`outputSchema` というフィールドは存在しないため使わない。
+LLM 会話呼び出しは **core stepKind `aiCall` + `context.catalogs.modelEndpoints.<key>`** で表現する (#935 で core 化、本サンプルは #865 で 2026-05-08 移行済み)。TTS / STT は業務ドメイン固有のため当面 namespace 拡張に維持する (将来 core 化候補)。
 
-例: `LlmDialog` の `schema` で `context` / `userInput` 構造を定義し、`outputType` で AI 応答を表す `FieldType` (拡張 `english-learning:dialogTurn` 等の object 型 fieldType を作る or string として簡略化) を指定する。
+各 stepKind の構造は `CustomStepKind` (`label` / `icon` / `description` / `schema` / `outputType`) に準拠。**`schema`** は `ExtensionStep.config` の入力構造を縛る subset JSON Schema (動的フォーム生成用)、**`outputType`** は `outputBinding` 結果の `FieldType` (型推論用)。`outputSchema` というフィールドは存在しないため使わない。
 
 **screenKinds** (`array`、各 item の `kind` は **camelCase**):
 
@@ -94,7 +93,7 @@ B2C 英会話学習アプリ (中規模、画面 ~11、テーブル ~10、処理
 |---|---|---|
 | `conversationPlayer` | `english-learning:conversationPlayer` | 会話プレイ画面 (字幕表示 + 録音ボタン + 履歴ペイン) |
 
-これにより **LLM/TTS/STT 呼び出しが step として統一的に扱える** ことを実証する (汎用エスケープ `type: "other"` ではなく namespace 拡張で表現する方針 — 詳細 3.5 節)。
+これにより **TTS/STT 呼び出しが step として統一的に扱える** ことを実証する (汎用エスケープ `type: "other"` ではなく namespace 拡張で表現する方針 — 詳細 3.5 節)。LLM 呼び出しは core 標準 `aiCall` を直接使う。
 
 ### 2.6 conventions catalog
 

--- a/docs/spec/examples-english-learning.md
+++ b/docs/spec/examples-english-learning.md
@@ -157,25 +157,47 @@ LLM 会話呼び出しは **core stepKind `aiCall` + `context.catalogs.modelEndp
 
 特に「LLM 応答の構造」「カラオケ用 wordTimings」「PhoneDiff 構造」等は `CustomStepKind.outputType` (FieldType) または `extensions.fieldTypes` の object 型 fieldType として表現すれば、schema 本体を触らずに済むはず。
 
-### 3.5 外部 AI (LLM/TTS/STT) の ProcessFlow 表現方針
+### 3.5 外部 AI の ProcessFlow 表現方針
 
-外部 AI 呼び出しは **`stepKind` 拡張で表現** し、実際の API 呼び出し詳細は description で記述する。**`type: "other"` (汎用エスケープ) は使わない** — namespace 拡張で表現できるならそちらを優先することがフレームワーク思想に沿う。
+外部 AI 呼び出しは概念別に **2 系統で表現**:
+
+1. **LLM 会話呼び出し**: core stepKind `aiCall` + `context.catalogs.modelEndpoints.<key>` (#935 / #865 で 2026-05-08 移行済み)。provider 切替が catalog 編集で完結し、tool use / structured output / vision input が業界共通の messages + responseFormat 構造で表現できる
+2. **業務ドメイン固有 AI 呼び出し** (TTS / STT / 発音採点 等): 当面 namespace 拡張 stepKind (`english-learning:TtsGenerate` / `english-learning:SttEvaluate`)。汎用エスケープ `type: "other"` は使わない — namespace 拡張で表現できるならそちらを優先することがフレームワーク思想に沿う
 
 ```jsonc
-// 例: S-2 progress-turn flow の LLM 呼び出しステップ (ExtensionStep)
+// 例: S-2 progress-turn flow の LLM 呼び出しステップ (core stepKind aiCall)
 {
-  "kind": "english-learning:LlmDialog",
+  "kind": "aiCall",
   "id": "step-llm-call",
-  "config": { "context": "@var.turnContext", "userInput": "@var.userInput" },
+  "modelRef": "dialogModel",
+  "messages": [
+    { "role": "system", "content": "あなたは日本人英語学習者向けの会話パートナーです。CEFR レベルに合った語彙と文法で英語応答してください。" },
+    { "role": "user", "content": "[会話履歴]\n@turnContext\n\n[最新の発話]\n@userInput" }
+  ],
   "outputBinding": { "name": "aiResponse" },
-  "description": "OpenAI GPT-4 / Anthropic Claude 等の LLM API を呼び出す。実装側で provider 選択。temperature 0.7 推奨。"
+  "description": "core stepKind aiCall + modelEndpoints.dialogModel で LLM 呼び出し。provider 選択は modelEndpoints catalog で完結。"
+}
+
+// modelEndpoints catalog (context.catalogs.modelEndpoints.dialogModel)
+// provider/model/auth/defaults を 1 箇所に集約。step 側は modelRef のみ持つ
+```
+
+```jsonc
+// 例: TTS 呼び出しステップ (namespace 拡張、業務ドメイン固有)
+{
+  "kind": "english-learning:TtsGenerate",
+  "id": "step-tts",
+  "config": { "text": "@aiResponse.text" },
+  "outputBinding": { "name": "aiAudioUrl" },
+  "description": "AI 応答テキストを TTS で音声化する。"
 }
 ```
 
 これにより:
-- ProcessFlow viewer 上で LLM 呼び出しが他 step と同じ抽象レベルで表示される
-- `CustomStepKind.schema` で `config` の入力構造が型安全に縛られ、`CustomStepKind.outputType` で `outputBinding` 結果型が後続 step の型推論で使える
-- 実装詳細 (provider / endpoint / auth) は description で記述、LLM 後段生成時にコード化
+- ProcessFlow viewer 上で LLM 呼び出し / TTS / STT が他 step と同じ抽象レベルで表示される
+- aiCall は `messages` (system/user/assistant role 別) + `tools` + `responseFormat` (text / json / structuredObject / streaming) の業界共通構造で型安全に表現
+- TTS / STT は `CustomStepKind.schema` で `config` の入力構造を縛り、`outputType` で `outputBinding` 結果型を後続 step の型推論で使える
+- 実装詳細は modelEndpoints catalog (LLM) または stepKind description (TTS/STT) に集約され、コード生成時に展開
 
 ### 3.6 動作確認は data/ コピー (retail と同じ運用)
 

--- a/docs/spec/process-flow-ai-step-kind.md
+++ b/docs/spec/process-flow-ai-step-kind.md
@@ -254,15 +254,26 @@ env 切替の典型:
 
 英語学習 sample の domain 固有 fieldType (`cefrLevel` / `ipa` / `audioUrl` / `pronunciationScore` / `dialogTurn`) は業務ドメイン固有のため namespace 拡張に残す (core 化対象外)。
 
-## 既存表現からの移行 (Phase 2、別 PR)
+## 既存表現からの移行 (Phase 2)
 
-本 spec を含む PR (Phase 1) は schema 改変 + spec + test fixture のみ。既存 sample (diary AI 4 flow + english-learning AI 3 flow) の `aiCall` / `aiAgent` への書き換えは **別セッションで Phase 2 として実施** する。Phase 2 完了時に:
+本 spec を含む PR (Phase 1) は schema 改変 + spec + test fixture のみ。既存 sample の書き換えと skill 拡張は Phase 2 で段階的に実施する。
 
-- `examples/diary` の `externalSystem` step + `catalogs.externalSystems.claudeApi` を `aiCall` + `catalogs.modelEndpoints.<key>` に移行
-- `examples/english-learning` の `english-learning:LlmDialog` を `aiAgent` (multi-turn) に移行
+### Phase 2-A — 既存 sample 移行 (完了 2026-05-08、#865)
+
+- `examples/diary` の AI 4 flow (要約/タグ提案/画像 alt/校正) を `aiCall` + `catalogs.modelEndpoints.<key>` に移行 (claudeApi externalSystem 廃止)
+- `examples/english-learning` の `english-learning:LlmDialog` step を **`aiCall`** (spec 準拠、tools 無しの単発呼び出しは `aiCall` を使う原則) に移行 — 元指示は "aiAgent (multi-turn)" だったが、当該 step は tool 無しの multi-turn 会話のため schema 上 `aiAgent` (tools minItems=1 必須) 不可。"multi-turn" は会話履歴を messages に並べることで表現する
 - `examples/english-learning/harmony/extensions/english-learning.v3.json` から `LlmDialog` stepKind 定義を削除 (`TtsGenerate` / `SttEvaluate` は当面残す)
-- `/generate-tests` skill の AI flow 検出ロジックを **`kind=aiCall|aiAgent`** に対応させる (現状 `kind=externalSystem` + `systemRef=claudeApi` 等の旧パターン検出のままだと、Phase 2 移行後の sample で AI flow が検出されず、生成テストが旧 fixture 期待のままになる)
-- `/generate-code` skill のテンプレート (`templates/backend/typescript-nestjs/` / `templates/backend/java-spring-boot/`) に `aiCall` / `aiAgent` step の SDK 切替コード生成ロジックを追加 (現状 `SKILL.md` の step kind table に方針記述のみで、テンプレート本体は未対応)
+- `examples/english-learning-tailwind/` (Bootstrap 版と同一スコープの Tailwind 版) も同 PR で同期移行
+- `examples/diary/harmony/conventions/catalog.json` の `extensionCategories.ai` (provider/model 重複定義) を削除し modelEndpoints catalog に一本化
+- 制限: 現 schema では `messages` が静的配列のため、prior turns を動的 spread できない。english-learning の multi-turn 会話は user content に `@turnContext` (DialogTurn[] JSON 文字列) を埋め込む暫定形で対応 (将来の core schema 拡張候補)
+
+### Phase 2-B — `/generate-tests` skill 拡張 (Phase 2-A 後、別 PR)
+
+- AI flow 検出ロジックを **`kind=aiCall|aiAgent`** に対応させる (現状 `kind=externalSystem` + `systemRef=claudeApi` 等の旧パターン検出のままだと、Phase 2-A 移行後の sample で AI flow が検出されず、生成テストが旧 fixture 期待のままになる)
+
+### Phase 2-C — `/generate-code` skill テンプレート拡張 (Phase 2-B と独立、別 PR)
+
+- テンプレート本体 (`templates/backend/typescript-nestjs/` / `templates/backend/java-spring-boot/`) に `aiCall` / `aiAgent` step の SDK 切替コード生成ロジックを追加 (現状 `SKILL.md` の step kind table に方針記述のみで、テンプレート本体は未対応)
 
 ## 関連
 

--- a/docs/spec/process-flow-ai-step-kind.md
+++ b/docs/spec/process-flow-ai-step-kind.md
@@ -82,6 +82,29 @@ N=2 で表現方法が分裂しており、放置すると後続 sample (CRM / E
 - `tools` が **必須** (`minItems=1`、tool なしなら `aiCall` を使う)
 - `maxIterations` (integer, default 10) で tool call ループ上限を指定
 
+### `outputBinding` の値構造 (provider 中立な正規化形式)
+
+`aiCall` / `aiAgent` の outputBinding は、provider 固有応答 (Anthropic `content[].text` / OpenAI `choices[].message.content` / Bedrock `output.message.content` 等) をランタイムが以下の正規化形式に変換した値を受け取る。後続 step (`compute` / `dbAccess` / `return`) はこの形式を前提に式参照する。
+
+| `responseFormat.kind` | outputBinding の値構造 | 後続 step での参照 |
+|---|---|---|
+| `text` (デフォルト、未指定) | `{ text: string, finishReason?: string, usage?: TokenUsage }` | `@<binding>.text` |
+| `json` | `{ object: any, raw: string, finishReason?: string, usage?: TokenUsage }` | `@<binding>.object` (parse 済み) / `@<binding>.raw` (生 JSON 文字列) |
+| `structuredObject` | `{ object: <responseFormat.schema 準拠オブジェクト>, raw: string, finishReason?: string, usage?: TokenUsage }` | `@<binding>.object.<field>` (型安全、JSON Schema 適合確認済み) |
+| `streaming` | `{ text: string, finishReason?: string, usage?: TokenUsage }` (完了後) | `@<binding>.text` (本フローでは partial を扱わない、SSE / WebSocket は実装層) |
+
+`tools` を伴う `aiCall` / `aiAgent` で tool call が発生した場合は、上記に加え:
+
+```ts
+{
+  toolCalls?: Array<{ id: string, name: string, arguments: any }>
+}
+```
+
+`aiAgent` は agent loop 完了後の最終 assistant メッセージを上記形式で受け取り、途中の tool 呼び出しはランタイムが自動処理する (個別 step として現れない)。
+
+`outcomes.failure.action = "abort"` で失敗時は HTTP 5xx 応答 (`responses[]` から responseId 一致を選択) を返し、outputBinding には何も入らない (`runIf` でガードされる後続 step は skip)。
+
 ### `AiMessage.content`
 
 `string` (シンプルテキスト) または content blocks 配列 (text / image)。Anthropic / OpenAI と整合。

--- a/examples/diary/harmony/conventions/catalog.json
+++ b/examples/diary/harmony/conventions/catalog.json
@@ -70,29 +70,5 @@
       "template": "casual-diary",
       "description": "校正の既定トーン。日記なら casual、公開ブログなら polite/professional"
     }
-  },
-  "extensionCategories": {
-    "ai": {
-      "summarizeModel": {
-        "provider": "anthropic",
-        "model": "claude-opus-4-7",
-        "description": "本文の要約に使うモデル。長文から 3-5 文の要約を出す"
-      },
-      "altTextModel": {
-        "provider": "anthropic",
-        "model": "claude-opus-4-7",
-        "description": "Vision API で画像 alt text を生成。日本語で簡潔に (40-100 字)"
-      },
-      "proofreadModel": {
-        "provider": "anthropic",
-        "model": "claude-opus-4-7",
-        "description": "本文校正に使うモデル (敬体/常体/誤字訂正)"
-      },
-      "tagSuggestModel": {
-        "provider": "anthropic",
-        "model": "claude-opus-4-7",
-        "description": "本文からタグ候補を提案するモデル (信頼度 score 付き)"
-      }
-    }
   }
 }

--- a/examples/diary/harmony/process-flows/a9b0c1d2-e3f4-4a5b-8c6d-7e8f9a0b1c2d.json
+++ b/examples/diary/harmony/process-flows/a9b0c1d2-e3f4-4a5b-8c6d-7e8f9a0b1c2d.json
@@ -3,11 +3,11 @@
   "meta": {
     "id": "a9b0c1d2-e3f4-4a5b-8c6d-7e8f9a0b1c2d",
     "name": "AIタグ提案",
-    "description": "投稿のタイトル + 本文を Claude AI へ送信し、信頼度付きタグ候補を取得する処理フロー。信頼度が conventions/catalog.json の limit.tagSuggestThreshold 未満のものは除外する。UI 側でユーザー選択後、確定は投稿作成/更新フロー経由で post_tags に INSERT。",
+    "description": "投稿のタイトル + 本文を AI モデルへ送信し、信頼度付きタグ候補を構造化出力 (responseFormat=structuredObject) で取得する処理フロー。信頼度が conventions/catalog.json の limit.tagSuggestThreshold 未満のものは除外する。UI 側でユーザー選択後、確定は投稿作成/更新フロー経由で post_tags に INSERT。",
     "kind": "common",
     "maturity": "draft",
     "createdAt": "2026-05-06T14:00:00.000Z",
-    "updatedAt": "2026-05-06T14:00:00.000Z"
+    "updatedAt": "2026-05-08T00:00:00.000Z"
   },
   "context": {
     "catalogs": {
@@ -22,37 +22,29 @@
           "httpStatus": 502,
           "defaultMessage": "AI API の呼び出しに失敗しました。",
           "responseId": "502-ai-error",
-          "description": "Claude API へのリクエストが失敗した場合。"
+          "description": "AI モデルへのリクエストが失敗した場合。"
         }
       },
-      "externalSystems": {
-        "claudeApi": {
-          "name": "Claude AI API",
-          "baseUrl": "@env.CLAUDE_API_BASE_URL",
+      "modelEndpoints": {
+        "tagSuggestModel": {
+          "provider": "anthropic",
+          "model": "claude-opus-4-7",
           "auth": {
             "kind": "bearer",
-            "tokenRef": "@secret.claudeApiKey"
+            "tokenRef": "@secret.anthropicApiKey"
           },
-          "timeoutMs": 30000,
-          "retryPolicy": {
-            "maxAttempts": 2,
-            "backoff": "exponential",
-            "initialDelayMs": 1000
-          }
+          "defaults": {
+            "maxTokens": 512,
+            "temperature": 0.5
+          },
+          "description": "本文からタグ候補を提案するモデル (信頼度 score 付き、structuredObject 形式)。"
         }
       },
       "secrets": {
-        "claudeApiKey": {
+        "anthropicApiKey": {
           "source": "env",
-          "name": "CLAUDE_API_KEY",
-          "description": "Claude API の認証キー。"
-        }
-      },
-      "envVars": {
-        "CLAUDE_API_BASE_URL": {
-          "type": "string",
-          "description": "Claude API base URL",
-          "default": "https://api.anthropic.com"
+          "name": "ANTHROPIC_API_KEY",
+          "description": "Anthropic API の認証キー。"
         }
       }
     },
@@ -181,13 +173,42 @@
         },
         {
           "id": "step-03",
-          "kind": "externalSystem",
-          "description": "Claude API にタグ抽出プロンプトを送信し、JSON 形式のタグ候補を取得する。",
-          "systemRef": "claudeApi",
-          "httpCall": {
-            "method": "POST",
-            "path": "/v1/messages",
-            "body": "{ model: @conv.ai.tagSuggestModel.model, max_tokens: 512, messages: [{ role: 'user', content: '以下の記事から関連するタグを抽出してください。除外するタグ: ' + JSON.stringify(@inputs.existingTags) + '\\n\\n# タイトル\\n' + @inputs.title + '\\n\\n# 本文\\n' + @inputs.body + '\\n\\n各タグの slug (英小文字ハイフン区切り), name (日本語), confidence (0.0〜1.0) を JSON 配列で返してください。形式: [{\"slug\": \"...\", \"name\": \"...\", \"confidence\": 0.9}]' }] }"
+          "kind": "aiCall",
+          "description": "AI モデルにタグ抽出プロンプトを送信し、structuredObject 形式 (JSON Schema 準拠) でタグ候補を取得する。",
+          "modelRef": "tagSuggestModel",
+          "messages": [
+            {
+              "role": "system",
+              "content": "あなたは日本語ブログ記事のタグ付け専門家です。記事内容から関連性の高いタグ候補を抽出し、各タグに 0.0〜1.0 の信頼度スコアを付与してください。slug は英小文字ハイフン区切り、name は日本語表記。"
+            },
+            {
+              "role": "user",
+              "content": "以下の記事に関連するタグを抽出してください。除外するタグ: @inputs.existingTags\n\n# タイトル\n@inputs.title\n\n# 本文\n@inputs.body"
+            }
+          ],
+          "responseFormat": {
+            "kind": "structuredObject",
+            "name": "TagSuggestResult",
+            "schema": {
+              "type": "object",
+              "required": ["tags"],
+              "properties": {
+                "tags": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": ["slug", "name", "confidence"],
+                    "properties": {
+                      "slug": { "type": "string", "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$" },
+                      "name": { "type": "string" },
+                      "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
           },
           "outputBinding": {
             "name": "aiResponse"
@@ -195,15 +216,15 @@
           "outcomes": {
             "failure": {
               "action": "abort",
-              "description": "Claude API 呼び出し失敗時は 502 を返す。"
+              "description": "AI モデル呼び出し失敗時は 502 を返す。"
             }
           }
         },
         {
           "id": "step-04",
           "kind": "compute",
-          "description": "AI レスポンスから候補配列を JSON パースし、信頼度フィルタ (0.6 以上) と isNew フラグを付与する。閾値は conventions/catalog.json の limit.tagSuggestThreshold に準拠。",
-          "expression": "JSON.parse(@aiResponse.content[0].text).filter(t => t.confidence >= 0.6).map(t => ({ ...t, isNew: !@allTagSlugs.some(s => s.slug === t.slug) }))",
+          "description": "structuredObject の出力 (aiResponse.object.tags) を信頼度フィルタ (0.6 以上) と isNew フラグで加工する。閾値は conventions/catalog.json の limit.tagSuggestThreshold に準拠。",
+          "expression": "@aiResponse.object.tags.filter(t => t.confidence >= 0.6).map(t => ({ ...t, isNew: !@allTagSlugs.some(s => s.slug === t.slug) }))",
           "outputBinding": {
             "name": "candidates"
           }

--- a/examples/diary/harmony/process-flows/a9b0c1d2-e3f4-4a5b-8c6d-7e8f9a0b1c2d.json
+++ b/examples/diary/harmony/process-flows/a9b0c1d2-e3f4-4a5b-8c6d-7e8f9a0b1c2d.json
@@ -223,8 +223,8 @@
         {
           "id": "step-04",
           "kind": "compute",
-          "description": "structuredObject の出力 (aiResponse.object.tags) を信頼度フィルタ (0.6 以上) と isNew フラグで加工する。閾値は conventions/catalog.json の limit.tagSuggestThreshold に準拠。",
-          "expression": "@aiResponse.object.tags.filter(t => t.confidence >= 0.6).map(t => ({ ...t, isNew: !@allTagSlugs.some(s => s.slug === t.slug) }))",
+          "description": "structuredObject の出力 (aiResponse.object.tags) を信頼度フィルタと isNew フラグで加工する。閾値は @conv.limit.tagSuggestThreshold (現在 0.6) を参照し、conventions 編集だけで全フローに反映できるよう抽象化する。",
+          "expression": "@aiResponse.object.tags.filter(t => t.confidence >= @conv.limit.tagSuggestThreshold).map(t => ({ ...t, isNew: !@allTagSlugs.some(s => s.slug === t.slug) }))",
           "outputBinding": {
             "name": "candidates"
           }

--- a/examples/diary/harmony/process-flows/b0c1d2e3-f4a5-4b6c-8d7e-8f9a0b1c2d3e.json
+++ b/examples/diary/harmony/process-flows/b0c1d2e3-f4a5-4b6c-8d7e-8f9a0b1c2d3e.json
@@ -3,11 +3,11 @@
   "meta": {
     "id": "b0c1d2e3-f4a5-4b6c-8d7e-8f9a0b1c2d3e",
     "name": "AI画像alt生成",
-    "description": "写真の URL を Claude Vision API へ送信し、日本語の alt テキスト (40-100 字) を生成して photos.alt に書き戻す処理フロー。使用モデルは conventions/catalog.json の extensionCategories.ai.altTextModel を参照。",
+    "description": "写真ファイル参照を AI モデル (vision multimodal) に送信し、日本語の alt テキスト (40-100 字) を生成して photos.alt に書き戻す処理フロー。messages の content blocks に image (fileRef) を含めて vision 入力を表現する。",
     "kind": "common",
     "maturity": "draft",
     "createdAt": "2026-05-06T14:00:00.000Z",
-    "updatedAt": "2026-05-06T14:00:00.000Z"
+    "updatedAt": "2026-05-08T00:00:00.000Z"
   },
   "context": {
     "catalogs": {
@@ -28,37 +28,29 @@
           "httpStatus": 502,
           "defaultMessage": "AI API の呼び出しに失敗しました。",
           "responseId": "502-ai-error",
-          "description": "Claude Vision API へのリクエストが失敗した場合。"
+          "description": "AI モデル (vision) へのリクエストが失敗した場合。"
         }
       },
-      "externalSystems": {
-        "claudeApi": {
-          "name": "Claude AI API (Vision)",
-          "baseUrl": "@env.CLAUDE_API_BASE_URL",
+      "modelEndpoints": {
+        "altTextModel": {
+          "provider": "anthropic",
+          "model": "claude-opus-4-7",
           "auth": {
             "kind": "bearer",
-            "tokenRef": "@secret.claudeApiKey"
+            "tokenRef": "@secret.anthropicApiKey"
           },
-          "timeoutMs": 45000,
-          "retryPolicy": {
-            "maxAttempts": 2,
-            "backoff": "exponential",
-            "initialDelayMs": 1000
-          }
+          "defaults": {
+            "maxTokens": 256,
+            "temperature": 0.4
+          },
+          "description": "Vision 入力対応モデル。画像を理解し alt text を日本語で簡潔に (40-100 字) 生成する。"
         }
       },
       "secrets": {
-        "claudeApiKey": {
+        "anthropicApiKey": {
           "source": "env",
-          "name": "CLAUDE_API_KEY",
-          "description": "Claude API の認証キー。"
-        }
-      },
-      "envVars": {
-        "CLAUDE_API_BASE_URL": {
-          "type": "string",
-          "description": "Claude API base URL",
-          "default": "https://api.anthropic.com"
+          "name": "ANTHROPIC_API_KEY",
+          "description": "Anthropic API の認証キー。"
         }
       }
     },
@@ -222,29 +214,46 @@
         },
         {
           "id": "step-05",
-          "kind": "externalSystem",
-          "description": "Claude Vision API に画像を送信し、日本語 alt テキスト (40-100 字) を取得する。",
-          "systemRef": "claudeApi",
-          "httpCall": {
-            "method": "POST",
-            "path": "/v1/messages",
-            "body": "{ model: @conv.ai.altTextModel.model, max_tokens: 256, messages: [{ role: 'user', content: [{ type: 'image', source: { type: 'url', url: @targetImageUrl } }, { type: 'text', text: 'この画像の alt テキストを日本語で 40〜100 字で記述してください。視覚障害者がスクリーンリーダーで内容を理解できるよう、具体的かつ簡潔に描写してください。alt テキストのみを返してください。' }] }] }"
-          },
+          "kind": "aiCall",
+          "description": "AI モデル (vision) に画像 + プロンプトを送信し、日本語 alt テキスト (40-100 字) を取得する。content blocks の image (fileRef) で画像入力を表現。",
+          "modelRef": "altTextModel",
+          "messages": [
+            {
+              "role": "system",
+              "content": "あなたは視覚障害者向け alt text 生成の専門家です。画像の内容をスクリーンリーダーで理解できるよう、日本語 40〜100 字で具体的かつ簡潔に描写してください。装飾語や前置きは付けず、alt テキストのみを返します。"
+            },
+            {
+              "role": "user",
+              "content": [
+                {
+                  "type": "image",
+                  "source": {
+                    "kind": "fileRef",
+                    "ref": "@targetImageUrl"
+                  }
+                },
+                {
+                  "type": "text",
+                  "text": "この画像の alt テキストを生成してください。"
+                }
+              ]
+            }
+          ],
           "outputBinding": {
             "name": "aiResponse"
           },
           "outcomes": {
             "failure": {
               "action": "abort",
-              "description": "Claude Vision API 呼び出し失敗時は 502 を返す。"
+              "description": "AI モデル呼び出し失敗時は 502 を返す。"
             }
           }
         },
         {
           "id": "step-06",
           "kind": "compute",
-          "description": "AI レスポンスから alt テキストを抽出する。",
-          "expression": "@aiResponse.content[0].text",
+          "description": "AI レスポンスから alt テキストを抽出する (provider 中立な assistant メッセージテキスト)。",
+          "expression": "@aiResponse.text",
           "outputBinding": {
             "name": "altText"
           }

--- a/examples/diary/harmony/process-flows/c1d2e3f4-a5b6-4c7d-8e9f-0a1b2c3d4e5f.json
+++ b/examples/diary/harmony/process-flows/c1d2e3f4-a5b6-4c7d-8e9f-0a1b2c3d4e5f.json
@@ -3,11 +3,11 @@
   "meta": {
     "id": "c1d2e3f4-a5b6-4c7d-8e9f-0a1b2c3d4e5f",
     "name": "AI文章校正",
-    "description": "投稿本文のテキストを Claude AI へ送信し、指定スタイルで校正した結果 + 変更箇所 diff を返す処理フロー。DB 書き込みなし (UI が結果を表示するのみ)。ユーザーが採用した場合は投稿更新フロー経由で body を更新する。",
+    "description": "投稿本文のテキストを AI モデルへ送信し、指定スタイルで校正した結果 + 変更箇所 diff を responseFormat=structuredObject で返す処理フロー。DB 書き込みなし (UI が結果を表示するのみ)。ユーザーが採用した場合は投稿更新フロー経由で body を更新する。",
     "kind": "common",
     "maturity": "draft",
     "createdAt": "2026-05-06T14:00:00.000Z",
-    "updatedAt": "2026-05-06T14:00:00.000Z"
+    "updatedAt": "2026-05-08T00:00:00.000Z"
   },
   "context": {
     "catalogs": {
@@ -22,37 +22,29 @@
           "httpStatus": 502,
           "defaultMessage": "AI API の呼び出しに失敗しました。",
           "responseId": "502-ai-error",
-          "description": "Claude API へのリクエストが失敗した場合。"
+          "description": "AI モデルへのリクエストが失敗した場合。"
         }
       },
-      "externalSystems": {
-        "claudeApi": {
-          "name": "Claude AI API",
-          "baseUrl": "@env.CLAUDE_API_BASE_URL",
+      "modelEndpoints": {
+        "proofreadModel": {
+          "provider": "anthropic",
+          "model": "claude-opus-4-7",
           "auth": {
             "kind": "bearer",
-            "tokenRef": "@secret.claudeApiKey"
+            "tokenRef": "@secret.anthropicApiKey"
           },
-          "timeoutMs": 60000,
-          "retryPolicy": {
-            "maxAttempts": 2,
-            "backoff": "exponential",
-            "initialDelayMs": 1000
-          }
+          "defaults": {
+            "maxTokens": 4096,
+            "temperature": 0.3
+          },
+          "description": "本文校正に使うモデル (敬体/常体/誤字訂正、structuredObject 形式で diff を返す)。"
         }
       },
       "secrets": {
-        "claudeApiKey": {
+        "anthropicApiKey": {
           "source": "env",
-          "name": "CLAUDE_API_KEY",
-          "description": "Claude API の認証キー。"
-        }
-      },
-      "envVars": {
-        "CLAUDE_API_BASE_URL": {
-          "type": "string",
-          "description": "Claude API base URL",
-          "default": "https://api.anthropic.com"
+          "name": "ANTHROPIC_API_KEY",
+          "description": "Anthropic API の認証キー。"
         }
       }
     },
@@ -181,13 +173,45 @@
         },
         {
           "id": "step-03",
-          "kind": "externalSystem",
-          "description": "Claude API に校正プロンプトを送信する。校正後全文 + diff 配列を JSON で返すよう指示する。",
-          "systemRef": "claudeApi",
-          "httpCall": {
-            "method": "POST",
-            "path": "/v1/messages",
-            "body": "{ model: @conv.ai.proofreadModel.model, max_tokens: 4096, messages: [{ role: 'user', content: '以下の文章を' + @styleDescription + 'に校正してください。\\n\\n元の文章:\\n' + @inputs.text + '\\n\\n以下の JSON 形式で返答してください:\\n{\"corrected\": \"校正後の全文\", \"changes\": [{\"type\": \"unchanged|added|removed\", \"text\": \"テキスト\"}]}' }] }"
+          "kind": "aiCall",
+          "description": "AI モデルに校正プロンプトを送信し、structuredObject 形式 (校正後全文 + 変更箇所 diff 配列) で結果を取得する。",
+          "modelRef": "proofreadModel",
+          "messages": [
+            {
+              "role": "system",
+              "content": "あなたは日本語文章校正の専門家です。指定されたスタイルで原文を校正し、校正後の全文と変更箇所の差分を構造化して返してください。changes 配列には unchanged / added / removed の type と該当 text を順序通りに並べ、原文と校正後を再構成可能な形にしてください。"
+            },
+            {
+              "role": "user",
+              "content": "以下の文章を @styleDescription に校正してください。\n\n# 元の文章\n@inputs.text"
+            }
+          ],
+          "responseFormat": {
+            "kind": "structuredObject",
+            "name": "ProofreadResult",
+            "schema": {
+              "type": "object",
+              "required": ["corrected", "changes"],
+              "properties": {
+                "corrected": {
+                  "type": "string",
+                  "description": "校正後の全文。"
+                },
+                "changes": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": ["type", "text"],
+                    "properties": {
+                      "type": { "type": "string", "enum": ["unchanged", "added", "removed"] },
+                      "text": { "type": "string" }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
           },
           "outputBinding": {
             "name": "aiResponse"
@@ -195,25 +219,16 @@
           "outcomes": {
             "failure": {
               "action": "abort",
-              "description": "Claude API 呼び出し失敗時は 502 を返す。"
+              "description": "AI モデル呼び出し失敗時は 502 を返す。"
             }
           }
         },
         {
           "id": "step-04",
-          "kind": "compute",
-          "description": "AI レスポンスから校正結果 JSON をパースする。",
-          "expression": "JSON.parse(@aiResponse.content[0].text)",
-          "outputBinding": {
-            "name": "proofreadResult"
-          }
-        },
-        {
-          "id": "step-05",
           "kind": "return",
-          "description": "200 校正結果を返す。",
+          "description": "200 校正結果を返す。aiCall の structuredObject 出力 (aiResponse.object) はランタイムが parse 済みのため JSON.parse 不要。",
           "responseId": "200-ok",
-          "bodyExpression": "{ corrected: @proofreadResult.corrected, changes: @proofreadResult.changes }"
+          "bodyExpression": "{ corrected: @aiResponse.object.corrected, changes: @aiResponse.object.changes }"
         }
       ]
     }

--- a/examples/diary/harmony/process-flows/f7a8b9c0-d1e2-4f3a-8b4c-5d6e7f8a9b0c.json
+++ b/examples/diary/harmony/process-flows/f7a8b9c0-d1e2-4f3a-8b4c-5d6e7f8a9b0c.json
@@ -3,11 +3,11 @@
   "meta": {
     "id": "f7a8b9c0-d1e2-4f3a-8b4c-5d6e7f8a9b0c",
     "name": "AI要約生成",
-    "description": "投稿本文を Claude AI へ送信し、3-5 文の日本語要約を生成して posts.summary に書き戻す処理フロー。投稿作成/更新後に非同期で呼ぶ想定 (TX 外、idempotent)。使用モデルは conventions/catalog.json の extensionCategories.ai.summarizeModel を参照。",
+    "description": "投稿本文を AI モデルへ送信し、3-5 文の日本語要約を生成して posts.summary に書き戻す処理フロー。投稿作成/更新後に非同期で呼ぶ想定 (TX 外、idempotent)。AI 呼び出しは aiCall step + modelEndpoints.summarizeModel で表現。provider 切替は modelEndpoints の編集だけで完結する。",
     "kind": "common",
     "maturity": "draft",
     "createdAt": "2026-05-06T14:00:00.000Z",
-    "updatedAt": "2026-05-06T14:00:00.000Z"
+    "updatedAt": "2026-05-08T00:00:00.000Z"
   },
   "context": {
     "catalogs": {
@@ -22,37 +22,29 @@
           "httpStatus": 502,
           "defaultMessage": "AI API の呼び出しに失敗しました。",
           "responseId": "502-ai-error",
-          "description": "Claude API へのリクエストが失敗した場合。"
+          "description": "AI モデルへのリクエストが失敗した場合。"
         }
       },
-      "externalSystems": {
-        "claudeApi": {
-          "name": "Claude AI API",
-          "baseUrl": "@env.CLAUDE_API_BASE_URL",
+      "modelEndpoints": {
+        "summarizeModel": {
+          "provider": "anthropic",
+          "model": "claude-opus-4-7",
           "auth": {
             "kind": "bearer",
-            "tokenRef": "@secret.claudeApiKey"
+            "tokenRef": "@secret.anthropicApiKey"
           },
-          "timeoutMs": 30000,
-          "retryPolicy": {
-            "maxAttempts": 2,
-            "backoff": "exponential",
-            "initialDelayMs": 1000
-          }
+          "defaults": {
+            "maxTokens": 512,
+            "temperature": 0.7
+          },
+          "description": "本文の要約に使うモデル。長文から 3-5 文の要約を出す。"
         }
       },
       "secrets": {
-        "claudeApiKey": {
+        "anthropicApiKey": {
           "source": "env",
-          "name": "CLAUDE_API_KEY",
-          "description": "Claude API の認証キー。"
-        }
-      },
-      "envVars": {
-        "CLAUDE_API_BASE_URL": {
-          "type": "string",
-          "description": "Claude API base URL",
-          "default": "https://api.anthropic.com"
+          "name": "ANTHROPIC_API_KEY",
+          "description": "Anthropic API の認証キー。"
         }
       }
     },
@@ -184,29 +176,34 @@
         },
         {
           "id": "step-04",
-          "kind": "externalSystem",
-          "description": "Claude API に要約プロンプトを送信し、3-5 文の日本語要約を取得する。",
-          "systemRef": "claudeApi",
-          "httpCall": {
-            "method": "POST",
-            "path": "/v1/messages",
-            "body": "{ model: @conv.ai.summarizeModel.model, max_tokens: 512, messages: [{ role: 'user', content: '以下の日記の文章を 3〜5 文で日本語で要約してください。\\n\\n' + @targetBody }] }"
-          },
+          "kind": "aiCall",
+          "description": "AI モデルに要約プロンプトを送信し、3-5 文の日本語要約を取得する。",
+          "modelRef": "summarizeModel",
+          "messages": [
+            {
+              "role": "system",
+              "content": "あなたは日本語の文章要約の専門家です。与えられた日記本文を 3〜5 文で簡潔に日本語要約してください。要約のみを返し、前置きや補足は付けないでください。"
+            },
+            {
+              "role": "user",
+              "content": "@targetBody"
+            }
+          ],
           "outputBinding": {
             "name": "aiResponse"
           },
           "outcomes": {
             "failure": {
               "action": "abort",
-              "description": "Claude API 呼び出し失敗時は 502 を返す。"
+              "description": "AI モデル呼び出し失敗時は 502 を返す。"
             }
           }
         },
         {
           "id": "step-05",
           "kind": "compute",
-          "description": "Claude API レスポンスから要約テキストを抽出する。",
-          "expression": "@aiResponse.content[0].text",
+          "description": "AI レスポンスから要約テキストを抽出する。aiCall は provider 中立な assistant メッセージテキストを返すため、後続 step では .text フィールドから取得する。",
+          "expression": "@aiResponse.text",
           "outputBinding": {
             "name": "summaryText"
           }

--- a/examples/english-learning-tailwind/harmony/extensions/english-learning.v3.json
+++ b/examples/english-learning-tailwind/harmony/extensions/english-learning.v3.json
@@ -3,7 +3,7 @@
   "namespace": "english-learning",
   "version": "1.0.0",
   "requiresCoreSchema": ">=3.0.0",
-  "description": "英会話学習アプリ向け v3 canonical 拡張定義。fieldTypes / actionTriggers / dbOperations / stepKinds / responseTypes / screenKinds を統合。外部 AI (LLM/TTS/STT) 呼び出しを stepKind 拡張で表現し、CEFR レベル / IPA / 発音スコア等の英語学習固有型を fieldType として定義する。",
+  "description": "英会話学習アプリ向け v3 canonical 拡張定義。fieldTypes / actionTriggers / dbOperations / stepKinds / responseTypes / screenKinds を統合。LLM 呼び出しは core stepKind aiCall + modelEndpoints catalog で表現するため、本拡張からは LlmDialog を削除済み (#865 / 2026-05-08)。TTS / STT は業務ドメイン固有のため当面 stepKind 拡張で表現を維持する。CEFR レベル / IPA / 発音スコア等の英語学習固有型を fieldType として定義する。",
   "fieldTypes": [
     {
       "kind": "ipa",
@@ -47,7 +47,7 @@
       "kind": "dialogTurn",
       "label": "会話ターン",
       "baseType": "json",
-      "description": "LLM 会話ターンの構造型。{ role: 'user' | 'assistant' | 'system', content: string } の配列として実装する。LlmDialog step の outputType として使用し、turn_logs.llm_context に保存される。"
+      "description": "LLM 会話ターンの構造型。{ role: 'user' | 'assistant' | 'system', content: string } の配列として実装する。aiCall step の messages 構築用入力 (turnContext) と turn_logs.llm_context の保存形式として使用する。"
     }
   ],
   "actionTriggers": [
@@ -85,38 +85,6 @@
     }
   ],
   "stepKinds": {
-    "LlmDialog": {
-      "label": "LLM 会話呼び出し",
-      "icon": "bi-chat-dots",
-      "description": "外部 LLM API (OpenAI GPT-4 / Anthropic Claude 等) に会話リクエストを送信する拡張 Step。context (会話履歴) と userInput を入力とし、AI 応答テキストを outputBinding に返す。S-2 progress-turn フローで使用する。provider 選択・temperature 等の詳細は実装層が決定する。",
-      "schema": {
-        "type": "object",
-        "required": ["context", "userInput"],
-        "properties": {
-          "context": {
-            "type": "string",
-            "description": "会話コンテキスト (DialogTurn[] の変数参照、例: @var.turnContext)"
-          },
-          "userInput": {
-            "type": "string",
-            "description": "ユーザーの最新発話テキスト (変数参照、例: @var.userInput)"
-          },
-          "systemPrompt": {
-            "type": "string",
-            "description": "システムプロンプト (省略時はデフォルト英会話学習プロンプト)"
-          },
-          "maxTokens": {
-            "type": "integer",
-            "description": "最大出力トークン数 (省略時は 500)"
-          }
-        },
-        "additionalProperties": false
-      },
-      "outputType": {
-        "kind": "extension",
-        "extensionRef": "english-learning:dialogTurn"
-      }
-    },
     "TtsGenerate": {
       "label": "TTS 音声生成",
       "icon": "bi-volume-up",
@@ -176,7 +144,7 @@
   },
   "responseTypes": {
     "DialogTurn": {
-      "description": "LLM 会話ターンレスポンス。LlmDialog step の outputBinding に格納される会話ターン構造。turn_logs.llm_context (JSON 配列) の 1 要素に対応する。",
+      "description": "LLM 会話ターンレスポンス。会話ターン (role + content + 任意 audioUrl) の構造型。turn_logs.llm_context (JSON 配列) の 1 要素に対応する。aiCall step の入出力構築・履歴保存に共通使用する。",
       "schema": {
         "type": "object",
         "required": ["role", "content"],

--- a/examples/english-learning-tailwind/harmony/process-flows/96118ae1-a0ab-401b-8584-dd645a45a81f.json
+++ b/examples/english-learning-tailwind/harmony/process-flows/96118ae1-a0ab-401b-8584-dd645a45a81f.json
@@ -3,12 +3,12 @@
   "meta": {
     "id": "96118ae1-a0ab-401b-8584-dd645a45a81f",
     "name": "会話ターン進行",
-    "description": "ユーザーの発話 (テキストまたは音声) を受け取り、LLM に会話リクエストを送信して AI 応答を取得する (S-2)。必要に応じて TTS で応答を音声化し、turn_logs に 1 ターン分のログを INSERT する。LLM 呼び出しは拡張 stepKind english-learning:LlmDialog で表現し、TTS 呼び出しは english-learning:TtsGenerate で表現する。ターン単位 request/response 方式。実装側で SSE / WebSocket による partial response ストリーム表示を行う想定 (description 待避、3.3 節)。",
+    "description": "ユーザーの発話 (テキストまたは音声) を受け取り、LLM に会話リクエストを送信して AI 応答を取得する (S-2)。必要に応じて TTS で応答を音声化し、turn_logs に 1 ターン分のログを INSERT する。LLM 呼び出しは core stepKind aiCall + modelEndpoints.dialogModel で表現し、TTS 呼び出しは english-learning:TtsGenerate で表現する。ターン単位 request/response 方式。実装側で SSE / WebSocket による partial response ストリーム表示を行う想定 (description 待避、3.3 節)。",
     "kind": "screen",
     "screenId": "a9d8eb6f-065d-4af6-ac9a-cc1fcf10b2b7",
     "maturity": "draft",
     "createdAt": "2026-05-04T00:00:00.000Z",
-    "updatedAt": "2026-05-04T00:00:00.000Z"
+    "updatedAt": "2026-05-08T00:00:00.000Z"
   },
   "context": {
     "catalogs": {
@@ -23,7 +23,29 @@
           "httpStatus": 502,
           "defaultMessage": "AI 応答の取得に失敗しました。しばらく待ってから再試行してください。",
           "responseId": "502-llm-failed",
-          "description": "english-learning:LlmDialog step が外部 LLM API から正常応答を得られなかった場合。"
+          "description": "aiCall step が外部 LLM API から正常応答を得られなかった場合。"
+        }
+      },
+      "modelEndpoints": {
+        "dialogModel": {
+          "provider": "anthropic",
+          "model": "claude-opus-4-7",
+          "auth": {
+            "kind": "bearer",
+            "tokenRef": "@secret.anthropicApiKey"
+          },
+          "defaults": {
+            "maxTokens": 500,
+            "temperature": 0.7
+          },
+          "description": "英会話学習用の対話モデル。日本語学習者向けに CEFR レベルに応じた英文応答を返す。provider 切替 (OpenAI / Google 等) は本 catalog 編集だけで完結。"
+        }
+      },
+      "secrets": {
+        "anthropicApiKey": {
+          "source": "env",
+          "name": "ANTHROPIC_API_KEY",
+          "description": "Anthropic API の認証キー。"
         }
       },
       "events": {
@@ -55,7 +77,7 @@
       "id": "act-001",
       "name": "会話ターン送信",
       "trigger": "submit",
-      "description": "会話プレイ画面で録音またはテキスト入力したユーザー発話を送信し、AI 応答を取得して画面に反映する。LLM 呼び出し (english-learning:LlmDialog) → 任意の TTS 音声化 (english-learning:TtsGenerate) → turn_logs INSERT の順で実行する。",
+      "description": "会話プレイ画面で録音またはテキスト入力したユーザー発話を送信し、AI 応答を取得して画面に反映する。LLM 呼び出し (aiCall + modelEndpoints.dialogModel) → 任意の TTS 音声化 (english-learning:TtsGenerate) → turn_logs INSERT の順で実行する。",
       "maturity": "draft",
       "httpRoute": {
         "method": "POST",
@@ -82,7 +104,7 @@
           "label": "会話コンテキスト",
           "type": "string",
           "required": false,
-          "description": "直近の会話履歴 (DialogTurn[] の JSON 文字列)。LlmDialog step の context 入力として使用する。"
+          "description": "直近の会話履歴 (DialogTurn[] の JSON 文字列)。aiCall step の user メッセージ content に埋め込んで LLM へ渡す。"
         },
         {
           "name": "generateAudio",
@@ -161,7 +183,7 @@
             }
           },
           "description": "LLM API 呼び出し失敗。",
-          "when": "english-learning:LlmDialog step が外部 API から正常応答を得られなかった場合。"
+          "when": "aiCall step が外部 API から正常応答を得られなかった場合。"
         }
       ],
       "steps": [
@@ -213,13 +235,26 @@
         },
         {
           "id": "step-03",
-          "kind": "english-learning:LlmDialog",
-          "description": "OpenAI GPT-4 / Anthropic Claude 等の LLM API を呼び出す。実装側で provider 選択。temperature 0.7 推奨。ストリーム応答は SSE / WebSocket で実装側が処理し、本フローでは完了後のテキストのみ受け取る。",
-          "config": {
-            "context": "@turnContext",
-            "userInput": "@userInput"
-          },
-          "outputBinding": { "name": "aiResponse" }
+          "kind": "aiCall",
+          "description": "core stepKind aiCall + modelEndpoints.dialogModel で LLM 呼び出しを行う。provider 選択は modelEndpoints catalog で完結。messages[] に system プロンプト + (会話履歴) + 最新 user 発話を並べる。messages[] は静的配列のため、prior turns は @turnContext (DialogTurn[] JSON 文字列) として user content に埋め込む暫定形 (動的 spread は core schema の今後の拡張候補)。ストリーム応答 (SSE / WebSocket) は実装側が処理し、本フローでは完了後の assistant テキストを受け取る。",
+          "modelRef": "dialogModel",
+          "messages": [
+            {
+              "role": "system",
+              "content": "あなたは日本人英語学習者向けの会話パートナーです。学習者の CEFR レベル (A1〜C2) に合った語彙と文法で英語応答してください。応答は 1〜3 文程度に抑え、次の発話を促す問いかけを含めると望ましい。"
+            },
+            {
+              "role": "user",
+              "content": "[会話履歴 (DialogTurn[])]\n@turnContext\n\n[最新の発話]\n@userInput"
+            }
+          ],
+          "outputBinding": { "name": "aiResponse" },
+          "outcomes": {
+            "failure": {
+              "action": "abort",
+              "description": "LLM 呼び出し失敗時は 502 を返す。"
+            }
+          }
         },
         {
           "id": "step-04",
@@ -240,7 +275,7 @@
                   "kind": "english-learning:TtsGenerate",
                   "description": "LLM の応答テキストを TTS で音声ファイルに変換する。生成した audioUrl を aiAudioUrl 変数に格納し、turn_logs.ai_audio_url として保存する。",
                   "config": {
-                    "text": "@aiResponse.content"
+                    "text": "@aiResponse.text"
                   },
                   "outputBinding": { "name": "aiAudioUrl" }
                 }
@@ -290,7 +325,7 @@
           "description": "turn_logs に 1 ターン分のログを INSERT する。user_input (ユーザー発話) と ai_response (AI 応答) + ai_audio_url を同時に記録する。llm_context には入力 turnContext と AI 応答を含む更新済み会話コンテキストを JSON として保存する。turn_number は step-04d で算出した次番号を使用する。",
           "tableId": "4e126323-4ab7-4747-961b-23cbaf651314",
           "operation": "INSERT",
-          "sql": "INSERT INTO turn_logs (session_id, turn_number, user_input, ai_response, ai_audio_url, llm_context, created_at) VALUES (@sessionId, @nextTurnNumber, @userInput, @aiResponse.content, @aiAudioUrl, @turnContext, CURRENT_TIMESTAMP) RETURNING id",
+          "sql": "INSERT INTO turn_logs (session_id, turn_number, user_input, ai_response, ai_audio_url, llm_context, created_at) VALUES (@sessionId, @nextTurnNumber, @userInput, @aiResponse.text, @aiAudioUrl, @turnContext, CURRENT_TIMESTAMP) RETURNING id",
           "outputBinding": { "name": "newTurnLog" },
           "lineage": {
             "writes": [
@@ -310,7 +345,7 @@
           "kind": "return",
           "description": "200 OK — AI 応答テキスト + ターンログ ID + 音声 URL (任意) を返す。",
           "responseId": "200-ok",
-          "bodyExpression": "{ aiResponseText: @aiResponse.content, aiAudioUrl: @aiAudioUrl, turnId: @newTurnLog.id }"
+          "bodyExpression": "{ aiResponseText: @aiResponse.text, aiAudioUrl: @aiAudioUrl, turnId: @newTurnLog.id }"
         }
       ]
     }

--- a/examples/english-learning-tailwind/harmony/screens/a9d8eb6f-065d-4af6-ac9a-cc1fcf10b2b7.json
+++ b/examples/english-learning-tailwind/harmony/screens/a9d8eb6f-065d-4af6-ac9a-cc1fcf10b2b7.json
@@ -37,7 +37,7 @@
       "label": "AI 応答テキスト",
       "type": "string",
       "direction": "output",
-      "description": "progress-turn フローの LlmDialog ステップが返した AI 応答テキスト (turn_logs.ai_response に保存済み)。"
+      "description": "progress-turn フローの aiCall ステップが返した AI 応答テキスト (turn_logs.ai_response に保存済み)。"
     },
     {
       "id": "recordButton",

--- a/examples/english-learning-tailwind/harmony/tables/4e126323-4ab7-4747-961b-23cbaf651314.json
+++ b/examples/english-learning-tailwind/harmony/tables/4e126323-4ab7-4747-961b-23cbaf651314.json
@@ -2,7 +2,7 @@
   "$schema": "../../../../schemas/v3/table.v3.schema.json",
   "id": "4e126323-4ab7-4747-961b-23cbaf651314",
   "name": "会話ターンログ",
-  "description": "学習セッション内の会話ターン (ユーザー発話 + AI 応答) のログテーブル。LLM 入力コンテキスト / ユーザー入力 / AI 応答 / TTS 音声 URL を JSON で保持する。S-2 会話ターン進行フローで LlmDialog + TtsGenerate step の出力を記録する。将来 SSE / WebSocket によるストリーム応答に対応する想定 (description 待避)。",
+  "description": "学習セッション内の会話ターン (ユーザー発話 + AI 応答) のログテーブル。LLM 入力コンテキスト / ユーザー入力 / AI 応答 / TTS 音声 URL を JSON で保持する。S-2 会話ターン進行フローで aiCall (core) + TtsGenerate (拡張) step の出力を記録する。将来 SSE / WebSocket によるストリーム応答に対応する想定 (description 待避)。",
   "maturity": "draft",
   "createdAt": "2026-05-04T00:00:00.000Z",
   "updatedAt": "2026-05-04T00:00:00.000Z",
@@ -56,7 +56,7 @@
       "name": "LLM コンテキスト",
       "dataType": "JSON",
       "notNull": false,
-      "comment": "LlmDialog step の入力コンテキスト JSON (会話履歴 / システムプロンプト等を含む)",
+      "comment": "aiCall step の messages 構築用 入力コンテキスト JSON (会話履歴 / システムプロンプト等を含む)",
       "description": "DialogTurn[] 配列形式。english-learning:DialogTurn responseType の構造に準拠。"
     },
     {

--- a/examples/english-learning/README.md
+++ b/examples/english-learning/README.md
@@ -50,11 +50,10 @@ examples/english-learning/
 
 | stepKind キー | 用途 | outputType |
 |---|---|---|
-| `LlmDialog` | LLM への会話リクエスト | `english-learning:dialogTurn` |
 | `TtsGenerate` | TTS 音声生成 | `english-learning:audioUrl` |
 | `SttEvaluate` | STT + 発音評価 | `english-learning:pronunciationScore` |
 
-外部 AI 呼び出しを `type: "other"` (汎用エスケープ) ではなく namespace 拡張で表現し、ProcessFlow viewer 上で他 step と同一抽象レベルで表示できることを実証する。
+外部 AI 呼び出しのうち、汎用 LLM 呼び出しは **core stepKind `aiCall` + `modelEndpoints` catalog** で表現する (#935 で 2026-05-08 に core 化、本サンプルも 2026-05-08 移行済み / #865)。TTS / STT は業務ドメイン固有のため、当面は namespace 拡張 stepKind で表現を維持する (将来 core 化する場合は `aiTts` / `aiStt` を追加候補とする / spec 12 節)。
 
 ## 開き方 (動作確認)
 

--- a/examples/english-learning/harmony/extensions/english-learning.v3.json
+++ b/examples/english-learning/harmony/extensions/english-learning.v3.json
@@ -3,7 +3,7 @@
   "namespace": "english-learning",
   "version": "1.0.0",
   "requiresCoreSchema": ">=3.0.0",
-  "description": "英会話学習アプリ向け v3 canonical 拡張定義。fieldTypes / actionTriggers / dbOperations / stepKinds / responseTypes / screenKinds を統合。外部 AI (LLM/TTS/STT) 呼び出しを stepKind 拡張で表現し、CEFR レベル / IPA / 発音スコア等の英語学習固有型を fieldType として定義する。",
+  "description": "英会話学習アプリ向け v3 canonical 拡張定義。fieldTypes / actionTriggers / dbOperations / stepKinds / responseTypes / screenKinds を統合。LLM 呼び出しは core stepKind aiCall + modelEndpoints catalog で表現するため、本拡張からは LlmDialog を削除済み (#865 / 2026-05-08)。TTS / STT は業務ドメイン固有のため当面 stepKind 拡張で表現を維持する。CEFR レベル / IPA / 発音スコア等の英語学習固有型を fieldType として定義する。",
   "fieldTypes": [
     {
       "kind": "ipa",
@@ -47,7 +47,7 @@
       "kind": "dialogTurn",
       "label": "会話ターン",
       "baseType": "json",
-      "description": "LLM 会話ターンの構造型。{ role: 'user' | 'assistant' | 'system', content: string } の配列として実装する。LlmDialog step の outputType として使用し、turn_logs.llm_context に保存される。"
+      "description": "LLM 会話ターンの構造型。{ role: 'user' | 'assistant' | 'system', content: string } の配列として実装する。aiCall step の messages 構築用入力 (turnContext) と turn_logs.llm_context の保存形式として使用する。"
     }
   ],
   "actionTriggers": [
@@ -85,38 +85,6 @@
     }
   ],
   "stepKinds": {
-    "LlmDialog": {
-      "label": "LLM 会話呼び出し",
-      "icon": "bi-chat-dots",
-      "description": "外部 LLM API (OpenAI GPT-4 / Anthropic Claude 等) に会話リクエストを送信する拡張 Step。context (会話履歴) と userInput を入力とし、AI 応答テキストを outputBinding に返す。S-2 progress-turn フローで使用する。provider 選択・temperature 等の詳細は実装層が決定する。",
-      "schema": {
-        "type": "object",
-        "required": ["context", "userInput"],
-        "properties": {
-          "context": {
-            "type": "string",
-            "description": "会話コンテキスト (DialogTurn[] の変数参照、例: @var.turnContext)"
-          },
-          "userInput": {
-            "type": "string",
-            "description": "ユーザーの最新発話テキスト (変数参照、例: @var.userInput)"
-          },
-          "systemPrompt": {
-            "type": "string",
-            "description": "システムプロンプト (省略時はデフォルト英会話学習プロンプト)"
-          },
-          "maxTokens": {
-            "type": "integer",
-            "description": "最大出力トークン数 (省略時は 500)"
-          }
-        },
-        "additionalProperties": false
-      },
-      "outputType": {
-        "kind": "extension",
-        "extensionRef": "english-learning:dialogTurn"
-      }
-    },
     "TtsGenerate": {
       "label": "TTS 音声生成",
       "icon": "bi-volume-up",
@@ -176,7 +144,7 @@
   },
   "responseTypes": {
     "DialogTurn": {
-      "description": "LLM 会話ターンレスポンス。LlmDialog step の outputBinding に格納される会話ターン構造。turn_logs.llm_context (JSON 配列) の 1 要素に対応する。",
+      "description": "LLM 会話ターンレスポンス。会話ターン (role + content + 任意 audioUrl) の構造型。turn_logs.llm_context (JSON 配列) の 1 要素に対応する。aiCall step の入出力構築・履歴保存に共通使用する。",
       "schema": {
         "type": "object",
         "required": ["role", "content"],

--- a/examples/english-learning/harmony/process-flows/96118ae1-a0ab-401b-8584-dd645a45a81f.json
+++ b/examples/english-learning/harmony/process-flows/96118ae1-a0ab-401b-8584-dd645a45a81f.json
@@ -3,12 +3,12 @@
   "meta": {
     "id": "96118ae1-a0ab-401b-8584-dd645a45a81f",
     "name": "会話ターン進行",
-    "description": "ユーザーの発話 (テキストまたは音声) を受け取り、LLM に会話リクエストを送信して AI 応答を取得する (S-2)。必要に応じて TTS で応答を音声化し、turn_logs に 1 ターン分のログを INSERT する。LLM 呼び出しは拡張 stepKind english-learning:LlmDialog で表現し、TTS 呼び出しは english-learning:TtsGenerate で表現する。ターン単位 request/response 方式。実装側で SSE / WebSocket による partial response ストリーム表示を行う想定 (description 待避、3.3 節)。",
+    "description": "ユーザーの発話 (テキストまたは音声) を受け取り、LLM に会話リクエストを送信して AI 応答を取得する (S-2)。必要に応じて TTS で応答を音声化し、turn_logs に 1 ターン分のログを INSERT する。LLM 呼び出しは core stepKind aiCall + modelEndpoints.dialogModel で表現し、TTS 呼び出しは english-learning:TtsGenerate で表現する。ターン単位 request/response 方式。実装側で SSE / WebSocket による partial response ストリーム表示を行う想定 (description 待避、3.3 節)。",
     "kind": "screen",
     "screenId": "a9d8eb6f-065d-4af6-ac9a-cc1fcf10b2b7",
     "maturity": "draft",
     "createdAt": "2026-05-04T00:00:00.000Z",
-    "updatedAt": "2026-05-04T00:00:00.000Z"
+    "updatedAt": "2026-05-08T00:00:00.000Z"
   },
   "context": {
     "catalogs": {
@@ -23,7 +23,29 @@
           "httpStatus": 502,
           "defaultMessage": "AI 応答の取得に失敗しました。しばらく待ってから再試行してください。",
           "responseId": "502-llm-failed",
-          "description": "english-learning:LlmDialog step が外部 LLM API から正常応答を得られなかった場合。"
+          "description": "aiCall step が外部 LLM API から正常応答を得られなかった場合。"
+        }
+      },
+      "modelEndpoints": {
+        "dialogModel": {
+          "provider": "anthropic",
+          "model": "claude-opus-4-7",
+          "auth": {
+            "kind": "bearer",
+            "tokenRef": "@secret.anthropicApiKey"
+          },
+          "defaults": {
+            "maxTokens": 500,
+            "temperature": 0.7
+          },
+          "description": "英会話学習用の対話モデル。日本語学習者向けに CEFR レベルに応じた英文応答を返す。provider 切替 (OpenAI / Google 等) は本 catalog 編集だけで完結。"
+        }
+      },
+      "secrets": {
+        "anthropicApiKey": {
+          "source": "env",
+          "name": "ANTHROPIC_API_KEY",
+          "description": "Anthropic API の認証キー。"
         }
       },
       "events": {
@@ -55,7 +77,7 @@
       "id": "act-001",
       "name": "会話ターン送信",
       "trigger": "submit",
-      "description": "会話プレイ画面で録音またはテキスト入力したユーザー発話を送信し、AI 応答を取得して画面に反映する。LLM 呼び出し (english-learning:LlmDialog) → 任意の TTS 音声化 (english-learning:TtsGenerate) → turn_logs INSERT の順で実行する。",
+      "description": "会話プレイ画面で録音またはテキスト入力したユーザー発話を送信し、AI 応答を取得して画面に反映する。LLM 呼び出し (aiCall + modelEndpoints.dialogModel) → 任意の TTS 音声化 (english-learning:TtsGenerate) → turn_logs INSERT の順で実行する。",
       "maturity": "draft",
       "httpRoute": {
         "method": "POST",
@@ -82,7 +104,7 @@
           "label": "会話コンテキスト",
           "type": "string",
           "required": false,
-          "description": "直近の会話履歴 (DialogTurn[] の JSON 文字列)。LlmDialog step の context 入力として使用する。"
+          "description": "直近の会話履歴 (DialogTurn[] の JSON 文字列)。aiCall step の user メッセージ content に埋め込んで LLM へ渡す。"
         },
         {
           "name": "generateAudio",
@@ -161,7 +183,7 @@
             }
           },
           "description": "LLM API 呼び出し失敗。",
-          "when": "english-learning:LlmDialog step が外部 API から正常応答を得られなかった場合。"
+          "when": "aiCall step が外部 API から正常応答を得られなかった場合。"
         }
       ],
       "steps": [
@@ -213,13 +235,26 @@
         },
         {
           "id": "step-03",
-          "kind": "english-learning:LlmDialog",
-          "description": "OpenAI GPT-4 / Anthropic Claude 等の LLM API を呼び出す。実装側で provider 選択。temperature 0.7 推奨。ストリーム応答は SSE / WebSocket で実装側が処理し、本フローでは完了後のテキストのみ受け取る。",
-          "config": {
-            "context": "@turnContext",
-            "userInput": "@userInput"
-          },
-          "outputBinding": { "name": "aiResponse" }
+          "kind": "aiCall",
+          "description": "core stepKind aiCall + modelEndpoints.dialogModel で LLM 呼び出しを行う。provider 選択は modelEndpoints catalog で完結。messages[] に system プロンプト + (会話履歴) + 最新 user 発話を並べる。messages[] は静的配列のため、prior turns は @turnContext (DialogTurn[] JSON 文字列) として user content に埋め込む暫定形 (動的 spread は core schema の今後の拡張候補)。ストリーム応答 (SSE / WebSocket) は実装側が処理し、本フローでは完了後の assistant テキストを受け取る。",
+          "modelRef": "dialogModel",
+          "messages": [
+            {
+              "role": "system",
+              "content": "あなたは日本人英語学習者向けの会話パートナーです。学習者の CEFR レベル (A1〜C2) に合った語彙と文法で英語応答してください。応答は 1〜3 文程度に抑え、次の発話を促す問いかけを含めると望ましい。"
+            },
+            {
+              "role": "user",
+              "content": "[会話履歴 (DialogTurn[])]\n@turnContext\n\n[最新の発話]\n@userInput"
+            }
+          ],
+          "outputBinding": { "name": "aiResponse" },
+          "outcomes": {
+            "failure": {
+              "action": "abort",
+              "description": "LLM 呼び出し失敗時は 502 を返す。"
+            }
+          }
         },
         {
           "id": "step-04",
@@ -240,7 +275,7 @@
                   "kind": "english-learning:TtsGenerate",
                   "description": "LLM の応答テキストを TTS で音声ファイルに変換する。生成した audioUrl を aiAudioUrl 変数に格納し、turn_logs.ai_audio_url として保存する。",
                   "config": {
-                    "text": "@aiResponse.content"
+                    "text": "@aiResponse.text"
                   },
                   "outputBinding": { "name": "aiAudioUrl" }
                 }
@@ -290,7 +325,7 @@
           "description": "turn_logs に 1 ターン分のログを INSERT する。user_input (ユーザー発話) と ai_response (AI 応答) + ai_audio_url を同時に記録する。llm_context には入力 turnContext と AI 応答を含む更新済み会話コンテキストを JSON として保存する。turn_number は step-04d で算出した次番号を使用する。",
           "tableId": "4e126323-4ab7-4747-961b-23cbaf651314",
           "operation": "INSERT",
-          "sql": "INSERT INTO turn_logs (session_id, turn_number, user_input, ai_response, ai_audio_url, llm_context, created_at) VALUES (@sessionId, @nextTurnNumber, @userInput, @aiResponse.content, @aiAudioUrl, @turnContext, CURRENT_TIMESTAMP) RETURNING id",
+          "sql": "INSERT INTO turn_logs (session_id, turn_number, user_input, ai_response, ai_audio_url, llm_context, created_at) VALUES (@sessionId, @nextTurnNumber, @userInput, @aiResponse.text, @aiAudioUrl, @turnContext, CURRENT_TIMESTAMP) RETURNING id",
           "outputBinding": { "name": "newTurnLog" },
           "lineage": {
             "writes": [
@@ -310,7 +345,7 @@
           "kind": "return",
           "description": "200 OK — AI 応答テキスト + ターンログ ID + 音声 URL (任意) を返す。",
           "responseId": "200-ok",
-          "bodyExpression": "{ aiResponseText: @aiResponse.content, aiAudioUrl: @aiAudioUrl, turnId: @newTurnLog.id }"
+          "bodyExpression": "{ aiResponseText: @aiResponse.text, aiAudioUrl: @aiAudioUrl, turnId: @newTurnLog.id }"
         }
       ]
     }

--- a/examples/english-learning/harmony/screens/a9d8eb6f-065d-4af6-ac9a-cc1fcf10b2b7.json
+++ b/examples/english-learning/harmony/screens/a9d8eb6f-065d-4af6-ac9a-cc1fcf10b2b7.json
@@ -37,7 +37,7 @@
       "label": "AI 応答テキスト",
       "type": "string",
       "direction": "output",
-      "description": "progress-turn フローの LlmDialog ステップが返した AI 応答テキスト (turn_logs.ai_response に保存済み)。"
+      "description": "progress-turn フローの aiCall ステップが返した AI 応答テキスト (turn_logs.ai_response に保存済み)。"
     },
     {
       "id": "recordButton",

--- a/examples/english-learning/harmony/tables/4e126323-4ab7-4747-961b-23cbaf651314.json
+++ b/examples/english-learning/harmony/tables/4e126323-4ab7-4747-961b-23cbaf651314.json
@@ -2,7 +2,7 @@
   "$schema": "../../../../schemas/v3/table.v3.schema.json",
   "id": "4e126323-4ab7-4747-961b-23cbaf651314",
   "name": "会話ターンログ",
-  "description": "学習セッション内の会話ターン (ユーザー発話 + AI 応答) のログテーブル。LLM 入力コンテキスト / ユーザー入力 / AI 応答 / TTS 音声 URL を JSON で保持する。S-2 会話ターン進行フローで LlmDialog + TtsGenerate step の出力を記録する。将来 SSE / WebSocket によるストリーム応答に対応する想定 (description 待避)。",
+  "description": "学習セッション内の会話ターン (ユーザー発話 + AI 応答) のログテーブル。LLM 入力コンテキスト / ユーザー入力 / AI 応答 / TTS 音声 URL を JSON で保持する。S-2 会話ターン進行フローで aiCall (core) + TtsGenerate (拡張) step の出力を記録する。将来 SSE / WebSocket によるストリーム応答に対応する想定 (description 待避)。",
   "maturity": "draft",
   "createdAt": "2026-05-04T00:00:00.000Z",
   "updatedAt": "2026-05-04T00:00:00.000Z",
@@ -56,7 +56,7 @@
       "name": "LLM コンテキスト",
       "dataType": "JSON",
       "notNull": false,
-      "comment": "LlmDialog step の入力コンテキスト JSON (会話履歴 / システムプロンプト等を含む)",
+      "comment": "aiCall step の messages 構築用 入力コンテキスト JSON (会話履歴 / システムプロンプト等を含む)",
       "description": "DialogTurn[] 配列形式。english-learning:DialogTurn responseType の構造に準拠。"
     },
     {


### PR DESCRIPTION
## 関連

- Closes #865
- 仕様: docs/spec/process-flow-ai-step-kind.md §既存表現からの移行 (Phase 2-A) / §`outputBinding` の値構造
- 仕様: docs/spec/examples-english-learning.md §2.2 シナリオ (S-2 会話ターン進行) / §2.5 拡張 namespace / §3.5 外部 AI の ProcessFlow 表現方針
- 派生元: PR #936 (c2be715、Phase 1 — schema + spec + test fixture)
- 上位 memory: project_ai_step_kind_core_2026_05_08.md

## 概要

PR #936 (Phase 1) で core schema に追加された `aiCall` / `aiAgent` / `modelEndpoints` catalog を、既存 sample (`examples/diary` の AI 4 flow + `examples/english-learning` の LlmDialog + Tailwind 版ミラー) に適用する Phase 2-A migration。これにより N=2 で分裂していた表現 (diary は `externalSystem` + `claudeApi`、english-learning は `english-learning:LlmDialog` 拡張 stepKind) を一本化し、provider 切替を catalog 編集だけで完結させる。

## 主な変更

### diary: `externalSystem(claudeApi)` → `aiCall + modelEndpoints`
- `f7a8b9c0` (要約生成): aiCall (text)、`modelEndpoints.summarizeModel` 新設
- `a9b0c1d2` (タグ提案): aiCall + `responseFormat=structuredObject`、`modelEndpoints.tagSuggestModel` 新設、フィルタ閾値は `@conv.limit.tagSuggestThreshold` 参照に変更
- `b0c1d2e3` (画像 alt 生成): aiCall + content blocks (image/`fileRef`) で vision 入力、`modelEndpoints.altTextModel` 新設
- `c1d2e3f4` (文章校正): aiCall + `responseFormat=structuredObject` (corrected + diff[])、`modelEndpoints.proofreadModel` 新設
- conventions: `extensionCategories.ai` (provider/model 重複定義) を削除し modelEndpoints catalog に一本化

### english-learning + english-learning-tailwind: `LlmDialog` → `aiCall`
- `96118ae1` (会話ターン進行) の step-03 を `english-learning:LlmDialog` から core stepKind `aiCall` に移行
- `modelEndpoints.dialogModel` catalog を追加
- 拡張 `english-learning.v3.json` から `LlmDialog` stepKind 定義を削除 (`TtsGenerate` / `SttEvaluate` は維持、業務ドメイン固有のため)
- 関連 documentation (README / table description / column comment / screen description / responseTypes.DialogTurn 説明 / fieldTypes.dialogTurn 説明) を更新

### docs spec
- `process-flow-ai-step-kind.md`:
  - 既存「Phase 2、別 PR」セクションを Phase 2-A 完了 + 2-B / 2-C 残作業に分割
  - **`outputBinding` の値構造 (provider 中立な正規化形式)** セクションを新設し、responseFormat.kind 別 (text / json / structuredObject / streaming) の値構造 + 後続 step での参照パターン (`@<binding>.text` / `@<binding>.object.<field>`) を確定 (Sonnet review Should-fix 1 で追加)
  - 設計判断 (LlmDialog → aiCall の理由) と既知の制約 (messages 動的 spread 不可) を記録
- `examples-english-learning.md`:
  - §2.2 シナリオ S-2 / §2.5 拡張 namespace stepKinds 表 / §2.5 末尾の「LLM/TTS/STT 統一実証」記述を aiCall + namespace 拡張 (TTS/STT のみ) に更新
  - §3.5 外部 AI 表現方針セクション全体を書き換え、aiCall + modelEndpoints の例 + TtsGenerate (拡張) の例の 2 系統に分けて説明 (Sonnet review Must-fix 1 で書き換え)

## 仕様逐条突合 (自己申告)

- spec §採用設計 step kinds (aiCall) → diary 4 flow 移行で実装 (f7a8b9c0/a9b0c1d2/b0c1d2e3/c1d2e3f4) ✓
- spec §使用例 1 (シンプル要約 text) → `f7a8b9c0-d1e2-4f3a-8b4c-5d6e7f8a9b0c.json:124-156` ✓
- spec §使用例 2 (structured output タグ提案) → `a9b0c1d2-e3f4-4a5b-8c6d-7e8f9a0b1c2d.json:131-198` ✓
- spec §使用例 3 (vision input) → `b0c1d2e3-f4a5-4b6c-8d7e-8f9a0b1c2d3e.json:215-258` ✓
- spec §catalog modelEndpoints (provider/model/auth/defaults) → diary 4 flow + english-learning(+tailwind) で実装 ✓
- spec §AiMessage.content (string + content blocks) → 全 5 flow (diary 4 + english-learning 1) で role 別に並び ✓
- spec §AiResponseFormat.structuredObject (schema 必須) → a9b0c1d2 / c1d2e3f4 で JSON Schema 準拠で定義 ✓
- spec §AiImageSource fileRef → b0c1d2e3 で `kind:fileRef, ref:@targetImageUrl` ✓
- spec §「tool が無い単発呼び出しは aiCall を使う」原則 → english-learning LlmDialog (tools 無し) を aiCall に移行 (aiAgent ではなく) ✓
- spec §既存表現からの移行 Phase 2-A 全項目 → 本 PR で完遂 (claudeApi 削除 / LlmDialog 削除 / extensionCategories.ai 削除 / docs 更新) ✓
- spec §ドメイン固有 AI 機能 (TTS/STT は当面 namespace 拡張) → english-learning の TtsGenerate / SttEvaluate を維持 ✓
- spec §`outputBinding` の値構造 (本 PR で追加した規約) → 全 5 flow で `@<binding>.text` (text) / `@<binding>.object.<field>` (structuredObject) 参照に統一 ✓

## レビューで特に見てほしい箇所

1. **LlmDialog → aiCall の判断**: 元指示 ("aiAgent (multi-turn) に移行") と異なるが、schema 上 aiAgent は `tools` minItems=1 必須で LlmDialog (tools 無し) を直接変換不可。spec mandate「tool が無い単発呼び出しは aiCall を使う」に従った。「multi-turn」は messages[] に会話履歴を並べることで表現する設計判断
2. **c1d2e3f4 (proofread) の structuredObject 化**: 元指示 "text" だが、出力が `{corrected, changes[]}` 構造のため structuredObject が spec-correct。JSON.parse step を削除 (ランタイム parse 済みのため)
3. **english-learning-tailwind の同 PR 吸収**: english-learning と同じ業務スコープ + データモデル + ProcessFlow を持つミラー sample のため、`feedback_pr_scope_absorb_pre_existing.md` / `feedback_consolidate_related_proposals_into_one_issue.md` に従い同 PR で同期移行
4. **`@aiResponse.text` / `@aiResponse.object.<field>` への参照**: aiCall 出力の正規化形式は schema が明示しないため、業界共通パターンを採用。**Sonnet review Should-fix 1 を受けて spec 側にも明文化** (`docs/spec/process-flow-ai-step-kind.md` §`outputBinding` の値構造)
5. **修正後 file:line 自己申告**: 上記「仕様逐条突合」は commit 後の最新行番号で再計算済み

## Sonnet 独立レビュー対応 (2026-05-08)

[初回レビュー](https://github.com/csilost2001/harmony/pull/937#issuecomment-4399286868) で検出:

- **Must-fix 1 解消**: `docs/spec/examples-english-learning.md` §3.5 の旧 LlmDialog コード例を aiCall + TtsGenerate の 2 系統例に書き換え (commit 4fc7863)
- **Should-fix 1 解消**: `docs/spec/process-flow-ai-step-kind.md` に `outputBinding` 値構造規約セクションを追加 (commit 4fc7863)
- **Should-fix 2 解消**: `a9b0c1d2` のフィルタ閾値を `@conv.limit.tagSuggestThreshold` 参照に変更 (commit 4fc7863)
- **Nit 1 (anthropicApiKey secrets 重複、4 flow)**: 現 schema では同一 secret を flow ごとに宣言する必要があり、project レベル共有 secret 機構が無い。schema 改変は権限外のため、本 PR では現 schema 制約として残置。将来の core schema 拡張候補 (project 共通 secrets / shared catalog 機構)
- **Nit 2 (b0c1d2e3 で fileRef を URL 文字列に使用)**: schema の `AiImageSource.url` variant は `format:uri` 制約 + リテラル URI 必須 (`type: string, format: uri`) のため、ランタイム変数 (`@targetImageUrl`) を渡す経路は `fileRef` のみ。`url` variant への ExpressionString 対応は spec / schema の今後の拡張候補

## テスト

- Vitest: 1811 件全 pass (新規追加なし、既存 ai-step-kind.schema.test.ts 12 件 + samples-v3.schema.test.ts 163 件含む)
- validate:samples: diary 17/17 / english-learning 5/5 / english-learning-tailwind 5/5 / retail 6/6 全 pass、realestate は既存 warning 維持 (本 PR と無関係)
- Playwright: 該当なし (UI 変更なし)
- MCP E2E: 該当なし

## UI 影響 / AI smoke test

- [x] UI 影響なし (auto テスト pass のみ)

業務リソースの schema 内容更新のみで、frontend / backend のコード・UI コンポーネントは未変更。既存 ProcessFlow viewer は core stepKind を扱える (PR #936 で対応済み)。

## spec 側の不足点 / 提案

### 既知の制約 (Phase 2-A 範囲外、将来の core schema 拡張候補)

- `aiCall.messages[]` は静的配列のため、prior turns の動的 spread が出来ない。english-learning の multi-turn 会話は user content に `@turnContext` (DialogTurn[] JSON 文字列) を埋め込む暫定形で対応中。messages 内 dynamic items / spread placeholder は core schema 拡張候補
- `AiImageSource.url` variant は literal URI 必須 (`format:uri`) で、ランタイム変数を渡せない。ExpressionString 対応は spec / schema の拡張候補 (現状は fileRef を semantic に拡大解釈して回避)
- secrets catalog の project レベル共有機構が無い (1 sample 内で同 secret を flow ごとに宣言)。schema 拡張候補

これらは schema 改変権限外のため本 PR では対応せず、設計者承認待ちで起票検討対象。

### Phase 2-B / 2-C 残作業

- Phase 2-B: `/generate-tests` skill の AI flow 検出ロジックを `kind=aiCall|aiAgent` 対応に拡張 (別 PR)
- Phase 2-C: `/generate-code` skill テンプレートに aiCall/aiAgent SDK 切替コード生成を実装 (別 PR)

## レビュー担当への申し送り

- schema governance に従い `schemas/` は一切変更していない (`git diff origin/main..HEAD -- schemas/` は空)。PR #936 の core schema を sample 側で消費するのみ
- `git diff` 16 ファイル + 修正 commit 3 ファイルすべて `examples/` または `docs/` 配下、業務リソース or 仕様文書の更新
- english-learning-tailwind の同期移行は同根の取り残し回避が目的 (ミラー sample のため同 PR で扱う必然性あり)
- Phase 2-B/2-C は別セッション担当のため本 PR では触れない
- 初回 Sonnet review の Must-fix 1 + Should-fix 2 は commit 4fc7863 で解消済み、Nit 2 件は schema 制約による現状やむを得ず (PR description に記録)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
