### PR TITLE
refactor(types): @ts-nocheck 除去 (中型 panel 3 file: Canvas/Marker/Workflow) (#1233)

### DIFF
--- a/frontend/src/components/process-flow/MarkerPanel.tsx
+++ b/frontend/src/components/process-flow/MarkerPanel.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck -- legacy marker panel types still span old/new process-flow shapes; tracked by #1016.
 /**
  * ProcessFlow.markers 編集パネル (#261)
  *
@@ -12,6 +11,12 @@
 import { useMemo, useState } from "react";
 import type { ProcessFlow, Marker, MarkerKind, Step } from "../../types/v3";
 import { generateUUID } from "../../utils/uuid";
+import type { StepWithSubSteps } from "../../utils/actionUtils";
+import {
+  isBranchStep,
+  isLoopStep,
+  isTransactionScopeStep,
+} from "../../utils/actionUtils";
 
 /** ProcessFlow 内の全 step.id を再帰的に収集 (anchor orphan 判定用) */
 function collectStepIds(group: ProcessFlow): Set<string> {
@@ -19,13 +24,14 @@ function collectStepIds(group: ProcessFlow): Set<string> {
   const visit = (steps: Step[]) => {
     for (const s of steps) {
       ids.add(s.id);
-      if (s.subSteps) visit(s.subSteps);
-      if (s.kind === "branch") {
+      const sw = s as StepWithSubSteps;
+      if (sw.subSteps) visit(sw.subSteps);
+      if (isBranchStep(s)) {
         for (const b of s.branches) visit(b.steps);
         if (s.elseBranch) visit(s.elseBranch.steps);
       }
-      if (s.kind === "loop") visit(s.steps);
-      if (s.kind === "transactionScope") {
+      if (isLoopStep(s)) visit(s.steps);
+      if (isTransactionScopeStep(s)) {
         visit(s.steps);
         if (s.onCommit) visit(s.onCommit);
         if (s.onRollback) visit(s.onRollback);
@@ -56,12 +62,14 @@ const KIND_LABELS: Record<MarkerKind, string> = {
   attention: "注目",
   todo: "TODO",
   question: "質問",
+  validator: "バリデーター",
 };
 const KIND_ICONS: Record<MarkerKind, string> = {
   chat: "bi-chat-left-text",
   attention: "bi-eye",
   todo: "bi-check2-square",
   question: "bi-question-circle",
+  validator: "bi-shield-exclamation",
 };
 
 export function MarkerPanel({ group, onChange, expanded: expandedProp, onExpandedChange, render = "full" }: Props) {

--- a/frontend/src/components/process-flow/MarkerPanel.tsx
+++ b/frontend/src/components/process-flow/MarkerPanel.tsx
@@ -14,6 +14,7 @@ import { generateUUID } from "../../utils/uuid";
 import type { StepWithSubSteps } from "../../utils/actionUtils";
 import {
   isBranchStep,
+  isExtensionStep,
   isLoopStep,
   isTransactionScopeStep,
 } from "../../utils/actionUtils";
@@ -36,7 +37,7 @@ function collectStepIds(group: ProcessFlow): Set<string> {
         if (s.onCommit) visit(s.onCommit);
         if (s.onRollback) visit(s.onRollback);
       }
-      if (s.kind === "externalSystem" && s.outcomes) {
+      if (s.kind === "externalSystem" && !isExtensionStep(s) && s.outcomes) {
         for (const oc of Object.values(s.outcomes)) {
           if (oc?.sideEffects) visit(oc.sideEffects);
         }
@@ -94,7 +95,7 @@ export function MarkerPanel({ group, onChange, expanded: expandedProp, onExpande
   // anchor の追跡先 step が現存するかを判定するために step id セットを memo 化
   const existingStepIds = useMemo(() => collectStepIds(group), [group]);
   const isOrphanAnchor = (m: Marker): boolean => {
-    const anchorId = m.shape?.anchorStepId ?? m.stepId;
+    const anchorId = m.anchor?.stepId;
     if (!anchorId) return false;
     // ActionMetaTabBar の body (基本情報タブ/カタログタブ) に描画された場合の擬似 ID (#309 フォローアップ)
     // これは group.actions[*].steps に存在しないが orphan ではなく「タブが閉じている」状態なので除外
@@ -106,11 +107,11 @@ export function MarkerPanel({ group, onChange, expanded: expandedProp, onExpande
     const body = newBody.trim();
     if (!body) return;
     const next: Marker = {
-      id: generateUUID(),
+      id: generateUUID() as Marker["id"],
       kind: newKind,
       body,
       author: "human",
-      createdAt: new Date().toISOString(),
+      createdAt: new Date().toISOString() as Marker["createdAt"],
     };
     onChange({ ...group, authoring: { ...(group.authoring ?? {}), markers: [...markers, next] } });
     setNewBody("");
@@ -133,11 +134,11 @@ export function MarkerPanel({ group, onChange, expanded: expandedProp, onExpande
 
   const confirmResolve = (id: string) => {
     const note = resolveNote.trim();
-    const next = markers.map((m) => (
+    const next: Marker[] = markers.map((m) => (
       m.id === id
         ? {
             ...m,
-            resolvedAt: new Date().toISOString(),
+            resolvedAt: new Date().toISOString() as Marker["resolvedAt"],
             resolution: note || "(人間が手動で解決)",
           }
         : m
@@ -205,10 +206,10 @@ export function MarkerPanel({ group, onChange, expanded: expandedProp, onExpande
                   <span className="marker-author small text-muted">
                     {m.author === "human" ? "人間" : "AI"}
                   </span>
-                  {m.stepId && (
+                  {m.anchor?.stepId && (
                     <span className="marker-step-ref small text-muted">
-                      step: {m.stepId}
-                      {m.fieldPath && `.${m.fieldPath}`}
+                      step: {m.anchor.stepId}
+                      {m.anchor.fieldPath && `.${m.anchor.fieldPath}`}
                     </span>
                   )}
                   {isOrphanAnchor(m) && !resolved && (

--- a/frontend/src/components/process-flow/SortableStepCard.tsx
+++ b/frontend/src/components/process-flow/SortableStepCard.tsx
@@ -32,7 +32,7 @@ interface SortableStepCardProps {
   onAddMarker?: (body: string, kind?: "todo" | "question" | "attention" | "chat") => void;
   markerCount?: number;
   markerTooltip?: string;
-  markerKinds?: { todo: number; question: number; attention: number; chat: number };
+  markerKinds?: { todo: number; question: number; attention: number; chat: number; validator: number };
   conventions?: ConventionsCatalog | null;
   group?: ProcessFlow | null;
   /** #1076 編集レベル (rough / detail / implementation) */

--- a/frontend/src/components/process-flow/StepCard.tsx
+++ b/frontend/src/components/process-flow/StepCard.tsx
@@ -83,7 +83,7 @@ interface StepCardProps {
   /** この step の未解決 marker tooltip 本文 */
   markerTooltip?: string;
   /** kind 別未解決件数 (#261 色分け badge 表示用、省略時は markerCount のみ表示) */
-  markerKinds?: { todo: number; question: number; attention: number; chat: number };
+  markerKinds?: { todo: number; question: number; attention: number; chat: number; validator: number };
   /** #1076 編集レベル (rough / detail / implementation)。デフォルトは implementation (全項目) */
   editLevel?: "rough" | "detail" | "implementation";
   /** #1076 AI 依頼ボタン押下時のコールバック */
@@ -261,6 +261,11 @@ export function StepCard({
                 {markerKinds.chat > 0 && (
                   <span className="step-marker-chip kind-chat" title={`メモ ${markerKinds.chat} 件`}>
                     <i className="bi bi-chat-dots-fill" />{markerKinds.chat}
+                  </span>
+                )}
+                {markerKinds.validator > 0 && (
+                  <span className="step-marker-chip kind-validator" title={`バリデーター ${markerKinds.validator} 件`}>
+                    <i className="bi bi-shield-exclamation" />{markerKinds.validator}
                   </span>
                 )}
               </span>

--- a/frontend/src/components/process-flow/WorkflowStepPanel.test.tsx
+++ b/frontend/src/components/process-flow/WorkflowStepPanel.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, fireEvent, within } from "@testing-library/react";
 import { WorkflowStepPanel } from "./WorkflowStepPanel";
-import type { Step, WorkflowStep } from "../../utils/processFlowMetadata";
+import type { Step, WorkflowStep } from "../../types/v3";
 import type { ConventionsCatalog } from "../../schemas/conventionsValidator";
 import { WORKFLOW_PATTERN_VALUES } from "../../utils/processFlowMetadata";
 
@@ -14,8 +14,8 @@ const conventions: ConventionsCatalog = {
 };
 
 const baseStep: WorkflowStep = {
-  id: "workflow-step",
-  type: "workflow",
+  id: "workflow-step" as WorkflowStep["id"],
+  kind: "workflow",
   description: "承認",
   maturity: "draft",
   pattern: "approval-sequential",
@@ -100,12 +100,12 @@ describe("WorkflowStepPanel", () => {
     const { container, rerender } = renderPanel({ ...baseStep, quorum: { type: "any" } }, onChange);
     expect(field(container, "quorum.n")).toBeNull();
 
-    fireEvent.change(firstSelect(container, "quorum.type"), { target: { value: "n-of-m" } });
-    expect(onChange).toHaveBeenLastCalledWith({ quorum: { type: "n-of-m", n: 1 } });
+    fireEvent.change(firstSelect(container, "quorum.type"), { target: { value: "nOfM" } });
+    expect(onChange).toHaveBeenLastCalledWith({ quorum: { type: "nOfM", n: 1 } });
 
     rerender(
       <WorkflowStepPanel
-        step={{ ...baseStep, quorum: { type: "n-of-m", n: 2 } }}
+        step={{ ...baseStep, quorum: { type: "nOfM", n: 2 } }}
         allSteps={[]}
         conventions={conventions}
         onChange={onChange}
@@ -126,8 +126,10 @@ describe("WorkflowStepPanel", () => {
       const patch = onChange.mock.lastCall?.[0] as Partial<WorkflowStep>;
       expect(patch[path]).toEqual([
         {
-          id: expect.stringMatching(/^workflow-/),
-          type: "other",
+          id: expect.stringMatching(/^[0-9a-f-]{36}$/),
+          kind: "log",
+          level: "info",
+          message: "",
           description: "",
           maturity: "draft",
         },
@@ -135,8 +137,10 @@ describe("WorkflowStepPanel", () => {
     }
 
     const child: Step = {
-      id: "child-step",
-      type: "other",
+      id: "child-step" as Step["id"],
+      kind: "log",
+      level: "info",
+      message: "子ステップ",
       description: "子ステップ",
       maturity: "draft",
     };

--- a/frontend/src/components/process-flow/WorkflowStepPanel.tsx
+++ b/frontend/src/components/process-flow/WorkflowStepPanel.tsx
@@ -1,7 +1,7 @@
-// @ts-nocheck -- legacy process-flow action panel types are being migrated; tracked by #1016.
 import type { ReactNode } from "react";
 // #1186 Phase 2-B: types/action → types/v3 + processFlowMetadata 移行
 import type {
+  LocalId,
   Step,
   WorkflowStep,
   WorkflowPattern,
@@ -17,6 +17,7 @@ import {
 } from "../../utils/processFlowMetadata";
 import type { ConventionsCatalog } from "../../schemas/conventionsValidator";
 import { ConvCompletionInput } from "../common/ConvCompletionInput";
+import { generateUUID } from "../../utils/uuid";
 
 interface Props {
   step: WorkflowStep;
@@ -95,8 +96,8 @@ export function WorkflowStepPanel({
 
   const updateQuorum = (patch: { type?: WorkflowQuorum["type"]; n?: number }) => {
     const type = patch.type ?? step.quorum?.type ?? "any";
-    if (type === "n-of-m") {
-      const currentN = step.quorum?.type === "n-of-m" ? step.quorum.n : undefined;
+    if (type === "nOfM") {
+      const currentN = step.quorum?.type === "nOfM" ? step.quorum.n : undefined;
       onChange({ quorum: { type, n: patch.n ?? currentN ?? 1 } });
     } else {
       onChange({ quorum: { type } });
@@ -146,8 +147,10 @@ export function WorkflowStepPanel({
           onStepsChange([
             ...steps,
             {
-              id: `workflow-${parentLabel.toLowerCase()}-${steps.length + 1}`,
-              type: "other",
+              id: generateUUID() as LocalId,
+              kind: "log" as const,
+              level: "info" as const,
+              message: "",
               description: "",
               maturity: "draft",
             },
@@ -211,10 +214,10 @@ export function WorkflowStepPanel({
             <option value="all">all</option>
             <option value="any">any</option>
             <option value="majority">majority</option>
-            <option value="n-of-m">n-of-m</option>
+            <option value="nOfM">n-of-m</option>
           </select>
         </div>
-        {step.quorum?.type === "n-of-m" && (
+        {step.quorum?.type === "nOfM" && (
           <div className="col-md-3" data-field-path="quorum.n">
             <label className="form-label">必要数 n</label>
             <input

--- a/frontend/src/components/process-flow/internal/CanvasPane.tsx
+++ b/frontend/src/components/process-flow/internal/CanvasPane.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck -- StepCard と同じ legacy/v3 union 緩和理由 (#1016)
 // Phase-3 (#1145): ProcessFlowEditor.tsx 中央キャンバス (ステップリスト) を抽出。
 // SortableContext + 各 SortableStepCard + StepInsertZone の組合せ。
 

--- a/frontend/src/components/process-flow/internal/CanvasPane.tsx
+++ b/frontend/src/components/process-flow/internal/CanvasPane.tsx
@@ -133,7 +133,7 @@ export function CanvasPane({
                 >
                   {activeAction.steps.map((step, index) => {
                     const stepMarkers = (group?.authoring?.markers ?? []).filter(
-                      (m) => !m.resolvedAt && (m.anchor?.stepId ?? (m as Marker & { stepId?: string }).stepId) === step.id,
+                      (m) => !m.resolvedAt && m.anchor?.stepId === step.id,
                     );
                     const markerCount = stepMarkers.length;
                     const markerTooltip =
@@ -149,6 +149,7 @@ export function CanvasPane({
                             question: stepMarkers.filter((m) => m.kind === "question").length,
                             attention: stepMarkers.filter((m) => m.kind === "attention").length,
                             chat: stepMarkers.filter((m) => m.kind === "chat").length,
+                            validator: stepMarkers.filter((m) => m.kind === "validator").length,
                           }
                         : undefined;
                     return (

--- a/frontend/src/components/process-flow/internal/CanvasPane.tsx
+++ b/frontend/src/components/process-flow/internal/CanvasPane.tsx
@@ -3,7 +3,7 @@
 
 import type { RefObject } from "react";
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
-import type { ActionDefinition, ProcessFlow, Step, StepType } from "../../../types/v3";
+import type { ActionDefinition, Marker, ProcessFlow, Step, StepType } from "../../../types/v3";
 import type { ConventionsCatalog } from "../../../schemas/conventionsValidator";
 import { SortableStepCard } from "../SortableStepCard";
 import { EmptyFlowDropZone, StepInsertZone } from "./PaletteButtons";
@@ -133,7 +133,7 @@ export function CanvasPane({
                 >
                   {activeAction.steps.map((step, index) => {
                     const stepMarkers = (group?.authoring?.markers ?? []).filter(
-                      (m) => !m.resolvedAt && m.stepId === step.id,
+                      (m) => !m.resolvedAt && (m.anchor?.stepId ?? (m as Marker & { stepId?: string }).stepId) === step.id,
                     );
                     const markerCount = stepMarkers.length;
                     const markerTooltip =
@@ -201,13 +201,13 @@ export function CanvasPane({
                           validationErrors={validationErrors}
                           onAddMarker={(body, kind = "todo") => {
                             updateGroupWithDraft((g) => {
-                              const m = {
-                                id: generateUUID(),
+                              const m: Marker = {
+                                id: generateUUID() as Marker["id"],
                                 kind,
                                 body,
-                                stepId: step.id,
-                                author: "human" as const,
-                                createdAt: new Date().toISOString(),
+                                anchor: { stepId: step.id },
+                                author: "human",
+                                createdAt: new Date().toISOString() as Marker["createdAt"],
                               };
                               g.authoring = {
                                 ...(g.authoring ?? {}),

--- a/frontend/src/styles/processFlow.css
+++ b/frontend/src/styles/processFlow.css
@@ -2063,6 +2063,7 @@
 .step-marker-chip.kind-question { background: #ede9fe; color: #5b21b6; border-color: #c4b5fd; }
 .step-marker-chip.kind-attention { background: #fef3c7; color: #92400e; border-color: #fcd34d; }
 .step-marker-chip.kind-chat { background: #dbeafe; color: #1e40af; border-color: #93c5fd; }
+.step-marker-chip.kind-validator { background: #fee2e2; color: #991b1b; border-color: #fca5a5; }
 .validation-code {
   font-family: ui-monospace, monospace;
   font-size: 0.7rem;


### PR DESCRIPTION
## 概要

ISSUE #1233 Batch 4b — 中型 panel 3 file の `// @ts-nocheck` を除去し、型エラーを修正する。

Refs #1233 (子バッチ継続、本 ISSUE Close しない、残 10 → 7 file)

## 対象 (3 file + 1 test、計 ~945 行)

| file | 行数 | 主な対応 |
|---|---|---|
| `frontend/src/components/process-flow/internal/CanvasPane.tsx` | 263 | `@ts-nocheck` 除去 + Marker 生成コード `Marker.anchor.stepId` 形式 (v3 規範) 化 |
| `frontend/src/components/process-flow/MarkerPanel.tsx` | 331 | `@ts-nocheck` 除去 + S-9 解消 + `subSteps` `StepWithSubSteps` cast 統一 + `Marker.anchor.*` 移行 + Uuid/Timestamp brand cast |
| `frontend/src/components/process-flow/WorkflowStepPanel.tsx` | 351 | `@ts-nocheck` 除去 + S-10 + S-11 解消 |
| `frontend/src/components/process-flow/WorkflowStepPanel.test.tsx` | (テスト連動更新) | S-10/S-11 期待値 v3 規範化、import を `processFlowMetadata` から `types/v3` に修正 |

## 検出した silent bug (本 PR 内で全て修正済)

| ID | 場所 | 旧 (v3 非規範) | 新 (v3 規範) |
|----|------|---------------|-------------|
| **S-9** | `MarkerPanel.tsx` `KIND_LABELS` / `KIND_ICONS` | `Record<MarkerKind, string>` に `"validator"` キー欠落 → undefined 返却 (UI 表示崩れ) | `validator: "バリデーター"` / `validator: "bi-shield-exclamation"` 追加 |
| **S-10** | `WorkflowStepPanel.tsx` `fallbackStepList` | `{ type: "other", description: "", maturity: "draft" }` (v3 非規範 `type` field) | `{ kind: "log", level: "info", message: "", description: "", maturity: "draft" }` (LogStep 必須 field 満たす) |
| **S-11** | `WorkflowStepPanel.tsx` `quorum.type` | UI option value `"n-of-m"` が TS 型 `"nOfM"` と乖離 (silent regression: 保存しても schema-invalid) | option value + 比較を `"nOfM"` に統一 |

## 適用パターン (Batch 2/3/4a 踏襲)

- 共通型ガード (`utils/actionUtils.ts` から export 済): `isBranchStep` / `isLoopStep` / `isTransactionScopeStep` / `isJumpStep` / `isValidationStep` / `isExtensionStep` / `StepWithSubSteps`
- ピンポイント修正: `@ts-nocheck` 削除 → tsc error 1 件ずつ type guard / 局所 cast / 型 alias で局所化

## 検証結果

- [x] `grep -c '^// @ts-nocheck' frontend/src/components/process-flow/internal/CanvasPane.tsx` → **0**
- [x] `grep -c '^// @ts-nocheck' frontend/src/components/process-flow/MarkerPanel.tsx` → **0**
- [x] `grep -c '^// @ts-nocheck' frontend/src/components/process-flow/WorkflowStepPanel.tsx` → **0**
- [x] `cd frontend && npm run build` → **0 errors** (chunk size warning のみ、pre-existing)
- [x] `cd frontend && npm run test:unit` → 2344 pass (dogfood-1038 の 25 失敗は pre-existing、origin/main でも同じ failures)
- [x] **schema governance (#511)**: `git diff origin/main..HEAD -- schemas/` → **空** (schema 変更なし)

## 役割分担

- 実装: Sonnet (Codex は今回 review only)
- レビュー: Codex (`Agent(codex:codex-rescue)` で `/codex:review` 相当、本 PR 作成後に Opus が実行)
- 判断・統合: Opus

## 既知の build 検証メモ

`npx tsc --noEmit` よりも `npm run build` (`tsc -b` + Vite build) の方が project references を完全解決するため厳格。今後の Batch では `npm run build` を最終確認の必須コマンドに含めること (本 PR ではこれで Marker 型エラーを追加検出)。

Refs #1233

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>