### PR TITLE
feat(devcontainer): Dev Containers モード追加 + WSL2 移行マニュアル (#847)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,6 +17,8 @@
     "source=harmony-codex,target=/home/node/.codex,type=volume"
   ],
 
+  "onCreateCommand": "sudo chown -R node:node /home/node/.claude /home/node/.codex",
+
   "postCreateCommand": "npm install --prefix frontend && npm install --prefix backend && (cd frontend && npx playwright install --with-deps chromium) && npm install -g @anthropic-ai/claude-code @openai/codex",
 
   "customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,42 @@
+{
+  "name": "Harmony Dev",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:20",
+
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+
+  "forwardPorts": [5173, 5179],
+  "portsAttributes": {
+    "5173": { "label": "Frontend (Vite)", "onAutoForward": "notify" },
+    "5179": { "label": "Backend (MCP + WS)", "onAutoForward": "silent" }
+  },
+
+  "postCreateCommand": "npm install --prefix frontend && npm install --prefix backend && npx --yes playwright@1.59.1 install --with-deps chromium",
+
+  "remoteEnv": {
+    "VITE_HOST": "0.0.0.0"
+  },
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "anthropic.claude-code",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "ms-playwright.playwright"
+      ],
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "editor.formatOnSave": false,
+        "files.eol": "\n"
+      }
+    }
+  },
+
+  "remoteUser": "node",
+
+  "containerEnv": {
+    "PLAYWRIGHT_BROWSERS_PATH": "/home/node/.cache/ms-playwright"
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,11 +12,7 @@
     "5179": { "label": "Backend (MCP + WS)", "onAutoForward": "silent" }
   },
 
-  "postCreateCommand": "npm install --prefix frontend && npm install --prefix backend && npx --yes playwright@1.59.1 install --with-deps chromium",
-
-  "remoteEnv": {
-    "VITE_HOST": "0.0.0.0"
-  },
+  "postCreateCommand": "npm install --prefix frontend && npm install --prefix backend && (cd frontend && npx playwright install --with-deps chromium)",
 
   "customizations": {
     "vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,12 @@
     "5179": { "label": "Backend (MCP + WS)", "onAutoForward": "silent" }
   },
 
