### PR TITLE
feat(designer): #1282 — TemplateString 式 (@var/@secret/@screen.<id>.item.<id>) 補完接続

### DIFF
--- a/frontend/src/components/process-flow/StepCard.tsx
+++ b/frontend/src/components/process-flow/StepCard.tsx
@@ -771,6 +771,7 @@ export function StepCard({
               )}
 
               {/* #1260 Phase 2 sub-section B: eventPublish / eventSubscribe dispatch */}
+              {/* #1282: group + conventions を追加 (payload/filter resolver context 用) */}
               {step.kind === "eventPublish" && !isExtensionStep(step) && (
                 <EventPublishStepCardBody
                   step={step}
@@ -779,6 +780,8 @@ export function StepCard({
                   onCommit={onCommit}
                   readOnly={readOnly}
                   workspace={workspace}
+                  group={group}
+                  conventions={conventions}
                 />
               )}
 
@@ -790,6 +793,8 @@ export function StepCard({
                   onCommit={onCommit}
                   readOnly={readOnly}
                   workspace={workspace}
+                  group={group}
+                  conventions={conventions}
                 />
               )}
 

--- a/frontend/src/components/process-flow/internal/step-cards/EventPublishStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/EventPublishStepCardBody.tsx
@@ -1,15 +1,21 @@
-// #1260 Phase 2 sub-section B: EventPublish step に topic 補完 bind + payload plain textarea。
+// #1260 Phase 2 sub-section B: EventPublish step に topic 補完 bind + payload ReferenceCompletionTextarea。
 // topic は topicResolver (context.catalogs.events キー) で @reference 補完対応。
-// payload は式入力のため plain textarea (resolver 未対応)。
+// payload は式入力のため ReferenceCompletionTextarea で補完対応 (#1282)。
 
-import type { EventPublishStep, EventTopic } from "../../../../types/v3";
+import type { EventPublishStep, EventTopic, ProcessFlow, TemplateString } from "../../../../types/v3";
 import type { WorkspaceRefs } from "../../../../utils/reference-completer/types";
 import { topicResolver } from "../../../../utils/reference-completer/workspaceResolver";
+import { convResolver } from "../../../../utils/reference-completer/convResolver";
+import { ALL_PROCESS_FLOW_SCOPE_RESOLVERS } from "../../../../utils/reference-completer/processFlowScopeResolver";
 import { ReferenceCompletionInput } from "../../../common/ReferenceCompletionInput";
+import { ReferenceCompletionTextarea } from "../../../common/ReferenceCompletionTextarea";
+import type { ConventionsCatalog } from "../../../../schemas/conventionsValidator";
 import type { StepCardBodyBaseProps } from "./types";
 
 export interface EventPublishStepCardBodyProps extends StepCardBodyBaseProps<EventPublishStep> {
   workspace?: WorkspaceRefs;
+  group?: ProcessFlow | null;
+  conventions?: ConventionsCatalog | null;
 }
 
 export function EventPublishStepCardBody({
@@ -18,7 +24,11 @@ export function EventPublishStepCardBody({
   onCommit,
   readOnly,
   workspace,
+  group,
+  conventions,
 }: EventPublishStepCardBodyProps) {
+  const payloadResolvers = [convResolver, ...ALL_PROCESS_FLOW_SCOPE_RESOLVERS];
+  const payloadCtx = { conventions: conventions ?? null, flow: group ?? undefined, workspace };
   return (
     <>
       <div className="row g-2 mb-2">
@@ -46,15 +56,17 @@ export function EventPublishStepCardBody({
             <i className="bi bi-box-arrow-up me-1" />
             payload (式)
           </label>
-          <textarea
-            className="form-control form-control-sm"
-            rows={2}
+          <ReferenceCompletionTextarea
             value={step.payload ?? ""}
-            onChange={(e) => onChange({ payload: e.target.value || undefined })}
-            onBlur={onCommit}
-            placeholder="例: @input.order"
+            onValueChange={(v) => onChange({ payload: (v || undefined) as TemplateString | undefined })}
+            onCommit={onCommit}
+            resolvers={payloadResolvers}
+            ctx={payloadCtx}
+            className="form-control form-control-sm"
+            placeholder="例: { orderId: @var.action.order.id }"
             style={{ fontFamily: "monospace", fontSize: "0.85rem" }}
             disabled={readOnly}
+            rows={2}
           />
         </div>
       </div>

--- a/frontend/src/components/process-flow/internal/step-cards/EventSubscribeStepCardBody.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/EventSubscribeStepCardBody.tsx
@@ -1,15 +1,21 @@
-// #1260 Phase 2 sub-section B: EventSubscribe step に topic 補完 bind + filter plain textarea。
+// #1260 Phase 2 sub-section B: EventSubscribe step に topic 補完 bind + filter ReferenceCompletionTextarea。
 // topic は topicResolver (context.catalogs.events キー) で @reference 補完対応。
-// filter は式入力のため plain textarea (resolver 未対応)。
+// filter は式入力のため ReferenceCompletionTextarea で補完対応 (#1282)。
 
-import type { EventSubscribeStep, EventTopic } from "../../../../types/v3";
+import type { EventSubscribeStep, EventTopic, ProcessFlow, TemplateString } from "../../../../types/v3";
 import type { WorkspaceRefs } from "../../../../utils/reference-completer/types";
 import { topicResolver } from "../../../../utils/reference-completer/workspaceResolver";
+import { convResolver } from "../../../../utils/reference-completer/convResolver";
+import { ALL_PROCESS_FLOW_SCOPE_RESOLVERS } from "../../../../utils/reference-completer/processFlowScopeResolver";
 import { ReferenceCompletionInput } from "../../../common/ReferenceCompletionInput";
+import { ReferenceCompletionTextarea } from "../../../common/ReferenceCompletionTextarea";
+import type { ConventionsCatalog } from "../../../../schemas/conventionsValidator";
 import type { StepCardBodyBaseProps } from "./types";
 
 export interface EventSubscribeStepCardBodyProps extends StepCardBodyBaseProps<EventSubscribeStep> {
   workspace?: WorkspaceRefs;
+  group?: ProcessFlow | null;
+  conventions?: ConventionsCatalog | null;
 }
 
 export function EventSubscribeStepCardBody({
@@ -18,7 +24,11 @@ export function EventSubscribeStepCardBody({
   onCommit,
   readOnly,
   workspace,
+  group,
+  conventions,
 }: EventSubscribeStepCardBodyProps) {
+  const filterResolvers = [convResolver, ...ALL_PROCESS_FLOW_SCOPE_RESOLVERS];
+  const filterCtx = { conventions: conventions ?? null, flow: group ?? undefined, workspace };
   return (
     <>
       <div className="row g-2 mb-2">
@@ -46,15 +56,17 @@ export function EventSubscribeStepCardBody({
             <i className="bi bi-funnel me-1" />
             filter (式)
           </label>
-          <textarea
-            className="form-control form-control-sm"
-            rows={2}
+          <ReferenceCompletionTextarea
             value={step.filter ?? ""}
-            onChange={(e) => onChange({ filter: e.target.value || undefined })}
-            onBlur={onCommit}
+            onValueChange={(v) => onChange({ filter: (v || undefined) as TemplateString | undefined })}
+            onCommit={onCommit}
+            resolvers={filterResolvers}
+            ctx={filterCtx}
+            className="form-control form-control-sm"
             placeholder="例: @event.amount > 1000"
             style={{ fontFamily: "monospace", fontSize: "0.85rem" }}
             disabled={readOnly}
+            rows={2}
           />
         </div>
       </div>

--- a/frontend/src/components/process-flow/internal/step-cards/step-cards.test.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/step-cards.test.tsx
@@ -5,7 +5,8 @@
 // 詳細な振る舞いテストは元々 StepCard 系では薄かったため、本 PR では rendering 中心。
 
 import { describe, expect, it, vi } from "vitest";
-import { render, fireEvent } from "@testing-library/react";
+import { render, fireEvent, act } from "@testing-library/react";
+import { useState } from "react";
 import type { WorkspaceRefs } from "../../../../utils/reference-completer/types";
 import {
   AiAgentStepCardBody,
@@ -847,5 +848,85 @@ describe("ExternalSystemStepCardBody auth section", () => {
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({
       auth: expect.objectContaining({ kind: "bearer" }),
     }));
+  });
+});
+
+// ── EventPublishStepCardBody resolver popup (#1282) ─────────────────────────
+// ReferenceCompletionTextarea は controlled component のため、
+// wrapper component で useState 管理してリレンダリングを発火させる必要がある。
+
+function EventPublishWrapper() {
+  const [payload, setPayload] = useState<string | undefined>(undefined);
+  const step = baseStep({
+    kind: "eventPublish",
+    topic: "order.placed",
+    payload,
+  });
+  return (
+    <EventPublishStepCardBody
+      step={step}
+      allSteps={[]}
+      onChange={(changes) => {
+        if (changes.payload !== undefined || "payload" in changes) {
+          setPayload(changes.payload as string | undefined);
+        }
+      }}
+      workspace={mockWorkspace}
+    />
+  );
+}
+
+describe("EventPublishStepCardBody resolver popup (#1282)", () => {
+  it("payload textarea で @secret. 入力時に補完 popup が描画される", () => {
+    const { container } = render(<EventPublishWrapper />);
+    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+    expect(textarea).not.toBeNull();
+    // wrapper が onChange でリレンダリングして value="@secret." になる
+    // cursorPos は e.target.value.length = 8 にフォールバックされる
+    act(() => {
+      fireEvent.change(textarea, { target: { value: "@secret." } });
+    });
+    // secretPrefixResolver が stripeApiKey を candidates に返すので listbox が出現する
+    const listbox = container.querySelector('[role="listbox"]');
+    expect(listbox).not.toBeNull();
+  });
+});
+
+// ── EventSubscribeStepCardBody resolver popup (#1282) ────────────────────────
+
+function EventSubscribeWrapper() {
+  const [filter, setFilter] = useState<string | undefined>(undefined);
+  const step = baseStep({
+    kind: "eventSubscribe",
+    topic: "order.placed",
+    filter,
+  });
+  return (
+    <EventSubscribeStepCardBody
+      step={step}
+      allSteps={[]}
+      onChange={(changes) => {
+        if (changes.filter !== undefined || "filter" in changes) {
+          setFilter(changes.filter as string | undefined);
+        }
+      }}
+      workspace={mockWorkspace}
+    />
+  );
+}
+
+describe("EventSubscribeStepCardBody resolver popup (#1282)", () => {
+  it("filter textarea で @var. 入力時に補完 popup が描画される", () => {
+    const { container } = render(<EventSubscribeWrapper />);
+    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+    expect(textarea).not.toBeNull();
+    // wrapper が onChange でリレンダリングして value="@var." になる
+    // cursorPos は e.target.value.length = 5 にフォールバックされる
+    act(() => {
+      fireEvent.change(textarea, { target: { value: "@var." } });
+    });
+    // varScopeResolver が scope candidates を返すので listbox が出現する
+    const listbox = container.querySelector('[role="listbox"]');
+    expect(listbox).not.toBeNull();
   });
 });

--- a/frontend/src/components/process-flow/internal/step-cards/step-cards.test.tsx
+++ b/frontend/src/components/process-flow/internal/step-cards/step-cards.test.tsx
@@ -889,6 +889,10 @@ describe("EventPublishStepCardBody resolver popup (#1282)", () => {
     // secretPrefixResolver が stripeApiKey を candidates に返すので listbox が出現する
     const listbox = container.querySelector('[role="listbox"]');
     expect(listbox).not.toBeNull();
+    // S-4: listbox 内容 assert — stripeApiKey が candidate として表示される
+    expect(listbox?.textContent).toContain("stripeApiKey");
+    const options = container.querySelectorAll('[role="option"]');
+    expect(options.length).toBeGreaterThanOrEqual(1);
   });
 });
 
@@ -928,5 +932,10 @@ describe("EventSubscribeStepCardBody resolver popup (#1282)", () => {
     // varScopeResolver が scope candidates を返すので listbox が出現する
     const listbox = container.querySelector('[role="listbox"]');
     expect(listbox).not.toBeNull();
+    // S-4: listbox 内容 assert — scope enum が candidate として表示される
+    expect(listbox?.textContent).toContain("flowParameter");
+    expect(listbox?.textContent).toContain("action");
+    const options = container.querySelectorAll('[role="option"]');
+    expect(options.length).toBe(6); // 6 scope enum 全件
   });
 });

--- a/frontend/src/components/screen-items/ScreenItemsView.tsx
+++ b/frontend/src/components/screen-items/ScreenItemsView.tsx
@@ -41,6 +41,8 @@ import { mcpBridge } from "../../mcp/mcpBridge";
 import { useWorkspaceReferences } from "../../hooks/useWorkspaceReferences";
 import { ReferenceCompletionInput } from "../common/ReferenceCompletionInput";
 import { handlerFlowIdResolver, handlerActionIdResolver } from "../../utils/reference-completer/workspaceResolver";
+import { convResolver } from "../../utils/reference-completer/convResolver";
+import { screenHierarchicalResolver } from "../../utils/reference-completer/screenHierarchicalResolver";
 import { screenItemTypeResolver } from "./screenItemTypeResolver";
 import { loadExtensionsFromBundle, type LoadedExtensions } from "../../schemas/loadExtensions";
 import type {
@@ -1332,16 +1334,24 @@ export function ScreenItemsView() {
                                         disabled={isReadonly}
                                       />
                                       <span className="screen-items-event-mapping-eq">=</span>
-                                      <input
-                                        className="form-control form-control-sm"
+                                      {/* #1282: input → ReferenceCompletionInput (@screen.<id>.item.<id> / @conv 補完) */}
+                                      <ReferenceCompletionInput
                                         value={v}
-                                        onChange={(e) => {
+                                        onValueChange={(val) => {
                                           const next = { ...(ev.argumentMapping ?? {}) };
-                                          next[k as Identifier] = e.target.value as TemplateString;
+                                          next[k as Identifier] = val as TemplateString;
                                           handleUpdateEvent(i, eIdx, { argumentMapping: next });
                                         }}
-                                        onBlur={commit}
-                                        placeholder="@screen.email"
+                                        onCommit={commit}
+                                        resolvers={[screenHierarchicalResolver, convResolver]}
+                                        ctx={{
+                                          workspace,
+                                          conventions,
+                                          currentScreenId: screenId,
+                                          currentScreenItems: (file?.items ?? []).map((it) => ({ id: it.id, label: it.label })),
+                                        }}
+                                        className="form-control form-control-sm"
+                                        placeholder="@screen.<screenId>.item.<itemId>"
                                         disabled={isReadonly}
                                       />
                                       <button

--- a/frontend/src/utils/reference-completer/processFlowScopeResolver.ts
+++ b/frontend/src/utils/reference-completer/processFlowScopeResolver.ts
@@ -1,13 +1,17 @@
 /**
- * ProcessFlow スコープ式補完 Resolver 群 (Phase 3 / #1255)。
+ * ProcessFlow スコープ式補完 Resolver 群 (Phase 3 / #1255 + #1282)。
  *
  * @stepResult.<stepId>.<field> / @inputs.<name> / @fieldErrors.<field>
  * の 3 種類のスコープ式を補完する。
+ *
+ * #1282 で varScopeResolver / secretPrefixResolver を追加。
  *
  * ctx.flow に ProcessFlow が渡されている場合のみ動作する。
  */
 
 import type { Candidate, CompletionContext, CompletionState, Resolver } from "./types";
+import { varScopeResolver } from "./varScopeResolver";
+import { secretPrefixResolver } from "./secretPrefixResolver";
 
 /** @stepResult.<stepId>.<field> resolver。 */
 export const stepResultResolver: Resolver = {
@@ -182,4 +186,6 @@ export const ALL_PROCESS_FLOW_SCOPE_RESOLVERS: Resolver[] = [
   stepResultResolver,
   inputsResolver,
   fieldErrorsResolver,
+  varScopeResolver,        // #1282: @var.<scope>.<name>
+  secretPrefixResolver,    // #1282: @secret.<key>
 ];

--- a/frontend/src/utils/reference-completer/screenHierarchicalResolver.test.ts
+++ b/frontend/src/utils/reference-completer/screenHierarchicalResolver.test.ts
@@ -1,0 +1,83 @@
+// #1282: screenHierarchicalResolver unit tests (5 件)
+
+import { describe, expect, it } from "vitest";
+import { screenHierarchicalResolver } from "./screenHierarchicalResolver";
+import type { CompletionContext } from "./types";
+
+const ctx: CompletionContext = {
+  workspace: {
+    screens: [
+      { id: "login-screen", name: "ログイン画面", maturity: "committed" },
+      { id: "order-list", name: "注文一覧", maturity: "draft" },
+      { id: "order-detail", name: "注文詳細", maturity: "draft" },
+    ],
+    tables: [],
+    viewDefinitions: [],
+    processFlows: [],
+    fragments: [],
+    components: [],
+    exceptionTypes: [],
+    modelEndpoints: [],
+    secrets: [],
+    events: [],
+  },
+  currentScreenId: "login-screen",
+  currentScreenItems: [
+    { id: "username", label: "ユーザー名" },
+    { id: "password", label: "パスワード" },
+    { id: "loginButton", label: "ログインボタン" },
+  ],
+};
+
+describe("screenHierarchicalResolver", () => {
+  it("@screen. 入力時に全 screens を候補として返す", () => {
+    const value = "@screen.";
+    const state = screenHierarchicalResolver.match(value, value.length, ctx);
+    expect(state?.phase).toBe("active");
+    if (state?.phase !== "active") return;
+    expect(state.candidates).toHaveLength(3);
+    expect(state.candidates.map((c) => c.value)).toContain("login-screen");
+    expect(state.candidates[0].trailing).toBe(".item.");
+  });
+
+  it("@screen.order で prefix フィルタが効く", () => {
+    const value = "@screen.order";
+    const state = screenHierarchicalResolver.match(value, value.length, ctx);
+    expect(state?.phase).toBe("active");
+    if (state?.phase !== "active") return;
+    const values = state.candidates.map((c) => c.value);
+    expect(values).toContain("order-list");
+    expect(values).toContain("order-detail");
+    expect(values).not.toContain("login-screen");
+  });
+
+  it("@screen.login-screen.item. で現画面の items が候補になる", () => {
+    const value = "@screen.login-screen.item.";
+    const state = screenHierarchicalResolver.match(value, value.length, ctx);
+    expect(state?.phase).toBe("active");
+    if (state?.phase !== "active") return;
+    const values = state.candidates.map((c) => c.value);
+    expect(values).toContain("username");
+    expect(values).toContain("password");
+    expect(values).toContain("loginButton");
+  });
+
+  it("@screen.login-screen.item.user で prefix フィルタが効く", () => {
+    const value = "@screen.login-screen.item.user";
+    const state = screenHierarchicalResolver.match(value, value.length, ctx);
+    expect(state?.phase).toBe("active");
+    if (state?.phase !== "active") return;
+    expect(state.candidates).toHaveLength(1);
+    expect(state.candidates[0].value).toBe("username");
+    expect(state.candidates[0].label).toBe("ユーザー名");
+  });
+
+  it("他画面 (order-list) の items は空候補になる", () => {
+    const value = "@screen.order-list.item.";
+    const state = screenHierarchicalResolver.match(value, value.length, ctx);
+    expect(state?.phase).toBe("active");
+    if (state?.phase !== "active") return;
+    // 他画面は未ロードのため空候補
+    expect(state.candidates).toHaveLength(0);
+  });
+});

--- a/frontend/src/utils/reference-completer/screenHierarchicalResolver.ts
+++ b/frontend/src/utils/reference-completer/screenHierarchicalResolver.ts
@@ -41,11 +41,13 @@ export const screenHierarchicalResolver: Resolver = {
     if (m1) {
       const prefix = m1[1];
       const screens = ctx.workspace?.screens ?? [];
+      const lowerPrefix = prefix.toLowerCase();
       const candidates = screens
         .filter(
           (s) =>
+            prefix === "" ||
             s.id.startsWith(prefix) ||
-            s.name.toLowerCase().includes(prefix.toLowerCase()),
+            s.name.toLowerCase().includes(lowerPrefix),
         )
         .map((s) => ({
           value: s.id,

--- a/frontend/src/utils/reference-completer/screenHierarchicalResolver.ts
+++ b/frontend/src/utils/reference-completer/screenHierarchicalResolver.ts
@@ -1,0 +1,67 @@
+/**
+ * @screen.<screenId>.item.<itemId> 補完 Resolver (#1282)。
+ *
+ * Phase 1: @screen.<screenId> の補完 (workspace.screens より)。
+ * Phase 2: @screen.<screenId>.item.<itemId> の補完 (currentScreenItems より)。
+ *          他画面の items は未ロードのため空候補 (本 ISSUE では現画面のみ対応)。
+ *
+ * spec 出典: process-flow-prefix-system.md §3
+ */
+
+import type { CompletionContext, CompletionState, Resolver } from "./types";
+
+export const screenHierarchicalResolver: Resolver = {
+  id: "screenHierarchical",
+
+  match(value: string, cursorPos: number, ctx: CompletionContext): CompletionState | null {
+    const before = value.slice(0, cursorPos);
+
+    // Phase 2: @screen.<screenId>.item.<itemId> 補完
+    const m2 = before.match(/@screen\.([\w-]+)\.item\.([\w-]*)$/);
+    if (m2) {
+      const screenId = m2[1];
+      const itemPrefix = m2[2];
+      // 現画面のみ items 補完 (他画面は未ロードのため空候補)
+      const items =
+        screenId === ctx.currentScreenId ? (ctx.currentScreenItems ?? []) : [];
+      const candidates = items
+        .filter((i) => i.id.startsWith(itemPrefix))
+        .map((i) => ({ value: i.id, label: i.label ?? i.id }));
+      return {
+        phase: "active",
+        resolverId: "screenHierarchical",
+        prefix: itemPrefix,
+        candidates,
+        replaceLen: itemPrefix.length,
+      };
+    }
+
+    // Phase 1: @screen.<screenId> 補完
+    const m1 = before.match(/@screen\.([\w-]*)$/);
+    if (m1) {
+      const prefix = m1[1];
+      const screens = ctx.workspace?.screens ?? [];
+      const candidates = screens
+        .filter(
+          (s) =>
+            s.id.startsWith(prefix) ||
+            s.name.toLowerCase().includes(prefix.toLowerCase()),
+        )
+        .map((s) => ({
+          value: s.id,
+          label: s.name,
+          hint: s.maturity,
+          trailing: ".item.",
+        }));
+      return {
+        phase: "active",
+        resolverId: "screenHierarchical",
+        prefix,
+        candidates,
+        replaceLen: prefix.length,
+      };
+    }
+
+    return null;
+  },
+};

--- a/frontend/src/utils/reference-completer/secretPrefixResolver.test.ts
+++ b/frontend/src/utils/reference-completer/secretPrefixResolver.test.ts
@@ -1,0 +1,52 @@
+// #1282: secretPrefixResolver unit tests (3 件)
+
+import { describe, expect, it } from "vitest";
+import { secretPrefixResolver } from "./secretPrefixResolver";
+import type { CompletionContext } from "./types";
+
+const ctx: CompletionContext = {
+  workspace: {
+    screens: [],
+    tables: [],
+    viewDefinitions: [],
+    processFlows: [],
+    fragments: [],
+    components: [],
+    exceptionTypes: [],
+    modelEndpoints: [],
+    secrets: [
+      { id: "stripeApiKey", name: "Stripe API Key" },
+      { id: "awsSecretKey", name: "AWS Secret Key" },
+      { id: "slackToken", name: "Slack Token" },
+    ],
+    events: [],
+  },
+};
+
+describe("secretPrefixResolver", () => {
+  it("@secret. 入力時に全 secrets を候補として返す", () => {
+    const value = "@secret.";
+    const state = secretPrefixResolver.match(value, value.length, ctx);
+    expect(state?.phase).toBe("active");
+    if (state?.phase !== "active") return;
+    expect(state.candidates).toHaveLength(3);
+    expect(state.candidates.map((c) => c.value)).toContain("stripeApiKey");
+    expect(state.candidates.map((c) => c.value)).toContain("awsSecretKey");
+  });
+
+  it("@secret.stripe で prefix フィルタが効く", () => {
+    const value = "@secret.stripe";
+    const state = secretPrefixResolver.match(value, value.length, ctx);
+    expect(state?.phase).toBe("active");
+    if (state?.phase !== "active") return;
+    expect(state.candidates).toHaveLength(1);
+    expect(state.candidates[0].value).toBe("stripeApiKey");
+    expect(state.candidates[0].hint).toBe("Stripe API Key");
+  });
+
+  it("workspace がない場合は null を返す", () => {
+    const value = "@secret.stripe";
+    const state = secretPrefixResolver.match(value, value.length, {});
+    expect(state).toBeNull();
+  });
+});

--- a/frontend/src/utils/reference-completer/secretPrefixResolver.ts
+++ b/frontend/src/utils/reference-completer/secretPrefixResolver.ts
@@ -1,0 +1,33 @@
+/**
+ * @secret.<key> 補完 Resolver (#1282)。
+ *
+ * ctx.workspace.secrets の id 一覧を候補として返す。
+ * spec 出典: process-flow-expression-language.md §context.catalogs.secrets
+ */
+
+import type { CompletionContext, CompletionState, Resolver } from "./types";
+
+export const secretPrefixResolver: Resolver = {
+  id: "secret",
+
+  match(value: string, cursorPos: number, ctx: CompletionContext): CompletionState | null {
+    if (!ctx.workspace) return null;
+
+    const before = value.slice(0, cursorPos);
+    const m = before.match(/@secret\.([\w-]*)$/);
+    if (!m) return null;
+
+    const prefix = m[1];
+    const candidates = (ctx.workspace.secrets ?? [])
+      .filter((s) => s.id.startsWith(prefix))
+      .map((s) => ({ value: s.id, label: s.id, hint: s.name }));
+
+    return {
+      phase: "active",
+      resolverId: "secret",
+      prefix,
+      candidates,
+      replaceLen: prefix.length,
+    };
+  },
+};

--- a/frontend/src/utils/reference-completer/types.ts
+++ b/frontend/src/utils/reference-completer/types.ts
@@ -71,6 +71,10 @@ export interface CompletionContext {
   extensions?: LoadedExtensions;
   /** handlerActionId resolver: 対象 flow の id。 */
   handlerFlowId?: string;
+  /** 現在編集中の画面の画面項目一覧 (@screen.<id>.item.<id> resolver 用、#1282)。 */
+  currentScreenItems?: { id: string; label?: string }[];
+  /** 現在編集中の画面の screenId (@screen.<id>.item.<id> resolver 用、#1282)。 */
+  currentScreenId?: string;
 }
 
 /** 補完 Resolver インターフェース。 */

--- a/frontend/src/utils/reference-completer/varScopeResolver.test.ts
+++ b/frontend/src/utils/reference-completer/varScopeResolver.test.ts
@@ -31,7 +31,7 @@ const mockFlow = {
 const ctx: CompletionContext = { flow: mockFlow };
 
 describe("varScopeResolver", () => {
-  it("@var. 入力時に全 scope 候補を返す", () => {
+  it("@var. 入力で 6 scope enum 全件候補", () => {
     const value = "@var.";
     const state = varScopeResolver.match(value, value.length, ctx);
     expect(state?.phase).toBe("active");
@@ -40,7 +40,10 @@ describe("varScopeResolver", () => {
     expect(values).toContain("flowParameter");
     expect(values).toContain("action");
     expect(values).toContain("step");
+    expect(values).toContain("tx");
+    expect(values).toContain("loop");
     expect(values).toContain("global");
+    expect(values.length).toBe(6);
   });
 
   it("@var.flow で prefix フィルタが効く", () => {
@@ -78,5 +81,19 @@ describe("varScopeResolver", () => {
     expect(state?.phase).toBe("active");
     if (state?.phase !== "active") return;
     expect(state.candidates.map((c) => c.value)).toContain("orderResult");
+  });
+
+  // S-3: Phase 1 範囲固定 — step / tx の name 補完は Phase 2-bis 未対応
+  it("@var.step.<id> name 補完は Phase 2-bis 未対応のため候補なし", () => {
+    const value = "@var.step.foo";
+    const state = varScopeResolver.match(value, value.length, { flow: mockFlow });
+    // Phase 2 regex は (flowParameter|action) 限定のため null
+    expect(state).toBeNull();
+  });
+
+  it("@var.tx.<id> name 補完も Phase 2-bis 未対応のため候補なし", () => {
+    const value = "@var.tx.bar";
+    const state = varScopeResolver.match(value, value.length, { flow: mockFlow });
+    expect(state).toBeNull();
   });
 });

--- a/frontend/src/utils/reference-completer/varScopeResolver.test.ts
+++ b/frontend/src/utils/reference-completer/varScopeResolver.test.ts
@@ -1,0 +1,82 @@
+// #1282: varScopeResolver unit tests (5 件)
+
+import { describe, expect, it } from "vitest";
+import { varScopeResolver } from "./varScopeResolver";
+import type { CompletionContext } from "./types";
+import type { ProcessFlow as V3ProcessFlow } from "../../types/v3";
+
+// 最小限の ProcessFlow fixture
+const mockFlow = {
+  id: "flow-1",
+  name: "テストフロー",
+  actions: [
+    {
+      id: "action-1",
+      name: "処理1",
+      inputs: [
+        { name: "orderId", type: "string" },
+        { name: "userId", type: "string" },
+      ],
+      steps: [
+        {
+          id: "step-1",
+          kind: "dbAccess",
+          outputBinding: { name: "orderResult" },
+        },
+      ],
+    },
+  ],
+} as unknown as V3ProcessFlow;
+
+const ctx: CompletionContext = { flow: mockFlow };
+
+describe("varScopeResolver", () => {
+  it("@var. 入力時に全 scope 候補を返す", () => {
+    const value = "@var.";
+    const state = varScopeResolver.match(value, value.length, ctx);
+    expect(state?.phase).toBe("active");
+    if (state?.phase !== "active") return;
+    const values = state.candidates.map((c) => c.value);
+    expect(values).toContain("flowParameter");
+    expect(values).toContain("action");
+    expect(values).toContain("step");
+    expect(values).toContain("global");
+  });
+
+  it("@var.flow で prefix フィルタが効く", () => {
+    const value = "@var.flow";
+    const state = varScopeResolver.match(value, value.length, ctx);
+    expect(state?.phase).toBe("active");
+    if (state?.phase !== "active") return;
+    expect(state.candidates).toHaveLength(1);
+    expect(state.candidates[0].value).toBe("flowParameter");
+    expect(state.candidates[0].trailing).toBe(".");
+  });
+
+  it("@var.flowParameter. で flowParameter name 補完が返る", () => {
+    const value = "@var.flowParameter.";
+    const state = varScopeResolver.match(value, value.length, ctx);
+    expect(state?.phase).toBe("active");
+    if (state?.phase !== "active") return;
+    const values = state.candidates.map((c) => c.value);
+    expect(values).toContain("orderId");
+    expect(values).toContain("userId");
+  });
+
+  it("@var.flowParameter.order で prefix フィルタが効く", () => {
+    const value = "@var.flowParameter.order";
+    const state = varScopeResolver.match(value, value.length, ctx);
+    expect(state?.phase).toBe("active");
+    if (state?.phase !== "active") return;
+    expect(state.candidates).toHaveLength(1);
+    expect(state.candidates[0].value).toBe("orderId");
+  });
+
+  it("@var.action. で action outputBinding 名が候補になる", () => {
+    const value = "@var.action.";
+    const state = varScopeResolver.match(value, value.length, ctx);
+    expect(state?.phase).toBe("active");
+    if (state?.phase !== "active") return;
+    expect(state.candidates.map((c) => c.value)).toContain("orderResult");
+  });
+});

--- a/frontend/src/utils/reference-completer/varScopeResolver.ts
+++ b/frontend/src/utils/reference-completer/varScopeResolver.ts
@@ -1,0 +1,74 @@
+/**
+ * @var.<scope>.<name> 補完 Resolver (#1282)。
+ *
+ * Phase 1: scope (flowParameter / action / step / tx / loop / global) の補完 +
+ *           flowParameter / action の name 補完まで実装。
+ * Phase 2-bis (別 ISSUE): step.<id> / tx.<id> / loop / global の name 補完は未対応。
+ *
+ * spec 出典: process-flow-variables.md §3.6
+ */
+
+import type { CompletionContext, CompletionState, Resolver } from "./types";
+
+const SCOPE_KEYS = ["flowParameter", "action", "step", "tx", "loop", "global"] as const;
+
+export const varScopeResolver: Resolver = {
+  id: "var",
+
+  match(value: string, cursorPos: number, ctx: CompletionContext): CompletionState | null {
+    const before = value.slice(0, cursorPos);
+
+    // Phase 2: @var.flowParameter.<name> / @var.action.<name> の name 補完
+    const n = before.match(/@var\.(flowParameter|action)\.([\w-]*)$/);
+    if (n) {
+      if (!ctx.flow) return null;
+      const scope = n[1];
+      const namePrefix = n[2];
+      const names = new Set<string>();
+      if (scope === "flowParameter") {
+        for (const action of ctx.flow.actions) {
+          for (const inp of action.inputs ?? []) {
+            if (typeof inp.name === "string") names.add(inp.name);
+          }
+        }
+      } else if (scope === "action") {
+        for (const action of ctx.flow.actions) {
+          for (const step of action.steps ?? []) {
+            const stepAny = step as unknown as Record<string, unknown>;
+            const ob = stepAny.outputBinding as Record<string, unknown> | undefined;
+            if (ob?.name && typeof ob.name === "string") names.add(ob.name);
+          }
+        }
+      }
+      const candidates = [...names]
+        .filter((nm) => nm.startsWith(namePrefix))
+        .map((v) => ({ value: v }));
+      return {
+        phase: "active",
+        resolverId: "var",
+        prefix: namePrefix,
+        candidates,
+        replaceLen: namePrefix.length,
+      };
+    }
+
+    // Phase 1: @var.<scope> 補完 (scope は固定 enum)
+    const m = before.match(/@var\.([\w-]*)$/);
+    if (m) {
+      const prefix = m[1];
+      const candidates = SCOPE_KEYS.filter((k) => k.startsWith(prefix)).map((k) => ({
+        value: k,
+        trailing: ".",
+      }));
+      return {
+        phase: "active",
+        resolverId: "var",
+        prefix,
+        candidates,
+        replaceLen: prefix.length,
+      };
+    }
+
+    return null;
+  },
+};


### PR DESCRIPTION
## Summary

ISSUE #1282 — screen-item / step-card で TemplateString 式 (`@var.<scope>.<name>` / `@secret.<key>` / `@screen.<id>.item.<id>` 等) を入力時補完できるよう resolver + bind UI を整備。

### 変更内容 (commit `ee747aaa`)

#### 新規 resolver 3 件 (prefix-based)

- `secretPrefixResolver` — `@secret.<key>` 入力で `workspace.secrets` 候補
- `varScopeResolver` — `@var.<scope>` 6 enum (flowParameter / action / step / tx / loop / global)、`@var.flowParameter.<name>` / `@var.action.<name>` で flow 内 inputs / outputBinding name (Phase 1)
- `screenHierarchicalResolver` — `@screen.<screenId>` / `@screen.<id>.item.<itemId>`

#### bind UI 接続

- `EventPublishStepCardBody` / `EventSubscribeStepCardBody`: `<textarea>` → `<ReferenceCompletionTextarea>` 化、Props に `group?` / `conventions?` 追加
- `StepCard.tsx:774-797`: EventPublish/Subscribe dispatch に `group={group}` + `conventions={conventions}` 追加 (caller chain 漏れ修正)
- `ScreenItemsView.tsx:1335-1352`: argumentMapping value `<input>` → `<ReferenceCompletionInput>` (resolver = `[screenHierarchicalResolver, convResolver]`)

#### test (15 件新規 → 17 件 with S-fix)

- `secretPrefixResolver.test.ts` (3 件)
- `varScopeResolver.test.ts` (5 → 7 件 / S-1, S-3 で +2)
- `screenHierarchicalResolver.test.ts` (5 件)
- `step-cards.test.tsx` 拡張: popup 描画 + 内容 assert (2 件)

### 独立レビュー指摘の本 PR 内吸収 (commit `165605a0`)

別 context Opus レビューで Must-fix 0 / Should-fix 4 / Nit 3 を検出 → Should-fix 4 件すべて吸収:

- **S-1**: `varScopeResolver` test に 6 scope enum 全件 assert (`toContain` 6 件 + `length === 6`)
- **S-2**: `screenHierarchicalResolver` 空 prefix 時の冗長 `toLowerCase` 排除 (early-return optimization)
- **S-3**: `@var.step.<id>` / `@var.tx.<id>` が `null` を返すこと固定 (Phase 1 範囲 lock、Phase 2-bis 実装時の test signal)
- **S-4**: `step-cards.test.tsx` の popup test で `listbox.textContent` 内容 assert + `options.length` 検証

Nit 3 件 (docstring 充実) は軽微、本 PR スコープ厳守で skip → orchestrator が follow-up 判断。

### スコープ判断

- **`@self.<field>` / `@session.<key>` は scope-out**: spec governance #511 上 prefix 24 種 (`process-flow-prefix-system.md` / `process-flow-expression-language.md`) に明記なし、勝手に resolver 新設は権限外。必要なら別 ISSUE で spec 議論先行 → 起票判断は本 PR merge 後 orchestrator (鉄則 0 遵守)
- **`@var.step.<id>` / `@var.tx.<id>` / `@var.loop` / `@var.global` の name 補完は Phase 2-bis**: 本 PR は Phase 1 (flowParameter / action) のみ、scope 名止まり後はユーザー手書き
- **schema 変更なし** (governance #511 安全圏、`git diff -- schemas/` 0 行確認済)

## Test plan

- [x] `npx tsc --noEmit` → 0 errors
- [x] `npm run lint` → pass
- [x] `vitest run src/utils/reference-completer src/components/process-flow/internal/step-cards` → 116/116 pass (9 files)
- [x] `vitest run` (full) → 2575 passed + 1 skipped (regression なし。dogfood-1038-structure.test.ts 25 fail は origin/main でも同件数 pre-existing)
- [x] `git diff -- schemas/` → empty (governance #511 OK)

Closes #1282

🤖 Generated with [Claude Code](https://claude.com/claude-code)