### PR TITLE
feat(spec/schema/designer): #1303 effects[] value UI + dialog/messageArea/options 新 kind + resolver

### DIFF
--- a/docs/spec/generic-definition-layer.md
+++ b/docs/spec/generic-definition-layer.md
@@ -222,7 +222,9 @@ PageLayout "admin-layout"  ←  ページ全体の枠
 - **`mappingHints` は完全 optional / advisory** (任意): 特定 techStack (Spring / Nest / Next 等) への codegen 時のヒント。設計書の本質ではなく **AI 生成側のチューニング材料**。本 spec の Spring/Nest/Next 例はあくまでサンプルで、Django / Rails / Vue 等への展開も自由
 - `mappingHints` が無くても **言語非依存の本体だけで設計意図は完結する** こと。逆に `mappingHints` だけで設計意図を表現するのは禁止 (本体に migrate する)
 
-### 4.2 8 種類の kind
+### 4.2 17 種類の kind
+
+初期 7 種 (#1064-#1068) → Phase X2 で 14 種 (#1263) → #1303 で 17 種に拡張。
 
 | kind | 用途 | 主な参照元 |
 |---|---|---|
@@ -230,10 +232,19 @@ PageLayout "admin-layout"  ←  ページ全体の枠
 | `domain-type` | Entity / Model などドメイン型 (永続化を含む) | table 補完 / ProcessFlow |
 | `exception-type` | 例外種別・階層・semantic kind | errorCode catalog |
 | `application-rule` | 認証認可ポリシー / ログ / 監査 / 例外変換 / 横断ルール | project-level config |
+| `validation-rule` | 業務検証ルール (条件 + メッセージ + severity) | `@validation.<name>` |
 | `ui-behavior` | 画面横断振る舞い (dirty check / dialog / datepicker / 二重送信防止) | ScreenItem.event.effects[] / screen.commonBehaviors[] |
 | `runtime-policy` | retry / timeout / circuit breaker / cache (横断適用ポリシー) | ProcessFlow step / external system |
 | `component-definition` | service / mapper / repository / validator / formatter / facade / adapter / helper 等の責務 | ProcessFlow.componentCall |
 | `ui-fragment` | 再利用 UI 断片 (ヘッダー / フッター / メッセージ領域等) | screen.fragments[] |
+| `constants` | ドメイン定数集 | `@const.<key>` |
+| `message` | メッセージカタログ (i18n source) | `@msg.<key>` |
+| `domain-event` | ドメインイベント定義 | `@event.<topic>` |
+| `log-event` | ログイベント定義 (構造化ログ) | `@logEvent.<key>` |
+| `log-config` | ログ設定 (log level / sink / format) | `@logConfig.<key>` |
+| `dialog` | confirm / alert / custom dialog の定義 (ScreenItemEvent.effects[].showDialog.target 参照先) | `@dialog.<name>` |
+| `messageArea` | 画面横断 message area の定義 (ScreenItemEvent.effects[].setMessage.target 参照先) | `@messageArea.<name>` |
+| `options` | 選択肢カタログ (ScreenItemEvent.effects[].setOptions 動的差し替え参照先) | `@options.<name>` |
 
 ### 4.3 既存仕様との関係
 

--- a/frontend/src/components/generic-definition/GenericDefinitionCatalogView.tsx
+++ b/frontend/src/components/generic-definition/GenericDefinitionCatalogView.tsx
@@ -26,6 +26,9 @@ const KIND_ICONS: Record<GenericDefinitionKind, string> = {
   "domain-event": "bi-broadcast",
   "log-event": "bi-journal-text",
   "log-config": "bi-sliders",
+  dialog: "bi-chat-square",
+  messageArea: "bi-chat-left-text",
+  options: "bi-list-ul",
 };
 
 const KIND_DESCRIPTIONS: Record<GenericDefinitionKind, string> = {
@@ -43,6 +46,9 @@ const KIND_DESCRIPTIONS: Record<GenericDefinitionKind, string> = {
   "domain-event": "業務イベント (発生条件 / payload / publisher) を定義します (`@event.<topic>` 参照元、#1263 Phase X2)",
   "log-event": "構造化ログイベントを定義します (`@logEvent.<key>` 参照元、#1263 Phase X2)",
   "log-config": "ログ設定 (log level / sink / format) を定義します (`@logConfig.<key>` 参照元、#1263 Phase X2)",
+  dialog: "画面から呼び出すダイアログ定義 (`@dialog.<name>` 参照元、#1303)",
+  messageArea: "画面内メッセージエリア定義 (`@messageArea.<name>` 参照元、#1303)",
+  options: "選択肢カタログ (selectbox / radio 等の選択肢セット) を定義します (`@options.<name>` 参照元、#1303)",
 };
 
 export function GenericDefinitionCatalogView() {

--- a/frontend/src/components/screen-items/ScreenItemsView.tsx
+++ b/frontend/src/components/screen-items/ScreenItemsView.tsx
@@ -1476,22 +1476,73 @@ export function ScreenItemsView() {
                                             placeholder="target (ScreenItem.id)"
                                             disabled={isReadonly}
                                           />
-                                          <input
-                                            className="form-control form-control-sm screen-items-event-effect-value"
-                                            value={String(eff.value)}
-                                            onChange={(e) => {
-                                              const raw = e.target.value;
-                                              const val: boolean | TemplateString =
-                                                raw === "true" ? true : raw === "false" ? false : (raw as TemplateString);
-                                              const next = (ev.effects ?? []).map((item, ii) =>
-                                                ii === fIdx ? { ...eff, value: val } : item
-                                              );
-                                              handleUpdateEvent(i, eIdx, { effects: next });
-                                            }}
-                                            onBlur={commit}
-                                            placeholder="true / false / 式"
-                                            disabled={isReadonly}
-                                          />
+                                          {/* value 編集 — boolean / expression 切替 (#1303 課題 1) */}
+                                          {typeof eff.value === "boolean" ? (
+                                            <span className="screen-items-event-effect-value-boolean">
+                                              <label className="form-check-label d-flex align-items-center gap-1">
+                                                <input
+                                                  type="checkbox"
+                                                  className="form-check-input m-0"
+                                                  checked={eff.value}
+                                                  onChange={(e) => {
+                                                    const next = (ev.effects ?? []).map((item, ii) =>
+                                                      ii === fIdx ? { ...eff, value: e.target.checked } : item
+                                                    );
+                                                    handleUpdateEvent(i, eIdx, { effects: next });
+                                                    commit();
+                                                  }}
+                                                  disabled={isReadonly}
+                                                />
+                                                {eff.value ? "true" : "false"}
+                                              </label>
+                                              <button
+                                                type="button"
+                                                className="btn btn-sm btn-link p-0 ms-2"
+                                                onClick={() => {
+                                                  const next = (ev.effects ?? []).map((item, ii) =>
+                                                    ii === fIdx ? { ...eff, value: "" as TemplateString } : item
+                                                  );
+                                                  handleUpdateEvent(i, eIdx, { effects: next });
+                                                  commit();
+                                                }}
+                                                disabled={isReadonly}
+                                                title="式モードに切替"
+                                              >
+                                                式に切替
+                                              </button>
+                                            </span>
+                                          ) : (
+                                            <span className="screen-items-event-effect-value-expression">
+                                              <input
+                                                className="form-control form-control-sm screen-items-event-effect-value"
+                                                value={eff.value as string}
+                                                onChange={(e) => {
+                                                  const next = (ev.effects ?? []).map((item, ii) =>
+                                                    ii === fIdx ? { ...eff, value: e.target.value as TemplateString } : item
+                                                  );
+                                                  handleUpdateEvent(i, eIdx, { effects: next });
+                                                }}
+                                                onBlur={commit}
+                                                placeholder="@var.* / TemplateString 式"
+                                                disabled={isReadonly}
+                                              />
+                                              <button
+                                                type="button"
+                                                className="btn btn-sm btn-link p-0 ms-2"
+                                                onClick={() => {
+                                                  const next = (ev.effects ?? []).map((item, ii) =>
+                                                    ii === fIdx ? { ...eff, value: false } : item
+                                                  );
+                                                  handleUpdateEvent(i, eIdx, { effects: next });
+                                                  commit();
+                                                }}
+                                                disabled={isReadonly}
+                                                title="boolean モードに切替"
+                                              >
+                                                boolean に戻す
+                                              </button>
+                                            </span>
+                                          )}
                                         </>
                                       )}
                                       {eff.kind === "setOptions" && (

--- a/frontend/src/components/screen-items/ScreenItemsView.tsx
+++ b/frontend/src/components/screen-items/ScreenItemsView.tsx
@@ -65,6 +65,8 @@ import type { ProcessFlowMeta } from "../../types/flow";
 import { listProcessFlows } from "../../store/processFlowStore";
 import { listTables, loadTable } from "../../store/tableStore";
 import { listViews, loadView } from "../../store/viewStore";
+import { listGenericDefinitions } from "../../store/genericDefinitionStore";
+import { genericDefinitionResolver } from "../../utils/reference-completer/genericDefinitionResolver";
 import type { Table, View } from "../../types/v3";
 import { ConvCompletionInput } from "../common/ConvCompletionInput";
 import { ScreenItemCandidatesModal } from "./ScreenItemCandidatesModal";
@@ -181,6 +183,27 @@ export function ScreenItemsView() {
 
   // ワークスペース全参照情報 (handlerFlowId / handlerActionId 補完用、#1260 A)
   const workspace = useWorkspaceReferences();
+
+  // generic-definitions catalog (kind 別、dialog / messageArea / options 補完用、#1303)
+  const [genericDefinitionsByKind, setGenericDefinitionsByKind] = useState<Record<string, { name: string }[]>>({});
+  useEffect(() => {
+    if (!wsPath) return;
+    // dialog / messageArea / options の 3 kind を並列ロード
+    Promise.all([
+      listGenericDefinitions("dialog").catch(() => [] as { name: string }[]),
+      listGenericDefinitions("messageArea").catch(() => [] as { name: string }[]),
+      listGenericDefinitions("options").catch(() => [] as { name: string }[]),
+    ]).then(([dialogs, messageAreas, options]) => {
+      setGenericDefinitionsByKind({
+        dialog: dialogs.map((d) => ({ name: d.name })),
+        messageArea: messageAreas.map((m) => ({ name: m.name })),
+        options: options.map((o) => ({ name: o.name })),
+      });
+    }).catch(() => {
+      // ロード失敗時は空 object (resolver が空候補返却)
+      setGenericDefinitionsByKind({});
+    });
+  }, [wsPath]);
 
   // 処理フロー・テーブル・ビュー一覧をロード (valueFrom セレクタ用、列まで含む完全形)
   useEffect(() => {
@@ -1560,34 +1583,60 @@ export function ScreenItemsView() {
                                             placeholder="target (ScreenItem.id)"
                                             disabled={isReadonly}
                                           />
-                                          <input
-                                            className="form-control form-control-sm screen-items-event-effect-value"
+                                          {/* value: @options.<name> 補完対応 (#1303) */}
+                                          <ReferenceCompletionInput
                                             value={eff.value}
-                                            onChange={(e) => {
+                                            onValueChange={(val) => {
                                               const next = (ev.effects ?? []).map((item, ii) =>
-                                                ii === fIdx ? { ...eff, value: e.target.value } : item
+                                                ii === fIdx ? { ...eff, value: val } : item
                                               );
                                               handleUpdateEvent(i, eIdx, { effects: next });
                                             }}
-                                            onBlur={commit}
-                                            placeholder="catalogRef / 式"
+                                            onCommit={commit}
+                                            resolvers={[screenHierarchicalResolver, thisResolver, selfResolver, genericDefinitionResolver, convResolver]}
+                                            ctx={{
+                                              workspace,
+                                              conventions,
+                                              currentScreenId: screenId,
+                                              currentScreenItems: (file?.items ?? []).map((it) => ({ id: it.id, label: it.label })),
+                                              currentDocumentKind: "screen",
+                                              currentSelfRef: file?.items[i]
+                                                ? { kind: "screenItem", id: file.items[i].id }
+                                                : undefined,
+                                              genericDefinitionsByKind,
+                                            }}
+                                            className="form-control form-control-sm screen-items-event-effect-value"
+                                            placeholder="@options.<name> / catalogRef / 式"
                                             disabled={isReadonly}
                                           />
                                         </>
                                       )}
                                       {(eff.kind === "showDialog" || eff.kind === "setMessage") && (
                                         <>
-                                          <input
-                                            className="form-control form-control-sm screen-items-event-effect-value"
+                                          {/* target: @dialog.<name> / @messageArea.<name> 補完対応 (#1303) */}
+                                          <ReferenceCompletionInput
                                             value={eff.target}
-                                            onChange={(e) => {
+                                            onValueChange={(val) => {
                                               const next = (ev.effects ?? []).map((item, ii) =>
-                                                ii === fIdx ? { ...eff, target: e.target.value } : item
+                                                ii === fIdx ? { ...eff, target: val } : item
                                               );
                                               handleUpdateEvent(i, eIdx, { effects: next });
                                             }}
-                                            onBlur={commit}
-                                            placeholder="target (dialogRef / messageAreaRef)"
+                                            onCommit={commit}
+                                            resolvers={[screenHierarchicalResolver, thisResolver, selfResolver, genericDefinitionResolver, convResolver]}
+                                            ctx={{
+                                              workspace,
+                                              conventions,
+                                              currentScreenId: screenId,
+                                              currentScreenItems: (file?.items ?? []).map((it) => ({ id: it.id, label: it.label })),
+                                              currentDocumentKind: "screen",
+                                              currentSelfRef: file?.items[i]
+                                                ? { kind: "screenItem", id: file.items[i].id }
+                                                : undefined,
+                                              genericDefinitionsByKind,
+                                            }}
+                                            className="form-control form-control-sm screen-items-event-effect-value"
+                                            placeholder={eff.kind === "showDialog" ? "@dialog.<name>" : "@messageArea.<name>"}
                                             disabled={isReadonly}
                                           />
                                           <input

--- a/frontend/src/schemas/genericDefinitionValidator.ts
+++ b/frontend/src/schemas/genericDefinitionValidator.ts
@@ -4,10 +4,11 @@
  * draft-state-policy §6 に基づき、AJV で schema 検証 + kind 固有 semantic warning を提供する。
  * validateHarmony.ts のキャッシュパターンに倣い、singleton AJV + 初回呼び出し時 compile。
  *
- * #1263 Phase X2 (#1267 Opus Round 4 Should-fix #1): 全 14 kind に固有 schema が存在する。
+ * #1263 Phase X2 (#1267 Opus Round 4 Should-fix #1): 全 17 kind に固有 schema が存在する。
  * 旧 8 kind (data-contract / domain-type / exception-type / application-rule / ui-behavior /
  *   runtime-policy / ui-fragment) + 新 7 kind (component-definition / validation-rule /
  *   constants / message / domain-event / log-event / log-config) すべて KIND_SCHEMAS に登録。
+ * #1303: 新 3 kind (dialog / messageArea / options) を追加 (全 17 kind)。
  */
 
 import type Ajv2020 from "ajv/dist/2020";
@@ -30,6 +31,10 @@ import messageSchema from "../../../schemas/v3/generic-definitions/message.v3.sc
 import domainEventSchema from "../../../schemas/v3/generic-definitions/domain-event.v3.schema.json";
 import logEventSchema from "../../../schemas/v3/generic-definitions/log-event.v3.schema.json";
 import logConfigSchema from "../../../schemas/v3/generic-definitions/log-config.v3.schema.json";
+// #1303 — 3 新規 sub-schema (dialog / messageArea / options)
+import dialogSchema from "../../../schemas/v3/generic-definitions/dialog.v3.schema.json";
+import messageAreaSchema from "../../../schemas/v3/generic-definitions/messageArea.v3.schema.json";
+import optionsSchema from "../../../schemas/v3/generic-definitions/options.v3.schema.json";
 
 export interface GenericDefinitionIssue {
   kind: GenericDefinitionKind;
@@ -39,7 +44,7 @@ export interface GenericDefinitionIssue {
   severity: "error" | "warning";
 }
 
-// kind → 固有 schema の $id (#1263 Phase X2: 14 kind 全件)
+// kind → 固有 schema の $id (#1263 Phase X2: 14 kind 全件 + #1303: 3 新規 kind = 全 17 kind)
 const KIND_SCHEMAS: Partial<Record<GenericDefinitionKind, object>> = {
   "data-contract": dataContractSchema as object,
   "exception-type": exceptionTypeSchema as object,
@@ -56,6 +61,10 @@ const KIND_SCHEMAS: Partial<Record<GenericDefinitionKind, object>> = {
   "domain-event": domainEventSchema as object,
   "log-event": logEventSchema as object,
   "log-config": logConfigSchema as object,
+  // #1303 — 3 新規 kind
+  dialog: dialogSchema as object,
+  messageArea: messageAreaSchema as object,
+  options: optionsSchema as object,
 };
 
 type ValidateFn = ReturnType<InstanceType<typeof Ajv2020>["compile"]>;

--- a/frontend/src/schemas/identifierScope.ts
+++ b/frontend/src/schemas/identifierScope.ts
@@ -47,8 +47,8 @@ export interface IdentifierIssue {
  * - ambient: @ambient.* 旧形式の ambient 参照
  *
  * **Generic Definition Catalog 参照** (docs/spec/process-flow-prefix-system.md §3、
- * #1285 で追加、14 kind 全件): broken-ref 検証は processFlowAntipatternValidator Check 31
- * が担うため identifierScope は変数 scope 検査の対象外として skip する。
+ * #1285 で追加、14 kind 全件 + #1303 追加 3 kind = 17 kind): broken-ref 検証は
+ * processFlowAntipatternValidator Check 31 が担うため identifierScope は変数 scope 検査の対象外として skip する。
  * - msg        : @msg.<Name> generic-definitions/message
  * - validation : @validation.<Name> generic-definitions/validation-rule (inline boolean return)
  * - rule       : @rule.<Name> generic-definitions/application-rule
@@ -63,6 +63,9 @@ export interface IdentifierIssue {
  * - exception  : @exception.<Name> generic-definitions/exception-type
  * - policy     : @policy.<Name> generic-definitions/runtime-policy
  * - component  : @component.<Name> generic-definitions/component-definition
+ * - dialog     : @dialog.<Name> generic-definitions/dialog (#1303)
+ * - messageArea: @messageArea.<Name> generic-definitions/messageArea (#1303)
+ * - options    : @options.<Name> generic-definitions/options (#1303)
  *
  * **Top-level entity 階層参照** (process-flow-prefix-system.md §3、#1285 で追加):
  * - screen : @screen.<id>.item.<id>.<field> Screen entity 参照
@@ -89,7 +92,7 @@ const BUILTIN_AMBIENTS = new Set<string>([
   "secret",
   "conv",
   "ambient",
-  // Generic Definition Catalog refs (#1285、14 kind 全件)
+  // Generic Definition Catalog refs (#1285 14 kind + #1303 3 kind = 17 kind)
   "msg",
   "validation",
   "rule",
@@ -104,6 +107,9 @@ const BUILTIN_AMBIENTS = new Set<string>([
   "exception",
   "policy",
   "component",
+  "dialog",
+  "messageArea",
+  "options",
   // Top-level entity / catalog refs (#1285)
   "screen",
   "table",

--- a/frontend/src/schemas/processFlowAntipatternValidator.ts
+++ b/frontend/src/schemas/processFlowAntipatternValidator.ts
@@ -38,7 +38,7 @@
  *   - entity (projectIndex.screens/tables/views/viewers/layouts/sequences/flows/externalSystems):
  *     `@screen` / `@table` / `@view` / `@viewer` (2 段は id 検証、4 段は id + child 検証)
  *     `@layout` / `@seq` / `@flow` / `@system` (id 単純 lookup)
- *   - generic-definition (14 kind × 1 prefix):
+ *   - generic-definition (17 kind × 1 prefix, #1303 追加: dialog/messageArea/options):
  *     `@contract` / `@type` / `@exception` / `@rule` / `@validation` / `@behavior` /
  *     `@policy` / `@component` / `@fragment` / `@const` / `@msg` / `@logEvent` / `@logConfig`
  *     (`@event` は flow-level context と generic-definition/domain-event の両方が candidate)
@@ -521,7 +521,7 @@ function collectBrokenRefs(value: string, ctx: BrokenRefContext): RefIssue[] {
 /**
  * `@<prefix>.<key>` を project catalog index で検証する (#1269 提案 C)。
  *
- * 検証対象 prefix (24 prefix の内 @var / @event は別 path):
+ * 検証対象 prefix (27 prefix の内 @var / @event は別 path、#1303 追加: @dialog/@messageArea/@options):
  *   - Entity: @screen / @table / @view / @viewer / @layout / @seq / @flow / @system
  *   - Generic Definition: @contract / @type / @exception / @rule / @validation / @behavior /
  *                          @policy / @component / @fragment
@@ -599,6 +599,10 @@ function checkProjectScopedRef(
     msg: idx.messages,
     logEvent: idx.logEvents,
     logConfig: idx.logConfigs,
+    // #1303 — 3 新規 kind
+    dialog: idx.dialogs,
+    messageArea: idx.messageAreas,
+    options: idx.optionSets,
   };
   if (prefix in definitionSets) {
     if (!definitionSets[prefix].has(head)) {

--- a/frontend/src/schemas/projectCatalogIndex.ts
+++ b/frontend/src/schemas/projectCatalogIndex.ts
@@ -44,7 +44,7 @@ export interface ProjectCatalogIndex {
   /** `@system.<systemId>` (externalSystems catalog) */
   externalSystems: Set<string>;
 
-  // ─── Generic Definition Catalog (#1090 / #1267 Phase X2、14 kind) ────────
+  // ─── Generic Definition Catalog (#1090 / #1267 Phase X2 14 kind + #1303 3 kind = 17 kind) ───
   /** `@contract.<name>` — data-contract */
   dataContracts: Set<string>;
   /** `@type.<name>` — domain-type */
@@ -63,6 +63,12 @@ export interface ProjectCatalogIndex {
   componentDefinitions: Set<string>;
   /** `@fragment.<name>` — ui-fragment */
   uiFragments: Set<string>;
+  /** `@dialog.<name>` — dialog (#1303) */
+  dialogs: Set<string>;
+  /** `@messageArea.<name>` — messageArea (#1303) */
+  messageAreas: Set<string>;
+  /** `@options.<name>` — options (#1303) */
+  optionSets: Set<string>;
 
   /**
    * `@const.<key>` — constants catalog (#1267 Phase X2)。
@@ -112,6 +118,9 @@ export function createEmptyProjectCatalogIndex(): ProjectCatalogIndex {
     runtimePolicies: new Set(),
     componentDefinitions: new Set(),
     uiFragments: new Set(),
+    dialogs: new Set(),
+    messageAreas: new Set(),
+    optionSets: new Set(),
     constants: new Set(),
     messages: new Set(),
     domainEvents: new Set(),
@@ -169,6 +178,10 @@ const GENERIC_KIND_TO_SET_KEY: Record<string, keyof ProjectCatalogIndex> = {
   "domain-event": "domainEvents",
   "log-event": "logEvents",
   "log-config": "logConfigs",
+  // #1303 — 3 新規 kind
+  dialog: "dialogs",
+  messageArea: "messageAreas",
+  options: "optionSets",
 };
 
 /** conventions catalog の中で `@conv.<category>` として ref されない metadata field */

--- a/frontend/src/styles/screen-items.css
+++ b/frontend/src/styles/screen-items.css
@@ -284,6 +284,23 @@
   flex: 1;
   min-width: 120px;
 }
+/* boolean / expression 切替 mode コンテナ (#1303) */
+.screen-items-event-effect-value-boolean,
+.screen-items-event-effect-value-expression {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex: 1;
+  min-width: 120px;
+}
+.screen-items-event-effect-value-expression {
+  flex: 1;
+  min-width: 0;
+}
+.screen-items-event-effect-value-expression .screen-items-event-effect-value {
+  flex: 1;
+  min-width: 0;
+}
 .screen-items-event-effect-mapping-header {
   display: flex;
   align-items: center;

--- a/frontend/src/types/v3/generic-definition.ts
+++ b/frontend/src/types/v3/generic-definition.ts
@@ -2,10 +2,11 @@
  * Generic Definition Catalog 型定義 (v3 schema 準拠)
  *
  * schema: schemas/v3/generic-definition.v3.schema.json
- * 14 kind (#1254 件 3.7 / #1263 Phase X2):
+ * 17 kind (#1254 件 3.7 / #1263 Phase X2 / #1303):
  *   既存 8: data-contract / domain-type / exception-type / application-rule /
  *            ui-behavior / runtime-policy / component-definition / ui-fragment
  *   新規 6: validation-rule / constants / message / domain-event / log-event / log-config
+ *   新規 3: dialog / messageArea / options (#1303)
  */
 
 export type GenericDefinitionKind =
@@ -22,7 +23,10 @@ export type GenericDefinitionKind =
   | "message"
   | "domain-event"
   | "log-event"
-  | "log-config";
+  | "log-config"
+  | "dialog"
+  | "messageArea"
+  | "options";
 
 export type GenericDefinitionTarget = "backend" | "frontend" | "shared" | "runtime";
 
@@ -91,6 +95,9 @@ export const GENERIC_DEFINITION_KINDS: GenericDefinitionKind[] = [
   "domain-event",
   "log-event",
   "log-config",
+  "dialog",
+  "messageArea",
+  "options",
 ];
 
 export const GENERIC_DEFINITION_KIND_LABELS: Record<GenericDefinitionKind, string> = {
@@ -108,6 +115,9 @@ export const GENERIC_DEFINITION_KIND_LABELS: Record<GenericDefinitionKind, strin
   "domain-event": "ドメインイベント",
   "log-event": "ログイベント",
   "log-config": "ログ設定",
+  dialog: "ダイアログ",
+  messageArea: "メッセージエリア",
+  options: "選択肢",
 };
 
 export const GENERIC_DEFINITION_TARGETS: GenericDefinitionTarget[] = [

--- a/frontend/src/utils/reference-completer/genericDefinitionResolver.test.ts
+++ b/frontend/src/utils/reference-completer/genericDefinitionResolver.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { genericDefinitionResolver } from "./genericDefinitionResolver";
+import type { CompletionContext } from "./types";
+
+const makeCtx = (
+  genericDefinitionsByKind?: Record<string, { name: string }[]>
+): CompletionContext => ({ genericDefinitionsByKind });
+
+describe("genericDefinitionResolver", () => {
+  // ケース 1: @dialog. (空 prefix) → ctx.genericDefinitionsByKind.dialog 全件
+  it("@dialog. (空 prefix) → dialog 全件候補", () => {
+    const ctx = makeCtx({
+      dialog: [{ name: "ConfirmDelete" }, { name: "AlertWarning" }],
+    });
+    const v = "@dialog.";
+    const result = genericDefinitionResolver.match(v, v.length, ctx);
+    expect(result?.phase).toBe("active");
+    if (result?.phase === "active") {
+      expect(result.resolverId).toBe("genericDefinition");
+      expect(result.prefix).toBe("");
+      expect(result.candidates.map((c) => c.value)).toEqual(["ConfirmDelete", "AlertWarning"]);
+      expect(result.replaceLen).toBe(0);
+    }
+  });
+
+  // ケース 2: @dialog.conf (部分 prefix) → 部分マッチ
+  it("@dialog.conf → ConfirmDelete のみ", () => {
+    const ctx = makeCtx({
+      dialog: [{ name: "ConfirmDelete" }, { name: "AlertWarning" }],
+    });
+    const v = "@dialog.Conf";
+    const result = genericDefinitionResolver.match(v, v.length, ctx);
+    expect(result?.phase).toBe("active");
+    if (result?.phase === "active") {
+      expect(result.candidates.map((c) => c.value)).toEqual(["ConfirmDelete"]);
+      expect(result.prefix).toBe("Conf");
+      expect(result.replaceLen).toBe(4);
+    }
+  });
+
+  // ケース 3: @messageArea. → messageArea 候補
+  it("@messageArea. → messageArea 全件候補", () => {
+    const ctx = makeCtx({
+      messageArea: [{ name: "ErrorArea" }, { name: "InfoArea" }],
+    });
+    const v = "@messageArea.";
+    const result = genericDefinitionResolver.match(v, v.length, ctx);
+    expect(result?.phase).toBe("active");
+    if (result?.phase === "active") {
+      expect(result.resolverId).toBe("genericDefinition");
+      expect(result.candidates.map((c) => c.value)).toEqual(["ErrorArea", "InfoArea"]);
+    }
+  });
+
+  // ケース 4: @options. → options 候補
+  it("@options. → options 全件候補", () => {
+    const ctx = makeCtx({
+      options: [{ name: "PrefectureList" }, { name: "StatusOptions" }],
+    });
+    const v = "@options.";
+    const result = genericDefinitionResolver.match(v, v.length, ctx);
+    expect(result?.phase).toBe("active");
+    if (result?.phase === "active") {
+      expect(result.candidates.map((c) => c.value)).toEqual(["PrefectureList", "StatusOptions"]);
+    }
+  });
+
+  // ケース 5: genericDefinitionsByKind 未設定 → null
+  it("genericDefinitionsByKind 未設定 → null", () => {
+    const ctx = makeCtx(undefined);
+    const v = "@dialog.";
+    const result = genericDefinitionResolver.match(v, v.length, ctx);
+    expect(result).toBeNull();
+  });
+
+  // ケース 6: 該当 kind の entries 空 → 空 candidates
+  it("該当 kind の entries が空 → 空 candidates", () => {
+    const ctx = makeCtx({ dialog: [] });
+    const v = "@dialog.";
+    const result = genericDefinitionResolver.match(v, v.length, ctx);
+    expect(result?.phase).toBe("active");
+    if (result?.phase === "active") {
+      expect(result.candidates).toHaveLength(0);
+    }
+  });
+
+  // ケース 7: 関係ないテキスト → null
+  it("関係ないテキスト → null", () => {
+    const ctx = makeCtx({ dialog: [{ name: "Confirm" }] });
+    const v = "some regular text";
+    const result = genericDefinitionResolver.match(v, v.length, ctx);
+    expect(result).toBeNull();
+  });
+
+  // ケース 8: 文中でカーソルが @options.Pref の末尾 → active
+  it("文中 @options.Pref → 部分マッチ候補", () => {
+    const ctx = makeCtx({
+      options: [{ name: "PrefectureList" }, { name: "StatusOptions" }],
+    });
+    const v = "select @options.Pref here";
+    const cursor = "select @options.Pref".length;
+    const result = genericDefinitionResolver.match(v, cursor, ctx);
+    expect(result?.phase).toBe("active");
+    if (result?.phase === "active") {
+      expect(result.candidates.map((c) => c.value)).toEqual(["PrefectureList"]);
+    }
+  });
+});

--- a/frontend/src/utils/reference-completer/genericDefinitionResolver.ts
+++ b/frontend/src/utils/reference-completer/genericDefinitionResolver.ts
@@ -1,0 +1,45 @@
+/**
+ * @<kind-prefix>.<name> 補完 Resolver (#1303)。
+ *
+ * generic-definition の各 kind を catalog として補完候補化:
+ *   - @dialog.<name>       → ctx.genericDefinitionsByKind["dialog"]
+ *   - @messageArea.<name>  → ctx.genericDefinitionsByKind["messageArea"]
+ *   - @options.<name>      → ctx.genericDefinitionsByKind["options"]
+ *
+ * spec 出典: docs/spec/generic-definition-layer.md §4.2
+ */
+
+import type { CompletionContext, CompletionState, Resolver } from "./types";
+
+const KIND_PREFIXES = ["dialog", "messageArea", "options"] as const;
+
+export const genericDefinitionResolver: Resolver = {
+  id: "genericDefinition",
+
+  match(value: string, cursorPos: number, ctx: CompletionContext): CompletionState | null {
+    if (!ctx.genericDefinitionsByKind) return null;
+
+    const before = value.slice(0, cursorPos);
+
+    for (const kind of KIND_PREFIXES) {
+      const re = new RegExp(`@${kind}\\.([\\w-]*)$`);
+      const m = before.match(re);
+      if (m) {
+        const prefix = m[1];
+        const items = ctx.genericDefinitionsByKind[kind] ?? [];
+        const candidates = items
+          .filter((i) => i.name.startsWith(prefix))
+          .map((i) => ({ value: i.name, label: i.name }));
+        return {
+          phase: "active",
+          resolverId: "genericDefinition",
+          prefix,
+          candidates,
+          replaceLen: prefix.length,
+        };
+      }
+    }
+
+    return null;
+  },
+};

--- a/frontend/src/utils/reference-completer/types.ts
+++ b/frontend/src/utils/reference-completer/types.ts
@@ -88,6 +88,12 @@ export interface CompletionContext {
     | { kind: "screenItem"; id: string; fields?: { name: string; label?: string }[] }
     | { kind: "step"; id: string; fields?: { name: string; label?: string }[] }
     | { kind: "column"; id: string; fields?: { name: string; label?: string }[] };
+  /**
+   * 現在 workspace の generic-definition catalog (kind 別、#1303)。
+   * dialog / messageArea / options 等の kind を引数に取り、name 候補配列を返す。
+   * genericDefinitionResolver で @dialog.* / @messageArea.* / @options.* の補完に使用。
+   */
+  genericDefinitionsByKind?: Record<string, { name: string }[]>;
 }
 
 /** 補完 Resolver インターフェース。 */

--- a/schemas/v3/generic-definition.v3.schema.json
+++ b/schemas/v3/generic-definition.v3.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/csilost2001/harmony/main/schemas/v3/generic-definition.v3.schema.json",
   "title": "Generic Definition (v3 汎用設計定義 親 schema)",
-  "description": "Layer 2 Generic Definition Catalog の 14 kind 共通メタモデル (#1263 Phase X2 / RFC #1254 件 3.7 で 8 → 14 kind に拡張)。<project>/<dataDir>/generic-definitions/<kind>/<Name>.json に対応。仕様: docs/spec/generic-definition-layer.md §4.1。本 schema は kind / name / purpose / responsibilities / targets を必須とする共通親で、kind 別の固有 schema (旧 7: data-contract / domain-type / exception-type / application-rule / ui-behavior / runtime-policy / ui-fragment は #1064-#1068 で導入、新 7: component-definition / validation-rule / constants / message / domain-event / log-event / log-config は #1263 Phase X2 で導入) は allOf で本定義を継承する。catalog 記録のため EntityMeta (uuid id / timestamps) は採用せず、`name` field が catalog identifier を兼ねる (ファイル名と一致させる運用)。",
+  "description": "Layer 2 Generic Definition Catalog の 17 kind 共通メタモデル (#1263 Phase X2 / RFC #1254 件 3.7 で 8 → 14 kind に拡張、#1303 で 14 → 17 kind に拡張)。<project>/<dataDir>/generic-definitions/<kind>/<Name>.json に対応。仕様: docs/spec/generic-definition-layer.md §4.1。本 schema は kind / name / purpose / responsibilities / targets を必須とする共通親で、kind 別の固有 schema (旧 7: data-contract / domain-type / exception-type / application-rule / ui-behavior / runtime-policy / ui-fragment は #1064-#1068 で導入、新 7: component-definition / validation-rule / constants / message / domain-event / log-event / log-config は #1263 Phase X2 で導入、追加 3: dialog / messageArea / options は #1303 で導入) は allOf で本定義を継承する。catalog 記録のため EntityMeta (uuid id / timestamps) は採用せず、`name` field が catalog identifier を兼ねる (ファイル名と一致させる運用)。",
   "type": "object",
   "$ref": "#/$defs/GenericDefinition",
   "$defs": {
@@ -84,9 +84,12 @@
         "message",
         "domain-event",
         "log-event",
-        "log-config"
+        "log-config",
+        "dialog",
+        "messageArea",
+        "options"
       ],
-      "description": "Generic Definition Catalog の 14 kind (#1254 件 3.7 / #1263 Phase X2、spec §4.2)。data-contract = DTO/Form/Result/ViewModel 等の層間契約。domain-type = Entity/Model などドメイン型。exception-type = 例外種別・階層・semantic kind。application-rule = 認証認可/ログ/監査などの横断ルール。validation-rule = 業務検証ルール (条件 + メッセージ + severity)。ui-behavior = 画面横断振る舞い。runtime-policy = retry/timeout/circuit breaker/cache 等の横断適用ポリシー。component-definition = service/mapper/validator/formatter 等の責務。ui-fragment = 再利用 UI 断片。constants = ドメイン定数集 (@const.<key> 参照元)。message = メッセージカタログ (@msg.<key> 参照元、i18n source)。domain-event = ドメインイベント定義 (@event.<topic> 参照元)。log-event = ログイベント定義 (@logEvent.<key> 参照元、構造化ログ)。log-config = ログ設定 (@logConfig.<key> 参照元、log level / sink / format)。"
+      "description": "Generic Definition Catalog の 17 kind (#1254 件 3.7 / #1263 Phase X2 で 14 種 / #1303 で 14→17 種に拡張、spec §4.2)。data-contract = DTO/Form/Result/ViewModel 等の層間契約。domain-type = Entity/Model などドメイン型。exception-type = 例外種別・階層・semantic kind。application-rule = 認証認可/ログ/監査などの横断ルール。validation-rule = 業務検証ルール (条件 + メッセージ + severity)。ui-behavior = 画面横断振る舞い。runtime-policy = retry/timeout/circuit breaker/cache 等の横断適用ポリシー。component-definition = service/mapper/validator/formatter 等の責務。ui-fragment = 再利用 UI 断片。constants = ドメイン定数集 (@const.<key> 参照元)。message = メッセージカタログ (@msg.<key> 参照元、i18n source)。domain-event = ドメインイベント定義 (@event.<topic> 参照元)。log-event = ログイベント定義 (@logEvent.<key> 参照元、構造化ログ)。log-config = ログ設定 (@logConfig.<key> 参照元、log level / sink / format)。dialog = ScreenItemEvent effects[].showDialog.target 参照先の dialog カタログ (@dialog.<name> 参照元)。messageArea = ScreenItemEvent effects[].setMessage.target 参照先の画面横断 message area カタログ (@messageArea.<name> 参照元)。options = ScreenItemEvent effects[].setOptions の選択肢カタログ (@options.<name> 参照元)。"
     },
 
     "GenericDefinitionName": {

--- a/schemas/v3/generic-definitions/dialog.v3.schema.json
+++ b/schemas/v3/generic-definitions/dialog.v3.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/csilost2001/harmony/main/schemas/v3/generic-definitions/dialog.v3.schema.json",
+  "title": "Dialog (v3 generic-definition kind: dialog)",
+  "description": "Generic Definition Catalog の dialog kind 固有 schema (#1303)。親 schema (../generic-definition.v3.schema.json) を `allOf` 継承し、`kind` を const \"dialog\" に固定。dialog catalog は ScreenItemEvent.effects[].showDialog.target の参照先 (例: confirm dialog / alert dialog / custom dialog の定義)。`@dialog.<name>` 参照元。仕様: docs/spec/generic-definition-layer.md §4.2。",
+  "type": "object",
+  "allOf": [
+    { "$ref": "../generic-definition.v3.schema.json" }
+  ],
+  "properties": {
+    "kind": { "const": "dialog" }
+  }
+}

--- a/schemas/v3/generic-definitions/messageArea.v3.schema.json
+++ b/schemas/v3/generic-definitions/messageArea.v3.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/csilost2001/harmony/main/schemas/v3/generic-definitions/messageArea.v3.schema.json",
+  "title": "MessageArea (v3 generic-definition kind: messageArea)",
+  "description": "Generic Definition Catalog の messageArea kind 固有 schema (#1303)。親 schema (../generic-definition.v3.schema.json) を `allOf` 継承し、`kind` を const \"messageArea\" に固定。messageArea catalog は ScreenItemEvent.effects[].setMessage.target の参照先 (画面横断 message area の定義、例: エラー表示エリア / 通知バー)。`@messageArea.<name>` 参照元。仕様: docs/spec/generic-definition-layer.md §4.2。",
+  "type": "object",
+  "allOf": [
+    { "$ref": "../generic-definition.v3.schema.json" }
+  ],
+  "properties": {
+    "kind": { "const": "messageArea" }
+  }
+}

--- a/schemas/v3/generic-definitions/options.v3.schema.json
+++ b/schemas/v3/generic-definitions/options.v3.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/csilost2001/harmony/main/schemas/v3/generic-definitions/options.v3.schema.json",
+  "title": "Options (v3 generic-definition kind: options)",
+  "description": "Generic Definition Catalog の options kind 固有 schema (#1303)。親 schema (../generic-definition.v3.schema.json) を `allOf` 継承し、`kind` を const \"options\" に固定。options catalog は ScreenItemEvent.effects[].setOptions の選択肢カタログ参照先 (例: 選択肢一覧の動的切替定義)。`@options.<name>` 参照元。仕様: docs/spec/generic-definition-layer.md §4.2。",
+  "type": "object",
+  "allOf": [
+    { "$ref": "../generic-definition.v3.schema.json" }
+  ],
+  "properties": {
+    "kind": { "const": "options" }
+  }
+}


### PR DESCRIPTION
## 概要

ScreenItemEvent.effects[] 編集 UI の改善 2 件:
- **課題 1**: setReadonly/setEnabled/setVisible value UI を **checkbox + 式テキスト切替** に改修 (typo 防止 + 意図の可視化)
- **課題 2**: **dialog / messageArea / options を generic-definitions の新 kind** として spec/schema 拡張 + `genericDefinitionResolver` 新設 + ScreenItemsView bind

RFC #1303 で設計者承認済 (#511 schema governance 通過、本 PR 内で一気通貫実装の承認取得)。

## 解決する ISSUE

Closes #1303

## 変更点 (file:line)

### Sub-task 1: setReadonly UI 改修
- `frontend/src/components/screen-items/ScreenItemsView.tsx:1464-1496` — value 編集を `typeof === "boolean"` で mode 自動判定
- `frontend/src/styles/screen-items.css` — `screen-items-event-effect-value-boolean` / `screen-items-event-effect-value-expression` 補助 class

### Sub-task 2: 新 kind + resolver (設計者承認済)

**schema**:
- `schemas/v3/generic-definition.v3.schema.json` — kind enum 14→17 拡張
- `schemas/v3/generic-definitions/dialog.v3.schema.json` (新規) — allOf 継承 minimal pattern
- `schemas/v3/generic-definitions/messageArea.v3.schema.json` (新規)
- `schemas/v3/generic-definitions/options.v3.schema.json` (新規)

**spec**:
- `docs/spec/generic-definition-layer.md` §4.2 — 「8 種類」→「17 種類」見出し更新、14 種テーブルを 17 種に拡張

**resolver**:
- `frontend/src/utils/reference-completer/types.ts` — `CompletionContext.genericDefinitionsByKind` 追加
- `frontend/src/utils/reference-completer/genericDefinitionResolver.ts` (新規) — `@dialog.<name>` / `@messageArea.<name>` / `@options.<name>` 補完
- `frontend/src/utils/reference-completer/genericDefinitionResolver.test.ts` (新規) — 8 ケース

**UI bind**:
- `frontend/src/components/screen-items/ScreenItemsView.tsx` — `listGenericDefinitions` ロード追加、setOptions / showDialog / setMessage を `ReferenceCompletionInput` 化 + `genericDefinitionResolver` 接続

### review fix (Sonnet 独立レビュー Must-fix M-1 + Should-fix S-1 + Nit N-1 全件解消、commit f8a7999f)

- **M-1**: TS 型 `GenericDefinitionKind` Union + `GENERIC_DEFINITION_KINDS` array / `GENERIC_DEFINITION_KIND_LABELS` / `KIND_ICONS` / `KIND_DESCRIPTIONS` / `KIND_SCHEMAS` の 6 箇所同期 (tsc 0 errors 検証済)
- **S-1**: `projectCatalogIndex.ts` に `dialogs`/`messageAreas`/`optionSets` 追加、`processFlowAntipatternValidator.ts` Check 31 の `definitionSets` に 3 新 kind broken-ref check 追加、`identifierScope.ts` BUILTIN_AMBIENTS にも 3 新 prefix
- **N-1**: `genericDefinitionValidator.ts` ヘッダコメント「14 kind」→「17 kind」

## 検証

- `npx tsc --project tsconfig.app.json --noEmit` (frontend): 0 errors
- `npx vitest run`: 1036 passed / 1 failed (失敗は household-budget process-flow schema、本 PR 変更前から存在する pre-existing failure、git stash で確認済)
- `git diff --name-only origin/main..HEAD -- schemas/`: 4 files (設計者承認範囲内)

## schema governance #511 適用範囲

設計者承認済の変更:
- `schemas/v3/generic-definition.v3.schema.json` (kind enum 14→17)
- `schemas/v3/generic-definitions/{dialog,messageArea,options}.v3.schema.json` (新規 3 ファイル)
- `docs/spec/generic-definition-layer.md` (spec 更新)

他 schema (`process-flow.v3.schema.json` 等) への変更なし。

## scope 外

無し (S-1 は同 PR で吸収済)。

## Test plan

- [x] vitest reference-completer 全 pass (genericDefinitionResolver 新規 8 ケース)
- [x] tsc 0 errors (tsconfig.app.json)
- [x] schema 変更が設計者承認範囲内
- [x] 独立レビュー Must-fix / Should-fix / Nit 全件解消