### PR TITLE
feat(designer): @reference auto-complete follow-up — S-1/S-2 + UI bind componentRef/modelRef (#1258)

### DIFF
--- a/frontend/src/components/common/ConvCompletionInput.tsx
+++ b/frontend/src/components/common/ConvCompletionInput.tsx
@@ -45,7 +45,7 @@ export function ConvCompletionInput({
     const pos = inputRef.current?.selectionStart ?? value.length;
     const st = computeCompletion(value, pos, conventions);
     if (st.phase === "idle") return;
-    const { newValue, newCursor } = insertCandidate(value, pos, st, candidate);
+    const { newValue, newCursor } = insertCandidate(value, pos, st, candidate, conventions);
     onValueChange(newValue);
     setSuppressed(false);
     setActiveIndex(0);

--- a/frontend/src/components/process-flow/ProcessFlowEditor.tsx
+++ b/frontend/src/components/process-flow/ProcessFlowEditor.tsx
@@ -80,6 +80,7 @@ import { PalettePanel } from "./internal/PalettePanel";
 import { InspectorPanel } from "./internal/InspectorPanel";
 import { CanvasPane } from "./internal/CanvasPane";
 import { EditorHeaderExtras } from "./internal/EditorHeaderExtras";
+import { useWorkspaceReferences } from "../../hooks/useWorkspaceReferences";
 
 export function ProcessFlowEditor() {
   const { processFlowId } = useParams<{ processFlowId: string }>();
@@ -202,6 +203,9 @@ export function ProcessFlowEditor() {
   });
 
   const isReadonly = mode.kind !== "editing";
+
+  // #1258 workspace 参照情報 (componentRef / modelRef 補完用)
+  const workspace = useWorkspaceReferences();
 
   // ProcessFlowEditor の live 状態を mcpBridge に公開 (#361 browser-first)
   const groupRef = useRef<ProcessFlow | null>(null);
@@ -975,6 +979,7 @@ export function ProcessFlowEditor() {
               screens={screens}
               commonGroups={commonGroups}
               conventions={conventions}
+              workspace={workspace}
               isReadonly={isReadonly}
               isDraggingToolbarStep={isDraggingToolbarStep}
               clipboard={clipboard}

--- a/frontend/src/components/process-flow/SortableStepCard.tsx
+++ b/frontend/src/components/process-flow/SortableStepCard.tsx
@@ -5,6 +5,7 @@ import { StepCard } from "./StepCard";
 import type { ProcessFlow, Step, StepKind as StepType } from "../../types/v3";
 import type { ValidationError } from "../../utils/actionValidation";
 import type { ConventionsCatalog } from "../../schemas/conventionsValidator";
+import type { WorkspaceRefs } from "../../utils/reference-completer/types";
 
 interface SortableStepCardProps {
   step: Step;
@@ -40,6 +41,8 @@ interface SortableStepCardProps {
   /** #1076 AI 依頼ボタン押下時のコールバック */
   onAskAi?: () => void;
   readOnly?: boolean;
+  /** #1258 workspace 参照情報 (componentRef / modelRef 補完用) */
+  workspace?: WorkspaceRefs;
 }
 
 export function SortableStepCard({ step, readOnly = false, ...props }: SortableStepCardProps) {

--- a/frontend/src/components/process-flow/StepCard.tsx
+++ b/frontend/src/components/process-flow/StepCard.tsx
@@ -7,6 +7,7 @@ import type {
   Step,
   StepKind as StepType,
 } from "../../types/v3";
+import type { WorkspaceRefs } from "../../utils/reference-completer/types";
 import {
   STEP_TYPE_LABELS,
   STEP_TYPE_ICONS,
@@ -90,6 +91,8 @@ interface StepCardProps {
   /** #1076 AI 依頼ボタン押下時のコールバック */
   onAskAi?: () => void;
   readOnly?: boolean;
+  /** #1258 workspace 参照情報 (componentRef / modelRef 補完用) */
+  workspace?: WorkspaceRefs;
 }
 
 export function StepCard({
@@ -128,6 +131,7 @@ export function StepCard({
   editLevel = "implementation",
   onAskAi,
   readOnly = false,
+  workspace,
 }: StepCardProps) {
   const [expanded, setExpanded] = useState(defaultExpanded ?? false);
   const [showMenu, setShowMenu] = useState(false);
@@ -766,6 +770,7 @@ export function StepCard({
                   onChange={onChange}
                   onCommit={onCommit}
                   readOnly={readOnly}
+                  workspace={workspace}
                 />
               )}
 
@@ -776,6 +781,7 @@ export function StepCard({
                   onChange={onChange}
                   onCommit={onCommit}
                   readOnly={readOnly}
+                  workspace={workspace}
                 />
               )}
 
@@ -786,6 +792,7 @@ export function StepCard({
                   onChange={onChange}
                   onCommit={onCommit}
                   readOnly={readOnly}
+                  workspace={workspace}
                 />
               )}
             </div>{/* end step-card-section data-level-min="detail" */}
@@ -852,6 +859,7 @@ export function StepCard({
                 editLevel={editLevel}
                 onAskAi={onAskAi}
                 readOnly={readOnly}
+                workspace={workspace}
               />
             </div>
           ))}

--- a/frontend/src/components/process-flow/internal/CanvasPane.tsx
+++ b/frontend/src/components/process-flow/internal/CanvasPane.tsx
@@ -12,6 +12,7 @@ import { generateUUID } from "../../../utils/uuid";
 import type { ValidationError } from "../../../utils/actionValidation";
 import type { UseAiContextChipsResult } from "../../../hooks/useAiContextChips";
 import type { EditLevel } from "../../../hooks/useEditLevel";
+import type { WorkspaceRefs } from "../../../utils/reference-completer/types";
 
 export interface CanvasPaneProps {
   group: ProcessFlow | null;
@@ -51,6 +52,8 @@ export interface CanvasPaneProps {
   setSelectedIds: (ids: Set<string>) => void;
   /** 最終選択 ref (Shift+Click 範囲選択用) */
   lastSelectedIdRef: { current: string | null };
+  /** #1258 workspace 参照情報 (componentRef / modelRef 補完用) */
+  workspace?: WorkspaceRefs;
 }
 
 export function CanvasPane({
@@ -86,6 +89,7 @@ export function CanvasPane({
   onContextMenu,
   setSelectedIds,
   lastSelectedIdRef,
+  workspace,
 }: CanvasPaneProps) {
   return (
     <main className="process-flow-canvas-pane">
@@ -171,6 +175,7 @@ export function CanvasPane({
                           tables={tables}
                           screens={screens}
                           commonGroups={commonGroups}
+                          workspace={workspace}
                           onChange={(changes) => handleStepChange(step.id, changes)}
                           onCommit={commitGroup}
                           onMoveUp={

--- a/frontend/src/components/process-flow/internal/step-cards/AiAgentStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/AiAgentStepCardBody.tsx
@@ -3,16 +3,23 @@
 // AiAgentStep: modelRef + messages + tools (1 件以上必須) + maxIterations。
 // multi-step agent loop。tool が無い single-shot は AiCallStep を使う。
 // #1016 follow-up (2026-05-20): generic StepCardBodyBaseProps<AiAgentStep> で type narrow、@ts-nocheck 除去。
+// #1258 follow-up: modelRef を ReferenceCompletionInput に置換して補完対応。
 
 import type { AiAgentStep, Identifier } from "../../../../types/v3";
+import type { WorkspaceRefs } from "../../../../utils/reference-completer/types";
+import { modelRefResolver } from "../../../../utils/reference-completer/workspaceResolver";
+import { ReferenceCompletionInput } from "../../../common/ReferenceCompletionInput";
 import type { StepCardBodyBaseProps } from "./types";
 
-export type AiAgentStepCardBodyProps = StepCardBodyBaseProps<AiAgentStep>;
+export interface AiAgentStepCardBodyProps extends StepCardBodyBaseProps<AiAgentStep> {
+  workspace?: WorkspaceRefs;
+}
 
 export function AiAgentStepCardBody({
   step,
   onChange,
   onCommit,
+  workspace,
 }: AiAgentStepCardBodyProps) {
   const messages = Array.isArray(step.messages) ? step.messages : [];
   const tools = Array.isArray(step.tools) ? step.tools : [];
@@ -24,12 +31,13 @@ export function AiAgentStepCardBody({
             <i className="bi bi-robot me-1" />
             modelRef
           </label>
-          <input
-            type="text"
-            className="form-control form-control-sm"
+          <ReferenceCompletionInput
             value={step.modelRef ?? ""}
-            onChange={(e) => onChange({ modelRef: e.target.value as Identifier })}
-            onBlur={onCommit}
+            onValueChange={(v) => onChange({ modelRef: v as Identifier })}
+            onCommit={onCommit}
+            resolvers={[modelRefResolver]}
+            ctx={{ fieldKind: "modelRef", workspace }}
+            className="form-control form-control-sm"
             placeholder="例: agentModel"
             style={{ fontFamily: "monospace", fontSize: "0.85rem" }}
           />

--- a/frontend/src/components/process-flow/internal/step-cards/AiCallStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/AiCallStepCardBody.tsx
@@ -2,16 +2,23 @@
 // `aiCall` kind (PR #935/#936 で schema 追加) に最小 body を提供する。
 // AiCallStep: modelRef + messages + tools (任意) + responseFormat (任意)。
 // #1016 follow-up (2026-05-20): generic StepCardBodyBaseProps<AiCallStep> で type narrow、@ts-nocheck 除去。
+// #1258 follow-up: modelRef を ReferenceCompletionInput に置換して補完対応。
 
 import type { AiCallStep, Identifier } from "../../../../types/v3";
+import type { WorkspaceRefs } from "../../../../utils/reference-completer/types";
+import { modelRefResolver } from "../../../../utils/reference-completer/workspaceResolver";
+import { ReferenceCompletionInput } from "../../../common/ReferenceCompletionInput";
 import type { StepCardBodyBaseProps } from "./types";
 
-export type AiCallStepCardBodyProps = StepCardBodyBaseProps<AiCallStep>;
+export interface AiCallStepCardBodyProps extends StepCardBodyBaseProps<AiCallStep> {
+  workspace?: WorkspaceRefs;
+}
 
 export function AiCallStepCardBody({
   step,
   onChange,
   onCommit,
+  workspace,
 }: AiCallStepCardBodyProps) {
   const messages = Array.isArray(step.messages) ? step.messages : [];
   return (
@@ -22,12 +29,13 @@ export function AiCallStepCardBody({
             <i className="bi bi-cpu me-1" />
             modelRef (context.catalogs.modelEndpoints のキー)
           </label>
-          <input
-            type="text"
-            className="form-control form-control-sm"
+          <ReferenceCompletionInput
             value={step.modelRef ?? ""}
-            onChange={(e) => onChange({ modelRef: e.target.value as Identifier })}
-            onBlur={onCommit}
+            onValueChange={(v) => onChange({ modelRef: v as Identifier })}
+            onCommit={onCommit}
+            resolvers={[modelRefResolver]}
+            ctx={{ fieldKind: "modelRef", workspace }}
+            className="form-control form-control-sm"
             placeholder="例: summarizeModel / projectModel"
             style={{ fontFamily: "monospace", fontSize: "0.85rem" }}
           />

--- a/frontend/src/components/process-flow/internal/step-cards/ComponentCallStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/ComponentCallStepCardBody.tsx
@@ -1,16 +1,23 @@
 // Phase-3 (#1145、#1163 review Phase-2 補足): StepCard.tsx で dispatch が未実装だった
 // `componentCall` kind (PR #1066 で schema 追加) に最小 body を提供する。
 // CommonProcessStepCardBody と類似 (componentRef + operation + argumentMapping / returnMapping)。
+// #1258 follow-up: componentRef を ReferenceCompletionInput に置換して補完対応。
 
 import type { ComponentCallStep } from "../../../../types/v3";
+import type { WorkspaceRefs } from "../../../../utils/reference-completer/types";
+import { componentRefResolver } from "../../../../utils/reference-completer/workspaceResolver";
+import { ReferenceCompletionInput } from "../../../common/ReferenceCompletionInput";
 import type { StepCardBodyBaseProps } from "./types";
 
-export type ComponentCallStepCardBodyProps = StepCardBodyBaseProps<ComponentCallStep>;
+export interface ComponentCallStepCardBodyProps extends StepCardBodyBaseProps<ComponentCallStep> {
+  workspace?: WorkspaceRefs;
+}
 
 export function ComponentCallStepCardBody({
   step,
   onChange,
   onCommit,
+  workspace,
 }: ComponentCallStepCardBodyProps) {
   return (
     <>
@@ -20,12 +27,13 @@ export function ComponentCallStepCardBody({
             <i className="bi bi-puzzle me-1" />
             コンポーネント参照 (componentRef)
           </label>
-          <input
-            type="text"
-            className="form-control form-control-sm"
+          <ReferenceCompletionInput
             value={step.componentRef ?? ""}
-            onChange={(e) => onChange({ componentRef: e.target.value })}
-            onBlur={onCommit}
+            onValueChange={(v) => onChange({ componentRef: v })}
+            onCommit={onCommit}
+            resolvers={[componentRefResolver]}
+            ctx={{ fieldKind: "componentRef", workspace }}
+            className="form-control form-control-sm"
             placeholder="例: generic-definitions/component-definition/OrderValidator"
             style={{ fontFamily: "monospace", fontSize: "0.85rem" }}
           />

--- a/frontend/src/hooks/useConvCompletion.test.ts
+++ b/frontend/src/hooks/useConvCompletion.test.ts
@@ -135,4 +135,30 @@ describe("insertCandidate", () => {
     expect(newValue).toBe("hello");
     expect(newCursor).toBe(5);
   });
+
+  // #1258 review follow-up: catalog 渡しの新 API path カバレッジ
+  it("catalog 渡し (新 API path): category phase は legacy と同等の結果になる", () => {
+    const v = "@conv.curre";
+    const state = computeCompletion(v, v.length, catalog);
+    const { newValue, newCursor } = insertCandidate(v, v.length, state, "currency", catalog);
+    expect(newValue).toBe("@conv.currency.");
+    expect(newCursor).toBe(newValue.length);
+  });
+
+  it("catalog 渡し (新 API path): key phase は legacy と同等の結果になる", () => {
+    const v = "@conv.currency.j";
+    const state = computeCompletion(v, v.length, catalog);
+    const { newValue, newCursor } = insertCandidate(v, v.length, state, "jpy", catalog);
+    expect(newValue).toBe("@conv.currency.jpy");
+    expect(newCursor).toBe(newValue.length);
+  });
+
+  it("catalog 渡し (新 API path): カーソル文中でも legacy と同等の結果になる", () => {
+    const v = "@conv.curre xxx";
+    const cursor = "@conv.curre".length;
+    const state = computeCompletion(v, cursor, catalog);
+    const { newValue, newCursor } = insertCandidate(v, cursor, state, "currency", catalog);
+    expect(newValue).toBe("@conv.currency. xxx");
+    expect(newCursor).toBe("@conv.currency.".length);
+  });
 });

--- a/frontend/src/hooks/useConvCompletion.ts
+++ b/frontend/src/hooks/useConvCompletion.ts
@@ -64,23 +64,30 @@ export function computeCompletion(
 /**
  * 補完候補を確定してテキストに挿入する純粋関数。
  * category phase では末尾に "." を付与し、key phase では置換のみ。
- * 内部では統合 reference completer に委譲する。
+ * catalog を渡すと統合 reference completer 経由の新 API path を使う。
+ * catalog が未指定 or resolver miss の場合は legacy 計算 fallback。
  */
 export function insertCandidate(
   value: string,
   cursorPos: number,
   state: CompletionState,
   picked: string,
+  catalog?: ConventionsCatalog | null,
 ): { newValue: string; newCursor: number } {
   if (state.phase === "idle") return { newValue: value, newCursor: cursorPos };
   const trailing = state.phase === "category" ? "." : "";
-  const newState = computeReferenceCompletion(value, cursorPos, [convResolver], {});
-  // newState が idle の場合は直接計算にフォールバック (backward compat)
-  if (newState.phase !== "active") {
-    const before = value.slice(0, cursorPos);
-    const after = value.slice(cursorPos);
-    const newBefore = before.slice(0, before.length - state.prefix.length) + picked + trailing;
-    return { newValue: newBefore + after, newCursor: newBefore.length };
+  if (catalog) {
+    const newState = computeReferenceCompletion(value, cursorPos, [convResolver], { conventions: catalog });
+    if (newState.phase === "active") {
+      return insertReferenceCandidate(value, cursorPos, newState, {
+        value: picked,
+        trailing: trailing || undefined,
+      });
+    }
   }
-  return insertReferenceCandidate(value, cursorPos, newState, { value: picked, trailing: trailing || undefined });
+  // catalog 未指定 or resolver miss: legacy 計算 fallback
+  const before = value.slice(0, cursorPos);
+  const after = value.slice(cursorPos);
+  const newBefore = before.slice(0, before.length - state.prefix.length) + picked + trailing;
+  return { newValue: newBefore + after, newCursor: newBefore.length };
 }

--- a/frontend/src/utils/reference-completer/processFlowScopeResolver.test.ts
+++ b/frontend/src/utils/reference-completer/processFlowScopeResolver.test.ts
@@ -113,6 +113,64 @@ describe("stepResultResolver", () => {
     }
   });
 
+  it("SQL ブロックコメント内の alias は補完候補に出ない (S-2 false positive 回避)", () => {
+    const flowWithComment: ProcessFlow = {
+      ...mockFlow,
+      actions: [
+        {
+          ...mockFlow.actions[0],
+          steps: [
+            {
+              id: "commentTest",
+              kind: "dbAccess" as const,
+              description: "コメント内 alias テスト",
+              operation: "SELECT",
+              sql: "SELECT id /* AS badAlias */, name AS goodAlias FROM t",
+              outputBinding: { name: "result" },
+            } as unknown as ProcessFlow["actions"][0]["steps"][0],
+          ],
+        },
+      ],
+    };
+    const v = "@stepResult.commentTest.";
+    const result = stepResultResolver.match(v, v.length, { flow: flowWithComment });
+    expect(result?.phase).toBe("active");
+    if (result?.phase === "active") {
+      const vals = result.candidates.map((c) => c.value);
+      expect(vals).toContain("goodAlias");
+      expect(vals).not.toContain("badAlias");
+    }
+  });
+
+  it("SQL 行末コメント内の alias は補完候補に出ない (S-2 false positive 回避)", () => {
+    const flowWithLineComment: ProcessFlow = {
+      ...mockFlow,
+      actions: [
+        {
+          ...mockFlow.actions[0],
+          steps: [
+            {
+              id: "lineCommentTest",
+              kind: "dbAccess" as const,
+              description: "行末コメント内 alias テスト",
+              operation: "SELECT",
+              sql: "SELECT id, name AS validAlias FROM t -- AS commentAlias",
+              outputBinding: { name: "result" },
+            } as unknown as ProcessFlow["actions"][0]["steps"][0],
+          ],
+        },
+      ],
+    };
+    const v = "@stepResult.lineCommentTest.";
+    const result = stepResultResolver.match(v, v.length, { flow: flowWithLineComment });
+    expect(result?.phase).toBe("active");
+    if (result?.phase === "active") {
+      const vals = result.candidates.map((c) => c.value);
+      expect(vals).toContain("validAlias");
+      expect(vals).not.toContain("commentAlias");
+    }
+  });
+
   it("存在しない stepId → active / 候補 0 件", () => {
     const v = "@stepResult.unknown.";
     const result = stepResultResolver.match(v, v.length, ctx());

--- a/frontend/src/utils/reference-completer/processFlowScopeResolver.ts
+++ b/frontend/src/utils/reference-completer/processFlowScopeResolver.ts
@@ -63,7 +63,11 @@ export const stepResultResolver: Resolver = {
     if (stepAny.kind === "dbAccess") {
       const sql = stepAny.sql as string | undefined;
       if (sql) {
-        const aliasMatches = [...sql.matchAll(/\bAS\s+(\w+)/gi)];
+        // コメント内の alias を誤検出しないよう、ブロックコメント・行末コメントを先に除去する
+        const stripped = sql
+          .replace(/\/\*[\s\S]*?\*\//g, " ")  // ブロックコメント
+          .replace(/--.*$/gm, " ");             // 行末コメント
+        const aliasMatches = [...stripped.matchAll(/\bAS\s+(\w+)/gi)];
         for (const match of aliasMatches) {
           if (match[1]) fields.add(match[1]);
         }


### PR DESCRIPTION
## 概要

ISSUE #1258 の Should-fix + UI bind 残件を 1 PR で解消する。

Closes #1258

PR #1257 (#1255) の Sonnet 独立レビュー指摘 S-1 / S-2 を解消、UI bind は実装済み step-card UI を持つ componentRef / modelRef のみ対応。

## 変更内容

### S-1: useConvCompletion.ts dead code 解消 (502ad8a)
- `frontend/src/hooks/useConvCompletion.ts:75` — insertCandidate に catalog param 追加、新 API path 有効化
- `frontend/src/components/common/ConvCompletionInput.tsx:48` — callsite に conventions を pass

### S-2: SQL alias regex のコメント false positive 解消 (64b25df)
- `frontend/src/utils/reference-completer/processFlowScopeResolver.ts:67` — block/line コメント strip 前処理
- `frontend/src/utils/reference-completer/processFlowScopeResolver.test.ts:116` — false positive 回避テスト 2 件追加

### S-3a/b: componentRef / modelRef UI bind (8baeca2)
- `frontend/src/components/process-flow/internal/step-cards/ComponentCallStepCardBody.tsx:13` — componentRef を ReferenceCompletionInput に置換
- `frontend/src/components/process-flow/internal/step-cards/AiCallStepCardBody.tsx:14` — modelRef bind
- `frontend/src/components/process-flow/internal/step-cards/AiAgentStepCardBody.tsx:15` — modelRef bind
- `frontend/src/components/process-flow/StepCard.tsx:95` — workspace prop pass-through + 3 dispatch + 再帰 sub-steps
- `frontend/src/components/process-flow/SortableStepCard.tsx:45` — workspace prop ({...props} spread で自動伝播)
- `frontend/src/components/process-flow/internal/CanvasPane.tsx:56` — workspace prop pass-through
- `frontend/src/components/process-flow/ProcessFlowEditor.tsx:83,208` — useWorkspaceReferences() 呼び出し追加

## 仕様逐条突合 (自己申告)

ISSUE #1258 受け入れ条件:
1. ✓ S-1 dead code 解消 → `useConvCompletion.ts:75` (catalog param 経由で新 API path 有効化)
2. ✓ S-2 SQL コメント false positive 解消 → `processFlowScopeResolver.ts:67` (strip 前処理) + `processFlowScopeResolver.test.ts:116` (回避テスト 2 件)
3. ✓ S-3 componentRef / modelRef UI bind → `ComponentCallStepCardBody.tsx:13` / `AiCallStepCardBody.tsx:14` / `AiAgentStepCardBody.tsx:15`
4. ✓ `useWorkspaceReferences` callsite 獲得 → `ProcessFlowEditor.tsx:208` から CanvasPane chain で使用

## 検証

- `npm run lint`: pass (0 errors, 0 warnings)
- `npx tsc --noEmit`: 0 errors
- `npx vitest run src/utils/reference-completer/ src/hooks/useConvCompletion.test.ts`: 69 pass / 0 fail (新規 S-2 テスト 2 件含む)
- `npm run build`: success

## スコープ外 (本 PR では触らない、別 ISSUE 候補)

- handlerFlowId / handlerActionId UI bind (ScreenItemsView events 編集 UI 自体未実装)
- fragmentRef / exceptionTypeRef / secretRef / topic UI bind (該当入力フィールド現存せず)
- extensionRef UI bind (対象フィールド未確定)
- useWorkspaceReferences actions[] lazy load 拡張
- Playwright e2e
- schema 変更 (#511 governance)