### PR TITLE
refactor(types): @ts-nocheck 除去 (大型 file: ProcessFlowEditor.tsx) (#1233 Batch 5c、シリーズ完了)

### DIFF
--- a/frontend/src/components/process-flow/ProcessFlowEditor.tsx
+++ b/frontend/src/components/process-flow/ProcessFlowEditor.tsx
@@ -1,5 +1,3 @@
-// @ts-nocheck -- large legacy editor migration remains open; tracked by #1016.
-//
 // Phase-3 (#1145): 94KB → 30KB 目標で以下を抽出:
 //   - internal/PaletteButtons.tsx (ToolbarStepButton / StepInsertZone / EmptyFlowDropZone / CustomStepButton)
 //   - internal/ActionHelpPopover.tsx
@@ -19,6 +17,9 @@ import type {
   ActionTrigger,
   Step,
   StepKind as StepType,
+  Uuid,
+  LocalId,
+  Timestamp,
 } from "../../types/v3";
 import { STEP_TEMPLATES, STEP_TYPE_LABELS } from "../../utils/processFlowMetadata";
 import {
@@ -32,7 +33,7 @@ import {
   addSubStep,
 } from "../../store/processFlowStore";
 import { applyProcessFlowMutation } from "./processFlowMutation";
-import { clearJumpReferences } from "../../utils/actionUtils";
+import { clearJumpReferences, type StepWithSubSteps } from "../../utils/actionUtils";
 import { hasBlockingErrors } from "../../utils/actionValidation";
 import { aggregateValidation } from "../../utils/aggregatedValidation";
 import { generateUUID } from "../../utils/uuid";
@@ -70,6 +71,7 @@ import { AddActionModal } from "./internal/AddActionModal";
 import { StepContextMenu } from "./internal/StepContextMenu";
 import { WarningsPanel } from "./internal/WarningsPanel";
 import { ALL_STEP_TYPES } from "./internal/stepCardConstants";
+import { getActionTriggerLabel } from "./internal/actionTriggerConstants";
 import { ProcessFlowDialogs } from "./internal/ProcessFlowDialogs";
 import { useProcessFlowCatalogs } from "./internal/useProcessFlowCatalogs";
 import { useActionHelpPopover } from "./internal/useActionHelpPopover";
@@ -193,7 +195,8 @@ export function ProcessFlowEditor() {
     onNotFound: handleNotFound,
     onLoaded: handleLoaded,
     // #891 fix: viewer mode で mid-edit broadcast を受信するため渡す
-    viewerMode: mode.kind,
+    // mode.kind の全バリアントを useResourceEditor の制限型にキャスト (非 viewer 値は内部で無視される)
+    viewerMode: mode.kind as "viewer" | "editing" | "readonly" | undefined,
     viewerResourceType: "process-flow",
     viewerEditSessionId: editSession?.id,
   });
@@ -451,7 +454,7 @@ export function ProcessFlowEditor() {
     updateGroupWithDraft((g) => {
       const act = g.actions.find((a) => a.id === activeActionId);
       if (!act) return;
-      for (const stepDef of tpl.steps) {
+      for (const stepDef of (tpl.steps ?? [])) {
         const step = { ...stepDef, id: generateUUID() } as Step;
         act.steps.push(step);
       }
@@ -481,9 +484,9 @@ export function ProcessFlowEditor() {
       const idx = act.steps.findIndex((s) => s.id === stepId);
       if (idx <= 0) return;
       const stepToMove = act.steps[idx];
-      const target = { ...act.steps[idx - 1] };
+      const target = { ...act.steps[idx - 1] } as StepWithSubSteps;
       target.subSteps = [...(target.subSteps ?? []), stepToMove];
-      act.steps[idx - 1] = target;
+      act.steps[idx - 1] = target as unknown as Step;
       act.steps.splice(idx, 1);
     });
   };
@@ -494,11 +497,11 @@ export function ProcessFlowEditor() {
       if (!act) return;
       const parentIdx = act.steps.findIndex((s) => s.id === parentStepId);
       if (parentIdx < 0) return;
-      const parent = act.steps[parentIdx];
+      const parent = act.steps[parentIdx] as StepWithSubSteps;
       const subIdx = (parent.subSteps ?? []).findIndex((s) => s.id === subStepId);
       if (subIdx < 0) return;
       const subStep = parent.subSteps![subIdx];
-      act.steps[parentIdx] = { ...parent, subSteps: parent.subSteps!.filter((s) => s.id !== subStepId) };
+      act.steps[parentIdx] = { ...parent, subSteps: parent.subSteps!.filter((s) => s.id !== subStepId) } as unknown as Step;
       act.steps.splice(parentIdx + 1, 0, subStep);
     });
   };
@@ -571,9 +574,10 @@ export function ProcessFlowEditor() {
       const idx = act.steps.findIndex((s) => s.id === stepId);
       if (idx < 0) return;
       const clone = JSON.parse(JSON.stringify(act.steps[idx])) as Step;
-      clone.id = generateUUID();
-      if (clone.subSteps) {
-        clone.subSteps = clone.subSteps.map((s) => ({ ...s, id: generateUUID() }));
+      clone.id = generateUUID() as LocalId;
+      const cloneWithSubs = clone as StepWithSubSteps;
+      if (cloneWithSubs.subSteps) {
+        cloneWithSubs.subSteps = cloneWithSubs.subSteps.map((s) => ({ ...s, id: generateUUID() as LocalId }));
       }
       act.steps.splice(idx + 1, 0, clone);
     });
@@ -650,9 +654,10 @@ export function ProcessFlowEditor() {
       if (!act) return;
       const newSteps = clipboard.steps.map((s) => {
         const clone = JSON.parse(JSON.stringify(s)) as Step;
-        clone.id = generateUUID();
-        if (clone.subSteps) {
-          clone.subSteps = clone.subSteps.map((sub: Step) => ({ ...sub, id: generateUUID() }));
+        clone.id = generateUUID() as LocalId;
+        const cloneWithSubs = clone as StepWithSubSteps;
+        if (cloneWithSubs.subSteps) {
+          cloneWithSubs.subSteps = cloneWithSubs.subSteps.map((sub) => ({ ...sub, id: generateUUID() as LocalId }));
         }
         return clone;
       });
@@ -746,21 +751,21 @@ export function ProcessFlowEditor() {
       // (anchor.shape は常に記録するので DrawingOverlay の位置追従は効く)。
       const isMetaTabAnchor = shape.anchorStepId?.startsWith("__meta-tab-") ?? false;
       g.authoring = { ...(g.authoring ?? {}), markers: [...(g.authoring?.markers ?? []), {
-        id: generateUUID(),
-        kind: "todo",
+        id: generateUUID() as Uuid,
+        kind: "todo" as const,
         body: body.trim(),
         anchor: {
-          stepId: isMetaTabAnchor ? undefined : shape.anchorStepId,
+          stepId: (isMetaTabAnchor ? undefined : shape.anchorStepId) as LocalId | undefined,
           fieldPath: isMetaTabAnchor ? undefined : shape.anchorFieldPath,
           shape: {
-            kind: "path",
+            kind: "path" as const,
             d: shape.d,
             color: shape.color,
             strokeWidth: shape.strokeWidth,
           },
         },
-        author: "human",
-        createdAt: new Date().toISOString(),
+        author: "human" as const,
+        createdAt: new Date().toISOString() as Timestamp,
       }] };
     });
     setDrawingMode(false);
@@ -812,8 +817,8 @@ export function ProcessFlowEditor() {
         showAiGenerateDialog={showAiGenerateDialog}
         showAiReviewDialog={showAiReviewDialog}
         serverChanged={serverChanged}
-        onForcedOutChoice={(choice) => editActions.handleForcedOut(choice)}
-        onAfterForceUnlockChoice={(choice) => editActions.handleAfterForceUnlock(choice)}
+        onForcedOutChoice={(choice) => editActions.handleForcedOut(choice as "continue" | "discard" | "adopt")}
+        onAfterForceUnlockChoice={(choice) => editActions.handleAfterForceUnlock(choice as "continue" | "discard" | "adopt")}
         onResumeContinue={handleResumeContinue}
         onResumeDiscard={handleResumeDiscard}
         onCancelResume={() => setShowResumeDialog(false)}
@@ -858,11 +863,11 @@ export function ProcessFlowEditor() {
         onAddAiDiffMarker={(body) => {
           updateGroupWithDraft((g) => {
             const m = {
-              id: generateUUID(),
+              id: generateUUID() as Uuid,
               kind: "chat" as const,
               body,
               author: "human" as const,
-              createdAt: new Date().toISOString(),
+              createdAt: new Date().toISOString() as Timestamp,
             };
             g.authoring = {
               ...(g.authoring ?? {}),

--- a/frontend/src/components/process-flow/internal/ActionTabBar.tsx
+++ b/frontend/src/components/process-flow/internal/ActionTabBar.tsx
@@ -1,7 +1,7 @@
 // Phase-3 (#1145): ProcessFlowEditor.tsx からアクションタブ + 検索 + ActionHelpPopover 統合を抽出。
 // 「コマンドバー」エリア全体 (アクション名 / 検索ボックス / タブ / popover / EditLevelToggle)。
 
-import type { ActionDefinition, ProcessFlow } from "../../../types/v3";
+import type { ActionDefinition, ProcessFlow, Maturity } from "../../../types/v3";
 import { MaturityBadge } from "../MaturityBadge";
 import { EditLevelToggle } from "../EditLevelToggle";
 import { ActionHelpPopover } from "./ActionHelpPopover";
@@ -23,7 +23,7 @@ export interface ActionTabBarProps {
   editLevel: import("../../../hooks/useEditLevel").EditLevel;
   onChangeEditLevel: (lv: import("../../../hooks/useEditLevel").EditLevel) => void;
   /** アクション maturity の更新 */
-  onChangeActionMaturity: (actionId: string, maturity: string) => void;
+  onChangeActionMaturity: (actionId: string, maturity: Maturity) => void;
   /** ActionHelpPopover */
   actionHelp: ActionHelpState | null;
   actionHelpTarget: ActionDefinition | null;

--- a/frontend/src/components/process-flow/internal/CanvasPane.tsx
+++ b/frontend/src/components/process-flow/internal/CanvasPane.tsx
@@ -27,7 +27,7 @@ export interface CanvasPaneProps {
   selectedIds: Set<string>;
   validationErrors: ValidationError[];
   editLevel: EditLevel;
-  stepListRef: RefObject<HTMLDivElement>;
+  stepListRef: RefObject<HTMLDivElement | null>;
   aiChips: UseAiContextChipsResult;
   aiPanelRef: RefObject<HTMLDivElement | null>;
   /** step 操作 */

--- a/frontend/src/components/process-flow/internal/EditorHeaderExtras.tsx
+++ b/frontend/src/components/process-flow/internal/EditorHeaderExtras.tsx
@@ -20,8 +20,8 @@ export interface EditorHeaderExtrasProps {
   onToggleDrawing: () => void;
   onToggleWarnings: () => void;
   onStartEditing: () => void;
-  onViewerAttached: () => void;
-  onAttachAsView: () => Promise<void>;
+  onViewerAttached: (editSessionId: string) => void;
+  onAttachAsView: (editSessionId: string) => Promise<void>;
   onTakeOver: () => Promise<void>;
 }
 


### PR DESCRIPTION
## 本 PR の変更要旨

`frontend/src/components/process-flow/ProcessFlowEditor.tsx` (1092 行) の `// @ts-nocheck` を除去し、全 TypeScript エラーを解消。

### 修正内容

**ProcessFlowEditor.tsx (主対象)**:
- `Uuid` / `LocalId` / `Timestamp` branded type cast: `generateUUID() as Uuid` / `generateUUID() as LocalId` / `new Date().toISOString() as Timestamp`
- `StepWithSubSteps` cast: `handleIndentStep` / `handleOutdentSubStep` / `handleDuplicateStep` / `handlePaste` の `subSteps` アクセス
- `viewerMode` 型キャスト: `mode.kind` を `useResourceEditor` の制限型 (`"viewer" | "editing" | "readonly"`) へ
- `ProcessFlowDialogs` の `choice unknown` → `as "continue" | "discard" | "adopt"` 型アサーション
- `tpl.steps ?? []`: `StepTemplate.steps` が optional のため undefined ガード追加
- import 追加: `getActionTriggerLabel` (未 import だった), `StepWithSubSteps`, `Uuid`, `LocalId`, `Timestamp`

**internal/ ファイル (pre-existing TS bug 同時解消)**:
- `EditorHeaderExtras.tsx`: `onViewerAttached` / `onAttachAsView` の prop 型を `EditSessionDropdown` 実際の型 (`(editSessionId: string) => void / Promise<void>`) に修正
- `ActionTabBar.tsx`: `onChangeActionMaturity` の `maturity` 型 `string` → `Maturity`
- `CanvasPane.tsx`: `stepListRef` 型 `RefObject<HTMLDivElement>` → `RefObject<HTMLDivElement | null>` (React 19 互換)

### 検出 silent bug (S-15 以降)

なし。静的事前調査通り、v3 非規範 field アクセスは検出されなかった。

---

## シリーズ全体のサマリ (Batch 1〜5c、全 26 file の @ts-nocheck 除去完了)

| Batch | PR | 対象 |
|---|---|---|
| 1 (Batch A) | #1238 | actionMigration.ts / processFlowStore.ts |
| 2 | #1239 | 共通型ガード export + step recursion 4 file |
| 3 | #1240 | 小型 panel/dialog 7 file |
| 4a | #1241 | StructuredFieldsEditor + 隣接 2 file + S-5 解消 |
| 4b | #1242 | 中型 panel 3 file (Canvas/Marker/Workflow) |
| 4c | #1243 | 大型 panel + test 3 file (TX/DrawingOverlay/step-cards.test) |
| 4d | #1244 | ValidationRulesPanel |
| 5a | #1245 | StepCard.tsx (大型) |
| 5b | #1246 | ProcessFlowListView.tsx (大型) |
| 5c | 本 PR | ProcessFlowEditor.tsx (最大、1092 行) |

---

## 検出 silent bug S-1〜S-14 一覧表

| ID | 場所 | 旧 | 新 |
|---|---|---|---|
| S-1 | stepSummaryText.ts case "externalSystem" | `step.protocol` | `step.httpCall?.method` |
| S-2 | specExporter.ts case "return" | `s.value` | `s.responseId` / `s.bodyExpression` |
| S-3 | specExporter.ts case "eventPublish"/"eventSubscribe" | `step.eventRef` | (削除 — v3 で廃止) |
| S-4 | specExporter.ts generateSpecJson | ProcessFlow flat-field access | `pfFlat()` ヘルパー (互換維持) |
| S-5 | ScreenItemPickerModal.v3TypeToV1 | `{ kind: "custom", ... }` に degrade | v3 FieldType そのまま通過 |
| S-6 | AmbientVariablesPanel | `v.type.kind === "custom"` | `kind: "domain"` + `domainKey` |
| S-7 | ExternalOutcomesPanel.addSideEffect | `type: "other"` + level/message 欠落 | `kind: "log"` + `level: "info"` + `message: ""` |
| S-8 | ExternalSystemCatalogPanel auth.kind | TS 型 5 値、schema 7 値 | 局所 cast で UI 7 値維持 (TS 型同期は別 ISSUE 候補) |
| S-9 | MarkerPanel.tsx KIND_LABELS/KIND_ICONS | `validator` キー欠落 | `validator: "バリデーター"` 等追加 |
| S-10 | WorkflowStepPanel fallbackStepList | `{ type: "other", description: "", maturity: "draft" }` | `{ kind: "log", level: "info", message: "", ... }` |
| S-11 | WorkflowStepPanel quorum.type | UI value `"n-of-m"` (TS は `"nOfM"`) | `"nOfM"` に統一 |
| S-12 | DrawingOverlay.tsx | `marker.shape` トップレベル | `marker.anchor?.shape` nested |
| S-13 | StepCard.tsx「メモ」textarea | `step.note: string` (v2 legacy) | dead textarea 除去 |
| S-14 | StepCard.tsx outputBinding | `outputBinding: name` (string 短縮) | `outputBinding: { name }` object |

---

## deferred / follow-up 候補

- `actionTriggerConstants.ts:179` の `legacyMarker.stepId` 系 read fallback — 本 PR スコープ外、別 ISSUE 起票候補

---

## 検証結果

- `npm run build`: 0 errors (warnings は既存)
- `npm run test:unit`: 173 test files / 2369 tests all passed
- `git diff origin/main..HEAD -- schemas/`: 空 (#511 governance OK)
- `grep -c '^// @ts-nocheck' frontend/src/components/process-flow/ProcessFlowEditor.tsx`: 0

## シリーズ最終確認

```
find frontend/src -type f \( -name '*.ts' -o -name '*.tsx' \) -exec grep -l '^// @ts-nocheck' {} \;
```

結果: **空 (残ファイルゼロ)** — シリーズ全 26 file 完了

---

Closes #1233