### PR TITLE
fix(devcontainer): host の ~/.config/gh を bind mount で gh CLI auth を永続化 (#1107)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,10 +16,11 @@
   "mounts": [
     "source=${localEnv:HOME}/.agent-containers/${localWorkspaceFolderBasename}/.claude,target=/home/node/.claude,type=bind,consistency=cached",
     "source=${localEnv:HOME}/.agent-containers/${localWorkspaceFolderBasename}/.codex,target=/home/node/.codex,type=bind,consistency=cached",
-    "source=${localEnv:HOME}/.agent-containers/${localWorkspaceFolderBasename}/.harmony,target=/home/node/.harmony,type=bind,consistency=cached"
+    "source=${localEnv:HOME}/.agent-containers/${localWorkspaceFolderBasename}/.harmony,target=/home/node/.harmony,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.config/gh,target=/home/node/.config/gh,type=bind,consistency=cached"
   ],
 
-  "onCreateCommand": "sudo chown -R node:node /home/node/.claude /home/node/.codex /home/node/.harmony",
+  "onCreateCommand": "sudo chown -R node:node /home/node/.claude /home/node/.codex /home/node/.harmony /home/node/.config/gh",
 
   "postCreateCommand": "npm install --prefix frontend && npm install --prefix backend && (cd frontend && npx playwright install --with-deps chromium) && npm install -g @openai/codex && ([ -f ~/.claude/.config.json ] || echo '{}' > ~/.claude/.config.json)",
 


### PR DESCRIPTION
Closes #1107

## Summary

- DevContainer rebuild 後に `gh auth status` が unauthenticated になっていた問題を解消
- WSL2 host の `~/.config/gh` を container の `/home/node/.config/gh` に bind mount
- `onCreateCommand` の chown 対象に `.config/gh` を追加 (UID 整合)

## 公式根拠

[cli/cli#3226](https://github.com/cli/cli/discussions/3226) で gh CLI maintainer (@mislav) が **dev container での auth 保持として hosts.yml マウント** を公式に推奨。本 PR はそのまま採用。

[devcontainers/features/github-cli](https://github.com/devcontainers/features/tree/main/src/github-cli) は install のみで auth は扱わないため、本リポジトリ側で対応する必要がある。

## なぜ host 直マウント (`~/.config/gh`) で per-workspace ではないか

- `.claude` / `.codex` は workspace 毎に identity 分離したい用途で `~/.agent-containers/<workspace>/` 配下
- gh 認証は通常 1 開発者 1 アカウントで host 共通 → host で `gh auth login` 1 回で全 workspace 反映
- `gh auth refresh` も rebuild 不要で自動反映

## なぜ `GH_TOKEN` env var 案 (memory `feedback_check_official_docs_before_reinventing.md`) ではないか

- WSL2 起動毎に `export GH_TOKEN=...` する手動運用負担
- token プレーンテキスト管理が必要
- gh maintainer 自身が headless / automation 用途と位置付けており、対話運用は hosts.yml マウントを優先

## Test plan

- [ ] WSL2 host で `gh auth status` が authenticated であることを確認
- [ ] 本 PR の branch で `Dev Containers: Rebuild Container` を実行
- [ ] container 内で `gh auth status` が authenticated を返すこと
- [ ] container 内で `gh issue list --limit 1` 等の API 呼び出しが成功すること
- [ ] container 内 `ls -la ~/.config/gh/` で hosts.yml が見えており permission が崩れていないこと