### PR TITLE
feat(schema/validator): table.v3 制約配列の uniqueItems + FK 件数一致検証 (#1185 追加#1+#2)

### DIFF
--- a/frontend/src/schemas/table-constraint-arrays.schema.test.ts
+++ b/frontend/src/schemas/table-constraint-arrays.schema.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Table constraint array schema tests (#1185 追加#1)
+ *
+ * UniqueConstraint / ForeignKeyConstraint の column 配列が uniqueItems で重複拒否することを検証。
+ * 件数一致 (#1185 追加#2) は AJV 単体では表現困難なため runtime validator (tableValidation.test.ts) で検証。
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { buildHarmonyAjv } from "../utils/buildHarmonyAjv";
+import type Ajv2020 from "ajv/dist/2020";
+
+const repoRoot = resolve(__dirname, "../../../");
+const v3Dir = resolve(repoRoot, "schemas/v3");
+
+function loadJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+let validateTable: ReturnType<InstanceType<typeof Ajv2020>["compile"]>;
+
+beforeAll(() => {
+  const ajv = buildHarmonyAjv();
+  ajv.addSchema(loadJson(join(v3Dir, "common.v3.schema.json")) as object);
+  validateTable = ajv.compile(loadJson(join(v3Dir, "table.v3.schema.json")) as object);
+});
+
+const TABLE_BASE = {
+  $schema: "../../../schemas/v3/table.v3.schema.json",
+  id: "11111111-1111-4111-8111-111111111111",
+  name: "fixture table",
+  physicalName: "fixtures",
+  createdAt: "2026-05-19T00:00:00.000Z",
+  updatedAt: "2026-05-19T00:00:00.000Z",
+  columns: [
+    { id: "col-01", no: 1, physicalName: "id", name: "ID", dataType: "VARCHAR", primaryKey: true },
+    { id: "col-02", no: 2, physicalName: "ref_a", name: "RefA", dataType: "VARCHAR" },
+    { id: "col-03", no: 3, physicalName: "ref_b", name: "RefB", dataType: "VARCHAR" },
+  ],
+  indexes: [],
+};
+
+function makeTable(constraints: Record<string, unknown>[]) {
+  return { ...TABLE_BASE, constraints };
+}
+
+describe("UniqueConstraint.columnIds uniqueItems (#1185 追加#1)", () => {
+  it("pass: 重複なし", () => {
+    const ok = validateTable(makeTable([{
+      id: "uq-01",
+      kind: "unique",
+      columnIds: ["col-02", "col-03"],
+    }]));
+    expect(ok, JSON.stringify(validateTable.errors)).toBe(true);
+  });
+
+  it("fail: 重複 column id", () => {
+    const ok = validateTable(makeTable([{
+      id: "uq-02",
+      kind: "unique",
+      columnIds: ["col-02", "col-02"],
+    }]));
+    expect(ok).toBe(false);
+    expect(JSON.stringify(validateTable.errors)).toContain("uniqueItems");
+  });
+});
+
+describe("ForeignKeyConstraint.columnIds + referencedColumnIds uniqueItems (#1185 追加#1)", () => {
+  it("pass: 両方とも重複なし", () => {
+    const ok = validateTable(makeTable([{
+      id: "fk-01",
+      kind: "foreignKey",
+      columnIds: ["col-02", "col-03"],
+      referencedTableId: "22222222-2222-4222-8222-222222222222",
+      referencedColumnIds: ["other_id_1", "other_id_2"],
+    }]));
+    expect(ok, JSON.stringify(validateTable.errors)).toBe(true);
+  });
+
+  it("fail: columnIds 重複", () => {
+    const ok = validateTable(makeTable([{
+      id: "fk-02",
+      kind: "foreignKey",
+      columnIds: ["col-02", "col-02"],
+      referencedTableId: "22222222-2222-4222-8222-222222222222",
+      referencedColumnIds: ["other_id_1", "other_id_2"],
+    }]));
+    expect(ok).toBe(false);
+    expect(JSON.stringify(validateTable.errors)).toContain("uniqueItems");
+  });
+
+  it("fail: referencedColumnIds 重複", () => {
+    const ok = validateTable(makeTable([{
+      id: "fk-03",
+      kind: "foreignKey",
+      columnIds: ["col-02", "col-03"],
+      referencedTableId: "22222222-2222-4222-8222-222222222222",
+      referencedColumnIds: ["other_id_1", "other_id_1"],
+    }]));
+    expect(ok).toBe(false);
+    expect(JSON.stringify(validateTable.errors)).toContain("uniqueItems");
+  });
+});

--- a/frontend/src/utils/tableValidation.test.ts
+++ b/frontend/src/utils/tableValidation.test.ts
@@ -110,4 +110,79 @@ describe("validateTable", () => {
 
     expect(validateTable(target, [target])).toEqual([]);
   });
+
+  // #1185 追加#2: FK columnIds と referencedColumnIds の件数一致検証
+  describe("FK column count mismatch (#1185 追加#2)", () => {
+    const fkColumn = (id: string, name: string, primaryKey = false): Column => column({
+      id: id as LocalId,
+      physicalName: name as PhysicalName,
+      name: name as DisplayName,
+      primaryKey,
+    });
+
+    it("件数一致 -> no error", () => {
+      const t = table({
+        columns: [fkColumn("col-01", "id", true), fkColumn("col-02", "ref_a"), fkColumn("col-03", "ref_b")],
+        constraints: [{
+          id: "fk-01",
+          kind: "foreignKey",
+          columnIds: ["col-02", "col-03"],
+          referencedTableId: "22222222-2222-4222-8222-222222222222",
+          referencedColumnIds: ["other_id_1", "other_id_2"],
+        }],
+      } as Partial<Table>);
+      const errors = validateTable(t, [t]);
+      expect(errors.find((e) => e.code === "table.foreignKey.columnCountMismatch")).toBeUndefined();
+    });
+
+    it("件数不一致 (1 vs 2) -> error", () => {
+      const t = table({
+        columns: [fkColumn("col-01", "id", true), fkColumn("col-02", "ref_a")],
+        constraints: [{
+          id: "fk-02",
+          kind: "foreignKey",
+          columnIds: ["col-02"],
+          referencedTableId: "22222222-2222-4222-8222-222222222222",
+          referencedColumnIds: ["other_id_1", "other_id_2"],
+        }],
+      } as Partial<Table>);
+      const errors = validateTable(t, [t]);
+      expect(errors).toContainEqual(expect.objectContaining({
+        severity: "error",
+        code: "table.foreignKey.columnCountMismatch",
+        path: "constraints[0].referencedColumnIds",
+      }));
+    });
+
+    it("件数不一致 (2 vs 1) -> error", () => {
+      const t = table({
+        columns: [fkColumn("col-01", "id", true), fkColumn("col-02", "ref_a"), fkColumn("col-03", "ref_b")],
+        constraints: [{
+          id: "fk-03",
+          kind: "foreignKey",
+          columnIds: ["col-02", "col-03"],
+          referencedTableId: "22222222-2222-4222-8222-222222222222",
+          referencedColumnIds: ["other_id_1"],
+        }],
+      } as Partial<Table>);
+      const errors = validateTable(t, [t]);
+      expect(errors).toContainEqual(expect.objectContaining({
+        severity: "error",
+        code: "table.foreignKey.columnCountMismatch",
+      }));
+    });
+
+    it("FK 以外の制約は対象外", () => {
+      const t = table({
+        columns: [fkColumn("col-01", "id", true), fkColumn("col-02", "ref_a")],
+        constraints: [{
+          id: "uq-01",
+          kind: "unique",
+          columnIds: ["col-02"],
+        }],
+      } as Partial<Table>);
+      const errors = validateTable(t, [t]);
+      expect(errors.find((e) => e.code === "table.foreignKey.columnCountMismatch")).toBeUndefined();
+    });
+  });
 });

--- a/frontend/src/utils/tableValidation.ts
+++ b/frontend/src/utils/tableValidation.ts
@@ -68,5 +68,22 @@ export function validateTable(table: Table, allTables: Table[]): ValidationError
     });
   }
 
