### PR TITLE
fix(ui): WarningsPanel + ErrorCatalogPanel の v3 schema silent bug 解消 (#1016)

### DIFF
--- a/frontend/src/components/process-flow/ErrorCatalogPanel.tsx
+++ b/frontend/src/components/process-flow/ErrorCatalogPanel.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck -- legacy process-flow action panel types are being migrated; tracked by #1016.
 /**
  * ProcessFlow.context.catalogs.errors 編集パネル (#278 / #570 v3 移行)
  *
@@ -6,7 +5,7 @@
  * キー追加・削除、各フィールドの行編集。
  */
 import { useState } from "react";
-import type { ProcessFlow, ErrorCatalogEntry } from "../../types/v3";
+import type { ProcessFlow, ErrorCatalogEntry, LocalId } from "../../types/v3";
 
 interface Props {
   group: ProcessFlow;
@@ -30,7 +29,7 @@ export function ErrorCatalogPanel({ group, onChange, expanded: expandedProp, onE
 
   // ProcessFlow 内の全 response ID を収集 (responseRef ドロップダウン用)
   const responseIds = Array.from(new Set(
-    group.actions.flatMap((a) => (a.responses ?? []).map((r) => r.id).filter((x): x is string => !!x)),
+    group.actions.flatMap((a) => (a.responses ?? []).map((r) => r.id).filter((x): x is LocalId => !!x)),
   ));
 
   const setCatalog = (next: Record<string, ErrorCatalogEntry> | undefined) => {
@@ -110,11 +109,11 @@ export function ErrorCatalogPanel({ group, onChange, expanded: expandedProp, onE
                     />
                   </label>
                   <label>
-                    responseRef
+                    responseId
                     <select
                       className="form-select form-select-sm"
-                      value={e.responseRef ?? ""}
-                      onChange={(ev) => updateEntry(k, { responseRef: ev.target.value || undefined })}
+                      value={e.responseId ?? ""}
+                      onChange={(ev) => updateEntry(k, { responseId: (ev.target.value || undefined) as LocalId | undefined })}
                     >
                       <option value="">—</option>
                       {responseIds.map((id) => (

--- a/frontend/src/components/process-flow/internal/WarningsPanel.tsx
+++ b/frontend/src/components/process-flow/internal/WarningsPanel.tsx
@@ -1,9 +1,8 @@
-// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
 // Phase-3 (#1145): ProcessFlowEditor.tsx から警告詳細パネル (#261 UI 統合) を抽出。
 // 警告一覧 + 「全て AI に依頼」 / 個別「AI に依頼」ボタン (既起票判定込み)。
 
 import { generateUUID } from "../../../utils/uuid";
-import type { ProcessFlow } from "../../../types/v3";
+import type { ProcessFlow, Marker, Uuid, Timestamp, LocalId } from "../../../types/v3";
 import type { ValidationError } from "../../../utils/actionValidation";
 
 export interface WarningsPanelProps {
@@ -28,20 +27,23 @@ export function WarningsPanel({
     const existingKeys = new Set(
       (group.authoring?.markers ?? [])
         .filter((m) => !m.resolvedAt && m.kind === "todo")
-        .map((m) => `${m.code ?? ""}|${m.path ?? ""}`),
+        .map((m) => `${m.validatorCode ?? ""}|${m.validatorPath ?? ""}`),
     );
     const newMarkers = warnings
       .filter((e) => e.path)
       .filter((e) => !existingKeys.has(`${e.code ?? ""}|${e.path ?? ""}`))
-      .map((e) => ({
-        id: generateUUID(),
-        kind: "todo" as const,
+      .map((e): Marker => ({
+        id: generateUUID() as Uuid,
+        kind: "todo",
         body: `警告解消: ${e.message}`,
-        stepId: e.stepId || undefined,
-        code: e.code,
-        path: e.path,
-        author: "human" as const,
-        createdAt: new Date().toISOString(),
+        // #1016 silent bug fix: stepId は anchor.stepId に、code/path → validatorCode/validatorPath (v3 Marker schema 規範)
+        anchor: e.stepId
+          ? { stepId: e.stepId as LocalId, fieldPath: e.path }
+          : (e.path ? { fieldPath: e.path } : undefined),
+        validatorCode: e.code,
+        validatorPath: e.path,
+        author: "human",
+        createdAt: new Date().toISOString() as Timestamp,
       }));
     if (newMarkers.length === 0) {
       window.alert("全ての警告は既に AI 依頼済みです");
@@ -77,7 +79,7 @@ export function WarningsPanel({
         {warnings.map((e, i) => {
           const isMarked = (group?.authoring?.markers ?? []).some(
             (m) =>
-              !m.resolvedAt && m.kind === "todo" && m.code === e.code && m.path === e.path,
+              !m.resolvedAt && m.kind === "todo" && m.validatorCode === e.code && m.validatorPath === e.path,
           );
           return (
             <li key={i}>
@@ -90,15 +92,18 @@ export function WarningsPanel({
                 title={isMarked ? "AI に依頼済み" : "この警告を marker として AI に依頼"}
                 onClick={() => {
                   if (!group || isMarked) return;
-                  const newMarker = {
-                    id: generateUUID(),
-                    kind: "todo" as const,
+                  const newMarker: Marker = {
+                    id: generateUUID() as Uuid,
+                    kind: "todo",
                     body: `警告解消: ${e.message}`,
-                    stepId: e.stepId || undefined,
-                    code: e.code,
-                    path: e.path,
-                    author: "human" as const,
-                    createdAt: new Date().toISOString(),
+                    // #1016 silent bug fix: stepId は anchor.stepId に、code/path → validatorCode/validatorPath
+                    anchor: e.stepId
+                      ? { stepId: e.stepId as LocalId, fieldPath: e.path }
+                      : (e.path ? { fieldPath: e.path } : undefined),
+                    validatorCode: e.code,
+                    validatorPath: e.path,
+                    author: "human",
+                    createdAt: new Date().toISOString() as Timestamp,
                   };
                   onUpdateProcessFlow((g) => {
                     g.authoring = {


### PR DESCRIPTION
## Summary

v3 strict 型移行で炙り出された **2 つの silent bug** を解消。AnyRecord 緩和時代は実行時に silent reject (unevaluatedProperties: false) されていたが、UI 上動作している風に見えていた pre-existing bug。

## 修正内容

### WarningsPanel.tsx

| field | 旧 | 新 (v3 規範) |
|---|---|---|
| stepId | top-level field 書込 | anchor.stepId 配下 |
| code | top-level field 書込 | validatorCode (top-level、v3 規範) |
| path | top-level field 書込 | validatorPath (top-level、v3 規範) |

→ AI 依頼 marker の anchor / validatorCode / validatorPath が正しく永続化、validator marker 自動起票機能が動作するように。

### ErrorCatalogPanel.tsx

| field | 旧 | 新 |
|---|---|---|
| ErrorCatalogEntry.responseRef | 表示 + 書込 (v3 schema に不在) | ErrorCatalogEntry.responseId (v3 規範) |

→ ErrorCatalog の responseId 設定が永続化されるように。

## ts-nocheck 除去

ErrorCatalogPanel.tsx から @ts-nocheck 除去。WarningsPanel.tsx も既に除去済。

## Test plan

- [x] frontend build → OK
- [x] frontend test → 2346 / 2346 pass

実機 dogfood で validator AI 依頼 / errorCatalog responseId 設定が永続化されることを別途確認推奨。

Refs #1016

🤖 Generated with [Claude Code](https://claude.com/claude-code)