### PR TITLE
refactor(types): PalettePanel の @ts-nocheck 除去 (#1016 batch 10)

### DIFF
--- a/frontend/src/components/process-flow/internal/PalettePanel.tsx
+++ b/frontend/src/components/process-flow/internal/PalettePanel.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
 // Phase-3 (#1145): ProcessFlowEditor.tsx 左サイドバー (パレット) を抽出。
 // 基本ステップ button / カスタムステップ button / テンプレート dropdown。
 
@@ -91,7 +90,7 @@ export function PalettePanel({
                 <div
                   key={tpl.id}
                   className="template-dropdown-item"
-                  onClick={() => onAddTemplate(tpl.id)}
+                  onClick={() => onAddTemplate(tpl.id ?? "")}
                 >
                   <div className="template-dropdown-item-label">{tpl.label}</div>
                   <div className="template-dropdown-item-desc">{tpl.description}</div>


### PR DESCRIPTION
## Summary

PalettePanel.tsx: テンプレートクリック時の \`onAddTemplate(tpl.id)\` で id が optional のため TS error。空文字 fallback で型を満たす。

## 修正

- @ts-nocheck 除去
- onAddTemplate(tpl.id ?? \"\") に変更

## Test plan

- [x] frontend build → OK
- [x] frontend test → 2343 / 2343 pass

Refs #1016

🤖 Generated with [Claude Code](https://claude.com/claude-code)