### PR TITLE
chore(skill): /release-review skill 新設 — リリース前 24h 自律レビュー orchestrator

### DIFF
--- a/.agents/skills/release-review
+++ b/.agents/skills/release-review
@@ -1,0 +1,1 @@
+../../ai-skills/release-review

--- a/.claude/skills/release-review
+++ b/.claude/skills/release-review
@@ -1,0 +1,1 @@
+../../ai-skills/release-review

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ Claude Code 向けの補足ガイダンス。
 - **`/generate-tests <flowId|screenId> [出力先]`** — ProcessFlow → backend e2e test (jest+supertest) / Screen → component test (vitest+testing-library) / multi-screen → playwright E2E / AI flow → mock+実 API 切替テストを spec から機械導出。`/generate-code` の対 (`ai-skills/generate-tests/SKILL.md`)
 - **`/import-md <project ディレクトリ>`** — Project の Markdown 設計書を Harmony JSON (screen / processFlow / table / generic-definitions/*) に変換。少数 MD は 1 回限り変換、継続更新ある場合は `<project>/scripts/import/*.ts` を生成。実体は [`docs/spec/conversion-guideline-for-ai.md`](docs/spec/conversion-guideline-for-ai.md) (#1060) (`ai-skills/import-md/SKILL.md`)
 - **`/publish-dev-image <version>`** — Harmony Dev Container 用 base image を ghcr.io に build + push する (maintainer 専用) (`ai-skills/publish-dev-image/SKILL.md`、#1118 Phase 3 で新設)
+- **`/release-review [--branch <name>] [--max-hours N] [--max-issues N] [--exclude-axes csv]`** — リリース前限定の徹底自律レビュー orchestrator。8 軸 (schema-drift / process-flow runtime / type contract / backend storage / frontend store / test coverage / security / dogfood smoke) を /loop で 24h 規模 self-pace、findings を auto-fix / 集約 ISSUE / spec-pending に分類。3 巡連続 0 件で枯渇停止、destructive 検出で self-stop (`ai-skills/release-review/SKILL.md`)
 
 Codex CLI 利用時はこれらのスキルは直接呼び出せません。等価機能は Codex plugin の `/codex:review` 等で代替するか、Opus が briefing で代替指示を出します。
 

--- a/ai-skills/release-review/SKILL.md
+++ b/ai-skills/release-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: release-review
 description: リリース前の徹底レビュー — 8 軸 × 複数巡で repo をしらみつぶしに自律監査し、findings を auto-fix / ISSUE 化 / spec-pending に分類して 24h 規模で進める。ユーザー睡眠中も自己再帰で稼働。
-argument-hint: [--branch <name>] [--max-issues <N>] [--exclude-axes <csv>] [--max-hours <N>]
+argument-hint: [--branch <name>] [--max-issues <N>] [--exclude-axes <csv>] [--max-hours <N>] [--resume] [--restart] [--bypass <reason_key>]
 disable-model-invocation: true
 ---
 

--- a/ai-skills/release-review/SKILL.md
+++ b/ai-skills/release-review/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: release-review
+description: リリース前の徹底レビュー — 8 軸 × 複数巡で repo をしらみつぶしに自律監査し、findings を auto-fix / ISSUE 化 / spec-pending に分類して 24h 規模で進める。ユーザー睡眠中も自己再帰で稼働。
+argument-hint: [--branch <name>] [--max-issues <N>] [--exclude-axes <csv>] [--max-hours <N>]
+disable-model-invocation: true
+---
+
+<!--
+  使い方:
+    `/release-review`               # 全 default で起動
+    `/release-review --max-hours 24` # wall-clock cap を 24h に
+    `/release-review --exclude-axes 08-dogfood-smoke` # 重い軸を除外
+
+  前提:
+    - 起動 AI = Claude Code (Opus or Sonnet)、 backend dev server (port 5179) が常駐
+    - gh CLI 認証済み、push 権限あり
+    - リリース前タイミング (AGENTS.md 鉄則は緩和、本 skill 期間中は massive ISSUE 起票許可)
+
+  起動形態:
+    本 skill は **orchestrator + /loop self-pace** で 24h 規模で動く。
+    起動セッションが /loop に移行し、ScheduleWakeup で自己再帰、各 wake で
+    axis Agent を並列 dispatch + finding 分類 + auto-fix or ISSUE 化を実行。
+
+  停止条件 (いずれか満たすと自然停止):
+    - 全 8 軸が 3 巡連続で新規 finding 0 件 (枯渇判定、default)
+    - `--max-hours` 経過 (default 36h、safety cap)
+    - destructive action 検出 (safety-rails.md 参照)
+    - 累計 ISSUE 起票数 = `--max-issues` (default なし、ユーザー指定時のみ)
+
+  artifact 配置:
+    .tmp/release-review/<branch>/
+      state.json            # 軸ごとの round / status / last finding count
+      findings.jsonl        # 全 findings (append-only)
+      STATUS.md             # 人間用 dashboard (各 wake で再生成)
+      auto-fixes.log        # commit history
+      issues.log            # gh issue create history
+      STOPPED.md            # 停止時のみ生成、停止理由 + 統計を記録
+
+  関連 docs:
+    - orchestrator-briefing.md  各 wake で実行する手順
+    - classification-rules.md   auto-fix / issue / spec-pending の境界
+    - safety-rails.md           destructive 検出 + self-stop
+    - axes/01〜08.md            各軸の scope / 必須 grep / 出力 format
+-->
+
+# /release-review — リリース前徹底レビュー orchestrator
+
+リリース前限定の自律レビュー skill。AGENTS.md の ISSUE 起票鉄則を **本 skill 起動期間に限り** 緩和し、findings は ユーザー判断ルール (`classification-rules.md`) で auto-fix / ISSUE 化 / spec-pending pending に振り分ける。
+
+## 起動時の動作 (この skill を invoke した Claude)
+
+ユーザーが `/release-review` と打った直後、本 doc の指示に従って **kickoff sequence** を実行する。以降は `/loop` に乗せて自走させる。
+
+### Step 0: 引数 parse + 既存 review の検出
+
+```bash
+# 引数を環境変数に展開 (未指定は default)
+BRANCH="${BRANCH:-feat/release-review-$(date +%Y%m%d)}"
+MAX_HOURS="${MAX_HOURS:-36}"
+MAX_ISSUES="${MAX_ISSUES:-}"   # 空 = 上限なし
+EXCLUDE_AXES="${EXCLUDE_AXES:-}"
+
+# 既存 review 進行中チェック
+if [[ -f ".tmp/release-review/${BRANCH}/state.json" ]]; then
+  # ユーザーに resume か restart か確認
+  echo "既存の review が見つかりました: ${BRANCH}"
+  # → AskUserQuestion で resume / restart / 新ブランチ
+fi
+```
+
+### Step 1: 隔離ブランチ作成 (or worktree)
+
+```bash
+git fetch origin main
+# main 直接 commit 防止。隔離ブランチ作成。
+git checkout -b "${BRANCH}" origin/main 2>/dev/null || git checkout "${BRANCH}"
+git push -u origin "${BRANCH}"
+```
+
+別 session が main で作業中の場合は worktree (`.tmp/worktrees/release-review-<date>/`) に切り出す。
+
+### Step 2: artifact dir 初期化
+
+```bash
+ART_DIR=".tmp/release-review/${BRANCH}"
+mkdir -p "${ART_DIR}"
+node ai-skills/release-review/scripts/orchestrator.mjs init \
+  --branch "${BRANCH}" \
+  --max-hours "${MAX_HOURS}" \
+  --max-issues "${MAX_ISSUES:-0}" \
+  --exclude-axes "${EXCLUDE_AXES}"
+```
+
+`state.json` が初期化される (8 軸 × round=0 / status=pending / last_findings=null)。
+
+### Step 3: 初回 axis dispatch (並列最大 3 本)
+
+`orchestrator.mjs next` で次に dispatch すべき axis 一覧を取得し、3 本まで並列 Agent 起動:
+
+```javascript
+// 擬似コード — 実際は Agent tool を 1 メッセージで複数 invoke
+const next = JSON.parse(execSync(`node ai-skills/release-review/scripts/orchestrator.mjs next --branch ${BRANCH} --slots 3`));
+// next = [{axis: "01-schema-spec-drift", round: 1}, ...]
+for (const {axis, round} of next) {
+  Agent({
+    description: `release-review axis ${axis} round ${round}`,
+    subagent_type: "general-purpose",
+    prompt: <axis briefing を ai-skills/release-review/axes/${axis}.md から読んで埋め込む>,
+    run_in_background: true,
+  });
+}
+```
+
+各 Agent は終了時に `${ART_DIR}/findings.jsonl` に 1 finding = 1 行で append (JSON Lines)。
+
+### Step 4: /loop で自己再帰
+
+最初の axis dispatch を流したら、**`/loop` skill を起動**して自己再帰モードに入る:
+
+```
+Skill({ skill: "loop", args: "/release-review --resume --branch <branch>" })
+```
+
+`/loop` は ScheduleWakeup で 30 分後の self-wake を予約。次回 wake では:
+
+1. `orchestrator.mjs aggregate --branch <branch>` で findings.jsonl を分類
+2. classification に応じて auto-fix commit / ISSUE 起票 / spec-pending ISSUE 起票
+3. `orchestrator.mjs next --slots 3` で次の axis を dispatch
+4. `orchestrator.mjs check-stop` で停止条件を判定
+5. 停止条件 false → 再度 ScheduleWakeup、true → STOPPED.md 生成して終了
+
+### Step 5 (停止後): 最終 PR / 集約 ISSUE
+
+停止条件発火後:
+
+```bash
+# auto-fix commit が積まれていれば PR
+if git log origin/main..HEAD --oneline | head -1 | grep -q .; then
+  gh pr create --title "chore(release-review): findings auto-fix bundle (${BRANCH})" \
+    --body "$(cat ${ART_DIR}/STOPPED.md)"
+fi
+
+# 集約 ISSUE が作られていればユーザーに dashboard を提示
+cat ${ART_DIR}/STOPPED.md
+```
+
+ユーザーが起きたら STATUS.md / STOPPED.md を見て次のアクションを決める。
+
+## 8 軸の overview
+
+| # | 軸 | scope | 重さ |
+|---|---|---|---|
+| 01 | schema-spec-drift | schemas/*.json ↔ docs/spec/*.md ↔ TS 型 ↔ examples/* 三重照合 | 中 |
+| 02 | process-flow-runtime | /review-flow 10 観点を全 examples 横断 (変数 lifecycle / TX / runIf / 補償 / event 双方向) | 重 |
+| 03 | type-contract | brand drift / cast hack / `as any` / `unknown` を全 grep + sabotage | 中 |
+| 04 | backend-storage | projectStorage の race / FS error path / lock immutability / draft persistence | 中 |
+| 05 | frontend-store | autosave / fallback / localStorage 廃止後の残骸 / dirty-check | 軽 |
+| 06 | test-coverage | public function vs vitest spec の網羅率、e2e click-path 抜け | 中 |
+| 07 | security | path traversal / prototype pollution / runtime executor ban (TemplateString 仕様) | 中 |
+| 08 | dogfood-smoke | `npm run dev` + Playwright headless で全画面 navigate + console error 監視 | 重 |
+
+各軸の詳細 briefing は `axes/<N>-<name>.md`。Agent dispatch 時は briefing をそのまま prompt に埋め込む。
+
+## Classification (詳細は classification-rules.md)
+
+各 finding は Agent が以下を **必ず** self-classify して findings.jsonl に書く:
+
+- `auto-fix`: docs typo / 例追加 / 言い換え / 明らかな bug fix (≤30 行 diff) — 即 commit
+- `issue`: 実装バグ / test gap / 軽微改善 (1-3h で fix 可、別途 review が欲しい) — 軸単位の集約 ISSUE に sub-section 追加
+- `spec-pending`: `schemas/v3/*.json` 変更必要 / 振る舞いが変わる spec 変更 — 個別 ISSUE 起票 + `spec-pending` label + 着手禁止 marker
+
+判定が境界線の場合は **保守側 = issue 起票** に倒す (auto-fix で漏れて main 汚染 > ISSUE 数増加)。
+
+## Safety rails (詳細は safety-rails.md)
+
+orchestrator は以下のいずれか検出で **即 self-stop**:
+
+- 単一 commit diff > 200 lines
+- `schemas/v3/*.json` の差分が auto-fix commit に含まれる
+- `git push --force` / `--force-with-lease` の試行
+- `rm -rf` / `git reset --hard` 等の destructive command 兆候
+
+self-stop 時は `${ART_DIR}/STOPPED.md` に理由と statistics を記録、orchestrator は次の wake をスケジュールしない。ユーザーに通知 (PushNotification 利用可なら send)。
+
+## 進捗確認 (ユーザー向け)
+
+ユーザーは以下のいずれかで進捗を見られる:
+
+```bash
+cat .tmp/release-review/<branch>/STATUS.md         # 軸別 / 巡別 finding 数 + 直近 actions
+gh pr view <auto-fix bundle PR number>             # auto-fix の積み上げ
+gh issue list --label release-review --state open  # 起票 ISSUE 一覧
+```
+
+## このskill自身の trace
+
+本 skill が `auto-fix` で commit する全ては label `release-review-auto-fix` 付き ISSUE 集約 issue へ trace を残す。終了時に集約 ISSUE をユーザーに提示。

--- a/ai-skills/release-review/axes/01-schema-spec-drift.md
+++ b/ai-skills/release-review/axes/01-schema-spec-drift.md
@@ -1,0 +1,116 @@
+# Axis 01 — schema-spec drift
+
+## scope
+
+`schemas/v3/*.json` (canonical) / `docs/spec/*.md` (人間向け仕様書) / `frontend/src/types/v3/*.ts` (TS 型) / `examples/<project>/**/*.json` (canonical サンプル) の **四重照合**。
+
+主な検出対象:
+
+- schema の field / pattern / required と TS 型の `interface` 定義の乖離
+- spec md の言及 field / 値域と schema 実体の乖離
+- examples の実 JSON が schema validate を通らない or TS 型として parse できない
+- TS JSDoc が古い field 名 / 旧用語を使い続けている (#1332 M3 type fix のような状況)
+
+## 必須 step
+
+### 1. schema 一覧と top-level keys を網羅
+
+```bash
+ls schemas/v3/*.json
+# 各 schema の $defs / required / properties を機械的に列挙
+for f in schemas/v3/*.v3.schema.json; do
+  echo "=== $f ==="
+  jq -r '.["$defs"] // {} | keys[]' "$f"
+done
+```
+
+### 2. TS 型ファイルとの cross-check
+
+```bash
+ls frontend/src/types/v3/*.ts
+# 各 schema の top-level $defs と対応する TS interface があるか
+# 例: schemas/v3/process-flow.v3.schema.json の "Step" → frontend/src/types/v3/process-flow.ts の Step type
+```
+
+主要照合ポイント:
+
+- `EntityMeta` (common.v3) の required = `["id", "uuid", "name", "createdAt", "updatedAt"]` と TS interface fields の照合
+- 各 entity の id field の brand 型 (`ScreenId` / `TableId` / ...) が schema の `$ref` 先と一致
+- discriminated union の `kind` enum 値が両側で完全一致
+
+### 3. docs/spec/*.md の振る舞い記述 vs schema 実体
+
+```bash
+ls docs/spec/*.md | head -30
+# 各 spec md 内の "X field は Y" / "required" / "pattern" 言及を grep
+grep -nE "required|optional|pattern|enum" docs/spec/*.md | head -50
+# schema 側の対応定義と突合
+```
+
+### 4. examples の AJV validate
+
+```bash
+cd frontend
+npx vitest run src/types/v3/v3-types.test.ts samples-v3.schema.test.ts 2>&1 | tail -20
+# 失敗があれば schema drift
+```
+
+`npm run validate:samples -- ../examples/<project-id>` も走らせて runtime 契約検証 (test と別の validator)。
+
+### 5. TS JSDoc の古い用語 grep
+
+過去 #1332 で blind spot だったパターン:
+
+```bash
+# "対象 X の Uuid" 系の旧用語が残っていないか
+grep -rnE "対象.+の\s*[Uu]uid|→\s*Uuid|: Uuid\b" frontend/src/types/v3/ docs/spec/ 2>&1 | grep -v "uuid:" | head -30
+
+# "Brand<Uuid, ..." (intersection が never に潰れる古い brand パターン)
+grep -rnE "Brand<Uuid," frontend/src/ backend/src/ 2>&1
+```
+
+### 6. schemas/v3/README.md と各 schema の $defs 列挙突合
+
+README に列挙されている型一覧が実 schema と一致しているか:
+
+```bash
+grep -oE "EntityId|EntityMeta|Uuid|LocalId|Identifier|...|TestAssertion" schemas/v3/README.md | sort -u
+# 各 schema の $defs と diff
+```
+
+## 出力 format
+
+各 finding を findings.jsonl に append:
+
+```json
+{
+  "axis": "01-schema-spec-drift",
+  "round": <N>,
+  "severity": "must|should|nit",
+  "classification": "spec-pending|issue|auto-fix",
+  "file": "path:line",
+  "title": "<軸内で unique な短い見出し>",
+  "body": "<該当 schema / TS / md / example の差分内容、再現コマンド、推奨 fix>",
+  "fix_diff": "<auto-fix 時のみ>",
+  "evidence_paths": ["..."],
+  "discovered_at": "<ISO>"
+}
+```
+
+## classification 指針 (本軸特化)
+
+- schemas/v3/*.json の field 追加 / required 化 / pattern 変更 → **spec-pending** 必須
+- docs/spec/*.md の振る舞い記述変更 (例: "X したら Y" → "X したら Z") → **spec-pending**
+- docs/spec/*.md の typo / 例追加 / 言い回し改善 → **auto-fix**
+- TS JSDoc の旧用語 → **auto-fix** (#1332 M3 patches と同じパターン)
+- TS interface field の追加 / 削除 / 型変更 → **issue** (schema 側が canonical なので、schema と一致させる調整は実装変更 = review 要)
+- examples の JSON 修正 (schema validate を通すための field 追加 / 修正) → **issue** (canonical サンプルなので慎重に)
+
+## 完了判定 (このラウンドの)
+
+- 上記 6 step を 1 巡実施し、新規 finding が前回 round より減って 0 件に達したら `completed` status で終了
+- 同じ finding を 2 巡連続で報告するのは NG (重複検出は orchestrator 側で merge するが、Agent 側でも `evidence_paths` で前回 round と比較)
+
+## previous round context
+
+orchestrator から渡される `previous rounds findings (本軸): N 件` を尊重。N=0 で再 dispatch された場合は「サンプリング軸を変えて再 grep」(例: 前回は common.v3 中心、今回は process-flow.v3 中心) で網羅性を上げる。

--- a/ai-skills/release-review/axes/02-process-flow-runtime.md
+++ b/ai-skills/release-review/axes/02-process-flow-runtime.md
@@ -1,0 +1,88 @@
+# Axis 02 — process-flow runtime contract
+
+## scope
+
+`examples/<project>/process-flows/*.json` および `workspaces/<dogfood>/process-flows/*.json` の **実行セマンティクス** を `/review-flow` の 10 観点で全件監査。schema validate は通っても runtime 契約 (変数 lifecycle / TX / runIf / 補償 / event 双方向) を満たさないものを発見する。
+
+`ai-skills/review-flow/SKILL.md` の 10 観点 + 18 ルールの既知パターンを ALL 適用。
+
+## 必須 step
+
+### 1. 対象 ProcessFlow 一覧
+
+```bash
+find examples/ workspaces/ -path "*/process-flows/*.json" -type f 2>/dev/null \
+  | grep -v dogfood-1036 \
+  | head -100
+# 既知不要 path は除外
+```
+
+### 2. ai-skills/review-flow/SKILL.md の 10 観点を全 PF に適用
+
+10 観点 (要約):
+
+1. 変数 lifecycle (flowParameter / action / step / tx / loop / global) の scope と参照タイミング整合
+2. TX (transactionScope) 内 step の DB I/O / 失敗時 rollback target
+3. runIf 条件式の型 (boolean になるか) と参照 variable の lifecycle
+4. 補償 (compensation) ペアの整合 (commit 系 step と rollback 系 step の対応)
+5. event 双方向 (publish ↔ subscribe) の topic / payload schema 一致
+6. response 分岐 (success / error / not_found 等) と outcome / errorMessage の整合
+7. http / api 呼出の retry policy / timeout / idempotency-key 設計
+8. workflow approval step の approvers / quorum / role 整合
+9. cdc / batch / scheduled の destination + captureMode 妥当性
+10. inputs/outputs の StructuredField 型と次 step 参照型の整合
+
+詳細は `ai-skills/review-flow/SKILL.md` を直接読む。
+
+### 3. 既知 pitfall 18 種の grep
+
+`feedback_processflow_known_pitfalls_retail_2026_05_02.md` (memory 参照、AI からは直接 read 不可なら以下を流用):
+
+- conv 参照リテラル化 (`@conv.X` を文字列リテラルに展開してしまう)
+- JSON 内 kind 重複 (同 step 内に kind 2 つ)
+- `screenTransition` と `httpRoute` の衝突
+- `nextSeq()` 採番不能
+- `rollbackOn` 欠落
+- `lineage.purpose` 誤り
+- loop 同名衝突
+- 複数文 SQL (1 step に複数 SQL 詰込)
+- ...
+
+### 4. 各 PF を実行コンテキストで mental simulation
+
+各 PF を 1 件読みながら:
+
+- 開始 (action invoke) → step 1 → ... → 終了 まで mentally execute
+- 各 step での変数定義 / 参照 / 上書きを stack 追跡
+- 例外パス (response='error' 等) も同様に simulate
+
+具体的 bug 検出:
+
+- step N で参照する変数が step (N-1) までに定義されていない
+- TX 内で `rollbackOn` 指定されていない step が失敗したら整合性が崩れる
+- `runIf: "@var.x === 'A'"` が false なら以降 step が変数未定義状態で走る
+
+### 5. 横断: examples / workspaces の network effect
+
+複数 PF 間で:
+
+- `commonProcess` の `refId` が存在しない PF
+- `screenTransition.target` が存在しない screen
+- `event.publish` topic に対する `subscribe` が存在しない (or 逆)
+
+## 出力 format
+
+各 finding を findings.jsonl に append (Axis 01 の format 同じ、`axis="02-process-flow-runtime"`)。
+
+`evidence_paths` には対象 PF の path を必ず入れる。
+
+## classification 指針
+
+- PF JSON の内容修正 (変数名 typo / step kind 誤り / 参照先 fix) → **issue** (canonical example は慎重に、人間レビュー要)
+- 同パターン (例: dashboard-kpi-summary.json の typo を 5 PF に展開) → **issue** で 1 集約 (鉄則 3 同根)
+- spec md の例コードが古い → **auto-fix**
+- schema 側に新規 step kind が必要 → **spec-pending**
+
+## 完了判定
+
+10 観点 × 対象 PF 全件を 1 巡走査し、新規 finding が前回 round より減って 0 件で `completed`。

--- a/ai-skills/release-review/axes/03-type-contract.md
+++ b/ai-skills/release-review/axes/03-type-contract.md
@@ -1,0 +1,100 @@
+# Axis 03 — type contract integrity
+
+## scope
+
+TS 型の **brand drift / cast hack / `as any` / 不適切 `unknown` の濫用** を全 grep + sabotage で検出。型レベル regression gate の機能性を実機で verify。
+
+## 必須 step
+
+### 1. cast hack の全 grep
+
+```bash
+# `as any` (must-fix 級)
+grep -rnE "\bas\s+any\b" frontend/src backend/src 2>&1 | grep -vE "// (eslint-disable|expected|fixme).*as any" | head -50
+
+# `as unknown as <SomeType>` (legacy migration pattern、解消できるか check)
+grep -rnE "as\s+unknown\s+as\s+\w+" frontend/src backend/src 2>&1 | head -50
+
+# `as <SomeBrandType>` で UUID string を brand に強引キャストしているもの
+grep -rnE '"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"\s+as\s+\w*Id' frontend/src backend/src 2>&1 | head -30
+```
+
+### 2. brand 型 sabotage で gate を verify
+
+```bash
+cd frontend
+# 1. base brand 縮退 sabotage
+cat > /tmp/sabotage-base.patch <<EOF
+--- a/src/types/v3/common.ts
++++ b/src/types/v3/common.ts
+@@ -40,1 +40,1 @@
+-export type EntityId = Brand<string, "EntityId">;
++export type EntityId = Brand<string, "Uuid">;
+EOF
+git apply /tmp/sabotage-base.patch
+npx tsc --noEmit -p tsconfig.test.json 2>&1 | head -5
+git apply -R /tmp/sabotage-base.patch
+# 期待: TS2578 unused @ts-expect-error が出る (gate が functional)
+# 出なければ gate が壊れている → issue
+```
+
+(複数 sabotage variant を試す。詳細は #1353 5 巡目 review log 参照)
+
+### 3. `unknown` の濫用検出
+
+```bash
+# function 引数 / 戻り値 で `unknown` を使っている箇所
+grep -rnE ":\s*unknown(\s*\)|\s*[,;]|\s*=>)" frontend/src backend/src 2>&1 | head -50
+# 大半は legitimate (boundary 型) だが、関数内部での `as unknown` 経由 narrowing は要 review
+```
+
+### 4. discriminated union の exhaustive check 漏れ
+
+```bash
+# switch (x.kind) で default / never assertion 無いもの
+grep -rnE "switch\s*\(.*\.kind\s*\)" frontend/src backend/src 2>&1 | head -30
+# 各 hit を Read で確認、`default:` or `_: never = x; throw ...` パターンが無ければ issue
+```
+
+### 5. process-flow.ts / screen-item.ts の Step / Effect 型と schema の `kind` enum 完全一致
+
+```bash
+# TS 側
+grep -nE "kind:\s*\"[a-zA-Z]+\"" frontend/src/types/v3/process-flow.ts | head -30
+# schema 側
+jq -r '..|.kind?|.enum?//empty' schemas/v3/process-flow.v3.schema.json | sort -u
+# diff
+```
+
+### 6. `null` vs `undefined` の境界
+
+```bash
+# Optional field を意図しているのに `: T | null` になっている (schema は通常 `optional`)
+grep -rnE ":\s*\w+\s*\|\s*null\b" frontend/src/types/v3/ 2>&1 | head -30
+```
+
+## 出力 format
+
+各 finding は findings.jsonl に append。`evidence_paths` には sabotage patch / TS gate test の path も含める。
+
+## classification 指針
+
+- `as any` 解消 (型付け or @ts-expect-error 化) → **issue** (実装変更を伴う)
+- 未使用 `as unknown as` キャスト削除 → **auto-fix** (純粋削除なら 1-2 行)
+- brand 型 sabotage gate が壊れている → **issue** (regression gate 強化、優先 high)
+- discriminated union exhaustive 化 → **issue**
+- `: T | null` → `?: T` の修正 → **issue** (API 変更扱い、慎重)
+- schemas/v3/*.json の新 enum 値追加 → **spec-pending**
+
+## 完了判定
+
+cast / unknown / brand drift / exhaustive 抜けの 4 観点を 1 巡し、新規 0 件で `completed`。
+
+## 注意
+
+過去 #1353 review log で:
+
+- ScreenId vs TableId の brand sabotage は捕捉できたが、ViewId / ViewDefinitionId / SequenceId / ProcessFlowId / PageLayoutId / ProjectId の narrow discriminator 取り違えは v3-types.test.ts では検出されないことが Nit として記録されている (`feedback_unified_review_prompt_for_multi_ai.md` 関連)
+- 本軸 round 2 以降で「n^2 ペア完全網羅」を assert する追加 test を提案する候補
+
+本軸は brand 系の hygiene を集中的に上げる。

--- a/ai-skills/release-review/axes/04-backend-storage.md
+++ b/ai-skills/release-review/axes/04-backend-storage.md
@@ -1,0 +1,97 @@
+# Axis 04 — backend storage / lock / draft
+
+## scope
+
+`backend/src/projectStorage.ts` を中心に、ファイル永続化層の **race / FS error path / lock immutability / draft persistence / uuid preserve** を網羅検査。
+
+## 必須 step
+
+### 1. read / write / list 関数の全列挙
+
+```bash
+grep -nE "^export (async )?function (read|write|list|delete)" backend/src/projectStorage.ts | head -50
+```
+
+各関数について以下を check:
+
+- argument の path traversal 防御 (`assertPathContained` が呼ばれているか)
+- error path (ENOENT / EACCES / parse error) の handling
+- concurrent write 時の race (lock or atomic rename を使っているか)
+
+### 2. `readEntityAndEnsureUuid` 全 entity bulk path coverage
+
+7 top-level entity (Screen / Table / ProcessFlow / Sequence / View / ViewDefinition / PageLayout) ごとに:
+
+- single read 経路 ✓
+- bulk list 経路 ✓
+- `.design.json` companion file 除外 (Screen / PageLayout のみ) ✓
+
+```bash
+grep -nE "preserveOrAssignUuid|readEntityAndEnsureUuid" backend/src/projectStorage.ts
+# uuid persist が必要な経路から漏れていないか
+```
+
+### 3. uuid immutability 確認
+
+```bash
+# preserveOrAssignUuid で existing uuid vs supplied の不一致 throw が機能
+grep -A 5 "uuid immutability violation" backend/src/projectStorage.ts
+```
+
+regression test の有無:
+
+```bash
+grep -rnE "uuid.*immutab|immutab.*uuid" backend/src/ 2>&1 | head -10
+# 各 entity に対する 2nd read uuid 不変 assertion test があるか
+```
+
+### 4. edit-session-draft の path safety
+
+```bash
+# data/.drafts/ 関連
+grep -rnE "draft.*Dir|\.drafts" backend/src/ 2>&1 | head -20
+# lock / TTL / cleanup path がどう実装されているか
+```
+
+### 5. wsBridge の broadcast / unicast
+
+```bash
+grep -nE "broadcast|sendTo|unicast" backend/src/wsBridge.ts 2>&1 | head -30
+# 他クライアントへ意図せず leak する message が無いか
+```
+
+### 6. tools.ts の MCP handler error wrapping
+
+```bash
+grep -nE "throw new McpError" backend/src/tools.ts backend/src/handlers/*.ts | wc -l
+# error path で McpError 以外を throw しているもの (=未 wrap) を検出
+```
+
+### 7. workspace lockdown / DESIGNER_DATA_DIR mode
+
+```bash
+grep -rnE "lockdown|DESIGNER_DATA_DIR" backend/src/ 2>&1 | head -10
+# lockdown 時の recent への書き込み禁止が enforce されているか
+```
+
+## 出力 format
+
+findings.jsonl に append。本軸は backend 中心なので `evidence_paths` に backend test file も含める。
+
+## classification 指針
+
+- race condition / 概念上の bug 修正 → **issue** (実装ロジック変更、review 要)
+- error path 強化 (ENOENT → graceful null return 等) → **issue**
+- uuid preserve のテスト追加 → **issue** (test だけなら自動化可能だが、test の妥当性 review 要)
+- `assertPathContained` 抜けの追加 → **issue** (security 強化、Axis 07 と重複なら統合)
+- backend tools.ts の 1 つの handler error wrap 抜け → **issue**
+- docs/spec/workspace.md の例コード古さ → **auto-fix**
+- backend/src/projectStorage.ts の関数 JSDoc 追加 → **auto-fix** (純粋 doc 追加なら)
+
+## 完了判定
+
+`projectStorage.ts` / `wsBridge.ts` / `tools.ts` / handler files / draft-related files の 5 領域を 1 巡しfindings.jsonl 0 件追加で `completed`。
+
+## 注意
+
+backend test (`backend/src/*.test.ts`) は **regression test として整備されているか** も確認。`projectStorageDataDir.test.ts` のような厚い test がある一方、未整備の関数も多い可能性。

--- a/ai-skills/release-review/axes/05-frontend-store.md
+++ b/ai-skills/release-review/axes/05-frontend-store.md
@@ -1,0 +1,86 @@
+# Axis 05 — frontend store / persistence
+
+## scope
+
+`frontend/src/store/*.ts` の **autosave / fallback / dirty-check / localStorage 廃止後の残骸** を網羅検査。#923-#928 シリーズ で localStorage fallback path 廃止が決定済 (memory `project_localstorage_fallback_removal_2026_05_08.md`)。残骸が無いか確認する。
+
+## 必須 step
+
+### 1. store 一覧と responsibility 把握
+
+```bash
+ls frontend/src/store/*.ts | grep -v test | head -30
+# 各 store の "load / save / set / clear" 公開 API を把握
+grep -nE "^export (async )?function (load|save|set|clear|create|delete|update)" frontend/src/store/*.ts | head -50
+```
+
+### 2. localStorage 残骸 grep
+
+```bash
+# localStorage 直接アクセスを全 grep
+grep -rn "localStorage\." frontend/src/ 2>&1 | grep -v "// removed\|@deprecated" | head -40
+# fallback path 経路 (mcpBridge 切断時) が残っているか
+grep -rnE "ws.*disconnect.*localStorage|fallback.*localStorage" frontend/src/ 2>&1 | head -20
+```
+
+### 3. dirty-check / autosave timing
+
+```bash
+# autosave debounce timer
+grep -rnE "debounce|setTimeout.*save|autosave" frontend/src/store/ 2>&1 | head -30
+# dirty flag setter
+grep -rnE "setDirty|isDirty|markDirty" frontend/src/store/ 2>&1 | head -20
+```
+
+dirty を set するが clear しない (永続 dirty) / save 後に clear し忘れる 等の bug を探す。
+
+### 4. mcpBridge との send/receive 整合
+
+```bash
+# wsBridge の対応 handler (backend) と一致するか
+grep -nE "sendCommand|sendMessage" frontend/src/mcp/mcpBridge.ts | head -30
+# backend 側 handler
+grep -rnE "case \"\w+\":" backend/src/wsBridge.ts backend/src/handlers/*.ts | head -30
+```
+
+frontend が send する command と backend が受ける case の集合一致を assert (sabotage 風 grep)。
+
+### 5. store load 経路の defensive default
+
+```bash
+# 旧 schema load 時の uuid fallback (I-7 で各 store に追加された)
+grep -rnE "uuid\s*\?\?|uuid.*\|\|" frontend/src/store/ 2>&1 | head -20
+# 必要なくなった defensive code の有無
+```
+
+### 6. dataDir / workspace switch 時の store reset
+
+```bash
+grep -rnE "loadWorkspaces|switchWorkspace|workspace.*reset" frontend/src/store/ 2>&1 | head -20
+# 旧 workspace data が新 workspace に混ざる risk
+```
+
+### 7. test での fake timer 問題
+
+過去 #1326 で `vi.useFakeTimers({ shouldAdvanceTime: true })` が debounce test で 25% flake していた。同パターンが他 store test に残っていないか:
+
+```bash
+grep -rnE "useFakeTimers\(\{[^}]*shouldAdvanceTime" frontend/src/store/ 2>&1
+```
+
+## 出力 format
+
+findings.jsonl に append。
+
+## classification 指針
+
+- localStorage 直接アクセスの削除 (廃止済 path の残骸) → **auto-fix** (純粋削除なら) or **issue** (周辺ロジック調整伴うなら)
+- dirty flag bug 修正 → **issue**
+- autosave timer の調整 → **issue**
+- workspace switch reset 漏れ修正 → **issue**
+- test flake (fake timer pattern) 修正 → **issue** (test の堅牢化、レビュー要)
+- store の JSDoc 追加 → **auto-fix**
+
+## 完了判定
+
+`frontend/src/store/` 配下の主要 store ファイル (10-15 個) を 1 巡し、findings.jsonl 0 件追加で `completed`。

--- a/ai-skills/release-review/axes/06-test-coverage.md
+++ b/ai-skills/release-review/axes/06-test-coverage.md
@@ -1,0 +1,96 @@
+# Axis 06 — test coverage gap
+
+## scope
+
+vitest / playwright spec の **網羅率と質** を確認。public function に対する unit test の有無、e2e の click-path 抜け、test の偽陽性 (skip / 弱い assertion / 不適切 expect)。
+
+## 必須 step
+
+### 1. vitest 全 spec の一覧
+
+```bash
+find frontend/src backend/src -name "*.test.ts" -o -name "*.test.tsx" 2>/dev/null | wc -l
+# 対応する非 test ファイル数
+find frontend/src backend/src -name "*.ts" -o -name "*.tsx" | grep -v test | wc -l
+# 比率を見る
+```
+
+### 2. public export と test の対応
+
+```bash
+# 各 .ts の export を列挙
+grep -rnE "^export (async )?function" frontend/src/store/ frontend/src/utils/ backend/src/ 2>&1 | head -100
+# 対応する test 内 import / describe を grep
+```
+
+特定 store / util に対して test が無い / test が 1 件しかない / happy path のみで edge case を assert していない、を検出。
+
+### 3. test 内の skip / fixme / todo
+
+```bash
+grep -rnE "(it|test|describe)\.skip|\.skip\(|skipIf|test\.fixme" frontend/src backend/src 2>&1 | head -30
+# 過去 #1299 で test.skip + 別 ISSUE 化が鉄則 0 違反として記録 (feedback_completion_blocker_weak_assertions.md)
+```
+
+skip / fixme / todo 化された test が release blocker かどうか個別判定。
+
+### 4. 弱い assertion の grep
+
+```bash
+# `not.toBe(error)` 等 (実質的に何も verify しない)
+grep -rnE "not\.toBe\(|not\.toEqual\(.*null\)|not\.toBeUndefined" frontend/src/**/*.test.* backend/src/**/*.test.* 2>&1 | head -30
+# `expect(x).toBeDefined()` のみ (中身を見ていない)
+grep -rnE "expect\([^)]+\)\.toBeDefined\(\)" frontend/src/**/*.test.* backend/src/**/*.test.* 2>&1 | head -30
+```
+
+### 5. playwright e2e spec の click-path 網羅
+
+```bash
+ls frontend/e2e/*.spec.ts | head -30
+# 主要 UI 画面 (画面一覧 / 画面フロー / 処理フロー / テーブル定義 / 等) に対する spec の有無
+```
+
+`AGENTS.md` の Tab policy 表に列挙された各 view に対し、最低 1 e2e spec が存在するか:
+
+```
+DashboardView / FlowEditor / ScreenListView / Designer / ScreenItemsView / TableListView /
+TableEditor / ErDiagram / ProcessFlowListView / ProcessFlowEditor / SequenceListView /
+SequenceEditor / ViewListView / ViewEditor / ViewDefinitionListView / ViewDefinitionEditor /
+PageLayoutListView / PageLayoutEditor / PageLayoutDesigner / GadgetListView /
+GenericDefinitionCatalogView / GenericDefinitionListView / GenericDefinitionEditor /
+ExtensionsPanel / ConventionsCatalogView / TechStackView / WorkspaceListView /
+WorkspaceSelectView / CodexSettingsView
+```
+
+### 6. AJV validate を経由しない test の検出
+
+```bash
+# AJV を import している test
+grep -rl "ajv\|Ajv\|validate.*schema" frontend/src/**/*.test.* backend/src/**/*.test.* 2>&1 | head -20
+# AJV 経由しない fixture builder が schema 違反を許容する余地
+```
+
+### 7. tsconfig.test.json の include スコープ
+
+```bash
+cat frontend/tsconfig.test.json
+# 過去 #1353 で v3-types.test.ts + src/test のみが typecheck 対象、他 .test.tsx は対象外と確認済
+# 他 test file への include 拡張要否を評価
+```
+
+## 出力 format
+
+findings.jsonl に append。`evidence_paths` には対象 test file path / 対応 source file path を必ず含める。
+
+## classification 指針
+
+- skip / fixme 化されている test を解除 / 修正 → **issue** (test 動作変更、review 要)
+- 弱い assertion を強い assertion に → **issue**
+- 不足 test の追加 → **issue**
+- tsconfig.test.json の include 拡張 → **issue** (build config 変更、影響範囲評価要)
+- test JSDoc / コメント追加 → **auto-fix**
+- e2e spec の新規追加 → **issue**
+
+## 完了判定
+
+vitest spec 一覧 / e2e spec 一覧 / skip-fixme 一覧 / 弱い assertion / 主要 view e2e の 5 領域を 1 巡し、findings.jsonl 0 件追加で `completed`。

--- a/ai-skills/release-review/axes/07-security.md
+++ b/ai-skills/release-review/axes/07-security.md
@@ -1,0 +1,100 @@
+# Axis 07 — security review
+
+## scope
+
+OWASP top 10 / dual-use risk / runtime executor ban (TemplateString 仕様) / path traversal / prototype pollution / sensitive data leak を網羅。defensive security 視点のみ (offensive 用途は対象外)。
+
+## 必須 step
+
+### 1. path traversal
+
+```bash
+# user input の path 結合
+grep -rnE "path\.(join|resolve)\([^)]*\b(req|args|input|userInput|name|id)\b" backend/src/ 2>&1 | head -30
+# assertPathContained の coverage
+grep -nE "assertPathContained" backend/src/projectStorage.ts | wc -l
+# user input → path 結合の経路で assertPathContained が呼ばれていない箇所を特定
+```
+
+### 2. prototype pollution
+
+```bash
+# Object.assign / spread で user input を受けている
+grep -rnE "Object\.assign\([^)]*req\b|\.\.\.req\.body" backend/src/ frontend/src/ 2>&1 | head -20
+# JSON.parse 直後に直接構造 access (sanitize 無し)
+grep -rnE "JSON\.parse\(.*\)\.(__proto__|constructor)" backend/src/ frontend/src/ 2>&1 | head -10
+```
+
+### 3. runtime executor ban (TemplateString 仕様)
+
+docs/spec/process-flow-expression-language.md の `${...}` 内禁止 keyword:
+
+```bash
+# TemplateString runtime invocation 経路で eval / Function constructor / fetch 等を許す箇所
+grep -rnE "new\s+Function\(|eval\(|setTimeout\([^,)]*\$\{|setInterval\([^,)]*\$\{" frontend/src backend/src 2>&1 | head -20
+# 仕様: @flow.* / @action.* / @step.* の副作用 invocation を ${...} 内で呼ぶのは禁止 (dispatch rule)
+```
+
+### 4. sensitive data leak
+
+```bash
+# log で password / secret / token / key を出力
+grep -rnE "console\.(log|info|warn|error)\([^)]*\b(password|secret|token|apiKey|cookie)\b" backend/src/ frontend/src/ 2>&1 | head -20
+# logger / pino / console 経由で env や req body 全文を吐く箇所
+grep -rnE "log\..*req\.body|console\..*process\.env\b" backend/src/ 2>&1 | head -20
+```
+
+### 5. CSP / iframe sandbox
+
+```bash
+grep -rnE "Content-Security-Policy|iframe.*sandbox" frontend/src backend/src 2>&1 | head -20
+# GrapesJS canvas iframe / Puck preview iframe の sandbox 設定
+```
+
+### 6. XSS リスク (innerHTML / dangerouslySetInnerHTML)
+
+```bash
+grep -rnE "innerHTML\s*=|dangerouslySetInnerHTML" frontend/src/ 2>&1 | head -30
+# 各 hit が sanitize されているか check
+```
+
+### 7. CORS / wsBridge origin check
+
+```bash
+grep -nE "origin\b|cors|Access-Control" backend/src/index.ts backend/src/wsBridge.ts 2>&1 | head -20
+# 0.0.0.0 listen + origin check 無しのリスク
+```
+
+### 8. dependency vulnerabilities (info only)
+
+```bash
+cd frontend && npm audit --production --json 2>&1 | jq '.metadata.vulnerabilities' || true
+cd ../backend && npm audit --production --json 2>&1 | jq '.metadata.vulnerabilities' || true
+# 重大度 high / critical があれば release blocker
+```
+
+## 出力 format
+
+findings.jsonl に append。severity は **慎重に**: 実 exploit 可能なら `must`、理論的余地なら `should` or `nit`。
+
+## classification 指針
+
+- 実 exploit 可能な path traversal / XSS / RCE → **issue** (release blocker 級、優先 max)
+- 理論的 prototype pollution 余地 (深い nest が必要) → **issue** (should 級)
+- sensitive data leak → **issue** (must or should、内容次第)
+- iframe sandbox 強化 → **issue** (UI に副作用、慎重)
+- dependency vulnerability → **issue** (auto-fix で `npm audit fix` できる場合のみ可、本 skill では原則 issue 化)
+- CSP header の追加 → **spec-pending** (deploy 仕様変更、release 後 RFC)
+- security 観点の docs/spec 追加 → **auto-fix**
+
+## 完了判定
+
+上記 8 step を 1 巡し、findings.jsonl 0 件追加で `completed`。
+
+## 注意
+
+system prompt の policy:
+
+> Assist with authorized security testing, defensive security, CTF challenges, and educational contexts. Refuse requests for destructive techniques, DoS attacks, mass targeting, supply chain compromise, or detection evasion for malicious purposes.
+
+本軸は defensive のみ。発見した vulnerability の **exploit code は書かない**。再現方法は最小限の説明に留める。

--- a/ai-skills/release-review/axes/08-dogfood-smoke.md
+++ b/ai-skills/release-review/axes/08-dogfood-smoke.md
@@ -1,0 +1,125 @@
+# Axis 08 — dogfood smoke (browser + backend integration)
+
+## scope
+
+`cd backend && npm run dev` を確認 (前提として user が常駐起動)、`cd frontend && npm run dev` で UI を立て、Playwright **headless** で全画面 navigate + console error / network 4xx-5xx 監視。MCP 連携の smoke も含む。
+
+## 前提
+
+- backend dev server が **既に常駐起動済** (port 5179) であること
+- frontend dev server は本 Agent が `run_in_background` で起動し、終了前に kill
+- Playwright MCP は `mcp__playwright__*` (headless) を使用、`mcp__playwright-headed__*` は使わない (memory `feedback_no_ai_managed_dev_server.md` / `feedback_browser_smoke_headless_chrome_devtools.md`)
+
+## 必須 step
+
+### 0. 環境前提チェック
+
+```bash
+# backend 常駐確認
+curl -sf http://localhost:5179/mcp -o /dev/null && echo "backend OK" || echo "backend NOT RUNNING"
+# 常駐していない場合は本軸 skip (ユーザーに通知して issue 起票)
+```
+
+### 1. frontend dev server 起動
+
+```bash
+cd frontend
+npm run dev &  # 注意: Agent 自身が manage、終了前に kill
+# 5-10 秒待って http://localhost:5173 が listen するか確認
+```
+
+### 2. 全 view navigate + console error 監視
+
+`AGENTS.md` Tab policy 表の全 view path に対し:
+
+```javascript
+// 擬似コード
+const views = [
+  "/", "/screen/flow", "/screen/list", "/table/list", "/table/er",
+  "/process-flow/list", "/sequence/list", "/view/list",
+  "/view-definition/list", "/page-layout/list", "/gadget/list",
+  "/generic-definition", "/extensions", "/conventions/catalog",
+  "/project/tech-stack", "/workspace/list", "/ai-settings",
+];
+
+for (const path of views) {
+  await mcp__playwright__browser_navigate({ url: `http://localhost:5173/w/<wsId>${path}` });
+  await mcp__playwright__browser_wait_for({ time: 1.5 });
+  const errors = await mcp__playwright__browser_console_messages({ level: "error" });
+  const networkBad = (await mcp__playwright__browser_network_requests({}))
+    .filter(r => r.status >= 400);
+  // 各 view の error / 4xx-5xx を finding として記録
+  // screenshot を .tmp/screenshots/release-review-<axis>-<view>.png に保存
+}
+```
+
+### 3. per-resource view (individual resource navigation)
+
+各 examples/<project>/ の harmony.json から id を 1-2 件 sample し:
+
+- `/screen/design/<screenId>` (GrapesJS or Puck)
+- `/screen/items/<screenId>`
+- `/table/edit/<tableId>`
+- `/process-flow/edit/<flowId>`
+- `/view/edit/<viewId>`
+- `/view-definition/edit/<viewDefId>`
+- `/page-layout/edit/<plId>` / `/page-layout/design/<plId>`
+
+各で console error / network 4xx-5xx を採集。
+
+### 4. CRUD smoke (1 resource type につき 1 sequence)
+
+例: テーブル定義で「新規作成 → カラム追加 → 保存 → 再読込 → 削除」を 1 sequence こなして:
+
+- 各 step で network 200 確認
+- save 後の sessionStorage / WebSocket message が backend に届いて persisted file が生成されているか
+
+### 5. workspace switch smoke
+
+```bash
+# 別 workspace への切替で前 workspace のデータが残らないか
+# active workspace の harmony.json と workspaces/ 配下の整合
+```
+
+### 6. MCP tool smoke (selected handful)
+
+```bash
+# 主要 MCP tool が backend 経由で動くか
+# (本 Agent から MCP tool を直接呼ぶ - mcp__harmony-mcp__designer__list_screens 等)
+```
+
+### 7. 終了処理
+
+```bash
+# frontend dev server を kill (起動した PID を track して kill)
+# screenshot を .tmp/release-review/<branch>/screenshots/ に整理
+```
+
+## 出力 format
+
+findings.jsonl に append。本軸特有 field:
+
+- `screenshot_path`: 該当 view の screenshot
+- `console_errors`: 観測されたエラー (truncated)
+- `failed_requests`: 4xx-5xx の URL list
+
+## classification 指針
+
+- console error が release blocker (例: TypeError で全画面 unmountable) → **issue** (severity=must)
+- 4xx-5xx (例: 404 on /api/X) → **issue**
+- 軽微な warning (deprecated API 警告等) → **nit issue** or **auto-fix** (内容次第)
+- 視覚的崩れ (alignment / spacing 等) → **issue** (should 級)
+- UX 改善提案 (機能改善案) → **issue** (nit 級) or **spec-pending** (機能仕様変更なら)
+
+## 完了判定
+
+全 view + per-resource sampling + CRUD smoke + workspace switch + MCP tool smoke の 5 領域を 1 巡し、findings.jsonl 0 件追加で `completed`。
+
+## 重さ
+
+本軸は重い (1 round で 30-60 分かかる可能性)。orchestrator は本軸の dispatch slot を 1 本固定、他 2 軸を並列で消化する。
+
+## 注意
+
+- frontend dev server を放置すると port 5173 を専有し続けるため、Agent 終了前に必ず kill (memory `feedback_no_ai_managed_dev_server.md` 違反防止)
+- screenshot 大量生成で `.tmp/screenshots/` が肥大化するため、本 round 終了時に古い screenshot (前 round 分) を削除

--- a/ai-skills/release-review/classification-rules.md
+++ b/ai-skills/release-review/classification-rules.md
@@ -1,0 +1,134 @@
+# Classification rules — finding → auto-fix / issue / spec-pending
+
+各 axis Agent は finding を発見したら **必ず** 以下のルールで self-classify して findings.jsonl の `classification` field を埋める。判定が境界線の場合は **保守側 = issue 起票** に倒す。
+
+## 判定フローチャート
+
+```
+finding 発見
+  │
+  ├─ schemas/v3/*.json の変更が必要?
+  │    └─ YES → classification = "spec-pending"
+  │
+  ├─ docs/spec/*.md の振る舞い記述 (例: "X したら Y する") の変更?
+  │    └─ YES → classification = "spec-pending"
+  │
+  ├─ public API (MCP tool / wsBridge message / 公開関数 signature) の変更?
+  │    └─ YES → classification = "spec-pending"
+  │
+  ├─ fix diff が ≤ 30 行 + tsc/vitest 影響なし + 自明な修正 (typo / 言い換え / 例追加 / 型注釈) ?
+  │    └─ YES → classification = "auto-fix"
+  │
+  └─ それ以外 (実装バグ / test gap / 軽微改善) → classification = "issue"
+```
+
+## カテゴリ詳細
+
+### auto-fix (即 commit)
+
+**境界**: 30 行以内の diff、build/test に影響なし、人間レビュー不要レベル。
+
+**典型例**:
+
+- `docs/spec/*.md` の typo / 言い換え / 例追加 (振る舞い記述は変えない)
+- TS JSDoc の言い回し更新 (例: "Uuid" → "EntityId" 同期、`#1332` の M3 fix のような sync)
+- 未使用 import / 未使用 variable の削除
+- 明らかな lint 違反 (eslint で `--fix` が効くもの)
+- 既存 test の `toBe` → `toEqual` 軽微補正 (assertion 強化)
+- comment 内の古いリンク / ISSUE 番号の更新
+
+**NG (auto-fix にしてはいけない)**:
+
+- ❌ 実装ロジックの変更 (たとえ 1 行でも)
+- ❌ schemas/v3/*.json の触る
+- ❌ test の skip 解除 / 期待値変更
+- ❌ public API signature 変更
+- ❌ dependency 追加 / 削除
+
+### issue (集約 ISSUE に sub-section 追加)
+
+**境界**: 1-3 時間で fix 可能だが、人間 or 別 AI の review を経てから main に入れたいレベル。
+
+**典型例**:
+
+- 実装バグ (null check 漏れ / race condition / FS error path 未処理)
+- test gap (covered function に対する vitest spec 未整備)
+- 軽微な refactor 提案 (`as any` → 型付け、cast hack 解消)
+- e2e click-path の抜け
+- security 観点の指摘 (path traversal 可能性 / prototype pollution 余地)
+- パフォーマンス問題 (明らかに O(n²) で許容範囲外)
+
+**集約 ISSUE の作り方**:
+
+軸単位で 1 ISSUE。タイトル: `release-review: <axis> findings (<branch>)`、body は `## 提案 A` `## 提案 B` ... 形式で個別 finding を sub-section 化。
+
+ラベル: `release-review`, `release-review-issue`.
+
+### spec-pending (個別 ISSUE 起票 + 着手禁止)
+
+**境界**: 設計者承認なしには触れない範囲。リリース後 or 別 RFC で扱う。
+
+**典型例**:
+
+- `schemas/v3/*.json` の構造変更が必要 (新 field 追加 / required 化 / pattern 変更)
+- `docs/spec/*.md` の振る舞い記述変更 (例: "Y したら Z"を"Y したら W"に)
+- public API の signature 変更 (MCP tool 引数 / wsBridge message format)
+- 大規模 refactor (1 PR で収まらない)
+- フレームワーク全体の設計変更
+
+**起票方法**:
+
+個別 ISSUE。タイトル: `spec-pending: <title> (release-review)`、ラベル: `release-review`, `spec-pending`, `blocked`.
+
+body には:
+
+- 発見軸 / 発見 round
+- 影響範囲 (file:line + 関連 ISSUE / spec doc)
+- なぜ spec-pending か (上記境界のどれに該当するか)
+- 提案する解決方向 (推奨 1 つ + 代替案、設計者が判断する材料)
+- **着手禁止 marker**: `## ⚠️ 着手禁止 - 設計者承認待ち` を冒頭に明示
+
+## 境界事例 (判断に迷ったら issue に倒す)
+
+| 状況 | 判定 |
+|---|---|
+| TS 型に `as unknown as TypeX` cast が残っている (legacy) → 型付けすれば消える | **issue** (実装変更を伴う) |
+| examples/*/screens/*.json の screen.kind が新 enum 値を使っていない | **spec-pending** (enum 定義変更要なら) or **issue** (既存 enum で表現可能なら) |
+| docs/spec/screen-items.md の例コードが古い field 名を使っている | **auto-fix** (例の更新は振る舞い変更ではない) |
+| test file の expect 値が "明らかに" 間違っている (実装が正しい) | **issue** (test 修正は人間レビュー要、auto-fix 禁止) |
+| ESLint warning の `prefer-const` | **auto-fix** (`--fix` で機械的) |
+| 関数 signature に optional param を追加すれば既存呼出全部互換 | **issue** (たとえ互換でも API 変更は review 要) |
+| process-flow.v3.schema.json の description 更新だけ | **spec-pending** (schemas/*.json governance、touch 自体禁止) |
+
+## 各 axis Agent の出力 format
+
+各 finding は findings.jsonl に 1 行 = 1 JSON で append:
+
+```json
+{
+  "axis": "03-type-contract",
+  "round": 2,
+  "severity": "must|should|nit",
+  "classification": "auto-fix|issue|spec-pending",
+  "file": "frontend/src/store/tableStore.ts:142",
+  "title": "tableStore.upsert で `as any` cast が残存",
+  "body": "...詳細な指摘内容、再現手順 / 影響範囲 / 推奨 fix...",
+  "fix_diff": "...auto-fix 時のみ unified diff or before/after を文字列で...",
+  "evidence_paths": ["...", "..."],
+  "discovered_at": "2026-05-27T15:00:00.000Z"
+}
+```
+
+- `severity`: must (release blocker) / should (release 前に直したい) / nit (リリース後でも可)
+- `fix_diff`: auto-fix 時のみ必須、orchestrator が apply-fix で適用する
+
+## orchestrator 側の追加チェック (Agent self-classify への二重検証)
+
+orchestrator が aggregate 時に **必ず** 以下を再確認:
+
+1. classification = `auto-fix` でも、`fix_diff` を parse して以下のいずれかに当たれば降格 → `issue`:
+   - schemas/v3/*.json への touch
+   - 30 行超の diff
+   - tsc / vitest が失敗 (apply 試行 → rollback)
+2. classification = `issue` でも、内容が schemas governance / public API 変更を伴うと検出したら昇格 → `spec-pending`
+3. 重複 finding (同 file:line + 類似 title) は merge (skip)

--- a/ai-skills/release-review/orchestrator-briefing.md
+++ b/ai-skills/release-review/orchestrator-briefing.md
@@ -1,0 +1,201 @@
+# Orchestrator briefing — 各 wake で実行する手順
+
+本 skill が `/loop` で自己再帰した時に、orchestrator が wake する度に実行する責務をここに集約する。SKILL.md の Step 4 以降のループ本体。
+
+## Wake シーケンス (毎回実行)
+
+### 1. state load
+
+```bash
+ART_DIR=".tmp/release-review/${BRANCH}"
+node ai-skills/release-review/scripts/orchestrator.mjs status --branch "${BRANCH}"
+```
+
+state.json から以下を取得:
+
+- 各軸の `round` / `status` (pending / dispatched / completed / stopped)
+- `consecutive_zero_rounds` (枯渇判定用)
+- `start_time` / `elapsed_hours`
+- `issued_count` / `auto_fix_count`
+- `stop_flag` (true なら以降を skip して finalize)
+
+### 2. 前回 dispatch 分の取り込み
+
+前回 wake で dispatch した axis Agent が完了して `findings.jsonl` に書き込んでいる可能性。差分を分類:
+
+```bash
+node ai-skills/release-review/scripts/orchestrator.mjs aggregate \
+  --branch "${BRANCH}" \
+  --since-last-wake
+```
+
+aggregate は各 finding を以下に振り分け:
+
+- `classification: auto-fix` → 別 worker (本 wake 内で直接 fix 実装) に渡す
+- `classification: issue` → 軸単位の集約 ISSUE に sub-section として追記 (または新規作成)
+- `classification: spec-pending` → 個別 ISSUE 起票 (label `spec-pending`、着手禁止 marker 付き)
+
+### 3. auto-fix の実施
+
+aggregate が返した auto-fix list を順次処理。**1 fix = 1 commit** 原則:
+
+```bash
+for fix in $(cat ${ART_DIR}/pending-autofix.jsonl); do
+  # diff < 200 lines / schemas/v3/*.json 含まない / destructive command 含まない を再検査
+  node ai-skills/release-review/scripts/orchestrator.mjs apply-fix --fix-id "${fix.id}"
+  # 失敗時は skip して issue 起票に降格
+done
+```
+
+apply-fix は内部で:
+
+1. fix 内容 (diff or 指示) を確認
+2. Edit/Write tool で適用
+3. tsc + vitest で smoke 確認 (失敗時は rollback + issue 降格)
+4. `git commit -m "fix(<axis>): <title> (release-review auto-fix)"`
+5. auto-fixes.log に追記
+
+### 4. ISSUE 起票
+
+集約 ISSUE への sub-section 追記 or 個別 ISSUE 起票:
+
+```bash
+# 軸単位の集約 ISSUE が無ければ作成
+gh issue create --title "release-review: <axis> findings (${BRANCH})" \
+  --label "release-review,release-review-issue" \
+  --body "$(...sub-sections appendable body...)"
+
+# 既存があれば edit --body で sub-section 追記
+gh issue edit <N> --body-file <updated>
+```
+
+spec-pending は個別起票:
+
+```bash
+gh issue create --title "spec-pending: <title> (release-review)" \
+  --label "release-review,spec-pending,blocked" \
+  --body "<schema 変更 or 振る舞い変更の必要性 + 影響範囲>"
+```
+
+### 5. 停止条件チェック
+
+```bash
+node ai-skills/release-review/scripts/orchestrator.mjs check-stop --branch "${BRANCH}"
+```
+
+返り値が `true` なら finalize へ:
+
+```bash
+node ai-skills/release-review/scripts/orchestrator.mjs finalize --branch "${BRANCH}"
+# STOPPED.md 生成、PR 作成 (auto-fix commit がある場合)、PushNotification 送信
+exit 0  # /loop を抜ける
+```
+
+返り値が `false` なら次の dispatch + ScheduleWakeup へ。
+
+### 6. 次 axis dispatch (並列 3 本)
+
+```bash
+NEXT=$(node ai-skills/release-review/scripts/orchestrator.mjs next \
+  --branch "${BRANCH}" --slots 3)
+```
+
+NEXT は dispatch すべき軸 + round のリスト (最大 3 件)。各 axis に対し `Agent` tool で並列起動 (1 メッセージ複数 tool call):
+
+```javascript
+for (const {axis, round} of NEXT) {
+  Agent({
+    description: `axis ${axis} r${round}`,
+    subagent_type: "general-purpose",
+    prompt: readFile(`ai-skills/release-review/axes/${axis}.md`)
+      + `\n\n## このラウンドの追加 context\n`
+      + `- branch: ${BRANCH}\n`
+      + `- round: ${round}\n`
+      + `- previous rounds findings (本軸): ${prevFindingsCount} 件\n`
+      + `- output: 必ず .tmp/release-review/${BRANCH}/findings.jsonl に append (JSON Lines、1 line = 1 finding)\n`
+      + `- 完了条件: 軸の scope に対し新規発見が無くなったら "completed" status で終了\n`,
+    run_in_background: true,
+  });
+}
+```
+
+`run_in_background: true` で並列、完了通知は ScheduleWakeup の次回 fire 時に findings.jsonl 差分で検知。
+
+### 7. STATUS.md 更新 + 次 wake 予約
+
+```bash
+node ai-skills/release-review/scripts/orchestrator.mjs status-md --branch "${BRANCH}"
+# .tmp/release-review/<branch>/STATUS.md 再生成 (人間用 dashboard)
+```
+
+ScheduleWakeup で 30 分後の self-wake を予約:
+
+```javascript
+ScheduleWakeup({
+  delaySeconds: 1800,  // 30 分 (cache miss 1 回で長い wait、効率的)
+  reason: "release-review orchestrator next wake — aggregate + dispatch",
+  prompt: "/release-review --resume --branch " + BRANCH,
+});
+```
+
+## 失敗時の挙動
+
+各 step で例外発生時:
+
+- step 2-4 (aggregate / fix / issue): STOPPED.md に記録、orchestrator は次 wake を予約 (recoverable とみなす)
+- step 5-7 (停止判定 / dispatch / schedule): STOPPED.md に記録 + push notification、wake 予約しない (致命)
+
+## artifact 出力 spec
+
+### findings.jsonl (JSON Lines)
+
+各行が 1 finding:
+
+```json
+{"axis":"01-schema-spec-drift","round":1,"severity":"must","classification":"issue","file":"frontend/src/types/v3/screen.ts:123","title":"...","body":"...","fix_diff":null,"discovered_at":"2026-05-27T15:00:00.000Z"}
+```
+
+必須 field: `axis` / `round` / `severity` / `classification` / `title` / `body` / `discovered_at`。
+任意 field: `file` / `fix_diff` (auto-fix 時のみ) / `evidence_paths`.
+
+### state.json
+
+```json
+{
+  "branch": "feat/release-review-20260527",
+  "started_at": "2026-05-27T14:00:00.000Z",
+  "max_hours": 36,
+  "max_issues": null,
+  "stop_flag": false,
+  "stop_reason": null,
+  "axes": {
+    "01-schema-spec-drift": {"round": 2, "status": "completed", "consecutive_zero": 1, "last_findings": 3},
+    "...": {}
+  },
+  "consecutive_global_zero_rounds": 0,
+  "issued_count": 12,
+  "auto_fix_count": 27
+}
+```
+
+### STATUS.md (人間用 dashboard、各 wake で再生成)
+
+```markdown
+# release-review status — feat/release-review-20260527
+
+Started: 2026-05-27 14:00 UTC (elapsed: 8h 22m)
+Stop flag: false (枯渇 0/3 巡 / max-hours 8.4/36h)
+
+## 軸別進捗
+
+| 軸 | round | status | last findings | total |
+|---|---|---|---|---|
+| 01 schema-spec-drift | 2 | completed | 3 | 7 |
+| ... |
+
+## 直近 actions
+
+- 14:30 auto-fix commit ad12345 — fix(docs): typo in schema-v3-design.md
+- 14:45 issue #2001 created — release-review: type-contract findings
+- ...
+```

--- a/ai-skills/release-review/orchestrator-briefing.md
+++ b/ai-skills/release-review/orchestrator-briefing.md
@@ -24,10 +24,10 @@ state.json から以下を取得:
 前回 wake で dispatch した axis Agent が完了して `findings.jsonl` に書き込んでいる可能性。差分を分類:
 
 ```bash
-node ai-skills/release-review/scripts/orchestrator.mjs aggregate \
-  --branch "${BRANCH}" \
-  --since-last-wake
+node ai-skills/release-review/scripts/orchestrator.mjs aggregate --branch "${BRANCH}"
 ```
+
+aggregate は state.json の `last_processed_index` (per-axis) を参照して既処理 finding を skip する。「前回 wake 以降」の概念は内部 index で自動管理されるため、明示フラグは不要。
 
 aggregate は各 finding を以下に振り分け:
 
@@ -54,6 +54,7 @@ apply-fix は内部で:
 3. tsc + vitest で smoke 確認 (失敗時は rollback + issue 降格)
 4. `git commit -m "fix(<axis>): <title> (release-review auto-fix)"`
 5. auto-fixes.log に追記
+6. `node scripts/orchestrator.mjs increment-count --branch ${BRANCH} --field auto_fix_count` で state に反映
 
 ### 4. ISSUE 起票
 
@@ -76,6 +77,15 @@ gh issue create --title "spec-pending: <title> (release-review)" \
   --label "release-review,spec-pending,blocked" \
   --body "<schema 変更 or 振る舞い変更の必要性 + 影響範囲>"
 ```
+
+ISSUE 起票後 (集約 ISSUE の新規作成 / spec-pending 個別起票どちらも) は必ず:
+
+```bash
+node ai-skills/release-review/scripts/orchestrator.mjs increment-count \
+  --branch "${BRANCH}" --field issued_count
+```
+
+を実行して state.issued_count を反映。`--max-issues` cap (safety-rails) はこの値で評価される。集約 ISSUE への sub-section 追記は新規 ISSUE ではないため increment しない。
 
 ### 5. 停止条件チェック
 

--- a/ai-skills/release-review/safety-rails.md
+++ b/ai-skills/release-review/safety-rails.md
@@ -1,0 +1,157 @@
+# Safety rails — destructive 検出 + self-stop
+
+24h 規模で自律稼働する skill のため、暴走時の被害を最小化する。AI が「これ位なら」と勝手に判断して main 汚染 / 履歴破壊 / 設計者の意図しない schema 変更 を起こさないよう、orchestrator が **必ず check + 即停止** する。
+
+## 自動停止トリガー (即時 self-stop)
+
+orchestrator は各 step の前後で以下を check し、いずれか引っ掛かれば **その wake で finalize、次 wake を予約しない**。
+
+### 1. commit サイズ guard
+
+```bash
+# auto-fix 試行直後
+DIFF_LINES=$(git diff HEAD~1 HEAD --stat | tail -1 | grep -oE "[0-9]+ insert" | head -1 | grep -oE "[0-9]+")
+if [[ ${DIFF_LINES:-0} -gt 200 ]]; then
+  # → 即 self-stop
+fi
+```
+
+200 行超の diff は auto-fix が classification を誤判定した可能性が高い (本来 issue 級)。
+
+### 2. schemas/v3/*.json 変更検出
+
+```bash
+# auto-fix commit 直後
+git diff HEAD~1 HEAD --name-only | grep -E "^schemas/v3/.*\.json$" && \
+  # → 即 self-stop + 当該 commit を revert
+```
+
+schemas/v3/*.json は #511 governance により AI 単独修正禁止。orchestrator が auto-fix で touch するのは絶対 NG。
+
+### 3. destructive git command 試行
+
+orchestrator script (scripts/orchestrator.mjs) は以下の command を絶対に発行しない:
+
+- `git push --force` / `--force-with-lease`
+- `git reset --hard`
+- `git checkout -- <path>` (uncommitted を捨てる)
+- `git clean -f`
+- `git branch -D` / `git tag -d`
+- `rm -rf` (Bash 経由含む)
+
+apply-fix worker (Agent dispatch 側) でも禁止。Agent briefing で明示。
+
+### 4. push 先 branch 確認
+
+```bash
+CURRENT=$(git rev-parse --abbrev-ref HEAD)
+if [[ "${CURRENT}" == "main" ]] || [[ "${CURRENT}" == "master" ]]; then
+  # → 即 self-stop
+fi
+```
+
+`release-review` 隔離 branch 以外への commit は禁止。worktree 経由で main HEAD が動いていた等の事故防止。
+
+### 5. ISSUE 起票数 cap (--max-issues 指定時のみ)
+
+```bash
+if [[ -n "${MAX_ISSUES}" ]] && [[ "${ISSUED_COUNT}" -ge "${MAX_ISSUES}" ]]; then
+  # → 自然停止 (ユーザー指定の hard cap)
+fi
+```
+
+### 6. wall-clock cap (--max-hours)
+
+```bash
+ELAPSED_SEC=$(($(date +%s) - ${STARTED_AT_SEC}))
+if [[ $((ELAPSED_SEC / 3600)) -ge ${MAX_HOURS:-36} ]]; then
+  # → 自然停止
+fi
+```
+
+default 36h、ユーザー指定可。budget hard cap。
+
+### 7. 並列 Agent 異常終了率
+
+```bash
+# 連続 3 wake で dispatch した Agent の 50% 以上が errored / timeout なら
+if [[ ${RECENT_ERROR_RATE:-0} -gt 50 ]]; then
+  # → self-stop (infra 異常の可能性)
+fi
+```
+
+network / API rate limit / token exhaustion 等の外部要因疑い。
+
+## 停止時の挙動
+
+self-stop 発火時、orchestrator は以下を順に実行:
+
+1. **state.json に stop_flag=true + stop_reason 記録**
+2. **STOPPED.md を ${ART_DIR}/STOPPED.md に書く**:
+
+   ```markdown
+   # release-review STOPPED — feat/release-review-20260527
+
+   Stopped at: 2026-05-27 22:15 UTC (elapsed: 8h 15m)
+   Reason: schema_governance_violation (auto-fix commit ad12345 が schemas/v3/screen.v3.schema.json を変更)
+
+   ## 取った緊急対応
+   - commit ad12345 を `git revert ad12345 --no-edit` で revert
+   - 当該 finding を issue 起票に降格 (issue #2042)
+
+   ## 統計 (停止時点)
+   - 経過時間: 8h 15m
+   - 完了 round: 14 / 24 (8 軸 × 3 巡)
+   - auto-fix 累計: 23 commits
+   - ISSUE 起票累計: 9 件 (release-review-issue: 7, spec-pending: 2)
+
+   ## 次のアクション (ユーザー判断)
+   - [ ] STOPPED.md の停止理由を確認
+   - [ ] revert commit ad12345 が正しいか確認
+   - [ ] 残り 10 round を再開するか、ここで打ち切るか判断
+   - [ ] 再開する場合: `/release-review --resume --branch feat/release-review-20260527 --bypass schema_governance_violation`
+   ```
+
+3. **PushNotification 送信** (ツール利用可能なら):
+
+   ```javascript
+   PushNotification({
+     title: "release-review stopped",
+     body: `Reason: ${stop_reason}. See ${ART_DIR}/STOPPED.md`,
+     priority: "high",
+   });
+   ```
+
+4. **PR 作成** (auto-fix commit が残っている場合):
+
+   ```bash
+   gh pr create --title "chore(release-review): partial findings bundle (stopped)" \
+     --body-file ${ART_DIR}/STOPPED.md \
+     --draft  # draft 状態でユーザーレビュー待ち
+   ```
+
+5. **ScheduleWakeup を発行しない** (自己再帰停止)。
+
+## ユーザー側の再開手段
+
+ユーザーが STOPPED.md を読んで再開判断したら:
+
+```bash
+# 通常再開 (停止原因が解消済の場合)
+/release-review --resume --branch feat/release-review-20260527
+
+# 特定の safety rail を一時 bypass (要注意、明示的 opt-out)
+/release-review --resume --branch <name> --bypass <reason_key>
+
+# fresh start (state.json を初期化、軸を再走)
+/release-review --restart --branch <name>
+```
+
+`--bypass` は **本 wake 限定**。次 wake 以降の safety rail は通常通り有効に戻る。
+
+## 設計の意図
+
+- **fail-loud > fail-silent**: 異常時は AI 自己判断で「リカバリ」せず、ユーザーに判断を求める
+- **revert 容易性 > 進行速度**: 1 fix = 1 commit、隔離 branch、PR 経由で main 取り込みを徹底
+- **trace 完全性**: STOPPED.md / state.json / findings.jsonl / auto-fixes.log / issues.log を全て残す
+- **再開可能性**: 停止しても state.json で再開可、再開時は前回 state を尊重 (重複起票防止)

--- a/ai-skills/release-review/scripts/orchestrator.mjs
+++ b/ai-skills/release-review/scripts/orchestrator.mjs
@@ -1,0 +1,448 @@
+#!/usr/bin/env node
+/**
+ * release-review orchestrator script (pure node, no deps)
+ *
+ * 各 subcommand を Bash 経由で呼び出して state.json / findings.jsonl を操作する。
+ * 呼出側 (本 skill SKILL.md / orchestrator-briefing.md) は本 script の出力を JSON で受け取る。
+ *
+ * Usage:
+ *   node orchestrator.mjs init --branch <name> [--max-hours N] [--max-issues N] [--exclude-axes csv]
+ *   node orchestrator.mjs status --branch <name>           # state.json を JSON で出力
+ *   node orchestrator.mjs status-md --branch <name>        # STATUS.md を再生成
+ *   node orchestrator.mjs aggregate --branch <name>        # 未分類 findings を分類して pending-* に振り分け
+ *   node orchestrator.mjs next --branch <name> --slots N   # 次 dispatch すべき axis list を JSON 出力
+ *   node orchestrator.mjs check-stop --branch <name>       # 停止条件評価、true/false を stdout に
+ *   node orchestrator.mjs finalize --branch <name>         # STOPPED.md 生成 + 統計出力
+ *   node orchestrator.mjs ingest-finding --branch <name> --json '<finding json>'
+ *                                                          # Agent からの追加 finding を手動 push (主に test 用)
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync, appendFileSync, readdirSync } from "node:fs";
+import { join, dirname, resolve } from "node:path";
+
+const AXES = [
+  "01-schema-spec-drift",
+  "02-process-flow-runtime",
+  "03-type-contract",
+  "04-backend-storage",
+  "05-frontend-store",
+  "06-test-coverage",
+  "07-security",
+  "08-dogfood-smoke",
+];
+
+const ZERO_ROUNDS_TO_STOP = 3;  // 3 巡連続 0 件で軸 completed
+const DEFAULT_MAX_HOURS = 36;
+
+function artDir(branch) {
+  return resolve(".tmp/release-review", branch);
+}
+
+function statePath(branch) {
+  return join(artDir(branch), "state.json");
+}
+
+function findingsPath(branch) {
+  return join(artDir(branch), "findings.jsonl");
+}
+
+function loadState(branch) {
+  const p = statePath(branch);
+  if (!existsSync(p)) {
+    throw new Error(`state.json not found: ${p}. Run 'init' first.`);
+  }
+  return JSON.parse(readFileSync(p, "utf-8"));
+}
+
+function saveState(branch, state) {
+  const p = statePath(branch);
+  mkdirSync(dirname(p), { recursive: true });
+  writeFileSync(p, JSON.stringify(state, null, 2));
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const next = argv[i + 1];
+      if (!next || next.startsWith("--")) {
+        args[key] = true;
+      } else {
+        args[key] = next;
+        i++;
+      }
+    }
+  }
+  return args;
+}
+
+function cmdInit(args) {
+  const branch = args.branch || `feat/release-review-${new Date().toISOString().slice(0, 10).replace(/-/g, "")}`;
+  const maxHours = parseInt(args["max-hours"] || DEFAULT_MAX_HOURS, 10);
+  const maxIssues = args["max-issues"] && args["max-issues"] !== "0" ? parseInt(args["max-issues"], 10) : null;
+  const excludeAxes = (args["exclude-axes"] || "").split(",").filter(Boolean);
+
+  const state = {
+    branch,
+    started_at: new Date().toISOString(),
+    max_hours: maxHours,
+    max_issues: maxIssues,
+    excluded_axes: excludeAxes,
+    stop_flag: false,
+    stop_reason: null,
+    axes: {},
+    consecutive_global_zero_rounds: 0,
+    issued_count: 0,
+    auto_fix_count: 0,
+    last_wake_at: null,
+    last_dispatched_axes: [],
+  };
+
+  for (const axis of AXES) {
+    if (excludeAxes.includes(axis)) {
+      state.axes[axis] = { round: 0, status: "excluded", consecutive_zero: 0, last_findings: null, total_findings: 0 };
+    } else {
+      state.axes[axis] = { round: 0, status: "pending", consecutive_zero: 0, last_findings: null, total_findings: 0 };
+    }
+  }
+
+  mkdirSync(artDir(branch), { recursive: true });
+  saveState(branch, state);
+  // findings.jsonl を初期化 (空)
+  writeFileSync(findingsPath(branch), "");
+  // auto-fixes.log / issues.log も初期化
+  writeFileSync(join(artDir(branch), "auto-fixes.log"), "");
+  writeFileSync(join(artDir(branch), "issues.log"), "");
+
+  console.log(JSON.stringify({ ok: true, branch, art_dir: artDir(branch) }));
+}
+
+function cmdStatus(args) {
+  const state = loadState(args.branch);
+  console.log(JSON.stringify(state));
+}
+
+function readFindings(branch) {
+  const p = findingsPath(branch);
+  if (!existsSync(p)) return [];
+  return readFileSync(p, "utf-8")
+    .split("\n")
+    .filter((l) => l.trim())
+    .map((l) => {
+      try { return JSON.parse(l); } catch { return null; }
+    })
+    .filter(Boolean);
+}
+
+function cmdAggregate(args) {
+  const state = loadState(args.branch);
+  const findings = readFindings(args.branch);
+
+  // state.axes[axis].last_processed_index で「ここまで処理済」を管理
+  // findings.jsonl の append-only 順序を信頼して index 比較
+  const pendingAutofix = [];
+  const pendingIssue = [];
+  const pendingSpecPending = [];
+
+  // axis 毎に新規 finding を集計
+  const newFindingsByAxis = {};
+  for (const axis of Object.keys(state.axes)) {
+    newFindingsByAxis[axis] = 0;
+  }
+
+  for (let i = 0; i < findings.length; i++) {
+    const f = findings[i];
+    const ax = state.axes[f.axis];
+    if (!ax) continue;
+    const lastIdx = ax.last_processed_index ?? -1;
+    if (i <= lastIdx) continue;  // 既処理 skip
+
+    switch (f.classification) {
+      case "auto-fix":
+        pendingAutofix.push(f);
+        break;
+      case "issue":
+        pendingIssue.push(f);
+        break;
+      case "spec-pending":
+        pendingSpecPending.push(f);
+        break;
+      default:
+        pendingIssue.push({ ...f, classification: "issue", _defaulted: true });
+    }
+
+    newFindingsByAxis[f.axis]++;
+    ax.total_findings = (ax.total_findings || 0) + 1;
+    ax.last_processed_index = i;
+  }
+
+  // dispatched axis に対し new findings 数を反映、consecutive_zero / status を更新
+  for (const [axis, ax] of Object.entries(state.axes)) {
+    if (ax.status !== "dispatched") continue;
+    const cnt = newFindingsByAxis[axis] || 0;
+    ax.last_findings = cnt;
+    if (cnt === 0) {
+      ax.consecutive_zero = (ax.consecutive_zero || 0) + 1;
+    } else {
+      ax.consecutive_zero = 0;
+    }
+    // 枯渇判定: 3 連続 0 件で completed
+    if (ax.consecutive_zero >= ZERO_ROUNDS_TO_STOP) {
+      ax.status = "completed";
+    } else {
+      ax.status = "pending";  // 次 dispatch 可能状態に戻す
+    }
+  }
+
+  // pending queue を file 出力
+  writeFileSync(
+    join(artDir(args.branch), "pending-autofix.jsonl"),
+    pendingAutofix.map((f) => JSON.stringify(f)).join("\n") + (pendingAutofix.length ? "\n" : ""),
+  );
+  writeFileSync(
+    join(artDir(args.branch), "pending-issue.jsonl"),
+    pendingIssue.map((f) => JSON.stringify(f)).join("\n") + (pendingIssue.length ? "\n" : ""),
+  );
+  writeFileSync(
+    join(artDir(args.branch), "pending-spec-pending.jsonl"),
+    pendingSpecPending.map((f) => JSON.stringify(f)).join("\n") + (pendingSpecPending.length ? "\n" : ""),
+  );
+
+  saveState(args.branch, state);
+
+  console.log(JSON.stringify({
+    autofix: pendingAutofix.length,
+    issue: pendingIssue.length,
+    spec_pending: pendingSpecPending.length,
+  }));
+}
+
+function cmdNext(args) {
+  const state = loadState(args.branch);
+  const slots = parseInt(args.slots || 3, 10);
+
+  if (state.stop_flag) {
+    console.log(JSON.stringify([]));
+    return;
+  }
+
+  // 次 dispatch すべき axis を選ぶ:
+  //   - status != excluded && status != completed
+  //   - consecutive_zero < ZERO_ROUNDS_TO_STOP
+  //   - 重い軸 (08) は同時 1 本固定
+  const candidates = [];
+  for (const [axis, ax] of Object.entries(state.axes)) {
+    if (ax.status === "excluded" || ax.status === "completed") continue;
+    if (ax.consecutive_zero >= ZERO_ROUNDS_TO_STOP) {
+      // この axis は枯渇判定 → completed
+      ax.status = "completed";
+      continue;
+    }
+    candidates.push({ axis, current_round: ax.round, priority: heavyAxisPriority(axis) });
+  }
+
+  // priority 順 (重い軸を後回し or 単独) でソート
+  candidates.sort((a, b) => a.priority - b.priority);
+
+  // 8 軸の dogfood-smoke (heavy) は単独 dispatch 推奨
+  const next = [];
+  let heavyInSlot = false;
+  for (const c of candidates) {
+    if (next.length >= slots) break;
+    if (c.axis === "08-dogfood-smoke") {
+      if (next.length > 0) continue;  // 他軸と並列しない
+      next.push({ axis: c.axis, round: c.current_round + 1 });
+      heavyInSlot = true;
+      break;
+    }
+    if (heavyInSlot) break;
+    next.push({ axis: c.axis, round: c.current_round + 1 });
+  }
+
+  // 各 axis の status を dispatched に
+  for (const { axis, round } of next) {
+    state.axes[axis].status = "dispatched";
+    state.axes[axis].round = round;
+    state.axes[axis].last_findings = 0;  // 新 round の findings カウント開始
+  }
+
+  state.last_wake_at = new Date().toISOString();
+  state.last_dispatched_axes = next.map((n) => n.axis);
+  saveState(args.branch, state);
+
+  console.log(JSON.stringify(next));
+}
+
+function heavyAxisPriority(axis) {
+  if (axis === "08-dogfood-smoke") return 100;
+  if (axis === "02-process-flow-runtime") return 50;
+  return 10;
+}
+
+function cmdCheckStop(args) {
+  const state = loadState(args.branch);
+
+  if (state.stop_flag) {
+    console.log(JSON.stringify({ stop: true, reason: state.stop_reason }));
+    return;
+  }
+
+  // wall-clock cap
+  const elapsed = (Date.now() - new Date(state.started_at).getTime()) / 1000 / 3600;
+  if (elapsed >= state.max_hours) {
+    state.stop_flag = true;
+    state.stop_reason = `max_hours_cap (${elapsed.toFixed(1)}h >= ${state.max_hours}h)`;
+    saveState(args.branch, state);
+    console.log(JSON.stringify({ stop: true, reason: state.stop_reason }));
+    return;
+  }
+
+  // max-issues cap
+  if (state.max_issues !== null && state.issued_count >= state.max_issues) {
+    state.stop_flag = true;
+    state.stop_reason = `max_issues_cap (${state.issued_count} >= ${state.max_issues})`;
+    saveState(args.branch, state);
+    console.log(JSON.stringify({ stop: true, reason: state.stop_reason }));
+    return;
+  }
+
+  // 全 axis が completed or excluded か
+  const remaining = Object.entries(state.axes).filter(
+    ([_, ax]) => ax.status !== "completed" && ax.status !== "excluded"
+  );
+  if (remaining.length === 0) {
+    state.stop_flag = true;
+    state.stop_reason = "all_axes_completed";
+    saveState(args.branch, state);
+    console.log(JSON.stringify({ stop: true, reason: state.stop_reason }));
+    return;
+  }
+
+  console.log(JSON.stringify({ stop: false, remaining_axes: remaining.length, elapsed_hours: elapsed.toFixed(2) }));
+}
+
+function cmdFinalize(args) {
+  const state = loadState(args.branch);
+  const findings = readFindings(args.branch);
+  const branch = args.branch;
+
+  const totalFindings = findings.length;
+  const byClass = findings.reduce((acc, f) => {
+    acc[f.classification] = (acc[f.classification] || 0) + 1;
+    return acc;
+  }, {});
+  const bySeverity = findings.reduce((acc, f) => {
+    acc[f.severity] = (acc[f.severity] || 0) + 1;
+    return acc;
+  }, {});
+
+  const elapsed = ((Date.now() - new Date(state.started_at).getTime()) / 1000 / 3600).toFixed(2);
+
+  const md = `# release-review STOPPED — ${branch}
+
+Started: ${state.started_at}
+Stopped: ${new Date().toISOString()} (elapsed: ${elapsed}h)
+Reason: ${state.stop_reason || "n/a"}
+
+## 統計
+
+- 総 findings: ${totalFindings}
+- by classification: ${JSON.stringify(byClass)}
+- by severity: ${JSON.stringify(bySeverity)}
+- auto-fix commits: ${state.auto_fix_count}
+- issues 起票: ${state.issued_count}
+
+## 軸別
+
+${Object.entries(state.axes).map(([axis, ax]) =>
+  `- ${axis}: round=${ax.round} status=${ax.status} total=${ax.total_findings || 0}`
+).join("\n")}
+
+## 次のアクション (ユーザー判断)
+
+- [ ] 本 STOPPED.md の停止理由を確認
+- [ ] auto-fix commit 一覧を \`cat .tmp/release-review/${branch}/auto-fixes.log\` で確認
+- [ ] 起票 ISSUE 一覧を \`gh issue list --label release-review --state open\` で確認
+- [ ] 再開する場合: \`/release-review --resume --branch ${branch}\`
+- [ ] 中止する場合: branch を削除 or PR を draft のまま放置
+`;
+
+  writeFileSync(join(artDir(branch), "STOPPED.md"), md);
+  console.log(JSON.stringify({ ok: true, stopped_md: join(artDir(branch), "STOPPED.md"), stats: { totalFindings, byClass, bySeverity } }));
+}
+
+function cmdStatusMd(args) {
+  const state = loadState(args.branch);
+  const findings = readFindings(args.branch);
+  const elapsed = ((Date.now() - new Date(state.started_at).getTime()) / 1000 / 3600).toFixed(2);
+
+  const recentActions = [];
+  // auto-fixes.log と issues.log の末尾を取り込む
+  for (const log of ["auto-fixes.log", "issues.log"]) {
+    const p = join(artDir(args.branch), log);
+    if (existsSync(p)) {
+      const lines = readFileSync(p, "utf-8").split("\n").filter((l) => l.trim()).slice(-5);
+      recentActions.push(...lines.map((l) => `[${log}] ${l}`));
+    }
+  }
+
+  const md = `# release-review status — ${args.branch}
+
+Started: ${state.started_at} (elapsed: ${elapsed}h / ${state.max_hours}h cap)
+Stop flag: ${state.stop_flag} ${state.stop_reason ? `(reason: ${state.stop_reason})` : ""}
+
+## 軸別進捗
+
+| 軸 | round | status | last findings | total | consec_zero |
+|---|---|---|---|---|---|
+${Object.entries(state.axes).map(([axis, ax]) =>
+  `| ${axis} | ${ax.round} | ${ax.status} | ${ax.last_findings ?? "-"} | ${ax.total_findings || 0} | ${ax.consecutive_zero || 0} |`
+).join("\n")}
+
+## 全体統計
+
+- Total findings: ${findings.length}
+- auto-fix commits: ${state.auto_fix_count}
+- ISSUE 起票: ${state.issued_count}
+- last wake: ${state.last_wake_at || "n/a"}
+- last dispatched axes: ${(state.last_dispatched_axes || []).join(", ") || "(none)"}
+
+## 直近 actions (auto-fix / ISSUE)
+
+${recentActions.length ? recentActions.join("\n") : "(none yet)"}
+`;
+
+  writeFileSync(join(artDir(args.branch), "STATUS.md"), md);
+  console.log(JSON.stringify({ ok: true, path: join(artDir(args.branch), "STATUS.md") }));
+}
+
+function cmdIngestFinding(args) {
+  // 主に dry-run test 用、Agent 側は直接 findings.jsonl に append する想定
+  const branch = args.branch;
+  if (!existsSync(artDir(branch))) throw new Error(`branch dir not initialized: ${branch}`);
+  const f = JSON.parse(args.json);
+  if (!f.discovered_at) f.discovered_at = new Date().toISOString();
+  appendFileSync(findingsPath(branch), JSON.stringify(f) + "\n");
+  console.log(JSON.stringify({ ok: true, finding: f }));
+}
+
+// ── dispatch ──
+const [, , cmd, ...rest] = process.argv;
+const args = parseArgs(rest);
+
+switch (cmd) {
+  case "init": cmdInit(args); break;
+  case "status": cmdStatus(args); break;
+  case "status-md": cmdStatusMd(args); break;
+  case "aggregate": cmdAggregate(args); break;
+  case "next": cmdNext(args); break;
+  case "check-stop": cmdCheckStop(args); break;
+  case "finalize": cmdFinalize(args); break;
+  case "ingest-finding": cmdIngestFinding(args); break;
+  default:
+    console.error(`Unknown command: ${cmd}`);
+    console.error(`Usage: node orchestrator.mjs <init|status|status-md|aggregate|next|check-stop|finalize|ingest-finding> [--args]`);
+    process.exit(1);
+}

--- a/ai-skills/release-review/scripts/orchestrator.mjs
+++ b/ai-skills/release-review/scripts/orchestrator.mjs
@@ -15,6 +15,9 @@
  *   node orchestrator.mjs finalize --branch <name>         # STOPPED.md 生成 + 統計出力
  *   node orchestrator.mjs ingest-finding --branch <name> --json '<finding json>'
  *                                                          # Agent からの追加 finding を手動 push (主に test 用)
+ *   node orchestrator.mjs increment-count --branch <name> --field <issued_count|auto_fix_count> [--by N]
+ *                                                          # state.json の counter を atomic に increment
+ *                                                          # (ISSUE 起票後 / auto-fix commit 後に呼ぶ、max-issues cap で必要)
  */
 
 import { readFileSync, writeFileSync, existsSync, mkdirSync, appendFileSync, readdirSync } from "node:fs";
@@ -93,12 +96,13 @@ function cmdInit(args) {
     stop_flag: false,
     stop_reason: null,
     axes: {},
-    consecutive_global_zero_rounds: 0,
     issued_count: 0,
     auto_fix_count: 0,
     last_wake_at: null,
     last_dispatched_axes: [],
   };
+  // 注: issued_count / auto_fix_count は AI が gh issue create / git commit を実行した直後に
+  // `increment-count --field <name>` で更新する。`--max-issues` cap はこの値を参照する。
 
   for (const axis of AXES) {
     if (excludeAxes.includes(axis)) {
@@ -418,6 +422,19 @@ ${recentActions.length ? recentActions.join("\n") : "(none yet)"}
   console.log(JSON.stringify({ ok: true, path: join(artDir(args.branch), "STATUS.md") }));
 }
 
+function cmdIncrementCount(args) {
+  const branch = args.branch;
+  const field = args.field;
+  const by = parseInt(args.by || 1, 10);
+  if (!["issued_count", "auto_fix_count"].includes(field)) {
+    throw new Error(`field must be one of: issued_count, auto_fix_count`);
+  }
+  const state = loadState(branch);
+  state[field] = (state[field] || 0) + by;
+  saveState(branch, state);
+  console.log(JSON.stringify({ ok: true, field, new_value: state[field] }));
+}
+
 function cmdIngestFinding(args) {
   // 主に dry-run test 用、Agent 側は直接 findings.jsonl に append する想定
   const branch = args.branch;
@@ -441,8 +458,9 @@ switch (cmd) {
   case "check-stop": cmdCheckStop(args); break;
   case "finalize": cmdFinalize(args); break;
   case "ingest-finding": cmdIngestFinding(args); break;
+  case "increment-count": cmdIncrementCount(args); break;
   default:
     console.error(`Unknown command: ${cmd}`);
-    console.error(`Usage: node orchestrator.mjs <init|status|status-md|aggregate|next|check-stop|finalize|ingest-finding> [--args]`);
+    console.error(`Usage: node orchestrator.mjs <init|status|status-md|aggregate|next|check-stop|finalize|ingest-finding|increment-count> [--args]`);
     process.exit(1);
 }


### PR DESCRIPTION
## Summary

リリース前限定の徹底自律レビュー skill `/release-review` を新設。8 軸 × 複数巡で repo をしらみつぶしに監査し、findings を auto-fix / 集約 ISSUE / spec-pending に分類して 24h 規模で自走、ユーザー睡眠中も /loop self-pace で進む。

## 機能 overview

### 8 軸

| # | 軸 | scope | 重さ |
|---|---|---|---|
| 01 | schema-spec-drift | schemas/*.json ↔ docs/spec/*.md ↔ TS 型 ↔ examples/* 四重照合 | 中 |
| 02 | process-flow-runtime | /review-flow 10 観点を全 examples 横断 | 重 |
| 03 | type-contract | brand drift / cast hack / `as any` を全 grep + sabotage | 中 |
| 04 | backend-storage | projectStorage の race / FS error path / lock immutability | 中 |
| 05 | frontend-store | autosave / fallback / localStorage 廃止後の残骸 | 軽 |
| 06 | test-coverage | public function vs vitest spec の網羅率、e2e click-path 抜け | 中 |
| 07 | security | path traversal / prototype pollution / runtime executor ban | 中 |
| 08 | dogfood-smoke | Playwright headless で全画面 navigate + console error 監視 | 重 |

### Classification

各 finding は Agent が以下を self-classify (orchestrator が二重検証):

- `auto-fix`: ≤30 行 diff + tsc/vitest 影響なし + 自明な修正 (typo / 言い換え / 例追加) → 即 commit
- `issue`: 1-3h で fix 可、人間 or 別 AI review 要 → 軸単位の集約 ISSUE に sub-section
- `spec-pending`: schemas/v3/*.json 変更 or 振る舞い変更 spec → 個別 ISSUE + `spec-pending` label + 着手禁止 marker

### Stop conditions

(1) 全 8 軸が 3 巡連続 0 件で自然停止
(2) wall-clock cap (default 36h、`--max-hours` で可変)
(3) destructive 検出 self-stop (schemas/*.json への commit / commit > 200 行 / force-push / rm -rf 兆候)
(4) max-issues cap (`--max-issues` 指定時)

### Safety rails

orchestrator が **必ず** 以下を check + 発火時 self-stop + STOPPED.md 生成 + PushNotification:

- schemas/v3/*.json への auto-fix commit 検出 → 即 revert + stop
- 単一 commit > 200 lines diff → stop
- destructive git command 試行 → stop
- main / master branch への commit 試行 → stop
- 並列 Agent 異常終了率 > 50% → stop (infra 異常)

### artifact

```
.tmp/release-review/<branch>/
  state.json            軸ごとの round / status / consecutive_zero
  findings.jsonl        全 findings (append-only、Agent が直接 append)
  STATUS.md             人間用 dashboard (各 wake で再生成)
  STOPPED.md            停止時のみ、停止理由 + 統計
  auto-fixes.log        commit history
  issues.log            gh issue create history
  pending-{autofix,issue,spec-pending}.jsonl   aggregate 後の作業 queue
```

## ファイル構成

```
ai-skills/release-review/
├── SKILL.md                       (entrypoint, 197 lines)
├── orchestrator-briefing.md       (各 wake の手順, 201 lines)
├── classification-rules.md        (134 lines)
├── safety-rails.md                (157 lines)
├── axes/
│   ├── 01-schema-spec-drift.md    (116 lines)
│   ├── 02-process-flow-runtime.md (88 lines)
│   ├── 03-type-contract.md        (100 lines)
│   ├── 04-backend-storage.md      (97 lines)
│   ├── 05-frontend-store.md       (86 lines)
│   ├── 06-test-coverage.md        (96 lines)
│   ├── 07-security.md             (100 lines)
│   └── 08-dogfood-smoke.md        (125 lines)
└── scripts/
    └── orchestrator.mjs           (448 lines, pure node no-deps)
```

symlink:
- `.claude/skills/release-review` → `../../ai-skills/release-review`
- `.agents/skills/release-review` → `../../ai-skills/release-review`

CLAUDE.md の skill 一覧にも追記。

## Dry-run verification

`scripts/orchestrator.mjs` を本 commit 前に以下シナリオで実機確認:

1. `init --branch dry-run-test --max-hours 1` で 8 軸 × round=0 / status=pending を初期化
2. `next --slots 3` で重さに応じた 3 軸 dispatch (heavy 軸 08 は単独 slot)
3. `ingest-finding` で fake finding を 3 種 (auto-fix / issue / spec-pending) 注入
4. `aggregate` で classification 別に pending-*.jsonl へ振り分け、axes 統計を更新
5. 0 件 round を 3 巡繰り返し → axes 7 個が `consecutive_zero=3` で `status=completed` に
6. 残り 1 軸 (08-dogfood-smoke) を 3 巡 → 全軸 completed
7. `check-stop` が `stop:true reason:all_axes_completed` を返す
8. `finalize` で STOPPED.md 生成 + 統計出力

dry-run 後 `.tmp/release-review/dry-run-test/` は cleanup 済。

## Closes

Closes #(N/A — リリース前限定 skill、独立 ISSUE は無し、本 PR で導入)

## Test plan

- [x] orchestrator.mjs lifecycle dry-run (init → next → ingest → aggregate → check-stop → finalize)
- [x] 8 軸 × 3 巡 連続 0 件 → all_axes_completed 自然停止 verify
- [x] dispatch slot heavy 軸単独固定 verify (08-dogfood-smoke が 03 と並列にならない)
- [x] symlink 動作 (`ls -la .claude/skills/release-review` / `.agents/skills/release-review`)
- [ ] 実機 kickoff は本 PR merge 後、別 PR (= 実際の release-review 走行) で行う

## 注意

本 skill は **リリース前期間限定** の運用想定。AGENTS.md の ISSUE 起票鉄則 (0-3) は本 skill 起動中のみ「結果として ISSUE 数増加が許容される」運用に切り替わるが、起票鉄則自体は変更しない (= リリース後は通常運用に戻る)。

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.7)