### PR TITLE
fix(examples): release pre-check D fix-iter-1 — 5 examples drift 17 件解消 (#1252)

### DIFF
--- a/examples/diary/harmony/process-flows/0671b051-4acc-49cf-ba92-9fa29b47f671.json
+++ b/examples/diary/harmony/process-flows/0671b051-4acc-49cf-ba92-9fa29b47f671.json
@@ -7,7 +7,7 @@
     "kind": "screen",
     "maturity": "draft",
     "createdAt": "2026-05-06T12:40:00.000Z",
-    "updatedAt": "2026-05-06T14:00:00.000Z",
+    "updatedAt": "2026-05-22T00:00:00.000Z",
     "screenId": "531619ae-0f5f-4f55-8043-03e5a9ef6670"
   },
   "context": {
@@ -271,131 +271,163 @@
         },
         {
           "id": "step-03",
-          "kind": "dbAccess",
-          "description": "posts テーブルに新規投稿を INSERT する。",
-          "tableId": "79d2c08c-7511-4d37-9051-e6f4587630e0",
-          "operation": "INSERT",
-          "sql": "INSERT INTO posts (user_id, title, body, mood, weather, location, status, published_at, created_at, updated_at) VALUES (@sessionUserId, @inputs.title, @inputs.body, @inputs.mood, @inputs.weather, @inputs.location, COALESCE(@inputs.status, 'draft'), @publishedAt, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP) RETURNING id AS \"postId\"",
+          "kind": "transactionScope",
+          "description": "posts / photos / post_tags / tags.usage_count の登録を 1 TX で原子的に実行する。TX 失敗時は全体をロールバックし @txResult に結果を expose する。POST_CREATE_FAILED / UNIQUE_VIOLATION はロールバックトリガーとして列挙する。",
+          "isolationLevel": "READ_COMMITTED",
+          "propagation": "REQUIRED",
+          "rollbackOn": [
+            "POST_CREATE_FAILED",
+            "UNIQUE_VIOLATION"
+          ],
           "outputBinding": {
-            "name": "newPost"
+            "name": "txResult"
           },
-          "affectedRowsCheck": {
-            "operator": "=",
-            "expected": 1,
-            "onViolation": "throw",
-            "errorCode": "POST_CREATE_FAILED"
-          },
-          "lineage": {
-            "writes": [
-              {
-                "tableId": "79d2c08c-7511-4d37-9051-e6f4587630e0",
-                "purpose": "insert"
-              }
-            ]
-          }
-        },
-        {
-          "id": "step-04",
-          "kind": "loop",
-          "description": "photos[] の各要素を photos テーブルに INSERT する。",
-          "loopKind": "collection",
-          "collectionSource": "@inputs.photos",
-          "collectionItemName": "photo",
           "steps": [
             {
-              "id": "step-04-01",
+              "id": "step-03-01",
               "kind": "dbAccess",
-              "description": "photos テーブルに写真を INSERT する。",
-              "tableId": "d8fc5f8a-9cd2-4e46-9f3d-03c337ae0e9f",
+              "description": "posts テーブルに新規投稿を INSERT する。",
+              "tableId": "79d2c08c-7511-4d37-9051-e6f4587630e0",
               "operation": "INSERT",
-              "sql": "INSERT INTO photos (post_id, url, thumbnail_url, alt, caption, order_index, width, height, exif_json, created_at) VALUES (@newPost.postId, @photo.url, @photo.thumbnail_url, @photo.alt, @photo.caption, COALESCE(@photo.order_index, 0), @photo.width, @photo.height, @photo.exif_json, CURRENT_TIMESTAMP)",
-              "lineage": {
-                "writes": [
-                  {
-                    "tableId": "d8fc5f8a-9cd2-4e46-9f3d-03c337ae0e9f",
-                    "purpose": "insert"
-                  }
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "id": "step-05",
-          "kind": "loop",
-          "description": "tags[] の各タグを post_tags に関連付ける。タグ ID が指定されていない場合は tags テーブルの slug で検索し、なければ新規 INSERT する。",
-          "loopKind": "collection",
-          "collectionSource": "@inputs.tags",
-          "collectionItemName": "tag",
-          "steps": [
-            {
-              "id": "step-05-01",
-              "kind": "dbAccess",
-              "description": "タグ名から既存タグを検索する (id 未指定の場合)。",
-              "tableId": "07439e21-0743-48ca-af9e-763e4be2d094",
-              "operation": "SELECT",
-              "sql": "SELECT id AS \"tagId\" FROM tags WHERE name = @tag.name LIMIT 1",
-              "runIf": "@tag.id == null",
+              "sql": "INSERT INTO posts (user_id, title, body, mood, weather, location, status, published_at, created_at, updated_at) VALUES (@sessionUserId, @inputs.title, @inputs.body, @inputs.mood, @inputs.weather, @inputs.location, COALESCE(@inputs.status, 'draft'), @publishedAt, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP) RETURNING id AS \"postId\"",
               "outputBinding": {
-                "name": "existingTag"
-              },
-              "lineage": {
-                "reads": [
-                  {
-                    "tableId": "07439e21-0743-48ca-af9e-763e4be2d094",
-                    "purpose": "lookup"
-                  }
-                ]
-              }
-            },
-            {
-              "id": "step-05-02",
-              "kind": "dbAccess",
-              "description": "既存タグが見つからない場合は新規 INSERT する。slug は UNIQUE 制約がありロール競合の場合は affectedRowsCheck でハンドリングする。",
-              "tableId": "07439e21-0743-48ca-af9e-763e4be2d094",
-              "operation": "INSERT",
-              "sql": "INSERT INTO tags (name, slug, usage_count, created_at) VALUES (@tag.name, LOWER(REPLACE(@tag.name, ' ', '-')), 0, CURRENT_TIMESTAMP) RETURNING id AS \"tagId\"",
-              "runIf": "@tag.id == null && @existingTag == null",
-              "outputBinding": {
-                "name": "newTag"
+                "name": "newPost"
               },
               "affectedRowsCheck": {
                 "operator": "=",
                 "expected": 1,
-                "onViolation": "log",
-                "errorCode": "UNIQUE_VIOLATION",
-                "description": "UNIQUE 制約違反 (slug 重複) の場合 0 行になるため log して続行。step-05-01 で事前チェック済みだが競合が起きた場合の安全装置。"
+                "onViolation": "throw",
+                "errorCode": "POST_CREATE_FAILED"
               },
               "lineage": {
                 "writes": [
                   {
-                    "tableId": "07439e21-0743-48ca-af9e-763e4be2d094",
+                    "tableId": "79d2c08c-7511-4d37-9051-e6f4587630e0",
                     "purpose": "insert"
                   }
                 ]
               }
             },
             {
-              "id": "step-05-03",
-              "kind": "compute",
-              "description": "使用するタグ ID を解決する: inputs.tag.id > existingTag.tagId > newTag.tagId の優先順で決定。",
-              "expression": "@tag.id ?? @existingTag.tagId ?? @newTag.tagId",
-              "outputBinding": {
-                "name": "resolvedTagId"
-              }
+              "id": "step-03-02",
+              "kind": "loop",
+              "description": "photos[] の各要素を photos テーブルに INSERT する。",
+              "loopKind": "collection",
+              "collectionSource": "@inputs.photos",
+              "collectionItemName": "photo",
+              "steps": [
+                {
+                  "id": "step-03-02-01",
+                  "kind": "dbAccess",
+                  "description": "photos テーブルに写真を INSERT する。",
+                  "tableId": "d8fc5f8a-9cd2-4e46-9f3d-03c337ae0e9f",
+                  "operation": "INSERT",
+                  "sql": "INSERT INTO photos (post_id, url, thumbnail_url, alt, caption, order_index, width, height, exif_json, created_at) VALUES (@newPost.postId, @photo.url, @photo.thumbnail_url, @photo.alt, @photo.caption, COALESCE(@photo.order_index, 0), @photo.width, @photo.height, @photo.exif_json, CURRENT_TIMESTAMP)",
+                  "lineage": {
+                    "writes": [
+                      {
+                        "tableId": "d8fc5f8a-9cd2-4e46-9f3d-03c337ae0e9f",
+                        "purpose": "insert"
+                      }
+                    ]
+                  }
+                }
+              ]
             },
             {
-              "id": "step-05-04",
+              "id": "step-03-03",
+              "kind": "loop",
+              "description": "tags[] の各タグを post_tags に関連付ける。タグ ID が指定されていない場合は tags テーブルの slug で検索し、なければ新規 INSERT する。",
+              "loopKind": "collection",
+              "collectionSource": "@inputs.tags",
+              "collectionItemName": "tag",
+              "steps": [
+                {
+                  "id": "step-03-03-01",
+                  "kind": "dbAccess",
+                  "description": "タグ名から既存タグを検索する (id 未指定の場合)。",
+                  "tableId": "07439e21-0743-48ca-af9e-763e4be2d094",
+                  "operation": "SELECT",
+                  "sql": "SELECT id AS \"tagId\" FROM tags WHERE name = @tag.name LIMIT 1",
+                  "runIf": "@tag.id == null",
+                  "outputBinding": {
+                    "name": "existingTag"
+                  },
+                  "lineage": {
+                    "reads": [
+                      {
+                        "tableId": "07439e21-0743-48ca-af9e-763e4be2d094",
+                        "purpose": "lookup"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "id": "step-03-03-02",
+                  "kind": "dbAccess",
+                  "description": "既存タグが見つからない場合は新規 INSERT する。slug は UNIQUE 制約がありロール競合の場合は affectedRowsCheck でハンドリングする。",
+                  "tableId": "07439e21-0743-48ca-af9e-763e4be2d094",
+                  "operation": "INSERT",
+                  "sql": "INSERT INTO tags (name, slug, usage_count, created_at) VALUES (@tag.name, LOWER(REPLACE(@tag.name, ' ', '-')), 0, CURRENT_TIMESTAMP) RETURNING id AS \"tagId\"",
+                  "runIf": "@tag.id == null && @existingTag == null",
+                  "outputBinding": {
+                    "name": "newTag"
+                  },
+                  "affectedRowsCheck": {
+                    "operator": "=",
+                    "expected": 1,
+                    "onViolation": "log",
+                    "errorCode": "UNIQUE_VIOLATION",
+                    "description": "UNIQUE 制約違反 (slug 重複) の場合 0 行になるため log して続行。step-03-03-01 で事前チェック済みだが競合が起きた場合の安全装置。"
+                  },
+                  "lineage": {
+                    "writes": [
+                      {
+                        "tableId": "07439e21-0743-48ca-af9e-763e4be2d094",
+                        "purpose": "insert"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "id": "step-03-03-03",
+                  "kind": "compute",
+                  "description": "使用するタグ ID を解決する: inputs.tag.id > existingTag.tagId > newTag.tagId の優先順で決定。",
+                  "expression": "@tag.id ?? @existingTag.tagId ?? @newTag.tagId",
+                  "outputBinding": {
+                    "name": "resolvedTagId"
+                  }
+                },
+                {
+                  "id": "step-03-03-04",
+                  "kind": "dbAccess",
+                  "description": "post_tags に投稿とタグの関連を INSERT する。",
+                  "tableId": "1681eee2-39d9-4548-9044-5cedac68d41e",
+                  "operation": "INSERT",
+                  "sql": "INSERT INTO post_tags (post_id, tag_id, source, confidence, created_at) VALUES (@newPost.postId, @resolvedTagId, COALESCE(@tag.source, 'manual'), COALESCE(@tag.confidence, 1.0), CURRENT_TIMESTAMP)",
+                  "lineage": {
+                    "writes": [
+                      {
+                        "tableId": "1681eee2-39d9-4548-9044-5cedac68d41e",
+                        "purpose": "insert"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "id": "step-03-04",
               "kind": "dbAccess",
-              "description": "post_tags に投稿とタグの関連を INSERT する。",
-              "tableId": "1681eee2-39d9-4548-9044-5cedac68d41e",
-              "operation": "INSERT",
-              "sql": "INSERT INTO post_tags (post_id, tag_id, source, confidence, created_at) VALUES (@newPost.postId, @resolvedTagId, COALESCE(@tag.source, 'manual'), COALESCE(@tag.confidence, 1.0), CURRENT_TIMESTAMP)",
+              "description": "tags.usage_count を更新する (TX 内 commit 前の最後の DB UPDATE)。",
+              "tableId": "07439e21-0743-48ca-af9e-763e4be2d094",
+              "operation": "UPDATE",
+              "sql": "UPDATE tags SET usage_count = usage_count + 1 WHERE id IN (SELECT tag_id AS \"tagId\" FROM post_tags WHERE post_id = @newPost.postId)",
               "lineage": {
                 "writes": [
                   {
-                    "tableId": "1681eee2-39d9-4548-9044-5cedac68d41e",
-                    "purpose": "insert"
+                    "tableId": "07439e21-0743-48ca-af9e-763e4be2d094",
+                    "purpose": "update"
                   }
                 ]
               }
@@ -403,27 +435,20 @@
           ]
         },
         {
-          "id": "step-06",
-          "kind": "dbAccess",
-          "description": "posts 作成 TX の最終ステップとして tags.usage_count を更新する (transactionScope.steps[] 内、commit 前の最後の DB UPDATE)。",
-          "tableId": "07439e21-0743-48ca-af9e-763e4be2d094",
-          "operation": "UPDATE",
-          "sql": "UPDATE tags SET usage_count = usage_count + 1 WHERE id IN (SELECT tag_id AS \"tagId\" FROM post_tags WHERE post_id = @newPost.postId)",
-          "lineage": {
-            "writes": [
-              {
-                "tableId": "07439e21-0743-48ca-af9e-763e4be2d094",
-                "purpose": "update"
-              }
-            ]
-          }
-        },
-        {
           "id": "step-07",
           "kind": "return",
-          "description": "201 作成成功を返す。",
+          "runIf": "@txResult.committed == true",
+          "description": "201 作成成功を返す。TX コミット後にのみ実行する。",
           "responseId": "201-created",
           "bodyExpression": "{ postId: @newPost.postId }"
+        },
+        {
+          "id": "step-08",
+          "kind": "return",
+          "runIf": "@txResult.committed != true",
+          "description": "500 内部エラーを返す。TX ロールバック時にのみ実行する。",
+          "responseId": "500-internal",
+          "bodyExpression": "{ code: 'POST_CREATE_FAILED', message: '投稿の作成に失敗しました。しばらく経ってから再度お試しください。' }"
         }
       ]
     }

--- a/examples/diary/harmony/process-flows/c4d5e6f7-a8b9-4c0d-8e1f-2a3b4c5d6e7f.json
+++ b/examples/diary/harmony/process-flows/c4d5e6f7-a8b9-4c0d-8e1f-2a3b4c5d6e7f.json
@@ -3,11 +3,11 @@
   "meta": {
     "id": "c4d5e6f7-a8b9-4c0d-8e1f-2a3b4c5d6e7f",
     "name": "投稿削除",
-    "description": "既存投稿を削除する処理フロー。所有者検証後、photos / post_tags / posts を順に DELETE する (FK CASCADE 想定だが明示的に削除順序を記述)。",
+    "description": "既存投稿を削除する処理フロー。所有者検証後、photos / post_tags / posts を 1 TX 内で順に DELETE する (FK CASCADE 想定だが明示的に削除順序を記述)。TX 失敗時は全体をロールバックする。",
     "kind": "common",
     "maturity": "draft",
     "createdAt": "2026-05-06T14:00:00.000Z",
-    "updatedAt": "2026-05-06T14:00:00.000Z"
+    "updatedAt": "2026-05-22T00:00:00.000Z"
   },
   "context": {
     "catalogs": {
@@ -29,6 +29,12 @@
           "defaultMessage": "投稿が見つかりません。",
           "responseId": "404-not-found",
           "description": "指定された postId の投稿が存在しない場合。"
+        },
+        "POST_DELETE_FAILED": {
+          "httpStatus": 422,
+          "defaultMessage": "投稿の削除に失敗しました。",
+          "responseId": "422-delete-failed",
+          "description": "TX ロールバックが発生した場合の catch-all エラー。photos / post_tags / posts のいずれかの DELETE が失敗した場合に TX 全体がロールバックされ 422 を返す。"
         }
       }
     },
@@ -46,7 +52,7 @@
       "id": "act-001",
       "name": "投稿削除",
       "trigger": "submit",
-      "description": "postId で既存投稿を特定し、所有者検証後に photos / post_tags / posts を順に DELETE する。",
+      "description": "postId で既存投稿を特定し、所有者検証後に photos / post_tags / posts を 1 TX 内で順に DELETE する。",
       "maturity": "draft",
       "httpRoute": {
         "method": "DELETE",
@@ -68,7 +74,7 @@
           "id": "204-no-content",
           "status": 204,
           "description": "投稿削除成功。",
-          "when": "全 DELETE が正常完了した場合。"
+          "when": "全 DELETE が正常完了し TX がコミットされた場合。"
         },
         {
           "id": "401-unauthorized",
@@ -87,6 +93,12 @@
           "status": 404,
           "description": "投稿が存在しない。",
           "when": "指定 postId の投稿が見つからない場合。"
+        },
+        {
+          "id": "422-delete-failed",
+          "status": 422,
+          "description": "投稿削除 TX 失敗。TX はロールバック済み。",
+          "when": "photos / post_tags / posts のいずれかの DELETE が失敗し TX がロールバックされた場合。"
         }
       ],
       "steps": [
@@ -173,63 +185,87 @@
         },
         {
           "id": "step-04",
-          "kind": "dbAccess",
-          "description": "photos テーブルから該当投稿の写真を全削除する。",
-          "tableId": "d8fc5f8a-9cd2-4e46-9f3d-03c337ae0e9f",
-          "operation": "DELETE",
-          "sql": "DELETE FROM photos WHERE post_id = @inputs.postId",
-          "lineage": {
-            "writes": [
-              {
-                "tableId": "d8fc5f8a-9cd2-4e46-9f3d-03c337ae0e9f",
-                "purpose": "soft-delete"
-              }
-            ]
-          }
-        },
-        {
-          "id": "step-05",
-          "kind": "dbAccess",
-          "description": "post_tags テーブルから該当投稿のタグ関連を全削除する。",
-          "tableId": "1681eee2-39d9-4548-9044-5cedac68d41e",
-          "operation": "DELETE",
-          "sql": "DELETE FROM post_tags WHERE post_id = @inputs.postId",
-          "lineage": {
-            "writes": [
-              {
-                "tableId": "1681eee2-39d9-4548-9044-5cedac68d41e",
-                "purpose": "soft-delete"
-              }
-            ]
-          }
-        },
-        {
-          "id": "step-06",
-          "kind": "dbAccess",
-          "description": "posts テーブルから該当投稿を削除する。",
-          "tableId": "79d2c08c-7511-4d37-9051-e6f4587630e0",
-          "operation": "DELETE",
-          "sql": "DELETE FROM posts WHERE id = @inputs.postId",
-          "affectedRowsCheck": {
-            "operator": "=",
-            "expected": 1,
-            "onViolation": "throw",
-            "errorCode": "POST_NOT_FOUND"
+          "kind": "transactionScope",
+          "description": "photos / post_tags / posts の DELETE を 1 TX で原子的に実行する。TX 失敗時は全体をロールバックし @txResult に結果を expose する。POST_DELETE_FAILED はロールバックトリガーとして列挙する。",
+          "isolationLevel": "READ_COMMITTED",
+          "propagation": "REQUIRED",
+          "rollbackOn": [
+            "POST_DELETE_FAILED"
+          ],
+          "outputBinding": {
+            "name": "txResult"
           },
-          "lineage": {
-            "writes": [
-              {
-                "tableId": "79d2c08c-7511-4d37-9051-e6f4587630e0",
-                "purpose": "soft-delete"
+          "steps": [
+            {
+              "id": "step-04-01",
+              "kind": "dbAccess",
+              "description": "photos テーブルから該当投稿の写真を全削除する。",
+              "tableId": "d8fc5f8a-9cd2-4e46-9f3d-03c337ae0e9f",
+              "operation": "DELETE",
+              "sql": "DELETE FROM photos WHERE post_id = @inputs.postId",
+              "lineage": {
+                "writes": [
+                  {
+                    "tableId": "d8fc5f8a-9cd2-4e46-9f3d-03c337ae0e9f",
+                    "purpose": "soft-delete"
+                  }
+                ]
               }
-            ]
-          }
+            },
+            {
+              "id": "step-04-02",
+              "kind": "dbAccess",
+              "description": "post_tags テーブルから該当投稿のタグ関連を全削除する。",
+              "tableId": "1681eee2-39d9-4548-9044-5cedac68d41e",
+              "operation": "DELETE",
+              "sql": "DELETE FROM post_tags WHERE post_id = @inputs.postId",
+              "lineage": {
+                "writes": [
+                  {
+                    "tableId": "1681eee2-39d9-4548-9044-5cedac68d41e",
+                    "purpose": "soft-delete"
+                  }
+                ]
+              }
+            },
+            {
+              "id": "step-04-03",
+              "kind": "dbAccess",
+              "description": "posts テーブルから該当投稿を削除する。",
+              "tableId": "79d2c08c-7511-4d37-9051-e6f4587630e0",
+              "operation": "DELETE",
+              "sql": "DELETE FROM posts WHERE id = @inputs.postId",
+              "affectedRowsCheck": {
+                "operator": "=",
+                "expected": 1,
+                "onViolation": "throw",
+                "errorCode": "POST_DELETE_FAILED"
+              },
+              "lineage": {
+                "writes": [
+                  {
+                    "tableId": "79d2c08c-7511-4d37-9051-e6f4587630e0",
+                    "purpose": "soft-delete"
+                  }
+                ]
+              }
+            }
+          ]
         },
         {
           "id": "step-07",
           "kind": "return",
-          "description": "204 削除成功を返す。",
+          "runIf": "@txResult.committed == true",
+          "description": "204 削除成功を返す。TX コミット後にのみ実行する。",
           "responseId": "204-no-content"
+        },
+        {
+          "id": "step-08",
+          "kind": "return",
+          "runIf": "@txResult.committed != true",
+          "description": "422 投稿削除失敗を返す。TX ロールバック時にのみ実行する。",
+          "responseId": "422-delete-failed",
+          "bodyExpression": "{ code: 'POST_DELETE_FAILED', message: '投稿の削除に失敗しました。しばらく経ってから再度お試しください。' }"
         }
       ]
     }

--- a/examples/english-learning-tailwind/README.md
+++ b/examples/english-learning-tailwind/README.md
@@ -87,7 +87,7 @@ npm run dev
 `examples/**/*.json` は schema 検証 test に組み込まれる。schema 進化時に本サンプルが breakage したら CI で検出。
 
 ```bash
-npm --prefix designer run validate:samples -- ../examples/english-learning-tailwind
+cd frontend && npm run validate:samples -- ../examples/english-learning-tailwind
 ```
 
 ## 関連

--- a/examples/english-learning-tailwind/README.md
+++ b/examples/english-learning-tailwind/README.md
@@ -90,6 +90,10 @@ npm run dev
 cd frontend && npm run validate:samples -- ../examples/english-learning-tailwind
 ```
 
+## generated/ の Prisma provider について
+
+注: `generated/` は #1038 dogfood の test fixture で Prisma provider に sqlite を採用 (test 高速化用)。本番 techStack の postgresql は別途 `/generate-code` で再生成する想定。`harmony.json` の techStack 宣言 (postgresql) が spec source として正しく、`generated/` の sqlite はテスト用の仮実装です。
+
 ## 関連
 
 - 親メタ: #793 (CSS フレームワーク切替対応)

--- a/examples/english-learning-tailwind/harmony/process-flows/21c25fb2-551a-483f-b32a-060db8f88aee.json
+++ b/examples/english-learning-tailwind/harmony/process-flows/21c25fb2-551a-483f-b32a-060db8f88aee.json
@@ -211,7 +211,7 @@
         {
           "id": "step-04",
           "kind": "dbAccess",
-          "description": "user_word_progress を UPSERT する (english-learning:UPSERT_WORD_PROGRESS)。新規の場合は status='new' で INSERT、既存の場合は correct_count / attempt_count / status / last_practiced_at を更新する。mastery 閾値 (conventions.extensionCategories.wordProgress.masteryThreshold = 3) 以上の連続正解で status='mastered' に昇格する。",
+          "description": "user_word_progress を UPSERT する (english-learning:UPSERT_WORD_PROGRESS)。新規の場合は status='new' で INSERT、既存の場合は correct_count / attempt_count / status / last_practiced_at を更新する。mastery 閾値 (@conv.wordProgress.masteryThreshold) 以上の連続正解で status='mastered' に昇格する。",
           "tableId": "7ab2cf24-7b66-47aa-a808-7fffd8290480",
           "operation": "english-learning:UPSERT_WORD_PROGRESS",
           "sql": "INSERT INTO user_word_progress (user_id, word_id, status, correct_count, attempt_count, last_practiced_at, updated_at) VALUES (@sessionUserId, @wordId, 'new', CASE WHEN @isCorrect THEN 1 ELSE 0 END, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP) ON CONFLICT (user_id, word_id) DO UPDATE SET attempt_count = user_word_progress.attempt_count + 1, correct_count = CASE WHEN @isCorrect THEN user_word_progress.correct_count + 1 ELSE user_word_progress.correct_count END, status = CASE WHEN @isCorrect AND (user_word_progress.correct_count + 1) >= @conv.wordProgress.masteryThreshold THEN 'mastered' WHEN user_word_progress.status != 'mastered' THEN 'learning' ELSE user_word_progress.status END, last_practiced_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP RETURNING id AS \"id\", status AS \"status\", correct_count AS \"correctCount\", attempt_count AS \"attemptCount\"",

--- a/examples/english-learning-tailwind/harmony/process-flows/6a49b14b-eb90-45bd-9df0-df4b5986626b.json
+++ b/examples/english-learning-tailwind/harmony/process-flows/6a49b14b-eb90-45bd-9df0-df4b5986626b.json
@@ -357,6 +357,12 @@
           },
           "outputBinding": {
             "name": "evalResult"
+          },
+          "outcomes": {
+            "failure": {
+              "action": "abort",
+              "description": "STT API 失敗時は abort。502-stt-failed カタログエントリに対応。"
+            }
           }
         },
         {
@@ -435,7 +441,7 @@
           "id": "step-08",
           "kind": "return",
           "runIf": "@txResult.committed == true",
-          "description": "201 Created — scoreId + score + diff を返す。TX コミット後にのみ実行する。score が合格ライン (conventions.extensionCategories.cefr.passingThreshold 参照) を下回る場合、UI 側でメッセージを表示する。",
+          "description": "201 Created — scoreId + score + diff を返す。TX コミット後にのみ実行する。score が合格ライン (@conv.cefr.passingThreshold 参照) を下回る場合、UI 側でメッセージを表示する。",
           "responseId": "201-created",
           "bodyExpression": "{ scoreId: @newScore.id, score: @pronunciationScore, diff: @evalResult.diff }"
         },

--- a/examples/english-learning-tailwind/harmony/process-flows/96118ae1-a0ab-401b-8584-dd645a45a81f.json
+++ b/examples/english-learning-tailwind/harmony/process-flows/96118ae1-a0ab-401b-8584-dd645a45a81f.json
@@ -90,9 +90,9 @@
         {
           "name": "turnContext",
           "label": "会話コンテキスト",
-          "type": "string",
+          "type": { "kind": "array", "itemType": { "kind": "extension", "extensionRef": "english-learning:dialogTurn" } },
           "required": false,
-          "description": "直近の会話履歴 (DialogTurn[] の JSON 文字列)。aiCall step の user メッセージ content に埋め込んで LLM へ渡す。"
+          "description": "直近の会話履歴 (DialogTurn 配列)。aiCall step の messages 内 spread item で role 別に展開し、LLM API に構造的に渡す (#939)。"
         },
         {
           "name": "generateAudio",

--- a/examples/english-learning-tailwind/harmony/screens/046e1f83-bed3-4b13-a5ac-b0fa06744dfe.json
+++ b/examples/english-learning-tailwind/harmony/screens/046e1f83-bed3-4b13-a5ac-b0fa06744dfe.json
@@ -56,7 +56,18 @@
       "label": "学習を開始する",
       "type": "string",
       "direction": "input",
-      "description": "クリック時に start-session 処理フローを実行し、learning_sessions レコードを作成してから会話プレイ画面 (/learn/:sessionId) へ遷移する。"
+      "description": "クリック時に start-session 処理フローを実行し、learning_sessions レコードを作成してから会話プレイ画面 (/learn/:sessionId) へ遷移する。",
+      "events": [
+        {
+          "id": "click",
+          "label": "セッション開始ボタンクリック",
+          "handlerFlowId": "cc173367-d92a-4525-acc9-689bad9a048e",
+          "handlerActionId": "act-001",
+          "argumentMapping": {
+            "storyId": "@routeParam.storyId"
+          }
+        }
+      ]
     }
   ],
   "design": {

--- a/examples/english-learning-tailwind/harmony/screens/297e9117-0982-4a40-9ce7-bced3bc6d2c5.json
+++ b/examples/english-learning-tailwind/harmony/screens/297e9117-0982-4a40-9ce7-bced3bc6d2c5.json
@@ -30,9 +30,9 @@
     {
       "id": "sessionList",
       "label": "学習セッション一覧",
-      "type": "json",
-      "direction": "output",
-      "description": "フィルタ条件で絞り込んだ learning_sessions 一覧 (JSON 配列)。各行に story_title / started_at / status / 総合スコアを含む。"
+      "direction": "viewer",
+      "viewDefinitionId": "4c9cdc85-2537-4ca8-a979-4de21a56e0fa",
+      "description": "フィルタ条件で絞り込んだ learning_sessions 一覧。学習履歴一覧 viewer (4c9cdc85) の列定義に従い story_title / started_at / status / 総合スコアを表示する。"
     }
   ],
   "design": {

--- a/examples/english-learning-tailwind/harmony/screens/5f411f06-8677-4fa8-a9b2-edc14a1d9ce1.json
+++ b/examples/english-learning-tailwind/harmony/screens/5f411f06-8677-4fa8-a9b2-edc14a1d9ce1.json
@@ -49,9 +49,9 @@
     {
       "id": "storyList",
       "label": "ストーリー一覧",
-      "type": "json",
-      "direction": "output",
-      "description": "フィルタ条件で絞り込んだ stories 一覧 (JSON 配列)。各行に title / cefr_level / scene_count / 未完了フラグを含む。"
+      "direction": "viewer",
+      "viewDefinitionId": "cfdbf081-368d-4a33-8a36-1c7a0c535011",
+      "description": "フィルタ条件で絞り込んだ stories 一覧。ストーリー一覧 viewer (cfdbf081) の列定義に従い title / cefr_level / scene_count を表示する。"
     }
   ],
   "design": {

--- a/examples/english-learning-tailwind/harmony/screens/a9d8eb6f-065d-4af6-ac9a-cc1fcf10b2b7.json
+++ b/examples/english-learning-tailwind/harmony/screens/a9d8eb6f-065d-4af6-ac9a-cc1fcf10b2b7.json
@@ -44,7 +44,20 @@
       "label": "録音ボタン",
       "type": "string",
       "direction": "input",
-      "description": "ブラウザ MediaRecorder API で録音し、終了後 audioUrl を english-learning:SttEvaluate ステップに POST する。録音中は Web Audio API AudioContext で波形描画 (canvas) を行う。aria-label は必須。"
+      "description": "ブラウザ MediaRecorder API で録音し、終了後 audioUrl を english-learning:SttEvaluate ステップに POST する。録音中は Web Audio API AudioContext で波形描画 (canvas) を行う。aria-label は必須。",
+      "events": [
+        {
+          "id": "click",
+          "label": "録音終了 → 発音採点",
+          "handlerFlowId": "6a49b14b-eb90-45bd-9df0-df4b5986626b",
+          "handlerActionId": "act-001",
+          "argumentMapping": {
+            "sessionId": "@screen.sessionId",
+            "dialogueLineId": "@screen.currentDialogueLine",
+            "audioUrl": "@self.audioUrl"
+          }
+        }
+      ]
     },
     {
       "id": "userTextInput",
@@ -53,7 +66,19 @@
       "direction": "input",
       "maxLength": 500,
       "placeholder": "テキストで入力する場合はこちら",
-      "description": "録音が困難な環境向けのテキスト入力代替手段。progress-turn フローに userInput として渡す。"
+      "description": "録音が困難な環境向けのテキスト入力代替手段。progress-turn フローに userInput として渡す。",
+      "events": [
+        {
+          "id": "submit",
+          "label": "テキスト送信 → 会話ターン進行",
+          "handlerFlowId": "96118ae1-a0ab-401b-8584-dd645a45a81f",
+          "handlerActionId": "act-001",
+          "argumentMapping": {
+            "sessionId": "@screen.sessionId",
+            "userInput": "@self.value"
+          }
+        }
+      ]
     },
     {
       "id": "turnHistory",

--- a/examples/english-learning-tailwind/harmony/screens/baddbabb-15e1-4f26-9f2b-0dc56b281019.json
+++ b/examples/english-learning-tailwind/harmony/screens/baddbabb-15e1-4f26-9f2b-0dc56b281019.json
@@ -14,9 +14,9 @@
     {
       "id": "packList",
       "label": "コンテンツパック一覧",
-      "type": "json",
-      "direction": "output",
-      "description": "content_packs 一覧 (JSON 配列)。pack_name / namespace_ref / story_count / is_active を含む。namespace_ref で拡張定義に紐付く分野別パックを識別する。"
+      "direction": "viewer",
+      "viewDefinitionId": "ba1c7d9d-5907-4535-99b9-f9fa170bb248",
+      "description": "content_packs 一覧。コンテンツパック一覧 viewer (ba1c7d9d) の列定義に従い pack_name / namespace_ref / story_count / is_active を表示する。"
     },
     {
       "id": "activatePackId",

--- a/examples/english-learning-tailwind/harmony/screens/fbf3995f-487a-47a9-b5cd-9c48a632db8c.json
+++ b/examples/english-learning-tailwind/harmony/screens/fbf3995f-487a-47a9-b5cd-9c48a632db8c.json
@@ -38,9 +38,9 @@
     {
       "id": "wordList",
       "label": "単語一覧",
-      "type": "json",
-      "direction": "output",
-      "description": "フィルタ条件で絞り込んだ user_word_progress JOIN words の一覧 (JSON 配列)。単語 / 訳 / IPA / 習熟度 / 最終学習日を含む。"
+      "direction": "viewer",
+      "viewDefinitionId": "090e9db0-ce45-4fc4-9fa6-5784f655ca07",
+      "description": "フィルタ条件で絞り込んだ user_word_progress JOIN words の一覧。単語帳 viewer (090e9db0) の列定義に従い単語 / 訳 / IPA / 習熟度 / 最終学習日を表示する。"
     }
   ],
   "design": {

--- a/examples/english-learning/harmony/process-flows/21c25fb2-551a-483f-b32a-060db8f88aee.json
+++ b/examples/english-learning/harmony/process-flows/21c25fb2-551a-483f-b32a-060db8f88aee.json
@@ -211,7 +211,7 @@
         {
           "id": "step-04",
           "kind": "dbAccess",
-          "description": "user_word_progress を UPSERT する (english-learning:UPSERT_WORD_PROGRESS)。新規の場合は status='new' で INSERT、既存の場合は correct_count / attempt_count / status / last_practiced_at を更新する。mastery 閾値 (conventions.extensionCategories.wordProgress.masteryThreshold = 3) 以上の連続正解で status='mastered' に昇格する。",
+          "description": "user_word_progress を UPSERT する (english-learning:UPSERT_WORD_PROGRESS)。新規の場合は status='new' で INSERT、既存の場合は correct_count / attempt_count / status / last_practiced_at を更新する。mastery 閾値 (@conv.wordProgress.masteryThreshold) 以上の連続正解で status='mastered' に昇格する。",
           "tableId": "7ab2cf24-7b66-47aa-a808-7fffd8290480",
           "operation": "english-learning:UPSERT_WORD_PROGRESS",
           "sql": "INSERT INTO user_word_progress (user_id, word_id, status, correct_count, attempt_count, last_practiced_at, updated_at) VALUES (@sessionUserId, @wordId, 'new', CASE WHEN @isCorrect THEN 1 ELSE 0 END, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP) ON CONFLICT (user_id, word_id) DO UPDATE SET attempt_count = user_word_progress.attempt_count + 1, correct_count = CASE WHEN @isCorrect THEN user_word_progress.correct_count + 1 ELSE user_word_progress.correct_count END, status = CASE WHEN @isCorrect AND (user_word_progress.correct_count + 1) >= @conv.wordProgress.masteryThreshold THEN 'mastered' WHEN user_word_progress.status != 'mastered' THEN 'learning' ELSE user_word_progress.status END, last_practiced_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP RETURNING id AS \"id\", status AS \"status\", correct_count AS \"correctCount\", attempt_count AS \"attemptCount\"",

--- a/examples/english-learning/harmony/process-flows/6a49b14b-eb90-45bd-9df0-df4b5986626b.json
+++ b/examples/english-learning/harmony/process-flows/6a49b14b-eb90-45bd-9df0-df4b5986626b.json
@@ -357,6 +357,12 @@
           },
           "outputBinding": {
             "name": "evalResult"
+          },
+          "outcomes": {
+            "failure": {
+              "action": "abort",
+              "description": "STT API 失敗時は abort。502-stt-failed カタログエントリに対応。"
+            }
           }
         },
         {
@@ -435,7 +441,7 @@
           "id": "step-08",
           "kind": "return",
           "runIf": "@txResult.committed == true",
-          "description": "201 Created — scoreId + score + diff を返す。TX コミット後にのみ実行する。score が合格ライン (conventions.extensionCategories.cefr.passingThreshold 参照) を下回る場合、UI 側でメッセージを表示する。",
+          "description": "201 Created — scoreId + score + diff を返す。TX コミット後にのみ実行する。score が合格ライン (@conv.cefr.passingThreshold 参照) を下回る場合、UI 側でメッセージを表示する。",
           "responseId": "201-created",
           "bodyExpression": "{ scoreId: @newScore.id, score: @pronunciationScore, diff: @evalResult.diff }"
         },

--- a/examples/english-learning/harmony/process-flows/96118ae1-a0ab-401b-8584-dd645a45a81f.json
+++ b/examples/english-learning/harmony/process-flows/96118ae1-a0ab-401b-8584-dd645a45a81f.json
@@ -90,9 +90,9 @@
         {
           "name": "turnContext",
           "label": "会話コンテキスト",
-          "type": "string",
+          "type": { "kind": "array", "itemType": { "kind": "extension", "extensionRef": "english-learning:dialogTurn" } },
           "required": false,
-          "description": "直近の会話履歴 (DialogTurn[] の JSON 文字列)。aiCall step の user メッセージ content に埋め込んで LLM へ渡す。"
+          "description": "直近の会話履歴 (DialogTurn 配列)。aiCall step の messages 内 spread item で role 別に展開し、LLM API に構造的に渡す (#939)。"
         },
         {
           "name": "generateAudio",

--- a/examples/english-learning/harmony/screens/046e1f83-bed3-4b13-a5ac-b0fa06744dfe.json
+++ b/examples/english-learning/harmony/screens/046e1f83-bed3-4b13-a5ac-b0fa06744dfe.json
@@ -56,7 +56,18 @@
       "label": "学習を開始する",
       "type": "string",
       "direction": "input",
-      "description": "クリック時に start-session 処理フローを実行し、learning_sessions レコードを作成してから会話プレイ画面 (/learn/:sessionId) へ遷移する。"
+      "description": "クリック時に start-session 処理フローを実行し、learning_sessions レコードを作成してから会話プレイ画面 (/learn/:sessionId) へ遷移する。",
+      "events": [
+        {
+          "id": "click",
+          "label": "セッション開始ボタンクリック",
+          "handlerFlowId": "cc173367-d92a-4525-acc9-689bad9a048e",
+          "handlerActionId": "act-001",
+          "argumentMapping": {
+            "storyId": "@routeParam.storyId"
+          }
+        }
+      ]
     }
   ],
   "design": {

--- a/examples/english-learning/harmony/screens/297e9117-0982-4a40-9ce7-bced3bc6d2c5.json
+++ b/examples/english-learning/harmony/screens/297e9117-0982-4a40-9ce7-bced3bc6d2c5.json
@@ -30,9 +30,9 @@
     {
       "id": "sessionList",
       "label": "学習セッション一覧",
-      "type": "json",
-      "direction": "output",
-      "description": "フィルタ条件で絞り込んだ learning_sessions 一覧 (JSON 配列)。各行に story_title / started_at / status / 総合スコアを含む。"
+      "direction": "viewer",
+      "viewDefinitionId": "4c9cdc85-2537-4ca8-a979-4de21a56e0fa",
+      "description": "フィルタ条件で絞り込んだ learning_sessions 一覧。学習履歴一覧 viewer (4c9cdc85) の列定義に従い story_title / started_at / status / 総合スコアを表示する。"
     }
   ],
   "design": {

--- a/examples/english-learning/harmony/screens/5f411f06-8677-4fa8-a9b2-edc14a1d9ce1.json
+++ b/examples/english-learning/harmony/screens/5f411f06-8677-4fa8-a9b2-edc14a1d9ce1.json
@@ -49,9 +49,9 @@
     {
       "id": "storyList",
       "label": "ストーリー一覧",
-      "type": "json",
-      "direction": "output",
-      "description": "フィルタ条件で絞り込んだ stories 一覧 (JSON 配列)。各行に title / cefr_level / scene_count / 未完了フラグを含む。"
+      "direction": "viewer",
+      "viewDefinitionId": "cfdbf081-368d-4a33-8a36-1c7a0c535011",
+      "description": "フィルタ条件で絞り込んだ stories 一覧。ストーリー一覧 viewer (cfdbf081) の列定義に従い title / cefr_level / scene_count を表示する。"
     }
   ],
   "design": {

--- a/examples/english-learning/harmony/screens/a9d8eb6f-065d-4af6-ac9a-cc1fcf10b2b7.json
+++ b/examples/english-learning/harmony/screens/a9d8eb6f-065d-4af6-ac9a-cc1fcf10b2b7.json
@@ -44,7 +44,20 @@
       "label": "録音ボタン",
       "type": "string",
       "direction": "input",
-      "description": "ブラウザ MediaRecorder API で録音し、終了後 audioUrl を english-learning:SttEvaluate ステップに POST する。録音中は Web Audio API AudioContext で波形描画 (canvas) を行う。aria-label は必須。"
+      "description": "ブラウザ MediaRecorder API で録音し、終了後 audioUrl を english-learning:SttEvaluate ステップに POST する。録音中は Web Audio API AudioContext で波形描画 (canvas) を行う。aria-label は必須。",
+      "events": [
+        {
+          "id": "click",
+          "label": "録音終了 → 発音採点",
+          "handlerFlowId": "6a49b14b-eb90-45bd-9df0-df4b5986626b",
+          "handlerActionId": "act-001",
+          "argumentMapping": {
+            "sessionId": "@screen.sessionId",
+            "dialogueLineId": "@screen.currentDialogueLine",
+            "audioUrl": "@self.audioUrl"
+          }
+        }
+      ]
     },
     {
       "id": "userTextInput",
@@ -53,7 +66,19 @@
       "direction": "input",
       "maxLength": 500,
       "placeholder": "テキストで入力する場合はこちら",
-      "description": "録音が困難な環境向けのテキスト入力代替手段。progress-turn フローに userInput として渡す。"
+      "description": "録音が困難な環境向けのテキスト入力代替手段。progress-turn フローに userInput として渡す。",
+      "events": [
+        {
+          "id": "submit",
+          "label": "テキスト送信 → 会話ターン進行",
+          "handlerFlowId": "96118ae1-a0ab-401b-8584-dd645a45a81f",
+          "handlerActionId": "act-001",
+          "argumentMapping": {
+            "sessionId": "@screen.sessionId",
+            "userInput": "@self.value"
+          }
+        }
+      ]
     },
     {
       "id": "turnHistory",

--- a/examples/english-learning/harmony/screens/baddbabb-15e1-4f26-9f2b-0dc56b281019.json
+++ b/examples/english-learning/harmony/screens/baddbabb-15e1-4f26-9f2b-0dc56b281019.json
@@ -14,9 +14,9 @@
     {
       "id": "packList",
       "label": "コンテンツパック一覧",
-      "type": "json",
-      "direction": "output",
-      "description": "content_packs 一覧 (JSON 配列)。pack_name / namespace_ref / story_count / is_active を含む。namespace_ref で拡張定義に紐付く分野別パックを識別する。"
+      "direction": "viewer",
+      "viewDefinitionId": "ba1c7d9d-5907-4535-99b9-f9fa170bb248",
+      "description": "content_packs 一覧。コンテンツパック一覧 viewer (ba1c7d9d) の列定義に従い pack_name / namespace_ref / story_count / is_active を表示する。"
     },
     {
       "id": "activatePackId",

--- a/examples/english-learning/harmony/screens/fbf3995f-487a-47a9-b5cd-9c48a632db8c.json
+++ b/examples/english-learning/harmony/screens/fbf3995f-487a-47a9-b5cd-9c48a632db8c.json
@@ -38,9 +38,9 @@
     {
       "id": "wordList",
       "label": "単語一覧",
-      "type": "json",
-      "direction": "output",
-      "description": "フィルタ条件で絞り込んだ user_word_progress JOIN words の一覧 (JSON 配列)。単語 / 訳 / IPA / 習熟度 / 最終学習日を含む。"
+      "direction": "viewer",
+      "viewDefinitionId": "090e9db0-ce45-4fc4-9fa6-5784f655ca07",
+      "description": "フィルタ条件で絞り込んだ user_word_progress JOIN words の一覧。単語帳 viewer (090e9db0) の列定義に従い単語 / 訳 / IPA / 習熟度 / 最終学習日を表示する。"
     }
   ],
   "design": {

--- a/examples/realestate/harmony.json
+++ b/examples/realestate/harmony.json
@@ -5,7 +5,7 @@
   "meta": {
     "id": "a1e2f3b4-c5d6-4e7f-8a9b-0c1d2e3f4a5b",
     "name": "不動産仲介システム",
-    "description": "不動産仲介業務サンプル。物件検索・顧客検索・取引履歴を軸に、viewer screen-item (#762) の direction=viewer パターンを実証する。",
+    "description": "ViewerScreenItem (#762) デモ用の最小サンプル。物件検索画面 1 つで物件マスタの一覧 / 詳細を viewer pattern で表示する構成のみを実装。顧客管理 / 内見予約 / 契約処理等の他業務軸は本サンプルのスコープ外。",
     "version": "1.0.0",
     "maturity": "provisional",
     "createdAt": "2026-05-03T00:00:00.000Z",

--- a/examples/realestate/harmony/conventions/catalog.json
+++ b/examples/realestate/harmony/conventions/catalog.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../../schemas/v3/conventions.v3.schema.json",
   "version": "1.0.0",
-  "description": "不動産仲介システムの横断規約カタログ。物件コード規約・メッセージ・限度値を集約する。",
+  "description": "不動産仲介システム (最小サンプル) の横断規約カタログ。i18n / 通貨 / DB 接続規約のみ定義し、viewer demo 構成と整合させた最小構成。",
   "updatedAt": "2026-05-03T00:00:00.000Z",
   "i18n": {
     "supportedLocales": ["ja-JP"],
@@ -10,38 +10,6 @@
     "timeFormat": { "ja-JP": "HH:mm" },
     "currencyDisplay": { "ja-JP": "symbol" },
     "numberGrouping": { "ja-JP": true }
-  },
-  "regex": {
-    "propertyCode": {
-      "pattern": "^RE-[0-9]{5}$",
-      "description": "物件コードの正規表現。'RE-' プレフィックス + 5 桁数字。例: RE-00001。",
-      "exampleValid": ["RE-00001", "RE-99999"],
-      "exampleInvalid": ["00001", "RE-001", "re-00001"]
-    }
-  },
-  "msg": {
-    "propertyNotFound": {
-      "template": "物件コード {propertyCode} の物件が見つかりません。",
-      "params": ["propertyCode"],
-      "description": "物件検索で該当なし時のメッセージ。"
-    },
-    "searchResultEmpty": {
-      "template": "指定した条件に合致する物件が見つかりませんでした。条件を変更してお試しください。",
-      "params": [],
-      "description": "物件検索結果が 0 件の場合に表示するメッセージ。"
-    }
-  },
-  "limit": {
-    "maxSearchResults": {
-      "value": 100,
-      "unit": "integer",
-      "description": "物件検索結果の最大返却件数。これを超えた場合はページングを促す。"
-    },
-    "propertyCodeMaxLength": {
-      "value": 20,
-      "unit": "char",
-      "description": "物件コードの最大文字数 (@conv.regex.propertyCode と整合)。"
-    }
   },
   "currency": {
     "jpy": {
@@ -54,12 +22,10 @@
   },
   "db": {
     "primary": {
-      "engine": "postgresql@15",
+      "engine": "postgresql@17",
       "namingConvention": "snake_case",
-      "timestampColumns": ["created_at", "updated_at"],
-      "logicalDeleteColumn": "is_active",
       "default": true,
-      "description": "本サンプルの主 DB。PostgreSQL 15 を想定。"
+      "description": "本サンプルの主 DB。PostgreSQL 17 を想定 (harmony.json techStack.database.version と整合)。"
     }
   }
 }

--- a/examples/realestate/harmony/screens/b2f3a4c5-d6e7-4f80-9a1b-2c3d4e5f6a7b.design.json
+++ b/examples/realestate/harmony/screens/b2f3a4c5-d6e7-4f80-9a1b-2c3d4e5f6a7b.design.json
@@ -1,0 +1,17 @@
+{
+  "dataSources": [],
+  "assets": [],
+  "styles": [],
+  "pages": [
+    {
+      "frames": [
+        {
+          "component": {
+            "type": "wrapper",
+            "components": "\n<div class=\"container py-4\">\n  <!-- 検索フォーム -->\n  <div class=\"card mb-4\">\n    <div class=\"card-header\">\n      <h5 class=\"mb-0\">物件検索</h5>\n    </div>\n    <div class=\"card-body\">\n      <form id=\"searchForm\" data-item-id=\"searchForm\">\n        <div class=\"row g-3\">\n          <div class=\"col-md-4\">\n            <label for=\"propertyType\" class=\"form-label\">物件種別</label>\n            <select id=\"propertyType\" name=\"propertyType\" data-item-id=\"propertyType\" class=\"form-select\">\n              <option value=\"\">すべて</option>\n              <option value=\"apartment\">マンション</option>\n              <option value=\"house\">一戸建て</option>\n              <option value=\"land\">土地</option>\n              <option value=\"office\">事務所</option>\n            </select>\n          </div>\n          <div class=\"col-md-4\">\n            <label for=\"maxPrice10kYen\" class=\"form-label\">上限価格 (万円)</label>\n            <input id=\"maxPrice10kYen\" name=\"maxPrice10kYen\" data-item-id=\"maxPrice10kYen\" type=\"number\" class=\"form-control\" placeholder=\"例: 5000\" min=\"0\" />\n          </div>\n          <div class=\"col-md-4\">\n            <label for=\"minAreaSqm\" class=\"form-label\">最小面積 (m2)</label>\n            <input id=\"minAreaSqm\" name=\"minAreaSqm\" data-item-id=\"minAreaSqm\" type=\"number\" class=\"form-control\" placeholder=\"例: 50.00\" min=\"0\" step=\"0.01\" />\n          </div>\n        </div>\n        <div class=\"mt-3\">\n          <button id=\"searchButton\" data-item-id=\"searchButton\" type=\"submit\" class=\"btn btn-primary\">検索</button>\n        </div>\n      </form>\n    </div>\n  </div>\n\n  <!-- 検索結果 (viewer) -->\n  <div class=\"card\">\n    <div class=\"card-header d-flex justify-content-between align-items-center\">\n      <h5 class=\"mb-0\">検索結果</h5>\n      <span id=\"totalCount\" data-item-id=\"totalCount\" class=\"badge bg-secondary\">0 件</span>\n    </div>\n    <div class=\"card-body p-0\">\n      <div id=\"propertyRows\" data-item-id=\"propertyRows\" data-viewer-bind=\"rows\">\n        <table class=\"table table-hover mb-0\">\n          <thead class=\"table-light\">\n            <tr>\n              <th>物件コード</th>\n              <th>物件名</th>\n              <th>種別</th>\n              <th>面積 (m2)</th>\n              <th>価格 (万円)</th>\n              <th>掲載日</th>\n            </tr>\n          </thead>\n          <tbody>\n            <tr>\n              <td>RE-00001</td>\n              <td>サンプルマンション渋谷</td>\n              <td>マンション</td>\n              <td>65.50</td>\n              <td>4,500</td>\n              <td>2026/04/01</td>\n            </tr>\n          </tbody>\n        </table>\n      </div>\n    </div>\n  </div>\n</div>\n"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/examples/realestate/harmony/tables/c3a4b5d6-e7f8-4091-ab2c-3d4e5f6a7b8c.json
+++ b/examples/realestate/harmony/tables/c3a4b5d6-e7f8-4091-ab2c-3d4e5f6a7b8c.json
@@ -16,6 +16,7 @@
       "dataType": "INTEGER",
       "notNull": true,
       "primaryKey": true,
+      "autoIncrement": true,
       "description": "物件の一意識別子 (auto increment)。"
     },
     {
@@ -51,6 +52,8 @@
       "name": "面積 (m2)",
       "physicalName": "area_sqm",
       "dataType": "DECIMAL",
+      "length": 10,
+      "scale": 2,
       "description": "物件の面積 (平方メートル)。土地の場合は敷地面積。"
     },
     {

--- a/examples/retail/harmony/extensions/retail.v3.json
+++ b/examples/retail/harmony/extensions/retail.v3.json
@@ -52,6 +52,13 @@
       "description": "クリック操作を発火する button-like 要素。直接のデータ binding は持たず、events[] で handlerFlow を起動する。typically direction='output' + readonly=true で使い、value はラベル文字列を流用する。"
     }
   ],
+  "screenKinds": [
+    {
+      "kind": "cart",
+      "label": "カート画面",
+      "description": "ショッピングカート画面 (購入手続き前の商品一覧)"
+    }
+  ],
   "actionTriggers": [
     {
       "value": "orderConfirmed",

--- a/examples/retail/harmony/generic-definitions/exception-type/StockInsufficientError.json
+++ b/examples/retail/harmony/generic-definitions/exception-type/StockInsufficientError.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../../../schemas/v3/generic-definition.v3.schema.json",
+  "$schema": "../../../../../schemas/v3/generic-definitions/exception-type.v3.schema.json",
   "kind": "exception-type",
   "name": "StockInsufficientError",
   "purpose": "在庫引当時に在庫不足を検出した場合の業務例外",


### PR DESCRIPTION
## 関連

- Closes #1252 (release pre-check D: 既存 examples の現行 spec/schema 整合性 drift 監査)
- 仕様: 個別 spec ファイル参照なし (本 PR は examples 整合性修正のみ、spec 変更なし)
- 関連 schema (本 PR では未変更): `schemas/v3/process-flow.v3.schema.json` (transactionScope wrapper) / `schemas/v3/screen.v3.schema.json` (events[] / viewer item) / `schemas/v3/conventions.v3.schema.json` / `schemas/v3/table.v3.schema.json` / `schemas/v3/extensions.v3.schema.json`
- 関連 audit comments (5 並列 Opus): #1252#issuecomment-4510479335 (A1 diary) / #1252#issuecomment-4510494953 (A2 english-learning) / #1252#issuecomment-4510521973 (A3 english-learning-tailwind) / #1252#issuecomment-4510473939 (A4 realestate) / #1252#issuecomment-4510504353 (A5 retail)

## 概要

ISSUE #1252 release pre-check D の audit-iter-0 で 5 並列 Opus が検出した 5 examples の drift 17 件 (Must-fix 4 / Should-fix 13) を fix-iter-1 で **直列 (1 Sonnet 1 example ずつ)** 解消。全 5 examples で `validate:samples` PASS / warning 0 件を確認。schemas/ 改訂を要する Pending Decisions は 0 件、本 PR は examples/ のみ変更。

## 主な変更

### diary (Must-fix 2、commit `095751a`)

- **F-A1-1 / F-A1-2 (TX 原子性回復)**: PR #1236 が `txBoundary` strip 時に `transactionScope` wrapper への変換漏れを起こした投稿作成 / 投稿削除フローを修正。step-03〜06 / step-04〜06 を `transactionScope` wrapper 内に格納、`rollbackOn` 列挙、step-07 return に `runIf: "@txResult.committed == true"` 付与。validate:samples では検出不能だった silent semantic bug。

### english-learning (Should-fix 6、commits `e32e280` / `a4d9f01`)

- **F-A2-S1 / F-A2-S2**: description 旧形式 `conventions.extensionCategories.*` → `@conv.*` (#1236 統一)
- **F-A2-S3**: `turnContext` input type を `string` → array (`dialogTurn[]` 相当) に修正、description 更新
- **F-A2-S4**: SttEvaluate step に `outcomes.failure.action: "abort"` 追加
- **F-A2-S5**: 4 list screens の主リスト item を `direction: "viewer"` + `viewDefinitionId` に変換 (viewer pattern #762 demo 化)
- **F-A2-S6 partial**: 対応 flow / input item を持つ 2 screens (会話プレイ / ストーリー詳細) に events[] 宣言追加。残 9 screens は対応 flow / input item なしで scope-out

### english-learning-tailwind (Should-fix 2 + sister 同期、commits `b2759c7` / `e1fc7ea` / `0433706`)

- **F-A3-1**: README.md `npm --prefix designer run validate:samples` → `cd frontend && npm run validate:samples` (#845 designer → frontend rename 反映)
- **F-A3-2**: README.md に generated/ Prisma provider (sqlite) vs harmony.json techStack (postgresql) の不整合注記追加 (test fixture 用途であることを明記)
- **Sister 同期**: english-learning 側 A2-S1〜S6 partial と同じ修正を sister 側 9 ファイル (process-flows 3 + screens 6) に適用 (同 ID 複製のため姉妹間整合維持)

### realestate (Must-fix 2 + Should-fix 3、commits `674010e` / `166e010` / `4eabc1e` / `cc4b642`)

- **F-A4-1 (Must-fix)**: harmony.json description を「物件検索・顧客検索・取引履歴 3 軸」宣言から「ViewerScreenItem (#762) デモ用最小サンプル」に書き換え、宣言と実装の乖離を解消
- **F-A4-2 (Must-fix)**: col-id に `autoIncrement: true` 追加 (description「auto increment」と実装の整合)
- **F-A4-3**: conventions/catalog.json 縮小: `engine` を postgresql@15 → @17 修正 (harmony.json と整合)、dead reference (`timestampColumns` / `logicalDeleteColumn` / `regex.propertyCode` / `msg.*` / `limit.maxSearchResults`) 全削除
- **F-A4-4**: col-area-sqm DECIMAL に `length: 10, scale: 2` 追加 (DDL 生成の DB-specific default 任せ解消)
- **F-A4-5**: design.json 最小スケルトン作成 (Bootstrap 検索フォーム + viewer 結果テーブル)、MISSING_DESIGN_FILE warning 解消

### retail (Should-fix 2、commits `a6ee8ad` / `69cfb6f`)

- **F-A5-1**: exception-type/StockInsufficientError.json `$schema` を base `generic-definition.v3.schema.json` から kind 別 `generic-definitions/exception-type.v3.schema.json` に修正 (#1075 で導入された kind 別 schema への drift 解消、他 6 kind と整合)
- **F-A5-2**: extensions/retail.v3.json に `screenKinds` セクション新設、`{ kind: "cart", label: "カート画面", description: "..." }` 追加。Screen `c73fa05c` の `kind: "retail:cart"` が extension 側未宣言だった silent-pass anti-pattern 解消

## 仕様逐条突合 (自己申告)

本 PR は spec 改訂を含まないため、spec 各条項に対する逐条突合は N/A。代わりに **5 audit comments の各 finding に対する fix file:line / commit** を網羅:

- F-A1-1: `examples/diary/harmony/process-flows/0671b051-...json` (transactionScope 化) — commit `095751a` ✓
- F-A1-2: `examples/diary/harmony/process-flows/c4d5e6f7-...json` (transactionScope 化) — commit `095751a` ✓
- F-A2-S1: `examples/english-learning/harmony/process-flows/6a49b14b-...json` description 修正 — commit `e32e280` ✓
- F-A2-S2: `examples/english-learning/harmony/process-flows/21c25fb2-...json` description 修正 — commit `e32e280` ✓
- F-A2-S3: `examples/english-learning/harmony/process-flows/96118ae1-...json` turnContext 型修正 — commit `e32e280` ✓
- F-A2-S4: `examples/english-learning/harmony/process-flows/6a49b14b-...json` SttEvaluate outcomes 追加 — commit `e32e280` ✓
- F-A2-S5: `examples/english-learning/harmony/screens/*.json` × 5 viewer 化 — commit `e32e280` ✓
- F-A2-S6 partial: `examples/english-learning/harmony/screens/{046e1f83,a9d8eb6f}.json` events[] 追加 — commit `a4d9f01` ✓ (残 9 screens は対応 flow なしで scope-out)
- F-A3-1: `examples/english-learning-tailwind/README.md` designer prefix 修正 — commit `b2759c7` ✓
- F-A3-2: `examples/english-learning-tailwind/README.md` sqlite/postgresql 注記追加 — commit `e1fc7ea` ✓
- A2-S1〜S6 sister 同期: `examples/english-learning-tailwind/harmony/{process-flows,screens}/*.json` × 9 — commit `0433706` ✓
- F-A4-1: `examples/realestate/harmony.json` description 修正 — commit `674010e` ✓
- F-A4-2: `examples/realestate/harmony/tables/c3a4b5d6-...json` autoIncrement 追加 — commit `166e010` ✓
- F-A4-3: `examples/realestate/harmony/conventions/catalog.json` 縮小 — commit `4eabc1e` ✓
- F-A4-4: `examples/realestate/harmony/tables/c3a4b5d6-...json` length/scale 追加 — commit `166e010` ✓
- F-A4-5: `examples/realestate/harmony/screens/b2f3a4c5-...design.json` 新設 — commit `cc4b642` ✓
- F-A5-1: `examples/retail/harmony/generic-definitions/exception-type/StockInsufficientError.json` $schema 修正 — commit `a6ee8ad` ✓
- F-A5-2: `examples/retail/harmony/extensions/retail.v3.json` screenKinds 追加 — commit `69cfb6f` ✓

## レビューで特に見てほしい箇所

1. **diary TX wrapper の atomic 性回復 (Must-fix 最重要)**: PR #1236 が機械的に txBoundary strip した際に欠落した transactionScope wrap が業務 semantic と一致しているか (rollbackOn の error catalog 名 / runIf のタイミング)
2. **english-learning S-3 turnContext 型変更**: `string` → array への変更が `AiMessageSpread` の期待構造と合致しているか、description が現実装と矛盾していないか
3. **english-learning-tailwind sister 同期完全性**: 同 ID 複製の姉妹サンプル間で variant 化が発生していないか (`git diff` で対応 ID の同一性確認)
4. **realestate description 縮小**: 「3 軸宣言 → 1 軸最小サンプル」の方針転換が release example の説明として妥当か (ユーザー混乱回避の観点)
5. **retail F-A5-2 silent-pass 解消**: extension namespace `retail:cart` 宣言追加が他 cart-related ファイル参照と整合しているか

## テスト

- **validate:samples 全 5 examples PASS** (warning 0 件):
  | example | flows | result | warning |
  |---|---|---|---|
  | diary | 15/15 | PASS | 0 |
  | english-learning | 5/5 | PASS | 0 |
  | english-learning-tailwind | 5/5 | PASS | 0 |
  | realestate | 1/1 | PASS | 0 |
  | retail | 7/7 | PASS | 0 |
- Vitest / Playwright: N/A (examples 修正のみ、frontend / backend code 変更なし)
- MCP E2E: N/A
- 軸 8 (E2E smoke): 5 examples Playwright MCP headless で workspace open → process-flow/list 描画確認、**全件 0 errors** (audit-iter-0 軸 8 結果)

## UI 影響 / AI smoke test

- [x] UI 影響なし (examples 修正のみ、frontend code 変更なし)
- [x] AI smoke test (audit-iter-0 軸 8 で 5 examples を実機 Playwright MCP smoke 済、全件 0 errors)

## スコープ外 / 別 ISSUE

- **F-A2-S6 残 9 screens への events[] 追加**: 対応 flow / input item が無いため scope-out。サンプル拡張時に対応 (本 ISSUE close 後の別件)
- **F-A4-3 で削除した conventions の reference 再追加**: 本サンプル方針が「最小構成」に確定したため削除のままで OK、catalog 充実化は別件
- **F-A5-2 component-definition kind 別 schema 未提供**: `schemas/v3/generic-definitions/component-definition.v3.schema.json` が存在しないため `component-definition.json` は base schema を refer 中。これは schema 不在のため fix 不能、別 ISSUE で kind 別 schema 追加が必要 (schema governance 観点で設計者承認待ち、本 PR では Pending Decisions に列挙せず観察ノートとして残す)
