### PR TITLE
fix(examples): english-learning(+tailwind) viewer item に type 追加 — AJV failures 8 件解消 (#1268)

### DIFF
--- a/examples/english-learning-tailwind/harmony/screens/297e9117-0982-4a40-9ce7-bced3bc6d2c5.json
+++ b/examples/english-learning-tailwind/harmony/screens/297e9117-0982-4a40-9ce7-bced3bc6d2c5.json
@@ -30,6 +30,7 @@
     {
       "id": "sessionList",
       "label": "学習セッション一覧",
+      "type": { "kind": "array", "itemType": "json" },
       "direction": "viewer",
       "viewDefinitionId": "4c9cdc85-2537-4ca8-a979-4de21a56e0fa",
       "description": "フィルタ条件で絞り込んだ learning_sessions 一覧。学習履歴一覧 viewer (4c9cdc85) の列定義に従い story_title / started_at / status / 総合スコアを表示する。"

--- a/examples/english-learning-tailwind/harmony/screens/5f411f06-8677-4fa8-a9b2-edc14a1d9ce1.json
+++ b/examples/english-learning-tailwind/harmony/screens/5f411f06-8677-4fa8-a9b2-edc14a1d9ce1.json
@@ -49,6 +49,7 @@
     {
       "id": "storyList",
       "label": "ストーリー一覧",
+      "type": { "kind": "array", "itemType": "json" },
       "direction": "viewer",
       "viewDefinitionId": "cfdbf081-368d-4a33-8a36-1c7a0c535011",
       "description": "フィルタ条件で絞り込んだ stories 一覧。ストーリー一覧 viewer (cfdbf081) の列定義に従い title / cefr_level / scene_count を表示する。"

--- a/examples/english-learning-tailwind/harmony/screens/baddbabb-15e1-4f26-9f2b-0dc56b281019.json
+++ b/examples/english-learning-tailwind/harmony/screens/baddbabb-15e1-4f26-9f2b-0dc56b281019.json
@@ -14,6 +14,7 @@
     {
       "id": "packList",
       "label": "コンテンツパック一覧",
+      "type": { "kind": "array", "itemType": "json" },
       "direction": "viewer",
       "viewDefinitionId": "ba1c7d9d-5907-4535-99b9-f9fa170bb248",
       "description": "content_packs 一覧。コンテンツパック一覧 viewer (ba1c7d9d) の列定義に従い pack_name / namespace_ref / story_count / is_active を表示する。"

--- a/examples/english-learning-tailwind/harmony/screens/fbf3995f-487a-47a9-b5cd-9c48a632db8c.json
+++ b/examples/english-learning-tailwind/harmony/screens/fbf3995f-487a-47a9-b5cd-9c48a632db8c.json
@@ -38,6 +38,7 @@
     {
       "id": "wordList",
       "label": "単語一覧",
+      "type": { "kind": "array", "itemType": "json" },
       "direction": "viewer",
       "viewDefinitionId": "090e9db0-ce45-4fc4-9fa6-5784f655ca07",
       "description": "フィルタ条件で絞り込んだ user_word_progress JOIN words の一覧。単語帳 viewer (090e9db0) の列定義に従い単語 / 訳 / IPA / 習熟度 / 最終学習日を表示する。"

--- a/examples/english-learning/harmony/screens/297e9117-0982-4a40-9ce7-bced3bc6d2c5.json
+++ b/examples/english-learning/harmony/screens/297e9117-0982-4a40-9ce7-bced3bc6d2c5.json
@@ -30,6 +30,7 @@
     {
       "id": "sessionList",
       "label": "学習セッション一覧",
+      "type": { "kind": "array", "itemType": "json" },
       "direction": "viewer",
       "viewDefinitionId": "4c9cdc85-2537-4ca8-a979-4de21a56e0fa",
       "description": "フィルタ条件で絞り込んだ learning_sessions 一覧。学習履歴一覧 viewer (4c9cdc85) の列定義に従い story_title / started_at / status / 総合スコアを表示する。"

--- a/examples/english-learning/harmony/screens/5f411f06-8677-4fa8-a9b2-edc14a1d9ce1.json
+++ b/examples/english-learning/harmony/screens/5f411f06-8677-4fa8-a9b2-edc14a1d9ce1.json
@@ -49,6 +49,7 @@
     {
       "id": "storyList",
       "label": "ストーリー一覧",
+      "type": { "kind": "array", "itemType": "json" },
       "direction": "viewer",
       "viewDefinitionId": "cfdbf081-368d-4a33-8a36-1c7a0c535011",
       "description": "フィルタ条件で絞り込んだ stories 一覧。ストーリー一覧 viewer (cfdbf081) の列定義に従い title / cefr_level / scene_count を表示する。"

--- a/examples/english-learning/harmony/screens/baddbabb-15e1-4f26-9f2b-0dc56b281019.json
+++ b/examples/english-learning/harmony/screens/baddbabb-15e1-4f26-9f2b-0dc56b281019.json
@@ -14,6 +14,7 @@
     {
       "id": "packList",
       "label": "コンテンツパック一覧",
+      "type": { "kind": "array", "itemType": "json" },
       "direction": "viewer",
       "viewDefinitionId": "ba1c7d9d-5907-4535-99b9-f9fa170bb248",
       "description": "content_packs 一覧。コンテンツパック一覧 viewer (ba1c7d9d) の列定義に従い pack_name / namespace_ref / story_count / is_active を表示する。"

--- a/examples/english-learning/harmony/screens/fbf3995f-487a-47a9-b5cd-9c48a632db8c.json
+++ b/examples/english-learning/harmony/screens/fbf3995f-487a-47a9-b5cd-9c48a632db8c.json
@@ -38,6 +38,7 @@
     {
       "id": "wordList",
       "label": "単語一覧",
+      "type": { "kind": "array", "itemType": "json" },
       "direction": "viewer",
       "viewDefinitionId": "090e9db0-ce45-4fc4-9fa6-5784f655ca07",
       "description": "フィルタ条件で絞り込んだ user_word_progress JOIN words の一覧。単語帳 viewer (090e9db0) の列定義に従い単語 / 訳 / IPA / 習熟度 / 最終学習日を表示する。"


### PR DESCRIPTION
## Summary

`frontend/src/schemas/samples-v3.schema.test.ts` で pre-existing な 8 件 AJV validation fail を解消。

ScreenItem schema (`schemas/v3/screen-item.v3.schema.json` の `required: ["id", "label", "type"]`) を満たすため、english-learning + english-learning-tailwind の viewer item 8 件に `type: { kind: "array", itemType: "json" }` を追加。

## 変更内容

各対象 item (`direction: "viewer"` + `viewDefinitionId` を持つ) に以下を `label` 直後に追加:

\`\`\`json
"type": { "kind": "array", "itemType": "json" }
\`\`\`

### 採用方針 (ISSUE 提案 `"json"` ではなく `{ kind: "array", itemType: "json" }` を採用した理由)

他 examples の viewer item は `array<json>` 慣習 (grep 実測):

- examples/retail/harmony/screens/cff4a398-...json items[0]: `{ kind: "array", itemType: "json" }`
- examples/retail/harmony/screens/e6147dc0-...json items[4]: 同上
- examples/realestate/harmony/screens/b2f3a4c5-...json items[4]: 同上

viewer は配列データ表示 (ViewDefinition query 結果) のため `array<json>` が semantic に正確。

### Category B (fieldErrorsVar) について

ISSUE 起票時に挙げられていた validation step の `fieldErrorsVar` 欠落 2 件は **既に解消済み**。当該 process-flow (`examples/*/harmony/process-flows/6a49b14b-...json`) の `actions/0/steps/4` は `kind: english-learning:SttEvaluate` であり、`kind: validation` step は存在しない (Phase X1/X2/X3 #1263 等の構造変化で別解消)。本 PR スコープ外。

## 変更ファイル (8 件)

### english-learning
- examples/english-learning/harmony/screens/297e9117-... items[2] (sessionList)
- examples/english-learning/harmony/screens/5f411f06-... items[3] (storyList)
- examples/english-learning/harmony/screens/baddbabb-... items[0] (packList)
- examples/english-learning/harmony/screens/fbf3995f-... items[2] (wordList)

### english-learning-tailwind (同 4 ファイル、同 items index)

## 仕様逐条突合 (自己申告)

- ScreenItem schema `required: ["id", "label", "type"]` (schemas/v3/screen-item.v3.schema.json:14-18): 全 viewer item に `type` 付与 ✓
- FieldType array variant (schemas/v3/common.v3.schema.json `$defs/FieldType` oneOf 2nd entry): `{ kind: "array", itemType: <FieldType> }` 形式準拠 ✓
- 既存 viewer item 慣習 (examples/retail / realestate): `{ kind: "array", itemType: "json" }` 採用 ✓
- schema governance #511: `schemas/*.json` は無変更 (git diff --name-only で確認) ✓

## Test plan

- [x] `cd frontend && npx vitest run src/schemas/samples-v3.schema.test.ts` で 179/179 pass (8 fail → 0 fail) 確認済
- [x] `git diff --name-only origin/main..HEAD | grep schemas/` で schema 変更なし確認済

## 関連

- Closes #1268
- Refs #1267 (検出元 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)