### PR TITLE
Fix issue review follow-ups for process flow broadcasts

### DIFF
--- a/backend/src/handlers/screenItem.ts
+++ b/backend/src/handlers/screenItem.ts
@@ -37,7 +37,7 @@ export const handleScreenItemTool: ToolHandler = async (name, args, root, sessio
       const renameRes = await renameScreenItemId(a.screenId, a.oldId, a.newId, root);
       wsBridge.broadcast({ wsId: workspaceContextManager.getActivePath(sessionId), event: "screenItemsChanged", data: { screenId: a.screenId } });
       for (const agId of renameRes.processFlowsUpdated) {
-        wsBridge.broadcast({ wsId: workspaceContextManager.getActivePath(sessionId), event: "processFlowChanged", data: { processFlowId: agId, id: agId } });
+        wsBridge.broadcast({ wsId: workspaceContextManager.getActivePath(sessionId), event: "processFlowChanged", data: { processFlowId: agId } });
       }
       if (renameRes.screenHtmlUpdated) {
         wsBridge.broadcast({ wsId: workspaceContextManager.getActivePath(sessionId), event: "screenChanged", data: { screenId: a.screenId } });
@@ -110,7 +110,7 @@ export const handleScreenItemTool: ToolHandler = async (name, args, root, sessio
         // ブラウザ側で適用済み → process flow refs のみファイル更新
         const { processFlowsUpdated } = await updateProcessFlowRefs(a.screenId, mapping, root);
         for (const agId of processFlowsUpdated) {
-          wsBridge.broadcast({ wsId: workspaceContextManager.getActivePath(sessionId), event: "processFlowChanged", data: { processFlowId: agId, id: agId } });
+          wsBridge.broadcast({ wsId: workspaceContextManager.getActivePath(sessionId), event: "processFlowChanged", data: { processFlowId: agId } });
         }
         // screenChanged / screenItemsChanged は broadcast しない (browser dirty、ファイルは古いまま)
 
@@ -134,7 +134,7 @@ export const handleScreenItemTool: ToolHandler = async (name, args, root, sessio
         wsBridge.broadcast({ wsId: workspaceContextManager.getActivePath(sessionId), event: "screenItemsChanged", data: { screenId: a.screenId } });
         const allAgs = new Set(result.succeeded.flatMap((s) => s.processFlowsUpdated));
         for (const agId of allAgs) {
-          wsBridge.broadcast({ wsId: workspaceContextManager.getActivePath(sessionId), event: "processFlowChanged", data: { processFlowId: agId, id: agId } });
+          wsBridge.broadcast({ wsId: workspaceContextManager.getActivePath(sessionId), event: "processFlowChanged", data: { processFlowId: agId } });
         }
         if (result.succeeded.some((s) => s.screenHtmlUpdated)) {
           wsBridge.broadcast({ wsId: workspaceContextManager.getActivePath(sessionId), event: "screenChanged", data: { screenId: a.screenId } });

--- a/backend/src/mcpHelpers.ts
+++ b/backend/src/mcpHelpers.ts
@@ -54,7 +54,7 @@ export async function saveAndBroadcast(agId: string, ag: ProcessFlowDoc, root: s
   ag.updatedAt = new Date().toISOString();
   await writeProcessFlow(agId, ag, root);
   // root が wsId = per-workspace scoping (#703 R-5 A-1)
-  wsBridge.broadcast({ wsId: root, event: "processFlowChanged", data: { processFlowId: agId, id: agId } });
+  wsBridge.broadcast({ wsId: root, event: "processFlowChanged", data: { processFlowId: agId } });
 }
 
 /**

--- a/backend/src/wsBridge/editSessionService.ts
+++ b/backend/src/wsBridge/editSessionService.ts
@@ -402,7 +402,7 @@ export class EditSessionService {
             break;
           case "process-flow":
             await writeProcessFlow(resId, payload, root);
-            resourceChange = { event: "processFlowChanged", data: { processFlowId: resId, id: resId } };
+            resourceChange = { event: "processFlowChanged", data: { processFlowId: resId } };
             break;
           case "view":
             await writeView(resId, payload, root);

--- a/backend/src/wsHandlers/misc.ts
+++ b/backend/src/wsHandlers/misc.ts
@@ -81,7 +81,7 @@ export const miscHandlers: RpcHandlerMap = {
     respond(result);
     bridge.broadcast({ wsId: wsId(), event: "screenItemsChanged", data: { screenId }, excludeClientId: clientId });
     for (const agId of result.processFlowsUpdated) {
-      bridge.broadcast({ wsId: wsId(), event: "processFlowChanged", data: { processFlowId: agId, id: agId }, excludeClientId: clientId });
+      bridge.broadcast({ wsId: wsId(), event: "processFlowChanged", data: { processFlowId: agId }, excludeClientId: clientId });
     }
     if (result.screenHtmlUpdated) {
       bridge.broadcast({ wsId: wsId(), event: "screenChanged", data: { screenId }, excludeClientId: clientId });

--- a/backend/src/wsHandlers/processFlow.ts
+++ b/backend/src/wsHandlers/processFlow.ts
@@ -56,7 +56,7 @@ export const processFlowHandlers: RpcHandlerMap = {
     // S-002: ID validation
     await writeProcessFlow(agId, agData, root());
     respond({ success: true });
-    bridge.broadcast({ wsId: wsId(), event: "processFlowChanged", data: { processFlowId: agId, id: agId }, excludeClientId: clientId });
+    bridge.broadcast({ wsId: wsId(), event: "processFlowChanged", data: { processFlowId: agId }, excludeClientId: clientId });
   },
 
   deleteProcessFlow: async ({ params, root, wsId, clientId, respond, bridge }) => {
@@ -65,7 +65,7 @@ export const processFlowHandlers: RpcHandlerMap = {
     // S-002: ID validation
     await deleteProcessFlowFile(agId, root());
     respond({ success: true });
-    bridge.broadcast({ wsId: wsId(), event: "processFlowChanged", data: { processFlowId: agId, id: agId, deleted: true }, excludeClientId: clientId });
+    bridge.broadcast({ wsId: wsId(), event: "processFlowChanged", data: { processFlowId: agId, deleted: true }, excludeClientId: clientId });
   },
 
   listProcessFlows: async ({ root, respond }) => {

--- a/frontend/e2e/mcp/mcp-tools.spec.ts
+++ b/frontend/e2e/mcp/mcp-tools.spec.ts
@@ -265,7 +265,8 @@ test.describe("wsBridge ファイル操作 (#958)", { tag: ["@regression"] }, ()
         () => sendBrowserRequest("saveProcessFlow", { processFlowId: id, data: testData }),
       );
       expect((saveResult as { success: boolean }).success).toBe(true);
-      expect(broadcast).toMatchObject({ processFlowId: id, id });
+      expect(broadcast).toMatchObject({ processFlowId: id });
+      expect(broadcast).not.toHaveProperty("id");
 
       const loadResult = await sendBrowserRequest("loadProcessFlow", { processFlowId: id });
       expect(loadResult).toMatchObject(testData);
@@ -289,7 +290,8 @@ test.describe("wsBridge ファイル操作 (#958)", { tag: ["@regression"] }, ()
         () => sendBrowserRequest("deleteProcessFlow", { processFlowId: id }),
       );
       expect((deleteResult as { success: boolean }).success).toBe(true);
-      expect(broadcast).toMatchObject({ processFlowId: id, id, deleted: true });
+      expect(broadcast).toMatchObject({ processFlowId: id, deleted: true });
+      expect(broadcast).not.toHaveProperty("id");
 
       const loadResult = await sendBrowserRequest("loadProcessFlow", { processFlowId: id });
       expect(loadResult).toBeNull();

--- a/frontend/e2e/refactor/rename-entity-genericdef-dirty-rename-block.spec.ts
+++ b/frontend/e2e/refactor/rename-entity-genericdef-dirty-rename-block.spec.ts
@@ -1,18 +1,16 @@
 /**
- * Rename entity → dirty GenericDefinition editor rename-block browser smoke
+ * Rename entity → GenericDefinition dirty ref-side edit block browser smoke
  * (#1334 K-3 Part A / I-7 Round 8 D, Round 7 Codex M-R7-4)
  *
  * 目的:
- *   GenericDefinitionEditor が dirty 状態の時、別ソースで entity rename が走り
- *   genericDefinitionChanged broadcast (reload: true) が届いた際に、Editor 上
- *   に reload banner が表示 + 保存ボタンが disabled になり、reload 後は最新
- *   def が editor に再ロードされることを browser lifecycle レベルで確認する。
+ *   GenericDefinitionEditor が dirty 状態の時、別ソースで entity rename が走ると、
+ *   server-side EditSession lock により rename が block され、編集中の GenericDefinition
+ *   が stale な参照更新で上書きされないことを browser lifecycle レベルで確認する。
  *
  * 既存の component test
- *   (frontend/src/components/generic-definition/GenericDefinitionEditor.test.tsx:52-72)
- * は mock broadcast でロジックを検証済。本 e2e は、実 backend を経由して broadcast
- * payload が wsBridge → mcpBridge → React subscription まで伝わることを保証する
- * (component test では拾えない通信レイヤの regression を検出)。
+ *   (frontend/src/components/generic-definition/GenericDefinitionEditor.test.tsx)
+ * で stale banner の mock broadcast 受信ロジックは検証済み。本 e2e は、実 backend
+ * を経由する rename path が dirty 参照側 editor を block することを保証する。
  */
 
 import { test, expect } from "@playwright/test";
@@ -28,21 +26,38 @@ import {
   closeBrowserSession,
 } from "../mcp/_helpers";
 
-const WS_KEY = "issue-1334-k3-genericdef-stale-save";
+const WS_KEY = "issue-1334-k3-genericdef-dirty-rename-block";
 const GD_KIND = "data-contract";
 const GD_NAME = "OrderForm";
 const TARGET_TABLE_ID = "order"; // examples/retail/harmony/tables/order.json
 const NEW_TABLE_ID = "order-k3";
 const OLD_TABLE_REF = `tables/${TARGET_TABLE_ID}`;
 const NEW_TABLE_REF = `tables/${NEW_TABLE_ID}`;
+const GD_EDIT_SESSION_RESOURCE_ID = `${GD_KIND}__${GD_NAME}`;
 
 let mcpAvailable = false;
 let ws: OpenedWorkspace;
 
+async function hasActiveGenericDefinitionEditorSession(): Promise<boolean> {
+  const result = await sendPersistent("editSession.list", {
+    resourceType: "generic-definition",
+    resourceId: GD_EDIT_SESSION_RESOURCE_ID,
+  }) as {
+    sessions?: Array<{
+      state?: string;
+      participants?: Record<string, { role?: string }>;
+    }>;
+  } | null;
+  return (result?.sessions ?? []).some((session) => (
+    session.state === "Active"
+    && Object.values(session.participants ?? {}).some((participant) => participant.role === "Edit")
+  ));
+}
+
 test.describe.configure({ mode: "serial" });
 
 test.describe(
-  "Rename entity → dirty GenericDefinition editor rename-block (#1334 K-3 / I-7 Round 8 D)",
+  "Rename entity → GenericDefinition dirty ref-side edit block (#1334 K-3 / I-7 Round 8 D)",
   { tag: ["@regression"] },
   () => {
     test.beforeAll(async () => {
@@ -80,7 +95,7 @@ test.describe(
       test.skip(!mcpAvailable, "backend (port 5179) が起動していません");
     });
 
-    test("dirty GD editor + 外部 table rename → banner 表示 + 保存 disabled + reload で復旧", async ({ page }) => {
+    test("dirty GD editor + 外部 table rename → rename block + dirty 編集保持", async ({ page }) => {
       // 1. GenericDefinitionEditor を開く
       await ws.gotoActive(page, `/generic-definition/${GD_KIND}/${GD_NAME}`);
 
@@ -99,34 +114,28 @@ test.describe(
       ).first();
       await expect(relationRefField).toHaveValue(OLD_TABLE_REF);
 
-      // 3. 外部から Table rename を発火 — backend が genericDefinitionChanged を
-      //    { reload: true } で broadcast する (refactor.ts:272-284 参照)。
-      //    sendPersistent (mcp/_helpers) は workspace.open 済みの永続 WS を使うため、
-      //    rename handler が wid 取得に成功し broadcast が page session にも届く。
-      await sendPersistent("renameEntityId", {
+      // 3. 外部から Table rename を発火 — 現行契約では参照側 GenericDefinition の
+      //    dirty EditSession があるため backend が rename を block する。
+      await expect.poll(
+        hasActiveGenericDefinitionEditorSession,
+        { timeout: 5000, message: "GenericDefinition dirty edit session should be active before rename" },
+      ).toBe(true);
+      await expect(sendPersistent("renameEntityId", {
         entityType: "table",
         oldId: TARGET_TABLE_ID,
         newId: NEW_TABLE_ID,
-      });
+      })).rejects.toThrow(/参照側 entity を編集中の他 session/);
 
-      // 4. reload banner が出る + 保存ボタンが disabled になる (dirty 編集を上書きしないよう rename-block)
-      await expect(page.getByTestId("generic-definition-reload-banner")).toBeVisible({ timeout: 8000 });
-      const saveBtn = page.getByRole("button", { name: "保存" });
-      await expect(saveBtn).toBeDisabled();
-
-      // 5. 「再読み込み」を押す → banner が消える + dirty 編集は破棄され、rename 済み ref を読む
-      await page.getByTestId("generic-definition-reload-btn").click();
-      await expect(page.getByTestId("generic-definition-reload-banner")).toBeHidden({ timeout: 5000 });
-      await expect(saveBtn).toBeEnabled({ timeout: 5000 });
-      const reloadedValue = await purposeField.inputValue();
-      expect(reloadedValue).toBe(initialValue);
-      await expect(relationRefField).toHaveValue(NEW_TABLE_REF);
+      // 4. rename は成立しないため reload banner は出ず、dirty 編集も保持される。
+      await expect(page.getByTestId("generic-definition-reload-banner")).toHaveCount(0);
+      expect(await purposeField.inputValue()).toBe(`${initialValue}__DIRTY_K3`);
+      await expect(relationRefField).toHaveValue(OLD_TABLE_REF);
       const persistedDefinition = await sendPersistent("loadGenericDefinition", {
         kind: GD_KIND,
         name: GD_NAME,
       }) as { relations?: Array<{ ref?: string }> };
-      expect(persistedDefinition.relations?.map((rel) => rel.ref)).toContain(NEW_TABLE_REF);
-      expect(persistedDefinition.relations?.map((rel) => rel.ref)).not.toContain(OLD_TABLE_REF);
+      expect(persistedDefinition.relations?.map((rel) => rel.ref)).toContain(OLD_TABLE_REF);
+      expect(persistedDefinition.relations?.map((rel) => rel.ref)).not.toContain(NEW_TABLE_REF);
 
       // cleanup: 後続テストへの影響回避は workspace cleanup (afterAll) で十分。
     });


### PR DESCRIPTION
## Summary
- remove deprecated `id` aliases from `processFlowChanged` broadcast payloads while keeping request-side `id` compatibility
- pin Mermaid docs rendering to `look: classic` and deterministic ID settings, then commit the regenerated edit-session draft HTML
- update E2E coverage for the current dirty GenericDefinition rename-block contract, including an explicit wait for the active EditSession

## Trace
- Refs #1335 — process flow broadcast payload cleanup after the param naming unification review
- Refs #1334 / #1331 — GenericDefinition dirty editor rename-block contract coverage
- Refs #1124 — docs-site generated HTML stability

## Notes
- `processFlowChanged` delete broadcasts still use the existing `{ processFlowId, deleted: true }` contract; this PR only removes the legacy `id` alias.
- Mermaid config mainly fixes the renderer look/default surface (`look: classic`) and IDs for forward compatibility. The regenerated SVG is still committed as the canonical docs artifact.
- The generated HTML conflict from #1396 was resolved by rebasing onto `origin/main` and rerunning `npm --prefix docs-site run build`.

## Validation
- `npm run build`
- `npm run lint`
- `npm --prefix docs-site run build`
- `VITE_PORT=5183 npm run test:e2e` (424 passed, 3 skipped)
- `VITE_PORT=5183 npm --prefix frontend run test:e2e -- e2e/refactor/rename-entity-genericdef-stale-save.spec.ts`
- `git diff --check`
- `git merge-tree --write-tree origin/main HEAD`
- `git diff --name-only origin/main -- schemas/` (empty)
