### PR TITLE
fix(ui): MarkersSummaryPanel に validator MarkerKind 対応追加 + @ts-nocheck 除去 (#1016 batch 5)

### DIFF
--- a/frontend/src/components/dashboard/panels/MarkersSummaryPanel.tsx
+++ b/frontend/src/components/dashboard/panels/MarkersSummaryPanel.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck -- legacy marker aggregation uses mixed v2/v3 shapes; tracked by #1016.
 /**
  * 未解決マーカー集計パネル (#261)
  *
@@ -30,14 +29,14 @@ interface Summary {
 
 const INITIAL: Summary = {
   total: 0,
-  byKind: { chat: 0, attention: 0, todo: 0, question: 0 },
+  byKind: { chat: 0, attention: 0, todo: 0, question: 0, validator: 0 },
   perGroup: [],
   recent: [],
 };
 
 async function fetchSummary(): Promise<Summary> {
   const metas = await listProcessFlows();
-  const s: Summary = { total: 0, byKind: { chat: 0, attention: 0, todo: 0, question: 0 }, perGroup: [], recent: [] };
+  const s: Summary = { total: 0, byKind: { chat: 0, attention: 0, todo: 0, question: 0, validator: 0 }, perGroup: [], recent: [] };
   for (const meta of metas) {
     const g: ProcessFlow | null = await loadProcessFlow(meta.id);
     if (!g) continue;
@@ -69,12 +68,14 @@ const KIND_LABEL: Record<MarkerKind, string> = {
   attention: "注目",
   todo: "TODO",
   question: "質問",
+  validator: "validator",
 };
 const KIND_COLOR: Record<MarkerKind, string> = {
   chat: "#3b82f6",
   attention: "#f59e0b",
   todo: "#10b981",
   question: "#8b5cf6",
+  validator: "#dc2626",
 };
 
 export function MarkersSummaryPanel() {


### PR DESCRIPTION
## Summary

v3 Marker.kind enum に \"validator\" が含まれるが、MarkersSummaryPanel.tsx は集計用 Record<MarkerKind, ...> の validator key が不在で **集計から validator marker が漏れていた pre-existing 可能性**。

## 修正

- INITIAL.byKind + fetchSummary 内に validator: 0 追加
- KIND_LABEL に validator: \"validator\" 追加
- KIND_COLOR に validator: \"#dc2626\" (赤系) 追加
- @ts-nocheck 除去

## Test plan

- [x] frontend build → OK
- [x] frontend test → 2346 / 2346 pass

Refs #1016

🤖 Generated with [Claude Code](https://claude.com/claude-code)