### PR TITLE
feat(designer): add gadget palette blocks

### DIFF
--- a/frontend/src/components/BlocksPanel.tsx
+++ b/frontend/src/components/BlocksPanel.tsx
@@ -4,6 +4,7 @@ import type { BlocksResultProps } from "@grapesjs/react";
 import { useEditorMaybe } from "@grapesjs/react";
 import type { Block } from "grapesjs";
 import { CUSTOM_BLOCK_CATEGORY } from "./design/DesignSubToolbar";
+import { GADGET_BLOCK_CATEGORY } from "../grapes/blocks";
 import { deleteCustomBlock } from "../store/customBlockStore";
 import { SharedBlockSyncModal } from "./SharedBlockSyncModal";
 
@@ -85,6 +86,7 @@ export function BlocksPanel({ mapCategoryBlocks, dragStart, dragStop }: BlocksRe
         {filtered.map(([cat, blocks]) => {
           const isCollapsed = query.trim() ? false : !!collapsed[cat];
           const isCustomCategory = cat === CUSTOM_BLOCK_CATEGORY;
+          const isGadgetCategory = cat === GADGET_BLOCK_CATEGORY;
           return (
             <section key={cat} className="blocks-category">
               <header
@@ -104,7 +106,7 @@ export function BlocksPanel({ mapCategoryBlocks, dragStart, dragStop }: BlocksRe
                     return (
                       <div
                         key={block.getId()}
-                        className={`block-item${isCustomCategory ? " custom-block" : ""}${isShared ? " shared-block" : ""}`}
+                        className={`block-item${isCustomCategory ? " custom-block" : ""}${isGadgetCategory ? " gadget-block" : ""}${isShared ? " shared-block" : ""}`}
                         draggable
                         onDragStart={(ev) => dragStart(block, ev.nativeEvent)}
                         onDragEnd={() => dragStop(false)}

--- a/frontend/src/components/Designer.tsx
+++ b/frontend/src/components/Designer.tsx
@@ -25,6 +25,7 @@ import { DESIGNER_REFERENCE_RELOAD_EVENTS, isReloadBroadcast, shouldNotifyScreen
 // react-hooks/refs (Designer scope 内 ref 含む closure が props 経由で渡される) を解消。
 import { PuckEditorHost } from "./designer/PuckEditorHost";
 import { GrapesEditorHost } from "./designer/GrapesEditorHost";
+import type { GadgetBlockScreen } from "../grapes/blocks";
 // #1388 sub-section A (Option 2): 共通ダイアログ群 (~145 行 JSX) を独立 component に抽出。
 import { DesignerDialogs } from "./designer/DesignerDialogs";
 import {
@@ -168,14 +169,40 @@ export function Designer({
   // Phase M Codex SF-1 (#1298 round 8): wsId scoped key で workspace 切替時の metadata 混在を防ぐ
   const [renameUndoToast, setRenameUndoToast] = useRenameEntityUndoToast("screen", screenId, wsId);
   const [allScreenIds, setAllScreenIds] = useState<string[]>([]);
+  const [gadgetBlocks, setGadgetBlocks] = useState<GadgetBlockScreen[]>([]);
+  const reloadDesignerProjectMetadata = useCallback(async () => {
+    const project = await loadProject();
+    setAllScreenIds((project.screens ?? []).map((s) => s.id));
+    setGadgetBlocks(
+      (project.screens ?? [])
+        .filter((s) => s.purpose === "gadget")
+        .map((s) => ({ id: s.id, name: s.name || s.id })),
+    );
+  }, []);
   useEffect(() => {
-    (async () => {
-      try {
-        const project = await loadProject();
-        setAllScreenIds((project.screens ?? []).map((s) => s.id));
-      } catch { /* backend 未接続時は空配列のまま */ }
-    })();
-  }, [screenId]);
+    let cancelled = false;
+    void Promise.resolve()
+      .then(() => reloadDesignerProjectMetadata())
+      .catch(() => {
+        if (!cancelled) {
+          setAllScreenIds([]);
+          setGadgetBlocks([]);
+        }
+      });
+    const unsubStatus = mcpBridge.onStatusChange((status) => {
+      if (status === "connected" && !cancelled) {
+        reloadDesignerProjectMetadata().catch(console.error);
+      }
+    });
+    const unsubProject = mcpBridge.onBroadcast("projectChanged", () => {
+      if (!cancelled) reloadDesignerProjectMetadata().catch(console.error);
+    });
+    return () => {
+      cancelled = true;
+      unsubStatus();
+      unsubProject();
+    };
+  }, [reloadDesignerProjectMetadata]);
   // localStorage 救済確認ダイアログ
   const [showLegacyRescueDialog, setShowLegacyRescueDialog] = useState(false);
   const legacyDataRef = useRef<unknown>(null);
@@ -1020,6 +1047,7 @@ export function Designer({
       reloadPayload={grapesReloadPayload}
       dialogsSlot={commonDialogs}
       mismatchWarnings={mismatchWarnings}
+      gadgetBlocks={gadgetBlocks}
       pageLayoutId={pageLayoutId}
       pageLayoutName={pageLayoutName}
       pageLayoutHtml={pageLayoutHtml}

--- a/frontend/src/components/designer/GrapesEditorHost.tsx
+++ b/frontend/src/components/designer/GrapesEditorHost.tsx
@@ -18,6 +18,7 @@ import type {
 import type { McpStatus } from "../../mcp/mcpBridge";
 import type { CssFramework } from "../../types/v3/harmony";
 import type { EditMode } from "../../hooks/useEditSession";
+import type { GadgetBlockScreen } from "../../grapes/blocks";
 import {
   composePreviewHtml,
   buildCompositionPreviewSrcDoc,
@@ -79,6 +80,7 @@ export interface GrapesEditorHostProps {
   pageLayoutCss?: string;
   gadgetCssMap?: Map<string, string>;
   onGrapesEditorReady?: (editor: import("grapesjs").Editor) => void;
+  gadgetBlocks?: GadgetBlockScreen[];
 }
 
 export function GrapesEditorHost(props: GrapesEditorHostProps) {
@@ -141,6 +143,7 @@ export function GrapesEditorHost(props: GrapesEditorHostProps) {
     onMcpStatusChange: props.onMcpStatusChange,
     onExternalThemeChange: props.onExternalThemeChange,
     reloadPayload: props.reloadPayload,
+    gadgetBlocks: props.gadgetBlocks,
     onGrapesEditorInstance: handleGrapesEditorInstance,
   };
 

--- a/frontend/src/editor/EditorBackend.ts
+++ b/frontend/src/editor/EditorBackend.ts
@@ -13,6 +13,7 @@
 import type { ReactNode } from "react";
 import type { CssFramework } from "../types/v3/harmony";
 import type { McpStatus } from "../mcp/mcpBridge";
+import type { GadgetBlockScreen } from "../grapes/blocks";
 
 export type ThemeId = "standard" | "card" | "compact" | "dark";
 export type PanelMode = "pinned" | "autohide" | "hidden";
@@ -127,6 +128,8 @@ export interface GrapesJSRenderEditorProps extends RenderEditorBaseProps {
   onServerChanged: () => void;
   onMcpStatusChange: (status: McpStatus) => void;
   onExternalThemeChange: (themeId: ThemeId) => void;
+  /** purpose="gadget" の Screen を block palette に参照型 block として登録する */
+  gadgetBlocks?: GadgetBlockScreen[];
   /** raw GrapesJS Editor インスタンスを受け取る (pl-5 #1026、optional) */
   onGrapesEditorInstance?: (editor: import("grapesjs").Editor) => void;
 }

--- a/frontend/src/editor/GrapesJSBackend.tsx
+++ b/frontend/src/editor/GrapesJSBackend.tsx
@@ -44,7 +44,8 @@ import type {
   ThemeId,
 } from "./EditorBackend";
 import type { CssFramework } from "../types/v3/harmony";
-import { registerBlocks } from "../grapes/blocks";
+import { registerBlocks, registerGadgetBlocks } from "../grapes/blocks";
+import { syncGadgetInstancePreviews } from "../grapes/gadgetInstancePreview";
 import { registerValidationTraits } from "../grapes/validationTraits";
 import { attachDataItemIdAutoAssign } from "../grapes/dataItemId";
 import { attachScreenItemsSync, reconcileScreenItems } from "../grapes/screenItemsSync";
@@ -123,6 +124,77 @@ body::after {
   display: block;
   height: 32px;
   flex: 0 0 32px;
+}
+`;
+    canvasDoc.head.appendChild(style);
+  } catch {
+    // canvas not ready
+  }
+}
+
+function injectGadgetInstanceCss(editor: GEditor) {
+  try {
+    const canvasDoc = editor.Canvas.getDocument();
+    if (!canvasDoc) return;
+    if (canvasDoc.getElementById("harmony-gadget-instance-css")) return;
+
+    const style = canvasDoc.createElement("style");
+    style.id = "harmony-gadget-instance-css";
+    style.textContent = `
+.harmony-gadget-instance {
+  position: relative;
+  min-height: 88px;
+  padding: 30px 14px 14px;
+  border: 2px dashed #0f766e;
+  background: rgba(20, 184, 166, 0.08);
+  color: #0f172a;
+  box-sizing: border-box;
+}
+.harmony-gadget-instance.gjs-selected {
+  border-style: solid;
+  box-shadow: 0 0 0 3px rgba(20, 184, 166, 0.18);
+}
+.harmony-gadget-instance::after {
+  content: "read-only gadget preview";
+  position: absolute;
+  top: 6px;
+  right: 8px;
+  color: #0f766e;
+  font: 600 10px/1 system-ui, sans-serif;
+}
+.harmony-gadget-instance__badge {
+  position: absolute;
+  top: 6px;
+  left: 8px;
+  display: inline-flex;
+  align-items: center;
+  height: 18px;
+  padding: 0 7px;
+  border-radius: 4px;
+  background: #0f766e;
+  color: #fff;
+  font: 700 11px/1 system-ui, sans-serif;
+}
+.harmony-gadget-instance__title {
+  font: 700 14px/1.4 system-ui, sans-serif;
+}
+.harmony-gadget-instance__id {
+  margin-top: 4px;
+  color: #475569;
+  font: 12px/1.4 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+.harmony-gadget-instance__preview {
+  margin-top: 12px;
+  padding: 10px;
+  border: 1px solid rgba(15, 118, 110, 0.22);
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.72);
+  pointer-events: none;
+  user-select: none;
+}
+.harmony-gadget-instance__preview.is-empty {
+  color: #64748b;
+  font: 12px/1.4 system-ui, sans-serif;
 }
 `;
     canvasDoc.head.appendChild(style);
@@ -251,6 +323,8 @@ interface GrapesJSEditorPaneProps {
   onExternalThemeChange?: (themeId: ThemeId) => void;
   /** raw GrapesJS Editor インスタンスを受け取る (pl-5 #1026、optional) */
   onGrapesEditorInstance?: (editor: GEditor) => void;
+  /** purpose="gadget" の Screen を block palette に登録するための metadata */
+  gadgetBlocks?: GrapesJSRenderEditorProps["gadgetBlocks"];
 }
 
 function GrapesJSEditorPane(props: GrapesJSEditorPaneProps) {
@@ -272,15 +346,20 @@ function GrapesJSEditorPane(props: GrapesJSEditorPaneProps) {
     onMcpStatusChange,
     onExternalThemeChange,
     onGrapesEditorInstance,
+    gadgetBlocks = [],
   } = props;
 
   const editorRef = useRef<GEditor | null>(null);
+  const gadgetBlocksRef = useRef(gadgetBlocks);
   // 初期 load 中および discard 中は markDirty を抑制 (component:* 内部発火を user 編集と区別)
   const isInternalLoadRef = useRef(true);
   const isReadonlyRef = useRef(isReadonly);
   useEffect(() => {
     isReadonlyRef.current = isReadonly;
   }, [isReadonly]);
+  useEffect(() => {
+    gadgetBlocksRef.current = gadgetBlocks;
+  }, [gadgetBlocks]);
 
   // canvas 状態
   const [ready, setReady] = useState(false);
@@ -359,6 +438,16 @@ function GrapesJSEditorPane(props: GrapesJSEditorPaneProps) {
       };
       editor.on("component:add component:remove component:update style:change", markDirty);
 
+      let previewTimer: ReturnType<typeof setTimeout> | null = null;
+      const scheduleGadgetPreviewSync = () => {
+        if (previewTimer) clearTimeout(previewTimer);
+        previewTimer = setTimeout(() => {
+          previewTimer = null;
+          syncGadgetInstancePreviews(editor, gadgetBlocksRef.current).catch(console.error);
+        }, 50);
+      };
+      editor.on("component:add component:update", scheduleGadgetPreviewSync);
+
       // #322: input/select/textarea ブロック drop 時に data-item-id を自動発番
       const unsubDataItemId = attachDataItemIdAutoAssign(editor);
 
@@ -384,19 +473,26 @@ function GrapesJSEditorPane(props: GrapesJSEditorPaneProps) {
       // - `oldId === screenId` → 自身が rename された場合
       // - 通常の screenChanged → 旧 filter 条件
       const unsubScreenChanged = mcpBridge.onBroadcast("screenChanged", (data) => {
-        if (!shouldNotifyScreenChanged(data, screenId)) return;
-        onServerChangedRef.current?.();
+        if (shouldNotifyScreenChanged(data, screenId)) {
+          onServerChangedRef.current?.();
+          return;
+        }
+        scheduleGadgetPreviewSync();
       });
+      const unsubProjectChanged = mcpBridge.onBroadcast("projectChanged", scheduleGadgetPreviewSync);
 
       return () => {
         unmounted = true;
+        if (previewTimer) clearTimeout(previewTimer);
         editor.off("component:add component:remove component:update style:change", markDirty);
+        editor.off("component:add component:update", scheduleGadgetPreviewSync);
         editor.off("block:drag:start", handleDragStart);
         editor.off("block:drag:stop", handleDragStop);
         unsubDataItemId();
         unsubScreenItemsSync();
         unsubStatus();
         unsubScreenChanged();
+        unsubProjectChanged();
         mcpBridge.setThemeHandler(null);
         mcpBridge.setCurrentScreenId(null);
         clearItemsFromCache(screenId);
@@ -404,6 +500,12 @@ function GrapesJSEditorPane(props: GrapesJSEditorPaneProps) {
     },
     [screenId],
   );
+
+  useEffect(() => {
+    if (!ready || !editorRef.current) return;
+    registerGadgetBlocks(editorRef.current, gadgetBlocks, screenId);
+    syncGadgetInstancePreviews(editorRef.current, gadgetBlocks).catch(console.error);
+  }, [ready, gadgetBlocks, screenId]);
 
   /** GrapesJS init 完了時 — initialPayload を loadProjectData で適用 / theme 適用 /
    * カスタムブロック CSS 注入 / EditorApi expose。
@@ -433,6 +535,7 @@ function GrapesJSEditorPane(props: GrapesJSEditorPaneProps) {
       // framework × variant の 2 軸 CSS を注入 (#793 子 5)
       applyThemeToCanvas(editorRef.current, themeVariantRef.current, cssFrameworkRef.current);
       injectDesignerCanvasScrollPadding(editorRef.current);
+      injectGadgetInstanceCss(editorRef.current);
       // カスタムブロック CSS をキャンバスに注入 (await の間に unmount された場合は editor を触らない)
       try {
         const customBlocks = await loadCustomBlocks();
@@ -464,6 +567,7 @@ function GrapesJSEditorPane(props: GrapesJSEditorPaneProps) {
             );
             editor.loadProjectData(safePayload);
             editor.UndoManager.clear();
+            await syncGadgetInstancePreviews(editor, gadgetBlocksRef.current);
           } finally {
             setTimeout(() => {
               isInternalLoadRef.current = false;
@@ -486,6 +590,7 @@ function GrapesJSEditorPane(props: GrapesJSEditorPaneProps) {
               "external-set",
             );
             editor.loadProjectData(safePayload);
+            syncGadgetInstancePreviews(editor, gadgetBlocksRef.current).catch(console.error);
           } finally {
             setTimeout(() => {
               isInternalLoadRef.current = false;
@@ -670,6 +775,7 @@ export class GrapesJSBackend implements EditorBackend<GrapesJSRenderEditorProps>
         onServerChanged={props.onServerChanged}
         onMcpStatusChange={props.onMcpStatusChange}
         onExternalThemeChange={props.onExternalThemeChange}
+        gadgetBlocks={props.gadgetBlocks}
         onGrapesEditorInstance={props.onGrapesEditorInstance}
       />
     );

--- a/frontend/src/grapes/blocks.test.ts
+++ b/frontend/src/grapes/blocks.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Editor } from "grapesjs";
+import {
+  GADGET_BLOCK_CATEGORY,
+  __testExports,
+  registerGadgetBlocks,
+} from "./blocks";
+
+function makeEditor(existingIds: string[] = []) {
+  const add = vi.fn();
+  const remove = vi.fn((id: string) => {
+    existingIds = existingIds.filter((existingId) => existingId !== id);
+  });
+  const get = vi.fn((id: string) => (
+    existingIds.includes(id) ? { getId: () => id } : undefined
+  ));
+  const getAll = vi.fn(() => existingIds.map((id) => ({ getId: () => id })));
+  const editor = {
+    BlockManager: { add, remove, get, getAll },
+  } as unknown as Editor;
+  return { editor, add, remove, get, getAll };
+}
+
+describe("gadget blocks", () => {
+  it("builds a reference placeholder instead of embedding gadget HTML", () => {
+    const content = __testExports.buildGadgetBlockContent({
+      id: "notice-gadget",
+      name: "Notice <Gadget>",
+    });
+
+    expect(content).toContain('data-harmony-component="gadget-instance"');
+    expect(content).toContain('data-gadget-screen-id="notice-gadget"');
+    expect(content).toContain("Notice &lt;Gadget&gt;");
+    expect(content).toContain("Gadget");
+    expect(content).not.toContain("<script");
+  });
+
+  it("registers purpose=gadget screens as palette blocks and excludes the current screen", () => {
+    const { editor, add, remove } = makeEditor();
+
+    registerGadgetBlocks(
+      editor,
+      [
+        { id: "current-gadget", name: "Current" },
+        { id: "message-area", name: "Message Area" },
+      ],
+      "current-gadget",
+    );
+
+    expect(add).toHaveBeenCalledTimes(1);
+    expect(remove).not.toHaveBeenCalled();
+    expect(add).toHaveBeenCalledWith(
+      "gadget:message-area",
+      expect.objectContaining({
+        label: "Message Area",
+        category: GADGET_BLOCK_CATEGORY,
+        content: expect.stringContaining('data-gadget-screen-id="message-area"'),
+      }),
+    );
+  });
+
+  it("removes stale gadget blocks during the second sync", () => {
+    const { editor, add, remove } = makeEditor(["gadget:old-message", "field-text"]);
+
+    registerGadgetBlocks(
+      editor,
+      [{ id: "message-area", name: "Message Area" }],
+      "page-a",
+    );
+
+    expect(remove).toHaveBeenCalledWith("gadget:old-message");
+    expect(remove).not.toHaveBeenCalledWith("field-text");
+    expect(add).toHaveBeenCalledWith(
+      "gadget:message-area",
+      expect.objectContaining({ label: "Message Area" }),
+    );
+  });
+
+  it("removes an existing gadget block when it becomes the current screen", () => {
+    const { editor, add, remove } = makeEditor(["gadget:message-area"]);
+
+    registerGadgetBlocks(
+      editor,
+      [{ id: "message-area", name: "Message Area" }],
+      "message-area",
+    );
+
+    expect(remove).toHaveBeenCalledWith("gadget:message-area");
+    expect(add).not.toHaveBeenCalled();
+  });
+
+  it("refreshes label and content for existing gadget blocks", () => {
+    const { editor, add, remove } = makeEditor(["gadget:message-area"]);
+
+    registerGadgetBlocks(
+      editor,
+      [{ id: "message-area", name: "Renamed Gadget" }],
+      "page-a",
+    );
+
+    expect(remove).toHaveBeenCalledWith("gadget:message-area");
+    expect(add).toHaveBeenCalledWith(
+      "gadget:message-area",
+      expect.objectContaining({
+        label: "Renamed Gadget",
+        content: expect.stringContaining('data-gadget-screen-name="Renamed Gadget"'),
+      }),
+    );
+  });
+});

--- a/frontend/src/grapes/blocks.ts
+++ b/frontend/src/grapes/blocks.ts
@@ -1,4 +1,4 @@
-import type { Editor, BlockProperties } from "grapesjs";
+import type { Editor, Block, BlockProperties } from "grapesjs";
 
 /* ==========================================================================
    ブロックカタログ — 業務システム向け標準部品 (semantic class 版 #793)
@@ -14,6 +14,13 @@ const CAT_FIELD  = "フィールド";
 const CAT_LIST   = "検索・一覧";
 const CAT_COMMON = "共通パーツ";
 const CAT_REGIONS = "Layout Regions";
+export const GADGET_BLOCK_CATEGORY = "ガジェット";
+const GADGET_BLOCK_ID_PREFIX = "gadget:";
+
+export interface GadgetBlockScreen {
+  id: string;
+  name: string;
+}
 
 // ---- HTML テンプレートヘルパ ----
 // form-field / field-label / field-value は common.css 独自 semantic class
@@ -50,6 +57,32 @@ const selectInput = () => `
 // ---- アイコン（Bootstrap Icons） ----
 const icon = (name: string) =>
   `<i class="bi bi-${name}" style="font-size:20px"></i>`;
+
+const escapeHtml = (value: string) =>
+  value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+
+const buildGadgetBlockContent = (gadget: GadgetBlockScreen) => {
+  const id = escapeHtml(gadget.id);
+  const name = escapeHtml(gadget.name || gadget.id);
+  return `
+    <div
+      class="harmony-gadget-instance"
+      data-harmony-component="gadget-instance"
+      data-gadget-screen-id="${id}"
+      data-gadget-screen-name="${name}"
+      contenteditable="false"
+    >
+      <div class="harmony-gadget-instance__badge">Gadget</div>
+      <div class="harmony-gadget-instance__title">${name}</div>
+      <div class="harmony-gadget-instance__id">${id}</div>
+    </div>
+  `.trim();
+};
 
 // ---- ブロック定義 ----
 export const appBlocks: (BlockProperties & { id: string })[] = [
@@ -409,3 +442,39 @@ export function registerBlocks(editor: Editor) {
   const bm = editor.BlockManager;
   appBlocks.forEach(({ id, ...props }) => bm.add(id, props));
 }
+
+export function registerGadgetBlocks(
+  editor: Editor,
+  gadgets: GadgetBlockScreen[],
+  currentScreenId: string,
+) {
+  const bm = editor.BlockManager;
+  const nextGadgets = gadgets
+    .filter((gadget) => gadget.id && gadget.id !== currentScreenId)
+    .map((gadget) => ({ ...gadget, blockId: `${GADGET_BLOCK_ID_PREFIX}${gadget.id}` }));
+  const nextBlockIds = new Set(nextGadgets.map((gadget) => gadget.blockId));
+
+  const existingBlocks = bm.getAll();
+  existingBlocks.forEach((block: Block) => {
+    const id = block.getId();
+    if (id.startsWith(GADGET_BLOCK_ID_PREFIX) && !nextBlockIds.has(id)) {
+      bm.remove(id);
+    }
+  });
+
+  nextGadgets.forEach((gadget) => {
+    if (bm.get(gadget.blockId)) {
+      bm.remove(gadget.blockId);
+    }
+    bm.add(gadget.blockId, {
+      label: gadget.name || gadget.id,
+      category: GADGET_BLOCK_CATEGORY,
+      media: icon("puzzle-fill"),
+      content: buildGadgetBlockContent(gadget),
+    });
+  });
+}
+
+export const __testExports = {
+  buildGadgetBlockContent,
+};

--- a/frontend/src/grapes/gadgetInstancePreview.test.ts
+++ b/frontend/src/grapes/gadgetInstancePreview.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Editor } from "grapesjs";
+import { scopeGadgetPreviewCss, syncGadgetInstancePreviews } from "./gadgetInstancePreview";
+import { mcpBridge } from "../mcp/mcpBridge";
+
+vi.mock("../mcp/mcpBridge", () => ({
+  mcpBridge: {
+    request: vi.fn(),
+  },
+}));
+
+function makeEditor(html: string) {
+  document.body.innerHTML = html;
+  return {
+    Canvas: {
+      getDocument: () => document,
+    },
+  } as unknown as Editor;
+}
+
+describe("syncGadgetInstancePreviews", () => {
+  beforeEach(() => {
+    vi.mocked(mcpBridge.request).mockReset();
+  });
+
+  it("expands placed gadget references with the referenced gadget design HTML", async () => {
+    vi.mocked(mcpBridge.request).mockResolvedValue({
+      pages: [{ frames: [{ component: { components: '<section class="message-card"><strong>Gadget Body</strong></section>' } }] }],
+      styles: [
+        { selectors: [{ name: "message-card", type: 1 }], style: { color: "red", "font-weight": "700" } },
+      ],
+    });
+    const editor = makeEditor(`
+      <section class="message-card">Consuming screen body</section>
+      <div
+        class="harmony-gadget-instance"
+        data-harmony-component="gadget-instance"
+        data-gadget-screen-id="message-area"
+        data-gadget-screen-name="Old Name"
+      >
+        <div class="harmony-gadget-instance__title">Old Name</div>
+        <div class="harmony-gadget-instance__id">message-area</div>
+      </div>
+    `);
+
+    await syncGadgetInstancePreviews(editor, [{ id: "message-area", name: "Message Area" }]);
+
+    expect(mcpBridge.request).toHaveBeenCalledWith("loadScreen", { screenId: "message-area" });
+    expect(document.querySelector(".harmony-gadget-instance__title")?.textContent).toBe("Message Area");
+    expect(document.querySelector("[data-harmony-gadget-preview]")?.innerHTML).toContain("Gadget Body");
+    const css = document.querySelector("[data-harmony-gadget-preview-css]")?.textContent ?? "";
+    expect(css).toContain('[data-harmony-gadget-preview-scope="gadget-0"] .message-card{');
+    expect(css).not.toMatch(/(^|})\.message-card\{/);
+    expect(css).toContain("color:red;");
+    expect(document.querySelector(".harmony-gadget-instance")?.getAttribute("data-gadget-screen-name")).toBe("Message Area");
+  });
+
+  it("replaces stale previews instead of nesting duplicate copies", async () => {
+    vi.mocked(mcpBridge.request).mockResolvedValue({
+      pages: [{ frames: [{ component: { components: "<section>Fresh</section>" } }] }],
+    });
+    const editor = makeEditor(`
+      <div
+        class="harmony-gadget-instance"
+        data-harmony-component="gadget-instance"
+        data-gadget-screen-id="message-area"
+      >
+        <style data-harmony-gadget-preview-css="true">.old{color:gray;}</style>
+        <div data-harmony-gadget-preview="true">Stale</div>
+      </div>
+    `);
+
+    await syncGadgetInstancePreviews(editor, [{ id: "message-area", name: "Message Area" }]);
+
+    expect(document.querySelectorAll("[data-harmony-gadget-preview]")).toHaveLength(1);
+    expect(document.querySelectorAll("[data-harmony-gadget-preview-css]")).toHaveLength(0);
+    expect(document.querySelector("[data-harmony-gadget-preview]")?.textContent).toBe("Fresh");
+  });
+
+  it("shows a missing-design placeholder when the referenced gadget cannot be loaded", async () => {
+    vi.mocked(mcpBridge.request).mockRejectedValue(new Error("missing"));
+    const editor = makeEditor(`
+      <div
+        class="harmony-gadget-instance"
+        data-harmony-component="gadget-instance"
+        data-gadget-screen-id="missing-gadget"
+      ></div>
+    `);
+
+    await syncGadgetInstancePreviews(editor, [{ id: "missing-gadget", name: "Missing Gadget" }]);
+
+    const preview = document.querySelector("[data-harmony-gadget-preview]");
+    expect(preview?.textContent).toBe("Gadget design が見つかりません");
+    expect(preview?.classList.contains("is-empty")).toBe(true);
+  });
+
+  it("scopes gadget CSS inside media rules as well", () => {
+    const scoped = scopeGadgetPreviewCss(
+      ".message-card{color:red;}\n@media (max-width: 600px){.message-card{display:block;}}",
+      '[data-harmony-gadget-preview-scope="gadget-0"]',
+    );
+
+    expect(scoped).toContain('[data-harmony-gadget-preview-scope="gadget-0"] .message-card{color:red;}');
+    expect(scoped).toContain('@media (max-width: 600px){[data-harmony-gadget-preview-scope="gadget-0"] .message-card{display:block;}}');
+    expect(scoped).not.toMatch(/(^|})\.message-card\{/);
+  });
+});

--- a/frontend/src/grapes/gadgetInstancePreview.ts
+++ b/frontend/src/grapes/gadgetInstancePreview.ts
@@ -1,0 +1,136 @@
+import type { Editor as GEditor } from "grapesjs";
+import DOMPurify from "dompurify";
+import { mcpBridge } from "../mcp/mcpBridge";
+import { extractGrapesCss, extractGrapesHtml } from "../utils/pageLayoutCompositionPreview";
+import type { GadgetBlockScreen } from "./blocks";
+
+const GADGET_INSTANCE_SELECTOR = '[data-harmony-component="gadget-instance"][data-gadget-screen-id]';
+const PREVIEW_ATTR = "data-harmony-gadget-preview";
+const PREVIEW_CSS_ATTR = "data-harmony-gadget-preview-css";
+const PREVIEW_SCOPE_ATTR = "data-harmony-gadget-preview-scope";
+
+interface GadgetPreviewPayload {
+  html: string | null;
+  css: string;
+}
+
+function findMatchingBrace(css: string, openIndex: number): number {
+  let depth = 0;
+  for (let i = openIndex; i < css.length; i += 1) {
+    if (css[i] === "{") depth += 1;
+    if (css[i] === "}") {
+      depth -= 1;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+function prefixSelectorList(selector: string, scopeSelector: string): string {
+  return selector
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .map((part) => {
+      if (part === ":root" || part === "html" || part === "body") return scopeSelector;
+      return `${scopeSelector} ${part}`;
+    })
+    .join(",");
+}
+
+export function scopeGadgetPreviewCss(css: string, scopeSelector: string): string {
+  let output = "";
+  let cursor = 0;
+
+  while (cursor < css.length) {
+    const open = css.indexOf("{", cursor);
+    if (open === -1) {
+      output += css.slice(cursor);
+      break;
+    }
+
+    const selector = css.slice(cursor, open).trim();
+    const close = findMatchingBrace(css, open);
+    if (close === -1) {
+      output += css.slice(cursor);
+      break;
+    }
+
+    const body = css.slice(open + 1, close);
+    if (selector.startsWith("@media") || selector.startsWith("@supports") || selector.startsWith("@container")) {
+      output += `${selector}{${scopeGadgetPreviewCss(body, scopeSelector)}}`;
+    } else if (selector.startsWith("@")) {
+      output += `${selector}{${body}}`;
+    } else if (selector) {
+      output += `${prefixSelectorList(selector, scopeSelector)}{${body}}`;
+    }
+    cursor = close + 1;
+  }
+
+  return output;
+}
+
+export async function syncGadgetInstancePreviews(
+  editor: GEditor,
+  gadgets: GadgetBlockScreen[],
+): Promise<void> {
+  const canvasDoc = editor.Canvas.getDocument();
+  if (!canvasDoc) return;
+
+  const instances = Array.from(canvasDoc.querySelectorAll<HTMLElement>(GADGET_INSTANCE_SELECTOR));
+  if (instances.length === 0) return;
+
+  const gadgetNameMap = new Map(gadgets.map((gadget) => [gadget.id, gadget.name || gadget.id]));
+  const ids = [...new Set(instances.map((el) => el.getAttribute("data-gadget-screen-id")).filter(Boolean) as string[])];
+  const payloadMap = new Map<string, GadgetPreviewPayload>();
+
+  await Promise.all(ids.map(async (id) => {
+    try {
+      const design = await mcpBridge.request("loadScreen", { screenId: id });
+      payloadMap.set(id, {
+        html: extractGrapesHtml(design),
+        css: extractGrapesCss(design),
+      });
+    } catch {
+      payloadMap.set(id, { html: null, css: "" });
+    }
+  }));
+
+  instances.forEach((instance, index) => {
+    const id = instance.getAttribute("data-gadget-screen-id") ?? "";
+    const name = gadgetNameMap.get(id) ?? instance.getAttribute("data-gadget-screen-name") ?? id;
+    instance.setAttribute("data-gadget-screen-name", name);
+
+    const title = instance.querySelector<HTMLElement>(".harmony-gadget-instance__title");
+    if (title) title.textContent = name;
+    const idLabel = instance.querySelector<HTMLElement>(".harmony-gadget-instance__id");
+    if (idLabel) idLabel.textContent = id;
+
+    instance.querySelectorAll(`[${PREVIEW_ATTR}]`).forEach((el) => el.remove());
+    instance.querySelectorAll(`[${PREVIEW_CSS_ATTR}]`).forEach((el) => el.remove());
+    const preview = canvasDoc.createElement("div");
+    preview.setAttribute(PREVIEW_ATTR, "true");
+    preview.setAttribute(PREVIEW_SCOPE_ATTR, `gadget-${index}`);
+    preview.className = "harmony-gadget-instance__preview";
+
+    const payload = payloadMap.get(id);
+    if (payload?.css) {
+      const style = canvasDoc.createElement("style");
+      style.setAttribute(PREVIEW_CSS_ATTR, "true");
+      style.textContent = scopeGadgetPreviewCss(
+        payload.css,
+        `[${PREVIEW_SCOPE_ATTR}="gadget-${index}"]`,
+      );
+      instance.appendChild(style);
+    }
+
+    if (payload?.html) {
+      preview.innerHTML = DOMPurify.sanitize(payload.html);
+    } else {
+      preview.textContent = "Gadget design が見つかりません";
+      preview.classList.add("is-empty");
+    }
+
+    instance.appendChild(preview);
+  });
+}

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -403,6 +403,16 @@ body[data-gjs-dragging] .panel-left-wrapper.is-autohide .panel-left {
   border-color: var(--dz-accent);
   transform: translateY(-1px);
 }
+.block-item.gadget-block {
+  border-color: rgba(20, 184, 166, 0.45);
+  background: rgba(20, 184, 166, 0.08);
+}
+.block-item.gadget-block .block-icon {
+  color: #0f766e;
+}
+.block-item.gadget-block:hover {
+  border-color: #0f766e;
+}
 .block-item:active {
   cursor: grabbing;
 }


### PR DESCRIPTION
## Summary

Closes #1435

- Load `purpose: "gadget"` screens from project metadata and expose them in the GrapesJS block palette.
- Add a `ガジェット` block category whose blocks drop a reference wrapper with `data-gadget-screen-id` / `data-gadget-screen-name` instead of embedding gadget HTML snapshots.
- Expand placed gadget references in the GrapesJS canvas by loading the referenced Gadget Screen design as a read-only preview.
- Re-sync gadget palette entries and placed previews on `projectChanged`, relevant `screenChanged`, reconnect, and component updates so Gadget edits are reflected in consuming designers.
- Keep Controller / API / processFlow ownership on the Gadget Screen and custom block behavior unchanged.

## Verification

- `npm run test:unit --workspace=frontend -- src/grapes/blocks.test.ts src/grapes/gadgetInstancePreview.test.ts`
- `npm run lint --workspace=frontend`
- `npm run build --workspace=frontend`
- `git diff --name-only origin/main..HEAD -- schemas/` (no output)
