### PR TITLE
refactor(types): step-card body 残り 8 file の @ts-nocheck 除去 + 4 silent bug fix (#1016 batch 2)

### DIFF
--- a/frontend/src/components/process-flow/internal/step-cards/BranchStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/BranchStepCardBody.tsx
@@ -1,12 +1,12 @@
-// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
 // Phase-2 (#1145): StepCard.tsx の `step.kind === "branch"` body を抽出 (Phase 3 ロジック含む)。
 //
 // `collapsedBranchIds` は branch body 専用の純粋 UI state のため、parent (StepCard) から
 // 切り離して本 sub-component 内に閉じ込めた。branch handler (setBranchAt / moveBranchUp/Down /
 // deleteBranch / addBranch / addElseBranch / toggleBranchCollapse) も同様に内部化。
+// #1016 follow-up (2026-05-20): generic StepCardBodyBaseProps<BranchStep> で type narrow、@ts-nocheck 除去。
 
 import { useState } from "react";
-import type { Branch, Step } from "../../../../types/v3";
+import type { BranchStep, Branch, ElseBranch, LocalId, ErrorCode } from "../../../../types/v3";
 import { generateUUID } from "../../../../utils/uuid";
 import { InlineStepList } from "../InlineStepList";
 import type {
@@ -19,7 +19,7 @@ import type {
 } from "./types";
 
 export interface BranchStepCardBodyProps
-  extends StepCardBodyBaseProps,
+  extends StepCardBodyBaseProps<BranchStep>,
     StepCardBodyCatalogProps,
     StepCardBodyTableProps,
     StepCardBodyScreenProps,
@@ -54,7 +54,7 @@ export function BranchStepCardBody({
   const setBranchAt = (idx: number, next: Branch) => {
     const branches = step.branches.slice();
     branches[idx] = next;
-    onChange({ branches } as Partial<Step>);
+    onChange({ branches });
   };
 
   const moveBranchUp = (idx: number) => {
@@ -62,7 +62,7 @@ export function BranchStepCardBody({
     const branches = step.branches.map((b) => ({ ...b }));
     [branches[idx - 1], branches[idx]] = [branches[idx], branches[idx - 1]];
     branches.forEach((b, i) => { b.code = String.fromCharCode(65 + i); });
-    onChange({ branches } as Partial<Step>);
+    onChange({ branches });
     onCommit?.();
   };
 
@@ -71,7 +71,7 @@ export function BranchStepCardBody({
     if (idx >= branches.length - 1) return;
     [branches[idx], branches[idx + 1]] = [branches[idx + 1], branches[idx]];
     branches.forEach((b, i) => { b.code = String.fromCharCode(65 + i); });
-    onChange({ branches } as Partial<Step>);
+    onChange({ branches });
     onCommit?.();
   };
 
@@ -81,20 +81,20 @@ export function BranchStepCardBody({
       ...b,
       code: String.fromCharCode(65 + i),
     }));
-    onChange({ branches } as Partial<Step>);
+    onChange({ branches });
     onCommit?.();
   };
 
   const addBranch = () => {
     const code = String.fromCharCode(65 + step.branches.length);
-    const newBranch: Branch = { id: generateUUID(), code, condition: { kind: "expression", expression: "" }, steps: [] };
-    onChange({ branches: [...step.branches, newBranch] } as Partial<Step>);
+    const newBranch: Branch = { id: generateUUID() as LocalId, code, condition: { kind: "expression", expression: "" }, steps: [] };
+    onChange({ branches: [...step.branches, newBranch] });
     onCommit?.();
   };
 
   const addElseBranch = () => {
-    const elseBranch: Branch = { id: generateUUID(), code: "ELSE", condition: { kind: "expression", expression: "" }, steps: [] };
-    onChange({ elseBranch } as Partial<Step>);
+    const elseBranch: ElseBranch = { id: generateUUID() as LocalId, code: "ELSE", steps: [] };
+    onChange({ elseBranch });
     onCommit?.();
   };
 
@@ -118,7 +118,7 @@ export function BranchStepCardBody({
                     placeholder="errorCode (例: STOCK_SHORTAGE)"
                     onChange={(e) => setBranchAt(bi, {
                       ...br,
-                      condition: { ...br.condition, errorCode: e.target.value },
+                      condition: { kind: "tryCatch", errorCode: e.target.value as ErrorCode },
                     })}
                     onBlur={onCommit}
                   />
@@ -149,7 +149,7 @@ export function BranchStepCardBody({
                       e.stopPropagation();
                       setBranchAt(bi, {
                         ...br,
-                        condition: { kind: "tryCatch", errorCode: "" },
+                        condition: { kind: "tryCatch", errorCode: "" as ErrorCode },
                       });
                     }}
                     style={{ flexShrink: 0 }}
@@ -247,7 +247,7 @@ export function BranchStepCardBody({
                 title="ELSE分岐を削除"
                 onClick={(e) => {
                   e.stopPropagation();
-                  onChange({ elseBranch: undefined } as Partial<Step>);
+                  onChange({ elseBranch: undefined });
                   onCommit?.();
                 }}
               >
@@ -268,7 +268,7 @@ export function BranchStepCardBody({
                   screens={screens}
                   commonGroups={commonGroups}
                   onChange={(newSteps) =>
-                    onChange({ elseBranch: { ...el, steps: newSteps } } as Partial<Step>)
+                    onChange({ elseBranch: { ...el, steps: newSteps } })
                   }
                   onCommit={onCommit}
                   onNavigateCommon={onNavigateCommon}

--- a/frontend/src/components/process-flow/internal/step-cards/DbAccessStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/DbAccessStepCardBody.tsx
@@ -1,15 +1,13 @@
-// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
 // Phase-2 (#1145): StepCard.tsx の `step.kind === "dbAccess"` body を抽出。
+// #1016 follow-up (2026-05-20): generic StepCardBodyBaseProps<DbAccessStep> で type narrow、@ts-nocheck 除去。
 
-// #1186 Phase 2-D: DbOperation は v3 に固有型なし、local string alias。constants は processFlowMetadata
-import type { Step } from "../../../../types/v3";
-type DbOperation = string;
+import type { DbAccessStep, DbOperation, TableId, ErrorCode } from "../../../../types/v3";
 import { DB_OPERATION_LABELS } from "../../../../utils/processFlowMetadata";
 import { DB_OPS } from "../stepCardConstants";
 import type { StepCardBodyBaseProps, StepCardBodyTableProps } from "./types";
 
 export interface DbAccessStepCardBodyProps
-  extends StepCardBodyBaseProps,
+  extends StepCardBodyBaseProps<DbAccessStep>,
     StepCardBodyTableProps {}
 
 export function DbAccessStepCardBody({
@@ -26,7 +24,7 @@ export function DbAccessStepCardBody({
           className="form-select form-select-sm"
           value={step.tableId ?? ""}
           onChange={(e) => {
-            onChange({ tableId: e.target.value || undefined } as Partial<Step>);
+            onChange({ tableId: (e.target.value || undefined) as TableId | undefined });
           }}
         >
           <option value="">（選択）</option>
@@ -41,7 +39,7 @@ export function DbAccessStepCardBody({
           <select
             className="form-select form-select-sm"
             value={step.operation}
-            onChange={(e) => onChange({ operation: e.target.value as DbOperation } as Partial<Step>)}
+            onChange={(e) => onChange({ operation: e.target.value as DbOperation })}
           >
             {DB_OPS.map((op) => (
               <option key={op} value={op}>{DB_OPERATION_LABELS[op]}</option>
@@ -53,7 +51,7 @@ export function DbAccessStepCardBody({
           <input
             className="form-control form-control-sm"
             value={step.fields ?? ""}
-            onChange={(e) => onChange({ fields: e.target.value } as Partial<Step>)}
+            onChange={(e) => onChange({ fields: e.target.value })}
             onBlur={onCommit}
             placeholder="概要"
           />
@@ -65,7 +63,7 @@ export function DbAccessStepCardBody({
           className="form-control form-control-sm"
           rows={2}
           value={step.sql ?? ""}
-          onChange={(e) => onChange({ sql: e.target.value || undefined } as Partial<Step>)}
+          onChange={(e) => onChange({ sql: e.target.value || undefined })}
           onBlur={onCommit}
           placeholder="例: SELECT ... JOIN ... WHERE ... / INSERT ... RETURNING ..."
           style={{ fontFamily: "monospace", fontSize: "0.8rem" }}
@@ -83,7 +81,7 @@ export function DbAccessStepCardBody({
               value={step.affectedRowsCheck?.operator ?? ""}
               onChange={(e) => {
                 if (!e.target.value) {
-                  onChange({ affectedRowsCheck: undefined } as Partial<Step>);
+                  onChange({ affectedRowsCheck: undefined });
                 } else {
                   onChange({
                     affectedRowsCheck: {
@@ -92,7 +90,7 @@ export function DbAccessStepCardBody({
                       onViolation: step.affectedRowsCheck?.onViolation ?? "throw",
                       errorCode: step.affectedRowsCheck?.errorCode,
                     },
-                  } as Partial<Step>);
+                  });
                 }
               }}
               style={{ width: "auto" }}
@@ -115,7 +113,7 @@ export function DbAccessStepCardBody({
                       ...step.affectedRowsCheck!,
                       expected: Number(e.target.value),
                     },
-                  } as Partial<Step>)}
+                  })}
                   onBlur={onCommit}
                   style={{ width: 70 }}
                 />
@@ -128,7 +126,7 @@ export function DbAccessStepCardBody({
                       ...step.affectedRowsCheck!,
                       onViolation: e.target.value as "throw" | "abort" | "log" | "continue",
                     },
-                  } as Partial<Step>)}
+                  })}
                   style={{ width: "auto" }}
                 >
                   <option value="throw">throw</option>
@@ -143,9 +141,9 @@ export function DbAccessStepCardBody({
                   onChange={(e) => onChange({
                     affectedRowsCheck: {
                       ...step.affectedRowsCheck!,
-                      errorCode: e.target.value || undefined,
+                      errorCode: (e.target.value || undefined) as ErrorCode | undefined,
                     },
-                  } as Partial<Step>)}
+                  })}
                   onBlur={onCommit}
                   placeholder="errorCode (例: STOCK_SHORTAGE)"
                   style={{ width: 200 }}

--- a/frontend/src/components/process-flow/internal/step-cards/ExternalSystemStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/ExternalSystemStepCardBody.tsx
@@ -1,12 +1,14 @@
-// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
 // Phase-2 (#1145): StepCard.tsx の `step.kind === "externalSystem"` body を抽出。
+// #1016 follow-up (2026-05-20): generic StepCardBodyBaseProps<ExternalSystemStep> で type narrow、
+// 副次 silent bug fix: `protocol` field 入力欄を削除 (v3 schema 上 ExternalSystemStep.protocol 不在、
+// unevaluatedProperties: false で reject される silent field だった)。
 
-import type { Step } from "../../../../types/v3";
+import type { ExternalSystemStep, Identifier } from "../../../../types/v3";
 import { ExternalOutcomesPanel } from "../../ExternalOutcomesPanel";
 import { trimToUndefined } from "../stepCardConstants";
 import type { StepCardBodyBaseProps } from "./types";
 
-export type ExternalSystemStepCardBodyProps = StepCardBodyBaseProps;
+export type ExternalSystemStepCardBodyProps = StepCardBodyBaseProps<ExternalSystemStep>;
 
 export function ExternalSystemStepCardBody({
   step,
@@ -15,28 +17,19 @@ export function ExternalSystemStepCardBody({
 }: ExternalSystemStepCardBodyProps) {
   return (
     <>
-      <div className="form-row-pair">
-        <div className="form-group">
-          <label className="form-label">接続先</label>
-          <input
-            className="form-control form-control-sm"
-            value={step.systemRef ?? ""}
-            onChange={(e) => onChange({ systemRef: e.target.value } as Partial<Step>)}
-            onBlur={onCommit}
-            placeholder="システム名 (context.catalogs.externalSystems のキー)"
-          />
-        </div>
-        <div className="form-group">
-          <label className="form-label">プロトコル</label>
-          <input
-            className="form-control form-control-sm"
-            value={step.protocol ?? ""}
-            onChange={(e) => onChange({ protocol: e.target.value } as Partial<Step>)}
-            onBlur={onCommit}
-            placeholder="REST / SOAP / gRPC"
-          />
-        </div>
+      <div className="form-group">
+        <label className="form-label">接続先</label>
+        <input
+          className="form-control form-control-sm"
+          value={step.systemRef ?? ""}
+          onChange={(e) => onChange({ systemRef: e.target.value as Identifier })}
+          onBlur={onCommit}
+          placeholder="システム名 (context.catalogs.externalSystems のキー)"
+        />
       </div>
+      {/* #1016 follow-up (2026-05-20): プロトコル入力欄を削除。
+         v3 ExternalSystemStep.protocol は schema に存在せず unevaluatedProperties: false で
+         silent reject されていた (実用には httpCall.method or operationRef で表現)。 */}
       <div className="row g-2 mb-2">
         <div className="col-6" data-field-path="operationRef">
           <label className="form-label">operationRef</label>
@@ -44,7 +37,7 @@ export function ExternalSystemStepCardBody({
             className="form-control form-control-sm"
             data-field-path="operationRef"
             value={step.operationRef ?? ""}
-            onChange={(e) => onChange({ operationRef: trimToUndefined(e.target.value) } as Partial<Step>)}
+            onChange={(e) => onChange({ operationRef: trimToUndefined(e.target.value) })}
             onBlur={onCommit}
             placeholder="/v1/payment_intents POST"
             style={{ fontFamily: "monospace" }}
@@ -56,7 +49,7 @@ export function ExternalSystemStepCardBody({
             className="form-control form-control-sm"
             data-field-path="operationId"
             value={step.operationId ?? ""}
-            onChange={(e) => onChange({ operationId: trimToUndefined(e.target.value) } as Partial<Step>)}
+            onChange={(e) => onChange({ operationId: trimToUndefined(e.target.value) })}
             onBlur={onCommit}
             placeholder="PostPaymentIntents"
             style={{ fontFamily: "monospace" }}
@@ -70,7 +63,7 @@ export function ExternalSystemStepCardBody({
             className="form-control form-control-sm"
             data-field-path="requestBodyRef"
             value={step.requestBodyRef ?? ""}
-            onChange={(e) => onChange({ requestBodyRef: trimToUndefined(e.target.value) } as Partial<Step>)}
+            onChange={(e) => onChange({ requestBodyRef: trimToUndefined(e.target.value) })}
             onBlur={onCommit}
             placeholder="#/components/schemas/PaymentIntentCreateParams"
             style={{ fontFamily: "monospace" }}
@@ -82,7 +75,7 @@ export function ExternalSystemStepCardBody({
             className="form-control form-control-sm"
             data-field-path="responseRef"
             value={step.responseRef ?? ""}
-            onChange={(e) => onChange({ responseRef: trimToUndefined(e.target.value) } as Partial<Step>)}
+            onChange={(e) => onChange({ responseRef: trimToUndefined(e.target.value) })}
             onBlur={onCommit}
             placeholder="#/components/responses/200/content/application~1json/schema"
             style={{ fontFamily: "monospace" }}
@@ -98,7 +91,7 @@ export function ExternalSystemStepCardBody({
             type="number"
             className="form-control form-control-sm"
             value={step.timeoutMs ?? ""}
-            onChange={(e) => onChange({ timeoutMs: e.target.value ? Number(e.target.value) : undefined } as Partial<Step>)}
+            onChange={(e) => onChange({ timeoutMs: e.target.value ? Number(e.target.value) : undefined })}
             onBlur={onCommit}
             placeholder="ms"
             style={{ width: 90 }}
@@ -111,7 +104,7 @@ export function ExternalSystemStepCardBody({
               type="checkbox"
               className="form-check-input me-1"
               checked={!!step.fireAndForget}
-              onChange={(e) => onChange({ fireAndForget: e.target.checked || undefined } as Partial<Step>)}
+              onChange={(e) => onChange({ fireAndForget: e.target.checked || undefined })}
             />
             fire-and-forget (同期レスポンス待たない)
           </label>
@@ -129,7 +122,7 @@ export function ExternalSystemStepCardBody({
             onChange={(e) => {
               const n = e.target.value ? Number(e.target.value) : 0;
               if (n <= 0) {
-                onChange({ retryPolicy: undefined } as Partial<Step>);
+                onChange({ retryPolicy: undefined });
               } else {
                 onChange({
                   retryPolicy: {
@@ -137,7 +130,7 @@ export function ExternalSystemStepCardBody({
                     backoff: step.retryPolicy?.backoff,
                     initialDelayMs: step.retryPolicy?.initialDelayMs,
                   },
-                } as Partial<Step>);
+                });
               }
             }}
             onBlur={onCommit}
@@ -156,7 +149,7 @@ export function ExternalSystemStepCardBody({
                     ...step.retryPolicy!,
                     backoff: e.target.value as "fixed" | "exponential" || undefined,
                   },
-                } as Partial<Step>)}
+                })}
                 style={{ width: "auto", fontSize: "0.8rem" }}
               >
                 <option value="">backoff: —</option>
@@ -174,7 +167,7 @@ export function ExternalSystemStepCardBody({
                     ...step.retryPolicy!,
                     initialDelayMs: e.target.value ? Number(e.target.value) : undefined,
                   },
-                } as Partial<Step>)}
+                })}
                 onBlur={onCommit}
                 placeholder="initialDelayMs"
                 style={{ width: 120, fontSize: "0.8rem" }}
@@ -185,7 +178,7 @@ export function ExternalSystemStepCardBody({
       </div>
       <ExternalOutcomesPanel
         step={step}
-        onChange={(patch) => onChange(patch as Partial<Step>)}
+        onChange={(patch) => onChange(patch)}
         onCommit={onCommit}
       />
     </>

--- a/frontend/src/components/process-flow/internal/step-cards/JumpStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/JumpStepCardBody.tsx
@@ -1,11 +1,11 @@
-// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
 // Phase-2 (#1145): StepCard.tsx の `step.kind === "jump"` body を抽出。
+// #1016 follow-up (2026-05-20): generic StepCardBodyBaseProps<JumpStep> で type narrow、@ts-nocheck 除去。
 
-import type { Step } from "../../../../types/v3";
+import type { JumpStep, LocalId } from "../../../../types/v3";
 import { JumpTargetSelector } from "../../JumpTargetSelector";
 import type { StepCardBodyBaseProps } from "./types";
 
-export type JumpStepCardBodyProps = StepCardBodyBaseProps;
+export type JumpStepCardBodyProps = StepCardBodyBaseProps<JumpStep>;
 
 export function JumpStepCardBody({
   step,
@@ -21,7 +21,7 @@ export function JumpStepCardBody({
           value={step.jumpTo}
           allSteps={allSteps}
           excludeStepId={step.id}
-          onChange={(val) => onChange({ jumpTo: val } as Partial<Step>)}
+          onChange={(val) => onChange({ jumpTo: val as LocalId })}
           onBlur={onCommit}
         />
       </div>

--- a/frontend/src/components/process-flow/internal/step-cards/LoopStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/LoopStepCardBody.tsx
@@ -1,10 +1,10 @@
-// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
 // Phase-2 (#1145): StepCard.tsx の `step.kind === "loop"` body を抽出 (Phase 4 ロジック)。
 //
 // `loopBodyCollapsed` は本 body 専用の純粋 UI state のため、parent から切り離して内部化。
+// #1016 follow-up (2026-05-20): generic StepCardBodyBaseProps<LoopStep> で type narrow、@ts-nocheck 除去。
 
 import { useState } from "react";
-import type { LoopConditionMode, LoopKind, Step } from "../../../../types/v3";
+import type { LoopStep, LoopConditionMode, LoopKind, Identifier } from "../../../../types/v3";
 import { InlineStepList } from "../InlineStepList";
 import type {
   StepCardBodyBaseProps,
@@ -16,7 +16,7 @@ import type {
 } from "./types";
 
 export interface LoopStepCardBodyProps
-  extends StepCardBodyBaseProps,
+  extends StepCardBodyBaseProps<LoopStep>,
     StepCardBodyCatalogProps,
     StepCardBodyTableProps,
     StepCardBodyScreenProps,
@@ -49,7 +49,7 @@ export function LoopStepCardBody({
               name={`loopkind-${step.id}`}
               value={k}
               checked={step.loopKind === k}
-              onChange={() => onChange({ loopKind: k } as Partial<Step>)}
+              onChange={() => onChange({ loopKind: k })}
             />
             {k === "count" ? "回数" : k === "condition" ? "条件" : "コレクション"}
           </label>
@@ -62,7 +62,7 @@ export function LoopStepCardBody({
           <input
             className="form-control form-control-sm"
             value={step.countExpression ?? ""}
-            onChange={(e) => onChange({ countExpression: e.target.value } as Partial<Step>)}
+            onChange={(e) => onChange({ countExpression: e.target.value })}
             onBlur={onCommit}
             placeholder="例: 3回, 検索結果の件数分"
           />
@@ -81,7 +81,7 @@ export function LoopStepCardBody({
                     name={`condmode-${step.id}`}
                     value={m}
                     checked={(step.conditionMode ?? "exit") === m}
-                    onChange={() => onChange({ conditionMode: m } as Partial<Step>)}
+                    onChange={() => onChange({ conditionMode: m })}
                   />
                   {m === "continue" ? "条件の間繰り返す (while)" : "条件になるまで繰り返す (until)"}
                 </label>
@@ -93,7 +93,7 @@ export function LoopStepCardBody({
             <input
               className="form-control form-control-sm"
               value={step.conditionExpression ?? ""}
-              onChange={(e) => onChange({ conditionExpression: e.target.value } as Partial<Step>)}
+              onChange={(e) => onChange({ conditionExpression: e.target.value })}
               onBlur={onCommit}
               placeholder="例: 残件数 > 0"
             />
@@ -108,7 +108,7 @@ export function LoopStepCardBody({
             <input
               className="form-control form-control-sm"
               value={step.collectionSource ?? ""}
-              onChange={(e) => onChange({ collectionSource: e.target.value } as Partial<Step>)}
+              onChange={(e) => onChange({ collectionSource: e.target.value })}
               onBlur={onCommit}
               placeholder="例: 検索結果"
             />
@@ -118,7 +118,7 @@ export function LoopStepCardBody({
             <input
               className="form-control form-control-sm"
               value={step.collectionItemName ?? ""}
-              onChange={(e) => onChange({ collectionItemName: e.target.value } as Partial<Step>)}
+              onChange={(e) => onChange({ collectionItemName: e.target.value as Identifier })}
               onBlur={onCommit}
               placeholder="例: ユーザー"
             />
@@ -147,7 +147,7 @@ export function LoopStepCardBody({
               tables={tables}
               screens={screens}
               commonGroups={commonGroups}
-              onChange={(newSteps) => onChange({ steps: newSteps } as Partial<Step>)}
+              onChange={(newSteps) => onChange({ steps: newSteps })}
               onCommit={onCommit}
               onNavigateCommon={onNavigateCommon}
               validationErrors={validationErrors}

--- a/frontend/src/components/process-flow/internal/step-cards/ReturnStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/ReturnStepCardBody.tsx
@@ -1,7 +1,9 @@
-// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
 // Phase-2 (#1145): StepCard.tsx の `step.kind === "return"` body を抽出。
+// #1016 follow-up (2026-05-20): generic StepCardBodyBaseProps<ReturnStep> で type narrow。
+// 副次 silent bug fix: input field 名と書込 field 名を `responseRef` → `responseId` に修正
+// (v3 schema ReturnStep.responseId、`responseRef` は schema 外で unevaluatedProperties: false reject)。
 
-import type { Step } from "../../../../types/v3";
+import type { ReturnStep, LocalId, ExpressionString } from "../../../../types/v3";
 import { ConvCompletionInput } from "../../../common/ConvCompletionInput";
 import type {
   StepCardBodyBaseProps,
@@ -9,7 +11,7 @@ import type {
 } from "./types";
 
 export interface ReturnStepCardBodyProps
-  extends StepCardBodyBaseProps,
+  extends StepCardBodyBaseProps<ReturnStep>,
     Pick<StepCardBodyCatalogProps, "conventions"> {}
 
 export function ReturnStepCardBody({
@@ -23,13 +25,13 @@ export function ReturnStepCardBody({
       <div className="col-6">
         <label className="form-label">
           <i className="bi bi-reply me-1" />
-          responseRef (action.responses[].id)
+          responseId (action.responses[].id)
         </label>
         <input
           type="text"
           className="form-control form-control-sm"
-          value={step.responseRef ?? ""}
-          onChange={(e) => onChange({ responseRef: e.target.value || undefined } as Partial<Step>)}
+          value={step.responseId ?? ""}
+          onChange={(e) => onChange({ responseId: (e.target.value || undefined) as LocalId | undefined })}
           onBlur={onCommit}
           placeholder="例: 409-stock-shortage"
         />
@@ -39,7 +41,7 @@ export function ReturnStepCardBody({
         <ConvCompletionInput
           className="form-control form-control-sm"
           value={step.bodyExpression ?? ""}
-          onValueChange={(v) => onChange({ bodyExpression: v || undefined } as Partial<Step>)}
+          onValueChange={(v) => onChange({ bodyExpression: (v || undefined) as ExpressionString | undefined })}
           onCommit={onCommit}
           conventions={conventions ?? null}
           placeholder="例: { code: 'STOCK_SHORTAGE', detail: @shortageList }"

--- a/frontend/src/components/process-flow/internal/step-cards/ScreenTransitionStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/ScreenTransitionStepCardBody.tsx
@@ -1,14 +1,17 @@
-// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
 // Phase-2 (#1145): StepCard.tsx の `step.kind === "screenTransition"` body を抽出。
+// #1016 follow-up (2026-05-20): generic StepCardBodyBaseProps<ScreenTransitionStep> で type narrow、
+// 副次 silent bug fix: `targetScreenName` field を削除 (v3 schema 上 ScreenTransitionStep.targetScreenName 不在、
+// unevaluatedProperties: false で reject される silent field だった)。
+// 画面名表示は screens lookup で派生 (永続化しない)。
 
-import type { Step } from "../../../../types/v3";
+import type { ScreenTransitionStep, ScreenId } from "../../../../types/v3";
 import type {
   StepCardBodyBaseProps,
   StepCardBodyScreenProps,
 } from "./types";
 
 export interface ScreenTransitionStepCardBodyProps
-  extends StepCardBodyBaseProps,
+  extends StepCardBodyBaseProps<ScreenTransitionStep>,
     StepCardBodyScreenProps {}
 
 export function ScreenTransitionStepCardBody({
@@ -17,6 +20,8 @@ export function ScreenTransitionStepCardBody({
   onChange,
   onCommit,
 }: ScreenTransitionStepCardBodyProps) {
+  // 画面名は targetScreenId から lookup で派生 (永続化しない、#1016 silent bug fix)
+  const screenDisplay = screens.find((s) => s.id === step.targetScreenId)?.name;
   return (
     <div className="row g-2 mb-2">
       <div className="col-12">
@@ -24,23 +29,19 @@ export function ScreenTransitionStepCardBody({
         <select
           className="form-select form-select-sm"
           value={step.targetScreenId ?? ""}
-          onChange={(e) => {
-            const s = screens.find((s) => s.id === e.target.value);
-            onChange({ targetScreenId: e.target.value, targetScreenName: s?.name ?? e.target.value } as Partial<Step>);
-          }}
+          onChange={(e) => onChange({ targetScreenId: e.target.value as ScreenId })}
+          onBlur={onCommit}
         >
-          <option value="">（選択または手入力）</option>
+          <option value="">（選択）</option>
           {screens.map((s) => (
             <option key={s.id} value={s.id}>{s.name}</option>
           ))}
         </select>
-        <input
-          className="form-control form-control-sm mt-1"
-          value={step.targetScreenName}
-          onChange={(e) => onChange({ targetScreenName: e.target.value } as Partial<Step>)}
-          onBlur={onCommit}
-          placeholder="画面名を直接入力"
-        />
+        {screenDisplay && (
+          <div className="form-text text-muted" style={{ fontSize: "0.75rem" }}>
+            選択中: {screenDisplay}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/process-flow/internal/step-cards/ValidationStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/ValidationStepCardBody.tsx
@@ -1,13 +1,16 @@
-// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
 // Phase-2 (#1145): StepCard.tsx の `step.kind === "validation"` body を抽出。
 // 振る舞いの変更は無し (純粋なファイル分割)。
+// #1016 follow-up (2026-05-20): generic StepCardBodyBaseProps<ValidationStep> で type narrow。
+// 副次 silent bug fix:
+//   - ngResponseRef → ngResponseId (v3 ValidationInlineBranch.ngResponseId、ngResponseRef は schema 外)
+//   - string-form ok/ng の handling 除去 (v3 ValidationInlineBranch.ok/ng は Step[] のみ、string は v1/v2 legacy で v3 schema 不一致)
 
-import type { Step } from "../../../../types/v3";
+import type { ValidationStep, LocalId, ExpressionString } from "../../../../types/v3";
 import { ValidationRulesPanel } from "../../ValidationRulesPanel";
 import type { StepCardBodyBaseProps, StepCardBodyCatalogProps } from "./types";
 
 export interface ValidationStepCardBodyProps
-  extends StepCardBodyBaseProps,
+  extends StepCardBodyBaseProps<ValidationStep>,
     Pick<StepCardBodyCatalogProps, "conventions"> {}
 
 export function ValidationStepCardBody({
@@ -23,8 +26,8 @@ export function ValidationStepCardBody({
           <label className="form-label">バリデーション条件 (自由記述)</label>
           <input
             className="form-control form-control-sm"
-            value={step.conditions}
-            onChange={(e) => onChange({ conditions: e.target.value } as Partial<Step>)}
+            value={step.conditions ?? ""}
+            onChange={(e) => onChange({ conditions: e.target.value })}
             onBlur={onCommit}
             placeholder="必須チェック、形式チェック等 (rules[] で構造化済なら補足用)"
           />
@@ -32,46 +35,22 @@ export function ValidationStepCardBody({
       </div>
       <ValidationRulesPanel
         rules={step.rules}
-        onChange={(rules) => onChange({ rules } as Partial<Step>)}
+        onChange={(rules) => onChange({ rules })}
         conventions={conventions ?? null}
       />
       {step.inlineBranch && (
         <div className="step-inline-branch">
           <div className="step-branch-box ok">
             <div className="step-branch-label">A: OK</div>
-            {typeof step.inlineBranch.ok === "string" ? (
-              <input
-                className="form-control form-control-sm"
-                value={step.inlineBranch.ok}
-                onChange={(e) =>
-                  onChange({ inlineBranch: { ...step.inlineBranch!, ok: e.target.value } } as Partial<Step>)
-                }
-                placeholder="OK時の処理"
-                onBlur={onCommit}
-              />
-            ) : (
-              <span className="form-control form-control-sm text-muted" style={{ cursor: "default" }}>
-                ステップ {step.inlineBranch.ok.length} 件 (JSON編集)
-              </span>
-            )}
+            <span className="form-control form-control-sm text-muted" style={{ cursor: "default" }}>
+              ステップ {step.inlineBranch.ok.length} 件 (JSON編集)
+            </span>
           </div>
           <div className="step-branch-box ng">
             <div className="step-branch-label">B: NG</div>
-            {typeof step.inlineBranch.ng === "string" ? (
-              <input
-                className="form-control form-control-sm"
-                value={step.inlineBranch.ng}
-                onChange={(e) =>
-                  onChange({ inlineBranch: { ...step.inlineBranch!, ng: e.target.value } } as Partial<Step>)
-                }
-                placeholder="NG時の処理"
-                onBlur={onCommit}
-              />
-            ) : (
-              <span className="form-control form-control-sm text-muted" style={{ cursor: "default" }}>
-                ステップ {step.inlineBranch.ng.length} 件 (JSON編集)
-              </span>
-            )}
+            <span className="form-control form-control-sm text-muted" style={{ cursor: "default" }}>
+              ステップ {step.inlineBranch.ng.length} 件 (JSON編集)
+            </span>
           </div>
         </div>
       )}
@@ -79,19 +58,19 @@ export function ValidationStepCardBody({
         <div className="row g-2 mb-2 mt-1" style={{ fontSize: "0.8rem" }}>
           <div className="col-5">
             <label className="form-label small mb-0">
-              NG → responseRef
+              NG → responseId
             </label>
             <input
               type="text"
               className="form-control form-control-sm"
-              value={step.inlineBranch.ngResponseRef ?? ""}
+              value={step.inlineBranch.ngResponseId ?? ""}
               onChange={(e) =>
                 onChange({
                   inlineBranch: {
                     ...step.inlineBranch!,
-                    ngResponseRef: e.target.value || undefined,
+                    ngResponseId: (e.target.value || undefined) as LocalId | undefined,
                   },
-                } as Partial<Step>)
+                })
               }
               onBlur={onCommit}
               placeholder="例: 400-validation"
@@ -110,9 +89,9 @@ export function ValidationStepCardBody({
                 onChange({
                   inlineBranch: {
                     ...step.inlineBranch!,
-                    ngBodyExpression: e.target.value || undefined,
+                    ngBodyExpression: (e.target.value || undefined) as ExpressionString | undefined,
                   },
-                } as Partial<Step>)
+                })
               }
               onBlur={onCommit}
               placeholder="例: { code: 'VALIDATION', fieldErrors: @fieldErrors }"

--- a/frontend/src/components/process-flow/internal/step-cards/step-cards.test.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/step-cards.test.tsx
@@ -100,13 +100,14 @@ describe("DbAccessStepCardBody", () => {
 // ── ExternalSystemStepCardBody ──────────────────────────────────────
 
 describe("ExternalSystemStepCardBody", () => {
-  it("systemRef / protocol input が描画される", () => {
-    const step = baseStep({ kind: "externalSystem", systemRef: "stripe", protocol: "REST" });
+  it("systemRef input が描画される (#1016: protocol は v3 schema 外のため削除済)", () => {
+    const step = baseStep({ kind: "externalSystem", systemRef: "stripe" });
     const { container } = render(
       <ExternalSystemStepCardBody step={step} allSteps={[]} onChange={noop} />,
     );
     expect(container.textContent).toContain("接続先");
-    expect(container.textContent).toContain("プロトコル");
+    // protocol は v3 schema に存在しないため UI から削除済
+    expect(container.textContent).not.toContain("プロトコル");
   });
 
   it("retryPolicy 未設定時は backoff select が出ない", () => {
@@ -153,12 +154,12 @@ describe("ComputeStepCardBody", () => {
 // ── ReturnStepCardBody ──────────────────────────────────────────────
 
 describe("ReturnStepCardBody", () => {
-  it("responseRef と bodyExpression input を描画する", () => {
-    const step = baseStep({ kind: "return", responseRef: "200-ok" });
+  it("responseId と bodyExpression input を描画する (#1016: v3 ReturnStep.responseId に rename)", () => {
+    const step = baseStep({ kind: "return", responseId: "200-ok" });
     const { container } = render(
       <ReturnStepCardBody step={step} allSteps={[]} onChange={noop} />,
     );
-    expect(container.textContent).toContain("responseRef");
+    expect(container.textContent).toContain("responseId");
     expect(container.textContent).toContain("bodyExpression");
   });
 });

--- a/frontend/src/types/v3/index.ts
+++ b/frontend/src/types/v3/index.ts
@@ -82,6 +82,10 @@ export type HttpAuthRequirement = "required" | "optional" | "none";
 // ── External Auth Kind (process-flow.v3 ExternalAuth.kind enum、frontend type alias) ──
 export type ExternalAuthKind = "bearer" | "basic" | "apiKey" | "oauth2" | "iamRole" | "azureAd" | "none";
 
+// ── Loop kind / condition mode (process-flow.v3 LoopStep と完全一致、#1186 Phase 1 で整合済) ──
+export type LoopKind = "count" | "condition" | "collection";
+export type LoopConditionMode = "continue" | "exit";
+
 // ── SLA / Transaction の frontend 拡張 enum (v3 schema には string で許容) ──
 export type OnTimeout = "throw" | "continue" | "compensate" | "log";
 export type TransactionIsolationLevel = "READ_COMMITTED" | "REPEATABLE_READ" | "SERIALIZABLE" | string;


### PR DESCRIPTION
## Summary

#1016 batch 1 (PR #1207) で deferred した 8 file を完了。step-card body 18 file 全完了。v3 strict 化で **AnyRecord がマスクしていた silent bug 4 件** も同時解消。

## 移行完了 (8 file)

BranchStepCardBody / DbAccessStepCardBody / ExternalSystemStepCardBody / JumpStepCardBody / LoopStepCardBody / ReturnStepCardBody / ScreenTransitionStepCardBody / ValidationStepCardBody

## Silent bug fix (4 件、v3 strict 化で炙り出された)

| # | step | 旧 | 新 | 影響 |
|---|---|---|---|---|
| 1 | ExternalSystemStep | プロトコル入力欄 → \`step.protocol\` 書込 | 入力欄削除 (schema 外 field) | プロトコル指定不能だった silent failure を解消 |
| 2 | ScreenTransitionStep | targetScreenName cache field 書込 | 画面名 lookup で派生 | 表示用 cache が silent reject されていた |
| 3 | ReturnStep | responseRef field 書込 | responseId に rename | 旧 field 書込が silent reject、ResponseRef 設定保存不能 |
| 4 | ValidationStep | ngResponseRef + string-form ok/ng | ngResponseId + Step[] のみ | NG response 設定保存不能 + dead code 除去 |

## generic 完全活用

全 18 step-card body が specific step variant 型で type narrow、\`as Partial<Step>\` cast 0 件達成。TypeScript 補完が正確に効き、新 step kind 追加時の漏れも検出可能に。

## v3 index.ts 拡張

LoopKind / LoopConditionMode を v3 export 追加 (旧 action.ts 経由のみだった)。

## test 更新

step-cards.test.tsx の 2 test を新仕様 (protocol 削除、responseId rename) に追随。

## Test plan

- [x] frontend build (tsc + vite) → OK
- [x] frontend test → 2346 / 2346 pass
- [x] validate:samples (retail) → 7/7 flows pass

## 残作業

step-card body 以外の @ts-nocheck 残存 file (ProcessFlowEditor / StepCard 等の大型 file) は #1016 で別途継続。

Refs #1016, #1186

🤖 Generated with [Claude Code](https://claude.com/claude-code)