### PR TITLE
fix(security): solution_pack / unpack の outputPath・inputPath に assertPathContained 適用 (#1229)

### DIFF
--- a/backend/src/handlers/processFlow.test.ts
+++ b/backend/src/handlers/processFlow.test.ts
@@ -354,3 +354,133 @@ describe("designer__list_process_flows — #1141 F-4 v3 meta path", () => {
     expect(text).not.toMatch(/\(undefined\)/);
   });
 });
+
+// ── 5. designer__solution_pack / solution_unpack の path traversal 拒否 (#1229 F-1) ──
+
+import fsSync from "node:fs";
+import AdmZip from "adm-zip";
+
+describe("designer__solution_pack — #1229 F-1 path traversal 拒否", () => {
+  const root = path.join(TMP_ROOT, "ws-pack-path");
+  beforeAll(async () => { await makeWorkspace(root); });
+
+  it("outputPath が workspace 外 (../ traversal) の場合は Error を throw する", async () => {
+    await expect(
+      handleProcessFlowTool(
+        "designer__solution_pack",
+        {
+          processFlowIds: ["aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"],
+          publisherPrefix: "test",
+          version: "1.0.0",
+          outputPath: "../../evil.zip",
+        },
+        root,
+        SESSION_ID,
+      ),
+    ).rejects.toThrow(/Path traversal detected/);
+  });
+
+  it("outputPath が絶対パスで workspace 外の場合は Error を throw する", async () => {
+    await expect(
+      handleProcessFlowTool(
+        "designer__solution_pack",
+        {
+          processFlowIds: ["aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"],
+          publisherPrefix: "test",
+          version: "1.0.0",
+          outputPath: "/tmp/evil.zip",
+        },
+        root,
+        SESSION_ID,
+      ),
+    ).rejects.toThrow(/Path traversal detected/);
+  });
+
+  it("outputPath が workspace 内の相対パスなら正常に実行される", async () => {
+    // 処理フローを事前に作成
+    const addRes = await handleProcessFlowTool(
+      "designer__add_process_flow",
+      { name: "pack-test-flow", kind: "common" },
+      root,
+      SESSION_ID,
+    );
+    const addText = addRes!.content[0].text as string;
+    const idMatch = addText.match(/ID: ([0-9a-f-]+)/);
+    const pfId = idMatch![1];
+
+    const res = await handleProcessFlowTool(
+      "designer__solution_pack",
+      {
+        processFlowIds: [pfId],
+        publisherPrefix: "test",
+        version: "1.0.0",
+        outputPath: "output/test.zip",
+      },
+      root,
+      SESSION_ID,
+    );
+    expect(res).not.toBeNull();
+    const text = res!.content[0].text as string;
+    expect(text).toMatch(/1 件をパックしました/);
+    // zip ファイルが workspace 内 (dataDir 配下) に作成されたことを確認
+    // _dataRoot = root/harmony なので outputPath 相対はそこに展開される
+    expect(fsSync.existsSync(path.join(root, "harmony", "output", "test.zip"))).toBe(true);
+  });
+});
+
+describe("designer__solution_unpack — #1229 F-1 path traversal 拒否", () => {
+  const root = path.join(TMP_ROOT, "ws-unpack-path");
+  beforeAll(async () => { await makeWorkspace(root); });
+
+  it("inputPath が workspace 外 (../ traversal) の場合は Error を throw する", async () => {
+    await expect(
+      handleProcessFlowTool(
+        "designer__solution_unpack",
+        { inputPath: "../../outside.zip" },
+        root,
+        SESSION_ID,
+      ),
+    ).rejects.toThrow(/Path traversal detected/);
+  });
+
+  it("inputPath が絶対パスで workspace 外の場合は Error を throw する", async () => {
+    await expect(
+      handleProcessFlowTool(
+        "designer__solution_unpack",
+        { inputPath: "/tmp/outside.zip" },
+        root,
+        SESSION_ID,
+      ),
+    ).rejects.toThrow(/Path traversal detected/);
+  });
+
+  it("inputPath が workspace 内の正常パスなら展開される", async () => {
+    // _dataRoot = root/harmony なので inputPath 相対はそこから解決される
+    const zipDir = path.join(root, "harmony", "input");
+    await fs.mkdir(zipDir, { recursive: true });
+    const zipPath = path.join(zipDir, "pack.zip");
+
+    const flowDoc = {
+      id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+      meta: { id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb", name: "unpack-test", kind: "common" },
+      context: {},
+      actions: [],
+      authoring: { markers: [] },
+    };
+    const zip = new AdmZip();
+    zip.addFile("manifest.json", Buffer.from(JSON.stringify({ publisher: "test", version: "1.0.0", processFlowIds: [flowDoc.id], createdAt: new Date().toISOString() }), "utf8"));
+    zip.addFile(`process-flows/${flowDoc.id}.json`, Buffer.from(JSON.stringify(flowDoc), "utf8"));
+    zip.writeZip(zipPath);
+
+    const res = await handleProcessFlowTool(
+      "designer__solution_unpack",
+      { inputPath: "input/pack.zip" },
+      root,
+      SESSION_ID,
+    );
+    expect(res).not.toBeNull();
+    const text = res!.content[0].text as string;
+    expect(text).toMatch(/展開完了/);
+    expect(text).toMatch(/OK: bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb/);
+  });
+});

--- a/backend/src/handlers/processFlow.test.ts
+++ b/backend/src/handlers/processFlow.test.ts
@@ -484,3 +484,78 @@ describe("designer__solution_unpack — #1229 F-1 path traversal 拒否", () => 
     expect(text).toMatch(/OK: bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb/);
   });
 });
