### PR TITLE
fix(designer): 破損データ起動時の recordError 呼び出し復活 (#953)

### DIFF
--- a/frontend/e2e/designer-corrupt-data.spec.ts
+++ b/frontend/e2e/designer-corrupt-data.spec.ts
@@ -88,15 +88,31 @@ test.describe("Designer 破損データ耐性 (#131)", () => {
     await expect(page.getByTestId("edit-mode-start")).toBeVisible({ timeout: 15000 });
   });
 
-  // TODO(#953): Designer の破損データ検知 → errorLog 記録 経路は
-  // edit-session-draft (#683) の refactor 過程で失われた。実装側で `recordError`
-  // 呼び出しを復活させる必要あり (#953 で対応)。
-  // 現状は edit-mode-start が出ること (= Designer 起動成功) のみで担保。
-  test.skip("破損データ起動時に errorLog に痕跡が残る (#953 follow-up)", async ({ page }) => {
+  // #953: Designer の破損データ検知 → errorLog 記録 を復活。
+  // 復活ポイントは Designer.tsx の grapesDraftRead (= backend.load の入口) で、
+  // 空 / pages 欠落データを検知した時点で recordError() を呼ぶ。
+  // edit-mode-start visible 時点 (= setGrapesState 後) には localStorage に書き込み済み。
+  test("破損データ起動時に errorLog に痕跡が残る (#953 follow-up)", async ({ page }) => {
     const key = `${WS_KEY_PREFIX}-errorlog`;
     wsKeys.push(key);
     await setupDesignerWithRawData(page, {}, key);
     await expect(page.getByTestId("edit-mode-start")).toBeVisible({ timeout: 15000 });
+
+    // recordError が呼ばれるまで polling 待機 (race-safe)
+    await page.waitForFunction(
+      () => {
+        const raw = localStorage.getItem("designer-error-log");
+        if (!raw) return false;
+        try {
+          const log = JSON.parse(raw) as Array<{ message: string }>;
+          return Array.isArray(log) && log.length > 0;
+        } catch {
+          return false;
+        }
+      },
+      undefined,
+      { timeout: 10000 },
+    );
 
     const log = await page.evaluate(() => {
       const raw = localStorage.getItem("designer-error-log");

--- a/frontend/src/components/Designer.tsx
+++ b/frontend/src/components/Designer.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { checkLegacyLocalStorage, executeRescue, clearLegacyLocalStorage } from "../grapes/legacyLocalStorageRescue";
 import { acknowledgeServerMtime } from "../utils/serverMtime";
+import { recordError } from "../utils/errorLog";
 import { DesignSubToolbar, DesignSubToolbarGrapesJSBridge } from "./design/DesignSubToolbar";
 import { ServerChangeBanner } from "./common/ServerChangeBanner";
 import { useErrorDialog } from "./common/ErrorDialogProvider";
@@ -243,7 +244,11 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
     isReadonlyRef.current = isReadonly;
   }, [isReadonly]);
 
-  // GrapesJS の draftRead — draft 優先 → 本体ファイル fallback (#815 PR-C: 明示 load)
+  // GrapesJS の draftRead — draft 優先 → 本体ファイル fallback (#815 PR-C: 明示 load)。
+  // 破損データ (空 object / pages 欠落) を検知したら errorLog に痕跡を残す (#953):
+  // GrapesJSEditorPane の ensureValidProject() でも recordError は呼ばれるが、
+  // そちらは onGjsReady (= GrapesJS init 完了後) のため timing 上 setGrapesState
+  // 後の UI 表示 (edit-mode-start visible) より遅い。本関数で早期検知する。
   const grapesDraftRead = useCallback(async (): Promise<unknown> => {
     try {
       const sessionsResult = await mcpBridge.request("editSession.list", { resourceType: "screen", resourceId: screenId }) as { sessions: Array<{ id: string }> } | null;
@@ -259,7 +264,26 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
     }
     try {
       const data = await mcpBridge.request("loadScreen", { screenId }) as Record<string, unknown> | null;
-      if (data && typeof data === "object" && Object.keys(data).length > 0) {
+      if (data && typeof data === "object") {
+        const keys = Object.keys(data);
+        if (keys.length === 0) {
+          // 空 object {} は破損データ扱い (#953)
+          recordError({
+            source: "manual",
+            message: `画面データが空のため、空のプロジェクトで起動します (screenId=${screenId})`,
+            context: { screenId, source: "designer/grapesDraftRead", keys: [] },
+          });
+          return null;
+        }
+        if (!Array.isArray(data.pages) || data.pages.length === 0) {
+          // pages 欠落データは破損扱いで起動継続するが痕跡を残す (#953)
+          recordError({
+            source: "manual",
+            message: `画面データの pages が欠落しています。デフォルト構造で補正しました (screenId=${screenId})`,
+            context: { screenId, source: "designer/grapesDraftRead", keys },
+          });
+          // 補正は ensureValidProject に任せて raw を返す (補正の単一責任化)
+        }
         return data;
       }
     } catch {


### PR DESCRIPTION
Closes #953

## 概要

#683 edit-session-draft refactor で実質呼ばれなくなった Designer 破損データ起動時の \`recordError\` 呼び出しを復活。

\`Designer.tsx\` の \`grapesDraftRead\` (= \`backend.load\` の入口) で空 \`{}\` / pages 欠落データを検知した時点で \`recordError\` を呼ぶ。\`setGrapesState\` 前に \`localStorage[\"designer-error-log\"]\` へ書き込み済み。

## 仕様逐条突合 (自己申告)

- [x] **受入 1**: Designer が pages 欠落 / 不正 design data を読み込んだ際に \`recordError({ source: \"manual\", message: \"画面データ...\" })\` を呼ぶ — \`frontend/src/components/Designer.tsx:265-282\`
- [x] **受入 2**: \`designer-corrupt-data.spec.ts:90\` の \`test.skip\` を解除し pass する — \`frontend/e2e/designer-corrupt-data.spec.ts:99\`
- [x] **受入 3**: 起動失敗にはせず、TabErrorFallback を回避しながらログだけ記録する — test 1/2/3 全 pass で確認

## 関連 ISSUE

- 親 ISSUE: #945 (e2e fail follow-up)

## 変更ファイル

- \`frontend/src/components/Designer.tsx\` — \`grapesDraftRead\` で破損データ検知 + \`recordError\` 呼出
- \`frontend/e2e/designer-corrupt-data.spec.ts\` — test.skip 解除 + \`waitForFunction\` で race-safe 待機

## テスト

- frontend e2e \`designer-corrupt-data.spec.ts\` 全 3 件 pass (4.3s)
- vitest \`remoteStorage.test.ts\` 7 件 pass

## schema 変更

なし (\`gh pr diff --name-only | grep schemas/\` 空、 #511 governance 遵守)

## UI 影響

なし (破損データ起動時のログ記録経路のみ、 通常 path への影響なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)