### PR TITLE
feat(designer): @reference auto-complete bind 先 UI — events / actions[] lazy load (#1260 Phase 1 A+D)

### DIFF
--- a/frontend/src/components/screen-items/ScreenItemsView.tsx
+++ b/frontend/src/components/screen-items/ScreenItemsView.tsx
@@ -38,10 +38,17 @@ import { loadConventions } from "../../store/conventionsStore";
 import { checkScreenItemConventionReferences } from "../../schemas/conventionsValidator";
 import type { ConventionsCatalog, ConventionIssue } from "../../schemas/conventionsValidator";
 import { mcpBridge } from "../../mcp/mcpBridge";
+import { useWorkspaceReferences } from "../../hooks/useWorkspaceReferences";
+import { ReferenceCompletionInput } from "../common/ReferenceCompletionInput";
+import { handlerFlowIdResolver, handlerActionIdResolver } from "../../utils/reference-completer/workspaceResolver";
 import type {
   ScreenItem,
+  ScreenItemEvent,
   FieldType,
   Identifier,
+  ProcessFlowId,
+  LocalId,
+  ExpressionString,
 } from "../../types/v3";
 import type { ScreenItemsDocument } from "../../store/screenItemsStore";
 // #1016 follow-up (2026-05-20): listProcessFlows() の return type は frontend/src/types/flow の ProcessFlowMeta
@@ -86,6 +93,7 @@ export function ScreenItemsView() {
   const [lintIssues, setLintIssues] = useState<ConventionIssue[]>([]);
   const [expandedErrorRows, setExpandedErrorRows] = useState<Set<number>>(new Set());
   const [expandedDetailRows, setExpandedDetailRows] = useState<Set<number>>(new Set());
+  const [expandedEventRows, setExpandedEventRows] = useState<Set<number>>(new Set());
   const [processFlows, setProcessFlows] = useState<ProcessFlowMeta[]>([]);
   const [tables, setTables] = useState<Table[]>([]);
   const [views, setViews] = useState<View[]>([]);
@@ -123,6 +131,9 @@ export function ScreenItemsView() {
   useEffect(() => {
     loadConventions().then(setConventions).catch(console.error);
   }, []);
+
+  // ワークスペース全参照情報 (handlerFlowId / handlerActionId 補完用、#1260 A)
+  const workspace = useWorkspaceReferences();
 
   // 処理フロー・テーブル・ビュー一覧をロード (valueFrom セレクタ用、列まで含む完全形)
   useEffect(() => {
@@ -654,11 +665,48 @@ export function ScreenItemsView() {
     });
   }, []);
 
+  const handleToggleEventRow = useCallback((idx: number) => {
+    setExpandedEventRows((prev) => {
+      const next = new Set(prev);
+      if (next.has(idx)) next.delete(idx);
+      else next.add(idx);
+      return next;
+    });
+  }, []);
+
+  const handleAddEvent = useCallback((idx: number) => {
+    updateWithDraft((f) => {
+      const item = f.items[idx];
+      if (!item.events) item.events = [];
+      item.events.push({ id: "", handlerFlowId: "" as ProcessFlowId });
+    });
+    commit();
+  }, [updateWithDraft, commit]);
+
+  const handleRemoveEvent = useCallback((idx: number, eventIdx: number) => {
+    updateWithDraft((f) => {
+      const item = f.items[idx];
+      if (!item.events) return;
+      item.events.splice(eventIdx, 1);
+      if (item.events.length === 0) delete item.events;
+    });
+    commit();
+  }, [updateWithDraft, commit]);
+
+  const handleUpdateEvent = useCallback((idx: number, eventIdx: number, patch: Partial<ScreenItemEvent>) => {
+    updateWithDraft((f) => {
+      const item = f.items[idx];
+      if (!item.events) return;
+      item.events[eventIdx] = { ...item.events[eventIdx], ...patch };
+    });
+  }, [updateWithDraft]);
+
   // ファイル切替時に選択・展開状態をリセット
   useEffect(() => {
     setSelectedIndices(new Set());
     setExpandedErrorRows(new Set());
     setExpandedDetailRows(new Set());
+    setExpandedEventRows(new Set());
   }, [screenId]);
 
   const selectedScreenName = screens.find((s) => s.id === screenId)?.name;
@@ -963,6 +1011,15 @@ export function ScreenItemsView() {
                       </button>
                       <button
                         type="button"
+                        className={`btn btn-sm btn-link p-0 ${expandedEventRows.has(i) ? "text-primary" : "text-secondary"}`}
+                        onClick={() => handleToggleEventRow(i)}
+                        title="イベントを展開"
+                        aria-label="イベント展開"
+                      >
+                        <i className={`bi bi-${expandedEventRows.has(i) ? "lightning-fill" : "lightning"}`} />
+                      </button>
+                      <button
+                        type="button"
                         className="btn btn-sm btn-link text-secondary p-0"
                         onClick={() => handleResetItems([i])}
                         title="IDをリセット (自動採番形式に戻す)"
@@ -1124,6 +1181,154 @@ export function ScreenItemsView() {
                               />
                             </label>
                           ))}
+                        </div>
+                      </td>
+                    </tr>
+                  )}
+                  {expandedEventRows.has(i) && (
+                    <tr className="screen-items-event-row">
+                      <td colSpan={11}>
+                        <div className="screen-items-event-list">
+                          {(item.events ?? []).map((ev, eIdx) => {
+                            const argEntries = Object.entries(ev.argumentMapping ?? {});
+                            return (
+                              <div key={eIdx} className="screen-items-event-card">
+                                <div className="screen-items-event-grid">
+                                  <label className="screen-items-event-field">
+                                    <span className="screen-items-event-label">id</span>
+                                    <input
+                                      className="form-control form-control-sm"
+                                      value={ev.id}
+                                      onChange={(e) => handleUpdateEvent(i, eIdx, { id: e.target.value })}
+                                      onBlur={commit}
+                                      placeholder="click"
+                                      disabled={isReadonly}
+                                    />
+                                  </label>
+                                  <label className="screen-items-event-field">
+                                    <span className="screen-items-event-label">label</span>
+                                    <input
+                                      className="form-control form-control-sm"
+                                      value={ev.label ?? ""}
+                                      onChange={(e) => handleUpdateEvent(i, eIdx, { label: e.target.value || undefined })}
+                                      onBlur={commit}
+                                      placeholder="クリック"
+                                      disabled={isReadonly}
+                                    />
+                                  </label>
+                                  <label className="screen-items-event-field">
+                                    <span className="screen-items-event-label">handlerFlowId</span>
+                                    <ReferenceCompletionInput
+                                      value={ev.handlerFlowId ?? ""}
+                                      onValueChange={(v) => handleUpdateEvent(i, eIdx, { handlerFlowId: v as ProcessFlowId })}
+                                      onCommit={commit}
+                                      resolvers={[handlerFlowIdResolver]}
+                                      ctx={{ fieldKind: "handlerFlowId", workspace }}
+                                      className="form-control form-control-sm"
+                                      placeholder="ProcessFlow ID"
+                                      disabled={isReadonly}
+                                    />
+                                  </label>
+                                  <label className="screen-items-event-field">
+                                    <span className="screen-items-event-label">handlerActionId</span>
+                                    <ReferenceCompletionInput
+                                      value={ev.handlerActionId ?? ""}
+                                      onValueChange={(v) => handleUpdateEvent(i, eIdx, { handlerActionId: (v || undefined) as LocalId | undefined })}
+                                      onCommit={commit}
+                                      resolvers={[handlerActionIdResolver]}
+                                      ctx={{ fieldKind: "handlerActionId", workspace, handlerFlowId: ev.handlerFlowId }}
+                                      className="form-control form-control-sm"
+                                      placeholder="action ID (省略時 actions[0])"
+                                      disabled={isReadonly}
+                                    />
+                                  </label>
+                                </div>
+                                <div className="screen-items-event-mapping">
+                                  <div className="screen-items-event-mapping-header">
+                                    <span className="screen-items-event-label">argumentMapping</span>
+                                    <button
+                                      type="button"
+                                      className="btn btn-sm btn-link p-0"
+                                      onClick={() => {
+                                        handleUpdateEvent(i, eIdx, { argumentMapping: { ...(ev.argumentMapping ?? {}), "": "" as ExpressionString } });
+                                      }}
+                                      disabled={isReadonly}
+                                      title="マッピング行を追加"
+                                    >
+                                      <i className="bi bi-plus-lg" /> 追加
+                                    </button>
+                                  </div>
+                                  {argEntries.length === 0 && (
+                                    <div className="screen-items-event-mapping-empty">なし</div>
+                                  )}
+                                  {argEntries.map(([k, v], aIdx) => (
+                                    <div key={aIdx} className="screen-items-event-mapping-row">
+                                      <input
+                                        className="form-control form-control-sm"
+                                        value={k}
+                                        onChange={(e) => {
+                                          const newKey = e.target.value;
+                                          const next: Record<string, ExpressionString> = {};
+                                          argEntries.forEach(([kk, vv], ii) => {
+                                            next[ii === aIdx ? newKey : kk] = vv;
+                                          });
+                                          handleUpdateEvent(i, eIdx, { argumentMapping: next });
+                                        }}
+                                        onBlur={commit}
+                                        placeholder="action 引数名 (Identifier)"
+                                        disabled={isReadonly}
+                                      />
+                                      <span className="screen-items-event-mapping-eq">=</span>
+                                      <input
+                                        className="form-control form-control-sm"
+                                        value={v}
+                                        onChange={(e) => {
+                                          const next = { ...(ev.argumentMapping ?? {}) };
+                                          next[k] = e.target.value as ExpressionString;
+                                          handleUpdateEvent(i, eIdx, { argumentMapping: next });
+                                        }}
+                                        onBlur={commit}
+                                        placeholder="@screen.email"
+                                        disabled={isReadonly}
+                                      />
+                                      <button
+                                        type="button"
+                                        className="btn btn-sm btn-link text-danger p-0"
+                                        onClick={() => {
+                                          const next = { ...(ev.argumentMapping ?? {}) };
+                                          delete next[k];
+                                          handleUpdateEvent(i, eIdx, { argumentMapping: Object.keys(next).length > 0 ? next : undefined });
+                                        }}
+                                        disabled={isReadonly}
+                                        title="マッピング行を削除"
+                                      >
+                                        <i className="bi bi-x" />
+                                      </button>
+                                    </div>
+                                  ))}
+                                </div>
+                                <div className="screen-items-event-actions">
+                                  <button
+                                    type="button"
+                                    className="btn btn-sm btn-link text-danger p-0"
+                                    onClick={() => handleRemoveEvent(i, eIdx)}
+                                    disabled={isReadonly}
+                                    title="イベントを削除"
+                                  >
+                                    <i className="bi bi-x" /> イベント削除
+                                  </button>
+                                </div>
+                              </div>
+                            );
+                          })}
+                          <button
+                            type="button"
+                            className="btn btn-sm btn-outline-primary"
+                            onClick={() => handleAddEvent(i)}
+                            disabled={isReadonly}
+                          >
+                            <i className="bi bi-plus-lg me-1" /> イベント追加
+                          </button>
                         </div>
                       </td>
                     </tr>

--- a/frontend/src/components/screen-items/ScreenItemsView.tsx
+++ b/frontend/src/components/screen-items/ScreenItemsView.tsx
@@ -356,6 +356,14 @@ export function ScreenItemsView() {
       }
       return next;
     });
