### PR TITLE
refactor(types): @ts-nocheck 除去 (actionMigration + processFlowStore) (#1233)

### DIFF
--- a/frontend/src/store/processFlowStore.ts
+++ b/frontend/src/store/processFlowStore.ts
@@ -1,5 +1,4 @@
-﻿// @ts-nocheck -- legacy process-flow store migration remains open; tracked by #1016.
-// #1186 Phase 2-C: types/action → types/v3 移行 (ProcessFlowType/StepType は v3 で ProcessFlowKind/StepKind に rename)
+﻿// #1186 Phase 2-C: types/action → types/v3 移行 (ProcessFlowType/StepType は v3 で ProcessFlowKind/StepKind に rename)
 import type {
   ActionDefinition,
   ActionTrigger,
@@ -221,6 +220,9 @@ export function createDefaultStep(kind: StepType): Step {
       step = { ...base, kind: "cdc", tableIds: [], captureMode: "incremental", destination: { kind: "auditLog", auditAction: "" } }; break;
     case "extension":
       step = { ...base, kind: "legacy:OtherStep", config: {} } as Step; break;
+    default:
+      // extension steps with namespace:StepName kind (ExtensionStep)
+      step = { ...base, config: {} } as Step; break;
   }
   return step;
 }
@@ -231,14 +233,16 @@ function countGroupNotes(group: ProcessFlow): number {
     for (const s of steps) {
       count += s.notes?.length ?? 0;
       if (s.kind === "branch") {
-        for (const b of s.branches) visit(b.steps);
-        if (s.elseBranch) visit(s.elseBranch.steps);
+        const branch = s as Step & { branches: { steps: Step[] }[]; elseBranch?: { steps: Step[] } };
+        for (const b of branch.branches) visit(b.steps);
+        if (branch.elseBranch) visit(branch.elseBranch.steps);
       }
-      if (s.kind === "loop") visit(s.steps);
+      if (s.kind === "loop") visit((s as Step & { steps: Step[] }).steps);
       if (s.kind === "transactionScope") {
-        visit(s.steps);
-        if (s.onCommit) visit(s.onCommit);
-        if (s.onRollback) visit(s.onRollback);
+        const tx = s as Step & { steps: Step[]; onCommit?: Step[]; onRollback?: Step[] };
+        visit(tx.steps);
+        if (tx.onCommit) visit(tx.onCommit);
+        if (tx.onRollback) visit(tx.onRollback);
       }
     }
   };

--- a/frontend/src/utils/actionMigration.ts
+++ b/frontend/src/utils/actionMigration.ts
@@ -5,7 +5,7 @@
   ProcessFlow,
   Step,
 } from "../types/v3";
-import type { Maturity, Mode } from "../types/v3/common";
+import type { LocalId, Maturity, Mode } from "../types/v3/common";
 import { generateUUID } from "./uuid";
 
 export const PROCESS_FLOW_V3_SCHEMA_REF = "../schemas/v3/process-flow.v3.schema.json";
@@ -110,7 +110,7 @@ function legacyToBranch(code: string, condition: unknown, raw: LegacyBranchField
   }
   const label = raw?.label?.trim();
   return {
-    id: generateUUID() as never,
+    id: generateUUID() as LocalId,
     code,
     label: label || undefined,
     condition: normalizeBranchCondition(condition),

--- a/frontend/src/utils/actionMigration.ts
+++ b/frontend/src/utils/actionMigration.ts
@@ -1,5 +1,4 @@
-﻿// @ts-nocheck -- legacy action migration spans old/new process-flow shapes; tracked by #1016.
-import type {
+﻿import type {
   ActionDefinition,
   Branch,
   BranchCondition,
@@ -111,7 +110,7 @@ function legacyToBranch(code: string, condition: unknown, raw: LegacyBranchField
   }
   const label = raw?.label?.trim();
   return {
-    id: generateUUID(),
+    id: generateUUID() as never,
     code,
     label: label || undefined,
     condition: normalizeBranchCondition(condition),


### PR DESCRIPTION
## Summary

ISSUE #1233 「@ts-nocheck 段階剥がし」の Batch 1 (タイプ A 2 file)。PR #1207-#1220 の継続。

- **utils/actionMigration.ts**: 先頭 `@ts-nocheck` 削除。`legacyToBranch` の `Branch.id` に `as never` cast を追加 (LocalId branded type 対応、processFlowStore と同形パターン)
- **store/processFlowStore.ts**: 先頭 `@ts-nocheck` 削除 (2 行目の #1186 Phase 2-C コメントは保持)。`createDefaultStep` に `default` case 追加 (ExtensionStep の `kind: string` variant でスイッチ網羅性が取れないため)。`countGroupNotes` の branch/loop/transactionScope kind narrowing 後に局所 intersection cast を追加 (ExtensionStep が union に残るため)

## Test plan

- [x] `npm run build` → 0 errors
- [x] `npm run test:unit` → 2366 pass (173 test files)
- [x] `grep -c '^// @ts-nocheck' src/utils/actionMigration.ts src/store/processFlowStore.ts` → 両方 0
- [x] schema 変更なし (`git diff origin/main..HEAD -- schemas/` → 空)

## 残作業

ISSUE #1233 は **本 PR では close しない** (残 24 file あり)。後続バッチで継続。

Refs #1233