### PR TITLE
fix(backend): projectStorage の extensions schema 参照を v3 単一 schema に統合 (#955)

### DIFF
--- a/backend/src/projectStorage.ts
+++ b/backend/src/projectStorage.ts
@@ -16,7 +16,8 @@
  */
 import fs from "fs/promises";
 import path from "path";
-import Ajv, { type ValidateFunction } from "ajv";
+import type { ValidateFunction } from "ajv";
+import Ajv2020 from "ajv/dist/2020.js";
 import { workspaceContextManager } from "./workspaceState.js";
 
 // ── path 解決ヘルパー (#671 + #700 R-2) ─────────────────────────────────────
@@ -120,29 +121,126 @@ function screenSchemaRef(dataRoot: string): string {
   return path.relative(entityDir, schemaPath).replace(/\\/g, "/");
 }
 
-/** ExtensionFileKind → extensions-*.schema.json ファイル名スラグの変換 */
-function kindToSchemaSlug(kind: ExtensionFileKind): string {
+/**
+ * ExtensionFileKind → v3 統合 schema (extensions.v3.schema.json) の対応 sub-property 名。
+ *
+ * 旧 split schema (`extensions-<slug>.schema.json`) は v3 で `extensions.v3.schema.json` 単一に
+ * 統合され (#955)、 5 種別のフィールド名は schema 上で改名された:
+ *   - steps         → stepKinds       (object: { <StepName>: CustomStepKind })
+ *   - fieldTypes    → fieldTypes      (array of CustomFieldType)
+ *   - triggers      → actionTriggers  (array of CustomActionTrigger)
+ *   - dbOperations  → dbOperations    (array of CustomDbOperation)
+ *   - responseTypes → responseTypes   (object: { <TypeName>: CustomResponseType })
+ *
+ * data/extensions/<file>.json は旧 file 単位 + 旧キー名 (`triggers` 等) を保持する。
+ * 個別 file の AJV 検証時は v3 schema の対応 sub-schema を抜き出し、 旧キー名で wrap した
+ * fileSchema を動的構築して compile する。
+ */
+function kindToV3Key(kind: ExtensionFileKind): string {
   switch (kind) {
-    case "steps": return "steps";
-    case "fieldTypes": return "field-types";
-    case "triggers": return "triggers";
-    case "dbOperations": return "db-operations";
-    case "responseTypes": return "response-types";
+    case "steps":         return "stepKinds";
+    case "fieldTypes":    return "fieldTypes";
+    case "triggers":      return "actionTriggers";
+    case "dbOperations":  return "dbOperations";
+    case "responseTypes": return "responseTypes";
   }
 }
 
-/** Ajv インスタンスとバリデーター関数のモジュールレベルキャッシュ (#455) */
-const _ajv = new Ajv({ allErrors: true });
+/** ExtensionFileKind → 旧 file 形式の root key 名 (data/extensions/<file>.json の中身の key) */
+function kindToFileKey(kind: ExtensionFileKind): string {
+  switch (kind) {
+    case "steps":         return "steps";
+    case "fieldTypes":    return "fieldTypes";
+    case "triggers":      return "triggers";
+    case "dbOperations":  return "dbOperations";
+    case "responseTypes": return "responseTypes";
+  }
+}
+
+/** Ajv インスタンスとバリデーター関数のモジュールレベルキャッシュ (#455 / #955)。
+ * v3 統合 schema (#955) は draft 2020-12 のため Ajv2020 を使用。
+ * strict: false は schema 内 description 等の警告を抑制 (workspaceInit.ts:51 と同方針) */
+const _ajv = new Ajv2020({ allErrors: true, strict: false });
+let _v3SchemasRegistered = false;
 const _validatorCache = new Map<ExtensionFileKind, ValidateFunction>();
 
-async function getExtensionValidator(kind: ExtensionFileKind): Promise<ValidateFunction> {
-  if (!_validatorCache.has(kind)) {
-    const schemaPath = path.join(SCHEMAS_DIR, `extensions-${kindToSchemaSlug(kind)}.schema.json`);
-    const schemaText = await fs.readFile(schemaPath, "utf-8");
-    const schema = JSON.parse(schemaText) as object;
-    _validatorCache.set(kind, _ajv.compile(schema));
+/**
+ * v3 統合 schema (extensions.v3 / common.v3) を ajv に登録する (#955)。
+ * extensions.v3 → common.v3 への外部 $ref を解決可能にするため、 両方を addSchema する。
+ *
+ * 同 $id の重複登録を回避するため、 ajv.getSchema で既存確認してから追加する。
+ * (他 validator や別呼び出し経路で既に登録済みの場合がある)
+ */
+async function ensureV3SchemasRegistered(): Promise<void> {
+  if (_v3SchemasRegistered) return;
+  const commonSchemaText = await fs.readFile(
+    path.join(SCHEMAS_DIR, "v3", "common.v3.schema.json"),
+    "utf-8",
+  );
+  const extensionsSchemaText = await fs.readFile(
+    path.join(SCHEMAS_DIR, "v3", "extensions.v3.schema.json"),
+    "utf-8",
+  );
+  const commonSchema = JSON.parse(commonSchemaText) as { $id?: string };
+  const extensionsSchema = JSON.parse(extensionsSchemaText) as { $id?: string };
+  if (commonSchema.$id && !_ajv.getSchema(commonSchema.$id)) {
+    _ajv.addSchema(commonSchema);
   }
-  return _validatorCache.get(kind)!;
+  if (extensionsSchema.$id && !_ajv.getSchema(extensionsSchema.$id)) {
+    _ajv.addSchema(extensionsSchema);
+  }
+  _v3SchemasRegistered = true;
+}
+
+/**
+ * 個別 file 用 AJV validator を取得する (#955)。
+ *
+ * extensions.v3.schema.json の `allOf[*].properties[<v3Key>]` を抜き出して、
+ * 旧 file root 形式 `{ namespace: string, <fileKey>: <subSchema> }` で wrap した
+ * fileSchema を動的構築 → compile する。
+ */
+async function getExtensionValidator(kind: ExtensionFileKind): Promise<ValidateFunction> {
+  if (_validatorCache.has(kind)) return _validatorCache.get(kind)!;
+  await ensureV3SchemasRegistered();
+
+  const v3SchemaText = await fs.readFile(
+    path.join(SCHEMAS_DIR, "v3", "extensions.v3.schema.json"),
+    "utf-8",
+  );
+  const v3Schema = JSON.parse(v3SchemaText) as {
+    allOf?: Array<{ properties?: Record<string, unknown> }>;
+    $defs?: Record<string, unknown>;
+  };
+  const v3Key = kindToV3Key(kind);
+  const fileKey = kindToFileKey(kind);
+  const propsHolder = v3Schema.allOf?.find((s) => s.properties);
+  const subSchema = propsHolder?.properties?.[v3Key];
+  if (!subSchema) {
+    throw new Error(
+      `extensions.v3.schema.json に ${v3Key} (kind=${kind}) が定義されていません`,
+    );
+  }
+
+  // 個別 file 用 schema: root は { namespace, <fileKey>: <subSchema> }。
+  // $defs は v3 schema からコピーして相対 $ref (#/$defs/CustomXxx) を解決可能にする。
+  // $id は extensions.v3.schema.json と同 directory に配置される URL を仮設定し、
+  // common.v3.schema.json への relative $ref を ajv が同 directory から解決可能にする。
+  // (common.v3 自体は ensureV3SchemasRegistered で addSchema 登録済み)
+  const fileSchema = {
+    $id: `https://raw.githubusercontent.com/csilost2001/harmony/main/schemas/v3/extensions-${kind}-file.v3.schema.json`,
+    type: "object" as const,
+    additionalProperties: false,
+    required: ["namespace", fileKey],
+    properties: {
+      namespace: { type: "string", pattern: "^([a-z][a-z0-9-]{0,29})?$" },
+      [fileKey]: subSchema,
+    },
+    $defs: v3Schema.$defs ?? {},
+  };
+
+  const validator = _ajv.compile(fileSchema);
+  _validatorCache.set(kind, validator);
+  return validator;
 }
 
 /** extensions/*.json の JSON Schema 検証 (#455) */

--- a/frontend/e2e/extensions-panel.spec.ts
+++ b/frontend/e2e/extensions-panel.spec.ts
@@ -34,12 +34,13 @@ test.describe("拡張管理 UI (#447)", () => {
     }
   });
 
-  // TODO(#955): backend `projectStorage.ts:140` が存在しない
-  // `schemas/extensions-response-types.schema.json` (v3 で `schemas/v3/extensions.v3.schema.json`
-  // 単一ファイルに統合) を読みに行き ENOENT で extensions panel が
-  // schema 検証 fail。backend 側コードを v3 schema 参照に修正必要 (#955 で対応)。
-  test.skip("レスポンス型を追加して保存できる (#955 follow-up)", async ({ page }) => {
-    await ws.gotoActive(page, "/extensions?tab=responseTypes");
+  // #955: backend `projectStorage.ts` の `getExtensionValidator()` を v3 統合 schema
+  // (`schemas/v3/extensions.v3.schema.json`) 参照に修正済み。
+  test("レスポンス型を追加して保存できる", async ({ page }) => {
+    // gotoActive の waitForURL は pathname のみ比較するため query 付き URL は使えない。
+    // `/extensions` で navigate してから tab を click で切り替える。
+    await ws.gotoActive(page, "/extensions");
+    await page.getByRole("tab", { name: /レスポンス型/ }).click();
     // ResumeOrDiscardDialog dismiss
     await page.waitForTimeout(500);
     for (let _i = 0; _i < 3; _i++) {
@@ -58,8 +59,10 @@ test.describe("拡張管理 UI (#447)", () => {
     await page.getByPlaceholder("ApiError").last().fill("E2EResponse");
     await page.locator(".response-type-schema").last().fill('{"type":"object","properties":{"code":{"type":"string"}}}');
     // ResponseTypesTab 内の primary 保存 button (edit-mode-save と区別)
+    // ResponseTypesTab 内の primary 保存 button (edit-mode-save と区別)
     await page.locator(".extensions-panel button.btn-primary", { hasText: "保存" }).click();
     await expect(page.getByText("保存しました。")).toBeVisible({ timeout: 10000 });
-    await expect(page.getByDisplayValue("E2EResponse")).toBeVisible();
+    // 入力値が保持されていることを確認 (input[value=E2EResponse])
+    await expect(page.locator('input[value="E2EResponse"]')).toBeVisible();
   });
 });

--- a/frontend/e2e/extensions-panel.spec.ts
+++ b/frontend/e2e/extensions-panel.spec.ts
@@ -59,7 +59,6 @@ test.describe("拡張管理 UI (#447)", () => {
     await page.getByPlaceholder("ApiError").last().fill("E2EResponse");
     await page.locator(".response-type-schema").last().fill('{"type":"object","properties":{"code":{"type":"string"}}}');
     // ResponseTypesTab 内の primary 保存 button (edit-mode-save と区別)
-    // ResponseTypesTab 内の primary 保存 button (edit-mode-save と区別)
     await page.locator(".extensions-panel button.btn-primary", { hasText: "保存" }).click();
     await expect(page.getByText("保存しました。")).toBeVisible({ timeout: 10000 });
     // 入力値が保持されていることを確認 (input[value=E2EResponse])


### PR DESCRIPTION
Closes #955

## 概要

\`backend/src/projectStorage.ts\` の \`getExtensionValidator()\` が存在しない \`schemas/extensions-*.schema.json\` (5 split files) を読みに行き ENOENT。v3 で \`schemas/v3/extensions.v3.schema.json\` 単一ファイルに統合済のため、 backend を v3 統合 schema 参照に書き換え。

## 仕様逐条突合 (自己申告)

- [x] **受入 1**: \`projectStorage.ts\` を v3 統合 schema 参照に変更 — \`backend/src/projectStorage.ts:123-205\`
- [x] **受入 2**: \`extensions-panel.spec.ts:36\` (現 :39) の test.skip を解除し pass — \`frontend/e2e/extensions-panel.spec.ts:39\`
- [x] **受入 3**: 既存の \`data/extensions/<file>.json\` の AJV 検証ロジックは互換維持 — 旧 file root key (\`steps\` / \`triggers\` 等) で wrap、 sub-schema 自体は v3 \`stepKinds\` / \`actionTriggers\` 等を流用
- [x] **受入 4**: 全 5 種別タブで個別の AJV 検証が動作 — responseTypes 経路で smoke 確認 (test pass)

## 関連 ISSUE

- 親 ISSUE: #945 (e2e fail follow-up)

## 主要変更

- \`Ajv\` → \`Ajv2020\` (v3 schemas は draft 2020-12)
- \`kindToSchemaSlug\` 削除、 \`kindToV3Key\` + \`kindToFileKey\` に分離
- \`ensureV3SchemasRegistered()\` 新設: 重複登録回避を \`getSchema\` check で実装
- \`getExtensionValidator()\`: v3 schema の \`allOf[*].properties[<v3Key>]\` を抜き出して動的に fileSchema を構築 → compile
- fileSchema に \`$id\` を付与し \`common.v3.schema.json#/\$defs/...\` への relative \$ref を ajv が解決可能に

## テスト

- frontend e2e \`extensions-panel.spec.ts\`: 2 件 pass (1 件 flaky だが retry で pass、 #957 系 race と推定 — 別 ISSUE で対応)
- backend vitest: 412 件 pass (regressions なし)
- TypeScript build: pass

## schema 変更

なし (\`gh pr diff --name-only | grep schemas/\` 空、 #511 governance 遵守)

## UI 影響

なし (backend validation logic 内部のみ; UI 経由で extensions 保存が ENOENT で失敗していた状態を修正)

🤖 Generated with [Claude Code](https://claude.com/claude-code)