### PR TITLE
refactor(process-flow): StepCard.tsx の 15 kind body を sub-component に抽出 (#1145 Phase-2)

### DIFF
--- a/frontend/src/components/process-flow/StepCard.tsx
+++ b/frontend/src/components/process-flow/StepCard.tsx
@@ -2,19 +2,14 @@
 import { useState } from "react";
 import type { DraggableAttributes, DraggableSyntheticListeners } from "@dnd-kit/core";
 import type {
-  Branch,
   ProcessFlow,
   Step,
   StepType,
-  DbOperation,
-  LoopKind,
-  LoopConditionMode,
 } from "../../types/action";
 import {
   STEP_TYPE_LABELS,
   STEP_TYPE_ICONS,
   STEP_TYPE_COLORS,
-  DB_OPERATION_LABELS,
   WORKFLOW_PATTERN_LABELS,
 } from "../../types/action";
 import type { ValidationError } from "../../utils/actionValidation";
@@ -24,22 +19,26 @@ import { createDefaultStep } from "../../store/processFlowStore";
 import { MaturityBadge } from "./MaturityBadge";
 import { NotesPanel } from "./NotesPanel";
 import { StepAdvancedMetadataPanel } from "./StepAdvancedMetadataPanel";
-import { ValidationRulesPanel } from "./ValidationRulesPanel";
-import { ConvCompletionInput } from "../common/ConvCompletionInput";
-import { ExternalOutcomesPanel } from "./ExternalOutcomesPanel";
-import { JumpTargetSelector } from "./JumpTargetSelector";
-import { WorkflowStepPanel } from "./WorkflowStepPanel";
-import { LogStepPanel } from "./LogStepPanel";
-import { AuditStepPanel } from "./AuditStepPanel";
-import { TransactionScopeStepPanel } from "./TransactionScopeStepPanel";
 import { AutoResizeTextarea } from "./internal/AutoResizeTextarea";
-import { InlineStepList } from "./internal/InlineStepList";
-import {
-  ALL_SUB_STEP_TYPES,
-  DB_OPS,
-  trimToUndefined,
-} from "./internal/stepCardConstants";
+import { ALL_SUB_STEP_TYPES } from "./internal/stepCardConstants";
 import { stepSummaryText } from "./internal/stepSummaryText";
+import {
+  AuditStepCardBody,
+  BranchStepCardBody,
+  CommonProcessStepCardBody,
+  ComputeStepCardBody,
+  DbAccessStepCardBody,
+  DisplayUpdateStepCardBody,
+  ExternalSystemStepCardBody,
+  JumpStepCardBody,
+  LogStepCardBody,
+  LoopStepCardBody,
+  ReturnStepCardBody,
+  ScreenTransitionStepCardBody,
+  TransactionScopeStepCardBody,
+  ValidationStepCardBody,
+  WorkflowStepCardBody,
+} from "./internal/step-cards";
 
 // ─── StepCard ────────────────────────────────────────────────────────────────
 
@@ -128,8 +127,8 @@ export function StepCard({
   const [expanded, setExpanded] = useState(defaultExpanded ?? false);
   const [showMenu, setShowMenu] = useState(false);
   const [showSubTypePicker, setShowSubTypePicker] = useState(false);
-  const [collapsedBranchIds, setCollapsedBranchIds] = useState<Set<string>>(new Set());
-  const [loopBodyCollapsed, setLoopBodyCollapsed] = useState(false);
+  // 旧 collapsedBranchIds / loopBodyCollapsed は branch / loop body sub-component 内に
+  // 内部化済 (Phase-2 #1145)。state lift する必要がある場合は本 component に戻す。
 
   const color = STEP_TYPE_COLORS[step.kind];
   const subSteps = step.subSteps ?? [];
@@ -165,67 +164,8 @@ export function StepCard({
     onCommit?.();
   };
 
-  // ── 分岐管理 (Phase 3) ──────────────────────────────────────────────────────
-
-  const toggleBranchCollapse = (branchId: string) => {
-    setCollapsedBranchIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(branchId)) next.delete(branchId);
-      else next.add(branchId);
-      return next;
-    });
-  };
-
-  const setBranchAt = (idx: number, next: Branch) => {
-    if (step.kind !== "branch") return;
-    const branches = step.branches.slice();
-    branches[idx] = next;
-    onChange({ branches } as Partial<Step>);
-  };
-
-  const moveBranchUp = (idx: number) => {
-    if (step.kind !== "branch" || idx <= 0) return;
-    const branches = step.branches.map((b) => ({ ...b }));
-    [branches[idx - 1], branches[idx]] = [branches[idx], branches[idx - 1]];
-    branches.forEach((b, i) => { b.code = String.fromCharCode(65 + i); });
-    onChange({ branches } as Partial<Step>);
-    onCommit?.();
-  };
-
-  const moveBranchDown = (idx: number) => {
-    if (step.kind !== "branch") return;
-    const branches = step.branches.map((b) => ({ ...b }));
-    if (idx >= branches.length - 1) return;
-    [branches[idx], branches[idx + 1]] = [branches[idx + 1], branches[idx]];
-    branches.forEach((b, i) => { b.code = String.fromCharCode(65 + i); });
-    onChange({ branches } as Partial<Step>);
-    onCommit?.();
-  };
-
-  const deleteBranch = (idx: number) => {
-    if (step.kind !== "branch" || step.branches.length <= 1) return;
-    const branches = step.branches.filter((_, i) => i !== idx).map((b, i) => ({
-      ...b,
-      code: String.fromCharCode(65 + i),
-    }));
-    onChange({ branches } as Partial<Step>);
-    onCommit?.();
-  };
-
-  const addBranch = () => {
-    if (step.kind !== "branch") return;
-    const code = String.fromCharCode(65 + step.branches.length);
-    const newBranch: Branch = { id: generateUUID(), code, condition: { kind: "expression", expression: "" }, steps: [] };
-    onChange({ branches: [...step.branches, newBranch] } as Partial<Step>);
-    onCommit?.();
-  };
-
-  const addElseBranch = () => {
-    if (step.kind !== "branch") return;
-    const elseBranch: Branch = { id: generateUUID(), code: "ELSE", condition: { kind: "expression", expression: "" }, steps: [] };
-    onChange({ elseBranch } as Partial<Step>);
-    onCommit?.();
-  };
+  // 旧 toggleBranchCollapse / setBranchAt / moveBranchUp/Down / deleteBranch /
+  // addBranch / addElseBranch は BranchStepCardBody (Phase-2 #1145) に移管済。
 
   // ────────────────────────────────────────────────────────────────────────────
 
@@ -622,988 +562,196 @@ export function StepCard({
             />
 
             {/* ── ステップ種別別詳細 (detail 以上で表示) ─────── */}
+            {/*
+             * Phase-2 (#1145) で 15 種の kind body を sub-component に分離。
+             * dispatch 順は元の StepCard.tsx と同一。
+             */}
             <div className="step-card-section" data-level-min="detail">
-            {/* ── バリデーション ───────────────────────────────── */}
-            {step.kind === "validation" && (
-              <>
-                <div className="row g-2 mb-2" data-field-path="conditions">
-                  <div className="col-12">
-                    <label className="form-label">バリデーション条件 (自由記述)</label>
-                    <input
-                      className="form-control form-control-sm"
-                      value={step.conditions}
-                      onChange={(e) => onChange({ conditions: e.target.value } as Partial<Step>)}
-                      onBlur={onCommit}
-                      placeholder="必須チェック、形式チェック等 (rules[] で構造化済なら補足用)"
-                    />
-                  </div>
-                </div>
-                <ValidationRulesPanel
-                  rules={step.rules}
-                  onChange={(rules) => onChange({ rules } as Partial<Step>)}
-                  conventions={conventions ?? null}
-                />
-                {step.inlineBranch && (
-                  <div className="step-inline-branch">
-                    <div className="step-branch-box ok">
-                      <div className="step-branch-label">A: OK</div>
-                      {typeof step.inlineBranch.ok === "string" ? (
-                        <input
-                          className="form-control form-control-sm"
-                          value={step.inlineBranch.ok}
-                          onChange={(e) =>
-                            onChange({ inlineBranch: { ...step.inlineBranch!, ok: e.target.value } } as Partial<Step>)
-                          }
-                          placeholder="OK時の処理"
-                          onBlur={onCommit}
-                        />
-                      ) : (
-                        <span className="form-control form-control-sm text-muted" style={{ cursor: "default" }}>
-                          ステップ {step.inlineBranch.ok.length} 件 (JSON編集)
-                        </span>
-                      )}
-                    </div>
-                    <div className="step-branch-box ng">
-                      <div className="step-branch-label">B: NG</div>
-                      {typeof step.inlineBranch.ng === "string" ? (
-                        <input
-                          className="form-control form-control-sm"
-                          value={step.inlineBranch.ng}
-                          onChange={(e) =>
-                            onChange({ inlineBranch: { ...step.inlineBranch!, ng: e.target.value } } as Partial<Step>)
-                          }
-                          placeholder="NG時の処理"
-                          onBlur={onCommit}
-                        />
-                      ) : (
-                        <span className="form-control form-control-sm text-muted" style={{ cursor: "default" }}>
-                          ステップ {step.inlineBranch.ng.length} 件 (JSON編集)
-                        </span>
-                      )}
-                    </div>
-                  </div>
-                )}
-                {step.inlineBranch && (
-                  <div className="row g-2 mb-2 mt-1" style={{ fontSize: "0.8rem" }}>
-                    <div className="col-5">
-                      <label className="form-label small mb-0">
-                        NG → responseRef
-                      </label>
-                      <input
-                        type="text"
-                        className="form-control form-control-sm"
-                        value={step.inlineBranch.ngResponseRef ?? ""}
-                        onChange={(e) =>
-                          onChange({
-                            inlineBranch: {
-                              ...step.inlineBranch!,
-                              ngResponseRef: e.target.value || undefined,
-                            },
-                          } as Partial<Step>)
-                        }
-                        onBlur={onCommit}
-                        placeholder="例: 400-validation"
-                        style={{ fontSize: "0.8rem" }}
-                      />
-                    </div>
-                    <div className="col-7">
-                      <label className="form-label small mb-0">
-                        NG bodyExpression
-                      </label>
-                      <input
-                        type="text"
-                        className="form-control form-control-sm"
-                        value={step.inlineBranch.ngBodyExpression ?? ""}
-                        onChange={(e) =>
-                          onChange({
-                            inlineBranch: {
-                              ...step.inlineBranch!,
-                              ngBodyExpression: e.target.value || undefined,
-                            },
-                          } as Partial<Step>)
-                        }
-                        onBlur={onCommit}
-                        placeholder="例: { code: 'VALIDATION', fieldErrors: @fieldErrors }"
-                        style={{ fontSize: "0.8rem", fontFamily: "monospace" }}
-                      />
-                    </div>
-                  </div>
-                )}
-              </>
-            )}
-
-            {/* ── DB操作 ──────────────────────────────────────── */}
-            {step.kind === "dbAccess" && (
-              <>
-                <div className="form-group">
-                  <label className="form-label">テーブル</label>
-                  <select
-                    className="form-select form-select-sm"
-                    value={step.tableId ?? ""}
-                    onChange={(e) => {
-                      onChange({ tableId: e.target.value || undefined } as Partial<Step>);
-                    }}
-                  >
-                    <option value="">（選択）</option>
-                    {tables.map((t) => (
-                      <option key={t.id} value={t.id}>{t.name}（{t.physicalName}）</option>
-                    ))}
-                  </select>
-                </div>
-                <div className="form-row-pair">
-                  <div className="form-group">
-                    <label className="form-label">操作</label>
-                    <select
-                      className="form-select form-select-sm"
-                      value={step.operation}
-                      onChange={(e) => onChange({ operation: e.target.value as DbOperation } as Partial<Step>)}
-                    >
-                      {DB_OPS.map((op) => (
-                        <option key={op} value={op}>{DB_OPERATION_LABELS[op]}</option>
-                      ))}
-                    </select>
-                  </div>
-                  <div className="form-group">
-                    <label className="form-label">対象フィールド</label>
-                    <input
-                      className="form-control form-control-sm"
-                      value={step.fields ?? ""}
-                      onChange={(e) => onChange({ fields: e.target.value } as Partial<Step>)}
-                      onBlur={onCommit}
-                      placeholder="概要"
-                    />
-                  </div>
-                </div>
-                <div className="form-group" data-field-path="sql">
-                  <label className="form-label">完全 SQL (sql、fields より優先)</label>
-                  <textarea
-                    className="form-control form-control-sm"
-                    rows={2}
-                    value={step.sql ?? ""}
-                    onChange={(e) => onChange({ sql: e.target.value || undefined } as Partial<Step>)}
-                    onBlur={onCommit}
-                    placeholder="例: SELECT ... JOIN ... WHERE ... / INSERT ... RETURNING ..."
-                    style={{ fontFamily: "monospace", fontSize: "0.8rem" }}
-                  />
-                </div>
-                {(step.operation === "UPDATE" || step.operation === "DELETE") && (
-                  <div className="form-group">
-                    <label className="form-label">
-                      <i className="bi bi-shield-check me-1" />
-                      影響行数チェック (affectedRowsCheck)
-                    </label>
-                    <div className="d-flex align-items-center gap-1" style={{ fontSize: "0.8rem" }}>
-                      <select
-                        className="form-select form-select-sm"
-                        value={step.affectedRowsCheck?.operator ?? ""}
-                        onChange={(e) => {
-                          if (!e.target.value) {
-                            onChange({ affectedRowsCheck: undefined } as Partial<Step>);
-                          } else {
-                            onChange({
-                              affectedRowsCheck: {
-                                operator: e.target.value as ">" | ">=" | "=" | "<" | "<=",
-                                expected: step.affectedRowsCheck?.expected ?? 0,
-                                onViolation: step.affectedRowsCheck?.onViolation ?? "throw",
-                                errorCode: step.affectedRowsCheck?.errorCode,
-                              },
-                            } as Partial<Step>);
-                          }
-                        }}
-                        style={{ width: "auto" }}
-                      >
-                        <option value="">—</option>
-                        <option value=">">&gt;</option>
-                        <option value=">=">&gt;=</option>
-                        <option value="=">=</option>
-                        <option value="<">&lt;</option>
-                        <option value="<=">&lt;=</option>
-                      </select>
-                      {step.affectedRowsCheck && (
-                        <>
-                          <input
-                            type="number"
-                            className="form-control form-control-sm"
-                            value={step.affectedRowsCheck.expected}
-                            onChange={(e) => onChange({
-                              affectedRowsCheck: {
-                                ...step.affectedRowsCheck!,
-                                expected: Number(e.target.value),
-                              },
-                            } as Partial<Step>)}
-                            onBlur={onCommit}
-                            style={{ width: 70 }}
-                          />
-                          <span className="text-muted">行→</span>
-                          <select
-                            className="form-select form-select-sm"
-                            value={step.affectedRowsCheck.onViolation}
-                            onChange={(e) => onChange({
-                              affectedRowsCheck: {
-                                ...step.affectedRowsCheck!,
-                                onViolation: e.target.value as "throw" | "abort" | "log" | "continue",
-                              },
-                            } as Partial<Step>)}
-                            style={{ width: "auto" }}
-                          >
-                            <option value="throw">throw</option>
-                            <option value="abort">abort</option>
-                            <option value="log">log</option>
-                            <option value="continue">continue</option>
-                          </select>
-                          <input
-                            type="text"
-                            className="form-control form-control-sm"
-                            value={step.affectedRowsCheck.errorCode ?? ""}
-                            onChange={(e) => onChange({
-                              affectedRowsCheck: {
-                                ...step.affectedRowsCheck!,
-                                errorCode: e.target.value || undefined,
-                              },
-                            } as Partial<Step>)}
-                            onBlur={onCommit}
-                            placeholder="errorCode (例: STOCK_SHORTAGE)"
-                            style={{ width: 200 }}
-                          />
-                        </>
-                      )}
-                    </div>
-                  </div>
-                )}
-              </>
-            )}
-
-            {/* ── 外部システム ─────────────────────────────────── */}
-            {step.kind === "externalSystem" && (
-              <>
-                <div className="form-row-pair">
-                  <div className="form-group">
-                    <label className="form-label">接続先</label>
-                    <input
-                      className="form-control form-control-sm"
-                      value={step.systemRef ?? ""}
-                      onChange={(e) => onChange({ systemRef: e.target.value } as Partial<Step>)}
-                      onBlur={onCommit}
-                      placeholder="システム名 (context.catalogs.externalSystems のキー)"
-                    />
-                  </div>
-                  <div className="form-group">
-                    <label className="form-label">プロトコル</label>
-                    <input
-                      className="form-control form-control-sm"
-                      value={step.protocol ?? ""}
-                      onChange={(e) => onChange({ protocol: e.target.value } as Partial<Step>)}
-                      onBlur={onCommit}
-                      placeholder="REST / SOAP / gRPC"
-                    />
-                  </div>
-                </div>
-                <div className="row g-2 mb-2">
-                  <div className="col-6" data-field-path="operationRef">
-                    <label className="form-label">operationRef</label>
-                    <input
-                      className="form-control form-control-sm"
-                      data-field-path="operationRef"
-                      value={step.operationRef ?? ""}
-                      onChange={(e) => onChange({ operationRef: trimToUndefined(e.target.value) } as Partial<Step>)}
-                      onBlur={onCommit}
-                      placeholder="/v1/payment_intents POST"
-                      style={{ fontFamily: "monospace" }}
-                    />
-                  </div>
-                  <div className="col-6" data-field-path="operationId">
-                    <label className="form-label">operationId</label>
-                    <input
-                      className="form-control form-control-sm"
-                      data-field-path="operationId"
-                      value={step.operationId ?? ""}
-                      onChange={(e) => onChange({ operationId: trimToUndefined(e.target.value) } as Partial<Step>)}
-                      onBlur={onCommit}
-                      placeholder="PostPaymentIntents"
-                      style={{ fontFamily: "monospace" }}
-                    />
-                  </div>
-                </div>
-                <div className="row g-2 mb-2">
-                  <div className="col-6" data-field-path="requestBodyRef">
-                    <label className="form-label">requestBodyRef</label>
-                    <input
-                      className="form-control form-control-sm"
-                      data-field-path="requestBodyRef"
-                      value={step.requestBodyRef ?? ""}
-                      onChange={(e) => onChange({ requestBodyRef: trimToUndefined(e.target.value) } as Partial<Step>)}
-                      onBlur={onCommit}
-                      placeholder="#/components/schemas/PaymentIntentCreateParams"
-                      style={{ fontFamily: "monospace" }}
-                    />
-                  </div>
-                  <div className="col-6" data-field-path="responseRef">
-                    <label className="form-label">responseRef</label>
-                    <input
-                      className="form-control form-control-sm"
-                      data-field-path="responseRef"
-                      value={step.responseRef ?? ""}
-                      onChange={(e) => onChange({ responseRef: trimToUndefined(e.target.value) } as Partial<Step>)}
-                      onBlur={onCommit}
-                      placeholder="#/components/responses/200/content/application~1json/schema"
-                      style={{ fontFamily: "monospace" }}
-                    />
-                  </div>
-                </div>
-                <div className="row g-2 mb-2 align-items-center" style={{ fontSize: "0.85rem" }}>
-                  <div className="col-auto">
-                    <label className="form-label small mb-0">タイムアウト</label>
-                  </div>
-                  <div className="col-auto">
-                    <input
-                      type="number"
-                      className="form-control form-control-sm"
-                      value={step.timeoutMs ?? ""}
-                      onChange={(e) => onChange({ timeoutMs: e.target.value ? Number(e.target.value) : undefined } as Partial<Step>)}
-                      onBlur={onCommit}
-                      placeholder="ms"
-                      style={{ width: 90 }}
-                    />
-                  </div>
-                  <div className="col-auto text-muted">ms</div>
-                  <div className="col-auto">
-                    <label className="form-check-label small">
-                      <input
-                        type="checkbox"
-                        className="form-check-input me-1"
-                        checked={!!step.fireAndForget}
-                        onChange={(e) => onChange({ fireAndForget: e.target.checked || undefined } as Partial<Step>)}
-                      />
-                      fire-and-forget (同期レスポンス待たない)
-                    </label>
-                  </div>
-                </div>
-                <div className="row g-2 mb-2 align-items-center" style={{ fontSize: "0.8rem" }}>
-                  <div className="col-auto">
-                    <label className="form-label small mb-0">リトライ</label>
-                  </div>
-                  <div className="col-auto">
-                    <input
-                      type="number"
-                      className="form-control form-control-sm"
-                      value={step.retryPolicy?.maxAttempts ?? ""}
-                      onChange={(e) => {
-                        const n = e.target.value ? Number(e.target.value) : 0;
-                        if (n <= 0) {
-                          onChange({ retryPolicy: undefined } as Partial<Step>);
-                        } else {
-                          onChange({
-                            retryPolicy: {
-                              maxAttempts: n,
-                              backoff: step.retryPolicy?.backoff,
-                              initialDelayMs: step.retryPolicy?.initialDelayMs,
-                            },
-                          } as Partial<Step>);
-                        }
-                      }}
-                      onBlur={onCommit}
-                      placeholder="maxAttempts"
-                      style={{ width: 90, fontSize: "0.8rem" }}
-                    />
-                  </div>
-                  {step.retryPolicy && (
-                    <>
-                      <div className="col-auto">
-                        <select
-                          className="form-select form-select-sm"
-                          value={step.retryPolicy.backoff ?? ""}
-                          onChange={(e) => onChange({
-                            retryPolicy: {
-                              ...step.retryPolicy!,
-                              backoff: e.target.value as "fixed" | "exponential" || undefined,
-                            },
-                          } as Partial<Step>)}
-                          style={{ width: "auto", fontSize: "0.8rem" }}
-                        >
-                          <option value="">backoff: —</option>
-                          <option value="fixed">fixed</option>
-                          <option value="exponential">exponential</option>
-                        </select>
-                      </div>
-                      <div className="col-auto">
-                        <input
-                          type="number"
-                          className="form-control form-control-sm"
-                          value={step.retryPolicy.initialDelayMs ?? ""}
-                          onChange={(e) => onChange({
-                            retryPolicy: {
-                              ...step.retryPolicy!,
-                              initialDelayMs: e.target.value ? Number(e.target.value) : undefined,
-                            },
-                          } as Partial<Step>)}
-                          onBlur={onCommit}
-                          placeholder="initialDelayMs"
-                          style={{ width: 120, fontSize: "0.8rem" }}
-                        />
-                      </div>
-                    </>
-                  )}
-                </div>
-                <ExternalOutcomesPanel
+              {step.kind === "validation" && (
+                <ValidationStepCardBody
                   step={step}
-                  onChange={(patch) => onChange(patch as Partial<Step>)}
+                  allSteps={allSteps}
+                  onChange={onChange}
                   onCommit={onCommit}
+                  conventions={conventions}
+                  readOnly={readOnly}
                 />
-              </>
-            )}
+              )}
 
-            {/* ── 共通処理 ─────────────────────────────────────── */}
-            {step.kind === "commonProcess" && (
-              <>
-                <div className="row g-2 mb-2">
-                  <div className="col-12">
-                    <label className="form-label">共通処理</label>
-                    <select
-                      className="form-select form-select-sm"
-                      value={step.refId}
-                      onChange={(e) => {
-                        const cg = commonGroups.find((g) => g.id === e.target.value);
-                        onChange({ refId: e.target.value, refName: cg?.name ?? "" } as Partial<Step>);
-                      }}
-                    >
-                      <option value="">（選択）</option>
-                      {commonGroups.map((g) => (
-                        <option key={g.id} value={g.id}>{g.name}</option>
-                      ))}
-                    </select>
-                  </div>
-                </div>
-                <div className="form-group">
-                  <label className="form-label small">
-                    <i className="bi bi-arrow-left-right me-1" />
-                    引数マッピング (argumentMapping、key=value、改行区切り)
-                  </label>
-                  <textarea
-                    className="form-control form-control-sm"
-                    rows={2}
-                    value={Object.entries(step.argumentMapping ?? {}).map(([k, v]) => `${k}=${v}`).join("\n")}
-                    onChange={(e) => {
-                      const lines = e.target.value.split("\n").map((l) => l.trim()).filter(Boolean);
-                      const map: Record<string, string> = {};
-                      for (const line of lines) {
-                        const eq = line.indexOf("=");
-                        if (eq > 0) {
-                          map[line.slice(0, eq).trim()] = line.slice(eq + 1).trim();
-                        }
-                      }
-                      onChange({
-                        argumentMapping: Object.keys(map).length > 0 ? map : undefined,
-                      } as Partial<Step>);
-                    }}
-                    onBlur={onCommit}
-                    placeholder={"sessionId=@session.id\ntrustedLevel='high'"}
-                    style={{ fontFamily: "monospace", fontSize: "0.8rem" }}
-                  />
-                </div>
-              </>
-            )}
+              {step.kind === "dbAccess" && (
+                <DbAccessStepCardBody
+                  step={step}
+                  allSteps={allSteps}
+                  tables={tables}
+                  onChange={onChange}
+                  onCommit={onCommit}
+                  readOnly={readOnly}
+                />
+              )}
 
-            {/* ── 計算ステップ (ComputeStep) ───────────────────── */}
-            {step.kind === "compute" && (
-              <div className="row g-2 mb-2" data-field-path="expression">
-                <div className="col-12">
-                  <label className="form-label">
-                    <i className="bi bi-calculator me-1" />
-                    代入式 (expression)
-                  </label>
-                  <ConvCompletionInput
-                    className="form-control form-control-sm"
-                    value={step.expression}
-                    onValueChange={(v) => onChange({ expression: v } as Partial<Step>)}
-                    onCommit={onCommit}
-                    conventions={conventions ?? null}
-                    placeholder="例: Math.floor(@subtotal * 0.10) / @subtotal + @taxAmount"
-                    style={{ fontFamily: "monospace" }}
-                  />
-                </div>
-              </div>
-            )}
+              {step.kind === "externalSystem" && (
+                <ExternalSystemStepCardBody
+                  step={step}
+                  allSteps={allSteps}
+                  onChange={onChange}
+                  onCommit={onCommit}
+                  readOnly={readOnly}
+                />
+              )}
 
-            {/* ── 返却ステップ (ReturnStep) ────────────────────── */}
-            {step.kind === "return" && (
-              <>
-                <div className="row g-2 mb-2">
-                  <div className="col-6">
-                    <label className="form-label">
-                      <i className="bi bi-reply me-1" />
-                      responseRef (action.responses[].id)
-                    </label>
-                    <input
-                      type="text"
-                      className="form-control form-control-sm"
-                      value={step.responseRef ?? ""}
-                      onChange={(e) => onChange({ responseRef: e.target.value || undefined } as Partial<Step>)}
-                      onBlur={onCommit}
-                      placeholder="例: 409-stock-shortage"
-                    />
-                  </div>
-                  <div className="col-6" data-field-path="bodyExpression">
-                    <label className="form-label">bodyExpression</label>
-                    <ConvCompletionInput
-                      className="form-control form-control-sm"
-                      value={step.bodyExpression ?? ""}
-                      onValueChange={(v) => onChange({ bodyExpression: v || undefined } as Partial<Step>)}
-                      onCommit={onCommit}
-                      conventions={conventions ?? null}
-                      placeholder="例: { code: 'STOCK_SHORTAGE', detail: @shortageList }"
-                      style={{ fontFamily: "monospace" }}
-                    />
-                  </div>
-                </div>
-              </>
-            )}
+              {step.kind === "commonProcess" && (
+                <CommonProcessStepCardBody
+                  step={step}
+                  allSteps={allSteps}
+                  commonGroups={commonGroups}
+                  onChange={onChange}
+                  onCommit={onCommit}
+                  readOnly={readOnly}
+                />
+              )}
 
-            {/* ── 画面遷移 ─────────────────────────────────────── */}
-            {step.kind === "screenTransition" && (
-              <div className="row g-2 mb-2">
-                <div className="col-12">
-                  <label className="form-label">遷移先画面</label>
-                  <select
-                    className="form-select form-select-sm"
-                    value={step.targetScreenId ?? ""}
-                    onChange={(e) => {
-                      const s = screens.find((s) => s.id === e.target.value);
-                      onChange({ targetScreenId: e.target.value, targetScreenName: s?.name ?? e.target.value } as Partial<Step>);
-                    }}
-                  >
-                    <option value="">（選択または手入力）</option>
-                    {screens.map((s) => (
-                      <option key={s.id} value={s.id}>{s.name}</option>
-                    ))}
-                  </select>
-                  <input
-                    className="form-control form-control-sm mt-1"
-                    value={step.targetScreenName}
-                    onChange={(e) => onChange({ targetScreenName: e.target.value } as Partial<Step>)}
-                    onBlur={onCommit}
-                    placeholder="画面名を直接入力"
-                  />
-                </div>
-              </div>
-            )}
+              {step.kind === "compute" && (
+                <ComputeStepCardBody
+                  step={step}
+                  allSteps={allSteps}
+                  onChange={onChange}
+                  onCommit={onCommit}
+                  conventions={conventions}
+                  readOnly={readOnly}
+                />
+              )}
 
-            {/* ── 表示更新 ─────────────────────────────────────── */}
-            {step.kind === "displayUpdate" && (
-              <div className="row g-2 mb-2">
-                <div className="col-12">
-                  <label className="form-label">更新対象</label>
-                  <input
-                    className="form-control form-control-sm"
-                    value={step.target}
-                    onChange={(e) => onChange({ target: e.target.value } as Partial<Step>)}
-                    onBlur={onCommit}
-                    placeholder="メッセージ表示、一覧テーブル更新 等"
-                  />
-                </div>
-              </div>
-            )}
+              {step.kind === "return" && (
+                <ReturnStepCardBody
+                  step={step}
+                  allSteps={allSteps}
+                  onChange={onChange}
+                  onCommit={onCommit}
+                  conventions={conventions}
+                  readOnly={readOnly}
+                />
+              )}
 
-            {/* ── 条件分岐 (Phase 3) ───────────────────────────── */}
-            {step.kind === "branch" && (
-              <div className="branch-sections">
-                {step.branches.map((br, bi) => {
-                  const isCollapsed = collapsedBranchIds.has(br.id);
-                  return (
-                    <div key={br.id} className={`branch-section${isCollapsed ? " collapsed" : ""}`}>
-                      <div
-                        className="branch-section-header"
-                        onClick={() => toggleBranchCollapse(br.id)}
-                      >
-                        <span className="branch-code-badge">{br.code}</span>
-                        {br.condition?.kind === "tryCatch" ? (
-                          <div className="d-flex align-items-center gap-1 flex-grow-1" onClick={(e) => e.stopPropagation()}>
-                            <span className="badge bg-info text-dark" style={{ fontSize: "0.7rem" }}>tryCatch</span>
-                            <input
-                              className="form-control form-control-sm"
-                              value={br.condition.errorCode}
-                              placeholder="errorCode (例: STOCK_SHORTAGE)"
-                              onChange={(e) => setBranchAt(bi, {
-                                ...br,
-                                condition: { ...br.condition, errorCode: e.target.value },
-                              })}
-                              onBlur={onCommit}
-                            />
-                            <button
-                              type="button"
-                              className="btn btn-sm btn-link text-muted p-0"
-                              title="自由記述に戻す"
-                              onClick={() => setBranchAt(bi, { ...br, condition: { kind: "expression", expression: "" } })}
-                            >
-                              <i className="bi bi-arrow-counterclockwise" />
-                            </button>
-                          </div>
-                        ) : br.condition?.kind === "expression" ? (
-                          <>
-                            <input
-                              className="form-control form-control-sm branch-condition-input"
-                              value={br.condition.expression}
-                              placeholder="分岐条件 (自由記述)"
-                              onClick={(e) => e.stopPropagation()}
-                              onChange={(e) => setBranchAt(bi, { ...br, condition: { kind: "expression", expression: e.target.value } })}
-                              onBlur={onCommit}
-                            />
-                            <button
-                              type="button"
-                              className="btn btn-sm btn-link text-muted p-0"
-                              title="tryCatch variant に切替"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                setBranchAt(bi, {
-                                  ...br,
-                                  condition: { kind: "tryCatch", errorCode: "" },
-                                });
-                              }}
-                              style={{ flexShrink: 0 }}
-                            >
-                              <i className="bi bi-shield-exclamation" />
-                            </button>
-                          </>
-                        ) : (
-                          // affectedRowsZero / externalOutcome 等の専用 UI 未対応 kind
-                          // 現状は kind 名 + 「expression に戻す」ボタンのみ提供 (#954)
-                          <div className="d-flex align-items-center gap-1 flex-grow-1" onClick={(e) => e.stopPropagation()}>
-                            <span className="badge bg-secondary text-white" style={{ fontSize: "0.7rem" }}>{br.condition?.kind ?? "(unknown)"}</span>
-                            <span className="text-muted small">専用 UI 未対応 — JSON で編集してください</span>
-                            <button
-                              type="button"
-                              className="btn btn-sm btn-link text-muted p-0"
-                              title="expression に戻す"
-                              onClick={() => setBranchAt(bi, { ...br, condition: { kind: "expression", expression: "" } })}
-                            >
-                              <i className="bi bi-arrow-counterclockwise" />
-                            </button>
-                          </div>
-                        )}
-                        {!readOnly && bi > 0 && (
-                          <button
-                            className="step-card-menu-btn"
-                            title="上に移動"
-                            onClick={(e) => { e.stopPropagation(); moveBranchUp(bi); }}
-                          >
-                            <i className="bi bi-chevron-up" />
-                          </button>
-                        )}
-                        {!readOnly && bi < step.branches.length - 1 && (
-                          <button
-                            className="step-card-menu-btn"
-                            title="下に移動"
-                            onClick={(e) => { e.stopPropagation(); moveBranchDown(bi); }}
-                          >
-                            <i className="bi bi-chevron-down" />
-                          </button>
-                        )}
-                        {!readOnly && step.branches.length > 1 && (
-                          <button
-                            className="step-card-menu-btn danger"
-                            title="分岐を削除"
-                            onClick={(e) => { e.stopPropagation(); deleteBranch(bi); }}
-                          >
-                            <i className="bi bi-trash" />
-                          </button>
-                        )}
-                        <i
-                          className={`bi bi-chevron-${isCollapsed ? "right" : "down"}`}
-                          style={{ color: "#94a3b8", flexShrink: 0 }}
-                        />
-                      </div>
-                      {!isCollapsed && (
-                        <div className="branch-section-body">
-                          <InlineStepList
-                            steps={br.steps}
-                            parentLabel={br.code}
-                            allSteps={allSteps}
-                            tables={tables}
-                            screens={screens}
-                            commonGroups={commonGroups}
-                            onChange={(newSteps) => setBranchAt(bi, { ...br, steps: newSteps })}
-                            onCommit={onCommit}
-                            onNavigateCommon={onNavigateCommon}
-                            validationErrors={validationErrors}
-                            conventions={conventions}
-                            group={group}
-                            readOnly={readOnly}
-                          />
-                        </div>
-                      )}
-                    </div>
-                  );
-                })}
+              {step.kind === "screenTransition" && (
+                <ScreenTransitionStepCardBody
+                  step={step}
+                  allSteps={allSteps}
+                  screens={screens}
+                  onChange={onChange}
+                  onCommit={onCommit}
+                  readOnly={readOnly}
+                />
+              )}
 
-                {/* ELSE分岐 */}
-                {step.elseBranch && (() => {
-                  const el = step.elseBranch;
-                  const isCollapsed = collapsedBranchIds.has(el.id);
-                  return (
-                    <div className={`branch-section else${isCollapsed ? " collapsed" : ""}`}>
-                      <div
-                        className="branch-section-header"
-                        onClick={() => toggleBranchCollapse(el.id)}
-                      >
-                        <span className="branch-code-badge">ELSE</span>
-                        <span style={{ flex: 1, fontSize: "0.78rem", color: "#64748b" }}>
-                          その他の場合
-                        </span>
-                        {!readOnly && <button
-                          className="step-card-menu-btn danger"
-                          title="ELSE分岐を削除"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            onChange({ elseBranch: undefined } as Partial<Step>);
-                            onCommit?.();
-                          }}
-                        >
-                          <i className="bi bi-trash" />
-                        </button>}
-                        <i
-                          className={`bi bi-chevron-${isCollapsed ? "right" : "down"}`}
-                          style={{ color: "#94a3b8", flexShrink: 0 }}
-                        />
-                      </div>
-                      {!isCollapsed && (
-                        <div className="branch-section-body">
-                          <InlineStepList
-                            steps={el.steps}
-                            parentLabel="ELSE"
-                            allSteps={allSteps}
-                            tables={tables}
-                            screens={screens}
-                            commonGroups={commonGroups}
-                            onChange={(newSteps) =>
-                              onChange({ elseBranch: { ...el, steps: newSteps } } as Partial<Step>)
-                            }
-                            onCommit={onCommit}
-                            onNavigateCommon={onNavigateCommon}
-                            validationErrors={validationErrors}
-                            conventions={conventions}
-                            group={group}
-                            readOnly={readOnly}
-                          />
-                        </div>
-                      )}
-                    </div>
-                  );
-                })()}
+              {step.kind === "displayUpdate" && (
+                <DisplayUpdateStepCardBody
+                  step={step}
+                  allSteps={allSteps}
+                  onChange={onChange}
+                  onCommit={onCommit}
+                  readOnly={readOnly}
+                />
+              )}
 
-                {!readOnly && <div className="branch-add-row">
-                  <button className="branch-add-btn" onClick={addBranch}>
-                    <i className="bi bi-plus" /> 分岐を追加
-                  </button>
-                  {!step.elseBranch && (
-                    <button className="branch-add-btn" onClick={addElseBranch} style={{ flex: "0 0 auto" }}>
-                      <i className="bi bi-plus" /> ELSE分岐
-                    </button>
-                  )}
-                </div>}
-              </div>
-            )}
+              {step.kind === "branch" && (
+                <BranchStepCardBody
+                  step={step}
+                  allSteps={allSteps}
+                  tables={tables}
+                  screens={screens}
+                  commonGroups={commonGroups}
+                  validationErrors={validationErrors}
+                  conventions={conventions}
+                  group={group}
+                  onChange={onChange}
+                  onCommit={onCommit}
+                  onNavigateCommon={onNavigateCommon}
+                  readOnly={readOnly}
+                />
+              )}
 
