### PR TITLE
feat(designer): #1316 varScopeResolver Phase 3 — nested 列挙 6 種 + 4-segment 文法 + UX 改善

### DIFF
--- a/docs/spec/process-flow-variables.md
+++ b/docs/spec/process-flow-variables.md
@@ -313,18 +313,20 @@ current step → enclosing loop/tryCatch → enclosing tx → action → flowPar
 
 editor 編集時の補完では両方の候補が並列に出る (resolver 別)。詳細は [process-flow-prefix-system.md § 11](process-flow-prefix-system.md#11-designer-time-alias-this--self-1301)。
 
-#### resolver 補完範囲 (#1282 / #1302)
+#### resolver 補完範囲 (#1282 / #1302 / #1316)
 
 `@var.<scope>.<name>` の補完 resolver (`varScopeResolver`) の実装状況:
 
-| scope | Phase 1/2 (#1282) | Phase 2-bis (#1302) |
-|---|---|---|
-| `flowParameter` | ✅ name 補完 | — |
-| `action` | ✅ name 補完 | — |
-| `step` | — | ✅ name 補完 (全 step id、TX/loop/branch 内 nested 含む) |
-| `tx` | — | ✅ name 補完 (kind="transactionScope" の id のみ) |
-| `loop` | — | ✅ name 補完 (collectionItemName / collectionIndexName / outputBinding.name) |
-| `global` | — | ⚠️ 空候補 (catalog 未確立、別 ISSUE で対応予定) |
+| scope | Phase 1/2 (#1282) | Phase 2-bis (#1302) | Phase 3 (#1316) |
+|---|---|---|---|
+| `flowParameter` | ✅ name 補完 | — | — |
+| `action` | ✅ name 補完 | — | — |
+| `step` | — | ✅ step-id 補完 (全 step id、TX/loop/branch/workflow/validation の nested 含む) | ✅ `@var.step.<id>.<binding-name>` 4-segment 補完 (`outputBinding.name`) + 候補に trailing "." 付与 |
+| `tx` | — | ✅ tx-id 補完 (kind="transactionScope" の id のみ) | ✅ `@var.tx.<id>.<member>` 4-segment 補完 (予約 3 値 `committed`/`error`/`diagnostics` + `outputBinding.expose[]`) + 候補に trailing "." 付与 |
+| `loop` | — | ✅ name 補完 (collectionItemName / collectionIndexName / outputBinding.name) | — (3-segment で完結) |
+| `global` | — | ⚠️ 空候補 (catalog 未確立、#1310 で対応予定) | — |
+
+注: Phase 2-bis の表記「name 補完」は実際には scope 階層第 3 segment (step-id / tx-id / loop-name) の補完を指す。`step` / `tx` は spec §3.6 line 250-251 の canonical 文法どおり 4-segment (`@var.step.<step-id>.<binding-name>` / `@var.tx.<tx-id>.<member>`) で完結し、Phase 3 (#1316) で最終 segment まで補完が繋がる。nested step 列挙の網羅は `iterSteps` ヘルパが担当 (compound step kind = transactionScope / loop / branch / workflow / validation の各 nested 配置 `steps[]` / `branches[].steps[]` / `elseBranch.steps[]` / `onCommit[]` / `onRollback[]` / `onApproved[]` / `onRejected[]` / `onTimeout[]` / `inlineBranch.{ok,ng}[]` を再帰列挙)。
 
 ### 3.7 TX (transactionScope) 境界での変数挙動 (#1264 verdict 観点 4 / #1267 Round 7 option C)
 

--- a/frontend/src/utils/reference-completer/varScopeResolver.test.ts
+++ b/frontend/src/utils/reference-completer/varScopeResolver.test.ts
@@ -136,6 +136,20 @@ describe("varScopeResolver", () => {
     expect(state.candidates.map((c) => c.value)).toContain("orderResult");
   });
 
+  // Phase 3 (#1317 review fix): action scope に nested step (TX/loop 内) の outputBinding も含む
+  it("@var.action. で TX/loop 内 nested step の outputBinding.name も候補に出る (PR #1317 review fix)", () => {
+    const value = "@var.action.";
+    const state = varScopeResolver.match(value, value.length, { flow: mockFlowPhase2bis });
+    expect(state?.phase).toBe("active");
+    if (state?.phase !== "active") return;
+    const values = state.candidates.map((c) => c.value);
+    expect(values).toContain("userResult");      // top-level step-01
+    expect(values).toContain("txResult");        // TX 自体の outputBinding
+    expect(values).toContain("createdOrder");    // TX 内 nested step-02
+    expect(values).toContain("enrichedItems");   // loop 自体の outputBinding
+    expect(values).toContain("lineTotal");       // loop 内 nested step-03
+  });
+
   // Phase 2-bis: step scope
   it("@var.step. で全 step id が候補になる (nested TX/loop 内含む)", () => {
     const value = "@var.step.";

--- a/frontend/src/utils/reference-completer/varScopeResolver.test.ts
+++ b/frontend/src/utils/reference-completer/varScopeResolver.test.ts
@@ -1,5 +1,6 @@
 // #1282: varScopeResolver unit tests
 // #1302: Phase 2-bis テスト (step / tx / loop / global name 補完) 追加
+// #1316: Phase 3 テスト (iterSteps nested 6 種網羅 + 4-segment 文法 + step/tx trailing)
 
 import { describe, expect, it } from "vitest";
 import { varScopeResolver } from "./varScopeResolver";
@@ -203,5 +204,263 @@ describe("varScopeResolver", () => {
     expect(state?.phase).toBe("active");
     if (state?.phase !== "active") return;
     expect(state.candidates).toHaveLength(0);
+  });
+
+  // Phase 3 (#1316): step / tx 候補に trailing: "." 付与 (4-segment 文法連動)
+  describe("Phase 3 (#1316) — step/tx 候補の trailing", () => {
+    it("@var.step. の各候補に trailing: \".\" が付く", () => {
+      const value = "@var.step.";
+      const state = varScopeResolver.match(value, value.length, { flow: mockFlowPhase2bis });
+      expect(state?.phase).toBe("active");
+      if (state?.phase !== "active") return;
+      expect(state.candidates.length).toBeGreaterThan(0);
+      state.candidates.forEach((c) => expect(c.trailing).toBe("."));
+    });
+
+    it("@var.tx. の候補に trailing: \".\" が付く", () => {
+      const value = "@var.tx.";
+      const state = varScopeResolver.match(value, value.length, { flow: mockFlowPhase2bis });
+      expect(state?.phase).toBe("active");
+      if (state?.phase !== "active") return;
+      expect(state.candidates.length).toBeGreaterThan(0);
+      state.candidates.forEach((c) => expect(c.trailing).toBe("."));
+    });
+
+    it("@var.loop. の候補には trailing が付かない (3-segment で完結)", () => {
+      const value = "@var.loop.";
+      const state = varScopeResolver.match(value, value.length, { flow: mockFlowPhase2bis });
+      expect(state?.phase).toBe("active");
+      if (state?.phase !== "active") return;
+      expect(state.candidates.length).toBeGreaterThan(0);
+      state.candidates.forEach((c) => expect(c.trailing).toBeUndefined());
+    });
+
+    it("@var.flowParameter. の候補にも trailing が付かない", () => {
+      const value = "@var.flowParameter.";
+      const state = varScopeResolver.match(value, value.length, ctx);
+      expect(state?.phase).toBe("active");
+      if (state?.phase !== "active") return;
+      expect(state.candidates.length).toBeGreaterThan(0);
+      state.candidates.forEach((c) => expect(c.trailing).toBeUndefined());
+    });
+  });
+
+  // Phase 3 (#1316): iterSteps の nested 6 種網羅
+  // workflow / TX.onCommit / TX.onRollback / branch.elseBranch / validation.inlineBranch
+  describe("Phase 3 (#1316) — iterSteps nested 網羅", () => {
+    const mockFlowPhase3Nested = {
+      id: "flow-3",
+      name: "phase3 nested",
+      actions: [
+        {
+          id: "action-1",
+          name: "compound nesting",
+          inputs: [],
+          steps: [
+            // TX.onCommit / onRollback 内 step
+            {
+              id: "tx-01",
+              kind: "transactionScope",
+              isolationLevel: "READ_COMMITTED",
+              rollbackOn: [],
+              steps: [{ id: "in-tx-body", kind: "dbAccess" }],
+              onCommit: [{ id: "in-tx-oncommit", kind: "log", message: "ok" }],
+              onRollback: [{ id: "in-tx-onrollback", kind: "log", message: "ng" }],
+            },
+            // branch.elseBranch 内 step
+            {
+              id: "branch-01",
+              kind: "branch",
+              description: "if-else",
+              branches: [
+                {
+                  id: "br-A",
+                  code: "A",
+                  condition: { kind: "expression", expression: "true" },
+                  steps: [{ id: "in-branch-a", kind: "dbAccess" }],
+                },
+              ],
+              elseBranch: {
+                id: "br-X",
+                code: "X",
+                steps: [{ id: "in-else-branch", kind: "log", message: "else" }],
+              },
+            },
+            // workflow.on{Approved,Rejected,Timeout} 内 step
+            {
+              id: "wf-01",
+              kind: "workflow",
+              description: "approval",
+              pattern: "approval-sequential",
+              approvers: [{ role: "manager" }],
+              onApproved: [{ id: "in-wf-approved", kind: "log", message: "ok" }],
+              onRejected: [{ id: "in-wf-rejected", kind: "log", message: "ng" }],
+              onTimeout: [{ id: "in-wf-timeout", kind: "log", message: "tm" }],
+            },
+            // validation.inlineBranch.{ok,ng} 内 step
+            {
+              id: "val-01",
+              kind: "validation",
+              description: "validate",
+              fieldErrorsVar: "fieldErrors",
+              inlineBranch: {
+                ok: [{ id: "in-val-ok", kind: "dbAccess" }],
+                ng: [{ id: "in-val-ng", kind: "log", message: "ng" }],
+              },
+            },
+          ],
+        },
+      ],
+    } as unknown as V3ProcessFlow;
+
+    it("@var.step. で TX.onCommit / onRollback 内 step id が候補に出る", () => {
+      const value = "@var.step.";
+      const state = varScopeResolver.match(value, value.length, { flow: mockFlowPhase3Nested });
+      expect(state?.phase).toBe("active");
+      if (state?.phase !== "active") return;
+      const values = state.candidates.map((c) => c.value);
+      expect(values).toContain("in-tx-body");
+      expect(values).toContain("in-tx-oncommit");
+      expect(values).toContain("in-tx-onrollback");
+    });
+
+    it("@var.step. で branch.elseBranch 内 step id が候補に出る", () => {
+      const value = "@var.step.";
+      const state = varScopeResolver.match(value, value.length, { flow: mockFlowPhase3Nested });
+      expect(state?.phase).toBe("active");
+      if (state?.phase !== "active") return;
+      const values = state.candidates.map((c) => c.value);
+      expect(values).toContain("in-branch-a");
+      expect(values).toContain("in-else-branch");
+    });
+
+    it("@var.step. で workflow.on{Approved,Rejected,Timeout} 内 step id が候補に出る", () => {
+      const value = "@var.step.";
+      const state = varScopeResolver.match(value, value.length, { flow: mockFlowPhase3Nested });
+      expect(state?.phase).toBe("active");
+      if (state?.phase !== "active") return;
+      const values = state.candidates.map((c) => c.value);
+      expect(values).toContain("in-wf-approved");
+      expect(values).toContain("in-wf-rejected");
+      expect(values).toContain("in-wf-timeout");
+    });
+
+    it("@var.step. で validation.inlineBranch.{ok,ng} 内 step id が候補に出る", () => {
+      const value = "@var.step.";
+      const state = varScopeResolver.match(value, value.length, { flow: mockFlowPhase3Nested });
+      expect(state?.phase).toBe("active");
+      if (state?.phase !== "active") return;
+      const values = state.candidates.map((c) => c.value);
+      expect(values).toContain("in-val-ok");
+      expect(values).toContain("in-val-ng");
+    });
+  });
+
+  // Phase 3 (#1316): 4-segment 文法 @var.step.<id>.<binding-name>
+  describe("Phase 3 (#1316) — 4-segment @var.step.<id>.<name>", () => {
+    it("@var.step.step-01. で該当 step の outputBinding.name が候補になる", () => {
+      const value = "@var.step.step-01.";
+      const state = varScopeResolver.match(value, value.length, { flow: mockFlowPhase2bis });
+      expect(state?.phase).toBe("active");
+      if (state?.phase !== "active") return;
+      const values = state.candidates.map((c) => c.value);
+      expect(values).toContain("userResult"); // step-01.outputBinding.name
+      expect(values.length).toBe(1);
+    });
+
+    it("@var.step.step-02. (TX 内 nested step) でも outputBinding.name が候補になる", () => {
+      const value = "@var.step.step-02.";
+      const state = varScopeResolver.match(value, value.length, { flow: mockFlowPhase2bis });
+      expect(state?.phase).toBe("active");
+      if (state?.phase !== "active") return;
+      const values = state.candidates.map((c) => c.value);
+      expect(values).toContain("createdOrder"); // step-02 (TX 内).outputBinding.name
+    });
+
+    it("@var.step.step-01.user で prefix フィルタが効く", () => {
+      const value = "@var.step.step-01.user";
+      const state = varScopeResolver.match(value, value.length, { flow: mockFlowPhase2bis });
+      expect(state?.phase).toBe("active");
+      if (state?.phase !== "active") return;
+      const values = state.candidates.map((c) => c.value);
+      expect(values).toContain("userResult");
+    });
+
+    it("@var.step.<存在しない id>. で空候補 (該当 step なし)", () => {
+      const value = "@var.step.nonexistent.";
+      const state = varScopeResolver.match(value, value.length, { flow: mockFlowPhase2bis });
+      expect(state?.phase).toBe("active");
+      if (state?.phase !== "active") return;
+      expect(state.candidates).toHaveLength(0);
+    });
+  });
+
+  // Phase 3 (#1316): 4-segment 文法 @var.tx.<id>.<member>
+  describe("Phase 3 (#1316) — 4-segment @var.tx.<id>.<member>", () => {
+    const mockFlowPhase3Tx = {
+      id: "flow-3-tx",
+      name: "phase3 tx with expose",
+      actions: [
+        {
+          id: "action-1",
+          name: "tx with expose",
+          inputs: [],
+          steps: [
+            {
+              id: "tx-with-expose",
+              kind: "transactionScope",
+              isolationLevel: "READ_COMMITTED",
+              rollbackOn: [],
+              outputBinding: { name: "txResult", expose: ["newOrderId", "stockReserved"] },
+              steps: [
+                { id: "tx-child-01", kind: "dbAccess", outputBinding: { name: "newOrderId" } },
+              ],
+            },
+            // 非 TX step (tx scope ではマッチしないことを確認)
+            { id: "not-tx-step", kind: "dbAccess", outputBinding: { name: "x" } },
+          ],
+        },
+      ],
+    } as unknown as V3ProcessFlow;
+
+    it("@var.tx.tx-with-expose. で予約 3 値 + expose[] が候補になる", () => {
+      const value = "@var.tx.tx-with-expose.";
+      const state = varScopeResolver.match(value, value.length, { flow: mockFlowPhase3Tx });
+      expect(state?.phase).toBe("active");
+      if (state?.phase !== "active") return;
+      const values = state.candidates.map((c) => c.value);
+      expect(values).toContain("committed");
+      expect(values).toContain("error");
+      expect(values).toContain("diagnostics");
+      expect(values).toContain("newOrderId");
+      expect(values).toContain("stockReserved");
+      expect(values.length).toBe(5);
+    });
+
+    it("@var.tx.tx-with-expose.comm で prefix フィルタが効く", () => {
+      const value = "@var.tx.tx-with-expose.comm";
+      const state = varScopeResolver.match(value, value.length, { flow: mockFlowPhase3Tx });
+      expect(state?.phase).toBe("active");
+      if (state?.phase !== "active") return;
+      const values = state.candidates.map((c) => c.value);
+      expect(values).toContain("committed");
+      expect(values.length).toBe(1);
+    });
+
+    it("@var.tx.not-tx-step. (非 TX step を tx scope で指定) は空候補", () => {
+      const value = "@var.tx.not-tx-step.";
+      const state = varScopeResolver.match(value, value.length, { flow: mockFlowPhase3Tx });
+      expect(state?.phase).toBe("active");
+      if (state?.phase !== "active") return;
+      expect(state.candidates).toHaveLength(0);
+    });
+
+    it("@var.tx.<存在しない id>. でも空候補", () => {
+      const value = "@var.tx.nonexistent.";
+      const state = varScopeResolver.match(value, value.length, { flow: mockFlowPhase3Tx });
+      expect(state?.phase).toBe("active");
+      if (state?.phase !== "active") return;
+      expect(state.candidates).toHaveLength(0);
+    });
   });
 });

--- a/frontend/src/utils/reference-completer/varScopeResolver.ts
+++ b/frontend/src/utils/reference-completer/varScopeResolver.ts
@@ -102,12 +102,14 @@ export const varScopeResolver: Resolver = {
           }
         }
       } else if (scope === "action") {
-        for (const action of ctx.flow.actions) {
-          for (const step of action.steps ?? []) {
-            const stepAny = step as unknown as Record<string, unknown>;
-            const ob = stepAny.outputBinding as Record<string, unknown> | undefined;
-            if (ob?.name && typeof ob.name === "string") names.add(ob.name);
-          }
+        // action body 全体 (top-level + TX/loop/branch/workflow/validation 内 nested 全 step)
+        // の outputBinding.name を列挙。spec §3.6 line 249 が "action body 全体で生きる" と
+        // 定義しており、Phase 2 までは top-level のみ参照していた pre-existing 問題を
+        // PR #1317 review (Should-fix) で吸収。
+        for (const { step } of iterAllSteps(ctx.flow)) {
+          const sAny = step as Record<string, unknown>;
+          const ob = sAny.outputBinding as Record<string, unknown> | undefined;
+          if (ob?.name && typeof ob.name === "string") names.add(ob.name);
         }
       } else if (scope === "step") {
         // step id を全列挙 (TX/loop/branch/validation/workflow 内 nested 含む)

--- a/frontend/src/utils/reference-completer/varScopeResolver.ts
+++ b/frontend/src/utils/reference-completer/varScopeResolver.ts
@@ -1,12 +1,18 @@
 /**
- * @var.<scope>.<name> 補完 Resolver (#1282 Phase 1/2 / #1302 Phase 2-bis)。
+ * @var.<scope>.<name> 補完 Resolver (#1282 Phase 1/2 / #1302 Phase 2-bis / #1316 Phase 3)。
  *
  * Phase 1: scope (flowParameter / action / step / tx / loop / global) の補完
  * Phase 2: flowParameter / action の name 補完
- * Phase 2-bis (#1302): step / tx / loop の name 補完を追加。
- *                      global は catalog spec 未確立のため空候補 (別 ISSUE で対応予定)
+ * Phase 2-bis (#1302): step / tx / loop の id / name 補完を追加。
+ *                      global は catalog spec 未確立のため空候補 (#1310 で対応予定)
+ * Phase 3 (#1316):
+ *   - iterSteps が網羅する nested Step[] を 6 種追加 (branch.elseBranch /
+ *     TX.onCommit / TX.onRollback / workflow.on{Approved,Rejected,Timeout} /
+ *     validation.inlineBranch.{ok,ng})
+ *   - 4-segment 文法 @var.step.<id>.<binding-name> / @var.tx.<id>.<member> 対応
+ *   - step / tx scope の候補に trailing: "." 付与 (4-segment 連動 UX)
  *
- * spec 出典: process-flow-variables.md §3.6
+ * spec 出典: process-flow-variables.md §3.6 / §3.7
  */
 
 import type { CompletionContext, CompletionState, Resolver } from "./types";
@@ -14,13 +20,74 @@ import type { ProcessFlow as V3ProcessFlow } from "../../types/v3";
 
 const SCOPE_KEYS = ["flowParameter", "action", "step", "tx", "loop", "global"] as const;
 
+/** TX 外参照可な予約 3 値 (process-flow-variables.md §3.7 / process-flow.v3.schema.json:519) */
+const TX_RESERVED_MEMBERS = ["committed", "error", "diagnostics"] as const;
+
 export const varScopeResolver: Resolver = {
   id: "var",
 
   match(value: string, cursorPos: number, ctx: CompletionContext): CompletionState | null {
     const before = value.slice(0, cursorPos);
 
-    // Phase 2 + Phase 2-bis: @var.<scope>.<name> の name 補完
+    // Phase 3: @var.step.<id>.<binding-name> / @var.tx.<id>.<member> の name 補完 (4-segment)
+    // 先に判定する (3-segment regex より長いので prefix 衝突回避)
+    const n3 = before.match(/@var\.(step|tx)\.([\w-]+)\.([\w-]*)$/);
+    if (n3) {
+      if (!ctx.flow) return null;
+      const scope = n3[1];
+      const stepId = n3[2];
+      const namePrefix = n3[3];
+
+      // 該当 step を flat 列挙から探す (scope === "tx" の場合は kind === "transactionScope" に限定)
+      let target: Record<string, unknown> | undefined;
+      for (const { step } of iterAllSteps(ctx.flow)) {
+        const sAny = step as Record<string, unknown>;
+        if (sAny.id !== stepId) continue;
+        if (scope === "tx" && sAny.kind !== "transactionScope") continue;
+        target = sAny;
+        break;
+      }
+      if (!target) {
+        // 該当 step なし: 空候補返却 (active mode、ユーザーは自由入力可)
+        return {
+          phase: "active",
+          resolverId: "var",
+          prefix: namePrefix,
+          candidates: [],
+          replaceLen: namePrefix.length,
+        };
+      }
+
+      const names = new Set<string>();
+      if (scope === "step") {
+        // step.outputBinding.name (単一)
+        const ob = target.outputBinding as Record<string, unknown> | undefined;
+        if (ob?.name && typeof ob.name === "string") names.add(ob.name);
+      } else {
+        // tx.<id>.<member>: 予約 3 値 (常に利用可) + outputBinding.expose[] (任意 inner var)
+        for (const k of TX_RESERVED_MEMBERS) names.add(k);
+        const ob = target.outputBinding as Record<string, unknown> | undefined;
+        const expose = ob?.expose;
+        if (Array.isArray(expose)) {
+          for (const k of expose) {
+            if (typeof k === "string") names.add(k);
+          }
+        }
+      }
+
+      const candidates = [...names]
+        .filter((nm) => nm.startsWith(namePrefix))
+        .map((v) => ({ value: v }));
+      return {
+        phase: "active",
+        resolverId: "var",
+        prefix: namePrefix,
+        candidates,
+        replaceLen: namePrefix.length,
+      };
+    }
+
+    // Phase 2 + Phase 2-bis: @var.<scope>.<name> の name 補完 (3-segment)
     const n = before.match(/@var\.(flowParameter|action|step|tx|loop|global)\.([\w-]*)$/);
     if (n) {
       if (!ctx.flow) return null;
@@ -43,7 +110,7 @@ export const varScopeResolver: Resolver = {
           }
         }
       } else if (scope === "step") {
-        // step id を全列挙 (TX/loop/branch 内 nested 含む)
+        // step id を全列挙 (TX/loop/branch/validation/workflow 内 nested 含む)
         for (const { step } of iterAllSteps(ctx.flow)) {
           const sAny = step as Record<string, unknown>;
           if (typeof sAny.id === "string") names.add(sAny.id);
@@ -68,14 +135,17 @@ export const varScopeResolver: Resolver = {
           }
         }
       } else if (scope === "global") {
-        // 候補 source 未確立 (spec/schema governance 未対応、follow-up ISSUE で対応予定)
+        // 候補 source 未確立 (#1310 follow-up で対応予定)
         // project.json / harmony.json に globals catalog が未定義のため、空候補返却で OK
         // (resolver は active mode、candidates: [] — ユーザーは自由入力可能)
       }
 
+      // step / tx の場合は 4-segment 文法 (@var.step.<id>.<name>) なので
+      // 候補に trailing: "." を付けて次段補完を誘発する
+      const needsTrailing = scope === "step" || scope === "tx";
       const candidates = [...names]
         .filter((nm) => nm.startsWith(namePrefix))
-        .map((v) => ({ value: v }));
+        .map((v) => (needsTrailing ? { value: v, trailing: "." } : { value: v }));
       return {
         phase: "active",
         resolverId: "var",
@@ -106,7 +176,7 @@ export const varScopeResolver: Resolver = {
   },
 };
 
-/** flow.actions[].steps[] を再帰列挙 (TX/loop/branch 内の nested step も含む) */
+/** flow.actions[].steps[] を再帰列挙 (nested step も含む) */
 function* iterAllSteps(flow: V3ProcessFlow): Generator<{ step: unknown }> {
   for (const action of flow.actions) {
     yield* iterSteps(action.steps ?? []);
@@ -117,18 +187,39 @@ function* iterSteps(steps: unknown[]): Generator<{ step: unknown }> {
   for (const s of steps) {
     yield { step: s };
     const sAny = s as Record<string, unknown>;
-    // TX scope の子 step
-    if (sAny.kind === "transactionScope" && Array.isArray(sAny.steps)) {
-      yield* iterSteps(sAny.steps);
+    // TX scope: steps[] + onCommit[] + onRollback[] (schema #/$defs/TransactionScopeStep)
+    if (sAny.kind === "transactionScope") {
+      if (Array.isArray(sAny.steps)) yield* iterSteps(sAny.steps);
+      if (Array.isArray(sAny.onCommit)) yield* iterSteps(sAny.onCommit);
+      if (Array.isArray(sAny.onRollback)) yield* iterSteps(sAny.onRollback);
     }
-    // loop scope の子 step
+    // loop scope
     if (sAny.kind === "loop" && Array.isArray(sAny.steps)) {
       yield* iterSteps(sAny.steps);
     }
-    // branch scope の子 step
-    if (sAny.kind === "branch" && Array.isArray(sAny.branches)) {
-      for (const br of sAny.branches as Record<string, unknown>[]) {
-        if (Array.isArray(br.steps)) yield* iterSteps(br.steps);
+    // branch: branches[].steps[] + elseBranch.steps[] (schema #/$defs/BranchStep)
+    if (sAny.kind === "branch") {
+      if (Array.isArray(sAny.branches)) {
+        for (const br of sAny.branches as Record<string, unknown>[]) {
+          if (Array.isArray(br.steps)) yield* iterSteps(br.steps);
+        }
+      }
+      const eb = sAny.elseBranch as Record<string, unknown> | undefined;
+      if (eb && Array.isArray(eb.steps)) yield* iterSteps(eb.steps);
+    }
+    // workflow: onApproved[] / onRejected[] / onTimeout[] (schema #/$defs/WorkflowStep)
+    if (sAny.kind === "workflow") {
+      for (const k of ["onApproved", "onRejected", "onTimeout"] as const) {
+        const arr = sAny[k];
+        if (Array.isArray(arr)) yield* iterSteps(arr);
+      }
+    }
+    // validation: inlineBranch.{ok,ng}[] (schema #/$defs/ValidationInlineBranch)
+    if (sAny.kind === "validation") {
+      const ib = sAny.inlineBranch as Record<string, unknown> | undefined;
+      if (ib) {
+        if (Array.isArray(ib.ok)) yield* iterSteps(ib.ok);
+        if (Array.isArray(ib.ng)) yield* iterSteps(ib.ng);
       }
     }
   }


### PR DESCRIPTION
## 概要

PR #1309 (Phase 2-bis、merged) の独立レビューで検出された Should-fix 3 件を follow-up で対応する。`varScopeResolver` を Phase 3 として拡張:

- **提案 A**: `iterSteps` に nested `Step[]` 列挙 6 種を追加
- **提案 B**: 4-segment 文法 `@var.step.<id>.<binding-name>` / `@var.tx.<id>.<member>` の補完を実装
- **提案 C**: step / tx scope 候補に `trailing: "."` を付与 (4-segment 連動 UX)

## 解決する ISSUE

Closes #1316

Refs #1309 (review 出典 PR、merged) / #1302 (親 Phase 2-bis)

## 関連 (spec / schema)

- spec: `docs/spec/process-flow-variables.md` §3.6 (resolver 補完範囲) / §3.7 (TX expose 仕様)
- schema: `schemas/v3/process-flow.v3.schema.json` — `Step` を含む arrays は全 12 箇所、本 PR で iterSteps が 11 箇所カバー (残 1 は ActionDefinition.steps[] = top-level entry で iterAllSteps が担当)

## レビュー出典

https://github.com/csilost2001/harmony/pull/1309#issuecomment-4527523155

## 変更点 (file:line)

### resolver

- `frontend/src/utils/reference-completer/varScopeResolver.ts` (236 行) — 主な変更:
  - line 23-25: `TX_RESERVED_MEMBERS = ["committed", "error", "diagnostics"]` 定数追加 (spec §3.7 / schema:519)
  - line 32-86: 提案 B (4-segment 補完) — 新 regex `/@var\.(step|tx)\.([\w-]+)\.([\w-]*)$/` + 該当 step 検索 + step は outputBinding.name / tx は予約 3 値 + expose[] を候補化
  - line 141-145: 提案 C (trailing) — scope === "step" || scope === "tx" の場合のみ candidate に `trailing: "."` 付与
  - line 184-225: 提案 A (iterSteps 拡張) — TX.onCommit / onRollback / branch.elseBranch / workflow.on{Approved,Rejected,Timeout} / validation.inlineBranch.{ok,ng} を追加再帰

### test

- `frontend/src/utils/reference-completer/varScopeResolver.test.ts` (466 行、+259 行) — Phase 3 テスト 16 件追加:
  - `Phase 3 — step/tx 候補の trailing` (4 件): step / tx は trailing 付き / loop / flowParameter は trailing なしを確認
  - `Phase 3 — iterSteps nested 網羅` (4 件): TX.onCommit/onRollback / branch.elseBranch / workflow.on* / validation.inlineBranch.{ok,ng} の各 nested step id が `@var.step.` 候補に出ることを確認 (新 fixture `mockFlowPhase3Nested`)
  - `Phase 3 — 4-segment @var.step.<id>.<name>` (4 件): step-01 直下 / TX 内 nested step (step-02) / prefix フィルタ / 存在しない id
  - `Phase 3 — 4-segment @var.tx.<id>.<member>` (4 件): 予約 3 値 + expose / prefix フィルタ / 非 TX step / 存在しない id (新 fixture `mockFlowPhase3Tx`)

### spec

- `docs/spec/process-flow-variables.md` §3.6 line 316-330 — resolver 補完範囲表に Phase 3 列を追加、Phase 2-bis 表記「name 補完」と canonical 4-segment 文法の対応関係を明文化、iterSteps 網羅 nested 配置を全 9 箇所列挙

## 仕様逐条突合 (自己申告)

### docs/spec/process-flow-variables.md §3.6 scope enum 6 値

| 条項 (spec line) | 実装箇所 | 判定 |
|---|---|---|
| `flowParameter` (line 248) — action 入力 | `varScopeResolver.ts:100-106` | ✅ (Phase 2 既存、本 PR 変更なし) |
| `action` (line 249) — action body 全体 | `varScopeResolver.ts:107-114` | ✅ (Phase 2 既存、本 PR 変更なし) |
| `step.<step-id>` (line 250) — 4-segment `@var.step.<step-id>.<binding-name>` | `varScopeResolver.ts:32-86` (Phase 3 4-seg) + `varScopeResolver.ts:115-121` (Phase 2-bis step-id) | ✅ 完全形対応 |
| `tx.<tx-id>` (line 251) — 4-segment `@var.tx.<tx-id>.<member>` | `varScopeResolver.ts:32-86` (Phase 3 4-seg) + `varScopeResolver.ts:122-129` (Phase 2-bis tx-id) | ✅ 完全形対応 |
| `loop` (line 252) — collectionItemName / collectionIndexName / outputBinding.name | `varScopeResolver.ts:130-140` | ✅ (Phase 2-bis、本 PR 変更なし) |
| `global` (line 253) — workspace/project 横断 | `varScopeResolver.ts:141-144` | ✅ 空候補返却 (#1310 follow-up) |

### docs/spec/process-flow-variables.md §3.7 TX expose 仕様

| 条項 | 実装箇所 | 判定 |
|---|---|---|
| TX 予約 3 値 `committed` / `error` / `diagnostics` は常に利用可 | `varScopeResolver.ts:23-24` (`TX_RESERVED_MEMBERS`) + `varScopeResolver.ts:67` | ✅ |
| TX 外参照可な inner var は `outputBinding.expose[]` で宣言 | `varScopeResolver.ts:69-74` (`expose` 配列を候補に追加) | ✅ |

### docs/spec/process-flow-variables.md §3.6 resolver 補完範囲表 (新規追加列)

| 表記 (line 322-328) | 判定 |
|---|---|
| `step` Phase 3 列 `✅ 4-segment 補完 + trailing` | `varScopeResolver.ts:32-86 (4-seg)` + line 141-145 (trailing) ✅ |
| `tx` Phase 3 列 `✅ 4-segment 補完 + trailing` | 同上 ✅ |
| `loop` Phase 3 列 `— (3-segment で完結)` | trailing 付与せず ✅ (line 141 の needsTrailing で除外) |

## 検証

- `cd frontend && npx tsc --noEmit`: **0 errors**
- `cd frontend && npx vitest run src/utils/reference-completer/varScopeResolver.test.ts`: **27/27 pass** (Phase 2-bis 11 + Phase 3 16)
- `cd frontend && npx vitest run src/utils/reference-completer/`: **110/110 pass** (全 resolver 退行なし)
- `git diff --name-only origin/main..HEAD -- schemas/`: empty (**schema 変更なし**、governance #511 適合)

## scope 外 (本 ISSUE で対応しない、明示)

- `@var.loop.<binding-name>` の enclosing loop chain による絞り込み (UX 性能の話、独立) — 別 ISSUE 候補
- `@var.global.<key>` の catalog 確立 — #1310 (既起票)
- `@var.tx.<id>.<member>.<sub-field>` の 5-segment 以降 (例: `@var.tx.tx-01.error.code`) の補完 — 構造把握には別 resolver / schema 解析が必要、本 PR scope 外

## review fix (commit 2cc67a94、Sonnet 独立レビュー Should-fix 吸収)

レビューで `action` scope が Phase 2 由来で nested 取りこぼしと指摘 (pre-existing)。
鉄則 1 + memory `feedback_pr_scope_absorb_pre_existing.md` に従い本 PR 内で吸収:

- `varScopeResolver.ts:107-117` — action scope を `iterAllSteps` 経由に変更 (5 行修正)
- test 新規 1 件追加 — `@var.action.` で TX/loop 内 nested step の `outputBinding.name` が候補に出ることを assert (mockFlowPhase2bis で createdOrder / lineTotal 等を確認)

これで `action` scope も spec §3.6 line 249 "action body 全体で生きる" の定義どおりの挙動。

## Test plan

- [x] vitest varScopeResolver 28/28 全 pass (Phase 2-bis 11 + Phase 3 16 + review fix 1)
- [x] reference-completer 全 resolver pass (regression なし)
- [x] tsc 0 errors
- [x] schema 変更なし
- [x] 独立レビュー (Sonnet) Must-fix 0、Should-fix 吸収済、Nit 解消済

## レビュー担当への申し送り

- **重点 review 観点**: iterSteps の 6 種網羅が schema 全箇所と一致しているか (`grep -nE '\$ref":\s*"#/\$defs/Step"' schemas/v3/process-flow.v3.schema.json` で 12 箇所、iterAllSteps entry を除く 11 箇所のうち 10 を iterSteps がカバー、残 1 は entry の重複)
- **4-segment regex の優先順序**: Phase 3 (`/@var\.(step|tx)\.([\w-]+)\.([\w-]*)$/`) を Phase 2 より先に判定する設計 (longer match 優先)。Phase 2 regex は 3-segment しか matchしないので衝突しないが、念のため順序確認推奨
- **TX outputBinding 解析**: `target.outputBinding` を `Record<string, unknown>` キャストで取り出し、`expose` field を Array.isArray で型 guard。schema:519 では `expose: { type: "array", items: { type: "string" } }` だが、ユーザー入力途中の draft 状態を考慮して防御的に書いた
- **fixture 構造の schema 適合**: `mockFlowPhase3Nested` / `mockFlowPhase3Tx` は最小限の schema 要件を満たす形 (kind / description / required fields)。AJV 検証は省略 (resolver は draft 状態でも動作することが要件)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
