### PR TITLE
improve(frontend): eslint-plugin-react-hooks 7.1.1 upgrade + React Compiler 警告 3 件解消 (#1379)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,7 +55,7 @@
     "ajv-formats": "^3.0.1",
     "autoprefixer": "^10.5.0",
     "eslint": "^9.39.4",
-    "eslint-plugin-react-hooks": "7.0.1",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
     "jsdom": "^29.0.2",

--- a/frontend/src/components/Designer.tsx
+++ b/frontend/src/components/Designer.tsx
@@ -710,14 +710,15 @@ export function Designer({
     [],
   );
 
+  const editSessionId = editSession?.id;
   const applyGeneratedDesignPayload = useCallback(async (payload: unknown) => {
     const api = editorApiRef.current;
-    if (!api || !editSession?.id) {
+    if (!api || !editSessionId) {
       throw new Error("編集セッションが開始されていないため、AI 生成結果を反映できません");
     }
 
     const nextPayload = payload;
-    await mcpBridge.request("editSession.update", { editSessionId: editSession.id, payload: nextPayload });
+    await mcpBridge.request("editSession.update", { editSessionId, payload: nextPayload });
     api.setProjectData(nextPayload);
 
     if (editorKind === "puck") {
@@ -730,7 +731,7 @@ export function Designer({
     setIsDirtyState(true);
     isDirtyRef.current = true;
     setDirty(tabId, true);
-  }, [editSession?.id, editorKind, tabId]);
+  }, [editSessionId, editorKind, tabId]);
 
   // Puck 画面の cross-tab 上書き保護 (Sh-1: puckDataChanged broadcast 購読)。
   // GrapesJS は screenChanged broadcast を購読して ServerChangeBanner を表示するのと同等。

--- a/frontend/src/components/table/TableListView.tsx
+++ b/frontend/src/components/table/TableListView.tsx
@@ -77,12 +77,10 @@ export function TableListView() {
     return await listTables();
   }, []);
 
-  const commitTableChanges = useCallback(commitTables, []);
-
   const editor = useListEditor<TableEntry>({
     getId: (t) => t.id,
     load: loadTables,
-    commit: commitTableChanges,
+    commit: commitTables,
     tabId: TAB_ID,
     renumber,
   });

--- a/frontend/src/hooks/useEditSession.ts
+++ b/frontend/src/hooks/useEditSession.ts
@@ -213,6 +213,36 @@ export function useEditSession(opts: UseEditSessionOptions): UseEditSessionResul
     ? Object.values(editSession.participants)
     : [];
 
+  // ── helper: EditSession state を fetch して states を更新 ──────────────────
+  // broadcast listener の useEffect から参照されるため、宣言順を先にする
+  // (#1379: react-hooks/preserve-manual-memoization は forward reference を許容しない)
+
+  const refreshEditSessionState = useCallback(async (esId: string) => {
+    try {
+      const result = await mcpBridge.request("editSession.list", {
+        resourceType,
+        resourceId,
+      }) as { sessions: EditSessionData[] };
+      const found = result.sessions?.find((s) => s.id === esId) ?? null;
+      if (found) {
+        setEditSession(found);
+        // myRole を participants から再導出 (#980-A): take-over や transferEdit など
+        // 他 session 起点で自分の role が変わった場合に broadcast 経由で myRole を反映する。
+        // 自分の sessionId は mcpBridge.getSessionId() (= clientId) で取得可能。
+        const mySessionId = mcpBridge.getSessionId();
+        const myParticipant = found.participants[mySessionId];
+        if (myParticipant) {
+          setMyRole(myParticipant.role);
+        } else {
+          // 自分が participants から外された (例: detach 完了の broadcast) → null にリセット
+          setMyRole(null);
+        }
+      }
+    } catch (e) {
+      console.warn("[useEditSession] refreshEditSessionState failed:", e);
+    }
+  }, [resourceType, resourceId]);
+
   // ── broadcast listener ──────────────────────────────────────────────────────
 
   useEffect(() => {
@@ -305,34 +335,6 @@ export function useEditSession(opts: UseEditSessionOptions): UseEditSessionResul
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editSession?.id]);
-
-  // ── helper: EditSession state を fetch して states を更新 ──────────────────
-
-  const refreshEditSessionState = useCallback(async (esId: string) => {
-    try {
-      const result = await mcpBridge.request("editSession.list", {
-        resourceType,
-        resourceId,
-      }) as { sessions: EditSessionData[] };
-      const found = result.sessions?.find((s) => s.id === esId) ?? null;
-      if (found) {
-        setEditSession(found);
-        // myRole を participants から再導出 (#980-A): take-over や transferEdit など
-        // 他 session 起点で自分の role が変わった場合に broadcast 経由で myRole を反映する。
-        // 自分の sessionId は mcpBridge.getSessionId() (= clientId) で取得可能。
-        const mySessionId = mcpBridge.getSessionId();
-        const myParticipant = found.participants[mySessionId];
-        if (myParticipant) {
-          setMyRole(myParticipant.role);
-        } else {
-          // 自分が participants から外された (例: detach 完了の broadcast) → null にリセット
-          setMyRole(null);
-        }
-      }
-    } catch (e) {
-      console.warn("[useEditSession] refreshEditSessionState failed:", e);
-    }
-  }, [resourceType, resourceId]);
 
   // ── startEditing ────────────────────────────────────────────────────────────
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
         "ajv-formats": "^3.0.1",
         "autoprefixer": "^10.5.0",
         "eslint": "^9.39.4",
-        "eslint-plugin-react-hooks": "7.0.1",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
         "jsdom": "^29.0.2",
@@ -105,26 +105,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
-      }
-    },
-    "frontend/node_modules/eslint-plugin-react-hooks": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
-      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.24.4",
-        "@babel/parser": "^7.24.4",
-        "hermes-parser": "^0.25.1",
-        "zod": "^3.25.0 || ^4.0.0",
-        "zod-validation-error": "^3.5.0 || ^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
       }
     },
     "frontend/node_modules/typescript": {
@@ -4166,6 +4146,26 @@
         "jiti": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-plugin-react-refresh": {


### PR DESCRIPTION
## 概要

PR #1378 (#1375 実装) で `eslint-plugin-react-hooks` を `7.0.1` exact pin して回避した
React Compiler 警告 3 件を本 PR で実コード修正により解消し、`^7.1.1` (semver) pin に戻す。

## 修正内容

### frontend/package.json:58 — semver 範囲復元

`"eslint-plugin-react-hooks": "7.0.1"` → `"^7.1.1"`。`package-lock.json` も追従し
`node_modules/eslint-plugin-react-hooks` 実体は `7.1.1` 解決。

### frontend/src/components/Designer.tsx:713 — `react-hooks/preserve-manual-memoization`

useCallback dependency に `editSession?.id` (optional chain) があると React Compiler が
manual memoization を preserve できない。`editSessionId` を render scope の const に
事前展開し、deps から optional chain を除去。本体内の `editSession.id` 参照も同変数に
置換した。

### frontend/src/components/table/TableListView.tsx:80 — `react-hooks/use-memo`

`useCallback(commitTables, [])` のように **非 inline (= 関数参照)** を渡すと 7.1.1 で error。
`commitTables` は store module の export (再 render 間で識別子安定) なので useCallback で
包む必要がない。他 6 ListView と同じく直接渡しに揃えた。

### frontend/src/hooks/useEditSession.ts:311 — `react-hooks/preserve-manual-memoization`

`refreshEditSessionState` (useCallback) が、それを参照する useEffect の broadcast handler 群
(line 253/260/267/275) の **後** で宣言されていた。forward reference が closure 経由で
runtime には機能するが React Compiler は宣言順を保てないため manual memoization を
skip する。`refreshEditSessionState` の宣言ブロックを useEffect の前 (participants 導出の
直後) に物理的に移動して解消。

## 検証

| コマンド | 結果 |
|---|---|
| `npm --workspace=frontend run lint` | **0 errors** / 56 pre-existing warnings (旧 60 problems から 3 errors を解消) |
| `npm --workspace=frontend run build` | built in 3.35s |
| `npx vitest run` (frontend) | 204 files / **3008 passed** / 1 skipped |

## 受入条件 (#1379)

- [x] `frontend/package.json` の `eslint-plugin-react-hooks` が `^7.1.1` semver 範囲指定
- [x] `npm --workspace=frontend run lint` が 0 errors で pass
- [x] `// eslint-disable-next-line` 退避なし、実コード修正のみで解消

## 残課題 (本 PR scope 外、別 ISSUE で trace 確立済)

7.1.1 upgrade で **新規発生した warning 56 件** (`react-hooks/refs` 30 / `react-hooks/set-state-in-effect` 24 / `react-hooks/immutability` 2 / `react-hooks/exhaustive-deps` 2) は本 ISSUE #1379 の完了条件 (error 解消のみ) を超え、pattern 再設計を要するため #1385 に切り出した。Phase A/B/C 分割案を本文に記載 (AGENTS.md 鉄則 0 / 鉄則 3 遵守)。

## 関連

- 派生元: PR #1378 (#1375 実装) の Must-fix #2 trace 確立
- 残 warning trace: #1385 (`react-hooks` 7.1.1 残 warning 56 件解消)
- AGENTS.md 鉄則 0 (放置禁止) 遵守

Refs #1385
Closes #1379
