### PR TITLE
chore(frontend): ESLint baseline を層別化 (#1016)

### DIFF
--- a/frontend/e2e/maturity-notes.spec.ts
+++ b/frontend/e2e/maturity-notes.spec.ts
@@ -146,6 +146,7 @@ test.describe("成熟度バッジ (#185/#189)", { tag: ["@regression"] }, () => 
     await setupEditor(page);
     // アクションタブが開いており、ステップが表示されている
     const firstStepCard = page.locator("[data-testid='data-list-row'], .step-card").first();
+    await expect(firstStepCard).toBeVisible();
     // MaturityBadge は role=button または span (onChange 渡しているので role=button)
     const badges = page.locator(".maturity-badge");
     await expect(badges.first()).toBeVisible();
@@ -174,6 +175,7 @@ test.describe("付箋 (#195/#199)", { tag: ["@regression"] }, () => {
     // 最初のステップカードのヘッダをクリックして展開
     const firstCard = page.locator(".step-card").first();
     const header = firstCard.locator(".step-card-header, .step-card-body").first();
+    await expect(header).toBeVisible();
     // step-card の上部 (type-label 付近) をクリックで展開
     await firstCard.locator(".step-card-type-label").first().click();
     // 付箋を追加ボタンが見える

--- a/frontend/e2e/schema-ui.spec.ts
+++ b/frontend/e2e/schema-ui.spec.ts
@@ -172,7 +172,6 @@ test.describe("step outputBinding 入力 (#204)", { tag: ["@regression"] }, () =
     await expect(nameInput).toBeVisible();
     await nameInput.fill("myResult");
     // 代入方式を accumulate に
-    const opSelect = card.locator("label", { hasText: "代入方式" }).locator("+ select, ~ select").first();
     // fallback: select after label containing 代入方式
     const opSelectAlt = card.locator("select").filter({ hasText: "accumulate" });
     if (await opSelectAlt.count() > 0) {

--- a/frontend/e2e/workspace-multi-routing.spec.ts
+++ b/frontend/e2e/workspace-multi-routing.spec.ts
@@ -41,18 +41,6 @@ async function setupWithNoWorkspace(page: Page) {
   });
 }
 
-async function setupWithLockdown(page: Page) {
-  // lockdown モード: DESIGNER_DATA_DIR が設定されている状態をシミュレート
-  // workspaceStore は MCP の workspace.list レスポンスで lockdown を判定するため
-  // 直接 localStorage で制御できない。
-  // 代わりに flow-project + tabs を設定して最低限のコンテンツが表示できる状態にする
-  await page.addInitScript(() => {
-    localStorage.clear();
-    window.alert = () => {};
-    window.confirm = () => false;
-  });
-}
-
 // ─── テスト ─────────────────────────────────────────────────────────────────
 
 test.describe("URL /w/:wsId/* 規約 - ルーティング基本", { tag: ["@regression"] }, () => {

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'test-results', 'playwright-report']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [
@@ -18,6 +18,54 @@ export default defineConfig([
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+    },
+    rules: {
+      '@typescript-eslint/no-unused-vars': ['error', {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
+      }],
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/ban-ts-comment': ['warn', {
+        'ts-expect-error': 'allow-with-description',
+        'ts-ignore': 'allow-with-description',
+        'ts-nocheck': 'allow-with-description',
+        'ts-check': false,
+        minimumDescriptionLength: 3,
+      }],
+      'react-hooks/exhaustive-deps': 'warn',
+      'react-hooks/set-state-in-effect': 'warn',
+      'react-hooks/immutability': 'warn',
+      'react-hooks/refs': 'warn',
+      'react-refresh/only-export-components': 'warn',
+    },
+  },
+  {
+    files: ['src/**/*.test.{ts,tsx}', 'e2e/**/*.spec.ts'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/ban-ts-comment': ['warn', {
+        'ts-expect-error': 'allow-with-description',
+        'ts-ignore': 'allow-with-description',
+        'ts-nocheck': 'allow-with-description',
+        'ts-check': false,
+        minimumDescriptionLength: 3,
+      }],
+    },
+  },
+  {
+    files: ['e2e/helpers/**/*.ts', 'e2e/mcp/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'warn',
+    },
+  },
+  {
+    // Puck の ComponentConfig.render はライブラリ側で React component として
+    // 呼び出される contract だが、ESLint は object property の render callback を
+    // component と判定できないため、primitive 定義に限って false positive を抑止する。
+    files: ['src/puck/primitives/**/*.tsx'],
+    rules: {
+      'react-hooks/rules-of-hooks': 'off',
     },
   },
 ])

