### PR TITLE
fix(backend): codex transport close() の永久 hang を解消し Ctrl+C 停止を回復 (#1414)

### DIFF
--- a/backend/src/codex/transport.test.ts
+++ b/backend/src/codex/transport.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
+
+// node:child_process.spawn を差し替える hoisted mock。
+// 実際の codex バイナリを起動せず、FakeChild を返す。
+const { spawnMock, childRef } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+  // FakeChild を保持する箱 (テスト本体から最後に spawn された child を参照する)
+  childRef: { current: null as unknown },
+}));
+
+vi.mock("node:child_process", () => ({ spawn: spawnMock }));
+
+import { StdioTransport } from "./transport.js";
+
+/**
+ * codex 子プロセスを模した fake。
+ * - exit イベントは simulateExit() を呼ばない限り発火しない (= D 状態 / ゾンビ模倣)
+ * - kill() は撃たれたシグナルを記録するだけで、exitCode は変えない
+ */
+class FakeChild extends EventEmitter {
+  exitCode: number | null = null;
+  killSignals: string[] = [];
+  unrefCalled = false;
+  stdin = { writable: true, write: vi.fn(() => true), end: vi.fn() };
+  stdout = Object.assign(new EventEmitter(), { setEncoding: vi.fn() });
+  stderr = Object.assign(new EventEmitter(), { setEncoding: vi.fn() });
+
+  unref(): void {
+    this.unrefCalled = true;
+  }
+
+  kill(signal?: string): boolean {
+    this.killSignals.push(signal ?? "SIGTERM");
+    return true;
+  }
+
+  /** 子プロセスが実際に exit したことを模擬する */
+  simulateExit(code = 0, signal: string | null = null): void {
+    this.exitCode = code;
+    this.emit("exit", code, signal);
+  }
+}
+
+function currentChild(): FakeChild {
+  return childRef.current as FakeChild;
+}
+
+describe("StdioTransport (#1414)", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    spawnMock.mockReset();
+    spawnMock.mockImplementation(() => {
+      const child = new FakeChild();
+      childRef.current = child;
+      return child;
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("constructor が child.unref() を呼ぶ (親 event loop を保持させない)", () => {
+    new StdioTransport({ command: "fake" });
+    expect(currentChild().unrefCalled).toBe(true);
+  });
+
+  it("close() は exit イベント発火で resolve する", async () => {
+    const transport = new StdioTransport({ command: "fake" });
+    const child = currentChild();
+    const p = transport.close({ sigtermDelayMs: 500, sigkillDelayMs: 1500 });
+    child.simulateExit(0, null);
+    await expect(p).resolves.toBeUndefined();
+  });
+
+  it("exit イベントが永久に来なくても SIGKILL+200ms で force-resolve する", async () => {
+    vi.useFakeTimers();
+    const transport = new StdioTransport({ command: "fake" });
+    const child = currentChild();
+    const p = transport.close({ sigtermDelayMs: 500, sigkillDelayMs: 1500 });
+
+    let settled = false;
+    void p.then(() => {
+      settled = true;
+    });
+
+    // SIGTERM 直前 (480ms): まだ kill されていない
+    await vi.advanceTimersByTimeAsync(480);
+    expect(child.killSignals).not.toContain("SIGTERM");
+    expect(settled).toBe(false);
+
+    // SIGTERM 発火後 (520ms): exitCode は null のままなので SIGTERM が撃たれる
+    await vi.advanceTimersByTimeAsync(40);
+    expect(child.killSignals).toContain("SIGTERM");
+
+    // SIGKILL 発火後・fallback 前 (1600ms): SIGKILL は撃たれたが 200ms fallback 未到達
+    await vi.advanceTimersByTimeAsync(1080);
+    expect(child.killSignals).toContain("SIGKILL");
+    expect(settled).toBe(false);
+
+    // fallback 到達 (1700ms 経過): exit イベント無しでも resolve する
+    await vi.advanceTimersByTimeAsync(120);
+    await expect(p).resolves.toBeUndefined();
+    expect(settled).toBe(true);
+  });
+
+  it("既に didClose 済なら close() は即 resolve (二重呼び出し安全)", async () => {
+    const transport = new StdioTransport({ command: "fake" });
+    const child = currentChild();
+    const p1 = transport.close({ sigtermDelayMs: 500, sigkillDelayMs: 1500 });
+    child.simulateExit(0, null);
+    await p1;
+    await expect(transport.close()).resolves.toBeUndefined();
+  });
+});

--- a/backend/src/codex/transport.ts
+++ b/backend/src/codex/transport.ts
@@ -58,6 +58,10 @@ export class StdioTransport extends JsonRpcTransport {
       env: options.env ?? process.env,
       cwd: options.cwd,
     });
