### PR TITLE
refactor(types): SecretRef を AnyRecord → SecretEntry strict 型 alias に修正 (Codex review follow-up)

### DIFF
--- a/frontend/src/types/v3/index.ts
+++ b/frontend/src/types/v3/index.ts
@@ -105,11 +105,15 @@ export type ValidationRuleType =
   | "enum"
   | "custom";
 
-// ── SecretRef / ErrorCatalogEntry / EventDef / EnvVarEntry 等の catalog entry 型 (frontend では緩く扱う) ──
-/* eslint-disable @typescript-eslint/no-explicit-any -- legacy compat */
+// ── Legacy catalog entry alias (frontend では緩く扱うが、strict 型がある場合は再 export) ──
+// #1186 Phase 2 で action.ts AnyRecord から v3 strict 型へ。Codex review 指摘 (2026-05-20)。
+import type { SecretEntry as _SecretEntry } from "./process-flow";
+/** @deprecated 旧 v1/v2 名。v3 strict 型は SecretEntry (process-flow.v3 #/$defs/SecretEntry) */
+export type SecretRef = _SecretEntry;
+
+/* eslint-disable @typescript-eslint/no-explicit-any -- 以下は v3 strict 型未定義のため互換 alias */
 type _AnyRecord = Record<string, any>;
 /* eslint-enable @typescript-eslint/no-explicit-any */
-export type SecretRef = _AnyRecord;
 export type StepBase = unknown;
 export type OtherStep = _AnyRecord;
 export type WorkflowApprover = _AnyRecord;


### PR DESCRIPTION
## Summary

- #1186 Phase 3 完了後の **Codex 独立 review** (2026-05-20) で指摘された type 精度問題を解消
- SecretRef を AnyRecord alias から SecretEntry (v3 strict 型) re-export に変更

## Codex 指摘

> \`frontend/src/types/v3/index.ts:108-110\` の SecretRef は本来 catalog entry として strict 型があるべきであり、AnyRecord で出すのは意味的に不正確

→ \`process-flow.v3.schema.json#/\$defs/SecretEntry\` (source / name / description) を re-export に変更。

## 変更

| file | 変更 |
|---|---|
| frontend/src/types/v3/index.ts | \`SecretRef = SecretEntry\` (process-flow.v3 #/\$defs/SecretEntry) |

## 他の AnyRecord alias は温存

OtherStep / WorkflowApprover / WorkflowQuorum / ExternalCallOutcomeSpec / StepBase は v3 schema 上 strict 型が現状存在しないため温存。これらが strict 必要になったタイミングで schema 拡張提案を別 ISSUE 起票。

## Test plan

- [x] frontend build (tsc + vite) → OK
- [x] frontend test → 2346 / 2346 pass
- [x] validate:samples 全 5 example → pass (retail 7/7, realestate 1/1+1warn, english-learning 5/5, english-learning-tailwind 5/5, diary 15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)