### PR TITLE
feat(designer): @reference auto-complete bind 先 UI — topic / secretRef step-card (#1260 Phase 2 sub-section B)

### DIFF
--- a/frontend/src/components/process-flow/StepCard.tsx
+++ b/frontend/src/components/process-flow/StepCard.tsx
@@ -765,7 +765,6 @@ export function StepCard({
                 />
               )}
 
-              {/* Phase-3 (#1145、#1163 review Phase-2 補足) 追加 3 dispatch */}
               {/* #1260 Phase 2 sub-section B: eventPublish / eventSubscribe dispatch */}
               {step.kind === "eventPublish" && !isExtensionStep(step) && (
                 <EventPublishStepCardBody
@@ -789,6 +788,7 @@ export function StepCard({
                 />
               )}
 
+              {/* Phase-3 (#1145、#1163 review Phase-2 補足) 追加 3 dispatch: componentCall / aiCall / aiAgent */}
               {step.kind === "componentCall" && !isExtensionStep(step) && (
                 <ComponentCallStepCardBody
                   step={step}

--- a/frontend/src/components/process-flow/StepCard.tsx
+++ b/frontend/src/components/process-flow/StepCard.tsx
@@ -35,6 +35,8 @@ import {
   ComputeStepCardBody,
   DbAccessStepCardBody,
   DisplayUpdateStepCardBody,
+  EventPublishStepCardBody,
+  EventSubscribeStepCardBody,
   ExternalSystemStepCardBody,
   JumpStepCardBody,
   LogStepCardBody,
@@ -605,6 +607,7 @@ export function StepCard({
                   onChange={onChange}
                   onCommit={onCommit}
                   readOnly={readOnly}
+                  workspace={workspace}
                 />
               )}
 
@@ -763,6 +766,29 @@ export function StepCard({
               )}
 
               {/* Phase-3 (#1145、#1163 review Phase-2 補足) 追加 3 dispatch */}
+              {/* #1260 Phase 2 sub-section B: eventPublish / eventSubscribe dispatch */}
+              {step.kind === "eventPublish" && !isExtensionStep(step) && (
+                <EventPublishStepCardBody
+                  step={step}
+                  allSteps={allSteps}
+                  onChange={onChange}
+                  onCommit={onCommit}
+                  readOnly={readOnly}
+                  workspace={workspace}
+                />
+              )}
+
+              {step.kind === "eventSubscribe" && !isExtensionStep(step) && (
+                <EventSubscribeStepCardBody
+                  step={step}
+                  allSteps={allSteps}
+                  onChange={onChange}
+                  onCommit={onCommit}
+                  readOnly={readOnly}
+                  workspace={workspace}
+                />
+              )}
+
               {step.kind === "componentCall" && !isExtensionStep(step) && (
                 <ComponentCallStepCardBody
                   step={step}

--- a/frontend/src/components/process-flow/internal/step-cards/EventPublishStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/EventPublishStepCardBody.tsx
@@ -2,7 +2,7 @@
 // topic は topicResolver (context.catalogs.events キー) で @reference 補完対応。
 // payload は式入力のため plain textarea (resolver 未対応)。
 
-import type { EventPublishStep } from "../../../../types/v3";
+import type { EventPublishStep, EventTopic } from "../../../../types/v3";
 import type { WorkspaceRefs } from "../../../../utils/reference-completer/types";
 import { topicResolver } from "../../../../utils/reference-completer/workspaceResolver";
 import { ReferenceCompletionInput } from "../../../common/ReferenceCompletionInput";
@@ -29,7 +29,7 @@ export function EventPublishStepCardBody({
           </label>
           <ReferenceCompletionInput
             value={step.topic ?? ""}
-            onValueChange={(v) => onChange({ topic: v as never })}
+            onValueChange={(v) => onChange({ topic: v as EventTopic })}
             onCommit={onCommit}
             resolvers={[topicResolver]}
             ctx={{ fieldKind: "topic", workspace }}

--- a/frontend/src/components/process-flow/internal/step-cards/EventPublishStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/EventPublishStepCardBody.tsx
@@ -1,0 +1,63 @@
+// #1260 Phase 2 sub-section B: EventPublish step に topic 補完 bind + payload plain textarea。
+// topic は topicResolver (context.catalogs.events キー) で @reference 補完対応。
+// payload は式入力のため plain textarea (resolver 未対応)。
+
+import type { EventPublishStep } from "../../../../types/v3";
+import type { WorkspaceRefs } from "../../../../utils/reference-completer/types";
+import { topicResolver } from "../../../../utils/reference-completer/workspaceResolver";
+import { ReferenceCompletionInput } from "../../../common/ReferenceCompletionInput";
+import type { StepCardBodyBaseProps } from "./types";
+
+export interface EventPublishStepCardBodyProps extends StepCardBodyBaseProps<EventPublishStep> {
+  workspace?: WorkspaceRefs;
+}
+
+export function EventPublishStepCardBody({
+  step,
+  onChange,
+  onCommit,
+  readOnly,
+  workspace,
+}: EventPublishStepCardBodyProps) {
+  return (
+    <>
+      <div className="row g-2 mb-2">
+        <div className="col-12">
+          <label className="form-label">
+            <i className="bi bi-broadcast-pin me-1" />
+            topic
+          </label>
+          <ReferenceCompletionInput
+            value={step.topic ?? ""}
+            onValueChange={(v) => onChange({ topic: v as never })}
+            onCommit={onCommit}
+            resolvers={[topicResolver]}
+            ctx={{ fieldKind: "topic", workspace }}
+            className="form-control form-control-sm"
+            placeholder="例: order.placed (context.catalogs.events のキー)"
+            style={{ fontFamily: "monospace", fontSize: "0.85rem" }}
+            disabled={readOnly}
+          />
+        </div>
+      </div>
+      <div className="row g-2 mb-2">
+        <div className="col-12">
+          <label className="form-label">
+            <i className="bi bi-box-arrow-up me-1" />
+            payload (式)
+          </label>
+          <textarea
+            className="form-control form-control-sm"
+            rows={2}
+            value={step.payload ?? ""}
+            onChange={(e) => onChange({ payload: e.target.value || undefined })}
+            onBlur={onCommit}
+            placeholder="例: @input.order"
+            style={{ fontFamily: "monospace", fontSize: "0.85rem" }}
+            disabled={readOnly}
+          />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/process-flow/internal/step-cards/EventSubscribeStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/EventSubscribeStepCardBody.tsx
@@ -2,7 +2,7 @@
 // topic は topicResolver (context.catalogs.events キー) で @reference 補完対応。
 // filter は式入力のため plain textarea (resolver 未対応)。
 
-import type { EventSubscribeStep } from "../../../../types/v3";
+import type { EventSubscribeStep, EventTopic } from "../../../../types/v3";
 import type { WorkspaceRefs } from "../../../../utils/reference-completer/types";
 import { topicResolver } from "../../../../utils/reference-completer/workspaceResolver";
 import { ReferenceCompletionInput } from "../../../common/ReferenceCompletionInput";
@@ -29,7 +29,7 @@ export function EventSubscribeStepCardBody({
           </label>
           <ReferenceCompletionInput
             value={step.topic ?? ""}
-            onValueChange={(v) => onChange({ topic: v as never })}
+            onValueChange={(v) => onChange({ topic: v as EventTopic })}
             onCommit={onCommit}
             resolvers={[topicResolver]}
             ctx={{ fieldKind: "topic", workspace }}

--- a/frontend/src/components/process-flow/internal/step-cards/EventSubscribeStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/EventSubscribeStepCardBody.tsx
@@ -1,0 +1,63 @@
+// #1260 Phase 2 sub-section B: EventSubscribe step に topic 補完 bind + filter plain textarea。
+// topic は topicResolver (context.catalogs.events キー) で @reference 補完対応。
+// filter は式入力のため plain textarea (resolver 未対応)。
+
+import type { EventSubscribeStep } from "../../../../types/v3";
+import type { WorkspaceRefs } from "../../../../utils/reference-completer/types";
+import { topicResolver } from "../../../../utils/reference-completer/workspaceResolver";
+import { ReferenceCompletionInput } from "../../../common/ReferenceCompletionInput";
+import type { StepCardBodyBaseProps } from "./types";
+
+export interface EventSubscribeStepCardBodyProps extends StepCardBodyBaseProps<EventSubscribeStep> {
+  workspace?: WorkspaceRefs;
+}
+
+export function EventSubscribeStepCardBody({
+  step,
+  onChange,
+  onCommit,
+  readOnly,
+  workspace,
+}: EventSubscribeStepCardBodyProps) {
+  return (
+    <>
+      <div className="row g-2 mb-2">
+        <div className="col-12">
+          <label className="form-label">
+            <i className="bi bi-broadcast me-1" />
+            topic
+          </label>
+          <ReferenceCompletionInput
+            value={step.topic ?? ""}
+            onValueChange={(v) => onChange({ topic: v as never })}
+            onCommit={onCommit}
+            resolvers={[topicResolver]}
+            ctx={{ fieldKind: "topic", workspace }}
+            className="form-control form-control-sm"
+            placeholder="例: order.placed (context.catalogs.events のキー)"
+            style={{ fontFamily: "monospace", fontSize: "0.85rem" }}
+            disabled={readOnly}
+          />
+        </div>
+      </div>
+      <div className="row g-2 mb-2">
+        <div className="col-12">
+          <label className="form-label">
+            <i className="bi bi-funnel me-1" />
+            filter (式)
+          </label>
+          <textarea
+            className="form-control form-control-sm"
+            rows={2}
+            value={step.filter ?? ""}
+            onChange={(e) => onChange({ filter: e.target.value || undefined })}
+            onBlur={onCommit}
+            placeholder="例: @event.amount > 1000"
+            style={{ fontFamily: "monospace", fontSize: "0.85rem" }}
+            disabled={readOnly}
+          />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/process-flow/internal/step-cards/ExternalSystemStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/ExternalSystemStepCardBody.tsx
@@ -26,6 +26,16 @@ export function ExternalSystemStepCardBody({
   const updateAuth = (patch: Partial<ExternalAuth>) => {
     const base: ExternalAuth = step.auth ?? { kind: "none" };
     const next: ExternalAuth = { ...base, ...patch };
+    // kind="none" の場合は stale tokenRef / headerName を strip して JSON ノイズを抑える
+    if (next.kind === "none") {
+      onChange({ auth: { kind: "none" } });
+      return;
+    }
+    // kind 変更時は前の kind に紐づく stale フィールドをクリアして semantic consistency を保つ
+    if (patch.kind !== undefined && patch.kind !== base.kind) {
+      onChange({ auth: { kind: next.kind } });
+      return;
+    }
     onChange({ auth: next });
   };
   return (
@@ -195,6 +205,7 @@ export function ExternalSystemStepCardBody({
         <div className="col-3">
           <select
             className="form-select form-select-sm"
+            data-field-path="auth.kind"
             value={step.auth?.kind ?? "none"}
             onChange={(e) => {
               updateAuth({ kind: e.target.value as ExternalAuthKind });

--- a/frontend/src/components/process-flow/internal/step-cards/ExternalSystemStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/ExternalSystemStepCardBody.tsx
@@ -2,19 +2,32 @@
 // #1016 follow-up (2026-05-20): generic StepCardBodyBaseProps<ExternalSystemStep> で type narrow、
 // 副次 silent bug fix: `protocol` field 入力欄を削除 (v3 schema 上 ExternalSystemStep.protocol 不在、
 // unevaluatedProperties: false で reject される silent field だった)。
+// #1260 Phase 2 sub-section B: auth 編集セクション追加 (auth.tokenRef を secretRef 補完 bind)。
 
-import type { ExternalSystemStep, Identifier } from "../../../../types/v3";
+import type { ExternalAuth, ExternalAuthKind, ExternalSystemStep, Identifier } from "../../../../types/v3";
+import type { WorkspaceRefs } from "../../../../utils/reference-completer/types";
+import { secretRefResolver } from "../../../../utils/reference-completer/workspaceResolver";
+import { ReferenceCompletionInput } from "../../../common/ReferenceCompletionInput";
 import { ExternalOutcomesPanel } from "../../ExternalOutcomesPanel";
 import { trimToUndefined } from "../stepCardConstants";
 import type { StepCardBodyBaseProps } from "./types";
 
-export type ExternalSystemStepCardBodyProps = StepCardBodyBaseProps<ExternalSystemStep>;
+export interface ExternalSystemStepCardBodyProps extends StepCardBodyBaseProps<ExternalSystemStep> {
+  workspace?: WorkspaceRefs;
+}
 
 export function ExternalSystemStepCardBody({
   step,
   onChange,
   onCommit,
+  readOnly,
+  workspace,
 }: ExternalSystemStepCardBodyProps) {
+  const updateAuth = (patch: Partial<ExternalAuth>) => {
+    const base: ExternalAuth = step.auth ?? { kind: "none" };
+    const next: ExternalAuth = { ...base, ...patch };
+    onChange({ auth: next });
+  };
   return (
     <>
       <div className="form-group">
@@ -175,6 +188,53 @@ export function ExternalSystemStepCardBody({
             </div>
           </>
         )}
+      </div>
+      {/* #1260 Phase 2: auth 編集セクション (secretRef 補完 bind) */}
+      <label className="form-label small">認証 (auth)</label>
+      <div className="row g-2 mb-2">
+        <div className="col-3">
+          <select
+            className="form-select form-select-sm"
+            value={step.auth?.kind ?? "none"}
+            onChange={(e) => {
+              updateAuth({ kind: e.target.value as ExternalAuthKind });
+            }}
+            onBlur={onCommit}
+            disabled={readOnly}
+          >
+            <option value="none">none</option>
+            <option value="bearer">bearer</option>
+            <option value="basic">basic</option>
+            <option value="apiKey">apiKey</option>
+            <option value="oauth2">oauth2</option>
+            <option value="iamRole">iamRole</option>
+            <option value="azureAd">azureAd</option>
+          </select>
+        </div>
+        <div className="col-5">
+          <ReferenceCompletionInput
+            value={step.auth?.tokenRef ?? ""}
+            onValueChange={(v) => updateAuth({ tokenRef: v || undefined })}
+            onCommit={onCommit}
+            resolvers={[secretRefResolver]}
+            ctx={{ fieldKind: "secretRef", workspace }}
+            className="form-control form-control-sm"
+            placeholder="例: stripeApiKey (@secret 参照)"
+            style={{ fontFamily: "monospace", fontSize: "0.85rem" }}
+            disabled={readOnly || !step.auth?.kind || step.auth.kind === "none"}
+          />
+        </div>
+        <div className="col-4">
+          <input
+            type="text"
+            className="form-control form-control-sm"
+            value={step.auth?.headerName ?? ""}
+            onChange={(e) => updateAuth({ headerName: e.target.value || undefined })}
+            onBlur={onCommit}
+            placeholder="X-API-Key"
+            disabled={readOnly || !step.auth?.kind || step.auth.kind === "none"}
+          />
+        </div>
       </div>
       <ExternalOutcomesPanel
         step={step}

--- a/frontend/src/components/process-flow/internal/step-cards/index.ts
+++ b/frontend/src/components/process-flow/internal/step-cards/index.ts
@@ -19,3 +19,6 @@ export { WorkflowStepCardBody } from "./WorkflowStepCardBody";
 export { ComponentCallStepCardBody } from "./ComponentCallStepCardBody";
 export { AiCallStepCardBody } from "./AiCallStepCardBody";
 export { AiAgentStepCardBody } from "./AiAgentStepCardBody";
+// #1260 Phase 2: eventPublish / eventSubscribe の step-card body (topic 補完 bind)
+export { EventPublishStepCardBody } from "./EventPublishStepCardBody";
+export { EventSubscribeStepCardBody } from "./EventSubscribeStepCardBody";

--- a/frontend/src/components/process-flow/internal/step-cards/step-cards.test.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/step-cards.test.tsx
@@ -16,6 +16,8 @@ import {
   ComputeStepCardBody,
   DbAccessStepCardBody,
   DisplayUpdateStepCardBody,
+  EventPublishStepCardBody,
+  EventSubscribeStepCardBody,
   ExternalSystemStepCardBody,
   JumpStepCardBody,
   LogStepCardBody,
@@ -523,5 +525,110 @@ describe("AiAgentStepCardBody", () => {
     const numberInput = container.querySelector('input[type="number"]') as HTMLInputElement;
     fireEvent.change(numberInput, { target: { value: "7" } });
     expect(onChange).toHaveBeenCalledWith({ maxIterations: 7 });
+  });
+});
+
+// ── EventPublishStepCardBody (#1260 Phase 2 sub-section B) ───────────────
+describe("EventPublishStepCardBody", () => {
+  it("topic input と payload textarea が描画される", () => {
+    const step = baseStep({
+      kind: "eventPublish",
+      topic: "order.placed",
+      payload: "@input.order",
+    });
+    const { container } = render(
+      <EventPublishStepCardBody step={step} allSteps={[]} onChange={noop} />,
+    );
+    expect(container.textContent).toContain("topic");
+    expect(container.textContent).toContain("payload");
+    const input = container.querySelector("input") as HTMLInputElement;
+    expect(input).not.toBeNull();
+    expect(input.value).toBe("order.placed");
+    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+    expect(textarea).not.toBeNull();
+    expect(textarea.value).toBe("@input.order");
+  });
+
+  it("topic 変更で onChange が呼ばれる", () => {
+    const onChange = vi.fn();
+    const step = baseStep({ kind: "eventPublish", topic: "", payload: undefined });
+    const { container } = render(
+      <EventPublishStepCardBody step={step} allSteps={[]} onChange={onChange} />,
+    );
+    const input = container.querySelector("input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "payment.completed" } });
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ topic: "payment.completed" }));
+  });
+});
+
+// ── EventSubscribeStepCardBody (#1260 Phase 2 sub-section B) ────────────
+describe("EventSubscribeStepCardBody", () => {
+  it("topic input と filter textarea が描画される", () => {
+    const step = baseStep({
+      kind: "eventSubscribe",
+      topic: "order.placed",
+      filter: "@event.amount > 1000",
+    });
+    const { container } = render(
+      <EventSubscribeStepCardBody step={step} allSteps={[]} onChange={noop} />,
+    );
+    expect(container.textContent).toContain("topic");
+    expect(container.textContent).toContain("filter");
+    const input = container.querySelector("input") as HTMLInputElement;
+    expect(input).not.toBeNull();
+    expect(input.value).toBe("order.placed");
+    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+    expect(textarea).not.toBeNull();
+    expect(textarea.value).toBe("@event.amount > 1000");
+  });
+
+  it("topic 変更で onChange が呼ばれる", () => {
+    const onChange = vi.fn();
+    const step = baseStep({ kind: "eventSubscribe", topic: "", filter: undefined });
+    const { container } = render(
+      <EventSubscribeStepCardBody step={step} allSteps={[]} onChange={onChange} />,
+    );
+    const input = container.querySelector("input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "inventory.low" } });
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ topic: "inventory.low" }));
+  });
+});
+
+// ── ExternalSystemStepCardBody auth セクション (#1260 Phase 2 sub-section B) ──
+describe("ExternalSystemStepCardBody auth section", () => {
+  it("auth.kind select が描画される (workspace prop あり)", () => {
+    const step = baseStep({
+      kind: "externalSystem",
+      systemRef: "stripe",
+      auth: { kind: "bearer", tokenRef: "@secret.stripeKey" },
+    });
+    const { container } = render(
+      <ExternalSystemStepCardBody step={step} allSteps={[]} onChange={noop} workspace={undefined} />,
+    );
+    expect(container.textContent).toContain("認証");
+    const selects = container.querySelectorAll("select");
+    // auth.kind select が存在する (他に retryPolicy backoff select がある場合もあり)
+    const authSelect = Array.from(selects).find(
+      (s) => (s as HTMLSelectElement).value === "bearer",
+    ) as HTMLSelectElement | undefined;
+    expect(authSelect).not.toBeUndefined();
+    expect(authSelect!.value).toBe("bearer");
+  });
+
+  it("auth.tokenRef input が描画される", () => {
+    const step = baseStep({
+      kind: "externalSystem",
+      systemRef: "stripe",
+      auth: { kind: "apiKey", tokenRef: "@secret.stripeKey" },
+    });
+    const { container } = render(
+      <ExternalSystemStepCardBody step={step} allSteps={[]} onChange={noop} />,
+    );
+    const inputs = container.querySelectorAll("input");
+    // tokenRef input が存在し値が "@secret.stripeKey" である
+    const tokenInput = Array.from(inputs).find(
+      (i) => (i as HTMLInputElement).value === "@secret.stripeKey",
+    ) as HTMLInputElement | undefined;
+    expect(tokenInput).not.toBeUndefined();
   });
 });

--- a/frontend/src/components/process-flow/internal/step-cards/step-cards.test.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/step-cards.test.tsx
@@ -6,6 +6,7 @@
 
 import { describe, expect, it, vi } from "vitest";
 import { render, fireEvent } from "@testing-library/react";
+import type { WorkspaceRefs } from "../../../../utils/reference-completer/types";
 import {
   AiAgentStepCardBody,
   AiCallStepCardBody,
@@ -37,6 +38,20 @@ const baseStep = (overrides: any = {}) => ({
   description: "",
   ...overrides,
 });
+
+// N-1/N-2 用: workspace prop あり テストで使う最小 mock
+const mockWorkspace: WorkspaceRefs = {
+  screens: [],
+  tables: [],
+  viewDefinitions: [],
+  processFlows: [],
+  fragments: [],
+  components: [],
+  exceptionTypes: [],
+  modelEndpoints: [],
+  secrets: [{ id: "stripeApiKey", name: "Stripe API Key" }],
+  events: [],
+};
 
 // ── ValidationStepCardBody ─────────────────────────────────────────
 
@@ -603,7 +618,7 @@ describe("ExternalSystemStepCardBody auth section", () => {
       auth: { kind: "bearer", tokenRef: "@secret.stripeKey" },
     });
     const { container } = render(
-      <ExternalSystemStepCardBody step={step} allSteps={[]} onChange={noop} workspace={undefined} />,
+      <ExternalSystemStepCardBody step={step} allSteps={[]} onChange={noop} workspace={mockWorkspace} />,
     );
     expect(container.textContent).toContain("認証");
     const selects = container.querySelectorAll("select");
@@ -630,5 +645,22 @@ describe("ExternalSystemStepCardBody auth section", () => {
       (i) => (i as HTMLInputElement).value === "@secret.stripeKey",
     ) as HTMLInputElement | undefined;
     expect(tokenInput).not.toBeUndefined();
+  });
+
+  it("auth.kind 変更で onChange に auth patch が届く", () => {
+    const onChange = vi.fn();
+    const step = baseStep({
+      kind: "externalSystem",
+      systemRef: "stripe",
+    });
+    const { container } = render(
+      <ExternalSystemStepCardBody step={step} allSteps={[]} onChange={onChange} workspace={mockWorkspace} />,
+    );
+    const authSelect = container.querySelector('select[data-field-path="auth.kind"]') as HTMLSelectElement;
+    expect(authSelect).not.toBeNull();
+    fireEvent.change(authSelect, { target: { value: "bearer" } });
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({
+      auth: expect.objectContaining({ kind: "bearer" }),
+    }));
   });
 });


### PR DESCRIPTION
## Summary

ISSUE #1260 Phase 2 (sub-section B、topic / secretRef のみ) を実装。Phase 1 (PR #1261) で resolver と一部 bind が完了済の reference auto-complete について、step-card UI 側の bind 先を追加。

- **EventPublishStepCardBody / EventSubscribeStepCardBody 新設** — `topic` field を `ReferenceCompletionInput` + `topicResolver` で bind。`payload` / `filter` は plain textarea (式補完 resolver は別 ISSUE)
- **ExternalSystemStepCardBody に auth 編集セクション追加** — `auth.tokenRef` を `ReferenceCompletionInput` + `secretRefResolver` で bind (kind select 7 値 + headerName plain input も同セクション)
- `StepCard.tsx` dispatch に `eventPublish` / `eventSubscribe` を追加 (workspace prop 経由で resolver context 接続)
- barrel export + 最小 render test 追加

Refs #1260

(Phase 3 = sub-section C extensionRef は議論先行で本 PR 対象外。ISSUE は OPEN 維持のため `Refs` を使用、`Closes` は使わない)

## スコープ判断 (schema governance #511 遵守)

ISSUE 本文の "ExternalSystemStepCardBody に secretRef field 追加" は schema 変更が必要に見えるが、既存 `ExternalSystemStep.auth.tokenRef` (`@secret.<key>` 表現の正規 slot) を `ReferenceCompletionInput` 化することで **schema 触らず達成**。AI 単独で `schemas/*.json` を改変するのは権限外。

`gh pr diff -- schemas/` が空であることを Step 5.0 で確認済。

## 実装スコープ

| sub | 内容 | 変更ファイル |
|-----|------|----|
| B-1 | EventPublishStepCardBody 新設 | `frontend/src/components/process-flow/internal/step-cards/EventPublishStepCardBody.tsx` (新規) |
| B-2 | EventSubscribeStepCardBody 新設 | `frontend/src/components/process-flow/internal/step-cards/EventSubscribeStepCardBody.tsx` (新規) |
| B-3 | StepCard.tsx dispatch 追加 | `frontend/src/components/process-flow/StepCard.tsx` |
| B-4 | barrel export 追加 | `frontend/src/components/process-flow/internal/step-cards/index.ts` |
| B-5 | ExternalSystemStepCardBody auth セクション追加 | `frontend/src/components/process-flow/internal/step-cards/ExternalSystemStepCardBody.tsx` |
| B-6 | ExternalSystemStepCardBody に workspace prop 追加 | 上記 + StepCard.tsx |
| B-7 | useWorkspaceReferences 拡張 | **不要** (events/secrets は projectCatalogs から populate 済) |
| B-8 | 最小 render test 追加 | `frontend/src/components/process-flow/internal/step-cards/step-cards.test.tsx` |

## 検証結果

- `npx tsc --noEmit`: **0 errors**
- `npm run lint`: **0 warnings**
- `npx vitest run src/components/process-flow/internal/step-cards/step-cards.test.tsx`: **35/35 pass** (+7 新テスト)
- `npx vitest run src/utils/reference-completer`: **55/55 pass** (退行なし)

## 仕様逐条突合 (自己申告)

- ✅ ISSUE 本文 提案 B 要件 1 (EventPublish/Subscribe step-card body + topic bind): `EventPublishStepCardBody.tsx:1-` / `EventSubscribeStepCardBody.tsx:1-` で実装、StepCard.tsx の dispatch に追加
- ✅ ISSUE 本文 提案 B 要件 2 (ExternalSystemStepCardBody に secretRef bind): `ExternalSystemStepCardBody.tsx` の auth セクションで `auth.tokenRef` を secretRefResolver bind
- ✅ ISSUE 本文 提案 B 要件 4 (StepCard.tsx dispatch 追加): EventPublish / EventSubscribe 2 件追加
- N/A 提案 B 要件 3 (fragmentRef / exceptionTypeRef): schema governance 議論先行、本 phase 対象外
- N/A 提案 C (extensionRef): 議論先行、本 phase 対象外
- N/A 提案 B - payload/filter の式補完: resolver 未整備、別 ISSUE 候補

## Test plan

- [ ] designer 起動 → ProcessFlow editor で eventPublish / eventSubscribe step を追加 → topic 入力で `@` 入力時に events catalog の候補が出る
- [ ] externalSystem step → auth セクションで tokenRef 入力時に `@` 入力で secrets catalog の候補が出る
- [ ] kind select 切替で UI が想定通り反応 (none → bearer 等)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
