### PR TITLE
fix(types): action.ts dead enum 削除 + v3 schema 整合 + JSDoc 同期 (#1186 Phase 1)

### DIFF
--- a/frontend/src/components/process-flow/ExternalSystemCatalogPanel.tsx
+++ b/frontend/src/components/process-flow/ExternalSystemCatalogPanel.tsx
@@ -12,7 +12,8 @@ interface Props {
   render?: "full" | "toggleOnly" | "bodyOnly";
 }
 
-const AUTH_KINDS: ExternalAuthKind[] = ["bearer", "basic", "apiKey", "oauth2", "none"];
+// #1186 Phase 1: process-flow.v3 ExternalAuth.kind enum (7 値) に整合。iamRole / azureAd は #867 / #939 で導入された AWS Bedrock / Azure OpenAI 認証
+const AUTH_KINDS: ExternalAuthKind[] = ["bearer", "basic", "apiKey", "oauth2", "iamRole", "azureAd", "none"];
 const trimToUndefined = (value: string) => {
   const trimmed = value.trim();
   return trimmed ? trimmed : undefined;

--- a/frontend/src/components/process-flow/NotesPanel.tsx
+++ b/frontend/src/components/process-flow/NotesPanel.tsx
@@ -8,18 +8,14 @@ interface Props {
   onChange: (notes: StepNote[]) => void;
 }
 
-// `StepNoteType` の全 7 値を網羅する。新エディション (assumption / decision / todo / risk /
-// question) と旧エディションの互換 (prerequisite / deferred) を両方サポート。
-// schema (schemas/v3/common.v3.schema.json) と migration (actionMigration.ts:noteKind) は
-// 旧 enum 寄せのため、ここで両方カバーすることで old data load 時の crash を回避する。
+// #1186 Phase 1: common.v3 Note.kind 規範に揃え 5 値のみ表示 (assumption / prerequisite / todo / deferred / question)。
+// 旧 enum の "decision" / "risk" 値は actionMigration.ts:noteKind で "deferred" に正規化される (read 時 fallback)。
 const TYPE_META: Record<StepNoteType, { icon: string; label: string; color: string }> = {
   assumption: { icon: "bi-lightbulb", label: "想定", color: "#64748b" },
-  decision: { icon: "bi-paperclip", label: "決定", color: "#0ea5e9" },
-  todo: { icon: "bi-check2-square", label: "TODO", color: "#a855f7" },
-  risk: { icon: "bi-exclamation-triangle", label: "リスク", color: "#f97316" },
-  question: { icon: "bi-question-circle", label: "質問", color: "#ef4444" },
   prerequisite: { icon: "bi-list-check", label: "前提", color: "#475569" },
+  todo: { icon: "bi-check2-square", label: "TODO", color: "#a855f7" },
   deferred: { icon: "bi-pause-circle", label: "保留", color: "#94a3b8" },
+  question: { icon: "bi-question-circle", label: "質問", color: "#ef4444" },
 };
 
 // defensive lookup — `type` が未定義 / 不明値の場合は `kind` (旧フィールド) も試し、

--- a/frontend/src/types/action.ts
+++ b/frontend/src/types/action.ts
@@ -19,18 +19,20 @@ export type ActionFields = StructuredField[] | string | undefined;
 export type MarkerKind = string;
 export type Marker = AnyRecord;
 
+// #1186 Phase 1: common.v3 Note.kind enum と完全一致 (assumption / prerequisite / todo / deferred / question)。
+// 旧 enum の "decision" / "risk" は schema 外の値で、actionMigration.ts:noteKind で "deferred" に正規化される (read 時 fallback あり)。
 export type StepNoteType =
   | "assumption"
-  | "decision"
-  | "todo"
-  | "risk"
-  | "question"
   | "prerequisite"
-  | "deferred";
+  | "todo"
+  | "deferred"
+  | "question";
 export interface StepNote {
   id: string;
+  /** common.v3 Note 規範。v3 schema 上 field 名は `kind` 必須 (旧 `type` は read 互換のみ)。 */
+  kind?: StepNoteType;
+  /** @deprecated v1/v2 legacy field。新規書込は `kind` を使用。 */
   type?: StepNoteType;
-  kind?: StepNoteType | "prerequisite" | "deferred";
   body: string;
   createdAt: string;
 }
@@ -89,7 +91,7 @@ export type ValidationRuleType =
   | "range"
   | "enum"
   | "custom";
-export type ValidationRuleKind = "Error" | "Msg" | "Noaccept" | "Default";
+// #1186 Phase 1: v3 で完全廃止 (field 名 kind→severity rename + lowerCamelCase に正規化)。Dead code として削除。
 export type ValidationRule = AnyRecord & { field?: string; type?: ValidationRuleType; severity?: string };
 
 export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
@@ -101,7 +103,8 @@ export type BodySchema = string | AnyRecord;
 export type ExternalCallOutcome = "success" | "failure" | "timeout";
 export type ExternalCallOutcomeSpec = AnyRecord;
 export type ExternalCallOutcomes = AnyRecord;
-export type ExternalAuthKind = "bearer" | "basic" | "apiKey" | "oauth2" | "none";
+// #1186 Phase 1: process-flow.v3 ExternalAuth.kind に iamRole / azureAd を追加 (AWS Bedrock / Azure OpenAI 認証、#867 / #939 連動)
+export type ExternalAuthKind = "bearer" | "basic" | "apiKey" | "oauth2" | "iamRole" | "azureAd" | "none";
 export type ExternalAuth = AnyRecord;
 
 export type Sla = AnyRecord;
@@ -112,8 +115,9 @@ export type TransactionIsolationLevel = "READ_COMMITTED" | "REPEATABLE_READ" | "
 export type TransactionPropagation = "REQUIRED" | "REQUIRES_NEW" | "NESTED" | string;
 export type ExternalChainPhase = "authorize" | "capture" | "cancel" | "other";
 export type ExternalChain = AnyRecord & { chainId?: string; phase?: ExternalChainPhase };
-export type LoopKind = "count" | "condition" | "collection" | "forEach" | "while" | "doWhile" | "for" | string;
-export type LoopConditionMode = "continue" | "exit" | "pre" | "post" | string;
+// #1186 Phase 1: process-flow.v3 LoopStep.loopKind / conditionMode と完全一致 (string 緩和削除、schema 外 enum 削除)
+export type LoopKind = "count" | "condition" | "collection";
+export type LoopConditionMode = "continue" | "exit";
 export type WorkflowPattern = V3ProcessFlow.WorkflowPattern | string;
 export type WorkflowApprover = AnyRecord;
 export type WorkflowQuorum = AnyRecord;
@@ -172,11 +176,12 @@ export interface StepTemplate {
   steps?: TemplateStep[];
 }
 
+// #1186 Phase 1: common.v3 Note.kind と完全一致 (5 値、順序は schema 列挙順)
 export const STEP_NOTE_TYPE_VALUES: readonly StepNoteType[] = [
   "assumption",
-  "decision",
+  "prerequisite",
   "todo",
-  "risk",
+  "deferred",
   "question",
 ] as const;
 

--- a/frontend/src/types/v3/process-flow.ts
+++ b/frontend/src/types/v3/process-flow.ts
@@ -2,9 +2,10 @@
  * v3 ProcessFlow 型定義 (`schemas/v3/process-flow.v3.schema.json` と 1:1 対応)
  *
  * - root 4 セクション: meta / context / actions / authoring
- * - 22 step variants (validation / dbAccess / externalSystem / commonProcess / screenTransition /
- *   displayUpdate / branch / loop / loopBreak / loopContinue / jump / compute / return / log /
- *   audit / workflow / transactionScope / eventPublish / eventSubscribe / closing / cdc / extension)
+ * - 25 step variants (validation / dbAccess / externalSystem / componentCall / commonProcess /
+ *   screenTransition / displayUpdate / branch / loop / loopBreak / loopContinue / jump / compute /
+ *   return / log / audit / workflow / transactionScope / eventPublish / eventSubscribe / closing /
+ *   cdc / aiCall / aiAgent / extension)  ※ componentCall (#1067) / aiCall / aiAgent (#940) を含む
  * - WorkflowApprover.order semantics (#539 R5-2) を JSDoc で明示
  * - datetime 算術 duration() 推奨 (#539 R5-3) を JSDoc で明示
  *
@@ -438,7 +439,7 @@ export interface DataLineage {
 /**
  * 全 Step variant 共通のプロパティ集合。
  * 各 variant は本定義を allOf でマージし、固有プロパティを追加 + unevaluatedProperties: false で閉じる。
- * #525 R3 fix: lineage を StepBaseProps に集約 (全 22 step variant で利用可能)。
+ * #525 R3 fix: lineage を StepBaseProps に集約 (全 25 step variant で利用可能)。
  */
 export interface StepBaseProps {
   id: LocalId;
@@ -610,7 +611,7 @@ export interface ExternalSystemStep extends StepBaseProps {
   successCriteria?: Criterion[];
 }
 
-// ─── 残り 19 step variants ─────────────────────────────────────────────
+// ─── 残り step variants ────────────────────────────────────────────────
 
 export interface CommonProcessStep extends StepBaseProps {
   kind: "commonProcess";
@@ -911,10 +912,10 @@ export interface ExtensionStep extends StepBaseProps {
   config?: Record<string, unknown>;
 }
 
-// ─── Step union (22 variants) ──────────────────────────────────────────
+// ─── Step union (25 variants) ──────────────────────────────────────────
 
 /**
- * Step union。kind プロパティで variant を識別。組み込み 21 + ExtensionStep の計 22 variant。
+ * Step union。kind プロパティで variant を識別。組み込み 24 + ExtensionStep の計 25 variant。
  *
  * AJV `discriminator: true` モードで kind を識別子として 1 branch のみエラー報告 (#525 F-4)。
  * ただし Step.oneOf は ExtensionStep の kind がパターン (`namespace:StepName`) のため


### PR DESCRIPTION
## Summary

- ISSUE #1186 の **Phase 1** (dead enum 削除 + JSDoc 同期、低リスク) を実施
- schemas/README.md L74-83 の「schema を正、TS 型と UI を schema に合わせる」規範に沿う
- Phase 2 (AnyRecord → strict 型移行) / Phase 3 (action.ts deprecation) は規模大のため別 PR で継続

## 変更内訳

### action.ts (5 enum + 1 const + 1 interface)

| 検出# | 旧 | 新 | 根拠 |
|---|---|---|---|
| 1 | StepNoteType 7 値 (assumption / decision / todo / risk / question / prerequisite / deferred) | 5 値 (assumption / prerequisite / todo / deferred / question) | common.v3 Note.kind |
| 2 | ValidationRuleKind = "Error"\|"Msg"\|"Noaccept"\|"Default" | 削除 (dead code) | v3 で kind→severity rename + lowerCamelCase 化、他参照なし |
| 3 | LoopKind 7 値 + string | 3 値 (count / condition / collection) | process-flow.v3 LoopStep.loopKind |
| 4 | LoopConditionMode 4 値 + string | 2 値 (continue / exit) | process-flow.v3 LoopStep.conditionMode |
| 5 | ExternalAuthKind 5 値 | 7 値 (iamRole / azureAd 追加) | process-flow.v3 ExternalAuth.kind |
| - | STEP_NOTE_TYPE_VALUES (5 件、旧 enum) | 5 値 schema 列挙順 | common.v3 Note.kind |
| - | StepNote { type?, kind? } 並列 | kind を正規、type を @deprecated | common.v3 Note 規範 |

### v3/process-flow.ts (JSDoc 4 箇所)

| 箇所 | 旧 | 新 |
|---|---|---|
| L5 header | 22 step variants | 25 step variants + componentCall/aiCall/aiAgent 追記 |
| L441 StepBaseProps | 全 22 step variant | 全 25 step variant |
| L613 区切りコメント | 残り 19 step variants | 残り step variants |
| L917 Step union | 組み込み 21 + ExtensionStep 計 22 | 組み込み 24 + ExtensionStep 計 25 |

### Consumer 修正 (型変更による波及)

| file | 修正内容 |
|---|---|
| NotesPanel.tsx | TYPE_META から decision/risk 削除、schema 5 値のみに |
| ExternalSystemCatalogPanel.tsx | AUTH_KINDS に iamRole / azureAd 追加 |

## データ移行不要の確認

- examples/ 配下に notes (StepNote) を持つ step なし → field 名 migration 不要
- 既存 user data の note.type=\"decision\"/\"risk\" は actionMigration.ts:noteKind で \"deferred\" に既存正規化済 (read 時 fallback)
- \"forEach\"/\"while\" 等の旧 LoopKind を使う examples なし

## Test plan

- [x] \`cd frontend && npm run build\` → tsc + vite build OK
- [x] \`cd frontend && npx vitest run\` → 2279 pass / 25 fail (pre-existing dogfood-1038 hardcoded path、本 PR 無関係)
- [x] schema validator は #1188 で discriminator + addFormats 有効化済 (本 PR と独立に動作)

## scope 外 (Phase 2-3 で別途)

- AnyRecord → strict 型への段階移行 (Step / ActionDefinition / ProcessFlow / Branch / Sla / HttpRoute 等 18+ 件、ProcessFlowEditor 等 10+ component の import 書き換え)
- StepKind union の \`\"extension\"\` 単一値廃止 + ExtensionStep.kind パターン (\`namespace:StepName\`) サポート
- 全 consumer 移行後 action.ts 削除 (または v3/* 再 export only に縮退)

これらは ISSUE #1186 の Phase 2-3 として継続。**本 PR は Closes ではなく Refs**。

Refs #1186

🤖 Generated with [Claude Code](https://claude.com/claude-code)