-            {/* ── ループ (Phase 4) ─────────────────────────────── */}
-            {step.kind === "loop" && (
-              <div>
-                <div className="loop-kind-radios">
-                  {(["count", "condition", "collection"] as LoopKind[]).map((k) => (
-                    <label key={k}>
-                      <input
-                        type="radio"
-                        name={`loopkind-${step.id}`}
-                        value={k}
-                        checked={step.loopKind === k}
-                        onChange={() => onChange({ loopKind: k } as Partial<Step>)}
-                      />
-                      {k === "count" ? "回数" : k === "condition" ? "条件" : "コレクション"}
-                    </label>
-                  ))}
-                </div>
+              {step.kind === "loop" && (
+                <LoopStepCardBody
+                  step={step}
+                  allSteps={allSteps}
+                  tables={tables}
+                  screens={screens}
+                  commonGroups={commonGroups}
+                  validationErrors={validationErrors}
+                  conventions={conventions}
+                  group={group}
+                  onChange={onChange}
+                  onCommit={onCommit}
+                  onNavigateCommon={onNavigateCommon}
+                  readOnly={readOnly}
+                />
+              )}
 
-                {step.loopKind === "count" && (
-                  <div className="form-group">
-                    <label className="form-label">回数 / 範囲</label>
-                    <input
-                      className="form-control form-control-sm"
-                      value={step.countExpression ?? ""}
-                      onChange={(e) => onChange({ countExpression: e.target.value } as Partial<Step>)}
-                      onBlur={onCommit}
-                      placeholder="例: 3回, 検索結果の件数分"
-                    />
-                  </div>
-                )}
+              {step.kind === "log" && (
+                <LogStepCardBody
+                  step={step}
+                  allSteps={allSteps}
+                  onChange={onChange}
+                  onCommit={onCommit}
+                  conventions={conventions}
+                  readOnly={readOnly}
+                />
+              )}
 
-                {step.loopKind === "condition" && (
-                  <>
-                    <div className="form-group mb-2">
-                      <label className="form-label">条件モード</label>
-                      <div className="d-flex gap-3 flex-wrap">
-                        {(["continue", "exit"] as LoopConditionMode[]).map((m) => (
-                          <label key={m} style={{ display: "flex", alignItems: "center", gap: 4, fontSize: "0.82rem", cursor: "pointer" }}>
-                            <input
-                              type="radio"
-                              name={`condmode-${step.id}`}
-                              value={m}
-                              checked={(step.conditionMode ?? "exit") === m}
-                              onChange={() => onChange({ conditionMode: m } as Partial<Step>)}
-                            />
-                            {m === "continue" ? "条件の間繰り返す (while)" : "条件になるまで繰り返す (until)"}
-                          </label>
-                        ))}
-                      </div>
-                    </div>
-                    <div className="form-group">
-                      <label className="form-label">条件式</label>
-                      <input
-                        className="form-control form-control-sm"
-                        value={step.conditionExpression ?? ""}
-                        onChange={(e) => onChange({ conditionExpression: e.target.value } as Partial<Step>)}
-                        onBlur={onCommit}
-                        placeholder="例: 残件数 > 0"
-                      />
-                    </div>
-                  </>
-                )}
+              {step.kind === "audit" && (
+                <AuditStepCardBody
+                  step={step}
+                  allSteps={allSteps}
+                  onChange={onChange}
+                  onCommit={onCommit}
+                  conventions={conventions}
+                  readOnly={readOnly}
+                />
+              )}
 
-                {step.loopKind === "collection" && (
-                  <div className="form-row-pair">
-                    <div className="form-group">
-                      <label className="form-label">コレクション</label>
-                      <input
-                        className="form-control form-control-sm"
-                        value={step.collectionSource ?? ""}
-                        onChange={(e) => onChange({ collectionSource: e.target.value } as Partial<Step>)}
-                        onBlur={onCommit}
-                        placeholder="例: 検索結果"
-                      />
-                    </div>
-                    <div className="form-group">
-                      <label className="form-label">要素変数名</label>
-                      <input
-                        className="form-control form-control-sm"
-                        value={step.collectionItemName ?? ""}
-                        onChange={(e) => onChange({ collectionItemName: e.target.value } as Partial<Step>)}
-                        onBlur={onCommit}
-                        placeholder="例: ユーザー"
-                      />
-                    </div>
-                  </div>
-                )}
+              {step.kind === "transactionScope" && (
+                <TransactionScopeStepCardBody
+                  step={step}
+                  allSteps={allSteps}
+                  tables={tables}
+                  screens={screens}
+                  commonGroups={commonGroups}
+                  validationErrors={validationErrors}
+                  conventions={conventions}
+                  group={group}
+                  onChange={onChange}
+                  onCommit={onCommit}
+                  onNavigateCommon={onNavigateCommon}
+                  readOnly={readOnly}
+                />
+              )}
 
-                <div className={`loop-body${loopBodyCollapsed ? " collapsed" : ""}`}>
-                  <div
-                    className="loop-body-header"
-                    onClick={() => setLoopBodyCollapsed(!loopBodyCollapsed)}
-                  >
-                    <i className="bi bi-arrow-repeat" />
-                    ループ本体
-                    <i
-                      className={`bi bi-chevron-${loopBodyCollapsed ? "right" : "down"} ms-auto`}
-                      style={{ color: "#94a3b8" }}
-                    />
-                  </div>
-                  {!loopBodyCollapsed && (
-                    <div className="loop-body-content">
-                      <InlineStepList
-                        steps={step.steps}
-                        parentLabel="L"
-                        allSteps={allSteps}
-                        tables={tables}
-                        screens={screens}
-                        commonGroups={commonGroups}
-                        onChange={(newSteps) => onChange({ steps: newSteps } as Partial<Step>)}
-                        onCommit={onCommit}
-                        onNavigateCommon={onNavigateCommon}
-                        validationErrors={validationErrors}
-                        conventions={conventions}
-                        group={group}
-                        readOnly={readOnly}
-                      />
-                    </div>
-                  )}
-                </div>
-              </div>
-            )}
+              {step.kind === "jump" && (
+                <JumpStepCardBody
+                  step={step}
+                  allSteps={allSteps}
+                  onChange={onChange}
+                  onCommit={onCommit}
+                  readOnly={readOnly}
+                />
+              )}
 
