### PR TITLE
fix(puck): Row > Col が横並びにならない不具合を修正 (#1404)

### DIFF
--- a/frontend/src/puck/__tests__/RowColLayout.test.tsx
+++ b/frontend/src/puck/__tests__/RowColLayout.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * Row / Col / Container primitive のレイアウト DOM 契約テスト。
+ *
+ * #1404: Puck の <DropZone> は外側コンテナと子要素の間に自前の wrapper div を
+ * 挟むため、横並びの flex/grid class を外側 div に付けても Col 群 (DropZone の子)
+ * には効かず縦積みになっていた。本テストは「横並びを司る flex/grid class が
+ * DropZone wrapper (= Col の直接の親) に渡される」ことを検証し、再発を検知する。
+ *
+ * 実描画 (DnD / AppStore 依存) は過剰モックを避け、<DropZone> を className/zone を
+ * そのまま DOM へ透過する軽量モックに差し替えて、各 primitive が渡す props を検査する。
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// <DropZone> を軽量モックに差し替える。
+// 実 Puck の DropZone は AppStore / DnD context に依存し単体描画できないため、
+// 受け取った className / zone を DOM 属性として透過する stub に置換する。
+// これにより「primitive が DropZone wrapper に何の class を渡したか」を検査できる。
+vi.mock("@measured/puck", () => ({
+  DropZone: ({ zone, className }: { zone: string; className?: string }) => (
+    <div data-testid="dropzone" data-zone={zone} className={className} />
+  ),
+}));
+
+import { RowConfig } from "../primitives/Row";
+import { ColConfig } from "../primitives/Col";
+import { ContainerConfig } from "../primitives/Container";
+import { CssFrameworkProvider } from "../CssFrameworkContext";
+import type { CssFramework } from "../layoutPropsMapping/types";
+
+// ComponentConfig.render を React コンポーネントとして呼び出すヘルパ。
+// render は通常関数なので JSX 要素にラップして RTL で描画する。
+function renderPrimitive(
+  renderFn: (props: never) => React.ReactNode,
+  props: Record<string, unknown>,
+  framework: CssFramework,
+) {
+  const El = () => <>{renderFn(props as never)}</>;
+  return render(
+    <CssFrameworkProvider value={framework}>
+      <El />
+    </CssFrameworkProvider>,
+  );
+}
+
+describe("Row primitive (#1404)", () => {
+  it("Tailwind: 横並び flex class を DropZone wrapper に渡す (外側 div ではない)", () => {
+    renderPrimitive(RowConfig.render, { gap: "sm" }, "tailwind");
+    const dropzone = screen.getByTestId("dropzone");
+    // 横並びの context は Col の直接の親 = DropZone wrapper に乗る必要がある
+    expect(dropzone.className).toContain("flex");
+    expect(dropzone.className).toContain("flex-row");
+    // 外側コンテナ (testid=puck-primitive-row) には flex class を付けない
+    const outer = screen.getByTestId("puck-primitive-row");
+    expect(outer.className).not.toContain("flex");
+  });
+
+  it("Bootstrap: row class を DropZone wrapper に渡す", () => {
+    renderPrimitive(RowConfig.render, { gap: "sm" }, "bootstrap");
+    const dropzone = screen.getByTestId("dropzone");
+    expect(dropzone.className).toContain("row");
+  });
+});
+
+describe("Col primitive (#1404)", () => {
+  it("Tailwind: 列幅 class は Col 自身の最外殻 div に乗る (flex item として横並びする)", () => {
+    renderPrimitive(ColConfig.render, { span: 3 }, "tailwind");
+    const outer = screen.getByTestId("puck-primitive-col");
+    // span=3 → w-3/12。Col の div が Row の flex の直接の子なので、ここで幅指定する
+    expect(outer.className).toContain("w-3/12");
+    // Col 内部の DropZone には列幅 class を渡さない (子は縦積みのまま)
+    const dropzone = screen.getByTestId("dropzone");
+    expect(dropzone.className ?? "").not.toContain("w-3/12");
+  });
+
+  it("Bootstrap: 列幅 class (col-N) は Col 自身の最外殻 div に乗る", () => {
+    renderPrimitive(ColConfig.render, { span: 4 }, "bootstrap");
+    const outer = screen.getByTestId("puck-primitive-col");
+    expect(outer.className).toContain("col-4");
+  });
+});
+
+describe("Container primitive (#1404)", () => {
+  it("direction=row: flex-row を DropZone wrapper に渡す", () => {
+    renderPrimitive(ContainerConfig.render, { direction: "row" }, "tailwind");
+    const dropzone = screen.getByTestId("dropzone");
+    expect(dropzone.className).toContain("flex");
+    expect(dropzone.className).toContain("flex-row");
+    const outer = screen.getByTestId("puck-primitive-container");
+    expect(outer.className).not.toContain("flex");
+  });
+
+  it("direction=column: flex-col を DropZone wrapper に渡す", () => {
+    renderPrimitive(ContainerConfig.render, { direction: "column" }, "tailwind");
+    const dropzone = screen.getByTestId("dropzone");
+    expect(dropzone.className).toContain("flex-col");
+  });
+});

--- a/frontend/src/puck/__tests__/RowColRealRender.test.tsx
+++ b/frontend/src/puck/__tests__/RowColRealRender.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * Row > Col x3 の実レイアウト構造テスト (#1404)。
+ *
+ * RowColLayout.test.tsx は DropZone をモックして「primitive が DropZone へ正しい class を
+ * 渡す」契約を検証する。本テストはそれを補完し、**実 @measured/puck の <Render>** を通して
+ * 実際の DOM 階層を検証する (モックでは検出できない item-wrapper 挿入の有無を実機で担保)。
+ *
+ * #1404 の核心:
+ *   - Puck の DropZone は className をその container div に付与する
+ *   - Puck 0.20.x は各子コンポーネントを item-wrapper で包まず、component 本体の root を
+ *     DropZone container の「直接の子」として配置する (data-puck-component は ref 経由で
+ *     component 本体 root に付与、選択 overlay は portal で別レイヤー)
+ *   - したがって Row が DropZone に付けた `flex flex-row` が効き、Col 本体 (w-N/12) が
+ *     flex item として横並びする
+ */
+
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { Render, type Config } from "@measured/puck";
+import { RowConfig } from "../primitives/Row";
+import { ColConfig } from "../primitives/Col";
+import { CssFrameworkProvider } from "../CssFrameworkContext";
+import type { CssFramework } from "../layoutPropsMapping/types";
+
+const config = {
+  components: { Row: RowConfig, Col: ColConfig },
+} as unknown as Config;
+
+function makeData(span: 1 | 2 | 3 | 4 | 6 | 12) {
+  return {
+    root: { props: {} },
+    content: [{ type: "Row", props: { id: "row-1", gap: "sm" } }],
+    zones: {
+      "row-1:content": [
+        { type: "Col", props: { id: "col-1", span } },
+        { type: "Col", props: { id: "col-2", span } },
+        { type: "Col", props: { id: "col-3", span } },
+      ],
+    },
+  } as never;
+}
+
+function renderRowCol(framework: CssFramework, span: 1 | 2 | 3 | 4 | 6 | 12) {
+  return render(
+    <CssFrameworkProvider value={framework}>
+      <Render config={config} data={makeData(span)} />
+    </CssFrameworkProvider>,
+  );
+}
+
+describe("Row > Col x3 実レイアウト (#1404, real Puck Render)", () => {
+  it("Tailwind: 3 つの Col 本体が同一 flex コンテナの直接の子として並ぶ", () => {
+    const { container } = renderRowCol("tailwind", 3);
+    const cols = Array.from(
+      container.querySelectorAll('[data-testid="puck-primitive-col"]'),
+    );
+    expect(cols).toHaveLength(3);
+
+    // 3 つの Col の親はすべて同一要素 (= Row が DropZone に付けた flex コンテナ)
+    const parents = new Set(cols.map((c) => c.parentElement));
+    expect(parents.size).toBe(1);
+
+    const flexParent = cols[0].parentElement!;
+    // 横並びの flex context がこの親 (Col の直接の親) に効いている
+    expect(flexParent.className).toContain("flex");
+    expect(flexParent.className).toContain("flex-row");
+
+    // 各 Col 本体に列幅 class が乗り、flex item として幅が決まる
+    cols.forEach((c) => expect(c.className).toContain("w-3/12"));
+
+    // item-wrapper が挟まっていない (Col の親が flex コンテナそのもの) ことの裏付け:
+    // 親の直接の子 3 つがすべて Col である
+    const directChildren = Array.from(flexParent.children);
+    expect(directChildren).toHaveLength(3);
+    directChildren.forEach((el) =>
+      expect(el.getAttribute("data-testid")).toBe("puck-primitive-col"),
+    );
+  });
+
+  it("Bootstrap: 3 つの Col 本体が row コンテナの直接の子として並ぶ", () => {
+    const { container } = renderRowCol("bootstrap", 4);
+    const cols = Array.from(
+      container.querySelectorAll('[data-testid="puck-primitive-col"]'),
+    );
+    expect(cols).toHaveLength(3);
+
+    const parents = new Set(cols.map((c) => c.parentElement));
+    expect(parents.size).toBe(1);
+
+    const rowParent = cols[0].parentElement!;
+    expect(rowParent.className).toContain("row");
+    cols.forEach((c) => expect(c.className).toContain("col-4"));
+  });
+});

--- a/frontend/src/puck/primitives/Col.tsx
+++ b/frontend/src/puck/primitives/Col.tsx
@@ -79,6 +79,10 @@ export const ColConfig: ComponentConfig<ColProps> = {
         ? (BOOTSTRAP_COL[span] ?? "col")
         : (TAILWIND_COL[span] ?? "w-6/12");
     const combinedClass = [colClass, layoutClass].filter(Boolean).join(" ");
+    // #1404: 列幅 class (w-N/12 / col-N) は Col 自身の最外殻 div に乗せる。
+    // この div は Row が DropZone へ付与した flex/grid context の「直接の子」
+    // (flex item) として並ぶため、ここで幅指定すれば横並びの列幅が反映される。
+    // Col 内部の DropZone は子を縦積みする通常コンテナ (block) のままで良い。
     return (
       <div data-testid="puck-primitive-col" className={combinedClass}>
         <DropZone zone="content" />

--- a/frontend/src/puck/primitives/Container.tsx
+++ b/frontend/src/puck/primitives/Container.tsx
@@ -37,9 +37,13 @@ export const ContainerConfig: ComponentConfig<ContainerProps> = {
     const layoutClass = mapper(props);
     const flexClass = props.direction === "row" ? "flex flex-row" : "flex flex-col";
     const combinedClass = [flexClass, layoutClass].filter(Boolean).join(" ");
+    // #1404: Puck の <DropZone> は外側コンテナと子要素の間に自前の wrapper div
+    // を挟むため、direction (flex-row / flex-col) を効かせる対象は「子の直接の
+    // 親」= DropZone wrapper である。flex class は外側ではなく DropZone の
+    // className に渡す (Row と同根)。
     return (
-      <div data-testid="puck-primitive-container" className={combinedClass}>
-        <DropZone zone="content" />
+      <div data-testid="puck-primitive-container">
+        <DropZone zone="content" className={combinedClass} />
       </div>
     );
   },

--- a/frontend/src/puck/primitives/Row.tsx
+++ b/frontend/src/puck/primitives/Row.tsx
@@ -26,9 +26,14 @@ export const RowConfig: ComponentConfig<RowProps> = {
     // Bootstrap では "row" + gap-* が自然。Tailwind では "flex flex-row"。
     const baseClass = framework === "bootstrap" ? "row" : "flex flex-row flex-wrap";
     const combinedClass = [baseClass, layoutClass].filter(Boolean).join(" ");
+    // #1404: Puck の <DropZone> は外側コンテナと Col 群の間に自前の wrapper div
+    // (data-puck-dropzone) を挟む。横並びの flex/grid context を効かせる対象は
+    // 「Col の直接の親」= この DropZone wrapper なので、レイアウト class は外側
+    // ではなく DropZone の className に渡す必要がある。外側 div は識別用の
+    // 単なるコンテナとして残す (display:block のまま、子の DropZone が 100% 幅)。
     return (
-      <div data-testid="puck-primitive-row" className={combinedClass}>
-        <DropZone zone="content" />
+      <div data-testid="puck-primitive-row">
+        <DropZone zone="content" className={combinedClass} />
       </div>
     );
   },


### PR DESCRIPTION
## 関連

- Closes #1404
- 仕様: N/A (Puck primitive のレイアウト実装バグ修正。spec ファイルなし)

## 概要

Puck デザイナーで `Row > Col x3` を配置しても 3 列横並びにならず縦積みになる不具合を修正する。`Row` / `Col` の公開契約 (横並びグリッド) と実描画が一致していなかった。

## 主な変更

- **Row / Container の DropZone へ flex/grid class を移譲**: `@measured/puck` 0.20.2 の `<DropZone>` は外側コンテナと子コンポーネントの間にコンテナ div を持ち、その子が直接の flow child になる。横並びの `flex flex-row` / `row` class を外側 div ではなく `<DropZone className=...>` に渡すことで、Col 本体が flex item として並ぶようにした。
- **Col**: 列幅 class (`w-N/12` / `col-N`) は Col 自身の最外殻 div に乗せたまま (この div が flex item になるため正しい)。意図をコメントで明記。
- **Container** (`direction: "row"`): 同根の問題のため同 PR で吸収。

## 仕様逐条突合 (自己申告)

spec ファイルなし。ISSUE #1404 の受け入れ条件に対して:

- 「Row 直下の 3 つの Col が横 3 列で並ぶ」→ `Row.tsx:30-32` (DropZone に flex class) + 実 Puck Render テスト `RowColRealRender.test.tsx:42-58` で 3 Col が同一 flex 親の直接の子であることを検証 ✓
- 「Col の span に応じて列幅が反映される」→ `Col.tsx:82-85` (w-N/12 / col-N を Col 外殻に付与) + `RowColRealRender.test.tsx:55,77` ✓

## レビューで特に見てほしい箇所

- 独立 Codex レビューが「DropZone が item-wrapper を挟むなら横並びにならない」と Must-fix 指摘 → Puck 0.20.2 ソース (`chunk-QIGVND56.mjs`) と実 `<Render>` の DOM ダンプで **item-wrapper は挟まれず、Col 本体が flex コンテナの直接の子になる** ことを実機確認済 (`RowColRealRender.test.tsx`)。選択 overlay は `createPortal` で別レイヤー、`data-puck-component` は ref 経由で component 本体 root に付与されるため flex flow を壊さない。

## テスト

- Vitest: 8 件 (新規 8 件) — `RowColLayout.test.tsx` (DropZone モックで class 受け渡し契約) + `RowColRealRender.test.tsx` (実 Puck Render で DOM 構造)
- Playwright: N/A
- MCP E2E: N/A
- 回帰: `src/puck` 全体 270 件 pass、`npm run build` pass

## UI 影響 / AI smoke test

- [x] UI 影響あり。実 `@measured/puck` の `<Render>` を通した DOM 構造テストで「3 Col が同一 flex コンテナの直接の子として `w-3/12` で並ぶ」ことを検証 (live screenshot より確実な構造検証)。flexbox レイアウト自体は決定的 CSS 挙動。

## スキーマ変更

- なし (`git diff origin/main...HEAD -- schemas/` 空)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
