### PR TITLE
fix(tab): tab click → URL sync race (#957)

### DIFF
--- a/frontend/e2e/tab-management.spec.ts
+++ b/frontend/e2e/tab-management.spec.ts
@@ -99,10 +99,9 @@ test.describe("タブ管理", () => {
       await setupWithScreens(page, [SCREEN_A_NORM, SCREEN_B_NORM]);
     });
 
-    // TODO(#957): tab click 後に AppShell の activeTab → URL sync useEffect が
-    // navigate しない race。lastSyncedActiveTabIdRef の初期化タイミング or
-    // tabStore localStorage seed のタイミング不整合の可能性 (#957 で実機調査)。
-    test.skip("タブをクリックすると切り替わる (#957 follow-up: tab→URL sync race)", async ({ page }) => {
+    // #957: tab click 後に AppShell の activeTab → URL sync useEffect が、 workspace state
+    // 未確立 + wsId URL 有り の状態で early return していた。 guard を緩めて navigate 許可。
+    test("タブをクリックすると切り替わる", async ({ page }) => {
       await page.locator(".tabbar-tab").filter({ hasText: "画面A" }).click();
       await expect(page.locator(".tabbar-tab.active")).toContainText("画面A");
       await expect(page).toHaveURL(new RegExp(`/w/[^/]+/screen/design/${SCREEN_A_NORM}`));

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -706,7 +706,11 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
   useEffect(() => {
     if (!activeTab) return;
     if (location.pathname === "/workspace/select") return;
-    if (workspaceState.active === null && !workspaceState.lockdown && activeTab.type !== "workspace-list") {
+    // workspace 未確立でも URL に wsId がある場合は navigate 許可 (#957)。
+    // tab → URL は activeTab.resourceId だけで決まるため、 workspace state の race は影響しない。
+    // recovery 中 (active=null + wsId 有) でもタブクリックで URL を切替えて、
+    // recovery 完了後に Designer mount のフローを保つ。
+    if (workspaceState.active === null && !workspaceState.lockdown && !wsId && activeTab.type !== "workspace-list") {
       return;
     }
     // activeTabId が前回 sync 済の値と同じなら何もしない

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -694,10 +694,14 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
   }, [location.pathname]);
 
   // アクティブタブ → URL 同期
-  // workspace 未選択中 (active=null) や /workspace/select 表示中は同期を停止する。
+  // workspace が完全未選択 (active=null + wsId 無し) や /workspace/select 表示中は同期を停止する。
   // localStorage に残った activeTabId が design:xxx 等を指していると、guard が
   // /workspace/select に redirect → 直後に本 effect が /screen/design/xxx へ navigate
   // を上書き → guard が再度 redirect、というループ / flicker を起こすため。
+  //
+  // ただし URL に wsId がある場合 (= /w/:wsId/* 経由) は recovery 中でも navigate 許可 (#957)。
+  // tab → URL は activeTab.resourceId だけで決まり workspace state race の影響は無く、
+  // recovery 完了後に Designer mount のフローを保てる。
   // workspace-list タブだけは select 画面からの誘導でも進入可能なので例外扱い。
   const activeTab = tabs.find((t) => t.id === activeTabId);
   // 前回 sync 済 activeTabId を ref で保持。本当に activeTabId が変化した時だけ navigate する


### PR DESCRIPTION
Closes #957

## 概要

\`AppShell.tsx:706\` の activeTab → URL sync useEffect で、 workspace 未確立 + wsId URL 有りの状態で early return していた問題を修正。 guard 条件に \`!wsId\` を追加して URL に wsId がある場合は navigate を許可。

## 仕様逐条突合 (自己申告)

- [x] **受入 1**: \`tab-management.spec.ts:96\` (現 :103) の test.skip 解除し isolation で pass — \`frontend/e2e/tab-management.spec.ts:103\`
- [x] **受入 2**: フル e2e の他 tab-management tests を regress させない — 14/14 全 pass

## 関連 ISSUE

- 親 ISSUE: #945 (e2e fail follow-up)

## 変更ファイル

- \`frontend/src/components/AppShell.tsx\` — guard 条件に \`!wsId\` 追加
- \`frontend/e2e/tab-management.spec.ts\` — test.skip 解除 + コメント更新

## テスト

- frontend e2e \`tab-management.spec.ts\`: 14 件 全 pass (17s)
- TypeScript build: pass

## schema 変更

なし (\`gh pr diff --name-only | grep schemas/\` 空、 #511 governance 遵守)

## UI 影響

- workspace recovery 中の tab click で URL も即座に切替わるようになる (修正前は workspace.active 確立まで navigate されなかった)
- 通常の tab 操作には影響なし (workspace.active が確立済みなら従来通り navigate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)