### PR TITLE
fix(workspace): show open failures in UI and logs

### DIFF
--- a/backend/src/wsBridge.ts
+++ b/backend/src/wsBridge.ts
@@ -665,6 +665,11 @@ export class WsBridge extends EventEmitter {
       }
     };
     const respondError = (error: string): void => {
+      logWarn("ws-bridge", "Browser request returned error", {
+        method,
+        clientId: clientId.substring(0, 8),
+        error,
+      });
       if (ws.readyState === WebSocket.OPEN) {
         ws.send(JSON.stringify({ type: "response", id, error }));
       }

--- a/frontend/src/components/workspace/WorkspaceListView.test.tsx
+++ b/frontend/src/components/workspace/WorkspaceListView.test.tsx
@@ -117,6 +117,17 @@ beforeEach(() => {
 });
 
 describe("WorkspaceListView navigation", () => {
+  it("shows workspace store errors after openWorkspace failure remounts the view", () => {
+    state = {
+      ...state,
+      error: "ワークスペースの harmony.json が不正です",
+    };
+
+    render(<WorkspaceListView />);
+
+    expect(screen.getByText(/harmony\.json が不正/)).toBeVisible();
+  });
+
   it("open button navigates to the opened workspace root", async () => {
     const { container } = render(<WorkspaceListView />);
 

--- a/frontend/src/components/workspace/WorkspaceListView.tsx
+++ b/frontend/src/components/workspace/WorkspaceListView.tsx
@@ -512,6 +512,7 @@ export function WorkspaceListView() {
   }, []);
 
   const { workspaces, active, lockdown } = storeState;
+  const visibleError = actionError ?? (storeState.error === "e2e bypass" ? null : storeState.error);
 
   const sortAccessor = useCallback((w: WorkspaceEntry, key: string): string | number => {
     switch (key) {
@@ -744,7 +745,7 @@ export function WorkspaceListView() {
           </div>
         </div>
 
-        {actionError && (
+        {visibleError && (
           <div style={{
             padding: "6px 12px",
             background: "var(--danger-bg, #f8d7da)",
@@ -753,7 +754,7 @@ export function WorkspaceListView() {
             marginBottom: "8px",
             fontSize: "0.85rem",
           }}>
-            <i className="bi bi-exclamation-circle" /> {actionError}
+            <i className="bi bi-exclamation-circle" /> {visibleError}
           </div>
         )}
 

--- a/frontend/src/components/workspace/WorkspaceSelectView.test.tsx
+++ b/frontend/src/components/workspace/WorkspaceSelectView.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { WorkspaceState } from "../../store/workspaceStore";
+
+const navigateMock = vi.fn();
+let state: WorkspaceState;
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => navigateMock,
+}));
+
+vi.mock("../../mcp/mcpBridge", () => ({
+  mcpBridge: {
+    startWithoutEditor: vi.fn(),
+    onStatusChange: vi.fn(() => () => {}),
+  },
+}));
+
+vi.mock("../../store/workspaceStore", async () => {
+  const actual = await vi.importActual<typeof import("../../store/workspaceStore")>("../../store/workspaceStore");
+  return {
+    ...actual,
+    getState: vi.fn(() => state),
+    subscribe: vi.fn(() => () => {}),
+    loadWorkspaces: vi.fn(() => Promise.resolve()),
+    openWorkspace: vi.fn(),
+  };
+});
+
+vi.mock("./WorkspaceListView", () => ({
+  AddWorkspaceDialog: () => null,
+}));
+
+const { WorkspaceSelectView } = await import("./WorkspaceSelectView");
+
+beforeEach(() => {
+  navigateMock.mockReset();
+  state = {
+    workspaces: [],
+    active: null,
+    lockdown: false,
+    lockdownPath: null,
+    loading: false,
+    error: null,
+  };
+});
+
+describe("WorkspaceSelectView", () => {
+  it("shows workspace store errors after openWorkspace failure remounts the view", () => {
+    state = {
+      ...state,
+      error: "ワークスペースの harmony.json が不正です",
+    };
+
+    render(<WorkspaceSelectView />);
+
+    expect(screen.getByText(/harmony\.json が不正/)).toBeVisible();
+  });
+
+  it("does not show the e2e bypass sentinel as a user-facing error", () => {
+    state = {
+      ...state,
+      error: "e2e bypass",
+    };
+
+    render(<WorkspaceSelectView />);
+
+    expect(screen.queryByText("e2e bypass")).toBeNull();
+  });
+});

--- a/frontend/src/components/workspace/WorkspaceSelectView.tsx
+++ b/frontend/src/components/workspace/WorkspaceSelectView.tsx
@@ -48,6 +48,7 @@ export function WorkspaceSelectView() {
   const { workspaces, lockdown } = state;
   const recentWorkspaces = workspaces.slice(0, 5);
   const hiddenCount = workspaces.length - 5;
+  const visibleError = actionError ?? (state.error === "e2e bypass" ? null : state.error);
 
   const handleOpenById = async (id: string) => {
     setActionError(null);
@@ -89,7 +90,7 @@ export function WorkspaceSelectView() {
           </p>
         </div>
 
-        {actionError && (
+        {visibleError && (
           <div style={{
             padding: "8px 12px",
             background: "rgba(248,113,113,0.15)",
@@ -99,7 +100,7 @@ export function WorkspaceSelectView() {
             fontSize: "0.85rem",
             marginBottom: "20px",
           }}>
-            <i className="bi bi-exclamation-circle" /> {actionError}
+            <i className="bi bi-exclamation-circle" /> {visibleError}
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- show persisted workspace store errors on the workspace select/list views so open failures remain visible after remount
- keep the existing e2e bypass sentinel hidden from user-facing error banners
- log browser RPC request errors from the WebSocket bridge, including workspace.open validation failures

## Root Cause
Selecting the recent diary workspace sends workspace.open successfully over WebSocket, but the backend rejects it because that workspace harmony.json fails the current schema validation. The frontend wrote the failure to the workspace store after AppShell had already remounted the select view, so the local actionError was lost and no banner was visible. The WebSocket bridge also returned the browser RPC error without logging it.

## Verification
- Playwright reproduction against http://127.0.0.1:5173/workspace/select confirmed the invalid diary workspace now shows the schema error on screen.
- Backend log now emits ws-bridge warn entries for workspace.open errors.
- npm --prefix frontend run test:unit -- src/components/workspace/WorkspaceSelectView.test.tsx src/components/workspace/WorkspaceListView.test.tsx
- npm --workspace=backend run build
- npm --prefix frontend run build
- git diff origin/main..HEAD -- schemas/ (no output)