### PR TITLE
fix(examples): ProcessFlow TX semantics Must-fix M-001/M-002/M-003 (#1226)

### DIFF
--- a/examples/diary/harmony/process-flows/b3a1c2d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d.json
+++ b/examples/diary/harmony/process-flows/b3a1c2d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d.json
@@ -313,92 +313,99 @@
         },
         {
           "id": "step-06",
-          "kind": "dbAccess",
-          "description": "posts テーブルを更新する。",
-          "tableId": "79d2c08c-7511-4d37-9051-e6f4587630e0",
-          "operation": "UPDATE",
-          "sql": "UPDATE posts SET title = COALESCE(@inputs.title, title), body = COALESCE(@inputs.body, body), mood = COALESCE(@inputs.mood, mood), weather = COALESCE(@inputs.weather, weather), location = COALESCE(@inputs.location, location), status = COALESCE(@inputs.status, status), published_at = @newPublishedAt, updated_at = CURRENT_TIMESTAMP WHERE id = @inputs.postId",
-          "txBoundary": { "role": "begin", "txId": "tx-post-update" },
-          "lineage": {
-            "writes": [{ "tableId": "79d2c08c-7511-4d37-9051-e6f4587630e0", "purpose": "update" }]
-          }
-        },
-        {
-          "id": "step-07",
-          "kind": "dbAccess",
-          "description": "既存写真を全削除する (photos が指定された場合)。",
-          "tableId": "d8fc5f8a-9cd2-4e46-9f3d-03c337ae0e9f",
-          "operation": "DELETE",
-          "sql": "DELETE FROM photos WHERE post_id = @inputs.postId",
-          "runIf": "@inputs.photos != null",
-          "txBoundary": { "role": "member", "txId": "tx-post-update" },
-          "lineage": {
-            "writes": [{ "tableId": "d8fc5f8a-9cd2-4e46-9f3d-03c337ae0e9f", "purpose": "soft-delete" }]
-          }
-        },
-        {
-          "id": "step-08",
-          "kind": "loop",
-          "description": "新しい写真を photos テーブルに INSERT する。",
-          "loopKind": "collection",
-          "collectionSource": "@inputs.photos",
-          "collectionItemName": "photo",
-          "runIf": "@inputs.photos != null",
-          "txBoundary": { "role": "member", "txId": "tx-post-update" },
+          "kind": "transactionScope",
+          "description": "posts / photos / post_tags の更新を 1 TX で原子的に実行する。TX 失敗時は全体をロールバックし @txResult に結果を expose する。photos / tags は省略可能 (runIf あり) だが TX 境界は wrapper が管理するため runIf による TX 未クローズ問題は発生しない。",
+          "isolationLevel": "READ_COMMITTED",
+          "propagation": "REQUIRED",
+          "rollbackOn": [],
+          "outputBinding": { "name": "txResult" },
           "steps": [
             {
-              "id": "step-08-01",
+              "id": "step-06-01",
               "kind": "dbAccess",
-              "description": "photos テーブルに写真を INSERT する。",
+              "description": "posts テーブルを更新する。",
+              "tableId": "79d2c08c-7511-4d37-9051-e6f4587630e0",
+              "operation": "UPDATE",
+              "sql": "UPDATE posts SET title = COALESCE(@inputs.title, title), body = COALESCE(@inputs.body, body), mood = COALESCE(@inputs.mood, mood), weather = COALESCE(@inputs.weather, weather), location = COALESCE(@inputs.location, location), status = COALESCE(@inputs.status, status), published_at = @newPublishedAt, updated_at = CURRENT_TIMESTAMP WHERE id = @inputs.postId",
+              "lineage": {
+                "writes": [{ "tableId": "79d2c08c-7511-4d37-9051-e6f4587630e0", "purpose": "update" }]
+              }
+            },
+            {
+              "id": "step-06-02",
+              "kind": "dbAccess",
+              "description": "既存写真を全削除する (photos が指定された場合)。",
               "tableId": "d8fc5f8a-9cd2-4e46-9f3d-03c337ae0e9f",
-              "operation": "INSERT",
-              "sql": "INSERT INTO photos (post_id, url, thumbnail_url, alt, caption, order_index, width, height, exif_json, created_at) VALUES (@inputs.postId, @photo.url, @photo.thumbnail_url, @photo.alt, @photo.caption, COALESCE(@photo.order_index, 0), @photo.width, @photo.height, @photo.exif_json, CURRENT_TIMESTAMP)",
+              "operation": "DELETE",
+              "sql": "DELETE FROM photos WHERE post_id = @inputs.postId",
+              "runIf": "@inputs.photos != null",
               "lineage": {
-                "writes": [{ "tableId": "d8fc5f8a-9cd2-4e46-9f3d-03c337ae0e9f", "purpose": "insert" }]
+                "writes": [{ "tableId": "d8fc5f8a-9cd2-4e46-9f3d-03c337ae0e9f", "purpose": "soft-delete" }]
               }
-            }
-          ]
-        },
-        {
-          "id": "step-09",
-          "kind": "dbAccess",
-          "description": "既存の post_tags を全削除する (tags が指定された場合)。",
-          "tableId": "1681eee2-39d9-4548-9044-5cedac68d41e",
-          "operation": "DELETE",
-          "sql": "DELETE FROM post_tags WHERE post_id = @inputs.postId",
-          "runIf": "@inputs.tags != null",
-          "txBoundary": { "role": "member", "txId": "tx-post-update" },
-          "lineage": {
-            "writes": [{ "tableId": "1681eee2-39d9-4548-9044-5cedac68d41e", "purpose": "soft-delete" }]
-          }
-        },
-        {
-          "id": "step-10",
-          "kind": "loop",
-          "description": "新しいタグを post_tags に INSERT する。",
-          "loopKind": "collection",
-          "collectionSource": "@inputs.tags",
-          "collectionItemName": "tag",
-          "runIf": "@inputs.tags != null",
-          "txBoundary": { "role": "end", "txId": "tx-post-update" },
-          "steps": [
+            },
             {
-              "id": "step-10-01",
+              "id": "step-06-03",
+              "kind": "loop",
+              "description": "新しい写真を photos テーブルに INSERT する。",
+              "loopKind": "collection",
+              "collectionSource": "@inputs.photos",
+              "collectionItemName": "photo",
+              "runIf": "@inputs.photos != null",
+              "steps": [
+                {
+                  "id": "step-06-03-01",
+                  "kind": "dbAccess",
+                  "description": "photos テーブルに写真を INSERT する。",
+                  "tableId": "d8fc5f8a-9cd2-4e46-9f3d-03c337ae0e9f",
+                  "operation": "INSERT",
+                  "sql": "INSERT INTO photos (post_id, url, thumbnail_url, alt, caption, order_index, width, height, exif_json, created_at) VALUES (@inputs.postId, @photo.url, @photo.thumbnail_url, @photo.alt, @photo.caption, COALESCE(@photo.order_index, 0), @photo.width, @photo.height, @photo.exif_json, CURRENT_TIMESTAMP)",
+                  "lineage": {
+                    "writes": [{ "tableId": "d8fc5f8a-9cd2-4e46-9f3d-03c337ae0e9f", "purpose": "insert" }]
+                  }
+                }
+              ]
+            },
+            {
+              "id": "step-06-04",
               "kind": "dbAccess",
-              "description": "post_tags に投稿とタグの関連を INSERT する。",
+              "description": "既存の post_tags を全削除する (tags が指定された場合)。",
               "tableId": "1681eee2-39d9-4548-9044-5cedac68d41e",
-              "operation": "INSERT",
-              "sql": "INSERT INTO post_tags (post_id, tag_id, source, confidence, created_at) VALUES (@inputs.postId, @tag.id, COALESCE(@tag.source, 'manual'), COALESCE(@tag.confidence, 1.0), CURRENT_TIMESTAMP)",
+              "operation": "DELETE",
+              "sql": "DELETE FROM post_tags WHERE post_id = @inputs.postId",
+              "runIf": "@inputs.tags != null",
               "lineage": {
-                "writes": [{ "tableId": "1681eee2-39d9-4548-9044-5cedac68d41e", "purpose": "insert" }]
+                "writes": [{ "tableId": "1681eee2-39d9-4548-9044-5cedac68d41e", "purpose": "soft-delete" }]
               }
+            },
+            {
+              "id": "step-06-05",
+              "kind": "loop",
+              "description": "新しいタグを post_tags に INSERT する。",
+              "loopKind": "collection",
+              "collectionSource": "@inputs.tags",
+              "collectionItemName": "tag",
+              "runIf": "@inputs.tags != null",
+              "steps": [
+                {
+                  "id": "step-06-05-01",
+                  "kind": "dbAccess",
+                  "description": "post_tags に投稿とタグの関連を INSERT する。",
+                  "tableId": "1681eee2-39d9-4548-9044-5cedac68d41e",
+                  "operation": "INSERT",
+                  "sql": "INSERT INTO post_tags (post_id, tag_id, source, confidence, created_at) VALUES (@inputs.postId, @tag.id, COALESCE(@tag.source, 'manual'), COALESCE(@tag.confidence, 1.0), CURRENT_TIMESTAMP)",
+                  "lineage": {
+                    "writes": [{ "tableId": "1681eee2-39d9-4548-9044-5cedac68d41e", "purpose": "insert" }]
+                  }
+                }
+              ]
             }
           ]
         },
         {
           "id": "step-11",
           "kind": "return",
-          "description": "200 更新成功を返す。",
+          "runIf": "@txResult.committed == true",
+          "description": "200 更新成功を返す。TX コミット後にのみ実行する。",
           "responseId": "200-ok",
           "bodyExpression": "{ postId: @inputs.postId, updatedAt: new Date().toISOString() }"
         }