+
+// ── 6. designer__solution_unpack — ZIP 由来 id の assertUuid 検証 (#1229 review-iter-1 I-001) ──
+
+describe("designer__solution_unpack — #1229 I-001 ZIP 由来 id の UUID 検証", () => {
+  const root = path.join(TMP_ROOT, "ws-unpack-id");
+  beforeAll(async () => { await makeWorkspace(root); });
+
+  async function makeZipWithId(id: string, entryName?: string): Promise<string> {
+    const zipDir = path.join(root, "harmony", "input-id");
+    await fs.mkdir(zipDir, { recursive: true });
+    const zipPath = path.join(zipDir, `${Date.now()}.zip`);
+    const flowDoc = { id, meta: { id, name: "t", kind: "common" }, context: {}, actions: [], authoring: { markers: [] } };
+    const zip = new AdmZip();
+    zip.addFile("manifest.json", Buffer.from(JSON.stringify({ publisher: "test", version: "1.0.0", processFlowIds: [id], createdAt: new Date().toISOString() }), "utf8"));
+    // entryName は必ず process-flows/ 配下に設定 (フィルタ通過のため)
+    const name = entryName ?? `process-flows/${id}.json`;
+    zip.addFile(name, Buffer.from(JSON.stringify(flowDoc), "utf8"));
+    zip.writeZip(zipPath);
+    return zipPath;
+  }
+
+  it("ZIP 内 JSON の id が UUID 形式でない場合は SKIP (invalid id) となる", async () => {
+    // entryName は process-flows/ で始める必要がある (フィルタ対象)
+    // JSON body の id に不正値を埋め込む
+    const zipPath = await makeZipWithId("../evil", "process-flows/evil.json");
+    const relPath = path.relative(path.join(root, "harmony"), zipPath);
+    const res = await handleProcessFlowTool(
+      "designer__solution_unpack",
+      { inputPath: relPath },
+      root,
+      SESSION_ID,
+    );
+    expect(res).not.toBeNull();
+    const text = res!.content[0].text as string;
+    expect(text).toMatch(/SKIP \(invalid id\)/);
+    expect(text).not.toMatch(/OK:/);
+  });
+
+  it("ZIP 内 JSON の id が空文字の場合は SKIP (no id) となる", async () => {
+    const zipDir = path.join(root, "harmony", "input-id");
+    await fs.mkdir(zipDir, { recursive: true });
+    const zipPath = path.join(zipDir, `empty-id-${Date.now()}.zip`);
+    const flowDoc = { id: "", meta: { id: "", name: "t", kind: "common" }, context: {}, actions: [], authoring: { markers: [] } };
+    const zip = new AdmZip();
+    zip.addFile("manifest.json", Buffer.from(JSON.stringify({ publisher: "test", version: "1.0.0", processFlowIds: [], createdAt: new Date().toISOString() }), "utf8"));
+    zip.addFile("process-flows/empty.json", Buffer.from(JSON.stringify(flowDoc), "utf8"));
+    zip.writeZip(zipPath);
+    const relPath = path.relative(path.join(root, "harmony"), zipPath);
+    const res = await handleProcessFlowTool(
+      "designer__solution_unpack",
+      { inputPath: relPath },
+      root,
+      SESSION_ID,
+    );
+    expect(res).not.toBeNull();
+    const text = res!.content[0].text as string;
+    expect(text).toMatch(/SKIP \(no id\)/);
+    expect(text).not.toMatch(/OK:/);
+  });
+
+  it("ZIP 内 JSON の id が正規 UUID の場合は OK となる", async () => {
+    const validId = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+    const zipPath = await makeZipWithId(validId);
+    const relPath = path.relative(path.join(root, "harmony"), zipPath);
+    const res = await handleProcessFlowTool(
+      "designer__solution_unpack",
+      { inputPath: relPath },
+      root,
+      SESSION_ID,
+    );
+    expect(res).not.toBeNull();
+    const text = res!.content[0].text as string;
+    expect(text).toMatch(/OK: cccccccc-cccc-4ccc-8ccc-cccccccccccc/);
+  });
+});

