### PR TITLE
fix(designer): composition preview iframe の CSS 欠落を修正 (#1406)

### DIFF
--- a/frontend/src/components/Designer.tsx
+++ b/frontend/src/components/Designer.tsx
@@ -69,6 +69,11 @@ export interface DesignerProps {
   pageLayoutAssignments?: Record<string, string>;
   /** gadget screenId → design HTML (event load 済の map) */
   gadgetHtmlMap?: Map<string, string>;
+  // #1406: composition preview に project CSS を合成するための CSS データ
+  /** PageLayout 自身の project CSS (GrapesJS styles を直列化したもの) */
+  pageLayoutCss?: string;
+  /** gadget screenId → project CSS */
+  gadgetCssMap?: Map<string, string>;
 }
 
 export function Designer({
@@ -84,6 +89,8 @@ export function Designer({
   pageLayoutHtml,
   pageLayoutAssignments,
   gadgetHtmlMap,
+  pageLayoutCss,
+  gadgetCssMap,
 }: DesignerProps) {
   const [isDirty, setIsDirtyState] = useState(false);
   // RFC #1021 pl-6 (Codex C-1): GrapesJS editor の生インスタンス参照 / composition preview modal の表示状態は
@@ -1023,6 +1030,8 @@ export function Designer({
       pageLayoutHtml={pageLayoutHtml}
       pageLayoutAssignments={pageLayoutAssignments}
       gadgetHtmlMap={gadgetHtmlMap}
+      pageLayoutCss={pageLayoutCss}
+      gadgetCssMap={gadgetCssMap}
       onGrapesEditorReady={onGrapesEditorReady}
     />
   );

--- a/frontend/src/components/DesignerTabHost.tsx
+++ b/frontend/src/components/DesignerTabHost.tsx
@@ -16,7 +16,7 @@ import { loadProject } from "../store/flowStore";
 import { loadPageLayout } from "../store/pageLayoutStore";
 import type { PageLayout } from "../store/pageLayoutStore";
 import { mcpBridge } from "../mcp/mcpBridge";
-import { extractGrapesHtml } from "../utils/pageLayoutCompositionPreview";
+import { extractGrapesHtml, extractGrapesCss } from "../utils/pageLayoutCompositionPreview";
 
 export interface DesignerTabHostProps {
   screenId: string;
@@ -29,6 +29,9 @@ export function DesignerTabHost({ screenId, screenName, isActive }: DesignerTabH
   const [pageLayoutId, setPageLayoutId] = useState<string | undefined>(undefined);
   const [pageLayoutHtml, setPageLayoutHtml] = useState<string | undefined>(undefined);
   const [gadgetHtmlMap, setGadgetHtmlMap] = useState<Map<string, string>>(new Map());
+  // #1406: composition preview に PageLayout / gadget の project CSS も合成する
+  const [pageLayoutCss, setPageLayoutCss] = useState<string | undefined>(undefined);
+  const [gadgetCssMap, setGadgetCssMap] = useState<Map<string, string>>(new Map());
 
   useEffect(() => {
     if (!screenId) return;
@@ -46,6 +49,8 @@ export function DesignerTabHost({ screenId, screenName, isActive }: DesignerTabH
           setPageLayout(null);
           setPageLayoutHtml(undefined);
           setGadgetHtmlMap(new Map());
+          setPageLayoutCss(undefined);
+          setGadgetCssMap(new Map());
           return;
         }
         setPageLayoutId(node.pageLayoutId);
@@ -56,11 +61,14 @@ export function DesignerTabHost({ screenId, screenName, isActive }: DesignerTabH
         setPageLayout(pl);
         if (!pl) return;
 
-        // PageLayout design HTML (composition preview 用) — dedicated handler
+        // PageLayout design HTML + CSS (composition preview 用) — dedicated handler
         try {
           const plDesign = await mcpBridge.request("loadPageLayoutDesign", { pageLayoutId: pl.id });
           const html = extractGrapesHtml(plDesign);
           if (mounted && html) setPageLayoutHtml(html);
+          // #1406: PageLayout の project CSS も抽出して preview に合成
+          const css = extractGrapesCss(plDesign);
+          if (mounted && css) setPageLayoutCss(css);
         } catch { /* ignore */ }
 
         // gadget design HTML 並列 pre-load
@@ -70,14 +78,21 @@ export function DesignerTabHost({ screenId, screenName, isActive }: DesignerTabH
           .filter((id) => typeof id === "string")
           .map((id) => id as string);
         const nextMap = new Map<string, string>();
+        const nextCssMap = new Map<string, string>();
         await Promise.all(gadgetIds.map(async (gid) => {
           try {
             const gd = await mcpBridge.request("loadScreen", { screenId: gid });
             const html = extractGrapesHtml(gd);
             if (html) nextMap.set(gid, html);
+            // #1406: gadget の project CSS も抽出
+            const css = extractGrapesCss(gd);
+            if (css) nextCssMap.set(gid, css);
           } catch { /* skip */ }
         }));
-        if (mounted) setGadgetHtmlMap(nextMap);
+        if (mounted) {
+          setGadgetHtmlMap(nextMap);
+          setGadgetCssMap(nextCssMap);
+        }
       } catch (e) {
         console.warn("[DesignerTabHost] pageLayout pre-load failed:", e);
       }
@@ -103,6 +118,8 @@ export function DesignerTabHost({ screenId, screenName, isActive }: DesignerTabH
       pageLayoutHtml={pageLayoutHtml}
       pageLayoutAssignments={pageLayout?.assignments}
       gadgetHtmlMap={gadgetHtmlMap.size > 0 ? gadgetHtmlMap : undefined}
+      pageLayoutCss={pageLayoutCss}
+      gadgetCssMap={gadgetCssMap.size > 0 ? gadgetCssMap : undefined}
     />
   );
 }

--- a/frontend/src/components/designer/GrapesEditorHost.tsx
+++ b/frontend/src/components/designer/GrapesEditorHost.tsx
@@ -18,7 +18,11 @@ import type {
 import type { McpStatus } from "../../mcp/mcpBridge";
 import type { CssFramework } from "../../types/v3/harmony";
 import type { EditMode } from "../../hooks/useEditSession";
-import { composePreviewHtml } from "../../utils/pageLayoutCompositionPreview";
+import {
+  composePreviewHtml,
+  buildCompositionPreviewSrcDoc,
+} from "../../utils/pageLayoutCompositionPreview";
+import { buildPreviewStyleHrefs } from "../../editor/grapesCanvasAssets";
 
 export interface GrapesEditorHostProps {
   backend: GrapesJSBackend;
@@ -71,6 +75,9 @@ export interface GrapesEditorHostProps {
   pageLayoutHtml?: string;
   pageLayoutAssignments?: Record<string, string>;
   gadgetHtmlMap?: Map<string, string>;
+  // #1406: composition preview に project CSS を合成するための CSS データ
+  pageLayoutCss?: string;
+  gadgetCssMap?: Map<string, string>;
   onGrapesEditorReady?: (editor: import("grapesjs").Editor) => void;
 }
 
@@ -146,6 +153,16 @@ export function GrapesEditorHost(props: GrapesEditorHostProps) {
     }
   }, [grapesEditor]);
 
+  // #1406: 編集中 Screen の project CSS (GrapesJS Style Manager で付与された規則) を
+  // composition preview に合成するため live editor から取得する。
+  const getScreenCss = useCallback(() => {
+    try {
+      return grapesEditor?.getCss?.() ?? "";
+    } catch {
+      return "";
+    }
+  }, [grapesEditor]);
+
   const handlePreviewClick = useCallback(() => {
     setShowCompositionPreview(true);
   }, []);
@@ -177,6 +194,11 @@ export function GrapesEditorHost(props: GrapesEditorHostProps) {
           assignments={props.pageLayoutAssignments ?? {}}
           gadgetHtmlMap={props.gadgetHtmlMap ?? new Map()}
           getScreenContent={getScreenContent}
+          getScreenCss={getScreenCss}
+          cssFramework={props.cssFramework}
+          themeVariant={props.themeVariant}
+          pageLayoutCss={props.pageLayoutCss}
+          gadgetCssMap={props.gadgetCssMap}
           onClose={handleClosePreview}
         />
       )}
@@ -290,6 +312,12 @@ interface CompositionPreviewModalProps {
   assignments: Record<string, string>;
   gadgetHtmlMap: Map<string, string>;
   getScreenContent: () => string;
+  // #1406: canvas と同一の CSS スタックを再現するための framework / variant / project CSS
+  getScreenCss: () => string;
+  cssFramework: CssFramework;
+  themeVariant: ThemeId;
+  pageLayoutCss?: string;
+  gadgetCssMap?: Map<string, string>;
   onClose: () => void;
 }
 
@@ -299,18 +327,46 @@ function CompositionPreviewModal({
   assignments,
   gadgetHtmlMap,
   getScreenContent,
+  getScreenCss,
+  cssFramework,
+  themeVariant,
+  pageLayoutCss,
+  gadgetCssMap,
   onClose,
 }: CompositionPreviewModalProps) {
   const composedSrcDoc = useMemo(() => {
     const screenContent = getScreenContent();
     const composed = composePreviewHtml(pageLayoutHtml, assignments, gadgetHtmlMap, screenContent);
-    return `<!DOCTYPE html><html><head>
-	<meta charset="utf-8" />
-	<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-	<link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.min.css" rel="stylesheet">
-	<style>body{margin:0;font-family:system-ui,sans-serif}</style>
-	</head><body>${composed}</body></html>`;
-  }, [pageLayoutHtml, assignments, gadgetHtmlMap, getScreenContent]);
+
+    // #1406: canvas (GrapesJSBackend) と同一の framework + variant CSS スタックを再現する。
+    // grapesCanvasAssets が canvas / preview 双方の単一 source of truth。
+    const styleHrefs = buildPreviewStyleHrefs(cssFramework, themeVariant);
+
+    // #1406: PageLayout / gadget / 編集中 Screen の project CSS を `<style>` で注入。
+    // gadget CSS は assignments で実際に使われているもののみ収集する。
+    const projectCssBlocks: string[] = [];
+    if (pageLayoutCss) projectCssBlocks.push(pageLayoutCss);
+    if (gadgetCssMap) {
+      for (const gadgetId of Object.values(assignments)) {
+        const css = gadgetCssMap.get(gadgetId);
+        if (css) projectCssBlocks.push(css);
+      }
+    }
+    const screenCss = getScreenCss();
+    if (screenCss) projectCssBlocks.push(screenCss);
+
+    return buildCompositionPreviewSrcDoc(composed, styleHrefs, projectCssBlocks);
+  }, [
+    pageLayoutHtml,
+    assignments,
+    gadgetHtmlMap,
+    getScreenContent,
+    getScreenCss,
+    cssFramework,
+    themeVariant,
+    pageLayoutCss,
+    gadgetCssMap,
+  ]);
 
   return (
     <div

--- a/frontend/src/editor/GrapesJSBackend.tsx
+++ b/frontend/src/editor/GrapesJSBackend.tsx
@@ -55,22 +55,17 @@ import { clearItemsFromCache } from "../store/screenItemsStore";
 import { BlocksPanel } from "../components/BlocksPanel";
 import { RightPanel } from "../components/RightPanel";
 import { shouldNotifyScreenChanged } from "./reloadEvents";
+import {
+  FRAMEWORK_URLS,
+  VARIANT_URLS,
+  buildCanvasBaseAssets,
+} from "./grapesCanvasAssets";
 
 // -----------------------------------------------------------------------
-// CSS 注入用 URL (Designer.tsx から移植)
+// CSS 注入用 URL は grapesCanvasAssets.ts に集約済 (#1406)。
+// canvas (本 backend) と composition preview iframe (GrapesEditorHost.tsx) が
+// 同一の asset 定義を参照することで CSS source of truth を一本化する。
 // -----------------------------------------------------------------------
-
-const FRAMEWORK_URLS: Record<CssFramework, string> = {
-  bootstrap: new URL("../styles/themes/theme-bootstrap.css", import.meta.url).href,
-  tailwind: new URL("../styles/themes/theme-tailwind.css", import.meta.url).href,
-};
-
-const VARIANT_URLS: Record<ThemeId, string | null> = {
-  standard: null,
-  card: new URL("../styles/theme-card.css", import.meta.url).href,
-  compact: new URL("../styles/theme-compact.css", import.meta.url).href,
-  dark: new URL("../styles/theme-dark.css", import.meta.url).href,
-};
 
 /**
  * canvas iframe に framework × variant の 2 軸 CSS を注入する (#793 子 5)。
@@ -119,16 +114,8 @@ function buildGjsOptions(): object {
     width: "auto",
     storageManager: { type: "none" },
     undoManager: { trackSelection: false },
-    canvas: {
-      styles: [
-        "https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css",
-        "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css",
-        new URL("../styles/common.css", import.meta.url).href,
-      ],
-      scripts: [
-        "https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js",
-      ],
-    },
+    // canvas base CSS / script は grapesCanvasAssets.ts に集約 (#1406)。
+    canvas: buildCanvasBaseAssets(),
     blockManager: { blocks: [] },
     deviceManager: {
       default: "desktop",

--- a/frontend/src/editor/grapesCanvasAssets.test.ts
+++ b/frontend/src/editor/grapesCanvasAssets.test.ts
@@ -1,0 +1,72 @@
+/**
+ * grapesCanvasAssets — canvas / composition preview の CSS asset 定義が
+ * 単一 source of truth として共有されていることを検証する (#1406)。
+ *
+ * 本テストの主眼:
+ *   1. buildCanvasBaseAssets() (canvas が使う) と buildPreviewStyleHrefs() (preview が使う) が
+ *      同一の base CSS (Bootstrap CDN / Bootstrap Icons / common.css) を含む
+ *   2. preview が framework (bootstrap/tailwind) + variant (card/compact/dark) を反映する
+ *      = canvas の applyThemeToCanvas と同じ FRAMEWORK_URLS / VARIANT_URLS を使う
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  FRAMEWORK_URLS,
+  VARIANT_URLS,
+  COMMON_CSS_URL,
+  BOOTSTRAP_CSS_URL,
+  BOOTSTRAP_ICONS_CSS_URL,
+  BOOTSTRAP_JS_URL,
+  buildCanvasBaseAssets,
+  buildPreviewStyleHrefs,
+} from "./grapesCanvasAssets";
+
+describe("grapesCanvasAssets — canvas / preview の CSS source of truth 共有 (#1406)", () => {
+  it("canvas base assets は Bootstrap CDN + Icons + common.css + Bootstrap JS を含む", () => {
+    const { styles, scripts } = buildCanvasBaseAssets();
+    expect(styles).toContain(BOOTSTRAP_CSS_URL);
+    expect(styles).toContain(BOOTSTRAP_ICONS_CSS_URL);
+    expect(styles).toContain(COMMON_CSS_URL);
+    expect(scripts).toContain(BOOTSTRAP_JS_URL);
+  });
+
+  it("preview の style href は canvas と同じ base (Bootstrap CDN / Icons / common.css) を含む", () => {
+    const hrefs = buildPreviewStyleHrefs("bootstrap", "standard");
+    const canvasBase = buildCanvasBaseAssets().styles;
+    // canvas base (script を除く CSS) が全て preview にも載っていること = source of truth 共有
+    for (const css of canvasBase) {
+      expect(hrefs).toContain(css);
+    }
+  });
+
+  it("preview は framework の theme CSS を反映する (bootstrap / tailwind)", () => {
+    expect(buildPreviewStyleHrefs("bootstrap", "standard")).toContain(FRAMEWORK_URLS.bootstrap);
+    expect(buildPreviewStyleHrefs("tailwind", "standard")).toContain(FRAMEWORK_URLS.tailwind);
+    // bootstrap 指定時に tailwind theme が混入しないこと
+    expect(buildPreviewStyleHrefs("bootstrap", "standard")).not.toContain(FRAMEWORK_URLS.tailwind);
+  });
+
+  it("preview は variant override CSS を反映する (card / compact / dark)", () => {
+    expect(buildPreviewStyleHrefs("bootstrap", "card")).toContain(VARIANT_URLS.card);
+    expect(buildPreviewStyleHrefs("bootstrap", "compact")).toContain(VARIANT_URLS.compact);
+    expect(buildPreviewStyleHrefs("bootstrap", "dark")).toContain(VARIANT_URLS.dark);
+  });
+
+  it("variant=standard では variant override を含まない (override なし)", () => {
+    const hrefs = buildPreviewStyleHrefs("bootstrap", "standard");
+    // standard は VARIANT_URLS が null のため、card/compact/dark のいずれも含まない
+    expect(hrefs).not.toContain(VARIANT_URLS.card);
+    expect(hrefs).not.toContain(VARIANT_URLS.compact);
+    expect(hrefs).not.toContain(VARIANT_URLS.dark);
+  });
+
+  it("style href の適用順は base → framework → variant (後勝ち)", () => {
+    const hrefs = buildPreviewStyleHrefs("bootstrap", "card");
+    const fwIdx = hrefs.indexOf(FRAMEWORK_URLS.bootstrap);
+    const variantIdx = hrefs.indexOf(VARIANT_URLS.card!);
+    const baseIdx = hrefs.indexOf(BOOTSTRAP_CSS_URL);
+    expect(baseIdx).toBeGreaterThanOrEqual(0);
+    expect(fwIdx).toBeGreaterThan(baseIdx);
+    expect(variantIdx).toBeGreaterThan(fwIdx);
+  });
+});

--- a/frontend/src/editor/grapesCanvasAssets.ts
+++ b/frontend/src/editor/grapesCanvasAssets.ts
@@ -1,0 +1,103 @@
+/**
+ * grapesCanvasAssets — GrapesJS canvas が利用する framework / theme CSS asset 定義の
+ * 単一 source of truth (#1406)。
+ *
+ * 背景 (#1406):
+ *   従来、canvas 側 (GrapesJSBackend.tsx) と composition preview iframe 側
+ *   (GrapesEditorHost.tsx の CompositionPreviewModal) で CSS asset の定義がそれぞれ
+ *   ハードコードされており、両者が乖離していた。
+ *   - canvas: FRAMEWORK_URLS (theme-bootstrap/tailwind) + VARIANT (card/compact/dark)
+ *             + styles/common.css + Bootstrap CDN を注入
+ *   - preview: iframe srcDoc に Bootstrap CDN のみを直書き (theme/variant/common.css/project CSS 欠落)
+ *   その結果、preview が canvas と異なる見た目で描画され「崩れて見える」問題が発生していた。
+ *
+ *   本モジュールに asset 定義を集約し、canvas と preview の双方が必ず同じ定義を参照する
+ *   ことで CSS source of truth を一本化する。
+ *
+ * 配置:
+ *   `import.meta.url` ベースの相対 asset URL (`new URL("../styles/...", import.meta.url).href`)
+ *   は vite が build 時に解決する。本モジュールは `frontend/src/editor/` 配下にあり、
+ *   従来 GrapesJSBackend.tsx (同じ `frontend/src/editor/`) で使われていた相対パスを
+ *   そのまま流用できる (基準ディレクトリが同一のため)。
+ */
+
+import type { CssFramework } from "../types/v3/harmony";
+import type { ThemeId } from "./EditorBackend";
+
+/**
+ * framework (bootstrap / tailwind) ごとの theme CSS URL。
+ * canvas / preview 双方で必ずこの定義を使う。
+ */
+export const FRAMEWORK_URLS: Record<CssFramework, string> = {
+  bootstrap: new URL("../styles/themes/theme-bootstrap.css", import.meta.url).href,
+  tailwind: new URL("../styles/themes/theme-tailwind.css", import.meta.url).href,
+};
+
+/**
+ * theme variant (standard / card / compact / dark) ごとの override CSS URL。
+ * standard は override なし (null)。
+ */
+export const VARIANT_URLS: Record<ThemeId, string | null> = {
+  standard: null,
+  card: new URL("../styles/theme-card.css", import.meta.url).href,
+  compact: new URL("../styles/theme-compact.css", import.meta.url).href,
+  dark: new URL("../styles/theme-dark.css", import.meta.url).href,
+};
+
+/** Harmony 共通 canvas スタイル (styles/common.css)。 */
+export const COMMON_CSS_URL: string = new URL("../styles/common.css", import.meta.url).href;
+
+/** Bootstrap base CSS (CDN)。canvas / preview 双方で読み込む。 */
+export const BOOTSTRAP_CSS_URL =
+  "https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css";
+
+/** Bootstrap Icons CSS (CDN)。 */
+export const BOOTSTRAP_ICONS_CSS_URL =
+  "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css";
+
+/** Bootstrap bundle JS (CDN)。canvas のみで利用 (preview は read-only のため script 不要)。 */
+export const BOOTSTRAP_JS_URL =
+  "https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js";
+
+/**
+ * GrapesJS `canvas` option に渡す base CSS / script URL を構築する。
+ *
+ * GrapesJSBackend.buildGjsOptions() がこれを使い、canvas の初期 base styles を設定する。
+ * framework / variant は GrapesJS 初期化後に applyThemeToCanvas() で動的に追加注入される
+ * ため、ここでは framework 非依存の base (Bootstrap CDN + common.css) のみを返す。
+ */
+export function buildCanvasBaseAssets(): { styles: string[]; scripts: string[] } {
+  return {
+    styles: [BOOTSTRAP_CSS_URL, BOOTSTRAP_ICONS_CSS_URL, COMMON_CSS_URL],
+    scripts: [BOOTSTRAP_JS_URL],
+  };
+}
+
+/**
+ * canvas / preview iframe に注入すべき framework + variant の CSS href を、
+ * 適用順に並べたリストとして返す。
+ *
+ * 適用順 (後勝ち):
+ *   1. Bootstrap CDN base
+ *   2. Bootstrap Icons
+ *   3. common.css
+ *   4. FRAMEWORK_URLS[framework]  (theme-bootstrap / theme-tailwind)
+ *   5. VARIANT_URLS[variant]      (card / compact / dark、standard は省略)
+ *
+ * composition preview iframe (GrapesEditorHost.tsx) が `<link>` タグ生成にこれを使うことで、
+ * canvas (applyThemeToCanvas + buildCanvasBaseAssets) と同一の CSS スタックを再現する。
+ */
+export function buildPreviewStyleHrefs(
+  framework: CssFramework,
+  variant: ThemeId,
+): string[] {
+  const hrefs: string[] = [
+    BOOTSTRAP_CSS_URL,
+    BOOTSTRAP_ICONS_CSS_URL,
+    COMMON_CSS_URL,
+    FRAMEWORK_URLS[framework],
+  ];
+  const variantUrl = VARIANT_URLS[variant];
+  if (variantUrl) hrefs.push(variantUrl);
+  return hrefs;
+}

--- a/frontend/src/utils/pageLayoutCompositionPreview.test.ts
+++ b/frontend/src/utils/pageLayoutCompositionPreview.test.ts
@@ -1,0 +1,138 @@
+/**
+ * pageLayoutCompositionPreview — composition preview の CSS 合成 (#1406) を検証する。
+ *
+ * 検証対象:
+ *   1. extractGrapesCss — GrapesJS design の styles 配列を CSS string に直列化する
+ *   2. composePreviewHtml — region 差し替え (既存挙動の回帰)
+ *   3. buildCompositionPreviewSrcDoc — link href + project CSS を iframe srcDoc に合成する
+ *      + `</style>` 注入の無害化 (S-003 / CWE-79 の延長)
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  extractGrapesCss,
+  extractGrapesHtml,
+  composePreviewHtml,
+  buildCompositionPreviewSrcDoc,
+} from "./pageLayoutCompositionPreview";
+
+describe("extractGrapesCss (#1406)", () => {
+  it("styles が空 / 欠落の design では空文字を返す", () => {
+    expect(extractGrapesCss(null)).toBe("");
+    expect(extractGrapesCss({})).toBe("");
+    expect(extractGrapesCss({ styles: [] })).toBe("");
+  });
+
+  it("class セレクタ + style を CSS 規則に直列化する", () => {
+    const design = {
+      styles: [
+        { selectors: [{ name: "card", type: 1 }], style: { color: "red", "font-size": "14px" } },
+      ],
+    };
+    const css = extractGrapesCss(design);
+    expect(css).toContain(".card{");
+    expect(css).toContain("color:red;");
+    expect(css).toContain("font-size:14px;");
+  });
+
+  it("id セレクタ (type=2) は # prefix で直列化する", () => {
+    const design = { styles: [{ selectors: [{ name: "main", type: 2 }], style: { margin: "0" } }] };
+    expect(extractGrapesCss(design)).toContain("#main{margin:0;}");
+  });
+
+  it("文字列セレクタ (prefix なし) は class 扱いにする", () => {
+    const design = { styles: [{ selectors: ["btn"], style: { padding: "4px" } }] };
+    expect(extractGrapesCss(design)).toContain(".btn{padding:4px;}");
+  });
+
+  it("state (hover 等) を擬似クラスとして付与する", () => {
+    const design = {
+      styles: [{ selectors: [{ name: "link", type: 1 }], state: "hover", style: { color: "blue" } }],
+    };
+    expect(extractGrapesCss(design)).toContain(".link:hover{color:blue;}");
+  });
+
+  it("media at-rule を @media でラップする", () => {
+    const design = {
+      styles: [
+        {
+          selectors: [{ name: "col", type: 1 }],
+          atRuleType: "media",
+          mediaText: "(max-width: 768px)",
+          style: { width: "100%" },
+        },
+      ],
+    };
+    const css = extractGrapesCss(design);
+    expect(css).toContain("@media (max-width: 768px){.col{width:100%;}}");
+  });
+
+  it("空 style の規則はスキップする", () => {
+    const design = { styles: [{ selectors: [{ name: "empty", type: 1 }], style: {} }] };
+    expect(extractGrapesCss(design)).toBe("");
+  });
+});
+
+describe("composePreviewHtml — region 差し替え (回帰)", () => {
+  it("main region は screen 本文に置換される", () => {
+    const html = '<div data-region-name="main"></div>';
+    const out = composePreviewHtml(html, {}, new Map(), "<p>本文</p>");
+    expect(out).toContain("本文");
+    expect(out).toContain('data-pl-content-slot="true"');
+  });
+
+  it("gadget region は assignments の gadget HTML に置換される", () => {
+    const html = '<div data-region-name="header"></div>';
+    const out = composePreviewHtml(html, { header: "gadget-1" }, new Map([["gadget-1", "<nav>menu</nav>"]]), "");
+    expect(out).toContain("menu");
+  });
+
+  it("extractGrapesHtml と組み合わせて design から HTML を取り出せる", () => {
+    const design = { pages: [{ frames: [{ component: { components: "<section>x</section>" } }] }] };
+    expect(extractGrapesHtml(design)).toBe("<section>x</section>");
+  });
+});
+
+describe("buildCompositionPreviewSrcDoc (#1406)", () => {
+  it("style href を <link> として head に注入する", () => {
+    const doc = buildCompositionPreviewSrcDoc("<div>body</div>", [
+      "https://cdn.example/bootstrap.css",
+      "/assets/theme-bootstrap.css",
+    ]);
+    expect(doc).toContain('<link href="https://cdn.example/bootstrap.css" rel="stylesheet">');
+    expect(doc).toContain('<link href="/assets/theme-bootstrap.css" rel="stylesheet">');
+    expect(doc).toContain("<div>body</div>");
+  });
+
+  it("project CSS ブロックを <style> として注入する", () => {
+    const doc = buildCompositionPreviewSrcDoc(
+      "<div></div>",
+      ["/a.css"],
+      [".card{color:red;}", "#main{margin:0;}"],
+    );
+    expect(doc).toContain("<style>.card{color:red;}</style>");
+    expect(doc).toContain("<style>#main{margin:0;}</style>");
+  });
+
+  it("空文字 / 空白のみの CSS ブロックは注入しない", () => {
+    const doc = buildCompositionPreviewSrcDoc("<div></div>", ["/a.css"], ["", "   ", ".x{color:blue;}"]);
+    const styleCount = (doc.match(/<style>/g) ?? []).length;
+    // body reset の 1 つ + project CSS 1 つ = 2 (空ブロックは載らない)
+    expect(styleCount).toBe(2);
+    expect(doc).toContain(".x{color:blue;}");
+  });
+
+  it("project CSS 内の </style> 注入を無害化する (S-003 / HTML injection 防止)", () => {
+    const malicious = ".a{}</style><script>alert(1)</script><style>.b{}";
+    const doc = buildCompositionPreviewSrcDoc("<div></div>", [], [malicious]);
+    // 生の </style> でブロックが閉じられていないこと (= script タグが style 外に漏れない)
+    expect(doc).not.toContain("</style><script>");
+    expect(doc).toContain("<\\/style");
+  });
+
+  it("link href の \" や < はエスケープ除去される", () => {
+    const doc = buildCompositionPreviewSrcDoc("<div></div>", ['/a.css" onload="x']);
+    expect(doc).not.toContain('onload="x"');
+    expect(doc).toContain('href="/a.css onload=x"');
+  });
+});

--- a/frontend/src/utils/pageLayoutCompositionPreview.test.ts
+++ b/frontend/src/utils/pageLayoutCompositionPreview.test.ts
@@ -5,7 +5,12 @@
  *   1. extractGrapesCss — GrapesJS design の styles 配列を CSS string に直列化する
  *   2. composePreviewHtml — region 差し替え (既存挙動の回帰)
  *   3. buildCompositionPreviewSrcDoc — link href + project CSS を iframe srcDoc に合成する
- *      + `</style>` 注入の無害化 (S-003 / CWE-79 の延長)
+ *      + href の HTML 属性エスケープ (Must-fix 1)
+ *      + `<style>` break-out の中和 (S-003 / CWE-79 の延長、Must-fix 2 / Should-fix 5)
+ *
+ * 注意 (Should-fix 5): `_neutralizeStyleClose` は CSS 全般の sanitize ではなく
+ * `<style>` 要素の break-out (`</style>` 注入) 中和に限定。body HTML 側の XSS 対策は
+ * composePreviewHtml() 内の DOMPurify が担う。
  */
 
 import { describe, it, expect } from "vitest";
@@ -71,6 +76,43 @@ describe("extractGrapesCss (#1406)", () => {
     const design = { styles: [{ selectors: [{ name: "empty", type: 1 }], style: {} }] };
     expect(extractGrapesCss(design)).toBe("");
   });
+
+  // Should-fix 4 (#1406 Codex review): singleAtRule (@font-face / @keyframes 等) は
+  // selector を持たず宣言ブロックのみを at-rule で包む。GrapesJS の永続化形式で
+  // atRuleType + singleAtRule:true として保持される。
+  it("@font-face (singleAtRule) は selector なしで宣言ブロックを包む", () => {
+    const design = {
+      styles: [
+        {
+          atRuleType: "font-face",
+          singleAtRule: true,
+          style: { "font-family": "MyFont", src: "url(/f.woff2)" },
+        },
+      ],
+    };
+    const css = extractGrapesCss(design);
+    expect(css).toContain("@font-face{");
+    expect(css).toContain("font-family:MyFont;");
+    expect(css).toContain("src:url(/f.woff2);");
+    // selector wrapper (.xxx{ や {{ ) が付いていないこと
+    expect(css).not.toContain("{{");
+  });
+
+  it("@keyframes (singleAtRule) を atRuleType で包む", () => {
+    const design = {
+      styles: [
+        {
+          atRuleType: "keyframes my-anim",
+          singleAtRule: true,
+          style: { from: "x", to: "y" },
+        },
+      ],
+    };
+    const css = extractGrapesCss(design);
+    expect(css).toContain("@keyframes my-anim{");
+    expect(css).toContain("from:x;");
+    expect(css).toContain("to:y;");
+  });
 });
 
 describe("composePreviewHtml — region 差し替え (回帰)", () => {
@@ -122,17 +164,52 @@ describe("buildCompositionPreviewSrcDoc (#1406)", () => {
     expect(doc).toContain(".x{color:blue;}");
   });
 
-  it("project CSS 内の </style> 注入を無害化する (S-003 / HTML injection 防止)", () => {
-    const malicious = ".a{}</style><script>alert(1)</script><style>.b{}";
+  // Must-fix 2 (#1406 Codex review): projectCssBlocks 由来の <style> ブロックだけを抽出し、
+  // その中身に「生の </style> で閉じられていない」「script が style 外に漏れない」ことを assert する。
+  // doc 全体に対する toContain は偽陽性 (body reset の <style> 等を拾う) になりうるため使わない。
+  //
+  // projectCssBlocks 由来の <style> は body reset (`<style>body{...}</style>`) の **後** に
+  // 連結されるため、最後の <style>...</style> ブロックを抽出して検証する。
+  const extractLastStyleBlock = (doc: string): string => {
+    const matches = [...doc.matchAll(/<style>([\s\S]*?)<\/style>/g)];
+    expect(matches.length).toBeGreaterThan(0);
+    return matches[matches.length - 1][1];
+  };
+
+  it.each([
+    [".a{}</style><script>alert(1)</script><style>.b{}", "小文字 </style>"],
+    [".a{}</STYLE><script>alert(1)</script>", "大文字 </STYLE>"],
+    ["x</style><script>alert(1)</script>", "script 混入"],
+    [".a{}</style ><script>alert(1)</script>", "末尾空白 </style >"],
+  ])("project CSS の %s 注入を無害化し style ブロックから漏れない (S-003)", (malicious) => {
     const doc = buildCompositionPreviewSrcDoc("<div></div>", [], [malicious]);
-    // 生の </style> でブロックが閉じられていないこと (= script タグが style 外に漏れない)
-    expect(doc).not.toContain("</style><script>");
-    expect(doc).toContain("<\\/style");
+    const block = extractLastStyleBlock(doc);
+    // style ブロック内に生の </style (= 閉じタグ) が残っていないこと
+    expect(block).not.toMatch(/<\/style/i);
+    // 中和された形 (<\/style) になっていること
+    expect(block).toContain("<\\/style");
+    // script タグが style ブロック内に閉じ込められている (= style 外に漏れていない)
+    expect(block).toContain("<script>");
   });
 
-  it("link href の \" や < はエスケープ除去される", () => {
+  // Must-fix 1 (#1406 Codex review): href は HTML 属性エスケープする (除去ではなく実体参照化)。
+  it('link href は HTML 属性エスケープされる ("/\'/<>/& を実体参照化)', () => {
     const doc = buildCompositionPreviewSrcDoc("<div></div>", ['/a.css" onload="x']);
+    // onload を実行できる生の属性境界 (") は残らない
     expect(doc).not.toContain('onload="x"');
-    expect(doc).toContain('href="/a.css onload=x"');
+    // " は &quot; にエスケープされる
+    expect(doc).toContain('href="/a.css&quot; onload=&quot;x"');
+  });
+
+  it("href の & は二重エスケープされない (& を最初に処理)", () => {
+    const doc = buildCompositionPreviewSrcDoc("<div></div>", ["/a.css?x=1&y=2"]);
+    expect(doc).toContain('href="/a.css?x=1&amp;y=2"');
+    // &amp; が &amp;amp; に二重エスケープされていないこと
+    expect(doc).not.toContain("&amp;amp;");
+  });
+
+  it("href の < > ' もエスケープされる", () => {
+    const doc = buildCompositionPreviewSrcDoc("<div></div>", ["/a<b>'c.css"]);
+    expect(doc).toContain('href="/a&lt;b&gt;&#39;c.css"');
   });
 });

--- a/frontend/src/utils/pageLayoutCompositionPreview.ts
+++ b/frontend/src/utils/pageLayoutCompositionPreview.ts
@@ -37,6 +37,99 @@ export function extractGrapesHtml(design: unknown): string | null {
   return typeof components === "string" ? components : null;
 }
 
+// ---------------------------------------------------------------------------
+// #1406: GrapesJS design data の `styles` (CssRule[] JSON) を CSS string に直列化する。
+//
+// 背景: composition preview は HTML だけを合成し、PageLayout / gadget design に紐づく
+// project CSS (GrapesJS Style Manager で付与された規則) を反映できていなかった。
+// canvas は live editor の `editor.getCss()` で project CSS を持つが、preview は raw
+// design JSON しか持たないため、ここで JSON → CSS の serializer を用意する。
+//
+// GrapesJS の永続化形式 (CssRuleJSON):
+//   { selectors: (string|{name,type?})[], selectorsAdd?, style?, state?,
+//     atRuleType?, mediaText?, singleAtRule? }
+// セレクタ type: 1=class (.foo) / 2=id (#foo) / 省略時は class 扱い。
+// ---------------------------------------------------------------------------
+
+/** GrapesJS selector JSON の最小型 */
+interface GrapesSelectorJson {
+  name: string;
+  type?: number;
+}
+
+/** GrapesJS CssRule JSON の最小型 */
+interface GrapesCssRuleJson {
+  selectors?: Array<string | GrapesSelectorJson>;
+  selectorsAdd?: string;
+  style?: Record<string, unknown>;
+  state?: string;
+  atRuleType?: string;
+  mediaText?: string;
+  singleAtRule?: boolean;
+}
+
+/** 単一 selector JSON を CSS セレクタ文字列に変換する (type 1=class / 2=id)。 */
+function _selectorToCss(sel: string | GrapesSelectorJson): string {
+  if (typeof sel === "string") {
+    // 文字列形式は素の class 名 (prefix なし) を想定。既に . / # 付きならそのまま使う。
+    return /^[.#]/.test(sel) ? sel : `.${sel}`;
+  }
+  const name = sel?.name ?? "";
+  if (!name) return "";
+  if (sel.type === 2) return `#${name}`;
+  return `.${name}`;
+}
+
+/** style オブジェクトを `prop: value;` 宣言ブロックに変換する。 */
+function _styleToDeclarations(style: Record<string, unknown> | undefined): string {
+  if (!style || typeof style !== "object") return "";
+  return Object.entries(style)
+    .filter(([, v]) => v !== undefined && v !== null && v !== "")
+    .map(([prop, value]) => `${prop}:${String(value)};`)
+    .join("");
+}
+
+/** 単一 CssRule JSON を CSS 規則文字列に変換する (media at-rule 対応)。 */
+function _ruleToCss(rule: GrapesCssRuleJson): string {
+  const decls = _styleToDeclarations(rule.style);
+  if (!decls) return "";
+
+  // セレクタ組み立て: selectors[] を連結 (例: .a.b) + state (例: :hover) + selectorsAdd
+  const selectorPart = (rule.selectors ?? [])
+    .map(_selectorToCss)
+    .filter(Boolean)
+    .join("");
+  const statePart = rule.state ? `:${rule.state}` : "";
+  let selector = `${selectorPart}${statePart}`;
+  if (rule.selectorsAdd) {
+    // selectorsAdd は追加セレクタ (例: タグ名や複合)。selector が空ならそのまま使う。
+    selector = selector ? `${selector}, ${rule.selectorsAdd}` : rule.selectorsAdd;
+  }
+  if (!selector) return "";
+
+  const body = `${selector}{${decls}}`;
+
+  // media クエリ等の at-rule をラップ
+  if (rule.atRuleType === "media" && rule.mediaText) {
+    return `@media ${rule.mediaText}{${body}}`;
+  }
+  return body;
+}
+
+/**
+ * #1406: GrapesJS design data の `styles` 配列を CSS string に直列化する。
+ * design が styles を持たない / 空配列の場合は空文字を返す。
+ */
+export function extractGrapesCss(design: unknown): string {
+  if (!design || typeof design !== "object") return "";
+  const d = design as { styles?: unknown };
+  if (!Array.isArray(d.styles) || d.styles.length === 0) return "";
+  return (d.styles as GrapesCssRuleJson[])
+    .map(_ruleToCss)
+    .filter(Boolean)
+    .join("\n");
+}
+
 /**
  * RFC #1021 pl-6 (Codex C-1): Page Screen の composition preview HTML を組み立てる。
  *
@@ -81,6 +174,51 @@ export function composePreviewHtml(
   } catch {
     return pageLayoutHtml;
   }
+}
+
+/**
+ * #1406: composition preview iframe の srcDoc (完全な HTML document) を組み立てる。
+ *
+ * canvas と同一の CSS スタックを再現するため、以下を `<head>` に注入する:
+ *   1. styleHrefs — grapesCanvasAssets.buildPreviewStyleHrefs() が返す framework + variant の
+ *      `<link>` (Bootstrap CDN / theme-bootstrap・tailwind / variant override / common.css)
+ *   2. projectCssBlocks — PageLayout / gadget / 編集中 Screen の GrapesJS project CSS を
+ *      `<style>` ブロックとして後から注入 (link より後勝ちで、設計者が付けた規則が優先される)
+ *
+ * セキュリティ (S-003 / CWE-79): bodyHtml は composePreviewHtml() 内で DOMPurify 済。
+ * projectCssBlocks は CSS 文字列であり HTML サニタイズ対象外だが、`<style>` ブロックからの
+ * 脱出 (`</style>` 注入による HTML injection) を防ぐため `_sanitizeCssBlock()` で
+ * `</style` シーケンスを無害化する。
+ */
+export function buildCompositionPreviewSrcDoc(
+  bodyHtml: string,
+  styleHrefs: string[],
+  projectCssBlocks: string[] = [],
+): string {
+  const links = styleHrefs
+    .filter((href) => typeof href === "string" && href.length > 0)
+    .map((href) => `<link href="${_escapeAttr(href)}" rel="stylesheet">`)
+    .join("\n");
+  const styleBlocks = projectCssBlocks
+    .filter((css) => typeof css === "string" && css.trim().length > 0)
+    .map((css) => `<style>${_sanitizeCssBlock(css)}</style>`)
+    .join("\n");
+  return `<!DOCTYPE html><html><head>
+<meta charset="utf-8" />
+${links}
+<style>body{margin:0;font-family:system-ui,sans-serif}</style>
+${styleBlocks}
+</head><body>${bodyHtml}</body></html>`;
+}
+
+/** `<style>` ブロック脱出防止: `</style` を無害化する (case-insensitive)。 */
+function _sanitizeCssBlock(css: string): string {
+  return css.replace(/<\/style/gi, "<\\/style");
+}
+
+/** href 属性値の最低限エスケープ (" と < を除去) — CDN/asset URL 想定。 */
+function _escapeAttr(value: string): string {
+  return value.replace(/["<>]/g, "");
 }
 
 /**

--- a/frontend/src/utils/pageLayoutCompositionPreview.ts
+++ b/frontend/src/utils/pageLayoutCompositionPreview.ts
@@ -89,10 +89,48 @@ function _styleToDeclarations(style: Record<string, unknown> | undefined): strin
     .join("");
 }
 
-/** 単一 CssRule JSON を CSS 規則文字列に変換する (media at-rule 対応)。 */
+/**
+ * GrapesJS の `getAtRuleFromProps` 相当: atRuleType / mediaText から `@media (...)` /
+ * `@font-face` 等の at-rule prelude を組み立てる。
+ *   - atRuleType あり → `@<atRuleType>` (+ mediaText あれば ` <mediaText>`)
+ *   - atRuleType なし & mediaText あり → `@media <mediaText>`
+ *   - どちらも無し → "" (at-rule なし)
+ * (grapesjs/dist/grapes.mjs CssRule.getAtRuleFromProps と同じ規則)
+ */
+function _atRulePrelude(rule: GrapesCssRuleJson): string {
+  const type = rule.atRuleType;
+  const condition = rule.mediaText;
+  const typeStr = type ? `@${type}` : condition ? "@media" : "";
+  if (!typeStr) return "";
+  return condition ? `${typeStr} ${condition}` : typeStr;
+}
+
+/**
+ * 単一 CssRule JSON を CSS 規則文字列に変換する。
+ *
+ * GrapesJS の永続化形式 (CssRuleJSON) を、live editor の `editor.getCss()` 相当の出力に
+ * 揃えるための serializer。以下を再現する (grapesjs CssRule.toCSS / getDeclaration 準拠):
+ *   - selectors[] 連結 + state (`:hover` 等) + `, selectorsAdd`
+ *   - media 系 at-rule: `@media (...){selector{decls}}`
+ *   - singleAtRule (`@font-face` / `@keyframes` / `@page` 等、宣言ブロックのみ持つ at-rule):
+ *     selector を付けず `@<atRuleType>{decls}` 形式で出力する
+ *
+ * selectorsAdd に state を付けない理由: GrapesJS の `selectorsToString` は state を主セレクタ群
+ * (`selectors[] + state`) にのみ付与し、selectorsAdd は別グループとして `, ` で連結する。
+ * 本実装もその契約に合わせる (state は selectorPart 側のみ)。
+ */
 function _ruleToCss(rule: GrapesCssRuleJson): string {
   const decls = _styleToDeclarations(rule.style);
   if (!decls) return "";
+
+  const atRule = _atRulePrelude(rule);
+
+  // singleAtRule (@font-face / @keyframes 等) は selector を持たず、宣言ブロックのみを at-rule で包む。
+  // GrapesJS: getDeclaration() は singleAtRule のとき style 文字列をそのまま返し、
+  // toCSS() が `@<type>{style}` で包む。
+  if (rule.singleAtRule && atRule) {
+    return `${atRule}{${decls}}`;
+  }
 
   // セレクタ組み立て: selectors[] を連結 (例: .a.b) + state (例: :hover) + selectorsAdd
   const selectorPart = (rule.selectors ?? [])
@@ -109,9 +147,9 @@ function _ruleToCss(rule: GrapesCssRuleJson): string {
 
   const body = `${selector}{${decls}}`;
 
-  // media クエリ等の at-rule をラップ
-  if (rule.atRuleType === "media" && rule.mediaText) {
-    return `@media ${rule.mediaText}{${body}}`;
+  // media クエリ等の at-rule をラップ (@media / @supports 等、selector を内側に持つ at-rule)
+  if (atRule) {
+    return `${atRule}{${body}}`;
   }
   return body;
 }
@@ -187,8 +225,10 @@ export function composePreviewHtml(
  *
  * セキュリティ (S-003 / CWE-79): bodyHtml は composePreviewHtml() 内で DOMPurify 済。
  * projectCssBlocks は CSS 文字列であり HTML サニタイズ対象外だが、`<style>` ブロックからの
- * 脱出 (`</style>` 注入による HTML injection) を防ぐため `_sanitizeCssBlock()` で
+ * 脱出 (`</style>` 注入による HTML injection) を防ぐため `_neutralizeStyleClose()` で
  * `</style` シーケンスを無害化する。
+ * styleHrefs は信頼できる asset URL (自前定数 / import.meta.url 解決) だが、防御として
+ * `_escapeAttr()` で HTML 属性エスケープを通してから埋め込む。
  */
 export function buildCompositionPreviewSrcDoc(
   bodyHtml: string,
@@ -201,7 +241,7 @@ export function buildCompositionPreviewSrcDoc(
     .join("\n");
   const styleBlocks = projectCssBlocks
     .filter((css) => typeof css === "string" && css.trim().length > 0)
-    .map((css) => `<style>${_sanitizeCssBlock(css)}</style>`)
+    .map((css) => `<style>${_neutralizeStyleClose(css)}</style>`)
     .join("\n");
   return `<!DOCTYPE html><html><head>
 <meta charset="utf-8" />
@@ -211,14 +251,34 @@ ${styleBlocks}
 </head><body>${bodyHtml}</body></html>`;
 }
 
-/** `<style>` ブロック脱出防止: `</style` を無害化する (case-insensitive)。 */
-function _sanitizeCssBlock(css: string): string {
+/**
+ * `<style>` 要素 break-out 中和専用ヘルパ。
+ *
+ * 責務は限定的: CSS 文字列中の `</style` シーケンス (case-insensitive、`</STYLE>` /
+ * `</style >` 含む) を `<\/style` に置換し、`<style>...</style>` ブロックを途中で閉じて
+ * その後ろに任意 HTML (`<script>` 等) を注入する break-out を防ぐ。CSS 構文として
+ * `<\/style` は無害な (適用されない) 宣言として扱われ、要素は閉じない。
+ *
+ * これは CSS 全般のサニタイズ **ではない** (CSS expression / url() 等は対象外)。
+ * preview body 側の HTML サニタイズは composePreviewHtml() 内の DOMPurify が担当しており、
+ * 本関数は `<style>` への CSS 注入経路に限った break-out 中和のみを担う。
+ */
+function _neutralizeStyleClose(css: string): string {
   return css.replace(/<\/style/gi, "<\\/style");
 }
 
-/** href 属性値の最低限エスケープ (" と < を除去) — CDN/asset URL 想定。 */
+/**
+ * HTML 属性値エスケープ。href は信頼できる asset URL 想定だが、防御として
+ * `&` / `"` / `'` / `<` / `>` を文字実体参照に変換する。
+ * `&` を最初に処理し、後続のエスケープ結果を二重エスケープしないようにする。
+ */
 function _escapeAttr(value: string): string {
-  return value.replace(/["<>]/g, "");
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 }
 
 /**


### PR DESCRIPTION
## 関連

- Closes #1406
- 仕様: N/A (composition preview の表示バグ修正。RFC #1021 pl-6 の preview 実装に対する fix)

## 概要

Page Screen Designer の「composition プレビューを開く」で表示される preview iframe が、designer canvas と CSS 適用条件が分離しているため見た目が崩れる不具合を修正する。preview が canvas と同一の framework/theme CSS スタックと project CSS を共有するようにした。

## 主な変更

- **CSS asset 定義の一本化** (`frontend/src/editor/grapesCanvasAssets.ts` 新規): canvas (`GrapesJSBackend.tsx`) にハードコードされていた framework theme URL / variant override / common.css / Bootstrap CDN を単一 source of truth に集約。canvas / preview の双方が同じ定義を参照する。
- **preview iframe が canvas と同一 CSS スタックを再現**: Bootstrap CDN 直書きを廃止し、現在の Screen の framework/variant を `buildPreviewStyleHrefs()` で反映 (適用順 base → framework → variant)。
- **project CSS の合成**: PageLayout / gadget / 編集中 Screen の GrapesJS project CSS を `extractGrapesCss()` で直列化し、`buildCompositionPreviewSrcDoc()` が `<style>` として注入。
- **wiring**: `DesignerTabHost` で PageLayout/gadget CSS を pre-load、`Designer` / `GrapesEditorHost` へ forward。編集中 Screen は live `editor.getCss()`。

## 仕様逐条突合 (自己申告)

ISSUE #1406 の受け入れ条件:

- 「preview が designer canvas と同じ framework/theme 前提で描画される」→ `grapesCanvasAssets.ts:66-79` (共通定義) + `GrapesEditorHost.tsx:329-335` (preview が buildPreviewStyleHrefs 使用) ✓
- 「custom CSS を含む GrapesJS design でも preview が崩れない」→ `pageLayoutCompositionPreview.ts` `extractGrapesCss` + `buildCompositionPreviewSrcDoc` の project CSS 注入 ✓
- 「focused test が追加され再発検知できる」→ `grapesCanvasAssets.test.ts` (7) + `pageLayoutCompositionPreview.test.ts` (新規 CSS 合成テスト) ✓

## レビューで特に見てほしい箇所

- 独立 Codex レビューの Must-fix 2 件を解消: (1) `_escapeAttr` を文字除去→HTML 属性エスケープ (`&` 最優先) に変更、(2) `</style>` break-out 中和テストを偽陽性でない形 (style ブロック抽出 + 大文字/script混入/末尾空白ケース) に強化 + 関数名を `_neutralizeStyleClose` に明確化。
- Should-fix: `selectorsAdd`+state と `singleAtRule` (@font-face/@keyframes) の扱いを GrapesJS 実ソース (`grapes.mjs`) で確認の上、`singleAtRule` 出力対応を追加、selectorsAdd+state は GrapesJS 契約に一致を確認して根拠コメント付き現状維持。
- canvas 側 (`GrapesJSBackend.tsx`) は import 元変更のみで挙動不変。

## テスト

- Vitest: 新規 `grapesCanvasAssets.test.ts` (7) + `pageLayoutCompositionPreview.test.ts` (拡充)。対象 2 ファイル計 28 件 pass
- Playwright: N/A
- MCP E2E: N/A
- 回帰: `src/utils` + `src/editor` 計 657 件 pass、`npm run build` pass、`npm run lint` (対象) clean

## UI 影響 / AI smoke test

- [x] UI 影響あり。CSS asset 共有 + project CSS 合成を unit test で検証 (asset 定義の canvas/preview 共有、CSS 直列化、`<style>` 注入と break-out 中和)。実機 preview は decltive な CSS 注入のため unit 検証で担保。

## スキーマ変更

- なし (`git diff origin/main...HEAD -- schemas/` 空)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