--- a/frontend/src/components/process-flow/StructuredFieldsEditor.tsx
+++ b/frontend/src/components/process-flow/StructuredFieldsEditor.tsx
@@ -83,7 +83,7 @@ export function StructuredFieldsEditor({ label, fields, onChange, onCommit, plac
     if (!isStructured) return;
     const next = fields.map((f, i) => {
       if (i !== idx) return f;
-      const { screenItemRef, ...rest } = f;
+      const { screenItemRef: _screenItemRef, ...rest } = f;
       return rest as StructuredField;
     });
     onChange(next);

--- a/frontend/src/schemas/sqlColumnValidator.test.ts
+++ b/frontend/src/schemas/sqlColumnValidator.test.ts
@@ -1,7 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { validateSql, checkSqlColumns } from "./sqlColumnValidator";
-import type { TableDefinition } from "./sqlColumnValidator";
-import type { ProcessFlow } from "../types/action";
+import { validateSql } from "./sqlColumnValidator";
 
 function makeSpec(name: string, cols: string[]): Map<string, { name: string; columns: Set<string> }> {
   return new Map([[name.toLowerCase(), { name: name.toLowerCase(), columns: new Set(cols.map((c) => c.toLowerCase())) }]]);
@@ -73,4 +71,3 @@ describe("validateSql — 単体 SQL 検査", () => {
     expect(issues.filter((i) => i.code === "UNKNOWN_COLUMN")).toHaveLength(0);
   });
 });
-

--- a/frontend/src/schemas/v3-samples.test.ts
+++ b/frontend/src/schemas/v3-samples.test.ts
@@ -18,9 +18,6 @@ let validateScreen: ValidateFunction;
 let validateTable: ValidateFunction;
 let validateProcessFlow: ValidateFunction;
 let validateExtension: ValidateFunction;
-let validateSequence: ValidateFunction;
-let validateScreenLayout: ValidateFunction;
-let validateErLayout: ValidateFunction;
 let validateViewDefinition: ValidateFunction;
 
 beforeAll(() => {
@@ -33,9 +30,9 @@ beforeAll(() => {
   validateTable = ajv.compile(loadJson(join(v3Dir, "table.v3.schema.json")) as object);
   validateProcessFlow = ajv.compile(loadJson(join(v3Dir, "process-flow.v3.schema.json")) as object);
   validateExtension = ajv.compile(loadJson(join(v3Dir, "extensions.v3.schema.json")) as object);
-  validateSequence = ajv.compile(loadJson(join(v3Dir, "sequence.v3.schema.json")) as object);
-  validateScreenLayout = ajv.compile(loadJson(join(v3Dir, "screen-layout.v3.schema.json")) as object);
-  validateErLayout = ajv.compile(loadJson(join(v3Dir, "er-layout.v3.schema.json")) as object);
+  ajv.compile(loadJson(join(v3Dir, "sequence.v3.schema.json")) as object);
+  ajv.compile(loadJson(join(v3Dir, "screen-layout.v3.schema.json")) as object);
+  ajv.compile(loadJson(join(v3Dir, "er-layout.v3.schema.json")) as object);
   validateViewDefinition = ajv.compile(loadJson(join(v3Dir, "view-definition.v3.schema.json")) as object);
 });
 

--- a/frontend/src/types/v3/v3-types.test.ts
+++ b/frontend/src/types/v3/v3-types.test.ts
@@ -27,7 +27,6 @@ import type { ScreenItem, ValueSource } from "./screen-item";
 import type {
   Uuid,
   TableId,
-  ProcessFlowId,
   Identifier,
   IdentifierPath,
   FieldType,

--- a/frontend/src/utils/actionMigration.ts
+++ b/frontend/src/utils/actionMigration.ts
@@ -3,7 +3,6 @@ import type {
   ActionDefinition,
   Branch,
   BranchCondition,
-  BranchStep,
   ProcessFlow,
   Step,
 } from "../types/action";


### PR DESCRIPTION
## 関連

- Closes #1016
- 仕様: N/A

## 概要

frontend の ESLint を本番コード / unit test / e2e spec / e2e helper で層別化し、`npm run lint` を実用的な gate として復旧します。テストコードも lint 対象に残しつつ、fixture や mock で摩擦が大きい rule は緩和します。

## 主な変更

- ESLint baseline: 未使用変数は error 維持、`_` prefix は許可
- TypeScript debt: `any` / `@ts-*` は warning として可視化
- test/e2e: spec 本体の `any` は許容、helper は warning
- React hooks: exhaustive-deps / compiler 系は warning として可視化
- Puck primitives: `ComponentConfig.render` callback の hooks false positive を専用 override で抑止
- 既存 unused error 13 件を小さく整理

## 仕様逐条突合 (自己申告)

- lint 対象は `dist`, `test-results`, `playwright-report` を除外 → frontend/eslint.config.js:9 ✓
- production/test 共通で未使用変数は error、`_` prefix は許可 → frontend/eslint.config.js:22-27 ✓
- `any` / `@ts-*` は warning として負債を可視化 → frontend/eslint.config.js:28-35 ✓
- unit/e2e spec は `any` を許容し、テスト記述の摩擦を下げる → frontend/eslint.config.js:43-54 ✓
- e2e helper は `any` を warning に留める → frontend/eslint.config.js:56-60 ✓
- Puck primitive の render callback hooks false positive は限定 override → frontend/eslint.config.js:62-69 ✓

## レビューで特に見てほしい箇所

- Puck primitives の `react-hooks/rules-of-hooks` override が限定的で妥当か
- React compiler 系 rule を error ではなく warning にした判断が、現状 baseline として妥当か
- test/e2e spec の `any` を off にしたことが緩すぎないか

## テスト

- ESLint: `npm run lint` — pass (0 errors / 66 warnings)
- Vitest: 37 件 — `sqlColumnValidator.test.ts`, `v3-samples.test.ts`, `v3-types.test.ts`
- Build: frontend `npm run build`

## UI 影響 / AI smoke test

- [ ] UI 影響あり (AI が chrome-devtools MCP / Playwright で smoke test 実施済み)
- [x] UI 影響なし (auto テスト pass のみ)

### UI 影響ありの場合、AI smoke test で確認した項目

- [ ] N/A

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

この PR は lint error を無差別に消すものではなく、まず `npm run lint` を gate として使える状態へ戻す baseline 整備です。warning には `@ts-nocheck`, hooks deps, set-state-in-effect, immutability などの負債が残るため、後続で warning を段階的に error 化する前提です。
