### PR TITLE
improve(ux): 「作成して編集」後にエディタを auto-edit モードで開く (#960)

### DIFF
--- a/frontend/e2e/view-definition.spec.ts
+++ b/frontend/e2e/view-definition.spec.ts
@@ -101,10 +101,9 @@ test.describe("ビュー定義 E2E", () => {
     await expect(page).toHaveURL(/\/w\/[^/]+\/view-definition\/edit\//);
     await expect(page.getByText("ビュー定義編集").first()).toBeVisible();
 
-    // edit-session-draft (#683): エディタは readonly で開くため明示的に編集開始する。
-    // 「作成して編集」ボタンの命名に反する UX gap (#960 で改善予定)
-    await page.getByTestId("edit-mode-start").click();
-    await expect(page.getByTestId("edit-mode-save")).toBeVisible({ timeout: 5000 });
+    // #960: 「作成して編集」経由は auto-edit モードで開く (sessionStorage 経由で
+    // ViewDefinitionEditor が自動的に actions.startEditing() を発火)。
+    await expect(page.getByTestId("edit-mode-save")).toBeVisible({ timeout: 10000 });
 
     await page.getByLabel(/表示名/).fill(UPDATED_NAME);
     // SaveResetButtons の保存ボタン (edit-mode-save と区別)

--- a/frontend/src/components/sequence/SequenceEditor.tsx
+++ b/frontend/src/components/sequence/SequenceEditor.tsx
@@ -93,6 +93,22 @@ export function SequenceEditor() {
 
   const isReadonly = mode.kind !== "editing";
 
+  // #960: 「作成して編集」経由で sessionStorage に flag があれば auto-edit モードで開く。
+  // ListView 側で setItem("harmony-auto-edit:sequence:<id>", "1") される。
+  // Editor 側で 1 回読んで削除し、 startEditing を発火する。
+  const autoEditFiredRef = useRef(false);
+  useEffect(() => {
+    if (autoEditFiredRef.current) return;
+    if (!sequenceId) return;
+    if (mode.kind !== "readonly") return;
+    if (sessionLoading) return;
+    const key = `harmony-auto-edit:sequence:${sequenceId}`;
+    if (sessionStorage.getItem(key) !== "1") return;
+    autoEditFiredRef.current = true;
+    sessionStorage.removeItem(key);
+    void actions.startEditing();
+  }, [sequenceId, mode.kind, sessionLoading, actions]);
+
   const seqRef = useRef<Sequence | null>(null);
   useEffect(() => { seqRef.current = seq ?? null; }, [seq]);
 

--- a/frontend/src/components/sequence/SequenceListView.tsx
+++ b/frontend/src/components/sequence/SequenceListView.tsx
@@ -237,6 +237,10 @@ export function SequenceListView() {
     setAddPhysicalName("");
     setAddName("");
     setAddPhysicalNameError("");
+    // #960: 「作成して編集」は auto-edit モードで Editor を開く。
+    // URL query は AppShell の tab→URL sync useEffect で上書きされるため
+    // sessionStorage 経由で Editor に edit 起動を伝える。 Editor 側で 1 回読んで削除。
+    sessionStorage.setItem(`harmony-auto-edit:sequence:${seq.id}`, "1");
     navigate(wsPath(`/sequence/edit/${encodeURIComponent(seq.id)}`));
   };
 

--- a/frontend/src/components/table/TableEditor.tsx
+++ b/frontend/src/components/table/TableEditor.tsx
@@ -101,6 +101,20 @@ export function TableEditor() {
 
   const isReadonly = mode.kind !== "editing";
 
+  // #960: 「作成して編集」経由で sessionStorage に flag があれば auto-edit モードで開く。
+  const autoEditFiredRef = useRef(false);
+  useEffect(() => {
+    if (autoEditFiredRef.current) return;
+    if (!tableId) return;
+    if (mode.kind !== "readonly") return;
+    if (sessionLoading) return;
+    const key = `harmony-auto-edit:table:${tableId}`;
+    if (sessionStorage.getItem(key) !== "1") return;
+    autoEditFiredRef.current = true;
+    sessionStorage.removeItem(key);
+    void actions.startEditing();
+  }, [tableId, mode.kind, sessionLoading, actions]);
+
   const tableRef = useRef<Table | null>(null);
   useEffect(() => { tableRef.current = table ?? null; }, [table]);
 

--- a/frontend/src/components/table/TableListView.tsx
+++ b/frontend/src/components/table/TableListView.tsx
@@ -305,6 +305,8 @@ export function TableListView() {
     setAddName("");
     setAddLogical("");
     setAddCategory("");
+    // #960: 「作成して編集」は auto-edit モードで Editor を開く (sessionStorage 経由)。
+    sessionStorage.setItem(`harmony-auto-edit:table:${table.id}`, "1");
     navigate(wsPath(`/table/edit/${table.id}`));
   };
 

--- a/frontend/src/components/view-definition/ViewDefinitionEditor.tsx
+++ b/frontend/src/components/view-definition/ViewDefinitionEditor.tsx
@@ -255,6 +255,20 @@ export function ViewDefinitionEditor() {
 
   const isReadonly = mode.kind !== "editing";
 
+  // #960: 「作成して編集」経由で sessionStorage に flag があれば auto-edit モードで開く。
+  const autoEditFiredRef = useRef(false);
+  useEffect(() => {
+    if (autoEditFiredRef.current) return;
+    if (!viewDefinitionId) return;
+    if (mode.kind !== "readonly") return;
+    if (sessionLoading) return;
+    const key = `harmony-auto-edit:view-definition:${viewDefinitionId}`;
+    if (sessionStorage.getItem(key) !== "1") return;
+    autoEditFiredRef.current = true;
+    sessionStorage.removeItem(key);
+    void actions.startEditing();
+  }, [viewDefinitionId, mode.kind, sessionLoading, actions]);
+
   const viewDefRef = useRef<ViewDefinition | null>(null);
   useEffect(() => { viewDefRef.current = viewDefinition ?? null; }, [viewDefinition]);
 

--- a/frontend/src/components/view-definition/ViewDefinitionListView.tsx
+++ b/frontend/src/components/view-definition/ViewDefinitionListView.tsx
@@ -336,6 +336,8 @@ export function ViewDefinitionListView() {
       resourceId: String(vd.id),
       label: vd.name,
     });
+    // #960: 「作成して編集」は auto-edit モードで Editor を開く (sessionStorage 経由)。
+    sessionStorage.setItem(`harmony-auto-edit:view-definition:${vd.id}`, "1");
     navigate(wsPath(`/view-definition/edit/${encodeURIComponent(String(vd.id))}`));
   };
 

--- a/frontend/src/components/view/ViewEditor.tsx
+++ b/frontend/src/components/view/ViewEditor.tsx
@@ -91,6 +91,20 @@ export function ViewEditor() {
 
   const isReadonly = mode.kind !== "editing";
 
+  // #960: 「作成して編集」経由で sessionStorage に flag があれば auto-edit モードで開く。
+  const autoEditFiredRef = useRef(false);
+  useEffect(() => {
+    if (autoEditFiredRef.current) return;
+    if (!viewId) return;
+    if (mode.kind !== "readonly") return;
+    if (sessionLoading) return;
+    const key = `harmony-auto-edit:view:${viewId}`;
+    if (sessionStorage.getItem(key) !== "1") return;
+    autoEditFiredRef.current = true;
+    sessionStorage.removeItem(key);
+    void actions.startEditing();
+  }, [viewId, mode.kind, sessionLoading, actions]);
+
   const viewRef = useRef<View | null>(null);
   useEffect(() => { viewRef.current = view ?? null; }, [view]);
 

--- a/frontend/src/components/view/ViewListView.tsx
+++ b/frontend/src/components/view/ViewListView.tsx
@@ -273,6 +273,8 @@ export function ViewListView() {
     setAddPhysicalName("");
     setAddName("");
     setAddPhysicalNameError("");
+    // #960: 「作成して編集」は auto-edit モードで Editor を開く (sessionStorage 経由)。
+    sessionStorage.setItem(`harmony-auto-edit:view:${v.id}`, "1");
     navigate(wsPath(`/view/edit/${encodeURIComponent(v.id)}`));
   };
 


### PR DESCRIPTION
Closes #960

## 概要

ListView の「作成して編集」ボタン経由で Editor を **auto-edit モード** で開く実装を追加。 ボタン名通りに edit-mode-start を明示 click せずに直接編集モードで開くように。

## 実装方式

**sessionStorage 経由** で ListView → Editor に edit 起動を伝達。

URL query (\`?action=edit\`) は AppShell の \`activeTab → URL sync\` useEffect (line 706) で activeTab open 時に query なしで navigate されるため即座に消える (実機 debug で確認)。 sessionStorage はタブ内のみ有効で確実に伝達できる。

## 仕様逐条突合 (自己申告)

- [x] **受入 1**: view-definition / sequence / view / table ListView の「作成して編集」が auto-edit で開く — 4 ListView + 4 Editor を修正
- [x] **受入 2**: \`view-definition.spec.ts:73\` (現 :104) の test 側 \`edit-mode-start\` click 行を削除しても pass する — \`frontend/e2e/view-definition.spec.ts:104-106\` で workaround 削除、 isolation 2/2 pass
- [x] **受入 3**: 既存テストを regress させない — combined run 13/14 pass (1 件は pre-existing flake、 retry で pass)

## 関連 ISSUE

- 親 ISSUE: #945 (e2e fail follow-up)
- workaround 元: PR #962 commit c490d02

## 変更ファイル

ListView 側 (sessionStorage 設定):
- \`frontend/src/components/sequence/SequenceListView.tsx\`
- \`frontend/src/components/view/ViewListView.tsx\`
- \`frontend/src/components/view-definition/ViewDefinitionListView.tsx\`
- \`frontend/src/components/table/TableListView.tsx\`

Editor 側 (sessionStorage 読取 + startEditing 発火):
- \`frontend/src/components/sequence/SequenceEditor.tsx\`
- \`frontend/src/components/view/ViewEditor.tsx\`
- \`frontend/src/components/view-definition/ViewDefinitionEditor.tsx\`
- \`frontend/src/components/table/TableEditor.tsx\`

Test:
- \`frontend/e2e/view-definition.spec.ts\` — workaround 削除

## テスト

- \`view-definition.spec.ts\`: 2/2 pass (3.2s isolation)
- combined (\`table-list.spec.ts\` + \`view-definition.spec.ts\`): 13/14 pass、 1 件は #955 由来の pre-existing flake
- TypeScript build: pass

## schema 変更

なし (\`gh pr diff --name-only | grep schemas/\` 空、 #511 governance 遵守)

## UI 影響

「作成して編集」ボタン押下後、 Editor が直接編集モードで開く (edit-mode-start を click 不要)。 UX 改善。 通常の navigate (一覧から既存リソース open など) には影響なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)