### PR TITLE
fix(workspace): workspace.list 応答に active.id を含めて reload 後の復元 race を解消 (#956)

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1113,12 +1113,15 @@ function createMcpServer(sessionId: string): Server {
       case "designer__workspace_list": {
         const { workspaces, lastActiveId } = await listWorkspaces();
         const activePath = getActivePath(sessionId);
+        const activeEntry = activePath ? await findByPath(activePath) : null;
         const lockdown = isLockdown();
         const lockdownPath = getLockdownPath();
         const payload = {
           workspaces,
           lastActiveId,
-          active: activePath ? { path: activePath } : null,
+          active: activePath
+            ? { id: activeEntry?.id ?? null, path: activePath, name: activeEntry?.name ?? null }
+            : null,
           lockdown,
           lockdownPath,
         };

--- a/backend/src/workspaceListActiveId.test.ts
+++ b/backend/src/workspaceListActiveId.test.ts
@@ -1,0 +1,139 @@
+/**
+ * workspace.list active.id 解決テスト (#956)
+ *
+ * `workspace.list` WS ハンドラおよび `designer__workspace_list` MCP ツールが
+ * `active.id` を正しく返すことを recentStore + findByPath レイヤーで検証する。
+ *
+ * wsBridge/index.ts の HTTP/WS サーバは起動せず、recentStore.findByPath を直接呼んで
+ * "ハンドラが findByPath を使った場合の期待値" を検証する方式。
+ *
+ * 真因: raw 文字列等価 (`w.path === activePath`) は path 正規化差で find 失敗 →
+ *       findByPath(activePath) の normalizePath 経由比較で解消される。
+ */
+import { describe, it, expect, beforeEach, afterAll, beforeAll } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+const TMP_DIR = path.join(os.tmpdir(), `harmony-ws-list-test-${process.pid}-${Date.now()}`);
+const TMP_FILE = path.join(TMP_DIR, "recent-workspaces.json");
+const ORIGINAL_ENV = process.env.DESIGNER_RECENT_FILE;
+
+// 環境変数を設定してから recentStore を import (関数経由で都度読まれるため import 順は問わないが明示)
+process.env.DESIGNER_RECENT_FILE = TMP_FILE;
+
+const {
+  upsertWorkspace,
+  findByPath,
+  listWorkspaces,
+} = await import("./recentStore.js");
+
+beforeAll(async () => {
+  await fs.mkdir(TMP_DIR, { recursive: true });
+});
+
+beforeEach(async () => {
+  try {
+    await fs.unlink(TMP_FILE);
+  } catch { /* not found is OK */ }
+});
+
+afterAll(async () => {
+  try {
+    await fs.rm(TMP_DIR, { recursive: true, force: true });
+  } catch { /* ignore */ }
+  if (ORIGINAL_ENV !== undefined) {
+    process.env.DESIGNER_RECENT_FILE = ORIGINAL_ENV;
+  } else {
+    delete process.env.DESIGNER_RECENT_FILE;
+  }
+});
+
+describe("workspace.list active.id 解決 (#956)", () => {
+  it("正常系: findByPath(activePath) で active.id が取得できる", async () => {
+    // workspace を事前登録
+    const entry = await upsertWorkspace("/tmp/ws-test-956", "テストWS");
+    expect(entry.id).toMatch(/^[0-9a-f-]{36}$/);
+
+    // workspace.list ハンドラの処理: findByPath で activeEntry を解決
+    const activePath = entry.path; // path.resolve("/tmp/ws-test-956")
+    const activeEntry = await findByPath(activePath);
+
+    expect(activeEntry).not.toBeNull();
+    expect(activeEntry?.id).toBe(entry.id);
+    expect(activeEntry?.name).toBe("テストWS");
+
+    // ハンドラが構築する active オブジェクトの shape を検証
+    const activePayload = activePath
+      ? { id: activeEntry?.id ?? null, path: activePath, name: activeEntry?.name ?? null }
+      : null;
+    expect(activePayload?.id).toBe(entry.id);
+    expect(activePayload?.path).toBe(activePath);
+    expect(activePayload?.name).toBe("テストWS");
+  });
+
+  it("path 正規化ロバスト性: 冗長な './' を含む path でも findByPath が同一エントリを返す", async () => {
+    const entry = await upsertWorkspace("/tmp/ws-normalize-test", "NormalizeWS");
+
+    // wsBridge が setActivePath 経由で保持する path には path.resolve 済みの絶対パスが来るが
+    // 万一 activePath に '/tmp/./ws-normalize-test' が来ても findByPath は normalizePath で解決できる
+    const activePathWithDot = "/tmp/./ws-normalize-test";
+    const activeEntry = await findByPath(activePathWithDot);
+
+    expect(activeEntry).not.toBeNull();
+    expect(activeEntry?.id).toBe(entry.id);
+    expect(activeEntry?.name).toBe("NormalizeWS");
+  });
+
+  it("path 正規化ロバスト性: 冗長な '../' を含む path でも findByPath が同一エントリを返す", async () => {
+    const entry = await upsertWorkspace("/tmp/ws-parent-test", "ParentWS");
+
+    // 冗長な ../tmp/ws-parent-test は resolve すると /tmp/ws-parent-test と等価
+    const activePathWithParent = "/tmp/other/../ws-parent-test";
+    const activeEntry = await findByPath(activePathWithParent);
+
+    expect(activeEntry).not.toBeNull();
+    expect(activeEntry?.id).toBe(entry.id);
+  });
+
+  it("旧実装 (raw 文字列等価) の find 失敗パターンを再現: normalizePath 差で旧実装が壊れる", async () => {
+    // upsertWorkspace は path.resolve で正規化して保存する
+    const entry = await upsertWorkspace("/tmp/ws-raw-test", "RawWS");
+    const { workspaces } = await listWorkspaces();
+
+    // 旧実装: workspaces.find((w) => w.path === activePath) の raw 等価比較
+    const rawActivePath = "/tmp/./ws-raw-test"; // resolve 前の冗長パス
+    const oldStyleFind = workspaces.find((w) => w.path === rawActivePath);
+
+    // 旧実装は null になる (id が取れない = 真因)
+    expect(oldStyleFind).toBeUndefined();
+
+    // 新実装: findByPath の normalizePath 経由
+    const newStyleFind = await findByPath(rawActivePath);
+    expect(newStyleFind?.id).toBe(entry.id); // 正しく解決できる
+  });
+
+  it("active が null の場合は active payload も null になる", async () => {
+    // activePath = null のケース (workspace 未選択)
+    const activePath: string | null = null;
+    const activeEntry = activePath ? await findByPath(activePath) : null;
+    const activePayload = activePath
+      ? { id: activeEntry?.id ?? null, path: activePath, name: activeEntry?.name ?? null }
+      : null;
+
+    expect(activePayload).toBeNull();
+  });
+
+  it("findByPath で workspace が見つからない場合 active.id は null になる", async () => {
+    // activePath が指す workspace が recentStore に未登録の場合
+    const activePath = "/tmp/ws-not-registered";
+    const activeEntry = await findByPath(activePath);
+
+    expect(activeEntry).toBeNull();
+
+    const activePayload = activePath
+      ? { id: activeEntry?.id ?? null, path: activePath, name: activeEntry?.name ?? null }
+      : null;
+    expect(activePayload?.id).toBeNull();
+  });
+});

--- a/backend/src/wsBridge.ts
+++ b/backend/src/wsBridge.ts
@@ -1336,11 +1336,12 @@ class WsBridge extends EventEmitter {
         case "workspace.list": {
           const { workspaces, lastActiveId } = await listWorkspacesEntries();
           const activePath = workspaceContextManager.getActivePath(clientId);
+          const activeEntry = activePath ? await findWorkspaceByPath(activePath) : null;
           respond({
             workspaces,
             lastActiveId,
             active: activePath
-              ? { path: activePath, name: (workspaces.find((w) => w.path === activePath)?.name ?? null) }
+              ? { id: activeEntry?.id ?? null, path: activePath, name: activeEntry?.name ?? null }
               : null,
             lockdown: isWorkspaceLockdown(),
             lockdownPath: getWorkspaceLockdownPath(),
@@ -1826,3 +1827,4 @@ function _serializeEditSession(session: import("./editSessionStore.js").EditSess
     participants: Object.fromEntries(session.participants.entries()),
   };
 }
+

--- a/frontend/src/store/workspaceStore.filter.test.ts
+++ b/frontend/src/store/workspaceStore.filter.test.ts
@@ -88,7 +88,7 @@ describe("workspaceStore subscribeWorkspaceChanges per-session フィルタ (#70
     (mcpBridge.request as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       workspaces: [{ id: "ws-001", path: "/workspace/A", name: "WS-A", lastOpenedAt: null }],
       lastActiveId: "ws-001",
-      active: { path: "/workspace/A", name: "WS-A" },
+      active: { id: "ws-001", path: "/workspace/A", name: "WS-A" },
       lockdown: false,
       lockdownPath: null,
     });
@@ -108,7 +108,7 @@ describe("workspaceStore subscribeWorkspaceChanges per-session フィルタ (#70
     (mcpBridge.request as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       workspaces: [{ id: "ws-A", path: "/workspace/A", name: "WS-A", lastOpenedAt: null }],
       lastActiveId: "ws-A",
-      active: { path: "/workspace/A", name: "WS-A" },
+      active: { id: "ws-A", path: "/workspace/A", name: "WS-A" },
       lockdown: false,
       lockdownPath: null,
     });
@@ -130,7 +130,7 @@ describe("workspaceStore subscribeWorkspaceChanges per-session フィルタ (#70
     (mcpBridge.request as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       workspaces: [{ id: "ws-A", path: "/workspace/A", name: "WS-A", lastOpenedAt: null }],
       lastActiveId: "ws-A",
-      active: { path: "/workspace/A", name: "WS-A" },
+      active: { id: "ws-A", path: "/workspace/A", name: "WS-A" },
       lockdown: false,
       lockdownPath: null,
     });

--- a/frontend/src/store/workspaceStore.ts
+++ b/frontend/src/store/workspaceStore.ts
@@ -127,7 +127,7 @@ async function _doLoadWorkspaces(): Promise<void> {
     const result = (await mcpBridge.request("workspace.list")) as {
       workspaces: WorkspaceEntry[];
       lastActiveId: string | null;
-      active: { path: string; name: string | null } | null;
+      active: { id: string | null; path: string; name: string | null } | null;
       lockdown: boolean;
       lockdownPath: string | null;
     };
@@ -140,7 +140,7 @@ async function _doLoadWorkspaces(): Promise<void> {
       workspaces: result.workspaces ?? [],
       active: result.active
         ? {
-            id: result.workspaces?.find((w) => w.path === result.active!.path)?.id,
+            id: result.active.id ?? undefined,
             path: result.active.path,
             name: result.active.name,
           }


### PR DESCRIPTION
## Summary

`page.reload()` 後の workspace state 復元 race (#956) の根本対応。backend の `workspace.list` 応答に `active.id` を含めて返し、frontend での path 文字列等価による逆引きを廃止する。

Closes #956

## Background

### 真因

backend `workspace.list` ハンドラ (`backend/src/wsBridge.ts:1336-1349`) は `active: { path, name }` のみ返し、`active.name` も `workspaces.find((w) => w.path === activePath)?.name` で raw 文字列等価で逆引きしていた。`recentStore.ts:findByPath` が `normalizePath` (= `path.resolve` ベース) で正規化比較する一方、ここでは未正規化のため、path 表記差で id/name とも null/undefined になる race が発生。

frontend `workspaceStore.ts:143` でも同じく `find((w) => w.path === active.path)?.id` の raw 等価逆引きを行っていたため、reload 直後に `active.id = undefined` のまま AppShell guard が永遠 splash で待機 → puck reload 失敗。

backend MCP tool 側 `index.ts:1113` (`designer__workspace_list`) は更に簡素で `active: { path }` のみ (name すら未返却) だった。

### 修正方針

1. **backend** `wsBridge.ts` / `index.ts` 両方で `findByPath(activePath)` を使って一意に entry を解決し、`active: { id, path, name }` を返す
2. **frontend** `workspaceStore.ts` で payload から `active.id` を直接受ける (逆引き find 完全削除)
3. **backend unit test** で path 正規化のロバスト性 (冗長な `./` / `../` 含む path で同一エントリ解決) を検証

## 変更ファイル

- `backend/src/wsBridge.ts:1336-1350` — `workspace.list` ハンドラで `findWorkspaceByPath` 経由で `active.id`/`name` を返す
- `backend/src/index.ts:1113-1129` — `designer__workspace_list` MCP tool も同形に揃え (`active.id` + `active.name` 追加)
- `backend/src/workspaceListActiveId.test.ts` — 新規 6 ケース: 正常系 / `./` 冗長 / `../` 冗長 / 旧実装 raw find 失敗パターン再現 / null 系 2 件
- `frontend/src/store/workspaceStore.ts:127-147` — payload 型に `id: string \| null` 追加、逆引き find 削除し `result.active.id ?? undefined` で受ける
- `frontend/src/store/workspaceStore.filter.test.ts:91/111/133` — 既存モックに `id` フィールドを追加 (新 active shape 対応)

## 仕様逐条突合 (自己申告)

本 PR は #956 真因対応 + e2e 復活で完結。schema 変更なし、UI 仕様変更なし。

- backend `workspace.list` 応答に `active.id` 含める: `backend/src/wsBridge.ts:1340` ✓
- backend `designer__workspace_list` 応答に `active.id`/`name` 含める: `backend/src/index.ts:1116-1124` ✓
- frontend `workspaceStore.ts` で逆引き find 削除: `frontend/src/store/workspaceStore.ts:143` ✓ (旧 `find((w) => w.path === result.active!.path)?.id` → `result.active.id ?? undefined`)
- 型 `active.id: string \| null` 追加: `frontend/src/store/workspaceStore.ts:130` ✓
- path 正規化 unit test: `backend/src/workspaceListActiveId.test.ts:75-97` ✓ (`./` / `../` 含む path 解決)
- 旧実装 raw find 失敗パターン再現 test: `backend/src/workspaceListActiveId.test.ts:99-114` ✓
- e2e `puck-editor.spec.ts:67` (test 4) 復活: pass 確認済 (詳細 Test plan 参照)

## Test plan

- [x] backend unit test: `npx vitest run src/workspaceListActiveId.test.ts` → 6/6 pass
- [x] backend `npm test`: 全 418 pass (既存テスト無 regression)
- [x] backend `npm run build`: 0 errors
- [x] frontend `npm run build`: 0 errors
- [x] e2e `puck-editor.spec.ts` 全 10 件 pass (test 4 「保存後に reload で Puck 復元」含む)
- [x] e2e `workspace-default-path.spec.ts` 4/4 pass
- [x] e2e `workspace-navigation-smoke.spec.ts` 4/4 pass
- [x] e2e `dirty-mark-resume.spec.ts` 4/4 pass (前回 bailout 時の regression 領域)
- [x] schema 変更なし (`git diff origin/main..HEAD -- schemas/` 空)

## Related

- Parent ISSUE: #945 (e2e fail follow-up メタ)
- 前回試行 (revert 済): c4e2284 / 53e6697 (AppShell recovery race 仮説、catastrophic regression で revert)
- bailout コメント: https://github.com/csilost2001/harmony/issues/956#issuecomment-4408931287