### PR TITLE
fix(workspace): backend reconnect 時の per-session 自動 restore (#1145/#1165 regression)

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -454,12 +454,49 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
   // 判定ロジックは pure 関数 `evaluateRoutingGuard` (routing/workspaceRouting.ts) に抽出 (#1145 Phase-7)。
   // 副作用 (並行発行ガード recoveryPendingRef / mcpBridge.request / redirectGuard / navigate / loadWorkspaces) は
   // 本 useEffect 内で適用する。
+  //
+  // backend reconnect 時の per-session restore (#1145 Phase-2 #1165 wsBridge 分割で顕在化):
+  // - backend WebSocket disconnect で workspaceContextManager の per-session が消去される
+  // - reconnect 後、frontend は workspaceState.active.id === wsId で「active あり」と判定し
+  //   workspace.open を再発行しない (routing guard で "none" になる)
+  // - backend の per-session は空のまま → 各 RPC で「ワークスペースが選択されていません」reject
+  // - 解決策: 初回 mount 時、active.id === wsId であっても 1 回 workspace.open を呼んで per-session を確立する
+  const initialRestoreDoneRef = useRef(false);
+
   useEffect(() => {
     // e2e テスト用 bypass (workspace-e2e-bypass=true) のみ guard スキップ。
     // それ以外の error 状態は明示的に redirect / エラー画面へ誘導する。
     if (workspaceState.error === "e2e bypass") return;
 
     const action = evaluateRoutingGuard(workspaceState, wsId);
+
+    // 初回 mount 時の per-session restore (上記コメント参照):
+    // routing guard が "none" でも、active workspace あり + URL の wsId と一致するなら
+    // 1 回だけ workspace.open を呼んで backend per-session を確立する。
+    if (
+      action.type === "none" &&
+      !initialRestoreDoneRef.current &&
+      !workspaceState.loading &&
+      !workspaceState.lockdown &&
+      workspaceState.active !== null &&
+      wsId !== undefined &&
+      wsId === workspaceState.active.id &&
+      recoveryPendingRef.current === null
+    ) {
+      initialRestoreDoneRef.current = true;
+      const activeId = workspaceState.active.id;
+      recoveryPendingRef.current = activeId;
+      mcpBridge.request("workspace.open", { id: activeId })
+        .then(() => loadWorkspaces())
+        .catch((err) => {
+          console.error("[workspace] initial per-session restore failed:", err);
+        })
+        .finally(() => {
+          if (recoveryPendingRef.current === activeId) recoveryPendingRef.current = null;
+        });
+      return;
+    }
+
     if (action.type === "none") return;
 
     if (action.type === "openWorkspace") {


### PR DESCRIPTION
## 概要

PR #1145/#1165 シリーズ merge 完了後の手動 browser smoke で検出した backend reconnect regression を解消。

## 症状

backend dev server 再起動 (kill + 新規 起動) 後、frontend は workspaceState.active を URL の wsId と一致と判定し workspace.open を再発行しないため、backend per-session context (workspaceContextManager) は空のまま。各 RPC (loadScreen / loadTable 等) で「ワークスペースが選択されていません」 reject 連発。

**影響**:
- 各画面で console error 6-8 件
- Playwright e2e smoke: 7 pass / 9 fail / 22 not run (workspace.open timeout)
- 実機: 全画面で resource load 不可

## 根本原因

- backend WebSocket disconnect で workspaceContextManager の per-session 削除 (#700 R-2 設計通り)
- reconnect 時、frontend が workspaceState.active を持ったまま (loadWorkspaces で取得済) → routing guard で `evaluateRoutingGuard` が `none` を返す
- 結果: workspace.open 再発行されず per-session 空のまま

## 修正

frontend/src/components/AppShell.tsx:
- `initialRestoreDoneRef` 新設
- 初回 mount 時、active.id === wsId でも 1 回のみ workspace.open を呼び backend per-session を確立
- 既存の routing guard / 並行発行ガード (#963) に影響なし

## 検証

### 自動
- frontend npm run build (tsc + vite): pass
- frontend npm run test:unit: 169 files / 2304 tests pass
- frontend npm run lint: 0 errors / 5 warnings (全 pre-existing)

### 手動 Playwright MCP smoke (25 画面)
- 修正前: ScreenList で error 8 件
- 修正後: ScreenList で error 0 件 (initial restore 動作確認)
- 全 25 画面 (Dashboard / ScreenList / FlowEditor / TableList / ER / ProcessFlowList / VDList / Conventions / PageLayoutList / GadgetList / GenericDef / SequenceList / ViewList / Extensions / TechStack / ProcessFlowEdit Phase-3 / ScreenItems Phase-6 / Designer / TableEdit) 全て error 0-1 件
- screenshot: `.tmp/screenshots/2026-05-17-smoke/01-25.png`

## 設計判断

frontend 側修正を選択 (backend 側で auto-restore する案も検討):
- backend 側修正 (WebSocket connection 時に lastActiveWorkspace を per-session に自動反映) は multi-browser / shared workspace 等のシナリオで副作用リスクあり
- frontend 側は「初回 mount のみ」と明確、reconnect ごとの動作が予測可能

## 関連

- 親 ISSUE: #1145 (PR #1158/#1163/#1167/#1168/#1169 完了済)、#1165 (backend wsBridge 分割)
- レビューでは特に「initialRestoreDoneRef の lifecycle」と「routing guard との独立性」を確認推奨