### PR TITLE
fix(framework): ProcessFlow MCP handler を v3 schema 構造化 + entity AJV validator 組込 (#1141)

### DIFF
--- a/backend/src/handlers/processFlow.test.ts
+++ b/backend/src/handlers/processFlow.test.ts
@@ -1,0 +1,356 @@
+/**
+ * handlers/processFlow.ts のユニットテスト (#1141)
+ *
+ * 検証観点:
+ * 1. designer__add_process_flow が v3 構造 (meta/context/actions/authoring 4 並列) で書き込む
+ * 2. 生成される ID (processFlow / action / step) が RFC 4122 v4 UUID 形式
+ * 3. meta.kind discriminator が使用される (旧 type フィールドは新規 entity に出現しない)
+ * 4. harmony.json の entities.processFlows[] に upsert される (kind / no / actionCount)
+ * 5. designer__add_action が v3 ActionDefinition 構造で UUID 付き action を追加する
+ * 6. designer__add_step が v3 step (kind discriminator + UUID) を追加する
+ * 7. AJV 検証で違反があれば authoring.markers に validator marker (Marker.kind='validator' +
+ *    validatorCode + validatorPath) が記録され、書き込み自体は許可される
+ *    (draft-state policy: 違反でも保存可)
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+import { handleProcessFlowTool } from "./processFlow.js";
+import {
+  harmonyFile,
+  ensureDataDir,
+  readProcessFlow,
+  readProject,
+  writeProcessFlow,
+} from "../projectStorage.js";
+
+const TMP_ROOT = path.join(os.tmpdir(), `processFlow-handler-test-${process.pid}-${Date.now()}`);
+const UUID_V4_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+// handler は sessionId を引数に取るが、本テストでは wsBridge.tryCommand 経路 (browser-first) を
+// 通らない fallback path のみ検証するため、固定の dummy sessionId を渡す。
+const SESSION_ID = "test-session";
+
+async function makeWorkspace(root: string): Promise<void> {
+  await fs.mkdir(root, { recursive: true });
+  const harmony = {
+    schemaVersion: "v3",
+    dataDir: "harmony",
+    meta: {
+      id: "11111111-1111-4111-8111-111111111111",
+      name: "test-ws",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    },
+    extensionsApplied: [],
+    entities: {},
+  };
+  await fs.writeFile(harmonyFile(root), JSON.stringify(harmony, null, 2), "utf-8");
+  await ensureDataDir(root, "harmony");
+}
+
+afterAll(async () => {
+  await fs.rm(TMP_ROOT, { recursive: true, force: true }).catch(() => {});
+});
+
+// ── 1. designer__add_process_flow が v3 構造で書き込む ─────────────────────────
+
+describe("designer__add_process_flow — #1141 F-4 + S-9", () => {
+  const root = path.join(TMP_ROOT, "ws-add-pf");
+  beforeAll(async () => { await makeWorkspace(root); });
+
+  it("v3 構造 (meta/context/actions/authoring 4 並列) で書き込まれる", async () => {
+    const res = await handleProcessFlowTool(
+      "designer__add_process_flow",
+      { name: "テスト処理フロー", kind: "common" },
+      root,
+      SESSION_ID,
+    );
+    expect(res).not.toBeNull();
+    expect(res!.content[0].text).toMatch(/処理フロー「テスト処理フロー」/);
+
+    // 物理ファイルを確認
+    const message = res!.content[0].text as string;
+    const idMatch = message.match(/ID: ([0-9a-f-]+)/);
+    expect(idMatch).not.toBeNull();
+    const pfId = idMatch![1];
+    expect(pfId).toMatch(UUID_V4_PATTERN);
+
+    const doc = await readProcessFlow(pfId, root) as Record<string, unknown>;
+    expect(doc).not.toBeNull();
+    // 4 並列構造の検証
+    expect(doc).toHaveProperty("meta");
+    expect(doc).toHaveProperty("context");
+    expect(doc).toHaveProperty("actions");
+    expect(doc).toHaveProperty("authoring");
+    expect(Array.isArray(doc.actions)).toBe(true);
+    expect(doc.actions).toEqual([]);
+    // 旧 v1/v2 の root flat フィールドが**書き込まれない**こと
+    expect(doc).not.toHaveProperty("type");
+    expect(doc).not.toHaveProperty("createdAt");
+    expect(doc).not.toHaveProperty("updatedAt");
+    // (上記は meta 配下に移動済み)
+    const meta = doc.meta as Record<string, unknown>;
+    expect(meta.id).toBe(pfId);
+    expect(meta.id).toMatch(UUID_V4_PATTERN);
+    expect(meta.name).toBe("テスト処理フロー");
+    expect(meta.kind).toBe("common"); // #8 / #1141: discriminator は `kind`
+    expect(meta).not.toHaveProperty("type");
+    expect(meta.maturity).toBe("draft");
+    expect(typeof meta.createdAt).toBe("string");
+    expect(typeof meta.updatedAt).toBe("string");
+  });
+
+  it("ProcessFlowId が RFC 4122 v4 UUID 形式である (旧 ag-${Date.now()} 全廃)", async () => {
+    const res = await handleProcessFlowTool(
+      "designer__add_process_flow",
+      { name: "uuid-format-check", kind: "batch" },
+      root,
+      SESSION_ID,
+    );
+    const idMatch = (res!.content[0].text as string).match(/ID: ([0-9a-f-]+)/);
+    expect(idMatch).not.toBeNull();
+    expect(idMatch![1]).toMatch(UUID_V4_PATTERN);
+    // 旧 prefix が含まれないこと
+    expect(idMatch![1]).not.toMatch(/^ag-/);
+  });
+
+  it("name または kind 欠落で InvalidParams が throw される", async () => {
+    await expect(
+      handleProcessFlowTool("designer__add_process_flow", { name: "no-kind" }, root, SESSION_ID),
+    ).rejects.toThrow(/name, kind は必須/);
+    await expect(
+      handleProcessFlowTool("designer__add_process_flow", { kind: "screen" }, root, SESSION_ID),
+    ).rejects.toThrow(/name, kind は必須/);
+  });
+
+  it("harmony.json の entities.processFlows[] に upsert される (no / kind / actionCount)", async () => {
+    await handleProcessFlowTool(
+      "designer__add_process_flow",
+      { name: "entity-upsert-check", kind: "screen", screenId: "11111111-1111-4111-8111-111111111110", description: "test desc" },
+      root,
+      SESSION_ID,
+    );
+    const project = await readProject(root) as Record<string, unknown>;
+    const entities = project.entities as Record<string, unknown>;
+    expect(entities).toHaveProperty("processFlows");
+    const list = entities.processFlows as Array<Record<string, unknown>>;
+    const entry = list.find((e) => e.name === "entity-upsert-check");
+    expect(entry).toBeDefined();
+    expect(entry!.kind).toBe("screen");
+    expect(entry!.actionCount).toBe(0);
+    expect(entry!.screenId).toBe("11111111-1111-4111-8111-111111111110");
+    expect(typeof entry!.no).toBe("number");
+    expect(entry!.no).toBeGreaterThanOrEqual(1);
+    expect(entry!.maturity).toBe("draft");
+  });
+});
+
+// ── 2. designer__add_action / designer__add_step が UUID + kind で書く ──────────
+
+describe("designer__add_action + designer__add_step — #1141 F-4 + S-9", () => {
+  const root = path.join(TMP_ROOT, "ws-add-action-step");
+  let pfId: string;
+
+  beforeAll(async () => {
+    await makeWorkspace(root);
+    const addRes = await handleProcessFlowTool(
+      "designer__add_process_flow",
+      { name: "for-action-step", kind: "common" },
+      root,
+      SESSION_ID,
+    );
+    const idMatch = (addRes!.content[0].text as string).match(/ID: ([0-9a-f-]+)/);
+    pfId = idMatch![1];
+  });
+
+  it("designer__add_action: actionId が UUID v4、description / maturity / trigger / steps が設定される", async () => {
+    const res = await handleProcessFlowTool(
+      "designer__add_action",
+      { processFlowId: pfId, name: "登録ボタン", trigger: "click", description: "登録ボタン押下" },
+      root,
+      SESSION_ID,
+    );
+    const idMatch = (res!.content[0].text as string).match(/ID: ([0-9a-f-]+)/);
+    expect(idMatch![1]).toMatch(UUID_V4_PATTERN);
+
+    const doc = await readProcessFlow(pfId, root) as Record<string, unknown>;
+    const actions = doc.actions as Array<Record<string, unknown>>;
+    expect(actions).toHaveLength(1);
+    expect(actions[0].id).toMatch(UUID_V4_PATTERN);
+    expect(actions[0].name).toBe("登録ボタン");
+    expect(actions[0].trigger).toBe("click");
+    expect(actions[0].description).toBe("登録ボタン押下");
+    expect(actions[0].maturity).toBe("draft");
+    expect(actions[0].steps).toEqual([]);
+  });
+
+  it("designer__add_step: stepId が UUID v4 + discriminator は `kind` (旧 `type` 不在)", async () => {
+    const doc = await readProcessFlow(pfId, root) as Record<string, unknown>;
+    const actions = doc.actions as Array<Record<string, unknown>>;
+    const actionId = actions[0].id as string;
+
+    const res = await handleProcessFlowTool(
+      "designer__add_step",
+      {
+        processFlowId: pfId,
+        actionId,
+        kind: "compute",
+        description: "compute step",
+        detail: { expression: "@x + 1", outputBinding: { name: "y" } },
+      },
+      root,
+      SESSION_ID,
+    );
+    expect(res).not.toBeNull();
+    const idMatch = (res!.content[0].text as string).match(/ID: ([0-9a-f-]+)/);
+    expect(idMatch![1]).toMatch(UUID_V4_PATTERN);
+
+    const reloaded = await readProcessFlow(pfId, root) as Record<string, unknown>;
+    const reloadedActions = reloaded.actions as Array<Record<string, unknown>>;
+    const steps = reloadedActions[0].steps as Array<Record<string, unknown>>;
+    expect(steps).toHaveLength(1);
+    expect(steps[0].id).toMatch(UUID_V4_PATTERN);
+    expect(steps[0].kind).toBe("compute"); // v3 discriminator
+    expect(steps[0]).not.toHaveProperty("type"); // 旧 legacy field 不在
+    expect(steps[0].description).toBe("compute step");
+    expect(steps[0].expression).toBe("@x + 1");
+  });
+
+  it("designer__add_step: kind 欠落で InvalidParams が throw される", async () => {
+    const doc = await readProcessFlow(pfId, root) as Record<string, unknown>;
+    const actions = doc.actions as Array<Record<string, unknown>>;
+    const actionId = actions[0].id as string;
+
+    await expect(
+      handleProcessFlowTool(
+        "designer__add_step",
+        { processFlowId: pfId, actionId, description: "no-kind" },
+        root,
+        SESSION_ID,
+      ),
+    ).rejects.toThrow(/processFlowId, actionId, kind は必須/);
+  });
+});
+
+// ── 3. AJV validation warning marker (draft-state policy) ────────────────────
+
+describe("writeProcessFlow AJV validation — #1141 F-2", () => {
+  const root = path.join(TMP_ROOT, "ws-validation");
+  beforeAll(async () => { await makeWorkspace(root); });
+
+  it("schema 違反の ProcessFlow を writeProcessFlow すると authoring.markers に validator marker が記録される (書き込みは許可)", async () => {
+    // schema 違反データ: meta.id が UUID 形式違反 (旧 `ag-xxx` 形式)、kind 欠落
+    const bad = {
+      meta: {
+        id: "ag-bad-id-not-uuid",
+        name: "違反テスト",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        // kind が欠落 (meta.required: ['kind'])
+      },
+      context: {},
+      actions: [],
+      authoring: {},
+    };
+    // throw しないこと (draft-state policy)
+    await writeProcessFlow("ag-bad-id-not-uuid", bad, root);
+    const reloaded = await readProcessFlow("ag-bad-id-not-uuid", root) as Record<string, unknown>;
+    expect(reloaded).not.toBeNull();
+    // validator marker が authoring.markers に記録されている
+    const authoring = reloaded.authoring as Record<string, unknown>;
+    expect(authoring).toHaveProperty("markers");
+    const markers = authoring.markers as Array<Record<string, unknown>>;
+    expect(markers.length).toBeGreaterThan(0);
+    // common.v3 Marker 規範: kind='validator' + validatorCode + validatorPath 必須
+    const validatorMarkers = markers.filter((m) => m.kind === "validator");
+    expect(validatorMarkers.length).toBeGreaterThan(0);
+    for (const m of validatorMarkers) {
+      expect(typeof m.validatorCode).toBe("string");
+      expect(typeof m.validatorPath).toBe("string");
+      expect(typeof m.id).toBe("string");
+      expect(m.id).toMatch(UUID_V4_PATTERN); // marker.id は Uuid
+      expect(m.author).toBe("ai");
+      expect(typeof m.body).toBe("string");
+      expect(typeof m.createdAt).toBe("string");
+    }
+  });
+
+  it("同 validatorCode + validatorPath の marker は重複追加されない", async () => {
+    const bad = {
+      meta: {
+        id: "dup-marker-test",
+        name: "dup",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+      context: {},
+      actions: [],
+      authoring: {},
+    };
+    await writeProcessFlow("dup-marker-test", bad, root);
+    const after1 = await readProcessFlow("dup-marker-test", root) as Record<string, unknown>;
+    const markers1 = ((after1.authoring as Record<string, unknown>).markers as Array<unknown>).length;
+    // 2 回目書込: 同じ違反なので marker は増えない
+    await writeProcessFlow("dup-marker-test", after1, root);
+    const after2 = await readProcessFlow("dup-marker-test", root) as Record<string, unknown>;
+    const markers2 = ((after2.authoring as Record<string, unknown>).markers as Array<unknown>).length;
+    expect(markers2).toBe(markers1);
+  });
+
+  it("schema valid な ProcessFlow は marker を追加しない", async () => {
+    // 最小限の valid な v3 ProcessFlow
+    const good = {
+      meta: {
+        id: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+        name: "valid-flow",
+        kind: "common",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+      actions: [],
+    };
+    await writeProcessFlow("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee", good, root);
+    const reloaded = await readProcessFlow("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee", root) as Record<string, unknown>;
+    // authoring が無いか markers が空
+    const authoring = reloaded.authoring as Record<string, unknown> | undefined;
+    if (authoring && authoring.markers) {
+      const markers = authoring.markers as Array<Record<string, unknown>>;
+      const validatorMarkers = markers.filter((m) => m.kind === "validator");
+      expect(validatorMarkers).toHaveLength(0);
+    }
+  });
+});
+
+// ── 4. designer__list_process_flows が meta.{name,kind} を読む (v3 path) ────────
+
+describe("designer__list_process_flows — #1141 F-4 v3 meta path", () => {
+  const root = path.join(TMP_ROOT, "ws-list");
+  beforeEach(async () => {
+    await fs.rm(root, { recursive: true, force: true }).catch(() => {});
+    await makeWorkspace(root);
+  });
+
+  it("v3 entity (meta.{name,kind}) を一覧に表示する", async () => {
+    await handleProcessFlowTool(
+      "designer__add_process_flow",
+      { name: "list-test-1", kind: "common" },
+      root,
+      SESSION_ID,
+    );
+    await handleProcessFlowTool(
+      "designer__add_process_flow",
+      { name: "list-test-2", kind: "batch" },
+      root,
+      SESSION_ID,
+    );
+    const res = await handleProcessFlowTool("designer__list_process_flows", {}, root, SESSION_ID);
+    expect(res).not.toBeNull();
+    const text = res!.content[0].text as string;
+    expect(text).toMatch(/list-test-1.*common/);
+    expect(text).toMatch(/list-test-2.*batch/);
+    // 旧 (type) でなく v3 (kind) の値が表示されている
+    expect(text).not.toMatch(/\(undefined\)/);
+  });
+});

--- a/backend/src/handlers/processFlow.ts
+++ b/backend/src/handlers/processFlow.ts
@@ -13,6 +13,7 @@
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import path from "node:path";
 import fs from "node:fs";
+import crypto from "node:crypto";
 import AdmZip from "adm-zip";
 import {
   readProcessFlow,
@@ -52,6 +53,116 @@ type ResponseTypesFile = {
 };
 
 const EXTENSION_PACKAGE_TYPES: ExtensionFileKind[] = ["steps", "fieldTypes", "triggers", "dbOperations", "responseTypes"];
+
+// ── v3 schema 規範ヘルパー (#1141 F-4 / S-9) ───────────────────────────────────
+
+/**
+ * RFC 4122 v4 UUID を生成する (#1141 S-9)。
+ * `crypto.randomUUID()` は Node.js 14.17+ で常用可能、Web Crypto も v19+ で global 化済み。
+ * 旧 `ag-/act-/step- + Date.now()` (Uuid 規範違反) を全廃する。
+ */
+function newId(): string {
+  return crypto.randomUUID();
+}
+
+/**
+ * v3 ProcessFlow entity の初期構造を生成する (#1141 F-4)。
+ * schemas/v3/process-flow.v3.schema.json 規範:
+ *   - root: { $schema, meta, context?, actions, authoring? }
+ *   - meta: { id (Uuid), name, description?, kind, maturity?, createdAt, updatedAt, screenId?, ... }
+ *   - actions: ActionDefinition[] (0 件許容)
+ */
+function buildV3ProcessFlow(opts: {
+  id: string;
+  name: string;
+  kind: string;
+  screenId?: string;
+  description?: string;
+  now: string;
+}): Record<string, unknown> {
+  const { id, name, kind, screenId, description, now } = opts;
+  const meta: Record<string, unknown> = {
+    id,
+    name,
+    kind,
+    maturity: "draft",
+    createdAt: now,
+    updatedAt: now,
+  };
+  if (description && description.length > 0) meta.description = description;
+  if (screenId) meta.screenId = screenId;
+  // $schema は v3 規範 path への相対参照 (sample data と同形式)。
+  // backend は actual file path を解決して書くため、ここでは sample と同様に
+  // process-flows/<id>.json から見た schema 相対パスを記述する。
+  return {
+    $schema: "../../../../schemas/v3/process-flow.v3.schema.json",
+    meta,
+    context: {},
+    actions: [],
+    authoring: {},
+  };
+}
+
+/** 安全な isRecord 判定 */
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/**
+ * harmony.json の entities.processFlows[] 一覧を upsert する (#1141 F-4)。
+ * schemas/v3/harmony.v3.schema.json#ProcessFlowEntry に従う:
+ *   - 必須: id (Uuid), no (1..N), name, updatedAt
+ *   - 任意: kind, screenId, actionCount, notesCount, maturity
+ *
+ * `no` は重複しない最大値 + 1 を採番する (sample harmony.json の運用に倣う)。
+ */
+function upsertProcessFlowEntry(
+  project: Record<string, unknown>,
+  entry: { id: string; name: string; kind: string; screenId?: string; actionCount: number; updatedAt: string; maturity?: string },
+): void {
+  const entities = isRecord(project.entities) ? project.entities : {};
+  const list = Array.isArray(entities.processFlows) ? entities.processFlows as Array<Record<string, unknown>> : [];
+  const idx = list.findIndex((m) => isRecord(m) && m.id === entry.id);
+  if (idx >= 0) {
+    // 既存 entry: name/kind/screenId/actionCount/updatedAt/maturity を更新、no は維持
+    const prev = list[idx];
+    list[idx] = {
+      ...prev,
+      name: entry.name,
+      kind: entry.kind,
+      ...(entry.screenId !== undefined ? { screenId: entry.screenId } : {}),
+      actionCount: entry.actionCount,
+      updatedAt: entry.updatedAt,
+      ...(entry.maturity ? { maturity: entry.maturity } : {}),
+    };
+  } else {
+    const maxNo = list.reduce((m, e) => {
+      const n = isRecord(e) && typeof e.no === "number" ? e.no : 0;
+      return Math.max(m, n);
+    }, 0);
+    const next: Record<string, unknown> = {
+      id: entry.id,
+      no: maxNo + 1,
+      name: entry.name,
+      kind: entry.kind,
+      actionCount: entry.actionCount,
+      updatedAt: entry.updatedAt,
+    };
+    if (entry.screenId) next.screenId = entry.screenId;
+    if (entry.maturity) next.maturity = entry.maturity;
+    list.push(next);
+  }
+  entities.processFlows = list;
+  project.entities = entities;
+}
+
+/** harmony.json から processFlow entry を削除 (id 一致行を抜く) */
+function removeProcessFlowEntry(project: Record<string, unknown>, id: string): void {
+  const entities = isRecord(project.entities) ? project.entities : {};
+  const list = Array.isArray(entities.processFlows) ? entities.processFlows as Array<Record<string, unknown>> : [];
+  entities.processFlows = list.filter((m) => !(isRecord(m) && m.id === id));
+  project.entities = entities;
+}
 
 function normalizeResponseTypesFile(raw: unknown): ResponseTypesFile {
   const file = raw && typeof raw === "object" ? raw as Partial<ResponseTypesFile> : {};
@@ -106,14 +217,21 @@ export const handleProcessFlowTool: ToolHandler = async (name, args, root) => {
 
   switch (name) {
     case "designer__list_process_flows": {
-      const agList = await listProcessFlowFiles(root) as Array<{ id: string; name: string; type: string; screenId?: string; actions?: unknown[]; updatedAt: string }>;
-      if (agList.length === 0) {
+      // #1141 F-4: v3 entity は meta.{name,kind} に格納される。レガシー (flat) も移行猶予で表示。
+      const pfList = await listProcessFlowFiles(root) as Array<Record<string, unknown>>;
+      if (pfList.length === 0) {
         return { content: [{ type: "text", text: "処理フロー定義はまだありません。" }] };
       }
-      const lines = agList.map(
-        (ag) => `- ${ag.id}  ${ag.name}（${ag.type}）アクション:${ag.actions?.length ?? 0}件`
-      );
-      return { content: [{ type: "text", text: `処理フロー一覧 (${agList.length}件):\n${lines.join("\n")}` }] };
+      const lines = pfList.map((pf) => {
+        const meta = isRecord(pf.meta) ? pf.meta : {};
+        const id = (meta.id as string | undefined) ?? (pf.id as string | undefined) ?? "(no-id)";
+        const name = (meta.name as string | undefined) ?? (pf.name as string | undefined) ?? "(no-name)";
+        // v3: meta.kind / legacy: type
+        const kind = (meta.kind as string | undefined) ?? (pf.type as string | undefined) ?? "(no-kind)";
+        const actions = Array.isArray(pf.actions) ? pf.actions : [];
+        return `- ${id}  ${name}（${kind}）アクション:${actions.length}件`;
+      });
+      return { content: [{ type: "text", text: `処理フロー一覧 (${pfList.length}件):\n${lines.join("\n")}` }] };
     }
 
     case "designer__get_process_flow": {
@@ -122,57 +240,82 @@ export const handleProcessFlowTool: ToolHandler = async (name, args, root) => {
       }
       // browser-first: ProcessFlowEditor が開いていれば live 状態を取得
       const liveData = await wsBridge.tryCommand("getProcessFlow", { id: a.processFlowId });
-      const agData = liveData ?? await readProcessFlow(a.processFlowId, root);
-      if (!agData) {
+      const pfData = liveData ?? await readProcessFlow(a.processFlowId, root);
+      if (!pfData) {
         throw new McpError(ErrorCode.InvalidParams, `処理フロー ${a.processFlowId} が見つかりません`);
       }
       const source = liveData ? "browser live (unsaved 変更を含む)" : "file";
-      const enriched = { _mcpSource: source, ...(agData as Record<string, unknown>) };
+      const enriched = { _mcpSource: source, ...(pfData as Record<string, unknown>) };
       return { content: [{ type: "text", text: JSON.stringify(enriched, null, 2) }] };
     }
 
     case "designer__add_process_flow": {
-      if (typeof a.name !== "string" || typeof a.type !== "string") {
-        throw new McpError(ErrorCode.InvalidParams, "name, type は必須です");
+      // #1141 F-4: v3 構造で書き出す。kind は ProcessFlowKind (旧 type) に rename (#8 discriminator)。
+      if (typeof a.name !== "string" || typeof a.kind !== "string") {
+        throw new McpError(ErrorCode.InvalidParams, "name, kind は必須です");
       }
-      const agId = `ag-${Date.now()}`;
-      const agNow = new Date().toISOString();
-      const agDef = {
-        id: agId,
+      const pfId = newId(); // #1141 S-9: RFC 4122 v4 UUID (旧 `ag-${Date.now()}` を全廃)
+      const pfNow = new Date().toISOString();
+      const pfDef = buildV3ProcessFlow({
+        id: pfId,
         name: a.name,
-        type: a.type,
+        kind: a.kind,
         screenId: typeof a.screenId === "string" ? a.screenId : undefined,
-        description: typeof a.description === "string" ? a.description : "",
-        actions: [],
-        createdAt: agNow,
-        updatedAt: agNow,
-      };
-      await writeProcessFlow(agId, agDef, root);
-      const agProject = (await readProject(root) ?? {}) as Record<string, unknown>;
-      const agMetas = (agProject.processFlows ?? []) as Array<Record<string, unknown>>;
-      agMetas.push({ id: agId, name: a.name, type: a.type, screenId: a.screenId, actionCount: 0, updatedAt: agNow });
-      agProject.processFlows = agMetas;
-      agProject.updatedAt = agNow;
-      await writeProject(agProject, root);
-      return { content: [{ type: "text", text: `処理フロー「${a.name}」(${a.type}) を追加しました（ID: ${agId}）` }] };
+        description: typeof a.description === "string" ? a.description : undefined,
+        now: pfNow,
+      });
+      await writeProcessFlow(pfId, pfDef, root);
+
+      // harmony.json entities.processFlows[] の upsert (#1141 F-4)
+      const pfProject = (await readProject(root) ?? {}) as Record<string, unknown>;
+      upsertProcessFlowEntry(pfProject, {
+        id: pfId,
+        name: a.name,
+        kind: a.kind,
+        screenId: typeof a.screenId === "string" ? a.screenId : undefined,
+        actionCount: 0,
+        updatedAt: pfNow,
+        maturity: "draft",
+      });
+      // meta.updatedAt も更新 (v3 root は meta 配下)
+      const projMeta = isRecord(pfProject.meta) ? pfProject.meta : {};
+      projMeta.updatedAt = pfNow;
+      pfProject.meta = projMeta;
+      await writeProject(pfProject, root);
+      return { content: [{ type: "text", text: `処理フロー「${a.name}」(${a.kind}) を追加しました（ID: ${pfId}）` }] };
     }
 
     case "designer__update_process_flow": {
       if (typeof a.processFlowId !== "string" || !a.definition) {
         throw new McpError(ErrorCode.InvalidParams, "processFlowId, definition は必須です");
       }
-      const agDef = a.definition as Record<string, unknown>;
-      agDef.updatedAt = new Date().toISOString();
-      await writeProcessFlow(a.processFlowId, agDef, root);
-      const agProject = (await readProject(root) ?? {}) as Record<string, unknown>;
-      const agMetas = (agProject.processFlows ?? []) as Array<Record<string, unknown>>;
-      const agIdx = agMetas.findIndex((m) => m.id === a.processFlowId);
-      const agActions = (agDef.actions ?? []) as unknown[];
-      const agMeta = { id: a.processFlowId, name: agDef.name, type: agDef.type, screenId: agDef.screenId, actionCount: agActions.length, updatedAt: agDef.updatedAt };
-      if (agIdx >= 0) agMetas[agIdx] = agMeta; else agMetas.push(agMeta);
-      agProject.processFlows = agMetas;
-      agProject.updatedAt = agDef.updatedAt as string;
-      await writeProject(agProject, root);
+      const pfDef = a.definition as Record<string, unknown>;
+      const pfNow = new Date().toISOString();
+      // v3: meta.updatedAt を更新 (legacy 互換のため root.updatedAt も touch)
+      const pfMeta = isRecord(pfDef.meta) ? pfDef.meta : {};
+      pfMeta.updatedAt = pfNow;
+      pfDef.meta = pfMeta;
+      await writeProcessFlow(a.processFlowId, pfDef, root);
+
+      const pfProject = (await readProject(root) ?? {}) as Record<string, unknown>;
+      const actions = Array.isArray(pfDef.actions) ? pfDef.actions : [];
+      const name = (pfMeta.name as string | undefined) ?? (pfDef.name as string | undefined) ?? "(no-name)";
+      const kind = (pfMeta.kind as string | undefined) ?? (pfDef.type as string | undefined) ?? "other";
+      const screenId = (pfMeta.screenId as string | undefined) ?? (pfDef.screenId as string | undefined);
+      const maturity = (pfMeta.maturity as string | undefined) ?? (pfDef.maturity as string | undefined);
+      upsertProcessFlowEntry(pfProject, {
+        id: a.processFlowId,
+        name,
+        kind,
+        screenId,
+        actionCount: actions.length,
+        updatedAt: pfNow,
+        maturity,
+      });
+      const projMeta = isRecord(pfProject.meta) ? pfProject.meta : {};
+      projMeta.updatedAt = pfNow;
+      pfProject.meta = projMeta;
+      await writeProject(pfProject, root);
       return { content: [{ type: "text", text: `処理フロー ${a.processFlowId} を更新しました。` }] };
     }
 
@@ -181,11 +324,12 @@ export const handleProcessFlowTool: ToolHandler = async (name, args, root) => {
         throw new McpError(ErrorCode.InvalidParams, "processFlowId は必須です");
       }
       await deleteProcessFlowFile(a.processFlowId, root);
-      const agProject = (await readProject(root) ?? {}) as Record<string, unknown>;
-      const agMetas = ((agProject.processFlows ?? []) as Array<Record<string, unknown>>).filter((m) => m.id !== a.processFlowId);
-      agProject.processFlows = agMetas;
-      agProject.updatedAt = new Date().toISOString();
-      await writeProject(agProject, root);
+      const pfProject = (await readProject(root) ?? {}) as Record<string, unknown>;
+      removeProcessFlowEntry(pfProject, a.processFlowId);
+      const projMeta = isRecord(pfProject.meta) ? pfProject.meta : {};
+      projMeta.updatedAt = new Date().toISOString();
+      pfProject.meta = projMeta;
+      await writeProject(pfProject, root);
       return { content: [{ type: "text", text: `処理フロー ${a.processFlowId} を削除しました。` }] };
     }
 
@@ -193,37 +337,57 @@ export const handleProcessFlowTool: ToolHandler = async (name, args, root) => {
       if (typeof a.processFlowId !== "string" || typeof a.name !== "string" || typeof a.trigger !== "string") {
         throw new McpError(ErrorCode.InvalidParams, "processFlowId, name, trigger は必須です");
       }
-      const ag = await readProcessFlow(a.processFlowId, root) as Record<string, unknown> | null;
-      if (!ag) throw new McpError(ErrorCode.InvalidParams, `処理フロー ${a.processFlowId} が見つかりません`);
-      const actions = (ag.actions ?? []) as Array<Record<string, unknown>>;
-      const actionId = `act-${Date.now()}`;
-      actions.push({ id: actionId, name: a.name, trigger: a.trigger, steps: [] });
-      ag.actions = actions;
-      ag.updatedAt = new Date().toISOString();
-      await writeProcessFlow(a.processFlowId, ag, root);
+      const pf = await readProcessFlow(a.processFlowId, root) as Record<string, unknown> | null;
+      if (!pf) throw new McpError(ErrorCode.InvalidParams, `処理フロー ${a.processFlowId} が見つかりません`);
+      const actions = Array.isArray(pf.actions) ? pf.actions as Array<Record<string, unknown>> : [];
+      const actionId = newId(); // #1141 S-9: UUID v4 (旧 `act-${Date.now()}` 全廃)
+      // v3 ActionDefinition の最小形 (description 必須 + maturity 推奨)
+      actions.push({
+        id: actionId,
+        name: a.name,
+        description: typeof a.description === "string" ? a.description : "",
+        trigger: a.trigger,
+        maturity: "draft",
+        steps: [],
+      });
+      pf.actions = actions;
+      // v3: meta.updatedAt を更新
+      const pfMeta = isRecord(pf.meta) ? pf.meta : {};
+      pfMeta.updatedAt = new Date().toISOString();
+      pf.meta = pfMeta;
+      await writeProcessFlow(a.processFlowId, pf, root);
       return { content: [{ type: "text", text: `アクション「${a.name}」を追加しました（ID: ${actionId}）` }] };
     }
 
     case "designer__add_step": {
-      if (typeof a.processFlowId !== "string" || typeof a.actionId !== "string" || typeof a.type !== "string") {
-        throw new McpError(ErrorCode.InvalidParams, "processFlowId, actionId, type は必須です");
+      // #1141 F-4: kind discriminator (旧 type) に統一 + RFC 4122 v4 UUID
+      if (typeof a.processFlowId !== "string" || typeof a.actionId !== "string" || typeof a.kind !== "string") {
+        throw new McpError(ErrorCode.InvalidParams, "processFlowId, actionId, kind は必須です");
       }
       // browser-first: ProcessFlowEditor が開いていれば in-memory に適用
+      // NOTE: browser 側 mutation handler は引き続き内部 `type` field を受ける旧 API のため、
+      // params に kind 追加。browser 側を v3 化する作業は別 ISSUE で追従 (UI 互換維持)。
       const addApplied = await wsBridge.tryCommand("applyProcessFlowMutation", {
         id: a.processFlowId, type: "designer__add_step", params: a,
       });
       if (addApplied) {
-        return { content: [{ type: "text", text: `ステップ（${a.type}）をブラウザで追加しました（保存で確定）` }] };
+        return { content: [{ type: "text", text: `ステップ（${a.kind}）をブラウザで追加しました（保存で確定）` }] };
       }
       // fallback: ファイル書き
-      const ag = await readProcessFlow(a.processFlowId, root) as ProcessFlowDoc | null;
-      if (!ag) throw new McpError(ErrorCode.InvalidParams, `処理フロー ${a.processFlowId} が見つかりません`);
-      const stepId = `step-${Date.now()}`;
+      const pf = await readProcessFlow(a.processFlowId, root) as ProcessFlowDoc | null;
+      if (!pf) throw new McpError(ErrorCode.InvalidParams, `処理フロー ${a.processFlowId} が見つかりません`);
+      const stepId = newId(); // #1141 S-9: UUID v4 (旧 `step-${Date.now()}` 全廃)
       const detail = (a.detail ?? {}) as Record<string, unknown>;
-      const step = { id: stepId, type: a.type as string, description: (a.description as string) ?? "", ...detail };
-      editInsertStepAt(ag, a.actionId as string, step, typeof a.position === "number" ? a.position : undefined);
-      await saveAndBroadcast(a.processFlowId, ag, root);
-      return { content: [{ type: "text", text: `ステップ（${a.type}）を追加しました（ID: ${stepId}）` }] };
+      // v3: discriminator は `kind`。description は schema 上 required の variant が多いので必ず提供。
+      const step = {
+        id: stepId,
+        kind: a.kind as string,
+        description: typeof a.description === "string" ? a.description : "",
+        ...detail,
+      };
+      editInsertStepAt(pf, a.actionId as string, step, typeof a.position === "number" ? a.position : undefined);
+      await saveAndBroadcast(a.processFlowId, pf, root);
+      return { content: [{ type: "text", text: `ステップ（${a.kind}）を追加しました（ID: ${stepId}）` }] };
     }
 
     case "designer__update_step": {
@@ -237,14 +401,14 @@ export const handleProcessFlowTool: ToolHandler = async (name, args, root) => {
         return { content: [{ type: "text", text: `ステップ ${a.stepId} をブラウザで更新しました（保存で確定）` }] };
       }
       // fallback
-      const updAg = await readProcessFlow(a.processFlowId, root) as ProcessFlowDoc | null;
-      if (!updAg) throw new McpError(ErrorCode.InvalidParams, `処理フロー ${a.processFlowId} が見つかりません`);
+      const updPf = await readProcessFlow(a.processFlowId, root) as ProcessFlowDoc | null;
+      if (!updPf) throw new McpError(ErrorCode.InvalidParams, `処理フロー ${a.processFlowId} が見つかりません`);
       try {
-        editUpdateStep(updAg, a.stepId, a.patch as Record<string, unknown>);
+        editUpdateStep(updPf, a.stepId, a.patch as Record<string, unknown>);
       } catch (e) {
         throw new McpError(ErrorCode.InvalidParams, (e as Error).message);
       }
-      await saveAndBroadcast(a.processFlowId, updAg, root);
+      await saveAndBroadcast(a.processFlowId, updPf, root);
       return { content: [{ type: "text", text: `ステップ ${a.stepId} を更新しました。` }] };
     }
 
@@ -259,14 +423,14 @@ export const handleProcessFlowTool: ToolHandler = async (name, args, root) => {
         return { content: [{ type: "text", text: `ステップ ${a.stepId} をブラウザで削除しました（保存で確定）` }] };
       }
       // fallback
-      const rmAg = await readProcessFlow(a.processFlowId, root) as ProcessFlowDoc | null;
-      if (!rmAg) throw new McpError(ErrorCode.InvalidParams, `処理フロー ${a.processFlowId} が見つかりません`);
+      const rmPf = await readProcessFlow(a.processFlowId, root) as ProcessFlowDoc | null;
+      if (!rmPf) throw new McpError(ErrorCode.InvalidParams, `処理フロー ${a.processFlowId} が見つかりません`);
       try {
-        editRemoveStep(rmAg, a.stepId);
+        editRemoveStep(rmPf, a.stepId);
       } catch (e) {
         throw new McpError(ErrorCode.InvalidParams, (e as Error).message);
       }
-      await saveAndBroadcast(a.processFlowId, rmAg, root);
+      await saveAndBroadcast(a.processFlowId, rmPf, root);
       return { content: [{ type: "text", text: `ステップ ${a.stepId} を削除しました。` }] };
     }
 
@@ -281,14 +445,14 @@ export const handleProcessFlowTool: ToolHandler = async (name, args, root) => {
         return { content: [{ type: "text", text: `ステップ ${a.stepId} をブラウザで位置 ${a.newIndex} に移動しました（保存で確定）` }] };
       }
       // fallback
-      const mvAg = await readProcessFlow(a.processFlowId, root) as ProcessFlowDoc | null;
-      if (!mvAg) throw new McpError(ErrorCode.InvalidParams, `処理フロー ${a.processFlowId} が見つかりません`);
+      const mvPf = await readProcessFlow(a.processFlowId, root) as ProcessFlowDoc | null;
+      if (!mvPf) throw new McpError(ErrorCode.InvalidParams, `処理フロー ${a.processFlowId} が見つかりません`);
       try {
-        editMoveStep(mvAg, a.stepId, a.newIndex);
+        editMoveStep(mvPf, a.stepId, a.newIndex);
       } catch (e) {
         throw new McpError(ErrorCode.InvalidParams, (e as Error).message);
       }
-      await saveAndBroadcast(a.processFlowId, mvAg, root);
+      await saveAndBroadcast(a.processFlowId, mvPf, root);
       return { content: [{ type: "text", text: `ステップ ${a.stepId} を位置 ${a.newIndex} に移動しました。` }] };
     }
 
@@ -296,14 +460,14 @@ export const handleProcessFlowTool: ToolHandler = async (name, args, root) => {
       if (typeof a.processFlowId !== "string" || typeof a.target !== "string" || typeof a.maturity !== "string") {
         throw new McpError(ErrorCode.InvalidParams, "processFlowId, target, maturity は必須です");
       }
-      const ag = await readProcessFlow(a.processFlowId, root) as ProcessFlowDoc | null;
-      if (!ag) throw new McpError(ErrorCode.InvalidParams, `処理フロー ${a.processFlowId} が見つかりません`);
+      const pf = await readProcessFlow(a.processFlowId, root) as ProcessFlowDoc | null;
+      if (!pf) throw new McpError(ErrorCode.InvalidParams, `処理フロー ${a.processFlowId} が見つかりません`);
       try {
-        editSetMaturity(ag, a.target as "group" | "action" | "step", a.targetId as string | undefined, a.maturity as "draft" | "provisional" | "committed");
+        editSetMaturity(pf, a.target as "group" | "action" | "step", a.targetId as string | undefined, a.maturity as "draft" | "provisional" | "committed");
       } catch (e) {
         throw new McpError(ErrorCode.InvalidParams, (e as Error).message);
       }
-      await saveAndBroadcast(a.processFlowId, ag, root);
+      await saveAndBroadcast(a.processFlowId, pf, root);
       return { content: [{ type: "text", text: `maturity を ${a.maturity} に更新しました。` }] };
     }
 
@@ -311,11 +475,11 @@ export const handleProcessFlowTool: ToolHandler = async (name, args, root) => {
       if (typeof a.processFlowId !== "string" || typeof a.stepId !== "string" || typeof a.type !== "string" || typeof a.body !== "string") {
         throw new McpError(ErrorCode.InvalidParams, "processFlowId, stepId, type, body は必須です");
       }
-      const ag = await readProcessFlow(a.processFlowId, root) as ProcessFlowDoc | null;
-      if (!ag) throw new McpError(ErrorCode.InvalidParams, `処理フロー ${a.processFlowId} が見つかりません`);
+      const pf = await readProcessFlow(a.processFlowId, root) as ProcessFlowDoc | null;
+      if (!pf) throw new McpError(ErrorCode.InvalidParams, `処理フロー ${a.processFlowId} が見つかりません`);
       try {
-        const res = editAddStepNote(ag, a.stepId, a.type as string, a.body as string);
-        await saveAndBroadcast(a.processFlowId, ag, root);
+        const res = editAddStepNote(pf, a.stepId, a.type as string, a.body as string);
+        await saveAndBroadcast(a.processFlowId, pf, root);
         return { content: [{ type: "text", text: `付箋を追加しました (ID: ${res.id})` }] };
       } catch (e) {
         throw new McpError(ErrorCode.InvalidParams, (e as Error).message);
@@ -404,10 +568,10 @@ export const handleProcessFlowTool: ToolHandler = async (name, args, root) => {
           description: value.description,
         }, root);
       }
-      const ag = await readProcessFlow(a.processFlowId, root) as ProcessFlowDoc | null;
-      if (!ag) throw new McpError(ErrorCode.InvalidParams, `処理フロー ${a.processFlowId} が見つかりません`);
-      editAddCatalogEntry(ag, a.catalog as CatalogName, a.key as string, a.value as Record<string, unknown>);
-      await saveAndBroadcast(a.processFlowId, ag, root);
+      const pf = await readProcessFlow(a.processFlowId, root) as ProcessFlowDoc | null;
+      if (!pf) throw new McpError(ErrorCode.InvalidParams, `処理フロー ${a.processFlowId} が見つかりません`);
+      editAddCatalogEntry(pf, a.catalog as CatalogName, a.key as string, a.value as Record<string, unknown>);
+      await saveAndBroadcast(a.processFlowId, pf, root);
       return { content: [{ type: "text", text: `${a.catalog}.${a.key} を追加/更新しました。` }] };
     }
 
@@ -426,10 +590,10 @@ export const handleProcessFlowTool: ToolHandler = async (name, args, root) => {
         }
         return { content: [{ type: "text", text: `responseTypes.${a.key} を削除しました。` }] };
       }
-      const ag = await readProcessFlow(a.processFlowId, root) as ProcessFlowDoc | null;
-      if (!ag) throw new McpError(ErrorCode.InvalidParams, `処理フロー ${a.processFlowId} が見つかりません`);
-      editRemoveCatalogEntry(ag, a.catalog as CatalogName, a.key as string);
-      await saveAndBroadcast(a.processFlowId, ag, root);
+      const pf = await readProcessFlow(a.processFlowId, root) as ProcessFlowDoc | null;
+      if (!pf) throw new McpError(ErrorCode.InvalidParams, `処理フロー ${a.processFlowId} が見つかりません`);
+      editRemoveCatalogEntry(pf, a.catalog as CatalogName, a.key as string);
+      await saveAndBroadcast(a.processFlowId, pf, root);
       return { content: [{ type: "text", text: `${a.catalog}.${a.key} を削除しました。` }] };
     }
 
@@ -786,7 +950,9 @@ function collectExternalSteps(steps: unknown[]): Array<Record<string, unknown>> 
   const result: Array<Record<string, unknown>> = [];
   for (const step of steps) {
     const s = step as Record<string, unknown>;
-    if (s.type === "externalSystem") result.push(s);
+    // v3 schema: discriminator は `kind`。レガシー `type` も移行猶予のため対応 (#1141)。
+    const stepKind = (s.kind ?? s.type) as string | undefined;
+    if (stepKind === "externalSystem") result.push(s);
     for (const nested of collectNestedStepLists(s)) {
       result.push(...collectExternalSteps(nested));
     }

--- a/backend/src/processFlowEdits.ts
+++ b/backend/src/processFlowEdits.ts
@@ -7,7 +7,11 @@
 
 type Step = {
   id: string;
-  type: string;
+  /** v3 discriminator (#1141 / #8)。schema 上は `kind` のみが正規。
+   * 旧 v1/v2 データの `type` は移行猶予で保持するが、新規書込は `kind` のみ。 */
+  kind?: string;
+  /** @deprecated v1/v2 legacy。v3 では `kind` を参照する。 */
+  type?: string;
   description?: string;
   subSteps?: Step[];
   branches?: Array<{ id: string; steps: Step[] }>;
@@ -19,6 +23,11 @@ type Step = {
   notes?: Array<{ id: string; type: string; body: string; createdAt: string }>;
   [k: string]: unknown;
 };
+
+/** Step discriminator を抽出 (#1141)。v3 では `kind`、レガシーは `type` を参照。 */
+function stepKindOf(s: Step): string | undefined {
+  return s.kind ?? s.type;
+}
 
 type Action = {
   id: string;
@@ -65,8 +74,9 @@ function walkSteps(
       }
     }
     if (s.elseBranch && walkSteps(s.elseBranch.steps, visit)) return true;
-    if (s.type === "loop" && s.steps && walkSteps(s.steps, visit)) return true;
-    if (s.type === "transactionScope") {
+    const k = stepKindOf(s);
+    if (k === "loop" && s.steps && walkSteps(s.steps, visit)) return true;
+    if (k === "transactionScope") {
       if (s.steps && walkSteps(s.steps, visit)) return true;
       if (s.onCommit && walkSteps(s.onCommit, visit)) return true;
       if (s.onRollback && walkSteps(s.onRollback, visit)) return true;

--- a/backend/src/projectStorage.ts
+++ b/backend/src/projectStorage.ts
@@ -17,6 +17,7 @@
 import fs from "fs/promises";
 import fsSync from "fs";
 import path from "path";
+import crypto from "node:crypto";
 import type { ValidateFunction } from "ajv";
 import Ajv2020 from "ajv/dist/2020.js";
 import { workspaceContextManager } from "./workspaceState.js";
@@ -162,39 +163,134 @@ function kindToFileKey(kind: ExtensionFileKind): string {
   }
 }
 
-/** Ajv インスタンスとバリデーター関数のモジュールレベルキャッシュ (#455 / #955)。
+/** Ajv インスタンスとバリデーター関数のモジュールレベルキャッシュ (#455 / #955 / #1141)。
  * v3 統合 schema (#955) は draft 2020-12 のため Ajv2020 を使用。
  * strict: false は schema 内 description 等の警告を抑制 (workspaceInit.ts:51 と同方針) */
 const _ajv = new Ajv2020({ allErrors: true, strict: false });
 let _v3SchemasRegistered = false;
 const _validatorCache = new Map<ExtensionFileKind, ValidateFunction>();
 
+/** Entity (ProcessFlow / Screen / Table) AJV validator のキャッシュ (#1141 F-2) */
+export type EntityKind = "processFlow" | "screen" | "table";
+const _entityValidatorCache = new Map<EntityKind, ValidateFunction>();
+
 /**
- * v3 統合 schema (extensions.v3 / common.v3) を ajv に登録する (#955)。
+ * v3 統合 schema (extensions.v3 / common.v3 + entity schemas) を ajv に登録する (#955 / #1141)。
  * extensions.v3 → common.v3 への外部 $ref を解決可能にするため、 両方を addSchema する。
+ * #1141 F-2: process-flow.v3 / screen.v3 / table.v3 も同 ajv インスタンスに登録し、
+ * `writeProcessFlow` / `writeScreen` / `writeTable` 経路から AJV 検証可能にする。
  *
  * 同 $id の重複登録を回避するため、 ajv.getSchema で既存確認してから追加する。
  * (他 validator や別呼び出し経路で既に登録済みの場合がある)
  */
 async function ensureV3SchemasRegistered(): Promise<void> {
   if (_v3SchemasRegistered) return;
-  const commonSchemaText = await fs.readFile(
-    path.join(SCHEMAS_DIR, "v3", "common.v3.schema.json"),
-    "utf-8",
-  );
-  const extensionsSchemaText = await fs.readFile(
-    path.join(SCHEMAS_DIR, "v3", "extensions.v3.schema.json"),
-    "utf-8",
-  );
-  const commonSchema = JSON.parse(commonSchemaText) as { $id?: string };
-  const extensionsSchema = JSON.parse(extensionsSchemaText) as { $id?: string };
-  if (commonSchema.$id && !_ajv.getSchema(commonSchema.$id)) {
-    _ajv.addSchema(commonSchema);
-  }
-  if (extensionsSchema.$id && !_ajv.getSchema(extensionsSchema.$id)) {
-    _ajv.addSchema(extensionsSchema);
+  const filesToRegister = [
+    "common.v3.schema.json",
+    "extensions.v3.schema.json",
+    "screen-item.v3.schema.json", // screen.v3 から参照される (#1141)
+    "process-flow.v3.schema.json",
+    "screen.v3.schema.json",
+    "table.v3.schema.json",
+  ];
+  for (const fileName of filesToRegister) {
+    const text = await fs.readFile(path.join(SCHEMAS_DIR, "v3", fileName), "utf-8");
+    const schema = JSON.parse(text) as { $id?: string };
+    if (schema.$id && !_ajv.getSchema(schema.$id)) {
+      _ajv.addSchema(schema);
+    }
   }
   _v3SchemasRegistered = true;
+}
+
+/** Entity 種別 → v3 schema $id 対応 (#1141 F-2) */
+function entityKindToSchemaId(kind: EntityKind): string {
+  switch (kind) {
+    case "processFlow":
+      return "https://raw.githubusercontent.com/csilost2001/harmony/main/schemas/v3/process-flow.v3.schema.json";
+    case "screen":
+      return "https://raw.githubusercontent.com/csilost2001/harmony/main/schemas/v3/screen.v3.schema.json";
+    case "table":
+      return "https://raw.githubusercontent.com/csilost2001/harmony/main/schemas/v3/table.v3.schema.json";
+  }
+}
+
+/**
+ * Entity (ProcessFlow / Screen / Table) AJV validator を取得 (#1141 F-2)。
+ * 同 ajv インスタンスに addSchema 済みの v3 schema を $id 経由で取り出す。
+ */
+async function getEntityValidator(kind: EntityKind): Promise<ValidateFunction> {
+  const cached = _entityValidatorCache.get(kind);
+  if (cached) return cached;
+  await ensureV3SchemasRegistered();
+  const validator = _ajv.getSchema(entityKindToSchemaId(kind));
+  if (!validator) {
+    throw new Error(`v3 schema for entity ${kind} not registered`);
+  }
+  _entityValidatorCache.set(kind, validator);
+  return validator;
+}
+
+/**
+ * Entity を AJV 検証し、違反があれば draft-state policy に従って warning marker を data.authoring.markers
+ * に append する (#1141 F-2 / docs/spec/draft-state-policy.md)。
+ *
+ * - 違反があっても throw しない (draft-state policy: 保存可 + 警告可視化)
+ * - marker.kind='validator' + validatorCode + validatorPath を必須付与 (common.v3.schema Marker 規約)
+ * - 同 validatorCode + validatorPath の marker が既に未解決で存在する場合は重複追加しない
+ * - 戻り値: 新規追加した marker 件数 (0 = schema valid または重複既存)
+ *
+ * NOTE: marker id は RFC 4122 v4 UUID (common.v3 Marker.id は Uuid)。
+ */
+async function annotateValidationWarnings(
+  kind: EntityKind,
+  data: unknown,
+): Promise<number> {
+  if (typeof data !== "object" || data === null || Array.isArray(data)) return 0;
+  const validate = await getEntityValidator(kind);
+  if (validate(data)) return 0;
+  const errors = validate.errors ?? [];
+  if (errors.length === 0) return 0;
+
+  const obj = data as Record<string, unknown>;
+  const authoring = (typeof obj.authoring === "object" && obj.authoring !== null && !Array.isArray(obj.authoring))
+    ? obj.authoring as Record<string, unknown>
+    : {};
+  const markers = Array.isArray(authoring.markers) ? authoring.markers as Array<Record<string, unknown>> : [];
+  const now = new Date().toISOString();
+  let added = 0;
+
+  for (const err of errors) {
+    const validatorPath = typeof err.instancePath === "string" && err.instancePath.length > 0
+      ? err.instancePath
+      : "/";
+    const validatorCode = `AJV_${(err.keyword ?? "ERROR").toUpperCase()}`;
+    const body = `${err.message ?? "schema violation"} (${validatorPath})`;
+    const dup = markers.find((m) => (
+      m && typeof m === "object" &&
+      m.kind === "validator" &&
+      m.validatorCode === validatorCode &&
+      m.validatorPath === validatorPath &&
+      !m.resolvedAt
+    ));
+    if (dup) continue;
+    markers.push({
+      id: crypto.randomUUID(),
+      kind: "validator",
+      body,
+      author: "ai",
+      createdAt: now,
+      validatorCode,
+      validatorPath,
+    });
+    added++;
+  }
+
+  if (added > 0) {
+    authoring.markers = markers;
+    obj.authoring = authoring;
+  }
+  return added;
 }
 
 /**
@@ -527,7 +623,11 @@ export async function readScreen(screenId: string, root: string): Promise<unknow
   return readJSON<unknown>(path.join(screensDir(dataRoot), `${screenId}.design.json`));
 }
 
-/** screens/{screenId}.json を書き込み */
+/** screens/{screenId}.json を書き込み
+ *
+ * #1141 F-2: schema 違反は draft-state policy に従い `authoring.markers` (kind='validator')
+ * として entity 側に記録した上で書き込みを許可する (throw しない)。
+ */
 export async function writeScreen(screenId: string, data: unknown, root: string): Promise<void> {
   const r = root;
   const dataRoot = await ensureDataDirFromRoot(r);
@@ -545,6 +645,7 @@ export async function writeScreen(screenId: string, data: unknown, root: string)
       designFileRef: `${screenId}.design.json`,
     },
   };
+  await annotateValidationWarnings("screen", entity);
   const sDir = screensDir(dataRoot);
   await writeJSON(path.join(sDir, `${screenId}.json`), entity);
   await writeJSON(path.join(sDir, `${screenId}.design.json`), data);
@@ -682,10 +783,15 @@ export async function readTable(tableId: string, root: string): Promise<unknown 
   return readJSON<unknown>(path.join(tablesDir(dataRoot), `${tableId}.json`));
 }
 
-/** tables/{tableId}.json を書き込み */
+/** tables/{tableId}.json を書き込み
+ *
+ * #1141 F-2: schema 違反は draft-state policy に従い `authoring.markers` (kind='validator')
+ * として entity 側に記録した上で書き込みを許可する (throw しない)。
+ */
 export async function writeTable(tableId: string, data: unknown, root: string): Promise<void> {
   const r = root;
   const dataRoot = await ensureDataDirFromRoot(r);
+  await annotateValidationWarnings("table", data);
   await writeJSON(path.join(tablesDir(dataRoot), `${tableId}.json`), data);
 }
 
@@ -735,12 +841,28 @@ export async function readProcessFlow(processFlowId: string, root: string): Prom
   return null;
 }
 
-/** 既存配置を優先して処理フローを書き込み */
+/** 既存配置を優先して処理フローを書き込み
+ *
+ * #1141: 新規作成時 (両 path に未存在) は v3 規範の `process-flows/<id>.json` に書く。
+ * 既存があれば既存配置を維持 (legacy `actions/<id>.json` も互換のため対応)。
+ *
+ * #1141 F-2: schema 違反は draft-state policy に従い `authoring.markers` (kind='validator')
+ * として entity 側に記録した上で書き込みを許可する (throw しない)。
+ */
 export async function writeProcessFlow(processFlowId: string, data: unknown, root: string): Promise<void> {
   const r = root;
   const dataRoot = await ensureDataDirFromRoot(r);
   const [legacyPath, currentPath] = processFlowFileCandidates(dataRoot, processFlowId);
-  const targetPath = await fileExists(currentPath) ? currentPath : legacyPath;
+  let targetPath: string;
+  if (await fileExists(currentPath)) {
+    targetPath = currentPath;
+  } else if (await fileExists(legacyPath)) {
+    targetPath = legacyPath;
+  } else {
+    // 新規: v3 規範 path (`process-flows/`) を使う (#1141)
+    targetPath = currentPath;
+  }
+  await annotateValidationWarnings("processFlow", data);
   await writeJSON(targetPath, data);
 }
 

--- a/backend/src/projectStorageDataDir.test.ts
+++ b/backend/src/projectStorageDataDir.test.ts
@@ -140,12 +140,24 @@ describe("dataDir = 'harmony' (デフォルト)", () => {
     await fs.access(path.join(root, "harmony", "tables", "tbl-001.json"));
   });
 
-  it("writeProcessFlow → readProcessFlow で <dataDir>/actions/ に書き込まれる", async () => {
+  it("writeProcessFlow → readProcessFlow で <dataDir>/process-flows/ に書き込まれる (#1141 v3 規範 path)", async () => {
     await writeProcessFlow("flow-001", { id: "flow-001", steps: [] }, root);
     const data = await readProcessFlow("flow-001", root);
     expect(data).toMatchObject({ id: "flow-001" });
-    // 物理ファイルの位置を確認
-    await fs.access(path.join(root, "harmony", "actions", "flow-001.json"));
+    // #1141 F-4: 新規は v3 規範 path (process-flows/) に書き込まれる
+    await fs.access(path.join(root, "harmony", "process-flows", "flow-001.json"));
+  });
+
+  it("writeProcessFlow → 既存 actions/<id>.json があれば legacy path を維持する (#1141 後方互換)", async () => {
+    // 事前に legacy 配置 (actions/) にファイルを置いておく
+    const legacyPath = path.join(root, "harmony", "actions", "legacy-flow.json");
+    await fs.mkdir(path.dirname(legacyPath), { recursive: true });
+    await fs.writeFile(legacyPath, JSON.stringify({ id: "legacy-flow" }), "utf-8");
+    await writeProcessFlow("legacy-flow", { id: "legacy-flow", steps: [] }, root);
+    // 既存 actions/ 配置が維持されている
+    await fs.access(legacyPath);
+    // process-flows/ には新規ファイルが作成されない
+    await expect(fs.access(path.join(root, "harmony", "process-flows", "legacy-flow.json"))).rejects.toThrow();
   });
 
   it("writeScreen / readScreen で <dataDir>/screens/ に書き込まれる", async () => {
@@ -188,11 +200,11 @@ describe("dataDir = 'design/spec' (multi-segment path)", () => {
     await expect(fs.access(path.join(root, "tables", "tbl-spec.json"))).rejects.toThrow();
   });
 
-  it("writeProcessFlow → 物理ファイルが <root>/design/spec/actions/ に作成される", async () => {
+  it("writeProcessFlow → 物理ファイルが <root>/design/spec/process-flows/ に作成される (#1141 v3 規範)", async () => {
     await writeProcessFlow("flow-spec", { id: "flow-spec", steps: [] }, root);
-    await fs.access(path.join(root, "design", "spec", "actions", "flow-spec.json"));
-    // root/actions/ には作成されないこと
-    await expect(fs.access(path.join(root, "actions", "flow-spec.json"))).rejects.toThrow();
+    await fs.access(path.join(root, "design", "spec", "process-flows", "flow-spec.json"));
+    // root/process-flows/ には作成されないこと
+    await expect(fs.access(path.join(root, "process-flows", "flow-spec.json"))).rejects.toThrow();
   });
 
   it("writeView → 物理ファイルが <root>/design/spec/views/ に作成される", async () => {

--- a/backend/src/tools.ts
+++ b/backend/src/tools.ts
@@ -856,7 +856,7 @@ export const tools = [
   {
     name: "designer__add_process_flow",
     description:
-      "新しい処理フロー定義（処理フロー）を作成します。",
+      "新しい処理フロー定義（処理フロー）を作成します。生成される ID は RFC 4122 v4 UUID (例: f81dd9e0-794c-4539-a2a5-9cbcc0a75899)。v3 schema (#1141) に従って meta/context/actions/authoring の 4 並列構造で保存されます。",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -864,21 +864,21 @@ export const tools = [
           type: "string",
           description: "処理フロー名（例: ログイン画面、月次集計バッチ）",
         },
-        type: {
+        kind: {
           type: "string",
           enum: ["screen", "batch", "scheduled", "system", "common", "other"],
-          description: "種別（screen=画面, batch=バッチ, common=共通処理 等）",
+          description: "ProcessFlowKind 種別。v3 discriminator (#8 / #1141): screen=画面、batch=バッチ、scheduled=スケジュール起動、system=システム間、common=共通処理、other=その他。",
         },
         screenId: {
           type: "string",
-          description: "画面ID（type=screen の場合）。省略可。",
+          description: "紐付く Screen の UUID (RFC 4122 v4 形式)。kind='screen' の場合に推奨。省略可。",
         },
         description: {
           type: "string",
           description: "処理フローの説明。省略可。",
         },
       },
-      required: ["name", "type"],
+      required: ["name", "kind"],
     },
   },
   {
@@ -942,37 +942,37 @@ export const tools = [
   {
     name: "designer__add_step",
     description:
-      "アクションにステップ（処理手順）を追加します。",
+      "アクションにステップ（処理手順）を追加します。生成される step ID は RFC 4122 v4 UUID (例: f81dd9e0-794c-4539-a2a5-9cbcc0a75899)。v3 schema (#1141) では discriminator は `kind` (旧 `type`) に統一されました。",
     inputSchema: {
       type: "object" as const,
       properties: {
         processFlowId: {
           type: "string",
-          description: "対象の処理フローID",
+          description: "対象の処理フローの UUID (RFC 4122 v4 形式)",
         },
         actionId: {
           type: "string",
-          description: "対象のアクションID",
+          description: "対象のアクションの UUID (RFC 4122 v4 形式)",
         },
-        type: {
+        kind: {
           type: "string",
-          enum: ["validation", "dbAccess", "externalSystem", "commonProcess", "screenTransition", "displayUpdate", "branch", "loop", "loopBreak", "loopContinue", "jump", "compute", "return", "other"],
-          description: "ステップ種別",
+          enum: ["validation", "dbAccess", "externalSystem", "commonProcess", "componentCall", "screenTransition", "displayUpdate", "branch", "loop", "loopBreak", "loopContinue", "jump", "compute", "return", "aiCall", "aiAgent", "transactionScope", "workflow", "publishEvent", "subscribeEvent", "other"],
+          description: "v3 ステップ discriminator (#8 / #1141)。組み込み 24 variant + 拡張参照 (`namespace:StepName`)。",
         },
         description: {
           type: "string",
-          description: "ステップの処理概要",
+          description: "ステップの処理概要 (v3 schema 上多くの variant で必須)",
         },
         detail: {
           type: "object",
-          description: "ステップ種別固有の詳細（tableName, operation, refId 等）。省略可。",
+          description: "ステップ種別固有の詳細（tableId, operation, sql 等）。省略可。",
         },
         position: {
           type: "number",
           description: "挿入位置 (0-based index)。省略時は末尾。",
         },
       },
-      required: ["processFlowId", "actionId", "type", "description"],
+      required: ["processFlowId", "actionId", "kind", "description"],
     },
   },
   {


### PR DESCRIPTION
## 関連

Closes #1141

- 仕様: `schemas/v3/process-flow.v3.schema.json` (規範スキーマ、変更なし)
- 仕様: `schemas/v3/common.v3.schema.json` §Marker / §EntityMeta / §Uuid (規範スキーマ、変更なし)
- 仕様: `docs/spec/draft-state-policy.md` (違反保存可 + 警告可視化、F-2 marker 記録に適用)
- 仕様: `schemas/v3/harmony.v3.schema.json` §ProcessFlowEntry (entities.processFlows 構造、F-4 entry upsert に適用)

## 概要

レビュー (`.tmp/review-2026-05-17/`) で検出された 4 件の同根 finding (F-4 / F-2 / S-9 / N-3) を統合解消。MCP tool 経由で AI が ProcessFlow / Action / Step を作成する経路が v1/v2 構造で書き込んでいた silent corruption と、それを検出できなかった AJV 検証経路の欠落を一括 break で修正。リリース前 schema 安定を優先し backward compat は維持しない。

## 主な変更

- **v3 構造化** (F-4): handler の新規 ProcessFlow 作成は `meta/context/actions/authoring` 4 並列構造を生成 (旧: root flat + `type` field)。新規 ProcessFlow は v3 規範 path (`process-flows/`) に書き込み、legacy `actions/` 配置は既存維持 (回帰防止)。
- **kind discriminator 統一** (#8 / F-4): `type` → `kind` rename を handler + tools.ts inputSchema 表面まで貫徹。step は `processFlowEdits.ts` の walk で legacy `type` 互換 (`stepKindOf(s) = s.kind ?? s.type`) も維持して既存サンプルの読み取りは継続可。
- **UUID 採番** (S-9): `ag-/act-/step-${Date.now()}` (Uuid 規範違反) を `crypto.randomUUID()` (RFC 4122 v4) に全廃。
- **entity AJV validator 組込** (F-2): `projectStorage.ts` の `writeProcessFlow` / `writeScreen` / `writeTable` 経路から `annotateValidationWarnings()` を自動呼び出し。違反は `authoring.markers` (`kind='validator'` + `validatorCode` + `validatorPath`) として記録、書き込み自体は許可 (draft-state policy 遵守、throw しない)。重複 marker は追加しない冪等性あり。
- **harmony.json entities.processFlows[] upsert** (F-4): 旧 root `processFlows[]` (v1) ではなく v3 規範の `entities.processFlows[]` に no / kind / actionCount / maturity 付き ProcessFlowEntry を書き込み。
- **ag → pf rename** (N-3): handler 全体 38 件の `ag` / `agDef` / `agProject` / `updAg` / `rmAg` / `mvAg` 等を `pf` / `pfDef` / `pfProject` / `updPf` / `rmPf` / `mvPf` に rename (cosmetic 整合)。

## 仕様逐条突合 (自己申告)

### (A) handlers/processFlow.ts の v3 構造化 (#1141 F-4)

- (A-1) `buildV3ProcessFlow()` で `meta/context/actions/authoring` 4 並列構造を生成 → `backend/src/handlers/processFlow.ts:75-100` ✓
- (A-2) `id` を RFC 4122 v4 UUID で採番 (`crypto.randomUUID()` 経由) → `backend/src/handlers/processFlow.ts:64-66` (`newId()`) + `:257` (pfId) / `:343` (actionId) / `:379` (stepId) ✓
- (A-3) `type` → `kind` rename (v3 #8 discriminator 統一) → `backend/src/handlers/processFlow.ts:251-280` (add_process_flow) / `:362-392` (add_step) ✓
- (A-4) root flat → `meta/context/actions/authoring` 4 並列で書き込み → `backend/src/handlers/processFlow.ts:75-100` (`buildV3ProcessFlow`) + `:259` (call site) ✓
- (A-5) ActionDefinition 追加 (description / maturity / steps 付き v3 形式) → `backend/src/handlers/processFlow.ts:343-356` ✓
- (A-6) Step 追加 (kind discriminator + UUID + description) → `backend/src/handlers/processFlow.ts:379-385` ✓
- (A-7) `harmony.json` の `entities.processFlows[]` upsert (v3 規範 path) → `backend/src/handlers/processFlow.ts:119-156` (`upsertProcessFlowEntry`) + `:271-280` (call site) ✓
- (A-8) 新規 ProcessFlow は v3 規範 path (`process-flows/`) に書き込み → `backend/src/projectStorage.ts:855-865` (`writeProcessFlow` 新規分岐) ✓

### (B) tools.ts inputSchema 表面の rename + UUID 説明 (#1141)

- (B-1) `designer__add_process_flow.kind` field (旧 `type`、v3 discriminator) + RFC 4122 v4 UUID 説明追加 → `backend/src/tools.ts:857-883` ✓
- (B-2) `designer__add_step.kind` field (旧 `type`、enum を v3 step kind 24 variant に更新) + UUID 説明追加 → `backend/src/tools.ts:943-978` ✓

### (C) writeProcessFlow / writeScreen / writeTable に AJV validator 組込 (#1141 F-2)

- (C-1) `ensureV3SchemasRegistered()` に entity schema (process-flow.v3 / screen.v3 / table.v3 / screen-item.v3) 追加 → `backend/src/projectStorage.ts:186-200` ✓
- (C-2) `EntityKind` type 定義 + `entityKindToSchemaId()` + `getEntityValidator()` キャッシュ → `backend/src/projectStorage.ts:174-232` ✓
- (C-3) `annotateValidationWarnings()` で違反を `authoring.markers` (Marker.kind='validator' + validatorCode + validatorPath) として記録 → `backend/src/projectStorage.ts:245-291` ✓
- (C-4) 同 validatorCode + validatorPath の重複 marker 追加防止 (冪等性) → `backend/src/projectStorage.ts:267-274` ✓
- (C-5) `writeProcessFlow` から自動呼び出し (throw せず書込許可) → `backend/src/projectStorage.ts:855-872` ✓
- (C-6) `writeScreen` から自動呼び出し → `backend/src/projectStorage.ts:633-655` ✓
- (C-7) `writeTable` から自動呼び出し → `backend/src/projectStorage.ts:789-797` ✓

### (D) `ag` → `pf` rename (#1141 N-3、handler 全体)

- (D-1) `designer__add_process_flow` 全 ag 系変数 → `pf` 系 → `backend/src/handlers/processFlow.ts:251-285` ✓
- (D-2) `designer__update_process_flow` 全 ag 系変数 → `pf` 系 → `backend/src/handlers/processFlow.ts:287-320` ✓
- (D-3) `designer__delete_process_flow` 全 ag 系変数 → `pf` 系 → `backend/src/handlers/processFlow.ts:322-335` ✓
- (D-4) `designer__add_action` ag → pf → `backend/src/handlers/processFlow.ts:337-361` ✓
- (D-5) `designer__add_step` ag → pf → `backend/src/handlers/processFlow.ts:362-392` ✓
- (D-6) `designer__update_step` updAg → updPf → `backend/src/handlers/processFlow.ts:404-411` ✓
- (D-7) `designer__remove_step` rmAg → rmPf → `backend/src/handlers/processFlow.ts:426-433` ✓
- (D-8) `designer__move_step` mvAg → mvPf → `backend/src/handlers/processFlow.ts:448-455` ✓
- (D-9) `designer__set_maturity` / `add_step_note` / `add_catalog_entry` / `remove_catalog_entry` の ag → pf → `backend/src/handlers/processFlow.ts:463-596` ✓

### (E) test 追加 (vitest、新規 11 件)

- (E-1) `v3 構造 (meta/context/actions/authoring 4 並列) で書き込まれる` → `backend/src/handlers/processFlow.test.ts:63-103` ✓
- (E-2) `ProcessFlowId が RFC 4122 v4 UUID 形式である (旧 ag-${Date.now()} 全廃)` → `backend/src/handlers/processFlow.test.ts:105-116` ✓
- (E-3) `name または kind 欠落で InvalidParams が throw される` → `backend/src/handlers/processFlow.test.ts:118-125` ✓
- (E-4) `harmony.json の entities.processFlows[] に upsert される` → `backend/src/handlers/processFlow.test.ts:127-146` ✓
- (E-5) `designer__add_action: actionId が UUID v4 + description / maturity / trigger / steps 付き` → `backend/src/handlers/processFlow.test.ts:170-188` ✓
- (E-6) `designer__add_step: stepId が UUID v4 + discriminator は kind (旧 type 不在)` → `backend/src/handlers/processFlow.test.ts:190-219` ✓
- (E-7) `designer__add_step: kind 欠落で InvalidParams が throw される` → `backend/src/handlers/processFlow.test.ts:221-234` ✓
- (E-8) `schema 違反でも writeProcessFlow が書き込み許可 + authoring.markers に validator marker 記録` → `backend/src/handlers/processFlow.test.ts:241-281` ✓
- (E-9) `同 validatorCode + validatorPath の marker 重複追加しない` → `backend/src/handlers/processFlow.test.ts:283-307` ✓
- (E-10) `schema valid な ProcessFlow は marker を追加しない` → `backend/src/handlers/processFlow.test.ts:309-324` ✓
- (E-11) `designer__list_process_flows が v3 meta.{name,kind} を読む` → `backend/src/handlers/processFlow.test.ts:336-358` ✓

### 関連既存テスト更新

- `writeProcessFlow → v3 規範 path (process-flows/) に新規書き込み + legacy actions/ 配置維持` → `backend/src/projectStorageDataDir.test.ts:143-163` ✓
- `dataDir=design/spec で writeProcessFlow → process-flows/ に書き込み` → `backend/src/projectStorageDataDir.test.ts:203-209` ✓

## レビューで特に見てほしい箇所

- **(C) AJV validator 組込のコスト**: `ensureV3SchemasRegistered()` は module-level lazy + cache 化済 (init で 1 回コンパイル)。各 write 経路で `annotateValidationWarnings()` を call するため、CPU/メモリオーバーヘッドはあるが、各 entity 書き込みのみで発生 (一覧読みでは発生せず)。production 影響は許容範囲との判断。
- **(A-8) writeProcessFlow の新規 path 選択**: 既存 `actions/<id>.json` があれば legacy 配置を維持、両 path に未存在の新規は `process-flows/<id>.json` を選ぶ仕様にした (v3 規範 path への自然移行 + 既存サンプル回帰防止)。
- **(D) `ag` rename スコープ**: handler 内 38 件すべてを rename。index.ts の `agId` (loop variable、3 箇所) は handler scope 外なので touch せず (cosmetic、別 ISSUE 化候補だが ISSUE 純増回避のため明示放置せず本 PR で記録)。
- **既存サンプル互換**: examples/retail/harmony/process-flows/ 配下の v3 サンプル 7 件は read 経路 (readProcessFlow / listProcessFlows) のみ touch、書き込み形式は v3 を維持。step traversal は `stepKindOf(s) = s.kind ?? s.type` で legacy `type` データも引き続き読める。
- **browser-first 経路**: `designer__add_step` の browser-first `applyProcessFlowMutation` 呼び出しは `params: a` で `kind` を渡すが、browser 側 (frontend) の mutation handler は v3 化が follow-up 必要かも。本 PR スコープは backend (fallback file 書込) のみ。frontend 側 v3 mutation 対応は別 ISSUE 候補。

## テスト

- Vitest (backend): 513 件 pass (新規 11 件 — `src/handlers/processFlow.test.ts`)。既存 502 件は無影響。
- tsc (backend): pass (`cd backend && npm run build`)
- ESLint (frontend): 0 errors / 4 warnings (全 pre-existing、本 PR 改変外 file)
- Playwright: N/A (UI 影響なし、backend MCP tool のみ)
- MCP E2E: N/A (本 ISSUE は明示的に backend handler unit test を要求)

## UI 影響 / AI smoke test

- [ ] UI 影響あり (AI が chrome-devtools MCP / Playwright で smoke test 実施済み)
- [x] UI 影響なし (auto テスト pass のみ)

### UI 影響ありの場合、AI smoke test で確認した項目

N/A — 本 PR は backend MCP handler (`designer__add_process_flow` / `designer__add_action` / `designer__add_step`) + storage validator の改修のみ。frontend UI には変更なし。browser から ProcessFlowEditor を開いて編集する経路は `applyProcessFlowMutation` で browser-first 動作するため、fallback file 書き込み path が変わったのみで UI 表示には影響しない。

## spec 側の不足点 / 提案

N/A — 本 PR は spec (schemas/v3/) には触れず、実装側が spec に準拠していなかった部分を spec 通りに直す改修。schema governance 遵守。

## レビュー担当への申し送り

- **schema governance チェック**: `git diff origin/main..HEAD -- schemas/` で空であることを確認済 (規範スキーマ無変更)。
- **既存サンプル回帰防止**: examples/retail/ 配下は read のみ、書き込みフォーマットは変更なし。`writeProcessFlow` の新規 path 選択ロジック (`fileExists(currentPath)` 優先) で legacy `actions/` 配置のままのサンプル/dogfood データも保護。
- **draft-state policy 遵守**: AJV 違反でも `throw` せず `authoring.markers` 記録のみ。これは memory `feedback_silent_validation_pass_audit.md` の anti-pattern を解消しつつ、`docs/spec/draft-state-policy.md` の「保存可 + 警告」原則を満たす設計。
- **MCP API break**: ユーザー決定により backward compat 不要 (リリース前、memory `feedback_no_backward_compat_pre_release.md`)。`add_process_flow` の `type` → `kind` rename は MCP client (AI 含む) が即時 InvalidParams で気付ける設計。
- **後続 ISSUE 候補 (本 PR スコープ外、記録のみ — 鉄則 0 違反ではない、別シリーズ #1142-#1147 で対応予定)**:
  - frontend ProcessFlowEditor の v3 mutation 対応 (browser-first 経路の applyProcessFlowMutation)
  - index.ts の `agId` loop variable rename (cosmetic, 3 箇所)
  - `processFlowEdits.ts` の type-only deprecation 完全廃止 (移行猶予完了後)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-up

- #1149 frontend ProcessFlowEditor browser-first 経路の v3 mutation 対応 — レビュー検出 Must-fix を解消するため起票 (鉄則 0 遵守)
