### PR TITLE
feat(devcontainer): 業務アプリ template + Harmony 本体に AI CLI 3 種 + 認証永続化 mount を同梱 (#1111)

### DIFF
--- a/.claude/skills/generate-code/SKILL.md
+++ b/.claude/skills/generate-code/SKILL.md
@@ -1742,14 +1742,32 @@ Step 0 で `--all` / `--workspace <wsId>` が指定された場合、Step 1〜6 
 
 判定キー: `techStack.backend.framework` ∈ {`spring-boot`, `nestjs`} × `techStack.frontend.library` ∈ {`thymeleaf`, `react`}
 
-| backend × frontend | base image | features 追加 | docker-compose default |
-|---|---|---|---|
-| spring-boot × thymeleaf | `mcr.microsoft.com/devcontainers/java:1-21-bookworm` | `java:1` (version 21, installMaven true)、`node:1`、`github-cli:1` | postgres:15 |
-| spring-boot × nextjs | 同上 | 同上 (Next.js dev server に Node 必須) | 同上 |
-| nestjs × thymeleaf | `mcr.microsoft.com/devcontainers/typescript-node:20` | `github-cli:1` のみ (NestJS が SSR するため Maven 不要、最小構成) | SQLite (Prisma file:./prisma/dev.db、Postgres section はコメントアウトで保持) |
-| nestjs × nextjs | `mcr.microsoft.com/devcontainers/typescript-node:20` | `github-cli:1` | 同上 |
+| backend × frontend | base image | features 追加 (基本) | features 追加 (AI CLI、#1111) | docker-compose default |
+|---|---|---|---|---|
+| spring-boot × thymeleaf | `mcr.microsoft.com/devcontainers/java:1-21-bookworm` | `java:1` (version 21, installMaven true)、`node:1`、`github-cli:1` | `claude-code:1.0`、`copilot-cli:1.1.2` + postCreateCommand で `codex` npm 同梱 | postgres:15 |
+| spring-boot × nextjs | 同上 | 同上 (Next.js dev server に Node 必須) | 同上 | 同上 |
+| nestjs × thymeleaf | `mcr.microsoft.com/devcontainers/typescript-node:20` | `github-cli:1` のみ (NestJS が SSR するため Maven 不要、最小構成) | 同上 | SQLite (Prisma file:./prisma/dev.db、Postgres section はコメントアウトで保持) |
+| nestjs × nextjs | `mcr.microsoft.com/devcontainers/typescript-node:20` | `github-cli:1` | 同上 | 同上 |
 
 > nestjs × thymeleaf 組合せは SKILL.md § 2 constraint 3 (thymeleaf は editorKind=grapesjs 必須) と合わせて稀。当面は最小テンプレ提供で、需要が顕在化したら拡充。
+
+### AI CLI 3 種同梱方針 (#1111)
+
+業務アプリ開発者は持っているサブスクが異なるため、**claude-code / codex / copilot-cli の 3 種を全 template にデフォルト install** する。利用者は手持ちのサブスクの CLI だけ login して使う。Harmony 本体 `.devcontainer/devcontainer.json` (#1097 / #1107 で確立) と統一したパターン:
+
+- **claude-code**: `ghcr.io/anthropics/devcontainer-features/claude-code:1.0` feature
+- **codex**: feature 未提供のため `postCreateCommand` で `npm install -g @openai/codex`
+- **copilot-cli**: `ghcr.io/devcontainers/features/copilot-cli:1.1.2` feature (gh auth に依存)
+
+認証永続化用 bind mount 3 種 (Harmony 本体と統一):
+
+- `${localEnv:HOME}/.agent-containers/${localWorkspaceFolderBasename}/.claude` → `/home/<user>/.claude` (Anthropic OAuth)
+- `${localEnv:HOME}/.agent-containers/${localWorkspaceFolderBasename}/.codex` → `/home/<user>/.codex` (OpenAI OAuth)
+- `${localEnv:HOME}/.config/gh` → `/home/<user>/.config/gh` (GitHub CLI auth、Copilot CLI が依存、`gh` 単体でも有用)
+
+`onCreateCommand` で chown (mount 先の所有権を user に揃える)、`postCreateCommand` で `~/.claude/.config.json` 空ファイル作成 (Claude wizard 抑制 workaround #1097)、`containerEnv` で `DISABLE_AUTOUPDATER=1` (rebuild ごとの自動更新を抑制)。
+
+`<user>` は template ごとに違う (`spring-boot-*` は `vscode`、`nestjs-*` は `node`)。chown / mount target の path はそれぞれ調整。
 
 ### postCreateCommand
 

--- a/.claude/skills/generate-code/templates/devcontainer/nestjs-nextjs/.devcontainer/devcontainer.json
+++ b/.claude/skills/generate-code/templates/devcontainer/nestjs-nextjs/.devcontainer/devcontainer.json
@@ -3,7 +3,9 @@
   "image": "mcr.microsoft.com/devcontainers/typescript-node:20",
 
   "features": {
-    "ghcr.io/devcontainers/features/github-cli:1": {}
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {},
+    "ghcr.io/devcontainers/features/copilot-cli:1.1.2": {}
   },
 
   "forwardPorts": [3000, 3001],
@@ -12,7 +14,15 @@
     "3001": { "label": "Backend (NestJS)", "onAutoForward": "notify" }
   },
 
-  "postCreateCommand": "npm install && (npx prisma generate 2>/dev/null || true)",
+  "mounts": [
+    "source=${localEnv:HOME}/.agent-containers/${localWorkspaceFolderBasename}/.claude,target=/home/node/.claude,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.agent-containers/${localWorkspaceFolderBasename}/.codex,target=/home/node/.codex,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.config/gh,target=/home/node/.config/gh,type=bind,consistency=cached"
+  ],
+
+  "onCreateCommand": "sudo chown -R node:node /home/node/.claude /home/node/.codex /home/node/.config/gh",
+
+  "postCreateCommand": "npm install && (npx prisma generate 2>/dev/null || true) && npm install -g @openai/codex && ([ -f ~/.claude/.config.json ] || echo '{}' > ~/.claude/.config.json)",
 
   "customizations": {
     "vscode": {
@@ -20,7 +30,8 @@
         "dbaeumer.vscode-eslint",
         "esbenp.prettier-vscode",
         "bradlc.vscode-tailwindcss",
-        "Prisma.prisma"
+        "Prisma.prisma",
+        "anthropic.claude-code"
       ],
       "settings": {
         "terminal.integrated.defaultProfile.linux": "bash",
@@ -29,5 +40,9 @@
     }
   },
 
-  "remoteUser": "node"
+  "remoteUser": "node",
+
+  "containerEnv": {
+    "DISABLE_AUTOUPDATER": "1"
+  }
 }

--- a/.claude/skills/generate-code/templates/devcontainer/nestjs-nextjs/README.snippet.md
+++ b/.claude/skills/generate-code/templates/devcontainer/nestjs-nextjs/README.snippet.md
@@ -23,6 +23,20 @@ VSCode + Dev Containers 拡張があれば、`git clone` 後に `Reopen in Conta
 
 詳細: [`.devcontainer/devcontainer.json`](.devcontainer/devcontainer.json)
 
+## AI CLI 利用 (任意)
+
+container 内に 3 つの AI CLI が install されています。**開発者が持っているサブスクの CLI だけ login** してください (全部入れる必要はなし)。
+
+| AI CLI | 必要なサブスク | 初回 login コマンド |
+|---|---|---|
+| Claude Code | Anthropic Claude Pro/Max | `claude /login` (ブラウザ OAuth) |
+| Codex | OpenAI ChatGPT Plus | `codex login` |
+| Copilot CLI | GitHub Copilot | `gh auth login` (or host の `~/.config/gh` を bind mount で継承済の場合は不要) |
+
+認証情報は host の `~/.agent-containers/<project>/.{claude,codex}/` と `~/.config/gh/` に bind mount で永続化されるため、**rebuild しても再 login 不要** (`refreshToken` で 60〜90 日は自動更新)。
+
+WSL2 host 側 `~/.claude/` (WSL2 native claude 用) には触りません — `~/.agent-containers/` という別名前空間を使うことで host claude と container claude を同時稼働させても干渉しません。
+
 ## 本番デプロイ (Docker)
 
 ```bash

--- a/.claude/skills/generate-code/templates/devcontainer/nestjs-thymeleaf/.devcontainer/devcontainer.json
+++ b/.claude/skills/generate-code/templates/devcontainer/nestjs-thymeleaf/.devcontainer/devcontainer.json
@@ -3,7 +3,9 @@
   "image": "mcr.microsoft.com/devcontainers/typescript-node:20",
 
   "features": {
-    "ghcr.io/devcontainers/features/github-cli:1": {}
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {},
+    "ghcr.io/devcontainers/features/copilot-cli:1.1.2": {}
   },
 
   "forwardPorts": [3000],
@@ -11,14 +13,23 @@
     "3000": { "label": "App (NestJS)", "onAutoForward": "notify" }
   },
 
-  "postCreateCommand": "npm install && (npx prisma generate 2>/dev/null || true)",
+  "mounts": [
+    "source=${localEnv:HOME}/.agent-containers/${localWorkspaceFolderBasename}/.claude,target=/home/node/.claude,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.agent-containers/${localWorkspaceFolderBasename}/.codex,target=/home/node/.codex,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.config/gh,target=/home/node/.config/gh,type=bind,consistency=cached"
+  ],
+
+  "onCreateCommand": "sudo chown -R node:node /home/node/.claude /home/node/.codex /home/node/.config/gh",
+
+  "postCreateCommand": "npm install && (npx prisma generate 2>/dev/null || true) && npm install -g @openai/codex && ([ -f ~/.claude/.config.json ] || echo '{}' > ~/.claude/.config.json)",
 
   "customizations": {
     "vscode": {
       "extensions": [
         "dbaeumer.vscode-eslint",
         "esbenp.prettier-vscode",
-        "redhat.vscode-xml"
+        "redhat.vscode-xml",
+        "anthropic.claude-code"
       ],
       "settings": {
         "terminal.integrated.defaultProfile.linux": "bash",
@@ -27,5 +38,9 @@
     }
   },
 
-  "remoteUser": "node"
+  "remoteUser": "node",
+
+  "containerEnv": {
+    "DISABLE_AUTOUPDATER": "1"
+  }
 }

--- a/.claude/skills/generate-code/templates/devcontainer/nestjs-thymeleaf/README.snippet.md
+++ b/.claude/skills/generate-code/templates/devcontainer/nestjs-thymeleaf/README.snippet.md
@@ -19,6 +19,20 @@ VSCode + Dev Containers 拡張があれば、`git clone` 後に `Reopen in Conta
 
 詳細: [`.devcontainer/devcontainer.json`](.devcontainer/devcontainer.json)
 
+## AI CLI 利用 (任意)
+
+container 内に 3 つの AI CLI が install されています。**開発者が持っているサブスクの CLI だけ login** してください (全部入れる必要はなし)。
+
+| AI CLI | 必要なサブスク | 初回 login コマンド |
+|---|---|---|
+| Claude Code | Anthropic Claude Pro/Max | `claude /login` (ブラウザ OAuth) |
+| Codex | OpenAI ChatGPT Plus | `codex login` |
+| Copilot CLI | GitHub Copilot | `gh auth login` (or host の `~/.config/gh` を bind mount で継承済の場合は不要) |
+
+認証情報は host の `~/.agent-containers/<project>/.{claude,codex}/` と `~/.config/gh/` に bind mount で永続化されるため、**rebuild しても再 login 不要** (`refreshToken` で 60〜90 日は自動更新)。
+
+WSL2 host 側 `~/.claude/` (WSL2 native claude 用) には触りません — `~/.agent-containers/` という別名前空間を使うことで host claude と container claude を同時稼働させても干渉しません。
+
 ## 本番デプロイ (Docker)
 
 ```bash

--- a/.claude/skills/generate-code/templates/devcontainer/spring-boot-nextjs/.devcontainer/devcontainer.json
+++ b/.claude/skills/generate-code/templates/devcontainer/spring-boot-nextjs/.devcontainer/devcontainer.json
@@ -5,7 +5,9 @@
   "features": {
     "ghcr.io/devcontainers/features/java:1": { "version": "21", "installMaven": true },
     "ghcr.io/devcontainers/features/node:1": { "version": "20" },
-    "ghcr.io/devcontainers/features/github-cli:1": {}
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {},
+    "ghcr.io/devcontainers/features/copilot-cli:1.1.2": {}
   },
 
   "forwardPorts": [8080, 3000, 5432],
@@ -15,7 +17,15 @@
     "5432": { "label": "Postgres", "onAutoForward": "silent" }
   },
 
