### PR TITLE
fix(generic-definition): Catalog UI で 8 kind 全てクリック可能化 (#1088 提案 A)

### DIFF
--- a/frontend/src/components/generic-definition/GenericDefinitionCatalogView.tsx
+++ b/frontend/src/components/generic-definition/GenericDefinitionCatalogView.tsx
@@ -11,8 +11,6 @@ import { makeTabId } from "../../store/tabStore";
 
 const TAB_ID = makeTabId("generic-definition-catalog", "main");
 
-const MVP_KINDS: ReadonlySet<GenericDefinitionKind> = new Set(["data-contract", "exception-type"]);
-
 const KIND_ICONS: Record<GenericDefinitionKind, string> = {
   "data-contract": "bi-file-earmark-code",
   "domain-type": "bi-diagram-2",
@@ -74,57 +72,41 @@ export function GenericDefinitionCatalogView() {
         gap: "16px",
       }}>
         {GENERIC_DEFINITION_KINDS.map((kind) => {
-          const isMvp = MVP_KINDS.has(kind);
           const count = counts[kind] ?? 0;
           return (
             <div
               key={kind}
-              onClick={() => isMvp ? navigate(wsPath(`/generic-definition/${kind}`)) : undefined}
+              onClick={() => navigate(wsPath(`/generic-definition/${kind}`))}
               style={{
                 border: "1px solid #ddd",
                 borderRadius: "8px",
                 padding: "16px",
-                cursor: isMvp ? "pointer" : "default",
-                opacity: isMvp ? 1 : 0.6,
-                backgroundColor: isMvp ? "#fff" : "#f8f9fa",
+                cursor: "pointer",
+                backgroundColor: "#fff",
                 transition: "box-shadow 0.15s",
               }}
               onMouseEnter={(e) => {
-                if (isMvp) (e.currentTarget as HTMLDivElement).style.boxShadow = "0 2px 8px rgba(0,0,0,0.12)";
+                (e.currentTarget as HTMLDivElement).style.boxShadow = "0 2px 8px rgba(0,0,0,0.12)";
               }}
               onMouseLeave={(e) => {
                 (e.currentTarget as HTMLDivElement).style.boxShadow = "none";
               }}
             >
               <div style={{ display: "flex", alignItems: "center", gap: "10px", marginBottom: "8px" }}>
-                <i className={`bi ${KIND_ICONS[kind]}`} style={{ fontSize: "1.3rem", color: isMvp ? "#0d6efd" : "#999" }} />
+                <i className={`bi ${KIND_ICONS[kind]}`} style={{ fontSize: "1.3rem", color: "#0d6efd" }} />
                 <span style={{ fontWeight: 600, fontSize: "0.95rem" }}>
                   {GENERIC_DEFINITION_KIND_LABELS[kind]}
                 </span>
-                {!isMvp && (
-                  <span style={{
-                    fontSize: "0.75rem",
-                    background: "#e9ecef",
-                    color: "#6c757d",
-                    padding: "2px 6px",
-                    borderRadius: "4px",
-                    marginLeft: "auto",
-                  }}>
-                    準備中
-                  </span>
-                )}
-                {isMvp && (
-                  <span style={{
-                    fontSize: "0.75rem",
-                    background: "#e8f4fd",
-                    color: "#0d6efd",
-                    padding: "2px 6px",
-                    borderRadius: "4px",
-                    marginLeft: "auto",
-                  }}>
-                    {count} 件
-                  </span>
-                )}
+                <span style={{
+                  fontSize: "0.75rem",
+                  background: "#e8f4fd",
+                  color: "#0d6efd",
+                  padding: "2px 6px",
+                  borderRadius: "4px",
+                  marginLeft: "auto",
+                }}>
+                  {count} 件
+                </span>
               </div>
               <p style={{ fontSize: "0.82rem", color: "#555", margin: 0 }}>
                 {KIND_DESCRIPTIONS[kind]}


### PR DESCRIPTION
## Summary

#1060 (Generic Definition Catalog) の **dogfood follow-up**。

`GenericDefinitionCatalogView` の `MVP_KINDS` 制限 (= `data-contract` / `exception-type` の 2 kind のみ) を撤廃し、残 6 kind (`domain-type` / `application-rule` / `ui-behavior` / `runtime-policy` / `component-definition` / `ui-fragment`) も同等にクリック可・件数表示・ナビゲート可とする。

#1078 UI MVP 時の暫定で、後続の #1077 (残 4 kind schema) / #1082 (draft-state-policy) / #1086 (maturity 採否) で実装が完成した後も削除されず残っていた。実態は **8 kind 完全対応** で、URL 直打ちなら全機能動作確認済 (実機 Playwright で 8 kind navigate / Editor 編集 / save round-trip / schema-violation inject 確認済)。

**Refs** #1088 の **提案 A** のみ (#1088 自体は提案 B が残るため auto-close しない / D は #1090 で別 ISSUE 起票済)。

## 背景

#1060 シリーズ merge 完了後の dogfood (2026-05-14、`workspaces/dogfood-generic-definition-20260514/` に `examples/retail/` を copy) で発見した 3 件のうち、最も簡易な提案 A を本 PR で吸収する。

| 検証 | 結果 |
|---|---|
| 8 kind URL 直打ちで一覧 / Editor / save round-trip 動作 | ✅ |
| AJV runtime hybrid (#1084-A) — schema 違反 inject で section inline + header / ListView バッジ検出 | ✅ |
| ListView validation inline (#1084-B) — store 関数なし、`validateGenericDefinition` 直呼び | ✅ |
| MaturityBadge 不採用 (#1083 B 案 / draft-state-policy §2.5 例外化) | ✅ |
| **Catalog UI 入口** で 6 kind が「準備中」表示・クリック不可 | ❌ → **本 PR で fix** |
| 切れリンク (`componentRef` / `exceptionTypeRef` / `fragmentRef`) の参照先存在検証 | ❌ → ISSUE #1090 で別途対応 |

## Test plan

- [x] 実機 Playwright dogfood: catalog 8 kind すべて cursor:pointer / opacity:1 / 「1 件」バッジ表示確認
- [x] 実機: ui-fragment カード (旧「準備中」kind) クリック → ListView 遷移、サンプル 1 件表示確認
- [x] `npx tsc --noEmit` clean
- [x] Sonnet 独立レビュー → マージ可 (Must-fix / Should-fix ゼロ、Nit 1 件は pre-existing 慣行)

## #1088 残提案の処理

- ✅ 提案 A: 本 PR (#1089)
- 🆕 提案 D: 別 ISSUE #1090 で起票済
- 🟡 提案 B (ListView 行クリック範囲): #1088 内に観察事項として残置 (DataList 共通 UI と関わるため、後続で他 ListView 比較してから判断)

## Schema governance (#511)

- schemas/ への変更なし ✅ (`gh pr diff 1089 -- schemas/` 空、Sonnet レビューでも確認)

## 関連

- 親メタ #1060 (CLOSED)
- ISSUE #1088 (起票元、提案 A/B/D 統合 / 本 PR は A のみ)
- ISSUE #1090 (提案 D = 切れリンク検出 / 別途実装)
- 関連 PR #1078 (UI MVP) / #1082 (draft-state-policy) / #1086 (maturity 採否)
- spec: [`docs/spec/generic-definition-layer.md`](docs/spec/generic-definition-layer.md) §10
- memory: `feedback_feature_complete_means_usable_ui.md` (UI 未到達は未完了)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
