### PR TITLE
feat(spec/schema/designer): #1310 globals catalog — generic-definitions/global kind 追加 (read-only)

### DIFF
--- a/docs/spec/generic-definition-layer.md
+++ b/docs/spec/generic-definition-layer.md
@@ -222,9 +222,9 @@ PageLayout "admin-layout"  ←  ページ全体の枠
 - **`mappingHints` は完全 optional / advisory** (任意): 特定 techStack (Spring / Nest / Next 等) への codegen 時のヒント。設計書の本質ではなく **AI 生成側のチューニング材料**。本 spec の Spring/Nest/Next 例はあくまでサンプルで、Django / Rails / Vue 等への展開も自由
 - `mappingHints` が無くても **言語非依存の本体だけで設計意図は完結する** こと。逆に `mappingHints` だけで設計意図を表現するのは禁止 (本体に migrate する)
 
-### 4.2 17 種類の kind
+### 4.2 18 種類の kind
 
-初期 7 種 (#1064-#1068) → Phase X2 で 14 種 (#1263) → #1303 で 17 種に拡張。#1318 で `messageArea` kind を `message-area` に kebab-case 統一 (prefix `@messageArea.<name>` は維持、kind=kebab/prefix=camelCase は log-event/logEvent と同じ分離パターン)。
+初期 7 種 (#1064-#1068) → Phase X2 で 14 種 (#1263) → #1303 で 17 種に拡張 → #1310 で 18 種に拡張。#1318 で `messageArea` kind を `message-area` に kebab-case 統一 (prefix `@messageArea.<name>` は維持、kind=kebab/prefix=camelCase は log-event/logEvent と同じ分離パターン)。
 
 | kind | 用途 | 主な参照元 |
 |---|---|---|
@@ -245,6 +245,7 @@ PageLayout "admin-layout"  ←  ページ全体の枠
 | `dialog` | confirm / alert / custom dialog の定義 (ScreenItemEvent.effects[].showDialog.target 参照先) | `@dialog.<name>` |
 | `message-area` | 画面横断 message area の定義 (ScreenItemEvent.effects[].setMessage.target 参照先、#1318 で `messageArea` → `message-area` kebab-case 統一、prefix は `@messageArea.` を維持 = log-event/logEvent 前例と同様の kind=kebab/prefix=camelCase 分離) | `@messageArea.<name>` |
 | `options` | 選択肢カタログ (ScreenItemEvent.effects[].setOptions 動的差し替え参照先) | `@options.<name>` |
+| `global` | workspace/project 横断の mutable 設定 slot (`@var.global.<key>` 参照元、Spring `@Value` / `@SessionScope` 相当、#1310)。read-only catalog として 1 instance = 1 設定群を定義、`fields[]` で field schema を記述。本 PR では catalog のみ、write semantics (step kind / lifetime) は将来 follow-up。 | `@var.global.<key>` |
 
 ### 4.3 既存仕様との関係
 

--- a/docs/spec/process-flow-variables.md
+++ b/docs/spec/process-flow-variables.md
@@ -250,7 +250,7 @@ RFC #1264 で確定した hybrid scope chain (case C) の具体仕様。**暗黙
 | `step.<step-id>` | step 出力 binding (`outputBinding.name`) | scope enter で生成 / exit で破棄 | `@var.step.step-05.newOrderNumber` |
 | `tx.<tx-id>` | TransactionScopeStep 内 binding | TX commit でマージ / rollback で破棄 | `@var.tx.step-06.txResult` |
 | `loop` | loop iteration 内 (`collectionItemName` / `collectionIndexName` / push operation の `outputBinding.name`) | iteration ごとに fresh / `outputBinding.name` は loop 終了後 enclosing scope に push | `@var.loop.cartItem`、`@var.loop.idx`、`@var.loop.enrichedItems` |
-| `global` | workspace / project 横断 (mutable、`@const` と区別) | session 全体 | `@var.global.tenantId` |
+| `global` | workspace / project 横断 catalog 定義 (mutable、`@const` と区別)、`generic-definitions/global/<key>.json` で定義 (#1310) | session 全体 (write 機能は将来 follow-up) | `@var.global.TenantContext` |
 
 `step.` / `tx.` 接頭辞は具体的な step-id / tx-id を後続する (LocalId pattern)。
 
@@ -324,9 +324,11 @@ editor 編集時の補完では両方の候補が並列に出る (resolver 別)�
 | `step` | — | ✅ step-id 補完 (全 step id、TX/loop/branch/workflow/validation の nested 含む) | ✅ `@var.step.<id>.<binding-name>` 4-segment 補完 (`outputBinding.name`) + 候補に trailing "." 付与 |
 | `tx` | — | ✅ tx-id 補完 (kind="transactionScope" の id のみ) | ✅ `@var.tx.<id>.<member>` 4-segment 補完 (予約 3 値 `committed`/`error`/`diagnostics` + `outputBinding.expose[]`) + 候補に trailing "." 付与 |
 | `loop` | — | ✅ name 補完 (collectionItemName / collectionIndexName / outputBinding.name) | — (3-segment で完結) |
-| `global` | — | ⚠️ 空候補 (catalog 未確立、#1310 で対応予定) | — |
+| `global` | — | ✅ catalog 補完 (#1310) | — |
 
 注: Phase 2-bis の表記「name 補完」は実際には scope 階層第 3 segment (step-id / tx-id / loop-name) の補完を指す。`step` / `tx` は spec §3.6 line 250-251 の canonical 文法どおり 4-segment (`@var.step.<step-id>.<binding-name>` / `@var.tx.<tx-id>.<member>`) で完結し、Phase 3 (#1316) で最終 segment まで補完が繋がる。nested step 列挙の網羅は `iterSteps` ヘルパが担当 (compound step kind = transactionScope / loop / branch / workflow / validation の各 nested 配置 `steps[]` / `branches[].steps[]` / `elseBranch.steps[]` / `onCommit[]` / `onRollback[]` / `onApproved[]` / `onRejected[]` / `onTimeout[]` / `inlineBranch.{ok,ng}[]` を再帰列挙)。
+
+注: `global` scope は #1310 で導入された generic-definitions/global/ catalog から `genericDefinitionsByKind` context 経由で候補取得する (read-only catalog のみ、write step kind は将来 follow-up)。
 
 ### 3.7 TX (transactionScope) 境界での変数挙動 (#1264 verdict 観点 4 / #1267 Round 7 option C)
 

--- a/examples/household-budget/harmony/generic-definitions/global/TenantContext.json
+++ b/examples/household-budget/harmony/generic-definitions/global/TenantContext.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../../../../schemas/v3/generic-definitions/global.v3.schema.json",
+  "kind": "global",
+  "name": "TenantContext",
+  "purpose": "マルチテナント切替コンテキスト (@var.global.TenantContext)。現在ログイン中ユーザーが扱うテナント識別子を保持。",
+  "responsibilities": [
+    "login 完了時に tenant resolver が値を確定する想定",
+    "全 ProcessFlow から @var.global.TenantContext で参照される",
+    "テナント切替 UI が値を書き換える (本 PR scope 外、将来 follow-up)"
+  ],
+  "targets": ["backend", "frontend", "shared"],
+  "fields": [
+    { "name": "tenantId", "type": "string", "description": "テナント識別子 (テナントごとに一意)" },
+    { "name": "tenantName", "type": "string", "description": "テナント表示名 (UI 表示用)" }
+  ],
+  "constraints": [
+    "tenantId は login 後 non-null",
+    "tenant 切替時は両 field を同時に更新する"
+  ],
+  "mappingHints": {
+    "defaultValue": null,
+    "setBy": ["login interceptor", "tenant switch action (follow-up)"],
+    "scope": "session"
+  }
+}

--- a/frontend/src/components/generic-definition/GenericDefinitionCatalogView.tsx
+++ b/frontend/src/components/generic-definition/GenericDefinitionCatalogView.tsx
@@ -29,6 +29,7 @@ const KIND_ICONS: Record<GenericDefinitionKind, string> = {
   dialog: "bi-chat-square",
   "message-area": "bi-chat-left-text",
   options: "bi-list-ul",
+  global: "bi-globe2",
 };
 
 const KIND_DESCRIPTIONS: Record<GenericDefinitionKind, string> = {
@@ -49,6 +50,7 @@ const KIND_DESCRIPTIONS: Record<GenericDefinitionKind, string> = {
   dialog: "画面から呼び出すダイアログ定義 (`@dialog.<name>` 参照元、#1303)",
   "message-area": "画面内メッセージエリア定義 (`@messageArea.<name>` 参照元、#1303 / #1318 で messageArea → message-area kebab-case 統一)",
   options: "選択肢カタログ (selectbox / radio 等の選択肢セット) を定義します (`@options.<name>` 参照元、#1303)",
+  global: "アプリケーション横断の mutable 設定 slot (Spring `@Value` / `@SessionScope` 相当、`@var.global.<key>` 参照元、#1310)",
 };
 
 export function GenericDefinitionCatalogView() {
@@ -82,7 +84,7 @@ export function GenericDefinitionCatalogView() {
     <div style={{ padding: "24px" }}>
       <h2 style={{ marginBottom: "8px", fontSize: "1.3rem" }}>汎用定義カタログ</h2>
       <p style={{ color: "#666", marginBottom: "24px", fontSize: "0.9rem" }}>
-        Generic Definition Catalog — データ契約・ドメイン型・例外型など 17 種類の汎用設計定義を管理します。
+        Generic Definition Catalog — データ契約・ドメイン型・例外型など 18 種類の汎用設計定義を管理します。
       </p>
       <div style={{
         display: "grid",

--- a/frontend/src/schemas/genericDefinitionValidator.test.ts
+++ b/frontend/src/schemas/genericDefinitionValidator.test.ts
@@ -76,6 +76,22 @@ describe("validateGenericDefinition", () => {
       const issues = validateGenericDefinition(validComponentDef);
       expect(issues).toHaveLength(0);
     });
+
+    it("global が正しければ issues は空 (#1310)", () => {
+      const validGlobal: GenericDefinition = {
+        kind: "global",
+        name: "TenantContext",
+        purpose: "マルチテナント切替コンテキスト (@var.global.TenantContext)",
+        responsibilities: ["login 完了時に値を確定する", "全 ProcessFlow から参照される"],
+        targets: ["backend", "frontend", "shared"],
+        fields: [
+          { name: "tenantId", type: "string" },
+          { name: "tenantName", type: "string" },
+        ],
+      };
+      const issues = validateGenericDefinition(validGlobal);
+      expect(issues.filter((i) => i.severity === "error")).toHaveLength(0);
+    });
   });
 
   describe("必須フィールド欠落", () => {

--- a/frontend/src/schemas/genericDefinitionValidator.ts
+++ b/frontend/src/schemas/genericDefinitionValidator.ts
@@ -5,10 +5,12 @@
  * validateHarmony.ts のキャッシュパターンに倣い、singleton AJV + 初回呼び出し時 compile。
  *
  * #1263 Phase X2 (#1267 Opus Round 4 Should-fix #1): 全 17 kind に固有 schema が存在する。
+ * #1310: global kind 追加 (全 18 kind)。
  * 旧 8 kind (data-contract / domain-type / exception-type / application-rule / ui-behavior /
  *   runtime-policy / ui-fragment) + 新 7 kind (component-definition / validation-rule /
  *   constants / message / domain-event / log-event / log-config) すべて KIND_SCHEMAS に登録。
  * #1303: 新 3 kind (dialog / message-area / options) を追加 (全 17 kind)。
+ * #1310: global kind 追加 (全 18 kind)。
  * #1318: messageArea → message-area kebab-case 統一 (kind は kebab-case 統一規約、
  *   prefix `@messageArea.<name>` は log-event/logEvent 前例と同様に camelCase 維持)。
  */
@@ -37,6 +39,8 @@ import logConfigSchema from "../../../schemas/v3/generic-definitions/log-config.
 import dialogSchema from "../../../schemas/v3/generic-definitions/dialog.v3.schema.json";
 import messageAreaSchema from "../../../schemas/v3/generic-definitions/message-area.v3.schema.json";
 import optionsSchema from "../../../schemas/v3/generic-definitions/options.v3.schema.json";
+// #1310 — global kind
+import globalSchema from "../../../schemas/v3/generic-definitions/global.v3.schema.json";
 
 export interface GenericDefinitionIssue {
   kind: GenericDefinitionKind;
@@ -46,7 +50,7 @@ export interface GenericDefinitionIssue {
   severity: "error" | "warning";
 }
 
-// kind → 固有 schema の $id (#1263 Phase X2: 14 kind 全件 + #1303: 3 新規 kind = 全 17 kind)
+// kind → 固有 schema の $id (#1263 Phase X2: 14 kind 全件 + #1303: 3 新規 kind = 全 17 kind + #1310: global = 全 18 kind)
 const KIND_SCHEMAS: Partial<Record<GenericDefinitionKind, object>> = {
   "data-contract": dataContractSchema as object,
   "exception-type": exceptionTypeSchema as object,
@@ -67,6 +71,8 @@ const KIND_SCHEMAS: Partial<Record<GenericDefinitionKind, object>> = {
   dialog: dialogSchema as object,
   "message-area": messageAreaSchema as object,
   options: optionsSchema as object,
+  // #1310 — global
+  global: globalSchema as object,
 };
 
 type ValidateFn = ReturnType<InstanceType<typeof Ajv2020>["compile"]>;

--- a/frontend/src/schemas/genericDefinitionValidator.ts
+++ b/frontend/src/schemas/genericDefinitionValidator.ts
@@ -4,12 +4,12 @@
  * draft-state-policy §6 に基づき、AJV で schema 検証 + kind 固有 semantic warning を提供する。
  * validateHarmony.ts のキャッシュパターンに倣い、singleton AJV + 初回呼び出し時 compile。
  *
- * #1263 Phase X2 (#1267 Opus Round 4 Should-fix #1): 全 17 kind に固有 schema が存在する。
+ * #1263 Phase X2 (#1267 Opus Round 4 Should-fix #1): 全 17 kind に固有 schema が存在する (→ #1310 で global 追加、全 18 kind)。
  * #1310: global kind 追加 (全 18 kind)。
  * 旧 8 kind (data-contract / domain-type / exception-type / application-rule / ui-behavior /
  *   runtime-policy / ui-fragment) + 新 7 kind (component-definition / validation-rule /
  *   constants / message / domain-event / log-event / log-config) すべて KIND_SCHEMAS に登録。
- * #1303: 新 3 kind (dialog / message-area / options) を追加 (全 17 kind)。
+ * #1303: 新 3 kind (dialog / message-area / options) を追加 (計 17 kind)。
  * #1310: global kind 追加 (全 18 kind)。
  * #1318: messageArea → message-area kebab-case 統一 (kind は kebab-case 統一規約、
  *   prefix `@messageArea.<name>` は log-event/logEvent 前例と同様に camelCase 維持)。

--- a/frontend/src/schemas/identifierScope.ts
+++ b/frontend/src/schemas/identifierScope.ts
@@ -47,7 +47,7 @@ export interface IdentifierIssue {
  * - ambient: @ambient.* 旧形式の ambient 参照
  *
  * **Generic Definition Catalog 参照** (docs/spec/process-flow-prefix-system.md §3、
- * #1285 で追加、14 kind 全件 + #1303 追加 3 kind = 17 kind): broken-ref 検証は
+ * #1285 で追加、14 kind 全件 + #1303 追加 3 kind + #1310 追加 1 kind (global) = 18 kind): broken-ref 検証は
  * processFlowAntipatternValidator Check 31 が担うため identifierScope は変数 scope 検査の対象外として skip する。
  * - msg        : @msg.<Name> generic-definitions/message
  * - validation : @validation.<Name> generic-definitions/validation-rule (inline boolean return)
@@ -92,7 +92,7 @@ const BUILTIN_AMBIENTS = new Set<string>([
   "secret",
   "conv",
   "ambient",
-  // Generic Definition Catalog refs (#1285 14 kind + #1303 3 kind = 17 kind)
+  // Generic Definition Catalog refs (#1285 14 kind + #1303 3 kind + #1310 1 kind = 18 kind)
   "msg",
   "validation",
   "rule",
@@ -370,7 +370,7 @@ function walkSteps(
  * - 明示 scope (path[0] が VAR_EXPLICIT_SCOPES の値):
  *   - flowParameter / action / loop: path[1] が対応 scope set に存在
  *   - step / tx: path[1]=stepId が stepIndex に存在 + path[2]=name が当該 step の binding と一致
- *   - global: silent pass (project-level、本 PR scope 外)
+ *   - global: silent pass (project-level、#1310 で generic-definitions/global catalog 化済、catalog 突合は別 PR で連動予定)
  * - shorthand (path[0] が 6 scope keyword 以外): path[0] を lexical chain (known + loopItems) で検索
  */
 function checkVarReference(

--- a/frontend/src/schemas/processFlowAntipatternValidator.ts
+++ b/frontend/src/schemas/processFlowAntipatternValidator.ts
@@ -38,7 +38,7 @@
  *   - entity (projectIndex.screens/tables/views/viewers/layouts/sequences/flows/externalSystems):
  *     `@screen` / `@table` / `@view` / `@viewer` (2 段は id 検証、4 段は id + child 検証)
  *     `@layout` / `@seq` / `@flow` / `@system` (id 単純 lookup)
- *   - generic-definition (17 kind × 1 prefix, #1303 追加: dialog/message-area/options、#1318 で kind=kebab/prefix=camelCase 分離):
+ *   - generic-definition (18 kind × 1 prefix, #1303 追加: dialog/message-area/options、#1310 追加: global、#1318 で kind=kebab/prefix=camelCase 分離):
  *     `@contract` / `@type` / `@exception` / `@rule` / `@validation` / `@behavior` /
  *     `@policy` / `@component` / `@fragment` / `@const` / `@msg` / `@logEvent` / `@logConfig`
  *     (`@event` は flow-level context と generic-definition/domain-event の両方が candidate)

--- a/frontend/src/schemas/projectCatalogIndex.ts
+++ b/frontend/src/schemas/projectCatalogIndex.ts
@@ -44,7 +44,7 @@ export interface ProjectCatalogIndex {
   /** `@system.<systemId>` (externalSystems catalog) */
   externalSystems: Set<string>;
 
-  // ─── Generic Definition Catalog (#1090 / #1267 Phase X2 14 kind + #1303 3 kind = 17 kind) ───
+  // ─── Generic Definition Catalog (#1090 / #1267 Phase X2 14 kind + #1303 3 kind = 17 kind + #1310 1 kind = 18 kind) ───
   /** `@contract.<name>` — data-contract */
   dataContracts: Set<string>;
   /** `@type.<name>` — domain-type */
@@ -69,6 +69,8 @@ export interface ProjectCatalogIndex {
   messageAreas: Set<string>;
   /** `@options.<name>` — options (#1303) */
   optionSets: Set<string>;
+  /** `@var.global.<key>` — global (#1310、workspace/project 横断 mutable 設定 slot) */
+  globals: Set<string>;
 
   /**
    * `@const.<key>` — constants catalog (#1267 Phase X2)。
@@ -121,6 +123,7 @@ export function createEmptyProjectCatalogIndex(): ProjectCatalogIndex {
     dialogs: new Set(),
     messageAreas: new Set(),
     optionSets: new Set(),
+    globals: new Set(),
     constants: new Set(),
     messages: new Set(),
     domainEvents: new Set(),
@@ -182,6 +185,8 @@ const GENERIC_KIND_TO_SET_KEY: Record<string, keyof ProjectCatalogIndex> = {
   dialog: "dialogs",
   "message-area": "messageAreas",
   options: "optionSets",
+  // #1310 — global
+  global: "globals",
 };
 
 /** conventions catalog の中で `@conv.<category>` として ref されない metadata field */

--- a/frontend/src/types/v3/generic-definition.ts
+++ b/frontend/src/types/v3/generic-definition.ts
@@ -2,11 +2,12 @@
  * Generic Definition Catalog 型定義 (v3 schema 準拠)
  *
  * schema: schemas/v3/generic-definition.v3.schema.json
- * 17 kind (#1254 件 3.7 / #1263 Phase X2 / #1303):
+ * 18 kind (#1254 件 3.7 / #1263 Phase X2 / #1303 / #1310):
  *   既存 8: data-contract / domain-type / exception-type / application-rule /
  *            ui-behavior / runtime-policy / component-definition / ui-fragment
  *   新規 6: validation-rule / constants / message / domain-event / log-event / log-config
  *   新規 3: dialog / message-area / options (#1303 で導入、#1318 で messageArea → message-area kebab-case 統一)
+ *   新規 1: global (#1310 で導入)
  *
  * 命名規約: 複合語 kind は kebab-case で統一。prefix は log-event/logEvent、log-config/logConfig、
  * message-area/messageArea のように camelCase 短縮形を取りうる (kind と prefix は別概念)。
@@ -29,7 +30,8 @@ export type GenericDefinitionKind =
   | "log-config"
   | "dialog"
   | "message-area"
-  | "options";
+  | "options"
+  | "global";
 
 export type GenericDefinitionTarget = "backend" | "frontend" | "shared" | "runtime";
 
@@ -101,6 +103,7 @@ export const GENERIC_DEFINITION_KINDS: GenericDefinitionKind[] = [
   "dialog",
   "message-area",
   "options",
+  "global",
 ];
 
 export const GENERIC_DEFINITION_KIND_LABELS: Record<GenericDefinitionKind, string> = {
@@ -121,6 +124,7 @@ export const GENERIC_DEFINITION_KIND_LABELS: Record<GenericDefinitionKind, strin
   dialog: "ダイアログ",
   "message-area": "メッセージエリア",
   options: "選択肢",
+  global: "グローバル設定",
 };
 
 export const GENERIC_DEFINITION_TARGETS: GenericDefinitionTarget[] = [

--- a/frontend/src/utils/reference-completer/varScopeResolver.test.ts
+++ b/frontend/src/utils/reference-completer/varScopeResolver.test.ts
@@ -211,13 +211,45 @@ describe("varScopeResolver", () => {
     expect(values.length).toBe(3);
   });
 
-  // Phase 2-bis: global scope (空候補)
-  it("@var.global. で空候補 (catalog 未確立、phase active のまま)", () => {
-    const value = "@var.global.";
-    const state = varScopeResolver.match(value, value.length, { flow: mockFlowPhase2bis });
-    expect(state?.phase).toBe("active");
-    if (state?.phase !== "active") return;
-    expect(state.candidates).toHaveLength(0);
+  // #1310: global scope (catalog 駆動)
+  describe("@var.global.<name> (catalog driven、#1310)", () => {
+    it("genericDefinitionsByKind 未渡しで空候補 (active mode 維持)", () => {
+      const value = "@var.global.";
+      const state = varScopeResolver.match(value, value.length, { flow: mockFlowPhase2bis });
+      expect(state?.phase).toBe("active");
+      if (state?.phase !== "active") return;
+      expect(state.candidates).toHaveLength(0);
+    });
+
+    it("global catalog 渡しで name 候補が返る", () => {
+      const value = "@var.global.";
+      const state = varScopeResolver.match(value, value.length, {
+        flow: mockFlowPhase2bis,
+        genericDefinitionsByKind: {
+          global: [{ name: "TenantContext" }, { name: "FeatureFlags" }],
+        },
+      });
+      expect(state?.phase).toBe("active");
+      if (state?.phase !== "active") return;
+      const values = state.candidates.map((c) => c.value);
+      expect(values).toContain("TenantContext");
+      expect(values).toContain("FeatureFlags");
+      expect(values.length).toBe(2);
+    });
+
+    it("@var.global.Ten で prefix フィルタが効く", () => {
+      const value = "@var.global.Ten";
+      const state = varScopeResolver.match(value, value.length, {
+        flow: mockFlowPhase2bis,
+        genericDefinitionsByKind: {
+          global: [{ name: "TenantContext" }, { name: "FeatureFlags" }],
+        },
+      });
+      expect(state?.phase).toBe("active");
+      if (state?.phase !== "active") return;
+      expect(state.candidates).toHaveLength(1);
+      expect(state.candidates[0].value).toBe("TenantContext");
+    });
   });
 
   // Phase 3 (#1316): step / tx 候補に trailing: "." 付与 (4-segment 文法連動)

--- a/frontend/src/utils/reference-completer/varScopeResolver.ts
+++ b/frontend/src/utils/reference-completer/varScopeResolver.ts
@@ -4,7 +4,7 @@
  * Phase 1: scope (flowParameter / action / step / tx / loop / global) の補完
  * Phase 2: flowParameter / action の name 補完
  * Phase 2-bis (#1302): step / tx / loop の id / name 補完を追加。
- *                      global は catalog spec 未確立のため空候補 (#1310 で対応予定)
+ *                      global は #1310 で catalog 駆動候補に対応
  * Phase 3 (#1316):
  *   - iterSteps が網羅する nested Step[] を 6 種追加 (branch.elseBranch /
  *     TX.onCommit / TX.onRollback / workflow.on{Approved,Rejected,Timeout} /
@@ -13,6 +13,7 @@
  *   - step / tx scope の候補に trailing: "." 付与 (4-segment 連動 UX)
  *
  * spec 出典: process-flow-variables.md §3.6 / §3.7
+ * #1310: @var.global.<name> を generic-definitions/global catalog 駆動の候補化に拡張
  */
 
 import type { CompletionContext, CompletionState, Resolver } from "./types";
@@ -137,9 +138,14 @@ export const varScopeResolver: Resolver = {
           }
         }
       } else if (scope === "global") {
-        // 候補 source 未確立 (#1310 follow-up で対応予定)
-        // project.json / harmony.json に globals catalog が未定義のため、空候補返却で OK
-        // (resolver は active mode、candidates: [] — ユーザーは自由入力可能)
+        // #1310: generic-definitions/global/*.json の name を候補化
+        // catalog 未渡し or 空 catalog の場合は空候補返却 (resolver は active mode、ユーザー自由入力可)
+        const globals = ctx.genericDefinitionsByKind?.["global"];
+        if (globals) {
+          for (const g of globals) {
+            if (typeof g?.name === "string") names.add(g.name);
+          }
+        }
       }
 
       // step / tx の場合は 4-segment 文法 (@var.step.<id>.<name>) なので

--- a/schemas/v3/generic-definition.v3.schema.json
+++ b/schemas/v3/generic-definition.v3.schema.json
@@ -2,13 +2,19 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/csilost2001/harmony/main/schemas/v3/generic-definition.v3.schema.json",
   "title": "Generic Definition (v3 汎用設計定義 親 schema)",
-  "description": "Layer 2 Generic Definition Catalog の 17 kind 共通メタモデル (#1263 Phase X2 / RFC #1254 件 3.7 で 8 → 14 kind に拡張、#1303 で 14 → 17 kind に拡張)。<project>/<dataDir>/generic-definitions/<kind>/<Name>.json に対応。仕様: docs/spec/generic-definition-layer.md §4.1。本 schema は kind / name / purpose / responsibilities / targets を必須とする共通親で、kind 別の固有 schema (旧 7: data-contract / domain-type / exception-type / application-rule / ui-behavior / runtime-policy / ui-fragment は #1064-#1068 で導入、新 7: component-definition / validation-rule / constants / message / domain-event / log-event / log-config は #1263 Phase X2 で導入、追加 3: dialog / message-area / options は #1303 で導入、#1318 で messageArea → message-area kebab-case 統一) は allOf で本定義を継承する。catalog 記録のため EntityMeta (uuid id / timestamps) は採用せず、`name` field が catalog identifier を兼ねる (ファイル名と一致させる運用)。",
+  "description": "Layer 2 Generic Definition Catalog の 18 kind 共通メタモデル (#1263 Phase X2 / RFC #1254 件 3.7 で 8 → 14 kind に拡張、#1303 で 14 → 17 kind に拡張、#1310 で 17 → 18 kind に拡張)。<project>/<dataDir>/generic-definitions/<kind>/<Name>.json に対応。仕様: docs/spec/generic-definition-layer.md §4.1。本 schema は kind / name / purpose / responsibilities / targets を必須とする共通親で、kind 別の固有 schema (旧 7: data-contract / domain-type / exception-type / application-rule / ui-behavior / runtime-policy / ui-fragment は #1064-#1068 で導入、新 7: component-definition / validation-rule / constants / message / domain-event / log-event / log-config は #1263 Phase X2 で導入、追加 3: dialog / message-area / options は #1303 で導入、#1318 で messageArea → message-area kebab-case 統一、#1310 で global 追加) は allOf で本定義を継承する。catalog 記録のため EntityMeta (uuid id / timestamps) は採用せず、`name` field が catalog identifier を兼ねる (ファイル名と一致させる運用)。",
   "type": "object",
   "$ref": "#/$defs/GenericDefinition",
   "$defs": {
     "GenericDefinition": {
       "type": "object",
-      "required": ["kind", "name", "purpose", "responsibilities", "targets"],
+      "required": [
+        "kind",
+        "name",
+        "purpose",
+        "responsibilities",
+        "targets"
+      ],
       "properties": {
         "$schema": {
           "type": "string",
@@ -28,35 +34,49 @@
         },
         "responsibilities": {
           "type": "array",
-          "items": { "type": "string", "minLength": 1 },
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
           "minItems": 1,
           "description": "本定義が担う責務の列挙。コード生成時の AI が読み取る semantic 情報源。"
         },
         "targets": {
           "type": "array",
-          "items": { "$ref": "#/$defs/GenericDefinitionTarget" },
+          "items": {
+            "$ref": "#/$defs/GenericDefinitionTarget"
+          },
           "minItems": 1,
           "uniqueItems": true,
           "description": "適用領域。backend / frontend / shared / runtime。例: data-contract の DTO は backend + frontend の shared、runtime-policy は runtime のみ。"
         },
         "fields": {
           "type": "array",
-          "items": { "$ref": "#/$defs/GenericField" },
+          "items": {
+            "$ref": "#/$defs/GenericField"
+          },
           "description": "本定義が保持する field / property 一覧 (data-contract / domain-type / exception-type 等で利用)。"
         },
         "operations": {
           "type": "array",
-          "items": { "$ref": "#/$defs/GenericOperation" },
+          "items": {
+            "$ref": "#/$defs/GenericOperation"
+          },
           "description": "本定義が提供する operation / method (component-definition / ui-behavior 等で利用)。"
         },
         "relations": {
           "type": "array",
-          "items": { "$ref": "#/$defs/GenericRelation" },
+          "items": {
+            "$ref": "#/$defs/GenericRelation"
+          },
           "description": "他 catalog 記録 / entity への関係 (継承 / 実装 / 利用 / 変換元先 / 適用対象)。"
         },
         "constraints": {
           "type": "array",
-          "items": { "type": "string", "minLength": 1 },
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
           "description": "不変条件・事前/事後条件の自然言語記述。AI コード生成のヒント。"
         },
         "mappingHints": {
@@ -67,7 +87,6 @@
       },
       "unevaluatedProperties": false
     },
-
     "GenericDefinitionKind": {
       "type": "string",
       "enum": [
@@ -87,11 +106,11 @@
         "log-config",
         "dialog",
         "message-area",
-        "options"
+        "options",
+        "global"
       ],
-      "description": "Generic Definition Catalog の 17 kind (#1254 件 3.7 / #1263 Phase X2 で 14 種 / #1303 で 14→17 種に拡張、spec §4.2)。data-contract = DTO/Form/Result/ViewModel 等の層間契約。domain-type = Entity/Model などドメイン型。exception-type = 例外種別・階層・semantic kind。application-rule = 認証認可/ログ/監査などの横断ルール。validation-rule = 業務検証ルール (条件 + メッセージ + severity)。ui-behavior = 画面横断振る舞い。runtime-policy = retry/timeout/circuit breaker/cache 等の横断適用ポリシー。component-definition = service/mapper/validator/formatter 等の責務。ui-fragment = 再利用 UI 断片。constants = ドメイン定数集 (@const.<key> 参照元)。message = メッセージカタログ (@msg.<key> 参照元、i18n source)。domain-event = ドメインイベント定義 (@event.<topic> 参照元)。log-event = ログイベント定義 (@logEvent.<key> 参照元、構造化ログ)。log-config = ログ設定 (@logConfig.<key> 参照元、log level / sink / format)。dialog = ScreenItemEvent effects[].showDialog.target 参照先の dialog カタログ (@dialog.<name> 参照元)。message-area = ScreenItemEvent effects[].setMessage.target 参照先の画面横断 message area カタログ (prefix `@messageArea.<name>` で参照、log-event/log-config と同様に kind=kebab-case / prefix=camelCase の分離、#1318)。options = ScreenItemEvent effects[].setOptions の選択肢カタログ (@options.<name> 参照元)。"
+      "description": "Generic Definition Catalog の 18 kind (#1254 件 3.7 / #1263 Phase X2 で 14 種 / #1303 で 14→17 種に拡張、#1310 で 17→18 種に拡張 (global 追加)、spec §4.2)。data-contract = DTO/Form/Result/ViewModel 等の層間契約。domain-type = Entity/Model などドメイン型。exception-type = 例外種別・階層・semantic kind。application-rule = 認証認可/ログ/監査などの横断ルール。validation-rule = 業務検証ルール (条件 + メッセージ + severity)。ui-behavior = 画面横断振る舞い。runtime-policy = retry/timeout/circuit breaker/cache 等の横断適用ポリシー。component-definition = service/mapper/validator/formatter 等の責務。ui-fragment = 再利用 UI 断片。constants = ドメイン定数集 (@const.<key> 参照元)。message = メッセージカタログ (@msg.<key> 参照元、i18n source)。domain-event = ドメインイベント定義 (@event.<topic> 参照元)。log-event = ログイベント定義 (@logEvent.<key> 参照元、構造化ログ)。log-config = ログ設定 (@logConfig.<key> 参照元、log level / sink / format)。dialog = ScreenItemEvent effects[].showDialog.target 参照先の dialog カタログ (@dialog.<name> 参照元)。message-area = ScreenItemEvent effects[].setMessage.target 参照先の画面横断 message area カタログ (prefix `@messageArea.<name>` で参照、log-event/log-config と同様に kind=kebab-case / prefix=camelCase の分離、#1318)。options = ScreenItemEvent effects[].setOptions の選択肢カタログ (@options.<name> 参照元)。global = workspace/project 横断の mutable 設定 slot (@var.global.<key> 参照元、Spring @Value / @SessionScope 相当、#1310)。"
     },
-
     "GenericDefinitionName": {
       "type": "string",
       "pattern": "^[A-Za-z][A-Za-z0-9_]*$",
@@ -99,16 +118,22 @@
       "maxLength": 64,
       "description": "catalog 記録の identifier。ファイル名 (拡張子除く) と一致させる運用。慣例的に PascalCase (OrderForm / UserNotFoundException 等) を推奨するが、camelCase / snake-ish も許容。Identifier (lowerCamelCase 強制) は採用しない (例外クラス名等で PascalCase が業界標準のため)。"
     },
-
     "GenericDefinitionTarget": {
       "type": "string",
-      "enum": ["backend", "frontend", "shared", "runtime"],
+      "enum": [
+        "backend",
+        "frontend",
+        "shared",
+        "runtime"
+      ],
       "description": "適用領域。backend / frontend / shared (両方) / runtime (実行時横断ポリシー)。"
     },
-
     "GenericField": {
       "type": "object",
-      "required": ["name", "type"],
+      "required": [
+        "name",
+        "type"
+      ],
       "properties": {
         "name": {
           "type": "string",
@@ -123,7 +148,10 @@
         },
         "constraints": {
           "type": "array",
-          "items": { "type": "string", "minLength": 1 },
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
           "description": "field 単位の制約 (必須 / 桁数 / 値域等の自然言語記述)。"
         },
         "description": {
@@ -133,10 +161,11 @@
       },
       "unevaluatedProperties": false
     },
-
     "GenericOperation": {
       "type": "object",
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "properties": {
         "name": {
           "type": "string",
@@ -146,12 +175,16 @@
         },
         "inputs": {
           "type": "array",
-          "items": { "$ref": "#/$defs/GenericField" },
+          "items": {
+            "$ref": "#/$defs/GenericField"
+          },
           "description": "入力パラメータ列。"
         },
         "outputs": {
           "type": "array",
-          "items": { "$ref": "#/$defs/GenericField" },
+          "items": {
+            "$ref": "#/$defs/GenericField"
+          },
           "description": "出力 (戻り値) 列。複数戻り値 / tuple を表現可能。"
         },
         "description": {
@@ -161,14 +194,23 @@
       },
       "unevaluatedProperties": false
     },
-
     "GenericRelation": {
       "type": "object",
-      "required": ["kind", "ref"],
+      "required": [
+        "kind",
+        "ref"
+      ],
       "properties": {
         "kind": {
           "type": "string",
-          "enum": ["extends", "implements", "uses", "transformsFrom", "transformsTo", "appliesTo"],
+          "enum": [
+            "extends",
+            "implements",
+            "uses",
+            "transformsFrom",
+            "transformsTo",
+            "appliesTo"
+          ],
           "description": "関係種別 (spec §4.1)。extends = 継承、implements = 契約実装、uses = 利用、transformsFrom/To = 変換源/先、appliesTo = 適用対象 (横断ポリシー → 適用先 component 等)。"
         },
         "ref": {

--- a/schemas/v3/generic-definitions/global.v3.schema.json
+++ b/schemas/v3/generic-definitions/global.v3.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/csilost2001/harmony/main/schemas/v3/generic-definitions/global.v3.schema.json",
+  "title": "Global (v3 generic-definition kind: global)",
+  "description": "Generic Definition Catalog の global kind 固有 schema (#1310)。親 schema (../generic-definition.v3.schema.json) を allOf 継承し、kind を const \"global\" に固定。global は workspace/project 横断の mutable 設定 slot (Spring の @Value / @SessionScope 相当) を catalog 化する。@var.global.<key> 参照元 (process-flow-variables.md §3.6 scope=global)。本 PR (#1310) では read-only catalog のみ実装、write semantics (step kind / lifetime) は将来 follow-up。仕様: docs/spec/generic-definition-layer.md §4.2 / docs/spec/process-flow-variables.md §3.6。",
+  "type": "object",
+  "allOf": [
+    { "$ref": "../generic-definition.v3.schema.json" }
+  ],
+  "properties": {
+    "kind": { "const": "global" }
+  }
+}


### PR DESCRIPTION
## 概要

Generic Definition Catalog に **`global` kind (18 番目)** を追加し、`@var.global.<key>` 補完を catalog 駆動に切り替える。本 PR は **read-only catalog のみ** の実装で、Spring の `@Value` / `@SessionScope` 相当の named configuration slot として位置付ける (component-definition の DI bean とは責務分離)。

`/issues 1310` セッション中の Opus orchestrator がユーザーと設計判断を行い、approach (A) generic-definitions/global/<key>.json kind 追加 + scope (a) read-only catalog のみで確定。詳細経緯: [#1310 設計コメント](https://github.com/csilost2001/harmony/issues/1310#issuecomment-4527746449)。

## 主な変更

### Schema (governance #511 user 承認下)

- **新設**: `schemas/v3/generic-definitions/global.v3.schema.json` (constants.v3.schema.json 同型、`allOf` 継承 + `kind` const `"global"`)
- **拡張**: `schemas/v3/generic-definition.v3.schema.json` の `GenericDefinitionKind` enum (17→18)、title / description / kind 説明文を 18 種に同期

### Frontend

- `frontend/src/types/v3/generic-definition.ts` — type union / KINDS / KIND_LABELS に `global` 追加
- `frontend/src/schemas/genericDefinitionValidator.ts` — globalSchema import + KIND_SCHEMAS map に追加
- `frontend/src/schemas/projectCatalogIndex.ts` — `globals: Set<string>` field 追加 / createEmpty / GENERIC_KIND_TO_SET_KEY
- `frontend/src/utils/reference-completer/varScopeResolver.ts:139-148` — `@var.global.<name>` 候補を `ctx.genericDefinitionsByKind["global"]` 駆動に変更
- `frontend/src/utils/reference-completer/varScopeResolver.test.ts` — global scope describe ブロック 3 件に拡張 (未渡し / 渡し / prefix filter)
- `frontend/src/components/generic-definition/GenericDefinitionCatalogView.tsx` — KIND_ICONS (`bi-globe2`) / KIND_DESCRIPTIONS に global 追加、ヘッダ「17 種類」→「18 種類」

### Example

- `examples/household-budget/harmony/generic-definitions/global/TenantContext.json` — multi-tenant 切替コンテキスト 1 件 (spec line 253 の `@var.global.tenantId` を具現化)

### Spec

- `docs/spec/process-flow-variables.md §3.6` — scope 表の global 行 + resolver 補完表 + 注釈 3 箇所更新
- `docs/spec/generic-definition-layer.md §4.2` — 17→18 種同期 + global 段落追加

## スコープ外 (将来 follow-up)

- write step kind (`setGlobal` 等) — process-flow.v3.schema.json への追加が必要、本 PR では未対応
- lifetime semantics (application / session / request) — `mappingHints.scope` で free-form 受け入れに留め、enum 強制は将来 RFC
- runtime 状態保持実装

## 仕様逐条突合 (自己申告)

- ✅ `schemas/v3/generic-definitions/global.v3.schema.json:1-13` 新設 (constants.v3.schema.json 同型)
- ✅ `schemas/v3/generic-definition.v3.schema.json:5,107,112` enum 拡張 + description 同期
- ✅ `frontend/src/types/v3/generic-definition.ts:33,104,124` type union / KINDS / LABELS 追加
- ✅ `frontend/src/schemas/genericDefinitionValidator.ts` global import + KIND_SCHEMAS
- ✅ `frontend/src/schemas/projectCatalogIndex.ts` globals Set + createEmpty + GENERIC_KIND_TO_SET_KEY
- ✅ `frontend/src/utils/reference-completer/varScopeResolver.ts:139-148` global catalog 駆動
- ✅ `frontend/src/utils/reference-completer/varScopeResolver.test.ts` describe 3 ケース
- ✅ `frontend/src/components/generic-definition/GenericDefinitionCatalogView.tsx:31,51,85` UI 反映
- ✅ `examples/household-budget/harmony/generic-definitions/global/TenantContext.json` 1 件
- ✅ `docs/spec/process-flow-variables.md:253,327,330` 3 箇所
- ✅ `docs/spec/generic-definition-layer.md:225,227,248` 段落追加

## 検証 (Codex 実装委譲時の自己申告)

- npm run lint (frontend): warnings ゼロ
- npx tsc --noEmit (frontend): 0 errors
- npm test -- varScopeResolver --run: 30 passed (既存 27 + 新規 3)
- npm test -- genericDefinitionValidator --run: 19 passed
- npm run validate:samples (household-budget): 5/5 flows passed

## Test plan

- [ ] 独立レビューで Must-fix なきこと
- [ ] CatalogView で "グローバル設定" カードが出現
- [ ] @var.global.<key> 補完が designer 上で動作 (catalog populated 時)

Closes #1310

🤖 Generated with [Claude Code](https://claude.com/claude-code)
