### PR TITLE
fix(ui): ActionHttpContractPanel HttpResponseSpec.id 補完 + @ts-nocheck 除去 (#1016 batch 6)

### DIFF
--- a/frontend/src/components/process-flow/ActionHttpContractPanel.tsx
+++ b/frontend/src/components/process-flow/ActionHttpContractPanel.tsx
@@ -1,6 +1,5 @@
-// @ts-nocheck -- legacy process-flow action panel types are being migrated; tracked by #1016.
 import { useState } from "react";
-import type { ActionDefinition, HttpMethod, HttpAuthRequirement, HttpResponseSpec } from "../../types/v3";
+import type { ActionDefinition, HttpMethod, HttpAuthRequirement, HttpResponseSpec, LocalId, BodySchema } from "../../types/v3";
 
 interface Props {
   action: ActionDefinition;
@@ -28,7 +27,8 @@ export function ActionHttpContractPanel({ action, onChange }: Props) {
   const clearRoute = () => onChange({ httpRoute: undefined });
 
   const addResponse = () => {
-    const next: HttpResponseSpec = { status: 200, description: "" };
+    // #1016 silent bug fix: v3 HttpResponseSpec.id は必須 (LocalId)。`200-ok` 等の kebab-case 規範
+    const next: HttpResponseSpec = { id: `r-${responses.length + 1}` as LocalId, status: 200, description: "" };
     onChange({ responses: [...responses, next] });
   };
 
@@ -130,7 +130,7 @@ export function ActionHttpContractPanel({ action, onChange }: Props) {
                   type="text"
                   className="form-control form-control-sm"
                   value={r.id ?? ""}
-                  onChange={(e) => updateResponse(i, { id: e.target.value || undefined })}
+                  onChange={(e) => updateResponse(i, { id: (e.target.value || "") as LocalId })}
                   placeholder="id (例: 409-stock-shortage)"
                   style={{ fontSize: "0.8rem" }}
                 />
@@ -140,7 +140,7 @@ export function ActionHttpContractPanel({ action, onChange }: Props) {
                   type="text"
                   className="form-control form-control-sm"
                   value={typeof r.bodySchema === "string" ? r.bodySchema : ""}
-                  onChange={(e) => updateResponse(i, { bodySchema: e.target.value || undefined })}
+                  onChange={(e) => updateResponse(i, { bodySchema: (e.target.value || undefined) as BodySchema | undefined })}
                   placeholder="bodySchema"
                   style={{ fontSize: "0.8rem" }}
                 />


### PR DESCRIPTION
## Summary

ActionHttpContractPanel.tsx の HttpResponseSpec オブジェクト生成で v3 schema 上必須の \`id: LocalId\` field が欠落していた **silent bug** を補完。

## 修正

- addResponse: 新規 response に \`id: r-N\` 形式の auto-generate ID を付与
- updateResponse: id update の cast を LocalId に明示
- bodySchema cast を BodySchema branded type に明示
- @ts-nocheck 除去

→ Action.responses[] に新規 response 追加時、v3 schema 必須 field の id が正しく永続化される (旧 AnyRecord 時代は id 不在で AJV reject されていたが UI 上動作風)。

## Test plan

- [x] frontend build → OK
- [x] frontend test → 2346 / 2346 pass

Refs #1016

🤖 Generated with [Claude Code](https://claude.com/claude-code)