### PR TITLE
fix(workspace): /workspace/list を recent 空状態で開くと点滅 (#1053)

### DIFF
--- a/frontend/src/components/workspace/WorkspaceListView.test.tsx
+++ b/frontend/src/components/workspace/WorkspaceListView.test.tsx
@@ -185,23 +185,4 @@ describe("WorkspaceListView reload guard", () => {
 
     expect(loadWorkspacesMock).toHaveBeenCalledTimes(1);
   });
-
-  it("reloads on initial connected fire when AppShell load is still in progress", () => {
-    state = {
-      workspaces: [],
-      active: null,
-      lockdown: false,
-      lockdownPath: null,
-      loading: true, // AppShell が未だ load 中
-      error: null,
-    };
-    onStatusChangeMock.mockImplementation((cb: (s: string) => void) => {
-      cb("connected");
-      return () => {};
-    });
-
-    render(<WorkspaceListView />);
-
-    expect(loadWorkspacesMock).toHaveBeenCalledTimes(1);
-  });
 });

--- a/frontend/src/components/workspace/WorkspaceListView.test.tsx
+++ b/frontend/src/components/workspace/WorkspaceListView.test.tsx
@@ -4,6 +4,7 @@ import type { WorkspaceEntry, WorkspaceState } from "../../store/workspaceStore"
 
 const navigateMock = vi.fn();
 const openWorkspaceMock = vi.fn();
