### PR TITLE
feat: container 配布 foundation (#1055) + workspace folder picker (#1056)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,10 +14,11 @@
 
   "mounts": [
     "source=harmony-claude,target=/home/node/.claude,type=volume",
-    "source=harmony-codex,target=/home/node/.codex,type=volume"
+    "source=harmony-codex,target=/home/node/.codex,type=volume",
+    "source=harmony-state,target=/home/node/.harmony,type=volume"
   ],
 
-  "onCreateCommand": "sudo chown -R node:node /home/node/.claude /home/node/.codex",
+  "onCreateCommand": "sudo chown -R node:node /home/node/.claude /home/node/.codex /home/node/.harmony",
 
   "postCreateCommand": "npm install --prefix frontend && npm install --prefix backend && (cd frontend && npx playwright install --with-deps chromium) && npm install -g @anthropic-ai/claude-code @openai/codex",
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,51 @@
+# Harmony L1 .dockerignore (#1055)
+#
+# Dockerfile が backend/ のみ COPY するため過剰除外は不要だが、
+# 仮にコンテキスト全体を読まれた場合の事故防止 + build 速度向上のため記載。
+
+# node modules (各 stage で npm ci する)
+**/node_modules
+
+# build artifacts
+**/dist
+**/build
+**/.next
+**/.vite
+**/coverage
+
+# git
+.git
+.gitignore
+.gitattributes
+
+# IDE / OS
+.vscode
+.idea
+.DS_Store
+Thumbs.db
+
+# dev container 専用 (image には不要)
+.devcontainer
+
+# テスト / 一時ファイル
+test-results
+**/playwright-report
+.tmp
+tmp
+logs
+
+# secrets
+.env*
+*.pem
+*.key
+
+# README / docs (将来 README を含めたい場合は許可リスト化)
+docs
+
+# 開発時 workspaces / data (利用者が volume mount する)
+workspaces
+data/.drafts
+
+# Claude / Codex 設定 (image には不要)
+.claude
+.codex

--- a/.dockerignore
+++ b/.dockerignore
@@ -44,7 +44,9 @@ docs
 
 # 開発時 workspaces / data (利用者が volume mount する)
 workspaces
-data/.drafts
+# data/ は built-in 拡張定義を含むが L1 image では同梱しない (docs/spec/path-conventions.md §7 参照)。
+# L2 で frontend + extensions を一括同梱する際にこの除外を解除する。
+data
 
 # Claude / Codex 設定 (image には不要)
 .claude

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,54 @@
+# Harmony L1 production Dockerfile (#1055)
+#
+# 目的: path 規約 (HARMONY_HOME / workspaces 親ディレクトリ) を確定し、
+#       将来 L2 (frontend 同梱) / L3 (公開配布) の base を作る。
+#
+# L1 制約 (本ファイル時点):
+#   - frontend は同梱しない。利用者が別途 `cd frontend && npm run dev`
+#     する必要がある (L2 で nginx or backend-static-serve で統合予定)
+#   - 配布用ではない。本 image は path 規約確定 + L2 への足場のためのみ
+#   - multi-arch (amd64/arm64) や healthcheck は L3 で対応
+#
+# 配布シナリオの想定 (将来):
+#   docker run \
+#     -v harmony-state:/home/node/.harmony \
+#     -v ~/projects:/data/workspaces \
+#     -p 5179:5179 \
+#     harnize/harmony:1.0
+#
+# 詳細仕様: docs/spec/path-conventions.md
+
+# ─── stage 1: build ─────────────────────────────────────────────────────────
+FROM node:20-alpine AS build
+WORKDIR /app
+
+COPY backend/package.json backend/package-lock.json* ./backend/
+RUN cd backend && npm ci
+
+COPY backend ./backend
+RUN cd backend && npm run build
+
+# ─── stage 2: runtime ───────────────────────────────────────────────────────
+FROM node:20-alpine AS runtime
+WORKDIR /app
+
+# backend のビルド成果物のみ持ち込み、production 依存を別途 install する
+# (build stage の node_modules には devDependencies が含まれるため runtime に
+#  そのまま持ち込まず、ここで `npm ci --omit=dev` で再構築する)
+COPY --from=build /app/backend/dist ./backend/dist
+COPY --from=build /app/backend/package.json ./backend/package.json
+COPY --from=build /app/backend/package-lock.json* ./backend/
+RUN cd backend && npm ci --omit=dev && npm cache clean --force
+
+# 規約: アプリ state (recent-workspaces.json 等) の置き場
+ENV HARMONY_HOME=/home/node/.harmony
+VOLUME ["/home/node/.harmony"]
+
+# 規約: workspaces 親ディレクトリ。ユーザーは bind mount で host のフォルダを
+#       マッピングするか、named volume を使う。中身は配布時には空。
+VOLUME ["/data/workspaces"]
+
+EXPOSE 5179
+
+USER node
+CMD ["node", "backend/dist/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,13 +40,16 @@ COPY --from=build /app/backend/package.json ./backend/package.json
 COPY --from=build /app/backend/package-lock.json* ./backend/
 RUN cd backend && npm ci --omit=dev && npm cache clean --force
 
-# 規約: アプリ state (recent-workspaces.json 等) の置き場
-ENV HARMONY_HOME=/home/node/.harmony
-VOLUME ["/home/node/.harmony"]
+# 規約: アプリ state (recent-workspaces.json 等) の置き場 + workspaces 親ディレクトリ
+# Docker は named volume を初期化する際 image 内の対応ディレクトリの所有者・モードを
+# volume にコピーする。VOLUME 宣言**前**にディレクトリを mkdir + chown して
+# `node` 所有にしておかないと、named volume が root:root で初期化されて `USER node`
+# 起動後の app が EACCES で書き込めない (Sonnet review Must-fix #1057)。
+RUN mkdir -p /home/node/.harmony /data/workspaces \
+    && chown -R node:node /home/node/.harmony /data/workspaces
 
-# 規約: workspaces 親ディレクトリ。ユーザーは bind mount で host のフォルダを
-#       マッピングするか、named volume を使う。中身は配布時には空。
-VOLUME ["/data/workspaces"]
+ENV HARMONY_HOME=/home/node/.harmony
+VOLUME ["/home/node/.harmony", "/data/workspaces"]
 
 EXPOSE 5179
 

--- a/backend/src/fsBrowse.test.ts
+++ b/backend/src/fsBrowse.test.ts
@@ -1,0 +1,173 @@
+/**
+ * fsBrowse 単体テスト (#1056)
+ *
+ * 実 fs を tmp ディレクトリに構築して browseFs() の動作を検証。
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { browseFs, BrowseFsError, resolveDefaultBrowsePath } from "./fsBrowse.js";
+
+const TMP_ROOT = path.join(os.tmpdir(), `harmony-fsbrowse-test-${process.pid}-${Date.now()}`);
+
+beforeAll(async () => {
+  await fs.mkdir(TMP_ROOT, { recursive: true });
+  // 構造:
+  //   TMP_ROOT/
+  //     ws-a/
+  //       harmony.json                  ← isWorkspace=true
+  //       screens/
+  //     ws-b/
+  //       harmony.json                  ← isWorkspace=true
+  //     not-a-workspace/
+  //       readme.md                     ← isWorkspace=false (harmony.json なし)
+  //     file-at-root.txt                ← isDir=false, isWorkspace=false
+  await fs.mkdir(path.join(TMP_ROOT, "ws-a", "screens"), { recursive: true });
+  await fs.writeFile(path.join(TMP_ROOT, "ws-a", "harmony.json"), "{}", "utf-8");
+  await fs.mkdir(path.join(TMP_ROOT, "ws-b"), { recursive: true });
+  await fs.writeFile(path.join(TMP_ROOT, "ws-b", "harmony.json"), "{}", "utf-8");
+  await fs.mkdir(path.join(TMP_ROOT, "not-a-workspace"), { recursive: true });
+  await fs.writeFile(path.join(TMP_ROOT, "not-a-workspace", "readme.md"), "# hi", "utf-8");
+  await fs.writeFile(path.join(TMP_ROOT, "file-at-root.txt"), "hello", "utf-8");
+});
+
+afterAll(async () => {
+  await fs.rm(TMP_ROOT, { recursive: true, force: true });
+});
+
+describe("browseFs", () => {
+  it("ディレクトリ内のエントリを返す + workspace 判定が正しい", async () => {
+    const r = await browseFs(TMP_ROOT);
+    expect(r.path).toBe(path.resolve(TMP_ROOT));
+    expect(r.parent).toBe(path.dirname(TMP_ROOT));
+    const names = r.entries.map((e) => e.name);
+    expect(names).toContain("ws-a");
+    expect(names).toContain("ws-b");
+    expect(names).toContain("not-a-workspace");
+    expect(names).toContain("file-at-root.txt");
+
+    const wsA = r.entries.find((e) => e.name === "ws-a")!;
+    expect(wsA.isDir).toBe(true);
+    expect(wsA.isWorkspace).toBe(true);
+
+    const notWs = r.entries.find((e) => e.name === "not-a-workspace")!;
+    expect(notWs.isDir).toBe(true);
+    expect(notWs.isWorkspace).toBe(false);
+
+    const file = r.entries.find((e) => e.name === "file-at-root.txt")!;
+    expect(file.isDir).toBe(false);
+    expect(file.isWorkspace).toBe(false);
+  });
+
+  it("ディレクトリ→ファイル順、各カテゴリ内は name 昇順でソート", async () => {
+    const r = await browseFs(TMP_ROOT);
+    // dir 群が file 群より前にあること
+    const firstFileIdx = r.entries.findIndex((e) => !e.isDir);
+    const lastDirIdx = r.entries.reduce((acc, e, i) => (e.isDir ? i : acc), -1);
+    expect(lastDirIdx).toBeLessThan(firstFileIdx);
+    // dir 部分が name 昇順
+    const dirs = r.entries.filter((e) => e.isDir).map((e) => e.name);
+    expect(dirs).toEqual([...dirs].sort((a, b) => a.localeCompare(b, "ja")));
+  });
+
+  it("mtime が ISO 8601 で返る", async () => {
+    const r = await browseFs(TMP_ROOT);
+    const wsA = r.entries.find((e) => e.name === "ws-a")!;
+    expect(wsA.mtime).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+
+  it("path 省略時は default 開始位置 (= resolveDefaultBrowsePath) を使う", async () => {
+    const originalWs = process.env.HARMONY_WORKSPACES_DIR;
+    const originalHome = process.env.HARMONY_HOME;
+    process.env.HARMONY_WORKSPACES_DIR = TMP_ROOT;
+    delete process.env.HARMONY_HOME;
+    try {
+      const r = await browseFs();
+      expect(r.path).toBe(path.resolve(TMP_ROOT));
+    } finally {
+      if (originalWs !== undefined) {
+        process.env.HARMONY_WORKSPACES_DIR = originalWs;
+      } else {
+        delete process.env.HARMONY_WORKSPACES_DIR;
+      }
+      if (originalHome !== undefined) process.env.HARMONY_HOME = originalHome;
+    }
+  });
+
+  it("../ を含む相対 path は path.resolve で正規化される", async () => {
+    const tricky = path.join(TMP_ROOT, "ws-a", "..", "ws-b");
+    const r = await browseFs(tricky);
+    expect(r.path).toBe(path.join(TMP_ROOT, "ws-b"));
+  });
+
+  it("notFound: 存在しない path", async () => {
+    await expect(browseFs(path.join(TMP_ROOT, "does-not-exist-xyz")))
+      .rejects.toThrow(BrowseFsError);
+    try {
+      await browseFs(path.join(TMP_ROOT, "does-not-exist-xyz"));
+    } catch (e) {
+      expect(e).toBeInstanceOf(BrowseFsError);
+      expect((e as BrowseFsError).code).toBe("notFound");
+    }
+  });
+
+  it("notDir: ファイルを指定", async () => {
+    try {
+      await browseFs(path.join(TMP_ROOT, "file-at-root.txt"));
+      throw new Error("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(BrowseFsError);
+      expect((e as BrowseFsError).code).toBe("notDir");
+    }
+  });
+
+  it("root の parent は null", async () => {
+    // Linux/macOS では '/'、Windows では 'C:\' 等
+    const root = path.parse(process.cwd()).root;
+    if (root && root !== "" && root !== process.cwd()) {
+      const r = await browseFs(root);
+      expect(r.parent).toBeNull();
+    }
+  });
+});
+
+describe("resolveDefaultBrowsePath", () => {
+  let originalWs: string | undefined;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    originalWs = process.env.HARMONY_WORKSPACES_DIR;
+    originalHome = process.env.HARMONY_HOME;
+    delete process.env.HARMONY_WORKSPACES_DIR;
+    delete process.env.HARMONY_HOME;
+  });
+
+  afterEach(() => {
+    if (originalWs !== undefined) {
+      process.env.HARMONY_WORKSPACES_DIR = originalWs;
+    } else {
+      delete process.env.HARMONY_WORKSPACES_DIR;
+    }
+    if (originalHome !== undefined) {
+      process.env.HARMONY_HOME = originalHome;
+    } else {
+      delete process.env.HARMONY_HOME;
+    }
+  });
+
+  it("HARMONY_WORKSPACES_DIR が最優先", () => {
+    process.env.HARMONY_WORKSPACES_DIR = "/data/workspaces";
+    process.env.HARMONY_HOME = "/home/node/.harmony";
+    expect(resolveDefaultBrowsePath()).toBe(path.resolve("/data/workspaces"));
+  });
+
+  it("HARMONY_HOME のみ指定時はその親ディレクトリ", () => {
+    process.env.HARMONY_HOME = "/home/node/.harmony";
+    expect(resolveDefaultBrowsePath()).toBe(path.resolve("/home/node"));
+  });
+
+  it("いずれも未設定なら os.homedir()", () => {
+    expect(resolveDefaultBrowsePath()).toBe(os.homedir());
+  });
+});

--- a/backend/src/fsBrowse.ts
+++ b/backend/src/fsBrowse.ts
@@ -1,0 +1,150 @@
+/**
+ * fsBrowse.ts (#1056)
+ *
+ * backend filesystem browser - workspace.browseFs MCP tool の実装。
+ *
+ * 目的: container / リモート開発で「ブラウザ側 file picker が使えない」状況に対し、
+ * backend が自身の filesystem をリストして frontend に tree UI を渡す。
+ *
+ * 設計判断 (L1):
+ * - **path 範囲は限定しない** (allowlist 不在)。container 内で動く前提なので、fs 全体に
+ *   意味のあるアクセス制御をかける必要が薄い。SaaS / multi-tenant 化時には
+ *   `HARMONY_ALLOWED_BROWSE_ROOTS` 等を別 ISSUE で追加する。
+ * - `path.resolve` で正規化して `..` 経由の relative escape は除去する。
+ * - `harmony.json` を含むフォルダは `isWorkspace=true` で frontend に強調表示させる。
+ *
+ * 詳細仕様: docs/spec/path-conventions.md §8
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+export type FsEntry = {
+  name: string;
+  isDir: boolean;
+  /** `harmony.json` を含むディレクトリの場合 true (isDir が true の時のみ意味を持つ) */
+  isWorkspace: boolean;
+  /** ISO 8601 形式の最終更新時刻 (取得失敗時は null) */
+  mtime: string | null;
+};
+
+export type BrowseResult = {
+  /** 解決された絶対パス (正規化済) */
+  path: string;
+  /** 親ディレクトリの絶対パス。root の場合 null */
+  parent: string | null;
+  /** ディレクトリ内のエントリ一覧。alphabetical sort、dir 優先 */
+  entries: FsEntry[];
+};
+
+export class BrowseFsError extends Error {
+  constructor(message: string, public readonly code: "notFound" | "notDir" | "permission" | "io") {
+    super(message);
+    this.name = "BrowseFsError";
+  }
+}
+
+/**
+ * `browseFs` の default 開始 path を解決する。
+ * 優先順位:
+ *   1. env `HARMONY_WORKSPACES_DIR` — 配布時のワークスペース親ディレクトリ規約
+ *   2. env `HARMONY_HOME` の 1 階層上 — state 配置場所の親 (例: `/home/node`)
+ *   3. `os.homedir()` — fallback
+ */
+export function resolveDefaultBrowsePath(): string {
+  const wsDir = process.env.HARMONY_WORKSPACES_DIR?.trim();
+  if (wsDir && wsDir.length > 0) return path.resolve(wsDir);
+  const harmonyHome = process.env.HARMONY_HOME?.trim();
+  if (harmonyHome && harmonyHome.length > 0) {
+    return path.resolve(path.dirname(harmonyHome));
+  }
+  return os.homedir();
+}
+
+/**
+ * 指定パスのディレクトリ内容をリストする。
+ *
+ * @param targetPath - 絶対 or 相対パス。省略時は default 開始位置 (`resolveDefaultBrowsePath`)
+ * @throws BrowseFsError - notFound / notDir / permission / io
+ */
+export async function browseFs(targetPath?: string): Promise<BrowseResult> {
+  const raw = (targetPath ?? "").trim();
+  const abs = raw.length > 0 ? path.resolve(raw) : resolveDefaultBrowsePath();
+
+  let stat: import("node:fs").Stats;
+  try {
+    stat = await fs.stat(abs);
+  } catch (e) {
+    const code = (e as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      throw new BrowseFsError(`フォルダが見つかりません: ${abs}`, "notFound");
+    }
+    if (code === "EACCES" || code === "EPERM") {
+      throw new BrowseFsError(`アクセス権限がありません: ${abs}`, "permission");
+    }
+    throw new BrowseFsError(`stat 失敗: ${e instanceof Error ? e.message : String(e)}`, "io");
+  }
+
+  if (!stat.isDirectory()) {
+    throw new BrowseFsError(`ディレクトリではありません: ${abs}`, "notDir");
+  }
+
+  let names: string[];
+  try {
+    names = await fs.readdir(abs);
+  } catch (e) {
+    const code = (e as NodeJS.ErrnoException).code;
+    if (code === "EACCES" || code === "EPERM") {
+      throw new BrowseFsError(`ディレクトリ読み取り権限がありません: ${abs}`, "permission");
+    }
+    throw new BrowseFsError(`readdir 失敗: ${e instanceof Error ? e.message : String(e)}`, "io");
+  }
+
+  // 各エントリの stat と harmony.json 存在チェックを並列実行
+  const entries = await Promise.all(names.map(async (name): Promise<FsEntry | null> => {
+    if (name === "." || name === "..") return null;
+    const child = path.join(abs, name);
+    let childStat: import("node:fs").Stats;
+    try {
+      // symlink を follow しない: symlink loop / 隠し外部 path への意図しない誘導を避ける
+      childStat = await fs.lstat(child);
+    } catch {
+      return null; // 読めないエントリは静かに skip
+    }
+    const isDir = childStat.isDirectory();
+    let isWorkspace = false;
+    if (isDir) {
+      try {
+        const harmonyStat = await fs.stat(path.join(child, "harmony.json"));
+        isWorkspace = harmonyStat.isFile();
+      } catch {
+        isWorkspace = false;
+      }
+    }
+    return {
+      name,
+      isDir,
+      isWorkspace,
+      mtime: childStat.mtime.toISOString(),
+    };
+  }));
+
+  const validEntries = entries.filter((e): e is FsEntry => e !== null);
+
+  // sort: ディレクトリを先、各カテゴリ内は name 昇順 (locale-aware)
+  validEntries.sort((a, b) => {
+    if (a.isDir !== b.isDir) return a.isDir ? -1 : 1;
+    return a.name.localeCompare(b.name, "ja");
+  });
+
+  // parent: root では null。Linux/macOS の `/`、Windows の `C:\` 等は path.dirname が
+  // 自分自身を返すので、その場合 null にする
+  const parentCandidate = path.dirname(abs);
+  const parent = parentCandidate === abs ? null : parentCandidate;
+
+  return {
+    path: abs,
+    parent,
+    entries: validEntries,
+  };
+}

--- a/backend/src/fsBrowse.ts
+++ b/backend/src/fsBrowse.ts
@@ -64,6 +64,12 @@ export function resolveDefaultBrowsePath(): string {
 /**
  * 指定パスのディレクトリ内容をリストする。
  *
+ * symlink の扱い:
+ *   - **target (引数 `targetPath`)** は `fs.stat` で follow する。ユーザーが明示的に
+ *     navigation した path のため、たとえ symlink 経由でも実体ディレクトリを開く。
+ *   - **子エントリ** は `fs.lstat` で follow しない。symlink loop / 意図しない外部
+ *     path への誘導を避けるため、子は symlink ファイル (isDir=false) として表示する。
+ *
  * @param targetPath - 絶対 or 相対パス。省略時は default 開始位置 (`resolveDefaultBrowsePath`)
  * @throws BrowseFsError - notFound / notDir / permission / io
  */
@@ -71,6 +77,7 @@ export async function browseFs(targetPath?: string): Promise<BrowseResult> {
   const raw = (targetPath ?? "").trim();
   const abs = raw.length > 0 ? path.resolve(raw) : resolveDefaultBrowsePath();
 
+  // target は fs.stat で symlink を follow (上記 docstring 参照)
   let stat: import("node:fs").Stats;
   try {
     stat = await fs.stat(abs);

--- a/backend/src/recentStore.test.ts
+++ b/backend/src/recentStore.test.ts
@@ -131,13 +131,73 @@ describe("recentStore", () => {
 
   it("env 未設定時のデフォルトは ~/.harmony/recent-workspaces.json", () => {
     const original = process.env.DESIGNER_RECENT_FILE;
+    const originalHome = process.env.HARMONY_HOME;
     delete process.env.DESIGNER_RECENT_FILE;
+    delete process.env.HARMONY_HOME;
     try {
       expect(_internals.recentFile()).toBe(
         path.join(os.homedir(), ".harmony", "recent-workspaces.json"),
       );
     } finally {
       if (original !== undefined) process.env.DESIGNER_RECENT_FILE = original;
+      if (originalHome !== undefined) process.env.HARMONY_HOME = originalHome;
+    }
+  });
+
+  it("env HARMONY_HOME 指定時は <HARMONY_HOME>/recent-workspaces.json (#1055)", () => {
+    const original = process.env.DESIGNER_RECENT_FILE;
+    const originalHome = process.env.HARMONY_HOME;
+    delete process.env.DESIGNER_RECENT_FILE;
+    process.env.HARMONY_HOME = "/tmp/harmony-state-xyz";
+    try {
+      expect(_internals.recentFile()).toBe("/tmp/harmony-state-xyz/recent-workspaces.json");
+    } finally {
+      if (original !== undefined) process.env.DESIGNER_RECENT_FILE = original;
+      if (originalHome !== undefined) {
+        process.env.HARMONY_HOME = originalHome;
+      } else {
+        delete process.env.HARMONY_HOME;
+      }
+    }
+  });
+
+  it("DESIGNER_RECENT_FILE は HARMONY_HOME より優先される (#1055)", () => {
+    const original = process.env.DESIGNER_RECENT_FILE;
+    const originalHome = process.env.HARMONY_HOME;
+    process.env.DESIGNER_RECENT_FILE = "/tmp/override-file.json";
+    process.env.HARMONY_HOME = "/tmp/should-be-ignored";
+    try {
+      expect(_internals.recentFile()).toBe(path.resolve("/tmp/override-file.json"));
+    } finally {
+      if (original !== undefined) {
+        process.env.DESIGNER_RECENT_FILE = original;
+      } else {
+        delete process.env.DESIGNER_RECENT_FILE;
+      }
+      if (originalHome !== undefined) {
+        process.env.HARMONY_HOME = originalHome;
+      } else {
+        delete process.env.HARMONY_HOME;
+      }
+    }
+  });
+
+  it("HARMONY_HOME が空文字 / 空白のみの場合はデフォルトに fallback (#1055)", () => {
+    const original = process.env.DESIGNER_RECENT_FILE;
+    const originalHome = process.env.HARMONY_HOME;
+    delete process.env.DESIGNER_RECENT_FILE;
+    process.env.HARMONY_HOME = "   ";
+    try {
+      expect(_internals.recentFile()).toBe(
+        path.join(os.homedir(), ".harmony", "recent-workspaces.json"),
+      );
+    } finally {
+      if (original !== undefined) process.env.DESIGNER_RECENT_FILE = original;
+      if (originalHome !== undefined) {
+        process.env.HARMONY_HOME = originalHome;
+      } else {
+        delete process.env.HARMONY_HOME;
+      }
     }
   });
 });

--- a/backend/src/recentStore.ts
+++ b/backend/src/recentStore.ts
@@ -38,14 +38,22 @@ type RecentFile = {
 const SCHEMA_TAG = "harmony-recent-workspaces-v1";
 
 /**
- * 永続化先の解決。env DESIGNER_RECENT_FILE で上書き可能 (テスト / VS Code 拡張等の
- * sandbox 用途)。未指定なら ~/.harmony/recent-workspaces.json。
+ * 永続化先の解決。優先順位 (高い順):
+ *   1. env `DESIGNER_RECENT_FILE` — 完全な file path (テスト / VS Code 拡張等の sandbox 用)
+ *   2. env `HARMONY_HOME`         — Harmony state 用のディレクトリ。recent-workspaces.json は
+ *                                   この配下に作られる (#1055: container 配布の path 規約)
+ *   3. default                    — ~/.harmony/recent-workspaces.json
+ *
  * 関数化することで、テスト中の vi.stubEnv / 直接代入が即座に反映される。
+ *
+ * 規約詳細: docs/spec/path-conventions.md
  */
 function recentFile(): string {
   const override = process.env.DESIGNER_RECENT_FILE;
   if (override && override.trim().length > 0) return path.resolve(override);
-  return path.join(os.homedir(), ".harmony", "recent-workspaces.json");
+  const home = process.env.HARMONY_HOME?.trim();
+  const dir = home && home.length > 0 ? path.resolve(home) : path.join(os.homedir(), ".harmony");
+  return path.join(dir, "recent-workspaces.json");
 }
 
 function recentDir(): string {

--- a/backend/src/wsBridge.ts
+++ b/backend/src/wsBridge.ts
@@ -44,6 +44,7 @@ import {
   initializeWorkspace as initializeWorkspaceFolder,
 } from "./workspaceInit.js";
 import { getHostInfo } from "./hostInfo.js";
+import { browseFs, BrowseFsError } from "./fsBrowse.js";
 import {
   EditSessionStore,
   EditSessionNotFoundError,
@@ -1576,6 +1577,20 @@ class WsBridge extends EventEmitter {
         case "workspace.hostInfo": {
           const info = await getHostInfo();
           respond(info);
+          break;
+        }
+        case "workspace.browseFs": {
+          const { path: targetPath } = (params ?? {}) as { path?: string };
+          try {
+            const result = await browseFs(typeof targetPath === "string" ? targetPath : undefined);
+            respond(result);
+          } catch (e) {
+            if (e instanceof BrowseFsError) {
+              respondError(e.message);
+            } else {
+              throw e;
+            }
+          }
           break;
         }
         case "workspace.open": {

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -36,6 +36,7 @@
 | **[schema-design-principles.md](schema-design-principles.md)** | **schema を どう書くか の規範** — 命名 / 構造 / フォーマット / コード補完 / 拡張判断 / 後方互換 / テスト規約 / 既知課題 | #517 |
 | **[workspace.md](workspace.md)** | ワークスペース (project) のライフサイクル / lockdown / プロトコル / 並行制御 — 複数ワークスペース管理機能 v1 の正規仕様 | #27 / #671-#676 / #678 |
 | **[workspace-multi.md](workspace-multi.md)** | マルチワークスペース対応 (v2) — per-session active state / URL `/w/:wsId/` / VSCode モデル | #679 |
+| **[path-conventions.md](path-conventions.md)** | 永続化データの配置規約 (Harmony state / 成果物 / built-in リソース 3 カテゴリ) + container 配布時の mount 戦略 + `HARMONY_HOME` 環境変数 | #1055 |
 | **[edit-session-draft.md](edit-session-draft.md)** | **サーバ側 draft 管理モデル** — 全エディタ明示保存 + ロック排他 + AI 連携 (D-1〜D-12 / 状態遷移図 / owner-actor 分離 / リスクマトリクス) | #683 / #684 |
 | **[edit-session-protocol.md](edit-session-protocol.md)** | **協調編集の正規プロトコル** — EditSession 一級概念 / 1-6 step ライフサイクル / role と take-over atomic / 複数 EditSession 並存 / TTL / AI 識別 (`Alice@AI`) — `collab-presence.md` の発展的後継 | #876 派生 / #855 |
 | [collab-presence.md](collab-presence.md) | 協調編集 (Direction B) overture — 採用根拠 / Forward-Compat 4 原則 / Activity taxonomy (正規プロトコルは `edit-session-protocol.md` 参照) | #876 / #855 |

--- a/docs/spec/path-conventions.md
+++ b/docs/spec/path-conventions.md
@@ -1,0 +1,153 @@
+# path-conventions.md
+
+Harmony の永続化対象データの配置規約と、container 配布時の mount 設計指針。
+
+関連: #1055 (本仕様の根拠 ISSUE) / [edit-session-draft.md](edit-session-draft.md) / [workspace.md](workspace.md)
+
+## 1. 永続化データのカテゴリ
+
+Harmony が扱うデータは性質によって 3 つに分類される。配置先と mount 戦略はカテゴリごとに異なる。
+
+| カテゴリ | 例 | 性質 | 配置 |
+|---------|-----|-----|-----|
+| **(a) Harmony state** | `recent-workspaces.json` (recent index) / 将来の AI cache / preferences | machine-specific なユーザー履歴 | `HARMONY_HOME` 配下 |
+| **(b) workspace 成果物** | `<workspace>/harmony.json` / `screens/` / `tables/` / `process-flows/` / `extensions/` / `.drafts/` | 業務設計の成果物、Git 管理対象 | ユーザーが任意配置 (絶対パス) |
+| **(c) built-in リソース** | `data/extensions/` (組み込み拡張定義 — field-types / response-types 等) | 配布物の一部、read-only | image 内に焼き込み |
+
+## 2. `HARMONY_HOME` 環境変数
+
+カテゴリ (a) の置き場を指定する。
+
+```
+default: ~/.harmony
+内容例:
+  ~/.harmony/recent-workspaces.json
+  ~/.harmony/ai-cache/  (将来)
+```
+
+優先順位 (`recentStore.ts` 実装):
+
+1. **`DESIGNER_RECENT_FILE`** — full file path、テスト / 拡張 sandbox 用
+2. **`HARMONY_HOME`** — ディレクトリ path。recent-workspaces.json は `<HARMONY_HOME>/recent-workspaces.json`
+3. **default** — `~/.harmony/recent-workspaces.json`
+
+container 内では `HARMONY_HOME=/home/node/.harmony` を ENV で指定し、`VOLUME ["/home/node/.harmony"]` を Dockerfile で宣言する (本リポの `Dockerfile` 参照)。
+
+## 3. workspaces 親ディレクトリ規約
+
+カテゴリ (b) は**規約上の親ディレクトリを強制しない**。`recent-workspaces.json` 内に各 workspace の**絶対パス**が記録される設計のため、workspace 実体はファイルシステム上のどこにあってもよい。
+
+ただし container 配布時の**推奨**として `/data/workspaces/` を親ディレクトリにし、`VOLUME ["/data/workspaces"]` を Dockerfile で宣言する。利用者はこの親パスを host bind mount するか named volume にする。
+
+```
+/data/workspaces/         ← 親 (mount point、本ファイル自体は空)
+├── my-app/               ← workspace 1
+│   ├── harmony.json
+│   ├── screens/
+│   ├── tables/
+│   ├── process-flows/
+│   └── .drafts/          ← edit session drafts (active workspace 配下、#683)
+├── another-app/          ← workspace 2
+│   └── harmony.json
+└── ...
+```
+
+利用者は UI の「追加」ボタンで `/data/workspaces/my-app` のような絶対パスを入力 → `recent-workspaces.json` に登録される (現行 flow と同じ)。
+
+## 4. mount 戦略マトリクス
+
+container 配布時、カテゴリ別に named volume / host bind を選ぶ:
+
+| カテゴリ | 推奨 | 理由 |
+|---------|-----|------|
+| (a) `HARMONY_HOME` | **named volume** | machine-specific、host 直接アクセス不要、container 廃止で痕跡残らないのが望ましい |
+| (b) workspaces 親 | **host bind mount** | Git 管理対象、host 上の他ツール (IDE / GUI) で編集する可能性、バックアップを host 側で取りたい |
+| (c) built-in リソース | mount 不要 | image 同梱 |
+
+### named volume vs host bind の差 (再掲)
+
+| 方式 | 書き方 | host から見える | 移植性 |
+|------|--------|---------------|--------|
+| **named volume** | `source=<名前>,target=<container path>,type=volume` | docker volume inspect 経由のみ | volume 名で再生成可、別マシン移行は `docker volume export/import` |
+| **host bind mount** | `source=<host path>,target=<container path>,type=bind` | host で普通にアクセス可 | host fs が永続する限り永続 |
+
+## 5. devcontainer.json (本リポの開発環境)
+
+開発用 Dev Container は本リポの `.devcontainer/devcontainer.json` で named volume 3 種類を mount している:
+
+```jsonc
+"mounts": [
+  "source=harmony-claude,target=/home/node/.claude,type=volume",
+  "source=harmony-codex,target=/home/node/.codex,type=volume",
+  "source=harmony-state,target=/home/node/.harmony,type=volume"
+]
+```
+
+- `harmony-claude` / `harmony-codex`: AI tool 設定 (auth 等)
+- `harmony-state`: Harmony state (recent-workspaces.json 等、本仕様の (a))
+
+workspaces 成果物 (b) は project bind mount (`/workspaces/harmony/workspaces/`) に内包される (現行 dev container の host bind mount を流用)。
+
+## 6. 配布シナリオ別 docker-compose 例
+
+将来 `harnize/harmony:1.0` を公開した時の利用者側 docker-compose 例。
+
+### 6.1 個人 PC で 1 user が使う想定 (典型)
+
+```yaml
+# docker-compose.yml
+services:
+  harmony:
+    image: harnize/harmony:1.0
+    ports:
+      - "5179:5179"
+    volumes:
+      - harmony-state:/home/node/.harmony   # (a) state は named volume
+      - ~/projects:/data/workspaces          # (b) 成果物は host の ~/projects に bind
+    environment:
+      HARMONY_HOME: /home/node/.harmony
+volumes:
+  harmony-state:
+```
+
+利用者は `~/projects/<任意名>/` 配下に harmony.json を含むワークスペースを置く。Harmony UI から `/data/workspaces/<任意名>` を絶対パスで「追加」する。
+
+### 6.2 host を一切汚さない想定 (CI / 一時起動)
+
+```yaml
+services:
+  harmony:
+    image: harnize/harmony:1.0
+    ports:
+      - "5179:5179"
+    volumes:
+      - harmony-state:/home/node/.harmony
+      - harmony-workspaces:/data/workspaces   # (b) も named volume にする
+volumes:
+  harmony-state:
+  harmony-workspaces:
+```
+
+利用者はワークスペースを host から直接編集できないが、container 完全 isolation が取れる。
+
+### 6.3 SaaS 配布の場合 (multi-tenant)
+
+file system による state 管理は行わず、DB の users / workspaces テーブルに格納する。本ファイル外。
+
+## 7. L1 / L2 / L3 スコープ
+
+L1 (本 ISSUE #1055): path 規約 + 最小 Dockerfile (backend のみ) + devcontainer 永続化。**配布の約束はしない**。
+
+L2 (将来): frontend 同梱、backend が静的配信、healthcheck 追加、self-host できる image。利用者が「1 container で全部動く」状態。
+
+L3 (将来): 公開配布。multi-arch (amd64/arm64) build、image tag 戦略、SBOM、脆弱性スキャン、リリースノート連携。
+
+## 8. 既知の課題 / 設計判断
+
+### `workspace.browseFs` のセキュリティ (#1056)
+
+L1 段階では backend folder browser API は**ホスト fs 全体をブラウズ可能**で、allowlist を強制しない (`path.resolve` で `../` 経由の relative escape のみ正規化)。
+
+理由: container 配布前提の path 規約フェーズであり、本格的な permission system は L2/L3 の認証・認可設計と一体で組む方が筋がよい。L1 では「container 内で動く前提なので fs 全体に意味のあるアクセス制御をかける必要が薄い」「dev 環境では開発者本人が UI を操作する前提」と整理する。
+
+将来 SaaS / multi-tenant 化時には `HARMONY_ALLOWED_BROWSE_ROOTS` 等で制限する仕様を別 ISSUE で追加する。

--- a/docs/spec/path-conventions.md
+++ b/docs/spec/path-conventions.md
@@ -142,6 +142,16 @@ L2 (将来): frontend 同梱、backend が静的配信、healthcheck 追加、se
 
 L3 (将来): 公開配布。multi-arch (amd64/arm64) build、image tag 戦略、SBOM、脆弱性スキャン、リリースノート連携。
 
+### L1 image の同梱範囲 (現状)
+
+§1 の表で (c) built-in リソース (`data/extensions/`) を「image 内に焼き込み」と分類しているが、**L1 Dockerfile では `backend/` のみ COPY** しており、`data/extensions/` は同梱されていない。理由:
+
+- L1 は path 規約確定が目的で、配布前提ではない
+- `backend/` 起動時は `data/extensions/` が無くても起動可能 (拡張定義が空の状態で動作)
+- L2 で frontend + extensions を同梱するタイミングで一括対応する
+
+**L1 image を実機で動かす場合の workaround**: ホストの `data/extensions/` を bind mount するか、`backend/` 内に default extensions を埋め込む shim を別途用意する。L2 完了までは Dev Container での開発用途に留めるのが妥当。
+
 ## 8. 既知の課題 / 設計判断
 
 ### `workspace.browseFs` のセキュリティ (#1056)

--- a/frontend/e2e/workspace-folder-picker.spec.ts
+++ b/frontend/e2e/workspace-folder-picker.spec.ts
@@ -1,0 +1,148 @@
+/**
+ * workspace-folder-picker.spec.ts (#1056)
+ *
+ * AddWorkspaceDialog の「参照」ボタン → BackendFolderPicker → 選択 → 入力欄反映の
+ * 一連フローを E2E で検証。
+ *
+ * 前提: backend (port 5179) と frontend (port 5173) が稼働中。
+ *
+ * backend の filesystem を実機ブラウズするため、`.tmp/e2e-folder-picker/` 配下に
+ * 固定のテスト用ディレクトリ構造 (workspace fixture) を毎回作成する。
+ */
+import { test, expect, type Page } from "@playwright/test";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const FIXTURE_ROOT = path.resolve(".tmp/e2e-folder-picker");
+const FIXTURE_WS_A = path.join(FIXTURE_ROOT, "ws-a");
+const FIXTURE_WS_B = path.join(FIXTURE_ROOT, "ws-b");
+const FIXTURE_NOT_WS = path.join(FIXTURE_ROOT, "not-a-workspace");
+
+async function ensureFixture(): Promise<void> {
+  await fs.mkdir(FIXTURE_WS_A, { recursive: true });
+  await fs.writeFile(
+    path.join(FIXTURE_WS_A, "harmony.json"),
+    JSON.stringify({ $schema: "harmony-project-v3", version: 3, meta: { name: "FixtureA" }, dataDir: "harmony" }),
+    "utf-8",
+  );
+  await fs.mkdir(FIXTURE_WS_B, { recursive: true });
+  await fs.writeFile(
+    path.join(FIXTURE_WS_B, "harmony.json"),
+    JSON.stringify({ $schema: "harmony-project-v3", version: 3, meta: { name: "FixtureB" }, dataDir: "harmony" }),
+    "utf-8",
+  );
+  await fs.mkdir(FIXTURE_NOT_WS, { recursive: true });
+  await fs.writeFile(path.join(FIXTURE_NOT_WS, "readme.md"), "# placeholder", "utf-8");
+}
+
+async function setupClean(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.clear();
+    window.alert = () => {};
+    window.confirm = () => false;
+  });
+}
+
+async function openAddDialog(page: Page): Promise<void> {
+  await page.goto("/workspace/list");
+  const addBtn = page.locator("button", { hasText: "追加" }).first();
+  await addBtn.click();
+  await expect(page.locator(".tbl-modal")).toBeVisible();
+}
+
+async function openFolderPicker(page: Page, initialPath: string): Promise<void> {
+  // 「参照」ボタン押下前に、初期 path を入力欄に入れて picker の initialPath として使う
+  const input = page.getByTestId("workspace-path-input");
+  await input.fill(initialPath);
+  await page.getByTestId("open-folder-picker").click();
+  // picker overlay が見えるまで待つ
+  await expect(page.getByTestId("backend-folder-picker-overlay")).toBeVisible();
+}
+
+test.describe("AddWorkspaceDialog — BackendFolderPicker (#1056)", { tag: ["@regression"] }, () => {
+  test.beforeEach(async () => {
+    await ensureFixture();
+  });
+
+  test("「参照」ボタンで picker が開き、fixture ディレクトリの一覧が表示される", async ({ page }) => {
+    await setupClean(page);
+    await openAddDialog(page);
+    await openFolderPicker(page, FIXTURE_ROOT);
+
+    // 現在 path 表示が fixture root
+    await expect(page.getByTestId("folder-picker-current-path")).toHaveText(FIXTURE_ROOT);
+
+    // entries: ws-a (workspace), ws-b (workspace), not-a-workspace (dir)
+    const entries = page.getByTestId("folder-picker-entry");
+    await expect(entries).toHaveCount(3);
+
+    // ws-a / ws-b は isWorkspace=true としてバッジ付き
+    await expect(entries.filter({ has: page.locator('[data-is-workspace="true"]') })).toHaveCount(0); // marker on parent
+    // 上記が data-attr の継承を取らないので別の方法で確認
+    const wsAEntry = entries.filter({ hasText: "ws-a" }).first();
+    await expect(wsAEntry).toHaveAttribute("data-is-workspace", "true");
+    const wsBEntry = entries.filter({ hasText: "ws-b" }).first();
+    await expect(wsBEntry).toHaveAttribute("data-is-workspace", "true");
+    const notWsEntry = entries.filter({ hasText: "not-a-workspace" }).first();
+    await expect(notWsEntry).toHaveAttribute("data-is-workspace", "false");
+  });
+
+  test("フォルダクリックで cd → 「このフォルダを選択」で path 入力欄に反映 → close", async ({ page }) => {
+    await setupClean(page);
+    await openAddDialog(page);
+    await openFolderPicker(page, FIXTURE_ROOT);
+
+    // ws-a クリックで cd
+    await page.getByTestId("folder-picker-entry").filter({ hasText: "ws-a" }).first().click();
+    await expect(page.getByTestId("folder-picker-current-path")).toHaveText(FIXTURE_WS_A);
+
+    // 「このフォルダを選択」
+    await page.getByTestId("folder-picker-select").click();
+
+    // picker が閉じる
+    await expect(page.getByTestId("backend-folder-picker-overlay")).toHaveCount(0);
+
+    // path 入力欄に絶対パスが入る
+    await expect(page.getByTestId("workspace-path-input")).toHaveValue(FIXTURE_WS_A);
+
+    // debounced auto-inspect が走り status badge が出る
+    const badge = page.getByTestId("workspace-status");
+    await expect(badge).toBeVisible({ timeout: 5000 });
+    // FIXTURE_WS_A は harmony.json があるが minimal schema なので AJV validation は通らない
+    // (project schema は project_id / 詳細 meta 等を要求)。実 fixture では invalid になる可能性が
+    // 高いが、本 e2e の目的は「picker → 入力欄反映 → inspect 起動」までで十分。
+    // status は ready / invalid / needsInit のいずれかであれば picker の wire は成功している。
+    await expect(badge).toHaveAttribute("data-status", /ready|invalid|needsInit|notFound/);
+  });
+
+  test("「上の階層」で parent に移動", async ({ page }) => {
+    await setupClean(page);
+    await openAddDialog(page);
+    await openFolderPicker(page, FIXTURE_WS_A);
+
+    await expect(page.getByTestId("folder-picker-current-path")).toHaveText(FIXTURE_WS_A);
+
+    await page.getByTestId("folder-picker-up").click();
+
+    await expect(page.getByTestId("folder-picker-current-path")).toHaveText(FIXTURE_ROOT);
+  });
+
+  test("外側 overlay クリックで picker close、path は変更されない", async ({ page }) => {
+    await setupClean(page);
+    await openAddDialog(page);
+    const input = page.getByTestId("workspace-path-input");
+    await input.fill(FIXTURE_ROOT);
+    await page.getByTestId("open-folder-picker").click();
+    await expect(page.getByTestId("backend-folder-picker-overlay")).toBeVisible();
+
+    // overlay の左上余白を狙ってクリック (modal 本体ではない位置)
+    const overlay = page.getByTestId("backend-folder-picker-overlay");
+    const box = await overlay.boundingBox();
+    if (!box) throw new Error("overlay bounding box not available");
+    await page.mouse.click(box.x + 5, box.y + 5);
+
+    await expect(page.getByTestId("backend-folder-picker-overlay")).toHaveCount(0);
+    // path 入力欄は変更されていない
+    await expect(input).toHaveValue(FIXTURE_ROOT);
+  });
+});

--- a/frontend/e2e/workspace-os-aware-input.spec.ts
+++ b/frontend/e2e/workspace-os-aware-input.spec.ts
@@ -1,11 +1,11 @@
 /**
  * workspace-os-aware-input.spec.ts (#858)
  *
- * AddWorkspaceDialog の WSL2 環境向け UX 改善を E2E で検証。
+ * AddWorkspaceDialog の host-aware UX を E2E で検証。
  *
  * カバー範囲:
  *  - host info (workspace.hostInfo) で OS-aware placeholder が出る
- *  - WSL2 環境 (本検証 host) では「WSL2 環境を検出しました」の専用ヒントが出る
+ *  - WSL2 環境の placeholder は Linux 形式の絶対パス (#1056 で旧 WSL 専用ヒント文は削除済)
  *  - debounced auto-inspect: パス入力 400ms 後に status badge が描画される
  *  - 「確認」ボタン (secondary) で即時検証も可能 (auto-inspect 待ち回避)
  *  - recent dropdown: input フォーカス / 入力時に最近のワークスペースが表示される

--- a/frontend/e2e/workspace-os-aware-input.spec.ts
+++ b/frontend/e2e/workspace-os-aware-input.spec.ts
@@ -46,7 +46,7 @@ async function isWslHost(): Promise<boolean> {
 }
 
 test.describe("AddWorkspaceDialog — WSL2 / OS-aware UX (#858)", { tag: ["@regression"] }, () => {
-  test("WSL2 環境では Linux 形式の絶対パスと専用ヒントが表示される", async ({ page }) => {
+  test("WSL2 環境では Linux 形式の絶対パスが placeholder に出る (#1056: 専用ヒント文は削除済)", async ({ page }) => {
     test.skip(!(await isWslHost()), "WSL2 ホスト前提の test (host /proc/version に Microsoft/WSL を含むときのみ実行)");
     await setupClean(page);
     await openAddDialog(page);
@@ -60,8 +60,9 @@ test.describe("AddWorkspaceDialog — WSL2 / OS-aware UX (#858)", { tag: ["@regr
     // 既存 #755 e2e と同様 workspaces/ 形式も placeholder に含まれること
     expect(placeholder).toContain("workspaces/my-app");
 
-    // WSL 検出ヒント (本ホストは WSL2 想定)
-    await expect(page.locator(".tbl-modal").getByText(/WSL2 環境を検出しました/)).toBeVisible();
+    // 旧 WSL 検出ヒント文 (#858 / #919) は #1056 で削除 — negative assert
+    // (新 BackendFolderPicker は WSL でも普通に動くので専用ヒントが不要になった)
+    await expect(page.locator(".tbl-modal").getByText(/WSL2 環境を検出しました/)).toHaveCount(0);
   });
 
   test("パス入力 → debounce 後に status badge が自動描画される", async ({ page }) => {

--- a/frontend/src/components/workspace/AddWorkspaceDialog.test.tsx
+++ b/frontend/src/components/workspace/AddWorkspaceDialog.test.tsx
@@ -43,7 +43,19 @@ vi.mock("react-router-dom", () => ({
 vi.mock("../../mcp/mcpBridge", () => ({
   mcpBridge: {
     onStatusChange: vi.fn(() => () => {}),
+    request: vi.fn(),
   },
+}));
+
+// BackendFolderPicker は内部で browseFs (mcpBridge.request 経由) を呼ぶ。
+// AddWorkspaceDialog のテストでは picker 内部までは検証しないので、軽量モックに差し替える。
+vi.mock("./BackendFolderPicker", () => ({
+  BackendFolderPicker: ({ onSelect, onClose }: { onSelect: (p: string) => void; onClose: () => void }) => (
+    <div data-testid="picker-mock">
+      <button data-testid="picker-mock-select" onClick={() => onSelect("/picked/path")}>select</button>
+      <button data-testid="picker-mock-close" onClick={onClose}>close</button>
+    </div>
+  ),
 }));
 
 vi.mock("../../store/workspaceStore", async () => {
@@ -92,18 +104,22 @@ describe("AddWorkspaceDialog (#858)", () => {
     expect(placeholder).toContain("workspaces/my-app");
   });
 
-  it("WSL 環境では Linux 形式の絶対パスと WSL 専用ヒントを表示する", async () => {
+  it("WSL 環境では Linux 形式の絶対パスを placeholder に出す (#1056 で WSL 専用ヒント文は削除)", async () => {
+    // 旧 showDirectoryPicker 経路を BackendFolderPicker (#1056) に置換した結果、
+    // WSL2 専用ヒント文 (「Windows ブラウザの『フォルダ参照』では Linux パスに到達不可」)
+    // は不要になったので削除した。host info に基づく placeholder 切替は維持。
     getHostInfoMock.mockResolvedValue(makeHost({ platform: "linux", isWSL: true, homeDir: "/home/wsluser" }));
     inspectWorkspaceMock.mockResolvedValue({ status: "notFound", path: "" } satisfies WorkspaceInspectResult);
 
     render(<AddWorkspaceDialog onClose={() => {}} onAdded={() => {}} />);
 
+    const input = await screen.findByTestId("workspace-path-input");
     await waitFor(() => {
-      expect(screen.getByText(/WSL2 環境を検出しました/)).toBeTruthy();
+      const placeholder = input.getAttribute("placeholder") ?? "";
+      expect(placeholder).toContain("/home/wsluser/projects/my-app");
     });
-    const input = screen.getByTestId("workspace-path-input");
-    const placeholder = input.getAttribute("placeholder") ?? "";
-    expect(placeholder).toContain("/home/wsluser/projects/my-app");
+    // 旧ヒント文が消えていることを negative assert で固定 (#1056 regression 防止)
+    expect(screen.queryByText(/WSL2 環境を検出しました/)).toBeNull();
   });
 
   it("Windows ホストではバックスラッシュ形式の例を出す", async () => {
@@ -221,6 +237,31 @@ describe("AddWorkspaceDialog (#858)", () => {
     await waitFor(() => {
       expect(screen.queryByRole("listbox", { name: "最近使ったワークスペース" })).toBeNull();
     });
+  });
+
+  it("「参照」ボタンで BackendFolderPicker を開き、選択結果が入力欄に反映される (#1056)", async () => {
+    getHostInfoMock.mockResolvedValue(makeHost());
+    inspectWorkspaceMock.mockResolvedValue({ status: "ready", path: "/picked/path", name: "Picked" } satisfies WorkspaceInspectResult);
+
+    render(<AddWorkspaceDialog onClose={() => {}} onAdded={() => {}} />);
+
+    // 初期状態では picker は閉じている
+    expect(screen.queryByTestId("picker-mock")).toBeNull();
+
+    // 「参照」ボタンクリックで picker を開く
+    const browseBtn = await screen.findByTestId("open-folder-picker");
+    fireEvent.click(browseBtn);
+
+    expect(screen.getByTestId("picker-mock")).toBeTruthy();
+
+    // picker 内 select クリックで入力欄が埋まり picker は閉じる
+    fireEvent.click(screen.getByTestId("picker-mock-select"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("picker-mock")).toBeNull();
+    });
+    const input = screen.getByTestId("workspace-path-input") as HTMLInputElement;
+    expect(input.value).toBe("/picked/path");
   });
 
   it("入力を空に戻すと進行中 inspect の遅延結果で UI が上書きされない (MF-1 race fix)", async () => {

--- a/frontend/src/components/workspace/BackendFolderPicker.test.tsx
+++ b/frontend/src/components/workspace/BackendFolderPicker.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * BackendFolderPicker 単体テスト (#1056)
+ *
+ * mcpBridge を mock し、navigate / parent / select / error の各経路を確認。
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { BrowseFsResult } from "../../store/workspaceStore";
+
+const browseFsMock = vi.fn<(path?: string) => Promise<BrowseFsResult>>();
+
+vi.mock("../../store/workspaceStore", () => ({
+  browseFs: (path?: string) => browseFsMock(path),
+}));
+
+const { BackendFolderPicker, _internals } = await import("./BackendFolderPicker");
+
+beforeEach(() => {
+  browseFsMock.mockReset();
+});
+
+describe("BackendFolderPicker", () => {
+  it("初期表示で browseFs を呼び、結果を一覧表示する", async () => {
+    browseFsMock.mockResolvedValueOnce({
+      path: "/home/node/projects",
+      parent: "/home/node",
+      entries: [
+        { name: "ws-a", isDir: true, isWorkspace: true, mtime: "2026-05-12T10:00:00Z" },
+        { name: "ws-b", isDir: true, isWorkspace: false, mtime: "2026-05-12T11:00:00Z" },
+        { name: "readme.md", isDir: false, isWorkspace: false, mtime: "2026-05-12T12:00:00Z" },
+      ],
+    });
+
+    render(<BackendFolderPicker onSelect={vi.fn()} onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("folder-picker-current-path")).toHaveTextContent("/home/node/projects");
+    });
+    const entries = screen.getAllByTestId("folder-picker-entry");
+    expect(entries.length).toBe(3);
+    expect(entries[0]).toHaveAttribute("data-name", "ws-a");
+    expect(entries[0]).toHaveAttribute("data-is-workspace", "true");
+    expect(entries[2]).toHaveAttribute("data-is-dir", "false");
+  });
+
+  it("フォルダクリックで cd (browseFs 再呼出)", async () => {
+    browseFsMock.mockResolvedValueOnce({
+      path: "/home/node/projects",
+      parent: "/home/node",
+      entries: [{ name: "ws-a", isDir: true, isWorkspace: true, mtime: null }],
+    });
+    browseFsMock.mockResolvedValueOnce({
+      path: "/home/node/projects/ws-a",
+      parent: "/home/node/projects",
+      entries: [{ name: "screens", isDir: true, isWorkspace: false, mtime: null }],
+    });
+
+    render(<BackendFolderPicker onSelect={vi.fn()} onClose={vi.fn()} />);
+    await waitFor(() => expect(screen.getAllByTestId("folder-picker-entry").length).toBe(1));
+
+    fireEvent.click(screen.getAllByTestId("folder-picker-entry")[0]);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("folder-picker-current-path")).toHaveTextContent(
+        "/home/node/projects/ws-a",
+      );
+    });
+    expect(browseFsMock).toHaveBeenNthCalledWith(2, "/home/node/projects/ws-a");
+  });
+
+  it("ファイルクリックでは何も起きない (isDir=false)", async () => {
+    browseFsMock.mockResolvedValueOnce({
+      path: "/home/node",
+      parent: null,
+      entries: [{ name: "readme.md", isDir: false, isWorkspace: false, mtime: null }],
+    });
+
+    render(<BackendFolderPicker onSelect={vi.fn()} onClose={vi.fn()} />);
+    await waitFor(() => expect(screen.getAllByTestId("folder-picker-entry").length).toBe(1));
+
+    fireEvent.click(screen.getAllByTestId("folder-picker-entry")[0]);
+
+    expect(browseFsMock).toHaveBeenCalledTimes(1); // 初期 1 回のみ、cd は起きていない
+  });
+
+  it("「上の階層」ボタンで parent に移動。root では disabled", async () => {
+    browseFsMock.mockResolvedValueOnce({
+      path: "/home/node",
+      parent: null, // root 扱い
+      entries: [],
+    });
+
+    render(<BackendFolderPicker onSelect={vi.fn()} onClose={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId("folder-picker-up")).toBeDisabled());
+  });
+
+  it("parent 有りなら「上の階層」が押せる", async () => {
+    browseFsMock.mockResolvedValueOnce({
+      path: "/home/node/projects",
+      parent: "/home/node",
+      entries: [],
+    });
+    browseFsMock.mockResolvedValueOnce({
+      path: "/home/node",
+      parent: "/home",
+      entries: [],
+    });
+
+    render(<BackendFolderPicker onSelect={vi.fn()} onClose={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId("folder-picker-up")).not.toBeDisabled());
+
+    fireEvent.click(screen.getByTestId("folder-picker-up"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("folder-picker-current-path")).toHaveTextContent("/home/node");
+    });
+    expect(browseFsMock).toHaveBeenNthCalledWith(2, "/home/node");
+  });
+
+  it("「このフォルダを選択」で現在 path を onSelect に渡し close 要求", () => {
+    const onSelect = vi.fn();
+    browseFsMock.mockResolvedValueOnce({
+      path: "/home/node/projects",
+      parent: "/home/node",
+      entries: [],
+    });
+
+    render(<BackendFolderPicker onSelect={onSelect} onClose={vi.fn()} />);
+    return waitFor(() => {
+      const selectBtn = screen.getByTestId("folder-picker-select");
+      expect(selectBtn).not.toBeDisabled();
+      fireEvent.click(selectBtn);
+      expect(onSelect).toHaveBeenCalledWith("/home/node/projects");
+    });
+  });
+
+  it("browseFs が throw した場合は error を表示し、UI が固まらない", async () => {
+    browseFsMock.mockRejectedValueOnce(new Error("フォルダが見つかりません: /nope"));
+
+    render(<BackendFolderPicker initialPath="/nope" onSelect={vi.fn()} onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("folder-picker-error")).toHaveTextContent(
+        "フォルダが見つかりません: /nope",
+      );
+    });
+  });
+
+  it("外側 overlay クリックで onClose", async () => {
+    browseFsMock.mockResolvedValueOnce({
+      path: "/home/node",
+      parent: null,
+      entries: [],
+    });
+    const onClose = vi.fn();
+    render(<BackendFolderPicker onSelect={vi.fn()} onClose={onClose} />);
+    await waitFor(() => expect(browseFsMock).toHaveBeenCalled());
+    fireEvent.click(screen.getByTestId("backend-folder-picker-overlay"));
+    expect(onClose).toHaveBeenCalled();
+  });
+});
+
+describe("joinPath (internal)", () => {
+  it("posix path: / 連結", () => {
+    expect(_internals.joinPath("/home/node/projects", "ws-a")).toBe("/home/node/projects/ws-a");
+  });
+
+  it("posix root: / + name", () => {
+    expect(_internals.joinPath("/", "tmp")).toBe("/tmp");
+  });
+
+  it("末尾 / は重複しない", () => {
+    expect(_internals.joinPath("/home/node/", "ws-a")).toBe("/home/node/ws-a");
+  });
+
+  it("windows path: \\ 連結 (path に \\ のみ含む場合)", () => {
+    expect(_internals.joinPath("C:\\Users\\node", "ws-a")).toBe("C:\\Users\\node\\ws-a");
+  });
+
+  it("windows drive root: C:\\ → C:\\name", () => {
+    expect(_internals.joinPath("C:\\", "Users")).toBe("C:\\Users");
+  });
+});

--- a/frontend/src/components/workspace/BackendFolderPicker.tsx
+++ b/frontend/src/components/workspace/BackendFolderPicker.tsx
@@ -1,0 +1,245 @@
+/**
+ * BackendFolderPicker (#1056)
+ *
+ * backend の filesystem をブラウズして 1 つのディレクトリを選択する modal。
+ *
+ * 用途:
+ *   container / remote 開発で「ブラウザ側 file picker が使えない」場合の workspace 選択 UX。
+ *   `showDirectoryPicker` (Web 仕様) は handle のみ返却で絶対 path を取れず、Harmony とは
+ *   相性が悪いため、backend の `workspace.browseFs` 経由で fs を navigate する。
+ *
+ * 操作:
+ *   - フォルダクリック: cd
+ *   - 「上の階層」ボタン: parent に移動 (root では disabled)
+ *   - 「このフォルダを選択」ボタン: 現在の path を onSelect で返して close
+ *   - 「キャンセル」: close のみ
+ *
+ * 関連: docs/spec/path-conventions.md §8
+ */
+import { useEffect, useState, useCallback } from "react";
+import { browseFs, type FsEntry, type BrowseFsResult } from "../../store/workspaceStore";
+
+export interface BackendFolderPickerProps {
+  /** 初期表示 path。省略時は backend の default (HARMONY_WORKSPACES_DIR / homedir 等) */
+  initialPath?: string;
+  /** フォルダ確定時に絶対 path を返す */
+  onSelect: (absolutePath: string) => void;
+  /** modal close 要求 (キャンセル / 外側クリック) */
+  onClose: () => void;
+}
+
+export function BackendFolderPicker({ initialPath, onSelect, onClose }: BackendFolderPickerProps) {
+  const [data, setData] = useState<BrowseFsResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [currentPath, setCurrentPath] = useState<string | null>(initialPath ?? null);
+
+  const navigate = useCallback(async (target?: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await browseFs(target);
+      setData(result);
+      setCurrentPath(result.path);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    navigate(initialPath);
+  }, [initialPath, navigate]);
+
+  const handleEntryClick = (entry: FsEntry) => {
+    if (!entry.isDir || !data) return;
+    const next = joinPath(data.path, entry.name);
+    navigate(next);
+  };
+
+  const handleParentClick = () => {
+    if (!data?.parent) return;
+    navigate(data.parent);
+  };
+
+  const handleSelectClick = () => {
+    if (currentPath) onSelect(currentPath);
+  };
+
+  return (
+    <div
+      className="tbl-modal-overlay"
+      onClick={onClose}
+      data-testid="backend-folder-picker-overlay"
+    >
+      <div
+        className="tbl-modal"
+        onClick={(e) => e.stopPropagation()}
+        style={{ maxWidth: "640px", width: "90vw" }}
+      >
+        <div className="tbl-modal-title">フォルダを選択</div>
+
+        {/* 現在 path (パンくず代わり) */}
+        <div
+          style={{
+            fontFamily: "monospace",
+            fontSize: "0.85rem",
+            padding: "6px 10px",
+            background: "var(--card-bg, #1f2230)",
+            borderRadius: "4px",
+            marginBottom: "8px",
+            overflowWrap: "anywhere",
+            color: "var(--muted-text, #aaa)",
+          }}
+          data-testid="folder-picker-current-path"
+        >
+          {currentPath ?? "—"}
+        </div>
+
+        <div style={{ display: "flex", gap: "6px", marginBottom: "8px" }}>
+          <button
+            type="button"
+            className="tbl-btn tbl-btn-ghost"
+            onClick={handleParentClick}
+            disabled={!data?.parent || loading}
+            title={data?.parent ? `${data.parent} へ移動` : "ルートのためこれ以上上には移動できません"}
+            data-testid="folder-picker-up"
+          >
+            <i className="bi bi-arrow-up" /> 上の階層
+          </button>
+        </div>
+
+        {/* エントリ一覧 */}
+        <div
+          style={{
+            border: "1px solid var(--border, #334)",
+            borderRadius: "4px",
+            maxHeight: "360px",
+            overflowY: "auto",
+            background: "var(--card-bg, #1f2230)",
+          }}
+          data-testid="folder-picker-entries"
+        >
+          {loading && (
+            <div style={{ padding: "12px", color: "var(--muted-text, #888)", fontSize: "0.85rem" }}>
+              <i className="bi bi-hourglass-split" /> 読み込み中...
+            </div>
+          )}
+          {!loading && error && (
+            <div
+              style={{
+                padding: "12px",
+                color: "var(--danger-text, #f88)",
+                fontSize: "0.85rem",
+              }}
+              data-testid="folder-picker-error"
+            >
+              <i className="bi bi-exclamation-circle" /> {error}
+            </div>
+          )}
+          {!loading && !error && data && data.entries.length === 0 && (
+            <div style={{ padding: "12px", color: "var(--muted-text, #888)", fontSize: "0.85rem" }}>
+              このフォルダは空です。
+            </div>
+          )}
+          {!loading && !error && data && data.entries.length > 0 && (
+            <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
+              {data.entries.map((entry) => {
+                const clickable = entry.isDir;
+                const baseStyle: React.CSSProperties = {
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "8px",
+                  padding: "6px 10px",
+                  borderBottom: "1px solid var(--border-faint, #2a2d3a)",
+                  fontSize: "0.85rem",
+                  cursor: clickable ? "pointer" : "default",
+                  color: clickable ? "inherit" : "var(--muted-text, #888)",
+                  background: entry.isWorkspace ? "rgba(77,171,247,0.08)" : undefined,
+                };
+                return (
+                  <li
+                    key={entry.name}
+                    onClick={() => handleEntryClick(entry)}
+                    onDoubleClick={() => clickable && handleEntryClick(entry)}
+                    style={baseStyle}
+                    data-testid="folder-picker-entry"
+                    data-name={entry.name}
+                    data-is-dir={entry.isDir}
+                    data-is-workspace={entry.isWorkspace}
+                  >
+                    <i
+                      className={
+                        entry.isWorkspace
+                          ? "bi bi-folder-fill"
+                          : entry.isDir
+                            ? "bi bi-folder2"
+                            : "bi bi-file-earmark"
+                      }
+                      style={{
+                        color: entry.isWorkspace ? "var(--accent, #4dabf7)" : undefined,
+                      }}
+                    />
+                    <span style={{ flex: 1, fontFamily: "monospace" }}>{entry.name}</span>
+                    {entry.isWorkspace && (
+                      <span
+                        style={{
+                          fontSize: "0.7rem",
+                          background: "var(--accent, #4dabf7)",
+                          color: "#fff",
+                          borderRadius: "3px",
+                          padding: "1px 5px",
+                        }}
+                      >
+                        ワークスペース
+                      </span>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+
+        <div className="tbl-modal-btns" style={{ marginTop: "10px" }}>
+          <button type="button" className="tbl-btn tbl-btn-ghost" onClick={onClose}>
+            キャンセル
+          </button>
+          <button
+            type="button"
+            className="tbl-btn tbl-btn-primary"
+            onClick={handleSelectClick}
+            disabled={!currentPath || loading}
+            data-testid="folder-picker-select"
+          >
+            このフォルダを選択
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * シンプルな path join。
+ *
+ * BackendFolderPicker は backend (= server) の path 形式を扱う。本来は
+ * `path.join` 相当を分離レイヤーで対応すべきだが、本コンポーネントは Linux/macOS
+ * の `/` 区切り + Windows `\` 区切りの両 default だけサポートできれば良いので
+ * 簡易実装する。`base` の末尾区切りを除去してから区切り文字で連結する。
+ */
+function joinPath(base: string, name: string): string {
+  const sep = base.includes("\\") && !base.includes("/") ? "\\" : "/";
+  const trimmed = base.replace(/[/\\]+$/, "");
+  // base が root だけ (Linux "/" or "C:\\") の場合、trimmed が空 or "C:" になるが、
+  // どちらも単に区切り文字を 1 つだけ前に挟めばよい
+  if (trimmed === "" || /^[A-Za-z]:$/.test(trimmed)) {
+    return `${trimmed}${sep}${name}`;
+  }
+  return `${trimmed}${sep}${name}`;
+}
+
+/** @internal テスト用 */
+// eslint-disable-next-line react-refresh/only-export-components
+export const _internals = { joinPath };

--- a/frontend/src/components/workspace/BackendFolderPicker.tsx
+++ b/frontend/src/components/workspace/BackendFolderPicker.tsx
@@ -231,12 +231,13 @@ export function BackendFolderPicker({ initialPath, onSelect, onClose }: BackendF
  */
 function joinPath(base: string, name: string): string {
   const sep = base.includes("\\") && !base.includes("/") ? "\\" : "/";
+  // 末尾の区切り文字を 1 個だけ残す形に正規化してから連結:
+  //   - "/"         → "" + "/" + name = "/<name>"
+  //   - "/foo/"     → "/foo" + "/" + name = "/foo/<name>"
+  //   - "C:\\"      → "C:" + "\\" + name = "C:\\<name>"
+  //   - "C:\\foo\\" → "C:\\foo" + "\\" + name = "C:\\foo\\<name>"
+  // root の場合と通常 path の場合で結果式が同じになるため if 分岐は不要。
   const trimmed = base.replace(/[/\\]+$/, "");
-  // base が root だけ (Linux "/" or "C:\\") の場合、trimmed が空 or "C:" になるが、
-  // どちらも単に区切り文字を 1 つだけ前に挟めばよい
-  if (trimmed === "" || /^[A-Za-z]:$/.test(trimmed)) {
-    return `${trimmed}${sep}${name}`;
-  }
   return `${trimmed}${sep}${name}`;
 }
 

--- a/frontend/src/components/workspace/WorkspaceListView.tsx
+++ b/frontend/src/components/workspace/WorkspaceListView.tsx
@@ -23,6 +23,7 @@ import { useListKeyboard } from "../../hooks/useListKeyboard";
 import { useListFilter } from "../../hooks/useListFilter";
 import { useListSort } from "../../hooks/useListSort";
 import { usePersistentState } from "../../hooks/usePersistentState";
+import { BackendFolderPicker } from "./BackendFolderPicker";
 import "../../styles/table.css";
 
 const STORAGE_KEY = "list-view-mode:workspace-list";
@@ -82,9 +83,9 @@ export function AddWorkspaceDialog({ onClose, onAdded }: AddWorkspaceDialogProps
   const [inspectName, setInspectName] = useState<string | null>(null);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [processing, setProcessing] = useState(false);
-  const [pickedFolderHint, setPickedFolderHint] = useState<string | null>(null);
   const [host, setHost] = useState<HostInfo | null>(null);
   const [showRecent, setShowRecent] = useState(false);
+  const [showFolderPicker, setShowFolderPicker] = useState(false);
   const debounceRef = useRef<number | null>(null);
   const inflightSeqRef = useRef(0);
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -189,27 +190,17 @@ export function AddWorkspaceDialog({ onClose, onAdded }: AddWorkspaceDialogProps
     }
   };
 
-  const handlePickFolder = async () => {
-    if (!("showDirectoryPicker" in window)) return;
-    try {
-      const handle = await (window as Window & { showDirectoryPicker: () => Promise<{ name: string }> }).showDirectoryPicker();
-      // showDirectoryPicker は絶対パスを返さない (フォルダ名 .name のみ)。
-      // 入力欄に書き込むと相対パスとして MCP server cwd 配下と誤解釈されるため、
-      // 入力欄には触れず、フォルダ名だけを「選択ヒント」として表示する。
-      setPickedFolderHint(handle.name);
-      setErrorMsg(null);
-    } catch (e) {
-      if ((e as { name?: string }).name !== "AbortError") {
-        setErrorMsg("フォルダ選択に失敗しました");
-      }
-    }
+  // 旧 `showDirectoryPicker` 経路 (#858 / #919) は #1056 で廃止。Browser File System Access API
+  // は handle のみ返却で絶対パスを取れず、WSL2 / container / リモート開発のいずれでも実用にならない。
+  // 代わりに backend filesystem を browseFs MCP tool 経由でブラウズする BackendFolderPicker
+  // を採用 (`docs/spec/path-conventions.md §8`)。
+  const handlePickedFolder = (absolutePath: string) => {
+    setPath(absolutePath);
+    setShowFolderPicker(false);
+    setErrorMsg(null);
+    // 入力欄に値が入った瞬間に既存の debounced auto-inspect が走るので明示再 inspect は不要
   };
 
-  // WSL2 + Windows ブラウザ環境では showDirectoryPicker が Linux パスに到達できず実質使えないので、
-  // ヒント文と整合させてフォルダ参照ボタンを非表示にする (#858 / #919 Opus review nit)
-  const hasPickerSupport = typeof window !== "undefined"
-    && "showDirectoryPicker" in window
-    && !host?.isWSL;
   const placeholder = buildPlaceholder(host);
   const exampleAbs = buildOsAwareExamplePath(host);
 
@@ -279,17 +270,15 @@ export function AddWorkspaceDialog({ onClose, onAdded }: AddWorkspaceDialogProps
               style={{ flex: 1, fontFamily: "monospace" }}
               data-testid="workspace-path-input"
             />
-            {hasPickerSupport && (
-              <button
-                type="button"
-                className="tbl-btn tbl-btn-ghost"
-                onClick={handlePickFolder}
-                title="フォルダ名を確認 (絶対パスは別途入力)"
-                tabIndex={-1}
-              >
-                <i className="bi bi-folder2-open" />
-              </button>
-            )}
+            <button
+              type="button"
+              className="tbl-btn tbl-btn-ghost"
+              onClick={() => setShowFolderPicker(true)}
+              title="backend のフォルダをブラウズして選択 (#1056)"
+              data-testid="open-folder-picker"
+            >
+              <i className="bi bi-folder2-open" /> 参照
+            </button>
             {showRecent && filteredRecents.length > 0 && (
               <ul
                 id={dropdownId}
@@ -299,7 +288,7 @@ export function AddWorkspaceDialog({ onClose, onAdded }: AddWorkspaceDialogProps
                   position: "absolute",
                   top: "100%",
                   left: 0,
-                  right: hasPickerSupport ? "44px" : 0,
+                  right: "80px",
                   marginTop: "2px",
                   padding: 0,
                   listStyle: "none",
@@ -345,23 +334,17 @@ export function AddWorkspaceDialog({ onClose, onAdded }: AddWorkspaceDialogProps
           リポジトリ直下の <code>workspaces/my-app</code> 形式の相対パスも使用できます。
         </p>
 
-        {host?.isWSL && (
-          <p style={{ fontSize: "0.78rem", color: "var(--muted-text, #888)", margin: "0 0 6px" }}>
-            <i className="bi bi-info-circle" /> WSL2 環境を検出しました。Windows ブラウザの「フォルダ参照」では Linux パス
-            (<code>/home/...</code>) に到達できないため、上の入力欄に手動で絶対パスを入力してください。
-          </p>
-        )}
+        <p style={{ fontSize: "0.78rem", color: "var(--muted-text, #888)", margin: "0 0 8px" }}>
+          ※「参照」は backend (Harmony サーバ) 側のファイルシステムをブラウズします。
+          ブラウザ実行マシンの fs ではない点に注意してください。
+        </p>
 
-        {hasPickerSupport && (
-          <p style={{ fontSize: "0.78rem", color: "var(--muted-text, #888)", margin: "0 0 8px" }}>
-            ※「フォルダ選択」ボタンはフォルダ名の確認のみ可能です (ブラウザ仕様で絶対パス取得不可)。
-          </p>
-        )}
-
-        {pickedFolderHint && (
-          <p style={{ fontSize: "0.82rem", color: "var(--muted-text, #888)", margin: "0 0 8px" }}>
-            選択したフォルダ名: <strong>{pickedFolderHint}</strong> — このフォルダの<em>絶対パス</em>を上の入力欄に入力してください。
-          </p>
+        {showFolderPicker && (
+          <BackendFolderPicker
+            initialPath={path.trim() || undefined}
+            onSelect={handlePickedFolder}
+            onClose={() => setShowFolderPicker(false)}
+          />
         )}
 
         {/* インライン状態表示 (debounced auto-inspect の結果) */}

--- a/frontend/src/store/workspaceStore.ts
+++ b/frontend/src/store/workspaceStore.ts
@@ -166,6 +166,35 @@ export async function inspectWorkspace(path: string): Promise<WorkspaceInspectRe
   return result;
 }
 
+// ─── backend filesystem browser (#1056) ─────────────────────────────────────
+
+export interface FsEntry {
+  name: string;
+  isDir: boolean;
+  isWorkspace: boolean;
+  mtime: string | null;
+}
+
+export interface BrowseFsResult {
+  path: string;
+  parent: string | null;
+  entries: FsEntry[];
+}
+
+/**
+ * backend の filesystem をブラウズ (#1056)。
+ * container / remote 開発で「ブラウザ側 file picker が使えない」状況に対し、
+ * backend が自身の fs をリストして frontend に渡す。
+ *
+ * @param path - 絶対 or 相対 path。省略時は backend 側の HARMONY_WORKSPACES_DIR →
+ *               HARMONY_HOME の親 → os.homedir() の順で fallback
+ */
+export async function browseFs(path?: string): Promise<BrowseFsResult> {
+  const params = path !== undefined ? { path } : {};
+  const result = (await mcpBridge.request("workspace.browseFs", params)) as BrowseFsResult;
+  return result;
+}
+
 let _hostInfoCache: HostInfo | null = null;
 let _hostInfoInflight: Promise<HostInfo> | null = null;
 


### PR DESCRIPTION
## 関連

Closes #1055
Closes #1056

- 前段: #1053 / PR #1054 (点滅修正)
- 旧経路: #858 / #919 (showDirectoryPicker 採用 PR、本 PR で廃止)
- 仕様: docs/spec/path-conventions.md (本 PR で新規追加)

## 概要

Harmony を container 配布できるための **path 規約と最小 image** を確立し、container / リモート環境でも使える workspace folder picker を導入する 2 ISSUE の統合 PR。

- **#1055 (L1)**: production Dockerfile 雛形 + devcontainer.json 永続化 + `HARMONY_HOME` env 規約 + path-conventions.md
- **#1056**: backend が自身の fs を browse する MCP/WS tool `workspace.browseFs` + frontend `BackendFolderPicker` + AddWorkspaceDialog 連携

旧 `showDirectoryPicker` (#858 / #919) は Web 仕様上絶対 path を返さず WSL2 / container 環境で実用にならなかったので、本 PR で完全廃止し、backend folder browse パターン (code-server / VS Code Web と同手法) に置換。

## 主な変更

### #1055 — L1: container 配布 foundation

- **`Dockerfile`** (新規): multi-stage build (backend のみ)、`VOLUME` で `/home/node/.harmony` (state) と `/data/workspaces` (成果物親) を宣言、`ENV HARMONY_HOME=/home/node/.harmony`。L1 制約 (frontend 非同梱 / 配布前提なし) を inline コメントに明記。
- **`.dockerignore`** (新規): build context 過剰読み込み防止 + secrets fail-safe。
- **`.devcontainer/devcontainer.json`**: `harmony-state` named volume を `/home/node/.harmony` に bind。rebuild 越えで `recent-workspaces.json` が消えなくなる (#1053 の根本対策)。
- **`backend/src/recentStore.ts`**: `recentFile()` の優先順位を `DESIGNER_RECENT_FILE > HARMONY_HOME > ~/.harmony` に整理。既存 dev 環境 (env なし) は default 動作で完全互換。
- **`docs/spec/path-conventions.md`** (新規): 永続化データ 3 カテゴリ (Harmony state / workspace 成果物 / built-in リソース)、container 配布時の mount 戦略 (named volume vs host bind)、docker-compose 例 3 シナリオ (個人 PC / CI / SaaS)、L1/L2/L3 スコープ分離。

### #1056 — backend folder picker

- **`backend/src/fsBrowse.ts`** (新規): `browseFs(targetPath?)` + `resolveDefaultBrowsePath()`。symlink follow 無し (lstat)、エラー分類 (notFound/notDir/permission/io)、harmony.json 含むディレクトリの `isWorkspace=true` 自動判定。
- **`backend/src/wsBridge.ts`**: `workspace.browseFs` ハンドラ追加。
- **`frontend/src/store/workspaceStore.ts`**: `browseFs()` API + `FsEntry` / `BrowseFsResult` 型エクスポート。
- **`frontend/src/components/workspace/BackendFolderPicker.tsx`** (新規): modal、パンくず + entry list、cd / parent / select / cancel 操作、エラー表示、workspace バッジ強調。
- **`frontend/src/components/workspace/WorkspaceListView.tsx`** (AddWorkspaceDialog 部分): 旧 `showDirectoryPicker` / `hasPickerSupport` / `pickedFolderHint` / WSL2 専用ヒント文を削除、「参照」ボタンで `BackendFolderPicker` を開く形に置換。debounced auto-inspect / recent dropdown / Escape/Tab handling は無変更。

## 仕様逐条突合 (自己申告)

仕様書 `docs/spec/path-conventions.md` (本 PR で新規追加) との突合:

### §2 `HARMONY_HOME` 環境変数 (recentStore.ts 実装)

- 優先順位 (1) `DESIGNER_RECENT_FILE` (full path) — `backend/src/recentStore.ts:47` ✓
- 優先順位 (2) `HARMONY_HOME` (ディレクトリ) — `backend/src/recentStore.ts:48-49` ✓
- 優先順位 (3) default `~/.harmony/recent-workspaces.json` — `backend/src/recentStore.ts:48` ✓
- `HARMONY_HOME` 空文字 / 空白のみは fallback — `backend/src/recentStore.ts:48` (`.trim()` + length check) ✓
- 単体テスト (3 ケース): `backend/src/recentStore.test.ts:132-203` ✓

### §3 workspaces 親ディレクトリ規約

- 強制しない (絶対 path 記録) — recent-workspaces.json 構造に変更なし (`backend/src/recentStore.ts:11-17`) ✓
- container 配布時の推奨 `/data/workspaces` — `Dockerfile:43` で `VOLUME ["/data/workspaces"]` ✓

### §4 mount 戦略マトリクス

- (a) `HARMONY_HOME` named volume — `.devcontainer/devcontainer.json:18` ✓
- (b) workspaces 親 host bind mount — `.devcontainer/devcontainer.json` は project bind に内包 (現行 dev container の `/workspaces/harmony/` mount を流用) ✓
- (c) built-in mount 不要 — Dockerfile 内に `data/extensions/` を含めない方針 (現 L1 では backend のみ COPY) ✓

### §5 devcontainer.json (本リポ dev 環境)

- `harmony-state` named volume 追加 — `.devcontainer/devcontainer.json:18` ✓
- `onCreateCommand` で `chown` 拡張 — `.devcontainer/devcontainer.json:21` ✓

### §8 `workspace.browseFs` セキュリティ (L1 段階)

- allowlist 未強制 — `backend/src/fsBrowse.ts:70` の `path.resolve(raw)` で正規化のみ ✓
- symlink follow 無し — `backend/src/fsBrowse.ts:104` で `fs.lstat` 使用 ✓
- 将来 `HARMONY_ALLOWED_BROWSE_ROOTS` 追加余地は別 ISSUE 化候補 (spec に明記) ✓

## レビューで特に見てほしい箇所

1. **`workspace.browseFs` セキュリティ判断** (`backend/src/fsBrowse.ts`): L1 段階で allowlist 未強制とした判断。代替案として:
   - (案 A) `HARMONY_WORKSPACES_DIR` 配下のみ許可 → 開発時にプロジェクト外を見たいケースで詰む
   - (案 B) 完全自由 (現状採用) → container 内なら問題なし、SaaS 時は別途設計
   - (案 C) ユーザーホーム配下のみ → home に置きがちな前提に依存

2. **`HARMONY_HOME` 名前空間**: 既存 `DESIGNER_RECENT_FILE` (`recentStore.ts:46`) と混在。互換性のため両方サポートしているが、将来 `DESIGNER_*` 群を `HARMONY_*` に rename するなら別 ISSUE 化。

3. **Dockerfile L1 制約の妥当性** (`Dockerfile:5-14`): frontend を image に同梱しない設計で「配布用 image としては不完全」。L2 で frontend 統合 + healthcheck を追加する前提だが、本 L1 のスコープ判断は妥当か。

4. **devcontainer.json `harmony-state` volume**: 既存の `harmony-claude` / `harmony-codex` と命名規則を揃え、同パターンで chown 拡張。実機 rebuild は未実施 (rebuild すると本セッションが落ちる) — マージ後に container rebuild してマウントが効くか確認が必要。

## テスト

- **backend vitest**: `cd backend && npx vitest run` → recentStore 14 pass (env 3 件新規) + fsBrowse 11 pass (新規)
- **frontend vitest**: `cd frontend && npx vitest run src/components/workspace/` → 28 pass (BackendFolderPicker 13 件新規 + AddWorkspaceDialog picker wire 1 件新規)
- **Playwright e2e (実機)**: 
  - `workspace-folder-picker.spec.ts` 4 pass (新規)
  - `workspace-os-aware-input.spec.ts` 4 pass (WSL hint negative assert に更新)
- **MCP E2E**: N/A (本 PR では `workspace.browseFs` は WS bridge 経由、MCP tool 非露出)

## UI 影響 / AI smoke test

- [x] UI 影響あり (AddWorkspaceDialog 改修)
- [ ] UI 影響なし

### AI smoke test で確認した項目

Playwright を chrome installed 後に本 dev container 内で実行:

- [x] `/workspace/list` で「追加」→「参照」ボタンで picker modal が開く
- [x] fixture (`.tmp/e2e-folder-picker/`) ディレクトリの一覧が isWorkspace バッジ付きで表示
- [x] フォルダクリックで cd、「上の階層」で parent 移動
- [x] 「このフォルダを選択」で path 入力欄に絶対パスが入り、debounced auto-inspect が走る
- [x] overlay クリックで picker close (path 変更なし)
- [x] WSL2 専用ヒント文が削除されている (negative assert)
- [x] 既存の placeholder / status badge / 確認ボタン / recent dropdown は無変更で動作

**Docker build smoke** は dev container 内に docker daemon が無いため未実行。配布 image 動作は L2 のスコープで、本 PR は規約確定が目的。マージ後に host 側で `docker build .` で smoke 可能。

**devcontainer rebuild** は本セッションの作業継続のため未実施。本 PR がマージされ user が次回 rebuild すれば `harmony-state` volume が効いて recent-workspaces.json が永続化される。

## spec 側の不足点 / 提案

- `HARMONY_WORKSPACES_DIR` (browseFs default の workspaces 親 path) は実装でのみ使用、spec への明文化が薄い。`docs/spec/path-conventions.md` への補強候補だが本 PR スコープではない (folder picker default 限定の env のため)。
- L2 / L3 への移行手順は spec §7 に概要のみ。実装時に詳細を追記する想定。

## レビュー担当への申し送り

- ISSUE #1055 と #1056 は性格が違う (infra vs UI feature) ため、commit を分けてある (`ba3f158` L1 / `7de4f2a` folder browser)。レビュー時は別々に diff を見ると把握しやすい
- `workspace-os-aware-input.spec.ts` の 1 件目テストは破壊的変更扱い。旧仕様 (WSL2 専用ヒント表示) が新仕様 (削除) に変わったので、negative assert へ更新した。新仕様の妥当性 (BackendFolderPicker が WSL でも普通に動く) を念のため確認してほしい
- `BackendFolderPicker.tsx:244` の `_internals` export に `eslint-disable-next-line react-refresh/only-export-components` を付けた (HMR 影響回避)。テストのために `joinPath` を外部から呼びたいが component と同居でも fast refresh は機能する想定
- 共通化候補: WorkspaceSelectView と WorkspaceListView の onStatusChange handler パターン (PR #1054 でも触れた) と、本 PR の `joinPath` ユーティリティ。両方ともスコープ外で follow-up 候補

🤖 Generated with [Claude Code](https://claude.com/claude-code)