### PR TITLE
improve(types): ExternalAuth.kind を 7 値に同期 (#1249)

### DIFF
--- a/frontend/src/components/process-flow/ExternalSystemCatalogPanel.tsx
+++ b/frontend/src/components/process-flow/ExternalSystemCatalogPanel.tsx
@@ -79,9 +79,7 @@ export function ExternalSystemCatalogPanel({ group, onChange, expanded: expanded
           {keys.length === 0 && <div className="catalog-empty">まだエントリがありません。</div>}
           {keys.map((k) => {
             const e = catalog[k];
-            // S-8 note: ExternalAuth.kind が "iamRole"/"azureAd" を含む ExternalAuthKind より狭いため
-            // 局所キャストで UI 機能 (7 auth kind) を維持する (#1233 Batch 4a)
-            const auth = (e.auth ?? { kind: "none" }) as { kind: ExternalAuthKind; tokenRef?: string; headerName?: string };
+            const auth: ExternalAuth = e.auth ?? { kind: "none" };
             return (
               <div className="catalog-row" key={k}>
                 <div className="catalog-row-header">
@@ -129,7 +127,7 @@ export function ExternalSystemCatalogPanel({ group, onChange, expanded: expanded
                     <select
                       className="form-select form-select-sm"
                       value={auth.kind}
-                      onChange={(ev) => updateEntry(k, { auth: { ...auth, kind: ev.target.value as ExternalAuthKind } as ExternalAuth })}
+                      onChange={(ev) => updateEntry(k, { auth: { ...auth, kind: ev.target.value as ExternalAuthKind } })}
                     >
                       {AUTH_KINDS.map((a) => <option key={a} value={a}>{a}</option>)}
                     </select>
@@ -140,7 +138,7 @@ export function ExternalSystemCatalogPanel({ group, onChange, expanded: expanded
                       <select
                         className="form-select form-select-sm"
                         value={auth.tokenRef ?? ""}
-                        onChange={(ev) => updateEntry(k, { auth: { ...auth, tokenRef: ev.target.value || undefined } as ExternalAuth })}
+                        onChange={(ev) => updateEntry(k, { auth: { ...auth, tokenRef: ev.target.value || undefined } })}
                       >
                         <option value="">—</option>
                         {secretKeys.map((s) => <option key={s} value={`@secret.${s}`}>@secret.{s}</option>)}
@@ -149,7 +147,7 @@ export function ExternalSystemCatalogPanel({ group, onChange, expanded: expanded
                       <input
                         className="form-control form-control-sm"
                         value={auth.tokenRef ?? ""}
-                        onChange={(ev) => updateEntry(k, { auth: { ...auth, tokenRef: ev.target.value || undefined } as ExternalAuth })}
+                        onChange={(ev) => updateEntry(k, { auth: { ...auth, tokenRef: ev.target.value || undefined } })}
                         placeholder="ENV:STRIPE_SECRET_KEY or @secret.X"
                       />
                     )}

--- a/frontend/src/types/v3/index.ts
+++ b/frontend/src/types/v3/index.ts
@@ -79,9 +79,6 @@ export type ProcessFlowMode = Mode;
 export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
 export type HttpAuthRequirement = "required" | "optional" | "none";
 
-// ── External Auth Kind (process-flow.v3 ExternalAuth.kind enum、frontend type alias) ──
-export type ExternalAuthKind = "bearer" | "basic" | "apiKey" | "oauth2" | "iamRole" | "azureAd" | "none";
-
 // ── Loop kind / condition mode (process-flow.v3 LoopStep と完全一致、#1186 Phase 1 で整合済) ──
 export type LoopKind = "count" | "condition" | "collection";
 export type LoopConditionMode = "continue" | "exit";

--- a/frontend/src/types/v3/process-flow.ts
+++ b/frontend/src/types/v3/process-flow.ts
@@ -107,9 +107,13 @@ export interface ErrorCatalogEntry {
   exceptionTypeRef?: string;
 }
 
+/** 外部システム認証種別 (process-flow.v3 ExternalAuth.kind enum と完全一致、7 値)。
+ *  iamRole / azureAd は #867 / #939 で AWS Bedrock / Azure OpenAI 認証用に追加。 */
+export type ExternalAuthKind = "bearer" | "basic" | "apiKey" | "oauth2" | "iamRole" | "azureAd" | "none";
+
 /** 外部システム認証定義 (旧 ENV: / SECRET: 形式は v3 廃止、@secret.<key> 推奨)。 */
 export interface ExternalAuth {
-  kind: "bearer" | "basic" | "apiKey" | "oauth2" | "none";
+  kind: ExternalAuthKind;
   /** `@secret.<key>` 推奨。 */
   tokenRef?: string;
   headerName?: string;


### PR DESCRIPTION
## Summary
- `ExternalAuthKind` 型を `process-flow.ts` 内に定義し、schema の 7 値 (bearer/basic/apiKey/oauth2/iamRole/azureAd/none) と完全同期
- `index.ts` の重複 `ExternalAuthKind` 定義を削除 (`export * from "./process-flow"` 経由で re-export)
- `ExternalSystemCatalogPanel.tsx` の局所キャスト 4 箇所を削除し型安全性を改善 (S-8 note コメントも除去)

## 検証
- `npm run build`: 0 errors (tsc -b + vite build 両方通過)
- `npm run test:unit -- --run`: 173 test files / 2369 tests 全 pass (baseline 維持)
- `git diff origin/main..HEAD -- schemas/`: 差分なし (schema 変更なし、#511 ガバナンス準拠)

Closes #1249

🤖 Generated with [Claude Code](https://claude.com/claude-code)