### PR TITLE
feat(schema): ScreenDesign/PageLayoutDesign に editorKind ↔ ref 排他制約 (#1185 提案 D)

### DIFF
--- a/frontend/src/schemas/design-exclusion.schema.test.ts
+++ b/frontend/src/schemas/design-exclusion.schema.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Design exclusion schema tests (#1185 提案 D)
+ *
+ * ScreenDesign / PageLayoutDesign の editorKind ↔ ref 排他を if/then で強制したことを検証:
+ * - editorKind=grapesjs + designFileRef のみ → pass
+ * - editorKind=puck + puckDataRef のみ → pass
+ * - editorKind=grapesjs + puckDataRef → fail (mismatch)
+ * - editorKind=puck + designFileRef → fail (mismatch)
+ * - editorKind=grapesjs only (ref 未設定) → pass (draft-state 互換)
+ * - editorKind=puck only (ref 未設定) → pass (draft-state 互換)
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { buildHarmonyAjv } from "../utils/buildHarmonyAjv";
+import type Ajv2020 from "ajv/dist/2020";
+
+const repoRoot = resolve(__dirname, "../../../");
+const v3Dir = resolve(repoRoot, "schemas/v3");
+
+function loadJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+let validateScreen: ReturnType<InstanceType<typeof Ajv2020>["compile"]>;
+let validatePageLayout: ReturnType<InstanceType<typeof Ajv2020>["compile"]>;
+
+beforeAll(() => {
+  const ajv = buildHarmonyAjv();
+  ajv.addSchema(loadJson(join(v3Dir, "common.v3.schema.json")) as object);
+  ajv.addSchema(loadJson(join(v3Dir, "screen-item.v3.schema.json")) as object);
+  validateScreen = ajv.compile(loadJson(join(v3Dir, "screen.v3.schema.json")) as object);
+  validatePageLayout = ajv.compile(loadJson(join(v3Dir, "page-layout.v3.schema.json")) as object);
+});
+
+const SCREEN_BASE = {
+  $schema: "../../../schemas/v3/screen.v3.schema.json",
+  id: "11111111-1111-4111-8111-111111111111",
+  name: "fixture screen",
+  kind: "form" as const,
+  path: "/fixture",
+  auth: "required" as const,
+  maturity: "draft" as const,
+  createdAt: "2026-05-19T00:00:00.000Z",
+  updatedAt: "2026-05-19T00:00:00.000Z",
+  items: [],
+};
+
+const PL_BASE = {
+  $schema: "../../../schemas/v3/page-layout.v3.schema.json",
+  id: "22222222-2222-4222-8222-222222222222",
+  name: "fixture layout",
+  maturity: "draft" as const,
+  createdAt: "2026-05-19T00:00:00.000Z",
+  updatedAt: "2026-05-19T00:00:00.000Z",
+  regions: [{ name: "main", description: "content slot" }],
+  assignments: {},
+};
+
+function makeScreen(design: Record<string, unknown> | undefined) {
+  return design === undefined ? SCREEN_BASE : { ...SCREEN_BASE, design };
+}
+function makePL(design: Record<string, unknown>) {
+  return { ...PL_BASE, design };
+}
+
+describe("ScreenDesign editorKind ↔ ref exclusion (#1185 提案 D)", () => {
+  it("pass: editorKind=grapesjs + designFileRef のみ", () => {
+    const ok = validateScreen(makeScreen({
+      editorKind: "grapesjs",
+      cssFramework: "bootstrap",
+      designFileRef: "design.json",
+    }));
+    expect(ok, JSON.stringify(validateScreen.errors)).toBe(true);
+  });
+
+  it("pass: editorKind=puck + puckDataRef のみ", () => {
+    const ok = validateScreen(makeScreen({
+      editorKind: "puck",
+      cssFramework: "tailwind",
+      puckDataRef: "puck-data.json",
+    }));
+    expect(ok, JSON.stringify(validateScreen.errors)).toBe(true);
+  });
+
+  it("pass: editorKind=grapesjs のみ (ref 未設定、draft-state 互換)", () => {
+    const ok = validateScreen(makeScreen({
+      editorKind: "grapesjs",
+      cssFramework: "bootstrap",
+    }));
+    expect(ok, JSON.stringify(validateScreen.errors)).toBe(true);
+  });
+
+  it("pass: editorKind=puck のみ (ref 未設定、draft-state 互換)", () => {
+    const ok = validateScreen(makeScreen({
+      editorKind: "puck",
+      cssFramework: "tailwind",
+    }));
+    expect(ok, JSON.stringify(validateScreen.errors)).toBe(true);
+  });
+
+  it("fail: editorKind=grapesjs + puckDataRef (mismatch)", () => {
+    const ok = validateScreen(makeScreen({
+      editorKind: "grapesjs",
+      cssFramework: "bootstrap",
+      puckDataRef: "puck-data.json",
+    }));
+    expect(ok).toBe(false);
+  });
+
+  it("fail: editorKind=puck + designFileRef (mismatch)", () => {
+    const ok = validateScreen(makeScreen({
+      editorKind: "puck",
+      cssFramework: "tailwind",
+      designFileRef: "design.json",
+    }));
+    expect(ok).toBe(false);
+  });
+
+  it("pass: design セクション自体が無い (省略可)", () => {
+    const ok = validateScreen(makeScreen(undefined));
+    expect(ok, JSON.stringify(validateScreen.errors)).toBe(true);
+  });
+});
+
+describe("PageLayoutDesign editorKind ↔ ref exclusion (#1185 提案 D)", () => {
+  it("pass: editorKind=grapesjs + designFileRef のみ", () => {
+    const ok = validatePageLayout(makePL({
+      editorKind: "grapesjs",
+      cssFramework: "bootstrap",
+      designFileRef: "design.json",
+    }));
+    expect(ok, JSON.stringify(validatePageLayout.errors)).toBe(true);
+  });
+
+  it("pass: editorKind=puck + puckDataRef のみ", () => {
+    const ok = validatePageLayout(makePL({
+      editorKind: "puck",
+      cssFramework: "tailwind",
+      puckDataRef: "puck-data.json",
+    }));
+    expect(ok, JSON.stringify(validatePageLayout.errors)).toBe(true);
+  });
+
+  it("pass: editorKind=grapesjs のみ (ref 未設定、draft-state 互換)", () => {
+    const ok = validatePageLayout(makePL({
+      editorKind: "grapesjs",
+      cssFramework: "bootstrap",
+    }));
+    expect(ok, JSON.stringify(validatePageLayout.errors)).toBe(true);
+  });
+
+  it("fail: editorKind=grapesjs + puckDataRef (mismatch)", () => {
+    const ok = validatePageLayout(makePL({
+      editorKind: "grapesjs",
+      cssFramework: "bootstrap",
+      puckDataRef: "puck-data.json",
+    }));
+    expect(ok).toBe(false);
+  });
+
+  it("fail: editorKind=puck + designFileRef (mismatch)", () => {
+    const ok = validatePageLayout(makePL({
+      editorKind: "puck",
+      cssFramework: "tailwind",
+      designFileRef: "design.json",
+    }));
+    expect(ok).toBe(false);
+  });
+});

--- a/schemas/v3/page-layout.v3.schema.json
+++ b/schemas/v3/page-layout.v3.schema.json
@@ -58,7 +58,7 @@
     },
 
     "PageLayoutDesign": {
-      "description": "PageLayout デザインの参照情報。生 HTML/CSS (GrapesJS) または Puck Data tree (Puck) は別ファイル (workspace 配下) で管理し、本 schema は参照のみ持つ。editorKind / cssFramework は PageLayout 作成時に固定、以降変更不可 (multi-editor-puck.md 仕様準拠)。",
+      "description": "PageLayout デザインの参照情報。生 HTML/CSS (GrapesJS) または Puck Data tree (Puck) は別ファイル (workspace 配下) で管理し、本 schema は参照のみ持つ。editorKind / cssFramework は PageLayout 作成時に固定、以降変更不可 (multi-editor-puck.md 仕様準拠)。editorKind と対応 ref (designFileRef / puckDataRef) の排他は allOf+if/then で強制 (#1185 提案 D、draft-state 互換 — 対応 ref の存在は必須化せず、不一致 ref の同時指定のみ禁止)。",
       "type": "object",
       "additionalProperties": false,
       "required": ["editorKind", "cssFramework"],
@@ -75,17 +75,27 @@
         },
         "designFileRef": {
           "type": "string",
-          "description": "GrapesJS デザインファイルへの相対パス (editorKind='grapesjs' のとき、例: 'design.json')。editorKind='puck' のときは指定しない。"
+          "description": "GrapesJS デザインファイルへの相対パス (editorKind='grapesjs' のとき、例: 'design.json')。editorKind='puck' のときは指定不可 (allOf if/then で強制)。"
         },
         "puckDataRef": {
           "type": "string",
-          "description": "Puck Data JSON への相対パス (editorKind='puck' のとき、例: 'puck-data.json')。editorKind='grapesjs' のときは指定しない。"
+          "description": "Puck Data JSON への相対パス (editorKind='puck' のとき、例: 'puck-data.json')。editorKind='grapesjs' のときは指定不可 (allOf if/then で強制)。"
         },
         "thumbnailRef": {
           "type": "string",
           "description": "サムネイル画像への相対パス または data URL。"
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "editorKind": { "const": "grapesjs" } }, "required": ["editorKind"] },
+          "then": { "not": { "required": ["puckDataRef"] } }
+        },
+        {
+          "if": { "properties": { "editorKind": { "const": "puck" } }, "required": ["editorKind"] },
+          "then": { "not": { "required": ["designFileRef"] } }
+        }
+      ]
     }
   }
 }