--- a/backend/src/handlers/processFlow.ts
+++ b/backend/src/handlers/processFlow.ts
@@ -41,7 +41,7 @@ import {
 } from "../processFlowEdits.js";
 import { saveAndBroadcast, type ToolHandler } from "../mcpHelpers.js";
 import { wsBridge } from "../wsBridge.js";
-import { assertUuid, assertSafeName } from "../security/idValidator.js";
+import { assertUuid, assertSafeName, assertPathContained } from "../security/idValidator.js";
 
 type ResponseTypeEntry = {
   description?: string;
@@ -652,9 +652,11 @@ export const handleProcessFlowTool: ToolHandler = async (name, args, root) => {
       }
 
       const _dataRoot = await resolveDataRoot(root);
-      const outPath = path.isAbsolute(a.outputPath as string)
+      const outPathRaw = path.isAbsolute(a.outputPath as string)
         ? (a.outputPath as string)
         : path.join(_dataRoot, a.outputPath as string);
+      // path traversal 対策: outputPath は workspace root 配下に限定 (#1229)
+      const outPath = assertPathContained(outPathRaw, root);
 
       const zip = new AdmZip();
       const manifest = {
@@ -685,9 +687,11 @@ export const handleProcessFlowTool: ToolHandler = async (name, args, root) => {
         throw new McpError(ErrorCode.InvalidParams, "inputPath は必須です");
       }
       const _unpackDataRoot = await resolveDataRoot(root);
-      const inPath = path.isAbsolute(a.inputPath as string)
+      const inPathRaw = path.isAbsolute(a.inputPath as string)
         ? (a.inputPath as string)
         : path.join(_unpackDataRoot, a.inputPath as string);
+      // path traversal 対策: inputPath は workspace root 配下に限定 (#1229)
+      const inPath = assertPathContained(inPathRaw, root);
       const conflict = (a.conflictResolution as string | undefined) ?? "skip";
 
       const zip = new AdmZip(inPath);

--- a/backend/src/handlers/processFlow.ts
+++ b/backend/src/handlers/processFlow.ts
@@ -708,6 +708,9 @@ export const handleProcessFlowTool: ToolHandler = async (name, args, root) => {
         const id = doc.id as string | undefined;
         if (!id) { results.push(`SKIP (no id): ${entry.entryName}`); continue; }
 
+        // ZIP 由来の id を UUID 形式で検証 (defense-in-depth, #1229 review-iter-1 I-001)
+        try { assertUuid(id, "id"); } catch { results.push(`SKIP (invalid id): ${entry.entryName}`); continue; }
+
         const destPath = path.join(actionsDir, `${id}.json`);
         const exists = fs.existsSync(destPath);
 


### PR DESCRIPTION
## 概要

ISSUE #1229 (pre-existing) の F-1 を解消。`designer__solution_pack` / `designer__solution_unpack` MCP ツールの `outputPath` / `inputPath` 引数に path containment validation を追加。

Closes #1229
Refs #1224

## 変更内容

- `backend/src/handlers/processFlow.ts`
  - `assertPathContained` を `idValidator.ts` からインポート追加
  - `designer__solution_pack`: `outPathRaw` 計算後に `assertPathContained(outPathRaw, root)` を適用 — workspace root 外への zip 書き込みを拒否
  - `designer__solution_unpack`: `inPathRaw` 計算後に `assertPathContained(inPathRaw, root)` を適用 — workspace root 外からの zip 読み込みを拒否
- `backend/src/handlers/processFlow.test.ts`
  - path traversal 拒否テスト 4 件 (pack: `../` traversal / 絶対パス外、unpack: `../` traversal / 絶対パス外)
  - 正常パス通過テスト 2 件 (pack / unpack)

## テスト結果

```
Tests  600 passed (600)
```

build + test PASS (新規 6 件含む全 600 件)

## 仕様逐条突合

| 条項 | file:line | 結果 |
|---|---|---|
| F-1: outputPath / inputPath に assertPathContained 適用 | `processFlow.ts:659`, `processFlow.ts:694` | ✅ |
| 既存 helper 再利用 | `idValidator.ts` の `assertPathContained` をそのまま利用 | ✅ |
| schemas/ 変更なし | `git diff HEAD -- schemas/` で確認 | ✅ |
| AGENTS.md / CLAUDE.md / docs/spec/ 変更なし | 本 PR では変更なし | ✅ |
| テスト追加 | 6 件 (traversal 拒否 4 + 正常通過 2) | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)