### PR TITLE
feat(designer): #1302 varScopeResolver Phase 2-bis — step/tx/loop name 補完

### DIFF
--- a/docs/spec/process-flow-variables.md
+++ b/docs/spec/process-flow-variables.md
@@ -313,6 +313,19 @@ current step → enclosing loop/tryCatch → enclosing tx → action → flowPar
 
 editor 編集時の補完では両方の候補が並列に出る (resolver 別)。詳細は [process-flow-prefix-system.md § 11](process-flow-prefix-system.md#11-designer-time-alias-this--self-1301)。
 
+#### resolver 補完範囲 (#1282 / #1302)
+
+`@var.<scope>.<name>` の補完 resolver (`varScopeResolver`) の実装状況:
+
+| scope | Phase 1/2 (#1282) | Phase 2-bis (#1302) |
+|---|---|---|
+| `flowParameter` | ✅ name 補完 | — |
+| `action` | ✅ name 補完 | — |
+| `step` | — | ✅ name 補完 (全 step id、TX/loop/branch 内 nested 含む) |
+| `tx` | — | ✅ name 補完 (kind="transactionScope" の id のみ) |
+| `loop` | — | ✅ name 補完 (collectionItemName / collectionIndexName / outputBinding.name) |
+| `global` | — | ⚠️ 空候補 (catalog 未確立、別 ISSUE で対応予定) |
+
 ### 3.7 TX (transactionScope) 境界での変数挙動 (#1264 verdict 観点 4 / #1267 Round 7 option C)
 
 R3 で 3 AI 完全合流した折衷案を、Round 7 で **option C (expose を任意 inner var 名まで拡張)** として最終化:

--- a/docs/spec/process-flow-variables.md
+++ b/docs/spec/process-flow-variables.md
@@ -249,7 +249,7 @@ RFC #1264 で確定した hybrid scope chain (case C) の具体仕様。**暗黙
 | `action` | action body 全体で生きる | action 全体 | `@var.action.totalAmount` |
 | `step.<step-id>` | step 出力 binding (`outputBinding.name`) | scope enter で生成 / exit で破棄 | `@var.step.step-05.newOrderNumber` |
 | `tx.<tx-id>` | TransactionScopeStep 内 binding | TX commit でマージ / rollback で破棄 | `@var.tx.step-06.txResult` |
-| `loop` | loop iteration 内 (`collectionItemName` / `collectionIndexName`) | iteration ごとに fresh | `@var.loop.cartItem`、`@var.loop.idx` |
+| `loop` | loop iteration 内 (`collectionItemName` / `collectionIndexName` / push operation の `outputBinding.name`) | iteration ごとに fresh / `outputBinding.name` は loop 終了後 enclosing scope に push | `@var.loop.cartItem`、`@var.loop.idx`、`@var.loop.enrichedItems` |
 | `global` | workspace / project 横断 (mutable、`@const` と区別) | session 全体 | `@var.global.tenantId` |
 
 `step.` / `tx.` 接頭辞は具体的な step-id / tx-id を後続する (LocalId pattern)。

--- a/frontend/src/utils/reference-completer/varScopeResolver.test.ts
+++ b/frontend/src/utils/reference-completer/varScopeResolver.test.ts
@@ -1,11 +1,12 @@
-// #1282: varScopeResolver unit tests (5 件)
+// #1282: varScopeResolver unit tests
+// #1302: Phase 2-bis テスト (step / tx / loop / global name 補完) 追加
 
 import { describe, expect, it } from "vitest";
 import { varScopeResolver } from "./varScopeResolver";
 import type { CompletionContext } from "./types";
 import type { ProcessFlow as V3ProcessFlow } from "../../types/v3";
 
-// 最小限の ProcessFlow fixture
+// 最小限の ProcessFlow fixture (Phase 1/2 用)
 const mockFlow = {
   id: "flow-1",
   name: "テストフロー",
@@ -29,6 +30,57 @@ const mockFlow = {
 } as unknown as V3ProcessFlow;
 
 const ctx: CompletionContext = { flow: mockFlow };
+
+// Phase 2-bis テスト用 fixture (loop / tx / nested step 含む)
+const mockFlowPhase2bis = {
+  id: "flow-1",
+  name: "テストフロー",
+  actions: [
+    {
+      id: "action-1",
+      name: "処理1",
+      inputs: [{ name: "orderId", type: "string" }],
+      steps: [
+        {
+          id: "step-01",
+          kind: "dbAccess",
+          outputBinding: { name: "userResult" },
+        },
+        {
+          id: "step-tx-01",
+          kind: "transactionScope",
+          isolationLevel: "READ_COMMITTED",
+          rollbackOn: [],
+          outputBinding: { name: "txResult", expose: [] },
+          steps: [
+            {
+              id: "step-02",
+              kind: "dbAccess",
+              outputBinding: { name: "createdOrder" },
+            },
+          ],
+        },
+        {
+          id: "step-loop-01",
+          kind: "loop",
+          loopKind: "collection",
+          collectionSource: "@var.flowParameter.cartItems",
+          collectionItemName: "cartItem",
+          collectionIndexName: "cartItemIdx",
+          outputBinding: { name: "enrichedItems", operation: "push", initialValue: "[]" },
+          steps: [
+            {
+              id: "step-03",
+              kind: "compute",
+              expression: "@var.loop.cartItem.price * @var.loop.cartItem.quantity",
+              outputBinding: { name: "lineTotal" },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+} as unknown as V3ProcessFlow;
 
 describe("varScopeResolver", () => {
   it("@var. 入力で 6 scope enum 全件候補", () => {
@@ -83,17 +135,73 @@ describe("varScopeResolver", () => {
     expect(state.candidates.map((c) => c.value)).toContain("orderResult");
   });
 
-  // S-3: Phase 1 範囲固定 — step / tx の name 補完は Phase 2-bis 未対応
-  it("@var.step.<id> name 補完は Phase 2-bis 未対応のため候補なし", () => {
-    const value = "@var.step.foo";
-    const state = varScopeResolver.match(value, value.length, { flow: mockFlow });
-    // Phase 2 regex は (flowParameter|action) 限定のため null
-    expect(state).toBeNull();
+  // Phase 2-bis: step scope
+  it("@var.step. で全 step id が候補になる (nested TX/loop 内含む)", () => {
+    const value = "@var.step.";
+    const state = varScopeResolver.match(value, value.length, { flow: mockFlowPhase2bis });
+    expect(state?.phase).toBe("active");
+    if (state?.phase !== "active") return;
+    const values = state.candidates.map((c) => c.value);
+    expect(values).toContain("step-01");
+    expect(values).toContain("step-tx-01");
+    expect(values).toContain("step-02"); // TX 内 nested
+    expect(values).toContain("step-loop-01");
+    expect(values).toContain("step-03"); // loop 内 nested
+    expect(values.length).toBe(5);
   });
 
-  it("@var.tx.<id> name 補完も Phase 2-bis 未対応のため候補なし", () => {
-    const value = "@var.tx.bar";
-    const state = varScopeResolver.match(value, value.length, { flow: mockFlow });
-    expect(state).toBeNull();
+  it("@var.step.step- で prefix フィルタが効く", () => {
+    const value = "@var.step.step-";
+    const state = varScopeResolver.match(value, value.length, { flow: mockFlowPhase2bis });
+    expect(state?.phase).toBe("active");
+    if (state?.phase !== "active") return;
+    const values = state.candidates.map((c) => c.value);
+    // "step-01", "step-tx-01", "step-02", "step-loop-01", "step-03" は全て "step-" で始まる
+    expect(values.length).toBe(5);
+    values.forEach((v) => expect(v.startsWith("step-")).toBe(true));
+  });
+
+  it("@var.step.foo で候補なし (foo 始まりの step id がない)", () => {
+    const value = "@var.step.foo";
+    const state = varScopeResolver.match(value, value.length, { flow: mockFlowPhase2bis });
+    expect(state?.phase).toBe("active");
+    if (state?.phase !== "active") return;
+    expect(state.candidates).toHaveLength(0);
+  });
+
+  // Phase 2-bis: tx scope
+  it("@var.tx. で kind=transactionScope の id のみ候補になる", () => {
+    const value = "@var.tx.";
+    const state = varScopeResolver.match(value, value.length, { flow: mockFlowPhase2bis });
+    expect(state?.phase).toBe("active");
+    if (state?.phase !== "active") return;
+    const values = state.candidates.map((c) => c.value);
+    expect(values).toContain("step-tx-01");
+    // 通常 step / loop step は含まれない
+    expect(values).not.toContain("step-01");
+    expect(values).not.toContain("step-loop-01");
+    expect(values.length).toBe(1);
+  });
+
+  // Phase 2-bis: loop scope
+  it("@var.loop. で loop の collectionItemName / collectionIndexName / outputBinding.name が候補になる", () => {
+    const value = "@var.loop.";
+    const state = varScopeResolver.match(value, value.length, { flow: mockFlowPhase2bis });
+    expect(state?.phase).toBe("active");
+    if (state?.phase !== "active") return;
+    const values = state.candidates.map((c) => c.value);
+    expect(values).toContain("cartItem");       // collectionItemName
+    expect(values).toContain("cartItemIdx");    // collectionIndexName
+    expect(values).toContain("enrichedItems"); // outputBinding.name
+    expect(values.length).toBe(3);
+  });
+
+  // Phase 2-bis: global scope (空候補)
+  it("@var.global. で空候補 (catalog 未確立、phase active のまま)", () => {
+    const value = "@var.global.";
+    const state = varScopeResolver.match(value, value.length, { flow: mockFlowPhase2bis });
+    expect(state?.phase).toBe("active");
+    if (state?.phase !== "active") return;
+    expect(state.candidates).toHaveLength(0);
   });
 });

--- a/frontend/src/utils/reference-completer/varScopeResolver.ts
+++ b/frontend/src/utils/reference-completer/varScopeResolver.ts
@@ -1,14 +1,16 @@
 /**
- * @var.<scope>.<name> 補完 Resolver (#1282)。
+ * @var.<scope>.<name> 補完 Resolver (#1282 Phase 1/2 / #1302 Phase 2-bis)。
  *
- * Phase 1: scope (flowParameter / action / step / tx / loop / global) の補完 +
- *           flowParameter / action の name 補完まで実装。
- * Phase 2-bis (別 ISSUE): step.<id> / tx.<id> / loop / global の name 補完は未対応。
+ * Phase 1: scope (flowParameter / action / step / tx / loop / global) の補完
+ * Phase 2: flowParameter / action の name 補完
+ * Phase 2-bis (#1302): step / tx / loop の name 補完を追加。
+ *                      global は catalog spec 未確立のため空候補 (別 ISSUE で対応予定)
  *
  * spec 出典: process-flow-variables.md §3.6
  */
 
 import type { CompletionContext, CompletionState, Resolver } from "./types";
+import type { ProcessFlow as V3ProcessFlow } from "../../types/v3";
 
 const SCOPE_KEYS = ["flowParameter", "action", "step", "tx", "loop", "global"] as const;
 
@@ -18,13 +20,14 @@ export const varScopeResolver: Resolver = {
   match(value: string, cursorPos: number, ctx: CompletionContext): CompletionState | null {
     const before = value.slice(0, cursorPos);
 
-    // Phase 2: @var.flowParameter.<name> / @var.action.<name> の name 補完
-    const n = before.match(/@var\.(flowParameter|action)\.([\w-]*)$/);
+    // Phase 2 + Phase 2-bis: @var.<scope>.<name> の name 補完
+    const n = before.match(/@var\.(flowParameter|action|step|tx|loop|global)\.([\w-]*)$/);
     if (n) {
       if (!ctx.flow) return null;
       const scope = n[1];
       const namePrefix = n[2];
       const names = new Set<string>();
+
       if (scope === "flowParameter") {
         for (const action of ctx.flow.actions) {
           for (const inp of action.inputs ?? []) {
@@ -39,7 +42,36 @@ export const varScopeResolver: Resolver = {
             if (ob?.name && typeof ob.name === "string") names.add(ob.name);
           }
         }
+      } else if (scope === "step") {
+        // step id を全列挙 (TX/loop/branch 内 nested 含む)
+        for (const { step } of iterAllSteps(ctx.flow)) {
+          const sAny = step as Record<string, unknown>;
+          if (typeof sAny.id === "string") names.add(sAny.id);
+        }
+      } else if (scope === "tx") {
+        // kind === "transactionScope" の id のみ
+        for (const { step } of iterAllSteps(ctx.flow)) {
+          const sAny = step as Record<string, unknown>;
+          if (sAny.kind === "transactionScope" && typeof sAny.id === "string") {
+            names.add(sAny.id);
+          }
+        }
+      } else if (scope === "loop") {
+        // loop step の collectionItemName / collectionIndexName / outputBinding.name
+        for (const { step } of iterAllSteps(ctx.flow)) {
+          const sAny = step as Record<string, unknown>;
+          if (sAny.kind === "loop") {
+            if (typeof sAny.collectionItemName === "string") names.add(sAny.collectionItemName);
+            if (typeof sAny.collectionIndexName === "string") names.add(sAny.collectionIndexName);
+            const ob = sAny.outputBinding as Record<string, unknown> | undefined;
+            if (ob?.name && typeof ob.name === "string") names.add(ob.name);
+          }
+        }
+      } else if (scope === "global") {
+        // 候補 source 未確立 (spec/schema governance 未対応、別 ISSUE 起票済)
+        // 空候補返却で OK (resolver は active mode、candidates: [])
       }
+
       const candidates = [...names]
         .filter((nm) => nm.startsWith(namePrefix))
         .map((v) => ({ value: v }));
@@ -72,3 +104,31 @@ export const varScopeResolver: Resolver = {
     return null;
   },
 };
+
+/** flow.actions[].steps[] を再帰列挙 (TX/loop/branch 内の nested step も含む) */
+function* iterAllSteps(flow: V3ProcessFlow): Generator<{ step: unknown }> {
+  for (const action of flow.actions) {
+    yield* iterSteps(action.steps ?? []);
+  }
+}
+
+function* iterSteps(steps: unknown[]): Generator<{ step: unknown }> {
+  for (const s of steps) {
+    yield { step: s };
+    const sAny = s as Record<string, unknown>;
+    // TX scope の子 step
+    if (sAny.kind === "transactionScope" && Array.isArray(sAny.steps)) {
+      yield* iterSteps(sAny.steps);
+    }
+    // loop scope の子 step
+    if (sAny.kind === "loop" && Array.isArray(sAny.steps)) {
+      yield* iterSteps(sAny.steps);
+    }
+    // branch scope の子 step
+    if (sAny.kind === "branch" && Array.isArray(sAny.branches)) {
+      for (const br of sAny.branches as Record<string, unknown>[]) {
+        if (Array.isArray(br.steps)) yield* iterSteps(br.steps);
+      }
+    }
+  }
+}

--- a/frontend/src/utils/reference-completer/varScopeResolver.ts
+++ b/frontend/src/utils/reference-completer/varScopeResolver.ts
@@ -68,8 +68,9 @@ export const varScopeResolver: Resolver = {
           }
         }
       } else if (scope === "global") {
-        // 候補 source 未確立 (spec/schema governance 未対応、別 ISSUE 起票済)
-        // 空候補返却で OK (resolver は active mode、candidates: [])
+        // 候補 source 未確立 (spec/schema governance 未対応、follow-up ISSUE で対応予定)
+        // project.json / harmony.json に globals catalog が未定義のため、空候補返却で OK
+        // (resolver は active mode、candidates: [] — ユーザーは自由入力可能)
       }
 
       const candidates = [...names]


### PR DESCRIPTION
## 概要

`varScopeResolver` を Phase 2-bis に拡張し、`@var.<scope>.<name>` の name 補完を `step` / `tx` / `loop` 3 scope で実装。`global` は catalog spec 未確立のため空候補 + follow-up ISSUE 起票予定で trace。

## 解決する ISSUE

Closes #1302

## 背景

#1282 (closed) で varScopeResolver Phase 1 (scope enum 補完) + Phase 2 (flowParameter / action name 補完) を実装。残 4 scope の name 補完が本 ISSUE。spec: `docs/spec/process-flow-variables.md §3.6`。

## 変更点 (file:line)

### resolver
- `frontend/src/utils/reference-completer/varScopeResolver.ts` (134 行) — Phase 2 regex を `(flowParameter|action)` → `(flowParameter|action|step|tx|loop|global)` に拡張、各 scope の name 候補生成ロジック追加、`iterAllSteps` / `iterSteps` helper (TX/loop/branch 内 nested step 再帰列挙) 追加

### test
- `frontend/src/utils/reference-completer/varScopeResolver.test.ts` (207 行) — Phase 2-bis テスト 6 件追加 (step / step prefix / step foo-no-match / tx / loop / global)、mockFlowPhase2bis fixture 追加 (TX/loop nested step 含む)、既存 S-3 null assert 2 件削除

### spec
- `docs/spec/process-flow-variables.md` §3.6 line 252 — loop 行に push operation の `outputBinding.name` を追加 (resolver 補完範囲との整合)
- `docs/spec/process-flow-variables.md` §3.6 末尾 — 「resolver 補完範囲 (#1282 / #1302)」表を挿入

## 仕様逐条突合 (自己申告)

- ✅ `step.<id>`: 全 step id を flat 列挙 (TX/loop/branch 内 nested 含む) — varScopeResolver.ts iterAllSteps 経由 (line 41-49 付近)
- ✅ `tx.<id>`: kind === "transactionScope" の id のみ (line 51-58 付近)
- ✅ `loop.<name>`: loop step の collectionItemName / collectionIndexName / outputBinding.name 3 source (line 60-69)
- ✅ `global.<key>`: 空候補返却 (`candidates: []`、phase: "active") — catalog 未確立、follow-up ISSUE で対応予定 (line 70-74)
- ✅ 既存 Phase 1/2 (`flowParameter` / `action`) は regex 拡張のみで動作不変

## review 対応 (PR #1309 独立レビュー)

- **S-1**: varScopeResolver.ts:71 コメント「別 ISSUE 起票済」 → 「起票予定 (本 PR merge 後)」に修正
- **S-2**: spec §3.6 line 252 loop 行に `outputBinding.name` を追記 (resolver 補完範囲表との整合確保)
- **N-1**: PR description の file 規模を実際の行数 (134 / 207) に修正

## 検証

- `npx tsc --noEmit` (frontend): 0 errors
- `npx vitest run src/utils/reference-completer/varScopeResolver.test.ts`: 11 件 pass (既存 5 + 新規 6)
- `npx vitest run src/utils/reference-completer/`: 86 件 pass (退行なし)
- `git diff --name-only origin/main..HEAD -- schemas/`: empty (schema 変更なし)

## scope 外 (別 ISSUE で対応)

- `@var.global.<key>` の候補 source (globals catalog 確立): schema/spec governance 案件 (#511) → Opus が本 PR merge 後に起票

## Test plan

- [x] vitest varScopeResolver 11 件全 pass
- [x] 既存 reference-completer test regression なし (86 件 pass)
- [x] tsc 0 errors
- [x] schemas/ 変更なし
- [x] 独立レビュー (Sonnet) Must-fix 0、Should-fix 2 件解消、Nit 1 件対応