### PR TITLE
[codex] Bound non-design routes to tab viewport

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1039,22 +1039,30 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
           子 Route は外側 AppShell の <Route path="/w/:wsId"> の children として
           宣言されている。 */}
       {!activeIsDesign && (
-        <ErrorBoundary
-          resetKey={activeTabId}
-          context={{ tabId: activeTabId, type: activeTab?.type, pathname: location.pathname }}
-          fallback={(error, reset) => (
-            <TabErrorFallback
-              error={error}
-              tabLabel={activeTab?.label ?? "コンテンツ"}
-              onRetry={reset}
-              onClose={() => {
-                if (activeTabId) handleCloseCrashedTab(activeTabId);
-              }}
-            />
-          )}
+        <div
+          style={{
+            height: "calc(100vh - var(--common-header-h, 0px) - var(--tabbar-h, 0px))",
+            minHeight: 0,
+            overflow: "hidden",
+          }}
         >
-          <Outlet />
-        </ErrorBoundary>
+          <ErrorBoundary
+            resetKey={activeTabId}
+            context={{ tabId: activeTabId, type: activeTab?.type, pathname: location.pathname }}
+            fallback={(error, reset) => (
+              <TabErrorFallback
+                error={error}
+                tabLabel={activeTab?.label ?? "コンテンツ"}
+                onRetry={reset}
+                onClose={() => {
+                  if (activeTabId) handleCloseCrashedTab(activeTabId);
+                }}
+              />
+            )}
+          >
+            <Outlet />
+          </ErrorBoundary>
+        </div>
       )}
     </>
   );


### PR DESCRIPTION
## Summary

Follow-up to #1432 / #1433.

The design tab viewport was fixed, but non-design workspace routes still rendered `<Outlet />` without a shared height boundary. Screens that rely on `height: 100%` or have content taller than the viewport could stretch `document.body` while the app body is globally `overflow: hidden`, causing the lower part of the screen to be clipped.

This PR wraps non-design route content in the same tab viewport height used by design tabs.

## Root Cause

`AppShell` gave design tabs an explicit:

```css
calc(100vh - var(--common-header-h) - var(--tabbar-h))
```

but non-design `<Outlet />` content had no equivalent parent height. Components were therefore split between:

- self-bounded routes using their own `calc(100vh - header - tabbar)`
- routes using `height: 100%` and depending on a parent that did not exist
- routes that stretched `body` beyond the viewport

Because `body` is `overflow: hidden`, the stretched document content could be visually clipped.

## Investigation

Measured 26 workspace routes in a retail example workspace at `1366x768`.

Before this PR, 9 routes had `BODY_CLIPPED`:

- `/sequence/edit/order-number-sequence`
- `/view/edit/order-with-customer-view`
- `/view-definition/edit/order-list-viewer`
- `/page-layout/edit/main-layout`
- `/page-layout/design/main-layout`
- `/generic-definition`
- `/generic-definition/data-contract`
- `/generic-definition/data-contract/OrderForm`
- `/project/tech-stack`

After this PR, the same audit reports `fails=0`.

## Changes

- Add a non-design route viewport wrapper around `<Outlet />`.
- Use the same `calc(100vh - header - tabbar)` height as design tabs.
- Keep `overflow: hidden` at the wrapper so each screen must scroll internally instead of stretching `body`.

## Validation

- Browser geometry audit before/after on 26 workspace routes
- `npm run build --workspace=frontend`
