### PR TITLE
feat(designer): #1260 Phase 3 — ErrorCatalog + ValidationRule に exceptionTypeRef bind UI

### DIFF
--- a/frontend/src/components/process-flow/ErrorCatalogPanel.test.tsx
+++ b/frontend/src/components/process-flow/ErrorCatalogPanel.test.tsx
@@ -1,0 +1,69 @@
+// #1260 Phase 3: ErrorCatalogPanel の exceptionTypeRef 入力欄追加の rendering / onChange test。
+
+import { describe, expect, it, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import type { ProcessFlow } from "../../types/v3";
+import { ErrorCatalogPanel } from "./ErrorCatalogPanel";
+
+function groupWith(errors: Record<string, Partial<{ httpStatus: number; defaultMessage: string; description: string; exceptionTypeRef: string }>>): ProcessFlow {
+  return {
+    schemaVersion: 3,
+    schemaUri: "",
+    actions: [],
+    context: { catalogs: { errors } },
+  } as unknown as ProcessFlow;
+}
+
+describe("ErrorCatalogPanel — exceptionTypeRef 入力欄 (#1260 B)", () => {
+  it("既存 entry に exceptionTypeRef 入力欄が描画される", () => {
+    const group = groupWith({
+      STOCK_SHORTAGE: { exceptionTypeRef: "generic-definitions/exception-type/StockShortage" },
+    });
+    const { container } = render(
+      <ErrorCatalogPanel group={group} onChange={() => {}} render="bodyOnly" />,
+    );
+    expect(container.textContent).toContain("exceptionTypeRef");
+    const input = container.querySelector(
+      'input[placeholder^="例: generic-definitions/exception-type/"]',
+    ) as HTMLInputElement;
+    expect(input).not.toBeNull();
+    expect(input.value).toBe("generic-definitions/exception-type/StockShortage");
+  });
+
+  it("exceptionTypeRef 変更で onChange が呼ばれる (raw storage 形式で保存)", () => {
+    const group = groupWith({
+      STOCK_SHORTAGE: {},
+    });
+    const onChange = vi.fn();
+    const { container } = render(
+      <ErrorCatalogPanel group={group} onChange={onChange} render="bodyOnly" />,
+    );
+    const input = container.querySelector(
+      'input[placeholder^="例: generic-definitions/exception-type/"]',
+    ) as HTMLInputElement;
+    fireEvent.change(input, {
+      target: { value: "generic-definitions/exception-type/Foo" },
+    });
+    expect(onChange).toHaveBeenCalled();
+    const lastCall = onChange.mock.calls.at(-1)![0] as ProcessFlow;
+    expect(lastCall.context?.catalogs?.errors?.STOCK_SHORTAGE.exceptionTypeRef).toBe(
+      "generic-definitions/exception-type/Foo",
+    );
+  });
+
+  it("空文字に戻すと exceptionTypeRef は undefined になる", () => {
+    const group = groupWith({
+      STOCK_SHORTAGE: { exceptionTypeRef: "generic-definitions/exception-type/Foo" },
+    });
+    const onChange = vi.fn();
+    const { container } = render(
+      <ErrorCatalogPanel group={group} onChange={onChange} render="bodyOnly" />,
+    );
+    const input = container.querySelector(
+      'input[placeholder^="例: generic-definitions/exception-type/"]',
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "" } });
+    const lastCall = onChange.mock.calls.at(-1)![0] as ProcessFlow;
+    expect(lastCall.context?.catalogs?.errors?.STOCK_SHORTAGE.exceptionTypeRef).toBeUndefined();
+  });
+});

--- a/frontend/src/components/process-flow/ErrorCatalogPanel.test.tsx
+++ b/frontend/src/components/process-flow/ErrorCatalogPanel.test.tsx
@@ -3,6 +3,24 @@
 import { describe, expect, it, vi } from "vitest";
 import { render, fireEvent } from "@testing-library/react";
 import type { ProcessFlow } from "../../types/v3";
