### PR TITLE
feat(schema): meta.kind → meta.flowType rename (#1263 Phase X1)

### DIFF
--- a/ai-skills/generate-tests/golden-examples/diary-post-lifecycle-e2e/README.md
+++ b/ai-skills/generate-tests/golden-examples/diary-post-lifecycle-e2e/README.md
@@ -82,7 +82,7 @@ diary アプリ (`examples/diary/harmony.json`) を題材にした
 | 投稿削除 | `c4d5e6f7-a8b9-4c0d-8e1f-2a3b4c5d6e7f` | DELETE /api/posts/:id |
 | 投稿詳細取得 | `d5e6f7a8-b9c0-4d1e-8f2a-3b4c5d6e7f8a` | GET /api/posts/:id |
 
-**注意**: 上記は ProcessFlow の kind/name から推定した値。
+**注意**: 上記は ProcessFlow の flowType/name から推定した値 (#1263 Phase X1: meta.kind → meta.flowType)。
 実際の httpRoute.path は各 ProcessFlow JSON を Read して確認すること。
 
 ---

--- a/backend/src/handlers/processFlow.test.ts
+++ b/backend/src/handlers/processFlow.test.ts
@@ -4,8 +4,8 @@
  * 検証観点:
  * 1. designer__add_process_flow が v3 構造 (meta/context/actions/authoring 4 並列) で書き込む
  * 2. 生成される ID (processFlow / action / step) が RFC 4122 v4 UUID 形式
- * 3. meta.kind discriminator が使用される (旧 type フィールドは新規 entity に出現しない)
- * 4. harmony.json の entities.processFlows[] に upsert される (kind / no / actionCount)
+ * 3. meta.flowType discriminator が使用される (旧 type / kind フィールドは新規 entity に出現しない、#1263 Phase X1)
+ * 4. harmony.json の entities.processFlows[] に upsert される (flowType / no / actionCount)
  * 5. designer__add_action が v3 ActionDefinition 構造で UUID 付き action を追加する
  * 6. designer__add_step が v3 step (kind discriminator + UUID) を追加する
  * 7. AJV 検証で違反があれば authoring.markers に validator marker (Marker.kind='validator' +
@@ -63,7 +63,7 @@ describe("designer__add_process_flow — #1141 F-4 + S-9", () => {
   it("v3 構造 (meta/context/actions/authoring 4 並列) で書き込まれる", async () => {
     const res = await handleProcessFlowTool(
       "designer__add_process_flow",
-      { name: "テスト処理フロー", kind: "common" },
+      { name: "テスト処理フロー", flowType: "common" },
       root,
       SESSION_ID,
     );
@@ -95,7 +95,8 @@ describe("designer__add_process_flow — #1141 F-4 + S-9", () => {
     expect(meta.id).toBe(pfId);
     expect(meta.id).toMatch(UUID_V4_PATTERN);
     expect(meta.name).toBe("テスト処理フロー");
-    expect(meta.kind).toBe("common"); // #8 / #1141: discriminator は `kind`
+    expect(meta.flowType).toBe("common"); // #8 / #1141 / #1263 Phase X1: discriminator は `flowType`
+    expect(meta).not.toHaveProperty("kind"); // #1263 Phase X1: 旧 meta.kind は出現しない
     expect(meta).not.toHaveProperty("type");
     expect(meta.maturity).toBe("draft");
     expect(typeof meta.createdAt).toBe("string");
@@ -105,7 +106,7 @@ describe("designer__add_process_flow — #1141 F-4 + S-9", () => {
   it("ProcessFlowId が RFC 4122 v4 UUID 形式である (旧 ag-${Date.now()} 全廃)", async () => {
     const res = await handleProcessFlowTool(
       "designer__add_process_flow",
-      { name: "uuid-format-check", kind: "batch" },
+      { name: "uuid-format-check", flowType: "batch" },
       root,
       SESSION_ID,
     );
@@ -116,19 +117,19 @@ describe("designer__add_process_flow — #1141 F-4 + S-9", () => {
     expect(idMatch![1]).not.toMatch(/^ag-/);
   });
 
-  it("name または kind 欠落で InvalidParams が throw される", async () => {
+  it("name または flowType 欠落で InvalidParams が throw される (#1263 Phase X1)", async () => {
     await expect(
-      handleProcessFlowTool("designer__add_process_flow", { name: "no-kind" }, root, SESSION_ID),
-    ).rejects.toThrow(/name, kind は必須/);
+      handleProcessFlowTool("designer__add_process_flow", { name: "no-flow-type" }, root, SESSION_ID),
+    ).rejects.toThrow(/name, flowType は必須/);
     await expect(
-      handleProcessFlowTool("designer__add_process_flow", { kind: "screen" }, root, SESSION_ID),
-    ).rejects.toThrow(/name, kind は必須/);
+      handleProcessFlowTool("designer__add_process_flow", { flowType: "screen" }, root, SESSION_ID),
+    ).rejects.toThrow(/name, flowType は必須/);
   });
 
-  it("harmony.json の entities.processFlows[] に upsert される (no / kind / actionCount)", async () => {
+  it("harmony.json の entities.processFlows[] に upsert される (no / flowType / actionCount, #1263 Phase X1)", async () => {
     await handleProcessFlowTool(
       "designer__add_process_flow",
-      { name: "entity-upsert-check", kind: "screen", screenId: "11111111-1111-4111-8111-111111111110", description: "test desc" },
+      { name: "entity-upsert-check", flowType: "screen", screenId: "11111111-1111-4111-8111-111111111110", description: "test desc" },
       root,
       SESSION_ID,
     );
@@ -138,7 +139,8 @@ describe("designer__add_process_flow — #1141 F-4 + S-9", () => {
     const list = entities.processFlows as Array<Record<string, unknown>>;
     const entry = list.find((e) => e.name === "entity-upsert-check");
     expect(entry).toBeDefined();
-    expect(entry!.kind).toBe("screen");
+    expect(entry!.flowType).toBe("screen");
+    expect(entry).not.toHaveProperty("kind"); // #1263 Phase X1: 旧 kind は出現しない
     expect(entry!.actionCount).toBe(0);
     expect(entry!.screenId).toBe("11111111-1111-4111-8111-111111111110");
     expect(typeof entry!.no).toBe("number");
@@ -157,7 +159,7 @@ describe("designer__add_action + designer__add_step — #1141 F-4 + S-9", () => 
     await makeWorkspace(root);
     const addRes = await handleProcessFlowTool(
       "designer__add_process_flow",
-      { name: "for-action-step", kind: "common" },
+      { name: "for-action-step", flowType: "common" },
       root,
       SESSION_ID,
     );
@@ -241,14 +243,14 @@ describe("writeProcessFlow AJV validation — #1141 F-2", () => {
   beforeAll(async () => { await makeWorkspace(root); });
 
   it("schema 違反の ProcessFlow を writeProcessFlow すると authoring.markers に validator marker が記録される (書き込みは許可)", async () => {
-    // schema 違反データ: meta.id が UUID 形式違反 (旧 `ag-xxx` 形式)、kind 欠落
+    // schema 違反データ: meta.id が UUID 形式違反 (旧 `ag-xxx` 形式)、flowType 欠落
     const bad = {
       meta: {
         id: "ag-bad-id-not-uuid",
         name: "違反テスト",
         createdAt: "2026-01-01T00:00:00.000Z",
         updatedAt: "2026-01-01T00:00:00.000Z",
-        // kind が欠落 (meta.required: ['kind'])
+        // flowType が欠落 (meta.required: ['flowType'], #1263 Phase X1)
       },
       context: {},
       actions: [],
@@ -305,7 +307,7 @@ describe("writeProcessFlow AJV validation — #1141 F-2", () => {
       meta: {
         id: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
         name: "valid-flow",
-        kind: "common",
+        flowType: "common",
         createdAt: "2026-01-01T00:00:00.000Z",
         updatedAt: "2026-01-01T00:00:00.000Z",
       },
@@ -323,7 +325,7 @@ describe("writeProcessFlow AJV validation — #1141 F-2", () => {
   });
 });
 
-// ── 4. designer__list_process_flows が meta.{name,kind} を読む (v3 path) ────────
+// ── 4. designer__list_process_flows が meta.{name,flowType} を読む (v3 path, #1263 Phase X1) ──
 
 describe("designer__list_process_flows — #1141 F-4 v3 meta path", () => {
   const root = path.join(TMP_ROOT, "ws-list");
@@ -332,16 +334,16 @@ describe("designer__list_process_flows — #1141 F-4 v3 meta path", () => {
     await makeWorkspace(root);
   });
 
-  it("v3 entity (meta.{name,kind}) を一覧に表示する", async () => {
+  it("v3 entity (meta.{name,flowType}) を一覧に表示する (#1263 Phase X1)", async () => {
     await handleProcessFlowTool(
       "designer__add_process_flow",
-      { name: "list-test-1", kind: "common" },
+      { name: "list-test-1", flowType: "common" },
       root,
       SESSION_ID,
     );
     await handleProcessFlowTool(
       "designer__add_process_flow",
-      { name: "list-test-2", kind: "batch" },
+      { name: "list-test-2", flowType: "batch" },
       root,
       SESSION_ID,
     );
@@ -350,7 +352,7 @@ describe("designer__list_process_flows — #1141 F-4 v3 meta path", () => {
     const text = res!.content[0].text as string;
     expect(text).toMatch(/list-test-1.*common/);
     expect(text).toMatch(/list-test-2.*batch/);
-    // 旧 (type) でなく v3 (kind) の値が表示されている
+    // 旧 (type) / 旧 (kind) でなく v3 (flowType) の値が表示されている
     expect(text).not.toMatch(/\(undefined\)/);
   });
 });
@@ -400,7 +402,7 @@ describe("designer__solution_pack — #1229 F-1 path traversal 拒否", () => {
     // 処理フローを事前に作成
     const addRes = await handleProcessFlowTool(
       "designer__add_process_flow",
-      { name: "pack-test-flow", kind: "common" },
+      { name: "pack-test-flow", flowType: "common" },
       root,
       SESSION_ID,
     );
@@ -462,7 +464,7 @@ describe("designer__solution_unpack — #1229 F-1 path traversal 拒否", () => 
 
     const flowDoc = {
       id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
-      meta: { id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb", name: "unpack-test", kind: "common" },
+      meta: { id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb", name: "unpack-test", flowType: "common" },
       context: {},
       actions: [],
       authoring: { markers: [] },
@@ -495,7 +497,7 @@ describe("designer__solution_unpack — #1229 I-001 ZIP 由来 id の UUID 検�
     const zipDir = path.join(root, "harmony", "input-id");
     await fs.mkdir(zipDir, { recursive: true });
     const zipPath = path.join(zipDir, `${Date.now()}.zip`);
-    const flowDoc = { id, meta: { id, name: "t", kind: "common" }, context: {}, actions: [], authoring: { markers: [] } };
+    const flowDoc = { id, meta: { id, name: "t", flowType: "common" }, context: {}, actions: [], authoring: { markers: [] } };
     const zip = new AdmZip();
     zip.addFile("manifest.json", Buffer.from(JSON.stringify({ publisher: "test", version: "1.0.0", processFlowIds: [id], createdAt: new Date().toISOString() }), "utf8"));
     // entryName は必ず process-flows/ 配下に設定 (フィルタ通過のため)
@@ -526,7 +528,7 @@ describe("designer__solution_unpack — #1229 I-001 ZIP 由来 id の UUID 検�
     const zipDir = path.join(root, "harmony", "input-id");
     await fs.mkdir(zipDir, { recursive: true });
     const zipPath = path.join(zipDir, `empty-id-${Date.now()}.zip`);
-    const flowDoc = { id: "", meta: { id: "", name: "t", kind: "common" }, context: {}, actions: [], authoring: { markers: [] } };
+    const flowDoc = { id: "", meta: { id: "", name: "t", flowType: "common" }, context: {}, actions: [], authoring: { markers: [] } };
     const zip = new AdmZip();
     zip.addFile("manifest.json", Buffer.from(JSON.stringify({ publisher: "test", version: "1.0.0", processFlowIds: [], createdAt: new Date().toISOString() }), "utf8"));
     zip.addFile("process-flows/empty.json", Buffer.from(JSON.stringify(flowDoc), "utf8"));

--- a/backend/src/handlers/processFlow.ts
+++ b/backend/src/handlers/processFlow.ts
@@ -70,22 +70,23 @@ function newId(): string {
  * v3 ProcessFlow entity の初期構造を生成する (#1141 F-4)。
  * schemas/v3/process-flow.v3.schema.json 規範:
  *   - root: { $schema, meta, context?, actions, authoring? }
- *   - meta: { id (Uuid), name, description?, kind, maturity?, createdAt, updatedAt, screenId?, ... }
+ *   - meta: { id (Uuid), name, description?, flowType, maturity?, createdAt, updatedAt, screenId?, ... }
+ *     - #1263 Phase X1: meta.kind → meta.flowType に rename
  *   - actions: ActionDefinition[] (0 件許容)
  */
 function buildV3ProcessFlow(opts: {
   id: string;
   name: string;
-  kind: string;
+  flowType: string;
   screenId?: string;
   description?: string;
   now: string;
 }): Record<string, unknown> {
-  const { id, name, kind, screenId, description, now } = opts;
+  const { id, name, flowType, screenId, description, now } = opts;
   const meta: Record<string, unknown> = {
     id,
     name,
-    kind,
+    flowType,
     maturity: "draft",
     createdAt: now,
     updatedAt: now,
@@ -113,24 +114,25 @@ function isRecord(v: unknown): v is Record<string, unknown> {
  * harmony.json の entities.processFlows[] 一覧を upsert する (#1141 F-4)。
  * schemas/v3/harmony.v3.schema.json#ProcessFlowEntry に従う:
  *   - 必須: id (Uuid), no (1..N), name, updatedAt
- *   - 任意: kind, screenId, actionCount, notesCount, maturity
+ *   - 任意: flowType, screenId, actionCount, notesCount, maturity
+ *   - #1263 Phase X1: kind → flowType に rename
  *
  * `no` は重複しない最大値 + 1 を採番する (sample harmony.json の運用に倣う)。
  */
 function upsertProcessFlowEntry(
   project: Record<string, unknown>,
-  entry: { id: string; name: string; kind: string; screenId?: string; actionCount: number; updatedAt: string; maturity?: string },
+  entry: { id: string; name: string; flowType: string; screenId?: string; actionCount: number; updatedAt: string; maturity?: string },
 ): void {
   const entities = isRecord(project.entities) ? project.entities : {};
   const list = Array.isArray(entities.processFlows) ? entities.processFlows as Array<Record<string, unknown>> : [];
   const idx = list.findIndex((m) => isRecord(m) && m.id === entry.id);
   if (idx >= 0) {
-    // 既存 entry: name/kind/screenId/actionCount/updatedAt/maturity を更新、no は維持
+    // 既存 entry: name/flowType/screenId/actionCount/updatedAt/maturity を更新、no は維持
     const prev = list[idx];
     list[idx] = {
       ...prev,
       name: entry.name,
-      kind: entry.kind,
+      flowType: entry.flowType,
       ...(entry.screenId !== undefined ? { screenId: entry.screenId } : {}),
       actionCount: entry.actionCount,
       updatedAt: entry.updatedAt,
@@ -145,7 +147,7 @@ function upsertProcessFlowEntry(
       id: entry.id,
       no: maxNo + 1,
       name: entry.name,
-      kind: entry.kind,
+      flowType: entry.flowType,
       actionCount: entry.actionCount,
       updatedAt: entry.updatedAt,
     };
@@ -220,7 +222,7 @@ export const handleProcessFlowTool: ToolHandler = async (name, args, root) => {
 
   switch (name) {
     case "designer__list_process_flows": {
-      // #1141 F-4: v3 entity は meta.{name,kind} に格納される。レガシー (flat) も移行猶予で表示。
+      // #1141 F-4 / #1263 Phase X1: v3 entity は meta.{name,flowType} に格納される。レガシー (flat) も移行猶予で表示。
       const pfList = await listProcessFlowFiles(root) as Array<Record<string, unknown>>;
       if (pfList.length === 0) {
         return { content: [{ type: "text", text: "処理フロー定義はまだありません。" }] };
@@ -229,10 +231,10 @@ export const handleProcessFlowTool: ToolHandler = async (name, args, root) => {
         const meta = isRecord(pf.meta) ? pf.meta : {};
         const id = (meta.id as string | undefined) ?? (pf.id as string | undefined) ?? "(no-id)";
         const name = (meta.name as string | undefined) ?? (pf.name as string | undefined) ?? "(no-name)";
-        // v3: meta.kind / legacy: type
-        const kind = (meta.kind as string | undefined) ?? (pf.type as string | undefined) ?? "(no-kind)";
+        // v3: meta.flowType (#1263 Phase X1) / legacy: type
+        const flowType = (meta.flowType as string | undefined) ?? (pf.type as string | undefined) ?? "(no-flowType)";
         const actions = Array.isArray(pf.actions) ? pf.actions : [];
-        return `- ${id}  ${name}（${kind}）アクション:${actions.length}件`;
+        return `- ${id}  ${name}（${flowType}）アクション:${actions.length}件`;
       });
       return { content: [{ type: "text", text: `処理フロー一覧 (${pfList.length}件):\n${lines.join("\n")}` }] };
     }
@@ -255,16 +257,16 @@ export const handleProcessFlowTool: ToolHandler = async (name, args, root) => {
     }
 
     case "designer__add_process_flow": {
-      // #1141 F-4: v3 構造で書き出す。kind は ProcessFlowKind (旧 type) に rename (#8 discriminator)。
-      if (typeof a.name !== "string" || typeof a.kind !== "string") {
-        throw new McpError(ErrorCode.InvalidParams, "name, kind は必須です");
+      // #1141 F-4 / #1263 Phase X1: v3 構造で書き出す。flowType は ProcessFlowKind (旧 type → kind → flowType) に rename (#8 discriminator)。
+      if (typeof a.name !== "string" || typeof a.flowType !== "string") {
+        throw new McpError(ErrorCode.InvalidParams, "name, flowType は必須です");
       }
       const pfId = newId(); // #1141 S-9: RFC 4122 v4 UUID (旧 `ag-${Date.now()}` を全廃)
       const pfNow = new Date().toISOString();
       const pfDef = buildV3ProcessFlow({
         id: pfId,
         name: a.name,
-        kind: a.kind,
+        flowType: a.flowType,
         screenId: typeof a.screenId === "string" ? a.screenId : undefined,
         description: typeof a.description === "string" ? a.description : undefined,
         now: pfNow,
@@ -276,7 +278,7 @@ export const handleProcessFlowTool: ToolHandler = async (name, args, root) => {
       upsertProcessFlowEntry(pfProject, {
         id: pfId,
         name: a.name,
-        kind: a.kind,
+        flowType: a.flowType,
         screenId: typeof a.screenId === "string" ? a.screenId : undefined,
         actionCount: 0,
         updatedAt: pfNow,
@@ -287,7 +289,7 @@ export const handleProcessFlowTool: ToolHandler = async (name, args, root) => {
       projMeta.updatedAt = pfNow;
       pfProject.meta = projMeta;
       await writeProject(pfProject, root);
-      return { content: [{ type: "text", text: `処理フロー「${a.name}」(${a.kind}) を追加しました（ID: ${pfId}）` }] };
+      return { content: [{ type: "text", text: `処理フロー「${a.name}」(${a.flowType}) を追加しました（ID: ${pfId}）` }] };
     }
 
     case "designer__update_process_flow": {
@@ -307,13 +309,14 @@ export const handleProcessFlowTool: ToolHandler = async (name, args, root) => {
       const pfProject = (await readProject(root) ?? {}) as Record<string, unknown>;
       const actions = Array.isArray(pfDef.actions) ? pfDef.actions : [];
       const name = (pfMeta.name as string | undefined) ?? (pfDef.name as string | undefined) ?? "(no-name)";
-      const kind = (pfMeta.kind as string | undefined) ?? (pfDef.type as string | undefined) ?? "other";
+      // #1263 Phase X1: meta.flowType (旧 meta.kind) / legacy: type
+      const flowType = (pfMeta.flowType as string | undefined) ?? (pfDef.type as string | undefined) ?? "other";
       const screenId = (pfMeta.screenId as string | undefined) ?? (pfDef.screenId as string | undefined);
       const maturity = (pfMeta.maturity as string | undefined) ?? (pfDef.maturity as string | undefined);
       upsertProcessFlowEntry(pfProject, {
         id: a.processFlowId,
         name,
-        kind,
+        flowType,
         screenId,
         actionCount: actions.length,
         updatedAt: pfNow,

--- a/backend/src/tools.ts
+++ b/backend/src/tools.ts
@@ -856,7 +856,7 @@ export const tools = [
   {
     name: "designer__add_process_flow",
     description:
-      "新しい処理フロー定義（処理フロー）を作成します。生成される ID は RFC 4122 v4 UUID (例: f81dd9e0-794c-4539-a2a5-9cbcc0a75899)。v3 schema (#1141) に従って meta/context/actions/authoring の 4 並列構造で保存されます。",
+      "新しい処理フロー定義（処理フロー）を作成します。生成される ID は RFC 4122 v4 UUID (例: f81dd9e0-794c-4539-a2a5-9cbcc0a75899)。v3 schema (#1141) に従って meta/context/actions/authoring の 4 並列構造で保存されます。#1263 Phase X1: kind 引数は flowType に rename。",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -864,21 +864,21 @@ export const tools = [
           type: "string",
           description: "処理フロー名（例: ログイン画面、月次集計バッチ）",
         },
-        kind: {
+        flowType: {
           type: "string",
           enum: ["screen", "batch", "scheduled", "system", "common", "other"],
-          description: "ProcessFlowKind 種別。v3 discriminator (#8 / #1141): screen=画面、batch=バッチ、scheduled=スケジュール起動、system=システム間、common=共通処理、other=その他。",
+          description: "ProcessFlowKind 種別。v3 discriminator (#8 / #1141 / #1263 Phase X1: meta.kind → meta.flowType): screen=画面、batch=バッチ、scheduled=スケジュール起動、system=システム間、common=共通処理、other=その他。",
         },
         screenId: {
           type: "string",
-          description: "紐付く Screen の UUID (RFC 4122 v4 形式)。kind='screen' の場合に推奨。省略可。",
+          description: "紐付く Screen の UUID (RFC 4122 v4 形式)。flowType='screen' の場合に推奨。省略可。",
         },
         description: {
           type: "string",
           description: "処理フローの説明。省略可。",
         },
       },
-      required: ["name", "kind"],
+      required: ["name", "flowType"],
     },
   },
   {

--- a/docs/spec/conversion-guideline-for-ai.md
+++ b/docs/spec/conversion-guideline-for-ai.md
@@ -344,7 +344,7 @@ ProcessFlow 側 (`pf-load-cities`) で API 呼び出し + `displayUpdate` で項
   "meta": {
     "id": "00000000-1060-4000-8000-000000000010",
     "name": "市区町村プルダウン更新",
-    "kind": "screen",
+    "flowType": "screen",
     "screenId": "00000000-1060-4000-8000-000000000001",
     "createdAt": "2026-05-13T00:00:00.000Z",
     "updatedAt": "2026-05-13T00:00:00.000Z"
@@ -482,7 +482,7 @@ ProcessFlow 側 (`pf-load-cities`) で API 呼び出し + `displayUpdate` で項
     "id": "00000000-1060-4000-8000-000000000030",
     "name": "注文受付",
     "description": "spec_OrderService.md placeOrder メソッドの変換。",
-    "kind": "common",
+    "flowType": "common",
     "createdAt": "2026-05-13T00:00:00.000Z",
     "updatedAt": "2026-05-13T00:00:00.000Z"
   },

--- a/docs/spec/examples-english-learning.md
+++ b/docs/spec/examples-english-learning.md
@@ -78,7 +78,7 @@ B2C 英会話学習アプリ (中規模、画面 ~11、テーブル ~10、処理
 
 **stepKinds** (`object`、**キーは PascalCase 必須** — `^[A-Z][A-Za-z0-9]*$`、ProcessFlow ステップ拡張):
 
-| キー (PascalCase) | ProcessFlow.kind 参照 | 用途 |
+| キー (PascalCase) | ProcessFlow.flowType 参照 (#1263 Phase X1: meta.kind → meta.flowType) | 用途 |
 |---|---|---|
 | `TtsGenerate` | `english-learning:TtsGenerate` | TTS 音声生成 (S-1 でストーリー音源プリロード、S-2 で AI 応答音声化に使用) |
 | `SttEvaluate` | `english-learning:SttEvaluate` | STT + 発音評価 |

--- a/docs/spec/process-flow-variables.md
+++ b/docs/spec/process-flow-variables.md
@@ -209,7 +209,7 @@ ScreenItem.valueFrom.flowVariable.variableName は **IdentifierPath** ($defs in 
 interface CommonProcessStep extends StepBaseProps {
   kind: "commonProcess";
   description: string;
-  refId: Uuid;                                   // 呼び出し先 ProcessFlow の Uuid (kind="common")
+  refId: Uuid;                                   // 呼び出し先 ProcessFlow の Uuid (flowType="common", #1263 Phase X1: kind → flowType)
   argumentMapping?: Record<string, ExpressionString>;
   // キー: 呼び先 inputs.name (Identifier)
   // 値: 値表現 (式)

--- a/docs/spec/schema-v3-design.md
+++ b/docs/spec/schema-v3-design.md
@@ -311,12 +311,12 @@ $statusCode (Criterion 内のみ)
     "meta": {
       "description": "ProcessFlow の identity と運用設定。",
       "type": "object",
-      "required": ["id", "name", "kind", "createdAt", "updatedAt"],
+      "required": ["id", "name", "flowType", "createdAt", "updatedAt"],
       "additionalProperties": false,
       "properties": {
         "id": { "$ref": "common.v2.schema.json#/$defs/Uuid" },
         "name": { "type": "string" },
-        "kind": { "$ref": "#/$defs/ProcessFlowKind" },
+        "flowType": { "$ref": "#/$defs/ProcessFlowKind" },
         "screenId": { "$ref": "common.v2.schema.json#/$defs/Uuid" },
         "description": { "$ref": "common.v2.schema.json#/$defs/Description" },
         "version": { "$ref": "common.v2.schema.json#/$defs/SemVer" },

--- a/examples/diary/harmony.json
+++ b/examples/diary/harmony.json
@@ -141,7 +141,7 @@
         "id": "0671b051-4acc-49cf-ba92-9fa29b47f671",
         "no": 1,
         "name": "投稿作成",
-        "kind": "screen",
+        "flowType": "screen",
         "actionCount": 1,
         "maturity": "draft",
         "updatedAt": "2026-05-06T14:00:00.000Z"
@@ -150,7 +150,7 @@
         "id": "b3a1c2d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
         "no": 2,
         "name": "投稿更新",
-        "kind": "screen",
+        "flowType": "screen",
         "actionCount": 1,
         "maturity": "draft",
         "updatedAt": "2026-05-06T14:00:00.000Z"
@@ -159,7 +159,7 @@
         "id": "c4d5e6f7-a8b9-4c0d-8e1f-2a3b4c5d6e7f",
         "no": 3,
         "name": "投稿削除",
-        "kind": "screen",
+        "flowType": "screen",
         "actionCount": 1,
         "maturity": "draft",
         "updatedAt": "2026-05-06T14:00:00.000Z"
@@ -168,7 +168,7 @@
         "id": "d5e6f7a8-b9c0-4d1e-8f2a-3b4c5d6e7f8a",
         "no": 4,
         "name": "投稿詳細取得",
-        "kind": "screen",
+        "flowType": "screen",
         "actionCount": 1,
         "maturity": "draft",
         "updatedAt": "2026-05-06T14:00:00.000Z"
@@ -177,7 +177,7 @@
         "id": "e6f7a8b9-c0d1-4e2f-8a3b-4c5d6e7f8a9b",
         "no": 5,
         "name": "投稿検索",
-        "kind": "screen",
+        "flowType": "screen",
         "actionCount": 1,
         "maturity": "draft",
         "updatedAt": "2026-05-06T14:00:00.000Z"
@@ -186,7 +186,7 @@
         "id": "f7a8b9c0-d1e2-4f3a-8b4c-5d6e7f8a9b0c",
         "no": 6,
         "name": "AI要約生成",
-        "kind": "common",
+        "flowType": "common",
         "actionCount": 1,
         "maturity": "draft",
         "updatedAt": "2026-05-06T14:00:00.000Z"
@@ -195,7 +195,7 @@
         "id": "a9b0c1d2-e3f4-4a5b-8c6d-7e8f9a0b1c2d",
         "no": 7,
         "name": "AIタグ提案",
-        "kind": "common",
+        "flowType": "common",
         "actionCount": 1,
         "maturity": "draft",
         "updatedAt": "2026-05-06T14:00:00.000Z"
@@ -204,7 +204,7 @@
         "id": "b0c1d2e3-f4a5-4b6c-8d7e-8f9a0b1c2d3e",
         "no": 8,
         "name": "AI画像alt生成",
-        "kind": "common",
+        "flowType": "common",
         "actionCount": 1,
         "maturity": "draft",
         "updatedAt": "2026-05-06T14:00:00.000Z"
@@ -213,7 +213,7 @@
         "id": "c1d2e3f4-a5b6-4c7d-8e9f-0a1b2c3d4e5f",
         "no": 9,
         "name": "AI文章校正",
-        "kind": "common",
+        "flowType": "common",
         "actionCount": 1,
         "maturity": "draft",
         "updatedAt": "2026-05-06T14:00:00.000Z"
@@ -222,7 +222,7 @@
         "id": "1ce956c5-7aa9-47b5-bb38-ca392ad73518",
         "no": 10,
         "name": "ログイン",
-        "kind": "screen",
+        "flowType": "screen",
         "actionCount": 1,
         "maturity": "draft",
         "updatedAt": "2026-05-07T00:00:00.000Z"
@@ -231,7 +231,7 @@
         "id": "9537764e-3fe9-459d-8172-00d69a575c09",
         "no": 11,
         "name": "トークン更新",
-        "kind": "screen",
+        "flowType": "screen",
         "actionCount": 1,
         "maturity": "draft",
         "updatedAt": "2026-05-07T00:00:00.000Z"
@@ -240,7 +240,7 @@
         "id": "46436b69-99f2-48b3-a5fa-07bf9fcd1478",
         "no": 12,
         "name": "ログアウト",
-        "kind": "screen",
+        "flowType": "screen",
         "actionCount": 1,
         "maturity": "draft",
         "updatedAt": "2026-05-07T00:00:00.000Z"
@@ -249,7 +249,7 @@
         "id": "2fecbf99-6a4e-4c62-840c-59d96e48ecb6",
         "no": 13,
         "name": "写真アップロード",
-        "kind": "screen",
+        "flowType": "screen",
         "actionCount": 1,
         "maturity": "draft",
         "updatedAt": "2026-05-07T00:00:00.000Z"
@@ -258,7 +258,7 @@
         "id": "803764e4-c27d-47fd-b3d9-924c1fa28bd8",
         "no": 14,
         "name": "タグ一覧取得",
-        "kind": "screen",
+        "flowType": "screen",
         "actionCount": 1,
         "maturity": "draft",
         "updatedAt": "2026-05-07T00:00:00.000Z"
@@ -267,7 +267,7 @@
         "id": "c7ca8f6d-b983-4a64-8e70-a7ef7081198f",
         "no": 15,
         "name": "タグ管理",
-        "kind": "screen",
+        "flowType": "screen",
         "actionCount": 3,
         "maturity": "draft",
         "updatedAt": "2026-05-11T00:00:00.000Z"

--- a/examples/diary/harmony/process-flows/0671b051-4acc-49cf-ba92-9fa29b47f671.json
+++ b/examples/diary/harmony/process-flows/0671b051-4acc-49cf-ba92-9fa29b47f671.json
@@ -4,7 +4,7 @@
     "id": "0671b051-4acc-49cf-ba92-9fa29b47f671",
     "name": "投稿作成",
     "description": "新規投稿を作成する処理フロー。タイトル + 本文 + 写真 + タグを受け取り、posts / photos / post_tags を 1 TX 内に登録する。status='published' の場合は published_at を NOW に設定する。AI 要約 (aiSummarize) は別フローで非同期実行を想定。",
-    "kind": "screen",
+    "flowType": "screen",
     "maturity": "draft",
     "createdAt": "2026-05-06T12:40:00.000Z",
     "updatedAt": "2026-05-22T00:00:00.000Z",

--- a/examples/diary/harmony/process-flows/1ce956c5-7aa9-47b5-bb38-ca392ad73518.json
+++ b/examples/diary/harmony/process-flows/1ce956c5-7aa9-47b5-bb38-ca392ad73518.json
@@ -4,7 +4,7 @@
     "id": "1ce956c5-7aa9-47b5-bb38-ca392ad73518",
     "name": "ログイン",
     "description": "username + password を受け取り、users テーブルで認証して JWT (access token + refresh token) を発行する処理フロー。1 ユーザー個人運用前提 + JWT stateless 認証。失敗ケース (ユーザー不在 / パスワード不一致) は同一の 401 INVALID_CREDENTIALS を返してユーザー列挙攻撃を防ぐ。",
-    "kind": "screen",
+    "flowType": "screen",
     "maturity": "draft",
     "createdAt": "2026-05-07T00:00:00.000Z",
     "updatedAt": "2026-05-07T00:00:00.000Z",

--- a/examples/diary/harmony/process-flows/2fecbf99-6a4e-4c62-840c-59d96e48ecb6.json
+++ b/examples/diary/harmony/process-flows/2fecbf99-6a4e-4c62-840c-59d96e48ecb6.json
@@ -4,7 +4,7 @@
     "id": "2fecbf99-6a4e-4c62-840c-59d96e48ecb6",
     "name": "写真アップロード",
     "description": "投稿に紐付く写真をアップロードする処理フロー。multipart/form-data で受け取り、ローカルファイルシステム (uploads/photos/) に保存 → サムネイル生成 → 寸法 + EXIF 抽出 → photos テーブル INSERT を 1 アップロード単位で実行する。photos.post_id は NOT NULL のため postId は必須 (post 作成後の upload を前提)。S3 / R2 互換ストレージへの切替は v2 で context.catalogs.externalSystems に photoStorage を登録して step-04 を externalSystem に置き換える。",
-    "kind": "common",
+    "flowType": "common",
     "maturity": "draft",
     "createdAt": "2026-05-07T00:00:00.000Z",
     "updatedAt": "2026-05-07T00:00:00.000Z"

--- a/examples/diary/harmony/process-flows/46436b69-99f2-48b3-a5fa-07bf9fcd1478.json
+++ b/examples/diary/harmony/process-flows/46436b69-99f2-48b3-a5fa-07bf9fcd1478.json
@@ -4,7 +4,7 @@
     "id": "46436b69-99f2-48b3-a5fa-07bf9fcd1478",
     "name": "ログアウト",
     "description": "ログアウトを受け付ける処理フロー。JWT stateless 認証 + 1 ユーザー個人運用前提のため、サーバ側のトークン失効処理 (blacklist) は行わず、監査ログだけ残して 204 を返す。クライアントは access/refresh トークンを localStorage から破棄するだけで完了する。",
-    "kind": "system",
+    "flowType": "system",
     "maturity": "draft",
     "createdAt": "2026-05-07T00:00:00.000Z",
     "updatedAt": "2026-05-07T00:00:00.000Z"

--- a/examples/diary/harmony/process-flows/803764e4-c27d-47fd-b3d9-924c1fa28bd8.json
+++ b/examples/diary/harmony/process-flows/803764e4-c27d-47fd-b3d9-924c1fa28bd8.json
@@ -4,7 +4,7 @@
     "id": "803764e4-c27d-47fd-b3d9-924c1fa28bd8",
     "name": "タグ一覧取得",
     "description": "タグマスタ全件を usage_count DESC で取得する処理フロー。タグの総件数は現実的に少ない (数十〜数百) ため、サーバ側では 1 種類の並び順 (タグクラウド表示用) のみ返し、別ソート (五十音 / 新着) は UI 側でクライアントサイド並び替えする方針 (#862 の v1 設計判断)。動的 ORDER BY は SQL injection 経路を増やすため避ける。",
-    "kind": "common",
+    "flowType": "common",
     "maturity": "draft",
     "createdAt": "2026-05-07T00:00:00.000Z",
     "updatedAt": "2026-05-07T00:00:00.000Z"

--- a/examples/diary/harmony/process-flows/9537764e-3fe9-459d-8172-00d69a575c09.json
+++ b/examples/diary/harmony/process-flows/9537764e-3fe9-459d-8172-00d69a575c09.json
@@ -4,7 +4,7 @@
     "id": "9537764e-3fe9-459d-8172-00d69a575c09",
     "name": "トークン更新",
     "description": "リフレッシュトークンを受け取り、検証成功時に新しいアクセストークンを発行して返す処理フロー。リフレッシュトークン自体は再発行しない (rotation 戦略は v1 では non-rotating で簡素化、必要なら別 ISSUE で導入)。",
-    "kind": "system",
+    "flowType": "system",
     "maturity": "draft",
     "createdAt": "2026-05-07T00:00:00.000Z",
     "updatedAt": "2026-05-07T00:00:00.000Z"

--- a/examples/diary/harmony/process-flows/a9b0c1d2-e3f4-4a5b-8c6d-7e8f9a0b1c2d.json
+++ b/examples/diary/harmony/process-flows/a9b0c1d2-e3f4-4a5b-8c6d-7e8f9a0b1c2d.json
@@ -4,7 +4,7 @@
     "id": "a9b0c1d2-e3f4-4a5b-8c6d-7e8f9a0b1c2d",
     "name": "AIタグ提案",
     "description": "投稿のタイトル + 本文を AI モデルへ送信し、信頼度付きタグ候補を構造化出力 (responseFormat=structuredObject) で取得する処理フロー。信頼度が conventions/catalog.json の limit.tagSuggestThreshold 未満のものは除外する。UI 側でユーザー選択後、確定は投稿作成/更新フロー経由で post_tags に INSERT。",
-    "kind": "common",
+    "flowType": "common",
     "maturity": "draft",
     "createdAt": "2026-05-06T14:00:00.000Z",
     "updatedAt": "2026-05-08T00:00:00.000Z"

--- a/examples/diary/harmony/process-flows/b0c1d2e3-f4a5-4b6c-8d7e-8f9a0b1c2d3e.json
+++ b/examples/diary/harmony/process-flows/b0c1d2e3-f4a5-4b6c-8d7e-8f9a0b1c2d3e.json
@@ -4,7 +4,7 @@
     "id": "b0c1d2e3-f4a5-4b6c-8d7e-8f9a0b1c2d3e",
     "name": "AI画像alt生成",
     "description": "写真ファイル参照を AI モデル (vision multimodal) に送信し、日本語の alt テキスト (40-100 字) を生成して photos.alt に書き戻す処理フロー。messages の content blocks に image (fileRef) を含めて vision 入力を表現する。",
-    "kind": "common",
+    "flowType": "common",
     "maturity": "draft",
     "createdAt": "2026-05-06T14:00:00.000Z",
     "updatedAt": "2026-05-08T00:00:00.000Z"

--- a/examples/diary/harmony/process-flows/b3a1c2d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d.json
+++ b/examples/diary/harmony/process-flows/b3a1c2d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d.json
@@ -4,7 +4,7 @@
     "id": "b3a1c2d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
     "name": "投稿更新",
     "description": "既存投稿を更新する処理フロー。所有者検証後、posts / photos / post_tags を 1 TX 内に更新する。status を 'published' に変更する場合は published_at を NOW に設定する。",
-    "kind": "screen",
+    "flowType": "screen",
     "maturity": "draft",
     "createdAt": "2026-05-06T14:00:00.000Z",
     "updatedAt": "2026-05-06T14:00:00.000Z",

--- a/examples/diary/harmony/process-flows/c1d2e3f4-a5b6-4c7d-8e9f-0a1b2c3d4e5f.json
+++ b/examples/diary/harmony/process-flows/c1d2e3f4-a5b6-4c7d-8e9f-0a1b2c3d4e5f.json
@@ -4,7 +4,7 @@
     "id": "c1d2e3f4-a5b6-4c7d-8e9f-0a1b2c3d4e5f",
     "name": "AI文章校正",
     "description": "投稿本文のテキストを AI モデルへ送信し、指定スタイルで校正した結果 + 変更箇所 diff を responseFormat=structuredObject で返す処理フロー。DB 書き込みなし (UI が結果を表示するのみ)。ユーザーが採用した場合は投稿更新フロー経由で body を更新する。",
-    "kind": "common",
+    "flowType": "common",
     "maturity": "draft",
     "createdAt": "2026-05-06T14:00:00.000Z",
     "updatedAt": "2026-05-08T00:00:00.000Z"

--- a/examples/diary/harmony/process-flows/c4d5e6f7-a8b9-4c0d-8e1f-2a3b4c5d6e7f.json
+++ b/examples/diary/harmony/process-flows/c4d5e6f7-a8b9-4c0d-8e1f-2a3b4c5d6e7f.json
@@ -4,7 +4,7 @@
     "id": "c4d5e6f7-a8b9-4c0d-8e1f-2a3b4c5d6e7f",
     "name": "投稿削除",
     "description": "既存投稿を削除する処理フロー。所有者検証後、photos / post_tags / posts を 1 TX 内で順に DELETE する (FK CASCADE 想定だが明示的に削除順序を記述)。TX 失敗時は全体をロールバックする。",
-    "kind": "common",
+    "flowType": "common",
     "maturity": "draft",
     "createdAt": "2026-05-06T14:00:00.000Z",
     "updatedAt": "2026-05-22T00:00:00.000Z"

--- a/examples/diary/harmony/process-flows/c7ca8f6d-b983-4a64-8e70-a7ef7081198f.json
+++ b/examples/diary/harmony/process-flows/c7ca8f6d-b983-4a64-8e70-a7ef7081198f.json
@@ -4,7 +4,7 @@
     "id": "c7ca8f6d-b983-4a64-8e70-a7ef7081198f",
     "name": "タグ管理",
     "description": "タグ管理画面 (c0bd613a) の CRUD ハンドラを集約した処理フロー (#1019)。1 画面 = 1 処理フロー + 複数アクション モデルの典型例として、create / update / delete の 3 actions を保持する。各 action は画面項目イベント側 events[].handlerActionId から個別に呼び出される。",
-    "kind": "screen",
+    "flowType": "screen",
     "screenId": "c0bd613a-ab67-4f72-8e2d-775e827bf9b2",
     "maturity": "draft",
     "createdAt": "2026-05-11T00:00:00.000Z",

--- a/examples/diary/harmony/process-flows/d5e6f7a8-b9c0-4d1e-8f2a-3b4c5d6e7f8a.json
+++ b/examples/diary/harmony/process-flows/d5e6f7a8-b9c0-4d1e-8f2a-3b4c5d6e7f8a.json
@@ -4,7 +4,7 @@
     "id": "d5e6f7a8-b9c0-4d1e-8f2a-3b4c5d6e7f8a",
     "name": "投稿詳細取得",
     "description": "投稿の詳細情報を取得する処理フロー。posts を取得し、users (author)、photos (order_index ASC)、tags (post_tags JOIN tags) の情報を結合して返す。公開状態チェック: status='published' は誰でもアクセス可、'draft'/'archived' は所有者のみ。",
-    "kind": "screen",
+    "flowType": "screen",
     "maturity": "draft",
     "createdAt": "2026-05-06T14:00:00.000Z",
     "updatedAt": "2026-05-06T14:00:00.000Z",

--- a/examples/diary/harmony/process-flows/e6f7a8b9-c0d1-4e2f-8a3b-4c5d6e7f8a9b.json
+++ b/examples/diary/harmony/process-flows/e6f7a8b9-c0d1-4e2f-8a3b-4c5d6e7f8a9b.json
@@ -4,7 +4,7 @@
     "id": "e6f7a8b9-c0d1-4e2f-8a3b-4c5d6e7f8a9b",
     "name": "投稿検索",
     "description": "投稿を動的条件で検索するフロー。全文検索 (title+body LIKE)、タグ絞り込み (slug AND 条件)、ステータス / 日付範囲 / ページネーションをサポートする。",
-    "kind": "screen",
+    "flowType": "screen",
     "maturity": "draft",
     "createdAt": "2026-05-06T14:00:00.000Z",
     "updatedAt": "2026-05-06T14:00:00.000Z",

--- a/examples/diary/harmony/process-flows/f7a8b9c0-d1e2-4f3a-8b4c-5d6e7f8a9b0c.json
+++ b/examples/diary/harmony/process-flows/f7a8b9c0-d1e2-4f3a-8b4c-5d6e7f8a9b0c.json
@@ -4,7 +4,7 @@
     "id": "f7a8b9c0-d1e2-4f3a-8b4c-5d6e7f8a9b0c",
     "name": "AI要約生成",
     "description": "投稿本文を AI モデルへ送信し、3-5 文の日本語要約を生成して posts.summary に書き戻す処理フロー。投稿作成/更新後に非同期で呼ぶ想定 (TX 外、idempotent)。AI 呼び出しは aiCall step + modelEndpoints.summarizeModel で表現。provider 切替は modelEndpoints の編集だけで完結する。",
-    "kind": "common",
+    "flowType": "common",
     "maturity": "draft",
     "createdAt": "2026-05-06T14:00:00.000Z",
     "updatedAt": "2026-05-08T00:00:00.000Z"

--- a/examples/english-learning-tailwind/harmony.json
+++ b/examples/english-learning-tailwind/harmony.json
@@ -416,7 +416,7 @@
         "id": "cc173367-d92a-4525-acc9-689bad9a048e",
         "no": 1,
         "name": "学習セッション開始",
-        "kind": "screen",
+        "flowType": "screen",
         "actionCount": 1,
         "maturity": "draft",
         "updatedAt": "2026-05-04T00:00:00.000Z"
@@ -425,7 +425,7 @@
         "id": "96118ae1-a0ab-401b-8584-dd645a45a81f",
         "no": 2,
         "name": "会話ターン進行",
-        "kind": "screen",
+        "flowType": "screen",
         "actionCount": 1,
         "maturity": "draft",
         "updatedAt": "2026-05-04T00:00:00.000Z"
@@ -434,7 +434,7 @@
         "id": "6a49b14b-eb90-45bd-9df0-df4b5986626b",
         "no": 3,
         "name": "発音採点",
-        "kind": "screen",
+        "flowType": "screen",
         "actionCount": 1,
         "maturity": "draft",
         "updatedAt": "2026-05-04T00:00:00.000Z"
@@ -443,7 +443,7 @@
         "id": "21c25fb2-551a-483f-b32a-060db8f88aee",
         "no": 4,
         "name": "単語習熟度更新",
-        "kind": "common",
+        "flowType": "common",
         "actionCount": 1,
         "maturity": "draft",
         "updatedAt": "2026-05-04T00:00:00.000Z"
@@ -452,7 +452,7 @@
         "id": "3c4d9bfd-f648-4875-a135-a04e709a87a7",
         "no": 5,
         "name": "連続学習日数リセット",
-        "kind": "scheduled",
+        "flowType": "scheduled",
         "actionCount": 1,
         "maturity": "draft",
         "updatedAt": "2026-05-04T00:00:00.000Z"

--- a/examples/english-learning-tailwind/harmony/process-flows/21c25fb2-551a-483f-b32a-060db8f88aee.json
+++ b/examples/english-learning-tailwind/harmony/process-flows/21c25fb2-551a-483f-b32a-060db8f88aee.json
@@ -4,7 +4,7 @@
     "id": "21c25fb2-551a-483f-b32a-060db8f88aee",
     "name": "単語習熟度更新",
     "description": "会話練習中にユーザーが単語を正解 / 練習したタイミングで呼び出す共通フロー (S-4)。user_word_progress に (user_id, word_id) で UPSERT し、correct_count / attempt_count / status を更新する。@conv.wordProgress.masteryThreshold 回の連続正解で status を 'mastered' に昇格させ、wordMastered トリガーを発行する。複数画面 (会話プレイ / 単語帳) から共通呼び出しされる common フロー。",
-    "kind": "common",
+    "flowType": "common",
     "maturity": "draft",
     "createdAt": "2026-05-04T00:00:00.000Z",
     "updatedAt": "2026-05-04T00:00:00.000Z"

--- a/examples/english-learning-tailwind/harmony/process-flows/3c4d9bfd-f648-4875-a135-a04e709a87a7.json
+++ b/examples/english-learning-tailwind/harmony/process-flows/3c4d9bfd-f648-4875-a135-a04e709a87a7.json
@@ -4,7 +4,7 @@
     "id": "3c4d9bfd-f648-4875-a135-a04e709a87a7",
     "name": "連続学習日数リセット",
     "description": "毎日 00:00 (UTC+9 / JST) に実行するスケジュールフロー。前日 24 時間以内に学習セッションを完了していないユーザーの users.streak_days を 0 にリセットする。バッチ UPDATE で対象ユーザーを一括処理する。仕様書 3.3 節の「連続学習日数の自動リセット job」に対応 (scheduled flow で定義のみ、実装は後段の LLM が担当)。",
-    "kind": "scheduled",
+    "flowType": "scheduled",
     "maturity": "draft",
     "createdAt": "2026-05-04T00:00:00.000Z",
     "updatedAt": "2026-05-04T00:00:00.000Z"

--- a/examples/english-learning-tailwind/harmony/process-flows/6a49b14b-eb90-45bd-9df0-df4b5986626b.json
+++ b/examples/english-learning-tailwind/harmony/process-flows/6a49b14b-eb90-45bd-9df0-df4b5986626b.json
@@ -4,7 +4,7 @@
     "id": "6a49b14b-eb90-45bd-9df0-df4b5986626b",
     "name": "発音採点",
     "description": "ユーザーが録音した音声を STT + 評価 API (english-learning:SttEvaluate) に送信し、発音スコアを算出して pronunciation_scores に INSERT する (S-3)。スコア保存後、learning_sessions のセッション平均スコア (score_avg) を更新する。TX 境界で scores INSERT + sessions UPDATE を原子的に実行する。@conv.cefr.passingThreshold を下回ったセッションは pronunciationScored トリガーを発行し、UI 側でメッセージを表示する。発音採点フィードバック UI (diff フィールドの PhoneDiff[] 音素単位色分け表示) は実装側で処理する (description 待避、3.3 節)。",
-    "kind": "screen",
+    "flowType": "screen",
     "screenId": "a9d8eb6f-065d-4af6-ac9a-cc1fcf10b2b7",
     "maturity": "draft",
     "createdAt": "2026-05-04T00:00:00.000Z",

--- a/examples/english-learning-tailwind/harmony/process-flows/96118ae1-a0ab-401b-8584-dd645a45a81f.json
+++ b/examples/english-learning-tailwind/harmony/process-flows/96118ae1-a0ab-401b-8584-dd645a45a81f.json
@@ -4,7 +4,7 @@
     "id": "96118ae1-a0ab-401b-8584-dd645a45a81f",
     "name": "会話ターン進行",
     "description": "ユーザーの発話 (テキストまたは音声) を受け取り、LLM に会話リクエストを送信して AI 応答を取得する (S-2)。必要に応じて TTS で応答を音声化し、turn_logs に 1 ターン分のログを INSERT する。LLM 呼び出しは core stepKind aiCall + modelEndpoints.dialogModel で表現し、TTS 呼び出しは english-learning:TtsGenerate で表現する。ターン単位 request/response 方式。実装側で SSE / WebSocket による partial response ストリーム表示を行う想定 (description 待避、3.3 節)。",
-    "kind": "screen",
+    "flowType": "screen",
     "screenId": "a9d8eb6f-065d-4af6-ac9a-cc1fcf10b2b7",
     "maturity": "draft",
     "createdAt": "2026-05-04T00:00:00.000Z",
@@ -90,7 +90,13 @@
         {
           "name": "turnContext",
           "label": "会話コンテキスト",
-          "type": { "kind": "array", "itemType": { "kind": "extension", "extensionRef": "english-learning:dialogTurn" } },
+          "type": {
+            "kind": "array",
+            "itemType": {
+              "kind": "extension",
+              "extensionRef": "english-learning:dialogTurn"
+            }
+          },
           "required": false,
           "description": "直近の会話履歴 (DialogTurn 配列)。aiCall step の messages 内 spread item で role 別に展開し、LLM API に構造的に渡す (#939)。"
         },

--- a/examples/english-learning-tailwind/harmony/process-flows/cc173367-d92a-4525-acc9-689bad9a048e.json
+++ b/examples/english-learning-tailwind/harmony/process-flows/cc173367-d92a-4525-acc9-689bad9a048e.json
@@ -4,7 +4,7 @@
     "id": "cc173367-d92a-4525-acc9-689bad9a048e",
     "name": "学習セッション開始",
     "description": "ユーザーがストーリーを選択して学習セッションを開始するフロー (S-1)。learning_sessions に新規セッションを INSERT し、会話プレイ画面遷移用のセッション ID を返す。子 2 で先行実装済 (validate:samples が flows ≥1 を要求するため)。子 4 では本フローを残し、S-2 (会話ターン進行) / S-3 (発音採点) / S-4 (履歴 / 単語復習) / scheduled (連続日数リセット) フローを追加する。",
-    "kind": "screen",
+    "flowType": "screen",
     "screenId": "046e1f83-bed3-4b13-a5ac-b0fa06744dfe",
     "maturity": "draft",
     "createdAt": "2026-05-04T00:00:00.000Z",

--- a/examples/english-learning/harmony.json
+++ b/examples/english-learning/harmony.json
@@ -415,7 +415,7 @@
         "id": "cc173367-d92a-4525-acc9-689bad9a048e",
         "no": 1,
         "name": "学習セッション開始",
-        "kind": "screen",
+        "flowType": "screen",
         "actionCount": 1,
         "maturity": "draft",
         "updatedAt": "2026-05-04T00:00:00.000Z"
@@ -424,7 +424,7 @@
         "id": "96118ae1-a0ab-401b-8584-dd645a45a81f",
         "no": 2,
         "name": "会話ターン進行",
-        "kind": "screen",
+        "flowType": "screen",
         "actionCount": 1,
         "maturity": "draft",
         "updatedAt": "2026-05-04T00:00:00.000Z"
@@ -433,7 +433,7 @@
         "id": "6a49b14b-eb90-45bd-9df0-df4b5986626b",
         "no": 3,
         "name": "発音採点",
-        "kind": "screen",
+        "flowType": "screen",
         "actionCount": 1,
         "maturity": "draft",
         "updatedAt": "2026-05-04T00:00:00.000Z"
@@ -442,7 +442,7 @@
         "id": "21c25fb2-551a-483f-b32a-060db8f88aee",
         "no": 4,
         "name": "単語習熟度更新",
-        "kind": "common",
+        "flowType": "common",
         "actionCount": 1,
         "maturity": "draft",
         "updatedAt": "2026-05-04T00:00:00.000Z"
@@ -451,7 +451,7 @@
         "id": "3c4d9bfd-f648-4875-a135-a04e709a87a7",
         "no": 5,
         "name": "連続学習日数リセット",
-        "kind": "scheduled",
+        "flowType": "scheduled",
         "actionCount": 1,
         "maturity": "draft",
         "updatedAt": "2026-05-04T00:00:00.000Z"

--- a/examples/english-learning/harmony/process-flows/21c25fb2-551a-483f-b32a-060db8f88aee.json
+++ b/examples/english-learning/harmony/process-flows/21c25fb2-551a-483f-b32a-060db8f88aee.json
@@ -4,7 +4,7 @@
     "id": "21c25fb2-551a-483f-b32a-060db8f88aee",
     "name": "単語習熟度更新",
     "description": "会話練習中にユーザーが単語を正解 / 練習したタイミングで呼び出す共通フロー (S-4)。user_word_progress に (user_id, word_id) で UPSERT し、correct_count / attempt_count / status を更新する。@conv.wordProgress.masteryThreshold 回の連続正解で status を 'mastered' に昇格させ、wordMastered トリガーを発行する。複数画面 (会話プレイ / 単語帳) から共通呼び出しされる common フロー。",
-    "kind": "common",
+    "flowType": "common",
     "maturity": "draft",
     "createdAt": "2026-05-04T00:00:00.000Z",
     "updatedAt": "2026-05-04T00:00:00.000Z"

--- a/examples/english-learning/harmony/process-flows/3c4d9bfd-f648-4875-a135-a04e709a87a7.json
+++ b/examples/english-learning/harmony/process-flows/3c4d9bfd-f648-4875-a135-a04e709a87a7.json
@@ -4,7 +4,7 @@
     "id": "3c4d9bfd-f648-4875-a135-a04e709a87a7",
     "name": "連続学習日数リセット",
     "description": "毎日 00:00 (UTC+9 / JST) に実行するスケジュールフロー。前日 24 時間以内に学習セッションを完了していないユーザーの users.streak_days を 0 にリセットする。バッチ UPDATE で対象ユーザーを一括処理する。仕様書 3.3 節の「連続学習日数の自動リセット job」に対応 (scheduled flow で定義のみ、実装は後段の LLM が担当)。",
-    "kind": "scheduled",
+    "flowType": "scheduled",
     "maturity": "draft",
     "createdAt": "2026-05-04T00:00:00.000Z",
     "updatedAt": "2026-05-04T00:00:00.000Z"

--- a/examples/english-learning/harmony/process-flows/6a49b14b-eb90-45bd-9df0-df4b5986626b.json
+++ b/examples/english-learning/harmony/process-flows/6a49b14b-eb90-45bd-9df0-df4b5986626b.json
@@ -4,7 +4,7 @@
     "id": "6a49b14b-eb90-45bd-9df0-df4b5986626b",
     "name": "発音採点",
     "description": "ユーザーが録音した音声を STT + 評価 API (english-learning:SttEvaluate) に送信し、発音スコアを算出して pronunciation_scores に INSERT する (S-3)。スコア保存後、learning_sessions のセッション平均スコア (score_avg) を更新する。TX 境界で scores INSERT + sessions UPDATE を原子的に実行する。@conv.cefr.passingThreshold を下回ったセッションは pronunciationScored トリガーを発行し、UI 側でメッセージを表示する。発音採点フィードバック UI (diff フィールドの PhoneDiff[] 音素単位色分け表示) は実装側で処理する (description 待避、3.3 節)。",
-    "kind": "screen",
+    "flowType": "screen",
     "screenId": "a9d8eb6f-065d-4af6-ac9a-cc1fcf10b2b7",
     "maturity": "draft",
     "createdAt": "2026-05-04T00:00:00.000Z",

--- a/examples/english-learning/harmony/process-flows/96118ae1-a0ab-401b-8584-dd645a45a81f.json
+++ b/examples/english-learning/harmony/process-flows/96118ae1-a0ab-401b-8584-dd645a45a81f.json
@@ -4,7 +4,7 @@
     "id": "96118ae1-a0ab-401b-8584-dd645a45a81f",
     "name": "会話ターン進行",
     "description": "ユーザーの発話 (テキストまたは音声) を受け取り、LLM に会話リクエストを送信して AI 応答を取得する (S-2)。必要に応じて TTS で応答を音声化し、turn_logs に 1 ターン分のログを INSERT する。LLM 呼び出しは core stepKind aiCall + modelEndpoints.dialogModel で表現し、TTS 呼び出しは english-learning:TtsGenerate で表現する。ターン単位 request/response 方式。実装側で SSE / WebSocket による partial response ストリーム表示を行う想定 (description 待避、3.3 節)。",
-    "kind": "screen",
+    "flowType": "screen",
     "screenId": "a9d8eb6f-065d-4af6-ac9a-cc1fcf10b2b7",
     "maturity": "draft",
     "createdAt": "2026-05-04T00:00:00.000Z",
@@ -90,7 +90,13 @@
         {
           "name": "turnContext",
           "label": "会話コンテキスト",
-          "type": { "kind": "array", "itemType": { "kind": "extension", "extensionRef": "english-learning:dialogTurn" } },
+          "type": {
+            "kind": "array",
+            "itemType": {
+              "kind": "extension",
+              "extensionRef": "english-learning:dialogTurn"
+            }
+          },
           "required": false,
           "description": "直近の会話履歴 (DialogTurn 配列)。aiCall step の messages 内 spread item で role 別に展開し、LLM API に構造的に渡す (#939)。"
         },

--- a/examples/english-learning/harmony/process-flows/cc173367-d92a-4525-acc9-689bad9a048e.json
+++ b/examples/english-learning/harmony/process-flows/cc173367-d92a-4525-acc9-689bad9a048e.json
@@ -4,7 +4,7 @@
     "id": "cc173367-d92a-4525-acc9-689bad9a048e",
     "name": "学習セッション開始",
     "description": "ユーザーがストーリーを選択して学習セッションを開始するフロー (S-1)。learning_sessions に新規セッションを INSERT し、会話プレイ画面遷移用のセッション ID を返す。子 2 で先行実装済 (validate:samples が flows ≥1 を要求するため)。子 4 では本フローを残し、S-2 (会話ターン進行) / S-3 (発音採点) / S-4 (履歴 / 単語復習) / scheduled (連続日数リセット) フローを追加する。",
-    "kind": "screen",
+    "flowType": "screen",
     "screenId": "046e1f83-bed3-4b13-a5ac-b0fa06744dfe",
     "maturity": "draft",
     "createdAt": "2026-05-04T00:00:00.000Z",

--- a/examples/realestate/harmony.json
+++ b/examples/realestate/harmony.json
@@ -70,7 +70,7 @@
         "id": "d4b5c6e7-f809-4112-bc3d-4e5f6a7b8c9d",
         "no": 1,
         "name": "物件検索",
-        "kind": "screen",
+        "flowType": "screen",
         "actionCount": 1,
         "maturity": "committed",
         "updatedAt": "2026-05-03T00:00:00.000Z"

--- a/examples/realestate/harmony/process-flows/d4b5c6e7-f809-4112-bc3d-4e5f6a7b8c9d.json
+++ b/examples/realestate/harmony/process-flows/d4b5c6e7-f809-4112-bc3d-4e5f6a7b8c9d.json
@@ -4,7 +4,7 @@
     "id": "d4b5c6e7-f809-4112-bc3d-4e5f6a7b8c9d",
     "name": "物件検索",
     "description": "物件種別・上限価格・最小面積を条件に properties テーブルを検索し、条件に合う物件一覧を返す。読取専用フロー (TX 不要)。viewer screen-item (#762) の動的 binding デモ用。",
-    "kind": "screen",
+    "flowType": "screen",
     "screenId": "b2f3a4c5-d6e7-4f80-9a1b-2c3d4e5f6a7b",
     "maturity": "committed",
     "createdAt": "2026-05-03T00:00:00.000Z",

--- a/examples/retail/harmony.json
+++ b/examples/retail/harmony.json
@@ -387,7 +387,7 @@
         "id": "efa7ac6e-e295-416e-b68d-17c4739b5097",
         "no": 1,
         "name": "店舗在庫照会",
-        "kind": "screen",
+        "flowType": "screen",
         "actionCount": 1,
         "maturity": "committed",
         "updatedAt": "2026-05-02T00:00:00.000Z"
@@ -396,7 +396,7 @@
         "id": "9515d6f6-8342-48cf-a045-9e9d8fab1cfa",
         "no": 2,
         "name": "カート追加",
-        "kind": "screen",
+        "flowType": "screen",
         "actionCount": 1,
         "maturity": "committed",
         "updatedAt": "2026-05-02T00:00:00.000Z"
@@ -405,7 +405,7 @@
         "id": "f81dd9e0-794c-4539-a2a5-9cbcc0a75899",
         "no": 3,
         "name": "注文確定",
-        "kind": "screen",
+        "flowType": "screen",
         "actionCount": 1,
         "maturity": "committed",
         "updatedAt": "2026-05-02T00:00:00.000Z"
@@ -414,7 +414,7 @@
         "id": "d63c703c-26ed-4704-8b76-329c6bfae9c9",
         "no": 4,
         "name": "配送指示",
-        "kind": "screen",
+        "flowType": "screen",
         "actionCount": 1,
         "maturity": "committed",
         "updatedAt": "2026-05-02T00:00:00.000Z"
@@ -423,7 +423,7 @@
         "id": "267e94bf-0397-44b8-b665-d3c40c38935b",
         "no": 5,
         "name": "カート集計",
-        "kind": "common",
+        "flowType": "common",
         "actionCount": 1,
         "maturity": "committed",
         "updatedAt": "2026-05-03T00:00:00.000Z"
@@ -432,7 +432,7 @@
         "id": "60e08c25-3daa-41b4-a7bd-b8f5fb571349",
         "no": 6,
         "name": "ヘッダーガジェット処理",
-        "kind": "common",
+        "flowType": "common",
         "actionCount": 1,
         "maturity": "committed",
         "updatedAt": "2026-05-12T00:00:00.000Z"

--- a/examples/retail/harmony/process-flows/267e94bf-0397-44b8-b665-d3c40c38935b.json
+++ b/examples/retail/harmony/process-flows/267e94bf-0397-44b8-b665-d3c40c38935b.json
@@ -4,7 +4,7 @@
     "id": "267e94bf-0397-44b8-b665-d3c40c38935b",
     "name": "カート集計",
     "description": "ログイン顧客のアクティブカートの明細件数 (itemCount) と税抜合計金額 (totalAmount) を 1 リクエストで集計する読取専用フロー。カート画面 (c73fa05c) のヘッダ表示と、カート確認画面 (cff4a398) の合計表示の双方から共通利用する。アクティブカートが無い / 明細 0 件の場合は (0, 0) を返す。明細表示用の rows は店舗情報 (storeCode/storeName) を含み multi-store inventory に整合する。",
-    "kind": "common",
+    "flowType": "common",
     "maturity": "committed",
     "createdAt": "2026-05-03T00:00:00.000Z",
     "updatedAt": "2026-05-03T00:00:00.000Z"

--- a/examples/retail/harmony/process-flows/60e08c25-3daa-41b4-a7bd-b8f5fb571349.json
+++ b/examples/retail/harmony/process-flows/60e08c25-3daa-41b4-a7bd-b8f5fb571349.json
@@ -4,7 +4,7 @@
     "id": "60e08c25-3daa-41b4-a7bd-b8f5fb571349",
     "name": "ヘッダーガジェット処理",
     "description": "PageLayout の header region に配置される グローバルヘッダ gadget の専用 ProcessFlow。logout ボタン押下時のセッション破棄 + ログイン画面リダイレクト処理を提供する。Thymeleaf 大規模パターンの『各ガジェットが専用 controller を持つ』方針を踏襲 (RFC #1021 決定 2)。",
-    "kind": "common",
+    "flowType": "common",
     "maturity": "committed",
     "createdAt": "2026-05-12T00:00:00.000Z",
     "updatedAt": "2026-05-12T00:00:00.000Z"

--- a/examples/retail/harmony/process-flows/9515d6f6-8342-48cf-a045-9e9d8fab1cfa.json
+++ b/examples/retail/harmony/process-flows/9515d6f6-8342-48cf-a045-9e9d8fab1cfa.json
@@ -4,7 +4,7 @@
     "id": "9515d6f6-8342-48cf-a045-9e9d8fab1cfa",
     "name": "カート追加",
     "description": "指定商品を、商品検索で在庫を確認した店舗から、ログイン顧客のカートに追加する。stores 存在確認 → products 存在確認 → carts UPSERT → cart_items UPSERT (retail:UPSERT_CART_ITEM) の順で実行し、(cart, product, store) の重複の場合は数量を加算する。multi-store inventory 整合のため storeCode 必須 (#780)。",
-    "kind": "screen",
+    "flowType": "screen",
     "screenId": "c73fa05c-4a71-4593-800d-b9814e97be83",
     "maturity": "committed",
     "createdAt": "2026-05-02T00:00:00.000Z",

--- a/examples/retail/harmony/process-flows/a3659922-3932-4857-a906-26dd605254fe.json
+++ b/examples/retail/harmony/process-flows/a3659922-3932-4857-a906-26dd605254fe.json
@@ -4,7 +4,7 @@
     "id": "a3659922-3932-4857-a906-26dd605254fe",
     "name": "ダッシュボード KPI 集計",
     "description": "ダッシュボード (765c3c23) の KPI カード 4 件 (todaySales / ordersToday / lowStockCount / dispatchPending) を 1 リクエストで集計する読取専用フロー。画面ロード時に GET で発火し、当日売上・本日注文件数・低在庫数・配送指示待ち件数を 3 SELECT (orders 集計 / inventory 低在庫件数 / orders 配送指示待ち件数) で取得する。",
-    "kind": "screen",
+    "flowType": "screen",
     "screenId": "765c3c23-8a0e-46b0-ae8b-ce84d10be0b0",
     "maturity": "committed",
     "createdAt": "2026-05-02T00:00:00.000Z",

--- a/examples/retail/harmony/process-flows/d63c703c-26ed-4704-8b76-329c6bfae9c9.json
+++ b/examples/retail/harmony/process-flows/d63c703c-26ed-4704-8b76-329c6bfae9c9.json
@@ -4,7 +4,7 @@
     "id": "d63c703c-26ed-4704-8b76-329c6bfae9c9",
     "name": "配送指示",
     "description": "バックオフィス担当者が注文一覧から対象注文を選択し、外部キャリア API (retail:DispatchShipment) に配送指示を送信する。成功時は orders.status を 'shipped' に更新し、retail.shipment.dispatched イベントを発行する。外部 API 失敗時は補償処理を実行してエラーを返す。",
-    "kind": "screen",
+    "flowType": "screen",
     "screenId": "c2254dd6-ab5d-4428-931f-d27c71e89951",
     "maturity": "committed",
     "createdAt": "2026-05-02T00:00:00.000Z",

--- a/examples/retail/harmony/process-flows/efa7ac6e-e295-416e-b68d-17c4739b5097.json
+++ b/examples/retail/harmony/process-flows/efa7ac6e-e295-416e-b68d-17c4739b5097.json
@@ -4,7 +4,7 @@
     "id": "efa7ac6e-e295-416e-b68d-17c4739b5097",
     "name": "店舗在庫照会",
     "description": "商品コード + 店舗コードで inventory を検索し、低在庫閾値 (@conv.limit.lowStockThreshold) を満たす行に警告フラグを付与して返す。読取専用フロー (TX 不要)。",
-    "kind": "screen",
+    "flowType": "screen",
     "screenId": "e6147dc0-94b7-436d-ba87-d0080ac34f44",
     "maturity": "committed",
     "createdAt": "2026-05-02T00:00:00.000Z",

--- a/examples/retail/harmony/process-flows/f81dd9e0-794c-4539-a2a5-9cbcc0a75899.json
+++ b/examples/retail/harmony/process-flows/f81dd9e0-794c-4539-a2a5-9cbcc0a75899.json
@@ -4,7 +4,7 @@
     "id": "f81dd9e0-794c-4539-a2a5-9cbcc0a75899",
     "name": "注文確定",
     "description": "カート内容を 1 TX (@conv.tx.orderConfirm) で確定する。在庫減算 (retail:DECREMENT_STOCK) → 注文番号採番 (@conv.numbering.orderNumber) → orders INSERT → order_items loop INSERT → カートクリア (retail:CLEAR_CART) の順に原子的に実行する。在庫減算は cart_items.store_id 単位で各店舗の inventory に対して実行する (multi-store inventory 整合)。TX 失敗時は 422 を返す。TX 後に persistedOrder を再取得してから注文確定イベントを発行する。支払方法 (paymentMethod) は credit_card / bank_transfer / cod の 3 択で受け付け、orders.payment_method 列に保存する。",
-    "kind": "screen",
+    "flowType": "screen",
     "screenId": "cff4a398-99cd-4aa5-bfbd-c12d5e72c5f3",
     "maturity": "committed",
     "createdAt": "2026-05-02T00:00:00.000Z",

--- a/frontend/e2e/__fixtures__/builders/processFlowBuilder.test.ts
+++ b/frontend/e2e/__fixtures__/builders/processFlowBuilder.test.ts
@@ -29,15 +29,15 @@ describe("buildProcessFlow", () => {
       console.error(validateProcessFlow.errors);
     }
     expect(ok).toBe(true);
-    expect(pf.meta.kind).toBe("other");
+    expect(pf.meta.flowType).toBe("other"); // #1263 Phase X1: meta.kind → meta.flowType
     expect(pf.meta.maturity).toBe("draft");
     expect(pf.actions).toEqual([]);
   });
 
   it("respects overrides", () => {
-    const pf = buildProcessFlow({ name: "注文処理", kind: "screen", mode: "upstream" });
+    const pf = buildProcessFlow({ name: "注文処理", flowType: "screen", mode: "upstream" });
     expect(pf.meta.name).toBe("注文処理");
-    expect(pf.meta.kind).toBe("screen");
+    expect(pf.meta.flowType).toBe("screen"); // #1263 Phase X1
     expect(pf.meta.mode).toBe("upstream");
   });
 

--- a/frontend/e2e/__fixtures__/builders/processFlowBuilder.ts
+++ b/frontend/e2e/__fixtures__/builders/processFlowBuilder.ts
@@ -4,7 +4,7 @@
  * defaults:
  * - createdAt/updatedAt: 固定値 "2026-05-08T00:00:00.000Z" (再現性)
  * - maturity: "draft"
- * - kind: "other"
+ * - flowType: "other"  (#1263 Phase X1: kind → flowType に rename)
  * - actions: [] (空 ProcessFlow も schema valid)
  */
 
@@ -27,7 +27,7 @@ const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 export interface BuildProcessFlowOpts {
   id?: string;
   name?: string;
-  kind?: ProcessFlowKind;
+  flowType?: ProcessFlowKind;
   screenId?: string;
   maturity?: Maturity;
   mode?: Mode;
@@ -47,7 +47,7 @@ export function buildProcessFlow(opts: BuildProcessFlowOpts = {}): ProcessFlow {
     meta: {
       id,
       name: opts.name ?? "テスト処理フロー",
-      kind: opts.kind ?? "other",
+      flowType: opts.flowType ?? "other",
       maturity: opts.maturity ?? "draft",
       mode: opts.mode,
       screenId: opts.screenId

--- a/frontend/e2e/action-list-marker-badge.spec.ts
+++ b/frontend/e2e/action-list-marker-badge.spec.ts
@@ -16,14 +16,14 @@ import type { ProjectEntities, Timestamp } from "../src/types/v3";
 const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 
 const dummyGroups = [
-  { id: "ag-with-markers", no: 1, name: "マーカー入り", kind: "screen", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS },
-  { id: "ag-clean", no: 2, name: "マーカーなし", kind: "batch", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS },
+  { id: "ag-with-markers", no: 1, name: "マーカー入り", flowType: "screen", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS },
+  { id: "ag-clean", no: 2, name: "マーカーなし", flowType: "batch", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS },
 ];
 
 const baseFlowWithMarkers = buildProcessFlow({
   id: "ag-with-markers",
   name: "マーカー入り",
-  kind: "screen",
+  flowType: "screen",
   mode: "upstream",
   actions: [{ id: "act-1", name: "", trigger: "click", maturity: "draft", responses: [{ id: "201-ok", status: 201 }], steps: [] }] as ReturnType<typeof buildProcessFlow>["actions"],
 });
@@ -43,7 +43,7 @@ const fullGroupWithMarkers = {
 const fullGroupClean = buildProcessFlow({
   id: "ag-clean",
   name: "マーカーなし",
-  kind: "batch",
+  flowType: "batch",
   mode: "upstream",
   actions: [{ id: "act-2", name: "", trigger: "click", maturity: "draft", responses: [{ id: "201-ok", status: 201 }], steps: [] }] as ReturnType<typeof buildProcessFlow>["actions"],
 });

--- a/frontend/e2e/action-list.spec.ts
+++ b/frontend/e2e/action-list.spec.ts
@@ -19,14 +19,14 @@ const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 // header (project.processFlows[]) 用 — actionCount / kind 等の表示用 meta を持つ
 // schema v3 EntryBase: id (Uuid), no, name, updatedAt 必須
 const dummyGroups = [
-  { id: "11111111-1111-4111-8111-111111111111", no: 1, name: "ログイン処理", kind: "screen", actionCount: 3, screenId: "screen-1", updatedAt: FIXED_TS },
-  { id: "22222222-2222-4222-8222-222222222222", no: 2, name: "月次集計バッチ", kind: "batch", actionCount: 5, updatedAt: FIXED_TS },
-  { id: "33333333-3333-4333-8333-333333333333", no: 3, name: "共通バリデーション", kind: "common", actionCount: 2, updatedAt: FIXED_TS },
+  { id: "11111111-1111-4111-8111-111111111111", no: 1, name: "ログイン処理", flowType: "screen", actionCount: 3, screenId: "screen-1", updatedAt: FIXED_TS },
+  { id: "22222222-2222-4222-8222-222222222222", no: 2, name: "月次集計バッチ", flowType: "batch", actionCount: 5, updatedAt: FIXED_TS },
+  { id: "33333333-3333-4333-8333-333333333333", no: 3, name: "共通バリデーション", flowType: "common", actionCount: 2, updatedAt: FIXED_TS },
 ];
 
 // body (process-flows/<id>.json) 用 — v3 ProcessFlow shape
 const dummyGroupBodies = dummyGroups.map((g) =>
-  buildProcessFlow({ id: g.id, name: g.name, kind: g.kind as Parameters<typeof buildProcessFlow>[0]["kind"], mode: "upstream" })
+  buildProcessFlow({ id: g.id, name: g.name, flowType: g.flowType as Parameters<typeof buildProcessFlow>[0]["flowType"], mode: "upstream" })
 );
 
 const dummyProject = buildProject({

--- a/frontend/e2e/catalog-panels.spec.ts
+++ b/frontend/e2e/catalog-panels.spec.ts
@@ -20,14 +20,14 @@ const groupId = "ag-catalog-all";
 const dummyGroupBody = buildProcessFlow({
   id: groupId,
   name: "all catalog UI",
-  kind: "screen",
+  flowType: "screen",
   mode: "upstream",
   actions: [{ id: "act-1", name: "ボタン", trigger: "click", maturity: "draft", responses: [], steps: [] }] as ReturnType<typeof buildProcessFlow>["actions"],
 });
 const dummyProject = buildProject({
   name: "catalog-ui",
   entities: {
-    processFlows: [{ id: groupId, no: 1, name: "all catalog UI", kind: "screen", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
+    processFlows: [{ id: groupId, no: 1, name: "all catalog UI", flowType: "screen", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
   } as ProjectEntities,
 });
 

--- a/frontend/e2e/collab/2-tab-smoke.spec.ts
+++ b/frontend/e2e/collab/2-tab-smoke.spec.ts
@@ -32,7 +32,7 @@ const PF_NORM = normalizeId(PF_ID);
 const dummyProcessFlowBody = buildProcessFlow({
   id: PF_ID,
   name: "協調編集スモークテスト",
-  kind: "screen",
+  flowType: "screen",
   mode: "upstream",
   actions: [],
 });
@@ -40,7 +40,7 @@ const dummyProcessFlowBody = buildProcessFlow({
 const dummyProject = buildProject({
   name: "collab-2tab-smoke-test",
   entities: {
-    processFlows: [{ id: PF_ID, no: 1, name: "協調編集スモークテスト", kind: "screen", actionCount: 0, maturity: "draft", updatedAt: FIXED_TS }],
+    processFlows: [{ id: PF_ID, no: 1, name: "協調編集スモークテスト", flowType: "screen", actionCount: 0, maturity: "draft", updatedAt: FIXED_TS }],
   } as ProjectEntities,
 });
 

--- a/frontend/e2e/collab/draft-history.spec.ts
+++ b/frontend/e2e/collab/draft-history.spec.ts
@@ -37,7 +37,7 @@ const PF_NORM = normalizeId(PF_ID);
 const dummyProcessFlowBody = buildProcessFlow({
   id: PF_ID,
   name: "履歴テストフロー",
-  kind: "screen",
+  flowType: "screen",
   mode: "upstream",
   actions: [],
 });
@@ -45,7 +45,7 @@ const dummyProcessFlowBody = buildProcessFlow({
 const dummyProject = buildProject({
   name: "collab-draft-history-test",
   entities: {
-    processFlows: [{ id: PF_ID, no: 1, name: "履歴テストフロー", kind: "screen", actionCount: 0, maturity: "draft", updatedAt: FIXED_TS }],
+    processFlows: [{ id: PF_ID, no: 1, name: "履歴テストフロー", flowType: "screen", actionCount: 0, maturity: "draft", updatedAt: FIXED_TS }],
   } as ProjectEntities,
 });
 

--- a/frontend/e2e/collab/presence-list.spec.ts
+++ b/frontend/e2e/collab/presence-list.spec.ts
@@ -31,7 +31,7 @@ const PF_NORM = normalizeId(PF_ID);
 const dummyProcessFlowBody = buildProcessFlow({
   id: PF_ID,
   name: "一覧バッジテストフロー",
-  kind: "screen",
+  flowType: "screen",
   mode: "upstream",
   actions: [],
 });
@@ -39,7 +39,7 @@ const dummyProcessFlowBody = buildProcessFlow({
 const dummyProject = buildProject({
   name: "collab-presence-list-test",
   entities: {
-    processFlows: [{ id: PF_ID, no: 1, name: "一覧バッジテストフロー", kind: "screen", actionCount: 0, maturity: "draft", updatedAt: FIXED_TS }],
+    processFlows: [{ id: PF_ID, no: 1, name: "一覧バッジテストフロー", flowType: "screen", actionCount: 0, maturity: "draft", updatedAt: FIXED_TS }],
   } as ProjectEntities,
 });
 

--- a/frontend/e2e/collab/take-over.spec.ts
+++ b/frontend/e2e/collab/take-over.spec.ts
@@ -33,7 +33,7 @@ const PF_NORM = normalizeId(PF_ID);
 const dummyProcessFlowBody = buildProcessFlow({
   id: PF_ID,
   name: "引継ぎテストフロー",
-  kind: "screen",
+  flowType: "screen",
   mode: "upstream",
   actions: [],
 });
@@ -41,7 +41,7 @@ const dummyProcessFlowBody = buildProcessFlow({
 const dummyProject = buildProject({
   name: "collab-takeover-test",
   entities: {
-    processFlows: [{ id: PF_ID, no: 1, name: "引継ぎテストフロー", kind: "screen", actionCount: 0, maturity: "draft", updatedAt: FIXED_TS }],
+    processFlows: [{ id: PF_ID, no: 1, name: "引継ぎテストフロー", flowType: "screen", actionCount: 0, maturity: "draft", updatedAt: FIXED_TS }],
   } as ProjectEntities,
 });
 

--- a/frontend/e2e/conv-completion.spec.ts
+++ b/frontend/e2e/conv-completion.spec.ts
@@ -35,7 +35,7 @@ const groupId = "ag-test-completion";
 const sampleGroupBody = buildProcessFlow({
   id: groupId,
   name: "補完テスト",
-  kind: "screen",
+  flowType: "screen",
   mode: "upstream",
   actions: [{
     id: "act-001", name: "テストアクション", trigger: "click",
@@ -46,7 +46,7 @@ const sampleGroupBody = buildProcessFlow({
 const dummyProject = buildProject({
   name: "補完 E2E テスト",
   entities: {
-    processFlows: [{ id: groupId, no: 1, name: "補完テスト", kind: "screen", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
+    processFlows: [{ id: groupId, no: 1, name: "補完テスト", flowType: "screen", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
   } as ProjectEntities,
 });
 

--- a/frontend/e2e/dashboard.spec.ts
+++ b/frontend/e2e/dashboard.spec.ts
@@ -24,9 +24,9 @@ const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 const dummyProject = buildProject({
   name: "E2Eダッシュボードテスト",
   entities: {
-    screens: [{ id: SCREEN_ID, no: 1, name: "ログイン画面", kind: "input", path: "/login", hasDesign: true, updatedAt: FIXED_TS }],
+    screens: [{ id: SCREEN_ID, no: 1, name: "ログイン画面", flowType: "input", path: "/login", hasDesign: true, updatedAt: FIXED_TS }],
     tables: [{ id: TABLE_ID, no: 1, physicalName: "users", name: "ユーザー", category: "マスタ", columnCount: 0, updatedAt: FIXED_TS }],
-    processFlows: [{ id: ACTION_ID, no: 1, name: "ログイン処理", kind: "screen", actionCount: 0, updatedAt: FIXED_TS }],
+    processFlows: [{ id: ACTION_ID, no: 1, name: "ログイン処理", flowType: "screen", actionCount: 0, updatedAt: FIXED_TS }],
   } as ProjectEntities,
 });
 

--- a/frontend/e2e/dirty-mark-resume.spec.ts
+++ b/frontend/e2e/dirty-mark-resume.spec.ts
@@ -33,7 +33,7 @@ const dummyTable = buildTable({
 const dummyProcessFlowBody = buildProcessFlow({
   id: PF_ID,
   name: "dirty マークテストフロー",
-  kind: "screen",
+  flowType: "screen",
   mode: "upstream",
   actions: [{ id: "act-001", name: "テストアクション", trigger: "click", maturity: "draft", steps: [] }] as ReturnType<typeof buildProcessFlow>["actions"],
 });
@@ -42,7 +42,7 @@ const dummyProject = buildProject({
   name: "dirty-mark-test",
   entities: {
     tables: [{ id: TABLE_ID, no: 1, name: dummyTable.name, physicalName: dummyTable.physicalName, category: dummyTable.category, columnCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
-    processFlows: [{ id: PF_ID, no: 1, name: "dirty マークテストフロー", kind: "screen", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
+    processFlows: [{ id: PF_ID, no: 1, name: "dirty マークテストフロー", flowType: "screen", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
   } as ProjectEntities,
 });
 

--- a/frontend/e2e/draft-state-validation.spec.ts
+++ b/frontend/e2e/draft-state-validation.spec.ts
@@ -160,7 +160,7 @@ const FLOW_ID = normalizeId("flow-a-draft-934");
 const processFlowA = buildProcessFlow({
   id: FLOW_ID,
   name: "意図的な未定義参照フロー",
-  kind: "screen",
+  flowType: "screen",
   mode: "upstream",
   maturity: "draft",
   actions: [
@@ -197,7 +197,7 @@ const dummyProject = buildProject({
   entities: {
     screens: [
       // puck 画面 (puckDataRef 欠落 → validatePuckScreen error)
-      { id: SCREEN_P_ID, no: 1, name: "puck 画面 (puckDataRef 欠落)", kind: "list", updatedAt: FIXED_TS },
+      { id: SCREEN_P_ID, no: 1, name: "puck 画面 (puckDataRef 欠落)", flowType: "list", updatedAt: FIXED_TS },
     ],
     tables: [
       { id: TABLE_A_ID, no: 1, physicalName: "orders_934",          name: "受注テーブル",        columnCount: 1, updatedAt: FIXED_TS, maturity: "draft" },
@@ -209,11 +209,11 @@ const dummyProject = buildProject({
       { id: VIEW_B_ID, no: 2, physicalName: "v_orders_934", name: "受注ビュー (重複)", updatedAt: FIXED_TS },
     ],
     viewDefinitions: [
-      { id: VD_A_ID, no: 1, name: "存在しないテーブルを参照する定義", kind: "list", updatedAt: FIXED_TS },
-      { id: VD_B_ID, no: 2, name: "alias が重複する定義 (DUPLICATE_QUERY_ALIAS)", kind: "list", updatedAt: FIXED_TS },
+      { id: VD_A_ID, no: 1, name: "存在しないテーブルを参照する定義", flowType: "list", updatedAt: FIXED_TS },
+      { id: VD_B_ID, no: 2, name: "alias が重複する定義 (DUPLICATE_QUERY_ALIAS)", flowType: "list", updatedAt: FIXED_TS },
     ],
     processFlows: [
-      { id: FLOW_ID, no: 1, name: "意図的な未定義参照フロー", kind: "screen", actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" },
+      { id: FLOW_ID, no: 1, name: "意図的な未定義参照フロー", flowType: "screen", actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" },
     ],
   } as ProjectEntities,
 });

--- a/frontend/e2e/drawing-anchor.spec.ts
+++ b/frontend/e2e/drawing-anchor.spec.ts
@@ -89,7 +89,7 @@ const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 const dummyProject = buildProject({
   name: "anchor",
   entities: {
-    processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, kind: dummyGroup.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
+    processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, flowType: dummyGroup.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
   } as ProjectEntities,
 });
 
@@ -115,7 +115,7 @@ async function setup(page: Page) {
 const dummyGroupBody = buildProcessFlow({
   id: groupId,
   name: dummyGroup.name,
-  kind: (dummyGroup.type ?? "screen") as Parameters<typeof buildProcessFlow>[0]["kind"],
+  flowType: (dummyGroup.type ?? "screen") as Parameters<typeof buildProcessFlow>[0]["flowType"],
   mode: "upstream",
   actions: dummyGroup.actions as ReturnType<typeof buildProcessFlow>["actions"],
   authoring: dummyGroup.markers !== undefined ? { markers: dummyGroup.markers } : undefined,

--- a/frontend/e2e/drawing-marker.spec.ts
+++ b/frontend/e2e/drawing-marker.spec.ts
@@ -38,7 +38,7 @@ const dummyGroup = {
 const dummyProject = buildProject({
   name: "draw",
   entities: {
-    processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, kind: dummyGroup.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
+    processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, flowType: dummyGroup.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
   } as ProjectEntities,
 });
 
@@ -72,7 +72,7 @@ async function drawStroke(page: Page, x0: number, y0: number, dx: number, dy: nu
 const dummyGroupBody = buildProcessFlow({
   id: groupId,
   name: dummyGroup.name,
-  kind: (dummyGroup.type ?? "screen") as Parameters<typeof buildProcessFlow>[0]["kind"],
+  flowType: (dummyGroup.type ?? "screen") as Parameters<typeof buildProcessFlow>[0]["flowType"],
   mode: "upstream",
   actions: dummyGroup.actions as ReturnType<typeof buildProcessFlow>["actions"],
   authoring: dummyGroup.markers !== undefined ? { markers: dummyGroup.markers } : undefined,

--- a/frontend/e2e/edit-mode.spec.ts
+++ b/frontend/e2e/edit-mode.spec.ts
@@ -62,7 +62,7 @@ const dummyTable = buildTable({
 const dummyProcessFlowBody = buildProcessFlow({
   id: PF_ID,
   name: "編集モードテストフロー",
-  kind: "screen",
+  flowType: "screen",
   mode: "upstream",
   actions: [{ id: "act-001", name: "テストアクション", trigger: "click", maturity: "draft", steps: [] }] as ReturnType<typeof buildProcessFlow>["actions"],
 });
@@ -74,9 +74,9 @@ const dummySequence = buildSequence({ id: SEQUENCE_ID, name: "E2E シーケン�
 const dummyProject = buildProject({
   name: "edit-mode-test",
   entities: {
-    screens: [{ id: SCREEN_ID, no: 1, name: "編集モードテスト画面", kind: "form", updatedAt: FIXED_TS }],
+    screens: [{ id: SCREEN_ID, no: 1, name: "編集モードテスト画面", flowType: "form", updatedAt: FIXED_TS }],
     tables: [{ id: TABLE_ID, no: 1, name: dummyTable.name, physicalName: dummyTable.physicalName, category: "マスタ", columnCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
-    processFlows: [{ id: PF_ID, no: 1, name: "編集モードテストフロー", kind: "screen", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
+    processFlows: [{ id: PF_ID, no: 1, name: "編集モードテストフロー", flowType: "screen", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
     views: [{ id: VIEW_ID, no: 1, name: "E2E ビュー", maturity: "draft", updatedAt: FIXED_TS }],
     viewDefinitions: [{ id: VIEW_DEF_ID, no: 1, name: "E2E ビュー定義", maturity: "draft", updatedAt: FIXED_TS }],
     sequences: [{ id: SEQUENCE_ID, no: 1, name: "E2E シーケンス", maturity: "draft", updatedAt: FIXED_TS }],

--- a/frontend/e2e/edit-session/1-6-step-flow.spec.ts
+++ b/frontend/e2e/edit-session/1-6-step-flow.spec.ts
@@ -37,7 +37,7 @@ const PF_NORM = normalizeId(PF_ID);
 const dummyProcessFlowBody = buildProcessFlow({
   id: PF_ID,
   name: "1-6 step フロー検証テスト",
-  kind: "screen",
+  flowType: "screen",
   mode: "upstream",
   actions: [],
 });
@@ -45,7 +45,7 @@ const dummyProcessFlowBody = buildProcessFlow({
 const dummyProject = buildProject({
   name: "edit-session-1-6-step-test",
   entities: {
-    processFlows: [{ id: PF_ID, no: 1, name: "1-6 step フロー検証テスト", kind: "screen", actionCount: 0, maturity: "draft", updatedAt: FIXED_TS }],
+    processFlows: [{ id: PF_ID, no: 1, name: "1-6 step フロー検証テスト", flowType: "screen", actionCount: 0, maturity: "draft", updatedAt: FIXED_TS }],
   } as ProjectEntities,
 });
 

--- a/frontend/e2e/edit-session/ai-participant.spec.ts
+++ b/frontend/e2e/edit-session/ai-participant.spec.ts
@@ -35,7 +35,7 @@ const PF_NORM = normalizeId(PF_ID);
 const dummyProcessFlowBody = buildProcessFlow({
   id: PF_ID,
   name: "AI participant 検証テスト",
-  kind: "screen",
+  flowType: "screen",
   mode: "upstream",
   actions: [],
 });
@@ -43,7 +43,7 @@ const dummyProcessFlowBody = buildProcessFlow({
 const dummyProject = buildProject({
   name: "edit-session-ai-participant-test",
   entities: {
-    processFlows: [{ id: PF_ID, no: 1, name: "AI participant 検証テスト", kind: "screen", actionCount: 0, maturity: "draft", updatedAt: FIXED_TS }],
+    processFlows: [{ id: PF_ID, no: 1, name: "AI participant 検証テスト", flowType: "screen", actionCount: 0, maturity: "draft", updatedAt: FIXED_TS }],
   } as ProjectEntities,
 });
 

--- a/frontend/e2e/edit-session/multi-session-branching.spec.ts
+++ b/frontend/e2e/edit-session/multi-session-branching.spec.ts
@@ -36,7 +36,7 @@ const PF_NORM = normalizeId(PF_ID);
 const dummyProcessFlowBody = buildProcessFlow({
   id: PF_ID,
   name: "A 案 / B 案 並行編集テスト",
-  kind: "screen",
+  flowType: "screen",
   mode: "upstream",
   actions: [],
 });
@@ -44,7 +44,7 @@ const dummyProcessFlowBody = buildProcessFlow({
 const dummyProject = buildProject({
   name: "edit-session-multi-branching-test",
   entities: {
-    processFlows: [{ id: PF_ID, no: 1, name: "A 案 / B 案 並行編集テスト", kind: "screen", actionCount: 0, maturity: "draft", updatedAt: FIXED_TS }],
+    processFlows: [{ id: PF_ID, no: 1, name: "A 案 / B 案 並行編集テスト", flowType: "screen", actionCount: 0, maturity: "draft", updatedAt: FIXED_TS }],
   } as ProjectEntities,
 });
 

--- a/frontend/e2e/edit-session/url-invitation.spec.ts
+++ b/frontend/e2e/edit-session/url-invitation.spec.ts
@@ -34,7 +34,7 @@ const PF_NORM = normalizeId(PF_ID);
 const dummyProcessFlowBody = buildProcessFlow({
   id: PF_ID,
   name: "URL 招待テスト",
-  kind: "screen",
+  flowType: "screen",
   mode: "upstream",
   actions: [],
 });
@@ -42,7 +42,7 @@ const dummyProcessFlowBody = buildProcessFlow({
 const dummyProject = buildProject({
   name: "edit-session-url-invitation-test",
   entities: {
-    processFlows: [{ id: PF_ID, no: 1, name: "URL 招待テスト", kind: "screen", actionCount: 0, maturity: "draft", updatedAt: FIXED_TS }],
+    processFlows: [{ id: PF_ID, no: 1, name: "URL 招待テスト", flowType: "screen", actionCount: 0, maturity: "draft", updatedAt: FIXED_TS }],
   } as ProjectEntities,
 });
 

--- a/frontend/e2e/error-catalog-panel.spec.ts
+++ b/frontend/e2e/error-catalog-panel.spec.ts
@@ -20,7 +20,7 @@ const groupId = "ag-ec-ui";
 const dummyGroupBody = buildProcessFlow({
   id: groupId,
   name: "errorCatalog UI",
-  kind: "screen",
+  flowType: "screen",
   mode: "upstream",
   actions: [{
     id: "act-1", name: "ボタン", trigger: "click", maturity: "draft",
@@ -36,7 +36,7 @@ const dummyGroupBody = buildProcessFlow({
 const dummyProject = buildProject({
   name: "ec-test",
   entities: {
-    processFlows: [{ id: groupId, no: 1, name: "errorCatalog UI", kind: "screen", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
+    processFlows: [{ id: groupId, no: 1, name: "errorCatalog UI", flowType: "screen", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
   } as ProjectEntities,
 });
 

--- a/frontend/e2e/extensions-palette.spec.ts
+++ b/frontend/e2e/extensions-palette.spec.ts
@@ -22,14 +22,14 @@ const groupId = "ag-extension-palette";
 const dummyGroupBody = buildProcessFlow({
   id: groupId,
   name: "extension palette",
-  kind: "screen",
+  flowType: "screen",
   mode: "upstream",
   actions: [{ id: "act-1", name: "ボタン", trigger: "click", maturity: "draft", responses: [], steps: [] }] as ReturnType<typeof buildProcessFlow>["actions"],
 });
 const dummyProject = buildProject({
   name: "extension-palette",
   entities: {
-    processFlows: [{ id: groupId, no: 1, name: "extension palette", kind: "screen", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
+    processFlows: [{ id: groupId, no: 1, name: "extension palette", flowType: "screen", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
   } as ProjectEntities,
 });
 

--- a/frontend/e2e/list-ops.spec.ts
+++ b/frontend/e2e/list-ops.spec.ts
@@ -20,14 +20,14 @@ import type { ProjectEntities, Timestamp, ProcessFlowKind, Maturity } from "../s
 const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 
 const listGroups = [
-  { id: "g-a", no: 1, name: "Alpha ログイン", kind: "screen" as ProcessFlowKind, actionCount: 2, updatedAt: FIXED_TS, maturity: "committed" as Maturity },
-  { id: "g-b", no: 2, name: "Beta バッチ", kind: "batch" as ProcessFlowKind, actionCount: 1, updatedAt: FIXED_TS, maturity: "provisional" as Maturity },
-  { id: "g-c", no: 3, name: "Charlie 共通", kind: "common" as ProcessFlowKind, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" as Maturity },
-  { id: "g-d", no: 4, name: "Delta 登録", kind: "screen" as ProcessFlowKind, actionCount: 3, updatedAt: FIXED_TS, maturity: "draft" as Maturity },
+  { id: "g-a", no: 1, name: "Alpha ログイン", flowType: "screen" as ProcessFlowKind, actionCount: 2, updatedAt: FIXED_TS, maturity: "committed" as Maturity },
+  { id: "g-b", no: 2, name: "Beta バッチ", flowType: "batch" as ProcessFlowKind, actionCount: 1, updatedAt: FIXED_TS, maturity: "provisional" as Maturity },
+  { id: "g-c", no: 3, name: "Charlie 共通", flowType: "common" as ProcessFlowKind, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" as Maturity },
+  { id: "g-d", no: 4, name: "Delta 登録", flowType: "screen" as ProcessFlowKind, actionCount: 3, updatedAt: FIXED_TS, maturity: "draft" as Maturity },
 ];
 
 const listGroupBodies = listGroups.map((g) =>
-  buildProcessFlow({ id: g.id, name: g.name, kind: g.kind, maturity: g.maturity, mode: "upstream" }),
+  buildProcessFlow({ id: g.id, name: g.name, flowType: g.flowType, maturity: g.maturity, mode: "upstream" }),
 );
 
 const project = buildProject({

--- a/frontend/e2e/marker-ergonomics.spec.ts
+++ b/frontend/e2e/marker-ergonomics.spec.ts
@@ -31,7 +31,7 @@ const baseMarkers = [
 const dummyGroupBody = buildProcessFlow({
   id: groupId,
   name: "erg test",
-  kind: "screen",
+  flowType: "screen",
   mode: "upstream",
   actions: baseActions,
   authoring: { markers: baseMarkers },
@@ -39,7 +39,7 @@ const dummyGroupBody = buildProcessFlow({
 const dummyGroupResolvedBody = buildProcessFlow({
   id: groupId,
   name: "erg test",
-  kind: "screen",
+  flowType: "screen",
   mode: "upstream",
   actions: baseActions,
   authoring: {
@@ -50,7 +50,7 @@ const dummyGroupResolvedBody = buildProcessFlow({
 const dummyProject = buildProject({
   name: "erg",
   entities: {
-    processFlows: [{ id: groupId, no: 1, name: "erg test", kind: "screen", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
+    processFlows: [{ id: groupId, no: 1, name: "erg test", flowType: "screen", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
   } as ProjectEntities,
 });
 

--- a/frontend/e2e/marker-panel.spec.ts
+++ b/frontend/e2e/marker-panel.spec.ts
@@ -19,14 +19,14 @@ const groupId = "ag-marker";
 const dummyGroupBody = buildProcessFlow({
   id: groupId,
   name: "marker test",
-  kind: "screen",
+  flowType: "screen",
   mode: "upstream",
   actions: [{ id: "act-1", name: "ボタン", trigger: "click", maturity: "draft", steps: [] }] as ReturnType<typeof buildProcessFlow>["actions"],
 });
 const dummyProject = buildProject({
   name: "marker",
   entities: {
-    processFlows: [{ id: groupId, no: 1, name: "marker test", kind: "screen", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
+    processFlows: [{ id: groupId, no: 1, name: "marker test", flowType: "screen", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
   } as ProjectEntities,
 });
 

--- a/frontend/e2e/maturity-notes.spec.ts
+++ b/frontend/e2e/maturity-notes.spec.ts
@@ -68,9 +68,9 @@ const dummyProject = buildProject({
   name: "maturity-test",
   entities: {
     processFlows: [
-      { id: groupId, no: 1, name: dummyGroup.name, kind: dummyGroup.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" },
-      { id: committedGroupId, no: 2, name: "確定フロー", kind: "screen", actionCount: 0, maturity: "committed", updatedAt: FIXED_TS },
-      { id: provisionalGroupId, no: 3, name: "暫定フロー", kind: "screen", actionCount: 0, maturity: "provisional", updatedAt: FIXED_TS },
+      { id: groupId, no: 1, name: dummyGroup.name, flowType: dummyGroup.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" },
+      { id: committedGroupId, no: 2, name: "確定フロー", flowType: "screen", actionCount: 0, maturity: "committed", updatedAt: FIXED_TS },
+      { id: provisionalGroupId, no: 3, name: "暫定フロー", flowType: "screen", actionCount: 0, maturity: "provisional", updatedAt: FIXED_TS },
     ],
   } as ProjectEntities,
 });
@@ -96,7 +96,7 @@ async function setupEditor(page: Page) {
 const dummyGroupBody = buildProcessFlow({
   id: groupId,
   name: dummyGroup.name,
-  kind: (dummyGroup.type ?? "screen") as Parameters<typeof buildProcessFlow>[0]["kind"],
+  flowType: (dummyGroup.type ?? "screen") as Parameters<typeof buildProcessFlow>[0]["flowType"],
   mode: "upstream",
   actions: dummyGroup.actions as ReturnType<typeof buildProcessFlow>["actions"],
   ...(dummyGroup.markers !== undefined ? { authoring: { markers: dummyGroup.markers } } : {}),
@@ -117,14 +117,14 @@ test.afterAll(async () => {
 const committedGroupBody = buildProcessFlow({
   id: committedGroupId,
   name: "確定フロー",
-  kind: "screen",
+  flowType: "screen",
   mode: "upstream",
   maturity: "committed",
 });
 const provisionalGroupBody = buildProcessFlow({
   id: provisionalGroupId,
   name: "暫定フロー",
-  kind: "screen",
+  flowType: "screen",
   mode: "upstream",
   maturity: "provisional",
 });

--- a/frontend/e2e/more-ui.spec.ts
+++ b/frontend/e2e/more-ui.spec.ts
@@ -19,7 +19,7 @@ const groupId = "ag-more-test";
 const dummyGroupBody = buildProcessFlow({
   id: groupId,
   name: "追加 UI テスト",
-  kind: "screen",
+  flowType: "screen",
   mode: "upstream",
   maturity: "provisional",
   actions: [
@@ -42,8 +42,8 @@ const dummyProject = buildProject({
   name: "more-e2e",
   entities: {
     processFlows: [
-      { id: groupId, no: 1, name: "追加 UI テスト", kind: "screen", actionCount: 1, maturity: "provisional", updatedAt: FIXED_TS },
-      { id: "ag-extra-committed", no: 2, name: "確定フロー", kind: "screen", actionCount: 1, maturity: "committed", updatedAt: FIXED_TS },
+      { id: groupId, no: 1, name: "追加 UI テスト", flowType: "screen", actionCount: 1, maturity: "provisional", updatedAt: FIXED_TS },
+      { id: "ag-extra-committed", no: 2, name: "確定フロー", flowType: "screen", actionCount: 1, maturity: "committed", updatedAt: FIXED_TS },
     ],
   } as ProjectEntities,
 });

--- a/frontend/e2e/process-flow-ai-ux.spec.ts
+++ b/frontend/e2e/process-flow-ai-ux.spec.ts
@@ -58,7 +58,7 @@ const project = buildProject({
       id: flowId,
       no: 1,
       name: "AI UX Smoke",
-      kind: "screen",
+      flowType: "screen",
       actionCount: 1,
       updatedAt: FIXED_TS,
       maturity: "draft",
@@ -69,7 +69,7 @@ const project = buildProject({
 const processFlow = buildProcessFlow({
   id: flowId,
   name: "AI UX Smoke",
-  kind: "screen",
+  flowType: "screen",
   mode: "upstream",
   actions: [action] as ReturnType<typeof buildProcessFlow>["actions"],
 });

--- a/frontend/e2e/save-reset-action.spec.ts
+++ b/frontend/e2e/save-reset-action.spec.ts
@@ -22,7 +22,7 @@ const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 const dummyProcessFlowBody = buildProcessFlow({
   id: PROCESS_FLOW_ID,
   name: "テスト処理フロー",
-  kind: "screen",
+  flowType: "screen",
   mode: "upstream",
   actions: [],
 });
@@ -30,7 +30,7 @@ const dummyProcessFlowBody = buildProcessFlow({
 const dummyProject = buildProject({
   name: "E2Eテスト用プロジェクト",
   entities: {
-    processFlows: [{ id: PROCESS_FLOW_ID, no: 1, name: "テスト処理フロー", kind: "screen", actionCount: 0, maturity: "draft", updatedAt: FIXED_TS }],
+    processFlows: [{ id: PROCESS_FLOW_ID, no: 1, name: "テスト処理フロー", flowType: "screen", actionCount: 0, maturity: "draft", updatedAt: FIXED_TS }],
   } as ProjectEntities,
 });
 

--- a/frontend/e2e/schema-ui.spec.ts
+++ b/frontend/e2e/schema-ui.spec.ts
@@ -85,7 +85,7 @@ const dummyProject = buildProject({
         id: groupId,
         no: 1,
         name: dummyGroup.name,
-        kind: dummyGroup.type as string,
+        flowType: dummyGroup.type as string,
         actionCount: 1,
         maturity: dummyGroup.maturity,
         updatedAt: FIXED_TS,
@@ -127,7 +127,7 @@ async function expandStep(page: Page, index: number) {
 const dummyGroupBody = buildProcessFlow({
   id: groupId,
   name: dummyGroup.name,
-  kind: (dummyGroup.type ?? "screen") as ReturnType<typeof buildProcessFlow>["meta"]["kind"],
+  flowType: (dummyGroup.type ?? "screen") as ReturnType<typeof buildProcessFlow>["meta"]["flowType"],
   mode: "upstream",
   actions: dummyGroup.actions as ReturnType<typeof buildProcessFlow>["actions"],
 });

--- a/frontend/e2e/step-advanced.spec.ts
+++ b/frontend/e2e/step-advanced.spec.ts
@@ -51,7 +51,7 @@ const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 const dummyProject = buildProject({
   name: "advanced",
   entities: {
-    processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, kind: dummyGroup.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
+    processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, flowType: dummyGroup.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
   } as ProjectEntities,
 });
 
@@ -77,7 +77,7 @@ async function setupEditor(page: Page) {
 const dummyGroupBody = buildProcessFlow({
   id: groupId,
   name: dummyGroup.name,
-  kind: (dummyGroup.type ?? "screen") as Parameters<typeof buildProcessFlow>[0]["kind"],
+  flowType: (dummyGroup.type ?? "screen") as Parameters<typeof buildProcessFlow>[0]["flowType"],
   mode: "upstream",
   actions: dummyGroup.actions as ReturnType<typeof buildProcessFlow>["actions"],
   authoring: dummyGroup.markers !== undefined ? { markers: dummyGroup.markers } : undefined,

--- a/frontend/e2e/step-marker-badge.spec.ts
+++ b/frontend/e2e/step-marker-badge.spec.ts
@@ -44,7 +44,7 @@ const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 const dummyProject = buildProject({
   name: "smb",
   entities: {
-    processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, kind: dummyGroup.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
+    processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, flowType: dummyGroup.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
   } as ProjectEntities,
 });
 
@@ -70,7 +70,7 @@ async function setup(page: Page) {
 const dummyGroupBody = buildProcessFlow({
   id: groupId,
   name: dummyGroup.name,
-  kind: (dummyGroup.type ?? "screen") as Parameters<typeof buildProcessFlow>[0]["kind"],
+  flowType: (dummyGroup.type ?? "screen") as Parameters<typeof buildProcessFlow>[0]["flowType"],
   mode: "upstream",
   actions: dummyGroup.actions as ReturnType<typeof buildProcessFlow>["actions"],
   authoring: dummyGroup.markers !== undefined ? { markers: dummyGroup.markers } : undefined,

--- a/frontend/e2e/step-ops.spec.ts
+++ b/frontend/e2e/step-ops.spec.ts
@@ -63,7 +63,7 @@ const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 const dummyProject = buildProject({
   name: "step-ops",
   entities: {
-    processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, kind: dummyGroup.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
+    processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, flowType: dummyGroup.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
   } as ProjectEntities,
 });
 
@@ -89,7 +89,7 @@ async function setupEditor(page: Page) {
 const dummyGroupBody = buildProcessFlow({
   id: groupId,
   name: dummyGroup.name,
-  kind: (dummyGroup.type ?? "screen") as Parameters<typeof buildProcessFlow>[0]["kind"],
+  flowType: (dummyGroup.type ?? "screen") as Parameters<typeof buildProcessFlow>[0]["flowType"],
   mode: "upstream",
   actions: dummyGroup.actions as ReturnType<typeof buildProcessFlow>["actions"],
   authoring: dummyGroup.markers !== undefined ? { markers: dummyGroup.markers } : undefined,

--- a/frontend/e2e/stepcard-marker-kind-badge.spec.ts
+++ b/frontend/e2e/stepcard-marker-kind-badge.spec.ts
@@ -45,7 +45,7 @@ const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 const dummyProject = buildProject({
   name: "stepchip",
   entities: {
-    processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, kind: dummyGroup.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
+    processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, flowType: dummyGroup.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
   } as ProjectEntities,
 });
 
@@ -71,7 +71,7 @@ async function setup(page: Page) {
 const dummyGroupBody = buildProcessFlow({
   id: groupId,
   name: dummyGroup.name,
-  kind: (dummyGroup.type ?? "screen") as Parameters<typeof buildProcessFlow>[0]["kind"],
+  flowType: (dummyGroup.type ?? "screen") as Parameters<typeof buildProcessFlow>[0]["flowType"],
   mode: "upstream",
   actions: dummyGroup.actions as ReturnType<typeof buildProcessFlow>["actions"],
   authoring: dummyGroup.markers !== undefined ? { markers: dummyGroup.markers } : undefined,

--- a/frontend/e2e/validation-sql-conv-panel.spec.ts
+++ b/frontend/e2e/validation-sql-conv-panel.spec.ts
@@ -80,7 +80,7 @@ const project = buildProject({
   name: "sql-conv",
   entities: {
     tables: [{ id: tableId, no: 1, physicalName: "customers", name: "顧客", columnCount: 2, updatedAt: FIXED_TS }],
-    processFlows: [{ id: groupId, no: 1, name: group.name, kind: group.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
+    processFlows: [{ id: groupId, no: 1, name: group.name, flowType: group.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
   } as ProjectEntities,
 });
 
@@ -106,7 +106,7 @@ async function setupEditor(page: Page) {
 const dummyGroupBody = buildProcessFlow({
   id: groupId,
   name: group.name,
-  kind: (group.type ?? "screen") as Parameters<typeof buildProcessFlow>[0]["kind"],
+  flowType: (group.type ?? "screen") as Parameters<typeof buildProcessFlow>[0]["flowType"],
   mode: "upstream",
   actions: group.actions as ReturnType<typeof buildProcessFlow>["actions"],
   authoring: (group as { markers?: unknown }).markers !== undefined

--- a/frontend/e2e/validation-warnings-panel.spec.ts
+++ b/frontend/e2e/validation-warnings-panel.spec.ts
@@ -66,7 +66,7 @@ const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 const dummyProject = buildProject({
   name: "validation-test",
   entities: {
-    processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, kind: dummyGroup.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
+    processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, flowType: dummyGroup.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
   } as ProjectEntities,
 });
 
@@ -92,7 +92,7 @@ async function setupEditor(page: Page) {
 const dummyGroupBody = buildProcessFlow({
   id: groupId,
   name: dummyGroup.name,
-  kind: (dummyGroup.type ?? "screen") as Parameters<typeof buildProcessFlow>[0]["kind"],
+  flowType: (dummyGroup.type ?? "screen") as Parameters<typeof buildProcessFlow>[0]["flowType"],
   mode: "upstream",
   actions: dummyGroup.actions as ReturnType<typeof buildProcessFlow>["actions"],
   authoring: dummyGroup.markers !== undefined ? { markers: dummyGroup.markers } : undefined,

--- a/frontend/e2e/warning-to-marker.spec.ts
+++ b/frontend/e2e/warning-to-marker.spec.ts
@@ -34,7 +34,7 @@ const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 const dummyProject = buildProject({
   name: "w2m",
   entities: {
-    processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, kind: dummyGroup.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
+    processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, flowType: dummyGroup.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
   } as ProjectEntities,
 });
 
@@ -60,7 +60,7 @@ async function setup(page: Page) {
 const dummyGroupBody = buildProcessFlow({
   id: groupId,
   name: dummyGroup.name,
-  kind: (dummyGroup.type ?? "screen") as Parameters<typeof buildProcessFlow>[0]["kind"],
+  flowType: (dummyGroup.type ?? "screen") as Parameters<typeof buildProcessFlow>[0]["flowType"],
   mode: "upstream",
   actions: dummyGroup.actions as ReturnType<typeof buildProcessFlow>["actions"],
   authoring: dummyGroup.markers !== undefined ? { markers: dummyGroup.markers } : undefined,

--- a/frontend/src/codex/processFlowGeneration.test.ts
+++ b/frontend/src/codex/processFlowGeneration.test.ts
@@ -12,7 +12,7 @@ function baseFlow(): ProcessFlow {
     meta: {
       id: "flow-1" as never,
       name: "既存フロー",
-      kind: "screen",
+      flowType: "screen", // #1263 Phase X1: meta.kind → meta.flowType
       screenId: "screen-1" as never,
       maturity: "draft",
       mode: "upstream",
@@ -107,7 +107,7 @@ describe("generateProcessFlowWithCodex", () => {
       meta: {
         id: "flow-1",
         name: "商品検索",
-        kind: "screen",
+        flowType: "screen", // #1263 Phase X1
         createdAt: "2026-05-01T00:00:00.000Z",
         updatedAt: "2026-05-12T00:00:00.000Z",
       },

--- a/frontend/src/codex/processFlowGeneration.ts
+++ b/frontend/src/codex/processFlowGeneration.ts
@@ -91,7 +91,7 @@ export function mergeGeneratedProcessFlow(current: ProcessFlow, generated: Proce
     createdAt: current.meta.createdAt,
     updatedAt: current.meta.updatedAt,
     screenId: current.meta.screenId ?? next.meta.screenId,
-    kind: next.meta.kind ?? current.meta.kind,
+    flowType: next.meta.flowType ?? current.meta.flowType,
   };
   next.authoring = current.authoring;
   return next;

--- a/frontend/src/codex/processFlowPartialRequest.test.ts
+++ b/frontend/src/codex/processFlowPartialRequest.test.ts
@@ -12,7 +12,7 @@ function baseFlow(): ProcessFlow {
     meta: {
       id: "flow-1" as never,
       name: "既存フロー",
-      kind: "screen",
+      flowType: "screen", // #1263 Phase X1: meta.kind → meta.flowType
       screenId: "screen-1" as never,
       maturity: "draft",
       mode: "upstream",
@@ -148,7 +148,7 @@ describe("requestProcessFlowPartial", () => {
       meta: {
         id: "different-id",
         name: "修正済フロー",
-        kind: "screen",
+        flowType: "screen", // #1263 Phase X1: meta.kind → meta.flowType
         screenId: "other-screen",
         createdAt: "2026-05-13T00:00:00.000Z",
         maturity: "draft",
@@ -181,7 +181,7 @@ describe("requestProcessFlowPartial", () => {
 
   it("includes contextString in the prompt when provided", async () => {
     const generated = {
-      meta: { id: "flow-1", name: "フロー", kind: "screen", maturity: "draft" },
+      meta: { id: "flow-1", name: "フロー", flowType: "screen", maturity: "draft" }, // #1263 Phase X1
       actions: [],
     };
     const { client, request } = authenticatedClientWithText(JSON.stringify(generated));
@@ -214,7 +214,7 @@ describe("requestProcessFlowPartial", () => {
 
   it("parses JSON wrapped in fenced code blocks", async () => {
     const generated = {
-      meta: { id: "flow-1", name: "フロー", kind: "screen", maturity: "draft" },
+      meta: { id: "flow-1", name: "フロー", flowType: "screen", maturity: "draft" }, // #1263 Phase X1
       actions: [],
     };
     const { client } = authenticatedClientWithText(`\`\`\`json\n${JSON.stringify(generated)}\n\`\`\``);
@@ -232,7 +232,7 @@ describe("requestProcessFlowPartial", () => {
     // 独立レビュー指摘 S-1: AI が `authoring: { markers: [] }` を返してきた場合でも
     // 既存のユーザ/システム生成マーカーを silently 失わないことを保証する
     const generated = {
-      meta: { id: "flow-1", name: "フロー", kind: "screen", maturity: "draft" },
+      meta: { id: "flow-1", name: "フロー", flowType: "screen", maturity: "draft" }, // #1263 Phase X1
       actions: [],
       authoring: { markers: [] },
     };

--- a/frontend/src/codex/processFlowPartialRequest.ts
+++ b/frontend/src/codex/processFlowPartialRequest.ts
@@ -105,7 +105,7 @@ export async function requestProcessFlowPartial({
     baseInstructions: [
       "You modify or extend a Harmony ProcessFlow JSON for a Japanese business application designer.",
       "Return only a complete JSON object. Do not include Markdown fences or commentary.",
-      "Preserve meta.id, meta.createdAt, meta.screenId, and meta.kind unless explicitly asked to change.",
+      "Preserve meta.id, meta.createdAt, meta.screenId, and meta.flowType unless explicitly asked to change.",
       "Preserve authoring.markers. Apply changes only to the portions relevant to the user request.",
       "Use draft-state semantics: incomplete details may remain draft/provisional.",
     ].join("\n"),
@@ -140,7 +140,7 @@ export async function requestProcessFlowPartial({
     createdAt: current.meta.createdAt,
     updatedAt: current.meta.updatedAt,
     screenId: current.meta.screenId ?? proposed.meta.screenId,
-    kind: proposed.meta.kind ?? current.meta.kind,
+    flowType: proposed.meta.flowType ?? current.meta.flowType,
   };
   // markers はユーザ/システム生成リソースで AI 提案では消さない (S-1 fix、独立レビュー指摘)
   proposed.authoring = {

--- a/frontend/src/components/process-flow/ActionMetaTabBar.tsx
+++ b/frontend/src/components/process-flow/ActionMetaTabBar.tsx
@@ -233,8 +233,8 @@ export function ActionMetaTabBar({ group, updateGroup, updateGroupSilent }: Prop
               <label className="form-label small fw-semibold">種別</label>
               <select
                 className="form-select form-select-sm"
-                value={group.meta?.kind ?? "other"}
-                onChange={(e) => handleInfoChange("kind", e.target.value)}
+                value={group.meta?.flowType ?? "other"}
+                onChange={(e) => handleInfoChange("flowType", e.target.value)}
               >
                 {(["screen", "batch", "scheduled", "system", "common", "other"] as ProcessFlowType[]).map((t) => (
                   <option key={t} value={t}>{PROCESS_FLOW_TYPE_LABELS[t]}</option>

--- a/frontend/src/components/process-flow/ProcessFlowListView.tsx
+++ b/frontend/src/components/process-flow/ProcessFlowListView.tsx
@@ -239,7 +239,7 @@ export function ProcessFlowListView() {
       return;
     }
     filter.applyFilter((g) => {
-      if (hasTypeFilter && g.kind !== filterType) return false;
+      if (hasTypeFilter && g.flowType !== filterType) return false;
       if (filterErrorsOnly && getErrorPriority(g.id) === 0) return false;
       if (filterMarkersOnly && (markerMap.get(g.id)?.total ?? 0) === 0) return false;
       if (hasMaturityFilter) {
@@ -254,7 +254,7 @@ export function ProcessFlowListView() {
   const sortAccessor = useCallback((g: ProcessFlowMeta, key: string): string | number => {
     switch (key) {
       case "name": return g.name;
-      case "type": return PROCESS_FLOW_TYPE_LABELS[g.kind as ProcessFlowType] ?? g.kind;
+      case "type": return PROCESS_FLOW_TYPE_LABELS[g.flowType as ProcessFlowType] ?? g.flowType ?? "";
       case "actionCount": return g.actionCount ?? 0;
       case "screenId": return g.screenId ? 1 : 0;
       case "errorPriority": return getErrorPriority(g.id);
@@ -608,11 +608,11 @@ export function ProcessFlowListView() {
       header: "種別",
       width: "130px",
       sortable: true,
-      sortAccessor: (g) => PROCESS_FLOW_TYPE_LABELS[g.kind as ProcessFlowType] ?? g.kind,
+      sortAccessor: (g) => PROCESS_FLOW_TYPE_LABELS[g.flowType as ProcessFlowType] ?? g.flowType ?? "",
       render: (g) => (
-        <span className={`process-flow-type-badge ${g.kind}`}>
-          <i className={`${PROCESS_FLOW_TYPE_ICONS[g.kind as ProcessFlowType] ?? "bi-three-dots"} me-1`} />
-          {PROCESS_FLOW_TYPE_LABELS[g.kind as ProcessFlowType] ?? g.kind}
+        <span className={`process-flow-type-badge ${g.flowType}`}>
+          <i className={`${PROCESS_FLOW_TYPE_ICONS[g.flowType as ProcessFlowType] ?? "bi-three-dots"} me-1`} />
+          {PROCESS_FLOW_TYPE_LABELS[g.flowType as ProcessFlowType] ?? g.flowType}
         </span>
       ),
     },
@@ -688,9 +688,9 @@ export function ProcessFlowListView() {
     return (
       <div className={`process-flow-card-content${hasError ? " has-error" : hasWarning ? " has-warning" : ""}`}>
         <div className="process-flow-card-head">
-          <span className={`process-flow-type-badge ${g.kind}`}>
-            <i className={`${PROCESS_FLOW_TYPE_ICONS[g.kind as ProcessFlowType] ?? "bi-three-dots"} me-1`} />
-            {PROCESS_FLOW_TYPE_LABELS[g.kind as ProcessFlowType] ?? g.kind}
+          <span className={`process-flow-type-badge ${g.flowType}`}>
+            <i className={`${PROCESS_FLOW_TYPE_ICONS[g.flowType as ProcessFlowType] ?? "bi-three-dots"} me-1`} />
+            {PROCESS_FLOW_TYPE_LABELS[g.flowType as ProcessFlowType] ?? g.flowType}
           </span>
           <MaturityBadge maturity={g.maturity} />
           <span className="process-flow-card-name">{g.name}</span>
@@ -721,7 +721,7 @@ export function ProcessFlowListView() {
 
   const typeCounts = useMemo(() => {
     const c: Record<string, number> = {};
-    for (const g of groups) if (g.kind != null) c[g.kind] = (c[g.kind] ?? 0) + 1;
+    for (const g of groups) if (g.flowType != null) c[g.flowType] = (c[g.flowType] ?? 0) + 1;
     return c;
   }, [groups]);
 

--- a/frontend/src/schemas/ai-step-kind.schema.test.ts
+++ b/frontend/src/schemas/ai-step-kind.schema.test.ts
@@ -53,7 +53,7 @@ function envelope(action: object) {
       id: "00000000-0000-4000-8000-000000000001",
       name: "Test",
       description: "test fixture for AI step kind",
-      kind: "common" as const,
+      flowType: "common" as const, // #1263 Phase X1: meta.kind → meta.flowType
       maturity: "draft" as const,
       createdAt: "2026-05-08T00:00:00.000Z",
       updatedAt: "2026-05-08T00:00:00.000Z",

--- a/frontend/src/schemas/loop-step-conditional.schema.test.ts
+++ b/frontend/src/schemas/loop-step-conditional.schema.test.ts
@@ -36,8 +36,8 @@ const META_BASE = {
   name: "fixture flow",
   createdAt: "2026-05-19T00:00:00.000Z",
   updatedAt: "2026-05-19T00:00:00.000Z",
-  kind: "screen",
-  // #1221 で kind="screen" の場合 screenId 必須
+  flowType: "screen", // #1263 Phase X1: meta.kind → meta.flowType
+  // #1221 で flowType="screen" の場合 screenId 必須
   screenId: "22222222-2222-4222-8222-222222222222",
 };
 

--- a/frontend/src/schemas/screen-item-events.schema.test.ts
+++ b/frontend/src/schemas/screen-item-events.schema.test.ts
@@ -41,7 +41,7 @@ function makeMeta(overrides: Record<string, unknown> = {}): Record<string, unkno
     maturity: "draft",
     createdAt: "2026-04-30T00:00:00.000Z",
     updatedAt: "2026-04-30T00:00:00.000Z",
-    kind: "common",
+    flowType: "common", // #1263 Phase X1: meta.kind → meta.flowType
     ...overrides,
   };
 }
@@ -196,7 +196,7 @@ describe("ProcessFlow.meta.primaryInvoker (#624)", () => {
   it("primaryInvoker (screen-item-event) を持つ正常系", () => {
     const flow = {
       meta: makeMeta({
-        kind: "screen", screenId: "22222222-2222-4222-8222-222222222222",
+        flowType: "screen", screenId: "22222222-2222-4222-8222-222222222222",
         primaryInvoker: {
           kind: "screen-item-event",
           screenId: SCREEN_UUID,
@@ -212,7 +212,7 @@ describe("ProcessFlow.meta.primaryInvoker (#624)", () => {
   it("primaryInvoker.screenId を欠落させると fail", () => {
     const flow = {
       meta: makeMeta({
-        kind: "screen", screenId: "22222222-2222-4222-8222-222222222222",
+        flowType: "screen", screenId: "22222222-2222-4222-8222-222222222222",
         primaryInvoker: {
           kind: "screen-item-event",
           itemId: "submitBtn",
@@ -227,7 +227,7 @@ describe("ProcessFlow.meta.primaryInvoker (#624)", () => {
   it("primaryInvoker.kind が未対応の値だと fail", () => {
     const flow = {
       meta: makeMeta({
-        kind: "screen", screenId: "22222222-2222-4222-8222-222222222222",
+        flowType: "screen", screenId: "22222222-2222-4222-8222-222222222222",
         primaryInvoker: { kind: "unknown-invoker" },
       }),
       actions: [],
@@ -238,7 +238,7 @@ describe("ProcessFlow.meta.primaryInvoker (#624)", () => {
   it("primaryInvoker に未知のトップレベルプロパティを含むと fail (additionalProperties: false)", () => {
     const flow = {
       meta: makeMeta({
-        kind: "screen", screenId: "22222222-2222-4222-8222-222222222222",
+        flowType: "screen", screenId: "22222222-2222-4222-8222-222222222222",
         primaryInvoker: {
           kind: "screen-item-event",
           screenId: SCREEN_UUID,
@@ -255,7 +255,7 @@ describe("ProcessFlow.meta.primaryInvoker (#624)", () => {
   it("primaryInvoker.itemId が Identifier 形式 (lowerCamelCase) でないと fail", () => {
     const flow = {
       meta: makeMeta({
-        kind: "screen", screenId: "22222222-2222-4222-8222-222222222222",
+        flowType: "screen", screenId: "22222222-2222-4222-8222-222222222222",
         primaryInvoker: {
           kind: "screen-item-event",
           screenId: SCREEN_UUID,
@@ -271,7 +271,7 @@ describe("ProcessFlow.meta.primaryInvoker (#624)", () => {
   it("primaryInvoker.actionId 付きで pass (#1019)", () => {
     const flow = {
       meta: makeMeta({
-        kind: "screen", screenId: "22222222-2222-4222-8222-222222222222",
+        flowType: "screen", screenId: "22222222-2222-4222-8222-222222222222",
         primaryInvoker: {
           kind: "screen-item-event",
           screenId: SCREEN_UUID,
@@ -288,7 +288,7 @@ describe("ProcessFlow.meta.primaryInvoker (#624)", () => {
   it("primaryInvoker.actionId が LocalId 形式を満たさないと fail (#1019)", () => {
     const flow = {
       meta: makeMeta({
-        kind: "screen", screenId: "22222222-2222-4222-8222-222222222222",
+        flowType: "screen", screenId: "22222222-2222-4222-8222-222222222222",
         primaryInvoker: {
           kind: "screen-item-event",
           screenId: SCREEN_UUID,

--- a/frontend/src/schemas/v3-samples.test.ts
+++ b/frontend/src/schemas/v3-samples.test.ts
@@ -135,7 +135,7 @@ describe("schema v3 examples (#774: examples/ を canonical サンプル領域�
         name: "F-2 lineage 透過テスト",
         createdAt: "2026-04-27T00:00:00.000Z",
         updatedAt: "2026-04-27T00:00:00.000Z",
-        kind: "screen", screenId: "22222222-2222-4222-8222-222222222222",
+        flowType: "screen", screenId: "22222222-2222-4222-8222-222222222222",
       },
       actions: [
         {
@@ -174,7 +174,7 @@ describe("schema v3 examples (#774: examples/ を canonical サンプル領域�
         name: "F-2 DbAccessStep lineage 継承テスト",
         createdAt: "2026-04-27T00:00:00.000Z",
         updatedAt: "2026-04-27T00:00:00.000Z",
-        kind: "screen", screenId: "22222222-2222-4222-8222-222222222222",
+        flowType: "screen", screenId: "22222222-2222-4222-8222-222222222222",
       },
       actions: [
         {
@@ -210,7 +210,7 @@ describe("schema v3 examples (#774: examples/ を canonical サンプル領域�
         name: "F-4 discriminator テスト",
         createdAt: "2026-04-27T00:00:00.000Z",
         updatedAt: "2026-04-27T00:00:00.000Z",
-        kind: "screen", screenId: "22222222-2222-4222-8222-222222222222",
+        flowType: "screen", screenId: "22222222-2222-4222-8222-222222222222",
       },
       actions: [
         {
@@ -252,7 +252,7 @@ describe("schema v3 examples (#774: examples/ を canonical サンプル領域�
         name: "F-4 CdcDestination",
         createdAt: "2026-04-27T00:00:00.000Z",
         updatedAt: "2026-04-27T00:00:00.000Z",
-        kind: "batch",
+        flowType: "batch",
       },
       actions: [
         {
@@ -289,7 +289,7 @@ describe("schema v3 examples (#774: examples/ を canonical サンプル領域�
         name: "F-4 TestPrecondition",
         createdAt: "2026-04-27T00:00:00.000Z",
         updatedAt: "2026-04-27T00:00:00.000Z",
-        kind: "screen", screenId: "22222222-2222-4222-8222-222222222222",
+        flowType: "screen", screenId: "22222222-2222-4222-8222-222222222222",
       },
       actions: [
         {

--- a/frontend/src/schemas/v3-variant-coverage.test.ts
+++ b/frontend/src/schemas/v3-variant-coverage.test.ts
@@ -26,8 +26,8 @@ const META_BASE = {
   name: "fixture flow",
   createdAt: "2026-04-28T00:00:00.000Z",
   updatedAt: "2026-04-28T00:00:00.000Z",
-  kind: "screen",
-  // #1221 で kind="screen" の場合 screenId 必須
+  flowType: "screen", // #1263 Phase X1: meta.kind → meta.flowType
+  // #1221 で flowType="screen" の場合 screenId 必須
   screenId: "22222222-2222-4222-8222-222222222222",
 };
 
@@ -642,18 +642,18 @@ describe("v3 schema fix #533 R3-2: ClosingStep.cutoffAt pattern (#533)", () => {
   });
 });
 
-describe("v3 schema fix #533 R3-3: scheduled + httpRoute 不整合 reject (#533)", () => {
-  it("kind=scheduled + Action に httpRoute なし → pass", () => {
+describe("v3 schema fix #533 R3-3: scheduled + httpRoute 不整合 reject (#533, #1263 Phase X1: meta.flowType)", () => {
+  it("flowType=scheduled + Action に httpRoute なし → pass", () => {
     const flow = makeFlow(
       [{ id: "step-01", kind: "log", description: "ok", level: "info", message: "ok" }],
-      { metaOverride: { kind: "scheduled" } },
+      { metaOverride: { flowType: "scheduled" } },
     );
     expectPass(flow, "scheduled + no httpRoute");
   });
 
-  it("kind=screen + Action に httpRoute あり → 従来通り pass", () => {
+  it("flowType=screen + Action に httpRoute あり → 従来通り pass", () => {
     const flow = {
-      meta: { ...META_BASE, kind: "screen" },
+      meta: { ...META_BASE, flowType: "screen" },
       actions: [
         {
           id: "act-001",
@@ -667,9 +667,9 @@ describe("v3 schema fix #533 R3-3: scheduled + httpRoute 不整合 reject (#533)
     expectPass(flow, "screen + httpRoute should pass");
   });
 
-  it("kind=scheduled + Action に httpRoute あり → reject (R3-3 if/then)", () => {
+  it("flowType=scheduled + Action に httpRoute あり → reject (R3-3 if/then)", () => {
     const flow = {
-      meta: { ...META_BASE, kind: "scheduled" },
+      meta: { ...META_BASE, flowType: "scheduled" },
       actions: [
         {
           id: "act-001",

--- a/frontend/src/store/processFlowStore.ts
+++ b/frontend/src/store/processFlowStore.ts
@@ -259,7 +259,7 @@ async function syncProcessFlowMeta(group: ProcessFlow): Promise<void> {
     id: group.meta.id as ProcessFlowId,
     no: idx >= 0 ? project.processFlows[idx].no : nextNo(project.processFlows),
     name: group.meta.name,
-    kind: group.meta.kind,
+    flowType: group.meta.flowType,
     screenId: group.meta.screenId as ScreenId | undefined,
     actionCount: group.actions.length,
     updatedAt: group.meta.updatedAt as Timestamp,

--- a/frontend/src/types/v3/harmony.ts
+++ b/frontend/src/types/v3/harmony.ts
@@ -67,9 +67,9 @@ export interface TableEntry extends EntryBase {
 
 export interface ProcessFlowEntry extends EntryBase {
   id: ProcessFlowId;
-  /** ProcessFlowKind (screen/batch/scheduled/system/common/other 等)。 */
-  kind?: string;
-  /** screen kind の場合の関連画面 ID。 */
+  /** ProcessFlowKind (screen/batch/scheduled/system/common/other 等)。#1263 Phase X1 で kind → flowType に rename。 */
+  flowType?: string;
+  /** flowType='screen' の場合の関連画面 ID。 */
   screenId?: ScreenId;
   actionCount?: number;
   notesCount?: number;

--- a/frontend/src/types/v3/process-flow.ts
+++ b/frontend/src/types/v3/process-flow.ts
@@ -67,9 +67,9 @@ export interface ProcessFlowMeta {
   maturity?: Maturity;
   createdAt: Timestamp;
   updatedAt: Timestamp;
-  // ProcessFlow 固有
-  kind: ProcessFlowKind;
-  /** kind='screen' の場合に紐付く Screen の Uuid。 */
+  // ProcessFlow 固有 (#1263 Phase X1: kind → flowType に rename)
+  flowType: ProcessFlowKind;
+  /** flowType='screen' の場合に紐付く Screen の Uuid。 */
   screenId?: ScreenId;
   /** ProcessFlow が公開する API のバージョン (例: `v1`, `2026-04-25`)。 */
   apiVersion?: string;

--- a/frontend/src/types/v3/v3-types.test.ts
+++ b/frontend/src/types/v3/v3-types.test.ts
@@ -207,7 +207,7 @@ describe("v3 TS 型 と examples/ JSON の compatibility", () => {
     const flow = loadJson<ProcessFlow>(
       join(examplesDir, "retail/harmony/process-flows/267e94bf-0397-44b8-b665-d3c40c38935b.json"),
     );
-    expect(flow.meta.kind).toBe("common");
+    expect(flow.meta.flowType).toBe("common"); // #1263 Phase X1: meta.kind → meta.flowType
     const firstStep: Step = flow.actions[0].steps[0];
     expect(firstStep.kind).toBe("dbAccess");
   });
@@ -250,6 +250,6 @@ describe("v3 TS 型 と examples/ JSON の compatibility", () => {
     const flow = loadJson<ProcessFlow>(
       join(examplesDir, "realestate/harmony/process-flows/d4b5c6e7-f809-4112-bc3d-4e5f6a7b8c9d.json"),
     );
-    expect(flow.meta.kind).toBeDefined();
+    expect(flow.meta.flowType).toBeDefined(); // #1263 Phase X1: meta.kind → meta.flowType
   });
 });

--- a/frontend/src/utils/actionMigration.test.ts
+++ b/frontend/src/utils/actionMigration.test.ts
@@ -254,9 +254,9 @@ describe("migrateProcessFlow — ProcessFlow 全体", () => {
 
     const migrated = migrateProcessFlow(sample) as ProcessFlow;
 
-    // v3: id / name / type は meta に移動 (v3 vocabulary に直接アクセス)
+    // v3: id / name / type は meta に移動 (v3 vocabulary に直接アクセス) — #1263 Phase X1: meta.kind → meta.flowType
     expect(migrated.meta.id).toBe(sample.id);
-    expect(migrated.meta.kind).toBe("common");
+    expect(migrated.meta.flowType).toBe("common");
     expect(migrated.actions).toHaveLength(1);
     const steps = migrated.actions[0].steps;
     expect(steps).toHaveLength(2);
@@ -458,7 +458,7 @@ describe("migrateProcessFlow — v3 root 4 セクション化 + maturity / mode 
     expect(migrated.meta).toMatchObject({
       id: "aaaaaaaa-0000-4000-8000-000000000001",
       name: "注文登録",
-      kind: "screen",
+      flowType: "screen", // #1263 Phase X1: meta.kind → meta.flowType
       screenId: "bbbbbbbb-0000-4000-8000-000000000001",
       mode: "downstream",
       maturity: "committed",

--- a/frontend/src/utils/actionMigration.ts
+++ b/frontend/src/utils/actionMigration.ts
@@ -21,7 +21,8 @@ function clone<T>(raw: T): T {
 }
 
 function isV3ProcessFlow(raw: Raw): boolean {
-  return raw.$schema === PROCESS_FLOW_V3_SCHEMA_REF || (isRecord(raw.meta) && typeof raw.meta.kind === "string");
+  // #1263 Phase X1: meta.kind → meta.flowType に rename
+  return raw.$schema === PROCESS_FLOW_V3_SCHEMA_REF || (isRecord(raw.meta) && typeof raw.meta.flowType === "string");
 }
 
 function isValidMaturity(v: unknown): v is Maturity {
@@ -291,7 +292,7 @@ export function migrateProcessFlow(raw: unknown): ProcessFlow {
     meta: {
       id: source.id,
       name: source.name ?? "",
-      kind: source.type ?? "other",
+      flowType: source.type ?? "other",
       description: source.description ?? "",
       version: source.version ?? "1.0.0",
       maturity: isValidMaturity(source.maturity) ? source.maturity : "draft",

--- a/frontend/src/utils/processFlowMetadata.ts
+++ b/frontend/src/utils/processFlowMetadata.ts
@@ -54,7 +54,7 @@ export const ACTION_TRIGGER_LABELS: Record<string, string> = {
   manual: "手動",
 };
 
-// ── ProcessFlow.meta.kind ───────────────────────────────────────────────────
+// ── ProcessFlow.meta.flowType (旧 meta.kind, #1263 Phase X1) ────────────────
 export const PROCESS_FLOW_TYPE_LABELS: Record<string, string> = {
   screen: "画面",
   batch: "バッチ",

--- a/frontend/src/utils/specExporter.ts
+++ b/frontend/src/utils/specExporter.ts
@@ -38,7 +38,8 @@ function pfFlat(g: ProcessFlow): Record<string, unknown> {
 }
 
 function pfKind(g: ProcessFlow): string {
-  return (g.meta?.kind ?? pfFlat(g)["kind"] ?? pfFlat(g)["type"] ?? "") as string;
+  // #1263 Phase X1: meta.flowType (旧 meta.kind) を優先、legacy も fallback で読む
+  return (g.meta?.flowType ?? pfFlat(g)["flowType"] ?? pfFlat(g)["kind"] ?? pfFlat(g)["type"] ?? "") as string;
 }
 
 function pfName(g: ProcessFlow): string {

--- a/schemas/v3/README.md
+++ b/schemas/v3/README.md
@@ -205,7 +205,7 @@ v3 EventTopic regex は `^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)*$` (lowercase + und
 
 | v1 | v3 |
 |---|---|
-| `type: "screen"` | `meta.kind: "screen"` |
+| `type: "screen"` | `meta.flowType: "screen"` (#1263 Phase X1: meta.kind → meta.flowType) |
 | `screenId`, `apiVersion`, `mode`, `maturity`, `description`, `version`, `createdAt`, `updatedAt` | `meta.{...}` (EntityMeta + ProcessFlow 固有) |
 | `errorCatalog: { CODE: { responseRef } }` | `context.catalogs.errors: { CODE: { responseId } }` |
 | `eventsCatalog` | `context.catalogs.events` (EventTopic 規範遵守) |

--- a/schemas/v3/extensions.v3.schema.json
+++ b/schemas/v3/extensions.v3.schema.json
@@ -25,7 +25,7 @@
         },
         "processFlowKinds": {
           "type": "array",
-          "description": "ProcessFlowKind の拡張。ProcessFlow.meta.kind の namespace:kindName で参照される。",
+          "description": "ProcessFlowKind の拡張。ProcessFlow.meta.flowType の namespace:kindName で参照される (#1263 Phase X1)。",
           "items": { "$ref": "#/$defs/CustomProcessFlowKind" }
         },
         "actionTriggers": {
@@ -168,7 +168,7 @@
     },
 
     "CustomProcessFlowKind": {
-      "description": "拡張 ProcessFlowKind。ProcessFlow.meta.kind の namespace:kindName で参照される。",
+      "description": "拡張 ProcessFlowKind。ProcessFlow.meta.flowType の namespace:kindName で参照される (#1263 Phase X1)。",
       "type": "object",
       "required": ["kind", "label"],
       "additionalProperties": false,

--- a/schemas/v3/harmony.v3.schema.json
+++ b/schemas/v3/harmony.v3.schema.json
@@ -221,8 +221,8 @@
       "allOf": [{ "$ref": "#/$defs/EntryBase" }],
       "type": "object",
       "properties": {
-        "kind": { "type": "string", "description": "ProcessFlowKind (screen/batch/scheduled/system/common/other、または 'retail:posTransaction' 等の拡張参照)。" },
-        "screenId": { "$ref": "common.v3.schema.json#/$defs/Uuid", "description": "screen kind の場合の関連画面 ID。" },
+        "flowType": { "type": "string", "description": "ProcessFlowKind (screen/batch/scheduled/system/common/other、または 'retail:posTransaction' 等の拡張参照)。#1263 Phase X1 で kind → flowType に rename。" },
+        "screenId": { "$ref": "common.v3.schema.json#/$defs/Uuid", "description": "flowType='screen' の場合の関連画面 ID。" },
         "actionCount": { "type": "integer", "minimum": 0 },
         "notesCount": { "type": "integer", "minimum": 0 }
       },

--- a/schemas/v3/process-flow.v3.schema.json
+++ b/schemas/v3/process-flow.v3.schema.json
@@ -21,14 +21,14 @@
     "properties": {
       "meta": {
         "type": "object",
-        "properties": { "kind": { "const": "scheduled" } },
-        "required": ["kind"]
+        "properties": { "flowType": { "const": "scheduled" } },
+        "required": ["flowType"]
       }
     },
     "required": ["meta"]
   },
   "then": {
-    "description": "#533 R3-3: meta.kind='scheduled' のフローでは、cron 起動の定期実行であり HTTP ルートからは呼ばれないため、Action.httpRoute を禁止する。",
+    "description": "#533 R3-3 / #1263 Phase X1: meta.flowType='scheduled' のフローでは、cron 起動の定期実行であり HTTP ルートからは呼ばれないため、Action.httpRoute を禁止する。",
     "properties": {
       "actions": {
         "items": { "not": { "required": ["httpRoute"] } }
@@ -39,19 +39,19 @@
   "$defs": {
 
     "Meta": {
-      "description": "ProcessFlow の identity と運用設定。kind='screen' は画面と直結した処理フローを表し、その場合は紐付く Screen の Uuid を `screenId` で必須宣言する (#1221)。画面に直結しない処理フロー (認証、共通 API、scheduled batch 等) は kind を `system` / `common` / `scheduled` / `batch` に分類する。",
+      "description": "ProcessFlow の identity と運用設定。flowType='screen' は画面と直結した処理フローを表し、その場合は紐付く Screen の Uuid を `screenId` で必須宣言する (#1221)。画面に直結しない処理フロー (認証、共通 API、scheduled batch 等) は flowType を `system` / `common` / `scheduled` / `batch` に分類する (#1263 Phase X1: meta.kind → meta.flowType rename)。",
       "allOf": [
         { "$ref": "common.v3.schema.json#/$defs/EntityMeta" },
         {
-          "if": { "properties": { "kind": { "const": "screen" } }, "required": ["kind"] },
+          "if": { "properties": { "flowType": { "const": "screen" } }, "required": ["flowType"] },
           "then": { "required": ["screenId"] }
         }
       ],
       "type": "object",
-      "required": ["kind"],
+      "required": ["flowType"],
       "properties": {
-        "kind": { "$ref": "#/$defs/ProcessFlowKind" },
-        "screenId": { "$ref": "common.v3.schema.json#/$defs/Uuid", "description": "kind='screen' の場合に紐付く Screen の Uuid。kind='screen' 時は必須 (#1221)。" },
+        "flowType": { "$ref": "#/$defs/ProcessFlowKind" },
+        "screenId": { "$ref": "common.v3.schema.json#/$defs/Uuid", "description": "flowType='screen' の場合に紐付く Screen の Uuid。flowType='screen' 時は必須 (#1221)。" },
         "apiVersion": { "type": "string", "description": "ProcessFlow が公開する API のバージョン (例: 'v1', '2026-04-25')。" },
         "mode": { "$ref": "common.v3.schema.json#/$defs/Mode" },
         "sla": { "$ref": "#/$defs/Sla" },


### PR DESCRIPTION
## Summary

[#1263](https://github.com/csilost2001/harmony/issues/1263) Phase X1 — RFC #1254 件 4 (`meta.kind` → `meta.flowType` rename、機械置換 100%) を実装。

**統合ブランチ**: `feat/schema-v3-revision-series` の Phase X1 子 PR。X2 / X3 完了後に統合ブランチから main へ 1 本の PR を出す。

## 変更内容

### schema (governance: user 着手承認済 #1263 ISSUE body)
- `schemas/v3/process-flow.v3.schema.json` — `Meta.kind` → `Meta.flowType` (required / if-then conditions も同時 rename、`ProcessFlowKind` 型定義名は据置: 他 `*Kind` 型との対称性のため)
- `schemas/v3/harmony.v3.schema.json` — `ProcessFlowEntry.kind` → `.flowType` (description も `flowType='screen'` ベースに rephrase)
- `schemas/v3/extensions.v3.schema.json` — description 内の `ProcessFlow.meta.kind` 参照を `ProcessFlow.meta.flowType` に更新
- `schemas/v3/README.md` — v3 構造変更表に rename を追記

### TS 型 + UI
- `frontend/src/types/v3/process-flow.ts` — `ProcessFlowMeta.kind` → `flowType`
- `frontend/src/types/v3/harmony.ts` — `ProcessFlowEntry.kind` → `flowType`
- `frontend/src/components/process-flow/ActionMetaTabBar.tsx` — meta 編集 UI の select bind を `flowType` に
- `frontend/src/components/process-flow/ProcessFlowListView.tsx` — filter / sort / badge / card 表示を `g.flowType` ベースに
- `frontend/e2e/__fixtures__/builders/processFlowBuilder.ts` — `BuildProcessFlowOpts.kind?` → `flowType?`

### backend handler / MCP tool
- `backend/src/handlers/processFlow.ts` — `buildV3ProcessFlow` / `upsertProcessFlowEntry` の引数と内部 read/write path 全部 `flowType` に。MCP tool `designer__add_process_flow` の入力 param も `kind` → `flowType`
- `backend/src/tools.ts` — MCP tool 定義の input schema 更新 (`required: ["name", "flowType"]`)

### code references
- `frontend/src/store/processFlowStore.ts` — harmony.json upsert 時の field
- `frontend/src/codex/processFlowGeneration.ts` / `processFlowPartialRequest.ts` — identity preserve list に `meta.flowType`
- `frontend/src/utils/actionMigration.ts` — v3 detection (`isV3ProcessFlow`) + v1→v3 migrate path
- `frontend/src/utils/processFlowMetadata.ts` — header comment 更新
- `frontend/src/utils/specExporter.ts` — `pfKind()` accessor (legacy fallback 維持)

### examples (33 process-flow JSON + 5 harmony.json)
全 example project (diary / english-learning / english-learning-tailwind / realestate / retail) で:
- `harmony/process-flows/*.json` の `meta.kind` → `meta.flowType`
- `harmony.json` の `entities.processFlows[].kind` → `.flowType`

(screen / table / actionTrigger entries の `kind` は別概念のため据置)

### e2e tests (35 spec file)
`buildProcessFlow({ kind: ... })` 呼び出し / `processFlows: [{ ... kind: "..." }]` 配列リテラル / `Parameters<typeof buildProcessFlow>[0]["kind"]` 型参照 を context-aware に `flowType` に置換。step.kind / Marker.kind / Constraint.kind / FieldType.kind 等の同名別概念には触れていない。

### docs
- `docs/spec/schema-v3-design.md` — Meta definition `kind` → `flowType`
- `docs/spec/conversion-guideline-for-ai.md` — JSON 例 2 箇所
- `docs/spec/examples-english-learning.md` — `ProcessFlow.kind 参照` 列ヘッダ
- `docs/spec/process-flow-variables.md` — `CommonProcessStep.refId` の説明コメント
- `ai-skills/generate-tests/golden-examples/diary-post-lifecycle-e2e/README.md` — 注意書き

## 検証

- ✅ `npm run validate:samples` で全 5 example project pass:
  - diary 15 / english-learning 5 / english-learning-tailwind 5 / realestate 1 / retail 7 = 33 flows
- ✅ backend test: **603/603 pass**
- ✅ frontend `test:unit`: **2424/2434 pass** (残 10 fail は本 PR 前から pre-existing な english-learning screen-item validation 失敗、`git stash` で本 PR 不在状態でも同じ 10 件失敗を確認済み — 本 rename とは無関係)
- ✅ frontend `npx tsc --noEmit`: pass

## Schema governance 確認

ISSUE #1263 本文の「## 🔗 統合 PR 情報」「## Phase X1」セクションで「meta.kind → meta.flowType rename (機械置換 100%、先行)」が明示。 user の「Phase X1 実装やって」着手指示は schema 変更承認に該当する (`AGENTS.md#schema-governance` で要求される設計者承認を満たす)。

## 関連

- 親 ISSUE: #1263 Phase X1 (本 PR で完了、Phase X2 / X3 後に統合 PR で main へ)
- 親 RFC: #1254 件 4

Refs #1263
Refs #1254