### PR TITLE
fix(view-definition): #1001 useTableOptions が table 更新を即時反映するよう tableStore に local pubsub 追加

### DIFF
--- a/frontend/src/components/view-definition/ViewDefinitionEditor.tsx
+++ b/frontend/src/components/view-definition/ViewDefinitionEditor.tsx
@@ -31,7 +31,7 @@ import type {
 import type { Table, TableEntry, Maturity, Identifier, FieldType, FieldTypePrimitive } from "../../types/v3";
 import type { TableId, LocalId } from "../../types/v3/common";
 import { loadViewDefinition, saveViewDefinition } from "../../store/viewDefinitionStore";
-import { listTables, loadTable } from "../../store/tableStore";
+import { listTables, loadTable, onTableChange } from "../../store/tableStore";
 import { mcpBridge } from "../../mcp/mcpBridge";
 import { useResourceEditor } from "../../hooks/useResourceEditor";
 import { useEditSession } from "../../hooks/useEditSession";
@@ -101,7 +101,7 @@ function useTablesForValidator(): TableDefinitionForView[] {
   const [tables, setTables] = useState<TableDefinitionForView[]>([]);
   useEffect(() => {
     let cancelled = false;
-    (async () => {
+    async function refresh(): Promise<void> {
       const entries = await listTables();
       const all = await Promise.all(entries.map((e: TableEntry) => loadTable(e.id)));
       const valid = all.filter((t): t is Table => t !== null);
@@ -109,8 +109,16 @@ function useTablesForValidator(): TableDefinitionForView[] {
         // Table is shape-compatible with TableDefinitionForView (id / name / physicalName / columns)
         setTables(valid as unknown as TableDefinitionForView[]);
       }
-    })().catch(console.error);
-    return () => { cancelled = true; };
+    }
+    refresh().catch(console.error);
+    // #1001: 同一 client 内 SPA 遷移先での table 変更通知 + 他 client (mcpBridge broadcast) 両カバー
+    const unsubLocal = onTableChange(() => { refresh().catch(console.error); });
+    const unsubBroadcast = mcpBridge.onBroadcast("tableChanged", () => { refresh().catch(console.error); });
+    return () => {
+      cancelled = true;
+      unsubLocal();
+      unsubBroadcast();
+    };
   }, []);
   return tables;
 }
@@ -127,7 +135,7 @@ function useTableOptions(): TableOption[] {
   const [options, setOptions] = useState<TableOption[]>([]);
   useEffect(() => {
     let cancelled = false;
-    (async () => {
+    async function refresh(): Promise<void> {
       const entries = await listTables();
       const tables = await Promise.all(entries.map((e: TableEntry) => loadTable(e.id)));
       if (!cancelled) {
@@ -145,8 +153,16 @@ function useTableOptions(): TableOption[] {
             })),
         );
       }
-    })().catch(console.error);
-    return () => { cancelled = true; };
+    }
+    refresh().catch(console.error);
+    // #1001: 同一 client 内 SPA 遷移先での table 変更通知 + 他 client (mcpBridge broadcast) 両カバー
+    const unsubLocal = onTableChange(() => { refresh().catch(console.error); });
+    const unsubBroadcast = mcpBridge.onBroadcast("tableChanged", () => { refresh().catch(console.error); });
+    return () => {
+      cancelled = true;
+      unsubLocal();
+      unsubBroadcast();
+    };
   }, []);
   return options;
 }

--- a/frontend/src/store/tableStore.test.ts
+++ b/frontend/src/store/tableStore.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { FlowProject } from "../types/flow";
-import type { TableEntry, TableId, Timestamp } from "../types/v3";
+import type { Table, TableEntry, TableId, Timestamp } from "../types/v3";
 import type { FlowStorageBackend } from "./flowStore";
 import { setFlowDraftMode, setFlowStorageBackend } from "./flowStore";
+import { setScreenLayoutStorageBackend } from "./screenLayoutStore";
 import type { TableStorageBackend } from "./tableStore";
-import { commitTables, deleteTable, setTableStorageBackend } from "./tableStore";
+import { commitTables, deleteTable, onTableChange, saveTable, setTableStorageBackend } from "./tableStore";
 
 const TS = "2026-04-29T00:00:00.000Z" as Timestamp;
 
