### PR TITLE
fix(mcp): backend tools.ts MCP inputSchema を schemas/v3 と整合 (#1187)

### DIFF
--- a/backend/src/handlers/processFlow.ts
+++ b/backend/src/handlers/processFlow.ts
@@ -471,13 +471,14 @@ export const handleProcessFlowTool: ToolHandler = async (name, args, root) => {
     }
 
     case "designer__add_step_note": {
-      if (typeof a.processFlowId !== "string" || typeof a.stepId !== "string" || typeof a.type !== "string" || typeof a.body !== "string") {
-        throw new McpError(ErrorCode.InvalidParams, "processFlowId, stepId, type, body は必須です");
+      // #1187 提案 C: tool param 名を common.v3 Note.kind に合わせて `kind` に統一 (旧 `type` を廃止)
+      if (typeof a.processFlowId !== "string" || typeof a.stepId !== "string" || typeof a.kind !== "string" || typeof a.body !== "string") {
+        throw new McpError(ErrorCode.InvalidParams, "processFlowId, stepId, kind, body は必須です");
       }
       const pf = await readProcessFlow(a.processFlowId, root) as ProcessFlowDoc | null;
       if (!pf) throw new McpError(ErrorCode.InvalidParams, `処理フロー ${a.processFlowId} が見つかりません`);
       try {
-        const res = editAddStepNote(pf, a.stepId, a.type as string, a.body as string);
+        const res = editAddStepNote(pf, a.stepId, a.kind as string, a.body as string);
         await saveAndBroadcast(a.processFlowId, pf, root);
         return { content: [{ type: "text", text: `付箋を追加しました (ID: ${res.id})` }] };
       } catch (e) {

--- a/backend/src/processFlowEdits.test.ts
+++ b/backend/src/processFlowEdits.test.ts
@@ -195,7 +195,8 @@ describe("addStepNote", () => {
     const s = findStep(ag, "s1");
     expect(s?.notes?.length).toBe(1);
     expect(s?.notes?.[0].id).toBe(id);
-    expect(s?.notes?.[0].type).toBe("question");
+    // #1187 提案 C: field 名は common.v3 Note.kind に統一 (旧 `type` は廃止)
+    expect(s?.notes?.[0].kind).toBe("question");
   });
 });
 

--- a/backend/src/processFlowEdits.ts
+++ b/backend/src/processFlowEdits.ts
@@ -20,7 +20,8 @@ type Step = {
   onCommit?: Step[]; // transactionScope: commit 成功後の追加処理
   onRollback?: Step[]; // transactionScope: rollback 後の補償処理
   outcomes?: Record<string, { sideEffects?: Step[] } | undefined>;
-  notes?: Array<{ id: string; type: string; body: string; createdAt: string }>;
+  /** common.v3 Note: kind は assumption/prerequisite/todo/deferred/question。`type` は legacy データ互換 (read-only)。 */
+  notes?: Array<{ id: string; kind: string; type?: string; body: string; createdAt: string }>;
   [k: string]: unknown;
 };
 
@@ -168,14 +169,15 @@ export function setMaturity(
 export function addStepNote(
   ag: ProcessFlowDoc,
   stepId: string,
-  type: string,
+  kind: string,
   body: string,
 ): { id: string } {
+  // #1187 提案 C: common.v3 Note.kind 規約に揃え、field 名を `type` から `kind` に統一
   const s = findStep(ag, stepId);
   if (!s) throw new Error(`step ${stepId} が見つかりません`);
   const note = {
     id: `note-${Date.now()}`,
-    type,
+    kind,
     body,
     createdAt: new Date().toISOString(),
   };

--- a/backend/src/tools.ts
+++ b/backend/src/tools.ts
@@ -170,7 +170,7 @@ export const tools = [
         },
         type: {
           type: "string",
-          enum: ["login","dashboard","list","detail","form","search","confirm","complete","error","modal","other"],
+          enum: ["login","dashboard","list","detail","form","search","confirm","complete","error","modal","wizard","other"],
           description: "画面種別。省略時は other",
         },
         path: {
@@ -218,7 +218,7 @@ export const tools = [
         name: { type: "string", description: "新しい画面名" },
         type: {
           type: "string",
-          enum: ["login","dashboard","list","detail","form","search","confirm","complete","error","modal","other"],
+          enum: ["login","dashboard","list","detail","form","search","confirm","complete","error","modal","wizard","other"],
           description: "新しい画面種別",
         },
         description: { type: "string", description: "新しい説明" },
@@ -932,8 +932,8 @@ export const tools = [
         },
         trigger: {
           type: "string",
-          enum: ["click", "submit", "select", "change", "load", "timer", "other"],
-          description: "トリガー種別",
+          enum: ["click", "submit", "select", "change", "load", "timer", "auto", "other"],
+          description: "トリガー種別 (auto = 画面ロード時に自動実行)",
         },
       },
       required: ["processFlowId", "name", "trigger"],
@@ -956,8 +956,8 @@ export const tools = [
         },
         kind: {
           type: "string",
-          enum: ["validation", "dbAccess", "externalSystem", "commonProcess", "componentCall", "screenTransition", "displayUpdate", "branch", "loop", "loopBreak", "loopContinue", "jump", "compute", "return", "aiCall", "aiAgent", "transactionScope", "workflow", "publishEvent", "subscribeEvent", "other"],
-          description: "v3 ステップ discriminator (#8 / #1141)。組み込み 24 variant + 拡張参照 (`namespace:StepName`)。",
+          enum: ["validation", "dbAccess", "externalSystem", "commonProcess", "componentCall", "screenTransition", "displayUpdate", "branch", "loop", "loopBreak", "loopContinue", "jump", "compute", "return", "aiCall", "aiAgent", "transactionScope", "workflow", "eventPublish", "eventSubscribe", "log", "audit", "closing", "cdc"],
+          description: "v3 ステップ discriminator (#8 / #1141 / #1187)。組み込み 24 variant に完全一致。拡張参照は `namespace:StepName` パターン (例: retail:OrderConfirm) を直接渡す (本 enum は組み込みのみ列挙、拡張は MCP 上は free string で受容)。",
         },
         description: {
           type: "string",
@@ -1036,10 +1036,10 @@ export const tools = [
       properties: {
         processFlowId: { type: "string" },
         stepId: { type: "string" },
-        type: { type: "string", enum: ["assumption", "prerequisite", "todo", "deferred", "question"] },
+        kind: { type: "string", enum: ["assumption", "prerequisite", "todo", "deferred", "question"], description: "Note 種別 (common.v3 Note.kind と同名・同値)" },
         body: { type: "string" },
       },
-      required: ["processFlowId", "stepId", "type", "body"],
+      required: ["processFlowId", "stepId", "kind", "body"],
     },
   },
   {
@@ -1179,7 +1179,7 @@ export const tools = [
       type: "object" as const,
       properties: {
         processFlowId: { type: "string" },
-        kind: { type: "string", enum: ["chat", "attention", "todo", "question"] },
+        kind: { type: "string", enum: ["chat", "attention", "todo", "question"], description: "Marker 種別 (schema の \"validator\" は意図的に除外 — validator marker は validator runtime のみが追加可能、AI 手動付与は想定外)" },
         body: { type: "string" },
         stepId: { type: "string", description: "紐付ける step id (省略時はグループ全体宛)" },
         fieldPath: { type: "string" },


### PR DESCRIPTION
## Summary

- backend/src/tools.ts MCP tool inputSchema が schemas/v3 と乖離していた問題を一括解消
- AI agent (MCP 経由) が schema-valid な操作を一部実行不可だった問題、および schema-invalid な値を書き込めた問題の両方を修正

## 5 提案すべて対応

| 提案 | 変更 | file:line |
|---|---|---|
| A-1 | step kind enum に \`log\` / \`audit\` / \`closing\` / \`cdc\` 追加 | backend/src/tools.ts:959 |
| A-2 | \`publishEvent\` → \`eventPublish\`、\`subscribeEvent\` → \`eventSubscribe\` (schema と逆順だった) | backend/src/tools.ts:959 |
| A-3 | step kind enum から \`\"other\"\` 削除 (schema にない) | backend/src/tools.ts:959 |
| B | ScreenKind enum に \`\"wizard\"\` 追加 (2 sites) | backend/src/tools.ts:173, 221 |
| C | designer__add_step_note: param 名 \`type\` → \`kind\` (Note.kind 規約に整合) | backend/src/tools.ts:1039 + handler + addStepNote() + test |
| D | designer__add_marker: \`\"validator\"\` 除外を description に明記 | backend/src/tools.ts:1182 |
| E | designer__add_action trigger enum に \`\"auto\"\` 追加 | backend/src/tools.ts:935 |

## 提案 C の波及 (field 名 rename)

\`designer__add_step_note\` の MCP param 名 \`type\` を common.v3 Note.kind に揃え \`kind\` に rename:

| file:line | 変更内容 |
|---|---|
| backend/src/tools.ts:1039 | param: \`type\` → \`kind\` |
| backend/src/tools.ts:1042 | required: \`type\` → \`kind\` |
| backend/src/handlers/processFlow.ts:474-480 | \`a.type\` → \`a.kind\` |
| backend/src/processFlowEdits.ts:168 | function signature \`type: string\` → \`kind: string\` |
| backend/src/processFlowEdits.ts:178 | note 構造 field \`type\` → \`kind\` (schema 違反の silent strip を解消) |
| backend/src/processFlowEdits.ts:23 | Step.notes 型: \`kind\` を必須に、\`type\` を legacy 互換 optional に |
| backend/src/processFlowEdits.test.ts:198 | test assertion: \`notes[0].type\` → \`notes[0].kind\` |

## データ移行不要の確認

- \`grep -rn '\"kind\": \"publishEvent\"' examples/\` → 0 件 (現在は eventPublish で記録)
- note.type を持つ既存データ → 0 件 (notes 配列を持つ step 0 件)
- frontend types/v3 → 元から schema 一致 (eventPublish/eventSubscribe/wizard)

## Test plan

- [x] \`cd backend && npm run build\` → tsc OK
- [x] \`cd backend && npm test\` → 516 tests pass
- [x] note.kind 修正テスト (processFlowEdits.test.ts) → pass

## frontend type alignment

frontend/src/types/v3/screen.ts:25 + types/v3/process-flow.ts:851/859 は元から schema 一致。本 PR は backend tools.ts のみ touch、frontend types/action.ts の drift は #1186 で別途対応。

Closes #1187

🤖 Generated with [Claude Code](https://claude.com/claude-code)