### PR TITLE
fix(generic-definition): ListView の name 列 single-click ショートカット削除 → 4 ListView 統一 (#1088 提案 B 案 A)

### DIFF
--- a/frontend/src/components/generic-definition/GenericDefinitionListView.tsx
+++ b/frontend/src/components/generic-definition/GenericDefinitionListView.tsx
@@ -248,9 +248,11 @@ export function GenericDefinitionListView() {
       header: "名前",
       sortable: true,
       sortAccessor: (item) => item.name,
+      // #1088 提案 B (案 A): name 列の single-click ショートカットを削除し、他 3 ListView
+      // (Screen / Table / ProcessFlow) と同じ dblclick / Enter で開く挙動に統一。
+      // navigation 経路: row dblclick (DataList 共通) または Enter キー (useListKeyboard)。
       render: (item) => (
-        <span style={{ fontWeight: 600, fontFamily: "monospace", color: "#0d6efd", cursor: "pointer" }}
-          onClick={() => handleActivate(item)}>
+        <span style={{ fontWeight: 600, fontFamily: "monospace", color: "#0d6efd" }}>
           {item.name}
         </span>
       ),
@@ -303,7 +305,7 @@ export function GenericDefinitionListView() {
         );
       },
     },
-  ], [handleActivate, validationMap]);
+  ], [validationMap]);
 
   const renderCard = useCallback((item: GenericDefinitionSummary) => {
     const v = validationMap.get(item.name);
@@ -314,8 +316,9 @@ export function GenericDefinitionListView() {
         className={hasError ? "has-error" : hasWarning ? "has-warning" : ""}
         style={{ padding: "12px" }}
       >
-        <div style={{ fontWeight: 600, fontFamily: "monospace", color: "#0d6efd", marginBottom: "4px", fontSize: "0.95rem" }}
-          onClick={() => handleActivate(item)}>
+        {/* #1088 提案 B (案 A): name の single-click ショートカット削除。card 全体の
+            dblclick (DataList 共通) または Enter キーで開く挙動に統一。 */}
+        <div style={{ fontWeight: 600, fontFamily: "monospace", color: "#0d6efd", marginBottom: "4px", fontSize: "0.95rem" }}>
           {item.name}
         </div>
         <div style={{ fontSize: "0.82rem", color: "#555", marginBottom: "8px" }}>{item.purpose}</div>
@@ -340,7 +343,7 @@ export function GenericDefinitionListView() {
         </div>
       </div>
     );
-  }, [handleActivate, validationMap]);
+  }, [validationMap]);
 
   if (!kind) {
     return <div style={{ padding: "24px", color: "#c00" }}>不正な kind です</div>;


### PR DESCRIPTION
## Summary

#1088 提案 B (案 A 採用) — GenericDefinitionListView の name 列 (table view + card view 両方) で、cursor:pointer + onClick={handleActivate} の **single-click ショートカットを削除**。他 3 ListView (Screen / Table / ProcessFlow) と同じく **dblclick** (DataList 共通) または **Enter キー** (useListKeyboard) で開く挙動に統一。

Closes #1088

## 背景

#1088 提案 B 調査 ([issuecomment-4447272677](https://github.com/csilost2001/harmony/issues/1088#issuecomment-4447272677)) で判明:

| ListView | name 列 single-click shortcut |
|---|---|
| Screen / Table / ProcessFlow | ❌ なし (dblclick/Enter のみ) |
| Generic Definition | ✅ あり (異色) |

DataList 共通仕様 (`DataList.tsx:376, 469`):
- single click → `selection?.handleRowClick` (= 行選択のみ)
- double click → `onActivate?.(item, index)` (= 編集に飛ぶ)
- Enter キー → useListKeyboard 経由で onActivate

= file explorer / VSCode サイドバー / Mac Finder 慣習。Generic Definition だけが異色だった。

#1088 提案 B 案 A (推奨案) として、ショートカットを削除して 4 ListView の挙動を統一する。

## 変更内容

`frontend/src/components/generic-definition/GenericDefinitionListView.tsx` のみ:

| 箇所 | 変更 |
|---|---|
| columns name 列 (line 251-256 → 254-259) | `cursor:pointer` + `onClick={handleActivate}` を削除、span は plain になる |
| renderCard 名前 div (line 317-318 → 319-321) | `onClick={handleActivate}` を削除 |
| useMemo dep (line 308 → 310) | `handleActivate` を dep array から削除 (body から消えたため) |
| useCallback dep (line 346 → 348) | 同上 |

各箇所に経緯コメント追加 (`#1088 提案 B (案 A): ...`)。

## 影響

- ユーザー操作: Generic Definition の name span single-click → 行選択のみ (他 3 ListView と統一)
- 編集に飛ぶ経路: row dblclick (DataList 共通) または Enter キー (useListKeyboard) ※ 既存挙動維持
- regression: なし (削除したのは shortcut のみで、navigation 本体は dblclick/Enter で機能)

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean
- [x] 4 ListView 比較確認: ScreenListView:464 / TableListView:500 / ProcessFlowListView:582 はいずれも name 列に onClick なし → 本 PR で挙動が完全一致
- [ ] Sonnet 独立レビュー (本 PR 作成後 spawn)
- 注: GenericDefinitionListView は component test 持たず (store / validator のみ)。schema/store/validator regression なし

## Schema governance (#511)

- 0 schemas/ ファイル変更 ✅

## 関連

- 元 ISSUE #1088 (本 PR で close)
- 元 dogfood ISSUE #1090 (CLOSED, Phase 1+2 完了)
- 親メタ #1060 (CLOSED)
- spec: `docs/spec/list-common.md` (DataList 共通 UI 仕様)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
