### PR TITLE
hotfix(devcontainer): volume 名を harmony-* に revert (codex auth 復旧)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,9 +14,9 @@
   },
 
   "mounts": [
-    "source=claude-code-config-${devcontainerId},target=/home/node/.claude,type=volume",
-    "source=codex-config-${devcontainerId},target=/home/node/.codex,type=volume",
-    "source=harmony-state-${devcontainerId},target=/home/node/.harmony,type=volume"
+    "source=harmony-claude,target=/home/node/.claude,type=volume",
+    "source=harmony-codex,target=/home/node/.codex,type=volume",
+    "source=harmony-state,target=/home/node/.harmony,type=volume"
   ],
 
   "onCreateCommand": "sudo chown -R node:node /home/node/.claude /home/node/.codex /home/node/.harmony",


### PR DESCRIPTION
PR #1100 の volume 命名変更 (`${devcontainerId}` 付き) で、新規 (空) volume が mount されて既存の codex / claude データが見えなくなる regression が発生 (実機検証で発覚)。

旧 `harmony-claude` / `harmony-codex` / `harmony-state` volume は Docker 側で残存しているため、命名を戻して再 mount する。

## 影響

| 変更前 (PR #1100) | 変更後 (本 hotfix) |
|---|---|
| `claude-code-config-${devcontainerId}` (空) | `harmony-claude` (既存データ) |
| `codex-config-${devcontainerId}` (空) | `harmony-codex` (既存データ、auth.json 含む) |
| `harmony-state-${devcontainerId}` (空) | `harmony-state` (既存データ) |

`${devcontainerId}` 命名は公式 reference の multi-project isolation 目的だが、本 repo は単一プロジェクト運用なので不要。

## 残課題 (本 PR スコープ外)

- 新規 volume bootstrap 時に Claude Code の theme picker / login method picker (onboarding wizard) が出る問題
- `CLAUDE_CODE_OAUTH_TOKEN` env var で auth は通るが wizard 自体は別系統 (`.claude.json` の `hasCompletedOnboarding` flag) で発火するため env var では skip 不可
- 解決候補: managed-settings.json の `forceLoginMethod: "claudeai"` で login picker step を skip (公式手順)、または `.claude.json` への flag 注入 (ハック)

→ 別途検討

Refs #1097
