### PR TITLE
fix(e2e): #1342 残 7 pre-existing fail を 3 提案統合 PR で解消 (A: lockdown / B: step-ops / C: folder-picker)

### DIFF
--- a/backend/src/security/originCheck.test.ts
+++ b/backend/src/security/originCheck.test.ts
@@ -38,6 +38,18 @@ describe("checkRequestOrigin", () => {
     expect(checkRequestOrigin(req)).toBeNull();
   });
 
+  // #1342 Proposal A: lockdown e2e config (playwright.lockdown.config.ts) は
+  // 5183/5189 を使うため、5183 系 Origin も allowlist に含まれる。
+  it("正常: Origin あり + allowlist 内 (localhost:5183, lockdown e2e) → null", () => {
+    const req = makeReq({ origin: "http://localhost:5183", host: "localhost:5189" });
+    expect(checkRequestOrigin(req)).toBeNull();
+  });
+
+  it("正常: Origin あり + allowlist 内 (127.0.0.1:5183, lockdown e2e) → null", () => {
+    const req = makeReq({ origin: "http://127.0.0.1:5183", host: "localhost:5189" });
+    expect(checkRequestOrigin(req)).toBeNull();
+  });
+
   it("異常: Origin あり + allowlist 外 → 拒否文字列を返す", () => {
     const req = makeReq({ origin: "http://evil.com", host: "localhost:5179" });
     const result = checkRequestOrigin(req);

--- a/backend/src/security/originCheck.ts
+++ b/backend/src/security/originCheck.ts
@@ -16,6 +16,11 @@ import type { IncomingMessage } from "node:http";
 const ALLOWED_ORIGINS = new Set([
   "http://localhost:5173",
   "http://127.0.0.1:5173",
+  // #1342 Proposal A: lockdown e2e config (playwright.lockdown.config.ts) は main
+  // config (5173/5179) と port 衝突回避のため frontend=5183 / backend=5189 で起動する。
+  // localhost に閉じた dev/test 用 port のため allowlist に追加する。
+  "http://localhost:5183",
+  "http://127.0.0.1:5183",
 ]);
 
 // ホスト名のみで DNS rebinding を防ぐ (ポートは問わない)。

--- a/frontend/e2e/lockdown-routing.spec.ts
+++ b/frontend/e2e/lockdown-routing.spec.ts
@@ -9,9 +9,9 @@ import { lockdownWorkspacePath } from "./helpers/workspaceFixture.ts";
 const LOCKDOWN_WORKSPACE = lockdownWorkspacePath();
 
 test.describe("lockdown routing", { tag: ["@regression"] }, () => {
-  // #1342 Proposal A: seed は playwright.lockdown.config.ts の globalSetup
-  // (helpers/lockdownGlobalSetup.ts) に集約 (webServer 起動前に backend が必要とする
-  // harmony.json を配置する必要があるため、spec.beforeAll では間に合わない)。
+  // #1342 Proposal A: seed は playwright.lockdown.config.ts module 読込時の同期 fs
+  // API 呼び出しに集約 (webServer 起動前に backend が必要とする harmony.json を配置
+  // する必要があるため、spec.beforeAll や Playwright globalSetup では間に合わない)。
   // 本 spec は seed 結果に依存して動くだけで、自身では seed しない。
 
   test.afterAll(async () => {

--- a/frontend/e2e/lockdown-routing.spec.ts
+++ b/frontend/e2e/lockdown-routing.spec.ts
@@ -1,11 +1,7 @@
 import { test, expect } from "@playwright/test";
 import fs from "node:fs/promises";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { lockdownWorkspacePath } from "./helpers/workspaceFixture.ts";
 
-const THIS_DIR = path.dirname(fileURLToPath(import.meta.url));
-const REPO_ROOT = path.resolve(THIS_DIR, "../..");
 // #1359 Round 1 M-1: workspaceFixture.ts:lockdownWorkspacePath() は **worker index 非依存
 // の stable path** を返す。lockdown config (playwright.lockdown.config.ts) と本 spec の
 // path 構築を単一 source of truth に集約しつつ、controller process (`TEST_WORKER_INDEX`
@@ -13,11 +9,10 @@ const REPO_ROOT = path.resolve(THIS_DIR, "../..");
 const LOCKDOWN_WORKSPACE = lockdownWorkspacePath();
 
 test.describe("lockdown routing", { tag: ["@regression"] }, () => {
-  test.beforeAll(async () => {
-    await fs.rm(LOCKDOWN_WORKSPACE, { recursive: true, force: true });
-    await fs.mkdir(path.dirname(LOCKDOWN_WORKSPACE), { recursive: true });
-    await fs.cp(path.join(REPO_ROOT, "examples", "retail"), LOCKDOWN_WORKSPACE, { recursive: true });
-  });
+  // #1342 Proposal A: seed は playwright.lockdown.config.ts の globalSetup
+  // (helpers/lockdownGlobalSetup.ts) に集約 (webServer 起動前に backend が必要とする
+  // harmony.json を配置する必要があるため、spec.beforeAll では間に合わない)。
+  // 本 spec は seed 結果に依存して動くだけで、自身では seed しない。
 
   test.afterAll(async () => {
     await fs.rm(LOCKDOWN_WORKSPACE, { recursive: true, force: true });

--- a/frontend/e2e/step-ops.spec.ts
+++ b/frontend/e2e/step-ops.spec.ts
@@ -133,13 +133,19 @@ test.describe("ステップツールバーから追加 (#246)", { tag: ["@regres
 });
 
 test.describe("ステップコンテキストメニュー (#246)", { tag: ["@regression"] }, () => {
+  // #1342: Playwright `.click()` が dnd-kit useSortable 環境下の menu item に対し React
+  // synthetic onClick を発火させない事象を確認 (実機調査: JS `(button).click()` /
+  // `.dispatchEvent('click')` は OK、Playwright pointer event 経路だけ silent fail)。
+  // 暫定対処として memory `feedback_playwright_key_dispatch.md` と同パターンの
+  // dispatchEvent fallback を採用。
   test("メニューから複製で 4 ステップに", async ({ page }) => {
     await setupEditor(page);
     // 1 つ目の card の ・・・ メニューを開く
     const firstCard = page.locator(".step-card").first();
     await firstCard.locator(".step-card-menu-btn").last().click();
-    // 複製 メニュー項目クリック
-    await page.getByRole("button", { name: /複製/ }).first().click();
+    await expect(page.locator(".step-context-menu")).toBeVisible();
+    // 複製 メニュー項目クリック (dispatchEvent fallback / 上記理由参照)
+    await page.getByRole("button", { name: /複製/ }).first().dispatchEvent("click");
     // 4 ステップに増える
     await expect(page.locator(".step-card")).toHaveCount(4);
   });
@@ -148,7 +154,8 @@ test.describe("ステップコンテキストメニュー (#246)", { tag: ["@reg
     await setupEditor(page);
     const firstCard = page.locator(".step-card").first();
     await firstCard.locator(".step-card-menu-btn").last().click();
-    await page.getByRole("button", { name: /削除/ }).first().click();
+    await expect(page.locator(".step-context-menu")).toBeVisible();
+    await page.getByRole("button", { name: /削除/ }).first().dispatchEvent("click");
     // ghost にはならず、即削除
     await expect(page.locator(".step-card")).toHaveCount(2);
   });

--- a/frontend/e2e/workspace-folder-picker.spec.ts
+++ b/frontend/e2e/workspace-folder-picker.spec.ts
@@ -13,6 +13,7 @@ import { test, expect, type Page } from "@playwright/test";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { folderPickerFixtureRoot } from "./helpers/workspaceFixture.ts";
+import { sendBrowserRequest } from "./helpers/realWorkspace.ts";
 
 // #1359: worker prefix 付き fixture root (`.tmp/e2e-folder-picker/w<idx>-root/`)。
 // workers > 1 で複数 worker が同 path に同時 write した時の race を回避する。
@@ -20,6 +21,24 @@ const FIXTURE_ROOT = folderPickerFixtureRoot();
 const FIXTURE_WS_A = path.join(FIXTURE_ROOT, "ws-a");
 const FIXTURE_WS_B = path.join(FIXTURE_ROOT, "ws-b");
 const FIXTURE_NOT_WS = path.join(FIXTURE_ROOT, "not-a-workspace");
+
+// #1342 Proposal C: backend が `HARMONY_ALLOWED_BROWSE_ROOTS` で `.tmp/*` を許可
+// していないと folder-picker browseFs が「アクセスが許可されていないパス」で reject
+// される。Playwright が backend を起動する場合は config の env で渡しているが、
+// 既存 backend を `reuseExistingServer: true` で reuse する場合は env が引き継がれず
+// 引っかかる。test 開始前に probe して、許可されていない環境では graceful に skip する。
+async function probeFolderPickerAllowed(): Promise<boolean> {
+  try {
+    await sendBrowserRequest("workspace.browseFs", { path: FIXTURE_ROOT });
+    return true;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    // permission code または "アクセスが許可されていない" メッセージで判定
+    if (/permission|アクセスが許可されていない/.test(msg)) return false;
+    // フォルダ未作成 (ensureFixture 前の probe) は許可有り扱い (上位 testで再現される)
+    return true;
+  }
+}
 
 async function ensureFixture(): Promise<void> {
   await fs.mkdir(FIXTURE_WS_A, { recursive: true });
@@ -63,7 +82,23 @@ async function openFolderPicker(page: Page, initialPath: string): Promise<void> 
 }
 
 test.describe("AddWorkspaceDialog — BackendFolderPicker (#1056)", { tag: ["@regression"] }, () => {
+  let folderPickerAllowed = false;
+
+  test.beforeAll(async () => {
+    await ensureFixture();
+    folderPickerAllowed = await probeFolderPickerAllowed();
+  });
+
   test.beforeEach(async () => {
+    // #1342 Proposal C: backend が HARMONY_ALLOWED_BROWSE_ROOTS で .tmp/* を許可
+    // していない場合 (= 既存 backend reuse で env 不足) は graceful skip。
+    // Playwright が backend を起動する経路では env で渡しているため通過する。
+    test.skip(
+      !folderPickerAllowed,
+      "backend `HARMONY_ALLOWED_BROWSE_ROOTS` に .tmp/* が含まれていません。" +
+      "Playwright config の webServer env を反映するため backend を再起動するか、" +
+      "手動起動時は `HARMONY_ALLOWED_BROWSE_ROOTS=/workspaces/harmony:/tmp` を付けて起動してください。",
+    );
     await ensureFixture();
   });
 

--- a/frontend/e2e/workspace-folder-picker.spec.ts
+++ b/frontend/e2e/workspace-folder-picker.spec.ts
@@ -95,9 +95,10 @@ test.describe("AddWorkspaceDialog — BackendFolderPicker (#1056)", { tag: ["@re
     // Playwright が backend を起動する経路では env で渡しているため通過する。
     test.skip(
       !folderPickerAllowed,
-      "backend `HARMONY_ALLOWED_BROWSE_ROOTS` に .tmp/* が含まれていません。" +
-      "Playwright config の webServer env を反映するため backend を再起動するか、" +
-      "手動起動時は `HARMONY_ALLOWED_BROWSE_ROOTS=/workspaces/harmony:/tmp` を付けて起動してください。",
+      "backend `HARMONY_ALLOWED_BROWSE_ROOTS` に repo root の .tmp/* が含まれていません。" +
+      "Playwright config の webServer env (動的算出: repo root + /tmp) を反映するため " +
+      "backend を再起動するか、手動起動時は環境に合わせて " +
+      "`HARMONY_ALLOWED_BROWSE_ROOTS=<repo root>:/tmp` を付けて起動してください。",
     );
     await ensureFixture();
   });

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig, devices } from "@playwright/test";
 
 // worktree 環境では VITE_PORT で別 port を指定可能 (#703 R-5 D-2 port 競合解決)
@@ -5,6 +7,14 @@ const VITE_PORT = parseInt(process.env.VITE_PORT ?? "5173", 10);
 const BASE_URL = `http://localhost:${VITE_PORT}`;
 const cliIncludesEndurance = process.argv.some((arg) => arg.includes("@endurance"));
 const includeEndurance = process.env.E2E_INCLUDE_ENDURANCE === "1" || cliIncludesEndurance;
+
+// #1342 Proposal C (Codex Round 1 Should-fix): repo root を `import.meta.url` から
+// 動的算出することで dev container (`/workspaces/harmony`) / WSL2 native
+// (`/home/<user>/projects/harmony` 等) / 別 clone path のいずれでも env が機能する。
+// `HARMONY_ALLOWED_BROWSE_ROOTS` は repo root + `/tmp` を `path.delimiter` で連結。
+const PLAYWRIGHT_CONFIG_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(PLAYWRIGHT_CONFIG_DIR, "..");
+const ALLOWED_BROWSE_ROOTS = `${REPO_ROOT}${path.delimiter}/tmp`;
 
 export default defineConfig({
   testDir: "./e2e",
@@ -51,12 +61,15 @@ export default defineConfig({
     },
     {
       // #1342 Proposal C: workspace-folder-picker.spec.ts は backend `fsBrowse` の
-      // allowlist (HARMONY_ALLOWED_BROWSE_ROOTS) に test fixture root (.tmp/*) が
-      // 含まれていないと「アクセスが許可されていないパスです」で fail する。
+      // allowlist (HARMONY_ALLOWED_BROWSE_ROOTS) に test fixture root (`<repo>/.tmp/*`)
+      // が含まれていないと「アクセスが許可されていないパスです」で fail する。
       // 既定値 (os.homedir() のみ) を repo root + tmp に拡張する env を渡す。
       // 既存 backend reuse 時は env が引き継がれないため、test 側に probe による
       // skipIf gate を用意 (workspace-folder-picker.spec.ts の beforeEach 参照)。
-      command: "cd ../backend && HARMONY_E2E_NO_AUTO_ACTIVATE=1 HARMONY_ALLOWED_BROWSE_ROOTS=/workspaces/harmony:/tmp npm run dev",
+      // Codex Round 1 Should-fix: repo root は `import.meta.url` から動的算出する
+      // (上の `ALLOWED_BROWSE_ROOTS` 参照) ことで dev container / WSL2 native / 別 clone
+      // path の全環境で機能させる。
+      command: `cd ../backend && HARMONY_E2E_NO_AUTO_ACTIVATE=1 HARMONY_ALLOWED_BROWSE_ROOTS=${ALLOWED_BROWSE_ROOTS} npm run dev`,
       url: "http://localhost:5179",
       reuseExistingServer: true, // 既存 backend があれば再利用 (常駐 backend に接続)
       timeout: 30000,
@@ -67,7 +80,7 @@ export default defineConfig({
       //       recent.lastActiveId の暗黙引き継ぎを断つ (spec が明示的 workspace.open で制御)
       env: {
         HARMONY_E2E_NO_AUTO_ACTIVATE: "1",
-        HARMONY_ALLOWED_BROWSE_ROOTS: "/workspaces/harmony:/tmp",
+        HARMONY_ALLOWED_BROWSE_ROOTS: ALLOWED_BROWSE_ROOTS,
       },
     },
   ],

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -50,7 +50,13 @@ export default defineConfig({
       timeout: 30000,
     },
     {
-      command: "cd ../backend && HARMONY_E2E_NO_AUTO_ACTIVATE=1 npm run dev",
+      // #1342 Proposal C: workspace-folder-picker.spec.ts は backend `fsBrowse` の
+      // allowlist (HARMONY_ALLOWED_BROWSE_ROOTS) に test fixture root (.tmp/*) が
+      // 含まれていないと「アクセスが許可されていないパスです」で fail する。
+      // 既定値 (os.homedir() のみ) を repo root + tmp に拡張する env を渡す。
+      // 既存 backend reuse 時は env が引き継がれないため、test 側に probe による
+      // skipIf gate を用意 (workspace-folder-picker.spec.ts の beforeEach 参照)。
+      command: "cd ../backend && HARMONY_E2E_NO_AUTO_ACTIVATE=1 HARMONY_ALLOWED_BROWSE_ROOTS=/workspaces/harmony:/tmp npm run dev",
       url: "http://localhost:5179",
       reuseExistingServer: true, // 既存 backend があれば再利用 (常駐 backend に接続)
       timeout: 30000,
@@ -59,7 +65,10 @@ export default defineConfig({
       // 未接続の場合は test.skip() で graceful skip される
       // #959: HARMONY_E2E_NO_AUTO_ACTIVATE=1 で autoActivateOnStartup を skip し
       //       recent.lastActiveId の暗黙引き継ぎを断つ (spec が明示的 workspace.open で制御)
-      env: { HARMONY_E2E_NO_AUTO_ACTIVATE: "1" },
+      env: {
+        HARMONY_E2E_NO_AUTO_ACTIVATE: "1",
+        HARMONY_ALLOWED_BROWSE_ROOTS: "/workspaces/harmony:/tmp",
+      },
     },
   ],
 });

--- a/frontend/playwright.lockdown.config.ts
+++ b/frontend/playwright.lockdown.config.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig, devices } from "@playwright/test";
 import { lockdownWorkspacePath } from "./e2e/helpers/workspaceFixture.ts";
 
@@ -13,6 +16,18 @@ const BASE_URL = `http://localhost:${VITE_PORT}`;
 // 本 config の `workers: 1` 設定 (下の defineConfig 参照) で並行 write は発生しないため
 // worker prefix は不要 = stable path で一致を担保する。
 const LOCKDOWN_WORKSPACE = lockdownWorkspacePath();
+
+// #1342 Proposal A: webServer 起動前に LOCKDOWN_WORKSPACE を seed する。
+// backend は `DESIGNER_DATA_DIR` 配下に `harmony.json` が無いと `process.exit(1)` する
+// (workspaceState.ts S-011) ため、spec の beforeAll では間に合わない (webServer 起動
+// timeout になる)。Playwright globalSetup も webServer 開始より後に実行されるため、
+// config module 読み込み時 (= webServer spawn より前) に同期 fs API で seed する。
+// `--config playwright.lockdown.config.ts` 経由でしか import されないため副作用 OK。
+const THIS_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(THIS_DIR, "..");
+fs.rmSync(LOCKDOWN_WORKSPACE, { recursive: true, force: true });
+fs.mkdirSync(path.dirname(LOCKDOWN_WORKSPACE), { recursive: true });
+fs.cpSync(path.join(REPO_ROOT, "examples", "retail"), LOCKDOWN_WORKSPACE, { recursive: true });
 
 export default defineConfig({
   testDir: "./e2e",


### PR DESCRIPTION
## 概要

#1342 で trace 確立済の 7 pre-existing fail (#1299 I-7 Round 12 由来) を 3 proposal
統合 PR で解消する。全 7 fail は I-7 scope 外の独立した test infra 問題で、
本 PR の変更は test 配線 + backend security allowlist / fsBrowse env wiring に限定。
production 機能ロジックは無変更。

## 修正内容

### Proposal A — lockdown-routing.spec.ts × 2 (commit 8bb71887)

**Root cause (2 段)**:

1. `playwright.lockdown.config.ts` の webServer が `DESIGNER_DATA_DIR` 配下に
   harmony.json を要求 (backend S-011) するが、spec.beforeAll の seed は webServer
   起動より後で間に合わず timeout。`globalSetup` も webServer 開始より後に走り不適。
2. #1227 (S-001 Origin allowlist) merge 時に lockdown e2e の port 5183/5189 が
   allowlist 未追加で、WS connection rejected。

**Fix**:

- `playwright.lockdown.config.ts` module 読込時 (= webServer spawn 前) に同期 fs API
  で `examples/retail/` を `LOCKDOWN_WORKSPACE` に seed (`fs.rmSync` + `fs.cpSync`)
- `backend/src/security/originCheck.ts` の ALLOWED_ORIGINS に `http://localhost:5183`
  / `http://127.0.0.1:5183` を追加 (localhost 限定 dev port)
- `originCheck.test.ts` に 5183 系の許可 case × 2 を追加 (regression gate)
- `lockdown-routing.spec.ts` の beforeAll seed は重複 + webServer 起動後 rm のリスク
  ありで削除、afterAll cleanup は保持

**検証**: `npm run test:e2e:lockdown` → 2 passed (8.2s)

### Proposal B — step-ops.spec.ts × 2 (commit 168ed86b)

**Root cause**: Playwright `.click()` (pointer event 経路) が dnd-kit useSortable 環境下
の `.step-context-menu-item` button に対し React synthetic onClick を発火させない事象。
JS-equivalent `.click()` / `.dispatchEvent('click')` は動作。実 browser での real-user
操作は影響なし (Playwright synthetic pointer event 特有の不整合)。

**Fix**: `step-ops.spec.ts:136,147` の menu item click を `.dispatchEvent("click")` に
置換。memory `feedback_playwright_key_dispatch.md` (keyboard 2 段 fallback) と同パターン。
menu visible の `expect(...toBeVisible())` も明示的 gate として追加。

**検証**: `npx playwright test step-ops.spec.ts -g "ステップコンテキストメニュー"` → 2 passed (4.6s)

### Proposal C — workspace-folder-picker.spec.ts × 3 (commit 7a28d801)

**Root cause**: backend `fsBrowse.assertWithinAllowedRoots` (S-008) は
`HARMONY_ALLOWED_BROWSE_ROOTS` env で root 制限し、未設定時 `os.homedir()`
(`/home/node`) のみ。test fixture (`.tmp/e2e-folder-picker/...`) は homedir 外なので
permission rejection で全 case fail。

**Fix**:

- `playwright.config.ts` webServer env に `HARMONY_ALLOWED_BROWSE_ROOTS=/workspaces/harmony:/tmp`
  追加 — Playwright が backend spawn する経路では env で propagate して動作
- `reuseExistingServer: true` で既存 backend を reuse する場合 env 不足、test 側に
  `workspace.browseFs` probe による `test.skip` graceful gate を追加。skip 理由
  message で再起動オプション (`HARMONY_ALLOWED_BROWSE_ROOTS=...` 付与) を明示

**検証**:

1. **env 配線確認 (unit-level)**: temp backend を `HARMONY_ALLOWED_BROWSE_ROOTS=/workspaces/harmony:/tmp`
   で port 5279 起動 + WS probe `workspace.browseFs({path: "/workspaces/harmony/.tmp"})`
   → entries 取得成功
2. **skipIf 経路**: env 無しの既存 backend (port 5179) で `npx playwright test
   workspace-folder-picker.spec.ts` → 4 tests skipped (graceful)
3. **Playwright auto-spawn 経路の full pass**: cdx 独立レビューで実機検証
   (本セッションでは user の dev backend を kill しないため未検証)

## 仕様逐条突合 (自己申告)

- Proposal A-1 (webServer 前 seed): `frontend/playwright.lockdown.config.ts:23-29`
- Proposal A-2 (Origin allowlist 拡張): `backend/src/security/originCheck.ts:16-24`
  + test `backend/src/security/originCheck.test.ts:42-52`
- Proposal A-3 (重複 seed 削除): `frontend/e2e/lockdown-routing.spec.ts:1-20`
- Proposal B (dispatchEvent fallback): `frontend/e2e/step-ops.spec.ts:140-160`
- Proposal C-1 (env 配線): `frontend/playwright.config.ts:52-70`
- Proposal C-2 (skipIf gate): `frontend/e2e/workspace-folder-picker.spec.ts:15-32,70-88`

## 検証 (累計)

- backend: `npx tsc --noEmit` clean / `npx vitest run` → 780 passed (originCheck +2 case 含む)
- frontend: `npm run lint` clean / `npx tsc --noEmit` clean
- e2e: lockdown 2 passed / step-ops 2 passed / folder-picker skip path 4 skipped (graceful)

## スコープ外 / 確認事項

- **Proposal B の UI root cause (Playwright synthetic pointer 不整合)**: user 承認の
  通り test-side fix のみ、UI 投資は不要 (実 browser real-user 操作は影響なし)
- **Proposal C の dev container 依存 path**: `/workspaces/harmony` は dev container
  固有。WSL native 等の他環境では env 上書きで対応 (skip 理由 message で誘導)
- **schema governance**: schema/v3/*.json は無変更 (`gh pr diff -- schemas/` で確認)

## 関連

- 親 ISSUE 出典: #1299 (CLOSED) — I-7 Round 12 で trace 確立
- 前段 follow-up: #1343 (MERGED 18 test 吸収) / #1344 (MERGED Round 14 M-R14-1)

Closes #1342