### PR TITLE
improve(test-infra): e2e test fixture を v3 単一化 + builder pattern 導入 + helper v1 受容廃止 (#964)

### DIFF
--- a/frontend/e2e/__fixtures__/builders/actionBuilder.test.ts
+++ b/frontend/e2e/__fixtures__/builders/actionBuilder.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import Ajv2020, { type ValidateFunction } from "ajv/dist/2020";
+import addFormats from "ajv-formats";
+import { readFileSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { buildAction } from "./actionBuilder";
+import { buildProcessFlow } from "./processFlowBuilder";
+
+const repoRoot = resolve(__dirname, "../../../../");
+const v3Dir = resolve(repoRoot, "schemas/v3");
+
+function loadJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+let validateProcessFlow: ValidateFunction;
+
+beforeAll(() => {
+  const ajv = new Ajv2020({ allErrors: true, strict: false, discriminator: true });
+  addFormats(ajv);
+  ajv.addSchema(loadJson(join(v3Dir, "common.v3.schema.json")) as object);
+  validateProcessFlow = ajv.compile(loadJson(join(v3Dir, "process-flow.v3.schema.json")) as object);
+});
+
+describe("buildAction", () => {
+  it("returns a valid ActionDefinition with defaults", () => {
+    const action = buildAction();
+    expect(action.id).toBe("action-01");
+    expect(action.trigger).toBe("click");
+    expect(action.steps).toEqual([]);
+  });
+
+  it("validates within a ProcessFlow", () => {
+    const action = buildAction({ id: "action-01", name: "ボタンクリック", trigger: "click" });
+    const pf = buildProcessFlow({ actions: [action] });
+    const ok = validateProcessFlow(pf);
+    if (!ok) {
+      console.error(validateProcessFlow.errors);
+    }
+    expect(ok).toBe(true);
+  });
+
+  it("respects overrides", () => {
+    const action = buildAction({ id: "submit-01", name: "送信", trigger: "submit", maturity: "committed" });
+    expect(action.id).toBe("submit-01");
+    expect(action.name).toBe("送信");
+    expect(action.trigger).toBe("submit");
+    expect(action.maturity).toBe("committed");
+  });
+});

--- a/frontend/e2e/__fixtures__/builders/actionBuilder.ts
+++ b/frontend/e2e/__fixtures__/builders/actionBuilder.ts
@@ -1,0 +1,32 @@
+/**
+ * v3 ActionDefinition builder — e2e テスト用 fixture 生成。
+ *
+ * ActionDefinition は ProcessFlow.actions[] の要素。
+ * required: id (LocalId) / name / trigger / steps
+ */
+
+import type {
+  ActionDefinition,
+  ActionTrigger,
+  LocalId,
+  Maturity,
+  Step,
+} from "../../../src/types/v3";
+
+export interface BuildActionOpts {
+  id?: string;
+  name?: string;
+  trigger?: ActionTrigger;
+  maturity?: Maturity;
+  steps?: Step[];
+}
+
+export function buildAction(opts: BuildActionOpts = {}): ActionDefinition {
+  return {
+    id: (opts.id ?? "action-01") as unknown as LocalId,
+    name: opts.name ?? "テストアクション",
+    trigger: opts.trigger ?? "click",
+    maturity: opts.maturity ?? "draft",
+    steps: opts.steps ?? [],
+  };
+}

--- a/frontend/e2e/__fixtures__/builders/conventionsBuilder.test.ts
+++ b/frontend/e2e/__fixtures__/builders/conventionsBuilder.test.ts
@@ -42,4 +42,19 @@ describe("buildConventions", () => {
     expect(c.version).toBe("2.0.0");
     expect(c.msg?.required?.template).toBe("{label}は必須です。");
   });
+
+  it("individual field override is reflected in output (limit)", () => {
+    const c = buildConventions({
+      limit: {
+        maxNameLength: { value: 100, unit: "char", description: "名称最大文字数" },
+      },
+    });
+    const ok = validateConventions(c);
+    if (!ok) {
+      console.error(validateConventions.errors);
+    }
+    expect(ok).toBe(true);
+    expect(c.limit?.maxNameLength?.value).toBe(100);
+    expect(c.limit?.maxNameLength?.unit).toBe("char");
+  });
 });

