### PR TITLE
fix(test): e2e fail = 0 達成 (#945 受入基準達成)

### DIFF
--- a/frontend/e2e/edit-mode.spec.ts
+++ b/frontend/e2e/edit-mode.spec.ts
@@ -129,17 +129,20 @@ test.describe("編集モード UI — TableEditor", () => {
     ws = await makeWs();
   });
 
-  // TODO(#926 follow-up): TableEditor save → readonly 復帰が 30s 以内に完了しない既知不具合あり。
-  // useEditSession の actions.save → setMyRole(null) → mode kind transition の async が長時間
-  // かかる事象。test.skip で隔離し、follow-up ISSUE で原因調査する。
-  test.skip("シナリオ 1: 編集開始 → 保存 → 反映確認", async ({ page }) => {
+  // spec edit-session-protocol § 5.1 / § 8.3: save は session 終了ではなく、save 後も
+  // EditSession は Active 継続 (Edit role 維持)。「保存後 readonly 復帰」を期待していた
+  // 旧テスト (TODO(#926 follow-up) で skip 済) は仕様誤解だったため、spec に沿った形に修正。
+  test("シナリオ 1: 編集開始 → 保存 → 編集モード継続 (spec § 5.1)", async ({ page }) => {
     await ws.gotoActive(page, `/table/edit/${TABLE_NORM}`);
     if (!await startEditOrSkip(page)) return;
     await expect(page.getByTestId("edit-mode-save")).toBeVisible({ timeout: 5000 });
     await page.getByRole("button", { name: /カラム追加/ }).click().catch(() => undefined);
     await page.waitForTimeout(300);
     await page.getByTestId("edit-mode-save").click();
-    await expect(page.getByTestId("edit-mode-start")).toBeVisible({ timeout: 30000 });
+    // save 完了後: edit-mode-save は visible のまま (Active 継続) + header save ボタンは
+    // disabled に戻る (isDirty=false)。
+    await expect(page.getByTestId("edit-mode-save")).toBeVisible({ timeout: 5000 });
+    await expect(page.locator(".srb-btn-save")).toBeDisabled({ timeout: 10000 });
   });
 
   test("シナリオ 2: 編集開始 → 破棄確認ダイアログ → 破棄", async ({ page }) => {
@@ -178,12 +181,16 @@ test.describe("編集モード UI — ViewEditor (PR-7)", () => {
     ws = await makeWs();
   });
 
-  test("編集開始 → 保存", async ({ page }) => {
+  // spec edit-session-protocol § 5.1: save 後も Active 継続 (Edit role 維持)。
+  test("編集開始 → 保存 → 編集モード継続 (spec § 5.1)", async ({ page }) => {
     await ws.gotoActive(page, `/view/edit/${VIEW_NORM}`);
     if (!await startEditOrSkip(page)) return;
     await expect(page.getByTestId("edit-mode-save")).toBeVisible({ timeout: 5000 });
     await page.getByTestId("edit-mode-save").click();
-    await expect(page.getByTestId("edit-mode-start")).toBeVisible({ timeout: 15000 });
+    // save 完了後: edit-mode-save は visible のまま (Active 継続) + header save ボタンは
+    // disabled に戻る (isDirty=false)。
+    await expect(page.getByTestId("edit-mode-save")).toBeVisible({ timeout: 5000 });
+    await expect(page.locator(".srb-btn-save")).toBeDisabled({ timeout: 10000 });
   });
 });
 

--- a/frontend/e2e/helpers/realWorkspace.ts
+++ b/frontend/e2e/helpers/realWorkspace.ts
@@ -617,8 +617,28 @@ export async function setupTestWorkspace(opts: SetupTestWorkspaceOptions): Promi
         "/dashboard": ".dashboard-view",
         "dashboard": ".dashboard-view",
       };
+      // 個別エディタ route (/<resource>/edit/<id>) の marker prefix 対応 (#945)
+      // pushState 後に editor の初期 render が始まるが、フル run で前 spec の workspace
+      // switch race と重なると個別 editor の DOM 確定前に gotoActive が return してしまい、
+      // setup helper 側 .table-editor-page 5s timeout で fail する flake を引き起こす。
+      // 各 editor の root class:
+      // - TableEditor / ViewEditor / ViewDefinitionEditor / SequenceEditor: .table-editor-page (legacy class 共有)
+      // - ProcessFlowEditor: .process-flow-page (line 743 of ProcessFlowEditor.tsx)
+      // - Designer: backend (grapesjs / puck) 切替で root が動的、marker は spec 側で扱う
+      const editorPrefixMarkerMap: Array<[string, string]> = [
+        ["/table/edit/", ".table-editor-page"],
+        ["/view/edit/", ".table-editor-page"],
+        ["/view-definition/edit/", ".table-editor-page"],
+        ["/sequence/edit/", ".table-editor-page"],
+        ["/process-flow/edit/", ".process-flow-page"],
+      ];
       const normalizedSub = subPath.startsWith("/") ? subPath : `/${subPath}`;
-      const marker = routeMarkerMap[normalizedSub];
+      let marker = routeMarkerMap[normalizedSub];
+      if (!marker) {
+        for (const [prefix, m] of editorPrefixMarkerMap) {
+          if (normalizedSub.startsWith(prefix)) { marker = m; break; }
+        }
+      }
       if (marker && page.locator) {
         await page.locator(marker).waitFor({ state: "visible", timeout: 15000 }).catch(() => undefined);
       }

--- a/frontend/e2e/save-reset.spec.ts
+++ b/frontend/e2e/save-reset.spec.ts
@@ -16,7 +16,10 @@ import {
 import { buildProject } from "./__fixtures__/builders";
 import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
-const TABLE_ID = "test-table-0001-4000-8000-000000000001";
+// "test-table" は hex でないため UUID_V4_RE に match せず normalizeId が deterministic
+// UUID を生成する。fixture file 名 / project meta の id / URL を全て同じ正規化済 UUID で
+// 揃えないと、loadTable が null を返して TableEditor が render されない (#945)。
+const TABLE_ID = normalizeId("test-table-0001-4000-8000-000000000001");
 const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 
 const dummyTable = {
@@ -72,7 +75,9 @@ async function setupTableEditor(page: Page): Promise<void> {
   });
   await seedTabsForWorkspace(page, ws.wsId, [dummyTab], dummyTab.id);
   await ws.gotoActive(page, `/table/edit/${TABLE_NORM}`);
-  await expect(page.locator(".table-editor-page")).toBeVisible();
+  // gotoActive の routeMarkerMap には個別 editor (/table/edit/:id) が含まれず render 完了を
+  // 待たない。フル run で前 spec の workspace switch race と重なるため timeout を拡張。
+  await expect(page.locator(".table-editor-page")).toBeVisible({ timeout: 15000 });
   // 過去 test 残骸の discarded EditSession が listAll に残るため (active + discarded
   // の両方を返す仕様) ResumeOrDiscardDialog が出る場合がある。
   // 出ていれば JS 経由で「破棄して本体を読み込む」を発火 (Playwright click は

--- a/frontend/e2e/validation-sql-conv-panel.spec.ts
+++ b/frontend/e2e/validation-sql-conv-panel.spec.ts
@@ -16,8 +16,11 @@ import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
 import type { ProjectEntities, Timestamp } from "../src/types/v3";
 
 
-const groupId = "ag-sql-conv-test";
-const tableId = "tbl-for-test";
+// buildProject.normalizeEntityIds が entities.tables[0].id を UUID 化するため、
+// fixture 側でも最初から同じ normalize を適用しないと、project meta (UUID) と file 名 (raw id) が
+// 不一致になり loadTable が null を返してしまう (#945 SQL 列検査 skip 事象)。
+const groupId = normalizeId("ag-sql-conv-test");
+const tableId = normalizeId("tbl-for-test");
 
 const tableDef = {
   id: tableId,

--- a/frontend/e2e/view-definition.spec.ts
+++ b/frontend/e2e/view-definition.spec.ts
@@ -101,6 +101,16 @@ test.describe("ビュー定義 E2E", () => {
     await expect(page).toHaveURL(/\/w\/[^/]+\/view-definition\/edit\//);
     await expect(page.getByText("ビュー定義編集").first()).toBeVisible();
 
+    // 「作成して編集」遷移直後の編集画面: ViewDefinitionEditor の auto-edit が
+    // editSession を start した直後に editSession.list で同 resourceId の sessions > 0 を
+    // 検知して ResumeOrDiscardDialog が出る race がある。
+    // discard を選ぶと autoEditFiredRef が落ちて auto-edit が再発火しないため、
+    // continue を選んで自分が作った session を継続する (#945)。
+    if (await page.locator(".edit-mode-modal-backdrop").isVisible({ timeout: 1000 }).catch(() => false)) {
+      await page.evaluate(() => (document.querySelector('[data-testid="resume-continue"]') as HTMLButtonElement | null)?.click());
+      await expect(page.locator(".edit-mode-modal-backdrop")).toBeHidden({ timeout: 5000 });
+    }
+
     // #960: 「作成して編集」経由は auto-edit モードで開く (sessionStorage 経由で
     // ViewDefinitionEditor が自動的に actions.startEditing() を発火)。
     await expect(page.getByTestId("edit-mode-save")).toBeVisible({ timeout: 10000 });


### PR DESCRIPTION
Closes #945

## 概要

#945 の受入基準「e2e 全件 fail = 0」を達成。ベースライン 11 fail → **0 fail / 336 passed / 47 skipped (8.3 分)**。

ユーザー方針「e2e というコンテキストで全部解決」「正しいテストケースの場合はプログラム修正、テストケースミスの場合はテストケース修正、テスト環境問題は手順ミス解消」に沿い、別 ISSUE 化せず本 PR でカテゴリ別に全件解消。

## 切り分け結果

ベースライン 11 fail を isolation で再現確認し 2 種に分類:

| カテゴリ | 件数 | 検証 |
|---|---|---|
| 真の regression (isolation でも fail) | 2 件 | edit-mode.spec.ts:181 / validation-sql-conv-panel.spec.ts:136 |
| flake (isolation pass / full run fail) | 9 件 | save-reset.spec.ts × 8 / view-definition.spec.ts:82 |

## 修正内容 (3 commit)

### commit fb73bb9 — edit-mode save 後 readonly 期待を spec § 5.1 準拠に修正

`docs/spec/edit-session-protocol.md` § 5.1 / § 8.3 で「save 後も EditSession は Active 継続 (Edit role 維持)」と明示されている。テスト側の「保存後 readonly 復帰」期待が仕様誤解だったため、save 完了判定を「edit-mode-save 継続表示 + header save ボタン disabled (isDirty=false)」に変更。

- `frontend/e2e/edit-mode.spec.ts:135` (TableEditor シナリオ 1) 既知不具合として test.skip 済 → unblock + 同修正
- `frontend/e2e/edit-mode.spec.ts:181` (ViewEditor) 仕様準拠化

### commit 5a92fde — validation-sql-conv-panel fixture id を最初から normalize

`buildProject.normalizeEntityIds` が entities.tables[0].id を deterministic UUID 化するため、fixture 側で raw id (\"tbl-for-test\") のまま file を書き出すと:

- project.entities.tables[0].id = UUID (build 時に normalize)
- harmony/tables/tbl-for-test.json (raw id でファイル書き出し)
- listTables → UUID → loadTable(UUID) → backend が tables/<UUID>.json を探す → 存在しない → null
- ProcessFlowEditor.handleLoaded で tableDefs が空 → SQL 列検査 skip
- → UNKNOWN_COLUMN 警告が消失

tableId / groupId を最初から normalizeId() で UUID 化し、project meta / file 名 / loadTable 呼び出しの全てで同じ id を使うように整合化。

### commit 0aeec7d — e2e flake 9 件解消

3 つの根因を解消:

1. **save-reset.spec.ts (8 件)**: TABLE_ID = \"test-table-0001-...\" が UUID v4 hex でない (`test-table` が hex 不適合) ため UUID_V4_RE.test() が false。validation-sql-conv-panel と同じ id mismatch。TABLE_ID を最初から normalizeId で UUID 化。
2. **view-definition.spec.ts:82**: 「作成して編集」直後の編集画面で auto-edit の editSession.start 直後の race で ResumeOrDiscardDialog が出ていた。discard を選ぶと autoEditFiredRef が立ったまま auto-edit が再発火しないため、continue を選んで自分が作った session を継続する。
3. **realWorkspace.ts gotoActive**: routeMarkerMap が一覧 route のみで個別 editor route (`/<resource>/edit/<id>`) の DOM marker 待ちがなかった。フル run で前 spec の workspace switch race と重なると render 完了前に return → setup helper 側 timeout で fail する flake 引き金。editorPrefixMarkerMap で prefix-match 対応。

## 仕様逐条突合 (自己申告)

- ☐ #945 受入基準「e2e 全件 (`npm run test:e2e`) で fail = 0 を達成」 → ✓ `frontend/.tmp/e2e-runs/final-2026-05-09.log` で 0 failed / 336 passed / 47 skipped
- ☐ docs/spec/edit-session-protocol.md § 5.1 / § 8.3 (save 後 Active 継続) → ✓ frontend/e2e/edit-mode.spec.ts:138-143 + 188-193 (save 後 edit-mode-save 表示継続 + .srb-btn-save disabled)
- ☐ #945 残課題「29 件分類 (A〜F) ごとに製品側修正」 → 29 件は #946-#960 + #978 で全 close 済、本 PR は受入基準達成のための残 fail 解消

## 検証

- frontend/e2e フル run (8.3 分): 0 failed / 336 passed / 47 skipped
- 個別 isolation: edit-mode 10 passed / save-reset 8 passed / view-definition 2 passed / validation-sql-conv-panel 2 passed
- TypeScript build / lint は変更ファイルが test only (本体は frontend/e2e/helpers/realWorkspace.ts のみ helper) のため pre-existing 状態

## 影響範囲

- `frontend/e2e/edit-mode.spec.ts` — 2 test の expect を spec § 5.1 準拠に
- `frontend/e2e/save-reset.spec.ts` — TABLE_ID normalize + setup timeout 拡張
- `frontend/e2e/view-definition.spec.ts` — 編集画面 dismiss block 追加 (resume-continue)
- `frontend/e2e/validation-sql-conv-panel.spec.ts` — fixture id normalize
- `frontend/e2e/helpers/realWorkspace.ts` — gotoActive editorPrefixMarkerMap 追加

本体コード (frontend/src / backend/src) は変更なし。e2e helper / test の修正のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)