### PR TITLE
fix(devcontainer): host subdir bind mount に切替え (Named Volume → bind) (#1097)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,9 +14,9 @@
   },
 
   "mounts": [
-    "source=harmony-claude,target=/home/node/.claude,type=volume",
-    "source=harmony-codex,target=/home/node/.codex,type=volume",
-    "source=harmony-state,target=/home/node/.harmony,type=volume"
+    "source=${localEnv:HOME}/.claude-containers/${localWorkspaceFolderBasename}/.claude,target=/home/node/.claude,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.claude-containers/${localWorkspaceFolderBasename}/.codex,target=/home/node/.codex,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.claude-containers/${localWorkspaceFolderBasename}/.harmony,target=/home/node/.harmony,type=bind,consistency=cached"
   ],
 
   "onCreateCommand": "sudo chown -R node:node /home/node/.claude /home/node/.codex /home/node/.harmony",

--- a/docs/setup/dev-containers.md
+++ b/docs/setup/dev-containers.md
@@ -215,32 +215,75 @@ source ~/.bashrc
 
 トークン期限 (1 年) 前の再発行は `~/dotfiles/scripts/refresh-claude-token.sh` (個人 dotfiles 側に同梱、後述) で半自動化可能。
 
-#### 3. データ永続化: named volume + `.config.json` workaround
+#### 3. データ永続化: host subdir bind mount + `.config.json` workaround
 
-`~/.claude/` (sessions / settings / projects 配下の memory) を named volume に保存:
+`~/.claude/` (sessions / settings / projects 配下の memory) を **WSL2 host の project 別 subdir に bind mount** する。Named Volume ではなく bind mount を選んだ理由は後述の比較表参照:
 
 ```jsonc
 "mounts": [
-  "source=harmony-claude,target=/home/node/.claude,type=volume"
+  "source=${localEnv:HOME}/.claude-containers/${localWorkspaceFolderBasename}/.claude,target=/home/node/.claude,type=bind,consistency=cached",
+  "source=${localEnv:HOME}/.claude-containers/${localWorkspaceFolderBasename}/.codex,target=/home/node/.codex,type=bind,consistency=cached",
+  "source=${localEnv:HOME}/.claude-containers/${localWorkspaceFolderBasename}/.harmony,target=/home/node/.harmony,type=bind,consistency=cached"
 ]
 ```
 
-これだけだと **`~/.claude.json` ファイル (= `$HOME` 直下、`.claude/` の外) が volume の対象外** で、rebuild 毎に消える → `hasCompletedOnboarding` flag が消えて wizard が毎回発火する問題が残る。
+- `${localEnv:HOME}` = WSL2 host の `~/` (例: `/home/hidekatsu`)
+- `${localWorkspaceFolderBasename}` = project フォルダ名 (例: `harmony`) → 複数 project の自動分離
+- 結果: host 側に `~/.claude-containers/harmony/.claude/`、`~/.claude-containers/harmony/.codex/`、`~/.claude-containers/harmony/.harmony/` のディレクトリ群が作られ、container 内 `/home/node/.{claude,codex,harmony}/` と双方向同期される
 
-**解決策 (undocumented だが claude binary に実装済の機能)**: `~/.claude/.config.json` (volume 内) を存在させると、claude は **`~/.claude.json` の代わりに `~/.claude/.config.json` を state file として使う**。`postCreateCommand` で空ファイルを初期化:
+**重要**: WSL2 host の `~/.claude/` (= WSL2 native claude の保管場所) は **触らない**。`~/.claude-containers/<project>/.claude/` という別の名前空間を使うことで、WSL2 native claude と container 内 claude を **同時稼働させても干渉しない** (host `~/.claude/` 直接 bind は同時稼働で statsig 等の write 競合が起きる、bcaccd7 → 235caeb で確認済)。
+
+##### `~/.claude.json` 問題と `.config.json` workaround (継続)
+
+bind mount でも **`~/.claude.json` ファイル (= `$HOME` 直下、`.claude/` の外) は mount 対象外** で、rebuild 毎に消える → `hasCompletedOnboarding` flag が消えて wizard が毎回発火する問題は残る。
+
+**解決策 (undocumented だが claude binary に実装済の機能)**: `~/.claude/.config.json` (mount target 内) を存在させると、claude は **`~/.claude.json` の代わりに `~/.claude/.config.json` を state file として使う**。`postCreateCommand` で空ファイルを初期化:
 
 ```jsonc
 "postCreateCommand": "... && ([ -f ~/.claude/.config.json ] || echo '{}' > ~/.claude/.config.json)"
 ```
 
 挙動:
