### PR TITLE
docs(agents): routing 表 + MCP tool 数 + Data Flow path の drift 修正 (#1143)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -341,22 +341,41 @@ AI Agent ──(http://localhost:5179/mcp)──┐
 
 URL 規約: **`/category/feature[/:id]`** 形式（Java 風階層）。ルートは単一概念で意味が通るよう、複数解釈できる複数形は避ける（例: `/flow` は 画面フロー／処理フロー どちらか不明なため不採用）。
 
+表中の Path は **workspace-scoped route 配下のサブパス** として記載 (実 URL は `/w/:wsId/<path>`)。`/workspace/*` と `/ai-settings` のみ workspace スコープ外 (top-level)。
+
 | Path | Component | Purpose | Opens as tab? |
 |------|-----------|---------|---------------|
-| `/` | DashboardView | 全体俯瞰ダッシュボード | ✅ singleton |
+| `/` (index) | DashboardView | 全体俯瞰ダッシュボード | ✅ singleton |
 | `/screen/flow` | FlowEditor | 画面フロー図（ReactFlow、キャンバス固定）| ✅ singleton |
 | `/screen/list` | ScreenListView | 画面一覧（カード ⇔ 表切替）| ✅ singleton |
-| `/screen/design/:screenId` | Designer | 画面デザイナー（GrapesJS）| ✅ per-resource |
+| `/screen/design/:screenId` | Designer (`ResourceLoading` でラップ) | 画面デザイナー（GrapesJS）| ✅ per-resource |
+| `/screen/items/:screenId` | ScreenItemsView | 画面項目編集 | ✅ per-resource |
 | `/table/list` | TableListView | テーブル一覧 | ✅ singleton |
 | `/table/edit/:tableId` | TableEditor | テーブル編集 | ✅ per-resource |
 | `/table/er` | ErDiagram | ER 図 | ✅ singleton |
 | `/process-flow/list` | ProcessFlowListView | 処理フロー一覧 | ✅ singleton |
-| `/extensions` | ExtensionsPanel | 拡張管理 | ✅ singleton |
 | `/process-flow/edit/:processFlowId` | ProcessFlowEditor | 処理フロー編集 | ✅ per-resource |
+| `/sequence/list` | SequenceListView | シーケンス一覧 | ✅ singleton |
+| `/sequence/edit/:sequenceId` | SequenceEditor | シーケンス編集 | ✅ per-resource |
+| `/view/list` | ViewListView | DB ビュー一覧 | ✅ singleton |
+| `/view/edit/:viewId` | ViewEditor | DB ビュー編集 | ✅ per-resource |
+| `/view-definition/list` | ViewDefinitionListView | ViewDefinition (viewer) 一覧 | ✅ singleton |
+| `/view-definition/edit/:viewDefinitionId` | ViewDefinitionEditor | ViewDefinition 編集 | ✅ per-resource |
 | `/page-layout/list` | PageLayoutListView | ページレイアウト一覧 (RFC #1021) | ✅ singleton |
 | `/page-layout/edit/:pageLayoutId` | PageLayoutEditor | ページレイアウト編集 | ✅ per-resource |
 | `/page-layout/design/:pageLayoutId` | PageLayoutDesigner | ページレイアウト Designer | ✅ per-resource |
 | `/gadget/list` | GadgetListView | ガジェット一覧 (Screen.purpose=gadget filter) | ✅ singleton |
+| `/generic-definition` | GenericDefinitionCatalogView | 汎用定義カタログ | ✅ singleton |
+| `/generic-definition/:kind` | GenericDefinitionListView | 汎用定義一覧 (kind 別) | ✅ per-resource (kind 単位) |
+| `/generic-definition/:kind/:name` | GenericDefinitionEditor | 汎用定義編集 | ✅ per-resource |
+| `/extensions` | ExtensionsPanel | 拡張管理 | ✅ singleton |
+| `/conventions/catalog` | ConventionsCatalogView | 横断規約カタログ | ✅ singleton |
+| `/project/tech-stack` | TechStackView | 技術スタック選定 | ✅ singleton |
+| `/workspace/list` (top-level) | WorkspaceListView | ワークスペース一覧 | ✅ singleton |
+| `/workspace/select` (top-level) | WorkspaceSelectView | ワークスペース選択 (フルスクリーン welcome) | ❌ route only (タブ対象外) |
+| `/ai-settings` (top-level) | CodexSettingsView | AI 設定 | ✅ singleton |
+
+**実装**: `frontend/src/components/AppShell.tsx:300-354` の `<Routes>` 定義 (workspace-scoped は `/w/:wsId` 配下 nested route)。
 
 ワークスペース概念 (active workspace / lockdown / recent / 切替プロトコル) は [docs/spec/workspace.md](docs/spec/workspace.md) を参照。複数ワークスペースの**同時並行編集** (v2) は [docs/spec/workspace-multi.md](docs/spec/workspace-multi.md) を参照 (#679 シリーズ)。
 
@@ -366,9 +385,9 @@ URL 規約: **`/category/feature[/:id]`** 形式（Java 風階層）。ルート
 
 | 種別 | 対象 | 性質 |
 |------|------|------|
-| シングルトンタブ | Dashboard / 画面フロー / 画面一覧 / テーブル一覧 / ER 図 / 処理フロー一覧 / 拡張管理 | 1 インスタンス固定、再オープン時は既存を再利用 |
-| マルチインスタンスタブ | Designer / TableEditor / ProcessFlowEditor | リソース ID 毎に独立タブ |
-| route only | なし | — |
+| シングルトンタブ | Dashboard / 画面フロー / 画面一覧 / テーブル一覧 / ER 図 / 処理フロー一覧 / シーケンス一覧 / DB ビュー一覧 / ViewDefinition 一覧 / ページレイアウト一覧 / ガジェット一覧 / 汎用定義カタログ / 拡張管理 / 横断規約カタログ / 技術スタック / ワークスペース一覧 / AI 設定 | 1 インスタンス固定、再オープン時は既存を再利用 |
+| マルチインスタンスタブ | Designer / ScreenItemsView / TableEditor / ProcessFlowEditor / SequenceEditor / ViewEditor / ViewDefinitionEditor / PageLayoutEditor / PageLayoutDesigner / GenericDefinitionListView (kind 別) / GenericDefinitionEditor | リソース ID 毎に独立タブ |
+| route only | `/workspace/select` (フルスクリーン welcome、ヘッダー・タブバーなし) | タブ管理対象外 |
 
 **理由**: 一覧画面は全機能の俯瞰・順序変更・検索・帳票出力等の中心機能で、**詳細より頻繁に開かれる**。タブ化しないと毎回 HeaderMenu から辿り直しで UX 劣化する。VS Code も Welcome / Settings / Source Control などシングルトンをタブで開く。
 
@@ -380,7 +399,7 @@ URL 規約: **`/category/feature[/:id]`** 形式（Java 風階層）。ルート
 - `frontend/src/grapes/blocks.ts` — 60+ pre-built block definitions
 - `frontend/src/store/` — Persistence layer (flowStore, customBlockStore)
 - `frontend/src/mcp/mcpBridge.ts` — Browser-side WebSocket client
-- `backend/src/tools.ts` — 20 MCP tool definitions
+- `backend/src/tools.ts` — 89 MCP tool definitions (実カウント: `grep -cE 'name:\s*"designer__' backend/src/tools.ts`、2026-05-17 時点)
 - `backend/src/wsBridge.ts` — WebSocket server + broadcast
 
 ### Data Flow

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -14,7 +14,7 @@ npm run build      # Compile to dist/
 
 ## Key Files
 
-- `src/tools.ts` — 20 MCP tool definitions
+- `src/tools.ts` — 89 MCP tool definitions (実カウント: `grep -cE 'name:\s*"designer__' src/tools.ts`、2026-05-17 時点)
 - `src/wsBridge.ts` — WebSocket server + broadcast
 
 ## MCP / WebSocket

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -20,9 +20,11 @@ npm run lint       # ESLint
 
 ## Data Flow
 
-- **Save:** GrapesJS autosave → remoteStorage → mcpBridge (WS) → wsBridge → `data/screens/{id}.json`
+- **Save:** GrapesJS autosave → remoteStorage → mcpBridge (WS) → wsBridge → active workspace の `<workspace>/<dataDir>/screens/{id}.json` (例: `workspaces/my-app/harmony/screens/{id}.json`、path は `harmony.json` の `dataDir` 設定に依存、#856 で `data/` 直書きから移行済)
 - **Fallback:** If WS disconnected → localStorage (`gjs-screen-{id}`)
 - **Sync:** wsBridge broadcasts changes to all connected browser tabs
+
+workspace / dataDir 構造の詳細は [`../docs/spec/workspace.md`](../docs/spec/workspace.md) を参照。
 
 ## Environment Notes
 
@@ -51,7 +53,7 @@ multi browser context の e2e で **Vite dev server (port 5173) が間欠 crash*
 ## Themes & Custom Blocks
 
 - Themes: standard (default Bootstrap), card, compact, dark — CSS injected into GrapesJS canvas iframe
-- Custom blocks persist to `data/custom-blocks.json` via customBlockStore
+- Custom blocks persist to active workspace の `<workspace>/<dataDir>/custom-blocks.json` via customBlockStore (例: `workspaces/my-app/harmony/custom-blocks.json`)
 
 ## Routing / Tab Policy
 


### PR DESCRIPTION
## 関連

Closes #1143

- 仕様: ガイダンス文書 drift 修正 (spec ファイルなし、AGENTS.md 自身が source of truth)
- 関連 memory: `feedback_pre_merge_propagation_check.md`

## 概要

レビューで検出された AGENTS.md 系ガイダンス文書 3 ファイルの drift (同根 2 finding + 独立レビュー追加発見 2 件) を統合修正。実態とのズレを解消する md 編集のみ、本体・schema・コード変更なし。

## 主な変更

- **(A) MCP tool 数 drift 修正**: `backend/src/tools.ts` の実カウント (`grep -cE 'name:\s*"designer__'` で 89 件、4倍以上の drift) を反映。root AGENTS.md と backend/AGENTS.md の同記述を両方更新。
- **(B) root AGENTS.md routing 表に 15 route 追加**: `AppShell.tsx:308-341` から漏れていた route (conventions/catalog, screen/items, sequence x2, view x2, view-definition x2, generic-definition x3, project/tech-stack, workspace x2, ai-settings) を追加。workspace-scoped vs top-level の区別と tab policy (singleton / per-resource / route only) も同時補記。Tab policy 表 (singleton / マルチインスタンス / route only) も対応する route を全て列挙する形に更新。
- **(C) frontend/AGENTS.md Data Flow path drift 修正**: workspace + dataDir 仕様 (#856) を反映し、`data/screens/{id}.json` → `<workspace>/<dataDir>/screens/{id}.json` 表記に統一。custom-blocks も同様。
- **(D) docs/spec/ 配下の routing 表との同期**: grep の結果、対象なし (workspace-multi.md / workspace.md / page-layout.md は各個別仕様向け subset table のみで全体 routing 一覧ではない)。波及対象なしと判定。
- **(E) docs-site rebuild**: `cd docs-site && npm run build` 実行成功 (71 pages built in 4.45s)。**AGENTS.md は docs-site の collection 対象外** (`docs-site/src/content.config.ts` は `docs/spec/` `docs/user-guide/` `docs/conventions/` `docs/setup/` の 4 ディレクトリのみ glob 対象)、よって `docs/html/` 差分は発生しない (commit に含めるべきファイルなし)。

## 仕様逐条突合 (自己申告)

### (A) MCP tool 数 (実数 89 件)

- `AGENTS.md:402` ✓ `- \`backend/src/tools.ts\` — 89 MCP tool definitions (実カウント: ...)`
- `backend/AGENTS.md:17` ✓ `- \`src/tools.ts\` — 89 MCP tool definitions (実カウント: ...)`

### (B) routing 表 15 route 追加 + 既存 1 route 補完

すべて `AGENTS.md` 内 (root):

- `AGENTS.md:344` ✓ 前置文 (workspace-scoped vs top-level の区別を明示)
- `AGENTS.md:352` ✓ `/screen/items/:screenId` → ScreenItemsView
- `AGENTS.md:358` ✓ `/sequence/list` → SequenceListView
- `AGENTS.md:359` ✓ `/sequence/edit/:sequenceId` → SequenceEditor
- `AGENTS.md:360` ✓ `/view/list` → ViewListView
- `AGENTS.md:361` ✓ `/view/edit/:viewId` → ViewEditor
- `AGENTS.md:362` ✓ `/view-definition/list` → ViewDefinitionListView
- `AGENTS.md:363` ✓ `/view-definition/edit/:viewDefinitionId` → ViewDefinitionEditor
- `AGENTS.md:368` ✓ `/generic-definition` → GenericDefinitionCatalogView
- `AGENTS.md:369` ✓ `/generic-definition/:kind` → GenericDefinitionListView
- `AGENTS.md:370` ✓ `/generic-definition/:kind/:name` → GenericDefinitionEditor
- `AGENTS.md:372` ✓ `/conventions/catalog` → ConventionsCatalogView
- `AGENTS.md:373` ✓ `/project/tech-stack` → TechStackView
- `AGENTS.md:374` ✓ `/workspace/list` (top-level) → WorkspaceListView
- `AGENTS.md:375` ✓ `/workspace/select` (top-level) → WorkspaceSelectView (route only)
- `AGENTS.md:376` ✓ `/ai-settings` (top-level) → CodexSettingsView
- `AGENTS.md:378` ✓ 実装出典明示 (`AppShell.tsx:300-354`)

Tab policy 補記:

- `AGENTS.md:388-390` ✓ シングルトンタブ / マルチインスタンスタブ / route only の対象リスト更新 (追加 route を全て include)

### (C) frontend/AGENTS.md Data Flow path

- `frontend/AGENTS.md:23` ✓ Save 経路の永続先を `<workspace>/<dataDir>/screens/{id}.json` 表記に修正 (#856 反映)
- `frontend/AGENTS.md:27` ✓ workspace / dataDir 詳細リンク (`../docs/spec/workspace.md`) 追加
- `frontend/AGENTS.md:56` ✓ custom-blocks の永続先表記も同期

### (D) docs/spec/ 配下の routing 表

- 対象なし (本 PR で変更ファイルなし)。grep 確認結果は「主な変更」(D) 参照。

### (E) docs-site build

- build success (出力 `71 page(s) built in 4.45s` / pagefind reindexed)
- `docs/html/` 差分: **0 ファイル** (AGENTS.md は docs-site collection 対象外、`docs-site/src/content.config.ts:11-28` で `spec` / `user-guide` / `conventions` / `setup` の 4 collection のみ glob 対象)
- 本 PR の最終変更ファイル: 3 (AGENTS.md / backend/AGENTS.md / frontend/AGENTS.md)、`docs/html/` の add/update なし

## レビューで特に見てほしい箇所

- routing 表の **「Path」列を実 URL ではなく `/w/:wsId/` 配下のサブパスとして記載する方針**を採用 (workspace-multi 仕様反映)。既存 entry も同じ表記方針だったため整合は取れているが、前置文 (`AGENTS.md:344`) で明示しなおした。これで OK か。
- `/workspace/select` を route only として記載 (`workspace.md:225` の「フルスクリーン welcome — タブ管理対象外」記述と整合)。tab policy 表の `route only` 行も `なし` → `/workspace/select` に更新。
- MCP tool 数を "89" と固定値で書いたが、tools.ts は今後も増減する想定。「実カウント方法 + 計測日 (2026-05-17 時点)」を併記したので drift しても次回検証可能。

## テスト

- Vitest: N/A (md 編集のみ)
- Playwright: N/A (md 編集のみ)
- MCP E2E: N/A

念のため frontend lint 実行 → 0 errors / 4 warnings (pre-existing、本 PR と無関係)。
docs-site build → success。

## UI 影響 / AI smoke test

- [x] UI 影響なし (auto テスト pass のみ — md 編集のため UI 変化なし)

### UI 影響ありの場合、AI smoke test で確認した項目

N/A

## spec 側の不足点 / 提案

- 本 PR 自体が AGENTS.md の drift を埋める作業。drift 防止には grep ベースの自動 check (CI または pre-merge skill) を検討する余地はあるが、本 PR スコープ外 (新規 ISSUE 化は CI 不採用方針 `feedback_no_github_actions_ci.md` と衝突するため見送り、必要なら別途検討)。

## レビュー担当への申し送り

- (B) routing 表追加で **`/workspace/select`** が新規 `route only` 行になった点、tab policy セクション両方を確認してほしい。
- `AGENTS.md:378` の `AppShell.tsx:300-354` line range が正しいか。`<Routes>` 開始 (L300) ～ 終了 (L354) を指す意図。
- (C) frontend/AGENTS.md の Data Flow 表記が backend/AGENTS.md:24 (`workspaces/<wsId>/harmony.json` + `<wsId>/<dataDir>/screens/*.json`) と意味的に整合しているか。
- (D) は対象なしと判定したが、もし大規模 routing 表が他 spec ファイルにあれば追加同期の必要あり。grep 範囲 `docs/spec/**/*.md` で `Path | Component | Purpose` パターン検索 → ヒットなしを確認済み。
