### PR TITLE
refactor(types): @ts-nocheck 除去 (step recursion 4 file + 共通型ガード) (#1233)

### DIFF
--- a/frontend/src/components/process-flow/ActionMetaTabBar.tsx
+++ b/frontend/src/components/process-flow/ActionMetaTabBar.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck -- v3 strict 型移行 (#1186 Phase 2-D) で loose access パターン (step.subSteps / .branches / .elseBranch / .steps / .onCommit / .onRollback、Process Flow.sla) が露呈、proper narrow は #1016 で deferred
 /**
  * 処理フローエディタの上部タブバー (#309)
  *
@@ -14,8 +13,14 @@ import { useState } from "react";
 import { Link } from "react-router-dom";
 import { useWorkspacePath } from "../../hooks/useWorkspacePath";
 // #1186 Phase 2-D: types/action → types/v3 + processFlowMetadata 移行
-import type { ProcessFlow, ProcessFlowType, Step } from "../../types/v3";
+import type { ProcessFlow, ProcessFlowMeta, ProcessFlowType, Step } from "../../types/v3";
 import { PROCESS_FLOW_TYPE_LABELS } from "../../utils/processFlowMetadata";
+import {
+  isBranchStep,
+  isLoopStep,
+  isTransactionScopeStep,
+  type StepWithSubSteps,
+} from "../../utils/actionUtils";
 import { MaturityBadge } from "./MaturityBadge";
 import { MarkerPanel } from "./MarkerPanel";
 import { ErrorCatalogPanel } from "./ErrorCatalogPanel";
@@ -44,13 +49,14 @@ function countMaturity(group: ProcessFlow): {
       else acc.committed++;
       acc.total++;
       acc.notes += s.notes?.length ?? 0;
-      if (s.subSteps) visit(s.subSteps);
-      if (s.kind === "branch") {
+      const sw = s as StepWithSubSteps;
+      if (sw.subSteps) visit(sw.subSteps);
+      if (isBranchStep(s)) {
         for (const b of s.branches) visit(b.steps);
         if (s.elseBranch) visit(s.elseBranch.steps);
       }
-      if (s.kind === "loop") visit(s.steps);
-      if (s.kind === "transactionScope") {
+      if (isLoopStep(s)) visit(s.steps);
+      if (isTransactionScopeStep(s)) {
         visit(s.steps);
         if (s.onCommit) visit(s.onCommit);
         if (s.onRollback) visit(s.onRollback);
@@ -77,7 +83,7 @@ export function ActionMetaTabBar({ group, updateGroup, updateGroupSilent }: Prop
       g.meta = { ...(g.meta ?? {}), [field]: value };
     });
   };
-  const handleSlaChange = (sla: ProcessFlow["sla"]) => {
+  const handleSlaChange = (sla: ProcessFlowMeta["sla"]) => {
     updateGroupSilent((g) => {
       g.meta = { ...(g.meta ?? {}), sla };
     });

--- a/frontend/src/components/process-flow/internal/InlineStepList.tsx
+++ b/frontend/src/components/process-flow/internal/InlineStepList.tsx
@@ -1,6 +1,6 @@
-// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
 import { useState } from "react";
 import type { ProcessFlow, Step, StepType } from "../../../types/v3";
+import type { StepWithSubSteps } from "../../../utils/actionUtils";
 // #1186 Phase 2-D: constants は processFlowMetadata から
 import {
   STEP_TYPE_COLORS,
@@ -100,7 +100,7 @@ export function InlineStepList({
             }}
             onDuplicate={() => {
               const clone = JSON.parse(JSON.stringify(step)) as Step;
-              clone.id = generateUUID();
+              clone.id = generateUUID() as typeof clone.id;
               const arr = steps.slice();
               arr.splice(si + 1, 0, clone);
               onChange(arr);
@@ -109,7 +109,8 @@ export function InlineStepList({
             onAddSubStep={(type) => {
               const newSub = createDefaultStep(type);
               const arr = steps.slice();
-              arr[si] = { ...arr[si], subSteps: [...(arr[si].subSteps ?? []), newSub] } as Step;
+              const cur = arr[si] as StepWithSubSteps;
+              arr[si] = { ...cur, subSteps: [...(cur.subSteps ?? []), newSub] } as unknown as Step;
               onChange(arr);
               onCommit?.();
             }}

--- a/frontend/src/components/process-flow/internal/stepSummaryText.ts
+++ b/frontend/src/components/process-flow/internal/stepSummaryText.ts
@@ -1,8 +1,7 @@
-// @ts-nocheck -- StepCard と同じ理由で legacy/v3 union を緩く扱う (#1016)
 import type { Step } from "../../../types/v3";
 // #1186 Phase 2-D: constants は processFlowMetadata から
 import { DB_OPERATION_LABELS, WORKFLOW_PATTERN_LABELS } from "../../../utils/processFlowMetadata";
-import { resolveJumpLabel } from "../../../utils/actionUtils";
+import { resolveJumpLabel, isExtensionStep } from "../../../utils/actionUtils";
 import { getBranchConditionText } from "../../../utils/branchCondition";
 
 /**
@@ -10,13 +9,15 @@ import { getBranchConditionText } from "../../../utils/branchCondition";
  * 元: components/process-flow/StepCard.tsx の summaryText() (#1145 で分離)
  */
 export function stepSummaryText(step: Step, allSteps: Step[]): string {
+  if (isExtensionStep(step)) return step.description || "拡張ステップ";
   switch (step.kind) {
     case "validation":
       return step.conditions || step.description || "バリデーション";
     case "dbAccess":
       return `${step.tableId || "?"} ${DB_OPERATION_LABELS[step.operation] ?? step.operation}${step.description ? ` - ${step.description}` : ""}`;
     case "externalSystem":
-      return `${step.systemRef || "?"}${step.protocol ? ` (${step.protocol})` : ""}${step.description ? ` - ${step.description}` : ""}`;
+      // silent bug: step.protocol は v3 schema に存在しない (#1233)
+      return `${step.systemRef || "?"}${step.httpCall?.method ? ` (${step.httpCall.method})` : ""}${step.description ? ` - ${step.description}` : ""}`;
     case "commonProcess":
       return step.refId || step.description || "共通処理";
     case "screenTransition":

--- a/frontend/src/utils/actionUtils.ts
+++ b/frontend/src/utils/actionUtils.ts
@@ -35,7 +35,11 @@ export function isValidationStep(step: Step): step is ValidationStep {
   return step.kind === "validation";
 }
 
-/** ExtensionStep は kind が "namespace:StepName" pattern。組み込み 24 種を除外したい型ガード。 */
+/**
+ * ExtensionStep は kind が "namespace:StepName" pattern (例: "retail:OrderConfirmStep")。
+ * 組み込み 24 種の kind には ":" を含むものは存在しないため、判定として安全。
+ * 将来 built-in kind に ":" を含むものが追加された場合、本判定を見直すこと。
+ */
 export function isExtensionStep(s: Step): s is ExtensionStep {
   return typeof s.kind === "string" && s.kind.includes(":");
 }
@@ -43,6 +47,7 @@ export function isExtensionStep(s: Step): s is ExtensionStep {
 /**
  * subSteps は StepBaseProps に未定義だが UI レイヤーで使用されている runtime プロパティ。
  * 型システム上は Step & { subSteps?: Step[] } として扱う。
+ * `actionUtils` / `InlineStepList` / `ActionMetaTabBar` 等で共用。
  */
 export type StepWithSubSteps = Step & { subSteps?: Step[] };
 

--- a/frontend/src/utils/actionUtils.ts
+++ b/frontend/src/utils/actionUtils.ts
@@ -9,36 +9,42 @@ import type {
   TransactionScopeStep,
   JumpStep,
   ValidationStep,
+  ExtensionStep,
   LocalId,
 } from "../types/v3";
 
 // ── Type guards ─────────────────────────────────────────────────────────
 
-function isBranchStep(step: Step): step is BranchStep {
+export function isBranchStep(step: Step): step is BranchStep {
   return step.kind === "branch";
 }
 
-function isLoopStep(step: Step): step is LoopStep {
+export function isLoopStep(step: Step): step is LoopStep {
   return step.kind === "loop";
 }
 
-function isTransactionScopeStep(step: Step): step is TransactionScopeStep {
+export function isTransactionScopeStep(step: Step): step is TransactionScopeStep {
   return step.kind === "transactionScope";
 }
 
-function isJumpStep(step: Step): step is JumpStep {
+export function isJumpStep(step: Step): step is JumpStep {
   return step.kind === "jump";
 }
 
-function isValidationStep(step: Step): step is ValidationStep {
+export function isValidationStep(step: Step): step is ValidationStep {
   return step.kind === "validation";
+}
+
+/** ExtensionStep は kind が "namespace:StepName" pattern。組み込み 24 種を除外したい型ガード。 */
+export function isExtensionStep(s: Step): s is ExtensionStep {
+  return typeof s.kind === "string" && s.kind.includes(":");
 }
 
 /**
  * subSteps は StepBaseProps に未定義だが UI レイヤーで使用されている runtime プロパティ。
  * 型システム上は Step & { subSteps?: Step[] } として扱う。
  */
-type StepWithSubSteps = Step & { subSteps?: Step[] };
+export type StepWithSubSteps = Step & { subSteps?: Step[] };
 
 /**
  * ステップの表示ラベルを生成（1, 2, 3... / 1-1, 1-2...）

--- a/frontend/src/utils/specExporter.test.ts
+++ b/frontend/src/utils/specExporter.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { generateSpecJson, type SpecStep } from "./specExporter";
-import type { Table, TableId, LocalId, PhysicalName, DisplayName, Timestamp, ErLayout } from "../types/v3";
+import type { Table, TableId, LocalId, Identifier, PhysicalName, DisplayName, Timestamp, ErLayout } from "../types/v3";
 import type { FlowProject } from "../types/flow";
 // #1186 Phase 2-B: types/action → types/v3 移行
 // 24 step variants は v3 strict 型、ProcessFlow も v3 strict
@@ -12,6 +12,7 @@ import type {
   DbAccessStep,
   EventPublishStep,
   EventSubscribeStep,
+  ExternalSystemStep,
   LogStep,
   LoopBreakStep,
   LoopContinueStep,
@@ -521,5 +522,44 @@ describe("toSpecStep — step detail", () => {
     } as OtherStep);
     expect(step.type).toBe("legacy:OtherStep");
     expect(step.detail).toEqual({});
+  });
+});
+
+describe("toSpecStep — silent bug 修正 S-1〜S-3 の回帰テスト", () => {
+  it("S-1: ExternalSystemStep の systemRef が出力 spec に反映される (httpCall.method 移行保証)", () => {
+    const step = getStep({
+      id: "s1" as LocalId,
+      kind: "externalSystem",
+      description: "外部 API 呼び出し",
+      systemRef: "stripe" as Identifier,
+      httpCall: { method: "POST", path: "/v1/charges" },
+    } as ExternalSystemStep);
+    expect(step.type).toBe("externalSystem");
+    expect((step.detail as Record<string, unknown>).systemRef).toBe("stripe");
+  });
+
+  it("S-2: ReturnStep の responseId / bodyExpression が出力 spec に反映される", () => {
+    const step = getStep({
+      id: "s2" as LocalId,
+      kind: "return",
+      description: "正常終了",
+      responseId: "200OK" as LocalId,
+      bodyExpression: "@output",
+    } as ReturnStep);
+    expect(step.type).toBe("return");
+    expect((step.detail as Record<string, unknown>).responseId).toBe("200OK");
+    expect((step.detail as Record<string, unknown>).bodyExpression).toBe("@output");
+  });
+
+  it("S-3: EventPublishStep に eventRef が無くても出力が壊れない (topic のみで完結)", () => {
+    const step = getStep({
+      id: "s3" as LocalId,
+      kind: "eventPublish",
+      description: "イベント発行",
+      topic: "order.created",
+    } as EventPublishStep);
+    expect(step.type).toBe("eventPublish");
+    expect((step.detail as Record<string, unknown>).topic).toBe("order.created");
+    expect((step.detail as Record<string, unknown>).eventRef).toBeUndefined();
   });
 });

--- a/frontend/src/utils/specExporter.ts
+++ b/frontend/src/utils/specExporter.ts
@@ -38,7 +38,7 @@ function pfFlat(g: ProcessFlow): Record<string, unknown> {
 }
 
 function pfKind(g: ProcessFlow): string {
-  return (g.meta?.kind ?? pfFlat(g)["kind"] ?? "") as string;
+  return (g.meta?.kind ?? pfFlat(g)["kind"] ?? pfFlat(g)["type"] ?? "") as string;
 }
 
 function pfName(g: ProcessFlow): string {

--- a/frontend/src/utils/specExporter.ts
+++ b/frontend/src/utils/specExporter.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck -- legacy spec exporter migration remains open; tracked by #1016.
 /**
  * specExporter.ts (v3, #556)
  * AI エージェント向け統合 JSON 仕様書の生成。
@@ -24,8 +23,39 @@ import type { ErLayout } from "../types/v3";
 import type { FlowProject } from "../types/flow";
 import type { ProcessFlow, Step } from "../types/v3";
 import { getAllRelations, type ErRelation } from "./erUtils";
-import { getStepLabel } from "./actionUtils";
+import { getStepLabel, isExtensionStep } from "./actionUtils";
 import { fieldsToText } from "./actionFields";
+
+/**
+ * ProcessFlow の flat-field アクセスヘルパー。
+ * v3 schema は meta セクションに階層化されているが、テストデータ・レガシーデータは
+ * root に直置きの flat shape で渡ってくる場合がある。
+ * runtime では実際のフィールドに安全にアクセスできるが TS 型は v3 strict のため
+ * unknown cast 経由でアクセスする (#1233)。
+ */
+function pfFlat(g: ProcessFlow): Record<string, unknown> {
+  return g as unknown as Record<string, unknown>;
+}
+
+function pfKind(g: ProcessFlow): string {
+  return (g.meta?.kind ?? pfFlat(g)["kind"] ?? "") as string;
+}
+
+function pfName(g: ProcessFlow): string {
+  return (g.meta?.name ?? pfFlat(g)["name"] ?? "") as string;
+}
+
+function pfDescription(g: ProcessFlow): string {
+  return (g.meta?.description ?? pfFlat(g)["description"] ?? "") as string;
+}
+
+function pfScreenId(g: ProcessFlow): string | undefined {
+  return (g.meta?.screenId ?? pfFlat(g)["screenId"]) as string | undefined;
+}
+
+function pfId(g: ProcessFlow): string {
+  return (g.meta?.id ?? pfFlat(g)["id"] ?? "") as string;
+}
 
 export interface SpecJson {
   /** プロジェクト名 */
@@ -158,8 +188,8 @@ export function generateSpecJson(
 ): SpecJson {
   const relations = getAllRelations(tables, erLayout);
 
-  const commonGroups = (processFlows ?? []).filter((g) => g.kind === "common");
-  const nonCommonGroups = (processFlows ?? []).filter((g) => g.kind !== "common");
+  const commonGroups = (processFlows ?? []).filter((g) => pfKind(g) === "common");
+  const nonCommonGroups = (processFlows ?? []).filter((g) => pfKind(g) !== "common");
 
   const result: SpecJson = {
     projectName: project.name,
@@ -187,14 +217,15 @@ export function generateSpecJson(
 
   if (processFlows && processFlows.length > 0) {
     result.processFlows = nonCommonGroups.map((g) => {
-      const screenName = g.screenId
-        ? project.screens.find((s) => s.id === g.screenId)?.name
+      const sId = pfScreenId(g);
+      const screenName = sId
+        ? project.screens.find((s) => s.id === sId)?.name
         : undefined;
       return {
-        name: g.name,
-        type: g.type,
+        name: pfName(g),
+        type: pfKind(g),
         screenName,
-        description: g.description,
+        description: pfDescription(g),
         actions: g.actions.map((a) => ({
           name: a.name,
           trigger: a.trigger,
@@ -207,9 +238,9 @@ export function generateSpecJson(
 
     if (commonGroups.length > 0) {
       result.commonProcesses = commonGroups.map((g) => ({
-        id: g.id,
-        name: g.name,
-        description: g.description,
+        id: pfId(g),
+        name: pfName(g),
+        description: pfDescription(g),
         steps: g.actions.length > 0
           ? g.actions[0].steps.map((s, i) => toSpecStep(s, i))
           : [],
@@ -307,6 +338,10 @@ function toSpecRelation(r: ErRelation): SpecRelation {
 
 function toSpecStep(s: Step, index: number): SpecStep {
   const detail: Record<string, unknown> = {};
+  if (isExtensionStep(s)) {
+    if (s.config) detail.config = s.config;
+    return { number: getStepLabel(index), type: s.kind, description: s.description, detail };
+  }
   switch (s.kind) {
     case "validation":
       detail.conditions = s.conditions;
@@ -354,7 +389,9 @@ function toSpecStep(s: Step, index: number): SpecStep {
       if (s.outputBinding) detail.outputBinding = s.outputBinding;
       break;
     case "return":
-      if (s.value) detail.value = s.value;
+      // silent bug: s.value は v3 schema に存在しない (responseId / bodyExpression を使用) (#1233)
+      if (s.responseId) detail.responseId = s.responseId;
+      if (s.bodyExpression) detail.bodyExpression = s.bodyExpression;
       break;
     case "log":
       detail.level = s.level;
@@ -393,12 +430,12 @@ function toSpecStep(s: Step, index: number): SpecStep {
       break;
     case "eventPublish":
       detail.topic = s.topic;
-      if (s.eventRef) detail.eventRef = s.eventRef;
+      // silent bug: s.eventRef は v3 schema で廃止 (topic に一本化) (#1233)
       if (s.payload) detail.payload = s.payload;
       break;
     case "eventSubscribe":
       detail.topic = s.topic;
-      if (s.eventRef) detail.eventRef = s.eventRef;
+      // silent bug: s.eventRef は v3 schema で廃止 (topic に一本化) (#1233)
       if (s.filter) detail.filter = s.filter;
       break;
   }


### PR DESCRIPTION
## Summary

ISSUE #1233 Batch 2 — 共通型ガード関数を `actionUtils.ts` から export し、step recursion narrow を要する 4 file の `@ts-nocheck` を除去。

### 変更

- `frontend/src/utils/actionUtils.ts` — `isBranchStep` / `isLoopStep` / `isTransactionScopeStep` / `isJumpStep` / `isValidationStep` を export 化 + `isExtensionStep` 新設 + `StepWithSubSteps` alias export
- `frontend/src/components/process-flow/internal/stepSummaryText.ts` — `@ts-nocheck` 除去
- `frontend/src/components/process-flow/ActionMetaTabBar.tsx` — `@ts-nocheck` 除去 (`countMaturity` 内 visit を型ガード適用)
- `frontend/src/components/process-flow/internal/InlineStepList.tsx` — `@ts-nocheck` 除去 (`subSteps` access を `StepWithSubSteps` cast に整理)
- `frontend/src/utils/specExporter.ts` — `@ts-nocheck` 除去 (`toSpecStep` の switch narrow 整理、ProcessFlow flat-field アクセスをヘルパー関数で互換維持)

### 検証

- [x] `npm run build` → 0 errors
- [x] `npm run test:unit` → 2366 pass
- [x] `git diff origin/main..HEAD -- schemas/` → 空 (#511 schema governance)
- [x] silent bug 検出時は ISSUE #1233 にコメント記録 (S-1〜S-4: https://github.com/csilost2001/harmony/issues/1233#issuecomment-4502482861)

### 検出した silent bug (ISSUE コメントに記録済)

| ID | 場所 | 内容 |
|----|------|------|
| S-1 | stepSummaryText.ts | `ExternalSystemStep.protocol` — v3 schema に存在しない (→ `httpCall?.method` に修正) |
| S-2 | specExporter.ts | `ReturnStep.value` — v3 schema に存在しない (→ `responseId` / `bodyExpression` に修正) |
| S-3 | specExporter.ts | `EventPublishStep/EventSubscribeStep.eventRef` — v3 で廃止 (→ 削除) |
| S-4 | specExporter.ts | ProcessFlow flat-field アクセス (id/name/type/description/screenId) — テストデータが v3 flat shape、test fixture の v3 化は next Batch 候補 |

Refs #1233

🤖 Generated with [Claude Code](https://claude.com/claude-code)