### PR TITLE
fix(validator): AJV 設定を schemas/v3/README.md 規範に揃える + buildHarmonyAjv helper 抽出 (#1188)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "adm-zip": "^0.5.17",
         "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1",
         "htmlparser2": "^12.0.0",
         "ws": "^8.20.0",
         "zod": "^3.23.8"
@@ -22,7 +23,6 @@
         "@types/adm-zip": "^0.5.8",
         "@types/node": "^20.0.0",
         "@types/ws": "^8.5.12",
-        "ajv-formats": "^3.0.1",
         "tsx": "^4.19.0",
         "typescript": "^5.5.0",
         "vitest": "^4.1.4"

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,6 +16,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "adm-zip": "^0.5.17",
     "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1",
     "htmlparser2": "^12.0.0",
     "ws": "^8.20.0",
     "zod": "^3.23.8"
@@ -24,7 +25,6 @@
     "@types/adm-zip": "^0.5.8",
     "@types/node": "^20.0.0",
     "@types/ws": "^8.5.12",
-    "ajv-formats": "^3.0.1",
     "tsx": "^4.19.0",
     "typescript": "^5.5.0",
     "vitest": "^4.1.4"

--- a/backend/src/buildHarmonyAjv.ts
+++ b/backend/src/buildHarmonyAjv.ts
@@ -1,0 +1,30 @@
+/**
+ * buildHarmonyAjv.ts (#1188)
+ *
+ * Harmony 共通 AJV インスタンスを生成する helper。
+ * `schemas/v3/README.md` L302 で documented されている設定を 1 箇所に集約し、
+ * backend 内 validator 群 (projectStorage / workspaceInit) の drift を防ぐ。
+ *
+ * 規範設定:
+ * - `strict: false` — schema 内 description / format 関連の warning を抑制
+ * - `allErrors: true` — 違反を 1 件目で止めず全列挙
+ * - `discriminator: true` — discriminator keyword 付き oneOf (BranchCondition / CdcDestination /
+ *   Constraint / TestPrecondition / TestAssertion 等) で kind 単位の focused エラー報告 (#525 F-4)
+ * - `addFormats(ajv)` — `date-time` / `uri` / `regex` 等の format 検証を有効化
+ *
+ * frontend 側の同名 helper (`frontend/src/utils/buildHarmonyAjv.ts`) と同一設定。
+ * monorepo package boundary 都合で frontend/backend に複製。
+ */
+
+import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+
+export function buildHarmonyAjv(): InstanceType<typeof Ajv2020> {
+  const ajv = new Ajv2020({
+    strict: false,
+    allErrors: true,
+    discriminator: true,
+  });
+  addFormats(ajv);
+  return ajv;
+}

--- a/backend/src/projectStorage.ts
+++ b/backend/src/projectStorage.ts
@@ -19,7 +19,7 @@ import fsSync from "fs";
 import path from "path";
 import crypto from "node:crypto";
 import type { ValidateFunction } from "ajv";
-import Ajv2020 from "ajv/dist/2020.js";
+import { buildHarmonyAjv } from "./buildHarmonyAjv.js";
 import { workspaceContextManager } from "./workspaceState.js";
 
 // ── path 解決ヘルパー (#671 + #700 R-2) ─────────────────────────────────────
@@ -163,10 +163,10 @@ function kindToFileKey(kind: ExtensionFileKind): string {
   }
 }
 
