### PR TITLE
docs(schema): ExternalSystemStep の httpCall / operationRef hierarchy を description で明文化 (#1185 提案 B + 追加#3)

### DIFF
--- a/schemas/v3/process-flow.v3.schema.json
+++ b/schemas/v3/process-flow.v3.schema.json
@@ -754,6 +754,7 @@
     },
 
     "ExternalSystemStep": {
+      "description": "外部システム呼出ステップ。invocation mode (#1185 提案 B + 追加#3 で hierarchy 明文化):\n  (1) **httpCall mode** — `httpCall` (method/path/query/body) で REST endpoint を直接指定。spec が無いケースや ad-hoc 呼出向け。\n  (2) **operationRef mode** — `operationRef` (例: '/v1/payment_intents POST') + `operationId` / `requestBodyRef` / `responseRef` で OpenAPI spec 駆動。systemRef → externalSystems catalog 経由で spec URL 解決、operation 単位の参照で型安全。\n両 mode の共存は schema 上 valid だが業界慣習として非推奨。共存時の loader 解釈順序: operationRef > httpCall (spec 駆動が優先、httpCall 側 query/body/headers は override として merge される実装が標準)。AJV による strict exclusion は採用しない (混合ニーズや段階的 migration を許容するため意図的に description 規約)。",
       "allOf": [
         { "$ref": "#/$defs/StepBaseProps" },
         {
@@ -765,11 +766,11 @@
               "$ref": "common.v3.schema.json#/$defs/Identifier",
               "description": "ProcessFlow.context.catalogs.externalSystems のキー参照 (Identifier / camelCase)。"
             },
-            "httpCall": { "$ref": "#/$defs/ExternalHttpCall" },
-            "operationRef": { "type": "string", "description": "OpenAPI operation 参照 (例: '/v1/payment_intents POST')。" },
-            "operationId": { "type": "string" },
-            "requestBodyRef": { "type": "string", "description": "OpenAPI request body schema への JSON Pointer。" },
-            "responseRef": { "type": "string" },
+            "httpCall": { "$ref": "#/$defs/ExternalHttpCall", "description": "**httpCall mode**: 直接 HTTP 呼出仕様 (method/path/query/body)。operationRef 系と排他推奨だが schema 強制せず (#1185 説明)。" },
+            "operationRef": { "type": "string", "description": "**operationRef mode**: OpenAPI operation 参照 (例: '/v1/payment_intents POST')。systemRef 経由で spec URL 解決。httpCall と排他推奨。" },
+            "operationId": { "type": "string", "description": "**operationRef mode**: OpenAPI operationId (operationRef より優先する場合の代替指定)。httpCall と排他推奨。" },
+            "requestBodyRef": { "type": "string", "description": "**operationRef mode**: OpenAPI request body schema への JSON Pointer (例: '#/components/schemas/CreatePaymentIntent')。httpCall.body と排他推奨。" },
+            "responseRef": { "type": "string", "description": "**operationRef mode**: OpenAPI response schema への JSON Pointer。httpCall mode では outcomes.success.responseSchema 等で代替。" },
             "outcomes": { "$ref": "#/$defs/ExternalCallOutcomes" },
             "timeoutMs": { "type": "integer", "minimum": 0 },
             "retryPolicy": { "$ref": "#/$defs/RetryPolicy" },


### PR DESCRIPTION
## Summary

- ISSUE #1185 提案 B + Codex 追加#3 を統合実装
- ExternalSystemStep の 2 つの invocation mode (httpCall vs operationRef + operationId / requestBodyRef / responseRef) の関係を description で明文化
- **strict exclusion を採用せず** description hierarchy で loader 解釈順序を規定 (混合ニーズや段階的 migration を許容)

## 提案 B + 追加#3 統合根拠

- ISSUE 本文 提案 B: httpCall ↔ operationRef の排他制約
- Codex 追加#3: operationId / requestBodyRef / responseRef も同様の整理が必要
- → 同 ExternalSystemStep schema 内の同根問題、鉄則 3 に従い 1 PR で統合解決

## 採用方針 (description-only)

ISSUE 本文 提案 B では \"discriminated union 化 (oneOf with mutual not.required)\" または \"共存許容を description で明文化\" の 2 択。私と Codex の合議で **後者 (description 明文化)** を採用:

- AJV による strict exclusion はせず混合ニーズを許容
- 共存時の loader 解釈順序を schema description で明確化:
  - operationRef > httpCall (spec 駆動が優先、httpCall 側 query/body/headers は override として merge)
- 各関連 field の description に \`**httpCall mode**\` / \`**operationRef mode**\` マーカーと排他推奨を inline 表記

## 挙動 (変更前後比較)

| ケース | 変更前 schema 挙動 | 変更後 schema 挙動 |
|---|---|---|
| httpCall のみ | pass | pass (httpCall mode と明示) |
| operationRef のみ | pass | pass (operationRef mode と明示) |
| 両方併用 | pass (loader 解釈不明確) | pass (operationRef 優先、httpCall は override と明文化) |
| 何も指定なし | pass (systemRef のみ) | pass (どちらの mode でもない初期 draft 状態) |

AJV 挙動は変わらず、description のみ刷新。

## Test plan

- [x] \`npm run validate:samples\` 全 examples 5 種 pass (description-only 変更のため当然)
- [x] description-only 変更 → schema governance 上 \"構造変更\" に該当しない (#1184 PR と同方針)

## migration 不要

description-only 変更のため AJV 挙動変化なし。既存データは全て valid のまま。

## ガバナンス

ISSUE #1185 設計者承認コメント (https://github.com/csilost2001/harmony/issues/1185#issuecomment-4488931724) に基づく。

Refs #1185 (PR 3/5 of series)

🤖 Generated with [Claude Code](https://claude.com/claude-code)