-- 初回 rebuild: 空 `.config.json` が作られる → claude 起動 → wizard 発火 (`hasCompletedOnboarding` 未設定) → user が wizard 完了 → flag が `.config.json` に書かれる (volume 内、永続)
-- **2 回目以降の rebuild**: `.config.json` が volume に残っている → flag を読んで wizard skip
+- 初回 rebuild: 空 `.config.json` が作られる → claude 起動 → wizard 発火 (`hasCompletedOnboarding` 未設定) → user が wizard 完了 → flag が `.config.json` に書かれる (host bind mount 内、永続)
+- **2 回目以降の rebuild**: `.config.json` が host 側に残っている → flag を読んで wizard skip
 
 出典: [Zenn — Dev Container で Claude Code を使う](https://zenn.dev/nstock/articles/2c1ea72861f87c)。公式 docs には未記載なので Anthropic アップデートで仕様変更の可能性ありだが、現状 (Claude Code 2.x) で動作確認済。
 
-- rebuild しても sessions / settings が残る (volume は container 破棄で消えない)
-- WSL2 host の `~/.claude/` とは独立 (memory / sessions は host と container で別々に育つ。公式が明確に「machine-local、cross-machine 共有非対応」と宣言: [Memory docs](https://code.claude.com/docs/en/memory))
+##### Named Volume vs host subdir bind mount の比較
+
+| 観点 | Named Volume (旧構成) | host subdir bind mount (現構成) |
+|---|---|---|
+| データの所在 | Docker-managed (`/var/lib/docker/volumes/...`) | WSL2 host `~/.claude-containers/<project>/` |
+| host から閲覧 | `docker run` 経由で見るしかない | 普通の `ls`/`cat`/`vi` 可能 |
+| WSL2 native claude との競合 | なし (完全分離) | なし (host `~/.claude/` は触らない、別名前空間) |
+| backup | `docker volume export` 等 | rsync / git / 通常手段 |
+| `docker volume prune` で消える | はい (誤操作リスク) | いいえ (host filesystem) |
+| project 自動分離 | `${devcontainerId}` (hash) | `${localWorkspaceFolderBasename}` (人間可読、`~/.claude-containers/<name>/`) |
+| 公式 docs 推奨度 | ◎ named volume を例示 | △ 明示言及なし (host `~/.claude/` 直接 bind は warning ありだが本構成は別名前空間なので該当せず) |
+
+bind mount に切り替えた狙い: **host から見えて backup / 障害復旧が楽**、`docker volume prune` で誤消失しない、`~/.claude-containers/<project>/` で人間可読な project 分離。
+
+##### Named Volume からの migration (旧構成からの初回切替)
+
+旧 `harmony-claude` / `harmony-codex` / `harmony-state` named volume を使っていた人は、bind mount 切替前に host へデータ移管する:
+
+```bash
+# host 側で受け入れ先作成 (UID は user で問題なし、node も UID 1000 想定)
+mkdir -p ~/.claude-containers/harmony/.claude \
+         ~/.claude-containers/harmony/.codex \
+         ~/.claude-containers/harmony/.harmony
+
+# Named Volume → host にコピー
+docker run --rm -v harmony-claude:/src:ro -v ~/.claude-containers/harmony/.claude:/dst alpine sh -c 'cp -aT /src /dst'
+docker run --rm -v harmony-codex:/src:ro  -v ~/.claude-containers/harmony/.codex:/dst  alpine sh -c 'cp -aT /src /dst'
+docker run --rm -v harmony-state:/src:ro  -v ~/.claude-containers/harmony/.harmony:/dst alpine sh -c 'cp -aT /src /dst'
+
+# 後で旧 volume が不要になったら (動作確認後)
+# docker volume rm harmony-claude harmony-codex harmony-state
+```
+
+- rebuild しても host 側のデータは container 破棄に影響されない
+- WSL2 host の `~/.claude/` とは独立 (memory / sessions は WSL2 native claude と container claude で別々に育つ。公式が明確に「machine-local、cross-machine 共有非対応」と宣言: [Memory docs](https://code.claude.com/docs/en/memory))
 
 ### Codex CLI
 
@@ -312,7 +355,7 @@ WSL2 native claude が読む     container 内 claude が読む
 | `codex login` / `claude` 起動で `Permission denied (os error 13)` | Named volume mount target (`/home/node/.claude` / `.codex`) の所有権が root になっている。`devcontainer.json` の `onCreateCommand` で `sudo chown -R node:node` を実行する仕組みあり (container 新規作成時 1 回だけ走る)。手動で直す場合: `sudo chown -R node:node ~/.claude ~/.codex` |
 | backend 起動時に `port 5179 already in use` | WSL2 native 側で backend が動いている。`pkill -f tsx` で WSL2 native プロセスを停止してから container 内で起動 |
 | Claude Code が container 内で MCP に繋がらない | `.mcp.json` の `http://localhost:5179/mcp` は container 内では localhost = container 自身。backend が container 内で `npm run dev` 起動中であることを確認 |
-| container が起動するが永続化が消える | named volume が正しく mount されていない。VSCode `Dev Containers: Show Container Log` で mount エラーを確認。`docker volume ls` で `claude-code-config-*` / `codex-config-*` / `harmony-state-*` の存在も確認 |
+| container が起動するが永続化が消える | host subdir bind mount が正しく動いていない。`ls ~/.claude-containers/<project>/.claude/` で host 側にファイルがあるか確認。空なら旧 Named Volume からの migration 未完了の可能性 — 本 doc「Named Volume からの migration」節参照。VSCode `Dev Containers: Show Container Log` で mount エラーも確認 |
 | rebuild の度に Claude が wizard / 再ログインを要求する | (1) `~/.claude/.config.json` が volume に無い (postCreateCommand 未実行/失敗) → 本 doc「3. データ永続化」節を参照。(2) host 側 `~/.bashrc` の `CLAUDE_CODE_OAUTH_TOKEN` が expire → `refresh-claude-token` で再発行 |
 | rebuild の度に `ccd` / `cdx` 等の個人 alias が消える | VS Code user settings.json に `dotfiles.repository` / `dotfiles.installCommand` の 3 行が未設定。本 doc「個人 alias: VS Code 公式 dotfiles 機能」節を参照 |
 | Docker Desktop ライセンスを使いたくない | rootless Docker (`apt install docker.io` を WSL2 内) でも動作。ただし Windows ホストからの port forward に追加設定要 |


### PR DESCRIPTION
Refs #1097

## 背景

PR #1102 で導入した `.config.json` workaround は機能するが、データ保管が Docker Named Volume (`/var/lib/docker/volumes/...`) で:
- host から直接見えない (`docker run` 経由で覗くしかない)
- backup しにくい
- `docker volume prune` 等で誤消失するリスク
- project 単位の自動分離は `${devcontainerId}` (hash) で人間可読でない

これらを解消するため **host filesystem の project 別 subdir に bind mount** に切替える。

## 変更内容

### `.devcontainer/devcontainer.json`

```diff
  "mounts": [
-   "source=harmony-claude,target=/home/node/.claude,type=volume",
-   "source=harmony-codex,target=/home/node/.codex,type=volume",
-   "source=harmony-state,target=/home/node/.harmony,type=volume"
+   "source=${localEnv:HOME}/.claude-containers/${localWorkspaceFolderBasename}/.claude,target=/home/node/.claude,type=bind,consistency=cached",
+   "source=${localEnv:HOME}/.claude-containers/${localWorkspaceFolderBasename}/.codex,target=/home/node/.codex,type=bind,consistency=cached",
+   "source=${localEnv:HOME}/.claude-containers/${localWorkspaceFolderBasename}/.harmony,target=/home/node/.harmony,type=bind,consistency=cached"
  ],
```

`postCreateCommand` の `.config.json` 初期化 (PR #1102) はそのまま維持 — bind mount 内のファイルとして同じ仕組みで永続化される。

### `docs/setup/dev-containers.md`

「3. データ永続化」節を bind mount 方式の解説に書き直し、Named Volume との比較表 + migration 手順 + WSL2 native claude との競合回避設計 (別名前空間) を明記。トラブルシューティング表の該当行も更新。

## host 側ディレクトリ構成

```
~/.claude-containers/
└── harmony/
    ├── .claude/    # container's /home/node/.claude/ と双方向同期
    ├── .codex/     # container's /home/node/.codex/
    └── .harmony/   # container's /home/node/.harmony/
```

別 project (例: `other-app`) を Dev Container で開くと `${localWorkspaceFolderBasename}` が `other-app` になり、`~/.claude-containers/other-app/.claude/` に自動分離。複数 project 同時利用しても干渉なし。

**重要**: WSL2 host の `~/.claude/` (WSL2 native claude 用) は **触らない**。`~/.claude-containers/<project>/.claude/` という別名前空間を使うことで、host claude と container claude を同時稼働させても statsig 等の write 競合が起きない設計 (bcaccd7 → 235caeb で確認された host bind mount の問題を回避)。

## migration (Named Volume → host bind mount)

PR 作成時に手動で実施済 (本 user さんの環境のみ):

```bash
mkdir -p ~/.claude-containers/harmony/.{claude,codex,harmony}
docker run --rm -v harmony-claude:/src:ro -v ~/.claude-containers/harmony/.claude:/dst alpine sh -c 'cp -aT /src /dst'
docker run --rm -v harmony-codex:/src:ro  -v ~/.claude-containers/harmony/.codex:/dst  alpine sh -c 'cp -aT /src /dst'
docker run --rm -v harmony-state:/src:ro  -v ~/.claude-containers/harmony/.harmony:/dst alpine sh -c 'cp -aT /src /dst'
```

検証結果:
- `~/.claude-containers/harmony/.claude/.credentials.json` (471B、OAuth token) ✓
- `~/.claude-containers/harmony/.claude/.config.json` (23409B、PR #1102 が書いた state) ✓
- `~/.claude-containers/harmony/.codex/auth.json` (4392B、codex 認証) ✓
- ownership UID 1000:1000 (node user と一致) ✓
- 合計 ~210MB

旧 Named Volume (`harmony-claude` 等) は merge 後の動作確認後に `docker volume rm` で掃除可能 (本 PR では削除しない、保険として残す)。

## 期待される動作 (user さん検証手順)

1. PR merge → VS Code で Rebuild Container
2. 起動時に `~/.claude-containers/harmony/.claude/` が `/home/node/.claude/` に bind mount される
3. `.config.json` が既に存在 (migration 済) → claude はこれを state file として読む
4. 起動時 wizard 出ない or 1 度きり完了で flag 書込み (host side)
5. **もう 1 度 rebuild** → host side `.config.json` 残存 → wizard skip
6. 動作確認後 (任意): `docker volume rm harmony-claude harmony-codex harmony-state` で旧 volume 掃除

## レビュー観点

| 観点 | 状態 |
|---|---|
| 仕様逐条突合 | bind mount 構文は Dev Containers spec 通り (`${localEnv:HOME}` / `${localWorkspaceFolderBasename}`) |
| schema 変更の有無 | なし |
| UI 影響 | なし |
| backwards compatibility | 不要 (リリース前)。旧 Named Volume は orphan として残るが mount されないので無害 |
| 他開発者環境への影響 | bind mount target が無い場合 Docker が自動作成 (root 所有) → `onCreateCommand` の chown で node 所有に修正される (既存ロジック)。fresh setup の人は migration 不要、空ディレクトリから claude 起動 → 1 度 wizard 通せば OK |

## 起票・PR 鉄則 self-check

- 鉄則 0: ☑ #1097 reopen 中、本 PR で正規対応継続
- 鉄則 1: ☑ #1097 内で完結
- 鉄則 3: ☑ 同根 (rebuild 後の作業環境復元) を 1 ISSUE 内
