### PR TITLE
fix(validator): identifierScope を @var.<scope>.<name> grammar-aware に refactor (#1289)

### DIFF
--- a/examples/diary/harmony/process-flows/0671b051-4acc-49cf-ba92-9fa29b47f671.json
+++ b/examples/diary/harmony/process-flows/0671b051-4acc-49cf-ba92-9fa29b47f671.json
@@ -279,7 +279,8 @@
             "name": "txResult",
             "expose": [
               "committed",
-              "error"
+              "error",
+              "newPost"
             ]
           },
           "steps": [
@@ -398,7 +399,7 @@
           "runIf": "@var.action.txResult.committed == true",
           "description": "201 作成成功を返す。TX コミット後にのみ実行する。",
           "responseId": "201-created",
-          "bodyExpression": "{ postId: @newPost.postId }"
+          "bodyExpression": "{ postId: @txResult.newPost.postId }"
         },
         {
           "id": "step-08",

--- a/examples/retail/harmony/process-flows/f81dd9e0-794c-4539-a2a5-9cbcc0a75899.json
+++ b/examples/retail/harmony/process-flows/f81dd9e0-794c-4539-a2a5-9cbcc0a75899.json
@@ -345,7 +345,7 @@
         {
           "id": "step-06",
           "kind": "transactionScope",
-          "description": "注文確定 TX (@conv.tx.orderConfirm)。在庫減算 → orders INSERT → order_items loop INSERT → カートクリアを原子的に実行する。いずれかが失敗した場合は全体をロールバックする。TX 結果は @var.action.txResult に expose され、後続 step-07 が @var.action.txResult.error.code で分岐する (ADR-007)。",
+          "description": "注文確定 TX (@conv.tx.orderConfirm)。在庫減算 → orders INSERT → order_items loop INSERT → カートクリアを原子的に実行する。いずれかが失敗した場合は全体をロールバックする。TX 結果は outputBinding.name=txResult として保持され、@var.action.txResult.committed / @var.action.txResult.error.code / @var.action.txResult.diagnostics で外部参照可能。後続 step-07 が @var.action.txResult.error.code で分岐する (ADR-007)。",
           "isolationLevel": "READ_COMMITTED",
           "propagation": "REQUIRED",
           "timeoutMs": 10000,

--- a/frontend/src/schemas/identifierScope.test.ts
+++ b/frontend/src/schemas/identifierScope.test.ts
@@ -585,3 +585,388 @@ describe("checkIdentifierScopes — ValidationStep inlineBranch", () => {
     expect(issues).toHaveLength(0);
   });
 });
