### PR TITLE
refactor(types): 14 consumer 移行 + StepKind alias + StepNote 移管 (#1186 Phase 2-B)

### DIFF
--- a/frontend/src/components/process-flow/ExternalOutcomesPanel.tsx
+++ b/frontend/src/components/process-flow/ExternalOutcomesPanel.tsx
@@ -1,13 +1,20 @@
 // @ts-nocheck -- legacy process-flow action panel types are being migrated; tracked by #1016.
 import { useState } from "react";
+// #1186 Phase 2-B: types/action → types/v3 + processFlowMetadata 移行
+// ExternalSystemStep / OtherStep / Step は v3 strict、ExternalCallOutcome / EXTERNAL_CALL_OUTCOME_VALUES は frontend UI metadata
 import type {
   ExternalSystemStep,
-  ExternalCallOutcome,
+  Step,
+} from "../../types/v3";
+// ExternalCallOutcomeSpec / OtherStep は AnyRecord 互換のため action.ts 経由 (#1186 Phase 2-D で v3 strict 化予定)
+import type {
   ExternalCallOutcomeSpec,
   OtherStep,
-  Step,
 } from "../../types/action";
-import { EXTERNAL_CALL_OUTCOME_VALUES } from "../../types/action";
+import {
+  EXTERNAL_CALL_OUTCOME_VALUES,
+  type ExternalCallOutcome,
+} from "../../utils/processFlowMetadata";
 import { generateUUID } from "../../utils/uuid";
 
 interface Props {

--- a/frontend/src/components/process-flow/MaturityBadge.tsx
+++ b/frontend/src/components/process-flow/MaturityBadge.tsx
@@ -1,4 +1,4 @@
-import type { Maturity } from "../../types/action";
+import type { Maturity } from "../../types/v3";
 
 interface Props {
   /** 未指定は "draft" 既定として扱う (docs/spec/process-flow-maturity.md §3) */

--- a/frontend/src/components/process-flow/NotesPanel.tsx
+++ b/frontend/src/components/process-flow/NotesPanel.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import type { StepNote, StepNoteType } from "../../types/action";
-import { STEP_NOTE_TYPE_VALUES } from "../../types/action";
+import type { StepNote, StepNoteType } from "../../utils/processFlowMetadata";
+import { STEP_NOTE_TYPE_VALUES } from "../../utils/processFlowMetadata";
 import { generateUUID } from "../../utils/uuid";
 
 interface Props {

--- a/frontend/src/components/process-flow/ProcessFlowEditor.tsx
+++ b/frontend/src/components/process-flow/ProcessFlowEditor.tsx
@@ -12,13 +12,15 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import { useWorkspacePath } from "../../hooks/useWorkspacePath";
+// #1186 Phase 2-B: types/action → types/v3 + processFlowMetadata 移行
+// ProcessFlow / Step は v3 strict 型、StepType は StepKind alias、ActionTrigger は v3 ActionTrigger
 import type {
   ProcessFlow,
   ActionTrigger,
   Step,
-  StepType,
-} from "../../types/action";
-import { STEP_TEMPLATES, STEP_TYPE_LABELS } from "../../types/action";
+  StepKind as StepType,
+} from "../../types/v3";
+import { STEP_TEMPLATES, STEP_TYPE_LABELS } from "../../utils/processFlowMetadata";
 import {
   loadProcessFlow,
   saveProcessFlow,

--- a/frontend/src/components/process-flow/SortableStepCard.tsx
+++ b/frontend/src/components/process-flow/SortableStepCard.tsx
@@ -1,7 +1,8 @@
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { StepCard } from "./StepCard";
-import type { ProcessFlow, Step, StepType } from "../../types/action";
+// #1186 Phase 2-B: types/action → types/v3 移行 (StepCard.tsx と整合)
+import type { ProcessFlow, Step, StepKind as StepType } from "../../types/v3";
 import type { ValidationError } from "../../utils/actionValidation";
 import type { ConventionsCatalog } from "../../schemas/conventionsValidator";
 

--- a/frontend/src/components/process-flow/StepCard.tsx
+++ b/frontend/src/components/process-flow/StepCard.tsx
@@ -1,17 +1,18 @@
 // @ts-nocheck -- StepCard still spans legacy/v3 process-flow unions; tracked by #1016.
 import { useState } from "react";
 import type { DraggableAttributes, DraggableSyntheticListeners } from "@dnd-kit/core";
+// #1186 Phase 2-B: types/action → types/v3 + processFlowMetadata 移行
 import type {
   ProcessFlow,
   Step,
-  StepType,
-} from "../../types/action";
+  StepKind as StepType,
+} from "../../types/v3";
 import {
   STEP_TYPE_LABELS,
   STEP_TYPE_ICONS,
   STEP_TYPE_COLORS,
   WORKFLOW_PATTERN_LABELS,
-} from "../../types/action";
+} from "../../utils/processFlowMetadata";
 import type { ValidationError } from "../../utils/actionValidation";
 import { getBindingName, getBindingOperation } from "../../utils/outputBinding";
 import { generateUUID } from "../../utils/uuid";

--- a/frontend/src/components/process-flow/TransactionScopeStepPanel.tsx
+++ b/frontend/src/components/process-flow/TransactionScopeStepPanel.tsx
@@ -1,18 +1,22 @@
 // @ts-nocheck -- legacy process-flow action panel types are being migrated; tracked by #1016.
 import { useState } from "react";
+// #1186 Phase 2-B: types/action → types/v3 + processFlowMetadata 移行
 import type {
   Step,
-  StepType,
+  StepKind as StepType,
   TransactionScopeStep,
+  ProcessFlow,
+} from "../../types/v3";
+// TransactionIsolationLevel / TransactionPropagation は action.ts に string 緩和あり、v3 strict 化は Phase 2-D
+import type {
   TransactionIsolationLevel,
   TransactionPropagation,
-  ProcessFlow,
 } from "../../types/action";
 import {
   STEP_TYPE_LABELS,
   STEP_TYPE_ICONS,
   STEP_TYPE_COLORS,
-} from "../../types/action";
+} from "../../utils/processFlowMetadata";
 import type { ConventionsCatalog } from "../../schemas/conventionsValidator";
 import type { ValidationError } from "../../utils/actionValidation";
 import { createDefaultStep } from "../../store/processFlowStore";

--- a/frontend/src/components/process-flow/WorkflowStepPanel.tsx
+++ b/frontend/src/components/process-flow/WorkflowStepPanel.tsx
@@ -1,16 +1,20 @@
 // @ts-nocheck -- legacy process-flow action panel types are being migrated; tracked by #1016.
 import type { ReactNode } from "react";
+// #1186 Phase 2-B: types/action → types/v3 + processFlowMetadata 移行
 import type {
   Step,
-  WorkflowApprover,
-  WorkflowPattern,
-  WorkflowQuorum,
   WorkflowStep,
+  WorkflowPattern,
+} from "../../types/v3";
+// WorkflowApprover / WorkflowQuorum は AnyRecord 互換のため action.ts 経由 (#1186 Phase 2-D で v3 strict 化予定)
+import type {
+  WorkflowApprover,
+  WorkflowQuorum,
 } from "../../types/action";
 import {
   WORKFLOW_PATTERN_LABELS,
   WORKFLOW_PATTERN_VALUES,
-} from "../../types/action";
+} from "../../utils/processFlowMetadata";
 import type { ConventionsCatalog } from "../../schemas/conventionsValidator";
 import { ConvCompletionInput } from "../common/ConvCompletionInput";
 

