### PR TITLE
fix(process-flow): readonly操作とmodelRef警告を修正 (#1087)

### DIFF
--- a/backend/src/projectStorage.ts
+++ b/backend/src/projectStorage.ts
@@ -89,6 +89,7 @@ const screensDir       = (dataRoot: string) => path.join(dataRoot, "screens");
 const tablesDir        = (dataRoot: string) => path.join(dataRoot, "tables");
 const actionsDir       = (dataRoot: string) => path.join(dataRoot, "actions");
 const processFlowsDir  = (dataRoot: string) => path.join(dataRoot, "process-flows");
+const catalogsDir      = (dataRoot: string) => path.join(dataRoot, "catalogs");
 const conventionsDir   = (dataRoot: string) => path.join(dataRoot, "conventions");
 const screenItemsDir   = (dataRoot: string) => path.join(dataRoot, "screen-items");
 const sequencesDir     = (dataRoot: string) => path.join(dataRoot, "sequences");
@@ -101,6 +102,7 @@ export const customBlocksFile   = (dataRoot: string) => path.join(dataRoot, "cus
 export const puckComponentsFile = (dataRoot: string) => path.join(dataRoot, "puck-components.json");
 export const erLayoutFile       = (dataRoot: string) => path.join(dataRoot, "er-layout.json");
 export const screenFlowPositionsFile = (dataRoot: string) => path.join(dataRoot, "screen-flow-positions.json");
+export const externalCatalogsFile = (dataRoot: string) => path.join(catalogsDir(dataRoot), "external.json");
 export const conventionsFile    = (dataRoot: string) => path.join(conventionsDir(dataRoot), "catalog.json");
 
 const EXTENSION_FILE_NAMES = {
@@ -758,6 +760,13 @@ export async function readConventions(root: string): Promise<unknown | null> {
   const r = root;
   const dataRoot = await resolveDataRoot(r);
   return readJSON<unknown>(conventionsFile(dataRoot));
+}
+
+/** catalogs/external.json を読み込み (#939 project-level external catalogs) */
+export async function readExternalCatalogs(root: string): Promise<unknown | null> {
+  const r = root;
+  const dataRoot = await resolveDataRoot(r);
+  return readJSON<unknown>(externalCatalogsFile(dataRoot));
 }
 
 /** conventions/catalog.json を書き込み (#317) */

--- a/backend/src/wsBridge.ts
+++ b/backend/src/wsBridge.ts
@@ -83,6 +83,7 @@ import {
   deleteProcessFlow as deleteProcessFlowFile,
   listProcessFlows as listProcessFlowFiles,
   readConventions,
+  readExternalCatalogs,
   writeConventions,
   readScreenItems,
   writeScreenItems,
@@ -1367,6 +1368,11 @@ class WsBridge extends EventEmitter {
         }
         case "loadConventions": {
           const catalog = await readConventions(root());
+          respond(catalog);
+          break;
+        }
+        case "loadProjectCatalogs": {
+          const catalog = await readExternalCatalogs(root());
           respond(catalog);
           break;
         }

--- a/frontend/src/components/process-flow/ProcessFlowEditor.tsx
+++ b/frontend/src/components/process-flow/ProcessFlowEditor.tsx
@@ -4,6 +4,7 @@ import { useParams, useNavigate, Link } from "react-router-dom";
 import { useWorkspacePath } from "../../hooks/useWorkspacePath";
 import type {
   ProcessFlow,
+  ActionDefinition,
   ActionTrigger,
   Step,
   StepType,
@@ -32,6 +33,7 @@ import { aggregateValidation } from "../../utils/aggregatedValidation";
 import type { TableDefinition as ValidatorTableDef } from "../../schemas/sqlColumnValidator";
 import type { ConventionsCatalog } from "../../schemas/conventionsValidator";
 import type { GenericDefinitionNames } from "../../schemas/referentialIntegrity";
+import type { ProjectCatalogs } from "../../schemas/projectCatalogs";
 import { loadExtensionsFromBundle, type LoadedExtensions } from "../../schemas/loadExtensions";
 import { loadConventions } from "../../store/conventionsStore";
 import { listGenericDefinitions } from "../../store/genericDefinitionStore";
@@ -89,19 +91,21 @@ import { ServerChangeBanner } from "../common/ServerChangeBanner";
 import "../../styles/processFlow.css";
 
 /** ツールバーのドラッグ可能なステップ種別ボタン */
-function ToolbarStepButton({ type, onClick }: { type: StepType; onClick: () => void }) {
+function ToolbarStepButton({ type, onClick, disabled = false }: { type: StepType; onClick: () => void; disabled?: boolean }) {
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: `toolbar-${type}`,
     data: { kind: "toolbar-step", stepType: type },
+    disabled,
   });
   return (
     <button
       ref={setNodeRef}
-      {...listeners}
-      {...attributes}
+      {...(disabled ? {} : listeners)}
+      {...(disabled ? {} : attributes)}
       className={`step-toolbar-btn${isDragging ? " dragging" : ""}`}
       onClick={onClick}
       title={`${STEP_TYPE_LABELS[type]}（ドラッグで挿入）`}
+      disabled={disabled}
       style={isDragging ? { opacity: 0.5, borderColor: STEP_TYPE_COLORS[type] } : undefined}
     >
       <i className={STEP_TYPE_ICONS[type]} />
@@ -116,16 +120,20 @@ function StepInsertZone({
   onClick,
   onPaste,
   dragVisible,
+  disabled = false,
 }: {
   index: number;
   onClick: () => void;
   onPaste?: () => void;
   dragVisible?: boolean;
+  disabled?: boolean;
 }) {
   const { setNodeRef, isOver } = useDroppable({
     id: `insert-${index}`,
     data: { kind: "insert-zone", insertIndex: index },
+    disabled,
   });
+  if (disabled) return null;
   return (
     <div
       ref={setNodeRef}
@@ -143,10 +151,11 @@ function StepInsertZone({
   );
 }
 
-function EmptyFlowDropZone({ children }: { children: ReactNode }) {
+function EmptyFlowDropZone({ children, disabled = false }: { children: ReactNode; disabled?: boolean }) {
   const { setNodeRef, isOver } = useDroppable({
     id: "empty-flow-drop",
     data: { kind: "insert-zone", insertIndex: 0 },
+    disabled,
   });
   return (
     <div ref={setNodeRef} className={`step-empty process-flow-empty-drop${isOver ? " drop-active" : ""}`}>
@@ -172,6 +181,60 @@ const ALL_SUB_STEP_TYPES: StepType[] = [
 ];
 
 const ALL_TRIGGERS: ActionTrigger[] = ["click", "submit", "select", "change", "load", "timer", "other"];
+
+const ACTION_TRIGGER_ICONS: Record<string, string> = {
+  click: "bi-cursor",
+  submit: "bi-send",
+  select: "bi-list-check",
+  change: "bi-pencil-square",
+  load: "bi-box-arrow-in-down",
+  unload: "bi-box-arrow-right",
+  timer: "bi-clock",
+  manual: "bi-person-check",
+  other: "bi-lightning-charge",
+};
+
+const ACTION_TRIGGER_HINTS: Record<string, string> = {
+  click: "ボタンやリンクのクリック時に実行する画面操作です。例: 登録ボタン、削除ボタン。",
+  submit: "フォーム送信時に実行する入力確定処理です。例: 入力検証、DB 保存、完了応答。",
+  select: "行や候補の選択時に実行する参照・反映処理です。例: 一覧行選択、候補選択。",
+  change: "入力値の変更時に実行する再計算・連動更新です。例: 金額再計算、項目表示切替。",
+  load: "画面やデータの読み込み時に実行する初期表示処理です。例: 初期検索、選択肢取得。",
+  unload: "画面離脱や終了時に実行する後始末です。例: 一時保存、ロック解放。",
+  timer: "一定時刻や周期で実行する処理です。例: 自動更新、期限チェック。",
+  manual: "ユーザーや運用者が明示的に起動する処理です。例: 手動再実行、管理操作。",
+  other: "上記に当てはまらない独自契機の処理です。trigger の意図を description に補足してください。",
+};
+
+const ACTION_TRIGGER_CATEGORIES: Record<string, string> = {
+  click: "画面操作",
+  submit: "入力確定",
+  select: "選択連動",
+  change: "値変更",
+  load: "初期表示",
+  unload: "終了処理",
+  timer: "時刻・周期",
+  manual: "手動実行",
+  other: "その他",
+};
+
+const getActionTriggerLabel = (trigger: string) => ACTION_TRIGGER_LABELS[trigger] ?? trigger;
+const getActionTriggerIcon = (trigger: string) => ACTION_TRIGGER_ICONS[trigger] ?? ACTION_TRIGGER_ICONS.other;
+const getActionTriggerHint = (trigger: string) => ACTION_TRIGGER_HINTS[trigger] ?? ACTION_TRIGGER_HINTS.other;
+const getActionTriggerCategory = (trigger: string) => ACTION_TRIGGER_CATEGORIES[trigger] ?? ACTION_TRIGGER_CATEGORIES.other;
+
+function buildActionTabTitle(action: ActionDefinition): string {
+  const triggerLabel = getActionTriggerLabel(action.trigger);
+  const inputs = action.inputs?.length ?? 0;
+  const outputs = action.outputs?.length ?? 0;
+  const responses = action.responses?.length ?? 0;
+  return [
+    `${action.name} (${triggerLabel})`,
+    `カテゴリ: ${getActionTriggerCategory(action.trigger)}`,
+    getActionTriggerHint(action.trigger),
+    `定義: steps ${action.steps.length}件 / inputs ${inputs}件 / outputs ${outputs}件 / responses ${responses}件`,
+  ].join("\n");
+}
 
 function CustomStepButton({ id, label, icon, description }: { id: string; label: string; icon: string; description: string }) {
   return (
@@ -217,6 +280,7 @@ export function ProcessFlowEditor() {
   const [extensions, setExtensions] = useState<LoadedExtensions | undefined>(undefined);
   // #1090: Generic Definition Catalog の name set (componentRef / exceptionTypeRef 検証用)
   const [genericDefNames, setGenericDefNames] = useState<GenericDefinitionNames>({});
+  const [projectCatalogs, setProjectCatalogs] = useState<ProjectCatalogs | null>(null);
   const [newStepIds, setNewStepIds] = useState<Set<string>>(new Set());
 
   // 選択・クリップボード state
@@ -277,6 +341,9 @@ export function ProcessFlowEditor() {
     loadConventions()
       .then((c) => setConventions(c as ConventionsCatalog | null))
       .catch(() => setConventions(null));
+    mcpBridge.request("loadProjectCatalogs")
+      .then((c) => setProjectCatalogs(c as ProjectCatalogs | null))
+      .catch(() => setProjectCatalogs(null));
     mcpBridge.getExtensions()
       .then((bundle) => setExtensions(loadExtensionsFromBundle(bundle).extensions))
       .catch(() => setExtensions(undefined));
@@ -428,7 +495,13 @@ export function ProcessFlowEditor() {
 
   // 保存時にバリデーションをチェック（blocking なエラーがあれば中断）
   const handleSave = useCallback(async () => {
-    if (!group || isReadonly || hasBlockingErrors(aggregateValidation(group, { tables: tableDefs, conventions, extensions, genericDefinitionNames: genericDefNames }))) return;
+    if (!group || isReadonly || hasBlockingErrors(aggregateValidation(group, {
+      tables: tableDefs,
+      conventions,
+      extensions,
+      genericDefinitionNames: genericDefNames,
+      projectCatalogs,
+    }))) return;
     // P1 fix (#908 round-5): debounce 中の draft を flush して即送信、その後 conflict check
     if (draftUpdateTimer.current) {
       clearTimeout(draftUpdateTimer.current);
@@ -441,7 +514,7 @@ export function ProcessFlowEditor() {
     const { conflicted, failed } = await editActions.save();
     if (conflicted || failed) return;
     await hookPostSave();
-  }, [group, isReadonly, hookPostSave, tableDefs, conventions, extensions, genericDefNames, editActions, editSession]);
+  }, [group, isReadonly, hookPostSave, tableDefs, conventions, extensions, genericDefNames, projectCatalogs, editActions, editSession]);
 
   // D&D: PointerSensor に移動距離閾値を設定（クリックとドラッグを区別）
   const sensors = useSensors(
@@ -505,8 +578,14 @@ export function ProcessFlowEditor() {
   }, [processFlowId, sessionLoading, mode.kind]);
 
   const validationErrors = useMemo(
-    () => group ? aggregateValidation(group, { tables: tableDefs, conventions, extensions, genericDefinitionNames: genericDefNames }) : [],
-    [group, tableDefs, conventions, extensions, genericDefNames],
+    () => group ? aggregateValidation(group, {
+      tables: tableDefs,
+      conventions,
+      extensions,
+      genericDefinitionNames: genericDefNames,
+      projectCatalogs,
+    }) : [],
+    [group, tableDefs, conventions, extensions, genericDefNames, projectCatalogs],
   );
 
   useEffect(() => {
@@ -531,7 +610,7 @@ export function ProcessFlowEditor() {
   const visibleActions = group?.actions.filter((act) => {
     if (!normalizedCommandQuery) return true;
     return act.name.toLowerCase().includes(normalizedCommandQuery)
-      || ACTION_TRIGGER_LABELS[act.trigger].toLowerCase().includes(normalizedCommandQuery)
+      || getActionTriggerLabel(act.trigger).toLowerCase().includes(normalizedCommandQuery)
       || act.trigger.toLowerCase().includes(normalizedCommandQuery);
   }) ?? [];
 
@@ -643,6 +722,7 @@ export function ProcessFlowEditor() {
 
   const handleDragEnd = (event: DragEndEvent) => {
     setIsDraggingToolbarStep(false);
+    if (isReadonly) return;
     const { active, over } = event;
     if (!over || !activeAction) return;
 
@@ -832,7 +912,7 @@ export function ProcessFlowEditor() {
     onMoveUp: () => handleMoveSelectedByKeyboard(-1),
     onMoveDown: () => handleMoveSelectedByKeyboard(1),
     onEscape: handleEscapeSelection,
-    enabled: selectedIds.size > 0 || clipboard !== null,
+    enabled: !isReadonly && (selectedIds.size > 0 || clipboard !== null),
   });
 
   // 画面項目ピッカーのコールバック (#321) — hooks は early return より前で定義
@@ -1169,7 +1249,7 @@ export function ProcessFlowEditor() {
           <div className="process-flow-command-title">
             <span className="process-flow-command-eyebrow">Action</span>
             <strong>{activeAction?.name ?? "アクション未選択"}</strong>
-            {activeAction && <span className="text-muted small">{ACTION_TRIGGER_LABELS[activeAction.trigger]}</span>}
+            {activeAction && <span className="text-muted small">{getActionTriggerLabel(activeAction.trigger)}</span>}
           </div>
           <div className="process-flow-command-search">
             <i className="bi bi-search" />
@@ -1186,7 +1266,11 @@ export function ProcessFlowEditor() {
                 <button
                   className={`process-flow-tab ${activeActionId === act.id ? "active" : ""}`}
                   onClick={() => setActiveActionId(act.id)}
+                  title={buildActionTabTitle(act)}
                 >
+                  <span className="process-flow-tab-trigger-icon" aria-hidden="true">
+                    <i className={`bi ${getActionTriggerIcon(act.trigger)}`} />
+                  </span>
                   <MaturityBadge
                     maturity={act.maturity}
                     onChange={(next) => {
@@ -1197,32 +1281,40 @@ export function ProcessFlowEditor() {
                     }}
                   />
                   {act.name}
-                  <span className="ms-1 text-muted small">({ACTION_TRIGGER_LABELS[act.trigger]})</span>
+                  <span className="process-flow-tab-trigger-label">{getActionTriggerLabel(act.trigger)}</span>
                 </button>
-                <button
-                  className="process-flow-tab-remove"
-                  onClick={() => handleDeleteAction(act.id)}
-                  title="アクション削除"
-                >
-                  <i className="bi bi-x" />
-                </button>
+                {!isReadonly && (
+                  <button
+                    className="process-flow-tab-remove"
+                    onClick={() => handleDeleteAction(act.id)}
+                    title="アクション削除"
+                  >
+                    <i className="bi bi-x" />
+                  </button>
+                )}
               </div>
             ))}
             {visibleActions.length === 0 && (
               <span className="process-flow-tab-empty">一致するアクションがありません</span>
             )}
-            <button
-              className="process-flow-tab-add"
-              onClick={() => setShowAddAction(true)}
-              title="アクション追加"
-            >
-              <i className="bi bi-plus-lg" />
-            </button>
+            {!isReadonly && (
+              <button
+                className="process-flow-tab-add"
+                onClick={() => setShowAddAction(true)}
+                title="アクション追加"
+              >
+                <i className="bi bi-plus-lg" />
+              </button>
+            )}
           </div>
           <div className="process-flow-command-hints">
-            <span><kbd>Ctrl</kbd>+<kbd>C</kbd> コピー</span>
-            <span><kbd>Ctrl</kbd>+<kbd>V</kbd> 貼付</span>
-            <span><kbd>右クリック</kbd> 操作</span>
+            {!isReadonly && (
+              <>
+                <span><kbd>Ctrl</kbd>+<kbd>C</kbd> コピー</span>
+                <span><kbd>Ctrl</kbd>+<kbd>V</kbd> 貼付</span>
+                <span><kbd>右クリック</kbd> 操作</span>
+              </>
+            )}
           </div>
           <EditLevelToggle
             value={editLevel}
@@ -1245,7 +1337,7 @@ export function ProcessFlowEditor() {
                   <span className="process-flow-pane-kicker">Blocks</span>
                   <h6>ブロック</h6>
                 </div>
-                <span className="process-flow-pane-badge">D&D</span>
+                {!isReadonly && <span className="process-flow-pane-badge">D&D</span>}
               </div>
               <div className="process-flow-palette-search">
                 <i className="bi bi-search" />
@@ -1259,7 +1351,7 @@ export function ProcessFlowEditor() {
               <div className="step-toolbar">
                 <div className="process-flow-palette-section">基本ステップ</div>
                 {filteredStepTypes.map((type) => (
-                  <ToolbarStepButton key={type} type={type} onClick={() => handleAddStep(type)} />
+                  <ToolbarStepButton key={type} type={type} onClick={() => handleAddStep(type)} disabled={isReadonly} />
                 ))}
                 {filteredStepTypes.length === 0 && (
                   <div className="process-flow-palette-empty">該当するブロックがありません</div>
@@ -1284,6 +1376,7 @@ export function ProcessFlowEditor() {
                   <button
                     className="step-template-btn"
                     onClick={() => setShowTemplates(!showTemplates)}
+                    disabled={isReadonly}
                   >
                     <i className="bi bi-collection" />
                     テンプレート
@@ -1324,15 +1417,16 @@ export function ProcessFlowEditor() {
                 {activeAction ? (
                   <div className="step-editor">
                     {activeAction.steps.length === 0 ? (
-                      <EmptyFlowDropZone>
+                      <EmptyFlowDropZone disabled={isReadonly}>
                         <i className="bi bi-plus-circle" />
                         <strong>ステップがありません</strong>
-                        <span>左のブロックをドラッグするか、ブロックをクリックして追加してください。</span>
+                        <span>{isReadonly ? "編集開始後にステップを追加できます。" : "左のブロックをドラッグするか、ブロックをクリックして追加してください。"}</span>
                         <StepInsertZone
                           index={0}
                           onClick={() => handleAddStep("other")}
-                          onPaste={clipboard ? () => handlePaste(0) : undefined}
+                          onPaste={clipboard && !isReadonly ? () => handlePaste(0) : undefined}
                           dragVisible={isDraggingToolbarStep}
+                          disabled={isReadonly}
                         />
                       </EmptyFlowDropZone>
                     ) : (
@@ -1358,8 +1452,9 @@ export function ProcessFlowEditor() {
                         <StepInsertZone
                           index={index}
                           onClick={() => handleAddStep("other", index)}
-                          onPaste={clipboard ? () => handlePaste(index) : undefined}
+                          onPaste={clipboard && !isReadonly ? () => handlePaste(index) : undefined}
                           dragVisible={isDraggingToolbarStep}
+                          disabled={isReadonly}
                         />
                         <SortableStepCard
                           step={step}
@@ -1378,6 +1473,7 @@ export function ProcessFlowEditor() {
                           onAddSubStep={(type) => handleAddSubStep(step.id, type)}
                           onContextMenu={(e) => {
                             e.preventDefault();
+                            if (isReadonly) return;
                             setSelectedIds(new Set([step.id]));
                             lastSelectedIdRef.current = step.id;
                             setContextMenu({ x: e.clientX, y: e.clientY, stepId: step.id });
@@ -1408,6 +1504,7 @@ export function ProcessFlowEditor() {
                           conventions={conventions}
                           group={group}
                           editLevel={editLevel}
+                          readOnly={isReadonly}
                           onAskAi={() => {
                             const label = `S${index + 1}: ${step.description ?? step.kind ?? step.id}`;
                             aiChips.addStepChip(String(step.id), label, step);
@@ -1420,8 +1517,9 @@ export function ProcessFlowEditor() {
                           <StepInsertZone
                             index={activeAction.steps.length}
                             onClick={() => handleAddStep("other")}
-                            onPaste={clipboard ? () => handlePaste(activeAction.steps.length) : undefined}
+                            onPaste={clipboard && !isReadonly ? () => handlePaste(activeAction.steps.length) : undefined}
                             dragVisible={isDraggingToolbarStep}
+                            disabled={isReadonly}
                           />
                         </div>
                       </SortableContext>
@@ -1467,12 +1565,20 @@ export function ProcessFlowEditor() {
                     } : undefined}
                   />
                 </div>
-                <ActionMetaTabBar
-                  group={group}
-                  updateGroup={updateGroup}
-                  updateGroupSilent={updateGroupSilent}
-                />
-                {activeAction && (
+                {isReadonly ? (
+                  <div className="process-flow-inspector-section">
+                    <div className="text-muted small">
+                      詳細項目の編集は「編集開始」後に利用できます。
+                    </div>
+                  </div>
+                ) : (
+                  <ActionMetaTabBar
+                    group={group}
+                    updateGroup={updateGroup}
+                    updateGroupSilent={updateGroupSilent}
+                  />
+                )}
+                {!isReadonly && activeAction && (
                   <>
                     <div className="process-flow-inspector-section">
                       <ActionHttpContractPanel
@@ -1540,7 +1646,7 @@ export function ProcessFlowEditor() {
       </div>
 
       {/* コンテキストメニュー */}
-      {contextMenu && (
+      {!isReadonly && contextMenu && (
         <div
           className="step-context-menu"
           style={{ top: contextMenu.y, left: contextMenu.x }}
@@ -1650,7 +1756,7 @@ export function ProcessFlowEditor() {
       )}
 
       {/* アクション追加モーダル */}
-      {showAddAction && (
+      {showAddAction && !isReadonly && (
         <div className="process-flow-modal-overlay" onClick={() => setShowAddAction(false)}>
           <div className="process-flow-modal" onClick={(e) => e.stopPropagation()}>
             <h6>アクション追加</h6>
@@ -1672,7 +1778,7 @@ export function ProcessFlowEditor() {
                 onChange={(e) => setNewActionTrigger(e.target.value as ActionTrigger)}
               >
                 {ALL_TRIGGERS.map((t) => (
-                  <option key={t} value={t}>{ACTION_TRIGGER_LABELS[t]}</option>
+                  <option key={t} value={t}>{getActionTriggerLabel(t)}</option>
                 ))}
               </select>
             </div>

--- a/frontend/src/components/process-flow/ProcessFlowListView.tsx
+++ b/frontend/src/components/process-flow/ProcessFlowListView.tsx
@@ -16,6 +16,7 @@ import { aggregateValidation } from "../../utils/aggregatedValidation";
 import type { TableDefinition as ValidatorTableDef } from "../../schemas/sqlColumnValidator";
 import type { ConventionsCatalog } from "../../schemas/conventionsValidator";
 import type { GenericDefinitionNames } from "../../schemas/referentialIntegrity";
+import type { ProjectCatalogs } from "../../schemas/projectCatalogs";
 import { loadConventions } from "../../store/conventionsStore";
 import { listTables, loadTable } from "../../store/tableStore";
 import { listGenericDefinitions } from "../../store/genericDefinitionStore";
@@ -88,6 +89,7 @@ export function ProcessFlowListView() {
   const [conventions, setConventions] = useState<ConventionsCatalog | null>(null);
   // #1090: Generic Definition Catalog の name set (componentRef / exceptionTypeRef 検証用)
   const [genericDefNames, setGenericDefNames] = useState<GenericDefinitionNames>({});
+  const [projectCatalogs, setProjectCatalogs] = useState<ProjectCatalogs | null>(null);
   const [viewMode, setViewMode] = usePersistentState<ViewMode>(STORAGE_KEY, "card");
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; items: ContextMenuItem[] } | null>(null);
   // #893: draft history modal
@@ -168,6 +170,9 @@ export function ProcessFlowListView() {
         "exception-type": new Set(exceptions.map((e) => e.name)),
       });
     });
+    mcpBridge.request("loadProjectCatalogs")
+      .then((c) => { if (!cancelled) setProjectCatalogs(c as ProjectCatalogs | null); })
+      .catch(() => setProjectCatalogs(null));
     return () => { cancelled = true; };
   }, []);
 
@@ -186,6 +191,7 @@ export function ProcessFlowListView() {
           tables: tableDefs,
           conventions,
           genericDefinitionNames: genericDefNames,
+          projectCatalogs,
         });
         setValidationMap((prev) => {
           const next = new Map(prev);
@@ -211,7 +217,7 @@ export function ProcessFlowListView() {
       }
     })();
     return () => { cancelled = true; };
-  }, [groups, tableDefs, conventions, genericDefNames]);
+  }, [groups, tableDefs, conventions, genericDefNames, projectCatalogs]);
 
   const getErrorPriority = useCallback((id: string): number => {
     const v = validationMap.get(id);

--- a/frontend/src/components/process-flow/SortableStepCard.tsx
+++ b/frontend/src/components/process-flow/SortableStepCard.tsx
@@ -38,9 +38,10 @@ interface SortableStepCardProps {
   editLevel?: "rough" | "detail" | "implementation";
   /** #1076 AI 依頼ボタン押下時のコールバック */
   onAskAi?: () => void;
+  readOnly?: boolean;
 }
 
-export function SortableStepCard({ step, ...props }: SortableStepCardProps) {
+export function SortableStepCard({ step, readOnly = false, ...props }: SortableStepCardProps) {
   const {
     attributes,
     listeners,
@@ -48,7 +49,7 @@ export function SortableStepCard({ step, ...props }: SortableStepCardProps) {
     transform,
     transition,
     isDragging,
-  } = useSortable({ id: step.id });
+  } = useSortable({ id: step.id, disabled: readOnly });
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -61,8 +62,9 @@ export function SortableStepCard({ step, ...props }: SortableStepCardProps) {
       <StepCard
         step={step}
         {...props}
-        dragHandleListeners={listeners}
-        dragHandleAttributes={attributes}
+        dragHandleListeners={readOnly ? undefined : listeners}
+        dragHandleAttributes={readOnly ? undefined : attributes}
+        readOnly={readOnly}
         depth={0}
       />
     </div>

--- a/frontend/src/components/process-flow/StepCard.tsx
+++ b/frontend/src/components/process-flow/StepCard.tsx
@@ -91,6 +91,7 @@ interface InlineStepListProps {
   validationErrors?: ValidationError[];
   conventions?: import("../../schemas/conventionsValidator").ConventionsCatalog | null;
   group?: ProcessFlow | null;
+  readOnly?: boolean;
 }
 
 function InlineStepList({
@@ -106,6 +107,7 @@ function InlineStepList({
   validationErrors,
   conventions,
   group,
+  readOnly = false,
 }: InlineStepListProps) {
   const [showTypePicker, setShowTypePicker] = useState(false);
 
@@ -171,10 +173,11 @@ function InlineStepList({
             validationErrors={validationErrors}
             conventions={conventions}
             group={group}
+            readOnly={readOnly}
           />
         </div>
       ))}
-      <div className="inline-step-add">
+      {!readOnly && <div className="inline-step-add">
         <button className="inline-add-btn" onClick={() => setShowTypePicker(!showTypePicker)}>
           <i className="bi bi-plus" /> ステップを追加
         </button>
@@ -188,7 +191,7 @@ function InlineStepList({
             ))}
           </div>
         )}
-      </div>
+      </div>}
     </div>
   );
 }
@@ -237,6 +240,7 @@ interface StepCardProps {
   editLevel?: "rough" | "detail" | "implementation";
   /** #1076 AI 依頼ボタン押下時のコールバック */
   onAskAi?: () => void;
+  readOnly?: boolean;
 }
 
 const DB_OPS: DbOperation[] = ["SELECT", "INSERT", "UPDATE", "DELETE"];
@@ -280,6 +284,7 @@ export function StepCard({
   markerKinds,
   editLevel = "implementation",
   onAskAi,
+  readOnly = false,
 }: StepCardProps) {
   const [expanded, setExpanded] = useState(defaultExpanded ?? false);
   const [showMenu, setShowMenu] = useState(false);
@@ -453,7 +458,7 @@ export function StepCard({
             }
           }}
         >
-          {(dragHandleListeners || dragHandleAttributes) && (
+          {!readOnly && (dragHandleListeners || dragHandleAttributes) && (
             <span
               className="step-card-drag-handle"
               title="ドラッグで移動"
@@ -631,7 +636,7 @@ export function StepCard({
               <i className="bi bi-robot" />
             </button>
           )}
-          <div className="d-flex gap-1 ms-auto" style={{ flexShrink: 0 }}>
+          {!readOnly && <div className="d-flex gap-1 ms-auto" style={{ flexShrink: 0 }}>
             {onOutdent && (
               <button className="step-card-menu-btn" onClick={(e) => { e.stopPropagation(); onOutdent(); }} title="上位レベルに移動（アウトデント）">
                 <i className="bi bi-chevron-left" />
@@ -711,7 +716,7 @@ export function StepCard({
                 </div>
               )}
             </div>
-          </div>
+          </div>}
         </div>
 
         {/* バリデーションメッセージ */}
@@ -1475,7 +1480,7 @@ export function StepCard({
                             </button>
                           </div>
                         )}
-                        {bi > 0 && (
+                        {!readOnly && bi > 0 && (
                           <button
                             className="step-card-menu-btn"
                             title="上に移動"
@@ -1484,7 +1489,7 @@ export function StepCard({
                             <i className="bi bi-chevron-up" />
                           </button>
                         )}
-                        {bi < step.branches.length - 1 && (
+                        {!readOnly && bi < step.branches.length - 1 && (
                           <button
                             className="step-card-menu-btn"
                             title="下に移動"
@@ -1493,7 +1498,7 @@ export function StepCard({
                             <i className="bi bi-chevron-down" />
                           </button>
                         )}
-                        {step.branches.length > 1 && (
+                        {!readOnly && step.branches.length > 1 && (
                           <button
                             className="step-card-menu-btn danger"
                             title="分岐を削除"
@@ -1522,6 +1527,7 @@ export function StepCard({
                             validationErrors={validationErrors}
                             conventions={conventions}
                             group={group}
+                            readOnly={readOnly}
                           />
                         </div>
                       )}
@@ -1543,7 +1549,7 @@ export function StepCard({
                         <span style={{ flex: 1, fontSize: "0.78rem", color: "#64748b" }}>
                           その他の場合
                         </span>
-                        <button
+                        {!readOnly && <button
                           className="step-card-menu-btn danger"
                           title="ELSE分岐を削除"
                           onClick={(e) => {
@@ -1553,7 +1559,7 @@ export function StepCard({
                           }}
                         >
                           <i className="bi bi-trash" />
-                        </button>
+                        </button>}
                         <i
                           className={`bi bi-chevron-${isCollapsed ? "right" : "down"}`}
                           style={{ color: "#94a3b8", flexShrink: 0 }}
@@ -1576,6 +1582,7 @@ export function StepCard({
                             validationErrors={validationErrors}
                             conventions={conventions}
                             group={group}
+                            readOnly={readOnly}
                           />
                         </div>
                       )}
@@ -1583,7 +1590,7 @@ export function StepCard({
                   );
                 })()}
 
-                <div className="branch-add-row">
+                {!readOnly && <div className="branch-add-row">
                   <button className="branch-add-btn" onClick={addBranch}>
                     <i className="bi bi-plus" /> 分岐を追加
                   </button>
@@ -1592,7 +1599,7 @@ export function StepCard({
                       <i className="bi bi-plus" /> ELSE分岐
                     </button>
                   )}
-                </div>
+                </div>}
               </div>
             )}
 
@@ -1711,6 +1718,7 @@ export function StepCard({
                         validationErrors={validationErrors}
                         conventions={conventions}
                         group={group}
+                        readOnly={readOnly}
                       />
                     </div>
                   )}
@@ -1791,6 +1799,7 @@ export function StepCard({
                     onNavigateCommon={onNavigateCommon}
                     validationErrors={validationErrors}
                     conventions={conventions}
+                    readOnly={readOnly}
                   />
                 )}
               />
@@ -1870,6 +1879,7 @@ export function StepCard({
                 group={group}
                 editLevel={editLevel}
                 onAskAi={onAskAi}
+                readOnly={readOnly}
               />
             </div>
           ))}

--- a/frontend/src/styles/processFlow.css
+++ b/frontend/src/styles/processFlow.css
@@ -215,6 +215,25 @@
   transition: color 0.15s, background 0.15s, box-shadow 0.15s;
 }
 
+.process-flow-tab-trigger-icon {
+  width: 18px;
+  height: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  background: #e0f2fe;
+  color: #0369a1;
+  font-size: 0.8rem;
+  flex: 0 0 auto;
+}
+
+.process-flow-tab-trigger-label {
+  color: #64748b;
+  font-size: 0.72rem;
+  font-weight: 600;
+}
+
 .process-flow-tab:hover {
   color: #334155;
 }
@@ -223,6 +242,11 @@
   color: #17202c;
   background: transparent;
   box-shadow: none;
+}
+
+.process-flow-tab.active .process-flow-tab-trigger-icon {
+  background: #dbeafe;
+  color: #1d4ed8;
 }
 
 .process-flow-tab-remove {

--- a/frontend/src/utils/aggregatedValidation.test.ts
+++ b/frontend/src/utils/aggregatedValidation.test.ts
@@ -280,4 +280,31 @@ describe("aggregateValidation — 統合テスト", () => {
     expect(errors.every((e) => e.code !== "UNKNOWN_COMPONENT_REF")).toBe(true);
     expect(errors.every((e) => e.code !== "UNKNOWN_EXCEPTION_TYPE_REF")).toBe(true);
   });
+
+  it("project-level modelEndpoints を参照整合性検査に渡す", () => {
+    const group = makeGroup({
+      actions: [{
+        id: "a1", name: "f", trigger: "click",
+        steps: [{
+          id: "s1",
+          kind: "aiCall",
+          description: "",
+          modelRef: "summarizeModel",
+          messages: [{ role: "user", content: "@body" }],
+        }],
+      }],
+    } as Partial<ProcessFlow>);
+
+    const withoutCatalog = aggregateValidation(group);
+    expect(withoutCatalog.some((e) => e.code === "UNKNOWN_MODEL_REF")).toBe(true);
+
+    const withCatalog = aggregateValidation(group, {
+      projectCatalogs: {
+        modelEndpoints: {
+          summarizeModel: { provider: "anthropic", model: "claude-opus-4-7" },
+        },
+      },
+    });
+    expect(withCatalog.some((e) => e.code === "UNKNOWN_MODEL_REF")).toBe(false);
+  });
 });

--- a/frontend/src/utils/aggregatedValidation.ts
+++ b/frontend/src/utils/aggregatedValidation.ts
@@ -16,6 +16,7 @@ import { checkSqlColumns, type TableDefinition } from "../schemas/sqlColumnValid
 import { checkConventionReferences, type ConventionsCatalog } from "../schemas/conventionsValidator";
 import { isBuiltinStep } from "../schemas/stepGuards";
 import type { LoadedExtensions } from "../schemas/loadExtensions";
+import type { ProjectCatalogs } from "../schemas/projectCatalogs";
 
 export interface AggregatedValidationOptions {
   /** テーブル定義。渡された場合は DbAccessStep.sql の列参照を検査 */
@@ -29,6 +30,8 @@ export interface AggregatedValidationOptions {
    * undefined の場合は silent pass (catalog ロード失敗時の互換性維持)。
    */
   genericDefinitionNames?: GenericDefinitionNames;
+  /** project-level external catalog。flow-level catalog と merge して参照検査する */
+  projectCatalogs?: ProjectCatalogs | null;
 }
 
 /**
@@ -47,7 +50,12 @@ export function aggregateValidation(
 
   // 2. 参照整合性 (responseId / errorCode / systemRef / typeRef / secretRef
   //    + componentRef / exceptionTypeRef #1090)
-  for (const issue of checkReferentialIntegrity(group, options.extensions, undefined, options.genericDefinitionNames)) {
+  for (const issue of checkReferentialIntegrity(
+    group,
+    options.extensions,
+    options.projectCatalogs ?? undefined,
+    options.genericDefinitionNames,
+  )) {
     errors.push({
       stepId: stepIdFromPath(issue.path, group) ?? "",
       severity: "warning",
@@ -58,7 +66,7 @@ export function aggregateValidation(
   }
 
   // 3. 識別子スコープ (@identifier)
-  for (const issue of checkIdentifierScopes(group)) {
+  for (const issue of checkIdentifierScopes(group, options.projectCatalogs ?? undefined)) {
     errors.push({
       stepId: stepIdFromPath(issue.path, group) ?? "",
       severity: "warning",


### PR DESCRIPTION
## 関連

- Closes #1087
- Follow-up: #1093
- 仕様: N/A
  - 既存の draft-state / edit-session readonly 方針に沿った不具合修正。新規 spec 追加なし。

## 概要

ProcessFlowEditor で project-level `modelEndpoints` が validation に渡らず、正しい `modelRef` が UNKNOWN_MODEL_REF として警告表示される問題を修正します。あわせて、readonly 状態でも D&D や削除メニューなど編集導線が見える問題を閉じ、アクションタブに簡易アイコンと短いヒントを追加します。

## 主な変更

- modelEndpoints 参照検査: `harmony/catalogs/external.json` を backend 経由で読み込み、ProcessFlowEditor / ProcessFlowListView の `aggregateValidation` に渡す
- readonly 操作抑止: ステップ D&D、挿入線、右クリック/三点編集メニュー、アクション追加/削除導線を editing 時だけ表示・有効化
- アクション一覧の簡易視認性: trigger アイコン、trigger ラベル、カテゴリ付き `title` ヒントを追加
- validation test: project-level `modelEndpoints.summarizeModel` で UNKNOWN_MODEL_REF が出ないケースを追加

## 仕様逐条突合 (自己申告)

- project-level catalogs を flow-level catalogs と merge して参照検査する: `frontend/src/utils/aggregatedValidation.ts:21` / `frontend/src/utils/aggregatedValidation.ts:53` ✓
- `harmony/catalogs/external.json` を backend から読み込む: `backend/src/projectStorage.ts:765` / `backend/src/wsBridge.ts:1374` ✓
- ProcessFlowEditor が project catalogs を読み込み validation に渡す: `frontend/src/components/process-flow/ProcessFlowEditor.tsx:344` / `frontend/src/components/process-flow/ProcessFlowEditor.tsx:580` ✓
- ProcessFlowListView が一覧 validation に project catalogs を渡す: `frontend/src/components/process-flow/ProcessFlowListView.tsx:173` / `frontend/src/components/process-flow/ProcessFlowListView.tsx:190` ✓
- readonly 時に編集導線を隠す / 無効化する: `frontend/src/components/process-flow/ProcessFlowEditor.tsx:1263` / `frontend/src/components/process-flow/ProcessFlowEditor.tsx:1340` / `frontend/src/components/process-flow/ProcessFlowEditor.tsx:1420` ✓
- アクション一覧の簡易アイコン・ヒントを表示する: `frontend/src/components/process-flow/ProcessFlowEditor.tsx:185` / `frontend/src/components/process-flow/ProcessFlowEditor.tsx:226` / `frontend/src/components/process-flow/ProcessFlowEditor.tsx:1266` ✓
- アイコン表示 CSS: `frontend/src/styles/processFlow.css:218` ✓
- regression test: `frontend/src/utils/aggregatedValidation.test.ts:284` ✓

## レビューで特に見てほしい箇所

- `aggregateValidation` は main 側の #1090 generic-definition 参照検査と今回の projectCatalogs を併用するよう rebase 時に統合しています。
- readonly 抑止は UI 導線の表示・D&D disabled を中心にしています。既存の `updateGroupWithDraft` readonly no-op は残しています。
- リッチヘルプは #1093 に切り出し、この PR では trigger アイコン + `title` の簡易版だけです。

## テスト

- Vitest: 41 件 (新規 1 件) — `src/utils/aggregatedValidation.test.ts` / `src/schemas/referentialIntegrity.test.ts`
- Playwright: N/A
- MCP E2E: N/A
- Build: `frontend npm run build` / `backend npm run build`

## UI 影響 / AI smoke test

- [x] UI 影響あり
- [ ] UI 影響なし (auto テスト pass のみ)

### UI 影響ありの場合、AI smoke test で確認した項目

- [ ] ProcessFlowEditor: readonly 時の D&D / メニュー非表示 — ブラウザ smoke は未実施
- [ ] ProcessFlowEditor: アクションタブのアイコン・title 表示 — ブラウザ smoke は未実施
- [ ] 保存直後の JSON が Git 差分で揺れない — N/A (データ保存操作なし)
- [x] 既存機能のリグレッションなし — targeted unit + frontend/backend build で確認

## spec 側の不足点 / 提案

- リッチヘルプの情報設計は #1093 で別途扱う。

## レビュー担当への申し送り

- diary サンプル側の `summarizeModel` は `workspaces/diary/harmony/catalogs/external.json` に存在するため、今回の根本原因はサンプルスキーマ違反ではなく validation 入力不足です。
- readonly 時の編集導線は見た目の抑止と D&D disabled を入れていますが、既存の no-op ガードも併用しています。抜けている編集導線がないか見てください。
