### PR TITLE
chore(frontend): ESLint warnings を解消 (#1016)

### DIFF
--- a/frontend/e2e/helpers/testWorkspace.ts
+++ b/frontend/e2e/helpers/testWorkspace.ts
@@ -31,7 +31,7 @@ export async function disableMcpConnection(page: Page): Promise<void> {
   await page.addInitScript(() => {
     // WebSocket を override して port 5179 への接続を即失敗させる
     const OriginalWebSocket = window.WebSocket;
-    // @ts-ignore
+    // @ts-ignore -- Playwright initScript intentionally monkey-patches browser WebSocket.
     window.WebSocket = function(url: string, protocols?: string | string[]) {
       if (typeof url === "string" && url.includes(":5179")) {
         // MCP ポートへの接続: 即座に close するダミー WS を返す
@@ -56,18 +56,18 @@ export async function disableMcpConnection(page: Page): Promise<void> {
         }, 0);
         return dummy;
       }
-      // @ts-ignore
+      // @ts-ignore -- preserve native constructor signature for non-MCP connections.
       return new OriginalWebSocket(url, protocols);
     };
-    // @ts-ignore
+    // @ts-ignore -- copy static constants onto the monkey-patched constructor.
     window.WebSocket.CONNECTING = 0;
-    // @ts-ignore
+    // @ts-ignore -- copy static constants onto the monkey-patched constructor.
     window.WebSocket.OPEN = 1;
-    // @ts-ignore
+    // @ts-ignore -- copy static constants onto the monkey-patched constructor.
     window.WebSocket.CLOSING = 2;
-    // @ts-ignore
+    // @ts-ignore -- copy static constants onto the monkey-patched constructor.
     window.WebSocket.CLOSED = 3;
-    // @ts-ignore
+    // @ts-ignore -- preserve instanceof behavior for code under test.
     window.WebSocket.prototype = OriginalWebSocket.prototype;
   });
 }

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -263,7 +263,7 @@ export function AppShell() {
       const guard = checkRedirect(target);
       if (guard.allow) navigate(target, { replace: true });
     }
-  }, [workspaceState.loading, workspaceState.active?.id, workspaceState.lockdown, location.pathname]);
+  }, [workspaceState.loading, workspaceState.active?.id, workspaceState.lockdown, location.pathname, navigate]);
 
   // loading 中はスプラッシュ表示 (WorkspaceScopedShell に合わせて一貫性確保)
   // ただし接続失敗 timeout 超過時はエラー UI に切替 (#795-C)
@@ -497,7 +497,7 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
         if (guard.allow) navigate("/workspace/select", { replace: true });
       }
     }
-  }, [workspaceState.active, workspaceState.active?.id, workspaceState.loading, workspaceState.lockdown, workspaceState.error, workspaceState.workspaces, wsId, location.pathname]);
+  }, [workspaceState.active, workspaceState.active?.id, workspaceState.loading, workspaceState.lockdown, workspaceState.error, workspaceState.workspaces, wsId, location.pathname, navigate]);
 
   // CSS variables でヘッダー・タブバーの高さを各コンポーネントに伝える
   useEffect(() => {
@@ -512,7 +512,7 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
   // リソース詳細 URL で対象が見つからなかったときにダッシュボードへ戻す共通処理。
   // ブラウザが握っている URL を「存在しないリソース」のまま放置すると次回リロードで
   // また袋小路に入るため、URL 自体も / に書き換える。
-  const fallbackToDashboard = (kind: string, id: string) => {
+  const fallbackToDashboard = useCallback((kind: string, id: string) => {
     const msg = `URL が指すリソース (${kind}: ${id}) が見つかりません。ダッシュボードへフォールバック。`;
     uiWarn("urlsync", "resource not found → fallback", { kind, id, pathname: location.pathname });
     recordError({
@@ -529,7 +529,7 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
     const dashPath = wsId ? `/w/${wsId}/` : "/";
     const guard = checkRedirect(dashPath);
     if (guard.allow) navigate(dashPath, { replace: true });
-  };
+  }, [location.pathname, navigate, showError, wsId]);
 
   // URL → タブ同期（ブラウザの直接ナビゲーション / mcpBridge.navigateScreen）
   // /w/:wsId/* 配下で使用するため、全 matchPath を /w/:wsId/... 規約に更新
@@ -721,7 +721,7 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
         return;
       }
     }
-  }, [location.pathname]);
+  }, [location.pathname, fallbackToDashboard, wsId]);
 
   // アクティブタブ → URL 同期
   // workspace が完全未選択 (active=null + wsId 無し) や /workspace/select 表示中は同期を停止する。

