### PR TITLE
fix(step-card): branch.condition 判定を kind discriminator base に修正 (#954)

### DIFF
--- a/frontend/e2e/schema-ui.spec.ts
+++ b/frontend/e2e/schema-ui.spec.ts
@@ -233,12 +233,9 @@ test.describe("ValidationRule[] 編集 (#212)", () => {
 });
 
 test.describe("Branch.condition tryCatch variant (#224)", () => {
-  // TODO(#954): StepCard.tsx の branch.condition 表示が
-  // `typeof condition === "object"` で tryCatch UI を出す古い実装になっている。
-  // schema v3 では condition は常に object (kind discriminated union) のため、
-  // expression を含む全 object が tryCatch UI に倒れて盾アイコン (切替ボタン) が
-  // 出ない。`condition.kind === "tryCatch"` で判定する実装修正が必要 (#954 で対応)。
-  test.skip("盾アイコンで tryCatch 変換、元に戻せる (#954 follow-up: StepCard 判定修正待ち)", async ({ page }) => {
+  // #954: StepCard.tsx の branch.condition 判定を kind discriminator base に修正。
+  // `br.condition?.kind === "tryCatch"` で判定し、expression / tryCatch / 他 kind を分岐。
+  test("盾アイコンで tryCatch 変換、元に戻せる", async ({ page }) => {
     await setupEditor(page);
     const card = await expandStep(page, 3); // step-branch
     // branch-sections の存在を確認 (step.kind === "branch" 経路で出る)

--- a/frontend/src/components/process-flow/StepCard.tsx
+++ b/frontend/src/components/process-flow/StepCard.tsx
@@ -405,14 +405,14 @@ export function StepCard({
   const addBranch = () => {
     if (step.kind !== "branch") return;
     const code = String.fromCharCode(65 + step.branches.length);
-    const newBranch: Branch = { id: generateUUID(), code, condition: "", steps: [] };
+    const newBranch: Branch = { id: generateUUID(), code, condition: { kind: "expression", expression: "" }, steps: [] };
     onChange({ branches: [...step.branches, newBranch] } as Partial<Step>);
     onCommit?.();
   };
 
   const addElseBranch = () => {
     if (step.kind !== "branch") return;
-    const elseBranch: Branch = { id: generateUUID(), code: "ELSE", condition: "", steps: [] };
+    const elseBranch: Branch = { id: generateUUID(), code: "ELSE", condition: { kind: "expression", expression: "" }, steps: [] };
     onChange({ elseBranch } as Partial<Step>);
     onCommit?.();
   };
@@ -1399,7 +1399,7 @@ export function StepCard({
                               placeholder="errorCode (例: STOCK_SHORTAGE)"
                               onChange={(e) => setBranchAt(bi, {
                                 ...br,
-                                condition: { ...br.condition as { kind: "tryCatch"; errorCode: string; description?: string }, errorCode: e.target.value },
+                                condition: { ...br.condition, errorCode: e.target.value },
                               })}
                               onBlur={onCommit}
                             />

--- a/frontend/src/components/process-flow/StepCard.tsx
+++ b/frontend/src/components/process-flow/StepCard.tsx
@@ -1390,12 +1390,12 @@ export function StepCard({
                         onClick={() => toggleBranchCollapse(br.id)}
                       >
                         <span className="branch-code-badge">{br.code}</span>
-                        {typeof br.condition === "object" ? (
+                        {br.condition?.kind === "tryCatch" ? (
                           <div className="d-flex align-items-center gap-1 flex-grow-1" onClick={(e) => e.stopPropagation()}>
                             <span className="badge bg-info text-dark" style={{ fontSize: "0.7rem" }}>tryCatch</span>
                             <input
                               className="form-control form-control-sm"
-                              value={(br.condition as { kind: "tryCatch"; errorCode: string }).errorCode}
+                              value={br.condition.errorCode}
                               placeholder="errorCode (例: STOCK_SHORTAGE)"
                               onChange={(e) => setBranchAt(bi, {
                                 ...br,
@@ -1407,19 +1407,19 @@ export function StepCard({
                               type="button"
                               className="btn btn-sm btn-link text-muted p-0"
                               title="自由記述に戻す"
-                              onClick={() => setBranchAt(bi, { ...br, condition: "" })}
+                              onClick={() => setBranchAt(bi, { ...br, condition: { kind: "expression", expression: "" } })}
                             >
                               <i className="bi bi-arrow-counterclockwise" />
                             </button>
                           </div>
-                        ) : (
+                        ) : br.condition?.kind === "expression" ? (
                           <>
                             <input
                               className="form-control form-control-sm branch-condition-input"
-                              value={br.condition}
+                              value={br.condition.expression}
                               placeholder="分岐条件 (自由記述)"
                               onClick={(e) => e.stopPropagation()}
-                              onChange={(e) => setBranchAt(bi, { ...br, condition: e.target.value })}
+                              onChange={(e) => setBranchAt(bi, { ...br, condition: { kind: "expression", expression: e.target.value } })}
                               onBlur={onCommit}
                             />
                             <button
@@ -1438,6 +1438,21 @@ export function StepCard({
                               <i className="bi bi-shield-exclamation" />
                             </button>
                           </>
+                        ) : (
+                          // affectedRowsZero / externalOutcome 等の専用 UI 未対応 kind
+                          // 現状は kind 名 + 「expression に戻す」ボタンのみ提供 (#954)
+                          <div className="d-flex align-items-center gap-1 flex-grow-1" onClick={(e) => e.stopPropagation()}>
+                            <span className="badge bg-secondary text-white" style={{ fontSize: "0.7rem" }}>{br.condition?.kind ?? "(unknown)"}</span>
+                            <span className="text-muted small">専用 UI 未対応 — JSON で編集してください</span>
+                            <button
+                              type="button"
+                              className="btn btn-sm btn-link text-muted p-0"
+                              title="expression に戻す"
+                              onClick={() => setBranchAt(bi, { ...br, condition: { kind: "expression", expression: "" } })}
+                            >
+                              <i className="bi bi-arrow-counterclockwise" />
+                            </button>
+                          </div>
                         )}
                         {bi > 0 && (
                           <button


### PR DESCRIPTION
Closes #954

## 概要

\`StepCard.tsx\` の \`branch.condition\` 判定が \`typeof condition === \"object\"\` のままで schema v3 の discriminated union に対応しておらず、expression を含む全 object が tryCatch UI に倒れる問題を修正。

\`br.condition?.kind === \"tryCatch\" / \"expression\" / その他\` の 3 分岐に書き換え。

## 仕様逐条突合 (自己申告)

- [x] **受入 1**: StepCard.tsx の condition 判定を kind 判別に変更 — \`frontend/src/components/process-flow/StepCard.tsx:1393\`
- [x] **受入 2**: \`schema-ui.spec.ts:230\` (現 :238) の test.skip を解除し pass — \`frontend/e2e/schema-ui.spec.ts:241\`
- [x] **受入 3**: expression / tryCatch 切替の round trip が動作 — テスト pass で確認
- [x] **受入 4**: 他 kind (affectedRowsZero / externalOutcome) のレンダリングを別途定義 or skip 明示 — \`frontend/src/components/process-flow/StepCard.tsx:1444-1457\` で kind バッジ + 戻すボタンのみ (専用 UI 未対応として skip 明示)

## 関連 ISSUE

- 親 ISSUE: #945 (e2e fail follow-up)

## 変更ファイル

- \`frontend/src/components/process-flow/StepCard.tsx\` — branch.condition 判定 3 分岐 + 値参照を kind 別に正規化
- \`frontend/e2e/schema-ui.spec.ts\` — test.skip 解除 + コメント更新

## テスト

- frontend e2e \`schema-ui.spec.ts\`: 6 件 pass (10.7s)

## schema 変更

なし (\`gh pr diff --name-only | grep schemas/\` 空、 #511 governance 遵守)

## UI 影響

- branch step の condition UI で:
  - expression: 自由記述 input + 盾アイコン (切替) — 現行と等価
  - tryCatch: バッジ + errorCode input + 戻すボタン — 現行と等価 (戻す先を expression valid に変更)
  - 他 kind: 「専用 UI 未対応 — JSON で編集してください」表示 + 戻すボタン (新規)

🤖 Generated with [Claude Code](https://claude.com/claude-code)