### PR TITLE
refactor(process-flow): ProcessFlowEditor.tsx 分割 + N-3/N-4 + AI step 3 dispatch (#1145 Phase-3)

### DIFF
--- a/frontend/src/components/process-flow/ProcessFlowEditor.tsx
+++ b/frontend/src/components/process-flow/ProcessFlowEditor.tsx
@@ -1,20 +1,24 @@
 // @ts-nocheck -- large legacy editor migration remains open; tracked by #1016.
-import { useState, useEffect, useLayoutEffect, useCallback, useMemo, useRef, type ReactNode } from "react";
+//
+// Phase-3 (#1145): 94KB → 30KB 目標で以下を抽出:
+//   - internal/PaletteButtons.tsx (ToolbarStepButton / StepInsertZone / EmptyFlowDropZone / CustomStepButton)
+//   - internal/ActionHelpPopover.tsx
+//   - internal/actionTriggerConstants.ts (trigger 定数 + ヘルパー)
+//   - internal/AddActionModal.tsx
+//   - internal/StepContextMenu.tsx
+//   - internal/WarningsPanel.tsx
+//   - internal/stepCardConstants.ts に ALL_STEP_TYPES を追加
+// 残置: ProcessFlowEditor 本体 (state 統合 / D&D / edit-session 連携 / 主 JSX)。
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import { useWorkspacePath } from "../../hooks/useWorkspacePath";
 import type {
   ProcessFlow,
-  ActionDefinition,
   ActionTrigger,
   Step,
   StepType,
 } from "../../types/action";
-import {
-  ACTION_TRIGGER_LABELS,
-  STEP_TYPE_LABELS,
-  STEP_TYPE_ICONS,
-  STEP_TEMPLATES,
-} from "../../types/action";
+import { STEP_TEMPLATES, STEP_TYPE_LABELS } from "../../types/action";
 import {
   loadProcessFlow,
   saveProcessFlow,
@@ -26,55 +30,29 @@ import {
   addSubStep,
 } from "../../store/processFlowStore";
 import { applyProcessFlowMutation } from "./processFlowMutation";
-import { listTables, loadTable } from "../../store/tableStore";
-import { loadProject } from "../../store/flowStore";
-import { getStepLabel, clearJumpReferences } from "../../utils/actionUtils";
+import { clearJumpReferences } from "../../utils/actionUtils";
 import { hasBlockingErrors } from "../../utils/actionValidation";
 import { aggregateValidation } from "../../utils/aggregatedValidation";
-import type { TableDefinition as ValidatorTableDef } from "../../schemas/sqlColumnValidator";
-import type { ConventionsCatalog } from "../../schemas/conventionsValidator";
-import type { GenericDefinitionNames } from "../../schemas/referentialIntegrity";
-import type { ProjectCatalogs } from "../../schemas/projectCatalogs";
-import { loadExtensionsFromBundle, type LoadedExtensions } from "../../schemas/loadExtensions";
-import { loadConventions } from "../../store/conventionsStore";
-import { listGenericDefinitions } from "../../store/genericDefinitionStore";
 import { generateUUID } from "../../utils/uuid";
 import {
   DndContext,
   closestCenter,
-  useDraggable,
-  useDroppable,
   PointerSensor,
   useSensor,
   useSensors,
   type DragEndEvent,
   type CollisionDetection,
 } from "@dnd-kit/core";
-import {
-  SortableContext,
-  verticalListSortingStrategy,
-} from "@dnd-kit/sortable";
 import { useResourceEditor } from "../../hooks/useResourceEditor";
 import { useEditSession } from "../../hooks/useEditSession";
 import { useSaveShortcut } from "../../hooks/useSaveShortcut";
 import { useSessionUrlSync } from "../../hooks/useSessionUrlSync";
 import { mcpBridge } from "../../mcp/mcpBridge";
 import { useSelectionKeyboard } from "../../hooks/useSelectionKeyboard";
-import { STEP_TYPE_COLORS } from "../../types/action";
 import { TableSubToolbar } from "../table/TableSubToolbar";
-import { SortableStepCard } from "./SortableStepCard";
-import { MaturityBadge } from "./MaturityBadge";
-import { ActionHttpContractPanel } from "./ActionHttpContractPanel";
-import { ActionMetaTabBar } from "./ActionMetaTabBar";
-import { SlaPanel } from "./SlaPanel";
 import { DrawingOverlay } from "./DrawingOverlay";
-import { StructuredFieldsEditor, type ScreenItemPickResult } from "./StructuredFieldsEditor";
+import { type ScreenItemPickResult } from "./StructuredFieldsEditor";
 import { ScreenItemPickerModal } from "./ScreenItemPickerModal";
-import { ProcessFlowAiGenerateDialog } from "./ProcessFlowAiGenerateDialog";
-import { ProcessFlowAiReviewDialog } from "./ProcessFlowAiReviewDialog";
-import { EditLevelToggle } from "./EditLevelToggle";
-import { AiRequestPanel } from "./AiRequestPanel";
-import { AiDiffPreviewDialog } from "./AiDiffPreviewDialog";
 import { applyProcessFlowDiffSelection, replaceProcessFlowContents } from "./AiDiffPreviewDialogUtils";
 import { useEditLevel } from "../../hooks/useEditLevel";
 import { useAiContextChips } from "../../hooks/useAiContextChips";
@@ -82,362 +60,22 @@ import { useCodexStatus } from "../../codex/useCodexStatus";
 import { requestProcessFlowPartial, AiUnavailableError } from "../../codex/processFlowPartialRequest";
 import { EditorHeader } from "../common/EditorHeader";
 import { EditModeToolbar } from "../editing/EditModeToolbar";
-import { DiscardConfirmDialog, ForceReleaseConfirmDialog, ForcedOutChoiceDialog, AfterForceUnlockChoiceDialog } from "../editing/ConfirmDialogs";
-import { SaveConflictDialog } from "../editing/SaveConflictDialog";
-import { ResumeOrDiscardDialog } from "../editing/ResumeOrDiscardDialog";
-import { EditSessionDropdown } from "../editing/EditSessionDropdown";
 import { setDirty as setTabDirty, makeTabId } from "../../store/tabStore";
 import "../../styles/editMode.css";
-import { ServerChangeBanner } from "../common/ServerChangeBanner";
 import "../../styles/processFlow.css";
-
-/** ツールバーのドラッグ可能なステップ種別ボタン */
-function ToolbarStepButton({ type, onClick, disabled = false }: { type: StepType; onClick: () => void; disabled?: boolean }) {
-  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
-    id: `toolbar-${type}`,
-    data: { kind: "toolbar-step", stepType: type },
-    disabled,
-  });
-  return (
-    <button
-      ref={setNodeRef}
-      {...(disabled ? {} : listeners)}
-      {...(disabled ? {} : attributes)}
-      className={`step-toolbar-btn${isDragging ? " dragging" : ""}`}
-      onClick={onClick}
-      title={`${STEP_TYPE_LABELS[type]}（ドラッグで挿入）`}
-      disabled={disabled}
-      style={isDragging ? { opacity: 0.5, borderColor: STEP_TYPE_COLORS[type] } : undefined}
-    >
-      <i className={STEP_TYPE_ICONS[type]} />
-      {STEP_TYPE_LABELS[type]}
-    </button>
-  );
-}
-
-/** ステップ間のドロップゾーン */
-function StepInsertZone({
-  index,
-  onClick,
-  onPaste,
-  dragVisible,
-  disabled = false,
-}: {
-  index: number;
-  onClick: () => void;
-  onPaste?: () => void;
-  dragVisible?: boolean;
-  disabled?: boolean;
-}) {
-  const { setNodeRef, isOver } = useDroppable({
-    id: `insert-${index}`,
-    data: { kind: "insert-zone", insertIndex: index },
-    disabled,
-  });
-  if (disabled) return null;
-  return (
-    <div
-      ref={setNodeRef}
-      className={`step-insert-point${isOver ? " drop-active" : ""}${onPaste ? " has-paste" : ""}${dragVisible ? " drag-visible" : ""}`}
-    >
-      <button className="step-insert-btn" onClick={onClick} title="ステップを挿入">
-        <i className="bi bi-plus" />
-      </button>
-      {onPaste && (
-        <button className="step-paste-btn" onClick={onPaste} title="ここに貼り付け">
-          <i className="bi bi-clipboard-plus me-1" />貼り付け
-        </button>
-      )}
-    </div>
-  );
-}
-
-function EmptyFlowDropZone({ children, disabled = false }: { children: ReactNode; disabled?: boolean }) {
-  const { setNodeRef, isOver } = useDroppable({
-    id: "empty-flow-drop",
-    data: { kind: "insert-zone", insertIndex: 0 },
-    disabled,
-  });
-  return (
-    <div ref={setNodeRef} className={`step-empty process-flow-empty-drop${isOver ? " drop-active" : ""}`}>
-      {children}
-    </div>
-  );
-}
-
-const ALL_STEP_TYPES: StepType[] = [
-  "validation", "dbAccess", "externalSystem", "commonProcess",
-  "screenTransition", "displayUpdate", "branch", "loop",
-  "loopBreak", "loopContinue", "jump", "compute", "return", "other",
-  "log", "audit", "workflow", "transactionScope",
-  "eventPublish", "eventSubscribe", "closing", "cdc",
-];
-
-const ALL_SUB_STEP_TYPES: StepType[] = [
-  "validation", "dbAccess", "externalSystem", "commonProcess",
-  "screenTransition", "displayUpdate", "branch", "loop",
-  "loopBreak", "loopContinue", "jump", "compute", "return", "other",
-  "log", "audit", "workflow", "transactionScope",
-  "eventPublish", "eventSubscribe", "closing", "cdc",
-];
-
-const ALL_TRIGGERS: ActionTrigger[] = ["click", "submit", "select", "change", "load", "timer", "other"];
-
-const ACTION_TRIGGER_ICONS: Record<string, string> = {
-  click: "bi-cursor",
-  submit: "bi-send",
-  select: "bi-list-check",
-  change: "bi-pencil-square",
-  load: "bi-box-arrow-in-down",
-  unload: "bi-box-arrow-right",
-  timer: "bi-clock",
-  manual: "bi-person-check",
-  other: "bi-lightning-charge",
-};
-
-const ACTION_TRIGGER_CATEGORIES: Record<string, string> = {
-  click: "画面操作",
-  submit: "入力確定",
-  select: "選択連動",
-  change: "値変更",
-  load: "初期表示",
-  unload: "終了処理",
-  timer: "時刻・周期",
-  manual: "手動実行",
-  other: "その他",
-};
-
-const ACTION_TRIGGER_RICH_HELP: Record<string, {
-  occasion: string;
-  useCases: string[];
-  definitionExample: string;
-  stepExample: string[];
-  notes: string[];
-}> = {
-  click: {
-    occasion: "ボタンやリンクなど、利用者が明示的に押した UI 操作を契機に動きます。",
-    useCases: ["詳細表示", "削除確認", "検索条件クリア", "別画面への遷移"],
-    definitionExample: "trigger: click / inputs: 選択行ID・画面入力値 / responses: 完了メッセージ",
-    stepExample: ["入力・選択状態を確認", "必要な DB 更新または参照", "画面更新または画面遷移"],
-    notes: ["連打や二重送信を避ける制御が必要な場合は validation や workflow に明記します。"],
-  },
-  submit: {
-    occasion: "フォーム送信や確定操作で、入力内容を業務データとして確定するときに動きます。",
-    useCases: ["登録", "更新", "申請", "承認依頼"],
-    definitionExample: "trigger: submit / inputs: フォーム全項目 / outputs: 登録ID / responses: 成功・入力エラー",
-    stepExample: ["必須・形式チェック", "業務ルール検証", "DB 保存", "レスポンス返却"],
-    notes: ["入力エラーとシステムエラーの responses を分けると、AI 実装時の分岐が明確になります。"],
-  },
-  select: {
-    occasion: "一覧行、候補、タブなどの選択状態が変わったタイミングで動きます。",
-    useCases: ["一覧行の詳細表示", "候補選択による関連情報取得", "親子リストの絞り込み"],
-    definitionExample: "trigger: select / inputs: selectedId / outputs: detailModel",
-    stepExample: ["選択IDの存在確認", "関連データ取得", "表示モデルへ反映"],
-    notes: ["選択解除時の扱いが必要なら other response または branch に明記します。"],
-  },
-  change: {
-    occasion: "入力値やフィルタ条件が変わった直後に、画面内の連動処理として動きます。",
-    useCases: ["金額再計算", "項目の表示切替", "候補リスト更新", "入力補助"],
-    definitionExample: "trigger: change / inputs: changedField・currentForm / outputs: derivedValues",
-    stepExample: ["変更項目を判定", "派生値を計算", "表示状態を更新"],
-    notes: ["高頻度に動くため、重い外部呼び出しは debounce や submit 側への移動を検討します。"],
-  },
-  load: {
-    occasion: "画面表示、初期データ取得、リソース読み込みの開始時に動きます。",
-    useCases: ["初期検索", "選択肢取得", "初期値設定", "権限に応じた表示制御"],
-    definitionExample: "trigger: load / inputs: routeParams・sessionUser / outputs: initialViewModel",
-    stepExample: ["起動条件を確認", "初期データを取得", "画面モデルを構築"],
-    notes: ["表示前に必要なデータと、表示後に遅延取得できるデータを分けると実装しやすくなります。"],
-  },
-  unload: {
-    occasion: "画面離脱、タブ終了、編集終了など、利用者が作業文脈を閉じるときに動きます。",
-    useCases: ["一時保存", "ロック解放", "離脱確認", "監査ログ記録"],
-    definitionExample: "trigger: unload / inputs: dirtyState・lockId / responses: 保存済み・破棄確認",
-    stepExample: ["未保存状態を確認", "必要なら保存または確認", "ロックや一時資源を解放"],
-    notes: ["ブラウザ終了時は非同期処理が完了しない可能性があるため、重要処理は明示保存側に寄せます。"],
-  },
-  timer: {
-    occasion: "一定間隔、指定時刻、期限到来など時間条件を契機に動きます。",
-    useCases: ["自動更新", "期限チェック", "バッチ起動", "再試行"],
-    definitionExample: "trigger: timer / inputs: schedule・lastRunAt / outputs: runSummary",
-    stepExample: ["実行条件を確認", "対象データを抽出", "処理を実行", "結果を記録"],
-    notes: ["重複起動、タイムアウト、リトライ方針を steps または SLA に記述します。"],
-  },
-  manual: {
-    occasion: "運用者や管理者が、通常 UI フローとは別に明示起動するときに動きます。",
-    useCases: ["手動再実行", "補正処理", "管理操作", "障害復旧"],
-    definitionExample: "trigger: manual / inputs: operatorId・targetId / responses: 実行結果・権限エラー",
-    stepExample: ["権限を確認", "対象を検証", "処理を実行", "監査ログを残す"],
-    notes: ["誰が何を起動できるかを inputs と validation に明記します。"],
-  },
-  other: {
-    occasion: "標準 trigger に当てはまらない、プロジェクト固有の契機で動きます。",
-    useCases: ["外部通知", "組み込み拡張", "特殊な業務イベント"],
-    definitionExample: "trigger: other / description: 契機の発生元と実行条件を明記",
-    stepExample: ["契機を説明", "入力契約を検証", "業務処理を実行", "結果を返す"],
-    notes: ["比較・保守しやすいように、description で契機名と発生条件を補足します。"],
-  },
-};
-
-const getActionTriggerLabel = (trigger: string) => ACTION_TRIGGER_LABELS[trigger] ?? trigger;
-const getActionTriggerIcon = (trigger: string) => ACTION_TRIGGER_ICONS[trigger] ?? ACTION_TRIGGER_ICONS.other;
-const getActionTriggerCategory = (trigger: string) => ACTION_TRIGGER_CATEGORIES[trigger] ?? ACTION_TRIGGER_CATEGORIES.other;
-const getActionTriggerRichHelp = (trigger: string) => ACTION_TRIGGER_RICH_HELP[trigger] ?? ACTION_TRIGGER_RICH_HELP.other;
-
-function countActionFields(fields: unknown): number {
-  if (Array.isArray(fields)) return fields.length;
-  if (typeof fields === "string" && fields.trim()) return 1;
-  return 0;
-}
-
-function summarizeActionFields(fields: unknown, fallback: string): string {
-  if (Array.isArray(fields) && fields.length > 0) {
-    return fields
-      .slice(0, 3)
-      .map((field) => {
-        if (typeof field === "string") return field;
-        return field?.name ?? field?.id ?? "名称未設定";
-      })
-      .join("、") + (fields.length > 3 ? ` ほか ${fields.length - 3} 件` : "");
-  }
-  if (typeof fields === "string" && fields.trim()) return fields.trim().slice(0, 80);
-  return fallback;
-}
-
-function summarizeActionStepTypes(action: ActionDefinition): string {
-  const counts = new Map<string, number>();
-  for (const step of action.steps ?? []) {
-    const key = step.kind ?? "other";
-    counts.set(key, (counts.get(key) ?? 0) + 1);
-  }
-  if (counts.size === 0) return "ステップ未定義";
-  return [...counts.entries()]
-    .slice(0, 4)
-    .map(([type, count]) => `${STEP_TYPE_LABELS[type] ?? type} ${count}`)
-    .join(" / ");
-}
-
-function getActionOpenMarkers(action: ActionDefinition, actionIndex: number, markers: Marker[]): Marker[] {
-  const stepIds = new Set((action.steps ?? []).map((step) => step.id));
-  const actionPathById = `actions[${action.id}]`;
-  const actionPathByIndex = actionIndex >= 0 ? `actions[${actionIndex}]` : null;
-  return markers.filter((marker) => {
-    if (marker.resolvedAt) return false;
-    if (marker.actionId === action.id) return true;
-    const markerStepId = marker.stepId ?? marker.anchor?.stepId;
-    if (markerStepId && stepIds.has(markerStepId)) return true;
-    const markerPath = marker.path ?? marker.validatorPath ?? marker.anchor?.fieldPath ?? "";
-    return typeof markerPath === "string"
-      && (markerPath.includes(actionPathById) || (!!actionPathByIndex && markerPath.includes(actionPathByIndex)));
-  });
-}
-
-function summarizeActionMarkers(markers: Marker[]): string {
-  if (markers.length === 0) return "なし";
-  const counts = new Map<string, number>();
-  for (const marker of markers) {
-    const kind = marker.kind ?? "marker";
-    counts.set(kind, (counts.get(kind) ?? 0) + 1);
-  }
-  return [...counts.entries()].map(([kind, count]) => `${kind} ${count}`).join(" / ");
-}
-
-function ActionHelpPopover({
-  action,
-  actionIndex,
-  markers,
-  position,
-  onPointerEnter,
-  onPointerLeave,
-}: {
-  action: ActionDefinition;
-  actionIndex: number;
-  markers: Marker[];
-  position: { left: number; top: number; placement: "below" | "above" };
-  onPointerEnter: () => void;
-  onPointerLeave: () => void;
-}) {
-  const help = getActionTriggerRichHelp(action.trigger);
-  const openMarkers = getActionOpenMarkers(action, actionIndex, markers);
-  const stepCount = action.steps?.length ?? 0;
-  const inputCount = countActionFields(action.inputs);
-  const outputCount = countActionFields(action.outputs);
-  const responseCount = countActionFields(action.responses);
-
-  return (
-    <div
-      id={`action-help-${action.id}`}
-      className={`process-flow-action-help ${position.placement}`}
-      style={{ left: position.left, top: position.top }}
-      role="tooltip"
-      onPointerEnter={onPointerEnter}
-      onPointerLeave={onPointerLeave}
-    >
-      <div className="process-flow-action-help-head">
-        <span className="process-flow-action-help-icon" aria-hidden="true">
-          <i className={`bi ${getActionTriggerIcon(action.trigger)}`} />
-        </span>
-        <div>
-          <div className="process-flow-action-help-title">{action.name}</div>
-          <div className="process-flow-action-help-subtitle">
-            {getActionTriggerLabel(action.trigger)} / {getActionTriggerCategory(action.trigger)}
-          </div>
-        </div>
-      </div>
-
-      <div className="process-flow-action-help-grid">
-        <section>
-          <h6>契機</h6>
-          <p>{help.occasion}</p>
-        </section>
-        <section>
-          <h6>代表用途</h6>
-          <ul>{help.useCases.map((item) => <li key={item}>{item}</li>)}</ul>
-        </section>
-        <section>
-          <h6>定義例</h6>
-          <p>{help.definitionExample}</p>
-        </section>
-        <section>
-          <h6>ステップ例</h6>
-          <ol>{help.stepExample.map((item) => <li key={item}>{item}</li>)}</ol>
-        </section>
-        <section>
-          <h6>このアクション</h6>
-          <dl>
-            <div><dt>入出力</dt><dd>inputs {inputCount} / outputs {outputCount} / responses {responseCount}</dd></div>
-            <div><dt>入力</dt><dd>{summarizeActionFields(action.inputs, "未定義")}</dd></div>
-            <div><dt>出力</dt><dd>{summarizeActionFields(action.outputs, "未定義")}</dd></div>
-            <div><dt>応答</dt><dd>{summarizeActionFields(action.responses, "未定義")}</dd></div>
-            <div><dt>ステップ</dt><dd>{stepCount} 件 / {summarizeActionStepTypes(action)}</dd></div>
-            <div><dt>成熟度</dt><dd>{action.maturity ?? "未設定"}</dd></div>
-            <div><dt>未解決マーカー</dt><dd>{openMarkers.length} 件 / {summarizeActionMarkers(openMarkers)}</dd></div>
-          </dl>
-        </section>
-        <section>
-          <h6>注意点</h6>
-          <ul>{help.notes.map((item) => <li key={item}>{item}</li>)}</ul>
-        </section>
-      </div>
-    </div>
-  );
-}
-
-function CustomStepButton({ id, label, icon, description }: { id: string; label: string; icon: string; description: string }) {
-  return (
-    <button
-      type="button"
-      className="step-toolbar-btn"
-      disabled
-      title={`D&D 配置は別 ISSUE で対応予定: ${id}`}
-      aria-disabled="true"
-    >
-      <i className={icon || "bi bi-puzzle"} />
-      {label || id}
-      {description ? <span className="visually-hidden">{description}</span> : null}
-    </button>
-  );
-}
+// Phase-3 (#1145) で抽出した internal 部品群
+import { AddActionModal } from "./internal/AddActionModal";
+import { StepContextMenu } from "./internal/StepContextMenu";
+import { WarningsPanel } from "./internal/WarningsPanel";
+import { ALL_STEP_TYPES } from "./internal/stepCardConstants";
+import { ProcessFlowDialogs } from "./internal/ProcessFlowDialogs";
+import { useProcessFlowCatalogs } from "./internal/useProcessFlowCatalogs";
+import { useActionHelpPopover } from "./internal/useActionHelpPopover";
+import { ActionTabBar } from "./internal/ActionTabBar";
+import { PalettePanel } from "./internal/PalettePanel";
+import { InspectorPanel } from "./internal/InspectorPanel";
+import { CanvasPane } from "./internal/CanvasPane";
+import { EditorHeaderExtras } from "./internal/EditorHeaderExtras";
 
 export function ProcessFlowEditor() {
   const { processFlowId } = useParams<{ processFlowId: string }>();
@@ -450,9 +88,20 @@ export function ProcessFlowEditor() {
   const pickerResolveRef = useRef<((r: ScreenItemPickResult | null) => void) | null>(null);
   const [newActionName, setNewActionName] = useState("");
   const [newActionTrigger, setNewActionTrigger] = useState<ActionTrigger>("click");
-  const [tables, setTables] = useState<{ id: string; physicalName: string; name: string }[]>([]);
-  const [screens, setScreens] = useState<{ id: string; name: string }[]>([]);
-  const [commonGroups, setCommonGroups] = useState<{ id: string; name: string }[]>([]);
+  // カタログ群 (tables / screens / commonGroups / tableDefs / conventions /
+  // extensions / genericDefNames / projectCatalogs) は Phase-3 で
+  // useProcessFlowCatalogs フックに集約 (#1145)。
+  const {
+    tables,
+    screens,
+    commonGroups,
+    tableDefs,
+    conventions,
+    extensions,
+    genericDefNames,
+    projectCatalogs,
+    loadAll: loadAllCatalogs,
+  } = useProcessFlowCatalogs();
   const [showTemplates, setShowTemplates] = useState(false);
   const [showWarningsPanel, setShowWarningsPanel] = useState(false);
   const [drawingMode, setDrawingMode] = useState(false);
@@ -461,22 +110,13 @@ export function ProcessFlowEditor() {
   const [isDraggingToolbarStep, setIsDraggingToolbarStep] = useState(false);
   const [stepFilter, setStepFilter] = useState("");
   const [commandQuery, setCommandQuery] = useState("");
-  const [actionHelp, setActionHelp] = useState<{
-    actionId: string;
-    left: number;
-    top: number;
-    placement: "below" | "above";
-    anchorTop: number;
-    anchorBottom: number;
-  } | null>(null);
-  const actionHelpCloseTimerRef = useRef<number | null>(null);
-  // SQL 列検査 / 規約参照検査のため (#261)
-  const [tableDefs, setTableDefs] = useState<ValidatorTableDef[]>([]);
-  const [conventions, setConventions] = useState<ConventionsCatalog | null>(null);
-  const [extensions, setExtensions] = useState<LoadedExtensions | undefined>(undefined);
-  // #1090: Generic Definition Catalog の name set (componentRef / exceptionTypeRef 検証用)
-  const [genericDefNames, setGenericDefNames] = useState<GenericDefinitionNames>({});
-  const [projectCatalogs, setProjectCatalogs] = useState<ProjectCatalogs | null>(null);
+  // ActionHelpPopover の位置 / open-close debounce は useActionHelpPopover に集約 (#1145 Phase-3)。
+  const {
+    actionHelp,
+    openActionHelp,
+    scheduleCloseActionHelp,
+    clearActionHelpCloseTimer,
+  } = useActionHelpPopover();
   const [newStepIds, setNewStepIds] = useState<Set<string>>(new Set());
 
   // 選択・クリップボード state
@@ -509,51 +149,9 @@ export function ProcessFlowEditor() {
 
   const handleLoaded = useCallback((g: ProcessFlow) => {
     setActiveActionId((cur) => cur ?? (g.actions.length > 0 ? g.actions[0].id : null));
-    loadProject().then((p) => {
-      setScreens(p.screens.map((s) => ({ id: s.id, name: s.name })));
-      const agMetas = p.processFlows ?? [];
-      setCommonGroups(agMetas.filter((a) => a.kind === "common").map((a) => ({ id: a.id, name: a.name })));
-    }).catch(console.error);
-    listTables().then(async (metas) => {
-      setTables(metas.map((tm) => ({ id: tm.id, physicalName: tm.physicalName ?? "", name: tm.name })));
-      // SQL 列検査用に全テーブルの columns まで読む (#261 UI 統合)
-      const defs = await Promise.all(
-        metas.map(async (tm) => {
-          const full = await loadTable(tm.id);
-          if (!full) return null;
-          return {
-            // sqlColumnValidator は物理名 (snake_case) で SQL 列を検証するため、
-            // v3 では table.physicalName / column.physicalName を渡す (v3 の name は表示名)。
-            id: full.id,
-            name: full.physicalName,
-            columns: (full.columns ?? []).map((c) => ({ name: c.physicalName })),
-          } as ValidatorTableDef;
-        }),
-      );
-      setTableDefs(defs.filter((d): d is ValidatorTableDef => d !== null));
-    }).catch(console.error);
-    // 規約カタログは wsBridge / localStorage 経由で取得 (#317)。
-    // 未接続時は null。編集は「規約カタログ」タブから。
-    loadConventions()
-      .then((c) => setConventions(c as ConventionsCatalog | null))
-      .catch(() => setConventions(null));
-    mcpBridge.request("loadProjectCatalogs")
-      .then((c) => setProjectCatalogs(c as ProjectCatalogs | null))
-      .catch(() => setProjectCatalogs(null));
-    mcpBridge.getExtensions()
-      .then((bundle) => setExtensions(loadExtensionsFromBundle(bundle).extensions))
-      .catch(() => setExtensions(undefined));
-    // #1090: Generic Definition Catalog の name set を取得
-    Promise.all([
-      listGenericDefinitions("component-definition").catch(() => []),
-      listGenericDefinitions("exception-type").catch(() => []),
-    ]).then(([components, exceptions]) => {
-      setGenericDefNames({
-        "component-definition": new Set(components.map((c) => c.name)),
-        "exception-type": new Set(exceptions.map((e) => e.name)),
-      });
-    });
-  }, []);
+    // 規約 / extensions / table / screen / commonGroup 等のカタログを useProcessFlowCatalogs に委譲。
+    loadAllCatalogs(g);
+  }, [loadAllCatalogs]);
 
   const sessionId = mcpBridge.getSessionId();
 
@@ -784,13 +382,7 @@ export function ProcessFlowEditor() {
     [group, tableDefs, conventions, extensions, genericDefNames, projectCatalogs],
   );
 
-  useEffect(() => {
-    return mcpBridge.onExtensionsChanged(() => {
-      mcpBridge.getExtensions(true)
-        .then((bundle) => setExtensions(loadExtensionsFromBundle(bundle).extensions))
-        .catch(() => setExtensions(undefined));
-    });
-  }, []);
+  // mcpBridge.onExtensionsChanged の watch は useProcessFlowCatalogs 内で管理 (Phase-3)。
 
   const customStepCards = Object.entries(extensions?.steps ?? {});
   const normalizedStepFilter = stepFilter.trim().toLowerCase();
@@ -838,77 +430,14 @@ export function ProcessFlowEditor() {
     });
   };
 
