### PR TITLE
feat(process-flow): 処理フローエディタUIを3ペイン構成に刷新する (#1071)

### DIFF
--- a/docs/prototypes/process-flow-editor-redesign-1071.html
+++ b/docs/prototypes/process-flow-editor-redesign-1071.html
@@ -324,14 +324,24 @@
     }
 
     .drop-line {
-      height: 26px;
-      border: 1px dashed #b7c4d6;
-      border-radius: 7px;
-      background: rgba(255, 255, 255, 0.74);
+      height: 12px;
+      border: 0;
+      border-radius: 999px;
+      background: transparent;
       display: grid;
       place-items: center;
-      color: var(--muted);
+      color: transparent;
       font-size: 12px;
+      opacity: 0;
+      transition: opacity 0.15s, height 0.15s;
+    }
+
+    .flow-column.drag-preview .drop-line,
+    .drop-line:hover {
+      height: 28px;
+      opacity: 1;
+      color: var(--muted);
+      background: linear-gradient(90deg, transparent 0 8%, #9db4d6 8% 92%, transparent 92% 100%);
     }
 
     .step {
@@ -775,7 +785,7 @@
         </div>
         <div class="flow-stage">
           <div class="flow-column">
-            <div class="drop-line">ここにブロックをドロップ</div>
+            <div class="drop-line">ドラッグ中のみ表示</div>
             <article class="step">
               <div class="step-head">
                 <span class="step-index">1</span>
@@ -787,7 +797,7 @@
                 <div class="mini-field"><label>失敗時</label><p>エラー表示して停止</p></div>
               </div>
             </article>
-            <div class="drop-line">ステップ間に挿入</div>
+            <div class="drop-line">ドラッグ中のみ表示</div>
             <article class="step selected">
               <div class="step-head">
                 <span class="step-index">2</span>
@@ -799,7 +809,7 @@
                 <div class="mini-field"><label>response</label><p>token, user, expiresAt</p></div>
               </div>
             </article>
-            <div class="drop-line">ステップ間に挿入</div>
+            <div class="drop-line">ドラッグ中のみ表示</div>
             <article class="step">
               <div class="step-head">
                 <span class="step-index">3</span>

--- a/docs/prototypes/process-flow-editor-redesign-1071.html
+++ b/docs/prototypes/process-flow-editor-redesign-1071.html
@@ -1,0 +1,975 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Process Flow Editor Redesign Concepts #1071</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f4f6f8;
+      --surface: #ffffff;
+      --surface-2: #f9fafb;
+      --surface-3: #eef2f6;
+      --line: #d8dee7;
+      --line-strong: #b9c3d0;
+      --text: #17202c;
+      --muted: #647285;
+      --faint: #8a96a8;
+      --blue: #2563eb;
+      --blue-soft: #eaf1ff;
+      --green: #16a34a;
+      --amber: #d97706;
+      --red: #dc2626;
+      --violet: #7c3aed;
+      --radius: 8px;
+      --shadow: 0 18px 42px rgba(23, 32, 44, 0.12);
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: var(--bg);
+      color: var(--text);
+      letter-spacing: 0;
+    }
+
+    button, input, select, textarea {
+      font: inherit;
+    }
+
+    .app {
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .topbar {
+      height: 52px;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 0 16px;
+      border-bottom: 1px solid var(--line);
+      background: rgba(255, 255, 255, 0.92);
+      backdrop-filter: blur(16px);
+      position: sticky;
+      top: 0;
+      z-index: 20;
+    }
+
+    .brand {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      min-width: 260px;
+      font-weight: 700;
+      color: #111827;
+    }
+
+    .brand-mark {
+      width: 28px;
+      height: 28px;
+      border-radius: 7px;
+      background: linear-gradient(145deg, #1f2937, #4b5563);
+      display: grid;
+      place-items: center;
+      color: #fff;
+      font-size: 13px;
+    }
+
+    .topbar-title {
+      display: flex;
+      flex-direction: column;
+      line-height: 1.15;
+    }
+
+    .topbar-title small {
+      color: var(--muted);
+      font-weight: 500;
+      font-size: 11px;
+    }
+
+    .topbar-actions {
+      margin-left: auto;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .segmented {
+      display: inline-flex;
+      align-items: center;
+      padding: 3px;
+      gap: 2px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: var(--surface-2);
+    }
+
+    .segmented button,
+    .btn {
+      border: 0;
+      border-radius: 6px;
+      padding: 6px 10px;
+      background: transparent;
+      color: var(--muted);
+      cursor: pointer;
+      white-space: nowrap;
+    }
+
+    .segmented button.active {
+      background: var(--surface);
+      color: var(--text);
+      box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+    }
+
+    .btn {
+      border: 1px solid var(--line);
+      background: var(--surface);
+      color: var(--text);
+    }
+
+    .btn.primary {
+      border-color: #1d4ed8;
+      background: #2563eb;
+      color: #fff;
+    }
+
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
+      height: 22px;
+      padding: 0 8px;
+      border-radius: 999px;
+      border: 1px solid var(--line);
+      background: var(--surface);
+      color: var(--muted);
+      font-size: 12px;
+      white-space: nowrap;
+    }
+
+    .badge.green {
+      color: #0f7a34;
+      border-color: #b7e5c4;
+      background: #edfdf2;
+    }
+
+    .badge.amber {
+      color: #9a5b00;
+      border-color: #f5d28b;
+      background: #fff8e8;
+    }
+
+    .concept {
+      display: none;
+      min-height: calc(100vh - 52px);
+    }
+
+    .concept.active {
+      display: flex;
+    }
+
+    .pane {
+      background: var(--surface);
+      border-right: 1px solid var(--line);
+      min-width: 0;
+    }
+
+    .pane-header {
+      min-height: 44px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+      padding: 10px 12px;
+      border-bottom: 1px solid var(--line);
+    }
+
+    .pane-title {
+      font-weight: 700;
+      font-size: 13px;
+      color: #1f2937;
+    }
+
+    .search {
+      width: 100%;
+      height: 32px;
+      border: 1px solid var(--line);
+      border-radius: 7px;
+      padding: 0 10px;
+      background: var(--surface-2);
+      color: var(--text);
+    }
+
+    .palette {
+      width: 278px;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .palette-body {
+      padding: 12px;
+      overflow: auto;
+    }
+
+    .group-label {
+      margin: 14px 0 8px;
+      font-size: 11px;
+      color: var(--faint);
+      font-weight: 800;
+      text-transform: uppercase;
+    }
+
+    .block-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 8px;
+    }
+
+    .block {
+      min-height: 58px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--surface);
+      padding: 9px;
+      cursor: grab;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .block:hover {
+      border-color: var(--blue);
+      background: var(--blue-soft);
+    }
+
+    .block-top {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+    }
+
+    .block-icon {
+      width: 24px;
+      height: 24px;
+      border-radius: 6px;
+      display: grid;
+      place-items: center;
+      background: #eef2ff;
+      color: var(--blue);
+      font-size: 13px;
+      font-weight: 800;
+    }
+
+    .block span:last-child {
+      font-size: 12px;
+      font-weight: 700;
+      color: #293241;
+    }
+
+    .canvas {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-width: 0;
+      background:
+        linear-gradient(#e9edf3 1px, transparent 1px),
+        linear-gradient(90deg, #e9edf3 1px, transparent 1px),
+        #f8fafc;
+      background-size: 28px 28px;
+    }
+
+    .canvas-header {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 14px;
+      border-bottom: 1px solid var(--line);
+      background: rgba(255, 255, 255, 0.86);
+      backdrop-filter: blur(10px);
+    }
+
+    .canvas-title {
+      min-width: 0;
+      flex: 1;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-weight: 800;
+    }
+
+    .canvas-title small {
+      color: var(--muted);
+      font-weight: 500;
+    }
+
+    .flow-stage {
+      flex: 1;
+      overflow: auto;
+      padding: 22px;
+    }
+
+    .flow-column {
+      width: min(860px, 100%);
+      margin: 0 auto;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .drop-line {
+      height: 26px;
+      border: 1px dashed #b7c4d6;
+      border-radius: 7px;
+      background: rgba(255, 255, 255, 0.74);
+      display: grid;
+      place-items: center;
+      color: var(--muted);
+      font-size: 12px;
+    }
+
+    .step {
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--surface);
+      box-shadow: 0 8px 22px rgba(23, 32, 44, 0.07);
+      overflow: hidden;
+    }
+
+    .step.selected {
+      border-color: #4f7df3;
+      box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12), 0 12px 28px rgba(23, 32, 44, 0.12);
+    }
+
+    .step-head {
+      min-height: 48px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 12px;
+      border-bottom: 1px solid var(--line);
+    }
+
+    .step-index {
+      width: 28px;
+      height: 28px;
+      border-radius: 7px;
+      display: grid;
+      place-items: center;
+      background: #111827;
+      color: white;
+      font-size: 12px;
+      font-weight: 800;
+    }
+
+    .step-main {
+      min-width: 0;
+      flex: 1;
+    }
+
+    .step-main strong {
+      display: block;
+      font-size: 13px;
+    }
+
+    .step-main span {
+      display: block;
+      margin-top: 2px;
+      font-size: 12px;
+      color: var(--muted);
+    }
+
+    .step-body {
+      padding: 10px 12px 12px;
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 8px;
+      background: var(--surface-2);
+    }
+
+    .mini-field {
+      border: 1px solid var(--line);
+      border-radius: 7px;
+      background: var(--surface);
+      padding: 8px;
+      min-width: 0;
+    }
+
+    .mini-field label {
+      display: block;
+      color: var(--faint);
+      font-size: 11px;
+      font-weight: 800;
+      margin-bottom: 4px;
+    }
+
+    .mini-field p {
+      margin: 0;
+      color: #273244;
+      font-size: 12px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .inspector {
+      width: 360px;
+      display: flex;
+      flex-direction: column;
+      border-left: 1px solid var(--line);
+      border-right: 0;
+    }
+
+    .tabs {
+      display: flex;
+      gap: 4px;
+      padding: 8px;
+      border-bottom: 1px solid var(--line);
+      background: var(--surface-2);
+      overflow-x: auto;
+    }
+
+    .tabs button {
+      border: 1px solid transparent;
+      border-radius: 6px;
+      padding: 6px 8px;
+      background: transparent;
+      color: var(--muted);
+      cursor: pointer;
+      font-size: 12px;
+      white-space: nowrap;
+    }
+
+    .tabs button.active {
+      background: var(--surface);
+      border-color: var(--line);
+      color: var(--text);
+    }
+
+    .inspector-body {
+      padding: 12px;
+      overflow: auto;
+    }
+
+    .form-stack {
+      display: grid;
+      gap: 10px;
+    }
+
+    .field {
+      display: grid;
+      gap: 5px;
+    }
+
+    .field label {
+      font-size: 12px;
+      font-weight: 750;
+      color: #334155;
+    }
+
+    .field input,
+    .field textarea,
+    .field select {
+      border: 1px solid var(--line);
+      border-radius: 7px;
+      min-height: 32px;
+      padding: 7px 8px;
+      background: var(--surface);
+      color: var(--text);
+    }
+
+    .field textarea {
+      min-height: 74px;
+      resize: vertical;
+    }
+
+    .contract-card {
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--surface);
+      padding: 10px;
+      display: grid;
+      gap: 8px;
+    }
+
+    .kv {
+      display: grid;
+      grid-template-columns: 78px 1fr;
+      gap: 8px;
+      font-size: 12px;
+    }
+
+    .kv span:first-child {
+      color: var(--faint);
+      font-weight: 750;
+    }
+
+    .canvas-first {
+      position: relative;
+      flex: 1;
+      background:
+        radial-gradient(circle at 25% 25%, rgba(37, 99, 235, 0.05), transparent 28%),
+        linear-gradient(#e6ebf2 1px, transparent 1px),
+        linear-gradient(90deg, #e6ebf2 1px, transparent 1px),
+        #f8fafc;
+      background-size: auto, 30px 30px, 30px 30px, auto;
+      overflow: hidden;
+    }
+
+    .floating-palette {
+      position: absolute;
+      left: 18px;
+      top: 18px;
+      width: 250px;
+      max-height: calc(100vh - 104px);
+      overflow: auto;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: rgba(255, 255, 255, 0.94);
+      box-shadow: var(--shadow);
+    }
+
+    .floating-toolbar {
+      position: absolute;
+      top: 18px;
+      left: 50%;
+      transform: translateX(-50%);
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: rgba(255, 255, 255, 0.94);
+      box-shadow: 0 10px 30px rgba(23, 32, 44, 0.12);
+    }
+
+    .floating-inspector {
+      position: absolute;
+      right: 18px;
+      top: 18px;
+      width: 380px;
+      max-height: calc(100vh - 104px);
+      overflow: auto;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: rgba(255, 255, 255, 0.96);
+      box-shadow: var(--shadow);
+    }
+
+    .node-map {
+      width: min(900px, calc(100% - 700px));
+      min-width: 460px;
+      margin: 118px auto 0;
+      display: grid;
+      gap: 22px;
+    }
+
+    .node-row {
+      display: flex;
+      justify-content: center;
+      gap: 18px;
+    }
+
+    .node {
+      width: 210px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--surface);
+      box-shadow: 0 12px 26px rgba(23, 32, 44, 0.1);
+      padding: 12px;
+    }
+
+    .node strong {
+      display: block;
+      margin-bottom: 6px;
+      font-size: 13px;
+    }
+
+    .node p {
+      margin: 0;
+      color: var(--muted);
+      font-size: 12px;
+      line-height: 1.45;
+    }
+
+    .command-layout {
+      flex: 1;
+      display: grid;
+      grid-template-rows: 46px 1fr;
+      min-width: 0;
+    }
+
+    .command-bar {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 7px 12px;
+      border-bottom: 1px solid var(--line);
+      background: var(--surface);
+    }
+
+    .command-input {
+      flex: 1;
+      height: 32px;
+      border: 1px solid var(--line);
+      border-radius: 7px;
+      padding: 0 12px;
+      background: var(--surface-2);
+    }
+
+    .compact-body {
+      display: grid;
+      grid-template-columns: 220px minmax(0, 1fr) 320px;
+      min-height: 0;
+    }
+
+    .rail {
+      border-right: 1px solid var(--line);
+      background: var(--surface);
+      overflow: auto;
+      padding: 10px;
+    }
+
+    .rail-item {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+      border: 1px solid transparent;
+      border-radius: 7px;
+      padding: 8px;
+      font-size: 12px;
+      color: var(--muted);
+    }
+
+    .rail-item.active {
+      border-color: #bfdbfe;
+      background: #eff6ff;
+      color: #1d4ed8;
+      font-weight: 750;
+    }
+
+    .compact-side {
+      border-left: 1px solid var(--line);
+      background: var(--surface);
+      overflow: auto;
+    }
+
+    .note {
+      margin: 0;
+      color: var(--muted);
+      font-size: 12px;
+      line-height: 1.55;
+    }
+
+    @media (max-width: 1120px) {
+      .palette { width: 220px; }
+      .inspector { width: 310px; }
+      .block-grid { grid-template-columns: 1fr; }
+      .floating-inspector { width: 330px; }
+      .node-map { width: calc(100% - 610px); min-width: 360px; }
+      .compact-body { grid-template-columns: 184px minmax(0, 1fr) 280px; }
+    }
+
+    @media (max-width: 820px) {
+      .brand { min-width: auto; }
+      .topbar { overflow-x: auto; }
+      .concept.active { display: block; }
+      .palette,
+      .inspector,
+      .compact-side,
+      .rail {
+        width: auto;
+        border-right: 0;
+        border-left: 0;
+      }
+      .compact-body { display: block; }
+      .floating-palette,
+      .floating-inspector,
+      .floating-toolbar {
+        position: static;
+        transform: none;
+        width: auto;
+        max-height: none;
+        margin: 12px;
+      }
+      .node-map {
+        width: auto;
+        min-width: 0;
+        margin: 12px;
+      }
+      .node-row { flex-direction: column; }
+      .node { width: auto; }
+    }
+  </style>
+</head>
+<body>
+  <div class="app">
+    <header class="topbar">
+      <div class="brand">
+        <div class="brand-mark">HF</div>
+        <div class="topbar-title">
+          <span>処理フローエディタ redesign #1071</span>
+          <small>JSON Schema変更なし。UI構造と編集体験の刷新案。</small>
+        </div>
+      </div>
+      <div class="segmented" aria-label="デザイン案切替">
+        <button class="active" data-concept-target="studio">Studio 3-pane</button>
+        <button data-concept-target="canvas">Canvas-first</button>
+        <button data-concept-target="command">Command Compact</button>
+      </div>
+      <div class="topbar-actions">
+        <span class="badge green">committed 8</span>
+        <span class="badge amber">warning 3</span>
+        <button class="btn">プレビュー</button>
+        <button class="btn primary">保存</button>
+      </div>
+    </header>
+
+    <main id="studio" class="concept active">
+      <aside class="pane palette">
+        <div class="pane-header">
+          <span class="pane-title">ブロック</span>
+          <span class="badge">D&D</span>
+        </div>
+        <div class="palette-body">
+          <input class="search" value="" placeholder="ブロックを検索" />
+          <div class="group-label">制御</div>
+          <div class="block-grid">
+            <div class="block"><div class="block-top"><span class="block-icon">if</span><span>分岐</span></div><span class="note">条件で経路を分ける</span></div>
+            <div class="block"><div class="block-top"><span class="block-icon">lp</span><span>ループ</span></div><span class="note">繰り返し処理</span></div>
+            <div class="block"><div class="block-top"><span class="block-icon">rt</span><span>return</span></div><span class="note">処理を終了</span></div>
+            <div class="block"><div class="block-top"><span class="block-icon">tx</span><span>TX範囲</span></div><span class="note">トランザクション</span></div>
+          </div>
+          <div class="group-label">処理</div>
+          <div class="block-grid">
+            <div class="block"><div class="block-top"><span class="block-icon">db</span><span>DB</span></div><span class="note">検索/更新</span></div>
+            <div class="block"><div class="block-top"><span class="block-icon">api</span><span>外部API</span></div><span class="note">HTTP連携</span></div>
+            <div class="block"><div class="block-top"><span class="block-icon">fx</span><span>計算</span></div><span class="note">式/変換</span></div>
+            <div class="block"><div class="block-top"><span class="block-icon">ui</span><span>表示更新</span></div><span class="note">画面反映</span></div>
+          </div>
+          <div class="group-label">テンプレート</div>
+          <div class="contract-card">
+            <strong>ログイン認証</strong>
+            <p class="note">入力検証、認証API、セッション保存、画面遷移をまとめて追加。</p>
+          </div>
+        </div>
+      </aside>
+
+      <section class="canvas">
+        <div class="canvas-header">
+          <div class="canvas-title">
+            <span>ログイン画面: submit</span>
+            <small>POST /auth/login</small>
+          </div>
+          <span class="badge">入力 2</span>
+          <span class="badge">出力 3</span>
+          <span class="badge green">保存済み</span>
+        </div>
+        <div class="flow-stage">
+          <div class="flow-column">
+            <div class="drop-line">ここにブロックをドロップ</div>
+            <article class="step">
+              <div class="step-head">
+                <span class="step-index">1</span>
+                <div class="step-main"><strong>入力値を検証する</strong><span>validation / required / email</span></div>
+                <span class="badge green">OK</span>
+              </div>
+              <div class="step-body">
+                <div class="mini-field"><label>対象</label><p>email, password</p></div>
+                <div class="mini-field"><label>失敗時</label><p>エラー表示して停止</p></div>
+              </div>
+            </article>
+            <div class="drop-line">ステップ間に挿入</div>
+            <article class="step selected">
+              <div class="step-head">
+                <span class="step-index">2</span>
+                <div class="step-main"><strong>認証APIを呼び出す</strong><span>externalSystem / AuthService.login</span></div>
+                <span class="badge amber">確認 2</span>
+              </div>
+              <div class="step-body">
+                <div class="mini-field"><label>request</label><p>{ email, password }</p></div>
+                <div class="mini-field"><label>response</label><p>token, user, expiresAt</p></div>
+              </div>
+            </article>
+            <div class="drop-line">ステップ間に挿入</div>
+            <article class="step">
+              <div class="step-head">
+                <span class="step-index">3</span>
+                <div class="step-main"><strong>ダッシュボードへ遷移</strong><span>screenTransition / dashboard</span></div>
+                <span class="badge green">OK</span>
+              </div>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <aside class="pane inspector">
+        <div class="pane-header">
+          <span class="pane-title">Inspector</span>
+          <span class="badge">選択中 Step 2</span>
+        </div>
+        <div class="tabs">
+          <button class="active">詳細</button>
+          <button>HTTP契約</button>
+          <button>入出力</button>
+          <button>エラー</button>
+          <button>外部</button>
+        </div>
+        <div class="inspector-body">
+          <div class="form-stack">
+            <div class="field"><label>ステップ名</label><input value="認証APIを呼び出す" /></div>
+            <div class="field"><label>説明</label><textarea>AuthService.login を呼び出し、認証トークンとユーザー情報を受け取る。</textarea></div>
+            <div class="contract-card">
+              <strong>HTTP契約 summary</strong>
+              <div class="kv"><span>method</span><strong>POST</strong></div>
+              <div class="kv"><span>path</span><strong>/auth/login</strong></div>
+              <div class="kv"><span>timeout</span><strong>3s</strong></div>
+            </div>
+            <p class="note">基本情報、HTTP契約、SLA、I/O、カタログはここに集約し、中央の処理フロー領域を押し下げない。</p>
+          </div>
+        </div>
+      </aside>
+    </main>
+
+    <main id="canvas" class="concept">
+      <section class="canvas-first">
+        <div class="floating-toolbar">
+          <button class="btn">戻る</button>
+          <button class="btn">自動整列</button>
+          <button class="btn">検証</button>
+          <button class="btn primary">AIに依頼</button>
+        </div>
+        <aside class="floating-palette">
+          <div class="pane-header"><span class="pane-title">Quick Add</span><span class="badge">検索</span></div>
+          <div class="palette-body">
+            <input class="search" placeholder="db, api, branch..." />
+            <div class="group-label">よく使う</div>
+            <div class="block-grid">
+              <div class="block"><div class="block-top"><span class="block-icon">db</span><span>DB</span></div></div>
+              <div class="block"><div class="block-top"><span class="block-icon">api</span><span>API</span></div></div>
+              <div class="block"><div class="block-top"><span class="block-icon">if</span><span>分岐</span></div></div>
+              <div class="block"><div class="block-top"><span class="block-icon">fx</span><span>計算</span></div></div>
+            </div>
+          </div>
+        </aside>
+        <div class="node-map">
+          <div class="node-row">
+            <div class="node"><strong>Start: submit</strong><p>POST /auth/login。入力 email, password。</p></div>
+          </div>
+          <div class="node-row">
+            <div class="node"><strong>Validation</strong><p>必須、形式、パスワード長を検証。</p></div>
+          </div>
+          <div class="node-row">
+            <div class="node"><strong>Auth API</strong><p>外部認証サービスへ連携。</p></div>
+            <div class="node"><strong>Error branch</strong><p>失敗時はメッセージ表示。</p></div>
+          </div>
+          <div class="node-row">
+            <div class="node"><strong>Transition</strong><p>成功時に dashboard へ遷移。</p></div>
+          </div>
+        </div>
+        <aside class="floating-inspector">
+          <div class="pane-header"><span class="pane-title">Action Details</span><span class="badge amber">draft</span></div>
+          <div class="tabs"><button class="active">HTTP</button><button>SLA</button><button>入出力</button><button>Marker</button></div>
+          <div class="inspector-body">
+            <div class="form-stack">
+              <div class="field"><label>Method</label><select><option>POST</option></select></div>
+              <div class="field"><label>Path</label><input value="/auth/login" /></div>
+              <div class="field"><label>Request schema</label><textarea>{ email, password }</textarea></div>
+              <p class="note">ReactFlow的なキャンバスを最大化する案。視覚表現は強いが、フォーム編集量が多い場合は右パネルの設計が重要。</p>
+            </div>
+          </div>
+        </aside>
+      </section>
+    </main>
+
+    <main id="command" class="concept">
+      <section class="command-layout">
+        <div class="command-bar">
+          <input class="command-input" value="" placeholder="コマンド検索: ブロック追加、HTTP契約、変数、外部システム..." />
+          <button class="btn">分岐</button>
+          <button class="btn">DB</button>
+          <button class="btn">API</button>
+          <button class="btn primary">追加</button>
+        </div>
+        <div class="compact-body">
+          <aside class="rail">
+            <div class="group-label">Actions</div>
+            <div class="rail-item active"><span>submit</span><span class="badge green">8</span></div>
+            <div class="rail-item"><span>init</span><span class="badge">3</span></div>
+            <div class="rail-item"><span>validate</span><span class="badge amber">2</span></div>
+            <div class="group-label">Meta</div>
+            <div class="rail-item"><span>基本情報</span></div>
+            <div class="rail-item"><span>HTTP契約</span></div>
+            <div class="rail-item"><span>外部システム</span></div>
+            <div class="rail-item"><span>Secrets / Env</span></div>
+          </aside>
+          <section class="canvas">
+            <div class="canvas-header">
+              <div class="canvas-title"><span>submit flow</span><small>compact authoring mode</small></div>
+              <span class="badge">選択 1</span>
+            </div>
+            <div class="flow-stage">
+              <div class="flow-column">
+                <article class="step selected">
+                  <div class="step-head">
+                    <span class="step-index">1</span>
+                    <div class="step-main"><strong>入力値検証</strong><span>validation</span></div>
+                    <span class="badge green">committed</span>
+                  </div>
+                </article>
+                <article class="step">
+                  <div class="step-head">
+                    <span class="step-index">2</span>
+                    <div class="step-main"><strong>認証API</strong><span>externalSystem</span></div>
+                    <span class="badge amber">marker</span>
+                  </div>
+                </article>
+                <article class="step">
+                  <div class="step-head">
+                    <span class="step-index">3</span>
+                    <div class="step-main"><strong>遷移</strong><span>screenTransition</span></div>
+                    <span class="badge green">committed</span>
+                  </div>
+                </article>
+              </div>
+            </div>
+          </section>
+          <aside class="compact-side">
+            <div class="pane-header"><span class="pane-title">Compact Inspector</span><span class="badge">⌘K対応想定</span></div>
+            <div class="inspector-body">
+              <div class="form-stack">
+                <div class="field"><label>現在の編集対象</label><input value="入力値検証" /></div>
+                <div class="field"><label>ルール</label><textarea>email: required, email&#10;password: required, minLength 8</textarea></div>
+                <div class="contract-card">
+                  <strong>設計意図</strong>
+                  <p class="note">上級者向けに上部を極小化し、検索とコマンドで素早く編集する案。情報密度は高いが初見性はStudio案より落ちる。</p>
+                </div>
+              </div>
+            </div>
+          </aside>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <script>
+    const buttons = document.querySelectorAll("[data-concept-target]");
+    const concepts = document.querySelectorAll(".concept");
+    buttons.forEach((button) => {
+      button.addEventListener("click", () => {
+        const target = button.getAttribute("data-concept-target");
+        buttons.forEach((b) => b.classList.toggle("active", b === button));
+        concepts.forEach((concept) => concept.classList.toggle("active", concept.id === target));
+      });
+    });
+  </script>
+</body>
+</html>

--- a/frontend/src/components/process-flow/ProcessFlowAiReviewDialog.tsx
+++ b/frontend/src/components/process-flow/ProcessFlowAiReviewDialog.tsx
@@ -33,7 +33,7 @@ export function ProcessFlowAiReviewDialog({ current, onClose }: Props) {
 
   return (
     <div className="edit-mode-modal-backdrop" role="presentation" onClick={(e) => { if (e.target === e.currentTarget && !reviewing) onClose(); }}>
-      <div className="edit-mode-modal process-flow-ai-generate-dialog" role="dialog" aria-modal="true" aria-labelledby="process-flow-ai-review-title">
+      <div className="edit-mode-modal process-flow-ai-review-dialog" role="dialog" aria-modal="true" aria-labelledby="process-flow-ai-review-title">
         <div className="edit-mode-modal-header">
           <h3 id="process-flow-ai-review-title" className="edit-mode-modal-title">
             <i className="bi bi-clipboard-check" /> AI レビュー
@@ -44,7 +44,7 @@ export function ProcessFlowAiReviewDialog({ current, onClose }: Props) {
           <label className="form-label">重点観点</label>
           <textarea
             className="form-control"
-            rows={4}
+            rows={10}
             value={focus}
             onChange={(e) => setFocus(e.target.value)}
             placeholder="例: 例外系、DB 更新のトランザクション境界、入力検証の不足を重点的に確認"

--- a/frontend/src/components/process-flow/ProcessFlowEditor.tsx
+++ b/frontend/src/components/process-flow/ProcessFlowEditor.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck -- large legacy editor migration remains open; tracked by #1016.
-import { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef, type ReactNode } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import { useWorkspacePath } from "../../hooks/useWorkspacePath";
 import type {
@@ -101,13 +101,26 @@ function ToolbarStepButton({ type, onClick }: { type: StepType; onClick: () => v
 }
 
 /** ステップ間のドロップゾーン */
-function StepInsertZone({ index, onClick, onPaste }: { index: number; onClick: () => void; onPaste?: () => void }) {
+function StepInsertZone({
+  index,
+  onClick,
+  onPaste,
+  dragVisible,
+}: {
+  index: number;
+  onClick: () => void;
+  onPaste?: () => void;
+  dragVisible?: boolean;
+}) {
   const { setNodeRef, isOver } = useDroppable({
     id: `insert-${index}`,
     data: { kind: "insert-zone", insertIndex: index },
   });
   return (
-    <div ref={setNodeRef} className={`step-insert-point${isOver ? " drop-active" : ""}${onPaste ? " has-paste" : ""}`}>
+    <div
+      ref={setNodeRef}
+      className={`step-insert-point${isOver ? " drop-active" : ""}${onPaste ? " has-paste" : ""}${dragVisible ? " drag-visible" : ""}`}
+    >
       <button className="step-insert-btn" onClick={onClick} title="ステップを挿入">
         <i className="bi bi-plus" />
       </button>
@@ -116,6 +129,18 @@ function StepInsertZone({ index, onClick, onPaste }: { index: number; onClick: (
           <i className="bi bi-clipboard-plus me-1" />貼り付け
         </button>
       )}
+    </div>
+  );
+}
+
+function EmptyFlowDropZone({ children }: { children: ReactNode }) {
+  const { setNodeRef, isOver } = useDroppable({
+    id: "empty-flow-drop",
+    data: { kind: "insert-zone", insertIndex: 0 },
+  });
+  return (
+    <div ref={setNodeRef} className={`step-empty process-flow-empty-drop${isOver ? " drop-active" : ""}`}>
+      {children}
     </div>
   );
 }
@@ -173,6 +198,9 @@ export function ProcessFlowEditor() {
   const [drawingMode, setDrawingMode] = useState(false);
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; stepId: string } | null>(null);
   const [contextMenuSubTypePicker, setContextMenuSubTypePicker] = useState(false);
+  const [isDraggingToolbarStep, setIsDraggingToolbarStep] = useState(false);
+  const [stepFilter, setStepFilter] = useState("");
+  const [commandQuery, setCommandQuery] = useState("");
   // SQL 列検査 / 規約参照検査のため (#261)
   const [tableDefs, setTableDefs] = useState<ValidatorTableDef[]>([]);
   const [conventions, setConventions] = useState<ConventionsCatalog | null>(null);
@@ -431,8 +459,22 @@ export function ProcessFlowEditor() {
   }, []);
 
   const customStepCards = Object.entries(extensions?.steps ?? {});
+  const normalizedStepFilter = stepFilter.trim().toLowerCase();
+  const filteredStepTypes = normalizedStepFilter
+    ? ALL_STEP_TYPES.filter((type) => {
+      const label = STEP_TYPE_LABELS[type] ?? type;
+      return type.toLowerCase().includes(normalizedStepFilter) || label.toLowerCase().includes(normalizedStepFilter);
+    })
+    : ALL_STEP_TYPES;
 
   const activeAction = group?.actions.find((a) => a.id === activeActionId) ?? null;
+  const normalizedCommandQuery = commandQuery.trim().toLowerCase();
+  const visibleActions = group?.actions.filter((act) => {
+    if (!normalizedCommandQuery) return true;
+    return act.name.toLowerCase().includes(normalizedCommandQuery)
+      || ACTION_TRIGGER_LABELS[act.trigger].toLowerCase().includes(normalizedCommandQuery)
+      || act.trigger.toLowerCase().includes(normalizedCommandQuery);
+  }) ?? [];
 
   const handleAddAction = () => {
     const name = newActionName.trim();
@@ -532,7 +574,16 @@ export function ProcessFlowEditor() {
     });
   };
 
+  const handleDragStart = (event: { active: { data: { current?: Record<string, unknown> } } }) => {
+    setIsDraggingToolbarStep(event.active.data.current?.kind === "toolbar-step");
+  };
+
+  const handleDragCancel = () => {
+    setIsDraggingToolbarStep(false);
+  };
+
   const handleDragEnd = (event: DragEndEvent) => {
+    setIsDraggingToolbarStep(false);
     const { active, over } = event;
     if (!over || !activeAction) return;
 
@@ -541,8 +592,12 @@ export function ProcessFlowEditor() {
     if (dragKind === "toolbar-step") {
       // #46: ツールバーからドロップ → 新規ステップを挿入
       const stepType = active.data.current?.stepType as StepType;
-      const insertIndex = over.data.current?.insertIndex as number | undefined;
-      handleAddStep(stepType, insertIndex ?? activeAction.steps.length);
+      let insertIndex = over.data.current?.insertIndex as number | undefined;
+      if (insertIndex === undefined) {
+        const overStepIndex = activeAction.steps.findIndex((s) => s.id === over.id);
+        insertIndex = overStepIndex >= 0 ? overStepIndex : activeAction.steps.length;
+      }
+      handleAddStep(stepType, insertIndex);
     } else {
       // #47: ステップカードの並べ替え
       if (active.id === over.id) return;
@@ -619,25 +674,27 @@ export function ProcessFlowEditor() {
   };
 
   // ── クリップボード操作 ────────────────────────────────────────
-  const handleCut = () => {
-    if (selectedIds.size === 0 || !activeAction) return;
-    const steps = activeAction.steps.filter((s) => selectedIds.has(s.id));
+  const handleCut = (ids = selectedIds) => {
+    if (ids.size === 0 || !activeAction) return;
+    const steps = activeAction.steps.filter((s) => ids.has(s.id));
     setClipboard({ steps: JSON.parse(JSON.stringify(steps)), mode: "cut" });
     updateGroupWithDraft((g) => {
       const act = g.actions.find((a) => a.id === activeActionId);
       if (!act) return;
-      for (const id of selectedIds) {
+      for (const id of ids) {
         clearJumpReferences(act.steps, id);
         removeStep(act, id);
       }
     });
     setSelectedIds(new Set());
+    closeContextMenu();
   };
 
-  const handleCopy = () => {
-    if (selectedIds.size === 0 || !activeAction) return;
-    const steps = activeAction.steps.filter((s) => selectedIds.has(s.id));
+  const handleCopy = (ids = selectedIds) => {
+    if (ids.size === 0 || !activeAction) return;
+    const steps = activeAction.steps.filter((s) => ids.has(s.id));
     setClipboard({ steps: JSON.parse(JSON.stringify(steps)), mode: "copy" });
+    closeContextMenu();
   };
 
   const handlePaste = (insertIndex?: number) => {
@@ -666,16 +723,55 @@ export function ProcessFlowEditor() {
     });
     if (clipboard.mode === "cut") setClipboard(null);
     setSelectedIds(new Set());
+    closeContextMenu();
+  };
+
+  const getContextStepIndex = () => {
+    if (!contextMenu || !activeAction) return -1;
+    return activeAction.steps.findIndex((s) => s.id === contextMenu.stepId);
+  };
+
+  const handleContextInsert = (offset: 0 | 1) => {
+    const idx = getContextStepIndex();
+    if (idx < 0) return;
+    handleAddStep("other", idx + offset);
+    closeContextMenu();
+  };
+
+  const handleContextPaste = (offset: 0 | 1) => {
+    const idx = getContextStepIndex();
+    if (idx < 0) return;
+    handlePaste(idx + offset);
   };
 
   const handleEscapeSelection = useCallback(() => {
     setSelectedIds(new Set());
   }, []);
 
+  const handleDeleteSelected = useCallback(() => {
+    if (selectedIds.size === 0) return;
+    for (const id of Array.from(selectedIds)) {
+      handleDeleteStep(id);
+    }
+    setSelectedIds(new Set());
+  }, [selectedIds, handleDeleteStep]);
+
+  const handleMoveSelectedByKeyboard = useCallback((direction: -1 | 1) => {
+    if (!activeAction || selectedIds.size !== 1) return;
+    const id = Array.from(selectedIds)[0];
+    const fromIndex = activeAction.steps.findIndex((s) => s.id === id);
+    const toIndex = fromIndex + direction;
+    if (fromIndex < 0 || toIndex < 0 || toIndex >= activeAction.steps.length) return;
+    handleMoveStep(fromIndex, toIndex);
+  }, [activeAction, selectedIds]);
+
   useSelectionKeyboard({
     onCut: handleCut,
     onCopy: handleCopy,
     onPaste: () => handlePaste(),
+    onDelete: handleDeleteSelected,
+    onMoveUp: () => handleMoveSelectedByKeyboard(-1),
+    onMoveDown: () => handleMoveSelectedByKeyboard(1),
     onEscape: handleEscapeSelection,
     enabled: selectedIds.size > 0 || clipboard !== null,
   });
@@ -1010,122 +1106,105 @@ export function ProcessFlowEditor() {
         </div>
       )}
 
-      {/* グループ情報 + カタログ群 (#309 タブバー化) */}
-      <ActionMetaTabBar
-        group={group}
-        updateGroup={updateGroup}
-        updateGroupSilent={updateGroupSilent}
-      />
-
-      {/* アクションタブ */}
-      <div className="process-flow-tabs">
-        {group.actions.map((act) => (
-          <div key={act.id} className="d-flex align-items-center">
+      <div className="process-flow-workbench">
+        <div className="process-flow-command-bar">
+          <div className="process-flow-command-title">
+            <span className="process-flow-command-eyebrow">Action</span>
+            <strong>{activeAction?.name ?? "アクション未選択"}</strong>
+            {activeAction && <span className="text-muted small">{ACTION_TRIGGER_LABELS[activeAction.trigger]}</span>}
+          </div>
+          <div className="process-flow-command-search">
+            <i className="bi bi-search" />
+            <input
+              value={commandQuery}
+              onChange={(e) => setCommandQuery(e.target.value)}
+              placeholder="アクションを検索"
+              aria-label="アクションを検索"
+            />
+          </div>
+          <div className="process-flow-tabs">
+            {visibleActions.map((act) => (
+              <div key={act.id} className={`process-flow-tab-wrap${activeActionId === act.id ? " active" : ""}`}>
+                <button
+                  className={`process-flow-tab ${activeActionId === act.id ? "active" : ""}`}
+                  onClick={() => setActiveActionId(act.id)}
+                >
+                  <MaturityBadge
+                    maturity={act.maturity}
+                    onChange={(next) => {
+                      updateGroupSilent((g) => {
+                        const a = g.actions.find((a2) => a2.id === act.id);
+                        if (a) a.maturity = next;
+                      });
+                    }}
+                  />
+                  {act.name}
+                  <span className="ms-1 text-muted small">({ACTION_TRIGGER_LABELS[act.trigger]})</span>
+                </button>
+                <button
+                  className="process-flow-tab-remove"
+                  onClick={() => handleDeleteAction(act.id)}
+                  title="アクション削除"
+                >
+                  <i className="bi bi-x" />
+                </button>
+              </div>
+            ))}
+            {visibleActions.length === 0 && (
+              <span className="process-flow-tab-empty">一致するアクションがありません</span>
+            )}
             <button
-              className={`process-flow-tab ${activeActionId === act.id ? "active" : ""}`}
-              onClick={() => setActiveActionId(act.id)}
+              className="process-flow-tab-add"
+              onClick={() => setShowAddAction(true)}
+              title="アクション追加"
             >
-              <MaturityBadge
-                maturity={act.maturity}
-                onChange={(next) => {
-                  updateGroupSilent((g) => {
-                    const a = g.actions.find((a2) => a2.id === act.id);
-                    if (a) a.maturity = next;
-                  });
-                }}
-              />
-              {act.name}
-              <span className="ms-1 text-muted small">({ACTION_TRIGGER_LABELS[act.trigger]})</span>
-            </button>
-            <button
-              className="btn btn-link btn-sm text-muted p-0 ms-1"
-              onClick={() => handleDeleteAction(act.id)}
-              title="アクション削除"
-              style={{ fontSize: "0.7rem" }}
-            >
-              <i className="bi bi-x" />
+              <i className="bi bi-plus-lg" />
             </button>
           </div>
-        ))}
-        <button
-          className="process-flow-tab-add"
-          onClick={() => setShowAddAction(true)}
-          title="アクション追加"
+          <div className="process-flow-command-hints">
+            <span><kbd>Ctrl</kbd>+<kbd>C</kbd> コピー</span>
+            <span><kbd>Ctrl</kbd>+<kbd>V</kbd> 貼付</span>
+            <span><kbd>右クリック</kbd> 操作</span>
+          </div>
+        </div>
+
+        <DndContext
+          sensors={sensors}
+          onDragStart={handleDragStart}
+          onDragCancel={handleDragCancel}
+          onDragEnd={handleDragEnd}
+          collisionDetection={collisionDetection}
         >
-          <i className="bi bi-plus-lg" />
-        </button>
-      </div>
-
-      {/* ステップエディタ */}
-      <div className="process-flow-content">
-        {activeAction ? (
-          <div className="step-editor">
-            {/* HTTP 契約 */}
-            <ActionHttpContractPanel
-              action={activeAction}
-              onChange={(patch) => {
-                updateGroupSilent((g) => {
-                  const act = g.actions.find((a) => a.id === activeActionId);
-                  if (act) Object.assign(act, patch);
-                });
-                commitGroup();
-              }}
-            />
-            <SlaPanel
-              label="アクション SLA / Timeout"
-              sla={activeAction.sla}
-              onChange={(sla) => {
-                updateGroupSilent((g) => {
-                  const act = g.actions.find((a) => a.id === activeActionId);
-                  if (act) act.sla = sla;
-                });
-                commitGroup();
-              }}
-            />
-            {/* I/O パネル */}
-            <div className="process-flow-io-panel">
-              <div className="process-flow-io-field">
-                <StructuredFieldsEditor
-                  label="入力データ"
-                  fields={activeAction.inputs}
-                  onChange={(val) => {
-                    updateGroupSilent((g) => {
-                      const act = g.actions.find((a) => a.id === activeActionId);
-                      if (act) act.inputs = val;
-                    });
-                  }}
-                  onCommit={commitGroup}
-                  placeholder="例: ユーザID、パスワード（改行で複数項目）"
-                  onPickScreenItem={handlePickScreenItem}
+          <div className="process-flow-workbench-grid">
+            <aside className="process-flow-palette-pane">
+              <div className="process-flow-pane-header">
+                <div>
+                  <span className="process-flow-pane-kicker">Blocks</span>
+                  <h6>ブロック</h6>
+                </div>
+                <span className="process-flow-pane-badge">D&D</span>
+              </div>
+              <div className="process-flow-palette-search">
+                <i className="bi bi-search" />
+                <input
+                  value={stepFilter}
+                  onChange={(e) => setStepFilter(e.target.value)}
+                  placeholder="ブロックを検索"
+                  aria-label="ブロックを検索"
                 />
               </div>
-              <div className="process-flow-io-field">
-                <StructuredFieldsEditor
-                  label="出力データ"
-                  fields={activeAction.outputs}
-                  onChange={(val) => {
-                    updateGroupSilent((g) => {
-                      const act = g.actions.find((a) => a.id === activeActionId);
-                      if (act) act.outputs = val;
-                    });
-                  }}
-                  onCommit={commitGroup}
-                  placeholder="例: セッションID、認証トークン（改行で複数項目）"
-                  onPickScreenItem={handlePickScreenItem}
-                />
-              </div>
-            </div>
-
-            <DndContext sensors={sensors} onDragEnd={handleDragEnd} collisionDetection={collisionDetection}>
-              {/* ツールバー */}
               <div className="step-toolbar">
-                {ALL_STEP_TYPES.map((type) => (
+                <div className="process-flow-palette-section">基本ステップ</div>
+                {filteredStepTypes.map((type) => (
                   <ToolbarStepButton key={type} type={type} onClick={() => handleAddStep(type)} />
                 ))}
+                {filteredStepTypes.length === 0 && (
+                  <div className="process-flow-palette-empty">該当するブロックがありません</div>
+                )}
                 {customStepCards.length > 0 && (
                   <>
                     <div className="step-toolbar-sep" />
-                    <div className="small text-muted d-flex align-items-center px-1">カスタム</div>
+                    <div className="process-flow-palette-section">カスタム</div>
                     {customStepCards.map(([id, step]) => (
                       <CustomStepButton
                         key={id}
@@ -1138,7 +1217,7 @@ export function ProcessFlowEditor() {
                   </>
                 )}
                 <div className="step-toolbar-sep" />
-                <div style={{ position: "relative" }}>
+                <div className="process-flow-template-anchor">
                   <button
                     className="step-template-btn"
                     onClick={() => setShowTemplates(!showTemplates)}
@@ -1162,17 +1241,41 @@ export function ProcessFlowEditor() {
                   )}
                 </div>
               </div>
+            </aside>
 
-              {/* ステップリスト */}
-              {activeAction.steps.length === 0 ? (
-                <div className="step-empty">
-                  <i className="bi bi-plus-circle" />
-                  ステップがありません。上のボタンから追加するか、テンプレートを使用してください。
+            <main className="process-flow-canvas-pane">
+              <div className="process-flow-canvas-header">
+                <div>
+                  <span className="process-flow-pane-kicker">Flow</span>
+                  <h6>{activeAction ? `${activeAction.name} の処理` : "処理フロー"}</h6>
                 </div>
-              ) : (
-                <SortableContext items={activeAction.steps.map((s) => s.id)} strategy={verticalListSortingStrategy}>
-                  <div className="step-list" ref={stepListRef}>
-                    {activeAction.steps.map((step, index) => {
+                {activeAction && (
+                  <div className="process-flow-canvas-metrics">
+                    <span>{activeAction.steps.length} steps</span>
+                    <span>{activeAction.inputs?.length ?? 0} inputs</span>
+                    <span>{activeAction.outputs?.length ?? 0} outputs</span>
+                  </div>
+                )}
+              </div>
+              <div className="process-flow-content">
+                {activeAction ? (
+                  <div className="step-editor">
+                    {activeAction.steps.length === 0 ? (
+                      <EmptyFlowDropZone>
+                        <i className="bi bi-plus-circle" />
+                        <strong>ステップがありません</strong>
+                        <span>左のブロックをドラッグするか、ブロックをクリックして追加してください。</span>
+                        <StepInsertZone
+                          index={0}
+                          onClick={() => handleAddStep("other")}
+                          onPaste={clipboard ? () => handlePaste(0) : undefined}
+                          dragVisible={isDraggingToolbarStep}
+                        />
+                      </EmptyFlowDropZone>
+                    ) : (
+                      <SortableContext items={activeAction.steps.map((s) => s.id)} strategy={verticalListSortingStrategy}>
+                        <div className={`step-list${isDraggingToolbarStep ? " drag-inserting" : ""}`} ref={stepListRef}>
+                          {activeAction.steps.map((step, index) => {
                       // この step に紐付いた未解決 marker 件数
                       const stepMarkers = (group.authoring?.markers ?? []).filter(
                         (m) => !m.resolvedAt && m.stepId === step.id,
@@ -1193,6 +1296,7 @@ export function ProcessFlowEditor() {
                           index={index}
                           onClick={() => handleAddStep("other", index)}
                           onPaste={clipboard ? () => handlePaste(index) : undefined}
+                          dragVisible={isDraggingToolbarStep}
                         />
                         <SortableStepCard
                           step={step}
@@ -1211,6 +1315,8 @@ export function ProcessFlowEditor() {
                           onAddSubStep={(type) => handleAddSubStep(step.id, type)}
                           onContextMenu={(e) => {
                             e.preventDefault();
+                            setSelectedIds(new Set([step.id]));
+                            lastSelectedIdRef.current = step.id;
                             setContextMenu({ x: e.clientX, y: e.clientY, stepId: step.id });
                           }}
                           onNavigateCommon={(refId) => navigate(wsPath(`/process-flow/edit/${refId}`))}
@@ -1241,24 +1347,105 @@ export function ProcessFlowEditor() {
                         />
                       </div>
                       );
-                    })}
-                    {/* 末尾の挿入ポイント */}
-                    <StepInsertZone
-                      index={activeAction.steps.length}
-                      onClick={() => handleAddStep("other")}
-                      onPaste={clipboard ? () => handlePaste(activeAction.steps.length) : undefined}
-                    />
+                          })}
+                          <StepInsertZone
+                            index={activeAction.steps.length}
+                            onClick={() => handleAddStep("other")}
+                            onPaste={clipboard ? () => handlePaste(activeAction.steps.length) : undefined}
+                            dragVisible={isDraggingToolbarStep}
+                          />
+                        </div>
+                      </SortableContext>
+                    )}
                   </div>
-                </SortableContext>
-              )}
-            </DndContext>
+                ) : (
+                  <div className="step-empty process-flow-empty-drop">
+                    <i className="bi bi-lightning" />
+                    <strong>アクションがありません</strong>
+                    <span>上部の + ボタンからアクションを追加してください。</span>
+                  </div>
+                )}
+              </div>
+            </main>
+
+            <aside className="process-flow-inspector-pane">
+              <div className="process-flow-pane-header">
+                <div>
+                  <span className="process-flow-pane-kicker">Inspector</span>
+                  <h6>詳細</h6>
+                </div>
+              </div>
+              <div className="process-flow-inspector-scroll">
+                <ActionMetaTabBar
+                  group={group}
+                  updateGroup={updateGroup}
+                  updateGroupSilent={updateGroupSilent}
+                />
+                {activeAction && (
+                  <>
+                    <div className="process-flow-inspector-section">
+                      <ActionHttpContractPanel
+                        action={activeAction}
+                        onChange={(patch) => {
+                          updateGroupSilent((g) => {
+                            const act = g.actions.find((a) => a.id === activeActionId);
+                            if (act) Object.assign(act, patch);
+                          });
+                          commitGroup();
+                        }}
+                      />
+                    </div>
+                    <div className="process-flow-inspector-section">
+                      <SlaPanel
+                        label="アクション SLA / Timeout"
+                        sla={activeAction.sla}
+                        onChange={(sla) => {
+                          updateGroupSilent((g) => {
+                            const act = g.actions.find((a) => a.id === activeActionId);
+                            if (act) act.sla = sla;
+                          });
+                          commitGroup();
+                        }}
+                      />
+                    </div>
+                    <div className="process-flow-io-panel">
+                      <div className="process-flow-io-field">
+                        <StructuredFieldsEditor
+                          label="入力データ"
+                          fields={activeAction.inputs}
+                          onChange={(val) => {
+                            updateGroupSilent((g) => {
+                              const act = g.actions.find((a) => a.id === activeActionId);
+                              if (act) act.inputs = val;
+                            });
+                          }}
+                          onCommit={commitGroup}
+                          placeholder="例: ユーザID、パスワード（改行で複数項目）"
+                          onPickScreenItem={handlePickScreenItem}
+                        />
+                      </div>
+                      <div className="process-flow-io-field">
+                        <StructuredFieldsEditor
+                          label="出力データ"
+                          fields={activeAction.outputs}
+                          onChange={(val) => {
+                            updateGroupSilent((g) => {
+                              const act = g.actions.find((a) => a.id === activeActionId);
+                              if (act) act.outputs = val;
+                            });
+                          }}
+                          onCommit={commitGroup}
+                          placeholder="例: セッションID、認証トークン（改行で複数項目）"
+                          onPickScreenItem={handlePickScreenItem}
+                        />
+                      </div>
+                    </div>
+                  </>
+                )}
+              </div>
+            </aside>
           </div>
-        ) : (
-          <div className="step-empty">
-            <i className="bi bi-lightning" />
-            アクションがありません。「+」ボタンからアクションを追加してください。
-          </div>
-        )}
+        </DndContext>
       </div>
 
       {/* コンテキストメニュー */}
@@ -1270,6 +1457,47 @@ export function ProcessFlowEditor() {
         >
           {!contextMenuSubTypePicker ? (
             <>
+              <button
+                className="step-context-menu-item"
+                onClick={() => handleContextInsert(0)}
+              >
+                <i className="bi bi-plus-circle" /> 前に挿入
+              </button>
+              <button
+                className="step-context-menu-item"
+                onClick={() => handleContextInsert(1)}
+              >
+                <i className="bi bi-plus-square" /> 後に挿入
+              </button>
+              {clipboard && (
+                <>
+                  <button
+                    className="step-context-menu-item"
+                    onClick={() => handleContextPaste(0)}
+                  >
+                    <i className="bi bi-clipboard-plus" /> 前に貼り付け
+                  </button>
+                  <button
+                    className="step-context-menu-item"
+                    onClick={() => handleContextPaste(1)}
+                  >
+                    <i className="bi bi-clipboard-plus" /> 後に貼り付け
+                  </button>
+                </>
+              )}
+              <div className="step-context-menu-sep" />
+              <button
+                className="step-context-menu-item"
+                onClick={() => handleCopy(new Set([contextMenu.stepId]))}
+              >
+                <i className="bi bi-files" /> コピー
+              </button>
+              <button
+                className="step-context-menu-item"
+                onClick={() => handleCut(new Set([contextMenu.stepId]))}
+              >
+                <i className="bi bi-scissors" /> カット
+              </button>
               <button
                 className="step-context-menu-item"
                 onClick={() => handleDuplicateStep(contextMenu.stepId)}

--- a/frontend/src/hooks/useSelectionKeyboard.ts
+++ b/frontend/src/hooks/useSelectionKeyboard.ts
@@ -4,17 +4,23 @@ interface SelectionKeyboardOpts {
   onCut: () => void;
   onCopy: () => void;
   onPaste: () => void;
+  onDelete?: () => void;
+  onMoveUp?: () => void;
+  onMoveDown?: () => void;
   onEscape: () => void;
   enabled?: boolean;
 }
 
 /**
- * Ctrl+X / Ctrl+C / Ctrl+V / Esc キーバインドフック
+ * Ctrl+X / Ctrl+C / Ctrl+V / Delete / Alt+Arrow / Esc キーバインドフック
  */
 export function useSelectionKeyboard({
   onCut,
   onCopy,
   onPaste,
+  onDelete,
+  onMoveUp,
+  onMoveDown,
   onEscape,
   enabled = true,
 }: SelectionKeyboardOpts): void {
@@ -34,6 +40,24 @@ export function useSelectionKeyboard({
         return;
       }
 
+      if ((e.key === "Delete" || e.key === "Backspace") && onDelete) {
+        e.preventDefault();
+        onDelete();
+        return;
+      }
+
+      if (e.altKey && e.key === "ArrowUp" && onMoveUp) {
+        e.preventDefault();
+        onMoveUp();
+        return;
+      }
+
+      if (e.altKey && e.key === "ArrowDown" && onMoveDown) {
+        e.preventDefault();
+        onMoveDown();
+        return;
+      }
+
       if (!ctrl) return;
 
       if (e.key === "x") {
@@ -50,5 +74,5 @@ export function useSelectionKeyboard({
 
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [onCut, onCopy, onPaste, onEscape, enabled]);
+  }, [onCut, onCopy, onPaste, onDelete, onMoveUp, onMoveDown, onEscape, enabled]);
 }

--- a/frontend/src/styles/processFlow.css
+++ b/frontend/src/styles/processFlow.css
@@ -7,14 +7,13 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  background: #f8f9fa;
+  background: #eef2f6;
 }
 
 .process-flow-content {
   flex: 1;
   overflow-y: auto;
-  /* #309 フォローアップ: 情報密度優先。4K で余白過多にならないよう縦 8px / 横 14px */
-  padding: 8px 14px;
+  padding: 18px 20px 28px;
 }
 
 /* ─── 処理フロー一覧 ─────────────────────────────────────────────── */
@@ -178,25 +177,42 @@
 
 .process-flow-tabs {
   display: flex;
-  gap: 0;
-  border-bottom: 2px solid #e2e8f0;
-  padding: 0 20px;
-  background: #fff;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  border: 1px solid #d8dee7;
+  border-radius: 8px;
+  padding: 3px;
+  background: #f8fafc;
   overflow-x: auto;
 }
 
+.process-flow-tab-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  border-radius: 6px;
+}
+
+.process-flow-tab-wrap.active {
+  background: #fff;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+}
+
 .process-flow-tab {
-  padding: 10px 16px;
-  font-size: 0.85rem;
-  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  font-size: 0.78rem;
+  font-weight: 600;
   color: #64748b;
   border: none;
-  background: none;
+  background: transparent;
   cursor: pointer;
   white-space: nowrap;
-  border-bottom: 2px solid transparent;
-  margin-bottom: -2px;
-  transition: color 0.15s, border-color 0.15s;
+  border-radius: 6px;
+  transition: color 0.15s, background 0.15s, box-shadow 0.15s;
 }
 
 .process-flow-tab:hover {
@@ -204,23 +220,451 @@
 }
 
 .process-flow-tab.active {
-  color: #6366f1;
-  border-bottom-color: #6366f1;
-  font-weight: 600;
+  color: #17202c;
+  background: transparent;
+  box-shadow: none;
+}
+
+.process-flow-tab-remove {
+  width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 3px;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: #94a3b8;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.process-flow-tab-remove:hover {
+  background: #fee2e2;
+  color: #dc2626;
+}
+
+.process-flow-tab-empty {
+  padding: 0 8px;
+  color: #94a3b8;
+  font-size: 0.78rem;
+  white-space: nowrap;
 }
 
 .process-flow-tab-add {
-  padding: 10px 12px;
-  font-size: 0.85rem;
+  padding: 6px 9px;
+  font-size: 0.8rem;
   color: #94a3b8;
   border: none;
-  background: none;
+  background: transparent;
+  border-radius: 6px;
   cursor: pointer;
-  margin-bottom: -2px;
 }
 
 .process-flow-tab-add:hover {
-  color: #6366f1;
+  color: #2563eb;
+  background: #eaf1ff;
+}
+
+/* ─── ProcessFlow editor workbench (#1071) ───────────────────────── */
+
+.process-flow-workbench {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  background: #eef2f6;
+}
+
+.process-flow-command-bar {
+  min-height: 58px;
+  display: grid;
+  grid-template-columns: minmax(180px, 240px) minmax(180px, 260px) minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 14px;
+  border-bottom: 1px solid #d8dee7;
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(14px);
+}
+
+.process-flow-command-title {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.process-flow-command-title strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #17202c;
+  font-size: 0.9rem;
+}
+
+.process-flow-command-search {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+  height: 34px;
+  padding: 0 10px;
+  border: 1px solid #d8dee7;
+  border-radius: 8px;
+  background: #f8fafc;
+  color: #64748b;
+}
+
+.process-flow-command-search input {
+  min-width: 0;
+  width: 100%;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: #17202c;
+  font-size: 0.8rem;
+}
+
+.process-flow-command-eyebrow,
+.process-flow-pane-kicker {
+  color: #7a8798;
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.process-flow-command-hints {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #64748b;
+  font-size: 0.74rem;
+  white-space: nowrap;
+}
+
+.process-flow-command-hints kbd {
+  padding: 1px 5px;
+  border: 1px solid #cbd5e1;
+  border-bottom-color: #94a3b8;
+  border-radius: 4px;
+  background: #fff;
+  color: #334155;
+  font-size: 0.68rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+.process-flow-workbench-grid {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: 260px minmax(420px, 1fr) 380px;
+  overflow: hidden;
+}
+
+.process-flow-palette-pane,
+.process-flow-canvas-pane,
+.process-flow-inspector-pane {
+  min-height: 0;
+  min-width: 0;
+  background: #fff;
+}
+
+.process-flow-palette-pane {
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid #d8dee7;
+}
+
+.process-flow-canvas-pane {
+  display: flex;
+  flex-direction: column;
+  background:
+    linear-gradient(#e4e9f0 1px, transparent 1px),
+    linear-gradient(90deg, #e4e9f0 1px, transparent 1px),
+    #f8fafc;
+  background-size: 28px 28px;
+}
+
+.process-flow-inspector-pane {
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid #d8dee7;
+}
+
+.process-flow-pane-header,
+.process-flow-canvas-header {
+  min-height: 52px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px 12px;
+  border-bottom: 1px solid #d8dee7;
+  background: rgba(255, 255, 255, 0.94);
+}
+
+.process-flow-pane-header h6,
+.process-flow-canvas-header h6 {
+  margin: 1px 0 0;
+  color: #17202c;
+  font-size: 0.88rem;
+  font-weight: 800;
+}
+
+.process-flow-pane-badge,
+.process-flow-canvas-metrics span {
+  display: inline-flex;
+  align-items: center;
+  height: 22px;
+  padding: 0 8px;
+  border: 1px solid #d8dee7;
+  border-radius: 999px;
+  background: #f8fafc;
+  color: #64748b;
+  font-size: 0.72rem;
+  font-weight: 650;
+  white-space: nowrap;
+}
+
+.process-flow-canvas-metrics {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.process-flow-palette-search {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin: 10px 12px 0;
+  padding: 0 9px;
+  height: 32px;
+  border: 1px solid #d8dee7;
+  border-radius: 8px;
+  background: #f8fafc;
+  color: #64748b;
+}
+
+.process-flow-palette-search input {
+  min-width: 0;
+  width: 100%;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: #17202c;
+  font-size: 0.8rem;
+}
+
+.process-flow-palette-section {
+  width: 100%;
+  color: #7a8798;
+  font-size: 0.68rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  margin: 4px 0 2px;
+}
+
+.process-flow-palette-empty {
+  padding: 14px 10px;
+  border: 1px dashed #cbd5e1;
+  border-radius: 8px;
+  background: #f8fafc;
+  color: #64748b;
+  font-size: 0.78rem;
+  text-align: center;
+}
+
+.process-flow-template-anchor {
+  position: relative;
+  width: 100%;
+}
+
+.process-flow-inspector-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 10px;
+  background: #f8fafc;
+}
+
+.process-flow-inspector-section {
+  margin-bottom: 10px;
+}
+
+/* #1071: ProcessFlow editor 内のフォーム部品は Bootstrap 未適用/素の input でも
+   ブラウザ標準の inset border に戻らないよう、画面スコープで基礎スタイルを固定する。 */
+.process-flow-workbench :where(input:not([type="checkbox"]):not([type="radio"]), select, textarea),
+.process-flow-modal :where(input:not([type="checkbox"]):not([type="radio"]), select, textarea),
+.process-flow-ai-review-dialog :where(input:not([type="checkbox"]):not([type="radio"]), select, textarea),
+.screen-item-picker :where(input:not([type="checkbox"]):not([type="radio"]), select, textarea) {
+  min-height: 30px;
+  width: 100%;
+  border: 1px solid #cbd5e1;
+  border-radius: 7px;
+  background-color: #fff;
+  color: #17202c;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.03);
+  font-size: 0.8rem;
+  line-height: 1.35;
+  padding: 5px 8px;
+  transition: border-color 0.14s, box-shadow 0.14s, background-color 0.14s;
+}
+
+.process-flow-workbench :where(textarea),
+.process-flow-modal :where(textarea),
+.process-flow-ai-review-dialog :where(textarea),
+.screen-item-picker :where(textarea) {
+  min-height: 64px;
+  resize: vertical;
+}
+
+.process-flow-workbench :where(select),
+.process-flow-modal :where(select),
+.process-flow-ai-review-dialog :where(select),
+.screen-item-picker :where(select) {
+  appearance: none;
+  padding-right: 28px;
+  background-image:
+    linear-gradient(45deg, transparent 50%, #64748b 50%),
+    linear-gradient(135deg, #64748b 50%, transparent 50%);
+  background-position:
+    calc(100% - 15px) 50%,
+    calc(100% - 10px) 50%;
+  background-size: 5px 5px, 5px 5px;
+  background-repeat: no-repeat;
+}
+
+.process-flow-workbench :where(input:not([type="checkbox"]):not([type="radio"]), select, textarea):hover,
+.process-flow-modal :where(input:not([type="checkbox"]):not([type="radio"]), select, textarea):hover,
+.process-flow-ai-review-dialog :where(input:not([type="checkbox"]):not([type="radio"]), select, textarea):hover,
+.screen-item-picker :where(input:not([type="checkbox"]):not([type="radio"]), select, textarea):hover {
+  border-color: #94a3b8;
+}
+
+.process-flow-workbench :where(input:not([type="checkbox"]):not([type="radio"]), select, textarea):focus,
+.process-flow-modal :where(input:not([type="checkbox"]):not([type="radio"]), select, textarea):focus,
+.process-flow-ai-review-dialog :where(input:not([type="checkbox"]):not([type="radio"]), select, textarea):focus,
+.screen-item-picker :where(input:not([type="checkbox"]):not([type="radio"]), select, textarea):focus {
+  outline: none;
+  border-color: #2563eb;
+  background-color: #fff;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.14);
+}
+
+.process-flow-workbench :where(input:not([type="checkbox"]):not([type="radio"]), select, textarea):disabled,
+.process-flow-modal :where(input:not([type="checkbox"]):not([type="radio"]), select, textarea):disabled,
+.process-flow-ai-review-dialog :where(input:not([type="checkbox"]):not([type="radio"]), select, textarea):disabled,
+.screen-item-picker :where(input:not([type="checkbox"]):not([type="radio"]), select, textarea):disabled {
+  background-color: #f1f5f9;
+  color: #94a3b8;
+  cursor: not-allowed;
+}
+
+.process-flow-workbench :where(.btn, button:not(.step-toolbar-btn):not(.step-insert-btn):not(.step-paste-btn):not(.process-flow-tab):not(.process-flow-tab-add)) {
+  border-radius: 7px;
+}
+
+.process-flow-page .editor-header,
+.process-flow-page .edit-mode-toolbar {
+  border-bottom-color: #d8dee7;
+  background: rgba(255, 255, 255, 0.96);
+}
+
+.process-flow-page .editor-header .btn,
+.process-flow-page .edit-mode-toolbar .btn,
+.process-flow-page .save-reset-buttons .btn,
+.process-flow-page .edit-session-dropdown-toggle {
+  min-height: 30px;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border: 1px solid #cbd5e1;
+  border-radius: 7px;
+  background: #fff;
+  color: #334155;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+  font-size: 0.8rem;
+  font-weight: 650;
+  line-height: 1.2;
+  padding: 5px 10px;
+  transition: border-color 0.14s, background-color 0.14s, color 0.14s, box-shadow 0.14s;
+}
+
+.process-flow-page .editor-header .btn:hover,
+.process-flow-page .edit-mode-toolbar .btn:hover,
+.process-flow-page .save-reset-buttons .btn:hover,
+.process-flow-page .edit-session-dropdown-toggle:hover {
+  border-color: #2563eb;
+  background: #eaf1ff;
+  color: #1d4ed8;
+}
+
+.process-flow-page .editor-header .btn-primary,
+.process-flow-page .edit-mode-toolbar .btn-primary,
+.process-flow-page .save-reset-buttons .btn-primary {
+  border-color: #2563eb;
+  background: #2563eb;
+  color: #fff;
+}
+
+.process-flow-page .edit-mode-toolbar .btn-success,
+.process-flow-page .save-reset-buttons .btn-success {
+  border-color: #16a34a;
+  background: #16a34a;
+  color: #fff;
+}
+
+.process-flow-page .editor-header .btn-primary:hover,
+.process-flow-page .edit-mode-toolbar .btn-primary:hover,
+.process-flow-page .save-reset-buttons .btn-primary:hover,
+.process-flow-page .edit-mode-toolbar .btn-success:hover,
+.process-flow-page .save-reset-buttons .btn-success:hover {
+  filter: brightness(0.96);
+  color: #fff;
+}
+
+.process-flow-page .edit-mode-toolbar--editing::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: #16a34a;
+  box-shadow: 0 0 0 3px rgba(22, 163, 74, 0.12);
+}
+
+.process-flow-inspector-pane :where(button:not(.catalog-panel-toggle):not(.step-context-menu-item)),
+.step-card-body :where(button:not(.step-card-menu-btn):not(.inline-type-btn)),
+.process-flow-io-panel :where(button) {
+  min-height: 26px;
+  border: 1px solid #cbd5e1;
+  border-radius: 7px;
+  background: #fff;
+  color: #334155;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.03);
+  font-size: 0.74rem;
+  line-height: 1.2;
+  padding: 4px 8px;
+  transition: border-color 0.14s, background-color 0.14s, color 0.14s, box-shadow 0.14s;
+}
+
+.process-flow-inspector-pane :where(button:not(.catalog-panel-toggle):not(.step-context-menu-item)):hover,
+.step-card-body :where(button:not(.step-card-menu-btn):not(.inline-type-btn)):hover,
+.process-flow-io-panel :where(button):hover {
+  border-color: #2563eb;
+  background: #eaf1ff;
+  color: #1d4ed8;
+}
+
+.process-flow-inspector-pane :where(button:not(.catalog-panel-toggle):not(.step-context-menu-item)):focus-visible,
+.step-card-body :where(button:not(.step-card-menu-btn):not(.inline-type-btn)):focus-visible,
+.process-flow-io-panel :where(button):focus-visible {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.14);
 }
 
 /* ─── I/O パネル ─────────────────────────────────────────────────── */
@@ -232,11 +676,11 @@
   display: grid;
   grid-template-columns: 1fr;
   gap: 10px;
-  margin-bottom: 16px;
-  padding: 12px;
-  background: #f8fafc;
-  border: 1px solid #e2e8f0;
-  border-radius: 6px;
+  margin-bottom: 10px;
+  padding: 10px;
+  background: #fff;
+  border: 1px solid #d8dee7;
+  border-radius: 8px;
 }
 /* 1600px 以上 (4K 半分や 1920 以上の横広) では入出力を左右並びに戻す。
    table-layout: fixed + col-*: 11em+9em+7em+... の合計 ≒ 400px 以上あれば折り返し
@@ -356,32 +800,35 @@
 
 .step-toolbar {
   display: flex;
+  flex-direction: column;
   gap: 6px;
-  padding: 12px 0;
-  flex-wrap: wrap;
-  border-bottom: 1px solid #e2e8f0;
-  margin-bottom: 16px;
+  padding: 12px;
+  overflow-y: auto;
+  min-height: 0;
+  flex: 1;
 }
 
 .step-toolbar-btn {
   display: flex;
   align-items: center;
-  gap: 4px;
-  padding: 5px 10px;
-  border: 1px solid #e2e8f0;
-  border-radius: 6px;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 9px;
+  border: 1px solid #d8dee7;
+  border-radius: 8px;
   background: #fff;
   font-size: 0.78rem;
-  color: #475569;
+  color: #334155;
   cursor: pointer;
-  transition: border-color 0.15s, background 0.15s;
+  transition: border-color 0.15s, background 0.15s, box-shadow 0.15s;
   white-space: nowrap;
 }
 
 .step-toolbar-btn:hover {
-  border-color: #6366f1;
-  background: #f5f3ff;
-  color: #4338ca;
+  border-color: #2563eb;
+  background: #eaf1ff;
+  color: #1d4ed8;
+  box-shadow: 0 4px 12px rgba(37, 99, 235, 0.1);
 }
 
 .step-toolbar-btn i {
@@ -389,18 +836,21 @@
 }
 
 .step-toolbar-sep {
-  width: 1px;
+  width: 100%;
+  height: 1px;
   background: #e2e8f0;
-  margin: 0 4px;
+  margin: 6px 0;
 }
 
 .step-template-btn {
   display: flex;
   align-items: center;
-  gap: 4px;
-  padding: 5px 10px;
+  justify-content: center;
+  gap: 6px;
+  width: 100%;
+  padding: 8px 10px;
   border: 1px dashed #cbd5e1;
-  border-radius: 6px;
+  border-radius: 8px;
   background: #f8fafc;
   font-size: 0.78rem;
   color: #64748b;
@@ -419,36 +869,62 @@
   display: flex;
   flex-direction: column;
   gap: 0;
+  max-width: 920px;
+  margin: 0 auto;
 }
 
 .step-insert-point {
+  position: relative;
   display: flex;
   justify-content: center;
-  padding: 4px 0;
+  align-items: center;
+  min-height: 12px;
+  padding: 2px 0;
   opacity: 0;
-  transition: opacity 0.15s;
+  transition: opacity 0.15s, min-height 0.15s, padding 0.15s;
 }
 
-.step-list:hover .step-insert-point,
+.step-insert-point::before {
+  content: "";
+  position: absolute;
+  left: 18px;
+  right: 18px;
+  top: 50%;
+  height: 2px;
+  border-radius: 999px;
+  background: #9db4d6;
+  transform: translateY(-50%);
+}
+
+.step-insert-point:hover,
+.step-insert-point.drag-visible,
 .step-insert-point:focus-within {
   opacity: 1;
+  min-height: 28px;
+  padding: 4px 0;
 }
 
 .step-insert-point.drop-active {
   opacity: 1;
-  padding: 12px 0;
-  background: rgba(99, 102, 241, 0.08);
-  border-radius: 6px;
-  border: 2px dashed #6366f1;
+  min-height: 38px;
+  padding: 8px 0;
+}
+
+.step-insert-point.drop-active::before {
+  height: 3px;
+  background: #2563eb;
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.12);
 }
 
 .step-insert-btn {
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-  border: 1px dashed #cbd5e1;
+  position: relative;
+  z-index: 1;
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  border: 1px solid #cbd5e1;
   background: #fff;
-  color: #94a3b8;
+  color: #64748b;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -458,22 +934,26 @@
 }
 
 .step-insert-btn:hover {
-  border-color: #6366f1;
-  color: #6366f1;
-  background: #f5f3ff;
+  border-color: #2563eb;
+  color: #2563eb;
+  background: #eaf1ff;
 }
 
 .step-insert-point.has-paste {
   opacity: 1;
+  min-height: 24px;
 }
 
 .step-paste-btn {
+  position: relative;
+  z-index: 1;
+  margin-left: 6px;
   font-size: 0.72rem;
   padding: 2px 8px;
-  border: 1px dashed #6366f1;
-  border-radius: 4px;
-  background: #f5f3ff;
-  color: #6366f1;
+  border: 1px solid #93c5fd;
+  border-radius: 999px;
+  background: #eff6ff;
+  color: #1d4ed8;
   cursor: pointer;
   transition: background 0.15s;
 }
@@ -483,15 +963,17 @@
 }
 
 .step-card {
-  border: 1px solid #e2e8f0;
+  border: 1px solid #d8dee7;
   border-radius: 8px;
   background: #fff;
-  border-left: 4px solid #e2e8f0;
-  transition: box-shadow 0.15s, border-color 0.15s;
+  border-left: 4px solid #cbd5e1;
+  box-shadow: 0 8px 20px rgba(23, 32, 44, 0.06);
+  transition: box-shadow 0.15s, border-color 0.15s, transform 0.15s;
 }
 
 .step-card:hover {
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+  box-shadow: 0 12px 28px rgba(23, 32, 44, 0.1);
+  transform: translateY(-1px);
 }
 
 .step-card.dragging {
@@ -509,8 +991,9 @@
 
 /* 選択状態 */
 .step-card.selected {
-  outline: 2px solid #6366f1;
-  background-color: rgba(99, 102, 241, 0.05);
+  outline: 2px solid #2563eb;
+  outline-offset: 1px;
+  background-color: #f8fbff;
 }
 
 .step-card-drag-handle {
@@ -681,6 +1164,35 @@
   padding: 40px 20px;
   color: #94a3b8;
   font-size: 0.9rem;
+}
+
+.process-flow-empty-drop {
+  display: grid;
+  place-items: center;
+  gap: 6px;
+  min-height: 320px;
+  margin: 0 auto;
+  max-width: 560px;
+  border: 1px dashed #b8c4d4;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.72);
+  color: #64748b;
+  transition: border-color 0.15s, background-color 0.15s, box-shadow 0.15s;
+}
+
+.process-flow-empty-drop.drop-active {
+  border-color: #2563eb;
+  background: rgba(239, 246, 255, 0.88);
+  box-shadow: inset 0 0 0 3px rgba(37, 99, 235, 0.12);
+}
+
+.process-flow-empty-drop strong {
+  color: #334155;
+  font-size: 1rem;
+}
+
+.process-flow-empty-drop span {
+  font-size: 0.82rem;
 }
 
 .step-empty i {
@@ -889,9 +1401,9 @@
   background: #fff;
   border: 1px solid #e2e8f0;
   border-radius: 8px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  box-shadow: 0 16px 34px rgba(23, 32, 44, 0.18);
   z-index: 200;
-  min-width: 160px;
+  min-width: 180px;
   padding: 4px 0;
 }
 
@@ -925,6 +1437,52 @@
   height: 1px;
   background: #e2e8f0;
   margin: 4px 0;
+}
+
+@media (max-width: 1280px) {
+  .process-flow-workbench-grid {
+    grid-template-columns: 220px minmax(360px, 1fr) 340px;
+  }
+
+  .process-flow-command-hints {
+    display: none;
+  }
+}
+
+@media (max-width: 980px) {
+  .process-flow-command-bar {
+    grid-template-columns: 1fr;
+    align-items: stretch;
+  }
+
+  .process-flow-workbench-grid {
+    grid-template-columns: 1fr;
+    overflow-y: auto;
+  }
+
+  .process-flow-palette-pane,
+  .process-flow-inspector-pane {
+    min-height: 220px;
+    border-right: 0;
+    border-left: 0;
+    border-bottom: 1px solid #d8dee7;
+  }
+
+  .step-toolbar {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(132px, 1fr));
+    max-height: 260px;
+  }
+
+  .process-flow-palette-section,
+  .step-toolbar-sep,
+  .process-flow-template-anchor {
+    grid-column: 1 / -1;
+  }
+
+  .process-flow-canvas-pane {
+    min-height: 60vh;
+  }
 }
 
 /* ─── 分岐セクション (Phase 3) ───────────────────────────────────── */
@@ -1413,54 +1971,66 @@
 /* ─── メタタブバー (#309) ─────────────────────────────────────────
    ProcessFlowEditor 上部の基本情報 + 6 カタログを 1 行のタブバーに集約し、
    排他的に 1 つだけ body を全幅で展開する。 */
-.process-flow-meta-tabbar {
+.process-flow-meta-tabbar,
+.action-meta-tabbar {
   padding: 3px 14px;
   background: #fff;
-  border-bottom: 1px solid #e2e8f0;
+  border: 1px solid #d8dee7;
+  border-radius: 8px;
+  margin-bottom: 10px;
   display: flex;
   flex-direction: column;
   gap: 2px;
 }
-.process-flow-meta-tabs {
+.process-flow-meta-tabs,
+.action-meta-tabs {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
   gap: 3px;
   row-gap: 3px;
 }
-.process-flow-meta-tabs .catalog-panel {
+.process-flow-meta-tabs .catalog-panel,
+.action-meta-tabs .catalog-panel {
   margin: 0;
   flex: 0 0 auto;
 }
-.process-flow-meta-tabs .catalog-panel-toggle {
+.process-flow-meta-tabs .catalog-panel-toggle,
+.action-meta-tabs .catalog-panel-toggle {
   width: auto;
   padding: 2px 8px;
   font-size: 0.76rem;
 }
 /* アクティブ (展開中) のパネルを強調: chevron-down アイコンの存在で判定 (:has) */
-.process-flow-meta-tabs .catalog-panel:has(.bi-chevron-down) {
+.process-flow-meta-tabs .catalog-panel:has(.bi-chevron-down),
+.action-meta-tabs .catalog-panel:has(.bi-chevron-down) {
   background: #dbeafe;
   border-color: #60a5fa;
 }
-.process-flow-meta-tabs .catalog-panel:has(.bi-chevron-down) .catalog-panel-toggle {
+.process-flow-meta-tabs .catalog-panel:has(.bi-chevron-down) .catalog-panel-toggle,
+.action-meta-tabs .catalog-panel:has(.bi-chevron-down) .catalog-panel-toggle {
   color: #1e40af;
 }
-.process-flow-meta-tabbar-spacer {
+.process-flow-meta-tabbar-spacer,
+.action-meta-tabbar-spacer {
   flex: 1 1 auto;
 }
-.process-flow-meta-tabbar-inline {
+.process-flow-meta-tabbar-inline,
+.action-meta-tabbar-inline {
   display: flex;
   align-items: center;
   gap: 8px;
   font-size: 0.78rem;
   padding: 0 4px;
 }
-.process-flow-meta-maturity-label {
+.process-flow-meta-maturity-label,
+.action-meta-maturity-label {
   font-weight: 600;
   color: #475569;
   font-size: 0.75rem;
 }
-.process-flow-meta-progress {
+.process-flow-meta-progress,
+.action-meta-progress {
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -1469,25 +2039,29 @@
   background: #f8fafc;
   border: 1px solid #e2e8f0;
 }
-.process-flow-meta-body {
+.process-flow-meta-body,
+.action-meta-body {
   padding: 6px 10px;
   background: #f8fafc;
   border: 1px solid #cbd5e1;
   border-radius: 4px;
-  max-height: 50vh;
+  max-height: 42vh;
   overflow-y: auto;
 }
-.process-flow-meta-body.process-flow-meta-info-body {
+.process-flow-meta-body.process-flow-meta-info-body,
+.action-meta-body.action-meta-info-body {
   padding: 8px 10px;
 }
 /* メタタブバー配下の body は外枠はタブバーが提供するので、
    各 Panel の border は解除して内側 padding のみにする */
-.process-flow-meta-body > .catalog-panel {
+.process-flow-meta-body > .catalog-panel,
+.action-meta-body > .catalog-panel {
   margin: 0;
   border: none;
   background: transparent;
 }
-.process-flow-meta-body > .catalog-panel > .catalog-panel-body {
+.process-flow-meta-body > .catalog-panel > .catalog-panel-body,
+.action-meta-body > .catalog-panel > .catalog-panel-body {
   max-height: none;
   padding: 0;
   border-top: none;
@@ -1772,12 +2346,71 @@
   line-height: 1;
 }
 
-.process-flow-ai-generate-dialog {
-  width: min(720px, calc(100vw - 32px));
+.process-flow-ai-generate-dialog,
+.process-flow-ai-review-dialog {
+  width: min(920px, calc(100vw - 48px));
+  max-width: 920px;
+  min-height: min(640px, calc(100vh - 72px));
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  overflow: hidden;
 }
 
-.process-flow-ai-generate-dialog textarea {
+.process-flow-ai-generate-dialog .process-flow-modal-header,
+.process-flow-ai-review-dialog .edit-mode-modal-header {
+  padding: 16px 20px;
+  border-bottom: 1px solid #d8dee7;
+  background: #fff;
+}
+
+.process-flow-ai-generate-dialog .form-group,
+.process-flow-ai-review-dialog .edit-mode-modal-body {
+  flex: 1;
+}
+
+.process-flow-ai-generate-dialog {
+  padding: 20px;
+}
+
+.process-flow-ai-generate-dialog textarea,
+.process-flow-ai-review-dialog textarea {
+  width: 100%;
+  min-height: 260px;
   resize: vertical;
+}
+
+.process-flow-ai-review-dialog .edit-mode-modal-body {
+  display: flex;
+  flex-direction: column;
+  padding: 18px 20px;
+}
+
+.process-flow-ai-review-dialog .edit-mode-modal-footer {
+  margin-top: auto;
+  padding-top: 14px;
+}
+
+.process-flow-ai-review-dialog .btn,
+.process-flow-ai-generate-dialog .btn,
+.process-flow-ai-generate-dialog button,
+.process-flow-ai-review-dialog button:not(.btn-close) {
+  min-height: 30px;
+  border: 1px solid #cbd5e1;
+  border-radius: 7px;
+  background: #fff;
+  color: #334155;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+  font-size: 0.8rem;
+  font-weight: 650;
+  padding: 5px 10px;
+}
+
+.process-flow-ai-review-dialog .btn-primary,
+.process-flow-ai-generate-dialog .btn-primary {
+  border-color: #2563eb;
+  background: #2563eb;
+  color: #fff;
 }
 
 .process-flow-ai-preview {


### PR DESCRIPTION
## 関連

- Closes #1071
- 仕様: N/A — UI redesign Issue #1071 の合意仕様コメントを基準に実装

## 概要

処理フローエディタの上部肥大を解消し、Studio 3-pane をベースにした編集画面へ刷新します。JSON Schema は変更せず、既存の処理フロー表現力と D&D 編集を維持したまま、中央のフロー編集領域を主役にします。

## 主な変更

- 画面構成: 左ブロックパレット / 中央フロー / 右 inspector の 3 ペイン構成へ再編
- コマンドバー: アクション検索、アクション切替、ショートカットヒント、追加/削除操作を薄い上部バーに集約
- ブロックパレット: D&D 可能なステップ種類を左ペイン化し、ブロック検索を追加
- inspector: 基本情報、HTTP 契約、SLA、I/O、catalog 類を右ペインへ移動
- 挿入 UI: 常時表示の「ここにブロックをドロップ」「ステップ間に挿入」を廃止し、ドラッグ中 / hover / drop active / paste 可能時だけ表示
- D&D 補強: 空フロー全体を drop target 化し、カード上に落とした場合も挿入位置を補完
- コンテキスト操作: 右クリックメニューに前後挿入、前後貼り付け、コピー、カットを追加
- キーボード操作: Ctrl+C / Ctrl+X / Ctrl+V / Delete / Backspace / Alt+↑↓ を追加
- CSS 適用: editor scoped input/select/textarea/button、AI レビューダイアログ、`ActionMetaTabBar` の `action-meta-*` class に対応
- プロトタイプ: 静的 HTML 案も挿入 UI の合意仕様に合わせて更新

## 仕様逐条突合 (自己申告)

- JSON Schema を変更しない → `git diff origin/main...HEAD -- schemas/` 差分なし ✓
- Studio 3-pane をベースにする → `frontend/src/components/process-flow/ProcessFlowEditor.tsx:1109` / `frontend/src/styles/processFlow.css:272` ✓
- コマンドバーとアクション検索を設ける → `frontend/src/components/process-flow/ProcessFlowEditor.tsx:1110` / `frontend/src/components/process-flow/ProcessFlowEditor.tsx:1116` / `frontend/src/styles/processFlow.css:280` ✓
- 左ブロックパレットを設ける → `frontend/src/components/process-flow/ProcessFlowEditor.tsx:1179` / `frontend/src/styles/processFlow.css:368` ✓
- ブロック検索を設ける → `frontend/src/components/process-flow/ProcessFlowEditor.tsx:202` / `frontend/src/styles/processFlow.css:439` ✓
- 中央フロー領域を主面積にする → `frontend/src/components/process-flow/ProcessFlowEditor.tsx:1246` / `frontend/src/styles/processFlow.css:360` ✓
- 右 inspector にメタ情報・HTTP 契約・SLA・I/O を移す → `frontend/src/components/process-flow/ProcessFlowEditor.tsx:1371` / `frontend/src/components/process-flow/ProcessFlowEditor.tsx:1379` / `frontend/src/components/process-flow/ProcessFlowEditor.tsx:1387` / `frontend/src/components/process-flow/ProcessFlowEditor.tsx:1399` / `frontend/src/components/process-flow/ProcessFlowEditor.tsx:1411` ✓
- 挿入ポイントを常時表示しない → `frontend/src/components/process-flow/ProcessFlowEditor.tsx:104` / `frontend/src/styles/processFlow.css:876` ✓
- ドラッグ中に挿入 UI を出す → `frontend/src/components/process-flow/ProcessFlowEditor.tsx:577` / `frontend/src/components/process-flow/ProcessFlowEditor.tsx:1171` / `frontend/src/components/process-flow/ProcessFlowEditor.tsx:1295` / `frontend/src/styles/processFlow.css:899` ✓
- 空フロー全体を drop target にする → `frontend/src/components/process-flow/ProcessFlowEditor.tsx:136` / `frontend/src/components/process-flow/ProcessFlowEditor.tsx:1264` / `frontend/src/styles/processFlow.css:1169` ✓
- カード上 drop でも挿入位置を補完する → `frontend/src/components/process-flow/ProcessFlowEditor.tsx:585` ✓
- 右クリックで挿入/コピー/カット/貼付ができる → `frontend/src/components/process-flow/ProcessFlowEditor.tsx:1316` / `frontend/src/components/process-flow/ProcessFlowEditor.tsx:1451` ✓
- キーボードでコピー/カット/貼付/Delete/Alt+↑↓を扱う → `frontend/src/hooks/useSelectionKeyboard.ts:14` / `frontend/src/components/process-flow/ProcessFlowEditor.tsx:768` ✓
- フォーム部品とダイアログの素のブラウザ見た目を避ける → `frontend/src/styles/processFlow.css:500` ✓
- `action-meta-*` CSS 不整合を解消する → `frontend/src/styles/processFlow.css:1993` ✓

## レビューで特に見てほしい箇所

- 3 ペイン化により、既存の ActionMetaTabBar / HTTP 契約 / SLA / I/O の配置移動で編集導線が破綻していないか
- D&D の drop zone を視覚的に隠したことで、ドラッグ追加・並び替えの操作感に問題がないか
- 空フロー、カード上 drop、insert-zone drop のすべてで挿入位置が直感どおりか
- 右クリック/ショートカットの追加が既存の StepCard 操作と衝突していないか
- `ActionMetaTabBar` を右 inspector に入れた際の高さ・スクロール・DrawingOverlay anchor の見え方
- 1280px 未満 / 980px 未満のレスポンシブ崩れ

## テスト

- Build: `cd frontend && npm run build` 成功
- Playwright ad-hoc smoke: `node .tmp/process-flow-ui-interaction-smoke.mjs` 成功
- Vitest: N/A (UI 構成変更中心)
- MCP E2E: N/A

## UI 影響 / AI smoke test

- [x] UI 影響あり
- [ ] UI 影響なし

### UI 影響ありの場合、AI smoke test で確認した項目

- [x] 処理フローエディタ: TypeScript/Vite build 成功
- [x] `schemas/` PR 差分なし
- [x] ブラウザ上でブロック D&D 追加を確認
- [x] ブラウザ上で既存ステップ D&D 並び替えを確認
- [x] ブラウザ上で右クリックメニューのコピー/カット表示を確認
- [x] ブラウザ上で挿入ポイントの貼り付けボタン表示と貼り付け追加を確認

### smoke artifact

- `.tmp/screenshots/process-flow-1071-interaction-smoke.png`
- `.tmp/screenshots/process-flow-1071-polished-main.png`
- `.tmp/screenshots/process-flow-1071-ai-review-dialog.png`

## spec 側の不足点 / 提案

N/A — 今回の UI 刷新仕様は Issue #1071 のコメントに集約済み。AI 依頼 UX の拡張は #1076 に分離済み。

## レビュー担当への申し送り

本 PR は #1071 の初期実装です。品質目標は Figma / Retool / Make / Zapier / ReactFlow 系 SaaS に近い編集体験です。全面 Canvas-first ではなく、Studio 3-pane を骨格にし、Command Compact の薄い上部バーと検索性を部分採用しています。

特に、常時表示の挿入ポイントを廃止した点は意図的な設計判断です。droppable zone は DOM 上に残し、ドラッグ中・hover・drop active・paste 可能時だけ見せています。
