### PR TITLE
improve(backend): #1374 — MCP editSession__create / list の resourceType allowlist 検証を WS handler と対称化

### DIFF
--- a/backend/src/editSessionStore.ts
+++ b/backend/src/editSessionStore.ts
@@ -21,22 +21,44 @@ import { assertPathContained } from "./security/idValidator.js";
 /**
  * DraftResourceType — Phase 6 (#903): draftStore.ts 削除に伴い editSessionStore.ts に移管。
  * frontend/src/types/draft.ts と同一リスト (両方を編集同期すること)。
+ *
+ * #1374: 型 union / runtime allowlist / MCP tool schema enum の drift を防止するため、
+ * `as const` literal 配列を source of truth として型と Set を導出する形に変更。
+ * 新 resource type 追加時は本配列 1 箇所の更新で `DraftResourceType` (型) /
+ * `VALID_RESOURCE_TYPES` (runtime Set) / tools.ts の MCP enum (本配列を spread) が同期される。
+ *
+ *   DRAFT_RESOURCE_TYPES (source of truth, as const)
+ *     ↓ typeof[number]
+ *   DraftResourceType (型 union)
+ *     ↓ new Set(...)
+ *   VALID_RESOURCE_TYPES (runtime allowlist, WS / MCP 両 handler で共有)
  */
