### PR TITLE
refactor(types): actionTriggerConstants の @ts-nocheck 除去 + legacy marker field を optional read fallback 化 (#1016 batch 7)

### DIFF
--- a/frontend/src/components/process-flow/internal/actionTriggerConstants.ts
+++ b/frontend/src/components/process-flow/internal/actionTriggerConstants.ts
@@ -1,6 +1,7 @@
-// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
 // Phase-3 (#1145): ProcessFlowEditor.tsx から action trigger 関連の定数 / ヘルパーを抽出。
 // アクション (trigger) の icon / カテゴリ / リッチヘルプ / ラベルの取得。
+// #1016 follow-up (2026-05-20): @ts-nocheck 除去。legacy marker field (actionId / stepId / path) は
+// pre-v3 data 互換のため optional read fallback として保持 (新規書込は v3 規範に従う)。
 
 // #1186 Phase 2-D: constants は processFlowMetadata から
 import { ACTION_TRIGGER_LABELS } from "../../../utils/processFlowMetadata";
@@ -172,10 +173,12 @@ export function getActionOpenMarkers(
   const actionPathByIndex = actionIndex >= 0 ? `actions[${actionIndex}]` : null;
   return markers.filter((marker) => {
     if (marker.resolvedAt) return false;
-    if (marker.actionId === action.id) return true;
-    const markerStepId = marker.stepId ?? marker.anchor?.stepId;
-    if (markerStepId && stepIds.has(markerStepId)) return true;
-    const markerPath = marker.path ?? marker.validatorPath ?? marker.anchor?.fieldPath ?? "";
+    // legacy v1/v2 field: marker.actionId (v3 では anchor 経由のみ、pre-v3 data 互換のため optional read)
+    const legacyMarker = marker as Marker & { actionId?: string; stepId?: string; path?: string };
+    if (legacyMarker.actionId === action.id) return true;
+    const markerStepId = legacyMarker.stepId ?? marker.anchor?.stepId;
+    if (markerStepId && stepIds.has(markerStepId as string)) return true;
+    const markerPath = legacyMarker.path ?? marker.validatorPath ?? marker.anchor?.fieldPath ?? "";
     return (
       typeof markerPath === "string" &&
       (markerPath.includes(actionPathById) ||


### PR DESCRIPTION
## Summary

actionTriggerConstants.ts:165 \`getActionOpenMarkers\` が \`marker.actionId\` / \`stepId\` / \`path\` を v3 strict 型でアクセスして TS error。これらは v1/v2 legacy field で v3 schema に不在。

## 修正

- @ts-nocheck 除去
- legacy field (actionId / stepId / path) は \`Marker & { ... }\` 型 augmentation で optional 化
- pre-v3 data 読み込み時の互換性は維持 (read-only fallback)
- 新規書込は v3 規範 (anchor / validatorPath) に従う設計を維持

## Test plan

- [x] frontend build → OK
- [x] frontend test → 2346 / 2346 pass

Refs #1016

🤖 Generated with [Claude Code](https://claude.com/claude-code)