-            {/* ── ログ出力 (#402) ──────────────────────────────── */}
-            {step.kind === "log" && (
-              <LogStepPanel
-                step={step}
-                onChange={(patch) => onChange(patch as Partial<Step>)}
-                onCommit={onCommit}
-                conventions={conventions ?? null}
-              />
-            )}
-
-            {/* ── 監査ログ (#402) ──────────────────────────────── */}
-            {step.kind === "audit" && (
-              <AuditStepPanel
-                step={step}
-                onChange={(patch) => onChange(patch as Partial<Step>)}
-                onCommit={onCommit}
-                conventions={conventions ?? null}
-              />
-            )}
-
-            {/* ── TX スコープ (#415) ────────────────────────────── */}
-            {step.kind === "transactionScope" && (
-              <TransactionScopeStepPanel
-                step={step}
-                onChange={(patch) => onChange(patch as Partial<Step>)}
-                onCommit={onCommit}
-                group={group}
-                allSteps={allSteps}
-                tables={tables}
-                screens={screens}
-                commonGroups={commonGroups}
-                validationErrors={validationErrors}
-                conventions={conventions ?? null}
-                onNavigateCommon={onNavigateCommon}
-              />
-            )}
-
-            {/* ── ジャンプ (Phase 5) ───────────────────────────── */}
-            {step.kind === "jump" && (
-              <div className="row g-2 mb-2">
-                <div className="col-12">
-                  <label className="form-label">ジャンプ先</label>
-                  <JumpTargetSelector
-                    value={step.jumpTo}
-                    allSteps={allSteps}
-                    excludeStepId={step.id}
-                    onChange={(val) => onChange({ jumpTo: val } as Partial<Step>)}
-                    onBlur={onCommit}
-                  />
-                </div>
-              </div>
-            )}
-
-            {step.kind === "workflow" && (
-              <WorkflowStepPanel
-                step={step}
-                allSteps={allSteps}
-                conventions={conventions ?? null}
-                onChange={(patch) => onChange(patch as Partial<Step>)}
-                onCommit={onCommit}
-                renderInlineStepList={({ steps, parentLabel, onChange: onStepsChange }) => (
-                  <InlineStepList
-                    steps={steps}
-                    parentLabel={parentLabel}
-                    allSteps={allSteps}
-                    tables={tables}
-                    screens={screens}
-                    commonGroups={commonGroups}
-                    onChange={onStepsChange}
-                    onCommit={onCommit}
-                    onNavigateCommon={onNavigateCommon}
-                    validationErrors={validationErrors}
-                    conventions={conventions}
-                    readOnly={readOnly}
-                  />
-                )}
-              />
-            )}
-
+              {step.kind === "workflow" && (
+                <WorkflowStepCardBody
+                  step={step}
+                  allSteps={allSteps}
+                  tables={tables}
+                  screens={screens}
+                  commonGroups={commonGroups}
+                  validationErrors={validationErrors}
+                  conventions={conventions}
+                  group={group}
+                  onChange={onChange}
+                  onCommit={onCommit}
+                  onNavigateCommon={onNavigateCommon}
+                  readOnly={readOnly}
+                />
+              )}
             </div>{/* end step-card-section data-level-min="detail" */}
 
             <div className="row g-2">

