### PR TITLE
refactor(utils): branchCondition の string 形式廃止 (v3 schema 整合) + @ts-nocheck 除去 (#1016 batch 8)

### DIFF
--- a/frontend/src/utils/branchCondition.test.ts
+++ b/frontend/src/utils/branchCondition.test.ts
@@ -1,25 +1,29 @@
 import { describe, it, expect } from "vitest";
-import type { BranchCondition } from "../types/v3";
+import type { BranchCondition, ErrorCode, ExpressionString } from "../types/v3";
 import {
   getBranchConditionText,
   isStructuredCondition,
   isTryCatchCondition,
 } from "./branchCondition";
 
+// #1016 follow-up (2026-05-20): v3 では BranchCondition は discriminated union のみ
+// (string 形式は v1/v2 で廃止)。expression 形式は { kind: "expression", expression: ... } で表現。
+
 describe("getBranchConditionText", () => {
-  it("string はそのまま返す", () => {
-    expect(getBranchConditionText("@x > 0")).toBe("@x > 0");
+  it("expression variant は expression 文字列を返す", () => {
+    const cond: BranchCondition = { kind: "expression", expression: "@x > 0" as ExpressionString };
+    expect(getBranchConditionText(cond)).toBe("@x > 0");
   });
 
   it("tryCatch variant は catch 記法の文字列に変換", () => {
-    const cond: BranchCondition = { kind: "tryCatch", errorCode: "STOCK_SHORTAGE" };
+    const cond: BranchCondition = { kind: "tryCatch", errorCode: "STOCK_SHORTAGE" as ErrorCode };
     expect(getBranchConditionText(cond)).toBe("catch STOCK_SHORTAGE");
   });
 
   it("tryCatch variant に description があれば併記", () => {
     const cond: BranchCondition = {
       kind: "tryCatch",
-      errorCode: "STOCK_SHORTAGE",
+      errorCode: "STOCK_SHORTAGE" as ErrorCode,
       description: "在庫不足で TX rollback",
     };
     expect(getBranchConditionText(cond)).toBe("catch STOCK_SHORTAGE (在庫不足で TX rollback)");
@@ -31,12 +35,13 @@ describe("getBranchConditionText", () => {
 });
 
 describe("isTryCatchCondition", () => {
-  it("string は false", () => {
-    expect(isTryCatchCondition("text")).toBe(false);
+  it("expression variant は false", () => {
+    const cond: BranchCondition = { kind: "expression", expression: "@x" as ExpressionString };
+    expect(isTryCatchCondition(cond)).toBe(false);
   });
 
   it("tryCatch variant は true", () => {
-    expect(isTryCatchCondition({ kind: "tryCatch", errorCode: "X" })).toBe(true);
+    expect(isTryCatchCondition({ kind: "tryCatch", errorCode: "X" as ErrorCode })).toBe(true);
   });
 
   it("undefined は false", () => {
@@ -45,12 +50,13 @@ describe("isTryCatchCondition", () => {
 });
 
 describe("isStructuredCondition", () => {
-  it("string は false (構造化でない)", () => {
-    expect(isStructuredCondition("anything")).toBe(false);
+  it("expression variant は true (構造化された discriminated union)", () => {
+    const cond: BranchCondition = { kind: "expression", expression: "anything" as ExpressionString };
+    expect(isStructuredCondition(cond)).toBe(true);
   });
 
   it("variant は true", () => {
-    expect(isStructuredCondition({ kind: "tryCatch", errorCode: "X" })).toBe(true);
+    expect(isStructuredCondition({ kind: "tryCatch", errorCode: "X" as ErrorCode })).toBe(true);
   });
 
   it("undefined は false", () => {
@@ -62,16 +68,19 @@ describe("BranchCondition union の典型運用", () => {
   it("TX 失敗時の branch 定義 (StockShortageError catch)", () => {
     const cond: BranchCondition = {
       kind: "tryCatch",
-      errorCode: "STOCK_SHORTAGE",
+      errorCode: "STOCK_SHORTAGE" as ErrorCode,
       description: "在庫不足",
     };
     expect(isTryCatchCondition(cond)).toBe(true);
     expect(getBranchConditionText(cond)).toContain("STOCK_SHORTAGE");
   });
 
-  it("通常の式ベース分岐 (string)", () => {
-    const cond: BranchCondition = "@shortageList.length > 0";
-    expect(isStructuredCondition(cond)).toBe(false);
+  it("通常の式ベース分岐 (expression variant)", () => {
+    const cond: BranchCondition = {
+      kind: "expression",
+      expression: "@shortageList.length > 0" as ExpressionString,
+    };
+    expect(isStructuredCondition(cond)).toBe(true);
     expect(getBranchConditionText(cond)).toBe("@shortageList.length > 0");
   });
 });

--- a/frontend/src/utils/branchCondition.ts
+++ b/frontend/src/utils/branchCondition.ts
@@ -1,19 +1,25 @@
-// @ts-nocheck -- legacy branch condition migration remains open; tracked by #1016.
 /**
  * branchCondition.ts
- * Branch.condition の union (string | BranchConditionVariant) を扱うヘルパー。
+ * Branch.condition (BranchCondition discriminated union) を扱うヘルパー。
  *
  * docs/spec, #151 (B) / #176
+ * #1016 follow-up (2026-05-20): v3 schema 整合化 — string 形式 (legacy v1/v2) サポート除去、
+ * `BranchConditionVariant` 別 alias 廃止し `BranchCondition` 直接使用。
  */
-import type { BranchCondition, BranchConditionVariant } from "../types/v3";
+import type { BranchCondition } from "../types/v3";
 
 /** condition を人間可読な文字列に変換 (UI 表示・description ログ用) */
 export function getBranchConditionText(cond: BranchCondition | undefined): string {
   if (cond == null) return "";
-  if (typeof cond === "string") return cond;
   switch (cond.kind) {
+    case "expression":
+      return cond.expression;
     case "tryCatch":
       return `catch ${cond.errorCode}${cond.description ? ` (${cond.description})` : ""}`;
+    case "affectedRowsZero":
+      return `affectedRowsZero${cond.stepId ? ` (@${cond.stepId})` : ""}`;
+    case "externalOutcome":
+      return `${cond.outcome}${cond.stepId ? ` (@${cond.stepId})` : ""}`;
     default:
       return "";
   }
@@ -22,13 +28,13 @@ export function getBranchConditionText(cond: BranchCondition | undefined): strin
 /** 型ガード: tryCatch variant か */
 export function isTryCatchCondition(
   cond: BranchCondition | undefined,
-): cond is Extract<BranchConditionVariant, { kind: "tryCatch" }> {
-  return cond != null && typeof cond === "object" && (cond as BranchConditionVariant).kind === "tryCatch";
+): cond is Extract<BranchCondition, { kind: "tryCatch" }> {
+  return cond != null && cond.kind === "tryCatch";
 }
 
-/** 型ガード: 構造化された variant か (string でないか) */
+/** 型ガード: 構造化された variant か (v3 では全て構造化、`null` でなければ true) */
 export function isStructuredCondition(
   cond: BranchCondition | undefined,
-): cond is BranchConditionVariant {
-  return cond != null && typeof cond === "object";
+): cond is BranchCondition {
+  return cond != null;
 }


### PR DESCRIPTION
## Summary

v3 BranchCondition は discriminated union のみ (expression / tryCatch / affectedRowsZero / externalOutcome)、v1/v2 の string 短縮形は廃止済。utility は string サポートを残していたため v3 strict 化で除去。

## 修正

- branchCondition.ts: typeof cond === \"string\" handling 除去、\`BranchConditionVariant\` alias 廃止 (\`BranchCondition\` 直接使用)
- expression / affectedRowsZero / externalOutcome variant の text 変換も追加 (旧来 tryCatch のみ対応)
- @ts-nocheck 除去
- branchCondition.test.ts: 全 string fixture を \`{ kind: \"expression\", expression: ... }\` 形式に書き換え

## Test plan

- [x] frontend build → OK
- [x] frontend test → 2346 / 2346 pass

Refs #1016

🤖 Generated with [Claude Code](https://claude.com/claude-code)