### PR TITLE
refactor(utils): outputBinding の string 形式廃止 (v3 schema 整合) + @ts-nocheck 除去 (#1016 batch 9)

### DIFF
--- a/frontend/src/utils/outputBinding.test.ts
+++ b/frontend/src/utils/outputBinding.test.ts
@@ -1,18 +1,16 @@
 import { describe, it, expect } from "vitest";
-import type { OutputBinding } from "../types/v3";
+import type { OutputBinding, Identifier } from "../types/v3";
 import {
   getBindingName,
   getBindingOperation,
   isStructuredBinding,
 } from "./outputBinding";
 
-describe("getBindingName", () => {
-  it("string 形式はそのまま返す", () => {
-    expect(getBindingName("duplicates")).toBe("duplicates");
-  });
+// #1016 follow-up (2026-05-20): v3 OutputBinding は object 形式のみ (string 短縮形は v1/v2 で廃止)
 
+describe("getBindingName", () => {
   it("object 形式は .name を返す", () => {
-    expect(getBindingName({ name: "shortageList", operation: "push" })).toBe("shortageList");
+    expect(getBindingName({ name: "shortageList" as Identifier, operation: "push" })).toBe("shortageList");
   });
 
   it("undefined は undefined", () => {
@@ -20,23 +18,18 @@ describe("getBindingName", () => {
   });
 
   it("空白のみは undefined として扱う", () => {
-    expect(getBindingName("   ")).toBeUndefined();
-    expect(getBindingName({ name: "  ", operation: "assign" })).toBeUndefined();
+    expect(getBindingName({ name: "  " as Identifier, operation: "assign" })).toBeUndefined();
   });
 });
 
 describe("getBindingOperation", () => {
-  it("string 形式は 'assign' 既定", () => {
-    expect(getBindingOperation("users")).toBe("assign");
-  });
-
   it("object 形式で operation 未指定は 'assign'", () => {
-    expect(getBindingOperation({ name: "x" })).toBe("assign");
+    expect(getBindingOperation({ name: "x" as Identifier })).toBe("assign");
   });
 
   it("object 形式で operation 明示時はその値", () => {
-    expect(getBindingOperation({ name: "subtotal", operation: "accumulate" })).toBe("accumulate");
-    expect(getBindingOperation({ name: "list", operation: "push" })).toBe("push");
+    expect(getBindingOperation({ name: "subtotal" as Identifier, operation: "accumulate" })).toBe("accumulate");
+    expect(getBindingOperation({ name: "list" as Identifier, operation: "push" })).toBe("push");
   });
 
   it("undefined は 'assign'", () => {
@@ -45,12 +38,8 @@ describe("getBindingOperation", () => {
 });
 
 describe("isStructuredBinding", () => {
-  it("string は false", () => {
-    expect(isStructuredBinding("users")).toBe(false);
-  });
-
-  it("object は true", () => {
-    expect(isStructuredBinding({ name: "x" })).toBe(true);
+  it("object は true (v3 では全て構造化)", () => {
+    expect(isStructuredBinding({ name: "x" as Identifier })).toBe(true);
   });
 
   it("undefined は false", () => {
@@ -58,21 +47,21 @@ describe("isStructuredBinding", () => {
   });
 });
 
-describe("OutputBinding union の運用パターン", () => {
+describe("OutputBinding 運用パターン", () => {
   it("typical accumulation: 小計の累積", () => {
-    const binding: OutputBinding = { name: "subtotal", operation: "accumulate" };
+    const binding: OutputBinding = { name: "subtotal" as Identifier, operation: "accumulate" };
     expect(getBindingName(binding)).toBe("subtotal");
     expect(getBindingOperation(binding)).toBe("accumulate");
   });
 
   it("typical push: 配列の要素追加", () => {
-    const binding: OutputBinding = { name: "enrichedItems", operation: "push" };
+    const binding: OutputBinding = { name: "enrichedItems" as Identifier, operation: "push" };
     expect(getBindingName(binding)).toBe("enrichedItems");
     expect(getBindingOperation(binding)).toBe("push");
   });
 
-  it("typical assign: 単純代入 (string 形式で十分)", () => {
-    const binding: OutputBinding = "authResult";
+  it("typical assign: 単純代入 (operation 未指定 → 'assign' 既定)", () => {
+    const binding: OutputBinding = { name: "authResult" as Identifier };
     expect(getBindingName(binding)).toBe("authResult");
     expect(getBindingOperation(binding)).toBe("assign");
   });

--- a/frontend/src/utils/outputBinding.ts
+++ b/frontend/src/utils/outputBinding.ts
@@ -1,31 +1,32 @@
-// @ts-nocheck -- v3 strict 型移行 (#1186 Phase 2-E)、string 形式の OutputBinding は v3 廃止 (legacy data 互換維持)
 /**
  * outputBinding.ts
- * StepBase.outputBinding の union (string | OutputBindingObject) を透過的に扱うヘルパー。
+ * Step.outputBinding を扱うヘルパー。
  *
  * docs/spec, #151 (B)
+ * #1016 follow-up (2026-05-20): v3 strict 整合 — string 形式 (v1/v2 短縮形) の OutputBinding を廃止、
+ * object 形式 (`{ name, operation? }`) のみ扱う。
  */
-import type { OutputBinding, OutputBindingOperation } from "../types/v3";
+import type { OutputBinding } from "../types/v3";
 
-/** outputBinding の変数名を取得 (string 形式はそのまま、object 形式は .name) */
+type OutputBindingOperation = "assign" | "accumulate" | "push";
+
+/** outputBinding の変数名を取得 (v3: object 形式の .name のみ、空白は undefined 扱い) */
 export function getBindingName(ob: OutputBinding | undefined): string | undefined {
   if (ob == null) return undefined;
-  if (typeof ob === "string") return ob.trim() || undefined;
   return ob.name.trim() || undefined;
 }
 
-/** outputBinding の代入方式を取得 (未指定や string 形式は "assign" 既定) */
+/** outputBinding の代入方式を取得 (未指定時は "assign" 既定) */
 export function getBindingOperation(
   ob: OutputBinding | undefined,
 ): OutputBindingOperation {
   if (ob == null) return "assign";
-  if (typeof ob === "string") return "assign";
   return ob.operation ?? "assign";
 }
 
-/** 型ガード: object 形式か */
+/** 型ガード: 構造化された OutputBinding か (v3 では string 形式廃止、object のみ) */
 export function isStructuredBinding(
   ob: OutputBinding | undefined,
-): ob is Exclude<OutputBinding, string> {
-  return ob != null && typeof ob === "object";
+): ob is OutputBinding {
+  return ob != null;
 }


### PR DESCRIPTION
## Summary

v3 OutputBinding は object 形式 (\`{ name, operation? }\`) のみ、v1/v2 の string 短縮形は廃止済。utility は string サポートを残していたため v3 strict 化で除去。

## 修正

- outputBinding.ts: typeof ob === \"string\" handling 除去、isStructuredBinding を null check のみに
- outputBinding.test.ts: 全 string fixture を object 形式に書き換え
- @ts-nocheck 除去

actionMigration.ts:63 の string typeof check は legacy → v3 migration 用に意図的に保持。

## Test plan

- [x] frontend build → OK
- [x] frontend test → 2343 / 2343 pass (3 件の string-only test を統合削除)

Refs #1016

🤖 Generated with [Claude Code](https://claude.com/claude-code)