+
+// #1289: @var.<scope>.<name> grammar-aware check (RFC #1264 verdict 実装)
+describe("checkIdentifierScopes — #1289 @var.<scope>.<name> grammar-aware", () => {
+  describe("flowParameter scope", () => {
+    it("@var.flowParameter.<name> が action.inputs に存在 → OK", () => {
+      const issues = checkIdentifierScopes(makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          inputs: [{ name: "customerId", type: "number" }],
+          steps: [
+            { id: "s1", kind: "compute", description: "", expression: "@var.flowParameter.customerId * 2", outputBinding: { name: "doubled" } },
+          ],
+        }],
+      }));
+      expect(issues.filter((i) => i.identifier.startsWith("var.flowParameter"))).toHaveLength(0);
+    });
+
+    it("@var.flowParameter.<name> が action.inputs に無い → UNKNOWN_IDENTIFIER", () => {
+      const issues = checkIdentifierScopes(makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          inputs: [{ name: "customerId", type: "number" }],
+          steps: [
+            { id: "s1", kind: "compute", description: "", expression: "@var.flowParameter.unknownInput", outputBinding: { name: "x" } },
+          ],
+        }],
+      }));
+      expect(issues.some((i) => i.identifier === "var.flowParameter.unknownInput")).toBe(true);
+    });
+
+    it("@var.flowParameter (name 欠落) → error", () => {
+      const issues = checkIdentifierScopes(makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [
+            { id: "s1", kind: "compute", description: "", expression: "@var.flowParameter", outputBinding: { name: "x" } },
+          ],
+        }],
+      }));
+      expect(issues.some((i) => i.identifier === "var.flowParameter")).toBe(true);
+    });
+  });
+
+  describe("action scope", () => {
+    it("@var.action.<name> が先行 step の outputBinding に存在 → OK (retail dogfood 実例)", () => {
+      const issues = checkIdentifierScopes(makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [
+            {
+              id: "tx-step", kind: "transactionScope", description: "",
+              steps: [
+                { id: "inner", kind: "compute", description: "", expression: "1", outputBinding: { name: "value" } },
+              ],
+              outputBinding: { name: "txResult" },
+            },
+            { id: "next", kind: "return", description: "", bodyExpression: "{ committed: @var.action.txResult.committed }" },
+          ],
+        }],
+      }));
+      expect(issues.filter((i) => i.identifier.startsWith("var.action"))).toHaveLength(0);
+    });
+
+    it("@var.action.<name> が action scope に無い → UNKNOWN_IDENTIFIER", () => {
+      const issues = checkIdentifierScopes(makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [
+            { id: "s1", kind: "compute", description: "", expression: "@var.action.notDeclared", outputBinding: { name: "x" } },
+          ],
+        }],
+      }));
+      expect(issues.some((i) => i.identifier === "var.action.notDeclared")).toBe(true);
+    });
+  });
+
+  describe("loop scope", () => {
+    it("@var.loop.<collectionItemName> → OK (loop iteration item 参照)", () => {
+      const issues = checkIdentifierScopes(makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          inputs: [{ name: "items", type: { kind: "array", itemType: "number" } }],
+          steps: [{
+            id: "loop1", kind: "loop", description: "",
+            loopKind: "collection",
+            collectionSource: "@inputs.items",
+            collectionItemName: "item",
+            steps: [
+              { id: "inner", kind: "compute", description: "", expression: "@var.loop.item * 2", outputBinding: { name: "doubled" } },
+            ],
+          }],
+        }],
+      }));
+      expect(issues.filter((i) => i.identifier.startsWith("var.loop"))).toHaveLength(0);
+    });
+
+    it("@var.loop.<collectionIndexName> → OK (collection loop index 参照、#1264 verdict 観点 3)", () => {
+      const issues = checkIdentifierScopes(makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          inputs: [{ name: "items", type: { kind: "array", itemType: "number" } }],
+          steps: [{
+            id: "loop1", kind: "loop", description: "",
+            loopKind: "collection",
+            collectionSource: "@inputs.items",
+            collectionItemName: "item",
+            collectionIndexName: "idx",
+            steps: [
+              { id: "inner", kind: "compute", description: "", expression: "@var.loop.idx + 1", outputBinding: { name: "nextIdx" } },
+            ],
+          }],
+        }],
+      }));
+      expect(issues.filter((i) => i.identifier.startsWith("var.loop"))).toHaveLength(0);
+    });
+
+    it("@var.loop.<name> が enclosing loop に無い → UNKNOWN_IDENTIFIER", () => {
+      const issues = checkIdentifierScopes(makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          inputs: [{ name: "items", type: { kind: "array", itemType: "number" } }],
+          steps: [{
+            id: "loop1", kind: "loop", description: "",
+            loopKind: "collection",
+            collectionSource: "@inputs.items",
+            collectionItemName: "item",
+            steps: [
+              { id: "inner", kind: "compute", description: "", expression: "@var.loop.notDeclared", outputBinding: { name: "x" } },
+            ],
+          }],
+        }],
+      }));
+      expect(issues.some((i) => i.identifier === "var.loop.notDeclared")).toBe(true);
+    });
+
+    it("@var.loop.<name> を loop 外で参照 → UNKNOWN_IDENTIFIER (loop item は外に leak しない)", () => {
+      const issues = checkIdentifierScopes(makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          inputs: [{ name: "items", type: { kind: "array", itemType: "number" } }],
+          steps: [
+            {
+              id: "loop1", kind: "loop", description: "",
+              loopKind: "collection",
+              collectionSource: "@inputs.items",
+              collectionItemName: "item",
+              steps: [],
+            },
+            { id: "after", kind: "compute", description: "", expression: "@var.loop.item", outputBinding: { name: "x" } },
+          ],
+        }],
+      }));
+      expect(issues.some((i) => i.identifier === "var.loop.item")).toBe(true);
+    });
+  });
+
+  describe("step scope", () => {
+    it("@var.step.<stepId>.<name> が outputBinding.name と一致 → OK", () => {
+      const issues = checkIdentifierScopes(makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [
+            { id: "fetch-step", kind: "compute", description: "", expression: "1", outputBinding: { name: "userData" } },
+            { id: "use", kind: "return", description: "", bodyExpression: "{ name: @var.step.fetch-step.userData }" },
+          ],
+        }],
+      }));
+      expect(issues.filter((i) => i.identifier.startsWith("var.step"))).toHaveLength(0);
+    });
+
+    it("@var.step.<unknown-id> → UNKNOWN_IDENTIFIER", () => {
+      const issues = checkIdentifierScopes(makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [
+            { id: "s1", kind: "compute", description: "", expression: "@var.step.no-such-step.field", outputBinding: { name: "x" } },
+          ],
+        }],
+      }));
+      expect(issues.some((i) => i.identifier === "var.step.no-such-step")).toBe(true);
+    });
+
+    it("@var.step.<id>.<wrongName> → outputBinding.name mismatch detected", () => {
+      const issues = checkIdentifierScopes(makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [
+            { id: "fetch-step", kind: "compute", description: "", expression: "1", outputBinding: { name: "correctName" } },
+            { id: "use", kind: "return", description: "", bodyExpression: "@var.step.fetch-step.wrongName" },
+          ],
+        }],
+      }));
+      expect(issues.some((i) => i.identifier === "var.step.fetch-step.wrongName")).toBe(true);
+    });
+  });
+
+  describe("tx scope", () => {
+    it("@var.tx.<txStepId>.committed (予約値) → OK (expose 不要)", () => {
+      const issues = checkIdentifierScopes(makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [
+            {
+              id: "tx-confirm", kind: "transactionScope", description: "",
+              steps: [
+                { id: "inner", kind: "compute", description: "", expression: "1", outputBinding: { name: "v" } },
+              ],
+            },
+            { id: "check", kind: "return", description: "", bodyExpression: "{ ok: @var.tx.tx-confirm.committed }" },
+          ],
+        }],
+      }));
+      expect(issues.filter((i) => i.identifier.startsWith("var.tx"))).toHaveLength(0);
+    });
+
+    it("@var.tx.<txStepId>.error / .diagnostics (予約値) → OK", () => {
+      const issues = checkIdentifierScopes(makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [
+            {
+              id: "tx-confirm", kind: "transactionScope", description: "",
+              steps: [
+                { id: "inner", kind: "compute", description: "", expression: "1", outputBinding: { name: "v" } },
+              ],
+            },
+            { id: "log-err", kind: "log", description: "", level: "error", message: "${@var.tx.tx-confirm.error.code} / ${@var.tx.tx-confirm.diagnostics}" },
+          ],
+        }],
+      }));
+      expect(issues.filter((i) => i.identifier.startsWith("var.tx"))).toHaveLength(0);
+    });
+
+    it("@var.tx.<unknown-id> → UNKNOWN_IDENTIFIER", () => {
+      const issues = checkIdentifierScopes(makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [
+            { id: "s1", kind: "compute", description: "", expression: "@var.tx.no-such-tx.committed", outputBinding: { name: "x" } },
+          ],
+        }],
+      }));
+      expect(issues.some((i) => i.identifier === "var.tx.no-such-tx")).toBe(true);
+    });
+
+    it("@var.tx.<stepId> で <stepId> が非 transactionScope → UNKNOWN_IDENTIFIER", () => {
+      const issues = checkIdentifierScopes(makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [
+            { id: "compute-step", kind: "compute", description: "", expression: "1", outputBinding: { name: "v" } },
+            { id: "wrong", kind: "return", description: "", bodyExpression: "@var.tx.compute-step.committed" },
+          ],
+        }],
+      }));
+      expect(issues.some((i) => i.identifier === "var.tx.compute-step")).toBe(true);
+    });
+  });
+
+  describe("global scope (silent pass、project-level)", () => {
+    it("@var.global.<name> は silent pass (本 PR scope 外、別 validator 担当)", () => {
+      const issues = checkIdentifierScopes(makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [
+            { id: "s1", kind: "compute", description: "", expression: "@var.global.tenantId", outputBinding: { name: "x" } },
+          ],
+        }],
+      }));
+      expect(issues.filter((i) => i.identifier.startsWith("var.global"))).toHaveLength(0);
+    });
+  });
+
+  describe("shorthand @var.<name> (lexical chain auto-infer)", () => {
+    it("@var.<name> が known scope に存在 → OK", () => {
+      const issues = checkIdentifierScopes(makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          inputs: [{ name: "amount", type: "number" }],
+          steps: [
+            { id: "s1", kind: "compute", description: "", expression: "@var.amount * 2", outputBinding: { name: "doubled" } },
+          ],
+        }],
+      }));
+      expect(issues.filter((i) => i.identifier.startsWith("var."))).toHaveLength(0);
+    });
+
+    it("@var.<name> が known scope に無い → UNKNOWN_IDENTIFIER", () => {
+      const issues = checkIdentifierScopes(makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [
+            { id: "s1", kind: "compute", description: "", expression: "@var.notDeclared", outputBinding: { name: "x" } },
+          ],
+        }],
+      }));
+      expect(issues.some((i) => i.identifier === "var.notDeclared")).toBe(true);
+    });
+
+    it("@var 単独 (path 欠落) → error", () => {
+      const issues = checkIdentifierScopes(makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [
+            { id: "s1", kind: "compute", description: "", expression: "@var", outputBinding: { name: "x" } },
+          ],
+        }],
+      }));
+      expect(issues.some((i) => i.identifier === "var")).toBe(true);
+    });
+  });
+
+  describe("tryCatch.errorVar (catch block 内 named binding)", () => {
+    it("catch branch 内で @var.<errorVar> 参照 → OK", () => {
+      const issues = checkIdentifierScopes(makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [
+            {
+              id: "br1", kind: "branch", description: "",
+              branches: [
+                {
+                  id: "catch", code: "A",
+                  condition: { kind: "tryCatch", errorCode: "VALIDATION_FAILED", errorVar: "caughtError" },
+                  steps: [
+                    { id: "log", kind: "log", description: "", level: "error", message: "${@var.caughtError.code}: ${@var.caughtError.message}" },
+                  ],
+                },
+              ],
+            },
+          ],
+        }],
+      }));
+      expect(issues.filter((i) => i.identifier.startsWith("var.caughtError"))).toHaveLength(0);
+    });
+
+    it("catch branch 外 (兄弟 branch) で errorVar 参照 → UNKNOWN_IDENTIFIER (scope leak しない)", () => {
+      const issues = checkIdentifierScopes(makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [
+            {
+              id: "br1", kind: "branch", description: "",
+              branches: [
+                {
+                  id: "catch", code: "A",
+                  condition: { kind: "tryCatch", errorCode: "VALIDATION_FAILED", errorVar: "caughtError" },
+                  steps: [],
+                },
+                {
+                  id: "other", code: "B",
+                  condition: { kind: "expression", expression: "@var.caughtError" },
+                  steps: [],
+                },
+              ],
+            },
+          ],
+        }],
+      }));
+      expect(issues.some((i) => i.identifier === "var.caughtError")).toBe(true);
+    });
+  });
+
+  describe("retail dogfood で実発生する canonical 形式の regression", () => {
+    it("@var.action.txResult.committed (TX expose 予約値) → OK", () => {
+      const issues = checkIdentifierScopes(makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [
+            {
+              id: "tx-confirm", kind: "transactionScope", description: "",
+              steps: [
+                { id: "inner", kind: "compute", description: "", expression: "1", outputBinding: { name: "v" } },
+              ],
+              outputBinding: { name: "txResult" },
+            },
+            { id: "after", kind: "return", description: "", bodyExpression: "@var.action.txResult.committed" },
+            { id: "alt", kind: "compute", description: "", expression: "@var.action.txResult.error.code === 'STOCK_SHORTAGE'", outputBinding: { name: "isShortage" }, runIf: "@var.action.txResult.committed == false" },
+          ],
+        }],
+      }));
+      expect(issues.filter((i) => i.identifier.startsWith("var"))).toHaveLength(0);
+    });
+  });
+});

