### PR TITLE
fix(dev): backend kill が orphan watcher も掃除するようにする

### DIFF
--- a/scripts/kill-ports.mjs
+++ b/scripts/kill-ports.mjs
@@ -12,6 +12,8 @@
  */
 
 import { execSync } from "node:child_process";
+import { readlinkSync } from "node:fs";
+import path from "node:path";
 
 const DEFAULT_PORTS = [5173, 5179];
 
@@ -29,19 +31,130 @@ function parsePorts() {
 }
 
 const PORTS = parsePorts();
+const selfPids = new Set([process.pid, process.ppid].filter(Boolean));
+const repoRoot = process.cwd();
+
+function execText(command) {
+  try {
+    return execSync(command, { encoding: "utf8" });
+  } catch {
+    return "";
+  }
+}
+
+function readProcessTable() {
+  return execText("ps -eo pid=,ppid=,command=")
+    .split("\n")
+    .map((line) => {
+      const match = line.trim().match(/^(\d+)\s+(\d+)\s+(.*)$/);
+      if (!match) return null;
+      return {
+        pid: Number(match[1]),
+        ppid: Number(match[2]),
+        command: match[3],
+      };
+    })
+    .filter(Boolean);
+}
+
+function cwdIsUnderRepo(pid) {
+  try {
+    const cwd = readlinkSync(`/proc/${pid}/cwd`);
+    const relative = path.relative(repoRoot, cwd);
+    return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+  } catch {
+    return false;
+  }
+}
+
+function descendantsOf(seedPids, processes) {
+  const all = new Set(seedPids);
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const proc of processes) {
+      if (!all.has(proc.pid) && all.has(proc.ppid)) {
+        all.add(proc.pid);
+        changed = true;
+      }
+    }
+  }
+  return all;
+}
+
+function collectBackendProcessPids() {
+  const processes = readProcessTable();
+  const seedPids = new Set();
+
+  for (const proc of processes) {
+    if (selfPids.has(proc.pid)) continue;
+    if (!cwdIsUnderRepo(proc.pid)) continue;
+    if (proc.command.includes("tsx watch src/index.ts") || proc.command.includes("codex app-server")) {
+      seedPids.add(proc.pid);
+    }
+  }
+
+  return [...descendantsOf(seedPids, processes)].filter((pid) => !selfPids.has(pid));
+}
+
+function collectPortPids(port) {
+  return execText(`lsof -ti:${port}`)
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((pid) => Number(pid))
+    .filter((pid) => Number.isInteger(pid) && !selfPids.has(pid));
+}
+
+function killPids(pidList, label) {
+  const unique = [...new Set(pidList)].filter(Boolean);
+  if (unique.length === 0) return false;
+
+  try {
+    execSync(`kill ${unique.join(" ")}`, { stdio: "ignore" });
+  } catch {
+    // すでに終了済みの PID が混ざることがあるため次の確認で吸収する
+  }
+
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 300);
+
+  const remaining = unique.filter((pid) => {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+
+  if (remaining.length > 0) {
+    try {
+      execSync(`kill -9 ${remaining.join(" ")}`, { stdio: "ignore" });
+    } catch {
+      // best effort
+    }
+  }
+
+  console.log(`\x1b[33m[kill-ports]\x1b[0m ${label} を終了しました (PID: ${unique.join(", ")})`);
+  return true;
+}
+
 let killed = false;
 
 for (const port of PORTS) {
-  try {
-    const pids = execSync(`lsof -ti:${port}`, { encoding: "utf8" }).trim();
-    if (pids) {
-      const pidList = pids.split("\n").filter(Boolean);
-      execSync(`kill -9 ${pidList.join(" ")}`);
-      console.log(`\x1b[33m[kill-ports]\x1b[0m Port ${port} のプロセスを終了しました (PID: ${pidList.join(", ")})`);
-      killed = true;
-    }
-  } catch {
-    // lsof が 0 件のときも非ゼロ終了するため握り潰す
+  const portPids = collectPortPids(port);
+  if (killPids(portPids, `Port ${port} のプロセス`)) {
+    killed = true;
+  }
+}
+
+// backend が TypeScript error 等で listen 前に壊れている場合、5179 は空でも
+// tsx watch / codex app-server だけが残ることがある。restart:backend が確実に
+// 復旧できるよう、backend kill 時は関連プロセスも掃除する。
+if (PORTS.includes(5179)) {
+  const backendPids = collectBackendProcessPids();
+  if (killPids(backendPids, "backend 関連プロセス")) {
+    killed = true;
   }
 }
 


### PR DESCRIPTION
## 概要

`npm run kill` / `npm run restart:backend` が port 5179 の listener だけを kill していたため、backend が TypeScript error 等で listen 前に壊れた場合や、Claude Code / E2E が別 port で backend を複数起動した場合に、`tsx watch src/index.ts` / `codex app-server` が残ることがありました。

この状態では Ctrl+C や restart が効かないように見え、次回起動時も古い watcher / Codex 子プロセスが残ります。

## 変更内容

- `kill-ports.mjs` で port PID だけでなく、backend kill 時 (`5179` を対象に含む場合) は repo 配下 cwd の以下も掃除
  - `tsx watch src/index.ts`
  - `codex app-server`
- 子孫 PID も辿って kill
- まず SIGTERM、残った場合のみ SIGKILL
- repo 配下 cwd に限定し、無関係な別ディレクトリの `codex app-server` を巻き込まないように制限

## テスト

- `node --check scripts/kill-ports.mjs`
- `node scripts/kill-ports.mjs --port 5179`

## Schema governance

- `schemas/` 変更なし