### PR TITLE
feat(schema/validator): PrimaryKeyConstraint 新設 + Column.primaryKey 重複ガード (#1185 提案 C)

### DIFF
--- a/frontend/src/schemas/primary-key-constraint.schema.test.ts
+++ b/frontend/src/schemas/primary-key-constraint.schema.test.ts
@@ -1,0 +1,114 @@
+/**
+ * PrimaryKeyConstraint schema tests (#1185 提案 C)
+ *
+ * 新設 PrimaryKeyConstraint を Constraint.oneOf に追加したことを検証。
+ * - kind="primaryKey" + columnIds で表現
+ * - composite PK (2 列以上) も valid
+ * - columnIds の重複は uniqueItems で拒否
+ * - Column.primaryKey との重複は runtime validator で検出 (本テストは schema レベル)
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { buildHarmonyAjv } from "../utils/buildHarmonyAjv";
+import type Ajv2020 from "ajv/dist/2020";
+
+const repoRoot = resolve(__dirname, "../../../");
+const v3Dir = resolve(repoRoot, "schemas/v3");
+
+function loadJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+let validateTable: ReturnType<InstanceType<typeof Ajv2020>["compile"]>;
+
+beforeAll(() => {
+  const ajv = buildHarmonyAjv();
+  ajv.addSchema(loadJson(join(v3Dir, "common.v3.schema.json")) as object);
+  validateTable = ajv.compile(loadJson(join(v3Dir, "table.v3.schema.json")) as object);
+});
+
+const TABLE_BASE = {
+  $schema: "../../../schemas/v3/table.v3.schema.json",
+  id: "11111111-1111-4111-8111-111111111111",
+  name: "fixture table",
+  physicalName: "fixtures",
+  createdAt: "2026-05-19T00:00:00.000Z",
+  updatedAt: "2026-05-19T00:00:00.000Z",
+  columns: [
+    { id: "col-01", no: 1, physicalName: "order_id", name: "OrderID", dataType: "VARCHAR" },
+    { id: "col-02", no: 2, physicalName: "line_no", name: "LineNo", dataType: "INTEGER" },
+  ],
+  indexes: [],
+};
+
+function makeTable(constraints: Record<string, unknown>[]) {
+  return { ...TABLE_BASE, constraints };
+}
+
+describe("PrimaryKeyConstraint schema (#1185 提案 C)", () => {
+  it("pass: 単一カラム PK", () => {
+    const ok = validateTable(makeTable([{
+      id: "pk-01",
+      kind: "primaryKey",
+      columnIds: ["col-01"],
+    }]));
+    expect(ok, JSON.stringify(validateTable.errors)).toBe(true);
+  });
+
+  it("pass: 複合 PK (composite)", () => {
+    const ok = validateTable(makeTable([{
+      id: "pk-02",
+      kind: "primaryKey",
+      columnIds: ["col-01", "col-02"],
+    }]));
+    expect(ok, JSON.stringify(validateTable.errors)).toBe(true);
+  });
+
+  it("pass: physicalName 指定あり", () => {
+    const ok = validateTable(makeTable([{
+      id: "pk-03",
+      kind: "primaryKey",
+      physicalName: "pk_order_items",
+      columnIds: ["col-01", "col-02"],
+    }]));
+    expect(ok, JSON.stringify(validateTable.errors)).toBe(true);
+  });
+
+  it("fail: columnIds 空", () => {
+    const ok = validateTable(makeTable([{
+      id: "pk-04",
+      kind: "primaryKey",
+      columnIds: [],
+    }]));
+    expect(ok).toBe(false);
+  });
+
+  it("fail: columnIds 欠落", () => {
+    const ok = validateTable(makeTable([{
+      id: "pk-05",
+      kind: "primaryKey",
+    }]));
+    expect(ok).toBe(false);
+  });
+
+  it("fail: columnIds 重複 (uniqueItems)", () => {
+    const ok = validateTable(makeTable([{
+      id: "pk-06",
+      kind: "primaryKey",
+      columnIds: ["col-01", "col-01"],
+    }]));
+    expect(ok).toBe(false);
+    expect(JSON.stringify(validateTable.errors)).toContain("uniqueItems");
+  });
+
+  it("pass: 既存 unique / check / foreignKey 制約と共存", () => {
+    const ok = validateTable(makeTable([
+      { id: "pk-07", kind: "primaryKey", columnIds: ["col-01"] },
+      { id: "uq-01", kind: "unique", columnIds: ["col-02"] },
+      { id: "ck-01", kind: "check", expression: "line_no > 0" },
+    ]));
+    expect(ok, JSON.stringify(validateTable.errors)).toBe(true);
+  });
+});

--- a/frontend/src/utils/tableValidation.test.ts
+++ b/frontend/src/utils/tableValidation.test.ts
@@ -185,4 +185,78 @@ describe("validateTable", () => {
       expect(errors.find((e) => e.code === "table.foreignKey.columnCountMismatch")).toBeUndefined();
     });
   });
+
+  // #1185 提案 C: PrimaryKeyConstraint と Column.primaryKey の重複検証
+  describe("PrimaryKey mutual exclusion (#1185 提案 C)", () => {
+    const pkCol = (id: string, name: string, primaryKey: boolean): Column => column({
+      id: id as LocalId,
+      physicalName: name as PhysicalName,
+      name: name as DisplayName,
+      primaryKey,
+    });
+
+    it("PK 未指定 (どちらもなし) -> warning", () => {
+      const t = table({
+        columns: [pkCol("col-01", "id", false)],
+      });
+      const errors = validateTable(t, [t]);
+      expect(errors).toContainEqual(expect.objectContaining({
+        code: "table.primaryKey.empty",
+      }));
+    });
+
+    it("Column.primaryKey のみ -> OK (single-column PK 表現)", () => {
+      const t = table({
+        columns: [pkCol("col-01", "id", true)],
+      });
+      const errors = validateTable(t, [t]);
+      expect(errors.find((e) => e.code === "table.primaryKey.empty")).toBeUndefined();
+      expect(errors.find((e) => e.code === "table.primaryKey.duplicated")).toBeUndefined();
+    });
+
+    it("PrimaryKeyConstraint のみ -> OK (composite PK 表現可)", () => {
+      const t = table({
+        columns: [pkCol("col-01", "order_id", false), pkCol("col-02", "line_no", false)],
+        constraints: [{
+          id: "pk-01",
+          kind: "primaryKey",
+          columnIds: ["col-01", "col-02"],
+        }],
+      } as Partial<Table>);
+      const errors = validateTable(t, [t]);
+      expect(errors.find((e) => e.code === "table.primaryKey.empty")).toBeUndefined();
+      expect(errors.find((e) => e.code === "table.primaryKey.duplicated")).toBeUndefined();
+    });
+
+    it("Column.primaryKey + PrimaryKeyConstraint 併用 -> error (duplicated)", () => {
+      const t = table({
+        columns: [pkCol("col-01", "id", true)],
+        constraints: [{
+          id: "pk-01",
+          kind: "primaryKey",
+          columnIds: ["col-01"],
+        }],
+      } as Partial<Table>);
+      const errors = validateTable(t, [t]);
+      expect(errors).toContainEqual(expect.objectContaining({
+        severity: "error",
+        code: "table.primaryKey.duplicated",
+      }));
+    });
+
+    it("PrimaryKeyConstraint 複数 -> error (multipleConstraints)", () => {
+      const t = table({
+        columns: [pkCol("col-01", "id_a", false), pkCol("col-02", "id_b", false)],
+        constraints: [
+          { id: "pk-01", kind: "primaryKey", columnIds: ["col-01"] },
+          { id: "pk-02", kind: "primaryKey", columnIds: ["col-02"] },
+        ],
+      } as Partial<Table>);
+      const errors = validateTable(t, [t]);
+      expect(errors).toContainEqual(expect.objectContaining({
+        severity: "error",
+        code: "table.primaryKey.multipleConstraints",
+      }));
+    });
+  });
 });

--- a/frontend/src/utils/tableValidation.ts
+++ b/frontend/src/utils/tableValidation.ts
@@ -12,6 +12,12 @@ export function validateTable(table: Table, allTables: Table[]): ValidationError
   const stepId = table.id;
 
   const columns = table.columns ?? [];
+  // #1185 提案 C: PK 表現は Column.primaryKey: true (single-column PK) と Constraint.kind=primaryKey (composite PK 含む) の 2 方式。
+  // 同時使用は禁止 (mutual exclusion) — どちらの方が PK か曖昧になり DDL 生成が壊れるため。
+  const constraintsRaw = (table as Table & { constraints?: Array<Record<string, unknown>> }).constraints ?? [];
+  const pkConstraints = constraintsRaw.filter((c) => c.kind === "primaryKey");
+  const columnsWithPk = columns.filter((c) => c.primaryKey);
+
   if (columns.length === 0) {
     errors.push({
       stepId,
@@ -21,13 +27,35 @@ export function validateTable(table: Table, allTables: Table[]): ValidationError
       message: "カラムが未定義です",
     });
     // columns 空の時点で PK 未指定は自明なので primaryKey.empty は重複発火させない
-  } else if (!columns.some((column) => column.primaryKey)) {
+  } else if (columnsWithPk.length === 0 && pkConstraints.length === 0) {
     errors.push({
       stepId,
       severity: "warning",
       code: "table.primaryKey.empty",
       path: "columns",
       message: "主キーが未指定です",
+    });
+  }
+
+  // #1185 提案 C: PK の二重定義は禁止 (Column.primaryKey と Constraint.kind=primaryKey の併用)
+  if (columnsWithPk.length > 0 && pkConstraints.length > 0) {
+    errors.push({
+      stepId,
+      severity: "error",
+      code: "table.primaryKey.duplicated",
+      path: "constraints",
+      message: `Column.primaryKey と Constraint.kind=primaryKey が併用されています。どちらか一方に統一してください (composite PK の場合は Constraint 側に統一、単一カラム PK は Column.primaryKey で OK)`,
+    });
+  }
+
+  // #1185 提案 C: PrimaryKeyConstraint は 1 table 内に最大 1 つ (1 table = 1 PK)
+  if (pkConstraints.length > 1) {
+    errors.push({
+      stepId,
+      severity: "error",
+      code: "table.primaryKey.multipleConstraints",
+      path: "constraints",
+      message: `PrimaryKeyConstraint が ${pkConstraints.length} 件定義されています。1 table = 1 PK のため 1 件に統合してください`,
     });
   }
 

--- a/schemas/v3/extensions.v3.schema.json
+++ b/schemas/v3/extensions.v3.schema.json
@@ -232,7 +232,7 @@
       "properties": {
         "id": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
         "label": { "$ref": "common.v3.schema.json#/$defs/DisplayName" },
-        "kind": { "type": "string", "enum": ["unique", "check", "foreignKey"] },
+        "kind": { "type": "string", "enum": ["primaryKey", "unique", "check", "foreignKey"], "description": "Constraint 種別。primaryKey は #1185 提案 C で追加 (composite PK 対応、table.v3 Constraint.oneOf と同期)。" },
         "description": { "$ref": "common.v3.schema.json#/$defs/Description" },
         "template": {
           "type": "object",

--- a/schemas/v3/table.v3.schema.json
+++ b/schemas/v3/table.v3.schema.json
@@ -114,13 +114,34 @@
     },
 
     "Constraint": {
-      "description": "テーブル制約。kind による discriminated union (unique / check / foreignKey)。",
+      "description": "テーブル制約。kind による discriminated union (primaryKey / unique / check / foreignKey)。複合 (composite) primary key は PrimaryKeyConstraint で表現 (#1185 提案 C)。単一カラム PK は従来通り Column.primaryKey: true でも表現可能だが、テーブル内で両方使うことは禁止 (mutual exclusion を runtime validator で強制、tableValidation.ts)。",
       "oneOf": [
+        { "$ref": "#/$defs/PrimaryKeyConstraint" },
         { "$ref": "#/$defs/UniqueConstraint" },
         { "$ref": "#/$defs/CheckConstraint" },
         { "$ref": "#/$defs/ForeignKeyConstraint" }
       ],
       "discriminator": { "propertyName": "kind" }
+    },
+
+    "PrimaryKeyConstraint": {
+      "description": "主キー (PRIMARY KEY) 制約。composite (複合) PK の表現に必須。単一カラム PK の場合は Column.primaryKey: true でも表現可能だが、本制約と Column.primaryKey の併用は禁止 (tableValidation.ts で runtime 検証、#1185 提案 C)。",
+      "type": "object",
+      "required": ["id", "kind", "columnIds"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
+        "kind": { "const": "primaryKey" },
+        "physicalName": { "$ref": "common.v3.schema.json#/$defs/PhysicalName", "description": "PK 制約の物理名 (例: 'pk_order_items')。省略時は DDL 生成側でテーブル名から自動生成。" },
+        "columnIds": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "common.v3.schema.json#/$defs/LocalId" },
+          "description": "PK を構成する Column.id 配列。複合 PK の場合は 2 件以上指定。"
+        },
+        "description": { "$ref": "common.v3.schema.json#/$defs/Description" }
+      }
     },
 
     "UniqueConstraint": {


### PR DESCRIPTION
## Summary

- ISSUE #1185 提案 C を実装、シリーズ最終 PR
- table.v3 Constraint.oneOf に PrimaryKeyConstraint を新設、**composite (複合) primary key** 表現を可能にする
- Column.primaryKey との重複は runtime validator (tableValidation.ts) で禁止 (mutual exclusion)
- ISSUE #1185 を本 PR で Close

## なぜ必要か

現状の schema では PK は \`Column.primaryKey: boolean\` のみで、**composite PK が表現不能**:
- 例: \`order_items\` を \`(order_id, line_no)\` で複合 PK にしたい場合、現状 schema では UniqueConstraint で代替するしかない
- ER 設計の自然な要求 (多対多中間テーブル / 履歴テーブル) で複合 PK は標準的

## 採用ポリシー

| 表現 | 用途 | 例 |
|---|---|---|
| Column.primaryKey: true | 単一カラム PK (backward compat) | UUID 主キー (現 examples の全 table) |
| PrimaryKeyConstraint (新設) | 単一/複合 PK 統一表現 (composite 必須) | \`(order_id, line_no)\` 複合 PK |
| 両者同時使用 | **禁止** (runtime validator で error) | DDL 生成が壊れるため |
| PrimaryKeyConstraint 複数 | **禁止** (1 table = 1 PK、runtime validator で error) | SQL semantic 違反 |

## 変更内訳

| file | 変更 |
|---|---|
| schemas/v3/table.v3.schema.json | PrimaryKeyConstraint \$def 新設、Constraint.oneOf 拡張、Constraint description 更新 |
| schemas/v3/extensions.v3.schema.json | CustomConstraintPattern.kind enum に \"primaryKey\" 追加 |
| frontend/src/utils/tableValidation.ts | PK 不在判定拡張 + 重複/多重 PK 制約検出 |
| frontend/src/utils/tableValidation.test.ts | PK mutual exclusion 5 tests 追加 |
| frontend/src/schemas/primary-key-constraint.schema.test.ts | 7 新規 schema tests |

## Test plan

- [x] \`npx vitest run src/schemas/primary-key-constraint.schema.test.ts\` → 7 / 7 pass
- [x] \`npx vitest run src/utils/tableValidation.test.ts\` → 17 / 17 pass (12 既存 + 5 新規)
- [x] \`npm run validate:samples\` 全 examples 5 種 pass
- [x] backend test 516 pass

## migration 不要

全 examples が single-column UUID PK で運用 (Column.primaryKey: true のみ使用)、PrimaryKeyConstraint を使う既存データなし。

## Future work

backend 側 DDL 生成 (将来) は Column.primaryKey と PrimaryKeyConstraint の両方を読み取る必要あり。本 PR では schema + runtime validator のみ実装、DDL 生成は別 ISSUE。

## ガバナンス

ISSUE #1185 設計者承認コメント (https://github.com/csilost2001/harmony/issues/1185#issuecomment-4488931724) に基づく。

Closes #1185 (PR 5/5 of series, final)

🤖 Generated with [Claude Code](https://claude.com/claude-code)