--- a/examples/diary/harmony/process-flows/b3a1c2d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d.json
+++ b/examples/diary/harmony/process-flows/b3a1c2d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d.json
@@ -35,6 +35,12 @@
           "defaultMessage": "投稿が見つかりません。",
           "responseId": "404-not-found",
           "description": "指定された postId の投稿が存在しない場合。"
+        },
+        "POST_UPDATE_FAILED": {
+          "httpStatus": 422,
+          "defaultMessage": "投稿の更新に失敗しました。",
+          "responseId": "422-update-failed",
+          "description": "TX ロールバックが発生した場合の catch-all エラー。posts / photos / post_tags のいずれかの更新が失敗した場合に TX 全体がロールバックされ 422 を返す。"
         }
       }
     },
@@ -194,6 +200,12 @@
           "status": 404,
           "description": "投稿が存在しない。",
           "when": "指定 postId の投稿が見つからない場合。"
+        },
+        {
+          "id": "422-update-failed",
+          "status": 422,
+          "description": "投稿更新 TX 失敗。TX はロールバック済み。",
+          "when": "posts / photos / post_tags のいずれかの更新が失敗し TX がロールバックされた場合。"
         }
       ],
       "steps": [
@@ -408,6 +420,14 @@
           "description": "200 更新成功を返す。TX コミット後にのみ実行する。",
           "responseId": "200-ok",
           "bodyExpression": "{ postId: @inputs.postId, updatedAt: new Date().toISOString() }"
+        },
+        {
+          "id": "step-12",
+          "kind": "return",
+          "runIf": "@txResult.committed != true",
+          "description": "422 投稿更新失敗を返す。TX ロールバック時にのみ実行する (ADR-007 整合)。posts / photos / post_tags のいずれかの更新が失敗した場合の catch-all レスポンス。",
+          "responseId": "422-update-failed",
+          "bodyExpression": "{ code: 'POST_UPDATE_FAILED', message: '投稿の更新に失敗しました。しばらく経ってから再度お試しください。' }"
         }
       ]
     }

