### PR TITLE
improve(backend): wsHandler の ProcessFlow param を entity-typed 化 (#1335)

### DIFF
--- a/backend/src/dogfoodDesignerWork.ts
+++ b/backend/src/dogfoodDesignerWork.ts
@@ -35,7 +35,7 @@ async function broadcastSave(id: string, data: ProcessFlowDoc): Promise<void> {
     ws.on("open", () => {
       ws.send(JSON.stringify({ type: "register", clientId }));
       setTimeout(() => {
-        ws.send(JSON.stringify({ type: "request", id: reqId, method: "saveProcessFlow", params: { id, data } }));
+        ws.send(JSON.stringify({ type: "request", id: reqId, method: "saveProcessFlow", params: { processFlowId: id, data } }));
       }, 100);
     });
     ws.on("message", (raw) => {

--- a/backend/src/handlers/screenItem.ts
+++ b/backend/src/handlers/screenItem.ts
@@ -37,7 +37,7 @@ export const handleScreenItemTool: ToolHandler = async (name, args, root, sessio
       const renameRes = await renameScreenItemId(a.screenId, a.oldId, a.newId, root);
       wsBridge.broadcast({ wsId: workspaceContextManager.getActivePath(sessionId), event: "screenItemsChanged", data: { screenId: a.screenId } });
       for (const agId of renameRes.processFlowsUpdated) {
-        wsBridge.broadcast({ wsId: workspaceContextManager.getActivePath(sessionId), event: "processFlowChanged", data: { processFlowId: agId } });
+        wsBridge.broadcast({ wsId: workspaceContextManager.getActivePath(sessionId), event: "processFlowChanged", data: { processFlowId: agId, id: agId } });
       }
       if (renameRes.screenHtmlUpdated) {
         wsBridge.broadcast({ wsId: workspaceContextManager.getActivePath(sessionId), event: "screenChanged", data: { screenId: a.screenId } });
@@ -110,7 +110,7 @@ export const handleScreenItemTool: ToolHandler = async (name, args, root, sessio
         // ブラウザ側で適用済み → process flow refs のみファイル更新
         const { processFlowsUpdated } = await updateProcessFlowRefs(a.screenId, mapping, root);
         for (const agId of processFlowsUpdated) {
-          wsBridge.broadcast({ wsId: workspaceContextManager.getActivePath(sessionId), event: "processFlowChanged", data: { processFlowId: agId } });
+          wsBridge.broadcast({ wsId: workspaceContextManager.getActivePath(sessionId), event: "processFlowChanged", data: { processFlowId: agId, id: agId } });
         }
         // screenChanged / screenItemsChanged は broadcast しない (browser dirty、ファイルは古いまま)
 
@@ -134,7 +134,7 @@ export const handleScreenItemTool: ToolHandler = async (name, args, root, sessio
         wsBridge.broadcast({ wsId: workspaceContextManager.getActivePath(sessionId), event: "screenItemsChanged", data: { screenId: a.screenId } });
         const allAgs = new Set(result.succeeded.flatMap((s) => s.processFlowsUpdated));
         for (const agId of allAgs) {
-          wsBridge.broadcast({ wsId: workspaceContextManager.getActivePath(sessionId), event: "processFlowChanged", data: { processFlowId: agId } });
+          wsBridge.broadcast({ wsId: workspaceContextManager.getActivePath(sessionId), event: "processFlowChanged", data: { processFlowId: agId, id: agId } });
         }
         if (result.succeeded.some((s) => s.screenHtmlUpdated)) {
           wsBridge.broadcast({ wsId: workspaceContextManager.getActivePath(sessionId), event: "screenChanged", data: { screenId: a.screenId } });

--- a/backend/src/handlers/screenItem.ts
+++ b/backend/src/handlers/screenItem.ts
@@ -37,7 +37,7 @@ export const handleScreenItemTool: ToolHandler = async (name, args, root, sessio
       const renameRes = await renameScreenItemId(a.screenId, a.oldId, a.newId, root);
       wsBridge.broadcast({ wsId: workspaceContextManager.getActivePath(sessionId), event: "screenItemsChanged", data: { screenId: a.screenId } });
       for (const agId of renameRes.processFlowsUpdated) {
-        wsBridge.broadcast({ wsId: workspaceContextManager.getActivePath(sessionId), event: "processFlowChanged", data: { id: agId } });
+        wsBridge.broadcast({ wsId: workspaceContextManager.getActivePath(sessionId), event: "processFlowChanged", data: { processFlowId: agId } });
       }
       if (renameRes.screenHtmlUpdated) {
         wsBridge.broadcast({ wsId: workspaceContextManager.getActivePath(sessionId), event: "screenChanged", data: { screenId: a.screenId } });
@@ -110,7 +110,7 @@ export const handleScreenItemTool: ToolHandler = async (name, args, root, sessio
         // ブラウザ側で適用済み → process flow refs のみファイル更新
         const { processFlowsUpdated } = await updateProcessFlowRefs(a.screenId, mapping, root);
         for (const agId of processFlowsUpdated) {
-          wsBridge.broadcast({ wsId: workspaceContextManager.getActivePath(sessionId), event: "processFlowChanged", data: { id: agId } });
+          wsBridge.broadcast({ wsId: workspaceContextManager.getActivePath(sessionId), event: "processFlowChanged", data: { processFlowId: agId } });
         }
         // screenChanged / screenItemsChanged は broadcast しない (browser dirty、ファイルは古いまま)
 
@@ -134,7 +134,7 @@ export const handleScreenItemTool: ToolHandler = async (name, args, root, sessio
         wsBridge.broadcast({ wsId: workspaceContextManager.getActivePath(sessionId), event: "screenItemsChanged", data: { screenId: a.screenId } });
         const allAgs = new Set(result.succeeded.flatMap((s) => s.processFlowsUpdated));
         for (const agId of allAgs) {
-          wsBridge.broadcast({ wsId: workspaceContextManager.getActivePath(sessionId), event: "processFlowChanged", data: { id: agId } });
+          wsBridge.broadcast({ wsId: workspaceContextManager.getActivePath(sessionId), event: "processFlowChanged", data: { processFlowId: agId } });
         }
         if (result.succeeded.some((s) => s.screenHtmlUpdated)) {
           wsBridge.broadcast({ wsId: workspaceContextManager.getActivePath(sessionId), event: "screenChanged", data: { screenId: a.screenId } });

--- a/backend/src/mcpHelpers.ts
+++ b/backend/src/mcpHelpers.ts
@@ -54,7 +54,7 @@ export async function saveAndBroadcast(agId: string, ag: ProcessFlowDoc, root: s
   ag.updatedAt = new Date().toISOString();
   await writeProcessFlow(agId, ag, root);
   // root が wsId = per-workspace scoping (#703 R-5 A-1)
-  wsBridge.broadcast({ wsId: root, event: "processFlowChanged", data: { id: agId } });
+  wsBridge.broadcast({ wsId: root, event: "processFlowChanged", data: { processFlowId: agId } });
 }
 
 /**

--- a/backend/src/mcpHelpers.ts
+++ b/backend/src/mcpHelpers.ts
@@ -54,7 +54,7 @@ export async function saveAndBroadcast(agId: string, ag: ProcessFlowDoc, root: s
   ag.updatedAt = new Date().toISOString();
   await writeProcessFlow(agId, ag, root);
   // root が wsId = per-workspace scoping (#703 R-5 A-1)
-  wsBridge.broadcast({ wsId: root, event: "processFlowChanged", data: { processFlowId: agId } });
+  wsBridge.broadcast({ wsId: root, event: "processFlowChanged", data: { processFlowId: agId, id: agId } });
 }
 
 /**

--- a/backend/src/processFlowEdits.ts
+++ b/backend/src/processFlowEdits.ts
@@ -2,7 +2,7 @@
  * ProcessFlow の細粒度編集ヘルパー (#261 MCP リアルタイム編集対応)。
  *
  * 各関数は ProcessFlow を mutate して返す (同じ参照)。呼び出し側で writeProcessFlow し、
- * wsBridge.broadcast("processFlowChanged", { id }) してブラウザを再描画させる。
+ * wsBridge.broadcast("processFlowChanged", { processFlowId }) してブラウザを再描画させる。
  */
 
 type Step = {

--- a/backend/src/wsBridge/editSessionService.ts
+++ b/backend/src/wsBridge/editSessionService.ts
@@ -392,7 +392,7 @@ export class EditSessionService {
             break;
           case "process-flow":
             await writeProcessFlow(resId, payload, root);
-            resourceChange = { event: "processFlowChanged", data: { id: resId } };
+            resourceChange = { event: "processFlowChanged", data: { processFlowId: resId } };
             break;
           case "view":
             await writeView(resId, payload, root);

--- a/backend/src/wsBridge/editSessionService.ts
+++ b/backend/src/wsBridge/editSessionService.ts
@@ -392,7 +392,7 @@ export class EditSessionService {
             break;
           case "process-flow":
             await writeProcessFlow(resId, payload, root);
-            resourceChange = { event: "processFlowChanged", data: { processFlowId: resId } };
+            resourceChange = { event: "processFlowChanged", data: { processFlowId: resId, id: resId } };
             break;
           case "view":
             await writeView(resId, payload, root);

--- a/backend/src/wsHandlers/misc.ts
+++ b/backend/src/wsHandlers/misc.ts
@@ -81,7 +81,7 @@ export const miscHandlers: RpcHandlerMap = {
     respond(result);
     bridge.broadcast({ wsId: wsId(), event: "screenItemsChanged", data: { screenId }, excludeClientId: clientId });
     for (const agId of result.processFlowsUpdated) {
-      bridge.broadcast({ wsId: wsId(), event: "processFlowChanged", data: { id: agId }, excludeClientId: clientId });
+      bridge.broadcast({ wsId: wsId(), event: "processFlowChanged", data: { processFlowId: agId }, excludeClientId: clientId });
     }
     if (result.screenHtmlUpdated) {
       bridge.broadcast({ wsId: wsId(), event: "screenChanged", data: { screenId }, excludeClientId: clientId });

--- a/backend/src/wsHandlers/misc.ts
+++ b/backend/src/wsHandlers/misc.ts
@@ -81,7 +81,7 @@ export const miscHandlers: RpcHandlerMap = {
     respond(result);
     bridge.broadcast({ wsId: wsId(), event: "screenItemsChanged", data: { screenId }, excludeClientId: clientId });
     for (const agId of result.processFlowsUpdated) {
-      bridge.broadcast({ wsId: wsId(), event: "processFlowChanged", data: { processFlowId: agId }, excludeClientId: clientId });
+      bridge.broadcast({ wsId: wsId(), event: "processFlowChanged", data: { processFlowId: agId, id: agId }, excludeClientId: clientId });
     }
     if (result.screenHtmlUpdated) {
       bridge.broadcast({ wsId: wsId(), event: "screenChanged", data: { screenId }, excludeClientId: clientId });

--- a/backend/src/wsHandlers/processFlow.ts
+++ b/backend/src/wsHandlers/processFlow.ts
@@ -43,29 +43,29 @@ import { assertSafeName, assertKind, assertEntityId } from "../security/idValida
 
 export const processFlowHandlers: RpcHandlerMap = {
   loadProcessFlow: async ({ params, root, respond }) => {
-    const { id: agId } = (params ?? {}) as { id: string };
+    const { processFlowId, id } = (params ?? {}) as { processFlowId?: string; id?: string };
+    const agId = assertEntityId(processFlowId ?? id, "processFlowId");
     // S-002: ID validation
-    assertEntityId(agId, "id");
     const agData = await readProcessFlow(agId, root());
     respond(agData);
   },
 
   saveProcessFlow: async ({ params, root, wsId, clientId, respond, bridge }) => {
-    const { id: agId, data: agData } = (params ?? {}) as { id: string; data: unknown };
+    const { processFlowId, id, data: agData } = (params ?? {}) as { processFlowId?: string; id?: string; data: unknown };
+    const agId = assertEntityId(processFlowId ?? id, "processFlowId");
     // S-002: ID validation
-    assertEntityId(agId, "id");
     await writeProcessFlow(agId, agData, root());
     respond({ success: true });
-    bridge.broadcast({ wsId: wsId(), event: "processFlowChanged", data: { id: agId }, excludeClientId: clientId });
+    bridge.broadcast({ wsId: wsId(), event: "processFlowChanged", data: { processFlowId: agId }, excludeClientId: clientId });
   },
 
   deleteProcessFlow: async ({ params, root, wsId, clientId, respond, bridge }) => {
-    const { id: agId } = (params ?? {}) as { id: string };
+    const { processFlowId, id } = (params ?? {}) as { processFlowId?: string; id?: string };
+    const agId = assertEntityId(processFlowId ?? id, "processFlowId");
     // S-002: ID validation
-    assertEntityId(agId, "id");
     await deleteProcessFlowFile(agId, root());
     respond({ success: true });
-    bridge.broadcast({ wsId: wsId(), event: "processFlowChanged", data: { id: agId, deleted: true }, excludeClientId: clientId });
+    bridge.broadcast({ wsId: wsId(), event: "processFlowChanged", data: { processFlowId: agId, deleted: true }, excludeClientId: clientId });
   },
 
   listProcessFlows: async ({ root, respond }) => {

--- a/backend/src/wsHandlers/processFlow.ts
+++ b/backend/src/wsHandlers/processFlow.ts
@@ -56,7 +56,7 @@ export const processFlowHandlers: RpcHandlerMap = {
     // S-002: ID validation
     await writeProcessFlow(agId, agData, root());
     respond({ success: true });
-    bridge.broadcast({ wsId: wsId(), event: "processFlowChanged", data: { processFlowId: agId }, excludeClientId: clientId });
+    bridge.broadcast({ wsId: wsId(), event: "processFlowChanged", data: { processFlowId: agId, id: agId }, excludeClientId: clientId });
   },
 
   deleteProcessFlow: async ({ params, root, wsId, clientId, respond, bridge }) => {
@@ -65,7 +65,7 @@ export const processFlowHandlers: RpcHandlerMap = {
     // S-002: ID validation
     await deleteProcessFlowFile(agId, root());
     respond({ success: true });
-    bridge.broadcast({ wsId: wsId(), event: "processFlowChanged", data: { processFlowId: agId, deleted: true }, excludeClientId: clientId });
+    bridge.broadcast({ wsId: wsId(), event: "processFlowChanged", data: { processFlowId: agId, id: agId, deleted: true }, excludeClientId: clientId });
   },
 
   listProcessFlows: async ({ root, respond }) => {

--- a/frontend/e2e/mcp/_helpers.ts
+++ b/frontend/e2e/mcp/_helpers.ts
@@ -122,3 +122,45 @@ export async function closeBrowserSession(): Promise<void> {
     ws.close();
   }
 }
+
+export async function observeBroadcastDuring<T>(
+  workspacePath: string,
+  event: string,
+  action: () => Promise<T>,
+): Promise<{ result: T; broadcast: unknown }> {
+  const observer = new WebSocketImpl("ws://localhost:5179");
+  const observerClientId = `observer-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const openReqId = `observer-open-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+  await new Promise<void>((resolve, reject) => {
+    observer.on("open", () => {
+      observer.send(JSON.stringify({ type: "register", clientId: observerClientId }));
+      observer.send(JSON.stringify({ type: "request", id: openReqId, method: "workspace.open", params: { path: workspacePath } }));
+    });
+    observer.on("message", (data) => {
+      const msg = JSON.parse(data.toString()) as { type?: string; id?: string; error?: string };
+      if (msg.type === "response" && msg.id === openReqId) {
+        if (msg.error) reject(new Error(msg.error));
+        else resolve();
+      }
+    });
+    observer.on("error", (err) => reject(new Error(`Observer WebSocket error: ${err.message}`)));
+  });
+
+  try {
+    const broadcastPromise = new Promise<unknown>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error(`Timeout waiting for broadcast ${event}`)), 10000);
+      observer.on("message", (data) => {
+        const msg = JSON.parse(data.toString()) as { type?: string; event?: string; data?: unknown };
+        if (msg.type === "broadcast" && msg.event === event) {
+          clearTimeout(timer);
+          resolve(msg.data);
+        }
+      });
+    });
+    const [result, broadcast] = await Promise.all([action(), broadcastPromise]);
+    return { result, broadcast };
+  } finally {
+    observer.close();
+  }
+}

--- a/frontend/e2e/mcp/mcp-tools.spec.ts
+++ b/frontend/e2e/mcp/mcp-tools.spec.ts
@@ -15,7 +15,13 @@
 import { test, expect } from "@playwright/test";
 import * as path from "path";
 import * as fs from "fs";
-import { isMcpRunning, sendBrowserRequest, openBrowserSessionWorkspace, closeBrowserSession } from "./_helpers";
+import {
+  isMcpRunning,
+  sendBrowserRequest,
+  openBrowserSessionWorkspace,
+  closeBrowserSession,
+  observeBroadcastDuring,
+} from "./_helpers";
 import { setupTestWorkspace, cleanupRealWorkspaces } from "../helpers/realWorkspace";
 import { buildProject } from "../__fixtures__/builders";
 
@@ -241,6 +247,7 @@ test.describe("wsBridge ファイル操作 (#958)", { tag: ["@regression"] }, ()
 
   test.describe("processFlow ファイル操作", () => {
     test("saveProcessFlow / loadProcessFlow でデータが往復する", async () => {
+      if (!workspacePath) throw new Error("workspacePath is not initialized");
       const id = "e2e-test-ag-001";
       const testData = {
         id,
@@ -252,8 +259,13 @@ test.describe("wsBridge ファイル操作 (#958)", { tag: ["@regression"] }, ()
         updatedAt: new Date().toISOString(),
       };
 
-      const saveResult = await sendBrowserRequest("saveProcessFlow", { processFlowId: id, data: testData });
+      const { result: saveResult, broadcast } = await observeBroadcastDuring(
+        workspacePath,
+        "processFlowChanged",
+        () => sendBrowserRequest("saveProcessFlow", { processFlowId: id, data: testData }),
+      );
       expect((saveResult as { success: boolean }).success).toBe(true);
+      expect(broadcast).toMatchObject({ processFlowId: id, id });
 
       const loadResult = await sendBrowserRequest("loadProcessFlow", { processFlowId: id });
       expect(loadResult).toMatchObject(testData);
@@ -264,14 +276,20 @@ test.describe("wsBridge ファイル操作 (#958)", { tag: ["@regression"] }, ()
     });
 
     test("deleteProcessFlow でファイルが削除される", async () => {
+      if (!workspacePath) throw new Error("workspacePath is not initialized");
       const id = "e2e-test-ag-del-001";
       await sendBrowserRequest("saveProcessFlow", {
         processFlowId: id,
         data: { id, name: "tmp", type: "screen", description: "", actions: [] },
       });
 
-      const deleteResult = await sendBrowserRequest("deleteProcessFlow", { processFlowId: id });
+      const { result: deleteResult, broadcast } = await observeBroadcastDuring(
+        workspacePath,
+        "processFlowChanged",
+        () => sendBrowserRequest("deleteProcessFlow", { processFlowId: id }),
+      );
       expect((deleteResult as { success: boolean }).success).toBe(true);
+      expect(broadcast).toMatchObject({ processFlowId: id, id, deleted: true });
 
       const loadResult = await sendBrowserRequest("loadProcessFlow", { processFlowId: id });
       expect(loadResult).toBeNull();
@@ -285,6 +303,18 @@ test.describe("wsBridge ファイル操作 (#958)", { tag: ["@regression"] }, ()
     test("loadProcessFlow は deprecated alias の id も受け付ける", async () => {
       const loadResult = await sendBrowserRequest("loadProcessFlow", { id: "nonexistent-ag-alias-xyz" });
       expect(loadResult).toBeNull();
+    });
+
+    test("saveProcessFlow / deleteProcessFlow は deprecated alias の id も受け付ける", async () => {
+      const id = "e2e-test-ag-alias-001";
+      const saveResult = await sendBrowserRequest("saveProcessFlow", {
+        id,
+        data: { id, name: "alias", type: "screen", description: "", actions: [] },
+      });
+      expect((saveResult as { success: boolean }).success).toBe(true);
+
+      const deleteResult = await sendBrowserRequest("deleteProcessFlow", { id });
+      expect((deleteResult as { success: boolean }).success).toBe(true);
     });
   });
 });

--- a/frontend/e2e/mcp/mcp-tools.spec.ts
+++ b/frontend/e2e/mcp/mcp-tools.spec.ts
@@ -252,10 +252,10 @@ test.describe("wsBridge ファイル操作 (#958)", { tag: ["@regression"] }, ()
         updatedAt: new Date().toISOString(),
       };
 
-      const saveResult = await sendBrowserRequest("saveProcessFlow", { id, data: testData });
+      const saveResult = await sendBrowserRequest("saveProcessFlow", { processFlowId: id, data: testData });
       expect((saveResult as { success: boolean }).success).toBe(true);
 
-      const loadResult = await sendBrowserRequest("loadProcessFlow", { id });
+      const loadResult = await sendBrowserRequest("loadProcessFlow", { processFlowId: id });
       expect(loadResult).toMatchObject(testData);
 
       // 後片付け
@@ -266,19 +266,24 @@ test.describe("wsBridge ファイル操作 (#958)", { tag: ["@regression"] }, ()
     test("deleteProcessFlow でファイルが削除される", async () => {
       const id = "e2e-test-ag-del-001";
       await sendBrowserRequest("saveProcessFlow", {
-        id,
+        processFlowId: id,
         data: { id, name: "tmp", type: "screen", description: "", actions: [] },
       });
 
-      const deleteResult = await sendBrowserRequest("deleteProcessFlow", { id });
+      const deleteResult = await sendBrowserRequest("deleteProcessFlow", { processFlowId: id });
       expect((deleteResult as { success: boolean }).success).toBe(true);
 
-      const loadResult = await sendBrowserRequest("loadProcessFlow", { id });
+      const loadResult = await sendBrowserRequest("loadProcessFlow", { processFlowId: id });
       expect(loadResult).toBeNull();
     });
 
-    test("存在しない id の loadProcessFlow は null", async () => {
-      const loadResult = await sendBrowserRequest("loadProcessFlow", { id: "nonexistent-ag-xyz" });
+    test("存在しない processFlowId の loadProcessFlow は null", async () => {
+      const loadResult = await sendBrowserRequest("loadProcessFlow", { processFlowId: "nonexistent-ag-xyz" });
+      expect(loadResult).toBeNull();
+    });
+
+    test("loadProcessFlow は deprecated alias の id も受け付ける", async () => {
+      const loadResult = await sendBrowserRequest("loadProcessFlow", { id: "nonexistent-ag-alias-xyz" });
       expect(loadResult).toBeNull();
     });
   });

--- a/frontend/e2e/refactor/rename-entity.spec.ts
+++ b/frontend/e2e/refactor/rename-entity.spec.ts
@@ -113,7 +113,7 @@ test.describe("Rename entity refactor — Table smoke (#1298 I-6)", { tag: ["@re
       // を使う。`designer__get_flow` は screen-flow (全 screen + edges) 用で別物。
       const bridge = (window as unknown as { __mcpBridge?: { request: (m: string, p: unknown) => Promise<unknown> } }).__mcpBridge;
       if (!bridge) return "";
-      const pf = await bridge.request("loadProcessFlow", { id }).catch(() => null);
+      const pf = await bridge.request("loadProcessFlow", { processFlowId: id }).catch(() => null);
       return pf ? JSON.stringify(pf) : "";
     }, REFERENCING_FLOW_ID);
     expect(pfTextAfterRename.length).toBeGreaterThan(0);
@@ -144,7 +144,7 @@ test.describe("Rename entity refactor — Table smoke (#1298 I-6)", { tag: ["@re
     const pfTextAfterUndo = await page.evaluate(async (id) => {
       const bridge = (window as unknown as { __mcpBridge?: { request: (m: string, p: unknown) => Promise<unknown> } }).__mcpBridge;
       if (!bridge) return "";
-      const pf = await bridge.request("loadProcessFlow", { id }).catch(() => null);
+      const pf = await bridge.request("loadProcessFlow", { processFlowId: id }).catch(() => null);
       return pf ? JSON.stringify(pf) : "";
     }, REFERENCING_FLOW_ID);
     expect(pfTextAfterUndo.length).toBeGreaterThan(0);

--- a/frontend/src/components/process-flow/ProcessFlowEditor.tsx
+++ b/frontend/src/components/process-flow/ProcessFlowEditor.tsx
@@ -212,7 +212,7 @@ export function ProcessFlowEditor() {
     load: loadProcessFlow,
     save: saveProcessFlow,
     broadcastName: "processFlowChanged",
-    broadcastIdField: "id",
+    broadcastIdField: "processFlowId",
     onNotFound: handleNotFound,
     onLoaded: handleLoaded,
     // #891 fix: viewer mode で mid-edit broadcast を受信するため渡す

--- a/frontend/src/mcp/mcpBridge.ts
+++ b/frontend/src/mcp/mcpBridge.ts
@@ -419,9 +419,9 @@ class McpBridgeImpl {
     setScreenFlowPositionsStorageBackend(screenFlowPositionsBackend);
 
     const actionBackend: ProcessFlowStorageBackend = {
-      loadProcessFlow: (id) => this.request("loadProcessFlow", { id }),
-      saveProcessFlow: (id, data) => this.request("saveProcessFlow", { id, data }).then(() => undefined),
-      deleteProcessFlow: (id) => this.request("deleteProcessFlow", { id }).then(() => undefined),
+      loadProcessFlow: (processFlowId) => this.request("loadProcessFlow", { processFlowId }),
+      saveProcessFlow: (processFlowId, data) => this.request("saveProcessFlow", { processFlowId, data }).then(() => undefined),
+      deleteProcessFlow: (processFlowId) => this.request("deleteProcessFlow", { processFlowId }).then(() => undefined),
       listProcessFlows: () => this.request("listProcessFlows"),
     };
     setProcessFlowStorageBackend(actionBackend);


### PR DESCRIPTION
## 関連

- Closes #1335
- 仕様: N/A (既存 WebSocket bridge 命名の整合化 follow-up。Issue #1335 本文を実装基準とする)

## 概要

ProcessFlow の WebSocket RPC param / broadcast payload で `{ id }` と `{ <entityType>Id }` が混在していたため、正規形を `{ processFlowId }` に統一します。既存呼び出し互換のため request param の `{ id }` は deprecated alias として残し、broadcast payload も deprecation window 中は `{ processFlowId, id }` を併送します。

## 主な変更

- ProcessFlow RPC: `loadProcessFlow` / `saveProcessFlow` / `deleteProcessFlow` の正規 param を `{ processFlowId }` に変更し、`{ id }` alias を維持
- ProcessFlow broadcast: `processFlowChanged` payload は正規 key `{ processFlowId }` に統一しつつ、互換 key `{ id }` を deprecation window として併送
- Frontend bridge/editor: `bridge.request` と `useResourceEditor` の broadcast filter を `processFlowId` に同期
- Dogfood CLI: first-party WS request を `{ processFlowId }` に更新
- E2E: 正規 param、deprecated alias、broadcast payload shape を検証

## 仕様逐条突合 (自己申告)

- Issue #1335 推奨修正 (request param を entity-typed に統一) → `backend/src/wsHandlers/processFlow.ts:45` / `backend/src/wsHandlers/processFlow.ts:53` / `backend/src/wsHandlers/processFlow.ts:62` ✓
- Issue #1335 推奨修正 (frontend bridge.request 呼び出しを同期更新) → `frontend/src/mcp/mcpBridge.ts:421` ✓
- Issue #1335 推奨修正 (first-party dogfood CLI の呼び出しを同期更新) → `backend/src/dogfoodDesignerWork.ts:38` ✓
- Issue #1335 推奨修正 (broadcast payload を entity-typed に統一) → `backend/src/wsHandlers/processFlow.ts:59` / `backend/src/wsHandlers/processFlow.ts:68` / `backend/src/mcpHelpers.ts:57` / `backend/src/wsBridge/editSessionService.ts:395` ✓
- Issue #1335 推奨修正 (onBroadcast listener の filter key を同期更新) → `frontend/src/components/process-flow/ProcessFlowEditor.tsx:214` ✓
- Issue #1335 推奨修正 (`{ id }` deprecated alias を受容) → `backend/src/wsHandlers/processFlow.ts:46` / `frontend/e2e/mcp/mcp-tools.spec.ts:303` / `frontend/e2e/mcp/mcp-tools.spec.ts:308` ✓
- Issue #1335 推奨修正 (broadcast payload shape を検証) → `frontend/e2e/mcp/mcp-tools.spec.ts:262` / `frontend/e2e/mcp/mcp-tools.spec.ts:291` ✓
- Schema governance (#511): `gh pr diff 1381 --name-only | grep -E "^schemas/"` で変更なし ✓

## レビューで特に見てほしい箇所

- `processFlowChanged` payload は canonical `processFlowId` に寄せつつ、外部/古い listener 互換のため deprecation window として `id` も併送しています。
- `processFlowChanged` を発火する backend 経路の grep 漏れがないか。

## テスト

- backend build: `npm run build` ✅
- backend Vitest: `npm test` — 38 files / 800 tests ✅
- frontend build: `npm run build` ✅
- frontend Vitest targeted: `npx vitest run src/hooks/useResourceEditor.test.ts src/store/create-uuid-coverage.test.ts` — 2 files / 26 tests ✅
- MCP E2E: `npx playwright test e2e/mcp/mcp-tools.spec.ts --grep "ProcessFlow|processFlow"` — 5 tests ✅
- frontend Vitest full: `npm run test:unit` ⚠️ 203 files / 2983 tests passed, 1 file / 25 tests failed because `.tmp/dogfood-1038/...` generated fixture files are absent in this worktree (`src/test/dogfood/dogfood-1038-structure.test.ts`). This is unrelated to #1335.

## UI 影響 / AI smoke test

- [x] UI 影響なし (auto テスト pass のみ)

### UI 影響ありの場合、AI smoke test で確認した項目

- [x] N/A

## spec 側の不足点 / 提案

N/A

## レビュー担当への申し送り

`processFlowChanged` の payload key 統一が主眼です。`rg "processFlowChanged" backend/src frontend/src frontend/e2e` で direct emitter を確認し、ID-specific payload は `{ processFlowId, id }` 併送になっています。request param の `{ id }` は alias として E2E で維持確認しています。