--- a/frontend/src/schemas/identifierScope.test.ts
+++ b/frontend/src/schemas/identifierScope.test.ts
@@ -969,4 +969,140 @@ describe("checkIdentifierScopes — #1289 @var.<scope>.<name> grammar-aware", ()
       expect(issues.filter((i) => i.identifier.startsWith("var"))).toHaveLength(0);
     });
   });
+
+  // #1289 独立レビュー follow-up: TX inner var leak 防止 (process-flow-variables.md §3.7)
+  describe("#1289 follow-up: TX inner var leak 防止", () => {
+    it("TX 内の outputBinding を TX 外で shorthand @<innerVar> 参照 → UNKNOWN_IDENTIFIER (leak しない)", () => {
+      const issues = checkIdentifierScopes(makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [
+            {
+              id: "tx-confirm", kind: "transactionScope", description: "",
+              steps: [
+                { id: "inner-step", kind: "compute", description: "", expression: "1", outputBinding: { name: "secretInnerVar" } },
+              ],
+              outputBinding: { name: "txResult" },
+            },
+            // TX 外で TX inner の outputBinding 名を shorthand 参照 → spec §3.7 違反、leak 防止が機能していれば UNKNOWN
+            { id: "leak-attempt", kind: "return", description: "", bodyExpression: "@secretInnerVar" },
+          ],
+        }],
+      }));
+      expect(issues.some((i) => i.identifier === "secretInnerVar")).toBe(true);
+    });
+
+    it("TX 内の outputBinding を TX 外で @var.<innerVar> shorthand 参照 → UNKNOWN_IDENTIFIER", () => {
+      const issues = checkIdentifierScopes(makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [
+            {
+              id: "tx-confirm", kind: "transactionScope", description: "",
+              steps: [
+                { id: "inner-step", kind: "compute", description: "", expression: "1", outputBinding: { name: "secretInnerVar" } },
+              ],
+              outputBinding: { name: "txResult" },
+            },
+            { id: "leak-attempt", kind: "return", description: "", bodyExpression: "@var.secretInnerVar" },
+          ],
+        }],
+      }));
+      expect(issues.some((i) => i.identifier === "var.secretInnerVar")).toBe(true);
+    });
+
+    it("TX 外の outputBinding (TX wrapper 自身) は引き続き参照可 (TX 完了後の通常変数として)", () => {
+      const issues = checkIdentifierScopes(makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [
+            {
+              id: "tx-confirm", kind: "transactionScope", description: "",
+              steps: [
+                { id: "inner-step", kind: "compute", description: "", expression: "1", outputBinding: { name: "secretInnerVar" } },
+              ],
+              outputBinding: { name: "txResult" },
+            },
+            // TX wrapper 自身 (`txResult`) は parent known に居る → shorthand 参照 OK
+            { id: "ok", kind: "return", description: "", bodyExpression: "@txResult" },
+          ],
+        }],
+      }));
+      expect(issues.filter((i) => i.identifier === "txResult")).toHaveLength(0);
+    });
+
+    it("TX 内 step が TX 内で先行 step の outputBinding を参照 → OK (TX scope 内では引き続き見える)", () => {
+      const issues = checkIdentifierScopes(makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [
+            {
+              id: "tx-confirm", kind: "transactionScope", description: "",
+              steps: [
+                { id: "step-a", kind: "compute", description: "", expression: "1", outputBinding: { name: "a" } },
+                { id: "step-b", kind: "compute", description: "", expression: "@a + 1", outputBinding: { name: "b" } },
+              ],
+            },
+          ],
+        }],
+      }));
+      expect(issues).toHaveLength(0);
+    });
+
+    it("TX.onCommit 内で TX 内 step の outputBinding 参照 → OK (commit context)", () => {
+      const issues = checkIdentifierScopes(makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [
+            {
+              id: "tx-confirm", kind: "transactionScope", description: "",
+              steps: [
+                { id: "step-a", kind: "compute", description: "", expression: "1", outputBinding: { name: "committedValue" } },
+              ],
+              onCommit: [
+                { id: "log-success", kind: "log", description: "", level: "info", message: "committed: ${@committedValue}" },
+              ],
+            },
+          ],
+        }],
+      }));
+      expect(issues).toHaveLength(0);
+    });
+  });
+
+  // #1289 独立レビュー follow-up: extractReferences regex の path 部 digit-start 許容
+  describe("#1289 follow-up: path 部 digit-start 許容", () => {
+    it("@var.step.<stepId>.404-not-found 形式の参照 (response-id / outcome-id) を正しく parse", () => {
+      // step の outputBinding.name と 404-not-found は一致しないため step scope 検証で
+      // mismatch error が出る (= regex が 404-not-found を path として正しく抽出している証拠)
+      const issues = checkIdentifierScopes(makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          steps: [
+            { id: "fetch-step", kind: "compute", description: "", expression: "1", outputBinding: { name: "data" } },
+            { id: "use", kind: "return", description: "", bodyExpression: "@var.step.fetch-step.404-not-found" },
+          ],
+        }],
+      }));
+      // path[2]="404-not-found" が抽出されて name 比較に到達、mismatch error として捕捉
+      expect(issues.some((i) => i.identifier === "var.step.fetch-step.404-not-found")).toBe(true);
+    });
+
+    it("path 部 digit-start を含む参照が完全に extract される (regex 部分一致で切れない)", () => {
+      // 旧 regex `[a-zA-Z_]` のみで digit-start path segment 不可だったため
+      // `@var.action.txResult` の後ろに `.committed` が続いても segment 名が `committed` なので OK だった。
+      // 本 fix の趣旨は digit-start 識別子 (例: outcome-id `404-not-found`) を含む path を扱えるようにすること。
+      // 副作用として通常の camelCase path は引き続き正しく動くことを確認:
+      const issues = checkIdentifierScopes(makeGroup({
+        actions: [{
+          id: "a1", name: "f", trigger: "click",
+          inputs: [{ name: "amount", type: "number" }],
+          steps: [
+            { id: "s1", kind: "compute", description: "", expression: "@var.flowParameter.amount", outputBinding: { name: "doubled" } },
+          ],
+        }],
+      }));
+      expect(issues.filter((i) => i.identifier.startsWith("var.flowParameter"))).toHaveLength(0);
+    });
+  });
 });

