### PR TITLE
chore(e2e): #1358 Project → Harmony 完全 rename + alias 削除 + /issues-cdx skill 新設

### DIFF
--- a/.agents/skills/issues-cdx
+++ b/.agents/skills/issues-cdx
@@ -1,1 +1,0 @@
-../../ai-skills/issues-cdx

--- a/.agents/skills/issues-cdx
+++ b/.agents/skills/issues-cdx
@@ -1,0 +1,1 @@
+../../ai-skills/issues-cdx

--- a/.claude/skills/issues-cdx
+++ b/.claude/skills/issues-cdx
@@ -1,0 +1,1 @@
+../../ai-skills/issues-cdx

--- a/ai-skills/issues-cdx/SKILL.md
+++ b/ai-skills/issues-cdx/SKILL.md
@@ -6,6 +6,10 @@ disable-model-invocation: true
 ---
 
 <!--
+  本 skill は **Claude Code 専用** (Codex 側からは呼ばない、`.agents/skills/` symlink なし)。
+  AskUserQuestion / Monitor / run_in_background / TaskCreate 等の Claude Code harness 専用 tool に依存するため。
+  Codex 側で同等のワークフローが欲しい場合は別 skill (tool-agnostic な手順記述) を新設する。
+
   使い方:
     `/issues-cdx 1354 1355 1356` のように 1 件以上の ISSUE 番号を指定。
     必要に応じて自然言語の補足指示を続ける (例:「設計判断を先に確定してから私は寝る」等)。
@@ -33,7 +37,7 @@ ISSUE #$ARGUMENTS を Opus 直接実装 + cdx 反復レビュー方式で解決�
 
 ## Step 0: ISSUE 群を読む
 
