### PR TITLE
test(e2e): GenericDefinition rename-block E2E spec filename を内容に合わせる (#1398)

### DIFF
--- a/frontend/e2e/refactor/rename-entity-genericdef-dirty-rename-block.spec.ts
+++ b/frontend/e2e/refactor/rename-entity-genericdef-dirty-rename-block.spec.ts
@@ -1,11 +1,11 @@
 /**
- * Rename entity → GenericDefinition stale-save banner browser smoke
+ * Rename entity → dirty GenericDefinition editor rename-block browser smoke
  * (#1334 K-3 Part A / I-7 Round 8 D, Round 7 Codex M-R7-4)
  *
  * 目的:
  *   GenericDefinitionEditor が dirty 状態の時、別ソースで entity rename が走り
  *   genericDefinitionChanged broadcast (reload: true) が届いた際に、Editor 上
- *   に stale-save banner が表示 + 保存ボタンが disabled になり、reload 後は最新
+ *   に reload banner が表示 + 保存ボタンが disabled になり、reload 後は最新
  *   def が editor に再ロードされることを browser lifecycle レベルで確認する。
  *
  * 既存の component test
@@ -42,7 +42,7 @@ let ws: OpenedWorkspace;
 test.describe.configure({ mode: "serial" });
 
 test.describe(
-  "Rename entity → GenericDefinition stale-save banner (#1334 K-3 / I-7 Round 8 D)",
+  "Rename entity → dirty GenericDefinition editor rename-block (#1334 K-3 / I-7 Round 8 D)",
   { tag: ["@regression"] },
   () => {
     test.beforeAll(async () => {
@@ -109,7 +109,7 @@ test.describe(
         newId: NEW_TABLE_ID,
       });
 
-      // 4. stale-save banner が出る + 保存ボタンが disabled になる
+      // 4. reload banner が出る + 保存ボタンが disabled になる (dirty 編集を上書きしないよう rename-block)
       await expect(page.getByTestId("generic-definition-reload-banner")).toBeVisible({ timeout: 8000 });
       const saveBtn = page.getByRole("button", { name: "保存" });
       await expect(saveBtn).toBeDisabled();


### PR DESCRIPTION
## 概要

PR #1397 で `rename-entity-genericdef-stale-save.spec.ts` のテスト内容を旧 stale-save banner 契約から現行の dirty GenericDefinition editor の rename-block 契約へ更新したが、ファイル名は旧名のまま残っていた (Claude Code review が Nit として指摘)。本 PR で内容と整合する名前へ rename + 内部 JSDoc/describe ラベルも整合させる。

## 修正内容

### #1398: ファイル rename + 内部文字列の整合性更新

- **rename** (`git mv`、similarity 93%):
  - `frontend/e2e/refactor/rename-entity-genericdef-stale-save.spec.ts`
  - → `frontend/e2e/refactor/rename-entity-genericdef-dirty-rename-block.spec.ts`
- **JSDoc / describe ラベル / コメント更新** (test 動作には影響なし):
  - L2: ヘッダー "stale-save banner browser smoke" → "dirty editor rename-block browser smoke"
  - L8: 目的説明 "stale-save banner が表示" → "reload banner が表示"
  - L45: describe ラベル "GenericDefinition stale-save banner" → "dirty GenericDefinition editor rename-block"
  - L112: step 4 コメント "stale-save banner" → "reload banner ... rename-block"

### 触っていないもの (意図的)

- `WS_KEY = "issue-1334-k3-genericdef-stale-save"` (Line 31)
  - workspace ID は test の独立性を保つ id で機能影響あり (rename すると別 workspace になる)
  - 起源 ISSUE #1334 K-3 のトレースも保持したいため touch しない
- test 本体の `expect` / `locator` / `testid` 参照
  - `generic-definition-reload-banner` 等の testid は実装の現行契約と一致しており未変更
  - assertion logic は PR #1397 で更新済の現行版を維持

## 検証

- **外部参照**: `grep -rln "rename-entity-genericdef-stale-save" --include="*.ts" --include="*.tsx" --include="*.md" --include="*.json" --include="*.mjs" --include="*.js" --include="*.yml" --include="*.yaml" .` → 0 件 (旧ファイル名は他所から import / 参照されていない)
- **test 実装未変更**: `git diff HEAD~1` で確認 — 文字列置換のみ (4 insertions / 4 deletions)。`expect(page.getByTestId(...))` 系の assertion は完全未変更のため、PR #1397 merge 後の現行 pass 状態を維持
- **ISSUE 検証コマンド**: `VITE_PORT=5183 npm --prefix frontend run test:e2e -- e2e/refactor/rename-entity-genericdef-dirty-rename-block.spec.ts` (backend 起動前提)

## スコープ外 (意図的非対応)

- GenericDefinition rename-block の実装挙動変更 (ISSUE 本文で明示的に除外)
- WS_KEY の文字列変更 (機能影響あり、現スコープ外)

## 関連

- Refs #1397 (元 PR、レビュー指摘の出所)
- Refs #1334 K-3 (rename-block 契約の起源)

Closes #1398