-  "postCreateCommand": "(./mvnw -B dependency:resolve 2>/dev/null || mvn -B dependency:resolve || true) && (cd frontend && npm install || true)",
+  "mounts": [
+    "source=${localEnv:HOME}/.agent-containers/${localWorkspaceFolderBasename}/.claude,target=/home/vscode/.claude,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.agent-containers/${localWorkspaceFolderBasename}/.codex,target=/home/vscode/.codex,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.config/gh,target=/home/vscode/.config/gh,type=bind,consistency=cached"
+  ],
+
+  "onCreateCommand": "sudo chown -R vscode:vscode /home/vscode/.claude /home/vscode/.codex /home/vscode/.config/gh",
+
+  "postCreateCommand": "(./mvnw -B dependency:resolve 2>/dev/null || mvn -B dependency:resolve || true) && (cd frontend && npm install || true) && npm install -g @openai/codex && ([ -f ~/.claude/.config.json ] || echo '{}' > ~/.claude/.config.json)",
 
   "customizations": {
     "vscode": {
@@ -24,7 +34,8 @@
         "vmware.vscode-boot-dev-pack",
         "dbaeumer.vscode-eslint",
         "esbenp.prettier-vscode",
-        "bradlc.vscode-tailwindcss"
+        "bradlc.vscode-tailwindcss",
+        "anthropic.claude-code"
       ],
       "settings": {
         "terminal.integrated.defaultProfile.linux": "bash",
@@ -33,5 +44,9 @@
     }
   },
 
