### PR TITLE
[codex] Fix GrapesJS designer scroll viewport sizing

### DIFF
--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -18,16 +18,16 @@
 }
 
 .designer-root {
-  height: 100vh;
-  width: 100vw;
+  height: 100%;
+  width: 100%;
   overflow: hidden;
 }
 
 .designer-layout {
   display: flex;
   flex-direction: column;
-  height: 100vh;
-  width: 100vw;
+  height: 100%;
+  width: 100%;
   background-color: var(--dz-bg);
   color: var(--dz-text);
 }


### PR DESCRIPTION
## Summary

Fixes #1431.

GrapesJS Designer was sizing its inner root/layout to the full browser viewport (`100vh` / `100vw`) even when rendered inside a design tab whose host is already reduced by the common header and tab bar. That made the canvas iframe extend below the visible tab area, which could make manual wheel/touchpad scrolling stop before the apparent bottom while automation could still drive the iframe document directly.

This PR changes the Designer root and layout to fill their parent tab host instead of the full viewport.

## Changes

- Change `.designer-root` from `100vh/100vw` to `100%/100%`
- Change `.designer-layout` from `100vh/100vw` to `100%/100%`

## Validation

- Isolated worktree investigation with frontend `5183` and backend `5189`
- Diagnostic tall GrapesJS design confirmed iframe no longer extends below the tab host:
  - before: tab host `696px`, `.designer-layout` `768px`, iframe bottom `824px`
  - after: tab host `696px`, `.designer-layout` `696px`, iframe bottom `752px`
- `npm run build --workspace=frontend`