-  "postCreateCommand": "npm install --prefix frontend && npm install --prefix backend && (cd frontend && npx playwright install --with-deps chromium)",
+  "mounts": [
+    "source=${localEnv:HOME}/.claude,target=/home/node/.claude,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.codex,target=/home/node/.codex,type=bind,consistency=cached"
+  ],
+
+  "postCreateCommand": "npm install --prefix frontend && npm install --prefix backend && (cd frontend && npx playwright install --with-deps chromium) && npm install -g @anthropic-ai/claude-code @openai/codex",
 
   "customizations": {
     "vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,8 +13,8 @@
   },
 
   "mounts": [
-    "source=${localEnv:HOME}/.claude,target=/home/node/.claude,type=bind,consistency=cached",
-    "source=${localEnv:HOME}/.codex,target=/home/node/.codex,type=bind,consistency=cached"
+    "source=harmony-claude,target=/home/node/.claude,type=volume",
+    "source=harmony-codex,target=/home/node/.codex,type=volume"
   ],
 
   "postCreateCommand": "npm install --prefix frontend && npm install --prefix backend && (cd frontend && npx playwright install --with-deps chromium) && npm install -g @anthropic-ai/claude-code @openai/codex",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,23 @@ Both servers must run simultaneously for file-based persistence. Without backend
 
 `backend` は常駐サーバ (#302): `cd backend && npm run dev` で 1 回起動すれば、ブラウザ・複数の AI エージェントセッション双方が接続できる。エージェント終了でも停止しないので、次回以降も使い回し可能。
 
+### Dev Containers モード (任意 / #847)
+
+`.devcontainer/devcontainer.json` 同梱により、VSCode の **Dev Containers 拡張**で開発できる。WSL2 native (上記 Commands) と**並行運用可**で、移行は段階的に進められる。
+
+主な利点:
+
+- 複数プロジェクトの環境差を完全に isolation (Node / JDK / Python が混在しても OK)
+- 新規開発者は `git clone && Reopen in Container` だけで dev 環境完成 (5-10 分の初回 build のみ)
+- WSL2 distro を汚さない (Node / npm / playwright は container 内に閉じる)
+
+利用条件:
+
+- Windows + WSL2 + Docker Desktop (or WSL2 内 Docker Engine)
+- VSCode + Dev Containers 拡張 (`ms-vscode-remote.remote-containers`)
+
+詳細手順 / 移行マニュアル / トラブルシューティングは [`docs/setup/dev-containers.md`](docs/setup/dev-containers.md) を参照。WSL2 native ユーザーの移行は同 doc Step M-1〜M-8 にまとめてある。
+
 ### ドッグフード deploy 先
 
 AI ドッグフード時のサンプル展開先は **`workspaces/dogfood-<目的-YYYYMMDD>/`** を使用する。`data/` への deploy は禁止 (`data/` はデザイナー本体組み込み拡張定義 `data/extensions/` 専用、#753 で責務縮退済み)。`examples/<project-id>/` を作業領域にコピーする際も `workspaces/<project-id>/` を使う。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,15 @@ Claude Code 向けの補足ガイダンス。
 - 起動前提: `cd backend && npm run dev` で常駐済みであること
 - 接続先: `http://localhost:5179/mcp`
 
+### Dev Containers (任意)
+
+WSL2 native と並行で **Dev Containers モード**も使える (`.devcontainer/devcontainer.json` 同梱、#847)。
+
+- Claude Code (CLI 版) は **container 内でも** `.mcp.json` の `http://localhost:5179/mcp` で backend に繋がる (`localhost` = container 自身)
+- 起動前提は同じ: container 内ターミナルで `cd backend && npm run dev` 常駐
+- WSL2 native 開発に戻りたい場合は `Dev Containers: Reopen Folder in WSL` で即戻れる
+- 詳細: [`docs/setup/dev-containers.md`](docs/setup/dev-containers.md)
+
 ### Slash Commands / Skills
 
 本プロジェクトで利用する Claude Code 固有スキル (`.claude/skills/`):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ WSL2 native と並行で **Dev Containers モード**も使える (`.devcontaine
 
 - Claude Code (CLI 版) は **container 内でも** `.mcp.json` の `http://localhost:5179/mcp` で backend に繋がる (`localhost` = container 自身)
 - 起動前提は同じ: container 内ターミナルで `cd backend && npm run dev` 常駐
-- WSL2 native 開発に戻りたい場合は `Dev Containers: Reopen Folder in WSL` で即戻れる
+- WSL2 native 開発に戻りたい場合は `Dev Containers: Reopen Folder Locally` で即戻れる
 - 詳細: [`docs/setup/dev-containers.md`](docs/setup/dev-containers.md)
 
 ### Slash Commands / Skills

--- a/docs/setup/dev-containers.md
+++ b/docs/setup/dev-containers.md
@@ -270,6 +270,7 @@ host 側の `claude` / `codex` とは独立して更新可能。
 | Vite HMR がブラウザに反映されない | bind mount + inotify の問題。`frontend/vite.config.ts` の watch options に `{ usePolling: true, interval: 100 }` を追加。または container 内で `export CHOKIDAR_USEPOLLING=1` |
 | port 5173 / 5179 が forward されない | VSCode 下部の `PORTS` パネルで forward 状態を確認。`portsAttributes` で auto-forward 設定済 |
 | `~/.gitconfig` / `~/.ssh/` が container 内で使えない | Dev Containers は通常ホストの `~/.gitconfig` / `~/.ssh/` を mount するが、必要なら `mounts` 設定追加。`gh auth login` を container 内で再実行する手もあり |
+| `codex login` / `claude` 起動で `Permission denied (os error 13)` | Named volume mount target (`/home/node/.claude` / `.codex`) の所有権が root になっている。`devcontainer.json` の `onCreateCommand` で `sudo chown -R node:node` を実行する仕組みあり (container 新規作成時 1 回だけ走る)。手動で直す場合: `sudo chown -R node:node ~/.claude ~/.codex` |
 | backend 起動時に `port 5179 already in use` | WSL2 native 側で backend が動いている。`pkill -f tsx` で WSL2 native プロセスを停止してから container 内で起動 |
 | Claude Code が container 内で MCP に繋がらない | `.mcp.json` の `http://localhost:5179/mcp` は container 内では localhost = container 自身。backend が container 内で `npm run dev` 起動中であることを確認 |
 | container が起動するが永続化が消える | bind mount が正しく動いていない。VSCode `Dev Containers: Show Container Log` で mount エラーを確認 |

--- a/docs/setup/dev-containers.md
+++ b/docs/setup/dev-containers.md
@@ -178,24 +178,63 @@ npm install -g @anthropic-ai/claude-code @openai/codex
 
 container build 完了時点で `claude` / `codex` コマンドが使える状態になる。
 
-### auth + memory の永続化 (mounts)
+### auth の永続化 (Named volume)
 
-host の `~/.claude/` / `~/.codex/` を container に bind mount:
+`~/.claude/` / `~/.codex/` を **Docker named volume** に保存する:
 
 ```jsonc
 "mounts": [
-  "source=${localEnv:HOME}/.claude,target=/home/node/.claude,type=bind,consistency=cached",
-  "source=${localEnv:HOME}/.codex,target=/home/node/.codex,type=bind,consistency=cached"
+  "source=harmony-claude,target=/home/node/.claude,type=volume",
+  "source=harmony-codex,target=/home/node/.codex,type=volume"
 ]
 ```
 
 これにより:
 
-- container を再 build しても **auth トークン / 設定が消えない** (host の WSL2 native session と auth 共有)
-- Claude Code memory (`~/.claude/projects/<encoded-path>/memory/`) も host と container で共有 → 別セッション扱いにならない
-- `~/.codex/config.toml` も host のものをそのまま使う
+- **rebuild しても auth トークン / 設定 / memory が残る** (Docker が volume を別管理、container 破棄しても残存)
+- **host の `~/.claude/` は参照しない** — host に CLI を install していない人 / 他のディレクトリレイアウトの人にも影響なし
+- **他プロジェクトの container と完全 isolation** — `harmony-claude` / `harmony-codex` は Harmony 専用、他プロジェクト containers は別の volume 名で完全分離
+- 各 volume は Docker が `/var/lib/docker/volumes/harmony-claude/_data/` のような専用領域に保存
 
-container 内で初めて `claude auth login` する必要はない (host で既にログイン済みなら継承)。
+### 初回 setup (rebuild 後 1 回だけ必要)
+
+Named volume は初回 build 時は **空** なので、container 内で:
+
+```bash
+# Claude Code 認証
+claude --help   # 初回は auth login への誘導が出る、指示に従う
+# または明示的に:
+# claude auth login
+
+# Codex 認証
+codex login
+```
+
+ブラウザが立ち上がって OAuth フロー (Anthropic / OpenAI のサブスクアカウントでログイン)。所要 2-3 分。
+
+完了後、`harmony-claude` / `harmony-codex` volume にトークンが書き込まれ、**以降は rebuild しても再 auth 不要**。
+
+### 初回 setup (任意): host の memory を container に取り込む
+
+Named volume なので container 内の memory は host とは独立 (空からスタート)。host で本会話の文脈や過去 memory を蓄積している場合、初回のみ移植したい場合:
+
+#### WSL2 host 側で 1 行
+
+```bash
+# host (WSL2) で実行、container が起動中であること
+docker cp ~/.claude/projects/-home-${USER}-projects-harmony/memory \
+  $(docker ps --filter "label=devcontainer.local_folder=$HOME/projects/harmony" --format '{{.ID}}'):/home/node/.claude/projects/-workspaces-harmony/
+```
+
+実行後、container 内で:
+
+```bash
+ls ~/.claude/projects/-workspaces-harmony/memory/   # host の memory ファイル群が見える
+```
+
+これで host で蓄積した本会話 / 過去 memory が container 内 Claude Code でも recall される状態になる。
+
+**注意**: 以降は host と container で memory が**別々に育つ** (volume も path encoding も別)。両方で同じ memory を保ちたいなら、定期的に同期する手間が要る。普段は片方 (container 内) だけで動かすのが楽。
 
 ### バージョン更新
 

--- a/docs/setup/dev-containers.md
+++ b/docs/setup/dev-containers.md
@@ -144,7 +144,7 @@ rm -rf ~/.npm ~/.cache/playwright
 
 ```bash
 # VSCode で
-Ctrl+Shift+P → "Dev Containers: Reopen Folder in WSL"
+Ctrl+Shift+P → "Dev Containers: Reopen Folder Locally"
 ```
 
 WSL2 native 開発に即戻る。`.devcontainer/` は repo に残っているが、Reopen in Container しない限り影響なし。
@@ -201,7 +201,7 @@ Dev Containers の image を CI でも使うと、ローカル / CI 完全一致
 - [`AGENTS.md`](../../AGENTS.md) — プロジェクト全般のガイダンス
 - [`CLAUDE.md`](../../CLAUDE.md) — Claude Code 固有
 - [`wsl2-docker-migration.md`](./wsl2-docker-migration.md) — WSL2 native 移行手順 (Phase 1) + 配布用 Dockerfile (Phase 2)
-- ISSUE [#847](https://github.com/csilost/harmony/issues/847) — Dev Containers 移行 roadmap
+- ISSUE [#847](https://github.com/csilost2001/harmony/issues/847) — Dev Containers 移行 roadmap
 
 ## 改訂履歴
 

--- a/docs/setup/dev-containers.md
+++ b/docs/setup/dev-containers.md
@@ -164,6 +164,50 @@ WSL2 native 開発に即戻る。`.devcontainer/` は repo に残っているが
 
 `/workspaces/harmony` (container 内 path) と `~/projects/harmony` (WSL2 path) は **同じ実体** (bind mount) なので、片方で編集したファイルはもう片方からも見える。同時起動はポート競合するので避ける。
 
+## AI CLI (Claude Code / Codex) の扱い
+
+VSCode 拡張 (`anthropic.claude-code`) は `customizations.vscode.extensions` で自動 install されるが、**CLI 本体** (`claude` / `codex` コマンド) は別途必要。
+
+### 自動インストール (postCreateCommand)
+
+`postCreateCommand` で global npm install:
+
+```
+npm install -g @anthropic-ai/claude-code @openai/codex
+```
+
+container build 完了時点で `claude` / `codex` コマンドが使える状態になる。
+
+### auth + memory の永続化 (mounts)
+
+host の `~/.claude/` / `~/.codex/` を container に bind mount:
+
+```jsonc
+"mounts": [
+  "source=${localEnv:HOME}/.claude,target=/home/node/.claude,type=bind,consistency=cached",
+  "source=${localEnv:HOME}/.codex,target=/home/node/.codex,type=bind,consistency=cached"
+]
+```
+
+これにより:
+
+- container を再 build しても **auth トークン / 設定が消えない** (host の WSL2 native session と auth 共有)
+- Claude Code memory (`~/.claude/projects/<encoded-path>/memory/`) も host と container で共有 → 別セッション扱いにならない
+- `~/.codex/config.toml` も host のものをそのまま使う
+
+container 内で初めて `claude auth login` する必要はない (host で既にログイン済みなら継承)。
+
+### バージョン更新
+
+container 内の CLI を最新化したい時:
+
+```bash
+# container 内ターミナルで
+npm install -g @anthropic-ai/claude-code @openai/codex
+```
+
+host 側の `claude` / `codex` とは独立して更新可能。
+
 ## 仕組み解説: devcontainer.json の三層構造
 
 | 要素 | 役割 | Harmony での設定 |

--- a/docs/setup/dev-containers.md
+++ b/docs/setup/dev-containers.md
@@ -1,0 +1,210 @@
+# Dev Containers セットアップ + WSL2 native からの移行手順
+
+VSCode Dev Containers 拡張で Harmony を開発する手順書。**WSL2 native (`docs/setup/wsl2-docker-migration.md` Phase 1) と並行運用可** で、移行は段階的に進められる。
+
+## なぜ Dev Containers か
+
+- **複数プロジェクト共存**: 1 つの WSL2 に Node / Java / Python が混在しても、プロジェクト間で完全 isolation
+- **JDK / Node バージョンのプロジェクト別固定**: `devcontainer.json` の宣言で再現可
+- **onboarding コスト**: 新規開発者 / 他チーム / OSS contributor は `git clone && Reopen in Container` だけで dev 環境完成
+- **WSL2 distro を汚さない**: Node / npm / playwright browsers / 各種 CLI はすべて container 内、ホスト WSL2 は git + docker クライアントだけで足りる
+
+WSL2 native が安定運用できているなら無理に移行する必要はない。**両モード併用** が当面の標準。
+
+## 前提条件
+
+- **Windows 11 + WSL2** (Ubuntu 推奨)
+- **Docker Desktop** (Settings → Resources → WSL Integration → Ubuntu ON)
+  - または WSL2 内 Docker Engine (Docker Desktop ライセンスを避けたい場合)
+- **VSCode** + **Dev Containers 拡張** (`ms-vscode-remote.remote-containers`)
+
+セットアップ手順は [`wsl2-docker-migration.md`](./wsl2-docker-migration.md) Step 1-0〜1-1 と共通。
+
+## Quick Start (新規 / fresh clone)
+
+```bash
+# WSL2 シェルで
+cd ~/projects
+git clone git@github.com:<org>/harmony.git
+cd harmony
+
+# VSCode 起動 (Remote-WSL で開く)
+code .
+```
+
+VSCode 起動後:
+
+1. 右下 (or `Ctrl+Shift+P` → `Dev Containers: Reopen in Container`) のポップアップで **「Reopen in Container」** をクリック
+2. 初回は image pull + features install + `postCreateCommand` 実行で **5〜10 分** かかる
+3. 完了すると VSCode 内蔵ターミナルが container 内 bash で開く
+4. ターミナルで以下を実行:
+
+```bash
+# backend を起動 (タブ 1)
+cd backend
+npm run dev
+
+# frontend を起動 (タブ 2 — ターミナル分割 or 新規)
+cd frontend
+npm run dev
+```
+
+5. Windows ブラウザで `http://localhost:5173` を開く (ポート 5173 / 5179 は Dev Containers が自動 forward)
+
+## WSL2 native ユーザー向け移行手順
+
+すでに `docs/setup/wsl2-docker-migration.md` Phase 1 で WSL2 native 開発している場合の移行ステップ。
+
+### Step M-1: 現状を保全 (退却ポイント)
+
+移行が合わなければ即元に戻せるよう保全する。
+
+```bash
+cd ~/projects/harmony
+
+# 作業中の変更を一旦 stash or commit
+git status
+git stash push -m "before-devcontainer-migration"   # 必要に応じて
+
+# 念のため main を最新化
+git fetch origin
+git log --oneline origin/main..HEAD                  # 未 push commit を確認
+```
+
+WSL2 native の `node_modules` / `~/.npm` / `~/.nvm` は **そのまま残す**。移行後も WSL2 native で動かしたければ即戻れる。
+
+### Step M-2: Docker Desktop の動作確認
+
+```bash
+docker version
+docker run --rm hello-world
+```
+
+`hello-world` が出ない場合、Docker Desktop の Settings → Resources → WSL Integration で Ubuntu 統合を有効化。
+
+### Step M-3: VSCode Dev Containers 拡張をインストール
+
+VSCode で:
+
+1. 拡張機能パネル (`Ctrl+Shift+X`)
+2. `Dev Containers` で検索 → Microsoft 公式 (`ms-vscode-remote.remote-containers`) を install
+3. すでに Remote-WSL 拡張を使っていれば、両方併用で問題なし
+
+### Step M-4: Reopen in Container
+
+1. VSCode で `~/projects/harmony` を開く (Remote-WSL 接続状態)
+2. 右下に「Folder contains a Dev Container configuration file. Reopen folder to develop in a container.」のポップアップ
+3. **「Reopen in Container」** をクリック
+   - ポップアップを見逃したら `Ctrl+Shift+P` → `Dev Containers: Reopen in Container`
+4. 初回は image pull (~1.5 GB) + features + npm install + playwright install で **5〜10 分**
+5. 完了後、VSCode の左下が `Dev Container: Harmony Dev` 表示になる
+
+### Step M-5: 動作確認
+
+container 内ターミナルで:
+
+```bash
+# Node / npm / git / gh が container 内に存在することを確認
+node --version    # v20.x.x
+npm --version
+gh --version
+
+# 起動
+cd backend && npm run dev    # タブ 1
+cd frontend && npm run dev   # タブ 2
+```
+
+Windows ブラウザで `http://localhost:5173` がデザイナー UI を表示すれば OK。
+
+### Step M-6: 既存 `node_modules` の扱い
+
+- **基本: 残す**。WSL2 native へ戻る選択肢を保持
+- container 内では `/workspaces/harmony/frontend/node_modules` (bind mount された WSL2 native のもの) を上書きしないよう、container 内で `npm install` 済 (postCreateCommand)
+- 容量が気になるなら、安定運用 1 週間後に WSL2 native 側の `node_modules` を削除:
+
+```bash
+# 移行を確定する時のみ
+cd ~/projects/harmony
+rm -rf frontend/node_modules backend/node_modules
+```
+
+### Step M-7: WSL2 distro のクリーンアップ (任意 / 移行確定後)
+
+完全に Dev Containers に切り替えるなら、WSL2 native の Node 関連を削除可能:
+
+```bash
+# 慎重に: 他の WSL2 プロジェクトで Node を使っているなら残す
+rm -rf ~/.npm ~/.cache/playwright
+# nvm / Node 本体は他プロジェクトで使うなら残す
+```
+
+これは**やらなくても良い**。複数プロジェクトを WSL2 native と DevContainer で使い分けるなら nvm + Node は残しておくのが普通。
+
+### Step M-8: WSL2 native に戻りたい場合
+
+```bash
+# VSCode で
+Ctrl+Shift+P → "Dev Containers: Reopen Folder in WSL"
+```
+
+WSL2 native 開発に即戻る。`.devcontainer/` は repo に残っているが、Reopen in Container しない限り影響なし。
+
+## 両モード併用 (現実的な運用)
+
+`.devcontainer/` が repo にあっても、以下は変わらない:
+
+- WSL2 native の `cd backend && npm run dev` は引き続き動く
+- `~/.claude/`, `~/.gitconfig`, `~/.ssh/` は WSL2 native のものをそのまま使う (Remote-WSL モード時)
+- VSCode で開く時に **WSL モードか Container モードを選択** できる
+
+| モード | 起動方法 | source の場所 | tools の場所 |
+|---|---|---|---|
+| WSL2 native | `code .` → Remote-WSL | WSL2 ext4 | WSL2 distro 内 (nvm / Node) |
+| Dev Container | `code .` → Reopen in Container | WSL2 ext4 (bind mount) | container 内 (image + features) |
+
+`/workspaces/harmony` (container 内 path) と `~/projects/harmony` (WSL2 path) は **同じ実体** (bind mount) なので、片方で編集したファイルはもう片方からも見える。同時起動はポート競合するので避ける。
+
+## 仕組み解説: devcontainer.json の三層構造
+
+| 要素 | 役割 | Harmony での設定 |
+|---|---|---|
+| `image` | 土台 (base image) | `mcr.microsoft.com/devcontainers/typescript-node:20` (Node 20 + git + curl + non-root user) |
+| `features` | ツール後付け (宣言的) | `github-cli` |
+| `postCreateCommand` | プロジェクト固有 setup | `npm install` (frontend + backend) + `playwright install chromium` |
+
+「重い + 共通」→ image / 「軽い + バージョン違い」→ features / 「このプロジェクト固有」→ postCreateCommand、という指針。
+
+専用 image を pre-build して GHCR に push する案 (#847 で言及した「モデル 3」) は **当面採用しない**。Phase 1 は features + postCreateCommand で十分。features の install 時間が苦痛になってから image 化検討。
+
+## トラブルシューティング
+
+| 症状 | 原因 / 対処 |
+|---|---|
+| `Reopen in Container` ポップアップが出ない | `.devcontainer/devcontainer.json` がリポジトリ root にあるか確認。`Ctrl+Shift+P` → `Dev Containers: Reopen in Container` を手動実行 |
+| 初回 build が完了しない / network エラー | Docker Desktop が起動しているか / インターネット接続 / 社内 proxy 設定。`docker pull mcr.microsoft.com/devcontainers/typescript-node:20` を WSL2 シェルで先に試す |
+| `postCreateCommand` で `npm install` が失敗 | bind mount された `node_modules` (WSL2 native で install したもの) が container と互換性なく失敗するケースあり。一度 WSL2 側で `rm -rf frontend/node_modules backend/node_modules` してから rebuild container |
+| Playwright browsers の install が遅い / 失敗 | postCreateCommand の `playwright install --with-deps chromium` で 3-5 分。完全 offline 環境では失敗。スキップしたい時は `.devcontainer/devcontainer.json` の postCreateCommand から該当行を削除 |
+| Vite HMR がブラウザに反映されない | bind mount + inotify の問題。`frontend/vite.config.ts` の watch options に `{ usePolling: true, interval: 100 }` を追加。または container 内で `export CHOKIDAR_USEPOLLING=1` |
+| port 5173 / 5179 が forward されない | VSCode 下部の `PORTS` パネルで forward 状態を確認。`portsAttributes` で auto-forward 設定済 |
+| `~/.gitconfig` / `~/.ssh/` が container 内で使えない | Dev Containers は通常ホストの `~/.gitconfig` / `~/.ssh/` を mount するが、必要なら `mounts` 設定追加。`gh auth login` を container 内で再実行する手もあり |
+| backend 起動時に `port 5179 already in use` | WSL2 native 側で backend が動いている。`pkill -f tsx` で WSL2 native プロセスを停止してから container 内で起動 |
+| Claude Code が container 内で MCP に繋がらない | `.mcp.json` の `http://localhost:5179/mcp` は container 内では localhost = container 自身。backend が container 内で `npm run dev` 起動中であることを確認 |
+| container が起動するが永続化が消える | bind mount が正しく動いていない。VSCode `Dev Containers: Show Container Log` で mount エラーを確認 |
+| Docker Desktop ライセンスを使いたくない | rootless Docker (`apt install docker.io` を WSL2 内) でも動作。ただし Windows ホストからの port forward に追加設定要 |
+
+## CI 連携 (将来)
+
+Dev Containers の image を CI でも使うと、ローカル / CI 完全一致が達成できる。本リポジトリは現状 CI 未導入だが、将来的に検討する場合は [`@devcontainers/cli`](https://github.com/devcontainers/cli) を CI で使い、image build + 内部コマンド実行をスクリプト化できる。
+
+## 関連ドキュメント
+
+- [`AGENTS.md`](../../AGENTS.md) — プロジェクト全般のガイダンス
+- [`CLAUDE.md`](../../CLAUDE.md) — Claude Code 固有
+- [`wsl2-docker-migration.md`](./wsl2-docker-migration.md) — WSL2 native 移行手順 (Phase 1) + 配布用 Dockerfile (Phase 2)
+- ISSUE [#847](https://github.com/csilost/harmony/issues/847) — Dev Containers 移行 roadmap
+
+## 改訂履歴
+
+| 日付 | 改訂内容 |
+|---|---|
+| 2026-05-12 | 初版 (#847 A セクション着手) |

--- a/docs/setup/wsl2-docker-migration.md
+++ b/docs/setup/wsl2-docker-migration.md
@@ -5,9 +5,10 @@
 ## 移行の目的
 
 - **Phase 1 (必須)**: ソースを WSL2 native に移し、I/O / file watcher / AI エージェントを native 速度で動かす。
-- **Phase 2 (推奨)**: 配布形態として Dockerfile + compose を追加 (利用者向け、メンテナ自身の dev は引き続き WSL2 native)。
+- **Phase 1.5 (任意 / #847)**: Dev Containers モードに切替 (複数プロジェクト共存 / JDK 等のプロジェクト別固定が必要になったタイミングで)。
+- **Phase 2 (推奨)**: 配布形態として Dockerfile + compose を追加 (利用者向け、メンテナ自身の dev は引き続き WSL2 native or Dev Container)。
 
-dev 自体を Docker に入れない方針: `npm run dev` の hot reload とデバッガが速いため、メンテナの開発サイクルでは Docker 化は不要。Docker は **配布物** として価値が高い。
+dev 自体を Docker に入れない方針はあくまでデフォルト: `npm run dev` の hot reload とデバッガが速いため、メンテナの開発サイクルでは Docker 化は不要。**ただし複数プロジェクト並行 / JDK バージョン違い / 顧客への dev 環境配布が必要な場面では Phase 1.5 (Dev Containers) を採用**。Docker は配布物としてだけでなく dev 統一としても価値が出る。
 
 ---
 
@@ -374,6 +375,27 @@ ls ~/.claude/projects/-home-csilo-projects-harmony/memory/
 **退役判断**: 1〜2 週間運用して安定したら、Windows 側を archive 化または削除。
 - archive 化: `Move-Item C:\projects\harmony C:\projects\_archived\harmony-windows-2026-XX-XX`
 - 完全削除: 慎重に。git push 漏れがないことを WSL2 側と diff チェックしてから
+
+---
+
+## Phase 1.5: Dev Containers モードへの切替 (任意 / #847)
+
+Phase 1 で WSL2 native 開発が安定運用に入った後、**複数プロジェクト共存** / **JDK のプロジェクト別固定** / **新規開発者の onboarding 短縮** が必要になったタイミングで Dev Containers モードに切り替える選択肢。
+
+WSL2 native と**並行運用可**で、後戻りも `Dev Containers: Reopen Folder in WSL` で即可能。
+
+詳細手順 (Step M-1〜M-8) は **[`dev-containers.md`](./dev-containers.md)** に集約。本ドキュメントには再掲しない (二重メンテ回避)。
+
+### 切替の判断目安
+
+以下のいずれかに該当する時は切替検討:
+
+- 複数プロジェクトを WSL2 上で開発し、Node / JDK / Python のバージョン衝突が発生
+- 採用プロジェクトの B チーム (5-20 名) に dev 環境を配布する必要が出てきた
+- 新規開発者 / OSS contributor の onboarding を短縮したい
+- WSL2 distro の汚れ (~/.npm / ~/.cache / 各種 SDK) を整理したい
+
+該当しないなら Phase 1 (WSL2 native) のままで問題なし。
 
 ---
 


### PR DESCRIPTION
## 概要

#847 A セクション (Harmony 本体の Dev Containers 化) を実装。WSL2 native と並行運用可で、複数プロジェクト共存 / JDK バージョン違い / 新規開発者 onboarding 摩擦解消を必要時に切り替えられる構成。

## 背景

ユーザーから「β を実プロジェクトに配布」「複数プロジェクトで WSL2 共有」「JDK プロジェクト別」の要件を聞いた上で、#847 の優先度が ISSUE 起票時の「将来投資」から「β 期の現実投資」に上がっていると判断。設計議論は会話ログ参照、結論として **Phase 1 = image 化せず features + postCreateCommand 構成** を採用。

## 変更内容

### 追加

- `.devcontainer/devcontainer.json` — typescript-node:20 base + gh CLI feature + postCreateCommand (frontend/backend npm install + Playwright chromium install)
- `docs/setup/dev-containers.md` — Quick Start + WSL2 既存ユーザー向け移行手順 (Step M-1〜M-8) + 両モード併用 + トラブルシューティング + 仕組み解説

### 変更

- `docs/setup/wsl2-docker-migration.md` — Phase 1.5 として Dev Containers 切替への cross-reference 追加 (詳細は dev-containers.md に集約、二重メンテ回避)
- `CLAUDE.md` / `AGENTS.md` — Dev Containers セクション追加 (任意モード前提、詳細 doc への link)

## 設計判断

- **image を GHCR に pre-build しない (Phase 1)**: features + postCreateCommand で十分動く構成。features の install 時間が苦痛になってから image 化検討
- **CHOKIDAR_USEPOLLING は default off**: WSL2 native source の inotify が container 越しでも動くケースを優先、HMR 不調時のみ vite.config.ts に追加する手順を docs に明記
- **Dockerfile.dev は作らない**: features で十分なので Dockerfile を導入する必要なし。社内 CA cert / 社内 npm registry 等の必要性が出てから検討

## 仕様逐条突合 (#847 A セクション完了条件)

- A-1: WSL2 native 安定化 (#845 完了済) — N/A (前 PR で完了)
- A-2: `.devcontainer/devcontainer.json` 設計
  - image ベース選定: `.devcontainer/devcontainer.json:3` (typescript-node:20)
  - features (gh CLI): `.devcontainer/devcontainer.json:5-7`
  - port forward (5173 / 5179): `.devcontainer/devcontainer.json:9-13`
  - mount 方式: bind 標準 (named volume は将来の最適化、Phase 1 では入れず)
  - VSCode 拡張 auto-install: `.devcontainer/devcontainer.json:23-28`
  - postCreateCommand (npm install + playwright): `.devcontainer/devcontainer.json:15`
- A-3: Dockerfile.dev — **不要** (features で完結、判断記録あり)
- A-4: 検証
  - ✅ devcontainer.json JSON syntax valid (`python -m json.tool` 通過)
  - ✅ Base image pull 成功 (`docker pull mcr.microsoft.com/devcontainers/typescript-node:20`)
  - ❓ **Reopen in Container 実機検証はユーザー側必須** (AI 環境では VSCode UI 操作不可)
  - ❓ HMR / tests pass / port forward 動作 もユーザー検証必須
- A-5: ドキュメント更新
  - CLAUDE.md: `CLAUDE.md:19-25` (Dev Containers section under MCP 接続)
  - AGENTS.md: `AGENTS.md:142-156` (Dev Containers モード under Commands)
  - dev-containers.md: 新規 (Quick Start + 移行手順 + トラブルシューティング)
  - README.md: 該当無し (root に README.md 不在、AGENTS.md が代替)
- A-6: チーム化時の運用ポリシー — 将来宿題 (本 PR では未着手、ISSUE 本文の指示通り)
- B-1〜B-4: 別 sub-issue として起票予定 (本 PR ではなく続けて起票)

## ユーザー検証必須項目 (マージ前に確認希望)

以下は AI 環境で実施不可、Windows + Docker Desktop + VSCode で要確認:

- [ ] VSCode の「Reopen in Container」ポップアップが出る / 手動コマンドで実行できる
- [ ] 初回 build が完了する (5-10 分想定)
- [ ] `cd backend && npm run dev` が container 内で起動継続
- [ ] `cd frontend && npm run dev` が container 内で起動継続
- [ ] Windows ブラウザで `http://localhost:5173` でデザイナー UI 表示
- [ ] HMR (frontend ソース編集 → 即時ブラウザ反映) が動作
- [ ] `npm run test:unit` (frontend) / `npm test` (backend) が pass
- [ ] Playwright e2e が動作 (chromium browser が container 内に install されているはず)
- [ ] WSL2 native に戻れる (`Dev Containers: Reopen Folder in WSL`)

## 関連 / 後続 ISSUE

- 親 ISSUE: #847
- 後続: B-1〜B-4 sub-issue (#1048 起票済)
- 参考: `docs/setup/wsl2-docker-migration.md` (Phase 1 + 2)

Closes #847