--- a/frontend/src/components/process-flow/internal/PaletteButtons.tsx
+++ b/frontend/src/components/process-flow/internal/PaletteButtons.tsx
@@ -7,8 +7,8 @@
 
 import type { ReactNode } from "react";
 import { useDraggable, useDroppable } from "@dnd-kit/core";
-import type { StepType } from "../../../types/action";
-import { STEP_TYPE_LABELS, STEP_TYPE_ICONS, STEP_TYPE_COLORS } from "../../../types/action";
+import type { StepKind as StepType } from "../../../types/v3";
+import { STEP_TYPE_LABELS, STEP_TYPE_ICONS, STEP_TYPE_COLORS } from "../../../utils/processFlowMetadata";
 
 export function ToolbarStepButton({
   type,

--- a/frontend/src/components/process-flow/internal/PalettePanel.tsx
+++ b/frontend/src/components/process-flow/internal/PalettePanel.tsx
@@ -2,8 +2,8 @@
 // Phase-3 (#1145): ProcessFlowEditor.tsx 左サイドバー (パレット) を抽出。
 // 基本ステップ button / カスタムステップ button / テンプレート dropdown。
 
-import type { StepType } from "../../../types/action";
-import { STEP_TEMPLATES } from "../../../types/action";
+import type { StepKind as StepType } from "../../../types/v3";
+import { STEP_TEMPLATES } from "../../../utils/processFlowMetadata";
 import { ToolbarStepButton, CustomStepButton } from "./PaletteButtons";
 
 export interface PalettePanelProps {

--- a/frontend/src/components/process-flow/internal/StepContextMenu.tsx
+++ b/frontend/src/components/process-flow/internal/StepContextMenu.tsx
@@ -2,8 +2,8 @@
 // Phase-3 (#1145): ProcessFlowEditor.tsx からステップカードの右クリックコンテキストメニューを抽出。
 // 通常モード ⇔ サブステップ追加 (subType picker) モードの切替を内部 prop 経由で受ける。
 
-import type { StepType } from "../../../types/action";
-import { STEP_TYPE_ICONS, STEP_TYPE_LABELS, STEP_TYPE_COLORS } from "../../../types/action";
+import type { StepKind as StepType } from "../../../types/v3";
+import { STEP_TYPE_ICONS, STEP_TYPE_LABELS, STEP_TYPE_COLORS } from "../../../utils/processFlowMetadata";
 import { ALL_SUB_STEP_TYPES } from "./stepCardConstants";
 
 export interface StepContextMenuProps {

--- a/frontend/src/components/process-flow/internal/stepCardConstants.ts
+++ b/frontend/src/components/process-flow/internal/stepCardConstants.ts
@@ -1,4 +1,7 @@
-import type { DbOperation, StepType } from "../../../types/action";
+// #1186 Phase 2-B: types/action → types/v3 移行
+import type { StepKind as StepType } from "../../../types/v3";
+// DbOperation は action.ts に string として定義、schema 上は DbAccessStep.operation 固有 (固有型なし)
+type DbOperation = string;
 
 /**
  * ProcessFlowEditor のパレット (toolbar) に表示する全 step kind。

--- a/frontend/src/types/action.ts
+++ b/frontend/src/types/action.ts
@@ -39,22 +39,9 @@ export type ActionFields = StructuredField[] | string | undefined;
 export type MarkerKind = string;
 export type Marker = AnyRecord;
 
-// ── StepNote (#1186 Phase 1 で 5 値正規化済) ────────────────────────────────
-export type StepNoteType =
-  | "assumption"
-  | "prerequisite"
-  | "todo"
-  | "deferred"
-  | "question";
-export interface StepNote {
-  id: string;
-  /** common.v3 Note 規範。v3 schema 上 field 名は `kind` 必須 (旧 `type` は read 互換のみ)。 */
-  kind?: StepNoteType;
-  /** @deprecated v1/v2 legacy field。新規書込は `kind` を使用。 */
-  type?: StepNoteType;
-  body: string;
-  createdAt: string;
-}
+// ── StepNote (#1186 Phase 2-B で processFlowMetadata.ts に移管) ─────────────
+// backward compat 用 re-export。新規 consumer は @/utils/processFlowMetadata 直接 import 推奨。
+export type { StepNoteType, StepNote } from "../utils/processFlowMetadata";
 
 // ── StepKind (v3 schema 25 種、componentCall / aiCall / aiAgent / cdc / closing / log / audit 含む) ──
 export type StepKind =
@@ -189,16 +176,7 @@ export type GlossaryEntry = AnyRecord;
 export type TestScenario = AnyRecord;
 export type TemplateStep = AnyRecord;
 
-// ── StepNote 関連定数 (Phase 1 で 5 値正規化済) ─────────────────────────────
-export const STEP_NOTE_TYPE_VALUES: readonly StepNoteType[] = [
-  "assumption",
-  "prerequisite",
-  "todo",
-  "deferred",
-  "question",
-] as const;
-
-// ── UI 表示メタデータ定数 (processFlowMetadata.ts から re-export、#1186 Phase 2-A) ──
+// ── UI 表示メタデータ定数 (processFlowMetadata.ts から re-export、#1186 Phase 2-A/B) ──
 // 旧 consumer の `import { STEP_TYPE_LABELS } from "@/types/action"` 互換維持。
 // 新規 consumer は `@/utils/processFlowMetadata` から直接 import すること。
 export {
@@ -213,5 +191,6 @@ export {
   WORKFLOW_PATTERN_LABELS,
   DB_OPERATION_LABELS,
   STEP_TEMPLATES,
+  STEP_NOTE_TYPE_VALUES,
   type StepTemplate,
 } from "../utils/processFlowMetadata";

--- a/frontend/src/types/v3/process-flow.ts
+++ b/frontend/src/types/v3/process-flow.ts
@@ -949,6 +949,13 @@ export type Step =
 /** Return を除く Step subset (ExternalCallOutcomeSpec.sideEffects 等で使用)。 */
 export type NonReturnStep = Exclude<Step, ReturnStep>;
 
+/**
+ * Step.kind の union (#1186 Phase 2-B で追加)。
+ * Step union から `kind` プロパティ型を抽出。25 variant + ExtensionStep の `namespace:StepName` pattern を含む。
+ * ExtensionStep の kind は `string` のため最終的に `string` に decay する点に注意 (組み込み 24 + 任意の文字列)。
+ */
+export type StepKind = Step["kind"];
+
 // ─── ProcessFlow root ────────────────────────────────────────────────────
 
 /**

--- a/frontend/src/utils/processFlowMetadata.ts
+++ b/frontend/src/utils/processFlowMetadata.ts
@@ -16,7 +16,31 @@
  * 新規 consumer は本ファイルから直接 import すること。
  */
 
+import type { Note } from "../types/v3/common";
 import type { WorkflowPattern } from "../types/v3/process-flow";
+
+// ── StepNote (common.v3 Note 派生 + v1/v2 legacy 互換 field) ────────────────
+// #1186 Phase 2-B: action.ts から移管 (UI 表示 + migration 互換が frontend 固有概念のため)
+export type StepNoteType = Note["kind"]; // common.v3 Note.kind と完全一致 (5 値)
+
+export interface StepNote {
+  id: string;
+  /** common.v3 Note 規範。v3 schema 上 field 名は `kind` 必須 (旧 `type` は read 互換のみ)。 */
+  kind?: StepNoteType;
+  /** @deprecated v1/v2 legacy field。新規書込は `kind` を使用。 */
+  type?: StepNoteType;
+  body: string;
+  createdAt: string;
+}
+
+// common.v3 Note.kind と完全一致 (5 値、順序は schema 列挙順)
+export const STEP_NOTE_TYPE_VALUES: readonly StepNoteType[] = [
+  "assumption",
+  "prerequisite",
+  "todo",
+  "deferred",
+  "question",
+] as const;
 
 // ── ActionTrigger (Action.trigger) ─────────────────────────────────────────
 export const ACTION_TRIGGER_LABELS: Record<string, string> = {

--- a/frontend/src/utils/specExporter.test.ts
+++ b/frontend/src/utils/specExporter.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import { generateSpecJson, type SpecStep } from "./specExporter";
 import type { Table, TableId, LocalId, PhysicalName, DisplayName, Timestamp, ErLayout } from "../types/v3";
 import type { FlowProject } from "../types/flow";
+// #1186 Phase 2-B: types/action → types/v3 移行
+// 24 step variants は v3 strict 型、ProcessFlow も v3 strict
 import type {
   AuditStep,
   CdcStep,
@@ -13,13 +15,14 @@ import type {
   LogStep,
   LoopBreakStep,
   LoopContinueStep,
-  OtherStep,
   ProcessFlow,
   ReturnStep,
   Step,
   ValidationStep,
   WorkflowStep,
-} from "../types/action";
+} from "../types/v3";
+// OtherStep は v3 に無い (extension で表現)、AnyRecord 互換のため action.ts 経由
+import type { OtherStep } from "../types/action";
 
 function makeFlow(steps: Step[]): ProcessFlow {
   return {


### PR DESCRIPTION
## Summary

- ISSUE #1186 Phase 2-B: action.ts 経由 import の段階移行 14 file
- types/v3/process-flow.ts に \`StepKind = Step[\"kind\"]\` named export 追加
- StepNote / StepNoteType / STEP_NOTE_TYPE_VALUES を types/action.ts から utils/processFlowMetadata.ts に移管 (UI metadata の自然な置き場所)

## 移行した consumer (14 file)

すべて leaf 寄りで型互換ある consumer から優先実施。AnyRecord 依存の重いコンポーネント (ProcessFlowEditor 系の一部、AiReviewDialog 等) は Phase 2-C/D で別 PR。

詳細は commit message 参照。

## 主要構造変更

| ファイル | 変更 |
|---|---|
| types/v3/process-flow.ts | \`export type StepKind = Step[\"kind\"]\` 追加 (consumer 利便性) |
| utils/processFlowMetadata.ts | StepNote / StepNoteType / STEP_NOTE_TYPE_VALUES 移管 |
| types/action.ts | 移管項目を re-export only に縮退 (backward compat) |

## 残置 (Phase 2-C/D 以降)

WorkflowApprover / WorkflowQuorum / TransactionIsolationLevel / TransactionPropagation / ExternalCallOutcomeSpec / OtherStep 等は action.ts に AnyRecord として残置。残り 85 file は backward compat re-export 経由で動作。

## Test plan

- [x] frontend build (tsc + vite) → OK
- [x] frontend test → 2346 / 2346 pass
- [x] backend test → 516 / 516 pass
- [x] validate:samples (retail / realestate) → 7+1 flows pass

Refs #1186

🤖 Generated with [Claude Code](https://claude.com/claude-code)