### PR TITLE
refactor(types): step-card body 10 file の @ts-nocheck 除去 + generic StepCardBodyBaseProps<S> 化 (#1016 batch 1)

### DIFF
--- a/frontend/src/components/process-flow/internal/step-cards/AiAgentStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/AiAgentStepCardBody.tsx
@@ -1,13 +1,13 @@
-// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
 // Phase-3 (#1145、#1163 review Phase-2 補足): StepCard.tsx で dispatch が未実装だった
 // `aiAgent` kind (PR #935/#936 で schema 追加) に最小 body を提供する。
 // AiAgentStep: modelRef + messages + tools (1 件以上必須) + maxIterations。
 // multi-step agent loop。tool が無い single-shot は AiCallStep を使う。
+// #1016 follow-up (2026-05-20): generic StepCardBodyBaseProps<AiAgentStep> で type narrow、@ts-nocheck 除去。
 
-import type { Step } from "../../../../types/v3";
+import type { AiAgentStep, Identifier } from "../../../../types/v3";
 import type { StepCardBodyBaseProps } from "./types";
 
-export type AiAgentStepCardBodyProps = StepCardBodyBaseProps;
+export type AiAgentStepCardBodyProps = StepCardBodyBaseProps<AiAgentStep>;
 
 export function AiAgentStepCardBody({
   step,
@@ -28,7 +28,7 @@ export function AiAgentStepCardBody({
             type="text"
             className="form-control form-control-sm"
             value={step.modelRef ?? ""}
-            onChange={(e) => onChange({ modelRef: e.target.value } as Partial<Step>)}
+            onChange={(e) => onChange({ modelRef: e.target.value as Identifier })}
             onBlur={onCommit}
             placeholder="例: agentModel"
             style={{ fontFamily: "monospace", fontSize: "0.85rem" }}
@@ -44,7 +44,7 @@ export function AiAgentStepCardBody({
             className="form-control form-control-sm"
             min={1}
             value={step.maxIterations ?? 10}
-            onChange={(e) => onChange({ maxIterations: Number(e.target.value) || 1 } as Partial<Step>)}
+            onChange={(e) => onChange({ maxIterations: Number(e.target.value) || 1 })}
             onBlur={onCommit}
           />
         </div>
@@ -62,7 +62,7 @@ export function AiAgentStepCardBody({
             try {
               const parsed = JSON.parse(e.target.value);
               if (Array.isArray(parsed)) {
-                onChange({ messages: parsed } as Partial<Step>);
+                onChange({ messages: parsed });
               }
             } catch {
               // ignore
@@ -86,7 +86,7 @@ export function AiAgentStepCardBody({
             try {
               const parsed = JSON.parse(e.target.value);
               if (Array.isArray(parsed)) {
-                onChange({ tools: parsed } as Partial<Step>);
+                onChange({ tools: parsed });
               }
             } catch {
               // ignore

--- a/frontend/src/components/process-flow/internal/step-cards/AiCallStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/AiCallStepCardBody.tsx
@@ -1,12 +1,12 @@
-// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
 // Phase-3 (#1145、#1163 review Phase-2 補足): StepCard.tsx で dispatch が未実装だった
 // `aiCall` kind (PR #935/#936 で schema 追加) に最小 body を提供する。
 // AiCallStep: modelRef + messages + tools (任意) + responseFormat (任意)。
+// #1016 follow-up (2026-05-20): generic StepCardBodyBaseProps<AiCallStep> で type narrow、@ts-nocheck 除去。
 
-import type { Step } from "../../../../types/v3";
+import type { AiCallStep, Identifier } from "../../../../types/v3";
 import type { StepCardBodyBaseProps } from "./types";
 
-export type AiCallStepCardBodyProps = StepCardBodyBaseProps;
+export type AiCallStepCardBodyProps = StepCardBodyBaseProps<AiCallStep>;
 
 export function AiCallStepCardBody({
   step,
@@ -26,7 +26,7 @@ export function AiCallStepCardBody({
             type="text"
             className="form-control form-control-sm"
             value={step.modelRef ?? ""}
-            onChange={(e) => onChange({ modelRef: e.target.value } as Partial<Step>)}
+            onChange={(e) => onChange({ modelRef: e.target.value as Identifier })}
             onBlur={onCommit}
             placeholder="例: summarizeModel / projectModel"
             style={{ fontFamily: "monospace", fontSize: "0.85rem" }}
@@ -46,7 +46,7 @@ export function AiCallStepCardBody({
             try {
               const parsed = JSON.parse(e.target.value);
               if (Array.isArray(parsed)) {
-                onChange({ messages: parsed } as Partial<Step>);
+                onChange({ messages: parsed });
               }
             } catch {
               // JSON parse 失敗は無視 (blur で再 commit)
@@ -69,13 +69,13 @@ export function AiCallStepCardBody({
           onChange={(e) => {
             const trimmed = e.target.value.trim();
             if (!trimmed) {
-              onChange({ parameters: undefined } as Partial<Step>);
+              onChange({ parameters: undefined });
               return;
             }
             try {
               const parsed = JSON.parse(trimmed);
               if (parsed && typeof parsed === "object") {
-                onChange({ parameters: parsed } as Partial<Step>);
+                onChange({ parameters: parsed });
               }
             } catch {
               // ignore

--- a/frontend/src/components/process-flow/internal/step-cards/AuditStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/AuditStepCardBody.tsx
@@ -1,7 +1,7 @@
-// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
 // Phase-2 (#1145): StepCard.tsx の `step.kind === "audit"` body を抽出 (#402)。
+// #1016 follow-up (2026-05-20): generic StepCardBodyBaseProps<AuditStep> で type narrow、@ts-nocheck 除去。
 
-import type { Step } from "../../../../types/v3";
+import type { AuditStep } from "../../../../types/v3";
 import { AuditStepPanel } from "../../AuditStepPanel";
 import type {
   StepCardBodyBaseProps,
@@ -9,7 +9,7 @@ import type {
 } from "./types";
 
 export interface AuditStepCardBodyProps
-  extends StepCardBodyBaseProps,
+  extends StepCardBodyBaseProps<AuditStep>,
     Pick<StepCardBodyCatalogProps, "conventions"> {}
 
 export function AuditStepCardBody({
@@ -21,7 +21,7 @@ export function AuditStepCardBody({
   return (
     <AuditStepPanel
       step={step}
-      onChange={(patch) => onChange(patch as Partial<Step>)}
+      onChange={onChange}
       onCommit={onCommit}
       conventions={conventions ?? null}
     />

--- a/frontend/src/components/process-flow/internal/step-cards/CommonProcessStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/CommonProcessStepCardBody.tsx
@@ -1,14 +1,14 @@
-// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
 // Phase-2 (#1145): StepCard.tsx の `step.kind === "commonProcess"` body を抽出。
+// #1016 follow-up (2026-05-20): generic StepCardBodyBaseProps<CommonProcessStep> で type narrow、@ts-nocheck 除去。
 
-import type { Step } from "../../../../types/v3";
+import type { CommonProcessStep, ProcessFlowId } from "../../../../types/v3";
 import type {
   StepCardBodyBaseProps,
   StepCardBodyCommonGroupsProps,
 } from "./types";
 
 export interface CommonProcessStepCardBodyProps
-  extends StepCardBodyBaseProps,
+  extends StepCardBodyBaseProps<CommonProcessStep>,
     StepCardBodyCommonGroupsProps {}
 
 export function CommonProcessStepCardBody({
@@ -26,8 +26,8 @@ export function CommonProcessStepCardBody({
             className="form-select form-select-sm"
             value={step.refId}
             onChange={(e) => {
-              const cg = commonGroups.find((g) => g.id === e.target.value);
-              onChange({ refId: e.target.value, refName: cg?.name ?? "" } as Partial<Step>);
+              // #1016 follow-up: refName は v3 schema 外 field のため除去 (AJV unevaluatedProperties: false で reject される silent bug を解消)
+              onChange({ refId: e.target.value as ProcessFlowId });
             }}
           >
             <option value="">（選択）</option>
@@ -57,7 +57,7 @@ export function CommonProcessStepCardBody({
             }
             onChange({
               argumentMapping: Object.keys(map).length > 0 ? map : undefined,
-            } as Partial<Step>);
+            });
           }}
           onBlur={onCommit}
           placeholder={"sessionId=@session.id\ntrustedLevel='high'"}

--- a/frontend/src/components/process-flow/internal/step-cards/ComponentCallStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/ComponentCallStepCardBody.tsx
@@ -1,12 +1,11 @@
-// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
 // Phase-3 (#1145、#1163 review Phase-2 補足): StepCard.tsx で dispatch が未実装だった
 // `componentCall` kind (PR #1066 で schema 追加) に最小 body を提供する。
 // CommonProcessStepCardBody と類似 (componentRef + operation + argumentMapping / returnMapping)。
 
-import type { Step } from "../../../../types/v3";
+import type { ComponentCallStep } from "../../../../types/v3";
 import type { StepCardBodyBaseProps } from "./types";
 
-export type ComponentCallStepCardBodyProps = StepCardBodyBaseProps;
+export type ComponentCallStepCardBodyProps = StepCardBodyBaseProps<ComponentCallStep>;
 
 export function ComponentCallStepCardBody({
   step,
@@ -25,7 +24,7 @@ export function ComponentCallStepCardBody({
             type="text"
             className="form-control form-control-sm"
             value={step.componentRef ?? ""}
-            onChange={(e) => onChange({ componentRef: e.target.value } as Partial<Step>)}
+            onChange={(e) => onChange({ componentRef: e.target.value })}
             onBlur={onCommit}
             placeholder="例: generic-definitions/component-definition/OrderValidator"
             style={{ fontFamily: "monospace", fontSize: "0.85rem" }}
@@ -42,7 +41,7 @@ export function ComponentCallStepCardBody({
             type="text"
             className="form-control form-control-sm"
             value={step.operation ?? ""}
-            onChange={(e) => onChange({ operation: e.target.value } as Partial<Step>)}
+            onChange={(e) => onChange({ operation: e.target.value })}
             onBlur={onCommit}
             placeholder="例: validate"
           />
@@ -68,7 +67,7 @@ export function ComponentCallStepCardBody({
             }
             onChange({
               argumentMapping: Object.keys(map).length > 0 ? map : undefined,
-            } as Partial<Step>);
+            });
           }}
           onBlur={onCommit}
           placeholder={"order=@input.order\nstrict=true"}
@@ -95,7 +94,7 @@ export function ComponentCallStepCardBody({
             }
             onChange({
               returnMapping: Object.keys(map).length > 0 ? map : undefined,
-            } as Partial<Step>);
+            });
           }}
           onBlur={onCommit}
           placeholder={"isValid=successFlag\nerrors=validationErrors"}

--- a/frontend/src/components/process-flow/internal/step-cards/ComputeStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/ComputeStepCardBody.tsx
@@ -1,7 +1,6 @@
-// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
 // Phase-2 (#1145): StepCard.tsx の `step.kind === "compute"` body を抽出。
 
-import type { Step } from "../../../../types/v3";
+import type { ComputeStep } from "../../../../types/v3";
 import { ConvCompletionInput } from "../../../common/ConvCompletionInput";
 import type {
   StepCardBodyBaseProps,
@@ -9,7 +8,7 @@ import type {
 } from "./types";
 
 export interface ComputeStepCardBodyProps
-  extends StepCardBodyBaseProps,
+  extends StepCardBodyBaseProps<ComputeStep>,
     Pick<StepCardBodyCatalogProps, "conventions"> {}
 
 export function ComputeStepCardBody({
@@ -28,7 +27,7 @@ export function ComputeStepCardBody({
         <ConvCompletionInput
           className="form-control form-control-sm"
           value={step.expression}
-          onValueChange={(v) => onChange({ expression: v } as Partial<Step>)}
+          onValueChange={(v) => onChange({ expression: v })}
           onCommit={onCommit}
           conventions={conventions ?? null}
           placeholder="例: Math.floor(@subtotal * 0.10) / @subtotal + @taxAmount"

--- a/frontend/src/components/process-flow/internal/step-cards/DisplayUpdateStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/DisplayUpdateStepCardBody.tsx
@@ -1,10 +1,9 @@
-// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
 // Phase-2 (#1145): StepCard.tsx の `step.kind === "displayUpdate"` body を抽出。
 
-import type { Step } from "../../../../types/v3";
+import type { DisplayUpdateStep } from "../../../../types/v3";
 import type { StepCardBodyBaseProps } from "./types";
 
-export type DisplayUpdateStepCardBodyProps = StepCardBodyBaseProps;
+export type DisplayUpdateStepCardBodyProps = StepCardBodyBaseProps<DisplayUpdateStep>;
 
 export function DisplayUpdateStepCardBody({
   step,
@@ -18,7 +17,7 @@ export function DisplayUpdateStepCardBody({
         <input
           className="form-control form-control-sm"
           value={step.target}
-          onChange={(e) => onChange({ target: e.target.value } as Partial<Step>)}
+          onChange={(e) => onChange({ target: e.target.value })}
           onBlur={onCommit}
           placeholder="メッセージ表示、一覧テーブル更新 等"
         />

--- a/frontend/src/components/process-flow/internal/step-cards/LogStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/LogStepCardBody.tsx
@@ -1,7 +1,6 @@
-// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
 // Phase-2 (#1145): StepCard.tsx の `step.kind === "log"` body を抽出 (#402)。
 
-import type { Step } from "../../../../types/v3";
+import type { LogStep } from "../../../../types/v3";
 import { LogStepPanel } from "../../LogStepPanel";
 import type {
   StepCardBodyBaseProps,
@@ -9,7 +8,7 @@ import type {
 } from "./types";
 
 export interface LogStepCardBodyProps
-  extends StepCardBodyBaseProps,
+  extends StepCardBodyBaseProps<LogStep>,
     Pick<StepCardBodyCatalogProps, "conventions"> {}
 
 export function LogStepCardBody({
@@ -21,7 +20,7 @@ export function LogStepCardBody({
   return (
     <LogStepPanel
       step={step}
-      onChange={(patch) => onChange(patch as Partial<Step>)}
+      onChange={(patch) => onChange(patch)}
       onCommit={onCommit}
       conventions={conventions ?? null}
     />

--- a/frontend/src/components/process-flow/internal/step-cards/TransactionScopeStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/TransactionScopeStepCardBody.tsx
@@ -1,7 +1,6 @@
-// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
 // Phase-2 (#1145): StepCard.tsx の `step.kind === "transactionScope"` body を抽出 (#415)。
 
-import type { Step } from "../../../../types/v3";
+import type { TransactionScopeStep } from "../../../../types/v3";
 import { TransactionScopeStepPanel } from "../../TransactionScopeStepPanel";
 import type {
   StepCardBodyBaseProps,
@@ -13,7 +12,7 @@ import type {
 } from "./types";
 
 export interface TransactionScopeStepCardBodyProps
-  extends StepCardBodyBaseProps,
+  extends StepCardBodyBaseProps<TransactionScopeStep>,
     StepCardBodyCatalogProps,
     StepCardBodyTableProps,
     StepCardBodyScreenProps,
@@ -36,7 +35,7 @@ export function TransactionScopeStepCardBody({
   return (
     <TransactionScopeStepPanel
       step={step}
-      onChange={(patch) => onChange(patch as Partial<Step>)}
+      onChange={(patch) => onChange(patch)}
       onCommit={onCommit}
       group={group}
       allSteps={allSteps}

--- a/frontend/src/components/process-flow/internal/step-cards/WorkflowStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/WorkflowStepCardBody.tsx
@@ -1,7 +1,6 @@
-// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
 // Phase-2 (#1145): StepCard.tsx の `step.kind === "workflow"` body を抽出。
 
-import type { Step } from "../../../../types/v3";
+import type { WorkflowStep } from "../../../../types/v3";
 import { WorkflowStepPanel } from "../../WorkflowStepPanel";
 import { InlineStepList } from "../InlineStepList";
 import type {
@@ -14,7 +13,7 @@ import type {
 } from "./types";
 
 export interface WorkflowStepCardBodyProps
-  extends StepCardBodyBaseProps,
+  extends StepCardBodyBaseProps<WorkflowStep>,
     StepCardBodyCatalogProps,
     StepCardBodyTableProps,
     StepCardBodyScreenProps,
@@ -39,7 +38,7 @@ export function WorkflowStepCardBody({
       step={step}
       allSteps={allSteps}
       conventions={conventions ?? null}
-      onChange={(patch) => onChange(patch as Partial<Step>)}
+      onChange={(patch) => onChange(patch)}
       onCommit={onCommit}
       renderInlineStepList={({ steps, parentLabel, onChange: onStepsChange }) => (
         <InlineStepList

--- a/frontend/src/components/process-flow/internal/step-cards/types.ts
+++ b/frontend/src/components/process-flow/internal/step-cards/types.ts
@@ -1,17 +1,17 @@
-// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
 // Phase-2 (#1145) で StepCard.tsx から各 kind 別 body sub-component を抽出する際の共通 props 型。
-// 各 sub-component は本 `StepCardBodyBaseProps` を拡張せず使い回す (1 sub = 1 kind 専用)。
+// #1016 follow-up (2026-05-20): generic 化により step を specific variant で narrow 可能に。
+// 各 sub-component は `StepCardBodyBaseProps<XxxStep>` で固有 step 型を指定する。
 
 import type { ProcessFlow, Step } from "../../../../types/v3";
 import type { ValidationError } from "../../../../utils/actionValidation";
 
-export interface StepCardBodyBaseProps {
-  /** 対象 step (kind discriminator は各 sub-component 側で検査済) */
-  step: Step;
+export interface StepCardBodyBaseProps<S extends Step = Step> {
+  /** 対象 step (kind discriminator narrow 済の specific variant) */
+  step: S;
   /** trail (subSteps の親含む) の全 step (jumpTarget / outputBinding 参照解決用) */
   allSteps: Step[];
   /** 部分更新 patch を親 StepCard に通知 */
-  onChange: (changes: Partial<Step>) => void;
+  onChange: (changes: Partial<S>) => void;
   /** edit-commit (blur 時 persistence flush) */
   onCommit?: () => void;
   /** read-only mode で input を disable */


### PR DESCRIPTION
## Summary

#1186 で v3 strict 型完備化 + AiCallStep/AiAgentStep 追加 (PR #1206) 後の自然な続編。step-card body 18 file 中 10 file から @ts-nocheck を除去。

## 構造変更

types.ts StepCardBodyBaseProps を generic 化:
\`\`\`ts
export interface StepCardBodyBaseProps<S extends Step = Step> {
  step: S;
  onChange: (changes: Partial<S>) => void;
}
\`\`\`

各 body は \`StepCardBodyBaseProps<XxxStep>\` で specific 型を指定、\`as Partial<Step>\` cast 不要に。

## 移行済 (10 file)

AiAgentStepCardBody / AiCallStepCardBody / AuditStepCardBody / CommonProcessStepCardBody / ComponentCallStepCardBody / ComputeStepCardBody / DisplayUpdateStepCardBody / LogStepCardBody / TransactionScopeStepCardBody / WorkflowStepCardBody

## 副次 silent bug fix

CommonProcessStepCardBody: \`refName: cg?.name\` 書き込み code を発見。v3 schema 上 CommonProcessStep.refName は存在しない (unevaluatedProperties: false で reject される silent field)。
→ 削除済。

## deferred (8 file、別 PR で個別対応)

BranchStep / DbAccess / ExternalSystem / Jump / Loop / Return / ScreenTransition / Validation。silent bug (protocol / responseRef / targetScreenName が v3 schema 外) や branded type 対応が必要。#1016 で別途精査。

## Test plan

- [x] frontend build → OK
- [x] frontend test → 2346 / 2346 pass
- [x] validate:samples (retail) → 7/7 flows pass

Refs #1016, #1186

🤖 Generated with [Claude Code](https://claude.com/claude-code)