### PR TITLE
fix(workspace): lockdown の初期遷移を復旧 (#1014)

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -18,7 +18,7 @@ import { handleAuthCheck, handlePropose } from "./aiRename.js";
 import { htmlToReact, toPascalCase } from "./reactExporter.js";
 import { readProject, readCustomBlocks, readTable, writeTable, deleteTable as deleteTableFile, writeProject, readErLayout, readProcessFlow, writeProcessFlow, deleteProcessFlow as deleteProcessFlowFile, listProcessFlows as listProcessFlowFiles, readPuckComponents, writePuckComponents } from "./projectStorage.js";
 import { mcpTableToSpecEntry } from "./specExport.js";
-import { initWorkspaceState, getActivePath, setActivePath, clearActive, connect as wsConnect, disconnect as wsDisconnect, isLockdown, getLockdownPath, LockdownError, WorkspaceUnsetError, workspaceContextManager } from "./workspaceState.js";
+import { initWorkspaceState, getActivePath, setActivePath, clearActive, connect as wsConnect, disconnect as wsDisconnect, isLockdown, getLockdownPath, LockdownError, WorkspaceUnsetError, workspaceContextManager, LOCKDOWN_WORKSPACE_ID } from "./workspaceState.js";
 import { listWorkspaces, upsertWorkspace, removeWorkspace, findById, findByPath, setLastActive } from "./recentStore.js";
 import { autoActivateOnStartup, inspectWorkspacePath, initializeWorkspace } from "./workspaceInit.js";
 import { initServerLog, shutdownServerLog, logInfo, logError, ingestClientLog } from "./serverLog.js";
@@ -1111,16 +1111,18 @@ function createMcpServer(sessionId: string): Server {
 
       // ── ワークスペース管理 (#671) ─────────────────────────────────
       case "designer__workspace_list": {
-        const { workspaces, lastActiveId } = await listWorkspaces();
+        const lockdown = isLockdown();
+        const { workspaces, lastActiveId } = lockdown
+          ? { workspaces: [], lastActiveId: null }
+          : await listWorkspaces();
         const activePath = getActivePath(sessionId);
         const activeEntry = activePath ? await findByPath(activePath) : null;
-        const lockdown = isLockdown();
         const lockdownPath = getLockdownPath();
         const payload = {
           workspaces,
           lastActiveId,
           active: activePath
-            ? { id: activeEntry?.id ?? null, path: activePath, name: activeEntry?.name ?? null }
+            ? { id: lockdown ? LOCKDOWN_WORKSPACE_ID : activeEntry?.id ?? null, path: activePath, name: activeEntry?.name ?? null }
             : null,
           lockdown,
           lockdownPath,

--- a/backend/src/workspaceListActiveId.test.ts
+++ b/backend/src/workspaceListActiveId.test.ts
@@ -27,6 +27,7 @@ const {
   findByPath,
   listWorkspaces,
 } = await import("./recentStore.js");
+const { LOCKDOWN_WORKSPACE_ID } = await import("./workspaceState.js");
 
 beforeAll(async () => {
   await fs.mkdir(TMP_DIR, { recursive: true });
@@ -135,5 +136,19 @@ describe("workspace.list active.id 解決 (#956)", () => {
       ? { id: activeEntry?.id ?? null, path: activePath, name: activeEntry?.name ?? null }
       : null;
     expect(activePayload?.id).toBeNull();
+  });
+
+  it("lockdown 時は recent エントリがなくても固定 active.id を返す", async () => {
+    const activePath = "/tmp/ws-lockdown-not-registered";
+    const activeEntry = await findByPath(activePath);
+    const lockdown = true;
+
+    expect(activeEntry).toBeNull();
+
+    const activePayload = activePath
+      ? { id: lockdown ? LOCKDOWN_WORKSPACE_ID : activeEntry?.id ?? null, path: activePath, name: activeEntry?.name ?? null }
+      : null;
+
+    expect(activePayload?.id).toBe("lockdown");
   });
 });

--- a/backend/src/workspaceState.ts
+++ b/backend/src/workspaceState.ts
@@ -41,6 +41,9 @@ let _initialized = false;
  */
 let _globalDefaultPath: string | null = null;
 
+/** lockdown モード時に URL / protocol 上で使う固定 workspace id */
+export const LOCKDOWN_WORKSPACE_ID = "lockdown";
+
 /** autoActivateOnStartup が設定するデフォルトの active path (#700 R-2) */
 export function setGlobalDefaultPath(absPath: string | null): void {
   _globalDefaultPath = absPath ? path.resolve(absPath) : null;

--- a/backend/src/wsBridge.ts
+++ b/backend/src/wsBridge.ts
@@ -20,6 +20,7 @@ import {
   isLockdown as isWorkspaceLockdown,
   getLockdownPath as getWorkspaceLockdownPath,
   LockdownError as WorkspaceLockdownError,
+  LOCKDOWN_WORKSPACE_ID,
   workspaceContextManager,
 } from "./workspaceState.js";
 import {
@@ -1347,16 +1348,19 @@ class WsBridge extends EventEmitter {
 
         // ── ワークスペース管理 (#671/#672/#673) ─────────────────────────
         case "workspace.list": {
-          const { workspaces, lastActiveId } = await listWorkspacesEntries();
+          const lockdown = isWorkspaceLockdown();
+          const { workspaces, lastActiveId } = lockdown
+            ? { workspaces: [], lastActiveId: null }
+            : await listWorkspacesEntries();
           const activePath = workspaceContextManager.getActivePath(clientId);
           const activeEntry = activePath ? await findWorkspaceByPath(activePath) : null;
           respond({
             workspaces,
             lastActiveId,
             active: activePath
-              ? { id: activeEntry?.id ?? null, path: activePath, name: activeEntry?.name ?? null }
+              ? { id: lockdown ? LOCKDOWN_WORKSPACE_ID : activeEntry?.id ?? null, path: activePath, name: activeEntry?.name ?? null }
               : null,
-            lockdown: isWorkspaceLockdown(),
+            lockdown,
             lockdownPath: getWorkspaceLockdownPath(),
           });
           break;
@@ -1840,4 +1844,3 @@ function _serializeEditSession(session: import("./editSessionStore.js").EditSess
     participants: Object.fromEntries(session.participants.entries()),
   };
 }
-

--- a/docs/spec/workspace.md
+++ b/docs/spec/workspace.md
@@ -281,7 +281,7 @@ backend offline 時 (port 5179 未接続) は `connectionFailed` が立ち、App
 
 | method | params | レスポンス |
 |--------|--------|-----------|
-| `workspace.list` | (なし) | `{ workspaces: WorkspaceEntry[], lastActiveId, active: { path, name } \| null, lockdown, lockdownPath }` |
+| `workspace.list` | (なし) | `{ workspaces: WorkspaceEntry[], lastActiveId, active: { id, path, name } \| null, lockdown, lockdownPath }` |
 | `workspace.status` | (なし) | `{ active: { path, name } \| null, lockdown, lockdownPath }` |
 | `workspace.inspect` | `{ path: string }` | `{ status: "ready" \| "needsInit" \| "notFound", path, name? }` |
 | `workspace.open` | `{ path?: string, id?: string, init?: boolean }` | `{ active: { id, path, name } }` または error |
@@ -298,6 +298,8 @@ backend offline 時 (port 5179 未接続) は `connectionFailed` が立ち、App
 
 `workspace.open` 成功時と `workspace.close` 成功時に broadcast される。
 UI 側は `workspaceStore.subscribeWorkspaceChanges()` で subscribe し、自動的に `loadWorkspaces()` を再実行する。
+
+lockdown 時の `workspace.list.active.id` は recent に依存せず固定値 `"lockdown"` を返す。これにより `/w/:wsId/*` の URL 正規化は recent エントリが存在しない環境でも `/w/lockdown/` として成立する。
 
 **実装**: `backend/src/wsBridge.ts:772-777, 789-791` (broadcast) / `frontend/src/store/workspaceStore.ts:163-190` (subscribe)
 

--- a/frontend/e2e/lockdown-routing.spec.ts
+++ b/frontend/e2e/lockdown-routing.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from "@playwright/test";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const THIS_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(THIS_DIR, "../..");
+const LOCKDOWN_WORKSPACE = path.join(REPO_ROOT, ".tmp", "e2e-workspaces", "lockdown-routing");
+
+test.describe("lockdown routing", { tag: ["@regression"] }, () => {
+  test.beforeAll(async () => {
+    await fs.rm(LOCKDOWN_WORKSPACE, { recursive: true, force: true });
+    await fs.mkdir(path.dirname(LOCKDOWN_WORKSPACE), { recursive: true });
+    await fs.cp(path.join(REPO_ROOT, "examples", "retail"), LOCKDOWN_WORKSPACE, { recursive: true });
+  });
+
+  test.afterAll(async () => {
+    await fs.rm(LOCKDOWN_WORKSPACE, { recursive: true, force: true });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.clear();
+      sessionStorage.clear();
+      window.alert = () => {};
+      window.confirm = () => false;
+    });
+  });
+
+  test("recent エントリなしの lockdown でも旧 URL / から dashboard へ遷移できる", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(page).toHaveURL(/\/w\/lockdown\/$/);
+    await expect(page.locator(".dashboard-view")).toBeVisible();
+    await expect(page.getByTestId("workspace-indicator-name")).not.toContainText("ワークスペース未選択");
+    await expect(page.locator("text=ワークスペース情報を読み込み中")).toHaveCount(0);
+    await expect(page.locator("text=ページを読み込み中")).toHaveCount(0);
+  });
+
+  test("lockdown の workspace.list は URL 用 active.id を返す", async ({ page }) => {
+    await page.goto("/");
+    await expect(page).toHaveURL(/\/w\/lockdown\/$/);
+
+    const state = await page.evaluate(async () => {
+      const bridge = window.__mcpBridge;
+      if (!bridge) throw new Error("mcpBridge not initialized");
+      return bridge.request("workspace.list") as Promise<{
+        active: { id: string | null; path: string; name: string | null } | null;
+        workspaces: unknown[];
+        lockdown: boolean;
+      }>;
+    });
+
+    expect(state.lockdown).toBe(true);
+    expect(state.workspaces).toHaveLength(0);
+    expect(state.active?.id).toBe("lockdown");
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "test:e2e": "playwright test",
     "test:e2e:smoke": "playwright test --grep @smoke",
     "test:e2e:regression": "playwright test --grep @regression",
+    "test:e2e:lockdown": "playwright test --config playwright.lockdown.config.ts",
     "test:e2e:endurance": "E2E_INCLUDE_ENDURANCE=1 playwright test --grep @endurance",
     "test:e2e:all": "E2E_INCLUDE_ENDURANCE=1 playwright test",
     "validate:samples": "tsx scripts/validate-samples.ts"

--- a/frontend/playwright.lockdown.config.ts
+++ b/frontend/playwright.lockdown.config.ts
@@ -1,0 +1,44 @@
+import path from "node:path";
+import { defineConfig, devices } from "@playwright/test";
+
+const VITE_PORT = parseInt(process.env.VITE_PORT ?? "5183", 10);
+const MCP_PORT = parseInt(process.env.DESIGNER_MCP_PORT ?? "5189", 10);
+const BASE_URL = `http://localhost:${VITE_PORT}`;
+const LOCKDOWN_WORKSPACE = path.resolve("..", ".tmp", "e2e-workspaces", "lockdown-routing");
+
+export default defineConfig({
+  testDir: "./e2e",
+  testMatch: /lockdown-routing\.spec\.ts$/,
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: "list",
+  use: {
+    baseURL: BASE_URL,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    { name: "chromium", use: { ...devices["Desktop Chrome"] } },
+  ],
+  webServer: [
+    {
+      command: `VITE_DESIGNER_MCP_PORT=${MCP_PORT} npm run dev -- --port ${VITE_PORT}`,
+      url: BASE_URL,
+      reuseExistingServer: true,
+      timeout: 30000,
+      env: { VITE_DESIGNER_MCP_PORT: String(MCP_PORT) },
+    },
+    {
+      command: `cd ../backend && DESIGNER_MCP_PORT=${MCP_PORT} DESIGNER_DATA_DIR="${LOCKDOWN_WORKSPACE}" npm run dev`,
+      url: `http://localhost:${MCP_PORT}`,
+      reuseExistingServer: true,
+      timeout: 30000,
+      env: {
+        DESIGNER_MCP_PORT: String(MCP_PORT),
+        DESIGNER_DATA_DIR: LOCKDOWN_WORKSPACE,
+      },
+    },
+  ],
+});

--- a/frontend/src/components/design/DesignSubToolbar.tsx
+++ b/frontend/src/components/design/DesignSubToolbar.tsx
@@ -14,7 +14,8 @@ import { upsertCustomBlock } from "../../store/customBlockStore";
 import { EditSessionDropdown } from "../editing/EditSessionDropdown";
 import type { EditMode } from "../../hooks/useEditSession";
 
-const MCP_HTTP_BASE = `http://${window.location.hostname}:5179`;
+const MCP_HTTP_PORT = import.meta.env.VITE_DESIGNER_MCP_PORT ?? "5179";
+const MCP_HTTP_BASE = `http://${window.location.hostname}:${MCP_HTTP_PORT}`;
 
 type AiRenameStage = "auth-check" | "analyzing" | "inferring" | "proposed" | "applying" | "done" | "error";
 

--- a/frontend/src/mcp/mcpBridge.ts
+++ b/frontend/src/mcp/mcpBridge.ts
@@ -99,7 +99,8 @@ type ProcessFlowHandler = {
   mutate: (type: string, params: unknown) => void;
 };
 
-const WS_URL = `ws://${window.location.hostname}:5179`;
+const MCP_PORT = import.meta.env.VITE_DESIGNER_MCP_PORT ?? "5179";
+const WS_URL = `ws://${window.location.hostname}:${MCP_PORT}`;
 const RETRY_DELAY_MS = 5000;
 const REQUEST_TIMEOUT_MS = 15000;
 

--- a/frontend/src/store/workspaceStore.test.ts
+++ b/frontend/src/store/workspaceStore.test.ts
@@ -33,10 +33,11 @@ const { mcpBridge } = await import("../mcp/mcpBridge");
 
 // ストアモジュールは vi.mock が確定した後にインポートする必要があるため動的 import
 const storeModule = await import("./workspaceStore");
-const { loadWorkspaces, getState, __resetLoadChainForTest } = storeModule;
+const { loadWorkspaces, getState, __resetLoadChainForTest, __resetStateForTest } = storeModule;
 
 beforeEach(() => {
   vi.clearAllMocks();
+  __resetStateForTest();
   // Nit: テスト間で _loadChain が持続しないようリセット
   __resetLoadChainForTest();
 });
@@ -131,5 +132,26 @@ describe("loadWorkspaces 直列化 (A)", () => {
     expect(st.error).toBeNull();
     expect(st.workspaces.length).toBe(1);
     expect(st.workspaces[0].id).toBe("ws-ok");
+  });
+
+  it("lockdown 時は recent エントリがなく active.id が null でも固定 id を補完する", async () => {
+    const mockReq = mcpBridge.request as ReturnType<typeof vi.fn>;
+    mockReq.mockResolvedValueOnce({
+      workspaces: [],
+      lastActiveId: null,
+      active: { id: null, path: "/tmp/lockdown-ws", name: null },
+      lockdown: true,
+      lockdownPath: "/tmp/lockdown-ws",
+    });
+
+    await loadWorkspaces();
+
+    const st = getState();
+    expect(st.lockdown).toBe(true);
+    expect(st.active).toEqual({
+      id: "lockdown",
+      path: "/tmp/lockdown-ws",
+      name: null,
+    });
   });
 });

--- a/frontend/src/store/workspaceStore.ts
+++ b/frontend/src/store/workspaceStore.ts
@@ -1,5 +1,7 @@
 import { mcpBridge } from "../mcp/mcpBridge";
 
+const LOCKDOWN_WORKSPACE_ID = "lockdown";
+
 // ─── 型定義 ─────────────────────────────────────────────────────────────────
 
 export interface WorkspaceEntry {
@@ -140,7 +142,7 @@ async function _doLoadWorkspaces(): Promise<void> {
       workspaces: result.workspaces ?? [],
       active: result.active
         ? {
-            id: result.active.id ?? undefined,
+            id: result.active.id ?? (result.lockdown ? LOCKDOWN_WORKSPACE_ID : undefined),
             path: result.active.path,
             name: result.active.name,
           }


### PR DESCRIPTION
## 関連

- Closes #1014
- 仕様: docs/spec/workspace.md §6.1 / §6.2

## 概要

lockdown モードで recent workspace エントリが無い場合でも、旧 URL `/` から `/w/lockdown/` へ正しく遷移できるようにします。`workspace.list.active.id` が null になることで AppShell の URL 正規化が止まり、読み込み中表示のままになる障害を修正します。

## 主な変更

- lockdown workspace ID: protocol / URL 用の固定 ID `lockdown` を追加
- workspace.list: lockdown 時は recent を読まず、`workspaces: []`, `lastActiveId: null`, `active.id: "lockdown"` を返す
- frontend fallback: lockdown + `active.id: null` の旧 backend 応答でも `lockdown` を補完
- E2E: 別ポートの lockdown backend + Vite で旧 URL から dashboard へ到達する regression test を追加
- test infra: `VITE_DESIGNER_MCP_PORT` で frontend の WS / HTTP MCP port を差し替え可能化

## 仕様逐条突合 (自己申告)

- §6.1 `workspace.list` は `active: { id, path, name }` を返す → docs/spec/workspace.md:284 / backend/src/wsBridge.ts:1357-1364 ✓
- §6.2 lockdown 時の `workspace.list.active.id` は recent 非依存の `"lockdown"` → docs/spec/workspace.md:302 / backend/src/wsBridge.ts:1350-1364 / backend/src/index.ts:1113-1129 ✓
- §4.2 lockdown 時は recent read/write を skip → backend/src/wsBridge.ts:1351-1354 / backend/src/index.ts:1114-1117 ✓
- `/w/:wsId/*` URL 正規化が recent 空でも成立 → frontend/src/store/workspaceStore.ts:141-150 / frontend/e2e/lockdown-routing.spec.ts:30-37 ✓
- lockdown 専用 E2E は通常 5179 backend と分離 → frontend/playwright.lockdown.config.ts:25-42 / frontend/src/mcp/mcpBridge.ts:102-103 / frontend/src/components/design/DesignSubToolbar.tsx:17-18 ✓

## レビューで特に見てほしい箇所

- `lockdown` を URL/protocol 用の固定 ID として扱う判断が、通常 workspace の UUID と衝突しない前提で妥当か
- lockdown 時に `workspace.list` の recent を空にすることで既存 UI 表示に副作用がないか
- `VITE_DESIGNER_MCP_PORT` 導入が通常 port 5179 の既存挙動を変えていないか

## テスト

- Vitest: 7 件 (新規 1 件) — `backend/src/workspaceListActiveId.test.ts`
- Vitest: 19 件 (新規 1 件) — `frontend/src/store/workspaceStore.test.ts` / `frontend/src/routing/workspaceRouting.test.ts`
- Playwright: 2 件 (新規 2 件) — `frontend/e2e/lockdown-routing.spec.ts`
- Build: backend `npm run build` / frontend `npm run build`
- ESLint: 変更ファイル限定 pass。全体 `npm run lint` は既存 126 errors で失敗

## UI 影響 / AI smoke test

- [x] UI 影響あり (AI が Playwright で smoke test 実施済み)
- [ ] UI 影響なし (auto テスト pass のみ)

### UI 影響ありの場合、AI smoke test で確認した項目

- [x] lockdown routing: `/` から `/w/lockdown/` へ遷移し dashboard が表示される — Playwright で確認
- [x] loading 表示が残らない — Playwright で確認
- [x] `workspace.list` が lockdown + recent 空 + `active.id: "lockdown"` を返す — Playwright で確認

## spec 側の不足点 / 提案

- `workspace.list` の response 表に `active.id` が未記載だったため、本 PR で追記しました。

## レビュー担当への申し送り

この障害の本質は backend active path は存在するが、lockdown では recent を使わないため URL 用 ID が作れない点です。通常 workspace と異なり lockdown は切替不能なので、固定 ID `lockdown` を protocol 境界で与える方針にしています。
