### PR TITLE
refactor(types): @ts-nocheck 除去 (StructuredFieldsEditor + 隣接 2 file) + S-5 解消 (#1233)

### DIFF
--- a/frontend/src/components/process-flow/ExternalOutcomesPanel.tsx
+++ b/frontend/src/components/process-flow/ExternalOutcomesPanel.tsx
@@ -1,15 +1,10 @@
-// @ts-nocheck -- legacy process-flow action panel types are being migrated; tracked by #1016.
 import { useState } from "react";
 // #1186 Phase 2-B: types/action → types/v3 + processFlowMetadata 移行
-// ExternalSystemStep / OtherStep / Step は v3 strict、ExternalCallOutcome / EXTERNAL_CALL_OUTCOME_VALUES は frontend UI metadata
+// ExternalSystemStep / NonReturnStep は v3 strict、ExternalCallOutcome / EXTERNAL_CALL_OUTCOME_VALUES は frontend UI metadata
 import type {
   ExternalSystemStep,
-  Step,
-} from "../../types/v3";
-// ExternalCallOutcomeSpec / OtherStep は AnyRecord 互換のため action.ts 経由 (#1186 Phase 2-D で v3 strict 化予定)
-import type {
   ExternalCallOutcomeSpec,
-  OtherStep,
+  NonReturnStep,
 } from "../../types/v3";
 import {
   EXTERNAL_CALL_OUTCOME_VALUES,
@@ -59,20 +54,21 @@ export function ExternalOutcomesPanel({ step, onChange, onCommit }: Props) {
 
   const addSideEffect = (key: ExternalCallOutcome) => {
     const spec = outcomes[key] ?? { action: "continue" as const };
-    const newStep: OtherStep = {
+    // S-7 fix: v3 では step 識別は `kind` (旧 `type` は非規範)。最小構成として kind="log" step を生成。
+    const newStep = {
       id: generateUUID(),
-      type: "other",
+      kind: "log",
       description: "",
       maturity: "draft",
-    };
-    const sideEffects = [...(spec.sideEffects ?? []), newStep as Step];
+    } as unknown as NonReturnStep;
+    const sideEffects = [...(spec.sideEffects ?? []), newStep];
     setOutcome(key, { sideEffects });
   };
 
-  const updateSideEffect = (key: ExternalCallOutcome, idx: number, patch: Partial<Step>) => {
+  const updateSideEffect = (key: ExternalCallOutcome, idx: number, patch: Partial<NonReturnStep>) => {
     const spec = outcomes[key];
     if (!spec?.sideEffects) return;
-    const next = spec.sideEffects.map((s, i) => (i === idx ? ({ ...s, ...patch } as Step) : s));
+    const next = spec.sideEffects.map((s, i) => (i === idx ? ({ ...s, ...patch } as NonReturnStep) : s));
     setOutcome(key, { sideEffects: next });
   };
 
@@ -198,13 +194,14 @@ export function ExternalOutcomesPanel({ step, onChange, onCommit }: Props) {
                 </div>
                 {spec.sideEffects?.map((se, i) => (
                   <div key={se.id ?? i} className="d-flex align-items-center gap-1 mb-1" style={{ fontSize: "0.75rem" }}>
+                    {/* S-7 fix: v3 では step 識別は kind (旧 type は非規範フィールド) */}
                     <select
                       className="form-select form-select-sm"
-                      value={se.type}
-                      onChange={(e) => updateSideEffect(key, i, { type: e.target.value as Step["type"] } as Partial<Step>)}
+                      value={se.kind}
+                      onChange={(e) => updateSideEffect(key, i, { kind: e.target.value } as Partial<NonReturnStep>)}
                       style={{ width: 110, fontSize: "0.75rem" }}
                     >
-                      <option value="other">other</option>
+                      <option value="log">log</option>
                       <option value="dbAccess">dbAccess</option>
                       <option value="externalSystem">externalSystem</option>
                       <option value="compute">compute</option>

--- a/frontend/src/components/process-flow/ExternalOutcomesPanel.tsx
+++ b/frontend/src/components/process-flow/ExternalOutcomesPanel.tsx
@@ -55,10 +55,13 @@ export function ExternalOutcomesPanel({ step, onChange, onCommit }: Props) {
   const addSideEffect = (key: ExternalCallOutcome) => {
     const spec = outcomes[key] ?? { action: "continue" as const };
     // S-7 fix: v3 では step 識別は `kind` (旧 `type` は非規範)。最小構成として kind="log" step を生成。
+    // M-1 fix: LogStep 必須フィールド level / message を追加 (schema valid な状態で生成)
     const newStep = {
       id: generateUUID(),
       kind: "log",
       description: "",
+      level: "info",
+      message: "",
       maturity: "draft",
     } as unknown as NonReturnStep;
     const sideEffects = [...(spec.sideEffects ?? []), newStep];

--- a/frontend/src/components/process-flow/ExternalSystemCatalogPanel.tsx
+++ b/frontend/src/components/process-flow/ExternalSystemCatalogPanel.tsx
@@ -1,9 +1,8 @@
-// @ts-nocheck -- v3 strict 型移行 (#1186 Phase 2-E) で loose access パターン露呈、proper narrow は #1016 で deferred
 /**
  * ProcessFlow.context.catalogs.externalSystems 編集パネル (#278 / #570 v3 移行)
  */
 import { useState } from "react";
-import type { ProcessFlow, ExternalSystemCatalogEntry, ExternalAuthKind } from "../../types/v3";
+import type { ProcessFlow, ExternalSystemCatalogEntry, ExternalAuth, ExternalAuthKind } from "../../types/v3";
 
 interface Props {
   group: ProcessFlow;
@@ -80,7 +79,9 @@ export function ExternalSystemCatalogPanel({ group, onChange, expanded: expanded
           {keys.length === 0 && <div className="catalog-empty">まだエントリがありません。</div>}
           {keys.map((k) => {
             const e = catalog[k];
-            const auth = e.auth ?? { kind: "none" as ExternalAuthKind };
+            // S-8 note: ExternalAuth.kind が "iamRole"/"azureAd" を含む ExternalAuthKind より狭いため
+            // 局所キャストで UI 機能 (7 auth kind) を維持する (#1233 Batch 4a)
+            const auth = (e.auth ?? { kind: "none" }) as { kind: ExternalAuthKind; tokenRef?: string; headerName?: string };
             return (
               <div className="catalog-row" key={k}>
                 <div className="catalog-row-header">
@@ -128,7 +129,7 @@ export function ExternalSystemCatalogPanel({ group, onChange, expanded: expanded
                     <select
                       className="form-select form-select-sm"
                       value={auth.kind}
-                      onChange={(ev) => updateEntry(k, { auth: { ...auth, kind: ev.target.value as ExternalAuthKind } })}
+                      onChange={(ev) => updateEntry(k, { auth: { ...auth, kind: ev.target.value as ExternalAuthKind } as ExternalAuth })}
                     >
                       {AUTH_KINDS.map((a) => <option key={a} value={a}>{a}</option>)}
                     </select>
@@ -139,7 +140,7 @@ export function ExternalSystemCatalogPanel({ group, onChange, expanded: expanded
                       <select
                         className="form-select form-select-sm"
                         value={auth.tokenRef ?? ""}
-                        onChange={(ev) => updateEntry(k, { auth: { ...auth, tokenRef: ev.target.value || undefined } })}
+                        onChange={(ev) => updateEntry(k, { auth: { ...auth, tokenRef: ev.target.value || undefined } as ExternalAuth })}
                       >
                         <option value="">—</option>
                         {secretKeys.map((s) => <option key={s} value={`@secret.${s}`}>@secret.{s}</option>)}
@@ -148,7 +149,7 @@ export function ExternalSystemCatalogPanel({ group, onChange, expanded: expanded
                       <input
                         className="form-control form-control-sm"
                         value={auth.tokenRef ?? ""}
-                        onChange={(ev) => updateEntry(k, { auth: { ...auth, tokenRef: ev.target.value || undefined } })}
+                        onChange={(ev) => updateEntry(k, { auth: { ...auth, tokenRef: ev.target.value || undefined } as ExternalAuth })}
                         placeholder="ENV:STRIPE_SECRET_KEY or @secret.X"
                       />
                     )}

--- a/frontend/src/components/process-flow/ScreenItemPickerModal.tsx
+++ b/frontend/src/components/process-flow/ScreenItemPickerModal.tsx
@@ -22,19 +22,10 @@ type ScreenMeta = { id: string; name: string };
 
 /**
  * v3 ScreenItem.type → FieldType への変換。
- * v3 のみの primitive (integer/datetime/json) は string にマップ。
- *
- * TODO(#1233 Batch 4): StructuredFieldsEditor が v3 FieldType (domain/extension) 表示対応したら
- * ここも v3 FieldType そのまま通過に書き換える。それまでは StructuredFieldsEditor が
- * `kind === "custom"` のみ表示対応のため legacy 形式に変換 (v3 schema 違反だが UI 表示優先)。
+ * StructuredFieldsEditor が v3 FieldType (domain/extension) 表示対応済のため、
+ * v3 FieldType をそのまま通過させる。S-5 完全解消 (#1233 Batch 4a)。
  */
 function v3TypeToV1(type: ScreenItem["type"]): V1FieldType {
-  if (typeof type === "string") {
-    if (type === "string" || type === "number" || type === "boolean" || type === "date") return type;
-    return "string";
-  }
-  if (type.kind === "extension") return { kind: "custom", label: type.extensionRef } as unknown as V1FieldType;
-  if (type.kind === "domain") return { kind: "custom", label: type.domainKey } as unknown as V1FieldType;
   return type;
 }
 

--- a/frontend/src/components/process-flow/StructuredFieldsEditor.tsx
+++ b/frontend/src/components/process-flow/StructuredFieldsEditor.tsx
@@ -1,6 +1,13 @@
-// @ts-nocheck -- v3 strict 型移行 (#1186 Phase 2-E) で loose access パターン露呈、proper narrow は #1016 で deferred
 import { useState } from "react";
-import type { ActionFields, FieldType, StructuredField } from "../../types/v3";
+import type {
+  ActionFields,
+  FieldType,
+  FieldTypeDomain,
+  FieldTypeExtension,
+  Identifier,
+  ScreenId,
+  StructuredField,
+} from "../../types/v3";
 import { fieldsToText, isStructuredFields, textToStructuredFields } from "../../utils/actionFields";
 
 /** 画面項目ピッカーで返る型 — StructuredField にコピー元の値を載せて返す */
@@ -30,6 +37,47 @@ interface Props {
 
 const PRIMITIVE_TYPES: Array<"string" | "number" | "boolean" | "date"> = ["string", "number", "boolean", "date"];
 
+/** FieldType オブジェクトをテキスト入力の表示値に変換する */
+function fieldTypeToDisplay(type: FieldType): string {
+  if (typeof type === "string") return type;
+  // legacy `kind: "custom"` (v3 非規範、既存データ互換)
+  const t = type as { kind: string; domainKey?: string; extensionRef?: string; label?: string };
+  switch (t.kind) {
+    case "domain":    return `domain:${t.domainKey ?? ""}`;
+    case "extension": return `ext:${t.extensionRef ?? ""}`;
+    case "custom":    return t.label ?? "";
+    default:          return t.kind;
+  }
+}
+
+/** テキスト入力値から FieldType に変換する */
+function displayToFieldType(v: string): FieldType {
+  if (v === "") return "string";
+  if ((PRIMITIVE_TYPES as string[]).includes(v)) return v as FieldType;
+  if (v.startsWith("domain:")) {
+    const domainKey = v.slice("domain:".length).trim();
+    return { kind: "domain", domainKey: domainKey || v } satisfies FieldTypeDomain;
+  }
+  if (v.startsWith("ext:")) {
+    const extensionRef = v.slice("ext:".length).trim();
+    return { kind: "extension", extensionRef: extensionRef || v } satisfies FieldTypeExtension;
+  }
+  // fallback: plain text → domain (PascalCase) or keep as custom-compat
+  return { kind: "domain", domainKey: v } satisfies FieldTypeDomain;
+}
+
+/** FieldType オブジェクトのツールチップ表示 */
+function fieldTypeTitle(type: FieldType): string | undefined {
+  if (typeof type === "string") return undefined;
+  const t = type as { kind: string; domainKey?: string; extensionRef?: string; label?: string };
+  switch (t.kind) {
+    case "domain":    return `ドメイン型: ${t.domainKey}`;
+    case "extension": return `拡張型: ${t.extensionRef}`;
+    case "custom":    return `カスタム型: ${t.label}`;  // legacy 互換
+    default:          return t.kind;
+  }
+}
+
 /**
  * ActionDefinition.inputs / outputs の編集 UI (#226 / #310)。
  * 自由記述モード (textarea) と表形式モード (StructuredField[]) を切替可能。
@@ -57,7 +105,7 @@ export function StructuredFieldsEditor({ label, fields, onChange, onCommit, plac
 
   const addField = () => {
     const curr = isStructured ? fields : [];
-    const newField: StructuredField = { name: "", type: "string" };
+    const newField: StructuredField = { name: "" as Identifier, type: "string" };
     onChange([...curr, newField]);
   };
 
@@ -68,12 +116,12 @@ export function StructuredFieldsEditor({ label, fields, onChange, onCommit, plac
     if (!result) return;
     const curr = isStructured ? fields : [];
     const newField: StructuredField = {
-      name: result.name,
+      name: result.name as Identifier,
       label: result.label,
       type: result.type,
       required: result.required,
       description: result.description,
-      screenItemRef: { screenId: result.screenId, itemId: result.itemId },
+      screenItemRef: { screenId: result.screenId as ScreenId, itemId: result.itemId as Identifier },
     };
     onChange([...curr, newField]);
     onCommit?.();
@@ -181,7 +229,7 @@ export function StructuredFieldsEditor({ label, fields, onChange, onCommit, plac
                       type="text"
                       className="form-control form-control-sm"
                       value={f.name}
-                      onChange={(e) => updateField(i, { name: e.target.value })}
+                      onChange={(e) => updateField(i, { name: e.target.value as Identifier })}
                       onBlur={() => onCommit?.()}
                       placeholder="name"
                     />
@@ -201,26 +249,11 @@ export function StructuredFieldsEditor({ label, fields, onChange, onCommit, plac
                       type="text"
                       list="structured-fields-type-list"
                       className="form-control form-control-sm"
-                      value={typeof f.type === "string"
-                        ? f.type
-                        : f.type.kind === "custom"
-                          ? f.type.label ?? ""
-                          : ""}
-                      onChange={(e) => {
-                        const v = e.target.value;
-                        if (v === "") {
-                          updateField(i, { type: "string" });
-                        } else if ((PRIMITIVE_TYPES as string[]).includes(v)) {
-                          updateField(i, { type: v as FieldType });
-                        } else {
-                          updateField(i, { type: { kind: "custom", label: v } });
-                        }
-                      }}
+                      value={fieldTypeToDisplay(f.type)}
+                      onChange={(e) => updateField(i, { type: displayToFieldType(e.target.value) })}
                       onBlur={() => onCommit?.()}
-                      placeholder="型 (string/DTO名 等)"
-                      title={typeof f.type === "object" && f.type.kind === "custom"
-                        ? `カスタム型: ${f.type.label}`
-                        : undefined}
+                      placeholder="型 (string / domain:Name / ext:ns:key)"
+                      title={fieldTypeTitle(f.type)}
                     />
                   </td>
                   <td className="text-center">

--- a/frontend/src/components/process-flow/StructuredFieldsEditor.tsx
+++ b/frontend/src/components/process-flow/StructuredFieldsEditor.tsx
@@ -4,6 +4,7 @@ import type {
   FieldType,
   FieldTypeDomain,
   FieldTypeExtension,
+  FieldTypePrimitive,
   Identifier,
   ScreenId,
   StructuredField,
@@ -35,7 +36,7 @@ interface Props {
   onPickScreenItem?: () => Promise<ScreenItemPickResult | null>;
 }
 
-const PRIMITIVE_TYPES: Array<"string" | "number" | "boolean" | "date"> = ["string", "number", "boolean", "date"];
+const PRIMITIVE_TYPES: FieldTypePrimitive[] = ["string", "number", "integer", "boolean", "date", "datetime", "json"];
 
 /** FieldType オブジェクトをテキスト入力の表示値に変換する */
 function fieldTypeToDisplay(type: FieldType): string {


### PR DESCRIPTION
## 概要

ISSUE #1233 Batch 4a。S-5 silent bug 完全解消セット。

## 変更ファイル

- `frontend/src/components/process-flow/StructuredFieldsEditor.tsx`: `@ts-nocheck` 除去 + v3 FieldType `domain` / `extension` の表示・編集対応 (S-5 解消の本丸)
  - `fieldTypeToDisplay()`: `domain:Key` / `ext:ns:ref` / legacy `custom` 全対応
  - `displayToFieldType()`: `"domain:"` / `"ext:"` prefix で parse → `FieldTypeDomain` / `FieldTypeExtension` 生成
  - `Identifier` / `ScreenId` branded type キャスト追加 (`name` / `screenItemRef`)
- `frontend/src/components/process-flow/ExternalOutcomesPanel.tsx`: `@ts-nocheck` 除去 + S-7 fix
  - `addSideEffect` が `type: "other"` (v3 非規範) → `kind: "log"` に修正
  - `se.type` → `se.kind` 参照修正、`updateSideEffect` patch を `Partial<NonReturnStep>` に
- `frontend/src/components/process-flow/ExternalSystemCatalogPanel.tsx`: `@ts-nocheck` 除去 + S-8 検出
  - `ExternalAuth.kind` (5 値) と `ExternalAuthKind` (7 値) 乖離 → 局所キャストで UI 機能維持
- `frontend/src/components/process-flow/ScreenItemPickerModal.tsx`: `v3TypeToV1()` を v3 FieldType そのまま通過 (domain/extension 含む) に再修正

## 検出した silent bug

- **S-7** (`ExternalOutcomesPanel`): `addSideEffect` が `type: "other"` (v3 非規範フィールド) で step を生成し、`se.type` (存在しないフィールド) を参照していた → `kind: "log"` に修正
- **S-8** (`ExternalSystemCatalogPanel`): `ExternalAuth.kind` (5 値) と `ExternalAuthKind` (7 値) が乖離。UI は全 7 値対応だが型エラー → 局所キャストで機能維持 (S-8 次候補: schema governance 側で `ExternalAuth.kind` を `ExternalAuthKind` と揃える)

## 検証

- [x] `cd frontend && npm run build` → 0 errors
- [x] `cd frontend && npm run test:unit` → 2369 tests all pass
- [x] schema governance (#511): `git diff origin/main..HEAD -- schemas/` → 空

## 関連

Refs #1233 (子バッチ継続、本 ISSUE Close しない、残 13 → 10 file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)