### PR TITLE
chore: 軽微 cleanup 集約 (sqlOrderValidator any 局所化 / dead RPC 削除 / console.log gate / コメント drift 修正 / spec 補強) (#1147)

### DIFF
--- a/backend/src/reactExporter.ts
+++ b/backend/src/reactExporter.ts
@@ -60,20 +60,20 @@ const ATTR_RENAME: Record<string, string> = {
 
 /** インラインイベントハンドラ → JSX イベントプロップ */
 const EVENT_HANDLERS: Record<string, { prop: string; handler: string }> = {
-  onclick:       { prop: "onClick",        handler: "() => { /* TODO */ }" },
-  ondblclick:    { prop: "onDoubleClick",  handler: "() => { /* TODO */ }" },
-  onchange:      { prop: "onChange",       handler: "(e) => { /* TODO */ }" },
-  onsubmit:      { prop: "onSubmit",       handler: "(e) => { e.preventDefault(); /* TODO */ }" },
-  oninput:       { prop: "onInput",        handler: "(e) => { /* TODO */ }" },
-  onblur:        { prop: "onBlur",         handler: "(e) => { /* TODO */ }" },
-  onfocus:       { prop: "onFocus",        handler: "(e) => { /* TODO */ }" },
-  onkeydown:     { prop: "onKeyDown",      handler: "(e) => { /* TODO */ }" },
-  onkeyup:       { prop: "onKeyUp",        handler: "(e) => { /* TODO */ }" },
-  onkeypress:    { prop: "onKeyPress",     handler: "(e) => { /* TODO */ }" },
-  onmouseenter:  { prop: "onMouseEnter",   handler: "() => { /* TODO */ }" },
-  onmouseleave:  { prop: "onMouseLeave",   handler: "() => { /* TODO */ }" },
-  onmousedown:   { prop: "onMouseDown",    handler: "(e) => { /* TODO */ }" },
-  onmouseup:     { prop: "onMouseUp",      handler: "(e) => { /* TODO */ }" },
+  onclick:       { prop: "onClick",        handler: "() => { /* USER_HANDLER */ }" },
+  ondblclick:    { prop: "onDoubleClick",  handler: "() => { /* USER_HANDLER */ }" },
+  onchange:      { prop: "onChange",       handler: "(e) => { /* USER_HANDLER */ }" },
+  onsubmit:      { prop: "onSubmit",       handler: "(e) => { e.preventDefault(); /* USER_HANDLER */ }" },
+  oninput:       { prop: "onInput",        handler: "(e) => { /* USER_HANDLER */ }" },
+  onblur:        { prop: "onBlur",         handler: "(e) => { /* USER_HANDLER */ }" },
+  onfocus:       { prop: "onFocus",        handler: "(e) => { /* USER_HANDLER */ }" },
+  onkeydown:     { prop: "onKeyDown",      handler: "(e) => { /* USER_HANDLER */ }" },
+  onkeyup:       { prop: "onKeyUp",        handler: "(e) => { /* USER_HANDLER */ }" },
+  onkeypress:    { prop: "onKeyPress",     handler: "(e) => { /* USER_HANDLER */ }" },
+  onmouseenter:  { prop: "onMouseEnter",   handler: "() => { /* USER_HANDLER */ }" },
+  onmouseleave:  { prop: "onMouseLeave",   handler: "() => { /* USER_HANDLER */ }" },
+  onmousedown:   { prop: "onMouseDown",    handler: "(e) => { /* USER_HANDLER */ }" },
+  onmouseup:     { prop: "onMouseUp",      handler: "(e) => { /* USER_HANDLER */ }" },
 };
 
 // ─── Type guards ─────────────────────────────────────────────────────────────

--- a/backend/src/wsBridge.ts
+++ b/backend/src/wsBridge.ts
@@ -85,9 +85,7 @@ import {
   readConventions,
   readExternalCatalogs,
   writeConventions,
-  readScreenItems,
   writeScreenItems,
-  deleteScreenItems,
   readSequence,
   writeSequence,
   deleteSequence as deleteSequenceFile,
@@ -1176,13 +1174,9 @@ class WsBridge extends EventEmitter {
           respond(data);
           break;
         }
-        case "savePageLayoutDesign": {
-          const { pageLayoutId, data } = (params ?? {}) as { pageLayoutId: string; data: unknown };
-          await writePageLayoutDesign(pageLayoutId, data, root());
-          respond({ success: true });
-          this.broadcast({ wsId: wsId(), event: "pageLayoutChanged", data: { pageLayoutId }, excludeClientId: clientId });
-          break;
-        }
+        // RPC "savePageLayoutDesign" は frontend / MCP tools 双方から参照 0 件 (dead)。
+        // saveScreen 経路 (screenId が "page-layout:" prefix 時) で同等処理が走るため不要。
+        // ISSUE #1147 S-16 で dispatcher から削除。
         case "saveScreen": {
           const { screenId, data } = (params ?? {}) as { screenId: string; data: unknown };
           // RFC #1021 pl-6 (Codex A-2): PageLayout design は専用 storage へ
@@ -1383,26 +1377,12 @@ class WsBridge extends EventEmitter {
           this.broadcast({ wsId: wsId(), event: "conventionsChanged", data: {}, excludeClientId: clientId });
           break;
         }
-        case "loadScreenItems": {
-          const { screenId } = (params ?? {}) as { screenId: string };
-          const items = await readScreenItems(screenId, root());
-          respond(items);
-          break;
-        }
-        case "saveScreenItems": {
-          const { screenId, data } = (params ?? {}) as { screenId: string; data: unknown };
-          await writeScreenItems(screenId, data, root());
-          respond({ success: true });
-          this.broadcast({ wsId: wsId(), event: "screenItemsChanged", data: { screenId }, excludeClientId: clientId });
-          break;
-        }
-        case "deleteScreenItems": {
-          const { screenId } = (params ?? {}) as { screenId: string };
-          await deleteScreenItems(screenId, root());
-          respond({ success: true });
-          this.broadcast({ wsId: wsId(), event: "screenItemsChanged", data: { screenId, deleted: true }, excludeClientId: clientId });
-          break;
-        }
+        // RPC "loadScreenItems" / "saveScreenItems" / "deleteScreenItems" は
+        // frontend が screenItemsStore 経由で loadScreenEntity / saveScreenEntity
+        // (Screen entity に embed された items を直接読み書き) に切り替えたため、
+        // 全て参照 0 件 (dead) となった。saveScreenEntity 経路で screenItemsChanged
+        // broadcast も継続発火されるため UI 同期に影響なし。
+        // ISSUE #1147 N-6 で dispatcher から削除。
         case "loadSequence": {
           const { sequenceId } = (params ?? {}) as { sequenceId: string };
           const seqData = await readSequence(sequenceId, root());

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -44,6 +44,7 @@
 | [e2e-vite-stability.md](e2e-vite-stability.md) | Vite dev server multi-context e2e crash 調査 + 既知回避策 + 再現 scaffold spec | #992 |
 | **[generic-definition-layer.md](generic-definition-layer.md)** | **汎用設計定義レイヤー (RFC v0.2)** — 既存 entity 構造化拡張 + Generic Definition Catalog (8 kind: data-contract / domain-type / exception-type / application-rule / ui-behavior / runtime-policy / component-definition / ui-fragment) + AI 向け変換マニュアル方式。配置 `examples/<project>/<dataDir>/generic-definitions/<kind>/*.json` (実例: examples/retail/harmony/...) | #1060 |
 | **[conversion-guideline-for-ai.md](conversion-guideline-for-ai.md)** | **Markdown → Harmony JSON 変換ガイドライン (AI 向け、RFC v0.1)** — entity 構造 / archetype 10 種類別の落とし方 (§3.1〜§3.7 に JSON before/after pair 付き、§3.8/§3.9 は概要のみ) / Generic Definition catalog の共通メタモデル / audit warning 12 種 / 1 回限り変換 vs Importer 生成の判断 / TS scaffold テンプレ / 既知落とし穴 / decision flowchart。`/import-md` skill 起動点 | #1060 |
+| [react-exporter.md](react-exporter.md) | `designer__export_screen` MCP tool 用 HTML→JSX 機械変換器 (backend/reactExporter.ts) の存在意義 / `/generate-code` skill との関係 / 14 event placeholder | #1147 (N-8) |
 
 **一次成果物**: JSON スキーマ [`schemas/process-flow.schema.json`](../../schemas/process-flow.schema.json) ([README](../../schemas/README.md))。仕様書と突合する機械可読版。
 

--- a/docs/spec/react-exporter.md
+++ b/docs/spec/react-exporter.md
@@ -1,0 +1,57 @@
+# reactExporter — designer__export_screen 用 HTML→JSX 変換器 (ISSUE #1147 N-8)
+
+## 位置付け
+
+`backend/src/reactExporter.ts` は **MCP tool `designer__export_screen` の実装** で、Designer (GrapesJS) が出力した HTML スニペットを React TSX コンポーネントの **構文骨格** に変換する低レベルユーティリティ。
+
+実装場所が backend なのは、ブラウザ側 (`exportScreen` ws コマンド) から取得した HTML を AI エージェントに JSX として返すまでが MCP 同期 RPC の流れに含まれるため。frontend にも同等の機能を置く必要がなく、backend で完結する。
+
+## `/generate-code` skill との関係
+
+両者は対象スコープが直交しており、置き換えではなく **補完関係**。
+
+| 観点 | `designer__export_screen` (reactExporter.ts) | `/generate-code` skill |
+|------|--------------------------------------------|----------------------|
+| 入力 | Designer (GrapesJS) の HTML スニペット | Screen JSON / ProcessFlow JSON + `project.techStack` |
+| 出力 | React TSX 構文骨格 1 ファイル (HTML→JSX の機械変換) | techStack 全体に整合した frontend / backend コード一式 |
+| 用途 | デザイン確認 / クイック取り込み / プロトタイピング | 業務システム本体の AI 生成 (Next.js / Thymeleaf / NestJS / Spring Boot) |
+| 機械的か AI 的か | 機械変換 (htmlparser2 ベース、`/* USER_HANDLER */` placeholder のみ残す) | AI 推論ベース (skill 内ルール + golden-examples) |
+| イベントハンドラ | `() => { /* USER_HANDLER */ }` プレースホルダ (S-19 で TODO から rename 済) | スペック / 設計から実装ロジックを推論 |
+| 出力先 | MCP レスポンス (markdown コードブロック、保存はユーザーに委ねる) | プロジェクト配下のファイル一式 (path 規約に従う) |
+
+## 維持判断
+
+将来の整理候補:
+- (a) 維持 — designer から手軽に React 骨格を引き出せる軽量ツールとして残す (現状の判断)
+- (b) `/generate-code` への統合 — techStack=NestJS+Next.js のサブ機能化
+- (c) 削除 — ユーザーが直接 Designer の export 機能経由で取得できるなら不要
+
+現状は **(a) 維持** が妥当:
+1. `htmlToReact()` は決定的変換 (機械的) であり、`/generate-code` の AI 推論経路とは
+   コスト・速度・確実性が異なる
+2. MCP tool 単位で AI エージェントから直接呼べる利便性がある
+3. 14 イベント属性の機械的変換テーブル等、`/generate-code` 側に持ち込むメリットが
+   薄い (skill prompt サイズが膨らむだけ)
+
+`/generate-code` skill の能力が「techStack に応じた componentized output 全 file 生成」に
+収束しているため、競合は発生していない。両者の境界を明確に保つ。
+
+## API
+
+```ts
+export function htmlToReact(html: string, componentName: string): {
+  code: string;       // 生成された TSX (`export default function ${componentName}() { return (...); }` 形)
+  warnings: string[]; // 変換不能だった属性 / 構造の警告
+};
+export function toPascalCase(str: string): string; // 画面名 → コンポーネント名変換
+```
+
+呼び出し元: `backend/src/handlers/screen.ts` の `case "designer__export_screen"`。
+
+## 実装メモ
+
+- htmlparser2 で DOM を walk、`ATTR_RENAME` テーブルで HTML → JSX 属性名変換
+- 14 種のイベント属性 (`onclick`, `onchange`, ...) は `() => { /* USER_HANDLER */ }`
+  形式の placeholder を残す (ユーザーが後でロジックを埋める)
+- ISSUE #1147 S-19 で `/* TODO */` から `/* USER_HANDLER */` に rename し、汎用
+  TODO grep のノイズを減らした

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -18,6 +18,24 @@ npm run lint       # ESLint
 - `src/store/` — Persistence layer (flowStore, customBlockStore)
 - `src/mcp/mcpBridge.ts` — Browser-side WebSocket client
 
+### `<feature>/` vs `components/<feature>/` 二重配置の規約 (ISSUE #1147 N-5)
+
+特定 feature の SDK / 環境連携と、その UI ダイアログを別ディレクトリに分離するパターン:
+
+- **`src/<feature>/`** — 外部 SDK ラッパー / 環境連携 / hooks / 純粋ロジック (UI 非依存)。
+  - 例: `src/codex/` (Codex CLI client + hooks)、`src/puck/` (Puck buildConfig + primitives 等)
+- **`src/components/<feature>/`** — その feature 専用の UI ダイアログ / view / panel コンポーネント。
+  - 例: `src/components/codex/` (CodexIndicator / CodexSettingsView)、
+    `src/components/puck/` (RegisterComponentDialog)
+
+判定基準:
+- ロジック / hook / API client / 型 → `<feature>/`
+- React component / ダイアログ / インジケータ / 設定画面 → `components/<feature>/`
+
+両者は循環依存を避けるため、`components/<feature>/` から `<feature>/` への片方向 import のみ
+を許容する。`<feature>/` 配下に JSX を持ち込まない (testing-library の jest-dom 等の
+セットアップ衝突を避けるため)。
+
 ## Data Flow
 
 - **Save:** GrapesJS autosave → remoteStorage → mcpBridge (WS) → wsBridge → active workspace の `<workspace>/<dataDir>/screens/{id}.json` (例: `workspaces/my-app/harmony/screens/{id}.json`、path は `harmony.json` の `dataDir` 設定に依存、#856 で `data/` 直書きから移行済)

--- a/frontend/src/components/Designer.tsx
+++ b/frontend/src/components/Designer.tsx
@@ -418,7 +418,7 @@ export function Designer({
     if (isDirtyRef.current) {
       setServerChanged(true);
     } else {
-      console.log("[Designer] screenChanged broadcast, reloading...");
+      if (import.meta.env.DEV) console.log("[Designer] screenChanged broadcast, reloading...");
       editorApiRef.current?.reload().catch(console.error);
     }
   }, []);
@@ -721,7 +721,7 @@ export function Designer({
       if (isDirtyRef.current) {
         setServerChanged(true);
       } else {
-        console.log("[Designer] puckDataChanged broadcast, marking server changed...");
+        if (import.meta.env.DEV) console.log("[Designer] puckDataChanged broadcast, marking server changed...");
         setServerChanged(true);
       }
     });

--- a/frontend/src/components/RightPanel.tsx
+++ b/frontend/src/components/RightPanel.tsx
@@ -148,7 +148,9 @@ export function RightPanel({ screenId }: RightPanelProps) {
         });
       }
     } catch {
-      // MCP 未接続: GrapesJS インメモリと screen-items localStorage を直接更新
+      // MCP renameScreenItem 失敗時のフォールバック:
+      // GrapesJS インメモリ更新 + screen-items file (backend screenStore 経由) を直接更新。
+      // localStorage fallback は #923 シリーズで廃止済 (spec D-8)、現状は backend save に統一。
       sel.addAttributes({ name: newId, id: newId });
       setSelectedItemName(newId);
       try {
@@ -159,7 +161,7 @@ export function RightPanel({ screenId }: RightPanelProps) {
           await saveScreenItems(siFile);
         }
       } catch {
-        // localStorage 更新失敗は無視 (GrapesJS 更新だけで続行)
+        // screen-items 更新失敗は無視 (GrapesJS 更新だけで続行)
       }
     }
   }, [editor, screenId, selectedItemName]);

--- a/frontend/src/mcp/mcpBridge.ts
+++ b/frontend/src/mcp/mcpBridge.ts
@@ -507,7 +507,9 @@ class McpBridgeImpl {
     if (msg.type === "broadcast") {
       const event = msg.event as string;
       const broadcastData = msg.data;
-      console.log("[mcpBridge] broadcast:", event, broadcastData);
+      // S-18 (#1147): production console 煩雑化回避のため DEV のみ出力。
+      // migration 通知 / 接続 lifecycle は production 保持。
+      if (import.meta.env.DEV) console.log("[mcpBridge] broadcast:", event, broadcastData);
       if (event === "extensionsChanged") {
         this.extensionsCache = null;
         this.extensionsChangedHandlers.forEach((handler) => handler());

--- a/frontend/src/schemas/sqlOrderValidator.ts
+++ b/frontend/src/schemas/sqlOrderValidator.ts
@@ -86,6 +86,63 @@ export interface SqlOrderIssue {
   message: string;
 }
 
+// ─── node-sql-parser AST 部分型 (ISSUE #1147 S-15: any 局所化) ──────────────
+//
+// node-sql-parser v5 (postgresql dialect) の AST は @types 提供範囲が薄く、
+// dialect / version で shape が揺れるため `unknown` は実用上扱い辛い。
+// 本 validator が依存する fields だけを optional な構造体で表現し、
+// `as any` を validator 全体に振り撒くのを避ける。
+// (関係 issue: S-15 「sqlOrderValidator.ts any 局所化」)
+
+/** AST ノードの最小共通型。`type` のみ前提として後段は in 演算子 / typeof で narrow する。 */
+interface SqlAstNode {
+  type?: string;
+  [key: string]: unknown;
+}
+
+/** INSERT の columns 要素 (v5: `{ type:"default", value:string }`、旧来: 文字列)。 */
+interface SqlColumnRef {
+  type?: string;
+  value?: string;
+  [key: string]: unknown;
+}
+
+/** INSERT VALUES 行: `{ type:"expr_list", value: SqlExprNode[] }` を持つ。 */
+interface SqlValueRow {
+  type?: string;
+  value?: SqlExprNode[];
+  [key: string]: unknown;
+}
+
+/** VALUES 内の式ノード (プレースホルダ / null / リテラル等)。 */
+interface SqlExprNode {
+  type?: string;
+  name?: number | string;
+  prefix?: string;
+  value?: unknown;
+  expr?: { type?: string; value?: string; [key: string]: unknown };
+  column?: string | { expr?: { value?: string }; value?: string; [key: string]: unknown };
+  left?: SqlExprNode;
+  right?: SqlExprNode;
+  where?: SqlExprNode;
+  [key: string]: unknown;
+}
+
+/** INSERT / UPDATE / DELETE / SELECT 共通 root AST。 */
+interface SqlRootNode extends SqlAstNode {
+  table?: Array<{ table?: string; [key: string]: unknown }>;
+  from?: Array<{ table?: string; [key: string]: unknown }>;
+  columns?: SqlColumnRef[];
+  values?: { type?: string; values?: SqlValueRow[] } | SqlValueRow[];
+  where?: SqlExprNode;
+}
+
+/** INSERT の values コンテナの両形式を吸収する union。 */
+type SqlValuesContainer =
+  | { type?: string; values?: SqlValueRow[] }
+  | SqlValueRow[]
+  | undefined;
+
 // ─── パーサー初期化 ─────────────────────────────────────────────────────────
 
 const parser = new Parser();
@@ -100,8 +157,7 @@ function substituteAtVars(sql: string): string {
 // ─── AST ヘルパー ───────────────────────────────────────────────────────────
 
 /** INSERT AST から対象テーブル名を取得 (lowercase)。 */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function extractInsertTableName(ast: any): string | null {
+function extractInsertTableName(ast: SqlRootNode | null | undefined): string | null {
   if (!ast || typeof ast !== "object") return null;
   if (ast.type === "insert" && Array.isArray(ast.table)) {
     for (const t of ast.table) {
@@ -118,8 +174,7 @@ function extractInsertTableName(ast: any): string | null {
  *   - ast.from: Array<{ table: string, ... }>  (PostgreSQL DELETE FROM)
  *   - ast.table: Array<{ table: string, ... }>  (一部 dialect フォールバック)
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function extractDeleteTableName(ast: any): string | null {
+function extractDeleteTableName(ast: SqlRootNode | null | undefined): string | null {
   if (!ast || typeof ast !== "object") return null;
   if (ast.type === "delete") {
     // PostgreSQL: DELETE FROM table_name → ast.from
@@ -150,32 +205,26 @@ function extractDeleteTableName(ast: any): string | null {
  *
  * @atVarMap: プレースホルダ番号 (1, 2, ...) → 元の @varName のルート名のマップ
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function extractInsertColumnVarMap(ast: any, atVarMap: Map<number, string>): Map<string, string | null> {
+function extractInsertColumnVarMap(ast: SqlRootNode | null | undefined, atVarMap: Map<number, string>): Map<string, string | null> {
   const result = new Map<string, string | null>();
   if (!ast || ast.type !== "insert") return result;
 
   // columns: Array<{ type: "default", value: string }> または string[] のどちらもサポート
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const columns: string[] = Array.isArray(ast.columns) ? ast.columns.map((c: any) => {
+  const columns: string[] = Array.isArray(ast.columns) ? (ast.columns as Array<SqlColumnRef | string>).map((c) => {
     if (typeof c === "string") return c;
     if (c && typeof c.value === "string") return c.value;
     return String(c);
   }) : [];
 
-  // values: { type: "values", values: Array<{ type: "expr_list", value: any[] }> }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const valuesContainer: any = ast.values;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let valueRows: any[][] = [];
-  if (valuesContainer && Array.isArray(valuesContainer.values)) {
+  // values: { type: "values", values: Array<{ type: "expr_list", value: SqlExprNode[] }> }
+  const valuesContainer = ast.values as SqlValuesContainer;
+  let valueRows: SqlExprNode[][] = [];
+  if (valuesContainer && !Array.isArray(valuesContainer) && Array.isArray(valuesContainer.values)) {
     // v5 形式: { type: "values", values: [...] }
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    valueRows = valuesContainer.values.map((row: any) => Array.isArray(row?.value) ? row.value : []);
+    valueRows = valuesContainer.values.map((row) => Array.isArray(row?.value) ? row.value : []);
   } else if (Array.isArray(valuesContainer)) {
     // フォールバック: 旧来の配列形式
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    valueRows = valuesContainer.map((row: any) => Array.isArray(row?.value) ? row.value : []);
+    valueRows = valuesContainer.map((row) => Array.isArray(row?.value) ? row.value : []);
   }
 
   if (columns.length === 0 || valueRows.length === 0) return result;
@@ -184,8 +233,7 @@ function extractInsertColumnVarMap(ast: any, atVarMap: Map<number, string>): Map
   const firstRow = valueRows[0];
   for (let i = 0; i < columns.length; i++) {
     const colName = columns[i].toLowerCase();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const valNode: any = firstRow[i];
+    const valNode: SqlExprNode | undefined = firstRow[i];
     if (!valNode) {
       result.set(colName, null);
       continue;
@@ -298,11 +346,11 @@ interface TableMeta {
  * テーブルまたはカラムの物理名を取得。
  * v3 では physicalName、v1 フォールバックでは name を使用。
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function getPhysicalName(obj: any): string | undefined {
-  return (typeof obj?.physicalName === "string" && obj.physicalName)
+function getPhysicalName(obj: { physicalName?: unknown; name?: unknown } | null | undefined): string | undefined {
+  if (!obj) return undefined;
+  return (typeof obj.physicalName === "string" && obj.physicalName)
     ? obj.physicalName
-    : (typeof obj?.name === "string" ? obj.name : undefined);
+    : (typeof obj.name === "string" ? obj.name : undefined);
 }
 
 function buildTableMeta(tables: OrderTableDefinition[]): Map<string, TableMeta> {
@@ -362,8 +410,7 @@ function buildTableMeta(tables: OrderTableDefinition[]): Map<string, TableMeta> 
 
     // Column.unique: true も単体 UNIQUE として収集
     for (const col of t.columns) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      if ((col as any).unique === true) {
+      if ((col as OrderTableColumn & { unique?: boolean }).unique === true) {
         const pName = getPhysicalName(col);
         if (pName) uniqueColumns.add(pName.toLowerCase());
       }
@@ -409,8 +456,7 @@ function isUniqueViolationErrorCode(code: string | undefined): boolean {
  * - { expr: { type: "default", value: "colName" } } オブジェクト (v5)
  * のどちらかになる。両方に対応する。
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function extractColumnName(node: any): string | null {
+function extractColumnName(node: SqlExprNode | null | undefined): string | null {
   if (!node || node.type !== "column_ref") return null;
   const col = node.column;
   if (typeof col === "string") return col.toLowerCase();
@@ -427,13 +473,11 @@ function extractColumnName(node: any): string | null {
  * SELECT SQL AST から WHERE 句で参照しているカラム物理名 (lowercase) を抽出する。
  * シンプルな `WHERE col = @var` 形式および `AND` / `OR` 連結を対象とする。
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function extractWhereColumns(ast: any): Set<string> {
+function extractWhereColumns(ast: SqlRootNode | null | undefined): Set<string> {
   const cols = new Set<string>();
   if (!ast || ast.type !== "select") return cols;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  function walk(node: any): void {
+  function walk(node: SqlExprNode | null | undefined): void {
     if (!node || typeof node !== "object") return;
     // binary expression: left/right
     if (node.type === "binary_expr") {
@@ -448,7 +492,7 @@ function extractWhereColumns(ast: any): Set<string> {
     if (node.where) walk(node.where);
   }
 
-  walk(ast);
+  walk(ast as SqlExprNode);
   return cols;
 }
 
@@ -475,8 +519,7 @@ function hasPriorSelectForUniqueColumns(
  * step の affectedRowsCheck.errorCode が UNIQUE_VIOLATION 系かどうかを確認する。
  * パターン 2: INSERT step 自身の affectedRowsCheck でハンドリングしている。
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function hasAffectedRowsUniqueCheck(step: any): boolean {
+function hasAffectedRowsUniqueCheck(step: { affectedRowsCheck?: { errorCode?: string } } | null | undefined): boolean {
   return isUniqueViolationErrorCode(step?.affectedRowsCheck?.errorCode);
 }
 
@@ -497,16 +540,18 @@ function hasTryCatchUniqueViolationInSteps(steps: Step[]): boolean {
     if (step.kind === "branch") {
       // branches の condition を確認
       for (const branch of step.branches) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const cond = branch.condition as any;
+        // condition は実行時 union (schema 上は object / string 双方ありうる) のため
+        // ローカル型で narrow する。tryCatch 形式は { kind: "tryCatch"; catchErrors: ... }。
+        type BranchCondition = { kind?: string; catchErrors?: unknown[] } | string | undefined;
+        const cond = branch.condition as BranchCondition;
         if (
-          cond?.kind === "tryCatch" &&
-          Array.isArray(cond?.catchErrors) &&
+          cond && typeof cond === "object" &&
+          cond.kind === "tryCatch" &&
+          Array.isArray(cond.catchErrors) &&
           cond.catchErrors.some((e: unknown) => {
             if (typeof e === "string") return isUniqueViolationErrorCode(e);
             if (e && typeof e === "object") {
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              const obj = e as any;
+              const obj = e as { errorCode?: string; code?: string; kind?: string };
               return isUniqueViolationErrorCode(obj.errorCode ?? obj.code ?? obj.kind ?? "");
             }
             return false;
@@ -531,8 +576,7 @@ function hasTryCatchUniqueViolationInSteps(steps: Step[]): boolean {
     }
     if (step.kind === "externalSystem") {
       for (const spec of Object.values(step.outcomes ?? {})) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const s = spec as any;
+        const s = spec as { sideEffects?: Step[] } | undefined;
         if (s?.sideEffects && hasTryCatchUniqueViolationInSteps(s.sideEffects)) return true;
       }
     }
@@ -562,9 +606,8 @@ function collectTxWriteTableNames(
         // SQL パースでテーブル名を取得
         const substituted = substituteAtVars(step.sql);
         try {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          let ast: any = parser.astify(substituted, { database: DIALECT });
-          ast = Array.isArray(ast) ? ast[0] : ast;
+          const rawAst = parser.astify(substituted, { database: DIALECT }) as unknown as SqlRootNode | SqlRootNode[];
+          const ast: SqlRootNode | undefined = Array.isArray(rawAst) ? rawAst[0] : rawAst;
           if (ast) {
             let tableName: string | null = null;
             if (ast.type === "insert") {
@@ -775,9 +818,8 @@ function checkAction(
     if (step.kind === "dbAccess" && step.operation === "SELECT" && step.sql) {
       const substitutedSel = substituteAtVars(step.sql);
       try {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- node-sql-parser exposes dialect-specific AST shapes without stable TS types.
-        let astSel: any = parser.astify(substitutedSel, { database: DIALECT });
-        astSel = Array.isArray(astSel) ? astSel[0] : astSel;
+        const rawSel = parser.astify(substitutedSel, { database: DIALECT }) as unknown as SqlRootNode | SqlRootNode[];
+        const astSel: SqlRootNode | undefined = Array.isArray(rawSel) ? rawSel[0] : rawSel;
         if (astSel && astSel.type === "select") {
           // SELECT 対象テーブル名を抽出 (FROM 句)
           const fromTables: string[] = [];
@@ -810,16 +852,15 @@ function checkAction(
     if (step.kind === "dbAccess" && step.operation === "DELETE" && step.sql) {
       const delSql = step.sql;
       const delSubstituted = substituteAtVars(delSql);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      let delAst: any;
+      let delAst: SqlRootNode | SqlRootNode[] | null;
       try {
-        delAst = parser.astify(delSubstituted, { database: DIALECT });
+        delAst = parser.astify(delSubstituted, { database: DIALECT }) as unknown as SqlRootNode | SqlRootNode[];
       } catch {
         // DELETE パース失敗は観点 4 をスキップ
         delAst = null;
       }
       if (delAst) {
-        const delRootNode = Array.isArray(delAst) ? delAst[0] : delAst;
+        const delRootNode: SqlRootNode | undefined = Array.isArray(delAst) ? delAst[0] : delAst;
         const delTableName = extractDeleteTableName(delRootNode);
         if (delTableName) {
           const delMeta = tableMeta.get(delTableName);
@@ -872,10 +913,9 @@ function checkAction(
     // SQL パース
     const atVarMap = buildAtVarMap(sql);
     const substituted = substituteAtVars(sql);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let ast: any;
+    let ast: SqlRootNode | SqlRootNode[];
     try {
-      ast = parser.astify(substituted, { database: DIALECT });
+      ast = parser.astify(substituted, { database: DIALECT }) as unknown as SqlRootNode | SqlRootNode[];
     } catch {
       issues.push({
         path: `${path}.sql`,


### PR DESCRIPTION
## 関連

- Closes #1147
- 仕様: ISSUE #1147 本文 (鉄則 3 同根統合で集約された 9 観点)
- 関連レビュー: `.tmp/review-2026-05-17/02-backend-arch.md` (F-6) / `04-code-quality.md` (S-15/S-16/S-18/S-19/N-5/N-6/N-7/N-8) / `06-independent-review.md` (F-6 格下げ根拠)

## 概要

軽微 cleanup を 1 PR に集約 (鉄則 3)。型情報の劣化抑止 (S-15) / 実装ドリフトの解消 (F-6) / dead code 除去 (S-16, N-6) / production console ノイズ削減 (S-18) / 機械置換 (S-19) / spec 補強 (N-5, N-8) を 6 commit に分けて trace。N-7 (cheat sheet 任意) は overengineering 判断で skip。schemas/ には一切触れない pure cleanup。

## 主な変更

- **F-6** (RightPanel.tsx): MCP renameScreenItem 失敗時 fallback の comment drift 修正。`localStorage 直接更新` → 実コードは backend `saveScreenEntity` 経由 (#923 で localStorage fallback 廃止済) に統一されている事実を spec D-8 参照込みで明記
- **S-16 + N-6** (backend/src/wsBridge.ts): 4 件の dead RPC dispatcher を一括削除
  - `savePageLayoutDesign` (S-16): `saveScreen` 経路で同等処理
  - `loadScreenItems` / `saveScreenItems` / `deleteScreenItems` (N-6): frontend が `loadScreenEntity` / `saveScreenEntity` (Screen entity に embed された items) に切替済、broadcast は saveScreenEntity 経路で継続発火
  - 関連未使用 import (`readScreenItems`, `deleteScreenItems`) も整理
- **S-18** (Designer.tsx / mcpBridge.ts): broadcast 発火ごと出る debug ログ 3 箇所を `if (import.meta.env.DEV)` でガード化。migration 通知 / 接続 lifecycle ログは production 保持
- **S-19** (backend/src/reactExporter.ts): event handler placeholder 14 件を `/* TODO */` → `/* USER_HANDLER */` rename。汎用 TODO grep ノイズ削減
- **S-15** (frontend/src/schemas/sqlOrderValidator.ts): `any` 24 件 (eslint-disable コメント 12 行含む) を node-sql-parser 用 5 interface + 1 type alias で局所化。挙動変更なし (50 test 全 pass)
- **N-5** (frontend/AGENTS.md): codex / puck で確立された `<feature>/` vs `components/<feature>/` 二重配置の規約を Key Directories 節に追記。SDK/hooks/型 vs UI ダイアログの判定基準 + 循環依存回避ルールを明示
- **N-8** (docs/spec/react-exporter.md 新設 + spec/README.md index 追加): `reactExporter.ts` が MCP tool `designer__export_screen` の実装であること、`/generate-code` skill とは直交関係で補完すること、(a) 維持 / (b) 統合 / (c) 削除 の比較で (a) 維持を選んだ根拠を明示

## 仕様逐条突合 (自己申告)

- **F-6**: コメント drift 修正
  - `frontend/src/components/RightPanel.tsx:151-153` — `MCP renameScreenItem 失敗時のフォールバック` + spec D-8 参照 ✓
  - `frontend/src/components/RightPanel.tsx:164` — `screen-items 更新失敗は無視` (`localStorage` 文言除去) ✓
- **S-16**: dead RPC `savePageLayoutDesign` 削除
  - `backend/src/wsBridge.ts:1177-1179` — 削除 + 経緯コメント ✓
  - 全体 grep: 削除後 `grep "savePageLayoutDesign" frontend backend` → src 0 件 (compiled dist のみ) ✓
- **S-18**: 3 lines を DEV ガード
  - `frontend/src/components/Designer.tsx:421` (screenChanged) ✓
  - `frontend/src/components/Designer.tsx:724` (puckDataChanged) ✓
  - `frontend/src/mcp/mcpBridge.ts:512` (broadcast event) ✓
- **S-19**: 14 件機械置換
  - `backend/src/reactExporter.ts:63-76` — 14 件全て `/* TODO */` → `/* USER_HANDLER */` ✓
  - 残 `/* TODO */`: 0 件 (`grep -c '/\* TODO \*/' backend/src/reactExporter.ts` = 0) ✓
- **S-15**: any 局所化
  - `frontend/src/schemas/sqlOrderValidator.ts:89-149` — 新規 interface/type 6 件 (`SqlAstNode` / `SqlColumnRef` / `SqlValueRow` / `SqlExprNode` / `SqlRootNode` / `SqlValuesContainer`) 定義 ✓
  - `extractInsertTableName` / `extractDeleteTableName` / `extractInsertColumnVarMap` / `extractColumnName` / `extractWhereColumns` / `getPhysicalName` / `hasAffectedRowsUniqueCheck` の signature 強化 ✓
  - `parser.astify` 4 箇所を `as unknown as SqlRootNode | SqlRootNode[]` で cast (node-sql-parser AST 型 vs Drop 等 dialect-specific shape の不整合を分離) — line 609 / 821 / 857 / 918 ✓
  - 残 `any` (コード本体): 0 件 (`grep -E ': any\b|<any>|as any\b' src/schemas/sqlOrderValidator.ts` → 全て doc comment のみ) ✓
- **N-6**: dead RPC 精査
  - 計測: dispatcher 57 RPC vs frontend 53 unique 呼出 → 差 4 件 (元 ISSUE の「16 件」は dispatcher 内の非 RPC switch 7 件を含む raw count)
  - `backend/src/wsBridge.ts:1381-1385` — 3 件削除 + 経緯コメント ✓
  - `backend/src/wsBridge.ts:88-90` — `readScreenItems` / `deleteScreenItems` 未使用 import 削除 ✓
- **N-5**: 規約明文化
  - `frontend/AGENTS.md:21-37` — `<feature>/` vs `components/<feature>/` 二重配置の規約 + 判定基準 + 循環依存ルール ✓
- **N-8**: 存在意義 spec
  - `docs/spec/react-exporter.md:1-57` — 新設 (位置付け / `/generate-code` との関係表 / 維持判断 / API / 実装メモ) ✓
  - `docs/spec/README.md:47` — index 追加 ✓
- **N-7**: 任意 (skip 判断)
  - 大規模リネーム reviewer cheat sheet template を `docs/process/` に残す案は overengineering と判断 (将来本当に再リネームが走る時に必要なら起票) — N-7 のみ未対応

## レビューで特に見てほしい箇所

- **S-15 の cast**: `parser.astify(...)` の戻りを `as unknown as SqlRootNode | SqlRootNode[]` で 2 段キャストしている。node-sql-parser 公式型 `AST | AST[]` (`Drop` 等の union 要素が index signature を持たないため direct cast 不可) を完全に置き換えるのは validator スコープ外 — 局所キャストで切り離している判断が妥当か
- **N-6 の精査結果**: 元 ISSUE の「差 16 件」根拠は `case "kind":` の総数を粗くカウントした raw 値で、実際の RPC 差分は 4 件 (今回全て削除済)。粒度が違うため ISSUE の文言と PR の結果は数字が一致しない (詳細は本 PR 本文の集計を参照)
- **S-16 + N-6 統合判断**: 元 ISSUE では S-16 (savePageLayoutDesign) と N-6 (残 15 件精査) を別観点としていたが、精査結果が S-16 と同質の dead RPC で同じファイルなので 1 commit に統合した。妥当か
- **N-5**: spec の置き場所判断 — `docs/spec/` ではなく `frontend/AGENTS.md` に追記した (frontend 内部規約のため)。`docs/spec/` の何かにマージするのが望ましければ指示ください

## テスト

- Vitest (frontend): 2197 / 2197 pass (新規 0、refactor 後の挙動同一性確認)
- Vitest (backend): 513 / 513 pass (新規 0、dead RPC 削除後の影響なし)
- ESLint: 既存 4 warnings (pre-existing useEditLevel)、本 PR 新規 0 warning
- TypeScript build: `frontend/npm run build` + `backend/npm run build` 両方 pass
- MCP E2E: 未実行 (本 PR は backend dispatcher の dead path 削除のみで MCP 表面契約は不変)

## UI 影響 / AI smoke test

- [x] UI 影響なし (auto テスト pass のみ)
- [ ] UI 影響あり (AI が chrome-devtools MCP / Playwright で smoke test 実施済み)

### UI 影響ありの場合、AI smoke test で確認した項目

N/A — 純粋な cleanup / refactor / dead code 除去 / spec 追記 (機能変更ゼロ)。S-18 の DEV ガードは production console の出力量変化のみで UI 挙動には影響しない。

## spec 側の不足点 / 提案

- N-7 (cheat sheet 任意) は skip 判断 — `docs/process/` 配下の cheat sheet template を作る意義が低い (将来再リネームが走る時に起票で十分)

## レビュー担当への申し送り

- 本 PR は 9 観点を集約した cleanup なので、観点ごと独立にレビュー可能 (各 commit 単位で trace)。レビュー時に NG が出たら commit revert で個別差し戻し可能
- S-15 の interface 設計は「validator が依存している fields のみ optional で受ける」方針 (完全な node-sql-parser AST 型を再現しない)。型注釈の劣化抑止と保守性のバランス重視
- N-6 の精査結果「ISSUE 文言の 16 件 vs 実差分 4 件」のギャップは ISSUE 起票時の概算 vs 実測の差。実測が正確
- N-5 の規約はあくまで frontend ローカルの module 構成パターン。schema / data model には無関係

