### PR TITLE
feat(designer): GrapesJS 画面デザイナーのリードオンリーをデフォルト化 (#1423)

### DIFF
--- a/frontend/e2e/designer-edit-session.spec.ts
+++ b/frontend/e2e/designer-edit-session.spec.ts
@@ -61,7 +61,10 @@ test.describe("画面デザイナー edit-session — シナリオ 1: 編集開�
     });
   });
 
-  test("readonly オーバーレイが表示 → 編集開始 → 保存 → save 後も editing 継続 → discard で readonly", async ({ page }) => {
+  // #1423: canvas 中央の readonly オーバーレイは廃止。編集開始はツールバーの
+  // edit-mode-start ボタンから行う (Puck デザイナー UX と統一)。readonly でも
+  // canvas は暗転せずデザインを完全に閲覧できる。
+  test("ツールバーから編集開始 → 保存 → save 後も editing 継続 → discard で readonly に戻る", async ({ page }) => {
     await ws.gotoActive(page, `/screen/design/${SCREEN_NORM}`);
 
     // 過去 test 残骸の draft が ResumeOrDiscardDialog として出る場合があるので dismiss
@@ -73,12 +76,12 @@ test.describe("画面デザイナー edit-session — シナリオ 1: 編集開�
       } else { break; }
     }
 
-    const overlay = page.getByTestId("canvas-readonly-overlay");
-    await expect(overlay).toBeVisible({ timeout: 10000 });
+    // 廃止された canvas オーバーレイは描画されない
+    await expect(page.getByTestId("canvas-readonly-overlay")).toHaveCount(0);
 
-    const canvasStartBtn = page.getByTestId("canvas-readonly-start");
-    await expect(canvasStartBtn).toBeVisible();
-    await canvasStartBtn.click();
+    const editStartBtn = page.getByTestId("edit-mode-start");
+    await expect(editStartBtn).toBeVisible({ timeout: 10000 });
+    await editStartBtn.click();
 
     await expect(page.getByTestId("edit-mode-save")).toBeVisible({ timeout: 5000 });
     await page.getByTestId("edit-mode-save").click();
@@ -93,7 +96,6 @@ test.describe("画面デザイナー edit-session — シナリオ 1: 編集開�
     await expect(page.getByTestId("discard-confirm")).toBeVisible({ timeout: 3000 });
     await page.getByTestId("discard-confirm").click();
     await expect(page.getByTestId("edit-mode-start")).toBeVisible({ timeout: 10000 });
-    await expect(page.getByTestId("canvas-readonly-overlay")).toBeVisible();
   });
 });
 
@@ -128,7 +130,6 @@ test.describe("画面デザイナー edit-session — シナリオ 2: 編集中 
     await expect(page.getByTestId("discard-confirm")).toBeVisible({ timeout: 3000 });
     await page.getByTestId("discard-confirm").click();
     await expect(page.getByTestId("edit-mode-start")).toBeVisible({ timeout: 8000 });
-    await expect(page.getByTestId("canvas-readonly-overlay")).toBeVisible();
   });
 });
 
@@ -219,9 +220,9 @@ test.describe("画面デザイナー edit-session — multi-tab ResumeOrDiscardD
           await pageA.locator(".edit-mode-modal-backdrop").waitFor({ state: "hidden", timeout: 5000 }).catch(() => undefined);
         } else { break; }
       }
-      const canvasStartBtn = pageA.getByTestId("canvas-readonly-start");
-      await expect(canvasStartBtn).toBeVisible({ timeout: 10000 });
-      await canvasStartBtn.click();
+      const editStartBtn = pageA.getByTestId("edit-mode-start");
+      await expect(editStartBtn).toBeVisible({ timeout: 10000 });
+      await editStartBtn.click();
       await expect(pageA.getByTestId("edit-mode-save")).toBeVisible({ timeout: 5000 });
 
       // bob: 同 resource を開く → 5s 待っても ResumeOrDiscardDialog が出ないことを確認

--- a/frontend/e2e/designer-puck-multitab.spec.ts
+++ b/frontend/e2e/designer-puck-multitab.spec.ts
@@ -77,14 +77,10 @@ test.describe("Designer (Puck) multi-tab ResumeOrDiscardDialog filter (#980-A)",
       }
       // Puck editor が表示されるまで待つ → editing mode 開始
       await expect(pageA.locator("[data-testid='puck-editor-container']")).toBeVisible({ timeout: 20000 });
