### PR TITLE
fix(generic-definition): Screen.fragments[].fragmentRef 切れリンク検出 (#1090 Phase 2)

### DIFF
--- a/docs/spec/generic-definition-layer.md
+++ b/docs/spec/generic-definition-layer.md
@@ -184,7 +184,7 @@ PageLayout "admin-layout"  ←  ページ全体の枠
 
 `exceptionTypeRef` pattern (#1066) と同様、kind-specific schema (`schemas/v3/generic-definitions/ui-fragment.v3.schema.json`) は親 schema (`generic-definition.v3.schema.json`) を `allOf` 継承し `kind` を const に固定する最小構造。slot binding / region 等の fragment 固有 field は将来 RFC で追加予定。
 
-`fragmentRef` pattern は `^generic-definitions/ui-fragment/[A-Za-z][A-Za-z0-9_]*$` で AJV gate 対象化済 (= **形式 pattern のみ**)。`<Name>` 部の **実在検証** は #1090 Phase 2 で Screen 側 validator integration (`puckScreenValidation.ts` 拡張または新 validator) によって追加予定。現状は形式 OK なら silent pass (= 無検出)。Phase 2 完了時には `UNKNOWN_FRAGMENT_REF` として ScreenListView / Editor のバッジに表示される設計。
+`fragmentRef` pattern は `^generic-definitions/ui-fragment/[A-Za-z][A-Za-z0-9_]*$` で AJV gate 対象化済 (= **形式 pattern のみ**)。`<Name>` 部の **実在検証** は `frontend/src/utils/screenRefValidation.ts` の `validateScreenRefs` で `UNKNOWN_FRAGMENT_REF` として検出する (#1090 Phase 2、severity=warning)。`screenStore.loadPuckScreenValidationMap` がオーケストレータとなり、Puck data 検証 (`validatePuckScreen`) と cross-resource ref 検証 (`validateScreenRefs`) を統合して ScreenListView のバッジに表示する。検証は editor-agnostic (Puck / GrapesJS の双方の screen で動作)。
 
 ---
 

--- a/examples/retail/harmony/screens/cff4a398-99cd-4aa5-bfbd-c12d5e72c5f3.json
+++ b/examples/retail/harmony/screens/cff4a398-99cd-4aa5-bfbd-c12d5e72c5f3.json
@@ -9,6 +9,9 @@
   "auth": "required",
   "groupId": "c720b549-ecf4-4d20-9be4-c8d38f89a13e",
   "maturity": "committed",
+  "fragments": [
+    { "fragmentRef": "generic-definitions/ui-fragment/messageArea", "instanceId": "errorArea" }
+  ],
   "createdAt": "2026-05-02T00:00:00.000Z",
   "updatedAt": "2026-05-02T00:00:00.000Z",
   "items": [

--- a/frontend/src/components/flow/ScreenListView.tsx
+++ b/frontend/src/components/flow/ScreenListView.tsx
@@ -8,6 +8,8 @@ import type { PageLayoutEntry } from "../../types/v3/project";
 import { loadProject, loadRawProject, saveProject, addScreen, removeScreen, DEFAULT_NODE_SIZE } from "../../store/flowStore";
 import { buildDefaultScreen, loadPuckScreenValidationMap, saveScreenEntity } from "../../store/screenStore";
 import { listPageLayouts } from "../../store/pageLayoutStore";
+import { listGenericDefinitions } from "../../store/genericDefinitionStore";
+import type { ScreenGenericDefinitionNames } from "../../utils/screenRefValidation";
 import { resolveEditorKind } from "../../utils/resolveEditorKind";
 import { resolveCssFramework } from "../../utils/resolveCssFramework";
 import { mcpBridge } from "../../mcp/mcpBridge";
@@ -66,6 +68,8 @@ export function ScreenListView() {
   const [validationMap, setValidationMap] = useState<Map<string, ValidationSummary>>(new Map());
   // pageLayoutId 選択 dropdown 用 (pl-4, #1025)
   const [pageLayouts, setPageLayouts] = useState<PageLayoutEntry[]>([]);
+  // #1090 Phase 2: ui-fragment catalog name set (fragmentRef 検証用)
+  const [genericDefNames, setGenericDefNames] = useState<ScreenGenericDefinitionNames>({});
 
   const loadScreens = useCallback(async (): Promise<ScreenNode[]> => {
     mcpBridge.startWithoutEditor();
@@ -120,14 +124,28 @@ export function ScreenListView() {
     listPageLayouts().then(setPageLayouts).catch(console.error);
   }, []);
 
-  // puck validation map のロード (TableListView.tsx と同パターン)
+  // #1090 Phase 2: ui-fragment catalog name set をロード
+  useEffect(() => {
+    let cancelled = false;
+    listGenericDefinitions("ui-fragment")
+      .then((items) => {
+        if (cancelled) return;
+        setGenericDefNames({ "ui-fragment": new Set(items.map((i) => i.name)) });
+      })
+      .catch(() => {
+        if (!cancelled) setGenericDefNames({});
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  // 画面 validation map のロード (Puck data 検証 + cross-resource ref 検証 #1090 Phase 2)
   useEffect(() => {
     if (screens.length === 0) {
       setValidationMap(new Map());
       return;
     }
     let cancelled = false;
-    loadPuckScreenValidationMap()
+    loadPuckScreenValidationMap({ genericDefinitionNames: genericDefNames })
       .then((map) => {
         if (cancelled) return;
         const next = new Map<string, ValidationSummary>();
@@ -141,7 +159,7 @@ export function ScreenListView() {
       })
       .catch(console.error);
     return () => { cancelled = true; };
-  }, [screens]);
+  }, [screens, genericDefNames]);
 
   const filter = useListFilter(screens);
 

--- a/frontend/src/store/screenStore.ts
+++ b/frontend/src/store/screenStore.ts
@@ -9,6 +9,10 @@ import { resolveEditorKind } from "../utils/resolveEditorKind";
 import { resolveCssFramework } from "../utils/resolveCssFramework";
 import { validatePuckScreen } from "../utils/puckScreenValidation";
 import type { PuckScreenValidationError } from "../utils/puckScreenValidation";
+import {
+  validateScreenRefs,
+  type ScreenGenericDefinitionNames,
+} from "../utils/screenRefValidation";
 
 export interface ScreenStorageBackend {
   loadScreenEntity(screenId: string): Promise<unknown>;
@@ -101,11 +105,19 @@ export async function loadScreenEntity(screenId: string): Promise<Screen> {
 }
 
 /**
- * 全 Puck 画面の validation エラーマップを返す。
- * loadTableValidationMap / loadViewValidationMap と同パターン (#806 S-1 / 仕様 §8)。
- * editorKind=puck の画面のみを対象とし、puckDataPayload は省略 (ファイル load 省略)。
+ * 全画面の validation エラーマップを返す (puck 検証 + cross-resource ref 整合性検証)。
+ *
+ * - **Puck 検証** (`validatePuckScreen`): editorKind=puck の画面のみ
+ * - **Cross-resource ref 検証** (`validateScreenRefs`, #1090 Phase 2): editorKind 不問
+ *   - fragments[].fragmentRef → generic-definitions/ui-fragment catalog の実在検証
+ *   - genericDefinitionNames が未指定の場合は ref 検査は silent pass
+ *
+ * 関数名は loadPuckScreenValidationMap のままだが、Phase 2 で screen 全体の validation
+ * orchestrator に責務拡張済み (loadTableValidationMap / loadViewValidationMap と同階層)。
  */
-export async function loadPuckScreenValidationMap(): Promise<Map<ScreenId, PuckScreenValidationError[]>> {
+export async function loadPuckScreenValidationMap(options?: {
+  genericDefinitionNames?: ScreenGenericDefinitionNames;
+}): Promise<Map<ScreenId, PuckScreenValidationError[]>> {
   const project = await loadProject();
   const validationMap = new Map<ScreenId, PuckScreenValidationError[]>();
   const backend = requireBackend();
@@ -125,15 +137,33 @@ export async function loadPuckScreenValidationMap(): Promise<Map<ScreenId, PuckS
       } as unknown as Screen;
     }),
   );
-  const puckEntities = rawEntities.filter(
-    (entity): entity is Screen => entity !== null && entity.design?.editorKind === "puck",
+  const allEntities = rawEntities.filter((entity): entity is Screen => entity !== null);
+  const puckEntities = allEntities.filter(
+    (entity) => entity.design?.editorKind === "puck",
   );
 
+  // Puck data 検証 (editorKind=puck のみ)
   for (const entity of puckEntities) {
     validationMap.set(
       entity.id as ScreenId,
       validatePuckScreen(entity, puckEntities, /* customComponents */ []),
     );
+  }
+
+  // Cross-resource ref 検証 (#1090 Phase 2、editorKind 不問)。
+  // ScreenRefIssue は { severity, message, field, code } を持つが、
+  // PuckScreenValidationError との互換のため code を捨てて merge する。
+  for (const entity of allEntities) {
+    const refIssues = validateScreenRefs(entity, options);
+    if (refIssues.length === 0) continue;
+    const id = entity.id as ScreenId;
+    const existing = validationMap.get(id) ?? [];
+    const converted: PuckScreenValidationError[] = refIssues.map((iss) => ({
+      severity: iss.severity,
+      message: iss.message,
+      field: iss.field,
+    }));
+    validationMap.set(id, [...existing, ...converted]);
   }
 
   return validationMap;

--- a/frontend/src/utils/screenRefValidation.test.ts
+++ b/frontend/src/utils/screenRefValidation.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import { validateScreenRefs } from "./screenRefValidation";
+import type { Screen } from "../types/v3/screen";
+
+function makeScreen(partial: Partial<Screen>): Screen {
+  return {
+    id: "s1",
+    name: "test",
+    purpose: "page",
+    kind: "form",
+    path: "/test",
+    items: [],
+    ...partial,
+  } as unknown as Screen;
+}
+
+describe("validateScreenRefs (#1090 Phase 2)", () => {
+  it("fragmentRef が catalog 内 → no issue", () => {
+    const issues = validateScreenRefs(
+      makeScreen({
+        fragments: [
+          { fragmentRef: "generic-definitions/ui-fragment/messageArea", instanceId: "errorArea" },
+        ],
+      } as Partial<Screen>),
+      { genericDefinitionNames: { "ui-fragment": new Set(["messageArea"]) } },
+    );
+    expect(issues).toHaveLength(0);
+  });
+
+  it("fragmentRef が catalog 外 → UNKNOWN_FRAGMENT_REF (severity warning)", () => {
+    const issues = validateScreenRefs(
+      makeScreen({
+        fragments: [
+          { fragmentRef: "generic-definitions/ui-fragment/NonExistentFragment" },
+        ],
+      } as Partial<Screen>),
+      { genericDefinitionNames: { "ui-fragment": new Set(["messageArea"]) } },
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("UNKNOWN_FRAGMENT_REF");
+    expect(issues[0].severity).toBe("warning");
+    expect(issues[0].field).toBe("fragments[0].fragmentRef");
+    expect(issues[0].message).toContain("NonExistentFragment");
+  });
+
+  it("複数 fragmentRef (一部切れ) → 切れた数だけ issue", () => {
+    const issues = validateScreenRefs(
+      makeScreen({
+        fragments: [
+          { fragmentRef: "generic-definitions/ui-fragment/messageArea", instanceId: "errorArea" },
+          { fragmentRef: "generic-definitions/ui-fragment/Missing1" },
+          { fragmentRef: "generic-definitions/ui-fragment/messageArea", instanceId: "infoArea" },
+          { fragmentRef: "generic-definitions/ui-fragment/Missing2" },
+        ],
+      } as Partial<Screen>),
+      { genericDefinitionNames: { "ui-fragment": new Set(["messageArea"]) } },
+    );
+    expect(issues).toHaveLength(2);
+    expect(issues[0].field).toBe("fragments[1].fragmentRef");
+    expect(issues[1].field).toBe("fragments[3].fragmentRef");
+  });
+
+  it("genericDefinitionNames['ui-fragment'] 未指定 → silent pass", () => {
+    // catalog ロード失敗時の互換性維持: 検査しない (誤検出を避ける)
+    const issues = validateScreenRefs(
+      makeScreen({
+        fragments: [
+          { fragmentRef: "generic-definitions/ui-fragment/Whatever" },
+        ],
+      } as Partial<Screen>),
+    );
+    expect(issues).toHaveLength(0);
+
+    // options 自体が undefined の場合も silent
+    const issues2 = validateScreenRefs(
+      makeScreen({
+        fragments: [
+          { fragmentRef: "generic-definitions/ui-fragment/Whatever" },
+        ],
+      } as Partial<Screen>),
+      undefined,
+    );
+    expect(issues2).toHaveLength(0);
+  });
+
+  it("空 Set → 全 ref が UNKNOWN_FRAGMENT_REF (catalog 0 件 = 全部 catalog 外)", () => {
+    const issues = validateScreenRefs(
+      makeScreen({
+        fragments: [
+          { fragmentRef: "generic-definitions/ui-fragment/messageArea" },
+        ],
+      } as Partial<Screen>),
+      { genericDefinitionNames: { "ui-fragment": new Set() } },
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("UNKNOWN_FRAGMENT_REF");
+  });
+
+  it("screen.fragments undefined / 空配列 → no issue", () => {
+    const issuesUndef = validateScreenRefs(
+      makeScreen({}),
+      { genericDefinitionNames: { "ui-fragment": new Set(["messageArea"]) } },
+    );
+    expect(issuesUndef).toHaveLength(0);
+
+    const issuesEmpty = validateScreenRefs(
+      makeScreen({ fragments: [] } as Partial<Screen>),
+      { genericDefinitionNames: { "ui-fragment": new Set(["messageArea"]) } },
+    );
+    expect(issuesEmpty).toHaveLength(0);
+  });
+
+  it("AJV pattern 不一致 (形式違反) → silent pass (AJV 側で error 報告される領域)", () => {
+    const issues = validateScreenRefs(
+      makeScreen({
+        fragments: [
+          // pattern にマッチしない (kind 部不正)
+          { fragmentRef: "generic-definitions/wrong-kind/Whatever" },
+          // pattern にマッチしない (prefix 不正)
+          { fragmentRef: "ui-fragment/Whatever" },
+        ],
+      } as Partial<Screen>),
+      { genericDefinitionNames: { "ui-fragment": new Set(["messageArea"]) } },
+    );
+    expect(issues).toHaveLength(0);
+  });
+});

--- a/frontend/src/utils/screenRefValidation.ts
+++ b/frontend/src/utils/screenRefValidation.ts
@@ -1,0 +1,75 @@
+/**
+ * screenRefValidation.ts — Screen entity の cross-resource ref 整合性検証 (#1090 Phase 2)
+ *
+ * Screen.fragments[].fragmentRef が Generic Definition Catalog の ui-fragment に
+ * 存在するか検証する。AJV pattern (`generic-definitions/ui-fragment/<Name>` 形式)
+ * は schema layer で gate 済みだが、`<Name>` 部の実在検証は AJV では行えない。
+ *
+ * 設計方針:
+ * - ProcessFlow 側の `referentialIntegrity.ts` (#1090 Phase 1) と同じ責務分離パターン
+ * - Puck data 検証 (`puckScreenValidation.ts`) とは別ファイル / 別関数 (editor-agnostic)
+ * - severity は既存 referentialIntegrity 慣行に合わせて warning 統一
+ *
+ * 仕様: docs/spec/generic-definition-layer.md §3.6
+ */
+
+import type { Screen } from "../types/v3/screen";
+
+/**
+ * Screen 検証で参照する Generic Definition Catalog の name set (#1090 Phase 2)。
+ * undefined の場合は silent pass (catalog ロード失敗時の互換性維持)。
+ */
+export interface ScreenGenericDefinitionNames {
+  "ui-fragment"?: Set<string>;
+}
+
+export interface ScreenRefIssue {
+  severity: "error" | "warning";
+  message: string;
+  /** ドットパス (例: "fragments[0].fragmentRef") */
+  field: string;
+  /** 識別子 */
+  code: "UNKNOWN_FRAGMENT_REF";
+}
+
+/**
+ * `generic-definitions/ui-fragment/<Name>` 形式の参照から <Name> を抽出する。
+ * AJV pattern gate で形式は担保される前提だが、防御的に regex 一致を確認する。
+ * 形式不一致の場合は null (= AJV 側で error 報告される領域なので本検証は skip)。
+ */
+function extractUiFragmentName(ref: string): string | null {
+  const m = ref.match(/^generic-definitions\/ui-fragment\/([A-Za-z][A-Za-z0-9_]*)$/);
+  return m ? m[1] : null;
+}
+
+/**
+ * Screen 単体の cross-resource ref 整合性を検証する。
+ * Phase 2 では fragments[].fragmentRef のみ対象。将来的に他 ref 種別が増えたら同関数を拡張。
+ */
+export function validateScreenRefs(
+  screen: Screen,
+  options?: { genericDefinitionNames?: ScreenGenericDefinitionNames },
+): ScreenRefIssue[] {
+  const issues: ScreenRefIssue[] = [];
+  const fragmentNames = options?.genericDefinitionNames?.["ui-fragment"];
+
+  // genericDefinitionNames["ui-fragment"] 未指定 → silent pass (catalog ロード失敗等)
+  if (!fragmentNames) return issues;
+
+  const fragments = screen.fragments ?? [];
+  fragments.forEach((f, i) => {
+    const ref = f?.fragmentRef;
+    if (!ref) return; // schema 側で required 担保
+    const name = extractUiFragmentName(ref);
+    if (name && !fragmentNames.has(name)) {
+      issues.push({
+        severity: "warning",
+        message: `screen.fragments[${i}].fragmentRef "${ref}" の <Name> が generic-definitions/ui-fragment catalog に存在しません`,
+        field: `fragments[${i}].fragmentRef`,
+        code: "UNKNOWN_FRAGMENT_REF",
+      });
+    }
+  });
+
+  return issues;
+}


### PR DESCRIPTION
## Summary

#1090 **Phase 2** (Phase 1 = PR #1091 merged)。Screen.fragments[].fragmentRef の **参照先存在検証** を新規 `screenRefValidation.ts` で実装。spec §3.6 で「AJV gate 対象化済」と記述されていたが、AJV pattern は形式 (`generic-definitions/ui-fragment/<Name>`) の合致までしか担保しておらず、`<Name>` 部の実在チェックは silent pass していた。

Closes #1090

## Phase 1 との設計対比

| 概念 | Phase 1 (ProcessFlow) | Phase 2 (Screen) |
|---|---|---|
| structural validator | `actionValidation.ts` | (Screen には独立した structural validator なし) |
| Puck data validator | (該当なし) | `puckScreenValidation.ts` |
| **cross-resource ref validator** | `referentialIntegrity.ts` (拡張) | **`screenRefValidation.ts` (新規)** |
| orchestrator | `aggregatedValidation.ts` | `screenStore.loadPuckScreenValidationMap` (責務拡張) |
| caller | `ProcessFlowEditor` / `ProcessFlowListView` | `ScreenListView` |
| catalog name set 取得 | `listGenericDefinitions("component-definition" / "exception-type")` | `listGenericDefinitions("ui-fragment")` |

新規 file (`screenRefValidation.ts`) として作成した理由:
- `puckScreenValidation.ts` は Puck data 専門 (editor=puck only) で責務が異なる
- `fragmentRef` は **editor-agnostic** (Puck / GrapesJS どちらでも適用)
- Phase 1 の `referentialIntegrity.ts` と概念が直接対応

## 変更内容

| ファイル | 変更 |
|---|---|
| `frontend/src/utils/screenRefValidation.ts` (新規) | `validateScreenRefs(screen, options)` + UNKNOWN_FRAGMENT_REF code |
| `frontend/src/utils/screenRefValidation.test.ts` (新規) | vitest 7 ケース |
| `frontend/src/store/screenStore.ts` | `loadPuckScreenValidationMap` に `genericDefinitionNames` option 追加 + 全 screen 対象の ref 検査統合 |
| `frontend/src/components/flow/ScreenListView.tsx` | ui-fragment catalog ロード + map 関数に渡す |
| `examples/retail/harmony/screens/cff4a398-...json` (カート確認) | `fragments[]: [{fragmentRef: "generic-definitions/ui-fragment/messageArea", instanceId: "errorArea"}]` 追加 |
| `docs/spec/generic-definition-layer.md` §3.6 | 「Phase 2 で対応予定」→ 「Phase 2 完了」に更新、validator 場所 + orchestrator 役割明記 |

## severity 判定

Phase 1 と同じく `severity=warning` (既存 referentialIntegrity 慣行に合致、draft-state-policy §3 の error 記述との乖離は別 ISSUE 扱い、PR #1091 description で説明済)。

## 受け入れ条件 (#1090 Phase 2)

- [x] Screen 側 runtime validator integration (新規 `screenRefValidation.ts` + `screenStore.loadPuckScreenValidationMap` 拡張)
- [x] retail/screens に fragments[] を 1 件追加 (カート確認 = `cff4a398-...` に messageArea 追加)
- [x] vitest 追加 — 7 ケース (正常 / 切れ / 複数混在 / 未指定 silent / 空 Set / 空 fragments / pattern 不一致)
- [x] spec §3.6 の「Phase 2 で対応予定」記述を完了反映に更新

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run screenRefValidation.test.ts` → 7/7 pass
- [x] `npx vitest run puckScreenValidation.test.ts` → 16/16 pass (regression なし)
- [ ] 実機 UI smoke (Playwright): 本 PR では skip。理由は PR #1091 と同じ (dev container の制約で main repo の `fix/issue-1087-...` branch + uncommitted state が live、worktree 側の変更を反映できず)。vitest 23/23 + tsc clean で integration 確認済
- [ ] Sonnet 独立レビュー (本 PR 作成後 spawn)

## Schema governance (#511)

- 0 schemas/ ファイル変更 ✅ (`gh pr diff <PR> -- schemas/` 空、validator + test + sample + spec のみ)

## #1090 全体完了

本 PR merge をもって ISSUE #1090 (Phase 1 + Phase 2) 全完了。

| Phase | 対応 PR | 対象 ref |
|---|---|---|
| Phase 1 | #1091 (merged) | ProcessFlow: componentRef + 2x exceptionTypeRef |
| Phase 2 | #1092 (本 PR) | Screen: fragmentRef |

## 関連

- 親メタ #1060 (CLOSED)
- ISSUE #1090 (本 PR で close)
- ISSUE #1088 (#1090 の起票元、提案 A merged in PR #1089、提案 B のみ残置中)
- 既存 PR #1066 / #1067 (componentCall + exceptionTypeRef + fragments[] 追加 / 本 PR は #1067 で生まれた fragmentRef silent pass を解消)
- spec: `docs/spec/generic-definition-layer.md` §3.6
- spec: `docs/spec/draft-state-policy.md` §3 severity 判定
- memory: `feedback_silent_validation_pass_audit.md` (silent pass anti-pattern)
- memory: `feedback_dogfood_two_stage_method.md` (機械 + AI 実機 dogfood、retail サンプル拡充の根拠)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
