### PR TITLE
fix(spec/types/skill): #1322 follow-up — Opus 再レビュー Should-fix 3 件解消

### DIFF
--- a/ai-skills/generate-code/SKILL.md
+++ b/ai-skills/generate-code/SKILL.md
@@ -389,7 +389,7 @@ export class RequestContextHolder { /* same shape */ }
 
 - 生成 Service 名は globals catalog name に基づく PascalCase + `Holder` suffix で安定化する
 - `@var.global.<globalName>` 読み出し側 (Read) と setGlobal (Write) は同 lifetime を使う前提。lifetime mismatch は warning として記録
-- TransactionScopeStep 内部での setGlobal は **コミット時のみ反映** すべきか議論あり (現状は即時反映で実装、TX rollback 時に globals が残る問題は #1322 後続の dogfood で再検証)
+- TransactionScopeStep 内部での `setGlobal` は **即時反映** で実装 (TX rollback 時の globals 値巻き戻しは現状未対応、必要性は dogfood で再検証 — spec 確定: [docs/spec/process-flow-variables.md §3.6 globals write](../../docs/spec/process-flow-variables.md))
 
 ### affectedRowsCheck → 実装パターン
 

--- a/frontend/src/types/v3/process-flow.ts
+++ b/frontend/src/types/v3/process-flow.ts
@@ -2,10 +2,11 @@
  * v3 ProcessFlow 型定義 (`schemas/v3/process-flow.v3.schema.json` と 1:1 対応)
  *
  * - root 4 セクション: meta / context / actions / authoring
- * - 25 step variants (validation / dbAccess / externalSystem / componentCall / commonProcess /
+ * - 26 step variants (validation / dbAccess / externalSystem / componentCall / commonProcess /
  *   screenTransition / displayUpdate / branch / loop / loopBreak / loopContinue / jump / compute /
- *   return / log / audit / workflow / transactionScope / eventPublish / eventSubscribe / closing /
- *   cdc / aiCall / aiAgent / extension)  ※ componentCall (#1067) / aiCall / aiAgent (#940) を含む
+ *   return / log / audit / setGlobal / workflow / transactionScope / eventPublish / eventSubscribe /
+ *   closing / cdc / aiCall / aiAgent / extension)  ※ componentCall (#1067) / aiCall / aiAgent (#940) /
+ *   setGlobal (#1322 Phase B-3e) を含む
  * - WorkflowApprover.order semantics (#539 R5-2) を JSDoc で明示
  * - datetime 算術 duration() 推奨 (#539 R5-3) を JSDoc で明示
  *

--- a/schemas/v3/process-flow.v3.schema.json
+++ b/schemas/v3/process-flow.v3.schema.json
@@ -1539,7 +1539,7 @@
             },
             "field": {
               "$ref": "common.v3.schema.json#/$defs/Identifier",
-              "description": "書き込み対象 field 名 (省略時は globals 全体を value で上書き)。指定時は globals.fields[].name のいずれかと一致 (validator は generic-definitions/global/<globalName> の fields[] を参照して照合)。"
+              "description": "書き込み対象 field 名 (省略時は globals 全体を value で上書き)。指定時は generic-definitions/global/<globalName>.json の fields[].name のいずれかと一致させる運用 (Phase B-3e 時点では schema-level の Identifier pattern 検証のみ。cross-catalog 検証 = `@var.global.<globalName>.<field>` 読み出し側と field 名整合 を validator で enforce するのは follow-up タスク)。"
             },
             "value": {
               "$ref": "common.v3.schema.json#/$defs/TemplateString",


### PR DESCRIPTION
## Summary

PR #1324 (#1322 Phase B-3 全 sub-phase) マージ後の **Opus 再レビュー** (NEEDS-FOLLOW-UP) で検出された Should-fix 3 件を解消する小規模 follow-up。

## 解消内容

| # | path:line | 内容 |
|---|---|---|
| 1 | `frontend/src/types/v3/process-flow.ts:5-8` | file header の "25 step variants" 列挙に `setGlobal` が欠落 (file 内本体 line 1105-1108 / 1146-1150 は #1324 で正しく 26 に bump 済だったが header 取り残し)。`setGlobal` を追加 + 合計を 26 に bump |
| 2 | `schemas/v3/process-flow.v3.schema.json:1542` | `SetGlobalStep.field` description が validator 検証を約束していたが Phase B-3e では未実装。description を「schema-level Identifier pattern 検証のみ、cross-catalog 検証は follow-up」と明示し誤誘導を防止 |
| 3 | `ai-skills/generate-code/SKILL.md:392` | TX 内 setGlobal を「議論あり」と表現していたが spec は確定済。"即時反映で実装 (rollback 時の globals 巻き戻し未対応)" に統一 |

## Re-review 観点 (Opus、独立 context、観点 1-13 確認済)

- schema governance: 設計者承認スコープ内 (`SetGlobalStep` 追加は #1322 で 2026-05-24 承認済、本 PR は **description 文言修正のみ、構造変更なし**)
- TS 型 ↔ schema 整合: header 修正のみ、型構造変更なし
- validator ロジック: 触らず
- pre-resolve util: 触らず
- spec ↔ 実装整合: 本 PR の目的 (gap の明示)

## Test plan

- [x] vitest 152/152 pass (set-global-step / processFlowAntipatternValidator / designerAliasResolve)
- [x] type check (`tsc --noEmit`) pass
- [x] validate:samples regression なし (touched files に validate 範囲外の description only changes)

Refs #1322

🤖 Generated with [Claude Code](https://claude.com/claude-code)
