### PR TITLE
refactor(utils): actionFields の @ts-nocheck 除去 + StructuredField branded type cast (#1016 batch 11)

### DIFF
--- a/frontend/src/utils/actionFields.ts
+++ b/frontend/src/utils/actionFields.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck -- v3 strict 型移行 (#1186 Phase 2-E) で loose access パターン露呈、proper narrow は #1016 で deferred
 /**
  * actionFields.ts
  * ActionDefinition.inputs / outputs の `string | StructuredField[]` union を扱うヘルパー。
@@ -8,8 +7,9 @@
  *
  * 現行 UI は自由記述 (string) のみ対応のため、表形式は fieldsToText でテキスト化して表示する。
  * Phase 1 時点では StructuredField[] の編集は未サポート (名前のみのテキスト表示)。
+ * #1016 follow-up (2026-05-20): @ts-nocheck 除去、StructuredField.name を Identifier branded type にcast。
  */
-import type { ActionFields, StructuredField } from "../types/v3";
+import type { ActionFields, StructuredField, Identifier } from "../types/v3";
 
 /** 値が StructuredField[] (新形式) かを判定する型ガード */
 export function isStructuredFields(
@@ -40,5 +40,5 @@ export function textToStructuredFields(text: string): StructuredField[] {
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter((line) => line.length > 0)
-    .map((name) => ({ name, type: "string" as const }));
+    .map((name): StructuredField => ({ name: name as Identifier, type: "string" }));
 }


### PR DESCRIPTION
## Summary

actionFields.ts: textToStructuredFields の return type で StructuredField.name (Identifier branded) への cast が不足、type 'string' literal narrowing が必要。

## 修正

- @ts-nocheck 除去
- Identifier 型 import 追加
- textToStructuredFields の map で name as Identifier cast 追加、return type を StructuredField に明示

## Test plan

- [x] frontend build → OK
- [x] frontend test → 2343 / 2343 pass

Refs #1016

🤖 Generated with [Claude Code](https://claude.com/claude-code)