### PR TITLE
feat(designer): @reference auto-complete (Phase 1-3) (#1255)

### DIFF
--- a/frontend/src/components/common/ReferenceCompletionInput.tsx
+++ b/frontend/src/components/common/ReferenceCompletionInput.tsx
@@ -1,0 +1,178 @@
+import { useState, useRef, useCallback } from "react";
+import { computeReferenceCompletion, insertReferenceCandidate } from "../../utils/reference-completer/completer";
+import type { Candidate, CompletionContext, Resolver } from "../../utils/reference-completer/types";
+
+interface ReferenceCompletionInputProps {
+  value: string;
+  onValueChange: (v: string) => void;
+  onCommit?: () => void;
+  /** 有効化する Resolver 一覧。 */
+  resolvers: Resolver[];
+  /** CompletionContext。conventions / workspace / flow / extensions 等を渡す。 */
+  ctx: CompletionContext;
+  className?: string;
+  style?: React.CSSProperties;
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+/**
+ * 統合 reference 補完ポップアップ付き input。
+ *
+ * 渡された resolvers / ctx に基づいて補完候補を計算し、
+ * ↑↓ / Enter / Tab / Esc でポップアップ操作ができる。
+ */
+export function ReferenceCompletionInput({
+  value,
+  onValueChange,
+  onCommit,
+  resolvers,
+  ctx,
+  className,
+  style,
+  placeholder,
+  disabled,
+}: ReferenceCompletionInputProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [cursorPos, setCursorPos] = useState(0);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [suppressed, setSuppressed] = useState(false);
+
+  const state = suppressed
+    ? ({ phase: "idle" } as const)
+    : computeReferenceCompletion(value, cursorPos, resolvers, ctx);
+
+  const candidates: Candidate[] = state.phase === "active" ? state.candidates : [];
+  const isOpen = candidates.length > 0;
+  const safeIndex = candidates.length > 0 ? Math.min(activeIndex, candidates.length - 1) : 0;
+
+  const pick = useCallback(
+    (candidate: Candidate) => {
+      const pos = inputRef.current?.selectionStart ?? value.length;
+      const st = computeReferenceCompletion(value, pos, resolvers, ctx);
+      if (st.phase === "idle") return;
+      const { newValue, newCursor } = insertReferenceCandidate(value, pos, st, candidate);
+      onValueChange(newValue);
+      setSuppressed(false);
+      setActiveIndex(0);
+      setCursorPos(newCursor);
+      requestAnimationFrame(() => {
+        inputRef.current?.setSelectionRange(newCursor, newCursor);
+        inputRef.current?.focus();
+      });
+    },
+    [value, resolvers, ctx, onValueChange],
+  );
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!isOpen) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveIndex((i) => (i + 1) % candidates.length);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIndex((i) => (i - 1 + candidates.length) % candidates.length);
+    } else if (e.key === "Enter" || e.key === "Tab") {
+      if (candidates[safeIndex]) {
+        e.preventDefault();
+        pick(candidates[safeIndex]);
+      }
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      setSuppressed(true);
+    }
+  };
+
+  return (
+    <div style={{ position: "relative" }}>
+      <input
+        ref={inputRef}
+        type="text"
+        className={className}
+        style={style}
+        value={value}
+        placeholder={placeholder}
+        autoComplete="off"
+        disabled={disabled}
+        onChange={(e) => {
+          const pos = e.target.selectionStart ?? e.target.value.length;
+          setCursorPos(pos);
+          setActiveIndex(0);
+          setSuppressed(false);
+          onValueChange(e.target.value);
+        }}
+        onKeyDown={handleKeyDown}
+        onSelect={(e) => {
+          setCursorPos((e.target as HTMLInputElement).selectionStart ?? 0);
+        }}
+        onBlur={() => {
+          setTimeout(() => setSuppressed(true), 150);
+          onCommit?.();
+        }}
+        onFocus={() => setSuppressed(false)}
+      />
+      {isOpen && (
+        <ul
+          role="listbox"
+          aria-label="補完候補"
+          style={{
+            position: "absolute",
+            top: "100%",
+            left: 0,
+            zIndex: 9999,
+            background: "#fff",
+            border: "1px solid #cbd5e1",
+            borderRadius: 6,
+            boxShadow: "0 4px 16px rgba(0,0,0,0.12)",
+            margin: "2px 0 0",
+            padding: "4px 0",
+            minWidth: "16em",
+            maxHeight: "14em",
+            overflowY: "auto",
+            listStyle: "none",
+          }}
+        >
+          {candidates.map((c, i) => (
+            <li
+              key={`${c.value}-${i}`}
+              role="option"
+              aria-selected={i === safeIndex}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                pick(c);
+              }}
+              style={{
+                padding: "4px 12px",
+                cursor: "pointer",
+                background: i === safeIndex ? "#6366f1" : "transparent",
+                color: i === safeIndex ? "#fff" : "#1e293b",
+                borderRadius: i === safeIndex ? 3 : 0,
+                margin: "0 4px",
+              }}
+            >
+              <span
+                style={{
+                  fontFamily: "ui-monospace, SFMono-Regular, monospace",
+                  fontSize: "0.82rem",
+                }}
+              >
+                {c.label ?? c.value}
+              </span>
+              {c.hint && (
+                <span
+                  style={{
+                    marginLeft: 8,
+                    fontSize: "0.75rem",
+                    opacity: 0.65,
+                  }}
+                >
+                  {c.hint}
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/common/ReferenceCompletionTextarea.tsx
+++ b/frontend/src/components/common/ReferenceCompletionTextarea.tsx
@@ -1,0 +1,179 @@
+import { useState, useRef, useCallback } from "react";
+import { computeReferenceCompletion, insertReferenceCandidate } from "../../utils/reference-completer/completer";
+import type { Candidate, CompletionContext, Resolver } from "../../utils/reference-completer/types";
+
+interface ReferenceCompletionTextareaProps {
+  value: string;
+  onValueChange: (v: string) => void;
+  onCommit?: () => void;
+  /** 有効化する Resolver 一覧。 */
+  resolvers: Resolver[];
+  /** CompletionContext。conventions / workspace / flow / extensions 等を渡す。 */
+  ctx: CompletionContext;
+  className?: string;
+  style?: React.CSSProperties;
+  placeholder?: string;
+  disabled?: boolean;
+  rows?: number;
+}
+
+/**
+ * 統合 reference 補完ポップアップ付き textarea。
+ * ReferenceCompletionInput の textarea 版 (Phase 3 / #1255)。
+ */
+export function ReferenceCompletionTextarea({
+  value,
+  onValueChange,
+  onCommit,
+  resolvers,
+  ctx,
+  className,
+  style,
+  placeholder,
+  disabled,
+  rows = 2,
+}: ReferenceCompletionTextareaProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [cursorPos, setCursorPos] = useState(0);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [suppressed, setSuppressed] = useState(false);
+
+  const state = suppressed
+    ? ({ phase: "idle" } as const)
+    : computeReferenceCompletion(value, cursorPos, resolvers, ctx);
+
+  const candidates: Candidate[] = state.phase === "active" ? state.candidates : [];
+  const isOpen = candidates.length > 0;
+  const safeIndex = candidates.length > 0 ? Math.min(activeIndex, candidates.length - 1) : 0;
+
+  const pick = useCallback(
+    (candidate: Candidate) => {
+      const pos = textareaRef.current?.selectionStart ?? value.length;
+      const st = computeReferenceCompletion(value, pos, resolvers, ctx);
+      if (st.phase === "idle") return;
+      const { newValue, newCursor } = insertReferenceCandidate(value, pos, st, candidate);
+      onValueChange(newValue);
+      setSuppressed(false);
+      setActiveIndex(0);
+      setCursorPos(newCursor);
+      requestAnimationFrame(() => {
+        textareaRef.current?.setSelectionRange(newCursor, newCursor);
+        textareaRef.current?.focus();
+      });
+    },
+    [value, resolvers, ctx, onValueChange],
+  );
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (!isOpen) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveIndex((i) => (i + 1) % candidates.length);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIndex((i) => (i - 1 + candidates.length) % candidates.length);
+    } else if (e.key === "Tab") {
+      if (candidates[safeIndex]) {
+        e.preventDefault();
+        pick(candidates[safeIndex]);
+      }
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      setSuppressed(true);
+    }
+    // Enter: textarea ではデフォルト改行のため Tab のみ補完確定
+  };
+
+  return (
+    <div style={{ position: "relative" }}>
+      <textarea
+        ref={textareaRef}
+        className={className}
+        style={style}
+        value={value}
+        placeholder={placeholder}
+        autoComplete="off"
+        disabled={disabled}
+        rows={rows}
+        onChange={(e) => {
+          const pos = e.target.selectionStart ?? e.target.value.length;
+          setCursorPos(pos);
+          setActiveIndex(0);
+          setSuppressed(false);
+          onValueChange(e.target.value);
+        }}
+        onKeyDown={handleKeyDown}
+        onSelect={(e) => {
+          setCursorPos((e.target as HTMLTextAreaElement).selectionStart ?? 0);
+        }}
+        onBlur={() => {
+          setTimeout(() => setSuppressed(true), 150);
+          onCommit?.();
+        }}
+        onFocus={() => setSuppressed(false)}
+      />
+      {isOpen && (
+        <ul
+          role="listbox"
+          aria-label="補完候補"
+          style={{
+            position: "absolute",
+            top: "100%",
+            left: 0,
+            zIndex: 9999,
+            background: "#fff",
+            border: "1px solid #cbd5e1",
+            borderRadius: 6,
+            boxShadow: "0 4px 16px rgba(0,0,0,0.12)",
+            margin: "2px 0 0",
+            padding: "4px 0",
+            minWidth: "16em",
+            maxHeight: "14em",
+            overflowY: "auto",
+            listStyle: "none",
+          }}
+        >
+          {candidates.map((c, i) => (
+            <li
+              key={`${c.value}-${i}`}
+              role="option"
+              aria-selected={i === safeIndex}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                pick(c);
+              }}
+              style={{
+                padding: "4px 12px",
+                cursor: "pointer",
+                background: i === safeIndex ? "#6366f1" : "transparent",
+                color: i === safeIndex ? "#fff" : "#1e293b",
+                borderRadius: i === safeIndex ? 3 : 0,
+                margin: "0 4px",
+              }}
+            >
+              <span
+                style={{
+                  fontFamily: "ui-monospace, SFMono-Regular, monospace",
+                  fontSize: "0.82rem",
+                }}
+              >
+                {c.label ?? c.value}
+              </span>
+              {c.hint && (
+                <span
+                  style={{
+                    marginLeft: 8,
+                    fontSize: "0.75rem",
+                    opacity: 0.65,
+                  }}
+                >
+                  {c.hint}
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/process-flow/StepCard.tsx
+++ b/frontend/src/components/process-flow/StepCard.tsx
@@ -589,6 +589,8 @@ export function StepCard({
                   onChange={onChange}
                   onCommit={onCommit}
                   readOnly={readOnly}
+                  conventions={conventions}
+                  group={group}
                 />
               )}
 

--- a/frontend/src/components/process-flow/internal/step-cards/DbAccessStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/DbAccessStepCardBody.tsx
@@ -1,21 +1,30 @@
 // Phase-2 (#1145): StepCard.tsx の `step.kind === "dbAccess"` body を抽出。
 // #1016 follow-up (2026-05-20): generic StepCardBodyBaseProps<DbAccessStep> で type narrow、@ts-nocheck 除去。
+// Phase-3 (#1255): SQL body textarea に @conv / @stepResult / @inputs / @fieldErrors 補完を追加。
 
 import type { DbAccessStep, DbOperation, TableId, ErrorCode } from "../../../../types/v3";
 import { DB_OPERATION_LABELS } from "../../../../utils/processFlowMetadata";
 import { DB_OPS } from "../stepCardConstants";
-import type { StepCardBodyBaseProps, StepCardBodyTableProps } from "./types";
+import type { StepCardBodyBaseProps, StepCardBodyCatalogProps, StepCardBodyTableProps } from "./types";
+import { ReferenceCompletionTextarea } from "../../../common/ReferenceCompletionTextarea";
+import { convResolver } from "../../../../utils/reference-completer/convResolver";
+import { ALL_PROCESS_FLOW_SCOPE_RESOLVERS } from "../../../../utils/reference-completer/processFlowScopeResolver";
 
 export interface DbAccessStepCardBodyProps
   extends StepCardBodyBaseProps<DbAccessStep>,
-    StepCardBodyTableProps {}
+    StepCardBodyTableProps,
+    Partial<StepCardBodyCatalogProps> {}
 
 export function DbAccessStepCardBody({
   step,
   tables,
   onChange,
   onCommit,
+  conventions,
+  group,
 }: DbAccessStepCardBodyProps) {
+  const sqlResolvers = [convResolver, ...ALL_PROCESS_FLOW_SCOPE_RESOLVERS];
+  const sqlCtx = { conventions: conventions ?? null, flow: group ?? undefined };
   return (
     <>
       <div className="form-group">
@@ -59,12 +68,14 @@ export function DbAccessStepCardBody({
       </div>
       <div className="form-group" data-field-path="sql">
         <label className="form-label">完全 SQL (sql、fields より優先)</label>
-        <textarea
+        <ReferenceCompletionTextarea
+          value={step.sql ?? ""}
+          onValueChange={(v) => onChange({ sql: v || undefined })}
+          onCommit={onCommit}
+          resolvers={sqlResolvers}
+          ctx={sqlCtx}
           className="form-control form-control-sm"
           rows={2}
-          value={step.sql ?? ""}
-          onChange={(e) => onChange({ sql: e.target.value || undefined })}
-          onBlur={onCommit}
           placeholder="例: SELECT ... JOIN ... WHERE ... / INSERT ... RETURNING ..."
           style={{ fontFamily: "monospace", fontSize: "0.8rem" }}
         />

--- a/frontend/src/hooks/useConvCompletion.ts
+++ b/frontend/src/hooks/useConvCompletion.ts
@@ -1,10 +1,23 @@
+/**
+ * @conv.* 補完フック (後方互換 wrapper)。
+ *
+ * 内部実装を utils/reference-completer/completer + convResolver に委譲しつつ、
+ * 旧来の CompletionState 型 (category / key / idle) と computeCompletion /
+ * insertCandidate 関数シグネチャを維持する。
+ *
+ * callsite 7 箇所 (ConvCompletionInput.tsx / AuditStepPanel.tsx 等) はこのまま使い続けられる。
+ */
+
 import type { ConventionsCatalog } from "../schemas/conventionsValidator";
+import { computeReferenceCompletion, insertReferenceCandidate } from "../utils/reference-completer/completer";
+import { convResolver } from "../utils/reference-completer/convResolver";
 
 export const ALL_CONV_CATEGORIES = [
   "msg", "regex", "limit", "scope", "currency", "tax", "auth",
   "db", "numbering", "tx", "externalOutcomeDefaults",
 ] as const;
 
+/** 旧来の CompletionState 型 (callsite 互換のため維持)。 */
 export type CompletionState =
   | { phase: "idle" }
   | { phase: "category"; prefix: string; candidates: string[] }
@@ -13,6 +26,7 @@ export type CompletionState =
 /**
  * カーソル直前の @conv.* パターンから補完状態を計算する純粋関数。
  * catalog が null なら常に idle を返す。
+ * 内部では統合 reference completer に委譲する。
  */
 export function computeCompletion(
   value: string,
@@ -20,6 +34,11 @@ export function computeCompletion(
   catalog: ConventionsCatalog | null,
 ): CompletionState {
   if (!catalog) return { phase: "idle" };
+
+  const s = computeReferenceCompletion(value, cursorPos, [convResolver], { conventions: catalog });
+  if (s.phase !== "active") return { phase: "idle" };
+
+  // 旧来の category / key phase 判別: before に regex で再マッチ
   const before = value.slice(0, cursorPos);
   const m = before.match(/@conv(?:\.([\w-]*)(?:\.([\w-]*))?)?$/);
   if (!m) return { phase: "idle" };
@@ -28,21 +47,24 @@ export function computeCompletion(
   const keyPart = m[2];
 
   if (keyPart === undefined) {
-    const prefix = catPart ?? "";
-    const candidates = ALL_CONV_CATEGORIES.filter((c) => c.startsWith(prefix));
-    return { phase: "category", prefix, candidates: [...candidates] };
-  } else {
-    const cat = (catalog as unknown as Record<string, unknown>)[catPart!];
-    if (!cat || typeof cat !== "object") return { phase: "idle" };
-    const keys = Object.keys(cat);
-    const candidates = keys.filter((k) => k.startsWith(keyPart));
-    return { phase: "key", category: catPart!, prefix: keyPart, candidates };
+    return {
+      phase: "category",
+      prefix: catPart ?? "",
+      candidates: s.candidates.map((c) => c.value),
+    };
   }
+  return {
+    phase: "key",
+    category: catPart!,
+    prefix: keyPart,
+    candidates: s.candidates.map((c) => c.value),
+  };
 }
 
 /**
  * 補完候補を確定してテキストに挿入する純粋関数。
  * category phase では末尾に "." を付与し、key phase では置換のみ。
+ * 内部では統合 reference completer に委譲する。
  */
 export function insertCandidate(
   value: string,
@@ -51,10 +73,14 @@ export function insertCandidate(
   picked: string,
 ): { newValue: string; newCursor: number } {
   if (state.phase === "idle") return { newValue: value, newCursor: cursorPos };
-  const before = value.slice(0, cursorPos);
-  const after = value.slice(cursorPos);
-  const prefixLen = state.prefix.length;
   const trailing = state.phase === "category" ? "." : "";
-  const newBefore = before.slice(0, before.length - prefixLen) + picked + trailing;
-  return { newValue: newBefore + after, newCursor: newBefore.length };
+  const newState = computeReferenceCompletion(value, cursorPos, [convResolver], {});
+  // newState が idle の場合は直接計算にフォールバック (backward compat)
+  if (newState.phase !== "active") {
+    const before = value.slice(0, cursorPos);
+    const after = value.slice(cursorPos);
+    const newBefore = before.slice(0, before.length - state.prefix.length) + picked + trailing;
+    return { newValue: newBefore + after, newCursor: newBefore.length };
+  }
+  return insertReferenceCandidate(value, cursorPos, newState, { value: picked, trailing: trailing || undefined });
 }

--- a/frontend/src/hooks/useWorkspaceReferences.ts
+++ b/frontend/src/hooks/useWorkspaceReferences.ts
@@ -81,9 +81,9 @@ export function useWorkspaceReferences(): WorkspaceRefs {
             maturity: v.maturity,
           })),
           processFlows: processFlowMetas.map((f) => ({
-            id: f.id,
+            id: f.id as unknown as string,
             name: f.name,
-            kind: f.kind,
+            kind: f.kind ?? "other",
             maturity: f.maturity,
             // actions: ProcessFlowMeta には actions がないため省略
             actions: undefined,

--- a/frontend/src/hooks/useWorkspaceReferences.ts
+++ b/frontend/src/hooks/useWorkspaceReferences.ts
@@ -1,0 +1,117 @@
+/**
+ * ワークスペース全体の参照情報を一括ロードする hook (Phase 2 / #1255)。
+ *
+ * useProcessFlowCatalogs.ts のパターンを参考に、補完用に必要な
+ * screens / tables / viewDefinitions / processFlows / fragments /
+ * components / exceptionTypes / modelEndpoints / secrets / events
+ * を取得する。
+ */
+
+import { useState, useEffect, useCallback } from "react";
+import { loadProject } from "../store/flowStore";
+import { listTables } from "../store/tableStore";
+import { listViewDefinitions } from "../store/viewDefinitionStore";
+import { listGenericDefinitions } from "../store/genericDefinitionStore";
+import { mcpBridge } from "../mcp/mcpBridge";
+import type { WorkspaceRefs } from "../utils/reference-completer/types";
+import type { ProjectCatalogs } from "../schemas/projectCatalogs";
+
+export type { WorkspaceRefs };
+
+function emptyRefs(): WorkspaceRefs {
+  return {
+    screens: [],
+    tables: [],
+    viewDefinitions: [],
+    processFlows: [],
+    fragments: [],
+    components: [],
+    exceptionTypes: [],
+    modelEndpoints: [],
+    secrets: [],
+    events: [],
+  };
+}
+
+/**
+ * ワークスペース全体の参照情報を取得する hook。
+ * mount 時に一度だけロードし、結果を state として保持する。
+ */
+export function useWorkspaceReferences(): WorkspaceRefs {
+  const [refs, setRefs] = useState<WorkspaceRefs>(emptyRefs);
+
+  const load = useCallback(() => {
+    Promise.allSettled([
+      loadProject(),
+      listTables(),
+      listViewDefinitions(),
+      listGenericDefinitions("ui-fragment"),
+      listGenericDefinitions("component-definition"),
+      listGenericDefinitions("exception-type"),
+      mcpBridge.request("loadProjectCatalogs").catch(() => null),
+    ]).then(
+      ([projectResult, tablesResult, viewDefsResult, fragmentsResult, componentsResult, exceptionsResult, catalogsResult]) => {
+        const projectData = projectResult.status === "fulfilled" ? projectResult.value : null;
+        const tablesData = tablesResult.status === "fulfilled" ? tablesResult.value : [];
+        const viewDefsData = viewDefsResult.status === "fulfilled" ? viewDefsResult.value : [];
+        const fragmentsData = fragmentsResult.status === "fulfilled" ? fragmentsResult.value : [];
+        const componentsData = componentsResult.status === "fulfilled" ? componentsResult.value : [];
+        const exceptionsData = exceptionsResult.status === "fulfilled" ? exceptionsResult.value : [];
+        const projectCatalogs = (catalogsResult.status === "fulfilled" ? catalogsResult.value : null) as ProjectCatalogs | null;
+
+        // processFlows は loadProject から meta 情報を取得
+        // actions は ProcessFlow を個別ロードしないと取れないため meta のみ
+        const processFlowMetas = projectData?.processFlows ?? [];
+
+        setRefs({
+          screens: (projectData?.screens ?? []).map((s) => ({
+            id: s.id,
+            name: s.name,
+            maturity: s.maturity,
+          })),
+          tables: tablesData.map((t) => ({
+            id: t.id,
+            physicalName: t.physicalName ?? "",
+            name: t.name,
+            maturity: t.maturity,
+          })),
+          viewDefinitions: viewDefsData.map((v) => ({
+            id: v.id as unknown as string,
+            name: v.name,
+            maturity: v.maturity,
+          })),
+          processFlows: processFlowMetas.map((f) => ({
+            id: f.id,
+            name: f.name,
+            kind: f.kind,
+            maturity: f.maturity,
+            // actions: ProcessFlowMeta には actions がないため省略
+            actions: undefined,
+          })),
+          fragments: fragmentsData.map((d) => ({ name: d.name })),
+          components: componentsData.map((d) => ({ name: d.name })),
+          exceptionTypes: exceptionsData.map((d) => ({ name: d.name })),
+          modelEndpoints: Object.keys(projectCatalogs?.modelEndpoints ?? {}).map((id) => ({
+            id,
+            name: id,
+          })),
+          secrets: Object.keys(projectCatalogs?.secrets ?? {}).map((id) => ({
+            id,
+            name: id,
+          })),
+          events: Object.keys(projectCatalogs?.events ?? {}).map((topic) => ({
+            topic,
+          })),
+        });
+      },
+    ).catch(() => {
+      // ロード失敗時は空のまま (UI は degraded state で動作継続)
+    });
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return refs;
+}

--- a/frontend/src/utils/reference-completer/completer.test.ts
+++ b/frontend/src/utils/reference-completer/completer.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { computeReferenceCompletion, insertReferenceCandidate } from "./completer";
+import { convResolver } from "./convResolver";
+import type { Candidate, CompletionContext } from "./types";
+import type { ConventionsCatalog } from "../../schemas/conventionsValidator";
+
+const catalog: ConventionsCatalog = {
+  version: "1.0.0",
+  msg: { required: { template: "{label}は必須入力です" } },
+  regex: {},
+  limit: {},
+  scope: {},
+  currency: { jpy: { code: "JPY" } },
+  tax: {},
+  auth: {},
+  db: {},
+  numbering: {},
+  tx: {},
+  externalOutcomeDefaults: {},
+};
+
+const ctx = (conventions: ConventionsCatalog | null = catalog): CompletionContext => ({
+  conventions,
+});
+
+describe("computeReferenceCompletion", () => {
+  it("resolver なし → idle", () => {
+    const s = computeReferenceCompletion("@conv.", 6, [], ctx());
+    expect(s.phase).toBe("idle");
+  });
+
+  it("convResolver でマッチ → active", () => {
+    const v = "@conv.";
+    const s = computeReferenceCompletion(v, v.length, [convResolver], ctx());
+    expect(s.phase).toBe("active");
+  });
+
+  it("マッチしない入力 → idle", () => {
+    const s = computeReferenceCompletion("hello world", 11, [convResolver], ctx());
+    expect(s.phase).toBe("idle");
+  });
+
+  it("conventions null → idle", () => {
+    const v = "@conv.";
+    const s = computeReferenceCompletion(v, v.length, [convResolver], ctx(null));
+    expect(s.phase).toBe("idle");
+  });
+});
+
+describe("insertReferenceCandidate", () => {
+  it("idle state → 変更なし", () => {
+    const candidate: Candidate = { value: "anything" };
+    const result = insertReferenceCandidate("hello", 5, { phase: "idle" }, candidate);
+    expect(result.newValue).toBe("hello");
+    expect(result.newCursor).toBe(5);
+  });
+
+  it("active state: prefix を置換し trailing を付与", () => {
+    const v = "@conv.curre";
+    const state = computeReferenceCompletion(v, v.length, [convResolver], ctx());
+    expect(state.phase).toBe("active");
+    const candidate: Candidate = { value: "currency", trailing: "." };
+    const { newValue, newCursor } = insertReferenceCandidate(v, v.length, state, candidate);
+    expect(newValue).toBe("@conv.currency.");
+    expect(newCursor).toBe(newValue.length);
+  });
+
+  it("active state: key 補完 (trailing なし)", () => {
+    const v = "@conv.currency.j";
+    const state = computeReferenceCompletion(v, v.length, [convResolver], ctx());
+    expect(state.phase).toBe("active");
+    const candidate: Candidate = { value: "jpy" };
+    const { newValue, newCursor } = insertReferenceCandidate(v, v.length, state, candidate);
+    expect(newValue).toBe("@conv.currency.jpy");
+    expect(newCursor).toBe(newValue.length);
+  });
+
+  it("カーソルが文中: カーソル以降を保持", () => {
+    const v = "@conv.curre xxx";
+    const cursor = "@conv.curre".length;
+    const state = computeReferenceCompletion(v, cursor, [convResolver], ctx());
+    expect(state.phase).toBe("active");
+    const candidate: Candidate = { value: "currency", trailing: "." };
+    const { newValue, newCursor } = insertReferenceCandidate(v, cursor, state, candidate);
+    expect(newValue).toBe("@conv.currency. xxx");
+    expect(newCursor).toBe("@conv.currency.".length);
+  });
+});

--- a/frontend/src/utils/reference-completer/completer.ts
+++ b/frontend/src/utils/reference-completer/completer.ts
@@ -1,0 +1,43 @@
+/**
+ * reference-completer 統合 API (Phase 1 / #1255)
+ *
+ * computeReferenceCompletion / insertReferenceCandidate を公開する。
+ * Resolver 一覧を受け取り、最初にマッチした Resolver の CompletionState を返す。
+ */
+
+import type { Candidate, CompletionContext, CompletionState, Resolver } from "./types";
+
+/**
+ * resolver 一覧を先頭から試し、最初にマッチした CompletionState を返す。
+ * どれもマッチしなければ { phase: "idle" } を返す。
+ */
+export function computeReferenceCompletion(
+  value: string,
+  cursorPos: number,
+  resolvers: Resolver[],
+  ctx: CompletionContext,
+): CompletionState {
+  for (const r of resolvers) {
+    const s = r.match(value, cursorPos, ctx);
+    if (s && s.phase === "active") return s;
+  }
+  return { phase: "idle" };
+}
+
+/**
+ * 補完候補を確定してテキストに挿入する純粋関数。
+ * state が idle なら何もしない。
+ */
+export function insertReferenceCandidate(
+  value: string,
+  cursorPos: number,
+  state: CompletionState,
+  picked: Candidate,
+): { newValue: string; newCursor: number } {
+  if (state.phase === "idle") return { newValue: value, newCursor: cursorPos };
+  const before = value.slice(0, cursorPos);
+  const after = value.slice(cursorPos);
+  const inserted = picked.value + (picked.trailing ?? "");
+  const newBefore = before.slice(0, before.length - state.replaceLen) + inserted;
+  return { newValue: newBefore + after, newCursor: newBefore.length };
+}

--- a/frontend/src/utils/reference-completer/convResolver.test.ts
+++ b/frontend/src/utils/reference-completer/convResolver.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { convResolver } from "./convResolver";
+import type { CompletionContext } from "./types";
+import type { ConventionsCatalog } from "../../schemas/conventionsValidator";
+
+const catalog: ConventionsCatalog = {
+  version: "1.0.0",
+  msg: { required: { template: "{label}は必須入力です" } },
+  regex: { "email-simple": { pattern: "^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$" } },
+  limit: { nameMax: { value: 100, unit: "char" } },
+  scope: { customerRegion: { value: "domestic" } },
+  currency: { jpy: { code: "JPY" }, usd: { code: "USD" } },
+  tax: { standard: { kind: "exclusive", rate: 0.1 } },
+  auth: { default: { scheme: "session-cookie" } },
+  db: { default: { engine: "postgresql@14" } },
+  numbering: { customerCode: { format: "C-NNNN" }, orderNumber: { format: "ORD-YYYY-NNNN" } },
+  tx: { singleOperation: { policy: "1 TX" } },
+  externalOutcomeDefaults: {
+    success: { outcome: "success", action: "continue" },
+    failure: { outcome: "failure", action: "abort" },
+  },
+};
+
+const ctx = (conventions: ConventionsCatalog | null = catalog): CompletionContext => ({
+  conventions,
+});
+
+describe("convResolver", () => {
+  it("conventions が null → null を返す", () => {
+    const result = convResolver.match("@conv.", 6, ctx(null));
+    expect(result).toBeNull();
+  });
+
+  it("@conv. → active / category 全 11 候補", () => {
+    const v = "@conv.";
+    const result = convResolver.match(v, v.length, ctx());
+    expect(result?.phase).toBe("active");
+    if (result?.phase === "active") {
+      expect(result.candidates).toHaveLength(11);
+      expect(result.resolverId).toBe("conv");
+      expect(result.prefix).toBe("");
+      // category 補完は trailing "." を持つ
+      expect(result.candidates[0].trailing).toBe(".");
+    }
+  });
+
+  it("@conv.curre → 1 候補 (currency)", () => {
+    const v = "@conv.curre";
+    const result = convResolver.match(v, v.length, ctx());
+    expect(result?.phase).toBe("active");
+    if (result?.phase === "active") {
+      expect(result.candidates.map((c) => c.value)).toEqual(["currency"]);
+      expect(result.prefix).toBe("curre");
+    }
+  });
+
+  it("@conv.currency. → key phase / 全キー", () => {
+    const v = "@conv.currency.";
+    const result = convResolver.match(v, v.length, ctx());
+    expect(result?.phase).toBe("active");
+    if (result?.phase === "active") {
+      const vals = result.candidates.map((c) => c.value);
+      expect(vals).toContain("jpy");
+      expect(vals).toContain("usd");
+      expect(result.prefix).toBe("");
+      // key 補完は trailing なし
+      expect(result.candidates[0].trailing).toBeUndefined();
+    }
+  });
+
+  it("@conv.currency.j → prefix 'j' でフィルタ", () => {
+    const v = "@conv.currency.j";
+    const result = convResolver.match(v, v.length, ctx());
+    expect(result?.phase).toBe("active");
+    if (result?.phase === "active") {
+      expect(result.candidates.map((c) => c.value)).toEqual(["jpy"]);
+    }
+  });
+
+  it("@conv.unknown. → null (catalog にないカテゴリ)", () => {
+    const v = "@conv.unknown.";
+    const result = convResolver.match(v, v.length, ctx());
+    // 候補 0 件 か null かどちらかで idle 相当であること
+    if (result !== null && result.phase === "active") {
+      expect(result.candidates).toHaveLength(0);
+    } else {
+      expect(result).toBeNull();
+    }
+  });
+
+  it("関係ないテキスト → null", () => {
+    const v = "Math.floor(subtotal * 0.10)";
+    const result = convResolver.match(v, v.length, ctx());
+    expect(result).toBeNull();
+  });
+
+  it("文中 @conv.msg.req でカーソルが 'req' 末尾 → active", () => {
+    const v = "foo @conv.msg.req bar";
+    const cursor = "foo @conv.msg.req".length;
+    const result = convResolver.match(v, cursor, ctx());
+    expect(result?.phase).toBe("active");
+    if (result?.phase === "active") {
+      expect(result.candidates.map((c) => c.value)).toContain("required");
+    }
+  });
+});

--- a/frontend/src/utils/reference-completer/convResolver.ts
+++ b/frontend/src/utils/reference-completer/convResolver.ts
@@ -1,0 +1,54 @@
+/**
+ * @conv.<category>.<key> 補完 Resolver (Phase 1 / #1255)
+ *
+ * 既存 useConvCompletion.ts の computeCompletion ロジックを
+ * Resolver 形式に移植したもの。
+ * ALL_CONV_CATEGORIES は useConvCompletion.ts で定義されたものを参照。
+ */
+
+import { ALL_CONV_CATEGORIES } from "../../hooks/useConvCompletion";
+import type { Candidate, CompletionContext, CompletionState, Resolver } from "./types";
+
+export const convResolver: Resolver = {
+  id: "conv",
+
+  match(value: string, cursorPos: number, ctx: CompletionContext): CompletionState | null {
+    if (!ctx.conventions) return null;
+
+    const before = value.slice(0, cursorPos);
+    // @conv 以降にカテゴリ部・キー部が続くパターンにマッチ
+    const m = before.match(/@conv(?:\.([\w-]*)(?:\.([\w-]*))?)?$/);
+    if (!m) return null;
+
+    const catPart = m[1];
+    const keyPart = m[2];
+
+    if (keyPart === undefined) {
+      // カテゴリ補完フェーズ
+      const prefix = catPart ?? "";
+      const candidates: Candidate[] = (ALL_CONV_CATEGORIES as readonly string[])
+        .filter((c) => c.startsWith(prefix))
+        .map((c) => ({ value: c, label: c, trailing: "." }));
+      return {
+        phase: "active",
+        resolverId: "conv",
+        prefix,
+        candidates,
+        replaceLen: prefix.length,
+      };
+    }
+
+    // キー補完フェーズ
+    const cat = (ctx.conventions as unknown as Record<string, unknown>)[catPart!];
+    if (!cat || typeof cat !== "object") return null;
+    const keys = Object.keys(cat as object).filter((k) => k.startsWith(keyPart));
+    const candidates: Candidate[] = keys.map((k) => ({ value: k }));
+    return {
+      phase: "active",
+      resolverId: "conv",
+      prefix: keyPart,
+      candidates,
+      replaceLen: keyPart.length,
+    };
+  },
+};

--- a/frontend/src/utils/reference-completer/extensionResolver.test.ts
+++ b/frontend/src/utils/reference-completer/extensionResolver.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import { extensionResolver } from "./extensionResolver";
+import type { CompletionContext } from "./types";
+import type { LoadedExtensions } from "../../schemas/loadExtensions";
+
+const mockExtensions: LoadedExtensions = {
+  steps: {
+    "myns:SendEmail": {
+      label: "メール送信",
+      icon: "bi-envelope",
+      description: "メールを送信する",
+      schema: {},
+    },
+    "myns:Notify": {
+      label: "通知",
+      icon: "bi-bell",
+      description: "通知を送信する",
+      schema: {},
+    },
+    "globalStep": {
+      label: "グローバル step",
+      icon: "bi-play",
+      description: "namespace なし",
+      schema: {},
+    },
+  },
+  triggers: [
+    { value: "myns:webhook", label: "Webhook" },
+    { value: "click", label: "クリック" }, // namespace なし → スキップ
+  ],
+  fieldTypes: [
+    { kind: "myns:customField", label: "カスタムフィールド" },
+  ],
+  dbOperations: [
+    { value: "myns:UPSERT", label: "UPSERT" },
+    { value: "SELECT", label: "SELECT" }, // namespace なし → スキップ
+  ],
+  responseTypes: {
+    "myns:PaginatedList": {
+      schema: { type: "object" },
+    },
+    "Success": {
+      schema: { type: "object" },
+    }, // namespace なし → スキップ
+  },
+};
+
+const ctx = (extra: Partial<CompletionContext> = {}): CompletionContext => ({
+  fieldKind: "extensionRef",
+  extensions: mockExtensions,
+  ...extra,
+});
+
+describe("extensionResolver", () => {
+  it("fieldKind='extensionRef' + extensions → namespace:kind 形式の候補", () => {
+    const result = extensionResolver.match("", 0, ctx());
+    expect(result?.phase).toBe("active");
+    if (result?.phase === "active") {
+      const vals = result.candidates.map((c) => c.value);
+      // namespace 付きのみ含む
+      expect(vals).toContain("myns:SendEmail");
+      expect(vals).toContain("myns:Notify");
+      expect(vals).toContain("myns:webhook");
+      expect(vals).toContain("myns:UPSERT");
+      expect(vals).toContain("myns:PaginatedList");
+      // namespace なしは含まない
+      expect(vals).not.toContain("globalStep");
+      expect(vals).not.toContain("click");
+      expect(vals).not.toContain("SELECT");
+      expect(vals).not.toContain("Success");
+    }
+  });
+
+  it("prefix フィルタ (myns:Send で絞り込み)", () => {
+    const result = extensionResolver.match("myns:Send", 9, ctx());
+    expect(result?.phase).toBe("active");
+    if (result?.phase === "active") {
+      expect(result.candidates.map((c) => c.value)).toContain("myns:SendEmail");
+      expect(result.candidates.map((c) => c.value)).not.toContain("myns:Notify");
+    }
+  });
+
+  it("hint に label が含まれる", () => {
+    const result = extensionResolver.match("myns:SendEmail", 14, ctx());
+    expect(result?.phase).toBe("active");
+    if (result?.phase === "active") {
+      const found = result.candidates.find((c) => c.value === "myns:SendEmail");
+      expect(found?.hint).toBe("メール送信");
+    }
+  });
+
+  it("fieldKind 不一致 → null", () => {
+    const result = extensionResolver.match("", 0, { ...ctx(), fieldKind: "other" });
+    expect(result).toBeNull();
+  });
+
+  it("extensions なし → null", () => {
+    const result = extensionResolver.match("", 0, { fieldKind: "extensionRef" });
+    expect(result).toBeNull();
+  });
+
+  it("重複は除去される (steps / responseTypes の同キー)", () => {
+    const extWithDup: LoadedExtensions = {
+      ...mockExtensions,
+      steps: { "myns:SendEmail": mockExtensions.steps["myns:SendEmail"] },
+      responseTypes: { "myns:SendEmail": { schema: {} } }, // 重複
+    };
+    const result = extensionResolver.match("", 0, { fieldKind: "extensionRef", extensions: extWithDup });
+    expect(result?.phase).toBe("active");
+    if (result?.phase === "active") {
+      const matches = result.candidates.filter((c) => c.value === "myns:SendEmail");
+      expect(matches).toHaveLength(1);
+    }
+  });
+});

--- a/frontend/src/utils/reference-completer/extensionResolver.ts
+++ b/frontend/src/utils/reference-completer/extensionResolver.ts
@@ -1,0 +1,90 @@
+/**
+ * 拡張 namespace:kindName 補完 Resolver (Phase 3 / #1255)。
+ *
+ * LoadedExtensions の steps / triggers / fieldTypes / dbOperations / responseTypes を
+ * walk して `<namespace>:<kindName>` 形式の候補を生成する。
+ *
+ * fieldKind="extensionRef" で起動する。
+ */
+
+import type { Candidate, CompletionContext, CompletionState, Resolver } from "./types";
+
+/**
+ * LoadedExtensions から namespace:kind 形式の候補を列挙する。
+ * - steps: Record<"ns:name", StepDef> → namespace:name
+ * - triggers: { value: "ns:trigger" }[] → namespace:trigger
+ * - fieldTypes (namespace:kind なし、単純 kind のみ) → スキップ
+ * - dbOperations (namespace:op) → namespace:op
+ * - responseTypes: Record<"ns:type", ...> → namespace:type
+ */
+function collectExtensionCandidates(ctx: CompletionContext): Candidate[] {
+  const ext = ctx.extensions;
+  if (!ext) return [];
+
+  const candidates: Candidate[] = [];
+  const seen = new Set<string>();
+
+  const add = (value: string, hint?: string) => {
+    if (!seen.has(value)) {
+      seen.add(value);
+      candidates.push({ value, hint });
+    }
+  };
+
+  // steps: "namespace:stepName" → namespace:stepName
+  for (const key of Object.keys(ext.steps)) {
+    if (key.includes(":")) {
+      const def = ext.steps[key];
+      add(key, def?.label);
+    }
+  }
+
+  // triggers: { value: "namespace:trigger" }
+  for (const t of ext.triggers) {
+    if (t.value.includes(":")) {
+      add(t.value, t.label);
+    }
+  }
+
+  // dbOperations: { value: "namespace:op" }
+  for (const op of ext.dbOperations) {
+    if (op.value.includes(":")) {
+      add(op.value, op.label);
+    }
+  }
+
+  // responseTypes: "namespace:type"
+  for (const key of Object.keys(ext.responseTypes)) {
+    if (key.includes(":")) {
+      add(key);
+    }
+  }
+
+  return candidates;
+}
+
+/** 拡張 namespace:kindName 補完 Resolver。 */
+export const extensionResolver: Resolver = {
+  id: "extensionRef",
+
+  match(value: string, _cursorPos: number, ctx: CompletionContext): CompletionState | null {
+    if (ctx.fieldKind !== "extensionRef") return null;
+    if (!ctx.extensions) return null;
+
+    const prefix = value;
+    const lowerPrefix = prefix.toLowerCase();
+    const all = collectExtensionCandidates(ctx);
+    const filtered = all.filter((c) => {
+      return c.value.toLowerCase().includes(lowerPrefix) ||
+        (c.hint ?? "").toLowerCase().includes(lowerPrefix);
+    });
+
+    return {
+      phase: "active",
+      resolverId: "extensionRef",
+      prefix,
+      candidates: filtered,
+      replaceLen: prefix.length,
+    };
+  },
+};

--- a/frontend/src/utils/reference-completer/processFlowScopeResolver.test.ts
+++ b/frontend/src/utils/reference-completer/processFlowScopeResolver.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from "vitest";
+import { stepResultResolver, inputsResolver, fieldErrorsResolver } from "./processFlowScopeResolver";
+import type { CompletionContext } from "./types";
+import type { ProcessFlow } from "../../types/v3";
+
+// テスト用 ProcessFlow モック
+const mockFlow: ProcessFlow = {
+  meta: {
+    id: "pf-test" as Parameters<typeof stepResultResolver.match>[2]["flow"] extends ProcessFlow ? ProcessFlow["meta"]["id"] : never,
+    name: "テストフロー",
+    kind: "screen",
+    createdAt: "2026-01-01T00:00:00Z" as unknown as Parameters<typeof stepResultResolver.match>[2]["flow"] extends ProcessFlow ? ProcessFlow["meta"]["createdAt"] : never,
+    updatedAt: "2026-01-01T00:00:00Z" as unknown as Parameters<typeof stepResultResolver.match>[2]["flow"] extends ProcessFlow ? ProcessFlow["meta"]["updatedAt"] : never,
+  },
+  actions: [
+    {
+      id: "act-1",
+      name: "メインアクション",
+      trigger: "submit",
+      inputs: [
+        { name: "userId", type: "string" },
+        { name: "amount", type: "number" },
+      ],
+      steps: [
+        {
+          id: "validate",
+          kind: "validation" as const,
+          description: "入力検証",
+          fieldErrorsVar: "fieldErrors" as unknown as Parameters<typeof fieldErrorsResolver.match>[2]["flow"] extends ProcessFlow ? ProcessFlow["actions"][0]["steps"][0] extends { fieldErrorsVar: infer F } ? F : never : never,
+          rules: [
+            { field: "userId", type: "required" },
+            { field: "amount", type: "minValue", min: 0 },
+          ],
+        } as unknown as ProcessFlow["actions"][0]["steps"][0],
+        {
+          id: "fetchUser",
+          kind: "dbAccess" as const,
+          description: "ユーザー取得",
+          operation: "SELECT",
+          sql: "SELECT id, name AS userName, email AS userEmail FROM users WHERE id = @inputs.userId",
+          outputBinding: {
+            name: "userResult",
+          },
+        } as unknown as ProcessFlow["actions"][0]["steps"][0],
+        {
+          id: "computeTotal",
+          kind: "compute" as const,
+          description: "合計計算",
+          outputBinding: {
+            name: "totalAmount",
+          },
+        } as unknown as ProcessFlow["actions"][0]["steps"][0],
+      ],
+    },
+  ],
+};
+
+const ctx = (extra: Partial<CompletionContext> = {}): CompletionContext => ({
+  flow: mockFlow,
+  ...extra,
+});
+
+describe("stepResultResolver", () => {
+  it("ctx.flow なし → null", () => {
+    const result = stepResultResolver.match("@stepResult.", 12, {});
+    expect(result).toBeNull();
+  });
+
+  it("@stepResult. → stepId 補完 (全 step)", () => {
+    const v = "@stepResult.";
+    const result = stepResultResolver.match(v, v.length, ctx());
+    expect(result?.phase).toBe("active");
+    if (result?.phase === "active") {
+      const vals = result.candidates.map((c) => c.value);
+      expect(vals).toContain("validate");
+      expect(vals).toContain("fetchUser");
+      expect(vals).toContain("computeTotal");
+      // stepId 補完は trailing "." を持つ
+      expect(result.candidates[0].trailing).toBe(".");
+    }
+  });
+
+  it("@stepResult.fetch → prefix フィルタ", () => {
+    const v = "@stepResult.fetch";
+    const result = stepResultResolver.match(v, v.length, ctx());
+    expect(result?.phase).toBe("active");
+    if (result?.phase === "active") {
+      expect(result.candidates.map((c) => c.value)).toContain("fetchUser");
+    }
+  });
+
+  it("@stepResult.fetchUser. → field 補完 (outputBinding.name + SQL alias)", () => {
+    const v = "@stepResult.fetchUser.";
+    const result = stepResultResolver.match(v, v.length, ctx());
+    expect(result?.phase).toBe("active");
+    if (result?.phase === "active") {
+      const vals = result.candidates.map((c) => c.value);
+      // outputBinding.name = "userResult"
+      expect(vals).toContain("userResult");
+      // SQL alias: userName, userEmail
+      expect(vals).toContain("userName");
+      expect(vals).toContain("userEmail");
+    }
+  });
+
+  it("@stepResult.computeTotal. → outputBinding.name のみ", () => {
+    const v = "@stepResult.computeTotal.";
+    const result = stepResultResolver.match(v, v.length, ctx());
+    expect(result?.phase).toBe("active");
+    if (result?.phase === "active") {
+      const vals = result.candidates.map((c) => c.value);
+      expect(vals).toContain("totalAmount");
+    }
+  });
+
+  it("存在しない stepId → active / 候補 0 件", () => {
+    const v = "@stepResult.unknown.";
+    const result = stepResultResolver.match(v, v.length, ctx());
+    // unknown step が見つからないため null または active 0 件
+    if (result !== null && result.phase === "active") {
+      expect(result.candidates).toHaveLength(0);
+    } else {
+      expect(result).toBeNull();
+    }
+  });
+
+  it("関係ないテキスト → null", () => {
+    const result = stepResultResolver.match("hello", 5, ctx());
+    expect(result).toBeNull();
+  });
+});
+
+describe("inputsResolver", () => {
+  it("ctx.flow なし → null", () => {
+    const result = inputsResolver.match("@inputs.u", 9, {});
+    expect(result).toBeNull();
+  });
+
+  it("@inputs. → 全 inputs 補完", () => {
+    const v = "@inputs.";
+    const result = inputsResolver.match(v, v.length, ctx());
+    expect(result?.phase).toBe("active");
+    if (result?.phase === "active") {
+      const vals = result.candidates.map((c) => c.value);
+      expect(vals).toContain("userId");
+      expect(vals).toContain("amount");
+    }
+  });
+
+  it("@inputs.u → prefix フィルタ", () => {
+    const v = "@inputs.u";
+    const result = inputsResolver.match(v, v.length, ctx());
+    expect(result?.phase).toBe("active");
+    if (result?.phase === "active") {
+      expect(result.candidates.map((c) => c.value)).toContain("userId");
+      expect(result.candidates.map((c) => c.value)).not.toContain("amount");
+    }
+  });
+
+  it("関係ないテキスト → null", () => {
+    expect(inputsResolver.match("hello", 5, ctx())).toBeNull();
+  });
+});
+
+describe("fieldErrorsResolver", () => {
+  it("ctx.flow なし → null", () => {
+    expect(fieldErrorsResolver.match("@fieldErrors.", 13, {})).toBeNull();
+  });
+
+  it("@fieldErrors. → validation step の field 候補", () => {
+    const v = "@fieldErrors.";
+    const result = fieldErrorsResolver.match(v, v.length, ctx());
+    expect(result?.phase).toBe("active");
+    if (result?.phase === "active") {
+      const vals = result.candidates.map((c) => c.value);
+      // fieldErrorsVar = "fieldErrors"
+      expect(vals).toContain("fieldErrors");
+      // rules[].field = "userId", "amount"
+      expect(vals).toContain("userId");
+      expect(vals).toContain("amount");
+    }
+  });
+
+  it("@fieldErrors.user → prefix フィルタ", () => {
+    const v = "@fieldErrors.user";
+    const result = fieldErrorsResolver.match(v, v.length, ctx());
+    expect(result?.phase).toBe("active");
+    if (result?.phase === "active") {
+      expect(result.candidates.map((c) => c.value)).toContain("userId");
+    }
+  });
+});

--- a/frontend/src/utils/reference-completer/processFlowScopeResolver.ts
+++ b/frontend/src/utils/reference-completer/processFlowScopeResolver.ts
@@ -17,7 +17,7 @@ export const stepResultResolver: Resolver = {
     if (!ctx.flow) return null;
 
     const before = value.slice(0, cursorPos);
-    const m = before.match(/@stepResult(?:\.([\w-]*)(?:\.([\w-]*))?)?$/);
+    const m = before.match(/@stepResult\.([\w-]*)(?:\.([\w-]*))?$/);
     if (!m) return null;
 
     const stepIdPart = m[1];

--- a/frontend/src/utils/reference-completer/processFlowScopeResolver.ts
+++ b/frontend/src/utils/reference-completer/processFlowScopeResolver.ts
@@ -1,0 +1,181 @@
+/**
+ * ProcessFlow スコープ式補完 Resolver 群 (Phase 3 / #1255)。
+ *
+ * @stepResult.<stepId>.<field> / @inputs.<name> / @fieldErrors.<field>
+ * の 3 種類のスコープ式を補完する。
+ *
+ * ctx.flow に ProcessFlow が渡されている場合のみ動作する。
+ */
+
+import type { Candidate, CompletionContext, CompletionState, Resolver } from "./types";
+
+/** @stepResult.<stepId>.<field> resolver。 */
+export const stepResultResolver: Resolver = {
+  id: "stepResult",
+
+  match(value: string, cursorPos: number, ctx: CompletionContext): CompletionState | null {
+    if (!ctx.flow) return null;
+
+    const before = value.slice(0, cursorPos);
+    const m = before.match(/@stepResult(?:\.([\w-]*)(?:\.([\w-]*))?)?$/);
+    if (!m) return null;
+
+    const stepIdPart = m[1];
+    const fieldPart = m[2];
+
+    // 全 step の id を収集
+    const allSteps = ctx.flow.actions.flatMap((action) => action.steps ?? []);
+
+    if (fieldPart === undefined) {
+      // stepId 補完フェーズ
+      const prefix = stepIdPart ?? "";
+      const stepIds = allSteps
+        .map((s) => s.id as unknown as string)
+        .filter((id): id is string => typeof id === "string" && id.startsWith(prefix));
+      const unique = [...new Set(stepIds)];
+      const candidates: Candidate[] = unique.map((id) => ({
+        value: id,
+        trailing: ".",
+      }));
+      return {
+        phase: "active",
+        resolverId: "stepResult",
+        prefix,
+        candidates,
+        replaceLen: prefix.length,
+      };
+    }
+
+    // field 補完フェーズ: 該当 step の outputBinding フィールドまたは dbAccess の SELECT alias
+    const targetStep = allSteps.find((s) => (s.id as unknown as string) === stepIdPart);
+    if (!targetStep) return null;
+
+    const fields = new Set<string>();
+
+    // outputBinding からフィールド名取得
+    const stepAny = targetStep as unknown as Record<string, unknown>;
+    const outputBinding = stepAny.outputBinding as Record<string, unknown> | undefined;
+    if (outputBinding && typeof outputBinding.name === "string") {
+      fields.add(outputBinding.name);
+    }
+
+    // dbAccess step の sql フィールドから SELECT alias 抽出
+    if (stepAny.kind === "dbAccess") {
+      const sql = stepAny.sql as string | undefined;
+      if (sql) {
+        const aliasMatches = [...sql.matchAll(/\bAS\s+(\w+)/gi)];
+        for (const match of aliasMatches) {
+          if (match[1]) fields.add(match[1]);
+        }
+      }
+    }
+
+    const prefix = fieldPart;
+    const candidates: Candidate[] = [...fields]
+      .filter((f) => f.startsWith(prefix))
+      .map((f) => ({ value: f }));
+
+    return {
+      phase: "active",
+      resolverId: "stepResult",
+      prefix,
+      candidates,
+      replaceLen: prefix.length,
+    };
+  },
+};
+
+/** @inputs.<name> resolver。 */
+export const inputsResolver: Resolver = {
+  id: "inputs",
+
+  match(value: string, cursorPos: number, ctx: CompletionContext): CompletionState | null {
+    if (!ctx.flow) return null;
+
+    const before = value.slice(0, cursorPos);
+    const m = before.match(/@inputs\.([\w-]*)$/);
+    if (!m) return null;
+
+    const prefix = m[1];
+
+    // 全 action の inputs からフィールド名収集
+    const inputNames = new Set<string>();
+    for (const action of ctx.flow.actions) {
+      for (const input of action.inputs ?? []) {
+        if (typeof input.name === "string") {
+          inputNames.add(input.name);
+        }
+      }
+    }
+
+    const candidates: Candidate[] = [...inputNames]
+      .filter((n) => n.startsWith(prefix))
+      .map((n) => ({ value: n }));
+
+    return {
+      phase: "active",
+      resolverId: "inputs",
+      prefix,
+      candidates,
+      replaceLen: prefix.length,
+    };
+  },
+};
+
+/** @fieldErrors.<field> resolver。 */
+export const fieldErrorsResolver: Resolver = {
+  id: "fieldErrors",
+
+  match(value: string, cursorPos: number, ctx: CompletionContext): CompletionState | null {
+    if (!ctx.flow) return null;
+
+    const before = value.slice(0, cursorPos);
+    const m = before.match(/@fieldErrors\.([\w-]*)$/);
+    if (!m) return null;
+
+    const prefix = m[1];
+
+    // 全 step の validation step から fieldErrorsVar を取得
+    const fields = new Set<string>();
+    for (const action of ctx.flow.actions) {
+      for (const step of action.steps ?? []) {
+        const stepAny = step as unknown as Record<string, unknown>;
+        if (stepAny.kind === "validation") {
+          const fieldErrorsVar = stepAny.fieldErrorsVar;
+          if (typeof fieldErrorsVar === "string") {
+            fields.add(fieldErrorsVar);
+          }
+          // rules から field 名も収集
+          const rules = stepAny.rules as Array<Record<string, unknown>> | undefined;
+          if (Array.isArray(rules)) {
+            for (const rule of rules) {
+              const field = rule.field;
+              if (typeof field === "string") {
+                fields.add(field);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    const candidates: Candidate[] = [...fields]
+      .filter((f) => f.startsWith(prefix))
+      .map((f) => ({ value: f }));
+
+    return {
+      phase: "active",
+      resolverId: "fieldErrors",
+      prefix,
+      candidates,
+      replaceLen: prefix.length,
+    };
+  },
+};
+
+/** 全 processFlow スコープ resolver のデフォルトセット。 */
+export const ALL_PROCESS_FLOW_SCOPE_RESOLVERS: Resolver[] = [
+  stepResultResolver,
+  inputsResolver,
+  fieldErrorsResolver,
+];

--- a/frontend/src/utils/reference-completer/types.ts
+++ b/frontend/src/utils/reference-completer/types.ts
@@ -1,0 +1,85 @@
+/**
+ * reference-completer 基盤型定義 (Phase 1 / #1255)
+ *
+ * ProcessFlow エディタ / ScreenItemsView 等の入力フィールドで
+ * @conv.* / @stepResult.* / @inputs.* / screenId / tableId 等の各種 reference を
+ * 補完する統合 API の型定義。
+ */
+
+import type { ConventionsCatalog } from "../../schemas/conventionsValidator";
+import type { LoadedExtensions } from "../../schemas/loadExtensions";
+import type { ProcessFlow } from "../../types/v3";
+
+/** 補完候補 1 件。 */
+export interface Candidate {
+  /** 補完で入力される文字列。 */
+  value: string;
+  /** 表示テキスト（省略時 value）。 */
+  label?: string;
+  /** サブテキスト (title / maturity 等)。 */
+  hint?: string;
+  /** 確定時の suffix (例: category → ".")。 */
+  trailing?: string;
+}
+
+/** 補完状態。 */
+export type CompletionState =
+  | { phase: "idle" }
+  | {
+      phase: "active";
+      /** どの Resolver が生成したかの識別子。 */
+      resolverId: string;
+      /** 入力済み prefix (置換対象)。 */
+      prefix: string;
+      /** 補完候補一覧。 */
+      candidates: Candidate[];
+      /** 置換する文字数 (通常 prefix.length)。 */
+      replaceLen: number;
+    };
+
+/** workspace 全体の参照情報。useWorkspaceReferences の返却型。 */
+export interface WorkspaceRefs {
+  screens: { id: string; name: string; maturity?: string }[];
+  tables: { id: string; physicalName: string; name: string; maturity?: string }[];
+  viewDefinitions: { id: string; name: string; maturity?: string }[];
+  processFlows: {
+    id: string;
+    name: string;
+    kind: string;
+    maturity?: string;
+    actions?: { id: string; name?: string }[];
+  }[];
+  fragments: { name: string }[];
+  components: { name: string }[];
+  exceptionTypes: { name: string }[];
+  modelEndpoints: { id: string; name?: string }[];
+  secrets: { id: string; name?: string }[];
+  events: { topic: string; description?: string }[];
+}
+
+/** 補完計算に必要なコンテキスト情報。 */
+export interface CompletionContext {
+  /** フィールド種別 (field-level resolver の起動判定用)。 */
+  fieldKind?: string;
+  /** 規約カタログ (@conv.* resolver 用)。 */
+  conventions?: ConventionsCatalog | null;
+  /** ワークスペース全参照情報 (cross-resource ID resolver 用)。 */
+  workspace?: WorkspaceRefs;
+  /** 現在編集中の ProcessFlow (scoped expression resolver 用)。 */
+  flow?: ProcessFlow;
+  /** 拡張定義 (extensionRef resolver 用)。 */
+  extensions?: LoadedExtensions;
+  /** handlerActionId resolver: 対象 flow の id。 */
+  handlerFlowId?: string;
+}
+
+/** 補完 Resolver インターフェース。 */
+export interface Resolver {
+  /** 識別子。 */
+  id: string;
+  /**
+   * 入力値・カーソル位置・コンテキストから補完状態を計算する。
+   * 補完対象外なら null または { phase: "idle" } を返す。
+   */
+  match(value: string, cursorPos: number, ctx: CompletionContext): CompletionState | null;
+}

--- a/frontend/src/utils/reference-completer/workspaceResolver.test.ts
+++ b/frontend/src/utils/reference-completer/workspaceResolver.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect } from "vitest";
+import {
+  screenIdResolver,
+  tableIdResolver,
+  viewDefinitionIdResolver,
+  handlerFlowIdResolver,
+  handlerActionIdResolver,
+  fragmentRefResolver,
+  componentRefResolver,
+  exceptionTypeRefResolver,
+  modelRefResolver,
+  secretRefResolver,
+  topicResolver,
+} from "./workspaceResolver";
+import type { CompletionContext, WorkspaceRefs } from "./types";
+
+const mockWorkspace: WorkspaceRefs = {
+  screens: [
+    { id: "scr-001", name: "ログイン画面", maturity: "committed" },
+    { id: "scr-002", name: "商品一覧", maturity: "draft" },
+    { id: "scr-003", name: "注文確認" },
+  ],
+  tables: [
+    { id: "tbl-001", physicalName: "users", name: "ユーザー", maturity: "committed" },
+    { id: "tbl-002", physicalName: "orders", name: "注文", maturity: "draft" },
+  ],
+  viewDefinitions: [
+    { id: "vd-001", name: "商品ビュー" },
+    { id: "vd-002", name: "注文ビュー", maturity: "committed" },
+  ],
+  processFlows: [
+    {
+      id: "pf-001",
+      name: "ログインフロー",
+      kind: "screen",
+      actions: [
+        { id: "act-login", name: "ログイン処理" },
+        { id: "act-logout", name: "ログアウト" },
+      ],
+    },
+    {
+      id: "pf-002",
+      name: "注文フロー",
+      kind: "screen",
+      actions: [{ id: "act-order", name: "注文処理" }],
+    },
+  ],
+  fragments: [
+    { name: "HeaderFragment" },
+    { name: "FooterFragment" },
+  ],
+  components: [
+    { name: "SearchBox" },
+    { name: "DataTable" },
+  ],
+  exceptionTypes: [
+    { name: "BusinessException" },
+    { name: "AuthException" },
+  ],
+  modelEndpoints: [
+    { id: "gpt4", name: "GPT-4" },
+    { id: "claude3", name: "Claude 3" },
+  ],
+  secrets: [
+    { id: "DB_PASSWORD", name: "DB_PASSWORD" },
+    { id: "API_KEY", name: "API_KEY" },
+  ],
+  events: [
+    { topic: "order.created", description: "注文作成" },
+    { topic: "user.login", description: "ログイン" },
+  ],
+};
+
+function ctx(fieldKind: string, extra: Partial<CompletionContext> = {}): CompletionContext {
+  return { fieldKind, workspace: mockWorkspace, ...extra };
+}
+
+describe("screenIdResolver", () => {
+  it("fieldKind='screenId' → 全 screen を返す", () => {
+    const s = screenIdResolver.match("", 0, ctx("screenId"));
+    expect(s?.phase).toBe("active");
+    if (s?.phase === "active") {
+      expect(s.candidates).toHaveLength(3);
+      expect(s.candidates[0].value).toBe("scr-001");
+      expect(s.candidates[0].label).toBe("ログイン画面");
+    }
+  });
+
+  it("prefix フィルタで絞り込み", () => {
+    const s = screenIdResolver.match("注文", 2, ctx("screenId"));
+    expect(s?.phase).toBe("active");
+    if (s?.phase === "active") {
+      // "注文確認" の 1 件 (商品一覧は除外)
+      expect(s.candidates.length).toBeGreaterThanOrEqual(1);
+      expect(s.candidates.every((c) => (c.label ?? "").includes("注文"))).toBe(true);
+    }
+  });
+
+  it("fieldKind 不一致 → null", () => {
+    const s = screenIdResolver.match("", 0, ctx("tableId"));
+    expect(s).toBeNull();
+  });
+});
+
+describe("tableIdResolver", () => {
+  it("fieldKind='tableId' → 全 table を返す", () => {
+    const s = tableIdResolver.match("", 0, ctx("tableId"));
+    expect(s?.phase).toBe("active");
+    if (s?.phase === "active") {
+      expect(s.candidates).toHaveLength(2);
+      // label に physicalName を含む
+      expect(s.candidates[0].label).toContain("users");
+    }
+  });
+
+  it("physicalName で絞り込み", () => {
+    const s = tableIdResolver.match("order", 5, ctx("tableId"));
+    expect(s?.phase).toBe("active");
+    if (s?.phase === "active") {
+      expect(s.candidates.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+});
+
+describe("viewDefinitionIdResolver", () => {
+  it("fieldKind='viewDefinitionId' → 全 viewDefinition を返す", () => {
+    const s = viewDefinitionIdResolver.match("", 0, ctx("viewDefinitionId"));
+    expect(s?.phase).toBe("active");
+    if (s?.phase === "active") {
+      expect(s.candidates).toHaveLength(2);
+    }
+  });
+});
+
+describe("handlerFlowIdResolver", () => {
+  it("fieldKind='handlerFlowId' → 全 processFlow を返す", () => {
+    const s = handlerFlowIdResolver.match("", 0, ctx("handlerFlowId"));
+    expect(s?.phase).toBe("active");
+    if (s?.phase === "active") {
+      expect(s.candidates).toHaveLength(2);
+      expect(s.candidates[0].hint).toBe("screen");
+    }
+  });
+
+  it("name で絞り込み", () => {
+    const s = handlerFlowIdResolver.match("ログイン", 4, ctx("handlerFlowId"));
+    expect(s?.phase).toBe("active");
+    if (s?.phase === "active") {
+      expect(s.candidates.length).toBeGreaterThanOrEqual(1);
+      expect(s.candidates[0].label).toContain("ログイン");
+    }
+  });
+});
+
+describe("handlerActionIdResolver", () => {
+  it("handlerFlowId 指定時: 該当フローの actions のみ", () => {
+    const s = handlerActionIdResolver.match("", 0, {
+      ...ctx("handlerActionId"),
+      handlerFlowId: "pf-001",
+    });
+    expect(s?.phase).toBe("active");
+    if (s?.phase === "active") {
+      expect(s.candidates).toHaveLength(2);
+      expect(s.candidates.map((c) => c.value)).toContain("act-login");
+    }
+  });
+
+  it("handlerFlowId 未指定時: 全フローの actions", () => {
+    const s = handlerActionIdResolver.match("", 0, ctx("handlerActionId"));
+    expect(s?.phase).toBe("active");
+    if (s?.phase === "active") {
+      // pf-001 の 2 件 + pf-002 の 1 件 = 3 件
+      expect(s.candidates).toHaveLength(3);
+    }
+  });
+});
+
+describe("fragmentRefResolver", () => {
+  it("fieldKind='fragmentRef' → 全 fragment を返す", () => {
+    const s = fragmentRefResolver.match("", 0, ctx("fragmentRef"));
+    expect(s?.phase).toBe("active");
+    if (s?.phase === "active") {
+      expect(s.candidates).toHaveLength(2);
+      expect(s.candidates.map((c) => c.value)).toContain("HeaderFragment");
+    }
+  });
+});
+
+describe("componentRefResolver", () => {
+  it("fieldKind='componentRef' → 全 component を返す", () => {
+    const s = componentRefResolver.match("", 0, ctx("componentRef"));
+    expect(s?.phase).toBe("active");
+    if (s?.phase === "active") {
+      expect(s.candidates).toHaveLength(2);
+    }
+  });
+});
+
+describe("exceptionTypeRefResolver", () => {
+  it("fieldKind='exceptionTypeRef' → 全 exceptionType を返す", () => {
+    const s = exceptionTypeRefResolver.match("", 0, ctx("exceptionTypeRef"));
+    expect(s?.phase).toBe("active");
+    if (s?.phase === "active") {
+      expect(s.candidates).toHaveLength(2);
+      expect(s.candidates.map((c) => c.value)).toContain("BusinessException");
+    }
+  });
+});
+
+describe("modelRefResolver", () => {
+  it("fieldKind='modelRef' → 全 modelEndpoint を返す", () => {
+    const s = modelRefResolver.match("", 0, ctx("modelRef"));
+    expect(s?.phase).toBe("active");
+    if (s?.phase === "active") {
+      expect(s.candidates).toHaveLength(2);
+      expect(s.candidates.map((c) => c.value)).toContain("gpt4");
+    }
+  });
+});
+
+describe("secretRefResolver", () => {
+  it("fieldKind='secretRef' → 全 secret を返す", () => {
+    const s = secretRefResolver.match("", 0, ctx("secretRef"));
+    expect(s?.phase).toBe("active");
+    if (s?.phase === "active") {
+      expect(s.candidates).toHaveLength(2);
+    }
+  });
+});
+
+describe("topicResolver", () => {
+  it("fieldKind='topic' → 全 event topic を返す", () => {
+    const s = topicResolver.match("", 0, ctx("topic"));
+    expect(s?.phase).toBe("active");
+    if (s?.phase === "active") {
+      expect(s.candidates).toHaveLength(2);
+      expect(s.candidates[0].value).toBe("order.created");
+      expect(s.candidates[0].hint).toBe("注文作成");
+    }
+  });
+
+  it("prefix フィルタ", () => {
+    const s = topicResolver.match("order", 5, ctx("topic"));
+    expect(s?.phase).toBe("active");
+    if (s?.phase === "active") {
+      expect(s.candidates).toHaveLength(1);
+      expect(s.candidates[0].value).toBe("order.created");
+    }
+  });
+});

--- a/frontend/src/utils/reference-completer/workspaceResolver.ts
+++ b/frontend/src/utils/reference-completer/workspaceResolver.ts
@@ -1,0 +1,152 @@
+/**
+ * workspace 参照 ID 補完 Resolver 群 (Phase 2 / #1255)。
+ *
+ * fieldKind を判定キーとして各 resolver を起動する。
+ * テキスト全体を prefix として contains フィルタで候補を絞り込む。
+ */
+
+import type { Candidate, CompletionContext, CompletionState, Resolver } from "./types";
+
+/**
+ * fieldKind ベースの ID/name resolver を生成するファクトリ。
+ * value 全体を prefix とみなし、contains マッチで候補を絞り込む。
+ */
+function makeIdResolver(
+  fieldKind: string,
+  source: (ctx: CompletionContext) => Candidate[],
+): Resolver {
+  return {
+    id: fieldKind,
+    match(value: string, _cursorPos: number, ctx: CompletionContext): CompletionState | null {
+      if (ctx.fieldKind !== fieldKind) return null;
+      const prefix = value;
+      const lowerPrefix = prefix.toLowerCase();
+      const all = source(ctx);
+      const filtered = all.filter((c) => {
+        const val = c.value.toLowerCase();
+        const lbl = (c.label ?? "").toLowerCase();
+        return val.includes(lowerPrefix) || lbl.includes(lowerPrefix);
+      });
+      return {
+        phase: "active",
+        resolverId: fieldKind,
+        prefix,
+        candidates: filtered,
+        replaceLen: prefix.length,
+      };
+    },
+  };
+}
+
+/** screenId 補完: workspace の全 Screen (id + name)。 */
+export const screenIdResolver = makeIdResolver("screenId", (ctx) =>
+  (ctx.workspace?.screens ?? []).map((s) => ({
+    value: s.id,
+    label: s.name,
+    hint: s.maturity,
+  })),
+);
+
+/** tableId 補完: workspace の全 Table (id + physicalName + name)。 */
+export const tableIdResolver = makeIdResolver("tableId", (ctx) =>
+  (ctx.workspace?.tables ?? []).map((t) => ({
+    value: t.id,
+    label: `${t.name}（${t.physicalName}）`,
+    hint: t.maturity,
+  })),
+);
+
+/** viewDefinitionId 補完: workspace の全 ViewDefinition (id + name)。 */
+export const viewDefinitionIdResolver = makeIdResolver("viewDefinitionId", (ctx) =>
+  (ctx.workspace?.viewDefinitions ?? []).map((v) => ({
+    value: v.id,
+    label: v.name,
+    hint: v.maturity,
+  })),
+);
+
+/** handlerFlowId 補完: workspace の全 ProcessFlow (id + name)。 */
+export const handlerFlowIdResolver = makeIdResolver("handlerFlowId", (ctx) =>
+  (ctx.workspace?.processFlows ?? []).map((f) => ({
+    value: f.id,
+    label: f.name,
+    hint: f.kind,
+  })),
+);
+
+/**
+ * handlerActionId 補完: ctx.handlerFlowId で指定された ProcessFlow の actions[].id。
+ * handlerFlowId が指定されていない場合は全 flow の actions を列挙する。
+ */
+export const handlerActionIdResolver = makeIdResolver("handlerActionId", (ctx) => {
+  const flows = ctx.workspace?.processFlows ?? [];
+  if (ctx.handlerFlowId) {
+    const target = flows.find((f) => f.id === ctx.handlerFlowId);
+    return (target?.actions ?? []).map((a) => ({
+      value: a.id,
+      label: a.name ?? a.id,
+    }));
+  }
+  // handlerFlowId 未指定時: 全フローの actions を列挙
+  return flows.flatMap((f) =>
+    (f.actions ?? []).map((a) => ({
+      value: a.id,
+      label: a.name ?? a.id,
+      hint: f.name,
+    })),
+  );
+});
+
+/** fragmentRef 補完: ui-fragment 汎用定義の name。 */
+export const fragmentRefResolver = makeIdResolver("fragmentRef", (ctx) =>
+  (ctx.workspace?.fragments ?? []).map((d) => ({ value: d.name })),
+);
+
+/** componentRef 補完: component-definition 汎用定義の name。 */
+export const componentRefResolver = makeIdResolver("componentRef", (ctx) =>
+  (ctx.workspace?.components ?? []).map((d) => ({ value: d.name })),
+);
+
+/** exceptionTypeRef 補完: exception-type 汎用定義の name。 */
+export const exceptionTypeRefResolver = makeIdResolver("exceptionTypeRef", (ctx) =>
+  (ctx.workspace?.exceptionTypes ?? []).map((d) => ({ value: d.name })),
+);
+
+/** modelRef 補完: projectCatalogs の modelEndpoints キー。 */
+export const modelRefResolver = makeIdResolver("modelRef", (ctx) =>
+  (ctx.workspace?.modelEndpoints ?? []).map((m) => ({
+    value: m.id,
+    label: m.name ?? m.id,
+  })),
+);
+
+/** secretRef 補完: projectCatalogs の secrets キー。 */
+export const secretRefResolver = makeIdResolver("secretRef", (ctx) =>
+  (ctx.workspace?.secrets ?? []).map((s) => ({
+    value: s.id,
+    label: s.name ?? s.id,
+  })),
+);
+
+/** topic 補完: eventCatalog の topic 一覧。 */
+export const topicResolver = makeIdResolver("topic", (ctx) =>
+  (ctx.workspace?.events ?? []).map((e) => ({
+    value: e.topic,
+    hint: e.description,
+  })),
+);
+
+/** 全 workspace resolver のデフォルトセット。 */
+export const ALL_WORKSPACE_RESOLVERS: Resolver[] = [
+  screenIdResolver,
+  tableIdResolver,
+  viewDefinitionIdResolver,
+  handlerFlowIdResolver,
+  handlerActionIdResolver,
+  fragmentRefResolver,
+  componentRefResolver,
+  exceptionTypeRefResolver,
+  modelRefResolver,
+  secretRefResolver,
+  topicResolver,
+];


### PR DESCRIPTION
## 概要

ISSUE #1255 の `@reference auto-complete` を **Phase 1-3 全完了** で実装する。

- Closes #1255

ユーザー指示により RFC #1254 (schema 改善議論) は考慮せず先行実装。schema 変更を伴わない UI / hook 実装のみ。

## Phase 別変更内容

### Phase 1: foundation refactor (commit `4860c2d`)

統合 reference completer 基盤を導入。既存 `@conv.*` の挙動は維持 (regression なし)。

**新規**:
- `frontend/src/utils/reference-completer/types.ts` — `Resolver` / `Candidate` / `CompletionContext` / `CompletionState` / `WorkspaceRefs` 型
- `frontend/src/utils/reference-completer/completer.ts` — `computeReferenceCompletion` / `insertReferenceCandidate` 統合 API
- `frontend/src/utils/reference-completer/convResolver.ts` — `@conv.<cat>.<key>` resolver (既存ロジックを移植)
- `frontend/src/utils/reference-completer/completer.test.ts` / `convResolver.test.ts`
- `frontend/src/components/common/ReferenceCompletionInput.tsx` — 統合 popup UI (input 版、↑↓ / Enter / Tab / Esc)

**変更**:
- `frontend/src/hooks/useConvCompletion.ts` — 旧 API export を維持しつつ内部実装を新基盤に委譲 (backward compat、既存 7 callsite は無修正)

### Phase 2: cross-resource ID 補完 (commit `368b6d3`)

11 種の workspace 横断 ID + reference を補完。

**新規**:
- `frontend/src/utils/reference-completer/workspaceResolver.ts` — `screenId` / `tableId` / `viewDefinitionId` / `handlerFlowId` / `handlerActionId` / `fragmentRef` / `componentRef` / `exceptionTypeRef` / `modelRef` / `secretRef` / `topic` の 11 resolver
- `frontend/src/utils/reference-completer/workspaceResolver.test.ts` — 17 テスト
- `frontend/src/hooks/useWorkspaceReferences.ts` — workspace 全体の参照情報を一括ロードする hook

`fieldKind` prop で resolver を切替。`handlerActionId` は `ctx.handlerFlowId` 受領で対象 flow の `actions[]` から候補生成。

### Phase 3: scoped expression + extension namespace 補完 (commit `7a12c33`)

ProcessFlow scope 依存の補完と extension namespace 補完を実装。

**新規**:
- `frontend/src/utils/reference-completer/processFlowScopeResolver.ts` — `@stepResult.<stepId>.<field>` (2 段補完 + dbAccess SQL alias 抽出) / `@inputs.<name>` / `@fieldErrors.<field>` の 3 resolver
- `frontend/src/utils/reference-completer/processFlowScopeResolver.test.ts` — 14 テスト
- `frontend/src/utils/reference-completer/extensionResolver.ts` — `<namespace>:<kindName>` 補完 (LoadedExtensions walk)
- `frontend/src/utils/reference-completer/extensionResolver.test.ts` — 6 テスト
- `frontend/src/components/common/ReferenceCompletionTextarea.tsx` — textarea 派生の popup UI (Tab で確定)

**変更**:
- `frontend/src/components/process-flow/internal/step-cards/DbAccessStepCardBody.tsx` — SQL body を `ReferenceCompletionTextarea` に置換、`@conv` / `@stepResult` / `@inputs` / `@fieldErrors` の 4 trigger をサポート

## 仕様逐条突合 (自己申告)

ISSUE 受け入れ基準:

1. ✓ `@conv.<category>.<key>` を SQL field で `@` 押下時 dropdown 表示 → `DbAccessStepCardBody.tsx:` (`ReferenceCompletionTextarea`) + `convResolver.ts:`
2. ✓ `handlerFlowId` 候補表示 (workspace processFlows ID + title) → `workspaceResolver.ts:` (`handlerFlowIdResolver`) + `useWorkspaceReferences.ts:`
3. ✓ `@stepResult.<stepId>.<field>` の同 PF 内前 step output 補完 → `processFlowScopeResolver.ts:` (2 段補完 + SQL alias 抽出)
4. ✓ 旧形式 `extensionCategories.<category>.*` は候補に出ない (新形式のみ提示) → `convResolver.ts:` で `ALL_CONV_CATEGORIES` 限定
5. ✓ silent-pass 解消の golden 観点: 未宣言 extension reference は extensionResolver の候補に出ない (登録 namespace 経由のみ) → `extensionResolver.ts:`

## スコープ外 (本 PR では触らない)

- `schemas/*.json` 変更 (schema governance #511、AI 権限外)
- spec ファイル (`docs/spec/*.md`) — 本 PR は UI/hook のみ、spec 反映は別 PR
- AI-assisted suggestion (Copilot/Cursor 風予測、別 ISSUE 候補)
- Playwright e2e (本 PR は vitest unit テストで担保、e2e は follow-up 起票候補)

## 検証結果

- `npm run lint` — pass
- `npx tsc --noEmit` — 0 errors
- `npx vitest run src/utils/reference-completer src/hooks/useConvCompletion.test.ts` — **67 pass / 0 fail** (新規 53 + 既存 14)
- `npx vitest run` (全テスト) — 2386 pass / 36 fail
  - 失敗は **本 PR 起因ではない** pre-existing 問題のみ:
    - `samples-v3.schema.test.ts` (english-learning の AJV 失敗) — origin/main でも同じ 10 件失敗を確認
    - `dogfood-1038-structure.test.ts` — `.tmp/dogfood-1038/` fixture が worktree に存在しないため (local artifact、git tracked ではない)
- `npm run build` — pass (3.79s)

## 残件 (follow-up 起票候補、本 PR スコープ外)

- **handlerFlowId / handlerActionId の UI bind**: ScreenItemsView に events 編集 UI が現状未実装のため resolver のみ完成。実装される時点で `ReferenceCompletionInput` を流用可
- **extensionRef の UI bind**: 対象フィールドが確定していないため resolver のみ完成
- **useWorkspaceReferences の actions**: `ProcessFlowMeta` には `actions[]` が含まれないため `actions: undefined` のまま。`loadProcessFlow(flowId)` 経由で個別 lazy load する形が将来拡張点

## テスト

- [x] `npm run lint` pass
- [x] `npx tsc --noEmit` 0 errors
- [x] 新規 53 test pass、既存 `useConvCompletion.test.ts` regression なし
- [x] production build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
