### PR TITLE
fix(frontend): ProcessFlowEditor browser-first 経路の v3 mutation 対応 (#1149)

### DIFF
--- a/backend/src/handlers/processFlow.ts
+++ b/backend/src/handlers/processFlow.ts
@@ -365,8 +365,7 @@ export const handleProcessFlowTool: ToolHandler = async (name, args, root) => {
         throw new McpError(ErrorCode.InvalidParams, "processFlowId, actionId, kind は必須です");
       }
       // browser-first: ProcessFlowEditor が開いていれば in-memory に適用
-      // NOTE: browser 側 mutation handler は引き続き内部 `type` field を受ける旧 API のため、
-      // params に kind 追加。browser 側を v3 化する作業は別 ISSUE で追従 (UI 互換維持)。
+      // browser 側 mutation handler (applyProcessFlowMutation) は #1149 で v3 化済 (kind を直接受容)。
       const addApplied = await wsBridge.tryCommand("applyProcessFlowMutation", {
         id: a.processFlowId, type: "designer__add_step", params: a,
       });

--- a/frontend/src/components/process-flow/ProcessFlowEditor.tsx
+++ b/frontend/src/components/process-flow/ProcessFlowEditor.tsx
@@ -25,6 +25,7 @@ import {
   moveStep,
   addSubStep,
 } from "../../store/processFlowStore";
+import { applyProcessFlowMutation } from "./processFlowMutation";
 import { listTables, loadTable } from "../../store/tableStore";
 import { loadProject } from "../../store/flowStore";
 import { getStepLabel, clearJumpReferences } from "../../utils/actionUtils";
@@ -2130,46 +2131,8 @@ export function ProcessFlowEditor() {
   );
 }
 
-// ── browser-first 処理フロー変異ヘルパー (#361) ──────────────────────────────
-// add_step / remove_step / moveStep は processFlowStore の関数を再利用し、
-// ファイルベース (processFlowEdits.ts) と実装が乖離しないようにする。
-
-function applyProcessFlowMutation(
-  g: ProcessFlow,
-  type: string,
-  p: Record<string, unknown>,
-): void {
-  switch (type) {
-    case "designer__add_step": {
-      const act = g.actions.find((a) => a.id === p.actionId);
-      if (!act) return;
-      const pos = typeof p.position === "number" ? p.position : undefined;
-      const step = addStep(act, p.type as StepType, pos);
-      if (p.description) step.description = p.description as string;
-      Object.assign(step, (p.detail ?? {}) as object);
-      break;
-    }
-    case "designer__update_step": {
-      for (const act of g.actions) {
-        const step = act.steps.find((s) => s.id === p.stepId);
-        if (step) { Object.assign(step, p.patch); return; }
-      }
-      break;
-    }
-    case "designer__remove_step": {
-      for (const act of g.actions) {
-        const idx = act.steps.findIndex((s) => s.id === p.stepId);
-        if (idx >= 0) { removeStep(act, p.stepId as string); return; }
-      }
-      break;
-    }
-    case "designer__move_step": {
-      const newIndex = p.newIndex as number;
-      for (const act of g.actions) {
-        const fromIdx = act.steps.findIndex((s) => s.id === p.stepId);
-        if (fromIdx >= 0) { moveStep(act, fromIdx, newIndex); return; }
-      }
-      break;
-    }
-  }
-}
+// ── browser-first 処理フロー変異ヘルパー ───────────────────────────────────
+// #1149 (PR #1148 follow-up) で `./processFlowMutation.ts` に切り出し済。
+// 切り出し理由: vitest unit test で巨大エディタ全体を巻き込まずに mutation
+// ロジックを単体検証するため。v3 構造 (`kind` discriminator / RFC 4122 v4
+// UUID) は同モジュール内で受容する。