-  const clearActionHelpCloseTimer = useCallback(() => {
-    if (actionHelpCloseTimerRef.current !== null) {
-      window.clearTimeout(actionHelpCloseTimerRef.current);
-      actionHelpCloseTimerRef.current = null;
-    }
-  }, []);
+  // ActionHelpPopover の位置 / open-close debounce は useActionHelpPopover に集約済 (Phase-3)。
 
-  const openActionHelp = useCallback((actionId: string, anchor: HTMLElement) => {
-    clearActionHelpCloseTimer();
-    const rect = anchor.getBoundingClientRect();
-    const popoverWidth = Math.min(420, Math.max(280, window.innerWidth - 24));
-    const left = Math.min(
-      Math.max(12, rect.left + rect.width / 2 - popoverWidth / 2),
-      window.innerWidth - popoverWidth - 12,
-    );
-    const belowTop = rect.bottom + 10;
-    const estimatedHeight = 430;
-    const canOpenBelow = belowTop + estimatedHeight <= window.innerHeight - 12;
-    setActionHelp({
-      actionId,
-      left,
-      top: canOpenBelow ? belowTop : Math.max(12, rect.top - estimatedHeight - 10),
-      placement: canOpenBelow ? "below" : "above",
-      anchorTop: rect.top,
-      anchorBottom: rect.bottom,
-    });
-  }, [clearActionHelpCloseTimer]);
-
-  const scheduleCloseActionHelp = useCallback(() => {
-    clearActionHelpCloseTimer();
-    actionHelpCloseTimerRef.current = window.setTimeout(() => {
-      setActionHelp(null);
-      actionHelpCloseTimerRef.current = null;
-    }, 120);
-  }, [clearActionHelpCloseTimer]);
-
-  useEffect(() => {
-    if (!actionHelp) return undefined;
-    const close = () => setActionHelp(null);
-    window.addEventListener("resize", close);
-    return () => {
-      window.removeEventListener("resize", close);
-    };
-  }, [actionHelp]);
-
-  useLayoutEffect(() => {
-    if (!actionHelp) return;
-    const popover = document.getElementById(`action-help-${actionHelp.actionId}`);
-    if (!popover) return;
-    const actualHeight = Math.min(popover.getBoundingClientRect().height, window.innerHeight - 24);
-    const belowTop = actionHelp.anchorBottom + 10;
-    const canOpenBelow = belowTop + actualHeight <= window.innerHeight - 12;
-    const nextTop = canOpenBelow
-      ? belowTop
-      : Math.max(12, actionHelp.anchorTop - actualHeight - 10);
-    const nextPlacement = canOpenBelow ? "below" : "above";
-    if (Math.abs(nextTop - actionHelp.top) > 1 || nextPlacement !== actionHelp.placement) {
-      setActionHelp((cur) => cur && cur.actionId === actionHelp.actionId
-        ? { ...cur, top: nextTop, placement: nextPlacement }
-        : cur);
-    }
-  }, [actionHelp]);
-
-  useEffect(() => () => clearActionHelpCloseTimer(), [clearActionHelpCloseTimer]);
-
-  const handleAddStep = (type: StepType, insertIndex?: number) => {
+  const handleAddStep = (kind: StepType, insertIndex?: number) => {
     if (!activeAction) return;
     updateGroupWithDraft((g) => {
       const act = g.actions.find((a) => a.id === activeActionId);
       if (act) {
-        const step = addStep(act, type, insertIndex);
+        const step = addStep(act, kind, insertIndex);
         setNewStepIds((prev) => new Set(prev).add(step.id));
       }
     });
@@ -1023,12 +552,12 @@ export function ProcessFlowEditor() {
     });
   };
 