+  // #1185 追加#2: FK の columnIds と referencedColumnIds の件数一致 (AJV 単体では表現困難なため runtime 検証)
+  const constraints = (table as Table & { constraints?: Array<Record<string, unknown>> }).constraints ?? [];
+  constraints.forEach((con, idx) => {
+    if (con.kind !== "foreignKey") return;
+    const cols = Array.isArray(con.columnIds) ? con.columnIds : [];
+    const refCols = Array.isArray(con.referencedColumnIds) ? con.referencedColumnIds : [];
+    if (cols.length !== refCols.length) {
+      errors.push({
+        stepId,
+        severity: "error",
+        code: "table.foreignKey.columnCountMismatch",
+        path: `constraints[${idx}].referencedColumnIds`,
+        message: `外部キー (constraint id: ${String(con.id ?? "?")}) の columnIds (${cols.length} 件) と referencedColumnIds (${refCols.length} 件) の件数が一致しません`,
+      });
+    }
+  });
+
   return errors;
 }

--- a/schemas/v3/table.v3.schema.json
+++ b/schemas/v3/table.v3.schema.json
@@ -134,7 +134,9 @@
         "columnIds": {
           "type": "array",
           "minItems": 1,
-          "items": { "$ref": "common.v3.schema.json#/$defs/LocalId" }
+          "uniqueItems": true,
+          "items": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
+          "description": "UNIQUE 制約を構成する Column.id 配列 (#1185 追加#1: 重複列指定禁止のため uniqueItems)。"
         },
         "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
       }