-  "remoteUser": "vscode"
+  "remoteUser": "vscode",
+
+  "containerEnv": {
+    "DISABLE_AUTOUPDATER": "1"
+  }
 }

--- a/.claude/skills/generate-code/templates/devcontainer/spring-boot-nextjs/README.snippet.md
+++ b/.claude/skills/generate-code/templates/devcontainer/spring-boot-nextjs/README.snippet.md
@@ -24,6 +24,20 @@ docker compose up db
 
 詳細: [`.devcontainer/devcontainer.json`](.devcontainer/devcontainer.json)
 
+## AI CLI 利用 (任意)
+
+container 内に 3 つの AI CLI が install されています。**開発者が持っているサブスクの CLI だけ login** してください (全部入れる必要はなし)。
+
+| AI CLI | 必要なサブスク | 初回 login コマンド |
+|---|---|---|
+| Claude Code | Anthropic Claude Pro/Max | `claude /login` (ブラウザ OAuth) |
+| Codex | OpenAI ChatGPT Plus | `codex login` |
+| Copilot CLI | GitHub Copilot | `gh auth login` (or host の `~/.config/gh` を bind mount で継承済の場合は不要) |
+
+認証情報は host の `~/.agent-containers/<project>/.{claude,codex}/` と `~/.config/gh/` に bind mount で永続化されるため、**rebuild しても再 login 不要** (`refreshToken` で 60〜90 日は自動更新)。
+
+WSL2 host 側 `~/.claude/` (WSL2 native claude 用) には触りません — `~/.agent-containers/` という別名前空間を使うことで host claude と container claude を同時稼働させても干渉しません。
+
 ## 本番デプロイ (Docker)
 
 ```bash

--- a/.claude/skills/generate-code/templates/devcontainer/spring-boot-thymeleaf/.devcontainer/devcontainer.json
+++ b/.claude/skills/generate-code/templates/devcontainer/spring-boot-thymeleaf/.devcontainer/devcontainer.json
@@ -5,7 +5,9 @@
   "features": {
     "ghcr.io/devcontainers/features/java:1": { "version": "21", "installMaven": true },
     "ghcr.io/devcontainers/features/node:1": { "version": "20" },
-    "ghcr.io/devcontainers/features/github-cli:1": {}
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {},
+    "ghcr.io/devcontainers/features/copilot-cli:1.1.2": {}
   },
 
   "forwardPorts": [8080, 5432],
@@ -14,7 +16,15 @@
     "5432": { "label": "Postgres", "onAutoForward": "silent" }
   },
 
-  "postCreateCommand": "./mvnw -B dependency:resolve 2>/dev/null || mvn -B dependency:resolve || true",
+  "mounts": [
+    "source=${localEnv:HOME}/.agent-containers/${localWorkspaceFolderBasename}/.claude,target=/home/vscode/.claude,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.agent-containers/${localWorkspaceFolderBasename}/.codex,target=/home/vscode/.codex,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.config/gh,target=/home/vscode/.config/gh,type=bind,consistency=cached"
+  ],
+
+  "onCreateCommand": "sudo chown -R vscode:vscode /home/vscode/.claude /home/vscode/.codex /home/vscode/.config/gh",
+
+  "postCreateCommand": "(./mvnw -B dependency:resolve 2>/dev/null || mvn -B dependency:resolve || true) && npm install -g @openai/codex && ([ -f ~/.claude/.config.json ] || echo '{}' > ~/.claude/.config.json)",
 
   "customizations": {
     "vscode": {
@@ -22,7 +32,8 @@
         "vscjava.vscode-java-pack",
         "vmware.vscode-boot-dev-pack",
         "redhat.vscode-xml",
-        "esbenp.prettier-vscode"
+        "esbenp.prettier-vscode",
+        "anthropic.claude-code"
       ],
       "settings": {
         "terminal.integrated.defaultProfile.linux": "bash",
@@ -31,5 +42,9 @@
     }
   },
 
-  "remoteUser": "vscode"
+  "remoteUser": "vscode",
+
+  "containerEnv": {
+    "DISABLE_AUTOUPDATER": "1"
+  }
 }

--- a/.claude/skills/generate-code/templates/devcontainer/spring-boot-thymeleaf/README.snippet.md
+++ b/.claude/skills/generate-code/templates/devcontainer/spring-boot-thymeleaf/README.snippet.md
@@ -19,6 +19,20 @@ docker compose up db
 
 詳細: [`.devcontainer/devcontainer.json`](.devcontainer/devcontainer.json)
 
+## AI CLI 利用 (任意)
+
+container 内に 3 つの AI CLI が install されています。**開発者が持っているサブスクの CLI だけ login** してください (全部入れる必要はなし)。
+
+| AI CLI | 必要なサブスク | 初回 login コマンド |
+|---|---|---|
+| Claude Code | Anthropic Claude Pro/Max | `claude /login` (ブラウザ OAuth) |
+| Codex | OpenAI ChatGPT Plus | `codex login` |
+| Copilot CLI | GitHub Copilot | `gh auth login` (or host の `~/.config/gh` を bind mount で継承済の場合は不要) |
+
+認証情報は host の `~/.agent-containers/<project>/.{claude,codex}/` と `~/.config/gh/` に bind mount で永続化されるため、**rebuild しても再 login 不要** (`refreshToken` で 60〜90 日は自動更新)。
+
+WSL2 host 側 `~/.claude/` (WSL2 native claude 用) には触りません — `~/.agent-containers/` という別名前空間を使うことで host claude と container claude を同時稼働させても干渉しません。
+
 ## 本番デプロイ (Docker)
 
 ```bash

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,8 @@
 
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {}
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {},
+    "ghcr.io/devcontainers/features/copilot-cli:1.1.2": {}
   },
 
   "forwardPorts": [5173, 5179],