@@ -78,5 +79,110 @@ describe("tableStore delete/commit batching", () => {
     expect(deleteTable).toHaveBeenCalledTimes(2);
     expect(deleteTable).toHaveBeenNthCalledWith(1, "b");
     expect(deleteTable).toHaveBeenNthCalledWith(2, "missing");
+  });
+});
+
+describe("tableStore onTableChange subscription (#1001)", () => {
+  beforeEach(() => {
+    setTableStorageBackend(null);
+    setFlowStorageBackend(null);
+    setScreenLayoutStorageBackend(null);
+    setFlowDraftMode(false);
+    localStorage.clear();
+  });
+
+  function setupBackends() {
+    // saveTable は syncTableMeta → flowStore.loadProject → screenLayoutStore.loadScreenLayout
+    // までチェーンするので、3 backend すべて mock する必要がある
+    const flowBackend: FlowStorageBackend = {
+      loadProject: vi.fn().mockResolvedValue(projectWithTables([])),
+      saveProject: vi.fn().mockResolvedValue(undefined),
+      deleteScreenData: vi.fn().mockResolvedValue(undefined),
+    };
+    const tableBackend: TableStorageBackend = {
+      loadTable: vi.fn().mockResolvedValue(null),
+      saveTable: vi.fn().mockResolvedValue(undefined),
+      deleteTable: vi.fn().mockResolvedValue(undefined),
+    };
+    const screenLayoutBackend = {
+      loadScreenLayout: vi.fn().mockResolvedValue(null),
+      saveScreenLayout: vi.fn().mockResolvedValue(undefined),
+    };
+    setFlowStorageBackend(flowBackend);
+    setTableStorageBackend(tableBackend);
+    setScreenLayoutStorageBackend(screenLayoutBackend);
+    return { flowBackend, tableBackend, screenLayoutBackend };
+  }
+
+  // schema 上 id は UUID v4 必須 (^[0-9a-f]{8}-[0-9a-f]{4}-4...)
+  const TABLE_UUID_1 = "11111111-aaaa-4bbb-8ccc-111111111111";
+  const TABLE_UUID_2 = "22222222-aaaa-4bbb-8ccc-222222222222";
+
+  function makeTable(id: string, label: string): Table {
+    return {
+      $schema: "../../schemas/v3/table.v3.schema.json",
+      id: id as TableId,
+      name: `table ${label}`,
+      physicalName: `table_${label}` as Table["physicalName"],
+      columns: [],
+      createdAt: TS,
+      updatedAt: TS,
+    };
+  }
+
+  it("saveTable は listener を { tableId } で呼び出す", async () => {
+    setupBackends();
+    const listener = vi.fn();
+    const unsub = onTableChange(listener);
+
+    await saveTable(makeTable(TABLE_UUID_1, "t1"));
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith({ tableId: TABLE_UUID_1 });
+
+    unsub();
+  });
+
+  it("deleteTable は listener を { tableId, deleted: true } で呼び出す", async () => {
+    setupBackends();
+    const listener = vi.fn();
+    const unsub = onTableChange(listener);
+
+    await deleteTable(TABLE_UUID_1);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith({ tableId: TABLE_UUID_1, deleted: true });
+
+    unsub();
+  });
+
+  it("unsubscribe 後は listener が呼ばれない", async () => {
+    setupBackends();
+    const listener = vi.fn();
+    const unsub = onTableChange(listener);
+
+    unsub();
+    await saveTable(makeTable(TABLE_UUID_2, "t2"));
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("listener が throw しても他 listener は実行される", async () => {
+    setupBackends();
+    const consoleErrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const failing = vi.fn().mockImplementation(() => { throw new Error("oops"); });
+    const ok = vi.fn();
+    const unsubA = onTableChange(failing);
+    const unsubB = onTableChange(ok);
+
+    await saveTable(makeTable(TABLE_UUID_1, "t1"));
+
+    expect(failing).toHaveBeenCalledTimes(1);
+    expect(ok).toHaveBeenCalledTimes(1);
+    expect(consoleErrSpy).toHaveBeenCalled();
+
+    unsubA();
+    unsubB();
+    consoleErrSpy.mockRestore();
   });
 });

--- a/frontend/src/store/tableStore.ts
+++ b/frontend/src/store/tableStore.ts
@@ -56,6 +56,36 @@ function nowTs(): Timestamp {
 
 // ─── 公開 API ────────────────────────────────────────────────────────────
 
+/**
+ * Table 変更通知 (#1001)。`saveTable` / `deleteTable` / `commitTables` の成功後に emit される。
+ *
+ * mcpBridge の `tableChanged` broadcast は backend が `excludeClientId` で originating client
+ * を除外するため、**同一 client 内の SPA 遷移先** (例: TableEditor で保存 → ViewDefinitionEditor)
+ * では受け取れない。この local pubsub は同一 client 内の listener を即時に refresh させる。
+ *
+ * cross-client (他ブラウザ tab / 他ユーザー) の変更は引き続き mcpBridge.onBroadcast("tableChanged")
+ * 経由で受け取る。両方を listen する hook を書くこと (例: ViewDefinitionEditor.useTableOptions)。
+ */
+export interface TableChangeEvent {
+  tableId: TableId;
+  /** true なら deleteTable 起因 */
+  deleted?: boolean;
+}
+
+type TableChangeListener = (event: TableChangeEvent) => void;
+const _tableChangeListeners = new Set<TableChangeListener>();
+
+export function onTableChange(listener: TableChangeListener): () => void {
+  _tableChangeListeners.add(listener);
+  return () => { _tableChangeListeners.delete(listener); };
+}
+
+function _emitTableChange(event: TableChangeEvent): void {
+  _tableChangeListeners.forEach((l) => {
+    try { l(event); } catch (e) { console.error("[tableStore] listener error:", e); }
+  });
+}
+
 /** テーブル一覧を取得 (harmony.json の TableEntry[]) */
 export async function listTables(): Promise<TableEntry[]> {
   const project = await loadProject();
@@ -104,6 +134,8 @@ export async function saveTable(table: Table): Promise<void> {
   await requireBackend().saveTable(toSave.id, toSave);
 
   await syncTableMeta(toSave);
+
+  _emitTableChange({ tableId: toSave.id });
 }
 
 /** テーブルを新規作成 */
@@ -133,6 +165,7 @@ export async function createTable(
 /** テーブルを削除 (per-file 削除 + harmony.json メタ削除) */
 export async function deleteTable(tableId: string): Promise<void> {
   await requireBackend().deleteTable(tableId);
+  _emitTableChange({ tableId: tableId as TableId, deleted: true });
 }
 
 interface CommitTablesDeps {


### PR DESCRIPTION
Closes #1001

## Summary

#932 (テーブル編集 column CRUD spec) 作業中に発覚した不具合の解決。table-editor で列追加 → 同セッション内で view-definition 編集画面に戻った際、refColumn select に新列が出現しない問題を、`tableStore` に local pubsub を追加して解決。

## 根本原因

`ViewDefinitionEditor` の `useTableOptions` / `useTablesForValidator` が **mount-only fetch** (deps 空配列の `useEffect`) で、mount 後の table 更新を取得しない。

backend は `saveTable` / `deleteTable` 時に `tableChanged` broadcast を送るが、**`excludeClientId` で originating client (= 同一 browser tab) を除外する**ため、同一 tab 内の SPA 遷移先 ViewDefinitionEditor は broadcast を受け取れなかった。

## 修正内容

### tableStore.ts: local pubsub を追加

`onTableChange(listener)` API を新設。`saveTable` / `deleteTable` 成功後に listener を emit する。同一 client 内で即時通知される。

cross-client (他 browser tab / 他ユーザー) の変更は引き続き `mcpBridge.onBroadcast("tableChanged")` 経由で受け取る。両方を listen する hook を書く。

### ViewDefinitionEditor.tsx: 2 hooks を subscription 駆動に変更

`useTableOptions` / `useTablesForValidator` の useEffect で:
1. mount 時に refresh (既存挙動)
2. `tableStore.onTableChange` を listen (同一 client)
3. `mcpBridge.onBroadcast("tableChanged")` を listen (他 client)
4. cleanup で 2/3 を unsubscribe

### tests

`tableStore.test.ts` に 4 ケース追加 (saveTable / deleteTable emit、unsubscribe、listener throw 時の他 listener 実行継続)。**6 tests pass**。

## 同根 hook の監査結果

`listTables` + `loadTable` の mount-only fetch は他にも下記。**本 PR scope 外** (列単位の選択候補を直接 UI 表示しないため):

- `frontend/src/components/sequence/SequenceEditor.tsx:206`
- `frontend/src/components/table/ErDiagram.tsx:147`
- `frontend/src/components/view-definition/ViewDefinitionListView.tsx:93`
- `frontend/src/components/view/ViewEditor.tsx:193`
- `frontend/src/components/process-flow/ProcessFlowEditor.tsx:201`
- `frontend/src/components/dashboard/panels/FunctionCountsPanel.tsx:26`

`tableStore` 側 API は既に整備済なので呼出側追加のみ。必要時に **follow-up** で導入。

## 受入基準への対応 (#1001)

- [x] table-editor で列追加 → 同セッション内で view-definition 編集画面に戻った時、refColumn select に新列が出現する
- [ ] **上記を検証する E2E test** → #932 spec の smoke 化部分の strict 化は **#932 が main に merge された後** に follow-up PR で実施する (現状 #932 は `feat/test-push-934-coverage` に staging 中のため依存できない)。**Vitest 単体テストで subscription mechanism は担保**
- [x] 同根 hook (他 editor の mount-only fetch) を監査 (上記)
- [x] memory `feedback_no_silent_test_modification.md` に従い既存 test の検証ロジックは温存

## Test plan

- [x] `npx vitest run src/store/tableStore.test.ts` → **6 tests pass**
- [x] `npx eslint` pass (3 changed files)
- [x] `npx tsc --noEmit -p tsconfig.app.json` pass
- [x] schema 変更ゼロ (governance 遵守、#511)

## ブランチ名について

クラウド版 proxy 制約 (CLAUDE.md `Claude Code クラウド版固有の制約` 節参照) により remote branch は `feat/test-push-1001-table-subscription`。content は ViewDefinitionEditor + tableStore の product code 修正。merge 後は branch 削除可。

https://claude.ai/code/session_01TumyBtkyjFU1TeQZjJjXyU

---
_Generated by [Claude Code](https://claude.ai/code/session_01TumyBtkyjFU1TeQZjJjXyU)_