### PR TITLE
fix(workspace): AppShell recovery の workspace.open 並行発行ガード追加 (#963)

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -422,6 +422,11 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
   }, [workspaceState.active?.id]);
 
   // ルーティングガード: wsId が active と異なる、または active===null の場合の処理
+  // 並行発行ガード (#963): 同一 wsId に対する workspace.open の二重発行を抑止する。
+  // useEffect は workspaceState 更新等で何度も再実行されるため、未完了 RPC があれば
+  // 同 wsId の再発行を skip する。RPC 完了 (success or fail) で ref をクリア。
+  const recoveryPendingRef = useRef<string | null>(null);
+
   // backend offline 時の localStorage fallback は #923 シリーズで廃止 (spec D-8)。
   // 接続失敗は AppShell 上位の `connectionFailed` (`markFailed()` 経由) が
   // `ConnectionFailedView` で UI を切り替える。本ガードは正常接続時の URL 同期に専念する。
@@ -442,11 +447,20 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
       if (wsId) {
         const recentEntry = workspaceState.workspaces.find((w) => w.id === wsId);
         if (recentEntry) {
-          mcpBridge.request("workspace.open", { id: wsId }).catch((err) => {
-            console.error("[workspace] workspace.open recovery failed:", err);
-            const guard = checkRedirect("/workspace/select");
-            if (guard.allow) navigate("/workspace/select", { replace: true });
-          });
+          // 並行発行ガード: 同 wsId に対する未完了 workspace.open RPC があれば skip (#963)
+          if (recoveryPendingRef.current === wsId) {
+            return;
+          }
+          recoveryPendingRef.current = wsId;
+          mcpBridge.request("workspace.open", { id: wsId })
+            .catch((err) => {
+              console.error("[workspace] workspace.open recovery failed:", err);
+              const guard = checkRedirect("/workspace/select");
+              if (guard.allow) navigate("/workspace/select", { replace: true });
+            })
+            .finally(() => {
+              if (recoveryPendingRef.current === wsId) recoveryPendingRef.current = null;
+            });
           return; // workspace.open 完了後に workspace.changed broadcast で active が復元される
         }
       }
@@ -456,11 +470,20 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
       // URL の :wsId が現在 active と異なる → workspace.open で同期
       const recentEntry = workspaceState.workspaces.find((w) => w.id === wsId);
       if (recentEntry) {
-        mcpBridge.request("workspace.open", { id: wsId }).catch((err) => {
-          console.error("[workspace] workspace.open from URL failed:", err);
-          const guard = checkRedirect("/workspace/select");
-          if (guard.allow) navigate("/workspace/select", { replace: true });
-        });
+        // 並行発行ガード (#963): URL 由来 sync 経路でも同 wsId 二重発行を抑止
+        if (recoveryPendingRef.current === wsId) {
+          return;
+        }
+        recoveryPendingRef.current = wsId;
+        mcpBridge.request("workspace.open", { id: wsId })
+          .catch((err) => {
+            console.error("[workspace] workspace.open from URL failed:", err);
+            const guard = checkRedirect("/workspace/select");
+            if (guard.allow) navigate("/workspace/select", { replace: true });
+          })
+          .finally(() => {
+            if (recoveryPendingRef.current === wsId) recoveryPendingRef.current = null;
+          });
       } else {
         // recent にない不正 wsId → /workspace/select
         const guard = checkRedirect("/workspace/select");


### PR DESCRIPTION
Closes #963

## 概要

\`AppShell.tsx\` useEffect 内で \`workspace.open\` を発行する 2 経路 (active=null + URL wsId 復元 / wsId 不一致による URL 由来 sync) に \`recoveryPendingRef\` で並行発行ガードを追加。

PR #962 review-pr-sonnet 指摘 SF-1 の対応。

## 仕様逐条突合 (自己申告)

- [x] **受入 1**: \`recoveryPendingRef\` 追加で同一 wsId への並行 \`workspace.open\` 抑止 — \`frontend/src/components/AppShell.tsx:430-433\` (declaration), \`:445-457\` (active=null path), \`:466-478\` (sync path)
- [x] **受入 2**: 既存テストを regress させない — tab-management 14 件 + designer-corrupt-data 3 件 全 pass。 extensions-panel:39 は \`#955\` 由来の独立 flake (本 PR で導入したものではない)
- (任意): 実機ログ観測は code review レベルで充足

## 関連 ISSUE

- 親 ISSUE: #945 (e2e fail follow-up)
- 元 review コメント: PR #962 (#945 series) review SF-1
- 関連 ISSUE: #956 (puck reload race、 別問題で bailout 済)

## 変更ファイル

- \`frontend/src/components/AppShell.tsx\` — \`recoveryPendingRef\` 追加 + 2 経路にガード

## テスト

- frontend e2e \`tab-management.spec.ts\`: 14 件 全 pass
- frontend e2e \`designer-corrupt-data.spec.ts\`: 3 件 全 pass

## schema 変更

なし (\`gh pr diff --name-only | grep schemas/\` 空、 #511 governance 遵守)

## UI 影響

なし (ガード追加で並行 RPC を抑制するのみ、 ユーザー体感の変化はない)

🤖 Generated with [Claude Code](https://claude.com/claude-code)