### PR TITLE
fix(reference-completer): #1260 follow-up — 3 generic-definition resolver の補完候補を full path 化

### DIFF
--- a/frontend/src/utils/reference-completer/workspaceResolver.test.ts
+++ b/frontend/src/utils/reference-completer/workspaceResolver.test.ts
@@ -176,33 +176,48 @@ describe("handlerActionIdResolver", () => {
 });
 
 describe("fragmentRefResolver", () => {
-  it("fieldKind='fragmentRef' → 全 fragment を返す", () => {
+  it("fieldKind='fragmentRef' → 全 fragment を full path 形式の value で返す", () => {
     const s = fragmentRefResolver.match("", 0, ctx("fragmentRef"));
     expect(s?.phase).toBe("active");
     if (s?.phase === "active") {
       expect(s.candidates).toHaveLength(2);
-      expect(s.candidates.map((c) => c.value)).toContain("HeaderFragment");
+      // schema: ^generic-definitions/ui-fragment/<Name>$ (補完 dropdown 選択時の schema 違反防止)
+      expect(s.candidates.map((c) => c.value)).toContain("generic-definitions/ui-fragment/HeaderFragment");
+      // label は短縮 name (表示用)
+      expect(s.candidates.map((c) => c.label)).toContain("HeaderFragment");
+    }
+  });
+  it("short name 入力 → label match で hit する", () => {
+    const s = fragmentRefResolver.match("Header", 0, ctx("fragmentRef"));
+    if (s?.phase === "active") {
+      expect(s.candidates.length).toBeGreaterThan(0);
+      expect(s.candidates[0].value).toMatch(/^generic-definitions\/ui-fragment\//);
     }
   });
 });
 
 describe("componentRefResolver", () => {
-  it("fieldKind='componentRef' → 全 component を返す", () => {
+  it("fieldKind='componentRef' → 全 component を full path 形式の value で返す", () => {
     const s = componentRefResolver.match("", 0, ctx("componentRef"));
     expect(s?.phase).toBe("active");
     if (s?.phase === "active") {
       expect(s.candidates).toHaveLength(2);
+      // schema: ^generic-definitions/component-definition/<Name>$
+      expect(s.candidates.every((c) => c.value.startsWith("generic-definitions/component-definition/"))).toBe(true);
+      expect(s.candidates.every((c) => typeof c.label === "string" && !c.label.includes("/"))).toBe(true);
     }
   });
 });
 
 describe("exceptionTypeRefResolver", () => {
-  it("fieldKind='exceptionTypeRef' → 全 exceptionType を返す", () => {
+  it("fieldKind='exceptionTypeRef' → 全 exceptionType を full path 形式の value で返す", () => {
     const s = exceptionTypeRefResolver.match("", 0, ctx("exceptionTypeRef"));
     expect(s?.phase).toBe("active");
     if (s?.phase === "active") {
       expect(s.candidates).toHaveLength(2);
-      expect(s.candidates.map((c) => c.value)).toContain("BusinessException");
+      // schema: ^generic-definitions/exception-type/<Name>$
+      expect(s.candidates.map((c) => c.value)).toContain("generic-definitions/exception-type/BusinessException");
+      expect(s.candidates.map((c) => c.label)).toContain("BusinessException");
     }
   });
 });

--- a/frontend/src/utils/reference-completer/workspaceResolver.test.ts
+++ b/frontend/src/utils/reference-completer/workspaceResolver.test.ts
@@ -203,8 +203,11 @@ describe("componentRefResolver", () => {
     if (s?.phase === "active") {
       expect(s.candidates).toHaveLength(2);
       // schema: ^generic-definitions/component-definition/<Name>$
+      // fragmentRef / exceptionTypeRef と同 symmetry の specific assertion (#1278 review S-1)
+      expect(s.candidates.map((c) => c.value)).toContain("generic-definitions/component-definition/SearchBox");
+      expect(s.candidates.find((c) => c.value.endsWith("/SearchBox"))?.label).toBe("SearchBox");
+      // 全件 schema pattern 適合の aggregate check (補強)
       expect(s.candidates.every((c) => c.value.startsWith("generic-definitions/component-definition/"))).toBe(true);
-      expect(s.candidates.every((c) => typeof c.label === "string" && !c.label.includes("/"))).toBe(true);
     }
   });
 });

--- a/frontend/src/utils/reference-completer/workspaceResolver.ts
+++ b/frontend/src/utils/reference-completer/workspaceResolver.ts
@@ -97,19 +97,38 @@ export const handlerActionIdResolver = makeIdResolver("handlerActionId", (ctx) =
   );
 });
 
-/** fragmentRef 補完: ui-fragment 汎用定義の name。 */
+// schema (process-flow.v3.schema.json / screen.v3.schema.json) は full path 形式必須:
+//   fragmentRef:      ^generic-definitions/ui-fragment/<Name>$
+//   componentRef:     ^generic-definitions/component-definition/<Name>$
+//   exceptionTypeRef: ^generic-definitions/exception-type/<Name>$
+// 補完 dropdown 選択時に short name のみ挿入すると schema 違反になるため、
+// value は full path、label は短縮表示用に name のみを保持する。
+const FRAGMENT_REF_PREFIX = "generic-definitions/ui-fragment/";
+const COMPONENT_REF_PREFIX = "generic-definitions/component-definition/";
+const EXCEPTION_TYPE_REF_PREFIX = "generic-definitions/exception-type/";
+
+/** fragmentRef 補完: ui-fragment 汎用定義 (value=full path, label=name)。 */
 export const fragmentRefResolver = makeIdResolver("fragmentRef", (ctx) =>
-  (ctx.workspace?.fragments ?? []).map((d) => ({ value: d.name })),
+  (ctx.workspace?.fragments ?? []).map((d) => ({
+    value: `${FRAGMENT_REF_PREFIX}${d.name}`,
+    label: d.name,
+  })),
 );
 
-/** componentRef 補完: component-definition 汎用定義の name。 */
+/** componentRef 補完: component-definition 汎用定義 (value=full path, label=name)。 */
 export const componentRefResolver = makeIdResolver("componentRef", (ctx) =>
-  (ctx.workspace?.components ?? []).map((d) => ({ value: d.name })),
+  (ctx.workspace?.components ?? []).map((d) => ({
+    value: `${COMPONENT_REF_PREFIX}${d.name}`,
+    label: d.name,
+  })),
 );
 
-/** exceptionTypeRef 補完: exception-type 汎用定義の name。 */
+/** exceptionTypeRef 補完: exception-type 汎用定義 (value=full path, label=name)。 */
 export const exceptionTypeRefResolver = makeIdResolver("exceptionTypeRef", (ctx) =>
-  (ctx.workspace?.exceptionTypes ?? []).map((d) => ({ value: d.name })),
+  (ctx.workspace?.exceptionTypes ?? []).map((d) => ({
+    value: `${EXCEPTION_TYPE_REF_PREFIX}${d.name}`,
+    label: d.name,
+  })),
 );
 
 /** modelRef 補完: projectCatalogs の modelEndpoints キー。 */


### PR DESCRIPTION
## Summary

PR #1277 (#1260 Phase 3) merge 後の独立レビュー iter-1 (本 session の Sonnet) で検出された Should-fix を別 PR で吸収。

- 並行 session で PR #1277 が先に merge された (`09c78a6d`、merge commit) ため、本 session の Sonnet review が指摘した resolver bug は main に残存
- 同 ISSUE #1260 由来の bug 修正のため Phase 3 follow-up として位置づけ
- `Refs #1260` (B-fragmentRef / C-extensionRef が残るため #1260 は open 維持、新規 trace 不要)

## 問題

`fragmentRefResolver` / `componentRefResolver` / `exceptionTypeRefResolver` の補完候補 value が schema pattern (`^generic-definitions/<kind>/<Name>$`) に違反する short name のみ (`d.name`) を返していた。

- 手入力 full path: 正しく保存される (placeholder で full path 提示、既存テストも full path で検証済)
- 補完 dropdown から選択: short name のみ挿入 → schema 違反

`componentRefResolver` は PR #1259 (#1258) 由来の pre-existing、`fragmentRefResolver` は #521 由来の pre-existing。`exceptionTypeRefResolver` は PR #1277 (#1260 Phase 3) で導入された UI bind から利用されたことで bug が顕在化。同 file 同根のため 3 件同時修正。

`secretRefResolver` (`@secret.<key>` 形式) と `topicResolver` / `modelRefResolver` (prefix なし) は別 semantic のため対象外。

## 修正

`frontend/src/utils/reference-completer/workspaceResolver.ts:100-130`

3 resolver の `value` を `\`generic-definitions/<kind>/\${d.name}\`` に変更、`label` に短縮 name を保持して dropdown 表示の可読性を維持。

```ts
const FRAGMENT_REF_PREFIX = "generic-definitions/ui-fragment/";
const COMPONENT_REF_PREFIX = "generic-definitions/component-definition/";
const EXCEPTION_TYPE_REF_PREFIX = "generic-definitions/exception-type/";

export const fragmentRefResolver = makeIdResolver("fragmentRef", (ctx) =>
  (ctx.workspace?.fragments ?? []).map((d) => ({
    value: `${FRAGMENT_REF_PREFIX}${d.name}`,
    label: d.name,
  })),
);
// 同様に componentRefResolver / exceptionTypeRefResolver も修正
```

`makeIdResolver` の filter は `value || label` 両方で includes match するため、ユーザーが short name (例: `Stock`) を type しても候補に hit する UX は維持される (テストで verify)。

## 仕様逐条突合 (自己申告)

`frontend/src/utils/reference-completer/workspaceResolver.ts`:
- ☑ FRAGMENT_REF_PREFIX 等の定数追加: `:106-108`
- ☑ fragmentRefResolver full path 化: `:111-117`
- ☑ componentRefResolver full path 化: `:120-126`
- ☑ exceptionTypeRefResolver full path 化: `:129-135`

`frontend/src/utils/reference-completer/workspaceResolver.test.ts`:
- ☑ fragmentRefResolver full path assertion 追加 + short name 入力 → label match test 追加: `:178-197`
- ☑ componentRefResolver full path assertion 追加 (every で全件検証): `:199-211`
- ☑ exceptionTypeRefResolver full path assertion 追加 (label 検証付き): `:213-223`

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vitest run src/utils/reference-completer src/components/process-flow src/components/screen-items` — 20 files / 189 tests pass (PR #1277 merge 後の 188 + 1 新規)
- [x] `npx eslint src/utils/reference-completer/workspaceResolver.{ts,test.ts}` — 0 errors
- [x] schema 変更ゼロ確認 (`gh pr diff` schemas/ 0 行) — governance #511 OK

## 経緯メモ (parallel session race)

本 session が PR #1277 の独立レビューを実施中、別 session が独自に独立レビューを実施し、test 堅牢性 (useWorkspaceReferences mock + 空 rules 描画 test) を S-1 / N-1 として指摘・修正・squash merge (`97dbbcd4` → `09c78a6d`) していた。

両 review は同じ S-1 番号で全く別観点を指摘していたため、本 session の指摘 (resolver schema 違反) は merge から漏れた。複数 session 並行運用時の race condition として memory に記録予定。

Refs #1260

🤖 Generated with [Claude Code](https://claude.com/claude-code)