### PR TITLE
test(backend): editSessionService save broadcast 契約を固定 (#1345)

### DIFF
--- a/backend/src/wsBridge/editSessionService.test.ts
+++ b/backend/src/wsBridge/editSessionService.test.ts
@@ -5,11 +5,12 @@
  * 通常保存 handler は originating client を exclude する一方、editSession.save は
  * same-SPA consumer と originating editor の双方へ echo する。
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { EditSessionService } from "./editSessionService.js";
+import { WsBridge } from "../wsBridge.js";
 import { workspaceContextManager, _resetForTest as resetWorkspaceStateForTest } from "../workspaceState.js";
 
 type BroadcastCall = {
@@ -82,5 +83,47 @@ describe("EditSessionService.save resource change broadcast", () => {
     expect(deliveredClientIds).toContain("client-consumer");
     expect(deliveredClientIds).toContain("client-editor");
     expect(deliveredClientIds).not.toContain("client-other-workspace");
+  });
+
+  it("WsBridge adapter 経由でも originating editor と same-workspace consumer に tableChanged を送信する", async () => {
+    const bridge = new WsBridge();
+    const sentByClient = new Map<string, string[]>([
+      ["client-editor", []],
+      ["client-consumer", []],
+      ["client-other-workspace", []],
+    ]);
+    const clients = (bridge as unknown as { clients: Map<string, { readyState: number; send: (message: string, cb?: (err?: Error) => void) => void }> }).clients;
+
+    for (const [clientId, sent] of sentByClient.entries()) {
+      clients.set(clientId, {
+        readyState: 1,
+        send: vi.fn((message: string, cb?: (err?: Error) => void) => {
+          sent.push(message);
+          cb?.();
+        }),
+      });
+    }
+
+    const { editSession } = bridge.editSessionCreate("client-editor", "table", "orders", "受注");
+    const editSessionId = (editSession as { id: string }).id;
+    bridge.editSessionAttachAsView("client-consumer", editSessionId, "別ページ consumer");
+    bridge.editSessionUpdate("client-editor", editSessionId, {
+      id: "orders",
+      name: "受注",
+      columns: [],
+    });
+
+    const result = await bridge.editSessionSave("client-editor", editSessionId);
+
+    expect(result.ok).toBe(true);
+    const tableChangedMessage = JSON.stringify({
+      type: "broadcast",
+      event: "tableChanged",
+      data: { tableId: "orders" },
+    });
+
+    expect(sentByClient.get("client-editor")).toContain(tableChangedMessage);
+    expect(sentByClient.get("client-consumer")).toContain(tableChangedMessage);
+    expect(sentByClient.get("client-other-workspace")).not.toContain(tableChangedMessage);
   });
 });

