### PR TITLE
chore(mcp): playwright MCP に --browser chromium --headless --no-sandbox flag 追加

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "playwright": {
       "command": "npx",
-      "args": ["-y", "@playwright/mcp@latest"]
+      "args": ["-y", "@playwright/mcp@latest", "--headless", "--browser", "chromium", "--no-sandbox"]
     },
     "harmony-mcp": {
       "type": "http",


### PR DESCRIPTION
## 関連

- Refs #1124 (メタ: Harmony 仕様書・プレゼン HTML 化プロジェクト、close 済) — メタ #1124 完了後の MCP 設定改善
- 直接 ISSUE 無し (本 PR は memory ルール違反の self-correction)

## 概要

`@playwright/mcp` の **defaultConfig が `channel: 'chrome'` を強制** する pitfall に対応。`/opt/google/chrome/` への system Chrome install を要求して container / headless で即失敗していたが、**bundled chromium への切替 flag を追加** すれば Linux headless container でも動作可能 (公式 README 通り)。

## 主な変更

`.mcp.json` の playwright entry:

```diff
 "playwright": {
   "command": "npx",
-  "args": ["-y", "@playwright/mcp@latest"]
+  "args": ["-y", "@playwright/mcp@latest", "--headless", "--browser", "chromium", "--no-sandbox"]
 }
```

事前準備済 (本セッションで実施):

- `npx playwright install chromium` 実行 → `~/.cache/ms-playwright/chromium-1217/chrome-linux64/` install 完了 (DEPENDENCIES_VALIDATED + INSTALLATION_COMPLETE)
- root 権限不要、user cache に install

## 期待効果

次セッション以降 (claude code 再起動後):

- `mcp__playwright__browser_navigate` 等が動作
- HTML サイト等の **browser smoke が AI 自動で実施可能**
- preview server (`cd docs-site && npm run preview`) を立てて navigate / screenshot / console messages 取得可

本 PR 後の workflow 例:

1. `cd docs-site && npm run preview` (background) → port 4321 で listen
2. `mcp__playwright__browser_navigate` で `http://127.0.0.1:4321/`
3. `mcp__playwright__browser_take_screenshot` で `.tmp/screenshots/` に保存
4. `mcp__playwright__browser_console_messages` で JS エラー確認

## 教訓 (self-correction)

本セッション 2026-05-17 で initial 失敗時に「Linux headless 環境制約で不可」と即断、memory に「不可」と記載 → **ユーザー (csilost2001) から「世界中でコンテナテストしてるはずなのにおかしい」と正論指摘** → 公式 README + context7 で 5 分検索したら即解決法判明。

memory `feedback_check_official_docs_before_reinventing.md` (2026-05-14 #1097 で叱責済の rule) の再発。再発防止のため:

- memory `feedback_browser_smoke_headless_chrome_devtools.md` を **訂正版** (defaultConfig pitfall + 解決 flag) に rewrite
- MEMORY.md index も訂正版に update

## 仕様逐条突合 (自己申告)

- [x] `.mcp.json` の playwright args に `--headless`, `--browser chromium`, `--no-sandbox` 追加
- [x] `npx playwright install chromium` で bundled chromium install (`~/.cache/ms-playwright/chromium-1217/`)
- [x] memory file (browser smoke) 訂正、MEMORY.md index 更新
- [ ] **本セッションで動作確認**: 不可 (旧設定 MCP server が起動中、新設定は claude code 再起動後)

## テスト

- N/A (本 PR は MCP 設定のみ)
- 動作確認は次セッション以降

## UI 影響 / AI smoke test

- [ ] UI 影響あり
- [x] UI 影響なし (MCP 設定のみ)
- ただし、本 PR merge 後の **次セッションで AI が browser smoke 実施可能になる** という 2 次効果あり

## spec 側の不足点 / 提案

なし。

## レビュー担当への申し送り

- `.mcp.json` の 1 行変更のみ、小規模
- 本 PR 後、AGENTS.md / CLAUDE.md の "Documentation HTML サイト" セクションに「browser smoke 実施手順」を追加する follow-up が必要かも (現状「人間が起床後 browser で確認」と書いているが、AI 自動 smoke 可能になる)

🤖 Generated with [Claude Code](https://claude.com/claude-code)