+
+// useWorkspaceReferences が内部で WS / store I/O を呼ぶため test 環境では mock して
+// store fallback 削除等の将来変更で silent breakage しないよう固定する (S-1 review feedback)
+vi.mock("../../hooks/useWorkspaceReferences", () => ({
+  useWorkspaceReferences: () => ({
+    screens: [],
+    tables: [],
+    viewDefinitions: [],
+    processFlows: [],
+    fragments: [],
+    components: [],
+    exceptionTypes: [],
+    modelEndpoints: [],
+    secrets: [],
+    events: [],
+  }),
+}));
+
 import { ErrorCatalogPanel } from "./ErrorCatalogPanel";
 
 function groupWith(errors: Record<string, Partial<{ httpStatus: number; defaultMessage: string; description: string; exceptionTypeRef: string }>>): ProcessFlow {

--- a/frontend/src/components/process-flow/ErrorCatalogPanel.tsx
+++ b/frontend/src/components/process-flow/ErrorCatalogPanel.tsx
@@ -6,6 +6,12 @@
  */
 import { useState } from "react";
 import type { ProcessFlow, ErrorCatalogEntry, LocalId } from "../../types/v3";
+import { useWorkspaceReferences } from "../../hooks/useWorkspaceReferences";
+import { exceptionTypeRefResolver } from "../../utils/reference-completer/workspaceResolver";
+import { ReferenceCompletionInput } from "../common/ReferenceCompletionInput";
+
+// schema: `^generic-definitions/exception-type/[A-Za-z][A-Za-z0-9_]*$`
+const EXCEPTION_TYPE_REF_PREFIX = "generic-definitions/exception-type/";
 
 interface Props {
   group: ProcessFlow;
@@ -24,6 +30,7 @@ export function ErrorCatalogPanel({ group, onChange, expanded: expandedProp, onE
     onExpandedChange?.(next);
   };
   const [newKey, setNewKey] = useState("");
+  const workspace = useWorkspaceReferences();
   const catalog = group.context?.catalogs?.errors ?? {};
   const keys = Object.keys(catalog);
 
@@ -137,6 +144,18 @@ export function ErrorCatalogPanel({ group, onChange, expanded: expandedProp, onE
                       value={e.description ?? ""}
                       onChange={(ev) => updateEntry(k, { description: ev.target.value || undefined })}
                       placeholder="例: 引当 UPDATE で rowCount=0"
+                    />
+                  </label>
+                  <label className="catalog-wide">
+                    exceptionTypeRef
+                    <ReferenceCompletionInput
+                      className="form-control form-control-sm"
+                      value={e.exceptionTypeRef ?? ""}
+                      onValueChange={(v) => updateEntry(k, { exceptionTypeRef: v || undefined })}
+                      resolvers={[exceptionTypeRefResolver]}
+                      ctx={{ fieldKind: "exceptionTypeRef", workspace }}
+                      placeholder={`例: ${EXCEPTION_TYPE_REF_PREFIX}StockShortage`}
+                      style={{ fontFamily: "monospace", fontSize: "0.85rem" }}
                     />
                   </label>
                 </div>

--- a/frontend/src/components/process-flow/ValidationRulesPanel.test.tsx
+++ b/frontend/src/components/process-flow/ValidationRulesPanel.test.tsx
@@ -4,6 +4,24 @@
 import { describe, expect, it, vi } from "vitest";
 import { render, fireEvent } from "@testing-library/react";
 import type { ValidationRule } from "../../types/v3";
+
+// useWorkspaceReferences が内部で WS / store I/O を呼ぶため test 環境では mock して
+// store fallback 削除等の将来変更で silent breakage しないよう固定する (S-1 review feedback)
+vi.mock("../../hooks/useWorkspaceReferences", () => ({
+  useWorkspaceReferences: () => ({
+    screens: [],
+    tables: [],
+    viewDefinitions: [],
+    processFlows: [],
+    fragments: [],
+    components: [],
+    exceptionTypes: [],
+    modelEndpoints: [],
+    secrets: [],
+    events: [],
+  }),
+}));
+
 import { ValidationRulesPanel } from "./ValidationRulesPanel";
 
 describe("ValidationRulesPanel — severity + exceptionTypeRef (#1260 B)", () => {
@@ -55,6 +73,15 @@ describe("ValidationRulesPanel — severity + exceptionTypeRef (#1260 B)", () =>
     expect(onChange).toHaveBeenCalledWith([
       expect.not.objectContaining({ severity: expect.anything() }),
     ]);
+  });
+
+  it("rules 空 + 初期 collapsed で severity / exceptionTypeRef 入力欄は描画されない", () => {
+    // panel は useState(list.length > 0) で初期展開を決めるので空 rules は collapsed
+    const { container } = render(
+      <ValidationRulesPanel rules={[]} onChange={() => {}} />,
+    );
+    expect(container.querySelector('select[aria-label="severity"]')).toBeNull();
+    expect(container.querySelector('input[placeholder^="exceptionTypeRef"]')).toBeNull();
   });
 
   it("exceptionTypeRef 変更で onChange が呼ばれる (raw storage 形式)", () => {

--- a/frontend/src/components/process-flow/ValidationRulesPanel.test.tsx
+++ b/frontend/src/components/process-flow/ValidationRulesPanel.test.tsx
@@ -1,0 +1,78 @@
+// #1260 Phase 3: ValidationRulesPanel の severity + exceptionTypeRef 入力欄追加の rendering / onChange test。
+// severity は pre-existing silent drift (schema にあるが UI 未実装) を同 PR で吸収。
+
+import { describe, expect, it, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import type { ValidationRule } from "../../types/v3";
+import { ValidationRulesPanel } from "./ValidationRulesPanel";
+
+describe("ValidationRulesPanel — severity + exceptionTypeRef (#1260 B)", () => {
+  it("既存 rule に severity select + exceptionTypeRef 入力欄が描画される", () => {
+    const rules: ValidationRule[] = [
+      {
+        field: "quantity",
+        type: "required",
+        severity: "error",
+        exceptionTypeRef: "generic-definitions/exception-type/StockShortage",
+      } as ValidationRule,
+    ];
+    const { container } = render(
+      <ValidationRulesPanel rules={rules} onChange={() => {}} />,
+    );
+    const severitySelect = container.querySelector('select[aria-label="severity"]') as HTMLSelectElement;
+    expect(severitySelect).not.toBeNull();
+    expect(severitySelect.value).toBe("error");
+    const refInput = container.querySelector(
+      'input[placeholder^="exceptionTypeRef"]',
+    ) as HTMLInputElement;
+    expect(refInput).not.toBeNull();
+    expect(refInput.value).toBe("generic-definitions/exception-type/StockShortage");
+  });
+
+  it("severity 変更で onChange が呼ばれる", () => {
+    const rules: ValidationRule[] = [{ field: "x", type: "required" } as ValidationRule];
+    const onChange = vi.fn();
+    const { container } = render(
+      <ValidationRulesPanel rules={rules} onChange={onChange} />,
+    );
+    const select = container.querySelector('select[aria-label="severity"]') as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "msg" } });
+    expect(onChange).toHaveBeenCalledWith([
+      expect.objectContaining({ severity: "msg" }),
+    ]);
+  });
+
+  it("severity を未選択に戻すと undefined になる", () => {
+    const rules: ValidationRule[] = [
+      { field: "x", type: "required", severity: "error" } as ValidationRule,
+    ];
+    const onChange = vi.fn();
+    const { container } = render(
+      <ValidationRulesPanel rules={rules} onChange={onChange} />,
+    );
+    const select = container.querySelector('select[aria-label="severity"]') as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "" } });
+    expect(onChange).toHaveBeenCalledWith([
+      expect.not.objectContaining({ severity: expect.anything() }),
+    ]);
+  });
+
+  it("exceptionTypeRef 変更で onChange が呼ばれる (raw storage 形式)", () => {
+    const rules: ValidationRule[] = [{ field: "x", type: "required" } as ValidationRule];
+    const onChange = vi.fn();
+    const { container } = render(
+      <ValidationRulesPanel rules={rules} onChange={onChange} />,
+    );
+    const input = container.querySelector(
+      'input[placeholder^="exceptionTypeRef"]',
+    ) as HTMLInputElement;
+    fireEvent.change(input, {
+      target: { value: "generic-definitions/exception-type/Foo" },
+    });
+    expect(onChange).toHaveBeenCalledWith([
+      expect.objectContaining({
+        exceptionTypeRef: "generic-definitions/exception-type/Foo",
+      }),
+    ]);
+  });
+});

--- a/frontend/src/components/process-flow/ValidationRulesPanel.tsx
+++ b/frontend/src/components/process-flow/ValidationRulesPanel.tsx
@@ -2,6 +2,20 @@ import { useState } from "react";
 import type { ValidationRule, ValidationRuleType } from "../../types/v3";
 import type { ConventionsCatalog } from "../../schemas/conventionsValidator";
 import { ConvCompletionInput } from "../common/ConvCompletionInput";
+import { useWorkspaceReferences } from "../../hooks/useWorkspaceReferences";
+import { exceptionTypeRefResolver } from "../../utils/reference-completer/workspaceResolver";
+import { ReferenceCompletionInput } from "../common/ReferenceCompletionInput";
+
+// schema: `^generic-definitions/exception-type/[A-Za-z][A-Za-z0-9_]*$`
+const EXCEPTION_TYPE_REF_PREFIX = "generic-definitions/exception-type/";
+
+type Severity = NonNullable<ValidationRule["severity"]>;
+const SEVERITY_OPTIONS: Array<{ value: Severity; label: string }> = [
+  { value: "error", label: "error (ブロック)" },
+  { value: "msg", label: "msg (続行可)" },
+  { value: "noaccept", label: "noaccept (受け付けない)" },
+  { value: "default", label: "default (既定値設定)" },
+];
 
 interface Props {
   rules: ValidationRule[] | undefined;
@@ -26,6 +40,7 @@ const RULE_TYPES: Array<{ value: ValidationRuleType; label: string }> = [
 export function ValidationRulesPanel({ rules, onChange, conventions }: Props) {
   const list = rules ?? [];
   const [expanded, setExpanded] = useState(list.length > 0);
+  const workspace = useWorkspaceReferences();
 
   const addRule = () => {
     onChange([...list, { field: "", type: "required" }]);
@@ -175,6 +190,37 @@ export function ValidationRulesPanel({ rules, onChange, conventions }: Props) {
             >
               <i className="bi bi-x" />
             </button>
+          </div>
+          <div className="col-12 d-flex gap-1 mt-1" style={{ fontSize: "0.8rem" }}>
+            <div style={{ width: 180 }}>
+              <select
+                className="form-select form-select-sm"
+                value={r.severity ?? ""}
+                onChange={(e) =>
+                  updateRule(i, {
+                    severity: (e.target.value || undefined) as Severity | undefined,
+                  })
+                }
+                aria-label="severity"
+                style={{ fontSize: "0.8rem" }}
+              >
+                <option value="">severity —</option>
+                {SEVERITY_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>{o.label}</option>
+                ))}
+              </select>
+            </div>
+            <div className="flex-grow-1">
+              <ReferenceCompletionInput
+                className="form-control form-control-sm"
+                value={r.exceptionTypeRef ?? ""}
+                onValueChange={(v) => updateRule(i, { exceptionTypeRef: v || undefined })}
+                resolvers={[exceptionTypeRefResolver]}
+                ctx={{ fieldKind: "exceptionTypeRef", workspace }}
+                placeholder={`exceptionTypeRef (例: ${EXCEPTION_TYPE_REF_PREFIX}StockShortage)`}
+                style={{ fontFamily: "monospace", fontSize: "0.8rem" }}
+              />
+            </div>
           </div>
         </div>
       ))}


### PR DESCRIPTION
## Summary

ISSUE #1260 Phase 3 (sub-section **B** の `exceptionTypeRef` 部分) — schema 既存 / UI 未実装の silent drift を解消。

- `ErrorCatalogPanel.tsx`: 各 entry に `exceptionTypeRef` 入力欄を追加 (`ReferenceCompletionInput` + `exceptionTypeRefResolver`、raw storage = full path 形式)
- `ValidationRulesPanel.tsx`: 各 rule に `severity` select + `exceptionTypeRef` 入力欄を追加。`severity` は schema にあるが UI 未実装の pre-existing silent drift で、同 `rules[]` field なので memory `feedback_pr_scope_absorb_pre_existing.md` に従い同 PR で吸収
- `useWorkspaceReferences()` を両 component 内で direct call (既存 `ScreenItemsView` と同パターン)

bind 形式は既存 `componentRef` bind (PR #1259) に倣う raw storage (= full path `generic-definitions/exception-type/<Name>`)。candidate 選択時は `<Name>` のみが挿入されるため、ユーザーは prefix を手入力する想定 (componentRef と同じ既知 UX)。改善は別 ISSUE 案件。

## 着手前 audit の結果 (#1260 残件の再分類)

ISSUE 本文 (#1258 から継承) の B-remaining / C 前提と schema 現状にズレを発見し、本セッション開始時に [#1260 コメント](https://github.com/csilost2001/harmony/issues/1260#issuecomment-4526005832) で再分類を投稿:

| 項目 | ISSUE 本文の前提 | schema 現状 (audit) | 判定 |
|---|---|---|---|
| `exceptionTypeRef` | 「対応 step kind が schema に無く設計者承認必須」 | PR #1075 (#1066) で `ErrorCatalogEntry.exceptionTypeRef` / `ValidationRule.exceptionTypeRef` 追加済 | **本 PR で完了** |
| `extensionRef` | 「bind 先 field が確定していない」 | `FieldType.kind="extension".extensionRef` (`common.v3.schema.json:366-374`) が schema v3 初版から存在、ScreenItemsView で raw text 入力中 | scope 外 — 別 ISSUE 化候補 (関連 component 複数で設計判断必要) |
| `fragmentRef` | 「ProcessFlow 側で fragmentRef を使う step kind が未定義」 | 同じく未定義のまま | **真の議論先行 blocked** |

## 仕様逐条突合 (自己申告)

`ErrorCatalogPanel.tsx`:
- ☑ exceptionTypeRef 入力欄追加 (`ReferenceCompletionInput` + `exceptionTypeRefResolver`): `frontend/src/components/process-flow/ErrorCatalogPanel.tsx:142-154`
- ☑ raw storage (full path) パターン (componentRef bind 倣う): `:147-148`
- ☑ useWorkspaceReferences() mount 時 call: `:27`

`ValidationRulesPanel.tsx`:
- ☑ severity select 追加 (error/msg/noaccept/default): `frontend/src/components/process-flow/ValidationRulesPanel.tsx:201-217`
- ☑ exceptionTypeRef 入力欄追加: `:218-226`
- ☑ useWorkspaceReferences() mount 時 call: `:44`
- ☑ Severity 型は ValidationRule["severity"] から派生 (drift 防止): `:14`

test:
- ☑ `ErrorCatalogPanel.test.tsx` 新規 (3 件: 描画 / onChange / 空文字 undefined 化)
- ☑ `ValidationRulesPanel.test.tsx` 新規 (4 件: severity 描画 / severity onChange / severity undefined / exceptionTypeRef onChange)

## scope 外 (本 PR 後の処理)

- **C (extensionRef bind)**: 本 PR merge 後に別 ISSUE 起票判断をユーザーに提示。`FieldType.kind="extension".extensionRef` への補完は ScreenItemsView の type input が primitive / extension 混在の datalist 設計で、関連 component (ScreenItemCandidatesModal / ScreenItemPickerModal) に影響 → 設計判断必要 → 鉄則 2 該当 (別機能領域の改修規模)
- **B (fragmentRef)**: ProcessFlow schema に bind 先無し、議論先行で blocked、本 ISSUE で trace 継続

## 完了後の #1260 状態

| sub | 状態 |
|-----|------|
| A: ScreenItem events 編集 UI | ✅ Phase 1 完了 (#1261) |
| D: useWorkspaceReferences actions[] lazy load | ✅ Phase 1 完了 (#1261) |
| B (topic / secretRef) | ✅ Phase 2 完了 (#1262) |
| B (exceptionTypeRef) | 🔄 **本 PR (Phase 3) で完了** |
| B (fragmentRef) | ⏳ schema 議論先行で blocked |
| C (extensionRef) | ➡️ 別 ISSUE 化候補 (本 PR 後に判断) |

`Closes` ではなく `Refs` を使用 (残 B-fragmentRef / C-extensionRef のため #1260 は open 維持)。

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint` — pass
- [x] `npx vitest run src/components/process-flow src/components/screen-items` — 132/132 pass
- [x] 新規 test 単独実行 — 7/7 pass
- [ ] UI 動作確認: 別 session の独立レビュー (`/review-pr 1276`) で確認

Refs #1260

🤖 Generated with [Claude Code](https://claude.com/claude-code)