### PR TITLE
feat(designer): #1269 Phase B — 3 step card に新 field の編集 UI 追加

### DIFF
--- a/frontend/src/components/process-flow/StepCard.tsx
+++ b/frontend/src/components/process-flow/StepCard.tsx
@@ -521,12 +521,15 @@ export function StepCard({
                   onChange={(e) => {
                     const name = e.target.value;
                     const op = getBindingOperation(step.outputBinding);
+                    // #1269 Phase B Round 1 M-1: existing expose / transformations / initialValue を保全
+                    // するため step.outputBinding を spread ベースに変更。name 削除時のみ全削除。
+                    const existing = step.outputBinding;
                     if (!name) {
                       onChange({ outputBinding: undefined } as Partial<Step>);
                     } else if (op === "assign") {
-                      onChange({ outputBinding: { name } } as Partial<Step>);
+                      onChange({ outputBinding: { ...existing, name, operation: undefined } } as Partial<Step>);
                     } else {
-                      onChange({ outputBinding: { name, operation: op } } as Partial<Step>);
+                      onChange({ outputBinding: { ...existing, name, operation: op } } as Partial<Step>);
                     }
                   }}
                   onBlur={onCommit}
@@ -545,10 +548,12 @@ export function StepCard({
                       // 名前未入力時は代入方式だけ先に決めても undefined 維持 (空の binding を作らない)
                       return;
                     }
+                    // #1269 Phase B Round 1 M-1: existing expose / transformations / initialValue を保全
+                    const existing = step.outputBinding;
                     if (op === "assign") {
-                      onChange({ outputBinding: { name } } as Partial<Step>);
+                      onChange({ outputBinding: { ...existing, name, operation: undefined } } as Partial<Step>);
                     } else {
-                      onChange({ outputBinding: { name, operation: op } } as Partial<Step>);
+                      onChange({ outputBinding: { ...existing, name, operation: op } } as Partial<Step>);
                     }
                   }}
                 >

--- a/frontend/src/components/process-flow/TransactionScopeStepPanel.tsx
+++ b/frontend/src/components/process-flow/TransactionScopeStepPanel.tsx
@@ -325,6 +325,52 @@ export function TransactionScopeStepPanel({
         </div>
       </div>
 
+      {/* #1269 Phase B: outputBinding.expose (TX 外参照可な inner var 名の明示宣言) */}
+      <div className="row g-2 mb-2" data-field-path="outputBinding.expose">
+        <div className="col-12">
+          <label className="form-label">
+            <i className="bi bi-box-arrow-right me-1" />
+            TX 外参照可な変数 (outputBinding.expose)
+            <span className="text-muted ms-1" style={{ fontSize: "0.75rem" }}>
+              — TX 内 step の outputBinding.name を列挙すると `@var.action.{step.outputBinding?.name ?? "<txName>"}.&lt;name&gt;.&lt;field&gt;` で TX 外参照可
+            </span>
+          </label>
+          <div className="text-muted small mb-1">
+            予約値 (<code>committed</code> / <code>error</code> / <code>diagnostics</code>) は常に利用可能、ここへの明示宣言不要 (#1264 verdict 観点 4)
+          </div>
+          <input
+            type="text"
+            className="form-control form-control-sm"
+            value={(step.outputBinding?.expose ?? []).join(", ")}
+            placeholder="例: newOrder, paymentReceipt (カンマ区切り、Identifier / camelCase)"
+            onChange={(e) => {
+              const list = e.target.value
+                .split(",")
+                .map((s) => s.trim())
+                .filter((s) => s.length > 0);
+              const currentName = step.outputBinding?.name;
+              if (!currentName) {
+                // outputBinding 自体が未設定なら expose は単独で意味を持たない → 何もしない
+                return;
+              }
+              const nextBinding = list.length > 0
+                ? { ...step.outputBinding, name: currentName, expose: list }
+                : { ...step.outputBinding, name: currentName, expose: undefined };
+              onChange({ outputBinding: nextBinding });
+            }}
+            onBlur={onCommit}
+            disabled={!step.outputBinding?.name}
+            title={step.outputBinding?.name ? undefined : "先に outputBinding.name (結果変数名) を設定してください"}
+          />
+          {!step.outputBinding?.name && (
+            <div className="text-muted small mt-1">
+              <i className="bi bi-info-circle me-1" />
+              先に結果変数名 (outputBinding) を上部で設定してください。
+            </div>
+          )}
+        </div>
+      </div>
+
       <div className="mb-2" data-field-path="steps">
         <label className="form-label small">
           <i className="bi bi-shield-fill me-1" style={{ color: "#dc2626" }} />

--- a/frontend/src/components/process-flow/TransactionScopeStepPanel.tsx
+++ b/frontend/src/components/process-flow/TransactionScopeStepPanel.tsx
@@ -332,7 +332,7 @@ export function TransactionScopeStepPanel({
             <i className="bi bi-box-arrow-right me-1" />
             TX 外参照可な変数 (outputBinding.expose)
             <span className="text-muted ms-1" style={{ fontSize: "0.75rem" }}>
-              — TX 内 step の outputBinding.name を列挙すると `@var.action.{step.outputBinding?.name ?? "<txName>"}.&lt;name&gt;.&lt;field&gt;` で TX 外参照可
+              — TX 内 step の outputBinding.name を列挙すると <code>{`@var.action.${step.outputBinding?.name ?? "<txName>"}.<name>.<field>`}</code> で TX 外参照可
             </span>
           </label>
           <div className="text-muted small mb-1">

--- a/frontend/src/components/process-flow/internal/step-cards/BranchStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/BranchStepCardBody.tsx
@@ -6,7 +6,7 @@
 // #1016 follow-up (2026-05-20): generic StepCardBodyBaseProps<BranchStep> で type narrow、@ts-nocheck 除去。
 
 import { useState } from "react";
-import type { BranchStep, Branch, ElseBranch, LocalId, ErrorCode } from "../../../../types/v3";
+import type { BranchStep, Branch, ElseBranch, LocalId, ErrorCode, Identifier } from "../../../../types/v3";
 import { generateUUID } from "../../../../utils/uuid";
 import { InlineStepList } from "../InlineStepList";
 import type {
@@ -110,7 +110,7 @@ export function BranchStepCardBody({
             >
               <span className="branch-code-badge">{br.code}</span>
               {br.condition?.kind === "tryCatch" ? (
-                <div className="d-flex align-items-center gap-1 flex-grow-1" onClick={(e) => e.stopPropagation()}>
+                <div className="d-flex align-items-center gap-1 flex-grow-1" onClick={(e) => e.stopPropagation()} data-field-path={`branches[${bi}].condition`}>
                   <span className="badge bg-info text-dark" style={{ fontSize: "0.7rem" }}>tryCatch</span>
                   <input
                     className="form-control form-control-sm"
@@ -118,9 +118,31 @@ export function BranchStepCardBody({
                     placeholder="errorCode (例: STOCK_SHORTAGE)"
                     onChange={(e) => setBranchAt(bi, {
                       ...br,
-                      condition: { kind: "tryCatch", errorCode: e.target.value as ErrorCode },
+                      condition: { kind: "tryCatch", errorCode: e.target.value as ErrorCode, errorVar: br.condition && br.condition.kind === "tryCatch" ? br.condition.errorVar : undefined },
                     })}
                     onBlur={onCommit}
+                    style={{ maxWidth: "12rem" }}
+                  />
+                  {/* #1269 Phase B: errorVar (catch block 内で error 全体を bind する変数名) */}
+                  <input
+                    className="form-control form-control-sm"
+                    value={br.condition.errorVar ?? ""}
+                    placeholder="errorVar (例: caughtError)"
+                    title="catch block 内で @var.<errorVar>.code / .message 参照に使う変数名 (任意 / camelCase)"
+                    pattern="^[a-z][a-zA-Z0-9]*$"
+                    onChange={(e) => {
+                      if (br.condition?.kind !== "tryCatch") return;
+                      setBranchAt(bi, {
+                        ...br,
+                        condition: {
+                          kind: "tryCatch",
+                          errorCode: br.condition.errorCode,
+                          errorVar: (e.target.value || undefined) as Identifier | undefined,
+                        },
+                      });
+                    }}
+                    onBlur={onCommit}
+                    style={{ maxWidth: "10rem" }}
                   />
                   <button
                     type="button"

--- a/frontend/src/components/process-flow/internal/step-cards/LoopStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/LoopStepCardBody.tsx
@@ -102,28 +102,47 @@ export function LoopStepCardBody({
       )}
 
       {step.loopKind === "collection" && (
-        <div className="form-row-pair">
-          <div className="form-group">
-            <label className="form-label">コレクション</label>
+        <>
+          <div className="form-row-pair">
+            <div className="form-group">
+              <label className="form-label">コレクション</label>
+              <input
+                className="form-control form-control-sm"
+                value={step.collectionSource ?? ""}
+                onChange={(e) => onChange({ collectionSource: e.target.value })}
+                onBlur={onCommit}
+                placeholder="例: 検索結果"
+              />
+            </div>
+            <div className="form-group">
+              <label className="form-label">要素変数名</label>
+              <input
+                className="form-control form-control-sm"
+                value={step.collectionItemName ?? ""}
+                onChange={(e) => onChange({ collectionItemName: e.target.value as Identifier })}
+                onBlur={onCommit}
+                placeholder="例: ユーザー"
+              />
+            </div>
+          </div>
+          {/* #1269 Phase B: collection mode の index 変数名 (任意) */}
+          <div className="form-group" data-field-path="collectionIndexName">
+            <label className="form-label">
+              index 変数名 (任意)
+              <span className="text-muted ms-1" style={{ fontSize: "0.75rem" }}>
+                — 0 始まりの index を loop 本体内で参照する場合に使用 (Identifier / camelCase)
+              </span>
+            </label>
             <input
               className="form-control form-control-sm"
-              value={step.collectionSource ?? ""}
-              onChange={(e) => onChange({ collectionSource: e.target.value })}
+              value={step.collectionIndexName ?? ""}
+              onChange={(e) => onChange({ collectionIndexName: (e.target.value || undefined) as Identifier | undefined })}
               onBlur={onCommit}
-              placeholder="例: 検索結果"
+              placeholder="例: idx"
+              pattern="^[a-z][a-zA-Z0-9]*$"
             />
           </div>
-          <div className="form-group">
-            <label className="form-label">要素変数名</label>
-            <input
-              className="form-control form-control-sm"
-              value={step.collectionItemName ?? ""}
-              onChange={(e) => onChange({ collectionItemName: e.target.value as Identifier })}
-              onBlur={onCommit}
-              placeholder="例: ユーザー"
-            />
-          </div>
-        </div>
+        </>
       )}
 
       <div className={`loop-body${loopBodyCollapsed ? " collapsed" : ""}`}>

--- a/frontend/src/components/process-flow/internal/step-cards/step-cards.test.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/step-cards.test.tsx
@@ -290,6 +290,57 @@ describe("BranchStepCardBody", () => {
     expect(call.branches.length).toBe(3);
     expect(call.branches[2].code).toBe("C");
   });
+
+  // #1269 Phase B: tryCatch errorVar UI 追加
+  it("tryCatch 分岐で errorVar input が描画される (#1269 Phase B)", () => {
+    const step = baseStep({
+      kind: "branch",
+      branches: [
+        { id: "b-1", code: "A", condition: { kind: "tryCatch", errorCode: "STOCK_SHORTAGE", errorVar: "caughtError" }, steps: [] },
+      ],
+    });
+    const { container } = render(
+      <BranchStepCardBody
+        step={step}
+        allSteps={[]}
+        tables={[]}
+        screens={[]}
+        commonGroups={[]}
+        onChange={noop}
+        onNavigateCommon={noop}
+      />,
+    );
+    const errorVarInput = container.querySelector('input[placeholder*="errorVar"]') as HTMLInputElement | null;
+    expect(errorVarInput).not.toBeNull();
+    expect(errorVarInput?.value).toBe("caughtError");
+  });
+
+  it("tryCatch errorVar 変更で onChange が errorCode を保持しつつ呼ばれる (#1269 Phase B)", () => {
+    const onChange = vi.fn();
+    const step = baseStep({
+      kind: "branch",
+      branches: [
+        { id: "b-1", code: "A", condition: { kind: "tryCatch", errorCode: "STOCK_SHORTAGE" }, steps: [] },
+      ],
+    });
+    const { container } = render(
+      <BranchStepCardBody
+        step={step}
+        allSteps={[]}
+        tables={[]}
+        screens={[]}
+        commonGroups={[]}
+        onChange={onChange}
+        onNavigateCommon={noop}
+      />,
+    );
+    const errorVarInput = container.querySelector('input[placeholder*="errorVar"]') as HTMLInputElement;
+    fireEvent.change(errorVarInput, { target: { value: "caughtError" } });
+    expect(onChange).toHaveBeenCalled();
+    const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
+    expect(lastCall.branches[0].condition.errorVar).toBe("caughtError");
+    expect(lastCall.branches[0].condition.errorCode).toBe("STOCK_SHORTAGE");
+  });
 });
 
 // ── LoopStepCardBody ────────────────────────────────────────────────
@@ -361,6 +412,33 @@ describe("LoopStepCardBody", () => {
     expect(container.textContent).toContain("コレクション");
     expect(container.textContent).toContain("要素変数名");
   });
+
+  // #1269 Phase B: collectionIndexName UI 追加
+  it("collection loop で index 変数名 input が描画される (#1269 Phase B)", () => {
+    const step = baseStep({
+      kind: "loop",
+      loopKind: "collection",
+      collectionSource: "items",
+      collectionItemName: "item",
+      collectionIndexName: "idx",
+      steps: [],
+    });
+    const { container } = render(
+      <LoopStepCardBody
+        step={step}
+        allSteps={[]}
+        tables={[]}
+        screens={[]}
+        commonGroups={[]}
+        onChange={noop}
+        onNavigateCommon={noop}
+      />,
+    );
+    expect(container.textContent).toContain("index 変数名");
+    const indexInput = container.querySelector('[data-field-path="collectionIndexName"] input') as HTMLInputElement | null;
+    expect(indexInput).not.toBeNull();
+    expect(indexInput?.value).toBe("idx");
+  });
 });
 
 // ── LogStepCardBody / AuditStepCardBody / TransactionScopeStepCardBody ──
@@ -406,6 +484,56 @@ describe("TransactionScopeStepCardBody", () => {
       />,
     );
     expect(container.firstChild).not.toBeNull();
+  });
+
+  // #1269 Phase B: outputBinding.expose UI 追加
+  it("outputBinding.expose input が描画され、設定済 expose が表示される (#1269 Phase B)", () => {
+    const step = baseStep({
+      kind: "transactionScope",
+      isolationLevel: "READ_COMMITTED",
+      propagation: "REQUIRED",
+      steps: [],
+      outputBinding: { name: "orderTx", expose: ["newOrder", "paymentReceipt"] },
+    });
+    const { container } = render(
+      <TransactionScopeStepCardBody
+        step={step}
+        allSteps={[]}
+        tables={[]}
+        screens={[]}
+        commonGroups={[]}
+        onChange={noop}
+        onNavigateCommon={noop}
+      />,
+    );
+    expect(container.textContent).toContain("TX 外参照可な変数");
+    const exposeInput = container.querySelector('[data-field-path="outputBinding.expose"] input') as HTMLInputElement | null;
+    expect(exposeInput).not.toBeNull();
+    expect(exposeInput?.value).toBe("newOrder, paymentReceipt");
+    expect(exposeInput?.disabled).toBe(false);
+  });
+
+  it("outputBinding.name が未設定だと expose input は disabled (#1269 Phase B)", () => {
+    const step = baseStep({
+      kind: "transactionScope",
+      isolationLevel: "READ_COMMITTED",
+      propagation: "REQUIRED",
+      steps: [],
+    });
+    const { container } = render(
+      <TransactionScopeStepCardBody
+        step={step}
+        allSteps={[]}
+        tables={[]}
+        screens={[]}
+        commonGroups={[]}
+        onChange={noop}
+        onNavigateCommon={noop}
+      />,
+    );
+    const exposeInput = container.querySelector('[data-field-path="outputBinding.expose"] input') as HTMLInputElement | null;
+    expect(exposeInput).not.toBeNull();
+    expect(exposeInput?.disabled).toBe(true);
   });
 });
 

--- a/frontend/src/components/process-flow/internal/step-cards/step-cards.test.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/step-cards.test.tsx
@@ -535,6 +535,63 @@ describe("TransactionScopeStepCardBody", () => {
     expect(exposeInput).not.toBeNull();
     expect(exposeInput?.disabled).toBe(true);
   });
+
+  // #1269 Phase B Round 1 S-2: expose onChange の payload 検証
+  it("expose input 変更で カンマ区切り parse + trim + 空項目除外 が動く (#1269 Phase B Round 1 S-2)", () => {
+    const onChange = vi.fn();
+    const step = baseStep({
+      kind: "transactionScope",
+      isolationLevel: "READ_COMMITTED",
+      propagation: "REQUIRED",
+      steps: [],
+      outputBinding: { name: "orderTx" },
+    });
+    const { container } = render(
+      <TransactionScopeStepCardBody
+        step={step}
+        allSteps={[]}
+        tables={[]}
+        screens={[]}
+        commonGroups={[]}
+        onChange={onChange}
+        onNavigateCommon={noop}
+      />,
+    );
+    const exposeInput = container.querySelector('[data-field-path="outputBinding.expose"] input') as HTMLInputElement;
+    fireEvent.change(exposeInput, { target: { value: "  newOrder ,  paymentReceipt , , empty " } });
+    expect(onChange).toHaveBeenCalled();
+    const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
+    expect(lastCall.outputBinding.name).toBe("orderTx");
+    expect(lastCall.outputBinding.expose).toEqual(["newOrder", "paymentReceipt", "empty"]);
+  });
+
+  it("expose を空文字に戻すと expose: undefined になり、name は保持される (#1269 Phase B Round 1 S-2)", () => {
+    const onChange = vi.fn();
+    const step = baseStep({
+      kind: "transactionScope",
+      isolationLevel: "READ_COMMITTED",
+      propagation: "REQUIRED",
+      steps: [],
+      outputBinding: { name: "orderTx", expose: ["newOrder"] },
+    });
+    const { container } = render(
+      <TransactionScopeStepCardBody
+        step={step}
+        allSteps={[]}
+        tables={[]}
+        screens={[]}
+        commonGroups={[]}
+        onChange={onChange}
+        onNavigateCommon={noop}
+      />,
+    );
+    const exposeInput = container.querySelector('[data-field-path="outputBinding.expose"] input') as HTMLInputElement;
+    fireEvent.change(exposeInput, { target: { value: "" } });
+    expect(onChange).toHaveBeenCalled();
+    const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
+    expect(lastCall.outputBinding.name).toBe("orderTx");
+    expect(lastCall.outputBinding.expose).toBeUndefined();
+  });
 });
 
 // ── JumpStepCardBody ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

[#1267](https://github.com/csilost2001/harmony/pull/1267) (Phase X2) で schema + TS 型に追加されたが UI 未対応だった 3 field の編集 input を ProcessFlow Editor に追加。これにより設計者が GUI から直接編集可能となり、JSON 直編集を回避できる。

Refs #1269 (4 sub-section の **Phase B 完了**、**Phase D** は #1272 で merge 済、Phase A / C は別 PR 予定)
Refs #1263 / #1254

## 対象 field と追加箇所

| field | 場所 | UI |
|---|---|---|
| `LoopStep.collectionIndexName` | `LoopStepCardBody.tsx` collection mode セクション | text input (Identifier / camelCase pattern + helper text) |
| `BranchCondition.tryCatch.errorVar` | `BranchStepCardBody.tsx` tryCatch variant section | text input (errorCode の右隣に並列配置、camelCase pattern) |
| `OutputBinding.expose` (transactionScope 専用) | `TransactionScopeStepPanel.tsx` (rollbackOn セクション直後) | カンマ区切り text input + 予約値 (`committed`/`error`/`diagnostics`) の説明、`outputBinding.name` 未設定時は disabled |

## 設計判断

- `errorVar` は tryCatch コンテナ内に errorCode と並列配置 (一体的に編集される)
- `collectionIndexName` は collection mode 内に新規行として追加 (任意フィールドのため最下段)
- `expose` は inner var 名のみ列挙、予約値 3 種 (`committed` / `error` / `diagnostics`) は明示宣言不要であることを inline 文書化
- `outputBinding.name` 未設定時は `expose` を編集できない (UI 上 disabled + ヘルプ文)、整合性 enforced

## 新規 test 5 件 (step-cards.test.tsx: 36 → 41)

- `collection loop で index 変数名 input が描画される`
- `tryCatch 分岐で errorVar input が描画される`
- `tryCatch errorVar 変更で onChange が errorCode を保持しつつ呼ばれる`
- `outputBinding.expose input が描画され、設定済 expose が表示される`
- `outputBinding.name が未設定だと expose input は disabled`

## Test 結果

- step-cards.test.tsx: 41 passed
- 全 unit test: 8 failed | 2480 passed | 1 skipped (failure は同 pre-existing english-learning のみ)
- Build: PASS

## Test plan

- [x] `cd frontend && npm run build` PASS
- [x] `cd frontend && npx vitest run src/components/process-flow/internal/step-cards/step-cards.test.tsx` 41/41 PASS
- [x] `cd frontend && npm run test:unit` 既存 8 fail 維持 (本 PR 無関係)

🤖 Generated with [Claude Code](https://claude.com/claude-code)