### PR TITLE
docs: Phase E — 運用ルール反映 (#1129)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,47 @@ Dev Containers の利点:
 
 過去 WSL2 native で開発していた利用者の Dev Containers 移行手順は `dev-containers.md` §「過去 WSL2 native だった人向け移行手順」を参照。
 
+### Documentation HTML サイト (docs-site/)
+
+仕様書 / プレゼン HTML 化サイト (Astro 5 + Tailwind v4 + pagefind + rehype-mermaid)。詳細は [`docs-site/README.md`](docs-site/README.md) 参照。メタ ISSUE: [#1124](https://github.com/csilost2001/harmony/issues/1124) (Phase A-E 完了済)。
+
+#### 出力構成
+
+- **Source of truth (canonical)**: `docs/spec/*.md` / `docs/user-guide/*.md` / `docs/conventions/*.md` / `docs/setup/*.md` (Markdown が一次成果物)
+- **Build artifact (配布物)**: `docs/html/` (git tracked、**手編集禁止**)
+- **プレゼン**: `docs/html/presentation/index.html` (1 ファイル完結、Swiper、16 スライド)
+
+#### 初回セットアップ
+
+```bash
+cd docs-site
+npm install
+npx playwright install chromium  # rehype-mermaid 用、初回のみ
+```
+
+#### 更新フロー (md 編集後の必須手順)
+
+1. `docs/spec/*.md` 等の Markdown を編集 (canonical source)
+2. `cd docs-site && npm run build` で `docs/html/` を再生成
+3. `git add docs/html/ docs-site/` で commit
+4. push / PR
+
+#### スキーマ反映
+
+`schemas/v3/*.json` 変更時:
+
+- `SchemaTable` component が build 時に schema を再読込
+- 上記更新フローと同じ手順で HTML に反映 (rebuild 必須)
+
+#### 注意事項
+
+- **`docs/html/` 配下の手編集は禁止** (build artifact、次回 build で上書きされる)
+- `_astro/*.{css,js}` の hash 名は内容変化で変わる (commit diff 増加要因、想定済)
+- pagefind index (`docs/html/pagefind/`) も build 毎に再生成 (`.pf_index` / `.pf_fragment` の hash 変動)
+- **Astro 5 系を採用** (Astro 6 は Node 22+ 必須、本プロジェクト Node 20 環境のため不適合)
+- mermaid 図は build-time SVG 生成 (Playwright chromium 経由、client JS 不要)
+- 内部 `*.md` link は rehype plugin で自動的に Astro route (`/<area>/<slug>/`) に変換、4 area 外 link は GitHub blob URL に fallback
+
 ### ドッグフード deploy 先
 
 AI ドッグフード時のサンプル展開先は **`workspaces/dogfood-<目的-YYYYMMDD>/`** を使用する。`data/` への deploy は禁止 (`data/` はデザイナー本体組み込み拡張定義 `data/extensions/` 専用、#753 で責務縮退済み)。`examples/<project-id>/` を作業領域にコピーする際も `workspaces/<project-id>/` を使う。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,17 @@ Claude Code 向けの補足ガイダンス。
 
 Codex CLI 利用時はこれらのスキルは直接呼び出せません。等価機能は Codex plugin の `/codex:review` 等で代替するか、Opus が briefing で代替指示を出します。
 
+### Documentation HTML サイト (docs-site/)
+
+仕様書 / プレゼン HTML 化サイト (Astro 5 + Tailwind v4 + pagefind)。詳細運用ルールは [AGENTS.md](AGENTS.md) の "Documentation HTML サイト (docs-site/)" セクション参照。
+
+- **出力先**: `docs/html/` (git tracked、配布物、手編集禁止)
+- **更新**: `docs/spec/*.md` 等の md 編集後 `cd docs-site && npm run build` → commit
+- **初回**: `cd docs-site && npm install && npx playwright install chromium`
+- **メタ ISSUE**: [#1124](https://github.com/csilost2001/harmony/issues/1124) (Phase A-E 完了済)
+
+Markdown が canonical source、HTML は build artifact。Phase E 完了 (2026-05-17) 以降、md 編集 → build → commit のフローを守ること。
+
 ### ワークスペース機能
 
 複数ワークスペース管理機能の仕様は [docs/spec/workspace.md](docs/spec/workspace.md) を参照。`backend` は **active workspace** 1 つに対応し、env `DESIGNER_DATA_DIR` が指定されている場合は lockdown モードで固定される (recent への読み書きなし)。


### PR DESCRIPTION
## 関連

- Closes #1129
- Refs #1124 (メタ: Harmony 仕様書・プレゼン HTML 化プロジェクト)

## 概要

メタ #1124 の Phase E。Documentation HTML サイト (`docs-site/`) の運用ルールを AGENTS.md / CLAUDE.md に追記。本 PR merge をもってメタ ISSUE #1124 を close する最終 Phase。

## 主な変更

### AGENTS.md (+41 行)

新セクション「### Documentation HTML サイト (docs-site/)」を `### 開発環境` の後に追加:

- **出力構成**: canonical = `docs/spec/*.md` 等の Markdown / build artifact = `docs/html/`
- **初回セットアップ**: `cd docs-site && npm install && npx playwright install chromium`
- **更新フロー**: md 編集 → `npm run build` → commit
- **スキーマ反映**: schemas/v3 変更も rebuild で SchemaTable 自動再読込
- **注意事項**: `docs/html/` 手編集禁止 / Astro 5 系採用理由 / mermaid build-time SVG / 内部 .md link 自動変換

### CLAUDE.md (+11 行)

新セクション「### Documentation HTML サイト (docs-site/)」を `### Slash Commands / Skills` の後に追加 (短い delegate、詳細は AGENTS.md 参照):

- 出力先 / 更新 / 初回セットアップ summary
- メタ ISSUE #1124 完了 (2026-05-17) 言及

## skill 検討結果

`/docs-build` skill 新設は **不要** と判断:

- 単純な `cd docs-site && npm run build` で十分
- AGENTS.md / CLAUDE.md に明記されているため AI が必要時に Bash で実行可
- 既存 `ai-skills/` の複雑 skill (issues / review-pr / generate-code 等) と異なり、wrapper のみで価値薄
- 維持コスト (template / skill 重複読込) > 価値

将来 build flow が複雑化した場合 (例: pre-build check / post-build deploy) は再検討。

## 仕様逐条突合 (自己申告)

ISSUE #1129 完成条件:

- [x] AGENTS.md / CLAUDE.md に更新フロー記載
- [x] `npm run docs:build` (相当: `cd docs-site && npm run build`) で md → HTML 再生成が動作 (Phase B-D で実証済、本 PR scope 外)
- [ ] **メタ ISSUE #1124 close** — 本 PR merge 後に手動 close 予定
- [x] チェックリスト全完了 (メタ ISSUE checklist は merge 後に更新)

## レビューで特に見てほしい箇所

1. **AGENTS.md 追記の section 位置** — `### 開発環境` の後、`### ドッグフード deploy 先` の前。位置として妥当か
2. **CLAUDE.md は短い delegate** — 詳細は AGENTS.md に集約、CLAUDE.md は entry point。一貫性ある分担か
3. **skill 不要判定の妥当性** — 将来 build flow が複雑化したら再検討、現状は AGENTS.md 明記で十分か

## テスト

- Vitest: N/A
- Playwright: N/A
- **build 影響**: なし (AGENTS.md / CLAUDE.md は docs/spec/ ではなく、docs-site/ の Astro が処理対象外)

## UI 影響 / AI smoke test

- [ ] UI 影響あり
- [x] UI 影響なし (メタファイルのみ)

## spec 側の不足点 / 提案

なし。

## レビュー担当への申し送り

- メタファイルのみの小規模 PR (52 行 / 2 file)
- Sonnet review は省略可能 (memory: 「スキル等メタファイルのみの更新は main 直 commit OK」相当)
- ただし他 Phase との一貫性のため通常の branch + PR フロー
- merge 後にメタ ISSUE #1124 本文 checklist 更新 + close 実施予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)