### PR DESCRIPTION
## 関連

- Closes #1111
- #1048 (closed) の follow-up — Dev Containers 同梱完了宣言時に AI CLI が実装漏れだった点を補完
- #1097 / #1107 (closed) の AI CLI 永続化パターンを業務アプリ template に統一移植

## 概要

業務アプリ devcontainer template (4 種) と Harmony 本体に AI CLI 3 種 (claude-code / codex / copilot-cli) を同梱し、認証永続化 mount を統一する。開発者ごとに持っているサブスクが異なるため 3 種全部 install してログイン側で選ばせる方針。

PR #1110 で docs を整理する過程で実装漏れが判明 (`/generate-code` で出力される業務アプリ devcontainer に AI CLI も認証 mount も無く、業務アプリ開発者の AI 操作シーンが破綻していた)。

## 主な変更

### A. 業務アプリ devcontainer template 4 種 (4 ファイル)

`.claude/skills/generate-code/templates/devcontainer/{spring-boot-thymeleaf,spring-boot-nextjs,nestjs-thymeleaf,nestjs-nextjs}/.devcontainer/devcontainer.json` すべてに:

- `features` に `claude-code:1.0` + `copilot-cli:1.1.2` 追加
- `mounts` 3 種追加 (`.claude` / `.codex` / `~/.config/gh`)
- `onCreateCommand` で chown (`spring-boot-*` は `vscode:vscode`、`nestjs-*` は `node:node`)
- `postCreateCommand` に `npm install -g @openai/codex` + `~/.claude/.config.json` workaround を末尾追加
- `containerEnv.DISABLE_AUTOUPDATER=1` 追加
- `customizations.vscode.extensions` に `anthropic.claude-code` 追加