@@ -154,7 +156,7 @@
     },
 
     "ForeignKeyConstraint": {
-      "description": "外部キー制約。単一カラム / 複合カラムを統一表現。referencedTableId は Uuid (物理名直書きは廃止)。",
+      "description": "外部キー制約。単一カラム / 複合カラムを統一表現。referencedTableId は Uuid (物理名直書きは廃止)。columnIds と referencedColumnIds の件数一致は AJV 単体では表現困難 (件数比較は別 schema keyword 必要) のため frontend/src/utils/tableValidation.ts で runtime 検証 (#1185 追加#2)。",
       "type": "object",
       "required": ["id", "kind", "columnIds", "referencedTableId", "referencedColumnIds"],
       "additionalProperties": false,
@@ -165,15 +167,17 @@
         "columnIds": {
           "type": "array",
           "minItems": 1,
+          "uniqueItems": true,
           "items": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
-          "description": "本テーブルの Column.id 配列。"
+          "description": "本テーブルの Column.id 配列 (#1185 追加#1: 重複列指定禁止のため uniqueItems)。"
         },
         "referencedTableId": { "$ref": "common.v3.schema.json#/$defs/Uuid", "description": "参照先 Table の Uuid。" },
         "referencedColumnIds": {
           "type": "array",
           "minItems": 1,
+          "uniqueItems": true,
           "items": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
-          "description": "参照先 Column.id 配列。"
+          "description": "参照先 Column.id 配列 (#1185 追加#1: 重複列指定禁止のため uniqueItems)。columnIds との件数一致は tableValidation.ts で runtime 検証。"
         },
         "onDelete": { "$ref": "#/$defs/FkAction" },
         "onUpdate": { "$ref": "#/$defs/FkAction" },


### PR DESCRIPTION
## Summary

- ISSUE #1185 への Codex review で発見された追加#1 + 追加#2 を統合実装
- table.v3 の UniqueConstraint / ForeignKeyConstraint の column 配列に重複防止 (uniqueItems) + FK の columnIds と referencedColumnIds の件数一致 runtime 検証を追加

## 変更内訳

### Schema 強化 (#1185 追加#1)

| 場所 | 変更 |
|---|---|
| UniqueConstraint.columnIds | uniqueItems: true 追加 |
| ForeignKeyConstraint.columnIds | uniqueItems: true 追加 |
| ForeignKeyConstraint.referencedColumnIds | uniqueItems: true 追加 |

### Runtime validator 拡張 (#1185 追加#2)

\`frontend/src/utils/tableValidation.ts\` に FK 件数一致検証を追加:
- code: \`table.foreignKey.columnCountMismatch\`
- columnIds.length !== referencedColumnIds.length のとき severity=error として報告

### なぜ FK 件数一致を AJV では表現しないか

JSON Schema 2020-12 には 2 配列間の length 比較 keyword なし。ajv-keywords の equalLength 等を導入することは可能だが、依存追加よりも既存 \`tableValidation.ts\` の runtime check で表現する方が draft-state policy (UI 側で警告可視化) との親和性が高い。

## 追加#1+#2 統合根拠

- Codex review で発見、ISSUE 本文 (元の A-D) には未記載
- 両方とも table.v3 ForeignKeyConstraint 周辺 → 同根、鉄則 3 に従い 1 PR 統合
- ISSUE #1185 [統合提案コメント](https://github.com/csilost2001/harmony/issues/1185#issuecomment-4488931724) で予告済

## Test plan

- [x] \`npx vitest run src/schemas/table-constraint-arrays.schema.test.ts\` → 5 / 5 pass (uniqueItems pass/fail)
- [x] \`npx vitest run src/utils/tableValidation.test.ts\` → 12 / 12 pass (FK 件数一致/不一致/他制約)
- [x] \`npm run validate:samples\` 全 examples 5 種 pass

## migration 不要

全 examples を validate、既存 UniqueConstraint / ForeignKeyConstraint で重複列指定や件数不一致のレコード 0 件。

## ガバナンス

ISSUE #1185 設計者承認コメント (https://github.com/csilost2001/harmony/issues/1185#issuecomment-4488931724) に基づく。

Refs #1185 (PR 4/5 of series)

🤖 Generated with [Claude Code](https://claude.com/claude-code)