--- a/schemas/v3/screen.v3.schema.json
+++ b/schemas/v3/screen.v3.schema.json
@@ -116,7 +116,7 @@
     },
 
     "ScreenDesign": {
-      "description": "画面デザインの参照情報。生 HTML/CSS/component tree (GrapesJS) または Puck Data tree (Puck) は別ファイル (workspace 配下) で管理し、本 schema は参照のみ持つ。editorKind / cssFramework は画面作成時に固定、以降変更不可 (multi-editor-puck.md 仕様)。",
+      "description": "画面デザインの参照情報。生 HTML/CSS/component tree (GrapesJS) または Puck Data tree (Puck) は別ファイル (workspace 配下) で管理し、本 schema は参照のみ持つ。editorKind / cssFramework は画面作成時に固定、以降変更不可 (multi-editor-puck.md 仕様)。editorKind と対応 ref (designFileRef / puckDataRef) の排他は allOf+if/then で強制 (#1185 提案 D、draft-state 互換 — 対応 ref の存在は必須化せず、不一致 ref の同時指定のみ禁止)。",
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -132,17 +132,27 @@
         },
         "designFileRef": {
           "type": "string",
-          "description": "GrapesJS デザインファイルへの相対パス (editorKind='grapesjs' のとき、例: 'design.json')。editorKind='puck' のときは指定しない。"
+          "description": "GrapesJS デザインファイルへの相対パス (editorKind='grapesjs' のとき、例: 'design.json')。editorKind='puck' のときは指定不可 (allOf if/then で強制)。"
         },
         "puckDataRef": {
           "type": "string",
-          "description": "Puck Data JSON への相対パス (editorKind='puck' のとき、例: 'puck-data.json')。editorKind='grapesjs' のときは指定しない。"
+          "description": "Puck Data JSON への相対パス (editorKind='puck' のとき、例: 'puck-data.json')。editorKind='grapesjs' のときは指定不可 (allOf if/then で強制)。"
         },
         "thumbnailRef": {
           "type": "string",
           "description": "サムネイル画像への相対パス または data URL。"
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "editorKind": { "const": "grapesjs" } }, "required": ["editorKind"] },
+          "then": { "not": { "required": ["puckDataRef"] } }
+        },
+        {
+          "if": { "properties": { "editorKind": { "const": "puck" } }, "required": ["editorKind"] },
+          "then": { "not": { "required": ["designFileRef"] } }
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

- ISSUE #1185 提案 D を **Codex 改善 sketch** で実装
- ScreenDesign / PageLayoutDesign の editorKind と対応 ref (designFileRef / puckDataRef) の組合せ不整合を schema で防止
- draft-state policy 互換 (対応 ref 必須化せず、mismatch のみ禁止)

## 採用した sketch (Codex 改善案)

ISSUE 本文の素朴 oneOf 案は \`required\` を強制するため draft-state policy と衝突。Codex 提案の \`not + required\` パターンを採用:

\`\`\`json
"allOf": [
  {"if":{"properties":{"editorKind":{"const":"grapesjs"}},"required":["editorKind"]},
   "then":{"not":{"required":["puckDataRef"]}}},
  {"if":{"properties":{"editorKind":{"const":"puck"}},"required":["editorKind"]},
   "then":{"not":{"required":["designFileRef"]}}}
]
\`\`\`

## 挙動マトリクス

| editorKind | designFileRef | puckDataRef | 結果 | 説明 |
|---|---|---|---|---|
| grapesjs | 有 | 無 | ✅ pass | 正規組合せ |
| grapesjs | 無 | 無 | ✅ pass | draft 状態 |
| grapesjs | 有 | 有 | ❌ fail | mismatch |
| grapesjs | 無 | 有 | ❌ fail | mismatch |
| puck | 無 | 有 | ✅ pass | 正規組合せ |
| puck | 無 | 無 | ✅ pass | draft 状態 |
| puck | 有 | 無 | ❌ fail | mismatch |
| puck | 有 | 有 | ❌ fail | mismatch |
| (省略) | 任意 | 任意 | ✅ pass | editorKind 省略時 (project.techStack デフォルト) |

## 変更

| file | 変更 |
|---|---|
| schemas/v3/screen.v3.schema.json | ScreenDesign に allOf+if/then 追加、description 更新 |
| schemas/v3/page-layout.v3.schema.json | PageLayoutDesign に同パターン追加、description 更新 |
| frontend/src/schemas/design-exclusion.schema.test.ts | 新規 12 test (Screen 7 + PageLayout 5) |

## Test plan

- [x] \`npx vitest run src/schemas/design-exclusion.schema.test.ts\` → 12 / 12 pass
- [x] \`npm run validate:samples -- ../examples/retail\` → 7 / 7 flows pass
- [x] \`npm run validate:samples -- ../examples/realestate\` → 1 / 1 flows pass
- [x] \`npm run validate:samples -- ../examples/english-learning-tailwind\` → 5 / 5 flows pass
- [x] \`npm run validate:samples -- ../examples/english-learning\` → 5 / 5 flows pass
- [x] \`npm run validate:samples -- ../examples/diary\` → 15 / 15 flows pass
- [x] \`cd frontend && npx vitest run src/schemas/\` → 24 files / 676 tests pass (本 PR の 12 含む 688)
- [x] \`cd backend && npm test\` → 516 tests pass

## migration 不要

jq 集計で全 examples の editorKind / 対応 ref 組合せを確認:
- editorKind=puck のレコード **0 件**
- grapesjs + 不正な puckDataRef のレコード **0 件**
- design 無しレコード 5 件 (全 valid)
- editorKind=grapesjs + designFileRef のみ 1 件 (正規パターン)
- editorKind=grapesjs + ref 未設定 3 件 (draft 状態、新制約でも pass)

→ 既存データ migration 不要、全 sample validate pass のまま。

## ガバナンス

schema 構造変更は #511 schema governance により本来 AI 単独禁止だが、設計者 (ISSUE 作者) が[本コメント](https://github.com/csilost2001/harmony/issues/1185#issuecomment-4488931724)で明示承認済み。

Refs #1185 (PR 1/5 of series)

🤖 Generated with [Claude Code](https://claude.com/claude-code)