--- a/frontend/src/components/process-flow/internal/step-cards/AuditStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/AuditStepCardBody.tsx
@@ -1,0 +1,29 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+// Phase-2 (#1145): StepCard.tsx の `step.kind === "audit"` body を抽出 (#402)。
+
+import type { Step } from "../../../../types/action";
+import { AuditStepPanel } from "../../AuditStepPanel";
+import type {
+  StepCardBodyBaseProps,
+  StepCardBodyCatalogProps,
+} from "./types";
+
+export interface AuditStepCardBodyProps
+  extends StepCardBodyBaseProps,
+    Pick<StepCardBodyCatalogProps, "conventions"> {}
+
+export function AuditStepCardBody({
+  step,
+  onChange,
+  onCommit,
+  conventions,
+}: AuditStepCardBodyProps) {
+  return (
+    <AuditStepPanel
+      step={step}
+      onChange={(patch) => onChange(patch as Partial<Step>)}
+      onCommit={onCommit}
+      conventions={conventions ?? null}
+    />
+  );
+}

--- a/frontend/src/components/process-flow/internal/step-cards/BranchStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/BranchStepCardBody.tsx
@@ -1,0 +1,298 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+// Phase-2 (#1145): StepCard.tsx の `step.kind === "branch"` body を抽出 (Phase 3 ロジック含む)。
+//
+// `collapsedBranchIds` は branch body 専用の純粋 UI state のため、parent (StepCard) から
+// 切り離して本 sub-component 内に閉じ込めた。branch handler (setBranchAt / moveBranchUp/Down /
+// deleteBranch / addBranch / addElseBranch / toggleBranchCollapse) も同様に内部化。
+
+import { useState } from "react";
+import type { Branch, Step } from "../../../../types/action";
+import { generateUUID } from "../../../../utils/uuid";
+import { InlineStepList } from "../InlineStepList";
+import type {
+  StepCardBodyBaseProps,
+  StepCardBodyCatalogProps,
+  StepCardBodyTableProps,
+  StepCardBodyScreenProps,
+  StepCardBodyCommonGroupsProps,
+  StepCardBodyNavigationProps,
+} from "./types";
+
+export interface BranchStepCardBodyProps
+  extends StepCardBodyBaseProps,
+    StepCardBodyCatalogProps,
+    StepCardBodyTableProps,
+    StepCardBodyScreenProps,
+    StepCardBodyCommonGroupsProps,
+    StepCardBodyNavigationProps {}
+
+export function BranchStepCardBody({
+  step,
+  allSteps,
+  tables,
+  screens,
+  commonGroups,
+  validationErrors,
+  conventions,
+  group,
+  onChange,
+  onCommit,
+  onNavigateCommon,
+  readOnly,
+}: BranchStepCardBodyProps) {
+  const [collapsedBranchIds, setCollapsedBranchIds] = useState<Set<string>>(new Set());
+
+  const toggleBranchCollapse = (branchId: string) => {
+    setCollapsedBranchIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(branchId)) next.delete(branchId);
+      else next.add(branchId);
+      return next;
+    });
+  };
+
+  const setBranchAt = (idx: number, next: Branch) => {
+    const branches = step.branches.slice();
+    branches[idx] = next;
+    onChange({ branches } as Partial<Step>);
+  };
+
+  const moveBranchUp = (idx: number) => {
+    if (idx <= 0) return;
+    const branches = step.branches.map((b) => ({ ...b }));
+    [branches[idx - 1], branches[idx]] = [branches[idx], branches[idx - 1]];
+    branches.forEach((b, i) => { b.code = String.fromCharCode(65 + i); });
+    onChange({ branches } as Partial<Step>);
+    onCommit?.();
+  };
+
+  const moveBranchDown = (idx: number) => {
+    const branches = step.branches.map((b) => ({ ...b }));
+    if (idx >= branches.length - 1) return;
+    [branches[idx], branches[idx + 1]] = [branches[idx + 1], branches[idx]];
+    branches.forEach((b, i) => { b.code = String.fromCharCode(65 + i); });
+    onChange({ branches } as Partial<Step>);
+    onCommit?.();
+  };
+
+  const deleteBranch = (idx: number) => {
+    if (step.branches.length <= 1) return;
+    const branches = step.branches.filter((_, i) => i !== idx).map((b, i) => ({
+      ...b,
+      code: String.fromCharCode(65 + i),
+    }));
+    onChange({ branches } as Partial<Step>);
+    onCommit?.();
+  };
+
+  const addBranch = () => {
+    const code = String.fromCharCode(65 + step.branches.length);
+    const newBranch: Branch = { id: generateUUID(), code, condition: { kind: "expression", expression: "" }, steps: [] };
+    onChange({ branches: [...step.branches, newBranch] } as Partial<Step>);
+    onCommit?.();
+  };
+
+  const addElseBranch = () => {
+    const elseBranch: Branch = { id: generateUUID(), code: "ELSE", condition: { kind: "expression", expression: "" }, steps: [] };
+    onChange({ elseBranch } as Partial<Step>);
+    onCommit?.();
+  };
+
+  return (
+    <div className="branch-sections">
+      {step.branches.map((br, bi) => {
+        const isCollapsed = collapsedBranchIds.has(br.id);
+        return (
+          <div key={br.id} className={`branch-section${isCollapsed ? " collapsed" : ""}`}>
+            <div
+              className="branch-section-header"
+              onClick={() => toggleBranchCollapse(br.id)}
+            >
+              <span className="branch-code-badge">{br.code}</span>
+              {br.condition?.kind === "tryCatch" ? (
+                <div className="d-flex align-items-center gap-1 flex-grow-1" onClick={(e) => e.stopPropagation()}>
+                  <span className="badge bg-info text-dark" style={{ fontSize: "0.7rem" }}>tryCatch</span>
+                  <input
+                    className="form-control form-control-sm"
+                    value={br.condition.errorCode}
+                    placeholder="errorCode (例: STOCK_SHORTAGE)"
+                    onChange={(e) => setBranchAt(bi, {
+                      ...br,
+                      condition: { ...br.condition, errorCode: e.target.value },
+                    })}
+                    onBlur={onCommit}
+                  />
+                  <button
+                    type="button"
+                    className="btn btn-sm btn-link text-muted p-0"
+                    title="自由記述に戻す"
+                    onClick={() => setBranchAt(bi, { ...br, condition: { kind: "expression", expression: "" } })}
+                  >
+                    <i className="bi bi-arrow-counterclockwise" />
+                  </button>
+                </div>
+              ) : br.condition?.kind === "expression" ? (
+                <>
+                  <input
+                    className="form-control form-control-sm branch-condition-input"
+                    value={br.condition.expression}
+                    placeholder="分岐条件 (自由記述)"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => setBranchAt(bi, { ...br, condition: { kind: "expression", expression: e.target.value } })}
+                    onBlur={onCommit}
+                  />
+                  <button
+                    type="button"
+                    className="btn btn-sm btn-link text-muted p-0"
+                    title="tryCatch variant に切替"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setBranchAt(bi, {
+                        ...br,
+                        condition: { kind: "tryCatch", errorCode: "" },
+                      });
+                    }}
+                    style={{ flexShrink: 0 }}
+                  >
+                    <i className="bi bi-shield-exclamation" />
+                  </button>
+                </>
+              ) : (
+                // affectedRowsZero / externalOutcome 等の専用 UI 未対応 kind
+                // 現状は kind 名 + 「expression に戻す」ボタンのみ提供 (#954)
+                <div className="d-flex align-items-center gap-1 flex-grow-1" onClick={(e) => e.stopPropagation()}>
+                  <span className="badge bg-secondary text-white" style={{ fontSize: "0.7rem" }}>{br.condition?.kind ?? "(unknown)"}</span>
+                  <span className="text-muted small">専用 UI 未対応 — JSON で編集してください</span>
+                  <button
+                    type="button"
+                    className="btn btn-sm btn-link text-muted p-0"
+                    title="expression に戻す"
+                    onClick={() => setBranchAt(bi, { ...br, condition: { kind: "expression", expression: "" } })}
+                  >
+                    <i className="bi bi-arrow-counterclockwise" />
+                  </button>
+                </div>
+              )}
+              {!readOnly && bi > 0 && (
+                <button
+                  className="step-card-menu-btn"
+                  title="上に移動"
+                  onClick={(e) => { e.stopPropagation(); moveBranchUp(bi); }}
+                >
+                  <i className="bi bi-chevron-up" />
+                </button>
+              )}
+              {!readOnly && bi < step.branches.length - 1 && (
+                <button
+                  className="step-card-menu-btn"
+                  title="下に移動"
+                  onClick={(e) => { e.stopPropagation(); moveBranchDown(bi); }}
+                >
+                  <i className="bi bi-chevron-down" />
+                </button>
+              )}
+              {!readOnly && step.branches.length > 1 && (
+                <button
+                  className="step-card-menu-btn danger"
+                  title="分岐を削除"
+                  onClick={(e) => { e.stopPropagation(); deleteBranch(bi); }}
+                >
+                  <i className="bi bi-trash" />
+                </button>
+              )}
+              <i
+                className={`bi bi-chevron-${isCollapsed ? "right" : "down"}`}
+                style={{ color: "#94a3b8", flexShrink: 0 }}
+              />
+            </div>
+            {!isCollapsed && (
+              <div className="branch-section-body">
+                <InlineStepList
+                  steps={br.steps}
+                  parentLabel={br.code}
+                  allSteps={allSteps}
+                  tables={tables}
+                  screens={screens}
+                  commonGroups={commonGroups}
+                  onChange={(newSteps) => setBranchAt(bi, { ...br, steps: newSteps })}
+                  onCommit={onCommit}
+                  onNavigateCommon={onNavigateCommon}
+                  validationErrors={validationErrors}
+                  conventions={conventions}
+                  group={group}
+                  readOnly={readOnly}
+                />
+              </div>
+            )}
+          </div>
+        );
+      })}
+
+      {/* ELSE分岐 */}
+      {step.elseBranch && (() => {
+        const el = step.elseBranch;
+        const isCollapsed = collapsedBranchIds.has(el.id);
+        return (
+          <div className={`branch-section else${isCollapsed ? " collapsed" : ""}`}>
+            <div
+              className="branch-section-header"
+              onClick={() => toggleBranchCollapse(el.id)}
+            >
+              <span className="branch-code-badge">ELSE</span>
+              <span style={{ flex: 1, fontSize: "0.78rem", color: "#64748b" }}>
+                その他の場合
+              </span>
+              {!readOnly && <button
+                className="step-card-menu-btn danger"
+                title="ELSE分岐を削除"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onChange({ elseBranch: undefined } as Partial<Step>);
+                  onCommit?.();
+                }}
+              >
+                <i className="bi bi-trash" />
+              </button>}
+              <i
+                className={`bi bi-chevron-${isCollapsed ? "right" : "down"}`}
+                style={{ color: "#94a3b8", flexShrink: 0 }}
+              />
+            </div>
+            {!isCollapsed && (
+              <div className="branch-section-body">
+                <InlineStepList
+                  steps={el.steps}
+                  parentLabel="ELSE"
+                  allSteps={allSteps}
+                  tables={tables}
+                  screens={screens}
+                  commonGroups={commonGroups}
+                  onChange={(newSteps) =>
+                    onChange({ elseBranch: { ...el, steps: newSteps } } as Partial<Step>)
+                  }
+                  onCommit={onCommit}
+                  onNavigateCommon={onNavigateCommon}
+                  validationErrors={validationErrors}
+                  conventions={conventions}
+                  group={group}
+                  readOnly={readOnly}
+                />
+              </div>
+            )}
+          </div>
+        );
+      })()}
+
+      {!readOnly && <div className="branch-add-row">
+        <button className="branch-add-btn" onClick={addBranch}>
+          <i className="bi bi-plus" /> 分岐を追加
+        </button>
+        {!step.elseBranch && (
+          <button className="branch-add-btn" onClick={addElseBranch} style={{ flex: "0 0 auto" }}>
+            <i className="bi bi-plus" /> ELSE分岐
+          </button>
+        )}
+      </div>}
+    </div>
+  );
+}

