### PR TITLE
fix(devcontainer): #1340 initializeCommand で bind mount source path を host 側で事前作成

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,6 +28,13 @@
     "source=/mnt/wslg,target=/mnt/wslg,type=bind,consistency=cached"
   ],
 
+  // initializeCommand: host 側でコンテナ起動「前」に bind mount source path を事前作成。
+  // Docker は missing source path を自動 mkdir しないため、fresh clone 後の初回
+  // Reopen in Container がここで失敗するのを防ぐ。既存ディレクトリ/ファイルは no-op。
+  // (host shell = bash 前提: WSL2 / macOS / Linux。Windows native cmd では動かないが
+  //  既存 mount (/tmp/.X11-unix 等) の時点で WSL2/Unix 前提のため整合) #1340
+  "initializeCommand": "bash -c 'mkdir -p ~/.agent-containers/${localWorkspaceFolderBasename}/{.claude,.codex,.copilot,.harmony} ~/.config/gh ~/.docker && touch ~/.gitconfig'",
+
   "onCreateCommand": "sudo chown -R node:node /home/node/.claude /home/node/.codex /home/node/.copilot /home/node/.harmony /home/node/.config/gh /home/node/.gitconfig",
 
   "postCreateCommand": "npm install --prefix frontend && npm install --prefix backend && ([ -f ~/.claude/.config.json ] || echo '{}' > ~/.claude/.config.json)",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,19 +21,17 @@
     "source=${localEnv:HOME}/.agent-containers/${localWorkspaceFolderBasename}/.harmony,target=/home/node/.harmony,type=bind,consistency=cached",
     "source=${localEnv:HOME}/.config/gh,target=/home/node/.config/gh,type=bind,consistency=cached",
     "source=${localEnv:HOME}/.gitconfig,target=/home/node/.gitconfig,type=bind,consistency=cached",
-    "source=${localEnv:HOME}/.docker,target=/home/node/.docker,type=bind,consistency=cached",
     // WSLg (Windows + WSL2 + Docker Desktop 前提): on-demand headed browser を Windows desktop に表示
     // 他 OS (macOS / Linux native) ではこの mount を当該行 comment out 推奨
     "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached",
     "source=/mnt/wslg,target=/mnt/wslg,type=bind,consistency=cached"
   ],
 
-  // initializeCommand: host 側でコンテナ起動「前」に bind mount source path を事前作成。
-  // Docker は missing source path を自動 mkdir しないため、fresh clone 後の初回
-  // Reopen in Container がここで失敗するのを防ぐ。既存ディレクトリ/ファイルは no-op。
-  // (host shell = bash 前提: WSL2 / macOS / Linux。Windows native cmd では動かないが
-  //  既存 mount (/tmp/.X11-unix 等) の時点で WSL2/Unix 前提のため整合) #1340
-  "initializeCommand": "bash -c 'mkdir -p ~/.agent-containers/${localWorkspaceFolderBasename}/{.claude,.codex,.copilot,.harmony} ~/.config/gh ~/.docker && touch ~/.gitconfig'",
+  // initializeCommand: container 起動「前」に host 側 bind mount source path を事前作成。
+  // Dev Containers は内部的に docker `--mount type=bind` を使い、`-v` と違い missing
+  // source は自動作成されない (`-v` は legacy 仕様で auto-create するが `--mount` は error)。
+  // host shell = bash 前提 (WSL2 / macOS / Linux); 既存 dir / file は no-op。 #1340
+  "initializeCommand": "bash -c 'mkdir -p ~/.agent-containers/${localWorkspaceFolderBasename}/{.claude,.codex,.copilot,.harmony} ~/.config/gh && touch ~/.gitconfig'",
 
   "onCreateCommand": "sudo chown -R node:node /home/node/.claude /home/node/.codex /home/node/.copilot /home/node/.harmony /home/node/.config/gh /home/node/.gitconfig",
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ VS Code 起動後:
 
 ### 初回起動時に作られるもの (利用者の事前準備は不要)
 
