### PR TITLE
fix(backend): Codex app-server の jsonrpc なしフレームを受信可能にする

### DIFF
--- a/backend/src/codex/jsonRpc.test.ts
+++ b/backend/src/codex/jsonRpc.test.ts
@@ -63,6 +63,63 @@ describe("JsonRpcClient", () => {
     });
   });
 
+  it("accepts Codex app-server notifications without jsonrpc field", () => {
+    const transport = new MockTransport();
+    const onNotification = vi.fn();
+    new JsonRpcClient({ transport, onNotification });
+    transport.inject({
+      method: "configWarning",
+      params: { summary: "Codex warning" },
+    });
+    expect(onNotification).toHaveBeenCalledWith({
+      method: "configWarning",
+      params: { summary: "Codex warning" },
+    });
+  });
+
+  it("accepts Codex app-server responses without jsonrpc field", async () => {
+    const transport = new MockTransport();
+    const client = new JsonRpcClient({ transport });
+    const promise = client.request<{ userAgent: string }>("initialize", {});
+    const sent = JSON.parse(transport.sent[0]!);
+
+    transport.inject({ id: sent.id, result: { userAgent: "Harnize Harmony/test" } });
+
+    await expect(promise).resolves.toEqual({ userAgent: "Harnize Harmony/test" });
+    await client.close();
+  });
+
+  it("accepts Codex app-server requests without jsonrpc field", async () => {
+    const transport = new MockTransport();
+    const onServerRequest = vi.fn().mockResolvedValue({ approved: true });
+    new JsonRpcClient({ transport, onServerRequest });
+
+    transport.inject({
+      id: 100,
+      method: "item/commandExecution/requestApproval",
+      params: {},
+    });
+
+    await new Promise((r) => setImmediate(r));
+    expect(onServerRequest).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(transport.sent[0]!)).toEqual({
+      jsonrpc: "2.0",
+      id: 100,
+      result: { approved: true },
+    });
+  });
+
+  it("rejects frames with an invalid jsonrpc field", () => {
+    const transport = new MockTransport();
+    const onParseError = vi.fn();
+    new JsonRpcClient({ transport, onParseError });
+
+    transport.inject({ jsonrpc: "1.0", method: "warning", params: {} });
+
+    expect(onParseError).toHaveBeenCalledTimes(1);
+    expect(onParseError.mock.calls[0]![1].message).toBe("Invalid jsonrpc field");
+  });
+
   it("answers server-initiated requests via onServerRequest", async () => {
     const transport = new MockTransport();
     const onServerRequest = vi.fn().mockResolvedValue({ approved: true });

--- a/backend/src/codex/jsonRpc.ts
+++ b/backend/src/codex/jsonRpc.ts
@@ -35,6 +35,12 @@ export interface JsonRpcNotification {
 
 export type JsonRpcMessage = JsonRpcRequest | JsonRpcResponse | JsonRpcNotification;
 
+type IncomingJsonRpcMessage =
+  | JsonRpcMessage
+  | Omit<JsonRpcRequest, "jsonrpc">
+  | Omit<JsonRpcResponse, "jsonrpc">
+  | Omit<JsonRpcNotification, "jsonrpc">;
+
 export class JsonRpcError extends Error {
   constructor(
     public readonly code: number,
@@ -144,15 +150,22 @@ export class JsonRpcClient {
   }
 
   private handleMessage = (raw: string): void => {
-    let msg: JsonRpcMessage;
+    let msg: IncomingJsonRpcMessage;
     try {
-      msg = JSON.parse(raw) as JsonRpcMessage;
+      msg = JSON.parse(raw) as IncomingJsonRpcMessage;
     } catch (err) {
       this.onParseError?.(raw, err as Error);
       return;
     }
-    if (typeof msg !== "object" || msg === null || (msg as { jsonrpc?: string }).jsonrpc !== "2.0") {
-      this.onParseError?.(raw, new Error("Missing jsonrpc:2.0 field"));
+    if (typeof msg !== "object" || msg === null) {
+      this.onParseError?.(raw, new Error("Unrecognized JSON-RPC frame"));
+      return;
+    }
+    if (
+      (msg as { jsonrpc?: string }).jsonrpc !== undefined &&
+      (msg as { jsonrpc?: string }).jsonrpc !== "2.0"
+    ) {
+      this.onParseError?.(raw, new Error("Invalid jsonrpc field"));
       return;
     }
     const hasId = "id" in msg && msg.id !== undefined && msg.id !== null;


### PR DESCRIPTION
## 概要

Codex app-server が `jsonrpc: "2.0"` を付けずに返す response / notification / server request を、backend の JSON-RPC 受信処理で許容するよう修正します。

実ログで `initialize` response、`configWarning`、`remoteControl/status/changed` が `jsonrpc` なしで届き、`Codex JSON-RPC parse error: Missing jsonrpc:2.0 field` として扱われていました。

## 変更内容

- 送信フレームは従来どおり `jsonrpc: "2.0"` を維持
- 受信フレームのみ `jsonrpc` 省略を許容
- `jsonrpc` が存在していて `"2.0"` 以外の場合は parse error として拒否
- Codex app-server 互換の notification / response / server request の unit test を追加

## Issue 判断

昨日の類似事象として確認した #1414 / PR #1418 は shutdown hang 対策であり、今回の parse error とは別原因でした。小さい backend 互換性修正なので新規 Issue 化せず本 PR に吸収します。

## テスト

- `npm --workspace=backend run test -- src/codex/jsonRpc.test.ts src/codex/connection.test.ts`
- `npm --workspace=backend run build`

## Schema governance

- `schemas/` 変更なし