+const loadWorkspacesMock = vi.fn(() => Promise.resolve());
 
 const workspace: WorkspaceEntry = {
   id: "ws-source",
@@ -18,9 +19,11 @@ vi.mock("react-router-dom", () => ({
   useNavigate: () => navigateMock,
 }));
 
+const onStatusChangeMock = vi.fn();
+
 vi.mock("../../mcp/mcpBridge", () => ({
   mcpBridge: {
-    onStatusChange: vi.fn(() => () => {}),
+    onStatusChange: onStatusChangeMock,
   },
 }));
 
@@ -30,7 +33,7 @@ vi.mock("../../store/workspaceStore", async () => {
     ...actual,
     getState: vi.fn(() => state),
     subscribe: vi.fn(() => () => {}),
-    loadWorkspaces: vi.fn(),
+    loadWorkspaces: loadWorkspacesMock,
     openWorkspace: openWorkspaceMock,
     inspectWorkspace: vi.fn(),
     initAndOpen: vi.fn(),
@@ -100,6 +103,9 @@ beforeEach(() => {
   navigateMock.mockReset();
   openWorkspaceMock.mockReset();
   openWorkspaceMock.mockResolvedValue("ws-target");
+  loadWorkspacesMock.mockClear();
+  onStatusChangeMock.mockReset();
+  onStatusChangeMock.mockImplementation(() => () => {});
   state = {
     workspaces: [workspace],
     active: null,
@@ -133,5 +139,69 @@ describe("WorkspaceListView navigation", () => {
       expect(openWorkspaceMock).toHaveBeenCalledWith("ws-source", true);
       expect(navigateMock).toHaveBeenCalledWith("/", { replace: true });
     });
+  });
+});
+
+describe("WorkspaceListView reload guard", () => {
+  // 過去の regression: 初回即時発火の skip 判定で `workspaces.length > 0` を要求していたため、
+  // recent が空 (= 初回起動) のときに loadWorkspaces → loading=true → AppShell スプラッシュ →
+  // unmount/remount → 即時発火 … の無限ループで点滅していた。loading だけで判定する。
+  it("skips loadWorkspaces on initial connected fire even when workspaces is empty", () => {
+    state = {
+      workspaces: [],
+      active: null,
+      lockdown: false,
+      lockdownPath: null,
+      loading: false,
+      error: null,
+    };
+    onStatusChangeMock.mockImplementation((cb: (s: string) => void) => {
+      cb("connected"); // mcpBridge.onStatusChange の即時発火を模す
+      return () => {};
+    });
+
+    render(<WorkspaceListView />);
+
+    expect(loadWorkspacesMock).not.toHaveBeenCalled();
+  });
+
+  it("reloads on reconnect (disconnected → connected) regardless of workspaces state", () => {
+    state = {
+      workspaces: [],
+      active: null,
+      lockdown: false,
+      lockdownPath: null,
+      loading: false,
+      error: null,
+    };
+    onStatusChangeMock.mockImplementation((cb: (s: string) => void) => {
+      cb("connected");    // 初回即時発火 → skip
+      cb("disconnected"); // 切断
+      cb("connected");    // 再接続 → reload
+      return () => {};
+    });
+
+    render(<WorkspaceListView />);
+
+    expect(loadWorkspacesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reloads on initial connected fire when AppShell load is still in progress", () => {
+    state = {
+      workspaces: [],
+      active: null,
+      lockdown: false,
+      lockdownPath: null,
+      loading: true, // AppShell が未だ load 中
+      error: null,
+    };
+    onStatusChangeMock.mockImplementation((cb: (s: string) => void) => {
+      cb("connected");
+      return () => {};
+    });
+
+    render(<WorkspaceListView />);
+
+    expect(loadWorkspacesMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/components/workspace/WorkspaceListView.tsx
+++ b/frontend/src/components/workspace/WorkspaceListView.tsx
@@ -498,17 +498,21 @@ export function WorkspaceListView() {
     // load と 2 重になり loading=true → AppShell スプラッシュ → アンマウント → 再マウント
     // → 再び即時発火 という無限ループを引き起こす (WorkspaceSelectView と同パターン、PR #813 ホットフィックス)。
     //
-    // 対策: 初回即時発火 (prevStatus=null) で AppShell の load 完了済 (workspaces 取得済) の場合は skip。
+    // 対策: 初回即時発火 (prevStatus=null) で AppShell の load 完了済 (loading=false) なら skip。
     // 再接続 (disconnected → connected) は常に reload。
+    //
+    // 注: 以前は `loading=false && workspaces.length > 0` で skip 判定していたが、
+    // recent-workspaces.json が存在しない初回起動など workspaces が空の正常完了状態でも
+    // skip が外れて loadWorkspaces → loading=true → splash → unmount/remount → 即時発火 …
+    // の無限ループに陥る regression があった (#1490aec の取り残し)。loading だけで判定する。
     let prevStatus: string | null = null;
     const unsubStatus = mcpBridge.onStatusChange((s) => {
       const isReconnect = prevStatus !== null && prevStatus !== "connected" && s === "connected";
       prevStatus = s;
       if (s !== "connected") return;
       if (!isReconnect) {
-        const { loading, workspaces } = getState();
-        // AppShell が load 完了済 (loading=false かつ workspaces 取得済) なら skip して 2 重 load を防ぐ
-        if (!loading && workspaces.length > 0) return;
+        const { loading } = getState();
+        if (!loading) return;
       }
       loadWorkspaces().catch(console.error);
     });


### PR DESCRIPTION
## 関連

- Closes #1053
- 関連 PR: #813 (#806 シリーズ初回 fix) / #816 (1490aec hotfix、本 PR が取り残し補完)
- 仕様: N/A (`AppShell` + `mcpBridge.onStatusChange` 連携の暗黙パターン、spec ファイル無し)

## 概要

`/workspace/list` を**recent workspace ゼロ件状態**で開くと無限ループで点滅する regression を修正。PR #816 (1490aec) で WorkspaceListView の二重 reload chain を直したが、初回即時発火 skip 判定に `workspaces.length > 0` を要求していたため、recent が空 (初回起動 / `~/.harmony/recent-workspaces.json` 未生成) のときに skip が外れて点滅していた取り残し。

## 主な変更

- `WorkspaceListView.tsx`: 初回即時発火の skip 判定を `loading=false && workspaces.length > 0` から `loading=false` 単独に変更 (WorkspaceSelectView と同一パターンに揃える)
- `WorkspaceListView.test.tsx`: regression テスト 3 件追加 (`onStatusChange` モック経由でループ条件を再現)

## 仕様逐条突合 (自己申告)

仕様書なしの暗黙パターンに対する突合:

- AppShell の load 完了済み (loading=false) なら ListView 側で重複 load しない → `WorkspaceListView.tsx:512` ✓
- 再接続 (disconnected → connected) 時のみ ListView 側が能動 reload する → `WorkspaceListView.tsx:505-510, 514` ✓
- WorkspaceSelectView と同一の判定パターン (PR #813 で確立済) を踏襲 → `WorkspaceSelectView.tsx:35-44` と `WorkspaceListView.tsx:507-516` の対比 ✓

## レビューで特に見てほしい箇所

- `workspaces.length > 0` 条件を外したことで、recent が空のとき AppShell が load 済の状態を**正しく load 済として扱える**ようになった。これが PR #816 の意図とズレていないかご確認ください (PR #816 description では「workspaces 取得済」と書かれているが、ここで言う「取得済」は length 不問の意図のはずで、空 list も valid な取得済状態)
- WorkspaceSelectView との対称性は維持されているか (両者の判定ロジックが揃ったので、将来同一 hook 化の余地あり — 本 PR では対象外)

## テスト

- Vitest: 5 件 (新規 3 件) — `WorkspaceListView.test.tsx` の `describe("WorkspaceListView reload guard", ...)`
  - recent 空 + loading=false + 即時発火 → loadWorkspaces 呼ばれない (今回の点滅再発防止)
  - 再接続 (disconnected → connected) は workspaces 状態に関係なく reload
  - 初回 mount で loading=true ならちゃんと load 走る
- Playwright: N/A (既存 e2e に該当ケースなし、追加検討は別 ISSUE 化候補だが本 PR では vitest で十分カバー)
- MCP E2E: N/A

## UI 影響 / AI smoke test

- [x] UI 影響あり
- [ ] UI 影響なし

### UI 影響ありの場合、AI smoke test で確認した項目

本 dev container 環境ではブラウザ実機 (chrome-devtools MCP / Playwright) が利用不可のため、AI による smoke test は**未実施**。Vitest の regression テストで `onStatusChange` immediate fire 経路をモック検証 (3 ケース全 pass)。

**ユーザー側で要確認**:
- [ ] `/workspace/list` を `~/.harmony/recent-workspaces.json` 不在状態で開いて点滅しないこと (本 PR の主目的)
- [ ] recent workspace ありの状態でも従来どおり点滅しないこと (既存パスの非破壊確認)
- [ ] disconnect → reconnect で reload が走ること

## spec 側の不足点 / 提案

`AppShell` + `mcpBridge.onStatusChange` + WorkspaceListView/WorkspaceSelectView の二重 load 防止パターンが**コードコメントだけに頼っている**現状はリスク。今回のような取り残しを構造的に防ぐには:

- 共通 hook (`useWorkspaceReloadOnConnect` 等) に集約
- もしくは spec ファイル (`docs/spec/workspace-loading.md`) に「skip 条件 = loading=false」を明文化

ただし本 PR スコープ外、別 ISSUE 起票候補 (AGENTS.md 鉄則 2 に該当: 別機能側の改善ではなくフレームワーク全体の小規模再設計)。**現状は本 PR で点滅を即時解消することを優先**し、共通 hook 化は本 PR がマージされた後に判断。

## レビュー担当への申し送り

- PR #816 (1490aec) と PR #813 (#806 シリーズ) を読んでから本 PR を見るとコンテキストが揃う
- 「`workspaces.length > 0` チェックを外して大丈夫か」が判断の中心。WorkspaceSelectView が同等パターンで安定稼働している実績を根拠としています
- `loadChain` (workspaceStore.ts:97) による並行直列化が backup として効くため、万一 race で二重 load しても無限ループにはならない (safety net)

🤖 Generated with [Claude Code](https://claude.com/claude-code)