### PR TITLE
docs(spec): Generic Definition Catalog の draft-state-policy / AJV 採用方針 follow-up (#1083 #1084)

### DIFF
--- a/docs/spec/draft-state-policy.md
+++ b/docs/spec/draft-state-policy.md
@@ -36,7 +36,7 @@ schema 変更は schema ガバナンス (#511) の対象であり、AI エージ
 
 各リソースは読み込み時に `validate<Resource>(item, allItems)` で検証する。単体項目だけで判定できない重複・参照整合性・リソース間関係は、必要な一覧を `allItems` として渡して判定する。
 
-store は一覧読み込みと同じ責務範囲で `load<Resource>ValidationMap()` を提供する。戻り値は `Map<Id, ValidationError[]>` とし、UI はこれを参照してバッジ・枠線・ヘッダー警告を描画する。
+各 store / UI は §5 のパターン A (`load<Resource>ValidationMap()` を提供) または パターン B (UI 側 inline 構築) のいずれかで validation 結果を UI に届ける。戻り値は `Map<Id, ValidationError[]>` 形式で統一し、UI はこれを参照してバッジ・枠線・ヘッダー警告を描画する。
 
 ### 2.4 違反は一覧と編集画面で示す
 
@@ -141,7 +141,7 @@ ListView / Editor 内で `validate<Resource>(item, allItems)` を直接呼び、
 - [ ] `<Resource>Validation.ts` を追加し、`validate<Resource>(item, allItems)` を提供する
 - [ ] 4 軸 severity 判定基準に照らして error / warning を分類する
 - [ ] validation の単体テストを追加し、error / warning の代表例を含める
-- [ ] store に `load<Resource>ValidationMap()` を追加する
+- [ ] §5 パターン A (store 関数化) を選んだ場合、store に `load<Resource>ValidationMap()` を追加する。パターン B (UI 側 inline 構築) を選んだ場合は省略する
 - [ ] ListView に `ValidationBadge` を表示する
 - [ ] カード表示または行表示に `has-error` / `has-warning` CSS クラスを付与する
 - [ ] Editor ヘッダーに `MaturityBadge` を表示し、`onChange` を接続する

--- a/docs/spec/draft-state-policy.md
+++ b/docs/spec/draft-state-policy.md
@@ -105,19 +105,34 @@ validation 表示の共通スタイルは `validation.css` に集約する。カ
 
 ## 5. Store responsibilities
 
-各 store は、一覧取得と同じ粒度で validation map を提供する。
+各 store は、validation 表示に必要な情報を UI に提供する。表示パターンは 2 つあり、リソース構造に応じて
+**いずれを採用してもよい**:
+
+### パターン A: store 関数化 (`load<Resource>ValidationMap()`)
 
 ```ts
 load<Resource>ValidationMap(): Promise<Map<Id, ValidationError[]>>
 ```
 
-validation map は、リソース ID を key、`ValidationError[]` を value とする。UI はリソース一覧と validation map を突き合わせ、バッジ・CSS クラス・編集画面ヘッダーの状態を描画する。
+- 適する: validation 結果を複数画面で再利用したい / 計算コストが高くキャッシュしたい / 1 RPC で bulk 取得できる場合
+- 例: `loadTableValidationMap()` / `loadViewValidationMap()` (#587 / PR #589)
 
 > **注**: `loadTableValidationMap()` / `loadViewValidationMap()` は backend が `listAllTables()` / `listAllViews()` を提供する場合 1 RPC で全件取得し、未提供時 (localStorage 等) は per-id にフォールバックする (#587 / PR #589 で実装)。bulk fetch 結果は harmony.json entries の ID で filter して orphan 互換性を維持する。
 
-ProcessFlow は既存の `aggregateValidation` を直接利用する。ProcessFlow 専用の validation 集約が既に存在するため、同じ判定を重複実装しない。
+### パターン B: UI 側 inline 構築
 
-> **運用差分**: ProcessFlow は構造が多階層 (action / step / nested branch / loop / transactionScope) なため、`load<Resource>ValidationMap()` 形式の単純 Map を store からは提供せず、UI 側 (例: `ProcessFlowListView.tsx`) で `aggregateValidation` を直接呼び出して action 単位や step 単位に集約する。新規リソース型が flat (View / Table) なら `loadValidationMap()` 形式、ネスト構造なら `aggregateValidation` 直接呼出形式を選ぶ。
+ListView / Editor 内で `validate<Resource>(item, allItems)` を直接呼び、Map を局所的に構築する。
+
+- 適する: ProcessFlow のような nested 構造で `aggregateValidation` を再利用する場合 / GenericDefinition のように
+  kind 別 instantiate されて store cache 効率が薄い場合 / validator が singleton 軽量で per-render 計算可能な場合
+- 例: `ProcessFlowListView.tsx` (`aggregateValidation` 直接呼び出し) / `GenericDefinitionListView.tsx` (kind 別 inline 構築)
+
+### 選択指針
+
+- **デフォルトは inline (パターン B)** — シンプル、新規 UI が即座に動く
+- **キャッシュ要件が顕在化したら store 関数化 (パターン A) へ移行** — 計算コスト or N+1 RPC が体感問題化したタイミングで切替
+
+両パターンとも `<ValidationBadge>` / `has-error` / `has-warning` の描画契約は同じ。
 
 ## 6. New resource addition checklist
 
@@ -164,23 +179,32 @@ AJV 導入方針は次の 3 案を比較した。
 
 ### 7.2 採用方針
 
-本仕様では **B: 現状維持** を採用する。
+本仕様では **C: hybrid** を採用する (#1079 PR #1082 / #1084 で改訂)。
+
+- schema で判定できる項目 (必須欠落 / 型違反 / pattern 違反 / enum 違反 等) は AJV を runtime で使う
+- 設計途中の draft-state を許容するための severity 分け (4 軸 severity) や UI 固有 warning は手書き validator が担う
+
+precedent (実装):
+
+- `frontend/src/utils/validateProject.ts` — Project schema を runtime AJV で検証
+- `frontend/src/schemas/genericDefinitionValidator.ts` — GenericDefinition 8 kind を runtime AJV で検証 + kind 別 semantic warning
 
 理由:
 
-1. UI は draft-state を許容するため、schema 違反を即 invalid とする AJV の標準用途と相性が悪い
-2. error / warning の粒度は 4 軸 severity 判定に基づくため、schema violation の種類だけでは十分に表現できない
-3. 実行時 UI に AJV を入れると bundle size (AJV 本体 ~30KB gzip + ajv-formats 追加分) と依存関係が増える。draft-state UX を維持するなら導入メリットが小さい
-4. AJV は既に test layer で schema 検証に使われており、最終形品質ゲートとしての役割は満たしている
-5. schema は最終形、手書き validator は設計途中の可視化という目的の違いが明確である
+1. schema 違反は本質的に「型として不正」のシグナルであり、UI で正確かつ統一的に表示すべき → AJV が適任
+2. 一方、severity 4 軸判定 (動作可能性 / 物理同一性 / 表示完成度 / 業務妥当性) や draft-state 寛容性は schema では表現しづらい → 手書き validator
+3. AJV bundle size (本体 ~30KB gzip) は許容範囲。validateProject / genericDefinition の precedent で動作確認済
+4. test layer の AJV (samples-v3.schema.test.ts 等) はそのまま継続。runtime と test の two-layer 体制
 
-### 7.3 将来の再検討条件
+### 7.3 hybrid 採用 (§7.2) の根拠となった事象
 
-以下のいずれかを満たした場合は、AJV の runtime / hybrid 導入を再検討する。
+旧 §7.3 の「将来再検討条件」のうち以下が #1079 (Generic Definition Catalog) で satisfy され、
+hybrid 採用に至った:
 
-- validation 対象のリソース種別が 5 種以上になり、手書き validator の重複が保守負荷になった
-- schema と手書き validator の実際の divergence が発生し、ユーザー影響のある誤判定が確認された
-- 業務要件として、UI 実行時に schema 準拠性そのものを表示・証跡化する必要が出た
+- **validation 対象が 5 種以上**: GenericDefinition は 8 kind を持ち、kind 別の重複手書き validator を避けるため
+  AJV dispatch (`KIND_SCHEMAS` lookup + 親 schema fallback) が保守上有意になった
+
+その他の旧条件 (実際の divergence / 業務要件証跡化) は本判断時点では発生していないが、hybrid 体制下で継続監視する。
 
 ### 7.4 適用範囲の明確化 (Conventions / Extensions は対象外)
 

--- a/docs/spec/draft-state-policy.md
+++ b/docs/spec/draft-state-policy.md
@@ -46,7 +46,7 @@ store は一覧読み込みと同じ責務範囲で `load<Resource>ValidationMap
 
 ### 2.5 成熟度表示は必須
 
-すべての業務リソース UI は `MaturityBadge` を表示する。成熟度未指定の既存データは `draft` として扱う。
+すべての業務リソース**実体** (instance) UI は `MaturityBadge` を表示する。GenericDefinition のような **kind-discriminated 定義カタログ** (≒ 参照語彙、永続化を伴わない設計定義) は本項の対象外とする (詳細は `generic-definition-layer.md` §4.5 参照)。成熟度未指定の既存データは `draft` として扱う。
 
 一覧画面の `MaturityBadge` は view-only とし、編集画面の `MaturityBadge` は `onChange` を受け取って成熟度を変更できる。`committed` は「下流工程へ渡せる確定状態」を示すため、validation の可視化と併用する。
 
@@ -134,6 +134,8 @@ ProcessFlow は既存の `aggregateValidation` を直接利用する。ProcessFl
 - [ ] schema は AI の変更対象外であることを確認する (#511)
 - [ ] schema と手書き validation の severity 不一致がある場合は、意図的な差分として PR に説明する
 - [ ] AJV は実行時 UI ではなく test layer の schema 検証として使う
+
+> **kind-discriminated 定義カタログ** (GenericDefinition 系) を追加する場合は本 checklist の `MaturityBadge` 項目を skip し、別途 `generic-definition-layer.md` の checklist に従う。
 
 ### 6.1 適用状況
 

--- a/docs/spec/draft-state-policy.md
+++ b/docs/spec/draft-state-policy.md
@@ -148,7 +148,7 @@ ListView / Editor 内で `validate<Resource>(item, allItems)` を直接呼び、
 - [ ] Editor の該当セクションに `ValidationBadge` または同等の警告表示を配置する
 - [ ] schema は AI の変更対象外であることを確認する (#511)
 - [ ] schema と手書き validation の severity 不一致がある場合は、意図的な差分として PR に説明する
-- [ ] AJV は実行時 UI ではなく test layer の schema 検証として使う
+- [ ] AJV を runtime UI に組み込むか、test layer のみに留めるかを §7.2 hybrid 方針に基づき判断する (schema で判定できる項目 → runtime AJV / UI 固有 severity → 手書き validator)
 
 > **kind-discriminated 定義カタログ** (GenericDefinition 系) を追加する場合は本 checklist の `MaturityBadge` 項目を skip し、別途 `generic-definition-layer.md` の checklist に従う。
 

--- a/docs/spec/generic-definition-layer.md
+++ b/docs/spec/generic-definition-layer.md
@@ -247,6 +247,25 @@ PageLayout "admin-layout"  ←  ページ全体の枠
 
 本 layer の schema 追加は **`docs/spec/schema-governance.md`** の対象 (= 設計者承認必須)。本ドラフトは整理段階であり、schema 切り出しは別 ISSUE で段階的に実施する。
 
+### 4.5 GenericDefinition と EntityMeta の関係 / maturity 不採用の理由
+
+GenericDefinition は他リソース (ProcessFlow / Screen / Table) と性質が根本的に異なるため、
+EntityMeta (`id: uuid`, `created_at`, `updated_at`, `maturity`) を採用しない。
+`kind` + `name` を identifier とし、設計者が手で命名・参照する「定義語彙」として扱う。
+
+| 観点 | 業務リソース実体 (ProcessFlow / Screen / Table) | GenericDefinition |
+|---|---|---|
+| 役割 | 業務システムの実体 | 定義語彙 / 参照カタログ |
+| identifier | uuid (machine-generated) | `kind + name` (human-readable) |
+| EntityMeta | 採用 | 不採用 |
+| 自然な進化モデル | draft → provisional → committed (制作進行) | stable ↔ experimental ↔ deprecated (lifecycle) |
+
+このため `draft-state-policy.md` §2.5 「成熟度表示は必須」は GenericDefinition には適用しない
+(§2.5 自体で例外化済)。
+
+将来 lifecycle 管理 (例: `status: stable / experimental / deprecated`) が業務上必要になった時点で、
+別 ISSUE を起票し設計者承認の上で C 案として field を追加する。本 RFC 段階では YAGNI に従い導入しない。
+
 ---
 
 ## 5. Layer 3 — AI 向け変換マニュアル + 生成 importer

--- a/frontend/src/schemas/genericDefinitionValidator.ts
+++ b/frontend/src/schemas/genericDefinitionValidator.ts
@@ -13,7 +13,6 @@ import addFormats from "ajv-formats";
 import type { GenericDefinition, GenericDefinitionKind } from "../types/v3";
 
 import parentSchema from "../../../schemas/v3/generic-definition.v3.schema.json";
-import commonSchema from "../../../schemas/v3/common.v3.schema.json";
 import dataContractSchema from "../../../schemas/v3/generic-definitions/data-contract.v3.schema.json";
 import exceptionTypeSchema from "../../../schemas/v3/generic-definitions/exception-type.v3.schema.json";
 import domainTypeSchema from "../../../schemas/v3/generic-definitions/domain-type.v3.schema.json";
@@ -53,8 +52,7 @@ function getValidators(): ValidatorMap {
   const ajv = new Ajv2020({ strict: false, allErrors: true });
   addFormats(ajv);
 
-  // common schema と 親 schema を先に登録して $ref 解決できるようにする
-  ajv.addSchema(commonSchema as object);
+  // 親 schema を先に登録して $ref 解決できるようにする
   ajv.addSchema(parentSchema as object);
 
   const validators = new Map<string, ValidateFn>();


### PR DESCRIPTION
## Summary

PR #1082 (#1079 Generic Definition Catalog draft-state-policy 適用) の follow-up 統合 PR。設計者との対話で確定した 4 つの設計判断 (#1083 / #1084-A / #1084-B + Nit cleanup) を一括実装する。

Closes #1083
Closes #1084

## 設計判断 (確定済、設計者対話により合意)

### #1083 → B 案 (maturity 不採用 + spec で例外化)

GenericDefinition は他リソース (ProcessFlow / Screen / Table) と性質が根本的に異なる **「定義語彙 / 参照カタログ」** であり、`kind + name` を identifier とする (uuid なし、EntityMeta なし) 当初設計判断と整合させる。

| 観点 | 業務リソース実体 | GenericDefinition |
|---|---|---|
| 役割 | 業務システムの実体 | 定義語彙 / 参照カタログ |
| identifier | uuid (machine-generated) | `kind + name` (human-readable) |
| EntityMeta | 採用 | 不採用 |
| 自然な進化モデル | draft → provisional → committed | stable ↔ experimental ↔ deprecated |

**A 案** (optional `maturity` 追加) は EntityMeta 不採用判断との一貫性を破る。**C 案** (`status` field 追加) は概念的に正しいが必要性未立証 (YAGNI)。**B 案** が最小設計で、将来 lifecycle 管理が業務上必要になれば C 案を別 ISSUE で非破壊的に追加可能。

### #1084-A → C 案 hybrid 採用 (spec §7.2 改訂)

実装実態 (`validateProject.ts` + `genericDefinitionValidator.ts` の runtime AJV 採用) と spec の divergence を解消。schema で判定できる項目は AJV runtime、UI 固有 severity は手書き validator が担う。§7.3 再検討条件「validation 対象が 5 種以上」は GenericDefinition 8 kind 追加で satisfy された旨を記載。

### #1084-B → inline 許容を一般化 (spec §5 改訂)

旧 §5 の二分 (flat = store 関数 / nested = inline) を 2 パターン許容モデルに変更。デフォルトは **inline (パターン B)**、キャッシュ要件が顕在化したら store 関数化 (パターン A) へ移行。ProcessFlowListView + GenericDefinitionListView の実態に合致。

### #1084-C → Nit cleanup

`genericDefinitionValidator.ts` の不要 `addSchema(commonSchema)` 削除 (親 schema が `$ref` していないため不要)。

### #1084-D → perf 検証 (コード読みのみ、commit なし)

下記「観察事項」に記載。

## Changes

### `docs/spec/draft-state-policy.md` (主要改訂)

- **§2.5**: 「業務リソース UI」→「業務リソース**実体** (instance) UI」に限定。GenericDefinition のような kind-discriminated 定義カタログは対象外と明示
- **§5**: store-method パターンを 2 パターン許容モデル (パターン A: store 関数 / パターン B: inline) に書き換え。デフォルト推奨は inline
- **§6**: kind-discriminated 定義カタログ用 but-clause 追加 + checklist の AJV 項目を hybrid 方針に整合
- **§7.2**: 方針 B (現状維持) → **方針 C (hybrid)** に書き換え。precedent として `validateProject.ts` + `genericDefinitionValidator.ts` を参照
- **§7.3**: 「将来再検討条件」→「hybrid 採用の根拠となった事象」に書き換え。GenericDefinition 8 kind で条件 1 satisfy 済を記載
- §7.4 (Conventions / Extensions 対象外) は触らず維持

### `docs/spec/generic-definition-layer.md` (新規節)

- **§4.5**: GenericDefinition と EntityMeta の関係 / maturity 不採用の理由 を新規追加 (B 案根拠を spec 化)

### `frontend/src/schemas/genericDefinitionValidator.ts` (Nit)

- L57 の `ajv.addSchema(commonSchema as object);` 削除
- L16 の `import commonSchema` 削除
- 19 unit test 全 pass

## 検証

| 項目 | 結果 |
|---|---|
| `npm run build` (frontend) | 0 TypeScript errors |
| `npm run test:unit genericDefinitionValidator` | 19 passed / 19 |
| `git diff origin/main..HEAD -- schemas/` | 空 (schema 変更ゼロ、#511 governance 遵守) |

## Commits

- `a7231a4` docs(spec): GenericDefinition は EntityMeta / maturity 不採用、§2.5 を業務リソース実体限定に改訂 (#1083)
- `09f8fb6` docs(spec): AJV 採用方針を C hybrid に改訂、§5 store パターンを inline 許容一般化 (#1084)
- `5e4b977` improve(validator): GenericDefinition の不要 addSchema(commonSchema) 削除 (#1084)
- `eb5010c` docs(spec): §6 checklist の AJV 項目を hybrid 方針に整合 (#1084)

## 観察事項 / 残課題

### #1084-D perf 観察結果

`frontend/src/components/generic-definition/GenericDefinitionListView.tsx` の validation map 構築:

- 構造: 逐次 `for (const item of items)` + `await loadGenericDefinition(...)` の sequential loop + `cancelled` フラグによる早期終了
- N=100 想定での体感: 各 RPC ~10-50ms × 100 件 = 最大 5 秒。incremental に各アイテムのバッジが表示されるため UX 的ブロックはない
- `cancelled` フラグ semantics により、単純な `Promise.all` 並列化は cancellation のクリーンさが下がる
- **判断**: **現状維持推奨**。N が 100 を大きく超えて体感問題化した場合、`Promise.allSettled` + chunk 分割でのバッチ並列化を別 ISSUE で検討

### 追加観察事項

- **§6 checklist と §7.2 の整合**: 当初実装 (commit a7231a4-5e4b977) で §7.2 を hybrid に書き換えた一方、§6 checklist の旧 "AJV は実行時 UI ではなく test layer の schema 検証として使う" 行が残置していた → commit `eb5010c` で hybrid 方針に整合。**他 spec ファイルでも同様に旧方針 B 前提の文言が残っていないか、独立レビューで確認したい**
- **`schemas/v3/generic-definition.v3.schema.json` の今後**: B 案により `maturity` field は今期は追加しないが、将来 lifecycle 管理 (status field) を追加する設計者承認 ISSUE が出た場合、`generic-definition-layer.md` §4.5 の前提を再検討する必要がある (現状は spec 上「YAGNI に従い導入しない」と明記)

## Issue 起票過程の問題点

本 PR の親 ISSUE 着手過程で発生した**プロセス上の問題点**を 1 件記録 (今後の運用改善のため):

- **`/loop` 自動化の事故**: 別セッションの Opus が `/issues` 実行中に `ScheduleWakeup` ツールを「Sonnet 委譲の stall 保険」として自発的に呼び、深夜に新セッションで疑似ユーザー入力を注入する事故が発生した (memory `feedback_no_schedulewakeup_outside_loop.md` 記録済)。本 PR の実装には影響なし。`/issues` skill 内で `ScheduleWakeup` を呼ばないガードを将来追加検討

## Test Plan

- [x] frontend tsc / vitest pass
- [x] schema 変更ゼロ確認
- [x] §6 checklist 内部矛盾解消
- [ ] 独立レビュー (review-pr-sonnet) で他 spec の整合確認待ち
- [ ] §4.5 の table が `generic-definition-layer.md` 既存 §4.x の節構成と矛盾していないか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 独立レビュー対応 (Sonnet 2026-05-14)

PR レビュー結果 (https://github.com/csilost2001/harmony/pull/1086#issuecomment-4446353575):
- Must-fix: 0 件
- Should-fix: 2 件 → 全件解消 (commit `64f3e80`)
  1. §2.3 の store 義務記述が §5 inline 許容方針と矛盾していた → 「パターン A または B のいずれかで届ける」に書き換え
  2. §6 checklist の `load<Resource>ValidationMap()` 項目が無条件だった → パターン A 選択時のみと条件付きに変更
- Nit: 1 件 (§4.5 タイトルが他 §4.x よりやや長い、内容問題なし、対応見送り)

最終 commit 5 件:
- `a7231a4` docs(spec): GenericDefinition は EntityMeta / maturity 不採用 (#1083)
- `09f8fb6` docs(spec): AJV 採用方針を C hybrid (#1084)
- `5e4b977` improve(validator): 不要 addSchema 削除 (#1084)
- `eb5010c` docs(spec): §6 checklist の AJV 項目整合 (#1084)
- `64f3e80` docs(spec): §2.3 + §6 checklist を §5 inline 方針に整合 (#1084)
