### PR TITLE
refactor(view-definition): ViewDefinitionEditor.tsx 分割 (#1145 Phase-4)

### DIFF
--- a/frontend/src/components/view-definition/ViewDefinitionEditor.tsx
+++ b/frontend/src/components/view-definition/ViewDefinitionEditor.tsx
@@ -11,6 +11,15 @@
  *  6. その他 (pageSize / groupBy)
  *
  * リアルタイム validator: checkViewDefinition() の結果を各フィールドの隣に inline 表示。
+ *
+ * #1145 Phase-4 (2026-05-18): 旧 1766 行 / 81KB を `internal/` 配下に責務分離。
+ * - DSL 3 level 別 sub-editor: Level1QueryEditor / Level2QueryEditor / Level3QueryEditor
+ * - 6 section: BasicInfoSection / (Query) / ColumnsSection / SortDefaultsSection / FilterDefaultsSection / MiscSection
+ * - 共通 hook: useTablesForValidator / useTableOptions (`internal/useViewDefinitionTables.ts`)
+ * - 共通 component: IssueHints
+ * - 共通 constants: viewDefinitionConstants (FIELD_TYPE_OPTIONS / FILTER_OPERATORS / KIND_LABELS / JOIN_KIND_OPTIONS / LEVEL_LABELS / isBuiltinKind)
+ *
+ * 本ファイルは編集セッション / draft 管理 / state orchestration + 6 section 配置に専念する。
  */
 
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
@@ -21,17 +30,11 @@ import type {
   ViewColumn,
   SortSpec,
   FilterSpec,
-  FilterOperator,
-  BuiltinViewDefinitionKind,
   ViewQueryStructured,
-  ViewQueryRawSql,
-  ViewQueryJoin,
-  ViewQueryParameterRef,
 } from "../../types/v3/view-definition";
-import type { Table, TableEntry, Maturity, Identifier, FieldType, FieldTypePrimitive } from "../../types/v3";
-import type { TableId, LocalId } from "../../types/v3/common";
+import type { FieldTypePrimitive } from "../../types/v3";
+import type { TableId, LocalId, Identifier } from "../../types/v3/common";
 import { loadViewDefinition, saveViewDefinition } from "../../store/viewDefinitionStore";
-import { listTables, loadTable, onTableChange } from "../../store/tableStore";
 import { mcpBridge } from "../../mcp/mcpBridge";
 import { useResourceEditor } from "../../hooks/useResourceEditor";
 import { useEditSession } from "../../hooks/useEditSession";
@@ -50,142 +53,25 @@ import {
 import { SaveConflictDialog } from "../editing/SaveConflictDialog";
 import { ResumeOrDiscardDialog } from "../editing/ResumeOrDiscardDialog";
 import { setDirty as setTabDirty, makeTabId } from "../../store/tabStore";
-import { MaturityBadge } from "../process-flow/MaturityBadge";
 import { ValidationBadge } from "../common/ValidationBadge";
-import { checkViewDefinition, type ViewDefinitionIssue, type TableDefinitionForView } from "../../schemas/viewDefinitionValidator";
+import { checkViewDefinition, type ViewDefinitionIssue } from "../../schemas/viewDefinitionValidator";
 import "../../styles/table.css";
 import "../../styles/editMode.css";
 
-// ─── FieldType primitives available for display ──────────────────────────────
+// Level 検出 + 切替ヘルパー (#748、3 レベル DSL UI 対応)
+import { detectLevel, type ViewLevel } from "./viewDefinitionLevels";
 
-const FIELD_TYPE_OPTIONS: FieldTypePrimitive[] = [
-  "string", "integer", "number", "boolean", "date", "datetime", "json",
-];
-
-// ─── FilterOperator options ───────────────────────────────────────────────────
-
-const FILTER_OPERATORS: FilterOperator[] = [
-  "eq", "neq", "gt", "gte", "lt", "lte",
-  "contains", "startsWith", "in", "between",
-];
-
-// ─── BuiltinViewDefinitionKind labels ────────────────────────────────────────
-
-const KIND_LABELS: Record<BuiltinViewDefinitionKind, string> = {
-  list: "list — 一覧",
-  detail: "detail — 詳細",
-  kanban: "kanban — カンバン",
-  calendar: "calendar — カレンダー",
-};
-
-// ─── Level 検出 + 切替ヘルパー (#748、3 レベル DSL UI 対応) ───────────────
-// テスト容易性のため別 module に切り出し済み (viewDefinitionLevels.ts)。
-import {
-  detectLevel,
-  migrateToLevel,
-  suggestAlias,
-  type ViewLevel,
-} from "./viewDefinitionLevels";
-
-const JOIN_KIND_OPTIONS: ViewQueryJoin["kind"][] = ["INNER", "LEFT", "RIGHT", "FULL"];
-
-const LEVEL_LABELS: Record<ViewLevel, string> = {
-  1: "Level 1 — Simple (1 テーブル)",
-  2: "Level 2 — Structured (joins + where)",
-  3: "Level 3 — Raw SQL (CTE / window 等)",
-};
-
-// ─── useTablesForValidator hook ───────────────────────────────────────────────
-
-function useTablesForValidator(): TableDefinitionForView[] {
-  const [tables, setTables] = useState<TableDefinitionForView[]>([]);
-  useEffect(() => {
-    let cancelled = false;
-    async function refresh(): Promise<void> {
-      const entries = await listTables();
-      const all = await Promise.all(entries.map((e: TableEntry) => loadTable(e.id)));
-      const valid = all.filter((t): t is Table => t !== null);
-      if (!cancelled) {
-        // Table is shape-compatible with TableDefinitionForView (id / name / physicalName / columns)
-        setTables(valid as unknown as TableDefinitionForView[]);
-      }
-    }
-    refresh().catch(console.error);
-    // #1001: 同一 client 内 SPA 遷移先での table 変更通知 + 他 client (mcpBridge broadcast) 両カバー
-    const unsubLocal = onTableChange(() => { refresh().catch(console.error); });
-    const unsubBroadcast = mcpBridge.onBroadcast("tableChanged", () => { refresh().catch(console.error); });
-    return () => {
-      cancelled = true;
-      unsubLocal();
-      unsubBroadcast();
-    };
-  }, []);
-  return tables;
-}
-
-// ─── TableOption ─────────────────────────────────────────────────────────────
-
-interface TableOption {
-  id: string;
-  name: string;
-  columns: Array<{ id: string; name: string; physicalName: string }>;
-}
-
-function useTableOptions(): TableOption[] {
-  const [options, setOptions] = useState<TableOption[]>([]);
-  useEffect(() => {
-    let cancelled = false;
-    async function refresh(): Promise<void> {
-      const entries = await listTables();
-      const tables = await Promise.all(entries.map((e: TableEntry) => loadTable(e.id)));
-      if (!cancelled) {
-        setOptions(
-          tables
-            .filter((t): t is Table => t !== null)
-            .map((t) => ({
-              id: t.id,
-              name: t.name ?? t.physicalName ?? t.id,
-              columns: (t.columns ?? []).map((c) => ({
-                id: c.id,
-                name: c.name ?? c.physicalName ?? c.id,
-                physicalName: c.physicalName ?? c.id,
-              })),
-            })),
-        );
-      }
-    }
-    refresh().catch(console.error);
-    // #1001: 同一 client 内 SPA 遷移先での table 変更通知 + 他 client (mcpBridge broadcast) 両カバー
-    const unsubLocal = onTableChange(() => { refresh().catch(console.error); });
-    const unsubBroadcast = mcpBridge.onBroadcast("tableChanged", () => { refresh().catch(console.error); });
-    return () => {
-      cancelled = true;
-      unsubLocal();
-      unsubBroadcast();
-    };
-  }, []);
-  return options;
-}
-
-// ─── Inline issue display helper ─────────────────────────────────────────────
-
-function IssueHints({ issues }: { issues: ViewDefinitionIssue[] }) {
-  if (issues.length === 0) return null;
-  return (
-    <div className="vd-editor-issue-hints">
-      {issues.map((iss, i) => (
-        <small
-          key={i}
-          className={`vd-editor-issue vd-editor-issue--${iss.severity}`}
-          title={iss.code}
-        >
-          <i className={`bi ${iss.severity === "error" ? "bi-x-circle-fill" : "bi-exclamation-triangle-fill"}`} />
-          {" "}{iss.message}
-        </small>
-      ))}
-    </div>
-  );
-}
+// Phase-4 抽出 sub-editor / section / hooks / constants
+import { useTablesForValidator, useTableOptions } from "./internal/useViewDefinitionTables";
+import { LEVEL_LABELS } from "./internal/viewDefinitionConstants";
+import { BasicInfoSection } from "./internal/BasicInfoSection";
+import { Level1QueryEditor } from "./internal/Level1QueryEditor";
+import { Level2QueryEditor } from "./internal/Level2QueryEditor";
+import { Level3QueryEditor } from "./internal/Level3QueryEditor";
+import { ColumnsSection } from "./internal/ColumnsSection";
+import { SortDefaultsSection } from "./internal/SortDefaultsSection";
+import { FilterDefaultsSection } from "./internal/FilterDefaultsSection";
+import { MiscSection } from "./internal/MiscSection";
 
 // ─── Main Component ───────────────────────────────────────────────────────────
 
@@ -442,23 +328,23 @@ export function ViewDefinitionEditor() {
   // path ヘルパー
   const vdId = viewDefinition?.id ?? "";
 
-  function colPath(ci: number, colName: string, field?: string): string {
+  const colPath = useCallback((ci: number, colName: string, field?: string): string => {
     const base = `ViewDefinition[${vdId}].columns[${ci}=${colName}]`;
     return field ? `${base}.${field}` : base;
-  }
+  }, [vdId]);
 
-  function sortPath(si: number, field?: string): string {
+  const sortPath = useCallback((si: number, field?: string): string => {
     const base = `ViewDefinition[${vdId}].sortDefaults[${si}].columnName`;
     return field ? `ViewDefinition[${vdId}].sortDefaults[${si}].${field}` : base;
-  }
+  }, [vdId]);
 
-  function filterPath(fi: number, field: string): string {
+  const filterPath = useCallback((fi: number, field: string): string => {
     return `ViewDefinition[${vdId}].filterDefaults[${fi}].${field}`;
-  }
+  }, [vdId]);
 
-  function getIssues(path: string): ViewDefinitionIssue[] {
+  const getIssues = useCallback((path: string): ViewDefinitionIssue[] => {
     return issuesByPath.get(path) ?? [];
-  }
+  }, [issuesByPath]);
 
   // ─── 読み込み中 ────────────────────────────────────────────────────────────
   if (!viewDefinition || sessionLoading) {
@@ -612,9 +498,6 @@ export function ViewDefinitionEditor() {
     });
   };
 
-  const isBuiltinKind = (k: string): k is BuiltinViewDefinitionKind =>
-    ["list", "detail", "kanban", "calendar"].includes(k);
-
   // ─── render ───────────────────────────────────────────────────────────────
 
   const lockedByOther = mode.kind === "locked-by-other" ? mode : null;
@@ -744,139 +627,17 @@ export function ViewDefinitionEditor() {
         <div className="seq-editor-left-col">
 
           {/* ───── Section 1: 基本情報 ────────────────────────────────────── */}
-          <section className="seq-editor-section">
-            <h3 className="seq-editor-section-title">基本情報</h3>
-            <div className="seq-editor-grid">
-
-              {/* ID (read-only) */}
-              <label className="tbl-field">
-                <span>ID</span>
-                <input
-                  type="text"
-                  value={viewDefinition.id}
-                  readOnly
-                  className="seq-readonly"
-                  title="ID は変更できません"
-                />
-              </label>
-
-              {/* 表示名 */}
-              <label className="tbl-field">
-                <span>表示名 <span className="vd-editor-required">*</span></span>
-                <input
-                  type="text"
-                  value={viewDefinition.name}
-                  onChange={(e) => updateSilentWithDraft((d) => { d.name = e.target.value as ViewDefinition["name"]; })}
-                  onBlur={() => { if (!isReadonly) commit(); }}
-                  placeholder="顧客一覧"
-                  disabled={isReadonly}
-                />
-              </label>
-
-              {/* 説明 */}
-              <label className="tbl-field">
-                <span>説明</span>
-                <textarea
-                  value={viewDefinition.description ?? ""}
-                  onChange={(e) => updateSilentWithDraft((d) => {
-                    d.description = e.target.value || undefined;
-                  })}
-                  onBlur={() => { if (!isReadonly) commit(); }}
-                  rows={2}
-                  placeholder="このビュー定義の用途を記述..."
-                  disabled={isReadonly}
-                />
-              </label>
-
-              {/* viewer 種別 */}
-              <div className="tbl-field">
-                <span>viewer 種別 <span className="vd-editor-required">*</span></span>
-                <div className="vd-editor-kind-row">
-                  {!kindExtMode ? (
-                    <select
-                      value={isBuiltinKind(viewDefinition.kind) ? viewDefinition.kind : "list"}
-                      onChange={(e) => updateWithDraft((d) => { d.kind = e.target.value; })}
-                      disabled={isReadonly}
-                    >
-                      {(Object.entries(KIND_LABELS) as [BuiltinViewDefinitionKind, string][]).map(([v, label]) => (
-                        <option key={v} value={v}>{label}</option>
-                      ))}
-                    </select>
-                  ) : (
-                    <input
-                      type="text"
-                      value={viewDefinition.kind}
-                      onChange={(e) => updateSilentWithDraft((d) => { d.kind = e.target.value; })}
-                      onBlur={() => { if (!isReadonly) commit(); }}
-                      placeholder="namespace:kindName (例: retail:storefront)"
-                      disabled={isReadonly}
-                    />
-                  )}
-                  <button
-                    type="button"
-                    className="tbl-btn tbl-btn-ghost tbl-btn-sm"
-                    onClick={() => {
-                      setKindExtMode((v) => !v);
-                      if (kindExtMode) {
-                        updateWithDraft((d) => { d.kind = "list"; });
-                      }
-                    }}
-                    title={kindExtMode ? "組み込み種別に戻す" : "拡張参照を入力"}
-                    disabled={isReadonly}
-                  >
-                    {kindExtMode ? "組み込みに戻す" : "拡張参照"}
-                  </button>
-                </div>
-              </div>
-
-              {/* Level 切替 (#748、3 レベル DSL) */}
-              <div className="tbl-field">
-                <span>クエリ Level <span className="vd-editor-required">*</span></span>
-                <div className="vd-editor-level-row">
-                  {([1, 2, 3] as ViewLevel[]).map((lv) => (
-                    <label key={lv} className="vd-editor-level-radio" title={LEVEL_LABELS[lv]}>
-                      <input
-                        type="radio"
-                        name="vd-level"
-                        checked={currentLevel === lv}
-                        onChange={() => {
-                          if (currentLevel === lv || isReadonly) return;
-                          const tableName = (id: string) =>
-                            tableOptions.find((t) => t.id === id)?.name;
-                          updateWithDraft((d) => {
-                            const migrated = migrateToLevel(d, lv, tableName);
-                            d.sourceTableId = migrated.sourceTableId;
-                            d.query = migrated.query;
-                          });
-                        }}
-                        disabled={isReadonly}
-                      />
-                      {" "}{LEVEL_LABELS[lv]}
-                    </label>
-                  ))}
-                </div>
-                <small className="vd-editor-level-hint">
-                  Level 切替時は <code>sourceTableId</code> と <code>query</code> が排他的に書き換わります (既存の columns / sort / filter は維持)。
-                </small>
-              </div>
-
-              {/* 成熟度 */}
-              <label className="tbl-field">
-                <span>成熟度</span>
-                <div className="vd-editor-maturity-row">
-                  <MaturityBadge
-                    maturity={viewDefinition.maturity}
-                    size="md"
-                    onChange={isReadonly ? undefined : (m: Maturity) => updateWithDraft((d) => { d.maturity = m; })}
-                  />
-                  <span className="vd-editor-maturity-label">
-                    {viewDefinition.maturity ?? "draft"}
-                  </span>
-                </div>
-              </label>
-
-            </div>
-          </section>
+          <BasicInfoSection
+            viewDefinition={viewDefinition}
+            currentLevel={currentLevel}
+            tableOptions={tableOptions}
+            isReadonly={isReadonly}
+            kindExtMode={kindExtMode}
+            setKindExtMode={setKindExtMode}
+            updateWithDraft={updateWithDraft}
+            updateSilentWithDraft={updateSilentWithDraft}
+            commit={commit}
+          />
 
           {/* ───── Section 2: Query (Level 別) (#748) ──────────────────────── */}
           <section className="seq-editor-section">
@@ -885,879 +646,96 @@ export function ViewDefinitionEditor() {
             </h3>
 
             {currentLevel === 1 && (
-              <div className="seq-editor-grid">
-                <div className="tbl-field">
-                  <span>ソーステーブル <span className="vd-editor-required">*</span></span>
-                  <select
-                    value={(viewDefinition.sourceTableId as string | undefined) ?? ""}
-                    onChange={(e) => updateWithDraft((d) => { d.sourceTableId = e.target.value as TableId; })}
-                    className={getIssues(`ViewDefinition[${vdId}].sourceTableId`).length > 0 ? "input-error" : undefined}
-                    disabled={isReadonly}
-                  >
-                    <option value="">— テーブルを選択 —</option>
-                    {tableOptions.map((t) => (
-                      <option key={t.id} value={t.id}>{t.name}</option>
-                    ))}
-                  </select>
-                  <IssueHints issues={getIssues(`ViewDefinition[${vdId}].sourceTableId`)} />
-                </div>
-              </div>
+              <Level1QueryEditor
+                viewDefinition={viewDefinition}
+                vdId={vdId}
+                tableOptions={tableOptions}
+                isReadonly={isReadonly}
+                updateWithDraft={updateWithDraft}
+                getIssues={getIssues}
+              />
             )}
 
-            {currentLevel === 2 && (() => {
-              const sq = (viewDefinition.query as ViewQueryStructured | undefined) ?? {
-                from: { tableId: "" as TableId, alias: "a" },
-              };
-              const fromIssuePath = `ViewDefinition[${vdId}].query.from.tableId`;
-              return (
-                <div className="vd-query-structured">
-                  {/* FROM */}
-                  <div className="vd-query-row">
-                    <span className="vd-query-label">FROM</span>
-                    <select
-                      value={(sq.from?.tableId as string | undefined) ?? ""}
-                      onChange={(e) => updateWithDraft((d) => {
-                        const cur = (d.query as ViewQueryStructured | undefined) ?? { from: { tableId: "" as TableId, alias: "a" } };
-                        d.query = { ...cur, from: { ...cur.from, tableId: e.target.value as TableId } };
-                      })}
-                      className={getIssues(fromIssuePath).length > 0 ? "input-error" : undefined}
-                      disabled={isReadonly}
-                    >
-                      <option value="">— テーブル —</option>
-                      {tableOptions.map((t) => (
-                        <option key={t.id} value={t.id}>{t.name}</option>
-                      ))}
-                    </select>
-                    <span className="vd-query-as">AS</span>
-                    <input
-                      type="text"
-                      value={sq.from?.alias ?? ""}
-                      onChange={(e) => updateSilentWithDraft((d) => {
-                        const cur = (d.query as ViewQueryStructured | undefined) ?? { from: { tableId: "" as TableId, alias: "" } };
-                        d.query = { ...cur, from: { ...cur.from, alias: e.target.value } };
-                      })}
-                      onBlur={() => { if (!isReadonly) commit(); }}
-                      placeholder="alias"
-                      className="vd-query-alias-input"
-                      pattern="^[a-z][a-z0-9_]*$"
-                      title="snake_case (^[a-z][a-z0-9_]*$)"
-                      disabled={isReadonly}
-                    />
-                  </div>
-                  <IssueHints issues={getIssues(fromIssuePath)} />
+            {currentLevel === 2 && (
+              <Level2QueryEditor
+                viewDefinition={viewDefinition}
+                vdId={vdId}
+                tableOptions={tableOptions}
+                isReadonly={isReadonly}
+                updateWithDraft={updateWithDraft}
+                updateSilentWithDraft={updateSilentWithDraft}
+                commit={commit}
+                getIssues={getIssues}
+              />
+            )}
 
-                  {/* JOINS */}
-                  <div className="vd-query-block">
-                    <div className="vd-query-block-title">JOINS</div>
-                    {(sq.joins ?? []).map((j, ji) => {
-                      const joinIssuePath = `ViewDefinition[${vdId}].query.joins[${ji}].tableId`;
-                      const aliasIssuePath = `ViewDefinition[${vdId}].query.joins[${ji}].alias`;
-                      return (
-                        <div key={ji} className="vd-query-join-row">
-                          <select
-                            value={j.kind}
-                            onChange={(e) => updateWithDraft((d) => {
-                              const cur = d.query as ViewQueryStructured;
-                              const joins = [...(cur.joins ?? [])];
-                              joins[ji] = { ...joins[ji], kind: e.target.value as ViewQueryJoin["kind"] };
-                              d.query = { ...cur, joins };
-                            })}
-                            disabled={isReadonly}
-                          >
-                            {JOIN_KIND_OPTIONS.map((k) => (
-                              <option key={k} value={k}>{k}</option>
-                            ))}
-                          </select>
-                          <span className="vd-query-as">JOIN</span>
-                          <select
-                            value={(j.tableId as string | undefined) ?? ""}
-                            onChange={(e) => updateWithDraft((d) => {
-                              const cur = d.query as ViewQueryStructured;
-                              const joins = [...(cur.joins ?? [])];
-                              joins[ji] = { ...joins[ji], tableId: e.target.value as TableId };
-                              d.query = { ...cur, joins };
-                            })}
-                            className={getIssues(joinIssuePath).length > 0 ? "input-error" : undefined}
-                            disabled={isReadonly}
-                          >
-                            <option value="">— テーブル —</option>
-                            {tableOptions.map((t) => (
-                              <option key={t.id} value={t.id}>{t.name}</option>
-                            ))}
-                          </select>
-                          <span className="vd-query-as">AS</span>
-                          <input
-                            type="text"
-                            value={j.alias}
-                            onChange={(e) => updateSilentWithDraft((d) => {
-                              const cur = d.query as ViewQueryStructured;
-                              const joins = [...(cur.joins ?? [])];
-                              joins[ji] = { ...joins[ji], alias: e.target.value };
-                              d.query = { ...cur, joins };
-                            })}
-                            onBlur={() => { if (!isReadonly) commit(); }}
-                            placeholder="alias"
-                            className={`vd-query-alias-input${getIssues(aliasIssuePath).length > 0 ? " input-error" : ""}`}
-                            disabled={isReadonly}
-                          />
-                          <span className="vd-query-as">ON</span>
-                          <div className="vd-query-on-list">
-                            {j.on.map((cond, oi) => (
-                              <input
-                                key={oi}
-                                type="text"
-                                value={cond}
-                                onChange={(e) => updateSilentWithDraft((d) => {
-                                  const cur = d.query as ViewQueryStructured;
-                                  const joins = [...(cur.joins ?? [])];
-                                  const on = [...(joins[ji].on ?? [])];
-                                  on[oi] = e.target.value;
-                                  joins[ji] = { ...joins[ji], on };
-                                  d.query = { ...cur, joins };
-                                })}
-                                onBlur={() => { if (!isReadonly) commit(); }}
-                                placeholder="o.customer_id = c.id"
-                                className="vd-query-fragment-input"
-                                disabled={isReadonly}
-                              />
-                            ))}
-                            <button
-                              type="button"
-                              className="tbl-btn-icon"
-                              onClick={() => updateWithDraft((d) => {
-                                const cur = d.query as ViewQueryStructured;
-                                const joins = [...(cur.joins ?? [])];
-                                const on = [...(joins[ji].on ?? []), ""];
-                                joins[ji] = { ...joins[ji], on };
-                                d.query = { ...cur, joins };
-                              })}
-                              disabled={isReadonly}
-                              title="ON 条件追加 (AND 結合)"
-                            >
-                              <i className="bi bi-plus-lg" />
-                            </button>
-                          </div>
-                          <button
-                            type="button"
-                            className="tbl-btn-icon danger"
-                            onClick={() => updateWithDraft((d) => {
-                              const cur = d.query as ViewQueryStructured;
-                              const joins = (cur.joins ?? []).filter((_, i) => i !== ji);
-                              d.query = { ...cur, joins: joins.length ? joins : undefined };
-                            })}
-                            disabled={isReadonly}
-                            title="JOIN 削除"
-                          >
-                            <i className="bi bi-trash" />
-                          </button>
-                          <IssueHints issues={[...getIssues(joinIssuePath), ...getIssues(aliasIssuePath)]} />
-                        </div>
-                      );
-                    })}
-                    <button
-                      type="button"
-                      className="tbl-btn tbl-btn-ghost"
-                      onClick={() => updateWithDraft((d) => {
-                        const cur = (d.query as ViewQueryStructured | undefined) ?? { from: { tableId: "" as TableId, alias: "a" } };
-                        const usedAliases = new Set<string>([cur.from?.alias ?? ""]);
-                        (cur.joins ?? []).forEach((j) => usedAliases.add(j.alias));
-                        const newJoin: ViewQueryJoin = {
-                          kind: "INNER",
-                          tableId: "" as TableId,
-                          alias: suggestAlias(undefined, usedAliases),
-                          on: [""],
-                        };
-                        d.query = { ...cur, joins: [...(cur.joins ?? []), newJoin] };
-                      })}
-                      disabled={isReadonly}
-                    >
-                      <i className="bi bi-plus-lg" /> JOIN 追加
-                    </button>
-                  </div>
-
-                  {/* WHERE / GROUP BY / HAVING / ORDER BY */}
-                  {(["where", "groupBy", "having", "orderBy"] as const).map((kw) => {
-                    const items = (sq[kw] ?? []) as string[];
-                    const labelMap = {
-                      where: ["WHERE", "AND 結合される条件式 (例: \"o.status = 'active'\")"],
-                      groupBy: ["GROUP BY", "GROUP BY 列式 (例: \"o.customer_id\")"],
-                      having: ["HAVING", "AND 結合される HAVING 条件 (例: \"COUNT(*) > 10\")"],
-                      orderBy: ["ORDER BY", "ORDER BY 式 (例: \"o.created_at DESC\")"],
-                    } as const;
-                    const [label, hint] = labelMap[kw];
-                    return (
-                      <div key={kw} className="vd-query-block">
-                        <div className="vd-query-block-title" title={hint}>{label}</div>
-                        {items.map((cond, idx) => (
-                          <div key={idx} className="vd-query-fragment-row">
-                            <input
-                              type="text"
-                              value={cond}
-                              onChange={(e) => updateSilentWithDraft((d) => {
-                                const cur = d.query as ViewQueryStructured;
-                                const arr = [...((cur[kw] as string[] | undefined) ?? [])];
-                                arr[idx] = e.target.value;
-                                d.query = { ...cur, [kw]: arr };
-                              })}
-                              onBlur={() => { if (!isReadonly) commit(); }}
-                              placeholder={hint}
-                              className="vd-query-fragment-input vd-query-fragment-input--full"
-                              disabled={isReadonly}
-                            />
-                            <button
-                              type="button"
-                              className="tbl-btn-icon danger"
-                              onClick={() => updateWithDraft((d) => {
-                                const cur = d.query as ViewQueryStructured;
-                                const arr = ((cur[kw] as string[] | undefined) ?? []).filter((_, i) => i !== idx);
-                                d.query = { ...cur, [kw]: arr.length ? arr : undefined };
-                              })}
-                              disabled={isReadonly}
-                              title="削除"
-                            >
-                              <i className="bi bi-trash" />
-                            </button>
-                          </div>
-                        ))}
-                        <button
-                          type="button"
-                          className="tbl-btn tbl-btn-ghost tbl-btn-sm"
-                          onClick={() => updateWithDraft((d) => {
-                            const cur = d.query as ViewQueryStructured;
-                            const arr = [...((cur[kw] as string[] | undefined) ?? []), ""];
-                            d.query = { ...cur, [kw]: arr };
-                          })}
-                          disabled={isReadonly}
-                        >
-                          <i className="bi bi-plus-lg" /> {label} 追加
-                        </button>
-                      </div>
-                    );
-                  })}
-                </div>
-              );
-            })()}
-
-            {currentLevel === 3 && (() => {
-              const rq = (viewDefinition.query as ViewQueryRawSql | undefined) ?? { sql: "", parameterRefs: [] };
-              return (
-                <div className="vd-query-rawsql">
-                  <div className="vd-query-block">
-                    <div className="vd-query-block-title">SQL</div>
-                    <textarea
-                      value={rq.sql ?? ""}
-                      onChange={(e) => updateSilentWithDraft((d) => {
-                        const cur = (d.query as ViewQueryRawSql | undefined) ?? { sql: "", parameterRefs: [] };
-                        d.query = { ...cur, sql: e.target.value };
-                      })}
-                      onBlur={() => { if (!isReadonly) commit(); }}
-                      placeholder={"WITH ranked AS (\n  SELECT id, name, ROW_NUMBER() OVER (PARTITION BY category ORDER BY price DESC) AS rn FROM products\n)\nSELECT * FROM ranked WHERE rn <= @param.topN"}
-                      rows={12}
-                      className="vd-query-sql-textarea"
-                      disabled={isReadonly}
-                    />
-                    <small className="vd-editor-level-hint">
-                      式補間は ProcessFlow と同じく <code>@&lt;var&gt;</code> / <code>@conv.*</code> / <code>@env.*</code> / <code>@param.&lt;name&gt;</code>。
-                    </small>
-                  </div>
-
-                  <div className="vd-query-block">
-                    <div className="vd-query-block-title">parameterRefs</div>
-                    {(rq.parameterRefs ?? []).map((p, pi) => (
-                      <div key={pi} className="vd-query-fragment-row">
-                        <input
-                          type="text"
-                          value={p.name as string}
-                          onChange={(e) => updateSilentWithDraft((d) => {
-                            const cur = d.query as ViewQueryRawSql;
-                            const params = [...(cur.parameterRefs ?? [])];
-                            params[pi] = { ...params[pi], name: e.target.value as Identifier };
-                            d.query = { ...cur, parameterRefs: params };
-                          })}
-                          onBlur={() => { if (!isReadonly) commit(); }}
-                          placeholder="paramName"
-                          className="vd-query-fragment-input"
-                          disabled={isReadonly}
-                        />
-                        <select
-                          value={typeof p.fieldType === "string" ? p.fieldType : "string"}
-                          onChange={(e) => updateWithDraft((d) => {
-                            const cur = d.query as ViewQueryRawSql;
-                            const params = [...(cur.parameterRefs ?? [])];
-                            params[pi] = { ...params[pi], fieldType: e.target.value as FieldType };
-                            d.query = { ...cur, parameterRefs: params };
-                          })}
-                          disabled={isReadonly}
-                        >
-                          {FIELD_TYPE_OPTIONS.map((ft) => (
-                            <option key={ft} value={ft}>{ft}</option>
-                          ))}
-                        </select>
-                        <input
-                          type="text"
-                          value={p.description ?? ""}
-                          onChange={(e) => updateSilentWithDraft((d) => {
-                            const cur = d.query as ViewQueryRawSql;
-                            const params = [...(cur.parameterRefs ?? [])];
-                            params[pi] = { ...params[pi], description: e.target.value || undefined };
-                            d.query = { ...cur, parameterRefs: params };
-                          })}
-                          onBlur={() => { if (!isReadonly) commit(); }}
-                          placeholder="description (任意)"
-                          className="vd-query-fragment-input vd-query-fragment-input--full"
-                          disabled={isReadonly}
-                        />
-                        <button
-                          type="button"
-                          className="tbl-btn-icon danger"
-                          onClick={() => updateWithDraft((d) => {
-                            const cur = d.query as ViewQueryRawSql;
-                            const params = (cur.parameterRefs ?? []).filter((_, i) => i !== pi);
-                            d.query = { ...cur, parameterRefs: params.length ? params : undefined };
-                          })}
-                          disabled={isReadonly}
-                          title="削除"
-                        >
-                          <i className="bi bi-trash" />
-                        </button>
-                      </div>
-                    ))}
-                    <button
-                      type="button"
-                      className="tbl-btn tbl-btn-ghost tbl-btn-sm"
-                      onClick={() => updateWithDraft((d) => {
-                        const cur = (d.query as ViewQueryRawSql | undefined) ?? { sql: "" };
-                        const newParam: ViewQueryParameterRef = {
-                          name: "" as Identifier,
-                          fieldType: "string" as FieldType,
-                        };
-                        d.query = { ...cur, parameterRefs: [...(cur.parameterRefs ?? []), newParam] };
-                      })}
-                      disabled={isReadonly}
-                    >
-                      <i className="bi bi-plus-lg" /> parameterRef 追加
-                    </button>
-                  </div>
-                </div>
-              );
-            })()}
+            {currentLevel === 3 && (
+              <Level3QueryEditor
+                viewDefinition={viewDefinition}
+                isReadonly={isReadonly}
+                updateWithDraft={updateWithDraft}
+                updateSilentWithDraft={updateSilentWithDraft}
+                commit={commit}
+              />
+            )}
           </section>
 
           {/* ───── Section 3: columns 編集 ────────────────────────────────── */}
-          <section className="seq-editor-section">
-            <h3 className="seq-editor-section-title">
-              カラム定義
-              <span className="vd-editor-col-count">
-                ({(viewDefinition.columns ?? []).length} 件)
-              </span>
-            </h3>
+          <ColumnsSection
+            viewDefinition={viewDefinition}
+            currentLevel={currentLevel}
+            tableOptions={tableOptions}
+            inScopeTables={inScopeTables}
+            colRefTableIds={colRefTableIds}
+            isReadonly={isReadonly}
+            addColumn={addColumn}
+            removeColumn={removeColumn}
+            moveColumn={moveColumn}
+            updateColumn={updateColumn}
+            setColRefTable={setColRefTable}
+            setColRefColumn={setColRefColumn}
+            updateSilentWithDraft={updateSilentWithDraft}
+            updateWithDraft={updateWithDraft}
+            commit={commit}
+            colPath={colPath}
+            getIssues={getIssues}
+          />
 
-            <div className="vd-editor-columns-table-wrap">
-              <table className="vd-editor-columns-table">
-                <thead>
-                  <tr>
-                    <th>name <span className="vd-editor-required">*</span></th>
-                    {currentLevel !== 3 && (
-                      <>
-                        <th title={currentLevel === 2 ? "from / joins[] のテーブルから選択" : "参照テーブル"}>
-                          {currentLevel === 2 ? "alias.テーブル" : "参照テーブル"}
-                        </th>
-                        <th>参照カラム</th>
-                      </>
-                    )}
-                    <th>表示名</th>
-                    <th>type <span className="vd-editor-required">*</span></th>
-                    <th>書式</th>
-                    <th>幅</th>
-                    <th>align</th>
-                    <th title="ソート可能">sort</th>
-                    <th title="フィルタ可能">filter</th>
-                    <th>linkTo</th>
-                    <th>操作</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {(viewDefinition.columns ?? []).map((col, ci) => {
-                    const colName = col.name as string;
-                    const refTableId = colRefTableIds[ci] ?? col.tableColumnRef?.tableId ?? viewDefinition.sourceTableId;
-                    const colOptions = tableOptions.find((t) => t.id === refTableId)?.columns ?? [];
-                    const basePath = colPath(ci, colName);
-                    const colIssues = [
-                      ...getIssues(basePath),
-                      ...getIssues(`${basePath}.tableColumnRef`),
-                      ...getIssues(`${basePath}.type`),
-                    ];
+          {/* ───── Section 4: sortDefaults ────────────────────────────────── */}
+          <SortDefaultsSection
+            viewDefinition={viewDefinition}
+            columnNames={columnNames}
+            isReadonly={isReadonly}
+            addSortSpec={addSortSpec}
+            removeSortSpec={removeSortSpec}
+            updateSortSpec={updateSortSpec}
+            sortPath={sortPath}
+            getIssues={getIssues}
+          />
 
-                    return (
-                      <tr key={ci} className={colIssues.some((i) => i.severity === "error") ? "vd-col-row--error" : colIssues.some((i) => i.severity === "warning") ? "vd-col-row--warning" : undefined}>
-                        {/* name */}
-                        <td>
-                          <input
-                            type="text"
-                            value={col.name as string}
-                            onChange={(e) => updateSilentWithDraft((d) => {
-                              d.columns[ci] = { ...d.columns[ci], name: e.target.value as Identifier };
-                            })}
-                            onBlur={() => { if (!isReadonly) commit(); }}
-                            placeholder="columnName"
-                            className="vd-col-input-sm"
-                            title="camelCase 識別子"
-                            disabled={isReadonly}
-                          />
-                        </td>
-                        {currentLevel !== 3 && (
-                          <>
-                            {/* 参照テーブル (cascade step 1) — Level 2 では in-scope alias リスト */}
-                            <td>
-                              <select
-                                value={refTableId ?? ""}
-                                onChange={(e) => setColRefTable(ci, e.target.value)}
-                                className="vd-col-select"
-                                disabled={isReadonly}
-                              >
-                                <option value="">— テーブル —</option>
-                                {currentLevel === 2
-                                  ? inScopeTables.map((s) => (
-                                      <option key={`${s.alias}-${s.tableId}`} value={s.tableId}>
-                                        {s.label}
-                                      </option>
-                                    ))
-                                  : tableOptions.map((t) => (
-                                      <option key={t.id} value={t.id}>{t.name}</option>
-                                    ))}
-                              </select>
-                            </td>
-                            {/* 参照カラム (cascade step 2) */}
-                            <td>
-                              <select
-                                value={col.tableColumnRef?.columnId ?? ""}
-                                onChange={(e) => setColRefColumn(ci, e.target.value)}
-                                className="vd-col-select"
-                                disabled={!refTableId || isReadonly}
-                              >
-                                <option value="">— カラム —</option>
-                                {colOptions.map((c) => (
-                                  <option key={c.id} value={c.id}>{c.name}</option>
-                                ))}
-                              </select>
-                            </td>
-                          </>
-                        )}
-                        {/* displayName */}
-                        <td>
-                          <input
-                            type="text"
-                            value={col.displayName ?? ""}
-                            onChange={(e) => updateSilentWithDraft((d) => {
-                              d.columns[ci] = {
-                                ...d.columns[ci],
-                                displayName: (e.target.value || undefined) as ViewColumn["displayName"],
-                              };
-                            })}
-                            onBlur={() => { if (!isReadonly) commit(); }}
-                            placeholder="表示名"
-                            className="vd-col-input-sm"
-                            disabled={isReadonly}
-                          />
-                        </td>
-                        {/* type */}
-                        <td>
-                          <select
-                            value={typeof col.type === "string" ? col.type : "string"}
-                            onChange={(e) => updateColumn(ci, "type", e.target.value as FieldType)}
-                            className="vd-col-select"
-                            disabled={isReadonly}
-                          >
-                            {FIELD_TYPE_OPTIONS.map((ft) => (
-                              <option key={ft} value={ft}>{ft}</option>
-                            ))}
-                          </select>
-                        </td>
-                        {/* displayFormat */}
-                        <td>
-                          <input
-                            type="text"
-                            value={col.displayFormat ?? ""}
-                            onChange={(e) => updateSilentWithDraft((d) => {
-                              d.columns[ci] = { ...d.columns[ci], displayFormat: e.target.value || undefined };
-                            })}
-                            onBlur={() => { if (!isReadonly) commit(); }}
-                            placeholder="#,##0"
-                            className="vd-col-input-xs"
-                            disabled={isReadonly}
-                          />
-                        </td>
-                        {/* width */}
-                        <td>
-                          <input
-                            type="text"
-                            value={col.width ?? ""}
-                            onChange={(e) => updateSilentWithDraft((d) => {
-                              d.columns[ci] = { ...d.columns[ci], width: e.target.value || undefined };
-                            })}
-                            onBlur={() => { if (!isReadonly) commit(); }}
-                            placeholder="120px"
-                            className="vd-col-input-xs"
-                            disabled={isReadonly}
-                          />
-                        </td>
-                        {/* align */}
-                        <td>
-                          <select
-                            value={col.align ?? ""}
-                            onChange={(e) => updateWithDraft((d) => {
-                              d.columns[ci] = {
-                                ...d.columns[ci],
-                                align: (e.target.value || undefined) as ViewColumn["align"],
-                              };
-                            })}
-                            className="vd-col-select-xs"
-                            disabled={isReadonly}
-                          >
-                            <option value="">—</option>
-                            <option value="left">left</option>
-                            <option value="center">center</option>
-                            <option value="right">right</option>
-                          </select>
-                        </td>
-                        {/* sortable */}
-                        <td className="vd-col-center">
-                          <input
-                            type="checkbox"
-                            checked={col.sortable ?? false}
-                            onChange={(e) => updateWithDraft((d) => {
-                              d.columns[ci] = { ...d.columns[ci], sortable: e.target.checked || undefined };
-                            })}
-                            disabled={isReadonly}
-                          />
-                        </td>
-                        {/* filterable */}
-                        <td className="vd-col-center">
-                          <input
-                            type="checkbox"
-                            checked={col.filterable ?? false}
-                            onChange={(e) => updateWithDraft((d) => {
-                              d.columns[ci] = { ...d.columns[ci], filterable: e.target.checked || undefined };
-                            })}
-                            disabled={isReadonly}
-                          />
-                        </td>
-                        {/* linkTo */}
-                        <td>
-                          <input
-                            type="text"
-                            value={col.linkTo ?? ""}
-                            onChange={(e) => updateSilentWithDraft((d) => {
-                              d.columns[ci] = { ...d.columns[ci], linkTo: e.target.value || undefined };
-                            })}
-                            onBlur={() => { if (!isReadonly) commit(); }}
-                            placeholder="/orders/:id"
-                            className="vd-col-input-sm"
-                            disabled={isReadonly}
-                          />
-                        </td>
-                        {/* 操作 */}
-                        <td className="vd-col-ops">
-                          <button
-                            type="button"
-                            className="tbl-btn-icon"
-                            onClick={() => moveColumn(ci, "up")}
-                            disabled={ci === 0 || isReadonly}
-                            title="上に移動"
-                          >
-                            <i className="bi bi-arrow-up" />
-                          </button>
-                          <button
-                            type="button"
-                            className="tbl-btn-icon"
-                            onClick={() => moveColumn(ci, "down")}
-                            disabled={ci === (viewDefinition.columns?.length ?? 0) - 1 || isReadonly}
-                            title="下に移動"
-                          >
-                            <i className="bi bi-arrow-down" />
-                          </button>
-                          <button
-                            type="button"
-                            className="tbl-btn-icon danger"
-                            onClick={() => removeColumn(ci)}
-                            title="削除"
-                            disabled={isReadonly}
-                          >
-                            <i className="bi bi-trash" />
-                          </button>
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
+          {/* ───── Section 5: filterDefaults ─────────────────────────────── */}
+          <FilterDefaultsSection
+            viewDefinition={viewDefinition}
+            columnNames={columnNames}
+            isReadonly={isReadonly}
+            addFilterSpec={addFilterSpec}
+            removeFilterSpec={removeFilterSpec}
+            updateFilterSpec={updateFilterSpec}
+            updateSilentWithDraft={updateSilentWithDraft}
+            commit={commit}
+            filterPath={filterPath}
+            getIssues={getIssues}
+          />
 
-            {/* 列ごとの issue 表示 */}
-            {(viewDefinition.columns ?? []).map((col, ci) => {
-              const colName = col.name as string;
-              const basePath = colPath(ci, colName);
-              const colIssues = [
-                ...getIssues(basePath),
-                ...getIssues(`${basePath}.tableColumnRef`),
-                ...getIssues(`${basePath}.type`),
-              ];
-              if (colIssues.length === 0) return null;
-              return (
-                <div key={ci} className="vd-editor-col-issues">
-                  <span className="vd-editor-col-issues-label">
-                    カラム {ci + 1} ({colName || "未設定"}):
-                  </span>
-                  <IssueHints issues={colIssues} />
-                </div>
-              );
-            })}
-
-            <button
-              type="button"
-              className="tbl-btn tbl-btn-ghost vd-editor-add-row-btn"
-              onClick={addColumn}
-              disabled={isReadonly}
-            >
-              <i className="bi bi-plus-lg" /> カラム追加
-            </button>
-          </section>
-
-          {/* ───── Section 3: sortDefaults ────────────────────────────────── */}
-          <section className="seq-editor-section">
-            <h3 className="seq-editor-section-title">
-              既定ソート順
-              <span className="vd-editor-col-count">({(viewDefinition.sortDefaults ?? []).length} 件)</span>
-            </h3>
-
-            {(viewDefinition.sortDefaults ?? []).length > 0 && (
-              <table className="vd-editor-sub-table">
-                <thead>
-                  <tr>
-                    <th>カラム名</th>
-                    <th>順序</th>
-                    <th>操作</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {(viewDefinition.sortDefaults ?? []).map((spec, si) => {
-                    const siIssues = getIssues(sortPath(si));
-                    return (
-                      <tr key={si} className={siIssues.some((i) => i.severity === "error") ? "vd-col-row--error" : undefined}>
-                        <td>
-                          <select
-                            value={spec.columnName as string}
-                            onChange={(e) => updateSortSpec(si, "columnName", e.target.value as Identifier)}
-                            className={siIssues.length > 0 ? "input-error" : undefined}
-                            disabled={isReadonly}
-                          >
-                            <option value="">— カラムを選択 —</option>
-                            {columnNames.map((cn) => (
-                              <option key={cn} value={cn}>{cn}</option>
-                            ))}
-                          </select>
-                          <IssueHints issues={siIssues} />
-                        </td>
-                        <td>
-                          <select
-                            value={spec.order}
-                            onChange={(e) => updateSortSpec(si, "order", e.target.value as "asc" | "desc")}
-                            disabled={isReadonly}
-                          >
-                            <option value="asc">asc (昇順)</option>
-                            <option value="desc">desc (降順)</option>
-                          </select>
-                        </td>
-                        <td>
-                          <button
-                            type="button"
-                            className="tbl-btn-icon danger"
-                            onClick={() => removeSortSpec(si)}
-                            title="削除"
-                            disabled={isReadonly}
-                          >
-                            <i className="bi bi-trash" />
-                          </button>
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            )}
-
-            <button
-              type="button"
-              className="tbl-btn tbl-btn-ghost vd-editor-add-row-btn"
-              onClick={addSortSpec}
-              disabled={isReadonly}
-            >
-              <i className="bi bi-plus-lg" /> ソート条件追加
-            </button>
-          </section>
-
-          {/* ───── Section 4: filterDefaults ─────────────────────────────── */}
-          <section className="seq-editor-section">
-            <h3 className="seq-editor-section-title">
-              初期フィルタ
-              <span className="vd-editor-col-count">({(viewDefinition.filterDefaults ?? []).length} 件)</span>
-            </h3>
-
-            {(viewDefinition.filterDefaults ?? []).length > 0 && (
-              <table className="vd-editor-sub-table">
-                <thead>
-                  <tr>
-                    <th>カラム名</th>
-                    <th>演算子</th>
-                    <th>値</th>
-                    <th>値 (式)</th>
-                    <th>操作</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {(viewDefinition.filterDefaults ?? []).map((spec, fi) => {
-                    const colIssues = getIssues(filterPath(fi, "columnName"));
-                    const opIssues = getIssues(filterPath(fi, "operator"));
-                    return (
-                      <tr
-                        key={fi}
-                        className={
-                          [...colIssues, ...opIssues].some((i) => i.severity === "error")
-                            ? "vd-col-row--error"
-                            : [...colIssues, ...opIssues].some((i) => i.severity === "warning")
-                              ? "vd-col-row--warning"
-                              : undefined
-                        }
-                      >
-                        <td>
-                          <select
-                            value={spec.columnName as string}
-                            onChange={(e) => updateFilterSpec(fi, "columnName", e.target.value as Identifier)}
-                            className={colIssues.length > 0 ? "input-error" : undefined}
-                            disabled={isReadonly}
-                          >
-                            <option value="">— カラムを選択 —</option>
-                            {columnNames.map((cn) => (
-                              <option key={cn} value={cn}>{cn}</option>
-                            ))}
-                          </select>
-                          <IssueHints issues={colIssues} />
-                        </td>
-                        <td>
-                          <select
-                            value={spec.operator}
-                            onChange={(e) => updateFilterSpec(fi, "operator", e.target.value as FilterOperator)}
-                            className={opIssues.length > 0 ? "input-error" : undefined}
-                            disabled={isReadonly}
-                          >
-                            {FILTER_OPERATORS.map((op) => (
-                              <option key={op} value={op}>{op}</option>
-                            ))}
-                          </select>
-                          <IssueHints issues={opIssues} />
-                        </td>
-                        <td>
-                          <input
-                            type="text"
-                            value={typeof spec.value === "string" ? spec.value : spec.value != null ? String(spec.value) : ""}
-                            onChange={(e) => updateSilentWithDraft((d) => {
-                              const specs = d.filterDefaults ?? [];
-                              specs[fi] = { ...specs[fi], value: e.target.value || undefined };
-                              d.filterDefaults = specs;
-                            })}
-                            onBlur={() => { if (!isReadonly) commit(); }}
-                            placeholder="比較値"
-                            className="vd-col-input-sm"
-                            disabled={isReadonly}
-                          />
-                        </td>
-                        <td>
-                          <input
-                            type="text"
-                            value={spec.valueExpression ?? ""}
-                            onChange={(e) => updateSilentWithDraft((d) => {
-                              const specs = d.filterDefaults ?? [];
-                              specs[fi] = { ...specs[fi], valueExpression: (e.target.value || undefined) as FilterSpec["valueExpression"] };
-                              d.filterDefaults = specs;
-                            })}
-                            onBlur={() => { if (!isReadonly) commit(); }}
-                            placeholder="@conv.numbering.threshold"
-                            className="vd-col-input-sm"
-                            disabled={isReadonly}
-                          />
-                        </td>
-                        <td>
-                          <button
-                            type="button"
-                            className="tbl-btn-icon danger"
-                            onClick={() => removeFilterSpec(fi)}
-                            title="削除"
-                            disabled={isReadonly}
-                          >
-                            <i className="bi bi-trash" />
-                          </button>
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            )}
-
-            <button
-              type="button"
-              className="tbl-btn tbl-btn-ghost vd-editor-add-row-btn"
-              onClick={addFilterSpec}
-              disabled={isReadonly}
-            >
-              <i className="bi bi-plus-lg" /> フィルタ条件追加
-            </button>
-          </section>
-
-          {/* ───── Section 5: その他 ─────────────────────────────────────── */}
-          <section className="seq-editor-section">
-            <h3 className="seq-editor-section-title">その他</h3>
-            <div className="seq-editor-grid">
-
-              {/* pageSize */}
-              <label className="tbl-field">
-                <span>ページサイズ <small>(1..1000)</small></span>
-                <input
-                  type="number"
-                  value={viewDefinition.pageSize ?? ""}
-                  min={1}
-                  max={1000}
-                  onChange={(e) => {
-                    const v = e.target.value ? Number(e.target.value) : undefined;
-                    updateWithDraft((d) => { d.pageSize = v; });
-                  }}
-                  placeholder="20"
-                  className="vd-editor-number-input"
-                  disabled={isReadonly}
-                />
-              </label>
-
-              {/* groupBy */}
-              <div className="tbl-field">
-                <span>groupBy</span>
-                <select
-                  value={viewDefinition.groupBy ?? ""}
-                  onChange={(e) => updateWithDraft((d) => {
-                    d.groupBy = (e.target.value || undefined) as Identifier | undefined;
-                  })}
-                  className={getIssues(`ViewDefinition[${vdId}].groupBy`).length > 0 ? "input-error" : undefined}
-                  disabled={isReadonly}
-                >
-                  <option value="">— なし —</option>
-                  {columnNames.map((cn) => (
-                    <option key={cn} value={cn}>{cn}</option>
-                  ))}
-                </select>
-                <IssueHints issues={getIssues(`ViewDefinition[${vdId}].groupBy`)} />
-              </div>
-
-            </div>
-          </section>
+          {/* ───── Section 6: その他 ─────────────────────────────────────── */}
+          <MiscSection
+            viewDefinition={viewDefinition}
+            vdId={vdId}
+            columnNames={columnNames}
+            isReadonly={isReadonly}
+            updateWithDraft={updateWithDraft}
+            getIssues={getIssues}
+          />
 
         </div>{/* seq-editor-left-col */}
       </div>

--- a/frontend/src/components/view-definition/internal/BasicInfoSection.tsx
+++ b/frontend/src/components/view-definition/internal/BasicInfoSection.tsx
@@ -1,0 +1,176 @@
+/**
+ * BasicInfoSection — Section 1: 基本情報 (Phase-4 抽出)
+ *
+ * id / name / description / kind (builtin or 拡張参照) / Level radio / maturity
+ */
+import type { ViewDefinition } from "../../../types/v3/view-definition";
+import type { Maturity } from "../../../types/v3";
+import { MaturityBadge } from "../../process-flow/MaturityBadge";
+import { migrateToLevel, type ViewLevel } from "../viewDefinitionLevels";
+import {
+  KIND_LABELS,
+  LEVEL_LABELS,
+  isBuiltinKind,
+} from "./viewDefinitionConstants";
+import type { TableOption } from "./useViewDefinitionTables";
+import type { BuiltinViewDefinitionKind } from "../../../types/v3/view-definition";
+
+interface Props {
+  viewDefinition: ViewDefinition;
+  currentLevel: ViewLevel;
+  tableOptions: TableOption[];
+  isReadonly: boolean;
+  kindExtMode: boolean;
+  setKindExtMode: (fn: (prev: boolean) => boolean) => void;
+  updateWithDraft: (fn: (s: ViewDefinition) => void) => void;
+  updateSilentWithDraft: (fn: (s: ViewDefinition) => void) => void;
+  commit: () => void;
+}
+
+export function BasicInfoSection({
+  viewDefinition,
+  currentLevel,
+  tableOptions,
+  isReadonly,
+  kindExtMode,
+  setKindExtMode,
+  updateWithDraft,
+  updateSilentWithDraft,
+  commit,
+}: Props) {
+  return (
+    <section className="seq-editor-section">
+      <h3 className="seq-editor-section-title">基本情報</h3>
+      <div className="seq-editor-grid">
+
+        {/* ID (read-only) */}
+        <label className="tbl-field">
+          <span>ID</span>
+          <input
+            type="text"
+            value={viewDefinition.id}
+            readOnly
+            className="seq-readonly"
+            title="ID は変更できません"
+          />
+        </label>
+
+        {/* 表示名 */}
+        <label className="tbl-field">
+          <span>表示名 <span className="vd-editor-required">*</span></span>
+          <input
+            type="text"
+            value={viewDefinition.name}
+            onChange={(e) => updateSilentWithDraft((d) => { d.name = e.target.value as ViewDefinition["name"]; })}
+            onBlur={() => { if (!isReadonly) commit(); }}
+            placeholder="顧客一覧"
+            disabled={isReadonly}
+          />
+        </label>
+
+        {/* 説明 */}
+        <label className="tbl-field">
+          <span>説明</span>
+          <textarea
+            value={viewDefinition.description ?? ""}
+            onChange={(e) => updateSilentWithDraft((d) => {
+              d.description = e.target.value || undefined;
+            })}
+            onBlur={() => { if (!isReadonly) commit(); }}
+            rows={2}
+            placeholder="このビュー定義の用途を記述..."
+            disabled={isReadonly}
+          />
+        </label>
+
+        {/* viewer 種別 */}
+        <div className="tbl-field">
+          <span>viewer 種別 <span className="vd-editor-required">*</span></span>
+          <div className="vd-editor-kind-row">
+            {!kindExtMode ? (
+              <select
+                value={isBuiltinKind(viewDefinition.kind) ? viewDefinition.kind : "list"}
+                onChange={(e) => updateWithDraft((d) => { d.kind = e.target.value; })}
+                disabled={isReadonly}
+              >
+                {(Object.entries(KIND_LABELS) as [BuiltinViewDefinitionKind, string][]).map(([v, label]) => (
+                  <option key={v} value={v}>{label}</option>
+                ))}
+              </select>
+            ) : (
+              <input
+                type="text"
+                value={viewDefinition.kind}
+                onChange={(e) => updateSilentWithDraft((d) => { d.kind = e.target.value; })}
+                onBlur={() => { if (!isReadonly) commit(); }}
+                placeholder="namespace:kindName (例: retail:storefront)"
+                disabled={isReadonly}
+              />
+            )}
+            <button
+              type="button"
+              className="tbl-btn tbl-btn-ghost tbl-btn-sm"
+              onClick={() => {
+                setKindExtMode((v) => !v);
+                if (kindExtMode) {
+                  updateWithDraft((d) => { d.kind = "list"; });
+                }
+              }}
+              title={kindExtMode ? "組み込み種別に戻す" : "拡張参照を入力"}
+              disabled={isReadonly}
+            >
+              {kindExtMode ? "組み込みに戻す" : "拡張参照"}
+            </button>
+          </div>
+        </div>
+
+        {/* Level 切替 (#748、3 レベル DSL) */}
+        <div className="tbl-field">
+          <span>クエリ Level <span className="vd-editor-required">*</span></span>
+          <div className="vd-editor-level-row">
+            {([1, 2, 3] as ViewLevel[]).map((lv) => (
+              <label key={lv} className="vd-editor-level-radio" title={LEVEL_LABELS[lv]}>
+                <input
+                  type="radio"
+                  name="vd-level"
+                  checked={currentLevel === lv}
+                  onChange={() => {
+                    if (currentLevel === lv || isReadonly) return;
+                    const tableName = (id: string) =>
+                      tableOptions.find((t) => t.id === id)?.name;
+                    updateWithDraft((d) => {
+                      const migrated = migrateToLevel(d, lv, tableName);
+                      d.sourceTableId = migrated.sourceTableId;
+                      d.query = migrated.query;
+                    });
+                  }}
+                  disabled={isReadonly}
+                />
+                {" "}{LEVEL_LABELS[lv]}
+              </label>
+            ))}
+          </div>
+          <small className="vd-editor-level-hint">
+            Level 切替時は <code>sourceTableId</code> と <code>query</code> が排他的に書き換わります (既存の columns / sort / filter は維持)。
+          </small>
+        </div>
+
+        {/* 成熟度 */}
+        <label className="tbl-field">
+          <span>成熟度</span>
+          <div className="vd-editor-maturity-row">
+            <MaturityBadge
+              maturity={viewDefinition.maturity}
+              size="md"
+              onChange={isReadonly ? undefined : (m: Maturity) => updateWithDraft((d) => { d.maturity = m; })}
+            />
+            <span className="vd-editor-maturity-label">
+              {viewDefinition.maturity ?? "draft"}
+            </span>
+          </div>
+        </label>
+
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/view-definition/internal/ColumnsSection.tsx
+++ b/frontend/src/components/view-definition/internal/ColumnsSection.tsx
@@ -1,0 +1,351 @@
+/**
+ * ColumnsSection — Section 3: columns 編集 (Phase-4 抽出)
+ *
+ * Level に応じて tableColumnRef 列を切替 (Level 1/2 = 参照テーブル/カラム cascade、Level 3 = 非表示)。
+ * 移動・削除・追加・各 cell 編集 + 列ごとの issue 集計表示。
+ *
+ * columns 操作 (addColumn / removeColumn / moveColumn / setColRefTable / setColRefColumn / updateColumn) は
+ * 親コンポーネントが colRefTableIds state を保持しているため props 経由で受け取る。
+ */
+import type {
+  ViewDefinition,
+  ViewColumn,
+} from "../../../types/v3/view-definition";
+import type { Identifier } from "../../../types/v3/common";
+import type { FieldType } from "../../../types/v3";
+import type { ViewDefinitionIssue } from "../../../schemas/viewDefinitionValidator";
+import { IssueHints } from "./IssueHints";
+import { FIELD_TYPE_OPTIONS } from "./viewDefinitionConstants";
+import type { TableOption } from "./useViewDefinitionTables";
+import type { ViewLevel } from "../viewDefinitionLevels";
+
+interface InScopeTable {
+  tableId: string;
+  alias: string;
+  label: string;
+  tableName: string;
+}
+
+interface Props {
+  viewDefinition: ViewDefinition;
+  currentLevel: ViewLevel;
+  tableOptions: TableOption[];
+  inScopeTables: InScopeTable[];
+  colRefTableIds: Record<number, string>;
+  isReadonly: boolean;
+  // column-level handlers
+  addColumn: () => void;
+  removeColumn: (ci: number) => void;
+  moveColumn: (ci: number, direction: "up" | "down") => void;
+  updateColumn: <K extends keyof ViewColumn>(ci: number, field: K, value: ViewColumn[K]) => void;
+  setColRefTable: (ci: number, tableId: string) => void;
+  setColRefColumn: (ci: number, columnId: string) => void;
+  // generic update (for free-form fields)
+  updateSilentWithDraft: (fn: (s: ViewDefinition) => void) => void;
+  updateWithDraft: (fn: (s: ViewDefinition) => void) => void;
+  commit: () => void;
+  // issue lookup
+  colPath: (ci: number, colName: string, field?: string) => string;
+  getIssues: (path: string) => ViewDefinitionIssue[];
+}
+
+export function ColumnsSection({
+  viewDefinition,
+  currentLevel,
+  tableOptions,
+  inScopeTables,
+  colRefTableIds,
+  isReadonly,
+  addColumn,
+  removeColumn,
+  moveColumn,
+  updateColumn,
+  setColRefTable,
+  setColRefColumn,
+  updateSilentWithDraft,
+  updateWithDraft,
+  commit,
+  colPath,
+  getIssues,
+}: Props) {
+  return (
+    <section className="seq-editor-section">
+      <h3 className="seq-editor-section-title">
+        カラム定義
+        <span className="vd-editor-col-count">
+          ({(viewDefinition.columns ?? []).length} 件)
+        </span>
+      </h3>
+
+      <div className="vd-editor-columns-table-wrap">
+        <table className="vd-editor-columns-table">
+          <thead>
+            <tr>
+              <th>name <span className="vd-editor-required">*</span></th>
+              {currentLevel !== 3 && (
+                <>
+                  <th title={currentLevel === 2 ? "from / joins[] のテーブルから選択" : "参照テーブル"}>
+                    {currentLevel === 2 ? "alias.テーブル" : "参照テーブル"}
+                  </th>
+                  <th>参照カラム</th>
+                </>
+              )}
+              <th>表示名</th>
+              <th>type <span className="vd-editor-required">*</span></th>
+              <th>書式</th>
+              <th>幅</th>
+              <th>align</th>
+              <th title="ソート可能">sort</th>
+              <th title="フィルタ可能">filter</th>
+              <th>linkTo</th>
+              <th>操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            {(viewDefinition.columns ?? []).map((col, ci) => {
+              const colName = col.name as string;
+              const refTableId = colRefTableIds[ci] ?? col.tableColumnRef?.tableId ?? viewDefinition.sourceTableId;
+              const colOptions = tableOptions.find((t) => t.id === refTableId)?.columns ?? [];
+              const basePath = colPath(ci, colName);
+              const colIssues = [
+                ...getIssues(basePath),
+                ...getIssues(`${basePath}.tableColumnRef`),
+                ...getIssues(`${basePath}.type`),
+              ];
+
+              return (
+                <tr key={ci} className={colIssues.some((i) => i.severity === "error") ? "vd-col-row--error" : colIssues.some((i) => i.severity === "warning") ? "vd-col-row--warning" : undefined}>
+                  {/* name */}
+                  <td>
+                    <input
+                      type="text"
+                      value={col.name as string}
+                      onChange={(e) => updateSilentWithDraft((d) => {
+                        d.columns[ci] = { ...d.columns[ci], name: e.target.value as Identifier };
+                      })}
+                      onBlur={() => { if (!isReadonly) commit(); }}
+                      placeholder="columnName"
+                      className="vd-col-input-sm"
+                      title="camelCase 識別子"
+                      disabled={isReadonly}
+                    />
+                  </td>
+                  {currentLevel !== 3 && (
+                    <>
+                      {/* 参照テーブル (cascade step 1) — Level 2 では in-scope alias リスト */}
+                      <td>
+                        <select
+                          value={refTableId ?? ""}
+                          onChange={(e) => setColRefTable(ci, e.target.value)}
+                          className="vd-col-select"
+                          disabled={isReadonly}
+                        >
+                          <option value="">— テーブル —</option>
+                          {currentLevel === 2
+                            ? inScopeTables.map((s) => (
+                                <option key={`${s.alias}-${s.tableId}`} value={s.tableId}>
+                                  {s.label}
+                                </option>
+                              ))
+                            : tableOptions.map((t) => (
+                                <option key={t.id} value={t.id}>{t.name}</option>
+                              ))}
+                        </select>
+                      </td>
+                      {/* 参照カラム (cascade step 2) */}
+                      <td>
+                        <select
+                          value={col.tableColumnRef?.columnId ?? ""}
+                          onChange={(e) => setColRefColumn(ci, e.target.value)}
+                          className="vd-col-select"
+                          disabled={!refTableId || isReadonly}
+                        >
+                          <option value="">— カラム —</option>
+                          {colOptions.map((c) => (
+                            <option key={c.id} value={c.id}>{c.name}</option>
+                          ))}
+                        </select>
+                      </td>
+                    </>
+                  )}
+                  {/* displayName */}
+                  <td>
+                    <input
+                      type="text"
+                      value={col.displayName ?? ""}
+                      onChange={(e) => updateSilentWithDraft((d) => {
+                        d.columns[ci] = {
+                          ...d.columns[ci],
+                          displayName: (e.target.value || undefined) as ViewColumn["displayName"],
+                        };
+                      })}
+                      onBlur={() => { if (!isReadonly) commit(); }}
+                      placeholder="表示名"
+                      className="vd-col-input-sm"
+                      disabled={isReadonly}
+                    />
+                  </td>
+                  {/* type */}
+                  <td>
+                    <select
+                      value={typeof col.type === "string" ? col.type : "string"}
+                      onChange={(e) => updateColumn(ci, "type", e.target.value as FieldType)}
+                      className="vd-col-select"
+                      disabled={isReadonly}
+                    >
+                      {FIELD_TYPE_OPTIONS.map((ft) => (
+                        <option key={ft} value={ft}>{ft}</option>
+                      ))}
+                    </select>
+                  </td>
+                  {/* displayFormat */}
+                  <td>
+                    <input
+                      type="text"
+                      value={col.displayFormat ?? ""}
+                      onChange={(e) => updateSilentWithDraft((d) => {
+                        d.columns[ci] = { ...d.columns[ci], displayFormat: e.target.value || undefined };
+                      })}
+                      onBlur={() => { if (!isReadonly) commit(); }}
+                      placeholder="#,##0"
+                      className="vd-col-input-xs"
+                      disabled={isReadonly}
+                    />
+                  </td>
+                  {/* width */}
+                  <td>
+                    <input
+                      type="text"
+                      value={col.width ?? ""}
+                      onChange={(e) => updateSilentWithDraft((d) => {
+                        d.columns[ci] = { ...d.columns[ci], width: e.target.value || undefined };
+                      })}
+                      onBlur={() => { if (!isReadonly) commit(); }}
+                      placeholder="120px"
+                      className="vd-col-input-xs"
+                      disabled={isReadonly}
+                    />
+                  </td>
+                  {/* align */}
+                  <td>
+                    <select
+                      value={col.align ?? ""}
+                      onChange={(e) => updateWithDraft((d) => {
+                        d.columns[ci] = {
+                          ...d.columns[ci],
+                          align: (e.target.value || undefined) as ViewColumn["align"],
+                        };
+                      })}
+                      className="vd-col-select-xs"
+                      disabled={isReadonly}
+                    >
+                      <option value="">—</option>
+                      <option value="left">left</option>
+                      <option value="center">center</option>
+                      <option value="right">right</option>
+                    </select>
+                  </td>
+                  {/* sortable */}
+                  <td className="vd-col-center">
+                    <input
+                      type="checkbox"
+                      checked={col.sortable ?? false}
+                      onChange={(e) => updateWithDraft((d) => {
+                        d.columns[ci] = { ...d.columns[ci], sortable: e.target.checked || undefined };
+                      })}
+                      disabled={isReadonly}
+                    />
+                  </td>
+                  {/* filterable */}
+                  <td className="vd-col-center">
+                    <input
+                      type="checkbox"
+                      checked={col.filterable ?? false}
+                      onChange={(e) => updateWithDraft((d) => {
+                        d.columns[ci] = { ...d.columns[ci], filterable: e.target.checked || undefined };
+                      })}
+                      disabled={isReadonly}
+                    />
+                  </td>
+                  {/* linkTo */}
+                  <td>
+                    <input
+                      type="text"
+                      value={col.linkTo ?? ""}
+                      onChange={(e) => updateSilentWithDraft((d) => {
+                        d.columns[ci] = { ...d.columns[ci], linkTo: e.target.value || undefined };
+                      })}
+                      onBlur={() => { if (!isReadonly) commit(); }}
+                      placeholder="/orders/:id"
+                      className="vd-col-input-sm"
+                      disabled={isReadonly}
+                    />
+                  </td>
+                  {/* 操作 */}
+                  <td className="vd-col-ops">
+                    <button
+                      type="button"
+                      className="tbl-btn-icon"
+                      onClick={() => moveColumn(ci, "up")}
+                      disabled={ci === 0 || isReadonly}
+                      title="上に移動"
+                    >
+                      <i className="bi bi-arrow-up" />
+                    </button>
+                    <button
+                      type="button"
+                      className="tbl-btn-icon"
+                      onClick={() => moveColumn(ci, "down")}
+                      disabled={ci === (viewDefinition.columns?.length ?? 0) - 1 || isReadonly}
+                      title="下に移動"
+                    >
+                      <i className="bi bi-arrow-down" />
+                    </button>
+                    <button
+                      type="button"
+                      className="tbl-btn-icon danger"
+                      onClick={() => removeColumn(ci)}
+                      title="削除"
+                      disabled={isReadonly}
+                    >
+                      <i className="bi bi-trash" />
+                    </button>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {/* 列ごとの issue 表示 */}
+      {(viewDefinition.columns ?? []).map((col, ci) => {
+        const colName = col.name as string;
+        const basePath = colPath(ci, colName);
+        const colIssues = [
+          ...getIssues(basePath),
+          ...getIssues(`${basePath}.tableColumnRef`),
+          ...getIssues(`${basePath}.type`),
+        ];
+        if (colIssues.length === 0) return null;
+        return (
+          <div key={ci} className="vd-editor-col-issues">
+            <span className="vd-editor-col-issues-label">
+              カラム {ci + 1} ({colName || "未設定"}):
+            </span>
+            <IssueHints issues={colIssues} />
+          </div>
+        );
+      })}
+
+      <button
+        type="button"
+        className="tbl-btn tbl-btn-ghost vd-editor-add-row-btn"
+        onClick={addColumn}
+        disabled={isReadonly}
+      >
+        <i className="bi bi-plus-lg" /> カラム追加
+      </button>
+    </section>
+  );
+}

--- a/frontend/src/components/view-definition/internal/FilterDefaultsSection.tsx
+++ b/frontend/src/components/view-definition/internal/FilterDefaultsSection.tsx
@@ -1,0 +1,156 @@
+/**
+ * FilterDefaultsSection — Section 5: filterDefaults 編集 (Phase-4 抽出)
+ *
+ * 初期フィルタを columnName / operator / value / valueExpression で複数指定。
+ */
+import type { ViewDefinition, FilterSpec, FilterOperator } from "../../../types/v3/view-definition";
+import type { Identifier } from "../../../types/v3/common";
+import type { ViewDefinitionIssue } from "../../../schemas/viewDefinitionValidator";
+import { IssueHints } from "./IssueHints";
+import { FILTER_OPERATORS } from "./viewDefinitionConstants";
+
+interface Props {
+  viewDefinition: ViewDefinition;
+  columnNames: string[];
+  isReadonly: boolean;
+  addFilterSpec: () => void;
+  removeFilterSpec: (fi: number) => void;
+  updateFilterSpec: <K extends keyof FilterSpec>(fi: number, field: K, value: FilterSpec[K]) => void;
+  updateSilentWithDraft: (fn: (s: ViewDefinition) => void) => void;
+  commit: () => void;
+  filterPath: (fi: number, field: string) => string;
+  getIssues: (path: string) => ViewDefinitionIssue[];
+}
+
+export function FilterDefaultsSection({
+  viewDefinition,
+  columnNames,
+  isReadonly,
+  addFilterSpec,
+  removeFilterSpec,
+  updateFilterSpec,
+  updateSilentWithDraft,
+  commit,
+  filterPath,
+  getIssues,
+}: Props) {
+  const specs = viewDefinition.filterDefaults ?? [];
+  return (
+    <section className="seq-editor-section">
+      <h3 className="seq-editor-section-title">
+        初期フィルタ
+        <span className="vd-editor-col-count">({specs.length} 件)</span>
+      </h3>
+
+      {specs.length > 0 && (
+        <table className="vd-editor-sub-table">
+          <thead>
+            <tr>
+              <th>カラム名</th>
+              <th>演算子</th>
+              <th>値</th>
+              <th>値 (式)</th>
+              <th>操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            {specs.map((spec, fi) => {
+              const colIssues = getIssues(filterPath(fi, "columnName"));
+              const opIssues = getIssues(filterPath(fi, "operator"));
+              return (
+                <tr
+                  key={fi}
+                  className={
+                    [...colIssues, ...opIssues].some((i) => i.severity === "error")
+                      ? "vd-col-row--error"
+                      : [...colIssues, ...opIssues].some((i) => i.severity === "warning")
+                        ? "vd-col-row--warning"
+                        : undefined
+                  }
+                >
+                  <td>
+                    <select
+                      value={spec.columnName as string}
+                      onChange={(e) => updateFilterSpec(fi, "columnName", e.target.value as Identifier)}
+                      className={colIssues.length > 0 ? "input-error" : undefined}
+                      disabled={isReadonly}
+                    >
+                      <option value="">— カラムを選択 —</option>
+                      {columnNames.map((cn) => (
+                        <option key={cn} value={cn}>{cn}</option>
+                      ))}
+                    </select>
+                    <IssueHints issues={colIssues} />
+                  </td>
+                  <td>
+                    <select
+                      value={spec.operator}
+                      onChange={(e) => updateFilterSpec(fi, "operator", e.target.value as FilterOperator)}
+                      className={opIssues.length > 0 ? "input-error" : undefined}
+                      disabled={isReadonly}
+                    >
+                      {FILTER_OPERATORS.map((op) => (
+                        <option key={op} value={op}>{op}</option>
+                      ))}
+                    </select>
+                    <IssueHints issues={opIssues} />
+                  </td>
+                  <td>
+                    <input
+                      type="text"
+                      value={typeof spec.value === "string" ? spec.value : spec.value != null ? String(spec.value) : ""}
+                      onChange={(e) => updateSilentWithDraft((d) => {
+                        const arr = d.filterDefaults ?? [];
+                        arr[fi] = { ...arr[fi], value: e.target.value || undefined };
+                        d.filterDefaults = arr;
+                      })}
+                      onBlur={() => { if (!isReadonly) commit(); }}
+                      placeholder="比較値"
+                      className="vd-col-input-sm"
+                      disabled={isReadonly}
+                    />
+                  </td>
+                  <td>
+                    <input
+                      type="text"
+                      value={spec.valueExpression ?? ""}
+                      onChange={(e) => updateSilentWithDraft((d) => {
+                        const arr = d.filterDefaults ?? [];
+                        arr[fi] = { ...arr[fi], valueExpression: (e.target.value || undefined) as FilterSpec["valueExpression"] };
+                        d.filterDefaults = arr;
+                      })}
+                      onBlur={() => { if (!isReadonly) commit(); }}
+                      placeholder="@conv.numbering.threshold"
+                      className="vd-col-input-sm"
+                      disabled={isReadonly}
+                    />
+                  </td>
+                  <td>
+                    <button
+                      type="button"
+                      className="tbl-btn-icon danger"
+                      onClick={() => removeFilterSpec(fi)}
+                      title="削除"
+                      disabled={isReadonly}
+                    >
+                      <i className="bi bi-trash" />
+                    </button>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+
+      <button
+        type="button"
+        className="tbl-btn tbl-btn-ghost vd-editor-add-row-btn"
+        onClick={addFilterSpec}
+        disabled={isReadonly}
+      >
+        <i className="bi bi-plus-lg" /> フィルタ条件追加
+      </button>
+    </section>
+  );
+}

--- a/frontend/src/components/view-definition/internal/IssueHints.tsx
+++ b/frontend/src/components/view-definition/internal/IssueHints.tsx
@@ -1,0 +1,24 @@
+/**
+ * ViewDefinitionEditor 共通 — issue 表示ヘルパー (Phase-4 抽出)
+ *
+ * 各セクションのフィールド直下に inline で issue を列挙する。
+ */
+import type { ViewDefinitionIssue } from "../../../schemas/viewDefinitionValidator";
+
+export function IssueHints({ issues }: { issues: ViewDefinitionIssue[] }) {
+  if (issues.length === 0) return null;
+  return (
+    <div className="vd-editor-issue-hints">
+      {issues.map((iss, i) => (
+        <small
+          key={i}
+          className={`vd-editor-issue vd-editor-issue--${iss.severity}`}
+          title={iss.code}
+        >
+          <i className={`bi ${iss.severity === "error" ? "bi-x-circle-fill" : "bi-exclamation-triangle-fill"}`} />
+          {" "}{iss.message}
+        </small>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/view-definition/internal/Level1QueryEditor.tsx
+++ b/frontend/src/components/view-definition/internal/Level1QueryEditor.tsx
@@ -1,0 +1,49 @@
+/**
+ * Level1QueryEditor — Level 1 (Simple, 1 テーブル) クエリ編集 (Phase-4 抽出)
+ *
+ * sourceTableId のみのシンプル選択。Level 2/3 と排他的。
+ */
+import type { ViewDefinition } from "../../../types/v3/view-definition";
+import type { TableId } from "../../../types/v3/common";
+import type { ViewDefinitionIssue } from "../../../schemas/viewDefinitionValidator";
+import { IssueHints } from "./IssueHints";
+import type { TableOption } from "./useViewDefinitionTables";
+
+interface Props {
+  viewDefinition: ViewDefinition;
+  vdId: string;
+  tableOptions: TableOption[];
+  isReadonly: boolean;
+  updateWithDraft: (fn: (s: ViewDefinition) => void) => void;
+  getIssues: (path: string) => ViewDefinitionIssue[];
+}
+
+export function Level1QueryEditor({
+  viewDefinition,
+  vdId,
+  tableOptions,
+  isReadonly,
+  updateWithDraft,
+  getIssues,
+}: Props) {
+  const path = `ViewDefinition[${vdId}].sourceTableId`;
+  return (
+    <div className="seq-editor-grid">
+      <div className="tbl-field">
+        <span>ソーステーブル <span className="vd-editor-required">*</span></span>
+        <select
+          value={(viewDefinition.sourceTableId as string | undefined) ?? ""}
+          onChange={(e) => updateWithDraft((d) => { d.sourceTableId = e.target.value as TableId; })}
+          className={getIssues(path).length > 0 ? "input-error" : undefined}
+          disabled={isReadonly}
+        >
+          <option value="">— テーブルを選択 —</option>
+          {tableOptions.map((t) => (
+            <option key={t.id} value={t.id}>{t.name}</option>
+          ))}
+        </select>
+        <IssueHints issues={getIssues(path)} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/view-definition/internal/Level2QueryEditor.tsx
+++ b/frontend/src/components/view-definition/internal/Level2QueryEditor.tsx
@@ -1,0 +1,271 @@
+/**
+ * Level2QueryEditor — Level 2 (Structured: from + joins + where/groupBy/having/orderBy) (Phase-4 抽出)
+ *
+ * FROM / JOINS / WHERE / GROUP BY / HAVING / ORDER BY のフラグメント編集 UI。
+ * 各フラグメントは AND 結合の式文字列で、AI/runtime 側で query へ展開する。
+ */
+import type {
+  ViewDefinition,
+  ViewQueryStructured,
+  ViewQueryJoin,
+} from "../../../types/v3/view-definition";
+import type { TableId } from "../../../types/v3/common";
+import type { ViewDefinitionIssue } from "../../../schemas/viewDefinitionValidator";
+import { IssueHints } from "./IssueHints";
+import { JOIN_KIND_OPTIONS } from "./viewDefinitionConstants";
+import { suggestAlias } from "../viewDefinitionLevels";
+import type { TableOption } from "./useViewDefinitionTables";
+
+interface Props {
+  viewDefinition: ViewDefinition;
+  vdId: string;
+  tableOptions: TableOption[];
+  isReadonly: boolean;
+  updateWithDraft: (fn: (s: ViewDefinition) => void) => void;
+  updateSilentWithDraft: (fn: (s: ViewDefinition) => void) => void;
+  commit: () => void;
+  getIssues: (path: string) => ViewDefinitionIssue[];
+}
+
+export function Level2QueryEditor({
+  viewDefinition,
+  vdId,
+  tableOptions,
+  isReadonly,
+  updateWithDraft,
+  updateSilentWithDraft,
+  commit,
+  getIssues,
+}: Props) {
+  const sq = (viewDefinition.query as ViewQueryStructured | undefined) ?? {
+    from: { tableId: "" as TableId, alias: "a" },
+  };
+  const fromIssuePath = `ViewDefinition[${vdId}].query.from.tableId`;
+  return (
+    <div className="vd-query-structured">
+      {/* FROM */}
+      <div className="vd-query-row">
+        <span className="vd-query-label">FROM</span>
+        <select
+          value={(sq.from?.tableId as string | undefined) ?? ""}
+          onChange={(e) => updateWithDraft((d) => {
+            const cur = (d.query as ViewQueryStructured | undefined) ?? { from: { tableId: "" as TableId, alias: "a" } };
+            d.query = { ...cur, from: { ...cur.from, tableId: e.target.value as TableId } };
+          })}
+          className={getIssues(fromIssuePath).length > 0 ? "input-error" : undefined}
+          disabled={isReadonly}
+        >
+          <option value="">— テーブル —</option>
+          {tableOptions.map((t) => (
+            <option key={t.id} value={t.id}>{t.name}</option>
+          ))}
+        </select>
+        <span className="vd-query-as">AS</span>
+        <input
+          type="text"
+          value={sq.from?.alias ?? ""}
+          onChange={(e) => updateSilentWithDraft((d) => {
+            const cur = (d.query as ViewQueryStructured | undefined) ?? { from: { tableId: "" as TableId, alias: "" } };
+            d.query = { ...cur, from: { ...cur.from, alias: e.target.value } };
+          })}
+          onBlur={() => { if (!isReadonly) commit(); }}
+          placeholder="alias"
+          className="vd-query-alias-input"
+          pattern="^[a-z][a-z0-9_]*$"
+          title="snake_case (^[a-z][a-z0-9_]*$)"
+          disabled={isReadonly}
+        />
+      </div>
+      <IssueHints issues={getIssues(fromIssuePath)} />
+
+      {/* JOINS */}
+      <div className="vd-query-block">
+        <div className="vd-query-block-title">JOINS</div>
+        {(sq.joins ?? []).map((j, ji) => {
+          const joinIssuePath = `ViewDefinition[${vdId}].query.joins[${ji}].tableId`;
+          const aliasIssuePath = `ViewDefinition[${vdId}].query.joins[${ji}].alias`;
+          return (
+            <div key={ji} className="vd-query-join-row">
+              <select
+                value={j.kind}
+                onChange={(e) => updateWithDraft((d) => {
+                  const cur = d.query as ViewQueryStructured;
+                  const joins = [...(cur.joins ?? [])];
+                  joins[ji] = { ...joins[ji], kind: e.target.value as ViewQueryJoin["kind"] };
+                  d.query = { ...cur, joins };
+                })}
+                disabled={isReadonly}
+              >
+                {JOIN_KIND_OPTIONS.map((k) => (
+                  <option key={k} value={k}>{k}</option>
+                ))}
+              </select>
+              <span className="vd-query-as">JOIN</span>
+              <select
+                value={(j.tableId as string | undefined) ?? ""}
+                onChange={(e) => updateWithDraft((d) => {
+                  const cur = d.query as ViewQueryStructured;
+                  const joins = [...(cur.joins ?? [])];
+                  joins[ji] = { ...joins[ji], tableId: e.target.value as TableId };
+                  d.query = { ...cur, joins };
+                })}
+                className={getIssues(joinIssuePath).length > 0 ? "input-error" : undefined}
+                disabled={isReadonly}
+              >
+                <option value="">— テーブル —</option>
+                {tableOptions.map((t) => (
+                  <option key={t.id} value={t.id}>{t.name}</option>
+                ))}
+              </select>
+              <span className="vd-query-as">AS</span>
+              <input
+                type="text"
+                value={j.alias}
+                onChange={(e) => updateSilentWithDraft((d) => {
+                  const cur = d.query as ViewQueryStructured;
+                  const joins = [...(cur.joins ?? [])];
+                  joins[ji] = { ...joins[ji], alias: e.target.value };
+                  d.query = { ...cur, joins };
+                })}
+                onBlur={() => { if (!isReadonly) commit(); }}
+                placeholder="alias"
+                className={`vd-query-alias-input${getIssues(aliasIssuePath).length > 0 ? " input-error" : ""}`}
+                disabled={isReadonly}
+              />
+              <span className="vd-query-as">ON</span>
+              <div className="vd-query-on-list">
+                {j.on.map((cond, oi) => (
+                  <input
+                    key={oi}
+                    type="text"
+                    value={cond}
+                    onChange={(e) => updateSilentWithDraft((d) => {
+                      const cur = d.query as ViewQueryStructured;
+                      const joins = [...(cur.joins ?? [])];
+                      const on = [...(joins[ji].on ?? [])];
+                      on[oi] = e.target.value;
+                      joins[ji] = { ...joins[ji], on };
+                      d.query = { ...cur, joins };
+                    })}
+                    onBlur={() => { if (!isReadonly) commit(); }}
+                    placeholder="o.customer_id = c.id"
+                    className="vd-query-fragment-input"
+                    disabled={isReadonly}
+                  />
+                ))}
+                <button
+                  type="button"
+                  className="tbl-btn-icon"
+                  onClick={() => updateWithDraft((d) => {
+                    const cur = d.query as ViewQueryStructured;
+                    const joins = [...(cur.joins ?? [])];
+                    const on = [...(joins[ji].on ?? []), ""];
+                    joins[ji] = { ...joins[ji], on };
+                    d.query = { ...cur, joins };
+                  })}
+                  disabled={isReadonly}
+                  title="ON 条件追加 (AND 結合)"
+                >
+                  <i className="bi bi-plus-lg" />
+                </button>
+              </div>
+              <button
+                type="button"
+                className="tbl-btn-icon danger"
+                onClick={() => updateWithDraft((d) => {
+                  const cur = d.query as ViewQueryStructured;
+                  const joins = (cur.joins ?? []).filter((_, i) => i !== ji);
+                  d.query = { ...cur, joins: joins.length ? joins : undefined };
+                })}
+                disabled={isReadonly}
+                title="JOIN 削除"
+              >
+                <i className="bi bi-trash" />
+              </button>
+              <IssueHints issues={[...getIssues(joinIssuePath), ...getIssues(aliasIssuePath)]} />
+            </div>
+          );
+        })}
+        <button
+          type="button"
+          className="tbl-btn tbl-btn-ghost"
+          onClick={() => updateWithDraft((d) => {
+            const cur = (d.query as ViewQueryStructured | undefined) ?? { from: { tableId: "" as TableId, alias: "a" } };
+            const usedAliases = new Set<string>([cur.from?.alias ?? ""]);
+            (cur.joins ?? []).forEach((j) => usedAliases.add(j.alias));
+            const newJoin: ViewQueryJoin = {
+              kind: "INNER",
+              tableId: "" as TableId,
+              alias: suggestAlias(undefined, usedAliases),
+              on: [""],
+            };
+            d.query = { ...cur, joins: [...(cur.joins ?? []), newJoin] };
+          })}
+          disabled={isReadonly}
+        >
+          <i className="bi bi-plus-lg" /> JOIN 追加
+        </button>
+      </div>
+
+      {/* WHERE / GROUP BY / HAVING / ORDER BY */}
+      {(["where", "groupBy", "having", "orderBy"] as const).map((kw) => {
+        const items = (sq[kw] ?? []) as string[];
+        const labelMap = {
+          where: ["WHERE", "AND 結合される条件式 (例: \"o.status = 'active'\")"],
+          groupBy: ["GROUP BY", "GROUP BY 列式 (例: \"o.customer_id\")"],
+          having: ["HAVING", "AND 結合される HAVING 条件 (例: \"COUNT(*) > 10\")"],
+          orderBy: ["ORDER BY", "ORDER BY 式 (例: \"o.created_at DESC\")"],
+        } as const;
+        const [label, hint] = labelMap[kw];
+        return (
+          <div key={kw} className="vd-query-block">
+            <div className="vd-query-block-title" title={hint}>{label}</div>
+            {items.map((cond, idx) => (
+              <div key={idx} className="vd-query-fragment-row">
+                <input
+                  type="text"
+                  value={cond}
+                  onChange={(e) => updateSilentWithDraft((d) => {
+                    const cur = d.query as ViewQueryStructured;
+                    const arr = [...((cur[kw] as string[] | undefined) ?? [])];
+                    arr[idx] = e.target.value;
+                    d.query = { ...cur, [kw]: arr };
+                  })}
+                  onBlur={() => { if (!isReadonly) commit(); }}
+                  placeholder={hint}
+                  className="vd-query-fragment-input vd-query-fragment-input--full"
+                  disabled={isReadonly}
+                />
+                <button
+                  type="button"
+                  className="tbl-btn-icon danger"
+                  onClick={() => updateWithDraft((d) => {
+                    const cur = d.query as ViewQueryStructured;
+                    const arr = ((cur[kw] as string[] | undefined) ?? []).filter((_, i) => i !== idx);
+                    d.query = { ...cur, [kw]: arr.length ? arr : undefined };
+                  })}
+                  disabled={isReadonly}
+                  title="削除"
+                >
+                  <i className="bi bi-trash" />
+                </button>
+              </div>
+            ))}
+            <button
+              type="button"
+              className="tbl-btn tbl-btn-ghost tbl-btn-sm"
+              onClick={() => updateWithDraft((d) => {
+                const cur = d.query as ViewQueryStructured;
+                const arr = [...((cur[kw] as string[] | undefined) ?? []), ""];
+                d.query = { ...cur, [kw]: arr };
+              })}
+              disabled={isReadonly}
+            >
+              <i className="bi bi-plus-lg" /> {label} 追加
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/view-definition/internal/Level3QueryEditor.tsx
+++ b/frontend/src/components/view-definition/internal/Level3QueryEditor.tsx
@@ -1,0 +1,132 @@
+/**
+ * Level3QueryEditor — Level 3 (Raw SQL + parameterRefs) クエリ編集 (Phase-4 抽出)
+ *
+ * raw SQL textarea + parameterRefs テーブル。式補間は ProcessFlow と同じ
+ * (`@var` / `@conv.*` / `@env.*` / `@param.<name>`)。
+ */
+import type {
+  ViewDefinition,
+  ViewQueryRawSql,
+  ViewQueryParameterRef,
+} from "../../../types/v3/view-definition";
+import type { Identifier } from "../../../types/v3/common";
+import type { FieldType } from "../../../types/v3";
+import { FIELD_TYPE_OPTIONS } from "./viewDefinitionConstants";
+
+interface Props {
+  viewDefinition: ViewDefinition;
+  isReadonly: boolean;
+  updateWithDraft: (fn: (s: ViewDefinition) => void) => void;
+  updateSilentWithDraft: (fn: (s: ViewDefinition) => void) => void;
+  commit: () => void;
+}
+
+export function Level3QueryEditor({
+  viewDefinition,
+  isReadonly,
+  updateWithDraft,
+  updateSilentWithDraft,
+  commit,
+}: Props) {
+  const rq = (viewDefinition.query as ViewQueryRawSql | undefined) ?? { sql: "", parameterRefs: [] };
+  return (
+    <div className="vd-query-rawsql">
+      <div className="vd-query-block">
+        <div className="vd-query-block-title">SQL</div>
+        <textarea
+          value={rq.sql ?? ""}
+          onChange={(e) => updateSilentWithDraft((d) => {
+            const cur = (d.query as ViewQueryRawSql | undefined) ?? { sql: "", parameterRefs: [] };
+            d.query = { ...cur, sql: e.target.value };
+          })}
+          onBlur={() => { if (!isReadonly) commit(); }}
+          placeholder={"WITH ranked AS (\n  SELECT id, name, ROW_NUMBER() OVER (PARTITION BY category ORDER BY price DESC) AS rn FROM products\n)\nSELECT * FROM ranked WHERE rn <= @param.topN"}
+          rows={12}
+          className="vd-query-sql-textarea"
+          disabled={isReadonly}
+        />
+        <small className="vd-editor-level-hint">
+          式補間は ProcessFlow と同じく <code>@&lt;var&gt;</code> / <code>@conv.*</code> / <code>@env.*</code> / <code>@param.&lt;name&gt;</code>。
+        </small>
+      </div>
+
+      <div className="vd-query-block">
+        <div className="vd-query-block-title">parameterRefs</div>
+        {(rq.parameterRefs ?? []).map((p, pi) => (
+          <div key={pi} className="vd-query-fragment-row">
+            <input
+              type="text"
+              value={p.name as string}
+              onChange={(e) => updateSilentWithDraft((d) => {
+                const cur = d.query as ViewQueryRawSql;
+                const params = [...(cur.parameterRefs ?? [])];
+                params[pi] = { ...params[pi], name: e.target.value as Identifier };
+                d.query = { ...cur, parameterRefs: params };
+              })}
+              onBlur={() => { if (!isReadonly) commit(); }}
+              placeholder="paramName"
+              className="vd-query-fragment-input"
+              disabled={isReadonly}
+            />
+            <select
+              value={typeof p.fieldType === "string" ? p.fieldType : "string"}
+              onChange={(e) => updateWithDraft((d) => {
+                const cur = d.query as ViewQueryRawSql;
+                const params = [...(cur.parameterRefs ?? [])];
+                params[pi] = { ...params[pi], fieldType: e.target.value as FieldType };
+                d.query = { ...cur, parameterRefs: params };
+              })}
+              disabled={isReadonly}
+            >
+              {FIELD_TYPE_OPTIONS.map((ft) => (
+                <option key={ft} value={ft}>{ft}</option>
+              ))}
+            </select>
+            <input
+              type="text"
+              value={p.description ?? ""}
+              onChange={(e) => updateSilentWithDraft((d) => {
+                const cur = d.query as ViewQueryRawSql;
+                const params = [...(cur.parameterRefs ?? [])];
+                params[pi] = { ...params[pi], description: e.target.value || undefined };
+                d.query = { ...cur, parameterRefs: params };
+              })}
+              onBlur={() => { if (!isReadonly) commit(); }}
+              placeholder="description (任意)"
+              className="vd-query-fragment-input vd-query-fragment-input--full"
+              disabled={isReadonly}
+            />
+            <button
+              type="button"
+              className="tbl-btn-icon danger"
+              onClick={() => updateWithDraft((d) => {
+                const cur = d.query as ViewQueryRawSql;
+                const params = (cur.parameterRefs ?? []).filter((_, i) => i !== pi);
+                d.query = { ...cur, parameterRefs: params.length ? params : undefined };
+              })}
+              disabled={isReadonly}
+              title="削除"
+            >
+              <i className="bi bi-trash" />
+            </button>
+          </div>
+        ))}
+        <button
+          type="button"
+          className="tbl-btn tbl-btn-ghost tbl-btn-sm"
+          onClick={() => updateWithDraft((d) => {
+            const cur = (d.query as ViewQueryRawSql | undefined) ?? { sql: "" };
+            const newParam: ViewQueryParameterRef = {
+              name: "" as Identifier,
+              fieldType: "string" as FieldType,
+            };
+            d.query = { ...cur, parameterRefs: [...(cur.parameterRefs ?? []), newParam] };
+          })}
+          disabled={isReadonly}
+        >
+          <i className="bi bi-plus-lg" /> parameterRef 追加
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/view-definition/internal/MiscSection.tsx
+++ b/frontend/src/components/view-definition/internal/MiscSection.tsx
@@ -1,0 +1,74 @@
+/**
+ * MiscSection — Section 6: その他 (Phase-4 抽出)
+ *
+ * pageSize / groupBy 等の補助オプション。
+ */
+import type { ViewDefinition } from "../../../types/v3/view-definition";
+import type { Identifier } from "../../../types/v3/common";
+import type { ViewDefinitionIssue } from "../../../schemas/viewDefinitionValidator";
+import { IssueHints } from "./IssueHints";
+
+interface Props {
+  viewDefinition: ViewDefinition;
+  vdId: string;
+  columnNames: string[];
+  isReadonly: boolean;
+  updateWithDraft: (fn: (s: ViewDefinition) => void) => void;
+  getIssues: (path: string) => ViewDefinitionIssue[];
+}
+
+export function MiscSection({
+  viewDefinition,
+  vdId,
+  columnNames,
+  isReadonly,
+  updateWithDraft,
+  getIssues,
+}: Props) {
+  const groupByPath = `ViewDefinition[${vdId}].groupBy`;
+  return (
+    <section className="seq-editor-section">
+      <h3 className="seq-editor-section-title">その他</h3>
+      <div className="seq-editor-grid">
+
+        {/* pageSize */}
+        <label className="tbl-field">
+          <span>ページサイズ <small>(1..1000)</small></span>
+          <input
+            type="number"
+            value={viewDefinition.pageSize ?? ""}
+            min={1}
+            max={1000}
+            onChange={(e) => {
+              const v = e.target.value ? Number(e.target.value) : undefined;
+              updateWithDraft((d) => { d.pageSize = v; });
+            }}
+            placeholder="20"
+            className="vd-editor-number-input"
+            disabled={isReadonly}
+          />
+        </label>
+
+        {/* groupBy */}
+        <div className="tbl-field">
+          <span>groupBy</span>
+          <select
+            value={viewDefinition.groupBy ?? ""}
+            onChange={(e) => updateWithDraft((d) => {
+              d.groupBy = (e.target.value || undefined) as Identifier | undefined;
+            })}
+            className={getIssues(groupByPath).length > 0 ? "input-error" : undefined}
+            disabled={isReadonly}
+          >
+            <option value="">— なし —</option>
+            {columnNames.map((cn) => (
+              <option key={cn} value={cn}>{cn}</option>
+            ))}
+          </select>
+          <IssueHints issues={getIssues(groupByPath)} />
+        </div>
+
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/view-definition/internal/SortDefaultsSection.tsx
+++ b/frontend/src/components/view-definition/internal/SortDefaultsSection.tsx
@@ -1,0 +1,106 @@
+/**
+ * SortDefaultsSection — Section 4: sortDefaults 編集 (Phase-4 抽出)
+ *
+ * 既定ソート順を columnName + order (asc/desc) で複数指定。
+ */
+import type { ViewDefinition, SortSpec } from "../../../types/v3/view-definition";
+import type { Identifier } from "../../../types/v3/common";
+import type { ViewDefinitionIssue } from "../../../schemas/viewDefinitionValidator";
+import { IssueHints } from "./IssueHints";
+
+interface Props {
+  viewDefinition: ViewDefinition;
+  columnNames: string[];
+  isReadonly: boolean;
+  addSortSpec: () => void;
+  removeSortSpec: (si: number) => void;
+  updateSortSpec: <K extends keyof SortSpec>(si: number, field: K, value: SortSpec[K]) => void;
+  sortPath: (si: number, field?: string) => string;
+  getIssues: (path: string) => ViewDefinitionIssue[];
+}
+
+export function SortDefaultsSection({
+  viewDefinition,
+  columnNames,
+  isReadonly,
+  addSortSpec,
+  removeSortSpec,
+  updateSortSpec,
+  sortPath,
+  getIssues,
+}: Props) {
+  const specs = viewDefinition.sortDefaults ?? [];
+  return (
+    <section className="seq-editor-section">
+      <h3 className="seq-editor-section-title">
+        既定ソート順
+        <span className="vd-editor-col-count">({specs.length} 件)</span>
+      </h3>
+
+      {specs.length > 0 && (
+        <table className="vd-editor-sub-table">
+          <thead>
+            <tr>
+              <th>カラム名</th>
+              <th>順序</th>
+              <th>操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            {specs.map((spec, si) => {
+              const siIssues = getIssues(sortPath(si));
+              return (
+                <tr key={si} className={siIssues.some((i) => i.severity === "error") ? "vd-col-row--error" : undefined}>
+                  <td>
+                    <select
+                      value={spec.columnName as string}
+                      onChange={(e) => updateSortSpec(si, "columnName", e.target.value as Identifier)}
+                      className={siIssues.length > 0 ? "input-error" : undefined}
+                      disabled={isReadonly}
+                    >
+                      <option value="">— カラムを選択 —</option>
+                      {columnNames.map((cn) => (
+                        <option key={cn} value={cn}>{cn}</option>
+                      ))}
+                    </select>
+                    <IssueHints issues={siIssues} />
+                  </td>
+                  <td>
+                    <select
+                      value={spec.order}
+                      onChange={(e) => updateSortSpec(si, "order", e.target.value as "asc" | "desc")}
+                      disabled={isReadonly}
+                    >
+                      <option value="asc">asc (昇順)</option>
+                      <option value="desc">desc (降順)</option>
+                    </select>
+                  </td>
+                  <td>
+                    <button
+                      type="button"
+                      className="tbl-btn-icon danger"
+                      onClick={() => removeSortSpec(si)}
+                      title="削除"
+                      disabled={isReadonly}
+                    >
+                      <i className="bi bi-trash" />
+                    </button>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+
+      <button
+        type="button"
+        className="tbl-btn tbl-btn-ghost vd-editor-add-row-btn"
+        onClick={addSortSpec}
+        disabled={isReadonly}
+      >
+        <i className="bi bi-plus-lg" /> ソート条件追加
+      </button>
+    </section>
+  );
+}

--- a/frontend/src/components/view-definition/internal/useViewDefinitionTables.ts
+++ b/frontend/src/components/view-definition/internal/useViewDefinitionTables.ts
@@ -1,0 +1,82 @@
+/**
+ * ViewDefinitionEditor 用 — テーブル取得 hooks (Phase-4 抽出)
+ *
+ * - useTablesForValidator: validator 入力用 (Table 全フィールド)
+ * - useTableOptions: cascade 選択肢生成用 (id / name / columns subset)
+ *
+ * 両者とも `tableStore.onTableChange` + `mcpBridge` broadcast を購読し、
+ * 他クライアントの編集や同一クライアント内 SPA 遷移にも追従する。
+ */
+import { useEffect, useState } from "react";
+import type { TableEntry, Table } from "../../../types/v3";
+import { listTables, loadTable, onTableChange } from "../../../store/tableStore";
+import { mcpBridge } from "../../../mcp/mcpBridge";
+import type { TableDefinitionForView } from "../../../schemas/viewDefinitionValidator";
+
+export function useTablesForValidator(): TableDefinitionForView[] {
+  const [tables, setTables] = useState<TableDefinitionForView[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    async function refresh(): Promise<void> {
+      const entries = await listTables();
+      const all = await Promise.all(entries.map((e: TableEntry) => loadTable(e.id)));
+      const valid = all.filter((t): t is Table => t !== null);
+      if (!cancelled) {
+        // Table is shape-compatible with TableDefinitionForView (id / name / physicalName / columns)
+        setTables(valid as unknown as TableDefinitionForView[]);
+      }
+    }
+    refresh().catch(console.error);
+    // #1001: 同一 client 内 SPA 遷移先での table 変更通知 + 他 client (mcpBridge broadcast) 両カバー
+    const unsubLocal = onTableChange(() => { refresh().catch(console.error); });
+    const unsubBroadcast = mcpBridge.onBroadcast("tableChanged", () => { refresh().catch(console.error); });
+    return () => {
+      cancelled = true;
+      unsubLocal();
+      unsubBroadcast();
+    };
+  }, []);
+  return tables;
+}
+
+export interface TableOption {
+  id: string;
+  name: string;
+  columns: Array<{ id: string; name: string; physicalName: string }>;
+}
+
+export function useTableOptions(): TableOption[] {
+  const [options, setOptions] = useState<TableOption[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    async function refresh(): Promise<void> {
+      const entries = await listTables();
+      const tables = await Promise.all(entries.map((e: TableEntry) => loadTable(e.id)));
+      if (!cancelled) {
+        setOptions(
+          tables
+            .filter((t): t is Table => t !== null)
+            .map((t) => ({
+              id: t.id,
+              name: t.name ?? t.physicalName ?? t.id,
+              columns: (t.columns ?? []).map((c) => ({
+                id: c.id,
+                name: c.name ?? c.physicalName ?? c.id,
+                physicalName: c.physicalName ?? c.id,
+              })),
+            })),
+        );
+      }
+    }
+    refresh().catch(console.error);
+    // #1001: 同一 client 内 SPA 遷移先での table 変更通知 + 他 client (mcpBridge broadcast) 両カバー
+    const unsubLocal = onTableChange(() => { refresh().catch(console.error); });
+    const unsubBroadcast = mcpBridge.onBroadcast("tableChanged", () => { refresh().catch(console.error); });
+    return () => {
+      cancelled = true;
+      unsubLocal();
+      unsubBroadcast();
+    };
+  }, []);
+  return options;
+}

--- a/frontend/src/components/view-definition/internal/view-definition-editors.test.tsx
+++ b/frontend/src/components/view-definition/internal/view-definition-editors.test.tsx
@@ -1,0 +1,513 @@
+// Phase-4 (#1145): ViewDefinitionEditor 分割 — sub-editor / section の最小 rendering test。
+//
+// 各 sub-component は ViewDefinitionEditor.tsx から純粋に抽出されたもの。本テストは
+// (1) crash せず render される (2) Level 別 / Section 別の固有要素が DOM に出る、を確認する。
+
+import { describe, expect, it, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import type { ViewDefinition } from "../../../types/v3/view-definition";
+import { BasicInfoSection } from "./BasicInfoSection";
+import { Level1QueryEditor } from "./Level1QueryEditor";
+import { Level2QueryEditor } from "./Level2QueryEditor";
+import { Level3QueryEditor } from "./Level3QueryEditor";
+import { ColumnsSection } from "./ColumnsSection";
+import { SortDefaultsSection } from "./SortDefaultsSection";
+import { FilterDefaultsSection } from "./FilterDefaultsSection";
+import { MiscSection } from "./MiscSection";
+import { IssueHints } from "./IssueHints";
+import { isBuiltinKind, FIELD_TYPE_OPTIONS, FILTER_OPERATORS } from "./viewDefinitionConstants";
+import type { TableOption } from "./useViewDefinitionTables";
+
+// ── 共通ヘルパ ─────────────────────────────────────────────────────
+
+const noop = () => {};
+const noopGetIssues = () => [];
+
+function buildVd(overrides: Partial<ViewDefinition> = {}): ViewDefinition {
+  return {
+    id: "v1",
+    name: "テストビュー",
+    kind: "list",
+    sourceTableId: "t1",
+    columns: [],
+    ...overrides,
+  } as ViewDefinition;
+}
+
+const tableOptions: TableOption[] = [
+  {
+    id: "t1",
+    name: "顧客",
+    columns: [
+      { id: "c1", name: "id", physicalName: "id" },
+      { id: "c2", name: "name", physicalName: "name" },
+    ],
+  },
+  {
+    id: "t2",
+    name: "注文",
+    columns: [
+      { id: "c3", name: "amount", physicalName: "amount" },
+    ],
+  },
+];
+
+// ── viewDefinitionConstants ────────────────────────────────────────
+
+describe("viewDefinitionConstants", () => {
+  it("FIELD_TYPE_OPTIONS は最低 string / integer を含む", () => {
+    expect(FIELD_TYPE_OPTIONS).toContain("string");
+    expect(FIELD_TYPE_OPTIONS).toContain("integer");
+  });
+
+  it("FILTER_OPERATORS は eq / contains を含む", () => {
+    expect(FILTER_OPERATORS).toContain("eq");
+    expect(FILTER_OPERATORS).toContain("contains");
+  });
+
+  it("isBuiltinKind は list/detail/kanban/calendar のみ true", () => {
+    expect(isBuiltinKind("list")).toBe(true);
+    expect(isBuiltinKind("detail")).toBe(true);
+    expect(isBuiltinKind("kanban")).toBe(true);
+    expect(isBuiltinKind("calendar")).toBe(true);
+    expect(isBuiltinKind("retail:custom")).toBe(false);
+  });
+});
+
+// ── IssueHints ─────────────────────────────────────────────────────
+
+describe("IssueHints", () => {
+  it("issues が空なら何も描画しない", () => {
+    const { container } = render(<IssueHints issues={[]} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("error severity の issue を描画する", () => {
+    const { container } = render(
+      <IssueHints
+        issues={[{ severity: "error", code: "TEST", path: "x", message: "テストエラー" }]}
+      />,
+    );
+    expect(container.querySelector(".vd-editor-issue--error")).not.toBeNull();
+    expect(container.textContent).toContain("テストエラー");
+  });
+});
+
+// ── BasicInfoSection ───────────────────────────────────────────────
+
+describe("BasicInfoSection", () => {
+  it("name / kind select / Level radio が描画される", () => {
+    const vd = buildVd({ name: "顧客一覧" });
+    const { container } = render(
+      <BasicInfoSection
+        viewDefinition={vd}
+        currentLevel={1}
+        tableOptions={tableOptions}
+        isReadonly={false}
+        kindExtMode={false}
+        setKindExtMode={noop}
+        updateWithDraft={noop}
+        updateSilentWithDraft={noop}
+        commit={noop}
+      />,
+    );
+    // 表示名 input
+    const nameInput = container.querySelector('input[placeholder="顧客一覧"]') as HTMLInputElement;
+    expect(nameInput).not.toBeNull();
+    expect(nameInput.value).toBe("顧客一覧");
+    // kind select (builtin mode)
+    const kindSelect = container.querySelector("select");
+    expect(kindSelect).not.toBeNull();
+    // Level radio 3 個
+    const radios = container.querySelectorAll('input[name="vd-level"]');
+    expect(radios.length).toBe(3);
+  });
+
+  it("kindExtMode=true で input が出る", () => {
+    const vd = buildVd({ kind: "retail:custom" });
+    const { container } = render(
+      <BasicInfoSection
+        viewDefinition={vd}
+        currentLevel={1}
+        tableOptions={tableOptions}
+        isReadonly={false}
+        kindExtMode={true}
+        setKindExtMode={noop}
+        updateWithDraft={noop}
+        updateSilentWithDraft={noop}
+        commit={noop}
+      />,
+    );
+    const input = container.querySelector('input[placeholder^="namespace:kindName"]') as HTMLInputElement;
+    expect(input).not.toBeNull();
+    expect(input.value).toBe("retail:custom");
+  });
+});
+
+// ── Level1QueryEditor ──────────────────────────────────────────────
+
+describe("Level1QueryEditor", () => {
+  it("ソーステーブル select が描画され、tableOptions が並ぶ", () => {
+    const vd = buildVd({ sourceTableId: "t1" });
+    const { container } = render(
+      <Level1QueryEditor
+        viewDefinition={vd}
+        vdId="v1"
+        tableOptions={tableOptions}
+        isReadonly={false}
+        updateWithDraft={noop}
+        getIssues={noopGetIssues}
+      />,
+    );
+    const select = container.querySelector("select") as HTMLSelectElement;
+    expect(select).not.toBeNull();
+    expect(select.value).toBe("t1");
+    expect(select.options.length).toBe(1 + tableOptions.length);
+  });
+
+  it("テーブル変更で updateWithDraft が呼ばれる", () => {
+    const vd = buildVd({ sourceTableId: "t1" });
+    const updateWithDraft = vi.fn();
+    const { container } = render(
+      <Level1QueryEditor
+        viewDefinition={vd}
+        vdId="v1"
+        tableOptions={tableOptions}
+        isReadonly={false}
+        updateWithDraft={updateWithDraft}
+        getIssues={noopGetIssues}
+      />,
+    );
+    const select = container.querySelector("select") as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "t2" } });
+    expect(updateWithDraft).toHaveBeenCalledOnce();
+  });
+});
+
+// ── Level2QueryEditor ──────────────────────────────────────────────
+
+describe("Level2QueryEditor", () => {
+  it("FROM / JOINS / WHERE 等の block が描画される", () => {
+    const vd = buildVd({
+      query: { from: { tableId: "t1" as never, alias: "c" }, joins: [], where: [] } as never,
+      sourceTableId: undefined,
+    });
+    const { container } = render(
+      <Level2QueryEditor
+        viewDefinition={vd}
+        vdId="v1"
+        tableOptions={tableOptions}
+        isReadonly={false}
+        updateWithDraft={noop}
+        updateSilentWithDraft={noop}
+        commit={noop}
+        getIssues={noopGetIssues}
+      />,
+    );
+    // FROM ラベル
+    expect(container.textContent).toContain("FROM");
+    // JOIN block タイトル
+    expect(container.textContent).toContain("JOINS");
+    // WHERE / GROUP BY / HAVING / ORDER BY block タイトル
+    expect(container.textContent).toContain("WHERE");
+    expect(container.textContent).toContain("GROUP BY");
+    expect(container.textContent).toContain("HAVING");
+    expect(container.textContent).toContain("ORDER BY");
+  });
+
+  it("JOIN 追加ボタン click で updateWithDraft が呼ばれる", () => {
+    const vd = buildVd({
+      query: { from: { tableId: "t1" as never, alias: "c" }, joins: [] } as never,
+      sourceTableId: undefined,
+    });
+    const updateWithDraft = vi.fn();
+    const { container } = render(
+      <Level2QueryEditor
+        viewDefinition={vd}
+        vdId="v1"
+        tableOptions={tableOptions}
+        isReadonly={false}
+        updateWithDraft={updateWithDraft}
+        updateSilentWithDraft={noop}
+        commit={noop}
+        getIssues={noopGetIssues}
+      />,
+    );
+    const addJoinBtn = Array.from(container.querySelectorAll("button")).find((b) =>
+      b.textContent?.includes("JOIN 追加"),
+    );
+    expect(addJoinBtn).not.toBeUndefined();
+    fireEvent.click(addJoinBtn!);
+    expect(updateWithDraft).toHaveBeenCalledOnce();
+  });
+});
+
+// ── Level3QueryEditor ──────────────────────────────────────────────
+
+describe("Level3QueryEditor", () => {
+  it("SQL textarea + parameterRefs ブロックが描画される", () => {
+    const vd = buildVd({
+      query: { sql: "SELECT * FROM products", parameterRefs: [] } as never,
+      sourceTableId: undefined,
+    });
+    const { container } = render(
+      <Level3QueryEditor
+        viewDefinition={vd}
+        isReadonly={false}
+        updateWithDraft={noop}
+        updateSilentWithDraft={noop}
+        commit={noop}
+      />,
+    );
+    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+    expect(textarea).not.toBeNull();
+    expect(textarea.value).toBe("SELECT * FROM products");
+    expect(container.textContent).toContain("parameterRefs");
+  });
+
+  it("parameterRef 追加ボタンが updateWithDraft を呼ぶ", () => {
+    const vd = buildVd({
+      query: { sql: "", parameterRefs: [] } as never,
+      sourceTableId: undefined,
+    });
+    const updateWithDraft = vi.fn();
+    const { container } = render(
+      <Level3QueryEditor
+        viewDefinition={vd}
+        isReadonly={false}
+        updateWithDraft={updateWithDraft}
+        updateSilentWithDraft={noop}
+        commit={noop}
+      />,
+    );
+    const addBtn = Array.from(container.querySelectorAll("button")).find((b) =>
+      b.textContent?.includes("parameterRef 追加"),
+    );
+    expect(addBtn).not.toBeUndefined();
+    fireEvent.click(addBtn!);
+    expect(updateWithDraft).toHaveBeenCalledOnce();
+  });
+});
+
+// ── ColumnsSection ─────────────────────────────────────────────────
+
+describe("ColumnsSection", () => {
+  const colPath = (ci: number, colName: string, field?: string) => {
+    const base = `ViewDefinition[v1].columns[${ci}=${colName}]`;
+    return field ? `${base}.${field}` : base;
+  };
+
+  it("columns 件数表示 + 追加ボタンが描画される (空)", () => {
+    const vd = buildVd({ columns: [] });
+    const { container } = render(
+      <ColumnsSection
+        viewDefinition={vd}
+        currentLevel={1}
+        tableOptions={tableOptions}
+        inScopeTables={[]}
+        colRefTableIds={{}}
+        isReadonly={false}
+        addColumn={noop}
+        removeColumn={noop}
+        moveColumn={noop}
+        updateColumn={noop}
+        setColRefTable={noop}
+        setColRefColumn={noop}
+        updateSilentWithDraft={noop}
+        updateWithDraft={noop}
+        commit={noop}
+        colPath={colPath}
+        getIssues={noopGetIssues}
+      />,
+    );
+    expect(container.textContent).toContain("(0 件)");
+    const addBtn = Array.from(container.querySelectorAll("button")).find((b) =>
+      b.textContent?.includes("カラム追加"),
+    );
+    expect(addBtn).not.toBeUndefined();
+  });
+
+  it("カラム追加ボタン click で addColumn が呼ばれる", () => {
+    const vd = buildVd({ columns: [] });
+    const addColumn = vi.fn();
+    const { container } = render(
+      <ColumnsSection
+        viewDefinition={vd}
+        currentLevel={1}
+        tableOptions={tableOptions}
+        inScopeTables={[]}
+        colRefTableIds={{}}
+        isReadonly={false}
+        addColumn={addColumn}
+        removeColumn={noop}
+        moveColumn={noop}
+        updateColumn={noop}
+        setColRefTable={noop}
+        setColRefColumn={noop}
+        updateSilentWithDraft={noop}
+        updateWithDraft={noop}
+        commit={noop}
+        colPath={colPath}
+        getIssues={noopGetIssues}
+      />,
+    );
+    const addBtn = Array.from(container.querySelectorAll("button")).find((b) =>
+      b.textContent?.includes("カラム追加"),
+    );
+    fireEvent.click(addBtn!);
+    expect(addColumn).toHaveBeenCalledOnce();
+  });
+
+  it("Level 3 では 参照テーブル / 参照カラム 列が消える", () => {
+    const vd = buildVd({
+      columns: [{ name: "x" as never, type: "string" }] as never,
+    });
+    const { container } = render(
+      <ColumnsSection
+        viewDefinition={vd}
+        currentLevel={3}
+        tableOptions={tableOptions}
+        inScopeTables={[]}
+        colRefTableIds={{}}
+        isReadonly={false}
+        addColumn={noop}
+        removeColumn={noop}
+        moveColumn={noop}
+        updateColumn={noop}
+        setColRefTable={noop}
+        setColRefColumn={noop}
+        updateSilentWithDraft={noop}
+        updateWithDraft={noop}
+        commit={noop}
+        colPath={colPath}
+        getIssues={noopGetIssues}
+      />,
+    );
+    const ths = Array.from(container.querySelectorAll("th")).map((th) => th.textContent ?? "");
+    expect(ths.some((t) => t.includes("参照テーブル"))).toBe(false);
+    expect(ths.some((t) => t.includes("参照カラム"))).toBe(false);
+  });
+});
+
+// ── SortDefaultsSection ────────────────────────────────────────────
+
+describe("SortDefaultsSection", () => {
+  const sortPath = (si: number, field?: string) => {
+    const base = `ViewDefinition[v1].sortDefaults[${si}].columnName`;
+    return field ? `ViewDefinition[v1].sortDefaults[${si}].${field}` : base;
+  };
+
+  it("空の場合は table 非表示 + 追加ボタンのみ", () => {
+    const vd = buildVd({});
+    const { container } = render(
+      <SortDefaultsSection
+        viewDefinition={vd}
+        columnNames={["a", "b"]}
+        isReadonly={false}
+        addSortSpec={noop}
+        removeSortSpec={noop}
+        updateSortSpec={noop}
+        sortPath={sortPath}
+        getIssues={noopGetIssues}
+      />,
+    );
+    expect(container.querySelector("table")).toBeNull();
+    expect(container.textContent).toContain("ソート条件追加");
+  });
+
+  it("ソート条件がある場合 table が描画される", () => {
+    const vd = buildVd({
+      sortDefaults: [{ columnName: "a" as never, order: "asc" }],
+    });
+    const { container } = render(
+      <SortDefaultsSection
+        viewDefinition={vd}
+        columnNames={["a", "b"]}
+        isReadonly={false}
+        addSortSpec={noop}
+        removeSortSpec={noop}
+        updateSortSpec={noop}
+        sortPath={sortPath}
+        getIssues={noopGetIssues}
+      />,
+    );
+    expect(container.querySelector("table")).not.toBeNull();
+    expect(container.textContent).toContain("(1 件)");
+  });
+});
+
+// ── FilterDefaultsSection ──────────────────────────────────────────
+
+describe("FilterDefaultsSection", () => {
+  const filterPath = (fi: number, field: string) =>
+    `ViewDefinition[v1].filterDefaults[${fi}].${field}`;
+
+  it("空の場合は table 非表示 + 追加ボタンのみ", () => {
+    const vd = buildVd({});
+    const { container } = render(
+      <FilterDefaultsSection
+        viewDefinition={vd}
+        columnNames={["a", "b"]}
+        isReadonly={false}
+        addFilterSpec={noop}
+        removeFilterSpec={noop}
+        updateFilterSpec={noop}
+        updateSilentWithDraft={noop}
+        commit={noop}
+        filterPath={filterPath}
+        getIssues={noopGetIssues}
+      />,
+    );
+    expect(container.querySelector("table")).toBeNull();
+    expect(container.textContent).toContain("フィルタ条件追加");
+  });
+
+  it("filter 条件がある場合 演算子 select が描画される", () => {
+    const vd = buildVd({
+      filterDefaults: [{ columnName: "a" as never, operator: "eq" }],
+    });
+    const { container } = render(
+      <FilterDefaultsSection
+        viewDefinition={vd}
+        columnNames={["a", "b"]}
+        isReadonly={false}
+        addFilterSpec={noop}
+        removeFilterSpec={noop}
+        updateFilterSpec={noop}
+        updateSilentWithDraft={noop}
+        commit={noop}
+        filterPath={filterPath}
+        getIssues={noopGetIssues}
+      />,
+    );
+    expect(container.querySelector("table")).not.toBeNull();
+    // FILTER_OPERATORS 全て option として描画
+    const selects = container.querySelectorAll("select");
+    expect(selects.length).toBeGreaterThan(0);
+  });
+});
+
+// ── MiscSection ────────────────────────────────────────────────────
+
+describe("MiscSection", () => {
+  it("pageSize input + groupBy select が描画される", () => {
+    const vd = buildVd({ pageSize: 50, columns: [{ name: "a" as never, type: "string" }] as never });
+    const { container } = render(
+      <MiscSection
+        viewDefinition={vd}
+        vdId="v1"
+        columnNames={["a"]}
+        isReadonly={false}
+        updateWithDraft={noop}
+        getIssues={noopGetIssues}
+      />,
+    );
+    const numberInput = container.querySelector('input[type="number"]') as HTMLInputElement;
+    expect(numberInput).not.toBeNull();
+    expect(numberInput.value).toBe("50");
+    const select = container.querySelector("select") as HTMLSelectElement;
+    expect(select).not.toBeNull();
+    // groupBy select は "なし" + columnNames 1 件
+    expect(select.options.length).toBe(2);
+  });
+});

--- a/frontend/src/components/view-definition/internal/viewDefinitionConstants.ts
+++ b/frontend/src/components/view-definition/internal/viewDefinitionConstants.ts
@@ -1,0 +1,44 @@
+/**
+ * ViewDefinitionEditor 共通定数 (Phase-4 抽出)
+ *
+ * - FIELD_TYPE_OPTIONS: type select の選択肢 (FieldTypePrimitive)
+ * - FILTER_OPERATORS: filter 演算子の選択肢
+ * - KIND_LABELS: builtin viewer 種別の表示ラベル
+ * - JOIN_KIND_OPTIONS: Level 2 structured query の JOIN 種別
+ * - LEVEL_LABELS: Level 1/2/3 の表示ラベル
+ */
+import type {
+  FilterOperator,
+  BuiltinViewDefinitionKind,
+  ViewQueryJoin,
+} from "../../../types/v3/view-definition";
+import type { FieldTypePrimitive } from "../../../types/v3";
+import type { ViewLevel } from "../viewDefinitionLevels";
+
+export const FIELD_TYPE_OPTIONS: FieldTypePrimitive[] = [
+  "string", "integer", "number", "boolean", "date", "datetime", "json",
+];
+
+export const FILTER_OPERATORS: FilterOperator[] = [
+  "eq", "neq", "gt", "gte", "lt", "lte",
+  "contains", "startsWith", "in", "between",
+];
+
+export const KIND_LABELS: Record<BuiltinViewDefinitionKind, string> = {
+  list: "list — 一覧",
+  detail: "detail — 詳細",
+  kanban: "kanban — カンバン",
+  calendar: "calendar — カレンダー",
+};
+
+export const JOIN_KIND_OPTIONS: ViewQueryJoin["kind"][] = ["INNER", "LEFT", "RIGHT", "FULL"];
+
+export const LEVEL_LABELS: Record<ViewLevel, string> = {
+  1: "Level 1 — Simple (1 テーブル)",
+  2: "Level 2 — Structured (joins + where)",
+  3: "Level 3 — Raw SQL (CTE / window 等)",
+};
+
+export function isBuiltinKind(k: string): k is BuiltinViewDefinitionKind {
+  return ["list", "detail", "kanban", "calendar"].includes(k);
+}


### PR DESCRIPTION
## 関連

- Refs #1145 (Phase-4、最終 Phase ではない。最終 Phase で `Closes #1145` を付ける予定)
- spec: 本 PR は仕様変更なし。`schemas/v3/view-definition.v3.schema.json` の DSL 3 level (L1/L2/L3) 構造に沿った UI 責務分離のみ。

## 概要

ViewDefinitionEditor.tsx (旧 81KB / 1766 行) を v3 schema の DSL 3 level 構造に合わせて
責務分離。Level 別 sub-editor + 6 section + 共通 hook/constants/components を
`internal/` 配下に切り出し、本体は state orchestration + section 配置に専念させる。
機能変更なし、純粋なリファクタ。

## 主な変更

**ファイルサイズ**:

| ファイル | 行数 | bytes | 備考 |
|---|---:|---:|---|
| `ViewDefinitionEditor.tsx` (Before) | 1766 | 80783 | — |
| `ViewDefinitionEditor.tsx` (After) | 744 | 30682 | -58% / -50101 bytes |

**新設ファイル** (`frontend/src/components/view-definition/internal/`):

DSL Level 別 sub-editor (#748 / v3 schema 3 level 規範):
- `Level1QueryEditor.tsx` — Level 1 (Simple, sourceTableId のみ)
- `Level2QueryEditor.tsx` — Level 2 (Structured: from + joins + where/groupBy/having/orderBy)
- `Level3QueryEditor.tsx` — Level 3 (Raw SQL textarea + parameterRefs テーブル)

Section 別 component:
- `BasicInfoSection.tsx` — Section 1 (id / name / description / kind / Level radio / maturity)
- `ColumnsSection.tsx` — Section 3 (columns 編集テーブル + 列ごとの issue 表示)
- `SortDefaultsSection.tsx` — Section 4 (既定ソート順テーブル)
- `FilterDefaultsSection.tsx` — Section 5 (初期フィルタテーブル)
- `MiscSection.tsx` — Section 6 (pageSize / groupBy)

共通:
- `IssueHints.tsx` — issue inline 表示ヘルパー
- `useViewDefinitionTables.ts` — `useTablesForValidator` / `useTableOptions` hooks + `TableOption` 型
- `viewDefinitionConstants.ts` — `FIELD_TYPE_OPTIONS` / `FILTER_OPERATORS` / `KIND_LABELS` / `JOIN_KIND_OPTIONS` / `LEVEL_LABELS` / `isBuiltinKind`

テスト:
- `view-definition-editors.test.tsx` — 全 sub-editor / section に rendering + 主要 callback test 21 件 (定数 / IssueHints 4 件、各 section 2-3 件)

**親コンポーネント側に残した責務**:

- 編集セッション / draft 管理 (`useEditSession` / `useResourceEditor` / `useSessionUrlSync`)
- `updateWithDraft` / `updateSilentWithDraft` / `commit` / `handleSave` / `handleDiscard` 等 lifecycle
- `colRefTableIds` state とそれを参照する column 操作 (`addColumn` / `removeColumn` / `moveColumn` / `setColRefTable` / `setColRefColumn`) — 親 state に依存するため Phase-3 InspectorPanel と同パターンで props 経由
- `inScopeTables` / `issuesByPath` / `colPath` / `sortPath` / `filterPath` / `getIssues` (validator integration 派生 memo)
- 各種 dialog (Discard / ForceRelease / Resume / SaveConflict / ForcedOut / AfterForceUnlock)

## 仕様逐条突合 (自己申告)

ViewDefinitionEditor.tsx ヘッダコメント 6 セクション構成に対する逐条突合:

- Section 1 (基本情報: id / name / description / kind / Level 切替 / maturity) → `internal/BasicInfoSection.tsx:39-176` ✓
- Section 2 — Level 1 (sourceTableId) → `internal/Level1QueryEditor.tsx:21-49` ✓
- Section 2 — Level 2 (Structured: from + joins + where/groupBy/having/orderBy) → `internal/Level2QueryEditor.tsx:33-271` ✓
- Section 2 — Level 3 (Raw SQL: sql + parameterRefs) → `internal/Level3QueryEditor.tsx:23-130` ✓
- Section 3 (columns 編集テーブル + Level に応じて tableColumnRef 列を切替) → `internal/ColumnsSection.tsx:51-351` ✓ (Level 3 で参照テーブル/カラム列を非表示は `:90-100` / `:138-178`)
- Section 4 (sortDefaults 編集テーブル) → `internal/SortDefaultsSection.tsx:29-106` ✓
- Section 5 (filterDefaults 編集テーブル) → `internal/FilterDefaultsSection.tsx:36-156` ✓
- Section 6 (その他: pageSize / groupBy) → `internal/MiscSection.tsx:26-74` ✓
- リアルタイム validator の inline 表示 (各セクション) → `internal/IssueHints.tsx:10-24` + 各 section の `getIssues(path)` 引き渡し ✓

Phase-4 抽出規範 (#1145 本文):
- DSL 3 level 別 sub-editor (level1 / level2 / level3) ✓ — `internal/Level{1,2,3}QueryEditor.tsx` 3 件
- 共通 wrapper ✓ — `internal/IssueHints.tsx` / `internal/viewDefinitionConstants.ts` / `internal/useViewDefinitionTables.ts`
- 配置パターン (Phase-2/3 `internal/` 配下) ✓ — `frontend/src/components/view-definition/internal/`

## レビューで特に見てほしい箇所

1. **責務境界 — 列操作 (`addColumn` 等) の親側残し判断**
   - `colRefTableIds` (`Record<index, tableId>`) は cascade select の UI state で、ViewDefinition 本体と別に親で保持。
   - column 追加/削除/移動時に index ベースで shift する必要があるため、`setColRefTableIds` を呼ぶ操作は ColumnsSection に移すとさらに props 増えるので親に残した。Phase-3 InspectorPanel と同方針。

2. **Level 3 の columns 動作**
   - Level 3 は `tableColumnRef` を持たないため (raw SQL の列は SQL 側で決まる)、ColumnsSection 内で `currentLevel === 3` 時に参照テーブル/カラム列を非表示にしている。これは元コードのまま (`ViewDefinitionEditor.tsx:1259-1268, 1308-1345` 旧) を `ColumnsSection.tsx:90-100, 138-178` に移植。

3. **`as never` キャスト (test)**
   - `view-definition-editors.test.tsx` は ViewDefinition の branded type (Identifier / TableId 等) を回避するため一部 `as never` を使用。`step-cards.test.tsx` が `@ts-nocheck` を使っているのと同方針だが、ファイル全体 nocheck ではなくキャスト局所化を選択。

4. **circular import チェック**
   - `internal/` 配下から親 `ViewDefinitionEditor.tsx` への import は無し。`internal/` 同士は `viewDefinitionConstants.ts` / `useViewDefinitionTables.ts` / `IssueHints.tsx` を leaf module として参照のみ (相互 import なし)。

## テスト

- Vitest: 2264 件 (新規 21 件、Test Files 165 → 166) — `view-definition-editors.test.tsx` で全 sub-editor / section / constants / IssueHints 網羅
- Playwright: 既存に影響なし (本 PR は機能変更なし、UI セレクタ・テキスト不変)
- MCP E2E: N/A

## UI 影響 / AI smoke test

- [x] UI 影響なし (auto テスト pass のみ — 純粋なリファクタ、機能・selector・DOM 構造変更なし)
- [ ] UI 影響あり

責務分離のみで、生成される DOM は完全同一を意図。class 名 / `data-*` 属性 / placeholder / option 順序 / handler 引数全て元のまま。

## spec 側の不足点 / 提案

N/A — Phase-4 は spec 変更なし。

## レビュー担当への申し送り

**Phase-3 (#1167) と同じ機械的責務分離パターン**:

- Level 1/2/3 sub-editor 分割は v3 schema の DSL 3 level 構造 (`schemas/v3/view-definition.v3.schema.json` の `query` discriminator) に 1:1 で対応。
- 親の handler 群 (`updateWithDraft` / `commit` / `getIssues` 等) を props で 6 section + 3 sub-editor に渡す形にして、render 部の煩雑さを解消。

**目標 30KB ほぼ達成** (-62% / -51KB、最終 30.6KB):

残 30KB は (a) 6 section 配置 + 全 props 配線、(b) 編集セッション / draft 管理、(c) 列操作 (addColumn 等)、(d) dialog 配置、(e) reload/save lifecycle の連結部。これ以上の機械的抽出は props inflation で逆に読みづらくなる (Phase-3 と同じ判断)。

**残 Phase**:

Phase-5: ConventionsCatalogView.tsx 72KB / Phase-6: ScreenItemsView.tsx 64KB / Phase-7: AppShell.tsx routing 抽出 51KB。
本 PR merge 後、次は Phase-5。
