### PR TITLE
fix(flow-editor): #1003 marker id の branded type を修正

### DIFF
--- a/frontend/src/components/flow/FlowMarkerPanel.tsx
+++ b/frontend/src/components/flow/FlowMarkerPanel.tsx
@@ -123,7 +123,7 @@ export function FlowMarkerPanel({
     const body = newBody.trim();
     if (!body || !newScreenId) return;
     const newMarker: Marker = {
-      id: generateUUID(),
+      id: generateUUID() as Marker["id"],
       kind: newKind,
       body,
       author: "human",


### PR DESCRIPTION
## 関連

- Refs #1003
- Refs #1011
- 仕様: N/A (merge 後 main の TypeScript build break 修正)

## 概要

#1011 merge 後の最新 main で `npx tsc -b --noEmit` が失敗していたため、FlowEditor marker の ID 型を既存 v3 branded type に合わせます。

## 主な変更

- `FlowMarkerPanel.tsx` で `generateUUID()` の戻り値を `Marker["id"]` に cast
- runtime 挙動は不変。型定義との整合だけを修正

## 仕様逐条突合 (自己申告)

- Marker ID は `frontend/src/types/v3/common.ts` の `Marker.id: Uuid` に従う → `frontend/src/components/flow/FlowMarkerPanel.tsx` で `Marker["id"]` に cast ✓

## レビューで特に見てほしい箇所

- 型修正のみで runtime 差分がないこと

## テスト

- Vitest: 27 件 — `FlowMarkerPanel.test.tsx` / `flowStore.roundtrip.test.ts` / `viewDefinitionStore.test.ts`
- Playwright: `--list` のみ
  - `npm run test:e2e -- --grep "画面間 anchor マーカー" --list` → 1 test
  - `npm run test:e2e -- --grep "draft-state validation 表示" --list` → 17 tests
- TypeScript: `npx tsc -b --noEmit` ✓
- ESLint: `npx eslint src/components/flow/FlowMarkerPanel.tsx` ✓
- `git diff --check` ✓

## UI 影響 / AI smoke test

- [x] UI 影響なし (auto テスト pass のみ)

### UI 影響ありの場合、AI smoke test で確認した項目

- [x] N/A

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

#1003 / #1004 完了後レビューで発見した build break の最小 follow-up です。#1003 の機能仕様や #1004 の validation UI には触れていません。