--- a/frontend/src/schemas/identifierScope.ts
+++ b/frontend/src/schemas/identifierScope.ts
@@ -85,10 +85,16 @@ const TX_RESERVED_VALUES = new Set<string>(["committed", "error", "diagnostics"]
  * #1289: path 部のセグメントに hyphen を許容するよう更新 (`@var.step.<step-id>.<name>` の
  * step-id が LocalId 形式で hyphen を含むため、例: `step-01-validate`)。root 部 (Identifier、
  * camelCase 強制) は従来通り hyphen 不許可。
+ *
+ * #1289 独立レビュー follow-up: path 部のセグメント先頭文字に digit (0-9) も許容
+ * (LocalId は `[A-Za-z0-9](?:[A-Za-z0-9_-]*[A-Za-z0-9])?` で digit-start を許容
+ * するため、`response-id: '404-not-found'` 等の参照 `@var.step.<stepId>.404-not-found`
+ * を拾えるようにする)。これにより processFlowAntipatternValidator.ts:426 の REF_RE
+ * と非対称が解消する。root 部は引き続き Identifier (camelCase / letter-start) のみ。
  */
 function extractReferences(src: string): Array<{ root: string; path: string[] }> {
   const result: Array<{ root: string; path: string[] }> = [];
-  const re = /@([a-zA-Z_][\w]*)(?:\.([a-zA-Z_][\w-]*(?:\.[a-zA-Z_][\w-]*)*))?/g;
+  const re = /@([a-zA-Z_][\w]*)(?:\.([a-zA-Z0-9_][\w-]*(?:\.[a-zA-Z0-9_][\w-]*)*))?/g;
   let m: RegExpExecArray | null;
   while ((m = re.exec(src)) !== null) {
     result.push({ root: m[1], path: m[2]?.split(".") ?? [] });
@@ -254,10 +260,25 @@ function walkSteps(
       walkSteps(step.steps, `${path}.steps`, known, childLoopItems, envVarNames, actionInputs, stepIndex, issues);
     }
     if (step.kind === "transactionScope") {
-      walkSteps(step.steps, `${path}.steps`, known, loopItems, envVarNames, actionInputs, stepIndex, issues);
-      if (step.onCommit) walkSteps(step.onCommit, `${path}.onCommit`, known, loopItems, envVarNames, actionInputs, stepIndex, issues);
+      // #1289 独立レビュー follow-up: TX inner var leak 防止 (spec process-flow-variables.md
+      // §3.7「TX 外参照は expose 経由のみ」)。TX body / onCommit / onRollback 内で宣言された
+      // outputBinding は parent scope に leak しない設計とする。
+      //
+      // 実装: known の snapshot (txKnown) を clone して TX body に渡す。inner step が
+      // outputBinding で txKnown を mutate しても、parent の known は影響を受けない。
+      // TX 完了後の parent は、TX wrapper 自体の outputBinding.name (既に上の `known.add(bindName)`
+      // で追加済) と予約値 / expose 列挙を `@var.action.<txWrapperName>.<accessor>` 経由で
+      // 参照する形になり、shorthand `@<innerVarName>` 直接参照は別 validator (Check 32) が
+      // 静的検出する。
+      //
+      // onCommit / onRollback は TX body の continuation で inner bindings (commit 後の値 /
+      // rollback context) を見られる必要があるため、同じ txKnown を渡す (parent への leak は
+      // 引き続き起こらない)。
+      const txKnown = new Set(known);
+      walkSteps(step.steps, `${path}.steps`, txKnown, loopItems, envVarNames, actionInputs, stepIndex, issues);
+      if (step.onCommit) walkSteps(step.onCommit, `${path}.onCommit`, txKnown, loopItems, envVarNames, actionInputs, stepIndex, issues);
       if (step.onRollback) {
-        const onRollbackKnown = new Set([...known, "error"]);
+        const onRollbackKnown = new Set([...txKnown, "error"]);
         walkSteps(step.onRollback, `${path}.onRollback`, onRollbackKnown, loopItems, envVarNames, actionInputs, stepIndex, issues);
       }
     }
@@ -414,6 +435,19 @@ function checkVarReference(
       });
       return;
     }
+    // #1289 独立レビュー follow-up: step scope name validation policy
+    //
+    // canonical 仕様 (process-flow-variables.md §3.6) は `@var.step.<step-id>.<name>` で
+    // `<name>` が step の outputBinding.name と一致することを要求する。それ以降の path
+    // segment (`<name>.<field>` 以降) は binding object の field access であり、本 validator
+    // では型解析を行わず free-form として受容する (例: dbAccess の SELECT 結果 row の各列、
+    // transformations で変換された各 field、object 型 outputBinding の sub-field 等は
+    // 全て name 以降の path として扱う)。
+    //
+    // outputBinding を持たない step (例: ReturnStep / LogStep / displayUpdate 等) への
+    // `@var.step.<id>.<anything>` 参照は silent pass (検証 skip)。理由: 一部の step は
+    // 暗黙的に値を産み出す可能性があり (例: ReturnStep の response object)、厳密 error 化は
+    // 過剰検出になり得るため、本 PR ではそれらを許容する保守的方針を採用。
     const bindName = step.outputBinding?.name;
     if (bindName && bindName !== name) {
       issues.push({
@@ -423,7 +457,6 @@ function checkVarReference(
         message: `@var.step.${stepId}.${name}: step "${stepId}" の outputBinding.name は "${bindName}" であり "${name}" と一致しません`,
       });
     }
-    // bindName が undefined (= step に outputBinding なし) の場合は検証 skip (silent pass)
     return;
   }
 

--- a/frontend/src/schemas/identifierScope.ts
+++ b/frontend/src/schemas/identifierScope.ts
@@ -6,12 +6,17 @@
  * - ActionDefinition.outputs[].name
  * - ProcessFlow.context.ambientVariables[].name
  * - 先行ステップの StepBase.outputBinding.name
- * - LoopStep.collectionItemName (ループ配下のスコープのみ)
+ * - LoopStep.collectionItemName / collectionIndexName (ループ配下のスコープのみ)
  * - ValidationStep.fieldErrorsVar の宣言
+ * - BranchCondition.tryCatch.errorVar (catch block 内のみ)
  * - BUILTIN_AMBIENTS (組み込み関数・グローバル識別子)
  *
