### PR TITLE
refactor(types): SecretsCatalogPanel + ScreenItemsView の @ts-nocheck 除去 (#1016 batch 12)

### DIFF
--- a/frontend/src/components/process-flow/SecretsCatalogPanel.tsx
+++ b/frontend/src/components/process-flow/SecretsCatalogPanel.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck -- v3 strict 型移行 (#1186 Phase 2-E) で loose access パターン露呈、proper narrow は #1016 で deferred
 /**
  * ProcessFlow.context.catalogs.secrets 編集パネル (#278 / #414 values 編集対応 / #570 v3 移行)。
  *
@@ -7,7 +6,7 @@
  *   旧フォーマット (values 無し) も valid のまま (後方互換)。
  */
 import { useState } from "react";
-import type { ProcessFlow, SecretRef } from "../../types/v3";
+import type { ProcessFlow, SecretRef, Timestamp } from "../../types/v3";
 
 interface Props {
   group: ProcessFlow;
@@ -236,7 +235,7 @@ export function SecretsCatalogPanel({ group, onChange, expanded: expandedProp, o
                       className="form-control form-control-sm"
                       value={e.lastRotatedAt ? e.lastRotatedAt.slice(0, 16) : ""}
                       data-field-path={`context.catalogs.secrets.${k}.lastRotatedAt`}
-                      onChange={(ev) => updateEntry(k, { lastRotatedAt: ev.target.value ? new Date(ev.target.value).toISOString() : undefined })}
+                      onChange={(ev) => updateEntry(k, { lastRotatedAt: ev.target.value ? new Date(ev.target.value).toISOString() as Timestamp : undefined })}
                     />
                   </label>
                   <label className="catalog-wide">

--- a/frontend/src/components/screen-items/ScreenItemsView.tsx
+++ b/frontend/src/components/screen-items/ScreenItemsView.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck -- v3 strict 型移行 (#1186 Phase 2-E) で loose access パターン露呈、proper narrow は #1016 で deferred
 /**
  * 画面項目定義ビュー (#318 プロトタイプ、#323 既存画面からの抽出対応)。
  *
@@ -45,7 +44,9 @@ import type {
   Identifier,
 } from "../../types/v3";
 import type { ScreenItemsDocument } from "../../store/screenItemsStore";
-import type { ProcessFlowMeta } from "../../types/v3";
+// #1016 follow-up (2026-05-20): listProcessFlows() の return type は frontend/src/types/flow の ProcessFlowMeta
+// (= ProcessFlowEntry alias)。v3 の ProcessFlowMeta (ProcessFlow.meta) とは別概念。
+import type { ProcessFlowMeta } from "../../types/flow";
 import { listProcessFlows } from "../../store/processFlowStore";
 import { listTables, loadTable } from "../../store/tableStore";
 import { listViews, loadView } from "../../store/viewStore";


### PR DESCRIPTION
## Summary

2 file の @ts-nocheck 除去 + 副次的な ProcessFlowMeta import path 不一致を修正。

## 修正

### SecretsCatalogPanel.tsx
- lastRotatedAt の cast を Timestamp branded type に明示
- @ts-nocheck 除去

### ScreenItemsView.tsx
- ProcessFlowMeta の import path 不一致 (v3 と frontend/types/flow で同名別概念) を修正
  - 旧: \`from \"../../types/v3\"\` (v3 ProcessFlow.meta block 型)
  - 新: \`from \"../../types/flow\"\` (ProcessFlowEntry alias、listProcessFlows() return type)
- @ts-nocheck 除去

## Test plan

- [x] frontend build → OK
- [x] frontend test → 2343 / 2343 pass

Refs #1016

🤖 Generated with [Claude Code](https://claude.com/claude-code)