--- a/examples/english-learning-tailwind/harmony/process-flows/6a49b14b-eb90-45bd-9df0-df4b5986626b.json
+++ b/examples/english-learning-tailwind/harmony/process-flows/6a49b14b-eb90-45bd-9df0-df4b5986626b.json
@@ -323,7 +323,6 @@
               "operation": "INSERT",
               "sql": "INSERT INTO pronunciation_scores (session_id, dialogue_line_id, audio_url, score, diff, created_at) VALUES (@sessionId, @dialogueLineId, @audioUrl, @pronunciationScore, @evalResult.diff, CURRENT_TIMESTAMP) RETURNING id",
               "outputBinding": { "name": "newScore" },
-              "txBoundary": { "role": "begin", "txId": "tx-score" },
               "lineage": {
                 "writes": [
                   { "tableId": "fefa79cf-4721-4956-86bb-595427bf6f81", "purpose": "insert" }
@@ -337,7 +336,6 @@
               "tableId": "d524cba6-0878-4cf5-ba70-deaa7b459103",
               "operation": "UPDATE",
               "sql": "UPDATE learning_sessions SET score_avg = (SELECT AVG(score) FROM pronunciation_scores WHERE session_id = @sessionId), updated_at = CURRENT_TIMESTAMP WHERE id = @sessionId",
-              "txBoundary": { "role": "end", "txId": "tx-score" },
               "lineage": {
                 "reads": [
                   { "tableId": "fefa79cf-4721-4956-86bb-595427bf6f81", "purpose": "lookup" }
@@ -352,14 +350,16 @@
         {
           "id": "step-07",
           "kind": "eventPublish",
-          "description": "発音採点完了イベントを発行し、UI の採点結果表示と CEFR 昇格判定をトリガーする。",
+          "runIf": "@txResult.committed == true",
+          "description": "発音採点完了イベントを発行し、UI の採点結果表示と CEFR 昇格判定をトリガーする。TX コミット後にのみ実行する (TX rollback 時の誤発火防止)。",
           "topic": "el.pronunciation.scored",
           "payload": "{ sessionId: @sessionId, scoreId: @newScore.id, score: @pronunciationScore }"
         },
         {
           "id": "step-08",
           "kind": "return",
-          "description": "201 Created — scoreId + score + diff を返す。score が合格ライン (conventions.extensionCategories.cefr.passingThreshold 参照) を下回る場合、UI 側でメッセージを表示する。",
+          "runIf": "@txResult.committed == true",
+          "description": "201 Created — scoreId + score + diff を返す。TX コミット後にのみ実行する。score が合格ライン (conventions.extensionCategories.cefr.passingThreshold 参照) を下回る場合、UI 側でメッセージを表示する。",
           "responseId": "201-created",
           "bodyExpression": "{ scoreId: @newScore.id, score: @pronunciationScore, diff: @evalResult.diff }"
         }

--- a/examples/english-learning-tailwind/harmony/process-flows/6a49b14b-eb90-45bd-9df0-df4b5986626b.json
+++ b/examples/english-learning-tailwind/harmony/process-flows/6a49b14b-eb90-45bd-9df0-df4b5986626b.json
@@ -362,6 +362,14 @@
           "description": "201 Created — scoreId + score + diff を返す。TX コミット後にのみ実行する。score が合格ライン (conventions.extensionCategories.cefr.passingThreshold 参照) を下回る場合、UI 側でメッセージを表示する。",
           "responseId": "201-created",
           "bodyExpression": "{ scoreId: @newScore.id, score: @pronunciationScore, diff: @evalResult.diff }"
+        },
+        {
+          "id": "step-09",
+          "kind": "return",
+          "runIf": "@txResult.committed != true",
+          "description": "422 スコア保存失敗を返す。TX ロールバック時にのみ実行する (ADR-007 整合)。pronunciation_scores INSERT または learning_sessions score_avg UPDATE が失敗した場合の catch-all レスポンス。",
+          "responseId": "422-score-failed",
+          "bodyExpression": "{ error: 'SCORE_INSERT_FAILED', message: '発音スコアの保存に失敗しました。しばらく経ってから再試行してください。' }"
         }
       ]
     }

--- a/examples/english-learning/harmony/process-flows/6a49b14b-eb90-45bd-9df0-df4b5986626b.json
+++ b/examples/english-learning/harmony/process-flows/6a49b14b-eb90-45bd-9df0-df4b5986626b.json
@@ -323,7 +323,6 @@
               "operation": "INSERT",
               "sql": "INSERT INTO pronunciation_scores (session_id, dialogue_line_id, audio_url, score, diff, created_at) VALUES (@sessionId, @dialogueLineId, @audioUrl, @pronunciationScore, @evalResult.diff, CURRENT_TIMESTAMP) RETURNING id",
               "outputBinding": { "name": "newScore" },
-              "txBoundary": { "role": "begin", "txId": "tx-score" },
               "lineage": {
                 "writes": [
                   { "tableId": "fefa79cf-4721-4956-86bb-595427bf6f81", "purpose": "insert" }
@@ -337,7 +336,6 @@
               "tableId": "d524cba6-0878-4cf5-ba70-deaa7b459103",
               "operation": "UPDATE",
               "sql": "UPDATE learning_sessions SET score_avg = (SELECT AVG(score) FROM pronunciation_scores WHERE session_id = @sessionId), updated_at = CURRENT_TIMESTAMP WHERE id = @sessionId",
-              "txBoundary": { "role": "end", "txId": "tx-score" },
               "lineage": {
                 "reads": [
                   { "tableId": "fefa79cf-4721-4956-86bb-595427bf6f81", "purpose": "lookup" }
@@ -352,14 +350,16 @@
         {
           "id": "step-07",
           "kind": "eventPublish",
-          "description": "発音採点完了イベントを発行し、UI の採点結果表示と CEFR 昇格判定をトリガーする。",
+          "runIf": "@txResult.committed == true",
+          "description": "発音採点完了イベントを発行し、UI の採点結果表示と CEFR 昇格判定をトリガーする。TX コミット後にのみ実行する (TX rollback 時の誤発火防止)。",
           "topic": "el.pronunciation.scored",
           "payload": "{ sessionId: @sessionId, scoreId: @newScore.id, score: @pronunciationScore }"
         },
         {
           "id": "step-08",
           "kind": "return",
-          "description": "201 Created — scoreId + score + diff を返す。score が合格ライン (conventions.extensionCategories.cefr.passingThreshold 参照) を下回る場合、UI 側でメッセージを表示する。",
+          "runIf": "@txResult.committed == true",
+          "description": "201 Created — scoreId + score + diff を返す。TX コミット後にのみ実行する。score が合格ライン (conventions.extensionCategories.cefr.passingThreshold 参照) を下回る場合、UI 側でメッセージを表示する。",
           "responseId": "201-created",
           "bodyExpression": "{ scoreId: @newScore.id, score: @pronunciationScore, diff: @evalResult.diff }"
         }

--- a/examples/english-learning/harmony/process-flows/6a49b14b-eb90-45bd-9df0-df4b5986626b.json
+++ b/examples/english-learning/harmony/process-flows/6a49b14b-eb90-45bd-9df0-df4b5986626b.json
@@ -362,6 +362,14 @@
           "description": "201 Created — scoreId + score + diff を返す。TX コミット後にのみ実行する。score が合格ライン (conventions.extensionCategories.cefr.passingThreshold 参照) を下回る場合、UI 側でメッセージを表示する。",
           "responseId": "201-created",
           "bodyExpression": "{ scoreId: @newScore.id, score: @pronunciationScore, diff: @evalResult.diff }"
+        },
+        {
+          "id": "step-09",
+          "kind": "return",
+          "runIf": "@txResult.committed != true",
+          "description": "422 スコア保存失敗を返す。TX ロールバック時にのみ実行する (ADR-007 整合)。pronunciation_scores INSERT または learning_sessions score_avg UPDATE が失敗した場合の catch-all レスポンス。",
+          "responseId": "422-score-failed",
+          "bodyExpression": "{ error: 'SCORE_INSERT_FAILED', message: '発音スコアの保存に失敗しました。しばらく経ってから再試行してください。' }"
         }
       ]
     }


### PR DESCRIPTION
## 関連

Closes #1226
Refs #1221

- 仕様: docs/spec/process-flow-*.md (TX semantics §8.3 / transactionScope / ADR-007)

## 概要

examples の draft maturity ProcessFlow に検出された TX 境界バグ 3 件を修正する。
`txBoundary begin/end` が `runIf` で skip されると TX が未クローズになる問題 (M-001)、
TX rollback 時に event 発火と 201 return が実行される問題 (M-002)、
`transactionScope` と `txBoundary` が二重宣言されている問題 (M-003) を統合修正する。

## 主な変更

- M-001: diary 投稿更新フロー (b3a1c2d4) — `txBoundary` パターンを廃止し、`kind: transactionScope` wrapper に step-06〜10 を格納。wrapper が TX 境界を管理するため `runIf` によるスキップの影響を受けない。`step-11` (return 200) に `runIf: "@txResult.committed == true"` を追加
- M-002: english-learning 発音採点フロー (6a49b14b × 2) — `step-07` (eventPublish) / `step-08` (return 201) に `runIf: "@txResult.committed == true"` を追加。TX rollback 時の誤発火を防止
- M-003: 同フロー — `step-06a` / `step-06b` から `txBoundary` フィールドを削除。`transactionScope` wrapper のみで TX 制御に統一

## 仕様逐条突合 (自己申告)

- §TX 境界制御: `transactionScope` wrapper による TX begin/end — b3a1c2d4 step-06 ✓
- §runIf ガード: TX commit 後にのみ event/return を実行 — 6a49b14b step-07/08 ✓
- §二重宣言禁止: `transactionScope` 内に `txBoundary` を併置しない — 6a49b14b step-06a/06b ✓
- §ADR-007 パターン: `outputBinding.name: "txResult"` + `@txResult.committed == true` — 全3 ファイル ✓
- §schema governance: schemas/ を一切変更しない — `git diff HEAD -- schemas/` 変更なし ✓

## レビューで特に見てほしい箇所

- M-001 の `transactionScope` wrapper 内 inner step の `outputBinding` 変数 (`@updatedPost` 等) が wrapper 外の `step-11` から参照できるか (retail/f81dd9e0 パターンと同様)。今回 diary フローは wrapper 外で inner step の outputBinding を参照していないため問題なし
- `step-06.rollbackOn: []` (空配列) が schema 的に有効か — retail パターンで `rollbackOn` に列挙されるのは TX inner から throw される具体エラーのみ。今回の diary フローはエラーコード未定義 (draft) のため空で OK

## テスト

- Vitest: 0 件 (新規 0 件) — examples JSON のみの変更、TypeScript コード変更なし
- Playwright: N/A
- MCP E2E: N/A
- `npm run validate:samples -- ../examples/diary ../examples/english-learning ../examples/english-learning-tailwind` — 全件 PASS (diary 15/15, english-learning 5/5)
- `npm run validate:samples -- ../examples/retail ../examples/realestate` — 全件 PASS (regression なし)

## UI 影響 / AI smoke test

- [x] UI 影響なし (auto テスト pass のみ)

## spec 側の不足点 / 提案

N/A — 今回の修正はフレームワーク仕様 (ADR-007 / transactionScope パターン) に既に明文化されている。

## レビュー担当への申し送り

- 3 ファイルはすべて `maturity: "draft"` のまま変更 (committed 昇格は別判断)
- M-001 の diary フローは「TX inner step の outputBinding が wrapper 外から参照可能か」が唯一の潜在懸念。現状 inner step の出力変数を wrapper 外で使用していないので影響なし
- M-002/M-003 は english-learning と english-learning-tailwind が 1:1 同一ファイルになった (diff で確認済み)
- `schemas/` 変更なし (schema governance 遵守)