### PR TITLE
feat: #1329 #1330 #1331 RFC #1284 follow-up — duplicate id 経路 + Screen rename 起動点 + GenericDefinition rename block

### DIFF
--- a/backend/src/editSessionStore.ts
+++ b/backend/src/editSessionStore.ts
@@ -35,7 +35,8 @@ export type DraftResourceType =
   | "extension"
   | "convention"
   | "flow"
-  | "er-layout";
+  | "er-layout"
+  | "generic-definition"; // #1331: GenericDefinition EditSession 化 (kind/name 複合 id)
 
 export interface ParticipantInfo {
   sessionId: string;

--- a/backend/src/renameEntity.test.ts
+++ b/backend/src/renameEntity.test.ts
@@ -1779,6 +1779,63 @@ describe("renameEntityId — Phase I E: generic-definitions の path 形式 ref 
     const updated = JSON.parse(await fs.readFile(gdPath, "utf-8")) as Record<string, unknown>;
     expect((updated.relations as Array<Record<string, unknown>>)[0].ref).toBe("process-flows/createTransaction");
   });
+
+  // #1331: GenericDefinition EditSession active 時の rename block 検証
+  it("GenericDefinition 編集中の Edit session が存在する場合、参照先 entity の rename は preview で報告 + execute で throw", async () => {
+    const root = await makeWorkspace();
+    await seedTable(root, "ref-tbl");
+
+    // generic-definitions/data-contract/Foo.json が `tables/ref-tbl` を参照
+    const gdDir = dataPath(root, "generic-definitions", "data-contract");
+    await fs.mkdir(gdDir, { recursive: true });
+    const gd = {
+      kind: "data-contract",
+      name: "Foo",
+      relations: [{ kind: "uses", ref: "tables/ref-tbl" }],
+    };
+    const gdPath = path.join(gdDir, "Foo.json");
+    await fs.writeFile(gdPath, JSON.stringify(gd, null, 2), "utf-8");
+
+    // fetchEditSessionsForRef を inject: GenericDefinition "data-contract/Foo" を別 session が Edit 中
+    // (frontend GenericDefinitionEditor が startEditing 済の状態を模倣)
+    const fetchEditSessionsForRef = (
+      entityKind: string,
+      entityId: string,
+    ): ReadonlyArray<EditSessionLike> => {
+      if (entityKind === "genericDefinition" && entityId === "data-contract/Foo") {
+        return [{
+          state: "Active",
+          participants: new Map([
+            ["other-sess", { sessionId: "other-sess", role: "Edit" }],
+          ]),
+        }];
+      }
+      return [];
+    };
+
+    // preview は concurrentEditRefs に genericDefinition を含む
+    const preview = await previewEntityRename("table", "ref-tbl", "new-tbl", root, {
+      sessionId: "self", fetchEditSessionsForRef,
+    });
+    const gdRefs = preview.concurrentEditRefs.filter((r) => r.entityKind === "genericDefinition");
+    expect(gdRefs.length).toBeGreaterThan(0);
+    expect(gdRefs[0].entityId).toBe("data-contract/Foo");
+    expect(gdRefs[0].sessionId).toBe("other-sess");
+
+    // execute は throw
+    await expect(
+      renameEntityId("table", "ref-tbl", "new-tbl", root, {
+        sessionId: "self", fetchEditSessionsForRef,
+      }),
+    ).rejects.toThrow(/参照側.*編集中/);
+
+    // ファイル状態は変化なし
+    await fs.access(dataPath(root, "tables", "ref-tbl.json"));
+    await expect(fs.access(dataPath(root, "tables", "new-tbl.json"))).rejects.toThrow();
+    // generic-definition の ref も rewrite されていない
+    const gdAfter = JSON.parse(await fs.readFile(gdPath, "utf-8")) as Record<string, unknown>;
+    expect((gdAfter.relations as Array<Record<string, unknown>>)[0].ref).toBe("tables/ref-tbl");
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/backend/src/wsHandlers/refactor.ts
+++ b/backend/src/wsHandlers/refactor.ts
@@ -132,7 +132,13 @@ function makeFetchEditSessionsForRef(
     // 通常 entity (Table/Screen/ProcessFlow 等): entityId を直接使用
     const resourceType = INTERNAL_KIND_TO_RESOURCE_TYPE[entityKind];
     if (resourceType) {
-      return bridge.editSessionListByResource(wsId, resourceType, entityId);
+      // #1331: genericDefinition の entityId は "<kind>/<name>" 形式だが、
+      // editSession.create の assertSafeName は `/` を許容しないため frontend は
+      // `/` → `__` に encode して create する。lookup 時にも同じ変換を適用する。
+      const resourceId = entityKind === "genericDefinition"
+        ? entityId.replace(/\//g, "__")
+        : entityId;
+      return bridge.editSessionListByResource(wsId, resourceType, resourceId);
     }
     // 副次 file (project/screenFlowPositions/erLayout): singleton EditSession を引く
     const singletonRT = INTERNAL_KIND_TO_SINGLETON_RESOURCE_TYPE[entityKind];

--- a/backend/src/wsHandlers/refactor.ts
+++ b/backend/src/wsHandlers/refactor.ts
@@ -84,6 +84,11 @@ const INTERNAL_KIND_TO_RESOURCE_TYPE: Record<string, EditSessionResourceType> = 
   view: "view",
   viewDefinition: "view-definition",
   pageLayout: "page-layout",
+  // #1331: GenericDefinition (kind/name 複合 id) を rename block 対象に含める。
+  // renameEntity scan source は entityKind="genericDefinition" / entityId="<kind>/<name>" で
+  // 列挙される (renameEntity.ts L1318)。frontend GenericDefinitionEditor が同形式の
+  // resourceId で EditSession を作成するため、ここで kebab-case の resourceType に変換する。
+  genericDefinition: "generic-definition",
 };
 
 /**

--- a/frontend/src/components/flow/FlowEditor.tsx
+++ b/frontend/src/components/flow/FlowEditor.tsx
@@ -59,6 +59,10 @@ import { duplicateScreenDesignData } from "../../store/duplicateScreen";
 import { makeDuplicatedEntityId } from "../../utils/entityIdSuggestion";
 import { resolveEditorKind } from "../../utils/resolveEditorKind";
 import { resolveCssFramework } from "../../utils/resolveCssFramework";
+import { RenameEntityDialog } from "../common/RenameEntityDialog";
+import { RenameEntityUndoToast } from "../common/RenameEntityUndoToast";
+import { useRenameEntityUndoToast } from "../common/useRenameEntityUndoToast";
+import { handleRenameSuccess } from "../../utils/handleRenameSuccess";
 import { useUndoKeyboard } from "../../hooks/useUndoKeyboard";
 import { useSaveShortcut } from "../../hooks/useSaveShortcut";
 import { useFlowProjectSync } from "../../hooks/useFlowProjectSync";
@@ -163,7 +167,7 @@ interface ContextMenu {
 
 function FlowEditorInner() {
   const navigate = useNavigate();
-  const { wsPath } = useWorkspacePath();
+  const { wsPath, wsId } = useWorkspacePath();
   const projectRef = useRef<FlowProject | null>(null);
   const { fitView, zoomTo } = useReactFlow();
   const { showError } = useErrorDialog();
@@ -362,6 +366,15 @@ function FlowEditorInner() {
 
   // Context menu
   const [contextMenu, setContextMenu] = useState<ContextMenu | null>(null);
+
+  // #1330: ScreenFlow node 右クリック起点の Screen rename refactor。
+  // 完了後は ScreenFlow に留まる (singleton 起動)。
+  const [renameTarget, setRenameTarget] = useState<{ id: string; name: string } | null>(null);
+  const [renameUndoToast, setRenameUndoToast] = useRenameEntityUndoToast(
+    "screen",
+    renameTarget?.id ?? "",
+    wsId,
+  );
 
   useEffect(() => {
     if (!contextMenu) return;
@@ -634,6 +647,16 @@ function FlowEditorInner() {
     navigate(wsPath(`/screen/design/${screenId}`));
     setContextMenu(null);
   }, [contextMenu, navigate, nodes, wsPath]);
+
+  // #1330: ScreenFlow 起点 Screen rename refactor 起動 (context menu item)。
+  const handleRenameNode = useCallback(() => {
+    if (!contextMenu || !projectRef.current) return;
+    const screen = projectRef.current.screens.find((s) => s.id === contextMenu.targetId);
+    if (screen) {
+      setRenameTarget({ id: screen.id, name: screen.name });
+    }
+    setContextMenu(null);
+  }, [contextMenu]);
 
   // ── Marker Panel Actions ──
 
@@ -1219,6 +1242,9 @@ function FlowEditorInner() {
               <button className="flow-context-menu-item" onClick={() => { handleDuplicateNode().catch(console.error); }}>
                 <i className="bi bi-copy" /> 複製
               </button>
+              <button className="flow-context-menu-item" onClick={handleRenameNode}>
+                <i className="bi bi-pencil-square" /> ID 変更…
+              </button>
               {(() => {
                 const screen = projectRef.current?.screens.find((s) => s.id === contextMenu.targetId);
                 const groups = projectRef.current?.groups ?? [];
@@ -1314,6 +1340,91 @@ function FlowEditorInner() {
             }
           }}
           onCancel={onSaveConflictCancel}
+        />
+      )}
+
+      {/* #1330: ScreenFlow 起点の Screen rename refactor dialog */}
+      {renameTarget && (
+        <RenameEntityDialog
+          entityType="screen"
+          currentId={renameTarget.id}
+          currentName={renameTarget.name}
+          existingIds={projectRef.current?.screens.map((s) => s.id) ?? []}
+          fetchExistingIds={async () => {
+            const project = await loadProject();
+            return (project.screens ?? []).map((s) => s.id);
+          }}
+          onClose={() => setRenameTarget(null)}
+          onSuccess={(newId, operationId, extra) => {
+            const target = renameTarget;
+            setRenameTarget(null);
+            handleRenameSuccess({
+              entityType: "screen",
+              oldId: target.id,
+              newId,
+              label: target.name || newId,
+              navigate,
+              wsPath,
+              wsId,
+              // #1330: Flow 起点 → 新 design tab を開かず ScreenFlow 画面に留まる
+              skipOpenNewTab: true,
+              originRoute: () => "/screen/flow",
+            });
+            // node graph を新 id で reload
+            loadProject().then((p) => {
+              projectRef.current = p;
+              setNodes((nds) => nds.map((n) => n.id === target.id
+                ? { ...n, id: newId, data: { ...n.data, id: newId } as RFNode["data"] }
+                : n));
+              setEdges((eds) => eds.map((e) => ({
+                ...e,
+                source: e.source === target.id ? newId : e.source,
+                target: e.target === target.id ? newId : e.target,
+              })));
+            }).catch(console.error);
+            setRenameUndoToast({
+              operationId, oldId: target.id, newId,
+              ttlMs: extra?.ttlMs,
+            });
+          }}
+        />
+      )}
+
+      {renameUndoToast && (
+        <RenameEntityUndoToast
+          operationId={renameUndoToast.operationId}
+          oldId={renameUndoToast.oldId}
+          newId={renameUndoToast.newId}
+          ttlMs={renameUndoToast.ttlMs}
+          entityLabel="画面"
+          onUndo={() => {
+            const oldId = renameUndoToast.newId;
+            const newId = renameUndoToast.oldId;
+            handleRenameSuccess({
+              entityType: "screen",
+              oldId,
+              newId,
+              label: newId,
+              navigate,
+              wsPath,
+              wsId,
+              skipOpenNewTab: true,
+              originRoute: () => "/screen/flow",
+            });
+            loadProject().then((p) => {
+              projectRef.current = p;
+              setNodes((nds) => nds.map((n) => n.id === oldId
+                ? { ...n, id: newId, data: { ...n.data, id: newId } as RFNode["data"] }
+                : n));
+              setEdges((eds) => eds.map((e) => ({
+                ...e,
+                source: e.source === oldId ? newId : e.source,
+                target: e.target === oldId ? newId : e.target,
+              })));
+            }).catch(console.error);
+            setRenameUndoToast(null);
+          }}
+          onDismiss={() => setRenameUndoToast(null)}
         />
       )}
     </div>

--- a/frontend/src/components/flow/FlowEditor.tsx
+++ b/frontend/src/components/flow/FlowEditor.tsx
@@ -56,6 +56,7 @@ import { buildDefaultScreen, loadScreenEntity, saveScreenEntity } from "../../st
 import { listPageLayouts } from "../../store/pageLayoutStore";
 import { clearScreenFlowPositionsPreview, saveScreenFlowPositionsPreview } from "../../store/screenFlowPositionsStore";
 import { duplicateScreenDesignData } from "../../store/duplicateScreen";
+import { makeDuplicatedEntityId } from "../../utils/entityIdSuggestion";
 import { resolveEditorKind } from "../../utils/resolveEditorKind";
 import { resolveCssFramework } from "../../utils/resolveCssFramework";
 import { useUndoKeyboard } from "../../hooks/useUndoKeyboard";
@@ -576,11 +577,16 @@ function FlowEditorInner() {
       const srcEntity = await loadScreenEntity(screen.id);
       const srcEditorKind = resolveEditorKind(srcEntity.design, undefined);
       const srcCssFramework = resolveCssFramework(srcEntity.design, undefined);
+      // RFC #1284 / #1329: duplicate 経路でも kebab-case id を発番する。
+      // 元 id + `-copy[-N]` で uniqueness 衝突回避 (TableListView duplicate と同パターン)。
+      const existingIds = new Set<string>(projectRef.current.screens.map((s) => s.id));
+      const newId = makeDuplicatedEntityId(screen.id, existingIds);
       const dup = await addScreen(
         projectRef.current,
         `${screen.name} (コピー)`,
         screen.kind,
         {
+          id: newId,
           path: screen.path,
           position: { x: screen.position.x + 30, y: screen.position.y + 30 },
           editorKind: srcEditorKind,

--- a/frontend/src/components/flow/FlowEditor.tsx
+++ b/frontend/src/components/flow/FlowEditor.tsx
@@ -370,9 +370,13 @@ function FlowEditorInner() {
   // #1330: ScreenFlow node 右クリック起点の Screen rename refactor。
   // 完了後は ScreenFlow に留まる (singleton 起動)。
   const [renameTarget, setRenameTarget] = useState<{ id: string; name: string } | null>(null);
+  // Codex Round 1 Should-fix: rename 成功時 setRenameTarget(null) で `currentId` が空文字に
+  // なり useRenameEntityUndoToast の key 切替で toast が即時 clear される race を回避するため、
+  // toast 用に新 id (= rename 後 id) を保持する独立 state を用意する。
+  const [renamedToastNewId, setRenamedToastNewId] = useState<string>("");
   const [renameUndoToast, setRenameUndoToast] = useRenameEntityUndoToast(
     "screen",
-    renameTarget?.id ?? "",
+    renamedToastNewId,
     wsId,
   );
 
@@ -1357,6 +1361,8 @@ function FlowEditorInner() {
           onClose={() => setRenameTarget(null)}
           onSuccess={(newId, operationId, extra) => {
             const target = renameTarget;
+            // Codex Round 1 Should-fix: toast key 用に newId を先に固定
+            setRenamedToastNewId(newId);
             setRenameTarget(null);
             handleRenameSuccess({
               entityType: "screen",
@@ -1400,6 +1406,8 @@ function FlowEditorInner() {
           onUndo={() => {
             const oldId = renameUndoToast.newId;
             const newId = renameUndoToast.oldId;
+            // undo: newId(=元 oldId) を toast key に切替
+            setRenamedToastNewId(newId);
             handleRenameSuccess({
               entityType: "screen",
               oldId,
@@ -1423,8 +1431,9 @@ function FlowEditorInner() {
               })));
             }).catch(console.error);
             setRenameUndoToast(null);
+            setRenamedToastNewId("");
           }}
-          onDismiss={() => setRenameUndoToast(null)}
+          onDismiss={() => { setRenameUndoToast(null); setRenamedToastNewId(""); }}
         />
       )}
     </div>

--- a/frontend/src/components/flow/ScreenListView.tsx
+++ b/frontend/src/components/flow/ScreenListView.tsx
@@ -32,6 +32,10 @@ import { useListEditor } from "../../hooks/useListEditor";
 import { usePersistentState } from "../../hooks/usePersistentState";
 import { ScreenEditModal, type ScreenFormData } from "./ScreenEditModal";
 import { useDraftRegistry } from "../../hooks/useDraftRegistry";
+import { RenameEntityDialog } from "../common/RenameEntityDialog";
+import { RenameEntityUndoToast } from "../common/RenameEntityUndoToast";
+import { useRenameEntityUndoToast } from "../common/useRenameEntityUndoToast";
+import { handleRenameSuccess } from "../../utils/handleRenameSuccess";
 import "../../styles/flow.css";
 import "../../styles/screenList.css";
 import "../../styles/editMode.css";
@@ -57,12 +61,19 @@ function formatDate(iso: string): string {
 
 export function ScreenListView() {
   const navigate = useNavigate();
-  const { wsPath } = useWorkspacePath();
+  const { wsPath, wsId } = useWorkspacePath();
   const [query, setQuery] = useState("");
   const [viewMode, setViewMode] = usePersistentState<ViewMode>(STORAGE_KEY, "card");
   const [screenModal, setScreenModal] = useState<{ open: boolean; editId?: string; initial?: Partial<ScreenFormData> }>({ open: false });
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; items: ContextMenuItem[] } | null>(null);
   const { hasDraft } = useDraftRegistry();
+  // #1330: ScreenListView 起点の Screen rename refactor。完了後は一覧に留まる (singleton 起動)。
+  const [renameTarget, setRenameTarget] = useState<{ id: string; name: string } | null>(null);
+  const [renameUndoToast, setRenameUndoToast] = useRenameEntityUndoToast(
+    "screen",
+    renameTarget?.id ?? "",
+    wsId,
+  );
   // project.techStack.designer の project default (画面作成ダイアログのデフォルト選択値)
   const [projectDefaultEditorKind, setProjectDefaultEditorKind] = useState<"grapesjs" | "puck">("grapesjs");
   const [projectDefaultCssFramework, setProjectDefaultCssFramework] = useState<"bootstrap" | "tailwind">("bootstrap");
@@ -390,6 +401,19 @@ export function ScreenListView() {
         disabled: !hasSelection || sortActive,
         disabledReason: sortActive ? sortReason : undefined,
         onClick: () => { if (items.length > 0) handleDuplicate(items).catch(console.error); },
+      },
+      {
+        // #1330: ScreenListView 起点 Screen rename (単一選択のみ有効)
+        key: "rename-id",
+        label: "ID 変更…",
+        icon: "bi-pencil-square",
+        disabled: items.length !== 1 || sortActive,
+        disabledReason: items.length !== 1
+          ? "ID 変更は 1 件選択時のみ"
+          : sortActive ? sortReason : undefined,
+        onClick: () => {
+          if (items.length === 1) setRenameTarget({ id: items[0].id, name: items[0].name });
+        },
       },
       { key: "sep3", separator: true },
       {
@@ -737,6 +761,69 @@ export function ScreenListView() {
           y={contextMenu.y}
           items={contextMenu.items}
           onClose={() => setContextMenu(null)}
+        />
+      )}
+
+      {/* #1330: ScreenListView 起点の Screen rename refactor dialog */}
+      {renameTarget && (
+        <RenameEntityDialog
+          entityType="screen"
+          currentId={renameTarget.id}
+          currentName={renameTarget.name}
+          existingIds={editor.items.map((s) => s.id as string)}
+          fetchExistingIds={async () => {
+            const project = await loadProject();
+            return (project.screens ?? []).map((s) => s.id);
+          }}
+          onClose={() => setRenameTarget(null)}
+          onSuccess={(newId, operationId, extra) => {
+            const target = renameTarget;
+            setRenameTarget(null);
+            handleRenameSuccess({
+              entityType: "screen",
+              oldId: target.id,
+              newId,
+              label: target.name || newId,
+              navigate,
+              wsPath,
+              wsId,
+              // #1330: List 起点 → 新 design tab を開かず一覧画面に留まる
+              skipOpenNewTab: true,
+              originRoute: () => "/screen/list",
+            });
+            // 一覧の reflect は backend の screenChanged broadcast で reload される
+            editor.reload().catch(console.error);
+            setRenameUndoToast({
+              operationId, oldId: target.id, newId,
+              ttlMs: extra?.ttlMs,
+            });
+          }}
+        />
+      )}
+
+      {renameUndoToast && (
+        <RenameEntityUndoToast
+          operationId={renameUndoToast.operationId}
+          oldId={renameUndoToast.oldId}
+          newId={renameUndoToast.newId}
+          ttlMs={renameUndoToast.ttlMs}
+          entityLabel="画面"
+          onUndo={() => {
+            handleRenameSuccess({
+              entityType: "screen",
+              oldId: renameUndoToast.newId,
+              newId: renameUndoToast.oldId,
+              label: renameUndoToast.oldId,
+              navigate,
+              wsPath,
+              wsId,
+              skipOpenNewTab: true,
+              originRoute: () => "/screen/list",
+            });
+            editor.reload().catch(console.error);
+            setRenameUndoToast(null);
+          }}
+          onDismiss={() => setRenameUndoToast(null)}
         />
       )}
     </div>

--- a/frontend/src/components/flow/ScreenListView.tsx
+++ b/frontend/src/components/flow/ScreenListView.tsx
@@ -69,9 +69,13 @@ export function ScreenListView() {
   const { hasDraft } = useDraftRegistry();
   // #1330: ScreenListView 起点の Screen rename refactor。完了後は一覧に留まる (singleton 起動)。
   const [renameTarget, setRenameTarget] = useState<{ id: string; name: string } | null>(null);
+  // Codex Round 1 Should-fix: rename 成功時 setRenameTarget(null) で `currentId` が空文字に
+  // なり useRenameEntityUndoToast の key 切替で toast が即時 clear される race を回避するため、
+  // toast 用に新 id (= rename 後 id) を保持する独立 state を用意する。
+  const [renamedToastNewId, setRenamedToastNewId] = useState<string>("");
   const [renameUndoToast, setRenameUndoToast] = useRenameEntityUndoToast(
     "screen",
-    renameTarget?.id ?? "",
+    renamedToastNewId,
     wsId,
   );
   // project.techStack.designer の project default (画面作成ダイアログのデフォルト選択値)
@@ -778,6 +782,9 @@ export function ScreenListView() {
           onClose={() => setRenameTarget(null)}
           onSuccess={(newId, operationId, extra) => {
             const target = renameTarget;
+            // Codex Round 1 Should-fix: toast key を newId に固定するため
+            // setRenameUndoToast より先に setRenamedToastNewId を呼ぶ
+            setRenamedToastNewId(newId);
             setRenameTarget(null);
             handleRenameSuccess({
               entityType: "screen",
@@ -809,6 +816,8 @@ export function ScreenListView() {
           ttlMs={renameUndoToast.ttlMs}
           entityLabel="画面"
           onUndo={() => {
+            // undo: newId → oldId に戻す。toast key は oldId に切替える前に setRenamedToastNewId。
+            setRenamedToastNewId(renameUndoToast.oldId);
             handleRenameSuccess({
               entityType: "screen",
               oldId: renameUndoToast.newId,
@@ -822,8 +831,9 @@ export function ScreenListView() {
             });
             editor.reload().catch(console.error);
             setRenameUndoToast(null);
+            setRenamedToastNewId("");
           }}
-          onDismiss={() => setRenameUndoToast(null)}
+          onDismiss={() => { setRenameUndoToast(null); setRenamedToastNewId(""); }}
         />
       )}
     </div>

--- a/frontend/src/components/generic-definition/GenericDefinitionEditor.test.tsx
+++ b/frontend/src/components/generic-definition/GenericDefinitionEditor.test.tsx
@@ -41,6 +41,12 @@ vi.mock("../../mcp/mcpBridge", () => ({
       broadcastHandler = handler;
       return () => undefined;
     }),
+    // #1331: useEditSession 依存 — test では EditSession 連携は no-op で良い
+    getSessionId: vi.fn(() => "test-session"),
+    request: vi.fn(async () => ({})),
+    onStatusChange: vi.fn(() => () => undefined),
+    getStatus: vi.fn(() => "connected"),
+    startWithoutEditor: vi.fn(),
   },
 }));
 

--- a/frontend/src/components/generic-definition/GenericDefinitionEditor.tsx
+++ b/frontend/src/components/generic-definition/GenericDefinitionEditor.tsx
@@ -88,10 +88,15 @@ export function GenericDefinitionEditor() {
   const editSessionIdRef = useRef<string | null>(null);
   // どの resourceId に対して current editSessionIdRef が紐付くか追跡。
   const sessionResourceIdRef = useRef<string>("");
-  // 進行中の create を resourceId 付きで追跡 (Codex Round 3 Must-fix)。
-  // pending start 中の resource A → B 遷移時、後続 ensureEditSession(B) が
-  // A の pending を誤って再利用するのを防ぐ。
-  const startingRef = useRef<{ resourceId: string; promise: Promise<string | null> } | null>(null);
+  // 進行中の create を resourceId + generation 付きで追跡 (Codex Round 5 Must-fix)。
+  // generation は ensureEditSession 呼出ごとに +1 し、pending の drift check / discardEditSession
+  // の同 resource 再編集 race を解消する。
+  const startingRef = useRef<{
+    resourceId: string;
+    generation: number;
+    promise: Promise<string | null>;
+  } | null>(null);
+  const generationRef = useRef(0);
   // currentResourceIdRef: 最新 editSessionSafeResourceId を常に保持 (render phase で同期更新)。
   // create 中の Promise body は closure capture により stale な target を持つため、
   // drift check は ref 経由で最新値を参照する必要がある。
@@ -100,7 +105,7 @@ export function GenericDefinitionEditor() {
 
   // ensureEditSession: 現 resource に対する active session を返す。なければ create。
   // pending start の resourceId 一致時のみ再利用、不一致なら新規 create を並行起動
-  // (古い pending は自身の drift check で created session を即 discard する)。
+  // (古い pending は自身の generation drift check で created session を即 discard する)。
   const ensureEditSession = useCallback(async (): Promise<string | null> => {
     const target = currentResourceIdRef.current;
     if (!target) return null;
@@ -112,7 +117,9 @@ export function GenericDefinitionEditor() {
     if (startingRef.current && startingRef.current.resourceId === target) {
       return startingRef.current.promise;
     }
-    // 新規 create (mismatched pending slot は上書き、その pending は自身の drift check で cleanup)
+    // 新規 create — generation を進める (古い pending を superseded 化)
+    generationRef.current += 1;
+    const myGen = generationRef.current;
     const promise = (async (): Promise<string | null> => {
       let createdId: string | null = null;
       try {
@@ -126,10 +133,9 @@ export function GenericDefinitionEditor() {
         return null;
       }
       if (!createdId) return null;
-      // Drift check: create 完了時点で current resource が変わっていれば即 discard。
-      // unmount 後も currentResourceIdRef は最後の値を保持するため、unmount → 別 resource
-      // でない場合は drift しない (= 通常 unmount cleanup 経路は discardEditSession 経由)。
-      if (currentResourceIdRef.current !== target) {
+      // Drift / superseded check: generation が進んでいる、または target resource が変わっていれば
+      // この create は捨てる (subsequent create / discard が先行)。
+      if (generationRef.current !== myGen || currentResourceIdRef.current !== target) {
         mcpBridge.request("editSession.discard", { editSessionId: createdId }).catch((e) => {
           console.warn("[GenericDefinitionEditor] drift discard failed:", e);
         });
@@ -139,7 +145,7 @@ export function GenericDefinitionEditor() {
       sessionResourceIdRef.current = target;
       return createdId;
     })();
-    const slot = { resourceId: target, promise };
+    const slot = { resourceId: target, generation: myGen, promise };
     startingRef.current = slot;
     // Settle 後、slot がまだ自分なら clear (別 create が overwrite していなければ)
     void promise.finally(() => {
@@ -151,26 +157,38 @@ export function GenericDefinitionEditor() {
   }, []);
 
   // 破棄: target resource に紐付く active session を discard する。
-  // pending start (target と一致する場合のみ) を await した後、active session が target と
-  // 一致している場合だけ実際に discard する。これにより以下の race を防ぐ (Codex Round 4):
-  //   1) user 編集 A → P_A pending → user save → discardEditSession("A") 呼出 → await P_A
-  //   2) await 中に user が B へ navigate + 編集 → ensureEditSession(B) で P_B 起動
-  //   3) discardEditSession の await 完了時 editSessionIdRef は B_id を保持
-  //   4) target "A" !== sessionResourceIdRef "B" → skip (B session を誤って discard しない)
+  // Generation tracking で以下 race を防ぐ (Codex Round 4 / Round 5):
+  //   - Round 4: save 後 discard の await 中に B へ遷移 → B session を誤 discard
+  //   - Round 5-1: A → B → A 戻り時 古い P_A が active 採用され重複 session
+  //   - Round 5-2: save 後 discard の await 中に同 resource 再編集 → P_A reuse + discard で
+  //                user 編集が EditSession なしになる
+  //
+  // 戦略:
+  //   1. pending start が target に一致するなら detach (startingRef.current = null) + generation +1。
+  //      これで subsequent ensureEditSession は fresh な pending を起動する。
+  //   2. detach 済 pending を await (drift check で自動 discard される)。
+  //   3. await 後、generation が我々の myGen から動いていれば (= 別 create が起動済) skip。
+  //   4. active session が target と一致する場合のみ discard + generation +1。
   const discardEditSession = useCallback(async (targetResourceId: string): Promise<void> => {
     if (!targetResourceId) return;
-    // pending start を await (target 一致時のみ。別 resource の pending は detach 済 or
-    // 自身の drift check で cleanup されるため await しない)
+    let myGen: number;
     const pending = startingRef.current;
     if (pending && pending.resourceId === targetResourceId) {
-      try { await pending.promise; } catch { /* create failed = nothing to discard */ }
+      // detach + bump generation (pending の drift check で created session を自動 discard)
+      startingRef.current = null;
+      generationRef.current += 1;
+      myGen = generationRef.current;
+      try { await pending.promise; } catch { /* ignore */ }
+    } else {
+      myGen = generationRef.current;
     }
-    // Active session が target と一致する場合のみ discard
+    // await 中に新 create が起動済なら skip (subsequent edit のセッションを誤って消さない)
+    if (generationRef.current !== myGen) return;
     const id = editSessionIdRef.current;
-    if (!id) return;
-    if (sessionResourceIdRef.current !== targetResourceId) return;
+    if (!id || sessionResourceIdRef.current !== targetResourceId) return;
     editSessionIdRef.current = null;
     sessionResourceIdRef.current = "";
+    generationRef.current += 1; // discard 後に何らかの pending が残っていても superseded 化
     try {
       await mcpBridge.request("editSession.discard", { editSessionId: id });
     } catch (e) {
@@ -178,10 +196,9 @@ export function GenericDefinitionEditor() {
     }
   }, []);
 
-  // Resource 変更時の cleanup (Codex Round 3 Must-fix):
+  // Resource 変更時の cleanup:
   //   - 旧 resource の active session を discard
-  //   - 旧 resource の pending start を slot detach (= 自身の drift check で created session 廃棄)
-  //   - editSessionSafeResourceId === "" 遷移 (kind/name 未定義化) も同等に処理
+  //   - 旧 resource の pending start を slot detach + generation +1 (drift check で auto-cleanup)
   useEffect(() => {
     const target = editSessionSafeResourceId;
     if (editSessionIdRef.current && sessionResourceIdRef.current !== target) {
@@ -193,9 +210,8 @@ export function GenericDefinitionEditor() {
       });
     }
     if (startingRef.current && startingRef.current.resourceId !== target) {
-      // detach: 古い pending は currentResourceIdRef が変わっているため drift check で
-      // 自動 discard される。slot を空けて新 ensureEditSession が即起動できるようにする。
       startingRef.current = null;
+      generationRef.current += 1; // 古い pending を superseded 化
     }
   }, [editSessionSafeResourceId]);
 

--- a/frontend/src/components/generic-definition/GenericDefinitionEditor.tsx
+++ b/frontend/src/components/generic-definition/GenericDefinitionEditor.tsx
@@ -150,15 +150,25 @@ export function GenericDefinitionEditor() {
     return promise;
   }, []);
 
-  // 破棄: pending start を await してから active session を discard。
-  // unmount cleanup + save 後 + 明示破棄から呼ばれる。
-  const discardEditSession = useCallback(async (): Promise<void> => {
+  // 破棄: target resource に紐付く active session を discard する。
+  // pending start (target と一致する場合のみ) を await した後、active session が target と
+  // 一致している場合だけ実際に discard する。これにより以下の race を防ぐ (Codex Round 4):
+  //   1) user 編集 A → P_A pending → user save → discardEditSession("A") 呼出 → await P_A
+  //   2) await 中に user が B へ navigate + 編集 → ensureEditSession(B) で P_B 起動
+  //   3) discardEditSession の await 完了時 editSessionIdRef は B_id を保持
+  //   4) target "A" !== sessionResourceIdRef "B" → skip (B session を誤って discard しない)
+  const discardEditSession = useCallback(async (targetResourceId: string): Promise<void> => {
+    if (!targetResourceId) return;
+    // pending start を await (target 一致時のみ。別 resource の pending は detach 済 or
+    // 自身の drift check で cleanup されるため await しない)
     const pending = startingRef.current;
-    if (pending) {
+    if (pending && pending.resourceId === targetResourceId) {
       try { await pending.promise; } catch { /* create failed = nothing to discard */ }
     }
+    // Active session が target と一致する場合のみ discard
     const id = editSessionIdRef.current;
     if (!id) return;
+    if (sessionResourceIdRef.current !== targetResourceId) return;
     editSessionIdRef.current = null;
     sessionResourceIdRef.current = "";
     try {
@@ -269,12 +279,14 @@ export function GenericDefinitionEditor() {
   }, [ensureEditSession]);
 
   // #1331: unmount 時に EditSession を discard (cleanup)。
-  // pending start (= mcpBridge.request 応答未到達) も await してから discard する。
-  // ref を closure に直接掴むため deps なし (eslint disable は意図的)。
+  // discardEditSession に target を渡し、await 中の resource 切替で誤って新 session を
+  // 消さないようにする (Codex Round 4 Must-fix)。currentResourceIdRef.current は最後の
+  // render 時の resourceId を保持する。
   useEffect(() => {
     return () => {
-      // fire-and-forget: discardEditSession 内で pending start を await + discard
-      discardEditSession().catch(() => { /* logged inside */ });
+      const targetAtUnmount = currentResourceIdRef.current;
+      // fire-and-forget: target 一致 session のみ discard (pending start 含めて await)
+      discardEditSession(targetAtUnmount).catch(() => { /* logged inside */ });
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -307,8 +319,10 @@ export function GenericDefinitionEditor() {
       initialSnapshotRef.current = JSON.stringify(def);
       setReloadBanner(false);
       // #1331: save 成功後は EditSession を discard し、他 session の rename block を解除する。
-      // 次の編集で再度 ensureEditSession が走る (lazy)。
-      discardEditSession().catch(() => { /* logged inside */ });
+      // 次の編集で再度 ensureEditSession が走る (lazy)。target を snapshot して、await 中の
+      // resource 切替で誤って新 session を消さないようにする (Codex Round 4 Must-fix)。
+      const targetAtSave = currentResourceIdRef.current;
+      discardEditSession(targetAtSave).catch(() => { /* logged inside */ });
       setTimeout(() => setSaveSuccess(false), 3000);
     } catch (e: unknown) {
       setSaveError(e instanceof Error ? e.message : String(e));

--- a/frontend/src/components/generic-definition/GenericDefinitionEditor.tsx
+++ b/frontend/src/components/generic-definition/GenericDefinitionEditor.tsx
@@ -26,9 +26,6 @@ import {
 import { ValidationBadge } from "../common/ValidationBadge";
 import { makeTabId, openTab } from "../../store/tabStore";
 import { mcpBridge } from "../../mcp/mcpBridge";
-// #1331: GenericDefinition EditSession 対応 — 編集中は EditSession を保持し、
-// 他 session の rename が detectConcurrentEditRefs 経由で本 editor を block できるようにする。
-import { useEditSession } from "../../hooks/useEditSession";
 
 function isValidKind(k: string): k is GenericDefinitionKind {
   return (GENERIC_DEFINITION_KINDS as string[]).includes(k);
@@ -70,22 +67,66 @@ export function GenericDefinitionEditor() {
   // dirty 検出用: loaded 直後の serialized snapshot を保持し、現 def との diff で判定
   const initialSnapshotRef = useRef<string | null>(null);
 
-  // #1331: GenericDefinition EditSession 統合。
-  // resourceId は kind/name 複合 ID (renameEntity の location.entityId と同形式)。
-  // 編集 (= def 変更) があった時に lazily startEditing し、他 session の rename を block する。
-  // 完全な mtime/etag 衝突検出は follow-up ISSUE で実装 (本 ISSUE では rename block のみ対応)。
-  const sessionId = mcpBridge.getSessionId();
-  const editSessionResourceId = kind && decodedName ? `${kind}/${decodedName}` : "";
-  const { editSession, actions: editSessionActions } = useEditSession({
-    resourceType: "generic-definition",
-    resourceId: editSessionResourceId,
-    sessionId,
-  });
-  // 編集開始済みフラグ — 同一 mount 内で startEditing を 1 回だけ実行する。
-  const startedEditingRef = useRef(false);
-  // unmount 時の discard 用 ref (closure 経由で最新 actions/session を参照)
-  const editSessionRef = useRef(editSession);
-  useEffect(() => { editSessionRef.current = editSession; }, [editSession]);
+  // #1331: GenericDefinition EditSession 統合 (mcpBridge 直接呼出版)。
+  // 編集 (= def 変更) があった時に lazily editSession.create し、他 session の rename を
+  // detectConcurrentEditRefs 経由で block する。
+  //
+  // 設計理由 (Codex Round 1 Must-fix 2 解消):
+  //   useEditSession hook 経由は startEditing() 解決前 unmount で race 発生 (cleanup 時点で
+  //   editSession state が null のため discard skip → orphan session)。mcpBridge.request を
+  //   直接呼ぶことで create response の editSessionId を即座に ref に保持し、unmount cleanup
+  //   が pending Promise を await してから discard 可能になる。
+  //
+  // resourceId encoding:
+  //   renameEntity location は entityId="<kind>/<name>" (例: "data-contract/Foo") を使うが、
+  //   editSession.create の assertSafeName は `/` を許容しない。frontend では `/` → `__` に
+  //   encode し、backend wsHandlers/refactor.ts の makeFetchEditSessionsForRef で逆変換する。
+  const editSessionRawId = kind && decodedName ? `${kind}/${decodedName}` : "";
+  const editSessionSafeResourceId = editSessionRawId.replace(/\//g, "__");
+  const editSessionIdRef = useRef<string | null>(null);
+  const startingPromiseRef = useRef<Promise<string | null> | null>(null);
+
+  // 編集開始: 同 mount 内で重複 create を防ぐため startingPromiseRef を await。
+  // 失敗時は次の updateDef で再試行可能 (idRef / promiseRef を null に戻す)。
+  const ensureEditSession = useCallback(async (): Promise<string | null> => {
+    if (editSessionIdRef.current) return editSessionIdRef.current;
+    if (startingPromiseRef.current) return startingPromiseRef.current;
+    if (!editSessionSafeResourceId) return null;
+    const promise = (async (): Promise<string | null> => {
+      try {
+        const result = await mcpBridge.request("editSession.create", {
+          resourceType: "generic-definition",
+          resourceId: editSessionSafeResourceId,
+        }) as { editSession?: { id?: string } } | null;
+        const id = result?.editSession?.id ?? null;
+        editSessionIdRef.current = id;
+        return id;
+      } catch (e) {
+        console.warn("[GenericDefinitionEditor] editSession.create failed:", e);
+        return null;
+      } finally {
+        startingPromiseRef.current = null;
+      }
+    })();
+    startingPromiseRef.current = promise;
+    return promise;
+  }, [editSessionSafeResourceId]);
+
+  // 破棄: pending startEditing があれば先に解決を待ち、その後 editSessionId が確定したら discard。
+  // unmount + save 後の両方で呼ぶ。
+  const discardEditSession = useCallback(async (): Promise<void> => {
+    if (startingPromiseRef.current) {
+      try { await startingPromiseRef.current; } catch { /* create failed = nothing to discard */ }
+    }
+    const id = editSessionIdRef.current;
+    if (!id) return;
+    editSessionIdRef.current = null;
+    try {
+      await mcpBridge.request("editSession.discard", { editSessionId: id });
+    } catch (e) {
+      console.warn("[GenericDefinitionEditor] editSession.discard failed:", e);
+    }
+  }, []);
 
   useEffect(() => {
     if (!kind || !decodedName) return;
@@ -162,29 +203,18 @@ export function GenericDefinitionEditor() {
 
   const updateDef = useCallback((updater: (prev: GenericDefinition) => GenericDefinition) => {
     setDef((prev) => prev ? updater(prev) : prev);
-    // #1331: 編集が初めて発生した時点で EditSession を作成 (lazy start)。
-    // 既に startEditing 済 / resourceId が未確定なら no-op。
-    if (!startedEditingRef.current && editSessionResourceId) {
-      startedEditingRef.current = true;
-      editSessionActions.startEditing().catch((e) => {
-        console.warn("[GenericDefinitionEditor] startEditing failed:", e);
-        startedEditingRef.current = false; // 失敗時は次回 update で再試行
-      });
-    }
-  }, [editSessionActions, editSessionResourceId]);
+    // #1331: 編集が発生したら EditSession を作成 (lazy)。重複 create は ensureEditSession 内で抑制。
+    ensureEditSession().catch(() => { /* logged inside */ });
+  }, [ensureEditSession]);
 
   // #1331: unmount 時に EditSession を discard (cleanup)。
-  // closure に最新 editSession を保持するため editSessionRef を参照。
+  // pending start (= mcpBridge.request 応答未到達) も await してから discard する。
+  // ref を closure に直接掴むため deps なし (eslint disable は意図的)。
   useEffect(() => {
     return () => {
-      const es = editSessionRef.current;
-      if (es && startedEditingRef.current) {
-        editSessionActions.discard().catch((e) => {
-          console.warn("[GenericDefinitionEditor] discard on unmount failed:", e);
-        });
-      }
+      // fire-and-forget: discardEditSession 内で pending start を await + discard
+      discardEditSession().catch(() => { /* logged inside */ });
     };
-    // unmount 時の cleanup のみが目的 — dependencies は意図的に空
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -216,20 +246,15 @@ export function GenericDefinitionEditor() {
       initialSnapshotRef.current = JSON.stringify(def);
       setReloadBanner(false);
       // #1331: save 成功後は EditSession を discard し、他 session の rename block を解除する。
-      // 次の編集で再度 startEditing が走る (lazy)。
-      if (startedEditingRef.current) {
-        startedEditingRef.current = false;
-        editSessionActions.discard().catch((e) => {
-          console.warn("[GenericDefinitionEditor] discard after save failed:", e);
-        });
-      }
+      // 次の編集で再度 ensureEditSession が走る (lazy)。
+      discardEditSession().catch(() => { /* logged inside */ });
       setTimeout(() => setSaveSuccess(false), 3000);
     } catch (e: unknown) {
       setSaveError(e instanceof Error ? e.message : String(e));
     } finally {
       setSaving(false);
     }
-  }, [def, reloadBanner, editSessionActions]);
+  }, [def, reloadBanner, discardEditSession]);
 
   const handleDelete = useCallback(async () => {
     if (!kind || !decodedName) return;

--- a/frontend/src/components/generic-definition/GenericDefinitionEditor.tsx
+++ b/frontend/src/components/generic-definition/GenericDefinitionEditor.tsx
@@ -84,46 +84,78 @@ export function GenericDefinitionEditor() {
   //   encoding (`/` → `__`) を適用して stored resourceId と突合する。
   const editSessionRawId = kind && decodedName ? `${kind}/${decodedName}` : "";
   const editSessionSafeResourceId = editSessionRawId.replace(/\//g, "__");
+  // active editSession の id (= 既に create が完了して紐付け済)
   const editSessionIdRef = useRef<string | null>(null);
-  const startingPromiseRef = useRef<Promise<string | null> | null>(null);
-  // どの resourceId に対して current editSessionIdRef が紐付くか追跡 (Codex Round 2 Must-fix)。
-  // 同 component が router 経由で `:kind/:name` 変更 (Tab A → B 遷移) で stay-mounted する場合、
-  // 旧 resource の session が新 resource にずれ込むのを防ぐ。
+  // どの resourceId に対して current editSessionIdRef が紐付くか追跡。
   const sessionResourceIdRef = useRef<string>("");
+  // 進行中の create を resourceId 付きで追跡 (Codex Round 3 Must-fix)。
+  // pending start 中の resource A → B 遷移時、後続 ensureEditSession(B) が
+  // A の pending を誤って再利用するのを防ぐ。
+  const startingRef = useRef<{ resourceId: string; promise: Promise<string | null> } | null>(null);
+  // currentResourceIdRef: 最新 editSessionSafeResourceId を常に保持 (render phase で同期更新)。
+  // create 中の Promise body は closure capture により stale な target を持つため、
+  // drift check は ref 経由で最新値を参照する必要がある。
+  const currentResourceIdRef = useRef<string>("");
+  currentResourceIdRef.current = editSessionSafeResourceId;
 
-  // 編集開始: 同 mount 内で重複 create を防ぐため startingPromiseRef を await。
-  // 失敗時は次の updateDef で再試行可能 (idRef / promiseRef を null に戻す)。
+  // ensureEditSession: 現 resource に対する active session を返す。なければ create。
+  // pending start の resourceId 一致時のみ再利用、不一致なら新規 create を並行起動
+  // (古い pending は自身の drift check で created session を即 discard する)。
   const ensureEditSession = useCallback(async (): Promise<string | null> => {
-    if (editSessionIdRef.current) return editSessionIdRef.current;
-    if (startingPromiseRef.current) return startingPromiseRef.current;
-    if (!editSessionSafeResourceId) return null;
-    const targetResourceId = editSessionSafeResourceId;
+    const target = currentResourceIdRef.current;
+    if (!target) return null;
+    // active session を再利用 (current target と一致時のみ)
+    if (editSessionIdRef.current && sessionResourceIdRef.current === target) {
+      return editSessionIdRef.current;
+    }
+    // pending start を再利用 (current target と一致時のみ)
+    if (startingRef.current && startingRef.current.resourceId === target) {
+      return startingRef.current.promise;
+    }
+    // 新規 create (mismatched pending slot は上書き、その pending は自身の drift check で cleanup)
     const promise = (async (): Promise<string | null> => {
+      let createdId: string | null = null;
       try {
         const result = await mcpBridge.request("editSession.create", {
           resourceType: "generic-definition",
-          resourceId: targetResourceId,
+          resourceId: target,
         }) as { editSession?: { id?: string } } | null;
-        const id = result?.editSession?.id ?? null;
-        editSessionIdRef.current = id;
-        sessionResourceIdRef.current = targetResourceId;
-        return id;
+        createdId = result?.editSession?.id ?? null;
       } catch (e) {
         console.warn("[GenericDefinitionEditor] editSession.create failed:", e);
         return null;
-      } finally {
-        startingPromiseRef.current = null;
       }
+      if (!createdId) return null;
+      // Drift check: create 完了時点で current resource が変わっていれば即 discard。
+      // unmount 後も currentResourceIdRef は最後の値を保持するため、unmount → 別 resource
+      // でない場合は drift しない (= 通常 unmount cleanup 経路は discardEditSession 経由)。
+      if (currentResourceIdRef.current !== target) {
+        mcpBridge.request("editSession.discard", { editSessionId: createdId }).catch((e) => {
+          console.warn("[GenericDefinitionEditor] drift discard failed:", e);
+        });
+        return null;
+      }
+      editSessionIdRef.current = createdId;
+      sessionResourceIdRef.current = target;
+      return createdId;
     })();
-    startingPromiseRef.current = promise;
+    const slot = { resourceId: target, promise };
+    startingRef.current = slot;
+    // Settle 後、slot がまだ自分なら clear (別 create が overwrite していなければ)
+    void promise.finally(() => {
+      if (startingRef.current === slot) {
+        startingRef.current = null;
+      }
+    });
     return promise;
-  }, [editSessionSafeResourceId]);
+  }, []);
 
-  // 破棄: pending startEditing があれば先に解決を待ち、その後 editSessionId が確定したら discard。
-  // unmount + save 後 + resourceId 変更時の 3 経路で呼ぶ。
+  // 破棄: pending start を await してから active session を discard。
+  // unmount cleanup + save 後 + 明示破棄から呼ばれる。
   const discardEditSession = useCallback(async (): Promise<void> => {
-    if (startingPromiseRef.current) {
-      try { await startingPromiseRef.current; } catch { /* create failed = nothing to discard */ }
+    const pending = startingRef.current;
+    if (pending) {
+      try { await pending.promise; } catch { /* create failed = nothing to discard */ }
     }
     const id = editSessionIdRef.current;
     if (!id) return;
@@ -136,17 +168,26 @@ export function GenericDefinitionEditor() {
     }
   }, []);
 
-  // Codex Round 2 Must-fix: route param 変更 (例: GenericDefinition A → B へ遷移) で
-  // editSessionSafeResourceId が変わったら、旧 resource の active session を discard する。
-  // sessionResourceIdRef が空 (= まだ create していない) なら no-op。
+  // Resource 変更時の cleanup (Codex Round 3 Must-fix):
+  //   - 旧 resource の active session を discard
+  //   - 旧 resource の pending start を slot detach (= 自身の drift check で created session 廃棄)
+  //   - editSessionSafeResourceId === "" 遷移 (kind/name 未定義化) も同等に処理
   useEffect(() => {
-    if (sessionResourceIdRef.current && sessionResourceIdRef.current !== editSessionSafeResourceId) {
-      // discard 内で pending start を await + idRef / sessionResourceIdRef を reset。
-      // 旧 session の create が pending 中でも、await pending → 完了後に discard が走るため
-      // orphan は残らない (新 resource 用 ensureEditSession は次の updateDef で再起動)。
-      discardEditSession().catch(() => { /* logged inside */ });
+    const target = editSessionSafeResourceId;
+    if (editSessionIdRef.current && sessionResourceIdRef.current !== target) {
+      const oldId = editSessionIdRef.current;
+      editSessionIdRef.current = null;
+      sessionResourceIdRef.current = "";
+      mcpBridge.request("editSession.discard", { editSessionId: oldId }).catch((e) => {
+        console.warn("[GenericDefinitionEditor] resource-change discard failed:", e);
+      });
     }
-  }, [editSessionSafeResourceId, discardEditSession]);
+    if (startingRef.current && startingRef.current.resourceId !== target) {
+      // detach: 古い pending は currentResourceIdRef が変わっているため drift check で
+      // 自動 discard される。slot を空けて新 ensureEditSession が即起動できるようにする。
+      startingRef.current = null;
+    }
+  }, [editSessionSafeResourceId]);
 
   useEffect(() => {
     if (!kind || !decodedName) return;

--- a/frontend/src/components/generic-definition/GenericDefinitionEditor.tsx
+++ b/frontend/src/components/generic-definition/GenericDefinitionEditor.tsx
@@ -26,6 +26,9 @@ import {
 import { ValidationBadge } from "../common/ValidationBadge";
 import { makeTabId, openTab } from "../../store/tabStore";
 import { mcpBridge } from "../../mcp/mcpBridge";
+// #1331: GenericDefinition EditSession 対応 — 編集中は EditSession を保持し、
+// 他 session の rename が detectConcurrentEditRefs 経由で本 editor を block できるようにする。
+import { useEditSession } from "../../hooks/useEditSession";
 
 function isValidKind(k: string): k is GenericDefinitionKind {
   return (GENERIC_DEFINITION_KINDS as string[]).includes(k);
@@ -66,6 +69,23 @@ export function GenericDefinitionEditor() {
   const [reloadBanner, setReloadBanner] = useState(false);
   // dirty 検出用: loaded 直後の serialized snapshot を保持し、現 def との diff で判定
   const initialSnapshotRef = useRef<string | null>(null);
+
+  // #1331: GenericDefinition EditSession 統合。
+  // resourceId は kind/name 複合 ID (renameEntity の location.entityId と同形式)。
+  // 編集 (= def 変更) があった時に lazily startEditing し、他 session の rename を block する。
+  // 完全な mtime/etag 衝突検出は follow-up ISSUE で実装 (本 ISSUE では rename block のみ対応)。
+  const sessionId = mcpBridge.getSessionId();
+  const editSessionResourceId = kind && decodedName ? `${kind}/${decodedName}` : "";
+  const { editSession, actions: editSessionActions } = useEditSession({
+    resourceType: "generic-definition",
+    resourceId: editSessionResourceId,
+    sessionId,
+  });
+  // 編集開始済みフラグ — 同一 mount 内で startEditing を 1 回だけ実行する。
+  const startedEditingRef = useRef(false);
+  // unmount 時の discard 用 ref (closure 経由で最新 actions/session を参照)
+  const editSessionRef = useRef(editSession);
+  useEffect(() => { editSessionRef.current = editSession; }, [editSession]);
 
   useEffect(() => {
     if (!kind || !decodedName) return;
@@ -142,6 +162,30 @@ export function GenericDefinitionEditor() {
 
   const updateDef = useCallback((updater: (prev: GenericDefinition) => GenericDefinition) => {
     setDef((prev) => prev ? updater(prev) : prev);
+    // #1331: 編集が初めて発生した時点で EditSession を作成 (lazy start)。
+    // 既に startEditing 済 / resourceId が未確定なら no-op。
+    if (!startedEditingRef.current && editSessionResourceId) {
+      startedEditingRef.current = true;
+      editSessionActions.startEditing().catch((e) => {
+        console.warn("[GenericDefinitionEditor] startEditing failed:", e);
+        startedEditingRef.current = false; // 失敗時は次回 update で再試行
+      });
+    }
+  }, [editSessionActions, editSessionResourceId]);
+
+  // #1331: unmount 時に EditSession を discard (cleanup)。
+  // closure に最新 editSession を保持するため editSessionRef を参照。
+  useEffect(() => {
+    return () => {
+      const es = editSessionRef.current;
+      if (es && startedEditingRef.current) {
+        editSessionActions.discard().catch((e) => {
+          console.warn("[GenericDefinitionEditor] discard on unmount failed:", e);
+        });
+      }
+    };
+    // unmount 時の cleanup のみが目的 — dependencies は意図的に空
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleSave = useCallback(async () => {
@@ -171,13 +215,21 @@ export function GenericDefinitionEditor() {
       // 起因する broadcast (reload event) で reloadBanner が誤発火しないようにする。
       initialSnapshotRef.current = JSON.stringify(def);
       setReloadBanner(false);
+      // #1331: save 成功後は EditSession を discard し、他 session の rename block を解除する。
+      // 次の編集で再度 startEditing が走る (lazy)。
+      if (startedEditingRef.current) {
+        startedEditingRef.current = false;
+        editSessionActions.discard().catch((e) => {
+          console.warn("[GenericDefinitionEditor] discard after save failed:", e);
+        });
+      }
       setTimeout(() => setSaveSuccess(false), 3000);
     } catch (e: unknown) {
       setSaveError(e instanceof Error ? e.message : String(e));
     } finally {
       setSaving(false);
     }
-  }, [def, reloadBanner]);
+  }, [def, reloadBanner, editSessionActions]);
 
   const handleDelete = useCallback(async () => {
     if (!kind || !decodedName) return;

--- a/frontend/src/components/generic-definition/GenericDefinitionEditor.tsx
+++ b/frontend/src/components/generic-definition/GenericDefinitionEditor.tsx
@@ -80,11 +80,16 @@ export function GenericDefinitionEditor() {
   // resourceId encoding:
   //   renameEntity location は entityId="<kind>/<name>" (例: "data-contract/Foo") を使うが、
   //   editSession.create の assertSafeName は `/` を許容しない。frontend では `/` → `__` に
-  //   encode し、backend wsHandlers/refactor.ts の makeFetchEditSessionsForRef で逆変換する。
+  //   encode し、backend wsHandlers/refactor.ts の makeFetchEditSessionsForRef でも同じ
+  //   encoding (`/` → `__`) を適用して stored resourceId と突合する。
   const editSessionRawId = kind && decodedName ? `${kind}/${decodedName}` : "";
   const editSessionSafeResourceId = editSessionRawId.replace(/\//g, "__");
   const editSessionIdRef = useRef<string | null>(null);
   const startingPromiseRef = useRef<Promise<string | null> | null>(null);
+  // どの resourceId に対して current editSessionIdRef が紐付くか追跡 (Codex Round 2 Must-fix)。
+  // 同 component が router 経由で `:kind/:name` 変更 (Tab A → B 遷移) で stay-mounted する場合、
+  // 旧 resource の session が新 resource にずれ込むのを防ぐ。
+  const sessionResourceIdRef = useRef<string>("");
 
   // 編集開始: 同 mount 内で重複 create を防ぐため startingPromiseRef を await。
   // 失敗時は次の updateDef で再試行可能 (idRef / promiseRef を null に戻す)。
@@ -92,14 +97,16 @@ export function GenericDefinitionEditor() {
     if (editSessionIdRef.current) return editSessionIdRef.current;
     if (startingPromiseRef.current) return startingPromiseRef.current;
     if (!editSessionSafeResourceId) return null;
+    const targetResourceId = editSessionSafeResourceId;
     const promise = (async (): Promise<string | null> => {
       try {
         const result = await mcpBridge.request("editSession.create", {
           resourceType: "generic-definition",
-          resourceId: editSessionSafeResourceId,
+          resourceId: targetResourceId,
         }) as { editSession?: { id?: string } } | null;
         const id = result?.editSession?.id ?? null;
         editSessionIdRef.current = id;
+        sessionResourceIdRef.current = targetResourceId;
         return id;
       } catch (e) {
         console.warn("[GenericDefinitionEditor] editSession.create failed:", e);
@@ -113,7 +120,7 @@ export function GenericDefinitionEditor() {
   }, [editSessionSafeResourceId]);
 
   // 破棄: pending startEditing があれば先に解決を待ち、その後 editSessionId が確定したら discard。
-  // unmount + save 後の両方で呼ぶ。
+  // unmount + save 後 + resourceId 変更時の 3 経路で呼ぶ。
   const discardEditSession = useCallback(async (): Promise<void> => {
     if (startingPromiseRef.current) {
       try { await startingPromiseRef.current; } catch { /* create failed = nothing to discard */ }
@@ -121,12 +128,25 @@ export function GenericDefinitionEditor() {
     const id = editSessionIdRef.current;
     if (!id) return;
     editSessionIdRef.current = null;
+    sessionResourceIdRef.current = "";
     try {
       await mcpBridge.request("editSession.discard", { editSessionId: id });
     } catch (e) {
       console.warn("[GenericDefinitionEditor] editSession.discard failed:", e);
     }
   }, []);
+
+  // Codex Round 2 Must-fix: route param 変更 (例: GenericDefinition A → B へ遷移) で
+  // editSessionSafeResourceId が変わったら、旧 resource の active session を discard する。
+  // sessionResourceIdRef が空 (= まだ create していない) なら no-op。
+  useEffect(() => {
+    if (sessionResourceIdRef.current && sessionResourceIdRef.current !== editSessionSafeResourceId) {
+      // discard 内で pending start を await + idRef / sessionResourceIdRef を reset。
+      // 旧 session の create が pending 中でも、await pending → 完了後に discard が走るため
+      // orphan は残らない (新 resource 用 ensureEditSession は次の updateDef で再起動)。
+      discardEditSession().catch(() => { /* logged inside */ });
+    }
+  }, [editSessionSafeResourceId, discardEditSession]);
 
   useEffect(() => {
     if (!kind || !decodedName) return;

--- a/frontend/src/components/screen-items/ScreenItemsView.tsx
+++ b/frontend/src/components/screen-items/ScreenItemsView.tsx
@@ -29,6 +29,10 @@ import {
 import { SaveConflictDialog } from "../editing/SaveConflictDialog";
 import { ResumeOrDiscardDialog } from "../editing/ResumeOrDiscardDialog";
 import { setDirty as setTabDirty, makeTabId } from "../../store/tabStore";
+import { RenameEntityDialog } from "../common/RenameEntityDialog";
+import { RenameEntityUndoToast } from "../common/RenameEntityUndoToast";
+import { useRenameEntityUndoToast } from "../common/useRenameEntityUndoToast";
+import { handleRenameSuccess } from "../../utils/handleRenameSuccess";
 import {
   loadScreenItems,
   saveScreenItems,
@@ -120,7 +124,7 @@ function defaultEffectFor(kind: ScreenItemEventEffect["kind"]): ScreenItemEventE
 export function ScreenItemsView() {
   const { screenId } = useParams<{ screenId: string }>();
   const navigate = useNavigate();
-  const { wsPath } = useWorkspacePath();
+  const { wsPath, wsId } = useWorkspacePath();
   const [screens, setScreens] = useState<ScreenMeta[]>([]);
   const [candidatesModalOpen, setCandidatesModalOpen] = useState(false);
   const [conventions, setConventions] = useState<ConventionsCatalog | null>(null);
@@ -136,6 +140,15 @@ export function ScreenItemsView() {
   const [showDiscardDialog, setShowDiscardDialog] = useState(false);
   const [showForceReleaseDialog, setShowForceReleaseDialog] = useState(false);
   const [showResumeDialog, setShowResumeDialog] = useState(false);
+
+  // #1330: ScreenItemsView 起点の Screen rename refactor。完了後は Items 画面に留まる。
+  const [showRenameDialog, setShowRenameDialog] = useState(false);
+  const [allScreenIds, setAllScreenIds] = useState<string[]>([]);
+  const [renameUndoToast, setRenameUndoToast] = useRenameEntityUndoToast(
+    "screen",
+    screenId ?? "",
+    wsId,
+  );
 
   const sessionId = mcpBridge.getSessionId();
 
@@ -226,6 +239,7 @@ export function ScreenItemsView() {
   }, []);
 
   // 画面一覧をロード (初回 + MCP 接続復帰時)。onNotFound ハンドリング用に画面一覧も保持。
+  // #1330: rename dialog 用に allScreenIds (全 Screen.id 配列) も同時更新する。
   useEffect(() => {
     let mounted = true;
     const doLoad = () => {
@@ -233,6 +247,7 @@ export function ScreenItemsView() {
         if (!mounted) return;
         const metas = p.screens.map((s) => ({ id: s.id, name: s.name }));
         setScreens(metas);
+        setAllScreenIds(p.screens.map((s) => s.id));
         // screenId が存在しない場合は画面一覧へ遷移
         if (screenId && !metas.some((m) => m.id === screenId)) {
           navigate(wsPath("/screen/list"), { replace: true });
@@ -871,16 +886,30 @@ export function ScreenItemsView() {
         }
         undoRedo={{ onUndo: undo, onRedo: redo, canUndo, canRedo }}
         extraRight={
-          <EditSessionDropdown
-            resourceType="screen-item"
-            resourceId={screenId ?? ""}
-            currentMode={mode}
-            currentSessionId={sessionId}
-            onStartEditing={() => { void actions.startEditing(); }}
-            onViewerAttached={syncSessionToUrl}
-            onAttachAsView={attach}
-            onTakeOver={takeOver}
-          />
+          <>
+            {/* #1330: Screen rename refactor を ScreenItemsView 起点でも起動可能にする */}
+            {screenId && (
+              <button
+                type="button"
+                className="btn btn-sm btn-outline-secondary me-2"
+                onClick={() => setShowRenameDialog(true)}
+                title="この画面の ID を変更します (参照を一括更新)"
+              >
+                <i className="bi bi-pencil-square me-1" />
+                ID 変更
+              </button>
+            )}
+            <EditSessionDropdown
+              resourceType="screen-item"
+              resourceId={screenId ?? ""}
+              currentMode={mode}
+              currentSessionId={sessionId}
+              onStartEditing={() => { void actions.startEditing(); }}
+              onViewerAttached={syncSessionToUrl}
+              onAttachAsView={attach}
+              onTakeOver={takeOver}
+            />
+          </>
         }
         saveReset={isReadonly ? undefined : { isDirty, isSaving, onSave: handleSave, onReset: () => setShowDiscardDialog(true) }}
       />
@@ -1923,6 +1952,65 @@ export function ScreenItemsView() {
             }
           }}
           onCancel={onSaveConflictCancel}
+        />
+      )}
+
+      {/* #1330: ScreenItemsView 起点の Screen rename refactor dialog */}
+      {showRenameDialog && screenId && (
+        <RenameEntityDialog
+          entityType="screen"
+          currentId={screenId}
+          currentName={selectedScreenName ?? ""}
+          existingIds={allScreenIds}
+          fetchExistingIds={async () => {
+            const project = await loadProject();
+            return (project.screens ?? []).map((s) => s.id);
+          }}
+          onClose={() => setShowRenameDialog(false)}
+          onSuccess={(newId, operationId, extra) => {
+            setShowRenameDialog(false);
+            handleRenameSuccess({
+              entityType: "screen",
+              oldId: screenId,
+              newId,
+              label: selectedScreenName ?? newId,
+              navigate,
+              wsPath,
+              wsId,
+              // #1330: ItemsView 起点 → screen-items tab + /screen/items/<newId> へ navigate
+              originTabType: "screen-items",
+              originRoute: (id) => `/screen/items/${id}`,
+            });
+            setRenameUndoToast({
+              operationId, oldId: screenId, newId,
+              ttlMs: extra?.ttlMs,
+            });
+          }}
+        />
+      )}
+
+      {renameUndoToast && (
+        <RenameEntityUndoToast
+          operationId={renameUndoToast.operationId}
+          oldId={renameUndoToast.oldId}
+          newId={renameUndoToast.newId}
+          ttlMs={renameUndoToast.ttlMs}
+          entityLabel="画面"
+          onUndo={() => {
+            handleRenameSuccess({
+              entityType: "screen",
+              oldId: renameUndoToast.newId,
+              newId: renameUndoToast.oldId,
+              label: selectedScreenName ?? renameUndoToast.oldId,
+              navigate,
+              wsPath,
+              wsId,
+              originTabType: "screen-items",
+              originRoute: (id) => `/screen/items/${id}`,
+            });
+            setRenameUndoToast(null);
+          }}
+          onDismiss={() => setRenameUndoToast(null)}
         />
       )}
     </div>

--- a/frontend/src/components/table/ErDiagram.tsx
+++ b/frontend/src/components/table/ErDiagram.tsx
@@ -34,6 +34,7 @@ import { generateUUID } from "../../utils/uuid";
 import { useUndoKeyboard } from "../../hooks/useUndoKeyboard";
 import { useSaveShortcut } from "../../hooks/useSaveShortcut";
 import { useEditSession } from "../../hooks/useEditSession";
+import { EntityIdInput, type EntityIdValidationState } from "../common/EntityIdInput";
 import { EditSessionDropdown } from "../editing/EditSessionDropdown";
 import { SaveConflictDialog } from "../editing/SaveConflictDialog";
 import html2canvas from "html2canvas";
@@ -317,9 +318,10 @@ function ErDiagramInner() {
   }, [isReadonly, persistLayoutChange, pushLayoutUndo]);
 
   // Add table from ER diagram
-  const handleAddTable = useCallback(async (physicalName: string, displayName: string, category?: string) => {
+  // RFC #1284 / #1329: kebab-case id を modal で受け取って createTable に渡す (UUID 形式禁止)。
+  const handleAddTable = useCallback(async (physicalName: string, displayName: string, id: string, category?: string) => {
     if (isReadonly) return;
-    const table = await createTable(physicalName as PhysicalName, displayName as DisplayName, "", category);
+    const table = await createTable(physicalName as PhysicalName, displayName as DisplayName, "", category, { id });
     const newTable = await loadTable(table.id);
     if (newTable) {
       setTables((prev) => [...prev, newTable]);
@@ -541,6 +543,7 @@ function ErDiagramInner() {
       {/* Add Table Modal */}
       {showAddTable && (
         <AddTableFromErModal
+          existingIds={tables.map((t) => t.id)}
           onAdd={handleAddTable}
           onClose={() => setShowAddTable(false)}
         />
@@ -717,14 +720,28 @@ function AddRelationModal({
 // ── ER図からテーブル追加モーダル ──────────────────────────────────────────
 
 function AddTableFromErModal({
-  onAdd, onClose,
+  existingIds, onAdd, onClose,
 }: {
-  onAdd: (physicalName: string, displayName: string, category?: string) => void;
+  existingIds: readonly string[];
+  onAdd: (physicalName: string, displayName: string, id: string, category?: string) => void;
   onClose: () => void;
 }) {
   const [physicalName, setPhysicalName] = useState("");
   const [displayName, setDisplayName] = useState("");
   const [category, setCategory] = useState("");
+  // RFC #1284 / #1329: kebab-case id 入力欄 (EntityIdInput) を ER 図 inline create にも追加。
+  // TableListView add dialog と同パターン (全創成経路で EntityIdInput 経由化が RFC 目標)。
+  const [id, setId] = useState("");
+  const [idValidation, setIdValidation] = useState<EntityIdValidationState>({
+    isFormatValid: false,
+    isUnique: true,
+    isInvalid: true,
+  });
+  const canSubmit = !!physicalName.trim() && !!displayName.trim() && !idValidation.isInvalid;
+  const submit = () => {
+    if (!canSubmit) return;
+    onAdd(physicalName.trim(), displayName.trim(), id.trim(), category || undefined);
+  };
 
   return (
     <div className="tbl-modal-overlay" onClick={onClose}>
@@ -740,7 +757,7 @@ function AddTableFromErModal({
             onChange={(e) => setPhysicalName(e.target.value)}
             placeholder="customers"
             autoFocus
-            onKeyDown={(e) => { if (e.key === "Enter" && physicalName.trim() && displayName.trim()) onAdd(physicalName.trim(), displayName.trim(), category || undefined); }}
+            onKeyDown={(e) => { if (e.key === "Enter") submit(); }}
           />
         </label>
         <label className="tbl-field">
@@ -750,7 +767,19 @@ function AddTableFromErModal({
             value={displayName}
             onChange={(e) => setDisplayName(e.target.value)}
             placeholder="顧客マスタ"
-            onKeyDown={(e) => { if (e.key === "Enter" && physicalName.trim() && displayName.trim()) onAdd(physicalName.trim(), displayName.trim(), category || undefined); }}
+            onKeyDown={(e) => { if (e.key === "Enter") submit(); }}
+          />
+        </label>
+        <label className="tbl-field">
+          <span>ID <small>(kebab-case)</small></span>
+          <EntityIdInput
+            value={id}
+            onChange={setId}
+            name={displayName}
+            existingIds={existingIds}
+            entityLabel="テーブル定義"
+            onEnter={submit}
+            onValidationChange={setIdValidation}
           />
         </label>
         <label className="tbl-field">
@@ -769,8 +798,8 @@ function AddTableFromErModal({
           <button className="tbl-btn tbl-btn-ghost" onClick={onClose}>キャンセル</button>
           <button
             className="tbl-btn tbl-btn-primary"
-            onClick={() => onAdd(physicalName.trim(), displayName.trim(), category || undefined)}
-            disabled={!physicalName.trim() || !displayName.trim()}
+            onClick={submit}
+            disabled={!canSubmit}
           >
             追加
           </button>

--- a/frontend/src/types/draft.ts
+++ b/frontend/src/types/draft.ts
@@ -11,4 +11,5 @@ export type DraftResourceType =
   | "extension"
   | "convention"
   | "flow"  // #690 PR-7: 画面遷移図用
-  | "er-layout";
+  | "er-layout"
+  | "generic-definition";  // #1331: GenericDefinition (kind/name 複合 id)

--- a/frontend/src/utils/handleRenameSuccess.ts
+++ b/frontend/src/utils/handleRenameSuccess.ts
@@ -18,6 +18,7 @@ import {
   closeTab,
   openTab,
   makeTabId,
+  type TabType,
 } from "../store/tabStore";
 import { _emitTableChangeForRename } from "../store/tableStore";
 import type { TableId } from "../types/v3/common";
@@ -41,6 +42,26 @@ export interface HandleRenameSuccessParams {
    * 省略時は従来動作 (`_` placeholder)。
    */
   wsId?: string;
+  /**
+   * #1330: rename 起動点が Designer / 各 entity 既定の editor 以外の場合に
+   * tab / navigate 先を override する。
+   *
+   * - `originTabType`: rename 完了後に open する tab type (省略時は `meta.tabType`)。
+   *   - Designer 起動 = undefined (default)
+   *   - ScreenItemsView 起動 = "screen-items"
+   *   - ScreenListView / ScreenFlow 起動 = undefined (per-resource tab を open しない)
+   * - `originRoute`: rename 完了後の navigate 先 path (省略時は `meta.editRoute(newId)`)。
+   *   - Items 起動 = `(id) => /screen/items/${id}`
+   *   - List 起動 = `() => /screen/list`
+   *   - Flow 起動 = `() => /screen/flow`
+   * - `skipOpenNewTab`: true なら新 tab を開かず navigate のみ。List / Flow singleton 起動用。
+   *
+   * 注: oldId の meta.tabType tab は常に close する (stale design tab 防止)。
+   *     originTabType が meta.tabType と異なる場合、追加で originTabType:oldId も close する。
+   */
+  originTabType?: TabType;
+  originRoute?: (newId: string) => string;
+  skipOpenNewTab?: boolean;
 }
 
 /**
@@ -57,10 +78,12 @@ export function handleRenameSuccess({
   navigate,
   wsPath,
   wsId,
+  originTabType,
+  originRoute,
+  skipOpenNewTab,
 }: HandleRenameSuccessParams): void {
   const meta = getRenameEntityMeta(entityType);
-  const oldTabId = makeTabId(meta.tabType, oldId);
-  const newTabId = makeTabId(meta.tabType, newId);
+  const effectiveTabType: TabType = originTabType ?? meta.tabType;
 
   // I-7 Round 2 F-3 (#1299 Codex review M-4 / Opus review M-2):
   // rename / undo 完了直後の窓 (broadcast 受信→reload→load(currentUrlId)=null) で
@@ -72,19 +95,28 @@ export function handleRenameSuccess({
   markRenameInProgress(entityType, oldId, wsId);
   markRenameInProgress(entityType, newId, wsId);
 
-  // 旧 tab は force=true で閉じる (refactor 完了で dirty 警告は不要)
-  closeTab(oldTabId, true);
+  // 旧 meta tab は常に close (stale 防止; Screen の場合 design:oldId が stale になる)。
+  // #1330: ItemsView 起動など originTabType が meta.tabType と異なる場合、追加で
+  //        originTabType:oldId も close (両方の stale tab を一度に掃除)。
+  closeTab(makeTabId(meta.tabType, oldId), true);
+  if (originTabType && originTabType !== meta.tabType) {
+    closeTab(makeTabId(originTabType, oldId), true);
+  }
 
-  // 新 tab を開く (既存なら label 更新 + active)
-  openTab({
-    id: newTabId,
-    type: meta.tabType,
-    resourceId: newId,
-    label: label && label.length > 0 ? label : newId,
-  });
+  // 新 tab を開く (#1330: skipOpenNewTab=true なら open せず navigate のみ。
+  // List / Flow singleton 起動はその場 (一覧/フロー画面) に留まる)。
+  if (!skipOpenNewTab) {
+    openTab({
+      id: makeTabId(effectiveTabType, newId),
+      type: effectiveTabType,
+      resourceId: newId,
+      label: label && label.length > 0 ? label : newId,
+    });
+  }
 
-  // URL を新 id に hard redirect (replace=true で履歴汚染を防ぐ)
-  navigate(wsPath(meta.editRoute(newId)), { replace: true });
+  // URL を navigate (#1330: originRoute 優先、無ければ meta.editRoute)
+  const targetPath = originRoute ? originRoute(newId) : meta.editRoute(newId);
+  navigate(wsPath(targetPath), { replace: true });
 
   // Phase J Must-fix E (#1298 round 4 Antigravity M-7): 同一 client 内 local pubsub に
   // rename 通知を発行。backend broadcast (`<entityType>Changed`) は network round trip が


### PR DESCRIPTION
## 概要

RFC #1284 (#1298 I-6 / #1297 I-5 follow-up シリーズ) の周辺機能を 3 ISSUE 統合 PR で完遂。

| ISSUE | 内容 |
|---|---|
| #1329 | duplicate / ErDiagram inline create 経路も kebab-case id 化 (UUID 形式排除) |
| #1330 | Designer 外起点 (ScreenItemsView/ScreenListView/ScreenFlow) からの Screen rename refactor |
| #1331 | GenericDefinition の EditSession 統合 Phase 1 (rename block 検証) |

## #1329 修正内容

- `frontend/src/components/flow/FlowEditor.tsx:570-619` — handleDuplicateNode で `makeDuplicatedEntityId(srcId, existingIds)` 経由の `<元 id>-copy[-N]` id を `addScreen({ id })` に渡す
- `frontend/src/components/table/ErDiagram.tsx:320-328` / 同 file `AddTableFromErModal` — EntityIdInput を組込 (displayName から AI 提案 + uniqueness 警告)、handleAddTable シグネチャに `id` 引数追加

acceptance (#1329):
- [x] FlowEditor.handleDuplicate で kebab-case id (UUID 形式禁止)
- [x] ErDiagram.handleAddTable で kebab-case id (UI 入力 + AI 提案 + uniqueness)
- [x] TableListView duplicate は #1297 で既対応済 (今回 scope 外)
- [x] uniqueness 衝突時の UX は EntityIdInput が「<候補> を適用」ボタンで明示

判断根拠: 「複製」は元 id 派生で UX 1 click 維持、「新規創成」(ER 図 inline create) は EntityIdInput を挟んで RFC #1284 「全創成経路で kebab-case id 入力 + AI 提案」目標と整合。

## #1330 修正内容

- `frontend/src/utils/handleRenameSuccess.ts:27-95` — `originTabType` / `originRoute` / `skipOpenNewTab` の 3 オプションを追加。起動点別に navigate 先 + tab 制御を切替
- `frontend/src/components/screen-items/ScreenItemsView.tsx` — EditorHeader extraRight に「ID 変更」ボタン、`originTabType: "screen-items"` + `originRoute: (id) => /screen/items/<id>` で起動
- `frontend/src/components/flow/ScreenListView.tsx` — row context menu に「ID 変更…」(単一選択時のみ有効)、`skipOpenNewTab: true` + `originRoute: () => "/screen/list"` で一覧に留まる
- `frontend/src/components/flow/FlowEditor.tsx` — node 右クリック menu に「ID 変更…」、`skipOpenNewTab: true` + `originRoute: () => "/screen/flow"` でフロー図に留まる
- (Round 1 fix) Codex Round 1 Should-fix: rename undo toast lifecycle race を `renamedToastNewId` 独立 state で回避

acceptance (#1330):
- [x] ScreenItemsView header に「ID 変更」ボタン
- [x] ScreenListView row context menu に「ID 変更…」
- [x] ScreenFlow node 右クリックで「ID 変更…」
- [x] rename 後 起動点 URL に navigate (Designer → /screen/design/<newId>、Items → /screen/items/<newId>、List → /screen/list、Flow → /screen/flow)
- [ ] Playwright e2e: ScreenItemsView/List/Flow 起動の rename smoke → **follow-up #1370** で trace 確立 (priority: low、3 spec の具体スコープ付き)

## #1331 修正内容 (Phase 1 のみ — Phase 2 は #1368 で trace)

- `backend/src/editSessionStore.ts:25-39` / `frontend/src/types/draft.ts:1-15` — DraftResourceType に "generic-definition" 追加 (両 file 同期)
- `backend/src/wsHandlers/refactor.ts:79-92,133-140` — INTERNAL_KIND_TO_RESOURCE_TYPE に `genericDefinition: "generic-definition"` 追加 + makeFetchEditSessionsForRef で entityId の `/` → `__` 逆変換 (assertSafeName 通過用 encoding に追従)
- `frontend/src/components/generic-definition/GenericDefinitionEditor.tsx` — mcpBridge.request("editSession.create"/"editSession.discard") を直接呼ぶ実装。lazy ensureEditSession (updateDef 初回) + save 後 / unmount で discardEditSession (pending start を await してから discard で race 回避)
- `backend/src/renameEntity.test.ts` — GenericDefinition Edit session active 時の Table rename block 検証 test 追加
- `frontend/src/components/generic-definition/GenericDefinitionEditor.test.tsx` — mcpBridge mock 拡充

(Round 1 fix) Codex Round 1 Must-fix 2: useEditSession 経由は startEditing() Promise 解決前 unmount で discard skip → orphan session の race があった。直接呼出 + pending Promise 追跡で解消。副次的に `/` → `__` encoding で assertSafeName 通過。

acceptance (#1331):
- [x] GenericDefinitionEditor で他 session の rename を block (preview.concurrentEditRefs)
- [ ] 編集中に他 session が save した場合 SaveConflictDialog 表示 → **Phase 2 follow-up #1368** で trace 確立 (saveGenericDefinition RPC に mtime tracking を追加する backend 拡張要)
- [x] 既存テスト regression なし
- [x] backend rename test に GenericDefinition EditSession active 時の block 検証を追加

Phase 1 / Phase 2 分割の根拠: ISSUE 本文も「規模感大きく独立スコープ」と明記。Phase 2 は backend save RPC の mtime tracking 拡張が独立スコープのため別 ISSUE で trace。

## 検証

- frontend: `npx tsc --noEmit` 0 errors / `npm run build` 0 errors / `npx vitest run` 3004 passed | 1 skipped (204 files)
- backend: `npx tsc --noEmit` 0 errors / `npm run build` 0 errors / `npx vitest run` 783 passed (37 files、renameEntity.test.ts +1 新 test)

## schema 変更

なし (#511 governance に反する変更なし)。

## 関連

- 親メタ: #1292 (RFC #1284 シリーズ)
- 親 ISSUE: #1297 (I-5) / #1298 (I-6) / #1299 (I-7) — いずれも完了済
- follow-up:
  - #1368 (#1331 Phase 2 — SaveConflictDialog with mtime tracking)
  - #1370 (#1330 Playwright e2e smoke 3 spec)

Closes #1329
Closes #1330
Closes #1331

🤖 Generated with [Claude Code](https://claude.com/claude-code)