### PR TITLE
fix(e2e): #1299 Codex Round 14/15 Must-fix + Nit follow-up — presence-list strict-mode + test title rename

### DIFF
--- a/frontend/e2e/__fixtures__/builders/projectBuilder.ts
+++ b/frontend/e2e/__fixtures__/builders/projectBuilder.ts
@@ -18,7 +18,7 @@ import type {
   Timestamp,
   Uuid,
 } from "../../../src/types/v3";
-import { deterministicUuid, normalizeId } from "../../helpers/realWorkspace";
+import { deterministicUuid } from "../../helpers/realWorkspace";
 
 const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 

--- a/frontend/e2e/collab/presence-list.spec.ts
+++ b/frontend/e2e/collab/presence-list.spec.ts
@@ -107,7 +107,7 @@ test.describe("協調編集 一覧 SessionBadge 表示", { tag: ["@regression"] 
       // tab2: 一覧
       await seedTabsForWorkspace(pageB, ws.wsId, [dummyTab], dummyTab.id);
       await ws.gotoActive(pageB, "/process-flow/list");
-      await expect(pageB.getByText("一覧バッジテストフロー")).toBeVisible({ timeout: 10000 });
+      await expect(pageB.locator(".process-flow-card-name").getByText("一覧バッジテストフロー")).toBeVisible({ timeout: 10000 });
 
       // EditSessionBadge が表示される (broadcast 受信後)
       const badge = pageB.locator('[data-testid="edit-session-badge"]').first();

--- a/frontend/e2e/more-ui.spec.ts
+++ b/frontend/e2e/more-ui.spec.ts
@@ -112,7 +112,7 @@ test.describe("more-ui (#244)", { tag: ["@regression"] }, () => {
   });
 
   test.describe("ReturnStep 編集 (#214)", () => {
-    test("responseRef + bodyExpression が編集できる", async ({ page }) => {
+    test("responseId + bodyExpression が編集できる", async ({ page }) => {
       await gotoEditor(page, `/process-flow/edit/${normalizeId(groupId)}`);
       const card = await expandStep(page, 1);
       const refInput = card.locator('input[placeholder*="409-stock-shortage"]').first();


### PR DESCRIPTION
## Summary

#1299 (PR #1343 merged) の事後 Codex Round 14/15 レビューで検出された **Must-fix M-R14-1** + Nit を follow-up で吸収する。

## 背景

PR #1343 merge 後の Codex Round 14 ([comment](https://github.com/csilost2001/harmony/issues/1299#issuecomment-4540425126)) / Round 15 ([comment](https://github.com/csilost2001/harmony/issues/1299#issuecomment-4540631354)) で:

- **Must-fix M-R14-1**: `frontend/e2e/collab/presence-list.spec.ts:110` の `pageB.getByText("一覧バッジテストフロー")` が tab label + list card の **2 要素にマッチして strict-mode violation**。Round 12 で「flake」として未処理にしていたが、locator scope 不足の実バグ。full regression での再現性あり (single page isolation では race 条件で 1 要素だけになるため pass する)
- **Nit**: `frontend/e2e/more-ui.spec.ts:115` の test title が `responseRef + bodyExpression` のままだが、fixture は #1263 で `responseId` に rename 済 → 名称も追随

合わせて lint 検出の **unused `normalizeId` import** も cleanup (projectBuilder.ts)。

## 変更内容

| commit | 対象 | 変更 |
|---|---|---|
| `bdd24d85` | presence-list.spec.ts:110 | `pageB.getByText(...)` → `pageB.locator(".process-flow-card-name").getByText(...)` で list card に限定 |
| `bdd24d85` | more-ui.spec.ts:115 | test title `responseRef` → `responseId` |
| `c60fe3da` | projectBuilder.ts | `import { deterministicUuid, normalizeId }` から unused `normalizeId` 削除 |

## 検証

- `npx playwright test e2e/collab/ --workers=1 --reporter=line` → **8 passed (24.3s)**
- `npx playwright test e2e/more-ui.spec.ts:115 --workers=1` → **1 passed**
- `npm run lint` / `npx tsc --noEmit` → clean

## Refs

- 親 ISSUE: #1299 (CLOSED、Round 14 で M-R14-1 検出、本 PR で吸収)
- 元 PR: #1343 (MERGED)
- Codex Round 14 review: https://github.com/csilost2001/harmony/issues/1299#issuecomment-4540425126
- Codex Round 15 review (再確認): https://github.com/csilost2001/harmony/issues/1299#issuecomment-4540631354

## Test plan

- [x] presence-list:95 + more-ui:115 isolation pass
- [x] collab suite 全 8 test pass
- [x] lint / tsc clean
- [ ] (任意) full regression 再走で 8 fail → 7 fail への減少確認 — #1342 残 7 fail を考えると merge 後にやってもよい

🤖 Generated with [Claude Code](https://claude.com/claude-code)