### PR TITLE
refactor(types): @ts-nocheck 除去 6 file (utility / palette / context-menu) (#1016 batch 4)

### DIFF
--- a/frontend/src/components/process-flow/internal/ActionTabBar.tsx
+++ b/frontend/src/components/process-flow/internal/ActionTabBar.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
 // Phase-3 (#1145): ProcessFlowEditor.tsx からアクションタブ + 検索 + ActionHelpPopover 統合を抽出。
 // 「コマンドバー」エリア全体 (アクション名 / 検索ボックス / タブ / popover / EditLevelToggle)。
 

--- a/frontend/src/components/process-flow/internal/AddActionModal.tsx
+++ b/frontend/src/components/process-flow/internal/AddActionModal.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
 // Phase-3 (#1145): ProcessFlowEditor.tsx からアクション追加モーダルを抽出。
 
 import type { ActionTrigger } from "../../../types/v3";

--- a/frontend/src/components/process-flow/internal/PaletteButtons.tsx
+++ b/frontend/src/components/process-flow/internal/PaletteButtons.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
 // Phase-3 (#1145): ProcessFlowEditor.tsx から palette / insert zone 系の小 component を抽出。
 // - ToolbarStepButton: 左サイドバー (パレット) のドラッグ可能なステップ種別ボタン
 // - StepInsertZone: ステップ間の "+" / paste ドロップゾーン

--- a/frontend/src/components/process-flow/internal/StepContextMenu.tsx
+++ b/frontend/src/components/process-flow/internal/StepContextMenu.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
 // Phase-3 (#1145): ProcessFlowEditor.tsx からステップカードの右クリックコンテキストメニューを抽出。
 // 通常モード ⇔ サブステップ追加 (subType picker) モードの切替を内部 prop 経由で受ける。
 

--- a/frontend/src/components/process-flow/internal/step-cards/index.ts
+++ b/frontend/src/components/process-flow/internal/step-cards/index.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
 // Phase-2 (#1145): StepCard.tsx の kind 別 body sub-component の barrel export。
 
 export { ValidationStepCardBody } from "./ValidationStepCardBody";

--- a/frontend/src/components/process-flow/internal/useProcessFlowCatalogs.ts
+++ b/frontend/src/components/process-flow/internal/useProcessFlowCatalogs.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
 // Phase-3 (#1145): ProcessFlowEditor.tsx の各種カタログ (tables / screens / commonGroups /
 // conventions / extensions / genericDefNames / projectCatalogs) ロード処理を集約したフック。
 // handleLoaded から呼び出される一括 fetch を含む。


### PR DESCRIPTION
## Summary

簡易な @ts-nocheck 残骸 6 file を除去。

## 移行 (6 file)

- internal/ActionTabBar.tsx
- internal/AddActionModal.tsx
- internal/PaletteButtons.tsx
- internal/StepContextMenu.tsx
- internal/step-cards/index.ts
- internal/useProcessFlowCatalogs.ts

## 試行した他の file (deferred、別 PR 候補)

以下は schema gap / silent bug あり deferred:

| file | 問題 |
|---|---|
| utils/specExporter.ts | ProcessFlow root flat access (pf.name etc) を meta.* に |
| utils/actionUtils.ts | step recursion narrow 必要 |
| utils/actionFields.ts | StructuredField strict 化 |
| utils/branchCondition.ts | BranchConditionVariant export 不在 |
| utils/outputBinding.ts | string-form OutputBinding 廃止 |
| utils/actionMigration.ts | legacy migration 型整合 |
| internal/ProcessFlowDialogs.tsx | ConflictInfo 型 |
| internal/actionTriggerConstants.ts | Marker.actionId/stepId/path silent bug |
| internal/stepSummaryText.ts | step recursion narrow 必要 |

## Test plan

- [x] frontend build → OK
- [x] frontend test → 2346 / 2346 pass

Refs #1016

🤖 Generated with [Claude Code](https://claude.com/claude-code)