### PR TITLE
refactor(process-flow): StepCard.tsx phase-1 抽出 + foundation (#1145)

### DIFF
--- a/frontend/src/components/process-flow/StepCard.tsx
+++ b/frontend/src/components/process-flow/StepCard.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck -- StepCard still spans legacy/v3 process-flow unions; tracked by #1016.
-import { useState, useRef, useEffect } from "react";
+import { useState } from "react";
 import type { DraggableAttributes, DraggableSyntheticListeners } from "@dnd-kit/core";
 import type {
   Branch,
@@ -17,9 +17,7 @@ import {
   DB_OPERATION_LABELS,
   WORKFLOW_PATTERN_LABELS,
 } from "../../types/action";
-import { resolveJumpLabel } from "../../utils/actionUtils";
 import type { ValidationError } from "../../utils/actionValidation";
-import { getBranchConditionText } from "../../utils/branchCondition";
 import { getBindingName, getBindingOperation } from "../../utils/outputBinding";
 import { generateUUID } from "../../utils/uuid";
 import { createDefaultStep } from "../../store/processFlowStore";
@@ -34,167 +32,14 @@ import { WorkflowStepPanel } from "./WorkflowStepPanel";
 import { LogStepPanel } from "./LogStepPanel";
 import { AuditStepPanel } from "./AuditStepPanel";
 import { TransactionScopeStepPanel } from "./TransactionScopeStepPanel";
-
-const ALL_SUB_STEP_TYPES: StepType[] = [
-  "validation", "dbAccess", "externalSystem", "commonProcess",
-  "screenTransition", "displayUpdate", "branch", "loop",
-  "loopBreak", "loopContinue", "jump", "compute", "return", "other",
-  "log", "audit", "workflow", "transactionScope",
-  "eventPublish", "eventSubscribe", "closing", "cdc",
-];
-
-// ─── ヘルパーコンポーネント ──────────────────────────────────────────────────
-
-function AutoResizeTextarea({
-  value, onChange, onBlur, placeholder, className,
-}: {
-  value: string;
-  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
-  onBlur?: () => void;
-  placeholder?: string;
-  className?: string;
-}) {
-  const ref = useRef<HTMLTextAreaElement>(null);
-  useEffect(() => {
-    if (ref.current) {
-      ref.current.style.height = "auto";
-      ref.current.style.height = `${ref.current.scrollHeight}px`;
-    }
-  }, [value]);
-  return (
-    <textarea
-      ref={ref}
-      className={className ?? "form-control form-control-sm auto-resize"}
-      value={value}
-      rows={1}
-      onChange={onChange}
-      onBlur={onBlur}
-      placeholder={placeholder}
-    />
-  );
-}
-
-// ─── インラインステップリスト ─────────────────────────────────────────────────
-// branch.steps / loop.steps の再帰レンダリング用。
-// function 宣言（ホイスティング）で定義することで StepCard との相互参照を実現。
-
-interface InlineStepListProps {
-  steps: Step[];
-  parentLabel: string;
-  allSteps: Step[];
-  tables: { id: string; physicalName: string; name: string }[];
-  screens: { id: string; name: string }[];
-  commonGroups: { id: string; name: string }[];
-  onChange: (steps: Step[]) => void;
-  onCommit?: () => void;
-  onNavigateCommon: (refId: string) => void;
-  validationErrors?: ValidationError[];
-  conventions?: import("../../schemas/conventionsValidator").ConventionsCatalog | null;
-  group?: ProcessFlow | null;
-  readOnly?: boolean;
-}
-
-function InlineStepList({
-  steps,
-  parentLabel,
-  allSteps,
-  tables,
-  screens,
-  commonGroups,
-  onChange,
-  onCommit,
-  onNavigateCommon,
-  validationErrors,
-  conventions,
-  group,
-  readOnly = false,
-}: InlineStepListProps) {
-  const [showTypePicker, setShowTypePicker] = useState(false);
-
-  const addStep = (type: StepType) => {
-    const newStep = createDefaultStep(type);
-    onChange([...steps, newStep]);
-    onCommit?.();
-    setShowTypePicker(false);
-  };
-
-  return (
-    <div className="inline-step-list">
-      {steps.map((step, si) => (
-        <div key={step.id} className="mb-1">
-          <StepCard
-            step={step}
-            index={si}
-            label={`${parentLabel}-${si + 1}`}
-            allSteps={allSteps}
-            tables={tables}
-            screens={screens}
-            commonGroups={commonGroups}
-            onChange={(changes) => {
-              const arr = steps.slice();
-              arr[si] = { ...arr[si], ...changes } as Step;
-              onChange(arr);
-            }}
-            onCommit={onCommit}
-            onMoveUp={si > 0 ? () => {
-              const arr = steps.slice();
-              [arr[si - 1], arr[si]] = [arr[si], arr[si - 1]];
-              onChange(arr);
-              onCommit?.();
-            } : undefined}
-            onMoveDown={si < steps.length - 1 ? () => {
-              const arr = steps.slice();
-              [arr[si], arr[si + 1]] = [arr[si + 1], arr[si]];
-              onChange(arr);
-              onCommit?.();
-            } : undefined}
-            onDelete={() => {
-              onChange(steps.filter((s) => s.id !== step.id));
-              onCommit?.();
-            }}
-            onDuplicate={() => {
-              const clone = JSON.parse(JSON.stringify(step)) as Step;
-              clone.id = generateUUID();
-              const arr = steps.slice();
-              arr.splice(si + 1, 0, clone);
-              onChange(arr);
-              onCommit?.();
-            }}
-            onAddSubStep={(type) => {
-              const newSub = createDefaultStep(type);
-              const arr = steps.slice();
-              arr[si] = { ...arr[si], subSteps: [...(arr[si].subSteps ?? []), newSub] } as Step;
-              onChange(arr);
-              onCommit?.();
-            }}
-            onContextMenu={(e) => e.preventDefault()}
-            onNavigateCommon={onNavigateCommon}
-            depth={1}
-            validationErrors={validationErrors}
-            conventions={conventions}
-            group={group}
-            readOnly={readOnly}
-          />
-        </div>
-      ))}
-      {!readOnly && <div className="inline-step-add">
-        <button className="inline-add-btn" onClick={() => setShowTypePicker(!showTypePicker)}>
-          <i className="bi bi-plus" /> ステップを追加
-        </button>
-        {showTypePicker && (
-          <div className="inline-type-picker">
-            {ALL_SUB_STEP_TYPES.map((t) => (
-              <button key={t} className="inline-type-btn" onClick={() => addStep(t)}>
-                <i className={`bi ${STEP_TYPE_ICONS[t]}`} style={{ color: STEP_TYPE_COLORS[t] }} />
-                {STEP_TYPE_LABELS[t]}
-              </button>
-            ))}
-          </div>
-        )}
-      </div>}
-    </div>
-  );
-}
+import { AutoResizeTextarea } from "./internal/AutoResizeTextarea";
+import { InlineStepList } from "./internal/InlineStepList";
+import {
+  ALL_SUB_STEP_TYPES,
+  DB_OPS,
+  trimToUndefined,
+} from "./internal/stepCardConstants";
+import { stepSummaryText } from "./internal/stepSummaryText";
 
 // ─── StepCard ────────────────────────────────────────────────────────────────
 
@@ -242,12 +87,6 @@ interface StepCardProps {
   onAskAi?: () => void;
   readOnly?: boolean;
 }
-
-const DB_OPS: DbOperation[] = ["SELECT", "INSERT", "UPDATE", "DELETE"];
-const trimToUndefined = (value: string) => {
-  const trimmed = value.trim();
-  return trimmed ? trimmed : undefined;
-};
 
 export function StepCard({
   step,
@@ -297,46 +136,6 @@ export function StepCard({
   const myErrors = validationErrors.filter((e) => e.stepId === step.id);
   const hasError = myErrors.some((e) => e.severity === "error");
   const hasWarning = myErrors.some((e) => e.severity === "warning");
-
-  const summaryText = (): string => {
-    switch (step.kind) {
-      case "validation":
-        return step.conditions || step.description || "バリデーション";
-      case "dbAccess":
-        return `${step.tableId || "?"} ${DB_OPERATION_LABELS[step.operation] ?? step.operation}${step.description ? ` - ${step.description}` : ""}`;
-      case "externalSystem":
-        return `${step.systemRef || "?"}${step.protocol ? ` (${step.protocol})` : ""}${step.description ? ` - ${step.description}` : ""}`;
-      case "commonProcess":
-        return step.refId || step.description || "共通処理";
-      case "screenTransition":
-        return `${step.targetScreenId || "?"}${step.description ? ` - ${step.description}` : ""}`;
-      case "displayUpdate":
-        return step.target || step.description || "表示更新";
-      case "branch":
-        return step.description || getBranchConditionText(step.branches[0]?.condition) || "条件分岐";
-      case "loop":
-        if (step.loopKind === "count") return step.countExpression || step.description || "ループ";
-        if (step.loopKind === "condition") return step.conditionExpression || step.description || "ループ";
-        return `${step.collectionSource || "コレクション"}${step.collectionItemName ? ` [${step.collectionItemName}]` : ""}`;
-      case "loopBreak":
-        return step.description || "ループ終了";
-      case "loopContinue":
-        return step.description || "次のループへ";
-      case "jump": {
-        const jumpLabel = resolveJumpLabel(step.jumpTo, allSteps);
-        return `[${jumpLabel}] へ${step.description ? ` - ${step.description}` : ""}`;
-      }
-      case "workflow":
-        return `${WORKFLOW_PATTERN_LABELS[step.pattern]} / 承認者 ${step.approvers.length}件${step.description ? ` - ${step.description}` : ""}`;
-      case "transactionScope": {
-        const n = step.steps.length;
-        const iso = step.isolationLevel ?? "READ_COMMITTED";
-        return `TX (${iso}, ${n} ステップ)${step.description ? ` - ${step.description}` : ""}`;
-      }
-      default:
-        return step.description || "その他";
-    }
-  };
 
   // ── サブステップ管理 ────────────────────────────────────────────────────────
 
@@ -616,7 +415,7 @@ export function StepCard({
               {WORKFLOW_PATTERN_LABELS[step.pattern]} / {step.approvers.length}件
             </span>
           )}
-          <span className="step-card-description">{summaryText()}</span>
+          <span className="step-card-description">{stepSummaryText(step, allSteps)}</span>
           {step.kind === "commonProcess" && step.refId && (
             <button
               className="btn btn-link btn-sm p-0 text-success"

--- a/frontend/src/components/process-flow/internal/AutoResizeTextarea.test.tsx
+++ b/frontend/src/components/process-flow/internal/AutoResizeTextarea.test.tsx
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render } from "@testing-library/react";
+import { AutoResizeTextarea } from "./AutoResizeTextarea";
+
+/**
+ * AutoResizeTextarea: StepCard から抽出 (#1145)。
+ * 入力値変更と onBlur ハンドリングが伝播することを確認。
+ */
+describe("AutoResizeTextarea", () => {
+  it("初期値を表示する", () => {
+    const { container } = render(
+      <AutoResizeTextarea value="初期値" onChange={() => {}} />,
+    );
+    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+    expect(textarea.value).toBe("初期値");
+  });
+
+  it("入力変更時に onChange を発火", () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <AutoResizeTextarea value="" onChange={onChange} />,
+    );
+    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "hi" } });
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("blur 時に onBlur を発火", () => {
+    const onBlur = vi.fn();
+    const { container } = render(
+      <AutoResizeTextarea value="x" onChange={() => {}} onBlur={onBlur} />,
+    );
+    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+    fireEvent.blur(textarea);
+    expect(onBlur).toHaveBeenCalledTimes(1);
+  });
+
+  it("placeholder と class を反映", () => {
+    const { container } = render(
+      <AutoResizeTextarea
+        value=""
+        onChange={() => {}}
+        placeholder="ph"
+        className="custom-class"
+      />,
+    );
+    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+    expect(textarea.placeholder).toBe("ph");
+    expect(textarea.className).toBe("custom-class");
+  });
+
+  it("className 未指定時は既定 class を使用", () => {
+    const { container } = render(
+      <AutoResizeTextarea value="" onChange={() => {}} />,
+    );
+    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+    expect(textarea.className).toBe("form-control form-control-sm auto-resize");
+  });
+});

--- a/frontend/src/components/process-flow/internal/AutoResizeTextarea.tsx
+++ b/frontend/src/components/process-flow/internal/AutoResizeTextarea.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * 高さが入力内容に追従する textarea。
+ * StepCard 内で複数箇所から呼ばれていたヘルパーを分離。
+ *
+ * 元: components/process-flow/StepCard.tsx (#1145 で分離)
+ */
+export function AutoResizeTextarea({
+  value,
+  onChange,
+  onBlur,
+  placeholder,
+  className,
+}: {
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  onBlur?: () => void;
+  placeholder?: string;
+  className?: string;
+}) {
+  const ref = useRef<HTMLTextAreaElement>(null);
+  useEffect(() => {
+    if (ref.current) {
+      ref.current.style.height = "auto";
+      ref.current.style.height = `${ref.current.scrollHeight}px`;
+    }
+  }, [value]);
+  return (
+    <textarea
+      ref={ref}
+      className={className ?? "form-control form-control-sm auto-resize"}
+      value={value}
+      rows={1}
+      onChange={onChange}
+      onBlur={onBlur}
+      placeholder={placeholder}
+    />
+  );
+}

--- a/frontend/src/components/process-flow/internal/InlineStepList.test.tsx
+++ b/frontend/src/components/process-flow/internal/InlineStepList.test.tsx
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { InlineStepList } from "./InlineStepList";
+import type { Step } from "../../../types/action";
+
+/**
+ * InlineStepList: StepCard.tsx から抽出 (#1145)。
+ *
+ * branch/loop の steps 配列を再帰レンダリングし、追加ボタンと型ピッカーから
+ * 新規 step を生成できる。本テストは、step 0 件で picker トグルが正しく
+ * 動作することと、`readOnly` で追加 UI が消えることを確認する。
+ *
+ * StepCard 自体は別レベルでテスト対象 — 当 spec では list ラッパー責務に絞る。
+ */
+describe("InlineStepList", () => {
+  const baseProps = {
+    parentLabel: "L",
+    allSteps: [] as Step[],
+    tables: [],
+    screens: [],
+    commonGroups: [],
+    onNavigateCommon: () => {},
+  };
+
+  it("steps 空 + readOnly=false でステップ追加ボタンを表示", () => {
+    const { container } = render(
+      <InlineStepList
+        {...baseProps}
+        steps={[]}
+        onChange={() => {}}
+      />,
+    );
+    const addBtn = container.querySelector(".inline-add-btn");
+    expect(addBtn).not.toBeNull();
+    expect(addBtn?.textContent).toContain("ステップを追加");
+  });
+
+  it("readOnly=true で追加 UI を非表示", () => {
+    const { container } = render(
+      <InlineStepList
+        {...baseProps}
+        steps={[]}
+        onChange={() => {}}
+        readOnly
+      />,
+    );
+    expect(container.querySelector(".inline-add-btn")).toBeNull();
+    expect(container.querySelector(".inline-step-add")).toBeNull();
+  });
+
+  it("追加ボタンを押すと型ピッカーが開き、22 種の kind が選べる", () => {
+    const { container } = render(
+      <InlineStepList
+        {...baseProps}
+        steps={[]}
+        onChange={() => {}}
+      />,
+    );
+    const addBtn = container.querySelector(".inline-add-btn") as HTMLButtonElement;
+    fireEvent.click(addBtn);
+
+    const picker = container.querySelector(".inline-type-picker");
+    expect(picker).not.toBeNull();
+    const typeButtons = picker?.querySelectorAll(".inline-type-btn");
+    // ALL_SUB_STEP_TYPES は 22 種
+    expect(typeButtons?.length).toBe(22);
+  });
+
+  it("型ピッカーから kind を選択すると onChange + onCommit が呼ばれる", () => {
+    const onChange = vi.fn();
+    const onCommit = vi.fn();
+    const { container } = render(
+      <InlineStepList
+        {...baseProps}
+        steps={[]}
+        onChange={onChange}
+        onCommit={onCommit}
+      />,
+    );
+    fireEvent.click(container.querySelector(".inline-add-btn") as HTMLButtonElement);
+    const firstType = container.querySelector(".inline-type-btn") as HTMLButtonElement;
+    fireEvent.click(firstType);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const newSteps = onChange.mock.calls[0][0];
+    expect(Array.isArray(newSteps)).toBe(true);
+    expect(newSteps.length).toBe(1);
+    expect(onCommit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/process-flow/internal/InlineStepList.tsx
+++ b/frontend/src/components/process-flow/internal/InlineStepList.tsx
@@ -1,0 +1,139 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+import { useState } from "react";
+import type { ProcessFlow, Step, StepType } from "../../../types/action";
+import {
+  STEP_TYPE_COLORS,
+  STEP_TYPE_ICONS,
+  STEP_TYPE_LABELS,
+} from "../../../types/action";
+import { createDefaultStep } from "../../../store/processFlowStore";
+import type { ValidationError } from "../../../utils/actionValidation";
+import { generateUUID } from "../../../utils/uuid";
+import { StepCard } from "../StepCard";
+import { ALL_SUB_STEP_TYPES } from "./stepCardConstants";
+
+export interface InlineStepListProps {
+  steps: Step[];
+  parentLabel: string;
+  allSteps: Step[];
+  tables: { id: string; physicalName: string; name: string }[];
+  screens: { id: string; name: string }[];
+  commonGroups: { id: string; name: string }[];
+  onChange: (steps: Step[]) => void;
+  onCommit?: () => void;
+  onNavigateCommon: (refId: string) => void;
+  validationErrors?: ValidationError[];
+  conventions?: import("../../../schemas/conventionsValidator").ConventionsCatalog | null;
+  group?: ProcessFlow | null;
+  readOnly?: boolean;
+}
+
+/**
+ * branch.steps / loop.steps の再帰レンダリング用インラインリスト。
+ * StepCard との相互参照あり (StepCard の循環 import を避けるため別ファイル化、#1145)。
+ *
+ * 元: components/process-flow/StepCard.tsx の InlineStepList (#1145 で分離)
+ */
+export function InlineStepList({
+  steps,
+  parentLabel,
+  allSteps,
+  tables,
+  screens,
+  commonGroups,
+  onChange,
+  onCommit,
+  onNavigateCommon,
+  validationErrors,
+  conventions,
+  group,
+  readOnly = false,
+}: InlineStepListProps) {
+  const [showTypePicker, setShowTypePicker] = useState(false);
+
+  const addStep = (type: StepType) => {
+    const newStep = createDefaultStep(type);
+    onChange([...steps, newStep]);
+    onCommit?.();
+    setShowTypePicker(false);
+  };
+
+  return (
+    <div className="inline-step-list">
+      {steps.map((step, si) => (
+        <div key={step.id} className="mb-1">
+          <StepCard
+            step={step}
+            index={si}
+            label={`${parentLabel}-${si + 1}`}
+            allSteps={allSteps}
+            tables={tables}
+            screens={screens}
+            commonGroups={commonGroups}
+            onChange={(changes) => {
+              const arr = steps.slice();
+              arr[si] = { ...arr[si], ...changes } as Step;
+              onChange(arr);
+            }}
+            onCommit={onCommit}
+            onMoveUp={si > 0 ? () => {
+              const arr = steps.slice();
+              [arr[si - 1], arr[si]] = [arr[si], arr[si - 1]];
+              onChange(arr);
+              onCommit?.();
+            } : undefined}
+            onMoveDown={si < steps.length - 1 ? () => {
+              const arr = steps.slice();
+              [arr[si], arr[si + 1]] = [arr[si + 1], arr[si]];
+              onChange(arr);
+              onCommit?.();
+            } : undefined}
+            onDelete={() => {
+              onChange(steps.filter((s) => s.id !== step.id));
+              onCommit?.();
+            }}
+            onDuplicate={() => {
+              const clone = JSON.parse(JSON.stringify(step)) as Step;
+              clone.id = generateUUID();
+              const arr = steps.slice();
+              arr.splice(si + 1, 0, clone);
+              onChange(arr);
+              onCommit?.();
+            }}
+            onAddSubStep={(type) => {
+              const newSub = createDefaultStep(type);
+              const arr = steps.slice();
+              arr[si] = { ...arr[si], subSteps: [...(arr[si].subSteps ?? []), newSub] } as Step;
+              onChange(arr);
+              onCommit?.();
+            }}
+            onContextMenu={(e) => e.preventDefault()}
+            onNavigateCommon={onNavigateCommon}
+            depth={1}
+            validationErrors={validationErrors}
+            conventions={conventions}
+            group={group}
+            readOnly={readOnly}
+          />
+        </div>
+      ))}
+      {!readOnly && (
+        <div className="inline-step-add">
+          <button className="inline-add-btn" onClick={() => setShowTypePicker(!showTypePicker)}>
+            <i className="bi bi-plus" /> ステップを追加
+          </button>
+          {showTypePicker && (
+            <div className="inline-type-picker">
+              {ALL_SUB_STEP_TYPES.map((t) => (
+                <button key={t} className="inline-type-btn" onClick={() => addStep(t)}>
+                  <i className={`bi ${STEP_TYPE_ICONS[t]}`} style={{ color: STEP_TYPE_COLORS[t] }} />
+                  {STEP_TYPE_LABELS[t]}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/process-flow/internal/InlineStepList.tsx
+++ b/frontend/src/components/process-flow/internal/InlineStepList.tsx
@@ -33,6 +33,11 @@ export interface InlineStepListProps {
  * StepCard との相互参照あり (StepCard の循環 import を避けるため別ファイル化、#1145)。
  *
  * 元: components/process-flow/StepCard.tsx の InlineStepList (#1145 で分離)
+ *
+ * ⚠️ 循環 import 注意 (#1158 review S-2): `StepCard` ⇔ `InlineStepList` の ESM 循環。
+ * 両方とも `export function` (hoisted) のため module 評価順に依存せず TDZ 安全。
+ * **将来 `let`/`const` declaration や lazy initialization へ変更する場合は TDZ で
+ * 実行時 ReferenceError になる**ため、両ファイルとも function declaration を維持すること。
  */
 export function InlineStepList({
   steps,

--- a/frontend/src/components/process-flow/internal/stepCardConstants.test.ts
+++ b/frontend/src/components/process-flow/internal/stepCardConstants.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  ALL_SUB_STEP_TYPES,
+  DB_OPS,
+  trimToUndefined,
+} from "./stepCardConstants";
+
+/**
+ * StepCard.tsx から抽出した定数とヘルパー (#1145) の回帰防止テスト。
+ */
+describe("stepCardConstants", () => {
+  describe("ALL_SUB_STEP_TYPES", () => {
+    it("22 種類の step kind を持つ (現行 spec)", () => {
+      expect(ALL_SUB_STEP_TYPES).toHaveLength(22);
+    });
+
+    it("代表的な kind を含む", () => {
+      expect(ALL_SUB_STEP_TYPES).toContain("validation");
+      expect(ALL_SUB_STEP_TYPES).toContain("dbAccess");
+      expect(ALL_SUB_STEP_TYPES).toContain("externalSystem");
+      expect(ALL_SUB_STEP_TYPES).toContain("transactionScope");
+      expect(ALL_SUB_STEP_TYPES).toContain("workflow");
+      expect(ALL_SUB_STEP_TYPES).toContain("eventPublish");
+      expect(ALL_SUB_STEP_TYPES).toContain("eventSubscribe");
+      expect(ALL_SUB_STEP_TYPES).toContain("cdc");
+    });
+
+    it("重複が無い", () => {
+      expect(new Set(ALL_SUB_STEP_TYPES).size).toBe(ALL_SUB_STEP_TYPES.length);
+    });
+  });
+
+  describe("DB_OPS", () => {
+    it("4 種類の DB 操作を含む", () => {
+      expect(DB_OPS).toEqual(["SELECT", "INSERT", "UPDATE", "DELETE"]);
+    });
+  });
+
+  describe("trimToUndefined", () => {
+    it("空白のみは undefined", () => {
+      expect(trimToUndefined("")).toBeUndefined();
+      expect(trimToUndefined("   ")).toBeUndefined();
+      expect(trimToUndefined("\t\n")).toBeUndefined();
+    });
+
+    it("有効文字列は trim 結果を返す", () => {
+      expect(trimToUndefined("hello")).toBe("hello");
+      expect(trimToUndefined("  hello  ")).toBe("hello");
+    });
+  });
+});

--- a/frontend/src/components/process-flow/internal/stepCardConstants.ts
+++ b/frontend/src/components/process-flow/internal/stepCardConstants.ts
@@ -1,0 +1,39 @@
+import type { DbOperation, StepType } from "../../../types/action";
+
+/**
+ * StepCard のサブステップ追加メニューに表示する全 step kind。
+ * 元: components/process-flow/StepCard.tsx (#1145 で分離)
+ */
+export const ALL_SUB_STEP_TYPES: StepType[] = [
+  "validation",
+  "dbAccess",
+  "externalSystem",
+  "commonProcess",
+  "screenTransition",
+  "displayUpdate",
+  "branch",
+  "loop",
+  "loopBreak",
+  "loopContinue",
+  "jump",
+  "compute",
+  "return",
+  "other",
+  "log",
+  "audit",
+  "workflow",
+  "transactionScope",
+  "eventPublish",
+  "eventSubscribe",
+  "closing",
+  "cdc",
+];
+
+/** DB 操作の選択肢。元: StepCard.tsx (#1145) */
+export const DB_OPS: DbOperation[] = ["SELECT", "INSERT", "UPDATE", "DELETE"];
+
+/** 空白だけの入力を undefined に丸める。元: StepCard.tsx (#1145) */
+export const trimToUndefined = (value: string): string | undefined => {
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+};

--- a/frontend/src/components/process-flow/internal/stepSummaryText.test.ts
+++ b/frontend/src/components/process-flow/internal/stepSummaryText.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import { stepSummaryText } from "./stepSummaryText";
+import type { Step } from "../../../types/action";
+
+/**
+ * stepSummaryText() の出力確認テスト。
+ * 元 StepCard.tsx 内 closure を抽出 (#1145) したため、各 step kind の summary
+ * 文字列フォーマットを回帰防止する。
+ */
+describe("stepSummaryText", () => {
+  it("validation: conditions を優先", () => {
+    const step = {
+      id: "s1",
+      kind: "validation",
+      conditions: "X is required",
+      description: "fallback",
+    } as unknown as Step;
+    expect(stepSummaryText(step, [])).toBe("X is required");
+  });
+
+  it("validation: conditions 空時は description fallback", () => {
+    const step = {
+      id: "s1",
+      kind: "validation",
+      conditions: "",
+      description: "fallback",
+    } as unknown as Step;
+    expect(stepSummaryText(step, [])).toBe("fallback");
+  });
+
+  it("validation: 両方空時は規定文言", () => {
+    const step = {
+      id: "s1",
+      kind: "validation",
+      conditions: "",
+      description: "",
+    } as unknown as Step;
+    expect(stepSummaryText(step, [])).toBe("バリデーション");
+  });
+
+  it("dbAccess: tableId + 操作名 + description を結合", () => {
+    const step = {
+      id: "s1",
+      kind: "dbAccess",
+      tableId: "orders",
+      operation: "SELECT",
+      description: "明細取得",
+    } as unknown as Step;
+    expect(stepSummaryText(step, [])).toBe("orders SELECT - 明細取得");
+  });
+
+  it("dbAccess: tableId 未設定時は ? 表示", () => {
+    const step = {
+      id: "s1",
+      kind: "dbAccess",
+      operation: "INSERT",
+    } as unknown as Step;
+    const summary = stepSummaryText(step, []);
+    expect(summary.startsWith("? ")).toBe(true);
+    expect(summary).toContain("INSERT");
+  });
+
+  it("commonProcess: refId 優先", () => {
+    const step = {
+      id: "s1",
+      kind: "commonProcess",
+      refId: "calcTax",
+      description: "ignored",
+    } as unknown as Step;
+    expect(stepSummaryText(step, [])).toBe("calcTax");
+  });
+
+  it("loop: loopKind=count では countExpression を返す", () => {
+    const step = {
+      id: "s1",
+      kind: "loop",
+      loopKind: "count",
+      countExpression: "10",
+    } as unknown as Step;
+    expect(stepSummaryText(step, [])).toBe("10");
+  });
+
+  it("loop: loopKind=collection では collectionSource + item を返す", () => {
+    const step = {
+      id: "s1",
+      kind: "loop",
+      loopKind: "collection",
+      collectionSource: "@items",
+      collectionItemName: "item",
+    } as unknown as Step;
+    expect(stepSummaryText(step, [])).toBe("@items [item]");
+  });
+
+  it("loopBreak: 規定文言", () => {
+    const step = { id: "s1", kind: "loopBreak" } as unknown as Step;
+    expect(stepSummaryText(step, [])).toBe("ループ終了");
+  });
+
+  it("transactionScope: isolationLevel + ステップ数", () => {
+    const step = {
+      id: "s1",
+      kind: "transactionScope",
+      isolationLevel: "SERIALIZABLE",
+      steps: [{ id: "a" }, { id: "b" }, { id: "c" }],
+    } as unknown as Step;
+    expect(stepSummaryText(step, [])).toBe("TX (SERIALIZABLE, 3 ステップ)");
+  });
+
+  it("transactionScope: isolationLevel 未指定で READ_COMMITTED にフォールバック", () => {
+    const step = {
+      id: "s1",
+      kind: "transactionScope",
+      steps: [],
+    } as unknown as Step;
+    expect(stepSummaryText(step, [])).toBe("TX (READ_COMMITTED, 0 ステップ)");
+  });
+
+  it("不明な kind は description / その他 にフォールバック", () => {
+    const step = {
+      id: "s1",
+      kind: "unknown-kind",
+      description: "詳細",
+    } as unknown as Step;
+    expect(stepSummaryText(step, [])).toBe("詳細");
+
+    const noDesc = { id: "s2", kind: "unknown-kind" } as unknown as Step;
+    expect(stepSummaryText(noDesc, [])).toBe("その他");
+  });
+});

--- a/frontend/src/components/process-flow/internal/stepSummaryText.ts
+++ b/frontend/src/components/process-flow/internal/stepSummaryText.ts
@@ -1,0 +1,49 @@
+// @ts-nocheck -- StepCard と同じ理由で legacy/v3 union を緩く扱う (#1016)
+import type { Step } from "../../../types/action";
+import { DB_OPERATION_LABELS, WORKFLOW_PATTERN_LABELS } from "../../../types/action";
+import { resolveJumpLabel } from "../../../utils/actionUtils";
+import { getBranchConditionText } from "../../../utils/branchCondition";
+
+/**
+ * StepCard の summary 表示文字列を生成。
+ * 元: components/process-flow/StepCard.tsx の summaryText() (#1145 で分離)
+ */
+export function stepSummaryText(step: Step, allSteps: Step[]): string {
+  switch (step.kind) {
+    case "validation":
+      return step.conditions || step.description || "バリデーション";
+    case "dbAccess":
+      return `${step.tableId || "?"} ${DB_OPERATION_LABELS[step.operation] ?? step.operation}${step.description ? ` - ${step.description}` : ""}`;
+    case "externalSystem":
+      return `${step.systemRef || "?"}${step.protocol ? ` (${step.protocol})` : ""}${step.description ? ` - ${step.description}` : ""}`;
+    case "commonProcess":
+      return step.refId || step.description || "共通処理";
+    case "screenTransition":
+      return `${step.targetScreenId || "?"}${step.description ? ` - ${step.description}` : ""}`;
+    case "displayUpdate":
+      return step.target || step.description || "表示更新";
+    case "branch":
+      return step.description || getBranchConditionText(step.branches[0]?.condition) || "条件分岐";
+    case "loop":
+      if (step.loopKind === "count") return step.countExpression || step.description || "ループ";
+      if (step.loopKind === "condition") return step.conditionExpression || step.description || "ループ";
+      return `${step.collectionSource || "コレクション"}${step.collectionItemName ? ` [${step.collectionItemName}]` : ""}`;
+    case "loopBreak":
+      return step.description || "ループ終了";
+    case "loopContinue":
+      return step.description || "次のループへ";
+    case "jump": {
+      const jumpLabel = resolveJumpLabel(step.jumpTo, allSteps);
+      return `[${jumpLabel}] へ${step.description ? ` - ${step.description}` : ""}`;
+    }
+    case "workflow":
+      return `${WORKFLOW_PATTERN_LABELS[step.pattern]} / 承認者 ${step.approvers.length}件${step.description ? ` - ${step.description}` : ""}`;
+    case "transactionScope": {
+      const n = step.steps.length;
+      const iso = step.isolationLevel ?? "READ_COMMITTED";
+      return `TX (${iso}, ${n} ステップ)${step.description ? ` - ${step.description}` : ""}`;
+    }
+    default:
+      return step.description || "その他";
+  }
+}


### PR DESCRIPTION
## 関連

- Refs #1145 (シリーズ統合メタ ISSUE。本 PR は phase-1 部分対応で完了扱いとせず、follow-up ISSUE で残作業継続)
- follow-up: #1152 (StepCard 22 種 step-kind body 抽出)
- follow-up: #1153 (ProcessFlowEditor 分割)
- follow-up: #1154 (ViewDefinitionEditor 分割)
- follow-up: #1155 (ConventionsCatalogView 分割 + test)
- follow-up: #1156 (ScreenItemsView 分割 + test)
- follow-up: #1157 (AppShell routing 抽出 S-14)
- 仕様: docs/spec/ — N/A (純粋なファイル分割、責務不変)

## 概要

#1145 シリーズの phase-1 として、`StepCard.tsx` 1890 行 (86KB) のうち責務が明確に独立した helper / 定数 / 純粋関数を `process-flow/internal/` 配下へ抽出。本体を 1689 行 (-201 行 / -10.6%) に削減。

#1145 全体 (5 巨大ファイル + routing 抽出 + test 0 件領域への test 追加) は subagent の context / 60 分タイムアウト的に 1 PR では不可能と判断。残作業は 5 つの follow-up ISSUE (#1152-#1156, #1157) で継続し、本 PR は phase-1 完了として merge する方針。

## 主な変更

- `process-flow/internal/AutoResizeTextarea.tsx` 新設 — textarea 高さ追従ヘルパー (StepCard.tsx L48-75 から移動)
- `process-flow/internal/InlineStepList.tsx` 新設 — branch/loop 用の再帰ステップ list (StepCard.tsx L81-197、StepCard と循環 import するため別ファイル必須)
- `process-flow/internal/stepCardConstants.ts` 新設 — `ALL_SUB_STEP_TYPES` (22 種) / `DB_OPS` / `trimToUndefined`
- `process-flow/internal/stepSummaryText.ts` 新設 — `step.kind` 別 summary 文字列生成 (元 `summaryText()` closure を関数化)
- `process-flow/StepCard.tsx` 変更 — 上記 4 ファイルを import し、抽出元のローカル定義を削除。`summaryText()` 呼び出しを `stepSummaryText(step, allSteps)` に置換
- test 追加 4 ファイル / 27 件

## 分割前後の定量比較

| File | Before (lines / KB) | After (lines / KB) |
|---|---|---|
| `StepCard.tsx` | 1890 / 86 | 1689 / 76 |
| `internal/AutoResizeTextarea.tsx` | — | 40 / 0.9 |
| `internal/InlineStepList.tsx` | — | 139 / 4.0 |
| `internal/stepCardConstants.ts` | — | 39 / 0.9 |
| `internal/stepSummaryText.ts` | — | 49 / 1.8 |
| **計** | 1890 / 86 | 1956 / 83.6 |

総行数は +66 (import / コメント分)、StepCard 単体は -201 行 (-10.6%)。

## 仕様逐条突合 (自己申告)

ISSUE #1145 「提案 A: 巨大 component 分割 (S-10)」の `StepCard.tsx 86KB → step kind 別 sub-component` のうち、まず明確に独立した helper / 定数 / 純粋関数を抽出。22 種 step kind 別 body component 化は follow-up #1152 として切り出し。

- `AutoResizeTextarea` 抽出 → frontend/src/components/process-flow/internal/AutoResizeTextarea.tsx:7-40 ✓
- `InlineStepList` 抽出 (循環 import 経由で StepCard を import) → frontend/src/components/process-flow/internal/InlineStepList.tsx:39-139 ✓
- `ALL_SUB_STEP_TYPES` (22 種) 抽出 → frontend/src/components/process-flow/internal/stepCardConstants.ts:7-30 ✓
- `DB_OPS` 抽出 → frontend/src/components/process-flow/internal/stepCardConstants.ts:33 ✓
- `trimToUndefined` 抽出 → frontend/src/components/process-flow/internal/stepCardConstants.ts:36-39 ✓
- `stepSummaryText` 抽出 → frontend/src/components/process-flow/internal/stepSummaryText.ts:10-49 ✓
- StepCard 本体は新規 helper を import → frontend/src/components/process-flow/StepCard.tsx:33-41 ✓
- `summaryText()` 呼び出し置換 → frontend/src/components/process-flow/StepCard.tsx:418 ✓

シリーズ #1145 の他 4 ファイル分割 + routing 抽出は follow-up ISSUE (#1152-#1157) で個別対応。

## レビューで特に見てほしい箇所

- **`InlineStepList` の循環 import**: `process-flow/internal/InlineStepList.tsx` は親 `StepCard` を import し、`StepCard.tsx` は子 `InlineStepList` を import する構造。元コードでも同じ問題があり function 宣言 (hoisting) で解決されていたが、ファイル分離後は ESM 循環 import になる。tsc / vitest / build 全て pass を確認したが、実機で `branch` / `loop` ステップを開いた時の挙動 (再帰描画) を smoke test したい
- **`stepSummaryText` のシグネチャ変更**: 元 `summaryText()` は closure で `step` / `allSteps` を捕捉していたが、抽出後は引数化。`step.kind === "transactionScope"` 等で `step.steps.length` を見ているため、`Step` union 型の絞り込みに `@ts-nocheck` を依存している (`StepCard.tsx` と同じ #1016 状況)
- **責務範囲の判断**: phase-1 では body JSX (各 kind の編集 form) は touch しなかった。これは local state (`expanded` / `collapsedBranchIds` / `loopBodyCollapsed`) を共有しており、安全な抽出には props 設計の検討が必要なため。follow-up #1152 で対応する判断は妥当か

## テスト

- Vitest: 2131 件 pass (前 2104 + 新規 27) — 全 149 ファイル green
  - 新規: `AutoResizeTextarea.test.tsx` 5 件 (rendering / onChange / onBlur / className)
  - 新規: `InlineStepList.test.tsx` 4 件 (readOnly hide / type picker open / 22 種 kind 列挙 / onChange+onCommit)
  - 新規: `stepCardConstants.test.ts` 5 件 (件数 / 代表 kind / 重複なし / DB_OPS / trimToUndefined)
  - 新規: `stepSummaryText.test.ts` 13 件 (各 step kind の summary 出力回帰)
- Playwright: 既存維持 (本 PR で touch なし、E2E smoke は follow-up シリーズ完了時に実施推奨)
- MCP E2E: N/A

## UI 影響 / AI smoke test

- [x] UI 影響なし (auto テスト pass のみ)
- [ ] UI 影響あり

純粋なファイル分割で responsibility は不変。`tsc + vitest + build` で機能等価性を確認。

ただし `InlineStepList` の循環 import がランタイム描画に影響しないかは念のため別 reviewer / main session 側で smoke する余地あり。

### UI 影響ありの場合、AI smoke test で確認した項目

N/A (UI 影響なし)

## spec 側の不足点 / 提案

N/A。本 PR は純粋なリファクタで spec / schema 変更なし。

## レビュー担当への申し送り

- **scope 段階分割の妥当性**: ISSUE #1145 が要求する 5 ファイル分割 + routing 抽出 + 0 件 test 領域への test 追加は、合計 9358 行 / 397KB の改修で 1 PR / 60 分タイムアウトに収まらないと判断。phase-1 (StepCard 部分のみ) + follow-up ISSUE 5 件起票で対応した
- **追加テスト方針**: ISSUE 提案 D で要求された「test 0 件領域への unit test 追加」は本 PR では conventions/ screen-items/ に到達できず、各 follow-up ISSUE に組み込んだ
- **schema 変更なし**: `git diff origin/main -- schemas/` で 0 lines 確認済 (#511 schema governance 遵守)
- 本 PR merge 後の follow-up は別 subagent に委譲予定 (ユーザー判断)
