### PR TITLE
refactor(types): @ts-nocheck 除去 (大型 file: ProcessFlowListView.tsx) (#1233 Batch 5b)

### DIFF
--- a/frontend/src/components/process-flow/ProcessFlowListView.tsx
+++ b/frontend/src/components/process-flow/ProcessFlowListView.tsx
@@ -1,9 +1,10 @@
-// @ts-nocheck -- list view still consumes mixed process-flow shapes; tracked by #1016.
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { useWorkspacePath } from "../../hooks/useWorkspacePath";
 // #1186 Phase 2-D: types/action → types/v3 + processFlowMetadata 移行
-import type { ProcessFlowMeta, ProcessFlowType, ProcessFlow } from "../../types/v3";
+// #1233 Batch 5b: ProcessFlowMeta (v3 inner) → ProcessFlowEntry (harmony.json entity shape)
+import type { ProcessFlowEntry, ProcessFlowType, ProcessFlow, LocalId } from "../../types/v3";
+type ProcessFlowMeta = ProcessFlowEntry; // ファイル内 alias、差分最小化 (#1233 Batch 5b)
 import { PROCESS_FLOW_TYPE_LABELS, PROCESS_FLOW_TYPE_ICONS } from "../../utils/processFlowMetadata";
 import {
   listProcessFlows,
@@ -254,7 +255,7 @@ export function ProcessFlowListView() {
     switch (key) {
       case "name": return g.name;
       case "type": return PROCESS_FLOW_TYPE_LABELS[g.kind as ProcessFlowType] ?? g.kind;
-      case "actionCount": return g.actionCount;
+      case "actionCount": return g.actionCount ?? 0;
       case "screenId": return g.screenId ? 1 : 0;
       case "errorPriority": return getErrorPriority(g.id);
       case "maturity": {
@@ -338,8 +339,8 @@ export function ProcessFlowListView() {
       },
       actions: full.actions.map((a) => ({
         ...a,
-        id: generateUUID(),
-        steps: a.steps.map((s) => ({ ...s, id: generateUUID() })),
+        id: generateUUID() as LocalId,
+        steps: a.steps.map((s) => ({ ...s, id: generateUUID() as LocalId })),
       })),
     };
     await saveProcessFlow(dup);
@@ -362,7 +363,7 @@ export function ProcessFlowListView() {
     if (!clipItems.length) return;
 
     if (mode === "cut") {
-      const cutIds = new Set(clipItems.map((c) => c.id));
+      const cutIds = new Set(clipItems.map((c) => c.id as string));
       const selIds = selection.selectedIds;
       const sameSet = selIds.size === cutIds.size && [...selIds].every((id) => cutIds.has(id));
       if (sameSet) return;
@@ -417,7 +418,7 @@ export function ProcessFlowListView() {
     setAddType("screen");
     setAddScreenId("");
     setAddDescription("");
-    navigate(wsPath(`/process-flow/edit/${group.meta?.id ?? group.id}`));
+    navigate(wsPath(`/process-flow/edit/${group.meta.id}`));
   };
 
   // docs/spec/list-common.md §3.11: 右クリックメニュー項目を構築
@@ -463,7 +464,7 @@ export function ProcessFlowListView() {
         disabled: pasteBlocked, disabledReason: pasteBlocked && sortActive ? sortReason : pasteReason,
         onClick: () => {
           const ids = Array.from(selection.selectedIds);
-          const allIds = editor.items.map((g) => g.id);
+          const allIds = editor.items.map((g) => g.id as string);
           const insertIndex = ids.length > 0
             ? Math.max(...ids.map((id) => allIds.indexOf(id))) + 1
             : null;
@@ -633,7 +634,7 @@ export function ProcessFlowListView() {
       width: "90px",
       align: "right",
       sortable: true,
-      sortAccessor: (g) => g.actionCount,
+      sortAccessor: (g) => g.actionCount ?? 0,
       render: (g) => <span>{g.actionCount}</span>,
     },
     {
@@ -720,7 +721,7 @@ export function ProcessFlowListView() {
 
   const typeCounts = useMemo(() => {
     const c: Record<string, number> = {};
-    for (const g of groups) c[g.kind] = (c[g.kind] ?? 0) + 1;
+    for (const g of groups) if (g.kind != null) c[g.kind] = (c[g.kind] ?? 0) + 1;
     return c;
   }, [groups]);
 


### PR DESCRIPTION
## 概要

ISSUE #1233 (frontend `@ts-nocheck` 段階剥がし) シリーズの **Batch 5b**。残 2 file のうち `ProcessFlowListView.tsx` (1016 行) を処理。

Refs #1233 (子バッチ継続、本 PR で Close しない、残 2 → 1 file)

## 変更内容

| 箇所 | 修正内容 |
|------|----------|
| line 1 | `// @ts-nocheck` 削除 |
| line 6-7 | `ProcessFlowEntry, LocalId` を追加 import、`type ProcessFlowMeta = ProcessFlowEntry` ファイル内 alias 追加 |
| line 258, 637 | `g.actionCount` → `g.actionCount ?? 0` (undefined 対応、sortAccessor 戻り値型) |
| line 340-344 | `generateUUID()` → `generateUUID() as LocalId` (ActionDefinition.id brand cast) |
| line 366 | `c.id` → `c.id as string` (Set<ProcessFlowId> → Set<string>、`cutIds.has()` brand 衝突解消) |
| line 421 | `group.meta?.id ?? group.id` → `group.meta.id` (ProcessFlow に top-level `id` は存在しない、legacy dead code 除去) |
| line 467 | `editor.items.map((g) => g.id)` → `.map((g) => g.id as string)` (indexOf brand 型衝突解消) |
| line 724 | `c[g.kind]` に `if (g.kind != null)` ガード追加 (`kind` は `string | undefined`) |

### type identity 解消

設計コメント (https://github.com/csilost2001/harmony/issues/1233#issuecomment-4508073445) で予告した通り、`ProcessFlowMeta` import を v3 内側 nested 形 (`types/v3/process-flow.ts:61`) から harmony.json entity 形 (`ProcessFlowEntry`, `types/v3/harmony.ts:68`) に差し替え。runtime 実態 (`listProcessFlows()` 返り値) と型注釈の identity 不整合を解消。

差分最小化のため `type ProcessFlowMeta = ProcessFlowEntry` ファイル内 alias で従来の `g.id` / `g.name` / `g.kind` / `g.no` / `g.actionCount` アクセスはそのまま温存。

## 検証結果

- `npm run build` (`tsc -b` + Vite build): **0 errors**
- `npm run test:unit`: **2369 passed / 0 failed**
- `git diff origin/main..HEAD -- schemas/`: **空** (#511 schema governance クリア)
- `grep -c '^// @ts-nocheck' frontend/src/components/process-flow/ProcessFlowListView.tsx`: **0**

## silent bug 検出

- **なし**。`step.protocol` / `step.eventRef` / `marker.shape` 等 v3 非規範 field access は見つからず。`group.meta?.id ?? group.id` は legacy dead code (top-level `id` は v3 で存在しない) で型エラーとして表面化、本 PR で `group.meta.id` に整流。

## 仕様逐条突合 (自己申告)

- [x] `// @ts-nocheck` 行削除 — `frontend/src/components/process-flow/ProcessFlowListView.tsx:1` (削除済)
- [x] `npm run build` → 0 errors
- [x] `npm run test:unit` → all pass
- [x] schema governance (#511) → `schemas/` 変更なし
- [x] silent bug は検出時に ISSUE コメント追記 → 本 Batch では検出なし

## 後続

| Batch | 対象 file | 行数 | 状態 |
|---|---|---|---|
| 5c | `process-flow/ProcessFlowEditor.tsx` | 1092 | 残 1 file、本シリーズ最終ボス |

別 ISSUE 候補 (本シリーズ完了後): `actionTriggerConstants.ts:179` 等の `legacyMarker.stepId` 系 read fallback の最終除去 (data migration 設計が前提、PR #1214 で意図的に維持)。

## 役割分担

- **実装**: Sonnet (Codex は今回 review only、ユーザー指示踏襲)
- **レビュー**: Codex (本 PR submit 後、Opus が `Agent(codex:codex-rescue)` で `/codex:review` 相当を実行)
- **判断・統合**: Opus

🤖 Generated with [Claude Code](https://claude.com/claude-code)
