### PR TITLE
chore(devcontainer): containerEnv に TZ=Asia/Tokyo 追加

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -53,6 +53,8 @@
   "containerEnv": {
     "DISABLE_AUTOUPDATER": "1",
     "PLAYWRIGHT_BROWSERS_PATH": "/home/node/.cache/ms-playwright",
+    // タイムゾーン (harmony は日本向けプロダクト、log/date を JST 表示)
+    "TZ": "Asia/Tokyo",
     // WSLg 経由 headed browser 用 (Windows + WSL2 + Docker Desktop)
     // headless mode 時は無視される、他 OS では設定値そのまま入るが mount なしのため使われない
     "DISPLAY": ":0",


### PR DESCRIPTION
## 関連

- Closes #N/A (ISSUE 起票なし — 軽微な単発設定追加、AGENTS.md 鉄則 2 の起票条件 (別機能 / 再設計 / 大規模 / 別チーム) いずれにも該当しない)
- 仕様: N/A

## 概要

Dev Container 内で UTC 表示だった `date` / log / Node.js `Date` 等を JST 表示に統一。harmony は日本向けプロダクトで AGENTS.md / CLAUDE.md / docs / UI も全部日本語のため、team default を JST にする方が実態に合う。

## 主な変更

- `.devcontainer/devcontainer.json:53-62` の `containerEnv` に `"TZ": "Asia/Tokyo"` を 1 行追加 (既存 `DISPLAY` / `WAYLAND_DISPLAY` と同じ場所)

## 仕様逐条突合 (自己申告)

N/A (spec 紐付けなし)

## レビューで特に見てほしい箇所

- 設計判断: 「team-wide で JST default に焼く」vs「個人 override に留める」 — 海外開発者が将来 join する可能性を勘案して議論済、現状 harmony は日本ローカル前提のため team default で commit。海外者が join したら devcontainer.json を 1 行戻すか、個人 `.bashrc` で `export TZ=UTC` 個別 override する形を想定
- 配置場所: `Dockerfile ENV` ではなく `containerEnv` を選択 — image 再 build と `publish-dev-image` での ghcr.io push が不要、devcontainer rebuild だけで反映するため

## テスト

- Vitest: N/A
- Playwright: N/A
- MCP E2E: N/A
- 手動確認: container 内で `TZ=Asia/Tokyo date` が `Mon May 18 11:45:11 PM JST 2026` 表示を確認 (commit 前検証)、tzdata も既に container に存在 (`/usr/share/zoneinfo/Asia/Tokyo`) — Dockerfile 変更不要
- container rebuild 後の `containerEnv` 反映は各自の rebuild 後セッションで確認

## UI 影響 / AI smoke test

- [x] UI 影響なし (設定 1 行追加のみ、frontend / backend コード不変)

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

- host (WSL2) には伝播しない、container 内のみ影響 (host kernel から epoch は継承するが TZ env は process 単位の表示変換)
- `containerEnv` 変更は **container rebuild 必須** (Dev Containers: Rebuild Container)、Dockerfile / image 不変なので image 再 build は不要
- 過去にこの種の team-wide locale 設定を入れた前例があるか分からない場合は議論余地あり — 反対なら revert + 個人 override 方式に切替可能 (1 行 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)