### PR TITLE
fix(test): dogfood-1038-structure.test.ts の hardcoded path を file-URL ベース解決に

### DIFF
--- a/frontend/src/test/dogfood/dogfood-1038-structure.test.ts
+++ b/frontend/src/test/dogfood/dogfood-1038-structure.test.ts
@@ -8,9 +8,12 @@
 import { describe, it, expect } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
 
-// 絶対パスで指定 (vitest context の __dirname は frontend/ なので相対パス解決に注意)
-const DOGFOOD_ROOT = '/home/hidekatsu/projects/harmony/.tmp/dogfood-1038';
+// projectRoot/.tmp/dogfood-1038 を file-URL ベースで解決 (machine 非依存、Dev Container / WSL / native すべてで動作)
+// 旧: hardcoded '/home/hidekatsu/projects/harmony/.tmp/dogfood-1038' は当 PC でのみ pass する
+const __filename = fileURLToPath(import.meta.url);
+const DOGFOOD_ROOT = path.resolve(path.dirname(__filename), '../../../../.tmp/dogfood-1038');
 
 describe('Dogfood #1038: 生成 test fixture structure 検証', () => {
 


### PR DESCRIPTION
## Summary

- PR #1044 由来の hardcoded \`/home/hidekatsu/projects/harmony/.tmp/dogfood-1038\` を file-URL 解決に置換
- Dev Container / WSL / 別ユーザー machine で 25 件 fail していた pre-existing 問題を解消

## 検証

| | 修正前 | 修正後 |
|---|---|---|
| dogfood-1038-structure.test.ts | 25 / 25 fail (ENOENT) | 25 / 25 pass |

## 発見経緯

ISSUE #1188 / #1187 / #1184 / #1186 (main 厳格レビュー 2026-05-19 由来) の対応中、frontend test suite 実行時に全 25 件 fail を観測。原因が hardcoded 絶対 path と判明、スコープ独立のため本 PR として分離 (test 1 file、5 行変更)。

## Test plan

- [x] \`cd frontend && npx vitest run src/test/dogfood/dogfood-1038-structure.test.ts\` → 25 / 25 pass
- [x] fixture path \`.tmp/dogfood-1038/\` が存在することを確認 (step3 / p3 / p4 / p5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)