### PR TITLE
refactor(types): 6 file 移行 (LogStep/AuditStep/store/AppShell) + legacy type field 解消 (#1186 Phase 2-C)

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -632,7 +632,8 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
       } else {
         loadProcessFlow(processFlowId).then((ag) => {
           if (ag) {
-            openTab({ id: tabId, type: "process-flow", resourceId: processFlowId, label: ag.name });
+            // #1186 Phase 2-C: v3 ProcessFlow は name を meta.name に持つ (旧 AnyRecord 時代の .name は undefined)
+            openTab({ id: tabId, type: "process-flow", resourceId: processFlowId, label: ag.meta.name });
           } else {
             fallbackToDashboard("処理フロー", processFlowId);
           }

--- a/frontend/src/components/process-flow/AuditStepPanel.test.tsx
+++ b/frontend/src/components/process-flow/AuditStepPanel.test.tsx
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, fireEvent } from "@testing-library/react";
 import { AuditStepPanel } from "./AuditStepPanel";
-import type { AuditStep } from "../../types/action";
+// #1186 Phase 2-C: types/action → types/v3 移行 + 旧 `type:` field を schema 正規 `kind:` に
+import type { AuditStep } from "../../types/v3";
 
 const baseStep: AuditStep = {
   id: "test-step",
-  type: "audit",
+  kind: "audit",
   description: "",
   action: "order.create",
   maturity: "draft",

--- a/frontend/src/components/process-flow/AuditStepPanel.tsx
+++ b/frontend/src/components/process-flow/AuditStepPanel.tsx
@@ -1,4 +1,5 @@
-import type { AuditStep } from "../../types/action";
+// #1186 Phase 2-C: types/action → types/v3 移行
+import type { AuditStep } from "../../types/v3";
 import type { ConventionsCatalog } from "../../schemas/conventionsValidator";
 import { ConvCompletionInput } from "../common/ConvCompletionInput";
 

--- a/frontend/src/components/process-flow/LogStepPanel.test.tsx
+++ b/frontend/src/components/process-flow/LogStepPanel.test.tsx
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, fireEvent } from "@testing-library/react";
 import { LogStepPanel } from "./LogStepPanel";
-import type { LogStep } from "../../types/action";
+// #1186 Phase 2-C: types/action → types/v3 移行 + 旧 `type:` field を schema 正規 `kind:` に
+import type { LogStep } from "../../types/v3";
 
 const baseStep: LogStep = {
   id: "test-step",
-  type: "log",
+  kind: "log",
   description: "",
   level: "info",
   message: "test",

--- a/frontend/src/components/process-flow/LogStepPanel.tsx
+++ b/frontend/src/components/process-flow/LogStepPanel.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from "react";
-import type { LogStep } from "../../types/action";
+// #1186 Phase 2-C: types/action → types/v3 移行
+import type { LogStep } from "../../types/v3";
 import type { ConventionsCatalog } from "../../schemas/conventionsValidator";
 import { ConvCompletionInput } from "../common/ConvCompletionInput";
 import { generateUUID } from "../../utils/uuid";

--- a/frontend/src/store/processFlowStore.ts
+++ b/frontend/src/store/processFlowStore.ts
@@ -1,12 +1,13 @@
 ﻿// @ts-nocheck -- legacy process-flow store migration remains open; tracked by #1016.
+// #1186 Phase 2-C: types/action → types/v3 移行 (ProcessFlowType/StepType は v3 で ProcessFlowKind/StepKind に rename)
 import type {
   ActionDefinition,
   ActionTrigger,
   ProcessFlow,
-  ProcessFlowType,
+  ProcessFlowKind as ProcessFlowType,
   Step,
-  StepType,
-} from "../types/action";
+  StepKind as StepType,
+} from "../types/v3";
 import type { ProcessFlowId, ScreenId, Timestamp } from "../types/v3";
 import type { ProcessFlowMeta as FlowProcessFlowMeta } from "../types/flow";
 import { migrateProcessFlow, PROCESS_FLOW_V3_SCHEMA_REF } from "../utils/actionMigration";


### PR DESCRIPTION
## Summary

- ISSUE #1186 Phase 2-C: LogStepPanel / AuditStepPanel 系を完全 v3 化
- processFlowStore.ts の ProcessFlowType/StepType を v3 alias 化
- **副次的発見**: AppShell.tsx の旧 AnyRecord 時代の dead-access (\`ag.name\` → \`ag.meta.name\`) 修正

## 変更 (6 file)

| file | 内容 |
|---|---|
| LogStepPanel.tsx | LogStep → v3 |
| LogStepPanel.test.tsx | LogStep → v3 + \`type: \"log\"\` → \`kind: \"log\"\` (schema 正規化) |
| AuditStepPanel.tsx | AuditStep → v3 |
| AuditStepPanel.test.tsx | AuditStep → v3 + \`type: \"audit\"\` → \`kind: \"audit\"\` |
| processFlowStore.ts | ActionDefinition/ActionTrigger/ProcessFlow/Step/ProcessFlowType/StepType → v3 |
| AppShell.tsx | \`ag.name\` → \`ag.meta.name\` (副次的バグ修正) |

## Migration による silent bug 発見

processFlowStore.ts の return type が v3 strict 化したことで AppShell.tsx の \`ag.name\` access が型エラーに。**v3 strict 化していなければ気づけなかった silent bug** (旧 AnyRecord 時代は undefined access で実行時 error にならず通っていた可能性) を解消。

→ Phase 2 進行の副産物として、似た silent bug が他にも潜んでいる可能性あり (今後の Phase 2-D/3 で順次顕在化見込み)。

## Test plan

- [x] frontend build (tsc + vite) → OK
- [x] frontend test → 2346 / 2346 pass
- [x] backend test → 516 / 516 pass
- [x] validate:samples → pass

## 残置 (#1186 Phase 2-D 以降で継続)

action.ts 経由 import の残り 85 file は AnyRecord 依存 (loose 型アクセス想定)。v3 strict 化には consumer 内部のアクセスパターン書き換えが必要、scope 大のため ISSUE #1186 で別 phase として継続。

Refs #1186

🤖 Generated with [Claude Code](https://claude.com/claude-code)