### PR TITLE
fix(generic-definition): #1368 — save を editSession.save 経由に統合 + SaveConflictDialog 対応

### DIFF
--- a/backend/src/handlers/editSession.ts
+++ b/backend/src/handlers/editSession.ts
@@ -18,6 +18,7 @@
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { wsBridge } from "../wsBridge.js";
 import { assertEntityIdMcp, type ToolHandler } from "../mcpHelpers.js";
+import { isValidKind, isValidSafeName } from "../security/idValidator.js";
 
 /**
  * #1332 Codex 10 巡目 M2: editSession__create / editSession__list の resourceId に
@@ -46,10 +47,40 @@ const SCREEN_DERIVED_RESOURCE_TYPES = new Set(["screen-item", "puck-data"]);
 /**
  * resourceType に応じた resourceId 検証。
  * 検証失敗時は McpError を throw する (caller は catch しない設計)。
+ *
+ * #1368 Codex Round 4 Should-fix: `generic-definition` は WS handler
+ * (`backend/src/wsHandlers/editSession.ts:assertResourceId`) と同じ
+ * `${kind}__${name}` composite 形式の decoded 検証を行い、AI/MCP 経路と
+ * browser/WS 経路で validation 契約を揃える。
  */
 function assertResourceIdForType(resourceType: string, resourceId: string): void {
   if (TOP_LEVEL_RESOURCE_TYPES.has(resourceType) || SCREEN_DERIVED_RESOURCE_TYPES.has(resourceType)) {
     assertEntityIdMcp(resourceId, "resourceId");
+    return;
+  }
+  if (resourceType === "generic-definition") {
+    // composite `${kind}__${name}` を decode して個別検証 (WS handler と同一契約)
+    const sep = resourceId.indexOf("__");
+    if (sep < 0) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `generic-definition resourceId は '\${kind}__\${name}' 形式である必要があります (got: ${JSON.stringify(resourceId)})`,
+      );
+    }
+    const decodedKind = resourceId.slice(0, sep);
+    const decodedName = resourceId.slice(sep + 2);
+    if (!isValidKind(decodedKind)) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `generic-definition resourceId の decoded kind が不正です: must match [a-z][a-z0-9:-]{0,63} (got: ${JSON.stringify(decodedKind)})`,
+      );
+    }
+    if (!isValidSafeName(decodedName)) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `generic-definition resourceId の decoded name が不正です: must match [A-Za-z0-9_-]{1,64} (got: ${JSON.stringify(decodedName)})`,
+      );
+    }
     return;
   }
   // singleton / 別管理 resource type は空文字のみ拒否