--- a/backend/src/wsBridge/editSessionService.test.ts
+++ b/backend/src/wsBridge/editSessionService.test.ts
@@ -1,0 +1,86 @@
+/**
+ * editSessionService.test.ts (#1345)
+ *
+ * EditSessionService.save の resource change broadcast 契約を固定する。
+ * 通常保存 handler は originating client を exclude する一方、editSession.save は
+ * same-SPA consumer と originating editor の双方へ echo する。
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { EditSessionService } from "./editSessionService.js";
+import { workspaceContextManager, _resetForTest as resetWorkspaceStateForTest } from "../workspaceState.js";
+
+type BroadcastCall = {
+  wsId: string | null;
+  event: string;
+  data: unknown;
+  excludeClientId?: string;
+};
+
+let tmpDir: string;
+let otherTmpDir: string;
+let broadcasts: BroadcastCall[];
+let service: EditSessionService;
+
+beforeEach(async () => {
+  resetWorkspaceStateForTest();
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "edit-session-service-test-"));
+  otherTmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "edit-session-service-other-"));
+  await fs.writeFile(
+    path.join(tmpDir, "harmony.json"),
+    JSON.stringify({ schemaVersion: "v3", dataDir: "data" }, null, 2),
+    "utf-8",
+  );
+
+  workspaceContextManager.connect("client-editor");
+  workspaceContextManager.connect("client-consumer");
+  workspaceContextManager.connect("client-other-workspace");
+  workspaceContextManager.setActivePath("client-editor", tmpDir);
+  workspaceContextManager.setActivePath("client-consumer", tmpDir);
+  workspaceContextManager.setActivePath("client-other-workspace", otherTmpDir);
+
+  broadcasts = [];
+  service = new EditSessionService((opts) => {
+    broadcasts.push(opts);
+  });
+});
+
+afterEach(async () => {
+  resetWorkspaceStateForTest();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+  await fs.rm(otherTmpDir, { recursive: true, force: true });
+});
+
+describe("EditSessionService.save resource change broadcast", () => {
+  it("tableChanged は originating editor を除外せず同 workspace consumer にも届く契約", async () => {
+    const { editSession } = service.create("client-editor", "table", "orders", "受注");
+    const editSessionId = (editSession as { id: string }).id;
+    service.attachAsView("client-consumer", editSessionId, "別ページ consumer");
+    service.update("client-editor", editSessionId, {
+      id: "orders",
+      name: "受注",
+      columns: [],
+    });
+
+    const result = await service.save("client-editor", editSessionId);
+
+    expect(result.ok).toBe(true);
+    const tableChanged = broadcasts.find((call) => call.event === "tableChanged");
+    expect(tableChanged).toEqual({
+      wsId: tmpDir,
+      event: "tableChanged",
+      data: { tableId: "orders" },
+    });
+    expect(tableChanged?.excludeClientId).toBeUndefined();
+
+    const deliveredClientIds = workspaceContextManager
+      .getClientIdsByPath(tableChanged?.wsId ?? "")
+      .filter((clientId) => clientId !== tableChanged?.excludeClientId);
+
+    expect(deliveredClientIds).toContain("client-consumer");
+    expect(deliveredClientIds).toContain("client-editor");
+    expect(deliveredClientIds).not.toContain("client-other-workspace");
+  });
+});


### PR DESCRIPTION
## 関連

- Closes #1345
- 仕様: N/A (既存 `editSession.save` 実装の broadcast 契約を contract test で固定するテスト追加)

## 概要

`editSession.save` 後の resource change broadcast が originating editor を除外せず、同一 workspace の別 consumer にも届く現行契約を backend contract test として固定します。

## 主な変更

- EditSessionService contract test: `tableChanged` broadcast の `wsId` / payload / `excludeClientId` 未指定を assertion
- WsBridge adapter delivery test: fake WebSocket を登録し、originating editor と same-workspace consumer の `send()` に `tableChanged` が届くことを assertion
- 他 workspace client には `tableChanged` が送信されないことを assertion

## 仕様逐条突合 (自己申告)

- #1345「same-SPA consumer (別 page session) で resource change を受信できる」→ `backend/src/wsBridge/editSessionService.test.ts:88` / `backend/src/wsBridge/editSessionService.test.ts:109` / `backend/src/wsBridge/editSessionService.test.ts:126` ✓
- #1345「originating editor 自身の local state がどうなるか (echo or skip) を明示 assertion」→ `backend/src/wsBridge/editSessionService.test.ts:77` / `backend/src/wsBridge/editSessionService.test.ts:125` ✓
- #1345「test 配置: editSessionService 周辺」→ `backend/src/wsBridge/editSessionService.test.ts:1` ✓

## レビューで特に見てほしい箇所

- `backend/src/wsBridge/editSessionService.test.ts:88-127`: `WsBridge` の public editSession adapter 経由で `editSessionSave` を実行し、fake WebSocket の `send()` まで到達することを確認しています。

## テスト

- Vitest: 2 件 (新規 2 件) — `cd backend && npx vitest run src/wsBridge/editSessionService.test.ts`
- Vitest: 780 件 — `cd backend && npx vitest run`
- Build: `cd backend && npm run build`
- Playwright: N/A
- MCP E2E: N/A

## UI 影響 / AI smoke test

- [ ] UI 影響あり (AI が chrome-devtools MCP / Playwright で smoke test 実施済み)
- [x] UI 影響なし (auto テスト pass のみ)

### UI 影響ありの場合、AI smoke test で確認した項目

- [ ] N/A

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

実装コードは変更していません。#1299 Round 14 の S-R14-2 follow-up として、`editSession.save` の resource change broadcast は通常保存 handler と違い `excludeClientId` を付けない、という現行契約を明示的に固定しています。

独立レビューの Should-fix を受け、service-level の injected broadcast assertion に加えて、`WsBridge` adapter 経由で fake WebSocket の `send()` まで検証する test を追加しました。