### PR TITLE
fix(framework): aiCall/aiAgent.modelRef の referential validator 追加 (#941)

### DIFF
--- a/frontend/src/schemas/referentialIntegrity.test.ts
+++ b/frontend/src/schemas/referentialIntegrity.test.ts
@@ -264,6 +264,141 @@ describe("checkReferentialIntegrity — typeRef (#261)", () => {
   });
 });
 
+describe("checkReferentialIntegrity — modelRef (#941)", () => {
+  it("flow level modelEndpoints に存在する modelRef は OK", () => {
+    const issues = checkReferentialIntegrity(makeGroup({
+      context: { catalogs: { modelEndpoints: {
+        summarizeModel: { provider: "anthropic", model: "claude-haiku-4-5" },
+      } } },
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [
+          { id: "s1", kind: "aiCall", description: "", modelRef: "summarizeModel", messages: [] },
+        ],
+      }],
+    } as never));
+    expect(issues).toHaveLength(0);
+  });
+
+  it("project level modelEndpoints (merged) に存在する modelRef も OK", () => {
+    const issues = checkReferentialIntegrity(
+      makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [
+            { id: "s1", kind: "aiCall", description: "", modelRef: "projectModel", messages: [] },
+          ],
+        }],
+      } as never),
+      undefined,
+      { modelEndpoints: { projectModel: { provider: "openai", model: "gpt-4" } } },
+    );
+    expect(issues).toHaveLength(0);
+  });
+
+  it("flow level が project level を override (同名キー)", () => {
+    const issues = checkReferentialIntegrity(
+      makeGroup({
+        context: { catalogs: { modelEndpoints: {
+          shared: { provider: "anthropic", model: "claude-opus-4-7" },
+        } } },
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [
+            { id: "s1", kind: "aiCall", description: "", modelRef: "shared", messages: [] },
+          ],
+        }],
+      } as never),
+      undefined,
+      { modelEndpoints: { shared: { provider: "openai", model: "gpt-4" } } },
+    );
+    expect(issues).toHaveLength(0);
+  });
+
+  it("タイポした modelRef を UNKNOWN_MODEL_REF として検出", () => {
+    const issues = checkReferentialIntegrity(makeGroup({
+      context: { catalogs: { modelEndpoints: {
+        summarizeModel: { provider: "anthropic", model: "claude-haiku-4-5" },
+      } } },
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [
+          { id: "s1", kind: "aiCall", description: "", modelRef: "summarizModel", messages: [] },
+        ],
+      }],
+    } as never));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("UNKNOWN_MODEL_REF");
+    expect(issues[0].value).toBe("summarizModel");
+    expect(issues[0].path).toBe("actions[0].steps[0].modelRef");
+  });
+
+  it("modelEndpoints catalog が空でも aiCall がある場合は検出", () => {
+    const issues = checkReferentialIntegrity(makeGroup({
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [
+          { id: "s1", kind: "aiCall", description: "", modelRef: "anyModel", messages: [] },
+        ],
+      }],
+    } as never));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("UNKNOWN_MODEL_REF");
+  });
+
+  it("aiAgent.modelRef も検査対象", () => {
+    const issues = checkReferentialIntegrity(makeGroup({
+      context: { catalogs: { modelEndpoints: {
+        agentModel: { provider: "anthropic", model: "claude-opus-4-7" },
+      } } },
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [
+          {
+            id: "s1", kind: "aiAgent", description: "",
+            modelRef: "missingAgentModel",
+            messages: [], tools: [{ name: "search" }],
+          },
+        ],
+      }],
+    } as never));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("UNKNOWN_MODEL_REF");
+    expect(issues[0].value).toBe("missingAgentModel");
+  });
+
+  it("ネスト (loop.steps 内) の aiCall.modelRef も検査", () => {
+    const issues = checkReferentialIntegrity(makeGroup({
+      context: { catalogs: { modelEndpoints: { good: {} } } },
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "lp", kind: "loop", description: "", loopKind: "count",
+          steps: [
+            { id: "ai", kind: "aiCall", description: "", modelRef: "bad", messages: [] },
+          ],
+        }],
+      }],
+    } as never));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("UNKNOWN_MODEL_REF");
+    expect(issues[0].path).toBe("actions[0].steps[0].steps[0].modelRef");
+  });
+
+  it("aiCall/aiAgent 以外の step の modelRef 風プロパティは検査対象外", () => {
+    const issues = checkReferentialIntegrity(makeGroup({
+      context: { catalogs: { modelEndpoints: { real: {} } } },
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [
+          { id: "s1", kind: "compute", description: "", expression: "" },
+        ],
+      }],
+    } as never));
+    expect(issues).toHaveLength(0);
+  });
+});
+
 describe("checkReferentialIntegrity — systemRef (#261)", () => {
   it("externalSystemCatalog 定義時、未登録 systemRef を検出", () => {
     const issues = checkReferentialIntegrity(makeGroup({

--- a/frontend/src/schemas/referentialIntegrity.ts
+++ b/frontend/src/schemas/referentialIntegrity.ts
@@ -27,7 +27,8 @@ export interface IntegrityIssue {
     | "UNKNOWN_ERROR_CODE"
     | "UNKNOWN_SYSTEM_REF"
     | "UNKNOWN_TYPE_REF"
-    | "UNKNOWN_SECRET_REF";
+    | "UNKNOWN_SECRET_REF"
+    | "UNKNOWN_MODEL_REF";
   /** 参照しようとした値 */
   value: string;
   /** エラーメッセージ */
@@ -55,6 +56,7 @@ export function checkReferentialIntegrity(
   const hasExtensions = extensions !== undefined && typeIds.size > 0;
   const secretKeys = new Set(Object.keys(merged.secrets ?? {}));
   const hasSecretsCatalog = secretKeys.size > 0;
+  const modelEndpointKeys = new Set(Object.keys(merged.modelEndpoints ?? {}));
 
   // externalSystems (merged: project + flow level).*.auth.tokenRef 内の @secret.* 参照を検査
   if (hasSecretsCatalog) {
@@ -103,6 +105,7 @@ export function checkReferentialIntegrity(
     });
     walkSteps(action.steps ?? [], `actions[${ai}].steps`, (step, path) => {
       checkStep(step, path, responseIds, errorCodes, hasErrorCatalog, systemIds, hasSystemCatalog, issues, secretKeys, hasSecretsCatalog);
+      checkAiModelRef(step, path, modelEndpointKeys, issues);
     });
 
     // context.catalogs.errors -> responses 参照
@@ -260,4 +263,25 @@ function checkStep(
       }
     });
   }
+}
+
+// aiCall / aiAgent は v3 TypeScript Step union に未追加のため (stepGuards.ts の BUILTIN_STEP_KINDS を参照)、
+// kind 判定は string 比較で行い modelRef を構造的に取り出す。schema 上は AiCallStep / AiAgentStep の
+// 必須フィールドとして定義済み。
+function checkAiModelRef(
+  step: Step,
+  path: string,
+  modelEndpointKeys: Set<string>,
+  issues: IntegrityIssue[],
+): void {
+  const s = step as { kind: string; modelRef?: string };
+  if (s.kind !== "aiCall" && s.kind !== "aiAgent") return;
+  if (!s.modelRef) return;
+  if (modelEndpointKeys.has(s.modelRef)) return;
+  issues.push({
+    path: `${path}.modelRef`,
+    code: "UNKNOWN_MODEL_REF",
+    value: s.modelRef,
+    message: `aiCall/aiAgent.modelRef "${s.modelRef}" が modelEndpoints catalog (project + flow merged) に存在しません`,
+  });
 }


### PR DESCRIPTION
## Summary

- `checkReferentialIntegrity` に `aiCall.modelRef` / `aiAgent.modelRef` の merged catalogs (project + flow level) 存在確認を追加
- 新エラーコード `UNKNOWN_MODEL_REF` を `IntegrityIssue.code` 共用体に追加
- 派生元: PR #940 Sonnet 独立レビュー Should-fix 指摘 (2026-05-08)

## 設計判断

- aiCall/aiAgent は v3 TS Step union (BUILTIN_STEP_KINDS) 未追加のため、kind 判定は string 比較で行い modelRef を構造的に取り出す。schema 上は AiCallStep / AiAgentStep の必須フィールドとして既に定義済みなので runtime safety は確保
- 既存の secrets / errors / systemRef は「catalog 未定義時は検査スキップ (後方互換)」だが、modelRef は **catalog が空でも検査** する
  - aiCall/aiAgent は PR #936 で新規追加された step kind であり後方互換懸念がない
  - schema が modelRef を必須にしているため、catalog 不在の aiCall は明確に不正
- merge 順は `mergeCatalogsForFlow()` に委ね、flow level が project level を override する semantics を踏襲

## 変更ファイル

- `frontend/src/schemas/referentialIntegrity.ts` (+25 / -1)
  - `IntegrityIssue.code` に `UNKNOWN_MODEL_REF` 追加 (L31)
  - `modelEndpointKeys` Set 構築 (L58)
  - 各 action の walkSteps callback で `checkAiModelRef()` 呼び出し (L106)
  - 新 helper `checkAiModelRef()` 追加 (L266-285)
- `frontend/src/schemas/referentialIntegrity.test.ts` (+135 / -0)
  - 新 describe block `modelRef (#941)` に 8 ケース追加 (L267-401)

## Test plan

- [x] `npx vitest run src/schemas/referentialIntegrity.test.ts` (27/27 passed: 既存 19 + 新規 8)
- [x] `npm run test:unit` (1831/1831 passed, 112 files)
- [x] `npx tsc --noEmit` (no errors)
- [x] `npm run lint` (新規 lint error なし、148 件は pre-existing)
- [x] `validate:samples` 全 sample pass:
  - diary (17 flows)
  - english-learning (5)
  - english-learning-tailwind (5)
  - realestate (1, pre-existing warning のみ)
  - retail (6)

## テストカバレッジ

新規 8 ケース:
1. flow level modelEndpoints に存在する modelRef → OK
2. project level (merged) に存在する modelRef → OK
3. flow level が project level を override (同名キー) → OK
4. タイポした modelRef → UNKNOWN_MODEL_REF (path/value 検証)
5. modelEndpoints catalog 空でも aiCall ありなら検出
6. aiAgent.modelRef も同様に検出
7. ネスト (loop.steps 内) の aiCall.modelRef も検出 (path 検証)
8. aiCall/aiAgent 以外の step は検査対象外 (false-positive 確認)

Closes #941

🤖 Generated with [Claude Code](https://claude.com/claude-code)