--- a/backend/src/tools.ts
+++ b/backend/src/tools.ts
@@ -1516,9 +1516,15 @@ export const tools = [
       properties: {
         resourceType: {
           type: "string",
+          // #1368: editSessionStore.ts DraftResourceType と同期。WS handler の
+          // VALID_RESOURCE_TYPES とも一致させる (#1331 で `generic-definition` を、
+          // 先行 PR で `page-layout` / `er-layout` を DraftResourceType に追加済だが
+          // MCP enum が漏れていた)。AI/MCP 経路で editSession.create を叩けないと
+          // GenericDefinition / PageLayout / ER 系の AI 編集が機能しない。
           enum: [
             "screen", "puck-data", "table", "process-flow", "view", "view-definition",
-            "screen-item", "sequence", "extension", "convention", "flow",
+            "page-layout", "screen-item", "sequence", "extension", "convention", "flow",
+            "er-layout", "generic-definition",
           ],
           description: "編集対象 resource の種別",
         },

--- a/backend/src/wsBridge/editSessionService.test.ts
+++ b/backend/src/wsBridge/editSessionService.test.ts
@@ -85,6 +85,50 @@ describe("EditSessionService.save resource change broadcast", () => {
     expect(deliveredClientIds).not.toContain("client-other-workspace");
   });
 
+  it("#1368 Codex Round 2 Must-fix: WS handler editSession.create が resourceType=\"generic-definition\" を accept する (VALID_RESOURCE_TYPES allowlist)", async () => {
+    // backend/src/wsHandlers/editSession.ts の VALID_RESOURCE_TYPES に "generic-definition"
+    // が含まれていないと、frontend GenericDefinitionEditor の `editSession.create` が
+    // assertResourceType で reject される (Round 2 で観測 — 実 browser 経路で動作不能だった)。
+    //
+    // editSessionHandlers["editSession.create"] を直接呼出し、stub bridge で
+    // editSessionCreate を caputure する。
+    const { editSessionHandlers } = await import("../wsHandlers/editSession.js");
+    const createHandler = editSessionHandlers["editSession.create"];
+    expect(createHandler).toBeDefined();
+
+    let respondedResult: unknown = undefined;
+    let respondedError: string | undefined;
+    const captures: Array<{ clientId: string; rt: string; rid: string }> = [];
+    const stubBridge = {
+      editSessionCreate: (clientId: string, rt: string, rid: string, _label?: string) => {
+        captures.push({ clientId, rt, rid });
+        return { editSession: { id: "stub-es-id", resourceType: rt, resourceId: rid } };
+      },
+    };
+
+    await createHandler({
+      params: {
+        resourceType: "generic-definition",
+        resourceId: "data-contract__OrderForm",
+        displayLabel: "tester",
+      },
+      clientId: "client-test",
+      root: () => tmpDir,
+      wsId: () => tmpDir,
+      respond: (r) => { respondedResult = r; },
+      respondError: (e) => { respondedError = e; },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      bridge: stubBridge as any,
+    });
+
+    expect(respondedError).toBeUndefined();
+    expect(respondedResult).toEqual({
+      editSession: { id: "stub-es-id", resourceType: "generic-definition", resourceId: "data-contract__OrderForm" },
+    });
+    expect(captures).toHaveLength(1);
+    expect(captures[0]).toMatchObject({ rt: "generic-definition", rid: "data-contract__OrderForm" });
+  });
+
   it("#1368 Codex Round 1 Must-fix: 不正な decoded kind / name は store.save 前に reject される", async () => {
     // 不正な kind ( `_` を含む = kind regex `[a-z][a-z0-9:-]{0,63}` 違反)
     // resourceId 全体としては assertSafeName `[A-Za-z0-9_-]{1,64}` を通る (= editSession.create で reject されない)

--- a/backend/src/wsBridge/editSessionService.test.ts
+++ b/backend/src/wsBridge/editSessionService.test.ts
@@ -85,6 +85,44 @@ describe("EditSessionService.save resource change broadcast", () => {
     expect(deliveredClientIds).not.toContain("client-other-workspace");
   });
 
+  it("#1368: generic-definition は resourceId を `${kind}__${name}` から分解して file 書込 + genericDefinitionChanged broadcast", async () => {
+    // frontend は editSessionRawId = `${kind}/${name}` を `/` → `__` 置換した resourceId を渡す。
+    // backend は `__` を delimiter として分割し、kind / name を復元して writeGenericDefinition で保存する。
+    const kind = "data-contract";
+    const name = "OrderForm";
+    const resourceId = `${kind}__${name}`;
+    const payload = {
+      $schema: "../../../../schemas/v3/generic-definition.v3.schema.json",
+      name,
+      kind,
+      purpose: "受注フォームのデータ契約",
+      responsibilities: ["商品コード入力", "数量入力"],
+      targets: ["frontend"],
+    };
+
+    const { editSession } = service.create("client-editor", "generic-definition", resourceId, "編集者A");
+    const editSessionId = (editSession as { id: string }).id;
+    service.update("client-editor", editSessionId, payload);
+
+    const result = await service.save("client-editor", editSessionId);
+    expect(result.ok).toBe(true);
+
+    // broadcast event 確認
+    const gdChanged = broadcasts.find((call) => call.event === "genericDefinitionChanged");
+    expect(gdChanged).toEqual({
+      wsId: tmpDir,
+      event: "genericDefinitionChanged",
+      data: { kind, name },
+    });
+    expect(gdChanged?.excludeClientId).toBeUndefined();
+
+    // 実 file 書込確認 (workspace 直下 data/generic-definitions/<kind>/<name>.json)
+    const filePath = path.join(tmpDir, "data", "generic-definitions", kind, `${name}.json`);
+    const written = JSON.parse(await fs.readFile(filePath, "utf-8")) as { kind: string; name: string };
+    expect(written.kind).toBe(kind);
+    expect(written.name).toBe(name);
+  });
+
   it("WsBridge adapter 経由でも originating editor と same-workspace consumer に tableChanged を送信する", async () => {
     const bridge = new WsBridge();
     const sentByClient = new Map<string, string[]>([

--- a/backend/src/wsBridge/editSessionService.test.ts
+++ b/backend/src/wsBridge/editSessionService.test.ts
@@ -85,6 +85,33 @@ describe("EditSessionService.save resource change broadcast", () => {
     expect(deliveredClientIds).not.toContain("client-other-workspace");
   });
 
+  it("#1368 Codex Round 1 Must-fix: 不正な decoded kind / name は store.save 前に reject される", async () => {
+    // 不正な kind ( `_` を含む = kind regex `[a-z][a-z0-9:-]{0,63}` 違反)
+    // resourceId 全体としては assertSafeName `[A-Za-z0-9_-]{1,64}` を通る (= editSession.create で reject されない)
+    // → 本 PR の pre-validation で reject されることを検証
+    const invalidResourceId = "data_contract__Order"; // `_` が kind 部に紛れている
+    const { editSession } = service.create("client-editor", "generic-definition", invalidResourceId, "編集者A");
+    const editSessionId = (editSession as { id: string }).id;
+    service.update("client-editor", editSessionId, { kind: "data_contract", name: "Order" });
+
+    await expect(service.save("client-editor", editSessionId)).rejects.toThrow(/decoded generic-definition kind/);
+
+    // store.save 前に reject されているため saveHistory には追加されていない
+    const gdChanged = broadcasts.find((call) => call.event === "genericDefinitionChanged");
+    expect(gdChanged).toBeUndefined();
+    const saved = broadcasts.find((call) => call.event === "editSession.saved");
+    expect(saved).toBeUndefined();
+  });
+
+  it("#1368 Codex Round 1 Must-fix: `__` separator 無しの resourceId は store.save 前に reject される", async () => {
+    const invalidResourceId = "no-separator-here";
+    const { editSession } = service.create("client-editor", "generic-definition", invalidResourceId, "編集者A");
+    const editSessionId = (editSession as { id: string }).id;
+    service.update("client-editor", editSessionId, { kind: "x", name: "Y" });
+
+    await expect(service.save("client-editor", editSessionId)).rejects.toThrow(/'__' separator not found/);
+  });
+
   it("#1368: generic-definition は resourceId を `${kind}__${name}` から分解して file 書込 + genericDefinitionChanged broadcast", async () => {
     // frontend は editSessionRawId = `${kind}/${name}` を `/` → `__` 置換した resourceId を渡す。
     // backend は `__` を delimiter として分割し、kind / name を復元して writeGenericDefinition で保存する。

--- a/backend/src/wsBridge/editSessionService.test.ts
+++ b/backend/src/wsBridge/editSessionService.test.ts
@@ -85,6 +85,76 @@ describe("EditSessionService.save resource change broadcast", () => {
     expect(deliveredClientIds).not.toContain("client-other-workspace");
   });
 
+  it("#1368 Codex Round 3 Must-fix: long composite generic-definition resourceId (>64 chars) も WS handler が accept する", async () => {
+    // assertSafeName は max 64 chars だが、`${kind}__${name}` 形式は最大 64 + 2 + 64 = 130 chars
+    // schema-valid な長い name で 64 chars を超える事例を捕捉する (Round 3 で観測):
+    //   kind = "data-contract" (13 chars), name = 52-char schema-valid name → 13+2+52 = 67 chars
+    const { editSessionHandlers } = await import("../wsHandlers/editSession.js");
+    const createHandler = editSessionHandlers["editSession.create"];
+    const longName = "A_very_long_but_schema_valid_generic_def_name_OrderForm";
+    expect(longName.length).toBe(55);
+    const longResourceId = `data-contract__${longName}`;
+    expect(longResourceId.length).toBeGreaterThan(64); // assertSafeName max 64 を超える
+
+    let respondedResult: unknown = undefined;
+    let respondedError: string | undefined;
+    const captures: Array<{ rid: string }> = [];
+    const stubBridge = {
+      editSessionCreate: (_clientId: string, _rt: string, rid: string) => {
+        captures.push({ rid });
+        return { editSession: { id: "stub-long-es", resourceId: rid } };
+      },
+    };
+
+    await createHandler({
+      params: {
+        resourceType: "generic-definition",
+        resourceId: longResourceId,
+        displayLabel: "tester",
+      },
+      clientId: "client-test",
+      root: () => tmpDir,
+      wsId: () => tmpDir,
+      respond: (r) => { respondedResult = r; },
+      respondError: (e) => { respondedError = e; },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      bridge: stubBridge as any,
+    });
+
+    expect(respondedError).toBeUndefined();
+    expect(respondedResult).toEqual({ editSession: { id: "stub-long-es", resourceId: longResourceId } });
+    expect(captures[0].rid).toBe(longResourceId);
+  });
+
+  it("#1368 Codex Round 3 Must-fix: WS handler が generic-definition resourceId の decoded kind / name を別個に検証する (invalid は reject)", async () => {
+    const { editSessionHandlers } = await import("../wsHandlers/editSession.js");
+    const createHandler = editSessionHandlers["editSession.create"];
+
+    // ケース 1: `__` separator 無し → reject
+    let errFromMissingSep: string | undefined;
+    await createHandler({
+      params: { resourceType: "generic-definition", resourceId: "no-separator-here" },
+      clientId: "c1", root: () => tmpDir, wsId: () => tmpDir,
+      respond: () => undefined,
+      respondError: (e) => { errFromMissingSep = e; },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      bridge: {} as any,
+    });
+    expect(errFromMissingSep).toMatch(/generic-definition resourceId.*'\${kind}__\${name}'/);
+
+    // ケース 2: 不正な decoded kind (`_` を含む = kind regex 違反) → reject
+    let errFromBadKind: string | undefined;
+    await createHandler({
+      params: { resourceType: "generic-definition", resourceId: "data_contract__Order" },
+      clientId: "c2", root: () => tmpDir, wsId: () => tmpDir,
+      respond: () => undefined,
+      respondError: (e) => { errFromBadKind = e; },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      bridge: {} as any,
+    });
+    expect(errFromBadKind).toMatch(/decoded kind/);
+  });
+
   it("#1368 Codex Round 2 Must-fix: WS handler editSession.create が resourceType=\"generic-definition\" を accept する (VALID_RESOURCE_TYPES allowlist)", async () => {
     // backend/src/wsHandlers/editSession.ts の VALID_RESOURCE_TYPES に "generic-definition"
     // が含まれていないと、frontend GenericDefinitionEditor の `editSession.create` が

--- a/backend/src/wsBridge/editSessionService.ts
+++ b/backend/src/wsBridge/editSessionService.ts
@@ -43,6 +43,7 @@ import {
   writeGenericDefinition,
   resolveRoot,
 } from "../projectStorage.js";
+import { assertKind, assertSafeName } from "../security/idValidator.js";
 
 /**
  * broadcast callback (wsBridge.broadcast を inject)。
@@ -343,6 +344,27 @@ export class EditSessionService {
       return { ok: true };
     }
 
+    // #1368 Codex Round 1 Must-fix: commit 前に resource-specific resourceId 整合性を
+    // 検証する。`store.save()` を呼ぶと saveHistory に記録され冪等に戻せないため、
+    // 「保存成功扱いだが本体 file 未書込」になるケースを最終 reject 点として防ぐ。
+    //
+    // generic-definition の resourceId は frontend で `${kind}/${name}` の `/` を `__` に
+    // 置換した encoded 形式で、create 時の `assertSafeName` は encoded 全体を検証するに
+    // 留まる (`data_contract__Order` のような偽 encoded もすり抜ける)。dispatcher 直前に
+    // decode 後の kind / name に `assertKind` / `assertSafeName` を適用する。
+    const sessionPreValidate = store.getById(editSessionId);
+    if (sessionPreValidate && sessionPreValidate.resourceType === "generic-definition") {
+      const resId = sessionPreValidate.resourceId;
+      const sep = resId.indexOf("__");
+      if (sep < 0) {
+        throw new Error(
+          `Invalid generic-definition resourceId: '__' separator not found (got: ${JSON.stringify(resId)})`,
+        );
+      }
+      assertKind(resId.slice(0, sep), "decoded generic-definition kind");
+      assertSafeName(resId.slice(sep + 2), "decoded generic-definition name");
+    }
+
     const saveEvent = await store.save(editSessionId, sessionId);
 
     // 本体 resource file へ atomic write (P1-1, #907 regression 解消)
@@ -398,14 +420,10 @@ export class EditSessionService {
             break;
           case "generic-definition": {
             // #1368: GenericDefinition の resourceId は frontend で `${kind}/${name}` の `/` を
-            // `__` に置換して `${kind}__${name}` 形式で渡される (assertSafeName は `/` を
-            // 許容しないため)。kind 正規表現 `[a-z][a-z0-9:-]{0,63}` は `_` を含まないので、
-            // 最初の `__` で分割すれば kind / name に安全に復元できる (name は `_` を含み得る)。
+            // `__` に置換して `${kind}__${name}` 形式で渡される。pre-validation (save method
+            // 冒頭) で sep>=0 / kind format / name format は確認済のため、ここでは re-parse
+            // のみで安全に decode できる。
             const sep = resId.indexOf("__");
-            if (sep < 0) {
-              console.error(`[editSession.save] generic-definition resourceId 形式不正 (${resId} に '__' が無い)`);
-              break;
-            }
             const gdKind = resId.slice(0, sep);
             const gdName = resId.slice(sep + 2);
             await writeGenericDefinition(gdName, gdKind, payload, root);

--- a/backend/src/wsBridge/editSessionService.ts
+++ b/backend/src/wsBridge/editSessionService.ts
@@ -348,10 +348,11 @@ export class EditSessionService {
     // 検証する。`store.save()` を呼ぶと saveHistory に記録され冪等に戻せないため、
     // 「保存成功扱いだが本体 file 未書込」になるケースを最終 reject 点として防ぐ。
     //
-    // generic-definition の resourceId は frontend で `${kind}/${name}` の `/` を `__` に
-    // 置換した encoded 形式で、create 時の `assertSafeName` は encoded 全体を検証するに
-    // 留まる (`data_contract__Order` のような偽 encoded もすり抜ける)。dispatcher 直前に
-    // decode 後の kind / name に `assertKind` / `assertSafeName` を適用する。
+    // Round 3 以降 WS handler (`wsHandlers/editSession.ts:assertResourceId`) と MCP
+    // handler (`handlers/editSession.ts:assertResourceIdForType`) が generic-definition の
+    // composite `${kind}__${name}` を decode して個別検証するようになったため、通常経路で
+    // ここに無効な値は届かない。本 service 直呼びテスト / 将来の経路追加に対する
+    // defense-in-depth として `assertKind` / `assertSafeName` を二重適用する。
     const sessionPreValidate = store.getById(editSessionId);
     if (sessionPreValidate && sessionPreValidate.resourceType === "generic-definition") {
       const resId = sessionPreValidate.resourceId;

--- a/backend/src/wsBridge/editSessionService.ts
+++ b/backend/src/wsBridge/editSessionService.ts
@@ -40,6 +40,7 @@ import {
   writePageLayout,
   writeScreenItems,
   writeSequence,
+  writeGenericDefinition,
   resolveRoot,
 } from "../projectStorage.js";
 
@@ -395,6 +396,22 @@ export class EditSessionService {
             await writeSequence(resId, payload, root);
             resourceChange = { event: "sequenceChanged", data: { sequenceId: resId } };
             break;
+          case "generic-definition": {
+            // #1368: GenericDefinition の resourceId は frontend で `${kind}/${name}` の `/` を
+            // `__` に置換して `${kind}__${name}` 形式で渡される (assertSafeName は `/` を
+            // 許容しないため)。kind 正規表現 `[a-z][a-z0-9:-]{0,63}` は `_` を含まないので、
+            // 最初の `__` で分割すれば kind / name に安全に復元できる (name は `_` を含み得る)。
+            const sep = resId.indexOf("__");
+            if (sep < 0) {
+              console.error(`[editSession.save] generic-definition resourceId 形式不正 (${resId} に '__' が無い)`);
+              break;
+            }
+            const gdKind = resId.slice(0, sep);
+            const gdName = resId.slice(sep + 2);
+            await writeGenericDefinition(gdName, gdKind, payload, root);
+            resourceChange = { event: "genericDefinitionChanged", data: { kind: gdKind, name: gdName } };
+            break;
+          }
           case "flow":
           case "er-layout":
           case "extension":

--- a/backend/src/wsHandlers/editSession.ts
+++ b/backend/src/wsHandlers/editSession.ts
@@ -11,7 +11,7 @@
  * 機能不変 — case body は一字一句変更なし。
  */
 import type { DraftResourceType as EditSessionResourceType } from "../editSessionStore.js";
-import { assertSafeName, assertHistoryId } from "../security/idValidator.js";
+import { assertSafeName, assertHistoryId, assertKind } from "../security/idValidator.js";
 import type { RpcHandlerMap } from "./types.js";
 
 const VALID_RESOURCE_TYPES = new Set<EditSessionResourceType>([
@@ -30,6 +30,43 @@ function assertResourceType(rt: unknown, label: string): EditSessionResourceType
   return rt as EditSessionResourceType;
 }
 
+/**
+ * #1368 Round 3: resourceType 別の resourceId validation。
+ *
+ * 多くの resource type (screen / table / process-flow / view 等) は resourceId が
+ * `[A-Za-z0-9_-]{1,64}` の単体 id なので `assertSafeName` で十分。
+ *
+ * 一方 `generic-definition` の resourceId は frontend で `${kind}/${name}` の `/` を
+ * `__` 置換した composite `${kind}__${name}` 形式 (assertSafeName が `/` を許容しないため)。
+ * 合計長は最大 64 (kind) + 2 (`__`) + 64 (name) = 130 chars に達し、assertSafeName の
+ * 64 char 上限を超えるため、合成 ID 全体に `assertSafeName` を掛けると schema-valid な
+ * 長い name が reject される (Codex Round 3 Must-fix)。
+ *
+ * `generic-definition` のみ `__` で分割して decoded kind / name を個別に
+ * `assertKind` / `assertSafeName` で検証する。
+ */
+function assertResourceId(
+  resourceType: EditSessionResourceType,
+  resourceId: unknown,
+  label: string,
+): string {
+  if (typeof resourceId !== "string") {
+    throw new Error(`Invalid ${label}: must be string (got ${typeof resourceId})`);
+  }
+  if (resourceType === "generic-definition") {
+    const sep = resourceId.indexOf("__");
+    if (sep < 0) {
+      throw new Error(
+        `Invalid ${label}: generic-definition resourceId must be '\${kind}__\${name}' (got ${JSON.stringify(resourceId)})`,
+      );
+    }
+    assertKind(resourceId.slice(0, sep), `${label} (decoded kind)`);
+    assertSafeName(resourceId.slice(sep + 2), `${label} (decoded name)`);
+    return resourceId;
+  }
+  return assertSafeName(resourceId, label);
+}
+
 export const editSessionHandlers: RpcHandlerMap = {
   "editSession.create": async ({ params, clientId, respond, respondError, bridge }) => {
     // #906: 公開 API editSessionCreate を adapter として呼ぶ (MCP tool と共有)
@@ -44,7 +81,7 @@ export const editSessionHandlers: RpcHandlerMap = {
     };
     try {
       const validatedRt = assertResourceType(esRt, "resourceType");
-      assertSafeName(esRid, "resourceId");
+      assertResourceId(validatedRt, esRid, "resourceId");
       const result = bridge.editSessionCreate(clientId, validatedRt, esRid, esLabel);
       respond(result);
     } catch (e) {
@@ -163,8 +200,16 @@ export const editSessionHandlers: RpcHandlerMap = {
       resourceId: esLstRid,
     } = (params ?? {}) as { resourceType?: EditSessionResourceType; resourceId?: string };
     try {
-      if (esLstRt !== undefined) assertResourceType(esLstRt, "resourceType");
-      if (esLstRid !== undefined) assertSafeName(esLstRid, "resourceId");
+      let validatedRt: EditSessionResourceType | undefined;
+      if (esLstRt !== undefined) validatedRt = assertResourceType(esLstRt, "resourceType");
+      if (esLstRid !== undefined) {
+        // #1368 Round 3: rt 既知なら resource-specific validation、未知なら safe-name fallback
+        if (validatedRt !== undefined) {
+          assertResourceId(validatedRt, esLstRid, "resourceId");
+        } else {
+          assertSafeName(esLstRid, "resourceId");
+        }
+      }
       const result = bridge.editSessionList(clientId, { resourceType: esLstRt, resourceId: esLstRid });
       respond(result);
     } catch (e) {
@@ -191,8 +236,9 @@ export const editSessionHandlers: RpcHandlerMap = {
       resourceId: esLhRid,
     } = (params ?? {}) as { resourceType: string; resourceId: string };
     try {
-      assertResourceType(esLhRt, "resourceType");
-      assertSafeName(esLhRid, "resourceId");
+      const validatedLhRt = assertResourceType(esLhRt, "resourceType");
+      // #1368 Round 3: resource-specific validation で long composite generic-definition も accept
+      assertResourceId(validatedLhRt, esLhRid, "resourceId");
       const result = await bridge.editSessionListHistory(clientId, esLhRt, esLhRid);
       respond(result);
     } catch (e) {

--- a/backend/src/wsHandlers/editSession.ts
+++ b/backend/src/wsHandlers/editSession.ts
@@ -8,7 +8,10 @@
  *
  * spec docs/spec/edit-session-protocol.md §14 / §15.1 に準拠。
  * 各 handler は wsBridge の公開 API (editSession*) を adapter として呼び出す。
- * 機能不変 — case body は一字一句変更なし。
+ *
+ * #1368 Round 3: resourceType 別の resourceId 検証 (`assertResourceId`) を新設し、
+ * `generic-definition` の `${kind}__${name}` composite (最大 130 chars) を decode して
+ * 個別検証する分岐を追加。それ以外の resource type は従来通り `assertSafeName` 適用。
  */
 import type { DraftResourceType as EditSessionResourceType } from "../editSessionStore.js";
 import { assertSafeName, assertHistoryId, assertKind } from "../security/idValidator.js";

--- a/backend/src/wsHandlers/editSession.ts
+++ b/backend/src/wsHandlers/editSession.ts
@@ -17,6 +17,10 @@ import type { RpcHandlerMap } from "./types.js";
 const VALID_RESOURCE_TYPES = new Set<EditSessionResourceType>([
   "screen", "puck-data", "table", "process-flow", "view", "view-definition",
   "page-layout", "screen-item", "sequence", "extension", "convention", "flow", "er-layout",
+  // #1368: GenericDefinition EditSession 統合 — frontend GenericDefinitionEditor が
+  // `editSession.create` に `resourceType: "generic-definition"` を送るため allowlist に追加。
+  // editSessionStore.ts DraftResourceType と同期 (#1331 で追加済)。
+  "generic-definition",
 ]);
 
 function assertResourceType(rt: unknown, label: string): EditSessionResourceType {

--- a/frontend/src/components/generic-definition/GenericDefinitionEditor.test.tsx
+++ b/frontend/src/components/generic-definition/GenericDefinitionEditor.test.tsx
@@ -6,6 +6,28 @@ import { GenericDefinitionEditor } from "./GenericDefinitionEditor";
 const saveGenericDefinition = vi.fn();
 let broadcastHandler: ((data: unknown) => void) | null = null;
 
+/**
+ * #1368: mcpBridge.request の per-method スタブ。各 test で挙動を上書き可能。
+ * - editSession.create: { editSession: { id: "test-es-1" } }
+ * - editSession.update: { sequence: 1 }
+ * - editSession.save: デフォルト { ok: true } / conflict 時は { ok: false, conflict: {...} }
+ * - editSession.discard: { discarded: true }
+ */
+const mcpRequest = vi.fn(async (method: string, _params?: unknown) => {
+  switch (method) {
+    case "editSession.create":
+      return { editSession: { id: "test-es-1" } };
+    case "editSession.update":
+      return { sequence: 1 };
+    case "editSession.save":
+      return { ok: true };
+    case "editSession.discard":
+      return { discarded: true };
+    default:
+      return {};
+  }
+});
+
 vi.mock("../../hooks/useWorkspacePath", () => ({
   useWorkspacePath: () => ({ wsPath: (path: string) => path }),
 }));
@@ -43,7 +65,7 @@ vi.mock("../../mcp/mcpBridge", () => ({
     }),
     // #1331: useEditSession 依存 — test では EditSession 連携は no-op で良い
     getSessionId: vi.fn(() => "test-session"),
-    request: vi.fn(async () => ({})),
+    request: (method: string, params?: unknown) => mcpRequest(method, params),
     onStatusChange: vi.fn(() => () => undefined),
     getStatus: vi.fn(() => "connected"),
     startWithoutEditor: vi.fn(),
@@ -52,8 +74,24 @@ vi.mock("../../mcp/mcpBridge", () => ({
 
 beforeEach(() => {
   saveGenericDefinition.mockReset();
+  mcpRequest.mockClear();
   broadcastHandler = null;
 });
+
+/**
+ * helper: editor を render して initial purpose input が出るまで待つ。
+ */
+async function renderEditor() {
+  const result = render(
+    <MemoryRouter initialEntries={["/generic-definition/data-contract/Order"]}>
+      <Routes>
+        <Route path="/generic-definition/:kind/:name" element={<GenericDefinitionEditor />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+  await screen.findByDisplayValue("initial purpose");
+  return result;
+}
 
 describe("GenericDefinitionEditor — Phase K stale save prevention", () => {
   it("dirty 編集中に rename reload を受信したら再読込まで保存を block する", async () => {
@@ -75,5 +113,180 @@ describe("GenericDefinitionEditor — Phase K stale save prevention", () => {
     expect(save.disabled).toBe(true);
     fireEvent.click(save);
     expect(saveGenericDefinition).not.toHaveBeenCalled();
+  });
+});
+
+describe("GenericDefinitionEditor — #1368 editSession.save 経路統合", () => {
+  it("save click は editSession.update + editSession.save 経由で commit する (saveGenericDefinition 直呼びはしない)", async () => {
+    await renderEditor();
+
+    // 編集して dirty 状態にしてから save
+    const purpose = screen.getByDisplayValue("initial purpose");
+    fireEvent.change(purpose, { target: { value: "edited purpose" } });
+
+    const save = screen.getByRole("button", { name: "保存" }) as HTMLButtonElement;
+    fireEvent.click(save);
+
+    // editSession.create → editSession.update → editSession.save の順で呼ばれる
+    await waitFor(() => {
+      const calls = mcpRequest.mock.calls.map((c) => c[0] as string);
+      expect(calls).toContain("editSession.update");
+      expect(calls).toContain("editSession.save");
+    });
+
+    // editSession.save の params に force: true が無い (通常 save path)
+    const saveCalls = mcpRequest.mock.calls.filter((c) => c[0] === "editSession.save");
+    expect(saveCalls.length).toBeGreaterThanOrEqual(1);
+    const saveParams = saveCalls[0][1] as { force?: boolean } | undefined;
+    expect(saveParams?.force).toBeUndefined();
+
+    // saveGenericDefinition 直呼び path は使われていない (#1368 で editSession.save に統合)
+    expect(saveGenericDefinition).not.toHaveBeenCalled();
+  });
+
+  it("editSession.save が { ok: false, conflict: { other } } を返したら SaveConflictDialog を表示する", async () => {
+    // editSession.save を conflict response に切替
+    mcpRequest.mockImplementation(async (method: string) => {
+      switch (method) {
+        case "editSession.create":
+          return { editSession: { id: "test-es-conflict" } };
+        case "editSession.update":
+          return { sequence: 1 };
+        case "editSession.save":
+          return {
+            ok: false,
+            conflict: {
+              other: {
+                editSessionId: "other-es-1",
+                savedBy: "alice@session-xyz",
+                savedAt: "2026-05-27T12:00:00.000Z",
+                displayLabel: "Alice",
+              },
+            },
+          };
+        default:
+          return {};
+      }
+    });
+
+    await renderEditor();
+
+    const purpose = screen.getByDisplayValue("initial purpose");
+    fireEvent.change(purpose, { target: { value: "edited" } });
+
+    const save = screen.getByRole("button", { name: "保存" }) as HTMLButtonElement;
+    fireEvent.click(save);
+
+    // SaveConflictDialog の上書き button が表示される
+    await waitFor(() => {
+      expect(screen.getByTestId("overwrite-confirm-btn")).toBeTruthy();
+    });
+    // 衝突相手 displayLabel が dialog 内に表示される
+    expect(screen.getByText(/Alice/)).toBeTruthy();
+  });
+
+  it("SaveConflictDialog で上書きを click すると editSession.save に force: true で再呼出する", async () => {
+    // 1 回目 save は conflict、2 回目 (overwrite) は ok=true
+    let saveCount = 0;
+    mcpRequest.mockImplementation(async (method: string) => {
+      switch (method) {
+        case "editSession.create":
+          return { editSession: { id: "test-es-overwrite" } };
+        case "editSession.update":
+          return { sequence: 1 };
+        case "editSession.save":
+          saveCount += 1;
+          if (saveCount === 1) {
+            return {
+              ok: false,
+              conflict: {
+                other: {
+                  editSessionId: "other-es-2",
+                  savedBy: "bob",
+                  savedAt: "2026-05-27T12:00:00.000Z",
+                  displayLabel: "Bob",
+                },
+              },
+            };
+          }
+          return { ok: true };
+        case "editSession.discard":
+          return { discarded: true };
+        default:
+          return {};
+      }
+    });
+
+    await renderEditor();
+
+    const purpose = screen.getByDisplayValue("initial purpose");
+    fireEvent.change(purpose, { target: { value: "overwrite test" } });
+
+    const save = screen.getByRole("button", { name: "保存" }) as HTMLButtonElement;
+    fireEvent.click(save);
+
+    // dialog 表示まで待つ
+    const overwriteBtn = await waitFor(() => screen.getByTestId("overwrite-confirm-btn"));
+    fireEvent.click(overwriteBtn);
+
+    // 2 回目の editSession.save が force: true で呼ばれる
+    await waitFor(() => {
+      const saveCalls = mcpRequest.mock.calls.filter((c) => c[0] === "editSession.save");
+      expect(saveCalls.length).toBeGreaterThanOrEqual(2);
+      const second = saveCalls[1][1] as { force?: boolean };
+      expect(second.force).toBe(true);
+    });
+  });
+
+  it("handleSaveOverwrite は reloadBanner 中なら force save を block する (Codex Round 1 Should-fix)", async () => {
+    // 1 回目 save は conflict、reloadBanner 立てた後に overwrite click → block
+    mcpRequest.mockImplementation(async (method: string) => {
+      switch (method) {
+        case "editSession.create":
+          return { editSession: { id: "test-es-overwrite-block" } };
+        case "editSession.update":
+          return { sequence: 1 };
+        case "editSession.save":
+          return {
+            ok: false,
+            conflict: {
+              other: {
+                editSessionId: "other-es-3",
+                savedBy: "carol",
+                savedAt: "2026-05-27T12:00:00.000Z",
+                displayLabel: "Carol",
+              },
+            },
+          };
+        default:
+          return {};
+      }
+    });
+
+    await renderEditor();
+
+    const purpose = screen.getByDisplayValue("initial purpose");
+    fireEvent.change(purpose, { target: { value: "overwrite block test" } });
+
+    const save = screen.getByRole("button", { name: "保存" }) as HTMLButtonElement;
+    fireEvent.click(save);
+
+    // conflict dialog 表示まで待つ
+    const overwriteBtn = await waitFor(() => screen.getByTestId("overwrite-confirm-btn"));
+
+    // dialog 表示中に rename/undo 由来の reload broadcast を受信させる
+    expect(broadcastHandler).not.toBeNull();
+    act(() => broadcastHandler?.({ reload: true }));
+    await waitFor(() => expect(screen.getByTestId("generic-definition-reload-banner")).toBeTruthy());
+
+    // 上書き click → block (force: true で editSession.save が呼ばれない)
+    const saveCallsBefore = mcpRequest.mock.calls.filter((c) => c[0] === "editSession.save").length;
+    fireEvent.click(overwriteBtn);
+
+    // しばらく待っても editSession.save の force: true 呼出は増えない
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const saveCallsAfter = mcpRequest.mock.calls.filter((c) => c[0] === "editSession.save");
+    expect(saveCallsAfter.length).toBe(saveCallsBefore); // 増えない
+    expect(saveCallsAfter.every((c) => !(c[1] as { force?: boolean })?.force)).toBe(true);
   });
 });

--- a/frontend/src/components/generic-definition/GenericDefinitionEditor.tsx
+++ b/frontend/src/components/generic-definition/GenericDefinitionEditor.tsx
@@ -392,10 +392,21 @@ export function GenericDefinitionEditor() {
   /**
    * #1368 SaveConflictDialog 「上書きする」 path。
    * editSession.save に force=true を渡して衝突無視 + 強制 commit (last-save-wins)。
+   *
+   * Codex Round 1 Should-fix: handleSave と同じく reloadBanner stale guard を入れる。
+   * conflict dialog 表示中に rename/undo 由来の `genericDefinitionChanged { reload: true }`
+   * が来ると、overwrite click が save-conflict だけでなく reload guard も迂回してしまう。
+   * stale な def を「上書き save」してしまうと、rename 後の正規 state を巻き戻すため block。
    */
   const handleSaveOverwrite = useCallback(async () => {
     if (!def) return;
     setSaveError("");
+    if (reloadBanner) {
+      setSaveError("外部更新を検出しました。再読み込みしてから保存してください");
+      // 衝突 dialog は閉じて user に reload UI へ誘導する
+      setSaveConflict(null);
+      return;
+    }
     setSaving(true);
     try {
       const sessionId = await ensureEditSession();
@@ -417,7 +428,7 @@ export function GenericDefinitionEditor() {
     } finally {
       setSaving(false);
     }
-  }, [def, ensureEditSession, postSaveSuccess]);
+  }, [def, reloadBanner, ensureEditSession, postSaveSuccess]);
 
   const handleDelete = useCallback(async () => {
     if (!kind || !decodedName) return;

--- a/frontend/src/components/generic-definition/GenericDefinitionEditor.tsx
+++ b/frontend/src/components/generic-definition/GenericDefinitionEditor.tsx
@@ -16,7 +16,6 @@ import {
 } from "../../types/v3";
 import {
   loadGenericDefinition,
-  saveGenericDefinition,
   deleteGenericDefinition,
 } from "../../store/genericDefinitionStore";
 import {
@@ -26,6 +25,7 @@ import {
 import { ValidationBadge } from "../common/ValidationBadge";
 import { makeTabId, openTab } from "../../store/tabStore";
 import { mcpBridge } from "../../mcp/mcpBridge";
+import { SaveConflictDialog, type ConflictInfo } from "../editing/SaveConflictDialog";
 
 function isValidKind(k: string): k is GenericDefinitionKind {
   return (GENERIC_DEFINITION_KINDS as string[]).includes(k);
@@ -60,6 +60,9 @@ export function GenericDefinitionEditor() {
   const [saveSuccess, setSaveSuccess] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [issues, setIssues] = useState<GenericDefinitionIssue[]>([]);
+  // #1368: 他 session が save した際の衝突情報 (spec §9.3 last-save-wins)。
+  // null なら非表示。SaveConflictDialog が render される。
+  const [saveConflict, setSaveConflict] = useState<ConflictInfo | null>(null);
   // Phase J Must-fix B (#1298 round 5 Codex M-2): rename / undo で backend が ref を書き換えた
   // 際に banner を出して user に再 load を促すフラグ。dirty (= 編集中) なら overwrite せず
   // banner 表示、clean なら自動 reload。
@@ -307,6 +310,25 @@ export function GenericDefinitionEditor() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  /**
+   * #1368: save 成功後の共通後処理。
+   * - saveSuccess banner 表示
+   * - initial snapshot 更新 (自分の save 起因の broadcast による reloadBanner 誤発火防止)
+   * - EditSession discard (他 session の rename block を解除)
+   * - saveConflict / reloadBanner state clear
+   */
+  const postSaveSuccess = useCallback((savedDef: GenericDefinition) => {
+    setSaveSuccess(true);
+    initialSnapshotRef.current = JSON.stringify(savedDef);
+    setReloadBanner(false);
+    setSaveConflict(null);
+    // #1331: save 成功後は EditSession を discard。target を snapshot して、await 中の
+    // resource 切替で誤って新 session を消さないようにする (Codex Round 4 Must-fix)。
+    const targetAtSave = currentResourceIdRef.current;
+    discardEditSession(targetAtSave).catch(() => { /* logged inside */ });
+    setTimeout(() => setSaveSuccess(false), 3000);
+  }, [discardEditSession]);
+
   const handleSave = useCallback(async () => {
     if (!def) return;
     setSaveError("");
@@ -328,24 +350,74 @@ export function GenericDefinitionEditor() {
     }
     setSaving(true);
     try {
-      await saveGenericDefinition(def);
-      setSaveSuccess(true);
-      // Phase J B: save 成功後は initial snapshot を現 def で update し、自分の save に
-      // 起因する broadcast (reload event) で reloadBanner が誤発火しないようにする。
-      initialSnapshotRef.current = JSON.stringify(def);
-      setReloadBanner(false);
-      // #1331: save 成功後は EditSession を discard し、他 session の rename block を解除する。
-      // 次の編集で再度 ensureEditSession が走る (lazy)。target を snapshot して、await 中の
-      // resource 切替で誤って新 session を消さないようにする (Codex Round 4 Must-fix)。
-      const targetAtSave = currentResourceIdRef.current;
-      discardEditSession(targetAtSave).catch(() => { /* logged inside */ });
-      setTimeout(() => setSaveSuccess(false), 3000);
+      // #1368: editSession.save 経路で conflict 検出付き save。直接 saveGenericDefinition RPC
+      // を呼ぶ旧 path から切替 (他 8 editor — View / PageLayout / Sequence / Table /
+      // ProcessFlow / Designer / Flow / ScreenItems — と整合)。conflict 時は
+      // SaveConflictDialog 表示で last-save-wins 確認を user に求める (spec §9.3)。
+      //
+      // Flow:
+      //   1. ensureEditSession: active session を取得 (lazy create)。未編集状態で
+      //      save (例: open 直後の force-save) も EditSession を起こす必要があるため
+      //      explicit に呼ぶ。
+      //   2. editSession.update: 現 def を payload として server に push (server payload は
+      //      lazy update 設計のため、save 直前に最新 def を流す必要がある)。
+      //   3. editSession.save: server が in-memory payload を canonical file へ atomic write、
+      //      他 session の save event と sequence 比較で衝突検出。
+      //      - { ok: false, conflict: { other } } 返却時は SaveConflictDialog 表示。
+      //      - 通常成功時は genericDefinitionChanged broadcast 発火 + saveHistory 記録。
+      const sessionId = await ensureEditSession();
+      if (!sessionId) {
+        setSaveError("EditSession を開始できませんでした");
+        return;
+      }
+      await mcpBridge.request("editSession.update", {
+        editSessionId: sessionId,
+        payload: def,
+      });
+      const res = await mcpBridge.request("editSession.save", {
+        editSessionId: sessionId,
+      }) as { ok?: boolean; conflict?: { other: ConflictInfo } } | undefined;
+      if (res && res.ok === false && res.conflict) {
+        setSaveConflict(res.conflict.other);
+        return;
+      }
+      postSaveSuccess(def);
     } catch (e: unknown) {
       setSaveError(e instanceof Error ? e.message : String(e));
     } finally {
       setSaving(false);
     }
-  }, [def, reloadBanner, discardEditSession]);
+  }, [def, reloadBanner, ensureEditSession, postSaveSuccess]);
+
+  /**
+   * #1368 SaveConflictDialog 「上書きする」 path。
+   * editSession.save に force=true を渡して衝突無視 + 強制 commit (last-save-wins)。
+   */
+  const handleSaveOverwrite = useCallback(async () => {
+    if (!def) return;
+    setSaveError("");
+    setSaving(true);
+    try {
+      const sessionId = await ensureEditSession();
+      if (!sessionId) {
+        setSaveError("EditSession を開始できませんでした");
+        return;
+      }
+      await mcpBridge.request("editSession.update", {
+        editSessionId: sessionId,
+        payload: def,
+      });
+      await mcpBridge.request("editSession.save", {
+        editSessionId: sessionId,
+        force: true,
+      });
+      postSaveSuccess(def);
+    } catch (e: unknown) {
+      setSaveError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  }, [def, ensureEditSession, postSaveSuccess]);
 
   const handleDelete = useCallback(async () => {
     if (!kind || !decodedName) return;
@@ -907,6 +979,15 @@ export function GenericDefinitionEditor() {
             </div>
           </div>
         </div>
+      )}
+
+      {/* #1368: 他 session save との衝突検出ダイアログ (spec §9.3 last-save-wins) */}
+      {saveConflict && (
+        <SaveConflictDialog
+          conflict={saveConflict}
+          onOverwrite={() => { handleSaveOverwrite().catch((e) => console.error("[GenericDefinitionEditor] overwrite failed:", e)); }}
+          onCancel={() => setSaveConflict(null)}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## 概要

#1331 Phase 2 として trace 確立した ISSUE。GenericDefinitionEditor 単独で `saveGenericDefinition` RPC を直呼びしていたため、他 session が同時 save した際の衝突検出 (SaveConflictDialog) が動作しなかった。

backend `editSession.save` dispatcher に `generic-definition` case を追加 + frontend save flow を `editSession.save` 経由に切替え。他 8 editor (View / PageLayout / Sequence / Table / ProcessFlow / Designer / Flow / ScreenItems) と整合する spec §9.3 last-save-wins 衝突検出 path に統一する。

## 設計判断

ISSUE 本文では「\`saveGenericDefinition\` RPC に expectedMtime/currentMtime tracking 追加」と書かれていたが、他 8 editor は **EditSession-based 衝突検出** で実現済 (mtime ではなく session の sequence + save event 比較)。

`AskUserQuestion` で確認し:
- ✅ **既存パターン整合 (editSession.save 経由)** — 採用
- ❌ ISSUE 本文通り mtime tracking 新設 — 非採用 (二重保守になる、他 editor と path 分岐)
- ❌ hybrid (mtime + EditSession 併用) — 非採用 (過剰実装)

ISSUE 本文の mtime 記述は当時 EditSession 統合ロジックを参照していなかった起票者の理解と乖離していたため、修正経路を変更した。

## 修正内容

### backend/src/wsBridge/editSessionService.ts

- \`editSession.save\` dispatcher switch に \`generic-definition\` case を追加
- resourceId は frontend が \`\${kind}__\${name}\` 形式で渡す (assertSafeName が \`/\` を許容しないため \`/\` → \`__\` 置換済)。kind 正規表現 \`[a-z][a-z0-9:-]{0,63}\` は \`_\` を含まないので、最初の \`__\` で split すれば kind / name に安全に復元できる (name は \`_\` を含み得る)
- \`writeGenericDefinition(name, kind, payload, root)\` で本体ファイルへ atomic write
- broadcast: \`genericDefinitionChanged\` { kind, name }

### backend/src/wsBridge/editSessionService.test.ts

#1368 用 test を追加: resourceId \`data-contract__OrderForm\` を decode して file 書込 + broadcast を確認 (\`{ kind: 'data-contract', name: 'OrderForm' }\`)

### frontend/src/components/generic-definition/GenericDefinitionEditor.tsx

- \`handleSave\`: \`saveGenericDefinition(def)\` 直呼びを \`editSession.update + editSession.save\` に置換。衝突時は backend が \`{ ok: false, conflict: { other } }\` を返すので \`SaveConflictDialog\` を表示
- \`handleSaveOverwrite\`: 「上書きする」 click 時の \`force: true\` 経路を追加 (spec §9.3)
- \`postSaveSuccess\`: save 成功後の共通後処理 (saveSuccess banner / initial snapshot 更新 / EditSession discard / saveConflict clear) を helper 化
- \`saveGenericDefinition\` import 削除 (unused — backend write 経路を \`editSession.save\` に一本化したため)
- \`SaveConflictDialog\` import + \`saveConflict\` state + dialog render を追加

## Phase 1 との関係 (#1331)

Phase 1 で導入した lazy \`ensureEditSession()\` / save 後 \`discardEditSession()\` の挙動は維持 (Codex Round 5 generation counter race fix も保全)。Phase 1 の Codex 5 round に渡る edit session 制御を再利用するため、\`useEditSession\` hook には移行せず低レベル制御を継続する設計。

## 仕様逐条突合 (#1368 受入条件)

- backend \`saveGenericDefinition\` handler 拡張 → \`backend/src/wsBridge/editSessionService.ts:394-410\` (editSession.save 経路に統合、本来の \`saveGenericDefinition\` RPC は AI 経路用に温存)
- frontend store \`saveGenericDefinition\` 追従 → ✅ N/A (editSession.save 経由のため store 経由しなくなった)
- frontend GenericDefinitionEditor save flow を SaveConflictDialog に統合 → \`frontend/src/components/generic-definition/GenericDefinitionEditor.tsx:351-403\` (\`handleSave\` + \`handleSaveOverwrite\` + \`SaveConflictDialog\` render)
- reload banner との整合 → \`postSaveSuccess\` で \`setReloadBanner(false)\` + \`setSaveConflict(null)\` を一括 clear (Phase J Must-fix B reloadBanner は別系統で残存)
- backend: saveGenericDefinition mtime 衝突 RPC 単体 test → ✅ 設計変更により mtime 経路ではなく editSession.save 経路で実装、test は \`editSessionService.test.ts:88-127\` (resourceId decode + file 書込 + broadcast 検証)
- frontend: GenericDefinitionEditor 衝突時 SaveConflictDialog 表示 component test → 設計変更 (mtime → editSession-based) により本 PR で追加せず。既存の各 editor (Table / View / Sequence 等) で SaveConflictDialog の使用は test 済、本 PR は backend dispatcher 拡張がコア
- regression: 既存テスト全件 pass → frontend 3004 / 1 skipped、backend 783 全 pass

## 検証

- \`npm run build\` (backend) → 0 errors
- \`npm run build\` (frontend) → 0 errors
- \`npx vitest run\` (backend) → 783 passed (#1368 test 1 件追加で 782 → 783)
- \`npx vitest run\` (frontend) → 3004 passed / 1 skipped (regression なし、GenericDefinitionEditor 関連 9 件全 pass)
- \`npx vitest run src/wsBridge/editSessionService.test.ts\` → 3 passed (新規 #1368 test 含む)

## schema governance

\`gh pr diff <N> --name-only | grep -E '^schemas/' || true\` → 該当なし。グローバル schema 変更なし。

## 関連

- 親 ISSUE: #1331 (Phase 1 rename block 実装、本 ISSUE が Phase 2)
- 親メタ: #1298 / RFC #1284
- 関連 spec: docs/spec/edit-session-draft.md / docs/spec/edit-session-protocol.md §9.3
- 起源 PR: #1369 (本体機能、merged 2026-05-27)

Closes #1368

🤖 Generated with [Claude Code](https://claude.com/claude-code)