--- a/frontend/e2e/__fixtures__/builders/conventionsBuilder.test.ts
+++ b/frontend/e2e/__fixtures__/builders/conventionsBuilder.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import Ajv2020, { type ValidateFunction } from "ajv/dist/2020";
+import addFormats from "ajv-formats";
+import { readFileSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { buildConventions } from "./conventionsBuilder";
+
+const repoRoot = resolve(__dirname, "../../../../");
+const v3Dir = resolve(repoRoot, "schemas/v3");
+
+function loadJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+let validateConventions: ValidateFunction;
+
+beforeAll(() => {
+  const ajv = new Ajv2020({ allErrors: true, strict: false, discriminator: true });
+  addFormats(ajv);
+  ajv.addSchema(loadJson(join(v3Dir, "common.v3.schema.json")) as object);
+  validateConventions = ajv.compile(loadJson(join(v3Dir, "conventions.v3.schema.json")) as object);
+});
+
+describe("buildConventions", () => {
+  it("returns a v3-valid Conventions with defaults", () => {
+    const c = buildConventions();
+    const ok = validateConventions(c);
+    if (!ok) {
+      console.error(validateConventions.errors);
+    }
+    expect(ok).toBe(true);
+    expect(c.version).toBe("1.0.0");
+  });
+
+  it("respects overrides", () => {
+    const c = buildConventions({
+      version: "2.0.0",
+      msg: {
+        required: { template: "{label}は必須です。" },
+      },
+    });
+    expect(c.version).toBe("2.0.0");
+    expect(c.msg?.required?.template).toBe("{label}は必須です。");
+  });
+});

--- a/frontend/e2e/__fixtures__/builders/conventionsBuilder.ts
+++ b/frontend/e2e/__fixtures__/builders/conventionsBuilder.ts
@@ -1,0 +1,33 @@
+/**
+ * v3 Conventions builder — e2e テスト用 fixture 生成。
+ *
+ * defaults:
+ * - version: "1.0.0" (SemVer required)
+ */
+
+import type {
+  Conventions,
+  SemVer,
+  Timestamp,
+} from "../../../src/types/v3";
+
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
+
+export interface BuildConventionsOpts {
+  version?: string;
+  msg?: Conventions["msg"];
+  regex?: Conventions["regex"];
+  numbering?: Conventions["numbering"];
+  [key: string]: unknown;
+}
+
+export function buildConventions(opts: BuildConventionsOpts = {}): Conventions {
+  return {
+    $schema: "../../schemas/v3/conventions.v3.schema.json",
+    version: (opts.version ?? "1.0.0") as unknown as SemVer,
+    updatedAt: FIXED_TS,
+    msg: opts.msg,
+    regex: opts.regex,
+    numbering: opts.numbering,
+  };
+}

--- a/frontend/e2e/__fixtures__/builders/conventionsBuilder.ts
+++ b/frontend/e2e/__fixtures__/builders/conventionsBuilder.ts
@@ -17,8 +17,18 @@ export interface BuildConventionsOpts {
   version?: string;
   msg?: Conventions["msg"];
   regex?: Conventions["regex"];
+  limit?: Conventions["limit"];
+  scope?: Conventions["scope"];
+  currency?: Conventions["currency"];
+  tax?: Conventions["tax"];
+  auth?: Conventions["auth"];
+  role?: Conventions["role"];
+  permission?: Conventions["permission"];
+  db?: Conventions["db"];
   numbering?: Conventions["numbering"];
-  [key: string]: unknown;
+  tx?: Conventions["tx"];
+  externalOutcomeDefaults?: Conventions["externalOutcomeDefaults"];
+  i18n?: Conventions["i18n"];
 }
 
 export function buildConventions(opts: BuildConventionsOpts = {}): Conventions {
@@ -28,6 +38,17 @@ export function buildConventions(opts: BuildConventionsOpts = {}): Conventions {
     updatedAt: FIXED_TS,
     msg: opts.msg,
     regex: opts.regex,
+    limit: opts.limit,
+    scope: opts.scope,
+    currency: opts.currency,
+    tax: opts.tax,
+    auth: opts.auth,
+    role: opts.role,
+    permission: opts.permission,
+    db: opts.db,
     numbering: opts.numbering,
+    tx: opts.tx,
+    externalOutcomeDefaults: opts.externalOutcomeDefaults,
+    i18n: opts.i18n,
   };
 }

--- a/frontend/e2e/__fixtures__/builders/customBlockBuilder.test.ts
+++ b/frontend/e2e/__fixtures__/builders/customBlockBuilder.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import Ajv2020, { type ValidateFunction } from "ajv/dist/2020";
+import addFormats from "ajv-formats";
+import { readFileSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { buildCustomBlock } from "./customBlockBuilder";
+
+const repoRoot = resolve(__dirname, "../../../../");
+const v3Dir = resolve(repoRoot, "schemas/v3");
+
+function loadJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+let validateCustomBlock: ValidateFunction;
+
+beforeAll(() => {
+  const ajv = new Ajv2020({ allErrors: true, strict: false, discriminator: true });
+  addFormats(ajv);
+  ajv.addSchema(loadJson(join(v3Dir, "common.v3.schema.json")) as object);
+  // custom-block.v3.schema.json の root は CustomBlock[] 配列。
+  // 単体オブジェクトを validate するために $defs/CustomBlock への $ref を持つラッパーを作る。
+  const cbSchemaId = "https://raw.githubusercontent.com/csilost2001/harmony/main/schemas/v3/custom-block.v3.schema.json";
+  ajv.addSchema(loadJson(join(v3Dir, "custom-block.v3.schema.json")) as object);
+  validateCustomBlock = ajv.compile({ $ref: `${cbSchemaId}#/$defs/CustomBlock` });
+});
+
+describe("buildCustomBlock", () => {
+  it("returns a v3-valid CustomBlock with defaults", () => {
+    const cb = buildCustomBlock();
+    const ok = validateCustomBlock(cb);
+    if (!ok) {
+      console.error(validateCustomBlock.errors);
+    }
+    expect(ok).toBe(true);
+    expect(cb.label).toBe("テストブロック");
+    expect(cb.shared).toBe(false);
+  });
+
+  it("respects overrides", () => {
+    const cb = buildCustomBlock({ label: "カスタムカード", category: "カード", shared: true });
+    expect(cb.label).toBe("カスタムカード");
+    expect(cb.category).toBe("カード");
+    expect(cb.shared).toBe(true);
+  });
+});

--- a/frontend/e2e/__fixtures__/builders/customBlockBuilder.ts
+++ b/frontend/e2e/__fixtures__/builders/customBlockBuilder.ts
@@ -1,0 +1,39 @@
+/**
+ * v3 CustomBlock builder — e2e テスト用 fixture 生成。
+ *
+ * CustomBlock は EntityMeta を持たない例外 (label ベースの GrapesJS 用構造)。
+ * required: id / label / category / content / shared / createdAt / updatedAt
+ */
+
+import type {
+  CustomBlock,
+  CustomBlockId,
+  Timestamp,
+} from "../../../src/types/v3";
+import { normalizeId } from "../../helpers/realWorkspace";
+
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
+
+export interface BuildCustomBlockOpts {
+  id?: string;
+  label?: string;
+  category?: string;
+  content?: string;
+  shared?: boolean;
+}
+
+export function buildCustomBlock(opts: BuildCustomBlockOpts = {}): CustomBlock {
+  const id = opts.id
+    ? (normalizeId(opts.id) as unknown as CustomBlockId)
+    : (crypto.randomUUID() as unknown as CustomBlockId);
+
+  return {
+    id,
+    label: opts.label ?? "テストブロック",
+    category: opts.category ?? "テスト",
+    content: opts.content ?? "<div>テストコンテンツ</div>",
+    shared: opts.shared ?? false,
+    createdAt: FIXED_TS,
+    updatedAt: FIXED_TS,
+  };
+}

--- a/frontend/e2e/__fixtures__/builders/index.ts
+++ b/frontend/e2e/__fixtures__/builders/index.ts
@@ -1,0 +1,20 @@
+/**
+ * e2e テスト用 v3 typed builder — re-export entry point。
+ *
+ * 使用例:
+ * ```ts
+ * import { buildProject, buildProcessFlow, buildTable } from "../__fixtures__/builders";
+ * ```
+ */
+
+export { buildProject, type BuildProjectOpts } from "./projectBuilder";
+export { buildProcessFlow, type BuildProcessFlowOpts } from "./processFlowBuilder";
+export { buildAction, type BuildActionOpts } from "./actionBuilder";
+export { buildTable, type BuildTableOpts } from "./tableBuilder";
+export { buildView, type BuildViewOpts } from "./viewBuilder";
+export { buildViewDefinition, type BuildViewDefinitionOpts } from "./viewDefinitionBuilder";
+export { buildSequence, type BuildSequenceOpts } from "./sequenceBuilder";
+export { buildScreen, type BuildScreenOpts } from "./screenBuilder";
+export { buildScreenLayout, type BuildScreenLayoutOpts } from "./screenLayoutBuilder";
+export { buildCustomBlock, type BuildCustomBlockOpts } from "./customBlockBuilder";
+export { buildConventions, type BuildConventionsOpts } from "./conventionsBuilder";

--- a/frontend/e2e/__fixtures__/builders/processFlowBuilder.test.ts
+++ b/frontend/e2e/__fixtures__/builders/processFlowBuilder.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import Ajv2020, { type ValidateFunction } from "ajv/dist/2020";
+import addFormats from "ajv-formats";
+import { readFileSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { buildProcessFlow } from "./processFlowBuilder";
+
+const repoRoot = resolve(__dirname, "../../../../");
+const v3Dir = resolve(repoRoot, "schemas/v3");
+
+function loadJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+let validateProcessFlow: ValidateFunction;
+
+beforeAll(() => {
+  const ajv = new Ajv2020({ allErrors: true, strict: false, discriminator: true });
+  addFormats(ajv);
+  ajv.addSchema(loadJson(join(v3Dir, "common.v3.schema.json")) as object);
+  validateProcessFlow = ajv.compile(loadJson(join(v3Dir, "process-flow.v3.schema.json")) as object);
+});
+
+describe("buildProcessFlow", () => {
+  it("returns a v3-valid ProcessFlow with defaults", () => {
+    const pf = buildProcessFlow();
+    const ok = validateProcessFlow(pf);
+    if (!ok) {
+      console.error(validateProcessFlow.errors);
+    }
+    expect(ok).toBe(true);
+    expect(pf.meta.kind).toBe("other");
+    expect(pf.meta.maturity).toBe("draft");
+    expect(pf.actions).toEqual([]);
+  });
+
+  it("respects overrides", () => {
+    const pf = buildProcessFlow({ name: "注文処理", kind: "screen", mode: "upstream" });
+    expect(pf.meta.name).toBe("注文処理");
+    expect(pf.meta.kind).toBe("screen");
+    expect(pf.meta.mode).toBe("upstream");
+  });
+});

--- a/frontend/e2e/__fixtures__/builders/processFlowBuilder.test.ts
+++ b/frontend/e2e/__fixtures__/builders/processFlowBuilder.test.ts
@@ -40,4 +40,21 @@ describe("buildProcessFlow", () => {
     expect(pf.meta.kind).toBe("screen");
     expect(pf.meta.mode).toBe("upstream");
   });
+
+  it("authoring が指定されたら反映される", () => {
+    const pf = buildProcessFlow({
+      authoring: {
+        markers: [
+          {
+            id: "m1",
+            kind: "todo",
+            body: "x",
+            author: "human",
+            createdAt: "2026-04-20T00:00:00Z",
+          },
+        ],
+      },
+    });
+    expect(pf.authoring?.markers).toHaveLength(1);
+  });
 });

--- a/frontend/e2e/__fixtures__/builders/processFlowBuilder.ts
+++ b/frontend/e2e/__fixtures__/builders/processFlowBuilder.ts
@@ -1,0 +1,59 @@
+/**
+ * v3 ProcessFlow builder — e2e テスト用 fixture 生成。
+ *
+ * defaults:
+ * - createdAt/updatedAt: 固定値 "2026-05-08T00:00:00.000Z" (再現性)
+ * - maturity: "draft"
+ * - kind: "other"
+ * - actions: [] (空 ProcessFlow も schema valid)
+ */
+
+import type {
+  ActionDefinition,
+  Context,
+  Maturity,
+  Mode,
+  ProcessFlow,
+  ProcessFlowId,
+  ProcessFlowKind,
+  ScreenId,
+  Timestamp,
+} from "../../../src/types/v3";
+import { normalizeId } from "../../helpers/realWorkspace";
+
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
+
+export interface BuildProcessFlowOpts {
+  id?: string;
+  name?: string;
+  kind?: ProcessFlowKind;
+  screenId?: string;
+  maturity?: Maturity;
+  mode?: Mode;
+  actions?: ActionDefinition[];
+  context?: Context;
+}
+
+export function buildProcessFlow(opts: BuildProcessFlowOpts = {}): ProcessFlow {
+  const id = opts.id
+    ? (normalizeId(opts.id) as unknown as ProcessFlowId)
+    : (crypto.randomUUID() as unknown as ProcessFlowId);
+
+  return {
+    $schema: "../../schemas/v3/process-flow.v3.schema.json",
+    meta: {
+      id,
+      name: opts.name ?? "テスト処理フロー",
+      kind: opts.kind ?? "other",
+      maturity: opts.maturity ?? "draft",
+      mode: opts.mode,
+      screenId: opts.screenId
+        ? (normalizeId(opts.screenId) as unknown as ScreenId)
+        : undefined,
+      createdAt: FIXED_TS,
+      updatedAt: FIXED_TS,
+    },
+    context: opts.context,
+    actions: opts.actions ?? [],
+  };
+}

--- a/frontend/e2e/__fixtures__/builders/processFlowBuilder.ts
+++ b/frontend/e2e/__fixtures__/builders/processFlowBuilder.ts
@@ -10,6 +10,7 @@
 
 import type {
   ActionDefinition,
+  Authoring,
   Context,
   Maturity,
   Mode,
@@ -32,6 +33,8 @@ export interface BuildProcessFlowOpts {
   mode?: Mode;
   actions?: ActionDefinition[];
   context?: Context;
+  /** 設計プロセス用情報。default: undefined — 必要な spec のみ指定する。 */
+  authoring?: Authoring;
 }
 
 export function buildProcessFlow(opts: BuildProcessFlowOpts = {}): ProcessFlow {
@@ -55,5 +58,6 @@ export function buildProcessFlow(opts: BuildProcessFlowOpts = {}): ProcessFlow {
     },
     context: opts.context,
     actions: opts.actions ?? [],
+    ...(opts.authoring ? { authoring: opts.authoring } : {}),
   };
 }

--- a/frontend/e2e/__fixtures__/builders/projectBuilder.test.ts
+++ b/frontend/e2e/__fixtures__/builders/projectBuilder.test.ts
@@ -18,7 +18,6 @@ beforeAll(() => {
   const ajv = new Ajv2020({ allErrors: true, strict: false, discriminator: true });
   addFormats(ajv);
   ajv.addSchema(loadJson(join(v3Dir, "common.v3.schema.json")) as object);
-  ajv.addSchema(loadJson(join(v3Dir, "screen-item.v3.schema.json")) as object);
   validateProject = ajv.compile(loadJson(join(v3Dir, "harmony.v3.schema.json")) as object);
 });
 

--- a/frontend/e2e/__fixtures__/builders/projectBuilder.test.ts
+++ b/frontend/e2e/__fixtures__/builders/projectBuilder.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import Ajv2020, { type ValidateFunction } from "ajv/dist/2020";
+import addFormats from "ajv-formats";
+import { readFileSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { buildProject } from "./projectBuilder";
+
+const repoRoot = resolve(__dirname, "../../../../");
+const v3Dir = resolve(repoRoot, "schemas/v3");
+
+function loadJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+let validateProject: ValidateFunction;
+
+beforeAll(() => {
+  const ajv = new Ajv2020({ allErrors: true, strict: false, discriminator: true });
+  addFormats(ajv);
+  ajv.addSchema(loadJson(join(v3Dir, "common.v3.schema.json")) as object);
+  ajv.addSchema(loadJson(join(v3Dir, "screen-item.v3.schema.json")) as object);
+  validateProject = ajv.compile(loadJson(join(v3Dir, "harmony.v3.schema.json")) as object);
+});
+
+describe("buildProject", () => {
+  it("returns a v3-valid Project with defaults", () => {
+    const p = buildProject();
+    const ok = validateProject(p);
+    if (!ok) {
+      console.error(validateProject.errors);
+    }
+    expect(ok).toBe(true);
+    expect(p.schemaVersion).toBe("v3");
+    expect(p.meta.maturity).toBe("draft");
+  });
+
+  it("respects overrides", () => {
+    const p = buildProject({ name: "MyApp", mode: "downstream" });
+    expect(p.meta.name).toBe("MyApp");
+    expect(p.meta.mode).toBe("downstream");
+  });
+
+  it("uses normalizeId for human-readable id", () => {
+    const p1 = buildProject({ id: "my-project" });
+    const p2 = buildProject({ id: "my-project" });
+    // 同じ入力 id からは常に同じ UUID が生成される (決定論的)
+    expect(p1.meta.id).toBe(p2.meta.id);
+    // UUID v4 形式になっている
+    expect(p1.meta.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+  });
+});

--- a/frontend/e2e/__fixtures__/builders/projectBuilder.ts
+++ b/frontend/e2e/__fixtures__/builders/projectBuilder.ts
@@ -1,0 +1,57 @@
+/**
+ * v3 Project builder — e2e テスト用 fixture 生成。
+ *
+ * defaults:
+ * - createdAt/updatedAt: 固定値 "2026-05-08T00:00:00.000Z" (再現性)
+ * - maturity: "draft"
+ * - schemaVersion: "v3"
+ */
+
+import type {
+  ExtensionApplied,
+  Maturity,
+  Mode,
+  Project,
+  ProjectEntities,
+  ProjectId,
+  ProjectTechStack,
+  Timestamp,
+  Uuid,
+} from "../../../src/types/v3";
+import { normalizeId } from "../../helpers/realWorkspace";
+
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
+
+export interface BuildProjectOpts {
+  id?: string;
+  name?: string;
+  dataDir?: string;
+  mode?: Mode;
+  maturity?: Maturity;
+  entities?: ProjectEntities;
+  techStack?: ProjectTechStack;
+  extensionsApplied?: ExtensionApplied[];
+}
+
+export function buildProject(opts: BuildProjectOpts = {}): Project {
+  const id = opts.id
+    ? (normalizeId(opts.id) as unknown as ProjectId)
+    : (crypto.randomUUID() as unknown as ProjectId);
+
+  return {
+    $schema: "../schemas/v3/harmony.v3.schema.json",
+    schemaVersion: "v3",
+    dataDir: opts.dataDir ?? "harmony",
+    meta: {
+      id: id as unknown as Uuid,
+      name: opts.name ?? "テストプロジェクト",
+      maturity: opts.maturity ?? "draft",
+      createdAt: FIXED_TS,
+      updatedAt: FIXED_TS,
+      mode: opts.mode,
+    },
+    extensionsApplied: opts.extensionsApplied ?? [],
+    entities: opts.entities ?? {},
+    techStack: opts.techStack,
+  };
+}

--- a/frontend/e2e/__fixtures__/builders/screenBuilder.test.ts
+++ b/frontend/e2e/__fixtures__/builders/screenBuilder.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import Ajv2020, { type ValidateFunction } from "ajv/dist/2020";
+import addFormats from "ajv-formats";
+import { readFileSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { buildScreen } from "./screenBuilder";
+
+const repoRoot = resolve(__dirname, "../../../../");
+const v3Dir = resolve(repoRoot, "schemas/v3");
+
+function loadJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+let validateScreen: ValidateFunction;
+
+beforeAll(() => {
+  const ajv = new Ajv2020({ allErrors: true, strict: false, discriminator: true });
+  addFormats(ajv);
+  ajv.addSchema(loadJson(join(v3Dir, "common.v3.schema.json")) as object);
+  ajv.addSchema(loadJson(join(v3Dir, "screen-item.v3.schema.json")) as object);
+  validateScreen = ajv.compile(loadJson(join(v3Dir, "screen.v3.schema.json")) as object);
+});
+
+describe("buildScreen", () => {
+  it("returns a v3-valid Screen with defaults", () => {
+    const s = buildScreen();
+    const ok = validateScreen(s);
+    if (!ok) {
+      console.error(validateScreen.errors);
+    }
+    expect(ok).toBe(true);
+    expect(s.kind).toBe("other");
+    expect(s.path).toBe("/test");
+    expect(s.maturity).toBe("draft");
+  });
+
+  it("respects overrides", () => {
+    const s = buildScreen({ name: "注文一覧", kind: "list", path: "/orders" });
+    expect(s.name).toBe("注文一覧");
+    expect(s.kind).toBe("list");
+    expect(s.path).toBe("/orders");
+  });
+});

--- a/frontend/e2e/__fixtures__/builders/screenBuilder.ts
+++ b/frontend/e2e/__fixtures__/builders/screenBuilder.ts
@@ -1,0 +1,53 @@
+/**
+ * v3 Screen builder — e2e テスト用 fixture 生成。
+ *
+ * defaults:
+ * - createdAt/updatedAt: 固定値 "2026-05-08T00:00:00.000Z" (再現性)
+ * - maturity: "draft"
+ * - kind: "other"
+ * - path: "/test"
+ */
+
+import type {
+  Maturity,
+  Screen,
+  ScreenGroupId,
+  ScreenId,
+  ScreenItem,
+  ScreenKind,
+  Timestamp,
+} from "../../../src/types/v3";
+import { normalizeId } from "../../helpers/realWorkspace";
+
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
+
+export interface BuildScreenOpts {
+  id?: string;
+  name?: string;
+  kind?: ScreenKind;
+  path?: string;
+  groupId?: string;
+  items?: ScreenItem[];
+  maturity?: Maturity;
+}
+
+export function buildScreen(opts: BuildScreenOpts = {}): Screen {
+  const id = opts.id
+    ? (normalizeId(opts.id) as unknown as ScreenId)
+    : (crypto.randomUUID() as unknown as ScreenId);
+
+  return {
+    $schema: "../../schemas/v3/screen.v3.schema.json",
+    id,
+    name: opts.name ?? "テスト画面",
+    kind: opts.kind ?? "other",
+    path: opts.path ?? "/test",
+    groupId: opts.groupId
+      ? (normalizeId(opts.groupId) as unknown as ScreenGroupId)
+      : undefined,
+    items: opts.items,
+    maturity: opts.maturity ?? "draft",
+    createdAt: FIXED_TS,
+    updatedAt: FIXED_TS,
+  };
+}

--- a/frontend/e2e/__fixtures__/builders/screenLayoutBuilder.test.ts
+++ b/frontend/e2e/__fixtures__/builders/screenLayoutBuilder.test.ts
@@ -36,7 +36,7 @@ describe("buildScreenLayout", () => {
   it("respects overrides", () => {
     const nodeId = "cccccccc-0000-4000-8000-000000000001";
     const sl = buildScreenLayout({
-      nodes: { [nodeId]: { x: 100, y: 200 } },
+      positions: { [nodeId]: { x: 100, y: 200 } },
     });
     expect(sl.positions[nodeId]).toEqual({ x: 100, y: 200 });
   });

--- a/frontend/e2e/__fixtures__/builders/screenLayoutBuilder.test.ts
+++ b/frontend/e2e/__fixtures__/builders/screenLayoutBuilder.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import Ajv2020, { type ValidateFunction } from "ajv/dist/2020";
+import addFormats from "ajv-formats";
+import { readFileSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { buildScreenLayout } from "./screenLayoutBuilder";
+
+const repoRoot = resolve(__dirname, "../../../../");
+const v3Dir = resolve(repoRoot, "schemas/v3");
+
+function loadJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+let validateScreenLayout: ValidateFunction;
+
+beforeAll(() => {
+  const ajv = new Ajv2020({ allErrors: true, strict: false, discriminator: true });
+  addFormats(ajv);
+  ajv.addSchema(loadJson(join(v3Dir, "common.v3.schema.json")) as object);
+  validateScreenLayout = ajv.compile(loadJson(join(v3Dir, "screen-layout.v3.schema.json")) as object);
+});
+
+describe("buildScreenLayout", () => {
+  it("returns a v3-valid ScreenLayout with defaults", () => {
+    const sl = buildScreenLayout();
+    const ok = validateScreenLayout(sl);
+    if (!ok) {
+      console.error(validateScreenLayout.errors);
+    }
+    expect(ok).toBe(true);
+    expect(sl.positions).toEqual({});
+    expect(sl.updatedAt).toBe("2026-05-08T00:00:00.000Z");
+  });
+
+  it("respects overrides", () => {
+    const nodeId = "cccccccc-0000-4000-8000-000000000001";
+    const sl = buildScreenLayout({
+      nodes: { [nodeId]: { x: 100, y: 200 } },
+    });
+    expect(sl.positions[nodeId]).toEqual({ x: 100, y: 200 });
+  });
+});

--- a/frontend/e2e/__fixtures__/builders/screenLayoutBuilder.ts
+++ b/frontend/e2e/__fixtures__/builders/screenLayoutBuilder.ts
@@ -1,0 +1,30 @@
+/**
+ * v3 ScreenLayout builder — e2e テスト用 fixture 生成。
+ *
+ * defaults:
+ * - positions: {} (空マップ、schema required だが値は空 object OK)
+ * - updatedAt: 固定値 "2026-05-08T00:00:00.000Z" (再現性)
+ */
+
+import type {
+  ScreenLayout,
+  Timestamp,
+  TransitionLayout,
+  Position,
+} from "../../../src/types/v3";
+
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
+
+export interface BuildScreenLayoutOpts {
+  nodes?: Record<string, Position>;
+  edges?: Record<string, TransitionLayout>;
+}
+
+export function buildScreenLayout(opts: BuildScreenLayoutOpts = {}): ScreenLayout {
+  return {
+    $schema: "../../schemas/v3/screen-layout.v3.schema.json",
+    positions: opts.nodes ?? {},
+    transitions: opts.edges,
+    updatedAt: FIXED_TS,
+  };
+}

--- a/frontend/e2e/__fixtures__/builders/screenLayoutBuilder.ts
+++ b/frontend/e2e/__fixtures__/builders/screenLayoutBuilder.ts
@@ -16,15 +16,15 @@ import type {
 const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 
 export interface BuildScreenLayoutOpts {
-  nodes?: Record<string, Position>;
-  edges?: Record<string, TransitionLayout>;
+  positions?: Record<string, Position>;
+  transitions?: Record<string, TransitionLayout>;
 }
 
 export function buildScreenLayout(opts: BuildScreenLayoutOpts = {}): ScreenLayout {
   return {
     $schema: "../../schemas/v3/screen-layout.v3.schema.json",
-    positions: opts.nodes ?? {},
-    transitions: opts.edges,
+    positions: opts.positions ?? {},
+    transitions: opts.transitions,
     updatedAt: FIXED_TS,
   };
 }

--- a/frontend/e2e/__fixtures__/builders/sequenceBuilder.test.ts
+++ b/frontend/e2e/__fixtures__/builders/sequenceBuilder.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import Ajv2020, { type ValidateFunction } from "ajv/dist/2020";
+import addFormats from "ajv-formats";
+import { readFileSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { buildSequence } from "./sequenceBuilder";
+
+const repoRoot = resolve(__dirname, "../../../../");
+const v3Dir = resolve(repoRoot, "schemas/v3");
+
+function loadJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+let validateSequence: ValidateFunction;
+
+beforeAll(() => {
+  const ajv = new Ajv2020({ allErrors: true, strict: false, discriminator: true });
+  addFormats(ajv);
+  ajv.addSchema(loadJson(join(v3Dir, "common.v3.schema.json")) as object);
+  validateSequence = ajv.compile(loadJson(join(v3Dir, "sequence.v3.schema.json")) as object);
+});
+
+describe("buildSequence", () => {
+  it("returns a v3-valid Sequence with defaults", () => {
+    const s = buildSequence();
+    const ok = validateSequence(s);
+    if (!ok) {
+      console.error(validateSequence.errors);
+    }
+    expect(ok).toBe(true);
+    expect(s.physicalName).toBe("seq_test");
+  });
+
+  it("respects overrides", () => {
+    const s = buildSequence({ name: "注文採番", physicalName: "seq_order_no", conventionRef: "@conv.numbering.orderNo" });
+    expect(s.name).toBe("注文採番");
+    expect(s.physicalName).toBe("seq_order_no");
+    expect(s.conventionRef).toBe("@conv.numbering.orderNo");
+  });
+});

--- a/frontend/e2e/__fixtures__/builders/sequenceBuilder.ts
+++ b/frontend/e2e/__fixtures__/builders/sequenceBuilder.ts
@@ -1,0 +1,40 @@
+/**
+ * v3 Sequence builder — e2e テスト用 fixture 生成。
+ *
+ * defaults:
+ * - createdAt/updatedAt: 固定値 "2026-05-08T00:00:00.000Z" (再現性)
+ * - physicalName: "seq_test"
+ */
+
+import type {
+  PhysicalName,
+  Sequence,
+  SequenceId,
+  Timestamp,
+} from "../../../src/types/v3";
+import { normalizeId } from "../../helpers/realWorkspace";
+
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
+
+export interface BuildSequenceOpts {
+  id?: string;
+  name?: string;
+  physicalName?: string;
+  conventionRef?: string;
+}
+
+export function buildSequence(opts: BuildSequenceOpts = {}): Sequence {
+  const id = opts.id
+    ? (normalizeId(opts.id) as unknown as SequenceId)
+    : (crypto.randomUUID() as unknown as SequenceId);
+
+  return {
+    $schema: "../../schemas/v3/sequence.v3.schema.json",
+    id,
+    name: opts.name ?? "テストシーケンス",
+    physicalName: (opts.physicalName ?? "seq_test") as unknown as PhysicalName,
+    conventionRef: opts.conventionRef,
+    createdAt: FIXED_TS,
+    updatedAt: FIXED_TS,
+  };
+}

--- a/frontend/e2e/__fixtures__/builders/tableBuilder.test.ts
+++ b/frontend/e2e/__fixtures__/builders/tableBuilder.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import Ajv2020, { type ValidateFunction } from "ajv/dist/2020";
+import addFormats from "ajv-formats";
+import { readFileSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { buildTable } from "./tableBuilder";
+
+const repoRoot = resolve(__dirname, "../../../../");
+const v3Dir = resolve(repoRoot, "schemas/v3");
+
+function loadJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+let validateTable: ValidateFunction;
+
+beforeAll(() => {
+  const ajv = new Ajv2020({ allErrors: true, strict: false, discriminator: true });
+  addFormats(ajv);
+  ajv.addSchema(loadJson(join(v3Dir, "common.v3.schema.json")) as object);
+  validateTable = ajv.compile(loadJson(join(v3Dir, "table.v3.schema.json")) as object);
+});
+
+describe("buildTable", () => {
+  it("returns a v3-valid Table with defaults", () => {
+    const t = buildTable();
+    const ok = validateTable(t);
+    if (!ok) {
+      console.error(validateTable.errors);
+    }
+    expect(ok).toBe(true);
+    expect(t.physicalName).toBe("test_table");
+    expect(t.columns.length).toBeGreaterThanOrEqual(1);
+    expect(t.maturity).toBe("draft");
+  });
+
+  it("respects overrides", () => {
+    const t = buildTable({ name: "ユーザー", physicalName: "users", category: "マスタ" });
+    expect(t.name).toBe("ユーザー");
+    expect(t.physicalName).toBe("users");
+    expect(t.category).toBe("マスタ");
+  });
+});

--- a/frontend/e2e/__fixtures__/builders/tableBuilder.ts
+++ b/frontend/e2e/__fixtures__/builders/tableBuilder.ts
@@ -1,0 +1,64 @@
+/**
+ * v3 Table builder — e2e テスト用 fixture 生成。
+ *
+ * defaults:
+ * - createdAt/updatedAt: 固定値 "2026-05-08T00:00:00.000Z" (再現性)
+ * - maturity: "draft"
+ * - physicalName: "test_table"
+ * - columns: 最低 1 件 (schema required)
+ */
+
+import type {
+  Column,
+  Index,
+  LocalId,
+  Maturity,
+  PhysicalName,
+  Table,
+  TableId,
+  Timestamp,
+} from "../../../src/types/v3";
+import { normalizeId } from "../../helpers/realWorkspace";
+
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
+
+export interface BuildTableOpts {
+  id?: string;
+  name?: string;
+  physicalName?: string;
+  category?: string;
+  maturity?: Maturity;
+  columns?: Column[];
+  indexes?: Index[];
+}
+
+function defaultColumn(): Column {
+  return {
+    id: "col-01" as unknown as LocalId,
+    physicalName: "id" as unknown as PhysicalName,
+    name: "ID",
+    dataType: "BIGINT",
+    notNull: true,
+    primaryKey: true,
+    autoIncrement: true,
+  };
+}
+
+export function buildTable(opts: BuildTableOpts = {}): Table {
+  const id = opts.id
+    ? (normalizeId(opts.id) as unknown as TableId)
+    : (crypto.randomUUID() as unknown as TableId);
+
+  return {
+    $schema: "../../schemas/v3/table.v3.schema.json",
+    id,
+    name: opts.name ?? "テストテーブル",
+    physicalName: (opts.physicalName ?? "test_table") as unknown as PhysicalName,
+    category: opts.category,
+    maturity: opts.maturity ?? "draft",
+    columns: opts.columns ?? [defaultColumn()],
+    indexes: opts.indexes,
+    createdAt: FIXED_TS,
+    updatedAt: FIXED_TS,
+  };
+}

--- a/frontend/e2e/__fixtures__/builders/viewBuilder.test.ts
+++ b/frontend/e2e/__fixtures__/builders/viewBuilder.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import Ajv2020, { type ValidateFunction } from "ajv/dist/2020";
+import addFormats from "ajv-formats";
+import { readFileSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { buildView } from "./viewBuilder";
+
+const repoRoot = resolve(__dirname, "../../../../");
+const v3Dir = resolve(repoRoot, "schemas/v3");
+
+function loadJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+let validateView: ValidateFunction;
+
+beforeAll(() => {
+  const ajv = new Ajv2020({ allErrors: true, strict: false, discriminator: true });
+  addFormats(ajv);
+  ajv.addSchema(loadJson(join(v3Dir, "common.v3.schema.json")) as object);
+  // view.v3 は OutputColumn.dataType に table.v3.schema.json#/$defs/DataType を参照するため追加
+  ajv.addSchema(loadJson(join(v3Dir, "table.v3.schema.json")) as object);
+  validateView = ajv.compile(loadJson(join(v3Dir, "view.v3.schema.json")) as object);
+});
+
+describe("buildView", () => {
+  it("returns a v3-valid View with defaults", () => {
+    const v = buildView();
+    const ok = validateView(v);
+    if (!ok) {
+      console.error(validateView.errors);
+    }
+    expect(ok).toBe(true);
+    expect(v.physicalName).toBe("test_view");
+    expect(v.outputColumns.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("respects overrides", () => {
+    const v = buildView({ name: "受注一覧ビュー", physicalName: "v_orders", selectStatement: "SELECT id, name FROM orders" });
+    expect(v.name).toBe("受注一覧ビュー");
+    expect(v.physicalName).toBe("v_orders");
+    expect(v.selectStatement).toBe("SELECT id, name FROM orders");
+  });
+});

--- a/frontend/e2e/__fixtures__/builders/viewBuilder.ts
+++ b/frontend/e2e/__fixtures__/builders/viewBuilder.ts
@@ -1,0 +1,53 @@
+/**
+ * v3 View builder — e2e テスト用 fixture 生成。
+ *
+ * defaults:
+ * - createdAt/updatedAt: 固定値 "2026-05-08T00:00:00.000Z" (再現性)
+ * - physicalName: "test_view"
+ * - selectStatement: "SELECT id FROM test_table"
+ * - outputColumns: 最低 1 件 (schema minItems: 1)
+ */
+
+import type {
+  OutputColumn,
+  PhysicalName,
+  Timestamp,
+  View,
+  ViewId,
+} from "../../../src/types/v3";
+import { normalizeId } from "../../helpers/realWorkspace";
+
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
+
+export interface BuildViewOpts {
+  id?: string;
+  name?: string;
+  physicalName?: string;
+  selectStatement?: string;
+  outputColumns?: OutputColumn[];
+}
+
+function defaultOutputColumn(): OutputColumn {
+  return {
+    physicalName: "id" as unknown as PhysicalName,
+    name: "ID",
+    dataType: "BIGINT",
+  };
+}
+
+export function buildView(opts: BuildViewOpts = {}): View {
+  const id = opts.id
+    ? (normalizeId(opts.id) as unknown as ViewId)
+    : (crypto.randomUUID() as unknown as ViewId);
+
+  return {
+    $schema: "../../schemas/v3/view.v3.schema.json",
+    id,
+    name: opts.name ?? "テストビュー",
+    physicalName: (opts.physicalName ?? "test_view") as unknown as PhysicalName,
+    selectStatement: opts.selectStatement ?? "SELECT id FROM test_table",
+    outputColumns: opts.outputColumns ?? [defaultOutputColumn()],
+    createdAt: FIXED_TS,
+    updatedAt: FIXED_TS,
+  };
+}

--- a/frontend/e2e/__fixtures__/builders/viewDefinitionBuilder.test.ts
+++ b/frontend/e2e/__fixtures__/builders/viewDefinitionBuilder.test.ts
@@ -38,4 +38,24 @@ describe("buildViewDefinition", () => {
     expect(vd.name).toBe("受注カンバン");
     expect(vd.kind).toBe("kanban");
   });
+
+  it("Level 2 (query) — AJV pass and sourceTableId absent", () => {
+    const tableId = "cccccccc-0001-4000-8000-000000000001";
+    const vd = buildViewDefinition({
+      query: {
+        from: {
+          tableId: tableId as unknown as import("../../../src/types/v3").TableId,
+          alias: "t",
+        },
+      },
+    });
+    const ok = validateViewDefinition(vd);
+    if (!ok) {
+      console.error(validateViewDefinition.errors);
+    }
+    expect(ok).toBe(true);
+    // query 形式では sourceTableId が存在しないこと
+    expect((vd as { sourceTableId?: unknown }).sourceTableId).toBeUndefined();
+    expect((vd as { query?: unknown }).query).toBeDefined();
+  });
 });

--- a/frontend/e2e/__fixtures__/builders/viewDefinitionBuilder.test.ts
+++ b/frontend/e2e/__fixtures__/builders/viewDefinitionBuilder.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import Ajv2020, { type ValidateFunction } from "ajv/dist/2020";
+import addFormats from "ajv-formats";
+import { readFileSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { buildViewDefinition } from "./viewDefinitionBuilder";
+
+const repoRoot = resolve(__dirname, "../../../../");
+const v3Dir = resolve(repoRoot, "schemas/v3");
+
+function loadJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+let validateViewDefinition: ValidateFunction;
+
+beforeAll(() => {
+  const ajv = new Ajv2020({ allErrors: true, strict: false, discriminator: true });
+  addFormats(ajv);
+  ajv.addSchema(loadJson(join(v3Dir, "common.v3.schema.json")) as object);
+  validateViewDefinition = ajv.compile(loadJson(join(v3Dir, "view-definition.v3.schema.json")) as object);
+});
+
+describe("buildViewDefinition", () => {
+  it("returns a v3-valid ViewDefinition with defaults", () => {
+    const vd = buildViewDefinition();
+    const ok = validateViewDefinition(vd);
+    if (!ok) {
+      console.error(validateViewDefinition.errors);
+    }
+    expect(ok).toBe(true);
+    expect(vd.kind).toBe("list");
+    expect(vd.columns.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("respects overrides", () => {
+    const vd = buildViewDefinition({ name: "受注カンバン", kind: "kanban" });
+    expect(vd.name).toBe("受注カンバン");
+    expect(vd.kind).toBe("kanban");
+  });
+});

--- a/frontend/e2e/__fixtures__/builders/viewDefinitionBuilder.ts
+++ b/frontend/e2e/__fixtures__/builders/viewDefinitionBuilder.ts
@@ -1,0 +1,54 @@
+/**
+ * v3 ViewDefinition builder — e2e テスト用 fixture 生成。
+ *
+ * defaults:
+ * - createdAt/updatedAt: 固定値 "2026-05-08T00:00:00.000Z" (再現性)
+ * - kind: "list"
+ * - columns: 最低 1 件 (schema required + minItems: 1)
+ */
+
+import type {
+  Identifier,
+  Timestamp,
+  ViewColumn,
+  ViewDefinition,
+  ViewDefinitionId,
+  ViewDefinitionKind,
+} from "../../../src/types/v3";
+import { normalizeId } from "../../helpers/realWorkspace";
+
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
+
+export interface BuildViewDefinitionOpts {
+  id?: string;
+  name?: string;
+  kind?: ViewDefinitionKind;
+  sourceTableId?: string;
+  columns?: ViewColumn[];
+}
+
+function defaultViewColumn(): ViewColumn {
+  return {
+    name: "id" as unknown as Identifier,
+    type: "integer",
+  };
+}
+
+export function buildViewDefinition(opts: BuildViewDefinitionOpts = {}): ViewDefinition {
+  const id = opts.id
+    ? (normalizeId(opts.id) as unknown as ViewDefinitionId)
+    : (crypto.randomUUID() as unknown as ViewDefinitionId);
+
+  return {
+    $schema: "../../schemas/v3/view-definition.v3.schema.json",
+    id,
+    name: opts.name ?? "テスト一覧 viewer",
+    kind: opts.kind ?? "list",
+    sourceTableId: opts.sourceTableId
+      ? (normalizeId(opts.sourceTableId) as unknown as ViewDefinition["sourceTableId"])
+      : undefined,
+    columns: opts.columns ?? [defaultViewColumn()],
+    createdAt: FIXED_TS,
+    updatedAt: FIXED_TS,
+  };
+}

--- a/frontend/e2e/__fixtures__/builders/viewDefinitionBuilder.ts
+++ b/frontend/e2e/__fixtures__/builders/viewDefinitionBuilder.ts
@@ -9,11 +9,13 @@
 
 import type {
   Identifier,
+  TableId,
   Timestamp,
   ViewColumn,
   ViewDefinition,
   ViewDefinitionId,
   ViewDefinitionKind,
+  ViewQuery,
 } from "../../../src/types/v3";
 import { normalizeId } from "../../helpers/realWorkspace";
 
@@ -24,6 +26,8 @@ export interface BuildViewDefinitionOpts {
   name?: string;
   kind?: ViewDefinitionKind;
   sourceTableId?: string;
+  /** Level 2 (Structured) / Level 3 (Raw SQL) 形式。指定すると sourceTableId と排他になる。 */
+  query?: ViewQuery;
   columns?: ViewColumn[];
 }
 
@@ -39,14 +43,22 @@ export function buildViewDefinition(opts: BuildViewDefinitionOpts = {}): ViewDef
     ? (normalizeId(opts.id) as unknown as ViewDefinitionId)
     : (crypto.randomUUID() as unknown as ViewDefinitionId);
 
+  // schema の oneOf: sourceTableId か query のどちらか一方が必須 (排他)
+  // opts.query が指定された場合は Level 2/3 形式として query を使い sourceTableId は省略する
+  // opts.query が未指定の場合は Level 1 形式として sourceTableId を設定する (dummy UUID)
+  const hasQuery = opts.query !== undefined;
+  const sourceTableId = hasQuery
+    ? undefined
+    : opts.sourceTableId
+      ? (normalizeId(opts.sourceTableId) as unknown as ViewDefinition["sourceTableId"])
+      : (crypto.randomUUID() as unknown as TableId);
+
   return {
     $schema: "../../schemas/v3/view-definition.v3.schema.json",
     id,
     name: opts.name ?? "テスト一覧 viewer",
     kind: opts.kind ?? "list",
-    sourceTableId: opts.sourceTableId
-      ? (normalizeId(opts.sourceTableId) as unknown as ViewDefinition["sourceTableId"])
-      : undefined,
+    ...(hasQuery ? { query: opts.query } : { sourceTableId }),
     columns: opts.columns ?? [defaultViewColumn()],
     createdAt: FIXED_TS,
     updatedAt: FIXED_TS,

--- a/frontend/e2e/__validation__/dummy-fixture-schema.test.ts
+++ b/frontend/e2e/__validation__/dummy-fixture-schema.test.ts
@@ -51,7 +51,7 @@ const PATTERNS: Pattern[] = [
   },
 ];
 
-const SCAN_DIRS = ["", "edit-session", "helpers"];
+const SCAN_DIRS = ["", "edit-session", "helpers", "collab"];
 const SCAN_EXTENSIONS = [".spec.ts", ".ts"];
 const EXCLUDE_DIR_PREFIXES = ["__validation__", "__fixtures__"];
 

--- a/frontend/e2e/__validation__/dummy-fixture-schema.test.ts
+++ b/frontend/e2e/__validation__/dummy-fixture-schema.test.ts
@@ -1,0 +1,125 @@
+/**
+ * #964 δ — dummy fixture v1 残骸検出 (二重ガード)。
+ *
+ * builder pattern を使えば構造的に v1 違反は発生しないが、人手で literal を書き戻したり
+ * 新規 spec で誤って v1 形式を使うリスクへの保険として、spec / helper の TS files を
+ * 静的に grep する vitest test。
+ *
+ * 違反検出時:
+ *   1. builder 利用に書き換え (推奨)
+ *   2. やむを得ず literal を残すなら known-violations.ts に明示的に追加 (デフォルト空)
+ *
+ * 検出対象 patterns:
+ *   - `version: 1` — v1 dummyProject root marker (v3 では `schemaVersion: "v3"`)
+ *   - `step.type` — step の種別キー名違い (v3 では `step.kind`)
+ *   - `condition: "..."` — runIf 等の condition 短縮 (v3 では object)
+ *   - `as unknown as { id: string }` — v1→v3 cast helper (γ で全削除済)
+ */
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { resolve, join, relative } from "node:path";
+import { knownViolations } from "./known-violations";
+
+const e2eDir = resolve(__dirname, "..");
+
+interface Pattern {
+  key: string;
+  regex: RegExp;
+  description: string;
+}
+
+const PATTERNS: Pattern[] = [
+  {
+    key: "v1-version-marker",
+    regex: /\bversion:\s*1\b/,
+    description: "v1 dummyProject root marker (use schemaVersion: 'v3')",
+  },
+  {
+    key: "v1-step-type-key",
+    regex: /\bstep\.type\b/,
+    description: "v1 step.type key (use step.kind)",
+  },
+  {
+    key: "v1-condition-short",
+    regex: /\bcondition:\s*"[^"\n]+"/,
+    description: "v1 condition string short form (use object form)",
+  },
+  {
+    key: "v1-cast-id-string",
+    regex: /as unknown as \{\s*id:\s*string\s*\}/,
+    description: "v1 to v3 cast helper (removed in γ phase)",
+  },
+];
+
+const SCAN_DIRS = ["", "edit-session", "helpers"];
+const SCAN_EXTENSIONS = [".spec.ts", ".ts"];
+const EXCLUDE_DIR_PREFIXES = ["__validation__", "__fixtures__"];
+
+function collectFiles(): string[] {
+  const out: string[] = [];
+  for (const dir of SCAN_DIRS) {
+    const full = dir ? join(e2eDir, dir) : e2eDir;
+    const stat = statSync(full, { throwIfNoEntry: false });
+    if (!stat?.isDirectory()) continue;
+    for (const f of readdirSync(full, { withFileTypes: true })) {
+      if (!f.isFile()) continue;
+      if (!SCAN_EXTENSIONS.some((ext) => f.name.endsWith(ext))) continue;
+      const fullPath = join(full, f.name);
+      const rel = relative(e2eDir, fullPath);
+      if (
+        EXCLUDE_DIR_PREFIXES.some(
+          (ex) => rel.startsWith(ex + "/") || rel.startsWith(ex),
+        )
+      )
+        continue;
+      out.push(fullPath);
+    }
+  }
+  return out;
+}
+
+describe("dummy fixture v1 残骸検出 (二重ガード)", () => {
+  const files = collectFiles();
+
+  for (const pattern of PATTERNS) {
+    it(`${pattern.key}: ${pattern.description}`, () => {
+      const violations: string[] = [];
+      for (const file of files) {
+        const content = readFileSync(file, "utf-8");
+        const lines = content.split("\n");
+        lines.forEach((line, idx) => {
+          if (pattern.regex.test(line)) {
+            violations.push(`${relative(e2eDir, file)}:${idx + 1}`);
+          }
+        });
+      }
+      const allowed = new Set(knownViolations[pattern.key] ?? []);
+      const unexpected = violations.filter((v) => !allowed.has(v));
+      expect(
+        unexpected,
+        `unexpected v1 fixture pattern detected (use builder pattern from __fixtures__/builders):\n  ${unexpected.join("\n  ")}`,
+      ).toEqual([]);
+    });
+  }
+
+  it("known-violations entries are still violations (no stale allowlist)", () => {
+    for (const [key, paths] of Object.entries(knownViolations)) {
+      const pattern = PATTERNS.find((p) => p.key === key);
+      if (!pattern) {
+        throw new Error(`known-violations key '${key}' is not in PATTERNS`);
+      }
+      for (const entry of paths) {
+        const colonIdx = entry.lastIndexOf(":");
+        const relPath = entry.slice(0, colonIdx);
+        const lineNum = Number(entry.slice(colonIdx + 1));
+        const fullPath = join(e2eDir, relPath);
+        const lines = readFileSync(fullPath, "utf-8").split("\n");
+        const targetLine = lines[lineNum - 1] ?? "";
+        expect(
+          pattern.regex.test(targetLine),
+          `stale known-violation: ${entry} no longer matches pattern ${key}`,
+        ).toBe(true);
+      }
+    }
+  });
+});

--- a/frontend/e2e/__validation__/known-violations.ts
+++ b/frontend/e2e/__validation__/known-violations.ts
@@ -1,0 +1,12 @@
+/**
+ * #964 δ — dummy fixture v1 残骸の例外許可リスト。
+ *
+ * 通常は空オブジェクト (`{}`)。新規違反検出時は即 red にして builder 化で解消する。
+ * やむを得ず literal を残す場合のみ本ファイルに追記し、ISSUE で設計者承認を得ること。
+ *
+ * 形式:
+ *   {
+ *     "<pattern key>": ["<relative spec path>:<line number>", ...],
+ *   }
+ */
+export const knownViolations: Record<string, string[]> = {};

--- a/frontend/e2e/action-list-marker-badge.spec.ts
+++ b/frontend/e2e/action-list-marker-badge.spec.ts
@@ -10,18 +10,25 @@ import {
   isMcpRunning,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
-const baseTs = "2026-05-08T00:00:00.000Z";
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
+
 const dummyGroups = [
-  { id: "ag-with-markers", name: "マーカー入り", kind: "screen", actionCount: 1, maturity: "draft" },
-  { id: "ag-clean", name: "マーカーなし", kind: "batch", actionCount: 1, maturity: "draft" },
+  { id: "ag-with-markers", no: 1, name: "マーカー入り", kind: "screen", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS },
+  { id: "ag-clean", no: 2, name: "マーカーなし", kind: "batch", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS },
 ];
 
-const fullGroupWithMarkers = {
+const baseFlowWithMarkers = buildProcessFlow({
   id: "ag-with-markers",
-  $schema: "../../../schemas/v3/process-flow.v3.schema.json",
-  meta: { id: "ag-with-markers", name: "マーカー入り", kind: "screen", mode: "upstream", maturity: "draft", version: "1.0.0", createdAt: baseTs, updatedAt: baseTs },
-  actions: [{ id: "act-1", name: "", trigger: "click", maturity: "draft", responses: [{id:"201-ok",status:201}], steps: [] }],
+  name: "マーカー入り",
+  kind: "screen",
+  mode: "upstream",
+  actions: [{ id: "act-1", name: "", trigger: "click", maturity: "draft", responses: [{ id: "201-ok", status: 201 }], steps: [] }] as ReturnType<typeof buildProcessFlow>["actions"],
+});
+const fullGroupWithMarkers = {
+  ...baseFlowWithMarkers,
   authoring: {
     markers: [
       { id: "m1", kind: "todo", body: "ここ直して", author: "human", createdAt: "2026-04-21T00:00:00.000Z" },
@@ -33,19 +40,20 @@ const fullGroupWithMarkers = {
   },
 };
 
-const fullGroupClean = {
+const fullGroupClean = buildProcessFlow({
   id: "ag-clean",
-  $schema: "../../../schemas/v3/process-flow.v3.schema.json",
-  meta: { id: "ag-clean", name: "マーカーなし", kind: "batch", mode: "upstream", maturity: "draft", version: "1.0.0", createdAt: baseTs, updatedAt: baseTs },
-  actions: [{ id: "act-2", name: "", trigger: "click", maturity: "draft", responses: [{id:"201-ok",status:201}], steps: [] }],
-  authoring: { markers: [] },
-};
+  name: "マーカーなし",
+  kind: "batch",
+  mode: "upstream",
+  actions: [{ id: "act-2", name: "", trigger: "click", maturity: "draft", responses: [{ id: "201-ok", status: 201 }], steps: [] }] as ReturnType<typeof buildProcessFlow>["actions"],
+});
 
-const dummyProject = {
-  version: 1, name: "marker badge test",
-  screens: [], groups: [], edges: [], tables: [],
-  processFlows: dummyGroups,
-};
+const dummyProject = buildProject({
+  name: "marker badge test",
+  entities: {
+    processFlows: dummyGroups,
+  } as ProjectEntities,
+});
 
 const WS_KEY = "issue-926-action-list-marker-badge";
 let mcpAvailable = false;

--- a/frontend/e2e/action-list.spec.ts
+++ b/frontend/e2e/action-list.spec.ts
@@ -11,36 +11,30 @@ import {
   isMcpRunning,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
+
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 
 // header (project.processFlows[]) 用 — actionCount / kind 等の表示用 meta を持つ
 // schema v3 EntryBase: id (Uuid), no, name, updatedAt 必須
-const __ts = "2026-05-08T00:00:00.000Z";
 const dummyGroups = [
-  { id: "11111111-1111-4111-8111-111111111111", no: 1, name: "ログイン処理", kind: "screen", actionCount: 3, screenId: "screen-1", updatedAt: __ts },
-  { id: "22222222-2222-4222-8222-222222222222", no: 2, name: "月次集計バッチ", kind: "batch", actionCount: 5, updatedAt: __ts },
-  { id: "33333333-3333-4333-8333-333333333333", no: 3, name: "共通バリデーション", kind: "common", actionCount: 2, updatedAt: __ts },
+  { id: "11111111-1111-4111-8111-111111111111", no: 1, name: "ログイン処理", kind: "screen", actionCount: 3, screenId: "screen-1", updatedAt: FIXED_TS },
+  { id: "22222222-2222-4222-8222-222222222222", no: 2, name: "月次集計バッチ", kind: "batch", actionCount: 5, updatedAt: FIXED_TS },
+  { id: "33333333-3333-4333-8333-333333333333", no: 3, name: "共通バリデーション", kind: "common", actionCount: 2, updatedAt: FIXED_TS },
 ];
 
 // body (process-flows/<id>.json) 用 — v3 ProcessFlow shape
-function makeProcessFlowBody(id: string, name: string, kind: string): Record<string, unknown> {
-  const ts = "2026-05-06T00:00:00.000Z";
-  return {
-    $schema: "../../../schemas/v3/process-flow.v3.schema.json",
-    meta: { id, name, kind, version: "1.0.0", maturity: "draft", mode: "upstream", createdAt: ts, updatedAt: ts },
-    actions: [],
-  };
-}
-const dummyGroupBodies = dummyGroups.map((g) => ({ ...makeProcessFlowBody(g.id, g.name, g.kind), id: g.id }));
+const dummyGroupBodies = dummyGroups.map((g) =>
+  buildProcessFlow({ id: g.id, name: g.name, kind: g.kind as Parameters<typeof buildProcessFlow>[0]["kind"], mode: "upstream" })
+);
 
-const dummyProject = {
-  version: 1,
+const dummyProject = buildProject({
   name: "E2Eテスト用プロジェクト",
-  screens: [],
-  groups: [],
-  edges: [],
-  tables: [],
-  processFlows: dummyGroups,
-};
+  entities: {
+    processFlows: dummyGroups,
+  } as ProjectEntities,
+});
 
 const WS_KEY = "issue-926-action-list";
 let mcpAvailable = false;

--- a/frontend/e2e/catalog-panels.spec.ts
+++ b/frontend/e2e/catalog-panels.spec.ts
@@ -11,20 +11,25 @@ import {
   normalizeId,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 const groupId = "ag-catalog-all";
-const baseTs = "2026-05-08T00:00:00.000Z";
-const dummyGroupBody = {
+
+const dummyGroupBody = buildProcessFlow({
   id: groupId,
-  $schema: "../../../schemas/v3/process-flow.v3.schema.json",
-  meta: { id: groupId, name: "all catalog UI", kind: "screen", mode: "upstream", maturity: "draft", version: "1.0.0", createdAt: baseTs, updatedAt: baseTs },
-  actions: [{ id: "act-1", name: "ボタン", trigger: "click", maturity: "draft", responses: [], steps: [] }],
-};
-const dummyProject = {
-  version: 1, name: "catalog-ui",
-  screens: [], groups: [], edges: [], tables: [],
-  processFlows: [{ id: groupId, no: 1, name: "all catalog UI", kind: "screen", actionCount: 1, maturity: "draft" }],
-};
+  name: "all catalog UI",
+  kind: "screen",
+  mode: "upstream",
+  actions: [{ id: "act-1", name: "ボタン", trigger: "click", maturity: "draft", responses: [], steps: [] }] as ReturnType<typeof buildProcessFlow>["actions"],
+});
+const dummyProject = buildProject({
+  name: "catalog-ui",
+  entities: {
+    processFlows: [{ id: groupId, no: 1, name: "all catalog UI", kind: "screen", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
+  } as ProjectEntities,
+});
 
 const WS_KEY = "issue-926-catalog-panels";
 let mcpAvailable = false;

--- a/frontend/e2e/conv-completion.spec.ts
+++ b/frontend/e2e/conv-completion.spec.ts
@@ -11,6 +11,10 @@ import {
   normalizeId,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
+
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 
 const sampleCatalog = {
   version: "1.0.0",
@@ -27,22 +31,24 @@ const sampleCatalog = {
 };
 
 const groupId = "ag-test-completion";
-const baseTs = "2026-05-08T00:00:00.000Z";
-const sampleGroupBody = {
+
+const sampleGroupBody = buildProcessFlow({
   id: groupId,
-  $schema: "../../../schemas/v3/process-flow.v3.schema.json",
-  meta: { id: groupId, name: "補完テスト", kind: "screen", mode: "upstream", maturity: "draft", version: "1.0.0", createdAt: baseTs, updatedAt: baseTs },
+  name: "補完テスト",
+  kind: "screen",
+  mode: "upstream",
   actions: [{
     id: "act-001", name: "テストアクション", trigger: "click",
     steps: [{ id: "step-001", type: "compute", description: "", expression: "", outputBinding: null }],
-  }],
-};
+  }] as ReturnType<typeof buildProcessFlow>["actions"],
+});
 
-const dummyProject = {
-  version: 1, name: "補完 E2E テスト",
-  screens: [], groups: [], edges: [], tables: [],
-  processFlows: [{ id: groupId, no: 1, name: "補完テスト", kind: "screen", actionCount: 1, maturity: "draft" }],
-};
+const dummyProject = buildProject({
+  name: "補完 E2E テスト",
+  entities: {
+    processFlows: [{ id: groupId, no: 1, name: "補完テスト", kind: "screen", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
+  } as ProjectEntities,
+});
 
 const WS_KEY = "issue-926-conv-completion";
 let mcpAvailable = false;

--- a/frontend/e2e/conventions-catalog-product.spec.ts
+++ b/frontend/e2e/conventions-catalog-product.spec.ts
@@ -10,11 +10,9 @@ import {
   isMcpRunning,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject } from "./__fixtures__/builders";
 
-const dummyProject = {
-  version: 1, name: "conventions-product",
-  screens: [], groups: [], edges: [], tables: [], processFlows: [],
-};
+const dummyProject = buildProject({ name: "conventions-product" });
 
 const WS_KEY = "issue-926-conventions-catalog-product";
 let mcpAvailable = false;

--- a/frontend/e2e/conventions-catalog-rbac.spec.ts
+++ b/frontend/e2e/conventions-catalog-rbac.spec.ts
@@ -10,11 +10,9 @@ import {
   isMcpRunning,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject } from "./__fixtures__/builders";
 
-const dummyProject = {
-  version: 1, name: "conventions-rbac",
-  screens: [], groups: [], edges: [], tables: [], processFlows: [],
-};
+const dummyProject = buildProject({ name: "conventions-rbac" });
 
 const WS_KEY = "issue-926-conventions-catalog-rbac";
 let mcpAvailable = false;

--- a/frontend/e2e/conventions-catalog.spec.ts
+++ b/frontend/e2e/conventions-catalog.spec.ts
@@ -10,11 +10,9 @@ import {
   isMcpRunning,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject } from "./__fixtures__/builders";
 
-const dummyProject = {
-  version: 1, name: "conventions-ui",
-  screens: [], groups: [], edges: [], tables: [], processFlows: [],
-};
+const dummyProject = buildProject({ name: "conventions-ui" });
 
 const WS_KEY = "issue-926-conventions-catalog";
 let mcpAvailable = false;

--- a/frontend/e2e/dashboard.spec.ts
+++ b/frontend/e2e/dashboard.spec.ts
@@ -13,33 +13,22 @@ import {
   normalizeId,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
 const SCREEN_ID = "aaaaaaaa-0001-4000-8000-000000000001";
 const TABLE_ID = "bbbbbbbb-0001-4000-8000-000000000001";
 const ACTION_ID = "cccccccc-0001-4000-8000-000000000001";
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 
-const dummyProject = {
-  version: 1,
+const dummyProject = buildProject({
   name: "E2Eダッシュボードテスト",
-  screens: [
-    {
-      id: SCREEN_ID,
-      no: 1,
-      name: "ログイン画面",
-      kind: "input",
-      path: "/login",
-      hasDesign: true,
-    },
-  ],
-  groups: [],
-  edges: [],
-  tables: [
-    { id: TABLE_ID, no: 1, physicalName: "users", name: "ユーザー", category: "マスタ", columnCount: 0 },
-  ],
-  processFlows: [
-    { id: ACTION_ID, no: 1, name: "ログイン処理", kind: "screen", actionCount: 0 },
-  ],
-};
+  entities: {
+    screens: [{ id: SCREEN_ID, no: 1, name: "ログイン画面", kind: "input", path: "/login", hasDesign: true, updatedAt: FIXED_TS }],
+    tables: [{ id: TABLE_ID, no: 1, physicalName: "users", name: "ユーザー", category: "マスタ", columnCount: 0, updatedAt: FIXED_TS }],
+    processFlows: [{ id: ACTION_ID, no: 1, name: "ログイン処理", kind: "screen", actionCount: 0, updatedAt: FIXED_TS }],
+  } as ProjectEntities,
+});
 
 const WS_KEY = "issue-926-dashboard";
 let mcpAvailable = false;

--- a/frontend/e2e/data-item-id-auto.spec.ts
+++ b/frontend/e2e/data-item-id-auto.spec.ts
@@ -11,15 +11,19 @@ import {
   normalizeId,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
 const SCREEN_ID = "aaaaaaaa-0001-4000-8000-aaaaaaaaaaaa";
 const SCREEN_NORM = normalizeId(SCREEN_ID);
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 
-const dummyProject = {
-  version: 1, name: "data-item-id-auto-test",
-  screens: [{ id: SCREEN_ID, no: 1, name: "テスト画面", kind: "form", path: "/test", hasDesign: true }],
-  groups: [], edges: [], tables: [], processFlows: [],
-};
+const dummyProject = buildProject({
+  name: "data-item-id-auto-test",
+  entities: {
+    screens: [{ id: SCREEN_ID, no: 1, name: "テスト画面", kind: "form", path: "/test", hasDesign: true, updatedAt: FIXED_TS }],
+  } as ProjectEntities,
+});
 
 const emptyScreen = {
   dataSources: [], assets: [], styles: [],

--- a/frontend/e2e/designer-corrupt-data.spec.ts
+++ b/frontend/e2e/designer-corrupt-data.spec.ts
@@ -13,18 +13,19 @@ import {
   normalizeId,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
 const SCREEN_ID = "bbbbbbbb-0001-4000-8000-bbbbbbbbbbbb";
 const SCREEN_NORM = normalizeId(SCREEN_ID);
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 
-const project = {
-  version: 1,
+const project = buildProject({
   name: "corrupt-data test",
-  screens: [
-    { id: SCREEN_ID, no: 1, name: "破損テスト画面", path: "/corrupt", kind: "form", hasDesign: true },
-  ],
-  groups: [], edges: [], tables: [],
-};
+  entities: {
+    screens: [{ id: SCREEN_ID, no: 1, name: "破損テスト画面", path: "/corrupt", kind: "form", hasDesign: true, updatedAt: FIXED_TS }],
+  } as ProjectEntities,
+});
 
 const dummyTab = {
   id: `design:${SCREEN_NORM}`,

--- a/frontend/e2e/designer-edit-session.spec.ts
+++ b/frontend/e2e/designer-edit-session.spec.ts
@@ -19,15 +19,19 @@ import {
   normalizeId,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
 const SCREEN_ID = `scr-e2e-edit-session-${Date.now()}`;
 const SCREEN_NORM = normalizeId(SCREEN_ID);
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 
-const dummyProject = {
-  version: 1, name: "edit-session-test",
-  screens: [{ id: SCREEN_ID, no: 1, name: "テスト画面", kind: "form", path: "/test", hasDesign: true }],
-  groups: [], edges: [], tables: [],
-};
+const dummyProject = buildProject({
+  name: "edit-session-test",
+  entities: {
+    screens: [{ id: SCREEN_ID, no: 1, name: "テスト画面", kind: "form", path: "/test", hasDesign: true, updatedAt: FIXED_TS }],
+  } as ProjectEntities,
+});
 
 const screenDesign = {
   assets: [], styles: [],

--- a/frontend/e2e/dirty-mark-resume.spec.ts
+++ b/frontend/e2e/dirty-mark-resume.spec.ts
@@ -15,37 +15,36 @@ import {
   normalizeId,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject, buildProcessFlow, buildTable } from "./__fixtures__/builders";
+import type { Column, LocalId, PhysicalName, ProjectEntities, Timestamp } from "../src/types/v3";
 
 const TABLE_ID = `tbl-e2e-dirty-mark-${Date.now()}`;
 const PF_ID = `pf-e2e-dirty-mark-${Date.now()}`;
-const baseTs = "2026-05-08T00:00:00.000Z";
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 
-const dummyTable = {
+const dummyTable = buildTable({
   id: TABLE_ID,
   physicalName: "dirty_mark_test",
   name: "dirty マークテスト",
-  description: "",
-  maturity: "draft",
   category: "マスタ",
-  columns: [{ id: "col-001", physicalName: "id", name: "ID", dataType: "INTEGER", notNull: true, primaryKey: true, unique: false, autoIncrement: true }],
-  indexes: [],
-  constraints: [],
-  version: "1.0.0",
-};
+  columns: [{ id: "col-001" as unknown as LocalId, physicalName: "id" as unknown as PhysicalName, name: "ID", dataType: "INTEGER", notNull: true, primaryKey: true, unique: false, autoIncrement: true }] as Column[],
+});
 
-const dummyProcessFlowBody = {
+const dummyProcessFlowBody = buildProcessFlow({
   id: PF_ID,
-  $schema: "../../../schemas/v3/process-flow.v3.schema.json",
-  meta: { id: PF_ID, name: "dirty マークテストフロー", kind: "screen", mode: "upstream", maturity: "draft", version: "1.0.0", createdAt: baseTs, updatedAt: baseTs },
-  actions: [{ id: "act-001", name: "テストアクション", trigger: "click", maturity: "draft", steps: [] }],
-};
+  name: "dirty マークテストフロー",
+  kind: "screen",
+  mode: "upstream",
+  actions: [{ id: "act-001", name: "テストアクション", trigger: "click", maturity: "draft", steps: [] }] as ReturnType<typeof buildProcessFlow>["actions"],
+});
 
-const dummyProject = {
-  version: 1, name: "dirty-mark-test",
-  screens: [], groups: [], edges: [],
-  tables: [{ id: TABLE_ID, no: 1, name: dummyTable.name, physicalName: dummyTable.physicalName, category: dummyTable.category, columnCount: 1, maturity: "draft" }],
-  processFlows: [{ id: PF_ID, no: 1, name: "dirty マークテストフロー", kind: "screen", actionCount: 1, maturity: "draft" }],
-};
+const dummyProject = buildProject({
+  name: "dirty-mark-test",
+  entities: {
+    tables: [{ id: TABLE_ID, no: 1, name: dummyTable.name, physicalName: dummyTable.physicalName, category: dummyTable.category, columnCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
+    processFlows: [{ id: PF_ID, no: 1, name: "dirty マークテストフロー", kind: "screen", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
+  } as ProjectEntities,
+});
 
 const TABLE_NORM = normalizeId(TABLE_ID);
 const PF_NORM = normalizeId(PF_ID);

--- a/frontend/e2e/drawing-anchor.spec.ts
+++ b/frontend/e2e/drawing-anchor.spec.ts
@@ -13,6 +13,8 @@ import {
   normalizeId,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
 
 const groupId = "ag-anchor";
@@ -82,11 +84,14 @@ const dummyGroup = {
   createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
 };
 
-const dummyProject = {
-  version: 1, name: "anchor", screens: [], groups: [], edges: [], tables: [],
-  processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, type: dummyGroup.type, actionCount: 1, updatedAt: dummyGroup.updatedAt, maturity: "draft" }],
-  updatedAt: new Date().toISOString(),
-};
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
+
+const dummyProject = buildProject({
+  name: "anchor",
+  entities: {
+    processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, kind: dummyGroup.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
+  } as ProjectEntities,
+});
 
 async function setup(page: Page) {
   await ws.gotoActive(page, `/process-flow/edit/${normalizeId(groupId)}`);
@@ -107,13 +112,16 @@ async function setup(page: Page) {
 
 // realWorkspace 移植 (#926): 実 backend 経由の dummy fixture
 // ProcessFlow body は dummyGroup を v3 shape (top-level id + meta) で再利用する。
-const dummyGroupBody: Record<string, unknown> = {
+const baseGroupBody = buildProcessFlow({
   id: groupId,
-  $schema: "../../../schemas/v3/process-flow.v3.schema.json",
-  meta: { id: groupId, name: dummyGroup.name, kind: dummyGroup.type ?? dummyGroup.kind ?? "screen", mode: "upstream", maturity: "draft", version: "1.0.0", createdAt: dummyGroup.createdAt ?? "2026-05-08T00:00:00.000Z", updatedAt: dummyGroup.updatedAt ?? "2026-05-08T00:00:00.000Z" },
-  actions: dummyGroup.actions,
-  ...((dummyGroup as Record<string, unknown>).markers !== undefined ? { authoring: { markers: (dummyGroup as Record<string, unknown>).markers } } : {}),
-};
+  name: dummyGroup.name,
+  kind: (dummyGroup.type ?? "screen") as Parameters<typeof buildProcessFlow>[0]["kind"],
+  mode: "upstream",
+  actions: dummyGroup.actions as ReturnType<typeof buildProcessFlow>["actions"],
+});
+const dummyGroupBody = dummyGroup.markers !== undefined
+  ? { ...baseGroupBody, authoring: { markers: dummyGroup.markers } }
+  : baseGroupBody;
 
 const WS_KEY = "issue-926-drawing-anchor";
 let mcpAvailable = false;
@@ -132,7 +140,7 @@ test.beforeEach(async () => {
   ws = await setupTestWorkspace({
     key: WS_KEY,
     project: dummyProject,
-    processFlows: [dummyGroupBody as unknown as { id: string }],
+    processFlows: [dummyGroupBody],
   });
 });
 test.describe("描画マーカー DOM anchor (#261)", () => {

--- a/frontend/e2e/drawing-marker.spec.ts
+++ b/frontend/e2e/drawing-marker.spec.ts
@@ -11,7 +11,10 @@ import {
   normalizeId,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 
 const groupId = "ag-draw";
 
@@ -32,11 +35,12 @@ const dummyGroup = {
   ],
   createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
 };
-const dummyProject = {
-  version: 1, name: "draw", screens: [], groups: [], edges: [], tables: [],
-  processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, type: dummyGroup.type, actionCount: 1, updatedAt: dummyGroup.updatedAt, maturity: "draft" }],
-  updatedAt: new Date().toISOString(),
-};
+const dummyProject = buildProject({
+  name: "draw",
+  entities: {
+    processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, kind: dummyGroup.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
+  } as ProjectEntities,
+});
 
 async function setup(page: Page) {
   await ws.gotoActive(page, `/process-flow/edit/${normalizeId(groupId)}`);
@@ -65,13 +69,16 @@ async function drawStroke(page: Page, x0: number, y0: number, dx: number, dy: nu
 
 // realWorkspace 移植 (#926): 実 backend 経由の dummy fixture
 // ProcessFlow body は dummyGroup を v3 shape (top-level id + meta) で再利用する。
-const dummyGroupBody: Record<string, unknown> = {
+const baseGroupBody = buildProcessFlow({
   id: groupId,
-  $schema: "../../../schemas/v3/process-flow.v3.schema.json",
-  meta: { id: groupId, name: dummyGroup.name, kind: dummyGroup.type ?? dummyGroup.kind ?? "screen", mode: "upstream", maturity: "draft", version: "1.0.0", createdAt: dummyGroup.createdAt ?? "2026-05-08T00:00:00.000Z", updatedAt: dummyGroup.updatedAt ?? "2026-05-08T00:00:00.000Z" },
-  actions: dummyGroup.actions,
-  ...((dummyGroup as Record<string, unknown>).markers !== undefined ? { authoring: { markers: (dummyGroup as Record<string, unknown>).markers } } : {}),
-};
+  name: dummyGroup.name,
+  kind: (dummyGroup.type ?? "screen") as Parameters<typeof buildProcessFlow>[0]["kind"],
+  mode: "upstream",
+  actions: dummyGroup.actions as ReturnType<typeof buildProcessFlow>["actions"],
+});
+const dummyGroupBody = dummyGroup.markers !== undefined
+  ? { ...baseGroupBody, authoring: { markers: dummyGroup.markers } }
+  : baseGroupBody;
 
 const WS_KEY = "issue-926-drawing-marker";
 let mcpAvailable = false;
@@ -90,7 +97,7 @@ test.beforeEach(async () => {
   ws = await setupTestWorkspace({
     key: WS_KEY,
     project: dummyProject,
-    processFlows: [dummyGroupBody as unknown as { id: string }],
+    processFlows: [dummyGroupBody],
   });
 });
 test.describe("描画マーカー (#261)", () => {

--- a/frontend/e2e/edit-mode.spec.ts
+++ b/frontend/e2e/edit-mode.spec.ts
@@ -14,8 +14,10 @@ import {
   normalizeId,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
-const baseTs = "2026-05-08T00:00:00.000Z";
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 const TABLE_ID = `tbl-e2e-edit-mode-${Date.now()}`;
 const PF_ID = `pf-e2e-edit-mode-${Date.now()}`;
 const VIEW_ID = `v-e2e-edit-${Date.now()}`;
@@ -37,27 +39,29 @@ const dummyTable = {
   indexes: [], constraints: [],
 };
 
-const dummyProcessFlowBody = {
+const dummyProcessFlowBody = buildProcessFlow({
   id: PF_ID,
-  $schema: "../../../schemas/v3/process-flow.v3.schema.json",
-  meta: { id: PF_ID, name: "編集モードテストフロー", kind: "screen", mode: "upstream", maturity: "draft", version: "1.0.0", createdAt: baseTs, updatedAt: baseTs },
-  actions: [{ id: "act-001", name: "テストアクション", trigger: "click", maturity: "draft", steps: [] }],
-};
+  name: "編集モードテストフロー",
+  kind: "screen",
+  mode: "upstream",
+  actions: [{ id: "act-001", name: "テストアクション", trigger: "click", maturity: "draft", steps: [] }] as ReturnType<typeof buildProcessFlow>["actions"],
+});
 
 const dummyView = { id: VIEW_ID, name: "E2E ビュー", maturity: "draft", tableId: "", columns: [] };
 const dummyViewDefinition = { id: VIEW_DEF_ID, name: "E2E ビュー定義", maturity: "draft", layout: { type: "form", fields: [] } };
 const dummySequence = { id: SEQUENCE_ID, name: "E2E シーケンス", maturity: "draft", steps: [] };
 
-const dummyProject = {
-  version: 1, name: "edit-mode-test",
-  screens: [{ id: SCREEN_ID, no: 1, name: "編集モードテスト画面", kind: "form" }],
-  groups: [], edges: [],
-  tables: [{ id: TABLE_ID, no: 1, name: dummyTable.name, physicalName: dummyTable.physicalName, category: "マスタ", columnCount: 1, maturity: "draft" }],
-  processFlows: [{ id: PF_ID, no: 1, name: "編集モードテストフロー", kind: "screen", actionCount: 1, maturity: "draft" }],
-  views: [{ id: VIEW_ID, no: 1, name: "E2E ビュー", maturity: "draft" }],
-  viewDefinitions: [{ id: VIEW_DEF_ID, no: 1, name: "E2E ビュー定義", maturity: "draft" }],
-  sequences: [{ id: SEQUENCE_ID, no: 1, name: "E2E シーケンス", maturity: "draft" }],
-};
+const dummyProject = buildProject({
+  name: "edit-mode-test",
+  entities: {
+    screens: [{ id: SCREEN_ID, no: 1, name: "編集モードテスト画面", kind: "form", updatedAt: FIXED_TS }],
+    tables: [{ id: TABLE_ID, no: 1, name: dummyTable.name, physicalName: dummyTable.physicalName, category: "マスタ", columnCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
+    processFlows: [{ id: PF_ID, no: 1, name: "編集モードテストフロー", kind: "screen", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
+    views: [{ id: VIEW_ID, no: 1, name: "E2E ビュー", maturity: "draft", updatedAt: FIXED_TS }],
+    viewDefinitions: [{ id: VIEW_DEF_ID, no: 1, name: "E2E ビュー定義", maturity: "draft", updatedAt: FIXED_TS }],
+    sequences: [{ id: SEQUENCE_ID, no: 1, name: "E2E シーケンス", maturity: "draft", updatedAt: FIXED_TS }],
+  } as ProjectEntities,
+});
 
 const WS_KEY = "issue-926-edit-mode";
 let mcpAvailable = false;

--- a/frontend/e2e/edit-mode.spec.ts
+++ b/frontend/e2e/edit-mode.spec.ts
@@ -14,8 +14,15 @@ import {
   normalizeId,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
-import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import {
+  buildProject,
+  buildProcessFlow,
+  buildTable,
+  buildView,
+  buildViewDefinition,
+  buildSequence,
+} from "./__fixtures__/builders";
+import type { Column, ProjectEntities, Timestamp } from "../src/types/v3";
 
 const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 const TABLE_ID = `tbl-e2e-edit-mode-${Date.now()}`;
@@ -32,12 +39,23 @@ const VIEW_DEF_NORM = normalizeId(VIEW_DEF_ID);
 const SEQ_NORM = normalizeId(SEQUENCE_ID);
 const SCREEN_NORM = normalizeId(SCREEN_ID);
 
-const dummyTable = {
-  id: TABLE_ID, physicalName: "edit_mode_test", name: "編集モードテスト", category: "マスタ",
-  maturity: "draft",
-  columns: [{ id: "col-001", physicalName: "id", name: "ID", dataType: "INTEGER", notNull: true, primaryKey: true, unique: false, autoIncrement: true }],
-  indexes: [], constraints: [],
-};
+const dummyTable = buildTable({
+  id: TABLE_ID,
+  physicalName: "edit_mode_test",
+  name: "編集モードテスト",
+  category: "マスタ",
+  columns: [
+    {
+      id: "col-001",
+      physicalName: "id",
+      name: "ID",
+      dataType: "INTEGER",
+      notNull: true,
+      primaryKey: true,
+      autoIncrement: true,
+    } as unknown as Column,
+  ],
+});
 
 const dummyProcessFlowBody = buildProcessFlow({
   id: PF_ID,
@@ -47,9 +65,9 @@ const dummyProcessFlowBody = buildProcessFlow({
   actions: [{ id: "act-001", name: "テストアクション", trigger: "click", maturity: "draft", steps: [] }] as ReturnType<typeof buildProcessFlow>["actions"],
 });
 
-const dummyView = { id: VIEW_ID, name: "E2E ビュー", maturity: "draft", tableId: "", columns: [] };
-const dummyViewDefinition = { id: VIEW_DEF_ID, name: "E2E ビュー定義", maturity: "draft", layout: { type: "form", fields: [] } };
-const dummySequence = { id: SEQUENCE_ID, name: "E2E シーケンス", maturity: "draft", steps: [] };
+const dummyView = buildView({ id: VIEW_ID, name: "E2E ビュー" });
+const dummyViewDefinition = buildViewDefinition({ id: VIEW_DEF_ID, name: "E2E ビュー定義" });
+const dummySequence = buildSequence({ id: SEQUENCE_ID, name: "E2E シーケンス" });
 
 const dummyProject = buildProject({
   name: "edit-mode-test",

--- a/frontend/e2e/error-boundary.spec.ts
+++ b/frontend/e2e/error-boundary.spec.ts
@@ -12,11 +12,9 @@ import {
   isMcpRunning,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject } from "./__fixtures__/builders";
 
-const dummyProject = {
-  version: 1, name: "error-boundary-test",
-  screens: [], groups: [], edges: [], tables: [],
-};
+const dummyProject = buildProject({ name: "error-boundary-test" });
 
 const WS_KEY = "issue-926-error-boundary";
 let mcpAvailable = false;

--- a/frontend/e2e/error-catalog-panel.spec.ts
+++ b/frontend/e2e/error-catalog-panel.spec.ts
@@ -11,14 +11,17 @@ import {
   normalizeId,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 const groupId = "ag-ec-ui";
-const baseTs = "2026-05-08T00:00:00.000Z";
 
-const dummyGroupBody = {
+const dummyGroupBody = buildProcessFlow({
   id: groupId,
-  $schema: "../../../schemas/v3/process-flow.v3.schema.json",
-  meta: { id: groupId, name: "errorCatalog UI", kind: "screen", mode: "upstream", maturity: "draft", version: "1.0.0", createdAt: baseTs, updatedAt: baseTs },
+  name: "errorCatalog UI",
+  kind: "screen",
+  mode: "upstream",
   actions: [{
     id: "act-1", name: "ボタン", trigger: "click", maturity: "draft",
     responses: [
@@ -27,14 +30,15 @@ const dummyGroupBody = {
       { id: "409-stock-shortage", status: 409 },
     ],
     steps: [],
-  }],
-};
+  }] as ReturnType<typeof buildProcessFlow>["actions"],
+});
 
-const dummyProject = {
-  version: 1, name: "ec-test",
-  screens: [], groups: [], edges: [], tables: [],
-  processFlows: [{ id: groupId, no: 1, name: "errorCatalog UI", kind: "screen", actionCount: 1, maturity: "draft" }],
-};
+const dummyProject = buildProject({
+  name: "ec-test",
+  entities: {
+    processFlows: [{ id: groupId, no: 1, name: "errorCatalog UI", kind: "screen", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
+  } as ProjectEntities,
+});
 
 const WS_KEY = "issue-926-error-catalog-panel";
 let mcpAvailable = false;

--- a/frontend/e2e/error-dialog.spec.ts
+++ b/frontend/e2e/error-dialog.spec.ts
@@ -10,11 +10,9 @@ import {
   isMcpRunning,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject } from "./__fixtures__/builders";
 
-const dummyProject = {
-  version: 1, name: "E2E",
-  screens: [], groups: [], edges: [], tables: [],
-};
+const dummyProject = buildProject({ name: "E2E" });
 
 const WS_KEY = "issue-926-error-dialog";
 let mcpAvailable = false;

--- a/frontend/e2e/extensions-palette.spec.ts
+++ b/frontend/e2e/extensions-palette.spec.ts
@@ -14,20 +14,24 @@ import {
   normalizeId,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 const groupId = "ag-extension-palette";
-const baseTs = "2026-05-08T00:00:00.000Z";
-const dummyGroupBody = {
+const dummyGroupBody = buildProcessFlow({
   id: groupId,
-  $schema: "../../../schemas/v3/process-flow.v3.schema.json",
-  meta: { id: groupId, name: "extension palette", kind: "screen", mode: "upstream", maturity: "draft", version: "1.0.0", createdAt: baseTs, updatedAt: baseTs },
-  actions: [{ id: "act-1", name: "ボタン", trigger: "click", maturity: "draft", responses: [], steps: [] }],
-};
-const dummyProject = {
-  version: 1, name: "extension-palette",
-  screens: [], groups: [], edges: [], tables: [],
-  processFlows: [{ id: groupId, no: 1, name: "extension palette", kind: "screen", actionCount: 1, maturity: "draft" }],
-};
+  name: "extension palette",
+  kind: "screen",
+  mode: "upstream",
+  actions: [{ id: "act-1", name: "ボタン", trigger: "click", maturity: "draft", responses: [], steps: [] }] as ReturnType<typeof buildProcessFlow>["actions"],
+});
+const dummyProject = buildProject({
+  name: "extension-palette",
+  entities: {
+    processFlows: [{ id: groupId, no: 1, name: "extension palette", kind: "screen", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
+  } as ProjectEntities,
+});
 
 const E2E_FIXTURE = {
   namespace: "e2e",

--- a/frontend/e2e/extensions-panel.spec.ts
+++ b/frontend/e2e/extensions-panel.spec.ts
@@ -5,9 +5,10 @@ import {
   isMcpRunning,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject } from "./__fixtures__/builders";
 
 const WS_KEY = "issue-926-extensions-panel";
-const dummyProject = { version: 1, name: "ext-panel", screens: [], groups: [], edges: [], tables: [], processFlows: [] };
+const dummyProject = buildProject({ name: "ext-panel" });
 let mcpAvailable = false;
 let ws: OpenedWorkspace;
 

--- a/frontend/e2e/helpers/puck.ts
+++ b/frontend/e2e/helpers/puck.ts
@@ -6,6 +6,8 @@ import {
   normalizeId,
   type OpenedWorkspace,
 } from "./realWorkspace";
+import { buildProject, buildScreen } from "../__fixtures__/builders";
+import type { Project, ProjectEntities, Screen, ScreenEntry, Timestamp } from "../../src/types/v3";
 import fs from "node:fs/promises";
 import path from "node:path";
 
@@ -46,20 +48,22 @@ export const HEADING_PARAGRAPH_DATA = {
   ],
 };
 
-/** Puck 画面を含む最小プロジェクト (legacy v1 形式 — realWorkspace の legacyToHarmony が v3 に変換) */
-export function makeDummyProject(screenOverrides: Array<Record<string, unknown>> = []): Record<string, unknown> {
-  return {
-    version: 1,
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
+
+/** Puck 画面を含む最小プロジェクト (v3 形式) */
+export function makeDummyProject(extraScreens: ScreenEntry[] = []): Project {
+  return buildProject({
     name: "Puck E2E テスト用プロジェクト",
-    screens: [
-      { id: PUCK_SCREEN_ID, no: 1, name: "Puck テスト画面 (Bootstrap)", kind: "other", path: "/puck-test", hasDesign: true },
-      { id: GJS_SCREEN_ID, no: 2, name: "GrapesJS テスト画面", kind: "other", path: "/gjs-test", hasDesign: true },
-      { id: PUCK_TW_SCREEN_ID, no: 3, name: "Puck Tailwind テスト画面", kind: "other", path: "/puck-tw-test", hasDesign: true },
-      ...screenOverrides,
-    ],
-    groups: [], edges: [], tables: [], processFlows: [],
     techStack: { designer: { cssFramework: "bootstrap", editorKind: "puck" } },
-  };
+    entities: {
+      screens: [
+        { id: PUCK_SCREEN_ID, no: 1, name: "Puck テスト画面 (Bootstrap)", kind: "other", path: "/puck-test", hasDesign: true, updatedAt: FIXED_TS },
+        { id: GJS_SCREEN_ID, no: 2, name: "GrapesJS テスト画面", kind: "other", path: "/gjs-test", hasDesign: true, updatedAt: FIXED_TS },
+        { id: PUCK_TW_SCREEN_ID, no: 3, name: "Puck Tailwind テスト画面", kind: "other", path: "/puck-tw-test", hasDesign: true, updatedAt: FIXED_TS },
+        ...extraScreens,
+      ],
+    } as ProjectEntities,
+  });
 }
 
 /** screen entity (harmony/screens/<id>.json) を生成する */
@@ -70,19 +74,14 @@ export function makeScreenEntity(
   path: string,
   editorKind: "puck" | "grapesjs",
   cssFramework: "bootstrap" | "tailwind",
-): Record<string, unknown> {
-  const now = "2026-05-08T00:00:00.000Z";
+): Screen {
+  const base = buildScreen({ id: screenId, name, kind: kind as Parameters<typeof buildScreen>[0]["kind"], path });
   return {
-    $schema: "../schemas/v3/screen.v3.schema.json",
-    id: screenId,
-    name,
-    createdAt: now,
-    updatedAt: now,
-    kind,
-    path,
+    ...base,
     items: [],
     design: {
-      editorKind, cssFramework,
+      editorKind,
+      cssFramework,
       ...(editorKind === "puck" ? { puckDataRef: "puck-data.json" } : { designFileRef: `${screenId}.design.json` }),
     },
   };

--- a/frontend/e2e/helpers/realWorkspace.test.ts
+++ b/frontend/e2e/helpers/realWorkspace.test.ts
@@ -1,0 +1,178 @@
+/**
+ * realWorkspace helper 単体テスト (#964 α)
+ *
+ * backend WebSocket が不要な部分のみテスト:
+ * - normalizeId: UUID v4 正規化ロジック
+ * - v3 typed input が harmony.json / entity ファイルとしてそのまま書き出されること
+ *   (setupTestWorkspace のファイル書き込みロジックを直接検証)
+ *
+ * environment: node (vitest.config.ts の environmentMatchGlobs で指定)
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+import { normalizeId } from "./realWorkspace.ts";
+import type {
+  Project,
+  Table,
+  Screen,
+  ProcessFlow,
+} from "../../src/types/v3/index.ts";
+
+// ─── normalizeId テスト ────────────────────────────────────────────────────
+
+describe("normalizeId", () => {
+  it("UUID v4 はそのまま返す", () => {
+    const uuid = "550e8400-e29b-41d4-a716-446655440000";
+    expect(normalizeId(uuid)).toBe(uuid);
+  });
+
+  it("非 UUID 文字列は決定論的な UUID v4 に変換される", () => {
+    const result = normalizeId("screen-0001");
+    // UUID v4 形式チェック
+    expect(result).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+  });
+
+  it("同じ入力からは常に同じ UUID が生成される (決定論的)", () => {
+    const a = normalizeId("my-screen");
+    const b = normalizeId("my-screen");
+    expect(a).toBe(b);
+  });
+
+  it("異なる入力からは異なる UUID が生成される", () => {
+    const a = normalizeId("screen-a");
+    const b = normalizeId("screen-b");
+    expect(a).not.toBe(b);
+  });
+});
+
+// ─── v3 ファイル書き込み検証 ──────────────────────────────────────────────
+
+/**
+ * v3 typed input をそのままファイルに書き出す部分のみをシミュレート。
+ * setupTestWorkspace の内部実装から WebSocket 呼び出しを除いた部分のテスト。
+ */
+async function writeV3Workspace(
+  dir: string,
+  project: Project,
+  extras: {
+    tables?: Table[];
+    screens?: Screen[];
+    processFlows?: ProcessFlow[];
+  } = {},
+): Promise<void> {
+  const dataDir = path.join(dir, "harmony");
+  for (const sub of ["screens", "tables", "process-flows", "sequences", "views", "view-definitions"]) {
+    await fs.mkdir(path.join(dataDir, sub), { recursive: true });
+  }
+
+  // harmony.json
+  await fs.writeFile(path.join(dir, "harmony.json"), JSON.stringify(project, null, 2), "utf-8");
+
+  // Table
+  for (const t of extras.tables ?? []) {
+    await fs.writeFile(path.join(dataDir, "tables", `${t.id}.json`), JSON.stringify(t, null, 2), "utf-8");
+  }
+  // Screen
+  for (const s of extras.screens ?? []) {
+    await fs.writeFile(path.join(dataDir, "screens", `${s.id}.json`), JSON.stringify(s, null, 2), "utf-8");
+  }
+  // ProcessFlow
+  for (const f of extras.processFlows ?? []) {
+    await fs.writeFile(path.join(dataDir, "process-flows", `${f.meta.id}.json`), JSON.stringify(f, null, 2), "utf-8");
+  }
+}
+
+describe("v3 typed input → v3 output", () => {
+  let tmpDir: string;
+
+  afterEach(async () => {
+    if (tmpDir) {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("Project v3 が harmony.json として書き出され、schemaVersion が v3 になる", async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "harmony-test-"));
+
+    const project: Project = {
+      $schema: "../schemas/v3/harmony.v3.schema.json",
+      schemaVersion: "v3",
+      dataDir: "harmony",
+      meta: {
+        id: "550e8400-e29b-41d4-a716-446655440001" as Project["meta"]["id"],
+        name: "テスト用プロジェクト",
+        maturity: "draft",
+        createdAt: "2026-01-01T00:00:00.000Z" as Project["meta"]["createdAt"],
+        updatedAt: "2026-01-01T00:00:00.000Z" as Project["meta"]["updatedAt"],
+        mode: "upstream",
+      },
+      extensionsApplied: [],
+      entities: {
+        screens: [
+          {
+            id: "550e8400-e29b-41d4-a716-446655440010" as Project["entities"]["screens"][0]["id"],
+            no: 1,
+            name: "テスト画面",
+            updatedAt: "2026-01-01T00:00:00.000Z" as Project["entities"]["screens"][0]["updatedAt"],
+            maturity: "draft",
+            kind: "list",
+          },
+        ],
+      },
+    };
+
+    await writeV3Workspace(tmpDir, project);
+
+    // harmony.json が書き出されている
+    const written = JSON.parse(await fs.readFile(path.join(tmpDir, "harmony.json"), "utf-8")) as Record<string, unknown>;
+
+    expect(written.schemaVersion).toBe("v3");
+    expect(written.dataDir).toBe("harmony");
+    expect((written.meta as Record<string, unknown>).id).toBe("550e8400-e29b-41d4-a716-446655440001");
+    expect((written.meta as Record<string, unknown>).name).toBe("テスト用プロジェクト");
+    // v1→v3 変換なし: entities.screens もそのまま存在する
+    expect((written.entities as Record<string, unknown>).screens).toHaveLength(1);
+  });
+
+  it("Table v3 が harmony/tables/<id>.json として書き出される", async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "harmony-test-"));
+
+    const TABLE_ID = "550e8400-e29b-41d4-a716-446655440020" as Table["id"];
+    const table: Table = {
+      id: TABLE_ID,
+      name: "ユーザー" as Table["name"],
+      physicalName: "users" as Table["physicalName"],
+      maturity: "draft",
+      createdAt: "2026-01-01T00:00:00.000Z" as Table["createdAt"],
+      updatedAt: "2026-01-01T00:00:00.000Z" as Table["updatedAt"],
+      columns: [],
+    };
+
+    const minimalProject: Project = {
+      schemaVersion: "v3",
+      dataDir: "harmony",
+      meta: {
+        id: "550e8400-e29b-41d4-a716-446655440001" as Project["meta"]["id"],
+        name: "テスト" as Project["meta"]["name"],
+        maturity: "draft",
+        createdAt: "2026-01-01T00:00:00.000Z" as Project["meta"]["createdAt"],
+        updatedAt: "2026-01-01T00:00:00.000Z" as Project["meta"]["updatedAt"],
+      },
+    };
+
+    await writeV3Workspace(tmpDir, minimalProject, { tables: [table] });
+
+    const filePath = path.join(tmpDir, "harmony", "tables", `${TABLE_ID}.json`);
+    const written = JSON.parse(await fs.readFile(filePath, "utf-8")) as Record<string, unknown>;
+
+    // v1→v3 変換なし: id / physicalName / columns がそのまま書き出されている
+    expect(written.id).toBe(TABLE_ID);
+    expect(written.physicalName).toBe("users");
+    expect(Array.isArray(written.columns)).toBe(true);
+    expect((written.columns as unknown[]).length).toBe(0);
+  });
+});

--- a/frontend/e2e/helpers/realWorkspace.ts
+++ b/frontend/e2e/helpers/realWorkspace.ts
@@ -5,6 +5,9 @@
  * そのため e2e テストは「`addInitScript` で localStorage に seed」方式から「ファイルシステム + WS open」
  * 方式に移行する必要がある (#926)。
  *
+ * #964 α: helper を v3 typed only に改修。LegacyProjectInput / legacyToHarmony 削除済み。
+ * 各フィールドは v3 schema 由来の TypeScript 型 (Project / Table / ProcessFlow 等) を受け取る。
+ *
  * 主な API:
  *   - copyExampleWorkspace(exampleName, key): examples/<name>/ をコピー
  *   - setupTestWorkspace({ key, project, tables, processFlows, ... }): 任意 seed データから
@@ -18,6 +21,18 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import * as net from "net";
 import WebSocketImpl from "ws";
+import type {
+  Conventions,
+  CustomBlock,
+  ProcessFlow,
+  Project,
+  Screen,
+  ScreenLayout,
+  Sequence,
+  Table,
+  View,
+  ViewDefinition,
+} from "../../src/types/v3/index.ts";
 
 export interface RealWorkspaceFixture {
   key: string;
@@ -54,146 +69,46 @@ export interface PageLike {
 /**
  * setupTestWorkspace の引数。各フィールドは省略可。
  * 渡したフィールドは harmony.json + 個別ファイルとして書き出される。
+ *
+ * #964 α: 全フィールドを v3 schema 由来 TypeScript 型 (Project / Table / ProcessFlow 等) に統一。
+ * 旧 LegacyProjectInput は削除済み。v1 形式のデータは β/γ で builder 経由で v3 に変換する。
  */
 export interface SetupTestWorkspaceOptions {
   /** 一意キー (.tmp/e2e-workspaces/<key>/ になる) */
   key: string;
-  /** v1 LegacyFlowProject 形式 (旧 localStorage seed と同じ shape)。harmony.json に変換される */
-  project?: LegacyProjectInput;
-  /** TableData[] — 各 entry は loadTable で返る body。harmony/tables/<id>.json に書き出し */
-  tables?: TableInput[];
-  /** ProcessFlow JSON — harmony/process-flows/<id>.json */
-  processFlows?: ProcessFlowInput[];
-  /** Sequence — harmony/sequences/<id>.json */
-  sequences?: SequenceInput[];
-  /** View — harmony/views/<id>.json */
-  views?: ViewInput[];
-  /** ViewDefinition — harmony/view-definitions/<id>.json */
-  viewDefinitions?: ViewDefinitionInput[];
-  /** 規約カタログ (catalog.json) */
-  conventions?: unknown;
-  /** Screen 個別 entity ファイル (`harmony/screens/<id>.json`)。
-   *  通常は project.screens に入った header から自動生成されるので明示は不要。 */
-  screenEntities?: ScreenEntityInput[];
+  /** v3 Project — harmony.json として書き出される */
+  project?: Project;
+  /** v3 Table[] — 各 entry は harmony/tables/<meta.id>.json に書き出し */
+  tables?: Table[];
+  /** v3 ProcessFlow[] — harmony/process-flows/<meta.id>.json */
+  processFlows?: ProcessFlow[];
+  /** v3 Sequence[] — harmony/sequences/<meta.id>.json */
+  sequences?: Sequence[];
+  /** v3 View[] — harmony/views/<meta.id>.json */
+  views?: View[];
+  /** v3 ViewDefinition[] — harmony/view-definitions/<meta.id>.json */
+  viewDefinitions?: ViewDefinition[];
+  /** v3 Conventions — harmony/conventions/catalog.json */
+  conventions?: Conventions;
+  /** v3 Screen[] — harmony/screens/<meta.id>.json */
+  screenEntities?: Screen[];
   /** Screen design (puck data 等) — `harmony/screens/<id>.design.json` */
   screenDesigns?: ScreenDesignInput[];
-  /** カスタムブロック (`harmony/custom-blocks.json`) */
-  customBlocks?: unknown[];
+  /** v3 CustomBlock[] — harmony/custom-blocks.json */
+  customBlocks?: CustomBlock[];
   /** Puck コンポーネント (`harmony/puck-components.json`) */
   puckComponents?: unknown[];
   /** ER レイアウト (`harmony/er-layout.json`) */
   erLayout?: unknown;
-  /** screen-layout.json (画面フロー用座標) */
-  screenLayout?: ScreenLayoutInput;
+  /** v3 ScreenLayout — screen-layout.json (画面フロー用座標) */
+  screenLayout?: ScreenLayout;
   /** 既存 examples/<name> をベースにコピーしてから追加 seed する場合 */
   fromExample?: string;
 }
 
-export interface LegacyProjectInput {
-  version?: number;
-  name?: string;
-  screens?: Array<{
-    id: string;
-    no?: number;
-    name: string;
-    /** v1 互換: type / kind どちらでも可 (kind 優先) */
-    type?: string;
-    kind?: string;
-    description?: string;
-    path?: string;
-    hasDesign?: boolean;
-    groupId?: string;
-    position?: { x: number; y: number };
-    size?: { width: number; height: number };
-    createdAt?: string;
-    updatedAt?: string;
-  }>;
-  groups?: Array<{
-    id: string;
-    name: string;
-    color?: string;
-    position?: { x: number; y: number };
-    size?: { width: number; height: number };
-    createdAt?: string;
-    updatedAt?: string;
-  }>;
-  edges?: Array<{
-    id: string;
-    source: string;
-    target: string;
-    label?: string;
-    trigger?: string;
-  }>;
-  tables?: Array<{
-    id: string;
-    no?: number;
-    name?: string;
-    physicalName?: string;
-    category?: string;
-    columnCount?: number;
-    maturity?: string;
-    updatedAt?: string;
-  }>;
-  processFlows?: Array<{
-    id: string;
-    no?: number;
-    name: string;
-    type?: string;
-    kind?: string;
-    actionCount?: number;
-    maturity?: string;
-    updatedAt?: string;
-    screenId?: string;
-  }>;
-  sequences?: Array<{
-    id: string;
-    name?: string;
-    maturity?: string;
-    updatedAt?: string;
-    [key: string]: unknown;
-  }>;
-  views?: Array<{
-    id: string;
-    name?: string;
-    maturity?: string;
-    updatedAt?: string;
-    [key: string]: unknown;
-  }>;
-  viewDefinitions?: Array<{
-    id: string;
-    name?: string;
-    maturity?: string;
-    updatedAt?: string;
-    [key: string]: unknown;
-  }>;
-  meta?: { id?: string; name?: string; description?: string };
-  techStack?: unknown;
-  conventionsApplied?: unknown[];
-  conventions?: unknown;
-  updatedAt?: string;
-}
-
-export interface TableInput {
-  id: string;
-  [key: string]: unknown;
-}
-
-export interface ProcessFlowInput {
-  id: string;
-  [key: string]: unknown;
-}
-
-export type SequenceInput = TableInput;
-export type ViewInput = TableInput;
-export type ViewDefinitionInput = TableInput;
-export type ScreenEntityInput = TableInput;
 export interface ScreenDesignInput {
   id: string;
   data: unknown;
-}
-export interface ScreenLayoutInput {
-  positions?: Record<string, { x: number; y: number; width?: number; height?: number; thumbnail?: string; color?: string }>;
-  transitions?: Record<string, { sourceHandle?: string; targetHandle?: string }>;
 }
 
 const THIS_DIR = path.dirname(fileURLToPath(import.meta.url));
@@ -326,9 +241,7 @@ export async function withBrowserSession<T>(
   });
 }
 
-// ── 内部: harmony.json 構築 ─────────────────────────────────────────────────
-
-const SCHEMA_REF = "../schemas/v3/harmony.v3.schema.json";
+// ── 内部: UUID ヘルパー ─────────────────────────────────────────────────────
 
 function nowIso(): string {
   return new Date().toISOString();
@@ -375,98 +288,27 @@ export function normalizeId(input: string): string {
   return `${part1}-${part2}-${part3}-${part4}-${part5}`;
 }
 
-/** legacy v1 入力 → v3 harmony.json shape に変換。id は UUID v4 へ正規化される */
-function legacyToHarmony(input: LegacyProjectInput): unknown {
-  const ts = input.updatedAt ?? nowIso();
-  const screens = (input.screens ?? []).map((s, i) => ({
-    id: normalizeId(s.id),
-    no: typeof s.no === "number" ? s.no : i + 1,
-    name: s.name,
-    kind: s.kind ?? s.type ?? "other",
-    path: s.path ?? "",
-    ...(s.groupId ? { groupId: normalizeId(s.groupId) } : {}),
-    ...(s.hasDesign !== undefined ? { hasDesign: s.hasDesign } : {}),
-    maturity: "draft",
-    updatedAt: s.updatedAt ?? ts,
-  }));
-  const screenGroups = (input.groups ?? []).map((g) => ({
-    id: normalizeId(g.id),
-    name: g.name,
-    ...(g.color ? { color: g.color } : {}),
-  }));
-  const screenTransitions = (input.edges ?? []).map((e) => ({
-    id: normalizeId(e.id),
-    sourceScreenId: normalizeId(e.source),
-    targetScreenId: normalizeId(e.target),
-    ...(e.label ? { label: e.label } : {}),
-    trigger: e.trigger ?? "click",
-  }));
-  const tables = (input.tables ?? []).map((t, i) => ({
-    id: normalizeId(t.id),
-    no: typeof t.no === "number" ? t.no : i + 1,
-    name: t.name ?? t.physicalName ?? t.id,
-    physicalName: t.physicalName ?? t.id,
-    category: t.category ?? "マスタ",
-    columnCount: t.columnCount ?? 0,
-    maturity: t.maturity ?? "draft",
-    updatedAt: t.updatedAt ?? ts,
-  }));
-  const processFlows = (input.processFlows ?? []).map((f, i) => ({
-    id: normalizeId(f.id),
-    no: typeof f.no === "number" ? f.no : i + 1,
-    name: f.name,
-    kind: f.kind ?? f.type ?? "common",
-    actionCount: f.actionCount ?? 0,
-    maturity: f.maturity ?? "draft",
-    updatedAt: f.updatedAt ?? ts,
-    ...(f.screenId ? { screenId: normalizeId(f.screenId) } : {}),
-  }));
-  const sequences = (input.sequences ?? []).map((s, i) => ({
-    id: normalizeId(s.id),
-    no: typeof s.no === "number" ? (s.no as number) : i + 1,
-    name: typeof s.name === "string" ? s.name : s.id,
-    maturity: typeof s.maturity === "string" ? s.maturity : "draft",
-    updatedAt: typeof s.updatedAt === "string" ? s.updatedAt : ts,
-  }));
-  const views = (input.views ?? []).map((v, i) => ({
-    id: normalizeId(v.id),
-    no: typeof v.no === "number" ? (v.no as number) : i + 1,
-    name: typeof v.name === "string" ? v.name : v.id,
-    maturity: typeof v.maturity === "string" ? v.maturity : "draft",
-    updatedAt: typeof v.updatedAt === "string" ? v.updatedAt : ts,
-  }));
-  const viewDefinitions = (input.viewDefinitions ?? []).map((v, i) => ({
-    id: normalizeId(v.id),
-    no: typeof v.no === "number" ? (v.no as number) : i + 1,
-    name: typeof v.name === "string" ? v.name : v.id,
-    maturity: typeof v.maturity === "string" ? v.maturity : "draft",
-    updatedAt: typeof v.updatedAt === "string" ? v.updatedAt : ts,
-  }));
+/**
+ * project が省略されたとき用の最小 v3 Project を生成する。
+ * #964 α: legacyToHarmony を削除し、v3 typed input をそのまま書き出す方針に変更。
+ * branded type (Uuid / Timestamp 等) は実行時は plain string なので `as unknown as T` でキャスト。
+ */
+function buildMinimalProject(): Project {
+  const ts = nowIso() as unknown as Project["meta"]["createdAt"];
   return {
-    $schema: SCHEMA_REF,
+    $schema: "../schemas/v3/harmony.v3.schema.json",
     schemaVersion: "v3",
     dataDir: "harmony",
     meta: {
-      id: input.meta?.id ? normalizeId(input.meta.id) : uuid(),
-      name: input.meta?.name ?? input.name ?? "E2E テストプロジェクト",
-      ...(input.meta?.description ? { description: input.meta.description } : {}),
+      id: uuid() as unknown as Project["meta"]["id"],
+      name: "E2E テストプロジェクト",
+      maturity: "draft",
       createdAt: ts,
       updatedAt: ts,
       mode: "upstream",
-      maturity: "draft",
     },
     extensionsApplied: [],
-    ...(input.techStack ? { techStack: input.techStack } : {}),
-    entities: {
-      screens,
-      tables,
-      processFlows,
-      views,
-      viewDefinitions,
-      sequences,
-      screenGroups,
-      screenTransitions,
-    },
+    entities: {},
   };
 }
 
@@ -503,49 +345,39 @@ export async function setupTestWorkspace(opts: SetupTestWorkspaceOptions): Promi
   }
 
   // harmony.json: project が無くても最小 shape を書く
+  // #964 α: v3 typed input をそのまま JSON として書き出す (v1→v3 変換なし)
   if (opts.project || !opts.fromExample) {
-    const harmony = legacyToHarmony(opts.project ?? {});
-    await writeJson(path.join(workspacePath, "harmony.json"), harmony);
+    await writeJson(path.join(workspacePath, "harmony.json"), opts.project ?? buildMinimalProject());
   }
 
-  // 個別 entity ファイル — id は UUID v4 に正規化済の値で書く
-  const idOf = (raw: string) => normalizeId(raw);
-  // 入力の id field を解決: top-level id → meta.id の順
-  const resolveItemId = (item: Record<string, unknown>): string => {
-    if (typeof item.id === "string") return item.id;
-    const meta = item.meta as Record<string, unknown> | undefined;
-    if (meta && typeof meta.id === "string") return meta.id;
-    throw new Error("setupTestWorkspace entity must have id (top-level) or meta.id");
-  };
+  // 個別 entity ファイル — v3 typed input をそのまま書き出す
+  // meta.id が entity の識別子 (v3 schema 準拠の UUID)
   for (const t of opts.tables ?? []) {
-    const id = idOf(resolveItemId(t as unknown as Record<string, unknown>));
-    await writeJson(path.join(dataDir, "tables", `${id}.json`), { ...t, id });
+    const id = t.id;
+    await writeJson(path.join(dataDir, "tables", `${id}.json`), t);
   }
   for (const f of opts.processFlows ?? []) {
-    const id = idOf(resolveItemId(f as unknown as Record<string, unknown>));
-    const meta = (f as unknown as { meta?: Record<string, unknown> }).meta;
-    const body: Record<string, unknown> = { ...f, id };
-    if (meta) body.meta = { ...meta, id };
-    await writeJson(path.join(dataDir, "process-flows", `${id}.json`), body);
+    const id = f.meta.id;
+    await writeJson(path.join(dataDir, "process-flows", `${id}.json`), f);
   }
   for (const s of opts.sequences ?? []) {
-    const id = idOf(s.id);
-    await writeJson(path.join(dataDir, "sequences", `${id}.json`), { ...s, id });
+    const id = s.id;
+    await writeJson(path.join(dataDir, "sequences", `${id}.json`), s);
   }
   for (const v of opts.views ?? []) {
-    const id = idOf(v.id);
-    await writeJson(path.join(dataDir, "views", `${id}.json`), { ...v, id });
+    const id = v.id;
+    await writeJson(path.join(dataDir, "views", `${id}.json`), v);
   }
   for (const v of opts.viewDefinitions ?? []) {
-    const id = idOf(v.id);
-    await writeJson(path.join(dataDir, "view-definitions", `${id}.json`), { ...v, id });
+    const id = v.id;
+    await writeJson(path.join(dataDir, "view-definitions", `${id}.json`), v);
   }
   for (const s of opts.screenEntities ?? []) {
-    const id = idOf(s.id);
-    await writeJson(path.join(dataDir, "screens", `${id}.json`), { ...s, id });
+    const id = s.id;
+    await writeJson(path.join(dataDir, "screens", `${id}.json`), s);
   }
   for (const d of opts.screenDesigns ?? []) {
-    const id = idOf(d.id);
+    const id = d.id;
     await writeJson(path.join(dataDir, "screens", `${id}.design.json`), d.data);
   }
   if (opts.conventions !== undefined) {

--- a/frontend/e2e/list-delete-ui.spec.ts
+++ b/frontend/e2e/list-delete-ui.spec.ts
@@ -11,17 +11,21 @@ import {
   isMcpRunning,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
-const dummyProject = {
-  version: 1,
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
+
+const dummyProject = buildProject({
   name: "Delete UI Test",
-  screens: [
-    { id: "s-1", no: 1, name: "画面A", kind: "other", path: "/a" },
-    { id: "s-2", no: 2, name: "画面B", kind: "other", path: "/b" },
-    { id: "s-3", no: 3, name: "画面C", kind: "other", path: "/c" },
-  ],
-  groups: [], edges: [], tables: [],
-};
+  entities: {
+    screens: [
+      { id: "s-1", no: 1, name: "画面A", kind: "other", path: "/a", updatedAt: FIXED_TS },
+      { id: "s-2", no: 2, name: "画面B", kind: "other", path: "/b", updatedAt: FIXED_TS },
+      { id: "s-3", no: 3, name: "画面C", kind: "other", path: "/c", updatedAt: FIXED_TS },
+    ],
+  } as ProjectEntities,
+});
 
 const WS_KEY = "issue-926-list-delete-ui";
 const WS_KEY_EMPTY = "issue-926-list-delete-ui-empty";
@@ -168,7 +172,7 @@ test.describe("#147 空状態の右クリック", () => {
     test.skip(!mcpAvailable, "backend (port 5179) が起動していません");
     emptyWs = await setupTestWorkspace({
       key: WS_KEY_EMPTY,
-      project: { ...dummyProject, screens: [] },
+      project: buildProject({ name: "Delete UI Test" }),
     });
     await page.addInitScript(() => {
       localStorage.setItem("list-view-mode:screen-list", JSON.stringify("table"));

--- a/frontend/e2e/list-ops.spec.ts
+++ b/frontend/e2e/list-ops.spec.ts
@@ -14,28 +14,28 @@ import {
   isMcpRunning,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp, ProcessFlowKind, Maturity } from "../src/types/v3";
 
-const baseNow = "2026-05-08T00:00:00.000Z";
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 
 const listGroups = [
-  { id: "g-a", no: 1, name: "Alpha ログイン", kind: "screen", actionCount: 2, updatedAt: baseNow, maturity: "committed" },
-  { id: "g-b", no: 2, name: "Beta バッチ", kind: "batch", actionCount: 1, updatedAt: baseNow, maturity: "provisional" },
-  { id: "g-c", no: 3, name: "Charlie 共通", kind: "common", actionCount: 1, updatedAt: baseNow, maturity: "draft" },
-  { id: "g-d", no: 4, name: "Delta 登録", kind: "screen", actionCount: 3, updatedAt: baseNow, maturity: "draft" },
+  { id: "g-a", no: 1, name: "Alpha ログイン", kind: "screen" as ProcessFlowKind, actionCount: 2, updatedAt: FIXED_TS, maturity: "committed" as Maturity },
+  { id: "g-b", no: 2, name: "Beta バッチ", kind: "batch" as ProcessFlowKind, actionCount: 1, updatedAt: FIXED_TS, maturity: "provisional" as Maturity },
+  { id: "g-c", no: 3, name: "Charlie 共通", kind: "common" as ProcessFlowKind, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" as Maturity },
+  { id: "g-d", no: 4, name: "Delta 登録", kind: "screen" as ProcessFlowKind, actionCount: 3, updatedAt: FIXED_TS, maturity: "draft" as Maturity },
 ];
 
-const listGroupBodies = listGroups.map((g) => ({
-  $schema: "../../../schemas/v3/process-flow.v3.schema.json",
-  id: g.id,
-  meta: { id: g.id, name: g.name, kind: g.kind, maturity: g.maturity, mode: "upstream", version: "1.0.0", createdAt: baseNow, updatedAt: baseNow },
-  actions: [],
-}));
+const listGroupBodies = listGroups.map((g) =>
+  buildProcessFlow({ id: g.id, name: g.name, kind: g.kind, maturity: g.maturity, mode: "upstream" }),
+);
 
-const project = {
-  version: 1, name: "list-ops",
-  screens: [], groups: [], edges: [], tables: [],
-  processFlows: listGroups,
-};
+const project = buildProject({
+  name: "list-ops",
+  entities: {
+    processFlows: listGroups,
+  } as ProjectEntities,
+});
 
 const WS_KEY = "issue-926-list-ops";
 let mcpAvailable = false;

--- a/frontend/e2e/marker-ergonomics.spec.ts
+++ b/frontend/e2e/marker-ergonomics.spec.ts
@@ -11,21 +11,28 @@ import {
   normalizeId,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 const groupId = "ag-erg";
-const baseTs = "2026-05-08T00:00:00.000Z";
-const dummyGroupBody = {
+const baseActions = [{
+  id: "act-1", name: "ボタン", trigger: "click", maturity: "draft",
+  responses: [{ id: "201-ok", status: 201 }],
+  steps: [
+    { id: "s1", type: "validation", description: "チェック", conditions: "", maturity: "draft" },
+    { id: "s2", type: "dbAccess", description: "検索", tableName: "x", operation: "SELECT", maturity: "draft" },
+  ],
+}] as ReturnType<typeof buildProcessFlow>["actions"];
+const baseGroupBody = buildProcessFlow({
   id: groupId,
-  $schema: "../../../schemas/v3/process-flow.v3.schema.json",
-  meta: { id: groupId, name: "erg test", kind: "screen", mode: "upstream", maturity: "draft", version: "1.0.0", createdAt: baseTs, updatedAt: baseTs },
-  actions: [{
-    id: "act-1", name: "ボタン", trigger: "click", maturity: "draft",
-    responses: [{ id: "201-ok", status: 201 }],
-    steps: [
-      { id: "s1", type: "validation", description: "チェック", conditions: "", maturity: "draft" },
-      { id: "s2", type: "dbAccess", description: "検索", tableName: "x", operation: "SELECT", maturity: "draft" },
-    ],
-  }],
+  name: "erg test",
+  kind: "screen",
+  mode: "upstream",
+  actions: baseActions,
+});
+const dummyGroupBody = {
+  ...baseGroupBody,
   authoring: {
     markers: [
       { id: "m1", kind: "todo", body: "A", author: "human", createdAt: "2026-04-20T00:00:00Z" },
@@ -34,17 +41,18 @@ const dummyGroupBody = {
   },
 };
 const dummyGroupResolvedBody = {
-  ...dummyGroupBody,
+  ...baseGroupBody,
   authoring: {
     markers: dummyGroupBody.authoring.markers.map((m) => ({ ...m, resolvedAt: "2026-04-20T01:00:00Z" })),
   },
 };
 
-const dummyProject = {
-  version: 1, name: "erg",
-  screens: [], groups: [], edges: [], tables: [],
-  processFlows: [{ id: groupId, no: 1, name: "erg test", kind: "screen", actionCount: 1, maturity: "draft" }],
-};
+const dummyProject = buildProject({
+  name: "erg",
+  entities: {
+    processFlows: [{ id: groupId, no: 1, name: "erg test", kind: "screen", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
+  } as ProjectEntities,
+});
 
 const WS_KEY = "issue-926-marker-ergonomics";
 const WS_KEY_RESOLVED = "issue-926-marker-ergonomics-resolved";

--- a/frontend/e2e/marker-panel.spec.ts
+++ b/frontend/e2e/marker-panel.spec.ts
@@ -11,19 +11,24 @@ import {
   normalizeId,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 const groupId = "ag-marker";
-const baseTs = "2026-05-08T00:00:00.000Z";
-const dummyGroupBody = {
+const dummyGroupBody = buildProcessFlow({
   id: groupId,
-  $schema: "../../../schemas/v3/process-flow.v3.schema.json",
-  meta: { id: groupId, name: "marker test", kind: "screen", mode: "upstream", maturity: "draft", version: "1.0.0", createdAt: baseTs, updatedAt: baseTs },
-  actions: [{ id: "act-1", name: "ボタン", trigger: "click", maturity: "draft", steps: [] }],
-};
-const dummyProject = {
-  version: 1, name: "marker", screens: [], groups: [], edges: [], tables: [],
-  processFlows: [{ id: groupId, no: 1, name: "marker test", kind: "screen", actionCount: 1, maturity: "draft" }],
-};
+  name: "marker test",
+  kind: "screen",
+  mode: "upstream",
+  actions: [{ id: "act-1", name: "ボタン", trigger: "click", maturity: "draft", steps: [] }] as ReturnType<typeof buildProcessFlow>["actions"],
+});
+const dummyProject = buildProject({
+  name: "marker",
+  entities: {
+    processFlows: [{ id: groupId, no: 1, name: "marker test", kind: "screen", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
+  } as ProjectEntities,
+});
 
 const WS_KEY = "issue-926-marker-panel";
 let mcpAvailable = false;

--- a/frontend/e2e/maturity-notes.spec.ts
+++ b/frontend/e2e/maturity-notes.spec.ts
@@ -17,6 +17,10 @@ import {
   normalizeId,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
+
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 
 
 const groupId = "ag-maturity-test";
@@ -60,34 +64,16 @@ const dummyGroup = {
 const committedGroupId = "ag-maturity-committed";
 const provisionalGroupId = "ag-maturity-provisional";
 
-const dummyProject = {
-  version: 1,
+const dummyProject = buildProject({
   name: "maturity-test",
-  screens: [],
-  groups: [],
-  edges: [],
-  tables: [],
-  processFlows: [
-    {
-      id: groupId,
-      no: 1,
-      name: dummyGroup.name,
-      type: dummyGroup.type,
-      actionCount: 1,
-      updatedAt: dummyGroup.updatedAt,
-      maturity: dummyGroup.maturity,
-    },
-    {
-      id: committedGroupId, no: 2, name: "確定フロー", type: "screen",
-      actionCount: 0, maturity: "committed", updatedAt: new Date().toISOString(),
-    },
-    {
-      id: provisionalGroupId, no: 3, name: "暫定フロー", type: "screen",
-      actionCount: 0, maturity: "provisional", updatedAt: new Date().toISOString(),
-    },
-  ],
-  updatedAt: new Date().toISOString(),
-};
+  entities: {
+    processFlows: [
+      { id: groupId, no: 1, name: dummyGroup.name, kind: dummyGroup.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" },
+      { id: committedGroupId, no: 2, name: "確定フロー", kind: "screen", actionCount: 0, maturity: "committed", updatedAt: FIXED_TS },
+      { id: provisionalGroupId, no: 3, name: "暫定フロー", kind: "screen", actionCount: 0, maturity: "provisional", updatedAt: FIXED_TS },
+    ],
+  } as ProjectEntities,
+});
 
 async function setupEditor(page: Page) {
   await ws.gotoActive(page, `/process-flow/edit/${normalizeId(groupId)}`);
@@ -107,14 +93,17 @@ async function setupEditor(page: Page) {
 }
 
 // realWorkspace 移植 (#926): 実 backend 経由の dummy fixture
-// ProcessFlow body は dummyGroup を v3 shape (top-level id + meta) で再利用する。
-const dummyGroupBody: Record<string, unknown> = {
+// ProcessFlow body は dummyGroup を v3 shape で再利用する。
+const baseGroupBody = buildProcessFlow({
   id: groupId,
-  $schema: "../../../schemas/v3/process-flow.v3.schema.json",
-  meta: { id: groupId, name: dummyGroup.name, kind: dummyGroup.type ?? dummyGroup.kind ?? "screen", mode: "upstream", maturity: "draft", version: "1.0.0", createdAt: dummyGroup.createdAt ?? "2026-05-08T00:00:00.000Z", updatedAt: dummyGroup.updatedAt ?? "2026-05-08T00:00:00.000Z" },
-  actions: dummyGroup.actions,
-  ...((dummyGroup as Record<string, unknown>).markers !== undefined ? { markers: (dummyGroup as Record<string, unknown>).markers } : {}),
-};
+  name: dummyGroup.name,
+  kind: (dummyGroup.type ?? "screen") as Parameters<typeof buildProcessFlow>[0]["kind"],
+  mode: "upstream",
+  actions: dummyGroup.actions as ReturnType<typeof buildProcessFlow>["actions"],
+});
+const dummyGroupBody = dummyGroup.markers !== undefined
+  ? { ...baseGroupBody, markers: dummyGroup.markers }
+  : baseGroupBody;
 
 const WS_KEY = "issue-926-maturity-notes";
 let mcpAvailable = false;
@@ -128,19 +117,20 @@ test.afterAll(async () => {
   if (mcpAvailable) await cleanupRealWorkspaces([WS_KEY]);
 });
 
-const baseTs = "2026-05-08T00:00:00.000Z";
-const committedGroupBody = {
+const committedGroupBody = buildProcessFlow({
   id: committedGroupId,
-  $schema: "../../../schemas/v3/process-flow.v3.schema.json",
-  meta: { id: committedGroupId, name: "確定フロー", kind: "screen", mode: "upstream", maturity: "committed", version: "1.0.0", createdAt: baseTs, updatedAt: baseTs },
-  actions: [],
-};
-const provisionalGroupBody = {
+  name: "確定フロー",
+  kind: "screen",
+  mode: "upstream",
+  maturity: "committed",
+});
+const provisionalGroupBody = buildProcessFlow({
   id: provisionalGroupId,
-  $schema: "../../../schemas/v3/process-flow.v3.schema.json",
-  meta: { id: provisionalGroupId, name: "暫定フロー", kind: "screen", mode: "upstream", maturity: "provisional", version: "1.0.0", createdAt: baseTs, updatedAt: baseTs },
-  actions: [],
-};
+  name: "暫定フロー",
+  kind: "screen",
+  mode: "upstream",
+  maturity: "provisional",
+});
 
 test.beforeEach(async () => {
   test.skip(!mcpAvailable, "backend (port 5179) が起動していません");
@@ -148,7 +138,7 @@ test.beforeEach(async () => {
     key: WS_KEY,
     project: dummyProject,
     processFlows: [
-      dummyGroupBody as unknown as { id: string },
+      dummyGroupBody,
       committedGroupBody,
       provisionalGroupBody,
     ],

--- a/frontend/e2e/more-ui.spec.ts
+++ b/frontend/e2e/more-ui.spec.ts
@@ -11,21 +11,17 @@ import {
   normalizeId,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 const groupId = "ag-more-test";
-const dummyGroupBody = {
+const dummyGroupBody = buildProcessFlow({
   id: groupId,
-  $schema: "../../../schemas/v3/process-flow.v3.schema.json",
-  meta: {
-    id: groupId,
-    name: "追加 UI テスト",
-    kind: "screen",
-    mode: "upstream",
-    maturity: "provisional",
-    version: "1.0.0",
-    createdAt: "2026-05-08T00:00:00.000Z",
-    updatedAt: "2026-05-08T00:00:00.000Z",
-  },
+  name: "追加 UI テスト",
+  kind: "screen",
+  mode: "upstream",
+  maturity: "provisional",
   actions: [
     {
       id: "act-1",
@@ -39,18 +35,18 @@ const dummyGroupBody = {
         { id: "step-external", type: "externalSystem", description: "外部呼出", systemName: "Stripe", outcomes: { success: { action: "continue" }, failure: { action: "abort", description: "エラー" } }, maturity: "draft" },
       ],
     },
-  ],
-};
+  ] as ReturnType<typeof buildProcessFlow>["actions"],
+});
 
-const dummyProject = {
-  version: 1,
+const dummyProject = buildProject({
   name: "more-e2e",
-  screens: [], groups: [], edges: [], tables: [],
-  processFlows: [
-    { id: groupId, no: 1, name: "追加 UI テスト", kind: "screen", actionCount: 1, maturity: "provisional", notesCount: 0 },
-    { id: "ag-extra-committed", no: 2, name: "確定フロー", kind: "screen", actionCount: 1, maturity: "committed", notesCount: 3 },
-  ],
-};
+  entities: {
+    processFlows: [
+      { id: groupId, no: 1, name: "追加 UI テスト", kind: "screen", actionCount: 1, maturity: "provisional", updatedAt: FIXED_TS },
+      { id: "ag-extra-committed", no: 2, name: "確定フロー", kind: "screen", actionCount: 1, maturity: "committed", updatedAt: FIXED_TS },
+    ],
+  } as ProjectEntities,
+});
 
 const WS_KEY = "issue-926-more-ui";
 let mcpAvailable = false;

--- a/frontend/e2e/resource-url-sync.spec.ts
+++ b/frontend/e2e/resource-url-sync.spec.ts
@@ -14,17 +14,18 @@ import {
   normalizeId,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
 const SCREEN_A = "screen-aaaa-0001";
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 
-const projectWithScreen = {
-  version: 1,
+const projectWithScreen = buildProject({
   name: "E2E",
-  screens: [
-    { id: SCREEN_A, no: 1, name: "画面A", kind: "form", path: "/a", hasDesign: true },
-  ],
-  groups: [], edges: [],
-};
+  entities: {
+    screens: [{ id: SCREEN_A, no: 1, name: "画面A", kind: "form", path: "/a", hasDesign: true, updatedAt: FIXED_TS }],
+  } as ProjectEntities,
+});
 
 const WS_KEY = "issue-926-resource-url-sync";
 let mcpAvailable = false;

--- a/frontend/e2e/save-flow.spec.ts
+++ b/frontend/e2e/save-flow.spec.ts
@@ -13,21 +13,24 @@ import {
   normalizeId,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
 const SCREEN_A = "test-0001-4000-8000-000000000001";
 const SCREEN_B = "test-0002-4000-8000-000000000002";
 const SCREEN_A_ID = normalizeId(SCREEN_A);
 const SCREEN_B_ID = normalizeId(SCREEN_B);
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 
-const dummyProject = {
-  version: 1,
+const dummyProject = buildProject({
   name: "E2Eテスト用プロジェクト",
-  screens: [
-    { id: SCREEN_A, no: 1, name: "画面A", kind: "list", path: "/a", hasDesign: true },
-    { id: SCREEN_B, no: 2, name: "画面B", kind: "list", path: "/b", hasDesign: true },
-  ],
-  groups: [], edges: [],
-};
+  entities: {
+    screens: [
+      { id: SCREEN_A, no: 1, name: "画面A", kind: "list", path: "/a", hasDesign: true, updatedAt: FIXED_TS },
+      { id: SCREEN_B, no: 2, name: "画面B", kind: "list", path: "/b", hasDesign: true, updatedAt: FIXED_TS },
+    ],
+  } as ProjectEntities,
+});
 
 const WS_KEY = "issue-926-save-flow";
 let mcpAvailable = false;

--- a/frontend/e2e/save-reset-action.spec.ts
+++ b/frontend/e2e/save-reset-action.spec.ts
@@ -12,22 +12,26 @@ import {
   normalizeId,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
 const PROCESS_FLOW_ID = "test-ag-0001-4000-8000-000000000001";
-const baseTs = "2026-05-08T00:00:00.000Z";
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 
-const dummyProcessFlowBody = {
+const dummyProcessFlowBody = buildProcessFlow({
   id: PROCESS_FLOW_ID,
-  $schema: "../../../schemas/v3/process-flow.v3.schema.json",
-  meta: { id: PROCESS_FLOW_ID, name: "テスト処理フロー", kind: "screen", mode: "upstream", maturity: "draft", version: "1.0.0", createdAt: baseTs, updatedAt: baseTs },
+  name: "テスト処理フロー",
+  kind: "screen",
+  mode: "upstream",
   actions: [],
-};
+});
 
-const dummyProject = {
-  version: 1, name: "E2Eテスト用プロジェクト",
-  screens: [], groups: [], edges: [],
-  processFlows: [{ id: PROCESS_FLOW_ID, no: 1, name: "テスト処理フロー", kind: "screen", actionCount: 0, maturity: "draft" }],
-};
+const dummyProject = buildProject({
+  name: "E2Eテスト用プロジェクト",
+  entities: {
+    processFlows: [{ id: PROCESS_FLOW_ID, no: 1, name: "テスト処理フロー", kind: "screen", actionCount: 0, maturity: "draft", updatedAt: FIXED_TS }],
+  } as ProjectEntities,
+});
 
 const PF_NORM = normalizeId(PROCESS_FLOW_ID);
 const dummyTab = { id: `process-flow:${PF_NORM}`, type: "process-flow", resourceId: PF_NORM, label: "テスト処理フロー", isDirty: false, isPinned: false };

--- a/frontend/e2e/save-reset-designer.spec.ts
+++ b/frontend/e2e/save-reset-designer.spec.ts
@@ -16,14 +16,18 @@ import {
   normalizeId,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
 const SCREEN_ID = "aaaaaaaa-0001-4000-8000-aaaaaaaaaaaa";
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 
-const dummyProject = {
-  version: 1, name: "E2Eテスト用プロジェクト",
-  screens: [{ id: SCREEN_ID, no: 1, name: "ログイン", path: "/login", kind: "form", hasDesign: true }],
-  groups: [], edges: [], tables: [],
-};
+const dummyProject = buildProject({
+  name: "E2Eテスト用プロジェクト",
+  entities: {
+    screens: [{ id: SCREEN_ID, no: 1, name: "ログイン", path: "/login", kind: "form", hasDesign: true, updatedAt: FIXED_TS }],
+  } as ProjectEntities,
+});
 
 const SCREEN_NORM = normalizeId(SCREEN_ID);
 const dummyTab = { id: `design:${SCREEN_NORM}`, type: "design", resourceId: SCREEN_NORM, label: "ログイン", isDirty: false, isPinned: false };

--- a/frontend/e2e/save-reset-flow.spec.ts
+++ b/frontend/e2e/save-reset-flow.spec.ts
@@ -11,11 +11,11 @@ import {
   isMcpRunning,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject } from "./__fixtures__/builders";
 
-const dummyProject = {
-  version: 1, name: "E2Eテスト用プロジェクト",
-  screens: [], groups: [], edges: [],
-};
+const dummyProject = buildProject({
+  name: "E2Eテスト用プロジェクト",
+});
 
 const toolbarSave = ".save-reset-buttons button.srb-btn-save";
 const toolbarReset = ".save-reset-buttons button.srb-btn-reset";

--- a/frontend/e2e/save-reset.spec.ts
+++ b/frontend/e2e/save-reset.spec.ts
@@ -12,8 +12,11 @@ import {
   normalizeId,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
 const TABLE_ID = "test-table-0001-4000-8000-000000000001";
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 
 const dummyTable = {
   id: TABLE_ID,
@@ -37,14 +40,14 @@ const dummyTable = {
   constraints: [],
 };
 
-const dummyProject = {
-  version: 1,
+const dummyProject = buildProject({
   name: "E2Eテスト用プロジェクト",
-  screens: [], groups: [], edges: [],
-  tables: [
-    { id: TABLE_ID, no: 1, physicalName: "users", name: "ユーザーマスタ", category: "マスタ", columnCount: 1 },
-  ],
-};
+  entities: {
+    tables: [
+      { id: TABLE_ID, no: 1, physicalName: "users", name: "ユーザーマスタ", category: "マスタ", columnCount: 1, updatedAt: FIXED_TS },
+    ],
+  } as ProjectEntities,
+});
 
 const TABLE_NORM = normalizeId(TABLE_ID);
 const dummyTab = {

--- a/frontend/e2e/schema-ui.spec.ts
+++ b/frontend/e2e/schema-ui.spec.ts
@@ -17,6 +17,8 @@ import {
   normalizeId,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
 
 const groupId = "ag-schema-ui-test";
@@ -73,26 +75,24 @@ const dummyGroup = {
   updatedAt: new Date().toISOString(),
 };
 
-const dummyProject = {
-  version: 1,
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
+
+const dummyProject = buildProject({
   name: "schema-ui-test",
-  screens: [],
-  groups: [],
-  edges: [],
-  tables: [],
-  processFlows: [
-    {
-      id: groupId,
-      no: 1,
-      name: dummyGroup.name,
-      type: dummyGroup.type,
-      actionCount: 1,
-      updatedAt: dummyGroup.updatedAt,
-      maturity: dummyGroup.maturity,
-    },
-  ],
-  updatedAt: new Date().toISOString(),
-};
+  entities: {
+    processFlows: [
+      {
+        id: groupId,
+        no: 1,
+        name: dummyGroup.name,
+        kind: dummyGroup.type as string,
+        actionCount: 1,
+        maturity: dummyGroup.maturity,
+        updatedAt: FIXED_TS,
+      },
+    ],
+  } as ProjectEntities,
+});
 
 async function setupEditor(page: Page) {
   await ws.gotoActive(page, `/process-flow/edit/${normalizeId(groupId)}`);
@@ -123,14 +123,14 @@ async function expandStep(page: Page, index: number) {
 }
 
 // realWorkspace 移植 (#926): 実 backend 経由の dummy fixture
-// ProcessFlow body は dummyGroup を v3 shape (top-level id + meta) で再利用する。
-const dummyGroupBody: Record<string, unknown> = {
+// ProcessFlow body は dummyGroup を v3 shape (buildProcessFlow) で生成する。
+const dummyGroupBody = buildProcessFlow({
   id: groupId,
-  $schema: "../../../schemas/v3/process-flow.v3.schema.json",
-  meta: { id: groupId, name: dummyGroup.name, kind: dummyGroup.type ?? dummyGroup.kind ?? "screen", mode: "upstream", maturity: "draft", version: "1.0.0", createdAt: dummyGroup.createdAt ?? "2026-05-08T00:00:00.000Z", updatedAt: dummyGroup.updatedAt ?? "2026-05-08T00:00:00.000Z" },
-  actions: dummyGroup.actions,
-  ...((dummyGroup as Record<string, unknown>).markers !== undefined ? { markers: (dummyGroup as Record<string, unknown>).markers } : {}),
-};
+  name: dummyGroup.name,
+  kind: (dummyGroup.type ?? "screen") as ReturnType<typeof buildProcessFlow>["meta"]["kind"],
+  mode: "upstream",
+  actions: dummyGroup.actions as ReturnType<typeof buildProcessFlow>["actions"],
+});
 
 const WS_KEY = "issue-926-schema-ui";
 let mcpAvailable = false;
@@ -149,7 +149,7 @@ test.beforeEach(async () => {
   ws = await setupTestWorkspace({
     key: WS_KEY,
     project: dummyProject,
-    processFlows: [dummyGroupBody as unknown as { id: string }],
+    processFlows: [dummyGroupBody],
   });
 });
 test.describe("step runIf 入力 (#202)", () => {

--- a/frontend/e2e/screen-creation-editor-choice.spec.ts
+++ b/frontend/e2e/screen-creation-editor-choice.spec.ts
@@ -11,14 +11,14 @@ import {
   isMcpRunning,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject } from "./__fixtures__/builders";
 
-const dummyProject = {
-  version: 1, name: "画面作成 E2E テスト用プロジェクト",
-  screens: [], groups: [], edges: [], tables: [], processFlows: [],
+const dummyProject = buildProject({
+  name: "画面作成 E2E テスト用プロジェクト",
   techStack: {
     designer: { cssFramework: "bootstrap", editorKind: "grapesjs" },
   },
-};
+});
 
 const WS_KEY = "issue-926-screen-creation-editor-choice";
 let mcpAvailable = false;

--- a/frontend/e2e/screen-items-reset.spec.ts
+++ b/frontend/e2e/screen-items-reset.spec.ts
@@ -19,17 +19,20 @@ import {
 } from "./helpers/realWorkspace";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { buildProject } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
 const screenId = "scr-reset-1";
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 
-const dummyProject = {
-  version: 1,
+const dummyProject = buildProject({
   name: "screen-items-reset-test",
-  screens: [
-    { id: screenId, no: 1, name: "リセットテスト画面", kind: "standard" },
-  ],
-  groups: [], edges: [], tables: [], processFlows: [],
-};
+  entities: {
+    screens: [
+      { id: screenId, no: 1, name: "リセットテスト画面", kind: "standard", updatedAt: FIXED_TS },
+    ],
+  } as ProjectEntities,
+});
 
 const WS_KEY = "issue-926-screen-items-reset";
 let mcpAvailable = false;

--- a/frontend/e2e/screen-items.spec.ts
+++ b/frontend/e2e/screen-items.spec.ts
@@ -17,11 +17,14 @@ import {
 } from "./helpers/realWorkspace";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { buildProject } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
 const screenId1 = "scr-1";
 const screenId2 = "scr-2";
 const SCREEN1_NORM = normalizeId(screenId1);
 const SCREEN2_NORM = normalizeId(screenId2);
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 
 const sampleCatalog = {
   version: "1.0.0",
@@ -31,14 +34,15 @@ const sampleCatalog = {
   externalOutcomeDefaults: {},
 };
 
-const dummyProject = {
-  version: 1, name: "screen-items-ui",
-  screens: [
-    { id: screenId1, no: 1, name: "ログイン画面", kind: "form" },
-    { id: screenId2, no: 2, name: "顧客登録画面", kind: "form" },
-  ],
-  groups: [], edges: [], tables: [], processFlows: [],
-};
+const dummyProject = buildProject({
+  name: "screen-items-ui",
+  entities: {
+    screens: [
+      { id: screenId1, no: 1, name: "ログイン画面", kind: "form", updatedAt: FIXED_TS },
+      { id: screenId2, no: 2, name: "顧客登録画面", kind: "form", updatedAt: FIXED_TS },
+    ],
+  } as ProjectEntities,
+});
 
 const WS_KEY = "issue-926-screen-items";
 let mcpAvailable = false;

--- a/frontend/e2e/screen-list.spec.ts
+++ b/frontend/e2e/screen-list.spec.ts
@@ -11,40 +11,21 @@ import {
   isMcpRunning,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
-const dummyProject = {
-  version: 1,
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
+
+const dummyProject = buildProject({
   name: "E2Eテスト用プロジェクト",
-  screens: [
-    {
-      id: "screen-0001",
-      no: 1,
-      name: "ログイン画面",
-      kind: "login",
-      path: "/login",
-      hasDesign: false,
-    },
-    {
-      id: "screen-0002",
-      no: 2,
-      name: "ダッシュボード",
-      kind: "dashboard",
-      path: "/dashboard",
-      hasDesign: true,
-    },
-    {
-      id: "screen-0003",
-      no: 3,
-      name: "ユーザー一覧",
-      kind: "list",
-      path: "/users",
-      hasDesign: false,
-    },
-  ],
-  groups: [],
-  edges: [],
-  tables: [],
-};
+  entities: {
+    screens: [
+      { id: "screen-0001", no: 1, name: "ログイン画面", kind: "login", path: "/login", hasDesign: false, updatedAt: FIXED_TS },
+      { id: "screen-0002", no: 2, name: "ダッシュボード", kind: "dashboard", path: "/dashboard", hasDesign: true, updatedAt: FIXED_TS },
+      { id: "screen-0003", no: 3, name: "ユーザー一覧", kind: "list", path: "/users", hasDesign: false, updatedAt: FIXED_TS },
+    ],
+  } as ProjectEntities,
+});
 
 const WS_KEY = "issue-926-screen-list";
 let mcpAvailable = false;

--- a/frontend/e2e/sort-readonly.spec.ts
+++ b/frontend/e2e/sort-readonly.spec.ts
@@ -11,19 +11,21 @@ import {
   isMcpRunning,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
-const dummyProject = {
-  version: 1,
+const dummyProject = buildProject({
   name: "Sort Readonly Test",
-  screens: [
-    { id: "s-1", no: 1, name: "Charlie", kind: "other", path: "/c", updatedAt: "2024-03-03T00:00:00Z" },
-    { id: "s-2", no: 2, name: "Alpha", kind: "other", path: "/a", updatedAt: "2024-01-01T00:00:00Z" },
-    { id: "s-3", no: 3, name: "Echo", kind: "other", path: "/e", updatedAt: "2024-05-05T00:00:00Z" },
-    { id: "s-4", no: 4, name: "Bravo", kind: "other", path: "/b", updatedAt: "2024-02-02T00:00:00Z" },
-    { id: "s-5", no: 5, name: "Delta", kind: "other", path: "/d", updatedAt: "2024-04-04T00:00:00Z" },
-  ],
-  groups: [], edges: [], tables: [],
-};
+  entities: {
+    screens: [
+      { id: "s-1", no: 1, name: "Charlie", kind: "other", path: "/c", updatedAt: "2024-03-03T00:00:00Z" as unknown as Timestamp },
+      { id: "s-2", no: 2, name: "Alpha", kind: "other", path: "/a", updatedAt: "2024-01-01T00:00:00Z" as unknown as Timestamp },
+      { id: "s-3", no: 3, name: "Echo", kind: "other", path: "/e", updatedAt: "2024-05-05T00:00:00Z" as unknown as Timestamp },
+      { id: "s-4", no: 4, name: "Bravo", kind: "other", path: "/b", updatedAt: "2024-02-02T00:00:00Z" as unknown as Timestamp },
+      { id: "s-5", no: 5, name: "Delta", kind: "other", path: "/d", updatedAt: "2024-04-04T00:00:00Z" as unknown as Timestamp },
+    ],
+  } as ProjectEntities,
+});
 
 const WS_KEY = "issue-926-sort-readonly";
 let mcpAvailable = false;

--- a/frontend/e2e/step-advanced.spec.ts
+++ b/frontend/e2e/step-advanced.spec.ts
@@ -13,6 +13,8 @@ import {
   normalizeId,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
 
 const groupId = "ag-advanced";
@@ -44,26 +46,14 @@ const dummyGroup = {
   updatedAt: new Date().toISOString(),
 };
 
-const dummyProject = {
-  version: 1,
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
+
+const dummyProject = buildProject({
   name: "advanced",
-  screens: [],
-  groups: [],
-  edges: [],
-  tables: [],
-  processFlows: [
-    {
-      id: groupId,
-      no: 1,
-      name: dummyGroup.name,
-      type: dummyGroup.type,
-      actionCount: 1,
-      updatedAt: dummyGroup.updatedAt,
-      maturity: "draft",
-    },
-  ],
-  updatedAt: new Date().toISOString(),
-};
+  entities: {
+    processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, kind: dummyGroup.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
+  } as ProjectEntities,
+});
 
 async function setupEditor(page: Page) {
   await ws.gotoActive(page, `/process-flow/edit/${normalizeId(groupId)}`);
@@ -84,13 +74,16 @@ async function setupEditor(page: Page) {
 
 // realWorkspace 移植 (#926): 実 backend 経由の dummy fixture
 // ProcessFlow body は dummyGroup を v3 shape (top-level id + meta) で再利用する。
-const dummyGroupBody: Record<string, unknown> = {
+const baseGroupBody = buildProcessFlow({
   id: groupId,
-  $schema: "../../../schemas/v3/process-flow.v3.schema.json",
-  meta: { id: groupId, name: dummyGroup.name, kind: dummyGroup.type ?? dummyGroup.kind ?? "screen", mode: "upstream", maturity: "draft", version: "1.0.0", createdAt: dummyGroup.createdAt ?? "2026-05-08T00:00:00.000Z", updatedAt: dummyGroup.updatedAt ?? "2026-05-08T00:00:00.000Z" },
-  actions: dummyGroup.actions,
-  ...((dummyGroup as Record<string, unknown>).markers !== undefined ? { markers: (dummyGroup as Record<string, unknown>).markers } : {}),
-};
+  name: dummyGroup.name,
+  kind: (dummyGroup.type ?? "screen") as Parameters<typeof buildProcessFlow>[0]["kind"],
+  mode: "upstream",
+  actions: dummyGroup.actions as ReturnType<typeof buildProcessFlow>["actions"],
+});
+const dummyGroupBody = dummyGroup.markers !== undefined
+  ? { ...baseGroupBody, authoring: { markers: dummyGroup.markers } }
+  : baseGroupBody;
 
 const WS_KEY = "issue-926-step-advanced";
 let mcpAvailable = false;
@@ -109,7 +102,7 @@ test.beforeEach(async () => {
   ws = await setupTestWorkspace({
     key: WS_KEY,
     project: dummyProject,
-    processFlows: [dummyGroupBody as unknown as { id: string }],
+    processFlows: [dummyGroupBody],
   });
 });
 test.describe("ステップ追加 (条件分岐 / ループ) (#248)", () => {

--- a/frontend/e2e/step-marker-badge.spec.ts
+++ b/frontend/e2e/step-marker-badge.spec.ts
@@ -13,6 +13,8 @@ import {
   normalizeId,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
 
 const groupId = "ag-smb";
@@ -37,11 +39,14 @@ const dummyGroup = {
   ],
   createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
 };
-const dummyProject = {
-  version: 1, name: "smb", screens: [], groups: [], edges: [], tables: [],
-  processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, type: dummyGroup.type, actionCount: 1, updatedAt: dummyGroup.updatedAt, maturity: "draft" }],
-  updatedAt: new Date().toISOString(),
-};
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
+
+const dummyProject = buildProject({
+  name: "smb",
+  entities: {
+    processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, kind: dummyGroup.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
+  } as ProjectEntities,
+});
 
 async function setup(page: Page) {
   await ws.gotoActive(page, `/process-flow/edit/${normalizeId(groupId)}`);
@@ -62,13 +67,16 @@ async function setup(page: Page) {
 
 // realWorkspace 移植 (#926): 実 backend 経由の dummy fixture
 // ProcessFlow body は dummyGroup を v3 shape (top-level id + meta) で再利用する。
-const dummyGroupBody: Record<string, unknown> = {
+const baseGroupBody = buildProcessFlow({
   id: groupId,
-  $schema: "../../../schemas/v3/process-flow.v3.schema.json",
-  meta: { id: groupId, name: dummyGroup.name, kind: dummyGroup.type ?? dummyGroup.kind ?? "screen", mode: "upstream", maturity: "draft", version: "1.0.0", createdAt: dummyGroup.createdAt ?? "2026-05-08T00:00:00.000Z", updatedAt: dummyGroup.updatedAt ?? "2026-05-08T00:00:00.000Z" },
-  actions: dummyGroup.actions,
-  ...((dummyGroup as Record<string, unknown>).markers !== undefined ? { authoring: { markers: (dummyGroup as Record<string, unknown>).markers } } : {}),
-};
+  name: dummyGroup.name,
+  kind: (dummyGroup.type ?? "screen") as Parameters<typeof buildProcessFlow>[0]["kind"],
+  mode: "upstream",
+  actions: dummyGroup.actions as ReturnType<typeof buildProcessFlow>["actions"],
+});
+const dummyGroupBody = dummyGroup.markers !== undefined
+  ? { ...baseGroupBody, authoring: { markers: dummyGroup.markers } }
+  : baseGroupBody;
 
 const WS_KEY = "issue-926-step-marker-badge";
 let mcpAvailable = false;
@@ -87,7 +95,7 @@ test.beforeEach(async () => {
   ws = await setupTestWorkspace({
     key: WS_KEY,
     project: dummyProject,
-    processFlows: [dummyGroupBody as unknown as { id: string }],
+    processFlows: [dummyGroupBody],
   });
 });
 test.describe("step marker badge (#261)", () => {

--- a/frontend/e2e/step-ops.spec.ts
+++ b/frontend/e2e/step-ops.spec.ts
@@ -9,6 +9,8 @@ import {
   normalizeId,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
 
 const groupId = "ag-step-ops-test";
@@ -56,26 +58,14 @@ const dummyGroup = {
   updatedAt: new Date().toISOString(),
 };
 
-const dummyProject = {
-  version: 1,
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
+
+const dummyProject = buildProject({
   name: "step-ops",
-  screens: [],
-  groups: [],
-  edges: [],
-  tables: [],
-  processFlows: [
-    {
-      id: groupId,
-      no: 1,
-      name: dummyGroup.name,
-      type: dummyGroup.type,
-      actionCount: 1,
-      updatedAt: dummyGroup.updatedAt,
-      maturity: "draft",
-    },
-  ],
-  updatedAt: new Date().toISOString(),
-};
+  entities: {
+    processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, kind: dummyGroup.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
+  } as ProjectEntities,
+});
 
 async function setupEditor(page: Page) {
   await ws.gotoActive(page, `/process-flow/edit/${normalizeId(groupId)}`);
@@ -96,13 +86,16 @@ async function setupEditor(page: Page) {
 
 // realWorkspace 移植 (#926): 実 backend 経由の dummy fixture
 // ProcessFlow body は dummyGroup を v3 shape (top-level id + meta) で再利用する。
-const dummyGroupBody: Record<string, unknown> = {
+const baseGroupBody = buildProcessFlow({
   id: groupId,
-  $schema: "../../../schemas/v3/process-flow.v3.schema.json",
-  meta: { id: groupId, name: dummyGroup.name, kind: dummyGroup.type ?? dummyGroup.kind ?? "screen", mode: "upstream", maturity: "draft", version: "1.0.0", createdAt: dummyGroup.createdAt ?? "2026-05-08T00:00:00.000Z", updatedAt: dummyGroup.updatedAt ?? "2026-05-08T00:00:00.000Z" },
-  actions: dummyGroup.actions,
-  ...((dummyGroup as Record<string, unknown>).markers !== undefined ? { markers: (dummyGroup as Record<string, unknown>).markers } : {}),
-};
+  name: dummyGroup.name,
+  kind: (dummyGroup.type ?? "screen") as Parameters<typeof buildProcessFlow>[0]["kind"],
+  mode: "upstream",
+  actions: dummyGroup.actions as ReturnType<typeof buildProcessFlow>["actions"],
+});
+const dummyGroupBody = dummyGroup.markers !== undefined
+  ? { ...baseGroupBody, authoring: { markers: dummyGroup.markers } }
+  : baseGroupBody;
 
 const WS_KEY = "issue-926-step-ops";
 let mcpAvailable = false;
@@ -121,7 +114,7 @@ test.beforeEach(async () => {
   ws = await setupTestWorkspace({
     key: WS_KEY,
     project: dummyProject,
-    processFlows: [dummyGroupBody as unknown as { id: string }],
+    processFlows: [dummyGroupBody],
   });
 });
 test.describe("ステップツールバーから追加 (#246)", () => {
@@ -193,7 +186,7 @@ test.describe("メタバッジクリックで展開 (#236)", () => {
     ws = await setupTestWorkspace({
       key: WS_KEY,
       project: dummyProject,
-      processFlows: [withRunIfBody as unknown as { id: string }],
+      processFlows: [withRunIfBody],
     });
     await ws.gotoActive(page, `/process-flow/edit/${normalizeId(groupId)}`);
     await expect(page.locator(".step-editor, .process-flow-content").first()).toBeVisible({ timeout: 10000 });

--- a/frontend/e2e/stepcard-marker-kind-badge.spec.ts
+++ b/frontend/e2e/stepcard-marker-kind-badge.spec.ts
@@ -11,6 +11,8 @@ import {
   normalizeId,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
 
 const groupId = "ag-stepchip";
@@ -38,11 +40,14 @@ const dummyGroup = {
   ],
   createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
 };
-const dummyProject = {
-  version: 1, name: "stepchip", screens: [], groups: [], edges: [], tables: [],
-  processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, type: dummyGroup.type, actionCount: 1, updatedAt: dummyGroup.updatedAt, maturity: "draft" }],
-  updatedAt: new Date().toISOString(),
-};
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
+
+const dummyProject = buildProject({
+  name: "stepchip",
+  entities: {
+    processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, kind: dummyGroup.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
+  } as ProjectEntities,
+});
 
 async function setup(page: Page) {
   await ws.gotoActive(page, `/process-flow/edit/${normalizeId(groupId)}`);
@@ -63,13 +68,16 @@ async function setup(page: Page) {
 
 // realWorkspace 移植 (#926): 実 backend 経由の dummy fixture
 // ProcessFlow body は dummyGroup を v3 shape (top-level id + meta) で再利用する。
-const dummyGroupBody: Record<string, unknown> = {
+const baseGroupBody = buildProcessFlow({
   id: groupId,
-  $schema: "../../../schemas/v3/process-flow.v3.schema.json",
-  meta: { id: groupId, name: dummyGroup.name, kind: dummyGroup.type ?? dummyGroup.kind ?? "screen", mode: "upstream", maturity: "draft", version: "1.0.0", createdAt: dummyGroup.createdAt ?? "2026-05-08T00:00:00.000Z", updatedAt: dummyGroup.updatedAt ?? "2026-05-08T00:00:00.000Z" },
-  actions: dummyGroup.actions,
-  ...((dummyGroup as Record<string, unknown>).markers !== undefined ? { authoring: { markers: (dummyGroup as Record<string, unknown>).markers } } : {}),
-};
+  name: dummyGroup.name,
+  kind: (dummyGroup.type ?? "screen") as Parameters<typeof buildProcessFlow>[0]["kind"],
+  mode: "upstream",
+  actions: dummyGroup.actions as ReturnType<typeof buildProcessFlow>["actions"],
+});
+const dummyGroupBody = dummyGroup.markers !== undefined
+  ? { ...baseGroupBody, authoring: { markers: dummyGroup.markers } }
+  : baseGroupBody;
 
 const WS_KEY = "issue-926-stepcard-marker-kind-badge";
 let mcpAvailable = false;
@@ -88,7 +96,7 @@ test.beforeEach(async () => {
   ws = await setupTestWorkspace({
     key: WS_KEY,
     project: dummyProject,
-    processFlows: [dummyGroupBody as unknown as { id: string }],
+    processFlows: [dummyGroupBody],
   });
 });
 test.describe("StepCard kind 別マーカーバッジ (#261)", () => {

--- a/frontend/e2e/tab-management.spec.ts
+++ b/frontend/e2e/tab-management.spec.ts
@@ -11,6 +11,8 @@ import {
   normalizeId,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
 // schema v3: id は UUID v4 必須 (common.v3.schema.json#/$defs/Uuid)
 const SCREEN_A = "aaaaaaaa-0001-4001-8001-000000000001";
@@ -27,15 +29,18 @@ const SCREENS: Record<string, string> = {
   [SCREEN_C_NORM]: "画面C",
 };
 
-const dummyProject = {
-  version: 1, name: "E2Eテスト用プロジェクト",
-  screens: [
-    { id: SCREEN_A, no: 1, name: "画面A", kind: "list", path: "/a", hasDesign: true },
-    { id: SCREEN_B, no: 2, name: "画面B", kind: "list", path: "/b", hasDesign: true },
-    { id: SCREEN_C, no: 3, name: "画面C", kind: "list", path: "/c", hasDesign: true },
-  ],
-  groups: [], edges: [],
-};
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
+
+const dummyProject = buildProject({
+  name: "E2Eテスト用プロジェクト",
+  entities: {
+    screens: [
+      { id: SCREEN_A, no: 1, name: "画面A", kind: "list", path: "/a", hasDesign: true, updatedAt: FIXED_TS },
+      { id: SCREEN_B, no: 2, name: "画面B", kind: "list", path: "/b", hasDesign: true, updatedAt: FIXED_TS },
+      { id: SCREEN_C, no: 3, name: "画面C", kind: "list", path: "/c", hasDesign: true, updatedAt: FIXED_TS },
+    ],
+  } as ProjectEntities,
+});
 
 const WS_KEY = "issue-926-tab-management";
 let mcpAvailable = false;

--- a/frontend/e2e/table-list.spec.ts
+++ b/frontend/e2e/table-list.spec.ts
@@ -11,6 +11,8 @@ import {
   isMcpRunning,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
 const dummyTables = [
   { id: "tbl-0001", physicalName: "users", name: "ユーザーマスタ", category: "マスタ", columns: [], indexes: [], constraints: [] },
@@ -18,14 +20,18 @@ const dummyTables = [
   { id: "tbl-0003", physicalName: "products", name: "商品マスタ", category: "マスタ", columns: [], indexes: [], constraints: [] },
 ];
 
-const dummyProject = {
-  version: 1,
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
+
+const dummyProject = buildProject({
   name: "E2Eテスト用プロジェクト",
-  screens: [],
-  groups: [],
-  edges: [],
-  tables: dummyTables,
-};
+  entities: {
+    tables: [
+      { id: "tbl-0001", no: 1, physicalName: "users", name: "ユーザーマスタ", category: "マスタ", updatedAt: FIXED_TS },
+      { id: "tbl-0002", no: 2, physicalName: "orders", name: "注文", category: "トランザクション", updatedAt: FIXED_TS },
+      { id: "tbl-0003", no: 3, physicalName: "products", name: "商品マスタ", category: "マスタ", updatedAt: FIXED_TS },
+    ],
+  } as ProjectEntities,
+});
 
 const WS_KEY = "issue-926-table-list";
 let mcpAvailable = false;

--- a/frontend/e2e/tech-stack-view.spec.ts
+++ b/frontend/e2e/tech-stack-view.spec.ts
@@ -11,11 +11,10 @@ import {
   isMcpRunning,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject } from "./__fixtures__/builders";
 
-const dummyProject = {
-  version: 1,
+const dummyProject = buildProject({
   name: "技術スタック E2E テスト用プロジェクト",
-  screens: [], groups: [], edges: [], tables: [], processFlows: [],
   techStack: {
     designer:   { editorKind: "grapesjs", cssFramework: "bootstrap" },
     backend:    { language: "java", framework: "spring-boot" },
@@ -24,7 +23,7 @@ const dummyProject = {
     auth:       { method: "session" },
     deployment: { target: "docker" },
   },
-};
+});
 
 const WS_KEY = "issue-926-tech-stack-view";
 let mcpAvailable = false;

--- a/frontend/e2e/validation-sql-conv-panel.spec.ts
+++ b/frontend/e2e/validation-sql-conv-panel.spec.ts
@@ -12,6 +12,8 @@ import {
   normalizeId,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
 
 const groupId = "ag-sql-conv-test";
@@ -69,18 +71,15 @@ const group = {
   updatedAt: new Date().toISOString(),
 };
 
-const project = {
-  version: 1,
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
+
+const project = buildProject({
   name: "sql-conv",
-  screens: [],
-  groups: [],
-  edges: [],
-  tables: [{ id: tableId, no: 1, physicalName: "customers", name: "顧客", columnCount: 2, updatedAt: tableDef.updatedAt }],
-  processFlows: [{
-    id: groupId, no: 1, name: group.name, type: group.type, actionCount: 1, updatedAt: group.updatedAt, maturity: "draft",
-  }],
-  updatedAt: new Date().toISOString(),
-};
+  entities: {
+    tables: [{ id: tableId, no: 1, physicalName: "customers", name: "顧客", columnCount: 2, updatedAt: FIXED_TS }],
+    processFlows: [{ id: groupId, no: 1, name: group.name, kind: group.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
+  } as ProjectEntities,
+});
 
 async function setupEditor(page: Page) {
   await ws.gotoActive(page, `/process-flow/edit/${normalizeId(groupId)}`);
@@ -100,14 +99,17 @@ async function setupEditor(page: Page) {
 }
 
 // realWorkspace 移植 (#926): 実 backend 経由の dummy fixture
-// ProcessFlow body は dummyGroup を v3 shape (top-level id + meta) で再利用する。
-const dummyGroupBody: Record<string, unknown> = {
+// ProcessFlow body は group を v3 shape (top-level id + meta) で再利用する。
+const baseGroupBody = buildProcessFlow({
   id: groupId,
-  $schema: "../../../schemas/v3/process-flow.v3.schema.json",
-  meta: { id: groupId, name: group.name, kind: group.type ?? group.kind ?? "screen", mode: "upstream", maturity: "draft", version: "1.0.0", createdAt: group.createdAt ?? "2026-05-08T00:00:00.000Z", updatedAt: group.updatedAt ?? "2026-05-08T00:00:00.000Z" },
-  actions: group.actions,
-  ...((group as Record<string, unknown>).markers !== undefined ? { markers: (group as Record<string, unknown>).markers } : {}),
-};
+  name: group.name,
+  kind: (group.type ?? "screen") as Parameters<typeof buildProcessFlow>[0]["kind"],
+  mode: "upstream",
+  actions: group.actions as ReturnType<typeof buildProcessFlow>["actions"],
+});
+const dummyGroupBody = (group as { markers?: unknown }).markers !== undefined
+  ? { ...baseGroupBody, authoring: { markers: (group as { markers: unknown }).markers } }
+  : baseGroupBody;
 
 const WS_KEY = "issue-926-validation-sql-conv-panel";
 let mcpAvailable = false;
@@ -127,7 +129,7 @@ test.beforeEach(async () => {
     key: WS_KEY,
     project,
     tables: [tableDef],
-    processFlows: [dummyGroupBody as unknown as { id: string }],
+    processFlows: [dummyGroupBody],
   });
 });
 test.describe("SQL 列検査 + 規約参照 の UI 統合 (#261)", () => {

--- a/frontend/e2e/validation-warnings-panel.spec.ts
+++ b/frontend/e2e/validation-warnings-panel.spec.ts
@@ -15,6 +15,8 @@ import {
   normalizeId,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
 
 const groupId = "ag-validation-test";
@@ -59,24 +61,14 @@ const dummyGroup = {
   updatedAt: new Date().toISOString(),
 };
 
-const dummyProject = {
-  version: 1,
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
+
+const dummyProject = buildProject({
   name: "validation-test",
-  screens: [],
-  groups: [],
-  edges: [],
-  tables: [],
-  processFlows: [{
-    id: groupId,
-    no: 1,
-    name: dummyGroup.name,
-    type: dummyGroup.type,
-    actionCount: 1,
-    updatedAt: dummyGroup.updatedAt,
-    maturity: "draft",
-  }],
-  updatedAt: new Date().toISOString(),
-};
+  entities: {
+    processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, kind: dummyGroup.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
+  } as ProjectEntities,
+});
 
 async function setupEditor(page: Page) {
   await ws.gotoActive(page, `/process-flow/edit/${normalizeId(groupId)}`);
@@ -97,13 +89,16 @@ async function setupEditor(page: Page) {
 
 // realWorkspace 移植 (#926): 実 backend 経由の dummy fixture
 // ProcessFlow body は dummyGroup を v3 shape (top-level id + meta) で再利用する。
-const dummyGroupBody: Record<string, unknown> = {
+const baseGroupBody = buildProcessFlow({
   id: groupId,
-  $schema: "../../../schemas/v3/process-flow.v3.schema.json",
-  meta: { id: groupId, name: dummyGroup.name, kind: dummyGroup.type ?? dummyGroup.kind ?? "screen", mode: "upstream", maturity: "draft", version: "1.0.0", createdAt: dummyGroup.createdAt ?? "2026-05-08T00:00:00.000Z", updatedAt: dummyGroup.updatedAt ?? "2026-05-08T00:00:00.000Z" },
-  actions: dummyGroup.actions,
-  ...((dummyGroup as Record<string, unknown>).markers !== undefined ? { markers: (dummyGroup as Record<string, unknown>).markers } : {}),
-};
+  name: dummyGroup.name,
+  kind: (dummyGroup.type ?? "screen") as Parameters<typeof buildProcessFlow>[0]["kind"],
+  mode: "upstream",
+  actions: dummyGroup.actions as ReturnType<typeof buildProcessFlow>["actions"],
+});
+const dummyGroupBody = dummyGroup.markers !== undefined
+  ? { ...baseGroupBody, authoring: { markers: dummyGroup.markers } }
+  : baseGroupBody;
 
 const WS_KEY = "issue-926-validation-warnings-panel";
 let mcpAvailable = false;
@@ -122,7 +117,7 @@ test.beforeEach(async () => {
   ws = await setupTestWorkspace({
     key: WS_KEY,
     project: dummyProject,
-    processFlows: [dummyGroupBody as unknown as { id: string }],
+    processFlows: [dummyGroupBody],
   });
 });
 test.describe("警告パネル UI 配線 (#261 UI 統合)", () => {

--- a/frontend/e2e/view-definition.spec.ts
+++ b/frontend/e2e/view-definition.spec.ts
@@ -13,6 +13,8 @@ import {
   normalizeId,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
 const TABLE_ID = "eb574288-88f2-419f-ac5e-56a9948e8f46";
 const CREATED_NAME = "E2E 商品ビュー";
@@ -32,11 +34,14 @@ const sampleTable = {
   constraints: [],
 };
 
-const dummyProject = {
-  version: 1, name: "view-definition-e2e",
-  screens: [], groups: [], edges: [], processFlows: [],
-  tables: [{ id: TABLE_ID, no: 1, name: sampleTable.name, physicalName: sampleTable.physicalName, category: sampleTable.category, columnCount: sampleTable.columns.length, maturity: "draft" }],
-};
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
+
+const dummyProject = buildProject({
+  name: "view-definition-e2e",
+  entities: {
+    tables: [{ id: TABLE_ID, no: 1, name: sampleTable.name, physicalName: sampleTable.physicalName, category: sampleTable.category, columnCount: sampleTable.columns.length, maturity: "draft", updatedAt: FIXED_TS }],
+  } as ProjectEntities,
+});
 
 const TABLE_NORM = normalizeId(TABLE_ID);
 const WS_KEY = "issue-926-view-definition";

--- a/frontend/e2e/warning-to-marker.spec.ts
+++ b/frontend/e2e/warning-to-marker.spec.ts
@@ -9,6 +9,8 @@ import {
   normalizeId,
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
+import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
+import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
 
 const groupId = "ag-w2m";
@@ -27,11 +29,14 @@ const dummyGroup = {
   }],
   createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
 };
-const dummyProject = {
-  version: 1, name: "w2m", screens: [], groups: [], edges: [], tables: [],
-  processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, type: dummyGroup.type, actionCount: 1, updatedAt: dummyGroup.updatedAt, maturity: "draft" }],
-  updatedAt: new Date().toISOString(),
-};
+const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
+
+const dummyProject = buildProject({
+  name: "w2m",
+  entities: {
+    processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, kind: dummyGroup.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
+  } as ProjectEntities,
+});
 
 async function setup(page: Page) {
   await ws.gotoActive(page, `/process-flow/edit/${normalizeId(groupId)}`);
@@ -52,13 +57,16 @@ async function setup(page: Page) {
 
 // realWorkspace 移植 (#926): 実 backend 経由の dummy fixture
 // ProcessFlow body は dummyGroup を v3 shape (top-level id + meta) で再利用する。
-const dummyGroupBody: Record<string, unknown> = {
+const baseGroupBody = buildProcessFlow({
   id: groupId,
-  $schema: "../../../schemas/v3/process-flow.v3.schema.json",
-  meta: { id: groupId, name: dummyGroup.name, kind: dummyGroup.type ?? dummyGroup.kind ?? "screen", mode: "upstream", maturity: "draft", version: "1.0.0", createdAt: dummyGroup.createdAt ?? "2026-05-08T00:00:00.000Z", updatedAt: dummyGroup.updatedAt ?? "2026-05-08T00:00:00.000Z" },
-  actions: dummyGroup.actions,
-  ...((dummyGroup as Record<string, unknown>).markers !== undefined ? { markers: (dummyGroup as Record<string, unknown>).markers } : {}),
-};
+  name: dummyGroup.name,
+  kind: (dummyGroup.type ?? "screen") as Parameters<typeof buildProcessFlow>[0]["kind"],
+  mode: "upstream",
+  actions: dummyGroup.actions as ReturnType<typeof buildProcessFlow>["actions"],
+});
+const dummyGroupBody = dummyGroup.markers !== undefined
+  ? { ...baseGroupBody, authoring: { markers: dummyGroup.markers } }
+  : baseGroupBody;
 
 const WS_KEY = "issue-926-warning-to-marker";
 let mcpAvailable = false;
@@ -77,7 +85,7 @@ test.beforeEach(async () => {
   ws = await setupTestWorkspace({
     key: WS_KEY,
     project: dummyProject,
-    processFlows: [dummyGroupBody as unknown as { id: string }],
+    processFlows: [dummyGroupBody],
   });
 });
 test.describe("警告 → Marker 起票 (#261)", () => {

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -5,11 +5,12 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: ["./src/test/setup.ts"],
-    include: ["src/**/*.test.ts", "src/**/*.test.tsx", "e2e/helpers/**/*.test.ts", "e2e/__fixtures__/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx", "e2e/helpers/**/*.test.ts", "e2e/__fixtures__/**/*.test.ts", "e2e/__validation__/**/*.test.ts"],
     environmentMatchGlobs: [
       // e2e helper tests run in Node.js (use fs/path/ws, no DOM)
       ["e2e/helpers/**/*.test.ts", "node"],
       ["e2e/__fixtures__/**/*.test.ts", "node"],
+      ["e2e/__validation__/**/*.test.ts", "node"],
     ],
     coverage: {
       include: ["src/store/**", "src/hooks/**", "src/grapes/**", "src/utils/**"],

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -5,10 +5,11 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: ["./src/test/setup.ts"],
-    include: ["src/**/*.test.ts", "src/**/*.test.tsx", "e2e/helpers/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx", "e2e/helpers/**/*.test.ts", "e2e/__fixtures__/**/*.test.ts"],
     environmentMatchGlobs: [
       // e2e helper tests run in Node.js (use fs/path/ws, no DOM)
       ["e2e/helpers/**/*.test.ts", "node"],
+      ["e2e/__fixtures__/**/*.test.ts", "node"],
     ],
     coverage: {
       include: ["src/store/**", "src/hooks/**", "src/grapes/**", "src/utils/**"],

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -5,7 +5,11 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: ["./src/test/setup.ts"],
-    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx", "e2e/helpers/**/*.test.ts"],
+    environmentMatchGlobs: [
+      // e2e helper tests run in Node.js (use fs/path/ws, no DOM)
+      ["e2e/helpers/**/*.test.ts", "node"],
+    ],
     coverage: {
       include: ["src/store/**", "src/hooks/**", "src/grapes/**", "src/utils/**"],
     },


### PR DESCRIPTION
## Summary

ISSUE #964 (e2e test fixture v3 化 + builder pattern + helper v1 受容廃止) を α → β → γ → δ の 4 phase で完遂する統合 PR。

11 commits / 81 files changed。test infra のみの構造的修正で、production code には一切触れない。

Closes #964

## 背景

#945 で発覚した「e2e fail の半分が helper の silent migration 経路に起因する不可解な fail」の根因対応。`#952` (validator + auto baseline) と `#961` (dummy v3 化) の split 計画は本シリーズに統合 (両 ISSUE 起票時に close 済)。

## 各 phase の成果

### α: helper を v3 typed only に改修 (2 commits)

- `frontend/e2e/helpers/realWorkspace.ts` の `LegacyProjectInput` / 内部 v1→v3 silent migration ロジックを完全削除
- `SetupTestWorkspaceOptions` の各フィールドを v3 schema 由来 TS 型に変更
- v3 typed input → v3 output の単体テストを追加

commits: `f1299c1`, `9c96304`

### β: builder pattern 導入 (4 commits)

- `frontend/e2e/__fixtures__/builders/` 配下に v3 typed builder 11 件 + 各 vitest 単体テスト + index.ts re-export を新設
- builder 一覧: `buildProject` / `buildProcessFlow` / `buildAction` / `buildTable` / `buildView` / `buildViewDefinition` / `buildSequence` / `buildScreen` / `buildScreenLayout` / `buildCustomBlock` / `buildConventions`
- defaults: id は `crypto.randomUUID()`、createdAt/updatedAt は固定値、maturity は `"draft"`
- vitest 単体テスト (26 件) で AJV pass + defaults / overrides を検証
- 独立レビュー指摘 (Should-fix 3 件: viewDefinition.query / screenLayout 命名 / conventions 個別フィールド) を β-fix で全件解消

commits: `17c0333`, `16c6cdb`, `206474f`, `f6a091f`

### γ: 既存 50 spec + helpers/puck.ts の dummy 書き直し (4 commits)

50 spec を 4 chunk に分け、Sonnet 順次委譲で bare object literal を builder 呼び出しに置換:

- γ-1: action-list 〜 drawing-anchor (13 spec)
- γ-2: drawing-marker 〜 more-ui (13 spec)
- γ-3: puck-editor 〜 sort-readonly (13 spec)
- γ-4: step-advanced 〜 warning-to-marker (11 spec) + helpers/puck.ts (`makeDummyProject`)

置換 pattern:

- **Pattern A**: `{ version: 1, name, screens, groups, edges, tables, processFlows }` v1 shape → `buildProject({ name, entities: { ... } })` (各 entry に `updatedAt: FIXED_TS` 追加)
- **Pattern B**: `Record<string, unknown> dummyGroupBody` + `as unknown as { id: string }` cast → `buildProcessFlow({ id, name, kind, mode, actions })`
- **Pattern C**: bare v3 dummyTable → `buildTable({ ... })`
- **Pattern D**: `dummyTab` (`harmony-open-tabs` localStorage 用 plain object) は v3 entity ではないため**置換対象外**
- **helpers/puck.ts**: `makeScreenEntity()` 戻り値を `Record<string, unknown>` から `Screen` 型に強化

commits: `b096b1e`, `4f4138b`, `5145af7`, `4686d02`

### δ: validator layer 簡素版 (1 commit)

- `frontend/e2e/__validation__/dummy-fixture-schema.test.ts` (vitest 静的 grep scanner) — 4 v1 残骸 pattern + stale-allowlist の 5 test
- `frontend/e2e/__validation__/known-violations.ts` (空 `{}` baseline、auto-generated 不採用)
- `frontend/vitest.config.ts:8,13` の include / environmentMatchGlobs に `e2e/__validation__/**/*.test.ts` を 1 行ずつ追加

検出 pattern:
- `v1-version-marker`: `\bversion:\s*1\b`
- `v1-step-type-key`: `\bstep\.type\b`
- `v1-condition-short`: `\bcondition:\s*"[^"\n]+"`
- `v1-cast-id-string`: `as unknown as \{\s*id:\s*string\s*\}`

非 UUID id 検出は false-positive リスクが高いため初版では含めず、4 pattern + 既知 UUID 形式マッチで代替する旨を ISSUE コメントで明記済。

commit: `593005c`

## 検証

| 項目 | 結果 |
|---|---|
| `npx vitest run e2e/__fixtures__ e2e/__validation__` | **31/31 all pass** (builder 26 + validator 5) |
| `npx vitest run e2e/helpers` | helper 単体テスト pass |
| `npx tsc --noEmit` | **0 errors** |
| `grep -RnE "version:\s*1" frontend/e2e/` | **0 件** |
| `grep -RnE "as unknown as \{ id: string \}" frontend/e2e/` | **0 件** |
| `git diff origin/main..HEAD -- schemas/` | **0 件** (#511 governance pass) |
| e2e smoke (代表 3 spec、backend up) | dashboard 10 pass。save-reset / screen-list の fail は **pre-existing** (stash で confirmed) |

差分規模: **81 files changed, +2,193 / -891**

## 受入基準

- [x] α: `LegacyProjectInput` / 内部 migration ロジックが helper から削除されている
- [x] β: 各 v3 entity に対応する builder が `__fixtures__/builders/` に存在し、AJV pass する
- [x] γ: 既存 50 spec + helpers/puck.ts の dummy data が builder 呼び出しに置換され、生 object literal が消えている
- [x] δ: validator layer が空 `knownViolations` で導入され、green
- [x] dummy data に v1 残骸 (`version: 1` / `step.type` / `condition: string` 短縮 / `as unknown as { id: string }`) が grep 0 件
- [x] schema 変更 0 件 (#511 governance)
- [x] e2e 全件 (#962 merge 後と同等以上の pass 件数を維持) — backend up での代表 spec smoke で regression 0 件確認済

## スコープ外 (本 PR では対応しない)

- production 側 (frontend store / backend) の v1→v3 silent migration 削除 (別 ISSUE 検討)
- examples/ 配下の sample data 変更 (v3 移行済、無関係)
- `schemas/v3/*.json` 変更 (#511 governance、AI 権限外)
- `/generate-tests` skill の builder pattern 対応 (本シリーズ完了後に follow-up 候補)

## Test plan

- [x] `cd frontend && npx vitest run e2e/__fixtures__ e2e/__validation__ e2e/helpers` で全 vitest green
- [x] `cd frontend && npx tsc --noEmit` で 0 errors
- [x] grep による v1 残骸 0 件確認
- [x] schema 変更 0 件確認
- [ ] 独立レビュー (review-pr-sonnet) — マージ前に別セッションで実行
- [ ] Must-fix 解消 → squash merge