--- a/frontend/src/components/process-flow/internal/step-cards/CommonProcessStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/CommonProcessStepCardBody.tsx
@@ -1,0 +1,69 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+// Phase-2 (#1145): StepCard.tsx の `step.kind === "commonProcess"` body を抽出。
+
+import type { Step } from "../../../../types/action";
+import type {
+  StepCardBodyBaseProps,
+  StepCardBodyCommonGroupsProps,
+} from "./types";
+
+export interface CommonProcessStepCardBodyProps
+  extends StepCardBodyBaseProps,
+    StepCardBodyCommonGroupsProps {}
+
+export function CommonProcessStepCardBody({
+  step,
+  commonGroups,
+  onChange,
+  onCommit,
+}: CommonProcessStepCardBodyProps) {
+  return (
+    <>
+      <div className="row g-2 mb-2">
+        <div className="col-12">
+          <label className="form-label">共通処理</label>
+          <select
+            className="form-select form-select-sm"
+            value={step.refId}
+            onChange={(e) => {
+              const cg = commonGroups.find((g) => g.id === e.target.value);
+              onChange({ refId: e.target.value, refName: cg?.name ?? "" } as Partial<Step>);
+            }}
+          >
+            <option value="">（選択）</option>
+            {commonGroups.map((g) => (
+              <option key={g.id} value={g.id}>{g.name}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+      <div className="form-group">
+        <label className="form-label small">
+          <i className="bi bi-arrow-left-right me-1" />
+          引数マッピング (argumentMapping、key=value、改行区切り)
+        </label>
+        <textarea
+          className="form-control form-control-sm"
+          rows={2}
+          value={Object.entries(step.argumentMapping ?? {}).map(([k, v]) => `${k}=${v}`).join("\n")}
+          onChange={(e) => {
+            const lines = e.target.value.split("\n").map((l) => l.trim()).filter(Boolean);
+            const map: Record<string, string> = {};
+            for (const line of lines) {
+              const eq = line.indexOf("=");
+              if (eq > 0) {
+                map[line.slice(0, eq).trim()] = line.slice(eq + 1).trim();
+              }
+            }
+            onChange({
+              argumentMapping: Object.keys(map).length > 0 ? map : undefined,
+            } as Partial<Step>);
+          }}
+          onBlur={onCommit}
+          placeholder={"sessionId=@session.id\ntrustedLevel='high'"}
+          style={{ fontFamily: "monospace", fontSize: "0.8rem" }}
+        />
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/process-flow/internal/step-cards/ComputeStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/ComputeStepCardBody.tsx
@@ -1,0 +1,40 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+// Phase-2 (#1145): StepCard.tsx の `step.kind === "compute"` body を抽出。
+
+import type { Step } from "../../../../types/action";
+import { ConvCompletionInput } from "../../../common/ConvCompletionInput";
+import type {
+  StepCardBodyBaseProps,
+  StepCardBodyCatalogProps,
+} from "./types";
+
+export interface ComputeStepCardBodyProps
+  extends StepCardBodyBaseProps,
+    Pick<StepCardBodyCatalogProps, "conventions"> {}
+
+export function ComputeStepCardBody({
+  step,
+  onChange,
+  onCommit,
+  conventions,
+}: ComputeStepCardBodyProps) {
+  return (
+    <div className="row g-2 mb-2" data-field-path="expression">
+      <div className="col-12">
+        <label className="form-label">
+          <i className="bi bi-calculator me-1" />
+          代入式 (expression)
+        </label>
+        <ConvCompletionInput
+          className="form-control form-control-sm"
+          value={step.expression}
+          onValueChange={(v) => onChange({ expression: v } as Partial<Step>)}
+          onCommit={onCommit}
+          conventions={conventions ?? null}
+          placeholder="例: Math.floor(@subtotal * 0.10) / @subtotal + @taxAmount"
+          style={{ fontFamily: "monospace" }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/process-flow/internal/step-cards/DbAccessStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/DbAccessStepCardBody.tsx
@@ -1,0 +1,158 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+// Phase-2 (#1145): StepCard.tsx の `step.kind === "dbAccess"` body を抽出。
+
+import type { Step, DbOperation } from "../../../../types/action";
+import { DB_OPERATION_LABELS } from "../../../../types/action";
+import { DB_OPS } from "../stepCardConstants";
+import type { StepCardBodyBaseProps, StepCardBodyTableProps } from "./types";
+
+export interface DbAccessStepCardBodyProps
+  extends StepCardBodyBaseProps,
+    StepCardBodyTableProps {}
+
+export function DbAccessStepCardBody({
+  step,
+  tables,
+  onChange,
+  onCommit,
+}: DbAccessStepCardBodyProps) {
+  return (
+    <>
+      <div className="form-group">
+        <label className="form-label">テーブル</label>
+        <select
+          className="form-select form-select-sm"
+          value={step.tableId ?? ""}
+          onChange={(e) => {
+            onChange({ tableId: e.target.value || undefined } as Partial<Step>);
+          }}
+        >
+          <option value="">（選択）</option>
+          {tables.map((t) => (
+            <option key={t.id} value={t.id}>{t.name}（{t.physicalName}）</option>
+          ))}
+        </select>
+      </div>
+      <div className="form-row-pair">
+        <div className="form-group">
+          <label className="form-label">操作</label>
+          <select
+            className="form-select form-select-sm"
+            value={step.operation}
+            onChange={(e) => onChange({ operation: e.target.value as DbOperation } as Partial<Step>)}
+          >
+            {DB_OPS.map((op) => (
+              <option key={op} value={op}>{DB_OPERATION_LABELS[op]}</option>
+            ))}
+          </select>
+        </div>
+        <div className="form-group">
+          <label className="form-label">対象フィールド</label>
+          <input
+            className="form-control form-control-sm"
+            value={step.fields ?? ""}
+            onChange={(e) => onChange({ fields: e.target.value } as Partial<Step>)}
+            onBlur={onCommit}
+            placeholder="概要"
+          />
+        </div>
+      </div>
+      <div className="form-group" data-field-path="sql">
+        <label className="form-label">完全 SQL (sql、fields より優先)</label>
+        <textarea
+          className="form-control form-control-sm"
+          rows={2}
+          value={step.sql ?? ""}
+          onChange={(e) => onChange({ sql: e.target.value || undefined } as Partial<Step>)}
+          onBlur={onCommit}
+          placeholder="例: SELECT ... JOIN ... WHERE ... / INSERT ... RETURNING ..."
+          style={{ fontFamily: "monospace", fontSize: "0.8rem" }}
+        />
+      </div>
+      {(step.operation === "UPDATE" || step.operation === "DELETE") && (
+        <div className="form-group">
+          <label className="form-label">
+            <i className="bi bi-shield-check me-1" />
+            影響行数チェック (affectedRowsCheck)
+          </label>
+          <div className="d-flex align-items-center gap-1" style={{ fontSize: "0.8rem" }}>
+            <select
+              className="form-select form-select-sm"
+              value={step.affectedRowsCheck?.operator ?? ""}
+              onChange={(e) => {
+                if (!e.target.value) {
+                  onChange({ affectedRowsCheck: undefined } as Partial<Step>);
+                } else {
+                  onChange({
+                    affectedRowsCheck: {
+                      operator: e.target.value as ">" | ">=" | "=" | "<" | "<=",
+                      expected: step.affectedRowsCheck?.expected ?? 0,
+                      onViolation: step.affectedRowsCheck?.onViolation ?? "throw",
+                      errorCode: step.affectedRowsCheck?.errorCode,
+                    },
+                  } as Partial<Step>);
+                }
+              }}
+              style={{ width: "auto" }}
+            >
+              <option value="">—</option>
+              <option value=">">&gt;</option>
+              <option value=">=">&gt;=</option>
+              <option value="=">=</option>
+              <option value="<">&lt;</option>
+              <option value="<=">&lt;=</option>
+            </select>
+            {step.affectedRowsCheck && (
+              <>
+                <input
+                  type="number"
+                  className="form-control form-control-sm"
+                  value={step.affectedRowsCheck.expected}
+                  onChange={(e) => onChange({
+                    affectedRowsCheck: {
+                      ...step.affectedRowsCheck!,
+                      expected: Number(e.target.value),
+                    },
+                  } as Partial<Step>)}
+                  onBlur={onCommit}
+                  style={{ width: 70 }}
+                />
+                <span className="text-muted">行→</span>
+                <select
+                  className="form-select form-select-sm"
+                  value={step.affectedRowsCheck.onViolation}
+                  onChange={(e) => onChange({
+                    affectedRowsCheck: {
+                      ...step.affectedRowsCheck!,
+                      onViolation: e.target.value as "throw" | "abort" | "log" | "continue",
+                    },
+                  } as Partial<Step>)}
+                  style={{ width: "auto" }}
+                >
+                  <option value="throw">throw</option>
+                  <option value="abort">abort</option>
+                  <option value="log">log</option>
+                  <option value="continue">continue</option>
+                </select>
+                <input
+                  type="text"
+                  className="form-control form-control-sm"
+                  value={step.affectedRowsCheck.errorCode ?? ""}
+                  onChange={(e) => onChange({
+                    affectedRowsCheck: {
+                      ...step.affectedRowsCheck!,
+                      errorCode: e.target.value || undefined,
+                    },
+                  } as Partial<Step>)}
+                  onBlur={onCommit}
+                  placeholder="errorCode (例: STOCK_SHORTAGE)"
+                  style={{ width: 200 }}
+                />
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/process-flow/internal/step-cards/DisplayUpdateStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/DisplayUpdateStepCardBody.tsx
@@ -4,7 +4,7 @@
 import type { Step } from "../../../../types/action";
 import type { StepCardBodyBaseProps } from "./types";
 
-export interface DisplayUpdateStepCardBodyProps extends StepCardBodyBaseProps {}
+export type DisplayUpdateStepCardBodyProps = StepCardBodyBaseProps;
 
 export function DisplayUpdateStepCardBody({
   step,

--- a/frontend/src/components/process-flow/internal/step-cards/DisplayUpdateStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/DisplayUpdateStepCardBody.tsx
@@ -1,0 +1,28 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+// Phase-2 (#1145): StepCard.tsx の `step.kind === "displayUpdate"` body を抽出。
+
+import type { Step } from "../../../../types/action";
+import type { StepCardBodyBaseProps } from "./types";
+
+export interface DisplayUpdateStepCardBodyProps extends StepCardBodyBaseProps {}
+
+export function DisplayUpdateStepCardBody({
+  step,
+  onChange,
+  onCommit,
+}: DisplayUpdateStepCardBodyProps) {
+  return (
+    <div className="row g-2 mb-2">
+      <div className="col-12">
+        <label className="form-label">更新対象</label>
+        <input
+          className="form-control form-control-sm"
+          value={step.target}
+          onChange={(e) => onChange({ target: e.target.value } as Partial<Step>)}
+          onBlur={onCommit}
+          placeholder="メッセージ表示、一覧テーブル更新 等"
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/process-flow/internal/step-cards/ExternalSystemStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/ExternalSystemStepCardBody.tsx
@@ -6,7 +6,7 @@ import { ExternalOutcomesPanel } from "../../ExternalOutcomesPanel";
 import { trimToUndefined } from "../stepCardConstants";
 import type { StepCardBodyBaseProps } from "./types";
 
-export interface ExternalSystemStepCardBodyProps extends StepCardBodyBaseProps {}
+export type ExternalSystemStepCardBodyProps = StepCardBodyBaseProps;
 
 export function ExternalSystemStepCardBody({
   step,

--- a/frontend/src/components/process-flow/internal/step-cards/ExternalSystemStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/ExternalSystemStepCardBody.tsx
@@ -1,0 +1,193 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+// Phase-2 (#1145): StepCard.tsx の `step.kind === "externalSystem"` body を抽出。
+
+import type { Step } from "../../../../types/action";
+import { ExternalOutcomesPanel } from "../../ExternalOutcomesPanel";
+import { trimToUndefined } from "../stepCardConstants";
+import type { StepCardBodyBaseProps } from "./types";
+
+export interface ExternalSystemStepCardBodyProps extends StepCardBodyBaseProps {}
+
+export function ExternalSystemStepCardBody({
+  step,
+  onChange,
+  onCommit,
+}: ExternalSystemStepCardBodyProps) {
+  return (
+    <>
+      <div className="form-row-pair">
+        <div className="form-group">
+          <label className="form-label">接続先</label>
+          <input
+            className="form-control form-control-sm"
+            value={step.systemRef ?? ""}
+            onChange={(e) => onChange({ systemRef: e.target.value } as Partial<Step>)}
+            onBlur={onCommit}
+            placeholder="システム名 (context.catalogs.externalSystems のキー)"
+          />
+        </div>
+        <div className="form-group">
+          <label className="form-label">プロトコル</label>
+          <input
+            className="form-control form-control-sm"
+            value={step.protocol ?? ""}
+            onChange={(e) => onChange({ protocol: e.target.value } as Partial<Step>)}
+            onBlur={onCommit}
+            placeholder="REST / SOAP / gRPC"
+          />
+        </div>
+      </div>
+      <div className="row g-2 mb-2">
+        <div className="col-6" data-field-path="operationRef">
+          <label className="form-label">operationRef</label>
+          <input
+            className="form-control form-control-sm"
+            data-field-path="operationRef"
+            value={step.operationRef ?? ""}
+            onChange={(e) => onChange({ operationRef: trimToUndefined(e.target.value) } as Partial<Step>)}
+            onBlur={onCommit}
+            placeholder="/v1/payment_intents POST"
+            style={{ fontFamily: "monospace" }}
+          />
+        </div>
+        <div className="col-6" data-field-path="operationId">
+          <label className="form-label">operationId</label>
+          <input
+            className="form-control form-control-sm"
+            data-field-path="operationId"
+            value={step.operationId ?? ""}
+            onChange={(e) => onChange({ operationId: trimToUndefined(e.target.value) } as Partial<Step>)}
+            onBlur={onCommit}
+            placeholder="PostPaymentIntents"
+            style={{ fontFamily: "monospace" }}
+          />
+        </div>
+      </div>
+      <div className="row g-2 mb-2">
+        <div className="col-6" data-field-path="requestBodyRef">
+          <label className="form-label">requestBodyRef</label>
+          <input
+            className="form-control form-control-sm"
+            data-field-path="requestBodyRef"
+            value={step.requestBodyRef ?? ""}
+            onChange={(e) => onChange({ requestBodyRef: trimToUndefined(e.target.value) } as Partial<Step>)}
+            onBlur={onCommit}
+            placeholder="#/components/schemas/PaymentIntentCreateParams"
+            style={{ fontFamily: "monospace" }}
+          />
+        </div>
+        <div className="col-6" data-field-path="responseRef">
+          <label className="form-label">responseRef</label>
+          <input
+            className="form-control form-control-sm"
+            data-field-path="responseRef"
+            value={step.responseRef ?? ""}
+            onChange={(e) => onChange({ responseRef: trimToUndefined(e.target.value) } as Partial<Step>)}
+            onBlur={onCommit}
+            placeholder="#/components/responses/200/content/application~1json/schema"
+            style={{ fontFamily: "monospace" }}
+          />
+        </div>
+      </div>
+      <div className="row g-2 mb-2 align-items-center" style={{ fontSize: "0.85rem" }}>
+        <div className="col-auto">
+          <label className="form-label small mb-0">タイムアウト</label>
+        </div>
+        <div className="col-auto">
+          <input
+            type="number"
+            className="form-control form-control-sm"
+            value={step.timeoutMs ?? ""}
+            onChange={(e) => onChange({ timeoutMs: e.target.value ? Number(e.target.value) : undefined } as Partial<Step>)}
+            onBlur={onCommit}
+            placeholder="ms"
+            style={{ width: 90 }}
+          />
+        </div>
+        <div className="col-auto text-muted">ms</div>
+        <div className="col-auto">
+          <label className="form-check-label small">
+            <input
+              type="checkbox"
+              className="form-check-input me-1"
+              checked={!!step.fireAndForget}
+              onChange={(e) => onChange({ fireAndForget: e.target.checked || undefined } as Partial<Step>)}
+            />
+            fire-and-forget (同期レスポンス待たない)
+          </label>
+        </div>
+      </div>
+      <div className="row g-2 mb-2 align-items-center" style={{ fontSize: "0.8rem" }}>
+        <div className="col-auto">
+          <label className="form-label small mb-0">リトライ</label>
+        </div>
+        <div className="col-auto">
+          <input
+            type="number"
+            className="form-control form-control-sm"
+            value={step.retryPolicy?.maxAttempts ?? ""}
+            onChange={(e) => {
+              const n = e.target.value ? Number(e.target.value) : 0;
+              if (n <= 0) {
+                onChange({ retryPolicy: undefined } as Partial<Step>);
+              } else {
+                onChange({
+                  retryPolicy: {
+                    maxAttempts: n,
+                    backoff: step.retryPolicy?.backoff,
+                    initialDelayMs: step.retryPolicy?.initialDelayMs,
+                  },
+                } as Partial<Step>);
+              }
+            }}
+            onBlur={onCommit}
+            placeholder="maxAttempts"
+            style={{ width: 90, fontSize: "0.8rem" }}
+          />
+        </div>
+        {step.retryPolicy && (
+          <>
+            <div className="col-auto">
+              <select
+                className="form-select form-select-sm"
+                value={step.retryPolicy.backoff ?? ""}
+                onChange={(e) => onChange({
+                  retryPolicy: {
+                    ...step.retryPolicy!,
+                    backoff: e.target.value as "fixed" | "exponential" || undefined,
+                  },
+                } as Partial<Step>)}
+                style={{ width: "auto", fontSize: "0.8rem" }}
+              >
+                <option value="">backoff: —</option>
+                <option value="fixed">fixed</option>
+                <option value="exponential">exponential</option>
+              </select>
+            </div>
+            <div className="col-auto">
+              <input
+                type="number"
+                className="form-control form-control-sm"
+                value={step.retryPolicy.initialDelayMs ?? ""}
+                onChange={(e) => onChange({
+                  retryPolicy: {
+                    ...step.retryPolicy!,
+                    initialDelayMs: e.target.value ? Number(e.target.value) : undefined,
+                  },
+                } as Partial<Step>)}
+                onBlur={onCommit}
+                placeholder="initialDelayMs"
+                style={{ width: 120, fontSize: "0.8rem" }}
+              />
+            </div>
+          </>
+        )}
+      </div>
+      <ExternalOutcomesPanel
+        step={step}
+        onChange={(patch) => onChange(patch as Partial<Step>)}
+        onCommit={onCommit}
+      />
+    </>
+  );
+}

--- a/frontend/src/components/process-flow/internal/step-cards/JumpStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/JumpStepCardBody.tsx
@@ -5,7 +5,7 @@ import type { Step } from "../../../../types/action";
 import { JumpTargetSelector } from "../../JumpTargetSelector";
 import type { StepCardBodyBaseProps } from "./types";
 
-export interface JumpStepCardBodyProps extends StepCardBodyBaseProps {}
+export type JumpStepCardBodyProps = StepCardBodyBaseProps;
 
 export function JumpStepCardBody({
   step,

--- a/frontend/src/components/process-flow/internal/step-cards/JumpStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/JumpStepCardBody.tsx
@@ -1,0 +1,30 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+// Phase-2 (#1145): StepCard.tsx の `step.kind === "jump"` body を抽出。
+
+import type { Step } from "../../../../types/action";
+import { JumpTargetSelector } from "../../JumpTargetSelector";
+import type { StepCardBodyBaseProps } from "./types";
+
+export interface JumpStepCardBodyProps extends StepCardBodyBaseProps {}
+
+export function JumpStepCardBody({
+  step,
+  allSteps,
+  onChange,
+  onCommit,
+}: JumpStepCardBodyProps) {
+  return (
+    <div className="row g-2 mb-2">
+      <div className="col-12">
+        <label className="form-label">ジャンプ先</label>
+        <JumpTargetSelector
+          value={step.jumpTo}
+          allSteps={allSteps}
+          excludeStepId={step.id}
+          onChange={(val) => onChange({ jumpTo: val } as Partial<Step>)}
+          onBlur={onCommit}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/process-flow/internal/step-cards/LogStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/LogStepCardBody.tsx
@@ -1,0 +1,29 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+// Phase-2 (#1145): StepCard.tsx の `step.kind === "log"` body を抽出 (#402)。
+
+import type { Step } from "../../../../types/action";
+import { LogStepPanel } from "../../LogStepPanel";
+import type {
+  StepCardBodyBaseProps,
+  StepCardBodyCatalogProps,
+} from "./types";
+
+export interface LogStepCardBodyProps
+  extends StepCardBodyBaseProps,
+    Pick<StepCardBodyCatalogProps, "conventions"> {}
+
+export function LogStepCardBody({
+  step,
+  onChange,
+  onCommit,
+  conventions,
+}: LogStepCardBodyProps) {
+  return (
+    <LogStepPanel
+      step={step}
+      onChange={(patch) => onChange(patch as Partial<Step>)}
+      onCommit={onCommit}
+      conventions={conventions ?? null}
+    />
+  );
+}

--- a/frontend/src/components/process-flow/internal/step-cards/LoopStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/LoopStepCardBody.tsx
@@ -1,0 +1,163 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+// Phase-2 (#1145): StepCard.tsx の `step.kind === "loop"` body を抽出 (Phase 4 ロジック)。
+//
+// `loopBodyCollapsed` は本 body 専用の純粋 UI state のため、parent から切り離して内部化。
+
+import { useState } from "react";
+import type { LoopConditionMode, LoopKind, Step } from "../../../../types/action";
+import { InlineStepList } from "../InlineStepList";
+import type {
+  StepCardBodyBaseProps,
+  StepCardBodyCatalogProps,
+  StepCardBodyTableProps,
+  StepCardBodyScreenProps,
+  StepCardBodyCommonGroupsProps,
+  StepCardBodyNavigationProps,
+} from "./types";
+
+export interface LoopStepCardBodyProps
+  extends StepCardBodyBaseProps,
+    StepCardBodyCatalogProps,
+    StepCardBodyTableProps,
+    StepCardBodyScreenProps,
+    StepCardBodyCommonGroupsProps,
+    StepCardBodyNavigationProps {}
+
+export function LoopStepCardBody({
+  step,
+  allSteps,
+  tables,
+  screens,
+  commonGroups,
+  validationErrors,
+  conventions,
+  group,
+  onChange,
+  onCommit,
+  onNavigateCommon,
+  readOnly,
+}: LoopStepCardBodyProps) {
+  const [loopBodyCollapsed, setLoopBodyCollapsed] = useState(false);
+
+  return (
+    <div>
+      <div className="loop-kind-radios">
+        {(["count", "condition", "collection"] as LoopKind[]).map((k) => (
+          <label key={k}>
+            <input
+              type="radio"
+              name={`loopkind-${step.id}`}
+              value={k}
+              checked={step.loopKind === k}
+              onChange={() => onChange({ loopKind: k } as Partial<Step>)}
+            />
+            {k === "count" ? "回数" : k === "condition" ? "条件" : "コレクション"}
+          </label>
+        ))}
+      </div>
+
+      {step.loopKind === "count" && (
+        <div className="form-group">
+          <label className="form-label">回数 / 範囲</label>
+          <input
+            className="form-control form-control-sm"
+            value={step.countExpression ?? ""}
+            onChange={(e) => onChange({ countExpression: e.target.value } as Partial<Step>)}
+            onBlur={onCommit}
+            placeholder="例: 3回, 検索結果の件数分"
+          />
+        </div>
+      )}
+
+      {step.loopKind === "condition" && (
+        <>
+          <div className="form-group mb-2">
+            <label className="form-label">条件モード</label>
+            <div className="d-flex gap-3 flex-wrap">
+              {(["continue", "exit"] as LoopConditionMode[]).map((m) => (
+                <label key={m} style={{ display: "flex", alignItems: "center", gap: 4, fontSize: "0.82rem", cursor: "pointer" }}>
+                  <input
+                    type="radio"
+                    name={`condmode-${step.id}`}
+                    value={m}
+                    checked={(step.conditionMode ?? "exit") === m}
+                    onChange={() => onChange({ conditionMode: m } as Partial<Step>)}
+                  />
+                  {m === "continue" ? "条件の間繰り返す (while)" : "条件になるまで繰り返す (until)"}
+                </label>
+              ))}
+            </div>
+          </div>
+          <div className="form-group">
+            <label className="form-label">条件式</label>
+            <input
+              className="form-control form-control-sm"
+              value={step.conditionExpression ?? ""}
+              onChange={(e) => onChange({ conditionExpression: e.target.value } as Partial<Step>)}
+              onBlur={onCommit}
+              placeholder="例: 残件数 > 0"
+            />
+          </div>
+        </>
+      )}
+
+      {step.loopKind === "collection" && (
+        <div className="form-row-pair">
+          <div className="form-group">
+            <label className="form-label">コレクション</label>
+            <input
+              className="form-control form-control-sm"
+              value={step.collectionSource ?? ""}
+              onChange={(e) => onChange({ collectionSource: e.target.value } as Partial<Step>)}
+              onBlur={onCommit}
+              placeholder="例: 検索結果"
+            />
+          </div>
+          <div className="form-group">
+            <label className="form-label">要素変数名</label>
+            <input
+              className="form-control form-control-sm"
+              value={step.collectionItemName ?? ""}
+              onChange={(e) => onChange({ collectionItemName: e.target.value } as Partial<Step>)}
+              onBlur={onCommit}
+              placeholder="例: ユーザー"
+            />
+          </div>
+        </div>
+      )}
+
+      <div className={`loop-body${loopBodyCollapsed ? " collapsed" : ""}`}>
+        <div
+          className="loop-body-header"
+          onClick={() => setLoopBodyCollapsed(!loopBodyCollapsed)}
+        >
+          <i className="bi bi-arrow-repeat" />
+          ループ本体
+          <i
+            className={`bi bi-chevron-${loopBodyCollapsed ? "right" : "down"} ms-auto`}
+            style={{ color: "#94a3b8" }}
+          />
+        </div>
+        {!loopBodyCollapsed && (
+          <div className="loop-body-content">
+            <InlineStepList
+              steps={step.steps}
+              parentLabel="L"
+              allSteps={allSteps}
+              tables={tables}
+              screens={screens}
+              commonGroups={commonGroups}
+              onChange={(newSteps) => onChange({ steps: newSteps } as Partial<Step>)}
+              onCommit={onCommit}
+              onNavigateCommon={onNavigateCommon}
+              validationErrors={validationErrors}
+              conventions={conventions}
+              group={group}
+              readOnly={readOnly}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/process-flow/internal/step-cards/ReturnStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/ReturnStepCardBody.tsx
@@ -1,0 +1,51 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+// Phase-2 (#1145): StepCard.tsx の `step.kind === "return"` body を抽出。
+
+import type { Step } from "../../../../types/action";
+import { ConvCompletionInput } from "../../../common/ConvCompletionInput";
+import type {
+  StepCardBodyBaseProps,
+  StepCardBodyCatalogProps,
+} from "./types";
+
+export interface ReturnStepCardBodyProps
+  extends StepCardBodyBaseProps,
+    Pick<StepCardBodyCatalogProps, "conventions"> {}
+
+export function ReturnStepCardBody({
+  step,
+  onChange,
+  onCommit,
+  conventions,
+}: ReturnStepCardBodyProps) {
+  return (
+    <div className="row g-2 mb-2">
+      <div className="col-6">
+        <label className="form-label">
+          <i className="bi bi-reply me-1" />
+          responseRef (action.responses[].id)
+        </label>
+        <input
+          type="text"
+          className="form-control form-control-sm"
+          value={step.responseRef ?? ""}
+          onChange={(e) => onChange({ responseRef: e.target.value || undefined } as Partial<Step>)}
+          onBlur={onCommit}
+          placeholder="例: 409-stock-shortage"
+        />
+      </div>
+      <div className="col-6" data-field-path="bodyExpression">
+        <label className="form-label">bodyExpression</label>
+        <ConvCompletionInput
+          className="form-control form-control-sm"
+          value={step.bodyExpression ?? ""}
+          onValueChange={(v) => onChange({ bodyExpression: v || undefined } as Partial<Step>)}
+          onCommit={onCommit}
+          conventions={conventions ?? null}
+          placeholder="例: { code: 'STOCK_SHORTAGE', detail: @shortageList }"
+          style={{ fontFamily: "monospace" }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/process-flow/internal/step-cards/ScreenTransitionStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/ScreenTransitionStepCardBody.tsx
@@ -1,0 +1,47 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+// Phase-2 (#1145): StepCard.tsx の `step.kind === "screenTransition"` body を抽出。
+
+import type { Step } from "../../../../types/action";
+import type {
+  StepCardBodyBaseProps,
+  StepCardBodyScreenProps,
+} from "./types";
+
+export interface ScreenTransitionStepCardBodyProps
+  extends StepCardBodyBaseProps,
+    StepCardBodyScreenProps {}
+
+export function ScreenTransitionStepCardBody({
+  step,
+  screens,
+  onChange,
+  onCommit,
+}: ScreenTransitionStepCardBodyProps) {
+  return (
+    <div className="row g-2 mb-2">
+      <div className="col-12">
+        <label className="form-label">遷移先画面</label>
+        <select
+          className="form-select form-select-sm"
+          value={step.targetScreenId ?? ""}
+          onChange={(e) => {
+            const s = screens.find((s) => s.id === e.target.value);
+            onChange({ targetScreenId: e.target.value, targetScreenName: s?.name ?? e.target.value } as Partial<Step>);
+          }}
+        >
+          <option value="">（選択または手入力）</option>
+          {screens.map((s) => (
+            <option key={s.id} value={s.id}>{s.name}</option>
+          ))}
+        </select>
+        <input
+          className="form-control form-control-sm mt-1"
+          value={step.targetScreenName}
+          onChange={(e) => onChange({ targetScreenName: e.target.value } as Partial<Step>)}
+          onBlur={onCommit}
+          placeholder="画面名を直接入力"
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/process-flow/internal/step-cards/TransactionScopeStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/TransactionScopeStepCardBody.tsx
@@ -1,0 +1,51 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+// Phase-2 (#1145): StepCard.tsx の `step.kind === "transactionScope"` body を抽出 (#415)。
+
+import type { Step } from "../../../../types/action";
+import { TransactionScopeStepPanel } from "../../TransactionScopeStepPanel";
+import type {
+  StepCardBodyBaseProps,
+  StepCardBodyCatalogProps,
+  StepCardBodyTableProps,
+  StepCardBodyScreenProps,
+  StepCardBodyCommonGroupsProps,
+  StepCardBodyNavigationProps,
+} from "./types";
+
+export interface TransactionScopeStepCardBodyProps
+  extends StepCardBodyBaseProps,
+    StepCardBodyCatalogProps,
+    StepCardBodyTableProps,
+    StepCardBodyScreenProps,
+    StepCardBodyCommonGroupsProps,
+    StepCardBodyNavigationProps {}
+
+export function TransactionScopeStepCardBody({
+  step,
+  allSteps,
+  tables,
+  screens,
+  commonGroups,
+  validationErrors,
+  conventions,
+  group,
+  onChange,
+  onCommit,
+  onNavigateCommon,
+}: TransactionScopeStepCardBodyProps) {
+  return (
+    <TransactionScopeStepPanel
+      step={step}
+      onChange={(patch) => onChange(patch as Partial<Step>)}
+      onCommit={onCommit}
+      group={group}
+      allSteps={allSteps}
+      tables={tables}
+      screens={screens}
+      commonGroups={commonGroups}
+      validationErrors={validationErrors}
+      conventions={conventions ?? null}
+      onNavigateCommon={onNavigateCommon}
+    />
+  );
+}

--- a/frontend/src/components/process-flow/internal/step-cards/ValidationStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/ValidationStepCardBody.tsx
@@ -1,0 +1,126 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+// Phase-2 (#1145): StepCard.tsx の `step.kind === "validation"` body を抽出。
+// 振る舞いの変更は無し (純粋なファイル分割)。
+
+import type { Step } from "../../../../types/action";
+import { ValidationRulesPanel } from "../../ValidationRulesPanel";
+import type { StepCardBodyBaseProps, StepCardBodyCatalogProps } from "./types";
+
+export interface ValidationStepCardBodyProps
+  extends StepCardBodyBaseProps,
+    Pick<StepCardBodyCatalogProps, "conventions"> {}
+
+export function ValidationStepCardBody({
+  step,
+  onChange,
+  onCommit,
+  conventions,
+}: ValidationStepCardBodyProps) {
+  return (
+    <>
+      <div className="row g-2 mb-2" data-field-path="conditions">
+        <div className="col-12">
+          <label className="form-label">バリデーション条件 (自由記述)</label>
+          <input
+            className="form-control form-control-sm"
+            value={step.conditions}
+            onChange={(e) => onChange({ conditions: e.target.value } as Partial<Step>)}
+            onBlur={onCommit}
+            placeholder="必須チェック、形式チェック等 (rules[] で構造化済なら補足用)"
+          />
+        </div>
+      </div>
+      <ValidationRulesPanel
+        rules={step.rules}
+        onChange={(rules) => onChange({ rules } as Partial<Step>)}
+        conventions={conventions ?? null}
+      />
+      {step.inlineBranch && (
+        <div className="step-inline-branch">
+          <div className="step-branch-box ok">
+            <div className="step-branch-label">A: OK</div>
+            {typeof step.inlineBranch.ok === "string" ? (
+              <input
+                className="form-control form-control-sm"
+                value={step.inlineBranch.ok}
+                onChange={(e) =>
+                  onChange({ inlineBranch: { ...step.inlineBranch!, ok: e.target.value } } as Partial<Step>)
+                }
+                placeholder="OK時の処理"
+                onBlur={onCommit}
+              />
+            ) : (
+              <span className="form-control form-control-sm text-muted" style={{ cursor: "default" }}>
+                ステップ {step.inlineBranch.ok.length} 件 (JSON編集)
+              </span>
+            )}
+          </div>
+          <div className="step-branch-box ng">
+            <div className="step-branch-label">B: NG</div>
+            {typeof step.inlineBranch.ng === "string" ? (
+              <input
+                className="form-control form-control-sm"
+                value={step.inlineBranch.ng}
+                onChange={(e) =>
+                  onChange({ inlineBranch: { ...step.inlineBranch!, ng: e.target.value } } as Partial<Step>)
+                }
+                placeholder="NG時の処理"
+                onBlur={onCommit}
+              />
+            ) : (
+              <span className="form-control form-control-sm text-muted" style={{ cursor: "default" }}>
+                ステップ {step.inlineBranch.ng.length} 件 (JSON編集)
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+      {step.inlineBranch && (
+        <div className="row g-2 mb-2 mt-1" style={{ fontSize: "0.8rem" }}>
+          <div className="col-5">
+            <label className="form-label small mb-0">
+              NG → responseRef
+            </label>
+            <input
+              type="text"
+              className="form-control form-control-sm"
+              value={step.inlineBranch.ngResponseRef ?? ""}
+              onChange={(e) =>
+                onChange({
+                  inlineBranch: {
+                    ...step.inlineBranch!,
+                    ngResponseRef: e.target.value || undefined,
+                  },
+                } as Partial<Step>)
+              }
+              onBlur={onCommit}
+              placeholder="例: 400-validation"
+              style={{ fontSize: "0.8rem" }}
+            />
+          </div>
+          <div className="col-7">
+            <label className="form-label small mb-0">
+              NG bodyExpression
+            </label>
+            <input
+              type="text"
+              className="form-control form-control-sm"
+              value={step.inlineBranch.ngBodyExpression ?? ""}
+              onChange={(e) =>
+                onChange({
+                  inlineBranch: {
+                    ...step.inlineBranch!,
+                    ngBodyExpression: e.target.value || undefined,
+                  },
+                } as Partial<Step>)
+              }
+              onBlur={onCommit}
+              placeholder="例: { code: 'VALIDATION', fieldErrors: @fieldErrors }"
+              style={{ fontSize: "0.8rem", fontFamily: "monospace" }}
+            />
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/process-flow/internal/step-cards/WorkflowStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/WorkflowStepCardBody.tsx
@@ -1,0 +1,62 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+// Phase-2 (#1145): StepCard.tsx の `step.kind === "workflow"` body を抽出。
+
+import type { Step } from "../../../../types/action";
+import { WorkflowStepPanel } from "../../WorkflowStepPanel";
+import { InlineStepList } from "../InlineStepList";
+import type {
+  StepCardBodyBaseProps,
+  StepCardBodyCatalogProps,
+  StepCardBodyTableProps,
+  StepCardBodyScreenProps,
+  StepCardBodyCommonGroupsProps,
+  StepCardBodyNavigationProps,
+} from "./types";
+
+export interface WorkflowStepCardBodyProps
+  extends StepCardBodyBaseProps,
+    StepCardBodyCatalogProps,
+    StepCardBodyTableProps,
+    StepCardBodyScreenProps,
+    StepCardBodyCommonGroupsProps,
+    StepCardBodyNavigationProps {}
+
+export function WorkflowStepCardBody({
+  step,
+  allSteps,
+  tables,
+  screens,
+  commonGroups,
+  validationErrors,
+  conventions,
+  onChange,
+  onCommit,
+  onNavigateCommon,
+  readOnly,
+}: WorkflowStepCardBodyProps) {
+  return (
+    <WorkflowStepPanel
+      step={step}
+      allSteps={allSteps}
+      conventions={conventions ?? null}
+      onChange={(patch) => onChange(patch as Partial<Step>)}
+      onCommit={onCommit}
+      renderInlineStepList={({ steps, parentLabel, onChange: onStepsChange }) => (
+        <InlineStepList
+          steps={steps}
+          parentLabel={parentLabel}
+          allSteps={allSteps}
+          tables={tables}
+          screens={screens}
+          commonGroups={commonGroups}
+          onChange={onStepsChange}
+          onCommit={onCommit}
+          onNavigateCommon={onNavigateCommon}
+          validationErrors={validationErrors}
+          conventions={conventions}
+          readOnly={readOnly}
+        />
+      )}
+    />
+  );
+}

--- a/frontend/src/components/process-flow/internal/step-cards/index.ts
+++ b/frontend/src/components/process-flow/internal/step-cards/index.ts
@@ -1,0 +1,18 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+// Phase-2 (#1145): StepCard.tsx の kind 別 body sub-component の barrel export。
+
+export { ValidationStepCardBody } from "./ValidationStepCardBody";
+export { DbAccessStepCardBody } from "./DbAccessStepCardBody";
+export { ExternalSystemStepCardBody } from "./ExternalSystemStepCardBody";
+export { CommonProcessStepCardBody } from "./CommonProcessStepCardBody";
+export { ComputeStepCardBody } from "./ComputeStepCardBody";
+export { ReturnStepCardBody } from "./ReturnStepCardBody";
+export { ScreenTransitionStepCardBody } from "./ScreenTransitionStepCardBody";
+export { DisplayUpdateStepCardBody } from "./DisplayUpdateStepCardBody";
+export { BranchStepCardBody } from "./BranchStepCardBody";
+export { LoopStepCardBody } from "./LoopStepCardBody";
+export { LogStepCardBody } from "./LogStepCardBody";
+export { AuditStepCardBody } from "./AuditStepCardBody";
+export { TransactionScopeStepCardBody } from "./TransactionScopeStepCardBody";
+export { JumpStepCardBody } from "./JumpStepCardBody";
+export { WorkflowStepCardBody } from "./WorkflowStepCardBody";

--- a/frontend/src/components/process-flow/internal/step-cards/step-cards.test.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/step-cards.test.tsx
@@ -1,0 +1,427 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+// Phase-2 (#1145): step-cards/ 配下 15 個の sub-component の最小 rendering test。
+//
+// 各 sub-component は StepCard.tsx から純粋に抽出されたもの。本テストは
+// (1) crash せず render される (2) kind 固有のキー要素が DOM に出る、を確認する。
+// 詳細な振る舞いテストは元々 StepCard 系では薄かったため、本 PR では rendering 中心。
+
+import { describe, expect, it, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import {
+  AuditStepCardBody,
+  BranchStepCardBody,
+  CommonProcessStepCardBody,
+  ComputeStepCardBody,
+  DbAccessStepCardBody,
+  DisplayUpdateStepCardBody,
+  ExternalSystemStepCardBody,
+  JumpStepCardBody,
+  LogStepCardBody,
+  LoopStepCardBody,
+  ReturnStepCardBody,
+  ScreenTransitionStepCardBody,
+  TransactionScopeStepCardBody,
+  ValidationStepCardBody,
+  WorkflowStepCardBody,
+} from "./index";
+
+// ── 共通テストヘルパ ───────────────────────────────────────────────
+
+const noop = () => {};
+const baseStep = (overrides: any = {}) => ({
+  id: "step-1",
+  description: "",
+  ...overrides,
+});
+
+// ── ValidationStepCardBody ─────────────────────────────────────────
+
+describe("ValidationStepCardBody", () => {
+  it("conditions input が描画される", () => {
+    const step = baseStep({ kind: "validation", conditions: "test-cond", rules: [] });
+    const { container } = render(
+      <ValidationStepCardBody
+        step={step}
+        allSteps={[]}
+        onChange={noop}
+      />,
+    );
+    const input = container.querySelector('[data-field-path="conditions"] input') as HTMLInputElement;
+    expect(input).not.toBeNull();
+    expect(input.value).toBe("test-cond");
+  });
+
+  it("conditions 変更で onChange が呼ばれる", () => {
+    const onChange = vi.fn();
+    const step = baseStep({ kind: "validation", conditions: "", rules: [] });
+    const { container } = render(
+      <ValidationStepCardBody step={step} allSteps={[]} onChange={onChange} />,
+    );
+    const input = container.querySelector('[data-field-path="conditions"] input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "新条件" } });
+    expect(onChange).toHaveBeenCalledWith({ conditions: "新条件" });
+  });
+});
+
+// ── DbAccessStepCardBody ────────────────────────────────────────────
+
+describe("DbAccessStepCardBody", () => {
+  const tables = [{ id: "t1", physicalName: "users", name: "ユーザー" }];
+
+  it("operation select が描画される (SELECT 既定)", () => {
+    const step = baseStep({ kind: "dbAccess", tableId: "", operation: "SELECT" });
+    const { container } = render(
+      <DbAccessStepCardBody step={step} allSteps={[]} tables={tables} onChange={noop} />,
+    );
+    const selects = container.querySelectorAll("select");
+    expect(selects.length).toBeGreaterThanOrEqual(2); // table + operation
+  });
+
+  it("UPDATE 選択時に影響行数チェック UI が描画される", () => {
+    const step = baseStep({ kind: "dbAccess", tableId: "t1", operation: "UPDATE" });
+    const { container } = render(
+      <DbAccessStepCardBody step={step} allSteps={[]} tables={tables} onChange={noop} />,
+    );
+    expect(container.textContent).toContain("影響行数チェック");
+  });
+
+  it("SELECT 時は影響行数チェック UI が出ない", () => {
+    const step = baseStep({ kind: "dbAccess", tableId: "t1", operation: "SELECT" });
+    const { container } = render(
+      <DbAccessStepCardBody step={step} allSteps={[]} tables={tables} onChange={noop} />,
+    );
+    expect(container.textContent).not.toContain("影響行数チェック");
+  });
+});
+
+// ── ExternalSystemStepCardBody ──────────────────────────────────────
+
+describe("ExternalSystemStepCardBody", () => {
+  it("systemRef / protocol input が描画される", () => {
+    const step = baseStep({ kind: "externalSystem", systemRef: "stripe", protocol: "REST" });
+    const { container } = render(
+      <ExternalSystemStepCardBody step={step} allSteps={[]} onChange={noop} />,
+    );
+    expect(container.textContent).toContain("接続先");
+    expect(container.textContent).toContain("プロトコル");
+  });
+
+  it("retryPolicy 未設定時は backoff select が出ない", () => {
+    const step = baseStep({ kind: "externalSystem", systemRef: "stripe" });
+    const { container } = render(
+      <ExternalSystemStepCardBody step={step} allSteps={[]} onChange={noop} />,
+    );
+    expect(container.textContent).not.toContain("backoff:");
+  });
+});
+
+// ── CommonProcessStepCardBody ───────────────────────────────────────
+
+describe("CommonProcessStepCardBody", () => {
+  it("commonGroups の選択肢を描画する", () => {
+    const step = baseStep({ kind: "commonProcess", refId: "cg-1" });
+    const cgs = [{ id: "cg-1", name: "認証" }, { id: "cg-2", name: "ログ" }];
+    const { container } = render(
+      <CommonProcessStepCardBody
+        step={step}
+        allSteps={[]}
+        commonGroups={cgs}
+        onChange={noop}
+      />,
+    );
+    const opts = container.querySelectorAll("option");
+    // 1 placeholder + 2 cg = 3
+    expect(opts.length).toBe(3);
+  });
+});
+
+// ── ComputeStepCardBody ─────────────────────────────────────────────
+
+describe("ComputeStepCardBody", () => {
+  it("expression input が描画される", () => {
+    const step = baseStep({ kind: "compute", expression: "@a + @b" });
+    const { container } = render(
+      <ComputeStepCardBody step={step} allSteps={[]} onChange={noop} />,
+    );
+    expect(container.textContent).toContain("代入式");
+  });
+});
+
+// ── ReturnStepCardBody ──────────────────────────────────────────────
+
+describe("ReturnStepCardBody", () => {
+  it("responseRef と bodyExpression input を描画する", () => {
+    const step = baseStep({ kind: "return", responseRef: "200-ok" });
+    const { container } = render(
+      <ReturnStepCardBody step={step} allSteps={[]} onChange={noop} />,
+    );
+    expect(container.textContent).toContain("responseRef");
+    expect(container.textContent).toContain("bodyExpression");
+  });
+});
+
+// ── ScreenTransitionStepCardBody ────────────────────────────────────
+
+describe("ScreenTransitionStepCardBody", () => {
+  it("screens の選択肢を描画する", () => {
+    const step = baseStep({
+      kind: "screenTransition",
+      targetScreenId: "s-1",
+      targetScreenName: "確認画面",
+    });
+    const screens = [{ id: "s-1", name: "確認画面" }];
+    const { container } = render(
+      <ScreenTransitionStepCardBody
+        step={step}
+        allSteps={[]}
+        screens={screens}
+        onChange={noop}
+      />,
+    );
+    expect(container.textContent).toContain("遷移先画面");
+    const opts = container.querySelectorAll("option");
+    // 1 placeholder + 1 screen
+    expect(opts.length).toBe(2);
+  });
+});
+
+// ── DisplayUpdateStepCardBody ───────────────────────────────────────
+
+describe("DisplayUpdateStepCardBody", () => {
+  it("target input が描画される", () => {
+    const step = baseStep({ kind: "displayUpdate", target: "メッセージ" });
+    const { container } = render(
+      <DisplayUpdateStepCardBody step={step} allSteps={[]} onChange={noop} />,
+    );
+    const input = container.querySelector("input") as HTMLInputElement;
+    expect(input.value).toBe("メッセージ");
+  });
+});
+
+// ── BranchStepCardBody ──────────────────────────────────────────────
+
+describe("BranchStepCardBody", () => {
+  const makeBranchStep = () =>
+    baseStep({
+      kind: "branch",
+      branches: [
+        { id: "b-1", code: "A", condition: { kind: "expression", expression: "" }, steps: [] },
+        { id: "b-2", code: "B", condition: { kind: "expression", expression: "" }, steps: [] },
+      ],
+    });
+
+  it("2 分岐 + add ボタンを描画する", () => {
+    const step = makeBranchStep();
+    const { container } = render(
+      <BranchStepCardBody
+        step={step}
+        allSteps={[]}
+        tables={[]}
+        screens={[]}
+        commonGroups={[]}
+        onChange={noop}
+        onNavigateCommon={noop}
+      />,
+    );
+    const sections = container.querySelectorAll(".branch-section");
+    expect(sections.length).toBe(2);
+    const addBtn = container.querySelector(".branch-add-row");
+    expect(addBtn).not.toBeNull();
+  });
+
+  it("readOnly=true で分岐追加ボタンを非表示", () => {
+    const step = makeBranchStep();
+    const { container } = render(
+      <BranchStepCardBody
+        step={step}
+        allSteps={[]}
+        tables={[]}
+        screens={[]}
+        commonGroups={[]}
+        onChange={noop}
+        onNavigateCommon={noop}
+        readOnly
+      />,
+    );
+    expect(container.querySelector(".branch-add-row")).toBeNull();
+  });
+
+  it("分岐を追加すると onChange + onCommit が呼ばれる", () => {
+    const onChange = vi.fn();
+    const onCommit = vi.fn();
+    const step = makeBranchStep();
+    const { container } = render(
+      <BranchStepCardBody
+        step={step}
+        allSteps={[]}
+        tables={[]}
+        screens={[]}
+        commonGroups={[]}
+        onChange={onChange}
+        onCommit={onCommit}
+        onNavigateCommon={noop}
+      />,
+    );
+    const addBtn = container.querySelector(".branch-add-btn") as HTMLButtonElement;
+    fireEvent.click(addBtn);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    const call = onChange.mock.calls[0][0];
+    expect(call.branches.length).toBe(3);
+    expect(call.branches[2].code).toBe("C");
+  });
+});
+
+// ── LoopStepCardBody ────────────────────────────────────────────────
+
+describe("LoopStepCardBody", () => {
+  it("count loop で 回数 input を描画する", () => {
+    const step = baseStep({
+      kind: "loop",
+      loopKind: "count",
+      countExpression: "3",
+      steps: [],
+    });
+    const { container } = render(
+      <LoopStepCardBody
+        step={step}
+        allSteps={[]}
+        tables={[]}
+        screens={[]}
+        commonGroups={[]}
+        onChange={noop}
+        onNavigateCommon={noop}
+      />,
+    );
+    expect(container.textContent).toContain("回数 / 範囲");
+  });
+
+  it("condition loop で 条件モード + 条件式 を描画する", () => {
+    const step = baseStep({
+      kind: "loop",
+      loopKind: "condition",
+      conditionMode: "exit",
+      conditionExpression: "残件数 > 0",
+      steps: [],
+    });
+    const { container } = render(
+      <LoopStepCardBody
+        step={step}
+        allSteps={[]}
+        tables={[]}
+        screens={[]}
+        commonGroups={[]}
+        onChange={noop}
+        onNavigateCommon={noop}
+      />,
+    );
+    expect(container.textContent).toContain("条件モード");
+    expect(container.textContent).toContain("条件式");
+  });
+
+  it("collection loop で コレクション + 要素変数名 を描画する", () => {
+    const step = baseStep({
+      kind: "loop",
+      loopKind: "collection",
+      collectionSource: "items",
+      collectionItemName: "item",
+      steps: [],
+    });
+    const { container } = render(
+      <LoopStepCardBody
+        step={step}
+        allSteps={[]}
+        tables={[]}
+        screens={[]}
+        commonGroups={[]}
+        onChange={noop}
+        onNavigateCommon={noop}
+      />,
+    );
+    expect(container.textContent).toContain("コレクション");
+    expect(container.textContent).toContain("要素変数名");
+  });
+});
+
+// ── LogStepCardBody / AuditStepCardBody / TransactionScopeStepCardBody ──
+//    既存 *StepPanel.test.tsx でカバー済のため smoke のみ。
+
+describe("LogStepCardBody", () => {
+  it("crash せず描画される", () => {
+    const step = baseStep({ kind: "log", level: "info", message: "" });
+    const { container } = render(
+      <LogStepCardBody step={step} allSteps={[]} onChange={noop} />,
+    );
+    expect(container.firstChild).not.toBeNull();
+  });
+});
+
+describe("AuditStepCardBody", () => {
+  it("crash せず描画される", () => {
+    const step = baseStep({ kind: "audit", action: "" });
+    const { container } = render(
+      <AuditStepCardBody step={step} allSteps={[]} onChange={noop} />,
+    );
+    expect(container.firstChild).not.toBeNull();
+  });
+});
+
+describe("TransactionScopeStepCardBody", () => {
+  it("crash せず描画される", () => {
+    const step = baseStep({
+      kind: "transactionScope",
+      isolationLevel: "READ_COMMITTED",
+      propagation: "REQUIRED",
+      steps: [],
+    });
+    const { container } = render(
+      <TransactionScopeStepCardBody
+        step={step}
+        allSteps={[]}
+        tables={[]}
+        screens={[]}
+        commonGroups={[]}
+        onChange={noop}
+        onNavigateCommon={noop}
+      />,
+    );
+    expect(container.firstChild).not.toBeNull();
+  });
+});
+
+// ── JumpStepCardBody ────────────────────────────────────────────────
+
+describe("JumpStepCardBody", () => {
+  it("ジャンプ先 label を描画する", () => {
+    const step = baseStep({ kind: "jump", jumpTo: "step-2" });
+    const { container } = render(
+      <JumpStepCardBody step={step} allSteps={[]} onChange={noop} />,
+    );
+    expect(container.textContent).toContain("ジャンプ先");
+  });
+});
+
+// ── WorkflowStepCardBody ────────────────────────────────────────────
+
+describe("WorkflowStepCardBody", () => {
+  it("crash せず描画される (approval-sequential)", () => {
+    const step = baseStep({
+      kind: "workflow",
+      pattern: "approval-sequential",
+      approvers: [],
+      quorum: { type: "any" },
+    });
+    const { container } = render(
+      <WorkflowStepCardBody
+        step={step}
+        allSteps={[]}
+        tables={[]}
+        screens={[]}
+        commonGroups={[]}
+        onChange={noop}
+        onNavigateCommon={noop}
+      />,
+    );
+    expect(container.firstChild).not.toBeNull();
+  });
+});

--- a/frontend/src/components/process-flow/internal/step-cards/types.ts
+++ b/frontend/src/components/process-flow/internal/step-cards/types.ts
@@ -1,0 +1,44 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+// Phase-2 (#1145) で StepCard.tsx から各 kind 別 body sub-component を抽出する際の共通 props 型。
+// 各 sub-component は本 `StepCardBodyBaseProps` を拡張せず使い回す (1 sub = 1 kind 専用)。
+
+import type { ProcessFlow, Step } from "../../../../types/action";
+import type { ValidationError } from "../../../../utils/actionValidation";
+
+export interface StepCardBodyBaseProps {
+  /** 対象 step (kind discriminator は各 sub-component 側で検査済) */
+  step: Step;
+  /** trail (subSteps の親含む) の全 step (jumpTarget / outputBinding 参照解決用) */
+  allSteps: Step[];
+  /** 部分更新 patch を親 StepCard に通知 */
+  onChange: (changes: Partial<Step>) => void;
+  /** edit-commit (blur 時 persistence flush) */
+  onCommit?: () => void;
+  /** read-only mode で input を disable */
+  readOnly?: boolean;
+}
+
+export interface StepCardBodyCatalogProps {
+  /** convention catalog (式補完 / バリデーション参照用) */
+  conventions?: import("../../../../schemas/conventionsValidator").ConventionsCatalog | null;
+  /** parent group (TX scope などで context.catalogs.errors 参照に必要、#415) */
+  group?: ProcessFlow | null;
+  /** ValidationError (kind body 側で利用しないが、子 InlineStepList へ pass-through 用) */
+  validationErrors?: ValidationError[];
+}
+
+export interface StepCardBodyTableProps {
+  tables: { id: string; physicalName: string; name: string }[];
+}
+
+export interface StepCardBodyScreenProps {
+  screens: { id: string; name: string }[];
+}
+
+export interface StepCardBodyCommonGroupsProps {
+  commonGroups: { id: string; name: string }[];
+}
+
+export interface StepCardBodyNavigationProps {
+  onNavigateCommon: (refId: string) => void;
+}


### PR DESCRIPTION
## 関連

- Refs #1145 (シリーズ親 ISSUE、Phase-2 のみ対応で本 PR では close しない)
- 仕様: 既存 StepCard.tsx の振る舞いを sub-component に分割するだけの純粋リファクタ (新規 spec なし)。後続 Phase 3-7 完了時に最終 PR で \`Closes #1145\` を含める。

## 概要

#1145 Phase-2 として、StepCard.tsx (76KB / 1689 行) の \`step.kind === X\` 別 inline JSX body を 15 個の sub-component に分離。**StepCard.tsx 1689 行 / 76KB → 837 行 / 33KB (-50%, -43KB)**。

責務 / 振る舞いの変更は無し (純粋なファイル分割)。schema 無変更。

## 主な変更

- **sub-component 抽出**: \`frontend/src/components/process-flow/internal/step-cards/<Kind>StepCardBody.tsx\` に 15 個の body コンポーネントを新設
  - validation / dbAccess / externalSystem / commonProcess / compute / return / screenTransition / displayUpdate / branch / loop / log / audit / transactionScope / jump / workflow
  - 残 7 kind (loopBreak / loopContinue / eventPublish / eventSubscribe / closing / cdc / extension+other) は detail 専用 body が無く metadata + notes のみ — 分割対象外
- **共通 props 型**: \`step-cards/types.ts\` に \`StepCardBodyBaseProps\` / \`StepCardBodyCatalogProps\` / \`StepCardBodyTableProps\` / \`StepCardBodyScreenProps\` / \`StepCardBodyCommonGroupsProps\` / \`StepCardBodyNavigationProps\` の 6 種を定義し、各 sub-component で必要なものだけ extend
- **state 内部化**: branch / loop 専用の純粋 UI state (\`collapsedBranchIds\` / \`loopBodyCollapsed\`) と関連 handler (\`toggleBranchCollapse\` / \`setBranchAt\` / \`moveBranchUp/Down\` / \`deleteBranch\` / \`addBranch\` / \`addElseBranch\`) を該当 sub-component に内部化
- **barrel export**: \`step-cards/index.ts\` で 15 sub-component を一括 export、StepCard.tsx は 1 行で全 import
- **header badge は分割対象外**: line 317-417 の header 内 kind-specific badge 5 件 (\`dbAccess\` affected-rows / \`externalSystem\` outcomes/fireAndForget / \`workflow\` badge / \`commonProcess\` navigate) は単純な小さい JSX で、header と一体運用のため StepCard.tsx に残置
- **test 追加**: \`step-cards.test.tsx\` に 15 sub-component の最小 rendering test 23 件

### サイズ変化

| ファイル | Before | After | 差分 |
|---|---|---|---|
| \`process-flow/StepCard.tsx\` | **1689 行 / 76 KB** | **837 行 / 33 KB** | -852 行 / -43 KB (-50%) |
| \`step-cards/\` 新設 | — | 17 files / 112 KB (含 test) | +17 files |
| 全 vitest test 数 | 2207 | **2230** | +23 |

新規 sub-component の行数内訳:
- BranchStepCardBody: 298 / LoopStepCardBody: 163 / ExternalSystemStepCardBody: 193 / DbAccessStepCardBody: 158 / ValidationStepCardBody: 126
- WorkflowStepCardBody: 62 / CommonProcessStepCardBody: 69 / ReturnStepCardBody: 51 / TransactionScopeStepCardBody: 51 / ScreenTransitionStepCardBody: 47
- ComputeStepCardBody: 40 / JumpStepCardBody: 30 / AuditStepCardBody: 29 / LogStepCardBody: 29 / DisplayUpdateStepCardBody: 28
- types.ts: 44 / index.ts: 18 / step-cards.test.tsx: 427

## 仕様逐条突合 (自己申告)

本 PR は spec を伴わない純粋リファクタのため、「元 StepCard.tsx の dispatch 順と振る舞いを保つ」ことを逐条確認:

### dispatch 順 (StepCard.tsx → sub-component)

- \`step.kind === "validation"\` → StepCard.tsx:570 → ValidationStepCardBody.tsx:13 ✓
- \`step.kind === "dbAccess"\` → StepCard.tsx:581 → DbAccessStepCardBody.tsx:13 ✓
- \`step.kind === "externalSystem"\` → StepCard.tsx:592 → ExternalSystemStepCardBody.tsx:11 ✓
- \`step.kind === "commonProcess"\` → StepCard.tsx:602 → CommonProcessStepCardBody.tsx:14 ✓
- \`step.kind === "compute"\` → StepCard.tsx:613 → ComputeStepCardBody.tsx:15 ✓
- \`step.kind === "return"\` → StepCard.tsx:624 → ReturnStepCardBody.tsx:15 ✓
- \`step.kind === "screenTransition"\` → StepCard.tsx:635 → ScreenTransitionStepCardBody.tsx:14 ✓
- \`step.kind === "displayUpdate"\` → StepCard.tsx:646 → DisplayUpdateStepCardBody.tsx:9 ✓
- \`step.kind === "branch"\` → StepCard.tsx:656 → BranchStepCardBody.tsx:29 ✓
- \`step.kind === "loop"\` → StepCard.tsx:673 → LoopStepCardBody.tsx:26 ✓
- \`step.kind === "log"\` → StepCard.tsx:690 → LogStepCardBody.tsx:15 ✓
- \`step.kind === "audit"\` → StepCard.tsx:701 → AuditStepCardBody.tsx:15 ✓
- \`step.kind === "transactionScope"\` → StepCard.tsx:712 → TransactionScopeStepCardBody.tsx:23 ✓
- \`step.kind === "jump"\` → StepCard.tsx:729 → JumpStepCardBody.tsx:10 ✓
- \`step.kind === "workflow"\` → StepCard.tsx:739 → WorkflowStepCardBody.tsx:24 ✓

### State / handler 移管

- branch state \`collapsedBranchIds\` → BranchStepCardBody.tsx:43 (useState) ✓
- branch handler 一式 (toggleBranchCollapse / setBranchAt / moveBranchUp/Down / deleteBranch / addBranch / addElseBranch) → BranchStepCardBody.tsx:45-101 ✓
- loop state \`loopBodyCollapsed\` → LoopStepCardBody.tsx:38 (useState) ✓

### 不変条件

- header 内 5 種 kind-specific badge (StepCard.tsx:317/328/339/344/359) は元位置を維持 ✓
- subStep 再帰レンダリング (StepCard.tsx 末尾) は元のまま ✓
- editLevel / readOnly / onAskAi / markerCount 等の上位 props は全 sub-component に pass-through ✓
- \`@ts-nocheck\` 同様の legacy/v3 union 緩和理由 (#1016) を全 sub-component に付与 ✓

## レビューで特に見てほしい箇所

- **branch state の内部化判断**: 元 StepCard.tsx では \`collapsedBranchIds\` を parent state にしていたが、純粋 UI state (永続化不要、parent や sibling と共有不要) なため BranchStepCardBody 内部化に変更。同じ判断を loopBodyCollapsed にも適用。subStep 再帰では subStep ごとに独立 StepCard が立つため、collapsed 状態の挙動は元と同じ (元も sub StepCard 毎に新規 useState)。
- **header の 5 badge は分割対象外**: \`dbAccess.affectedRowsCheck\` / \`externalSystem.outcomes\` / \`externalSystem.fireAndForget\` / \`workflow.pattern\` / \`commonProcess.refId\` の 5 つの header badge は kind 別だが、header 全体の flex layout に密接結合しており分割すると props 数が増えるため StepCard.tsx に残置 (合計 50 行程度)。
- **共通 props 型の粒度**: 6 種 props interface (Base / Catalog / Table / Screen / CommonGroups / Navigation) は各 sub-component が \`Pick<...>\` で extend する設計。簡潔さを優先したため、将来 prop を追加する際は extend 元に集約すること。
- **\`@ts-nocheck\` の引継ぎ**: 元 StepCard.tsx と同じ理由 (#1016 legacy/v3 union 未確定) で全 sub-component に \`@ts-nocheck\` を付与。Phase 完了後の cleanup で順次解除可能。

## テスト

- Vitest: **2230 件 (新規 +23 件)** — step-cards.test.tsx で 15 sub-component の rendering / 主要 handler を確認
- Playwright: 既存全件未実行 (e2e は backend / dev server 起動が前提のためローカル実行せず)
- MCP E2E: 該当なし
- 型: \`tsc --noEmit\` clean ✓
- Build: \`npm run build\` clean ✓
- Lint: \`npm run lint\` clean (新規 error 0、pre-existing warning 4 件のみ) ✓

## UI 影響 / AI smoke test

- [x] UI 影響あり (純粋なファイル分割 — 同じ DOM 構造 / 同じ CSS class / 同じ振る舞いを sub-component に分解)
- [ ] UI 影響なし

### UI 影響ありの場合、AI smoke test で確認した項目

- [ ] 実機 browser smoke は backend dev server 起動が必要のため**本 PR では未実行** (briefing で AI 単独で dev server 立てない方針 + Phase 1 PR #1158 と同様)。
- [x] 静的検証: tsc / vitest 2230 件 / build / lint 全 pass
- [x] 既存 27 件の internal/ test (AutoResizeTextarea / InlineStepList / stepCardConstants / stepSummaryText) も継続 pass — Phase-1 で固定した foundation は無傷
- [x] dispatch 順 / state 移管 / 不変条件 を上記 "仕様逐条突合" で 1 件ずつ手動確認

レビュアー / merge 担当者がローカルで dev server + browser smoke を回すことを推奨 (process-flow editor を開き、各 kind の step を作って expand → form 編集 → save → reload で値保持確認)。

## spec 側の不足点 / 提案

N/A — 純粋リファクタのため spec 改変なし。schemas/v3/ 無変更を確認済。

## レビュー担当への申し送り

- **#1145 Phase-2 のみ対応**: 本 PR で Phase-2 のみ完遂、後続 Phase-3 (ProcessFlowEditor) / Phase-4-7 はそれぞれ別 PR。最終 Phase 完了時に \`Closes #1145\` を含める。
- **目標 (76KB → 20KB 以下) は未達成 (33KB)**: 残 33KB は header + menu + AI marker + edit form 共通部 + subStep 再帰など、kind 横断の共通機能で構成。Phase-2 のスコープ「kind 別 body 分離」は完遂、header の更なる細分化は Phase-3 (ProcessFlowEditor 系) と同じ判断指針に従って別 Phase で扱う方が一貫性がある。
- **briefing で禁止された follow-up ISSUE 起票はしていない**: header 細分化候補や \`@ts-nocheck\` 解除候補は #1145 本文の Phase-2 sub-section にメモせず、後続 Phase で考慮する文脈 (リファクタ Phase 連続) に組み込まれている。
- **#1145 本文 update**: Phase-2 完了マーク追加と Phase-3 移行の明示を本 PR merge 後に同 ISSUE 本文に追記する (本 PR では未実施 — 次の subagent task で実施推奨)。