-引数が複数 ISSUE 番号の場合は **並列で全件取得**:
+引数が複数 ISSUE 番号の場合は 1 コマンドで連結して取得 (Bash 内で `&&` 連結、各 ISSUE 間は `---SEP---` で区切る):
 
 ```bash
 gh issue view <N1> && echo "---SEP---" && gh issue view <N2> && echo "---SEP---" && gh issue view <N3>

--- a/ai-skills/issues-cdx/SKILL.md
+++ b/ai-skills/issues-cdx/SKILL.md
@@ -1,0 +1,391 @@
+---
+name: issues-cdx
+description: ISSUE を Opus 直接実装 + Codex CLI (cdx エイリアス) 反復レビューで完遂する。設計判断を先に確定 → user 不在中も自律実行。1 ISSUE / 複数 ISSUE 統合どちらも対応
+argument-hint: <ISSUE番号> [追加ISSUE番号...] [自然言語の補足]
+disable-model-invocation: true
+---
+
+<!--
+  使い方:
+    `/issues-cdx 1354 1355 1356` のように 1 件以上の ISSUE 番号を指定。
+    必要に応じて自然言語の補足指示を続ける (例:「設計判断を先に確定してから私は寝る」等)。
+
+  /issues との違い:
+    /issues          : Opus orchestrator (実装は Codex/Sonnet 委譲)、レビューは review-pr-sonnet subagent
+    /issues-cdx      : Opus が直接実装、レビューは cdx (Codex CLI) を Bash で直接呼ぶ、設計確定→自律実行型
+
+  前提:
+    - gh CLI がパスに通っていること
+    - backend が起動していること (MCP ツールが必要な ISSUE の場合)
+    - `cdx` エイリアスが定義されていること (~/dotfiles/.bash_aliases 等で
+      `cdx () { command codex --dangerously-bypass-approvals-and-sandbox "$@"; }` を定義済)
+    - `disable-model-invocation: true`: ユーザーが明示的に `/issues-cdx <N>` と打った時のみ起動
+
+  運用原則:
+    - Opus = 設計判断 + 実装 + レビュー対応のすべてを担当 (Sonnet/Codex 委譲なし)
+    - レビュー = cdx exec (Codex CLI 直接呼出し、subagent ではなく Bash 経由)
+    - 設計判断は **着手前に AskUserQuestion で一括確定** (user 不在中の自律実行を可能にする)
+    - レビュー approve まで commit→review→修正→commit→review の反復
+    - スコープ外と判明した課題は **follow-up ISSUE で必ず trace 確立** (鉄則 0)
+-->
+
+ISSUE #$ARGUMENTS を Opus 直接実装 + cdx 反復レビュー方式で解決します。
+
+## Step 0: ISSUE 群を読む
+
+引数が複数 ISSUE 番号の場合は **並列で全件取得**:
+
+```bash
+gh issue view <N1> && echo "---SEP---" && gh issue view <N2> && echo "---SEP---" && gh issue view <N3>
+```
+
+本文・ラベル・コメント・state を確認。自然言語の補足指示があれば user の追加要件として解釈する。
+
+## Step 1: 統合 PR / 関連性判定
+
+### 1-A: 各 ISSUE 本文に `## 🔗 統合 PR 情報` セクションがある
+
+セクション記載の統合ブランチに従う (`/issues` Step 1 と同じ)。
+
+### 1-B: 複数 ISSUE が指定されているが統合宣言なし
+
+- 同一シリーズ派生 (タイトルや本文に共通の親 ISSUE / PR 参照)、または同根ファイル群を触る場合は **統合 PR 化を提案候補に**
+- 完全に独立した別機能なら個別 PR
+
+### 1-C: 1 ISSUE 単独
+
+- 関連 open ISSUE 検索 (`gh issue list --state open --search "<keyword>"`)
+- 関連発見 → 統合提案候補に
+
+## Step 2: 規模実測 (重要、設計判断の根拠)
+
+ISSUE 完了条件に「N 件を全消し」「N 件を全 pass」等の数量がある場合、**着手前に実測値を取得** して user に提示:
+
+| ISSUE タイプ | 実測コマンド例 |
+|---|---|
+| typecheck errors の全消し系 | `npx tsc --noEmit \| grep -c "error TS"` (拡張前後で比較) |
+| test fail の全 pass 系 | `npx vitest run --reporter=basic 2>&1 \| tail -3` |
+| sample / fixture migration 系 | `find <dir> -name "*.json" \| wc -l` |
+| schema 変更系 | `gh pr diff <PR> -- schemas/` で governance 確認 |
+
+実測なしで AskUserQuestion すると「ISSUE 起票時の見積もり N 件」を信用してしまい、scope 判断が外れる。**必ず数字を持って質問する**。
+
+## Step 3: 設計判断を **着手前に** 確定 (重要 — user 不在中の自律実行の前提)
+
+### AskUserQuestion で一括確定
+
+ISSUE 数だけ + 統合 PR 構成 + 規模判断分の質問を **1 回の AskUserQuestion でまとめて発行** (最大 4 質問)。
+
+### 質問設計の禁止事項 (鉄則 0 違反防止)
+
+- ❌ 「却下 / 現状維持 / defer」だけの選択肢提示は禁止
+  - trace 確立 ISSUE は「対応する」前提。「却下」を並べると ISSUE 不要扱いのシグナルになり叱責される
+  - memory `feedback_dont_offer_status_quo_for_trace_issues.md` 参照
+- ✅ 「実施スコープ A / B / C」(全件 / 部分 / Phase 分割) を提示する
+- ✅ defer する場合は理由を明示し、follow-up ISSUE での trace を含めた選択肢にする
+- ❌ ギリシャ文字 (α / β / γ) を選択肢ヘッダーに使わない (日本語キーボードで入力不可、memory `feedback_no_greek_letters_in_options.md`)
+
+### 質問パターン (今回の実例 = 3 ISSUE 統合)
+
+1. ISSUE-A の実施方針 (承認 / 部分実施 / defer + 起票)
+2. ISSUE-B の実施スコープ (全件 fix / Phase 分割 / defer)
+3. ISSUE-C のアプローチ選択 (a / b / c 等 ISSUE 本文記載の候補から)
+4. PR 構成 (統合 PR 1 本 / 個別 PR 複数 / 部分統合)
+
+### user が寝た場合の前提確認
+
+user 指示に「設計判断確定後に寝る」「自律完遂」「途中で止まらない」等があれば、AskUserQuestion を発行した後の処理を **完全自律モード** に切り替える:
+
+- 以降の判断は user 確認なしで Opus が単独で行う
+- レビュー指摘の解消・スコープ判断・follow-up ISSUE 起票も自律
+- 着手不可な事故 (権限超過 / repo 状態異常) のみ ScheduleWakeup ではなく **その時点で停止して報告残し**
+
+## Step 4: 統合ブランチ作成
+
+```bash
+git checkout -b feat/issue-<topic-slug>-series origin/main
+# 例: feat/issue-1332-followup-series (派生シリーズの場合)
+# 例: feat/issue-1354-<keyword>      (単独の場合)
+```
+
+worktree は使わない (本セッションで連続 commit するため、本 repo の branch 切替で十分。memory `feedback_no_worktree_sequential_work.md`)。
+
+## Step 5: ISSUE 単位で commit
+
+### 順序の原則
+
+**小さい → 中規模 → 大きい** で進める。失敗時の rollback コストを最小化:
+
+1. 文字列修正系 / description 同期 (commit 1)
+2. 中規模ロジック追加 (commit 2)
+3. 大規模 refactor / mass fix (commit 3+)
+
+### Opus 直接実装の責務
+
+- 全コードを Opus が **Edit / Write ツールで直接編集**
+- Codex / Sonnet 委譲しない (本 skill の前提)
+- 各 commit メッセージに ISSUE 番号 + 詳細 + 検証結果を記載
+- commit message に `Closes #N` を含めない (PR description で一括処理)、`Refs #N` を使う
+
+### 型変更 / fixture 大量修正の落とし穴 (今回学んだもの)
+
+`({...} as unknown) as <Type>` パターンで type errors を一掃する誘惑があるが、**type fidelity を弱体化させる ため Codex Must-fix を必ず受ける**。代わりに:
+
+- ✅ `const x: <Type> = { ... brand-only cast ... }` で type 注釈を残す
+- ✅ `satisfies <Type>` も使える (excess property 検証は維持される)
+- ✅ legacy field 参照は `(x as unknown as Record<string, unknown>).<field>` で意図明示
+- ❌ outer object 全体の `as unknown as <Type>` cast はやらない (Codex に必ず指摘される)
+
+詳細: 本 skill 末尾「失敗パターン集」#1。
+
+## Step 6: PR 作成 (全 ISSUE 完了時に 1 本)
+
+```bash
+gh pr create --title "..." --body "$(cat <<'EOF'
+## 概要
+<目的>
+
+## 修正内容
+### #N1: ...
+### #N2: ...
+### #N3: ...
+
+## 検証
+- npm run build → 0 errors
+- npx vitest run → X passed
+- ...
+
+## 関連
+- 親メタ: #M
+- 起源 PR: #P
+
+Closes #N1
+Closes #N2
+Closes #N3
+EOF
+)"
+```
+
+**Closes は改行区切りで各 ISSUE 個別に書く** (`Closes #A, #B, #C` は先頭しか auto-close されない、AGENTS.md より)。
+
+## Step 7: cdx review ループ (本 skill の核心)
+
+### 7-1: cdx review の起動
+
+**stdin 必須クローズ** (`</dev/null`) — これを忘れると codex が stdin 待ちで永久 hang する (今回学んだ):
+
+```bash
+source ~/dotfiles/.bash_aliases  # cdx 関数を読み込む
+
+cdx exec "PR #<PR番号> (branch <branch>) Round <N> 独立レビュー。
+
+特に観点:
+- schema governance #511 (グローバル schema 変更は AI 権限外、description のみは例外)
+- 鉄則 0 (trace 確立、PR description / コメントだけで完了扱いは禁止)
+- type fidelity (Codex は ({...} as unknown) as <Type> 等の outer cast を必ず指摘する)
+- ISSUE 完了条件と本 PR 対応範囲の整合
+
+cwd /workspaces/harmony/frontend (or backend) で npm run build / npx tsc --noEmit / npx vitest run 検証可能。
+
+出力 format: Must-fix / Should-fix / Nit 分類、file:line 明記、最後に approve/reject 判断。" </dev/null 2>&1 | tail -300
+```
+
+実行は **必ず background** (`run_in_background: true`) — codex は 5-30 分かかる。
+
+### 7-2: 完了監視 (Monitor で待機)
+
+```bash
+# Monitor で codex プロセス終了を待つ
+Monitor: while sleep 60; do
+  f=<output-file>
+  if [ -s "$f" ] && tail -1 "$f" 2>/dev/null | grep -q "tokens used"; then
+    echo "completed"; tail -5 "$f"; break
+  fi
+  if ! pgrep -f "exec PR #<N>.*Round <R>" > /dev/null 2>&1; then
+    echo "process exited"; tail -3 "$f"; break
+  fi
+done; echo "---END---"
+```
+
+timeout は 2400000-2700000 ms (40-45 min) を目安に。
+
+### 7-3: 結果分類
+
+cdx は **Must-fix / Should-fix / Nit / approve・reject** の形式で返す。
+
+| 種別 | 対応 |
+|---|---|
+| Must-fix | 全件解消必須、commit して次 round へ |
+| Should-fix (スコープ内) | 解消推奨。scope 外なら follow-up ISSUE 化 |
+| Should-fix (scope 外) | follow-up ISSUE 起票 (鉄則 0 trace)、PR description に link |
+| Nit | 余力あれば対応、approve 阻害しない |
+| approve | Step 8 (merge) へ |
+
+### 7-4: 修正 commit のメッセージ規約
+
+`fix(test-infra): Codex Round <N> Must-fix 解消 — <要点>` 形式で、解消した指摘を箇条書きで記載。次 round 再投時の prompt に含めて codex に差分を理解させる。
+
+### 7-5: 反復
+
+```
+commit → cdx review → Must-fix 解消 commit → cdx review (Round N+1) → ...
+```
+
+**approve が出るまで永遠に反復する** (本 skill の前提)。
+
+## Step 8: スコープ外指摘 → follow-up ISSUE 起票 (鉄則 0)
+
+cdx が指摘した残課題のうち本 PR で吸収不可なものは **必ず follow-up ISSUE 化**:
+
+```bash
+gh issue create --title "improve(<area>): <要約> (#<元 PR>派生)" --body "$(cat <<'EOF'
+## 背景
+PR #<元 PR> で <作業内容> を実装したが、Codex Round <N> で以下の残対応が判明...
+
+## 残対応 / 想定アプローチ
+- Phase 1: ...
+- Phase 2: ...
+
+## スコープ外
+- 本 ISSUE の trace 確立のみが目的、実装は別途
+
+## 関連
+- 親 PR: #<元 PR>
+- AGENTS.md 鉄則 0
+EOF
+)" --label "priority: low"
+```
+
+起票後、以下に番号を埋め込む:
+
+- 元 ISSUE の本文 (該当する場合) → `gh issue edit <N> --body-file` で scope 訂正
+- PR description → follow-up link を「関連」セクションに追記
+- code の relevant comment (例: deprecated alias 付近) → `(#<新 ISSUE> で削除予定)` を JSDoc に追加
+
+## Step 9: squash merge
+
+cdx が **approve** した後:
+
+```bash
+gh pr merge <PR番号> --squash --auto
+```
+
+merge 後に ISSUE state を確認:
+
+```bash
+gh issue view <N1> --json state --jq .state  # CLOSED 確認
+```
+
+## Step 10: 完了報告
+
+`/issues` Step 9 と同じ。マージした PR 番号 / closed ISSUE 番号 / follow-up ISSUE 番号 / `/clear` 推奨判断 + 次プロンプト提示。
+
+---
+
+## 失敗パターン集 (今回学んだもの、回避必須)
+
+### 1. type fidelity 弱体化 (Codex Must-fix の頻出パターン)
+
+**禁止**:
+```ts
+const step = ({
+  id: "s",
+  kind: "compute",
+  description: "",
+  ...
+} as unknown) as ComputeStep;  // ← outer cast で excess property 検証無効化
+```
+
+**正解**:
+```ts
+const step: ComputeStep = {
+  id: "s" as LocalId,            // brand 局所 cast
+  kind: "compute",
+  description: "" as Description,
+  expression: "@x" as TemplateString,
+};
+```
+
+または `satisfies` を使う:
+```ts
+const step = {
+  id: "s" as LocalId,
+  kind: "compute" as const,
+  ...
+} satisfies ComputeStep;
+```
+
+### 2. cdx exec の stdin 開きっぱなし → 永久 hang
+
+```bash
+# 禁止: 30 分 hang する
+cdx exec "..."
+
+# 正解: stdin を /dev/null で閉じる
+cdx exec "..." </dev/null
+```
+
+### 3. AskUserQuestion で「却下」選択肢を出す → 鉄則 0 違反シグナル
+
+trace 確立 ISSUE (鉄則 0 のために起票された ISSUE) は **対応前提**。「却下 / 現状維持」を並べると user から「ISSUE 不要扱い?」と叱責される。
+
+`feedback_dont_offer_status_quo_for_trace_issues.md` 参照。
+
+### 4. ISSUE 完了条件と実測の乖離を放置 → Codex reject
+
+ISSUE 本文の完了条件 (例: 「workers=2 で全 test pass」) が本 PR の対応範囲を超える場合、**ISSUE 本文を編集してスコープを訂正** + **follow-up ISSUE で残対応を trace**。
+
+放置すると Codex review が必ず reject する。
+
+### 5. pre-existing tech debt を本 PR で無理に吸収 → scope creep
+
+別 ISSUE 由来の broken state (例: `Project` → `Harmony` 未追従の e2e 側) を本 PR で全部 rename しようとすると 20+ files の修正が発生。
+
+**正解**: 暫定的に backward compat alias 等で build gate を通過させ、完全 rename は follow-up ISSUE 化。
+
+### 6. cdx Round 1 で完璧を期待しない
+
+cdx review は 1 round で全件出ない。Round 1 で気付かなかった問題が Round 2/3 で出る (前 round の修正が新たな盲点を作る)。
+
+**前提**: 3-5 round の反復を許容、各 round の修正 commit を分けて trace を残す。
+
+### 7. backward compat alias の trace 義務
+
+`/** @deprecated */` だけでは AGENTS.md 鉄則 0 に違反する (PR description / コメントだけは禁止)。alias 追加と同じ commit で **follow-up ISSUE を起票** し、JSDoc / コメントに ISSUE 番号を埋め込む。
+
+### 8. cdx の background 起動で Monitor 監視
+
+cdx は 5-30 分かかるため必ず background。Monitor で polling すると process 終了を検知できる:
+
+```
+Monitor:
+  while sleep 60; do
+    if ! pgrep -f "exec PR #<N>.*Round <R>" > /dev/null 2>&1; then break; fi
+  done
+```
+
+timeout は 40-45 min を目安に。実時間 25-30 min 程度が多いが余裕を持つ。
+
+---
+
+## /issues との使い分け
+
+| 状況 | 推奨 skill |
+|---|---|
+| 単独 ISSUE、Sonnet/Codex 委譲で OK | `/issues` |
+| ISSUE 規模が中程度 (commit 数 < 5)、設計判断複雑、user 不在中に自律完遂したい | `/issues-cdx` |
+| 複数 ISSUE 派生、Codex の厳格レビューで type fidelity を担保したい | `/issues-cdx` |
+| user 介入を残したい (途中で user に再確認) | `/issues` |
+| cdx エイリアスが未定義 / Codex CLI が使えない環境 | `/issues` |
+
+---
+
+## 制約 (必守)
+
+- **Opus が実装の全責任を持つ** — Sonnet / Codex subagent への委譲なし
+- **レビューは cdx (Bash) 直接呼出し** — review-pr-sonnet subagent は使わない
+- **設計判断は AskUserQuestion で着手前に一括確定** — user 不在中の自律実行の前提
+- **cdx exec は `</dev/null` で stdin closed 必須**
+- **approve まで反復** — Round 1 で完璧を期待しない
+- **scope 外指摘は follow-up ISSUE で必ず trace** (鉄則 0)
+- **type fidelity を弱体化させる outer cast は使わない** (`({...} as unknown) as X` 禁止)

