### PR TITLE
feat(schema): ProcessFlow componentCall step + exception-type catalog (#1066)

### DIFF
--- a/docs/spec/conversion-guideline-for-ai.md
+++ b/docs/spec/conversion-guideline-for-ai.md
@@ -36,15 +36,14 @@
 | 印 | 種別 | 実体 | AJV 検証 |
 |---|---|---|---|
 | ✅ | **現行 schema 適合形** | `schemas/v3/*.json` に既存 (`generic-definition.v3.schema.json` 含む、#1063)。今すぐ使える | **必須通過** (§10 完了判定の対象) |
-| ✨ | **RFC 将来 schema 案** | ISSUE #1060 系の **kind 別固有 schema** (data-contract / domain-type は #1064 で AJV gate 対象化、残 6 kind は #1066 以降の子 ISSUE 予定)、および既存 entity 拡張で残るもの (componentCall / exceptionTypeRef 等、#1066 以降想定)。**binding / events.effects** は #1065 で AJV gate 対象化済 (✅ 側)。残 kind / 既存 entity 拡張は **まだ schema が無い** | **検証対象外** (生成すると親 schema `unevaluatedProperties: false` で AJV 失敗、`description` 退避 + audit warning) |
+| ✨ | **RFC 将来 schema 案** | ISSUE #1060 系の **kind 別固有 schema** (data-contract / domain-type は #1064 で AJV gate 対象化、exception-type は #1066 で AJV gate 対象化、残 5 kind は #1067-#1068 で予定)。**binding / events.effects** は #1065 で AJV gate 対象化済 (✅ 側)。**componentCall / exceptionTypeRef** は **#1066 で AJV gate 対象化済 (✅ 側)**。残 kind 固有 field は **まだ schema が無い** | **検証対象外** (生成すると親 schema `unevaluatedProperties: false` で AJV 失敗、`description` 退避 + audit warning) |
 
 ### 何が ✨ RFC 将来案か
 
 - `screenItem.binding.{kind,path,role,formatHint,sourceNote}` — **#1065 で導入済 (AJV gate 対象)**。spec §3.1 の `optionSource` / `parseHint` は本 #1065 では追加せず将来 ISSUE 想定
 - `screenItemEvent.effects[]` — **#1065 で導入済 (AJV gate 対象)**。`event.trigger` / `event.target` (top-level) は #1065 範囲外、将来 ISSUE 想定。`event.id` 自体が trigger 名 (click/submit/change/blur) を兼ねる現行設計を本 PR 後も維持
-- ProcessFlow step `kind: "componentCall"`, `kind: "dbQuery"|"dbInsert"|"dbUpdate"` — 現行は `commonProcess` / `dbAccess` (operation: SELECT/INSERT/UPDATE/DELETE)
-- `validation[].throw.exceptionTypeRef` (step 内 inline) — 現行は `errorCode` catalog 参照
-- `generic-definitions/<kind>/*.json` の **kind 固有 field** — 親 schema (`schemas/v3/generic-definition.v3.schema.json`、#1063 で導入済) は確定し、共通メタモデル (kind / name / purpose / responsibilities / targets / fields / operations / relations / constraints / mappingHints) は AJV 検証対象。**kind 別の固有 schema** (data-contract / domain-type は #1064 で導入、残 6 kind は #1066-#1068 で順次切り出し中)
+- `dbQuery` / `dbInsert` / `dbUpdate` — DB 操作はすべて `dbAccess` + `operation` で表現する (細分化は #1066 で採用しないと決定)
+- `generic-definitions/<kind>/*.json` の **kind 固有 field** — 親 schema (`schemas/v3/generic-definition.v3.schema.json`、#1063 で導入済) は確定し、共通メタモデル (kind / name / purpose / responsibilities / targets / fields / operations / relations / constraints / mappingHints) は AJV 検証対象。**kind 別の固有 schema** (data-contract / domain-type は #1064 で導入、exception-type は #1066 で導入、残 5 kind は #1067-#1068 で順次切り出し中)
 - `step.outputBinding: "stock"` の string 短縮形 — v3 で廃止、`{ name: "stock" }` のみ
 
 ### AI が今すべきこと
@@ -460,13 +459,13 @@ ProcessFlow 側 (`pf-load-cities`) で API 呼び出し + `displayUpdate` で項
 ```
 (完全な動作する例は本節末尾 §3.3 ✅ After を参照)
 
-**Step union (24 variants)** ([schema:529](../../schemas/v3/process-flow.v3.schema.json)):
-`validation` / `dbAccess` / `externalSystem` / `commonProcess` / `screenTransition` / `displayUpdate` / `branch` / `loop` / `loopBreak` / `loopContinue` / `jump` / `compute` / `return` / `log` / `audit` / `workflow` / `transactionScope` / `eventPublish` / `eventSubscribe` / `closing` / `cdc` / `aiCall` / `aiAgent` / `extension`
+**Step union (25 variants)** ([schema:529](../../schemas/v3/process-flow.v3.schema.json)):
+`validation` / `dbAccess` / `externalSystem` / `commonProcess` / `componentCall` / `screenTransition` / `displayUpdate` / `branch` / `loop` / `loopBreak` / `loopContinue` / `jump` / `compute` / `return` / `log` / `audit` / `workflow` / `transactionScope` / `eventPublish` / `eventSubscribe` / `closing` / `cdc` / `aiCall` / `aiAgent` / `extension`
 
 **Step kind ではない** (混同しやすい — 別の場所で使う kind):
 - `expression` / `tryCatch` / `affectedRowsZero` / `externalOutcome` — **BranchCondition の kind** (`branch.branches[].condition.kind`)
 - `auditLog` — **CDC 出力先の kind** (`cdc.outputs[].kind`)
-- `componentCall` / `dbQuery` / `dbInsert` / `dbUpdate` — 存在しない (RFC 将来案)
+- `dbQuery` / `dbInsert` / `dbUpdate` — 存在しない (DB 操作はすべて `dbAccess` + `operation` で表現する。細分化は本 ISSUE #1066 で採用しないと決定)
 
 **マッピング**:
 - DB 操作 → **すべて `kind: "dbAccess"`** + `operation: "SELECT|INSERT|UPDATE|DELETE|MERGE|LOCK"` + `tableId` (Uuid) + 完全 `sql`
@@ -619,21 +618,21 @@ ProcessFlow 側 (`pf-load-cities`) で API 呼び出し + `displayUpdate` で項
 }
 ```
 
-#### ✨ Alternative — RFC 将来 schema 案 (#1060 確定後)
+#### ✅ componentCall — Generic Definition Catalog の component-definition 呼び出し (#1066 で AJV gate 対象化)
 
-`kind: "componentCall"` + `exceptionTypeRef` + 簡易 inline 構文が schema に追加されたら以下に migrate (現在 AJV 落ちるため **生成しない**):
+`kind: "componentCall"` は #1066 で schema に追加済。Generic Definition Catalog の `component-definition` を参照する場合に使用する:
 
 ```jsonc
-// 【RFC 将来案・現状不可】
 {
   "id": "step-04",
   "kind": "componentCall",
+  "description": "メール送信コンポーネント呼び出し",
   "componentRef": "generic-definitions/component-definition/MailComponent",
   "operation": "send"
 }
 ```
 
-このパターンは [`generic-definition-layer.md` §3.3](generic-definition-layer.md) で提案中、子 ISSUE で schema 拡張予定。
+このパターンは [`generic-definition-layer.md` §3.3](generic-definition-layer.md) に記載。`commonProcess` (他 ProcessFlow への参照) と混同しないこと。
 
 **落とし方 hints (✅ 現行)**:
 - 「共通処理: X.Y(...)」→ `kind: "commonProcess"` + `refId` (呼び先 ProcessFlow Uuid) + `argumentMapping`
@@ -661,6 +660,7 @@ ProcessFlow 側 (`pf-load-cities`) で API 呼び出し + `displayUpdate` で項
 | `dbAccess` | `tableId`, `operation` | DB 操作 (`sql` は任意だが現行ほぼ必須) |
 | `externalSystem` | `systemRef` | 外部システム呼び出し |
 | `commonProcess` | `refId` | 他 ProcessFlow 呼び出し |
+| `componentCall` | `componentRef` | Generic Definition Catalog の component-definition 呼び出し (#1066) |
 | `screenTransition` | `targetScreenId` | 画面遷移 |
 | `displayUpdate` | `target` | 画面表示更新 |
 | `branch` | `branches` (各 Branch: `id`/`code`/`condition`/`steps`、ElseBranch: `id`/`code`/`steps`、BranchCondition.kind により `expression`/`errorCode`/`outcome` 等が追加必須) | 条件分岐 |
@@ -703,19 +703,19 @@ spec 編集者の記憶に頼って書き換えない。不確実な場合は必
 
 ### ✨ §3.4 〜 §3.7 についての注記 (必読)
 
-以下 §3.4 (exception-model) / §3.5 (class-definition) / §3.6 (frontend-script) / §3.7 (configuration-class) はすべて **`generic-definitions/<kind>/*.json` 配下への出力**。親 schema (#1063) で AJV 検証対象。data-contract / domain-type の kind 別 schema は #1064 で導入済、残 6 kind (exception-type / application-rule / ui-behavior / runtime-policy / component-definition / ui-fragment) は #1066-#1068 で順次。
+以下 §3.4 (exception-model) / §3.5 (class-definition) / §3.6 (frontend-script) / §3.7 (configuration-class) はすべて **`generic-definitions/<kind>/*.json` 配下への出力**。親 schema (#1063) で AJV 検証対象。data-contract / domain-type の kind 別 schema は #1064 で導入済、exception-type の kind 別 schema は #1066 で導入済、残 5 kind (application-rule / ui-behavior / runtime-policy / component-definition / ui-fragment) は #1067-#1068 で順次。
 
 **例の読み方 — 2 fence split 契約**:
 
 各 §3.4-§3.7 は **2 種類の fence** を提示する:
 
 1. **✅ 現状 (#1063 適合形)** — 親 schema (`kind` / `name` / `purpose` / `responsibilities` / `targets` + 任意の `relations` / `fields` / `operations` / `constraints` / `mappingHints`) のみで構成。親 schema は `unevaluatedProperties: false` のため **kind 固有 field を含めると AJV reject される**。AI は本形式で **そのまま `generic-definitions/<kind>/<Name>.json` に保存** する。
-2. **✨ 残 kind (#1066-#1068 以降の追加 field)** — `semanticKind` / `recoverable` / `trigger` / `effects` / `rules` 等の kind 固有 field のシグナル (exception-type / application-rule / ui-behavior 等)。AI は元 MD から抽出した情報を **`description` 内に構造化文字列として退避** (§0.5 (a))、audit に warning `rfc_future_field_skipped` を kind 別件数で記録する。#1066-#1068 で対応する kind 別 schema が確定したら、これら field が AJV validation 対象に追加される。(data-contract / domain-type の kind 別 schema は #1064 で導入済)
+2. **✨ 残 kind (#1067-#1068 以降の追加 field)** — `semanticKind` / `recoverable` / `trigger` / `effects` / `rules` 等の kind 固有 field のシグナル (application-rule / ui-behavior / runtime-policy / component-definition / ui-fragment 等)。AI は元 MD から抽出した情報を **`description` 内に構造化文字列として退避** (§0.5 (a))、audit に warning `rfc_future_field_skipped` を kind 別件数で記録する。#1067-#1068 で対応する kind 別 schema が確定したら、これら field が AJV validation 対象に追加される。(data-contract / domain-type は #1064、exception-type は #1066 で kind 別 schema 導入済)
 
 **現状の扱い**:
 - `examples/<project>/<dataDir>/generic-definitions/<kind>/<name>.json` ファイルに書き出す (実例: `examples/retail/harmony/generic-definitions/data-contract/OrderForm.json` 等、#1063 で 3 件配置済)
 - 現行 loader はまだ読まない (UI 統合は #1069 で順次対応、それまでは設計資産として保存のみ)
-- **AJV 検証**: 親 schema の共通メタモデルは検証対象 (`scripts/spec-check/test.mjs` § 3b)。data-contract / domain-type kind 別 schema は #1064 で AJV gate 対象化済 (test.mjs § 3c で kind 別 dispatch)、残 6 kind は #1066-#1068 で追加
+- **AJV 検証**: 親 schema の共通メタモデルは検証対象 (`scripts/spec-check/test.mjs` § 3b)。data-contract / domain-type kind 別 schema は #1064、exception-type kind 別 schema は #1066 で AJV gate 対象化済 (test.mjs § 3c で kind 別 dispatch)、残 5 kind は #1067-#1068 で追加
 - 物理配置 (path ↔ kind 一致) は `scripts/spec-check/lint-generic-definitions.mjs` で soft lint
 - 親 schema にマッチしない kind 固有 field を生成しようとした場合は audit に **warning `rfc_future_field_skipped`** を kind 別件数で残す
 
@@ -723,7 +723,7 @@ JSON 構造は [`generic-definition-layer.md` §4.1 共通メタモデル](gener
 
 ---
 
-### 3.4 `exception-model` → generic-definitions/exception-type (✨ RFC 将来案)
+### 3.4 `exception-model` → generic-definitions/exception-type (#1066 で kind 別 schema AJV gate 対象化済)
 
 **Before**:
 ```markdown
@@ -774,9 +774,9 @@ JSON 構造は [`generic-definition-layer.md` §4.1 共通メタモデル](gener
 }
 ```
 
-**✨ #1066 以降の追加 field (exception-type)** (現状は AJV reject、`description` 退避 + audit warning `rfc_future_field_skipped`):
+**✨ 将来追加予定の kind 固有 field (exception-type)** (現状は kind 別 schema に未追加、`description` 退避 + audit warning `rfc_future_field_skipped`):
 
-| MD 記述 | 退避先 field (#1066 で AJV 対象化予定) | 値の例 |
+| MD 記述 | 将来追加候補 field | 値の例 |
 |---|---|---|
 | 「種別: 業務エラー / 業務中断 / 検証エラー / 認証エラー / 認可エラー / 競合 / システムエラー」 | `semanticKind` | `"validation-error"` / `"business-abort"` / `"auth-error"` 等 |
 | 「回復可能: yes/no」 | `recoverable` | `true` / `false` |
@@ -784,7 +784,7 @@ JSON 構造は [`generic-definition-layer.md` §4.1 共通メタモデル](gener
 
 **落とし方 hints**:
 - 「親: X」→ `relations[].kind = "extends"` (親 schema 対応済、現状適合形に含める)
-- 「種別」/「回復可能」/「既定処理」→ ✨ kind 固有 field (#1066 で AJV 対象化予定、それまで `description` 退避)
+- 「種別」/「回復可能」/「既定処理」→ 将来 kind 固有 field (現在は `description` 退避 + audit warning)
 
 ### 3.5 `class-definition` → data-contract or domain-type (✨ RFC 将来案)
 
@@ -990,7 +990,7 @@ enum / コード値は `conventions/codeMaster` または `extensions/<namespace
 | `exception_semantic_kind_undecided` | §3.4 で semanticKind 推測不能 | warning |
 | `data_contract_kind_undecided` | §3.5 で data-contract vs domain-type 判定不能 | warning |
 | `commonprocess_ref_unresolved` | §3.3 ✅ 現行形の `commonProcess` step の `refId` (呼び先 ProcessFlow Uuid) が未定義 | error |
-| `rfc_future_field_skipped` | RFC 将来 schema 案 (componentCall / exceptionTypeRef / generic-definitions の残 6 kind 等、#1066 以降想定) を生成しようとした際、現行 schema に未対応のため `description` 退避 or 別ディレクトリ書き出しに切り替えた。**binding / events.effects は #1065 で導入済のため本 warning 対象外** | warning |
+| `rfc_future_field_skipped` | RFC 将来 schema 案 (generic-definitions の残 5 kind 固有 field 等、#1067-#1068 以降想定) を生成しようとした際、現行 schema に未対応のため `description` 退避 or 別ディレクトリ書き出しに切り替えた。**binding / events.effects は #1065 で導入済、componentCall / exceptionTypeRef / exception-type は #1066 で導入済のため本 warning 対象外** | warning |
 
 ### 5.3 audit summary
 
@@ -1025,9 +1025,9 @@ MD が少数 (~数十ファイル) で更新もまれな場合の手順。
 3. **archetype 分類** — §2 アルゴリズムで各ファイルを分類、`unknown` は warning ログ
 4. **catalog 系から処理** — `pulldown-catalog` / `reference-catalog` を先に変換し、conventions を確立 (他 archetype の binding 解決に必要)
 5. **screen / processFlow / table** — §3.1-§3.3 の **✅ 現行 schema 適合形** で変換 (§0.5 参照)
-6. **generic-definitions** — §3.4-§3.7 の **✅ 現状適合形** で `examples/<project>/<dataDir>/generic-definitions/<kind>/*.json` に書き出し、AJV 検証必須 (親 schema + data-contract / domain-type は kind 別 schema #1064 で対象化済)。残 6 kind の kind 固有 field (✨ #1066-#1068 で対応予定) は `description` 退避 + audit warning `rfc_future_field_skipped` で kind 別件数記録
-7. **ProcessFlow `commonProcess` の link** — `refId` (呼び先 ProcessFlow Uuid) を解決、未解決は **error** `commonprocess_ref_unresolved` を audit に出す (§10 (A) hard gate 対象、warning ではないので review gate で必ず止まる)。RFC 将来案の `componentCall` ref は generic-definitions/ 側のみで保持 (現行 hard gate 対象外)
-8. **AJV 検証 (現行 schema 範囲)** — `schemas/v3/*.json` 配下で生成した JSON を AJV で検証。`generic-definitions/<kind>/*.json` は親 schema (`generic-definition.v3.schema.json`) で共通メタモデル検証 + data-contract / domain-type は kind 別 schema (#1064) で strict 検証。残 6 kind の kind 別 schema は #1066-#1068 の子 ISSUE 完了後に追加 (§10 (A)/(B) 参照)
+6. **generic-definitions** — §3.4-§3.7 の **✅ 現状適合形** で `examples/<project>/<dataDir>/generic-definitions/<kind>/*.json` に書き出し、AJV 検証必須 (親 schema + data-contract / domain-type は kind 別 schema #1064 で対象化済、exception-type は #1066 で対象化済)。残 5 kind の kind 固有 field (✨ #1067-#1068 で対応予定) は `description` 退避 + audit warning `rfc_future_field_skipped` で kind 別件数記録
+7. **ProcessFlow `commonProcess` / `componentCall` の link** — `commonProcess.refId` (呼び先 ProcessFlow Uuid) を解決、未解決は **error** `commonprocess_ref_unresolved` を audit に出す (§10 (A) hard gate 対象)。`componentCall.componentRef` は `generic-definitions/component-definition/<Name>` 形式で schema gate 対象化済 (#1066)
+8. **AJV 検証 (現行 schema 範囲)** — `schemas/v3/*.json` 配下で生成した JSON を AJV で検証。`generic-definitions/<kind>/*.json` は親 schema (`generic-definition.v3.schema.json`) で共通メタモデル検証 + data-contract / domain-type は kind 別 schema (#1064) で、exception-type は kind 別 schema (#1066) で strict 検証。残 5 kind の kind 別 schema は #1067-#1068 の子 ISSUE 完了後に追加 (§10 (A)/(B) 参照)
 9. **audit summary** — §5.3 形式で出力、PR description に貼る (`rfc_future_field_skipped` の kind 別件数を含む)
 10. **完了判定** — §10 (A) hard gate を全件パス、§10 (B) soft gate は warning として残す
 
@@ -1517,7 +1517,7 @@ MD が ~30 ファイル以下 ?
    ```
 - [ ] coverage (project ごとの基準、未指定なら screen-controller / service-flow-spec / reference-catalog の 95% 以上)
 - [ ] ScreenItem binding metadata は **structured `binding` 優先 (#1065)**、`missing_binding_source` 0 件。legacy `[binding.v1]` description sentinel は migration script (`scripts/migrate-binding-v1-to-structured.mjs --apply`) で変換推奨
-- [ ] ProcessFlow step kind が `schemas/v3/process-flow.v3.schema.json#/$defs/Step` oneOf の 24 variant (`validation` / `dbAccess` / `externalSystem` / `commonProcess` / `screenTransition` / `displayUpdate` / `branch` / `loop` / `loopBreak` / `loopContinue` / `jump` / `compute` / `return` / `log` / `audit` / `workflow` / `transactionScope` / `eventPublish` / `eventSubscribe` / `closing` / `cdc` / `aiCall` / `aiAgent` / `extension`) のみ。`expression` / `tryCatch` (BranchCondition kind) / `auditLog` (CDC 出力先 kind) を Step として使っていないこと
+- [ ] ProcessFlow step kind が `schemas/v3/process-flow.v3.schema.json#/$defs/Step` oneOf の 25 variant (`validation` / `dbAccess` / `externalSystem` / `commonProcess` / `componentCall` / `screenTransition` / `displayUpdate` / `branch` / `loop` / `loopBreak` / `loopContinue` / `jump` / `compute` / `return` / `log` / `audit` / `workflow` / `transactionScope` / `eventPublish` / `eventSubscribe` / `closing` / `cdc` / `aiCall` / `aiAgent` / `extension`) のみ。`expression` / `tryCatch` (BranchCondition kind) / `auditLog` (CDC 出力先 kind) を Step として使っていないこと
 - [ ] ProcessFlow `commonProcess` step の `refId` が全件解決済 (生成した ProcessFlow と一致)
 - [ ] ProcessFlow `validation` step の `inlineBranch.ng[]` 内 `return` の `responseId` が Action.responses[].id と一致、対応する error code が `context.catalogs.errors.<CODE>` に登録済
 - [ ] `unknown` archetype 0 件 (もしくは設計者承認済)
@@ -1527,9 +1527,9 @@ MD が ~30 ファイル以下 ?
 
 以下は **AJV gate 部分通過 + 残部分は warning として記録**、draft-state policy ([`draft-state-policy.md`](draft-state-policy.md)) に従って保存:
 
-- `examples/<project>/<dataDir>/generic-definitions/<kind>/*.json` 配下の出力 — **親 schema + data-contract / domain-type kind 別 schema は AJV gate 対象** (#1063 + #1064)、残 6 kind の kind 別 schema は #1066-#1068 で追加。loader 取り込み (UI) は #1069 で対応
-- `description` 内に埋め込んだ ✨ RFC binding metadata / UI effects / componentCall ref / exceptionTypeRef
-- audit warning `rfc_future_field_skipped` で kind 固有 field の件数を記録 (親 schema 部分は通過想定)
+- `examples/<project>/<dataDir>/generic-definitions/<kind>/*.json` 配下の出力 — **親 schema + data-contract / domain-type / exception-type kind 別 schema は AJV gate 対象** (#1063 + #1064 + #1066)、残 5 kind の kind 別 schema は #1067-#1068 で追加。loader 取り込み (UI) は #1069 で対応
+- `description` 内に埋め込んだ ✨ RFC binding metadata / UI effects (binding / effects は #1065 で AJV gate 対象化済、componentCall / exceptionTypeRef は #1066 で AJV gate 対象化済)
+- audit warning `rfc_future_field_skipped` で残 5 kind 固有 field の件数を記録 (親 schema 部分は通過想定)
 
 **AJV gate (親 schema) + soft lint の併用** ([`scripts/spec-check/lint-generic-definitions.mjs`](../../scripts/spec-check/lint-generic-definitions.mjs) + `scripts/spec-check/test.mjs` § 3b):
 

--- a/docs/spec/generic-definition-layer.md
+++ b/docs/spec/generic-definition-layer.md
@@ -111,37 +111,35 @@
 
 **判断**: `event` 配下に `effects[]` を追加。既存 `handlerFlowId` は維持し、effect の一種扱いにはしない (UI ローカル効果と処理起動は概念分離)。
 
-### 3.3 ProcessFlow の internal reusable call 抽象
+### 3.3 ProcessFlow の internal reusable call 抽象 (#1066 で AJV gate 対象化済)
 
-**現状の不足**: DB / external / AI / TX などの step kind はあるが、「内部共通処理」「共有コンポーネント」「ドメインサービス呼び出し」を first-class に参照する抽象が弱い。
+**追加済**: `#1066` で ProcessFlow に `componentCall` step kind を追加。Generic Definition Catalog の `component-definition` を参照する。
 
-**追加候補**: step kind に `componentCall` を追加し、Generic Definition Catalog の `component-definition` を参照する。
-
-```json
+```jsonc
+// generic-definitions/component-definition/<Name>.json を componentRef で参照
 {
+  "id": "step-01",
   "kind": "componentCall",
-  "componentRef": "validators/customer-input-validator",
-  "inputs": { ... },
-  "outputs": { ... }
+  "description": "OrderValidator コンポーネントで入力検証",
+  "componentRef": "generic-definitions/component-definition/OrderValidator",
+  "operation": "validate",
+  "argumentMapping": { "order": "@inputs.order" },
+  "returnMapping": { "errors": "validationErrors" }
 }
 ```
 
-**判断**: schema 追加が必要。既存の `compute` step + 説明文への退避をやめ、共有ロジックの責務分割を formal にする。
+**判断確定**: schema に追加済 (#1066)。既存の `compute` step + 説明文への退避をやめ、共有ロジックの責務分割を formal にした。`componentRef` pattern は `^generic-definitions/component-definition/[A-Za-z][A-Za-z0-9_]*$` で AJV gate 対象化済。
 
-### 3.4 ProcessFlow の error semantics 拡張
+### 3.4 ProcessFlow の error semantics 拡張 (#1066 で AJV gate 対象化済)
 
-**現状の不足**: `errorCode` catalog や response はあるが、設計書では以下も必要:
+**追加済**: `#1066` で `exception-type` kind 別 schema を新設し、ProcessFlow の `ErrorCatalogEntry` / `ValidationRule` に `exceptionTypeRef` フィールドを追加。
 
-- 失敗種別 (business-abort / validation-error / authentication-error / system-error)
-- recoverable / non-recoverable
-- 中断 / 継続 / 再試行可否
-- 上位へ返す意味
-- 既定ハンドリングポリシー
-- UI message 変換方針
+- `ErrorCatalogEntry.exceptionTypeRef` — errorCode が業務例外として上位レイヤへ伝達される際の意味論を catalog 側に保持
+- `ValidationRule.exceptionTypeRef` — severity='error' 時に違反を業務例外として throw する際の意味論を catalog から引く
 
-**追加候補**: Generic Definition Catalog の `exception-type` を導入し、`errorCode` 側から `exceptionTypeRef` で参照する。
+`exceptionTypeRef` pattern は `^generic-definitions/exception-type/[A-Za-z][A-Za-z0-9_]*$` で AJV gate 対象化済。
 
-**判断**: 階層 (parent / children) と semantic kind は Catalog 側に置き、ProcessFlow からは ref のみ。
+**判断確定**: 階層 (parent / children) と semantic kind は Catalog 側 (`exception-type`) に置き、ProcessFlow からは ref のみ。失敗種別 (business-abort / validation-error 等) / recoverable / defaultHandling 等の kind 固有 field は将来 ISSUE で kind 別 schema に追加予定。
 
 ### 3.5 再利用 named contract の参照導線
 
@@ -335,8 +333,8 @@ P0 内部の切り出し順序は **下層が上層に依存しない依存順**
 
 ### P1
 
-5. ProcessFlow `componentCall` step + `component-definition` (Layer 1 §3.3 + Layer 2)
-6. `exception-type` catalog + ProcessFlow error semantics 拡張 (Layer 1 §3.4 + Layer 2)
+5. ✅ ProcessFlow `componentCall` step + `component-definition` (Layer 1 §3.3 + Layer 2) — **#1066 で AJV gate 対象化済**
+6. ✅ `exception-type` catalog + ProcessFlow error semantics 拡張 (Layer 1 §3.4 + Layer 2) — **#1066 で AJV gate 対象化済**
 7. `ui-fragment` catalog + `screen.fragments` 参照 (Layer 1 §3.6 + Layer 2)
 
 ### P2
@@ -394,8 +392,8 @@ P0 内部の切り出し順序は **下層が上層に依存しない依存順**
 | 2 | data-contract / domain-type catalog schema | `schemas/v3/generic-definitions/data-contract.v3.schema.json` 等 | 単独 ISSUE (子 2)、子 1 完了後着手 | 子 2 → #1064 |
 | 3 | ScreenItem `binding` 構造化拡張 | `schemas/v3/screen-item.v3.schema.json` 変更 | 単独 ISSUE (子 3)、子 2 完了後着手 | 子 3 → #1065 |
 | 4 | ScreenItemEvent `effects[]` 拡張 | 同 schema 変更 | 子 3 と統合 (同 schema / 同画面項目領域、鉄則 3 同根統合) | (子 3 に統合) |
-| 5 | ProcessFlow `componentCall` step kind + component-definition + DB step `dbQuery/Insert/Update` 細分化検討 | `schemas/v3/process-flow.v3.schema.json` 変更 | 単独 ISSUE (子 4)、子 2 完了後着手 | 子 4 → #1066 |
-| 6 | exception-type catalog + ProcessFlow error semantics 拡張 | 同上 + catalog 新設 | 子 4 と統合 (同 schema / error 領域、鉄則 3) | (子 4 に統合) |
+| 5 | ProcessFlow `componentCall` step kind + component-definition + DB step `dbQuery/Insert/Update` 細分化検討 (→ 細分化は採用しないと決定) | `schemas/v3/process-flow.v3.schema.json` 変更 | 単独 ISSUE (子 4)、子 2 完了後着手 | 子 4 → #1066 **完了済 (本 PR でマージ)** |
+| 6 | exception-type catalog + ProcessFlow error semantics 拡張 | 同上 + catalog 新設 | 子 4 と統合 (同 schema / error 領域、鉄則 3) | (子 4 に統合) **完了済 (#1066)** |
 | 7 | ui-fragment catalog + `screen.fragments[]` | `schemas/v3/screen.v3.schema.json` 変更 + catalog 新設 | 単独 ISSUE (子 5)、子 2 完了後着手 | 子 5 → #1067 |
 | 8 | application-rule / runtime-policy / ui-behavior catalog | catalog 各 schema 新設 | 単独 ISSUE (子 6)、子 2 完了後着手 | 子 6 → #1068 |
 | 9 | UI 側の表示・編集対応 (新規 catalog 種別ごとの ListView / Editor) | frontend | 単独 ISSUE (子 7)、子 2-6 完了後着手 | 子 7 → #1069 |

--- a/frontend/src/types/v3/process-flow.ts
+++ b/frontend/src/types/v3/process-flow.ts
@@ -102,6 +102,8 @@ export interface ErrorCatalogEntry {
   /** Action.responses[].id 参照。 */
   responseId?: LocalId;
   description?: Description;
+  /** Generic Definition Catalog の exception-type 参照 (#1066)。形式: 'generic-definitions/exception-type/<Name>'。 */
+  exceptionTypeRef?: string;
 }
 
 /** 外部システム認証定義 (旧 ENV: / SECRET: 形式は v3 廃止、@secret.<key> 推奨)。 */
@@ -182,6 +184,8 @@ export interface ValidationRule {
   condition?: ExpressionString;
   /** 違反メッセージ (`@conv.msg.<key>` 推奨)。 */
   message?: string;
+  /** Generic Definition Catalog の exception-type 参照 (#1066)。形式: 'generic-definitions/exception-type/<Name>'。severity='error' 時に違反を業務例外として throw する際の意味論を catalog から引く。 */
+  exceptionTypeRef?: string;
 }
 
 /** ドメイン型 catalog エントリ。 */
@@ -577,6 +581,20 @@ export interface CommonProcessStep extends StepBaseProps {
   returnMapping?: Record<string, string>;
 }
 
+/** ProcessFlow 内で Generic Definition Catalog の component-definition を呼び出す step (#1066)。 */
+export interface ComponentCallStep extends StepBaseProps {
+  kind: "componentCall";
+  description: Description;
+  /** Generic Definition Catalog の component-definition への参照 (例: "generic-definitions/component-definition/OrderValidator")。 */
+  componentRef: string;
+  /** 呼び出す operation 名 (component-definition の operations[].name と一致)。 */
+  operation?: string;
+  /** 呼び先 inputs 名 → 引数式の対応。 */
+  argumentMapping?: Record<string, ExpressionString>;
+  /** 呼び先 outputs 名 → 説明 / バインド先の対応。 */
+  returnMapping?: Record<string, string>;
+}
+
 export interface ScreenTransitionStep extends StepBaseProps {
   kind: "screenTransition";
   description: Description;
@@ -865,6 +883,7 @@ export type Step =
   | DbAccessStep
   | ExternalSystemStep
   | CommonProcessStep
+  | ComponentCallStep
   | ScreenTransitionStep
   | DisplayUpdateStep
   | BranchStep

--- a/schemas/v3/generic-definitions/exception-type.v3.schema.json
+++ b/schemas/v3/generic-definitions/exception-type.v3.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/csilost2001/harmony/main/schemas/v3/generic-definitions/exception-type.v3.schema.json",
   "title": "Exception Type (v3 generic-definition kind: exception-type)",
-  "description": "Generic Definition Catalog の exception-type kind 固有 schema。親 schema (../generic-definition.v3.schema.json、#1063) を `allOf` 継承し、`kind` を const \"exception-type\" に固定。exception-type は例外種別・階層・semantic kind を表す。ProcessFlow の errorCode catalog から `exceptionTypeRef` で参照される (#1066)。kind 固有 field は親 schema の `fields[]` / `relations[]` / `constraints[]` で表現する。将来的に semanticKind / recoverable / defaultHandling 等の kind 固有 field を追加する余地は残す (#1066 以降)。仕様: docs/spec/generic-definition-layer.md §4.2。",
+  "description": "Generic Definition Catalog の exception-type kind 固有 schema。親 schema (../generic-definition.v3.schema.json、#1063) を `allOf` 継承し、`kind` を const \"exception-type\" に固定。exception-type は例外種別・階層・semantic kind を表す。ProcessFlow の errorCode catalog から `exceptionTypeRef` で参照される (#1066)。kind 固有 field は親 schema の `fields[]` / `relations[]` / `constraints[]` で表現する。将来的に semanticKind / recoverable / defaultHandling 等の kind 固有 field を追加する余地は残す (#1067 以降)。仕様: docs/spec/generic-definition-layer.md §4.2。",
   "type": "object",
   "allOf": [
     { "$ref": "../generic-definition.v3.schema.json" }

--- a/schemas/v3/generic-definitions/exception-type.v3.schema.json
+++ b/schemas/v3/generic-definitions/exception-type.v3.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/csilost2001/harmony/main/schemas/v3/generic-definitions/exception-type.v3.schema.json",
+  "title": "Exception Type (v3 generic-definition kind: exception-type)",
+  "description": "Generic Definition Catalog の exception-type kind 固有 schema。親 schema (../generic-definition.v3.schema.json、#1063) を `allOf` 継承し、`kind` を const \"exception-type\" に固定。exception-type は例外種別・階層・semantic kind を表す。ProcessFlow の errorCode catalog から `exceptionTypeRef` で参照される (#1066)。kind 固有 field は親 schema の `fields[]` / `relations[]` / `constraints[]` で表現する。将来的に semanticKind / recoverable / defaultHandling 等の kind 固有 field を追加する余地は残す (#1066 以降)。仕様: docs/spec/generic-definition-layer.md §4.2。",
+  "type": "object",
+  "allOf": [
+    { "$ref": "../generic-definition.v3.schema.json" }
+  ],
+  "properties": {
+    "kind": { "const": "exception-type" }
+  }
+}

--- a/schemas/v3/process-flow.v3.schema.json
+++ b/schemas/v3/process-flow.v3.schema.json
@@ -183,7 +183,12 @@
         "httpStatus": { "type": "integer", "minimum": 100, "maximum": 599 },
         "defaultMessage": { "type": "string" },
         "responseId": { "$ref": "common.v3.schema.json#/$defs/LocalId", "description": "Action.responses[].id 参照。" },
-        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" },
+        "exceptionTypeRef": {
+          "type": "string",
+          "pattern": "^generic-definitions/exception-type/[A-Za-z][A-Za-z0-9_]*$",
+          "description": "Generic Definition Catalog の exception-type 参照 (#1066)。形式: 'generic-definitions/exception-type/<Name>'。errorCode が業務例外として上位レイヤへ伝達される際の意味論 (recoverable / non-recoverable, handling 方針) を catalog 側に保持する。"
+        }
       }
     },
 
@@ -527,12 +532,13 @@
     },
 
     "Step": {
-      "description": "Step union。kind プロパティで variant を識別。組み込み 23 variant + ExtensionStep の計 24 variant。ExtensionStep は kind にパターン (namespace:StepName) を取るため AJV `discriminator: true` の strict const 要件を満たさず、本 oneOf には discriminator keyword を付けない (#525 F-4 limitation)。Step.kind ミスマッチ時のエラー読みやすさは AJV `allErrors: true` + 上位 UI 側でフィルタ推奨。",
+      "description": "Step union。kind プロパティで variant を識別。組み込み 24 variant + ExtensionStep の計 25 variant。ExtensionStep は kind にパターン (namespace:StepName) を取るため AJV `discriminator: true` の strict const 要件を満たさず、本 oneOf には discriminator keyword を付けない (#525 F-4 limitation)。Step.kind ミスマッチ時のエラー読みやすさは AJV `allErrors: true` + 上位 UI 側でフィルタ推奨。",
       "oneOf": [
         { "$ref": "#/$defs/ValidationStep" },
         { "$ref": "#/$defs/DbAccessStep" },
         { "$ref": "#/$defs/ExternalSystemStep" },
         { "$ref": "#/$defs/CommonProcessStep" },
+        { "$ref": "#/$defs/ComponentCallStep" },
         { "$ref": "#/$defs/ScreenTransitionStep" },
         { "$ref": "#/$defs/DisplayUpdateStep" },
         { "$ref": "#/$defs/BranchStep" },
@@ -563,6 +569,7 @@
         { "$ref": "#/$defs/DbAccessStep" },
         { "$ref": "#/$defs/ExternalSystemStep" },
         { "$ref": "#/$defs/CommonProcessStep" },
+        { "$ref": "#/$defs/ComponentCallStep" },
         { "$ref": "#/$defs/ScreenTransitionStep" },
         { "$ref": "#/$defs/DisplayUpdateStep" },
         { "$ref": "#/$defs/BranchStep" },
@@ -628,7 +635,12 @@
         "lengthRef": { "type": "string", "description": "@conv.limit.<key> 参照 (length の代替)。loader が integer 値に展開する。" },
         "values": { "type": "array", "items": { "type": "string" } },
         "condition": { "$ref": "common.v3.schema.json#/$defs/ExpressionString" },
-        "message": { "type": "string", "description": "違反メッセージ (@conv.msg.<key> 推奨)。" }
+        "message": { "type": "string", "description": "違反メッセージ (@conv.msg.<key> 推奨)。" },
+        "exceptionTypeRef": {
+          "type": "string",
+          "pattern": "^generic-definitions/exception-type/[A-Za-z][A-Za-z0-9_]*$",
+          "description": "Generic Definition Catalog の exception-type 参照 (#1066)。形式: 'generic-definitions/exception-type/<Name>'。severity='error' 時に違反を業務例外として throw する際の意味論を catalog から引く。"
+        }
       }
     },
 
@@ -1164,6 +1176,41 @@
           "properties": {
             "kind": { "const": "commonProcess" },
             "refId": { "$ref": "common.v3.schema.json#/$defs/Uuid", "description": "呼び出し先 ProcessFlow の Uuid (kind='common' の他フロー)。" },
+            "argumentMapping": {
+              "type": "object",
+              "additionalProperties": { "$ref": "common.v3.schema.json#/$defs/ExpressionString" },
+              "description": "呼び先 inputs 名 → 引数式の対応。"
+            },
+            "returnMapping": {
+              "type": "object",
+              "additionalProperties": { "type": "string" },
+              "description": "呼び先 outputs 名 → 説明 / バインド先の対応。"
+            }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+
+    "ComponentCallStep": {
+      "allOf": [
+        { "$ref": "#/$defs/StepBaseProps" },
+        {
+          "type": "object",
+          "required": ["id", "kind", "description", "componentRef"],
+          "properties": {
+            "kind": { "const": "componentCall" },
+            "componentRef": {
+              "type": "string",
+              "pattern": "^generic-definitions/component-definition/[A-Za-z][A-Za-z0-9_]*$",
+              "description": "Generic Definition Catalog の component-definition への参照 (#1066)。形式: 'generic-definitions/component-definition/<Name>'。"
+            },
+            "operation": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 64,
+              "description": "呼び出す operation 名 (component-definition の operations[].name と一致)。"
+            },
             "argumentMapping": {
               "type": "object",
               "additionalProperties": { "$ref": "common.v3.schema.json#/$defs/ExpressionString" },

--- a/scripts/spec-check/test.mjs
+++ b/scripts/spec-check/test.mjs
@@ -58,7 +58,7 @@ console.log("\n## extract-step-required.mjs (full snapshot)");
   if (error) console.log(`  (spawn error: ${error.message})`);
   if (signal) console.log(`  (signal: ${signal})`);
   assert("exits 0", status === 0);
-  assert("Total: 24 step kinds output", /Total: 24 step kinds/.test(stdout));
+  assert("Total: 25 step kinds output", /Total: 25 step kinds/.test(stdout));
   assert("no `?` placeholder", !/^- `\?`/m.test(stdout), "kind 未解決の variant が残存");
 
   // schema から動的に 24 step variant の (kind, required - [id,kind,description]) を抽出
@@ -465,7 +465,7 @@ console.log("\n## generic-definition.v3.schema.json (AJV strict)");
 //     各 kind-specific schema は親 schema を allOf 継承し kind を const に固定。
 //     retail walk を kind 別 dispatch に改修して silent pass を防ぐ。
 // =============================================================================
-console.log("\n## kind-specific schema AJV strict gate (data-contract / domain-type, #1064)");
+console.log("\n## kind-specific schema AJV strict gate (data-contract / domain-type / exception-type, #1064 / #1066)");
 {
   const { default: Ajv2020 } = await import("ajv/dist/2020.js");
   const { default: addFormats } = await import("ajv-formats");
@@ -481,9 +481,11 @@ console.log("\n## kind-specific schema AJV strict gate (data-contract / domain-t
 
   const dcSchema = JSON.parse(readFileSync(join(ROOT, "schemas/v3/generic-definitions/data-contract.v3.schema.json"), "utf8"));
   const dtSchema = JSON.parse(readFileSync(join(ROOT, "schemas/v3/generic-definitions/domain-type.v3.schema.json"), "utf8"));
+  const etSchema = JSON.parse(readFileSync(join(ROOT, "schemas/v3/generic-definitions/exception-type.v3.schema.json"), "utf8"));
 
   const validateDataContract = ajv.compile(dcSchema);
   const validateDomainType = ajv.compile(dtSchema);
+  const validateExceptionType = ajv.compile(etSchema);
 
   // --- data-contract cases ---
   const dcCases = [
@@ -603,6 +605,92 @@ console.log("\n## kind-specific schema AJV strict gate (data-contract / domain-t
     }
   }
 
+  // --- exception-type cases ---
+  const etCases = [
+    {
+      name: "exception-type: minimum valid",
+      valid: true,
+      data: {
+        kind: "exception-type",
+        name: "StockInsufficientError",
+        purpose: "在庫不足エラー",
+        responsibilities: ["在庫不足を呼び出し側に伝える"],
+        targets: ["backend"],
+      },
+    },
+    {
+      name: "exception-type: kind 不一致 (data-contract) rejected",
+      valid: false,
+      data: {
+        kind: "data-contract",
+        name: "OrderForm",
+        purpose: "注文フォーム DTO",
+        responsibilities: ["入力保持"],
+        targets: ["backend"],
+      },
+    },
+    {
+      name: "exception-type: purpose 欠落 rejected",
+      valid: false,
+      data: {
+        kind: "exception-type",
+        name: "NoPurpose",
+        responsibilities: ["y"],
+        targets: ["backend"],
+      },
+    },
+    {
+      name: "exception-type: name pattern violation (starts with digit) rejected",
+      valid: false,
+      data: {
+        kind: "exception-type",
+        name: "1Invalid",
+        purpose: "x",
+        responsibilities: ["y"],
+        targets: ["backend"],
+      },
+    },
+  ];
+
+  for (const c of etCases) {
+    const ok = validateExceptionType(c.data);
+    if (c.valid) {
+      const detail = ok
+        ? ""
+        : (validateExceptionType.errors || []).slice(0, 3).map((e) => `${e.instancePath || "/"} ${e.message}`).join("; ");
+      assert(`✓ et valid: ${c.name}`, ok, detail);
+    } else {
+      assert(`✗ et invalid rejected: ${c.name}`, !ok);
+    }
+  }
+
+  // --- bidirectional sabotage: parent schema から exception-type を削除した copy で validate → fail ---
+  // [[feedback_drift_gate_bidirectional_sabotage]]: parent schema から exception-type を消した
+  // copy で kind-specific schema 側だけ validate → fail を確認 (片方向 only では sabotage 検出不可)
+  {
+    const gdSchemaCopy = JSON.parse(JSON.stringify(gdSchema));
+    // GenericDefinitionKind.enum から exception-type を除去
+    const kindEnum = gdSchemaCopy.$defs?.GenericDefinitionKind?.enum;
+    if (kindEnum && Array.isArray(kindEnum)) {
+      gdSchemaCopy.$defs.GenericDefinitionKind.enum = kindEnum.filter((k) => k !== "exception-type");
+    }
+    const ajv2 = new Ajv2020({ strict: false, allErrors: true });
+    addFormats(ajv2);
+    ajv2.addSchema(commonSchema);
+    ajv2.addSchema(gdSchemaCopy, "../generic-definition.v3.schema.json");
+    const etSchemaCopy = JSON.parse(JSON.stringify(etSchema));
+    const validateEt2 = ajv2.compile(etSchemaCopy);
+    const validData = {
+      kind: "exception-type",
+      name: "StockInsufficientError",
+      purpose: "在庫不足エラー",
+      responsibilities: ["在庫不足を呼び出し側に伝える"],
+      targets: ["backend"],
+    };
+    const sabotageOk = validateEt2(validData);
+    assert("bidirectional sabotage: exception-type removed from parent → kind-specific schema rejects", !sabotageOk);
+  }
+
   // --- retail walk: kind 別 dispatch ---
   // ファイル path から kind を抽出して kind 別 schema で validate する。
   // 未知の kind は silent pass を防ぐため fail させる。
@@ -619,10 +707,11 @@ console.log("\n## kind-specific schema AJV strict gate (data-contract / domain-t
       return out;
     }
 
-    // kind → validator map (本 PR 対象の 2 kind)
+    // kind → validator map (data-contract / domain-type #1064、exception-type #1066)
     const kindValidators = {
       "data-contract": validateDataContract,
       "domain-type": validateDomainType,
+      "exception-type": validateExceptionType,
     };
 
     const sampleFiles2 = walk2(retailGdRoot2);
@@ -1000,6 +1089,166 @@ console.log("\n## migrate-binding-v1-to-structured.mjs fixture test (#1065)");
 }
 
 // =============================================================================
+// 3f. process-flow.v3.schema.json componentCall / exceptionTypeRef AJV gate (#1066)
+//     ComponentCallStep (positive / negative 4 種) +
+//     ErrorCatalogEntry.exceptionTypeRef (positive / negative) +
+//     ValidationRule.exceptionTypeRef (positive / negative)
+// =============================================================================
+console.log("\n## process-flow.v3.schema.json componentCall / exceptionTypeRef strict gate (#1066)");
+{
+  const { default: Ajv2020 } = await import("ajv/dist/2020.js");
+  const { default: addFormats } = await import("ajv-formats");
+  const ajv3f = new Ajv2020({ strict: false, allErrors: true });
+  addFormats(ajv3f);
+  const commonSchema3f = JSON.parse(readFileSync(join(ROOT, "schemas/v3/common.v3.schema.json"), "utf8"));
+  const pfSchema = JSON.parse(readFileSync(join(ROOT, "schemas/v3/process-flow.v3.schema.json"), "utf8"));
+  ajv3f.addSchema(commonSchema3f);
+  const validatePf = ajv3f.compile(pfSchema);
+
+  // ── ComponentCallStep cases ───────────────────────────────────────────
+  // 共通の最小 ProcessFlow wrapper (actions[].steps[] に step を埋め込む)
+  function wrapStep(step) {
+    return {
+      $schema: "https://raw.githubusercontent.com/csilost2001/harmony/main/schemas/v3/process-flow.v3.schema.json",
+      meta: {
+        id: "ffffffff-0001-4000-8000-000000000001",
+        name: "テストフロー",
+        kind: "screen",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+      actions: [
+        {
+          id: "act-001",
+          name: "テストアクション",
+          trigger: "submit",
+          steps: [step],
+        },
+      ],
+    };
+  }
+
+  function assertPf(name, data, expectValid) {
+    const ok = validatePf(data);
+    if (expectValid) {
+      const detail = ok
+        ? ""
+        : (validatePf.errors || []).slice(0, 3).map((e) => `${e.instancePath || "/"} ${e.message}`).join("; ");
+      assert(`✓ pf valid: ${name}`, ok, detail);
+    } else {
+      assert(`✗ pf invalid rejected: ${name}`, !ok);
+    }
+  }
+
+  // positive: 必須 4 field 揃った componentCall
+  assertPf("componentCall positive (minimal)", wrapStep({
+    id: "step-01",
+    kind: "componentCall",
+    description: "OrderValidator コンポーネント呼び出し",
+    componentRef: "generic-definitions/component-definition/OrderValidator",
+  }), true);
+
+  // positive: all fields
+  assertPf("componentCall positive (all fields)", wrapStep({
+    id: "step-01",
+    kind: "componentCall",
+    description: "OrderValidator コンポーネント呼び出し",
+    componentRef: "generic-definitions/component-definition/OrderValidator",
+    operation: "validate",
+    argumentMapping: { "order": "@inputs.order" },
+    returnMapping: { "errors": "validationErrors" },
+  }), true);
+
+  // negative: componentRef pattern violation (must start with generic-definitions/component-definition/)
+  assertPf("componentCall negative (componentRef pattern violation)", wrapStep({
+    id: "step-01",
+    kind: "componentCall",
+    description: "不正 ref",
+    componentRef: "validators/customer-input-validator",
+  }), false);
+
+  // negative: operation 過大長 (> 64 chars)
+  assertPf("componentCall negative (operation over maxLength)", wrapStep({
+    id: "step-01",
+    kind: "componentCall",
+    description: "operation 超過",
+    componentRef: "generic-definitions/component-definition/OrderValidator",
+    operation: "a".repeat(65),
+  }), false);
+
+  // negative: unevaluatedProperties violation (extra field)
+  assertPf("componentCall negative (unevaluatedProperties extra field)", wrapStep({
+    id: "step-01",
+    kind: "componentCall",
+    description: "extra field",
+    componentRef: "generic-definitions/component-definition/OrderValidator",
+    extraField: "should-be-rejected",
+  }), false);
+
+  // negative: componentRef 欠落 (required violation)
+  assertPf("componentCall negative (componentRef missing)", wrapStep({
+    id: "step-01",
+    kind: "componentCall",
+    description: "componentRef 欠落",
+  }), false);
+
+  // ── ErrorCatalogEntry.exceptionTypeRef cases ──────────────────────────
+  function wrapErrorCatalog(exceptionTypeRef) {
+    return {
+      $schema: "https://raw.githubusercontent.com/csilost2001/harmony/main/schemas/v3/process-flow.v3.schema.json",
+      meta: {
+        id: "ffffffff-0001-4000-8000-000000000002",
+        name: "エラーカタログテスト",
+        kind: "screen",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+      context: {
+        catalogs: {
+          errors: {
+            STOCK_INSUFFICIENT: {
+              httpStatus: 409,
+              defaultMessage: "在庫不足",
+              exceptionTypeRef,
+            },
+          },
+        },
+      },
+      actions: [],
+    };
+  }
+
+  // positive: valid exceptionTypeRef
+  assertPf("ErrorCatalogEntry.exceptionTypeRef positive", wrapErrorCatalog("generic-definitions/exception-type/StockInsufficientError"), true);
+
+  // negative: pattern violation (invalid prefix)
+  assertPf("ErrorCatalogEntry.exceptionTypeRef negative (pattern violation)", wrapErrorCatalog("exception-types/StockInsufficientError"), false);
+
+  // ── ValidationRule.exceptionTypeRef cases ────────────────────────────
+  function wrapValidationRule(exceptionTypeRef) {
+    return wrapStep({
+      id: "step-01",
+      kind: "validation",
+      description: "入力検証",
+      rules: [
+        {
+          field: "quantity",
+          type: "range",
+          min: 1,
+          exceptionTypeRef,
+        },
+      ],
+    });
+  }
+
+  // positive: valid exceptionTypeRef in ValidationRule
+  assertPf("ValidationRule.exceptionTypeRef positive", wrapValidationRule("generic-definitions/exception-type/ValidationException"), true);
+
+  // negative: pattern violation in ValidationRule
+  assertPf("ValidationRule.exceptionTypeRef negative (pattern violation)", wrapValidationRule("exception-type/ValidationException"), false);
+}
+
+// =============================================================================
 // 4. spec doc 本体を input にした gate (Round 11 review M-1/M-2/M-3 対応)
 //    Round 11 で指摘された「test.mjs が spec doc を一切読まない → cheatsheet /
 //    jsonc fence / ✅ JSON 例の drift が CI gate を素通り」を解消する。
@@ -1094,7 +1343,7 @@ console.log("\n## ✅ 例 AJV validation against schemas/v3/");
 console.log("\n## §3.3 cheatsheet rows vs schema required (drift gate)");
 {
   const cheatsheet = parseStepCheatsheet(specDoc);
-  assert("cheatsheet has 24 step kind rows", cheatsheet.size === 24, `actual=${cheatsheet.size}`);
+  assert("cheatsheet has 25 step kind rows", cheatsheet.size === 25, `actual=${cheatsheet.size}`);
 
   const BASE = new Set(["id", "kind", "description"]);
   const stepUnion = $defs.Step.oneOf.map((r) => r.$ref.replace("#/$defs/", ""));


### PR DESCRIPTION
## Summary

ISSUE #1066 (#1060 子 4) — ProcessFlow に `componentCall` step kind 追加、Generic Definition Catalog の `exception-type` kind 別 schema 新設、`errorCode` / `validation` から `exception-type` への参照導線 (`exceptionTypeRef`) を追加。

設計コメント (Opus 先書き): https://github.com/csilost2001/harmony/issues/1066#issuecomment-4443361786

### 4 commit 構成

1. `fed590d` feat(schema) — `ComponentCallStep` を $defs に追加 (Step/NonReturnStep union 23→24 + ExtensionStep で計 25)、`ErrorCatalogEntry.exceptionTypeRef` / `ValidationRule.exceptionTypeRef` 追加、`exception-type.v3.schema.json` 新規 (`data-contract` と同パターン: 親 schema allOf 継承 + kind const 固定)
2. `3f48973` feat(types) — `ComponentCallStep` interface 追加、`ErrorCatalogEntry` / `ValidationRule` に `exceptionTypeRef?: string` 追加、Step union に追加 (TS は派生物として schema を追従)
3. `d9efda4` test(spec-check) — §3c に exception-type kindValidator + bidirectional sabotage assertion 追加、§3f 新設で ComponentCallStep + exceptionTypeRef AJV gate (positive + negative 多数)、step kind count assertion 24→25 更新
4. `eb6fa58` docs(spec) — `generic-definition-layer.md` §3.3/§3.4/§8/§12 を「完了済 (#1066)」反映、`conversion-guideline-for-ai.md` で `componentCall / exceptionTypeRef` を ✅ 現行に昇格、`dbQuery|dbInsert|dbUpdate` RFC 表記を削除 (本 ISSUE で「採用しない」と決定)

### DB step 細分化採否 (受け入れ条件 4)

**採用しない**。理由:

- 既存 `DbAccessStep.operation` enum (`SELECT / INSERT / UPDATE / DELETE / MERGE / LOCK`) で既に discriminated 済で codegen に十分
- 細分化すると Step union が増え `MERGE / LOCK` の扱いで二次論争発生、benefit が無い
- 既存 sample 移行コストが純粋な loss

判断は `docs/spec/conversion-guideline-for-ai.md` line 45, 468 に明記、warning `rfc_future_field_skipped` の対象からも除外済。

## 仕様逐条突合 (自己申告)

ISSUE 受け入れ条件:

- ✓ `commonProcess` step に加えて `componentCall` を追加 — `schemas/v3/process-flow.v3.schema.json:1195` (`ComponentCallStep` $def)、Step union `schemas/v3/process-flow.v3.schema.json:541` 追加
- ✓ `exception-type` catalog schema 新設 — `schemas/v3/generic-definitions/exception-type.v3.schema.json` (新規、13 行、`data-contract` 同パターン)
- ✓ `validation` step の `exceptionTypeRef` 参照導線 — `schemas/v3/process-flow.v3.schema.json:639` (`ValidationRule.exceptionTypeRef`) + `ErrorCatalogEntry.exceptionTypeRef` (line 187) で 2 経路
- ✓ DB step 細分化採否を決定 — **採用しない**、`docs/spec/conversion-guideline-for-ai.md:45,468` で明記

## 検証結果

- `node scripts/spec-check/test.mjs`: Pass **256**, Fail 0 (+19 from main の 237)
- `cd frontend && npx tsc --noEmit`: 0 errors
- `node scripts/spec-check/lint-generic-definitions.mjs examples/retail`: Linted 4, errors 0, warnings 0
- `git diff origin/main..HEAD -- schemas/`: 期待通り 2 ファイル (process-flow.v3 + exception-type.v3)、他 schema 未変更

## Schema governance 確認 (#511)

`git diff --name-only origin/main..HEAD -- schemas/`:
- `schemas/v3/process-flow.v3.schema.json` (additive: 1 step kind + 2 optional fields)
- `schemas/v3/generic-definitions/exception-type.v3.schema.json` (新規、親 schema 継承のみ)

両方とも meta #1060 (子 4) の設計者承認範囲。同シリーズの先行子 (#1063/#1064/#1065 すべて merged) と同パターン。

## Test plan

- [x] spec-check 全 pass (256/256)
- [x] tsc 0 errors
- [x] lint-generic-definitions on retail OK
- [x] schema diff scope 確認 (脱線無し)
- [x] 既存 sample (`StockInsufficientError.json` / `OrderValidator.json`) は AJV pass

Closes #1066
