### PR TITLE
test(e2e): #930 partial — 71 既存 spec へのタグ (@regression / @smoke) 付与

### DIFF
--- a/frontend/e2e/action-list-marker-badge.spec.ts
+++ b/frontend/e2e/action-list-marker-badge.spec.ts
@@ -68,7 +68,7 @@ async function setup(page: Page) {
   await expect(page.locator(".process-flow-marker-badges").first()).toBeVisible({ timeout: 10000 });
 }
 
-test.describe("処理フロー一覧 マーカー件数バッジ (#261)", () => {
+test.describe("処理フロー一覧 マーカー件数バッジ (#261)", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
     if (!mcpAvailable) return;

--- a/frontend/e2e/action-list.spec.ts
+++ b/frontend/e2e/action-list.spec.ts
@@ -40,7 +40,7 @@ const WS_KEY = "issue-926-action-list";
 let mcpAvailable = false;
 let ws: OpenedWorkspace;
 
-test.describe("処理フロー一覧", () => {
+test.describe("処理フロー一覧", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });

--- a/frontend/e2e/catalog-panels.spec.ts
+++ b/frontend/e2e/catalog-panels.spec.ts
@@ -53,7 +53,7 @@ async function setup(page: Page) {
   await expect(page.getByTestId("edit-mode-save")).toBeVisible();
 }
 
-test.describe("ProcessFlow カタログ編集パネル (#278)", () => {
+test.describe("ProcessFlow カタログ編集パネル (#278)", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });

--- a/frontend/e2e/collab/2-tab-smoke.spec.ts
+++ b/frontend/e2e/collab/2-tab-smoke.spec.ts
@@ -63,7 +63,7 @@ async function gotoEditorAndDismissDialogs(page: Page) {
   }
 }
 
-test.describe("協調編集 2-tab smoke", () => {
+test.describe("協調編集 2-tab smoke", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });

--- a/frontend/e2e/collab/draft-history.spec.ts
+++ b/frontend/e2e/collab/draft-history.spec.ts
@@ -81,7 +81,7 @@ async function ensureReadOnly(page: Page) {
   }
 }
 
-test.describe("draft history 7 日保持 UI (#893)", () => {
+test.describe("draft history 7 日保持 UI (#893)", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });

--- a/frontend/e2e/collab/presence-list.spec.ts
+++ b/frontend/e2e/collab/presence-list.spec.ts
@@ -74,7 +74,7 @@ async function gotoEditorAndStart(page: Page) {
   await expect(page.getByTestId("edit-mode-save")).toBeVisible({ timeout: 10000 });
 }
 
-test.describe("協調編集 一覧 SessionBadge 表示", () => {
+test.describe("協調編集 一覧 SessionBadge 表示", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });

--- a/frontend/e2e/collab/take-over.spec.ts
+++ b/frontend/e2e/collab/take-over.spec.ts
@@ -77,7 +77,7 @@ async function ensureReadOnly(page: Page) {
   }
 }
 
-test.describe("協調編集 引継ぎ (take-over)", () => {
+test.describe("協調編集 引継ぎ (take-over)", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });

--- a/frontend/e2e/conv-completion.spec.ts
+++ b/frontend/e2e/conv-completion.spec.ts
@@ -77,7 +77,7 @@ async function openComputeStep(page: Page) {
   await expect(page.locator('[data-field-path="expression"]')).toBeVisible({ timeout: 5000 });
 }
 
-test.describe("@conv.* 補完ポップアップ (#349)", () => {
+test.describe("@conv.* 補完ポップアップ (#349)", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
     if (!mcpAvailable) return;

--- a/frontend/e2e/conventions-catalog-product.spec.ts
+++ b/frontend/e2e/conventions-catalog-product.spec.ts
@@ -18,7 +18,7 @@ const WS_KEY = "issue-926-conventions-catalog-product";
 let mcpAvailable = false;
 let ws: OpenedWorkspace;
 
-test.describe("プロダクト規約タブ (#347)", () => {
+test.describe("プロダクト規約タブ (#347)", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });

--- a/frontend/e2e/conventions-catalog-rbac.spec.ts
+++ b/frontend/e2e/conventions-catalog-rbac.spec.ts
@@ -18,7 +18,7 @@ const WS_KEY = "issue-926-conventions-catalog-rbac";
 let mcpAvailable = false;
 let ws: OpenedWorkspace;
 
-test.describe("役割・権限タブ (#555)", () => {
+test.describe("役割・権限タブ (#555)", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });

--- a/frontend/e2e/conventions-catalog.spec.ts
+++ b/frontend/e2e/conventions-catalog.spec.ts
@@ -18,7 +18,7 @@ const WS_KEY = "issue-926-conventions-catalog";
 let mcpAvailable = false;
 let ws: OpenedWorkspace;
 
-test.describe("規約カタログ編集ビュー (#317)", () => {
+test.describe("規約カタログ編集ビュー (#317)", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });

--- a/frontend/e2e/dashboard.spec.ts
+++ b/frontend/e2e/dashboard.spec.ts
@@ -34,7 +34,7 @@ const WS_KEY = "issue-926-dashboard";
 let mcpAvailable = false;
 let ws: OpenedWorkspace;
 
-test.describe("ダッシュボード", () => {
+test.describe("ダッシュボード", { tag: ["@smoke"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
     if (!mcpAvailable) return;

--- a/frontend/e2e/data-item-id-auto.spec.ts
+++ b/frontend/e2e/data-item-id-auto.spec.ts
@@ -73,7 +73,7 @@ type GEditor = {
   };
 };
 
-test.describe("部品配置時 name / id / data-item-id 自動入力 (#328, #331)", () => {
+test.describe("部品配置時 name / id / data-item-id 自動入力 (#328, #331)", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });

--- a/frontend/e2e/designer-corrupt-data.spec.ts
+++ b/frontend/e2e/designer-corrupt-data.spec.ts
@@ -53,7 +53,7 @@ async function setupDesignerWithRawData(page: Page, rawData: unknown, key: strin
   return ws;
 }
 
-test.describe("Designer 破損データ耐性 (#131)", () => {
+test.describe("Designer 破損データ耐性 (#131)", { tag: ["@regression"] }, () => {
   const wsKeys: string[] = [];
 
   test.beforeAll(async () => {

--- a/frontend/e2e/designer-edit-session.spec.ts
+++ b/frontend/e2e/designer-edit-session.spec.ts
@@ -43,7 +43,7 @@ const WS_KEY = "issue-926-designer-edit-session";
 let mcpAvailable = false;
 let ws: OpenedWorkspace;
 
-test.describe("画面デザイナー edit-session — シナリオ 1: 編集開始 → 保存", () => {
+test.describe("画面デザイナー edit-session — シナリオ 1: 編集開始 → 保存", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });
@@ -97,7 +97,7 @@ test.describe("画面デザイナー edit-session — シナリオ 1: 編集開�
   });
 });
 
-test.describe("画面デザイナー edit-session — シナリオ 2: 編集中 → 破棄", () => {
+test.describe("画面デザイナー edit-session — シナリオ 2: 編集中 → 破棄", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });
@@ -132,7 +132,7 @@ test.describe("画面デザイナー edit-session — シナリオ 2: 編集中 
   });
 });
 
-test.describe("画面デザイナー edit-session — シナリオ 3: 再オープン → ResumeOrDiscardDialog", () => {
+test.describe("画面デザイナー edit-session — シナリオ 3: 再オープン → ResumeOrDiscardDialog", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });
@@ -185,7 +185,7 @@ test.describe("画面デザイナー edit-session — シナリオ 3: 再オー�
 // #980-A: ResumeOrDiscardDialog filter (participants[mySessionId] のみ) が
 // Designer (GrapesJS resourceType: "screen" / Puck resourceType: "puck-data") でも
 // 正しく動作することを multi-tab で検証する。
-test.describe("画面デザイナー edit-session — multi-tab ResumeOrDiscardDialog filter (#980-A)", () => {
+test.describe("画面デザイナー edit-session — multi-tab ResumeOrDiscardDialog filter (#980-A)", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });

--- a/frontend/e2e/designer-puck-multitab.spec.ts
+++ b/frontend/e2e/designer-puck-multitab.spec.ts
@@ -31,7 +31,7 @@ const WS_KEY = "issue-980-puck-multitab";
 let mcpAvailable = false;
 let ws: OpenedWorkspace;
 
-test.describe("Designer (Puck) multi-tab ResumeOrDiscardDialog filter (#980-A)", () => {
+test.describe("Designer (Puck) multi-tab ResumeOrDiscardDialog filter (#980-A)", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });

--- a/frontend/e2e/dirty-mark-resume.spec.ts
+++ b/frontend/e2e/dirty-mark-resume.spec.ts
@@ -52,7 +52,7 @@ const WS_KEY = "issue-926-dirty-mark-resume";
 let mcpAvailable = false;
 let ws: OpenedWorkspace;
 
-test.describe("dirty マーク + 再オープン — TableEditor", () => {
+test.describe("dirty マーク + 再オープン — TableEditor", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });
@@ -122,7 +122,7 @@ test.describe("dirty マーク + 再オープン — TableEditor", () => {
   });
 });
 
-test.describe("dirty マーク + 再オープン — ProcessFlowEditor", () => {
+test.describe("dirty マーク + 再オープン — ProcessFlowEditor", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });
@@ -177,7 +177,7 @@ test.describe("dirty マーク + 再オープン — ProcessFlowEditor", () => {
   });
 });
 
-test.describe("broadcast 経由の即時反映", () => {
+test.describe("broadcast 経由の即時反映", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });

--- a/frontend/e2e/drawing-anchor.spec.ts
+++ b/frontend/e2e/drawing-anchor.spec.ts
@@ -141,7 +141,7 @@ test.beforeEach(async () => {
     processFlows: [dummyGroupBody],
   });
 });
-test.describe("描画マーカー DOM anchor (#261)", () => {
+test.describe("描画マーカー DOM anchor (#261)", { tag: ["@regression"] }, () => {
   test("anchor 付き marker が対象 step の field bbox に位置合わせされる", async ({ page }) => {
     await setup(page);
 

--- a/frontend/e2e/drawing-marker.spec.ts
+++ b/frontend/e2e/drawing-marker.spec.ts
@@ -98,7 +98,7 @@ test.beforeEach(async () => {
     processFlows: [dummyGroupBody],
   });
 });
-test.describe("描画マーカー (#261)", () => {
+test.describe("描画マーカー (#261)", { tag: ["@regression"] }, () => {
   test("既存 shape marker が SVG overlay に描画される (path 要素)", async ({ page }) => {
     await setup(page);
     const overlay = page.locator(".drawing-overlay");

--- a/frontend/e2e/edit-mode.spec.ts
+++ b/frontend/e2e/edit-mode.spec.ts
@@ -138,7 +138,7 @@ async function startEditFailFast(page: import("@playwright/test").Page) {
   await page.getByTestId("edit-mode-start").click();
 }
 
-test.describe("編集モード UI — TableEditor", () => {
+test.describe("編集モード UI — TableEditor", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });
@@ -177,7 +177,7 @@ test.describe("編集モード UI — TableEditor", () => {
   });
 });
 
-test.describe("編集モード UI — ProcessFlowEditor", () => {
+test.describe("編集モード UI — ProcessFlowEditor", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => { mcpAvailable = await isMcpRunning(); });
   test.beforeEach(async () => {
     test.skip(!mcpAvailable, "backend (port 5179) が起動していません");
@@ -195,7 +195,7 @@ test.describe("編集モード UI — ProcessFlowEditor", () => {
   });
 });
 
-test.describe("編集モード UI — ViewEditor (PR-7)", () => {
+test.describe("編集モード UI — ViewEditor (PR-7)", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => { mcpAvailable = await isMcpRunning(); });
   test.beforeEach(async () => {
     test.skip(!mcpAvailable, "backend (port 5179) が起動していません");
@@ -215,7 +215,7 @@ test.describe("編集モード UI — ViewEditor (PR-7)", () => {
   });
 });
 
-test.describe("編集モード UI — ViewDefinitionEditor (PR-7)", () => {
+test.describe("編集モード UI — ViewDefinitionEditor (PR-7)", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => { mcpAvailable = await isMcpRunning(); });
   test.beforeEach(async () => {
     test.skip(!mcpAvailable, "backend (port 5179) が起動していません");
@@ -228,7 +228,7 @@ test.describe("編集モード UI — ViewDefinitionEditor (PR-7)", () => {
   });
 });
 
-test.describe("編集モード UI — SequenceEditor (PR-7)", () => {
+test.describe("編集モード UI — SequenceEditor (PR-7)", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => { mcpAvailable = await isMcpRunning(); });
   test.beforeEach(async () => {
     test.skip(!mcpAvailable, "backend (port 5179) が起動していません");
@@ -241,7 +241,7 @@ test.describe("編集モード UI — SequenceEditor (PR-7)", () => {
   });
 });
 
-test.describe("編集モード UI — ScreenItemsView per-screen (#696)", () => {
+test.describe("編集モード UI — ScreenItemsView per-screen (#696)", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => { mcpAvailable = await isMcpRunning(); });
   test.beforeEach(async () => {
     test.skip(!mcpAvailable, "backend (port 5179) が起動していません");
@@ -254,7 +254,7 @@ test.describe("編集モード UI — ScreenItemsView per-screen (#696)", () => 
   });
 });
 
-test.describe("編集モード UI — ConventionsCatalogView singleton (PR-7)", () => {
+test.describe("編集モード UI — ConventionsCatalogView singleton (PR-7)", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => { mcpAvailable = await isMcpRunning(); });
   test.beforeEach(async () => {
     test.skip(!mcpAvailable, "backend (port 5179) が起動していません");
@@ -269,7 +269,7 @@ test.describe("編集モード UI — ConventionsCatalogView singleton (PR-7)", 
   });
 });
 
-test.describe("編集モード UI — ExtensionsPanel singleton (PR-7)", () => {
+test.describe("編集モード UI — ExtensionsPanel singleton (PR-7)", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => { mcpAvailable = await isMcpRunning(); });
   test.beforeEach(async () => {
     test.skip(!mcpAvailable, "backend (port 5179) が起動していません");
@@ -284,7 +284,7 @@ test.describe("編集モード UI — ExtensionsPanel singleton (PR-7)", () => {
   });
 });
 
-test.describe("編集モード UI — FlowEditor singleton (PR-7)", () => {
+test.describe("編集モード UI — FlowEditor singleton (PR-7)", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => { mcpAvailable = await isMcpRunning(); });
   test.beforeEach(async () => {
     test.skip(!mcpAvailable, "backend (port 5179) が起動していません");
@@ -298,7 +298,7 @@ test.describe("編集モード UI — FlowEditor singleton (PR-7)", () => {
 });
 
 // 強制解除シナリオ — 2 browser context + transferEdit 連携 (#980-A 対応)
-test.describe("編集モード UI — 強制解除シナリオ", () => {
+test.describe("編集モード UI — 強制解除シナリオ", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => { mcpAvailable = await isMcpRunning(); });
   test.beforeEach(async () => {
     test.skip(!mcpAvailable, "backend (port 5179) が起動していません");
@@ -341,7 +341,7 @@ test.describe("編集モード UI — 強制解除シナリオ", () => {
 // ProcessFlow 以外のエディタでも正しく動作することを multi-tab で検証する。
 // alice が編集中に bob が同 resource を開いても ResumeOrDiscardDialog は表示されない
 // (= 「他人の Active session を自分の draft と誤認しない」)。
-test.describe("編集モード UI — ResumeOrDiscardDialog filter (multi-tab) #980-A", () => {
+test.describe("編集モード UI — ResumeOrDiscardDialog filter (multi-tab) #980-A", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => { mcpAvailable = await isMcpRunning(); });
   test.beforeEach(async () => {
     test.skip(!mcpAvailable, "backend (port 5179) が起動していません");

--- a/frontend/e2e/edit-session/1-6-step-flow.spec.ts
+++ b/frontend/e2e/edit-session/1-6-step-flow.spec.ts
@@ -81,7 +81,7 @@ async function ensureReadOnly(page: Page) {
   }
 }
 
-test.describe("spec §5 1-6 step 完全フロー (EditSession ライフサイクル)", () => {
+test.describe("spec §5 1-6 step 完全フロー (EditSession ライフサイクル)", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });

--- a/frontend/e2e/edit-session/ai-participant.spec.ts
+++ b/frontend/e2e/edit-session/ai-participant.spec.ts
@@ -78,7 +78,7 @@ async function gotoEditorAndStart(page: Page) {
   await expect(page.getByTestId("edit-mode-save")).toBeVisible({ timeout: 10000 });
 }
 
-test.describe("spec §10 AI participant smoke", () => {
+test.describe("spec §10 AI participant smoke", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });

--- a/frontend/e2e/edit-session/multi-session-branching.spec.ts
+++ b/frontend/e2e/edit-session/multi-session-branching.spec.ts
@@ -80,7 +80,7 @@ async function ensureReadOnly(page: Page) {
   }
 }
 
-test.describe("spec §9 複数 EditSession 並存 (A 案 / B 案)", () => {
+test.describe("spec §9 複数 EditSession 並存 (A 案 / B 案)", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });

--- a/frontend/e2e/edit-session/url-invitation.spec.ts
+++ b/frontend/e2e/edit-session/url-invitation.spec.ts
@@ -78,7 +78,7 @@ async function ensureReadOnly(page: Page) {
   }
 }
 
-test.describe("spec §11 URL ?session= 招待", () => {
+test.describe("spec §11 URL ?session= 招待", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });

--- a/frontend/e2e/error-boundary.spec.ts
+++ b/frontend/e2e/error-boundary.spec.ts
@@ -20,7 +20,7 @@ const WS_KEY = "issue-926-error-boundary";
 let mcpAvailable = false;
 let ws: OpenedWorkspace;
 
-test.describe("起動時 localStorage バリデーション", () => {
+test.describe("起動時 localStorage バリデーション", { tag: ["@smoke"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
     if (!mcpAvailable) return;

--- a/frontend/e2e/error-catalog-panel.spec.ts
+++ b/frontend/e2e/error-catalog-panel.spec.ts
@@ -61,7 +61,7 @@ async function setup(page: Page) {
   await expect(page.getByTestId("edit-mode-save")).toBeVisible();
 }
 
-test.describe("errorCatalog 編集パネル (#278)", () => {
+test.describe("errorCatalog 編集パネル (#278)", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });

--- a/frontend/e2e/error-dialog.spec.ts
+++ b/frontend/e2e/error-dialog.spec.ts
@@ -28,7 +28,7 @@ async function setupClipboardCapture(page: Page) {
   });
 }
 
-test.describe("ErrorDialog", () => {
+test.describe("ErrorDialog", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
     if (!mcpAvailable) return;

--- a/frontend/e2e/extensions-palette.spec.ts
+++ b/frontend/e2e/extensions-palette.spec.ts
@@ -49,7 +49,7 @@ const WS_KEY = "issue-926-extensions-palette";
 let mcpAvailable = false;
 let ws: OpenedWorkspace;
 
-test.describe("カスタムステップカードパレット (#447)", () => {
+test.describe("カスタムステップカードパレット (#447)", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
     if (!mcpAvailable) return;

--- a/frontend/e2e/extensions-panel.spec.ts
+++ b/frontend/e2e/extensions-panel.spec.ts
@@ -12,7 +12,7 @@ const dummyProject = buildProject({ name: "ext-panel" });
 let mcpAvailable = false;
 let ws: OpenedWorkspace;
 
-test.describe("拡張管理 UI (#447)", () => {
+test.describe("拡張管理 UI (#447)", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });

--- a/frontend/e2e/list-delete-ui.spec.ts
+++ b/frontend/e2e/list-delete-ui.spec.ts
@@ -32,7 +32,7 @@ const WS_KEY_EMPTY = "issue-926-list-delete-ui-empty";
 let mcpAvailable = false;
 let ws: OpenedWorkspace;
 
-test.describe("#147 一覧 削除 UI", () => {
+test.describe("#147 一覧 削除 UI", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });
@@ -161,7 +161,7 @@ test.describe("#147 一覧 削除 UI", () => {
   });
 });
 
-test.describe("#147 空状態の右クリック", () => {
+test.describe("#147 空状態の右クリック", { tag: ["@regression"] }, () => {
   let emptyWs: OpenedWorkspace;
 
   test.beforeAll(async () => {

--- a/frontend/e2e/list-ops.spec.ts
+++ b/frontend/e2e/list-ops.spec.ts
@@ -41,7 +41,7 @@ const WS_KEY = "issue-926-list-ops";
 let mcpAvailable = false;
 let ws: OpenedWorkspace;
 
-test.describe("ProcessFlowListView 操作 (#248)", () => {
+test.describe("ProcessFlowListView 操作 (#248)", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });

--- a/frontend/e2e/marker-ergonomics.spec.ts
+++ b/frontend/e2e/marker-ergonomics.spec.ts
@@ -86,7 +86,7 @@ async function setupDashboard(page: Page, fixture: OpenedWorkspace) {
   await expect(page.locator(".markers-summary-panel").first()).toBeVisible({ timeout: 10000 });
 }
 
-test.describe("marker-ergonomics (#261)", () => {
+test.describe("marker-ergonomics (#261)", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
     if (!mcpAvailable) return;

--- a/frontend/e2e/marker-panel.spec.ts
+++ b/frontend/e2e/marker-panel.spec.ts
@@ -41,7 +41,7 @@ async function setup(page: Page) {
   await expect(page.locator(".marker-panel .catalog-panel-body")).toBeVisible();
 }
 
-test.describe("MarkerPanel (#261)", () => {
+test.describe("MarkerPanel (#261)", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });

--- a/frontend/e2e/maturity-notes.spec.ts
+++ b/frontend/e2e/maturity-notes.spec.ts
@@ -141,7 +141,7 @@ test.beforeEach(async () => {
     ],
   });
 });
-test.describe("成熟度バッジ (#185/#189)", () => {
+test.describe("成熟度バッジ (#185/#189)", { tag: ["@regression"] }, () => {
   test("ステップカードに maturity バッジが表示される", async ({ page }) => {
     await setupEditor(page);
     // アクションタブが開いており、ステップが表示されている
@@ -168,7 +168,7 @@ test.describe("成熟度バッジ (#185/#189)", () => {
   });
 });
 
-test.describe("付箋 (#195/#199)", () => {
+test.describe("付箋 (#195/#199)", { tag: ["@regression"] }, () => {
   test("ステップを展開して付箋を追加できる、件数バッジが出る", async ({ page }) => {
     await setupEditor(page);
     // 最初のステップカードのヘッダをクリックして展開
@@ -190,7 +190,7 @@ test.describe("付箋 (#195/#199)", () => {
   });
 });
 
-test.describe("モード切替 + 下流警告 (#191/#197)", () => {
+test.describe("モード切替 + 下流警告 (#191/#197)", { tag: ["@regression"] }, () => {
   test("モードを下流に切り替えると warning が表示される (draft あり)", async ({ page }) => {
     await setupEditor(page);
     // 基本情報 タブを開く (下流ボタンは基本情報 expand 配下)
@@ -202,7 +202,7 @@ test.describe("モード切替 + 下流警告 (#191/#197)", () => {
   });
 });
 
-test.describe("処理フロー一覧のカード成熟度 + フィルタ (#187/#219/#233)", () => {
+test.describe("処理フロー一覧のカード成熟度 + フィルタ (#187/#219/#233)", { tag: ["@regression"] }, () => {
   // setupList は元 spec で list view 用の setup だったが realWorkspace 移植時に
   // setupEditor 統一しその関数が落ちた。一覧ページ navigate を直接行う。
   async function gotoList(page: Page) {

--- a/frontend/e2e/mcp/bulk-load.spec.ts
+++ b/frontend/e2e/mcp/bulk-load.spec.ts
@@ -6,7 +6,7 @@ import { buildProject } from "../__fixtures__/builders";
 const WS_KEY = "issue-958-mcp-bulk-load";
 
 // #958: 永続 WS + clientId 共有構造 + beforeAll workspace.open で activePath を立てる
-test.describe("wsBridge bulk load (#587) (#958)", () => {
+test.describe("wsBridge bulk load (#587) (#958)", { tag: ["@regression"] }, () => {
   let mcpAvailable = false;
 
   test.beforeAll(async () => {

--- a/frontend/e2e/mcp/designer-reconnect.spec.ts
+++ b/frontend/e2e/mcp/designer-reconnect.spec.ts
@@ -118,7 +118,7 @@ async function loadCallCount(page: Page): Promise<number> {
   });
 }
 
-test.describe("Designer MCP reconnect reload behavior (#578) (#948)", () => {
+test.describe("Designer MCP reconnect reload behavior (#578) (#948)", { tag: ["@regression"] }, () => {
   let mcpAvailable = false;
   let ws: OpenedWorkspace;
 

--- a/frontend/e2e/mcp/mcp-tools.spec.ts
+++ b/frontend/e2e/mcp/mcp-tools.spec.ts
@@ -26,7 +26,7 @@ const WS_KEY = "issue-958-mcp-tools";
 // #958: sendBrowserRequest を永続 WS + clientId 共有構造に書き直し、
 // beforeAll で test workspace を作成 + openBrowserSessionWorkspace で永続 WS の
 // activePath を立てる。
-test.describe("wsBridge ファイル操作 (#958)", () => {
+test.describe("wsBridge ファイル操作 (#958)", { tag: ["@regression"] }, () => {
   let mcpAvailable = false;
   let workspacePath: string | null = null;
 

--- a/frontend/e2e/more-ui.spec.ts
+++ b/frontend/e2e/more-ui.spec.ts
@@ -79,7 +79,7 @@ async function gotoEditor(page: Page, subPath: string) {
   }
 }
 
-test.describe("more-ui (#244)", () => {
+test.describe("more-ui (#244)", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
     if (!mcpAvailable) return;

--- a/frontend/e2e/puck-editor.spec.ts
+++ b/frontend/e2e/puck-editor.spec.ts
@@ -20,7 +20,7 @@ import {
 } from "./helpers/puck";
 import { setupTestWorkspace, normalizeId } from "./helpers/realWorkspace";
 
-test.describe("Puck エディタ基本動作", () => {
+test.describe("Puck エディタ基本動作", { tag: ["@regression"] }, () => {
   test("1. editorKind=puck の画面を開くと Puck デザイナが表示される", async ({ page }) => {
     await setupPuckScreen(page);
 
@@ -80,7 +80,7 @@ test.describe("Puck エディタ基本動作", () => {
   });
 });
 
-test.describe("GrapesJS と Puck の混在", () => {
+test.describe("GrapesJS と Puck の混在", { tag: ["@regression"] }, () => {
   test("5. 同一プロジェクトで grapesjs 画面と puck 画面が独立して存在できる", async ({ page }) => {
     // realWorkspace 経由 (#926): puck + grapesjs 両 entity を 1 workspace に seed
     const PUCK_NORM = normalizeId(PUCK_SCREEN_ID);
@@ -114,7 +114,7 @@ test.describe("GrapesJS と Puck の混在", () => {
   });
 });
 
-test.describe("cssFramework 切替", () => {
+test.describe("cssFramework 切替", { tag: ["@regression"] }, () => {
   test("6a. cssFramework=bootstrap の Puck 画面が表示される", async ({ page }) => {
     // console listener は setupPuckScreen 前に登録 (Puck 初期化中エラーも捕捉するため #839)
     const errors: string[] = [];
@@ -164,7 +164,7 @@ test.describe("cssFramework 切替", () => {
   });
 });
 
-test.describe("動的コンポーネント登録", () => {
+test.describe("動的コンポーネント登録", { tag: ["@regression"] }, () => {
   test("7. 動的コンポーネント登録ダイアログが存在する", async ({ page }) => {
     await setupPuckScreen(page);
 
@@ -192,7 +192,7 @@ test.describe("動的コンポーネント登録", () => {
   });
 });
 
-test.describe("スクリーンショット撮影 (視覚回帰検証用)", () => {
+test.describe("スクリーンショット撮影 (視覚回帰検証用)", { tag: ["@regression"] }, () => {
   test("screenshot: Puck × bootstrap 画面", async ({ page }) => {
     await setupPuckScreen(page, { puckData: PUCK_DATA_WITH_HEADING });
 

--- a/frontend/e2e/puck-visual-regression.spec.ts
+++ b/frontend/e2e/puck-visual-regression.spec.ts
@@ -32,7 +32,7 @@ import {
   setupPuckScreen,
 } from "./helpers/puck";
 
-test.describe("Puck visual regression", () => {
+test.describe("Puck visual regression", { tag: ["@regression"] }, () => {
   test.use({ viewport: { width: 1280, height: 720 } });
 
   test("Bootstrap chrome (palette + sub-toolbar + right panel)", async ({ page }) => {

--- a/frontend/e2e/resource-url-sync.spec.ts
+++ b/frontend/e2e/resource-url-sync.spec.ts
@@ -31,7 +31,7 @@ const WS_KEY = "issue-926-resource-url-sync";
 let mcpAvailable = false;
 let ws: OpenedWorkspace;
 
-test.describe("resource-url-sync", () => {
+test.describe("resource-url-sync", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
     if (!mcpAvailable) return;

--- a/frontend/e2e/save-flow.spec.ts
+++ b/frontend/e2e/save-flow.spec.ts
@@ -56,7 +56,7 @@ async function setupWithTabs(page: Page, screenIds: string[], labels: Record<str
   );
 }
 
-test.describe("保存フロー (タブ復元)", () => {
+test.describe("保存フロー (タブ復元)", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
     if (!mcpAvailable) return;

--- a/frontend/e2e/save-reset-action.spec.ts
+++ b/frontend/e2e/save-reset-action.spec.ts
@@ -87,7 +87,7 @@ async function addAction(page: Page, name: string) {
   await expect(page.locator(".process-flow-modal")).not.toBeVisible();
 }
 
-test.describe("処理フローエディタ：保存/リセットボタン", () => {
+test.describe("処理フローエディタ：保存/リセットボタン", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });

--- a/frontend/e2e/save-reset-designer.spec.ts
+++ b/frontend/e2e/save-reset-designer.spec.ts
@@ -70,7 +70,7 @@ async function setupDesigner(page: Page, opts: { emptyScreen?: boolean } = {}) {
   await ws.gotoActive(page, `/screen/design/${SCREEN_NORM}`);
 }
 
-test.describe("画面デザイナー：リセットボタン (smoke)", () => {
+test.describe("画面デザイナー：リセットボタン (smoke)", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });

--- a/frontend/e2e/save-reset-flow.spec.ts
+++ b/frontend/e2e/save-reset-flow.spec.ts
@@ -73,7 +73,7 @@ async function addScreenViaModal(
   await page.locator('.flow-modal button[type="submit"]').click();
 }
 
-test.describe("フロー画面：保存/リセットボタン", () => {
+test.describe("フロー画面：保存/リセットボタン", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });

--- a/frontend/e2e/save-reset.spec.ts
+++ b/frontend/e2e/save-reset.spec.ts
@@ -96,7 +96,7 @@ async function setupTableEditor(page: Page): Promise<void> {
   await expect(page.getByTestId("edit-mode-save")).toBeVisible();
 }
 
-test.describe("テーブルエディタ：保存/リセットボタン", () => {
+test.describe("テーブルエディタ：保存/リセットボタン", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });

--- a/frontend/e2e/schema-ui.spec.ts
+++ b/frontend/e2e/schema-ui.spec.ts
@@ -152,7 +152,7 @@ test.beforeEach(async () => {
     processFlows: [dummyGroupBody],
   });
 });
-test.describe("step runIf 入力 (#202)", () => {
+test.describe("step runIf 入力 (#202)", { tag: ["@regression"] }, () => {
   test("runIf 欄に入力すると反映される", async ({ page }) => {
     await setupEditor(page);
     const card = await expandStep(page, 2); // step-other
@@ -164,7 +164,7 @@ test.describe("step runIf 入力 (#202)", () => {
   });
 });
 
-test.describe("step outputBinding 入力 (#204)", () => {
+test.describe("step outputBinding 入力 (#204)", { tag: ["@regression"] }, () => {
   test("結果変数名 + 代入方式を設定できる", async ({ page }) => {
     await setupEditor(page);
     const card = await expandStep(page, 2);
@@ -182,7 +182,7 @@ test.describe("step outputBinding 入力 (#204)", () => {
   });
 });
 
-test.describe("アクション HTTP 契約編集 (#206)", () => {
+test.describe("アクション HTTP 契約編集 (#206)", { tag: ["@regression"] }, () => {
   test("httpRoute (method/path/auth) と responses[] を編集できる", async ({ page }) => {
     await setupEditor(page);
     // HTTP 契約パネルを開く
@@ -201,7 +201,7 @@ test.describe("アクション HTTP 契約編集 (#206)", () => {
   });
 });
 
-test.describe("dbAccess affectedRowsCheck (#210)", () => {
+test.describe("dbAccess affectedRowsCheck (#210)", { tag: ["@regression"] }, () => {
   test("UPDATE ステップで affectedRowsCheck を設定できる", async ({ page }) => {
     await setupEditor(page);
     const card = await expandStep(page, 1); // step-dbaccess (UPDATE)
@@ -218,7 +218,7 @@ test.describe("dbAccess affectedRowsCheck (#210)", () => {
   });
 });
 
-test.describe("ValidationRule[] 編集 (#212)", () => {
+test.describe("ValidationRule[] 編集 (#212)", { tag: ["@regression"] }, () => {
   test("構造化ルールを追加・削除できる", async ({ page }) => {
     await setupEditor(page);
     const card = await expandStep(page, 0); // step-validation
@@ -232,7 +232,7 @@ test.describe("ValidationRule[] 編集 (#212)", () => {
   });
 });
 
-test.describe("Branch.condition tryCatch variant (#224)", () => {
+test.describe("Branch.condition tryCatch variant (#224)", { tag: ["@regression"] }, () => {
   // #954: StepCard.tsx の branch.condition 判定を kind discriminator base に修正。
   // `br.condition?.kind === "tryCatch"` で判定し、expression / tryCatch / 他 kind を分岐。
   test("盾アイコンで tryCatch 変換、元に戻せる", async ({ page }) => {

--- a/frontend/e2e/screen-creation-editor-choice.spec.ts
+++ b/frontend/e2e/screen-creation-editor-choice.spec.ts
@@ -53,7 +53,7 @@ async function openAddScreenModal(page: Page) {
   await expect(page.locator('.flow-modal')).toBeVisible();
 }
 
-test.describe("画面作成ダイアログ — editorKind / cssFramework 選択 UI (#825)", () => {
+test.describe("画面作成ダイアログ — editorKind / cssFramework 選択 UI (#825)", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });

--- a/frontend/e2e/screen-items-reset.spec.ts
+++ b/frontend/e2e/screen-items-reset.spec.ts
@@ -73,7 +73,7 @@ async function setup(page: Page, items: Array<{ id: string; label: string; type:
   await expect(page.getByTestId("edit-mode-save")).toBeVisible();
 }
 
-test.describe("画面項目 ID リセット (#334)", () => {
+test.describe("画面項目 ID リセット (#334)", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });

--- a/frontend/e2e/screen-items.spec.ts
+++ b/frontend/e2e/screen-items.spec.ts
@@ -119,7 +119,7 @@ async function setup(page: Page, opts: SetupOptions = {}) {
   }
 }
 
-test.describe("画面項目定義プロトタイプ (#318)", () => {
+test.describe("画面項目定義プロトタイプ (#318)", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });
@@ -266,7 +266,7 @@ test.describe("画面項目定義プロトタイプ (#318)", () => {
   });
 });
 
-test.describe("@conv.* lint + 補完 + errorMessages 永続化 (#351 #352)", () => {
+test.describe("@conv.* lint + 補完 + errorMessages 永続化 (#351 #352)", { tag: ["@regression"] }, () => {
   test("存在しない @conv.regex を pattern に書いて保存すると lint バナーが表示される", async ({ page }) => {
     await setup(page, { catalog: sampleCatalog });
     // 項目追加
@@ -366,7 +366,7 @@ test.describe("@conv.* lint + 補完 + errorMessages 永続化 (#351 #352)", () 
   });
 });
 
-test.describe("詳細フィールド展開行 (#353)", () => {
+test.describe("詳細フィールド展開行 (#353)", { tag: ["@regression"] }, () => {
   test("⚙ ボタンで detail-row が開閉する", async ({ page }) => {
     await setup(page);
     await page.locator(".screen-items-view button:has-text('項目追加')").click();
@@ -488,7 +488,7 @@ test.describe("詳細フィールド展開行 (#353)", () => {
   });
 });
 
-test.describe("per-screen タブ独立編集 (#696)", () => {
+test.describe("per-screen タブ独立編集 (#696)", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => { mcpAvailable = await isMcpRunning(); });
   test.beforeEach(async () => {
     test.skip(!mcpAvailable, "backend (port 5179) が起動していません");

--- a/frontend/e2e/screen-list.spec.ts
+++ b/frontend/e2e/screen-list.spec.ts
@@ -31,7 +31,7 @@ const WS_KEY = "issue-926-screen-list";
 let mcpAvailable = false;
 let ws: OpenedWorkspace;
 
-test.describe("画面一覧", () => {
+test.describe("画面一覧", { tag: ["@smoke"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
     if (!mcpAvailable) return;

--- a/frontend/e2e/sort-readonly.spec.ts
+++ b/frontend/e2e/sort-readonly.spec.ts
@@ -31,7 +31,7 @@ const WS_KEY = "issue-926-sort-readonly";
 let mcpAvailable = false;
 let ws: OpenedWorkspace;
 
-test.describe("#148 一覧 ソート中 Read-only + No 列", () => {
+test.describe("#148 一覧 ソート中 Read-only + No 列", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });

--- a/frontend/e2e/step-advanced.spec.ts
+++ b/frontend/e2e/step-advanced.spec.ts
@@ -103,7 +103,7 @@ test.beforeEach(async () => {
     processFlows: [dummyGroupBody],
   });
 });
-test.describe("ステップ追加 (条件分岐 / ループ) (#248)", () => {
+test.describe("ステップ追加 (条件分岐 / ループ) (#248)", { tag: ["@regression"] }, () => {
   test("ツールバーから 条件分岐 を追加", async ({ page }) => {
     await setupEditor(page);
     await expect(page.locator(".step-card")).toHaveCount(1);
@@ -128,7 +128,7 @@ test.describe("ステップ追加 (条件分岐 / ループ) (#248)", () => {
   });
 });
 
-test.describe("Subtype picker でサブステップ追加 (#248)", () => {
+test.describe("Subtype picker でサブステップ追加 (#248)", { tag: ["@regression"] }, () => {
   test("コンテキストメニュー → サブステップ追加 → 種別選択", async ({ page }) => {
     await setupEditor(page);
     const firstCard = page.locator(".step-card").first();
@@ -142,7 +142,7 @@ test.describe("Subtype picker でサブステップ追加 (#248)", () => {
   });
 });
 
-test.describe("テンプレートボタン (#248)", () => {
+test.describe("テンプレートボタン (#248)", { tag: ["@regression"] }, () => {
   // STEP_TEMPLATES は空配列に変更されたため (action.ts:330)、テンプレート候補は出ない。
   // テンプレートボタン自体の存在確認のみ smoke test として残す。
   test("テンプレートボタンが存在する (空 STEP_TEMPLATES でも button は表示)", async ({ page }) => {

--- a/frontend/e2e/step-marker-badge.spec.ts
+++ b/frontend/e2e/step-marker-badge.spec.ts
@@ -96,7 +96,7 @@ test.beforeEach(async () => {
     processFlows: [dummyGroupBody],
   });
 });
-test.describe("step marker badge (#261)", () => {
+test.describe("step marker badge (#261)", { tag: ["@regression"] }, () => {
   test("step-card に未解決 marker の kind 別チップが出る (解決済みは除外)", async ({ page }) => {
     await setup(page);
 

--- a/frontend/e2e/step-ops.spec.ts
+++ b/frontend/e2e/step-ops.spec.ts
@@ -115,7 +115,7 @@ test.beforeEach(async () => {
     processFlows: [dummyGroupBody],
   });
 });
-test.describe("ステップツールバーから追加 (#246)", () => {
+test.describe("ステップツールバーから追加 (#246)", { tag: ["@regression"] }, () => {
   test("ツールバーの DBアクセス をクリックで末尾に追加される", async ({ page }) => {
     await setupEditor(page);
     await expect(page.locator(".step-card")).toHaveCount(3);
@@ -132,7 +132,7 @@ test.describe("ステップツールバーから追加 (#246)", () => {
   });
 });
 
-test.describe("ステップコンテキストメニュー (#246)", () => {
+test.describe("ステップコンテキストメニュー (#246)", { tag: ["@regression"] }, () => {
   test("メニューから複製で 4 ステップに", async ({ page }) => {
     await setupEditor(page);
     // 1 つ目の card の ・・・ メニューを開く
@@ -154,7 +154,7 @@ test.describe("ステップコンテキストメニュー (#246)", () => {
   });
 });
 
-test.describe("ステップヘッダクリックで展開・閉じる (#246)", () => {
+test.describe("ステップヘッダクリックで展開・閉じる (#246)", { tag: ["@regression"] }, () => {
   test("type label クリックで body が表示される", async ({ page }) => {
     await setupEditor(page);
     const firstCard = page.locator(".step-card").first();
@@ -166,7 +166,7 @@ test.describe("ステップヘッダクリックで展開・閉じる (#246)", (
   });
 });
 
-test.describe("メタバッジクリックで展開 (#236)", () => {
+test.describe("メタバッジクリックで展開 (#236)", { tag: ["@regression"] }, () => {
   test("runIf を設定したステップのアイコンクリックで展開される", async ({ page }) => {
     // 事前に runIf 入りステップを seed (realWorkspace 経路で再 setup)
     const withRunIfBody = {

--- a/frontend/e2e/stepcard-marker-kind-badge.spec.ts
+++ b/frontend/e2e/stepcard-marker-kind-badge.spec.ts
@@ -97,7 +97,7 @@ test.beforeEach(async () => {
     processFlows: [dummyGroupBody],
   });
 });
-test.describe("StepCard kind 別マーカーバッジ (#261)", () => {
+test.describe("StepCard kind 別マーカーバッジ (#261)", { tag: ["@regression"] }, () => {
   test("s1 に todo/question/attention 色分けチップが表示される", async ({ page }) => {
     await setup(page);
     // s1 の StepCard ヘッダ内に step-marker-chip 要素あり

--- a/frontend/e2e/tab-management.spec.ts
+++ b/frontend/e2e/tab-management.spec.ts
@@ -64,7 +64,7 @@ async function setupWithScreens(page: Page, screenIds: string[]) {
   await expect(page.locator(".tabbar-tab")).toHaveCount(screenIds.length);
 }
 
-test.describe("タブ管理", () => {
+test.describe("タブ管理", { tag: ["@smoke"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
     if (!mcpAvailable) return;

--- a/frontend/e2e/table-list.spec.ts
+++ b/frontend/e2e/table-list.spec.ts
@@ -37,7 +37,7 @@ const WS_KEY = "issue-926-table-list";
 let mcpAvailable = false;
 let ws: OpenedWorkspace;
 
-test.describe("テーブル一覧", () => {
+test.describe("テーブル一覧", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
     if (!mcpAvailable) return;

--- a/frontend/e2e/tech-stack-view.spec.ts
+++ b/frontend/e2e/tech-stack-view.spec.ts
@@ -33,7 +33,7 @@ async function setup(page: Page) {
   await ws.gotoActive(page, "/project/tech-stack");
 }
 
-test.describe("技術スタック選定画面 (#826)", () => {
+test.describe("技術スタック選定画面 (#826)", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
     if (!mcpAvailable) return;

--- a/frontend/e2e/validation-sql-conv-panel.spec.ts
+++ b/frontend/e2e/validation-sql-conv-panel.spec.ts
@@ -135,7 +135,7 @@ test.beforeEach(async () => {
     processFlows: [dummyGroupBody],
   });
 });
-test.describe("SQL 列検査 + 規約参照 の UI 統合 (#261)", () => {
+test.describe("SQL 列検査 + 規約参照 の UI 統合 (#261)", { tag: ["@regression"] }, () => {
   test("UNKNOWN_COLUMN 警告がパネルに表示される", async ({ page }) => {
     await setupEditor(page);
     // テーブル定義と規約カタログが load されるまで待つ

--- a/frontend/e2e/validation-warnings-panel.spec.ts
+++ b/frontend/e2e/validation-warnings-panel.spec.ts
@@ -118,7 +118,7 @@ test.beforeEach(async () => {
     processFlows: [dummyGroupBody],
   });
 });
-test.describe("警告パネル UI 配線 (#261 UI 統合)", () => {
+test.describe("警告パネル UI 配線 (#261 UI 統合)", { tag: ["@regression"] }, () => {
   test("警告バッジが表示される (UNKNOWN_IDENTIFIER + UNKNOWN_RESPONSE_REF)", async ({ page }) => {
     await setupEditor(page);
     const badge = page.locator(".validation-badge.warning");

--- a/frontend/e2e/view-definition.spec.ts
+++ b/frontend/e2e/view-definition.spec.ts
@@ -48,7 +48,7 @@ const WS_KEY = "issue-926-view-definition";
 let mcpAvailable = false;
 let ws: OpenedWorkspace;
 
-test.describe("ビュー定義 E2E", () => {
+test.describe("ビュー定義 E2E", { tag: ["@regression"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
   });

--- a/frontend/e2e/vite-stress.spec.ts
+++ b/frontend/e2e/vite-stress.spec.ts
@@ -71,7 +71,7 @@ async function pingVite(): Promise<{ ok: boolean; status?: number; error?: strin
   }
 }
 
-test.describe("Vite dev server multi-context stress (#992)", () => {
+test.describe("Vite dev server multi-context stress (#992)", { tag: ["@regression"] }, () => {
   test.skip(!STRESS_ENABLED, "HARMONY_E2E_VITE_STRESS=1 で明示有効化したときのみ実行");
   test.skip((_, testInfo) => testInfo.project.name !== "chromium", "chromium のみ");
   test.beforeAll(async () => {

--- a/frontend/e2e/warning-to-marker.spec.ts
+++ b/frontend/e2e/warning-to-marker.spec.ts
@@ -86,7 +86,7 @@ test.beforeEach(async () => {
     processFlows: [dummyGroupBody],
   });
 });
-test.describe("警告 → Marker 起票 (#261)", () => {
+test.describe("警告 → Marker 起票 (#261)", { tag: ["@regression"] }, () => {
   test("警告パネル内の AI に依頼ボタンで marker 作成", async ({ page }) => {
     await setup(page);
     // 警告バッジが出ていること

--- a/frontend/e2e/workspace-default-path.spec.ts
+++ b/frontend/e2e/workspace-default-path.spec.ts
@@ -22,7 +22,7 @@ async function setupWithNoWorkspace(page: Page) {
   });
 }
 
-test.describe("AddWorkspaceDialog — デフォルトパスのヒント (#755)", () => {
+test.describe("AddWorkspaceDialog — デフォルトパスのヒント (#755)", { tag: ["@regression"] }, () => {
   test("WorkspaceListView の「追加」ボタンでダイアログが開き workspaces/ ヒントが表示される", async ({ page }) => {
     await setupWithNoWorkspace(page);
     await page.goto("/workspace/list");
@@ -88,7 +88,7 @@ test.describe("AddWorkspaceDialog — デフォルトパスのヒント (#755)",
   });
 });
 
-test.describe("WorkspaceSelectView — 新規作成ボタン (#755)", () => {
+test.describe("WorkspaceSelectView — 新規作成ボタン (#755)", { tag: ["@regression"] }, () => {
   test("「新しくワークスペースを追加」ボタンで AddWorkspaceDialog が開く", async ({ page }) => {
     await setupWithNoWorkspace(page);
     await page.goto("/workspace/select");

--- a/frontend/e2e/workspace-multi-parallel.spec.ts
+++ b/frontend/e2e/workspace-multi-parallel.spec.ts
@@ -18,7 +18,7 @@ import { test, expect } from "@playwright/test";
 const WS_A_ID = "aaaaaaaa-0001-4000-8000-000000000001";
 const WS_B_ID = "bbbbbbbb-0002-4000-8000-000000000002";
 
-test.describe("並行ブラウザコンテキスト — workspace URL 独立性", () => {
+test.describe("並行ブラウザコンテキスト — workspace URL 独立性", { tag: ["@regression"] }, () => {
   test("2 ブラウザコンテキストの URL が互いに独立している", async ({ browser }) => {
     const ctxA = await browser.newContext();
     const ctxB = await browser.newContext();

--- a/frontend/e2e/workspace-multi-routing.spec.ts
+++ b/frontend/e2e/workspace-multi-routing.spec.ts
@@ -55,7 +55,7 @@ async function setupWithLockdown(page: Page) {
 
 // ─── テスト ─────────────────────────────────────────────────────────────────
 
-test.describe("URL /w/:wsId/* 規約 - ルーティング基本", () => {
+test.describe("URL /w/:wsId/* 規約 - ルーティング基本", { tag: ["@regression"] }, () => {
   test("/workspace/select は workspace 選択画面が表示される", async ({ page }) => {
     await setupWithNoWorkspace(page);
     await page.goto("/workspace/select");
@@ -86,7 +86,7 @@ test.describe("URL /w/:wsId/* 規約 - ルーティング基本", () => {
   });
 });
 
-test.describe("URL /w/:wsId/* 規約 - パス検証", () => {
+test.describe("URL /w/:wsId/* 規約 - パス検証", { tag: ["@regression"] }, () => {
   test("/w/:wsId/ 形式の URL にアクセスしてもエラーにならない", async ({ page }) => {
     await setupWithNoWorkspace(page);
     const testWsId = "aaaaaaaa-0001-4000-8000-000000000001";

--- a/frontend/e2e/workspace-navigation-smoke.spec.ts
+++ b/frontend/e2e/workspace-navigation-smoke.spec.ts
@@ -100,7 +100,7 @@ async function openFirstResource(page: Page, listPath: string, editorUrl: RegExp
   await expect(page.locator(".tabbar-tab.active")).toBeVisible();
 }
 
-test.describe("workspace navigation smoke with backend backend", () => {
+test.describe("workspace navigation smoke with backend backend", { tag: ["@smoke"] }, () => {
   test.beforeAll(async () => {
     mcpAvailable = await isMcpRunning();
     if (!mcpAvailable) return;

--- a/frontend/e2e/workspace-os-aware-input.spec.ts
+++ b/frontend/e2e/workspace-os-aware-input.spec.ts
@@ -45,7 +45,7 @@ async function isWslHost(): Promise<boolean> {
   }
 }
 
-test.describe("AddWorkspaceDialog — WSL2 / OS-aware UX (#858)", () => {
+test.describe("AddWorkspaceDialog — WSL2 / OS-aware UX (#858)", { tag: ["@regression"] }, () => {
   test("WSL2 環境では Linux 形式の絶対パスと専用ヒントが表示される", async ({ page }) => {
     test.skip(!(await isWslHost()), "WSL2 ホスト前提の test (host /proc/version に Microsoft/WSL を含むときのみ実行)");
     await setupClean(page);


### PR DESCRIPTION
Closes #930

## 概要

#1007 で partial 分離していた #930 の残部分を、本 follow-up small PR で完遂する。AGENTS.md 鉄則 1 (本 PR / follow-up small PR で吸収) 遵守。

## 経緯

- 当初 #930 は `87d2ea7` で 71 spec へのタグ付与 + 設定 + docs を 1 commit で実装
- 並行する **#986** が e2e specs を大規模再構築 → タグ付与 patch と conflict
- **#1007** で設定 (`playwright.config.ts` grepInvert / `package.json` script / `docs/test-strategy.md`) のみ partial merge
- 71 spec タグ付与は当初 #1008 として別 ISSUE 起票したが、AGENTS.md 鉄則 1/2 違反 (1-2 時間で吸収可能な作業を別 ISSUE 化していた) → close → **本 follow-up small PR で吸収** (本 PR)

## 内容

`frontend/e2e/**/*.spec.ts` の **top-level** `test.describe(...)` を全件タグ付与:

| タグ | 対象 | 件数 |
|---|---|---|
| `@smoke` | `dashboard` / `error-boundary` / `workspace-navigation-smoke` / `tab-management` / `screen-list` の 5 spec | 5 describe |
| `@regression` | 上記以外の全 top-level describe (#1007 で既に `@endurance` / `@regression` 付与済の 4 spec を除く) | 102 describe |

合計 **107 top-level describe** に変更。**nested describes は対象外** (top-level から継承)。

## 変更ファイル

**69 spec files modified** (top-level `e2e/` + `collab/` + `edit-session/` + `mcp/` サブディレクトリ)

各ファイルの変更は `test.describe("xxx", () => {` → `test.describe("xxx", { tag: ["@regression"] }, () => {` (`@smoke` は 5 spec のみ)。テスト本体ロジックには一切触れず (`feedback_no_silent_test_modification.md`)。

## Schema governance (#511)

`git diff origin/main..HEAD -- schemas/` → **0 行** (違反なし)

## 検証

- `npx tsc -b --noEmit` ✅
- `npx eslint e2e/` → 13 errors すべて origin/main pre-existing (本 PR 起因 0 errors)
- `@smoke` grep → 5 describes (5 correct files)
- `@regression` grep → 106+ tagged lines

## 本 PR の効果

#1007 で merge 済の npm script 群が初めて意味を持つ:

```bash
npm run test:e2e:smoke       # 5 spec / < 1 分目安
npm run test:e2e:regression  # 大半 / 10-20 分目安
npm run test:e2e:endurance   # examples-walkthrough のみ / 30 分超
npm run test:e2e:all         # 全タグ含む
```

## ブランチ運用 (備考)

クラウド版 git proxy 制約のため source branch は staging pattern `feat/test-push-930-tags`。Squash merge により main に 1 commit として統合される。

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Thfo4wJs7d3xk3VriwgAbA)_