+    // codex 子プロセスが親 (backend) の event loop を保持しないようにする (#1414)。
+    // 子が D 状態 / ゾンビ等で exit イベントを発火しないケースでも、親プロセスが
+    // 子の handle 参照だけで生き残るのを防ぎ、shutdown 時の hang を緩和する。
+    this.child.unref();
 
     this.child.stdout.setEncoding("utf8");
     this.child.stdout.on("data", (chunk: string) => this.handleStdout(chunk));
@@ -103,13 +107,25 @@ export class StdioTransport extends JsonRpcTransport {
     const sigtermMs = opts?.sigtermDelayMs ?? 5000;
     const sigkillMs = opts?.sigkillDelayMs ?? 10000;
     return new Promise<void>((resolve) => {
-      this.child.once("exit", () => resolve());
+      // exit イベントと SIGKILL 後の fallback timer の両方から呼ばれるため
+      // idempotent にして二重 resolve を防ぐ (#1414)。
+      let resolved = false;
+      const done = () => {
+        if (resolved) return;
+        resolved = true;
+        resolve();
+      };
+      this.child.once("exit", done);
       this.child.stdin.end();
       setTimeout(() => {
         if (this.child.exitCode === null) this.child.kill("SIGTERM");
       }, sigtermMs).unref();
       setTimeout(() => {
         if (this.child.exitCode === null) this.child.kill("SIGKILL");
+        // SIGKILL 後 200ms 経っても exit イベントが来なければ強制 resolve (#1414)。
+        // 子が D 状態 / ゾンビ等で exit を発火しないと Promise が永久 hang し、
+        // shutdown シーケンス全体 (wsBridge.stop → exitHandler) が止まるため。
+        setTimeout(done, 200).unref();
       }, sigkillMs).unref();
       this.emit("close", { kind: "local" });
     });


### PR DESCRIPTION
Closes #1414

## 概要

`npm run backend` (tsx watch) 起動中に Ctrl+C / ファイル変更リスタートを行っても backend プロセスが終了せずハングする問題を修正する。`backend/src/codex/transport.ts` の `StdioTransport.close()` が `child.once('exit')` の resolve だけに依存しており、codex 子プロセスが D 状態 / ゾンビ等で SIGKILL 後も `exit` イベントを発火しない場合に Promise が永久 hang していた。これにより shutdown シーケンス (`wsBridge.stop()` → `exitHandler()`) 全体が止まり、tsx watch の 5 秒 force-kill でも Node プロセス自体が止まらなかった。

ISSUE #1414 記載の根本原因分析・修正方針にそのまま沿って実装した。

## 変更内容

### `backend/src/codex/transport.ts`

1. **`StdioTransport.close()` に SIGKILL 後の force-resolve fallback を追加**
   - `resolved` フラグ + idempotent な `done()` を導入し、`once('exit')` と fallback timer の二重 resolve を防止
   - SIGKILL timer 内で `setTimeout(done, 200).unref()` を仕込み、`exit` が来なくても確実に resolve
   - shutdown 時 (`sigkillDelayMs: 1500`) の worst case: 1500 + 200 = **1700ms で確実完了**
2. **constructor に `this.child.unref()` を追加**
   - codex 子プロセスの handle 参照だけで親 (backend) の event loop が生き残るのを防止

### `backend/src/codex/transport.test.ts` (新規)

`node:child_process` を `vi.mock` + `FakeChild` で差し替え (実 codex バイナリ不要):

- ① constructor が `child.unref()` を呼ぶ
- ② `exit` イベント発火で `close()` が resolve する
- ③ **`exit` が永久に来なくても** SIGTERM → SIGKILL → +200ms で force-resolve する (#1414 本体、fake timer 検証)
- ④ 二重 `close()` 呼び出しが安全 (didClose 済なら即 resolve)

## 影響範囲

- `backend/src/codex/transport.ts` のみ (schema 変更なし)
- 通常の tool 呼び出し動作には影響なし (`close()` は shutdown 時のみ呼ばれる)
- `WebSocketTransport` は不変

## テスト

- `vitest run src/codex/transport.test.ts` → 4 passed
- backend 全テスト `vitest run` → **39 files / 807 tests passed** (regression なし)
- `tsc --noEmit` → エラーなし

## 関連

- #1400 (Ctrl+C 停止不能 初回修正)
- #1414 (本 ISSUE、根本原因分析済)

## 仕様逐条突合 (自己申告)

- ISSUE 「修正内容 1. SIGKILL 後に強制 resolve」 → `backend/src/codex/transport.ts:115-131` (idempotent done + 200ms fallback)
- ISSUE 「修正内容 2. child.unref() を追加」 → `backend/src/codex/transport.ts:61-64`
- worst case 1700ms 完了 → test ③ `backend/src/codex/transport.test.ts:96-122` で検証

## チェックリスト

- [x] schema (`schemas/*.json`) 変更なし
- [x] backend 全テスト pass
- [x] tsc pass
- [x] UI 影響なし (backend shutdown 経路のみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)