### B. 業務アプリ template README snippet 4 種 (4 ファイル)

各 `README.snippet.md` に「AI CLI 利用 (任意)」セクションを追加。手持ちのサブスクの CLI だけ login する手順表を載せる。

### C. Harmony 本体 \`.devcontainer/devcontainer.json\` (同根、鉄則 1 で同 PR 吸収)

- `copilot-cli:1.1.2` feature 1 行追加 (Harmony 本体には欠落していた)
- `~/.config/gh` bind mount は #1107 で既存のためそのまま活用

### D. `/generate-code` SKILL.md Step 5.5 セクション

- techStack 比較表に「features 追加 (AI CLI、#1111)」列を追加
- 「AI CLI 3 種同梱方針 (#1111)」小節を新設 (claude-code/codex/copilot-cli の install 方式、mount 3 種、user 別 path 切替の方針を明記)

## 仕様逐条突合 (自己申告)

ISSUE #1111 受け入れ条件と突合:

- ✓ 4 つの business app devcontainer template (.json) に claude-code / copilot-cli feature → 4 ファイル × 2 feature 全部追加済 (検証コマンド: `python3 -c "import json; ..." で features 確認、全 True)
- ✓ 4 つすべてに 3 種の bind mount (\`.claude\` / \`.codex\` / \`~/.config/gh\`) → mount target 検証で全 4 ファイル 3 mount 確認
- ✓ 4 つすべてに onCreateCommand chown + postCreateCommand 拡張 → 検証コマンドで全 4 ファイル confirmed
- ✓ 4 つすべてに containerEnv \`DISABLE_AUTOUPDATER=1\` → 検証コマンドで全 True
- ✓ Harmony 本体 \`.devcontainer/devcontainer.json\` に copilot-cli feature 追加 → \`.devcontainer/devcontainer.json:8\`
- ✓ template README snippet に初回 OAuth 手順記載 → 4 ファイルすべて「AI CLI 利用 (任意)」セクション追加
- ✓ \`/generate-code\` SKILL.md Step 5.5 に AI CLI 同梱旨追記 → SKILL.md:1745-1772 (比較表更新 + 新小節追加)

## レビューで特に見てほしい箇所

- **user / path 整合性**: \`spring-boot-*\` は \`remoteUser: vscode\` (= mount target \`/home/vscode/...\` + chown \`vscode:vscode\`)、\`nestjs-*\` は \`remoteUser: node\` (= mount target \`/home/node/...\` + chown \`node:node\`)。template ごとに正しく切り替わっているか
- **postCreateCommand の連結順序**: 既存の build/install 系コマンドの後ろに `&&` 連結で codex install + .config.json workaround を末尾追加。前段が失敗した場合のフォールバック挙動 (前段に \`|| true\` がある template はそのまま影響を後段に伝播しないか確認)
- **Harmony 本体の Copilot CLI 追加スコープ**: ISSUE では「同根なので同 PR 吸収」と明記したが、Harmony 本体は既に gh bind mount があるので feature 追加 1 行のみ。これを別 ISSUE 化せず吸収した判断の妥当性
- **\`.devcontainer/.claude\` の名前空間衝突回避**: bind mount source は \`~/.agent-containers/<project>/.claude\` (= Harmony 本体と同パターン)、project ごとに \`${localWorkspaceFolderBasename}\` で自動分離。複数 project を Dev Container で開いても干渉しないか

## テスト

- JSON 構文検証: \`python3 -c "import json; json.load(open(...))"\` で 5 ファイル (4 template + Harmony 本体) すべて pass
- 整合性自動検査: 4 template すべてで user / mount target / chown / feature の整合が取れていることを script で検証済
- 実機 build テスト: 本 PR は **template の static ファイル変更** で、生成 skill (\`/generate-code\`) の実行を要する。実機検証は別途 `/generate-code retail` 等の dogfood で確認する形 (本 PR スコープでは未実施)

## UI 影響 / AI smoke test

- [x] UI 影響なし (devcontainer.json 設定 + SKILL.md docs のみ)

## spec 側の不足点 / 提案

- \`/generate-code\` 出力済の examples (\`examples/retail/generated/\` 等) に \`.devcontainer/\` が無い件は本 PR スコープ外 (別 ISSUE 候補、PR #1110 description でも言及)
- \`distribution-roadmap.md\` の AI mount セクション (commit c649f6e) と本 PR の方針は整合済

## レビュー担当への申し送り

- 本 PR は **既存生成 sample (\`examples/*/generated/\`) には影響しない** (template だけ更新、再生成は別タイミング)
- Harmony 本体 \`.devcontainer/\` の copilot-cli 追加は次回 Dev Container rebuild 時に有効化される。本セッションでは既に開いてる container は rebuild していない (rebuild 通知だけ出ているはず)
- \`/codex:review\` で独立レビューする際は、4 template の **物理的構造一致** (= 同じ user/path パターンで揃っているか) を必ず突合してほしい (memory feedback_scaffold_template_review_physical_check.md パターン)

🤖 Generated with [Claude Code](https://claude.com/claude-code)