### PR TITLE
feat(designer): #1281 — Screen.fragments[] 編集 UI 新設 + fragmentRef bind

### DIFF
--- a/frontend/src/components/screen-items/ScreenItemsView.tsx
+++ b/frontend/src/components/screen-items/ScreenItemsView.tsx
@@ -754,13 +754,18 @@ export function ScreenItemsView() {
     });
   }, [updateSilentWithDraft]);
 
-  // #1281: ui-fragment instance 一覧の更新ハンドラ
+  // #1281: ui-fragment instance 一覧の更新ハンドラ (S-1: silent update に分離し per-keystroke commit 解消)
+  // テキスト変更 (fragmentRef / instanceId の onChange) は silent update のみ → undo stack 肥大化防止
+  // 構造変更 (add/remove) は FragmentsPanel 内で onCommit を呼び commit 確定させる
   const handleFragmentsChange = useCallback((next: ScreenFragmentInstance[] | undefined) => {
-    updateWithDraft((f) => {
+    updateSilentWithDraft((f) => {
       f.fragments = next;
     });
+  }, [updateSilentWithDraft]);
+
+  const handleFragmentsCommit = useCallback(() => {
     commit();
-  }, [updateWithDraft, commit]);
+  }, [commit]);
 
   // ファイル切替時に選択・展開状態をリセット
   useEffect(() => {
@@ -874,6 +879,7 @@ export function ScreenItemsView() {
           <FragmentsPanel
             fragments={file.fragments ?? []}
             onChange={handleFragmentsChange}
+            onCommit={handleFragmentsCommit}
             readonly={isReadonly}
           />
           <div className="screen-items-table-wrap">

--- a/frontend/src/components/screen-items/ScreenItemsView.tsx
+++ b/frontend/src/components/screen-items/ScreenItemsView.tsx
@@ -49,6 +49,7 @@ import type {
   ScreenItem,
   ScreenItemEvent,
   ScreenItemEventEffect,
+  ScreenFragmentInstance,
   FieldType,
   Identifier,
   ProcessFlowId,
@@ -77,6 +78,7 @@ import {
   JS_IDENTIFIER_RE,
 } from "./internal/screenItemsConstants";
 import { OutputFields } from "./internal/sections/OutputFields";
+import { FragmentsPanel } from "./internal/sections/FragmentsPanel";
 
 type ScreenMeta = { id: string; name: string };
 
@@ -752,6 +754,14 @@ export function ScreenItemsView() {
     });
   }, [updateSilentWithDraft]);
 
+  // #1281: ui-fragment instance 一覧の更新ハンドラ
+  const handleFragmentsChange = useCallback((next: ScreenFragmentInstance[] | undefined) => {
+    updateWithDraft((f) => {
+      f.fragments = next;
+    });
+    commit();
+  }, [updateWithDraft, commit]);
+
   // ファイル切替時に選択・展開状態をリセット
   useEffect(() => {
     setSelectedIndices(new Set());
@@ -860,6 +870,12 @@ export function ScreenItemsView() {
               </ul>
             </div>
           )}
+          {/* #1281: ui-fragment 使用一覧 (collapsible、default collapsed) */}
+          <FragmentsPanel
+            fragments={file.fragments ?? []}
+            onChange={handleFragmentsChange}
+            readonly={isReadonly}
+          />
           <div className="screen-items-table-wrap">
             <table className="screen-items-table">
               <colgroup>

--- a/frontend/src/components/screen-items/internal/sections/FragmentsPanel.test.tsx
+++ b/frontend/src/components/screen-items/internal/sections/FragmentsPanel.test.tsx
@@ -35,7 +35,7 @@ describe("FragmentsPanel", () => {
   it("1. 既存 fragments が描画される (fragmentRef + instanceId 両方 input に値が入る)", () => {
     const frags = [makeFragment("generic-definitions/ui-fragment/messageArea", "errorArea")];
     const { container } = render(
-      <FragmentsPanel fragments={frags} onChange={() => {}} readonly={false} defaultExpanded />,
+      <FragmentsPanel fragments={frags} onChange={() => {}} onCommit={() => {}} readonly={false} defaultExpanded />,
     );
     const inputs = container.querySelectorAll("input");
     const fragmentRefInput = Array.from(inputs).find(
@@ -55,7 +55,7 @@ describe("FragmentsPanel", () => {
     const frags = [makeFragment("generic-definitions/ui-fragment/messageArea")];
     const onChange = vi.fn();
     const { container } = render(
-      <FragmentsPanel fragments={frags} onChange={onChange} readonly={false} defaultExpanded />,
+      <FragmentsPanel fragments={frags} onChange={onChange} onCommit={() => {}} readonly={false} defaultExpanded />,
     );
     const fragmentRefInput = Array.from(container.querySelectorAll("input")).find(
       (inp) => inp.placeholder.startsWith("例: generic-definitions/ui-fragment/"),
@@ -72,7 +72,7 @@ describe("FragmentsPanel", () => {
     const frags = [makeFragment("generic-definitions/ui-fragment/messageArea", "slot1")];
     const onChange = vi.fn();
     const { container } = render(
-      <FragmentsPanel fragments={frags} onChange={onChange} readonly={false} defaultExpanded />,
+      <FragmentsPanel fragments={frags} onChange={onChange} onCommit={() => {}} readonly={false} defaultExpanded />,
     );
     const instanceIdInput = Array.from(container.querySelectorAll("input")).find(
       (inp) => inp.placeholder === "例: errorArea",
@@ -83,11 +83,12 @@ describe("FragmentsPanel", () => {
     expect(result[0].instanceId).toBeUndefined();
   });
 
-  it("4. 追加ボタンで空欄 fragment 追加 (onChange 引数長 +1、最後の要素 {fragmentRef: ''})", () => {
+  it("4. 追加ボタンで空欄 fragment 追加 (onChange 引数長 +1、最後の要素 {fragmentRef: ''}、onCommit 呼出)", () => {
     const frags = [makeFragment("generic-definitions/ui-fragment/messageArea")];
     const onChange = vi.fn();
+    const onCommit = vi.fn();
     const { container } = render(
-      <FragmentsPanel fragments={frags} onChange={onChange} readonly={false} defaultExpanded />,
+      <FragmentsPanel fragments={frags} onChange={onChange} onCommit={onCommit} readonly={false} defaultExpanded />,
     );
     const addBtn = Array.from(container.querySelectorAll("button")).find(
       (btn) => btn.textContent?.includes("追加"),
@@ -98,13 +99,15 @@ describe("FragmentsPanel", () => {
     const result = onChange.mock.calls.at(-1)![0] as ScreenFragmentInstance[];
     expect(result).toHaveLength(2);
     expect(result.at(-1)).toEqual({ fragmentRef: "" });
+    expect(onCommit).toHaveBeenCalledOnce(); // 構造変更は commit が必要
   });
 
-  it("5. 削除ボタンで該当 fragment 除去 (最後の 1 件削除で undefined)", () => {
+  it("5. 削除ボタンで該当 fragment 除去 (最後の 1 件削除で undefined、onCommit 呼出)", () => {
     const frags = [makeFragment("generic-definitions/ui-fragment/messageArea")];
     const onChange = vi.fn();
+    const onCommit = vi.fn();
     const { container } = render(
-      <FragmentsPanel fragments={frags} onChange={onChange} readonly={false} defaultExpanded />,
+      <FragmentsPanel fragments={frags} onChange={onChange} onCommit={onCommit} readonly={false} defaultExpanded />,
     );
     const deleteBtn = Array.from(container.querySelectorAll("button")).find(
       (btn) => btn.title === "削除",
@@ -114,16 +117,27 @@ describe("FragmentsPanel", () => {
     expect(onChange).toHaveBeenCalled();
     const result = onChange.mock.calls.at(-1)![0];
     expect(result).toBeUndefined();
+    expect(onCommit).toHaveBeenCalledOnce(); // 構造変更は commit が必要
   });
 
   it("6. broken fragmentRef は warning icon (catalog 不在の name で warning)", () => {
     // "nonExistent" は mock catalog (messageArea / uploadRow) に存在しない
     const frags = [makeFragment("generic-definitions/ui-fragment/nonExistent")];
     const { container } = render(
-      <FragmentsPanel fragments={frags} onChange={() => {}} readonly={false} defaultExpanded />,
+      <FragmentsPanel fragments={frags} onChange={() => {}} onCommit={() => {}} readonly={false} defaultExpanded />,
     );
     const warningIcon = container.querySelector(".bi-exclamation-triangle.text-warning");
     expect(warningIcon).not.toBeNull();
+  });
+
+  it("6b. 空文字 fragmentRef は broken 扱いしない (新規追加直後の視覚ノイズ抑制、S-4)", () => {
+    // 追加直後は fragmentRef="" になる → broken badge を出さない
+    const frags = [makeFragment("")];
+    const { container } = render(
+      <FragmentsPanel fragments={frags} onChange={() => {}} onCommit={() => {}} readonly={false} defaultExpanded />,
+    );
+    const warningIcon = container.querySelector(".bi-exclamation-triangle.text-warning");
+    expect(warningIcon).toBeNull();
   });
 
   it("7. (fragmentRef, instanceId) ペア重複は warning icon (同一 pair の 2 件で両方 warning)", () => {
@@ -132,7 +146,7 @@ describe("FragmentsPanel", () => {
       makeFragment("generic-definitions/ui-fragment/messageArea", "slot1"),
     ];
     const { container } = render(
-      <FragmentsPanel fragments={frags} onChange={() => {}} readonly={false} defaultExpanded />,
+      <FragmentsPanel fragments={frags} onChange={() => {}} onCommit={() => {}} readonly={false} defaultExpanded />,
     );
     const warningIcons = container.querySelectorAll(".bi-exclamation-triangle.text-warning");
     expect(warningIcons.length).toBeGreaterThanOrEqual(2);
@@ -141,7 +155,7 @@ describe("FragmentsPanel", () => {
   it("8. readonly モードで input disabled + 追加/削除ボタン非表示", () => {
     const frags = [makeFragment("generic-definitions/ui-fragment/messageArea", "slot1")];
     const { container } = render(
-      <FragmentsPanel fragments={frags} onChange={() => {}} readonly defaultExpanded />,
+      <FragmentsPanel fragments={frags} onChange={() => {}} onCommit={() => {}} readonly defaultExpanded />,
     );
     // input は disabled になっている
     const inputs = container.querySelectorAll("input");

--- a/frontend/src/components/screen-items/internal/sections/FragmentsPanel.test.tsx
+++ b/frontend/src/components/screen-items/internal/sections/FragmentsPanel.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * FragmentsPanel unit tests (#1281)
+ *
+ * Screen.fragments[] CRUD + broken/重複 inline warning の rendering と onChange 契約を検証。
+ * useWorkspaceReferences の全 field を固定 mock して store I/O を排除する
+ * (ErrorCatalogPanel.test.tsx パターン踏襲)。
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import type { ScreenFragmentInstance } from "../../../../types/v3";
+
+// useWorkspaceReferences が内部で WS / store I/O を呼ぶため test 環境では mock する
+vi.mock("../../../../hooks/useWorkspaceReferences", () => ({
+  useWorkspaceReferences: () => ({
+    screens: [],
+    tables: [],
+    viewDefinitions: [],
+    processFlows: [],
+    fragments: [{ name: "messageArea" }, { name: "uploadRow" }],
+    components: [],
+    exceptionTypes: [],
+    modelEndpoints: [],
+    secrets: [],
+    events: [],
+  }),
+}));
+
+import { FragmentsPanel } from "./FragmentsPanel";
+
+function makeFragment(fragmentRef: string, instanceId?: string): ScreenFragmentInstance {
+  return instanceId !== undefined ? { fragmentRef, instanceId } : { fragmentRef };
+}
+
+describe("FragmentsPanel", () => {
+  it("1. 既存 fragments が描画される (fragmentRef + instanceId 両方 input に値が入る)", () => {
+    const frags = [makeFragment("generic-definitions/ui-fragment/messageArea", "errorArea")];
+    const { container } = render(
+      <FragmentsPanel fragments={frags} onChange={() => {}} readonly={false} defaultExpanded />,
+    );
+    const inputs = container.querySelectorAll("input");
+    const fragmentRefInput = Array.from(inputs).find(
+      (inp) => inp.placeholder.startsWith("例: generic-definitions/ui-fragment/"),
+    ) as HTMLInputElement | undefined;
+    expect(fragmentRefInput).not.toBeUndefined();
+    expect(fragmentRefInput!.value).toBe("generic-definitions/ui-fragment/messageArea");
+
+    const instanceIdInput = Array.from(inputs).find(
+      (inp) => inp.placeholder === "例: errorArea",
+    ) as HTMLInputElement | undefined;
+    expect(instanceIdInput).not.toBeUndefined();
+    expect(instanceIdInput!.value).toBe("errorArea");
+  });
+
+  it("2. fragmentRef 変更で onChange (full path 形式)", () => {
+    const frags = [makeFragment("generic-definitions/ui-fragment/messageArea")];
+    const onChange = vi.fn();
+    const { container } = render(
+      <FragmentsPanel fragments={frags} onChange={onChange} readonly={false} defaultExpanded />,
+    );
+    const fragmentRefInput = Array.from(container.querySelectorAll("input")).find(
+      (inp) => inp.placeholder.startsWith("例: generic-definitions/ui-fragment/"),
+    ) as HTMLInputElement;
+    fireEvent.change(fragmentRefInput, {
+      target: { value: "generic-definitions/ui-fragment/uploadRow" },
+    });
+    expect(onChange).toHaveBeenCalled();
+    const result = onChange.mock.calls.at(-1)![0] as ScreenFragmentInstance[];
+    expect(result[0].fragmentRef).toBe("generic-definitions/ui-fragment/uploadRow");
+  });
+
+  it("3. instanceId 空文字 → undefined", () => {
+    const frags = [makeFragment("generic-definitions/ui-fragment/messageArea", "slot1")];
+    const onChange = vi.fn();
+    const { container } = render(
+      <FragmentsPanel fragments={frags} onChange={onChange} readonly={false} defaultExpanded />,
+    );
+    const instanceIdInput = Array.from(container.querySelectorAll("input")).find(
+      (inp) => inp.placeholder === "例: errorArea",
+    ) as HTMLInputElement;
+    fireEvent.change(instanceIdInput, { target: { value: "" } });
+    expect(onChange).toHaveBeenCalled();
+    const result = onChange.mock.calls.at(-1)![0] as ScreenFragmentInstance[];
+    expect(result[0].instanceId).toBeUndefined();
+  });
+
+  it("4. 追加ボタンで空欄 fragment 追加 (onChange 引数長 +1、最後の要素 {fragmentRef: ''})", () => {
+    const frags = [makeFragment("generic-definitions/ui-fragment/messageArea")];
+    const onChange = vi.fn();
+    const { container } = render(
+      <FragmentsPanel fragments={frags} onChange={onChange} readonly={false} defaultExpanded />,
+    );
+    const addBtn = Array.from(container.querySelectorAll("button")).find(
+      (btn) => btn.textContent?.includes("追加"),
+    );
+    expect(addBtn).not.toBeUndefined();
+    fireEvent.click(addBtn!);
+    expect(onChange).toHaveBeenCalled();
+    const result = onChange.mock.calls.at(-1)![0] as ScreenFragmentInstance[];
+    expect(result).toHaveLength(2);
+    expect(result.at(-1)).toEqual({ fragmentRef: "" });
+  });
+
+  it("5. 削除ボタンで該当 fragment 除去 (最後の 1 件削除で undefined)", () => {
+    const frags = [makeFragment("generic-definitions/ui-fragment/messageArea")];
+    const onChange = vi.fn();
+    const { container } = render(
+      <FragmentsPanel fragments={frags} onChange={onChange} readonly={false} defaultExpanded />,
+    );
+    const deleteBtn = Array.from(container.querySelectorAll("button")).find(
+      (btn) => btn.title === "削除",
+    );
+    expect(deleteBtn).not.toBeUndefined();
+    fireEvent.click(deleteBtn!);
+    expect(onChange).toHaveBeenCalled();
+    const result = onChange.mock.calls.at(-1)![0];
+    expect(result).toBeUndefined();
+  });
+
+  it("6. broken fragmentRef は warning icon (catalog 不在の name で warning)", () => {
+    // "nonExistent" は mock catalog (messageArea / uploadRow) に存在しない
+    const frags = [makeFragment("generic-definitions/ui-fragment/nonExistent")];
+    const { container } = render(
+      <FragmentsPanel fragments={frags} onChange={() => {}} readonly={false} defaultExpanded />,
+    );
+    const warningIcon = container.querySelector(".bi-exclamation-triangle.text-warning");
+    expect(warningIcon).not.toBeNull();
+  });
+
+  it("7. (fragmentRef, instanceId) ペア重複は warning icon (同一 pair の 2 件で両方 warning)", () => {
+    const frags = [
+      makeFragment("generic-definitions/ui-fragment/messageArea", "slot1"),
+      makeFragment("generic-definitions/ui-fragment/messageArea", "slot1"),
+    ];
+    const { container } = render(
+      <FragmentsPanel fragments={frags} onChange={() => {}} readonly={false} defaultExpanded />,
+    );
+    const warningIcons = container.querySelectorAll(".bi-exclamation-triangle.text-warning");
+    expect(warningIcons.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("8. readonly モードで input disabled + 追加/削除ボタン非表示", () => {
+    const frags = [makeFragment("generic-definitions/ui-fragment/messageArea", "slot1")];
+    const { container } = render(
+      <FragmentsPanel fragments={frags} onChange={() => {}} readonly defaultExpanded />,
+    );
+    // input は disabled になっている
+    const inputs = container.querySelectorAll("input");
+    inputs.forEach((inp) => {
+      expect(inp.disabled).toBe(true);
+    });
+    // 追加/削除ボタンは存在しない
+    const deleteBtn = Array.from(container.querySelectorAll("button")).find(
+      (btn) => btn.title === "削除",
+    );
+    expect(deleteBtn).toBeUndefined();
+    const addBtn = Array.from(container.querySelectorAll("button")).find(
+      (btn) => btn.textContent?.includes("追加"),
+    );
+    expect(addBtn).toBeUndefined();
+  });
+});

--- a/frontend/src/components/screen-items/internal/sections/FragmentsPanel.tsx
+++ b/frontend/src/components/screen-items/internal/sections/FragmentsPanel.tsx
@@ -1,0 +1,161 @@
+/**
+ * FragmentsPanel — Screen が使用する ui-fragment instance 一覧の編集パネル (#1281)。
+ *
+ * Screen.fragments[] (ScreenFragmentInstance[]) の CRUD + fragmentRef 補完 +
+ * broken / 重複 inline warning を提供。ScreenItemsView.tsx 内に collapsible panel として挿入。
+ *
+ * 参考: schemas/v3/screen.v3.schema.json#/$defs/ScreenFragmentInstance
+ *       docs/spec/generic-definition-layer.md §3.6
+ */
+import { useState, useMemo } from "react";
+import type { ScreenFragmentInstance } from "../../../../types/v3";
+import { useWorkspaceReferences } from "../../../../hooks/useWorkspaceReferences";
+import { fragmentRefResolver } from "../../../../utils/reference-completer/workspaceResolver";
+import { ReferenceCompletionInput } from "../../../common/ReferenceCompletionInput";
+
+// schema: `^generic-definitions/ui-fragment/[A-Za-z][A-Za-z0-9_]*$`
+const FRAGMENT_REF_PREFIX = "generic-definitions/ui-fragment/";
+
+interface Props {
+  fragments: ScreenFragmentInstance[];
+  onChange: (next: ScreenFragmentInstance[] | undefined) => void;
+  readonly: boolean;
+  defaultExpanded?: boolean;
+}
+
+export function FragmentsPanel({ fragments, onChange, readonly, defaultExpanded = false }: Props) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const workspace = useWorkspaceReferences();
+
+  const fragmentNameSet = useMemo(
+    () => new Set(workspace.fragments.map((f) => f.name)),
+    [workspace.fragments],
+  );
+
+  /** catalog 不在の fragmentRef を持つ index の集合 */
+  const brokenIdx = useMemo(() => {
+    const broken = new Set<number>();
+    fragments.forEach((f, i) => {
+      const m = f.fragmentRef.match(/^generic-definitions\/ui-fragment\/([A-Za-z][A-Za-z0-9_]*)$/);
+      if (!m || !fragmentNameSet.has(m[1])) broken.add(i);
+    });
+    return broken;
+  }, [fragments, fragmentNameSet]);
+
+  /** (fragmentRef, instanceId) ペアが重複している index の集合 */
+  const dupIdx = useMemo(() => {
+    const seen = new Map<string, number>();
+    const dups = new Set<number>();
+    fragments.forEach((f, i) => {
+      const key = `${f.fragmentRef}:${f.instanceId ?? ""}`;
+      const prev = seen.get(key);
+      if (prev !== undefined) {
+        dups.add(i);
+        dups.add(prev);
+      } else {
+        seen.set(key, i);
+      }
+    });
+    return dups;
+  }, [fragments]);
+
+  const updateAt = (i: number, patch: Partial<ScreenFragmentInstance>) => {
+    const next = fragments.map((f, idx) => (idx === i ? { ...f, ...patch } : f));
+    onChange(next);
+  };
+
+  const removeAt = (i: number) => {
+    const next = fragments.filter((_, idx) => idx !== i);
+    onChange(next.length > 0 ? next : undefined);
+  };
+
+  const add = () => {
+    onChange([...fragments, { fragmentRef: "" }]);
+  };
+
+  return (
+    <div className="catalog-panel fragments-panel">
+      <button
+        type="button"
+        className="catalog-panel-toggle"
+        onClick={() => setExpanded((v) => !v)}
+      >
+        <i className={`bi bi-chevron-${expanded ? "down" : "right"}`} />
+        <i className="bi bi-puzzle" />
+        {" "}使用する UI fragment ({fragments.length} 件)
+        {brokenIdx.size > 0 && (
+          <span className="badge bg-warning text-dark ms-2">
+            broken {brokenIdx.size}
+          </span>
+        )}
+      </button>
+      {expanded && (
+        <div className="catalog-panel-body">
+          {fragments.length === 0 && (
+            <div className="catalog-empty">使用中の fragment はありません。</div>
+          )}
+          {fragments.map((f, i) => (
+            <div className="catalog-row fragments-panel-row" key={i}>
+              <div className="catalog-row-fields">
+                <label className="catalog-wide">
+                  fragmentRef
+                  <ReferenceCompletionInput
+                    className="form-control form-control-sm"
+                    value={f.fragmentRef}
+                    onValueChange={(v) => updateAt(i, { fragmentRef: v })}
+                    resolvers={[fragmentRefResolver]}
+                    ctx={{ fieldKind: "fragmentRef", workspace }}
+                    placeholder={`例: ${FRAGMENT_REF_PREFIX}messageArea`}
+                    style={{ fontFamily: "monospace", fontSize: "0.85rem" }}
+                    disabled={readonly}
+                  />
+                </label>
+                <label>
+                  instanceId
+                  <input
+                    className="form-control form-control-sm"
+                    value={f.instanceId ?? ""}
+                    onChange={(e) => updateAt(i, { instanceId: e.target.value || undefined })}
+                    placeholder="例: errorArea"
+                    disabled={readonly}
+                  />
+                </label>
+                <label>
+                  {brokenIdx.has(i) && (
+                    <i
+                      className="bi bi-exclamation-triangle text-warning"
+                      title="catalog に存在しない fragmentRef"
+                    />
+                  )}
+                  {dupIdx.has(i) && (
+                    <i
+                      className="bi bi-exclamation-triangle text-warning"
+                      title="(fragmentRef, instanceId) ペアが重複"
+                    />
+                  )}
+                  {!readonly && (
+                    <button
+                      type="button"
+                      className="btn btn-sm btn-link text-danger"
+                      onClick={() => removeAt(i)}
+                      title="削除"
+                    >
+                      <i className="bi bi-trash" />
+                    </button>
+                  )}
+                </label>
+              </div>
+            </div>
+          ))}
+          {!readonly && (
+            <div className="catalog-row catalog-row-add">
+              <button type="button" className="btn btn-sm btn-outline-primary" onClick={add}>
+                <i className="bi bi-plus-lg" /> 追加
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/screen-items/internal/sections/FragmentsPanel.tsx
+++ b/frontend/src/components/screen-items/internal/sections/FragmentsPanel.tsx
@@ -10,20 +10,20 @@
 import { useState, useMemo } from "react";
 import type { ScreenFragmentInstance } from "../../../../types/v3";
 import { useWorkspaceReferences } from "../../../../hooks/useWorkspaceReferences";
-import { fragmentRefResolver } from "../../../../utils/reference-completer/workspaceResolver";
+import { fragmentRefResolver, FRAGMENT_REF_PREFIX } from "../../../../utils/reference-completer/workspaceResolver";
 import { ReferenceCompletionInput } from "../../../common/ReferenceCompletionInput";
-
-// schema: `^generic-definitions/ui-fragment/[A-Za-z][A-Za-z0-9_]*$`
-const FRAGMENT_REF_PREFIX = "generic-definitions/ui-fragment/";
 
 interface Props {
   fragments: ScreenFragmentInstance[];
+  /** テキスト変更時の silent update (per-keystroke、undo stack に積まない) */
   onChange: (next: ScreenFragmentInstance[] | undefined) => void;
+  /** 構造変更 (add/remove) 完了時の commit trigger */
+  onCommit: () => void;
   readonly: boolean;
   defaultExpanded?: boolean;
 }
 
-export function FragmentsPanel({ fragments, onChange, readonly, defaultExpanded = false }: Props) {
+export function FragmentsPanel({ fragments, onChange, onCommit, readonly, defaultExpanded = false }: Props) {
   const [expanded, setExpanded] = useState(defaultExpanded);
   const workspace = useWorkspaceReferences();
 
@@ -32,10 +32,11 @@ export function FragmentsPanel({ fragments, onChange, readonly, defaultExpanded 
     [workspace.fragments],
   );
 
-  /** catalog 不在の fragmentRef を持つ index の集合 */
+  /** catalog 不在の fragmentRef を持つ index の集合 (空文字は「未入力」扱い、broken 対象外) */
   const brokenIdx = useMemo(() => {
     const broken = new Set<number>();
     fragments.forEach((f, i) => {
+      if (!f.fragmentRef) return; // 空文字は broken 扱いしない (新規追加直後の視覚ノイズ抑制)
       const m = f.fragmentRef.match(/^generic-definitions\/ui-fragment\/([A-Za-z][A-Za-z0-9_]*)$/);
       if (!m || !fragmentNameSet.has(m[1])) broken.add(i);
     });
@@ -67,10 +68,12 @@ export function FragmentsPanel({ fragments, onChange, readonly, defaultExpanded 
   const removeAt = (i: number) => {
     const next = fragments.filter((_, idx) => idx !== i);
     onChange(next.length > 0 ? next : undefined);
+    onCommit(); // 削除は undo 単位として記録する
   };
 
   const add = () => {
     onChange([...fragments, { fragmentRef: "" }]);
+    onCommit(); // 追加は undo 単位として記録する
   };
 
   return (
@@ -95,10 +98,10 @@ export function FragmentsPanel({ fragments, onChange, readonly, defaultExpanded 
             <div className="catalog-empty">使用中の fragment はありません。</div>
           )}
           {fragments.map((f, i) => (
-            <div className="catalog-row fragments-panel-row" key={i}>
+            <div className="catalog-row fragments-panel-row" key={`${i}-${f.fragmentRef}`}>
               <div className="catalog-row-fields">
                 <label className="catalog-wide">
-                  fragmentRef
+                  <span>fragmentRef</span>
                   <ReferenceCompletionInput
                     className="form-control form-control-sm"
                     value={f.fragmentRef}
@@ -111,7 +114,7 @@ export function FragmentsPanel({ fragments, onChange, readonly, defaultExpanded 
                   />
                 </label>
                 <label>
-                  instanceId
+                  <span>instanceId</span>
                   <input
                     className="form-control form-control-sm"
                     value={f.instanceId ?? ""}

--- a/frontend/src/store/screenItemsStore.test.ts
+++ b/frontend/src/store/screenItemsStore.test.ts
@@ -1,0 +1,112 @@
+/**
+ * screenItemsStore — fragments[] passthrough 契約テスト (#1281)
+ *
+ * loadScreenItems / saveScreenItems が Screen.fragments[] を正しく passthrough することを検証。
+ * screenStore の backend injection を使って実際の I/O を排除する。
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  setScreenStorageBackend,
+  type ScreenStorageBackend,
+} from "./screenStore";
+import { setFlowStorageBackend, type FlowStorageBackend } from "./flowStore";
+import { loadScreenItems, saveScreenItems, clearItemsFromCache } from "./screenItemsStore";
+import type { ScreenId, Timestamp } from "../types/v3";
+
+const SCREEN_ID = "test-frags-001" as ScreenId;
+const TIMESTAMP = "2026-05-24T00:00:00.000Z" as Timestamp;
+
+function makeMockBackend(): ScreenStorageBackend & { _store: Map<string, unknown> } {
+  const store = new Map<string, unknown>();
+  return {
+    _store: store,
+    async loadScreenEntity(screenId: string) {
+      return store.get(screenId) ?? null;
+    },
+    async saveScreenEntity(screenId: string, data: unknown) {
+      store.set(screenId, data);
+    },
+  };
+}
+
+function baseScreen(extra: Record<string, unknown> = {}) {
+  return {
+    $schema: "../schemas/v3/screen.v3.schema.json",
+    id: SCREEN_ID,
+    name: "テスト画面",
+    kind: "form",
+    path: "/test",
+    createdAt: TIMESTAMP,
+    updatedAt: TIMESTAMP,
+    items: [],
+    design: { editorKind: "grapesjs", designFileRef: `${SCREEN_ID}.design.json` },
+    ...extra,
+  };
+}
+
+describe("screenItemsStore — fragments[] passthrough (#1281)", () => {
+  let backend: ReturnType<typeof makeMockBackend>;
+
+  beforeEach(() => {
+    backend = makeMockBackend();
+    setScreenStorageBackend(backend);
+    clearItemsFromCache(SCREEN_ID);
+    // buildDefaultScreen が flowStore.loadProject / loadRawProject を呼ぶため passive mock
+    const flowBackend: FlowStorageBackend = {
+      loadProject: vi.fn().mockResolvedValue(null),
+      saveProject: vi.fn().mockResolvedValue(undefined),
+      deleteScreenData: vi.fn().mockResolvedValue(undefined),
+    };
+    setFlowStorageBackend(flowBackend);
+  });
+
+  afterEach(() => {
+    setScreenStorageBackend(null);
+    setFlowStorageBackend(null);
+    clearItemsFromCache(SCREEN_ID);
+  });
+
+  it("9. loadScreenItems が fragments[] を保持 (entity に fragments があれば document.fragments に含まれる)", async () => {
+    backend._store.set(SCREEN_ID, baseScreen({
+      fragments: [
+        { fragmentRef: "generic-definitions/ui-fragment/messageArea", instanceId: "top" },
+        { fragmentRef: "generic-definitions/ui-fragment/uploadRow" },
+      ],
+    }));
+
+    const doc = await loadScreenItems(SCREEN_ID);
+    expect(doc.fragments).toHaveLength(2);
+    expect(doc.fragments![0].fragmentRef).toBe("generic-definitions/ui-fragment/messageArea");
+    expect(doc.fragments![0].instanceId).toBe("top");
+    expect(doc.fragments![1].fragmentRef).toBe("generic-definitions/ui-fragment/uploadRow");
+    expect(doc.fragments![1].instanceId).toBeUndefined();
+  });
+
+  it("10. saveScreenItems が空 fragments[] を undefined として entity 書き戻し", async () => {
+    backend._store.set(SCREEN_ID, baseScreen());
+
+    const doc = await loadScreenItems(SCREEN_ID);
+    // 空配列を渡した場合、entity には fragments を書き込まない (undefined 化)
+    await saveScreenItems({ ...doc, fragments: [] });
+
+    const saved = backend._store.get(SCREEN_ID) as Record<string, unknown>;
+    expect(saved.fragments).toBeUndefined();
+  });
+
+  it("11. saveScreenItems が fragments[] を保持して書き戻し", async () => {
+    backend._store.set(SCREEN_ID, baseScreen());
+
+    const doc = await loadScreenItems(SCREEN_ID);
+    const frags = [
+      { fragmentRef: "generic-definitions/ui-fragment/messageArea", instanceId: "banner" },
+    ];
+    await saveScreenItems({ ...doc, fragments: frags });
+
+    const saved = backend._store.get(SCREEN_ID) as Record<string, unknown>;
+    const savedFrags = saved.fragments as typeof frags;
+    expect(Array.isArray(savedFrags)).toBe(true);
+    expect(savedFrags).toHaveLength(1);
+    expect(savedFrags[0].fragmentRef).toBe("generic-definitions/ui-fragment/messageArea");
+    expect(savedFrags[0].instanceId).toBe("banner");
+  });
+});

--- a/frontend/src/store/screenItemsStore.ts
+++ b/frontend/src/store/screenItemsStore.ts
@@ -1,10 +1,12 @@
-import type { ScreenItem, ScreenId, Timestamp } from "../types/v3";
+import type { ScreenItem, ScreenFragmentInstance, ScreenId, Timestamp } from "../types/v3";
 import { loadScreenEntity, saveScreenEntity } from "./screenStore";
 
 export interface ScreenItemsDocument {
   screenId: ScreenId;
   updatedAt: Timestamp;
   items: ScreenItem[];
+  /** 本画面が使用する ui-fragment instance 一覧 (#1067 / #1281)。 */
+  fragments?: ScreenFragmentInstance[];
 }
 
 const _cache = new Map<string, ScreenItemsDocument>();
@@ -31,13 +33,18 @@ export function clearItemsFromCache(screenId: string): void {
 
 export async function loadScreenItems(screenId: string): Promise<ScreenItemsDocument> {
   const cached = _cache.get(screenId);
-  if (cached) return { ...cached, items: [...cached.items] };
+  if (cached) return {
+    ...cached,
+    items: [...cached.items],
+    fragments: cached.fragments ? [...cached.fragments] : undefined,
+  };
 
   const screen = await loadScreenEntity(screenId);
   return {
     screenId: screen.id as ScreenId,
     updatedAt: screen.updatedAt,
     items: [...(screen.items ?? [])],
+    fragments: screen.fragments ? [...screen.fragments] : undefined,
   };
 }
 
@@ -46,6 +53,8 @@ export async function saveScreenItems(file: ScreenItemsDocument): Promise<void> 
   await saveScreenEntity({
     ...screen,
     items: [...file.items],
+    // 空 array は entity に書き込まない (undefined 化)
+    fragments: file.fragments && file.fragments.length > 0 ? [...file.fragments] : undefined,
     updatedAt: nowTs(),
   });
   _cache.delete(file.screenId);

--- a/frontend/src/utils/reference-completer/workspaceResolver.ts
+++ b/frontend/src/utils/reference-completer/workspaceResolver.ts
@@ -103,7 +103,7 @@ export const handlerActionIdResolver = makeIdResolver("handlerActionId", (ctx) =
 //   exceptionTypeRef: ^generic-definitions/exception-type/<Name>$
 // 補完 dropdown 選択時に short name のみ挿入すると schema 違反になるため、
 // value は full path、label は短縮表示用に name のみを保持する。
-const FRAGMENT_REF_PREFIX = "generic-definitions/ui-fragment/";
+export const FRAGMENT_REF_PREFIX = "generic-definitions/ui-fragment/";
 const COMPONENT_REF_PREFIX = "generic-definitions/component-definition/";
 const EXCEPTION_TYPE_REF_PREFIX = "generic-definitions/exception-type/";
 


### PR DESCRIPTION
## Summary

ISSUE #1281 — `Screen.fragments[]` UI editor 新設、`fragmentRefResolver` で補完接続。

#1067 (closed 2026-05-13) で `ui-fragment` catalog + `Screen.fragments[]` schema 追加後、編集 UI が未整備 (JSON 直編集要) だった部分を解消し、ui-fragment 機能を end-to-end (catalog → Screen binding → cross-resource validation) で完結。

### 変更内容 (commit `43bb01dc`)

- **store** (`screenItemsStore.ts`): `ScreenItemsDocument.fragments?: ScreenFragmentInstance[]` 追加、`loadScreenItems` / `saveScreenItems` で passthrough (空 array は entity に書き込まない undefined 化)
- **新 component** (`internal/sections/FragmentsPanel.tsx` 新規): collapsible panel、CRUD、`fragmentRefResolver` full path 補完、broken + (fragmentRef, instanceId) ペア重複の inline warning
- **integration** (`ScreenItemsView.tsx`): FragmentsPanel を `<div className="screen-items-content">` 直下、lintIssues と table-wrap の間に挿入
- **test** (FragmentsPanel.test.tsx 8 件 + screenItemsStore.test.ts 3 件 = 11 件新規 → 12 件 with S-fix)

### 独立レビュー指摘の本 PR 内吸収 (commit `9e9f6a93`)

別 context Opus レビューで Must-fix 0 / Should-fix 4 / Nit 3 を検出 → Should-fix 3 + Nit 2 を吸収:

- **S-1**: `handleFragmentsChange` を silent update + `handleFragmentsCommit` (commit trigger) に分離 — per-keystroke commit による undo stack 肥大化を解消、`handleUpdateItem` パターンに整合
- **S-3**: row map `key={i}` → `key={\`${i}-${fragmentRef}\`}` — 中間 row 削除時の React reconciliation 安定化
- **S-4**: 空文字 fragmentRef は broken 警告対象外 — 新規追加直後の視覚ノイズ解消
- **N-1**: `<label>` 内 text node を `<span>` 化 — HTML5 native label-input ネストパターン適切化
- **N-3**: `FRAGMENT_REF_PREFIX` を `workspaceResolver.ts` から `export` 化 + import — DRY

#### Skip 判定 (本 PR 対応せず)

- **S-2** (`dupIdx` separator `:` 衝突源): 現 schema では `instanceId` pattern `^[a-z][a-zA-Z0-9]*$` で `:` 出現不能、現状問題なし → 将来 instanceId pattern 拡張時に follow-up
- **N-2** (`defaultExpanded` prop 未使用): 将来の外部制御 hook として残置、コスト 0

### スコープ判断

- **schema 変更なし** (`#511` governance 安全圏、`git diff -- schemas/` 0 行確認済)
- `workspaceResolver.ts` は **export 追加のみ** (`FRAGMENT_REF_PREFIX` named export 化、N-3)、resolver ロジック無変更
- `screenRefValidation.ts` (#1090 Phase 2 で実装済) は **無変更**
- ScreenListView / FlowEditor / Designer / ScreenEditModal は **touch しない**
- 並び替え UI 不要 (spec §3.6 が順序意味を定義せず、instanceId で区別する設計)

## Test plan

- [x] `npx tsc --noEmit` → 0 errors
- [x] `npm run lint` → pass
- [x] `vitest run src/components/screen-items src/store/screenItemsStore.test.ts src/utils/reference-completer` → 102/102 pass
- [x] `vitest run` (full) → 2588 + 1 skipped (regression なし。dogfood-1038-structure.test.ts 25 fail は origin/main の pre-existing ENOENT、本 PR 無関係)
- [x] `git diff -- schemas/` → empty (governance #511 OK)

Closes #1281
Refs #1067, #1090, #1277

🤖 Generated with [Claude Code](https://claude.com/claude-code)