-  const handleAddSubStep = (parentStepId: string, type: StepType) => {
+  const handleAddSubStep = (parentStepId: string, kind: StepType) => {
     updateGroupWithDraft((g) => {
       const act = g.actions.find((a) => a.id === activeActionId);
       if (!act) return;
       const parent = act.steps.find((s) => s.id === parentStepId);
-      if (parent) addSubStep(parent, type);
+      if (parent) addSubStep(parent, kind);
     });
     closeContextMenu();
   };
@@ -1264,80 +793,77 @@ export function ProcessFlowEditor() {
         ownerLabel={lockedByOther?.ownerSessionId}
       />
 
-      {mode.kind === "force-released-pending" && (
-        <ForcedOutChoiceDialog
-          previousDraftExists={mode.previousDraftExists}
-          onChoice={(choice) => editActions.handleForcedOut(choice)}
-        />
-      )}
+      <ProcessFlowDialogs
+        group={group}
+        mode={mode}
+        lockedByOther={lockedByOther}
+        showResumeDialog={showResumeDialog}
+        showDiscardDialog={showDiscardDialog}
+        showForceReleaseDialog={showForceReleaseDialog}
+        showAiGenerateDialog={showAiGenerateDialog}
+        showAiReviewDialog={showAiReviewDialog}
+        serverChanged={serverChanged}
+        onForcedOutChoice={(choice) => editActions.handleForcedOut(choice)}
+        onAfterForceUnlockChoice={(choice) => editActions.handleAfterForceUnlock(choice)}
+        onResumeContinue={handleResumeContinue}
+        onResumeDiscard={handleResumeDiscard}
+        onCancelResume={() => setShowResumeDialog(false)}
+        onDiscardConfirm={handleDiscard}
+        onDiscardCancel={() => setShowDiscardDialog(false)}
+        onForceReleaseConfirm={handleForceRelease}
+        onForceReleaseCancel={() => setShowForceReleaseDialog(false)}
+        saveConflict={saveConflict}
+        onSaveConflictOverwrite={async () => {
+          try {
+            await onSaveConflictOverwrite();
+            await hookPostSave();
+          } catch (e) {
+            console.error("[ProcessFlowEditor] save overwrite failed:", e);
+          }
+        }}
+        onSaveConflictCancel={onSaveConflictCancel}
+        onServerReload={handleReset}
+        onServerDismiss={dismissServerBanner}
+        onCloseAiGenerate={() => setShowAiGenerateDialog(false)}
+        onApplyAiGenerate={(next) => {
+          updateGroupWithDraft((g) => {
+            replaceProcessFlowContents(g, next);
+          });
+        }}
+        onCloseAiReview={() => setShowAiReviewDialog(false)}
+        aiDiffProposed={aiDiffProposed}
+        aiPromptSummary={aiPromptSummary}
+        onApplyAiDiff={(proposed) => {
+          updateGroupWithDraft((g) => {
+            replaceProcessFlowContents(g, proposed);
+          });
+          setAiDiffProposed(null);
+        }}
+        onApplyAiDiffSelected={(proposed, paths) => {
+          updateGroupWithDraft((g) => {
+            applyProcessFlowDiffSelection(g, proposed, paths);
+          });
+          setAiDiffProposed(null);
+        }}
+        onDiscardAiDiff={() => setAiDiffProposed(null)}
+        onAddAiDiffMarker={(body) => {
+          updateGroupWithDraft((g) => {
+            const m = {
+              id: generateUUID(),
+              kind: "chat" as const,
+              body,
+              author: "human" as const,
+              createdAt: new Date().toISOString(),
+            };
+            g.authoring = {
+              ...(g.authoring ?? {}),
+              markers: [...(g.authoring?.markers ?? []), m],
+            };
+          });
+          setAiDiffProposed(null);
+        }}
+      />
 
-      {mode.kind === "after-force-unlock" && (
-        <AfterForceUnlockChoiceDialog
-          previousOwner={mode.previousOwner}
-          onChoice={(choice) => editActions.handleAfterForceUnlock(choice)}
-        />
-      )}
-
-      {showResumeDialog && (
-        <ResumeOrDiscardDialog
-          onResume={handleResumeContinue}
-          onDiscard={handleResumeDiscard}
-          onCancel={() => setShowResumeDialog(false)}
-        />
-      )}
-
-      {showDiscardDialog && (
-        <DiscardConfirmDialog
-          onConfirm={handleDiscard}
-          onCancel={() => setShowDiscardDialog(false)}
-        />
-      )}
-
-      {saveConflict && (
-        <SaveConflictDialog
-          conflict={saveConflict}
-          onOverwrite={async () => {
-            try {
-              await onSaveConflictOverwrite();
-              await hookPostSave();
-            } catch (e) {
-              console.error("[ProcessFlowEditor] save overwrite failed:", e);
-            }
-          }}
-          onCancel={onSaveConflictCancel}
-        />
-      )}
-
-      {showForceReleaseDialog && lockedByOther && (
-        <ForceReleaseConfirmDialog
-          ownerSessionId={lockedByOther.ownerSessionId}
-          onConfirm={handleForceRelease}
-          onCancel={() => setShowForceReleaseDialog(false)}
-        />
-      )}
-
-      {serverChanged && (
-        <ServerChangeBanner onReload={handleReset} onDismiss={dismissServerBanner} />
-      )}
-
-      {showAiGenerateDialog && (
-        <ProcessFlowAiGenerateDialog
-          current={group}
-          onClose={() => setShowAiGenerateDialog(false)}
-          onApply={(next) => {
-            updateGroupWithDraft((g) => {
-              replaceProcessFlowContents(g, next);
-            });
-          }}
-        />
-      )}
-
-      {showAiReviewDialog && (
-        <ProcessFlowAiReviewDialog
-          current={group}
-          onClose={() => setShowAiReviewDialog(false)}
-        />
-      )}
 
       <EditorHeader
         title={
@@ -1349,261 +875,64 @@ export function ProcessFlowEditor() {
         }
         undoRedo={{ onUndo: undo, onRedo: redo, canUndo, canRedo }}
         extraRight={
-          <>
-            {!isReadonly && (
-              <button
-                type="button"
-                className="btn btn-sm btn-outline-primary"
-                onClick={() => setShowAiGenerateDialog(true)}
-                title="要件テキストから処理フロー JSON を生成"
-              >
-                <i className="bi bi-stars" /> AI 生成
-              </button>
-            )}
-            <button
-              type="button"
-              className="btn btn-sm btn-outline-secondary"
-              onClick={() => setShowAiReviewDialog(true)}
-              title="現在の処理フロー JSON を AI でレビュー"
-            >
-              <i className="bi bi-clipboard-check" /> AI レビュー
-            </button>
-            <EditSessionDropdown
-              resourceType="process-flow"
-              resourceId={processFlowId ?? ""}
-              currentMode={mode}
-              currentSessionId={sessionId}
-              onStartEditing={() => { void editActions.startEditing(); }}
-              onViewerAttached={syncSessionToUrl}
-              onAttachAsView={editAttach}
-              onTakeOver={editTakeOver}
-            />
-            <button
-              type="button"
-              className={`btn btn-sm ${drawingMode ? "btn-danger" : "btn-outline-secondary"}`}
-              onClick={() => setDrawingMode((v) => !v)}
-              title="赤線マーカー (ドラッグで描画、離すとマーカー起票)"
-            >
-              <i className="bi bi-pencil" /> {drawingMode ? "描画中" : "描画"}
-            </button>
-            {validationErrors.filter((e) => e.severity === "error").length > 0 && (
-              <span
-                className="validation-badge error"
-                title={validationErrors
-                  .filter((e) => e.severity === "error")
-                  .map((e) => (e.path ? `[${e.path}] ${e.message}` : e.message))
-                  .join("\n")}
-              >
-                <i className="bi bi-x-circle-fill" />
-                {validationErrors.filter((e) => e.severity === "error").length} エラー
-              </span>
-            )}
-            {validationErrors.filter((e) => e.severity === "warning").length > 0 && (
-              <span
-                className="validation-badge warning clickable"
-                title={validationErrors
-                  .filter((e) => e.severity === "warning")
-                  .slice(0, 20)
-                  .map((e) => (e.path ? `[${e.path}] ${e.message}` : e.message))
-                  .join("\n")}
-                onClick={() => setShowWarningsPanel((v) => !v)}
-                role="button"
-                tabIndex={0}
-                onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") setShowWarningsPanel((v) => !v); }}
-              >
-                <i className="bi bi-exclamation-triangle-fill" />
-                {validationErrors.filter((e) => e.severity === "warning").length} 警告
-                <i className={`bi bi-chevron-${showWarningsPanel ? "up" : "down"} ms-1`} />
-              </span>
-            )}
-          </>
+          <EditorHeaderExtras
+            isReadonly={isReadonly}
+            drawingMode={drawingMode}
+            showWarningsPanel={showWarningsPanel}
+            validationErrors={validationErrors}
+            processFlowId={processFlowId ?? ""}
+            mode={mode}
+            sessionId={sessionId}
+            onOpenAiGenerate={() => setShowAiGenerateDialog(true)}
+            onOpenAiReview={() => setShowAiReviewDialog(true)}
+            onToggleDrawing={() => setDrawingMode((v) => !v)}
+            onToggleWarnings={() => setShowWarningsPanel((v) => !v)}
+            onStartEditing={() => { void editActions.startEditing(); }}
+            onViewerAttached={syncSessionToUrl}
+            onAttachAsView={editAttach}
+            onTakeOver={editTakeOver}
+          />
         }
         saveReset={isReadonly ? undefined : { isDirty, isSaving, onSave: handleSave, onReset: handleReset }}
       />
 
-      {/* 警告詳細パネル (#261 UI 統合) */}
-      {showWarningsPanel && validationErrors.filter((e) => e.severity === "warning").length > 0 && (
-        <div className="process-flow-validation-panel">
-          <div className="process-flow-validation-panel-header">
-            <i className="bi bi-exclamation-triangle-fill" /> 警告 ({validationErrors.filter((e) => e.severity === "warning").length} 件)
-            <button
-              className="btn btn-sm btn-link process-flow-validation-panel-bulk-ai"
-              onClick={() => {
-                // 全警告をまとめて marker 化 (既に起票済のものは skip)
-                if (!group) return;
-                const existingKeys = new Set((group.authoring?.markers ?? [])
-                  .filter((m) => !m.resolvedAt && m.kind === "todo")
-                  .map((m) => `${m.code ?? ""}|${m.path ?? ""}`));
-                const newMarkers = validationErrors
-                  .filter((e) => e.severity === "warning" && e.path)
-                  .filter((e) => !existingKeys.has(`${e.code ?? ""}|${e.path ?? ""}`))
-                  .map((e) => ({
-                    id: generateUUID(),
-                    kind: "todo" as const,
-                    body: `警告解消: ${e.message}`,
-                    stepId: e.stepId || undefined,
-                    code: e.code,
-                    path: e.path,
-                    author: "human" as const,
-                    createdAt: new Date().toISOString(),
-                  }));
-                if (newMarkers.length === 0) {
-                  window.alert("全ての警告は既に AI 依頼済みです");
-                  return;
-                }
-                updateGroupWithDraft((g) => {
-                  g.authoring = { ...(g.authoring ?? {}), markers: [...(g.authoring?.markers ?? []), ...newMarkers] };
-                });
-                window.alert(`${newMarkers.length} 件の警告を marker として起票しました。/designer-work で処理できます。`);
-              }}
-              title="全ての警告をまとめて AI 依頼 marker として起票"
-            >
-              <i className="bi bi-robot" /> 全て AI に依頼
-            </button>
-            <button
-              className="btn btn-sm btn-link ms-1"
-              onClick={() => setShowWarningsPanel(false)}
-              title="閉じる"
-            >
-              <i className="bi bi-x-lg" />
-            </button>
-          </div>
-          <ul className="process-flow-validation-panel-list">
-            {validationErrors
-              .filter((e) => e.severity === "warning")
-              .map((e, i) => {
-                const isMarked = (group?.authoring?.markers ?? [])
-                  .some((m) => !m.resolvedAt && m.kind === "todo"
-                    && m.code === e.code && m.path === e.path);
-                return (
-                  <li key={i}>
-                    {e.code && <span className="validation-code">{e.code}</span>}
-                    <span className="validation-message">{e.message}</span>
-                    {e.path && <span className="validation-path">{e.path}</span>}
-                    <button
-                      className={`btn btn-sm validation-ask-ai-btn ${isMarked ? "asked" : ""}`}
-                      disabled={isMarked || !group}
-                      title={isMarked ? "AI に依頼済み" : "この警告を marker として AI に依頼"}
-                      onClick={() => {
-                        if (!group || isMarked) return;
-                        const newMarker = {
-                          id: generateUUID(),
-                          kind: "todo" as const,
-                          body: `警告解消: ${e.message}`,
-                          stepId: e.stepId || undefined,
-                          code: e.code,
-                          path: e.path,
-                          author: "human" as const,
-                          createdAt: new Date().toISOString(),
-                        };
-                        updateGroupWithDraft((g) => {
-                          g.authoring = { ...(g.authoring ?? {}), markers: [...(g.authoring?.markers ?? []), newMarker] };
-                        });
-                      }}
-                    >
-                      <i className={`bi ${isMarked ? "bi-check-circle-fill" : "bi-robot"}`} />
-                      {" "}{isMarked ? "依頼済" : "AI に依頼"}
-                    </button>
-                  </li>
-                );
-              })}
-          </ul>
-        </div>
+      {/* 警告詳細パネル (#261 UI 統合、Phase-3 で internal/WarningsPanel に抽出) */}
+      {showWarningsPanel && (
+        <WarningsPanel
+          group={group}
+          validationErrors={validationErrors}
+          onClose={() => setShowWarningsPanel(false)}
+          onUpdateProcessFlow={updateGroupWithDraft}
+        />
       )}
 
       <div className="process-flow-workbench">
-        <div className="process-flow-command-bar">
-          <div className="process-flow-command-title">
-            <span className="process-flow-command-eyebrow">Action</span>
-            <strong>{activeAction?.name ?? "アクション未選択"}</strong>
-            {activeAction && <span className="text-muted small">{getActionTriggerLabel(activeAction.trigger)}</span>}
-          </div>
-          <div className="process-flow-command-search">
-            <i className="bi bi-search" />
-            <input
-              value={commandQuery}
-              onChange={(e) => setCommandQuery(e.target.value)}
-              placeholder="アクションを検索"
-              aria-label="アクションを検索"
-            />
-          </div>
-          <div className="process-flow-tabs">
-            {visibleActions.map((act) => (
-              <div key={act.id} className={`process-flow-tab-wrap${activeActionId === act.id ? " active" : ""}`}>
-                <button
-                  className={`process-flow-tab ${activeActionId === act.id ? "active" : ""}`}
-                  onClick={() => setActiveActionId(act.id)}
-                  onPointerEnter={(e) => openActionHelp(act.id, e.currentTarget)}
-                  onPointerLeave={scheduleCloseActionHelp}
-                  onFocus={(e) => openActionHelp(act.id, e.currentTarget)}
-                  onBlur={scheduleCloseActionHelp}
-                  aria-describedby={actionHelp?.actionId === act.id ? `action-help-${act.id}` : undefined}
-                  aria-label={`${act.name} (${getActionTriggerLabel(act.trigger)})`}
-                >
-                  <span className="process-flow-tab-trigger-icon" aria-hidden="true">
-                    <i className={`bi ${getActionTriggerIcon(act.trigger)}`} />
-                  </span>
-                  <MaturityBadge
-                    maturity={act.maturity}
-                    onChange={(next) => {
-                      updateGroupSilent((g) => {
-                        const a = g.actions.find((a2) => a2.id === act.id);
-                        if (a) a.maturity = next;
-                      });
-                    }}
-                  />
-                  {act.name}
-                  <span className="process-flow-tab-trigger-label">{getActionTriggerLabel(act.trigger)}</span>
-                </button>
-                {!isReadonly && (
-                  <button
-                    className="process-flow-tab-remove"
-                    onClick={() => handleDeleteAction(act.id)}
-                    title="アクション削除"
-                  >
-                    <i className="bi bi-x" />
-                  </button>
-                )}
-              </div>
-            ))}
-            {visibleActions.length === 0 && (
-              <span className="process-flow-tab-empty">一致するアクションがありません</span>
-            )}
-            {!isReadonly && (
-              <button
-                className="process-flow-tab-add"
-                onClick={() => setShowAddAction(true)}
-                title="アクション追加"
-              >
-                <i className="bi bi-plus-lg" />
-              </button>
-            )}
-          </div>
-          {actionHelpTarget && actionHelp && (
-            <ActionHelpPopover
-              action={actionHelpTarget}
-              actionIndex={actionHelpTargetIndex}
-              markers={group?.authoring?.markers ?? []}
-              position={actionHelp}
-              onPointerEnter={clearActionHelpCloseTimer}
-              onPointerLeave={scheduleCloseActionHelp}
-            />
-          )}
-          <div className="process-flow-command-hints">
-            {!isReadonly && (
-              <>
-                <span><kbd>Ctrl</kbd>+<kbd>C</kbd> コピー</span>
-                <span><kbd>Ctrl</kbd>+<kbd>V</kbd> 貼付</span>
-                <span><kbd>右クリック</kbd> 操作</span>
-              </>
-            )}
-          </div>
-          <EditLevelToggle
-            value={editLevel}
-            onChange={setEditLevel}
-            disabled={isReadonly}
-          />
-        </div>
+        <ActionTabBar
+          group={group}
+          activeAction={activeAction}
+          activeActionId={activeActionId}
+          visibleActions={visibleActions}
+          commandQuery={commandQuery}
+          onChangeCommandQuery={setCommandQuery}
+          onSelectAction={setActiveActionId}
+          onDeleteAction={handleDeleteAction}
+          onAddActionClick={() => setShowAddAction(true)}
+          isReadonly={isReadonly}
+          editLevel={editLevel}
+          onChangeEditLevel={setEditLevel}
+          onChangeActionMaturity={(actId, next) => {
+            updateGroupSilent((g) => {
+              const a = g.actions.find((a2) => a2.id === actId);
+              if (a) a.maturity = next;
+            });
+          }}
+          actionHelp={actionHelp}
+          actionHelpTarget={actionHelpTarget}
+          actionHelpTargetIndex={actionHelpTargetIndex}
+          openActionHelp={openActionHelp}
+          scheduleCloseActionHelp={scheduleCloseActionHelp}
+          clearActionHelpCloseTimer={clearActionHelpCloseTimer}
+        />
 
         <DndContext
           sensors={sensors}
@@ -1613,467 +942,120 @@ export function ProcessFlowEditor() {
           collisionDetection={collisionDetection}
         >
           <div className="process-flow-workbench-grid">
-            <aside className="process-flow-palette-pane">
-              <div className="process-flow-pane-header">
-                <div>
-                  <span className="process-flow-pane-kicker">Blocks</span>
-                  <h6>ブロック</h6>
-                </div>
-                {!isReadonly && <span className="process-flow-pane-badge">D&D</span>}
-              </div>
-              <div className="process-flow-palette-search">
-                <i className="bi bi-search" />
-                <input
-                  value={stepFilter}
-                  onChange={(e) => setStepFilter(e.target.value)}
-                  placeholder="ブロックを検索"
-                  aria-label="ブロックを検索"
-                />
-              </div>
-              <div className="step-toolbar">
-                <div className="process-flow-palette-section">基本ステップ</div>
-                {filteredStepTypes.map((type) => (
-                  <ToolbarStepButton key={type} type={type} onClick={() => handleAddStep(type)} disabled={isReadonly} />
-                ))}
-                {filteredStepTypes.length === 0 && (
-                  <div className="process-flow-palette-empty">該当するブロックがありません</div>
-                )}
-                {customStepCards.length > 0 && (
-                  <>
-                    <div className="step-toolbar-sep" />
-                    <div className="process-flow-palette-section">カスタム</div>
-                    {customStepCards.map(([id, step]) => (
-                      <CustomStepButton
-                        key={id}
-                        id={id}
-                        label={step.label}
-                        icon={step.icon}
-                        description={step.description}
-                      />
-                    ))}
-                  </>
-                )}
-                <div className="step-toolbar-sep" />
-                <div className="process-flow-template-anchor">
-                  <button
-                    className="step-template-btn"
-                    onClick={() => setShowTemplates(!showTemplates)}
-                    disabled={isReadonly}
-                  >
-                    <i className="bi bi-collection" />
-                    テンプレート
-                  </button>
-                  {showTemplates && (
-                    <div className="template-dropdown">
-                      {STEP_TEMPLATES.map((tpl) => (
-                        <div
-                          key={tpl.id}
-                          className="template-dropdown-item"
-                          onClick={() => handleAddTemplate(tpl.id)}
-                        >
-                          <div className="template-dropdown-item-label">{tpl.label}</div>
-                          <div className="template-dropdown-item-desc">{tpl.description}</div>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              </div>
-            </aside>
+            <PalettePanel
+              stepFilter={stepFilter}
+              onChangeStepFilter={setStepFilter}
+              filteredStepTypes={filteredStepTypes}
+              customStepCards={customStepCards}
+              showTemplates={showTemplates}
+              onToggleTemplates={() => setShowTemplates(!showTemplates)}
+              onAddStep={handleAddStep}
+              onAddTemplate={handleAddTemplate}
+              isReadonly={isReadonly}
+            />
 
-            <main className="process-flow-canvas-pane">
-              <div className="process-flow-canvas-header">
-                <div>
-                  <span className="process-flow-pane-kicker">Flow</span>
-                  <h6>{activeAction ? `${activeAction.name} の処理` : "処理フロー"}</h6>
-                </div>
-                {activeAction && (
-                  <div className="process-flow-canvas-metrics">
-                    <span>{activeAction.steps.length} steps</span>
-                    <span>{activeAction.inputs?.length ?? 0} inputs</span>
-                    <span>{activeAction.outputs?.length ?? 0} outputs</span>
-                  </div>
-                )}
-              </div>
-              <div className="process-flow-content">
-                {activeAction ? (
-                  <div className="step-editor">
-                    {activeAction.steps.length === 0 ? (
-                      <EmptyFlowDropZone disabled={isReadonly}>
-                        <i className="bi bi-plus-circle" />
-                        <strong>ステップがありません</strong>
-                        <span>{isReadonly ? "編集開始後にステップを追加できます。" : "左のブロックをドラッグするか、ブロックをクリックして追加してください。"}</span>
-                        <StepInsertZone
-                          index={0}
-                          onClick={() => handleAddStep("other")}
-                          onPaste={clipboard && !isReadonly ? () => handlePaste(0) : undefined}
-                          dragVisible={isDraggingToolbarStep}
-                          disabled={isReadonly}
-                        />
-                      </EmptyFlowDropZone>
-                    ) : (
-                      <SortableContext items={activeAction.steps.map((s) => s.id)} strategy={verticalListSortingStrategy}>
-                        <div className={`step-list${isDraggingToolbarStep ? " drag-inserting" : ""}`} ref={stepListRef}>
-                          {activeAction.steps.map((step, index) => {
-                      // この step に紐付いた未解決 marker 件数
-                      const stepMarkers = (group.authoring?.markers ?? []).filter(
-                        (m) => !m.resolvedAt && m.stepId === step.id,
-                      );
-                      const markerCount = stepMarkers.length;
-                      const markerTooltip = markerCount > 0
-                        ? `AI 依頼マーカー ${markerCount} 件:\n${stepMarkers.map((m) => `- [${m.kind}] ${m.body.slice(0, 60)}`).join("\n")}`
-                        : undefined;
-                      const markerKinds = markerCount > 0 ? {
-                        todo: stepMarkers.filter((m) => m.kind === "todo").length,
-                        question: stepMarkers.filter((m) => m.kind === "question").length,
-                        attention: stepMarkers.filter((m) => m.kind === "attention").length,
-                        chat: stepMarkers.filter((m) => m.kind === "chat").length,
-                      } : undefined;
-                      return (
-                      <div key={step.id}>
-                        <StepInsertZone
-                          index={index}
-                          onClick={() => handleAddStep("other", index)}
-                          onPaste={clipboard && !isReadonly ? () => handlePaste(index) : undefined}
-                          dragVisible={isDraggingToolbarStep}
-                          disabled={isReadonly}
-                        />
-                        <SortableStepCard
-                          step={step}
-                          index={index}
-                          label={getStepLabel(index)}
-                          allSteps={activeAction.steps}
-                          tables={tables}
-                          screens={screens}
-                          commonGroups={commonGroups}
-                          onChange={(changes) => handleStepChange(step.id, changes)}
-                          onCommit={commitGroup}
-                          onMoveUp={index > 0 ? () => handleMoveStep(index, index - 1) : undefined}
-                          onMoveDown={index < activeAction.steps.length - 1 ? () => handleMoveStep(index, index + 1) : undefined}
-                          onDelete={() => handleDeleteStep(step.id)}
-                          onDuplicate={() => handleDuplicateStep(step.id)}
-                          onAddSubStep={(type) => handleAddSubStep(step.id, type)}
-                          onContextMenu={(e) => {
-                            e.preventDefault();
-                            if (isReadonly) return;
-                            setSelectedIds(new Set([step.id]));
-                            lastSelectedIdRef.current = step.id;
-                            setContextMenu({ x: e.clientX, y: e.clientY, stepId: step.id });
-                          }}
-                          onNavigateCommon={(refId) => navigate(wsPath(`/process-flow/edit/${refId}`))}
-                          defaultExpanded={newStepIds.has(step.id)}
-                          selected={selectedIds.has(step.id)}
-                          onHeaderClick={(e) => handleStepClick(step.id, e)}
-                          onIndent={index > 0 ? () => handleIndentStep(step.id) : undefined}
-                          onOutdentSubStep={(subId) => handleOutdentSubStep(step.id, subId)}
-                          validationErrors={validationErrors}
-                          onAddMarker={(body, kind = "todo") => {
-                            updateGroupWithDraft((g) => {
-                              const m = {
-                                id: generateUUID(),
-                                kind,
-                                body,
-                                stepId: step.id,
-                                author: "human" as const,
-                                createdAt: new Date().toISOString(),
-                              };
-                              g.authoring = { ...(g.authoring ?? {}), markers: [...(g.authoring?.markers ?? []), m] };
-                            });
-                          }}
-                          markerCount={markerCount}
-                          markerTooltip={markerTooltip}
-                          markerKinds={markerKinds}
-                          conventions={conventions}
-                          group={group}
-                          editLevel={editLevel}
-                          readOnly={isReadonly}
-                          onAskAi={() => {
-                            const label = `S${index + 1}: ${step.description ?? step.kind ?? step.id}`;
-                            aiChips.addStepChip(String(step.id), label, step);
-                            aiPanelRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" });
-                          }}
-                        />
-                      </div>
-                      );
-                          })}
-                          <StepInsertZone
-                            index={activeAction.steps.length}
-                            onClick={() => handleAddStep("other")}
-                            onPaste={clipboard && !isReadonly ? () => handlePaste(activeAction.steps.length) : undefined}
-                            dragVisible={isDraggingToolbarStep}
-                            disabled={isReadonly}
-                          />
-                        </div>
-                      </SortableContext>
-                    )}
-                  </div>
-                ) : (
-                  <div className="step-empty process-flow-empty-drop">
-                    <i className="bi bi-lightning" />
-                    <strong>アクションがありません</strong>
-                    <span>上部の + ボタンからアクションを追加してください。</span>
-                  </div>
-                )}
-              </div>
-            </main>
+            <CanvasPane
+              group={group}
+              activeAction={activeAction}
+              tables={tables}
+              screens={screens}
+              commonGroups={commonGroups}
+              conventions={conventions}
+              isReadonly={isReadonly}
+              isDraggingToolbarStep={isDraggingToolbarStep}
+              clipboard={clipboard}
+              newStepIds={newStepIds}
+              selectedIds={selectedIds}
+              validationErrors={validationErrors}
+              editLevel={editLevel}
+              stepListRef={stepListRef}
+              aiChips={aiChips}
+              aiPanelRef={aiPanelRef}
+              handleAddStep={handleAddStep}
+              handlePaste={handlePaste}
+              handleStepChange={handleStepChange}
+              commitGroup={commitGroup}
+              handleMoveStep={handleMoveStep}
+              handleDeleteStep={handleDeleteStep}
+              handleDuplicateStep={handleDuplicateStep}
+              handleAddSubStep={handleAddSubStep}
+              handleIndentStep={handleIndentStep}
+              handleOutdentSubStep={handleOutdentSubStep}
+              handleStepClick={handleStepClick}
+              onNavigateCommon={(refId) => navigate(wsPath(`/process-flow/edit/${refId}`))}
+              updateGroupWithDraft={updateGroupWithDraft}
+              onContextMenu={(stepId, x, y) => setContextMenu({ x, y, stepId })}
+              setSelectedIds={setSelectedIds}
+              lastSelectedIdRef={lastSelectedIdRef}
+            />
+            {/* CanvasPane (#1145 Phase-3 で抽出): ステップリスト + D&D 挿入ゾーン */}
 
-            <aside className="process-flow-inspector-pane">
-              <div className="process-flow-pane-header">
-                <div>
-                  <span className="process-flow-pane-kicker">Inspector</span>
-                  <h6>詳細</h6>
-                </div>
-              </div>
-              <div className="process-flow-inspector-scroll">
-                {/* #1076 AI 依頼パネル */}
-                <div className="process-flow-inspector-section">
-                  <AiRequestPanel
-                    chips={aiChips.chips}
-                    onRemoveChip={aiChips.removeChip}
-                    onClearChips={aiChips.clearChips}
-                    onSubmit={handleAiSubmit}
-                    busy={aiRequestBusy}
-                    error={aiRequestError}
-                    isConnected={isCodexConnected}
-                    panelRef={aiPanelRef}
-                    actionLabel={activeAction?.name}
-                    onAddActionContext={activeAction ? () => {
-                      aiChips.addActionChip(String(activeAction.id), activeAction.name, activeAction);
-                    } : undefined}
-                    onAddFlowContext={group ? () => {
-                      const flowName = group.meta?.name ?? "処理フロー";
-                      const flowId = processFlowId ?? "flow";
-                      aiChips.addFlowChip(flowId, flowName, group);
-                    } : undefined}
-                  />
-                </div>
-                {isReadonly ? (
-                  <div className="process-flow-inspector-section">
-                    <div className="text-muted small">
-                      詳細項目の編集は「編集開始」後に利用できます。
-                    </div>
-                  </div>
-                ) : (
-                  <ActionMetaTabBar
-                    group={group}
-                    updateGroup={updateGroup}
-                    updateGroupSilent={updateGroupSilent}
-                  />
-                )}
-                {!isReadonly && activeAction && (
-                  <>
-                    <div className="process-flow-inspector-section">
-                      <ActionHttpContractPanel
-                        action={activeAction}
-                        onChange={(patch) => {
-                          updateGroupSilent((g) => {
-                            const act = g.actions.find((a) => a.id === activeActionId);
-                            if (act) Object.assign(act, patch);
-                          });
-                          commitGroup();
-                        }}
-                      />
-                    </div>
-                    <div className="process-flow-inspector-section">
-                      <SlaPanel
-                        label="アクション SLA / Timeout"
-                        sla={activeAction.sla}
-                        onChange={(sla) => {
-                          updateGroupSilent((g) => {
-                            const act = g.actions.find((a) => a.id === activeActionId);
-                            if (act) act.sla = sla;
-                          });
-                          commitGroup();
-                        }}
-                      />
-                    </div>
-                    <div className="process-flow-io-panel">
-                      <div className="process-flow-io-field">
-                        <StructuredFieldsEditor
-                          label="入力データ"
-                          fields={activeAction.inputs}
-                          onChange={(val) => {
-                            updateGroupSilent((g) => {
-                              const act = g.actions.find((a) => a.id === activeActionId);
-                              if (act) act.inputs = val;
-                            });
-                          }}
-                          onCommit={commitGroup}
-                          placeholder="例: ユーザID、パスワード（改行で複数項目）"
-                          onPickScreenItem={handlePickScreenItem}
-                        />
-                      </div>
-                      <div className="process-flow-io-field">
-                        <StructuredFieldsEditor
-                          label="出力データ"
-                          fields={activeAction.outputs}
-                          onChange={(val) => {
-                            updateGroupSilent((g) => {
-                              const act = g.actions.find((a) => a.id === activeActionId);
-                              if (act) act.outputs = val;
-                            });
-                          }}
-                          onCommit={commitGroup}
-                          placeholder="例: セッションID、認証トークン（改行で複数項目）"
-                          onPickScreenItem={handlePickScreenItem}
-                        />
-                      </div>
-                    </div>
-                  </>
-                )}
-              </div>
-            </aside>
+            <InspectorPanel
+              group={group}
+              activeAction={activeAction}
+              activeActionId={activeActionId}
+              isReadonly={isReadonly}
+              processFlowId={processFlowId}
+              aiChips={aiChips}
+              handleAiSubmit={handleAiSubmit}
+              aiRequestBusy={aiRequestBusy}
+              aiRequestError={aiRequestError}
+              isCodexConnected={isCodexConnected}
+              aiPanelRef={aiPanelRef}
+              updateGroup={updateGroup}
+              updateGroupSilent={updateGroupSilent}
+              commitGroup={commitGroup}
+              handlePickScreenItem={handlePickScreenItem}
+            />
+            {/* InspectorPanel (#1145 Phase-3 で抽出): AI 依頼 / Meta / HTTP contract / SLA / I/O */}
           </div>
         </DndContext>
       </div>
 
-      {/* コンテキストメニュー */}
+      {/* コンテキストメニュー (Phase-3 で internal/StepContextMenu に抽出) */}
       {!isReadonly && contextMenu && (
-        <div
-          className="step-context-menu"
-          style={{ top: contextMenu.y, left: contextMenu.x }}
-          onClick={(e) => e.stopPropagation()}
-        >
-          {!contextMenuSubTypePicker ? (
-            <>
-              <button
-                className="step-context-menu-item"
-                onClick={() => handleContextInsert(0)}
-              >
-                <i className="bi bi-plus-circle" /> 前に挿入
-              </button>
-              <button
-                className="step-context-menu-item"
-                onClick={() => handleContextInsert(1)}
-              >
-                <i className="bi bi-plus-square" /> 後に挿入
-              </button>
-              {clipboard && (
-                <>
-                  <button
-                    className="step-context-menu-item"
-                    onClick={() => handleContextPaste(0)}
-                  >
-                    <i className="bi bi-clipboard-plus" /> 前に貼り付け
-                  </button>
-                  <button
-                    className="step-context-menu-item"
-                    onClick={() => handleContextPaste(1)}
-                  >
-                    <i className="bi bi-clipboard-plus" /> 後に貼り付け
-                  </button>
-                </>
-              )}
-              <div className="step-context-menu-sep" />
-              <button
-                className="step-context-menu-item"
-                onClick={() => handleCopy(new Set([contextMenu.stepId]))}
-              >
-                <i className="bi bi-files" /> コピー
-              </button>
-              <button
-                className="step-context-menu-item"
-                onClick={() => handleCut(new Set([contextMenu.stepId]))}
-              >
-                <i className="bi bi-scissors" /> カット
-              </button>
-              <button
-                className="step-context-menu-item"
-                onClick={() => handleDuplicateStep(contextMenu.stepId)}
-              >
-                <i className="bi bi-copy" /> 複製
-              </button>
-              <button
-                className="step-context-menu-item"
-                onClick={() => setContextMenuSubTypePicker(true)}
-              >
-                <i className="bi bi-diagram-2" /> サブステップ追加 ▶
-              </button>
-              <div className="step-context-menu-sep" />
-              <button
-                className="step-context-menu-item"
-                onClick={() => {
-                  const step = group?.actions?.flatMap((a) => a.steps ?? []).find((s) => s.id === contextMenu.stepId);
-                  if (step) {
-                    const action = group?.actions?.find((a) => (a.steps ?? []).some((s) => s.id === contextMenu.stepId));
-                    const stepIndex = (action?.steps ?? []).findIndex((s) => s.id === contextMenu.stepId);
-                    const label = `S${stepIndex + 1}: ${step.description ?? step.kind ?? step.id}`;
-                    aiChips.addStepChip(String(contextMenu.stepId), label, step);
-                  }
-                  aiPanelRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" });
-                  setContextMenu(null);
-                }}
-              >
-                <i className="bi bi-robot" /> このステップを AI に依頼
-              </button>
-              <button
-                className="step-context-menu-item danger"
-                onClick={() => handleDeleteStep(contextMenu.stepId)}
-              >
-                <i className="bi bi-trash" /> 削除
-              </button>
-            </>
-          ) : (
-            <>
-              <button
-                className="step-context-menu-item"
-                onClick={() => setContextMenuSubTypePicker(false)}
-              >
-                <i className="bi bi-arrow-left" /> 戻る
-              </button>
-              <div className="step-context-menu-sep" />
-              {ALL_SUB_STEP_TYPES.map((t) => (
-                <button
-                  key={t}
-                  className="step-context-menu-item"
-                  onClick={() => { handleAddSubStep(contextMenu.stepId, t); }}
-                >
-                  <i className={`bi ${STEP_TYPE_ICONS[t]}`} style={{ color: STEP_TYPE_COLORS[t] }} />
-                  {" "}{STEP_TYPE_LABELS[t]}
-                </button>
-              ))}
-            </>
-          )}
-        </div>
+        <StepContextMenu
+          x={contextMenu.x}
+          y={contextMenu.y}
+          stepId={contextMenu.stepId}
+          subTypePickerOpen={contextMenuSubTypePicker}
+          hasClipboard={!!clipboard}
+          onToggleSubTypePicker={setContextMenuSubTypePicker}
+          onInsertBefore={() => handleContextInsert(0)}
+          onInsertAfter={() => handleContextInsert(1)}
+          onPasteBefore={() => handleContextPaste(0)}
+          onPasteAfter={() => handleContextPaste(1)}
+          onCopy={() => handleCopy(new Set([contextMenu.stepId]))}
+          onCut={() => handleCut(new Set([contextMenu.stepId]))}
+          onDuplicate={() => handleDuplicateStep(contextMenu.stepId)}
+          onAddSubStep={(kind) => handleAddSubStep(contextMenu.stepId, kind)}
+          onAskAi={() => {
+            const step = group?.actions?.flatMap((a) => a.steps ?? []).find((s) => s.id === contextMenu.stepId);
+            if (step) {
+              const action = group?.actions?.find((a) =>
+                (a.steps ?? []).some((s) => s.id === contextMenu.stepId),
+              );
+              const stepIndex = (action?.steps ?? []).findIndex((s) => s.id === contextMenu.stepId);
+              const label = `S${stepIndex + 1}: ${step.description ?? step.kind ?? step.id}`;
+              aiChips.addStepChip(String(contextMenu.stepId), label, step);
+            }
+            aiPanelRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+            setContextMenu(null);
+          }}
+          onDelete={() => handleDeleteStep(contextMenu.stepId)}
+        />
       )}
 
-      {/* アクション追加モーダル */}
+      {/* アクション追加モーダル (Phase-3 で internal/AddActionModal に抽出) */}
       {showAddAction && !isReadonly && (
-        <div className="process-flow-modal-overlay" onClick={() => setShowAddAction(false)}>
-          <div className="process-flow-modal" onClick={(e) => e.stopPropagation()}>
-            <h6>アクション追加</h6>
-            <div className="form-group">
-              <label className="form-label">アクション名 *</label>
-              <input
-                className="form-control form-control-sm"
-                value={newActionName}
-                onChange={(e) => setNewActionName(e.target.value)}
-                placeholder="例: 登録ボタン、検索ボタン"
-                autoFocus
-              />
-            </div>
-            <div className="form-group">
-              <label className="form-label">トリガー</label>
-              <select
-                className="form-select form-select-sm"
-                value={newActionTrigger}
-                onChange={(e) => setNewActionTrigger(e.target.value as ActionTrigger)}
-              >
-                {ALL_TRIGGERS.map((t) => (
-                  <option key={t} value={t}>{getActionTriggerLabel(t)}</option>
-                ))}
-              </select>
-            </div>
-            <div className="process-flow-modal-footer">
-              <button className="btn btn-outline-secondary btn-sm" onClick={() => setShowAddAction(false)}>
-                キャンセル
-              </button>
-              <button className="btn btn-primary btn-sm" onClick={handleAddAction} disabled={!newActionName.trim()}>
-                追加
-              </button>
-            </div>
-          </div>
-        </div>
+        <AddActionModal
+          name={newActionName}
+          trigger={newActionTrigger}
+          onChangeName={setNewActionName}
+          onChangeTrigger={setNewActionTrigger}
+          onSubmit={handleAddAction}
+          onCancel={() => setShowAddAction(false)}
+        />
       )}
       {/* 赤線マーカー描画オーバーレイ (#261) */}
       <DrawingOverlay
@@ -2089,44 +1071,7 @@ export function ProcessFlowEditor() {
         onClose={handlePickerClose}
         onPick={handlePickerPick}
       />
-      {/* #1076 AI 差分プレビューダイアログ */}
-      {aiDiffProposed && group && (
-        <AiDiffPreviewDialog
-          current={group}
-          proposed={aiDiffProposed}
-          promptSummary={aiPromptSummary}
-          onApply={() => {
-            if (!aiDiffProposed) return;
-            const proposed = aiDiffProposed;
-            updateGroupWithDraft((g) => {
-              replaceProcessFlowContents(g, proposed);
-            });
-            setAiDiffProposed(null);
-          }}
-          onApplySelected={(paths) => {
-            if (!aiDiffProposed) return;
-            const proposed = aiDiffProposed;
-            updateGroupWithDraft((g) => {
-              applyProcessFlowDiffSelection(g, proposed, paths);
-            });
-            setAiDiffProposed(null);
-          }}
-          onDiscard={() => setAiDiffProposed(null)}
-          onAddMarker={(body) => {
-            updateGroupWithDraft((g) => {
-              const m = {
-                id: generateUUID(),
-                kind: "chat" as const,
-                body,
-                author: "human" as const,
-                createdAt: new Date().toISOString(),
-              };
-              g.authoring = { ...(g.authoring ?? {}), markers: [...(g.authoring?.markers ?? []), m] };
-            });
-            setAiDiffProposed(null);
-          }}
-        />
-      )}
+      {/* AI 差分プレビューダイアログ (Phase-3 で ProcessFlowDialogs に統合) */}
     </div>
   );
 }

--- a/frontend/src/components/process-flow/StepCard.tsx
+++ b/frontend/src/components/process-flow/StepCard.tsx
@@ -23,9 +23,12 @@ import { AutoResizeTextarea } from "./internal/AutoResizeTextarea";
 import { ALL_SUB_STEP_TYPES } from "./internal/stepCardConstants";
 import { stepSummaryText } from "./internal/stepSummaryText";
 import {
+  AiAgentStepCardBody,
+  AiCallStepCardBody,
   AuditStepCardBody,
   BranchStepCardBody,
   CommonProcessStepCardBody,
+  ComponentCallStepCardBody,
   ComputeStepCardBody,
   DbAccessStepCardBody,
   DisplayUpdateStepCardBody,
@@ -749,6 +752,37 @@ export function StepCard({
                   onChange={onChange}
                   onCommit={onCommit}
                   onNavigateCommon={onNavigateCommon}
+                  readOnly={readOnly}
+                />
+              )}
+
+              {/* Phase-3 (#1145、#1163 review Phase-2 補足) 追加 3 dispatch */}
+              {step.kind === "componentCall" && (
+                <ComponentCallStepCardBody
+                  step={step}
+                  allSteps={allSteps}
+                  onChange={onChange}
+                  onCommit={onCommit}
+                  readOnly={readOnly}
+                />
+              )}
+
+              {step.kind === "aiCall" && (
+                <AiCallStepCardBody
+                  step={step}
+                  allSteps={allSteps}
+                  onChange={onChange}
+                  onCommit={onCommit}
+                  readOnly={readOnly}
+                />
+              )}
+
+              {step.kind === "aiAgent" && (
+                <AiAgentStepCardBody
+                  step={step}
+                  allSteps={allSteps}
+                  onChange={onChange}
+                  onCommit={onCommit}
                   readOnly={readOnly}
                 />
               )}

--- a/frontend/src/components/process-flow/internal/ActionHelpPopover.tsx
+++ b/frontend/src/components/process-flow/internal/ActionHelpPopover.tsx
@@ -1,0 +1,99 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+// Phase-3 (#1145): ProcessFlowEditor.tsx から ActionHelpPopover を抽出。
+// アクションタブにホバー時のリッチヘルプ popover (契機 / 用途 / 定義例 / ステップ例 / メタ要約)。
+
+import type { ActionDefinition, Marker } from "../../../types/action";
+import {
+  countActionFields,
+  getActionOpenMarkers,
+  getActionTriggerCategory,
+  getActionTriggerIcon,
+  getActionTriggerLabel,
+  getActionTriggerRichHelp,
+  summarizeActionFields,
+  summarizeActionMarkers,
+  summarizeActionStepTypes,
+} from "./actionTriggerConstants";
+
+export interface ActionHelpPopoverProps {
+  action: ActionDefinition;
+  actionIndex: number;
+  markers: Marker[];
+  position: { left: number; top: number; placement: "below" | "above" };
+  onPointerEnter: () => void;
+  onPointerLeave: () => void;
+}
+
+export function ActionHelpPopover({
+  action,
+  actionIndex,
+  markers,
+  position,
+  onPointerEnter,
+  onPointerLeave,
+}: ActionHelpPopoverProps) {
+  const help = getActionTriggerRichHelp(action.trigger);
+  const openMarkers = getActionOpenMarkers(action, actionIndex, markers);
+  const stepCount = action.steps?.length ?? 0;
+  const inputCount = countActionFields(action.inputs);
+  const outputCount = countActionFields(action.outputs);
+  const responseCount = countActionFields(action.responses);
+
+  return (
+    <div
+      id={`action-help-${action.id}`}
+      className={`process-flow-action-help ${position.placement}`}
+      style={{ left: position.left, top: position.top }}
+      role="tooltip"
+      onPointerEnter={onPointerEnter}
+      onPointerLeave={onPointerLeave}
+    >
+      <div className="process-flow-action-help-head">
+        <span className="process-flow-action-help-icon" aria-hidden="true">
+          <i className={`bi ${getActionTriggerIcon(action.trigger)}`} />
+        </span>
+        <div>
+          <div className="process-flow-action-help-title">{action.name}</div>
+          <div className="process-flow-action-help-subtitle">
+            {getActionTriggerLabel(action.trigger)} / {getActionTriggerCategory(action.trigger)}
+          </div>
+        </div>
+      </div>
+
+      <div className="process-flow-action-help-grid">
+        <section>
+          <h6>契機</h6>
+          <p>{help.occasion}</p>
+        </section>
+        <section>
+          <h6>代表用途</h6>
+          <ul>{help.useCases.map((item) => <li key={item}>{item}</li>)}</ul>
+        </section>
+        <section>
+          <h6>定義例</h6>
+          <p>{help.definitionExample}</p>
+        </section>
+        <section>
+          <h6>ステップ例</h6>
+          <ol>{help.stepExample.map((item) => <li key={item}>{item}</li>)}</ol>
+        </section>
+        <section>
+          <h6>このアクション</h6>
+          <dl>
+            <div><dt>入出力</dt><dd>inputs {inputCount} / outputs {outputCount} / responses {responseCount}</dd></div>
+            <div><dt>入力</dt><dd>{summarizeActionFields(action.inputs, "未定義")}</dd></div>
+            <div><dt>出力</dt><dd>{summarizeActionFields(action.outputs, "未定義")}</dd></div>
+            <div><dt>応答</dt><dd>{summarizeActionFields(action.responses, "未定義")}</dd></div>
+            <div><dt>ステップ</dt><dd>{stepCount} 件 / {summarizeActionStepTypes(action)}</dd></div>
+            <div><dt>成熟度</dt><dd>{action.maturity ?? "未設定"}</dd></div>
+            <div><dt>未解決マーカー</dt><dd>{openMarkers.length} 件 / {summarizeActionMarkers(openMarkers)}</dd></div>
+          </dl>
+        </section>
+        <section>
+          <h6>注意点</h6>
+          <ul>{help.notes.map((item) => <li key={item}>{item}</li>)}</ul>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/process-flow/internal/ActionTabBar.tsx
+++ b/frontend/src/components/process-flow/internal/ActionTabBar.tsx
@@ -1,0 +1,152 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+// Phase-3 (#1145): ProcessFlowEditor.tsx からアクションタブ + 検索 + ActionHelpPopover 統合を抽出。
+// 「コマンドバー」エリア全体 (アクション名 / 検索ボックス / タブ / popover / EditLevelToggle)。
+
+import type { ActionDefinition, ProcessFlow } from "../../../types/action";
+import { MaturityBadge } from "../MaturityBadge";
+import { EditLevelToggle } from "../EditLevelToggle";
+import { ActionHelpPopover } from "./ActionHelpPopover";
+import { getActionTriggerIcon, getActionTriggerLabel } from "./actionTriggerConstants";
+import type { ActionHelpState } from "./useActionHelpPopover";
+
+export interface ActionTabBarProps {
+  group: ProcessFlow | null;
+  activeAction: ActionDefinition | null;
+  activeActionId: string | null;
+  visibleActions: ActionDefinition[];
+  commandQuery: string;
+  onChangeCommandQuery: (q: string) => void;
+  onSelectAction: (id: string) => void;
+  onDeleteAction: (id: string) => void;
+  onAddActionClick: () => void;
+  isReadonly: boolean;
+  /** EditLevelToggle */
+  editLevel: import("../../../hooks/useEditLevel").EditLevel;
+  onChangeEditLevel: (lv: import("../../../hooks/useEditLevel").EditLevel) => void;
+  /** アクション maturity の更新 */
+  onChangeActionMaturity: (actionId: string, maturity: string) => void;
+  /** ActionHelpPopover */
+  actionHelp: ActionHelpState | null;
+  actionHelpTarget: ActionDefinition | null;
+  actionHelpTargetIndex: number;
+  openActionHelp: (actionId: string, anchor: HTMLElement) => void;
+  scheduleCloseActionHelp: () => void;
+  clearActionHelpCloseTimer: () => void;
+}
+
+export function ActionTabBar({
+  group,
+  activeAction,
+  activeActionId,
+  visibleActions,
+  commandQuery,
+  onChangeCommandQuery,
+  onSelectAction,
+  onDeleteAction,
+  onAddActionClick,
+  isReadonly,
+  editLevel,
+  onChangeEditLevel,
+  onChangeActionMaturity,
+  actionHelp,
+  actionHelpTarget,
+  actionHelpTargetIndex,
+  openActionHelp,
+  scheduleCloseActionHelp,
+  clearActionHelpCloseTimer,
+}: ActionTabBarProps) {
+  return (
+    <div className="process-flow-command-bar">
+      <div className="process-flow-command-title">
+        <span className="process-flow-command-eyebrow">Action</span>
+        <strong>{activeAction?.name ?? "アクション未選択"}</strong>
+        {activeAction && (
+          <span className="text-muted small">{getActionTriggerLabel(activeAction.trigger)}</span>
+        )}
+      </div>
+      <div className="process-flow-command-search">
+        <i className="bi bi-search" />
+        <input
+          value={commandQuery}
+          onChange={(e) => onChangeCommandQuery(e.target.value)}
+          placeholder="アクションを検索"
+          aria-label="アクションを検索"
+        />
+      </div>
+      <div className="process-flow-tabs">
+        {visibleActions.map((act) => (
+          <div
+            key={act.id}
+            className={`process-flow-tab-wrap${activeActionId === act.id ? " active" : ""}`}
+          >
+            <button
+              className={`process-flow-tab ${activeActionId === act.id ? "active" : ""}`}
+              onClick={() => onSelectAction(act.id)}
+              onPointerEnter={(e) => openActionHelp(act.id, e.currentTarget)}
+              onPointerLeave={scheduleCloseActionHelp}
+              onFocus={(e) => openActionHelp(act.id, e.currentTarget)}
+              onBlur={scheduleCloseActionHelp}
+              aria-describedby={
+                actionHelp?.actionId === act.id ? `action-help-${act.id}` : undefined
+              }
+              aria-label={`${act.name} (${getActionTriggerLabel(act.trigger)})`}
+            >
+              <span className="process-flow-tab-trigger-icon" aria-hidden="true">
+                <i className={`bi ${getActionTriggerIcon(act.trigger)}`} />
+              </span>
+              <MaturityBadge
+                maturity={act.maturity}
+                onChange={(next) => onChangeActionMaturity(act.id, next)}
+              />
+              {act.name}
+              <span className="process-flow-tab-trigger-label">
+                {getActionTriggerLabel(act.trigger)}
+              </span>
+            </button>
+            {!isReadonly && (
+              <button
+                className="process-flow-tab-remove"
+                onClick={() => onDeleteAction(act.id)}
+                title="アクション削除"
+              >
+                <i className="bi bi-x" />
+              </button>
+            )}
+          </div>
+        ))}
+        {visibleActions.length === 0 && (
+          <span className="process-flow-tab-empty">一致するアクションがありません</span>
+        )}
+        {!isReadonly && (
+          <button
+            className="process-flow-tab-add"
+            onClick={onAddActionClick}
+            title="アクション追加"
+          >
+            <i className="bi bi-plus-lg" />
+          </button>
+        )}
+      </div>
+      {actionHelpTarget && actionHelp && (
+        <ActionHelpPopover
+          action={actionHelpTarget}
+          actionIndex={actionHelpTargetIndex}
+          markers={group?.authoring?.markers ?? []}
+          position={actionHelp}
+          onPointerEnter={clearActionHelpCloseTimer}
+          onPointerLeave={scheduleCloseActionHelp}
+        />
+      )}
+      <div className="process-flow-command-hints">
+        {!isReadonly && (
+          <>
+            <span><kbd>Ctrl</kbd>+<kbd>C</kbd> コピー</span>
+            <span><kbd>Ctrl</kbd>+<kbd>V</kbd> 貼付</span>
+            <span><kbd>右クリック</kbd> 操作</span>
+          </>
+        )}
+      </div>
+      <EditLevelToggle value={editLevel} onChange={onChangeEditLevel} disabled={isReadonly} />
+    </div>
+  );
+}

--- a/frontend/src/components/process-flow/internal/AddActionModal.tsx
+++ b/frontend/src/components/process-flow/internal/AddActionModal.tsx
@@ -1,0 +1,67 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+// Phase-3 (#1145): ProcessFlowEditor.tsx からアクション追加モーダルを抽出。
+
+import type { ActionTrigger } from "../../../types/action";
+import { ALL_TRIGGERS, getActionTriggerLabel } from "./actionTriggerConstants";
+
+export interface AddActionModalProps {
+  name: string;
+  trigger: ActionTrigger;
+  onChangeName: (name: string) => void;
+  onChangeTrigger: (trigger: ActionTrigger) => void;
+  onSubmit: () => void;
+  onCancel: () => void;
+}
+
+export function AddActionModal({
+  name,
+  trigger,
+  onChangeName,
+  onChangeTrigger,
+  onSubmit,
+  onCancel,
+}: AddActionModalProps) {
+  return (
+    <div className="process-flow-modal-overlay" onClick={onCancel}>
+      <div className="process-flow-modal" onClick={(e) => e.stopPropagation()}>
+        <h6>アクション追加</h6>
+        <div className="form-group">
+          <label className="form-label">アクション名 *</label>
+          <input
+            className="form-control form-control-sm"
+            value={name}
+            onChange={(e) => onChangeName(e.target.value)}
+            placeholder="例: 登録ボタン、検索ボタン"
+            autoFocus
+          />
+        </div>
+        <div className="form-group">
+          <label className="form-label">トリガー</label>
+          <select
+            className="form-select form-select-sm"
+            value={trigger}
+            onChange={(e) => onChangeTrigger(e.target.value as ActionTrigger)}
+          >
+            {ALL_TRIGGERS.map((t) => (
+              <option key={t} value={t}>
+                {getActionTriggerLabel(t)}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="process-flow-modal-footer">
+          <button className="btn btn-outline-secondary btn-sm" onClick={onCancel}>
+            キャンセル
+          </button>
+          <button
+            className="btn btn-primary btn-sm"
+            onClick={onSubmit}
+            disabled={!name.trim()}
+          >
+            追加
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/process-flow/internal/CanvasPane.tsx
+++ b/frontend/src/components/process-flow/internal/CanvasPane.tsx
@@ -1,0 +1,263 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+// Phase-3 (#1145): ProcessFlowEditor.tsx 中央キャンバス (ステップリスト) を抽出。
+// SortableContext + 各 SortableStepCard + StepInsertZone の組合せ。
+
+import type { RefObject } from "react";
+import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import type { ActionDefinition, ProcessFlow, Step, StepType } from "../../../types/action";
+import type { ConventionsCatalog } from "../../../schemas/conventionsValidator";
+import { SortableStepCard } from "../SortableStepCard";
+import { EmptyFlowDropZone, StepInsertZone } from "./PaletteButtons";
+import { getStepLabel } from "../../../utils/actionUtils";
+import { generateUUID } from "../../../utils/uuid";
+import type { ValidationError } from "../../../utils/actionValidation";
+import type { UseAiContextChipsResult } from "../../../hooks/useAiContextChips";
+import type { EditLevel } from "../../../hooks/useEditLevel";
+
+export interface CanvasPaneProps {
+  group: ProcessFlow | null;
+  activeAction: ActionDefinition | null;
+  tables: { id: string; physicalName: string; name: string }[];
+  screens: { id: string; name: string }[];
+  commonGroups: { id: string; name: string }[];
+  conventions: ConventionsCatalog | null;
+  isReadonly: boolean;
+  isDraggingToolbarStep: boolean;
+  clipboard: { steps: Step[]; mode: "cut" | "copy" } | null;
+  newStepIds: Set<string>;
+  selectedIds: Set<string>;
+  validationErrors: ValidationError[];
+  editLevel: EditLevel;
+  stepListRef: RefObject<HTMLDivElement>;
+  aiChips: UseAiContextChipsResult;
+  aiPanelRef: RefObject<HTMLDivElement | null>;
+  /** step 操作 */
+  handleAddStep: (kind: StepType, insertIndex?: number) => void;
+  handlePaste: (insertIndex?: number) => void;
+  handleStepChange: (stepId: string, changes: Partial<Step>) => void;
+  commitGroup: () => void;
+  handleMoveStep: (fromIndex: number, toIndex: number) => void;
+  handleDeleteStep: (stepId: string) => void;
+  handleDuplicateStep: (stepId: string) => void;
+  handleAddSubStep: (parentStepId: string, kind: StepType) => void;
+  handleIndentStep: (stepId: string) => void;
+  handleOutdentSubStep: (parentStepId: string, subStepId: string) => void;
+  handleStepClick: (stepId: string, e: React.MouseEvent) => void;
+  onNavigateCommon: (refId: string) => void;
+  /** マーカー追加 (StepCard 内 onAddMarker) */
+  updateGroupWithDraft: (fn: (g: ProcessFlow) => void) => void;
+  /** context menu open */
+  onContextMenu: (stepId: string, x: number, y: number) => void;
+  /** 選択状態 */
+  setSelectedIds: (ids: Set<string>) => void;
+  /** 最終選択 ref (Shift+Click 範囲選択用) */
+  lastSelectedIdRef: { current: string | null };
+}
+
+export function CanvasPane({
+  group,
+  activeAction,
+  tables,
+  screens,
+  commonGroups,
+  conventions,
+  isReadonly,
+  isDraggingToolbarStep,
+  clipboard,
+  newStepIds,
+  selectedIds,
+  validationErrors,
+  editLevel,
+  stepListRef,
+  aiChips,
+  aiPanelRef,
+  handleAddStep,
+  handlePaste,
+  handleStepChange,
+  commitGroup,
+  handleMoveStep,
+  handleDeleteStep,
+  handleDuplicateStep,
+  handleAddSubStep,
+  handleIndentStep,
+  handleOutdentSubStep,
+  handleStepClick,
+  onNavigateCommon,
+  updateGroupWithDraft,
+  onContextMenu,
+  setSelectedIds,
+  lastSelectedIdRef,
+}: CanvasPaneProps) {
+  return (
+    <main className="process-flow-canvas-pane">
+      <div className="process-flow-canvas-header">
+        <div>
+          <span className="process-flow-pane-kicker">Flow</span>
+          <h6>{activeAction ? `${activeAction.name} の処理` : "処理フロー"}</h6>
+        </div>
+        {activeAction && (
+          <div className="process-flow-canvas-metrics">
+            <span>{activeAction.steps.length} steps</span>
+            <span>{activeAction.inputs?.length ?? 0} inputs</span>
+            <span>{activeAction.outputs?.length ?? 0} outputs</span>
+          </div>
+        )}
+      </div>
+      <div className="process-flow-content">
+        {activeAction ? (
+          <div className="step-editor">
+            {activeAction.steps.length === 0 ? (
+              <EmptyFlowDropZone disabled={isReadonly}>
+                <i className="bi bi-plus-circle" />
+                <strong>ステップがありません</strong>
+                <span>
+                  {isReadonly
+                    ? "編集開始後にステップを追加できます。"
+                    : "左のブロックをドラッグするか、ブロックをクリックして追加してください。"}
+                </span>
+                <StepInsertZone
+                  index={0}
+                  onClick={() => handleAddStep("other")}
+                  onPaste={clipboard && !isReadonly ? () => handlePaste(0) : undefined}
+                  dragVisible={isDraggingToolbarStep}
+                  disabled={isReadonly}
+                />
+              </EmptyFlowDropZone>
+            ) : (
+              <SortableContext
+                items={activeAction.steps.map((s) => s.id)}
+                strategy={verticalListSortingStrategy}
+              >
+                <div
+                  className={`step-list${isDraggingToolbarStep ? " drag-inserting" : ""}`}
+                  ref={stepListRef}
+                >
+                  {activeAction.steps.map((step, index) => {
+                    const stepMarkers = (group?.authoring?.markers ?? []).filter(
+                      (m) => !m.resolvedAt && m.stepId === step.id,
+                    );
+                    const markerCount = stepMarkers.length;
+                    const markerTooltip =
+                      markerCount > 0
+                        ? `AI 依頼マーカー ${markerCount} 件:\n${stepMarkers
+                            .map((m) => `- [${m.kind}] ${m.body.slice(0, 60)}`)
+                            .join("\n")}`
+                        : undefined;
+                    const markerKinds =
+                      markerCount > 0
+                        ? {
+                            todo: stepMarkers.filter((m) => m.kind === "todo").length,
+                            question: stepMarkers.filter((m) => m.kind === "question").length,
+                            attention: stepMarkers.filter((m) => m.kind === "attention").length,
+                            chat: stepMarkers.filter((m) => m.kind === "chat").length,
+                          }
+                        : undefined;
+                    return (
+                      <div key={step.id}>
+                        <StepInsertZone
+                          index={index}
+                          onClick={() => handleAddStep("other", index)}
+                          onPaste={
+                            clipboard && !isReadonly ? () => handlePaste(index) : undefined
+                          }
+                          dragVisible={isDraggingToolbarStep}
+                          disabled={isReadonly}
+                        />
+                        <SortableStepCard
+                          step={step}
+                          index={index}
+                          label={getStepLabel(index)}
+                          allSteps={activeAction.steps}
+                          tables={tables}
+                          screens={screens}
+                          commonGroups={commonGroups}
+                          onChange={(changes) => handleStepChange(step.id, changes)}
+                          onCommit={commitGroup}
+                          onMoveUp={
+                            index > 0 ? () => handleMoveStep(index, index - 1) : undefined
+                          }
+                          onMoveDown={
+                            index < activeAction.steps.length - 1
+                              ? () => handleMoveStep(index, index + 1)
+                              : undefined
+                          }
+                          onDelete={() => handleDeleteStep(step.id)}
+                          onDuplicate={() => handleDuplicateStep(step.id)}
+                          onAddSubStep={(kind) => handleAddSubStep(step.id, kind)}
+                          onContextMenu={(e) => {
+                            e.preventDefault();
+                            if (isReadonly) return;
+                            setSelectedIds(new Set([step.id]));
+                            lastSelectedIdRef.current = step.id;
+                            onContextMenu(step.id, e.clientX, e.clientY);
+                          }}
+                          onNavigateCommon={onNavigateCommon}
+                          defaultExpanded={newStepIds.has(step.id)}
+                          selected={selectedIds.has(step.id)}
+                          onHeaderClick={(e) => handleStepClick(step.id, e)}
+                          onIndent={index > 0 ? () => handleIndentStep(step.id) : undefined}
+                          onOutdentSubStep={(subId) =>
+                            handleOutdentSubStep(step.id, subId)
+                          }
+                          validationErrors={validationErrors}
+                          onAddMarker={(body, kind = "todo") => {
+                            updateGroupWithDraft((g) => {
+                              const m = {
+                                id: generateUUID(),
+                                kind,
+                                body,
+                                stepId: step.id,
+                                author: "human" as const,
+                                createdAt: new Date().toISOString(),
+                              };
+                              g.authoring = {
+                                ...(g.authoring ?? {}),
+                                markers: [...(g.authoring?.markers ?? []), m],
+                              };
+                            });
+                          }}
+                          markerCount={markerCount}
+                          markerTooltip={markerTooltip}
+                          markerKinds={markerKinds}
+                          conventions={conventions}
+                          group={group}
+                          editLevel={editLevel}
+                          readOnly={isReadonly}
+                          onAskAi={() => {
+                            const label = `S${index + 1}: ${step.description ?? step.kind ?? step.id}`;
+                            aiChips.addStepChip(String(step.id), label, step);
+                            aiPanelRef.current?.scrollIntoView({
+                              behavior: "smooth",
+                              block: "nearest",
+                            });
+                          }}
+                        />
+                      </div>
+                    );
+                  })}
+                  <StepInsertZone
+                    index={activeAction.steps.length}
+                    onClick={() => handleAddStep("other")}
+                    onPaste={
+                      clipboard && !isReadonly
+                        ? () => handlePaste(activeAction.steps.length)
+                        : undefined
+                    }
+                    dragVisible={isDraggingToolbarStep}
+                    disabled={isReadonly}
+                  />
+                </div>
+              </SortableContext>
+            )}
+          </div>
+        ) : (
+          <div className="step-empty process-flow-empty-drop">
+            <i className="bi bi-lightning" />
+            <strong>アクションがありません</strong>
+            <span>上部の + ボタンからアクションを追加してください。</span>
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/components/process-flow/internal/EditorHeaderExtras.tsx
+++ b/frontend/src/components/process-flow/internal/EditorHeaderExtras.tsx
@@ -1,0 +1,121 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+// Phase-3 (#1145): ProcessFlowEditor.tsx の EditorHeader.extraRight に渡す
+// ボタン群 (AI 生成 / AI レビュー / EditSession ドロップダウン / 描画 / 検証バッジ) を抽出。
+
+import type { ValidationError } from "../../../utils/actionValidation";
+import { EditSessionDropdown } from "../../editing/EditSessionDropdown";
+
+export interface EditorHeaderExtrasProps {
+  isReadonly: boolean;
+  drawingMode: boolean;
+  showWarningsPanel: boolean;
+  validationErrors: ValidationError[];
+  /** ProcessFlow ID (EditSessionDropdown 用) */
+  processFlowId: string;
+  /** EditSession 情報 */
+  mode: import("../../../hooks/useEditSession").EditMode;
+  sessionId: string;
+  /** 各種ハンドラ */
+  onOpenAiGenerate: () => void;
+  onOpenAiReview: () => void;
+  onToggleDrawing: () => void;
+  onToggleWarnings: () => void;
+  onStartEditing: () => void;
+  onViewerAttached: () => void;
+  onAttachAsView: () => Promise<void>;
+  onTakeOver: () => Promise<void>;
+}
+
+export function EditorHeaderExtras({
+  isReadonly,
+  drawingMode,
+  showWarningsPanel,
+  validationErrors,
+  processFlowId,
+  mode,
+  sessionId,
+  onOpenAiGenerate,
+  onOpenAiReview,
+  onToggleDrawing,
+  onToggleWarnings,
+  onStartEditing,
+  onViewerAttached,
+  onAttachAsView,
+  onTakeOver,
+}: EditorHeaderExtrasProps) {
+  const errorCount = validationErrors.filter((e) => e.severity === "error").length;
+  const warningCount = validationErrors.filter((e) => e.severity === "warning").length;
+
+  return (
+    <>
+      {!isReadonly && (
+        <button
+          type="button"
+          className="btn btn-sm btn-outline-primary"
+          onClick={onOpenAiGenerate}
+          title="要件テキストから処理フロー JSON を生成"
+        >
+          <i className="bi bi-stars" /> AI 生成
+        </button>
+      )}
+      <button
+        type="button"
+        className="btn btn-sm btn-outline-secondary"
+        onClick={onOpenAiReview}
+        title="現在の処理フロー JSON を AI でレビュー"
+      >
+        <i className="bi bi-clipboard-check" /> AI レビュー
+      </button>
+      <EditSessionDropdown
+        resourceType="process-flow"
+        resourceId={processFlowId}
+        currentMode={mode}
+        currentSessionId={sessionId}
+        onStartEditing={onStartEditing}
+        onViewerAttached={onViewerAttached}
+        onAttachAsView={onAttachAsView}
+        onTakeOver={onTakeOver}
+      />
+      <button
+        type="button"
+        className={`btn btn-sm ${drawingMode ? "btn-danger" : "btn-outline-secondary"}`}
+        onClick={onToggleDrawing}
+        title="赤線マーカー (ドラッグで描画、離すとマーカー起票)"
+      >
+        <i className="bi bi-pencil" /> {drawingMode ? "描画中" : "描画"}
+      </button>
+      {errorCount > 0 && (
+        <span
+          className="validation-badge error"
+          title={validationErrors
+            .filter((e) => e.severity === "error")
+            .map((e) => (e.path ? `[${e.path}] ${e.message}` : e.message))
+            .join("\n")}
+        >
+          <i className="bi bi-x-circle-fill" />
+          {errorCount} エラー
+        </span>
+      )}
+      {warningCount > 0 && (
+        <span
+          className="validation-badge warning clickable"
+          title={validationErrors
+            .filter((e) => e.severity === "warning")
+            .slice(0, 20)
+            .map((e) => (e.path ? `[${e.path}] ${e.message}` : e.message))
+            .join("\n")}
+          onClick={onToggleWarnings}
+          role="button"
+          tabIndex={0}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") onToggleWarnings();
+          }}
+        >
+          <i className="bi bi-exclamation-triangle-fill" />
+          {warningCount} 警告
+          <i className={`bi bi-chevron-${showWarningsPanel ? "up" : "down"} ms-1`} />
+        </span>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/process-flow/internal/InspectorPanel.tsx
+++ b/frontend/src/components/process-flow/internal/InspectorPanel.tsx
@@ -1,0 +1,173 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+// Phase-3 (#1145): ProcessFlowEditor.tsx 右サイドバー (詳細インスペクタ) を抽出。
+// AI 依頼パネル / Meta タブ (ActionMetaTabBar) / HTTP contract / SLA / 入出力データ。
+
+import type { RefObject } from "react";
+import type { ActionDefinition, ProcessFlow } from "../../../types/action";
+import { AiRequestPanel } from "../AiRequestPanel";
+import { ActionMetaTabBar } from "../ActionMetaTabBar";
+import { ActionHttpContractPanel } from "../ActionHttpContractPanel";
+import { SlaPanel } from "../SlaPanel";
+import { StructuredFieldsEditor, type ScreenItemPickResult } from "../StructuredFieldsEditor";
+import type { UseAiContextChipsResult } from "../../../hooks/useAiContextChips";
+
+export interface InspectorPanelProps {
+  group: ProcessFlow | null;
+  activeAction: ActionDefinition | null;
+  activeActionId: string | null;
+  isReadonly: boolean;
+  /** ProcessFlow ID (AI チップ追加用) */
+  processFlowId: string | undefined;
+  /** AI 依頼パネル */
+  aiChips: UseAiContextChipsResult;
+  handleAiSubmit: (prompt: string) => Promise<void>;
+  aiRequestBusy: boolean;
+  aiRequestError: string | null;
+  isCodexConnected: boolean;
+  aiPanelRef: RefObject<HTMLDivElement | null>;
+  /** ProcessFlow 全体 mutation */
+  updateGroup: (fn: (g: ProcessFlow) => void) => void;
+  updateGroupSilent: (fn: (g: ProcessFlow) => void) => void;
+  commitGroup: () => void;
+  /** 画面項目ピッカー */
+  handlePickScreenItem: () => Promise<ScreenItemPickResult | null>;
+}
+
+export function InspectorPanel({
+  group,
+  activeAction,
+  activeActionId,
+  isReadonly,
+  processFlowId,
+  aiChips,
+  handleAiSubmit,
+  aiRequestBusy,
+  aiRequestError,
+  isCodexConnected,
+  aiPanelRef,
+  updateGroup,
+  updateGroupSilent,
+  commitGroup,
+  handlePickScreenItem,
+}: InspectorPanelProps) {
+  return (
+    <aside className="process-flow-inspector-pane">
+      <div className="process-flow-pane-header">
+        <div>
+          <span className="process-flow-pane-kicker">Inspector</span>
+          <h6>詳細</h6>
+        </div>
+      </div>
+      <div className="process-flow-inspector-scroll">
+        {/* #1076 AI 依頼パネル */}
+        <div className="process-flow-inspector-section">
+          <AiRequestPanel
+            chips={aiChips.chips}
+            onRemoveChip={aiChips.removeChip}
+            onClearChips={aiChips.clearChips}
+            onSubmit={handleAiSubmit}
+            busy={aiRequestBusy}
+            error={aiRequestError}
+            isConnected={isCodexConnected}
+            panelRef={aiPanelRef}
+            actionLabel={activeAction?.name}
+            onAddActionContext={
+              activeAction
+                ? () => {
+                    aiChips.addActionChip(
+                      String(activeAction.id),
+                      activeAction.name,
+                      activeAction,
+                    );
+                  }
+                : undefined
+            }
+            onAddFlowContext={
+              group
+                ? () => {
+                    const flowName = group.meta?.name ?? "処理フロー";
+                    const flowId = processFlowId ?? "flow";
+                    aiChips.addFlowChip(flowId, flowName, group);
+                  }
+                : undefined
+            }
+          />
+        </div>
+        {isReadonly ? (
+          <div className="process-flow-inspector-section">
+            <div className="text-muted small">
+              詳細項目の編集は「編集開始」後に利用できます。
+            </div>
+          </div>
+        ) : (
+          <ActionMetaTabBar
+            group={group}
+            updateGroup={updateGroup}
+            updateGroupSilent={updateGroupSilent}
+          />
+        )}
+        {!isReadonly && activeAction && (
+          <>
+            <div className="process-flow-inspector-section">
+              <ActionHttpContractPanel
+                action={activeAction}
+                onChange={(patch) => {
+                  updateGroupSilent((g) => {
+                    const act = g.actions.find((a) => a.id === activeActionId);
+                    if (act) Object.assign(act, patch);
+                  });
+                  commitGroup();
+                }}
+              />
+            </div>
+            <div className="process-flow-inspector-section">
+              <SlaPanel
+                label="アクション SLA / Timeout"
+                sla={activeAction.sla}
+                onChange={(sla) => {
+                  updateGroupSilent((g) => {
+                    const act = g.actions.find((a) => a.id === activeActionId);
+                    if (act) act.sla = sla;
+                  });
+                  commitGroup();
+                }}
+              />
+            </div>
+            <div className="process-flow-io-panel">
+              <div className="process-flow-io-field">
+                <StructuredFieldsEditor
+                  label="入力データ"
+                  fields={activeAction.inputs}
+                  onChange={(val) => {
+                    updateGroupSilent((g) => {
+                      const act = g.actions.find((a) => a.id === activeActionId);
+                      if (act) act.inputs = val;
+                    });
+                  }}
+                  onCommit={commitGroup}
+                  placeholder="例: ユーザID、パスワード（改行で複数項目）"
+                  onPickScreenItem={handlePickScreenItem}
+                />
+              </div>
+              <div className="process-flow-io-field">
+                <StructuredFieldsEditor
+                  label="出力データ"
+                  fields={activeAction.outputs}
+                  onChange={(val) => {
+                    updateGroupSilent((g) => {
+                      const act = g.actions.find((a) => a.id === activeActionId);
+                      if (act) act.outputs = val;
+                    });
+                  }}
+                  onCommit={commitGroup}
+                  placeholder="例: セッションID、認証トークン（改行で複数項目）"
+                  onPickScreenItem={handlePickScreenItem}
+                />
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/frontend/src/components/process-flow/internal/PaletteButtons.tsx
+++ b/frontend/src/components/process-flow/internal/PaletteButtons.tsx
@@ -1,0 +1,128 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+// Phase-3 (#1145): ProcessFlowEditor.tsx から palette / insert zone 系の小 component を抽出。
+// - ToolbarStepButton: 左サイドバー (パレット) のドラッグ可能なステップ種別ボタン
+// - StepInsertZone: ステップ間の "+" / paste ドロップゾーン
+// - EmptyFlowDropZone: アクションが空の場合の全面ドロップゾーン
+// - CustomStepButton: 拡張カスタムステップのプレースホルダーボタン (D&D は別 ISSUE)
+
+import type { ReactNode } from "react";
+import { useDraggable, useDroppable } from "@dnd-kit/core";
+import type { StepType } from "../../../types/action";
+import { STEP_TYPE_LABELS, STEP_TYPE_ICONS, STEP_TYPE_COLORS } from "../../../types/action";
+
+export function ToolbarStepButton({
+  type,
+  onClick,
+  disabled = false,
+}: {
+  type: StepType;
+  onClick: () => void;
+  disabled?: boolean;
+}) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: `toolbar-${type}`,
+    data: { kind: "toolbar-step", stepType: type },
+    disabled,
+  });
+  return (
+    <button
+      ref={setNodeRef}
+      {...(disabled ? {} : listeners)}
+      {...(disabled ? {} : attributes)}
+      className={`step-toolbar-btn${isDragging ? " dragging" : ""}`}
+      onClick={onClick}
+      title={`${STEP_TYPE_LABELS[type]}（ドラッグで挿入）`}
+      disabled={disabled}
+      style={isDragging ? { opacity: 0.5, borderColor: STEP_TYPE_COLORS[type] } : undefined}
+    >
+      <i className={STEP_TYPE_ICONS[type]} />
+      {STEP_TYPE_LABELS[type]}
+    </button>
+  );
+}
+
+export function StepInsertZone({
+  index,
+  onClick,
+  onPaste,
+  dragVisible,
+  disabled = false,
+}: {
+  index: number;
+  onClick: () => void;
+  onPaste?: () => void;
+  dragVisible?: boolean;
+  disabled?: boolean;
+}) {
+  const { setNodeRef, isOver } = useDroppable({
+    id: `insert-${index}`,
+    data: { kind: "insert-zone", insertIndex: index },
+    disabled,
+  });
+  if (disabled) return null;
+  return (
+    <div
+      ref={setNodeRef}
+      className={`step-insert-point${isOver ? " drop-active" : ""}${onPaste ? " has-paste" : ""}${
+        dragVisible ? " drag-visible" : ""
+      }`}
+    >
+      <button className="step-insert-btn" onClick={onClick} title="ステップを挿入">
+        <i className="bi bi-plus" />
+      </button>
+      {onPaste && (
+        <button className="step-paste-btn" onClick={onPaste} title="ここに貼り付け">
+          <i className="bi bi-clipboard-plus me-1" />貼り付け
+        </button>
+      )}
+    </div>
+  );
+}
+
+export function EmptyFlowDropZone({
+  children,
+  disabled = false,
+}: {
+  children: ReactNode;
+  disabled?: boolean;
+}) {
+  const { setNodeRef, isOver } = useDroppable({
+    id: "empty-flow-drop",
+    data: { kind: "insert-zone", insertIndex: 0 },
+    disabled,
+  });
+  return (
+    <div
+      ref={setNodeRef}
+      className={`step-empty process-flow-empty-drop${isOver ? " drop-active" : ""}`}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function CustomStepButton({
+  id,
+  label,
+  icon,
+  description,
+}: {
+  id: string;
+  label: string;
+  icon: string;
+  description: string;
+}) {
+  return (
+    <button
+      type="button"
+      className="step-toolbar-btn"
+      disabled
+      title={`D&D 配置は別 ISSUE で対応予定: ${id}`}
+      aria-disabled="true"
+    >
+      <i className={icon || "bi bi-puzzle"} />
+      {label || id}
+      {description ? <span className="visually-hidden">{description}</span> : null}
+    </button>
+  );
+}

--- a/frontend/src/components/process-flow/internal/PalettePanel.tsx
+++ b/frontend/src/components/process-flow/internal/PalettePanel.tsx
@@ -1,0 +1,106 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+// Phase-3 (#1145): ProcessFlowEditor.tsx 左サイドバー (パレット) を抽出。
+// 基本ステップ button / カスタムステップ button / テンプレート dropdown。
+
+import type { StepType } from "../../../types/action";
+import { STEP_TEMPLATES } from "../../../types/action";
+import { ToolbarStepButton, CustomStepButton } from "./PaletteButtons";
+
+export interface PalettePanelProps {
+  stepFilter: string;
+  onChangeStepFilter: (q: string) => void;
+  filteredStepTypes: StepType[];
+  customStepCards: [string, { label: string; icon: string; description: string }][];
+  showTemplates: boolean;
+  onToggleTemplates: () => void;
+  onAddStep: (kind: StepType) => void;
+  onAddTemplate: (templateId: string) => void;
+  isReadonly: boolean;
+}
+
+export function PalettePanel({
+  stepFilter,
+  onChangeStepFilter,
+  filteredStepTypes,
+  customStepCards,
+  showTemplates,
+  onToggleTemplates,
+  onAddStep,
+  onAddTemplate,
+  isReadonly,
+}: PalettePanelProps) {
+  return (
+    <aside className="process-flow-palette-pane">
+      <div className="process-flow-pane-header">
+        <div>
+          <span className="process-flow-pane-kicker">Blocks</span>
+          <h6>ブロック</h6>
+        </div>
+        {!isReadonly && <span className="process-flow-pane-badge">D&D</span>}
+      </div>
+      <div className="process-flow-palette-search">
+        <i className="bi bi-search" />
+        <input
+          value={stepFilter}
+          onChange={(e) => onChangeStepFilter(e.target.value)}
+          placeholder="ブロックを検索"
+          aria-label="ブロックを検索"
+        />
+      </div>
+      <div className="step-toolbar">
+        <div className="process-flow-palette-section">基本ステップ</div>
+        {filteredStepTypes.map((type) => (
+          <ToolbarStepButton
+            key={type}
+            type={type}
+            onClick={() => onAddStep(type)}
+            disabled={isReadonly}
+          />
+        ))}
+        {filteredStepTypes.length === 0 && (
+          <div className="process-flow-palette-empty">該当するブロックがありません</div>
+        )}
+        {customStepCards.length > 0 && (
+          <>
+            <div className="step-toolbar-sep" />
+            <div className="process-flow-palette-section">カスタム</div>
+            {customStepCards.map(([id, step]) => (
+              <CustomStepButton
+                key={id}
+                id={id}
+                label={step.label}
+                icon={step.icon}
+                description={step.description}
+              />
+            ))}
+          </>
+        )}
+        <div className="step-toolbar-sep" />
+        <div className="process-flow-template-anchor">
+          <button
+            className="step-template-btn"
+            onClick={onToggleTemplates}
+            disabled={isReadonly}
+          >
+            <i className="bi bi-collection" />
+            テンプレート
+          </button>
+          {showTemplates && (
+            <div className="template-dropdown">
+              {STEP_TEMPLATES.map((tpl) => (
+                <div
+                  key={tpl.id}
+                  className="template-dropdown-item"
+                  onClick={() => onAddTemplate(tpl.id)}
+                >
+                  <div className="template-dropdown-item-label">{tpl.label}</div>
+                  <div className="template-dropdown-item-desc">{tpl.description}</div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/frontend/src/components/process-flow/internal/ProcessFlowDialogs.tsx
+++ b/frontend/src/components/process-flow/internal/ProcessFlowDialogs.tsx
@@ -1,0 +1,168 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+// Phase-3 (#1145): ProcessFlowEditor.tsx の各種 confirm / save-conflict / AI 生成
+// / AI レビューダイアログを 1 component に束ねた wrapper。
+// state は親側 (ProcessFlowEditor) が保持、本 component は宣言的レンダリングのみ。
+
+import type { ProcessFlow } from "../../../types/action";
+import {
+  DiscardConfirmDialog,
+  ForceReleaseConfirmDialog,
+  ForcedOutChoiceDialog,
+  AfterForceUnlockChoiceDialog,
+} from "../../editing/ConfirmDialogs";
+import { SaveConflictDialog } from "../../editing/SaveConflictDialog";
+import { ResumeOrDiscardDialog } from "../../editing/ResumeOrDiscardDialog";
+import { ServerChangeBanner } from "../../common/ServerChangeBanner";
+import { ProcessFlowAiGenerateDialog } from "../ProcessFlowAiGenerateDialog";
+import { ProcessFlowAiReviewDialog } from "../ProcessFlowAiReviewDialog";
+import { AiDiffPreviewDialog } from "../AiDiffPreviewDialog";
+
+export interface ProcessFlowDialogsProps {
+  group: ProcessFlow | null;
+  mode: import("../../../hooks/useEditSession").EditMode;
+  lockedByOther: { ownerSessionId: string } | null;
+  /** flags */
+  showResumeDialog: boolean;
+  showDiscardDialog: boolean;
+  showForceReleaseDialog: boolean;
+  showAiGenerateDialog: boolean;
+  showAiReviewDialog: boolean;
+  serverChanged: boolean;
+  /** edit session actions */
+  onForcedOutChoice: (choice: unknown) => void;
+  onAfterForceUnlockChoice: (choice: unknown) => void;
+  onResumeContinue: () => void;
+  onResumeDiscard: () => void;
+  onCancelResume: () => void;
+  onDiscardConfirm: () => void;
+  onDiscardCancel: () => void;
+  onForceReleaseConfirm: () => void;
+  onForceReleaseCancel: () => void;
+  /** save conflict */
+  saveConflict: unknown;
+  onSaveConflictOverwrite: () => Promise<void>;
+  onSaveConflictCancel: () => void;
+  /** server banner */
+  onServerReload: () => void;
+  onServerDismiss: () => void;
+  /** AI 生成 / レビュー */
+  onCloseAiGenerate: () => void;
+  onApplyAiGenerate: (next: ProcessFlow) => void;
+  onCloseAiReview: () => void;
+  /** AI 差分 */
+  aiDiffProposed: ProcessFlow | null;
+  aiPromptSummary: string;
+  onApplyAiDiff: (proposed: ProcessFlow) => void;
+  onApplyAiDiffSelected: (proposed: ProcessFlow, paths: string[]) => void;
+  onDiscardAiDiff: () => void;
+  onAddAiDiffMarker: (body: string) => void;
+}
+
+export function ProcessFlowDialogs({
+  group,
+  mode,
+  lockedByOther,
+  showResumeDialog,
+  showDiscardDialog,
+  showForceReleaseDialog,
+  showAiGenerateDialog,
+  showAiReviewDialog,
+  serverChanged,
+  onForcedOutChoice,
+  onAfterForceUnlockChoice,
+  onResumeContinue,
+  onResumeDiscard,
+  onCancelResume,
+  onDiscardConfirm,
+  onDiscardCancel,
+  onForceReleaseConfirm,
+  onForceReleaseCancel,
+  saveConflict,
+  onSaveConflictOverwrite,
+  onSaveConflictCancel,
+  onServerReload,
+  onServerDismiss,
+  onCloseAiGenerate,
+  onApplyAiGenerate,
+  onCloseAiReview,
+  aiDiffProposed,
+  aiPromptSummary,
+  onApplyAiDiff,
+  onApplyAiDiffSelected,
+  onDiscardAiDiff,
+  onAddAiDiffMarker,
+}: ProcessFlowDialogsProps) {
+  return (
+    <>
+      {mode.kind === "force-released-pending" && (
+        <ForcedOutChoiceDialog
+          previousDraftExists={mode.previousDraftExists}
+          onChoice={onForcedOutChoice}
+        />
+      )}
+
+      {mode.kind === "after-force-unlock" && (
+        <AfterForceUnlockChoiceDialog
+          previousOwner={mode.previousOwner}
+          onChoice={onAfterForceUnlockChoice}
+        />
+      )}
+
+      {showResumeDialog && (
+        <ResumeOrDiscardDialog
+          onResume={onResumeContinue}
+          onDiscard={onResumeDiscard}
+          onCancel={onCancelResume}
+        />
+      )}
+
+      {showDiscardDialog && (
+        <DiscardConfirmDialog onConfirm={onDiscardConfirm} onCancel={onDiscardCancel} />
+      )}
+
+      {saveConflict && (
+        <SaveConflictDialog
+          conflict={saveConflict}
+          onOverwrite={onSaveConflictOverwrite}
+          onCancel={onSaveConflictCancel}
+        />
+      )}
+
+      {showForceReleaseDialog && lockedByOther && (
+        <ForceReleaseConfirmDialog
+          ownerSessionId={lockedByOther.ownerSessionId}
+          onConfirm={onForceReleaseConfirm}
+          onCancel={onForceReleaseCancel}
+        />
+      )}
+
+      {serverChanged && (
+        <ServerChangeBanner onReload={onServerReload} onDismiss={onServerDismiss} />
+      )}
+
+      {showAiGenerateDialog && (
+        <ProcessFlowAiGenerateDialog
+          current={group}
+          onClose={onCloseAiGenerate}
+          onApply={onApplyAiGenerate}
+        />
+      )}
+
+      {showAiReviewDialog && (
+        <ProcessFlowAiReviewDialog current={group} onClose={onCloseAiReview} />
+      )}
+
+      {aiDiffProposed && group && (
+        <AiDiffPreviewDialog
+          current={group}
+          proposed={aiDiffProposed}
+          promptSummary={aiPromptSummary}
+          onApply={() => onApplyAiDiff(aiDiffProposed)}
+          onApplySelected={(paths) => onApplyAiDiffSelected(aiDiffProposed, paths)}
+          onDiscard={onDiscardAiDiff}
+          onAddMarker={onAddAiDiffMarker}
+        />
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/process-flow/internal/StepContextMenu.tsx
+++ b/frontend/src/components/process-flow/internal/StepContextMenu.tsx
@@ -1,0 +1,125 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+// Phase-3 (#1145): ProcessFlowEditor.tsx からステップカードの右クリックコンテキストメニューを抽出。
+// 通常モード ⇔ サブステップ追加 (subType picker) モードの切替を内部 prop 経由で受ける。
+
+import type { StepType } from "../../../types/action";
+import { STEP_TYPE_ICONS, STEP_TYPE_LABELS, STEP_TYPE_COLORS } from "../../../types/action";
+import { ALL_SUB_STEP_TYPES } from "./stepCardConstants";
+
+export interface StepContextMenuProps {
+  x: number;
+  y: number;
+  stepId: string;
+  /** subType picker mode (サブステップ追加候補一覧を表示) */
+  subTypePickerOpen: boolean;
+  /** クリップボードが空かどうかで「貼り付け」項目を出すか決める */
+  hasClipboard: boolean;
+  /** subType picker 切替 */
+  onToggleSubTypePicker: (open: boolean) => void;
+  /** 「前/後ろに挿入」(other ステップ) */
+  onInsertBefore: () => void;
+  onInsertAfter: () => void;
+  /** 「前/後ろに貼り付け」 */
+  onPasteBefore: () => void;
+  onPasteAfter: () => void;
+  /** 単一ステップ操作 */
+  onCopy: () => void;
+  onCut: () => void;
+  onDuplicate: () => void;
+  onAddSubStep: (kind: StepType) => void;
+  /** AI 依頼 (group / step lookup は親側で実施済の前提) */
+  onAskAi: () => void;
+  onDelete: () => void;
+}
+
+export function StepContextMenu({
+  x,
+  y,
+  stepId: _stepId,
+  subTypePickerOpen,
+  hasClipboard,
+  onToggleSubTypePicker,
+  onInsertBefore,
+  onInsertAfter,
+  onPasteBefore,
+  onPasteAfter,
+  onCopy,
+  onCut,
+  onDuplicate,
+  onAddSubStep,
+  onAskAi,
+  onDelete,
+}: StepContextMenuProps) {
+  return (
+    <div
+      className="step-context-menu"
+      style={{ top: y, left: x }}
+      onClick={(e) => e.stopPropagation()}
+    >
+      {!subTypePickerOpen ? (
+        <>
+          <button className="step-context-menu-item" onClick={onInsertBefore}>
+            <i className="bi bi-plus-circle" /> 前に挿入
+          </button>
+          <button className="step-context-menu-item" onClick={onInsertAfter}>
+            <i className="bi bi-plus-square" /> 後に挿入
+          </button>
+          {hasClipboard && (
+            <>
+              <button className="step-context-menu-item" onClick={onPasteBefore}>
+                <i className="bi bi-clipboard-plus" /> 前に貼り付け
+              </button>
+              <button className="step-context-menu-item" onClick={onPasteAfter}>
+                <i className="bi bi-clipboard-plus" /> 後に貼り付け
+              </button>
+            </>
+          )}
+          <div className="step-context-menu-sep" />
+          <button className="step-context-menu-item" onClick={onCopy}>
+            <i className="bi bi-files" /> コピー
+          </button>
+          <button className="step-context-menu-item" onClick={onCut}>
+            <i className="bi bi-scissors" /> カット
+          </button>
+          <button className="step-context-menu-item" onClick={onDuplicate}>
+            <i className="bi bi-copy" /> 複製
+          </button>
+          <button
+            className="step-context-menu-item"
+            onClick={() => onToggleSubTypePicker(true)}
+          >
+            <i className="bi bi-diagram-2" /> サブステップ追加 ▶
+          </button>
+          <div className="step-context-menu-sep" />
+          <button className="step-context-menu-item" onClick={onAskAi}>
+            <i className="bi bi-robot" /> このステップを AI に依頼
+          </button>
+          <button className="step-context-menu-item danger" onClick={onDelete}>
+            <i className="bi bi-trash" /> 削除
+          </button>
+        </>
+      ) : (
+        <>
+          <button
+            className="step-context-menu-item"
+            onClick={() => onToggleSubTypePicker(false)}
+          >
+            <i className="bi bi-arrow-left" /> 戻る
+          </button>
+          <div className="step-context-menu-sep" />
+          {ALL_SUB_STEP_TYPES.map((t: StepType) => (
+            <button
+              key={t}
+              className="step-context-menu-item"
+              onClick={() => onAddSubStep(t)}
+            >
+              <i className={`bi ${STEP_TYPE_ICONS[t]}`} style={{ color: STEP_TYPE_COLORS[t] }} />
+              {" "}
+              {STEP_TYPE_LABELS[t]}
+            </button>
+          ))}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/process-flow/internal/WarningsPanel.tsx
+++ b/frontend/src/components/process-flow/internal/WarningsPanel.tsx
@@ -1,0 +1,121 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+// Phase-3 (#1145): ProcessFlowEditor.tsx から警告詳細パネル (#261 UI 統合) を抽出。
+// 警告一覧 + 「全て AI に依頼」 / 個別「AI に依頼」ボタン (既起票判定込み)。
+
+import { generateUUID } from "../../../utils/uuid";
+import type { ProcessFlow } from "../../../types/action";
+import type { ValidationError } from "../../../utils/actionValidation";
+
+export interface WarningsPanelProps {
+  group: ProcessFlow | null;
+  validationErrors: ValidationError[];
+  onClose: () => void;
+  /** マーカーを 1 件以上追加するため、ProcessFlow を updater で更新する */
+  onUpdateProcessFlow: (fn: (g: ProcessFlow) => void) => void;
+}
+
+export function WarningsPanel({
+  group,
+  validationErrors,
+  onClose,
+  onUpdateProcessFlow,
+}: WarningsPanelProps) {
+  const warnings = validationErrors.filter((e) => e.severity === "warning");
+  if (warnings.length === 0) return null;
+
+  const handleBulkAskAi = () => {
+    if (!group) return;
+    const existingKeys = new Set(
+      (group.authoring?.markers ?? [])
+        .filter((m) => !m.resolvedAt && m.kind === "todo")
+        .map((m) => `${m.code ?? ""}|${m.path ?? ""}`),
+    );
+    const newMarkers = warnings
+      .filter((e) => e.path)
+      .filter((e) => !existingKeys.has(`${e.code ?? ""}|${e.path ?? ""}`))
+      .map((e) => ({
+        id: generateUUID(),
+        kind: "todo" as const,
+        body: `警告解消: ${e.message}`,
+        stepId: e.stepId || undefined,
+        code: e.code,
+        path: e.path,
+        author: "human" as const,
+        createdAt: new Date().toISOString(),
+      }));
+    if (newMarkers.length === 0) {
+      window.alert("全ての警告は既に AI 依頼済みです");
+      return;
+    }
+    onUpdateProcessFlow((g) => {
+      g.authoring = {
+        ...(g.authoring ?? {}),
+        markers: [...(g.authoring?.markers ?? []), ...newMarkers],
+      };
+    });
+    window.alert(
+      `${newMarkers.length} 件の警告を marker として起票しました。/designer-work で処理できます。`,
+    );
+  };
+
+  return (
+    <div className="process-flow-validation-panel">
+      <div className="process-flow-validation-panel-header">
+        <i className="bi bi-exclamation-triangle-fill" /> 警告 ({warnings.length} 件)
+        <button
+          className="btn btn-sm btn-link process-flow-validation-panel-bulk-ai"
+          onClick={handleBulkAskAi}
+          title="全ての警告をまとめて AI 依頼 marker として起票"
+        >
+          <i className="bi bi-robot" /> 全て AI に依頼
+        </button>
+        <button className="btn btn-sm btn-link ms-1" onClick={onClose} title="閉じる">
+          <i className="bi bi-x-lg" />
+        </button>
+      </div>
+      <ul className="process-flow-validation-panel-list">
+        {warnings.map((e, i) => {
+          const isMarked = (group?.authoring?.markers ?? []).some(
+            (m) =>
+              !m.resolvedAt && m.kind === "todo" && m.code === e.code && m.path === e.path,
+          );
+          return (
+            <li key={i}>
+              {e.code && <span className="validation-code">{e.code}</span>}
+              <span className="validation-message">{e.message}</span>
+              {e.path && <span className="validation-path">{e.path}</span>}
+              <button
+                className={`btn btn-sm validation-ask-ai-btn ${isMarked ? "asked" : ""}`}
+                disabled={isMarked || !group}
+                title={isMarked ? "AI に依頼済み" : "この警告を marker として AI に依頼"}
+                onClick={() => {
+                  if (!group || isMarked) return;
+                  const newMarker = {
+                    id: generateUUID(),
+                    kind: "todo" as const,
+                    body: `警告解消: ${e.message}`,
+                    stepId: e.stepId || undefined,
+                    code: e.code,
+                    path: e.path,
+                    author: "human" as const,
+                    createdAt: new Date().toISOString(),
+                  };
+                  onUpdateProcessFlow((g) => {
+                    g.authoring = {
+                      ...(g.authoring ?? {}),
+                      markers: [...(g.authoring?.markers ?? []), newMarker],
+                    };
+                  });
+                }}
+              >
+                <i className={`bi ${isMarked ? "bi-check-circle-fill" : "bi-robot"}`} />
+                {" "}
+                {isMarked ? "依頼済" : "AI に依頼"}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/components/process-flow/internal/actionTriggerConstants.ts
+++ b/frontend/src/components/process-flow/internal/actionTriggerConstants.ts
@@ -1,0 +1,193 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+// Phase-3 (#1145): ProcessFlowEditor.tsx から action trigger 関連の定数 / ヘルパーを抽出。
+// アクション (trigger) の icon / カテゴリ / リッチヘルプ / ラベルの取得。
+
+import { ACTION_TRIGGER_LABELS } from "../../../types/action";
+import type { ActionDefinition, ActionTrigger, Marker } from "../../../types/action";
+
+export const ALL_TRIGGERS: ActionTrigger[] = [
+  "click",
+  "submit",
+  "select",
+  "change",
+  "load",
+  "timer",
+  "other",
+];
+
+export const ACTION_TRIGGER_ICONS: Record<string, string> = {
+  click: "bi-cursor",
+  submit: "bi-send",
+  select: "bi-list-check",
+  change: "bi-pencil-square",
+  load: "bi-box-arrow-in-down",
+  unload: "bi-box-arrow-right",
+  timer: "bi-clock",
+  manual: "bi-person-check",
+  other: "bi-lightning-charge",
+};
+
+export const ACTION_TRIGGER_CATEGORIES: Record<string, string> = {
+  click: "画面操作",
+  submit: "入力確定",
+  select: "選択連動",
+  change: "値変更",
+  load: "初期表示",
+  unload: "終了処理",
+  timer: "時刻・周期",
+  manual: "手動実行",
+  other: "その他",
+};
+
+export interface ActionTriggerRichHelp {
+  occasion: string;
+  useCases: string[];
+  definitionExample: string;
+  stepExample: string[];
+  notes: string[];
+}
+
+export const ACTION_TRIGGER_RICH_HELP: Record<string, ActionTriggerRichHelp> = {
+  click: {
+    occasion: "ボタンやリンクなど、利用者が明示的に押した UI 操作を契機に動きます。",
+    useCases: ["詳細表示", "削除確認", "検索条件クリア", "別画面への遷移"],
+    definitionExample: "trigger: click / inputs: 選択行ID・画面入力値 / responses: 完了メッセージ",
+    stepExample: ["入力・選択状態を確認", "必要な DB 更新または参照", "画面更新または画面遷移"],
+    notes: ["連打や二重送信を避ける制御が必要な場合は validation や workflow に明記します。"],
+  },
+  submit: {
+    occasion: "フォーム送信や確定操作で、入力内容を業務データとして確定するときに動きます。",
+    useCases: ["登録", "更新", "申請", "承認依頼"],
+    definitionExample: "trigger: submit / inputs: フォーム全項目 / outputs: 登録ID / responses: 成功・入力エラー",
+    stepExample: ["必須・形式チェック", "業務ルール検証", "DB 保存", "レスポンス返却"],
+    notes: ["入力エラーとシステムエラーの responses を分けると、AI 実装時の分岐が明確になります。"],
+  },
+  select: {
+    occasion: "一覧行、候補、タブなどの選択状態が変わったタイミングで動きます。",
+    useCases: ["一覧行の詳細表示", "候補選択による関連情報取得", "親子リストの絞り込み"],
+    definitionExample: "trigger: select / inputs: selectedId / outputs: detailModel",
+    stepExample: ["選択IDの存在確認", "関連データ取得", "表示モデルへ反映"],
+    notes: ["選択解除時の扱いが必要なら other response または branch に明記します。"],
+  },
+  change: {
+    occasion: "入力値やフィルタ条件が変わった直後に、画面内の連動処理として動きます。",
+    useCases: ["金額再計算", "項目の表示切替", "候補リスト更新", "入力補助"],
+    definitionExample: "trigger: change / inputs: changedField・currentForm / outputs: derivedValues",
+    stepExample: ["変更項目を判定", "派生値を計算", "表示状態を更新"],
+    notes: ["高頻度に動くため、重い外部呼び出しは debounce や submit 側への移動を検討します。"],
+  },
+  load: {
+    occasion: "画面表示、初期データ取得、リソース読み込みの開始時に動きます。",
+    useCases: ["初期検索", "選択肢取得", "初期値設定", "権限に応じた表示制御"],
+    definitionExample: "trigger: load / inputs: routeParams・sessionUser / outputs: initialViewModel",
+    stepExample: ["起動条件を確認", "初期データを取得", "画面モデルを構築"],
+    notes: ["表示前に必要なデータと、表示後に遅延取得できるデータを分けると実装しやすくなります。"],
+  },
+  unload: {
+    occasion: "画面離脱、タブ終了、編集終了など、利用者が作業文脈を閉じるときに動きます。",
+    useCases: ["一時保存", "ロック解放", "離脱確認", "監査ログ記録"],
+    definitionExample: "trigger: unload / inputs: dirtyState・lockId / responses: 保存済み・破棄確認",
+    stepExample: ["未保存状態を確認", "必要なら保存または確認", "ロックや一時資源を解放"],
+    notes: ["ブラウザ終了時は非同期処理が完了しない可能性があるため、重要処理は明示保存側に寄せます。"],
+  },
+  timer: {
+    occasion: "一定間隔、指定時刻、期限到来など時間条件を契機に動きます。",
+    useCases: ["自動更新", "期限チェック", "バッチ起動", "再試行"],
+    definitionExample: "trigger: timer / inputs: schedule・lastRunAt / outputs: runSummary",
+    stepExample: ["実行条件を確認", "対象データを抽出", "処理を実行", "結果を記録"],
+    notes: ["重複起動、タイムアウト、リトライ方針を steps または SLA に記述します。"],
+  },
+  manual: {
+    occasion: "運用者や管理者が、通常 UI フローとは別に明示起動するときに動きます。",
+    useCases: ["手動再実行", "補正処理", "管理操作", "障害復旧"],
+    definitionExample: "trigger: manual / inputs: operatorId・targetId / responses: 実行結果・権限エラー",
+    stepExample: ["権限を確認", "対象を検証", "処理を実行", "監査ログを残す"],
+    notes: ["誰が何を起動できるかを inputs と validation に明記します。"],
+  },
+  other: {
+    occasion: "標準 trigger に当てはまらない、プロジェクト固有の契機で動きます。",
+    useCases: ["外部通知", "組み込み拡張", "特殊な業務イベント"],
+    definitionExample: "trigger: other / description: 契機の発生元と実行条件を明記",
+    stepExample: ["契機を説明", "入力契約を検証", "業務処理を実行", "結果を返す"],
+    notes: ["比較・保守しやすいように、description で契機名と発生条件を補足します。"],
+  },
+};
+
+export const getActionTriggerLabel = (trigger: string): string =>
+  ACTION_TRIGGER_LABELS[trigger] ?? trigger;
+export const getActionTriggerIcon = (trigger: string): string =>
+  ACTION_TRIGGER_ICONS[trigger] ?? ACTION_TRIGGER_ICONS.other;
+export const getActionTriggerCategory = (trigger: string): string =>
+  ACTION_TRIGGER_CATEGORIES[trigger] ?? ACTION_TRIGGER_CATEGORIES.other;
+export const getActionTriggerRichHelp = (trigger: string): ActionTriggerRichHelp =>
+  ACTION_TRIGGER_RICH_HELP[trigger] ?? ACTION_TRIGGER_RICH_HELP.other;
+
+// ── アクションのメタ要約用ヘルパー ─────────────────────────────────────
+import { STEP_TYPE_LABELS } from "../../../types/action";
+
+export function countActionFields(fields: unknown): number {
+  if (Array.isArray(fields)) return fields.length;
+  if (typeof fields === "string" && fields.trim()) return 1;
+  return 0;
+}
+
+export function summarizeActionFields(fields: unknown, fallback: string): string {
+  if (Array.isArray(fields) && fields.length > 0) {
+    return (
+      fields
+        .slice(0, 3)
+        .map((field) => {
+          if (typeof field === "string") return field;
+          return field?.name ?? field?.id ?? "名称未設定";
+        })
+        .join("、") + (fields.length > 3 ? ` ほか ${fields.length - 3} 件` : "")
+    );
+  }
+  if (typeof fields === "string" && fields.trim()) return fields.trim().slice(0, 80);
+  return fallback;
+}
+
+export function summarizeActionStepTypes(action: ActionDefinition): string {
+  const counts = new Map<string, number>();
+  for (const step of action.steps ?? []) {
+    const key = step.kind ?? "other";
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  if (counts.size === 0) return "ステップ未定義";
+  return [...counts.entries()]
+    .slice(0, 4)
+    .map(([type, count]) => `${STEP_TYPE_LABELS[type] ?? type} ${count}`)
+    .join(" / ");
+}
+
+export function getActionOpenMarkers(
+  action: ActionDefinition,
+  actionIndex: number,
+  markers: Marker[],
+): Marker[] {
+  const stepIds = new Set((action.steps ?? []).map((step: { id: string }) => step.id));
+  const actionPathById = `actions[${action.id}]`;
+  const actionPathByIndex = actionIndex >= 0 ? `actions[${actionIndex}]` : null;
+  return markers.filter((marker) => {
+    if (marker.resolvedAt) return false;
+    if (marker.actionId === action.id) return true;
+    const markerStepId = marker.stepId ?? marker.anchor?.stepId;
+    if (markerStepId && stepIds.has(markerStepId)) return true;
+    const markerPath = marker.path ?? marker.validatorPath ?? marker.anchor?.fieldPath ?? "";
+    return (
+      typeof markerPath === "string" &&
+      (markerPath.includes(actionPathById) ||
+        (!!actionPathByIndex && markerPath.includes(actionPathByIndex)))
+    );
+  });
+}
+
+export function summarizeActionMarkers(markers: Marker[]): string {
+  if (markers.length === 0) return "なし";
+  const counts = new Map<string, number>();
+  for (const marker of markers) {
+    const kind = marker.kind ?? "marker";
+    counts.set(kind, (counts.get(kind) ?? 0) + 1);
+  }
+  return [...counts.entries()].map(([kind, count]) => `${kind} ${count}`).join(" / ");
+}

--- a/frontend/src/components/process-flow/internal/step-cards/AiAgentStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/AiAgentStepCardBody.tsx
@@ -1,0 +1,102 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+// Phase-3 (#1145、#1163 review Phase-2 補足): StepCard.tsx で dispatch が未実装だった
+// `aiAgent` kind (PR #935/#936 で schema 追加) に最小 body を提供する。
+// AiAgentStep: modelRef + messages + tools (1 件以上必須) + maxIterations。
+// multi-step agent loop。tool が無い single-shot は AiCallStep を使う。
+
+import type { Step } from "../../../../types/action";
+import type { StepCardBodyBaseProps } from "./types";
+
+export type AiAgentStepCardBodyProps = StepCardBodyBaseProps;
+
+export function AiAgentStepCardBody({
+  step,
+  onChange,
+  onCommit,
+}: AiAgentStepCardBodyProps) {
+  const messages = Array.isArray(step.messages) ? step.messages : [];
+  const tools = Array.isArray(step.tools) ? step.tools : [];
+  return (
+    <>
+      <div className="row g-2 mb-2">
+        <div className="col-8">
+          <label className="form-label">
+            <i className="bi bi-robot me-1" />
+            modelRef
+          </label>
+          <input
+            type="text"
+            className="form-control form-control-sm"
+            value={step.modelRef ?? ""}
+            onChange={(e) => onChange({ modelRef: e.target.value } as Partial<Step>)}
+            onBlur={onCommit}
+            placeholder="例: agentModel"
+            style={{ fontFamily: "monospace", fontSize: "0.85rem" }}
+          />
+        </div>
+        <div className="col-4">
+          <label className="form-label">
+            <i className="bi bi-arrow-repeat me-1" />
+            maxIterations
+          </label>
+          <input
+            type="number"
+            className="form-control form-control-sm"
+            min={1}
+            value={step.maxIterations ?? 10}
+            onChange={(e) => onChange({ maxIterations: Number(e.target.value) || 1 } as Partial<Step>)}
+            onBlur={onCommit}
+          />
+        </div>
+      </div>
+      <div className="form-group">
+        <label className="form-label small">
+          <i className="bi bi-chat-left-text me-1" />
+          初期 messages ({messages.length} 件、JSON 形式)
+        </label>
+        <textarea
+          className="form-control form-control-sm"
+          rows={5}
+          value={JSON.stringify(messages, null, 2)}
+          onChange={(e) => {
+            try {
+              const parsed = JSON.parse(e.target.value);
+              if (Array.isArray(parsed)) {
+                onChange({ messages: parsed } as Partial<Step>);
+              }
+            } catch {
+              // ignore
+            }
+          }}
+          onBlur={onCommit}
+          placeholder={'[\n  { "role": "system", "content": "..." },\n  { "role": "user", "content": "..." }\n]'}
+          style={{ fontFamily: "monospace", fontSize: "0.8rem" }}
+        />
+      </div>
+      <div className="form-group">
+        <label className="form-label small">
+          <i className="bi bi-tools me-1" />
+          tools ({tools.length} 件、JSON 形式、1 件以上必須)
+        </label>
+        <textarea
+          className="form-control form-control-sm"
+          rows={4}
+          value={JSON.stringify(tools, null, 2)}
+          onChange={(e) => {
+            try {
+              const parsed = JSON.parse(e.target.value);
+              if (Array.isArray(parsed)) {
+                onChange({ tools: parsed } as Partial<Step>);
+              }
+            } catch {
+              // ignore
+            }
+          }}
+          onBlur={onCommit}
+          placeholder={'[\n  { "functionRef": "catalogs.functions.search" }\n]'}
+          style={{ fontFamily: "monospace", fontSize: "0.8rem" }}
+        />
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/process-flow/internal/step-cards/AiCallStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/AiCallStepCardBody.tsx
@@ -1,0 +1,91 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+// Phase-3 (#1145、#1163 review Phase-2 補足): StepCard.tsx で dispatch が未実装だった
+// `aiCall` kind (PR #935/#936 で schema 追加) に最小 body を提供する。
+// AiCallStep: modelRef + messages + tools (任意) + responseFormat (任意)。
+
+import type { Step } from "../../../../types/action";
+import type { StepCardBodyBaseProps } from "./types";
+
+export type AiCallStepCardBodyProps = StepCardBodyBaseProps;
+
+export function AiCallStepCardBody({
+  step,
+  onChange,
+  onCommit,
+}: AiCallStepCardBodyProps) {
+  const messages = Array.isArray(step.messages) ? step.messages : [];
+  return (
+    <>
+      <div className="row g-2 mb-2">
+        <div className="col-12">
+          <label className="form-label">
+            <i className="bi bi-cpu me-1" />
+            modelRef (context.catalogs.modelEndpoints のキー)
+          </label>
+          <input
+            type="text"
+            className="form-control form-control-sm"
+            value={step.modelRef ?? ""}
+            onChange={(e) => onChange({ modelRef: e.target.value } as Partial<Step>)}
+            onBlur={onCommit}
+            placeholder="例: summarizeModel / projectModel"
+            style={{ fontFamily: "monospace", fontSize: "0.85rem" }}
+          />
+        </div>
+      </div>
+      <div className="form-group">
+        <label className="form-label small">
+          <i className="bi bi-chat-left-text me-1" />
+          messages ({messages.length} 件、JSON 形式)
+        </label>
+        <textarea
+          className="form-control form-control-sm"
+          rows={6}
+          value={JSON.stringify(messages, null, 2)}
+          onChange={(e) => {
+            try {
+              const parsed = JSON.parse(e.target.value);
+              if (Array.isArray(parsed)) {
+                onChange({ messages: parsed } as Partial<Step>);
+              }
+            } catch {
+              // JSON parse 失敗は無視 (blur で再 commit)
+            }
+          }}
+          onBlur={onCommit}
+          placeholder={'[\n  { "role": "system", "content": "..." },\n  { "role": "user", "content": "..." }\n]'}
+          style={{ fontFamily: "monospace", fontSize: "0.8rem" }}
+        />
+      </div>
+      <div className="form-group">
+        <label className="form-label small">
+          <i className="bi bi-sliders me-1" />
+          parameters (任意、JSON: temperature / maxTokens 等)
+        </label>
+        <textarea
+          className="form-control form-control-sm"
+          rows={2}
+          value={step.parameters ? JSON.stringify(step.parameters, null, 2) : ""}
+          onChange={(e) => {
+            const trimmed = e.target.value.trim();
+            if (!trimmed) {
+              onChange({ parameters: undefined } as Partial<Step>);
+              return;
+            }
+            try {
+              const parsed = JSON.parse(trimmed);
+              if (parsed && typeof parsed === "object") {
+                onChange({ parameters: parsed } as Partial<Step>);
+              }
+            } catch {
+              // ignore
+            }
+          }}
+          onBlur={onCommit}
+          placeholder='{"temperature": 0.2, "maxTokens": 800}'
+          style={{ fontFamily: "monospace", fontSize: "0.8rem" }}
+        />
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/process-flow/internal/step-cards/ComponentCallStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/ComponentCallStepCardBody.tsx
@@ -1,0 +1,107 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+// Phase-3 (#1145、#1163 review Phase-2 補足): StepCard.tsx で dispatch が未実装だった
+// `componentCall` kind (PR #1066 で schema 追加) に最小 body を提供する。
+// CommonProcessStepCardBody と類似 (componentRef + operation + argumentMapping / returnMapping)。
+
+import type { Step } from "../../../../types/action";
+import type { StepCardBodyBaseProps } from "./types";
+
+export type ComponentCallStepCardBodyProps = StepCardBodyBaseProps;
+
+export function ComponentCallStepCardBody({
+  step,
+  onChange,
+  onCommit,
+}: ComponentCallStepCardBodyProps) {
+  return (
+    <>
+      <div className="row g-2 mb-2">
+        <div className="col-12">
+          <label className="form-label">
+            <i className="bi bi-puzzle me-1" />
+            コンポーネント参照 (componentRef)
+          </label>
+          <input
+            type="text"
+            className="form-control form-control-sm"
+            value={step.componentRef ?? ""}
+            onChange={(e) => onChange({ componentRef: e.target.value } as Partial<Step>)}
+            onBlur={onCommit}
+            placeholder="例: generic-definitions/component-definition/OrderValidator"
+            style={{ fontFamily: "monospace", fontSize: "0.85rem" }}
+          />
+        </div>
+      </div>
+      <div className="row g-2 mb-2">
+        <div className="col-12">
+          <label className="form-label">
+            <i className="bi bi-play me-1" />
+            operation
+          </label>
+          <input
+            type="text"
+            className="form-control form-control-sm"
+            value={step.operation ?? ""}
+            onChange={(e) => onChange({ operation: e.target.value } as Partial<Step>)}
+            onBlur={onCommit}
+            placeholder="例: validate"
+          />
+        </div>
+      </div>
+      <div className="form-group">
+        <label className="form-label small">
+          <i className="bi bi-arrow-left-right me-1" />
+          引数マッピング (argumentMapping、key=value、改行区切り)
+        </label>
+        <textarea
+          className="form-control form-control-sm"
+          rows={2}
+          value={Object.entries(step.argumentMapping ?? {}).map(([k, v]) => `${k}=${v}`).join("\n")}
+          onChange={(e) => {
+            const lines = e.target.value.split("\n").map((l) => l.trim()).filter(Boolean);
+            const map: Record<string, string> = {};
+            for (const line of lines) {
+              const eq = line.indexOf("=");
+              if (eq > 0) {
+                map[line.slice(0, eq).trim()] = line.slice(eq + 1).trim();
+              }
+            }
+            onChange({
+              argumentMapping: Object.keys(map).length > 0 ? map : undefined,
+            } as Partial<Step>);
+          }}
+          onBlur={onCommit}
+          placeholder={"order=@input.order\nstrict=true"}
+          style={{ fontFamily: "monospace", fontSize: "0.8rem" }}
+        />
+      </div>
+      <div className="form-group">
+        <label className="form-label small">
+          <i className="bi bi-arrow-return-right me-1" />
+          戻り値マッピング (returnMapping、key=value、改行区切り)
+        </label>
+        <textarea
+          className="form-control form-control-sm"
+          rows={2}
+          value={Object.entries(step.returnMapping ?? {}).map(([k, v]) => `${k}=${v}`).join("\n")}
+          onChange={(e) => {
+            const lines = e.target.value.split("\n").map((l) => l.trim()).filter(Boolean);
+            const map: Record<string, string> = {};
+            for (const line of lines) {
+              const eq = line.indexOf("=");
+              if (eq > 0) {
+                map[line.slice(0, eq).trim()] = line.slice(eq + 1).trim();
+              }
+            }
+            onChange({
+              returnMapping: Object.keys(map).length > 0 ? map : undefined,
+            } as Partial<Step>);
+          }}
+          onBlur={onCommit}
+          placeholder={"isValid=successFlag\nerrors=validationErrors"}
+          style={{ fontFamily: "monospace", fontSize: "0.8rem" }}
+        />
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/process-flow/internal/step-cards/index.ts
+++ b/frontend/src/components/process-flow/internal/step-cards/index.ts
@@ -16,3 +16,7 @@ export { AuditStepCardBody } from "./AuditStepCardBody";
 export { TransactionScopeStepCardBody } from "./TransactionScopeStepCardBody";
 export { JumpStepCardBody } from "./JumpStepCardBody";
 export { WorkflowStepCardBody } from "./WorkflowStepCardBody";
+// Phase-3 (#1145、#1163 review Phase-2 補足): 元 StepCard.tsx で dispatch 未実装だった 3 kind を追加。
+export { ComponentCallStepCardBody } from "./ComponentCallStepCardBody";
+export { AiCallStepCardBody } from "./AiCallStepCardBody";
+export { AiAgentStepCardBody } from "./AiAgentStepCardBody";

--- a/frontend/src/components/process-flow/internal/step-cards/step-cards.test.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/step-cards.test.tsx
@@ -8,9 +8,12 @@
 import { describe, expect, it, vi } from "vitest";
 import { render, fireEvent } from "@testing-library/react";
 import {
+  AiAgentStepCardBody,
+  AiCallStepCardBody,
   AuditStepCardBody,
   BranchStepCardBody,
   CommonProcessStepCardBody,
+  ComponentCallStepCardBody,
   ComputeStepCardBody,
   DbAccessStepCardBody,
   DisplayUpdateStepCardBody,
@@ -423,5 +426,102 @@ describe("WorkflowStepCardBody", () => {
       />,
     );
     expect(container.firstChild).not.toBeNull();
+  });
+});
+
+// ── ComponentCallStepCardBody (Phase-3 #1145、#1163 review Phase-2 補足) ──
+describe("ComponentCallStepCardBody", () => {
+  it("componentRef / operation input が描画される", () => {
+    const step = baseStep({
+      kind: "componentCall",
+      componentRef: "generic-definitions/component-definition/OrderValidator",
+      operation: "validate",
+    });
+    const { container } = render(
+      <ComponentCallStepCardBody step={step} allSteps={[]} onChange={noop} />,
+    );
+    expect(container.textContent).toContain("componentRef");
+    expect(container.textContent).toContain("operation");
+    const inputs = container.querySelectorAll("input");
+    expect(inputs[0].value).toBe("generic-definitions/component-definition/OrderValidator");
+    expect(inputs[1].value).toBe("validate");
+  });
+
+  it("componentRef 変更で onChange が呼ばれる", () => {
+    const onChange = vi.fn();
+    const step = baseStep({ kind: "componentCall", componentRef: "", operation: "" });
+    const { container } = render(
+      <ComponentCallStepCardBody step={step} allSteps={[]} onChange={onChange} />,
+    );
+    const input = container.querySelector("input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "newRef" } });
+    expect(onChange).toHaveBeenCalledWith({ componentRef: "newRef" });
+  });
+});
+
+// ── AiCallStepCardBody (Phase-3 #1145、#1163 review Phase-2 補足) ────────
+describe("AiCallStepCardBody", () => {
+  it("modelRef input と messages textarea が描画される", () => {
+    const step = baseStep({
+      kind: "aiCall",
+      modelRef: "summarizeModel",
+      messages: [{ role: "system", content: "you are helpful" }],
+    });
+    const { container } = render(
+      <AiCallStepCardBody step={step} allSteps={[]} onChange={noop} />,
+    );
+    expect(container.textContent).toContain("modelRef");
+    expect(container.textContent).toContain("messages");
+    const input = container.querySelector("input") as HTMLInputElement;
+    expect(input.value).toBe("summarizeModel");
+  });
+
+  it("modelRef 変更で onChange が呼ばれる", () => {
+    const onChange = vi.fn();
+    const step = baseStep({ kind: "aiCall", modelRef: "", messages: [] });
+    const { container } = render(
+      <AiCallStepCardBody step={step} allSteps={[]} onChange={onChange} />,
+    );
+    const input = container.querySelector("input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "claude-opus" } });
+    expect(onChange).toHaveBeenCalledWith({ modelRef: "claude-opus" });
+  });
+});
+
+// ── AiAgentStepCardBody (Phase-3 #1145、#1163 review Phase-2 補足) ───────
+describe("AiAgentStepCardBody", () => {
+  it("modelRef / maxIterations / tools が描画される", () => {
+    const step = baseStep({
+      kind: "aiAgent",
+      modelRef: "agentModel",
+      messages: [],
+      tools: [{ functionRef: "catalogs.functions.search" }],
+      maxIterations: 5,
+    });
+    const { container } = render(
+      <AiAgentStepCardBody step={step} allSteps={[]} onChange={noop} />,
+    );
+    expect(container.textContent).toContain("modelRef");
+    expect(container.textContent).toContain("maxIterations");
+    expect(container.textContent).toContain("tools");
+    const numberInput = container.querySelector('input[type="number"]') as HTMLInputElement;
+    expect(numberInput.value).toBe("5");
+  });
+
+  it("maxIterations 変更で onChange が呼ばれる", () => {
+    const onChange = vi.fn();
+    const step = baseStep({
+      kind: "aiAgent",
+      modelRef: "x",
+      messages: [],
+      tools: [],
+      maxIterations: 10,
+    });
+    const { container } = render(
+      <AiAgentStepCardBody step={step} allSteps={[]} onChange={onChange} />,
+    );
+    const numberInput = container.querySelector('input[type="number"]') as HTMLInputElement;
+    fireEvent.change(numberInput, { target: { value: "7" } });
+    expect(onChange).toHaveBeenCalledWith({ maxIterations: 7 });
   });
 });

--- a/frontend/src/components/process-flow/internal/stepCardConstants.test.ts
+++ b/frontend/src/components/process-flow/internal/stepCardConstants.test.ts
@@ -1,14 +1,32 @@
 import { describe, expect, it } from "vitest";
 import {
+  ALL_STEP_TYPES,
   ALL_SUB_STEP_TYPES,
   DB_OPS,
   trimToUndefined,
 } from "./stepCardConstants";
 
 /**
- * StepCard.tsx から抽出した定数とヘルパー (#1145) の回帰防止テスト。
+ * StepCard.tsx / ProcessFlowEditor.tsx から抽出した定数とヘルパー (#1145) の
+ * 回帰防止テスト。
  */
 describe("stepCardConstants", () => {
+  describe("ALL_STEP_TYPES (Phase-3 #1145 で追加)", () => {
+    it("22 種類の step kind を持つ (パレット側 toolbar 用)", () => {
+      expect(ALL_STEP_TYPES).toHaveLength(22);
+    });
+
+    it("代表的な kind を含む", () => {
+      expect(ALL_STEP_TYPES).toContain("validation");
+      expect(ALL_STEP_TYPES).toContain("workflow");
+      expect(ALL_STEP_TYPES).toContain("transactionScope");
+    });
+
+    it("重複が無い", () => {
+      expect(new Set(ALL_STEP_TYPES).size).toBe(ALL_STEP_TYPES.length);
+    });
+  });
+
   describe("ALL_SUB_STEP_TYPES", () => {
     it("22 種類の step kind を持つ (現行 spec)", () => {
       expect(ALL_SUB_STEP_TYPES).toHaveLength(22);

--- a/frontend/src/components/process-flow/internal/stepCardConstants.ts
+++ b/frontend/src/components/process-flow/internal/stepCardConstants.ts
@@ -1,6 +1,37 @@
 import type { DbOperation, StepType } from "../../../types/action";
 
 /**
+ * ProcessFlowEditor のパレット (toolbar) に表示する全 step kind。
+ * 元: components/process-flow/ProcessFlowEditor.tsx (#1145 Phase-3 で分離)。
+ * v3 schema には `componentCall` / `aiCall` / `aiAgent` も含まれるが、現状
+ * パレット D&D は別 ISSUE で対応予定 (StepCard 側 dispatch は Phase-3 で追加済)。
+ */
+export const ALL_STEP_TYPES: StepType[] = [
+  "validation",
+  "dbAccess",
+  "externalSystem",
+  "commonProcess",
+  "screenTransition",
+  "displayUpdate",
+  "branch",
+  "loop",
+  "loopBreak",
+  "loopContinue",
+  "jump",
+  "compute",
+  "return",
+  "other",
+  "log",
+  "audit",
+  "workflow",
+  "transactionScope",
+  "eventPublish",
+  "eventSubscribe",
+  "closing",
+  "cdc",
+];
+
+/**
  * StepCard のサブステップ追加メニューに表示する全 step kind。
  * 元: components/process-flow/StepCard.tsx (#1145 で分離)
  */

--- a/frontend/src/components/process-flow/internal/useActionHelpPopover.ts
+++ b/frontend/src/components/process-flow/internal/useActionHelpPopover.ts
@@ -1,0 +1,105 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+// Phase-3 (#1145): ProcessFlowEditor.tsx から ActionHelpPopover の位置計算 +
+// open/close debounce 制御を切り出したフック。
+
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+
+export interface ActionHelpState {
+  actionId: string;
+  left: number;
+  top: number;
+  placement: "below" | "above";
+  anchorTop: number;
+  anchorBottom: number;
+}
+
+export interface UseActionHelpPopover {
+  actionHelp: ActionHelpState | null;
+  openActionHelp: (actionId: string, anchor: HTMLElement) => void;
+  scheduleCloseActionHelp: () => void;
+  clearActionHelpCloseTimer: () => void;
+}
+
+const POPOVER_WIDTH_MIN = 280;
+const POPOVER_WIDTH_MAX = 420;
+const POPOVER_ESTIMATED_HEIGHT = 430;
+const CLOSE_DELAY_MS = 120;
+
+export function useActionHelpPopover(): UseActionHelpPopover {
+  const [actionHelp, setActionHelp] = useState<ActionHelpState | null>(null);
+  const closeTimerRef = useRef<number | null>(null);
+
+  const clearActionHelpCloseTimer = useCallback(() => {
+    if (closeTimerRef.current !== null) {
+      window.clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+  }, []);
+
+  const openActionHelp = useCallback(
+    (actionId: string, anchor: HTMLElement) => {
+      clearActionHelpCloseTimer();
+      const rect = anchor.getBoundingClientRect();
+      const popoverWidth = Math.min(POPOVER_WIDTH_MAX, Math.max(POPOVER_WIDTH_MIN, window.innerWidth - 24));
+      const left = Math.min(
+        Math.max(12, rect.left + rect.width / 2 - popoverWidth / 2),
+        window.innerWidth - popoverWidth - 12,
+      );
+      const belowTop = rect.bottom + 10;
+      const canOpenBelow = belowTop + POPOVER_ESTIMATED_HEIGHT <= window.innerHeight - 12;
+      setActionHelp({
+        actionId,
+        left,
+        top: canOpenBelow ? belowTop : Math.max(12, rect.top - POPOVER_ESTIMATED_HEIGHT - 10),
+        placement: canOpenBelow ? "below" : "above",
+        anchorTop: rect.top,
+        anchorBottom: rect.bottom,
+      });
+    },
+    [clearActionHelpCloseTimer],
+  );
+
+  const scheduleCloseActionHelp = useCallback(() => {
+    clearActionHelpCloseTimer();
+    closeTimerRef.current = window.setTimeout(() => {
+      setActionHelp(null);
+      closeTimerRef.current = null;
+    }, CLOSE_DELAY_MS);
+  }, [clearActionHelpCloseTimer]);
+
+  // window resize で popover を閉じる
+  useEffect(() => {
+    if (!actionHelp) return undefined;
+    const close = () => setActionHelp(null);
+    window.addEventListener("resize", close);
+    return () => {
+      window.removeEventListener("resize", close);
+    };
+  }, [actionHelp]);
+
+  // 実際の DOM 高さに基づいて placement を補正
+  useLayoutEffect(() => {
+    if (!actionHelp) return;
+    const popover = document.getElementById(`action-help-${actionHelp.actionId}`);
+    if (!popover) return;
+    const actualHeight = Math.min(popover.getBoundingClientRect().height, window.innerHeight - 24);
+    const belowTop = actionHelp.anchorBottom + 10;
+    const canOpenBelow = belowTop + actualHeight <= window.innerHeight - 12;
+    const nextTop = canOpenBelow
+      ? belowTop
+      : Math.max(12, actionHelp.anchorTop - actualHeight - 10);
+    const nextPlacement: "below" | "above" = canOpenBelow ? "below" : "above";
+    if (Math.abs(nextTop - actionHelp.top) > 1 || nextPlacement !== actionHelp.placement) {
+      setActionHelp((cur) =>
+        cur && cur.actionId === actionHelp.actionId
+          ? { ...cur, top: nextTop, placement: nextPlacement }
+          : cur,
+      );
+    }
+  }, [actionHelp]);
+
+  // unmount cleanup
+  useEffect(() => () => clearActionHelpCloseTimer(), [clearActionHelpCloseTimer]);
+
+  return { actionHelp, openActionHelp, scheduleCloseActionHelp, clearActionHelpCloseTimer };
+}

--- a/frontend/src/components/process-flow/internal/useProcessFlowCatalogs.ts
+++ b/frontend/src/components/process-flow/internal/useProcessFlowCatalogs.ts
@@ -1,0 +1,118 @@
+// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
+// Phase-3 (#1145): ProcessFlowEditor.tsx の各種カタログ (tables / screens / commonGroups /
+// conventions / extensions / genericDefNames / projectCatalogs) ロード処理を集約したフック。
+// handleLoaded から呼び出される一括 fetch を含む。
+//
+// 役割:
+// - ProcessFlow ロード時にプロジェクト全体のカタログを一度に取得 (load 関数を返す)
+// - mcpBridge.onExtensionsChanged 監視で extensions を auto-refresh
+
+import { useEffect, useState } from "react";
+import type { ProcessFlow } from "../../../types/action";
+import { listTables, loadTable } from "../../../store/tableStore";
+import { loadProject } from "../../../store/flowStore";
+import type { TableDefinition as ValidatorTableDef } from "../../../schemas/sqlColumnValidator";
+import type { ConventionsCatalog } from "../../../schemas/conventionsValidator";
+import type { GenericDefinitionNames } from "../../../schemas/referentialIntegrity";
+import type { ProjectCatalogs } from "../../../schemas/projectCatalogs";
+import { loadExtensionsFromBundle, type LoadedExtensions } from "../../../schemas/loadExtensions";
+import { loadConventions } from "../../../store/conventionsStore";
+import { listGenericDefinitions } from "../../../store/genericDefinitionStore";
+import { mcpBridge } from "../../../mcp/mcpBridge";
+
+export interface ProcessFlowCatalogs {
+  tables: { id: string; physicalName: string; name: string }[];
+  screens: { id: string; name: string }[];
+  commonGroups: { id: string; name: string }[];
+  tableDefs: ValidatorTableDef[];
+  conventions: ConventionsCatalog | null;
+  extensions: LoadedExtensions | undefined;
+  genericDefNames: GenericDefinitionNames;
+  projectCatalogs: ProjectCatalogs | null;
+  /** loadProcessFlow の onLoaded コールバックから呼んで全カタログを一括ロードする */
+  loadAll: (g: ProcessFlow) => void;
+}
+
+export function useProcessFlowCatalogs(): ProcessFlowCatalogs {
+  const [tables, setTables] = useState<{ id: string; physicalName: string; name: string }[]>([]);
+  const [screens, setScreens] = useState<{ id: string; name: string }[]>([]);
+  const [commonGroups, setCommonGroups] = useState<{ id: string; name: string }[]>([]);
+  const [tableDefs, setTableDefs] = useState<ValidatorTableDef[]>([]);
+  const [conventions, setConventions] = useState<ConventionsCatalog | null>(null);
+  const [extensions, setExtensions] = useState<LoadedExtensions | undefined>(undefined);
+  const [genericDefNames, setGenericDefNames] = useState<GenericDefinitionNames>({});
+  const [projectCatalogs, setProjectCatalogs] = useState<ProjectCatalogs | null>(null);
+
+  const loadAll = (_g: ProcessFlow) => {
+    loadProject()
+      .then((p) => {
+        setScreens(p.screens.map((s) => ({ id: s.id, name: s.name })));
+        const agMetas = p.processFlows ?? [];
+        setCommonGroups(
+          agMetas.filter((a) => a.kind === "common").map((a) => ({ id: a.id, name: a.name })),
+        );
+      })
+      .catch(console.error);
+    listTables()
+      .then(async (metas) => {
+        setTables(
+          metas.map((tm) => ({ id: tm.id, physicalName: tm.physicalName ?? "", name: tm.name })),
+        );
+        const defs = await Promise.all(
+          metas.map(async (tm) => {
+            const full = await loadTable(tm.id);
+            if (!full) return null;
+            return {
+              id: full.id,
+              name: full.physicalName,
+              columns: (full.columns ?? []).map((c) => ({ name: c.physicalName })),
+            } as ValidatorTableDef;
+          }),
+        );
+        setTableDefs(defs.filter((d): d is ValidatorTableDef => d !== null));
+      })
+      .catch(console.error);
+    loadConventions()
+      .then((c) => setConventions(c as ConventionsCatalog | null))
+      .catch(() => setConventions(null));
+    mcpBridge
+      .request("loadProjectCatalogs")
+      .then((c) => setProjectCatalogs(c as ProjectCatalogs | null))
+      .catch(() => setProjectCatalogs(null));
+    mcpBridge
+      .getExtensions()
+      .then((bundle) => setExtensions(loadExtensionsFromBundle(bundle).extensions))
+      .catch(() => setExtensions(undefined));
+    Promise.all([
+      listGenericDefinitions("component-definition").catch(() => []),
+      listGenericDefinitions("exception-type").catch(() => []),
+    ]).then(([components, exceptions]) => {
+      setGenericDefNames({
+        "component-definition": new Set(components.map((c) => c.name)),
+        "exception-type": new Set(exceptions.map((e) => e.name)),
+      });
+    });
+  };
+
+  // Extensions の auto-refresh
+  useEffect(() => {
+    return mcpBridge.onExtensionsChanged(() => {
+      mcpBridge
+        .getExtensions(true)
+        .then((bundle) => setExtensions(loadExtensionsFromBundle(bundle).extensions))
+        .catch(() => setExtensions(undefined));
+    });
+  }, []);
+
+  return {
+    tables,
+    screens,
+    commonGroups,
+    tableDefs,
+    conventions,
+    extensions,
+    genericDefNames,
+    projectCatalogs,
+    loadAll,
+  };
+}

--- a/frontend/src/components/process-flow/processFlowMutation.test.ts
+++ b/frontend/src/components/process-flow/processFlowMutation.test.ts
@@ -7,7 +7,7 @@
 // - update / remove / move 各 mutation が UUID 形式の stepId を引けること
 // - description / detail を step に merge できること
 
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { applyProcessFlowMutation } from "./processFlowMutation";
 import { setProcessFlowStorageBackend } from "../../store/processFlowStore";
 import type { ProcessFlow, ActionDefinition } from "../../types/action";
@@ -192,6 +192,70 @@ describe("applyProcessFlowMutation (browser-first v3, #1149)", () => {
       applyProcessFlowMutation(g, "designer__unknown_mutation", { actionId: act.id });
 
       expect(g.actions[0].steps).toHaveLength(0);
+    });
+  });
+
+  // ── #1145 Phase-3 N-3: mismatch 時 console.warn で痕跡を残す ─────────
+  describe("N-3: silent no-op → console.warn 化", () => {
+    it("actionId 不一致時に console.warn が呼ばれる", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const act = makeAction("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
+        const g = makeProcessFlow([act]);
+        applyProcessFlowMutation(g, "designer__add_step", {
+          actionId: "ffffffff-ffff-4fff-8fff-ffffffffffff",
+          kind: "log",
+        });
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy.mock.calls[0][0]).toContain("actionId not found");
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("kind 欠落時に console.warn が呼ばれる", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const act = makeAction("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
+        const g = makeProcessFlow([act]);
+        applyProcessFlowMutation(g, "designer__add_step", {
+          actionId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          type: "log", // 旧 field、v3 では拒否
+        });
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy.mock.calls[0][0]).toContain("kind is missing");
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("stepId 不一致 (update) で console.warn が呼ばれる", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const act = makeAction("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
+        const g = makeProcessFlow([act]);
+        applyProcessFlowMutation(g, "designer__update_step", {
+          stepId: "ffffffff-ffff-4fff-8fff-ffffffffffff",
+          patch: { description: "新" },
+        });
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy.mock.calls[0][0]).toContain("stepId not found");
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("未知の mutation type で console.warn が呼ばれる", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const act = makeAction("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
+        const g = makeProcessFlow([act]);
+        applyProcessFlowMutation(g, "designer__unknown_mutation", { actionId: act.id });
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy.mock.calls[0][0]).toContain("unknown mutation type");
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
   });
 });

--- a/frontend/src/components/process-flow/processFlowMutation.ts
+++ b/frontend/src/components/process-flow/processFlowMutation.ts
@@ -21,6 +21,16 @@
 import type { ProcessFlow, StepType } from "../../types/action";
 import { addStep, removeStep, moveStep } from "../../store/processFlowStore";
 
+// #1145 Phase-3 N-3: mismatch / silent no-op を診断 log 化。
+// 古い client / 誤った params 経由で来た mutation は production でも
+// console.warn で痕跡を残し、開発者が後追いできるようにする。
+// `import.meta.env.DEV` ガードは敢えて掛けない (#1162 review N-3:
+// production browser console の warn は無害かつ trace 価値が高い)。
+function warnNoOp(type: string, reason: string, p: Record<string, unknown>): void {
+  // 診断 log として明示的に出す (#1145 N-3)
+  console.warn(`[applyProcessFlowMutation] ${type}: ${reason}`, p);
+}
+
 export function applyProcessFlowMutation(
   g: ProcessFlow,
   type: string,
@@ -29,11 +39,17 @@ export function applyProcessFlowMutation(
   switch (type) {
     case "designer__add_step": {
       const act = g.actions.find((a: { id: string }) => a.id === p.actionId);
-      if (!act) return;
+      if (!act) {
+        warnNoOp(type, `actionId not found: ${String(p.actionId)}`, p);
+        return;
+      }
       const pos = typeof p.position === "number" ? p.position : undefined;
       // v3: backend は `kind` を送る (旧 `type` は #1148 で全廃)。
       const kind = p.kind as StepType | undefined;
-      if (!kind) return;
+      if (!kind) {
+        warnNoOp(type, "kind is missing (v3 requires `kind` discriminator)", p);
+        return;
+      }
       const step = addStep(act, kind, pos);
       if (p.description) step.description = p.description as string;
       Object.assign(step, (p.detail ?? {}) as object);
@@ -44,6 +60,7 @@ export function applyProcessFlowMutation(
         const step = act.steps.find((s: { id: string }) => s.id === p.stepId);
         if (step) { Object.assign(step, p.patch); return; }
       }
+      warnNoOp(type, `stepId not found: ${String(p.stepId)}`, p);
       break;
     }
     case "designer__remove_step": {
@@ -51,6 +68,7 @@ export function applyProcessFlowMutation(
         const idx = act.steps.findIndex((s: { id: string }) => s.id === p.stepId);
         if (idx >= 0) { removeStep(act, p.stepId as string); return; }
       }
+      warnNoOp(type, `stepId not found: ${String(p.stepId)}`, p);
       break;
     }
     case "designer__move_step": {
@@ -59,6 +77,11 @@ export function applyProcessFlowMutation(
         const fromIdx = act.steps.findIndex((s: { id: string }) => s.id === p.stepId);
         if (fromIdx >= 0) { moveStep(act, fromIdx, newIndex); return; }
       }
+      warnNoOp(type, `stepId not found: ${String(p.stepId)}`, p);
+      break;
+    }
+    default: {
+      warnNoOp(type, "unknown mutation type", p);
       break;
     }
   }

--- a/frontend/src/store/processFlowStore.ts
+++ b/frontend/src/store/processFlowStore.ts
@@ -124,8 +124,10 @@ export function removeAction(group: ProcessFlow, actionId: string): void {
   if (idx >= 0) group.actions.splice(idx, 1);
 }
 
-export function addStep(action: ActionDefinition, type: StepType, insertIndex?: number): Step {
-  const step = createDefaultStep(type);
+// #1145 Phase-3 N-4: 引数名を v3 統一規範 (`kind` discriminator) に合わせて
+// legacy `type` から `kind` にリネーム。createDefaultStep / addSubStep も同様。
+export function addStep(action: ActionDefinition, kind: StepType, insertIndex?: number): Step {
+  const step = createDefaultStep(kind);
   if (insertIndex !== undefined && insertIndex >= 0 && insertIndex <= action.steps.length) {
     action.steps.splice(insertIndex, 0, step);
   } else {
@@ -146,8 +148,8 @@ export function moveStep(action: ActionDefinition, fromIndex: number, toIndex: n
   action.steps.splice(toIndex, 0, step);
 }
 
-export function addSubStep(parentStep: Step, type: StepType): Step {
-  const step = createDefaultStep(type);
+export function addSubStep(parentStep: Step, kind: StepType): Step {
+  const step = createDefaultStep(kind);
   const parent = parentStep as Step & { steps?: Step[] };
   if (!Array.isArray(parent.steps)) parent.steps = [];
   parent.steps.push(step);
@@ -161,10 +163,10 @@ export function removeSubStep(parentStep: Step, subStepId: string): void {
   if (idx >= 0) parent.steps.splice(idx, 1);
 }
 
-export function createDefaultStep(type: StepType): Step {
-  const base = { id: generateUUID() as never, kind: type, description: "" };
+export function createDefaultStep(kind: StepType): Step {
+  const base = { id: generateUUID() as never, kind, description: "" };
   let step: Step;
-  switch (type) {
+  switch (kind) {
     case "validation":
       step = { ...base, kind: "validation", conditions: "", inlineBranch: { ok: [], ng: [] } }; break;
     case "dbAccess":


### PR DESCRIPTION
## 関連

- Refs #1145 (Phase-3、最終 Phase ではない。残: Phase-4 ViewDefinitionEditor / Phase-5 Conventions / Phase-6 ScreenItems / Phase-7 AppShell routing)
- Refs #1162 (N-3 / N-4 由来の Phase-3 追加考慮事項)
- Refs #1163 (Phase-2 完了補足の componentCall / aiCall / aiAgent dispatch)

## 概要

`ProcessFlowEditor.tsx` (94KB / 2138 行) を機能領域別に 14 ファイル (component 12 + hook 2) に分割し、純粋な責務分離で **44KB / 1083 行 (-53%、-50KB)** に削減。併せて、Phase-3 着手時に統合対応するよう指示された 3 件 (N-3 / N-4 / Phase-2 補足の AI step dispatch) を本 PR で完遂。

目標 30KB には未達 (-14KB 不足、後段の Phase で追加抽出余地あり)。理由: state 統合 / edit-session 連携 / D&D handler 群 (`useEditSession` + `useResourceEditor` + 各種 handler) は親 component 状態を多数参照しており、これ以上の機械的抽出はトレードオフ大 (props inflation で読みづらくなる)。

## 主な変更

### ProcessFlowEditor.tsx 分割 (12 component 新設、責務別)

- `internal/PaletteButtons.tsx` — ToolbarStepButton / StepInsertZone / EmptyFlowDropZone / CustomStepButton
- `internal/actionTriggerConstants.ts` — trigger 定数 (ICONS / CATEGORIES / RICH_HELP) + 5 ヘルパー関数 (countActionFields / summarizeActionFields / summarizeActionStepTypes / getActionOpenMarkers / summarizeActionMarkers)
- `internal/ActionHelpPopover.tsx` — アクションタブ hover 時の rich popover
- `internal/AddActionModal.tsx` — アクション追加モーダル
- `internal/StepContextMenu.tsx` — ステップ右クリックコンテキストメニュー (subType picker mode 込み)
- `internal/WarningsPanel.tsx` — 警告詳細パネル (#261 UI 統合)
- `internal/ActionTabBar.tsx` — コマンドバー全体 (検索 + アクションタブ + popover + EditLevelToggle)
- `internal/PalettePanel.tsx` — 左サイドバー (ブロックパレット + カスタム + テンプレート)
- `internal/CanvasPane.tsx` — 中央キャンバス (ステップリスト + D&D 挿入ゾーン + marker 集計)
- `internal/InspectorPanel.tsx` — 右サイドバー (AI 依頼 / ActionMetaTabBar / HTTP / SLA / I/O StructuredFieldsEditor)
- `internal/EditorHeaderExtras.tsx` — EditorHeader 右側ボタン群 (AI 生成 / レビュー / EditSession / 描画 / 検証バッジ)
- `internal/ProcessFlowDialogs.tsx` — 各種 confirm / save-conflict / AI 生成 / AI レビュー / AI 差分プレビュー dialog 一括 wrapper

### hook 抽出 (2 hook 新設)

- `internal/useProcessFlowCatalogs.ts` — `tables / screens / commonGroups / tableDefs / conventions / extensions / genericDefNames / projectCatalogs` のロード集約 (5 mcpBridge コール + onExtensionsChanged watcher)
- `internal/useActionHelpPopover.ts` — ActionHelpPopover の位置計算 + open/close debounce

### stepCardConstants.ts 拡張

- `ALL_STEP_TYPES` を追加 (パレット側 toolbar 用、ProcessFlowEditor から引っ越し)
- 既存 `ALL_SUB_STEP_TYPES` と並存 (StepCard のサブステップ追加メニュー用、現状は内容同一だが将来 divergence を許容)

### N-3 (#1162 review): applyProcessFlowMutation の silent no-op を error log 化

`processFlowMutation.ts` の mismatch 時 silently no-op を全 case で `console.warn` 化:
- actionId not found / kind missing / stepId not found (update/remove/move 各) / unknown mutation type
- production browser console でも痕跡を残し、古い client / 誤った params の検出を容易化
- `import.meta.env.DEV` ガードは敢えて掛けない (warn は無害かつ trace 価値が高い)
- 4 件のテストを `processFlowMutation.test.ts` に追加 (`vi.spyOn(console, 'warn')`)

### N-4 (#1162 review): addStep / addSubStep / createDefaultStep の引数名 `type` → `kind` rename

`processFlowStore.ts` の `addStep(action, type, ...)` → `addStep(action, kind, ...)`。`createDefaultStep` / `addSubStep` も同様。ProcessFlowEditor 内のローカル handler 引数名 (`handleAddStep` / `handleAddSubStep`) も一貫して `kind` に統一。

callsite は store import 経由が **2 件のみ** (ProcessFlowEditor:435 + processFlowMutation:37) で、他は各 component 内の local function (panel 内コールバック) のため非対象。v3 統一規範 (#8 discriminator は kind) が adapter/wire 層で完成。

### Phase-2 補足 (#1163 review): componentCall / aiCall / aiAgent dispatch 追加

元 StepCard.tsx で **dispatch 未実装** だった 3 kind を追加 (Phase-2 と同じ sub-component pattern):

- `internal/step-cards/ComponentCallStepCardBody.tsx` (#1066 schema 追加時の取り残し)
- `internal/step-cards/AiCallStepCardBody.tsx` (#935/#936 AI step kind 追加時の取り残し)
- `internal/step-cards/AiAgentStepCardBody.tsx` (同上)

StepCard.tsx に 3 dispatch + import 追加、`index.ts` barrel に export 追加、`step-cards.test.tsx` に 6 rendering test を追加 (componentRef / modelRef / maxIterations の input + state 検証)。

## 仕様逐条突合 (自己申告)

### 分割対象別 file:line

- ToolbarStepButton 抽出 → `internal/PaletteButtons.tsx:17-41` (元 ProcessFlowEditor.tsx:95-116)
- StepInsertZone 抽出 → `internal/PaletteButtons.tsx:43-79` (元 119-153)
- EmptyFlowDropZone 抽出 → `internal/PaletteButtons.tsx:81-102` (元 155-166)
- CustomStepButton 抽出 → `internal/PaletteButtons.tsx:104-126` (元 426-440)
- ALL_STEP_TYPES 移設 → `internal/stepCardConstants.ts:8-31` (元 168-174)
- ALL_TRIGGERS / ACTION_TRIGGER_ICONS / CATEGORIES / RICH_HELP / get* ヘルパー 5 種 / countActionFields / summarizeActionFields / summarizeActionStepTypes / getActionOpenMarkers / summarizeActionMarkers 抽出 → `internal/actionTriggerConstants.ts:7-200` (元 184-343)
- ActionHelpPopover 抽出 → `internal/ActionHelpPopover.tsx:21-92` (元 345-424)
- AddActionModal 抽出 → `internal/AddActionModal.tsx:18-64` (元 2042-2077 旧)
- StepContextMenu 抽出 → `internal/StepContextMenu.tsx:33-120` (元 1931-2038 旧)
- WarningsPanel 抽出 → `internal/WarningsPanel.tsx:17-119` (元 1424-1512 旧)
- ActionTabBar 抽出 → `internal/ActionTabBar.tsx:34-144` (元 988-1079 旧)
- PalettePanel 抽出 → `internal/PalettePanel.tsx:22-101` (元 1089-1155 旧)
- CanvasPane 抽出 → `internal/CanvasPane.tsx:57-244` (元 1037-1171 旧)
- InspectorPanel 抽出 → `internal/InspectorPanel.tsx:38-167` (元 1173-1278 旧)
- EditorHeaderExtras 抽出 → `internal/EditorHeaderExtras.tsx:30-114` (元 908-977 旧)
- ProcessFlowDialogs 抽出 → `internal/ProcessFlowDialogs.tsx:59-152` (元 802-875 + 1082-1118 旧)
- useProcessFlowCatalogs 抽出 → `internal/useProcessFlowCatalogs.ts:33-118` (元 142-148, 179-225, 408-415 旧)
- useActionHelpPopover 抽出 → `internal/useActionHelpPopover.ts:25-103` (元 133-141, 463-526 旧)
- ProcessFlowEditor.tsx 参照側差し替え:
  - PalettePanel 利用 → `ProcessFlowEditor.tsx:983-993`
  - ActionTabBar 利用 → `ProcessFlowEditor.tsx:964-981`
  - CanvasPane 利用 → `ProcessFlowEditor.tsx:995-1027`
  - InspectorPanel 利用 → `ProcessFlowEditor.tsx:1029-1046`
  - StepContextMenu 利用 → `ProcessFlowEditor.tsx:1051-1077`
  - AddActionModal 利用 → `ProcessFlowEditor.tsx:1080-1088`
  - WarningsPanel 利用 → `ProcessFlowEditor.tsx:949-955`
  - EditorHeaderExtras 利用 → `ProcessFlowEditor.tsx:872-887`
  - ProcessFlowDialogs 利用 → `ProcessFlowEditor.tsx:777-844`
  - useProcessFlowCatalogs / useActionHelpPopover 利用 → `ProcessFlowEditor.tsx:118-138`

### N-3 (silent no-op → console.warn 化)

- warnNoOp ヘルパー → `processFlowMutation.ts:8-11`
- designer__add_step (actionId / kind) → `processFlowMutation.ts:22-32`
- designer__update_step → `processFlowMutation.ts:42-49`
- designer__remove_step → `processFlowMutation.ts:50-58`
- designer__move_step → `processFlowMutation.ts:59-68`
- default (unknown type) → `processFlowMutation.ts:69-72`
- test 4 件 → `processFlowMutation.test.ts:198-256`

### N-4 (addStep 引数名 type → kind rename)

- store: `addStep(action, kind, insertIndex)` → `processFlowStore.ts:127-137`
- store: `addSubStep(parentStep, kind)` → `processFlowStore.ts:151-157`
- store: `createDefaultStep(kind)` → `processFlowStore.ts:166-223`
- ProcessFlowEditor 内 handleAddStep(kind) → `ProcessFlowEditor.tsx:435-444`
- ProcessFlowEditor 内 handleAddSubStep(parentStepId, kind) → `ProcessFlowEditor.tsx:555-563`
- callsite: ProcessFlowEditor → `ProcessFlowEditor.tsx:440` (positional argument のため変更不要)
- callsite: processFlowMutation → `processFlowMutation.ts:37` (positional argument のため変更不要)

### Phase-2 補足 (componentCall / aiCall / aiAgent dispatch)

- ComponentCallStepCardBody → `internal/step-cards/ComponentCallStepCardBody.tsx:10-104`
- AiCallStepCardBody → `internal/step-cards/AiCallStepCardBody.tsx:9-92`
- AiAgentStepCardBody → `internal/step-cards/AiAgentStepCardBody.tsx:10-105`
- StepCard.tsx dispatch:
  - componentCall → `StepCard.tsx:758-766`
  - aiCall → `StepCard.tsx:768-776`
  - aiAgent → `StepCard.tsx:778-786`
- StepCard.tsx import 追加 → `StepCard.tsx:26-43`
- index.ts barrel 追加 → `internal/step-cards/index.ts:23-26`
- test 6 件 → `internal/step-cards/step-cards.test.tsx:336-455`

## LOC + KB 比較

| 指標 | Phase-2 完了時 | Phase-3 完了時 | 削減 |
|---|---|---|---|
| ProcessFlowEditor.tsx LOC | 2138 | 1083 | -49% |
| ProcessFlowEditor.tsx KB | 94 | 44 | -53% |

(目標 30KB に対し -14KB 不足。理由: state 統合 / edit-session 連携 / D&D handler は親 component の多数 state に依存しており、これ以上の機械的抽出は props inflation で逆に読みづらくなる)

新規ファイル数: 17 (component 12 + hook 2 + step-card sub 3)
新規 test 数: +13 件 (step-cards +6, processFlowMutation +4, stepCardConstants +3)

## レビューで特に見てほしい箇所

- `internal/ProcessFlowDialogs.tsx` の callback 経由のクロージャ参照 (元 inline JSX を props 化、aiDiffProposed のクロージャ捕捉が崩れていないか)
- `useProcessFlowCatalogs.loadAll(g: ProcessFlow)` の引数受け取り: 現在 `_g` で未使用だが、将来 flow 内容に依存する catalog load (e.g., processFlowId 由来の per-flow scope) を視野に signature 維持
- `useActionHelpPopover` の `useLayoutEffect` 内 setState は元 ProcessFlowEditor の `useLayoutEffect` をそのまま移植 (新 lint warning 1 件は同パターン由来、振る舞い不変)
- N-3 の `warnNoOp` を全 case で呼んでいるが、case 内 `for of` ループ後の `warnNoOp` は found 時 `return` するので "not found" のみ警告 (loop 外で warn する形)
- componentCall / aiCall / aiAgent の sub-component は最小 (textarea で JSON 直編集) → 後続で structured editor に拡張可

## テスト

- Vitest: 全 2243 件 pass (+13 件、本 PR で追加)
  - step-cards rendering 6 件 (ComponentCall / AiCall / AiAgent × 2 each)
  - processFlowMutation N-3 console.warn 検証 4 件
  - stepCardConstants ALL_STEP_TYPES 3 件
- Playwright: 既存 e2e 改変なし、新規追加なし (純粋な責務分離のため smoke 不要と判断)
- MCP E2E: N/A

## UI 影響 / AI smoke test

- [x] UI 影響なし (auto テスト pass のみ、純粋な責務分離 + 機能改善 N-3 / N-4 / dispatch 追加)

純粋分離: 元 ProcessFlowEditor.tsx の JSX を別 component に移し、props 経由で同じ state / callback を渡しているのみ。N-3 は console.warn のみ、N-4 は引数名 rename のみ、componentCall / aiCall / aiAgent dispatch は元 StepCard.tsx 内で fall-through していた kind の最小 UI を追加 (元の状態は「dispatch されない = render されない」だったため regression なし、機能向上のみ)。

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

- 後続 Phase: Phase-4 (ViewDefinitionEditor.tsx 81KB)、Phase-5 (Conventions 72KB)、Phase-6 (ScreenItems 64KB)、Phase-7 (AppShell routing 51KB)
- ProcessFlowEditor.tsx の残り 44KB は state 統合 + DnD / edit-session / AI 連携の handler 群。step-editing handler 群を `useStepEditing` 等にさらに集約する余地はあるが、props inflation のトレードオフあり。後続 Phase での learnings を踏まえて再評価予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)