### PR TITLE
improve(flow-editor): #1003 画面 node anchor マーカー機能を FlowEditor に追加

### DIFF
--- a/frontend/e2e/flow-editor.spec.ts
+++ b/frontend/e2e/flow-editor.spec.ts
@@ -366,6 +366,12 @@ test.describe("画面フロー — node D&D / edge / marker / 削除動線", { t
     // 4. パネルに未解決 marker (1 件) が表示されることを assert
     await expect(page.getByText("ヘッダー統一して")).toBeVisible({ timeout: 5000 });
 
+    // 4b. screen node に未解決 marker バッジ (数字 1) が表示されることを assert (#1003 Should-fix)
+    const screenNode = page.locator(".react-flow__node-screenNode").filter({ hasText: "marker test" });
+    const markerBadge = screenNode.getByTestId("screen-node-marker-badge");
+    await expect(markerBadge).toBeVisible({ timeout: 5000 });
+    await expect(markerBadge).toContainText("1");
+
     // 5. 「解決」ボタン → 解決メモ入力 → confirm → resolved 状態
     const markerRows = page.locator(".marker-row");
     const firstRow = markerRows.first();
@@ -377,6 +383,9 @@ test.describe("画面フロー — node D&D / edge / marker / 削除動線", { t
 
     // resolved になると行が非表示になる (showResolved=false のため)
     await expect(page.locator(".marker-row:not(.resolved)")).toHaveCount(0, { timeout: 5000 });
+
+    // 5b. resolve 後はバッジが非表示になる (unresolvedCount=0) (#1003 Should-fix)
+    await expect(markerBadge).not.toBeVisible({ timeout: 5000 });
 
     // 6. 「解決済みも表示」を on にして resolved 件数 1 件を assert
     await page.getByTestId("show-resolved-checkbox").click();

--- a/frontend/e2e/flow-editor.spec.ts
+++ b/frontend/e2e/flow-editor.spec.ts
@@ -342,18 +342,45 @@ test.describe("画面フロー — node D&D / edge / marker / 削除動線", { t
     await expect(page.locator(".react-flow__node-screenNode")).toHaveCount(0, { timeout: 5000 });
   });
 
-  // ── (C) 画面間 anchor マーカー追加 ─────────────────────────────────────
+  // ── (C) 画面間 anchor マーカー追加 → 解決 (#1003 で実装) ────────────────
 
-  test.skip("(C) 画面間 anchor マーカー追加 → 解決 [未実装 → skip]", async ({ page: _page }) => {
-    void _page;
-    /**
-     * FlowEditor には画面 node に対する anchor 付きマーカー機能が存在しない。
-     * MarkerPanel (frontend/src/components/process-flow/MarkerPanel.tsx) は
-     * ProcessFlowEditor 専用であり、FlowEditor では参照されていない。
-     * DrawingOverlay の anchor も process-flow 側の実装。
-     *
-     * 機能追加は #1003 で計画中。本 test は #1003 完了時に skip 解除し strict assert に戻す。
-     */
+  test("(C) 画面間 anchor マーカー追加 → 解決", async ({ page }) => {
+    await setupFlowEditor(page);
+
+    // 1. 画面を 1 つ作成
+    await addScreenViaModal(page, "marker test");
+
+    // 2. FlowSubToolbar の「マーカー」ボタンをクリック → FlowMarkerPanel が開く
+    await page.getByTestId("marker-panel-toggle-btn").click();
+    await expect(page.getByTestId("flow-marker-panel")).toBeVisible({ timeout: 5000 });
+
+    // 3. 対象画面を select で選び、kind=todo / body 入力 → 「追加」ボタン
+    const screenSelect = page.getByTestId("marker-screen-select");
+    await expect(screenSelect).toBeVisible({ timeout: 5000 });
+    // select には「marker test」が option として入っているはず
+    await screenSelect.selectOption({ label: "marker test" });
+    await page.getByTestId("marker-kind-select").selectOption("todo");
+    await page.getByTestId("marker-body-input").fill("ヘッダー統一して");
+    await page.getByTestId("marker-add-btn").click();
+
+    // 4. パネルに未解決 marker (1 件) が表示されることを assert
+    await expect(page.getByText("ヘッダー統一して")).toBeVisible({ timeout: 5000 });
+
+    // 5. 「解決」ボタン → 解決メモ入力 → confirm → resolved 状態
+    const markerRows = page.locator(".marker-row");
+    const firstRow = markerRows.first();
+    await expect(firstRow).toBeVisible({ timeout: 5000 });
+    const resolveBtn = firstRow.locator(".marker-resolve-btn");
+    await resolveBtn.click();
+    await page.getByTestId("resolve-note-textarea").fill("対応完了");
+    await page.getByTestId("resolve-confirm-btn").click();
+
+    // resolved になると行が非表示になる (showResolved=false のため)
+    await expect(page.locator(".marker-row:not(.resolved)")).toHaveCount(0, { timeout: 5000 });
+
+    // 6. 「解決済みも表示」を on にして resolved 件数 1 件を assert
+    await page.getByTestId("show-resolved-checkbox").click();
+    await expect(page.locator(".marker-row.resolved")).toHaveCount(1, { timeout: 5000 });
   });
 
   // ── (F) 画面名変更 → screen entity 反映 ─────────────────────────────────

--- a/frontend/src/components/flow/FlowEditor.tsx
+++ b/frontend/src/components/flow/FlowEditor.tsx
@@ -590,8 +590,22 @@ function FlowEditorInner() {
   /** marker 追加/解決/削除時に screen entity を更新して保存 */
   const handleMarkerChange = useCallback(
     async (screenId: string, updatedMarkers: Marker[]) => {
-      const entity = screenEntities.get(screenId);
-      if (!entity) return;
+      // Should-fix #1003: panel open 後に追加された画面は screenEntities に未登録の場合があるため
+      // entity が無ければ on-demand で load して Map に追加する (silent fail 防止)
+      let entity = screenEntities.get(screenId);
+      if (!entity) {
+        try {
+          entity = await loadScreenEntity(screenId);
+          setScreenEntities((prev) => {
+            const next = new Map(prev);
+            next.set(screenId, entity!);
+            return next;
+          });
+        } catch {
+          // ghost screen (entity ファイルが存在しない) の場合はスキップ
+          return;
+        }
+      }
       const updated: Screen = {
         ...entity,
         authoring: {
@@ -925,6 +939,22 @@ function FlowEditorInner() {
   useSaveShortcut(() => {
     if (isDirty && !isSaving && !isReadonly) handleSave();
   });
+
+  // Should-fix #1003: screenEntities が更新されたとき (marker 追加/解決/panel open 時) に
+  // 各 ScreenNode の data.unresolvedCount を同期して badge 表示を最新に保つ
+  useEffect(() => {
+    if (screenEntities.size === 0) return;
+    setNodes((nds) =>
+      nds.map((n) => {
+        if (n.type !== "screenNode") return n;
+        const entity = screenEntities.get(n.id);
+        if (!entity) return n;
+        const unresolvedCount = (entity.authoring?.markers ?? []).filter((m) => !m.resolvedAt).length;
+        if ((n.data as { unresolvedCount?: number }).unresolvedCount === unresolvedCount) return n;
+        return { ...n, data: { ...n.data, unresolvedCount } };
+      })
+    );
+  }, [screenEntities, setNodes]);
 
   const isEmpty = !isLoading && nodes.filter((n) => n.type === "screenNode").length === 0;
   const screenCount = nodes.filter((n) => n.type === "screenNode").length;

--- a/frontend/src/components/flow/FlowEditor.tsx
+++ b/frontend/src/components/flow/FlowEditor.tsx
@@ -84,7 +84,11 @@ const nodeTypes = {
   groupNode: GroupNodeComponent,
 };
 
-function toRFNodesWithGroups(screens: ScreenNode[], groups: ScreenGroup[]): RFNode[] {
+function toRFNodesWithGroups(
+  screens: ScreenNode[],
+  groups: ScreenGroup[],
+  screenEntities?: Map<string, Screen>,
+): RFNode[] {
   // Group nodes must come first so ReactFlow knows about parents before children
   const groupNodes: RFNode[] = (groups ?? []).map((g) => ({
     id: g.id,
@@ -98,11 +102,15 @@ function toRFNodesWithGroups(screens: ScreenNode[], groups: ScreenGroup[]): RFNo
   }));
 
   const screenNodes: RFNode[] = screens.map((s) => {
+    const entity = screenEntities?.get(s.id);
+    const unresolvedCount = entity
+      ? (entity.authoring?.markers ?? []).filter((m) => !m.resolvedAt).length
+      : 0;
     const node: RFNode = {
       id: s.id,
       type: "screenNode",
       position: s.position,
-      data: { ...s },
+      data: { ...s, unresolvedCount },
     };
     if (s.groupId) {
       node.parentId = s.groupId;
@@ -174,6 +182,9 @@ function FlowEditorInner() {
   // ── マーカーパネル ──
   const [markerPanelOpen, setMarkerPanelOpen] = useState(false);
   const [screenEntities, setScreenEntities] = useState<Map<string, Screen>>(new Map());
+  // useCallback 内から最新 screenEntities を参照するための ref
+  const screenEntitiesRef = useRef<Map<string, Screen>>(new Map());
+  useEffect(() => { screenEntitiesRef.current = screenEntities; }, [screenEntities]);
 
   const sessionId = mcpBridge.getSessionId();
 
@@ -213,7 +224,7 @@ function FlowEditorInner() {
     const prev = undoStackRef.current[undoStackRef.current.length - 1];
     undoStackRef.current = undoStackRef.current.slice(0, -1);
     projectRef.current = prev;
-    setNodes(toRFNodesWithGroups(prev.screens, prev.groups ?? []));
+    setNodes(toRFNodesWithGroups(prev.screens, prev.groups ?? [], screenEntitiesRef.current));
     setEdges(toRFEdges(prev.edges));
     setProjectName(prev.name);
     saveProject(prev).catch(console.error);
@@ -227,7 +238,7 @@ function FlowEditorInner() {
     const next = redoStackRef.current[redoStackRef.current.length - 1];
     redoStackRef.current = redoStackRef.current.slice(0, -1);
     projectRef.current = next;
-    setNodes(toRFNodesWithGroups(next.screens, next.groups ?? []));
+    setNodes(toRFNodesWithGroups(next.screens, next.groups ?? [], screenEntitiesRef.current));
     setEdges(toRFEdges(next.edges));
     setProjectName(next.name);
     saveProject(next).catch(console.error);
@@ -241,7 +252,7 @@ function FlowEditorInner() {
   const reloadProject = useCallback(async () => {
     const [project, raw] = await Promise.all([loadProject(), loadRawProject()]);
     projectRef.current = project;
-    setNodes(toRFNodesWithGroups(project.screens, project.groups ?? []));
+    setNodes(toRFNodesWithGroups(project.screens, project.groups ?? [], screenEntitiesRef.current));
     setEdges(toRFEdges(project.edges));
     setProjectName(project.name);
     setProjectDefaultEditorKind(resolveEditorKind(undefined, raw.techStack));
@@ -664,7 +675,7 @@ function FlowEditorInner() {
       return;
     }
     await storeRemoveGroup(projectRef.current, contextMenu.targetId);
-    setNodes(toRFNodesWithGroups(projectRef.current.screens, projectRef.current.groups ?? []));
+    setNodes(toRFNodesWithGroups(projectRef.current.screens, projectRef.current.groups ?? [], screenEntitiesRef.current));
     setContextMenu(null);
   }, [contextMenu, setNodes]);
 
@@ -689,7 +700,7 @@ function FlowEditorInner() {
     screen.groupId = groupId;
     screen.updatedAt = new Date().toISOString() as Timestamp;
     await saveProject(projectRef.current);
-    setNodes(toRFNodesWithGroups(projectRef.current.screens, projectRef.current.groups ?? []));
+    setNodes(toRFNodesWithGroups(projectRef.current.screens, projectRef.current.groups ?? [], screenEntitiesRef.current));
     setContextMenu(null);
   }, [contextMenu, setNodes]);
 
@@ -707,7 +718,7 @@ function FlowEditorInner() {
     screen.groupId = undefined;
     screen.updatedAt = new Date().toISOString() as Timestamp;
     await saveProject(projectRef.current);
-    setNodes(toRFNodesWithGroups(projectRef.current.screens, projectRef.current.groups ?? []));
+    setNodes(toRFNodesWithGroups(projectRef.current.screens, projectRef.current.groups ?? [], screenEntitiesRef.current));
     setContextMenu(null);
   }, [contextMenu, setNodes]);
 
@@ -766,7 +777,7 @@ function FlowEditorInner() {
         return storeRemoveGroup(project, n.id).then(() => {
           // Rebuild nodes to reflect ungrouped screens
           if (projectRef.current) {
-            setNodes(toRFNodesWithGroups(projectRef.current.screens, projectRef.current.groups ?? []));
+            setNodes(toRFNodesWithGroups(projectRef.current.screens, projectRef.current.groups ?? [], screenEntitiesRef.current));
           }
           return true;
         });
@@ -814,7 +825,7 @@ function FlowEditorInner() {
     try {
       const imported = await importProjectJSON(json);
       projectRef.current = imported;
-      setNodes(toRFNodesWithGroups(imported.screens, imported.groups ?? []));
+      setNodes(toRFNodesWithGroups(imported.screens, imported.groups ?? [], screenEntitiesRef.current));
       setEdges(toRFEdges(imported.edges));
       setProjectName(imported.name);
       needsFitViewRef.current = imported.screens.length > 0;

--- a/frontend/src/components/flow/FlowEditor.tsx
+++ b/frontend/src/components/flow/FlowEditor.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useEffect } from "react";
+import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { useWorkspacePath } from "../../hooks/useWorkspacePath";
 import {
@@ -24,9 +24,12 @@ import "@xyflow/react/dist/style.css";
 import ScreenNodeComponent from "./ScreenNode";
 import GroupNodeComponent from "./GroupNodeComponent";
 import { FlowSubToolbar } from "./FlowSubToolbar";
+import { FlowMarkerPanel } from "./FlowMarkerPanel";
 import { ScreenEditModal, type ScreenFormData } from "./ScreenEditModal";
 import { EdgeEditModal, type EdgeFormData, type HandlePosition } from "./EdgeEditModal";
 import type { FlowProject, ScreenNode, ScreenEdge, ScreenGroup } from "../../types/flow";
+import type { Screen } from "../../types/v3/screen";
+import type { Marker } from "../../types/v3/common";
 import { TRIGGER_LABELS } from "../../types/flow";
 import type { ScreenGroupId, ScreenKind, ScreenLayout, Timestamp } from "../../types/v3";
 import {
@@ -167,6 +170,10 @@ function FlowEditorInner() {
   const [showDiscardDialog, setShowDiscardDialog] = useState(false);
   const [showForceReleaseDialog, setShowForceReleaseDialog] = useState(false);
   const [showResumeDialog, setShowResumeDialog] = useState(false);
+
+  // ── マーカーパネル ──
+  const [markerPanelOpen, setMarkerPanelOpen] = useState(false);
+  const [screenEntities, setScreenEntities] = useState<Map<string, Screen>>(new Map());
 
   const sessionId = mcpBridge.getSessionId();
 
@@ -558,6 +565,50 @@ function FlowEditorInner() {
     setContextMenu(null);
   }, [contextMenu, navigate, nodes]);
 
+  // ── Marker Panel Actions ──
+
+  /** panel を開く時だけ全 screen entity を lazy load */
+  const handleToggleMarkerPanel = useCallback(async () => {
+    const opening = !markerPanelOpen;
+    setMarkerPanelOpen(opening);
+    if (opening && projectRef.current) {
+      const map = new Map<string, Screen>();
+      await Promise.all(
+        projectRef.current.screens.map(async (s) => {
+          try {
+            const entity = await loadScreenEntity(s.id);
+            map.set(s.id, entity);
+          } catch {
+            // 読み込み失敗時はスキップ (ghost screen)
+          }
+        }),
+      );
+      setScreenEntities(map);
+    }
+  }, [markerPanelOpen]);
+
+  /** marker 追加/解決/削除時に screen entity を更新して保存 */
+  const handleMarkerChange = useCallback(
+    async (screenId: string, updatedMarkers: Marker[]) => {
+      const entity = screenEntities.get(screenId);
+      if (!entity) return;
+      const updated: Screen = {
+        ...entity,
+        authoring: {
+          ...(entity.authoring ?? {}),
+          markers: updatedMarkers.length > 0 ? updatedMarkers : undefined,
+        },
+      };
+      await saveScreenEntity(updated);
+      setScreenEntities((prev) => {
+        const next = new Map(prev);
+        next.set(screenId, updated);
+        return next;
+      });
+    },
+    [screenEntities],
+  );
+
   // ── Group Actions ──
 
   const handleAddGroup = useCallback(async () => {
@@ -877,6 +928,11 @@ function FlowEditorInner() {
 
   const isEmpty = !isLoading && nodes.filter((n) => n.type === "screenNode").length === 0;
   const screenCount = nodes.filter((n) => n.type === "screenNode").length;
+  const flowScreenNodes = useMemo(
+    () => (projectRef.current?.screens ?? []),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [nodes],
+  );
   const lockedByOther = mode.kind === "locked-by-other" ? mode : null;
 
   return (
@@ -964,7 +1020,23 @@ function FlowEditorInner() {
         isSaving={isSaving}
         onSave={() => { handleSave().catch(console.error); }}
         onReset={() => { handleReset().catch(console.error); }}
+        onToggleMarkerPanel={() => { handleToggleMarkerPanel().catch(console.error); }}
+        markerPanelOpen={markerPanelOpen}
       />
+
+      {/* マーカーパネル (flow-canvas の右側にオーバーレイ表示) */}
+      {markerPanelOpen && (
+        <div className="flow-marker-panel-overlay">
+          <FlowMarkerPanel
+            screens={flowScreenNodes}
+            screenEntities={screenEntities}
+            onMarkerChange={(screenId, markers) =>
+              handleMarkerChange(screenId, markers)
+            }
+            onClose={() => setMarkerPanelOpen(false)}
+          />
+        </div>
+      )}
 
       <div className="flow-canvas">
         {isLoading ? (

--- a/frontend/src/components/flow/FlowMarkerPanel.test.tsx
+++ b/frontend/src/components/flow/FlowMarkerPanel.test.tsx
@@ -1,0 +1,215 @@
+/**
+ * FlowMarkerPanel unit tests (#1003)
+ *
+ * flowProject.screens + screenEntities mock を渡し、
+ * 追加 / 解決 / 削除 / orphan フラグ判定の各分岐を検証する。
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent, screen, waitFor } from "@testing-library/react";
+import { FlowMarkerPanel } from "./FlowMarkerPanel";
+import type { Screen } from "../../types/v3/screen";
+import type { Marker } from "../../types/v3/common";
+import type { ScreenNode } from "../../types/flow";
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+function makeScreenNode(id: string, name: string): ScreenNode {
+  return {
+    id: id as ScreenNode["id"],
+    no: 1,
+    name,
+    kind: "other",
+    description: "",
+    path: `/${id}`,
+    position: { x: 0, y: 0 },
+    size: { width: 160, height: 80 },
+    hasDesign: false,
+    createdAt: "2026-01-01T00:00:00.000Z" as ScreenNode["createdAt"],
+    updatedAt: "2026-01-01T00:00:00.000Z" as ScreenNode["updatedAt"],
+  };
+}
+
+function makeScreenEntity(id: string, name: string, markers: Marker[] = []): Screen {
+  return {
+    id: id as Screen["id"],
+    name,
+    kind: "other",
+    path: `/${id}`,
+    createdAt: "2026-01-01T00:00:00.000Z" as Screen["createdAt"],
+    updatedAt: "2026-01-01T00:00:00.000Z" as Screen["updatedAt"],
+    authoring: markers.length > 0 ? { markers } : undefined,
+  };
+}
+
+function makeMarker(id: string, body: string, resolved = false): Marker {
+  return {
+    id: id as Marker["id"],
+    kind: "todo",
+    body,
+    author: "human",
+    createdAt: "2026-01-01T00:00:00.000Z" as Marker["createdAt"],
+    resolvedAt: resolved
+      ? ("2026-01-02T00:00:00.000Z" as Marker["resolvedAt"])
+      : undefined,
+    resolution: resolved ? "(手動解決)" : undefined,
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("FlowMarkerPanel", () => {
+  const screenA = makeScreenNode("screen-a", "画面A");
+  const screenB = makeScreenNode("screen-b", "画面B");
+
+  it("画面横断で markers を集約表示する", () => {
+    const entityA = makeScreenEntity("screen-a", "画面A", [makeMarker("mk-01", "テスト指示A")]);
+    const entityB = makeScreenEntity("screen-b", "画面B", [makeMarker("mk-02", "テスト指示B")]);
+    const entitiesMap = new Map<string, Screen>([
+      ["screen-a", entityA],
+      ["screen-b", entityB],
+    ]);
+
+    render(
+      <FlowMarkerPanel
+        screens={[screenA, screenB]}
+        screenEntities={entitiesMap}
+        onMarkerChange={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("テスト指示A")).toBeTruthy();
+    expect(screen.getByText("テスト指示B")).toBeTruthy();
+  });
+
+  it("マーカーを追加すると onMarkerChange が呼ばれる", async () => {
+    const entityA = makeScreenEntity("screen-a", "画面A");
+    const entitiesMap = new Map<string, Screen>([["screen-a", entityA]]);
+    const onMarkerChange = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <FlowMarkerPanel
+        screens={[screenA]}
+        screenEntities={entitiesMap}
+        onMarkerChange={onMarkerChange}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByTestId("marker-body-input");
+    fireEvent.change(input, { target: { value: "ヘッダー統一して" } });
+    const addBtn = screen.getByTestId("marker-add-btn");
+    fireEvent.click(addBtn);
+
+    await waitFor(() => {
+      expect(onMarkerChange).toHaveBeenCalledTimes(1);
+      const [calledScreenId, calledMarkers] = onMarkerChange.mock.calls[0] as [string, Marker[]];
+      expect(calledScreenId).toBe("screen-a");
+      expect(calledMarkers).toHaveLength(1);
+      expect(calledMarkers[0].body).toBe("ヘッダー統一して");
+      expect(calledMarkers[0].kind).toBe("chat"); // 初期値
+    });
+  });
+
+  it("解決ボタンを押すと resolvedAt が埋まる", async () => {
+    const mk = makeMarker("mk-resolve", "解決検証用");
+    const entityA = makeScreenEntity("screen-a", "画面A", [mk]);
+    const entitiesMap = new Map<string, Screen>([["screen-a", entityA]]);
+    const onMarkerChange = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <FlowMarkerPanel
+        screens={[screenA]}
+        screenEntities={entitiesMap}
+        onMarkerChange={onMarkerChange}
+        onClose={vi.fn()}
+      />,
+    );
+
+    // 解決ボタンをクリック
+    const resolveBtn = screen.getByTestId("resolve-btn-mk-resolve");
+    fireEvent.click(resolveBtn);
+
+    // 解決確定ボタンをクリック
+    const confirmBtn = screen.getByTestId("resolve-confirm-btn");
+    fireEvent.click(confirmBtn);
+
+    await waitFor(() => {
+      expect(onMarkerChange).toHaveBeenCalledTimes(1);
+      const [, calledMarkers] = onMarkerChange.mock.calls[0] as [string, Marker[]];
+      expect(calledMarkers[0].resolvedAt).toBeDefined();
+      expect(calledMarkers[0].resolution).toBeTruthy();
+    });
+  });
+
+  it("「解決済みも表示」オフ時は resolved marker は非表示", () => {
+    const resolvedMk = makeMarker("mk-resolved", "解決済みマーカー", true);
+    const entityA = makeScreenEntity("screen-a", "画面A", [resolvedMk]);
+    const entitiesMap = new Map<string, Screen>([["screen-a", entityA]]);
+
+    render(
+      <FlowMarkerPanel
+        screens={[screenA]}
+        screenEntities={entitiesMap}
+        onMarkerChange={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    // 解決済みは非表示 (初期状態は showResolved=false)
+    expect(screen.queryByText("解決済みマーカー")).toBeNull();
+
+    // 「解決済みも表示」チェックオン
+    const checkbox = screen.getByTestId("show-resolved-checkbox");
+    fireEvent.click(checkbox);
+
+    expect(screen.getByText("解決済みマーカー")).toBeTruthy();
+  });
+
+  it("orphan marker (flowProject.screens に存在しない screenId) に orphan バッジが表示される", () => {
+    const orphanMk = makeMarker("mk-orphan", "orphan マーカー");
+    // orphan-screen は screenNode 一覧に含まれない
+    const orphanEntity = makeScreenEntity("orphan-screen", "消えた画面", [orphanMk]);
+    const entitiesMap = new Map<string, Screen>([["orphan-screen", orphanEntity]]);
+
+    render(
+      <FlowMarkerPanel
+        screens={[screenA]} // orphan-screen は含まれない
+        screenEntities={entitiesMap}
+        onMarkerChange={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("orphan マーカー")).toBeTruthy();
+    expect(screen.getByTestId("marker-orphan-badge")).toBeTruthy();
+  });
+
+  it("マーカーを削除すると onMarkerChange が空配列で呼ばれる", async () => {
+    const mk = makeMarker("mk-delete", "削除検証");
+    const entityA = makeScreenEntity("screen-a", "画面A", [mk]);
+    const entitiesMap = new Map<string, Screen>([["screen-a", entityA]]);
+    const onMarkerChange = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <FlowMarkerPanel
+        screens={[screenA]}
+        screenEntities={entitiesMap}
+        onMarkerChange={onMarkerChange}
+        onClose={vi.fn()}
+      />,
+    );
+
+    // trash ボタンをクリック
+    const row = screen.getByTestId("marker-row-mk-delete");
+    const deleteBtn = row.querySelector(".btn-link.text-danger") as HTMLButtonElement;
+    fireEvent.click(deleteBtn);
+
+    await waitFor(() => {
+      expect(onMarkerChange).toHaveBeenCalledTimes(1);
+      const [, calledMarkers] = onMarkerChange.mock.calls[0] as [string, Marker[]];
+      expect(calledMarkers).toHaveLength(0);
+    });
+  });
+});

--- a/frontend/src/components/flow/FlowMarkerPanel.tsx
+++ b/frontend/src/components/flow/FlowMarkerPanel.tsx
@@ -1,0 +1,416 @@
+/**
+ * FlowEditor 用 マーカーパネル (#1003)
+ *
+ * 画面フロー上の各 screen.authoring.markers を横断集約して表示・編集する。
+ * ProcessFlow 側の MarkerPanel.tsx を参考に、screen-flow 用に新設。
+ * - @ts-nocheck は使わない (型をしっかり付ける)
+ * - validator kind は手動追加 UI に出さない (AI/runtime が生成するもの)
+ * - 手動追加可能な kind: chat / attention / todo / question の 4 種
+ */
+
+import { useState, useCallback } from "react";
+import type { Screen } from "../../types/v3/screen";
+import type { Marker, MarkerKind } from "../../types/v3/common";
+import type { ScreenNode } from "../../types/flow";
+import { generateUUID } from "../../utils/uuid";
+
+// ── 定数 ────────────────────────────────────────────────────────────────────
+
+const ADDABLE_KINDS: MarkerKind[] = ["chat", "attention", "todo", "question"];
+
+const KIND_LABELS: Record<MarkerKind, string> = {
+  chat: "チャット",
+  attention: "注目",
+  todo: "TODO",
+  question: "質問",
+  validator: "バリデーター",
+};
+
+const KIND_ICONS: Record<MarkerKind, string> = {
+  chat: "bi-chat-left-text",
+  attention: "bi-eye",
+  todo: "bi-check2-square",
+  question: "bi-question-circle",
+  validator: "bi-exclamation-triangle",
+};
+
+// ── 型 ──────────────────────────────────────────────────────────────────────
+
+/** 集約済みマーカー: 所属 screen 情報付き */
+export interface AggregatedMarker {
+  marker: Marker;
+  screenId: string;
+  screenName: string;
+  /** flowProject.screens に対象 screen が存在しない = orphan */
+  isOrphan: boolean;
+}
+
+export interface Props {
+  /** flowProject.screens の ScreenNode 一覧 (orphan 判定用) */
+  screens: ScreenNode[];
+  /** screenId → Screen entity (loadScreenEntity 済み) */
+  screenEntities: Map<string, Screen>;
+  /** マーカー追加 / 解決 / 削除後に呼ばれるコールバック (screen entity を save する責務は呼び出し側) */
+  onMarkerChange: (screenId: string, updatedMarkers: Marker[]) => Promise<void>;
+  /** パネルを閉じる */
+  onClose: () => void;
+}
+
+// ── ヘルパー ─────────────────────────────────────────────────────────────────
+
+function aggregateMarkers(
+  screens: ScreenNode[],
+  screenEntities: Map<string, Screen>,
+): AggregatedMarker[] {
+  const result: AggregatedMarker[] = [];
+  const validScreenIds = new Set(screens.map((s) => s.id));
+
+  // screenEntities に含まれる全 screen を走査 (orphan も含む)
+  for (const [screenId, entity] of screenEntities) {
+    const markers = entity.authoring?.markers ?? [];
+    for (const marker of markers) {
+      result.push({
+        marker,
+        screenId,
+        screenName: entity.name ?? screenId,
+        isOrphan: !validScreenIds.has(screenId as unknown as ScreenNode["id"]),
+      });
+    }
+  }
+
+  // 作成日時降順
+  result.sort(
+    (a, b) =>
+      new Date(b.marker.createdAt).getTime() - new Date(a.marker.createdAt).getTime(),
+  );
+  return result;
+}
+
+// ── コンポーネント ────────────────────────────────────────────────────────────
+
+export function FlowMarkerPanel({
+  screens,
+  screenEntities,
+  onMarkerChange,
+  onClose,
+}: Props) {
+  const [newScreenId, setNewScreenId] = useState<string>(screens[0]?.id ?? "");
+  const [newKind, setNewKind] = useState<MarkerKind>("chat");
+  const [newBody, setNewBody] = useState("");
+  const [showResolved, setShowResolved] = useState(false);
+  const [resolvingId, setResolvingId] = useState<string | null>(null);
+  const [resolveNote, setResolveNote] = useState("");
+
+  const aggregated = aggregateMarkers(screens, screenEntities);
+  const displayed = showResolved
+    ? aggregated
+    : aggregated.filter((a) => !a.marker.resolvedAt);
+  const unresolvedCount = aggregated.filter((a) => !a.marker.resolvedAt).length;
+
+  // ── helpers ────────────────────────────────────────────────────────────────
+
+  const getMarkersForScreen = useCallback(
+    (screenId: string): Marker[] => {
+      const entity = screenEntities.get(screenId);
+      return entity?.authoring?.markers ?? [];
+    },
+    [screenEntities],
+  );
+
+  // ── actions ────────────────────────────────────────────────────────────────
+
+  const handleAdd = useCallback(async () => {
+    const body = newBody.trim();
+    if (!body || !newScreenId) return;
+    const newMarker: Marker = {
+      id: generateUUID(),
+      kind: newKind,
+      body,
+      author: "human",
+      createdAt: new Date().toISOString() as Marker["createdAt"],
+    };
+    const current = getMarkersForScreen(newScreenId);
+    await onMarkerChange(newScreenId, [...current, newMarker]);
+    setNewBody("");
+  }, [newBody, newScreenId, newKind, getMarkersForScreen, onMarkerChange]);
+
+  const handleStartResolve = useCallback((id: string) => {
+    setResolvingId(id);
+    setResolveNote("");
+  }, []);
+
+  const handleCancelResolve = useCallback(() => {
+    setResolvingId(null);
+    setResolveNote("");
+  }, []);
+
+  const handleConfirmResolve = useCallback(
+    async (screenId: string, id: string) => {
+      const note = resolveNote.trim();
+      const current = getMarkersForScreen(screenId);
+      const updated = current.map((m) =>
+        m.id === id
+          ? {
+              ...m,
+              resolvedAt: new Date().toISOString() as Marker["resolvedAt"],
+              resolution: note || "(人間が手動で解決)",
+            }
+          : m,
+      );
+      await onMarkerChange(screenId, updated);
+      setResolvingId(null);
+      setResolveNote("");
+    },
+    [resolveNote, getMarkersForScreen, onMarkerChange],
+  );
+
+  const handleUnresolve = useCallback(
+    async (screenId: string, id: string) => {
+      const current = getMarkersForScreen(screenId);
+      const updated = current.map((m) =>
+        m.id === id ? { ...m, resolvedAt: undefined, resolution: undefined } : m,
+      );
+      await onMarkerChange(screenId, updated);
+    },
+    [getMarkersForScreen, onMarkerChange],
+  );
+
+  const handleRemove = useCallback(
+    async (screenId: string, id: string) => {
+      const current = getMarkersForScreen(screenId);
+      const updated = current.filter((m) => m.id !== id);
+      await onMarkerChange(screenId, updated);
+    },
+    [getMarkersForScreen, onMarkerChange],
+  );
+
+  // ── render ─────────────────────────────────────────────────────────────────
+
+  return (
+    <div className="flow-marker-panel" data-testid="flow-marker-panel">
+      <div className="flow-marker-panel-header">
+        <span className="flow-marker-panel-title">
+          <i className="bi bi-megaphone" />{" "}
+          AI へのマーカー ({unresolvedCount} 未解決 / {aggregated.length} 総件数)
+        </span>
+        <button
+          type="button"
+          className="btn btn-sm btn-link flow-marker-panel-close"
+          onClick={onClose}
+          title="閉じる"
+        >
+          <i className="bi bi-x-lg" />
+        </button>
+      </div>
+
+      <div className="flow-marker-panel-body">
+        <div className="catalog-help" style={{ marginBottom: 8, fontSize: "0.8rem" }}>
+          画面フロー上の各画面に AI (Claude Code) への指示・質問を紐付けます。
+          <br />
+          <code>/designer-work</code> で未解決マーカーをまとめて処理させる。
+        </div>
+
+        {/* 解決済み表示切替 */}
+        <div className="d-flex align-items-center gap-2 mb-2">
+          <label className="small d-flex align-items-center gap-1">
+            <input
+              type="checkbox"
+              checked={showResolved}
+              onChange={(e) => setShowResolved(e.target.checked)}
+              data-testid="show-resolved-checkbox"
+            />
+            解決済みも表示
+          </label>
+        </div>
+
+        {/* マーカー一覧 */}
+        {displayed.length === 0 && (
+          <div className="catalog-empty" data-testid="marker-empty">
+            {aggregated.length === 0
+              ? "まだマーカーがありません。"
+              : "未解決のマーカーはありません。"}
+          </div>
+        )}
+
+        {displayed.map(({ marker: m, screenId, screenName, isOrphan }) => {
+          const resolved = !!m.resolvedAt;
+          const isResolving = resolvingId === m.id;
+          return (
+            <div
+              key={m.id}
+              className={`catalog-row marker-row marker-kind-${m.kind}${resolved ? " resolved" : ""}`}
+              data-testid={`marker-row-${m.id}`}
+            >
+              <div className="catalog-row-header">
+                <span className="marker-kind-badge">
+                  <i className={`bi ${KIND_ICONS[m.kind]}`} />{" "}
+                  {KIND_LABELS[m.kind] ?? m.kind}
+                </span>
+                <span className="marker-screen-ref small text-muted" style={{ maxWidth: 120, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                  {screenName}
+                </span>
+                <span className="marker-author small text-muted">
+                  {m.author === "human" ? "人間" : "AI"}
+                </span>
+                {isOrphan && !resolved && (
+                  <span
+                    className="marker-orphan-badge small"
+                    title="紐付く画面が削除されたため、マーカーは孤立しています"
+                    data-testid="marker-orphan-badge"
+                  >
+                    <i className="bi bi-unlock" /> 該当画面なし
+                  </span>
+                )}
+                {resolved ? (
+                  <button
+                    type="button"
+                    className="btn btn-sm btn-link text-success ms-auto"
+                    onClick={() => { void handleUnresolve(screenId, m.id); }}
+                    title="未解決に戻す"
+                  >
+                    <i className="bi bi-check-circle-fill" />
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    className="btn btn-sm btn-link ms-auto marker-resolve-btn"
+                    onClick={() => handleStartResolve(m.id)}
+                    title="解決済みにする (メモ付き)"
+                    disabled={isResolving}
+                    data-testid={`resolve-btn-${m.id}`}
+                  >
+                    <i className="bi bi-check-circle" />
+                  </button>
+                )}
+                <button
+                  type="button"
+                  className="btn btn-sm btn-link text-danger"
+                  onClick={() => { void handleRemove(screenId, m.id); }}
+                  title="削除"
+                >
+                  <i className="bi bi-trash" />
+                </button>
+              </div>
+
+              <div className="marker-body">{m.body}</div>
+
+              {isResolving && !resolved && (
+                <div className="marker-resolve-form">
+                  <textarea
+                    className="form-control form-control-sm"
+                    rows={2}
+                    value={resolveNote}
+                    placeholder="解決メモ (任意): 何をしたか・なぜ閉じるか"
+                    onChange={(e) => setResolveNote(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+                        e.preventDefault();
+                        void handleConfirmResolve(screenId, m.id);
+                      } else if (e.key === "Escape") {
+                        e.preventDefault();
+                        handleCancelResolve();
+                      }
+                    }}
+                    autoFocus
+                    data-testid="resolve-note-textarea"
+                  />
+                  <div className="marker-resolve-form-actions">
+                    <button
+                      type="button"
+                      className="btn btn-sm btn-success"
+                      onClick={() => { void handleConfirmResolve(screenId, m.id); }}
+                      title="解決済みとして閉じる (Ctrl+Enter)"
+                      data-testid="resolve-confirm-btn"
+                    >
+                      <i className="bi bi-check-lg" /> 解決
+                    </button>
+                    <button
+                      type="button"
+                      className="btn btn-sm btn-outline-secondary"
+                      onClick={handleCancelResolve}
+                      title="キャンセル (Esc)"
+                    >
+                      キャンセル
+                    </button>
+                  </div>
+                </div>
+              )}
+
+              {resolved && m.resolution && (
+                <div className="marker-resolution">
+                  <strong>解決メモ:</strong> {m.resolution}
+                </div>
+              )}
+
+              <div className="marker-timestamps small text-muted">
+                {new Date(m.createdAt).toLocaleString("ja-JP")}
+                {resolved && m.resolvedAt && (
+                  <> — 解決: {new Date(m.resolvedAt).toLocaleString("ja-JP")}</>
+                )}
+              </div>
+            </div>
+          );
+        })}
+
+        {/* マーカー追加フォーム */}
+        <div className="catalog-row catalog-row-add marker-add-row" style={{ marginTop: 8 }}>
+          <div className="d-flex gap-2 mb-2 flex-wrap">
+            <select
+              className="form-select form-select-sm"
+              value={newScreenId}
+              onChange={(e) => setNewScreenId(e.target.value)}
+              style={{ maxWidth: 160 }}
+              data-testid="marker-screen-select"
+            >
+              {screens.length === 0 && (
+                <option value="">（画面がありません）</option>
+              )}
+              {screens.map((s) => (
+                <option key={s.id} value={s.id}>
+                  {s.name}
+                </option>
+              ))}
+            </select>
+            <select
+              className="form-select form-select-sm"
+              value={newKind}
+              onChange={(e) => setNewKind(e.target.value as MarkerKind)}
+              style={{ maxWidth: 120 }}
+              data-testid="marker-kind-select"
+            >
+              {ADDABLE_KINDS.map((k) => (
+                <option key={k} value={k}>
+                  {KIND_LABELS[k]}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="d-flex gap-2">
+            <input
+              className="form-control form-control-sm"
+              placeholder="AI への指示・質問を入力 (例: ヘッダーを統一して)"
+              value={newBody}
+              onChange={(e) => setNewBody(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault();
+                  void handleAdd();
+                }
+              }}
+              data-testid="marker-body-input"
+            />
+            <button
+              type="button"
+              className="btn btn-sm btn-outline-primary"
+              onClick={() => { void handleAdd(); }}
+              disabled={!newBody.trim() || !newScreenId}
+              data-testid="marker-add-btn"
+            >
+              <i className="bi bi-plus-lg" /> 追加
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/flow/FlowSubToolbar.tsx
+++ b/frontend/src/components/flow/FlowSubToolbar.tsx
@@ -23,6 +23,10 @@ interface Props {
   isSaving?: boolean;
   onSave?: () => void;
   onReset?: () => void;
+  /** マーカーパネルを開く */
+  onToggleMarkerPanel?: () => void;
+  /** マーカーパネルが開いているか */
+  markerPanelOpen?: boolean;
 }
 
 export function FlowSubToolbar({
@@ -32,6 +36,7 @@ export function FlowSubToolbar({
   onZoomChange, onFitView,
   onUndo, onRedo, canUndo, canRedo,
   isDirty, isSaving, onSave, onReset,
+  onToggleMarkerPanel, markerPanelOpen,
 }: Props) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(projectName);
@@ -184,6 +189,16 @@ export function FlowSubToolbar({
             />
           </div>
 
+          {onToggleMarkerPanel && (
+            <button
+              className={`flow-btn ${markerPanelOpen ? "flow-btn-primary" : "flow-btn-secondary"}`}
+              onClick={onToggleMarkerPanel}
+              title="マーカーパネルを開く"
+              data-testid="marker-panel-toggle-btn"
+            >
+              <i className="bi bi-megaphone" /> マーカー
+            </button>
+          )}
           <button className="flow-btn flow-btn-secondary" onClick={onAddGroup} title="グループを追加">
             <i className="bi bi-collection" /> グループ
           </button>

--- a/frontend/src/components/flow/ScreenNode.tsx
+++ b/frontend/src/components/flow/ScreenNode.tsx
@@ -3,20 +3,37 @@ import { Handle, Position, type NodeProps } from "@xyflow/react";
 import type { ScreenNode as ScreenNodeData } from "../../types/flow";
 import { SCREEN_KIND_LABELS, SCREEN_KIND_ICONS } from "../../types/flow";
 
+/** ScreenNode data に注入される marker 集計 (FlowEditor が screenEntities から計算)。 */
+type ScreenNodeDataWithMarker = ScreenNodeData & {
+  unresolvedCount?: number;
+};
+
 type ScreenNodeProps = NodeProps & {
-  data: ScreenNodeData;
+  data: ScreenNodeDataWithMarker;
   selected?: boolean;
 };
 
 function ScreenNodeComponent({ data, selected }: ScreenNodeProps) {
   const icon = SCREEN_KIND_ICONS[data.kind] ?? "bi-circle";
   const kindLabel = SCREEN_KIND_LABELS[data.kind] ?? data.kind;
+  const unresolvedCount = data.unresolvedCount ?? 0;
 
   return (
     <>
       <Handle type="target" position={Position.Top} id="top" />
       <Handle type="target" position={Position.Left} id="left" />
-      <div className={`screen-node${selected ? " selected" : ""}`} data-screen-id={data.id}>
+      <div className={`screen-node${selected ? " selected" : ""}`} data-screen-id={data.id} style={{ position: "relative" }}>
+        {/* Should-fix #1003: 未解決 marker バッジ — ReactFlow ノードと一体で position / zoom 追従 */}
+        {unresolvedCount > 0 && (
+          <span
+            className="screen-node-marker-badge"
+            data-testid="screen-node-marker-badge"
+            title={`未解決マーカー ${unresolvedCount} 件`}
+          >
+            <i className="bi bi-megaphone-fill" style={{ fontSize: 9, marginRight: 2 }} />
+            {unresolvedCount}
+          </span>
+        )}
         <div className="screen-node-header">
           <i className={`bi ${icon} screen-node-icon`} />
           <span className="screen-node-name">{data.name}</span>

--- a/frontend/src/components/flow/ScreenNode.tsx
+++ b/frontend/src/components/flow/ScreenNode.tsx
@@ -22,7 +22,7 @@ function ScreenNodeComponent({ data, selected }: ScreenNodeProps) {
     <>
       <Handle type="target" position={Position.Top} id="top" />
       <Handle type="target" position={Position.Left} id="left" />
-      <div className={`screen-node${selected ? " selected" : ""}`} data-screen-id={data.id} style={{ position: "relative" }}>
+      <div className={`screen-node${selected ? " selected" : ""}`} data-screen-id={data.id}>
         {/* Should-fix #1003: 未解決 marker バッジ — ReactFlow ノードと一体で position / zoom 追従 */}
         {unresolvedCount > 0 && (
           <span

--- a/frontend/src/components/flow/ScreenNode.tsx
+++ b/frontend/src/components/flow/ScreenNode.tsx
@@ -16,7 +16,7 @@ function ScreenNodeComponent({ data, selected }: ScreenNodeProps) {
     <>
       <Handle type="target" position={Position.Top} id="top" />
       <Handle type="target" position={Position.Left} id="left" />
-      <div className={`screen-node${selected ? " selected" : ""}`}>
+      <div className={`screen-node${selected ? " selected" : ""}`} data-screen-id={data.id}>
         <div className="screen-node-header">
           <i className={`bi ${icon} screen-node-icon`} />
           <span className="screen-node-name">{data.name}</span>

--- a/frontend/src/styles/flow.css
+++ b/frontend/src/styles/flow.css
@@ -5,6 +5,8 @@
   height: calc(100vh - var(--common-header-h, 0px) - var(--tabbar-h, 0px));
   background: #f1f5f9;
   font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  /* Must-fix #1003: .flow-marker-panel-overlay の absolute 配置の基準 ancestor にする */
+  position: relative;
 }
 
 /* ── Flow Topbar (EditorHeader の title/center/extraRight slot 内で使用) ─── */
@@ -958,6 +960,27 @@
   color: #6c757d;
 }
 
+/* ── Screen Node Marker Badge (#1003 Should-fix) ─────────────── */
+
+.screen-node-marker-badge {
+  position: absolute;
+  top: -8px;
+  right: -8px;
+  display: inline-flex;
+  align-items: center;
+  background: #f59e0b;
+  color: #fff;
+  border-radius: 10px;
+  padding: 1px 5px;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1.4;
+  white-space: nowrap;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  z-index: 1;
+  pointer-events: none;
+}
+
 /* ── Flow Marker Panel (#1003) ───────────────────────────────── */
 
 .flow-marker-panel-overlay {
@@ -1019,7 +1042,5 @@
   white-space: nowrap;
 }
 
-/* flow-canvas が marker panel を隠さないよう relative 配置 */
-.flow-root .flow-canvas {
-  position: relative;
-}
+/* .flow-canvas は flex:1 で伸長し、ReactFlow キャンバスを内包する */
+/* (position: relative は既に .flow-canvas に定義済み — line 175付近) */

--- a/frontend/src/styles/flow.css
+++ b/frontend/src/styles/flow.css
@@ -185,6 +185,7 @@
 
 /* ── Screen Node ───────────────────────────── */
 .screen-node {
+  position: relative;
   background: #fff;
   border: 2px solid #e2e8f0;
   border-radius: 10px;

--- a/frontend/src/styles/flow.css
+++ b/frontend/src/styles/flow.css
@@ -957,3 +957,69 @@
   font-size: 11px;
   color: #6c757d;
 }
+
+/* ── Flow Marker Panel (#1003) ───────────────────────────────── */
+
+.flow-marker-panel-overlay {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 380px;
+  max-width: 100%;
+  height: 100%;
+  z-index: 20;
+  overflow-y: auto;
+  box-shadow: -2px 0 8px rgba(0, 0, 0, 0.12);
+  background: #fff;
+}
+
+.flow-marker-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: #fff;
+  border-left: 1px solid #e2e8f0;
+}
+
+.flow-marker-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border-bottom: 1px solid #e2e8f0;
+  background: #f8fafc;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.flow-marker-panel-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #334155;
+}
+
+.flow-marker-panel-close {
+  color: #64748b;
+  padding: 2px 6px;
+}
+
+.flow-marker-panel-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+}
+
+.flow-marker-panel .marker-screen-ref {
+  font-size: 11px;
+  color: #6c757d;
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* flow-canvas が marker panel を隠さないよう relative 配置 */
+.flow-root .flow-canvas {
+  position: relative;
+}


### PR DESCRIPTION
## Summary

Closes #1003

FlowEditor (`/screen/flow`) に **画面 node を anchor 対象とするマーカー (チャット / 注目 / TODO / 質問)** を追加できる UI を組み込みました。

- 各 marker は対象画面の `screen.json` の `authoring.markers[]` に格納 (既存 `Screen.authoring` フィールドを流用)
- **schema 変更ゼロ** (`Screen.authoring.markers` / `MarkerAnchor.shape` は既存) — schema governance (#511) を厳守
- `MarkerPanel.tsx` (process-flow 用、331 行) は流用ではなく screen-flow 用に簡潔に新設
- `FlowSubToolbar` の「マーカー」ボタンでパネル開閉、ReactFlow Pane と並列表示
- `ScreenNode` に `data-screen-id={id}` を追加して DOM anchor 起点を提供 (既存 `markerAnchor.ts` 互換)
- screen 削除時は screen.json 自体が消えるため markers も自動消滅、orphan は基本発生しない (集約時に flowProject.screens 不在なら orphan フラグ表示)
- #933 で skip した `frontend/e2e/flow-editor.spec.ts` test (C) を strict assert に戻して受入条件を満たした

## 変更ファイル

| ファイル | 種別 | 概要 |
|---|---|---|
| `frontend/src/components/flow/FlowMarkerPanel.tsx` | 新規 | screen 横断 marker 集約 + 追加 / 解決 / 削除 / orphan フラグ |
| `frontend/src/components/flow/FlowMarkerPanel.test.tsx` | 新規 | vitest 6 件 (集約 / 追加 / 解決 / 削除 / orphan / resolved 切替) |
| `frontend/src/components/flow/FlowEditor.tsx` | 改修 | `FlowMarkerPanel` 組込・lazy load・`loadScreenEntity` / `saveScreenEntity` 経由の marker 読み書き。PR review 修正: on-demand load (新規画面 silent fail 防止) + screenEntities→nodes data 同期 useEffect (badge 表示最新化) |
| `frontend/src/components/flow/ScreenNode.tsx` | 改修 | `data-screen-id={data.id}` 追加 + 未解決 marker バッジ (`screen-node-marker-badge`) 追加 — ReactFlow ノードと一体で position / zoom 追従 |
| `frontend/src/components/flow/FlowSubToolbar.tsx` | 改修 | マーカーボタン追加 (`onToggleMarkerPanel` / `markerPanelOpen` props) |
| `frontend/e2e/flow-editor.spec.ts` | 改修 | test (C) skip 解除 → strict assert (追加→表示→解決→件数) + badge 表示アサーション追加 |
| `frontend/src/styles/flow.css` | 改修 | `.flow-root { position: relative }` (overlay positioning fix) / `.screen-node-marker-badge` / `.flow-marker-panel-overlay` / `.flow-marker-panel` スタイル |

## 仕様逐条突合 (受入条件)

ISSUE #1003 の受入条件 6 項目を以下に file:line で突合:

- [x] FlowEditor に MarkerPanel を統合 — `frontend/src/components/flow/FlowEditor.tsx` (`FlowMarkerPanel` import + 組込)
- [x] 画面 node を anchor 対象に持つ marker を追加できる — `FlowMarkerPanel.tsx` (画面 select + kind/body 入力 + 追加 button)
- [x] anchor が node の DOM 位置に追従 — `ScreenNode.tsx` に未解決数 badge を埋め込み、ReactFlow ノードと一体で position / zoom 追従。`data-screen-id` も将来の SVG drawing overlay 拡張用 anchor として残置
- [x] 「解決」操作で resolved 状態 — `FlowMarkerPanel.tsx` (resolve メモ入力 + confirm)
- [x] orphan marker (anchor 対象 node が削除された) の表示 — `FlowMarkerPanel.tsx` (flowProject.screens 不在時 orphan フラグ)
- [x] `frontend/e2e/flow-editor.spec.ts` test (C) の `test.skip` 解除 + strict assert に戻す — `frontend/e2e/flow-editor.spec.ts:347`

## PR review 修正 (3 件)

- **Must-fix CSS**: `.flow-root { position: relative }` 追加 — `.flow-marker-panel-overlay` の absolute 配置が viewport ベースで誤位置になる CSS bug を修正
- **Should-fix silent fail**: `handleMarkerChange` で on-demand `loadScreenEntity` 実装 — panel open 後に新規追加した画面への marker 追加が silent fail する問題を修正
- **Should-fix badge**: `ScreenNode.tsx` に `screen-node-marker-badge` バッジ追加 — 未解決 marker 数を ReactFlow ノード右上に表示 (ノードと一体で position / zoom 追従)。E2E test (C) にバッジ表示アサーション追加

## #1004 並行作業との衝突回避

#1004 (draft-state validation UI 拡張) と並行 worktree 進行中のため、以下を **触らない** よう厳守:

- `frontend/src/store/flowStore.ts` (#1004 が改修)
- `frontend/src/store/screenStore.ts` (#1004 が `loadValidationMap()` 追加)
- `frontend/src/components/flow/ScreenListView.tsx` (#1004 が ValidationBadge 追加)

`screenStore` の API は既存 `loadScreenEntity` / `saveScreenEntity` のみ使用 (新規 export なし)。merge 順序は #1003 と #1004 のどちらが先でも衝突なし。

## schema governance (#511)

- ✅ `git diff --name-only origin/main..HEAD -- 'schemas/*'` → 空 (schema 変更なし)
- 設計 (ISSUE comment) で「`ScreenLayout` への `markers` フィールド追加」「`MarkerAnchor` への `screenId` 追加」を意識的に避けた

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vitest run FlowMarkerPanel` — 6 passed
- [x] `npx playwright test flow-editor.spec.ts` — 7 passed (test (C) 含む、badge アサーション pass)
- [x] `npx eslint .` — 新規ファイルは 0 errors (`EdgeEditModal.tsx` の pre-existing 6 warnings は本 PR 範囲外)
- [x] schema diff 空確認
- [x] #1004 衝突ファイル diff 空確認

## 既知の制約

- worktree で E2E 実行する際は `VITE_PORT=5174` が必要 (5173 は本リポジトリ dev server が占有)。これは worktree 運用一般の制約で本 ISSUE スコープ外

🤖 Generated with [Claude Code](https://claude.com/claude-code)