+ * #1289: @var.<scope>.<name> grammar-aware check 追加 (RFC #1264 verdict 実装)。
+ * `@var` 系参照は path[0] で 6 scope (flowParameter / action / loop / global / step / tx) に
+ * 分岐して semantic 検証する。shorthand `@var.<name>` は lexical chain auto-infer。
+ *
  * 単純な regex ベースの識別子抽出 + スコープ走査。
- * 式の完全パースや型推論は今は行わない (path 部分は無視、root 識別子のみ検査)。
+ * 式の完全パースや型推論は今は行わない (path 部分は scope keyword と最初の name のみ検査)。
  */
 import { mergeCatalogsForFlow, type ProjectCatalogs } from "./projectCatalogs";
 import type {
@@ -42,6 +47,9 @@ export interface IdentifierIssue {
  *
  * @env.* は special-case として checkStep 内で context.catalogs.envVars と突合するため
  * ここには含めない (下記 root === "env" ブランチを参照)。
+ *
+ * @var.* も special-case として root === "var" ブランチで grammar-aware 検査 (#1289)。
+ * BUILTIN_AMBIENTS には含めない。
  */
 const BUILTIN_AMBIENTS = new Set<string>([
   "fn",
@@ -52,10 +60,35 @@ const BUILTIN_AMBIENTS = new Set<string>([
   "ambient",
 ]);
 
-/** 任意の文字列から @identifier と property path を抽出 */
+/**
+ * `@var.<scope>.<name>` の明示 scope 6 値 (RFC #1264 verdict / process-flow-variables.md §3.6)。
+ * `step` / `tx` は後続に step-id が続く (`@var.step.<step-id>.<name>`)。
+ */
+const VAR_EXPLICIT_SCOPES = new Set<string>([
+  "flowParameter",
+  "action",
+  "loop",
+  "global",
+  "step",
+  "tx",
+]);
+
+/**
+ * TransactionScopeStep の `@var.tx.<step-id>.<name>` で常時参照可能な予約値
+ * (process-flow-variables.md §3.7、`expose` 列挙不要)。
+ */
+const TX_RESERVED_VALUES = new Set<string>(["committed", "error", "diagnostics"]);
+
+/**
+ * 任意の文字列から @identifier と property path を抽出。
+ *
+ * #1289: path 部のセグメントに hyphen を許容するよう更新 (`@var.step.<step-id>.<name>` の
+ * step-id が LocalId 形式で hyphen を含むため、例: `step-01-validate`)。root 部 (Identifier、
+ * camelCase 強制) は従来通り hyphen 不許可。
+ */
 function extractReferences(src: string): Array<{ root: string; path: string[] }> {
   const result: Array<{ root: string; path: string[] }> = [];
-  const re = /@([a-zA-Z_][\w]*)(?:\.([a-zA-Z_][\w]*(?:\.[a-zA-Z_][\w]*)*))?/g;
+  const re = /@([a-zA-Z_][\w]*)(?:\.([a-zA-Z_][\w-]*(?:\.[a-zA-Z_][\w-]*)*))?/g;
   let m: RegExpExecArray | null;
   while ((m = re.exec(src)) !== null) {
     result.push({ root: m[1], path: m[2]?.split(".") ?? [] });
@@ -69,6 +102,47 @@ function getBindingName(binding: OutputBinding | undefined): string | null {
 
 function fieldNames(fields: StructuredField[] | undefined): string[] {
   return fields?.map((f) => f.name as string) ?? [];
+}
+
+/**
+ * action 内の全 step を id 一意 index に flatten (#1289 で `@var.step.<id>.<name>` /
+ * `@var.tx.<id>.<name>` の存在検証用)。ネスト構造 (branch / loop / transactionScope /
+ * workflow / validation.inlineBranch / externalSystem.outcomes.sideEffects) も walk する。
+ */
+function buildStepIndex(steps: Step[]): Map<string, Step> {
+  const index = new Map<string, Step>();
+  function walk(stepList: Step[]): void {
+    for (const step of stepList) {
+      if (step.id) index.set(step.id, step);
+      if (!isBuiltinStep(step)) continue;
+      if (step.kind === "branch") {
+        step.branches.forEach((b) => walk(b.steps));
+        if (step.elseBranch) walk(step.elseBranch.steps);
+      }
+      if (step.kind === "loop") walk(step.steps);
+      if (step.kind === "transactionScope") {
+        walk(step.steps);
+        if (step.onCommit) walk(step.onCommit);
+        if (step.onRollback) walk(step.onRollback);
+      }
+      if (step.kind === "workflow") {
+        if (step.onApproved) walk(step.onApproved);
+        if (step.onRejected) walk(step.onRejected);
+        if (step.onTimeout) walk(step.onTimeout);
+      }
+      if (step.kind === "validation" && step.inlineBranch) {
+        walk(step.inlineBranch.ok);
+        walk(step.inlineBranch.ng);
+      }
+      if (step.kind === "externalSystem") {
+        Object.values(step.errorHandling?.outcomes ?? {}).forEach((spec) => {
+          if (spec?.sideEffects) walk(spec.sideEffects);
+        });
+      }
+    }
+  }
+  walk(steps);
+  return index;
 }
 
 /**
@@ -88,6 +162,7 @@ export function checkIdentifierScopes(
 
   group.actions.forEach((action, ai) => {
     const knownInAction = new Set<string>(ambientNames);
+    const actionInputs = new Set<string>(fieldNames(action.inputs));
     // inputs: 個別フィールド名 + "inputs" 全体 (@inputs.field 参照を許容)
     if (Array.isArray(action.inputs)) {
       knownInAction.add("inputs");
@@ -99,12 +174,17 @@ export function checkIdentifierScopes(
       for (const f of action.outputs) knownInAction.add(f.name);
     }
 
+    // #1289: action 全体の step index を事前構築 (`@var.step.<id>` / `@var.tx.<id>` の存在検証用)
+    const stepIndex = buildStepIndex(action.steps ?? []);
+
     walkSteps(
       action.steps ?? [],
       `actions[${ai}].steps`,
       knownInAction,
       [],
       envVarNames,
+      actionInputs,
+      stepIndex,
       issues,
     );
   });
@@ -115,7 +195,9 @@ export function checkIdentifierScopes(
 /**
  * ステップ列を走査。
  * @param known  このスコープで参照可能な識別子の set (mutable: outputBinding で add)
- * @param loopItems 包含ループの collectionItemName 列 (ネスト可)
+ * @param loopItems 包含ループの collectionItemName / collectionIndexName 列 (ネスト可)
+ * @param actionInputs action.inputs[].name の set (#1289、`@var.flowParameter.<name>` 検証用)
+ * @param stepIndex action 内の全 step を id-indexed (#1289、`@var.step` / `@var.tx` 検証用)
  */
 function walkSteps(
   steps: Step[],
@@ -123,12 +205,14 @@ function walkSteps(
   known: Set<string>,
   loopItems: string[],
   envVarNames: Set<string>,
+  actionInputs: Set<string>,
+  stepIndex: Map<string, Step>,
   issues: IdentifierIssue[],
 ): void {
   steps.forEach((step, i) => {
     const path = `${basePath}[${i}]`;
     const available = new Set<string>([...known, ...loopItems]);
-    checkStep(step, path, available, envVarNames, issues);
+    checkStep(step, path, available, known, new Set(loopItems), actionInputs, stepIndex, envVarNames, issues);
 
     // outputBinding は StepBaseProps 共通フィールド。拡張 step も継承するため kind 関係なく known に追加
     const bindName = getBindingName(step.outputBinding);
@@ -150,43 +234,239 @@ function walkSteps(
     // loopItems はループ配下のみ有効 (ループ外に leak させない)。
     if (step.kind === "branch") {
       step.branches.forEach((b, bi) => {
-        walkSteps(b.steps, `${path}.branches[${bi}].steps`, known, loopItems, envVarNames, issues);
+        // #1289 / #1264 verdict 観点 3: tryCatch.errorVar は catch block 内 named binding
+        // として導入される。enclosing scope には漏らさない (branch-local known に注入)。
+        let branchKnown = known;
+        if (b.condition.kind === "tryCatch" && b.condition.errorVar) {
+          branchKnown = new Set([...known, b.condition.errorVar]);
+        }
+        walkSteps(b.steps, `${path}.branches[${bi}].steps`, branchKnown, loopItems, envVarNames, actionInputs, stepIndex, issues);
       });
       if (step.elseBranch) {
-        walkSteps(step.elseBranch.steps, `${path}.elseBranch.steps`, known, loopItems, envVarNames, issues);
+        walkSteps(step.elseBranch.steps, `${path}.elseBranch.steps`, known, loopItems, envVarNames, actionInputs, stepIndex, issues);
       }
     }
     if (step.kind === "loop") {
-      const childLoopItems = step.collectionItemName
-        ? [...loopItems, step.collectionItemName]
-        : loopItems;
-      walkSteps(step.steps, `${path}.steps`, known, childLoopItems, envVarNames, issues);
+      // #1289 / #1264 verdict 観点 3: collection loop の collectionIndexName も loopItems に注入
+      const childLoopItems = [...loopItems];
+      if (step.collectionItemName) childLoopItems.push(step.collectionItemName);
+      if (step.collectionIndexName) childLoopItems.push(step.collectionIndexName);
+      walkSteps(step.steps, `${path}.steps`, known, childLoopItems, envVarNames, actionInputs, stepIndex, issues);
     }
     if (step.kind === "transactionScope") {
-      walkSteps(step.steps, `${path}.steps`, known, loopItems, envVarNames, issues);
-      if (step.onCommit) walkSteps(step.onCommit, `${path}.onCommit`, known, loopItems, envVarNames, issues);
+      walkSteps(step.steps, `${path}.steps`, known, loopItems, envVarNames, actionInputs, stepIndex, issues);
+      if (step.onCommit) walkSteps(step.onCommit, `${path}.onCommit`, known, loopItems, envVarNames, actionInputs, stepIndex, issues);
       if (step.onRollback) {
         const onRollbackKnown = new Set([...known, "error"]);
-        walkSteps(step.onRollback, `${path}.onRollback`, onRollbackKnown, loopItems, envVarNames, issues);
+        walkSteps(step.onRollback, `${path}.onRollback`, onRollbackKnown, loopItems, envVarNames, actionInputs, stepIndex, issues);
       }
     }
     if (step.kind === "workflow") {
-      if (step.onApproved) walkSteps(step.onApproved, `${path}.onApproved`, known, loopItems, envVarNames, issues);
-      if (step.onRejected) walkSteps(step.onRejected, `${path}.onRejected`, known, loopItems, envVarNames, issues);
-      if (step.onTimeout) walkSteps(step.onTimeout, `${path}.onTimeout`, known, loopItems, envVarNames, issues);
+      if (step.onApproved) walkSteps(step.onApproved, `${path}.onApproved`, known, loopItems, envVarNames, actionInputs, stepIndex, issues);
+      if (step.onRejected) walkSteps(step.onRejected, `${path}.onRejected`, known, loopItems, envVarNames, actionInputs, stepIndex, issues);
+      if (step.onTimeout) walkSteps(step.onTimeout, `${path}.onTimeout`, known, loopItems, envVarNames, actionInputs, stepIndex, issues);
     }
     if (step.kind === "validation" && step.inlineBranch) {
-      walkSteps(step.inlineBranch.ok, `${path}.inlineBranch.ok`, known, loopItems, envVarNames, issues);
-      walkSteps(step.inlineBranch.ng, `${path}.inlineBranch.ng`, known, loopItems, envVarNames, issues);
+      walkSteps(step.inlineBranch.ok, `${path}.inlineBranch.ok`, known, loopItems, envVarNames, actionInputs, stepIndex, issues);
+      walkSteps(step.inlineBranch.ng, `${path}.inlineBranch.ng`, known, loopItems, envVarNames, actionInputs, stepIndex, issues);
     }
     if (step.kind === "externalSystem") {
       Object.entries(step.errorHandling?.outcomes ?? {}).forEach(([k, spec]) => {
         if (spec?.sideEffects) {
-          walkSteps(spec.sideEffects, `${path}.outcomes.${k}.sideEffects`, known, loopItems, envVarNames, issues);
+          walkSteps(spec.sideEffects, `${path}.outcomes.${k}.sideEffects`, known, loopItems, envVarNames, actionInputs, stepIndex, issues);
         }
       });
     }
   });
+}
+
+/**
+ * `@var.<scope>.<name>` / `@var.<name>` (shorthand) の grammar-aware 検証 (#1289)。
+ * RFC #1264 verdict / process-flow-variables.md §3.6 の 6 scope 仕様に従う。
+ *
+ * - 明示 scope (path[0] が VAR_EXPLICIT_SCOPES の値):
+ *   - flowParameter / action / loop: path[1] が対応 scope set に存在
+ *   - step / tx: path[1]=stepId が stepIndex に存在 + path[2]=name が当該 step の binding と一致
+ *   - global: silent pass (project-level、本 PR scope 外)
+ * - shorthand (path[0] が 6 scope keyword 以外): path[0] を lexical chain (known + loopItems) で検索
+ */
+function checkVarReference(
+  refPath: string[],
+  fieldPath: string,
+  known: Set<string>,
+  loopItems: Set<string>,
+  actionInputs: Set<string>,
+  stepIndex: Map<string, Step>,
+  issues: IdentifierIssue[],
+): void {
+  if (refPath.length === 0) {
+    issues.push({
+      path: fieldPath,
+      code: "UNKNOWN_IDENTIFIER",
+      identifier: "var",
+      message: "@var は単独では参照不可。`@var.<scope>.<name>` または shorthand `@var.<name>` で指定してください",
+    });
+    return;
+  }
+  const scope = refPath[0];
+
+  // shorthand `@var.<name>` — path[0] が 6 scope keyword でなければ name 扱い
+  if (!VAR_EXPLICIT_SCOPES.has(scope)) {
+    if (!known.has(scope) && !loopItems.has(scope)) {
+      issues.push({
+        path: fieldPath,
+        code: "UNKNOWN_IDENTIFIER",
+        identifier: `var.${scope}`,
+        message: `@var.${scope} (shorthand): ${scope} がこのスコープで宣言されていません (inputs / outputs / outputBinding / ambientVariables / loop item のいずれにも無い)`,
+      });
+    }
+    return;
+  }
+
+  // 明示 scope: path[1] が name (step/tx の場合は path[1]=stepId、path[2]=name)
+  if (scope === "global") return; // silent pass、project-level は別 validator
+
+  if (scope === "flowParameter") {
+    const name = refPath[1];
+    if (!name) {
+      issues.push({
+        path: fieldPath,
+        code: "UNKNOWN_IDENTIFIER",
+        identifier: "var.flowParameter",
+        message: "@var.flowParameter.<name> の <name> 部分が欠落",
+      });
+      return;
+    }
+    if (!actionInputs.has(name)) {
+      issues.push({
+        path: fieldPath,
+        code: "UNKNOWN_IDENTIFIER",
+        identifier: `var.flowParameter.${name}`,
+        message: `@var.flowParameter.${name}: ${name} は action.inputs に宣言されていません`,
+      });
+    }
+    return;
+  }
+
+  if (scope === "action") {
+    const name = refPath[1];
+    if (!name) {
+      issues.push({
+        path: fieldPath,
+        code: "UNKNOWN_IDENTIFIER",
+        identifier: "var.action",
+        message: "@var.action.<name> の <name> 部分が欠落",
+      });
+      return;
+    }
+    if (!known.has(name)) {
+      issues.push({
+        path: fieldPath,
+        code: "UNKNOWN_IDENTIFIER",
+        identifier: `var.action.${name}`,
+        message: `@var.action.${name}: ${name} は action scope (inputs / outputs / outputBinding) に宣言されていません`,
+      });
+    }
+    return;
+  }
+
+  if (scope === "loop") {
+    const name = refPath[1];
+    if (!name) {
+      issues.push({
+        path: fieldPath,
+        code: "UNKNOWN_IDENTIFIER",
+        identifier: "var.loop",
+        message: "@var.loop.<name> の <name> 部分が欠落",
+      });
+      return;
+    }
+    if (!loopItems.has(name)) {
+      issues.push({
+        path: fieldPath,
+        code: "UNKNOWN_IDENTIFIER",
+        identifier: `var.loop.${name}`,
+        message: `@var.loop.${name}: ${name} は enclosing loop の collectionItemName / collectionIndexName に宣言されていません`,
+      });
+    }
+    return;
+  }
+
+  if (scope === "step") {
+    const stepId = refPath[1];
+    const name = refPath[2];
+    if (!stepId || !name) {
+      issues.push({
+        path: fieldPath,
+        code: "UNKNOWN_IDENTIFIER",
+        identifier: `var.step.${refPath.slice(1).join(".") || "(missing)"}`,
+        message: "@var.step.<step-id>.<name> の step-id または <name> 部分が欠落",
+      });
+      return;
+    }
+    const step = stepIndex.get(stepId);
+    if (!step) {
+      issues.push({
+        path: fieldPath,
+        code: "UNKNOWN_IDENTIFIER",
+        identifier: `var.step.${stepId}`,
+        message: `@var.step.${stepId}: step-id "${stepId}" が action 内に存在しません`,
+      });
+      return;
+    }
+    const bindName = step.outputBinding?.name;
+    if (bindName && bindName !== name) {
+      issues.push({
+        path: fieldPath,
+        code: "UNKNOWN_IDENTIFIER",
+        identifier: `var.step.${stepId}.${name}`,
+        message: `@var.step.${stepId}.${name}: step "${stepId}" の outputBinding.name は "${bindName}" であり "${name}" と一致しません`,
+      });
+    }
+    // bindName が undefined (= step に outputBinding なし) の場合は検証 skip (silent pass)
+    return;
+  }
+
+  if (scope === "tx") {
+    const stepId = refPath[1];
+    const name = refPath[2];
+    if (!stepId || !name) {
+      issues.push({
+        path: fieldPath,
+        code: "UNKNOWN_IDENTIFIER",
+        identifier: `var.tx.${refPath.slice(1).join(".") || "(missing)"}`,
+        message: "@var.tx.<step-id>.<name> の step-id または <name> 部分が欠落",
+      });
+      return;
+    }
+    const step = stepIndex.get(stepId);
+    if (!step) {
+      issues.push({
+        path: fieldPath,
+        code: "UNKNOWN_IDENTIFIER",
+        identifier: `var.tx.${stepId}`,
+        message: `@var.tx.${stepId}: step-id "${stepId}" が action 内に存在しません`,
+      });
+      return;
+    }
+    if (!isBuiltinStep(step) || step.kind !== "transactionScope") {
+      issues.push({
+        path: fieldPath,
+        code: "UNKNOWN_IDENTIFIER",
+        identifier: `var.tx.${stepId}`,
+        message: `@var.tx.${stepId}: step "${stepId}" は transactionScope ではありません (kind=${(step as { kind?: string }).kind})`,
+      });
+      return;
+    }
+    // 予約値 (committed / error / diagnostics) は常時参照可
+    if (TX_RESERVED_VALUES.has(name)) return;
+    // expose で明示宣言された inner var は OK
+    const exposed = step.outputBinding?.expose ?? [];
+    if (Array.isArray(exposed) && exposed.includes(name)) return;
+    // expose 未宣言: TX scope 越境禁止 (process-flow-variables.md §3.7 / Check 32 で別途厳密検出)
+    // identifierScope は silent pass (Check 32 が detect 担当)
+    return;
+  }
 }
 
 /** 1 step の式フィールドを全走査、@ 識別子を known と突合 */
@@ -194,6 +474,10 @@ function checkStep(
   step: Step,
   path: string,
   availableIn: Set<string>,
+  known: Set<string>,
+  loopItems: Set<string>,
+  actionInputs: Set<string>,
+  stepIndex: Map<string, Step>,
   envVarNames: Set<string>,
   issues: IdentifierIssue[],
 ): void {
@@ -205,6 +489,10 @@ function checkStep(
   const available = new Set(availableIn);
   if (step.kind === "validation" && step.fieldErrorsVar) {
     available.add(step.fieldErrorsVar);
+  }
+  const knownForVar = new Set(known);
+  if (step.kind === "validation" && step.fieldErrorsVar) {
+    knownForVar.add(step.fieldErrorsVar);
   }
 
   const expressions: Array<{ src: string; field: string }> = [];
@@ -278,6 +566,11 @@ function checkStep(
           identifier: key ? `env.${refPath.join(".")}` : "env",
           message: `@env.${refPath.join(".")} が envVars catalog (project + flow merged) で宣言されていません`,
         });
+        continue;
+      }
+      // #1289: @var.<scope>.<name> grammar-aware check
+      if (root === "var") {
+        checkVarReference(refPath, `${path}.${field}`, knownForVar, loopItems, actionInputs, stepIndex, issues);
         continue;
       }
       // 組み込み関数・グローバル識別子は宣言不要


### PR DESCRIPTION
## 関連

- Closes #1289
- 親 grammar 確定: Refs #1264 (closed、RFC verdict 観点 1〜4)
- 親 schema 実装: Refs #1263 Phase X2 (closed、PR #1267 / #1271)
- 兄弟 validator: Refs #1275 (closed、Check 31 で broken-ref 検証実装) / #1286 (open、identifierScope BUILTIN_AMBIENTS 拡張)
- 仕様: docs/spec/process-flow-variables.md §3.6 (scope enum 6 値) / §3.7 (TX expose)
- 仕様: docs/spec/process-flow-prefix-system.md §3 (24 prefix 一覧)

## 概要

#1264 verdict で確定した `@var.<scope>.<name>` 6 値 enum grammar (RFC 観点 1) は schema (#1263 Phase X2) と processFlowAntipatternValidator (#1275 Check 31) には反映済だったが、**identifierScope は取り残されていた**。examples は新 grammar を既に採用していたため、identifierScope が `@var` を bare variable と誤解して UNKNOWN_IDENTIFIER を**計 22 件**多発させていた (5 examples regression check で検出、PR #1286)。

本 PR で identifierScope を **grammar-aware に refactor** し、6 scope 仕様に従って semantic 検証する。同時に regression check で発見した retail step-06 description の TX 不完全 ref も同 PR で吸収修正 (AGENTS.md 鉄則 1、1 行 text 修正)。

## 主な変更

### 主修正: identifierScope grammar-aware refactor (commit deb077ee)

- **`checkVarReference`** 関数を新設、checkStep に root === 'var' の特別処理を追加
- **`buildStepIndex`** で action 内の全 step を id-indexed Map に flatten (ネスト構造を walk)
- **collectionIndexName** を loopItems に注入 (#1264 verdict 観点 3)
- **tryCatch.errorVar** を catch branch-local known に注入 (#1264 verdict 観点 3、scope leak しない)
- **extractReferences regex の path 部に hyphen 許容** (LocalId step-id 対応: `step-01-validate` 等)
- **TX 予約値** committed / error / diagnostics は expose 不要で常時参照可
- expose 未宣言の TX inner var 参照は **silent pass** (Check 32 が別途厳密検出)

### 吸収修正: retail step-06 description の TX 不完全 ref 書き直し (commit 6fbc0157)

regression check で発見、AGENTS.md 鉄則 1 (1-3 時間以内なら本 PR 吸収) に基づき同 PR で対応。`@var.action.txResult` (accessor 欠落) の説明 text を `@var.action.txResult.committed` / `.error.code` / `.diagnostics` の complete form 列挙に置換 (1 行 text 修正)。retail を 6/7 → 7/7 へ。

## scope 別 semantic 検証

| scope | path 形式 | 検証 | 失敗時 identifier |
|---|---|---|---|
| flowParameter | `@var.flowParameter.<name>` | name が action.inputs[].name に存在 | `var.flowParameter.<name>` |
| action | `@var.action.<name>` | name が known (inputs / outputs / outputBinding) に存在 | `var.action.<name>` |
| loop | `@var.loop.<name>` | name が enclosing loop の collectionItemName / collectionIndexName に存在 | `var.loop.<name>` |
| global | `@var.global.<name>` | silent pass (project-level、別 ISSUE 担当) | — |
| step | `@var.step.<stepId>.<name>` | stepId 存在 + name が step.outputBinding.name と一致 | `var.step.<stepId>` / `var.step.<stepId>.<name>` |
| tx | `@var.tx.<stepId>.<name>` | stepId が transactionScope + name が予約値 or expose 列挙 | `var.tx.<stepId>` |
| shorthand | `@var.<name>` | name が lexical chain (known + loopItems) に存在 | `var.<name>` |

## 仕様逐条突合 (自己申告)

- process-flow-variables.md §3.6 (scope enum 6 値): identifierScope.ts:81-89 `VAR_EXPLICIT_SCOPES` 定義 + checkVarReference 内 6 scope 分岐 ✓
- process-flow-variables.md §3.7 (TX 予約値 committed / error / diagnostics): identifierScope.ts:94 `TX_RESERVED_VALUES` ✓
- process-flow-variables.md §3.7 (expose 経由のみ TX 外参照可): checkVarReference scope==='tx' branch で予約値 / expose 列挙チェック ✓
- #1264 verdict 観点 3 (collectionIndexName): identifierScope.ts:227-232 loop の childLoopItems に注入 ✓
- #1264 verdict 観点 3 (tryCatch errorVar named binding): identifierScope.ts:215-219 catch branch 内 branchKnown に注入 ✓
- ISSUE #1289 「実装方針」全項目: 上記の主な変更節と対応 ✓

## レビューで特に見てほしい箇所

- **regex の hyphen 許容** (identifierScope.ts:103): path 部のみ hyphen 追加、root 部は据置 (Identifier camelCase 強制と整合)。既存 `@conv.msg.required` 等の点記法に影響しない (テスト regression 検証済)
- **shorthand vs 明示 scope の判定** (checkVarReference の VAR_EXPLICIT_SCOPES 判定): path[0] が 6 scope keyword と完全一致しない場合は shorthand 扱いに fallback
- **TX expose silent pass** の trade-off: identifierScope レベルでは expose 列挙未対応の場合 silent pass にし、Check 32 で厳密検出する分担
- **catch branch errorVar の scope 制約**: branches[].condition.kind === 'tryCatch' な branch の steps[] のみに注入。兄弟 branch (kind: expression 等) には leak しない (test で leak 検証あり)
- **retail description の text 修正**: 1 commit 別途 (`6fbc0157`)、validator が記述 string 中の @-prefix を analyze するため text 表現を完全 form に揃える方針

## テスト

- Vitest: 55 件 (新規 23 件、6 scope × valid/invalid 各 ~3 + tryCatch errorVar leak/non-leak + retail dogfood 実例 regression) — identifierScope.test.ts
- Playwright: N/A (validator のロジック変更のみ)
- MCP E2E: N/A

## UI 影響 / AI smoke test

- [x] UI 影響なし (auto テスト pass のみ)

理由: identifierScope.ts は純粋 validator。UI 表示には影響しないが、誤検出 error が大幅に減少することで designer の error panel が clean になる方向の改善

## regression check (5 既存 examples、最終)

worktree `fix/issue-1289-identifier-scope-var-grammar` (HEAD `6fbc0157`、retail fix 含む) で `npm run validate:samples`:

| project | Before (PR #1286) | After (本 PR) | 解消件数 |
|---|---|---|---|
| retail | 6/7 (identifierScope 8 errors + antipattern 1) | **7/7 (clean)** | 8 + 1 |
| diary | 12/15 (errors 6 + warnings 4) | **15/15 (warnings 4)** | 6 |
| english-learning | 4/5 (errors 4) | **5/5 (clean)** | 4 |
| english-learning-tailwind | 4/5 (errors 4) | **5/5 (clean)** | 4 |
| realestate | 1/1 (clean) | 1/1 (clean、@var 未使用) | 0 |

**合計 23 件 error 解消**、5 examples すべて clean。diary に残る warnings 4 件は pre-existing で本 PR scope 外。

## spec 側の不足点 / 提案

N/A — process-flow-variables.md §3.6 / §3.7 の canonical spec と整合済。

## レビュー担当への申し送り

- 本 PR は PR #1286 (#1285) の regression check で発見した validator gap の独立 PR。#1286 と本 PR は独立 mergeable、順序問わず
- household-budget サンプル (PR 未作成、`feat/example-household-budget` ブランチ) では `@var.fieldErrors` の暫定回避策として `@fieldErrors` shorthand を使用中。本 PR merge 後、本来の `@var.<name>` shorthand 形式に書き戻し可能 (どちらも本 PR で対応済の grammar)
- retail description 修正は本来 retail 改善 ISSUE 候補だが、regression check 由来の同根発見 (AGENTS.md 鉄則 1、1 行 text 修正で 5 min 以内) のため本 PR 内吸収