### PR TITLE
fix(workspace): prune noisy recent entries

### DIFF
--- a/backend/src/handlers/workspace.ts
+++ b/backend/src/handlers/workspace.ts
@@ -25,7 +25,7 @@ import {
   LOCKDOWN_WORKSPACE_ID,
 } from "../workspaceState.js";
 import {
-  listWorkspaces,
+  listDisplayWorkspaces,
   upsertWorkspace,
   removeWorkspace,
   findById,
@@ -44,7 +44,7 @@ export const handleWorkspaceTool: ToolHandler = async (name, args, _root, sessio
       const lockdown = isLockdown();
       const { workspaces, lastActiveId } = lockdown
         ? { workspaces: [], lastActiveId: null }
-        : await listWorkspaces();
+        : await listDisplayWorkspaces();
       const activePath = getActivePath(sessionId);
       const activeEntry = activePath ? await findByPath(activePath) : null;
       const lockdownPath = getLockdownPath();

--- a/backend/src/recentStore.test.ts
+++ b/backend/src/recentStore.test.ts
@@ -23,6 +23,7 @@ const {
   findById,
   findByPath,
   listWorkspaces,
+  listDisplayWorkspaces,
   setLastActive,
   readRecent,
   _internals,
@@ -123,6 +124,47 @@ describe("recentStore", () => {
     const { workspaces, lastActiveId } = await listWorkspaces();
     expect(workspaces.length).toBe(2);
     expect(lastActiveId).toBe(e1.id);
+  });
+
+  it("listDisplayWorkspaces: 存在しない path / harmony.json 不在 entry を recent から prune する", async () => {
+    const readyDir = path.join(TMP_DIR, "ready-ws");
+    const noManifestDir = path.join(TMP_DIR, "no-manifest-ws");
+    await fs.mkdir(readyDir, { recursive: true });
+    await fs.mkdir(noManifestDir, { recursive: true });
+    await fs.writeFile(path.join(readyDir, "harmony.json"), "{}", "utf-8");
+
+    const ready = await upsertWorkspace(readyDir, "Ready");
+    const missing = await upsertWorkspace(path.join(TMP_DIR, "missing-ws"), "Missing");
+    await upsertWorkspace(noManifestDir, "NoManifest");
+    await setLastActive(missing.id);
+
+    const listed = await listDisplayWorkspaces();
+
+    expect(listed.workspaces.map((w) => w.id)).toEqual([ready.id]);
+    expect(listed.lastActiveId).toBeNull();
+    expect(listed.prunedCount).toBe(2);
+
+    const persisted = await readRecent();
+    expect(persisted.workspaces.map((w) => w.id)).toEqual([ready.id]);
+    expect(persisted.lastActiveId).toBeNull();
+  });
+
+  it("listDisplayWorkspaces: .tmp/e2e-workspaces 配下は recent に保持しつつ通常一覧から隠す", async () => {
+    const readyDir = path.join(TMP_DIR, "normal-ws");
+    const e2eDir = path.join(TMP_DIR, ".tmp", "e2e-workspaces", "w0-smoke");
+    await fs.mkdir(readyDir, { recursive: true });
+    await fs.mkdir(e2eDir, { recursive: true });
+    await fs.writeFile(path.join(readyDir, "harmony.json"), "{}", "utf-8");
+    await fs.writeFile(path.join(e2eDir, "harmony.json"), "{}", "utf-8");
+
+    const ready = await upsertWorkspace(readyDir, "Ready");
+    const e2e = await upsertWorkspace(e2eDir, "E2E");
+
+    const listed = await listDisplayWorkspaces();
+
+    expect(listed.workspaces.map((w) => w.id)).toEqual([ready.id]);
+    expect(listed.hiddenCount).toBe(1);
+    expect(await findById(e2e.id)).not.toBeNull();
   });
 
   it("recentFile() は env DESIGNER_RECENT_FILE を尊重 (現在値が TMP_FILE)", () => {

--- a/backend/src/recentStore.ts
+++ b/backend/src/recentStore.ts
@@ -200,6 +200,24 @@ export async function findByPath(workspacePath: string): Promise<WorkspaceEntry 
   return file.workspaces.find((w) => normalizePath(w.path) === norm) ?? null;
 }
 
+async function hasWorkspaceManifest(workspacePath: string): Promise<boolean> {
+  try {
+    const stat = await fs.stat(path.join(workspacePath, "harmony.json"));
+    return stat.isFile();
+  } catch {
+    return false;
+  }
+}
+
+function isE2eWorkspacePath(workspacePath: string): boolean {
+  const normalized = normalizePath(workspacePath);
+  const parts = normalized.split(path.sep);
+  for (let i = 0; i < parts.length - 1; i++) {
+    if (parts[i] === ".tmp" && parts[i + 1] === "e2e-workspaces") return true;
+  }
+  return false;
+}
+
 export async function listWorkspaces(): Promise<{
   workspaces: WorkspaceEntry[];
   lastActiveId: string | null;
@@ -208,10 +226,54 @@ export async function listWorkspaces(): Promise<{
   return { workspaces: file.workspaces, lastActiveId: file.lastActiveId };
 }
 
+export async function listDisplayWorkspaces(): Promise<{
+  workspaces: WorkspaceEntry[];
+  lastActiveId: string | null;
+  prunedCount: number;
+  hiddenCount: number;
+}> {
+  return withWriteLock(async () => {
+    const file = await readRecent();
+    const kept: WorkspaceEntry[] = [];
+    const visible: WorkspaceEntry[] = [];
+    let prunedCount = 0;
+    let hiddenCount = 0;
+
+    for (const entry of file.workspaces) {
+      if (!(await hasWorkspaceManifest(entry.path))) {
+        prunedCount += 1;
+        continue;
+      }
+      kept.push(entry);
+      if (isE2eWorkspacePath(entry.path)) {
+        hiddenCount += 1;
+        continue;
+      }
+      visible.push(entry);
+    }
+
+    let lastActiveId = file.lastActiveId;
+    if (lastActiveId && !kept.some((entry) => entry.id === lastActiveId)) {
+      lastActiveId = null;
+    }
+
+    if (prunedCount > 0 || lastActiveId !== file.lastActiveId) {
+      await writeRecent({
+        ...file,
+        workspaces: kept,
+        lastActiveId,
+      });
+    }
+
+    return { workspaces: visible, lastActiveId, prunedCount, hiddenCount };
+  });
+}
+
 /** test-only */
 export const _internals = {
   recentFile,
   recentDir,
   emptyFile,
   isRecentFile,
+  isE2eWorkspacePath,
 };

--- a/backend/src/wsHandlers/workspace.ts
+++ b/backend/src/wsHandlers/workspace.ts
@@ -19,7 +19,7 @@ import {
   workspaceContextManager,
 } from "../workspaceState.js";
 import {
-  listWorkspaces as listWorkspacesEntries,
+  listDisplayWorkspaces as listWorkspacesEntries,
   upsertWorkspace as upsertWorkspaceEntry,
   removeWorkspace as removeWorkspaceEntry,
   findById as findWorkspaceById,


### PR DESCRIPTION
## Summary
- prune missing workspace paths and entries without harmony.json when workspace.list is requested
- hide .tmp/e2e-workspaces entries from normal workspace list responses while keeping them resolvable by id/path for active test sessions
- apply the same display filtering to browser WS and MCP workspace list handlers

## Local cleanup performed
- backed up /home/node/.harmony/recent-workspaces.json to .tmp/recent-workspaces.before-prune-2026-05-29T18-51-54-043Z.json
- reduced current recent registry from 741 entries to 6 entries
- removed 729 .tmp/e2e-workspaces entries, 5 missing paths, and the workspaces/diary entry
- removed local workspaces/diary directory

## Verification
- npm --workspace=backend test -- recentStore.test.ts workspaceListActiveId.test.ts
- npm --workspace=backend run build
- git diff origin/main..HEAD -- schemas/ (no output)

Note: examples/realestate/harmony/screens/property-search.json has pre-existing local changes and is intentionally not included.