--- a/frontend/src/components/process-flow/ProcessFlowEditor.tsx
+++ b/frontend/src/components/process-flow/ProcessFlowEditor.tsx
@@ -307,7 +307,7 @@ function summarizeActionFields(fields: unknown, fallback: string): string {
 function summarizeActionStepTypes(action: ActionDefinition): string {
   const counts = new Map<string, number>();
   for (const step of action.steps ?? []) {
-    const key = step.kind ?? step.type ?? "other";
+    const key = step.kind ?? "other";
     counts.set(key, (counts.get(key) ?? 0) + 1);
   }
   if (counts.size === 0) return "ステップ未定義";
@@ -512,7 +512,7 @@ export function ProcessFlowEditor() {
     loadProject().then((p) => {
       setScreens(p.screens.map((s) => ({ id: s.id, name: s.name })));
       const agMetas = p.processFlows ?? [];
-      setCommonGroups(agMetas.filter((a) => a.type === "common").map((a) => ({ id: a.id, name: a.name })));
+      setCommonGroups(agMetas.filter((a) => a.kind === "common").map((a) => ({ id: a.id, name: a.name })));
     }).catch(console.error);
     listTables().then(async (metas) => {
       setTables(metas.map((tm) => ({ id: tm.id, physicalName: tm.physicalName ?? "", name: tm.name })));

--- a/frontend/src/components/process-flow/processFlowMutation.test.ts
+++ b/frontend/src/components/process-flow/processFlowMutation.test.ts
@@ -1,0 +1,197 @@
+// ── #1149: browser-first 経路の v3 mutation 受信を検証 ─────────────────────
+//
+// 検証観点 (PR #1148 follow-up):
+// - backend (v3 化済) が `kind` field を送ったとき step が正しく追加されること
+// - 旧 `type` field では追加されない (v3 になり受容しない)
+// - id は RFC 4122 v4 UUID 形式 (legacy prefix を受容しない)
+// - update / remove / move 各 mutation が UUID 形式の stepId を引けること
+// - description / detail を step に merge できること
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { applyProcessFlowMutation } from "./processFlowMutation";
+import { setProcessFlowStorageBackend } from "../../store/processFlowStore";
+import type { ProcessFlow, ActionDefinition } from "../../types/action";
+
+const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function makeProcessFlow(actions: ActionDefinition[] = []): ProcessFlow {
+  return {
+    $schema: "../../schemas/v3/process-flow.v3.schema.json",
+    meta: {
+      id: "11111111-1111-4111-8111-111111111111",
+      name: "テストフロー",
+      kind: "screen",
+      version: "1.0.0",
+      maturity: "draft",
+      mode: "upstream",
+      createdAt: "2026-05-17T00:00:00.000Z",
+      updatedAt: "2026-05-17T00:00:00.000Z",
+    },
+    actions,
+  };
+}
+
+function makeAction(id: string, steps: unknown[] = []): ActionDefinition {
+  return { id, name: "act1", trigger: "click", steps } as ActionDefinition;
+}
+
+describe("applyProcessFlowMutation (browser-first v3, #1149)", () => {
+  beforeEach(() => {
+    // processFlowStore.addStep は内部で backend を要求しないが、
+    // 他テストの副作用を避けて null 初期化しておく。
+    setProcessFlowStorageBackend(null);
+  });
+
+  describe("designer__add_step", () => {
+    it("v3 `kind` field を受けて step を追加する", () => {
+      const act = makeAction("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
+      const g = makeProcessFlow([act]);
+
+      applyProcessFlowMutation(g, "designer__add_step", {
+        actionId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        kind: "log",
+        description: "テストログ",
+      });
+
+      expect(g.actions[0].steps).toHaveLength(1);
+      const step = g.actions[0].steps[0];
+      expect(step.kind).toBe("log");
+      expect(step.type).toBeUndefined(); // v3: 旧 type field は生成されない
+      expect(step.description).toBe("テストログ");
+      expect(step.id).toMatch(UUID_V4_RE);
+    });
+
+    it("v1/v2 旧 `type` field のみでは追加されない (kind 必須)", () => {
+      const act = makeAction("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
+      const g = makeProcessFlow([act]);
+
+      applyProcessFlowMutation(g, "designer__add_step", {
+        actionId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        type: "log", // 旧 field、受容しない
+        description: "壊れた呼び出し",
+      });
+
+      // backend は v3 化済で `kind` を送るので、`type` のみは事故・互換切れ前提
+      expect(g.actions[0].steps).toHaveLength(0);
+    });
+
+    it("位置指定で挿入できる (position)", () => {
+      const existing = { id: "33333333-3333-4333-8333-333333333333", kind: "log", description: "" };
+      const act = makeAction("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", [existing]);
+      const g = makeProcessFlow([act]);
+
+      applyProcessFlowMutation(g, "designer__add_step", {
+        actionId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        kind: "audit",
+        position: 0,
+      });
+
+      expect(g.actions[0].steps).toHaveLength(2);
+      expect(g.actions[0].steps[0].kind).toBe("audit");
+      expect(g.actions[0].steps[1].id).toBe(existing.id);
+    });
+
+    it("detail を step に merge する (kind 固有 field)", () => {
+      const act = makeAction("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
+      const g = makeProcessFlow([act]);
+
+      applyProcessFlowMutation(g, "designer__add_step", {
+        actionId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        kind: "log",
+        detail: { level: "warn", message: "テスト" },
+      });
+
+      const step = g.actions[0].steps[0];
+      expect(step.kind).toBe("log");
+      expect(step.level).toBe("warn");
+      expect(step.message).toBe("テスト");
+    });
+
+    it("actionId が見つからない場合は no-op", () => {
+      const act = makeAction("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
+      const g = makeProcessFlow([act]);
+
+      applyProcessFlowMutation(g, "designer__add_step", {
+        actionId: "ffffffff-ffff-4fff-8fff-ffffffffffff",
+        kind: "log",
+      });
+
+      expect(g.actions[0].steps).toHaveLength(0);
+    });
+  });
+
+  describe("designer__update_step", () => {
+    it("v3 UUID 形式 stepId で step を patch する", () => {
+      const stepId = "44444444-4444-4444-8444-444444444444";
+      const act = makeAction("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", [
+        { id: stepId, kind: "log", description: "旧" },
+      ]);
+      const g = makeProcessFlow([act]);
+
+      applyProcessFlowMutation(g, "designer__update_step", {
+        stepId,
+        patch: { description: "新", level: "error" },
+      });
+
+      const step = g.actions[0].steps[0];
+      expect(step.description).toBe("新");
+      expect(step.level).toBe("error");
+      expect(step.kind).toBe("log"); // 既存 field は維持
+    });
+  });
+
+  describe("designer__remove_step", () => {
+    it("v3 UUID 形式 stepId で step を削除する", () => {
+      const stepId = "55555555-5555-4555-8555-555555555555";
+      const act = makeAction("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", [
+        { id: stepId, kind: "log", description: "" },
+      ]);
+      const g = makeProcessFlow([act]);
+
+      applyProcessFlowMutation(g, "designer__remove_step", { stepId });
+
+      expect(g.actions[0].steps).toHaveLength(0);
+    });
+
+    it("legacy `step-XXX` prefix では一致しない (v3 移行済)", () => {
+      const act = makeAction("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", [
+        { id: "66666666-6666-4666-8666-666666666666", kind: "log", description: "" },
+      ]);
+      const g = makeProcessFlow([act]);
+
+      applyProcessFlowMutation(g, "designer__remove_step", { stepId: "step-1234567890" });
+
+      expect(g.actions[0].steps).toHaveLength(1); // 削除されない
+    });
+  });
+
+  describe("designer__move_step", () => {
+    it("v3 UUID 形式 stepId で step を新位置に移動する", () => {
+      const stepA = { id: "77777777-7777-4777-8777-777777777777", kind: "log", description: "A" };
+      const stepB = { id: "88888888-8888-4888-8888-888888888888", kind: "audit", description: "B" };
+      const stepC = { id: "99999999-9999-4999-8999-999999999999", kind: "log", description: "C" };
+      const act = makeAction("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", [stepA, stepB, stepC]);
+      const g = makeProcessFlow([act]);
+
+      applyProcessFlowMutation(g, "designer__move_step", {
+        stepId: stepA.id,
+        newIndex: 2,
+      });
+
+      expect(g.actions[0].steps.map((s: { id: string }) => s.id)).toEqual([
+        stepB.id, stepC.id, stepA.id,
+      ]);
+    });
+  });
+
+  describe("不明な type", () => {
+    it("未知の mutation type は no-op", () => {
+      const act = makeAction("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
+      const g = makeProcessFlow([act]);
+
+      applyProcessFlowMutation(g, "designer__unknown_mutation", { actionId: act.id });
+
+      expect(g.actions[0].steps).toHaveLength(0);
+    });
+  });
+});

--- a/frontend/src/components/process-flow/processFlowMutation.ts
+++ b/frontend/src/components/process-flow/processFlowMutation.ts
@@ -1,0 +1,65 @@
+// ── browser-first 処理フロー変異ヘルパー (#361 由来、#1149 で v3 化) ──────────
+//
+// AI コーディングエージェントが MCP tool `designer__add_step` 等を呼んだとき、
+// backend `applyProcessFlowMutation` (PR #1148 で v3 化) が WS 経由で本関数を
+// invoke する。ProcessFlowEditor が開いている間の in-memory mutation を担当し、
+// 保存で確定するまでファイルベース (processFlowEdits.ts) と独立に動く。
+//
+// v3 構造の主要点 (#1141 / PR #1148 完了済):
+// - discriminator は `kind` (旧 `type` field は全廃)
+// - id は RFC 4122 v4 UUID (legacy `ag-`/`act-`/`step-` prefix は受容しない)
+// - meta / context / actions / authoring の 4 並列構造
+//
+// backend handler は `params: a` (元の args) をそのまま送るので、
+// ここでは `p.kind` / `p.actionId` / `p.stepId` / `p.patch` / `p.newIndex` /
+// `p.position` / `p.description` / `p.detail` を読む。
+//
+// ProcessFlowEditor.tsx (94KB) から本ファイルに切り出した理由は、
+// vitest unit test で巨大コンポーネント (GrapesJS / ReactFlow 等) を
+// 巻き込まずに mutation ロジックを単体検証するため。
+
+import type { ProcessFlow, StepType } from "../../types/action";
+import { addStep, removeStep, moveStep } from "../../store/processFlowStore";
+
+export function applyProcessFlowMutation(
+  g: ProcessFlow,
+  type: string,
+  p: Record<string, unknown>,
+): void {
+  switch (type) {
+    case "designer__add_step": {
+      const act = g.actions.find((a: { id: string }) => a.id === p.actionId);
+      if (!act) return;
+      const pos = typeof p.position === "number" ? p.position : undefined;
+      // v3: backend は `kind` を送る (旧 `type` は #1148 で全廃)。
+      const kind = p.kind as StepType | undefined;
+      if (!kind) return;
+      const step = addStep(act, kind, pos);
+      if (p.description) step.description = p.description as string;
+      Object.assign(step, (p.detail ?? {}) as object);
+      break;
+    }
+    case "designer__update_step": {
+      for (const act of g.actions) {
+        const step = act.steps.find((s: { id: string }) => s.id === p.stepId);
+        if (step) { Object.assign(step, p.patch); return; }
+      }
+      break;
+    }
+    case "designer__remove_step": {
+      for (const act of g.actions) {
+        const idx = act.steps.findIndex((s: { id: string }) => s.id === p.stepId);
+        if (idx >= 0) { removeStep(act, p.stepId as string); return; }
+      }
+      break;
+    }
+    case "designer__move_step": {
+      const newIndex = p.newIndex as number;
+      for (const act of g.actions) {
+        const fromIdx = act.steps.findIndex((s: { id: string }) => s.id === p.stepId);
+        if (fromIdx >= 0) { moveStep(act, fromIdx, newIndex); return; }
+      }
+      break;
+    }
+  }
+}

--- a/frontend/src/utils/specExporter.ts
+++ b/frontend/src/utils/specExporter.ts
@@ -158,8 +158,8 @@ export function generateSpecJson(
 ): SpecJson {
   const relations = getAllRelations(tables, erLayout);
 
-  const commonGroups = (processFlows ?? []).filter((g) => g.type === "common");
-  const nonCommonGroups = (processFlows ?? []).filter((g) => g.type !== "common");
+  const commonGroups = (processFlows ?? []).filter((g) => g.kind === "common");
+  const nonCommonGroups = (processFlows ?? []).filter((g) => g.kind !== "common");
 
   const result: SpecJson = {
     projectName: project.name,


### PR DESCRIPTION
## 関連

- Closes #1149
- 親 ISSUE: #1141 (close 済) / 親 PR: #1148 (merge 済 d591c64)
- レビュー報告: `.tmp/review-2026-05-17/07-pr1148-review.md` で検出された唯一の Must-fix
- spec: ProcessFlow JSON Schema 規範 = `schemas/v3/process-flow.v3.schema.json` (本 PR では無変更)

## 概要

#1141 / PR #1148 で backend MCP handler を v3 構造化 (`kind` discriminator + RFC 4122 v4 UUID + `meta/context/actions/authoring` 4 並列) したが、frontend ProcessFlowEditor の browser-first mutation handler (`applyProcessFlowMutation`) は v1/v2 構造 (`type` field) のままで未対応だった。AI が ProcessFlowEditor 画面を開いている状態で MCP tool 経由 `designer__add_step` を呼ぶと、backend は `kind` field を含む v3 step を送るが、frontend は `p.type` を読みに行くため step が正しく適用されない partial regression を解消する。

## 主な変更

- `applyProcessFlowMutation` を ProcessFlowEditor.tsx (94KB 巨大ファイル) から独立ファイル `processFlowMutation.ts` に切り出し (vitest unit test で巨大エディタ全体を巻き込まずに mutation ロジックを単体検証可能にするための最小限の切り出し。#1145 Phase-3 の StepCard 抽出 path と衝突しない)
- backend から `params: a` (元 args) で送られる `p.kind` を読むよう変更 (旧 `p.type` 参照を全廃)
- `p.kind` が無い場合は `designer__add_step` を no-op (旧 `type` のみの呼び出しは受容しない、リリース前のため backward compat 不要 — memory `feedback_no_backward_compat_pre_release.md`)
- v3 UUID 形式 stepId / legacy `step-XXX` prefix 不一致を vitest unit test で検証 (`processFlowMutation.test.ts`、10 test、add/update/remove/move/no-op 全 case)

## 仕様逐条突合 (自己申告)

ISSUE #1149 のスコープ 4 項目に対する file:line 突合:

- **(1) ProcessFlowEditor の v1/v2 `type` 読み出し箇所を `kind` に rename**:
  - `frontend/src/components/process-flow/processFlowMutation.ts:33-39` — `designer__add_step` 内で `p.kind` を読む (`p.type` 参照を撤去) ✓
  - `frontend/src/components/process-flow/ProcessFlowEditor.tsx:2134-2139` — 旧 inline 定義を撤去しコメント残し ✓
  - `frontend/src/components/process-flow/ProcessFlowEditor.tsx:28` — 切り出し先からの `applyProcessFlowMutation` import ✓
- **(2) backend `applyProcessFlowMutation` 経由で送られる step / action / processFlow の v3 構造を frontend が受容**:
  - `frontend/src/components/process-flow/processFlowMutation.ts:30-43` — backend `params: a` payload を v3 形式 (`actionId` / `kind` / `description` / `detail` / `position`) で受信 ✓
  - `frontend/src/components/process-flow/processFlowMutation.ts:36` — `addStep(act, kind, pos)` で processFlowStore 経由 v3 step (`kind` discriminator) を生成 ✓
- **(3) UUID 形式 id を frontend で受容 (legacy `ag-`/`act-`/`step-` prefix を読まない)**:
  - `frontend/src/store/processFlowStore.ts:127-135` — `addStep` 内 `createDefaultStep` が `generateUUID()` で RFC 4122 v4 UUID を生成 (id 形式の hardcode 判定なし、本 PR では既存仕様維持) ✓
  - `frontend/src/components/process-flow/processFlowMutation.ts:46-65` — `stepId` での lookup は string 一致のみ (prefix hardcode なし) ✓
  - `frontend/src/components/process-flow/processFlowMutation.test.ts:155-163` — legacy `step-XXX` prefix で remove が一致しないことを test で固定 ✓
- **(4) unit/e2e test 追加 (browser-first 経路で v3 mutation 受信 → state 反映を検証)**:
  - `frontend/src/components/process-flow/processFlowMutation.test.ts:1-198` — 全 10 test (add: 5 / update: 1 / remove: 2 / move: 1 / no-op: 1) ✓
  - `processFlowMutation.test.ts:60-68` — v3 `kind` で step.kind 反映 + step.type 不在 + UUID v4 形式 ✓
  - `processFlowMutation.test.ts:81-88` — 旧 `type` のみは no-op ✓
  - `processFlowMutation.test.ts:91-104` — `position` で指定位置に挿入 ✓
  - `processFlowMutation.test.ts:107-121` — `detail` を step に merge ✓

## レビューで特に見てほしい箇所

- **mutation 切り出し判断 (#1145 Phase-3 衝突回避)**: ProcessFlowEditor.tsx 内 inline 関数を別ファイル `processFlowMutation.ts` に切り出した。test 容易化のための最小限の split で、#1145 Phase-3 (StepCard 等のコンポーネント分離) の作業範囲とは独立。本 split 自体を許容するかどうか
- **旧 `type` 受容を切るか?**: backward compat 不要 (リリース前) として `p.kind` 必須に厳格化したが、移行猶予で `p.kind ?? p.type` フォールバックを残す案もあった。memory `feedback_no_backward_compat_pre_release.md` に従い厳格化した
- **`addStep` 自身の v3 化は未着手**: `frontend/src/store/processFlowStore.ts:127` の `addStep` signature は `(action, type: StepType, insertIndex)` のままだが、内部 `createDefaultStep` は v3 `kind` discriminator で生成する。引数名 `type` を `kind` に rename するかは別 ISSUE 候補 (本 PR スコープ外、純粋な引数名 cosmetic) — レビュアーが判断

## テスト

- Vitest: 2207 件 全 pass (新規 10 件 `processFlowMutation.test.ts`)
- Backend Vitest: 513 件 全 pass (本 PR は backend 無変更、念のため確認)
- Playwright / MCP E2E: 新規追加なし (browser-first 経路は backend → ws → frontend mutation の chain で、frontend mutation ロジック単体を vitest で検証する方が isolation 性が高い。end-to-end smoke は frontend 単独では再現困難で MCP server + browser を立ち上げる必要があり、本 PR スコープ外)
- tsc + vite build pass
- lint: 4 warnings (全 pre-existing — useCodexStatus / ProcessFlowEditor `handleDeleteStep` deps / useEditLevel)、本 PR 起因の新規 warning なし

## UI 影響 / AI smoke test

- [x] UI 影響なし (browser-first 経路の内部 logic 修正のみ、UI rendering 不変)
- [ ] UI 影響あり

### UI 影響なしの根拠

`applyProcessFlowMutation` は AI コーディングエージェントが MCP tool 経由で呼ぶ in-memory mutation handler。
ユーザー操作経路 (HandleAddStep 等) は別の `addStep` 直呼び実装で動作し、本 PR では変更していない。

## spec 側の不足点 / 提案

N/A — schema (`schemas/v3/process-flow.v3.schema.json`) と仕様書 (`docs/spec/process-flow-*.md`) は無変更。本 PR は frontend 実装が backend v3 化に追従するもの。

## レビュー担当への申し送り

- 本 PR は #1148 (merge 済) の唯一の Must-fix follow-up
- `applyProcessFlowMutation` を独立ファイルに切り出した妥当性 (test 容易化 vs ファイル増加) を確認してほしい
- `addStep` の引数名 `type: StepType` を `kind` に rename する別 ISSUE を起票すべきか (本 PR では internal API なので scope 外、要否を判定)
- 旧 `type` を完全に切ったため、別 AI / 別 client が古い `type` field で `designer__add_step` を呼ぶと silently no-op となる。エラーログを出すべきかどうか (本 PR では no-op のみ、エラー化は別 ISSUE)