-Reopen in Container すると以下が WSL2 host 側に自動作成されます (Docker bind mount が自動 mkdir):
+Reopen in Container すると以下が WSL2 host 側に自動作成されます (`initializeCommand` が container 起動前に mkdir、#1340):
 
 ```
 ~/.agent-containers/harmony/

--- a/docs/setup/dev-containers.md
+++ b/docs/setup/dev-containers.md
@@ -57,7 +57,7 @@ npm run dev
 
 ## 初回起動で WSL2 host 側に何が作られるか
 
-Reopen in Container を実行すると、以下が自動で WSL2 host 側に作られます。**利用者の事前準備は不要**です (`devcontainer.json` の `initializeCommand` が container 起動「前」に host 側で `mkdir -p` を実行、#1340。Docker の bind mount 自体は missing source path を自動作成しない仕様のため明示 mkdir が必要):
+Reopen in Container を実行すると、以下が自動で WSL2 host 側に作られます。**利用者の事前準備は不要**です (`devcontainer.json` の `initializeCommand` が container 起動「前」に host 側で `mkdir -p` を実行、#1340。Dev Containers は内部で docker `--mount type=bind` を使い、legacy `-v` と違って missing source path を自動作成しないため、明示 mkdir が必要):
 
 ```
 ~/.agent-containers/                       ← AI agent 用データ root
@@ -90,6 +90,7 @@ container 起動後、以下の認証作業を 1 度だけ行います (rebuild 
    同様に `~/.agent-containers/<project>/.codex/auth.json` に保存される。
 3. **GitHub Copilot CLI**: 認証は `gh auth` (= `~/.config/gh/`) を共有するため、host で `gh auth login` 済みなら追加 OAuth 不要。Copilot CLI が初回起動時に必要な権限を付与するよう促す場合あり。session / memory / history は `~/.agent-containers/<project>/.copilot/` に永続化される (#1114)。
 4. **(任意) 個人 alias (`ccd` / `cdx` 等)**: VS Code user settings.json に dotfiles 3 行を追加。詳細は本書「個人 alias」節を参照。
+5. **(host 側で `git config --global` 未実施の場合のみ)** container 内で `git config --global user.email <addr>` / `user.name <name>` を 1 度実行 (bind mount で host `~/.gitconfig` に書き戻される、以降の rebuild で永続)。`initializeCommand` は host に空 `~/.gitconfig` が無い時 `touch` で作るため、container 内 `git commit` が `Author identity unknown` で失敗するのを防ぐ初回手順。
 
 OAuth が必要なのは初回 + refreshToken expire 後 (60〜90 日) のみ。日々の rebuild では認証は維持されます。
 

--- a/docs/setup/dev-containers.md
+++ b/docs/setup/dev-containers.md
@@ -90,7 +90,7 @@ container 起動後、以下の認証作業を 1 度だけ行います (rebuild 
    同様に `~/.agent-containers/<project>/.codex/auth.json` に保存される。
 3. **GitHub Copilot CLI**: 認証は `gh auth` (= `~/.config/gh/`) を共有するため、host で `gh auth login` 済みなら追加 OAuth 不要。Copilot CLI が初回起動時に必要な権限を付与するよう促す場合あり。session / memory / history は `~/.agent-containers/<project>/.copilot/` に永続化される (#1114)。
 4. **(任意) 個人 alias (`ccd` / `cdx` 等)**: VS Code user settings.json に dotfiles 3 行を追加。詳細は本書「個人 alias」節を参照。
-5. **(host 側で `git config --global` 未実施の場合のみ)** container 内で `git config --global user.email <addr>` / `user.name <name>` を 1 度実行 (bind mount で host `~/.gitconfig` に書き戻される、以降の rebuild で永続)。`initializeCommand` は host に空 `~/.gitconfig` が無い時 `touch` で作るため、container 内 `git commit` が `Author identity unknown` で失敗するのを防ぐ初回手順。
+5. **(host 側で `git config --global user.email/user.name` 未設定の場合のみ)** container 内で `git config --global user.email <addr>` / `user.name <name>` を 1 度実行 (bind mount で host `~/.gitconfig` に書き戻され、以降の rebuild で永続)。`initializeCommand` は host に `~/.gitconfig` が無い時に `touch` で空ファイルを作るため bind mount は通るが、内容が空だと container 内 `git commit` が `Author identity unknown` で失敗する — その回避手順。
 
 OAuth が必要なのは初回 + refreshToken expire 後 (60〜90 日) のみ。日々の rebuild では認証は維持されます。
 

--- a/docs/setup/dev-containers.md
+++ b/docs/setup/dev-containers.md
@@ -57,7 +57,7 @@ npm run dev
 
 ## 初回起動で WSL2 host 側に何が作られるか
 
-Reopen in Container を実行すると、以下が自動で WSL2 host 側に作られます。**利用者の事前準備は不要**です (Docker bind mount が missing path を自動 mkdir する仕様):
+Reopen in Container を実行すると、以下が自動で WSL2 host 側に作られます。**利用者の事前準備は不要**です (`devcontainer.json` の `initializeCommand` が container 起動「前」に host 側で `mkdir -p` を実行、#1340。Docker の bind mount 自体は missing source path を自動作成しない仕様のため明示 mkdir が必要):
 
 ```
 ~/.agent-containers/                       ← AI agent 用データ root


### PR DESCRIPTION
## Summary

- fresh clone 後の初回 `Reopen in Container` が host 側 `~/.agent-containers/<ws>/.claude` 等の bind mount source path 未存在で `docker run` 段階で start 失敗していたのを `initializeCommand` で解消
- doc の auto-mkdir 説明を正確化 (Docker `--mount type=bind` (Dev Containers が内部使用) は missing source path を自動作成しない — `-v` は legacy で auto-create するが本構成では不該当)
- 派生: `~/.docker` bind mount が P5b (#1122) 以降 dead code だったので同時除去
- 派生: 初回手順に「host で `git config --global user.email/user.name` 未設定の場合の container 内 1 度実行」を追加 (空 `~/.gitconfig` が container 内 git commit を失敗させる UX)

Closes #1340

## 背景・原因

Dev Containers は内部で docker `--mount type=bind` 形式を使い、legacy `-v` と違って **source path が存在しないと `docker run` 段階で必ず失敗** する。既存 dev container ユーザーは過去のセッションで host 側 `~/.agent-containers/<project>/...` が作成済みのため気付かなかったが、fresh clone した新規開発者 / 新マシンでは初回 `Reopen in Container` がエラー終了する。

`onCreateCommand` / `postCreateCommand` は container 起動「後」のため救済不可。container 起動「前」に host で走る `initializeCommand` lifecycle hook に bash 1 行を追加して解消。

## 変更点

### commit 1 (`67cc5f8e`) — 初版

- `.devcontainer/devcontainer.json` — `initializeCommand` 追加 (`~/.agent-containers/<ws>/{.claude,.codex,.copilot,.harmony}` / `~/.config/gh` / `~/.docker` を `mkdir -p`、`~/.gitconfig` を `touch`)
- `README.md:46` — 「Docker bind mount が自動 mkdir」→「`initializeCommand` が mkdir」訂正
- `docs/setup/dev-containers.md:60` — 同様の訂正

### commit 2 (`933b0354`) — adversarial review follow-up

独立 subagent + 自己再レビュー指摘の解消:

- `.devcontainer/devcontainer.json` — `~/.docker` mount を削除 (P5b で container 内 docker CLI 削除済み、consumer 不在の dead code)、`initializeCommand` からも `~/.docker` mkdir 削除
- `.devcontainer/devcontainer.json` のコメント精密化 — 「Docker の bind mount」→「Dev Containers が内部使用する `--mount type=bind` (legacy `-v` と違って auto-create しない)」
- `docs/setup/dev-containers.md:60` — 同様に精密化
- `docs/setup/dev-containers.md` 初回手順に 5. を追加 (host で `git config --global` 未設定環境の container 内 git commit 失敗対策)

### commit 3 (`b6a52122`) — 3rd-round 自己レビュー

- `docs/setup/dev-containers.md:93` — parse-ambiguous 表現 ("空 `~/.gitconfig` が無い時") を修正、条件節を「user.email/user.name 未設定」に精密化

## 仕様逐条突合 (自己申告)

ISSUE #1340 修正案 3 項目すべて対応:

- [x] 修正案 1: `initializeCommand` 追加で host 側ディレクトリ事前作成 — `.devcontainer/devcontainer.json:36`
  - mount 対象に対応: `~/.agent-containers/<ws>/{.claude,.codex,.copilot,.harmony}` ✓ / `~/.config/gh` ✓ / `~/.gitconfig` (touch) ✓
  - 不要 mount (`~/.docker`) は同時除去で本 PR 内整合化
- [x] 修正案 2: `onCreateCommand` は所有権調整のみに留める — `.devcontainer/devcontainer.json:38` (元から chown のみ、変更不要)
- [x] 修正案 3: doc の旧説明訂正 — `README.md:46`, `docs/setup/dev-containers.md:60`

## Test plan

- [x] JSONC 構文 valid 確認 (`node -e ... JSON.parse` で 3 commit 全てで OK)
- [x] mount sources と initializeCommand mkdir 対象の 1:1 照合 (.agent-containers の 4 dir / .config/gh / .gitconfig touch、計 6 = mounts 非WSLg 全件カバー)
- [x] VS Code variable substitution が initializeCommand 内で効くこと: containers.dev/implementors/json_reference 明文 + 同 devcontainer.json `mounts` 行が同変数を既に解決して container が動いている実機証拠
- [ ] 実機 fresh clone 状態 (`~/.agent-containers/` リネーム → Reopen in Container) で初回起動が成功することの実機検証は本 PR 作成 container 内では再現不可。reviewer 側 or ISSUE reporter (@mh78019) 環境で確認推奨

🤖 Generated with [Claude Code](https://claude.com/claude-code)