-      // edit-mode-start (header) または canvas-readonly-start のいずれかをクリックして editing mode へ
-      const editStartBtn = pageA.getByTestId("edit-mode-start");
-      const editStartVisible = await editStartBtn.isVisible({ timeout: 5000 }).catch(() => false);
-      if (editStartVisible) {
-        await editStartBtn.click();
-      } else {
-        await pageA.getByTestId("canvas-readonly-start").click();
-      }
+      // ツールバーの edit-mode-start をクリックして editing mode へ
+      // (#1423: canvas 中央の readonly オーバーレイは廃止済)
+      await expect(pageA.getByTestId("edit-mode-start")).toBeVisible({ timeout: 5000 });
+      await pageA.getByTestId("edit-mode-start").click();
       await expect(pageA.getByTestId("edit-mode-save")).toBeVisible({ timeout: 15000 });
 
       // bob: 同 resource を開く → Puck 経路の filter で Resume dialog 非表示

--- a/frontend/src/components/designer/GrapesEditorHost.tsx
+++ b/frontend/src/components/designer/GrapesEditorHost.tsx
@@ -135,7 +135,6 @@ export function GrapesEditorHost(props: GrapesEditorHostProps) {
     onTogglePin: props.onTogglePin,
     onClosePanel: props.onClosePanel,
     screenId: props.screenId,
-    onStartEditing: props.onStartEditing,
     onChange: props.onChange,
     onReady: props.onReady,
     onServerChanged: props.onServerChanged,

--- a/frontend/src/components/designer/PuckEditorHost.tsx
+++ b/frontend/src/components/designer/PuckEditorHost.tsx
@@ -97,7 +97,6 @@ export function PuckEditorHost(props: PuckEditorHostProps) {
     onTogglePin: props.onTogglePin,
     onClosePanel: props.onClosePanel,
     screenId: props.screenId,
-    onStartEditing: props.onStartEditing,
     onChange: props.onChange,
     onReady: props.onReady,
     reloadPayload: props.reloadPayload,

--- a/frontend/src/editor/EditorBackend.test.ts
+++ b/frontend/src/editor/EditorBackend.test.ts
@@ -51,7 +51,6 @@ const baseRenderProps: Omit<RenderEditorBaseProps, "state"> = {
   onTogglePin: () => { /* no-op */ },
   onClosePanel: () => { /* no-op */ },
   screenId: "screen-001",
-  onStartEditing: () => { /* no-op */ },
   reloadPayload: async () => null,
 };
 

--- a/frontend/src/editor/EditorBackend.ts
+++ b/frontend/src/editor/EditorBackend.ts
@@ -96,9 +96,6 @@ export interface RenderEditorBaseProps {
   /** 編集対象 screenId (RightPanel 等で利用) */
   screenId: string;
 
-  /** readonly overlay の「編集開始」ボタン用 */
-  onStartEditing: () => void;
-
   /** 編集中変更通知 — Backend は user 編集を検出したら呼ぶ */
   onChange?: (newState: EditorState) => void;
 

--- a/frontend/src/editor/GrapesJSBackend.tsx
+++ b/frontend/src/editor/GrapesJSBackend.tsx
@@ -204,7 +204,6 @@ interface GrapesJSEditorPaneProps {
 
   onTogglePin: () => void;
   onClosePanel: () => void;
-  onStartEditing: () => void;
 
   /** Backend.load() で pre-load 済みの payload。GrapesJS init 時の projectData として渡す (#815 PR-C) */
   initialPayload: unknown;
@@ -236,7 +235,6 @@ function GrapesJSEditorPane(props: GrapesJSEditorPaneProps) {
     dialogsSlot,
     onTogglePin,
     onClosePanel,
-    onStartEditing,
     initialPayload,
     reloadPayload,
     onChange,
@@ -544,20 +542,9 @@ function GrapesJSEditorPane(props: GrapesJSEditorPaneProps) {
 
           <main className="panel-canvas">
             <Canvas className="designer-canvas" />
-            {/* read-only オーバーレイ: 編集中でないときに canvas 中央に「編集開始」ボタンを表示 */}
-            {isReadonly && ready && (
-              <div className="canvas-readonly-overlay" data-testid="canvas-readonly-overlay">
-                <button
-                  type="button"
-                  className="canvas-readonly-start-btn"
-                  onClick={onStartEditing}
-                  data-testid="canvas-readonly-start"
-                >
-                  <i className="bi bi-pencil-fill" />
-                  編集開始
-                </button>
-              </div>
-            )}
+            {/* #1423: 画面デザインは画面仕様書なので readonly でもデザインを完全に閲覧できるよう、
+                canvas 中央の「編集開始」オーバーレイは廃止した。編集開始はツールバーの
+                EditModeToolbar (data-testid="edit-mode-start") から行う (Puck の UX と統一)。 */}
             {canvasEmpty && ready && !isReadonly && (
               <div className="canvas-empty-hint">
                 <i className="bi bi-grid-1x2" />
@@ -646,7 +633,6 @@ export class GrapesJSBackend implements EditorBackend<GrapesJSRenderEditorProps>
         dialogsSlot={props.dialogsSlot}
         onTogglePin={props.onTogglePin}
         onClosePanel={props.onClosePanel}
-        onStartEditing={props.onStartEditing}
         initialPayload={props.state.payload}
         reloadPayload={props.reloadPayload}
         onChange={props.onChange}

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -481,53 +481,11 @@ body[data-gjs-dragging] .panel-left-wrapper.is-autohide .panel-left {
   background-color: #ffffff !important;
 }
 
-/* ==========================================================================
-   Canvas read-only オーバーレイ (#689)
-   ========================================================================== */
-.canvas-readonly-overlay {
-  position: absolute;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.45);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 10;
-  pointer-events: auto;
-}
-
-.canvas-readonly-start-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  padding: 16px 32px;
-  font-size: 18px;
-  font-weight: 700;
-  color: #fff;
-  background: #6366f1;
-  border: none;
-  border-radius: 10px;
-  cursor: pointer;
-  box-shadow: 0 4px 20px rgba(99, 102, 241, 0.6);
-  transition: background 0.15s, box-shadow 0.15s, transform 0.1s;
-}
-.canvas-readonly-start-btn:hover {
-  background: #7c7ff1;
-  box-shadow: 0 6px 28px rgba(99, 102, 241, 0.8);
-  transform: translateY(-1px);
-}
-.canvas-readonly-start-btn:active {
-  transform: translateY(0);
-}
-.canvas-readonly-start-btn i {
-  font-size: 20px;
-}
-
-/* read-only 時はパネルを半透明・操作不可にする */
-.designer-root.is-readonly .panel-left,
-.designer-root.is-readonly .panel-right {
-  pointer-events: none;
-  opacity: 0.5;
-}
+/* #1423: 画面デザインは画面仕様書なので、readonly でもデザイン・レイヤー・トレイト
+   (項目バインディング情報) を完全に閲覧できる必要がある。旧 read-only オーバーレイ
+   (canvas 中央の「編集開始」ボタン + 暗転マスク、#689) と panel-left/right の
+   半透明・操作不可化は仕様確認の妨げになるため廃止した。編集モードへの切替は
+   ツールバーの EditModeToolbar から行う (Puck デザイナーの UX と統一)。 */
 
 /* ==========================================================================
    Right Panel — Styles / Traits / Layers


### PR DESCRIPTION
Closes #1423

## 概要

GrapesJS ベース画面デザイナーを開いた際に canvas 中央に表示されていた「編集開始」オーバーレイ（暗転マスク + 大型ボタン）を廃止し、リードオンリーをデフォルト状態にしました。

画面デザインは**画面仕様書**であり、設計書として閲覧するユースケースが最も多いため、開いた直後から全仕様を確認できるよう変更しています。

## 変更内容

### 廃止したもの
- `canvas-readonly-overlay` — canvas 全面を覆う暗転マスク
- `canvas-readonly-start-btn` — 中央に表示されていた「編集開始」ボタン
- `is-readonly` によるパネル（左ブロック / 右トレイト）の半透明・操作不可化

### 追加・変更したもの
- なし（削除のみ）

### 波及修正
- `EditorBackend.ts` / `GrapesEditorHost.tsx` / `PuckEditorHost.tsx` — 不要になった `onStartEditing` prop を除去
- E2E 2 本 — `canvas-readonly-start` → `edit-mode-start`（ツールバーボタン）に selector 変更、overlay が描画されないことを `toHaveCount(0)` で検証

## After（リードオンリー状態）

| 変更前 | 変更後 |
|--------|--------|
| 暗転マスク + 中央ボタンで canvas を覆い隠す | canvas・左パネル・右パネルが完全に見える |
| パネルが半透明で項目情報を確認しにくい | パネルが通常表示で仕様を完全閲覧可能 |
| 編集するには中央ボタンを押す必要あり | ツールバー左端「編集開始」ボタンから編集（Puck と統一） |

## 仕様逐条突合（自己申告）

| 条項 | 対応箇所 |
|------|----------|
| readonly でもデザイン確認できる | `app.css:484` — overlay / パネル dimming 削除 |
| readonly でも仕様を完全に見れる | `app.css:484` — `is-readonly .panel-left/right` 削除 |
| 編集モードへの切替は明示的操作で | `EditModeToolbar` (既存)、オーバーレイは廃止 |
| Puck の UX と統一 | Puck 側は元々オーバーレイなし、GrapesJS 側を合わせた |

## テスト

- `npm run build`（tsc）✅
- `npm run lint` ✅
- `EditorBackend.test.ts` 12件 ✅
- `e2e/designer-edit-session.spec.ts` 4件 ✅
- `e2e/designer-puck-multitab.spec.ts` 1件 ✅
- ブラウザ実機スモーク：readonly 状態でパネル完全表示・ツールバーに「編集開始」ボタン確認 ✅

🤖 Generated with [Claude Code](https://claude.ai/claude-code)