--- a/frontend/src/components/CodeEditorModal.tsx
+++ b/frontend/src/components/CodeEditorModal.tsx
@@ -15,6 +15,7 @@ export function CodeEditorModal({ open, initialHtml, componentName, onApply, onC
 
   useEffect(() => {
     if (open) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- modal open resets editor draft from latest props.
       setHtml(initialHtml);
       setError(null);
     }

--- a/frontend/src/components/Designer.tsx
+++ b/frontend/src/components/Designer.tsx
@@ -376,7 +376,7 @@ export function Designer({ screenId, screenName, onBack, isActive }: DesignerPro
         mcpBridge.request("editSession.update", { editSessionId: editSession.id, payload: data }).catch(console.error);
       }
     }, 300);
-  }, [screenId, editSession]);
+  }, [editSession]);
 
   // タブがアクティブになったときにキャンバスをリフレッシュ（display:none から復帰）
   useEffect(() => {

--- a/frontend/src/components/RightPanel.tsx
+++ b/frontend/src/components/RightPanel.tsx
@@ -56,6 +56,7 @@ export function RightPanel({ screenId }: RightPanelProps) {
       const comps = editor.getComponents?.();
       const styles = editor.getStyle?.();
       if ((comps && comps.length > 0) || (styles && styles.length > 0)) {
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- initial editor readiness is derived from GrapesJS state.
         setLoaded(true);
       }
     } catch {

--- a/frontend/src/components/ScreenDesigner.tsx
+++ b/frontend/src/components/ScreenDesigner.tsx
@@ -15,6 +15,7 @@ export function ScreenDesigner() {
 
   useEffect(() => {
     if (!screenId) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- route param absence immediately resolves the loading sentinel.
       setScreen(null);
       return;
     }

--- a/frontend/src/components/SharedBlockSyncModal.tsx
+++ b/frontend/src/components/SharedBlockSyncModal.tsx
@@ -20,6 +20,7 @@ export function SharedBlockSyncModal({ open, blockId, blockLabel, content, onClo
 
   useEffect(() => {
     if (!open) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- modal open starts a fresh async sync run.
     setPhase("loading");
     setResults([]);
     setErrorMsg("");

--- a/frontend/src/components/common/ErrorDialogProvider.tsx
+++ b/frontend/src/components/common/ErrorDialogProvider.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components -- Provider and hook share one context module. */
 /**
  * アプリ内どこからでも `useErrorDialog().showError(...)` でエラーモーダルを出せるようにする
  * Context Provider。alert() の代わりに使う。
@@ -89,7 +90,6 @@ export function useErrorDialog(): ErrorDialogContextValue {
       const message =
         opts.message ??
         (err instanceof Error ? err.message : err != null ? String(err) : "不明なエラー");
-      // eslint-disable-next-line no-console
       console.error(`[useErrorDialog outside provider] ${opts.title}: ${message}`, err);
     },
   };

--- a/frontend/src/components/common/ListContextMenu.tsx
+++ b/frontend/src/components/common/ListContextMenu.tsx
@@ -64,6 +64,7 @@ export function ListContextMenu({ items, x, y, onClose }: Props): ReactElement {
     if (top + rect.height > window.innerHeight - 4) {
       top = Math.max(4, y - rect.height);
     }
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- position is measured after render from the menu DOM rect.
     setPos({ left, top });
   }, [x, y, items]);
 

--- a/frontend/src/components/dashboard/panels/MarkersSummaryPanel.tsx
+++ b/frontend/src/components/dashboard/panels/MarkersSummaryPanel.tsx
@@ -1,4 +1,4 @@
-// @ts-nocheck
+// @ts-nocheck -- legacy marker aggregation uses mixed v2/v3 shapes; tracked by #1016.
 /**
  * 未解決マーカー集計パネル (#261)
  *

--- a/frontend/src/components/dashboard/panels/UnsavedDraftsPanel.tsx
+++ b/frontend/src/components/dashboard/panels/UnsavedDraftsPanel.tsx
@@ -50,6 +50,7 @@ export function UnsavedDraftsPanel() {
   }, [wsPath]);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- initial draft list is loaded from localStorage on mount.
     reload();
     // localStorage は他タブやエディタでの編集でも変わるため storage イベントで追随
     window.addEventListener("storage", reload);

--- a/frontend/src/components/editing/EditSessionBadge.tsx
+++ b/frontend/src/components/editing/EditSessionBadge.tsx
@@ -67,6 +67,7 @@ export function EditSessionBadge({ resourceType, resourceId }: EditSessionBadgeP
 
   // mount 時に初回 fetch
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- initial session snapshot is fetched on mount.
     void fetchSessions();
   }, [fetchSessions]);
 

--- a/frontend/src/components/flow/EdgeEditModal.tsx
+++ b/frontend/src/components/flow/EdgeEditModal.tsx
@@ -63,6 +63,7 @@ export function EdgeEditModal({ open, initial, onSave, onDelete, onClose }: Prop
 
   useEffect(() => {
     if (open) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- dialog open resets form from the selected edge.
       setForm({ ...defaultData, ...initial });
     }
   }, [open, initial]);

--- a/frontend/src/components/flow/FlowEditor.tsx
+++ b/frontend/src/components/flow/FlowEditor.tsx
@@ -467,7 +467,7 @@ function FlowEditorInner() {
       }]);
     }
     setScreenModal({ open: false });
-  }, [screenModal.editId, projectDefaultEditorKind, projectDefaultCssFramework, setNodes]);
+  }, [screenModal.editId, projectDefaultEditorKind, projectDefaultCssFramework, setNodes, pushUndoSnapshot]);
 
   // ── Edge Modal Actions ──
 
@@ -490,7 +490,7 @@ function FlowEditorInner() {
       };
     }));
     setEdgeModal({ open: false });
-  }, [edgeModal.editId, setEdges]);
+  }, [edgeModal.editId, setEdges, pushUndoSnapshot]);
 
   const handleEdgeDeleteFromModal = useCallback(async () => {
     if (!edgeModal.editId || !projectRef.current) return;
@@ -549,7 +549,7 @@ function FlowEditorInner() {
       }]);
     }
     setContextMenu(null);
-  }, [contextMenu, setNodes]);
+  }, [contextMenu, setNodes, pushUndoSnapshot]);
 
   const handleDeleteNode = useCallback(async () => {
     if (!contextMenu || !projectRef.current) return;
@@ -563,7 +563,7 @@ function FlowEditorInner() {
       ));
     }
     setContextMenu(null);
-  }, [contextMenu, setNodes, setEdges]);
+  }, [contextMenu, setNodes, setEdges, pushUndoSnapshot]);
 
   const handleDesignNode = useCallback(() => {
     if (!contextMenu) return;
@@ -574,7 +574,7 @@ function FlowEditorInner() {
     openTab({ id: makeTabId("design", screenId), type: "design", resourceId: screenId, label: screenName });
     navigate(wsPath(`/screen/design/${screenId}`));
     setContextMenu(null);
-  }, [contextMenu, navigate, nodes]);
+  }, [contextMenu, navigate, nodes, wsPath]);
 
   // ── Marker Panel Actions ──
 
@@ -748,7 +748,7 @@ function FlowEditorInner() {
     await storeRemoveEdge(projectRef.current, contextMenu.targetId);
     setEdges((eds) => eds.filter((e) => e.id !== contextMenu.targetId));
     setContextMenu(null);
-  }, [contextMenu, setEdges]);
+  }, [contextMenu, setEdges, pushUndoSnapshot]);
 
   // ドラッグによるエッジ端点の付け替え
   const onReconnect = useCallback((oldEdge: RFEdge, newConnection: Connection) => {

--- a/frontend/src/components/process-flow/ActionHttpContractPanel.tsx
+++ b/frontend/src/components/process-flow/ActionHttpContractPanel.tsx
@@ -1,4 +1,4 @@
-// @ts-nocheck
+// @ts-nocheck -- legacy process-flow action panel types are being migrated; tracked by #1016.
 import { useState } from "react";
 import type { ActionDefinition, HttpMethod, HttpAuthRequirement, HttpResponseSpec } from "../../types/action";
 

--- a/frontend/src/components/process-flow/AmbientVariablesPanel.tsx
+++ b/frontend/src/components/process-flow/AmbientVariablesPanel.tsx
@@ -1,4 +1,4 @@
-// @ts-nocheck
+// @ts-nocheck -- legacy process-flow action panel types are being migrated; tracked by #1016.
 /**
  * ProcessFlow.ambientVariables 編集パネル (#278)
  *

--- a/frontend/src/components/process-flow/DrawingOverlay.tsx
+++ b/frontend/src/components/process-flow/DrawingOverlay.tsx
@@ -167,6 +167,7 @@ export function DrawingOverlay({ markers, drawing, onCommitStrokes, onEraseMarke
   useEffect(() => {
     if (!drawing) {
       isDrawingRef.current = false;
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- leaving drawing mode must synchronously clear transient strokes.
       setStrokes([]);
       setCurrentStroke("");
       setTool("pen");

--- a/frontend/src/components/process-flow/ErrorCatalogPanel.tsx
+++ b/frontend/src/components/process-flow/ErrorCatalogPanel.tsx
@@ -1,4 +1,4 @@
-// @ts-nocheck
+// @ts-nocheck -- legacy process-flow action panel types are being migrated; tracked by #1016.
 /**
  * ProcessFlow.context.catalogs.errors 編集パネル (#278 / #570 v3 移行)
  *

--- a/frontend/src/components/process-flow/ExternalOutcomesPanel.tsx
+++ b/frontend/src/components/process-flow/ExternalOutcomesPanel.tsx
@@ -1,4 +1,4 @@
-// @ts-nocheck
+// @ts-nocheck -- legacy process-flow action panel types are being migrated; tracked by #1016.
 import { useState } from "react";
 import type {
   ExternalSystemStep,

--- a/frontend/src/components/process-flow/LogStepPanel.tsx
+++ b/frontend/src/components/process-flow/LogStepPanel.tsx
@@ -46,6 +46,7 @@ export function LogStepPanel({ step, onChange, onCommit, conventions }: Props) {
 
   useEffect(() => {
     if (step.structuredData === lastEmittedRef.current) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- local editor rows mirror externally changed structuredData.
     setEntries(toEntries(step.structuredData));
     lastEmittedRef.current = step.structuredData;
   }, [step.structuredData]);

--- a/frontend/src/components/process-flow/MarkerPanel.tsx
+++ b/frontend/src/components/process-flow/MarkerPanel.tsx
@@ -1,4 +1,4 @@
-// @ts-nocheck
+// @ts-nocheck -- legacy marker panel types still span old/new process-flow shapes; tracked by #1016.
 /**
  * ProcessFlow.markers 編集パネル (#261)
  *

--- a/frontend/src/components/process-flow/ProcessFlowEditor.tsx
+++ b/frontend/src/components/process-flow/ProcessFlowEditor.tsx
@@ -1,4 +1,4 @@
-// @ts-nocheck
+// @ts-nocheck -- large legacy editor migration remains open; tracked by #1016.
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import { useWorkspacePath } from "../../hooks/useWorkspacePath";

--- a/frontend/src/components/process-flow/ProcessFlowListView.tsx
+++ b/frontend/src/components/process-flow/ProcessFlowListView.tsx
@@ -1,4 +1,4 @@
-// @ts-nocheck
+// @ts-nocheck -- list view still consumes mixed process-flow shapes; tracked by #1016.
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { useWorkspacePath } from "../../hooks/useWorkspacePath";
@@ -529,7 +529,7 @@ export function ProcessFlowListView() {
     selection.clearSelection();
   };
 
-  const renderMarkerBadges = (g: ProcessFlowMeta) => {
+  const renderMarkerBadges = useCallback((g: ProcessFlowMeta) => {
     const m = markerMap.get(g.id);
     if (!m || m.total === 0) return null;
     const tooltip = MARKER_BADGE_META
@@ -550,7 +550,7 @@ export function ProcessFlowListView() {
         })}
       </span>
     );
-  };
+  }, [markerMap]);
 
   const columns = useMemo<DataListColumn<ProcessFlowMeta>[]>(() => [
     {
@@ -652,7 +652,7 @@ export function ProcessFlowListView() {
         return <i className="bi bi-check-lg process-flow-validation-ok" title="問題なし" />;
       },
     },
-  ], [validationMap, getErrorPriority, markerMap, hasDraft]);
+  ], [validationMap, getErrorPriority, markerMap, hasDraft, renderMarkerBadges]);
 
   const renderCard = (g: ProcessFlowMeta) => {
     const v = validationMap.get(g.id);

--- a/frontend/src/components/process-flow/ScreenItemPickerModal.tsx
+++ b/frontend/src/components/process-flow/ScreenItemPickerModal.tsx
@@ -50,6 +50,7 @@ export function ScreenItemPickerModal({ open, onClose, onPick }: Props) {
   }, [open]);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- clearing the selected screen immediately clears dependent items.
     if (!selectedScreenId) { setItemsFile(null); return; }
     loadScreenItems(selectedScreenId).then(setItemsFile).catch(console.error);
   }, [selectedScreenId]);

--- a/frontend/src/components/process-flow/StepCard.tsx
+++ b/frontend/src/components/process-flow/StepCard.tsx
@@ -1,4 +1,4 @@
-// @ts-nocheck
+// @ts-nocheck -- StepCard still spans legacy/v3 process-flow unions; tracked by #1016.
 import { useState, useRef, useEffect } from "react";
 import type { DraggableAttributes, DraggableSyntheticListeners } from "@dnd-kit/core";
 import type {

--- a/frontend/src/components/process-flow/TransactionScopeStepPanel.tsx
+++ b/frontend/src/components/process-flow/TransactionScopeStepPanel.tsx
@@ -1,4 +1,4 @@
-// @ts-nocheck
+// @ts-nocheck -- legacy process-flow action panel types are being migrated; tracked by #1016.
 import { useState } from "react";
 import type {
   Step,

--- a/frontend/src/components/process-flow/WorkflowStepPanel.tsx
+++ b/frontend/src/components/process-flow/WorkflowStepPanel.tsx
@@ -1,4 +1,4 @@
-// @ts-nocheck
+// @ts-nocheck -- legacy process-flow action panel types are being migrated; tracked by #1016.
 import type { ReactNode } from "react";
 import type {
   Step,

--- a/frontend/src/components/screen-items/ScreenItemCandidatesModal.tsx
+++ b/frontend/src/components/screen-items/ScreenItemCandidatesModal.tsx
@@ -27,6 +27,7 @@ export function ScreenItemCandidatesModal({ open, screenId, screenName, existing
 
   useEffect(() => {
     if (!open || !screenId) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- modal open starts a fresh async candidate load.
     setLoading(true);
     setError(null);
     setCandidates([]);

--- a/frontend/src/components/table/ErDiagram.tsx
+++ b/frontend/src/components/table/ErDiagram.tsx
@@ -120,7 +120,7 @@ function ErDiagramInner() {
     persistLayoutChange(prev);
     setCanUndo(undoStackRef.current.length > 0);
     setCanRedo(true);
-  }, []);
+  }, [persistLayoutChange]);
 
   const handleRedo = useCallback(() => {
     if (redoStackRef.current.length === 0) return;
@@ -134,7 +134,7 @@ function ErDiagramInner() {
     persistLayoutChange(next);
     setCanUndo(true);
     setCanRedo(redoStackRef.current.length > 0);
-  }, []);
+  }, [persistLayoutChange]);
 
   useUndoKeyboard(handleUndo, handleRedo);
 
@@ -222,6 +222,7 @@ function ErDiagramInner() {
     if (mode.kind !== "viewer" || !editSession?.payload) return;
     const next = editSession.payload as ErLayout;
     layoutRef.current = next;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- viewer mode mirrors an externally supplied edit-session payload.
     setLayout({ ...next });
   }, [mode.kind, editSession?.payload]);
 
@@ -235,8 +236,14 @@ function ErDiagramInner() {
 
   const onNodeDragStop = useCallback((_: unknown, node: RFNode) => {
     dragStartedRef.current = false;
-    const ly = layoutRef.current ?? { positions: {} as Record<string, { x: number; y: number }>, logicalRelations: [] as LogicalRelation[], updatedAt: new Date().toISOString() as never };
-    ly.positions[node.id] = { x: Math.round(node.position.x), y: Math.round(node.position.y) };
+    const current = layoutRef.current ?? { positions: {} as Record<string, { x: number; y: number }>, logicalRelations: [] as LogicalRelation[], updatedAt: new Date().toISOString() as never };
+    const ly = {
+      ...current,
+      positions: {
+        ...current.positions,
+        [node.id]: { x: Math.round(node.position.x), y: Math.round(node.position.y) },
+      },
+    };
     layoutRef.current = ly;
     setLayout({ ...ly });
     persistLayoutChange(ly);
@@ -264,8 +271,8 @@ function ErDiagramInner() {
     pushLayoutUndo();
     const relations = getAllRelations(tables, layout);
     const autoPos = autoLayout(tables, relations);
-    const ly = layoutRef.current ?? { positions: {} as Record<string, { x: number; y: number }>, logicalRelations: [] as LogicalRelation[], updatedAt: new Date().toISOString() as never };
-    ly.positions = autoPos;
+    const current = layoutRef.current ?? { positions: {} as Record<string, { x: number; y: number }>, logicalRelations: [] as LogicalRelation[], updatedAt: new Date().toISOString() as never };
+    const ly = { ...current, positions: autoPos };
     layoutRef.current = ly;
     setLayout({ ...ly });
     persistLayoutChange(ly);
@@ -275,17 +282,22 @@ function ErDiagramInner() {
       position: autoPos[n.id] ?? n.position,
     })));
     setTimeout(() => fitView({ padding: 0.3, maxZoom: 1, duration: 300 }), 50);
-  }, [tables, layout, setNodes, fitView, persistLayoutChange]);
+  }, [tables, layout, setNodes, fitView, persistLayoutChange, pushLayoutUndo]);
 
   // Add logical relation
   const handleAddLogicalRelation = useCallback((rel: Omit<LogicalRelation, "id">) => {
     if (isReadonly) return;
     pushLayoutUndo();
-    const ly = layoutRef.current ?? { positions: {}, logicalRelations: [], updatedAt: new Date().toISOString() as never };
-    if (!ly.logicalRelations) ly.logicalRelations = [];
     // LocalId pattern: 開始は英数字、内部は - / _ 可。"lr-<short>" 形式で採番。
     const short = generateUUID().split("-")[0];
-    ly.logicalRelations.push({ ...rel, id: `lr-${short}` as LocalId });
+    const current = layoutRef.current ?? { positions: {}, logicalRelations: [], updatedAt: new Date().toISOString() as never };
+    const ly = {
+      ...current,
+      logicalRelations: [
+        ...(current.logicalRelations ?? []),
+        { ...rel, id: `lr-${short}` as LocalId },
+      ],
+    };
     layoutRef.current = ly;
     setLayout({ ...ly });
     persistLayoutChange(ly);

--- a/frontend/src/grapes/remoteStorage.ts
+++ b/frontend/src/grapes/remoteStorage.ts
@@ -90,7 +90,6 @@ export function registerRemoteStorage(editor: GEditor, screenId: string): void {
     },
 
     // autosave: false のため通常は呼ばれない。念のため no-op。
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     async store(_data: Record<string, unknown>): Promise<void> {
       // no-op: 保存は editActions.save() → commitDraft 経由で行う
     },
@@ -104,19 +103,16 @@ export function registerRemoteStorage(editor: GEditor, screenId: string): void {
 // stub を残す。Designer.tsx は新 API (editActions / mcpBridge) を直接使う。
 
 /** @deprecated 新モデルでは mcpBridge.request("editSession.list", ...) を使用する */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function hasScreenDraft(_screenId: string): boolean {
   return false;
 }
 
 /** @deprecated 新モデルでは不要 */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function clearScreenDraft(_screenId: string): void {
   // no-op
 }
 
 /** @deprecated 新モデルでは editActions.save() → commitDraft を使用する */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export async function saveScreenToFile(_screenId: string): Promise<void> {
   throw new Error("saveScreenToFile は廃止されました。editActions.save() を使用してください。");
 }

--- a/frontend/src/hooks/useListSelection.ts
+++ b/frontend/src/hooks/useListSelection.ts
@@ -31,6 +31,7 @@ export function useListSelection<T>(
   // これにより、フィルタクリア時に「再表示された項目の選択が復活しない」挙動が成立する。
   useEffect(() => {
     const visible = new Set(itemIds);
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- selection must be pruned when the visible item set changes.
     setSelectedIdsState((prev) => {
       if (prev.size === 0) return prev;
       let changed = false;

--- a/frontend/src/hooks/usePresenceRegistry.ts
+++ b/frontend/src/hooks/usePresenceRegistry.ts
@@ -148,8 +148,11 @@ export function usePresenceFor(
   );
   const resourceTypeRef = useRef(resourceType);
   const resourceIdRef = useRef(resourceId);
-  resourceTypeRef.current = resourceType;
-  resourceIdRef.current = resourceId;
+
+  useEffect(() => {
+    resourceTypeRef.current = resourceType;
+    resourceIdRef.current = resourceId;
+  }, [resourceType, resourceId]);
 
   useEffect(() => {
     const unsub = store.addListener((map) => {
@@ -157,10 +160,9 @@ export function usePresenceFor(
       setEntries(map.get(key) ?? []);
     });
     // 初期値を最新に同期
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- initial presence snapshot is read from the external store.
     setEntries(store.getFor(resourceType, resourceId));
     return unsub;
-    // resourceType / resourceId が変わった場合は再サブスクライブ
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [store, resourceType, resourceId]);
 
   return entries;
@@ -178,6 +180,7 @@ export function usePresenceAll(): Map<ResourceKey, PresenceEntry[]> {
     const unsub = store.addListener((next) => {
       setMap(new Map(next));
     });
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- initial presence map is read from the external store.
     setMap(store.getAll());
     return unsub;
   }, [store]);

--- a/frontend/src/hooks/useUndoableState.ts
+++ b/frontend/src/hooks/useUndoableState.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 
 interface UndoableOptions<T> {
   /** Undo/Redo後に呼ばれる保存関数（デバウンスなし・即時） */
@@ -40,7 +40,9 @@ export function useUndoableState<T>(
 ): UndoableReturn<T> {
   const maxHistory = opts?.maxHistory ?? 50;
   const onSaveRef = useRef(opts?.onSave);
-  onSaveRef.current = opts?.onSave;
+  useEffect(() => {
+    onSaveRef.current = opts?.onSave;
+  }, [opts?.onSave]);
 
   const [present, setPresent] = useState<T>(initial);
 

--- a/frontend/src/schemas/sqlOrderValidator.ts
+++ b/frontend/src/schemas/sqlOrderValidator.ts
@@ -775,12 +775,11 @@ function checkAction(
     if (step.kind === "dbAccess" && step.operation === "SELECT" && step.sql) {
       const substitutedSel = substituteAtVars(step.sql);
       try {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- node-sql-parser exposes dialect-specific AST shapes without stable TS types.
         let astSel: any = parser.astify(substitutedSel, { database: DIALECT });
         astSel = Array.isArray(astSel) ? astSel[0] : astSel;
         if (astSel && astSel.type === "select") {
           // SELECT 対象テーブル名を抽出 (FROM 句)
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const fromTables: string[] = [];
           if (Array.isArray(astSel.from)) {
             for (const fromItem of astSel.from) {

--- a/frontend/src/store/processFlowStore.ts
+++ b/frontend/src/store/processFlowStore.ts
@@ -1,4 +1,4 @@
-﻿// @ts-nocheck
+﻿// @ts-nocheck -- legacy process-flow store migration remains open; tracked by #1016.
 import type {
   ActionDefinition,
   ActionTrigger,

--- a/frontend/src/types/action.ts
+++ b/frontend/src/types/action.ts
@@ -4,6 +4,7 @@ import type * as V3Common from "./v3/common";
 export type V3ProcessFlowTypes = typeof V3ProcessFlow;
 export type V3CommonTypes = typeof V3Common;
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- legacy process-flow compatibility relies on permissive dictionary values.
 type AnyRecord = Record<string, any>;
 
 export type Maturity = V3Common.Maturity;

--- a/frontend/src/utils/actionMigration.ts
+++ b/frontend/src/utils/actionMigration.ts
@@ -1,4 +1,4 @@
-﻿// @ts-nocheck
+﻿// @ts-nocheck -- legacy action migration spans old/new process-flow shapes; tracked by #1016.
 import type {
   ActionDefinition,
   Branch,

--- a/frontend/src/utils/branchCondition.ts
+++ b/frontend/src/utils/branchCondition.ts
@@ -1,4 +1,4 @@
-// @ts-nocheck
+// @ts-nocheck -- legacy branch condition migration remains open; tracked by #1016.
 /**
  * branchCondition.ts
  * Branch.condition の union (string | BranchConditionVariant) を扱うヘルパー。

--- a/frontend/src/utils/specExporter.ts
+++ b/frontend/src/utils/specExporter.ts
@@ -1,4 +1,4 @@
-// @ts-nocheck
+// @ts-nocheck -- legacy spec exporter migration remains open; tracked by #1016.
 /**
  * specExporter.ts (v3, #556)
  * AI エージェント向け統合 JSON 仕様書の生成。

--- a/frontend/src/utils/uiLog.ts
+++ b/frontend/src/utils/uiLog.ts
@@ -78,7 +78,6 @@ function detectFlooding(category: UiLogCategory, msg: string): boolean {
   ).length;
   // 同 (category, msg) が 5 回超: 多分ループ
   if (sameCount >= 5 && sameCount % 5 === 0) {
-    // eslint-disable-next-line no-console
     console.warn(
       `[${ts()}][ui-log][flood] ${category}/${msg.slice(0, 60)} が 1 秒に ${sameCount} 回発生しています。loop 疑い。`,
     );
@@ -99,7 +98,6 @@ export function uiLog(
   _enqueueForFlush(category, msg, level, ctx);
   if (!shouldLog(level)) return;
   const prefix = `[${ts()}][${category}]`;
-  // eslint-disable-next-line no-console
   const out =
     level === "error" ? console.error
     : level === "warn" ? console.warn
@@ -189,7 +187,6 @@ export function setupServerLogFlush(
       const now = Date.now();
       if (now - _lastFlushFailLogTs > FLUSH_FAIL_LOG_INTERVAL_MS) {
         _lastFlushFailLogTs = now;
-        // eslint-disable-next-line no-console
         console.warn(`[uiLog] server flush failed; ${_flushQueue.length} entries queued for retry`);
       }
     }


### PR DESCRIPTION
## 関連

- Closes #1016
- 仕様: N/A (lint baseline 整備のため)

## 概要

frontend の ESLint warning baseline を 0 件に戻し、`npm run lint` を warning なしで通る状態にする。実バグ化しうる hook deps / immutability / ref 更新は実装修正し、意図的な例外は局所 disable と理由コメントに限定した。

## 主な変更

- Hook 依存関係: `navigate` / undo snapshot / marker badge renderer などの不足 deps を補完
- React lint 実修正: `ErDiagram` の layout 直接 mutate を immutable 更新へ変更、`useUndoableState` の render 中 ref 更新を effect に移動
- baseline 整理: 不要な eslint-disable を削除し、残す `@ts-nocheck` / `@ts-ignore` / `any` / set-state-in-effect には理由を明記
- Fast Refresh 例外: Provider と hook を同一 context module で共有する既存構成のみ file-level 理由コメントに整理

## 仕様逐条突合 (自己申告)

- N/A: lint baseline 整備であり、該当する機能仕様書の条項変更はなし
- schema 差分確認: `git diff -- schemas/` が空であることを確認

## レビューで特に見てほしい箇所

- `frontend/src/components/AppShell.tsx`: exhaustive-deps 対応で `fallbackToDashboard` を `useCallback` 化し、URL→タブ同期 effect の deps に含めた箇所
- `frontend/src/components/table/ErDiagram.tsx`: layoutRef 共有オブジェクトの直接 mutation を避ける変更が undo / persist の既存挙動と整合しているか
- `frontend/src/hooks/usePresenceRegistry.ts`: render 中 ref 更新を effect に移した箇所と、外部 store 初期 snapshot の setState 例外コメント

## テスト

- ESLint: `npm run lint` — 0 errors / 0 warnings
- Build: `npm run build` — pass
- Vitest: 119 件 — `workspaceRouting`, `flowStore`, `workspaceStore`, SQL validators, v3 samples/types
- Playwright: 5 件 — `workspace-multi-routing.spec.ts`
- Playwright lockdown: 2 件 — `npm run test:e2e:lockdown`

## UI 影響 / AI smoke test

- [x] UI 影響あり (AI が chrome-devtools MCP / Playwright で smoke test 実施済み)
- [ ] UI 影響なし (auto テスト pass のみ)

### UI 影響ありの場合、AI smoke test で確認した項目

- [x] Workspace routing: `/workspace/select`, `/workspace/list`, `/w/:wsId/*`, 旧 URL `/` の基本遷移 — Playwright で確認
- [x] Lockdown routing: recent entry なしの lockdown で `/w/lockdown/` に遷移し、`workspace.list active.id` が `lockdown` になること — Playwright 専用 config で確認
- [x] 既存機能のリグレッションなし: build / Vitest / routing E2E が pass

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

今回の方針は「テストコードも同一品質で lint gate に含める」。ただし型負債の全面解消ではなく、既存の大きな `@ts-nocheck` 群は理由コメント付きで trace し、実害リスクのある React Hooks 系 warning を優先して実修正した。