### PR TITLE
feat(verify): full-suite Playwright failure ↔ trace ISSUE 機械照合 gate を repo tracked 化 (#1346)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -77,8 +77,8 @@
   E2E を走らせなかった PR (docs / schema / config 等) は「N/A (e2e 未実行)」と明記。
 -->
 
-- [ ] `npm run test:e2e:regression:json > .tmp/regression-results.json` を実行
-- [ ] `node scripts/verify/regression-trace-check.mjs .tmp/regression-results.json` を実行し exit 0
+- [ ] `node scripts/verify/regression-trace-check.mjs --auto-run` を実行し exit 0
+      (または `npm run --silent test:e2e:regression:json > .tmp/regression-results.json` で file 出力 → `regression-trace-check.mjs .tmp/regression-results.json` でも可。`--silent` を忘れると npm banner で JSON 壊れる)
 - [ ] flake 主張する spec があれば `--flake <path>` で渡し、`frontend/test-results/isolation-<sanitized>.json` に 3x pass 証跡あり
 - [ ] N/A (e2e 未実行 PR / docs / schema / config 専用) — 該当時のみ理由を 1 行明記
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -68,6 +68,20 @@
 - [ ] 保存直後の JSON が Git 差分で揺れない
 - [ ] 既存機能のリグレッションなし
 
+## regression trace gate (#1346, e2e 走らせた PR は必須)
+
+<!--
+  `npm run test:e2e:regression` を走らせた PR は、merge 前に
+  `scripts/verify/regression-trace-check.mjs` で全 fail が trace 済 / flake 確認済か
+  機械検証する (詳細: docs/conventions/completion-gate.md / AGENTS.md §「regression suite ↔ trace ISSUE 機械照合 gate」)。
+  E2E を走らせなかった PR (docs / schema / config 等) は「N/A (e2e 未実行)」と明記。
+-->
+
+- [ ] `npm run test:e2e:regression:json > .tmp/regression-results.json` を実行
+- [ ] `node scripts/verify/regression-trace-check.mjs .tmp/regression-results.json` を実行し exit 0
+- [ ] flake 主張する spec があれば `--flake <path>` で渡し、`frontend/test-results/isolation-<sanitized>.json` に 3x pass 証跡あり
+- [ ] N/A (e2e 未実行 PR / docs / schema / config 専用) — 該当時のみ理由を 1 行明記
+
 ## spec 側の不足点 / 提案
 
 <!--

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -549,12 +549,16 @@ E2E regression (`npm run test:e2e:regression`) を走らせて failure が残っ
 **呼び方** (一例 — orchestrator が必須で 1 回通す):
 
 ```bash
-# 1. regression suite を JSON reporter で実行 (出力を tmp ファイルに保存)
-npm run test:e2e:regression:json > .tmp/regression-results.json || true   # fail 時も非 0 を許容
-
-# 2. trace 照合 gate を走らせる
-node scripts/verify/regression-trace-check.mjs .tmp/regression-results.json \
+# 推奨: --auto-run (npm banner を介さず playwright を直接 spawn するため shell redirect の落とし穴を回避)
+node scripts/verify/regression-trace-check.mjs --auto-run \
   --flake e2e/foo.spec.ts   # flake 主張する spec があれば明示
+
+# 別法: 既に regression を走らせて results.json を持っている場合は file 渡し
+#   注意: npm scripts は stdout 先頭に banner ("> harmony-workspace@... \n> playwright test ...") を出すため
+#   shell redirect で file 化するときは必ず `--silent` を付ける (付けないと JSON parse fail で exit 2)
+npm run --silent test:e2e:regression:json > .tmp/regression-results.json || true
+node scripts/verify/regression-trace-check.mjs .tmp/regression-results.json \
+  --flake e2e/foo.spec.ts
 # isolation 3x pass の証跡 (frontend/test-results/isolation-<sanitized>.json) を別途要求
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -540,6 +540,38 @@ Claude Code 利用時は `/test-strategy` スキルが自動起動 (詳細は `C
 - レビュー結果が Must-fix を含む場合はマージしない。Should-fix は AI が判断し、対応 or スコープ外として別 ISSUE 化
 - **PR 単位 / 機能単位のユーザー確認は不要**。AI が build / test / UI smoke (chrome-devtools MCP / Playwright) / 独立レビュー / Must-fix 解決 / マージまで完遂する。ユーザー確認は**大規模改修一連の作業の最終リリース時のみ**
 
+### regression suite ↔ trace ISSUE 機械照合 gate (#1346 / 必須、全 AI)
+
+E2E regression (`npm run test:e2e:regression`) を走らせて failure が残った場合、**PR を merge する前**に `scripts/verify/regression-trace-check.mjs` で全 fail が「trace 済 OPEN ISSUE 参照あり」または「isolation 3x pass 証跡ありの flake」であることを機械検証する。
+
+背景: #1299 Round 12-14 で「full suite に 8 fail 残ったまま merge-ready 判定」「単一 spec の strict-mode 違反を isolation pass = flake と誤判定」の事故が連続再発したため、private memory ベースの完了判定ルールを repo tracked な script に昇格 (case A)。
+
+**呼び方** (一例 — orchestrator が必須で 1 回通す):
+
+```bash
+# 1. regression suite を JSON reporter で実行 (出力を tmp ファイルに保存)
+npm run test:e2e:regression:json > .tmp/regression-results.json || true   # fail 時も非 0 を許容
+
+# 2. trace 照合 gate を走らせる
+node scripts/verify/regression-trace-check.mjs .tmp/regression-results.json \
+  --flake e2e/foo.spec.ts   # flake 主張する spec があれば明示
+# isolation 3x pass の証跡 (frontend/test-results/isolation-<sanitized>.json) を別途要求
+```
+
+**判定**:
+
+- exit 0 → 全 fail が OPEN ISSUE で trace 済 or flake 確認済 → merge gate 通過
+- exit 1 → trace なし fail が 1 件以上 → **merge 禁止**。不足分の OPEN ISSUE を起票 (鉄則 0) して再走、または fail を解消するまで merge しない
+- exit 2 → 入力エラー / gh 未配置等 → 設定不備、AI セッションでは原因究明して再走
+
+**flake 主張する場合の必須証跡**:
+
+isolation 再走 3 回連続 pass の JSON 証跡が `frontend/test-results/isolation-<sanitized>.json` に存在すること。`runs` の **末尾 3 件** が `{ "status": "passed", ... }` であれば flake 確定。前段に fail が混じっていても末尾 3 連続 pass なら OK。証跡 file は `--auto-isolation-rerun` flag で script に自動生成させることもできる。
+
+**注意 (memory `feedback_e2e_flake_isolation_vs_full_run.md` の補足)**: locator selector が `strict-mode violation` を起こしうる場合 (例: 同 name の要素が複数描画される画面で `getByText` を直 use)、isolation pass を flake 根拠にしてはならない。`.first()` / `.last()` / specific scope (`.locator(...).filter(...)`) を必ず付与する。strict-mode の場合は flake ではなく実バグなので OPEN ISSUE で trace する。
+
+詳細: `scripts/verify/regression-trace-check.mjs` の top コメント + `docs/conventions/completion-gate.md`。
+
 ## シリーズ PR (統合 PR) 運用
 
 ISSUE 本文の冒頭に `## 🔗 統合 PR 情報` セクションがある ISSUE は、**単独 PR ではなく統合 PR の一部** として実装する。実装者 (AI エージェント) は ISSUE 本文を読んだ時点で以下を自動実行する:

--- a/docs/conventions/completion-gate.md
+++ b/docs/conventions/completion-gate.md
@@ -66,15 +66,17 @@ isolation pass を flake 根拠にすると次の round で必ず再現する (R
 PR を merge 可と判定する前に、orchestrator が必ず実行:
 
 ```bash
-# 1. regression suite を JSON reporter で実行
-npm run test:e2e:regression:json > .tmp/regression-results.json || true
-
-# 2. trace 照合 gate
-node scripts/verify/regression-trace-check.mjs .tmp/regression-results.json
-#   または scope 限定の flake 主張ありの場合:
-node scripts/verify/regression-trace-check.mjs .tmp/regression-results.json \
+# 推奨: --auto-run (npm banner を介さず playwright を直接 spawn するため shell redirect 不要)
+node scripts/verify/regression-trace-check.mjs --auto-run
+#   flake 主張ありの場合:
+node scripts/verify/regression-trace-check.mjs --auto-run \
   --flake e2e/folder-picker.spec.ts \
   --auto-isolation-rerun
+
+# 別法: 既に regression を走らせて results.json を持っている場合
+#   ※ `npm run` は banner を stdout に出す。shell redirect で file 化する時は `--silent` 必須
+npm run --silent test:e2e:regression:json > .tmp/regression-results.json || true
+node scripts/verify/regression-trace-check.mjs .tmp/regression-results.json
 ```
 
 - exit 0 → 全 fail trace 済 / flake 確認済 → merge 可

--- a/docs/conventions/completion-gate.md
+++ b/docs/conventions/completion-gate.md
@@ -1,0 +1,102 @@
+# 完了判定 / merge gate 規約
+
+#1299 Round 12-14 で発生した「full regression に 8 fail 残ったまま merge-ready 判定」
+「単一 spec の strict-mode 違反を isolation pass = flake と誤判定」事故を受け、
+private memory ベースの判定ルールを repo tracked な規約に昇格したもの (#1346 case A/B)。
+
+全 AI orchestrator (Claude Code / Codex / Antigravity) は本規約に従う。
+
+## 1. 原則 — 「full suite に failure が残ったまま完了報告しない」
+
+PR を merge 可と判定する前に、以下のいずれかを満たさなければならない:
+
+- (a) `npm run test:e2e:regression` が **全 pass**
+- (b) 残 fail が `scripts/verify/regression-trace-check.mjs` で **全件 trace 済または flake 確認済** と判定される (exit 0)
+
+(a)(b) のどちらでもないまま「merge-ready」と申告するのは禁止。第 3 の選択肢
+(「次セッションで対応」「memory にメモ」「PR description に将来課題として記録」等)
+は鉄則 0 違反であり、本規約でも明示的に禁止する。
+
+## 2. trace 済の定義
+
+failed spec を「trace 済」と判定するには、以下のいずれか:
+
+- **OPEN ISSUE が title または body に spec path (or basename) を含んでいる**
+  - 例: ISSUE #1342 が `e2e/presence-list.spec.ts:110` の trace を引き受けている
+  - 機械検証は `gh issue list --state open --search "<spec-basename>"` + client side で
+    title/body に spec path を実際含むものへ絞り込む (search index の noisy match を除去)
+- **本 PR で実装される fix で同時に該当 fail が解消される** (= 本 PR description に
+  `Closes #N` で trace されている)
+
+CLOSED ISSUE は trace と認めない。**鉄則 0 違反防止** で、closed ISSUE への
+申し送りコメントは誰も読まないため (memory `feedback_closed_issue_note_not_trace.md`)。
+
+## 3. flake 判定の厳格化 — isolation 3x pass 証跡必須 (#1346 case C)
+
+「isolation pass = flake」と判定するには、以下を満たすこと:
+
+1. spec を **isolation で 3 回連続 pass** させた証跡 JSON が
+   `frontend/test-results/isolation-<sanitized>.json` に存在
+2. 証跡の `runs` 配列の **末尾 3 件** が `{ "status": "passed", ... }` である
+3. その間に locator が **strict-mode violation** を起こす可能性が無いことを human
+   または別 AI が確認済 (本規約 §4 参照)
+
+`runs` は累積記録 (前段に failed run があっても末尾 3 連続 pass で確定 OK)。証跡は
+`--auto-isolation-rerun` flag で `regression-trace-check.mjs` に自動生成させても良い。
+
+### Strict-mode 違反は flake 扱い禁止
+
+以下に該当する spec は、**isolation で何度 pass しても flake と判定しない**:
+
+- `getByText` / `getByRole` / `getByLabel` 等で **同名要素が複数描画され得る画面** を
+  scope 指定なしで叩いている
+- `.first()` / `.last()` / `.locator(...).filter(...)` / scope 限定の `getByTestId`
+  のいずれも付与されていない
+
+このような spec は **isolation pass / full-run fail のばらつき** が「先行 test の状態
+残留 + 並列実行 race」ではなく **locator 設計バグ** に由来する可能性が高く、
+isolation pass を flake 根拠にすると次の round で必ず再現する (Round 12 の
+`presence-list:110` 事故そのもの)。`.first()` 等の付与または scope 修正を行い、
+別 ISSUE で trace する。
+
+参考 memory: `feedback_e2e_flake_isolation_vs_full_run.md` の補強事項。
+
+## 4. orchestrator の機械チェック手順
+
+PR を merge 可と判定する前に、orchestrator が必ず実行:
+
+```bash
+# 1. regression suite を JSON reporter で実行
+npm run test:e2e:regression:json > .tmp/regression-results.json || true
+
+# 2. trace 照合 gate
+node scripts/verify/regression-trace-check.mjs .tmp/regression-results.json
+#   または scope 限定の flake 主張ありの場合:
+node scripts/verify/regression-trace-check.mjs .tmp/regression-results.json \
+  --flake e2e/folder-picker.spec.ts \
+  --auto-isolation-rerun
+```
+
+- exit 0 → 全 fail trace 済 / flake 確認済 → merge 可
+- exit 1 → trace なし fail 残存 → **merge 不可**。trace ISSUE を起票するか、本 PR で fail を解消する
+- exit 2 → 入力 / 設定エラー → 原因究明して再走、未解消で merge 不可
+
+## 5. private memory との関係
+
+本規約は以下の 3 件の private memory を repo tracked 化したもの:
+
+- `feedback_orchestrator_completion_gate.md` (HEAD 実走 / 自己申告で完了判定しない)
+- `feedback_completion_blocker_weak_assertions.md` (skip 追加 / 弱 assertion を解消と数えない)
+- `feedback_derived_issue_state_cross_check.md` (派生 ISSUE state の機械照合)
+
+private memory は per-user / per-machine のため、Codex / Antigravity / 他セッションから
+強制不能。本規約 + `scripts/verify/regression-trace-check.mjs` が共通の機械化された
+gate として機能する。
+
+## 6. 関連
+
+- 親 ISSUE: #1346 (本規約の起源)
+- 元 review: https://github.com/csilost2001/harmony/issues/1299#issuecomment-4540425126
+- script: `scripts/verify/regression-trace-check.mjs`
+- script test: `scripts/verify/test.mjs`
+- AGENTS.md §「regression suite ↔ trace ISSUE 機械照合 gate (#1346)」

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "build": "npm run build --workspace=@harmony/shared && concurrently -n frontend,backend -c cyan,magenta \"npm --prefix frontend run build\" \"npm --prefix backend run build\"",
     "test:unit": "npm --prefix frontend run test:unit",
     "test:e2e": "npm --prefix frontend run test:e2e",
+    "test:e2e:regression:json": "npm --prefix frontend run test:e2e:regression -- --reporter=json",
     "test:spec-check": "node scripts/spec-check/test.mjs && node scripts/spec-check/test-binding-grammar.mjs",
+    "test:verify": "node scripts/verify/test.mjs",
+    "verify:regression-trace": "node scripts/verify/regression-trace-check.mjs",
     "lint": "npm --prefix frontend run lint"
   },
   "devDependencies": {

--- a/scripts/verify/fixtures/playwright-report-all-pass.json
+++ b/scripts/verify/fixtures/playwright-report-all-pass.json
@@ -1,0 +1,35 @@
+{
+  "config": {
+    "testDir": "/workspaces/harmony/frontend/e2e"
+  },
+  "suites": [
+    {
+      "title": "e2e/foo.spec.ts",
+      "file": "/workspaces/harmony/frontend/e2e/foo.spec.ts",
+      "specs": [],
+      "suites": [
+        {
+          "title": "foo group",
+          "specs": [
+            {
+              "title": "passes happy path",
+              "ok": true,
+              "tags": ["@regression"],
+              "file": "e2e/foo.spec.ts",
+              "line": 12,
+              "tests": [
+                {
+                  "results": [
+                    { "status": "passed", "duration": 120 }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "stats": { "expected": 1, "unexpected": 0, "flaky": 0, "skipped": 0, "duration": 120 },
+  "errors": []
+}

--- a/scripts/verify/fixtures/playwright-report-mixed.json
+++ b/scripts/verify/fixtures/playwright-report-mixed.json
@@ -1,0 +1,85 @@
+{
+  "config": { "testDir": "/workspaces/harmony/frontend/e2e" },
+  "suites": [
+    {
+      "title": "e2e/presence-list.spec.ts",
+      "file": "/workspaces/harmony/frontend/e2e/presence-list.spec.ts",
+      "specs": [],
+      "suites": [
+        {
+          "title": "presence list",
+          "specs": [
+            {
+              "title": "strict mode locator (multi match)",
+              "ok": false,
+              "tags": ["@regression"],
+              "file": "e2e/presence-list.spec.ts",
+              "line": 110,
+              "tests": [
+                {
+                  "results": [
+                    {
+                      "status": "failed",
+                      "duration": 2200,
+                      "error": { "message": "strict mode violation: 2 elements" }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "happy path",
+              "ok": true,
+              "tags": ["@regression"],
+              "file": "e2e/presence-list.spec.ts",
+              "line": 30,
+              "tests": [
+                { "results": [{ "status": "passed", "duration": 50 }] }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "e2e/folder-picker.spec.ts",
+      "specs": [
+        {
+          "title": "folder picker open",
+          "ok": false,
+          "tags": ["@regression"],
+          "file": "e2e/folder-picker.spec.ts",
+          "line": 42,
+          "tests": [
+            {
+              "results": [
+                {
+                  "status": "timedOut",
+                  "duration": 30000,
+                  "errors": [{ "message": "Test timeout of 30000ms exceeded" }]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "e2e/step-ops.spec.ts",
+      "specs": [
+        {
+          "title": "step ops drag",
+          "ok": false,
+          "tags": ["@regression"],
+          "file": "e2e/step-ops.spec.ts",
+          "line": 88,
+          "tests": [
+            { "results": [{ "status": "failed", "duration": 1500, "error": { "message": "boom" } }] }
+          ]
+        }
+      ]
+    }
+  ],
+  "stats": { "expected": 1, "unexpected": 3, "flaky": 0, "skipped": 0, "duration": 36000 },
+  "errors": []
+}

--- a/scripts/verify/regression-trace-check.mjs
+++ b/scripts/verify/regression-trace-check.mjs
@@ -140,9 +140,16 @@ export function parseArgs(argv) {
           `例: --traced e2e/foo.spec.ts:1342`,
         );
       }
+      // parseInt は 2^53 を超える値で silent precision loss を起こすため、
+      // Number.isSafeInteger で安全整数範囲内であることを明示的に保証する
+      // (将来 GitHub の issue 番号が JS safe integer 上限を越える可能性は実質ゼロだが
+      //  edge を明示することで anti-fuzzing 兼ねる)。
       const issueNumber = parseInt(m[2], 10);
-      if (!Number.isFinite(issueNumber) || issueNumber <= 0) {
-        throw new Error(`--traced issue number must be a positive integer (got: ${m[2]})`);
+      if (!Number.isSafeInteger(issueNumber) || issueNumber <= 0) {
+        throw new Error(
+          `--traced issue number must be a positive safe integer (got: ${m[2]}). ` +
+          `Number.MAX_SAFE_INTEGER = ${Number.MAX_SAFE_INTEGER}`,
+        );
       }
       opt.tracedSpecs.push({ spec: m[1], issueNumber });
       continue;
@@ -513,13 +520,11 @@ export function evaluate(ctx) {
   let report;
   if (options.autoRun) {
     report = runRegressionSuite();
-  } else if (options.resultsPath === "-" || options.resultsPath === "/dev/stdin") {
-    // stdin はラッパー側で読む方が安全。ここでは明示エラー化。
-    throw new Error("stdin reading is handled outside evaluate(); pass resultsPath = a temp file");
   } else {
     if (!options.resultsPath) {
       throw new Error("results path is required unless --auto-run is set");
     }
+    // stdin ("-" or "/dev/stdin") は loadReport 側で readFileSync(0, "utf8") で処理する
     report = loadReport(options.resultsPath);
   }
 
@@ -652,15 +657,16 @@ function printHelp() {
   cat results.json | node scripts/verify/regression-trace-check.mjs - [options]
 
 Options:
-  --flake <spec>            failed spec を flake 扱い (isolation 3x pass 証跡必須)
-  --auto-run                regression suite を JSON reporter で先に走らせる
-  --auto-isolation-rerun    --flake 指定 spec を自動 isolation 3 回再走
-  --isolation-evidence-dir  証跡 dir (default: frontend/test-results)
-  --no-gh                   gh CLI 呼び出し skip (test 用)
-  --traced <spec>           手動 trace mark (test 用)
-  --json                    JSON 出力
-  --verbose, -v             詳細出力
-  --help, -h                このヘルプ
+  --flake <spec>             failed spec を flake 扱い (isolation 3x pass 証跡必須)
+  --auto-run                 regression suite を JSON reporter で先に走らせる (推奨)
+  --auto-isolation-rerun     --flake 指定 spec を自動 isolation 3 回再走
+  --isolation-evidence-dir   証跡 dir (default: frontend/test-results)
+  --no-gh                    gh CLI 呼び出し skip (オフライン / test 用)
+  --traced <spec>:<issue#>   手動 trace mark (issue 番号必須 + useGh 時 OPEN 検証)
+                             例: --traced e2e/foo.spec.ts:1342
+  --json                     JSON 出力
+  --verbose, -v              詳細出力
+  --help, -h                 このヘルプ
 
 Exit codes:
   0  全 failure が trace 済 or flake 確認済

--- a/scripts/verify/regression-trace-check.mjs
+++ b/scripts/verify/regression-trace-check.mjs
@@ -1,0 +1,697 @@
+#!/usr/bin/env node
+// scripts/verify/regression-trace-check.mjs
+// #1346 (case A): full-suite Playwright failure ↔ trace ISSUE の機械照合 gate.
+//
+// #1299 Round 12-14 で「full regression に failure が残ったまま merge-ready 判定」
+// 「単一 spec の strict-mode 違反を isolation pass = flake と誤判定」の事故が
+// 連続再発したことを受け、private memory ベースの完了判定ルールを repo tracked
+// な script に昇格したもの。
+//
+// === 目的 ===
+//
+// 1. Playwright JSON reporter 出力を parse し、unexpected な (= 期待 passed なのに
+//    failed/timedOut した) test を抽出する。
+// 2. 各 failure について `gh issue list --search "<spec-basename>"` で OPEN ISSUE が
+//    trace 済か照合する。spec ファイル名または `file:line` が title / body に存在する
+//    OPEN ISSUE が 1 件以上あれば「trace 済」と判定。
+// 3. flake 扱いするには `--flake <spec>` flag を明示し、isolation 3 回連続 pass の
+//    証跡 (frontend/test-results/isolation-<sanitized>.json) または `--auto-isolation-rerun`
+//    での自動再走を要件化する。
+// 4. trace なし fail が 1 件でも残れば exit 1 (gate fail)。
+//
+// === Usage ===
+//
+//   node scripts/verify/regression-trace-check.mjs <results.json> [options]
+//   node scripts/verify/regression-trace-check.mjs --auto-run [options]
+//   cat results.json | node scripts/verify/regression-trace-check.mjs - [options]
+//
+// === Options ===
+//
+//   --flake <spec>            Failed spec を flake 扱いする (例: e2e/foo.spec.ts)。
+//                             repeat 可能。isolation 3x pass 証跡を要求。
+//   --auto-run                regression suite を JSON reporter で先に走らせる
+//                             (`npm run test:e2e:regression -- --reporter=json`)
+//   --auto-isolation-rerun    --flake 指定の spec を自動で isolation 3 回走らせる
+//                             (`npx playwright test <spec> --workers=1`)。3 回全 pass で
+//                             flake 確定、それ以外は実 fail と判定。
+//   --isolation-evidence-dir <dir>
+//                             isolation 3x pass 証跡 JSON の格納先 (default:
+//                             frontend/test-results)。
+//   --no-gh                   gh CLI 呼び出しを skip (オフライン / test 用)。
+//                             この場合 trace 済判定は外部 input (--traced) に依存。
+//   --traced <spec>           trace 済として手動 mark (test 用、本来 gh で判定すべき)。
+//                             repeat 可能。
+//   --json                    machine-readable JSON で出力。
+//   --verbose, -v             詳細出力 (gh 呼出しの引数 / 反復ループ等)。
+//   --help, -h                このヘルプ。
+//
+// === Exit codes ===
+//
+//   0  すべての failure が trace 済 (OPEN ISSUE 参照あり) または flake 確認済
+//   1  trace なし fail が 1 件以上残る (= gate fail)
+//   2  入力 / 設定エラー (results 読めない、gh コマンドなし、等)
+//
+// === 出力例 ===
+//
+// (人間 format)
+//   ⚠ 8 failed tests detected:
+//     ✓ e2e/foo.spec.ts:10 — TRACED to #1342, #1344
+//     ✓ e2e/bar.spec.ts:25 — FLAKE confirmed (isolation 3/3 pass at frontend/test-results/...)
+//     ✗ e2e/baz.spec.ts:42 — UNTRACED: no OPEN ISSUE found
+//   Result: 2 traced, 1 flake-confirmed, 5 UNTRACED → gate FAILED.
+//
+// === AGENTS.md / PR template から呼ばれる前提 ===
+//
+// PR 作成 / merge 判断時、AI orchestrator は本 script を必ず通過させる。
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { readFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve, basename, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "../..");
+const FRONTEND_DIR = join(REPO_ROOT, "frontend");
+const DEFAULT_EVIDENCE_DIR = join(FRONTEND_DIR, "test-results");
+const ISOLATION_REQUIRED_PASS_COUNT = 3;
+
+// ─────────────────────────────────────────────────────────────
+// CLI parsing
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * @typedef {Object} CliOptions
+ * @property {string|null} resultsPath
+ * @property {string[]} flakeSpecs
+ * @property {string[]} tracedSpecs
+ * @property {boolean} autoRun
+ * @property {boolean} autoIsolationRerun
+ * @property {string} isolationEvidenceDir
+ * @property {boolean} useGh
+ * @property {boolean} jsonOutput
+ * @property {boolean} verbose
+ * @property {boolean} help
+ */
+
+/**
+ * @param {string[]} argv
+ * @returns {CliOptions}
+ */
+export function parseArgs(argv) {
+  /** @type {CliOptions} */
+  const opt = {
+    resultsPath: null,
+    flakeSpecs: [],
+    tracedSpecs: [],
+    autoRun: false,
+    autoIsolationRerun: false,
+    isolationEvidenceDir: DEFAULT_EVIDENCE_DIR,
+    useGh: true,
+    jsonOutput: false,
+    verbose: false,
+    help: false,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--flake") {
+      const v = argv[++i];
+      if (!v) throw new Error("--flake requires a spec path");
+      opt.flakeSpecs.push(v);
+      continue;
+    }
+    if (a === "--traced") {
+      const v = argv[++i];
+      if (!v) throw new Error("--traced requires a spec path");
+      opt.tracedSpecs.push(v);
+      continue;
+    }
+    if (a === "--auto-run") { opt.autoRun = true; continue; }
+    if (a === "--auto-isolation-rerun") { opt.autoIsolationRerun = true; continue; }
+    if (a === "--isolation-evidence-dir") {
+      const v = argv[++i];
+      if (!v) throw new Error("--isolation-evidence-dir requires a path");
+      opt.isolationEvidenceDir = resolve(REPO_ROOT, v);
+      continue;
+    }
+    if (a === "--no-gh") { opt.useGh = false; continue; }
+    if (a === "--json") { opt.jsonOutput = true; continue; }
+    if (a === "--verbose" || a === "-v") { opt.verbose = true; continue; }
+    if (a === "--help" || a === "-h") { opt.help = true; continue; }
+    if (a.startsWith("--")) { throw new Error(`Unknown option: ${a}`); }
+    if (!opt.resultsPath) { opt.resultsPath = a; continue; }
+    throw new Error(`Unexpected positional argument: ${a}`);
+  }
+
+  return opt;
+}
+
+// ─────────────────────────────────────────────────────────────
+// Playwright JSON 解析
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * @typedef {Object} FailedTest
+ * @property {string} file         spec ファイル path (例: "e2e/foo.spec.ts")
+ * @property {number} line         test 行番号
+ * @property {string} title        spec title
+ * @property {string} status       "failed" | "timedOut"
+ * @property {string|null} errorMessage
+ */
+
+/**
+ * Playwright JSON reporter 出力から failed test を抽出。
+ * `ok: false` の spec のうち、test results に "failed" / "timedOut" を含むものを採用。
+ *
+ * spec.file は Playwright が testDir 起点の相対 path で出力する (e.g., "e2e/foo.spec.ts")。
+ * 古い report が "foo.spec.ts" のように prefix なしの場合は呼び出し側で補正する。
+ *
+ * @param {unknown} report
+ * @returns {FailedTest[]}
+ */
+export function extractFailedTests(report) {
+  /** @type {FailedTest[]} */
+  const failed = [];
+  if (!report || typeof report !== "object") return failed;
+  const suites = /** @type {any} */ (report).suites;
+  if (!Array.isArray(suites)) return failed;
+
+  /** @param {any} suite */
+  const walk = (suite) => {
+    if (!suite || typeof suite !== "object") return;
+    if (Array.isArray(suite.specs)) {
+      for (const spec of suite.specs) {
+        if (!spec || typeof spec !== "object") continue;
+        if (spec.ok !== false) continue;
+        const tests = Array.isArray(spec.tests) ? spec.tests : [];
+        let status = null;
+        let errorMessage = null;
+        for (const t of tests) {
+          const results = Array.isArray(t?.results) ? t.results : [];
+          for (const r of results) {
+            if (r?.status === "failed" || r?.status === "timedOut") {
+              status = r.status;
+              if (!errorMessage) {
+                const err = r.error ?? (Array.isArray(r.errors) ? r.errors[0] : null);
+                if (err) {
+                  errorMessage = typeof err === "string" ? err : (err.message ?? err.value ?? null);
+                }
+              }
+            }
+          }
+        }
+        if (status) {
+          failed.push({
+            file: typeof spec.file === "string" ? spec.file : "",
+            line: typeof spec.line === "number" ? spec.line : 0,
+            title: typeof spec.title === "string" ? spec.title : "(no title)",
+            status,
+            errorMessage,
+          });
+        }
+      }
+    }
+    if (Array.isArray(suite.suites)) {
+      for (const child of suite.suites) walk(child);
+    }
+  };
+
+  for (const top of suites) walk(top);
+  return failed;
+}
+
+// ─────────────────────────────────────────────────────────────
+// gh issue list 照合
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * @typedef {Object} IssueRef
+ * @property {number} number
+ * @property {string} title
+ * @property {string} url
+ */
+
+/**
+ * gh issue list を spec basename で検索し、title / body / comments に
+ * file path or "file:line" を含む OPEN ISSUE を返す。
+ *
+ * GitHub search はトークン化 (`/` で分割等) されるため、search で取得後
+ * client side で `text.includes(name)` の precise filter を必ずかける。
+ *
+ * @param {string} specFile             spec の相対 path (e.g., "e2e/foo.spec.ts")
+ * @param {number} line                 spec の行番号 (0 なら無視)
+ * @param {(cmd: string, args: string[]) => string} runGh  injectable for testing
+ * @returns {IssueRef[]}
+ */
+export function findTracingIssues(specFile, line, runGh) {
+  const name = basename(specFile);
+  if (!name) return [];
+  const out = runGh("gh", [
+    "issue", "list",
+    "--state", "open",
+    "--search", name,
+    "--json", "number,title,body,url",
+    "--limit", "50",
+  ]);
+  /** @type {Array<{number:number,title:string,body?:string,url:string}>} */
+  let issues;
+  try {
+    issues = JSON.parse(out);
+  } catch (err) {
+    throw new Error(`gh issue list output was not JSON: ${err.message}`);
+  }
+  /** @type {IssueRef[]} */
+  const matches = [];
+  for (const issue of issues) {
+    const text = `${issue.title || ""}\n${issue.body || ""}`;
+    // file or basename を必ず含む (title/body precise filter)
+    if (text.includes(specFile) || text.includes(name)) {
+      matches.push({ number: issue.number, title: issue.title || "", url: issue.url });
+    }
+  }
+  return matches;
+}
+
+/**
+ * gh CLI 実行 (sync)。stderr は捨てる。non-zero exit でも stdout を返す
+ * (gh は 0 件ヒットでも 0 exit するため、err 判定は呼び出し側で JSON parse fail に委ねる)。
+ *
+ * @param {string} cmd
+ * @param {string[]} args
+ * @returns {string}
+ */
+function runGhCli(cmd, args) {
+  const result = spawnSync(cmd, args, {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    timeout: 30_000,
+  });
+  if (result.error) {
+    throw new Error(`Failed to run ${cmd}: ${result.error.message}`);
+  }
+  if (typeof result.status === "number" && result.status !== 0) {
+    // gh search が miss でも status 0 のはずだが、念のため err message を含めて throw
+    const tail = (result.stderr || "").trim().slice(0, 400);
+    throw new Error(`${cmd} exited with status ${result.status}: ${tail}`);
+  }
+  return result.stdout || "";
+}
+
+// ─────────────────────────────────────────────────────────────
+// isolation 証跡 / 自動再走
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * spec path を file system safe な sanitized 名に変換 (証跡 file 名用)。
+ * @param {string} spec
+ * @returns {string}
+ */
+export function sanitizeSpecName(spec) {
+  return spec.replace(/[^a-zA-Z0-9._-]+/g, "_");
+}
+
+/**
+ * isolation 証跡 JSON を読み、ISOLATION_REQUIRED_PASS_COUNT 回連続 pass を確認。
+ *
+ * 証跡 file format:
+ *   { "spec": "e2e/foo.spec.ts", "runs": [ { "status": "passed", "duration": 1234 }, ... ] }
+ *
+ * @param {string} spec
+ * @param {string} dir
+ * @returns {{ ok: boolean, reason: string, evidencePath: string }}
+ */
+export function checkIsolationEvidence(spec, dir) {
+  const path = join(dir, `isolation-${sanitizeSpecName(spec)}.json`);
+  if (!existsSync(path)) {
+    return { ok: false, reason: `evidence file not found: ${path}`, evidencePath: path };
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf8"));
+  } catch (err) {
+    return { ok: false, reason: `evidence file is not JSON: ${err.message}`, evidencePath: path };
+  }
+  const runs = Array.isArray(parsed?.runs) ? parsed.runs : null;
+  if (!runs || runs.length < ISOLATION_REQUIRED_PASS_COUNT) {
+    return {
+      ok: false,
+      reason: `expected at least ${ISOLATION_REQUIRED_PASS_COUNT} runs, found ${runs?.length ?? 0}`,
+      evidencePath: path,
+    };
+  }
+  const lastN = runs.slice(-ISOLATION_REQUIRED_PASS_COUNT);
+  const allPass = lastN.every((r) => r?.status === "passed");
+  if (!allPass) {
+    return {
+      ok: false,
+      reason: `last ${ISOLATION_REQUIRED_PASS_COUNT} runs not all passed: ${lastN.map((r) => r?.status).join(", ")}`,
+      evidencePath: path,
+    };
+  }
+  return { ok: true, reason: `isolation ${ISOLATION_REQUIRED_PASS_COUNT}/${ISOLATION_REQUIRED_PASS_COUNT} pass`, evidencePath: path };
+}
+
+/**
+ * spec を isolation で 3 回走らせ、証跡 file に書き出す。
+ * 既存 evidence が 3 回連続 pass なら skip。
+ *
+ * @param {string} spec
+ * @param {string} dir
+ * @param {(cmd: string, args: string[], opts?: {cwd?:string}) => {status: number, stdout: string, stderr: string}} runProc
+ * @param {boolean} verbose
+ * @returns {{ ok: boolean, reason: string, evidencePath: string }}
+ */
+export function runIsolationLoop(spec, dir, runProc, verbose) {
+  mkdirSync(dir, { recursive: true });
+  const evidencePath = join(dir, `isolation-${sanitizeSpecName(spec)}.json`);
+  /** @type {Array<{status: string, duration: number, ranAt: string}>} */
+  const runs = [];
+  for (let i = 1; i <= ISOLATION_REQUIRED_PASS_COUNT; i++) {
+    if (verbose) console.error(`  isolation run ${i}/${ISOLATION_REQUIRED_PASS_COUNT}: ${spec}`);
+    const r = runProc("npx", [
+      "playwright", "test", spec,
+      "--workers=1",
+      "--reporter=json",
+    ], { cwd: FRONTEND_DIR });
+    let status = "failed";
+    let duration = 0;
+    if (r.status === 0) {
+      try {
+        const report = JSON.parse(r.stdout);
+        const fails = extractFailedTests(report);
+        if (fails.length === 0) status = "passed";
+        duration = report?.stats?.duration ?? 0;
+      } catch {
+        status = "failed";
+      }
+    }
+    runs.push({ status, duration, ranAt: new Date().toISOString() });
+    if (status !== "passed") {
+      // fail at any run → cease, write evidence anyway
+      writeFileSync(evidencePath, JSON.stringify({ spec, runs }, null, 2));
+      return {
+        ok: false,
+        reason: `isolation run ${i} did not pass (status=${status})`,
+        evidencePath,
+      };
+    }
+  }
+  writeFileSync(evidencePath, JSON.stringify({ spec, runs }, null, 2));
+  return { ok: true, reason: `isolation ${ISOLATION_REQUIRED_PASS_COUNT}/${ISOLATION_REQUIRED_PASS_COUNT} pass`, evidencePath };
+}
+
+// ─────────────────────────────────────────────────────────────
+// main pipeline
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * @typedef {Object} Evaluation
+ * @property {FailedTest} failed
+ * @property {"traced"|"flake-confirmed"|"untraced"} verdict
+ * @property {string} detail
+ * @property {IssueRef[]} tracingIssues
+ */
+
+/**
+ * @typedef {Object} Pipeline
+ * @property {CliOptions} options
+ * @property {(path: string) => unknown} loadReport
+ * @property {() => unknown} runRegressionSuite
+ * @property {(cmd: string, args: string[]) => string} runGh
+ * @property {(cmd: string, args: string[], opts?: {cwd?: string}) => {status: number, stdout: string, stderr: string}} runProc
+ */
+
+/**
+ * core pipeline. injectable for testing。
+ *
+ * @param {Pipeline} ctx
+ * @returns {{ evaluations: Evaluation[], gateOk: boolean }}
+ */
+export function evaluate(ctx) {
+  const { options, loadReport, runRegressionSuite, runGh, runProc } = ctx;
+
+  let report;
+  if (options.autoRun) {
+    report = runRegressionSuite();
+  } else if (options.resultsPath === "-" || options.resultsPath === "/dev/stdin") {
+    // stdin はラッパー側で読む方が安全。ここでは明示エラー化。
+    throw new Error("stdin reading is handled outside evaluate(); pass resultsPath = a temp file");
+  } else {
+    if (!options.resultsPath) {
+      throw new Error("results path is required unless --auto-run is set");
+    }
+    report = loadReport(options.resultsPath);
+  }
+
+  const failed = extractFailedTests(report);
+  /** @type {Evaluation[]} */
+  const evaluations = [];
+
+  /** flake spec の正規化 (basename / 相対 path 両対応) */
+  const flakeSet = new Set();
+  for (const s of options.flakeSpecs) {
+    flakeSet.add(s);
+    flakeSet.add(basename(s));
+  }
+  const tracedManualSet = new Set();
+  for (const s of options.tracedSpecs) {
+    tracedManualSet.add(s);
+    tracedManualSet.add(basename(s));
+  }
+
+  for (const f of failed) {
+    const fileKeys = [f.file, basename(f.file)];
+
+    // 1. manual traced
+    if (fileKeys.some((k) => tracedManualSet.has(k))) {
+      evaluations.push({
+        failed: f,
+        verdict: "traced",
+        detail: "manually marked via --traced",
+        tracingIssues: [],
+      });
+      continue;
+    }
+
+    // 2. flake (要証跡)
+    if (fileKeys.some((k) => flakeSet.has(k))) {
+      let result;
+      if (options.autoIsolationRerun) {
+        result = runIsolationLoop(f.file, options.isolationEvidenceDir, runProc, options.verbose);
+      } else {
+        result = checkIsolationEvidence(f.file, options.isolationEvidenceDir);
+      }
+      evaluations.push({
+        failed: f,
+        verdict: result.ok ? "flake-confirmed" : "untraced",
+        detail: result.ok
+          ? `flake-confirmed (${result.reason}, evidence: ${result.evidencePath})`
+          : `flake claim REJECTED: ${result.reason}`,
+        tracingIssues: [],
+      });
+      continue;
+    }
+
+    // 3. gh issue trace
+    if (options.useGh) {
+      const issues = findTracingIssues(f.file, f.line, runGh);
+      if (issues.length > 0) {
+        evaluations.push({
+          failed: f,
+          verdict: "traced",
+          detail: `OPEN ISSUE: ${issues.map((i) => `#${i.number}`).join(", ")}`,
+          tracingIssues: issues,
+        });
+        continue;
+      }
+    }
+
+    evaluations.push({
+      failed: f,
+      verdict: "untraced",
+      detail: options.useGh
+        ? "no OPEN ISSUE found referencing this spec"
+        : "--no-gh mode and no --traced / --flake mark",
+      tracingIssues: [],
+    });
+  }
+
+  const gateOk = evaluations.every((e) => e.verdict !== "untraced");
+  return { evaluations, gateOk };
+}
+
+// ─────────────────────────────────────────────────────────────
+// CLI entry
+// ─────────────────────────────────────────────────────────────
+
+function printHelp() {
+  // top コメントから抽出するのは面倒なので簡易版を出す
+  console.log(`Usage:
+  node scripts/verify/regression-trace-check.mjs <results.json> [options]
+  node scripts/verify/regression-trace-check.mjs --auto-run [options]
+  cat results.json | node scripts/verify/regression-trace-check.mjs - [options]
+
+Options:
+  --flake <spec>            failed spec を flake 扱い (isolation 3x pass 証跡必須)
+  --auto-run                regression suite を JSON reporter で先に走らせる
+  --auto-isolation-rerun    --flake 指定 spec を自動 isolation 3 回再走
+  --isolation-evidence-dir  証跡 dir (default: frontend/test-results)
+  --no-gh                   gh CLI 呼び出し skip (test 用)
+  --traced <spec>           手動 trace mark (test 用)
+  --json                    JSON 出力
+  --verbose, -v             詳細出力
+  --help, -h                このヘルプ
+
+Exit codes:
+  0  全 failure が trace 済 or flake 確認済
+  1  trace なし fail が 1 件以上
+  2  入力 / 設定エラー
+
+詳細: scripts/verify/regression-trace-check.mjs top コメント参照。`);
+}
+
+/**
+ * @param {string} path
+ * @returns {unknown}
+ */
+function loadReportFromFile(path) {
+  if (path === "-" || path === "/dev/stdin") {
+    return JSON.parse(readFileSync(0, "utf8"));
+  }
+  const resolved = resolve(REPO_ROOT, path);
+  return JSON.parse(readFileSync(resolved, "utf8"));
+}
+
+/**
+ * @returns {unknown}
+ */
+function runRegressionSuiteImpl() {
+  const r = spawnSync(
+    "npx",
+    ["playwright", "test", "--grep", "@regression", "--reporter=json"],
+    { cwd: FRONTEND_DIR, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+  );
+  if (r.error) {
+    throw new Error(`Failed to run playwright: ${r.error.message}`);
+  }
+  // playwright は fail 時に non-zero で抜けるが JSON は stdout に出る
+  return JSON.parse(r.stdout);
+}
+
+/**
+ * @param {string} cmd
+ * @param {string[]} args
+ * @param {{cwd?: string}} [opts]
+ */
+function runProcImpl(cmd, args, opts = {}) {
+  const r = spawnSync(cmd, args, {
+    cwd: opts.cwd ?? REPO_ROOT,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return {
+    status: typeof r.status === "number" ? r.status : (r.error ? 127 : 1),
+    stdout: r.stdout || "",
+    stderr: r.stderr || "",
+  };
+}
+
+/**
+ * @param {Evaluation[]} evaluations
+ * @param {boolean} gateOk
+ * @param {boolean} jsonOutput
+ */
+function emitReport(evaluations, gateOk, jsonOutput) {
+  if (jsonOutput) {
+    console.log(JSON.stringify({
+      gateOk,
+      summary: {
+        total: evaluations.length,
+        traced: evaluations.filter((e) => e.verdict === "traced").length,
+        flakeConfirmed: evaluations.filter((e) => e.verdict === "flake-confirmed").length,
+        untraced: evaluations.filter((e) => e.verdict === "untraced").length,
+      },
+      evaluations: evaluations.map((e) => ({
+        file: e.failed.file,
+        line: e.failed.line,
+        title: e.failed.title,
+        status: e.failed.status,
+        verdict: e.verdict,
+        detail: e.detail,
+        tracingIssues: e.tracingIssues,
+      })),
+    }, null, 2));
+    return;
+  }
+  if (evaluations.length === 0) {
+    console.log("✓ No failed tests in report — gate PASS.");
+    return;
+  }
+  console.log(`⚠ ${evaluations.length} failed tests detected:`);
+  for (const e of evaluations) {
+    const icon = e.verdict === "untraced" ? "✗" : "✓";
+    const tag =
+      e.verdict === "traced" ? "TRACED"
+      : e.verdict === "flake-confirmed" ? "FLAKE confirmed"
+      : "UNTRACED";
+    console.log(`  ${icon} ${e.failed.file}:${e.failed.line} [${e.failed.status}] — ${tag}: ${e.detail}`);
+  }
+  const summary = {
+    traced: evaluations.filter((e) => e.verdict === "traced").length,
+    flake: evaluations.filter((e) => e.verdict === "flake-confirmed").length,
+    untraced: evaluations.filter((e) => e.verdict === "untraced").length,
+  };
+  console.log(
+    `\nResult: ${summary.traced} traced, ${summary.flake} flake-confirmed, ${summary.untraced} UNTRACED → gate ${gateOk ? "PASS" : "FAILED"}.`,
+  );
+}
+
+/** CLI entry — `node scripts/verify/regression-trace-check.mjs ...` で直接起動された時のみ走る */
+async function main() {
+  /** @type {CliOptions} */
+  let opt;
+  try {
+    opt = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
+    printHelp();
+    process.exit(2);
+  }
+  if (opt.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (!opt.autoRun && !opt.resultsPath) {
+    console.error("Error: results.json path or --auto-run is required.");
+    printHelp();
+    process.exit(2);
+  }
+
+  try {
+    const result = evaluate({
+      options: opt,
+      loadReport: loadReportFromFile,
+      runRegressionSuite: runRegressionSuiteImpl,
+      runGh: runGhCli,
+      runProc: runProcImpl,
+    });
+    emitReport(result.evaluations, result.gateOk, opt.jsonOutput);
+    process.exit(result.gateOk ? 0 : 1);
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
+    if (opt.verbose) console.error(err.stack);
+    process.exit(2);
+  }
+}
+
+// import される時 (test から) は main() を起動しない
+const invokedDirectly = (() => {
+  try {
+    return resolve(process.argv[1] ?? "") === resolve(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
+})();
+if (invokedDirectly) {
+  main();
+}

--- a/scripts/verify/regression-trace-check.mjs
+++ b/scripts/verify/regression-trace-check.mjs
@@ -39,8 +39,10 @@
 //                             frontend/test-results)。
 //   --no-gh                   gh CLI 呼び出しを skip (オフライン / test 用)。
 //                             この場合 trace 済判定は外部 input (--traced) に依存。
-//   --traced <spec>           trace 済として手動 mark (test 用、本来 gh で判定すべき)。
-//                             repeat 可能。
+//   --traced <spec>:<issue#>  trace 済として手動 mark (例: e2e/foo.spec.ts:1342)。
+//                             gate の意図を破らないように **issue 番号必須** + useGh 時は
+//                             `gh issue view <N> --json state` で OPEN を機械検証する
+//                             (CLOSED や存在しない番号は trace と認めない)。repeat 可能。
 //   --json                    machine-readable JSON で出力。
 //   --verbose, -v             詳細出力 (gh 呼出しの引数 / 反復ループ等)。
 //   --help, -h                このヘルプ。
@@ -80,10 +82,16 @@ const ISOLATION_REQUIRED_PASS_COUNT = 3;
 // ─────────────────────────────────────────────────────────────
 
 /**
+ * @typedef {Object} TracedRef
+ * @property {string} spec         spec の相対 path or basename (parseArgs で両方 set される)
+ * @property {number} issueNumber  trace 先 OPEN ISSUE 番号 (整数)
+ */
+
+/**
  * @typedef {Object} CliOptions
  * @property {string|null} resultsPath
  * @property {string[]} flakeSpecs
- * @property {string[]} tracedSpecs
+ * @property {TracedRef[]} tracedSpecs    manual trace (<spec>:<issue#> 形式必須)
  * @property {boolean} autoRun
  * @property {boolean} autoIsolationRerun
  * @property {string} isolationEvidenceDir
@@ -122,8 +130,21 @@ export function parseArgs(argv) {
     }
     if (a === "--traced") {
       const v = argv[++i];
-      if (!v) throw new Error("--traced requires a spec path");
-      opt.tracedSpecs.push(v);
+      if (!v) throw new Error("--traced requires <spec>:<issue#> (例: e2e/foo.spec.ts:1342)");
+      // spec path に `:` を含めない前提 (Playwright spec path には通常 colon は出現しない)。
+      // 末尾の `:<整数>` を issue 番号として切り出す。
+      const m = /^(.+):(\d+)$/.exec(v);
+      if (!m) {
+        throw new Error(
+          `--traced requires <spec>:<issue#> format with integer issue number (got: ${v}). ` +
+          `例: --traced e2e/foo.spec.ts:1342`,
+        );
+      }
+      const issueNumber = parseInt(m[2], 10);
+      if (!Number.isFinite(issueNumber) || issueNumber <= 0) {
+        throw new Error(`--traced issue number must be a positive integer (got: ${m[2]})`);
+      }
+      opt.tracedSpecs.push({ spec: m[1], issueNumber });
       continue;
     }
     if (a === "--auto-run") { opt.autoRun = true; continue; }
@@ -232,11 +253,13 @@ export function extractFailedTests(report) {
  */
 
 /**
- * gh issue list を spec basename で検索し、title / body / comments に
- * file path or "file:line" を含む OPEN ISSUE を返す。
+ * gh issue list を spec basename で検索し、title / body に
+ * file path or basename を含む OPEN ISSUE を返す。
  *
  * GitHub search はトークン化 (`/` で分割等) されるため、search で取得後
  * client side で `text.includes(name)` の precise filter を必ずかける。
+ * comment 内まで照合したい場合は別途 `gh issue view --comments` を呼ぶ必要があるが、
+ * 現状の規約 (docs/conventions/completion-gate.md §2) では title/body のみを trace 対象とする。
  *
  * @param {string} specFile             spec の相対 path (e.g., "e2e/foo.spec.ts")
  * @param {number} line                 spec の行番号 (0 なら無視)
@@ -270,6 +293,29 @@ export function findTracingIssues(specFile, line, runGh) {
     }
   }
   return matches;
+}
+
+/**
+ * gh issue view <N> --json state --jq .state を呼び、OPEN / CLOSED / null を返す。
+ * `--traced <spec>:<issue#>` の手動 trace 検証用 (gate の意図上 CLOSED は trace と認めない)。
+ *
+ * @param {number} issueNumber
+ * @param {(cmd: string, args: string[]) => string} runGh
+ * @returns {"OPEN"|"CLOSED"|null}
+ */
+export function checkIssueState(issueNumber, runGh) {
+  try {
+    const out = runGh("gh", [
+      "issue", "view", String(issueNumber),
+      "--json", "state",
+      "--jq", ".state",
+    ]);
+    const trimmed = (out || "").trim().toUpperCase();
+    if (trimmed === "OPEN" || trimmed === "CLOSED") return trimmed;
+    return null;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -401,6 +447,40 @@ export function runIsolationLoop(spec, dir, runProc, verbose) {
 }
 
 // ─────────────────────────────────────────────────────────────
+// strict-mode 違反検出 (#1346 case C — flake 扱い禁止の機械化)
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * Playwright の strict-mode locator violation error pattern を検出する。
+ *
+ * 規約: locator selector が strict-mode に違反する可能性がある fail は
+ * 「先行 test の状態残留 + 並列 race」由来の flake ではなく **locator 設計バグ** に
+ * 由来する可能性が高く、isolation pass を flake 根拠にすると同じ事象が次の round で
+ * 必ず再現する (#1299 Round 12 の `presence-list:110` 事故そのもの)。
+ *
+ * 本関数が true を返す failure は、--flake + isolation 3x pass 証跡があっても
+ * flake-confirmed に降格してはならず、`.first()` / `.last()` / scope 限定の付与
+ * または別 ISSUE での実バグ trace を要求する。
+ *
+ * 検出パターン (Playwright の error message から抽出):
+ * - "strict mode violation"   (canonical message)
+ * - "resolved to N elements"  (英語 fallback)
+ * - "strict mode"             (緩めの match、誤検出より見逃し回避を優先)
+ *
+ * @param {string|null|undefined} errorMessage
+ * @returns {boolean}
+ */
+export function isStrictModeViolation(errorMessage) {
+  if (!errorMessage || typeof errorMessage !== "string") return false;
+  const lc = errorMessage.toLowerCase();
+  if (lc.includes("strict mode violation")) return true;
+  if (lc.includes("strict mode")) return true;
+  // Playwright の strict-mode error の構造化 message が変わった場合の fallback
+  if (/resolved to \d+ elements?/i.test(errorMessage)) return true;
+  return false;
+}
+
+// ─────────────────────────────────────────────────────────────
 // main pipeline
 // ─────────────────────────────────────────────────────────────
 
@@ -453,28 +533,68 @@ export function evaluate(ctx) {
     flakeSet.add(s);
     flakeSet.add(basename(s));
   }
-  const tracedManualSet = new Set();
-  for (const s of options.tracedSpecs) {
-    tracedManualSet.add(s);
-    tracedManualSet.add(basename(s));
+  /** manual traced: spec 名 (両形態) → issueNumber */
+  const tracedManualMap = new Map();
+  for (const t of options.tracedSpecs) {
+    tracedManualMap.set(t.spec, t.issueNumber);
+    tracedManualMap.set(basename(t.spec), t.issueNumber);
   }
 
   for (const f of failed) {
     const fileKeys = [f.file, basename(f.file)];
 
-    // 1. manual traced
-    if (fileKeys.some((k) => tracedManualSet.has(k))) {
-      evaluations.push({
-        failed: f,
-        verdict: "traced",
-        detail: "manually marked via --traced",
-        tracingIssues: [],
-      });
-      continue;
+    // 1. manual traced (要 issue 番号 + useGh=true 時は OPEN 検証)
+    {
+      let manualIssue = null;
+      for (const k of fileKeys) {
+        if (tracedManualMap.has(k)) {
+          manualIssue = tracedManualMap.get(k);
+          break;
+        }
+      }
+      if (manualIssue !== null) {
+        if (options.useGh) {
+          const state = checkIssueState(manualIssue, runGh);
+          if (state !== "OPEN") {
+            evaluations.push({
+              failed: f,
+              verdict: "untraced",
+              detail:
+                `--traced #${manualIssue} REJECTED: state=${state ?? "unknown"} (must be OPEN). ` +
+                `CLOSED ISSUE は trace と認めない (docs/conventions/completion-gate.md §2)`,
+              tracingIssues: [],
+            });
+            continue;
+          }
+        }
+        evaluations.push({
+          failed: f,
+          verdict: "traced",
+          detail: options.useGh
+            ? `manually traced via --traced (#${manualIssue} verified OPEN)`
+            : `manually traced via --traced (#${manualIssue}, --no-gh: OPEN unverified)`,
+          tracingIssues: [{ number: manualIssue, title: "(via --traced)", url: "" }],
+        });
+        continue;
+      }
     }
 
     // 2. flake (要証跡)
     if (fileKeys.some((k) => flakeSet.has(k))) {
+      // 2a. strict-mode violation は locator 設計バグ由来のため flake 扱いを拒否
+      //     (docs/conventions/completion-gate.md §3 — case C 機械化)
+      if (isStrictModeViolation(f.errorMessage)) {
+        evaluations.push({
+          failed: f,
+          verdict: "untraced",
+          detail:
+            "flake claim REJECTED: error indicates strict-mode locator violation — " +
+            "isolation pass cannot be used as flake evidence (see docs/conventions/completion-gate.md §3). " +
+            "Fix the locator (`.first()` / `.last()` / scope) and trace via OPEN ISSUE.",
+          tracingIssues: [],
+        });
+        continue;
+      }
       let result;
       if (options.autoIsolationRerun) {
         result = runIsolationLoop(f.file, options.isolationEvidenceDir, runProc, options.verbose);

--- a/scripts/verify/test.mjs
+++ b/scripts/verify/test.mjs
@@ -18,6 +18,8 @@ import {
   sanitizeSpecName,
   checkIsolationEvidence,
   runIsolationLoop,
+  isStrictModeViolation,
+  checkIssueState,
   evaluate,
 } from "./regression-trace-check.mjs";
 
@@ -53,11 +55,14 @@ group("parseArgs", () => {
   assert("default useGh = true", opt.useGh === true);
   assert("default autoRun = false", opt.autoRun === false);
 
-  const opt2 = parseArgs(["--auto-run", "--no-gh", "--json", "--traced", "e2e/x.spec.ts"]);
+  const opt2 = parseArgs(["--auto-run", "--no-gh", "--json", "--traced", "e2e/x.spec.ts:1234"]);
   assert("autoRun without positional", opt2.autoRun === true && opt2.resultsPath === null);
   assert("--no-gh flips useGh", opt2.useGh === false);
   assert("--json flag", opt2.jsonOutput === true);
-  assert("--traced collected", opt2.tracedSpecs[0] === "e2e/x.spec.ts");
+  assert(
+    "--traced collected as TracedRef",
+    opt2.tracedSpecs[0]?.spec === "e2e/x.spec.ts" && opt2.tracedSpecs[0]?.issueNumber === 1234,
+  );
 
   let threw = false;
   try { parseArgs(["--flake"]); } catch (e) { threw = e.message.includes("requires a spec path"); }
@@ -66,6 +71,22 @@ group("parseArgs", () => {
   let threw2 = false;
   try { parseArgs(["--unknown-flag"]); } catch (e) { threw2 = e.message.includes("Unknown option"); }
   assert("unknown option throws", threw2);
+
+  // --traced format requirements
+  let threwT1 = false;
+  try { parseArgs(["dummy", "--traced", "e2e/foo.spec.ts"]); }
+  catch (e) { threwT1 = e.message.includes("<issue#>"); }
+  assert("--traced without issue# throws", threwT1);
+
+  let threwT2 = false;
+  try { parseArgs(["dummy", "--traced", "e2e/foo.spec.ts:abc"]); }
+  catch (e) { threwT2 = e.message.includes("<issue#>"); }
+  assert("--traced non-numeric issue throws", threwT2);
+
+  let threwT3 = false;
+  try { parseArgs(["dummy", "--traced", "e2e/foo.spec.ts:0"]); }
+  catch (e) { threwT3 = e.message.includes("positive integer"); }
+  assert("--traced zero issue throws", threwT3);
 });
 
 // ─────────────────────────────────────────────────────────────
@@ -124,6 +145,51 @@ group("findTracingIssues with gh stub", () => {
   ]);
   const m3 = findTracingIssues("e2e/foo.spec.ts", 1, runGhBody);
   assert("body containing spec path → match", m3.length === 1 && m3[0].number === 555);
+});
+
+// ─────────────────────────────────────────────────────────────
+// isStrictModeViolation (#1346 case C 機械化)
+// ─────────────────────────────────────────────────────────────
+group("isStrictModeViolation", () => {
+  assert(
+    "canonical Playwright message detected",
+    isStrictModeViolation("Error: strict mode violation: locator('.btn') resolved to 3 elements"),
+  );
+  assert(
+    "loose match (just 'strict mode')",
+    isStrictModeViolation("got strict mode error from playwright"),
+  );
+  assert(
+    "resolved to N elements fallback",
+    isStrictModeViolation("Locator resolved to 2 elements: foo, bar"),
+  );
+  assert("regular timeout not strict-mode", isStrictModeViolation("Test timeout of 30000ms exceeded") === false);
+  assert("null / undefined safe", isStrictModeViolation(null) === false && isStrictModeViolation(undefined) === false);
+  assert("empty string safe", isStrictModeViolation("") === false);
+});
+
+// ─────────────────────────────────────────────────────────────
+// checkIssueState (gh issue view stub)
+// ─────────────────────────────────────────────────────────────
+group("checkIssueState", () => {
+  const ghOpen = () => "OPEN\n";
+  const ghClosed = () => "CLOSED\n";
+  const ghEmpty = () => "";
+  const ghThrow = () => { throw new Error("gh: issue not found"); };
+  const ghOther = () => "DRAFT\n";
+
+  assert("OPEN state", checkIssueState(1234, ghOpen) === "OPEN");
+  assert("CLOSED state", checkIssueState(1234, ghClosed) === "CLOSED");
+  assert("empty output → null", checkIssueState(1234, ghEmpty) === null);
+  assert("gh throws → null", checkIssueState(1234, ghThrow) === null);
+  assert("unknown state → null", checkIssueState(1234, ghOther) === null);
+
+  // Validate args
+  let captured;
+  const ghCapture = (cmd, args) => { captured = { cmd, args }; return "OPEN"; };
+  checkIssueState(1346, ghCapture);
+  assert("gh issue view called", captured?.args?.[0] === "issue" && captured?.args?.[1] === "view" && captured?.args?.[2] === "1346");
+  assert("gh --jq .state passed", captured?.args?.includes("--jq") && captured?.args?.includes(".state"));
 });
 
 // ─────────────────────────────────────────────────────────────
@@ -308,8 +374,13 @@ group("evaluate end-to-end", () => {
   assert("D: gateOk = false (all untraced)", resD.gateOk === false);
   assert("D: every verdict = untraced", resD.evaluations.every((e) => e.verdict === "untraced"));
 
-  // Scenario E: --traced manual mark
-  const optE = parseArgs(["dummy", "--no-gh", "--traced", "e2e/presence-list.spec.ts", "--traced", "e2e/folder-picker.spec.ts", "--traced", "e2e/step-ops.spec.ts"]);
+  // Scenario E: --traced manual mark with issue numbers (--no-gh, skip OPEN check)
+  const optE = parseArgs([
+    "dummy", "--no-gh",
+    "--traced", "e2e/presence-list.spec.ts:1342",
+    "--traced", "e2e/folder-picker.spec.ts:9999",
+    "--traced", "e2e/step-ops.spec.ts:8888",
+  ]);
   const resE = evaluate({
     options: optE,
     loadReport,
@@ -317,7 +388,111 @@ group("evaluate end-to-end", () => {
     runGh: () => { throw new Error("should not call gh"); },
     runProc: () => ({ status: 0, stdout: "", stderr: "" }),
   });
-  assert("E: all traced manually → gateOk = true", resE.gateOk === true);
+  assert("E: all traced manually (no-gh) → gateOk = true", resE.gateOk === true);
+  const presenceE = resE.evaluations.find((ev) => ev.failed.file === "e2e/presence-list.spec.ts");
+  assert(
+    "E: tracingIssues contains #1342 from --traced",
+    presenceE?.tracingIssues?.[0]?.number === 1342,
+  );
+
+  // Scenario F: strict-mode violation + --flake + isolation evidence → still UNTRACED (case C)
+  const dirF = mkdtempSync(join(tmpdir(), "eval-scenarioF-"));
+  writeFileSync(
+    join(dirF, `isolation-${sanitizeSpecName("e2e/presence-list.spec.ts")}.json`),
+    JSON.stringify({
+      spec: "e2e/presence-list.spec.ts",
+      runs: [{ status: "passed" }, { status: "passed" }, { status: "passed" }],
+    }),
+  );
+  const optF = parseArgs([
+    "dummy", "--no-gh",
+    "--flake", "e2e/presence-list.spec.ts",
+    "--flake", "e2e/folder-picker.spec.ts",
+    "--flake", "e2e/step-ops.spec.ts",
+    "--isolation-evidence-dir", dirF,
+  ]);
+  // Also provide isolation evidence for folder-picker and step-ops (these are NOT strict-mode)
+  writeFileSync(
+    join(dirF, `isolation-${sanitizeSpecName("e2e/folder-picker.spec.ts")}.json`),
+    JSON.stringify({
+      spec: "e2e/folder-picker.spec.ts",
+      runs: [{ status: "passed" }, { status: "passed" }, { status: "passed" }],
+    }),
+  );
+  writeFileSync(
+    join(dirF, `isolation-${sanitizeSpecName("e2e/step-ops.spec.ts")}.json`),
+    JSON.stringify({
+      spec: "e2e/step-ops.spec.ts",
+      runs: [{ status: "passed" }, { status: "passed" }, { status: "passed" }],
+    }),
+  );
+  const resF = evaluate({
+    options: optF,
+    loadReport,
+    runRegressionSuite,
+    runGh: () => { throw new Error("should not call gh"); },
+    runProc: () => ({ status: 0, stdout: "", stderr: "" }),
+  });
+  const presenceF = resF.evaluations.find((ev) => ev.failed.file === "e2e/presence-list.spec.ts");
+  assert(
+    "F: strict-mode failure with isolation evidence → UNTRACED (case C guard)",
+    presenceF?.verdict === "untraced" && presenceF?.detail?.includes("strict-mode") === true,
+  );
+  const folderF = resF.evaluations.find((ev) => ev.failed.file === "e2e/folder-picker.spec.ts");
+  assert(
+    "F: non strict-mode timedOut + isolation 3x pass → flake-confirmed",
+    folderF?.verdict === "flake-confirmed",
+  );
+  assert(
+    "F: gateOk = false (strict-mode 1 件 untraced)",
+    resF.gateOk === false,
+  );
+
+  // Scenario G: --traced with gh validation (OPEN / CLOSED) — uses useGh path
+  const optG_open = parseArgs(["dummy", "--traced", "e2e/presence-list.spec.ts:1342"]);
+  // For this test, treat folder-picker / step-ops as gh-traced via title match (or via --traced too)
+  const optG_open2 = parseArgs([
+    "dummy",
+    "--traced", "e2e/presence-list.spec.ts:1342",
+    "--traced", "e2e/folder-picker.spec.ts:9999",
+    "--traced", "e2e/step-ops.spec.ts:8888",
+  ]);
+  // gh stub: 1342 = OPEN, 9999 / 8888 = OPEN as well
+  const ghAllOpen = (cmd, args) => {
+    if (args[1] === "view") return "OPEN";
+    return "[]";
+  };
+  const resG_open = evaluate({
+    options: optG_open2,
+    loadReport,
+    runRegressionSuite,
+    runGh: ghAllOpen,
+    runProc: () => ({ status: 0, stdout: "", stderr: "" }),
+  });
+  assert("G-open: all OPEN issue traces → gateOk = true", resG_open.gateOk === true);
+
+  // gh stub: 1342 = CLOSED
+  const ghClosedForPresence = (cmd, args) => {
+    if (args[1] === "view") {
+      const issueNum = args[2];
+      if (issueNum === "1342") return "CLOSED";
+      return "OPEN";
+    }
+    return "[]";
+  };
+  const resG_closed = evaluate({
+    options: optG_open2,
+    loadReport,
+    runRegressionSuite,
+    runGh: ghClosedForPresence,
+    runProc: () => ({ status: 0, stdout: "", stderr: "" }),
+  });
+  const presenceG = resG_closed.evaluations.find((ev) => ev.failed.file === "e2e/presence-list.spec.ts");
+  assert(
+    "G-closed: CLOSED issue rejected as traced",
+    presenceG?.verdict === "untraced" && presenceG?.detail?.includes("CLOSED"),
+  );
+  assert("G-closed: gateOk = false", resG_closed.gateOk === false);
 });
 
 // ─────────────────────────────────────────────────────────────

--- a/scripts/verify/test.mjs
+++ b/scripts/verify/test.mjs
@@ -1,0 +1,328 @@
+#!/usr/bin/env node
+// scripts/verify/ 内 script の自動テスト。
+// #1346 case A で導入された regression-trace-check.mjs の parse / 照合 /
+// flake 判定ロジックを fixture と stub で検証する。
+//
+// Usage: node scripts/verify/test.mjs
+// Exit code: 0 = pass, 1 = fail
+
+import { readFileSync, mkdtempSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import {
+  parseArgs,
+  extractFailedTests,
+  findTracingIssues,
+  sanitizeSpecName,
+  checkIsolationEvidence,
+  runIsolationLoop,
+  evaluate,
+} from "./regression-trace-check.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURES = join(__dirname, "fixtures");
+
+let pass = 0;
+let fail = 0;
+
+function assert(name, cond, detail = "") {
+  if (cond) {
+    console.log(`  ✓ ${name}`);
+    pass++;
+  } else {
+    console.log(`  ✗ ${name}${detail ? `: ${detail}` : ""}`);
+    fail++;
+  }
+}
+
+function group(title, fn) {
+  console.log(`\n• ${title}`);
+  fn();
+}
+
+// ─────────────────────────────────────────────────────────────
+// parseArgs
+// ─────────────────────────────────────────────────────────────
+group("parseArgs", () => {
+  const opt = parseArgs(["results.json", "--flake", "e2e/a.spec.ts", "--flake", "e2e/b.spec.ts", "--verbose"]);
+  assert("resultsPath captured", opt.resultsPath === "results.json");
+  assert("flakeSpecs collected", opt.flakeSpecs.length === 2 && opt.flakeSpecs[1] === "e2e/b.spec.ts");
+  assert("verbose flag", opt.verbose === true);
+  assert("default useGh = true", opt.useGh === true);
+  assert("default autoRun = false", opt.autoRun === false);
+
+  const opt2 = parseArgs(["--auto-run", "--no-gh", "--json", "--traced", "e2e/x.spec.ts"]);
+  assert("autoRun without positional", opt2.autoRun === true && opt2.resultsPath === null);
+  assert("--no-gh flips useGh", opt2.useGh === false);
+  assert("--json flag", opt2.jsonOutput === true);
+  assert("--traced collected", opt2.tracedSpecs[0] === "e2e/x.spec.ts");
+
+  let threw = false;
+  try { parseArgs(["--flake"]); } catch (e) { threw = e.message.includes("requires a spec path"); }
+  assert("--flake without value throws", threw);
+
+  let threw2 = false;
+  try { parseArgs(["--unknown-flag"]); } catch (e) { threw2 = e.message.includes("Unknown option"); }
+  assert("unknown option throws", threw2);
+});
+
+// ─────────────────────────────────────────────────────────────
+// extractFailedTests
+// ─────────────────────────────────────────────────────────────
+group("extractFailedTests", () => {
+  const allPass = JSON.parse(readFileSync(join(FIXTURES, "playwright-report-all-pass.json"), "utf8"));
+  assert("all-pass report → empty array", extractFailedTests(allPass).length === 0);
+
+  const mixed = JSON.parse(readFileSync(join(FIXTURES, "playwright-report-mixed.json"), "utf8"));
+  const failed = extractFailedTests(mixed);
+  assert("mixed report → 3 failures", failed.length === 3, `got ${failed.length}`);
+
+  const presence = failed.find((f) => f.file === "e2e/presence-list.spec.ts");
+  assert("presence-list captured", presence !== undefined);
+  assert("presence-list line = 110", presence?.line === 110);
+  assert("presence-list status = failed", presence?.status === "failed");
+  assert("error message captured", presence?.errorMessage?.includes("strict mode") === true);
+
+  const folder = failed.find((f) => f.file === "e2e/folder-picker.spec.ts");
+  assert("folder-picker captured as timedOut", folder?.status === "timedOut");
+  assert("folder-picker errors[] handled", folder?.errorMessage?.includes("timeout") === true);
+
+  // Edge: malformed input
+  assert("null report → empty", extractFailedTests(null).length === 0);
+  assert("undefined report → empty", extractFailedTests(undefined).length === 0);
+  assert("missing suites → empty", extractFailedTests({}).length === 0);
+});
+
+// ─────────────────────────────────────────────────────────────
+// findTracingIssues (gh stub)
+// ─────────────────────────────────────────────────────────────
+group("findTracingIssues with gh stub", () => {
+  const stubResults = JSON.stringify([
+    { number: 1342, title: "follow-up for e2e/presence-list.spec.ts:110", body: "details", url: "https://x/1342" },
+    { number: 1999, title: "unrelated", body: "", url: "https://x/1999" },
+  ]);
+  const captured = { args: null };
+  const runGh = (cmd, args) => {
+    captured.args = args;
+    return stubResults;
+  };
+  const matches = findTracingIssues("e2e/presence-list.spec.ts", 110, runGh);
+  assert("gh args contain --state open", captured.args?.includes("open") === true);
+  assert("gh search arg = basename", captured.args?.[captured.args.indexOf("--search") + 1] === "presence-list.spec.ts");
+  assert("only matching issue returned", matches.length === 1 && matches[0].number === 1342);
+
+  // No match scenario
+  const runGhEmpty = () => JSON.stringify([{ number: 999, title: "other", body: "no spec ref", url: "" }]);
+  const m2 = findTracingIssues("e2e/foo.spec.ts", 10, runGhEmpty);
+  assert("non-matching issue filtered out", m2.length === 0);
+
+  // body match
+  const runGhBody = () => JSON.stringify([
+    { number: 555, title: "general issue", body: "see e2e/foo.spec.ts for repro", url: "" },
+  ]);
+  const m3 = findTracingIssues("e2e/foo.spec.ts", 1, runGhBody);
+  assert("body containing spec path → match", m3.length === 1 && m3[0].number === 555);
+});
+
+// ─────────────────────────────────────────────────────────────
+// sanitizeSpecName
+// ─────────────────────────────────────────────────────────────
+group("sanitizeSpecName", () => {
+  assert("slash → underscore", sanitizeSpecName("e2e/foo.spec.ts") === "e2e_foo.spec.ts");
+  assert("colon → underscore", sanitizeSpecName("foo:bar:baz") === "foo_bar_baz");
+  assert("dot preserved", sanitizeSpecName("a.b.c") === "a.b.c");
+});
+
+// ─────────────────────────────────────────────────────────────
+// checkIsolationEvidence / runIsolationLoop
+// ─────────────────────────────────────────────────────────────
+group("checkIsolationEvidence", () => {
+  const dir = mkdtempSync(join(tmpdir(), "isolation-evidence-"));
+  const spec = "e2e/presence-list.spec.ts";
+  // 1. file 不存在
+  const r1 = checkIsolationEvidence(spec, dir);
+  assert("absent evidence → ok=false", r1.ok === false && r1.reason.includes("not found"));
+
+  // 2. invalid JSON
+  writeFileSync(join(dir, `isolation-${sanitizeSpecName(spec)}.json`), "{ not json");
+  const r2 = checkIsolationEvidence(spec, dir);
+  assert("invalid JSON → ok=false", r2.ok === false && r2.reason.includes("not JSON"));
+
+  // 3. runs < 3
+  writeFileSync(
+    join(dir, `isolation-${sanitizeSpecName(spec)}.json`),
+    JSON.stringify({ spec, runs: [{ status: "passed" }, { status: "passed" }] }),
+  );
+  const r3 = checkIsolationEvidence(spec, dir);
+  assert("runs < 3 → ok=false", r3.ok === false && r3.reason.includes("at least"));
+
+  // 4. 3 runs but last has fail
+  writeFileSync(
+    join(dir, `isolation-${sanitizeSpecName(spec)}.json`),
+    JSON.stringify({ spec, runs: [{ status: "passed" }, { status: "passed" }, { status: "failed" }] }),
+  );
+  const r4 = checkIsolationEvidence(spec, dir);
+  assert("last 3 not all pass → ok=false", r4.ok === false && r4.reason.includes("not all passed"));
+
+  // 5. all 3 pass → ok=true
+  writeFileSync(
+    join(dir, `isolation-${sanitizeSpecName(spec)}.json`),
+    JSON.stringify({ spec, runs: [{ status: "passed" }, { status: "passed" }, { status: "passed" }] }),
+  );
+  const r5 = checkIsolationEvidence(spec, dir);
+  assert("3 consecutive pass → ok=true", r5.ok === true);
+
+  // 6. 5 runs with last 3 passed → ok=true (前段の fail があっても last 3 で判定)
+  writeFileSync(
+    join(dir, `isolation-${sanitizeSpecName(spec)}.json`),
+    JSON.stringify({ spec, runs: [{ status: "failed" }, { status: "failed" }, { status: "passed" }, { status: "passed" }, { status: "passed" }] }),
+  );
+  const r6 = checkIsolationEvidence(spec, dir);
+  assert("last 3 pass after earlier fails → ok=true", r6.ok === true);
+});
+
+group("runIsolationLoop", () => {
+  const dir = mkdtempSync(join(tmpdir(), "isolation-loop-"));
+  const spec = "e2e/foo.spec.ts";
+  // stub runProc: 3 回連続 passed report を返す
+  let calls = 0;
+  const stubPass = () => {
+    calls++;
+    return {
+      status: 0,
+      stdout: JSON.stringify({ suites: [], stats: { duration: 100 } }),
+      stderr: "",
+    };
+  };
+  const r = runIsolationLoop(spec, dir, stubPass, false);
+  assert("3 pass runs → ok=true", r.ok === true);
+  assert("runProc called 3 times", calls === 3);
+  const ev = JSON.parse(readFileSync(r.evidencePath, "utf8"));
+  assert("evidence file persisted", ev.runs.length === 3 && ev.runs.every((x) => x.status === "passed"));
+
+  // 2 回目で fail
+  let calls2 = 0;
+  const stubFail = () => {
+    calls2++;
+    if (calls2 === 2) {
+      return {
+        status: 1,
+        stdout: JSON.stringify({
+          suites: [{ specs: [{ ok: false, file: "e2e/foo.spec.ts", line: 1, tests: [{ results: [{ status: "failed", error: { message: "x" } }] }] }] }],
+          stats: { duration: 100 },
+        }),
+        stderr: "",
+      };
+    }
+    return { status: 0, stdout: JSON.stringify({ suites: [], stats: { duration: 100 } }), stderr: "" };
+  };
+  const dir2 = mkdtempSync(join(tmpdir(), "isolation-loop-fail-"));
+  const r2 = runIsolationLoop(spec, dir2, stubFail, false);
+  assert("fail at run 2 → ok=false", r2.ok === false);
+  assert("stops early (calls=2)", calls2 === 2);
+});
+
+// ─────────────────────────────────────────────────────────────
+// evaluate (E2E)
+// ─────────────────────────────────────────────────────────────
+group("evaluate end-to-end", () => {
+  const mixed = JSON.parse(readFileSync(join(FIXTURES, "playwright-report-mixed.json"), "utf8"));
+  const loadReport = () => mixed;
+  const runRegressionSuite = () => { throw new Error("should not auto-run"); };
+
+  // Scenario A: gh stub returns issue for presence-list, --flake folder-picker (no evidence) → step-ops UNTRACED
+  const dir = mkdtempSync(join(tmpdir(), "eval-scenarioA-"));
+  const ghStubA = (cmd, args) => {
+    const searchTerm = args[args.indexOf("--search") + 1];
+    if (searchTerm === "presence-list.spec.ts") {
+      return JSON.stringify([{ number: 1342, title: "presence-list strict mode @ e2e/presence-list.spec.ts:110", body: "", url: "" }]);
+    }
+    return JSON.stringify([]);
+  };
+  const optA = parseArgs(["dummy", "--flake", "e2e/folder-picker.spec.ts", "--isolation-evidence-dir", dir]);
+  const resA = evaluate({
+    options: optA,
+    loadReport,
+    runRegressionSuite,
+    runGh: ghStubA,
+    runProc: () => ({ status: 1, stdout: "", stderr: "" }),
+  });
+  assert("3 evaluations", resA.evaluations.length === 3);
+  const presenceEv = resA.evaluations.find((e) => e.failed.file === "e2e/presence-list.spec.ts");
+  const folderEv = resA.evaluations.find((e) => e.failed.file === "e2e/folder-picker.spec.ts");
+  const stepEv = resA.evaluations.find((e) => e.failed.file === "e2e/step-ops.spec.ts");
+  assert("presence-list traced via gh", presenceEv?.verdict === "traced");
+  assert("folder-picker flake rejected (no evidence)", folderEv?.verdict === "untraced");
+  assert("step-ops untraced", stepEv?.verdict === "untraced");
+  assert("gateOk = false", resA.gateOk === false);
+
+  // Scenario B: provide isolation evidence for folder-picker, gh trace for step-ops → all green
+  const dir2 = mkdtempSync(join(tmpdir(), "eval-scenarioB-"));
+  writeFileSync(
+    join(dir2, `isolation-${sanitizeSpecName("e2e/folder-picker.spec.ts")}.json`),
+    JSON.stringify({ spec: "e2e/folder-picker.spec.ts", runs: [{ status: "passed" }, { status: "passed" }, { status: "passed" }] }),
+  );
+  const ghStubB = (cmd, args) => {
+    const term = args[args.indexOf("--search") + 1];
+    if (term === "presence-list.spec.ts") return JSON.stringify([{ number: 1342, title: "tracks e2e/presence-list.spec.ts", body: "", url: "" }]);
+    if (term === "step-ops.spec.ts") return JSON.stringify([{ number: 1888, title: "step-ops follow up (e2e/step-ops.spec.ts)", body: "", url: "" }]);
+    return JSON.stringify([]);
+  };
+  const optB = parseArgs(["dummy", "--flake", "e2e/folder-picker.spec.ts", "--isolation-evidence-dir", dir2]);
+  const resB = evaluate({
+    options: optB,
+    loadReport,
+    runRegressionSuite,
+    runGh: ghStubB,
+    runProc: () => ({ status: 1, stdout: "", stderr: "" }),
+  });
+  assert("B: gateOk = true", resB.gateOk === true);
+  assert(
+    "B: folder-picker flake confirmed",
+    resB.evaluations.find((e) => e.failed.file === "e2e/folder-picker.spec.ts")?.verdict === "flake-confirmed",
+  );
+
+  // Scenario C: no failures → gateOk = true, evaluations empty
+  const optC = parseArgs(["dummy"]);
+  const resC = evaluate({
+    options: optC,
+    loadReport: () => JSON.parse(readFileSync(join(FIXTURES, "playwright-report-all-pass.json"), "utf8")),
+    runRegressionSuite,
+    runGh: () => JSON.stringify([]),
+    runProc: () => ({ status: 0, stdout: "", stderr: "" }),
+  });
+  assert("C: no failures → empty evaluations", resC.evaluations.length === 0);
+  assert("C: gateOk = true", resC.gateOk === true);
+
+  // Scenario D: --no-gh & no --traced → all UNTRACED unless --flake with evidence
+  const optD = parseArgs(["dummy", "--no-gh"]);
+  const resD = evaluate({
+    options: optD,
+    loadReport,
+    runRegressionSuite,
+    runGh: () => { throw new Error("should not call gh"); },
+    runProc: () => ({ status: 0, stdout: "", stderr: "" }),
+  });
+  assert("D: gateOk = false (all untraced)", resD.gateOk === false);
+  assert("D: every verdict = untraced", resD.evaluations.every((e) => e.verdict === "untraced"));
+
+  // Scenario E: --traced manual mark
+  const optE = parseArgs(["dummy", "--no-gh", "--traced", "e2e/presence-list.spec.ts", "--traced", "e2e/folder-picker.spec.ts", "--traced", "e2e/step-ops.spec.ts"]);
+  const resE = evaluate({
+    options: optE,
+    loadReport,
+    runRegressionSuite,
+    runGh: () => { throw new Error("should not call gh"); },
+    runProc: () => ({ status: 0, stdout: "", stderr: "" }),
+  });
+  assert("E: all traced manually → gateOk = true", resE.gateOk === true);
+});
+
+// ─────────────────────────────────────────────────────────────
+// Result summary
+// ─────────────────────────────────────────────────────────────
+console.log(`\n────────────────────────────────────────────`);
+console.log(`Result: ${pass} pass, ${fail} fail`);
+if (fail > 0) process.exit(1);

--- a/scripts/verify/test.mjs
+++ b/scripts/verify/test.mjs
@@ -85,8 +85,28 @@ group("parseArgs", () => {
 
   let threwT3 = false;
   try { parseArgs(["dummy", "--traced", "e2e/foo.spec.ts:0"]); }
-  catch (e) { threwT3 = e.message.includes("positive integer"); }
+  catch (e) { threwT3 = e.message.includes("positive safe integer"); }
   assert("--traced zero issue throws", threwT3);
+
+  // unsafe integer rejection (#1346 Codex Round 2 Nit guard)
+  let threwT4 = false;
+  try { parseArgs(["dummy", "--traced", "e2e/foo.spec.ts:9007199254740993"]); }
+  catch (e) { threwT4 = e.message.includes("safe integer"); }
+  assert("--traced > MAX_SAFE_INTEGER throws", threwT4);
+
+  // ok-path: large but safe integer
+  const optLarge = parseArgs(["dummy", "--traced", "e2e/foo.spec.ts:9007199254740991"]);
+  assert(
+    "--traced MAX_SAFE_INTEGER accepted",
+    optLarge.tracedSpecs[0]?.issueNumber === Number.MAX_SAFE_INTEGER,
+  );
+
+  // Windows-style paths: regex takes last `:<digits>` so backslash paths work
+  const optWin = parseArgs(["dummy", "--traced", "e2e\\foo.spec.ts:42"]);
+  assert(
+    "--traced Windows path parsed (last :<digits> wins)",
+    optWin.tracedSpecs[0]?.spec === "e2e\\foo.spec.ts" && optWin.tracedSpecs[0]?.issueNumber === 42,
+  );
 });
 
 // ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 関連

- Closes #1346
- 仕様: docs/conventions/completion-gate.md (本 PR で新規追加)
- 起源 Codex review: https://github.com/csilost2001/harmony/issues/1299#issuecomment-4540425126
- 親 ISSUE: #1299 (CLOSED)

## 概要

#1299 Round 12-14 で「full regression に 8 fail 残ったまま merge-ready 判定」
「単一 spec の strict-mode 違反を isolation pass = flake と誤判定」事故が
連続再発したため、private memory ベースの完了判定ルールを repo tracked な
機械化 gate に昇格 (case A)。同時に規約も `docs/conventions/completion-gate.md`
として明文化 (case B 相当を吸収)、strict-mode violation の flake 扱い禁止
ルール (case C 相当) も同規約に統合した。フォローアップ ISSUE 化はせず、
case A + B + C を 1 PR で完結。

## 主な変更

- **判定 script**: `scripts/verify/regression-trace-check.mjs` (新規、697 行 / コメント込み)
  - Playwright JSON reporter 出力 (`--reporter=json`) を parse し、`ok: false`
    の spec を抽出
  - `gh issue list --state open --search "<basename>"` で OPEN ISSUE を取得し、
    title/body に spec path or basename を実際に含むもの (search index の noisy
    match を client side で除去) を trace 済と判定
  - flake は `--flake <spec>` flag + isolation 3 回連続 pass 証跡で確定
    (`frontend/test-results/isolation-<sanitized>.json` 形式)
  - `--auto-isolation-rerun` で isolation を自動 3 回走らせ証跡を生成可能
  - exit code: 0 = 全件 trace 済 / flake 確認済、1 = trace なし fail 残存、
    2 = 入力エラー
  - test injection 用 / test 用に `--no-gh` / `--traced <spec>` / `--json` /
    `--verbose` を装備
- **テスト**: `scripts/verify/test.mjs` (新規、53 assertions、全 pass)
  - parseArgs / extractFailedTests / findTracingIssues / sanitizeSpecName /
    checkIsolationEvidence / runIsolationLoop / evaluate end-to-end の 7 グループ
  - stub injection で gh / process 呼出しを mock
  - fixture: playwright-report-all-pass.json / playwright-report-mixed.json
- **規約 doc**: `docs/conventions/completion-gate.md` (新規、102 行)
  - private memory 3 件 (`feedback_orchestrator_completion_gate.md` 等) の
    昇格版
  - trace 済の定義 / flake 判定の厳格化 / orchestrator の機械チェック手順を明記
  - strict-mode violation を flake 扱い禁止するルール (case C 相当を吸収)
- **規約配線**: AGENTS.md §「PR 作成・レビューの規約」末尾に
  「regression suite ↔ trace ISSUE 機械照合 gate (#1346)」セクションを追加
- **npm scripts**: root package.json に 3 件追加
  - `test:verify` — 本 script の自動テスト
  - `test:e2e:regression:json` — JSON reporter で regression 実行
  - `verify:regression-trace` — 本 script を呼ぶ shortcut
- **PR template**: `.github/pull_request_template.md` に「regression trace gate」
  セクションを追加 (UI 影響セクション直後、4 項目 checklist)

## 仕様逐条突合 (自己申告)

ISSUE #1346 case A の期待される対応 5 項目:

- ✓ (1) `scripts/verify/regression-trace-check.ts` 等を新規作成 →
  `scripts/verify/regression-trace-check.mjs:1` (mjs に統一、scripts/spec-check と
  同パターン)
- ✓ (2) Playwright JSON reporter 出力を parse →
  `extractFailedTests()` `regression-trace-check.mjs:188-237`
- ✓ (3) gh issue list で trace 済か照合 →
  `findTracingIssues()` `regression-trace-check.mjs:255-283`
- ✓ (4) flake 扱いに isolation 3 回連続 pass 証跡必須 →
  `checkIsolationEvidence()` `regression-trace-check.mjs:308-339` /
  `runIsolationLoop()` `regression-trace-check.mjs:349-385`
- ✓ (5) trace なし fail が exit 1 → `regression-trace-check.mjs:459-462` /
  `regression-trace-check.mjs:619-624`
- ✓ (6) PR レビュー時の AI orchestrator 実行を AGENTS.md / PR template で規約化 →
  `AGENTS.md:542-583` (新セクション) / `.github/pull_request_template.md:72-82`
  (新セクション)

case B (memory を repo tracked に昇格) 吸収:

- ✓ `docs/conventions/completion-gate.md:1-102` (新規、private memory 3 件の昇格)
- ✓ AGENTS.md から link `AGENTS.md:582`

case C (flake 判定の厳格化) 吸収:

- ✓ `docs/conventions/completion-gate.md:43-58` (Strict-mode 違反は flake 扱い禁止)
- ✓ AGENTS.md にも記載 `AGENTS.md:578-580`

## レビューで特に見てほしい箇所

- `findTracingIssues()` の client side filter: gh search 結果から title/body に
  spec path or basename を実際含むものへ絞り込む処理。GitHub 全文検索の noisy
  match を除去しつつ、`e2e/foo.spec.ts` と `foo.spec.ts` 両方を確認している
  (`regression-trace-check.mjs:275-281`)
- `checkIsolationEvidence()` で `runs` 配列の **末尾 3 件** を見る判定。前段に
  fail が混じっていても末尾 3 連続 pass で確定 OK にしているのは、isolation
  rerun で徐々に flake を解消したケースを許容するため
  (`regression-trace-check.mjs:329-339`)
- evaluate() の優先順位: manual `--traced` > `--flake` (isolation 証跡判定) >
  gh trace 照合 > untraced。Scenario A〜E の 5 パターンを test で網羅
  (`test.mjs:206-273`)
- Strict-mode violation を flake 扱い禁止するルール
  (`docs/conventions/completion-gate.md:43-58`): script 側では明示的なチェック
  機構は入れていない (locator selector の static 解析は別 ISSUE 案件)。本 PR は
  「規約 doc 側で禁止 + AI orchestrator が判断する」の運用ルール化に留めた

## テスト

- Vitest: 0 件 (新規 0 件) — N/A (mjs script のため node 直接 test)
- node test: 53 件 (新規 53 件) — `scripts/verify/test.mjs` ですべて pass
- Playwright: 0 件 — N/A (regression trace gate 自体は E2E 起動しないため)
- MCP E2E: 0 件 — N/A

## UI 影響 / AI smoke test

- [ ] UI 影響あり
- [x] UI 影響なし (auto テスト pass のみ)

理由: tooling script + 規約 doc + AGENTS.md / PR template 改訂のみ。frontend
ランタイム / UI には一切触れていない。

## regression trace gate (#1346)

- [ ] `npm run test:e2e:regression:json` を実行
- [ ] `node scripts/verify/regression-trace-check.mjs ...` exit 0 確認
- [ ] flake 主張 spec の isolation 証跡あり
- [x] N/A (e2e 未実行 PR) — 本 PR 自体は regression suite を実行する変更を
  含まない (gate 機構の新設のみ)。本 gate が次回以降の PR で実運用される

## spec 側の不足点 / 提案

N/A — case A の ISSUE 仕様を上回って case B / C も吸収した形だが、ISSUE 本文末尾
「(case A + B + C の組合せが理想)」に合致する形で実装済み。

## レビュー担当への申し送り

- script は `.mjs` (ES Module + JSDoc 型注釈)。scripts/spec-check と同パターン
- 設計判断: isolation 証跡を別 JSON file で外部化 (`frontend/test-results/isolation-<sanitized>.json`)
  したのは、`--auto-isolation-rerun` で時間のかかる isolation 走行を CI / local の
  両方で再利用可能にするため。証跡 file は gitignored 領域に書く想定
- 設計判断: `--no-gh` flag は test 用に意図的に残した。production 利用では
  `--traced <spec>` で gh を完全 bypass する形は推奨しない (規約上は OPEN ISSUE
  存在を前提とする)
- 規約 doc の置き場所は `docs/conventions/` (既存 `expressions.md` /
  `product-scope.md` / `validation-rules.md` の隣)
- 鉄則 4-6 を遵守: フォローアップ ISSUE は 1 件も切らず、case A + B + C を本 PR
  に吸収。ユーザー指示通り

🤖 Generated with [Claude Code](https://claude.com/claude-code)