--- a/frontend/e2e/__fixtures__/builders/projectBuilder.test.ts
+++ b/frontend/e2e/__fixtures__/builders/projectBuilder.test.ts
@@ -26,7 +26,7 @@ beforeAll(() => {
 });
 
 describe("buildProject", () => {
-  it("returns a v3-valid Project with defaults", () => {
+  it("returns a v3-valid Harmony with defaults", () => {
     const p = buildProject();
     const ok = validateProject(p);
     if (!ok) {

--- a/frontend/e2e/__fixtures__/builders/projectBuilder.ts
+++ b/frontend/e2e/__fixtures__/builders/projectBuilder.ts
@@ -1,5 +1,5 @@
 /**
- * v3 Project builder — e2e テスト用 fixture 生成。
+ * v3 Harmony builder — e2e テスト用 fixture 生成。
  *
  * defaults:
  * - createdAt/updatedAt: 固定値 "2026-05-08T00:00:00.000Z" (再現性)
@@ -11,10 +11,10 @@ import type {
   ExtensionApplied,
   Maturity,
   Mode,
-  Project,
-  ProjectEntities,
+  Harmony,
+  HarmonyEntities,
   ProjectId,
-  ProjectTechStack,
+  HarmonyTechStack,
   Timestamp,
   Uuid,
 } from "../../../src/types/v3";
@@ -49,7 +49,7 @@ export function normalizeToKebabId(val: string): string {
   return ENTITY_ID_RE.test(slug) ? slug : `id-${slug || "auto"}`;
 }
 
-function normalizeEntityIds(entities: ProjectEntities): ProjectEntities {
+function normalizeEntityIds(entities: HarmonyEntities): HarmonyEntities {
   const result: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(entities)) {
     if (!Array.isArray(value)) {
@@ -68,7 +68,7 @@ function normalizeEntityIds(entities: ProjectEntities): ProjectEntities {
       return normalized;
     });
   }
-  return result as ProjectEntities;
+  return result as HarmonyEntities;
 }
 
 export interface BuildProjectOpts {
@@ -77,12 +77,12 @@ export interface BuildProjectOpts {
   dataDir?: string;
   mode?: Mode;
   maturity?: Maturity;
-  entities?: ProjectEntities;
-  techStack?: ProjectTechStack;
+  entities?: HarmonyEntities;
+  techStack?: HarmonyTechStack;
   extensionsApplied?: ExtensionApplied[];
 }
 
-export function buildProject(opts: BuildProjectOpts = {}): Project {
+export function buildProject(opts: BuildProjectOpts = {}): Harmony {
   // RFC #1284: id は kebab-case EntityId、uuid は不変識別子 (UUID v4)。
   const id = opts.id
     ? (normalizeToKebabId(opts.id) as unknown as ProjectId)

--- a/frontend/e2e/action-list-marker-badge.spec.ts
+++ b/frontend/e2e/action-list-marker-badge.spec.ts
@@ -11,7 +11,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 
@@ -52,7 +52,7 @@ const dummyProject = buildProject({
   name: "marker badge test",
   entities: {
     processFlows: dummyGroups,
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const WS_KEY = "issue-926-action-list-marker-badge";

--- a/frontend/e2e/action-list.spec.ts
+++ b/frontend/e2e/action-list.spec.ts
@@ -12,7 +12,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 
@@ -33,7 +33,7 @@ const dummyProject = buildProject({
   name: "E2Eテスト用プロジェクト",
   entities: {
     processFlows: dummyGroups,
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const WS_KEY = "issue-926-action-list";

--- a/frontend/e2e/catalog-panels.spec.ts
+++ b/frontend/e2e/catalog-panels.spec.ts
@@ -12,7 +12,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 const groupId = "ag-catalog-all";
@@ -28,7 +28,7 @@ const dummyProject = buildProject({
   name: "catalog-ui",
   entities: {
     processFlows: [{ id: groupId, no: 1, name: "all catalog UI", flowType: "screen", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const WS_KEY = "issue-926-catalog-panels";

--- a/frontend/e2e/collab/2-tab-smoke.spec.ts
+++ b/frontend/e2e/collab/2-tab-smoke.spec.ts
@@ -23,7 +23,7 @@ import {
   type OpenedWorkspace,
 } from "../helpers/realWorkspace";
 import { buildProject, buildProcessFlow } from "../__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../../src/types/v3";
 
 const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 const PF_ID = `pf-collab-smoke-${Date.now()}`;
@@ -41,7 +41,7 @@ const dummyProject = buildProject({
   name: "collab-2tab-smoke-test",
   entities: {
     processFlows: [{ id: PF_ID, no: 1, name: "協調編集スモークテスト", flowType: "screen", actionCount: 0, maturity: "draft", updatedAt: FIXED_TS }],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const dummyTab = { id: `process-flow:${PF_NORM}`, type: "process-flow", resourceId: PF_NORM, label: "協調編集スモークテスト", isDirty: false, isPinned: false };

--- a/frontend/e2e/collab/draft-history.spec.ts
+++ b/frontend/e2e/collab/draft-history.spec.ts
@@ -28,7 +28,7 @@ import {
   openHistoryModal,
 } from "../helpers/editSessionDropdown";
 import { buildProject, buildProcessFlow } from "../__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../../src/types/v3";
 
 const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 const PF_ID = `pf-collab-history-${Date.now()}`;
@@ -46,7 +46,7 @@ const dummyProject = buildProject({
   name: "collab-draft-history-test",
   entities: {
     processFlows: [{ id: PF_ID, no: 1, name: "履歴テストフロー", flowType: "screen", actionCount: 0, maturity: "draft", updatedAt: FIXED_TS }],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const dummyTab = { id: `process-flow:${PF_NORM}`, type: "process-flow", resourceId: PF_NORM, label: "履歴テストフロー", isDirty: false, isPinned: false };

--- a/frontend/e2e/collab/presence-list.spec.ts
+++ b/frontend/e2e/collab/presence-list.spec.ts
@@ -22,7 +22,7 @@ import {
   type OpenedWorkspace,
 } from "../helpers/realWorkspace";
 import { buildProject, buildProcessFlow } from "../__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../../src/types/v3";
 
 const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 const PF_ID = `pf-collab-presence-list-${Date.now()}`;
@@ -40,7 +40,7 @@ const dummyProject = buildProject({
   name: "collab-presence-list-test",
   entities: {
     processFlows: [{ id: PF_ID, no: 1, name: "一覧バッジテストフロー", flowType: "screen", actionCount: 0, maturity: "draft", updatedAt: FIXED_TS }],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const dummyTab = { id: `process-flow:${PF_NORM}`, type: "process-flow", resourceId: PF_NORM, label: "一覧バッジテストフロー", isDirty: false, isPinned: false };

--- a/frontend/e2e/collab/take-over.spec.ts
+++ b/frontend/e2e/collab/take-over.spec.ts
@@ -24,7 +24,7 @@ import {
 } from "../helpers/realWorkspace";
 import { attachAsViewer, takeOver } from "../helpers/editSessionDropdown";
 import { buildProject, buildProcessFlow } from "../__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../../src/types/v3";
 
 const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 const PF_ID = `pf-collab-takeover-${Date.now()}`;
@@ -42,7 +42,7 @@ const dummyProject = buildProject({
   name: "collab-takeover-test",
   entities: {
     processFlows: [{ id: PF_ID, no: 1, name: "引継ぎテストフロー", flowType: "screen", actionCount: 0, maturity: "draft", updatedAt: FIXED_TS }],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const dummyTab = { id: `process-flow:${PF_NORM}`, type: "process-flow", resourceId: PF_NORM, label: "引継ぎテストフロー", isDirty: false, isPinned: false };

--- a/frontend/e2e/conv-completion.spec.ts
+++ b/frontend/e2e/conv-completion.spec.ts
@@ -12,7 +12,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 
@@ -47,7 +47,7 @@ const dummyProject = buildProject({
   name: "補完 E2E テスト",
   entities: {
     processFlows: [{ id: groupId, no: 1, name: "補完テスト", flowType: "screen", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const WS_KEY = "issue-926-conv-completion";

--- a/frontend/e2e/dashboard.spec.ts
+++ b/frontend/e2e/dashboard.spec.ts
@@ -14,7 +14,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 // RFC #1284 / I-7: top-level entity id は kebab-case EntityId (UUID-like reject)
 const SCREEN_ID = "dashboard-login-screen";
@@ -28,7 +28,7 @@ const dummyProject = buildProject({
     screens: [{ id: SCREEN_ID, no: 1, name: "ログイン画面", kind: "form", path: "/login", hasDesign: true, updatedAt: FIXED_TS }],
     tables: [{ id: TABLE_ID, no: 1, physicalName: "users", name: "ユーザー", category: "マスタ", columnCount: 0, updatedAt: FIXED_TS }],
     processFlows: [{ id: ACTION_ID, no: 1, name: "ログイン処理", flowType: "screen", actionCount: 0, updatedAt: FIXED_TS }],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const WS_KEY = "issue-926-dashboard";

--- a/frontend/e2e/data-item-id-auto.spec.ts
+++ b/frontend/e2e/data-item-id-auto.spec.ts
@@ -13,7 +13,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 // RFC #1284 / I-7: top-level entity id は kebab-case EntityId (UUID-like reject)
 const SCREEN_ID = "data-item-id-auto-screen";
@@ -24,7 +24,7 @@ const dummyProject = buildProject({
   name: "data-item-id-auto-test",
   entities: {
     screens: [{ id: SCREEN_ID, no: 1, name: "テスト画面", kind: "form", path: "/test", hasDesign: true, updatedAt: FIXED_TS }],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const emptyScreen = {

--- a/frontend/e2e/designer-corrupt-data.spec.ts
+++ b/frontend/e2e/designer-corrupt-data.spec.ts
@@ -14,7 +14,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 // RFC #1284 / I-7: top-level entity id は kebab-case EntityId (UUID-like reject)
 const SCREEN_ID = "corrupt-data-screen";
@@ -25,7 +25,7 @@ const project = buildProject({
   name: "corrupt-data test",
   entities: {
     screens: [{ id: SCREEN_ID, no: 1, name: "破損テスト画面", path: "/corrupt", kind: "form", hasDesign: true, updatedAt: FIXED_TS }],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const dummyTab = {

--- a/frontend/e2e/designer-edit-session.spec.ts
+++ b/frontend/e2e/designer-edit-session.spec.ts
@@ -21,7 +21,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 const SCREEN_ID = `scr-e2e-edit-session-${Date.now()}`;
 const SCREEN_NORM = normalizeId(SCREEN_ID);
@@ -31,7 +31,7 @@ const dummyProject = buildProject({
   name: "edit-session-test",
   entities: {
     screens: [{ id: SCREEN_ID, no: 1, name: "テスト画面", kind: "form", path: "/test", hasDesign: true, updatedAt: FIXED_TS }],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const screenDesign = {

--- a/frontend/e2e/dirty-mark-resume.spec.ts
+++ b/frontend/e2e/dirty-mark-resume.spec.ts
@@ -16,7 +16,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject, buildProcessFlow, buildTable } from "./__fixtures__/builders";
-import type { Column, LocalId, PhysicalName, ProjectEntities, Timestamp } from "../src/types/v3";
+import type { Column, LocalId, PhysicalName, HarmonyEntities, Timestamp } from "../src/types/v3";
 
 const TABLE_ID = `tbl-e2e-dirty-mark-${Date.now()}`;
 const PF_ID = `pf-e2e-dirty-mark-${Date.now()}`;
@@ -43,7 +43,7 @@ const dummyProject = buildProject({
   entities: {
     tables: [{ id: TABLE_ID, no: 1, name: dummyTable.name, physicalName: dummyTable.physicalName, category: dummyTable.category, columnCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
     processFlows: [{ id: PF_ID, no: 1, name: "dirty マークテストフロー", flowType: "screen", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const TABLE_NORM = normalizeId(TABLE_ID);

--- a/frontend/e2e/draft-state-validation.spec.ts
+++ b/frontend/e2e/draft-state-validation.spec.ts
@@ -31,7 +31,7 @@ import {
   buildProcessFlow,
   buildScreen,
 } from "./__fixtures__/builders";
-import type { ProjectEntities, Screen, TableId, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Screen, TableId, Timestamp } from "../src/types/v3";
 
 // ────────────────────────────────────────────────────────────────────
 // 定数 / ヘルパー
@@ -191,7 +191,7 @@ const processFlowA = buildProcessFlow({
   ] as ReturnType<typeof buildProcessFlow>["actions"],
 });
 
-// --- Project ---
+// --- Harmony ---
 const dummyProject = buildProject({
   name: "draft-state-validation-test",
   entities: {
@@ -215,7 +215,7 @@ const dummyProject = buildProject({
     processFlows: [
       { id: FLOW_ID, no: 1, name: "意図的な未定義参照フロー", flowType: "screen", actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" },
     ],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 // ────────────────────────────────────────────────────────────────────

--- a/frontend/e2e/drawing-anchor.spec.ts
+++ b/frontend/e2e/drawing-anchor.spec.ts
@@ -14,7 +14,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 
 const groupId = "ag-anchor";
@@ -88,7 +88,7 @@ const dummyProject = buildProject({
   name: "anchor",
   entities: {
     processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, flowType: dummyGroup.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 async function setup(page: Page) {

--- a/frontend/e2e/drawing-marker.spec.ts
+++ b/frontend/e2e/drawing-marker.spec.ts
@@ -12,7 +12,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 
@@ -42,7 +42,7 @@ const dummyProject = buildProject({
   name: "draw",
   entities: {
     processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, flowType: dummyGroup.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 async function setup(page: Page) {

--- a/frontend/e2e/edit-mode.spec.ts
+++ b/frontend/e2e/edit-mode.spec.ts
@@ -24,7 +24,7 @@ import {
   buildViewDefinition,
   buildSequence,
 } from "./__fixtures__/builders";
-import type { Column, ProjectEntities, Timestamp } from "../src/types/v3";
+import type { Column, HarmonyEntities, Timestamp } from "../src/types/v3";
 
 const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 const TABLE_ID = `tbl-e2e-edit-mode-${Date.now()}`;
@@ -80,7 +80,7 @@ const dummyProject = buildProject({
     views: [{ id: VIEW_ID, no: 1, name: "E2E ビュー", maturity: "draft", updatedAt: FIXED_TS }],
     viewDefinitions: [{ id: VIEW_DEF_ID, no: 1, name: "E2E ビュー定義", maturity: "draft", updatedAt: FIXED_TS }],
     sequences: [{ id: SEQUENCE_ID, no: 1, name: "E2E シーケンス", maturity: "draft", updatedAt: FIXED_TS }],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const WS_KEY = "issue-926-edit-mode";

--- a/frontend/e2e/edit-session/1-6-step-flow.spec.ts
+++ b/frontend/e2e/edit-session/1-6-step-flow.spec.ts
@@ -28,7 +28,7 @@ import {
   type OpenedWorkspace,
 } from "../helpers/realWorkspace";
 import { buildProject, buildProcessFlow } from "../__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../../src/types/v3";
 
 const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 const PF_ID = `pf-edit-session-flow-${Date.now()}`;
@@ -46,7 +46,7 @@ const dummyProject = buildProject({
   name: "edit-session-1-6-step-test",
   entities: {
     processFlows: [{ id: PF_ID, no: 1, name: "1-6 step フロー検証テスト", flowType: "screen", actionCount: 0, maturity: "draft", updatedAt: FIXED_TS }],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const dummyTab = { id: `process-flow:${PF_NORM}`, type: "process-flow", resourceId: PF_NORM, label: "1-6 step フロー検証テスト", isDirty: false, isPinned: false };

--- a/frontend/e2e/edit-session/ai-participant.spec.ts
+++ b/frontend/e2e/edit-session/ai-participant.spec.ts
@@ -26,7 +26,7 @@ import {
   type OpenedWorkspace,
 } from "../helpers/realWorkspace";
 import { buildProject, buildProcessFlow } from "../__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../../src/types/v3";
 
 const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 const PF_ID = `pf-ai-participant-${Date.now()}`;
@@ -44,7 +44,7 @@ const dummyProject = buildProject({
   name: "edit-session-ai-participant-test",
   entities: {
     processFlows: [{ id: PF_ID, no: 1, name: "AI participant 検証テスト", flowType: "screen", actionCount: 0, maturity: "draft", updatedAt: FIXED_TS }],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const dummyTab = { id: `process-flow:${PF_NORM}`, type: "process-flow", resourceId: PF_NORM, label: "AI participant 検証テスト", isDirty: false, isPinned: false };

--- a/frontend/e2e/edit-session/multi-session-branching.spec.ts
+++ b/frontend/e2e/edit-session/multi-session-branching.spec.ts
@@ -27,7 +27,7 @@ import {
 } from "../helpers/realWorkspace";
 import { startNewDraft } from "../helpers/editSessionDropdown";
 import { buildProject, buildProcessFlow } from "../__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../../src/types/v3";
 
 const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 const PF_ID = `pf-multi-session-${Date.now()}`;
@@ -45,7 +45,7 @@ const dummyProject = buildProject({
   name: "edit-session-multi-branching-test",
   entities: {
     processFlows: [{ id: PF_ID, no: 1, name: "A 案 / B 案 並行編集テスト", flowType: "screen", actionCount: 0, maturity: "draft", updatedAt: FIXED_TS }],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const dummyTab = { id: `process-flow:${PF_NORM}`, type: "process-flow", resourceId: PF_NORM, label: "A 案 / B 案 並行編集テスト", isDirty: false, isPinned: false };

--- a/frontend/e2e/edit-session/url-invitation.spec.ts
+++ b/frontend/e2e/edit-session/url-invitation.spec.ts
@@ -25,7 +25,7 @@ import {
   type OpenedWorkspace,
 } from "../helpers/realWorkspace";
 import { buildProject, buildProcessFlow } from "../__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../../src/types/v3";
 
 const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 const PF_ID = `pf-url-invitation-${Date.now()}`;
@@ -43,7 +43,7 @@ const dummyProject = buildProject({
   name: "edit-session-url-invitation-test",
   entities: {
     processFlows: [{ id: PF_ID, no: 1, name: "URL 招待テスト", flowType: "screen", actionCount: 0, maturity: "draft", updatedAt: FIXED_TS }],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const dummyTab = { id: `process-flow:${PF_NORM}`, type: "process-flow", resourceId: PF_NORM, label: "URL 招待テスト", isDirty: false, isPinned: false };

--- a/frontend/e2e/error-catalog-panel.spec.ts
+++ b/frontend/e2e/error-catalog-panel.spec.ts
@@ -12,7 +12,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 const groupId = "ag-ec-ui";
@@ -37,7 +37,7 @@ const dummyProject = buildProject({
   name: "ec-test",
   entities: {
     processFlows: [{ id: groupId, no: 1, name: "errorCatalog UI", flowType: "screen", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const WS_KEY = "issue-926-error-catalog-panel";

--- a/frontend/e2e/extensions-palette.spec.ts
+++ b/frontend/e2e/extensions-palette.spec.ts
@@ -15,7 +15,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 const groupId = "ag-extension-palette";
@@ -30,7 +30,7 @@ const dummyProject = buildProject({
   name: "extension-palette",
   entities: {
     processFlows: [{ id: groupId, no: 1, name: "extension palette", flowType: "screen", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const E2E_FIXTURE = {

--- a/frontend/e2e/helpers/puck.ts
+++ b/frontend/e2e/helpers/puck.ts
@@ -7,7 +7,7 @@ import {
   type OpenedWorkspace,
 } from "./realWorkspace";
 import { buildProject, buildScreen } from "../__fixtures__/builders";
-import type { Project, ProjectEntities, Screen, ScreenEntry, Timestamp } from "../../src/types/v3";
+import type { Harmony, HarmonyEntities, Screen, ScreenEntry, Timestamp } from "../../src/types/v3";
 import fs from "node:fs/promises";
 import path from "node:path";
 
@@ -53,7 +53,7 @@ export const HEADING_PARAGRAPH_DATA = {
 const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 
 /** Puck 画面を含む最小プロジェクト (v3 形式) */
-export function makeDummyProject(extraScreens: ScreenEntry[] = []): Project {
+export function makeDummyProject(extraScreens: ScreenEntry[] = []): Harmony {
   return buildProject({
     name: "Puck E2E テスト用プロジェクト",
     techStack: { designer: { cssFramework: "bootstrap", editorKind: "puck" } },
@@ -64,7 +64,7 @@ export function makeDummyProject(extraScreens: ScreenEntry[] = []): Project {
         { id: PUCK_TW_SCREEN_ID, no: 3, name: "Puck Tailwind テスト画面", kind: "other", path: "/puck-tw-test", hasDesign: true, updatedAt: FIXED_TS },
         ...extraScreens,
       ],
-    } as ProjectEntities,
+    } as HarmonyEntities,
   });
 }
 

--- a/frontend/e2e/helpers/realWorkspace.test.ts
+++ b/frontend/e2e/helpers/realWorkspace.test.ts
@@ -18,7 +18,7 @@ import os from "node:os";
 
 import { normalizeId } from "./realWorkspace.ts";
 import type {
-  Project,
+  Harmony,
   Table,
   Screen,
   ProcessFlow,
@@ -72,7 +72,7 @@ describe("normalizeId (Round 6 Phase A: UUID v4 生成 → kebab-case EntityId �
  */
 async function writeV3Workspace(
   dir: string,
-  project: Project,
+  project: Harmony,
   extras: {
     tables?: Table[];
     screens?: Screen[];
@@ -110,30 +110,30 @@ describe("v3 typed input → v3 output", () => {
     }
   });
 
-  it("Project v3 が harmony.json として書き出され、schemaVersion が v3 になる", async () => {
+  it("Harmony v3 が harmony.json として書き出され、schemaVersion が v3 になる", async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "harmony-test-"));
 
-    const project: Project = {
+    const project: Harmony = {
       $schema: "../schemas/v3/harmony.v3.schema.json",
       schemaVersion: "v3",
       dataDir: "harmony",
       meta: {
-        id: "realworkspace-test-project" as Project["meta"]["id"],
-        uuid: "11111111-1111-4111-8111-111111111111" as Project["meta"]["uuid"],
+        id: "realworkspace-test-project" as Harmony["meta"]["id"],
+        uuid: "11111111-1111-4111-8111-111111111111" as Harmony["meta"]["uuid"],
         name: "テスト用プロジェクト",
         maturity: "draft",
-        createdAt: "2026-01-01T00:00:00.000Z" as Project["meta"]["createdAt"],
-        updatedAt: "2026-01-01T00:00:00.000Z" as Project["meta"]["updatedAt"],
+        createdAt: "2026-01-01T00:00:00.000Z" as Harmony["meta"]["createdAt"],
+        updatedAt: "2026-01-01T00:00:00.000Z" as Harmony["meta"]["updatedAt"],
         mode: "upstream",
       },
       extensionsApplied: [],
       entities: {
         screens: [
           {
-            id: "realworkspace-test-screen" as NonNullable<NonNullable<Project["entities"]>["screens"]>[0]["id"],
+            id: "realworkspace-test-screen" as NonNullable<NonNullable<Harmony["entities"]>["screens"]>[0]["id"],
             no: 1,
             name: "テスト画面",
-            updatedAt: "2026-01-01T00:00:00.000Z" as NonNullable<NonNullable<Project["entities"]>["screens"]>[0]["updatedAt"],
+            updatedAt: "2026-01-01T00:00:00.000Z" as NonNullable<NonNullable<Harmony["entities"]>["screens"]>[0]["updatedAt"],
             maturity: "draft",
             kind: "list",
           },
@@ -169,16 +169,16 @@ describe("v3 typed input → v3 output", () => {
       columns: [],
     };
 
-    const minimalProject: Project = {
+    const minimalProject: Harmony = {
       schemaVersion: "v3",
       dataDir: "harmony",
       meta: {
-        id: "realworkspace-test-project" as Project["meta"]["id"],
-        uuid: "11111111-1111-4111-8111-111111111111" as Project["meta"]["uuid"],
-        name: "テスト" as Project["meta"]["name"],
+        id: "realworkspace-test-project" as Harmony["meta"]["id"],
+        uuid: "11111111-1111-4111-8111-111111111111" as Harmony["meta"]["uuid"],
+        name: "テスト" as Harmony["meta"]["name"],
         maturity: "draft",
-        createdAt: "2026-01-01T00:00:00.000Z" as Project["meta"]["createdAt"],
-        updatedAt: "2026-01-01T00:00:00.000Z" as Project["meta"]["updatedAt"],
+        createdAt: "2026-01-01T00:00:00.000Z" as Harmony["meta"]["createdAt"],
+        updatedAt: "2026-01-01T00:00:00.000Z" as Harmony["meta"]["updatedAt"],
       },
     };
 

--- a/frontend/e2e/helpers/realWorkspace.ts
+++ b/frontend/e2e/helpers/realWorkspace.ts
@@ -6,7 +6,7 @@
  * 方式に移行する必要がある (#926)。
  *
  * #964 α: helper を v3 typed only に改修。LegacyProjectInput / legacyToHarmony 削除済み。
- * 各フィールドは v3 schema 由来の TypeScript 型 (Project / Table / ProcessFlow 等) を受け取る。
+ * 各フィールドは v3 schema 由来の TypeScript 型 (Harmony / Table / ProcessFlow 等) を受け取る。
  *
  * 主な API:
  *   - copyExampleWorkspace(exampleName, key): examples/<name>/ をコピー
@@ -25,7 +25,7 @@ import type {
   Conventions,
   CustomBlock,
   ProcessFlow,
-  Project,
+  Harmony,
   Screen,
   ScreenFlowPositions,
   Sequence,
@@ -94,7 +94,7 @@ export interface PageLike {
  * setupTestWorkspace の引数。各フィールドは省略可。
  * 渡したフィールドは harmony.json + 個別ファイルとして書き出される。
  *
- * #964 α: 全フィールドを v3 schema 由来 TypeScript 型 (Project / Table / ProcessFlow 等) に統一。
+ * #964 α: 全フィールドを v3 schema 由来 TypeScript 型 (Harmony / Table / ProcessFlow 等) に統一。
  * 旧 LegacyProjectInput は削除済み。v1 形式のデータは β/γ で builder 経由で v3 に変換する。
  */
 export interface SetupTestWorkspaceOptions {
@@ -109,8 +109,8 @@ export interface SetupTestWorkspaceOptions {
    * 現在は `ws.resetRuntimeState()` を test.afterEach から手動で呼ぶことで同等効果が得られる。
    */
   resetEachTest?: boolean;
-  /** v3 Project — harmony.json として書き出される */
-  project?: Project;
+  /** v3 Harmony — harmony.json として書き出される */
+  project?: Harmony;
   /** v3 Table[] — 各 entry は harmony/tables/<meta.id>.json に書き出し */
   tables?: Table[];
   /** v3 ProcessFlow[] — harmony/process-flows/<meta.id>.json */
@@ -167,7 +167,7 @@ const TMP_ROOT = path.join(REPO_ROOT, ".tmp", "e2e-workspaces");
  *
  * #1356: 旧来 `.tmp/e2e-workspaces/<key>/` 直下に書き出していたため Playwright workers > 1
  * で同一 key を複数 worker が同時に書き込むと storage 競合が発生していた。本 prefix で
- * 完全隔離した結果、`buildMinimalProject` の Project.meta.id は固定値のまま (storage が
+ * 完全隔離した結果、`buildMinimalProject` の Harmony.meta.id は固定値のまま (storage が
  * worker 別 directory に分かれているため EntityId 重複は別 namespace 上の同名扱いとなり問題なし)。
  *
  * **本 helper のスコープ**: `tempWorkspacePath` 経由の fixture (`setupTestWorkspace` /
@@ -469,12 +469,12 @@ export function deterministicUuid(input: string): string {
 }
 
 /**
- * project が省略されたとき用の最小 v3 Project を生成する。
+ * project が省略されたとき用の最小 v3 Harmony を生成する。
  * #964 α: legacyToHarmony を削除し、v3 typed input をそのまま書き出す方針に変更。
  * branded type (Uuid / Timestamp 等) は実行時は plain string なので `as unknown as T` でキャスト。
  */
-function buildMinimalProject(): Project {
-  const ts = nowIso() as unknown as Project["meta"]["createdAt"];
+function buildMinimalProject(): Harmony {
+  const ts = nowIso() as unknown as Harmony["meta"]["createdAt"];
   // RFC #1284 / I-7-1: id は kebab-case EntityId、uuid は UUID v4 (required)。
   // setupTestWorkspace が project 省略時に呼ぶ最小 fixture なので、
   // 決定論的ではなく毎回ユニークな値で OK (workspace key と独立)。
@@ -484,9 +484,9 @@ function buildMinimalProject(): Project {
     dataDir: "harmony",
     meta: {
       // #1356: workspace path 自体に worker index を embed する (tempWorkspacePath) ことで
-      // workers > 1 でも storage 衝突しないため、Project.meta.id は固定 EntityId のまま運用可能。
-      id: "e2e-test-project" as unknown as Project["meta"]["id"],
-      uuid: uuid() as unknown as Project["meta"]["uuid"],
+      // workers > 1 でも storage 衝突しないため、Harmony.meta.id は固定 EntityId のまま運用可能。
+      id: "e2e-test-project" as unknown as Harmony["meta"]["id"],
+      uuid: uuid() as unknown as Harmony["meta"]["uuid"],
       name: "E2E テストプロジェクト",
       maturity: "draft",
       createdAt: ts,

--- a/frontend/e2e/list-delete-ui.spec.ts
+++ b/frontend/e2e/list-delete-ui.spec.ts
@@ -12,7 +12,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 
@@ -24,7 +24,7 @@ const dummyProject = buildProject({
       { id: "s-2", no: 2, name: "画面B", kind: "other", path: "/b", updatedAt: FIXED_TS },
       { id: "s-3", no: 3, name: "画面C", kind: "other", path: "/c", updatedAt: FIXED_TS },
     ],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const WS_KEY = "issue-926-list-delete-ui";

--- a/frontend/e2e/list-ops.spec.ts
+++ b/frontend/e2e/list-ops.spec.ts
@@ -15,7 +15,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp, ProcessFlowKind, Maturity } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp, ProcessFlowKind, Maturity } from "../src/types/v3";
 
 const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 
@@ -34,7 +34,7 @@ const project = buildProject({
   name: "list-ops",
   entities: {
     processFlows: listGroups,
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const WS_KEY = "issue-926-list-ops";

--- a/frontend/e2e/marker-ergonomics.spec.ts
+++ b/frontend/e2e/marker-ergonomics.spec.ts
@@ -12,7 +12,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 const groupId = "ag-erg";
@@ -51,7 +51,7 @@ const dummyProject = buildProject({
   name: "erg",
   entities: {
     processFlows: [{ id: groupId, no: 1, name: "erg test", flowType: "screen", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const WS_KEY = "issue-926-marker-ergonomics";

--- a/frontend/e2e/marker-panel.spec.ts
+++ b/frontend/e2e/marker-panel.spec.ts
@@ -12,7 +12,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 const groupId = "ag-marker";
@@ -27,7 +27,7 @@ const dummyProject = buildProject({
   name: "marker",
   entities: {
     processFlows: [{ id: groupId, no: 1, name: "marker test", flowType: "screen", actionCount: 1, maturity: "draft", updatedAt: FIXED_TS }],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const WS_KEY = "issue-926-marker-panel";

--- a/frontend/e2e/maturity-notes.spec.ts
+++ b/frontend/e2e/maturity-notes.spec.ts
@@ -18,7 +18,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 
@@ -72,7 +72,7 @@ const dummyProject = buildProject({
       { id: committedGroupId, no: 2, name: "確定フロー", flowType: "screen", actionCount: 0, maturity: "committed", updatedAt: FIXED_TS },
       { id: provisionalGroupId, no: 3, name: "暫定フロー", flowType: "screen", actionCount: 0, maturity: "provisional", updatedAt: FIXED_TS },
     ],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 async function setupEditor(page: Page) {

--- a/frontend/e2e/mcp/designer-reconnect.spec.ts
+++ b/frontend/e2e/mcp/designer-reconnect.spec.ts
@@ -13,7 +13,7 @@ import { test, expect, type Page } from "@playwright/test";
 import { setupTestWorkspace, cleanupRealWorkspaces, isMcpRunning, normalizeId, type OpenedWorkspace } from "../helpers/realWorkspace";
 import { sendBrowserRequest, openBrowserSessionWorkspace, closeBrowserSession } from "./_helpers";
 import { buildProject } from "../__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../../src/types/v3";
 
 // RFC #1284 / I-7: top-level entity id は kebab-case EntityId (UUID-like reject)
 const SCREEN_ID = "mcp-reconnect-screen";
@@ -54,7 +54,7 @@ const project = buildProject({
   name: "issue-578-designer-reconnect",
   entities: {
     screens: [{ id: SCREEN_ID, no: 1, name: "Issue 578 Designer", path: "/issue-578", kind: "form", hasDesign: true, updatedAt: FIXED_TS }],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const dummyTab = {

--- a/frontend/e2e/more-ui.spec.ts
+++ b/frontend/e2e/more-ui.spec.ts
@@ -12,7 +12,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 const groupId = "ag-more-test";
@@ -45,7 +45,7 @@ const dummyProject = buildProject({
       { id: groupId, no: 1, name: "追加 UI テスト", flowType: "screen", actionCount: 1, maturity: "provisional", updatedAt: FIXED_TS },
       { id: "ag-extra-committed", no: 2, name: "確定フロー", flowType: "screen", actionCount: 1, maturity: "committed", updatedAt: FIXED_TS },
     ],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const WS_KEY = "issue-926-more-ui";

--- a/frontend/e2e/process-flow-ai-ux.spec.ts
+++ b/frontend/e2e/process-flow-ai-ux.spec.ts
@@ -15,7 +15,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 const flowId = "pf-ai-ux-smoke";
 const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
@@ -63,7 +63,7 @@ const project = buildProject({
       updatedAt: FIXED_TS,
       maturity: "draft",
     }],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const processFlow = buildProcessFlow({

--- a/frontend/e2e/resource-url-sync.spec.ts
+++ b/frontend/e2e/resource-url-sync.spec.ts
@@ -15,7 +15,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 const SCREEN_A = "screen-aaaa-0001";
 const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
@@ -24,7 +24,7 @@ const projectWithScreen = buildProject({
   name: "E2E",
   entities: {
     screens: [{ id: SCREEN_A, no: 1, name: "画面A", kind: "form", path: "/a", hasDesign: true, updatedAt: FIXED_TS }],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const WS_KEY = "issue-926-resource-url-sync";

--- a/frontend/e2e/save-flow.spec.ts
+++ b/frontend/e2e/save-flow.spec.ts
@@ -14,7 +14,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 const SCREEN_A = "test-0001-4000-8000-000000000001";
 const SCREEN_B = "test-0002-4000-8000-000000000002";
@@ -29,7 +29,7 @@ const dummyProject = buildProject({
       { id: SCREEN_A, no: 1, name: "画面A", kind: "list", path: "/a", hasDesign: true, updatedAt: FIXED_TS },
       { id: SCREEN_B, no: 2, name: "画面B", kind: "list", path: "/b", hasDesign: true, updatedAt: FIXED_TS },
     ],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const WS_KEY = "issue-926-save-flow";

--- a/frontend/e2e/save-reset-action.spec.ts
+++ b/frontend/e2e/save-reset-action.spec.ts
@@ -14,7 +14,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 const PROCESS_FLOW_ID = "test-ag-0001-4000-8000-000000000001";
 const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
@@ -31,7 +31,7 @@ const dummyProject = buildProject({
   name: "E2Eテスト用プロジェクト",
   entities: {
     processFlows: [{ id: PROCESS_FLOW_ID, no: 1, name: "テスト処理フロー", flowType: "screen", actionCount: 0, maturity: "draft", updatedAt: FIXED_TS }],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const PF_NORM = normalizeId(PROCESS_FLOW_ID);

--- a/frontend/e2e/save-reset-designer.spec.ts
+++ b/frontend/e2e/save-reset-designer.spec.ts
@@ -17,7 +17,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 // RFC #1284 / I-7: top-level entity id は kebab-case EntityId (UUID-like reject)
 const SCREEN_ID = "save-reset-designer-screen";
@@ -27,7 +27,7 @@ const dummyProject = buildProject({
   name: "E2Eテスト用プロジェクト",
   entities: {
     screens: [{ id: SCREEN_ID, no: 1, name: "ログイン", path: "/login", kind: "form", hasDesign: true, updatedAt: FIXED_TS }],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const SCREEN_NORM = normalizeId(SCREEN_ID);

--- a/frontend/e2e/save-reset.spec.ts
+++ b/frontend/e2e/save-reset.spec.ts
@@ -14,7 +14,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 // "test-table" は hex でないため UUID_V4_RE に match せず normalizeId が deterministic
 // UUID を生成する。fixture file 名 / project meta の id / URL を全て同じ正規化済 UUID で
@@ -50,7 +50,7 @@ const dummyProject = buildProject({
     tables: [
       { id: TABLE_ID, no: 1, physicalName: "users", name: "ユーザーマスタ", category: "マスタ", columnCount: 1, updatedAt: FIXED_TS },
     ],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const TABLE_NORM = normalizeId(TABLE_ID);

--- a/frontend/e2e/schema-ui.spec.ts
+++ b/frontend/e2e/schema-ui.spec.ts
@@ -18,7 +18,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 
 const groupId = "ag-schema-ui-test";
@@ -91,7 +91,7 @@ const dummyProject = buildProject({
         updatedAt: FIXED_TS,
       },
     ],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 async function setupEditor(page: Page) {

--- a/frontend/e2e/screen-items-reset.spec.ts
+++ b/frontend/e2e/screen-items-reset.spec.ts
@@ -20,7 +20,7 @@ import {
 import fs from "node:fs/promises";
 import path from "node:path";
 import { buildProject } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 const screenId = "scr-reset-1";
 const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
@@ -31,7 +31,7 @@ const dummyProject = buildProject({
     screens: [
       { id: screenId, no: 1, name: "リセットテスト画面", kind: "standard", updatedAt: FIXED_TS },
     ],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const WS_KEY = "issue-926-screen-items-reset";

--- a/frontend/e2e/screen-items.spec.ts
+++ b/frontend/e2e/screen-items.spec.ts
@@ -18,7 +18,7 @@ import {
 import fs from "node:fs/promises";
 import path from "node:path";
 import { buildProject } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 const screenId1 = "scr-1";
 const screenId2 = "scr-2";
@@ -41,7 +41,7 @@ const dummyProject = buildProject({
       { id: screenId1, no: 1, name: "ログイン画面", kind: "form", updatedAt: FIXED_TS },
       { id: screenId2, no: 2, name: "顧客登録画面", kind: "form", updatedAt: FIXED_TS },
     ],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const WS_KEY = "issue-926-screen-items";

--- a/frontend/e2e/screen-list.spec.ts
+++ b/frontend/e2e/screen-list.spec.ts
@@ -12,7 +12,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 const FIXED_TS = "2026-05-08T00:00:00.000Z" as unknown as Timestamp;
 
@@ -24,7 +24,7 @@ const dummyProject = buildProject({
       { id: "screen-0002", no: 2, name: "ダッシュボード", kind: "dashboard", path: "/dashboard", hasDesign: true, updatedAt: FIXED_TS },
       { id: "screen-0003", no: 3, name: "ユーザー一覧", kind: "list", path: "/users", hasDesign: false, updatedAt: FIXED_TS },
     ],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const WS_KEY = "issue-926-screen-list";

--- a/frontend/e2e/sort-readonly.spec.ts
+++ b/frontend/e2e/sort-readonly.spec.ts
@@ -12,7 +12,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 const dummyProject = buildProject({
   name: "Sort Readonly Test",
@@ -24,7 +24,7 @@ const dummyProject = buildProject({
       { id: "s-4", no: 4, name: "Bravo", kind: "other", path: "/b", updatedAt: "2024-02-02T00:00:00Z" as unknown as Timestamp },
       { id: "s-5", no: 5, name: "Delta", kind: "other", path: "/d", updatedAt: "2024-04-04T00:00:00Z" as unknown as Timestamp },
     ],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const WS_KEY = "issue-926-sort-readonly";

--- a/frontend/e2e/step-advanced.spec.ts
+++ b/frontend/e2e/step-advanced.spec.ts
@@ -14,7 +14,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 
 const groupId = "ag-advanced";
@@ -52,7 +52,7 @@ const dummyProject = buildProject({
   name: "advanced",
   entities: {
     processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, flowType: dummyGroup.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 async function setupEditor(page: Page) {

--- a/frontend/e2e/step-marker-badge.spec.ts
+++ b/frontend/e2e/step-marker-badge.spec.ts
@@ -14,7 +14,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 
 const groupId = "ag-smb";
@@ -46,7 +46,7 @@ const dummyProject = buildProject({
   name: "smb",
   entities: {
     processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, flowType: dummyGroup.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 async function setup(page: Page) {

--- a/frontend/e2e/step-ops.spec.ts
+++ b/frontend/e2e/step-ops.spec.ts
@@ -10,7 +10,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 
 const groupId = "ag-step-ops-test";
@@ -64,7 +64,7 @@ const dummyProject = buildProject({
   name: "step-ops",
   entities: {
     processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, flowType: dummyGroup.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 async function setupEditor(page: Page) {

--- a/frontend/e2e/stepcard-marker-kind-badge.spec.ts
+++ b/frontend/e2e/stepcard-marker-kind-badge.spec.ts
@@ -12,7 +12,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 
 const groupId = "ag-stepchip";
@@ -47,7 +47,7 @@ const dummyProject = buildProject({
   name: "stepchip",
   entities: {
     processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, flowType: dummyGroup.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 async function setup(page: Page) {

--- a/frontend/e2e/tab-management.spec.ts
+++ b/frontend/e2e/tab-management.spec.ts
@@ -12,7 +12,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 // RFC #1284 / I-7: top-level entity id は kebab-case EntityId (UUID-like reject)
 const SCREEN_A = "scr-a";
@@ -39,7 +39,7 @@ const dummyProject = buildProject({
       { id: SCREEN_B, no: 2, name: "画面B", kind: "list", path: "/b", hasDesign: true, updatedAt: FIXED_TS },
       { id: SCREEN_C, no: 3, name: "画面C", kind: "list", path: "/c", hasDesign: true, updatedAt: FIXED_TS },
     ],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const WS_KEY = "issue-926-tab-management";

--- a/frontend/e2e/table-edit.spec.ts
+++ b/frontend/e2e/table-edit.spec.ts
@@ -22,7 +22,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject, buildViewDefinition } from "./__fixtures__/builders";
-import type { Column, ProjectEntities, Timestamp, ViewDefinition } from "../src/types/v3";
+import type { Column, HarmonyEntities, Timestamp, ViewDefinition } from "../src/types/v3";
 
 // ── Fixture データ ────────────────────────────────────────────────────────────
 
@@ -44,7 +44,7 @@ const dummyProject = buildProject({
     viewDefinitions: [
       { id: VIEW_DEFINITION_ID, no: 1, name: "注文一覧", kind: "list", maturity: "committed", updatedAt: FIXED_TS },
     ],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 /** customers テーブル (FK 参照先として必要) */

--- a/frontend/e2e/table-list.spec.ts
+++ b/frontend/e2e/table-list.spec.ts
@@ -12,7 +12,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 const dummyTables = [
   { id: "tbl-0001", physicalName: "users", name: "ユーザーマスタ", category: "マスタ", columns: [], indexes: [], constraints: [] },
@@ -30,7 +30,7 @@ const dummyProject = buildProject({
       { id: "tbl-0002", no: 2, physicalName: "orders", name: "注文", category: "トランザクション", updatedAt: FIXED_TS },
       { id: "tbl-0003", no: 3, physicalName: "products", name: "商品マスタ", category: "マスタ", updatedAt: FIXED_TS },
     ],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const WS_KEY = "issue-926-table-list";

--- a/frontend/e2e/validation-sql-conv-panel.spec.ts
+++ b/frontend/e2e/validation-sql-conv-panel.spec.ts
@@ -13,7 +13,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 
 // buildProject.normalizeEntityIds が entities.tables[0].id を UUID 化するため、
@@ -81,7 +81,7 @@ const project = buildProject({
   entities: {
     tables: [{ id: tableId, no: 1, physicalName: "customers", name: "顧客", columnCount: 2, updatedAt: FIXED_TS }],
     processFlows: [{ id: groupId, no: 1, name: group.name, flowType: group.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 async function setupEditor(page: Page) {

--- a/frontend/e2e/validation-warnings-panel.spec.ts
+++ b/frontend/e2e/validation-warnings-panel.spec.ts
@@ -16,7 +16,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 
 const groupId = "ag-validation-test";
@@ -67,7 +67,7 @@ const dummyProject = buildProject({
   name: "validation-test",
   entities: {
     processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, flowType: dummyGroup.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 async function setupEditor(page: Page) {

--- a/frontend/e2e/view-definition.spec.ts
+++ b/frontend/e2e/view-definition.spec.ts
@@ -14,7 +14,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 // RFC #1284 / I-7: top-level entity id は kebab-case EntityId (UUID-like reject)
 const TABLE_ID = "vd-spec-products-table";
@@ -41,7 +41,7 @@ const dummyProject = buildProject({
   name: "view-definition-e2e",
   entities: {
     tables: [{ id: TABLE_ID, no: 1, name: sampleTable.name, physicalName: sampleTable.physicalName, category: sampleTable.category, columnCount: sampleTable.columns.length, maturity: "draft", updatedAt: FIXED_TS }],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 const TABLE_NORM = normalizeId(TABLE_ID);

--- a/frontend/e2e/warning-to-marker.spec.ts
+++ b/frontend/e2e/warning-to-marker.spec.ts
@@ -10,7 +10,7 @@ import {
   type OpenedWorkspace,
 } from "./helpers/realWorkspace";
 import { buildProject, buildProcessFlow } from "./__fixtures__/builders";
-import type { ProjectEntities, Timestamp } from "../src/types/v3";
+import type { HarmonyEntities, Timestamp } from "../src/types/v3";
 
 
 const groupId = "ag-w2m";
@@ -35,7 +35,7 @@ const dummyProject = buildProject({
   name: "w2m",
   entities: {
     processFlows: [{ id: groupId, no: 1, name: dummyGroup.name, flowType: dummyGroup.type, actionCount: 1, updatedAt: FIXED_TS, maturity: "draft" }],
-  } as ProjectEntities,
+  } as HarmonyEntities,
 });
 
 async function setup(page: Page) {

--- a/frontend/src/types/v3/index.ts
+++ b/frontend/src/types/v3/index.ts
@@ -121,15 +121,3 @@ export type ExternalCallOutcomeSpec = _AnyRecord;
 // ── OutputBinding (frontend 表示専用、v3 OutputBindingObject に近い概念) ──
 export type OutputBindingOperation = "assign" | "accumulate" | "push";
 
-// ─── Backward compat aliases (#1142 で Project → Harmony rename、e2e fixture が未追従) ───
-// #1355 で tsconfig.test.json の include を拡張した結果、e2e helpers / fixtures の旧
-// Project / ProjectEntities / ProjectTechStack 名参照が build gate で error 化したため、
-// 暫定的に type alias を export。**完全 rename trace は #1358** で正規化済 (AGENTS.md 鉄則 0)、
-// #1358 完了時に本 alias 群を削除する。
-import type { Harmony as _Harmony, HarmonyEntities as _HarmonyEntities, HarmonyTechStack as _HarmonyTechStack } from "./harmony";
-/** @deprecated Use Harmony directly (#1358 で削除予定) */
-export type Project = _Harmony;
-/** @deprecated Use HarmonyEntities directly (#1358 で削除予定) */
-export type ProjectEntities = _HarmonyEntities;
-/** @deprecated Use HarmonyTechStack directly (#1358 で削除予定) */
-export type ProjectTechStack = _HarmonyTechStack;

--- a/frontend/src/types/v3/index.ts
+++ b/frontend/src/types/v3/index.ts
@@ -120,4 +120,3 @@ export type ExternalCallOutcomeSpec = _AnyRecord;
 
 // ── OutputBinding (frontend 表示専用、v3 OutputBindingObject に近い概念) ──
 export type OutputBindingOperation = "assign" | "accumulate" | "push";
-


### PR DESCRIPTION
## 概要

PR #1357 で暫定的に追加した `Project` / `ProjectEntities` / `ProjectTechStack` の backward compat alias (#1142 rename 未追従の e2e/ 配下を build gate 通過させるための措置) を、e2e/ 全 57 files で完全 rename して alias 削除する。

副次的に、PR #1357 で実証した「Opus 直接実装 + cdx 反復レビュー」ワークフローを `/issues-cdx` skill として標準化。

## 修正内容

### 4fe8e6fc: #1358 Project → Harmony 完全 rename + alias 削除

- e2e/ 配下 57 files で word-boundary regex (`\bProject\b` 等) で type を rename
  - `Project` → `Harmony`
  - `ProjectEntities` → `HarmonyEntities`
  - `ProjectTechStack` → `HarmonyTechStack`
- src/types/v3/index.ts の deprecated alias 3 個を削除

**保護されたもの (rename 対象外、ISSUE 注記通り)**:
- `ProjectId` (kebab-case branded type、I が後続のため word boundary に該当せず) — 1 file
- `buildProject` / `BuildProjectOpts` 等の関数 / option 名 — 70+ files (別議論として保留)

### ed4d5f53: /issues-cdx skill 新設

PR #1357 (3 ISSUE 統合 + 5 round cdx review) で実証したワークフローを skill 化。

- 配置: `ai-skills/issues-cdx/SKILL.md` (canonical) + Claude Code/Codex symlinks
- 10 step workflow + 失敗パターン集 8 件 + /issues との使い分け
- /issues との違い: Opus 直接実装、cdx 直接呼出し、設計確定→自律実行型

## 検証

- `cd frontend && npm run build` → 0 errors
- `cd frontend && npx tsc -p tsconfig.test.json --noEmit` → 0 errors
- `cd frontend && npx vitest run` → 2999 pass / 1 skip / 0 new failures
- `cd frontend && npx playwright test e2e/collab/presence-list.spec.ts` → 1 passed (smoke 検証)
- 残存 grep 確認: `Project` (type) → 0、`ProjectId` → 1 (保護)、`buildProject` → 70 (保護)

## 関連

- 親メタ: #1332 (RFC implement: EntityId brand 型導入)
- 親 rename PR: #1142 (Project → Harmony rename)
- alias 追加 PR: #1357 (#1355 派生、本 ISSUE の起源 + skill 実証元)
- AGENTS.md 鉄則 0: trace 確立義務 (#1358 で alias trace 確立済、本 PR で alias 削除して完結)

Closes #1358