### PR TITLE
feat(designer): #1260 Phase 4 — ScreenItem type 列 extensionRef 補完接続 (sub-section C 完了)

### DIFF
--- a/frontend/src/components/screen-items/ScreenItemsView.tsx
+++ b/frontend/src/components/screen-items/ScreenItemsView.tsx
@@ -41,6 +41,8 @@ import { mcpBridge } from "../../mcp/mcpBridge";
 import { useWorkspaceReferences } from "../../hooks/useWorkspaceReferences";
 import { ReferenceCompletionInput } from "../common/ReferenceCompletionInput";
 import { handlerFlowIdResolver, handlerActionIdResolver } from "../../utils/reference-completer/workspaceResolver";
+import { screenItemTypeResolver } from "./screenItemTypeResolver";
+import { loadExtensionsFromBundle, type LoadedExtensions } from "../../schemas/loadExtensions";
 import type {
   ScreenItem,
   ScreenItemEvent,
@@ -130,6 +132,21 @@ export function ScreenItemsView() {
   // 規約カタログをロード (初回のみ)
   useEffect(() => {
     loadConventions().then(setConventions).catch(console.error);
+  }, []);
+
+  // 拡張定義をロード (type 列 extensionRef 補完用、#1260 Phase 4)
+  const [extensions, setExtensions] = useState<LoadedExtensions | undefined>(undefined);
+  useEffect(() => {
+    mcpBridge
+      .getExtensions()
+      .then((bundle) => setExtensions(loadExtensionsFromBundle(bundle).extensions))
+      .catch(() => setExtensions(undefined));
+    return mcpBridge.onExtensionsChanged(() => {
+      mcpBridge
+        .getExtensions(true)
+        .then((bundle) => setExtensions(loadExtensionsFromBundle(bundle).extensions))
+        .catch(() => setExtensions(undefined));
+    });
   }, []);
 
   // ワークスペース全参照情報 (handlerFlowId / handlerActionId 補完用、#1260 A)
@@ -909,26 +926,25 @@ export function ScreenItemsView() {
                       />
                     </td>
                     <td>
-                      <input
-                        type="text"
-                        list="screen-items-type-list"
+                      <ReferenceCompletionInput
                         className="form-control form-control-sm"
                         value={typeof item.type === "string"
                           ? item.type
                           : item.type.kind === "extension"
                             ? item.type.extensionRef
                             : item.type.kind}
-                        onChange={(e) => {
-                          const v = e.target.value;
+                        onValueChange={(v) => {
                           if (v === "") {
                             handleUpdateItem(i, { type: "string" });
-                          } else if ((PRIMITIVE_TYPES as string[]).includes(v)) {
+                          } else if ((PRIMITIVE_TYPES as readonly string[]).includes(v)) {
                             handleUpdateItem(i, { type: v as FieldType });
                           } else {
                             handleUpdateItem(i, { type: { kind: "extension", extensionRef: v } });
                           }
                         }}
-                        onBlur={commit}
+                        onCommit={commit}
+                        resolvers={[screenItemTypeResolver]}
+                        ctx={{ fieldKind: "extensionRef", extensions }}
                         placeholder="string"
                         disabled={isReadonly}
                       />
@@ -1381,9 +1397,6 @@ export function ScreenItemsView() {
                 </button>
               )}
             </div>
-            <datalist id="screen-items-type-list">
-              {PRIMITIVE_TYPES.map((t) => <option key={t} value={t} />)}
-            </datalist>
             <datalist id="screen-items-display-format-list">
               {DISPLAY_FORMAT_PRESETS.map((f) => <option key={f} value={f} />)}
             </datalist>

--- a/frontend/src/components/screen-items/screenItemTypeResolver.test.ts
+++ b/frontend/src/components/screen-items/screenItemTypeResolver.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { screenItemTypeResolver } from "./screenItemTypeResolver";
+import type { CompletionContext } from "../../utils/reference-completer/types";
+import type { LoadedExtensions } from "../../schemas/loadExtensions";
+
+const mockExtensions: LoadedExtensions = {
+  steps: {},
+  fieldTypes: [
+    { kind: "productCode", label: "商品コード", namespace: "retail" },
+    { kind: "janCode", label: "JAN", namespace: "retail" },
+  ],
+  triggers: [],
+  dbOperations: [],
+  responseTypes: {},
+};
+
+const ctx = (extensions?: LoadedExtensions): CompletionContext => ({
+  fieldKind: "extensionRef",
+  extensions,
+});
+
+describe("screenItemTypeResolver", () => {
+  it("空 prefix → primitives + extensions 全候補", () => {
+    const r = screenItemTypeResolver.match("", 0, ctx(mockExtensions));
+    expect(r?.phase).toBe("active");
+    if (r?.phase === "active") {
+      const vals = r.candidates.map((c) => c.value);
+      expect(vals).toContain("string");
+      expect(vals).toContain("number");
+      expect(vals).toContain("retail:productCode");
+      expect(vals).toContain("retail:janCode");
+    }
+  });
+
+  it("\"str\" prefix → primitive filter", () => {
+    const r = screenItemTypeResolver.match("str", 3, ctx(mockExtensions));
+    if (r?.phase === "active") {
+      const vals = r.candidates.map((c) => c.value);
+      expect(vals).toEqual(["string"]);
+    }
+  });
+
+  it("\"retail\" prefix → extension filter", () => {
+    const r = screenItemTypeResolver.match("retail", 6, ctx(mockExtensions));
+    if (r?.phase === "active") {
+      const vals = r.candidates.map((c) => c.value);
+      expect(vals).toContain("retail:productCode");
+      expect(vals).toContain("retail:janCode");
+      expect(vals).not.toContain("string");
+    }
+  });
+
+  it("ctx.extensions が undefined → primitives のみ", () => {
+    const r = screenItemTypeResolver.match("", 0, ctx(undefined));
+    if (r?.phase === "active") {
+      const vals = r.candidates.map((c) => c.value);
+      expect(vals).toContain("string");
+      expect(vals).not.toContain("retail:productCode");
+    }
+  });
+});

--- a/frontend/src/components/screen-items/screenItemTypeResolver.test.ts
+++ b/frontend/src/components/screen-items/screenItemTypeResolver.test.ts
@@ -34,6 +34,7 @@ describe("screenItemTypeResolver", () => {
 
   it("\"str\" prefix → primitive filter", () => {
     const r = screenItemTypeResolver.match("str", 3, ctx(mockExtensions));
+    expect(r?.phase).toBe("active");
     if (r?.phase === "active") {
       const vals = r.candidates.map((c) => c.value);
       expect(vals).toEqual(["string"]);
@@ -42,6 +43,7 @@ describe("screenItemTypeResolver", () => {
 
   it("\"retail\" prefix → extension filter", () => {
     const r = screenItemTypeResolver.match("retail", 6, ctx(mockExtensions));
+    expect(r?.phase).toBe("active");
     if (r?.phase === "active") {
       const vals = r.candidates.map((c) => c.value);
       expect(vals).toContain("retail:productCode");
@@ -52,6 +54,7 @@ describe("screenItemTypeResolver", () => {
 
   it("ctx.extensions が undefined → primitives のみ", () => {
     const r = screenItemTypeResolver.match("", 0, ctx(undefined));
+    expect(r?.phase).toBe("active");
     if (r?.phase === "active") {
       const vals = r.candidates.map((c) => c.value);
       expect(vals).toContain("string");

--- a/frontend/src/components/screen-items/screenItemTypeResolver.ts
+++ b/frontend/src/components/screen-items/screenItemTypeResolver.ts
@@ -1,0 +1,48 @@
+/**
+ * 画面項目 type フィールド補完 Resolver (#1260 Phase 4)。
+ *
+ * primitive (string / number / ...) + fieldType extension (namespace:kind) を統合した候補を返す。
+ * fieldKind の制約なし (常に active を返す) で、ScreenItemsView の type 列専用として使用する。
+ */
+
+import type { Candidate, CompletionContext, Resolver } from "../../utils/reference-completer/types";
+import { PRIMITIVE_TYPES } from "./internal/screenItemsConstants";
+
+/** 画面項目 type フィールド用補完 Resolver。primitive + fieldType extension を統合する。 */
+export const screenItemTypeResolver: Resolver = {
+  id: "screenItemType",
+
+  match(value: string, _cursorPos: number, ctx: CompletionContext) {
+    const lower = value.toLowerCase();
+
+    const primitives: Candidate[] = (PRIMITIVE_TYPES as readonly string[]).map((t) => ({
+      value: t,
+      hint: "primitive",
+    }));
+
+    const extensions: Candidate[] = [];
+    const seen = new Set<string>();
+    for (const ft of ctx.extensions?.fieldTypes ?? []) {
+      if (ft.namespace) {
+        const full = `${ft.namespace}:${ft.kind}`;
+        if (!seen.has(full)) {
+          seen.add(full);
+          extensions.push({ value: full, hint: ft.label });
+        }
+      }
+    }
+
+    const all = [...primitives, ...extensions].filter((c) =>
+      c.value.toLowerCase().includes(lower) ||
+      (c.hint ?? "").toLowerCase().includes(lower),
+    );
+
+    return {
+      phase: "active",
+      resolverId: "screenItemType",
+      prefix: value,
+      candidates: all,
+      replaceLen: value.length,
+    };
+  },
+};

--- a/frontend/src/schemas/loadExtensions.ts
+++ b/frontend/src/schemas/loadExtensions.ts
@@ -14,6 +14,7 @@ export interface StepDef {
 export interface FieldTypeDef {
   kind: string;
   label: string;
+  namespace?: string;
 }
 
 export interface TriggerDef {
@@ -242,9 +243,10 @@ function loadFieldTypes(raw: unknown, extensions: LoadedExtensions, errors: Exte
     pushSchemaError(errors, "fieldTypes", "fieldTypes は array である必要があります");
     return;
   }
+  const namespace = file.namespace as string;
   for (const item of file.fieldTypes) {
     if (isRecord(item) && typeof item.kind === "string" && item.kind && typeof item.label === "string" && item.label) {
-      extensions.fieldTypes.push({ kind: item.kind, label: item.label });
+      extensions.fieldTypes.push({ kind: item.kind, label: item.label, namespace });
     } else {
       pushSchemaError(errors, "fieldTypes", "fieldTypes の各要素は kind と label が必要です");
     }


### PR DESCRIPTION
## Summary

ISSUE #1260 Phase 4 (sub-section C = extensionRef) — `ScreenItemsView.tsx` の type 列を `ReferenceCompletionInput` 化し、primitive + fieldType extension の補完を統合する。

### 変更内容

- **C-1**: `frontend/src/schemas/loadExtensions.ts:14-17, 246-249` — `FieldTypeDef.namespace?: string` 追加、`loadFieldTypes` で push 時に namespace 保持 (`mergeFieldTypes` の legacy code path は無変更 backward-compat)
- **C-2**: `frontend/src/components/screen-items/screenItemTypeResolver.ts` (新規 48 行) — primitive (string/number/integer/boolean/date/datetime/json) + fieldType extension (`namespace:kind`) を統合した補完 Resolver
- **C-3**: `frontend/src/components/screen-items/ScreenItemsView.tsx:44-45, 137-149, 928-947` — `ReferenceCompletionInput` 化 + `mcpBridge.getExtensions()` + `onExtensionsChanged` 経路で LoadedExtensions ロード (auto-refresh 対応)
- **C-4**: `frontend/src/components/screen-items/ScreenItemsView.tsx:1399-1401` — primitive datalist (`screen-items-type-list`) 削除 (popup に統合済)
- **C-5**: `frontend/src/components/screen-items/screenItemTypeResolver.test.ts` (新規 60 行) — 4 件 (空 prefix / "str" filter / "retail" filter / extensions undefined)

### スコープ判断

- 本 PR は **TS 型と UI のみ** 変更。`schemas/*.json` 不変 (governance #511 遵守、`git diff -- schemas/` 空を確認済)
- `PRIMITIVE_TYPES` は既存の `internal/screenItemsConstants.ts` から import (重複定義なし)
- `mergeFieldTypes` (loadExtensions.ts:415-) のレガシー code path は `def.kind` を bare のまま使う動作維持 → 既存 `loadExtensions.test.ts` の bare kind assert はそのまま pass

### B (fragmentRef) について (ISSUE close 時に注記)

ProcessFlow 側で fragmentRef を使う step kind は schema にも実用 use case にも未定義。`Screen.fragments[]` の編集 UI は #1067 系 (ui-fragment 機能) の責務範囲。本 ISSUE のスコープからは drop し、merge 後 #1260 close 時に注記する。

## Test plan

- [x] `npx tsc --noEmit` → 0 errors
- [x] `npm run lint` → pass
- [x] `npx vitest run src/components/screen-items/screenItemTypeResolver.test.ts src/schemas/loadExtensions.test.ts` → 16/16 pass
- [x] `npx vitest run src/schemas/loadExtensions src/utils/reference-completer src/components/screen-items` → 87/87 pass (9 files)
- [x] `git diff -- schemas/` → empty (governance #511 OK)

## 仕様逐条突合 (自己申告)

| step | 要件 | 実装箇所 | 判定 |
|------|------|----------|------|
| C-1 | `FieldTypeDef.namespace?` 追加 + `loadFieldTypes` で push 時 namespace 保持 | `loadExtensions.ts:17`, `:246` | ✓ |
| C-2 | primitive + fieldType extension を統合した Resolver 新設 | `screenItemTypeResolver.ts` 新規 | ✓ |
| C-3 | type 列を `ReferenceCompletionInput` 化 + LoadedExtensions ロード | `ScreenItemsView.tsx:137-149, 928-947` | ✓ |
| C-4 | primitive datalist 削除 | `ScreenItemsView.tsx:1397` (削除) | ✓ |
| C-5 | screenItemTypeResolver test (4 件) | `screenItemTypeResolver.test.ts` 新規 | ✓ |
| C-6 | tsc / lint / vitest 全 pass + schema diff 空 | 上記 Test plan で全 ✓ | ✓ |

Closes #1260

🤖 Generated with [Claude Code](https://claude.com/claude-code)