-export type DraftResourceType =
-  | "screen"
-  | "puck-data"
-  | "table"
-  | "process-flow"
-  | "view"
-  | "view-definition"
-  | "page-layout"
-  | "screen-item"
-  | "sequence"
-  | "extension"
-  | "convention"
-  | "flow"
-  | "er-layout"
-  | "generic-definition"; // #1331: GenericDefinition EditSession 化 (kind/name 複合 id)
+export const DRAFT_RESOURCE_TYPES = [
+  "screen",
+  "puck-data",
+  "table",
+  "process-flow",
+  "view",
+  "view-definition",
+  "page-layout",
+  "screen-item",
+  "sequence",
+  "extension",
+  "convention",
+  "flow",
+  "er-layout",
+  "generic-definition", // #1331: GenericDefinition EditSession 化 (kind/name 複合 id)
+] as const;
+
+export type DraftResourceType = typeof DRAFT_RESOURCE_TYPES[number];
+
+/**
+ * resourceType の runtime allowlist。
+ * #1374: 旧来 wsHandlers/editSession.ts に local 定義されていた `VALID_RESOURCE_TYPES` を集約し、
+ * WS handler と MCP handler (handlers/editSession.ts) の双方から import する。
+ * これで 4 表現 (型 / WS Set / MCP allowlist / MCP tool schema enum) の drift を構造的に防止する。
+ */
+export const VALID_RESOURCE_TYPES: ReadonlySet<DraftResourceType> = new Set(DRAFT_RESOURCE_TYPES);
 
 export interface ParticipantInfo {
   sessionId: string;

--- a/backend/src/handlers/editSession.test.ts
+++ b/backend/src/handlers/editSession.test.ts
@@ -1,0 +1,222 @@
+/**
+ * MCP handler editSession__create / editSession__list の resourceType allowlist 検証テスト
+ * (#1374 — #1372 派生)。
+ *
+ * 検証観点:
+ * 1. editSession__create: 未知 resourceType (allowlist 外) は McpError(InvalidParams) で reject
+ * 2. editSession__create: 不正型 (number / null) も同 McpError で reject
+ * 3. editSession__list: undefined resourceType は通過 (全件 filter)
+ * 4. editSession__list: 未知 resourceType は McpError(InvalidParams) で reject
+ * 5. WS handler 側 allowlist と完全一致 (editSessionStore.ts の VALID_RESOURCE_TYPES 共有)
+ * 6. allowlist 通過後の downstream エラー (resourceId 不正等) は別 message で出る → allowlist
+ *    layer が正しく resourceType だけを評価していることを確認
+ *
+ * 設計:
+ * - 本テストは MCP handler の **入力 validation 層** だけを検証する。allowlist を通過した後の
+ *   wsBridge.editSessionCreate 等の挙動は既存テスト (multiEditSession.test.ts /
+ *   wsBridge.editSession.test.ts / editSessionService.test.ts) でカバー済。
+ * - allowlist 通過後は wsBridge が initialize されていないため別 error が発生するが、
+ *   それは allowlist layer の責務外であり本テストでは catch して message のみ検証する。
+ */
+import { describe, it, expect } from "vitest";
+import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+import { handleEditSessionTool } from "./editSession.js";
+import {
+  DRAFT_RESOURCE_TYPES,
+  VALID_RESOURCE_TYPES,
+} from "../editSessionStore.js";
+
+// handler は sessionId を引数に取るが、本テストでは validation 層のみを検証するため固定の dummy 値を渡す。
+const SESSION_ID = "test-session-1374";
+const ROOT = "/tmp/__editSession_handler_test_1374"; // 実際には wsBridge 経路を通らないので未使用
+
+describe("editSession__create — #1374 resourceType allowlist 検証", () => {
+  it("未知 resourceType (allowlist 外) は McpError(InvalidParams) で reject される", async () => {
+    let caught: unknown;
+    try {
+      await handleEditSessionTool(
+        "editSession__create",
+        { resourceType: "unknown-type", resourceId: "x" },
+        ROOT,
+        SESSION_ID,
+      );
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(McpError);
+    expect((caught as McpError).code).toBe(ErrorCode.InvalidParams);
+    // allowlist 専用エラーメッセージ (resourceId 検証エラーとは区別される)
+    expect((caught as McpError).message).toMatch(/許可された resource type/);
+    expect((caught as McpError).message).toMatch(/unknown-type/);
+  });
+
+  it("typeof !== string (number) も同 McpError で reject される", async () => {
+    let caught: unknown;
+    try {
+      await handleEditSessionTool(
+        "editSession__create",
+        { resourceType: 42, resourceId: "x" },
+        ROOT,
+        SESSION_ID,
+      );
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(McpError);
+    expect((caught as McpError).code).toBe(ErrorCode.InvalidParams);
+    expect((caught as McpError).message).toMatch(/許可された resource type/);
+  });
+
+  it("resourceType undefined も同 McpError で reject される", async () => {
+    let caught: unknown;
+    try {
+      await handleEditSessionTool(
+        "editSession__create",
+        { resourceId: "x" },
+        ROOT,
+        SESSION_ID,
+      );
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(McpError);
+    expect((caught as McpError).code).toBe(ErrorCode.InvalidParams);
+    expect((caught as McpError).message).toMatch(/許可された resource type/);
+  });
+
+  it("有効 resourceType + 不正 resourceId (空文字) は resourceId 検証エラーで reject (allowlist 通過確認)", async () => {
+    // "extension" は singleton resource type なので空文字のみが拒否される (assertResourceIdForType の else 分岐)
+    let caught: unknown;
+    try {
+      await handleEditSessionTool(
+        "editSession__create",
+        { resourceType: "extension", resourceId: "" },
+        ROOT,
+        SESSION_ID,
+      );
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(McpError);
+    expect((caught as McpError).code).toBe(ErrorCode.InvalidParams);
+    // resourceId 専用エラー (allowlist エラーとは別 message) — allowlist layer が "extension" を accept した証拠
+    expect((caught as McpError).message).toMatch(/resourceId/);
+    expect((caught as McpError).message).not.toMatch(/許可された resource type/);
+  });
+});
+
+describe("editSession__list — #1374 resourceType allowlist 検証", () => {
+  it("未知 resourceType は McpError(InvalidParams) で reject される", async () => {
+    let caught: unknown;
+    try {
+      await handleEditSessionTool(
+        "editSession__list",
+        { resourceType: "unknown-type" },
+        ROOT,
+        SESSION_ID,
+      );
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(McpError);
+    expect((caught as McpError).code).toBe(ErrorCode.InvalidParams);
+    expect((caught as McpError).message).toMatch(/許可された resource type/);
+    expect((caught as McpError).message).toMatch(/unknown-type/);
+  });
+
+  it("typeof !== string (number) も同 McpError で reject される", async () => {
+    let caught: unknown;
+    try {
+      await handleEditSessionTool(
+        "editSession__list",
+        { resourceType: 123 },
+        ROOT,
+        SESSION_ID,
+      );
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(McpError);
+    expect((caught as McpError).code).toBe(ErrorCode.InvalidParams);
+    expect((caught as McpError).message).toMatch(/許可された resource type/);
+  });
+
+  it("resourceType + resourceId 同時指定で未知 resourceType は allowlist 層で reject (resourceId 層に到達しない)", async () => {
+    let caught: unknown;
+    try {
+      await handleEditSessionTool(
+        "editSession__list",
+        { resourceType: "unknown-type", resourceId: "x" },
+        ROOT,
+        SESSION_ID,
+      );
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(McpError);
+    expect((caught as McpError).code).toBe(ErrorCode.InvalidParams);
+    // resourceType allowlist エラーが先に出る (resourceId 関連 message ではない)
+    expect((caught as McpError).message).toMatch(/許可された resource type/);
+    expect((caught as McpError).message).not.toMatch(/resourceId filter/);
+  });
+
+  it("resourceId のみ指定 (resourceType 未指定) は resourceType 必須エラー (allowlist 層は通過)", async () => {
+    let caught: unknown;
+    try {
+      await handleEditSessionTool(
+        "editSession__list",
+        { resourceId: "x" },
+        ROOT,
+        SESSION_ID,
+      );
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(McpError);
+    expect((caught as McpError).code).toBe(ErrorCode.InvalidParams);
+    // allowlist layer は通過 (resourceType undefined は許容)、resourceId filter 側で reject
+    expect((caught as McpError).message).toMatch(/resourceId filter/);
+    expect((caught as McpError).message).not.toMatch(/許可された resource type/);
+  });
+});
+
+describe("#1374 allowlist source of truth — WS handler との完全一致確認", () => {
+  it("DRAFT_RESOURCE_TYPES と VALID_RESOURCE_TYPES は同一範囲 (型と Set の drift 防止)", () => {
+    // editSessionStore.ts で `new Set(DRAFT_RESOURCE_TYPES)` で導出されている前提を test 化
+    expect(VALID_RESOURCE_TYPES.size).toBe(DRAFT_RESOURCE_TYPES.length);
+    for (const rt of DRAFT_RESOURCE_TYPES) {
+      expect(VALID_RESOURCE_TYPES.has(rt)).toBe(true);
+    }
+  });
+
+  it("全 14 種の resourceType が allowlist 通過する (現行 DraftResourceType 範囲)", async () => {
+    // 各 resourceType を順番に allowlist 通過させ、resourceId 層 (allowlist 後段) のエラーが出ることを確認。
+    // resourceId は空文字を渡し、allowlist 層が accept したかを「reject message が allowlist 由来でない」ことで確認。
+    for (const rt of DRAFT_RESOURCE_TYPES) {
+      let caught: unknown;
+      try {
+        await handleEditSessionTool(
+          "editSession__create",
+          { resourceType: rt, resourceId: "" },
+          ROOT,
+          SESSION_ID,
+        );
+      } catch (e) {
+        caught = e;
+      }
+      // 何らかのエラーは出る (空 resourceId or downstream)、ただし allowlist 由来ではない
+      expect(caught).toBeInstanceOf(McpError);
+      expect((caught as McpError).message).not.toMatch(/許可された resource type/);
+    }
+  });
+
+  it("editSessionStore.ts DRAFT_RESOURCE_TYPES に新 type が追加されたら VALID_RESOURCE_TYPES も自動追従する (構造的不変条件)", () => {
+    // typeof[number] / new Set() による導出を test で固定 — 将来 editSessionStore.ts の
+    // VALID_RESOURCE_TYPES を別途手動定義に書き戻されると本テストが落ちる仕組み。
+    const computed = new Set<string>(DRAFT_RESOURCE_TYPES);
+    expect(computed.size).toBe(VALID_RESOURCE_TYPES.size);
+    for (const rt of computed) {
+      expect(VALID_RESOURCE_TYPES.has(rt as typeof DRAFT_RESOURCE_TYPES[number])).toBe(true);
+    }
+  });
+});

--- a/backend/src/handlers/editSession.ts
+++ b/backend/src/handlers/editSession.ts
@@ -19,6 +19,33 @@ import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { wsBridge } from "../wsBridge.js";
 import { assertEntityIdMcp, type ToolHandler } from "../mcpHelpers.js";
 import { isValidKind, isValidSafeName } from "../security/idValidator.js";
+import {
+  type DraftResourceType,
+  VALID_RESOURCE_TYPES,
+} from "../editSessionStore.js";
+
+/**
+ * #1374: resourceType allowlist 検証を WS handler と対称化する (#1372 派生)。
+ *
+ * 旧来 MCP handler は `typeof resourceType === "string"` だけで通過させており、tool schema
+ * enum を無視する MCP client (= AI が enum 外の任意文字列を送ってくる場合) からは
+ * 未知 resourceType + 非空 resourceId で invalid EditSession を作成できた。
+ * WS handler 側は `VALID_RESOURCE_TYPES` allowlist + `assertResourceType` で守られていたため、
+ * MCP 経路だけが抜け道になっていた。
+ *
+ * 本関数は WS handler (`backend/src/wsHandlers/editSession.ts:assertResourceType`) と
+ * 同一の allowlist (editSessionStore.ts から共有 import) を用い、MCP convention に従って
+ * `McpError(InvalidParams)` で reject する。
+ */
+function assertResourceTypeMcp(rt: unknown, label: string): DraftResourceType {
+  if (typeof rt !== "string" || !VALID_RESOURCE_TYPES.has(rt as DraftResourceType)) {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      `${label} は許可された resource type のいずれかである必要があります (got: ${JSON.stringify(rt)})`,
+    );
+  }
+  return rt as DraftResourceType;
+}
 
 /**
  * #1332 Codex 10 巡目 M2: editSession__create / editSession__list の resourceId に
@@ -94,17 +121,17 @@ export const handleEditSessionTool: ToolHandler = async (name, args, _root, sess
 
   switch (name) {
     case "editSession__create": {
-      if (typeof a.resourceType !== "string") {
-        throw new McpError(ErrorCode.InvalidParams, "resourceType は必須です");
-      }
+      // #1374: resourceType allowlist 検証 (WS handler 対称化)。
+      // 未知 resourceType を許すと invalid EditSession を作成できる抜け道になる。
+      const validatedRt = assertResourceTypeMcp(a.resourceType, "resourceType");
       if (typeof a.resourceId !== "string") {
         throw new McpError(ErrorCode.InvalidParams, "resourceId は必須です");
       }
       // #1332 Codex 10 巡目 M2: resourceType に応じた resourceId 検証
-      assertResourceIdForType(a.resourceType, a.resourceId);
+      assertResourceIdForType(validatedRt, a.resourceId);
       const result = wsBridge.editSessionCreate(
         sessionId,
-        a.resourceType as Parameters<typeof wsBridge.editSessionCreate>[1],
+        validatedRt,
         a.resourceId,
         typeof a.displayLabel === "string" ? a.displayLabel : undefined,
       );
@@ -186,12 +213,18 @@ export const handleEditSessionTool: ToolHandler = async (name, args, _root, sess
     }
 
     case "editSession__list": {
+      // #1374: resourceType allowlist 検証 (WS handler 対称化)。
+      // filter 用なので resourceType 未指定 (undefined) は許容、指定時は allowlist 必須。
+      let validatedListRt: DraftResourceType | undefined;
+      if (a.resourceType !== undefined) {
+        validatedListRt = assertResourceTypeMcp(a.resourceType, "resourceType");
+      }
       // #1332 Codex 10 巡目 M2: filter として resourceId が指定された場合は
       // resourceType と整合する検証を行う (create と同じポリシー)。
       // filter 用なので空文字は空 filter として弾かず undefined 化のみ。
       if (typeof a.resourceId === "string" && a.resourceId.length > 0) {
-        if (typeof a.resourceType === "string" && a.resourceType.length > 0) {
-          assertResourceIdForType(a.resourceType, a.resourceId);
+        if (validatedListRt !== undefined) {
+          assertResourceIdForType(validatedListRt, a.resourceId);
         } else {
           // resourceType 未指定で resourceId のみ filter は通常用法ではないが許容、空文字のみ拒否
           // (resourceType 不明だと検証分岐できないため明示エラー)
@@ -202,9 +235,7 @@ export const handleEditSessionTool: ToolHandler = async (name, args, _root, sess
         }
       }
       const result = wsBridge.editSessionList(sessionId, {
-        resourceType: typeof a.resourceType === "string"
-          ? (a.resourceType as Parameters<typeof wsBridge.editSessionList>[1] extends { resourceType?: infer R } ? R : never)
-          : undefined,
+        resourceType: validatedListRt,
         resourceId: typeof a.resourceId === "string" ? a.resourceId : undefined,
       });
       return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };

--- a/backend/src/tools.ts
+++ b/backend/src/tools.ts
@@ -1,3 +1,10 @@
+// #1374: editSession__create / editSession__list の resourceType enum を、
+// editSessionStore.ts の source of truth (DRAFT_RESOURCE_TYPES) から導出する。
+// 旧来 inline 列挙していた enum 配列が drift しやすく、実際 editSession__list 側に
+// `page-layout` / `er-layout` / `generic-definition` が漏れて MCP enum と allowlist の
+// 範囲が不一致になっていた。本配列 1 箇所の更新で型 / Set / MCP enum が同期する。
+import { DRAFT_RESOURCE_TYPES } from "./editSessionStore.js";
+
 export const tools = [
   {
     name: "designer__get_html",
@@ -1516,16 +1523,10 @@ export const tools = [
       properties: {
         resourceType: {
           type: "string",
-          // #1368: editSessionStore.ts DraftResourceType と同期。WS handler の
-          // VALID_RESOURCE_TYPES とも一致させる (#1331 で `generic-definition` を、
-          // 先行 PR で `page-layout` / `er-layout` を DraftResourceType に追加済だが
-          // MCP enum が漏れていた)。AI/MCP 経路で editSession.create を叩けないと
-          // GenericDefinition / PageLayout / ER 系の AI 編集が機能しない。
-          enum: [
-            "screen", "puck-data", "table", "process-flow", "view", "view-definition",
-            "page-layout", "screen-item", "sequence", "extension", "convention", "flow",
-            "er-layout", "generic-definition",
-          ],
+          // #1374: editSessionStore.ts の DRAFT_RESOURCE_TYPES (source of truth) から
+          // 直接参照。旧 inline 列挙は #1368 で `generic-definition` 等の追加追従漏れが
+          // 発生していた (MCP enum と runtime allowlist の drift)。
+          enum: [...DRAFT_RESOURCE_TYPES],
           description: "編集対象 resource の種別",
         },
         resourceId: { type: "string", description: "編集対象 resource の ID (singleton resource は \"singleton\" 等)" },
@@ -1642,10 +1643,11 @@ export const tools = [
       properties: {
         resourceType: {
           type: "string",
-          enum: [
-            "screen", "puck-data", "table", "process-flow", "view", "view-definition",
-            "screen-item", "sequence", "extension", "convention", "flow",
-          ],
+          // #1374: editSessionStore.ts の DRAFT_RESOURCE_TYPES (source of truth) を共有。
+          // 旧 inline 列挙は editSession__create 側と drift しており、`page-layout` /
+          // `er-layout` / `generic-definition` の 3 type が漏れて MCP `editSession__list`
+          // から filter できなくなっていた。
+          enum: [...DRAFT_RESOURCE_TYPES],
           description: "絞り込み: resource 種別",
         },
         resourceId: { type: "string", description: "絞り込み: resource ID (resourceType と同時指定)" },

--- a/backend/src/wsHandlers/editSession.ts
+++ b/backend/src/wsHandlers/editSession.ts
@@ -13,18 +13,16 @@
  * `generic-definition` の `${kind}__${name}` composite (最大 130 chars) を decode して
  * 個別検証する分岐を追加。それ以外の resource type は従来通り `assertSafeName` 適用。
  */
-import type { DraftResourceType as EditSessionResourceType } from "../editSessionStore.js";
+import {
+  type DraftResourceType as EditSessionResourceType,
+  VALID_RESOURCE_TYPES,
+} from "../editSessionStore.js";
 import { assertSafeName, assertHistoryId, assertKind } from "../security/idValidator.js";
 import type { RpcHandlerMap } from "./types.js";
 
-const VALID_RESOURCE_TYPES = new Set<EditSessionResourceType>([
-  "screen", "puck-data", "table", "process-flow", "view", "view-definition",
-  "page-layout", "screen-item", "sequence", "extension", "convention", "flow", "er-layout",
-  // #1368: GenericDefinition EditSession 統合 — frontend GenericDefinitionEditor が
-  // `editSession.create` に `resourceType: "generic-definition"` を送るため allowlist に追加。
-  // editSessionStore.ts DraftResourceType と同期 (#1331 で追加済)。
-  "generic-definition",
-]);
+// #1374: 旧 local `VALID_RESOURCE_TYPES` Set は editSessionStore.ts に集約され
+// import 経由で取得する。MCP handler (handlers/editSession.ts) も同じ Set を共有する
+// ことで、WS と MCP の resourceType 検証契約 (allowlist 範囲) を構造的に対称化する。
 
 function assertResourceType(rt: unknown, label: string): EditSessionResourceType {
   if (typeof rt !== "string" || !VALID_RESOURCE_TYPES.has(rt as EditSessionResourceType)) {


### PR DESCRIPTION
## 概要

ISSUE #1374 (#1372 派生 Should-fix)。MCP handler の `editSession__create` / `editSession__list` に
`resourceType` allowlist 検証を導入し、WS handler と対称化する。

同根の drift (tools.ts MCP enum の `editSession__list` 側に `page-layout` / `er-layout` /
`generic-definition` の 3 type が漏れていた問題) も同 PR で吸収。

## 修正内容

### 1. editSessionStore.ts: `DRAFT_RESOURCE_TYPES` を source of truth 化

旧来 TypeScript union 型 + 別ファイルの runtime Set 別管理だったものを、`as const` literal
配列を起点として型 / Set を導出する形に変更:

\`\`\`ts
export const DRAFT_RESOURCE_TYPES = [\"screen\", \"puck-data\", ...] as const;
export type DraftResourceType = typeof DRAFT_RESOURCE_TYPES[number];
export const VALID_RESOURCE_TYPES: ReadonlySet<DraftResourceType> = new Set(DRAFT_RESOURCE_TYPES);
\`\`\`

新 resource type の追加は本配列 1 箇所の更新で型 / runtime Set / MCP tool schema enum が
全て同期する状態。

### 2. handlers/editSession.ts: MCP allowlist 検証を導入 (本 ISSUE 受入条件)

- `assertResourceTypeMcp(rt, label): DraftResourceType` を新設 (`McpError(InvalidParams)` で reject)
- `editSession__create` (`backend/src/handlers/editSession.ts:111-115`) で resourceType 必須 + allowlist 検証
- `editSession__list` (`backend/src/handlers/editSession.ts:197-200`) で resourceType 指定時のみ allowlist 検証
- 検証通過後の resourceId 検証 (#1332 由来 `assertResourceIdForType`) は維持

### 3. wsHandlers/editSession.ts: 共有 import に変更

local 定義の `VALID_RESOURCE_TYPES` を削除し editSessionStore.ts から import
(`backend/src/wsHandlers/editSession.ts:16-19`)。WS / MCP が同一 Set インスタンスを共有して
allowlist 範囲の drift を構造的に防止。

### 4. tools.ts: MCP enum を共有配列に切替

- `editSession__create` enum (`backend/src/tools.ts:1518-1525`) を `[...DRAFT_RESOURCE_TYPES]` で導出
- `editSession__list` enum (`backend/src/tools.ts:1648-1655`) も同様に切替
- これにより既存 drift (`editSession__list` 側に `page-layout` / `er-layout` /
  `generic-definition` の 3 type 欠落) を同時解消

### 5. handlers/editSession.test.ts (新規、11 件): allowlist 検証テスト

- 未知 resourceType / 不正型 (number) / undefined を `McpError(InvalidParams)` で reject
- allowlist 通過後の resourceId エラーは別 message (`resourceId` 含む / `許可された resource type` 含まない)
- 全 14 種の valid resourceType が allowlist を通過することを brute-force 検証
- `DRAFT_RESOURCE_TYPES` と `VALID_RESOURCE_TYPES` の範囲一致を test 化 (将来の手動書き戻しを検知)

## ISSUE 受入条件突合

- [x] `backend/src/handlers/editSession.ts` の `editSession__create` で未知 resourceType が `McpError(InvalidParams)` で reject される
  → `assertResourceTypeMcp` (`backend/src/handlers/editSession.ts:31-44`) で実装、test \"未知 resourceType (allowlist 外) は McpError(InvalidParams) で reject される\" で確認
- [x] 同じく `editSession__list` で resourceType 検証が入る
  → `editSession__list` case (`backend/src/handlers/editSession.ts:196-200`) で実装、test \"editSession__list — #1374\" describe 配下で確認
- [x] MCP handler 経由の test を追加し、enum 外の `resourceType` が reject されることを固定
  → `backend/src/handlers/editSession.test.ts` (11 test) で固定
- [x] 既存 test 全件 pass
  → `npx vitest run` 800 / 800 passed

## スコープ外 → follow-up trace

- **#1375** improve(frontend): DraftResourceType の frontend/backend 二重定義を解消 — 起票済

ISSUE #1374 本文で out-of-scope 宣言済の「WS / MCP validation 統合リファクタリング」は
本 PR でも対象外 (各 handler の error type が異なるため意図的に別実装で維持)。

## 検証

- `npx tsc --noEmit`: 0 errors
- `npm run build`: success (backend)
- `npx vitest run`: 38 files / 800 tests passed (新規 11 test 含む、duration 3.96s)

## Schema governance 確認

`git diff origin/main..HEAD -- schemas/` で 0 件確認済 (本 PR は schemas/ を触っていない)。

## 関連

- 親 ISSUE: #1374
- 起源 PR: #1372 (#1368 GenericDefinition save 統合、Round 5 で本 issue 検出)
- 親メタ: #1298 / RFC #1284
- follow-up: #1375 (frontend dedup)

Closes #1374