### PR TITLE
refactor(types): @ts-nocheck 除去 3 file (#1016 batch 3)

### DIFF
--- a/frontend/src/components/process-flow/internal/ActionHelpPopover.tsx
+++ b/frontend/src/components/process-flow/internal/ActionHelpPopover.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
 // Phase-3 (#1145): ProcessFlowEditor.tsx から ActionHelpPopover を抽出。
 // アクションタブにホバー時のリッチヘルプ popover (契機 / 用途 / 定義例 / ステップ例 / メタ要約)。
 

--- a/frontend/src/components/process-flow/internal/EditorHeaderExtras.tsx
+++ b/frontend/src/components/process-flow/internal/EditorHeaderExtras.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
 // Phase-3 (#1145): ProcessFlowEditor.tsx の EditorHeader.extraRight に渡す
 // ボタン群 (AI 生成 / AI レビュー / EditSession ドロップダウン / 描画 / 検証バッジ) を抽出。
 

--- a/frontend/src/components/process-flow/internal/useActionHelpPopover.ts
+++ b/frontend/src/components/process-flow/internal/useActionHelpPopover.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
 // Phase-3 (#1145): ProcessFlowEditor.tsx から ActionHelpPopover の位置計算 +
 // open/close debounce 制御を切り出したフック。
 


### PR DESCRIPTION
## Summary

トリビアルな ts-nocheck 残骸 3 file を除去。

## 移行 (3 file)

- ActionHelpPopover.tsx
- internal/useActionHelpPopover.ts
- internal/EditorHeaderExtras.tsx

## 試行した他の panel (deferred、別 ISSUE 候補)

以下は loose access や silent bug があり deferred:

| file | 問題 | 推奨対応 |
|---|---|---|
| MarkerPanel / ActionMetaTabBar | step recursion narrow 必要 | 共通 step recursion helper 作成 |
| AmbientVariablesPanel | StructuredField \`type: \"custom\"\` が v3 にない | silent bug 調査 + 削除 or schema 拡張 |
| ErrorCatalogPanel | \`responseRef\` が v3 schema 外 | \`responseId\` rename (ReturnStep 同様) |
| WarningsPanel | Marker.code / Marker.path 不在 | validatorCode / validatorPath にrename |

## Test plan

- [x] frontend build → OK
- [x] frontend test → 2346 / 2346 pass

Refs #1016

🤖 Generated with [Claude Code](https://claude.com/claude-code)