-/** Ajv インスタンスとバリデーター関数のモジュールレベルキャッシュ (#455 / #955 / #1141)。
+/** Ajv インスタンスとバリデーター関数のモジュールレベルキャッシュ (#455 / #955 / #1141 / #1188)。
  * v3 統合 schema (#955) は draft 2020-12 のため Ajv2020 を使用。
- * strict: false は schema 内 description 等の警告を抑制 (workspaceInit.ts:51 と同方針) */
-const _ajv = new Ajv2020({ allErrors: true, strict: false });
+ * 共通設定 (strict: false / allErrors / discriminator / addFormats) は buildHarmonyAjv で集約 (#1188) */
+const _ajv = buildHarmonyAjv();
 let _v3SchemasRegistered = false;
 const _validatorCache = new Map<ExtensionFileKind, ValidateFunction>();
 

--- a/backend/src/workspaceInit.ts
+++ b/backend/src/workspaceInit.ts
@@ -20,7 +20,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
-import Ajv2020 from "ajv/dist/2020.js";
+import { buildHarmonyAjv } from "./buildHarmonyAjv.js";
 import {
   isLockdown,
   setGlobalDefaultPath,
@@ -46,9 +46,9 @@ let _validateHarmonyCache: ((data: unknown) => boolean) & { errors?: unknown } |
 
 async function getHarmonyValidator(): Promise<((data: unknown) => boolean) & { errors?: unknown }> {
   if (_validateHarmonyCache) return _validateHarmonyCache;
-  // strict: false で format 系 ($ref 解決に format 制約が含まれる) の警告を抑制
+  // 共通設定 (strict: false / allErrors / discriminator: true / addFormats) は buildHarmonyAjv で集約 (#1188)
   // schemas/v3/*.schema.json は JSON Schema draft 2020-12 を使用 (Ajv2020 が必要)
-  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  const ajv = buildHarmonyAjv();
   // load schemas: harmony.v3 + common.v3 (referenced via $ref)
   const harmonySchema = JSON.parse(
     await fs.readFile(path.join(SCHEMAS_DIR, "v3", "harmony.v3.schema.json"), "utf-8"),

--- a/frontend/src/schemas/genericDefinitionValidator.ts
+++ b/frontend/src/schemas/genericDefinitionValidator.ts
@@ -8,9 +8,9 @@
  * 親 schema 単独で検証する (briefing 指示に従う)。
  */
 
-import Ajv2020 from "ajv/dist/2020";
-import addFormats from "ajv-formats";
+import type Ajv2020 from "ajv/dist/2020";
 import type { GenericDefinition, GenericDefinitionKind } from "../types/v3";
+import { buildHarmonyAjv } from "../utils/buildHarmonyAjv";
 
 import parentSchema from "../../../schemas/v3/generic-definition.v3.schema.json";
 import dataContractSchema from "../../../schemas/v3/generic-definitions/data-contract.v3.schema.json";
@@ -49,8 +49,7 @@ let _validators: ValidatorMap | null = null;
 function getValidators(): ValidatorMap {
   if (_validators) return _validators;
 
-  const ajv = new Ajv2020({ strict: false, allErrors: true });
-  addFormats(ajv);
+  const ajv = buildHarmonyAjv();
 
   // 親 schema を先に登録して $ref 解決できるようにする
   ajv.addSchema(parentSchema as object);

--- a/frontend/src/utils/buildHarmonyAjv.ts
+++ b/frontend/src/utils/buildHarmonyAjv.ts
@@ -1,0 +1,30 @@
+/**
+ * buildHarmonyAjv.ts (#1188)
+ *
+ * Harmony 共通 AJV インスタンスを生成する helper。
+ * `schemas/v3/README.md` L302 で documented されている設定を 1 箇所に集約し、
+ * frontend 内 validator 群 (validateHarmony / genericDefinitionValidator 等) の drift を防ぐ。
+ *
+ * 規範設定:
+ * - `strict: false` — schema 内 description / format 関連の warning を抑制
+ * - `allErrors: true` — 違反を 1 件目で止めず全列挙
+ * - `discriminator: true` — discriminator keyword 付き oneOf (BranchCondition / CdcDestination /
+ *   Constraint / TestPrecondition / TestAssertion 等) で kind 単位の focused エラー報告 (#525 F-4)
+ * - `addFormats(ajv)` — `date-time` / `uri` / `regex` 等の format 検証を有効化
+ *
+ * 呼出し側は本関数で得た ajv に対し `addSchema()` で必要な schema を登録し、
+ * `compile()` で validator を取り出す。
+ */
+
+import Ajv2020 from "ajv/dist/2020";
+import addFormats from "ajv-formats";
+
+export function buildHarmonyAjv(): InstanceType<typeof Ajv2020> {
+  const ajv = new Ajv2020({
+    strict: false,
+    allErrors: true,
+    discriminator: true,
+  });
+  addFormats(ajv);
+  return ajv;
+}

--- a/frontend/src/utils/validateHarmony.ts
+++ b/frontend/src/utils/validateHarmony.ts
@@ -7,18 +7,17 @@
  * JSON import は resolveJsonModule: true + Vite の JSON plugin で解決される。
  */
 
-import Ajv2020 from "ajv/dist/2020";
-import addFormats from "ajv-formats";
+import type Ajv2020 from "ajv/dist/2020";
 import type { Harmony } from "../types/v3/harmony";
 import commonSchema from "../../../schemas/v3/common.v3.schema.json";
 import harmonySchema from "../../../schemas/v3/harmony.v3.schema.json";
+import { buildHarmonyAjv } from "./buildHarmonyAjv";
 
 let _validateFn: ReturnType<InstanceType<typeof Ajv2020>["compile"]> | null = null;
 
 function getValidateFn(): ReturnType<InstanceType<typeof Ajv2020>["compile"]> {
   if (_validateFn) return _validateFn;
-  const ajv = new Ajv2020({ strict: false, allErrors: true });
-  addFormats(ajv);
+  const ajv = buildHarmonyAjv();
   // common schema を先に登録して $ref 解決できるようにする
   ajv.addSchema(commonSchema as object);
   _validateFn = ajv.compile(harmonySchema as object);


### PR DESCRIPTION
## Summary

- schemas/v3/README.md L302 で documented されている AJV 設定 (\`discriminator: true\` + \`addFormats\`) が、本番 AJV 4 インスタンス全てで未適用だった drift を解消する
- 共通 helper \`buildHarmonyAjv()\` を frontend/backend 双方に新設し、規範設定 1 箇所集約

## 何を変えたか

| 変更 | file:line |
|---|---|
| frontend helper 新設 | frontend/src/utils/buildHarmonyAjv.ts (new) |
| backend helper 新設 | backend/src/buildHarmonyAjv.ts (new) |
| frontend validator A | frontend/src/utils/validateHarmony.ts:18-21 |
| frontend validator B | frontend/src/schemas/genericDefinitionValidator.ts:49-51 |
| backend validator C | backend/src/projectStorage.ts:166-169 |
| backend validator D | backend/src/workspaceInit.ts:47-51 |
| backend deps | backend/package.json: ajv-formats を deps へ昇格 |

## 効果

- **提案 A** (\`discriminator: true\`): BranchCondition / CdcDestination / Constraint / TestPrecondition / TestAssertion oneOf で kind 単位の focused エラー報告に切替 (#525 F-4)
- **提案 B** (backend \`addFormats\`): Timestamp (\`date-time\`) / regex / uri format 制約が backend でも有効化、frontend/backend の非対称 silent pass を解消
- **提案 C** (helper 抽出): 4 箇所の AJV 設定 drift を構造的に防止

## Test plan

- [x] \`cd backend && npm run build\` → tsc OK
- [x] \`cd backend && npm test\` → 516 tests pass
- [x] \`cd frontend && npm run build\` → vite build OK
- [x] frontend validator 関連テスト (validateHarmony.test / genericDefinitionValidator.test / harmony-v3.schema.test) → 26 tests pass
- [x] frontend 全体テスト → 2279 pass / 25 fail (pre-existing: dogfood-1038-structure.test.ts の hardcoded \`/home/hidekatsu/...\` path、PR #1044 由来、#1188 と無関係)

## 既知のスコープ外

- \`frontend/src/test/dogfood/dogfood-1038-structure.test.ts\` の hardcoded path 25 件は別 follow-up で対応予定 (本 PR と無関係の pre-existing)
- 提案 C の helper はあえて 2 file (frontend / backend) 複製。monorepo / package boundary 都合 (ISSUE 本文に明記)

Closes #1188

🤖 Generated with [Claude Code](https://claude.com/claude-code)