### PR TITLE
infra(test): mcp/_helpers sendBrowserRequest を WS 永続化 + clientId 共有構造に書き直し (#958)

### DIFF
--- a/frontend/e2e/mcp/_helpers.ts
+++ b/frontend/e2e/mcp/_helpers.ts
@@ -16,40 +16,109 @@ export async function isMcpRunning(): Promise<boolean> {
 }
 
 /**
- * ブラウザ役として wsBridge (ws://localhost:5179) にリクエストを送るヘルパー。
- * `register` (clientId) → `request` (method/params) の順でメッセージを送り、
- * 同じ id の `response` が返るのを待つ。10 秒でタイムアウト。
+ * ブラウザ役として wsBridge (ws://localhost:5179) にリクエストを送るヘルパー (#958)。
  *
- * `WebSocket` は Node 22+ で global だが、Node 20 では未定義のため `ws` パッケージを使う。
+ * #683 で per-session activePath を廃止した結果、 短命 WS + 都度 clientId 発行では
+ * `workspace.open` 後の次 request で activePath が消える構造的問題があった。
+ * 永続 WS + clientId 共有構造に書き直し:
+ *   - 1 spec / 1 process で 1 つの WS connection を保持
+ *   - 同一 connection で同一 clientId を保ち、 activePath を維持
+ *   - `openBrowserSessionWorkspace` で初回 workspace.open を呼ぶ
+ *   - reqId による response 多重化 (同時 in-flight に対応)
+ *   - `closeBrowserSession` で afterAll cleanup
+ *
+ * `WebSocket` は Node 22+ で global だが、 Node 20 では未定義のため `ws` パッケージを使う。
  */
-export function sendBrowserRequest(method: string, params: unknown = {}): Promise<unknown> {
-  return new Promise((resolve, reject) => {
+
+let _ws: WebSocketImpl | null = null;
+let _clientId: string | null = null;
+let _connectPromise: Promise<void> | null = null;
+const _pendingRequests = new Map<string, { resolve: (v: unknown) => void; reject: (e: Error) => void; timer: ReturnType<typeof setTimeout> }>();
+
+async function ensureConnected(): Promise<void> {
+  if (_ws && _ws.readyState === WebSocketImpl.OPEN) return;
+  if (_connectPromise) return _connectPromise;
+  _connectPromise = new Promise<void>((resolve, reject) => {
     const ws = new WebSocketImpl("ws://localhost:5179");
-    const clientId = `test-client-${Date.now()}`;
-    const reqId = `req-${Date.now()}`;
-
-    const timeout = setTimeout(() => {
-      ws.close();
-      reject(new Error(`Timeout waiting for response to ${method}`));
-    }, 10000);
-
+    const clientId = `test-client-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     ws.on("open", () => {
       ws.send(JSON.stringify({ type: "register", clientId }));
-      ws.send(JSON.stringify({ type: "request", id: reqId, method, params }));
+      _ws = ws;
+      _clientId = clientId;
+      resolve();
     });
-
+    ws.on("error", (err) => {
+      _connectPromise = null;
+      reject(new Error(`WebSocket error: ${err.message}`));
+    });
     ws.on("message", (data) => {
       try {
         const msg = JSON.parse(data.toString()) as { type?: string; id?: string; error?: string; result?: unknown };
-        if (msg.type === "response" && msg.id === reqId) {
-          clearTimeout(timeout);
-          ws.close();
-          if (msg.error) reject(new Error(msg.error));
-          else resolve(msg.result);
+        if (msg.type === "response" && typeof msg.id === "string") {
+          const pending = _pendingRequests.get(msg.id);
+          if (pending) {
+            clearTimeout(pending.timer);
+            _pendingRequests.delete(msg.id);
+            if (msg.error) pending.reject(new Error(msg.error));
+            else pending.resolve(msg.result);
+          }
         }
-      } catch { /* 別メッセージは無視 */ }
+      } catch {
+        /* 別メッセージは無視 */
+      }
     });
-
-    ws.on("error", (err) => reject(new Error(`WebSocket error: ${err.message}`)));
+    ws.on("close", () => {
+      _ws = null;
+      _clientId = null;
+      _connectPromise = null;
+      _pendingRequests.forEach(({ reject, timer }) => {
+        clearTimeout(timer);
+        reject(new Error("WebSocket closed"));
+      });
+      _pendingRequests.clear();
+    });
   });
+  return _connectPromise;
+}
+
+export async function sendBrowserRequest(method: string, params: unknown = {}): Promise<unknown> {
+  await ensureConnected();
+  const reqId = `req-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      _pendingRequests.delete(reqId);
+      reject(new Error(`Timeout waiting for response to ${method}`));
+    }, 10000);
+    _pendingRequests.set(reqId, { resolve, reject, timer });
+    if (!_ws || _ws.readyState !== WebSocketImpl.OPEN) {
+      clearTimeout(timer);
+      _pendingRequests.delete(reqId);
+      reject(new Error("WebSocket is not open"));
+      return;
+    }
+    _ws.send(JSON.stringify({ type: "request", id: reqId, method, params }));
+  });
+}
+
+/**
+ * 永続 WS の clientId に対して workspace.open を発行し、 以降の request で
+ * activePath が立った状態を維持する。 各 spec の beforeAll で呼ぶ想定。
+ */
+export async function openBrowserSessionWorkspace(workspacePath: string): Promise<void> {
+  await ensureConnected();
+  await sendBrowserRequest("workspace.open", { path: workspacePath });
+}
+
+/**
+ * afterAll で WS を閉じる。 同一 process 内で複数 spec が走る場合、
+ * 後続 spec が再接続するため close でも問題ない (lazy init)。
+ */
+export async function closeBrowserSession(): Promise<void> {
+  if (_ws) {
+    const ws = _ws;
+    _ws = null;
+    _clientId = null;
+    _connectPromise = null;
+    ws.close();
+  }
 }

--- a/frontend/e2e/mcp/bulk-load.spec.ts
+++ b/frontend/e2e/mcp/bulk-load.spec.ts
@@ -1,11 +1,28 @@
 import { test, expect } from "@playwright/test";
-import { isMcpRunning, sendBrowserRequest } from "./_helpers";
+import { isMcpRunning, sendBrowserRequest, openBrowserSessionWorkspace, closeBrowserSession } from "./_helpers";
+import { setupTestWorkspace, cleanupRealWorkspaces } from "../helpers/realWorkspace";
+import { buildProject } from "../__fixtures__/builders";
 
-// TODO(#958): mcp-tools.spec.ts と同じく sendBrowserRequest 構造修正待ち
-test.describe.skip("wsBridge bulk load (#587) (#958 follow-up)", () => {
+const WS_KEY = "issue-958-mcp-bulk-load";
+
+// #958: 永続 WS + clientId 共有構造 + beforeAll workspace.open で activePath を立てる
+test.describe("wsBridge bulk load (#587) (#958)", () => {
+  let mcpAvailable = false;
+
+  test.beforeAll(async () => {
+    mcpAvailable = await isMcpRunning();
+    if (!mcpAvailable) return;
+    const ws = await setupTestWorkspace({ key: WS_KEY, project: buildProject({ name: "mcp-bulk-load-e2e" }) });
+    await openBrowserSessionWorkspace(ws.workspacePath);
+  });
+
+  test.afterAll(async () => {
+    await closeBrowserSession();
+    if (mcpAvailable) await cleanupRealWorkspaces([WS_KEY]);
+  });
+
   test.beforeEach(async () => {
-    const running = await isMcpRunning();
-    if (!running) test.skip();
+    if (!mcpAvailable) test.skip();
   });
 
   test("listAllTables は配列を返す", async () => {

--- a/frontend/e2e/mcp/mcp-tools.spec.ts
+++ b/frontend/e2e/mcp/mcp-tools.spec.ts
@@ -15,20 +15,36 @@
 import { test, expect } from "@playwright/test";
 import * as path from "path";
 import * as fs from "fs";
-import { isMcpRunning, sendBrowserRequest } from "./_helpers";
+import { isMcpRunning, sendBrowserRequest, openBrowserSessionWorkspace, closeBrowserSession } from "./_helpers";
+import { setupTestWorkspace, cleanupRealWorkspaces } from "../helpers/realWorkspace";
+import { buildProject } from "../__fixtures__/builders";
 
+const WS_KEY = "issue-958-mcp-tools";
 
 // ─── テスト ─────────────────────────────────────────────────────────────────
 
-// TODO(#958): sendBrowserRequest が短命 WS で都度 clientId を発行する
-// ため、workspace.open を呼んでも次の request で活性 path が消える
-// (#683 backend per-session activePath 廃止後の構造的問題)。
-// _helpers.ts の sendBrowserRequest を「WS 永続化 + clientId 共有 + 初回 workspace.open」
-// 構造に書き直す必要あり。本 ISSUE スコープ外、#958 で対応。
-test.describe.skip("wsBridge ファイル操作 (#958 follow-up: sendBrowserRequest 構造修正待ち)", () => {
+// #958: sendBrowserRequest を永続 WS + clientId 共有構造に書き直し、
+// beforeAll で test workspace を作成 + openBrowserSessionWorkspace で永続 WS の
+// activePath を立てる。
+test.describe("wsBridge ファイル操作 (#958)", () => {
+  let mcpAvailable = false;
+  let workspacePath: string | null = null;
+
+  test.beforeAll(async () => {
+    mcpAvailable = await isMcpRunning();
+    if (!mcpAvailable) return;
+    const ws = await setupTestWorkspace({ key: WS_KEY, project: buildProject({ name: "mcp-tools-e2e" }) });
+    workspacePath = ws.workspacePath;
+    await openBrowserSessionWorkspace(workspacePath);
+  });
+
+  test.afterAll(async () => {
+    await closeBrowserSession();
+    if (mcpAvailable) await cleanupRealWorkspaces([WS_KEY]);
+  });
+
   test.beforeEach(async () => {
-    const running = await isMcpRunning();
-    if (!running) test.skip();
+    if (!mcpAvailable) test.skip();
   });
 
   test("loadProject でプロジェクトデータが返る", async () => {


### PR DESCRIPTION
Closes #958

## 概要

\`frontend/e2e/mcp/_helpers.ts\` の \`sendBrowserRequest\` が短命 WS で都度 clientId を発行する構造のため、 workspace.open 後の次 request で activePath が消える (#683 後の構造的問題)。 これにより \`mcp/mcp-tools.spec.ts\` 14 件 + \`mcp/bulk-load.spec.ts\` 2 件が \`WorkspaceUnsetError\` で fail していた。

\`_helpers.ts\` を永続 WS + clientId 共有構造に書き直し。

## 仕様逐条突合 (自己申告)

- [x] **受入 1**: \`_helpers.ts:sendBrowserRequest\` を永続 WS + clientId 共有構造に書き直し — \`frontend/e2e/mcp/_helpers.ts:34-104\`
- [x] **受入 2**: \`mcp/mcp-tools.spec.ts\` の \`describe.skip\` 解除し全 14 件 pass — 14/14 pass (1.4s)
- [x] **受入 3**: \`mcp/bulk-load.spec.ts\` の \`describe.skip\` 解除し全 2 件 pass — 2/2 pass (1.0s)
- [x] **受入 4**: テスト fixture 切替時の cleanup を漏らさない — afterAll で \`closeBrowserSession\` + \`cleanupRealWorkspaces\`

## 関連 ISSUE

- 親 ISSUE: #945 (e2e fail follow-up)
- 後続: #948 (mcp/designer-reconnect spec real backend) は本修正後に実装可能

## 主要変更

- 永続 WS connection (lazy init + 再利用) by module-level state
- clientId 共有 (同 connection 内で固定)
- reqId による response 多重化 (\`_pendingRequests\` Map)
- 新規 export: \`openBrowserSessionWorkspace\` / \`closeBrowserSession\`
- 既存 \`sendBrowserRequest\` API は signature 互換維持

## テスト

- \`mcp/bulk-load.spec.ts\`: 2/2 pass (1.0s)
- \`mcp/mcp-tools.spec.ts\`: 14/14 pass (1.4s)

## schema 変更

なし (\`gh pr diff --name-only | grep schemas/\` 空、 #511 governance 遵守)

## UI 影響

なし (test infra のみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)