### PR TITLE
feat(puck): 外部 React Component / 複合部品の project-scoped 読込対応シリーズ (#1409〜#1413)

### DIFF
--- a/backend/src/handlers/puckComponentAssets.test.ts
+++ b/backend/src/handlers/puckComponentAssets.test.ts
@@ -1,0 +1,178 @@
+/**
+ * puckComponentAssets.test.ts — 外部 component 静的配信ハンドラのテスト (#1409 P-1)。
+ *
+ * - active workspace 未設定 → 404
+ * - 許可拡張子の Content-Type + CORS header
+ * - path traversal → 403
+ * - 拡張子非許可 → 404
+ * - OPTIONS preflight → 204
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { handlePuckComponentAsset } from "./puckComponentAssets.js";
+import { setGlobalDefaultPath, _resetForTest } from "../workspaceState.js";
+
+interface MockRes extends ServerResponse {
+  _status?: number;
+  _body?: string | Buffer;
+  _headers: Record<string, string | string[]>;
+}
+
+function makeRes(): MockRes {
+  const headers: Record<string, string | string[]> = {};
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const obj: any = {
+    _status: undefined,
+    _body: undefined,
+    _headers: headers,
+    writeHead(status: number, h?: Record<string, string | string[]>) {
+      obj._status = status;
+      if (h) Object.assign(headers, h);
+      return obj;
+    },
+    end(body?: string | Buffer) {
+      obj._body = body;
+      return obj;
+    },
+  };
+  return obj as MockRes;
+}
+
+function makeReq(url: string, method = "GET"): IncomingMessage {
+  // origin / host は wsBridge 側で検証済の前提のため、ハンドラ単体テストでは付与不要。
+  // CORS echo 確認用に origin を allowlist 内の値で付ける。
+  return {
+    url,
+    method,
+    headers: { origin: "http://localhost:5173", host: "localhost:5179" },
+    socket: { remoteAddress: "127.0.0.1" },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+let tmpRoot: string;
+let dataRoot: string;
+
+beforeEach(() => {
+  _resetForTest();
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "puck-assets-test-"));
+  // harmony.json で dataDir を指定
+  fs.writeFileSync(
+    path.join(tmpRoot, "harmony.json"),
+    JSON.stringify({ dataDir: "data" }),
+    "utf-8",
+  );
+  dataRoot = path.join(tmpRoot, "data");
+  const puckDir = path.join(dataRoot, "puck-components", "dist");
+  fs.mkdirSync(puckDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dataRoot, "puck-components", "manifest.json"),
+    JSON.stringify({ schemaVersion: "1", components: [] }),
+    "utf-8",
+  );
+  fs.writeFileSync(
+    path.join(puckDir, "foo.mjs"),
+    "export default function Foo(){return null;}",
+    "utf-8",
+  );
+});
+
+afterEach(() => {
+  _resetForTest();
+  try {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+const PREFIX = "/workspace-assets/puck-components/";
+
+describe("handlePuckComponentAsset", () => {
+  it("active workspace 未設定なら 404", async () => {
+    // setGlobalDefaultPath を呼ばない → resolveActiveRoot() = null
+    const res = makeRes();
+    await handlePuckComponentAsset(makeReq(`${PREFIX}manifest.json`), res);
+    expect(res._status).toBe(404);
+  });
+
+  it("manifest.json を application/json + CORS header で配信する", async () => {
+    setGlobalDefaultPath(tmpRoot);
+    const res = makeRes();
+    await handlePuckComponentAsset(makeReq(`${PREFIX}manifest.json`), res);
+    expect(res._status).toBe(200);
+    expect(res._headers["Content-Type"]).toContain("application/json");
+    expect(res._headers["Access-Control-Allow-Origin"]).toBe(
+      "http://localhost:5173",
+    );
+    expect(String(res._body)).toContain("schemaVersion");
+  });
+
+  it(".mjs を text/javascript で配信する", async () => {
+    setGlobalDefaultPath(tmpRoot);
+    const res = makeRes();
+    await handlePuckComponentAsset(makeReq(`${PREFIX}dist/foo.mjs`), res);
+    expect(res._status).toBe(200);
+    expect(res._headers["Content-Type"]).toContain("text/javascript");
+    expect(String(res._body)).toContain("export default");
+  });
+
+  it("存在しないファイルは 404", async () => {
+    setGlobalDefaultPath(tmpRoot);
+    const res = makeRes();
+    await handlePuckComponentAsset(makeReq(`${PREFIX}dist/missing.mjs`), res);
+    expect(res._status).toBe(404);
+  });
+
+  it("許可されない拡張子は 404", async () => {
+    setGlobalDefaultPath(tmpRoot);
+    const res = makeRes();
+    await handlePuckComponentAsset(makeReq(`${PREFIX}secret.env`), res);
+    expect(res._status).toBe(404);
+  });
+
+  it("path traversal (..) は 403", async () => {
+    setGlobalDefaultPath(tmpRoot);
+    const res = makeRes();
+    // ../../harmony.json を狙う (decode 後に .. を含む) → base 外なので 403
+    await handlePuckComponentAsset(
+      makeReq(`${PREFIX}..%2f..%2fharmony.json`),
+      res,
+    );
+    expect(res._status).toBe(403);
+  });
+
+  it("OPTIONS preflight は 204 + CORS header", async () => {
+    setGlobalDefaultPath(tmpRoot);
+    const res = makeRes();
+    await handlePuckComponentAsset(
+      makeReq(`${PREFIX}manifest.json`, "OPTIONS"),
+      res,
+    );
+    expect(res._status).toBe(204);
+    expect(res._headers["Access-Control-Allow-Methods"]).toContain("GET");
+  });
+
+  it("GET / OPTIONS 以外は 405", async () => {
+    setGlobalDefaultPath(tmpRoot);
+    const res = makeRes();
+    await handlePuckComponentAsset(
+      makeReq(`${PREFIX}manifest.json`, "POST"),
+      res,
+    );
+    expect(res._status).toBe(405);
+  });
+
+  it("query 付き URL でも relpath を正しく解決する", async () => {
+    setGlobalDefaultPath(tmpRoot);
+    const res = makeRes();
+    await handlePuckComponentAsset(
+      makeReq(`${PREFIX}dist/foo.mjs?v=123`),
+      res,
+    );
+    expect(res._status).toBe(200);
+  });
+});

--- a/backend/src/handlers/puckComponentAssets.test.ts
+++ b/backend/src/handlers/puckComponentAssets.test.ts
@@ -251,6 +251,37 @@ describe("handlePuckComponentAsset", () => {
     expect(String(res._body)).toContain("schemaVersion");
   });
 
+  // --- P2-7: symlink escape 防御 ---
+  it("base 外を指す symlink (allowed 拡張子) は実体を返さず 403", async () => {
+    // base 外に秘密ファイルを置く。
+    const secretDir = fs.mkdtempSync(path.join(os.tmpdir(), "puck-assets-secret-"));
+    try {
+      const secretFile = path.join(secretDir, "secret.txt");
+      fs.writeFileSync(secretFile, "TOP-SECRET-CONTENT", "utf-8");
+
+      // puck-components 配下に allowed 拡張子 (.mjs) の symlink を作り、base 外の secret を指す。
+      const puckRoot = path.join(tmpRoot, "data", "puck-components");
+      const linkPath = path.join(puckRoot, "evil.mjs");
+      fs.symlinkSync(secretFile, linkPath);
+
+      const res = makeRes();
+      await handlePuckComponentAsset(makeReq(`${prefix()}evil.mjs`), res);
+      // 字句 path check は通過するが realpath 検証で base 外と判定 → 403。
+      expect(res._status).toBe(403);
+      expect(String(res._body ?? "")).not.toContain("TOP-SECRET-CONTENT");
+    } finally {
+      fs.rmSync(secretDir, { recursive: true, force: true });
+    }
+  });
+
+  it("通常ファイル (symlink でない) は従来どおり 200 で配信する", async () => {
+    // P2-7 の realpath 検証導入後も通常 file 配信が壊れないことの回帰確認。
+    const res = makeRes();
+    await handlePuckComponentAsset(makeReq(`${prefix()}dist/foo.mjs`), res);
+    expect(res._status).toBe(200);
+    expect(String(res._body)).toContain("export default");
+  });
+
   it("lockdown モード: 'lockdown' 以外の wsId は 404 (recent を引かない)", async () => {
     vi.stubEnv("DESIGNER_DATA_DIR", tmpRoot);
     initWorkspaceState();

--- a/backend/src/handlers/puckComponentAssets.test.ts
+++ b/backend/src/handlers/puckComponentAssets.test.ts
@@ -1,19 +1,24 @@
 /**
- * puckComponentAssets.test.ts — 外部 component 静的配信ハンドラのテスト (#1409 P-1)。
+ * puckComponentAssets.test.ts — 外部 component 静的配信ハンドラのテスト (#1409 P-1 / #1415 P2-1)。
  *
- * - active workspace 未設定 → 404
+ * URL 契約: GET /workspace-assets/<wsId>/puck-components/<relpath>
+ *
+ * - wsId 不正 / 未登録 → 404
  * - 許可拡張子の Content-Type + CORS header
  * - path traversal → 403
  * - 拡張子非許可 → 404
  * - OPTIONS preflight → 204
+ * - per-session scoping: 別 wsId は別 root が解決される (#1415 P2-1)
+ * - lockdown モード: recent を使わず lockdown path に固定する (#1415 P2-1)
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { handlePuckComponentAsset } from "./puckComponentAssets.js";
-import { setGlobalDefaultPath, _resetForTest } from "../workspaceState.js";
+import { _resetForTest, initWorkspaceState } from "../workspaceState.js";
+import { upsertWorkspace } from "../recentStore.js";
 
 interface MockRes extends ServerResponse {
   _status?: number;
@@ -53,19 +58,14 @@ function makeReq(url: string, method = "GET"): IncomingMessage {
   } as any;
 }
 
-let tmpRoot: string;
-let dataRoot: string;
-
-beforeEach(() => {
-  _resetForTest();
-  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "puck-assets-test-"));
-  // harmony.json で dataDir を指定
+/** <root>/data/puck-components/ に manifest + dist/foo.mjs を作る fixture を仕込む。 */
+function seedWorkspace(root: string): string {
   fs.writeFileSync(
-    path.join(tmpRoot, "harmony.json"),
+    path.join(root, "harmony.json"),
     JSON.stringify({ dataDir: "data" }),
     "utf-8",
   );
-  dataRoot = path.join(tmpRoot, "data");
+  const dataRoot = path.join(root, "data");
   const puckDir = path.join(dataRoot, "puck-components", "dist");
   fs.mkdirSync(puckDir, { recursive: true });
   fs.writeFileSync(
@@ -78,9 +78,32 @@ beforeEach(() => {
     "export default function Foo(){return null;}",
     "utf-8",
   );
+  return dataRoot;
+}
+
+let tmpRoot: string;
+let recentFile: string;
+let wsId: string;
+
+/** prefix builder: `/workspace-assets/<wsId>/puck-components/`。 */
+function prefix(id = wsId): string {
+  return `/workspace-assets/${encodeURIComponent(id)}/puck-components/`;
+}
+
+beforeEach(async () => {
+  _resetForTest();
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "puck-assets-test-"));
+  seedWorkspace(tmpRoot);
+  // recent-workspaces.json を独立 tmp file に向ける → findById がここを読む。
+  recentFile = path.join(tmpRoot, "recent-workspaces.json");
+  vi.stubEnv("DESIGNER_RECENT_FILE", recentFile);
+  vi.stubEnv("DESIGNER_DATA_DIR", "");
+  const entry = await upsertWorkspace(tmpRoot, "test-ws");
+  wsId = entry.id;
 });
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   _resetForTest();
   try {
     fs.rmSync(tmpRoot, { recursive: true, force: true });
@@ -89,20 +112,19 @@ afterEach(() => {
   }
 });
 
-const PREFIX = "/workspace-assets/puck-components/";
-
 describe("handlePuckComponentAsset", () => {
-  it("active workspace 未設定なら 404", async () => {
-    // setGlobalDefaultPath を呼ばない → resolveActiveRoot() = null
+  it("未登録 wsId なら 404", async () => {
     const res = makeRes();
-    await handlePuckComponentAsset(makeReq(`${PREFIX}manifest.json`), res);
+    await handlePuckComponentAsset(
+      makeReq(`${prefix("does-not-exist")}manifest.json`),
+      res,
+    );
     expect(res._status).toBe(404);
   });
 
   it("manifest.json を application/json + CORS header で配信する", async () => {
-    setGlobalDefaultPath(tmpRoot);
     const res = makeRes();
-    await handlePuckComponentAsset(makeReq(`${PREFIX}manifest.json`), res);
+    await handlePuckComponentAsset(makeReq(`${prefix()}manifest.json`), res);
     expect(res._status).toBe(200);
     expect(res._headers["Content-Type"]).toContain("application/json");
     expect(res._headers["Access-Control-Allow-Origin"]).toBe(
@@ -112,44 +134,39 @@ describe("handlePuckComponentAsset", () => {
   });
 
   it(".mjs を text/javascript で配信する", async () => {
-    setGlobalDefaultPath(tmpRoot);
     const res = makeRes();
-    await handlePuckComponentAsset(makeReq(`${PREFIX}dist/foo.mjs`), res);
+    await handlePuckComponentAsset(makeReq(`${prefix()}dist/foo.mjs`), res);
     expect(res._status).toBe(200);
     expect(res._headers["Content-Type"]).toContain("text/javascript");
     expect(String(res._body)).toContain("export default");
   });
 
   it("存在しないファイルは 404", async () => {
-    setGlobalDefaultPath(tmpRoot);
     const res = makeRes();
-    await handlePuckComponentAsset(makeReq(`${PREFIX}dist/missing.mjs`), res);
+    await handlePuckComponentAsset(makeReq(`${prefix()}dist/missing.mjs`), res);
     expect(res._status).toBe(404);
   });
 
   it("許可されない拡張子は 404", async () => {
-    setGlobalDefaultPath(tmpRoot);
     const res = makeRes();
-    await handlePuckComponentAsset(makeReq(`${PREFIX}secret.env`), res);
+    await handlePuckComponentAsset(makeReq(`${prefix()}secret.env`), res);
     expect(res._status).toBe(404);
   });
 
   it("path traversal (..) は 403", async () => {
-    setGlobalDefaultPath(tmpRoot);
     const res = makeRes();
     // ../../harmony.json を狙う (decode 後に .. を含む) → base 外なので 403
     await handlePuckComponentAsset(
-      makeReq(`${PREFIX}..%2f..%2fharmony.json`),
+      makeReq(`${prefix()}..%2f..%2fharmony.json`),
       res,
     );
     expect(res._status).toBe(403);
   });
 
   it("OPTIONS preflight は 204 + CORS header", async () => {
-    setGlobalDefaultPath(tmpRoot);
     const res = makeRes();
     await handlePuckComponentAsset(
-      makeReq(`${PREFIX}manifest.json`, "OPTIONS"),
+      makeReq(`${prefix()}manifest.json`, "OPTIONS"),
       res,
     );
     expect(res._status).toBe(204);
@@ -157,22 +174,90 @@ describe("handlePuckComponentAsset", () => {
   });
 
   it("GET / OPTIONS 以外は 405", async () => {
-    setGlobalDefaultPath(tmpRoot);
     const res = makeRes();
     await handlePuckComponentAsset(
-      makeReq(`${PREFIX}manifest.json`, "POST"),
+      makeReq(`${prefix()}manifest.json`, "POST"),
       res,
     );
     expect(res._status).toBe(405);
   });
 
   it("query 付き URL でも relpath を正しく解決する", async () => {
-    setGlobalDefaultPath(tmpRoot);
+    const res = makeRes();
+    await handlePuckComponentAsset(makeReq(`${prefix()}dist/foo.mjs?v=123`), res);
+    expect(res._status).toBe(200);
+  });
+
+  it("wsId segment が無い URL は 404", async () => {
+    const res = makeRes();
+    // 旧形式 (/workspace-assets/puck-components/...) は wsId が無いので 404。
+    await handlePuckComponentAsset(
+      makeReq(`/workspace-assets/puck-components/manifest.json`),
+      res,
+    );
+    expect(res._status).toBe(404);
+  });
+
+  // --- #1415 P2-1: per-session workspace scoping ---
+  it("別 wsId は別 root を解決する (workspace 間で混入しない)", async () => {
+    // 2 つ目の workspace を別 root + 別 manifest 内容で登録する。
+    const otherRoot = fs.mkdtempSync(path.join(os.tmpdir(), "puck-assets-other-"));
+    try {
+      fs.writeFileSync(
+        path.join(otherRoot, "harmony.json"),
+        JSON.stringify({ dataDir: "data" }),
+        "utf-8",
+      );
+      const otherData = path.join(otherRoot, "data", "puck-components");
+      fs.mkdirSync(otherData, { recursive: true });
+      fs.writeFileSync(
+        path.join(otherData, "manifest.json"),
+        JSON.stringify({ schemaVersion: "1", marker: "OTHER" }),
+        "utf-8",
+      );
+      const otherEntry = await upsertWorkspace(otherRoot, "other-ws");
+
+      // wsId=A の manifest には marker 無し。
+      const resA = makeRes();
+      await handlePuckComponentAsset(makeReq(`${prefix(wsId)}manifest.json`), resA);
+      expect(resA._status).toBe(200);
+      expect(String(resA._body)).not.toContain("OTHER");
+
+      // wsId=B (otherEntry) は marker:"OTHER" を返す。
+      const resB = makeRes();
+      await handlePuckComponentAsset(
+        makeReq(`${prefix(otherEntry.id)}manifest.json`),
+        resB,
+      );
+      expect(resB._status).toBe(200);
+      expect(String(resB._body)).toContain("OTHER");
+    } finally {
+      fs.rmSync(otherRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("lockdown モード: wsId='lockdown' は lockdown path を解決し、recent は使わない", async () => {
+    // DESIGNER_DATA_DIR を tmpRoot に向けて lockdown を有効化する。
+    vi.stubEnv("DESIGNER_DATA_DIR", tmpRoot);
+    // VITEST=true のため initWorkspaceState は harmony.json 存在検証を skip する。
+    initWorkspaceState();
+
     const res = makeRes();
     await handlePuckComponentAsset(
-      makeReq(`${PREFIX}dist/foo.mjs?v=123`),
+      makeReq(`/workspace-assets/lockdown/puck-components/manifest.json`),
       res,
     );
     expect(res._status).toBe(200);
+    expect(String(res._body)).toContain("schemaVersion");
+  });
+
+  it("lockdown モード: 'lockdown' 以外の wsId は 404 (recent を引かない)", async () => {
+    vi.stubEnv("DESIGNER_DATA_DIR", tmpRoot);
+    initWorkspaceState();
+
+    // recent に登録済の wsId であっても lockdown 中は拒否する。
+    const res = makeRes();
+    await handlePuckComponentAsset(makeReq(`${prefix(wsId)}manifest.json`), res);
+    expect(res._status).toBe(404);
   });
 });

--- a/backend/src/handlers/puckComponentAssets.ts
+++ b/backend/src/handlers/puckComponentAssets.ts
@@ -1,30 +1,52 @@
 /**
- * puckComponentAssets.ts — 外部 React Component 静的配信ハンドラ (#1409 P-1)。
+ * puckComponentAssets.ts — 外部 React Component 静的配信ハンドラ (#1409 P-1 / #1415 P2-1)。
  *
- * GET /workspace-assets/puck-components/<relpath>
- *   active workspace の <dataRoot>/puck-components/ 配下の `.mjs` / `.js` / `.json` / `.map`
- *   を配信する。manifest.json と各 component の ESM bundle (dist/*.mjs) を frontend ローダ
- *   (externalComponents.ts) が fetch / import() で読み込む経路。
+ * GET /workspace-assets/<wsId>/puck-components/<relpath>
+ *   URL 内の <wsId> で **要求ごとに** workspace を解決し、その <dataRoot>/puck-components/
+ *   配下の `.mjs` / `.js` / `.json` / `.map` を配信する。manifest.json と各 component の
+ *   ESM bundle (dist/*.mjs) を frontend ローダ (externalComponents.ts) が fetch / import()
+ *   で読み込む経路。
+ *
+ * #1415 P2-1 (per-session workspace scoping):
+ *   旧実装は process-global な resolveActiveRoot() (lockdown ?? globalDefault) を使っていたが、
+ *   backend のデータ層は #679 (v2) で per-session active workspace (workspaceContextManager) に
+ *   なっており、HTTP の静的 asset GET はセッション文脈を持たないため、複数タブが別 workspace を
+ *   active にしていると別 workspace の外部 component を読みうる cap5 violation があった。
+ *   asset URL に wsId を埋め込み、recentStore.findById(wsId) で当該 workspace root を解決する
+ *   ことで要求ごとに scope する。lockdown モード時は recent を使わず lockdown path に固定する。
  *
  * セキュリティ:
  * - origin / host 検証は wsBridge._handleHttp が全 route に強制済 (追加不要)。
+ * - wsId は recentStore に登録済 (= 既知) の workspace のみ解決、未登録 / 不正なら 404 (SSRF 防止)。
  * - path traversal は assertPathContained で防御 (resolved target が base 配下のみ許可)。
  * - 拡張子 allowlist で配信対象を限定 (任意ファイル露出を防ぐ)。
  * - エラー本文は最小 (内部情報を漏らさない、既存 S-013 方針)。
  *
- * RFC #1405 シリーズ P-1。
+ * RFC #1405 シリーズ P-1 / #1415 P2-1。
  */
 
 import type { IncomingMessage, ServerResponse } from "node:http";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { getLockdownPath, getGlobalDefaultPath } from "../workspaceState.js";
+import {
+  getLockdownPath,
+  isLockdown,
+  LOCKDOWN_WORKSPACE_ID,
+} from "../workspaceState.js";
+import { findById } from "../recentStore.js";
 import { resolveDataRoot } from "../projectStorage.js";
 import { assertPathContained } from "../security/idValidator.js";
 import { getAllowedOriginHeader } from "../security/originCheck.js";
 import { logWarn, logError } from "../serverLog.js";
 
-const ROUTE_PREFIX = "/workspace-assets/puck-components/";
+/**
+ * route prefix。wsBridge は url === prefix / startsWith(prefix + "/") でマッチするため、
+ * wsId を URL path segment に含める本 handler は親 prefix `/workspace-assets` で登録する。
+ * handler 内で `/workspace-assets/<wsId>/puck-components/<relpath>` を parse する。
+ */
+const ROUTE_PREFIX = "/workspace-assets";
+/** wsId の後ろに来る固定 segment。 */
+const PUCK_SEGMENT = "puck-components";
 
 /** 拡張子 → Content-Type の allowlist。これ以外は 404。 */
 const CONTENT_TYPES: Record<string, string> = {
@@ -60,9 +82,53 @@ function sendStatus(
   res.end(body);
 }
 
-/** active workspace root を解決する。lockdown 優先、なければ global default。null なら未選択。 */
-function resolveActiveRoot(): string | null {
-  return getLockdownPath() ?? getGlobalDefaultPath();
+/**
+ * URL から `/workspace-assets/<wsId>/puck-components/<relpath>` を parse する。
+ * 失敗時は null (= 404 扱い)。relpath は decode 済。
+ */
+function parseAssetUrl(
+  rawUrl: string,
+): { wsId: string; relpath: string } | null {
+  const pathPart = rawUrl.split("?")[0];
+  // ROUTE_PREFIX (`/workspace-assets`) で登録されているため必ず prefix で始まる前提だが、
+  // 念のため確認し、`/workspace-assets/` の後ろを segment 分解する。
+  if (pathPart !== ROUTE_PREFIX && !pathPart.startsWith(ROUTE_PREFIX + "/")) {
+    return null;
+  }
+  const rest = pathPart.slice(ROUTE_PREFIX.length).replace(/^\//, "");
+  // rest = "<wsId>/puck-components/<relpath...>"
+  const firstSlash = rest.indexOf("/");
+  if (firstSlash < 0) return null;
+  const wsIdRaw = rest.slice(0, firstSlash);
+  const afterWsId = rest.slice(firstSlash + 1);
+  if (!afterWsId.startsWith(PUCK_SEGMENT + "/")) return null;
+  const relpathRaw = afterWsId.slice(PUCK_SEGMENT.length + 1);
+  let wsId: string;
+  let relpath: string;
+  try {
+    wsId = decodeURIComponent(wsIdRaw);
+    relpath = decodeURIComponent(relpathRaw);
+  } catch {
+    return null;
+  }
+  if (wsId.length === 0 || relpath.length === 0) return null;
+  return { wsId, relpath };
+}
+
+/**
+ * wsId から workspace root を解決する。
+ * - lockdown モード時は wsId に関わらず lockdown path に固定する (recent は読み書きしない仕様)。
+ *   ただし frontend は lockdown 時 wsId="lockdown" を送るため、それ以外の wsId は不正として拒否。
+ * - 通常モードは recentStore.findById(wsId) で既知の workspace のみ解決する (SSRF 防止)。
+ * 解決できなければ null。
+ */
+async function resolveRootForWsId(wsId: string): Promise<string | null> {
+  if (isLockdown()) {
+    if (wsId !== LOCKDOWN_WORKSPACE_ID) return null;
+    return getLockdownPath();
+  }
+  const entry = await findById(wsId);
+  return entry ? entry.path : null;
 }
 
 export async function handlePuckComponentAsset(
@@ -81,28 +147,18 @@ export async function handlePuckComponentAsset(
     return;
   }
 
-  const activeRoot = resolveActiveRoot();
-  if (!activeRoot) {
-    sendStatus(res, req, 404, "No active workspace");
+  // URL から wsId / relpath を parse する。
+  const parsed = parseAssetUrl(req.url ?? "");
+  if (!parsed) {
+    sendStatus(res, req, 404, "Not Found");
     return;
   }
+  const { wsId, relpath } = parsed;
 
-  // URL から prefix と query を除いた relpath を decode する
-  const rawUrl = req.url ?? "";
-  const pathPart = rawUrl.split("?")[0];
-  if (!pathPart.startsWith(ROUTE_PREFIX)) {
-    sendStatus(res, req, 404, "Not Found");
-    return;
-  }
-  let relpath: string;
-  try {
-    relpath = decodeURIComponent(pathPart.slice(ROUTE_PREFIX.length));
-  } catch {
-    sendStatus(res, req, 400, "Bad Request");
-    return;
-  }
-  if (relpath.length === 0) {
-    sendStatus(res, req, 404, "Not Found");
+  // wsId → workspace root を要求ごとに解決 (per-session scoping、#1415 P2-1)。
+  const root = await resolveRootForWsId(wsId);
+  if (!root) {
+    sendStatus(res, req, 404, "No such workspace");
     return;
   }
 
@@ -117,7 +173,7 @@ export async function handlePuckComponentAsset(
   // dataRoot 解決 → base = <dataRoot>/puck-components/
   let base: string;
   try {
-    const dataRoot = await resolveDataRoot(activeRoot);
+    const dataRoot = await resolveDataRoot(root);
     base = path.join(dataRoot, "puck-components");
   } catch (e) {
     logWarn("puck-assets", "Failed to resolve dataRoot", {

--- a/backend/src/handlers/puckComponentAssets.ts
+++ b/backend/src/handlers/puckComponentAssets.ts
@@ -18,7 +18,10 @@
  * セキュリティ:
  * - origin / host 検証は wsBridge._handleHttp が全 route に強制済 (追加不要)。
  * - wsId は recentStore に登録済 (= 既知) の workspace のみ解決、未登録 / 不正なら 404 (SSRF 防止)。
- * - path traversal は assertPathContained で防御 (resolved target が base 配下のみ許可)。
+ * - path traversal は assertPathContained で防御 (resolved target が base 配下のみ許可、字句的)。
+ * - symlink escape は fs.realpath で実体パスを解決し、base の realpath 配下に収まるか
+ *   再検証することで防御 (P2-7、多層防御)。allowed 拡張子の symlink で base 外の任意ファイル
+ *   (例 /etc/passwd) を指しても字句 check を通過し fs.readFile が follow する穴を塞ぐ。
  * - 拡張子 allowlist で配信対象を限定 (任意ファイル露出を防ぐ)。
  * - エラー本文は最小 (内部情報を漏らさない、既存 S-013 方針)。
  *
@@ -131,6 +134,20 @@ async function resolveRootForWsId(wsId: string): Promise<string | null> {
   return entry ? entry.path : null;
 }
 
+/**
+ * child が parent ディレクトリ配下に収まるか判定する (realpath 同士の比較を想定、P2-7)。
+ * path separator を付与して prefix 比較することで、`/a/bc` が `/a/b` 配下と誤判定されるのを防ぐ。
+ */
+function isWithin(parent: string, child: string): boolean {
+  if (child === parent) return true;
+  const rel = path.relative(parent, child);
+  return (
+    rel.length > 0 &&
+    !rel.startsWith("..") &&
+    !path.isAbsolute(rel)
+  );
+}
+
 export async function handlePuckComponentAsset(
   req: IncomingMessage,
   res: ServerResponse,
@@ -183,13 +200,40 @@ export async function handlePuckComponentAsset(
     return;
   }
 
-  // path traversal 防御
+  // path traversal 防御 (字句的)
   const target = path.join(base, relpath);
   try {
     assertPathContained(target, base);
   } catch {
     logWarn("puck-assets", "Path traversal blocked", { relpath });
     sendStatus(res, req, 403, "Forbidden");
+    return;
+  }
+
+  // symlink escape 防御 (P2-7、多層防御): 実体パスを realpath で解決し、
+  // base の realpath 配下に収まることを再検証する。allowed 拡張子の symlink で
+  // base 外 (例 /etc/passwd) を指しても、字句 check を通過した後ここで弾く。
+  // base 自体も realpath 化して比較する (base が symlink 経由のケースも正しく扱う)。
+  try {
+    const realBase = await fs.realpath(base);
+    const realTarget = await fs.realpath(target);
+    if (!isWithin(realBase, realTarget)) {
+      logWarn("puck-assets", "Symlink escape blocked", { relpath });
+      sendStatus(res, req, 403, "Forbidden");
+      return;
+    }
+  } catch (e) {
+    const code = (e as NodeJS.ErrnoException)?.code;
+    // 実体が存在しない / 中間 component が file 等は 404 扱い (ENOENT / ENOTDIR)。
+    if (code === "ENOENT" || code === "ENOTDIR") {
+      sendStatus(res, req, 404, "Not Found");
+      return;
+    }
+    logError("puck-assets", "Failed to realpath asset", {
+      relpath,
+      error: e instanceof Error ? e.message : String(e),
+    });
+    sendStatus(res, req, 500, "Internal Server Error");
     return;
   }
 

--- a/backend/src/handlers/puckComponentAssets.ts
+++ b/backend/src/handlers/puckComponentAssets.ts
@@ -1,0 +1,164 @@
+/**
+ * puckComponentAssets.ts — 外部 React Component 静的配信ハンドラ (#1409 P-1)。
+ *
+ * GET /workspace-assets/puck-components/<relpath>
+ *   active workspace の <dataRoot>/puck-components/ 配下の `.mjs` / `.js` / `.json` / `.map`
+ *   を配信する。manifest.json と各 component の ESM bundle (dist/*.mjs) を frontend ローダ
+ *   (externalComponents.ts) が fetch / import() で読み込む経路。
+ *
+ * セキュリティ:
+ * - origin / host 検証は wsBridge._handleHttp が全 route に強制済 (追加不要)。
+ * - path traversal は assertPathContained で防御 (resolved target が base 配下のみ許可)。
+ * - 拡張子 allowlist で配信対象を限定 (任意ファイル露出を防ぐ)。
+ * - エラー本文は最小 (内部情報を漏らさない、既存 S-013 方針)。
+ *
+ * RFC #1405 シリーズ P-1。
+ */
+
+import type { IncomingMessage, ServerResponse } from "node:http";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { getLockdownPath, getGlobalDefaultPath } from "../workspaceState.js";
+import { resolveDataRoot } from "../projectStorage.js";
+import { assertPathContained } from "../security/idValidator.js";
+import { getAllowedOriginHeader } from "../security/originCheck.js";
+import { logWarn, logError } from "../serverLog.js";
+
+const ROUTE_PREFIX = "/workspace-assets/puck-components/";
+
+/** 拡張子 → Content-Type の allowlist。これ以外は 404。 */
+const CONTENT_TYPES: Record<string, string> = {
+  ".mjs": "text/javascript; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".map": "application/json; charset=utf-8",
+};
+
+function corsHeaders(req: IncomingMessage): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Access-Control-Allow-Methods": "GET, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+  };
+  const allowedOrigin = getAllowedOriginHeader(req);
+  if (allowedOrigin) {
+    headers["Access-Control-Allow-Origin"] = allowedOrigin;
+    headers["Vary"] = "Origin";
+  }
+  return headers;
+}
+
+function sendStatus(
+  res: ServerResponse,
+  req: IncomingMessage,
+  status: number,
+  body: string,
+): void {
+  res.writeHead(status, {
+    "Content-Type": "text/plain; charset=utf-8",
+    ...corsHeaders(req),
+  });
+  res.end(body);
+}
+
+/** active workspace root を解決する。lockdown 優先、なければ global default。null なら未選択。 */
+function resolveActiveRoot(): string | null {
+  return getLockdownPath() ?? getGlobalDefaultPath();
+}
+
+export async function handlePuckComponentAsset(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  // CORS preflight
+  if (req.method === "OPTIONS") {
+    res.writeHead(204, corsHeaders(req));
+    res.end();
+    return;
+  }
+
+  if (req.method !== "GET") {
+    sendStatus(res, req, 405, "Method Not Allowed");
+    return;
+  }
+
+  const activeRoot = resolveActiveRoot();
+  if (!activeRoot) {
+    sendStatus(res, req, 404, "No active workspace");
+    return;
+  }
+
+  // URL から prefix と query を除いた relpath を decode する
+  const rawUrl = req.url ?? "";
+  const pathPart = rawUrl.split("?")[0];
+  if (!pathPart.startsWith(ROUTE_PREFIX)) {
+    sendStatus(res, req, 404, "Not Found");
+    return;
+  }
+  let relpath: string;
+  try {
+    relpath = decodeURIComponent(pathPart.slice(ROUTE_PREFIX.length));
+  } catch {
+    sendStatus(res, req, 400, "Bad Request");
+    return;
+  }
+  if (relpath.length === 0) {
+    sendStatus(res, req, 404, "Not Found");
+    return;
+  }
+
+  // 拡張子 allowlist
+  const ext = path.extname(relpath).toLowerCase();
+  const contentType = CONTENT_TYPES[ext];
+  if (!contentType) {
+    sendStatus(res, req, 404, "Not Found");
+    return;
+  }
+
+  // dataRoot 解決 → base = <dataRoot>/puck-components/
+  let base: string;
+  try {
+    const dataRoot = await resolveDataRoot(activeRoot);
+    base = path.join(dataRoot, "puck-components");
+  } catch (e) {
+    logWarn("puck-assets", "Failed to resolve dataRoot", {
+      error: e instanceof Error ? e.message : String(e),
+    });
+    sendStatus(res, req, 404, "Not Found");
+    return;
+  }
+
+  // path traversal 防御
+  const target = path.join(base, relpath);
+  try {
+    assertPathContained(target, base);
+  } catch {
+    logWarn("puck-assets", "Path traversal blocked", { relpath });
+    sendStatus(res, req, 403, "Forbidden");
+    return;
+  }
+
+  // file 読込
+  let content: Buffer;
+  try {
+    content = await fs.readFile(target);
+  } catch (e) {
+    const code = (e as NodeJS.ErrnoException)?.code;
+    if (code === "ENOENT" || code === "EISDIR") {
+      sendStatus(res, req, 404, "Not Found");
+      return;
+    }
+    logError("puck-assets", "Failed to read asset", {
+      relpath,
+      error: e instanceof Error ? e.message : String(e),
+    });
+    sendStatus(res, req, 500, "Internal Server Error");
+    return;
+  }
+
+  res.writeHead(200, {
+    "Content-Type": contentType,
+    "Cache-Control": "no-cache",
+    ...corsHeaders(req),
+  });
+  res.end(content);
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -11,6 +11,7 @@ import {
 import { wsBridge } from "./wsBridge.js";
 import { tools } from "./tools.js";
 import { handleAuthCheck, handlePropose } from "./aiRename.js";
+import { handlePuckComponentAsset } from "./handlers/puckComponentAssets.js";
 import {
   initWorkspaceState,
   connect as wsConnect,
@@ -248,6 +249,10 @@ async function main() {
   // AI 命名 endpoints (#337)
   wsBridge.registerHttpHandler("/ai/rename-screen-ids/auth-check", handleAuthCheck);
   wsBridge.registerHttpHandler("/ai/rename-screen-ids/propose", handlePropose);
+
+  // 外部 React Component 静的配信 (#1409 P-1): active workspace の
+  // <dataRoot>/puck-components/ 配下の manifest.json / *.mjs を GET 配信する。
+  wsBridge.registerHttpHandler("/workspace-assets/puck-components", handlePuckComponentAsset);
 
   console.error(`[MCP] harmony-mcp HTTP transport mounted at http://localhost:${process.env.DESIGNER_MCP_PORT ?? 5179}/mcp`);
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -250,9 +250,11 @@ async function main() {
   wsBridge.registerHttpHandler("/ai/rename-screen-ids/auth-check", handleAuthCheck);
   wsBridge.registerHttpHandler("/ai/rename-screen-ids/propose", handlePropose);
 
-  // 外部 React Component 静的配信 (#1409 P-1): active workspace の
-  // <dataRoot>/puck-components/ 配下の manifest.json / *.mjs を GET 配信する。
-  wsBridge.registerHttpHandler("/workspace-assets/puck-components", handlePuckComponentAsset);
+  // 外部 React Component 静的配信 (#1409 P-1 / #1415 P2-1): URL 内の wsId で要求ごとに
+  // workspace を解決し、その <dataRoot>/puck-components/ 配下の manifest.json / *.mjs を
+  // GET 配信する。`/workspace-assets/<wsId>/puck-components/<relpath>` 形式を handler 内で
+  // parse するため、親 prefix `/workspace-assets` で登録する。
+  wsBridge.registerHttpHandler("/workspace-assets", handlePuckComponentAsset);
 
   console.error(`[MCP] harmony-mcp HTTP transport mounted at http://localhost:${process.env.DESIGNER_MCP_PORT ?? 5179}/mcp`);
 }

--- a/docs/spec/dogfood-2026-05-29-puck-external-components.md
+++ b/docs/spec/dogfood-2026-05-29-puck-external-components.md
@@ -21,20 +21,20 @@
 
 | capability | 検証手段 (test 名 + file:line) | 結果 | 証跡 |
 |---|---|---|---|
-| **cap1** ローディング + React 二重化防止 | `cap1: 実 build した .mjs を loader で読み込み status=ok…` (test:96) | ✅ | 実 vite build した `.mjs` を `loadExternalComponents({ importImpl })` で実 import → `status:"ok"`。`createElement` で render し、内部 `useState` が throw せず動作 (= host React 同一インスタンス)。status バッジ「承認済み」が描画される |
-| **cap2** palette カテゴリ登録 | `cap2+cap3: mergeExternalComponents で projectExternal…` (test:124) | ✅ | `config.components["approval-status-bar"]` 存在 + label「(外部) 承認ステータス帯」+ `categories.projectExternal.components` に id。base カテゴリ (layout/Container) 不変 |
-| **cap3** props→fields 変換 | 同上 (test:124) | ✅ | `title` (string)→`text` field、`status` (enum)→`select` field で enum options 透過。`defaultProps` に title/status の default 集約 |
-| **cap4** slot field + render-prop | `cap4(slot): content slot が slot field…` (test:163) | ✅ | `fields.content.type==="slot"`、`defaultProps.content===[]`、render-prop 注入で `content()` 内部 (`SLOT_INNER_BODY`) が描画される |
-| **cap4** 複合部品 (#1412) ロード済展開 | `cap4(composite): approval-status-bar を内包する複合部品をロード済…` (test:198) | ✅ | `mergeCompositeComponents` で placeholder が `projectComposite` に登録。`expandCompositePlaceholders` で展開し、内部の `approval-status-bar` が error-card にならず残る。`collectDependencies` が `["approval-status-bar"]` を返す |
-| **cap4** 複合部品 未ロード依存 (zones) | `cap4(composite): 未ロードの外部 type を内包…` (test:258) | ✅ | 外部 component を load しない config で展開すると、依存ノードが `compositeErrorTypeName` の error-card 型に差し替わり `missingType==="approval-status-bar"` |
+| **cap1** ローディング + React 二重化防止 | `cap1: 実 build した .mjs を loader で読み込み status=ok…` | ✅ | 実 vite build した `.mjs` を `loadExternalComponents({ importImpl })` で実 import → `status:"ok"`。`createElement` で render し、内部 `useState` が throw せず動作 (= host React 同一インスタンス)。status バッジ「承認済み」が描画される |
+| **cap2** palette カテゴリ登録 | `cap2+cap3: mergeExternalComponents で projectExternal…` | ✅ | `config.components["approval-status-bar"]` 存在 + label「(外部) 承認ステータス帯」+ `categories.projectExternal.components` に id。base カテゴリ (layout/Container) 不変 |
+| **cap3** props→fields 変換 | 同上 | ✅ | `title` (string)→`text` field、`status` (enum)→`select` field で enum options 透過。`defaultProps` に title/status の default 集約 |
+| **cap4** slot field + render-prop | `cap4(slot): content slot が slot field…` | ✅ | `fields.content.type==="slot"`、`defaultProps.content===[]`、render-prop 注入で `content()` 内部 (`SLOT_INNER_BODY`) が描画される |
+| **cap4** 複合部品 (#1412) ロード済展開 | `cap4(composite): approval-status-bar を内包する複合部品をロード済…` | ✅ | `mergeCompositeComponents` で placeholder が `projectComposite` に登録。`expandCompositePlaceholders` で展開し、内部の `approval-status-bar` が error-card にならず残る。`collectDependencies` が `["approval-status-bar"]` を返す |
+| **cap4** 複合部品 未ロード依存 (zones) | `cap4(composite): 未ロードの外部 type を内包…` | ✅ | 外部 component を load しない config で展開すると、依存ノードが `compositeErrorTypeName` の error-card 型に差し替わり `missingType==="approval-status-bar"` |
 | **cap4** 複合部品 未ロード依存 (slot props) #1415 P2-2 | `cap4(composite, #1415 P2-2): slot 内 (props 配列) に外部部品を内包…` | ✅ | slot field の子は zones ではなく **props.<slot> の Puck node 配列** に格納される。`collectDependencies` が slot 内 nested `approval-status-bar` を依存として返し、未ロード時の `expandCompositePlaceholders` で当該 nested ノードが error-card 型に差し替わる (`missingType==="approval-status-bar"`) |
-| **cap5** project scoping (#1415 P2-1 per-session) | `cap5: 別 workspace の manifest を別 fetchImpl で解決…` (test:316) | ✅ | asset URL は wsId-scoped (`/workspace-assets/<wsId>/puck-components/`)。workspace A (approval-status-bar) と B (billing-summary) を別 wsId / 別 fetchImpl で解決し互いの component が混入しない (`projectExternal.components` が各 1 件)。backend は要求ごとに wsId → `recentStore.findById(wsId)` で root を解決し process-global state に依存しない |
-| **cap5** id 衝突防御 | `cap5: 既存 built-in id と衝突する外部 component…` (test:355) | ✅ | `id:"Container"` の外部 component は built-in Container を上書きせず、別 key の `id-collision` エラーカードに落ちる |
-| **cap6** manifest-invalid | `cap6: manifest-invalid (schemaVersion 不正)…` (test:395) | ✅ | `schemaVersion:"999"` → `errorKind:"manifest-invalid"` |
-| **cap6** version-mismatch | `cap6: version-mismatch (engine.react=18)…` (test:407) | ✅ | `engine.react:"18"` → `version-mismatch`、import 未実行 (importSpy 未 call) |
-| **cap6** missing-export | `cap6: missing-export (export 名不在)…` (test:425) | ✅ | `export:"NotExist"` を実 .mjs (default のみ export) に向ける → `missing-export` |
-| **cap6** load-error (SSRF) | `cap6: load-error (module が配信範囲外 = SSRF)…` (test:441) | ✅ | `module:"https://evil.example.com/x.mjs"` → import せず `load-error`、detail に「配信範囲外」 |
-| **cap6** エラーカード UX | `cap6: 各 errorKind の entry は…エラーカード化…` (test:462) | ✅ | `mergeExternalComponents` がエラー entry を `ExternalComponentErrorCard` 化、`data-error-kind` + 日本語文言「バージョン不一致」+ 部品名が表示される |
+| **cap5** project scoping (#1415 P2-1 per-session) | `cap5: 別 workspace の manifest を別 fetchImpl で解決…` | ✅ | asset URL は wsId-scoped (`/workspace-assets/<wsId>/puck-components/`)。workspace A (approval-status-bar) と B (billing-summary) を別 wsId / 別 fetchImpl で解決し互いの component が混入しない (`projectExternal.components` が各 1 件)。backend は要求ごとに wsId → `recentStore.findById(wsId)` で root を解決し process-global state に依存しない |
+| **cap5** id 衝突防御 | `cap5: 既存 built-in id と衝突する外部 component…` | ✅ | `id:"Container"` の外部 component は built-in Container を上書きせず、別 key の `id-collision` エラーカードに落ちる |
+| **cap6** manifest-invalid | `cap6: manifest-invalid (schemaVersion 不正)…` | ✅ | `schemaVersion:"999"` → `errorKind:"manifest-invalid"` |
+| **cap6** version-mismatch | `cap6: version-mismatch (engine.react=18)…` | ✅ | `engine.react:"18"` → `version-mismatch`、import 未実行 (importSpy 未 call) |
+| **cap6** missing-export | `cap6: missing-export (export 名不在)…` | ✅ | `export:"NotExist"` を実 .mjs (default のみ export) に向ける → `missing-export` |
+| **cap6** load-error (SSRF) | `cap6: load-error (module が配信範囲外 = SSRF)…` | ✅ | `module:"https://evil.example.com/x.mjs"` → import せず `load-error`、detail に「配信範囲外」 |
+| **cap6** エラーカード UX | `cap6: 各 errorKind の entry は…エラーカード化…` | ✅ | `mergeExternalComponents` がエラー entry を `ExternalComponentErrorCard` 化、`data-error-kind` + 日本語文言「バージョン不一致」+ 部品名が表示される |
 
 注: errorKind 網羅の細目 (404→空配列 / network throw→空配列 / `../` 脱出 / protocol-relative / 拡張子 allowlist 等) は既存 `frontend/src/puck/externalComponents.test.ts` が網羅済のため、本 dogfood は代表 4 種 (manifest-invalid / version-mismatch / missing-export / load-error(SSRF)) のみを通し検証している。
 
@@ -151,7 +151,7 @@ export {
 |---|---|---|
 | `manifest-invalid` | manifest 不正 | `schemaVersion: "1" である必要があります (got "999")` |
 | `version-mismatch` | バージョン不一致 | `react major 18 != host 19` |
-| `missing-export` | export が見つかりません | `export "NotExist" が関数ではありません` |
+| `missing-export` | export が見つかりません | `export "NotExist" が妥当な React component ではありません` |
 | `load-error` | モジュール読込失敗 | `module パスが配信範囲外です (origin 不一致): https://evil.example.com/x.mjs` |
 | `id-collision` | ID 衝突 | `ID 'Container' は既存 component と衝突` |
 | `missing-dependency` | 依存部品が未ロード | `部品 type 'approval-status-bar' が読み込めません (未ロードの外部 component の可能性)` |

--- a/docs/spec/dogfood-2026-05-29-puck-external-components.md
+++ b/docs/spec/dogfood-2026-05-29-puck-external-components.md
@@ -11,7 +11,7 @@
   - props: `title` (string) / `status` (enum: pending / approved / rejected)
   - slot: `content` (editable region)
   - 内部で `React.useState` を使用 (host React と同一インスタンスでないと "Invalid hook call" で落ちる → React 二重化防止の証跡に利用)
-- **検証手段**: 1 ファイルの通し vitest (`frontend/src/puck/__tests__/dogfoodExternalComponents.test.tsx`、12 ケース全 green)。fixture は実 build 成果物 (.mjs) を commit して hermetic 化。
+- **検証手段**: 1 ファイルの通し vitest (`frontend/src/puck/__tests__/dogfoodExternalComponents.test.tsx`、13 ケース全 green。うち 1 件は #1415 P2-2 で追加した slot props 内 nested 依存の error-card 化検証)。fixture は実 build 成果物 (.mjs) を commit して hermetic 化。
 
 ---
 
@@ -26,8 +26,9 @@
 | **cap3** props→fields 変換 | 同上 (test:124) | ✅ | `title` (string)→`text` field、`status` (enum)→`select` field で enum options 透過。`defaultProps` に title/status の default 集約 |
 | **cap4** slot field + render-prop | `cap4(slot): content slot が slot field…` (test:163) | ✅ | `fields.content.type==="slot"`、`defaultProps.content===[]`、render-prop 注入で `content()` 内部 (`SLOT_INNER_BODY`) が描画される |
 | **cap4** 複合部品 (#1412) ロード済展開 | `cap4(composite): approval-status-bar を内包する複合部品をロード済…` (test:198) | ✅ | `mergeCompositeComponents` で placeholder が `projectComposite` に登録。`expandCompositePlaceholders` で展開し、内部の `approval-status-bar` が error-card にならず残る。`collectDependencies` が `["approval-status-bar"]` を返す |
-| **cap4** 複合部品 未ロード依存 | `cap4(composite): 未ロードの外部 type を内包…` (test:258) | ✅ | 外部 component を load しない config で展開すると、依存ノードが `compositeErrorTypeName` の error-card 型に差し替わり `missingType==="approval-status-bar"` |
-| **cap5** project scoping | `cap5: 別 workspace の manifest を別 fetchImpl で解決…` (test:316) | ✅ | workspace A (approval-status-bar) と B (billing-summary) を別 fetchImpl で解決。互いの component が混入しない (`projectExternal.components` が各 1 件) |
+| **cap4** 複合部品 未ロード依存 (zones) | `cap4(composite): 未ロードの外部 type を内包…` (test:258) | ✅ | 外部 component を load しない config で展開すると、依存ノードが `compositeErrorTypeName` の error-card 型に差し替わり `missingType==="approval-status-bar"` |
+| **cap4** 複合部品 未ロード依存 (slot props) #1415 P2-2 | `cap4(composite, #1415 P2-2): slot 内 (props 配列) に外部部品を内包…` | ✅ | slot field の子は zones ではなく **props.<slot> の Puck node 配列** に格納される。`collectDependencies` が slot 内 nested `approval-status-bar` を依存として返し、未ロード時の `expandCompositePlaceholders` で当該 nested ノードが error-card 型に差し替わる (`missingType==="approval-status-bar"`) |
+| **cap5** project scoping (#1415 P2-1 per-session) | `cap5: 別 workspace の manifest を別 fetchImpl で解決…` (test:316) | ✅ | asset URL は wsId-scoped (`/workspace-assets/<wsId>/puck-components/`)。workspace A (approval-status-bar) と B (billing-summary) を別 wsId / 別 fetchImpl で解決し互いの component が混入しない (`projectExternal.components` が各 1 件)。backend は要求ごとに wsId → `recentStore.findById(wsId)` で root を解決し process-global state に依存しない |
 | **cap5** id 衝突防御 | `cap5: 既存 built-in id と衝突する外部 component…` (test:355) | ✅ | `id:"Container"` の外部 component は built-in Container を上書きせず、別 key の `id-collision` エラーカードに落ちる |
 | **cap6** manifest-invalid | `cap6: manifest-invalid (schemaVersion 不正)…` (test:395) | ✅ | `schemaVersion:"999"` → `errorKind:"manifest-invalid"` |
 | **cap6** version-mismatch | `cap6: version-mismatch (engine.react=18)…` (test:407) | ✅ | `engine.react:"18"` → `version-mismatch`、import 未実行 (importSpy 未 call) |
@@ -161,10 +162,10 @@ export {
 
 ## ブラウザ smoke
 
-**未実施**。自動 test (上記 12 ケース) を一次証跡とした。理由:
+**未実施**。自動 test (上記 13 ケース) を一次証跡とした。理由:
 
 - worktree の frontend (5173) を起動すると、開発中の main frontend と port 競合するため。
-- backend (5179) は main 由来コードが常駐しており、`/workspace-assets/puck-components/manifest.json` を probe したところ HTTP 404 (= 本シリーズの route / 配置サンプルが未反映)。実機配信の前提が揃っていない。
+- backend (5179) は main 由来コードが常駐しており、`/workspace-assets/<wsId>/puck-components/manifest.json` (#1415 P2-1 で wsId-scoped URL に変更) を probe したところ HTTP 404 (= 本シリーズの route / 配置サンプルが未反映)。実機配信の前提が揃っていない。
 
 cap1 は **実 vite build 成果物の .mjs を vitest (vite transform) 経由で実 import → render → hooks 動作**まで確認しており、ブラウザ smoke の主目的 (実 artifact が host React で動く) は自動 test で代替できている。実機ブラウザ smoke は本シリーズ最終 PR のリリース確認時に実施する。
 

--- a/docs/spec/dogfood-2026-05-29-puck-external-components.md
+++ b/docs/spec/dogfood-2026-05-29-puck-external-components.md
@@ -160,14 +160,18 @@ export {
 
 ---
 
-## ブラウザ smoke
+## ブラウザ smoke (実機実施済、2026-05-29)
 
-**未実施**。自動 test (上記 13 ケース) を一次証跡とした。理由:
+worktree のコードを **隔離 port** (backend 5189 lockdown / frontend 5183、`VITE_DESIGNER_MCP_PORT=5189`) で起動し、`examples/household-budget` を base にした dogfood workspace (`<dataRoot>/puck-components/` に本部品の manifest + 実 build `.mjs` を配置) を lockdown で開いて Playwright で確認した。main の常駐 backend(5179)/frontend(5173) には触れていない。
 
-- worktree の frontend (5173) を起動すると、開発中の main frontend と port 競合するため。
-- backend (5179) は main 由来コードが常駐しており、`/workspace-assets/<wsId>/puck-components/manifest.json` (#1415 P2-1 で wsId-scoped URL に変更) を probe したところ HTTP 404 (= 本シリーズの route / 配置サンプルが未反映)。実機配信の前提が揃っていない。
+| 確認項目 | 結果 | 証跡 |
+|---|---|---|
+| **P2-1** wsId-scoped 配信 route | ✅ | `GET /workspace-assets/lockdown/puck-components/manifest.json` → HTTP 200、`.../dist/approval-status-bar.mjs` → HTTP 200 (`text/javascript`)。lockdown wsId=`lockdown` で root 解決 |
+| **cap1** ローディング + React 二重化防止 | ✅ | Puck デザイナを開くと外部部品がロードされ、**console error 0 件** (Invalid hook call / load-error なし = host React 同一インスタンス) |
+| **cap2** palette + カテゴリ分け | ✅ | 左パレットに専用カテゴリ **「プロジェクト部品 (外部)」** が出現し、その中に **「(外部) 承認ステータス帯」** が built-in (レイアウト/テキスト/フォーム/データ/業務複合/レイアウト領域) と別カテゴリで表示 (screenshot: `.tmp/screenshots/puck-ext-01-palette.png`) |
+| **cap6** validation / fallback (エラー UX) | ✅ | manifest の `engine.react` を `18` に改変 → reload すると palette item が **「(外部·エラー) 承認ステータス帯」** に変化 (loader が version-mismatch を検出し ExternalComponentErrorCard エントリに置換)。`19` に戻すと正常表示に復帰 (screenshot: `.tmp/screenshots/puck-ext-02-error-card.png`) |
 
-cap1 は **実 vite build 成果物の .mjs を vitest (vite transform) 経由で実 import → render → hooks 動作**まで確認しており、ブラウザ smoke の主目的 (実 artifact が host React で動く) は自動 test で代替できている。実機ブラウザ smoke は本シリーズ最終 PR のリリース確認時に実施する。
+**cap3 (props→fields) / cap4 (slot / 複合部品の配置・保存)** は、Puck の dnd-kit が Playwright MCP の keyboard 抽象では PointerSensor/KeyboardSensor を起動できない (テストハーネス制約、製品欠陥ではない) ため、実ブラウザでの drag 配置までは未実施。これらは本 dogfood の through-line 自動 test (実 vite build 成果物 `.mjs` を実 loader → `mergeExternalComponents` → slot field → composite 展開まで通す 13+ ケース) と frontend 407 件 / backend asset 15 件のユニットテストで決定的に検証済。実機 drag を含む UI 操作確認は、CLI 版 Playwright (keyboard-dnd helper `dragPrimitiveByKeyboard`) を使う E2E spec 化を将来の継続検証として推奨。
 
 ---
 

--- a/docs/spec/dogfood-2026-05-29-puck-external-components.md
+++ b/docs/spec/dogfood-2026-05-29-puck-external-components.md
@@ -1,0 +1,187 @@
+# dogfood レポート — 外部 React Component + 複合部品 通し検証 (2026-05-29)
+
+> **📝 ステータス**: RFC #1405「外部 React Component を Puck に取り込む」シリーズ P-5 (#1413) の dogfood 検証記録。P-1〜P-4 (#1409〜#1412) で実装した基盤を、実際に scaffold → vite build した本物の業務部品で通し検証した。
+
+## 概要
+
+- **対象**: RFC #1405 外部 React Component 読込基盤シリーズ — P-5 (#1413)「外部 component + 複合部品の dogfood 通し検証」
+- **目的**: P-1〜P-4 で個別に実装・テストした基盤を、**実 scaffold → 実 vite build した業務部品**で end-to-end に通し検証し、capability 1〜6 が連続して動作することを確認する
+- **日付**: 2026-05-29
+- **サンプル業務部品**: `approval-status-bar` (承認ステータス帯)
+  - props: `title` (string) / `status` (enum: pending / approved / rejected)
+  - slot: `content` (editable region)
+  - 内部で `React.useState` を使用 (host React と同一インスタンスでないと "Invalid hook call" で落ちる → React 二重化防止の証跡に利用)
+- **検証手段**: 1 ファイルの通し vitest (`frontend/src/puck/__tests__/dogfoodExternalComponents.test.tsx`、12 ケース全 green)。fixture は実 build 成果物 (.mjs) を commit して hermetic 化。
+
+---
+
+## capability 1〜6 逐条検証表
+
+実証跡となる test file: `frontend/src/puck/__tests__/dogfoodExternalComponents.test.tsx`
+
+| capability | 検証手段 (test 名 + file:line) | 結果 | 証跡 |
+|---|---|---|---|
+| **cap1** ローディング + React 二重化防止 | `cap1: 実 build した .mjs を loader で読み込み status=ok…` (test:96) | ✅ | 実 vite build した `.mjs` を `loadExternalComponents({ importImpl })` で実 import → `status:"ok"`。`createElement` で render し、内部 `useState` が throw せず動作 (= host React 同一インスタンス)。status バッジ「承認済み」が描画される |
+| **cap2** palette カテゴリ登録 | `cap2+cap3: mergeExternalComponents で projectExternal…` (test:124) | ✅ | `config.components["approval-status-bar"]` 存在 + label「(外部) 承認ステータス帯」+ `categories.projectExternal.components` に id。base カテゴリ (layout/Container) 不変 |
+| **cap3** props→fields 変換 | 同上 (test:124) | ✅ | `title` (string)→`text` field、`status` (enum)→`select` field で enum options 透過。`defaultProps` に title/status の default 集約 |
+| **cap4** slot field + render-prop | `cap4(slot): content slot が slot field…` (test:163) | ✅ | `fields.content.type==="slot"`、`defaultProps.content===[]`、render-prop 注入で `content()` 内部 (`SLOT_INNER_BODY`) が描画される |
+| **cap4** 複合部品 (#1412) ロード済展開 | `cap4(composite): approval-status-bar を内包する複合部品をロード済…` (test:198) | ✅ | `mergeCompositeComponents` で placeholder が `projectComposite` に登録。`expandCompositePlaceholders` で展開し、内部の `approval-status-bar` が error-card にならず残る。`collectDependencies` が `["approval-status-bar"]` を返す |
+| **cap4** 複合部品 未ロード依存 | `cap4(composite): 未ロードの外部 type を内包…` (test:258) | ✅ | 外部 component を load しない config で展開すると、依存ノードが `compositeErrorTypeName` の error-card 型に差し替わり `missingType==="approval-status-bar"` |
+| **cap5** project scoping | `cap5: 別 workspace の manifest を別 fetchImpl で解決…` (test:316) | ✅ | workspace A (approval-status-bar) と B (billing-summary) を別 fetchImpl で解決。互いの component が混入しない (`projectExternal.components` が各 1 件) |
+| **cap5** id 衝突防御 | `cap5: 既存 built-in id と衝突する外部 component…` (test:355) | ✅ | `id:"Container"` の外部 component は built-in Container を上書きせず、別 key の `id-collision` エラーカードに落ちる |
+| **cap6** manifest-invalid | `cap6: manifest-invalid (schemaVersion 不正)…` (test:395) | ✅ | `schemaVersion:"999"` → `errorKind:"manifest-invalid"` |
+| **cap6** version-mismatch | `cap6: version-mismatch (engine.react=18)…` (test:407) | ✅ | `engine.react:"18"` → `version-mismatch`、import 未実行 (importSpy 未 call) |
+| **cap6** missing-export | `cap6: missing-export (export 名不在)…` (test:425) | ✅ | `export:"NotExist"` を実 .mjs (default のみ export) に向ける → `missing-export` |
+| **cap6** load-error (SSRF) | `cap6: load-error (module が配信範囲外 = SSRF)…` (test:441) | ✅ | `module:"https://evil.example.com/x.mjs"` → import せず `load-error`、detail に「配信範囲外」 |
+| **cap6** エラーカード UX | `cap6: 各 errorKind の entry は…エラーカード化…` (test:462) | ✅ | `mergeExternalComponents` がエラー entry を `ExternalComponentErrorCard` 化、`data-error-kind` + 日本語文言「バージョン不一致」+ 部品名が表示される |
+
+注: errorKind 網羅の細目 (404→空配列 / network throw→空配列 / `../` 脱出 / protocol-relative / 拡張子 allowlist 等) は既存 `frontend/src/puck/externalComponents.test.ts` が網羅済のため、本 dogfood は代表 4 種 (manifest-invalid / version-mismatch / missing-export / load-error(SSRF)) のみを通し検証している。
+
+---
+
+## 実 scaffold → install → build の実行ログ
+
+### 1. scaffold
+
+```
+$ node scripts/scaffold/puck-component.mjs approval-status-bar --out .tmp/dogfood-puck-ext-20260529
+外部 Puck Component を生成します: approval-status-bar (ApprovalStatusBar)
+  生成: .tmp/dogfood-puck-ext-20260529/approval-status-bar/package.json
+  生成: .tmp/dogfood-puck-ext-20260529/approval-status-bar/vite.config.ts
+  生成: .tmp/dogfood-puck-ext-20260529/approval-status-bar/tsconfig.json
+  生成: .tmp/dogfood-puck-ext-20260529/approval-status-bar/src/ApprovalStatusBar.tsx
+  生成: .tmp/dogfood-puck-ext-20260529/approval-status-bar/manifest.json
+  生成: .tmp/dogfood-puck-ext-20260529/approval-status-bar/README.md
+```
+
+生成後、`src/ApprovalStatusBar.tsx` を業務部品 (承認ステータス帯、`status` enum + `title` + `content` slot + `useState`) に編集し、`manifest.json` を props/enum/slot に合わせて編集した。
+
+### 2. install
+
+```
+$ cd .tmp/dogfood-puck-ext-20260529/approval-status-bar && npm install
+added 85 packages, and audited 86 packages in 13s
+```
+
+### 3. build (vite lib build、react/react-dom/@measured/puck external)
+
+```
+$ npm run build
+> @harmony-external/approval-status-bar@0.1.0 build
+> vite build
+
+vite v6.4.2 building for production...
+transforming...
+✓ 1 modules transformed.
+rendering chunks...
+computing gzip size...
+dist/approval-status-bar.mjs  2.37 kB │ gzip: 0.93 kB
+✓ built in 50ms
+```
+
+build 成果物 `dist/approval-status-bar.mjs` の冒頭 (react が bundle されず import = external 化されている証跡):
+
+```js
+import { jsxs as o, jsx as d } from "react/jsx-runtime";
+import * as c from "react";
+...
+export {
+  g as default
+};
+```
+
+`react` / `react/jsx-runtime` が bundle されず bare specifier の `import` として残る = host (Harmony) と React を共有する契約どおり。`.mjs` / `manifest.json` / 出典 `.source.tsx` は `frontend/src/puck/__tests__/fixtures/external-dogfood/` に commit し、test を hermetic 化した (生成プロジェクト本体は `.tmp/` 配下で gitignored)。
+
+---
+
+## 生成・編集済 manifest.json 全文
+
+```json
+{
+  "schemaVersion": "1",
+  "components": [
+    {
+      "id": "approval-status-bar",
+      "label": "承認ステータス帯",
+      "module": "./dist/approval-status-bar.mjs",
+      "export": "default",
+      "version": "0.1.0",
+      "engine": {
+        "react": "19",
+        "puck": "0.20"
+      },
+      "props": [
+        {
+          "name": "title",
+          "type": "string",
+          "label": "見出し",
+          "default": "承認ステータス"
+        },
+        {
+          "name": "status",
+          "type": "enum",
+          "label": "承認状態",
+          "default": "pending",
+          "enum": [
+            { "label": "承認待ち", "value": "pending" },
+            { "label": "承認済み", "value": "approved" },
+            { "label": "却下", "value": "rejected" }
+          ]
+        }
+      ],
+      "slots": [
+        {
+          "name": "content",
+          "label": "本文スロット"
+        }
+      ]
+    }
+  ]
+}
+```
+
+---
+
+## エラー UX サンプル (各 errorKind の detail 文言)
+
+`ExternalComponentErrorCard` (`frontend/src/components/puck/ExternalComponentErrorCard.tsx`) が canvas 上に表示する赤系カードの headline。各 errorKind は以下の日本語文言で可視化される:
+
+| errorKind | headline | detail の例 |
+|---|---|---|
+| `manifest-invalid` | manifest 不正 | `schemaVersion: "1" である必要があります (got "999")` |
+| `version-mismatch` | バージョン不一致 | `react major 18 != host 19` |
+| `missing-export` | export が見つかりません | `export "NotExist" が関数ではありません` |
+| `load-error` | モジュール読込失敗 | `module パスが配信範囲外です (origin 不一致): https://evil.example.com/x.mjs` |
+| `id-collision` | ID 衝突 | `ID 'Container' は既存 component と衝突` |
+| `missing-dependency` | 依存部品が未ロード | `部品 type 'approval-status-bar' が読み込めません (未ロードの外部 component の可能性)` |
+
+カードは部品名 (label) + id + 折り畳み式の detail を持つ。
+
+---
+
+## ブラウザ smoke
+
+**未実施**。自動 test (上記 12 ケース) を一次証跡とした。理由:
+
+- worktree の frontend (5173) を起動すると、開発中の main frontend と port 競合するため。
+- backend (5179) は main 由来コードが常駐しており、`/workspace-assets/puck-components/manifest.json` を probe したところ HTTP 404 (= 本シリーズの route / 配置サンプルが未反映)。実機配信の前提が揃っていない。
+
+cap1 は **実 vite build 成果物の .mjs を vitest (vite transform) 経由で実 import → render → hooks 動作**まで確認しており、ブラウザ smoke の主目的 (実 artifact が host React で動く) は自動 test で代替できている。実機ブラウザ smoke は本シリーズ最終 PR のリリース確認時に実施する。
+
+---
+
+## 発見した制約 / 対応
+
+### F-1: 外部 component を `Component({...})` と直呼びすると hooks が必ず落ちる (test 作法、本 PR で吸収)
+
+通し test 初版で cap1 を `item.Component({ status, title })` と関数直呼びで render しようとしたところ、`useState` が `Invalid hook call` で throw した。これは React component を render ツリー外で関数として呼ぶと dispatcher が null になるためで、**実装バグではなく test 作法の問題**。`createElement(item.Component, props)` で React element として render するよう修正し解消した (本 PR 内、`dogfoodExternalComponents.test.tsx:96`)。
+
+→ 既存 `mergeExternalComponents` の render 経路は `createElement(Component, props)` を使っており正しい。外部 component を利用する側は必ず element 化して render する必要がある旨を本 dogfood で確認した (基盤側の追加対応は不要)。
+
+### F-2: hermetic fixture .mjs の TS 型宣言 (本 PR で吸収)
+
+実 build した `.mjs` を test から動的 import すると `tsc` が TS7016 (implicit any、宣言ファイル無し) を出した。`moduleResolution: bundler` では `*.mjs` import の宣言は `*.d.mts` のため、`approval-status-bar.d.mts` (default: unknown の最小宣言) を fixture に追加して解消した (本 PR 内)。
+
+### 制約まとめ
+
+P-1〜P-4 基盤に対する **修正を要する実装バグは検出されなかった**。capability 1〜6 はすべて実 build 成果物で期待どおり動作した。発見事項 F-1 / F-2 はいずれも本 dogfood test 側の作法・型宣言であり、本 PR 内で対応済 (鉄則 0 / 鉄則 1 遵守、放置・別 ISSUE 化なし)。

--- a/docs/spec/dogfood-2026-05-29-puck-external-components.md
+++ b/docs/spec/dogfood-2026-05-29-puck-external-components.md
@@ -171,7 +171,9 @@ worktree のコードを **隔離 port** (backend 5189 lockdown / frontend 5183�
 | **cap2** palette + カテゴリ分け | ✅ | 左パレットに専用カテゴリ **「プロジェクト部品 (外部)」** が出現し、その中に **「(外部) 承認ステータス帯」** が built-in (レイアウト/テキスト/フォーム/データ/業務複合/レイアウト領域) と別カテゴリで表示 (screenshot: `.tmp/screenshots/puck-ext-01-palette.png`) |
 | **cap6** validation / fallback (エラー UX) | ✅ | manifest の `engine.react` を `18` に改変 → reload すると palette item が **「(外部·エラー) 承認ステータス帯」** に変化 (loader が version-mismatch を検出し ExternalComponentErrorCard エントリに置換)。`19` に戻すと正常表示に復帰 (screenshot: `.tmp/screenshots/puck-ext-02-error-card.png`) |
 
-**cap3 (props→fields) / cap4 (slot / 複合部品の配置・保存)** は、Puck の dnd-kit が Playwright MCP の keyboard 抽象では PointerSensor/KeyboardSensor を起動できない (テストハーネス制約、製品欠陥ではない) ため、実ブラウザでの drag 配置までは未実施。これらは本 dogfood の through-line 自動 test (実 vite build 成果物 `.mjs` を実 loader → `mergeExternalComponents` → slot field → composite 展開まで通す 13+ ケース) と frontend 407 件 / backend asset 15 件のユニットテストで決定的に検証済。実機 drag を含む UI 操作確認は、CLI 版 Playwright (keyboard-dnd helper `dragPrimitiveByKeyboard`) を使う E2E spec 化を将来の継続検証として推奨。
+**cap3 (props→fields) / cap4 (slot / 複合部品の配置・保存)** は、Puck の dnd-kit が Playwright MCP の keyboard 抽象では PointerSensor/KeyboardSensor を起動できない (テストハーネス制約、製品欠陥ではない) ため、実ブラウザでの drag 配置までは未実施。これらは本 dogfood の through-line 自動 test (実 vite build 成果物 `.mjs` を実 loader → `mergeExternalComponents` → slot field → composite 展開まで通す 13+ ケース) と frontend 407 件 / backend asset 15 件のユニットテストで決定的に検証済。
+
+**実機 drag を含む UI 操作の自動検証は #1420 に分離**: 本リポの Puck E2E ハーネスが未完成 (`dragPrimitiveByKeyboard` 等の drag helper がどの spec からも未使用 / GrapesJS 系 `remoteStorage` normalizer が editorKind=puck 画面でも走り生 Puck データを `{pages}` 既定構造で破壊 / `realWorkspace.ts` の backend port 5179 固定で worktree 隔離実行不可 / closed #926 の `puck-editor`・`puck-visual-regression` 移植積み残し) のため、配置→props→slot→複合の実ブラウザ E2E は成立しなかった。これは外部部品機能とは別レイヤのテスト基盤課題のため #1420 で修復し、その後「使用」フローを実機 E2E で再検証する。詳細な状況・root cause・実装設計は #1420 を参照。
 
 ---
 

--- a/docs/spec/multi-editor-puck.md
+++ b/docs/spec/multi-editor-puck.md
@@ -305,6 +305,48 @@ export interface EditorBackend {
 
 定義後、即座に Puck パレットに反映される (再起動不要)。
 
+### 4.5 複合部品 (composite / 再利用部品) — #1412 P-4
+
+設計者が Puck 上で組み合わせた subtree (① built-in primitive / ② JSON カスタム / ③ 外部コード部品の任意混在) を **「複合部品」として保存** し、パレットから再配置できる no-code WYSIWYG authoring 機能。RFC #1405 シリーズ P-4。
+
+#### 方式: expand-on-drop "pattern"
+
+複合部品 = 保存済み Puck subtree。パレットから drop すると subtree が **その場で展開挿入** され、各ノードが個別に WYSIWYG 編集可能になる。複合部品ノードは永続ラッパーとして残さない。これは GrapesJS customBlock の哲学 (HTML 貼付 → 自由編集) と同一であり、「no-code・完全 WYSIWYG」「①②③ を自由に内包可」「再配置」の要件に合致する。
+
+- パレット上は **placeholder component** (`__composite__<id>` 型、カテゴリ「複合部品」= `projectComposite`) として並ぶ。
+- drop 後、`PuckBackend` の `onChange` で複合部品 placeholder を検出 → subtree に展開 → placeholder 自体は消える。
+- 展開処理は **冪等** (placeholder 無し → 同一構造を返す) なので、controlled mode の data prop 更新で無限ループしない。
+
+#### 保存形式 (`puck-components.json` 相乗り)
+
+カスタムコンポーネント定義は `kind` で判別する discriminated union:
+
+- `{ kind: "primitive", id, label, primitive, propsSchema }` — 従来の単発 primitive 派生部品 (§4.4)。
+- `{ kind: "composite", id, label, tree: { content, zones? }, dependencies? }` — 複合部品。
+  - `tree` = 自己完結した Puck Data 断片 (`content` + legacy DropZone 用 `zones` サブセット)。`root` は持たない (展開時はホスト Data の content に merge されるため)。
+  - `dependencies` = subtree が内包する外部 component (#1409 P-1) の type 一覧 (built-in primitive 以外)。capability 6 判定に使う。
+
+`kind` 無しの旧レコードは load 時に `kind: "primitive"` へ正規化する (後方安全)。backend handler / `projectStorage.ts` / broadcast (`puckComponentsChanged`) は無改修。
+
+#### subtree 切出し / 展開の 2 系統
+
+- **legacy DropZone 系** (built-in primitive: Container / Row / Col / Card 等): 子は `data.zones["<itemId>:<zoneName>"]` map に格納される。`extractSubtree` は `<itemId>:zone` キーを再帰的に辿り subtree 内の zones サブセットのみ収集する。
+- **slot 系** (外部 component #1411 P-3 の `{ type: "slot" }` field): 子は当該ノードの props に co-located で格納されるため、ノードごと自然に取り込まれる (追加収集不要)。
+
+#### id 再生成 (核心)
+
+複合部品の再配置・複製では id 衝突を防ぐため、展開時に subtree 全ノードの `props.id` を再生成する。`regeneratePuckDataIds` は `props.id` に加えて **zones map のキー (`<itemId>:<zoneName>`) の itemId 部分も同一 idMap で書き換える** (#1412 P-4 で拡張)。idMap に無い itemId (subtree 外 orphan / リテラルキー) のキーは不変のまま保持する。
+
+#### 依存解決エラー (capability 6)
+
+展開時、subtree 内ノードの type が現在の config に存在しない (= 未ロードの外部 component を内包する複合部品を、その部品が無いワークスペースで配置した) 場合、該当ノードを **`missing-dependency` エラーカード** (`ExternalComponentErrorCard`、日本語「依存部品が未ロード」) に差し替える。展開自体は継続し、設計者に欠落を可視化する。
+
+#### 保存 UI
+
+`<Puck>` の `overrides.headerActions` に「+ 選択を複合部品化」ボタンを差し込む (Puck の `usePuck` は `<Puck>` context 内でのみ利用可のため)。選択中ノードを `usePuck((s) => s.selectedItem)` で取得 → `extractSubtree` → 名前入力ダイアログ (`SaveCompositeDialog`) → `addCustomPuckComponent({ kind: "composite", ... })`。選択無しのときボタンは無効化される。
+
+配置規約 (frontend/AGENTS.md): 切出し / 展開ロジックは `src/editor/puckSubtree.ts` (純粋関数)、保存ダイアログ UI は `src/components/puck/SaveCompositeDialog.tsx`。
+
 ---
 
 ## 5. CSS マッピング層

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,25 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Harmony</title>
+    <!--
+      外部 React Component 読込基盤 (#1409 P-1): runtime ESM import される業務 component
+      の bare specifier (react / react-dom / @measured/puck 等) を host 共有 shim にマップする。
+      host 自身 (/src/main.tsx) の import は Vite が build / pre-bundle 段階で具体 path に
+      解決済みのため bare specifier として browser に届かず、import map の影響を受けない
+      (import map は bare specifier にのみ作用する)。これにより React 二重化を防ぐ。
+      import map は main.tsx の bridge 設置と shim (/harmony-externals/*.mjs) と対で機能する。
+    -->
+    <script type="importmap">
+      {
+        "imports": {
+          "react": "/harmony-externals/react.mjs",
+          "react/jsx-runtime": "/harmony-externals/react-jsx-runtime.mjs",
+          "react-dom": "/harmony-externals/react-dom.mjs",
+          "react-dom/client": "/harmony-externals/react-dom-client.mjs",
+          "@measured/puck": "/harmony-externals/puck.mjs"
+        }
+      }
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/public/harmony-externals/puck.mjs
+++ b/frontend/public/harmony-externals/puck.mjs
@@ -1,0 +1,11 @@
+// harmony-externals/puck.mjs — 外部 component 用 @measured/puck shim (#1409 P-1)
+//
+// host 共有の Puck namespace を re-export。DropZone / Render 等 (slot 連携は P-3 で拡充)。
+const m = (window.__HARMONY_SHARED_DEPS__ ?? {})["@measured/puck"];
+if (!m) {
+  throw new Error(
+    "[harmony-externals] @measured/puck bridge 未設置。main.tsx の bridge 設置を確認してください。",
+  );
+}
+export default m;
+export const { DropZone, Puck, Render } = m;

--- a/frontend/public/harmony-externals/puck.mjs
+++ b/frontend/public/harmony-externals/puck.mjs
@@ -8,4 +8,15 @@ if (!m) {
   );
 }
 export default m;
-export const { DropZone, Puck, Render } = m;
+// @measured/puck の主要 public export を網羅する。
+// host 実体に無い名前は undefined になるが named export 宣言は通る (静的 import 解決のため)。
+// DropZone は P-3 の slot 連携で必須。
+export const {
+  DropZone,
+  Puck,
+  Render,
+  FieldLabel,
+  usePuck,
+  Drawer,
+  AutoField,
+} = m;

--- a/frontend/public/harmony-externals/react-dom-client.mjs
+++ b/frontend/public/harmony-externals/react-dom-client.mjs
@@ -1,0 +1,13 @@
+// harmony-externals/react-dom-client.mjs — 外部 component 用 react-dom/client shim (#1409 P-1)
+//
+// React 19 では createRoot / hydrateRoot は "react-dom/client" に存在する。
+// host が main.tsx で window.__HARMONY_SHARED_DEPS__["react-dom/client"] に設置する。
+// 外部 component が自前で root を作ることは稀だが、import 解決失敗を避けるため shim を用意する。
+const m = (window.__HARMONY_SHARED_DEPS__ ?? {})["react-dom/client"];
+if (!m) {
+  throw new Error(
+    "[harmony-externals] react-dom/client bridge 未設置。main.tsx の bridge 設置を確認してください。",
+  );
+}
+export default m;
+export const { createRoot, hydrateRoot, version } = m;

--- a/frontend/public/harmony-externals/react-dom.mjs
+++ b/frontend/public/harmony-externals/react-dom.mjs
@@ -8,4 +8,17 @@ if (!m) {
   );
 }
 export default m;
-export const { createPortal, flushSync, version } = m;
+// react-dom の安定 public surface を網羅する。
+// host 実体に無い名前は undefined になるが named export 宣言は通る (静的 import 解決のため)。
+export const {
+  createPortal,
+  flushSync,
+  version,
+  preload,
+  preconnect,
+  prefetchDNS,
+  preinit,
+  preinitModule,
+  preloadModule,
+  requestFormReset,
+} = m;

--- a/frontend/public/harmony-externals/react-dom.mjs
+++ b/frontend/public/harmony-externals/react-dom.mjs
@@ -13,6 +13,7 @@ export default m;
 export const {
   createPortal,
   flushSync,
+  useFormStatus,
   version,
   preload,
   preconnect,

--- a/frontend/public/harmony-externals/react-dom.mjs
+++ b/frontend/public/harmony-externals/react-dom.mjs
@@ -1,0 +1,11 @@
+// harmony-externals/react-dom.mjs — 外部 component 用 react-dom shim (#1409 P-1)
+//
+// host 共有の react-dom namespace を re-export。createPortal / flushSync 等。
+const m = (window.__HARMONY_SHARED_DEPS__ ?? {})["react-dom"];
+if (!m) {
+  throw new Error(
+    "[harmony-externals] react-dom bridge 未設置。main.tsx の bridge 設置を確認してください。",
+  );
+}
+export default m;
+export const { createPortal, flushSync, version } = m;

--- a/frontend/public/harmony-externals/react-jsx-runtime.mjs
+++ b/frontend/public/harmony-externals/react-jsx-runtime.mjs
@@ -1,0 +1,11 @@
+// harmony-externals/react-jsx-runtime.mjs — 外部 component 用 react/jsx-runtime shim (#1409 P-1)
+//
+// jsx transform (automatic runtime) が import する "react/jsx-runtime" を host 共有にマップ。
+const m = (window.__HARMONY_SHARED_DEPS__ ?? {})["react/jsx-runtime"];
+if (!m) {
+  throw new Error(
+    "[harmony-externals] react/jsx-runtime bridge 未設置。main.tsx の bridge 設置を確認してください。",
+  );
+}
+export const { jsx, jsxs, Fragment } = m;
+export default m;

--- a/frontend/public/harmony-externals/react.mjs
+++ b/frontend/public/harmony-externals/react.mjs
@@ -35,6 +35,8 @@ export const {
   useDeferredValue,
   useDebugValue,
   use,
+  useActionState,
+  useOptimistic,
   // element / ref API
   createElement,
   cloneElement,

--- a/frontend/public/harmony-externals/react.mjs
+++ b/frontend/public/harmony-externals/react.mjs
@@ -13,7 +13,12 @@ if (!m) {
   );
 }
 export default m;
+// React 19 の安定 public surface を網羅する。
+// host 実体に存在しない名前は undefined になるが、named export 宣言自体は通るため
+// 外部 component の静的 import 解決は成功する (実体は host 19 が供給)。
+// 除外: act (test 専用) / unstable_* / experimental_*。
 export const {
+  // hooks
   useState,
   useEffect,
   useRef,
@@ -28,9 +33,13 @@ export const {
   useInsertionEffect,
   useTransition,
   useDeferredValue,
+  useDebugValue,
+  use,
+  // element / ref API
   createElement,
   cloneElement,
   isValidElement,
+  createRef,
   Children,
   Fragment,
   forwardRef,
@@ -38,9 +47,13 @@ export const {
   createContext,
   lazy,
   Suspense,
+  Profiler,
   startTransition,
+  // class API
   Component,
   PureComponent,
   StrictMode,
+  // misc
+  cache,
   version,
 } = m;

--- a/frontend/public/harmony-externals/react.mjs
+++ b/frontend/public/harmony-externals/react.mjs
@@ -1,0 +1,46 @@
+// harmony-externals/react.mjs — 外部 component 用 React shim (#1409 P-1)
+//
+// host (Harmony frontend) が main.tsx で window.__HARMONY_SHARED_DEPS__ に
+// 設置した React namespace を re-export する。これにより外部 component と host が
+// 同一 React インスタンスを共有し、二重化 (Invalid hook call 等) を防ぐ。
+//
+// import map (index.html) で bare specifier "react" → このファイルにマップする。
+// host 自身の import は Vite が pre-bundle 段階で具体 path に書き換えるため影響しない。
+const m = (window.__HARMONY_SHARED_DEPS__ ?? {})["react"];
+if (!m) {
+  throw new Error(
+    "[harmony-externals] React bridge 未設置 (window.__HARMONY_SHARED_DEPS__['react'])。main.tsx の bridge 設置を確認してください。",
+  );
+}
+export default m;
+export const {
+  useState,
+  useEffect,
+  useRef,
+  useMemo,
+  useCallback,
+  useContext,
+  useReducer,
+  useLayoutEffect,
+  useId,
+  useSyncExternalStore,
+  useImperativeHandle,
+  useInsertionEffect,
+  useTransition,
+  useDeferredValue,
+  createElement,
+  cloneElement,
+  isValidElement,
+  Children,
+  Fragment,
+  forwardRef,
+  memo,
+  createContext,
+  lazy,
+  Suspense,
+  startTransition,
+  Component,
+  PureComponent,
+  StrictMode,
+  version,
+} = m;

--- a/frontend/src/components/puck/ExternalComponentErrorCard.tsx
+++ b/frontend/src/components/puck/ExternalComponentErrorCard.tsx
@@ -1,0 +1,104 @@
+/**
+ * ExternalComponentErrorCard.tsx — 外部 component 読込失敗時のエラーカード (#1409 P-1)。
+ *
+ * 外部 React Component の読込・検証に失敗した entry を Puck canvas 上に赤系カードで表示する。
+ * errorKind 別の日本語メッセージ + 部品 label/id + detail 折り畳みを持つ。
+ *
+ * frontend/AGENTS.md の規約に従い、UI コンポーネントは src/components/puck/ に配置する
+ * (ロジックは src/puck/externalComponents.ts)。
+ */
+
+import { useState } from "react";
+import type { ExternalComponentErrorKind } from "../../puck/externalComponents";
+
+const ERROR_KIND_MESSAGES: Record<ExternalComponentErrorKind, string> = {
+  "load-error": "モジュール読込失敗",
+  "missing-export": "export が見つかりません",
+  "version-mismatch": "バージョン不一致",
+  "manifest-invalid": "manifest 不正",
+};
+
+export interface ExternalComponentErrorCardProps {
+  errorKind: ExternalComponentErrorKind;
+  /** 部品の表示名 */
+  label?: string;
+  /** 部品 id */
+  id?: string;
+  /** 詳細メッセージ (折り畳み表示) */
+  detail?: string;
+}
+
+export function ExternalComponentErrorCard({
+  errorKind,
+  label,
+  id,
+  detail,
+}: ExternalComponentErrorCardProps) {
+  const [showDetail, setShowDetail] = useState(false);
+  const headline = ERROR_KIND_MESSAGES[errorKind] ?? "外部コンポーネントエラー";
+
+  return (
+    <div
+      data-testid="external-component-error-card"
+      data-error-kind={errorKind}
+      style={{
+        border: "1px solid #dc3545",
+        background: "#fff5f5",
+        borderRadius: 6,
+        padding: "12px 14px",
+        color: "#842029",
+        fontSize: 13,
+        lineHeight: 1.5,
+        margin: 4,
+      }}
+    >
+      <div style={{ fontWeight: 600, marginBottom: 4 }}>
+        <span aria-hidden="true" style={{ marginRight: 6 }}>
+          ⚠
+        </span>
+        外部コンポーネント読込エラー: {headline}
+      </div>
+      <div style={{ fontSize: 12, color: "#6c2127" }}>
+        {label ? `部品: ${label}` : null}
+        {id ? ` (id: ${id})` : null}
+      </div>
+      {detail ? (
+        <div style={{ marginTop: 6 }}>
+          <button
+            type="button"
+            onClick={() => setShowDetail((v) => !v)}
+            style={{
+              background: "transparent",
+              border: "1px solid #dc3545",
+              color: "#842029",
+              borderRadius: 4,
+              padding: "2px 8px",
+              fontSize: 11,
+              cursor: "pointer",
+            }}
+          >
+            {showDetail ? "詳細を隠す" : "詳細を表示"}
+          </button>
+          {showDetail ? (
+            <pre
+              style={{
+                marginTop: 6,
+                marginBottom: 0,
+                whiteSpace: "pre-wrap",
+                wordBreak: "break-word",
+                background: "#fff",
+                border: "1px solid #f1c0c4",
+                borderRadius: 4,
+                padding: 8,
+                fontSize: 11,
+                color: "#6c2127",
+              }}
+            >
+              {detail}
+            </pre>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/puck/ExternalComponentErrorCard.tsx
+++ b/frontend/src/components/puck/ExternalComponentErrorCard.tsx
@@ -16,6 +16,7 @@ const ERROR_KIND_MESSAGES: Record<ExternalComponentErrorKind, string> = {
   "missing-export": "export が見つかりません",
   "version-mismatch": "バージョン不一致",
   "manifest-invalid": "manifest 不正",
+  "id-collision": "ID 衝突",
 };
 
 export interface ExternalComponentErrorCardProps {

--- a/frontend/src/components/puck/ExternalComponentErrorCard.tsx
+++ b/frontend/src/components/puck/ExternalComponentErrorCard.tsx
@@ -17,6 +17,7 @@ const ERROR_KIND_MESSAGES: Record<ExternalComponentErrorKind, string> = {
   "version-mismatch": "バージョン不一致",
   "manifest-invalid": "manifest 不正",
   "id-collision": "ID 衝突",
+  "missing-dependency": "依存部品が未ロード",
 };
 
 export interface ExternalComponentErrorCardProps {

--- a/frontend/src/components/puck/RegisterComponentDialog.tsx
+++ b/frontend/src/components/puck/RegisterComponentDialog.tsx
@@ -163,6 +163,7 @@ export function RegisterComponentDialog({ onClose, onSaved }: Props) {
     }
 
     const def: CustomPuckComponentDef = {
+      kind: "primitive",
       id: generateUUID(),
       label: label.trim(),
       primitive,

--- a/frontend/src/components/puck/SaveCompositeDialog.tsx
+++ b/frontend/src/components/puck/SaveCompositeDialog.tsx
@@ -1,0 +1,163 @@
+/**
+ * SaveCompositeDialog.tsx — 選択中ノードを「複合部品」として保存するダイアログ (#1412 P-4)。
+ *
+ * 設計者が Puck 上で選択した subtree を再利用部品 (composite) として保存する。
+ * subtree 切出し (extractSubtree) と依存検出 (collectDependencies) は呼び出し側
+ * (PuckBackend の headerActions ボタン) が済ませ、本ダイアログには切出し済 tree を渡す。
+ *
+ * frontend/AGENTS.md の配置規約に従い、ロジックは editor/puckSubtree.ts、UI は本ファイル
+ * (components/puck/) に置く。
+ */
+
+import { useState } from "react";
+import {
+  addCustomPuckComponent,
+  type CompositePuckComponentDef,
+} from "../../store/puckComponentsStore";
+import type { Subtree } from "../../editor/puckSubtree";
+import { generateUUID } from "../../utils/uuid";
+
+interface Props {
+  /** 切出し済 subtree 断片 (content + zones サブセット)。 */
+  tree: Subtree;
+  /** subtree が内包する依存部品 (built-in 以外の type) の一覧。 */
+  dependencies: string[];
+  onClose: () => void;
+  onSaved?: (def: CompositePuckComponentDef) => void;
+}
+
+export function SaveCompositeDialog({ tree, dependencies, onClose, onSaved }: Props) {
+  const [label, setLabel] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  async function handleSave() {
+    setError(null);
+    if (!label.trim()) {
+      setError("複合部品名は必須です。");
+      return;
+    }
+    const def: CompositePuckComponentDef = {
+      kind: "composite",
+      id: generateUUID(),
+      label: label.trim(),
+      tree: {
+        content: tree.content,
+        ...(tree.zones ? { zones: tree.zones } : {}),
+      },
+      ...(dependencies.length > 0 ? { dependencies } : {}),
+    };
+    setSaving(true);
+    try {
+      await addCustomPuckComponent(def);
+      onSaved?.(def);
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "保存に失敗しました。");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const nodeCount =
+    tree.content.length +
+    (tree.zones
+      ? Object.values(tree.zones).reduce((sum, arr) => sum + arr.length, 0)
+      : 0);
+
+  return (
+    <div
+      data-testid="save-composite-dialog"
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(0,0,0,0.5)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 9999,
+      }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        style={{
+          background: "#fff",
+          borderRadius: 8,
+          padding: 24,
+          minWidth: 420,
+          maxWidth: 560,
+          maxHeight: "90vh",
+          overflowY: "auto",
+          boxShadow: "0 4px 24px rgba(0,0,0,0.2)",
+        }}
+      >
+        <h2 style={{ marginTop: 0, marginBottom: 16, fontSize: 18 }}>
+          選択を複合部品として保存
+        </h2>
+
+        <div style={{ marginBottom: 12 }}>
+          <label style={{ display: "block", fontWeight: "bold", marginBottom: 4 }}>
+            複合部品名 <span style={{ color: "red" }}>*</span>
+          </label>
+          <input
+            type="text"
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            placeholder="例: 検索フォーム一式"
+            style={{ width: "100%", padding: "6px 8px", boxSizing: "border-box" }}
+          />
+        </div>
+
+        <p style={{ fontSize: 13, color: "#555", marginBottom: 8 }}>
+          含まれるノード数: {nodeCount}
+        </p>
+
+        {dependencies.length > 0 && (
+          <div style={{ marginBottom: 12 }}>
+            <span style={{ fontSize: 13, fontWeight: "bold" }}>依存部品:</span>
+            <ul style={{ margin: "4px 0 0", paddingLeft: 20, fontSize: 12, color: "#555" }}>
+              {dependencies.map((dep) => (
+                <li key={dep}>{dep}</li>
+              ))}
+            </ul>
+            <p style={{ fontSize: 11, color: "#888", marginTop: 4 }}>
+              これらの部品が未ロードのワークスペースで配置すると、依存エラーとして表示されます。
+            </p>
+          </div>
+        )}
+
+        {error && (
+          <p style={{ color: "red", fontSize: 13, marginBottom: 12 }}>{error}</p>
+        )}
+
+        <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={saving}
+            style={{ padding: "8px 16px", cursor: "pointer" }}
+          >
+            キャンセル
+          </button>
+          <button
+            type="button"
+            onClick={() => void handleSave()}
+            disabled={saving}
+            style={{
+              padding: "8px 16px",
+              cursor: saving ? "not-allowed" : "pointer",
+              background: "#0070f3",
+              color: "#fff",
+              border: "none",
+              borderRadius: 4,
+            }}
+          >
+            {saving ? "保存中..." : "保存"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/editor/PuckBackend.tsx
+++ b/frontend/src/editor/PuckBackend.tsx
@@ -65,6 +65,7 @@ import {
 import { RegisterComponentDialog } from "../components/puck/RegisterComponentDialog";
 import { SaveCompositeDialog } from "../components/puck/SaveCompositeDialog";
 import { mcpBridge } from "../mcp/mcpBridge";
+import { useWorkspacePath } from "../hooks/useWorkspacePath";
 
 // -----------------------------------------------------------------------
 // 空の Puck Data (新規画面のデフォルト)
@@ -117,6 +118,10 @@ function PuckEditorPane({
   onReady,
   reloadPayload,
 }: PuckEditorPaneProps) {
+  // 現在の active workspace の wsId (#1415 P2-1)。外部 component asset URL を当該 workspace に
+  // scope するために loadExternalComponents に渡す。Designer は /w/:wsId/screen/design/:id 配下で
+  // マウントされるため useParams 経由で取得できる。
+  const { wsId } = useWorkspacePath();
   const [customComponents, setCustomComponents] = useState<CustomPuckComponentDef[]>([]);
   // 複合部品 (#1412 P-4): subtree 再利用部品。同じ puck-components.json に相乗りで永続化。
   const [composites, setComposites] = useState<CompositePuckComponentDef[]>([]);
@@ -185,13 +190,14 @@ function PuckEditorPane({
   // manifest 無し → 空配列 (正常系)。失敗 entry はエラーカードとして config に統合される。
   const reloadExternalComponents = useCallback(async () => {
     try {
-      const loaded = await loadExternalComponents();
+      // wsId scope (#1415 P2-1)。wsId が取れない場合は loader が空配列を返す (外部部品なし扱い)。
+      const loaded = await loadExternalComponents({ wsId });
       setExternalComponents(loaded);
       setRemountKey((k) => k + 1);
     } catch (e) {
       console.warn("[PuckBackend] Failed to load external components:", e);
     }
-  }, []);
+  }, [wsId]);
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect

--- a/frontend/src/editor/PuckBackend.tsx
+++ b/frontend/src/editor/PuckBackend.tsx
@@ -45,6 +45,7 @@ import {
   mergeExternalComponents,
   mergeCompositeComponents,
   compositeErrorTypeName,
+  BUILTIN_PRIMITIVE_TYPE_NAMES,
 } from "../puck/buildConfig";
 import {
   loadExternalComponents,
@@ -74,6 +75,12 @@ const EMPTY_PUCK_DATA: Data = {
   root: { props: {} },
   content: [],
 };
+
+/**
+ * built-in primitive の Puck config type 名集合 (S-3)。
+ * collectDependencies に渡すと外部 component を「built-in 扱いしない」→ 依存として正しく記録される。
+ */
+const BUILTIN_PRIMITIVE_TYPE_SET = new Set<string>(BUILTIN_PRIMITIVE_TYPE_NAMES);
 
 /** unknown を Puck Data に安全にキャストする。失敗したら EMPTY_PUCK_DATA を返す。 */
 function toPuckData(payload: unknown): Data {
@@ -295,11 +302,20 @@ function PuckEditorPane({
   const handleRequestSaveComposite = useCallback(
     (data: Data, rootItemId: string) => {
       const tree = extractSubtree(data, rootItemId);
-      if (!tree) return;
-      const dependencies = collectDependencies(tree, availableTypes);
+      if (!tree) {
+        // S-2: 完全無音失敗を避ける (zones 探索後も見つからない異常系のみここに来る)。
+        console.warn(
+          `[PuckBackend] 複合部品化: rootItemId '${rootItemId}' のノードが content・zones いずれにも見つかりません`,
+        );
+        return;
+      }
+      // S-3: 依存メタは built-in primitive 型のみを「built-in 扱い」にする。
+      // availableTypes (= 全 config 型、外部 component 込み) を渡すと外部 component が
+      // dependencies[] から除外され不完全になるため、BUILTIN_PRIMITIVE_NAMES から集合を作る。
+      const dependencies = collectDependencies(tree, BUILTIN_PRIMITIVE_TYPE_SET);
       setCompositeToSave({ tree, dependencies });
     },
-    [availableTypes],
+    [],
   );
 
   // overrides.headerActions に複合部品化ボタンを差し込む (<Puck> context 内で usePuck 利用可)。

--- a/frontend/src/editor/PuckBackend.tsx
+++ b/frontend/src/editor/PuckBackend.tsx
@@ -18,9 +18,13 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Puck } from "@measured/puck";
-import type { Data } from "@measured/puck";
+import { Puck, createUsePuck } from "@measured/puck";
+import type { Data, Overrides } from "@measured/puck";
 import "@measured/puck/puck.css";
+
+// usePuck は <Puck> context 内 (children / overrides) でのみ利用可 (Puck 0.20)。
+// 複合部品化ボタンを overrides.headerActions に置くために factory で生成する。
+const usePuck = createUsePuck();
 
 // Puck canvas はメイン app DOM 内に描画されるため、GrapesJS の canvas iframe と異なり
 // theme CSS をメイン document.head に直接注入する必要がある (#835)。
@@ -36,7 +40,12 @@ import type {
   PuckRenderEditorProps,
 } from "./EditorBackend";
 import { CssFrameworkProvider } from "../puck/CssFrameworkContext";
-import { buildConfigWithCustomComponents, mergeExternalComponents } from "../puck/buildConfig";
+import {
+  buildConfigWithCustomComponents,
+  mergeExternalComponents,
+  mergeCompositeComponents,
+  compositeErrorTypeName,
+} from "../puck/buildConfig";
 import {
   loadExternalComponents,
   type LoadedExternalComponent,
@@ -44,8 +53,16 @@ import {
 import {
   loadCustomPuckComponents,
   type CustomPuckComponentDef,
+  type CompositePuckComponentDef,
 } from "../store/puckComponentsStore";
+import {
+  expandCompositePlaceholders,
+  extractSubtree,
+  collectDependencies,
+  type ExpandableComposite,
+} from "./puckSubtree";
 import { RegisterComponentDialog } from "../components/puck/RegisterComponentDialog";
+import { SaveCompositeDialog } from "../components/puck/SaveCompositeDialog";
 import { mcpBridge } from "../mcp/mcpBridge";
 
 // -----------------------------------------------------------------------
@@ -94,10 +111,17 @@ function PuckEditorPane({
   reloadPayload,
 }: PuckEditorPaneProps) {
   const [customComponents, setCustomComponents] = useState<CustomPuckComponentDef[]>([]);
+  // 複合部品 (#1412 P-4): subtree 再利用部品。同じ puck-components.json に相乗りで永続化。
+  const [composites, setComposites] = useState<CompositePuckComponentDef[]>([]);
   // 外部 React Component (#1409 P-1): manifest 経由で runtime 読込される業務 component。
   // 初期は空配列、解決後に反映 (ロード中も既存 UI を阻害しない)。
   const [externalComponents, setExternalComponents] = useState<LoadedExternalComponent[]>([]);
   const [showRegisterDialog, setShowRegisterDialog] = useState(false);
+  // 複合部品保存ダイアログ。headerActions ボタンが切出し済 subtree をセットして開く。
+  const [compositeToSave, setCompositeToSave] = useState<{
+    tree: import("./puckSubtree").Subtree;
+    dependencies: string[];
+  } | null>(null);
   // 編集中の Puck Data を state として保持 (カスタムコンポーネント変更による Puck 再マウント時に
   // 未保存編集を保持するため Puck の data prop に渡す値を持続させる)。
   const [currentData, setCurrentData] = useState<Data>(initialData);
@@ -130,7 +154,13 @@ function PuckEditorPane({
   const reloadCustomComponents = useCallback(async () => {
     try {
       const loaded = await loadCustomPuckComponents();
+      // primitive / composite を kind で振り分ける (#1412 P-4)。
       setCustomComponents(loaded);
+      setComposites(
+        loaded.filter(
+          (c): c is CompositePuckComponentDef => c.kind === "composite",
+        ),
+      );
       setRemountKey((k) => k + 1);
     } catch (e) {
       console.warn("[PuckBackend] Failed to load custom puck components:", e);
@@ -211,24 +241,79 @@ function PuckEditorPane({
 
   const config = useMemo(
     () =>
-      mergeExternalComponents(
-        buildConfigWithCustomComponents(customComponents),
-        externalComponents,
+      // config チェーン 3 段: custom (primitive) → external (#1411) → composite (#1412 P-4)。
+      mergeCompositeComponents(
+        mergeExternalComponents(
+          buildConfigWithCustomComponents(customComponents),
+          externalComponents,
+        ),
+        composites,
       ),
-    [customComponents, externalComponents],
+    [customComponents, externalComponents, composites],
+  );
+
+  // 複合部品展開で「依存解決済」判定に使う、現 config に存在する全 type 名集合。
+  const availableTypes = useMemo(
+    () => new Set(Object.keys(config.components)),
+    [config],
+  );
+
+  // 複合部品の展開可能形 (placeholder type 検出 + 依存欠落差し替え先 errorType)。
+  const expandableComposites = useMemo<ExpandableComposite[]>(
+    () =>
+      composites.map((c) => ({
+        id: c.id,
+        label: c.label,
+        tree: { content: c.tree.content, ...(c.tree.zones ? { zones: c.tree.zones } : {}) },
+        errorType: compositeErrorTypeName(c.id),
+      })),
+    [composites],
   );
 
   const handleChange = useCallback(
     (data: Data) => {
-      setCurrentData(data);
-      onChange?.({ payload: data });
+      // 複合部品 placeholder が含まれていればその場で subtree に展開する (expand-on-drop)。
+      // expandCompositePlaceholders は冪等 (placeholder 無し → 同一構造) なので
+      // 展開後 data には placeholder が無く、再度の onChange でループしない。
+      const expanded = expandCompositePlaceholders(
+        data,
+        expandableComposites,
+        availableTypes,
+      );
+      setCurrentData(expanded);
+      onChange?.({ payload: expanded });
     },
-    [onChange],
+    [onChange, expandableComposites, availableTypes],
   );
 
   const handleComponentSaved = useCallback(() => {
     void reloadCustomComponents();
   }, [reloadCustomComponents]);
+
+  // 「選択を複合部品化」要求のハンドラ。CompositeSaveButton (usePuck で selectedItem /
+  // appState.data を取得) から呼ばれ、subtree を切出して保存ダイアログを開く。
+  const handleRequestSaveComposite = useCallback(
+    (data: Data, rootItemId: string) => {
+      const tree = extractSubtree(data, rootItemId);
+      if (!tree) return;
+      const dependencies = collectDependencies(tree, availableTypes);
+      setCompositeToSave({ tree, dependencies });
+    },
+    [availableTypes],
+  );
+
+  // overrides.headerActions に複合部品化ボタンを差し込む (<Puck> context 内で usePuck 利用可)。
+  const overrides = useMemo<Partial<Overrides>>(
+    () => ({
+      headerActions: ({ children }) => (
+        <>
+          <CompositeSaveButton onRequestSave={handleRequestSaveComposite} />
+          {children}
+        </>
+      ),
+    }),
+    [handleRequestSaveComposite],
+  );
 
   return (
     <CssFrameworkProvider value={cssFramework}>
@@ -263,6 +348,7 @@ function PuckEditorPane({
         config={config}
         data={currentData}
         onChange={handleChange}
+        overrides={overrides}
         // ヘッダーのデフォルト "Publish" ボタンは PuckBackend では使わない。
         // 明示保存式 (#683) なので onPublish は no-op。
         onPublish={() => { /* no-op: 明示保存は Designer.tsx の handleSave 経由 */ }}
@@ -274,7 +360,71 @@ function PuckEditorPane({
           onSaved={handleComponentSaved}
         />
       )}
+
+      {compositeToSave && (
+        <SaveCompositeDialog
+          tree={compositeToSave.tree}
+          dependencies={compositeToSave.dependencies}
+          onClose={() => setCompositeToSave(null)}
+          onSaved={() => {
+            setCompositeToSave(null);
+            void reloadCustomComponents();
+          }}
+        />
+      )}
     </CssFrameworkProvider>
+  );
+}
+
+// -----------------------------------------------------------------------
+// CompositeSaveButton — <Puck> context 内で selectedItem を読む複合部品化ボタン。
+//   usePuck は <Puck> の children / overrides でのみ利用可 (Puck 0.20) のため、
+//   overrides.headerActions から render される本コンポーネント内で利用する。
+// -----------------------------------------------------------------------
+
+interface CompositeSaveButtonProps {
+  /** 選択中ノードを root とする subtree 切出し + 保存ダイアログ起動を要求する。 */
+  onRequestSave: (data: Data, rootItemId: string) => void;
+}
+
+function CompositeSaveButton({ onRequestSave }: CompositeSaveButtonProps) {
+  // 選択中 item と現在の Data を granular selector で購読する (無関係 state 変化で再描画しない)。
+  const selectedItem = usePuck((s) => s.selectedItem);
+  const data = usePuck((s) => s.appState.data);
+
+  const selectedId =
+    selectedItem && typeof selectedItem.props?.id === "string"
+      ? selectedItem.props.id
+      : null;
+  const disabled = !selectedId;
+
+  return (
+    <button
+      type="button"
+      data-testid="save-composite-button"
+      disabled={disabled}
+      title={
+        disabled
+          ? "キャンバス上のノードを選択すると複合部品化できます"
+          : "選択中ノードを複合部品として保存"
+      }
+      onClick={() => {
+        if (!selectedId) return;
+        onRequestSave(data, selectedId);
+      }}
+      style={{
+        padding: "6px 12px",
+        background: disabled ? "#9bb7e0" : "#0070f3",
+        color: "#fff",
+        border: "none",
+        borderRadius: 4,
+        cursor: disabled ? "not-allowed" : "pointer",
+        fontSize: 13,
+        marginRight: 8,
+      }}
+    >
+      + 選択を複合部品化
+    </button>
   );
 }
 

--- a/frontend/src/editor/PuckBackend.tsx
+++ b/frontend/src/editor/PuckBackend.tsx
@@ -36,7 +36,11 @@ import type {
   PuckRenderEditorProps,
 } from "./EditorBackend";
 import { CssFrameworkProvider } from "../puck/CssFrameworkContext";
-import { buildConfigWithCustomComponents } from "../puck/buildConfig";
+import { buildConfigWithCustomComponents, mergeExternalComponents } from "../puck/buildConfig";
+import {
+  loadExternalComponents,
+  type LoadedExternalComponent,
+} from "../puck/externalComponents";
 import {
   loadCustomPuckComponents,
   type CustomPuckComponentDef,
@@ -90,6 +94,9 @@ function PuckEditorPane({
   reloadPayload,
 }: PuckEditorPaneProps) {
   const [customComponents, setCustomComponents] = useState<CustomPuckComponentDef[]>([]);
+  // 外部 React Component (#1409 P-1): manifest 経由で runtime 読込される業務 component。
+  // 初期は空配列、解決後に反映 (ロード中も既存 UI を阻害しない)。
+  const [externalComponents, setExternalComponents] = useState<LoadedExternalComponent[]>([]);
   const [showRegisterDialog, setShowRegisterDialog] = useState(false);
   // 編集中の Puck Data を state として保持 (カスタムコンポーネント変更による Puck 再マウント時に
   // 未保存編集を保持するため Puck の data prop に渡す値を持続させる)。
@@ -136,6 +143,23 @@ function PuckEditorPane({
     // eslint-disable-next-line react-hooks/set-state-in-effect
     void reloadCustomComponents();
   }, [reloadCustomComponents]);
+
+  // 外部 React Component (#1409 P-1) を manifest 経由で読み込む。
+  // manifest 無し → 空配列 (正常系)。失敗 entry はエラーカードとして config に統合される。
+  const reloadExternalComponents = useCallback(async () => {
+    try {
+      const loaded = await loadExternalComponents();
+      setExternalComponents(loaded);
+      setRemountKey((k) => k + 1);
+    } catch (e) {
+      console.warn("[PuckBackend] Failed to load external components:", e);
+    }
+  }, []);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void reloadExternalComponents();
+  }, [reloadExternalComponents]);
 
   // mcpBridge broadcast: 別タブでカスタムコンポーネントが変わったら再ロード
   useEffect(() => {
@@ -186,8 +210,12 @@ function PuckEditorPane({
   }, [onReady]);
 
   const config = useMemo(
-    () => buildConfigWithCustomComponents(customComponents),
-    [customComponents],
+    () =>
+      mergeExternalComponents(
+        buildConfigWithCustomComponents(customComponents),
+        externalComponents,
+      ),
+    [customComponents, externalComponents],
   );
 
   const handleChange = useCallback(

--- a/frontend/src/editor/puckIdRegeneration.test.ts
+++ b/frontend/src/editor/puckIdRegeneration.test.ts
@@ -127,6 +127,84 @@ describe("regeneratePuckDataIds", () => {
     expect((result.content[0] as any).props.id).toBeUndefined();
   });
 
+  // ── zones キーの itemId 同期 (#1412 P-4) ──────────────────────────────────
+
+  it("content の親ノード id 再生成と zones キーの itemId が同期する", () => {
+    // 親ノードが content にあり、その DropZone (`<親id>:content`) に子がある構成。
+    const data = puckData({
+      root: { props: {} },
+      content: [{ type: "Card", props: { id: "card-old" } }],
+      zones: {
+        "card-old:content": [{ type: "Heading", props: { id: "head-old" } }],
+      },
+    });
+
+    const result = regeneratePuckDataIds(data);
+
+    const newCardId = result.content[0].props.id;
+    expect(newCardId).toBe("uuid-1");
+    // zones キーの itemId 部分が新 card id に書き換わっている (zoneName は保持)。
+    expect(result.zones).toHaveProperty(`${newCardId}:content`);
+    expect(result.zones).not.toHaveProperty("card-old:content");
+    // 子ノードの props.id も再生成されている。
+    expect(result.zones?.[`${newCardId}:content`][0].props.id).toBe("uuid-2");
+  });
+
+  it("ネストした DropZone の itemId も再帰的に同期する", () => {
+    const data = puckData({
+      root: { props: {} },
+      content: [{ type: "Card", props: { id: "outer" } }],
+      zones: {
+        "outer:content": [{ type: "Row", props: { id: "inner" } }],
+        "inner:content": [{ type: "Text", props: { id: "leaf" } }],
+      },
+    });
+
+    const result = regeneratePuckDataIds(data);
+
+    const outerNew = result.content[0].props.id;
+    const innerNew = result.zones?.[`${outerNew}:content`][0].props.id;
+    expect(typeof innerNew).toBe("string");
+    // inner の DropZone キーも新 inner id に同期している。
+    expect(result.zones).toHaveProperty(`${innerNew}:content`);
+    expect(result.zones).not.toHaveProperty("inner:content");
+  });
+
+  it("idMap に無い itemId の zones キー (orphan / リテラル) はそのまま保持される", () => {
+    // content / zones value に "main" / "aside" を props.id とするノードが無いため、
+    // これらのリテラルキーは idMap に載らず不変のまま (後方互換)。
+    const data = puckData({
+      root: { props: {} },
+      content: [],
+      zones: {
+        "main:zone": [{ type: "Card", props: { id: "x" } }],
+        aside: [{ type: "Field", props: { id: "y" } }],
+      },
+    });
+
+    const result = regeneratePuckDataIds(data);
+
+    expect(result.zones).toHaveProperty("main:zone");
+    expect(result.zones).toHaveProperty("aside");
+    // value 内ノードの props.id は再生成される。
+    expect(result.zones?.["main:zone"][0].props.id).not.toBe("x");
+  });
+
+  it("zoneName に ':' が含まれても最初の ':' でのみ分割しキーを保持する", () => {
+    const data = puckData({
+      root: { props: {} },
+      content: [{ type: "Card", props: { id: "p" } }],
+      zones: {
+        "p:zone:weird": [{ type: "Text", props: { id: "c" } }],
+      },
+    });
+
+    const result = regeneratePuckDataIds(data);
+
+    const newP = result.content[0].props.id;
+    expect(result.zones).toHaveProperty(`${newP}:zone:weird`);
+  });
+
   it("props.id が数値型等 string 以外でも content 直下なら UUID に置換される (regenerateItem は id キーを無条件置換)", () => {
     // regenerateContent は regenerateItem を直接呼ぶため isComponentItem ガードを経由しない。
     // regenerateItem は key === "id" を無条件で nextId() に渡すので、数値 id も UUID に置換される。

--- a/frontend/src/editor/puckIdRegeneration.ts
+++ b/frontend/src/editor/puckIdRegeneration.ts
@@ -59,20 +59,52 @@ function regenerateContent(
   return content.map((item) => regenerateItem(item as ComponentItem, idMap)) as Data["content"];
 }
 
+/**
+ * legacy DropZone の zones map キー (`<itemId>:<zoneName>`) の itemId 部分を
+ * idMap で書き換える (#1412 P-4)。
+ *
+ * - キーを最初の ":" で分解し、itemId 部分が idMap に登録済 (= subtree 内で id 再生成された
+ *   親ノード) なら新 itemId に置換する。
+ * - idMap に未登録の itemId (= subtree 外を指す orphan key、または既存の "main:zone" のような
+ *   リテラルキー) はそのまま保持する。これにより既存 data の zones キーは破壊されない。
+ * - zoneName 部分に ":" が含まれても、最初の ":" のみで分割するため保持される。
+ */
+function regenerateZoneKey(zoneKey: string, idMap: Map<string, string>): string {
+  const sepIdx = zoneKey.indexOf(":");
+  if (sepIdx < 0) return zoneKey; // ":" 無しキーはそのまま
+  const itemId = zoneKey.slice(0, sepIdx);
+  const zoneName = zoneKey.slice(sepIdx + 1);
+  const newItemId = idMap.get(itemId);
+  if (!newItemId) return zoneKey; // subtree 外 / リテラルキーは不変
+  return `${newItemId}:${zoneName}`;
+}
+
 export function regeneratePuckDataIds(data: Data): Data {
   const idMap = new Map<string, string>();
-  const zones = data.zones
+  // 先に content / zones の各 value を処理して idMap (旧 itemId → 新 itemId) を充填する。
+  // zones の value 配列内ノードの props.id も再生成され idMap に載るため、
+  // ネストした DropZone の親 itemId もこの段階で idMap に揃う。
+  const newContent = regenerateContent(data.content, idMap);
+  const regeneratedZoneEntries = data.zones
+    ? Object.entries(data.zones).map(
+        ([zoneId, content]) =>
+          [zoneId, regenerateContent(content, idMap)] as const,
+      )
+    : undefined;
+
+  // value 処理後の idMap を使って zones キーの itemId 部分を書き換える。
+  const zones = regeneratedZoneEntries
     ? Object.fromEntries(
-      Object.entries(data.zones).map(([zoneId, content]) => [
-        zoneId,
-        regenerateContent(content, idMap),
-      ]),
-    )
+        regeneratedZoneEntries.map(([zoneId, content]) => [
+          regenerateZoneKey(zoneId, idMap),
+          content,
+        ]),
+      )
     : undefined;
 
   return {
     ...data,
-    content: regenerateContent(data.content, idMap),
+    content: newContent,
     ...(zones ? { zones } : {}),
   };
 }

--- a/frontend/src/editor/puckSubtree.test.ts
+++ b/frontend/src/editor/puckSubtree.test.ts
@@ -602,4 +602,83 @@ describe("expandCompositePlaceholders", () => {
     expect(inner.type).toBe("__composite_error__comp-slot");
     expect(inner.props.missingType).toBe("InnerExtWidget");
   });
+
+  // --- #1415 P2-4: slot props に drop された複合部品 placeholder も展開する ---
+  it("slot props 内に drop された複合部品 placeholder が subtree に展開され transient placeholder が残らない", () => {
+    // 外部 component ExtCard の slot (props.body) に comp-a の placeholder を drop した状態の data。
+    const d = data({
+      root: { props: {} },
+      content: [
+        {
+          type: "ExtCard",
+          props: {
+            id: "card-host",
+            body: [
+              { type: "Paragraph", props: { id: "p-keep" } },
+              { type: compositeTypeName("comp-a"), props: { id: "ph-in-slot" } },
+            ],
+          },
+        },
+      ],
+    });
+    const availableWithExt = new Set([
+      "ExtCard",
+      "Card",
+      "Heading",
+      "Paragraph",
+      compositeTypeName("comp-a"),
+    ]);
+
+    const result = expandCompositePlaceholders(d, [composite], availableWithExt);
+
+    // host ノード (ExtCard) は残る。
+    const host = result.content.find(
+      (i) => (i as { type: string }).type === "ExtCard",
+    ) as { props: { body: { type: string; props: { id: string } }[] } };
+    expect(host).toBeDefined();
+    const slotTypes = host.props.body.map((n) => n.type);
+    // slot 内の placeholder は展開され Card に置き換わり、transient placeholder は消える。
+    expect(slotTypes).toContain("Card");
+    expect(slotTypes).not.toContain(compositeTypeName("comp-a"));
+    // slot 内の既存ノードは保持。
+    expect(slotTypes).toContain("Paragraph");
+    // 展開された subtree の nested zones (Card:content の Heading) が merge される。
+    const zoneKeys = Object.keys(result.zones ?? {});
+    expect(zoneKeys.some((k) => k.endsWith(":content"))).toBe(true);
+    // 元の subtree id は再生成され残らない & 全 id 一意。
+    const slotIds = host.props.body.map((n) => n.props.id);
+    expect(slotIds).not.toContain("card-orig");
+    const allResultIds = [...allIds(result), ...slotIds];
+    expect(new Set(allResultIds).size).toBe(allResultIds.length);
+  });
+
+  it("slot props のみに placeholder がある場合でも早期 return せず展開される (再適用で冪等)", () => {
+    const d = data({
+      root: { props: {} },
+      content: [
+        {
+          type: "ExtCard",
+          props: {
+            id: "card-host",
+            body: [{ type: compositeTypeName("comp-a"), props: { id: "ph-in-slot" } }],
+          },
+        },
+      ],
+    });
+    const availableWithExt = new Set([
+      "ExtCard",
+      "Card",
+      "Heading",
+      compositeTypeName("comp-a"),
+    ]);
+
+    const first = expandCompositePlaceholders(d, [composite], availableWithExt);
+    const firstHost = first.content[0] as { props: { body: { type: string }[] } };
+    expect(firstHost.props.body.map((n) => n.type)).not.toContain(
+      compositeTypeName("comp-a"),
+    );
+    // 再適用すると placeholder が無いため参照透過に同一構造を返す (冪等)。
+    const second = expandCompositePlaceholders(first, [composite], availableWithExt);
+    expect(second).toBe(first);
+  });
 });

--- a/frontend/src/editor/puckSubtree.test.ts
+++ b/frontend/src/editor/puckSubtree.test.ts
@@ -105,6 +105,127 @@ describe("extractSubtree", () => {
     expect(extractSubtree(d, "missing")).toBeNull();
   });
 
+  // --- #1415 P2-3: slot 子孫ノードが持つ legacy DropZone zones も収集する ---
+  it("slot 系: slot 内の built-in が持つ legacy DropZone zones も subtree に保持する", () => {
+    // root (外部 slot 部品) の props.body に、自前 DropZone (zones) を持つ built-in Card を
+    // 内包するケース。slot 子ノード自体は props 同居で取り込まれるが、その Card が所有する
+    // "inner-card:content" は zones map に別格納されるため別途収集が必要。
+    const d = data({
+      root: { props: {} },
+      content: [
+        {
+          type: "ExtSection",
+          props: {
+            id: "sec-1",
+            body: [{ type: "Card", props: { id: "inner-card" } }], // slot prop 内 built-in
+          },
+        },
+        { type: "Heading", props: { id: "other" } }, // subtree 外
+      ],
+      zones: {
+        // slot 子 (inner-card) が所有する legacy DropZone。
+        "inner-card:content": [{ type: "Paragraph", props: { id: "p-inner" } }],
+        "other:content": [{ type: "Text", props: { id: "t-other" } }], // 切り出さない
+      },
+    });
+
+    const sub = extractSubtree(d, "sec-1");
+    expect(sub).not.toBeNull();
+    expect(sub!.content).toHaveLength(1);
+    // slot 子孫の zones が脱落せず収集されている。
+    expect(sub!.zones).toHaveProperty("inner-card:content");
+    // subtree 外の zones は含めない。
+    expect(sub!.zones).not.toHaveProperty("other:content");
+  });
+
+  it("slot 系: slot 子孫の DropZone がさらに slot 部品を含む場合も再帰収集する", () => {
+    // ExtSection (root) → slot body 内 Card → Card の DropZone 内 ExtWidget → その slot 内 Card
+    // という多段ネストでも全 zones が漏れず収集されることを検証。
+    const d = data({
+      root: { props: {} },
+      content: [
+        {
+          type: "ExtSection",
+          props: {
+            id: "sec-1",
+            body: [{ type: "Card", props: { id: "card-a" } }],
+          },
+        },
+      ],
+      zones: {
+        "card-a:content": [
+          {
+            type: "ExtWidget",
+            props: {
+              id: "w-1",
+              // slot 内にさらに legacy DropZone を持つ Card。
+              slot: [{ type: "Card", props: { id: "card-b" } }],
+            },
+          },
+        ],
+        "card-b:content": [{ type: "Text", props: { id: "leaf" } }],
+      },
+    });
+
+    const sub = extractSubtree(d, "sec-1");
+    expect(sub!.zones).toHaveProperty("card-a:content");
+    // slot 子孫 (card-b) の DropZone も収集される (zone 子の slot 走査経由)。
+    expect(sub!.zones).toHaveProperty("card-b:content");
+  });
+
+  it("slot 系: save (extract) → expand round-trip で slot 子孫の nested 内容が保持される (#1415 P2-3)", () => {
+    const d = data({
+      root: { props: {} },
+      content: [
+        {
+          type: "ExtSection",
+          props: {
+            id: "sec-1",
+            body: [{ type: "Card", props: { id: "inner-card" } }],
+          },
+        },
+      ],
+      zones: {
+        "inner-card:content": [{ type: "Paragraph", props: { id: "p-inner" } }],
+      },
+    });
+
+    const sub = extractSubtree(d, "sec-1");
+    expect(sub!.zones).toHaveProperty("inner-card:content");
+
+    // この subtree を複合部品として展開する。
+    const composite: ExpandableComposite = {
+      id: "comp-sec",
+      label: "セクション複合",
+      tree: sub!,
+      errorType: "__composite_error__comp-sec",
+    };
+    const available = new Set([
+      "ExtSection",
+      "Card",
+      "Paragraph",
+      compositeTypeName("comp-sec"),
+    ]);
+    const placeholder = data({
+      root: { props: {} },
+      content: [{ type: compositeTypeName("comp-sec"), props: { id: "ph" } }],
+    });
+
+    const result = expandCompositePlaceholders(placeholder, [composite], available);
+
+    // root (ExtSection) が展開され、その slot 子 Card が保持されている。
+    const root = result.content.find(
+      (i) => (i as { type: string }).type === "ExtSection",
+    ) as { props: { body: { type: string }[] } };
+    expect(root).toBeDefined();
+    expect(root.props.body[0].type).toBe("Card");
+    // Card の nested DropZone (id 再生成済) の中身 Paragraph が脱落していない。
+    const paragraphZone = Object.values(result.zones ?? {}).find((zc) =>
+      zc.some((n) => (n as { type: string }).type === "Paragraph"),
+    );
+    expect(paragraphZone).toBeDefined();
+  });
+
   it("zones 内のみに存在する rootItemId を切り出せる (S-2)", () => {
     // DropZone 内のノードを選択して複合部品化するケース。content 直下には無い。
     const d = data({

--- a/frontend/src/editor/puckSubtree.test.ts
+++ b/frontend/src/editor/puckSubtree.test.ts
@@ -1,0 +1,242 @@
+/**
+ * puckSubtree.test.ts — 複合部品 subtree 切出し / 展開ユーティリティの単体テスト (#1412 P-4)。
+ *
+ * - extractSubtree: DropZone 系 (zones map) / slot 系 (props 同居) の両系統。
+ * - expandCompositePlaceholders: 展開 / id 一意性 / 冪等 / missing-dependency error-card 差替。
+ */
+
+import { describe, it, expect } from "vitest";
+import type { Data } from "@measured/puck";
+import {
+  extractSubtree,
+  expandCompositePlaceholders,
+  collectSubtreeTypes,
+  collectDependencies,
+  compositeTypeName,
+  type ExpandableComposite,
+  type Subtree,
+} from "./puckSubtree";
+
+function data(d: unknown): Data {
+  return d as Data;
+}
+
+// content / zones 全ノードの props.id を集める。
+function allIds(d: Data): string[] {
+  const ids: string[] = [];
+  for (const item of d.content) {
+    const id = (item as { props?: { id?: unknown } }).props?.id;
+    if (typeof id === "string") ids.push(id);
+  }
+  if (d.zones) {
+    for (const zc of Object.values(d.zones)) {
+      for (const item of zc) {
+        const id = (item as { props?: { id?: unknown } }).props?.id;
+        if (typeof id === "string") ids.push(id);
+      }
+    }
+  }
+  return ids;
+}
+
+describe("extractSubtree", () => {
+  it("DropZone 系: ルートノード + 紐づく zones サブセットを切り出す", () => {
+    const d = data({
+      root: { props: {} },
+      content: [
+        { type: "Card", props: { id: "card-1" } },
+        { type: "Heading", props: { id: "other" } }, // subtree 外
+      ],
+      zones: {
+        "card-1:content": [{ type: "Paragraph", props: { id: "p-1" } }],
+        "other:content": [{ type: "Text", props: { id: "t-other" } }], // 切り出さない
+      },
+    });
+
+    const sub = extractSubtree(d, "card-1");
+    expect(sub).not.toBeNull();
+    expect(sub!.content).toHaveLength(1);
+    expect((sub!.content[0] as { props: { id: string } }).props.id).toBe("card-1");
+    expect(sub!.zones).toHaveProperty("card-1:content");
+    // subtree 外の zones は含めない。
+    expect(sub!.zones).not.toHaveProperty("other:content");
+  });
+
+  it("DropZone 系: ネストした DropZone も再帰的に収集する", () => {
+    const d = data({
+      root: { props: {} },
+      content: [{ type: "Card", props: { id: "outer" } }],
+      zones: {
+        "outer:content": [{ type: "Row", props: { id: "inner" } }],
+        "inner:content": [{ type: "Text", props: { id: "leaf" } }],
+      },
+    });
+
+    const sub = extractSubtree(d, "outer");
+    expect(sub!.zones).toHaveProperty("outer:content");
+    expect(sub!.zones).toHaveProperty("inner:content");
+  });
+
+  it("slot 系: 子が props 同居なのでルートノードを含めれば自然に取り込まれる", () => {
+    const d = data({
+      root: { props: {} },
+      content: [
+        {
+          type: "ExtWidget",
+          props: {
+            id: "w-1",
+            body: [{ type: "Heading", props: { id: "h-1" } }], // slot prop
+          },
+        },
+      ],
+    });
+
+    const sub = extractSubtree(d, "w-1");
+    expect(sub!.content).toHaveLength(1);
+    // slot 中身は content ノードに co-located のまま含まれる。
+    const props = (sub!.content[0] as { props: Record<string, unknown> }).props;
+    expect(props.body).toBeDefined();
+    // DropZone を使っていないので zones は付かない。
+    expect(sub!.zones).toBeUndefined();
+  });
+
+  it("存在しない rootItemId は null を返す", () => {
+    const d = data({ root: { props: {} }, content: [] });
+    expect(extractSubtree(d, "missing")).toBeNull();
+  });
+});
+
+describe("collectSubtreeTypes / collectDependencies", () => {
+  const tree: Subtree = {
+    content: [{ type: "Card", props: { id: "c" } }],
+    zones: {
+      "c:content": [
+        { type: "Heading", props: { id: "h" } },
+        { type: "ExtWidget", props: { id: "w" } },
+      ],
+    },
+  };
+
+  it("content + zones の全 type を列挙する", () => {
+    const types = collectSubtreeTypes(tree);
+    expect(types.sort()).toEqual(["Card", "ExtWidget", "Heading"]);
+  });
+
+  it("built-in 以外の type のみ dependencies として返す", () => {
+    const builtins = new Set(["Card", "Heading"]);
+    expect(collectDependencies(tree, builtins)).toEqual(["ExtWidget"]);
+  });
+});
+
+describe("expandCompositePlaceholders", () => {
+  const composite: ExpandableComposite = {
+    id: "comp-a",
+    label: "複合A",
+    tree: {
+      content: [{ type: "Card", props: { id: "card-orig" } }],
+      zones: {
+        "card-orig:content": [{ type: "Heading", props: { id: "head-orig" } }],
+      },
+    },
+    errorType: "__composite_error__comp-a",
+  };
+  const available = new Set(["Card", "Heading", compositeTypeName("comp-a")]);
+
+  it("placeholder を subtree に展開し placeholder 自体は消える", () => {
+    const d = data({
+      root: { props: {} },
+      content: [
+        { type: "Paragraph", props: { id: "p-keep" } },
+        { type: compositeTypeName("comp-a"), props: { id: "ph-1" } },
+      ],
+    });
+
+    const result = expandCompositePlaceholders(d, [composite], available);
+
+    const types = result.content.map((i) => (i as { type: string }).type);
+    // placeholder は消え、subtree の Card が展開挿入される。
+    expect(types).toContain("Card");
+    expect(types).not.toContain(compositeTypeName("comp-a"));
+    // 既存ノードは保持。
+    expect(types).toContain("Paragraph");
+    // subtree の zones が merge される (id は再生成済なのでキーは変わる)。
+    const zoneKeys = Object.keys(result.zones ?? {});
+    expect(zoneKeys.some((k) => k.endsWith(":content"))).toBe(true);
+  });
+
+  it("展開後ノードの id は再生成され元の id と異なり一意になる", () => {
+    const d = data({
+      root: { props: {} },
+      content: [{ type: compositeTypeName("comp-a"), props: { id: "ph-1" } }],
+    });
+
+    const result = expandCompositePlaceholders(d, [composite], available);
+    const ids = allIds(result);
+    // 元の "card-orig" / "head-orig" は残っていない。
+    expect(ids).not.toContain("card-orig");
+    expect(ids).not.toContain("head-orig");
+    // 全 id が一意。
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("2 回連続 drop しても id 衝突しない (展開ごとに別 id)", () => {
+    const d = data({
+      root: { props: {} },
+      content: [
+        { type: compositeTypeName("comp-a"), props: { id: "ph-1" } },
+        { type: compositeTypeName("comp-a"), props: { id: "ph-2" } },
+      ],
+    });
+
+    const result = expandCompositePlaceholders(d, [composite], available);
+    const ids = allIds(result);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("冪等: placeholder が無ければ同一構造をそのまま返す", () => {
+    const d = data({
+      root: { props: {} },
+      content: [{ type: "Paragraph", props: { id: "p-1" } }],
+    });
+
+    const result = expandCompositePlaceholders(d, [composite], available);
+    expect(result).toBe(d); // 参照透過 (早期 return)
+  });
+
+  it("missing-dependency: 依存 type が availableTypes に無いノードは error-card 型に差し替える", () => {
+    const compositeWithExt: ExpandableComposite = {
+      id: "comp-ext",
+      label: "外部依存複合",
+      tree: {
+        content: [{ type: "Card", props: { id: "card-x" } }],
+        zones: {
+          "card-x:content": [{ type: "ExtWidget", props: { id: "w-x" } }],
+        },
+      },
+      errorType: "__composite_error__comp-ext",
+    };
+    // ExtWidget は available に無い (= 未ロード外部 component)。
+    const availableNoExt = new Set([
+      "Card",
+      "Heading",
+      compositeTypeName("comp-ext"),
+      "__composite_error__comp-ext",
+    ]);
+    const d = data({
+      root: { props: {} },
+      content: [{ type: compositeTypeName("comp-ext"), props: { id: "ph" } }],
+    });
+
+    const result = expandCompositePlaceholders(d, [compositeWithExt], availableNoExt);
+
+    // zones 内の ExtWidget ノードが error-card 型に差し替わっている。
+    const zoneNodes = Object.values(result.zones ?? {}).flat();
+    const errorNode = zoneNodes.find(
+      (n) => (n as { type: string }).type === "__composite_error__comp-ext",
+    );
+    expect(errorNode).toBeDefined();
+    expect(
+      (errorNode as { props: { missingType?: string } }).props.missingType,
+    ).toBe("ExtWidget");
+  });
+});

--- a/frontend/src/editor/puckSubtree.test.ts
+++ b/frontend/src/editor/puckSubtree.test.ts
@@ -104,6 +104,45 @@ describe("extractSubtree", () => {
     const d = data({ root: { props: {} }, content: [] });
     expect(extractSubtree(d, "missing")).toBeNull();
   });
+
+  it("zones 内のみに存在する rootItemId を切り出せる (S-2)", () => {
+    // DropZone 内のノードを選択して複合部品化するケース。content 直下には無い。
+    const d = data({
+      root: { props: {} },
+      content: [{ type: "Container", props: { id: "container-1" } }],
+      zones: {
+        "container-1:content": [
+          { type: "Card", props: { id: "card-in-zone" } },
+          { type: "Heading", props: { id: "h-sibling" } }, // subtree 外
+        ],
+        "card-in-zone:content": [{ type: "Paragraph", props: { id: "p-1" } }],
+        "h-sibling:content": [{ type: "Text", props: { id: "t-other" } }], // 切り出さない
+      },
+    });
+
+    const sub = extractSubtree(d, "card-in-zone");
+    expect(sub).not.toBeNull();
+    expect(sub!.content).toHaveLength(1);
+    expect((sub!.content[0] as { props: { id: string } }).props.id).toBe(
+      "card-in-zone",
+    );
+    // card-in-zone 配下の zone は収集する。
+    expect(sub!.zones).toHaveProperty("card-in-zone:content");
+    // root 自身が属していた zone (container-1:content) や兄弟の zone は含めない。
+    expect(sub!.zones).not.toHaveProperty("container-1:content");
+    expect(sub!.zones).not.toHaveProperty("h-sibling:content");
+  });
+
+  it("content・zones いずれにも存在しない rootItemId は null を返す (S-2)", () => {
+    const d = data({
+      root: { props: {} },
+      content: [{ type: "Container", props: { id: "container-1" } }],
+      zones: {
+        "container-1:content": [{ type: "Card", props: { id: "card-1" } }],
+      },
+    });
+    expect(extractSubtree(d, "missing")).toBeNull();
+  });
 });
 
 describe("collectSubtreeTypes / collectDependencies", () => {

--- a/frontend/src/editor/puckSubtree.test.ts
+++ b/frontend/src/editor/puckSubtree.test.ts
@@ -165,6 +165,67 @@ describe("collectSubtreeTypes / collectDependencies", () => {
     const builtins = new Set(["Card", "Heading"]);
     expect(collectDependencies(tree, builtins)).toEqual(["ExtWidget"]);
   });
+
+  // --- #1415 P2-2: slot content (props 内 node 配列) を走査する ---
+  it("slot content (props.<slot> の node 配列) 内の nested type も収集する", () => {
+    const slotTree: Subtree = {
+      content: [
+        {
+          type: "ExtCard", // 外部 slot 部品 (root)
+          props: {
+            id: "ext-1",
+            // slot field の子は props.<slotName> の Puck node 配列に co-located。
+            body: [
+              { type: "Heading", props: { id: "h-1" } },
+              { type: "InnerExtWidget", props: { id: "iw-1" } }, // nested 外部部品
+            ],
+          },
+        },
+      ],
+    };
+    expect(collectSubtreeTypes(slotTree).sort()).toEqual([
+      "ExtCard",
+      "Heading",
+      "InnerExtWidget",
+    ]);
+  });
+
+  it("slot content 内の nested 外部部品が dependencies に含まれる (#1415 P2-2)", () => {
+    const slotTree: Subtree = {
+      content: [
+        {
+          type: "ExtCard",
+          props: {
+            id: "ext-1",
+            body: [{ type: "InnerExtWidget", props: { id: "iw-1" } }],
+          },
+        },
+      ],
+    };
+    const builtins = new Set(["Heading", "Card"]);
+    // ExtCard と nested InnerExtWidget の両方が依存として上がる。
+    expect(collectDependencies(slotTree, builtins).sort()).toEqual([
+      "ExtCard",
+      "InnerExtWidget",
+    ]);
+  });
+
+  it("業務 props がたまたま配列でも Puck node 形でなければ slot content とみなさない (誤検出回避)", () => {
+    const tricky: Subtree = {
+      content: [
+        {
+          type: "Widget",
+          props: {
+            id: "w-1",
+            // type / props を持たない普通の配列 → slot content ではない。
+            tags: ["a", "b"],
+            rows: [{ value: 1 }, { value: 2 }],
+          },
+        },
+      ],
+    };
+    expect(collectSubtreeTypes(tricky)).toEqual(["Widget"]);
+  });
 });
 
 describe("expandCompositePlaceholders", () => {
@@ -376,5 +437,48 @@ describe("expandCompositePlaceholders", () => {
     expect(
       (errorNode as { props: { missingType?: string } }).props.missingType,
     ).toBe("ExtWidget");
+  });
+
+  // --- #1415 P2-2: slot content 内の未ロード依存も error-card 化する ---
+  it("missing-dependency: slot content (props 内 node 配列) 内の未ロード type も error-card 型に差し替える", () => {
+    const compositeSlot: ExpandableComposite = {
+      id: "comp-slot",
+      label: "slot 内外部依存複合",
+      tree: {
+        // root は available な ExtCard。その slot (props.body) に未ロード InnerExtWidget を内包。
+        content: [
+          {
+            type: "ExtCard",
+            props: {
+              id: "card-slot",
+              body: [{ type: "InnerExtWidget", props: { id: "iw-1" } }],
+            },
+          },
+        ],
+      },
+      errorType: "__composite_error__comp-slot",
+    };
+    // ExtCard は available、InnerExtWidget は available に無い (= 未ロード)。
+    const availableNoInner = new Set([
+      "ExtCard",
+      compositeTypeName("comp-slot"),
+      "__composite_error__comp-slot",
+    ]);
+    const d = data({
+      root: { props: {} },
+      content: [{ type: compositeTypeName("comp-slot"), props: { id: "ph" } }],
+    });
+
+    const result = expandCompositePlaceholders(d, [compositeSlot], availableNoInner);
+
+    // 展開後 content の root ノード (ExtCard) は残り、その props.body 内 InnerExtWidget が
+    // error-card 型に差し替わっている。
+    const root = result.content.find(
+      (i) => (i as { type: string }).type === "ExtCard",
+    ) as { props: { body: { type: string; props: { missingType?: string } }[] } };
+    expect(root).toBeDefined();
+    const inner = root.props.body[0];
+    expect(inner.type).toBe("__composite_error__comp-slot");
+    expect(inner.props.missingType).toBe("InnerExtWidget");
   });
 });

--- a/frontend/src/editor/puckSubtree.test.ts
+++ b/frontend/src/editor/puckSubtree.test.ts
@@ -173,6 +173,96 @@ describe("extractSubtree", () => {
     expect(sub!.zones).toHaveProperty("card-b:content");
   });
 
+  // --- #1415 P2: root 探索が slot props 内ノードも deep-search する ---
+  it("slot 系: slot props 内ノードを root に extract できる (deep-search、#1415 P2)", () => {
+    // 外部 component の slot (props.body) 内ノードを選択して複合部品化するケース。
+    // content / zones の浅い探索では見つからないため deep-search が必須。
+    const d = data({
+      root: { props: {} },
+      content: [
+        {
+          type: "ExtSection",
+          props: {
+            id: "sec-1",
+            body: [
+              { type: "Card", props: { id: "card-in-slot" } }, // slot 内 root 候補
+              { type: "Heading", props: { id: "h-sibling" } }, // subtree 外
+            ],
+          },
+        },
+      ],
+    });
+
+    const sub = extractSubtree(d, "card-in-slot");
+    expect(sub).not.toBeNull();
+    expect(sub!.content).toHaveLength(1);
+    expect((sub!.content[0] as { props: { id: string } }).props.id).toBe(
+      "card-in-slot",
+    );
+    // root が DropZone を持たないので zones は付かない。
+    expect(sub!.zones).toBeUndefined();
+  });
+
+  it("slot 系: slot props 内 root が自前 legacy zones を持つ場合その zones も収集する (deep-search root + BFS、#1415 P2)", () => {
+    // slot 内ノードを root に選択 → その root が legacy DropZone を所有しているケース。
+    // root 探索が slot を deep-search できないと null になり、できても BFS が root 配下の
+    // zones を収集できる必要がある。
+    const d = data({
+      root: { props: {} },
+      content: [
+        {
+          type: "ExtSection",
+          props: {
+            id: "sec-1",
+            body: [{ type: "Card", props: { id: "card-in-slot" } }],
+          },
+        },
+      ],
+      zones: {
+        // slot 内 root (card-in-slot) が所有する legacy DropZone。
+        "card-in-slot:content": [{ type: "Paragraph", props: { id: "p-leaf" } }],
+        // 別系統 (subtree 外) の zone。
+        "other:content": [{ type: "Text", props: { id: "t-other" } }],
+      },
+    });
+
+    const sub = extractSubtree(d, "card-in-slot");
+    expect(sub).not.toBeNull();
+    expect((sub!.content[0] as { props: { id: string } }).props.id).toBe(
+      "card-in-slot",
+    );
+    // slot 内 root の zones が BFS で収集される。
+    expect(sub!.zones).toHaveProperty("card-in-slot:content");
+    // subtree 外の zone は含めない。
+    expect(sub!.zones).not.toHaveProperty("other:content");
+  });
+
+  it("slot 系: zones 内ノードの slot props に置かれた root も deep-search できる (#1415 P2)", () => {
+    // zone 直下の外部 component の slot 内ノードを root に選択するケース。
+    // 「全 zones の各配列 → 各ノードの slot props を再帰」の探索経路を検証。
+    const d = data({
+      root: { props: {} },
+      content: [{ type: "Container", props: { id: "container-1" } }],
+      zones: {
+        "container-1:content": [
+          {
+            type: "ExtSection",
+            props: {
+              id: "sec-in-zone",
+              body: [{ type: "Card", props: { id: "card-deep" } }],
+            },
+          },
+        ],
+      },
+    });
+
+    const sub = extractSubtree(d, "card-deep");
+    expect(sub).not.toBeNull();
+    expect((sub!.content[0] as { props: { id: string } }).props.id).toBe(
+      "card-deep",
+    );
+  });
+
   it("slot 系: save (extract) → expand round-trip で slot 子孫の nested 内容が保持される (#1415 P2-3)", () => {
     const d = data({
       root: { props: {} },

--- a/frontend/src/editor/puckSubtree.test.ts
+++ b/frontend/src/editor/puckSubtree.test.ts
@@ -203,6 +203,105 @@ describe("expandCompositePlaceholders", () => {
     expect(result).toBe(d); // 参照透過 (早期 return)
   });
 
+  it("DropZone 内 drop: zone content 配列内の placeholder も展開される", () => {
+    const d = data({
+      root: { props: {} },
+      content: [{ type: "Container", props: { id: "container-1" } }],
+      zones: {
+        "container-1:content": [
+          { type: "Paragraph", props: { id: "p-keep" } },
+          { type: compositeTypeName("comp-a"), props: { id: "ph-in-zone" } },
+        ],
+      },
+    });
+
+    const result = expandCompositePlaceholders(d, [composite], available);
+
+    const zone = result.zones!["container-1:content"];
+    const zoneTypes = zone.map((i) => (i as { type: string }).type);
+    // placeholder は消え、subtree の Card が zone 内に展開挿入される。
+    expect(zoneTypes).toContain("Card");
+    expect(zoneTypes).not.toContain(compositeTypeName("comp-a"));
+    // 既存 zone ノードは保持。
+    expect(zoneTypes).toContain("Paragraph");
+    // 展開された subtree の nested zones (id 再生成済) も merge される。
+    const zoneKeys = Object.keys(result.zones ?? {});
+    expect(zoneKeys).toContain("container-1:content");
+    // subtree 内 Card の :content zone が新規キー (UUID) で追加されている。
+    expect(zoneKeys.filter((k) => k.endsWith(":content")).length).toBeGreaterThan(1);
+  });
+
+  it("DropZone 内 drop: nested zones を持つ複合部品を zone 内に展開 → merge & id 一意", () => {
+    const d = data({
+      root: { props: {} },
+      content: [{ type: "Container", props: { id: "container-1" } }],
+      zones: {
+        "container-1:content": [
+          { type: compositeTypeName("comp-a"), props: { id: "ph-in-zone" } },
+        ],
+      },
+    });
+
+    const result = expandCompositePlaceholders(d, [composite], available);
+    const ids = allIds(result);
+    // 元の subtree id は残っていない (再生成済)。
+    expect(ids).not.toContain("card-orig");
+    expect(ids).not.toContain("head-orig");
+    // 全 id が一意。
+    expect(new Set(ids).size).toBe(ids.length);
+    // 展開された Card の :content zone が新規キーで追加され、その中に Heading がある。
+    const headingZone = Object.entries(result.zones ?? {}).find(
+      ([k, zc]) =>
+        k !== "container-1:content" &&
+        zc.some((n) => (n as { type: string }).type === "Heading"),
+    );
+    expect(headingZone).toBeDefined();
+  });
+
+  it("content + zones 両方に placeholder がある場合に両方展開される", () => {
+    const d = data({
+      root: { props: {} },
+      content: [
+        { type: compositeTypeName("comp-a"), props: { id: "ph-top" } },
+        { type: "Container", props: { id: "container-1" } },
+      ],
+      zones: {
+        "container-1:content": [
+          { type: compositeTypeName("comp-a"), props: { id: "ph-in-zone" } },
+        ],
+      },
+    });
+
+    const result = expandCompositePlaceholders(d, [composite], available);
+
+    // content 直下の placeholder は消え Card に展開。
+    const contentTypes = result.content.map((i) => (i as { type: string }).type);
+    expect(contentTypes).toContain("Card");
+    expect(contentTypes).not.toContain(compositeTypeName("comp-a"));
+    // zone 内の placeholder も消え Card に展開。
+    const zoneTypes = result.zones!["container-1:content"].map(
+      (i) => (i as { type: string }).type,
+    );
+    expect(zoneTypes).toContain("Card");
+    expect(zoneTypes).not.toContain(compositeTypeName("comp-a"));
+    // 全 id が一意 (2 回の展開で衝突しない)。
+    const ids = allIds(result);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("冪等: placeholder が content・zones いずれにも無ければ同一構造をそのまま返す", () => {
+    const d = data({
+      root: { props: {} },
+      content: [{ type: "Container", props: { id: "container-1" } }],
+      zones: {
+        "container-1:content": [{ type: "Paragraph", props: { id: "p-1" } }],
+      },
+    });
+
+    const result = expandCompositePlaceholders(d, [composite], available);
+    expect(result).toBe(d); // 参照透過 (早期 return)
+  });
+
   it("missing-dependency: 依存 type が availableTypes に無いノードは error-card 型に差し替える", () => {
     const compositeWithExt: ExpandableComposite = {
       id: "comp-ext",

--- a/frontend/src/editor/puckSubtree.ts
+++ b/frontend/src/editor/puckSubtree.ts
@@ -107,7 +107,10 @@ function slotContentEntries(item: ComponentData): [string, ComponentData[]][] {
  *   無音 null になり保存が失敗する。
  * - legacy DropZone 系: `<itemId>:zone` キーを再帰的に辿り、subtree 内ノードに紐づく zones
  *   サブセットのみ収集する。
- * - slot 系: 子は props 同居なのでルートノードを含めれば自然に取り込まれる (追加収集不要)。
+ * - slot 系 (#1411 P-3): slot 直下の子ノード自体は props 同居なのでルートノードを含めれば
+ *   自然に取り込まれる。ただし **その子が legacy DropZone (zones) を持つ場合** は、その
+ *   `<childId>:zone` も別途収集しないと nested DropZone 内容が subtree から脱落する
+ *   (#1415 P2-3)。slot 子孫ノードも走査対象に含めて zones を漏れなく収集する。
  *
  * 見つからない場合は null を返す。
  */
@@ -127,24 +130,35 @@ export function extractSubtree(data: Data, rootItemId: string): Subtree | null {
 
   const collectedZones: Zones = {};
 
-  // BFS で subtree 内の全 itemId を辿りつつ、紐づく zones サブセットを収集する。
-  const queue: string[] = [rootItemId];
-  const seen = new Set<string>();
+  // BFS で subtree 内の全ノードを辿りつつ、紐づく zones サブセットを収集する。
+  // id だけでなく **node** を queue に積むことで、zone 由来の子ノード・slot props 由来の
+  // 子ノード双方について「自身が持つ zones / slot」を漏れなく走査できる (#1415 P2-3)。
+  const queue: ComponentData[] = [root];
+  const seenIds = new Set<string>();
   while (queue.length > 0) {
-    const id = queue.shift()!;
-    if (seen.has(id)) continue;
-    seen.add(id);
-    // この id を親 itemId に持つ zone キーをすべて収集する。
-    for (const [zoneKey, zoneContent] of Object.entries(allZones)) {
-      const sepIdx = zoneKey.indexOf(":");
-      if (sepIdx < 0) continue;
-      const parentId = zoneKey.slice(0, sepIdx);
-      if (parentId !== id) continue;
-      collectedZones[zoneKey] = zoneContent;
-      // zone 内の子ノードを辿る (ネストした DropZone のため)。
-      for (const child of zoneContent) {
-        const childId = itemId(child);
-        if (childId) queue.push(childId);
+    const node = queue.shift()!;
+    const id = itemId(node);
+    if (id) {
+      if (seenIds.has(id)) continue;
+      seenIds.add(id);
+      // この id を親 itemId に持つ legacy DropZone zone キーをすべて収集する。
+      for (const [zoneKey, zoneContent] of Object.entries(allZones)) {
+        const sepIdx = zoneKey.indexOf(":");
+        if (sepIdx < 0) continue;
+        const parentId = zoneKey.slice(0, sepIdx);
+        if (parentId !== id) continue;
+        collectedZones[zoneKey] = zoneContent;
+        // zone 内の子ノードを辿る (ネストした DropZone のため)。zone 子も slot を持ちうる。
+        for (const child of zoneContent) {
+          queue.push(child);
+        }
+      }
+    }
+    // slot props 内の子ノードを辿る (#1415 P2-3)。slot 直下の子は subtree に co-located で
+    // 含まれるが、その子が legacy zones を持つ場合の収集はここで queue に積むことで賄う。
+    for (const [, children] of slotContentEntries(node)) {
+      for (const child of children) {
+        queue.push(child);
       }
     }
   }

--- a/frontend/src/editor/puckSubtree.ts
+++ b/frontend/src/editor/puckSubtree.ts
@@ -55,7 +55,10 @@ function itemId(item: ComponentData): string | undefined {
 /**
  * 指定 itemId をルートとする subtree (ルートノード + 全子孫) を自己完結 Data 断片に切り出す。
  *
- * - ルートノードは data.content から探す (現状の保存 UI は content 直下選択を前提)。
+ * - ルートノードは data.content と **全 data.zones の各配列** から探す (S-2)。
+ *   展開 (expandCompositePlaceholders) が zones 内対応済なので、保存 (切出し) も対称に
+ *   DropZone 内ノードの選択を受け付ける。content 直下のみ探すと zone 内ノード選択で
+ *   無音 null になり保存が失敗する。
  * - legacy DropZone 系: `<itemId>:zone` キーを再帰的に辿り、subtree 内ノードに紐づく zones
  *   サブセットのみ収集する。
  * - slot 系: 子は props 同居なのでルートノードを含めれば自然に取り込まれる (追加収集不要)。
@@ -63,10 +66,19 @@ function itemId(item: ComponentData): string | undefined {
  * 見つからない場合は null を返す。
  */
 export function extractSubtree(data: Data, rootItemId: string): Subtree | null {
-  const root = data.content.find((item) => itemId(item) === rootItemId);
+  const allZones: Zones = data.zones ?? {};
+  // root を content 直下 → 全 zones の各配列の順で探す (S-2)。
+  let root: ComponentData | undefined = data.content.find(
+    (item) => itemId(item) === rootItemId,
+  );
+  if (!root) {
+    for (const zoneContent of Object.values(allZones)) {
+      root = zoneContent.find((item) => itemId(item) === rootItemId);
+      if (root) break;
+    }
+  }
   if (!root) return null;
 
-  const allZones: Zones = data.zones ?? {};
   const collectedZones: Zones = {};
 
   // BFS で subtree 内の全 itemId を辿りつつ、紐づく zones サブセットを収集する。
@@ -122,7 +134,11 @@ export function collectSubtreeTypes(tree: Subtree): string[] {
  *
  * built-in primitive は常に config に存在するため依存ではない。それ以外の type
  * (外部 component の entry.id 等) を dependencies として記録し、capability 6 判定に使う。
- * `builtinTypes` には config の built-in primitive type 名集合を渡す。
+ *
+ * `builtinTypes` には **built-in primitive 型のみ** の集合を渡すこと (S-3)。
+ * config 全 type (= 外部 component 込みの availableTypes) を渡すと外部 component が
+ * dependencies[] から除外され不完全になる。呼出側は buildConfig の
+ * `BUILTIN_PRIMITIVE_TYPE_NAMES` から作った集合を渡す。
  */
 export function collectDependencies(
   tree: Subtree,

--- a/frontend/src/editor/puckSubtree.ts
+++ b/frontend/src/editor/puckSubtree.ts
@@ -201,15 +201,48 @@ export interface ExpandableComposite {
 }
 
 /**
+ * 1 つの Content 配列内の複合部品 placeholder を展開し、展開後の配列と
+ * merge すべき zones サブセットを返す内部ヘルパ。
+ *
+ * placeholder は該当 index に subtree (id 再生成済) を flat 挿入する。
+ * placeholder でないノードはそのまま保持する。
+ */
+function expandContentArray(
+  content: Content,
+  byType: Map<string, ExpandableComposite>,
+  availableTypes: Set<string>,
+): { content: Content; zones: Zones } {
+  const newContent: Content = [];
+  const zones: Zones = {};
+  for (const item of content) {
+    const type = (item as { type?: unknown }).type;
+    const composite = typeof type === "string" ? byType.get(type) : undefined;
+    if (!composite) {
+      newContent.push(item);
+      continue;
+    }
+    // placeholder を subtree に展開 (その場 flat 挿入)。
+    const expanded = expandOne(composite, availableTypes);
+    newContent.push(...expanded.content);
+    Object.assign(zones, expanded.zones);
+  }
+  return { content: newContent, zones };
+}
+
+/**
  * data 内の複合部品 placeholder ノードを subtree に展開する純粋・冪等関数 (#1412 P-4)。
  *
  * - content 直下の placeholder ノードを検出 → 該当 index に subtree (id 再生成済) を展開。
  *   zones サブセットは data.zones に merge する。
+ * - data.zones の各 zone content 配列内 (= Container/Row/Col/Card の DropZone に drop された
+ *   placeholder) も同じロジックで展開する。zone key (`<itemId>:<zoneName>`) は保持し、中身の
+ *   配列のみ書き換える。
+ * - 展開した subtree が自身の zones サブセット (nested DropZone) を持つ場合、それらも
+ *   data.zones に merge する。展開ノードの id は regeneratePuckDataIds で UUID 再生成済のため
+ *   新規 zones キーは既存キーと衝突しない。
  * - 依存 type が `availableTypes` に無い subtree 内ノードは error-card 型に差し替える (capability 6)。
- * - placeholder が無ければ参照透過に同一構造を返す (冪等、無限ループ防止)。
- *
- * 注意: placeholder は content 直下にのみ現れる想定 (パレットからの drop は content 直下 or
- * DropZone 内だが、本実装では content 直下のみ展開する。DropZone 内 drop の展開は将来対応)。
+ * - placeholder が content・zones いずれにも無ければ参照透過に同一構造を返す
+ *   (冪等、controlled mode の onChange→展開→setData 無限ループ防止)。
  */
 export function expandCompositePlaceholders(
   data: Data,
@@ -221,27 +254,33 @@ export function expandCompositePlaceholders(
     byType.set(compositeTypeName(c.id), c);
   }
 
-  // content 直下に placeholder があるか判定 (冪等性のため早期 return)。
-  const hasPlaceholder = data.content.some((item) => {
+  const isPlaceholder = (item: unknown): boolean => {
     const type = (item as { type?: unknown }).type;
     return typeof type === "string" && byType.has(type);
-  });
-  if (!hasPlaceholder) return data;
+  };
 
-  const newContent: Content = [];
-  const mergedZones: Zones = { ...(data.zones ?? {}) };
+  // content 直下・zones いずれかに placeholder があるか判定 (冪等性のため早期 return)。
+  const dataZones: Zones = data.zones ?? {};
+  const hasContentPlaceholder = data.content.some(isPlaceholder);
+  const hasZonePlaceholder = Object.values(dataZones).some((zc) =>
+    zc.some(isPlaceholder),
+  );
+  if (!hasContentPlaceholder && !hasZonePlaceholder) return data;
 
-  for (const item of data.content) {
-    const type = (item as { type?: unknown }).type;
-    const composite = typeof type === "string" ? byType.get(type) : undefined;
-    if (!composite) {
-      newContent.push(item);
-      continue;
-    }
-    // placeholder を subtree に展開 (その場挿入)。
-    const expanded = expandOne(composite, availableTypes);
-    newContent.push(...expanded.content);
-    Object.assign(mergedZones, expanded.zones);
+  // 既存 zones を起点に merge していく (展開で増える nested zones を Object.assign で追加)。
+  const mergedZones: Zones = {};
+
+  // content 直下の placeholder を展開。
+  const expandedContent = expandContentArray(data.content, byType, availableTypes);
+  const newContent = expandedContent.content;
+  Object.assign(mergedZones, expandedContent.zones);
+
+  // 既存 zones の各 zone content 配列内 placeholder を展開 (zone key は保持、中身のみ書換)。
+  // 展開で増える nested zones は別キー (UUID) なので Object.assign の順序で既存を壊さない。
+  for (const [zoneKey, zoneContent] of Object.entries(dataZones)) {
+    const expandedZone = expandContentArray(zoneContent, byType, availableTypes);
+    mergedZones[zoneKey] = expandedZone.content;
+    Object.assign(mergedZones, expandedZone.zones);
   }
 
   return {

--- a/frontend/src/editor/puckSubtree.ts
+++ b/frontend/src/editor/puckSubtree.ts
@@ -1,0 +1,252 @@
+/**
+ * puckSubtree.ts — 複合部品 (composite) の subtree 切出し / 展開ユーティリティ (#1412 P-4)。
+ *
+ * 純粋関数のみ (副作用なし、単体テスト容易)。frontend/AGENTS.md に従い JSX を持ち込まない。
+ *
+ * 取り扱う 2 系統 (調査確認済):
+ *   - built-in primitive (Container/Row/Col/Card 等) は legacy `<DropZone zone="content">`
+ *     → 子は `data.zones["<itemId>:<zoneName>"]` map に格納される。
+ *   - 外部 component (#1411 P-3) は `{ type: "slot" }` field
+ *     → 子は当該ノードの props に co-located で格納される (ノードごと自然に含まれる)。
+ *
+ * 設計方針: expand-on-drop "pattern" 方式 (GrapesJS customBlock 哲学)。
+ * 複合部品を drop すると subtree がその場で展開挿入され、各ノードが個別編集可能になる。
+ *
+ * 詳細仕様: docs/spec/multi-editor-puck.md § 4.5
+ */
+
+import type { Data } from "@measured/puck";
+import { regeneratePuckDataIds } from "./puckIdRegeneration";
+
+type Content = Data["content"];
+type Zones = NonNullable<Data["zones"]>;
+type ComponentData = Content[number];
+
+/** subtree 断片。自己完結した content + (legacy DropZone 用) zones サブセット。 */
+export interface Subtree {
+  content: Content;
+  zones?: Zones;
+}
+
+/** 複合部品 placeholder ノードの type prefix。drop 直後に検出 → 展開される。 */
+export const COMPOSITE_TYPE_PREFIX = "__composite__";
+
+/** entry.id から複合部品 placeholder の Puck component type 名を作る。 */
+export function compositeTypeName(id: string): string {
+  return `${COMPOSITE_TYPE_PREFIX}${id}`;
+}
+
+/** Puck component type が複合部品 placeholder かどうか。 */
+export function isCompositeType(type: string): boolean {
+  return type.startsWith(COMPOSITE_TYPE_PREFIX);
+}
+
+/** 複合部品 placeholder type から元の entry.id を取り出す。 */
+export function compositeIdFromType(type: string): string {
+  return type.slice(COMPOSITE_TYPE_PREFIX.length);
+}
+
+/** ComponentData から props.id を安全に取り出す。 */
+function itemId(item: ComponentData): string | undefined {
+  const id = (item as { props?: { id?: unknown } }).props?.id;
+  return typeof id === "string" ? id : undefined;
+}
+
+/**
+ * 指定 itemId をルートとする subtree (ルートノード + 全子孫) を自己完結 Data 断片に切り出す。
+ *
+ * - ルートノードは data.content から探す (現状の保存 UI は content 直下選択を前提)。
+ * - legacy DropZone 系: `<itemId>:zone` キーを再帰的に辿り、subtree 内ノードに紐づく zones
+ *   サブセットのみ収集する。
+ * - slot 系: 子は props 同居なのでルートノードを含めれば自然に取り込まれる (追加収集不要)。
+ *
+ * 見つからない場合は null を返す。
+ */
+export function extractSubtree(data: Data, rootItemId: string): Subtree | null {
+  const root = data.content.find((item) => itemId(item) === rootItemId);
+  if (!root) return null;
+
+  const allZones: Zones = data.zones ?? {};
+  const collectedZones: Zones = {};
+
+  // BFS で subtree 内の全 itemId を辿りつつ、紐づく zones サブセットを収集する。
+  const queue: string[] = [rootItemId];
+  const seen = new Set<string>();
+  while (queue.length > 0) {
+    const id = queue.shift()!;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    // この id を親 itemId に持つ zone キーをすべて収集する。
+    for (const [zoneKey, zoneContent] of Object.entries(allZones)) {
+      const sepIdx = zoneKey.indexOf(":");
+      if (sepIdx < 0) continue;
+      const parentId = zoneKey.slice(0, sepIdx);
+      if (parentId !== id) continue;
+      collectedZones[zoneKey] = zoneContent;
+      // zone 内の子ノードを辿る (ネストした DropZone のため)。
+      for (const child of zoneContent) {
+        const childId = itemId(child);
+        if (childId) queue.push(childId);
+      }
+    }
+  }
+
+  return {
+    content: [root],
+    ...(Object.keys(collectedZones).length > 0 ? { zones: collectedZones } : {}),
+  };
+}
+
+/**
+ * subtree に含まれる全ノードの type を列挙する (content + 全 zones)。
+ */
+export function collectSubtreeTypes(tree: Subtree): string[] {
+  const types = new Set<string>();
+  for (const item of tree.content) {
+    const t = (item as { type?: unknown }).type;
+    if (typeof t === "string") types.add(t);
+  }
+  if (tree.zones) {
+    for (const zoneContent of Object.values(tree.zones)) {
+      for (const item of zoneContent) {
+        const t = (item as { type?: unknown }).type;
+        if (typeof t === "string") types.add(t);
+      }
+    }
+  }
+  return [...types];
+}
+
+/**
+ * subtree が内包する「依存部品」(= built-in primitive 以外の type) の一覧を返す (#1412 P-4)。
+ *
+ * built-in primitive は常に config に存在するため依存ではない。それ以外の type
+ * (外部 component の entry.id 等) を dependencies として記録し、capability 6 判定に使う。
+ * `builtinTypes` には config の built-in primitive type 名集合を渡す。
+ */
+export function collectDependencies(
+  tree: Subtree,
+  builtinTypes: Set<string>,
+): string[] {
+  return collectSubtreeTypes(tree).filter((t) => !builtinTypes.has(t));
+}
+
+/**
+ * 1 つの複合部品 placeholder ノードを、その subtree に展開する (id 再生成済)。
+ * `availableTypes` に含まれない type を持つ subtree 内ノードは error-card 型に差し替える。
+ *
+ * 戻り値: { content: 展開後 content ノード配列, zones: merge する zones サブセット }
+ */
+function expandOne(
+  composite: ExpandableComposite,
+  availableTypes: Set<string>,
+): { content: Content; zones: Zones } {
+  // subtree を Data 形に整形 → id 再生成 (props.id + zones キー itemId 同期)。
+  const dataFragment: Data = {
+    root: { props: {} },
+    content: composite.tree.content,
+    ...(composite.tree.zones ? { zones: composite.tree.zones } : {}),
+  };
+  const regenerated = regeneratePuckDataIds(dataFragment);
+
+  const content = regenerated.content.map((item) =>
+    guardNode(item, composite, availableTypes),
+  );
+  const zones: Zones = {};
+  if (regenerated.zones) {
+    for (const [zoneKey, zoneContent] of Object.entries(regenerated.zones)) {
+      zones[zoneKey] = zoneContent.map((item) =>
+        guardNode(item, composite, availableTypes),
+      );
+    }
+  }
+  return { content, zones };
+}
+
+/**
+ * subtree 内ノードの type が config に無ければ missing-dependency error-card 型に差し替える。
+ * error-card 型 (= `makeErrorCardConfig` が config に登録するキー) は別途 mergeComposite 側で
+ * 登録される前提。ここでは type / props を error-card 用に書き換えるのみ。
+ */
+function guardNode(
+  item: ComponentData,
+  composite: ExpandableComposite,
+  availableTypes: Set<string>,
+): ComponentData {
+  const type = (item as { type?: unknown }).type;
+  if (typeof type === "string" && !availableTypes.has(type)) {
+    return {
+      type: composite.errorType,
+      props: {
+        id: itemId(item) ?? `${composite.errorType}-${type}`,
+        missingType: type,
+        compositeLabel: composite.label,
+      },
+    } as ComponentData;
+  }
+  return item;
+}
+
+/**
+ * expandCompositePlaceholders に渡す複合部品の展開可能形。
+ * - id: 複合部品の entry.id
+ * - errorType: 依存欠落ノードを差し替える error-card の Puck component type 名
+ *   (mergeCompositeComponents が config に登録するキーと一致させる)
+ */
+export interface ExpandableComposite {
+  id: string;
+  label: string;
+  tree: Subtree;
+  errorType: string;
+}
+
+/**
+ * data 内の複合部品 placeholder ノードを subtree に展開する純粋・冪等関数 (#1412 P-4)。
+ *
+ * - content 直下の placeholder ノードを検出 → 該当 index に subtree (id 再生成済) を展開。
+ *   zones サブセットは data.zones に merge する。
+ * - 依存 type が `availableTypes` に無い subtree 内ノードは error-card 型に差し替える (capability 6)。
+ * - placeholder が無ければ参照透過に同一構造を返す (冪等、無限ループ防止)。
+ *
+ * 注意: placeholder は content 直下にのみ現れる想定 (パレットからの drop は content 直下 or
+ * DropZone 内だが、本実装では content 直下のみ展開する。DropZone 内 drop の展開は将来対応)。
+ */
+export function expandCompositePlaceholders(
+  data: Data,
+  composites: ExpandableComposite[],
+  availableTypes: Set<string>,
+): Data {
+  const byType = new Map<string, ExpandableComposite>();
+  for (const c of composites) {
+    byType.set(compositeTypeName(c.id), c);
+  }
+
+  // content 直下に placeholder があるか判定 (冪等性のため早期 return)。
+  const hasPlaceholder = data.content.some((item) => {
+    const type = (item as { type?: unknown }).type;
+    return typeof type === "string" && byType.has(type);
+  });
+  if (!hasPlaceholder) return data;
+
+  const newContent: Content = [];
+  const mergedZones: Zones = { ...(data.zones ?? {}) };
+
+  for (const item of data.content) {
+    const type = (item as { type?: unknown }).type;
+    const composite = typeof type === "string" ? byType.get(type) : undefined;
+    if (!composite) {
+      newContent.push(item);
+      continue;
+    }
+    // placeholder を subtree に展開 (その場挿入)。
+    const expanded = expandOne(composite, availableTypes);
+    newContent.push(...expanded.content);
+    Object.assign(mergedZones, expanded.zones);
+  }
+
+  return {
+    ...data,
+    content: newContent,
+    ...(Object.keys(mergedZones).length > 0 ? { zones: mergedZones } : {}),
+  };
+}

--- a/frontend/src/editor/puckSubtree.ts
+++ b/frontend/src/editor/puckSubtree.ts
@@ -99,12 +99,33 @@ function slotContentEntries(item: ComponentData): [string, ComponentData[]][] {
 }
 
 /**
+ * ノード配列 (とその各ノードの props 内 slot content) を深さ優先で辿り、itemId 一致ノードを返す
+ * (#1415 P2)。slot field (#1411 P-3) 内ノードは `props.<slotName>` 配列に co-located で格納される
+ * ため、content / zones の浅い探索では見つからない。各ノードについて itemId 一致を確認し、無ければ
+ * `slotContentEntries(node)` の各子配列を再帰探索する。
+ */
+function findNodeDeep(
+  nodes: ComponentData[],
+  id: string,
+): ComponentData | undefined {
+  for (const node of nodes) {
+    if (itemId(node) === id) return node;
+    for (const [, children] of slotContentEntries(node)) {
+      const found = findNodeDeep(children, id);
+      if (found) return found;
+    }
+  }
+  return undefined;
+}
+
+/**
  * 指定 itemId をルートとする subtree (ルートノード + 全子孫) を自己完結 Data 断片に切り出す。
  *
- * - ルートノードは data.content と **全 data.zones の各配列** から探す (S-2)。
- *   展開 (expandCompositePlaceholders) が zones 内対応済なので、保存 (切出し) も対称に
- *   DropZone 内ノードの選択を受け付ける。content 直下のみ探すと zone 内ノード選択で
- *   無音 null になり保存が失敗する。
+ * - ルートノードは data.content・**全 data.zones の各配列**・各ノードの props 内 slot content
+ *   (#1411 P-3) を再帰的に deep-search して探す (S-2 / #1415 P2)。展開
+ *   (expandCompositePlaceholders) が content / zones / slot props すべてに対応済なので、保存
+ *   (切出し) も対称にいずれの階層のノード選択も受け付ける。content / zone 直下のみ探すと
+ *   slot 内ノード選択で無音 null になり保存が失敗する。
  * - legacy DropZone 系: `<itemId>:zone` キーを再帰的に辿り、subtree 内ノードに紐づく zones
  *   サブセットのみ収集する。
  * - slot 系 (#1411 P-3): slot 直下の子ノード自体は props 同居なのでルートノードを含めれば
@@ -116,13 +137,12 @@ function slotContentEntries(item: ComponentData): [string, ComponentData[]][] {
  */
 export function extractSubtree(data: Data, rootItemId: string): Subtree | null {
   const allZones: Zones = data.zones ?? {};
-  // root を content 直下 → 全 zones の各配列の順で探す (S-2)。
-  let root: ComponentData | undefined = data.content.find(
-    (item) => itemId(item) === rootItemId,
-  );
+  // root を content 直下 → 全 zones の各配列 → (各ノードの slot props を再帰) の順で deep-search
+  // する (S-2 / #1415 P2)。content / zones 内ノードの slot props も探索対象にする。
+  let root: ComponentData | undefined = findNodeDeep(data.content, rootItemId);
   if (!root) {
     for (const zoneContent of Object.values(allZones)) {
-      root = zoneContent.find((item) => itemId(item) === rootItemId);
+      root = findNodeDeep(zoneContent, rootItemId);
       if (root) break;
     }
   }

--- a/frontend/src/editor/puckSubtree.ts
+++ b/frontend/src/editor/puckSubtree.ts
@@ -7,7 +7,11 @@
  *   - built-in primitive (Container/Row/Col/Card 等) は legacy `<DropZone zone="content">`
  *     → 子は `data.zones["<itemId>:<zoneName>"]` map に格納される。
  *   - 外部 component (#1411 P-3) は `{ type: "slot" }` field
- *     → 子は当該ノードの props に co-located で格納される (ノードごと自然に含まれる)。
+ *     → 子は当該ノードの props (`props.<slotName>` の Puck node 配列) に co-located で格納される。
+ *
+ * #1415 P2-2: 依存収集 (collectSubtreeTypes) と展開 (guardNode) は、slot 系の props 内 node 配列を
+ * 再帰的に走査する。これにより slot 内に外部 component を含む複合部品でも、その nested 部品が
+ * dependencies 収集に乗り、未ロード時の展開で missing-dependency error-card に差し替わる。
  *
  * 設計方針: expand-on-drop "pattern" 方式 (GrapesJS customBlock 哲学)。
  * 複合部品を drop すると subtree がその場で展開挿入され、各ノードが個別編集可能になる。
@@ -50,6 +54,48 @@ export function compositeIdFromType(type: string): string {
 function itemId(item: ComponentData): string | undefined {
   const id = (item as { props?: { id?: unknown } }).props?.id;
   return typeof id === "string" ? id : undefined;
+}
+
+/**
+ * value が Puck node (= `{ type: string, props: object }`) かどうか (#1415 P2-2)。
+ *
+ * slot field (#1411 P-3) の子ノードは props.<slotName> の **配列** に co-located で格納される
+ * (buildConfig.ts: `defaultProps[slot.name] = []`)。slot 名は manifest 依存でハードコードできない
+ * ため、「props value が Puck node を要素に持つ配列」を generic に slot content とみなす。
+ *
+ * 誤検出 (業務 props がたまたま type/props を持つ) を避けるため、判定は puckIdRegeneration の
+ * node 判定と同一形 (`type:string` かつ `props` が object) に揃える。
+ */
+function isPuckNode(value: unknown): value is ComponentData {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    typeof (value as { type?: unknown }).type === "string" &&
+    typeof (value as { props?: unknown }).props === "object" &&
+    (value as { props?: unknown }).props !== null
+  );
+}
+
+/** value が「Puck node を要素に持つ配列」(= slot content) かどうか。 */
+function isSlotContentArray(value: unknown): value is ComponentData[] {
+  return Array.isArray(value) && value.length > 0 && value.every(isPuckNode);
+}
+
+/**
+ * 1 ノードの props 内 slot content (= Puck node 配列) を列挙する (#1415 P2-2)。
+ * 戻り値は [propName, childNode[]] のペア配列。
+ */
+function slotContentEntries(item: ComponentData): [string, ComponentData[]][] {
+  const props = (item as { props?: Record<string, unknown> }).props;
+  if (!props || typeof props !== "object") return [];
+  const result: [string, ComponentData[]][] = [];
+  for (const [key, value] of Object.entries(props)) {
+    if (isSlotContentArray(value)) {
+      result.push([key, value]);
+    }
+  }
+  return result;
 }
 
 /**
@@ -110,19 +156,33 @@ export function extractSubtree(data: Data, rootItemId: string): Subtree | null {
 }
 
 /**
- * subtree に含まれる全ノードの type を列挙する (content + 全 zones)。
+ * 1 ノードの type と、その props 内 slot content (#1411 P-3) を再帰的に types に収集する
+ * (#1415 P2-2)。slot 内に外部 component を含む複合部品で、nested 部品が dependencies 収集から
+ * 漏れるのを防ぐ。
+ */
+function collectNodeTypes(item: ComponentData, types: Set<string>): void {
+  const t = (item as { type?: unknown }).type;
+  if (typeof t === "string") types.add(t);
+  // props 内 slot content (Puck node 配列) を再帰的に辿る。
+  for (const [, children] of slotContentEntries(item)) {
+    for (const child of children) {
+      collectNodeTypes(child, types);
+    }
+  }
+}
+
+/**
+ * subtree に含まれる全ノードの type を列挙する (content + 全 zones + props 内 slot content)。
  */
 export function collectSubtreeTypes(tree: Subtree): string[] {
   const types = new Set<string>();
   for (const item of tree.content) {
-    const t = (item as { type?: unknown }).type;
-    if (typeof t === "string") types.add(t);
+    collectNodeTypes(item, types);
   }
   if (tree.zones) {
     for (const zoneContent of Object.values(tree.zones)) {
       for (const item of zoneContent) {
-        const t = (item as { type?: unknown }).type;
-        if (typeof t === "string") types.add(t);
+        collectNodeTypes(item, types);
       }
     }
   }
@@ -183,6 +243,10 @@ function expandOne(
  * subtree 内ノードの type が config に無ければ missing-dependency error-card 型に差し替える。
  * error-card 型 (= `makeErrorCardConfig` が config に登録するキー) は別途 mergeComposite 側で
  * 登録される前提。ここでは type / props を error-card 用に書き換えるのみ。
+ *
+ * #1415 P2-2: ノード自身の type が available な場合でも、props 内 slot content
+ * (#1411 P-3、= Puck node 配列) を再帰的に guard する。slot 内に未ロード外部 component を
+ * 含む複合部品が、その nested ノードを error-card 化せず素通りするのを防ぐ。
  */
 function guardNode(
   item: ComponentData,
@@ -200,7 +264,16 @@ function guardNode(
       },
     } as ComponentData;
   }
-  return item;
+  // ノード自身は OK。props 内 slot content を再帰的に guard する。
+  const slotEntries = slotContentEntries(item);
+  if (slotEntries.length === 0) return item;
+  const props = { ...(item as { props: Record<string, unknown> }).props };
+  for (const [propName, children] of slotEntries) {
+    props[propName] = children.map((child) =>
+      guardNode(child, composite, availableTypes),
+    );
+  }
+  return { ...item, props } as ComponentData;
 }
 
 /**

--- a/frontend/src/editor/puckSubtree.ts
+++ b/frontend/src/editor/puckSubtree.ts
@@ -229,9 +229,11 @@ export function collectDependencies(
  */
 function expandOne(
   composite: ExpandableComposite,
+  byType: Map<string, ExpandableComposite>,
   availableTypes: Set<string>,
 ): { content: Content; zones: Zones } {
-  // subtree を Data 形に整形 → id 再生成 (props.id + zones キー itemId 同期)。
+  // subtree を Data 形に整形 → id 再生成 (props.id + zones キー itemId 同期、props 内 slot
+  // ノードの id も regeneratePuckDataIds が props 再帰処理で再生成する)。
   const dataFragment: Data = {
     root: { props: {} },
     content: composite.tree.content,
@@ -239,16 +241,33 @@ function expandOne(
   };
   const regenerated = regeneratePuckDataIds(dataFragment);
 
-  const content = regenerated.content.map((item) =>
+  // 1. まず本 subtree の直接ノードを guardNode で未ロード依存 error-card 化する
+  //    (props 内 slot content も再帰 guard、#1415 P2-2)。複合部品 placeholder type 自体は
+  //    config 登録済 (availableTypes 内) なので guard では落ちず、次段の展開に回る。
+  const guardedContent = regenerated.content.map((item) =>
     guardNode(item, composite, availableTypes),
   );
-  const zones: Zones = {};
+  const guardedZones: Zones = {};
   if (regenerated.zones) {
     for (const [zoneKey, zoneContent] of Object.entries(regenerated.zones)) {
-      zones[zoneKey] = zoneContent.map((item) =>
+      guardedZones[zoneKey] = zoneContent.map((item) =>
         guardNode(item, composite, availableTypes),
       );
     }
+  }
+
+  // 2. subtree 自身が nested 複合部品 placeholder を内包する場合に備え、content / zones を
+  //    expandContentArray で再帰展開する (slot props 内 placeholder もここで展開、#1415 P2-4)。
+  //    nested 展開は各 nested composite 自身の expandOne→guardNode が依存解決するため、
+  //    ここで再 guard はしない (outer errorType で二重ラップしないため)。
+  const zones: Zones = {};
+  const expandedContent = expandContentArray(guardedContent, byType, availableTypes);
+  Object.assign(zones, expandedContent.zones);
+  const content = expandedContent.content;
+  for (const [zoneKey, zoneContent] of Object.entries(guardedZones)) {
+    const expandedZone = expandContentArray(zoneContent, byType, availableTypes);
+    Object.assign(zones, expandedZone.zones);
+    zones[zoneKey] = expandedZone.content;
   }
   return { content, zones };
 }
@@ -308,7 +327,10 @@ export interface ExpandableComposite {
  * merge すべき zones サブセットを返す内部ヘルパ。
  *
  * placeholder は該当 index に subtree (id 再生成済) を flat 挿入する。
- * placeholder でないノードはそのまま保持する。
+ * placeholder でないノードはそのまま保持する。ただし非 placeholder ノードでも、その
+ * **props 内 slot content** (#1411 P-3、= Puck node 配列) に placeholder が drop されている
+ * 場合はその slot 配列も再帰的に展開し、展開後の配列を props に書き戻す (#1415 P2-4)。
+ * slot 内展開で生まれる nested zones も呼出側に伝播するよう zones に集約する。
  */
 function expandContentArray(
   content: Content,
@@ -320,16 +342,40 @@ function expandContentArray(
   for (const item of content) {
     const type = (item as { type?: unknown }).type;
     const composite = typeof type === "string" ? byType.get(type) : undefined;
-    if (!composite) {
-      newContent.push(item);
+    if (composite) {
+      // placeholder を subtree に展開 (その場 flat 挿入)。
+      const expanded = expandOne(composite, byType, availableTypes);
+      newContent.push(...expanded.content);
+      Object.assign(zones, expanded.zones);
       continue;
     }
-    // placeholder を subtree に展開 (その場 flat 挿入)。
-    const expanded = expandOne(composite, availableTypes);
-    newContent.push(...expanded.content);
-    Object.assign(zones, expanded.zones);
+    // 非 placeholder ノード。props 内 slot content に placeholder があれば再帰展開する。
+    newContent.push(expandNodeSlots(item, byType, availableTypes, zones));
   }
   return { content: newContent, zones };
+}
+
+/**
+ * 1 ノードの props 内 slot content (#1411 P-3) 内の複合部品 placeholder を再帰展開する
+ * (#1415 P2-4)。各 slot 配列を expandContentArray に通し、展開後の配列を props に書き戻した
+ * ノードを返す。slot が無ければ参照透過に同一ノードを返す (冪等)。slot 展開で生まれる nested
+ * zones は引数 zones (= 親が集約する Zones) に Object.assign する。
+ */
+function expandNodeSlots(
+  item: ComponentData,
+  byType: Map<string, ExpandableComposite>,
+  availableTypes: Set<string>,
+  zones: Zones,
+): ComponentData {
+  const slotEntries = slotContentEntries(item);
+  if (slotEntries.length === 0) return item;
+  const props = { ...(item as { props: Record<string, unknown> }).props };
+  for (const [propName, children] of slotEntries) {
+    const expanded = expandContentArray(children as Content, byType, availableTypes);
+    props[propName] = expanded.content;
+    Object.assign(zones, expanded.zones);
+  }
+  return { ...item, props } as ComponentData;
 }
 
 /**
@@ -343,8 +389,11 @@ function expandContentArray(
  * - 展開した subtree が自身の zones サブセット (nested DropZone) を持つ場合、それらも
  *   data.zones に merge する。展開ノードの id は regeneratePuckDataIds で UUID 再生成済のため
  *   新規 zones キーは既存キーと衝突しない。
+ * - 外部 component の slot props (`props.<slotName>` 配列、#1411 P-3) に drop された placeholder も
+ *   再帰的に展開する (#1415 P2-4)。展開後の配列を props に書き戻し、slot 内 placeholder が生む
+ *   nested zones も data.zones に merge する。slot 内 slot のさらなるネストも辿る。
  * - 依存 type が `availableTypes` に無い subtree 内ノードは error-card 型に差し替える (capability 6)。
- * - placeholder が content・zones いずれにも無ければ参照透過に同一構造を返す
+ * - placeholder が content・zones・slot props いずれにも無ければ参照透過に同一構造を返す
  *   (冪等、controlled mode の onChange→展開→setData 無限ループ防止)。
  */
 export function expandCompositePlaceholders(
@@ -362,11 +411,21 @@ export function expandCompositePlaceholders(
     return typeof type === "string" && byType.has(type);
   };
 
-  // content 直下・zones いずれかに placeholder があるか判定 (冪等性のため早期 return)。
+  // ノード自身が placeholder か、または props 内 slot content (#1411 P-3) のいずれかの
+  // 階層に placeholder を内包するか (再帰、slot 内 slot も考慮) を判定する (#1415 P2-4)。
+  const nodeContainsPlaceholder = (item: ComponentData): boolean => {
+    if (isPlaceholder(item)) return true;
+    for (const [, children] of slotContentEntries(item)) {
+      if (children.some(nodeContainsPlaceholder)) return true;
+    }
+    return false;
+  };
+
+  // content 直下・zones・slot props いずれかに placeholder があるか判定 (冪等性のため早期 return)。
   const dataZones: Zones = data.zones ?? {};
-  const hasContentPlaceholder = data.content.some(isPlaceholder);
+  const hasContentPlaceholder = data.content.some(nodeContainsPlaceholder);
   const hasZonePlaceholder = Object.values(dataZones).some((zc) =>
-    zc.some(isPlaceholder),
+    zc.some(nodeContainsPlaceholder),
   );
   if (!hasContentPlaceholder && !hasZonePlaceholder) return data;
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -9,6 +9,31 @@ import { AppErrorFallback } from "./components/common/ErrorFallback";
 import { ErrorDialogProvider } from "./components/common/ErrorDialogProvider";
 import { installGlobalErrorHandlers } from "./utils/errorLog";
 
+// 外部 React Component 読込基盤 (#1409 P-1): host の React / ReactDOM / Puck インスタンスを
+// window bridge に公開する。frontend/public/harmony-externals/*.mjs (import map で bare
+// specifier にマップ) がこれを re-export することで、外部 component が host と同一インスタンス
+// を共有し二重化 (Invalid hook call 等) を防ぐ。
+// namespace import を bridge 専用に追加 (host 自身は通常の named import を使い続ける)。
+import * as ReactNamespace from "react";
+import * as ReactDOMNamespace from "react-dom";
+import * as ReactDOMClientNamespace from "react-dom/client";
+import * as ReactJsxRuntimeNamespace from "react/jsx-runtime";
+import * as PuckNamespace from "@measured/puck";
+
+declare global {
+  interface Window {
+    __HARMONY_SHARED_DEPS__?: Record<string, unknown>;
+  }
+}
+
+window.__HARMONY_SHARED_DEPS__ = {
+  "react": ReactNamespace,
+  "react-dom": ReactDOMNamespace,
+  "react-dom/client": ReactDOMClientNamespace,
+  "react/jsx-runtime": ReactJsxRuntimeNamespace,
+  "@measured/puck": PuckNamespace,
+};
+
 installGlobalErrorHandlers();
 
 createRoot(document.getElementById("root")!).render(

--- a/frontend/src/puck/__tests__/buildConfig.test.ts
+++ b/frontend/src/puck/__tests__/buildConfig.test.ts
@@ -158,6 +158,15 @@ describe("buildPuckConfig categories (#1410 P-2)", () => {
       expect(assigned.has(key)).toBe(true);
     }
   });
+
+  it("categories に列挙された component 名はすべて config.components に実在する", () => {
+    const componentKeys = new Set(Object.keys(config.components));
+    for (const cat of Object.values(config.categories!)) {
+      for (const name of cat?.components ?? []) {
+        expect(componentKeys.has(name)).toBe(true);
+      }
+    }
+  });
 });
 
 describe("buildConfigWithCustomComponents categories + fields (#1410 P-2)", () => {

--- a/frontend/src/puck/__tests__/buildConfig.test.ts
+++ b/frontend/src/puck/__tests__/buildConfig.test.ts
@@ -8,8 +8,13 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { buildPuckConfig, BUILTIN_PRIMITIVE_NAMES } from "../buildConfig";
+import {
+  buildPuckConfig,
+  buildConfigWithCustomComponents,
+  BUILTIN_PRIMITIVE_NAMES,
+} from "../buildConfig";
 import { LAYOUT_FIELDS } from "../buildConfig";
+import type { CustomPuckComponentDef } from "../../store/puckComponentsStore";
 
 const LAYOUT_FIELD_KEYS = Object.keys(LAYOUT_FIELDS);
 
@@ -118,6 +123,113 @@ describe("LAYOUT_FIELDS", () => {
 
   it("rawClass は text 型", () => {
     expect(LAYOUT_FIELDS.rawClass.type).toBe("text");
+  });
+});
+
+describe("buildPuckConfig categories (#1410 P-2)", () => {
+  const config = buildPuckConfig();
+
+  it("categories が定義され 6 カテゴリ (layout/text/form/data/composite/regions) を持つ", () => {
+    expect(config.categories).toBeDefined();
+    const cats = config.categories!;
+    for (const key of ["layout", "text", "form", "data", "composite", "regions"]) {
+      expect(cats).toHaveProperty(key);
+    }
+  });
+
+  it("各カテゴリに日本語 title が付く", () => {
+    const cats = config.categories!;
+    expect(cats.layout!.title).toBe("レイアウト");
+    expect(cats.text!.title).toBe("テキスト");
+    expect(cats.form!.title).toBe("フォーム");
+    expect(cats.data!.title).toBe("データ");
+    expect(cats.composite!.title).toBe("業務複合");
+    expect(cats.regions!.title).toBe("レイアウト領域");
+  });
+
+  it("全ビルトイン component がいずれかのカテゴリに割り当てられている (other に落ちない)", () => {
+    const assigned = new Set<string>();
+    for (const cat of Object.values(config.categories!)) {
+      for (const c of cat?.components ?? []) {
+        assigned.add(c as string);
+      }
+    }
+    for (const key of Object.keys(config.components)) {
+      expect(assigned.has(key)).toBe(true);
+    }
+  });
+});
+
+describe("buildConfigWithCustomComponents categories + fields (#1410 P-2)", () => {
+  const customDef: CustomPuckComponentDef = {
+    id: "my-widget",
+    label: "マイウィジェット",
+    primitive: "container",
+    propsSchema: {
+      title: { type: "string", label: "タイトル" },
+      count: { type: "number", label: "件数" },
+      enabled: { type: "boolean", label: "有効" },
+      mode: {
+        type: "enum",
+        label: "モード",
+        enum: [
+          { label: "標準", value: "normal" },
+          { label: "高速", value: "fast" },
+        ],
+      },
+    },
+  };
+
+  it("custom 0 件なら projectCustom カテゴリは無い", () => {
+    const config = buildConfigWithCustomComponents([]);
+    expect(config.categories?.projectCustom).toBeUndefined();
+    // base の 6 カテゴリは保持
+    expect(config.categories?.layout).toBeDefined();
+  });
+
+  it("custom を渡すと projectCustom カテゴリができ components に custom id が入る", () => {
+    const config = buildConfigWithCustomComponents([customDef]);
+    expect(config.categories?.projectCustom).toBeDefined();
+    expect(config.categories!.projectCustom!.title).toBe("プロジェクト部品 (カスタム)");
+    expect(config.categories!.projectCustom!.components).toContain("my-widget");
+    // base カテゴリは不変
+    expect(config.categories?.layout?.components).toContain("Container");
+  });
+
+  it("custom の各 prop 型が正しい Puck field 型に変換される", () => {
+    const config = buildConfigWithCustomComponents([customDef]);
+    const fields = config.components["my-widget"].fields!;
+
+    expect(fields.title.type).toBe("text");
+    expect(fields.count.type).toBe("number");
+    expect(fields.enabled.type).toBe("radio");
+    expect(fields.mode.type).toBe("select");
+  });
+
+  it("boolean は はい/いいえ の radio options (string value)", () => {
+    const config = buildConfigWithCustomComponents([customDef]);
+    const f = config.components["my-widget"].fields!.enabled as {
+      type: string;
+      options: { label: string; value: string }[];
+    };
+    expect(f.type).toBe("radio");
+    expect(f.options).toEqual([
+      { label: "はい", value: "true" },
+      { label: "いいえ", value: "false" },
+    ]);
+  });
+
+  it("enum は options を反映した select", () => {
+    const config = buildConfigWithCustomComponents([customDef]);
+    const f = config.components["my-widget"].fields!.mode as {
+      type: string;
+      options: { label: string; value: string }[];
+    };
+    expect(f.type).toBe("select");
+    expect(f.options).toEqual([
+      { label: "標準", value: "normal" },
+      { label: "高速", value: "fast" },
+    ]);
   });
 });
 

--- a/frontend/src/puck/__tests__/buildConfig.test.ts
+++ b/frontend/src/puck/__tests__/buildConfig.test.ts
@@ -14,6 +14,7 @@ import {
   mergeCompositeComponents,
   compositeErrorTypeName,
   BUILTIN_PRIMITIVE_NAMES,
+  BUILTIN_PRIMITIVE_TYPE_NAMES,
 } from "../buildConfig";
 import { LAYOUT_FIELDS } from "../buildConfig";
 import { compositeTypeName } from "../../editor/puckSubtree";
@@ -277,6 +278,25 @@ describe("BUILTIN_PRIMITIVE_NAMES", () => {
 
   it("region-main を含む", () => {
     expect(BUILTIN_PRIMITIVE_NAMES).toContain("region-main");
+  });
+});
+
+describe("BUILTIN_PRIMITIVE_TYPE_NAMES drift guard (#1412 P-4 S-3 hardening)", () => {
+  it("派生 type 名集合 (BUILTIN_PRIMITIVE_TYPE_NAMES) と base config の実 component キー集合が双方向完全一致する", () => {
+    // base = カスタム / 外部 / 複合を一切渡さずに生成した config。
+    // この config.components には built-in primitive の実登録キーのみが入り、
+    // error-card / 動的キーは混じらない (それらは merge* 経路でのみ追加される)。
+    const base = buildPuckConfig();
+    const actualKeys = new Set(Object.keys(base.components));
+    const derivedNames = new Set(BUILTIN_PRIMITIVE_TYPE_NAMES);
+
+    // 派生名にあって実 config に無いもの (= 派生規則が config 登録キーとズレた / primitive 削除漏れ)。
+    const missingFromConfig = [...derivedNames].filter((n) => !actualKeys.has(n));
+    // 実 config にあって派生名に無いもの (= primitive 追加時に BUILTIN_PRIMITIVE_NAMES へ反映漏れ)。
+    const extraInConfig = [...actualKeys].filter((n) => !derivedNames.has(n));
+
+    expect(missingFromConfig).toEqual([]);
+    expect(extraInConfig).toEqual([]);
   });
 });
 

--- a/frontend/src/puck/__tests__/buildConfig.test.ts
+++ b/frontend/src/puck/__tests__/buildConfig.test.ts
@@ -11,10 +11,16 @@ import { describe, it, expect } from "vitest";
 import {
   buildPuckConfig,
   buildConfigWithCustomComponents,
+  mergeCompositeComponents,
+  compositeErrorTypeName,
   BUILTIN_PRIMITIVE_NAMES,
 } from "../buildConfig";
 import { LAYOUT_FIELDS } from "../buildConfig";
-import type { CustomPuckComponentDef } from "../../store/puckComponentsStore";
+import { compositeTypeName } from "../../editor/puckSubtree";
+import type {
+  CustomPuckComponentDef,
+  CompositePuckComponentDef,
+} from "../../store/puckComponentsStore";
 
 const LAYOUT_FIELD_KEYS = Object.keys(LAYOUT_FIELDS);
 
@@ -171,6 +177,7 @@ describe("buildPuckConfig categories (#1410 P-2)", () => {
 
 describe("buildConfigWithCustomComponents categories + fields (#1410 P-2)", () => {
   const customDef: CustomPuckComponentDef = {
+    kind: "primitive",
     id: "my-widget",
     label: "マイウィジェット",
     primitive: "container",
@@ -270,5 +277,69 @@ describe("BUILTIN_PRIMITIVE_NAMES", () => {
 
   it("region-main を含む", () => {
     expect(BUILTIN_PRIMITIVE_NAMES).toContain("region-main");
+  });
+});
+
+describe("mergeCompositeComponents (#1412 P-4)", () => {
+  const compositeDef: CompositePuckComponentDef = {
+    kind: "composite",
+    id: "saved-form",
+    label: "保存フォーム",
+    tree: {
+      content: [{ type: "Card", props: { id: "card-1" } }],
+      zones: { "card-1:content": [{ type: "Heading", props: { id: "h-1" } }] },
+    },
+  };
+
+  it("composite 0 件なら projectComposite カテゴリは無く base を返す", () => {
+    const base = buildConfigWithCustomComponents([]);
+    const result = mergeCompositeComponents(base, []);
+    expect(result).toBe(base);
+    expect(result.categories?.projectComposite).toBeUndefined();
+  });
+
+  it("composite を渡すと projectComposite カテゴリ (title「複合部品」) ができる", () => {
+    const config = mergeCompositeComponents(buildPuckConfig(), [compositeDef]);
+    expect(config.categories?.projectComposite).toBeDefined();
+    expect(config.categories!.projectComposite!.title).toBe("複合部品");
+  });
+
+  it("placeholder type (__composite__<id>) が components に登録されパレットに並ぶ", () => {
+    const config = mergeCompositeComponents(buildPuckConfig(), [compositeDef]);
+    const placeholderType = compositeTypeName("saved-form");
+    expect(config.components).toHaveProperty(placeholderType);
+    expect(config.categories!.projectComposite!.components).toContain(placeholderType);
+  });
+
+  it("missing-dependency error-card type も登録されるがパレットには出さない", () => {
+    const config = mergeCompositeComponents(buildPuckConfig(), [compositeDef]);
+    const errorType = compositeErrorTypeName("saved-form");
+    expect(config.components).toHaveProperty(errorType);
+    // パレット (projectComposite) には error type は含めない。
+    expect(config.categories!.projectComposite!.components).not.toContain(errorType);
+  });
+
+  it("projectComposite は既存カテゴリ (composite = 業務複合) と別物で衝突しない", () => {
+    const config = mergeCompositeComponents(buildPuckConfig(), [compositeDef]);
+    // 業務複合 primitive の composite カテゴリは不変。
+    expect(config.categories?.composite?.title).toBe("業務複合");
+    expect(config.categories?.composite?.components).toContain("Card");
+    // 複合部品は別カテゴリ。
+    expect(config.categories?.projectComposite).toBeDefined();
+  });
+
+  it("base.components の既存 key は上書きしない (衝突安全)", () => {
+    const base = buildPuckConfig();
+    const cardRender = base.components.Card.render;
+    const config = mergeCompositeComponents(base, [compositeDef]);
+    expect(config.components.Card.render).toBe(cardRender);
+  });
+
+  it("placeholder の render は最小ラベルを返す (実体は drop 後に展開される)", () => {
+    const config = mergeCompositeComponents(buildPuckConfig(), [compositeDef]);
+    const placeholderType = compositeTypeName("saved-form");
+    const comp = config.components[placeholderType];
+    expect(comp.label).toBe("複合部品: 保存フォーム");
+    expect(typeof comp.render).toBe("function");
   });
 });

--- a/frontend/src/puck/__tests__/buildConfig.test.ts
+++ b/frontend/src/puck/__tests__/buildConfig.test.ts
@@ -7,7 +7,7 @@
  * #806 子 4
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   buildPuckConfig,
   buildConfigWithCustomComponents,
@@ -361,5 +361,42 @@ describe("mergeCompositeComponents (#1412 P-4)", () => {
     const comp = config.components[placeholderType];
     expect(comp.label).toBe("複合部品: 保存フォーム");
     expect(typeof comp.render).toBe("function");
+  });
+
+  it("placeholder type が base.components と衝突する composite は登録を skip し既存を保持する (#1415 P3)", () => {
+    const placeholderType = compositeTypeName("saved-form");
+    // base.components に同名 type の既存 component を予め置く (型整合のため
+    // 既存 Card component config を流用し、参照同一性で「保持」を検証する)。
+    const base = buildPuckConfig();
+    const sentinel = { ...base.components.Card, label: "既存コンポーネント" };
+    base.components = {
+      ...base.components,
+      [placeholderType]: sentinel,
+    };
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const config = mergeCompositeComponents(base, [compositeDef]);
+
+      // base 側の既存 component が保持され、composite placeholder で上書きされていない。
+      expect(config.components[placeholderType]).toBe(sentinel);
+      expect(config.components[placeholderType].label).toBe("既存コンポーネント");
+      // skip された def の error-card / categories も登録されない。
+      const errorType = compositeErrorTypeName("saved-form");
+      expect(config.components).not.toHaveProperty(errorType);
+      expect(config.categories?.projectComposite).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("衝突しない通常 composite は従来どおり登録される (skip 導入後も回帰なし)", () => {
+    const config = mergeCompositeComponents(buildPuckConfig(), [compositeDef]);
+    const placeholderType = compositeTypeName("saved-form");
+    const errorType = compositeErrorTypeName("saved-form");
+    expect(config.components).toHaveProperty(placeholderType);
+    expect(config.components).toHaveProperty(errorType);
+    expect(config.categories!.projectComposite!.components).toContain(placeholderType);
   });
 });

--- a/frontend/src/puck/__tests__/dogfoodExternalComponents.test.tsx
+++ b/frontend/src/puck/__tests__/dogfoodExternalComponents.test.tsx
@@ -44,7 +44,9 @@ import {
 import type { CompositePuckComponentDef } from "../../store/puckComponentsStore";
 
 const ORIGIN = "http://localhost:5179";
-const ASSET_PREFIX = "/workspace-assets/puck-components/";
+// #1415 P2-1: asset URL は wsId-scoped (`/workspace-assets/<wsId>/puck-components/`)。
+const WS_ID = "dogfood-ws";
+const ASSET_PREFIX = `/workspace-assets/${WS_ID}/puck-components/`;
 // 実 vite build 成果物 (.mjs)。loader が解決する moduleUrl はこの fixture へ向ける。
 const FIXTURE_MJS_URL = `${ORIGIN}${ASSET_PREFIX}dist/approval-status-bar.mjs`;
 
@@ -95,6 +97,7 @@ describe("dogfood: 外部 component 通し検証 (#1413 P-5)", () => {
   // -----------------------------------------------------------------------
   it("cap1: 実 build した .mjs を loader で読み込み status=ok、render すると hooks が動く (React 同一インスタンス)", async () => {
     const loaded = await loadExternalComponents({
+      wsId: WS_ID,
       backendOrigin: ORIGIN,
       fetchImpl: fixtureFetch(),
       importImpl: realFixtureImport,
@@ -123,6 +126,7 @@ describe("dogfood: 外部 component 通し検証 (#1413 P-5)", () => {
   // -----------------------------------------------------------------------
   it("cap2+cap3: mergeExternalComponents で projectExternal カテゴリ登録 + props が Puck fields に変換される", async () => {
     const loaded = await loadExternalComponents({
+      wsId: WS_ID,
       backendOrigin: ORIGIN,
       fetchImpl: fixtureFetch(),
       importImpl: realFixtureImport,
@@ -162,6 +166,7 @@ describe("dogfood: 外部 component 通し検証 (#1413 P-5)", () => {
   // -----------------------------------------------------------------------
   it("cap4(slot): content slot が slot field + defaultProps[content]=[] で初期化され、render-prop 注入で内部が描画される", async () => {
     const loaded = await loadExternalComponents({
+      wsId: WS_ID,
       backendOrigin: ORIGIN,
       fetchImpl: fixtureFetch(),
       importImpl: realFixtureImport,
@@ -197,6 +202,7 @@ describe("dogfood: 外部 component 通し検証 (#1413 P-5)", () => {
   // -----------------------------------------------------------------------
   it("cap4(composite): approval-status-bar を内包する複合部品をロード済 config で展開すると成功する", async () => {
     const loaded = await loadExternalComponents({
+      wsId: WS_ID,
       backendOrigin: ORIGIN,
       fetchImpl: fixtureFetch(),
       importImpl: realFixtureImport,
@@ -310,12 +316,86 @@ describe("dogfood: 外部 component 通し検証 (#1413 P-5)", () => {
     expect(config.components[compositeErrorTypeName("approval-card")]).toBeDefined();
   });
 
+  it("cap4(composite, #1415 P2-2): slot 内 (props 配列) に外部部品を内包する複合部品の未ロード依存も missing-dependency error-card に落ちる", () => {
+    // approval-status-bar をロードしない config (= built-in のみ)。
+    const config = mergeCompositeComponents(buildPuckConfig(), [
+      {
+        id: "slot-card",
+        kind: "composite",
+        label: "スロット内承認帯カード",
+        tree: {
+          // Card の中に Container を置き、Container の slot field (props.content) に
+          // 外部部品 approval-status-bar を内包する (= zones ではなく props 同居 slot)。
+          content: [
+            {
+              type: "Card",
+              props: {
+                id: "card-root",
+                content: [
+                  { type: "approval-status-bar", props: { id: "asb-1" } },
+                ],
+              },
+            },
+          ],
+        },
+        dependencies: ["approval-status-bar"],
+      } satisfies CompositePuckComponentDef,
+    ]);
+
+    const tree: Subtree = {
+      content: [
+        {
+          type: "Card",
+          props: {
+            id: "card-root",
+            content: [{ type: "approval-status-bar", props: { id: "asb-1" } }],
+          },
+        },
+      ],
+    };
+
+    // cap6 依存収集: slot 内 nested 外部部品が dependencies に上がる (#1415 P2-2)。
+    const builtinTypes = new Set(BUILTIN_PRIMITIVE_TYPE_NAMES);
+    expect(collectDependencies(tree, builtinTypes)).toEqual([
+      "approval-status-bar",
+    ]);
+
+    const expandable: ExpandableComposite = {
+      id: "slot-card",
+      label: "スロット内承認帯カード",
+      tree,
+      errorType: compositeErrorTypeName("slot-card"),
+    };
+    // availableTypes に approval-status-bar が無い (= 未ロード)。
+    const availableTypes = new Set(Object.keys(config.components));
+    expect(availableTypes.has("approval-status-bar")).toBe(false);
+
+    const data = {
+      root: { props: {} },
+      content: [{ type: compositeTypeName("slot-card"), props: { id: "ph" } }],
+    } as Data;
+    const result = expandCompositePlaceholders(data, [expandable], availableTypes);
+
+    // 展開後、Card は残り、その props.content (slot) 内の approval-status-bar が error-card 型に
+    // 差し替わっている (slot content の依存欠落も検出される)。
+    const card = result.content.find(
+      (i) => (i as { type: string }).type === "Card",
+    ) as { props: { content: { type: string; props: { missingType?: string } }[] } };
+    expect(card).toBeDefined();
+    const inner = card.props.content[0];
+    expect(inner.type).toBe(compositeErrorTypeName("slot-card"));
+    expect(inner.props.missingType).toBe("approval-status-bar");
+    // error-card 型は config に登録済 → 描画可能。
+    expect(config.components[compositeErrorTypeName("slot-card")]).toBeDefined();
+  });
+
   // -----------------------------------------------------------------------
   // cap5: project scoping
   // -----------------------------------------------------------------------
   it("cap5: 別 workspace の manifest を別 fetchImpl で解決すると互いに混入しない", async () => {
     // workspace A = fixture (approval-status-bar)
     const loadedA = await loadExternalComponents({
+      wsId: WS_ID,
       backendOrigin: ORIGIN,
       fetchImpl: fixtureFetch(),
       importImpl: realFixtureImport,
@@ -333,6 +413,7 @@ describe("dogfood: 外部 component 通し検証 (#1413 P-5)", () => {
       ],
     };
     const loadedB = await loadExternalComponents({
+      wsId: WS_ID,
       backendOrigin: ORIGIN,
       fetchImpl: fixtureFetch(manifestB),
       importImpl: async () => ({ default: () => null }),
@@ -365,6 +446,7 @@ describe("dogfood: 外部 component 通し検証 (#1413 P-5)", () => {
       ],
     };
     const loaded = await loadExternalComponents({
+      wsId: WS_ID,
       backendOrigin: ORIGIN,
       fetchImpl: fixtureFetch(collidingManifest),
       importImpl: async () => ({ default: () => null }),
@@ -394,6 +476,7 @@ describe("dogfood: 外部 component 通し検証 (#1413 P-5)", () => {
   // -----------------------------------------------------------------------
   it("cap6: manifest-invalid (schemaVersion 不正) は manifest-invalid", async () => {
     const loaded = await loadExternalComponents({
+      wsId: WS_ID,
       backendOrigin: ORIGIN,
       fetchImpl: fixtureFetch({ schemaVersion: "999", components: [] }),
       importImpl: realFixtureImport,
@@ -411,6 +494,7 @@ describe("dogfood: 外部 component 通し検証 (#1413 P-5)", () => {
       components: [{ ...manifestJson.components[0], engine: { react: "18", puck: "0.20" } }],
     };
     const loaded = await loadExternalComponents({
+      wsId: WS_ID,
       backendOrigin: ORIGIN,
       fetchImpl: fixtureFetch(badEngine),
       importImpl: importSpy,
@@ -428,6 +512,7 @@ describe("dogfood: 外部 component 通し検証 (#1413 P-5)", () => {
       components: [{ ...manifestJson.components[0], export: "NotExist" }],
     };
     const loaded = await loadExternalComponents({
+      wsId: WS_ID,
       backendOrigin: ORIGIN,
       fetchImpl: fixtureFetch(wrongExport),
       importImpl: realFixtureImport, // default だけ export する実 .mjs
@@ -447,6 +532,7 @@ describe("dogfood: 外部 component 通し検証 (#1413 P-5)", () => {
       ],
     };
     const loaded = await loadExternalComponents({
+      wsId: WS_ID,
       backendOrigin: ORIGIN,
       fetchImpl: fixtureFetch(evilModule),
       importImpl: importSpy,

--- a/frontend/src/puck/__tests__/dogfoodExternalComponents.test.tsx
+++ b/frontend/src/puck/__tests__/dogfoodExternalComponents.test.tsx
@@ -1,0 +1,480 @@
+/**
+ * dogfoodExternalComponents.test.tsx — 外部 component + 複合部品 dogfood 通し検証 (#1413 P-5)。
+ *
+ * RFC #1405 シリーズ P-5。P-1〜P-4 で実装した外部 React Component 読込基盤を、
+ * **実 scaffold → vite build した本物の業務部品** (承認ステータス帯) で 1 ファイルに通し検証する。
+ *
+ * fixture (hermetic):
+ *   - fixtures/external-dogfood/approval-status-bar.mjs  : 実 vite build 成果物 (ESM)
+ *   - fixtures/external-dogfood/manifest.json            : 編集済 manifest (enum prop + slot)
+ *   - fixtures/external-dogfood/ApprovalStatusBar.source.tsx : 出典ソース (参照用)
+ *
+ * capability 1-6 を it 名に cap 番号付きで明示する:
+ *   cap1: loading + React 二重化防止 (実 .mjs を vitest 経由で実 import → render → hooks 動作)
+ *   cap2: palette カテゴリ登録 / cap3: props→fields 変換
+ *   cap4: slot field + 複合部品 (#1412) 展開 (ロード済 / 未ロード)
+ *   cap5: project scoping (workspace 間で混入しない / id 衝突防御)
+ *   cap6: validation / fallback (manifest-invalid / version-mismatch / missing-export / load-error)
+ *
+ * 既存 externalComponents.test.ts / mergeExternalComponents.test.tsx / puckSubtree.test.ts の
+ * API シグネチャ・書き方に合わせている。
+ */
+import { createElement } from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import type { Data } from "@measured/puck";
+
+import manifestJson from "./fixtures/external-dogfood/manifest.json";
+import { loadExternalComponents } from "../externalComponents";
+import type { LoadedExternalComponent } from "../externalComponents";
+import {
+  buildPuckConfig,
+  mergeExternalComponents,
+  mergeCompositeComponents,
+  compositeErrorTypeName,
+  BUILTIN_PRIMITIVE_TYPE_NAMES,
+} from "../buildConfig";
+import {
+  compositeTypeName,
+  expandCompositePlaceholders,
+  collectDependencies,
+  type ExpandableComposite,
+  type Subtree,
+} from "../../editor/puckSubtree";
+import type { CompositePuckComponentDef } from "../../store/puckComponentsStore";
+
+const ORIGIN = "http://localhost:5179";
+const ASSET_PREFIX = "/workspace-assets/puck-components/";
+// 実 vite build 成果物 (.mjs)。loader が解決する moduleUrl はこの fixture へ向ける。
+const FIXTURE_MJS_URL = `${ORIGIN}${ASSET_PREFIX}dist/approval-status-bar.mjs`;
+
+/** fixture manifest.json をそのまま返す fetch stub。 */
+function fixtureFetch(manifest: unknown = manifestJson): typeof fetch {
+  return vi.fn(async (url: string) => {
+    // loader は `${origin}${prefix}manifest.json` を取りに来る。
+    expect(String(url)).toContain("manifest.json");
+    return {
+      ok: true,
+      status: 200,
+      json: async () => manifest,
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+}
+
+/**
+ * 実 .mjs を vitest (vite transform) 経由で動的 import する importImpl。
+ *
+ * loader が resolveSafeModuleUrl で生成する moduleUrl
+ * (= `${ORIGIN}${ASSET_PREFIX}dist/approval-status-bar.mjs`) を、ローカル fixture の
+ * 相対 import に振り替える。これにより「実 build 成果物を host React で実 import して render」
+ * = cap1 (React 二重化防止) を本物の artifact で検証できる。
+ *
+ * fixture .mjs は bare specifier `import * as React from "react"` /
+ * `import { jsx } from "react/jsx-runtime"` を持つため、vitest がそれを host (テストプロセス) の
+ * react に解決する → host React と同一インスタンスになる (= 二重化しない)。
+ */
+async function realFixtureImport(url: string): Promise<Record<string, unknown>> {
+  expect(url).toBe(FIXTURE_MJS_URL);
+  const mod = await import("./fixtures/external-dogfood/approval-status-bar.mjs");
+  return mod as unknown as Record<string, unknown>;
+}
+
+/** loaded 配列から id で 1 件取り出す。 */
+function pick(
+  loaded: LoadedExternalComponent[],
+  id: string,
+): LoadedExternalComponent {
+  const found = loaded.find((l) => l.entry.id === id);
+  if (!found) throw new Error(`loaded entry not found: ${id}`);
+  return found;
+}
+
+describe("dogfood: 外部 component 通し検証 (#1413 P-5)", () => {
+  // -----------------------------------------------------------------------
+  // cap1: loading + React 二重化防止
+  // -----------------------------------------------------------------------
+  it("cap1: 実 build した .mjs を loader で読み込み status=ok、render すると hooks が動く (React 同一インスタンス)", async () => {
+    const loaded = await loadExternalComponents({
+      backendOrigin: ORIGIN,
+      fetchImpl: fixtureFetch(),
+      importImpl: realFixtureImport,
+    });
+    expect(loaded).toHaveLength(1);
+    const item = pick(loaded, "approval-status-bar");
+    expect(item.status).toBe("ok");
+    if (item.status !== "ok") return;
+
+    // 実 component を React element として render する (createElement、Puck の render 経路と同じ)。
+    // 内部で useState を使うため、host React と別インスタンスなら "Invalid hook call" で throw
+    // する。throw せず描画できることが二重化防止の証跡。
+    // 注意: Component({...}) と直呼びすると render 外実行になり dispatcher が null で hooks が
+    // 必ず落ちる。必ず createElement 経由で render する。
+    const { getByText, getByTestId } = render(
+      createElement(item.Component, { status: "approved", title: "稟議書 #42" }),
+    );
+    // 見出しと status バッジ (hooks 経由の描画) が出る。
+    expect(getByText("稟議書 #42")).toBeTruthy();
+    const badge = getByTestId("approval-status-badge");
+    expect(badge.textContent).toBe("承認済み");
+  });
+
+  // -----------------------------------------------------------------------
+  // cap2 (palette) + cap3 (props→fields)
+  // -----------------------------------------------------------------------
+  it("cap2+cap3: mergeExternalComponents で projectExternal カテゴリ登録 + props が Puck fields に変換される", async () => {
+    const loaded = await loadExternalComponents({
+      backendOrigin: ORIGIN,
+      fetchImpl: fixtureFetch(),
+      importImpl: realFixtureImport,
+    });
+    const config = mergeExternalComponents(buildPuckConfig(), loaded);
+
+    // cap2: component 登録 + palette カテゴリ
+    expect(config.components["approval-status-bar"]).toBeDefined();
+    expect(config.components["approval-status-bar"].label).toBe("(外部) 承認ステータス帯");
+    expect(config.categories?.projectExternal?.components).toContain("approval-status-bar");
+    // base カテゴリは不変 (回帰なし)
+    expect(config.categories?.layout?.components).toContain("Container");
+
+    // cap3: props→fields
+    const fields = config.components["approval-status-bar"].fields!;
+    // title (string) → text
+    expect(fields.title.type).toBe("text");
+    // status (enum) → select、enum options が透過される
+    const statusField = fields.status as {
+      type: string;
+      options: { label: string; value: string }[];
+    };
+    expect(statusField.type).toBe("select");
+    expect(statusField.options).toEqual([
+      { label: "承認待ち", value: "pending" },
+      { label: "承認済み", value: "approved" },
+      { label: "却下", value: "rejected" },
+    ]);
+    // defaultProps は manifest default 集約 (title / status) + slot 空配列
+    const dp = config.components["approval-status-bar"].defaultProps!;
+    expect(dp.title).toBe("承認ステータス");
+    expect(dp.status).toBe("pending");
+  });
+
+  // -----------------------------------------------------------------------
+  // cap4: slot field + render-prop 注入
+  // -----------------------------------------------------------------------
+  it("cap4(slot): content slot が slot field + defaultProps[content]=[] で初期化され、render-prop 注入で内部が描画される", async () => {
+    const loaded = await loadExternalComponents({
+      backendOrigin: ORIGIN,
+      fetchImpl: fixtureFetch(),
+      importImpl: realFixtureImport,
+    });
+    const config = mergeExternalComponents(buildPuckConfig(), loaded);
+    const def = config.components["approval-status-bar"];
+
+    // slot field
+    const contentField = def.fields!.content as { type: string; label?: string };
+    expect(contentField.type).toBe("slot");
+    expect(contentField.label).toBe("本文スロット");
+    // 空 editable region で初期化
+    expect(def.defaultProps!.content).toEqual([]);
+
+    // render-prop 注入: Puck は slot prop を render-prop に変換して注入する。
+    // mergeExternalComponents の render は createElement(Component, props) で透過するため、
+    // content() が呼ばれて内部が描画される。
+    const { getByText } = render(
+      <>
+        {def.render({
+          status: "pending",
+          title: "申請書",
+          content: () => <span>SLOT_INNER_BODY</span>,
+          puck: { renderDropZone: () => null },
+        } as never)}
+      </>,
+    );
+    expect(getByText("SLOT_INNER_BODY")).toBeTruthy();
+  });
+
+  // -----------------------------------------------------------------------
+  // cap4: 複合部品 (#1412) — ロード済 / 未ロード
+  // -----------------------------------------------------------------------
+  it("cap4(composite): approval-status-bar を内包する複合部品をロード済 config で展開すると成功する", async () => {
+    const loaded = await loadExternalComponents({
+      backendOrigin: ORIGIN,
+      fetchImpl: fixtureFetch(),
+      importImpl: realFixtureImport,
+    });
+    let config = mergeExternalComponents(buildPuckConfig(), loaded);
+
+    const def: CompositePuckComponentDef = {
+      id: "approval-card",
+      kind: "composite",
+      label: "承認カード",
+      tree: {
+        content: [{ type: "Card", props: { id: "card-root" } }],
+        zones: {
+          // Card の中に外部部品 approval-status-bar を内包する。
+          "card-root:content": [
+            { type: "approval-status-bar", props: { id: "asb-1", status: "approved" } },
+          ],
+        },
+      },
+      dependencies: ["approval-status-bar"],
+    };
+
+    config = mergeCompositeComponents(config, [def]);
+    // placeholder が projectComposite カテゴリに並ぶ
+    expect(config.categories?.projectComposite?.components).toContain(
+      compositeTypeName("approval-card"),
+    );
+
+    const expandable: ExpandableComposite = {
+      id: def.id,
+      label: def.label,
+      tree: def.tree as Subtree,
+      errorType: compositeErrorTypeName(def.id),
+    };
+    // availableTypes は config の全 type (外部 component 込み)。
+    const availableTypes = new Set(Object.keys(config.components));
+    // ロード済なので外部 component は available に含まれる → 依存欠落なし。
+    const builtinTypes = new Set(BUILTIN_PRIMITIVE_TYPE_NAMES);
+    expect(collectDependencies(def.tree as Subtree, builtinTypes)).toEqual([
+      "approval-status-bar",
+    ]);
+
+    const data = {
+      root: { props: {} },
+      content: [{ type: compositeTypeName("approval-card"), props: { id: "ph" } }],
+    } as Data;
+    const result = expandCompositePlaceholders(data, [expandable], availableTypes);
+
+    // placeholder は消え Card に展開、内部に approval-status-bar が残る (error-card にならない)。
+    const contentTypes = result.content.map((i) => (i as { type: string }).type);
+    expect(contentTypes).toContain("Card");
+    expect(contentTypes).not.toContain(compositeTypeName("approval-card"));
+    const zoneNodes = Object.values(result.zones ?? {}).flat();
+    const types = zoneNodes.map((n) => (n as { type: string }).type);
+    expect(types).toContain("approval-status-bar");
+    expect(types).not.toContain(compositeErrorTypeName("approval-card"));
+  });
+
+  it("cap4(composite): 未ロードの外部 type を内包する複合部品は missing-dependency error-card に落ちる", () => {
+    // approval-status-bar をロードしない config (= built-in のみ)。
+    const config = mergeCompositeComponents(buildPuckConfig(), [
+      {
+        id: "approval-card",
+        kind: "composite",
+        label: "承認カード",
+        tree: {
+          content: [{ type: "Card", props: { id: "card-root" } }],
+          zones: {
+            "card-root:content": [
+              { type: "approval-status-bar", props: { id: "asb-1" } },
+            ],
+          },
+        },
+        dependencies: ["approval-status-bar"],
+      } satisfies CompositePuckComponentDef,
+    ]);
+
+    const expandable: ExpandableComposite = {
+      id: "approval-card",
+      label: "承認カード",
+      tree: {
+        content: [{ type: "Card", props: { id: "card-root" } }],
+        zones: {
+          "card-root:content": [
+            { type: "approval-status-bar", props: { id: "asb-1" } },
+          ],
+        },
+      },
+      errorType: compositeErrorTypeName("approval-card"),
+    };
+    // availableTypes に approval-status-bar が無い (= 未ロード)。
+    const availableTypes = new Set(Object.keys(config.components));
+    expect(availableTypes.has("approval-status-bar")).toBe(false);
+
+    const data = {
+      root: { props: {} },
+      content: [{ type: compositeTypeName("approval-card"), props: { id: "ph" } }],
+    } as Data;
+    const result = expandCompositePlaceholders(data, [expandable], availableTypes);
+
+    // 依存欠落ノードが error-card 型に差し替わる。
+    const zoneNodes = Object.values(result.zones ?? {}).flat();
+    const errorNode = zoneNodes.find(
+      (n) => (n as { type: string }).type === compositeErrorTypeName("approval-card"),
+    );
+    expect(errorNode).toBeDefined();
+    expect(
+      (errorNode as { props: { missingType?: string } }).props.missingType,
+    ).toBe("approval-status-bar");
+    // error-card 型は config に登録済 (mergeCompositeComponents が登録) → 描画可能。
+    expect(config.components[compositeErrorTypeName("approval-card")]).toBeDefined();
+  });
+
+  // -----------------------------------------------------------------------
+  // cap5: project scoping
+  // -----------------------------------------------------------------------
+  it("cap5: 別 workspace の manifest を別 fetchImpl で解決すると互いに混入しない", async () => {
+    // workspace A = fixture (approval-status-bar)
+    const loadedA = await loadExternalComponents({
+      backendOrigin: ORIGIN,
+      fetchImpl: fixtureFetch(),
+      importImpl: realFixtureImport,
+    });
+    // workspace B = 別 id の manifest (実 import しない簡易 stub)
+    const manifestB = {
+      schemaVersion: "1",
+      components: [
+        {
+          id: "billing-summary",
+          label: "請求サマリ",
+          module: "./dist/billing-summary.mjs",
+          version: "1.0.0",
+        },
+      ],
+    };
+    const loadedB = await loadExternalComponents({
+      backendOrigin: ORIGIN,
+      fetchImpl: fixtureFetch(manifestB),
+      importImpl: async () => ({ default: () => null }),
+    });
+
+    const configA = mergeExternalComponents(buildPuckConfig(), loadedA);
+    const configB = mergeExternalComponents(buildPuckConfig(), loadedB);
+
+    // A には B の component が混入しない、B には A が混入しない。
+    expect(configA.components["approval-status-bar"]).toBeDefined();
+    expect(configA.components["billing-summary"]).toBeUndefined();
+    expect(configB.components["billing-summary"]).toBeDefined();
+    expect(configB.components["approval-status-bar"]).toBeUndefined();
+    expect(configA.categories?.projectExternal?.components).toEqual([
+      "approval-status-bar",
+    ]);
+    expect(configB.categories?.projectExternal?.components).toEqual(["billing-summary"]);
+  });
+
+  it("cap5: 既存 built-in id と衝突する外部 component は built-in を上書きせず id-collision に落ちる", async () => {
+    const collidingManifest = {
+      schemaVersion: "1",
+      components: [
+        {
+          id: "Container", // built-in と衝突
+          label: "悪意のContainer",
+          module: "./dist/x.mjs",
+          version: "1.0.0",
+        },
+      ],
+    };
+    const loaded = await loadExternalComponents({
+      backendOrigin: ORIGIN,
+      fetchImpl: fixtureFetch(collidingManifest),
+      importImpl: async () => ({ default: () => null }),
+    });
+    const base = buildPuckConfig();
+    const originalContainer = base.components["Container"];
+    const merged = mergeExternalComponents(base, loaded);
+
+    // built-in Container は不変。
+    expect(merged.components["Container"]).toBe(originalContainer);
+    expect(merged.components["Container"].label).not.toContain("外部");
+    // 衝突は別 key の id-collision エラーカードに落ちる。
+    const collisionKeys = Object.keys(merged.components).filter(
+      (k) => !(k in base.components),
+    );
+    expect(collisionKeys).toHaveLength(1);
+    const { getByTestId } = render(
+      <>{merged.components[collisionKeys[0]].render({ puck: { renderDropZone: () => null } } as never)}</>,
+    );
+    expect(
+      getByTestId("external-component-error-card").getAttribute("data-error-kind"),
+    ).toBe("id-collision");
+  });
+
+  // -----------------------------------------------------------------------
+  // cap6: validation / fallback (各 errorKind の代表)
+  // -----------------------------------------------------------------------
+  it("cap6: manifest-invalid (schemaVersion 不正) は manifest-invalid", async () => {
+    const loaded = await loadExternalComponents({
+      backendOrigin: ORIGIN,
+      fetchImpl: fixtureFetch({ schemaVersion: "999", components: [] }),
+      importImpl: realFixtureImport,
+    });
+    expect(loaded[0].status).toBe("error");
+    if (loaded[0].status === "error") {
+      expect(loaded[0].errorKind).toBe("manifest-invalid");
+    }
+  });
+
+  it("cap6: version-mismatch (engine.react=18) は version-mismatch (import せず)", async () => {
+    const importSpy = vi.fn(async () => ({ default: () => null }));
+    const badEngine = {
+      ...manifestJson,
+      components: [{ ...manifestJson.components[0], engine: { react: "18", puck: "0.20" } }],
+    };
+    const loaded = await loadExternalComponents({
+      backendOrigin: ORIGIN,
+      fetchImpl: fixtureFetch(badEngine),
+      importImpl: importSpy,
+    });
+    expect(loaded[0].status).toBe("error");
+    if (loaded[0].status === "error") {
+      expect(loaded[0].errorKind).toBe("version-mismatch");
+    }
+    expect(importSpy).not.toHaveBeenCalled();
+  });
+
+  it("cap6: missing-export (export 名不在) は missing-export", async () => {
+    const wrongExport = {
+      ...manifestJson,
+      components: [{ ...manifestJson.components[0], export: "NotExist" }],
+    };
+    const loaded = await loadExternalComponents({
+      backendOrigin: ORIGIN,
+      fetchImpl: fixtureFetch(wrongExport),
+      importImpl: realFixtureImport, // default だけ export する実 .mjs
+    });
+    expect(loaded[0].status).toBe("error");
+    if (loaded[0].status === "error") {
+      expect(loaded[0].errorKind).toBe("missing-export");
+    }
+  });
+
+  it("cap6: load-error (module が配信範囲外 = SSRF) は import せず load-error", async () => {
+    const importSpy = vi.fn(async () => ({ default: () => null }));
+    const evilModule = {
+      ...manifestJson,
+      components: [
+        { ...manifestJson.components[0], module: "https://evil.example.com/x.mjs" },
+      ],
+    };
+    const loaded = await loadExternalComponents({
+      backendOrigin: ORIGIN,
+      fetchImpl: fixtureFetch(evilModule),
+      importImpl: importSpy,
+    });
+    expect(loaded[0].status).toBe("error");
+    if (loaded[0].status === "error") {
+      expect(loaded[0].errorKind).toBe("load-error");
+      expect(loaded[0].detail).toContain("配信範囲外");
+    }
+    expect(importSpy).not.toHaveBeenCalled();
+  });
+
+  it("cap6: 各 errorKind の entry は mergeExternalComponents でエラーカード化され UX 文言が出る", async () => {
+    const loaded: LoadedExternalComponent[] = [
+      {
+        entry: { id: "e1", label: "稟議部品", module: "", version: "1.0.0" },
+        status: "error",
+        errorKind: "version-mismatch",
+        detail: "react major 18 != host 19",
+      },
+    ];
+    const merged = mergeExternalComponents(buildPuckConfig(), loaded);
+    const { getByTestId } = render(
+      <>{merged.components["e1"].render({ puck: { renderDropZone: () => null } } as never)}</>,
+    );
+    const card = getByTestId("external-component-error-card");
+    expect(card.getAttribute("data-error-kind")).toBe("version-mismatch");
+    expect(card.textContent).toContain("バージョン不一致");
+    expect(card.textContent).toContain("稟議部品");
+  });
+});

--- a/frontend/src/puck/__tests__/fixtures/external-dogfood/ApprovalStatusBar.source.tsx
+++ b/frontend/src/puck/__tests__/fixtures/external-dogfood/ApprovalStatusBar.source.tsx
@@ -1,0 +1,108 @@
+// ApprovalStatusBar.source.tsx — 出典ソース (参照用、#1413 P-5 dogfood fixture)。
+//
+// この .tsx は `node scripts/scaffold/puck-component.mjs approval-status-bar` で生成した
+// 雛形を業務的に編集した出典ソース。同ディレクトリの `approval-status-bar.mjs` は
+// このソースを `npm run build` (vite lib build、react/@measured/puck external) した成果物。
+// fixture を hermetic に保つため build 成果物 (.mjs) と manifest.json と共に commit している。
+// テスト (dogfoodExternalComponents.test.tsx) は .mjs を実 import して検証する。
+//
+// ApprovalStatusBar.tsx — 外部 Puck Component サンプル (承認ステータス帯、RFC #1405 P-5 dogfood)。
+//
+// 業務部品: 申請の承認状態を色付き帯で示すヘッダ。タイトル + ステータスバッジ + 任意の本文 slot。
+// props は manifest.json の props 宣言と対応させる。
+// React は host と共有されるため、必ず "react" から import する (import map で解決)。
+import * as React from "react";
+
+export type ApprovalStatus = "pending" | "approved" | "rejected";
+
+export interface ApprovalStatusBarProps {
+  /** 承認状態 (manifest enum prop と対応) */
+  status?: ApprovalStatus;
+  /** 帯に表示する見出し */
+  title?: string;
+  /**
+   * named slot (editable region) の render-prop。manifest の slots 宣言と対応する。
+   * host (Harmony) が Puck の slot field を render-prop に変換して注入するため、
+   * 外部部品側で DropZone を import する必要はない。呼び出すと、設計者がその領域に
+   * Puck で配置した部品が描画される (#1411 P-3)。
+   */
+  content?: (props?: Record<string, unknown>) => React.ReactNode;
+}
+
+const STATUS_LABELS: Record<ApprovalStatus, string> = {
+  pending: "承認待ち",
+  approved: "承認済み",
+  rejected: "却下",
+};
+
+const STATUS_COLORS: Record<ApprovalStatus, { bg: string; fg: string; border: string }> = {
+  pending: { bg: "#fff8e1", fg: "#7a5b00", border: "#f0c040" },
+  approved: { bg: "#e8f5e9", fg: "#1b5e20", border: "#4caf50" },
+  rejected: { bg: "#ffebee", fg: "#b71c1c", border: "#e53935" },
+};
+
+export default function ApprovalStatusBar({
+  status = "pending",
+  title = "承認ステータス",
+  content,
+}: ApprovalStatusBarProps) {
+  // React hooks を 1 つ使い、host React と同一インスタンスであることを実証する
+  // (二重 React なら "Invalid hook call" で落ちる)。
+  const [expanded, setExpanded] = React.useState(true);
+  const palette = STATUS_COLORS[status] ?? STATUS_COLORS.pending;
+  const statusLabel = STATUS_LABELS[status] ?? status;
+
+  return (
+    <div
+      data-external-component="ApprovalStatusBar"
+      data-status={status}
+      style={{
+        border: `1px solid ${palette.border}`,
+        borderRadius: 6,
+        overflow: "hidden",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 12,
+          padding: "8px 12px",
+          background: palette.bg,
+          color: palette.fg,
+        }}
+      >
+        <strong>{title}</strong>
+        <span
+          data-testid="approval-status-badge"
+          style={{
+            border: `1px solid ${palette.border}`,
+            borderRadius: 999,
+            padding: "2px 10px",
+            fontSize: 12,
+            fontWeight: 600,
+            background: "#fff",
+          }}
+        >
+          {statusLabel}
+        </span>
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          style={{
+            border: "none",
+            background: "transparent",
+            cursor: "pointer",
+            color: palette.fg,
+            fontSize: 12,
+          }}
+        >
+          {expanded ? "折りたたむ" : "展開する"}
+        </button>
+      </div>
+      {/* editable region: host 注入 slot。設計者が Puck で内部に部品を配置できる。 */}
+      {expanded && content ? <div style={{ padding: 12 }}>{content()}</div> : null}
+    </div>
+  );
+}

--- a/frontend/src/puck/__tests__/fixtures/external-dogfood/approval-status-bar.d.mts
+++ b/frontend/src/puck/__tests__/fixtures/external-dogfood/approval-status-bar.d.mts
@@ -1,0 +1,14 @@
+/**
+ * approval-status-bar.d.mts — dogfood fixture (#1413 P-5) の型宣言。
+ *
+ * 同ディレクトリの `approval-status-bar.mjs` は外部 component の実 vite build 成果物
+ * (ESM、JS only) のため型宣言を持たない。dogfoodExternalComponents.test.tsx が
+ * 動的 import (`import("./...approval-status-bar.mjs")`) する際の implicit-any (TS7016) を
+ * 避けるための最小宣言。moduleResolution=bundler では `*.mjs` import の宣言は `*.d.mts`。
+ *
+ * 実体 (default export) は React FunctionComponent だが、テストは loader 契約
+ * (ComponentType<any> として受け取り createElement で render) を検証するのみのため、
+ * ここでは緩い型 (default: unknown) で十分。
+ */
+declare const ApprovalStatusBar: unknown;
+export default ApprovalStatusBar;

--- a/frontend/src/puck/__tests__/fixtures/external-dogfood/approval-status-bar.mjs
+++ b/frontend/src/puck/__tests__/fixtures/external-dogfood/approval-status-bar.mjs
@@ -1,0 +1,83 @@
+import { jsxs as o, jsx as d } from "react/jsx-runtime";
+import * as c from "react";
+const b = {
+  pending: "承認待ち",
+  approved: "承認済み",
+  rejected: "却下"
+}, a = {
+  pending: { bg: "#fff8e1", fg: "#7a5b00", border: "#f0c040" },
+  approved: { bg: "#e8f5e9", fg: "#1b5e20", border: "#4caf50" },
+  rejected: { bg: "#ffebee", fg: "#b71c1c", border: "#e53935" }
+};
+function g({
+  status: r = "pending",
+  title: p = "承認ステータス",
+  content: t
+}) {
+  const [n, i] = c.useState(!0), e = a[r] ?? a.pending, s = b[r] ?? r;
+  return /* @__PURE__ */ o(
+    "div",
+    {
+      "data-external-component": "ApprovalStatusBar",
+      "data-status": r,
+      style: {
+        border: `1px solid ${e.border}`,
+        borderRadius: 6,
+        overflow: "hidden"
+      },
+      children: [
+        /* @__PURE__ */ o(
+          "div",
+          {
+            style: {
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: 12,
+              padding: "8px 12px",
+              background: e.bg,
+              color: e.fg
+            },
+            children: [
+              /* @__PURE__ */ d("strong", { children: p }),
+              /* @__PURE__ */ d(
+                "span",
+                {
+                  "data-testid": "approval-status-badge",
+                  style: {
+                    border: `1px solid ${e.border}`,
+                    borderRadius: 999,
+                    padding: "2px 10px",
+                    fontSize: 12,
+                    fontWeight: 600,
+                    background: "#fff"
+                  },
+                  children: s
+                }
+              ),
+              /* @__PURE__ */ d(
+                "button",
+                {
+                  type: "button",
+                  onClick: () => i((l) => !l),
+                  style: {
+                    border: "none",
+                    background: "transparent",
+                    cursor: "pointer",
+                    color: e.fg,
+                    fontSize: 12
+                  },
+                  children: n ? "折りたたむ" : "展開する"
+                }
+              )
+            ]
+          }
+        ),
+        n && t ? /* @__PURE__ */ d("div", { style: { padding: 12 }, children: t() }) : null
+      ]
+    }
+  );
+}
+export {
+  g as default
+};

--- a/frontend/src/puck/__tests__/fixtures/external-dogfood/manifest.json
+++ b/frontend/src/puck/__tests__/fixtures/external-dogfood/manifest.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": "1",
+  "components": [
+    {
+      "id": "approval-status-bar",
+      "label": "承認ステータス帯",
+      "module": "./dist/approval-status-bar.mjs",
+      "export": "default",
+      "version": "0.1.0",
+      "engine": {
+        "react": "19",
+        "puck": "0.20"
+      },
+      "props": [
+        {
+          "name": "title",
+          "type": "string",
+          "label": "見出し",
+          "default": "承認ステータス"
+        },
+        {
+          "name": "status",
+          "type": "enum",
+          "label": "承認状態",
+          "default": "pending",
+          "enum": [
+            { "label": "承認待ち", "value": "pending" },
+            { "label": "承認済み", "value": "approved" },
+            { "label": "却下", "value": "rejected" }
+          ]
+        }
+      ],
+      "slots": [
+        {
+          "name": "content",
+          "label": "本文スロット"
+        }
+      ]
+    }
+  ]
+}

--- a/frontend/src/puck/__tests__/mergeExternalComponents.test.tsx
+++ b/frontend/src/puck/__tests__/mergeExternalComponents.test.tsx
@@ -294,6 +294,90 @@ describe("mergeExternalComponents props→fields (#1410 P-2)", () => {
   });
 });
 
+describe("mergeExternalComponents slot fields (#1411 P-3)", () => {
+  const slotEntry: ExternalComponentEntry = {
+    id: "ext-slot",
+    label: "外部Slot",
+    module: "./dist/slot.mjs",
+    version: "1.0.0",
+    slots: [{ name: "content", label: "本文スロット" }],
+  };
+
+  it("slots 宣言された ok entry は当該 slot 名で slot field を生成する", () => {
+    const loaded: LoadedExternalComponent[] = [
+      { entry: slotEntry, status: "ok", Component: () => null },
+    ];
+    const merged = mergeExternalComponents(buildPuckConfig(), loaded);
+    const fields = merged.components["ext-slot"].fields!;
+    expect(fields.content.type).toBe("slot");
+    expect((fields.content as { label?: string }).label).toBe("本文スロット");
+  });
+
+  it("slot label 省略時は slot 名を label に使う", () => {
+    const noLabel: ExternalComponentEntry = {
+      ...slotEntry,
+      slots: [{ name: "content" }],
+    };
+    const loaded: LoadedExternalComponent[] = [
+      { entry: noLabel, status: "ok", Component: () => null },
+    ];
+    const merged = mergeExternalComponents(buildPuckConfig(), loaded);
+    const f = merged.components["ext-slot"].fields!.content as {
+      type: string;
+      label?: string;
+    };
+    expect(f.type).toBe("slot");
+    expect(f.label).toBe("content");
+  });
+
+  it("defaultProps[slotName] は空配列で初期化される", () => {
+    const loaded: LoadedExternalComponent[] = [
+      { entry: slotEntry, status: "ok", Component: () => null },
+    ];
+    const merged = mergeExternalComponents(buildPuckConfig(), loaded);
+    expect(merged.components["ext-slot"].defaultProps!.content).toEqual([]);
+  });
+
+  it("slot + prop 併存時、両方が fields に乗り prop field 型は従来通り", () => {
+    const mixed: ExternalComponentEntry = {
+      id: "ext-mixed",
+      label: "外部Mixed",
+      module: "./dist/mixed.mjs",
+      version: "1.0.0",
+      props: [
+        { name: "title", type: "string", label: "タイトル", default: "T" },
+        { name: "count", type: "number", label: "件数" },
+      ],
+      slots: [{ name: "body", label: "本体" }],
+    };
+    const loaded: LoadedExternalComponent[] = [
+      { entry: mixed, status: "ok", Component: () => null },
+    ];
+    const merged = mergeExternalComponents(buildPuckConfig(), loaded);
+    const fields = merged.components["ext-mixed"].fields!;
+    expect(fields.title.type).toBe("text");
+    expect(fields.count.type).toBe("number");
+    expect(fields.body.type).toBe("slot");
+    // prop default は維持、slot は空配列で初期化
+    expect(merged.components["ext-mixed"].defaultProps).toEqual({
+      title: "T",
+      body: [],
+    });
+  });
+
+  it("slot 無し entry は slot field を追加しない (回帰なし)", () => {
+    const loaded: LoadedExternalComponent[] = [
+      { entry, status: "ok", Component: () => null },
+    ];
+    const merged = mergeExternalComponents(buildPuckConfig(), loaded);
+    const fields = merged.components["ext-foo"].fields!;
+    const slotFieldKeys = Object.entries(fields).filter(
+      ([, def]) => (def as { type: string }).type === "slot",
+    );
+    expect(slotFieldKeys.length).toBe(0);
+  });
+});
+
 describe("mergeExternalComponents categories (#1410 P-2)", () => {
   it("外部 0 件 (loaded=[]) のとき categories は base と同一 (projectExternal 無し)", () => {
     const base = buildPuckConfig();

--- a/frontend/src/puck/__tests__/mergeExternalComponents.test.tsx
+++ b/frontend/src/puck/__tests__/mergeExternalComponents.test.tsx
@@ -77,8 +77,9 @@ describe("mergeExternalComponents", () => {
 
   it("id 衝突 (built-in Container): 既存を上書きせずエラーカードを別 key で登録", () => {
     const base = buildPuckConfig();
-    // built-in の Container render 関数を控えておく
-    const originalContainerRender = base.components["Container"].render;
+    // built-in の Container 実体 (config object) を控えておく
+    const originalContainer = base.components["Container"];
+    const originalContainerRender = originalContainer.render;
     const collidingEntry: ExternalComponentEntry = {
       ...entry,
       id: "Container",
@@ -89,12 +90,19 @@ describe("mergeExternalComponents", () => {
     ];
     const merged = mergeExternalComponents(base, loaded);
 
-    // built-in Container は上書きされず保持される
+    // built-in Container は上書きされず元の実体がそのまま保持される
+    expect(merged.components["Container"]).toBe(originalContainer);
     expect(merged.components["Container"].render).toBe(originalContainerRender);
     expect(merged.components["Container"].label).not.toContain("外部");
 
-    // 衝突は別 key でエラーカードとして登録される
-    const collisionDef = merged.components["__ext_collision__Container"];
+    // 衝突は base に無い一意 key でエラーカードとして登録される
+    const collisionEntries = Object.entries(merged.components).filter(
+      ([k]) => !(k in base.components) && k !== "Container",
+    );
+    expect(collisionEntries.length).toBe(1);
+    const [collisionKey, collisionDef] = collisionEntries[0];
+    // 採番 key は base.components の既存 key と衝突しない
+    expect(base.components[collisionKey]).toBeUndefined();
     expect(collisionDef).toBeDefined();
     const { getByTestId } = render(
       <>{collisionDef.render({ puck: { renderDropZone: () => null } } as never)}</>,
@@ -106,6 +114,7 @@ describe("mergeExternalComponents", () => {
 
   it("id 衝突なし: 通常通り実 component を登録する", () => {
     const base = buildPuckConfig();
+    const baseKeyCount = Object.keys(base.components).length;
     const loaded: LoadedExternalComponent[] = [
       { entry, status: "ok", Component: () => null },
     ];
@@ -113,8 +122,94 @@ describe("mergeExternalComponents", () => {
     const def = merged.components["ext-foo"];
     expect(def).toBeDefined();
     expect(def.label).toBe("(外部) 外部Foo");
-    // 衝突 key は作られない
-    expect(merged.components["__ext_collision__ext-foo"]).toBeUndefined();
+    // 衝突カードは作られず、base + 1 component のみ
+    expect(Object.keys(merged.components).length).toBe(baseKeyCount + 1);
+  });
+
+  it("同一 manifest 内で id 重複: 1 件目は実 component、2 件目は id-collision、base 不変", () => {
+    const base = buildPuckConfig();
+    const baseKeys = Object.keys(base.components);
+    const dupEntry: ExternalComponentEntry = {
+      ...entry,
+      id: "ext-dup",
+      label: "重複ext",
+    };
+    const loaded: LoadedExternalComponent[] = [
+      { entry: dupEntry, status: "ok", Component: () => <div>first</div> },
+      { entry: dupEntry, status: "ok", Component: () => <div>second</div> },
+    ];
+    const merged = mergeExternalComponents(base, loaded);
+
+    // 1 件目は実 component として ext-dup key に登録
+    expect(merged.components["ext-dup"]).toBeDefined();
+    expect(merged.components["ext-dup"].label).toBe("(外部) 重複ext");
+
+    // 2 件目は id-collision エラーカードとして別 key に登録
+    const extra = Object.entries(merged.components).filter(
+      ([k]) => !baseKeys.includes(k) && k !== "ext-dup",
+    );
+    expect(extra.length).toBe(1);
+    const [collisionKey, collisionDef] = extra[0];
+    expect(base.components[collisionKey]).toBeUndefined();
+    const { getByTestId } = render(
+      <>{collisionDef.render({ puck: { renderDropZone: () => null } } as never)}</>,
+    );
+    expect(getByTestId("external-component-error-card").getAttribute("data-error-kind")).toBe(
+      "id-collision",
+    );
+
+    // base.components は不変 (key 数も実体も)
+    for (const k of baseKeys) {
+      expect(merged.components[k]).toBe(base.components[k]);
+    }
+  });
+
+  it("衝突カード key が既存 literal key と衝突しない (一意採番)", () => {
+    // base に collision カードが採番しうる literal key を仕込んでおく。
+    // i=0 の衝突カードは `__ext_error__Container__0` を採番しようとするため、
+    // それを base に literal で予約しておき、別の一意 key に逃げることを検証する。
+    const rawBase = buildPuckConfig();
+    const occupiedKey = "__ext_error__Container__0";
+    const base: typeof rawBase = {
+      ...rawBase,
+      components: {
+        ...rawBase.components,
+        [occupiedKey]: {
+          label: "占有済みカスタム",
+          fields: {},
+          defaultProps: {},
+          render: () => <div data-testid="occupier">occupier</div>,
+        },
+      },
+    };
+    const occupierDef = base.components[occupiedKey];
+    const collidingEntry: ExternalComponentEntry = {
+      ...entry,
+      id: "Container",
+      label: "悪意のContainer",
+    };
+    const loaded: LoadedExternalComponent[] = [
+      { entry: collidingEntry, status: "ok", Component: () => null },
+    ];
+    const merged = mergeExternalComponents(base, loaded);
+
+    // 占有済み key は上書きされず元の実体がそのまま保持される
+    expect(merged.components[occupiedKey]).toBe(occupierDef);
+
+    // 衝突カードは occupiedKey とも Container とも別の一意 key に登録される
+    const collisionEntries = Object.entries(merged.components).filter(
+      ([k]) => !(k in base.components),
+    );
+    expect(collisionEntries.length).toBe(1);
+    const [collisionKey, collisionDef] = collisionEntries[0];
+    expect(collisionKey).not.toBe(occupiedKey);
+    expect(collisionKey).not.toBe("Container");
+    const { getByTestId } = render(
+      <>{collisionDef.render({ puck: { renderDropZone: () => null } } as never)}</>,
+    );
+    expect(getByTestId("external-component-error-card").getAttribute("data-error-kind")).toBe(
+      "id-collision",
+    );
   });
 
   it("base の既存 component を保持する", () => {

--- a/frontend/src/puck/__tests__/mergeExternalComponents.test.tsx
+++ b/frontend/src/puck/__tests__/mergeExternalComponents.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * mergeExternalComponents.test.tsx — 外部 component の Puck config 統合テスト (#1409 P-1)。
+ *
+ * - status="ok": 実 component を render する render 関数になる
+ * - status="error": ExternalComponentErrorCard を render する render 関数になる
+ */
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { buildPuckConfig, mergeExternalComponents } from "../buildConfig";
+import type { LoadedExternalComponent } from "../externalComponents";
+import type { ExternalComponentEntry } from "../externalComponentManifest";
+
+const entry: ExternalComponentEntry = {
+  id: "ext-foo",
+  label: "外部Foo",
+  module: "./dist/foo.mjs",
+  version: "1.0.0",
+  props: [
+    { name: "title", type: "string", default: "デフォルト見出し" },
+    { name: "noDefault", type: "string" },
+  ],
+};
+
+describe("mergeExternalComponents", () => {
+  it("loaded が空なら base をそのまま返す", () => {
+    const base = buildPuckConfig();
+    const merged = mergeExternalComponents(base, []);
+    expect(Object.keys(merged.components).length).toBe(
+      Object.keys(base.components).length,
+    );
+  });
+
+  it("status=ok: 実 component を render する config を登録する", () => {
+    const ExtComponent = (props: { title?: string }) => (
+      <div data-testid="ext-rendered">{props.title}</div>
+    );
+    const loaded: LoadedExternalComponent[] = [
+      { entry, status: "ok", Component: ExtComponent },
+    ];
+    const merged = mergeExternalComponents(buildPuckConfig(), loaded);
+
+    const def = merged.components["ext-foo"];
+    expect(def).toBeDefined();
+    expect(def.label).toBe("(外部) 外部Foo");
+    // defaultProps は manifest props の default 集約
+    expect(def.defaultProps).toEqual({ title: "デフォルト見出し" });
+
+    const { getByTestId } = render(
+      <>{def.render({ title: "実行時タイトル", puck: { renderDropZone: () => null } } as never)}</>,
+    );
+    expect(getByTestId("ext-rendered").textContent).toBe("実行時タイトル");
+  });
+
+  it("status=error: エラーカードを render する config を登録する", () => {
+    const loaded: LoadedExternalComponent[] = [
+      {
+        entry,
+        status: "error",
+        errorKind: "load-error",
+        detail: "boom detail",
+      },
+    ];
+    const merged = mergeExternalComponents(buildPuckConfig(), loaded);
+
+    const def = merged.components["ext-foo"];
+    expect(def).toBeDefined();
+    expect(def.label).toBe("(外部·エラー) 外部Foo");
+
+    const { getByTestId } = render(
+      <>{def.render({ puck: { renderDropZone: () => null } } as never)}</>,
+    );
+    const card = getByTestId("external-component-error-card");
+    expect(card.getAttribute("data-error-kind")).toBe("load-error");
+    expect(card.textContent).toContain("モジュール読込失敗");
+    expect(card.textContent).toContain("外部Foo");
+  });
+
+  it("base の既存 component を保持する", () => {
+    const base = buildPuckConfig();
+    const baseKeys = Object.keys(base.components);
+    const loaded: LoadedExternalComponent[] = [
+      { entry, status: "ok", Component: () => null },
+    ];
+    const merged = mergeExternalComponents(base, loaded);
+    for (const k of baseKeys) {
+      expect(merged.components[k]).toBeDefined();
+    }
+    expect(merged.components["ext-foo"]).toBeDefined();
+  });
+});

--- a/frontend/src/puck/__tests__/mergeExternalComponents.test.tsx
+++ b/frontend/src/puck/__tests__/mergeExternalComponents.test.tsx
@@ -409,6 +409,113 @@ describe("mergeExternalComponents slot fields (#1411 P-3)", () => {
   });
 });
 
+describe("mergeExternalComponents boolean prop coerce (#1415 P2-5)", () => {
+  const boolEntry: ExternalComponentEntry = {
+    id: "ext-bool",
+    label: "外部Bool",
+    module: "./dist/bool.mjs",
+    version: "1.0.0",
+    props: [
+      { name: "title", type: "string", label: "タイトル" },
+      { name: "enabled", type: "boolean", label: "有効", default: false },
+    ],
+  };
+
+  // 受け取った enabled prop の実型を data 属性で曝露する probe component。
+  const BoolProbe = (props: { enabled?: unknown; title?: string }) => (
+    <div
+      data-testid="bool-probe"
+      data-enabled-type={typeof props.enabled}
+      data-enabled-value={String(props.enabled)}
+    >
+      {props.title}
+    </div>
+  );
+
+  it("文字列 \"false\" は render 境界で実 boolean false に coerce される", () => {
+    const loaded: LoadedExternalComponent[] = [
+      { entry: boolEntry, status: "ok", Component: BoolProbe },
+    ];
+    const merged = mergeExternalComponents(buildPuckConfig(), loaded);
+    const def = merged.components["ext-bool"];
+
+    const { getByTestId } = render(
+      <>
+        {def.render({
+          enabled: "false",
+          title: "T",
+          puck: { renderDropZone: () => null },
+        } as never)}
+      </>,
+    );
+    const probe = getByTestId("bool-probe");
+    expect(probe.getAttribute("data-enabled-type")).toBe("boolean");
+    expect(probe.getAttribute("data-enabled-value")).toBe("false");
+  });
+
+  it("文字列 \"true\" は実 boolean true に coerce される", () => {
+    const loaded: LoadedExternalComponent[] = [
+      { entry: boolEntry, status: "ok", Component: BoolProbe },
+    ];
+    const merged = mergeExternalComponents(buildPuckConfig(), loaded);
+    const def = merged.components["ext-bool"];
+
+    const { getByTestId } = render(
+      <>
+        {def.render({
+          enabled: "true",
+          puck: { renderDropZone: () => null },
+        } as never)}
+      </>,
+    );
+    const probe = getByTestId("bool-probe");
+    expect(probe.getAttribute("data-enabled-type")).toBe("boolean");
+    expect(probe.getAttribute("data-enabled-value")).toBe("true");
+  });
+
+  it("defaultProps の boolean default も実 boolean に正規化される (field 型は radio のまま)", () => {
+    const loaded: LoadedExternalComponent[] = [
+      { entry: boolEntry, status: "ok", Component: BoolProbe },
+    ];
+    const merged = mergeExternalComponents(buildPuckConfig(), loaded);
+    const def = merged.components["ext-bool"];
+    // defaultProps は実 boolean (default: false → false)。
+    expect(def.defaultProps!.enabled).toBe(false);
+    expect(typeof def.defaultProps!.enabled).toBe("boolean");
+    // field 定義は従来通り radio + string value (custom 挙動の厳密保持)。
+    const f = def.fields!.enabled as {
+      type: string;
+      options: { label: string; value: string }[];
+    };
+    expect(f.type).toBe("radio");
+    expect(f.options).toEqual([
+      { label: "はい", value: "true" },
+      { label: "いいえ", value: "false" },
+    ]);
+  });
+
+  it("非 boolean prop は coerce されず素通りする", () => {
+    const loaded: LoadedExternalComponent[] = [
+      { entry: boolEntry, status: "ok", Component: BoolProbe },
+    ];
+    const merged = mergeExternalComponents(buildPuckConfig(), loaded);
+    const def = merged.components["ext-bool"];
+
+    const { getByTestId } = render(
+      <>
+        {def.render({
+          enabled: true,
+          title: "見出しテキスト",
+          puck: { renderDropZone: () => null },
+        } as never)}
+      </>,
+    );
+    const probe = getByTestId("bool-probe");
+    // title は string のまま透過。
+    expect(probe.textContent).toBe("見出しテキスト");
+  });
+});
+
 describe("mergeExternalComponents categories (#1410 P-2)", () => {
   it("外部 0 件 (loaded=[]) のとき categories は base と同一 (projectExternal 無し)", () => {
     const base = buildPuckConfig();

--- a/frontend/src/puck/__tests__/mergeExternalComponents.test.tsx
+++ b/frontend/src/puck/__tests__/mergeExternalComponents.test.tsx
@@ -4,6 +4,7 @@
  * - status="ok": 実 component を render する render 関数になる
  * - status="error": ExternalComponentErrorCard を render する render 関数になる
  */
+import type { ReactNode } from "react";
 import { describe, it, expect } from "vitest";
 import { render } from "@testing-library/react";
 import { buildPuckConfig, mergeExternalComponents } from "../buildConfig";
@@ -375,6 +376,36 @@ describe("mergeExternalComponents slot fields (#1411 P-3)", () => {
       ([, def]) => (def as { type: string }).type === "slot",
     );
     expect(slotFieldKeys.length).toBe(0);
+  });
+
+  it("render path: slot prop (render-prop) が外部 Component に forward され中身が描画される", () => {
+    // Puck は render 時に slot prop を SlotComponent (render-prop) に変換して props
+    // 経由で注入する。mergeExternalComponents が生成する render 関数は
+    // createElement(Component, props) で props をそのまま透過するため、外部 Component が
+    // props.content() を呼べば slot 内に配置された中身が描画される。
+    const SlotConsumer = (props: {
+      content?: () => ReactNode;
+    }) => (
+      <div data-testid="slot-consumer">{props.content ? props.content() : null}</div>
+    );
+    const loaded: LoadedExternalComponent[] = [
+      { entry: slotEntry, status: "ok", Component: SlotConsumer },
+    ];
+    const merged = mergeExternalComponents(buildPuckConfig(), loaded);
+    const def = merged.components["ext-slot"];
+
+    const { getByTestId } = render(
+      <>
+        {def.render({
+          // Puck が注入する slot render-prop を模擬。設計者が slot に配置した中身を
+          // 描画する関数を渡す。
+          content: () => <span>SLOT_CONTENT</span>,
+          puck: { renderDropZone: () => null },
+        } as never)}
+      </>,
+    );
+    const consumer = getByTestId("slot-consumer");
+    expect(consumer.textContent).toBe("SLOT_CONTENT");
   });
 });
 

--- a/frontend/src/puck/__tests__/mergeExternalComponents.test.tsx
+++ b/frontend/src/puck/__tests__/mergeExternalComponents.test.tsx
@@ -75,6 +75,48 @@ describe("mergeExternalComponents", () => {
     expect(card.textContent).toContain("外部Foo");
   });
 
+  it("id 衝突 (built-in Container): 既存を上書きせずエラーカードを別 key で登録", () => {
+    const base = buildPuckConfig();
+    // built-in の Container render 関数を控えておく
+    const originalContainerRender = base.components["Container"].render;
+    const collidingEntry: ExternalComponentEntry = {
+      ...entry,
+      id: "Container",
+      label: "悪意のContainer",
+    };
+    const loaded: LoadedExternalComponent[] = [
+      { entry: collidingEntry, status: "ok", Component: () => null },
+    ];
+    const merged = mergeExternalComponents(base, loaded);
+
+    // built-in Container は上書きされず保持される
+    expect(merged.components["Container"].render).toBe(originalContainerRender);
+    expect(merged.components["Container"].label).not.toContain("外部");
+
+    // 衝突は別 key でエラーカードとして登録される
+    const collisionDef = merged.components["__ext_collision__Container"];
+    expect(collisionDef).toBeDefined();
+    const { getByTestId } = render(
+      <>{collisionDef.render({ puck: { renderDropZone: () => null } } as never)}</>,
+    );
+    const card = getByTestId("external-component-error-card");
+    expect(card.getAttribute("data-error-kind")).toBe("id-collision");
+    expect(card.textContent).toContain("ID 衝突");
+  });
+
+  it("id 衝突なし: 通常通り実 component を登録する", () => {
+    const base = buildPuckConfig();
+    const loaded: LoadedExternalComponent[] = [
+      { entry, status: "ok", Component: () => null },
+    ];
+    const merged = mergeExternalComponents(base, loaded);
+    const def = merged.components["ext-foo"];
+    expect(def).toBeDefined();
+    expect(def.label).toBe("(外部) 外部Foo");
+    // 衝突 key は作られない
+    expect(merged.components["__ext_collision__ext-foo"]).toBeUndefined();
+  });
+
   it("base の既存 component を保持する", () => {
     const base = buildPuckConfig();
     const baseKeys = Object.keys(base.components);

--- a/frontend/src/puck/__tests__/mergeExternalComponents.test.tsx
+++ b/frontend/src/puck/__tests__/mergeExternalComponents.test.tsx
@@ -225,3 +225,148 @@ describe("mergeExternalComponents", () => {
     expect(merged.components["ext-foo"]).toBeDefined();
   });
 });
+
+describe("mergeExternalComponents props→fields (#1410 P-2)", () => {
+  const fieldEntry: ExternalComponentEntry = {
+    id: "ext-fields",
+    label: "外部Fields",
+    module: "./dist/fields.mjs",
+    version: "1.0.0",
+    props: [
+      { name: "title", type: "string", label: "タイトル" },
+      { name: "count", type: "number", label: "件数" },
+      { name: "enabled", type: "boolean", label: "有効" },
+      {
+        name: "mode",
+        type: "enum",
+        label: "モード",
+        enum: [
+          { label: "標準", value: "normal" },
+          { label: "高速", value: "fast" },
+        ],
+      },
+    ],
+  };
+
+  it("status=ok の props が正しい Puck field 型に変換される", () => {
+    const loaded: LoadedExternalComponent[] = [
+      { entry: fieldEntry, status: "ok", Component: () => null },
+    ];
+    const merged = mergeExternalComponents(buildPuckConfig(), loaded);
+    const fields = merged.components["ext-fields"].fields!;
+
+    expect(fields.title.type).toBe("text");
+    expect(fields.count.type).toBe("number");
+    expect(fields.enabled.type).toBe("radio");
+    expect(fields.mode.type).toBe("select");
+  });
+
+  it("boolean は はい/いいえ の radio options", () => {
+    const loaded: LoadedExternalComponent[] = [
+      { entry: fieldEntry, status: "ok", Component: () => null },
+    ];
+    const merged = mergeExternalComponents(buildPuckConfig(), loaded);
+    const f = merged.components["ext-fields"].fields!.enabled as {
+      type: string;
+      options: { label: string; value: string }[];
+    };
+    expect(f.type).toBe("radio");
+    expect(f.options).toEqual([
+      { label: "はい", value: "true" },
+      { label: "いいえ", value: "false" },
+    ]);
+  });
+
+  it("enum は options を反映した select", () => {
+    const loaded: LoadedExternalComponent[] = [
+      { entry: fieldEntry, status: "ok", Component: () => null },
+    ];
+    const merged = mergeExternalComponents(buildPuckConfig(), loaded);
+    const f = merged.components["ext-fields"].fields!.mode as {
+      type: string;
+      options: { label: string; value: string }[];
+    };
+    expect(f.type).toBe("select");
+    expect(f.options).toEqual([
+      { label: "標準", value: "normal" },
+      { label: "高速", value: "fast" },
+    ]);
+  });
+});
+
+describe("mergeExternalComponents categories (#1410 P-2)", () => {
+  it("外部 0 件 (loaded=[]) のとき categories は base と同一 (projectExternal 無し)", () => {
+    const base = buildPuckConfig();
+    const merged = mergeExternalComponents(base, []);
+    expect(merged.categories?.projectExternal).toBeUndefined();
+    // early return で base そのものが返る
+    expect(merged.categories).toBe(base.categories);
+  });
+
+  it("projectExternal カテゴリに ok 外部 id が入る", () => {
+    const loaded: LoadedExternalComponent[] = [
+      { entry, status: "ok", Component: () => null },
+    ];
+    const merged = mergeExternalComponents(buildPuckConfig(), loaded);
+    expect(merged.categories?.projectExternal).toBeDefined();
+    expect(merged.categories!.projectExternal!.title).toBe("プロジェクト部品 (外部)");
+    expect(merged.categories!.projectExternal!.components).toContain("ext-foo");
+    // base カテゴリは不変
+    expect(merged.categories?.layout?.components).toContain("Container");
+  });
+
+  it("status=error の entry の key も projectExternal.components に含まれる", () => {
+    const errEntry: ExternalComponentEntry = {
+      ...entry,
+      id: "ext-err",
+      label: "エラーext",
+    };
+    const loaded: LoadedExternalComponent[] = [
+      {
+        entry: errEntry,
+        status: "error",
+        errorKind: "load-error",
+        detail: "boom",
+      },
+    ];
+    const merged = mergeExternalComponents(buildPuckConfig(), loaded);
+    expect(merged.categories!.projectExternal!.components).toContain("ext-err");
+  });
+
+  it("id 衝突カードの採番 key も projectExternal.components に含まれる", () => {
+    const base = buildPuckConfig();
+    const collidingEntry: ExternalComponentEntry = {
+      ...entry,
+      id: "Container",
+      label: "悪意のContainer",
+    };
+    const loaded: LoadedExternalComponent[] = [
+      { entry: collidingEntry, status: "ok", Component: () => null },
+    ];
+    const merged = mergeExternalComponents(base, loaded);
+
+    const ext = merged.categories!.projectExternal!.components as string[];
+    expect(ext.length).toBe(1);
+    const collisionKey = ext[0];
+    // Container 本体ではなく採番された衝突カード key
+    expect(collisionKey).not.toBe("Container");
+    expect(base.components[collisionKey]).toBeUndefined();
+    expect(merged.components[collisionKey]).toBeDefined();
+  });
+
+  it("base が projectCustom を持つ場合も保持しつつ projectExternal を追加する", () => {
+    const base: ReturnType<typeof buildPuckConfig> = {
+      ...buildPuckConfig(),
+      categories: {
+        ...buildPuckConfig().categories,
+        projectCustom: { title: "プロジェクト部品 (カスタム)", components: ["c1"] },
+      },
+    };
+    const loaded: LoadedExternalComponent[] = [
+      { entry, status: "ok", Component: () => null },
+    ];
+    const merged = mergeExternalComponents(base, loaded);
+    expect(merged.categories?.projectCustom?.components).toContain("c1");
+    expect(merged.categories?.projectExternal?.components).toContain("ext-foo");
+  });
+});

--- a/frontend/src/puck/buildConfig.ts
+++ b/frontend/src/puck/buildConfig.ts
@@ -342,8 +342,15 @@ export function buildConfigWithCustomComponents(customComponents: CustomPuckComp
  *   defaultProps は manifest props の default 集約。
  *   fields は P-1 では最小 (空)。props→fields の本格化は P-2。
  * - status="error": ExternalComponentErrorCard を render するエラーカードを登録。
- * - id 衝突 (built-in / 既存 custom と同じ id): 既存を上書きせず、id-collision の
- *   エラーカードに差し替える。意図しない built-in 部品の置換を防ぐ。
+ * - id 衝突 (built-in / 既存 custom / 先行 external と同じ id): 既存を上書きせず、
+ *   id-collision のエラーカードに差し替える。意図しない built-in 部品の置換を防ぐ。
+ *
+ * 衝突安全性 (defense-in-depth、validator で弾く前提でも merge 層で保証):
+ *   1. base.components の既存 key は **絶対に上書きしない**。
+ *   2. extraComponents の key はすべて usedKeys 採番済 (uniqueKey helper) で、
+ *      base.components とも extraComponents 内でも非衝突であることを保証する。
+ *   3. 同一 manifest 内で id が重複した entry は 2 件目以降が id-collision 扱いになり、
+ *      silent overwrite を防ぐ。
  *
  * 既存 JSON-only custom component 経路 (buildConfigWithCustomComponents) とは別ソースとして
  * 統合する。両者を併用する場合は buildConfigWithCustomComponents の戻り値を base に渡せる。
@@ -355,20 +362,27 @@ export function mergeExternalComponents(
   if (loaded.length === 0) return base;
 
   const extraComponents: Config["components"] = {};
+  // base の全 key を起点にした「使用済み key」集合。
+  // 以降に登録する key (実 component / エラーカード / 衝突カード) はすべてこの集合に
+  // add していき、新規 key 採番時の衝突判定に使う。base の key は不変。
+  const usedKeys = new Set<string>(Object.keys(base.components));
 
-  for (const item of loaded) {
+  for (let i = 0; i < loaded.length; i++) {
+    const item = loaded[i];
     const { entry } = item;
 
-    // id 衝突チェック: base (built-in / 既存 custom) に同じ id があれば上書きせず、
-    // 衝突 entry 専用の別 key (__ext_collision__<id>) でエラーカードを登録する。
-    // これにより既存 built-in / custom 部品は保持したまま、衝突を可視化できる。
-    if (base.components[entry.id] !== undefined) {
-      extraComponents[`__ext_collision__${entry.id}`] = makeErrorCardConfig(
+    // id 衝突チェック: entry.id が built-in / 既存 custom / 先行 external のいずれかと
+    // 既出なら衝突扱い。base を上書きせず、usedKeys に無い一意 key を採番して
+    // id-collision エラーカードを登録する。
+    if (usedKeys.has(entry.id)) {
+      const collisionKey = uniqueKey(`__ext_error__${entry.id}__${i}`, usedKeys);
+      extraComponents[collisionKey] = makeErrorCardConfig(
         entry.label,
         entry.id,
         "id-collision",
         `ID '${entry.id}' は既存 component と衝突`,
       );
+      usedKeys.add(collisionKey);
       continue;
     }
 
@@ -398,6 +412,7 @@ export function mergeExternalComponents(
         detail,
       );
     }
+    usedKeys.add(entry.id);
   }
 
   return {
@@ -407,6 +422,23 @@ export function mergeExternalComponents(
       ...extraComponents,
     },
   };
+}
+
+/**
+ * usedKeys に存在しない一意な key を返す。
+ * preferred がそのまま空いていればそれを返し、衝突する場合は suffix
+ * (`__2`, `__3`, ...) を付与して必ず空き key を得る。
+ * これにより、衝突カード用の key 自体が既存 literal key と衝突する事故を防ぐ。
+ */
+function uniqueKey(preferred: string, usedKeys: Set<string>): string {
+  if (!usedKeys.has(preferred)) return preferred;
+  let n = 2;
+  let candidate = `${preferred}__${n}`;
+  while (usedKeys.has(candidate)) {
+    n += 1;
+    candidate = `${preferred}__${n}`;
+  }
+  return candidate;
 }
 
 /** ExternalComponentErrorCard を render する Puck component config を生成する。 */

--- a/frontend/src/puck/buildConfig.ts
+++ b/frontend/src/puck/buildConfig.ts
@@ -603,8 +603,11 @@ export function mergeExternalComponents(
  * カテゴリは `projectComposite` (title「複合部品」)。既存 `composite` (業務複合 primitive) とは
  * 別物なので名前衝突を避けて projectComposite を使う。
  *
- * 衝突安全性: mergeExternalComponents と同じく base.components の既存 key は絶対に上書きせず、
- * usedKeys / uniqueKey で新規 key の非衝突を保証する。
+ * 衝突安全性 (S-1): placeholder / error-card の type 名は `compositeTypeName(def.id)` /
+ * `compositeErrorTypeName(def.id)` を **そのまま** config キーに使う (uniqueKey で採番しない)。
+ * PuckBackend / expandCompositePlaceholders が同じ名前を直接生成して参照するため、3 者が
+ * 決定論的に一致する必要があるため。`__composite__<uuid>` 構造上、実用上衝突しないが、
+ * 万一の衝突は console.warn で検知し黙って上書きしない (base.components の既存 key は不変)。
  */
 export function mergeCompositeComponents(
   base: Config,
@@ -620,9 +623,27 @@ export function mergeCompositeComponents(
 
   for (let i = 0; i < composites.length; i++) {
     const def = composites[i];
-    const placeholderType = uniqueKey(compositeTypeName(def.id), usedKeys);
+    // S-1: placeholder / error-card の type 名は uniqueKey で採番しない。
+    // PuckBackend (expandableComposites) と expandCompositePlaceholders が
+    // `compositeTypeName(def.id)` / `compositeErrorTypeName(def.id)` を直接生成して
+    // 参照するため、config 登録キーも同じ決定論的な名前である必要がある
+    // (uniqueKey で suffix が付くと参照型と登録型が乖離する)。
+    // `__composite__<uuid>` prefix + UUID 構造上、実用上は衝突しない。
+    // 万一の衝突 (同名キーが既に base.components に存在) は黙って上書きせず
+    // console.warn で検知ログのみ残す。
+    const placeholderType = compositeTypeName(def.id);
+    if (usedKeys.has(placeholderType)) {
+      console.warn(
+        `[mergeCompositeComponents] composite placeholder type '${placeholderType}' は既存 component と衝突 (上書きしません)`,
+      );
+    }
     usedKeys.add(placeholderType);
-    const errorType = uniqueKey(compositeErrorTypeName(def.id), usedKeys);
+    const errorType = compositeErrorTypeName(def.id);
+    if (usedKeys.has(errorType)) {
+      console.warn(
+        `[mergeCompositeComponents] composite error-card type '${errorType}' は既存 component と衝突 (上書きしません)`,
+      );
+    }
     usedKeys.add(errorType);
 
     // placeholder component (drop 直後に展開され消える、render は最小ラベル)。
@@ -634,6 +655,10 @@ export function mergeCompositeComponents(
         createElement(
           "div",
           {
+            // N-2: placeholder の DOM anchor。drop 直後に expandCompositePlaceholders で
+            // subtree に置換され消える transient ノードのため通常は DOM に残らないが、
+            // 展開前の一瞬を E2E / 手動デバッグで掴むための selector hook として付与する
+            // (def.id を埋めることで「どの複合部品の placeholder か」を識別可能)。
             "data-composite-placeholder": def.id,
             style: { padding: 8, color: "#666", fontSize: 13 },
           },
@@ -757,3 +782,23 @@ export const BUILTIN_PRIMITIVE_NAMES = [
 ] as const;
 
 export type BuiltinPrimitiveName = (typeof BUILTIN_PRIMITIVE_NAMES)[number];
+
+/** kebab-case primitive 名を Puck config component type 名 (PascalCase) に変換する。 */
+function toBuiltinTypeName(name: string): string {
+  return name
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join("");
+}
+
+/**
+ * built-in primitive の **Puck config component type 名** (PascalCase) 一覧。
+ *
+ * `BUILTIN_PRIMITIVE_NAMES` は kebab-case (UI 表示・primitive 識別子用) だが、
+ * buildPuckConfig() が config.components に登録する実 type 名は PascalCase
+ * ("Container" / "InputGroup" / "DataList" / "RegionHeader" 等)。
+ * 依存判定 (collectDependencies) は subtree ノードの type (= config キー) と
+ * 突合するため、PascalCase に揃えた集合が必要 (S-3)。
+ */
+export const BUILTIN_PRIMITIVE_TYPE_NAMES: readonly string[] =
+  BUILTIN_PRIMITIVE_NAMES.map(toBuiltinTypeName);

--- a/frontend/src/puck/buildConfig.ts
+++ b/frontend/src/puck/buildConfig.ts
@@ -41,6 +41,7 @@ import type {
   LoadedExternalComponent,
   ExternalComponentErrorKind,
 } from "./externalComponents";
+import type { ExternalSlotDecl } from "./externalComponentManifest";
 import { ExternalComponentErrorCard } from "../components/puck/ExternalComponentErrorCard";
 
 // ---------------------------------------------------------------------------
@@ -195,6 +196,30 @@ function buildFieldsFromPropDecls(
         label: decl.label ?? decl.name,
       };
     }
+  }
+  return fields;
+}
+
+/**
+ * 外部 component の slot 宣言を Puck の slot field に変換する (#1411 P-3)。
+ *
+ * Puck v0.20 の `{ type: "slot" }` field を宣言すると、Puck は render 時に当該 prop を
+ * SlotComponent (= render-prop) に変換して props 経由で注入する。slot 中身は
+ * 当該 component の props に co-located で保存されるため、save/load (PuckBackend が
+ * Puck Data JSON をそのまま draftWrite/draftRead) を無改修で素通りする。
+ *
+ * prop field 生成 (buildFieldsFromPropDecls) とは別ヘルパー。マージ側で
+ * `{ ...propFields, ...slotFields }` の順で合流させる。
+ */
+function buildSlotFields(
+  slots: ExternalSlotDecl[],
+): NonNullable<Config["components"][string]["fields"]> {
+  const fields: NonNullable<Config["components"][string]["fields"]> = {};
+  for (const slot of slots) {
+    fields[slot.name] = {
+      type: "slot" as const,
+      label: slot.label ?? slot.name,
+    };
   }
   return fields;
 }
@@ -487,18 +512,27 @@ export function mergeExternalComponents(
           defaultProps[prop.name] = prop.default;
         }
       }
+      // slot は空の editable region として初期化する (#1411 P-3)。
+      // Puck は defaultProps の slot 値 (= Content 配列) を起点に DropZone を描画する。
+      for (const slot of entry.slots ?? []) {
+        defaultProps[slot.name] = [];
+      }
+      // props field を先に作り、slot field を後ろにマージする (#1411 P-3)。
+      const propFields = buildFieldsFromPropDecls(
+        (entry.props ?? []).map((p) => ({
+          name: p.name,
+          type: p.type,
+          label: p.label,
+          enum: p.enum,
+        })),
+      );
+      const slotFields = buildSlotFields(entry.slots ?? []);
       const Component = item.Component;
       extraComponents[entry.id] = {
         label: `(外部) ${entry.label}`,
         // props → Puck fields 変換 (#1410 P-2、custom 経路と共有ヘルパー)。
-        fields: buildFieldsFromPropDecls(
-          (entry.props ?? []).map((p) => ({
-            name: p.name,
-            type: p.type,
-            label: p.label,
-            enum: p.enum,
-          })),
-        ),
+        // slot field (#1411 P-3) を後ろにマージ (Puck が render-prop に変換して注入する)。
+        fields: { ...propFields, ...slotFields },
         defaultProps,
         render: (props: Record<string, unknown>) =>
           createElement(Component, props),

--- a/frontend/src/puck/buildConfig.ts
+++ b/frontend/src/puck/buildConfig.ts
@@ -230,6 +230,45 @@ function buildSlotFields(
 }
 
 /**
+ * boolean prop の値を実 boolean に正規化する (#1415 P2-5)。
+ *
+ * Puck の boolean field は radio で文字列 "true"/"false" を保持する (既存 custom 挙動を
+ * 厳密保持するため、buildFieldsFromPropDecls 参照)。外部 React component の render 境界では
+ * 文字列 "false" が truthy 評価される事故を防ぐため、実 boolean に coerce する。
+ *
+ * - 文字列 "true" → true / "false" → false (大文字小文字無視、前後空白許容)
+ * - 既に boolean → そのまま
+ * - それ以外 (undefined / 数値等) → Boolean() で評価 (manifest default が boolean 以外の
+ *   不正値でも render が落ちないようにする保険)
+ */
+function coerceBoolean(value: unknown): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === "true") return true;
+    if (normalized === "false") return false;
+  }
+  return Boolean(value);
+}
+
+/**
+ * props のうち booleanPropNames に含まれるキーのみ coerceBoolean を適用した新オブジェクトを返す
+ * (#1415 P2-5)。元 props は破壊しない。boolean prop が無ければ呼出側で props 透過する。
+ */
+function coerceBooleanProps(
+  props: Record<string, unknown>,
+  booleanPropNames: Set<string>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...props };
+  for (const name of booleanPropNames) {
+    if (name in result) {
+      result[name] = coerceBoolean(result[name]);
+    }
+  }
+  return result;
+}
+
+/**
  * 全 primitive に共通追加するレイアウト props の Puck Fields 定義。
  * escape hatch の rawClass は隠し扱い (custom フィールドは Puck v0.20 では type:"custom" が必要だが、
  * 簡易実装として text 型で提供し、UI 上末尾に配置する)。
@@ -516,10 +555,21 @@ export function mergeExternalComponents(
     }
 
     if (item.status === "ok") {
+      // boolean prop の名前集合 (#1415 P2-5)。boolean field は radio の文字列
+      // "true"/"false" で保持されるため (既存 custom 挙動の厳密保持)、外部 component の
+      // render 境界でのみ実 boolean に coerce する。
+      const booleanPropNames = new Set(
+        (entry.props ?? [])
+          .filter((p) => p.type === "boolean")
+          .map((p) => p.name),
+      );
       const defaultProps: Record<string, unknown> = {};
       for (const prop of entry.props ?? []) {
         if (prop.default !== undefined) {
-          defaultProps[prop.name] = prop.default;
+          // defaultProps も coerce 対象に含め、render と一貫させる (#1415 P2-5)。
+          defaultProps[prop.name] = booleanPropNames.has(prop.name)
+            ? coerceBoolean(prop.default)
+            : prop.default;
         }
       }
       // slot は空の editable region として初期化する (#1411 P-3)。
@@ -544,8 +594,16 @@ export function mergeExternalComponents(
         // slot field (#1411 P-3) を後ろにマージ (Puck が render-prop に変換して注入する)。
         fields: { ...propFields, ...slotFields },
         defaultProps,
+        // render 境界で boolean prop の文字列 "true"/"false" を実 boolean に coerce してから
+        // 外部 Component に渡す (#1415 P2-5)。custom (JSON-only) 経路や field 定義 (radio の
+        // string value 表示) は変更せず、external render のみに適用する。
         render: (props: Record<string, unknown>) =>
-          createElement(Component, props),
+          createElement(
+            Component,
+            booleanPropNames.size > 0
+              ? coerceBooleanProps(props, booleanPropNames)
+              : props,
+          ),
       };
     } else {
       // エラー entry はエラーカードを描画する component として登録する。

--- a/frontend/src/puck/buildConfig.ts
+++ b/frontend/src/puck/buildConfig.ts
@@ -36,13 +36,18 @@ import { RegionHeaderConfig } from "./primitives/RegionHeader";
 import { RegionSidebarConfig } from "./primitives/RegionSidebar";
 import { RegionFooterConfig } from "./primitives/RegionFooter";
 import { RegionMainConfig } from "./primitives/RegionMain";
-import type { CustomPuckComponentDef } from "../store/puckComponentsStore";
+import type {
+  CustomPuckComponentDef,
+  CompositePuckComponentDef,
+  PrimitivePuckComponentDef,
+} from "../store/puckComponentsStore";
 import type {
   LoadedExternalComponent,
   ExternalComponentErrorKind,
 } from "./externalComponents";
 import type { ExternalSlotDecl } from "./externalComponentManifest";
 import { ExternalComponentErrorCard } from "../components/puck/ExternalComponentErrorCard";
+import { compositeTypeName } from "../editor/puckSubtree";
 
 // ---------------------------------------------------------------------------
 // 共通レイアウト props の Fields 定義
@@ -372,12 +377,17 @@ export function buildPuckConfig(): Config {
 export function buildConfigWithCustomComponents(customComponents: CustomPuckComponentDef[]): Config {
   const base = buildPuckConfig();
 
-  if (customComponents.length === 0) return base;
+  // primitive 経路のみ対象 (composite は mergeCompositeComponents が別途扱う、#1412 P-4)。
+  const primitiveComponents = customComponents.filter(
+    (c): c is PrimitivePuckComponentDef => c.kind === "primitive",
+  );
+
+  if (primitiveComponents.length === 0) return base;
 
   const extraComponents: Config["components"] = {};
   const customIds: string[] = [];
 
-  for (const def of customComponents) {
+  for (const def of primitiveComponents) {
     customIds.push(def.id);
     const primitiveKey = Object.keys(base.components).find(
       (k) => k.toLowerCase() === def.primitive.toLowerCase().replace(/-/g, ""),
@@ -574,6 +584,110 @@ export function mergeExternalComponents(
       ...extraComponents,
     },
   };
+}
+
+/**
+ * 複合部品 (composite / subtree 再利用、#1412 P-4) を Puck config に統合する。
+ *
+ * 設計方針: expand-on-drop。複合部品は **placeholder component** として登録され、
+ * drop されると PuckBackend の handleChange → expandCompositePlaceholders で
+ * その場で subtree に展開され、placeholder 自体は消える。
+ *
+ * 登録する key 2 種:
+ *   1. placeholder: `compositeTypeName(def.id)` (= `__composite__<id>`)
+ *      パレットに「複合部品: <label>」として並ぶ。render は最小ラベル。
+ *   2. missing-dependency error-card: `compositeErrorTypeName(def.id)`
+ *      展開時、subtree 内に config 未登録 type (= 未ロードの外部 component 等) があった
+ *      ノードを差し替える先 (capability 6)。expandCompositePlaceholders が参照する。
+ *
+ * カテゴリは `projectComposite` (title「複合部品」)。既存 `composite` (業務複合 primitive) とは
+ * 別物なので名前衝突を避けて projectComposite を使う。
+ *
+ * 衝突安全性: mergeExternalComponents と同じく base.components の既存 key は絶対に上書きせず、
+ * usedKeys / uniqueKey で新規 key の非衝突を保証する。
+ */
+export function mergeCompositeComponents(
+  base: Config,
+  composites: CompositePuckComponentDef[],
+): Config {
+  if (composites.length === 0) return base;
+
+  const extraComponents: Config["components"] = {};
+  const usedKeys = new Set<string>(Object.keys(base.components));
+  // パレット (projectComposite カテゴリ) に並べる placeholder key のみ収集する。
+  // error-card key はパレットに出さない (展開時の差し替え先専用)。
+  const placeholderKeys: string[] = [];
+
+  for (let i = 0; i < composites.length; i++) {
+    const def = composites[i];
+    const placeholderType = uniqueKey(compositeTypeName(def.id), usedKeys);
+    usedKeys.add(placeholderType);
+    const errorType = uniqueKey(compositeErrorTypeName(def.id), usedKeys);
+    usedKeys.add(errorType);
+
+    // placeholder component (drop 直後に展開され消える、render は最小ラベル)。
+    extraComponents[placeholderType] = {
+      label: `複合部品: ${def.label}`,
+      fields: {},
+      defaultProps: {},
+      render: () =>
+        createElement(
+          "div",
+          {
+            "data-composite-placeholder": def.id,
+            style: { padding: 8, color: "#666", fontSize: 13 },
+          },
+          `複合部品: ${def.label}`,
+        ),
+    };
+    placeholderKeys.push(placeholderType);
+
+    // missing-dependency error-card (展開時の依存欠落ノード差し替え先、capability 6)。
+    extraComponents[errorType] = {
+      label: `(複合部品·依存エラー) ${def.label}`,
+      fields: {},
+      defaultProps: {},
+      render: (props: Record<string, unknown>) =>
+        createElement(ExternalComponentErrorCard, {
+          errorKind: "missing-dependency",
+          label:
+            typeof props.compositeLabel === "string"
+              ? props.compositeLabel
+              : def.label,
+          id: typeof props.missingType === "string" ? props.missingType : def.id,
+          detail:
+            typeof props.missingType === "string"
+              ? `部品 type '${props.missingType}' が読み込めません (未ロードの外部 component の可能性)`
+              : undefined,
+        }),
+    };
+  }
+
+  const categories: Config["categories"] = {
+    ...(base.categories ?? {}),
+    ...(placeholderKeys.length > 0
+      ? {
+          projectComposite: {
+            title: "複合部品",
+            components: placeholderKeys,
+          },
+        }
+      : {}),
+  };
+
+  return {
+    ...base,
+    categories,
+    components: {
+      ...base.components,
+      ...extraComponents,
+    },
+  };
+}
+
+/** entry.id から複合部品 missing-dependency error-card の Puck component type 名を作る。 */
+export function compositeErrorTypeName(id: string): string {
+  return `__composite_error__${id}`;
 }
 
 /**

--- a/frontend/src/puck/buildConfig.ts
+++ b/frontend/src/puck/buildConfig.ts
@@ -153,7 +153,6 @@ interface NormalizedPropDecl {
   name: string;
   type: "string" | "number" | "boolean" | "enum";
   label?: string;
-  default?: unknown;
   enum?: { label: string; value: string }[];
 }
 
@@ -365,7 +364,6 @@ export function buildConfigWithCustomComponents(customComponents: CustomPuckComp
         name,
         type: f.type,
         label: f.label,
-        default: f.default,
         enum: f.enum,
       })),
     );
@@ -382,8 +380,8 @@ export function buildConfigWithCustomComponents(customComponents: CustomPuckComp
         ...baseComponentConfig,
         label: `(カスタム) ${def.label}`,
         fields: {
-          ...customFields,
           ...(baseComponentConfig.fields ?? {}),
+          ...customFields,
         },
         defaultProps: {
           ...(baseComponentConfig.defaultProps ?? {}),
@@ -498,7 +496,6 @@ export function mergeExternalComponents(
             name: p.name,
             type: p.type,
             label: p.label,
-            default: p.default,
             enum: p.enum,
           })),
         ),

--- a/frontend/src/puck/buildConfig.ts
+++ b/frontend/src/puck/buildConfig.ts
@@ -665,7 +665,8 @@ export function mergeExternalComponents(
  * `compositeErrorTypeName(def.id)` を **そのまま** config キーに使う (uniqueKey で採番しない)。
  * PuckBackend / expandCompositePlaceholders が同じ名前を直接生成して参照するため、3 者が
  * 決定論的に一致する必要があるため。`__composite__<uuid>` 構造上、実用上衝突しないが、
- * 万一の衝突は console.warn で検知し黙って上書きしない (base.components の既存 key は不変)。
+ * 万一の衝突は console.warn で検知し、当該 def の登録を skip する (base.components の
+ * 既存 key を上書きしない、#1415 P3)。
  */
 export function mergeCompositeComponents(
   base: Config,
@@ -690,18 +691,24 @@ export function mergeCompositeComponents(
     // 万一の衝突 (同名キーが既に base.components に存在) は黙って上書きせず
     // console.warn で検知ログのみ残す。
     const placeholderType = compositeTypeName(def.id);
+    const errorType = compositeErrorTypeName(def.id);
+    // placeholder / error-card のどちらかが既存 (built-in / custom / external /
+    // 先行 composite) と衝突する場合、この def の登録を skip する。既存 component を
+    // 上書きすると palette item / render 定義が失われるため (mergeExternalComponents の
+    // id 衝突防御と同方針)。skip する def の key は usedKeys に足さない (既存を消さない)。
     if (usedKeys.has(placeholderType)) {
       console.warn(
-        `[mergeCompositeComponents] composite placeholder type '${placeholderType}' は既存 component と衝突 (上書きしません)`,
+        `[mergeCompositeComponents] composite placeholder type '${placeholderType}' は既存 component と衝突 (この複合部品の登録を skip)`,
       );
+      continue;
     }
-    usedKeys.add(placeholderType);
-    const errorType = compositeErrorTypeName(def.id);
     if (usedKeys.has(errorType)) {
       console.warn(
-        `[mergeCompositeComponents] composite error-card type '${errorType}' は既存 component と衝突 (上書きしません)`,
+        `[mergeCompositeComponents] composite error-card type '${errorType}' は既存 component と衝突 (この複合部品の登録を skip)`,
       );
+      continue;
     }
+    usedKeys.add(placeholderType);
     usedKeys.add(errorType);
 
     // placeholder component (drop 直後に展開され消える、render は最小ラベル)。

--- a/frontend/src/puck/buildConfig.ts
+++ b/frontend/src/puck/buildConfig.ts
@@ -37,7 +37,10 @@ import { RegionSidebarConfig } from "./primitives/RegionSidebar";
 import { RegionFooterConfig } from "./primitives/RegionFooter";
 import { RegionMainConfig } from "./primitives/RegionMain";
 import type { CustomPuckComponentDef } from "../store/puckComponentsStore";
-import type { LoadedExternalComponent } from "./externalComponents";
+import type {
+  LoadedExternalComponent,
+  ExternalComponentErrorKind,
+} from "./externalComponents";
 import { ExternalComponentErrorCard } from "../components/puck/ExternalComponentErrorCard";
 
 // ---------------------------------------------------------------------------
@@ -339,6 +342,8 @@ export function buildConfigWithCustomComponents(customComponents: CustomPuckComp
  *   defaultProps は manifest props の default 集約。
  *   fields は P-1 では最小 (空)。props→fields の本格化は P-2。
  * - status="error": ExternalComponentErrorCard を render するエラーカードを登録。
+ * - id 衝突 (built-in / 既存 custom と同じ id): 既存を上書きせず、id-collision の
+ *   エラーカードに差し替える。意図しない built-in 部品の置換を防ぐ。
  *
  * 既存 JSON-only custom component 経路 (buildConfigWithCustomComponents) とは別ソースとして
  * 統合する。両者を併用する場合は buildConfigWithCustomComponents の戻り値を base に渡せる。
@@ -353,6 +358,19 @@ export function mergeExternalComponents(
 
   for (const item of loaded) {
     const { entry } = item;
+
+    // id 衝突チェック: base (built-in / 既存 custom) に同じ id があれば上書きせず、
+    // 衝突 entry 専用の別 key (__ext_collision__<id>) でエラーカードを登録する。
+    // これにより既存 built-in / custom 部品は保持したまま、衝突を可視化できる。
+    if (base.components[entry.id] !== undefined) {
+      extraComponents[`__ext_collision__${entry.id}`] = makeErrorCardConfig(
+        entry.label,
+        entry.id,
+        "id-collision",
+        `ID '${entry.id}' は既存 component と衝突`,
+      );
+      continue;
+    }
 
     if (item.status === "ok") {
       const defaultProps: Record<string, unknown> = {};
@@ -373,18 +391,12 @@ export function mergeExternalComponents(
     } else {
       // エラー entry はエラーカードを描画する component として登録する。
       const { errorKind, detail } = item;
-      extraComponents[entry.id] = {
-        label: `(外部·エラー) ${entry.label}`,
-        fields: {},
-        defaultProps: {},
-        render: () =>
-          createElement(ExternalComponentErrorCard, {
-            errorKind,
-            label: entry.label,
-            id: entry.id,
-            detail,
-          }),
-      };
+      extraComponents[entry.id] = makeErrorCardConfig(
+        entry.label,
+        entry.id,
+        errorKind,
+        detail,
+      );
     }
   }
 
@@ -394,6 +406,27 @@ export function mergeExternalComponents(
       ...base.components,
       ...extraComponents,
     },
+  };
+}
+
+/** ExternalComponentErrorCard を render する Puck component config を生成する。 */
+function makeErrorCardConfig(
+  label: string,
+  id: string,
+  errorKind: ExternalComponentErrorKind,
+  detail?: string,
+): Config["components"][string] {
+  return {
+    label: `(外部·エラー) ${label}`,
+    fields: {},
+    defaultProps: {},
+    render: () =>
+      createElement(ExternalComponentErrorCard, {
+        errorKind,
+        label,
+        id,
+        detail,
+      }),
   };
 }
 

--- a/frontend/src/puck/buildConfig.ts
+++ b/frontend/src/puck/buildConfig.ts
@@ -37,6 +37,8 @@ import { RegionSidebarConfig } from "./primitives/RegionSidebar";
 import { RegionFooterConfig } from "./primitives/RegionFooter";
 import { RegionMainConfig } from "./primitives/RegionMain";
 import type { CustomPuckComponentDef } from "../store/puckComponentsStore";
+import type { LoadedExternalComponent } from "./externalComponents";
+import { ExternalComponentErrorCard } from "../components/puck/ExternalComponentErrorCard";
 
 // ---------------------------------------------------------------------------
 // 共通レイアウト props の Fields 定義
@@ -317,6 +319,71 @@ export function buildConfigWithCustomComponents(customComponents: CustomPuckComp
           { "data-custom-component": def.id, "data-primitive": def.primitive },
           JSON.stringify(props),
         ),
+      };
+    }
+  }
+
+  return {
+    ...base,
+    components: {
+      ...base.components,
+      ...extraComponents,
+    },
+  };
+}
+
+/**
+ * 外部 React Component (#1409 P-1) を Puck config に統合する。
+ *
+ * - status="ok": entry.Component を render する component を登録。
+ *   defaultProps は manifest props の default 集約。
+ *   fields は P-1 では最小 (空)。props→fields の本格化は P-2。
+ * - status="error": ExternalComponentErrorCard を render するエラーカードを登録。
+ *
+ * 既存 JSON-only custom component 経路 (buildConfigWithCustomComponents) とは別ソースとして
+ * 統合する。両者を併用する場合は buildConfigWithCustomComponents の戻り値を base に渡せる。
+ */
+export function mergeExternalComponents(
+  base: Config,
+  loaded: LoadedExternalComponent[],
+): Config {
+  if (loaded.length === 0) return base;
+
+  const extraComponents: Config["components"] = {};
+
+  for (const item of loaded) {
+    const { entry } = item;
+
+    if (item.status === "ok") {
+      const defaultProps: Record<string, unknown> = {};
+      for (const prop of entry.props ?? []) {
+        if (prop.default !== undefined) {
+          defaultProps[prop.name] = prop.default;
+        }
+      }
+      const Component = item.Component;
+      extraComponents[entry.id] = {
+        label: `(外部) ${entry.label}`,
+        // P-1 では fields は最小 (空)。props→fields 本格化は P-2。
+        fields: {},
+        defaultProps,
+        render: (props: Record<string, unknown>) =>
+          createElement(Component, props),
+      };
+    } else {
+      // エラー entry はエラーカードを描画する component として登録する。
+      const { errorKind, detail } = item;
+      extraComponents[entry.id] = {
+        label: `(外部·エラー) ${entry.label}`,
+        fields: {},
+        defaultProps: {},
+        render: () =>
+          createElement(ExternalComponentErrorCard, {
+            errorKind,
+            label: entry.label,
+            id: entry.id,
+            detail,
+          }),
       };
     }
   }

--- a/frontend/src/puck/buildConfig.ts
+++ b/frontend/src/puck/buildConfig.ts
@@ -110,6 +110,96 @@ const SHADOW_OPTIONS = [
   { label: "大", value: "lg" },
 ];
 
+// ---------------------------------------------------------------------------
+// palette カテゴリ定義 (#1410 P-2)
+// ---------------------------------------------------------------------------
+
+/**
+ * buildPuckConfig の戻り値に乗せる静的カテゴリ定義。
+ *
+ * 重要: Puck は categories を定義すると、どのカテゴリにも未割当の component を
+ * `other` カテゴリへ落とす。そのためビルトイン 24 個を必ず全て割り当てる。
+ * (各カテゴリの意味区分は従来 buildPuckConfig 内コメントの区分を踏襲)
+ */
+const BUILTIN_CATEGORIES: NonNullable<Config["categories"]> = {
+  layout: { title: "レイアウト", components: ["Container", "Row", "Col", "Section"] },
+  text: { title: "テキスト", components: ["Heading", "Paragraph", "Link"] },
+  form: {
+    title: "フォーム",
+    components: ["Input", "Select", "Textarea", "Checkbox", "Radio", "Button"],
+  },
+  data: { title: "データ", components: ["Table", "Image", "Icon"] },
+  composite: {
+    title: "業務複合",
+    components: ["InputGroup", "Card", "DataList", "Pagination"],
+  },
+  regions: {
+    title: "レイアウト領域",
+    components: ["RegionHeader", "RegionSidebar", "RegionFooter", "RegionMain"],
+  },
+};
+
+// ---------------------------------------------------------------------------
+// props → Puck fields 変換ヘルパー (#1410 P-2)
+// custom 経路と external 経路の両方が使う共有ロジック (divergence 防止)。
+// ---------------------------------------------------------------------------
+
+/**
+ * props → fields 変換の正規化入力。
+ * custom (PropSchemaField) と external (ExternalPropDecl) の両方を
+ * この形に揃えてから buildFieldsFromPropDecls に渡す。
+ */
+interface NormalizedPropDecl {
+  name: string;
+  type: "string" | "number" | "boolean" | "enum";
+  label?: string;
+  default?: unknown;
+  enum?: { label: string; value: string }[];
+}
+
+/**
+ * 正規化済み prop 宣言の配列を Puck Fields に変換する。
+ *
+ * - enum (非空) → select
+ * - number → number (P-2 で追加した分岐)
+ * - boolean → radio (はい/いいえ、value は string で既存 custom 挙動を厳密保持)
+ * - その他 (string 含む) → text
+ */
+function buildFieldsFromPropDecls(
+  decls: NormalizedPropDecl[],
+): NonNullable<Config["components"][string]["fields"]> {
+  const fields: NonNullable<Config["components"][string]["fields"]> = {};
+  for (const decl of decls) {
+    if (decl.type === "enum" && decl.enum && decl.enum.length > 0) {
+      fields[decl.name] = {
+        type: "select" as const,
+        label: decl.label ?? decl.name,
+        options: decl.enum.map((opt) => ({ label: opt.label, value: opt.value })),
+      };
+    } else if (decl.type === "number") {
+      fields[decl.name] = {
+        type: "number" as const,
+        label: decl.label ?? decl.name,
+      };
+    } else if (decl.type === "boolean") {
+      fields[decl.name] = {
+        type: "radio" as const,
+        label: decl.label ?? decl.name,
+        options: [
+          { label: "はい", value: "true" },
+          { label: "いいえ", value: "false" },
+        ],
+      };
+    } else {
+      fields[decl.name] = {
+        type: "text" as const,
+        label: decl.label ?? decl.name,
+      };
+    }
+  }
+  return fields;
+}
+
 /**
  * 全 primitive に共通追加するレイアウト props の Puck Fields 定義。
  * escape hatch の rawClass は隠し扱い (custom フィールドは Puck v0.20 では type:"custom" が必要だが、
@@ -143,6 +233,7 @@ export const LAYOUT_FIELDS: Fields<Record<string, unknown>> = {
  */
 export function buildPuckConfig(): Config {
   return {
+    categories: { ...BUILTIN_CATEGORIES },
     components: {
       // --- レイアウト ---
       Container: {
@@ -260,37 +351,24 @@ export function buildConfigWithCustomComponents(customComponents: CustomPuckComp
   if (customComponents.length === 0) return base;
 
   const extraComponents: Config["components"] = {};
+  const customIds: string[] = [];
 
   for (const def of customComponents) {
+    customIds.push(def.id);
     const primitiveKey = Object.keys(base.components).find(
       (k) => k.toLowerCase() === def.primitive.toLowerCase().replace(/-/g, ""),
     );
     const baseComponentConfig = primitiveKey ? base.components[primitiveKey] : undefined;
 
-    const customFields: Config["components"][string]["fields"] = {};
-    for (const [fieldName, fieldDef] of Object.entries(def.propsSchema)) {
-      if (fieldDef.type === "enum" && fieldDef.enum && fieldDef.enum.length > 0) {
-        customFields[fieldName] = {
-          type: "select" as const,
-          label: fieldDef.label ?? fieldName,
-          options: fieldDef.enum.map((opt) => ({ label: opt.label, value: opt.value })),
-        };
-      } else if (fieldDef.type === "boolean") {
-        customFields[fieldName] = {
-          type: "radio" as const,
-          label: fieldDef.label ?? fieldName,
-          options: [
-            { label: "はい", value: "true" },
-            { label: "いいえ", value: "false" },
-          ],
-        };
-      } else {
-        customFields[fieldName] = {
-          type: "text" as const,
-          label: fieldDef.label ?? fieldName,
-        };
-      }
-    }
+    const customFields = buildFieldsFromPropDecls(
+      Object.entries(def.propsSchema).map(([name, f]) => ({
+        name,
+        type: f.type,
+        label: f.label,
+        default: f.default,
+        enum: f.enum,
+      })),
+    );
 
     const defaultProps: Record<string, unknown> = {};
     for (const [fieldName, fieldDef] of Object.entries(def.propsSchema)) {
@@ -326,8 +404,23 @@ export function buildConfigWithCustomComponents(customComponents: CustomPuckComp
     }
   }
 
+  // categories は base を immutable に複製。custom が 1 件以上あるときのみ
+  // projectCustom を追加する (0 件なら空カテゴリを作らない)。base の既存カテゴリは不変。
+  const categories: Config["categories"] = {
+    ...(base.categories ?? {}),
+    ...(customIds.length > 0
+      ? {
+          projectCustom: {
+            title: "プロジェクト部品 (カスタム)",
+            components: customIds,
+          },
+        }
+      : {}),
+  };
+
   return {
     ...base,
+    categories,
     components: {
       ...base.components,
       ...extraComponents,
@@ -340,7 +433,7 @@ export function buildConfigWithCustomComponents(customComponents: CustomPuckComp
  *
  * - status="ok": entry.Component を render する component を登録。
  *   defaultProps は manifest props の default 集約。
- *   fields は P-1 では最小 (空)。props→fields の本格化は P-2。
+ *   fields は manifest props を buildFieldsFromPropDecls で変換 (#1410 P-2)。
  * - status="error": ExternalComponentErrorCard を render するエラーカードを登録。
  * - id 衝突 (built-in / 既存 custom / 先行 external と同じ id): 既存を上書きせず、
  *   id-collision のエラーカードに差し替える。意図しない built-in 部品の置換を防ぐ。
@@ -366,6 +459,8 @@ export function mergeExternalComponents(
   // 以降に登録する key (実 component / エラーカード / 衝突カード) はすべてこの集合に
   // add していき、新規 key 採番時の衝突判定に使う。base の key は不変。
   const usedKeys = new Set<string>(Object.keys(base.components));
+  // projectExternal カテゴリに割り当てる外部由来の key (ok / error / 衝突カード) を全て収集。
+  const externalKeys: string[] = [];
 
   for (let i = 0; i < loaded.length; i++) {
     const item = loaded[i];
@@ -383,6 +478,7 @@ export function mergeExternalComponents(
         `ID '${entry.id}' は既存 component と衝突`,
       );
       usedKeys.add(collisionKey);
+      externalKeys.push(collisionKey);
       continue;
     }
 
@@ -396,8 +492,16 @@ export function mergeExternalComponents(
       const Component = item.Component;
       extraComponents[entry.id] = {
         label: `(外部) ${entry.label}`,
-        // P-1 では fields は最小 (空)。props→fields 本格化は P-2。
-        fields: {},
+        // props → Puck fields 変換 (#1410 P-2、custom 経路と共有ヘルパー)。
+        fields: buildFieldsFromPropDecls(
+          (entry.props ?? []).map((p) => ({
+            name: p.name,
+            type: p.type,
+            label: p.label,
+            default: p.default,
+            enum: p.enum,
+          })),
+        ),
         defaultProps,
         render: (props: Record<string, unknown>) =>
           createElement(Component, props),
@@ -413,10 +517,27 @@ export function mergeExternalComponents(
       );
     }
     usedKeys.add(entry.id);
+    externalKeys.push(entry.id);
   }
+
+  // categories は受け取った base を immutable に複製。外部が 1 件以上あるときのみ
+  // projectExternal を追加する (0 件なら追加しない)。base の既存カテゴリ
+  // (projectCustom 含む) は不変。なお loaded.length === 0 は冒頭で early return 済。
+  const categories: Config["categories"] = {
+    ...(base.categories ?? {}),
+    ...(externalKeys.length > 0
+      ? {
+          projectExternal: {
+            title: "プロジェクト部品 (外部)",
+            components: externalKeys,
+          },
+        }
+      : {}),
+  };
 
   return {
     ...base,
+    categories,
     components: {
       ...base.components,
       ...extraComponents,

--- a/frontend/src/puck/externalComponentManifest.test.ts
+++ b/frontend/src/puck/externalComponentManifest.test.ts
@@ -204,4 +204,34 @@ describe("validateExternalComponentManifest", () => {
       ).toBe(true);
     }
   });
+
+  it("slot 名 unique 検証は per-entry scope: 別 entry 間で同名 slot は許容する", () => {
+    // slot 名の一意性は entry ごとに閉じている。別 component が同名 slot を
+    // 持っていても衝突ではない (各 component の props 名前空間が独立しているため)。
+    const result = validateExternalComponentManifest({
+      schemaVersion: "1",
+      components: [
+        {
+          id: "panel-a",
+          label: "Panel A",
+          module: "./a.mjs",
+          version: "1.0",
+          slots: [{ name: "content", label: "本文" }],
+        },
+        {
+          id: "panel-b",
+          label: "Panel B",
+          module: "./b.mjs",
+          version: "1.0",
+          slots: [{ name: "content", label: "本文" }],
+        },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.manifest.components).toHaveLength(2);
+      expect(result.manifest.components[0].slots?.[0].name).toBe("content");
+      expect(result.manifest.components[1].slots?.[0].name).toBe("content");
+    }
+  });
 });

--- a/frontend/src/puck/externalComponentManifest.test.ts
+++ b/frontend/src/puck/externalComponentManifest.test.ts
@@ -1,0 +1,135 @@
+/**
+ * externalComponentManifest.test.ts — manifest validator のテスト (#1409 P-1)。
+ */
+import { describe, it, expect } from "vitest";
+import { validateExternalComponentManifest } from "./externalComponentManifest";
+
+describe("validateExternalComponentManifest", () => {
+  it("最小限の valid manifest を受理する", () => {
+    const input = {
+      schemaVersion: "1",
+      components: [
+        { id: "foo", label: "Foo", module: "./dist/foo.mjs", version: "1.0.0" },
+      ],
+    };
+    const result = validateExternalComponentManifest(input);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.manifest.components).toHaveLength(1);
+      expect(result.manifest.components[0].id).toBe("foo");
+    }
+  });
+
+  it("engine / props / slots / export を含む valid manifest を受理する", () => {
+    const input = {
+      schemaVersion: "1",
+      components: [
+        {
+          id: "bar",
+          label: "Bar",
+          module: "./dist/bar.mjs",
+          export: "Bar",
+          version: "2.1.0",
+          engine: { react: "19", puck: "0.20" },
+          props: [
+            { name: "title", type: "string", label: "見出し", default: "x" },
+            {
+              name: "mode",
+              type: "enum",
+              enum: [
+                { label: "A", value: "a" },
+                { label: "B", value: "b" },
+              ],
+            },
+          ],
+          slots: [{ name: "content", label: "本文" }],
+        },
+      ],
+    };
+    const result = validateExternalComponentManifest(input);
+    expect(result.ok).toBe(true);
+  });
+
+  it("schemaVersion が不正なら拒否する", () => {
+    const result = validateExternalComponentManifest({
+      schemaVersion: "2",
+      components: [],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.some((e) => e.includes("schemaVersion"))).toBe(true);
+    }
+  });
+
+  it("components が配列でないなら拒否する", () => {
+    const result = validateExternalComponentManifest({
+      schemaVersion: "1",
+      components: {},
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.some((e) => e.includes("components"))).toBe(true);
+    }
+  });
+
+  it("必須 field (version) 欠落を検出する", () => {
+    const result = validateExternalComponentManifest({
+      schemaVersion: "1",
+      components: [{ id: "foo", label: "Foo", module: "./dist/foo.mjs" }],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.some((e) => e.includes("version"))).toBe(true);
+    }
+  });
+
+  it("型不正 (module が数値) を検出する", () => {
+    const result = validateExternalComponentManifest({
+      schemaVersion: "1",
+      components: [{ id: "foo", label: "Foo", module: 123, version: "1.0" }],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.some((e) => e.includes("module"))).toBe(true);
+    }
+  });
+
+  it("id 重複を検出する", () => {
+    const result = validateExternalComponentManifest({
+      schemaVersion: "1",
+      components: [
+        { id: "dup", label: "A", module: "./a.mjs", version: "1.0" },
+        { id: "dup", label: "B", module: "./b.mjs", version: "1.0" },
+      ],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.some((e) => e.includes("重複"))).toBe(true);
+    }
+  });
+
+  it("enum 型で enum 配列が無いと拒否する", () => {
+    const result = validateExternalComponentManifest({
+      schemaVersion: "1",
+      components: [
+        {
+          id: "foo",
+          label: "Foo",
+          module: "./foo.mjs",
+          version: "1.0",
+          props: [{ name: "mode", type: "enum" }],
+        },
+      ],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.some((e) => e.includes("enum"))).toBe(true);
+    }
+  });
+
+  it("オブジェクトでない入力を拒否する", () => {
+    expect(validateExternalComponentManifest(null).ok).toBe(false);
+    expect(validateExternalComponentManifest("x").ok).toBe(false);
+    expect(validateExternalComponentManifest([]).ok).toBe(false);
+  });
+});

--- a/frontend/src/puck/externalComponentManifest.test.ts
+++ b/frontend/src/puck/externalComponentManifest.test.ts
@@ -132,4 +132,76 @@ describe("validateExternalComponentManifest", () => {
     expect(validateExternalComponentManifest("x").ok).toBe(false);
     expect(validateExternalComponentManifest([]).ok).toBe(false);
   });
+
+  // --- slot 検証 (#1411 P-3) ---
+
+  it("slot あり (prop と非衝突) の正常 manifest を受理する", () => {
+    const result = validateExternalComponentManifest({
+      schemaVersion: "1",
+      components: [
+        {
+          id: "foo",
+          label: "Foo",
+          module: "./foo.mjs",
+          version: "1.0",
+          props: [{ name: "title", type: "string" }],
+          slots: [
+            { name: "header", label: "ヘッダ" },
+            { name: "content", label: "本文" },
+          ],
+        },
+      ],
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("slot 名重複を検出する", () => {
+    const result = validateExternalComponentManifest({
+      schemaVersion: "1",
+      components: [
+        {
+          id: "foo",
+          label: "Foo",
+          module: "./foo.mjs",
+          version: "1.0",
+          slots: [
+            { name: "content", label: "A" },
+            { name: "content", label: "B" },
+          ],
+        },
+      ],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(
+        result.errors.some(
+          (e) => e.includes("content") && e.includes("重複"),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it("slot 名と prop 名の衝突を検出する", () => {
+    const result = validateExternalComponentManifest({
+      schemaVersion: "1",
+      components: [
+        {
+          id: "foo",
+          label: "Foo",
+          module: "./foo.mjs",
+          version: "1.0",
+          props: [{ name: "content", type: "string" }],
+          slots: [{ name: "content", label: "本文" }],
+        },
+      ],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(
+        result.errors.some(
+          (e) => e.includes("content") && e.includes("衝突"),
+        ),
+      ).toBe(true);
+    }
+  });
 });

--- a/frontend/src/puck/externalComponentManifest.ts
+++ b/frontend/src/puck/externalComponentManifest.ts
@@ -1,0 +1,227 @@
+/**
+ * externalComponentManifest.ts — 外部 React Component 読込基盤の manifest 規格と検証 (#1409 P-1)。
+ *
+ * 外部業務 React Component を runtime ESM import で Puck に取り込むための manifest 定義。
+ * manifest 本体は workspace 内ファイル (`<dataDir>/puck-components/manifest.json`) であり、
+ * グローバル schema (`schemas/v3/*.json`) ではない。
+ *
+ * 検証は Zod 等の外部依存を使わず、手書き type guard 方式で行う。
+ * RFC #1405 シリーズ P-1。
+ */
+
+/** prop 宣言 (manifest entry の props 要素)。 */
+export interface ExternalPropDecl {
+  name: string;
+  type: "string" | "number" | "boolean" | "enum";
+  label?: string;
+  default?: unknown;
+  /** type === "enum" の場合の選択肢。 */
+  enum?: { label: string; value: string }[];
+}
+
+/** slot 宣言 (DropZone 相当、P-3 で本格活用)。 */
+export interface ExternalSlotDecl {
+  name: string;
+  label?: string;
+}
+
+/** engine 互換性宣言。major version の一致確認に使う。 */
+export interface ExternalEngineDecl {
+  react?: string;
+  puck?: string;
+}
+
+/** manifest の 1 component entry。 */
+export interface ExternalComponentEntry {
+  /** Puck config 上の component key (workspace 内 unique)。 */
+  id: string;
+  /** パレット表示名。 */
+  label: string;
+  /** manifest.json からの相対 module path (例: "./dist/foo.mjs")。 */
+  module: string;
+  /** 読み込む export 名。省略時 "default"。 */
+  export?: string;
+  /** 部品バージョン (任意の文字列)。 */
+  version: string;
+  /** host との engine 互換要件 (任意)。 */
+  engine?: ExternalEngineDecl;
+  /** prop 宣言 (P-2 で fields 本格化、P-1 では型保持のみ)。 */
+  props?: ExternalPropDecl[];
+  /** slot 宣言 (P-3 で活用)。 */
+  slots?: ExternalSlotDecl[];
+}
+
+/** manifest 全体。 */
+export interface ExternalComponentManifest {
+  schemaVersion: "1";
+  components: ExternalComponentEntry[];
+}
+
+export type ValidateManifestResult =
+  | { ok: true; manifest: ExternalComponentManifest }
+  | { ok: false; errors: string[] };
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function validatePropDecl(
+  prop: unknown,
+  path: string,
+  errors: string[],
+): void {
+  if (!isPlainObject(prop)) {
+    errors.push(`${path}: prop はオブジェクトである必要があります`);
+    return;
+  }
+  if (typeof prop.name !== "string" || prop.name.length === 0) {
+    errors.push(`${path}.name: 必須の文字列です`);
+  }
+  const allowedTypes = ["string", "number", "boolean", "enum"];
+  if (typeof prop.type !== "string" || !allowedTypes.includes(prop.type)) {
+    errors.push(
+      `${path}.type: "string" | "number" | "boolean" | "enum" のいずれかが必要です`,
+    );
+  }
+  if (prop.label !== undefined && typeof prop.label !== "string") {
+    errors.push(`${path}.label: 文字列である必要があります`);
+  }
+  if (prop.type === "enum") {
+    if (!Array.isArray(prop.enum) || prop.enum.length === 0) {
+      errors.push(`${path}.enum: type="enum" の場合は非空配列が必要です`);
+    } else {
+      prop.enum.forEach((opt, i) => {
+        if (
+          !isPlainObject(opt) ||
+          typeof opt.label !== "string" ||
+          typeof opt.value !== "string"
+        ) {
+          errors.push(
+            `${path}.enum[${i}]: { label: string; value: string } が必要です`,
+          );
+        }
+      });
+    }
+  }
+}
+
+function validateSlotDecl(
+  slot: unknown,
+  path: string,
+  errors: string[],
+): void {
+  if (!isPlainObject(slot)) {
+    errors.push(`${path}: slot はオブジェクトである必要があります`);
+    return;
+  }
+  if (typeof slot.name !== "string" || slot.name.length === 0) {
+    errors.push(`${path}.name: 必須の文字列です`);
+  }
+  if (slot.label !== undefined && typeof slot.label !== "string") {
+    errors.push(`${path}.label: 文字列である必要があります`);
+  }
+}
+
+function validateEngineDecl(
+  engine: unknown,
+  path: string,
+  errors: string[],
+): void {
+  if (!isPlainObject(engine)) {
+    errors.push(`${path}: engine はオブジェクトである必要があります`);
+    return;
+  }
+  if (engine.react !== undefined && typeof engine.react !== "string") {
+    errors.push(`${path}.react: 文字列である必要があります`);
+  }
+  if (engine.puck !== undefined && typeof engine.puck !== "string") {
+    errors.push(`${path}.puck: 文字列である必要があります`);
+  }
+}
+
+function validateEntry(
+  entry: unknown,
+  index: number,
+  seenIds: Set<string>,
+  errors: string[],
+): void {
+  const path = `components[${index}]`;
+  if (!isPlainObject(entry)) {
+    errors.push(`${path}: entry はオブジェクトである必要があります`);
+    return;
+  }
+  if (typeof entry.id !== "string" || entry.id.length === 0) {
+    errors.push(`${path}.id: 必須の文字列です`);
+  } else {
+    if (seenIds.has(entry.id)) {
+      errors.push(`${path}.id: id "${entry.id}" が重複しています`);
+    }
+    seenIds.add(entry.id);
+  }
+  if (typeof entry.label !== "string" || entry.label.length === 0) {
+    errors.push(`${path}.label: 必須の文字列です`);
+  }
+  if (typeof entry.module !== "string" || entry.module.length === 0) {
+    errors.push(`${path}.module: 必須の文字列です`);
+  }
+  if (typeof entry.version !== "string" || entry.version.length === 0) {
+    errors.push(`${path}.version: 必須の文字列です`);
+  }
+  if (entry.export !== undefined && typeof entry.export !== "string") {
+    errors.push(`${path}.export: 文字列である必要があります`);
+  }
+  if (entry.engine !== undefined) {
+    validateEngineDecl(entry.engine, `${path}.engine`, errors);
+  }
+  if (entry.props !== undefined) {
+    if (!Array.isArray(entry.props)) {
+      errors.push(`${path}.props: 配列である必要があります`);
+    } else {
+      entry.props.forEach((p, i) =>
+        validatePropDecl(p, `${path}.props[${i}]`, errors),
+      );
+    }
+  }
+  if (entry.slots !== undefined) {
+    if (!Array.isArray(entry.slots)) {
+      errors.push(`${path}.slots: 配列である必要があります`);
+    } else {
+      entry.slots.forEach((s, i) =>
+        validateSlotDecl(s, `${path}.slots[${i}]`, errors),
+      );
+    }
+  }
+}
+
+/**
+ * 外部 component manifest を検証する。
+ * 必須 field 欠落 / 型不正 / id 重複を検出し、すべての違反を errors に列挙する。
+ */
+export function validateExternalComponentManifest(
+  input: unknown,
+): ValidateManifestResult {
+  const errors: string[] = [];
+
+  if (!isPlainObject(input)) {
+    return { ok: false, errors: ["manifest はオブジェクトである必要があります"] };
+  }
+
+  if (input.schemaVersion !== "1") {
+    errors.push(`schemaVersion: "1" である必要があります (got ${JSON.stringify(input.schemaVersion)})`);
+  }
+
+  if (!Array.isArray(input.components)) {
+    errors.push("components: 配列である必要があります");
+    return { ok: false, errors };
+  }
+
+  const seenIds = new Set<string>();
+  input.components.forEach((entry, i) =>
+    validateEntry(entry, i, seenIds, errors),
+  );
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+  return { ok: true, manifest: input as unknown as ExternalComponentManifest };
+}

--- a/frontend/src/puck/externalComponentManifest.ts
+++ b/frontend/src/puck/externalComponentManifest.ts
@@ -109,6 +109,8 @@ function validateSlotDecl(
   slot: unknown,
   path: string,
   errors: string[],
+  seenSlotNames: Set<string>,
+  propNames: Set<string>,
 ): void {
   if (!isPlainObject(slot)) {
     errors.push(`${path}: slot はオブジェクトである必要があります`);
@@ -116,6 +118,16 @@ function validateSlotDecl(
   }
   if (typeof slot.name !== "string" || slot.name.length === 0) {
     errors.push(`${path}.name: 必須の文字列です`);
+  } else {
+    // slot 名は同 entry 内で unique であること。
+    if (seenSlotNames.has(slot.name)) {
+      errors.push(`${path}.name: slot 名 "${slot.name}" が重複しています`);
+    }
+    // slot 名は Puck props 名前空間を prop と共有するため、prop 名と衝突してはならない。
+    if (propNames.has(slot.name)) {
+      errors.push(`${path}.name: prop 名 "${slot.name}" と衝突しています`);
+    }
+    seenSlotNames.add(slot.name);
   }
   if (slot.label !== undefined && typeof slot.label !== "string") {
     errors.push(`${path}.label: 文字列である必要があります`);
@@ -173,6 +185,8 @@ function validateEntry(
   if (entry.engine !== undefined) {
     validateEngineDecl(entry.engine, `${path}.engine`, errors);
   }
+  // prop 名集合は slot 名衝突検証で参照するため先に収集する。
+  const propNames = new Set<string>();
   if (entry.props !== undefined) {
     if (!Array.isArray(entry.props)) {
       errors.push(`${path}.props: 配列である必要があります`);
@@ -180,14 +194,20 @@ function validateEntry(
       entry.props.forEach((p, i) =>
         validatePropDecl(p, `${path}.props[${i}]`, errors),
       );
+      for (const p of entry.props) {
+        if (isPlainObject(p) && typeof p.name === "string" && p.name.length > 0) {
+          propNames.add(p.name);
+        }
+      }
     }
   }
   if (entry.slots !== undefined) {
     if (!Array.isArray(entry.slots)) {
       errors.push(`${path}.slots: 配列である必要があります`);
     } else {
+      const seenSlotNames = new Set<string>();
       entry.slots.forEach((s, i) =>
-        validateSlotDecl(s, `${path}.slots[${i}]`, errors),
+        validateSlotDecl(s, `${path}.slots[${i}]`, errors, seenSlotNames, propNames),
       );
     }
   }

--- a/frontend/src/puck/externalComponents.test.ts
+++ b/frontend/src/puck/externalComponents.test.ts
@@ -4,6 +4,7 @@
  * fetch / import は DI で差し替えてエラー分類を網羅する。
  */
 import { describe, it, expect, vi } from "vitest";
+import { memo, forwardRef, lazy } from "react";
 import { loadExternalComponents, assetPrefixFor } from "./externalComponents";
 
 const ORIGIN = "http://localhost:5179";
@@ -125,6 +126,85 @@ describe("loadExternalComponents", () => {
       backendOrigin: ORIGIN,
       fetchImpl: makeFetch({ schemaVersion: "1", components: [validEntry] }),
       importImpl: async () => ({ default: 42 }),
+    });
+    expect(result[0].status).toBe("error");
+    if (result[0].status === "error") {
+      expect(result[0].errorKind).toBe("missing-export");
+    }
+  });
+
+  // --- P2-6: memo / forwardRef / lazy も妥当な component として ok ---
+  it("ok: React.memo() で作った component は status=ok", async () => {
+    const Component = memo(() => null);
+    const result = await loadExternalComponents({
+      wsId: WS,
+      backendOrigin: ORIGIN,
+      fetchImpl: makeFetch({ schemaVersion: "1", components: [validEntry] }),
+      importImpl: async () => ({ default: Component }),
+    });
+    expect(result[0].status).toBe("ok");
+    if (result[0].status === "ok") {
+      expect(result[0].Component).toBe(Component);
+    }
+  });
+
+  it("ok: React.forwardRef() で作った component は status=ok", async () => {
+    const Component = forwardRef<HTMLDivElement>((_props, _ref) => null);
+    const result = await loadExternalComponents({
+      wsId: WS,
+      backendOrigin: ORIGIN,
+      fetchImpl: makeFetch({ schemaVersion: "1", components: [validEntry] }),
+      importImpl: async () => ({ default: Component }),
+    });
+    expect(result[0].status).toBe("ok");
+    if (result[0].status === "ok") {
+      expect(result[0].Component).toBe(Component);
+    }
+  });
+
+  it("ok: React.lazy() で作った component は status=ok", async () => {
+    const Component = lazy(async () => ({ default: () => null }));
+    const result = await loadExternalComponents({
+      wsId: WS,
+      backendOrigin: ORIGIN,
+      fetchImpl: makeFetch({ schemaVersion: "1", components: [validEntry] }),
+      importImpl: async () => ({ default: Component }),
+    });
+    expect(result[0].status).toBe("ok");
+  });
+
+  it("missing-export: 文字列 export は missing-export (component でない)", async () => {
+    const result = await loadExternalComponents({
+      wsId: WS,
+      backendOrigin: ORIGIN,
+      fetchImpl: makeFetch({ schemaVersion: "1", components: [validEntry] }),
+      importImpl: async () => ({ default: "div" }),
+    });
+    expect(result[0].status).toBe("error");
+    if (result[0].status === "error") {
+      expect(result[0].errorKind).toBe("missing-export");
+    }
+  });
+
+  it("missing-export: null export は missing-export", async () => {
+    const result = await loadExternalComponents({
+      wsId: WS,
+      backendOrigin: ORIGIN,
+      fetchImpl: makeFetch({ schemaVersion: "1", components: [validEntry] }),
+      importImpl: async () => ({ default: null }),
+    });
+    expect(result[0].status).toBe("error");
+    if (result[0].status === "error") {
+      expect(result[0].errorKind).toBe("missing-export");
+    }
+  });
+
+  it("missing-export: $$typeof を持たない plain object は missing-export", async () => {
+    const result = await loadExternalComponents({
+      wsId: WS,
+      backendOrigin: ORIGIN,
+      fetchImpl: makeFetch({ schemaVersion: "1", components: [validEntry] }),
+      importImpl: async () => ({ default: { foo: "bar" } }),
     });
     expect(result[0].status).toBe("error");
     if (result[0].status === "error") {

--- a/frontend/src/puck/externalComponents.test.ts
+++ b/frontend/src/puck/externalComponents.test.ts
@@ -24,6 +24,26 @@ function fetch404(): typeof fetch {
   ) as unknown as typeof fetch;
 }
 
+/** ok=false の任意 HTTP status を返す fetch (403/500 等)。 */
+function fetchHttpError(status: number): typeof fetch {
+  return vi.fn(async () =>
+    ({ ok: false, status, json: async () => ({}) }) as unknown as Response,
+  ) as unknown as typeof fetch;
+}
+
+/** ok=true だが res.json() が throw する fetch (JSON parse 失敗)。 */
+function fetchJsonThrows(): typeof fetch {
+  return vi.fn(async () =>
+    ({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new SyntaxError("Unexpected token < in JSON");
+      },
+    }) as unknown as Response,
+  ) as unknown as typeof fetch;
+}
+
 const validEntry = {
   id: "foo",
   label: "Foo",
@@ -175,5 +195,141 @@ describe("loadExternalComponents", () => {
     expect(importSpy).toHaveBeenCalledWith(
       `${ORIGIN}/workspace-assets/puck-components/dist/foo.mjs`,
     );
+  });
+
+  // --- SF2: manifest fetch の HTTP / parse error を握り潰さない ---
+  it("manifest が 500 等の HTTP error なら manifest-invalid を返す", async () => {
+    const result = await loadExternalComponents({
+      backendOrigin: ORIGIN,
+      fetchImpl: fetchHttpError(500),
+      importImpl: async () => ({}),
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe("error");
+    if (result[0].status === "error") {
+      expect(result[0].errorKind).toBe("manifest-invalid");
+      expect(result[0].detail).toContain("HTTP 500");
+    }
+  });
+
+  it("manifest が 403 でも manifest-invalid を返す (404 のみ空配列)", async () => {
+    const result = await loadExternalComponents({
+      backendOrigin: ORIGIN,
+      fetchImpl: fetchHttpError(403),
+      importImpl: async () => ({}),
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe("error");
+    if (result[0].status === "error") {
+      expect(result[0].errorKind).toBe("manifest-invalid");
+      expect(result[0].detail).toContain("HTTP 403");
+    }
+  });
+
+  it("manifest の JSON parse 失敗なら manifest-invalid を返す", async () => {
+    const result = await loadExternalComponents({
+      backendOrigin: ORIGIN,
+      fetchImpl: fetchJsonThrows(),
+      importImpl: async () => ({}),
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe("error");
+    if (result[0].status === "error") {
+      expect(result[0].errorKind).toBe("manifest-invalid");
+    }
+  });
+
+  it("network throw (backend down) は空配列 (エラーカードを出さない)", async () => {
+    const result = await loadExternalComponents({
+      backendOrigin: ORIGIN,
+      fetchImpl: vi.fn(async () => {
+        throw new TypeError("Failed to fetch");
+      }) as unknown as typeof fetch,
+      importImpl: async () => ({}),
+    });
+    expect(result).toEqual([]);
+  });
+
+  // --- MF1: loader の任意 origin import を塞ぐ (SSRF 防止) ---
+  it("module が他 origin (https://evil) なら import せず load-error", async () => {
+    const importSpy = vi.fn(async () => ({ default: () => null }));
+    const result = await loadExternalComponents({
+      backendOrigin: ORIGIN,
+      fetchImpl: makeFetch({
+        schemaVersion: "1",
+        components: [{ ...validEntry, module: "https://evil.example.com/x.mjs" }],
+      }),
+      importImpl: importSpy,
+    });
+    expect(result[0].status).toBe("error");
+    if (result[0].status === "error") {
+      expect(result[0].errorKind).toBe("load-error");
+      expect(result[0].detail).toContain("配信範囲外");
+    }
+    expect(importSpy).not.toHaveBeenCalled();
+  });
+
+  it("module が ../ で配信範囲外へ脱出するなら import せず load-error", async () => {
+    const importSpy = vi.fn(async () => ({ default: () => null }));
+    const result = await loadExternalComponents({
+      backendOrigin: ORIGIN,
+      fetchImpl: makeFetch({
+        schemaVersion: "1",
+        components: [{ ...validEntry, module: "../../etc/secret.mjs" }],
+      }),
+      importImpl: importSpy,
+    });
+    expect(result[0].status).toBe("error");
+    if (result[0].status === "error") {
+      expect(result[0].errorKind).toBe("load-error");
+      expect(result[0].detail).toContain("配信範囲外");
+    }
+    expect(importSpy).not.toHaveBeenCalled();
+  });
+
+  it("module が protocol-relative (//host) なら import せず load-error", async () => {
+    const importSpy = vi.fn(async () => ({ default: () => null }));
+    const result = await loadExternalComponents({
+      backendOrigin: ORIGIN,
+      fetchImpl: makeFetch({
+        schemaVersion: "1",
+        components: [{ ...validEntry, module: "//evil.example.com/x.mjs" }],
+      }),
+      importImpl: importSpy,
+    });
+    expect(result[0].status).toBe("error");
+    if (result[0].status === "error") {
+      expect(result[0].errorKind).toBe("load-error");
+    }
+    expect(importSpy).not.toHaveBeenCalled();
+  });
+
+  it("module の拡張子が allowlist 外 (.json 等) なら import せず load-error", async () => {
+    const importSpy = vi.fn(async () => ({ default: () => null }));
+    const result = await loadExternalComponents({
+      backendOrigin: ORIGIN,
+      fetchImpl: makeFetch({
+        schemaVersion: "1",
+        components: [{ ...validEntry, module: "./dist/foo.json" }],
+      }),
+      importImpl: importSpy,
+    });
+    expect(result[0].status).toBe("error");
+    if (result[0].status === "error") {
+      expect(result[0].errorKind).toBe("load-error");
+      expect(result[0].detail).toContain("拡張子");
+    }
+    expect(importSpy).not.toHaveBeenCalled();
+  });
+
+  it("正常な ./dist/foo.mjs は import して ok", async () => {
+    const importSpy = vi.fn(async () => ({ default: () => null }));
+    const result = await loadExternalComponents({
+      backendOrigin: ORIGIN,
+      fetchImpl: makeFetch({ schemaVersion: "1", components: [validEntry] }),
+      importImpl: importSpy,
+    });
+    expect(result[0].status).toBe("ok");
+    expect(importSpy).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/src/puck/externalComponents.test.ts
+++ b/frontend/src/puck/externalComponents.test.ts
@@ -1,0 +1,179 @@
+/**
+ * externalComponents.test.ts — 外部 component ローダのエラー分類テスト (#1409 P-1)。
+ *
+ * fetch / import は DI で差し替えてエラー分類を網羅する。
+ */
+import { describe, it, expect, vi } from "vitest";
+import { loadExternalComponents } from "./externalComponents";
+
+const ORIGIN = "http://localhost:5179";
+
+function makeFetch(manifest: unknown, ok = true, status = 200): typeof fetch {
+  return vi.fn(async () =>
+    ({
+      ok,
+      status,
+      json: async () => manifest,
+    }) as unknown as Response,
+  ) as unknown as typeof fetch;
+}
+
+function fetch404(): typeof fetch {
+  return vi.fn(async () =>
+    ({ ok: false, status: 404, json: async () => ({}) }) as unknown as Response,
+  ) as unknown as typeof fetch;
+}
+
+const validEntry = {
+  id: "foo",
+  label: "Foo",
+  module: "./dist/foo.mjs",
+  version: "1.0.0",
+};
+
+describe("loadExternalComponents", () => {
+  it("manifest が 404 なら空配列を返す (正常系)", async () => {
+    const result = await loadExternalComponents({
+      backendOrigin: ORIGIN,
+      fetchImpl: fetch404(),
+      importImpl: async () => ({}),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("fetch が例外を投げたら空配列を返す", async () => {
+    const result = await loadExternalComponents({
+      backendOrigin: ORIGIN,
+      fetchImpl: vi.fn(async () => {
+        throw new Error("network");
+      }) as unknown as typeof fetch,
+      importImpl: async () => ({}),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("manifest 不正なら manifest-invalid を返す", async () => {
+    const result = await loadExternalComponents({
+      backendOrigin: ORIGIN,
+      fetchImpl: makeFetch({ schemaVersion: "1", components: [{ id: "x" }] }),
+      importImpl: async () => ({}),
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe("error");
+    if (result[0].status === "error") {
+      expect(result[0].errorKind).toBe("manifest-invalid");
+    }
+  });
+
+  it("ok: export が関数なら status=ok で Component を返す", async () => {
+    const Component = () => null;
+    const result = await loadExternalComponents({
+      backendOrigin: ORIGIN,
+      fetchImpl: makeFetch({ schemaVersion: "1", components: [validEntry] }),
+      importImpl: async () => ({ default: Component }),
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe("ok");
+    if (result[0].status === "ok") {
+      expect(result[0].Component).toBe(Component);
+    }
+  });
+
+  it("カスタム export 名を解決する", async () => {
+    const Component = () => null;
+    const result = await loadExternalComponents({
+      backendOrigin: ORIGIN,
+      fetchImpl: makeFetch({
+        schemaVersion: "1",
+        components: [{ ...validEntry, export: "MyComp" }],
+      }),
+      importImpl: async () => ({ MyComp: Component, default: 123 }),
+    });
+    expect(result[0].status).toBe("ok");
+  });
+
+  it("missing-export: export が関数でないなら missing-export", async () => {
+    const result = await loadExternalComponents({
+      backendOrigin: ORIGIN,
+      fetchImpl: makeFetch({ schemaVersion: "1", components: [validEntry] }),
+      importImpl: async () => ({ default: 42 }),
+    });
+    expect(result[0].status).toBe("error");
+    if (result[0].status === "error") {
+      expect(result[0].errorKind).toBe("missing-export");
+    }
+  });
+
+  it("load-error: import が例外を投げたら load-error", async () => {
+    const result = await loadExternalComponents({
+      backendOrigin: ORIGIN,
+      fetchImpl: makeFetch({ schemaVersion: "1", components: [validEntry] }),
+      importImpl: async () => {
+        throw new Error("boom");
+      },
+    });
+    expect(result[0].status).toBe("error");
+    if (result[0].status === "error") {
+      expect(result[0].errorKind).toBe("load-error");
+      expect(result[0].detail).toContain("boom");
+    }
+  });
+
+  it("version-mismatch: react major 不一致なら version-mismatch (import せず)", async () => {
+    const importSpy = vi.fn(async () => ({ default: () => null }));
+    const result = await loadExternalComponents({
+      backendOrigin: ORIGIN,
+      fetchImpl: makeFetch({
+        schemaVersion: "1",
+        components: [{ ...validEntry, engine: { react: "18" } }],
+      }),
+      importImpl: importSpy,
+    });
+    expect(result[0].status).toBe("error");
+    if (result[0].status === "error") {
+      expect(result[0].errorKind).toBe("version-mismatch");
+    }
+    expect(importSpy).not.toHaveBeenCalled();
+  });
+
+  it("version-mismatch: puck minor 不一致なら version-mismatch", async () => {
+    const result = await loadExternalComponents({
+      backendOrigin: ORIGIN,
+      fetchImpl: makeFetch({
+        schemaVersion: "1",
+        components: [{ ...validEntry, engine: { puck: "0.19" } }],
+      }),
+      importImpl: async () => ({ default: () => null }),
+    });
+    expect(result[0].status).toBe("error");
+    if (result[0].status === "error") {
+      expect(result[0].errorKind).toBe("version-mismatch");
+    }
+  });
+
+  it("engine が host と一致 (react 19 / puck 0.20) なら ok", async () => {
+    const result = await loadExternalComponents({
+      backendOrigin: ORIGIN,
+      fetchImpl: makeFetch({
+        schemaVersion: "1",
+        components: [
+          { ...validEntry, engine: { react: "^19.2.4", puck: "0.20.2" } },
+        ],
+      }),
+      importImpl: async () => ({ default: () => null }),
+    });
+    expect(result[0].status).toBe("ok");
+  });
+
+  it("module URL を backend origin + asset prefix で解決して import する", async () => {
+    const importSpy = vi.fn(async () => ({ default: () => null }));
+    await loadExternalComponents({
+      backendOrigin: ORIGIN,
+      fetchImpl: makeFetch({ schemaVersion: "1", components: [validEntry] }),
+      importImpl: importSpy,
+    });
+    expect(importSpy).toHaveBeenCalledWith(
+      `${ORIGIN}/workspace-assets/puck-components/dist/foo.mjs`,
+    );
+  });
+});

--- a/frontend/src/puck/externalComponents.test.ts
+++ b/frontend/src/puck/externalComponents.test.ts
@@ -4,9 +4,11 @@
  * fetch / import は DI で差し替えてエラー分類を網羅する。
  */
 import { describe, it, expect, vi } from "vitest";
-import { loadExternalComponents } from "./externalComponents";
+import { loadExternalComponents, assetPrefixFor } from "./externalComponents";
 
 const ORIGIN = "http://localhost:5179";
+const WS = "ws-A";
+const PREFIX = assetPrefixFor(WS); // "/workspace-assets/ws-A/puck-components/"
 
 function makeFetch(manifest: unknown, ok = true, status = 200): typeof fetch {
   return vi.fn(async () =>
@@ -54,6 +56,7 @@ const validEntry = {
 describe("loadExternalComponents", () => {
   it("manifest が 404 なら空配列を返す (正常系)", async () => {
     const result = await loadExternalComponents({
+      wsId: WS,
       backendOrigin: ORIGIN,
       fetchImpl: fetch404(),
       importImpl: async () => ({}),
@@ -63,6 +66,7 @@ describe("loadExternalComponents", () => {
 
   it("fetch が例外を投げたら空配列を返す", async () => {
     const result = await loadExternalComponents({
+      wsId: WS,
       backendOrigin: ORIGIN,
       fetchImpl: vi.fn(async () => {
         throw new Error("network");
@@ -74,6 +78,7 @@ describe("loadExternalComponents", () => {
 
   it("manifest 不正なら manifest-invalid を返す", async () => {
     const result = await loadExternalComponents({
+      wsId: WS,
       backendOrigin: ORIGIN,
       fetchImpl: makeFetch({ schemaVersion: "1", components: [{ id: "x" }] }),
       importImpl: async () => ({}),
@@ -88,6 +93,7 @@ describe("loadExternalComponents", () => {
   it("ok: export が関数なら status=ok で Component を返す", async () => {
     const Component = () => null;
     const result = await loadExternalComponents({
+      wsId: WS,
       backendOrigin: ORIGIN,
       fetchImpl: makeFetch({ schemaVersion: "1", components: [validEntry] }),
       importImpl: async () => ({ default: Component }),
@@ -102,6 +108,7 @@ describe("loadExternalComponents", () => {
   it("カスタム export 名を解決する", async () => {
     const Component = () => null;
     const result = await loadExternalComponents({
+      wsId: WS,
       backendOrigin: ORIGIN,
       fetchImpl: makeFetch({
         schemaVersion: "1",
@@ -114,6 +121,7 @@ describe("loadExternalComponents", () => {
 
   it("missing-export: export が関数でないなら missing-export", async () => {
     const result = await loadExternalComponents({
+      wsId: WS,
       backendOrigin: ORIGIN,
       fetchImpl: makeFetch({ schemaVersion: "1", components: [validEntry] }),
       importImpl: async () => ({ default: 42 }),
@@ -126,6 +134,7 @@ describe("loadExternalComponents", () => {
 
   it("load-error: import が例外を投げたら load-error", async () => {
     const result = await loadExternalComponents({
+      wsId: WS,
       backendOrigin: ORIGIN,
       fetchImpl: makeFetch({ schemaVersion: "1", components: [validEntry] }),
       importImpl: async () => {
@@ -142,6 +151,7 @@ describe("loadExternalComponents", () => {
   it("version-mismatch: react major 不一致なら version-mismatch (import せず)", async () => {
     const importSpy = vi.fn(async () => ({ default: () => null }));
     const result = await loadExternalComponents({
+      wsId: WS,
       backendOrigin: ORIGIN,
       fetchImpl: makeFetch({
         schemaVersion: "1",
@@ -158,6 +168,7 @@ describe("loadExternalComponents", () => {
 
   it("version-mismatch: puck minor 不一致なら version-mismatch", async () => {
     const result = await loadExternalComponents({
+      wsId: WS,
       backendOrigin: ORIGIN,
       fetchImpl: makeFetch({
         schemaVersion: "1",
@@ -173,6 +184,7 @@ describe("loadExternalComponents", () => {
 
   it("engine が host と一致 (react 19 / puck 0.20) なら ok", async () => {
     const result = await loadExternalComponents({
+      wsId: WS,
       backendOrigin: ORIGIN,
       fetchImpl: makeFetch({
         schemaVersion: "1",
@@ -185,21 +197,23 @@ describe("loadExternalComponents", () => {
     expect(result[0].status).toBe("ok");
   });
 
-  it("module URL を backend origin + asset prefix で解決して import する", async () => {
+  it("module URL を backend origin + wsId-scoped asset prefix で解決して import する", async () => {
     const importSpy = vi.fn(async () => ({ default: () => null }));
     await loadExternalComponents({
+      wsId: WS,
       backendOrigin: ORIGIN,
       fetchImpl: makeFetch({ schemaVersion: "1", components: [validEntry] }),
       importImpl: importSpy,
     });
     expect(importSpy).toHaveBeenCalledWith(
-      `${ORIGIN}/workspace-assets/puck-components/dist/foo.mjs`,
+      `${ORIGIN}${PREFIX}dist/foo.mjs`,
     );
   });
 
   // --- SF2: manifest fetch の HTTP / parse error を握り潰さない ---
   it("manifest が 500 等の HTTP error なら manifest-invalid を返す", async () => {
     const result = await loadExternalComponents({
+      wsId: WS,
       backendOrigin: ORIGIN,
       fetchImpl: fetchHttpError(500),
       importImpl: async () => ({}),
@@ -214,6 +228,7 @@ describe("loadExternalComponents", () => {
 
   it("manifest が 403 でも manifest-invalid を返す (404 のみ空配列)", async () => {
     const result = await loadExternalComponents({
+      wsId: WS,
       backendOrigin: ORIGIN,
       fetchImpl: fetchHttpError(403),
       importImpl: async () => ({}),
@@ -228,6 +243,7 @@ describe("loadExternalComponents", () => {
 
   it("manifest の JSON parse 失敗なら manifest-invalid を返す", async () => {
     const result = await loadExternalComponents({
+      wsId: WS,
       backendOrigin: ORIGIN,
       fetchImpl: fetchJsonThrows(),
       importImpl: async () => ({}),
@@ -241,6 +257,7 @@ describe("loadExternalComponents", () => {
 
   it("network throw (backend down) は空配列 (エラーカードを出さない)", async () => {
     const result = await loadExternalComponents({
+      wsId: WS,
       backendOrigin: ORIGIN,
       fetchImpl: vi.fn(async () => {
         throw new TypeError("Failed to fetch");
@@ -254,6 +271,7 @@ describe("loadExternalComponents", () => {
   it("module が他 origin (https://evil) なら import せず load-error", async () => {
     const importSpy = vi.fn(async () => ({ default: () => null }));
     const result = await loadExternalComponents({
+      wsId: WS,
       backendOrigin: ORIGIN,
       fetchImpl: makeFetch({
         schemaVersion: "1",
@@ -272,6 +290,7 @@ describe("loadExternalComponents", () => {
   it("module が ../ で配信範囲外へ脱出するなら import せず load-error", async () => {
     const importSpy = vi.fn(async () => ({ default: () => null }));
     const result = await loadExternalComponents({
+      wsId: WS,
       backendOrigin: ORIGIN,
       fetchImpl: makeFetch({
         schemaVersion: "1",
@@ -290,6 +309,7 @@ describe("loadExternalComponents", () => {
   it("module が protocol-relative (//host) なら import せず load-error", async () => {
     const importSpy = vi.fn(async () => ({ default: () => null }));
     const result = await loadExternalComponents({
+      wsId: WS,
       backendOrigin: ORIGIN,
       fetchImpl: makeFetch({
         schemaVersion: "1",
@@ -307,6 +327,7 @@ describe("loadExternalComponents", () => {
   it("module の拡張子が allowlist 外 (.json 等) なら import せず load-error", async () => {
     const importSpy = vi.fn(async () => ({ default: () => null }));
     const result = await loadExternalComponents({
+      wsId: WS,
       backendOrigin: ORIGIN,
       fetchImpl: makeFetch({
         schemaVersion: "1",
@@ -325,11 +346,84 @@ describe("loadExternalComponents", () => {
   it("正常な ./dist/foo.mjs は import して ok", async () => {
     const importSpy = vi.fn(async () => ({ default: () => null }));
     const result = await loadExternalComponents({
+      wsId: WS,
       backendOrigin: ORIGIN,
       fetchImpl: makeFetch({ schemaVersion: "1", components: [validEntry] }),
       importImpl: importSpy,
     });
     expect(result[0].status).toBe("ok");
     expect(importSpy).toHaveBeenCalledOnce();
+  });
+
+  // --- #1415 P2-1: per-session workspace scoping ---
+  it("wsId 未指定なら fetch せず空配列を返す (配信先 workspace 不明)", async () => {
+    const fetchSpy = vi.fn(async () => ({ ok: true, status: 200, json: async () => ({}) }) as unknown as Response);
+    const result = await loadExternalComponents({
+      backendOrigin: ORIGIN,
+      fetchImpl: fetchSpy as unknown as typeof fetch,
+      importImpl: async () => ({}),
+    });
+    expect(result).toEqual([]);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("wsId が空文字なら空配列を返す", async () => {
+    const result = await loadExternalComponents({
+      wsId: "   ",
+      backendOrigin: ORIGIN,
+      fetchImpl: makeFetch({ schemaVersion: "1", components: [validEntry] }),
+      importImpl: async () => ({}),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("manifest URL が wsId-scoped prefix で組まれる", async () => {
+    const fetchSpy = vi.fn(async () =>
+      ({ ok: true, status: 200, json: async () => ({ schemaVersion: "1", components: [] }) }) as unknown as Response,
+    );
+    await loadExternalComponents({
+      wsId: WS,
+      backendOrigin: ORIGIN,
+      fetchImpl: fetchSpy as unknown as typeof fetch,
+      importImpl: async () => ({}),
+    });
+    expect(fetchSpy).toHaveBeenCalledWith(`${ORIGIN}${PREFIX}manifest.json`);
+  });
+
+  it("別 wsId は別 prefix の URL を組む (workspace 間で混入しない)", async () => {
+    const fetchB = vi.fn(async () =>
+      ({ ok: true, status: 200, json: async () => ({ schemaVersion: "1", components: [] }) }) as unknown as Response,
+    );
+    await loadExternalComponents({
+      wsId: "ws-B",
+      backendOrigin: ORIGIN,
+      fetchImpl: fetchB as unknown as typeof fetch,
+      importImpl: async () => ({}),
+    });
+    expect(fetchB).toHaveBeenCalledWith(
+      `${ORIGIN}/workspace-assets/ws-B/puck-components/manifest.json`,
+    );
+  });
+
+  it("module が別 wsId の配信範囲を指すと load-error (横移動拒否)", async () => {
+    const importSpy = vi.fn(async () => ({ default: () => null }));
+    // wsId=ws-A の prefix を base に、../../ws-B/puck-components/x.mjs で横移動を狙う。
+    const result = await loadExternalComponents({
+      wsId: WS,
+      backendOrigin: ORIGIN,
+      fetchImpl: makeFetch({
+        schemaVersion: "1",
+        components: [
+          { ...validEntry, module: "../../ws-B/puck-components/dist/x.mjs" },
+        ],
+      }),
+      importImpl: importSpy,
+    });
+    expect(result[0].status).toBe("error");
+    if (result[0].status === "error") {
+      expect(result[0].errorKind).toBe("load-error");
+      expect(result[0].detail).toContain("配信範囲外");
+    }
+    expect(importSpy).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/puck/externalComponents.ts
+++ b/frontend/src/puck/externalComponents.ts
@@ -10,7 +10,8 @@
  * - engine major 不一致 → errorKind="version-mismatch"
  * - module パスが配信範囲外 (任意 origin / 配信外脱出 / 拡張子不正) → errorKind="load-error" (SSRF 防止)
  * - import 失敗 → errorKind="load-error"
- * - export が関数でない → errorKind="missing-export"
+ * - export が妥当な React element type でない → errorKind="missing-export"
+ *   (通常関数/クラス component に加え、React.memo / React.forwardRef / React.lazy も許容する)
  *
  * fetch / import は引数で差し替え可能 (DI) にしてテスト容易化している。
  * JSX は持ち込まない (frontend/AGENTS.md: src/puck/ はロジックのみ)。
@@ -240,12 +241,12 @@ export async function loadExternalComponents(
     // 5. export 取得
     const exportName = entry.export ?? "default";
     const candidate = mod[exportName];
-    if (typeof candidate !== "function") {
+    if (!isValidComponentType(candidate)) {
       results.push({
         entry,
         status: "error",
         errorKind: "missing-export",
-        detail: `export "${exportName}" が関数ではありません`,
+        detail: `export "${exportName}" が妥当な React component ではありません`,
       });
       continue;
     }
@@ -259,6 +260,44 @@ export async function loadExternalComponents(
   }
 
   return results;
+}
+
+/**
+ * React element type として妥当な `$$typeof` Symbol の集合 (P2-6)。
+ * React.memo / React.forwardRef で作られた component は **関数ではなく object** で、
+ * これらの `$$typeof` を持つ。react-is が無い環境向けの最小実装。
+ *
+ * - `react.memo` — React.memo(Component)
+ * - `react.forward_ref` — React.forwardRef(render)
+ * - `react.lazy` — React.lazy(() => import(...))
+ *
+ * Symbol.for は global registry を共有するため、外部 component が別 React copy で
+ * memo/forwardRef を生成していても (案 B の import map で host React 共有が原則だが)
+ * 同一 Symbol になり判定できる。
+ */
+const VALID_COMPONENT_SYMBOL_KEYS = new Set([
+  "react.memo",
+  "react.forward_ref",
+  "react.lazy",
+]);
+
+/**
+ * candidate が React element type (= Puck の render 対象) として妥当かを判定する (P2-6)。
+ *
+ * - `typeof === "function"` — 通常の関数 component / クラス component
+ * - object かつ `$$typeof` が memo / forwardRef / lazy 等の妥当な element type Symbol
+ *
+ * 文字列 tag ("div" 等) / number / null / 通常の object は拒否する。
+ * react-is があれば isValidElementType がより堅牢だが、本プロジェクトには未導入のため
+ * `$$typeof` ベースの最小実装で memo / forwardRef / lazy をカバーする。
+ */
+function isValidComponentType(candidate: unknown): boolean {
+  if (typeof candidate === "function") return true;
+  if (typeof candidate !== "object" || candidate === null) return false;
+  const tag = (candidate as { $$typeof?: unknown }).$$typeof;
+  if (typeof tag !== "symbol") return false;
+  const key = Symbol.keyFor(tag);
+  return key !== undefined && VALID_COMPONENT_SYMBOL_KEYS.has(key);
 }
 
 /** frontend 側で import を許可する module 拡張子 allowlist。 */

--- a/frontend/src/puck/externalComponents.ts
+++ b/frontend/src/puck/externalComponents.ts
@@ -2,8 +2,8 @@
  * externalComponents.ts — 外部 React Component の runtime ESM ローダ (#1409 P-1)。
  *
  * 案 B (runtime ESM import) + import map による React/Puck 共有方式。
- * backend の `/workspace-assets/puck-components/` 静的配信から manifest.json と
- * 各 component の `.mjs` を取得し、`import()` で読み込む。
+ * backend の `/workspace-assets/<wsId>/puck-components/` 静的配信 (wsId-scoped、#1415 P2-1) から
+ * manifest.json と各 component の `.mjs` を取得し、`import()` で読み込む。
  *
  * - manifest が無い (404) / fetch 到達不可 (backend down) → 空配列 (正常系)
  * - manifest HTTP error (403/500 等) / JSON parse 失敗 / manifest 不正 → errorKind="manifest-invalid"
@@ -63,9 +63,21 @@ export function defaultBackendOrigin(): string {
   return `http://${hostname}:${port}`;
 }
 
-const ASSET_PREFIX = "/workspace-assets/puck-components/";
+/**
+ * wsId を含む asset 配信 base prefix を組む (#1415 P2-1)。
+ * `/workspace-assets/<wsId>/puck-components/` 形式。wsId は encode して path segment に埋める。
+ */
+export function assetPrefixFor(wsId: string): string {
+  return `/workspace-assets/${encodeURIComponent(wsId)}/puck-components/`;
+}
 
 export interface LoadExternalComponentsOptions {
+  /**
+   * 現在の active workspace の wsId (#1415 P2-1)。
+   * asset URL を `/workspace-assets/<wsId>/puck-components/` に scope するため必須。
+   * 省略 / 空文字なら配信不可とみなし空配列を返す (= 外部部品なし扱い)。
+   */
+  wsId?: string;
   /** backend origin。省略時は defaultBackendOrigin()。 */
   backendOrigin?: string;
   /** fetch 差し替え (テスト用)。 */
@@ -131,7 +143,12 @@ export async function loadExternalComponents(
   const fetchImpl = opts.fetchImpl ?? fetch;
   const importImpl = opts.importImpl ?? defaultImport;
 
-  const manifestUrl = `${backendOrigin}${ASSET_PREFIX}manifest.json`;
+  // wsId が無ければ配信先 workspace を特定できない → 外部部品なし扱い (空配列、正常系)。
+  const wsId = opts.wsId?.trim();
+  if (!wsId) return [];
+  const assetPrefix = assetPrefixFor(wsId);
+
+  const manifestUrl = `${backendOrigin}${assetPrefix}manifest.json`;
 
   // 1. manifest fetch
   let raw: unknown;
@@ -194,7 +211,7 @@ export async function loadExternalComponents(
     // 4. module URL を解決し、配信範囲内であることを検証する (SSRF 防止)。
     //    entry.module に "https://evil/..." / "//host/..." / "../../" などが書かれていても
     //    backend の asset 配信範囲外へ import が飛ばないようにする。
-    const resolved = resolveSafeModuleUrl(backendOrigin, entry.module);
+    const resolved = resolveSafeModuleUrl(backendOrigin, assetPrefix, entry.module);
     if (!resolved.ok) {
       results.push({
         entry,
@@ -255,16 +272,18 @@ type SafeUrlResult =
  * entry.module を backend asset 配信範囲内の URL に解決する (SSRF 防止)。
  *
  * - 解決後 URL の origin が backend origin と一致すること
- * - 解決後 pathname が ASSET_PREFIX 配下に収まること (../ での配信外脱出を拒否)
+ * - 解決後 pathname が assetPrefix (wsId-scoped、#1415 P2-1) 配下に収まること
+ *   (../ での配信外脱出 / 別 wsId 配信範囲への横移動を拒否)
  * - 拡張子が allowlist (.mjs / .js) であること
  *
  * いずれか満たさない場合は import せず load-error として扱う。
  */
 function resolveSafeModuleUrl(
   backendOrigin: string,
+  assetPrefix: string,
   moduleRel: string,
 ): SafeUrlResult {
-  const base = `${backendOrigin}${ASSET_PREFIX}`;
+  const base = `${backendOrigin}${assetPrefix}`;
   let resolved: URL;
   let expectedOrigin: string;
   try {
@@ -283,7 +302,7 @@ function resolveSafeModuleUrl(
       detail: `module パスが配信範囲外です (origin 不一致): ${moduleRel}`,
     };
   }
-  if (!resolved.pathname.startsWith(ASSET_PREFIX)) {
+  if (!resolved.pathname.startsWith(assetPrefix)) {
     return {
       ok: false,
       detail: `module パスが配信範囲外です: ${moduleRel}`,

--- a/frontend/src/puck/externalComponents.ts
+++ b/frontend/src/puck/externalComponents.ts
@@ -35,7 +35,10 @@ export type ExternalComponentErrorKind =
   | "version-mismatch"
   | "load-error"
   | "missing-export"
-  | "id-collision";
+  | "id-collision"
+  // 複合部品 (#1412 P-4) 展開時、subtree 内ノードの type が config に存在しない場合。
+  // 主に未ロードの外部 component (#1409 P-1) を内包する複合部品で発生する。
+  | "missing-dependency";
 
 export type LoadedExternalComponent =
   | {

--- a/frontend/src/puck/externalComponents.ts
+++ b/frontend/src/puck/externalComponents.ts
@@ -1,0 +1,259 @@
+/**
+ * externalComponents.ts — 外部 React Component の runtime ESM ローダ (#1409 P-1)。
+ *
+ * 案 B (runtime ESM import) + import map による React/Puck 共有方式。
+ * backend の `/workspace-assets/puck-components/` 静的配信から manifest.json と
+ * 各 component の `.mjs` を取得し、`import()` で読み込む。
+ *
+ * - manifest が無い / 404 → 空配列 (外部部品未使用 = 正常系)
+ * - manifest 不正 → 全 entry を errorKind="manifest-invalid" で返す
+ * - engine major 不一致 → errorKind="version-mismatch"
+ * - import 失敗 → errorKind="load-error"
+ * - export が関数でない → errorKind="missing-export"
+ *
+ * fetch / import は引数で差し替え可能 (DI) にしてテスト容易化している。
+ * JSX は持ち込まない (frontend/AGENTS.md: src/puck/ はロジックのみ)。
+ *
+ * RFC #1405 シリーズ P-1。
+ */
+
+import type { ComponentType } from "react";
+import {
+  validateExternalComponentManifest,
+  type ExternalComponentEntry,
+} from "./externalComponentManifest";
+
+/** host が提供する依存の major version。version-mismatch 判定の基準。 */
+export const HOST_REACT_MAJOR = 19;
+export const HOST_PUCK_MAJOR = 0;
+/** Puck は 0.x のため minor も互換境界として扱う (0.20)。 */
+export const HOST_PUCK_MINOR = 20;
+
+export type ExternalComponentErrorKind =
+  | "manifest-invalid"
+  | "version-mismatch"
+  | "load-error"
+  | "missing-export";
+
+export type LoadedExternalComponent =
+  | {
+      entry: ExternalComponentEntry;
+      status: "ok";
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      Component: ComponentType<any>;
+    }
+  | {
+      entry: ExternalComponentEntry;
+      status: "error";
+      errorKind: ExternalComponentErrorKind;
+      detail?: string;
+    };
+
+/** mcpBridge と同一ロジックで backend origin を算出する。 */
+export function defaultBackendOrigin(): string {
+  const port =
+    (import.meta.env?.VITE_DESIGNER_MCP_PORT as string | undefined) ?? "5179";
+  const hostname =
+    typeof window !== "undefined" ? window.location.hostname : "localhost";
+  return `http://${hostname}:${port}`;
+}
+
+const ASSET_PREFIX = "/workspace-assets/puck-components/";
+
+export interface LoadExternalComponentsOptions {
+  /** backend origin。省略時は defaultBackendOrigin()。 */
+  backendOrigin?: string;
+  /** fetch 差し替え (テスト用)。 */
+  fetchImpl?: typeof fetch;
+  /**
+   * dynamic import 差し替え (テスト用)。
+   * 本番では vite-ignore 付き dynamic import (defaultImport) を使う。
+   */
+  importImpl?: (url: string) => Promise<Record<string, unknown>>;
+}
+
+function defaultImport(url: string): Promise<Record<string, unknown>> {
+  return import(/* @vite-ignore */ url) as Promise<Record<string, unknown>>;
+}
+
+/** "19.2.4" → 19 / "0.20.2" → 0 のように先頭の数値を取り出す。 */
+function parseMajor(version: string): number | null {
+  const m = /^\s*\^?~?(\d+)/.exec(version);
+  return m ? Number(m[1]) : null;
+}
+
+/** "0.20.2" → 20。 */
+function parseMinor(version: string): number | null {
+  const m = /^\s*\^?~?\d+\.(\d+)/.exec(version);
+  return m ? Number(m[1]) : null;
+}
+
+/** engine 宣言が host と互換か検証する。null = OK、文字列 = 不一致理由。 */
+function checkEngineCompat(entry: ExternalComponentEntry): string | null {
+  const engine = entry.engine;
+  if (!engine) return null;
+
+  if (engine.react) {
+    const major = parseMajor(engine.react);
+    if (major !== null && major !== HOST_REACT_MAJOR) {
+      return `react major ${major} != host ${HOST_REACT_MAJOR}`;
+    }
+  }
+  if (engine.puck) {
+    const major = parseMajor(engine.puck);
+    if (major !== null && major !== HOST_PUCK_MAJOR) {
+      return `puck major ${major} != host ${HOST_PUCK_MAJOR}`;
+    }
+    // Puck は 0.x のため minor も互換境界
+    if (major === 0) {
+      const minor = parseMinor(engine.puck);
+      if (minor !== null && minor !== HOST_PUCK_MINOR) {
+        return `puck minor 0.${minor} != host 0.${HOST_PUCK_MINOR}`;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * 外部 component manifest を読み込み、各 entry を解決する。
+ * manifest 取得失敗 (404 / network) は外部部品未使用とみなし空配列を返す。
+ */
+export async function loadExternalComponents(
+  opts: LoadExternalComponentsOptions = {},
+): Promise<LoadedExternalComponent[]> {
+  const backendOrigin = opts.backendOrigin ?? defaultBackendOrigin();
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const importImpl = opts.importImpl ?? defaultImport;
+
+  const manifestUrl = `${backendOrigin}${ASSET_PREFIX}manifest.json`;
+
+  // 1. manifest fetch
+  let raw: unknown;
+  try {
+    const res = await fetchImpl(manifestUrl);
+    if (!res.ok) {
+      // 404 等 = manifest 無し = 外部部品未使用 (正常系)
+      return [];
+    }
+    raw = await res.json();
+  } catch {
+    // network / parse 失敗 = manifest 無し扱い
+    return [];
+  }
+
+  // 2. manifest 検証
+  const validated = validateExternalComponentManifest(raw);
+  if (!validated.ok) {
+    const detail = validated.errors.join("; ");
+    // entry を取り出せる範囲でエラー列挙、無理なら 1 件の汎用エラー
+    const entries = extractEntriesForErrorReport(raw);
+    if (entries.length === 0) {
+      return [
+        {
+          entry: {
+            id: "(manifest)",
+            label: "外部コンポーネント manifest",
+            module: "",
+            version: "",
+          },
+          status: "error",
+          errorKind: "manifest-invalid",
+          detail,
+        },
+      ];
+    }
+    return entries.map((entry) => ({
+      entry,
+      status: "error" as const,
+      errorKind: "manifest-invalid" as const,
+      detail,
+    }));
+  }
+
+  // 3-5. 各 entry を解決
+  const results: LoadedExternalComponent[] = [];
+  for (const entry of validated.manifest.components) {
+    // 3. engine 互換
+    const incompat = checkEngineCompat(entry);
+    if (incompat) {
+      results.push({
+        entry,
+        status: "error",
+        errorKind: "version-mismatch",
+        detail: incompat,
+      });
+      continue;
+    }
+
+    // 4. dynamic import
+    const moduleUrl = resolveModuleUrl(backendOrigin, entry.module);
+    let mod: Record<string, unknown>;
+    try {
+      mod = await importImpl(moduleUrl);
+    } catch (e) {
+      results.push({
+        entry,
+        status: "error",
+        errorKind: "load-error",
+        detail: e instanceof Error ? e.message : String(e),
+      });
+      continue;
+    }
+
+    // 5. export 取得
+    const exportName = entry.export ?? "default";
+    const candidate = mod[exportName];
+    if (typeof candidate !== "function") {
+      results.push({
+        entry,
+        status: "error",
+        errorKind: "missing-export",
+        detail: `export "${exportName}" が関数ではありません`,
+      });
+      continue;
+    }
+
+    results.push({
+      entry,
+      status: "ok",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      Component: candidate as ComponentType<any>,
+    });
+  }
+
+  return results;
+}
+
+/** backend origin + asset prefix を base に entry.module を URL 解決する。 */
+function resolveModuleUrl(backendOrigin: string, moduleRel: string): string {
+  const base = `${backendOrigin}${ASSET_PREFIX}`;
+  return new URL(moduleRel, base).href;
+}
+
+/**
+ * manifest 不正時でも entry っぽいものを取り出してエラー表示に使う。
+ * 完全な検証は通っていないため best-effort。
+ */
+function extractEntriesForErrorReport(raw: unknown): ExternalComponentEntry[] {
+  if (
+    typeof raw !== "object" ||
+    raw === null ||
+    !Array.isArray((raw as Record<string, unknown>).components)
+  ) {
+    return [];
+  }
+  const components = (raw as Record<string, unknown>).components as unknown[];
+  return components.map((c, i) => {
+    const obj = (typeof c === "object" && c !== null ? c : {}) as Record<
+      string,
+      unknown
+    >;
+    return {
+      id: typeof obj.id === "string" ? obj.id : `(entry-${i})`,
+      label: typeof obj.label === "string" ? obj.label : `entry ${i}`,
+      module: typeof obj.module === "string" ? obj.module : "",
+      version: typeof obj.version === "string" ? obj.version : "",
+    };
+  });
+}

--- a/frontend/src/puck/externalComponents.ts
+++ b/frontend/src/puck/externalComponents.ts
@@ -5,9 +5,10 @@
  * backend の `/workspace-assets/puck-components/` 静的配信から manifest.json と
  * 各 component の `.mjs` を取得し、`import()` で読み込む。
  *
- * - manifest が無い / 404 → 空配列 (外部部品未使用 = 正常系)
- * - manifest 不正 → 全 entry を errorKind="manifest-invalid" で返す
+ * - manifest が無い (404) / fetch 到達不可 (backend down) → 空配列 (正常系)
+ * - manifest HTTP error (403/500 等) / JSON parse 失敗 / manifest 不正 → errorKind="manifest-invalid"
  * - engine major 不一致 → errorKind="version-mismatch"
+ * - module パスが配信範囲外 (任意 origin / 配信外脱出 / 拡張子不正) → errorKind="load-error" (SSRF 防止)
  * - import 失敗 → errorKind="load-error"
  * - export が関数でない → errorKind="missing-export"
  *
@@ -33,7 +34,8 @@ export type ExternalComponentErrorKind =
   | "manifest-invalid"
   | "version-mismatch"
   | "load-error"
-  | "missing-export";
+  | "missing-export"
+  | "id-collision";
 
 export type LoadedExternalComponent =
   | {
@@ -133,12 +135,24 @@ export async function loadExternalComponents(
   try {
     const res = await fetchImpl(manifestUrl);
     if (!res.ok) {
-      // 404 等 = manifest 無し = 外部部品未使用 (正常系)
-      return [];
+      // 404 = manifest 無し = 外部部品未使用 (正常系) → 空配列。
+      if (res.status === 404) return [];
+      // それ以外の HTTP error (403/500 等) は設定/サーバ異常 → manifest-invalid で可視化。
+      return [manifestError(`HTTP ${res.status}`)];
     }
-    raw = await res.json();
+    try {
+      raw = await res.json();
+    } catch (e) {
+      // JSON parse 失敗 = manifest 破損 → manifest-invalid で可視化 (握り潰さない)。
+      return [
+        manifestError(
+          `JSON parse 失敗: ${e instanceof Error ? e.message : String(e)}`,
+        ),
+      ];
+    }
   } catch {
-    // network / parse 失敗 = manifest 無し扱い
+    // fetch 自体の throw = network 到達不可 (= backend 未起動)。
+    // editor で backend 未起動時にエラーカードを出さないため空配列扱い (正常系)。
     return [];
   }
 
@@ -149,19 +163,7 @@ export async function loadExternalComponents(
     // entry を取り出せる範囲でエラー列挙、無理なら 1 件の汎用エラー
     const entries = extractEntriesForErrorReport(raw);
     if (entries.length === 0) {
-      return [
-        {
-          entry: {
-            id: "(manifest)",
-            label: "外部コンポーネント manifest",
-            module: "",
-            version: "",
-          },
-          status: "error",
-          errorKind: "manifest-invalid",
-          detail,
-        },
-      ];
+      return [manifestError(detail)];
     }
     return entries.map((entry) => ({
       entry,
@@ -186,8 +188,22 @@ export async function loadExternalComponents(
       continue;
     }
 
-    // 4. dynamic import
-    const moduleUrl = resolveModuleUrl(backendOrigin, entry.module);
+    // 4. module URL を解決し、配信範囲内であることを検証する (SSRF 防止)。
+    //    entry.module に "https://evil/..." / "//host/..." / "../../" などが書かれていても
+    //    backend の asset 配信範囲外へ import が飛ばないようにする。
+    const resolved = resolveSafeModuleUrl(backendOrigin, entry.module);
+    if (!resolved.ok) {
+      results.push({
+        entry,
+        status: "error",
+        errorKind: "load-error",
+        detail: resolved.detail,
+      });
+      continue;
+    }
+    const moduleUrl = resolved.url;
+
+    // dynamic import
     let mod: Record<string, unknown>;
     try {
       mod = await importImpl(moduleUrl);
@@ -225,10 +241,73 @@ export async function loadExternalComponents(
   return results;
 }
 
-/** backend origin + asset prefix を base に entry.module を URL 解決する。 */
-function resolveModuleUrl(backendOrigin: string, moduleRel: string): string {
+/** frontend 側で import を許可する module 拡張子 allowlist。 */
+const ALLOWED_MODULE_EXTENSIONS = [".mjs", ".js"];
+
+type SafeUrlResult =
+  | { ok: true; url: string }
+  | { ok: false; detail: string };
+
+/**
+ * entry.module を backend asset 配信範囲内の URL に解決する (SSRF 防止)。
+ *
+ * - 解決後 URL の origin が backend origin と一致すること
+ * - 解決後 pathname が ASSET_PREFIX 配下に収まること (../ での配信外脱出を拒否)
+ * - 拡張子が allowlist (.mjs / .js) であること
+ *
+ * いずれか満たさない場合は import せず load-error として扱う。
+ */
+function resolveSafeModuleUrl(
+  backendOrigin: string,
+  moduleRel: string,
+): SafeUrlResult {
   const base = `${backendOrigin}${ASSET_PREFIX}`;
-  return new URL(moduleRel, base).href;
+  let resolved: URL;
+  let expectedOrigin: string;
+  try {
+    resolved = new URL(moduleRel, base);
+    expectedOrigin = new URL(backendOrigin).origin;
+  } catch (e) {
+    return {
+      ok: false,
+      detail: `module パスが解決できません: ${moduleRel} (${e instanceof Error ? e.message : String(e)})`,
+    };
+  }
+
+  if (resolved.origin !== expectedOrigin) {
+    return {
+      ok: false,
+      detail: `module パスが配信範囲外です (origin 不一致): ${moduleRel}`,
+    };
+  }
+  if (!resolved.pathname.startsWith(ASSET_PREFIX)) {
+    return {
+      ok: false,
+      detail: `module パスが配信範囲外です: ${moduleRel}`,
+    };
+  }
+  if (!ALLOWED_MODULE_EXTENSIONS.some((ext) => resolved.pathname.endsWith(ext))) {
+    return {
+      ok: false,
+      detail: `module の拡張子が許可されていません (.mjs / .js のみ): ${moduleRel}`,
+    };
+  }
+  return { ok: true, url: resolved.href };
+}
+
+/** manifest 取得/検証段階の単一エラー結果を生成する。 */
+function manifestError(detail: string): LoadedExternalComponent {
+  return {
+    entry: {
+      id: "(manifest)",
+      label: "外部コンポーネント manifest",
+      module: "",
+      version: "",
+    },
+    status: "error",
+    errorKind: "manifest-invalid",
+    detail,
+  };
 }
 
 /**

--- a/frontend/src/puck/harmonyExternalsShim.test.ts
+++ b/frontend/src/puck/harmonyExternalsShim.test.ts
@@ -1,0 +1,136 @@
+/**
+ * harmonyExternalsShim.test.ts — 外部 component 用 import map shim mjs の検証 (#1409 P-1)。
+ *
+ * frontend/public/harmony-externals/*.mjs は host が window.__HARMONY_SHARED_DEPS__ に
+ * 設置した実 module を re-export する素の ESM。ここでは window bridge に実 react /
+ * react-dom / react-dom/client / react/jsx-runtime / @measured/puck を設置した上で
+ * 各 shim を評価し、代表 named export が host 実体と一致 (=== or typeof) することを assert する。
+ *
+ * jsdom 環境。public/*.mjs は Vite を介さず fs で読み出し、ESM の export 文を
+ * 評価可能な形に変換して window bridge 経由の解決を検証する。
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import * as ReactNS from "react";
+import * as ReactDOMNS from "react-dom";
+import * as ReactDOMClientNS from "react-dom/client";
+import * as ReactJsxRuntimeNS from "react/jsx-runtime";
+import * as PuckNS from "@measured/puck";
+
+const SHIM_DIR = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../public/harmony-externals",
+);
+
+/**
+ * 素の ESM shim mjs を評価し、export された binding を Record で返す。
+ *
+ * shim は次の 2 形態のみ使う:
+ *   - `export default m;`
+ *   - `export const { a, b, ... } = m;`
+ * これらを評価可能な JS に変換し、window bridge 経由で解決させて binding を回収する。
+ * `window` への参照はそのまま (jsdom の global window を使う)。
+ */
+function evalShim(fileName: string): Record<string, unknown> {
+  const source = readFileSync(resolve(SHIM_DIR, fileName), "utf-8");
+
+  // export 文を回収用の代入に書き換える。
+  const exportsBag: Record<string, unknown> = {};
+  const rewritten = source
+    // `export default X;` → `__exports__.default = X;`
+    .replace(/export\s+default\s+([^;]+);/g, "__exports__.default = $1;")
+    // `export const { ... } = m;` → `Object.assign(__exports__, (() => { const { ... } = m; return { ... }; })());`
+    .replace(
+      /export\s+const\s+\{([\s\S]*?)\}\s*=\s*([^;]+);/g,
+      (_m, names: string, rhs: string) => {
+        // names から identifier (コメント除去) を抽出
+        const idents = names
+          .split(",")
+          .map((s) => s.replace(/\/\/.*$/gm, "").trim())
+          .filter((s) => s.length > 0 && /^[A-Za-z_$][\w$]*$/.test(s));
+        const destructure = idents.join(", ");
+        const reassemble = idents.map((n) => `${n}: ${n}`).join(", ");
+        return `Object.assign(__exports__, (() => { const { ${destructure} } = ${rhs}; return { ${reassemble} }; })());`;
+      },
+    );
+
+  // window はテスト側で設置済みの jsdom global を使う。
+  const fn = new Function("__exports__", "window", rewritten);
+  fn(exportsBag, window);
+  return exportsBag;
+}
+
+beforeAll(() => {
+  (window as unknown as { __HARMONY_SHARED_DEPS__?: Record<string, unknown> }).__HARMONY_SHARED_DEPS__ =
+    {
+      react: ReactNS,
+      "react-dom": ReactDOMNS,
+      "react-dom/client": ReactDOMClientNS,
+      "react/jsx-runtime": ReactJsxRuntimeNS,
+      "@measured/puck": PuckNS,
+    };
+});
+
+describe("harmony-externals shim mjs", () => {
+  it("react.mjs: 代表 named export が host 実体と一致する", () => {
+    const ex = evalShim("react.mjs");
+    expect(ex.useState).toBe((ReactNS as Record<string, unknown>).useState);
+    expect(ex.useEffect).toBe((ReactNS as Record<string, unknown>).useEffect);
+    expect(ex.createElement).toBe(
+      (ReactNS as Record<string, unknown>).createElement,
+    );
+    // React 19 安定 surface (use)。host に存在することを確認。
+    expect(ex.use).toBe((ReactNS as Record<string, unknown>).use);
+    expect(typeof ex.use).toBe("function");
+    // default は React namespace 全体
+    expect(ex.default).toBe(ReactNS);
+  });
+
+  it("react-dom.mjs: createPortal が host 実体と一致する", () => {
+    const ex = evalShim("react-dom.mjs");
+    expect(ex.createPortal).toBe(
+      (ReactDOMNS as Record<string, unknown>).createPortal,
+    );
+    expect(typeof ex.createPortal).toBe("function");
+    expect(ex.default).toBe(ReactDOMNS);
+  });
+
+  it("react-dom-client.mjs: createRoot が host 実体と一致する", () => {
+    const ex = evalShim("react-dom-client.mjs");
+    expect(ex.createRoot).toBe(
+      (ReactDOMClientNS as Record<string, unknown>).createRoot,
+    );
+    expect(typeof ex.createRoot).toBe("function");
+    expect(ex.hydrateRoot).toBe(
+      (ReactDOMClientNS as Record<string, unknown>).hydrateRoot,
+    );
+  });
+
+  it("react-jsx-runtime.mjs: jsx が host 実体と一致する", () => {
+    const ex = evalShim("react-jsx-runtime.mjs");
+    expect(ex.jsx).toBe((ReactJsxRuntimeNS as Record<string, unknown>).jsx);
+    expect(typeof ex.jsx).toBe("function");
+  });
+
+  it("puck.mjs: DropZone が host 実体と一致する", () => {
+    const ex = evalShim("puck.mjs");
+    expect(ex.DropZone).toBe((PuckNS as Record<string, unknown>).DropZone);
+    expect(ex.DropZone).toBeDefined();
+    expect(ex.default).toBe(PuckNS);
+  });
+
+  it("bridge 未設置なら shim は throw する", () => {
+    const saved = (window as unknown as { __HARMONY_SHARED_DEPS__?: unknown })
+      .__HARMONY_SHARED_DEPS__;
+    (window as unknown as { __HARMONY_SHARED_DEPS__?: unknown }).__HARMONY_SHARED_DEPS__ =
+      {};
+    try {
+      expect(() => evalShim("react.mjs")).toThrow(/bridge 未設置/);
+    } finally {
+      (window as unknown as { __HARMONY_SHARED_DEPS__?: unknown }).__HARMONY_SHARED_DEPS__ =
+        saved;
+    }
+  });
+});

--- a/frontend/src/puck/harmonyExternalsShim.test.ts
+++ b/frontend/src/puck/harmonyExternalsShim.test.ts
@@ -84,6 +84,15 @@ describe("harmony-externals shim mjs", () => {
     // React 19 安定 surface (use)。host に存在することを確認。
     expect(ex.use).toBe((ReactNS as Record<string, unknown>).use);
     expect(typeof ex.use).toBe("function");
+    // React 19 安定 surface (useActionState / useOptimistic)。
+    // host 実体と一致すること (host に存在すれば function、無ければ undefined だが
+    // いずれにせよ shim の named export 宣言は host 実体に解決される)。
+    expect(ex.useActionState).toBe(
+      (ReactNS as Record<string, unknown>).useActionState,
+    );
+    expect(ex.useOptimistic).toBe(
+      (ReactNS as Record<string, unknown>).useOptimistic,
+    );
     // default は React namespace 全体
     expect(ex.default).toBe(ReactNS);
   });
@@ -94,6 +103,10 @@ describe("harmony-externals shim mjs", () => {
       (ReactDOMNS as Record<string, unknown>).createPortal,
     );
     expect(typeof ex.createPortal).toBe("function");
+    // React 19 安定 surface (useFormStatus、react-dom に存在)。host 実体と一致。
+    expect(ex.useFormStatus).toBe(
+      (ReactDOMNS as Record<string, unknown>).useFormStatus,
+    );
     expect(ex.default).toBe(ReactDOMNS);
   });
 

--- a/frontend/src/store/puckComponentsStore.test.ts
+++ b/frontend/src/store/puckComponentsStore.test.ts
@@ -13,6 +13,8 @@ import {
   saveCustomPuckComponents,
   setPuckComponentsBackend,
   type CustomPuckComponentDef,
+  type PrimitivePuckComponentDef,
+  type CompositePuckComponentDef,
   type PuckComponentsStorageBackend,
 } from "./puckComponentsStore";
 
@@ -35,8 +37,11 @@ Object.defineProperty(globalThis, "localStorage", {
 
 // ── テスト用フィクスチャ ───────────────────────────────────────────────────────
 
-function makeComponent(overrides?: Partial<CustomPuckComponentDef>): CustomPuckComponentDef {
+function makeComponent(
+  overrides?: Partial<PrimitivePuckComponentDef>,
+): PrimitivePuckComponentDef {
   return {
+    kind: "primitive",
     id: "test-comp-1",
     label: "テストコンポーネント",
     primitive: "card",
@@ -44,6 +49,22 @@ function makeComponent(overrides?: Partial<CustomPuckComponentDef>): CustomPuckC
       title: { type: "string", default: "タイトル" },
       count: { type: "number" },
     },
+    ...overrides,
+  };
+}
+
+function makeComposite(
+  overrides?: Partial<CompositePuckComponentDef>,
+): CompositePuckComponentDef {
+  return {
+    kind: "composite",
+    id: "composite-1",
+    label: "複合部品テスト",
+    tree: {
+      content: [{ type: "Card", props: { id: "card-1" } }],
+      zones: { "card-1:content": [{ type: "Heading", props: { id: "h-1" } }] },
+    },
+    dependencies: [],
     ...overrides,
   };
 }
@@ -88,7 +109,7 @@ describe("puckComponentsStore — with storage backend", () => {
     await addCustomPuckComponent(makeComponent());
     const result = await loadCustomPuckComponents();
     expect(result).toHaveLength(1);
-    expect(result[0].primitive).toBe("card");
+    expect((result[0] as PrimitivePuckComponentDef).primitive).toBe("card");
   });
 
   it("バックエンド経由で remove が動く", async () => {
@@ -177,7 +198,68 @@ describe("puckComponentsStore — with storage backend", () => {
     });
     await addCustomPuckComponent(def);
     const result = await loadCustomPuckComponents();
-    expect(result[0].propsSchema.color.type).toBe("enum");
-    expect(result[0].propsSchema.color.enum).toHaveLength(2);
+    const restored = result[0] as PrimitivePuckComponentDef;
+    expect(restored.propsSchema.color.type).toBe("enum");
+    expect(restored.propsSchema.color.enum).toHaveLength(2);
+  });
+
+  // ── 複合部品 (composite) CRUD + kind normalize (#1412 P-4) ────────────────
+
+  it("composite レコードを add → load で復元できる", async () => {
+    await addCustomPuckComponent(makeComposite());
+    const result = await loadCustomPuckComponents();
+    expect(result).toHaveLength(1);
+    expect(result[0].kind).toBe("composite");
+    const comp = result[0] as CompositePuckComponentDef;
+    expect(comp.tree.content).toHaveLength(1);
+    expect(comp.tree.zones?.["card-1:content"]).toHaveLength(1);
+  });
+
+  it("primitive と composite を混在保存・load で両方復元できる", async () => {
+    await addCustomPuckComponent(makeComponent({ id: "prim" }));
+    await addCustomPuckComponent(makeComposite({ id: "comp" }));
+    const result = await loadCustomPuckComponents();
+    expect(result).toHaveLength(2);
+    expect(result.find((c) => c.id === "prim")?.kind).toBe("primitive");
+    expect(result.find((c) => c.id === "comp")?.kind).toBe("composite");
+  });
+
+  it("composite を dependencies 付きで保存・復元できる", async () => {
+    await addCustomPuckComponent(
+      makeComposite({ id: "with-deps", dependencies: ["ext-widget-a"] }),
+    );
+    const result = await loadCustomPuckComponents();
+    expect((result[0] as CompositePuckComponentDef).dependencies).toEqual([
+      "ext-widget-a",
+    ]);
+  });
+
+  it("composite を remove できる", async () => {
+    await addCustomPuckComponent(makeComposite({ id: "c-del" }));
+    await removeCustomPuckComponent("c-del");
+    const result = await loadCustomPuckComponents();
+    expect(result).toHaveLength(0);
+  });
+
+  it("kind 無しの旧レコードは load 時に kind:'primitive' に normalize される", async () => {
+    // kind を持たない旧形式レコードを直接 backend に書き込む。
+    const legacyRecord = {
+      id: "legacy-prim",
+      label: "旧レコード",
+      primitive: "card",
+      propsSchema: {},
+    };
+    await saveCustomPuckComponents([legacyRecord as unknown as CustomPuckComponentDef]);
+    const result = await loadCustomPuckComponents();
+    expect(result[0].kind).toBe("primitive");
+    expect((result[0] as PrimitivePuckComponentDef).primitive).toBe("card");
+  });
+
+  it("update は kind を変更しない", async () => {
+    await addCustomPuckComponent(makeComposite({ id: "c-upd" }));
+    await updateCustomPuckComponent("c-upd", { label: "更新後" });
+    const result = await loadCustomPuckComponents();
+    expect(result[0].kind).toBe("composite");
+    expect(result[0].label).toBe("更新後");
   });
 });

--- a/frontend/src/store/puckComponentsStore.ts
+++ b/frontend/src/store/puckComponentsStore.ts
@@ -9,6 +9,7 @@
  * customBlockStore と同パターン (#806 子 5)
  */
 
+import type { Data } from "@measured/puck";
 import type { BUILTIN_PRIMITIVE_NAMES } from "../puck/buildConfig";
 import { uiInfo } from "../utils/uiLog";
 
@@ -21,12 +22,47 @@ export interface PropSchemaField {
   label?: string;
 }
 
-export interface CustomPuckComponentDef {
+/**
+ * primitive ベースの単発カスタムコンポーネント定義 (#806 子 5)。
+ * 既存形式。1 つの primitive に propsSchema を付与した派生部品。
+ */
+export interface PrimitivePuckComponentDef {
+  kind: "primitive";
   id: string;
   label: string;
   primitive: (typeof BUILTIN_PRIMITIVE_NAMES)[number] | string; // BUILTIN_PRIMITIVE_NAMES のいずれか
   propsSchema: Record<string, PropSchemaField>;
 }
+
+/**
+ * 複合部品 (subtree 再利用、#1412 P-4)。
+ * 設計者が Puck 上で組み合わせた subtree を「再利用部品」として保存したもの。
+ * パレットから drop すると subtree がその場で展開挿入される (expand-on-drop)。
+ *
+ * - `tree` = 自己完結した Puck Data 断片 (content + zones サブセット)。
+ *   root は持たない (展開時はホスト Data の content に merge されるため)。
+ * - `dependencies` = subtree が内包する外部 component (#1409 P-1) の entry.id 一覧。
+ *   未ロードの外部 component を含む場合の capability 6 (依存解決エラー) 判定に使う。
+ */
+export interface CompositePuckComponentDef {
+  kind: "composite";
+  id: string;
+  label: string;
+  tree: {
+    content: Data["content"];
+    zones?: Data["zones"];
+  };
+  dependencies?: string[];
+}
+
+/**
+ * カスタム Puck コンポーネント定義の discriminated union (#1412 P-4)。
+ * `kind` で primitive / composite を判別する。`kind` 無しの旧レコードは
+ * load 時に `kind: "primitive"` へ normalize される (後方安全)。
+ */
+export type CustomPuckComponentDef =
+  | PrimitivePuckComponentDef
+  | CompositePuckComponentDef;
 
 // ─── ストレージバックエンド ───────────────────────────────────────────────────
 
@@ -57,10 +93,24 @@ function readLegacyLocalStorage(): CustomPuckComponentDef[] {
   try {
     const raw = localStorage.getItem(LEGACY_LS_KEY);
     if (!raw) return [];
-    return JSON.parse(raw) as CustomPuckComponentDef[];
+    return normalizeRecords(JSON.parse(raw) as unknown[]);
   } catch {
     return [];
   }
+}
+
+/**
+ * 永続化されたレコード配列を `kind` 付き discriminated union に正規化する (#1412 P-4)。
+ * `kind` 無しの旧レコード (P-4 以前は primitive 形式のみ) は `kind: "primitive"` を付与する。
+ * 後方安全のため、不明な構造のレコードはそのまま通す (draft-state policy)。
+ */
+function normalizeRecords(records: unknown[]): CustomPuckComponentDef[] {
+  return records.map((rec) => {
+    if (rec && typeof rec === "object" && !("kind" in rec)) {
+      return { kind: "primitive", ...(rec as object) } as CustomPuckComponentDef;
+    }
+    return rec as CustomPuckComponentDef;
+  });
 }
 
 // ─── 公開 API ─────────────────────────────────────────────────────────────────
@@ -68,7 +118,7 @@ function readLegacyLocalStorage(): CustomPuckComponentDef[] {
 /** すべてのカスタム Puck コンポーネント定義を読み込む */
 export async function loadCustomPuckComponents(): Promise<CustomPuckComponentDef[]> {
   const backend = requireBackend();
-  const data = (await backend.loadPuckComponents()) as CustomPuckComponentDef[];
+  const data = normalizeRecords(await backend.loadPuckComponents());
   if (data.length > 0) return data;
   // ファイルが空 → 旧 localStorage から 1 度きり migration
   const legacy = readLegacyLocalStorage();
@@ -102,7 +152,11 @@ export async function removeCustomPuckComponent(id: string): Promise<void> {
   await saveCustomPuckComponents(filtered);
 }
 
-/** 部分更新 */
+/**
+ * 部分更新。
+ * `kind` をまたぐ更新 (primitive → composite 等) は想定しないため、
+ * 同 kind 内のフィールド patch のみを許可する。id は変更不可。
+ */
 export async function updateCustomPuckComponent(
   id: string,
   patch: Partial<CustomPuckComponentDef>,
@@ -110,6 +164,12 @@ export async function updateCustomPuckComponent(
   const components = await loadCustomPuckComponents();
   const idx = components.findIndex((c) => c.id === id);
   if (idx < 0) throw new Error(`puck component "${id}" not found`);
-  components[idx] = { ...components[idx], ...patch, id }; // id は変更不可
+  // id / kind は不変。それ以外を patch でマージする。
+  components[idx] = {
+    ...components[idx],
+    ...patch,
+    id,
+    kind: components[idx].kind,
+  } as CustomPuckComponentDef;
   await saveCustomPuckComponents(components);
 }

--- a/frontend/src/utils/puckScreenValidation.test.ts
+++ b/frontend/src/utils/puckScreenValidation.test.ts
@@ -149,6 +149,7 @@ describe("validatePuckScreen — カスタムコンポーネント定義の prim
   it("有効な primitive のカスタムコンポーネントは error なし", () => {
     const customComponents: CustomPuckComponentDef[] = [
       {
+        kind: "primitive",
         id: "my-card",
         label: "マイカード",
         primitive: "card",
@@ -164,6 +165,7 @@ describe("validatePuckScreen — カスタムコンポーネント定義の prim
   it("存在しない primitive のカスタムコンポーネントは error", () => {
     const customComponents: CustomPuckComponentDef[] = [
       {
+        kind: "primitive",
         id: "invalid-comp",
         label: "不正コンポーネント",
         primitive: "non-existent-primitive",

--- a/frontend/src/utils/puckScreenValidation.ts
+++ b/frontend/src/utils/puckScreenValidation.ts
@@ -175,7 +175,8 @@ export function validatePuckScreen(
 
           // カスタムコンポーネントの primitive 存在検証
           const customDef = customComponents.find((c) => c.id === item.type);
-          if (customDef) {
+          // primitive 経路のみ primitive 存在検証する (composite は subtree のため対象外、#1412 P-4)。
+          if (customDef && customDef.kind === "primitive") {
             if (!(BUILTIN_PRIMITIVE_NAMES as readonly string[]).includes(customDef.primitive)) {
               errors.push({
                 severity: "error",
@@ -210,6 +211,8 @@ export function validatePuckScreen(
 
   // ── カスタムコンポーネント定義の primitive 存在検証 ───────────────────────
   for (const def of customComponents) {
+    // composite は primitive を持たないため検証対象外 (#1412 P-4)。
+    if (def.kind !== "primitive") continue;
     if (!(BUILTIN_PRIMITIVE_NAMES as readonly string[]).includes(def.primitive)) {
       errors.push({
         severity: "error",

--- a/scripts/scaffold/puck-component.mjs
+++ b/scripts/scaffold/puck-component.mjs
@@ -99,6 +99,8 @@ import react from "@vitejs/plugin-react";
 // 外部 Puck Component の build 設定 (#1409 P-1)。
 // react / react-dom / @measured/puck は host (Harmony) と共有するため external 化し、
 // bundle に含めない。host は index.html の import map + window bridge でこれらを供給する。
+// predicate 形式で subpath (react-dom/client, react/jsx-runtime, @measured/puck/* 等) も
+// 漏れなく external 化する。
 export default defineConfig({
   plugins: [react()],
   build: {
@@ -108,7 +110,7 @@ export default defineConfig({
       fileName: () => "${name}.mjs",
     },
     rollupOptions: {
-      external: ["react", "react-dom", "react/jsx-runtime", "@measured/puck"],
+      external: (id) => /^(react|react-dom|@measured\\/puck)(\\/.*)?$/.test(id),
     },
   },
 });

--- a/scripts/scaffold/puck-component.mjs
+++ b/scripts/scaffold/puck-component.mjs
@@ -202,6 +202,11 @@ export interface ${pascal}Props {
    * host (Harmony) が Puck の slot field を render-prop に変換して注入するため、
    * 外部部品側で DropZone を import する必要はありません。呼び出すと、設計者が
    * その領域に Puck で配置した部品が描画されます (#1411 P-3)。
+   *
+   * 型は意図的にゆるく \`(props?: ...) => React.ReactNode\` としています。実体は host が
+   * 注入する Puck の SlotComponent (render-prop) ですが、外部部品は host の
+   * \`@measured/puck\` 型に依存しない設計のため、その型を import せず最小の関数シグネチャ
+   * で受け取ります (依存非依存方針)。呼び出し方 (\`content()\`) は変わりません。
    */
   content?: (props?: Record<string, unknown>) => React.ReactNode;
 }

--- a/scripts/scaffold/puck-component.mjs
+++ b/scripts/scaffold/puck-component.mjs
@@ -186,7 +186,7 @@ ${original
 }
 
 function buildComponentSample(pascal) {
-  return `// ${pascal}.tsx — 外部 Puck Component サンプル (#1409 P-1)。
+  return `// ${pascal}.tsx — 外部 Puck Component サンプル (#1409 P-1 / slot 対応 #1411 P-3)。
 //
 // props は manifest.json の props 宣言と対応させてください。
 // React は host と共有されるため、必ず "react" から import します (import map で解決)。
@@ -197,9 +197,20 @@ export interface ${pascal}Props {
   title?: string;
   /** 本文 */
   message?: string;
+  /**
+   * named slot (editable region) の render-prop。manifest の slots 宣言と対応します。
+   * host (Harmony) が Puck の slot field を render-prop に変換して注入するため、
+   * 外部部品側で DropZone を import する必要はありません。呼び出すと、設計者が
+   * その領域に Puck で配置した部品が描画されます (#1411 P-3)。
+   */
+  content?: (props?: Record<string, unknown>) => React.ReactNode;
 }
 
-export default function ${pascal}({ title = "サンプル外部部品", message = "" }: ${pascal}Props) {
+export default function ${pascal}({
+  title = "サンプル外部部品",
+  message = "",
+  content,
+}: ${pascal}Props) {
   return (
     <div
       data-external-component="${pascal}"
@@ -212,6 +223,8 @@ export default function ${pascal}({ title = "サンプル外部部品", message 
     >
       <strong>{title}</strong>
       {message ? <p style={{ margin: "6px 0 0" }}>{message}</p> : null}
+      {/* editable region: host 注入 slot。設計者が Puck で内部に部品を配置できる。 */}
+      {content ? content() : null}
     </div>
   );
 }
@@ -234,6 +247,7 @@ function buildManifest(name, pascal) {
             { name: "title", type: "string", label: "見出し", default: pascal },
             { name: "message", type: "string", label: "本文" },
           ],
+          slots: [{ name: "content", label: "本文スロット" }],
         },
       ],
     },
@@ -288,7 +302,29 @@ npm run build          # → dist/${name}.mjs を生成
 | \`version\` | ✅ | 部品バージョン |
 | \`engine\` | | \`{ react, puck }\` の互換 major。host (react 19 / puck 0.20) と不一致なら読込エラー |
 | \`props\` | | prop 宣言 (P-1 では default 集約のみ反映、fields 本格化は P-2) |
-| \`slots\` | | DropZone 相当 (P-3 で活用) |
+| \`slots\` | | named slot (editable region)。設計者が内部に部品を配置できる (P-3) |
+
+## slot 契約 (editable region、#1411 P-3)
+
+manifest の \`slots\` で named slot を宣言すると、host (Harmony) はその slot を Puck の
+slot field として登録します。Puck は render 時に **対応する \`props.<slotName>\` を
+render-prop (関数) に変換して注入** するため、component はその関数を呼んで描画するだけです。
+
+- component は対応する \`props.<slotName>\` を **描画** する (例: \`content ? content() : null\`)。
+- 設計者は Puck デザイナー上でその領域 (editable region) に他の部品を **ドラッグ配置** できる。
+- 配置内容は当該 component の props に co-located で保存され、通常の保存/読込で素通りします。
+- **\`@measured/puck\` の DropZone を自分で import する必要はありません** (host が注入)。
+
+\`\`\`tsx
+export interface SampleProps {
+  content?: (props?: Record<string, unknown>) => React.ReactNode;
+}
+export default function Sample({ content }: SampleProps) {
+  return <div>{content ? content() : null}</div>;
+}
+\`\`\`
+
+slot 名は同 entry 内で unique かつ prop 名と衝突しないこと (manifest validator が検出します)。
 
 ## エラー時の挙動
 

--- a/scripts/scaffold/puck-component.mjs
+++ b/scripts/scaffold/puck-component.mjs
@@ -1,0 +1,356 @@
+#!/usr/bin/env node
+/**
+ * scripts/scaffold/puck-component.mjs — 外部 Puck Component scaffold (#1409 P-1)。
+ *
+ * 外部業務 React Component を Harmony Puck に読み込ませる雛形プロジェクトを生成する。
+ * React / ReactDOM / @measured/puck は host (Harmony frontend) と共有する契約のため
+ * external 扱いとし、bundle には含めない (import map + window bridge で host が供給する)。
+ *
+ * 使い方:
+ *   node scripts/scaffold/puck-component.mjs <name> [--from-primitive <PrimitiveName>] [--out <dir>]
+ *
+ *   <name>               生成する component / package 名 (例: order-summary)
+ *   --from-primitive X   frontend/src/puck/primitives/X.tsx を出発点にコピー (簡易化あり)
+ *   --out <dir>          出力先ディレクトリ (省略時 ./<name>。data/ への直書きはしない)
+ *
+ * 生成物 (<out>/<name>/):
+ *   package.json / vite.config.ts / tsconfig.json / src/<Name>.tsx / manifest.json / README.md
+ *
+ * build → dist/<name>.mjs 生成 → workspace の <dataDir>/puck-components/ に dist/ と
+ * manifest.json を配置すると Harmony が runtime ESM import で読み込む。
+ *
+ * RFC #1405 シリーズ P-1。
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+// scripts/scaffold/ → scripts/ → repo root
+const REPO_ROOT = path.resolve(__dirname, "../..");
+const PRIMITIVES_DIR = path.join(REPO_ROOT, "frontend/src/puck/primitives");
+
+function parseArgs(argv) {
+  const args = { name: undefined, fromPrimitive: undefined, out: undefined };
+  const rest = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--from-primitive") {
+      args.fromPrimitive = argv[++i];
+    } else if (a === "--out") {
+      args.out = argv[++i];
+    } else if (a.startsWith("--")) {
+      throw new Error(`不明なオプション: ${a}`);
+    } else {
+      rest.push(a);
+    }
+  }
+  args.name = rest[0];
+  return args;
+}
+
+/** kebab-case / snake_case → PascalCase */
+function toPascalCase(name) {
+  return name
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+    .join("");
+}
+
+function writeFile(dir, rel, content) {
+  const full = path.join(dir, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content, "utf-8");
+  console.log(`  生成: ${path.relative(process.cwd(), full)}`);
+}
+
+function buildPackageJson(name) {
+  return JSON.stringify(
+    {
+      name: `@harmony-external/${name}`,
+      version: "0.1.0",
+      type: "module",
+      private: true,
+      scripts: {
+        build: "vite build",
+      },
+      devDependencies: {
+        vite: "^6.0.0",
+        "@vitejs/plugin-react": "^4.3.0",
+        typescript: "^5.6.0",
+        "@types/react": "^19.0.0",
+        react: "^19.2.4",
+        "react-dom": "^19.2.4",
+        "@measured/puck": "^0.20.2",
+      },
+    },
+    null,
+    2,
+  ) + "\n";
+}
+
+function buildViteConfig(name, pascal) {
+  return `import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+// 外部 Puck Component の build 設定 (#1409 P-1)。
+// react / react-dom / @measured/puck は host (Harmony) と共有するため external 化し、
+// bundle に含めない。host は index.html の import map + window bridge でこれらを供給する。
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    lib: {
+      entry: "src/${pascal}.tsx",
+      formats: ["es"],
+      fileName: () => "${name}.mjs",
+    },
+    rollupOptions: {
+      external: ["react", "react-dom", "react/jsx-runtime", "@measured/puck"],
+    },
+  },
+});
+`;
+}
+
+function buildTsConfig() {
+  return JSON.stringify(
+    {
+      compilerOptions: {
+        target: "ES2022",
+        module: "ESNext",
+        moduleResolution: "Bundler",
+        jsx: "react-jsx",
+        strict: true,
+        esModuleInterop: true,
+        skipLibCheck: true,
+        lib: ["ES2022", "DOM", "DOM.Iterable"],
+      },
+      include: ["src"],
+    },
+    null,
+    2,
+  ) + "\n";
+}
+
+/**
+ * primitive ソースを出発点にする場合、host 固有依存 (useCssFramework / layoutPropsMapping)
+ * を import しない簡易版に変換する。完全移植は README で external 化の方針を案内する。
+ */
+function buildComponentFromPrimitive(pascal, primitiveName) {
+  const src = path.join(PRIMITIVES_DIR, `${primitiveName}.tsx`);
+  if (!fs.existsSync(src)) {
+    throw new Error(
+      `primitive が見つかりません: ${src}\n` +
+        `frontend/src/puck/primitives/ 内の名前 (例: Card / Button) を指定してください。`,
+    );
+  }
+  const original = fs.readFileSync(src, "utf-8");
+  return `// ${pascal}.tsx — frontend/src/puck/primitives/${primitiveName}.tsx を出発点に scaffold (#1409 P-1)。
+//
+// 注意: 元の primitive は host 内部の useCssFramework() / layoutPropsMapping に依存します。
+// 外部 component では host と共有されないため、以下いずれかで対応してください:
+//   (1) 必要な class を props で受け取り単純化する (推奨、最小構成)
+//   (2) host が将来 export する Context を import map に追加して共有する (P-3 以降)
+// 下記は (1) の最小サンプルです。元ソースは末尾のコメントを参照してください。
+import * as React from "react";
+
+export interface ${pascal}Props {
+  title?: string;
+  className?: string;
+  children?: React.ReactNode;
+}
+
+export default function ${pascal}({ title, className, children }: ${pascal}Props) {
+  return (
+    <div data-external-component="${pascal}" className={className}>
+      {title ? <h3>{title}</h3> : null}
+      {children}
+    </div>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * 元 primitive ソース (${primitiveName}.tsx) — 移植時の参考用:
+ *
+${original
+    .split("\n")
+    .map((l) => ` * ${l}`)
+    .join("\n")}
+ * ───────────────────────────────────────────────────────────────────────── */
+`;
+}
+
+function buildComponentSample(pascal) {
+  return `// ${pascal}.tsx — 外部 Puck Component サンプル (#1409 P-1)。
+//
+// props は manifest.json の props 宣言と対応させてください。
+// React は host と共有されるため、必ず "react" から import します (import map で解決)。
+import * as React from "react";
+
+export interface ${pascal}Props {
+  /** 見出し */
+  title?: string;
+  /** 本文 */
+  message?: string;
+}
+
+export default function ${pascal}({ title = "サンプル外部部品", message = "" }: ${pascal}Props) {
+  return (
+    <div
+      data-external-component="${pascal}"
+      style={{
+        border: "1px solid #0d6efd",
+        borderRadius: 6,
+        padding: 12,
+        background: "#f0f7ff",
+      }}
+    >
+      <strong>{title}</strong>
+      {message ? <p style={{ margin: "6px 0 0" }}>{message}</p> : null}
+    </div>
+  );
+}
+`;
+}
+
+function buildManifest(name, pascal) {
+  return JSON.stringify(
+    {
+      schemaVersion: "1",
+      components: [
+        {
+          id: name,
+          label: pascal,
+          module: `./dist/${name}.mjs`,
+          export: "default",
+          version: "0.1.0",
+          engine: { react: "19", puck: "0.20" },
+          props: [
+            { name: "title", type: "string", label: "見出し", default: pascal },
+            { name: "message", type: "string", label: "本文" },
+          ],
+        },
+      ],
+    },
+    null,
+    2,
+  ) + "\n";
+}
+
+function buildReadme(name, pascal) {
+  return `# ${pascal} — 外部 Puck Component (#1409 P-1)
+
+Harmony の Puck デザイナーに runtime ESM import で読み込ませる外部業務 React Component です。
+
+## 契約 (重要)
+
+- **React / ReactDOM / @measured/puck は host (Harmony) と共有** します。bundle には含めません
+  (\`vite.config.ts\` の \`rollupOptions.external\`)。host が index.html の import map +
+  \`window.__HARMONY_SHARED_DEPS__\` bridge でこれらを供給するため、外部部品と host が
+  同一インスタンスを共有し React 二重化 (Invalid hook call 等) を防ぎます。
+- import は必ず bare specifier (\`import * as React from "react"\`) を使ってください。
+  host 内部 path を直接 import しないこと。
+
+## build と配置
+
+\`\`\`bash
+npm install
+npm run build          # → dist/${name}.mjs を生成
+\`\`\`
+
+生成後、active workspace の \`<dataDir>/puck-components/\` に以下を配置します
+(\`<dataDir>\` は workspace の \`harmony.json\` の \`dataDir\` 設定。例: \`workspaces/my-app/harmony/\`):
+
+\`\`\`
+<dataDir>/puck-components/
+  manifest.json        ← 本リポジトリの manifest.json をコピー
+  dist/${name}.mjs     ← build 成果物
+\`\`\`
+
+複数部品を 1 workspace に置く場合は \`manifest.json\` の \`components\` 配列に追記してマージします
+(各 entry の \`module\` は \`puck-components/\` からの相対 path)。
+
+## manifest.json
+
+\`schemaVersion: "1"\`。各 component entry:
+
+| field | 必須 | 説明 |
+|---|---|---|
+| \`id\` | ✅ | Puck config 上の key (workspace 内 unique) |
+| \`label\` | ✅ | パレット表示名 |
+| \`module\` | ✅ | \`puck-components/\` からの相対 \`.mjs\` path |
+| \`export\` | | 読み込む export 名 (省略時 \`default\`) |
+| \`version\` | ✅ | 部品バージョン |
+| \`engine\` | | \`{ react, puck }\` の互換 major。host (react 19 / puck 0.20) と不一致なら読込エラー |
+| \`props\` | | prop 宣言 (P-1 では default 集約のみ反映、fields 本格化は P-2) |
+| \`slots\` | | DropZone 相当 (P-3 で活用) |
+
+## エラー時の挙動
+
+manifest 不正 / engine 不一致 / 読込失敗 / export 不在 の場合、Puck canvas 上に赤系の
+エラーカードが表示され、原因 (errorKind + 詳細) を確認できます。
+`;
+}
+
+function main() {
+  let args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (e) {
+    console.error(`エラー: ${e.message}`);
+    process.exit(1);
+  }
+
+  if (!args.name) {
+    console.error(
+      "使い方: node scripts/scaffold/puck-component.mjs <name> [--from-primitive <PrimitiveName>] [--out <dir>]",
+    );
+    process.exit(1);
+  }
+
+  const name = args.name;
+  const pascal = toPascalCase(name);
+  // 出力先は明示 --out があればそこ、なければ cwd 直下の ./<name>。
+  // data/ への直書きは避ける (AGENTS.md)。
+  const outBase = args.out ?? process.cwd();
+  if (path.resolve(outBase).split(path.sep).includes("data")) {
+    console.error(
+      "エラー: data/ への scaffold は禁止です。--out で workspace 外の作業ディレクトリを指定してください。",
+    );
+    process.exit(1);
+  }
+  const targetDir = path.join(outBase, name);
+
+  if (fs.existsSync(targetDir)) {
+    console.error(`エラー: 出力先が既に存在します: ${targetDir}`);
+    process.exit(1);
+  }
+
+  console.log(`外部 Puck Component を生成します: ${name} (${pascal})`);
+  if (args.fromPrimitive) {
+    console.log(`  primitive を出発点にコピー: ${args.fromPrimitive}`);
+  }
+
+  writeFile(targetDir, "package.json", buildPackageJson(name));
+  writeFile(targetDir, "vite.config.ts", buildViteConfig(name, pascal));
+  writeFile(targetDir, "tsconfig.json", buildTsConfig());
+  writeFile(
+    targetDir,
+    `src/${pascal}.tsx`,
+    args.fromPrimitive
+      ? buildComponentFromPrimitive(pascal, args.fromPrimitive)
+      : buildComponentSample(pascal),
+  );
+  writeFile(targetDir, "manifest.json", buildManifest(name, pascal));
+  writeFile(targetDir, "README.md", buildReadme(name, pascal));
+
+  console.log(`\n完了。次の手順:`);
+  console.log(`  cd ${path.relative(process.cwd(), targetDir) || "."}`);
+  console.log(`  npm install && npm run build`);
+  console.log(`  → dist/${name}.mjs と manifest.json を workspace の <dataDir>/puck-components/ に配置`);
+}
+
+main();


### PR DESCRIPTION
## 関連

Closes #1409
Closes #1410
Closes #1411
Closes #1412
Closes #1413
Refs #1405

- 仕様: docs/spec/multi-editor-puck.md (Puck エディタ基盤) / docs/spec/dogfood-2026-05-29-puck-external-components.md (本シリーズの dogfood 検証)
- 親 RFC: #1405 (外部 React Component / primitive 読込)。全 Phase 完了後に手動 close。

## 概要

Puck で利用できる component / primitive が Harmony frontend bundle 内 built-in に固定されていた制約を解消し、業務プロジェクト側が独自 React Component を **project-scoped** で追加して Puck パレットから WYSIWYG 配置できるようにする (RFC #1405)。Harmony は編集基盤、業務アプリ側は project 固有 UI 部品、という役割分担を実現する。

## 主な変更 (Phase 別)

- **P-1 (#1409) 読込基盤**: 外部 component manifest 規格 (`externalComponentManifest.ts`) + runtime ESM ローダ (`externalComponents.ts`、import map による React/Puck 共有・SSRF 防止・engine 互換チェック) + backend 静的配信 route `/workspace-assets/puck-components/` (`puckComponentAssets.ts`) + scaffold script (`scripts/scaffold/puck-component.mjs`) + 読込失敗エラーカード UI。
- **P-2 (#1410) palette 統合 + props 定義**: ロード済 component を `projectExternal` カテゴリで左パレットに表示 (built-in と識別)、manifest の props 宣言 (string/number/boolean/enum) を Puck fields に変換 (`mergeExternalComponents` / `buildConfig.ts`)。custom (JSON-only) 経路と共存。
- **P-3 (#1411) slot / editable region**: manifest の named slot 宣言 → Puck の `type:"slot"` field。host が render-prop を注入し、外部部品側は `@measured/puck` 非依存で内部 editable region を構造編集可能に。
- **P-4 (#1412) 複合部品 (composite)**: 設計者が Puck 上で primitive / JSON / 外部部品の subtree を「再利用部品」として保存し no-code で再配置 (`puckSubtree.ts`、expand-on-drop)。未ロード外部依存は `missing-dependency` エラーカード。
- **P-5 (#1413) dogfood 通し検証**: 実 scaffold → vite build (ESM) した業務部品 `approval-status-bar` で capability 1〜6 を end-to-end 通し検証する自動 test (12 ケース) + dogfood 検証 doc。

## 仕様逐条突合 (自己申告) — RFC #1405 Required Capabilities

- **cap1 project-scoped component loading** → `frontend/src/puck/externalComponents.ts:loadExternalComponents` (runtime ESM import + import map で React 共有)。検証: `dogfoodExternalComponents.test.tsx:96` ✓
- **cap2 palette integration** → `frontend/src/puck/buildConfig.ts:mergeExternalComponents` (`projectExternal` カテゴリ)。検証: `dogfoodExternalComponents.test.tsx:124` ✓
- **cap3 props definition** → `buildConfig.ts` props→fields 変換 (string/number/boolean/enum)。検証: `dogfoodExternalComponents.test.tsx:124` ✓
- **cap4 slot / editable region** → `buildConfig.ts:buildSlotFields` (`type:"slot"` + defaultProps[slot]=[])。検証: `dogfoodExternalComponents.test.tsx:163` ✓
- **cap5 project scoping** → loader が active workspace `<dataRoot>/puck-components/` のみ参照 + id 衝突防御。検証: `dogfoodExternalComponents.test.tsx:316,355` ✓
- **cap6 validation / fallback** → `externalComponents.ts` errorKind (manifest-invalid / version-mismatch / load-error(SSRF) / missing-export / id-collision / missing-dependency) + `ExternalComponentErrorCard`。検証: `dogfoodExternalComponents.test.tsx:395-480` ✓
- **複合部品 (P-4 新 capability)** → `frontend/src/editor/puckSubtree.ts` (expandCompositePlaceholders / compositeErrorTypeName)。検証: `dogfoodExternalComponents.test.tsx:198,258` ✓

## レビューで特に見てほしい箇所

- **外部 ESM の runtime import 安全性** (`externalComponents.ts:resolveSafeModuleUrl`): origin 一致 + ASSET_PREFIX 配下 + 拡張子 allowlist で SSRF / 配信外脱出を拒否。
- **React 二重化防止**: import map + `window.__HARMONY_SHARED_DEPS__` bridge + vite externals。P-5 cap1 test が実 build 成果物を実 import → `useState` 描画で同一インスタンスを実証。
- **id 衝突時の防御**: built-in / 既存 custom / 先行 external と同 id の外部部品は上書きせず `id-collision` エラーカード化。
- **複合部品の未ロード依存ハンドリング** (`puckSubtree.ts`): 内包する外部部品が当該 workspace で未ロードの場合に `missing-dependency` に落とす。

## テスト

- Vitest: puck 関連 12 ファイル 377 件 (うち P-5 新規 `dogfoodExternalComponents.test.tsx` 12 件) + P-1〜P-4 各 Phase の unit test (manifest validator / loader / mergeExternalComponents / buildConfig / puckSubtree / shim 等)。
- Playwright: 既存 puck E2E (puck-editor.spec.ts 等) は本シリーズで構造変更なし。
- MCP E2E: N/A。
- orchestrator が branch HEAD で実機再走確認: dogfood test 12 green / puck 回帰 377 green / `npm run build` ✓ (型エラー 0)。

## UI 影響 / AI smoke test

- [x] UI 影響あり (Puck パレット + canvas)。ただし **本シリーズ内では実ブラウザ smoke 未実施** — 理由は下記。
- [ ] UI 影響なし

### UI 影響ありの場合、AI smoke test で確認した項目

- 実ブラウザ smoke は **未実施**。worktree frontend が開発中 main frontend と port 競合し、現行常駐 backend(5179) が main 由来で外部 component 配信 route を未反映 (404) のため。
- 代替として P-5 cap1 test が **実 vite build した `.mjs` を実 import → React render → hooks 動作** まで自動検証済 (実 artifact が host React で動くことを実証)。
- 実機ブラウザ smoke (パレット配置 → props → slot 入れ子 → 複合保存 → 再配置) は **本 PR merge 後のリリース確認時に実施推奨**。詳細: `docs/spec/dogfood-2026-05-29-puck-external-components.md` §ブラウザ smoke。

## regression trace gate (#1346)

- N/A (e2e regression 未実行)。本シリーズは frontend unit test (vitest) + backend handler test + 型チェック中心で、E2E regression suite は走らせていない。既存 puck E2E spec に構造変更なし。

## schema governance (#511)

- `git diff origin/main..HEAD -- schemas/` は **空** (グローバル schema 無変更)。manifest は workspace 内ファイル (`<dataRoot>/puck-components/manifest.json`) で schema 対象外。

## spec 側の不足点

- N/A。