+    setExpandedEventRows((prev) => {
+      const next = new Set<number>();
+      for (const i of prev) {
+        if (i < idx) next.add(i);
+        else if (i > idx) next.add(i - 1);
+      }
+      return next;
+    });
   }, [updateWithDraft]);
 
   /** 複数インデックスのリセット用新 ID を計算 (バッチ内で重複しないよう pool を積み上げ) */
@@ -694,12 +702,12 @@ export function ScreenItemsView() {
   }, [updateWithDraft, commit]);
 
   const handleUpdateEvent = useCallback((idx: number, eventIdx: number, patch: Partial<ScreenItemEvent>) => {
-    updateWithDraft((f) => {
+    updateSilentWithDraft((f) => {
       const item = f.items[idx];
       if (!item.events) return;
       item.events[eventIdx] = { ...item.events[eventIdx], ...patch };
     });
-  }, [updateWithDraft]);
+  }, [updateSilentWithDraft]);
 
   // ファイル切替時に選択・展開状態をリセット
   useEffect(() => {
@@ -1250,7 +1258,9 @@ export function ScreenItemsView() {
                                       type="button"
                                       className="btn btn-sm btn-link p-0"
                                       onClick={() => {
-                                        handleUpdateEvent(i, eIdx, { argumentMapping: { ...(ev.argumentMapping ?? {}), "": "" as ExpressionString } });
+                                        const current = ev.argumentMapping ?? {};
+                                        if ("" in current) return; // 既に空キー行がある場合は追加しない
+                                        handleUpdateEvent(i, eIdx, { argumentMapping: { ...current, "": "" as ExpressionString } });
                                       }}
                                       disabled={isReadonly}
                                       title="マッピング行を追加"
@@ -1268,6 +1278,9 @@ export function ScreenItemsView() {
                                         value={k}
                                         onChange={(e) => {
                                           const newKey = e.target.value;
+                                          // 自身以外の既存 key と衝突する場合は rename を拒否 (silent rollback)
+                                          const collision = argEntries.some(([kk, _vv], ii) => ii !== aIdx && kk === newKey && newKey !== "");
+                                          if (collision) return;
                                           const next: Record<string, ExpressionString> = {};
                                           argEntries.forEach(([kk, vv], ii) => {
                                             next[ii === aIdx ? newKey : kk] = vv;

--- a/frontend/src/hooks/useWorkspaceReferences.ts
+++ b/frontend/src/hooks/useWorkspaceReferences.ts
@@ -12,6 +12,7 @@ import { loadProject } from "../store/flowStore";
 import { listTables } from "../store/tableStore";
 import { listViewDefinitions } from "../store/viewDefinitionStore";
 import { listGenericDefinitions } from "../store/genericDefinitionStore";
+import { loadProcessFlow } from "../store/processFlowStore";
 import { mcpBridge } from "../mcp/mcpBridge";
 import type { WorkspaceRefs } from "../utils/reference-completer/types";
 import type { ProjectCatalogs } from "../schemas/projectCatalogs";
@@ -41,76 +42,87 @@ export function useWorkspaceReferences(): WorkspaceRefs {
   const [refs, setRefs] = useState<WorkspaceRefs>(emptyRefs);
 
   const load = useCallback(() => {
-    Promise.allSettled([
-      loadProject(),
-      listTables(),
-      listViewDefinitions(),
-      listGenericDefinitions("ui-fragment"),
-      listGenericDefinitions("component-definition"),
-      listGenericDefinitions("exception-type"),
-      mcpBridge.request("loadProjectCatalogs").catch(() => null),
-    ]).then(
-      ([projectResult, tablesResult, viewDefsResult, fragmentsResult, componentsResult, exceptionsResult, catalogsResult]) => {
-        const projectData = projectResult.status === "fulfilled" ? projectResult.value : null;
-        const tablesData = tablesResult.status === "fulfilled" ? tablesResult.value : [];
-        const viewDefsData = viewDefsResult.status === "fulfilled" ? viewDefsResult.value : [];
-        const fragmentsData = fragmentsResult.status === "fulfilled" ? fragmentsResult.value : [];
-        const componentsData = componentsResult.status === "fulfilled" ? componentsResult.value : [];
-        const exceptionsData = exceptionsResult.status === "fulfilled" ? exceptionsResult.value : [];
-        const projectCatalogs = (catalogsResult.status === "fulfilled" ? catalogsResult.value : null) as ProjectCatalogs | null;
+    (async () => {
+      const [projectResult, tablesResult, viewDefsResult, fragmentsResult, componentsResult, exceptionsResult, catalogsResult] =
+        await Promise.allSettled([
+          loadProject(),
+          listTables(),
+          listViewDefinitions(),
+          listGenericDefinitions("ui-fragment"),
+          listGenericDefinitions("component-definition"),
+          listGenericDefinitions("exception-type"),
+          mcpBridge.request("loadProjectCatalogs").catch(() => null),
+        ]);
 
-        // processFlows は loadProject から meta 情報を取得
-        // actions は ProcessFlow を個別ロードしないと取れないため meta のみ
-        const processFlowMetas = projectData?.processFlows ?? [];
+      const projectData = projectResult.status === "fulfilled" ? projectResult.value : null;
+      const tablesData = tablesResult.status === "fulfilled" ? tablesResult.value : [];
+      const viewDefsData = viewDefsResult.status === "fulfilled" ? viewDefsResult.value : [];
+      const fragmentsData = fragmentsResult.status === "fulfilled" ? fragmentsResult.value : [];
+      const componentsData = componentsResult.status === "fulfilled" ? componentsResult.value : [];
+      const exceptionsData = exceptionsResult.status === "fulfilled" ? exceptionsResult.value : [];
+      const projectCatalogs = (catalogsResult.status === "fulfilled" ? catalogsResult.value : null) as ProjectCatalogs | null;
 
-        setRefs({
-          screens: (projectData?.screens ?? []).map((s) => ({
-            id: s.id,
-            name: s.name,
-            maturity: s.maturity,
-          })),
-          tables: tablesData.map((t) => ({
-            id: t.id,
-            physicalName: t.physicalName ?? "",
-            name: t.name,
-            maturity: t.maturity,
-          })),
-          viewDefinitions: viewDefsData.map((v) => ({
-            id: v.id as unknown as string,
-            name: v.name,
-            maturity: v.maturity,
-          })),
-          processFlows: processFlowMetas.map((f) => ({
+      // processFlows は loadProject から meta 情報を取得
+      // actions は各 ProcessFlow を parallel ロードして取得 (#1260 D)
+      const processFlowMetas = projectData?.processFlows ?? [];
+
+      // actions[] を eager parallel preload する
+      const actionsResults = await Promise.allSettled(
+        processFlowMetas.map((m) => loadProcessFlow(m.id as unknown as string)),
+      );
+
+      setRefs({
+        screens: (projectData?.screens ?? []).map((s) => ({
+          id: s.id,
+          name: s.name,
+          maturity: s.maturity,
+        })),
+        tables: tablesData.map((t) => ({
+          id: t.id,
+          physicalName: t.physicalName ?? "",
+          name: t.name,
+          maturity: t.maturity,
+        })),
+        viewDefinitions: viewDefsData.map((v) => ({
+          id: v.id as unknown as string,
+          name: v.name,
+          maturity: v.maturity,
+        })),
+        processFlows: processFlowMetas.map((f, idx) => {
+          const result = actionsResults[idx];
+          const loaded = result.status === "fulfilled" ? result.value : null;
+          return {
             id: f.id as unknown as string,
             name: f.name,
             kind: f.kind ?? "other",
             maturity: f.maturity,
-            // actions: ProcessFlowMeta には actions がないため省略
-            actions: undefined,
-          })),
-          fragments: fragmentsData.map((d) => ({ name: d.name })),
-          components: componentsData.map((d) => ({ name: d.name })),
-          exceptionTypes: exceptionsData.map((d) => ({ name: d.name })),
-          modelEndpoints: Object.keys(projectCatalogs?.modelEndpoints ?? {}).map((id) => ({
-            id,
-            name: id,
-          })),
-          secrets: Object.keys(projectCatalogs?.secrets ?? {}).map((id) => ({
-            id,
-            name: id,
-          })),
-          events: Object.keys(projectCatalogs?.events ?? {}).map((topic) => ({
-            topic,
-          })),
-        });
-      },
-    ).catch(() => {
+            actions: loaded?.actions?.map((a) => ({ id: a.id as unknown as string, name: a.name })),
+          };
+        }),
+        fragments: fragmentsData.map((d) => ({ name: d.name })),
+        components: componentsData.map((d) => ({ name: d.name })),
+        exceptionTypes: exceptionsData.map((d) => ({ name: d.name })),
+        modelEndpoints: Object.keys(projectCatalogs?.modelEndpoints ?? {}).map((id) => ({
+          id,
+          name: id,
+        })),
+        secrets: Object.keys(projectCatalogs?.secrets ?? {}).map((id) => ({
+          id,
+          name: id,
+        })),
+        events: Object.keys(projectCatalogs?.events ?? {}).map((topic) => ({
+          topic,
+        })),
+      });
+    })().catch(() => {
       // ロード失敗時は空のまま (UI は degraded state で動作継続)
     });
   }, []);
 
   useEffect(() => {
     load();
+    const unsub = mcpBridge.onBroadcast("processFlowChanged", load);
+    return unsub;
   }, [load]);
 
   return refs;

--- a/frontend/src/styles/screen-items.css
+++ b/frontend/src/styles/screen-items.css
@@ -188,6 +188,71 @@
   font-family: ui-monospace, SFMono-Regular, monospace;
 }
 
+/* イベント (#624) 展開行 (#1260) */
+.screen-items-event-row > td {
+  background: #fff7ed;
+  padding: 6px 8px;
+  border-bottom: 1px solid #fed7aa;
+}
+.screen-items-event-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.screen-items-event-card {
+  background: #ffffff;
+  border: 1px solid #fed7aa;
+  border-radius: 4px;
+  padding: 8px;
+}
+.screen-items-event-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.screen-items-event-field {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 14em;
+  flex: 1;
+}
+.screen-items-event-label {
+  font-size: 0.68rem;
+  font-weight: 600;
+  color: #92400e;
+  font-family: ui-monospace, SFMono-Regular, monospace;
+}
+.screen-items-event-mapping {
+  margin-top: 8px;
+  border-top: 1px dashed #fed7aa;
+  padding-top: 6px;
+}
+.screen-items-event-mapping-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+.screen-items-event-mapping-empty {
+  font-size: 0.78rem;
+  color: #94a3b8;
+}
+.screen-items-event-mapping-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 4px;
+}
+.screen-items-event-mapping-eq {
+  color: #64748b;
+  font-family: ui-monospace, SFMono-Regular, monospace;
+}
+.screen-items-event-actions {
+  margin-top: 6px;
+  text-align: right;
+}
+
 /* 出力項目専用フィールド (#377) */
 .screen-items-output-section {
   width: 100%;


### PR DESCRIPTION
## Summary

ISSUE #1260 Phase 1 (sub-section **A** + **D**) — @reference auto-complete の bind 先 UI を整備。残 B (topic/secretRef step-card) / C (extensionRef 議論先行) は別 phase。

### sub-section A: ScreenItemsView events 編集 UI 新設

- 各 ScreenItem 行に **3 つ目の expand panel** (`bi-lightning`) を追加
- 展開時に events[] を編集できるカード UI:
  - `id` / `label` (text input)
  - `handlerFlowId` → `ReferenceCompletionInput` + `handlerFlowIdResolver` (workspace.processFlows 候補)
  - `handlerActionId` → `ReferenceCompletionInput` + `handlerActionIdResolver` (handlerFlowId 連動)
  - `argumentMapping` → key/value 行リスト (追加・削除)
  - 並び替えは省略 (events 配列順は handler 実行順に影響しないため defer)

### sub-section D: useWorkspaceReferences actions[] eager preload

- `loadProject()` 完了後、各 ProcessFlow を `Promise.allSettled(loadProcessFlow(id))` で並列ロード
- `actions[].{id, name}` のみ extract して `WorkspaceRefs.processFlows[].actions` に格納
- `mcpBridge.onBroadcast("processFlowChanged", reload)` で flow 編集時に自動再ロード
- per-flow Map cache は実装簡素化のため省略 (refs 全体一括 useState の既存パターンに合わせ全体再ロードで invalidation)

### Out of scope

- `ScreenItemEvent.effects[]` (schema にはあるが TS 型未反映の pre-existing drift、別 ISSUE 化候補)
- argumentMapping value への `@screen.* / @self.*` 補完 resolver (resolver 自体未実装、別 ISSUE)
- B (topic/secretRef step-card body) — 別 PR
- C (extensionRef bind 先) — 議論先行

## 仕様逐条突合 (自己申告)

ISSUE 本文の sub-section A / D の要件項目:

**A**:
- ☑ events 編集セクション追加 (3 つ目 expand panel): `frontend/src/components/screen-items/ScreenItemsView.tsx:1188-1336`
- ☑ handlerFlowId field を `ReferenceCompletionInput fieldKind="handlerFlowId" resolvers={[handlerFlowIdResolver]}`: `ScreenItemsView.tsx:1218-1227`
- ☑ handlerActionId field を `ReferenceCompletionInput fieldKind="handlerActionId" resolvers={[handlerActionIdResolver]} ctx={{ handlerFlowId, workspace }}`: `ScreenItemsView.tsx:1230-1239`
- ☑ useWorkspaceReferences() を ScreenItemsView で呼び出し: `ScreenItemsView.tsx:136`
- ☑ events 編集 UI の追加/削除操作 (並び替えは defer、本文「3-5 日」を絞る判断): `ScreenItemsView.tsx:1295-1310, 1325-1334`

**D**:
- ☑ lazy load 実装 (eager parallel preload 案): `frontend/src/hooks/useWorkspaceReferences.ts:70-72`
- ☑ キャッシュ: refs 全体 useState で重複 load を avoid (1 mount = 1 load)
- ☑ invalidation: `processFlowChanged` broadcast subscribe: `useWorkspaceReferences.ts:122-126`

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint` — pass
- [x] `npx vitest run src/hooks/useWorkspaceReferences src/components/screen-items` — 15 / 15 pass
- [ ] UI 動作確認: 別 session の独立レビュー (`/review-pr`) で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
