### PR TITLE
improve(frontend): #1388 residual cleanup — type cast + DesignerDialogs grouped props を実測ベースで解消

### DIFF
--- a/frontend/src/components/Designer.tsx
+++ b/frontend/src/components/Designer.tsx
@@ -808,87 +808,106 @@ export function Designer({
   // ---------------------------------------------------------------------------
   const commonDialogs = (
     <DesignerDialogs
-      mode={mode}
-      isSaving={isSaving}
-      lockedByOther={lockedByOther}
-      onStartEditing={handleStartEditing}
-      onSave={handleSave}
-      onOpenDiscard={() => setShowDiscardDialog(true)}
-      onOpenForceRelease={() => setShowForceReleaseDialog(true)}
-      onForcedOutChoice={editActions.handleForcedOut}
-      onAfterForceUnlockChoice={editActions.handleAfterForceUnlock}
-      showResumeDialog={showResumeDialog}
-      onResumeContinue={handleResumeContinue}
-      onResumeDiscard={handleResumeDiscard}
-      onCancelResume={() => setShowResumeDialog(false)}
-      showDiscardDialog={showDiscardDialog}
-      onConfirmDiscard={handleDiscard}
-      onCancelDiscard={() => setShowDiscardDialog(false)}
-      showForceReleaseDialog={showForceReleaseDialog}
-      onConfirmForceRelease={handleForceRelease}
-      onCancelForceRelease={() => setShowForceReleaseDialog(false)}
-      showLegacyRescueDialog={showLegacyRescueDialog}
-      onLegacyRescueAdopt={handleLegacyRescueAdopt}
-      onLegacyRescueDiscard={handleLegacyRescueDiscard}
-      saveConflict={saveConflict}
-      onSaveConflictOverwrite={async () => {
-        try {
-          await onSaveConflictOverwrite();
-          await commitAfterSave();
-        } catch (e) {
-          console.error("[Designer] save overwrite failed:", e);
-        }
+      editMode={{
+        mode,
+        isSaving,
+        lockedByOther,
+        onStartEditing: handleStartEditing,
+        onSave: handleSave,
+        onOpenDiscard: () => setShowDiscardDialog(true),
+        onOpenForceRelease: () => setShowForceReleaseDialog(true),
+        onForcedOutChoice: editActions.handleForcedOut,
+        onAfterForceUnlockChoice: editActions.handleAfterForceUnlock,
       }}
-      onSaveConflictCancel={onSaveConflictCancel}
-      serverChanged={serverChanged}
-      onServerChangeReload={handleServerChangeReload}
-      onServerChangeDismiss={() => setServerChanged(false)}
-      showAiGenerateDialog={showAiGenerateDialog}
-      aiDialogInitialPayload={aiDialogInitialPayload}
-      editorKind={editorKind}
-      cssFramework={cssFramework}
-      screenName={screenName}
-      onApplyAiGenerated={applyGeneratedDesignPayload}
-      onCloseAiGenerate={() => setShowAiGenerateDialog(false)}
-      showRenameDialog={showRenameDialog}
-      screenId={screenId}
-      allScreenIds={allScreenIds}
-      fetchExistingScreenIds={async () => {
-        const project = await loadProject();
-        return (project.screens ?? []).map((s) => s.id);
+      resume={{
+        show: showResumeDialog,
+        onContinue: handleResumeContinue,
+        onDiscard: handleResumeDiscard,
+        onCancel: () => setShowResumeDialog(false),
       }}
-      onCloseRename={() => setShowRenameDialog(false)}
-      onRenameSuccess={(newId, operationId, extra) => {
-        setShowRenameDialog(false);
-        handleRenameSuccess({
-          entityType: "screen",
-          oldId: screenId,
-          newId,
-          label: screenName ?? newId,
-          navigate,
-          wsPath,
-          wsId,
-        });
-        setRenameUndoToast({
-          operationId, oldId: screenId, newId,
-          ttlMs: extra?.ttlMs,
-        });
+      discard={{
+        show: showDiscardDialog,
+        onConfirm: handleDiscard,
+        onCancel: () => setShowDiscardDialog(false),
       }}
-      renameUndoToast={renameUndoToast}
-      onRenameUndo={() => {
-        if (!renameUndoToast) return;
-        handleRenameSuccess({
-          entityType: "screen",
-          oldId: renameUndoToast.newId,
-          newId: renameUndoToast.oldId,
-          label: screenName ?? renameUndoToast.oldId,
-          navigate,
-          wsPath,
-          wsId,
-        });
-        setRenameUndoToast(null);
+      forceRelease={{
+        show: showForceReleaseDialog,
+        onConfirm: handleForceRelease,
+        onCancel: () => setShowForceReleaseDialog(false),
       }}
-      onRenameUndoDismiss={() => setRenameUndoToast(null)}
+      legacyRescue={{
+        show: showLegacyRescueDialog,
+        onAdopt: handleLegacyRescueAdopt,
+        onDiscard: handleLegacyRescueDiscard,
+      }}
+      saveConflict={{
+        conflict: saveConflict,
+        onOverwrite: async () => {
+          try {
+            await onSaveConflictOverwrite();
+            await commitAfterSave();
+          } catch (e) {
+            console.error("[Designer] save overwrite failed:", e);
+          }
+        },
+        onCancel: onSaveConflictCancel,
+      }}
+      serverChange={{
+        changed: serverChanged,
+        onReload: handleServerChangeReload,
+        onDismiss: () => setServerChanged(false),
+      }}
+      ai={{
+        show: showAiGenerateDialog,
+        initialPayload: aiDialogInitialPayload,
+        editorKind,
+        cssFramework,
+        screenName,
+        onApply: applyGeneratedDesignPayload,
+        onClose: () => setShowAiGenerateDialog(false),
+      }}
+      rename={{
+        show: showRenameDialog,
+        screenId,
+        screenName,
+        allScreenIds,
+        fetchExistingScreenIds: async () => {
+          const project = await loadProject();
+          return (project.screens ?? []).map((s) => s.id);
+        },
+        onClose: () => setShowRenameDialog(false),
+        onSuccess: (newId, operationId, extra) => {
+          setShowRenameDialog(false);
+          handleRenameSuccess({
+            entityType: "screen",
+            oldId: screenId,
+            newId,
+            label: screenName ?? newId,
+            navigate,
+            wsPath,
+            wsId,
+          });
+          setRenameUndoToast({
+            operationId, oldId: screenId, newId,
+            ttlMs: extra?.ttlMs,
+          });
+        },
+        undoToast: renameUndoToast,
+        onUndo: () => {
+          if (!renameUndoToast) return;
+          handleRenameSuccess({
+            entityType: "screen",
+            oldId: renameUndoToast.newId,
+            newId: renameUndoToast.oldId,
+            label: screenName ?? renameUndoToast.oldId,
+            navigate,
+            wsPath,
+            wsId,
+          });
+          setRenameUndoToast(null);
+        },
+        onUndoDismiss: () => setRenameUndoToast(null),
+      }}
     />
   );
 

--- a/frontend/src/components/designer/DesignerDialogs.tsx
+++ b/frontend/src/components/designer/DesignerDialogs.tsx
@@ -2,7 +2,7 @@
 // 独立 component に抽出し、Designer.tsx の責務を縮小する。
 // 機能変更なし — JSX 構造 + 依存関係 (props) は元の commonDialogs と完全に等価。
 //
-// #1388 follow-up (PR #1394 sequel): Codex Round 1 Should-fix #2 (33-prop flat interface) を
+// #1388 residual cleanup (PR #1395): Codex Round 1 Should-fix #2 (33-prop flat interface) を
 // 解消するため、props を概念単位の grouped object に再構成。
 // editMode / resume / discard / forceRelease / legacyRescue / saveConflict / serverChange /
 // ai / rename の 9 グループに分解。

--- a/frontend/src/components/designer/DesignerDialogs.tsx
+++ b/frontend/src/components/designer/DesignerDialogs.tsx
@@ -1,6 +1,11 @@
 // #1388 sub-section A (Option 2 部分): Designer.tsx の commonDialogs (~145 行) を
 // 独立 component に抽出し、Designer.tsx の責務を縮小する。
 // 機能変更なし — JSX 構造 + 依存関係 (props) は元の commonDialogs と完全に等価。
+//
+// #1388 follow-up (PR #1394 sequel): Codex Round 1 Should-fix #2 (33-prop flat interface) を
+// 解消するため、props を概念単位の grouped object に再構成。
+// editMode / resume / discard / forceRelease / legacyRescue / saveConflict / serverChange /
+// ai / rename の 9 グループに分解。
 import type { ReactNode } from "react";
 import { EditModeToolbar } from "../editing/EditModeToolbar";
 import { ScreenDesignAiGenerateDialog } from "../design/ScreenDesignAiGenerateDialog";
@@ -22,8 +27,7 @@ import type { EditMode } from "../../hooks/useEditSession";
 import type { CssFramework } from "../../types/v3/harmony";
 import type { EditorKind } from "../../utils/resolveEditorKind";
 
-export interface DesignerDialogsProps {
-  // 編集モードツールバー + Forced 系
+export interface DesignerEditModeProps {
   mode: EditMode;
   isSaving: boolean;
   lockedByOther: { ownerSessionId: string } | null;
@@ -33,168 +37,190 @@ export interface DesignerDialogsProps {
   onOpenForceRelease: () => void;
   onForcedOutChoice: (choice: ForcedOutChoice) => Promise<void> | void;
   onAfterForceUnlockChoice: (choice: ForceUnlockChoice) => Promise<void> | void;
+}
 
-  // Resume / Discard / ForceRelease ダイアログ
-  showResumeDialog: boolean;
-  onResumeContinue: () => Promise<void>;
-  onResumeDiscard: () => Promise<void>;
-  onCancelResume: () => void;
+export interface DesignerResumeProps {
+  show: boolean;
+  onContinue: () => Promise<void>;
+  onDiscard: () => Promise<void>;
+  onCancel: () => void;
+}
 
-  showDiscardDialog: boolean;
-  onConfirmDiscard: () => Promise<void>;
-  onCancelDiscard: () => void;
+export interface DesignerDiscardProps {
+  show: boolean;
+  onConfirm: () => Promise<void>;
+  onCancel: () => void;
+}
 
-  showForceReleaseDialog: boolean;
-  onConfirmForceRelease: () => Promise<void>;
-  onCancelForceRelease: () => void;
+export interface DesignerForceReleaseProps {
+  show: boolean;
+  onConfirm: () => Promise<void>;
+  onCancel: () => void;
+}
 
-  // Legacy rescue
-  showLegacyRescueDialog: boolean;
-  onLegacyRescueAdopt: () => Promise<void>;
-  onLegacyRescueDiscard: () => void;
+export interface DesignerLegacyRescueProps {
+  show: boolean;
+  onAdopt: () => Promise<void>;
+  onDiscard: () => void;
+}
 
-  // Save conflict
-  saveConflict: ConflictInfo | null;
-  onSaveConflictOverwrite: () => Promise<void>;
-  onSaveConflictCancel: () => void;
+export interface DesignerSaveConflictProps {
+  conflict: ConflictInfo | null;
+  onOverwrite: () => Promise<void>;
+  onCancel: () => void;
+}
 
-  // ServerChangeBanner
-  serverChanged: boolean;
-  onServerChangeReload: () => Promise<void>;
-  onServerChangeDismiss: () => void;
+export interface DesignerServerChangeProps {
+  changed: boolean;
+  onReload: () => Promise<void>;
+  onDismiss: () => void;
+}
 
-  // AI 生成
-  showAiGenerateDialog: boolean;
-  aiDialogInitialPayload: unknown;
+export interface DesignerAiGenerateProps {
+  show: boolean;
+  initialPayload: unknown;
   editorKind: EditorKind;
   cssFramework: CssFramework;
   screenName?: string;
-  onApplyAiGenerated: (payload: unknown) => Promise<void>;
-  onCloseAiGenerate: () => void;
+  onApply: (payload: unknown) => Promise<void>;
+  onClose: () => void;
+}
 
-  // Rename
-  showRenameDialog: boolean;
+export interface DesignerRenameProps {
+  show: boolean;
   screenId: string;
+  screenName?: string;
   allScreenIds: string[];
   fetchExistingScreenIds: () => Promise<string[]>;
-  onCloseRename: () => void;
-  onRenameSuccess: (newId: string, operationId: string, extra?: { ttlMs?: number }) => void;
-
-  // Rename undo toast
-  renameUndoToast:
+  onClose: () => void;
+  onSuccess: (newId: string, operationId: string, extra?: { ttlMs?: number }) => void;
+  undoToast:
     | { operationId: string; oldId: string; newId: string; ttlMs?: number }
     | null;
-  onRenameUndo: () => void;
-  onRenameUndoDismiss: () => void;
+  onUndo: () => void;
+  onUndoDismiss: () => void;
+}
+
+export interface DesignerDialogsProps {
+  editMode: DesignerEditModeProps;
+  resume: DesignerResumeProps;
+  discard: DesignerDiscardProps;
+  forceRelease: DesignerForceReleaseProps;
+  legacyRescue: DesignerLegacyRescueProps;
+  saveConflict: DesignerSaveConflictProps;
+  serverChange: DesignerServerChangeProps;
+  ai: DesignerAiGenerateProps;
+  rename: DesignerRenameProps;
 }
 
 export function DesignerDialogs(props: DesignerDialogsProps): ReactNode {
+  const { editMode, resume, discard, forceRelease, legacyRescue, saveConflict, serverChange, ai, rename } = props;
   return (
     <>
       {/* 編集モードツールバー */}
       <EditModeToolbar
-        mode={props.mode}
-        onStartEditing={props.onStartEditing}
-        onSave={props.onSave}
-        onDiscardClick={props.onOpenDiscard}
-        onForceReleaseClick={props.onOpenForceRelease}
-        saving={props.isSaving}
-        ownerLabel={props.lockedByOther?.ownerSessionId}
+        mode={editMode.mode}
+        onStartEditing={editMode.onStartEditing}
+        onSave={editMode.onSave}
+        onDiscardClick={editMode.onOpenDiscard}
+        onForceReleaseClick={editMode.onOpenForceRelease}
+        saving={editMode.isSaving}
+        ownerLabel={editMode.lockedByOther?.ownerSessionId}
       />
 
       {/* 強制解除 / ForcedOut / AfterForceUnlock ダイアログ */}
-      {props.mode.kind === "force-released-pending" && (
+      {editMode.mode.kind === "force-released-pending" && (
         <ForcedOutChoiceDialog
-          previousDraftExists={props.mode.previousDraftExists}
-          onChoice={props.onForcedOutChoice}
+          previousDraftExists={editMode.mode.previousDraftExists}
+          onChoice={editMode.onForcedOutChoice}
         />
       )}
-      {props.mode.kind === "after-force-unlock" && (
+      {editMode.mode.kind === "after-force-unlock" && (
         <AfterForceUnlockChoiceDialog
-          previousOwner={props.mode.previousOwner}
-          onChoice={props.onAfterForceUnlockChoice}
+          previousOwner={editMode.mode.previousOwner}
+          onChoice={editMode.onAfterForceUnlockChoice}
         />
       )}
 
-      {props.showResumeDialog && (
+      {resume.show && (
         <ResumeOrDiscardDialog
-          onResume={props.onResumeContinue}
-          onDiscard={props.onResumeDiscard}
-          onCancel={props.onCancelResume}
+          onResume={resume.onContinue}
+          onDiscard={resume.onDiscard}
+          onCancel={resume.onCancel}
         />
       )}
 
-      {props.showDiscardDialog && (
+      {discard.show && (
         <DiscardConfirmDialog
-          onConfirm={props.onConfirmDiscard}
-          onCancel={props.onCancelDiscard}
+          onConfirm={discard.onConfirm}
+          onCancel={discard.onCancel}
         />
       )}
 
-      {props.showForceReleaseDialog && props.lockedByOther && (
+      {forceRelease.show && editMode.lockedByOther && (
         <ForceReleaseConfirmDialog
-          ownerSessionId={props.lockedByOther.ownerSessionId}
-          onConfirm={props.onConfirmForceRelease}
-          onCancel={props.onCancelForceRelease}
+          ownerSessionId={editMode.lockedByOther.ownerSessionId}
+          onConfirm={forceRelease.onConfirm}
+          onCancel={forceRelease.onCancel}
         />
       )}
 
-      {props.showLegacyRescueDialog && (
+      {legacyRescue.show && (
         <LegacyRescueDialog
-          onAdopt={props.onLegacyRescueAdopt}
-          onDiscard={props.onLegacyRescueDiscard}
+          onAdopt={legacyRescue.onAdopt}
+          onDiscard={legacyRescue.onDiscard}
         />
       )}
 
-      {props.saveConflict && (
+      {saveConflict.conflict && (
         <SaveConflictDialog
-          conflict={props.saveConflict}
-          onOverwrite={props.onSaveConflictOverwrite}
-          onCancel={props.onSaveConflictCancel}
+          conflict={saveConflict.conflict}
+          onOverwrite={saveConflict.onOverwrite}
+          onCancel={saveConflict.onCancel}
         />
       )}
 
-      {props.serverChanged && (
+      {serverChange.changed && (
         <ServerChangeBanner
-          onReload={props.onServerChangeReload}
-          onDismiss={props.onServerChangeDismiss}
+          onReload={serverChange.onReload}
+          onDismiss={serverChange.onDismiss}
         />
       )}
 
-      {props.showAiGenerateDialog && (
+      {ai.show && (
         <ScreenDesignAiGenerateDialog
-          current={props.aiDialogInitialPayload}
-          editorKind={props.editorKind}
-          cssFramework={props.cssFramework}
-          screenName={props.screenName}
-          onApply={props.onApplyAiGenerated}
-          onClose={props.onCloseAiGenerate}
+          current={ai.initialPayload}
+          editorKind={ai.editorKind}
+          cssFramework={ai.cssFramework}
+          screenName={ai.screenName}
+          onApply={ai.onApply}
+          onClose={ai.onClose}
         />
       )}
 
       {/* #1298 I-6 (RFC #1284): id rename refactor dialog */}
-      {props.showRenameDialog && (
+      {rename.show && (
         <RenameEntityDialog
           entityType="screen"
-          currentId={props.screenId}
-          currentName={props.screenName ?? ""}
-          existingIds={props.allScreenIds}
+          currentId={rename.screenId}
+          currentName={rename.screenName ?? ""}
+          existingIds={rename.allScreenIds}
           // Phase J SF-α (#1298 round 5 Opus SF-1): dialog open 時の existingIds rehydration
-          fetchExistingIds={props.fetchExistingScreenIds}
-          onClose={props.onCloseRename}
-          onSuccess={props.onRenameSuccess}
+          fetchExistingIds={rename.fetchExistingScreenIds}
+          onClose={rename.onClose}
+          onSuccess={rename.onSuccess}
         />
       )}
 
-      {props.renameUndoToast && (
+      {rename.undoToast && (
         <RenameEntityUndoToast
-          operationId={props.renameUndoToast.operationId}
-          oldId={props.renameUndoToast.oldId}
-          newId={props.renameUndoToast.newId}
-          ttlMs={props.renameUndoToast.ttlMs}
+          operationId={rename.undoToast.operationId}
+          oldId={rename.undoToast.oldId}
+          newId={rename.undoToast.newId}
+          ttlMs={rename.undoToast.ttlMs}
           entityLabel="画面"
-          onUndo={props.onRenameUndo}
-          onDismiss={props.onRenameUndoDismiss}
+          onUndo={rename.onUndo}
+          onDismiss={rename.onUndoDismiss}
         />
       )}
     </>

--- a/frontend/src/components/flow/FlowEditor.tsx
+++ b/frontend/src/components/flow/FlowEditor.tsx
@@ -665,7 +665,7 @@ function FlowEditorInner() {
         id: dup.id,
         type: "screenNode" as const,
         position: dup.position,
-        data: dup as unknown as RFNode["data"],
+        data: { ...dup },
       }]);
     }
     setContextMenu(null);


### PR DESCRIPTION
## 概要

PR #1393 / #1394 merge 後の **2 件の残課題** を解消する追加 follow-up small PR。ユーザー指摘「実測せずに『現状維持』判断は鉄則 5 違反」を受け、両候補とも 1 件サンプル fix で実測してから本 PR 吸収を選択した。ISSUE 純増なし。

## 解消した残課題

### 候補 1: PR #1393 Round 1 Nit (FlowEditor.tsx:668 dup type cast) — **23 秒で解消**

\`\`\`tsx
// 旧
data: dup as unknown as RFNode["data"],

// 新 (同ファイル handleScreenSave の add path と同 pattern)
data: { ...dup },
\`\`\`

\`as unknown as\` outer cast は type fidelity の典型的 anti-pattern。spread copy で同等の narrowing を実現しつつ cast を排除。

### 候補 2: PR #1393 Round 1 Should-fix #2 (DesignerDialogs 33-prop flat interface) — **160 秒で解消**

flat 33 props を 9 個の grouped object props に再構成 (Codex 提案 \`editSessionDialogs\` / \`renameDialogs\` / \`aiDialog\` を含む細粒度版):

| グループ | フィールド数 | 内容 |
|---|---|---|
| editMode | 9 | mode / isSaving / lockedByOther / startEditing / save / forced 系 callbacks |
| resume | 4 | show / continue / discard / cancel |
| discard | 3 | show / confirm / cancel |
| forceRelease | 3 | show / confirm / cancel |
| legacyRescue | 3 | show / adopt / discard |
| saveConflict | 3 | conflict / overwrite / cancel |
| serverChange | 3 | changed / reload / dismiss |
| ai | 7 | show / payload / editorKind / cssFramework / screenName / apply / close |
| rename | 10 | show / ids / fetch / close / success + undo toast 関連 |

Designer.tsx の \`<DesignerDialogs {...} />\` call site も grouped object literal に書き換え。

## 鉄則 5 (規模実測) の証跡

両候補とも「実測してから判断」を遵守:

- **候補 1**: 単発の 1 行 fix で 23 秒
- **候補 2**: handleScreenSave sample (35 秒) と類比した見積もり 40 分、実工数 160 秒で完遂

ユーザー指摘「実測せずに『現状維持』判断は規模感の怠慢」を反省し、両候補とも実測ベースで本 PR (small PR) 吸収を選択。

## 検証

- \`npm --workspace=frontend run lint\` → **0 errors / 0 warnings**
- \`npx tsc --noEmit\` → pass (EXIT=0)
- \`npx vitest run\` → 204 files / **3008 passed / 1 skipped** (regression なし)

## 関連

- 元 PR: #1393 (sub-section A 派生 + B case A、merged) / #1394 (immutable update follow-up、merged)
- 親 ISSUE: #1388 (CLOSED、本 PR で残課題完全解消)
- AGENTS.md 鉄則 1 / 5 / 6 遵守の追加実例

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) via /issues-cdx follow-up