### PR TITLE
[codex] fix frontend extensions panel styling

### DIFF
--- a/frontend/src/components/extensions/DbOperationsTab.tsx
+++ b/frontend/src/components/extensions/DbOperationsTab.tsx
@@ -15,19 +15,22 @@ export function DbOperationsTab({ bundle, saving, onSave, isReadonly }: Extensio
   const [rows, setRows] = useState<Row[]>(Array.isArray(file.dbOperations) ? file.dbOperations : []);
 
   return (
-    <div>
-      <div className="row g-2 align-items-end mb-3">
-        <div className="col-md-3"><label className="form-label small fw-semibold">namespace</label><input className="form-control form-control-sm" value={namespace} onChange={(e) => setNamespace(e.target.value)} disabled={isReadonly} /></div>
-        <div className="col-md-auto"><button className="btn btn-primary btn-sm" disabled={saving || isReadonly} onClick={() => void onSave("dbOperations", { namespace, dbOperations: rows.filter((r) => r.value.trim() && r.label.trim()) })}>保存</button></div>
+    <div className="extensions-simple-tab">
+      <div className="extensions-tab-toolbar">
+        <div className="extensions-namespace-field"><label className="form-label small fw-semibold">namespace</label><input className="form-control form-control-sm" value={namespace} onChange={(e) => setNamespace(e.target.value)} disabled={isReadonly} /></div>
+        <div className="extensions-toolbar-actions"><button className="btn btn-primary btn-sm" disabled={saving || isReadonly} onClick={() => void onSave("dbOperations", { namespace, dbOperations: rows.filter((r) => r.value.trim() && r.label.trim()) })}>保存</button></div>
       </div>
+      {rows.length === 0 ? <div className="extensions-empty">DB 操作は未登録です。</div> : null}
       {rows.map((row, index) => (
-        <div className="row g-2 mb-2" key={index}>
-          <div className="col-md-4"><input className="form-control form-control-sm" placeholder="value" value={row.value} onChange={(e) => setRows(rows.map((r, i) => i === index ? { ...r, value: e.target.value } : r))} disabled={isReadonly} /></div>
-          <div className="col-md-6"><input className="form-control form-control-sm" placeholder="label" value={row.label} onChange={(e) => setRows(rows.map((r, i) => i === index ? { ...r, label: e.target.value } : r))} disabled={isReadonly} /></div>
-          <div className="col-md-2 text-end"><button className="btn btn-outline-danger btn-sm" onClick={() => setRows(rows.filter((_, i) => i !== index))} disabled={isReadonly}>削除</button></div>
+        <div className="extensions-simple-row" key={index}>
+          <input className="form-control form-control-sm extensions-mono-input" placeholder="value" value={row.value} onChange={(e) => setRows(rows.map((r, i) => i === index ? { ...r, value: e.target.value } : r))} disabled={isReadonly} />
+          <input className="form-control form-control-sm" placeholder="label" value={row.label} onChange={(e) => setRows(rows.map((r, i) => i === index ? { ...r, label: e.target.value } : r))} disabled={isReadonly} />
+          <button className="btn btn-outline-danger btn-sm extensions-delete-button" onClick={() => setRows(rows.filter((_, i) => i !== index))} disabled={isReadonly}>削除</button>
         </div>
       ))}
-      <button className="btn btn-outline-primary btn-sm" onClick={() => setRows([...rows, { value: "", label: "" }])} disabled={isReadonly}>追加</button>
+      <div className="extensions-footer-actions">
+        <button className="btn btn-outline-primary btn-sm" onClick={() => setRows([...rows, { value: "", label: "" }])} disabled={isReadonly}>追加</button>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/extensions/ExtensionsPanel.tsx
+++ b/frontend/src/components/extensions/ExtensionsPanel.tsx
@@ -19,6 +19,7 @@ import {
 import { ResumeOrDiscardDialog } from "../editing/ResumeOrDiscardDialog";
 import { SaveConflictDialog } from "../editing/SaveConflictDialog";
 import { setDirty as setTabDirty, makeTabId } from "../../store/tabStore";
+import "../../styles/extensions.css";
 import "../../styles/editMode.css";
 
 export type ExtensionKind = "steps" | "fieldTypes" | "triggers" | "dbOperations" | "responseTypes";
@@ -202,7 +203,7 @@ export function ExtensionsPanel() {
   const tabProps: ExtensionTabProps = { bundle, saving, onSave: handleSave, isReadonly };
 
   return (
-    <div className={`container-fluid py-3 extensions-panel${isReadonly ? " readonly-mode" : ""}`}>
+    <div className={`extensions-panel${isReadonly ? " readonly-mode" : ""}`}>
       {showDiscardDialog && (
         <DiscardConfirmDialog
           onConfirm={() => { void handleDiscard(); }}
@@ -274,7 +275,7 @@ export function ExtensionsPanel() {
       />
 
       {/* #994: collab UX 整合 — Viewer attach / take-over / 新規 draft / 履歴 */}
-      <div className="d-flex justify-content-end" style={{ padding: "4px 8px" }}>
+      <div className="extensions-session-row">
         <EditSessionDropdown
           resourceType="extension"
           resourceId={active}
@@ -286,10 +287,13 @@ export function ExtensionsPanel() {
         />
       </div>
 
-      <div className="d-flex align-items-center justify-content-between mb-3">
+      <div className="extensions-header">
         <div>
-          <h1 className="h5 mb-1">拡張管理</h1>
-          <div className="text-muted small">
+          <h1 className="extensions-title">
+            <i className="bi bi-puzzle" aria-hidden="true" />
+            拡張管理
+          </h1>
+          <div className="extensions-description">
             data/extensions のステップ型・フィールド型・トリガー・DB 操作・レスポンス型を管理します。
           </div>
         </div>
@@ -308,12 +312,12 @@ export function ExtensionsPanel() {
         </div>
       ) : null}
 
-      <ul className="nav nav-tabs" role="tablist">
+      <ul className="extensions-tabs" role="tablist">
         {TABS.map((tab) => (
-          <li className="nav-item" role="presentation" key={tab.key}>
+          <li className="extensions-tab-item" role="presentation" key={tab.key}>
             <button
               type="button"
-              className={`nav-link${active === tab.key ? " active" : ""}`}
+              className={`extensions-tab${active === tab.key ? " active" : ""}`}
               role="tab"
               aria-selected={active === tab.key}
               onClick={() => setActiveTab(tab.key)}
@@ -325,7 +329,7 @@ export function ExtensionsPanel() {
         ))}
       </ul>
 
-      <div className="border border-top-0 p-3 bg-white">
+      <div className="extensions-content">
         {loading ? (
           <div className="text-muted">読み込み中...</div>
         ) : (

--- a/frontend/src/components/extensions/FieldTypesTab.tsx
+++ b/frontend/src/components/extensions/FieldTypesTab.tsx
@@ -43,20 +43,22 @@ function SimpleRows({
   onSave: () => Promise<void>;
 }) {
   return (
-    <div>
-      <div className="row g-2 align-items-end mb-3">
-        <div className="col-md-3"><label className="form-label small fw-semibold">namespace</label><input className="form-control form-control-sm" value={namespace} onChange={(e) => onNamespaceChange(e.target.value)} disabled={isReadonly} /></div>
-        <div className="col-md-auto"><button className="btn btn-primary btn-sm" disabled={saving || isReadonly} onClick={() => void onSave()}>保存</button></div>
+    <div className="extensions-simple-tab">
+      <div className="extensions-tab-toolbar">
+        <div className="extensions-namespace-field"><label className="form-label small fw-semibold">namespace</label><input className="form-control form-control-sm" value={namespace} onChange={(e) => onNamespaceChange(e.target.value)} disabled={isReadonly} /></div>
+        <div className="extensions-toolbar-actions"><button className="btn btn-primary btn-sm" disabled={saving || isReadonly} onClick={() => void onSave()}>保存</button></div>
       </div>
-      {rows.length === 0 ? <div className="text-muted small mb-2">{title} は未登録です。</div> : null}
+      {rows.length === 0 ? <div className="extensions-empty">{title} は未登録です。</div> : null}
       {rows.map((row, index) => (
-        <div className="row g-2 mb-2" key={index}>
-          <div className="col-md-4"><input className="form-control form-control-sm" placeholder={keyName} value={row.kind} onChange={(e) => onRowsChange(rows.map((r, i) => i === index ? { ...r, kind: e.target.value } : r))} disabled={isReadonly} /></div>
-          <div className="col-md-6"><input className="form-control form-control-sm" placeholder="label" value={row.label} onChange={(e) => onRowsChange(rows.map((r, i) => i === index ? { ...r, label: e.target.value } : r))} disabled={isReadonly} /></div>
-          <div className="col-md-2 text-end"><button className="btn btn-outline-danger btn-sm" onClick={() => onRowsChange(rows.filter((_, i) => i !== index))} disabled={isReadonly}>削除</button></div>
+        <div className="extensions-simple-row" key={index}>
+          <input className="form-control form-control-sm extensions-mono-input" placeholder={keyName} value={row.kind} onChange={(e) => onRowsChange(rows.map((r, i) => i === index ? { ...r, kind: e.target.value } : r))} disabled={isReadonly} />
+          <input className="form-control form-control-sm" placeholder="label" value={row.label} onChange={(e) => onRowsChange(rows.map((r, i) => i === index ? { ...r, label: e.target.value } : r))} disabled={isReadonly} />
+          <button className="btn btn-outline-danger btn-sm extensions-delete-button" onClick={() => onRowsChange(rows.filter((_, i) => i !== index))} disabled={isReadonly}>削除</button>
         </div>
       ))}
-      <button className="btn btn-outline-primary btn-sm" onClick={() => onRowsChange([...rows, { kind: "", label: "" }])} disabled={isReadonly}>追加</button>
+      <div className="extensions-footer-actions">
+        <button className="btn btn-outline-primary btn-sm" onClick={() => onRowsChange([...rows, { kind: "", label: "" }])} disabled={isReadonly}>追加</button>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/extensions/ResponseTypesTab.tsx
+++ b/frontend/src/components/extensions/ResponseTypesTab.tsx
@@ -46,24 +46,27 @@ export function ResponseTypesTab({ bundle, saving, onSave, isReadonly }: Extensi
 
   return (
     <div className="extensions-response-types-tab">
-      <div className="row g-2 align-items-end mb-3">
-        <div className="col-md-3"><label className="form-label small fw-semibold">namespace</label><input className="form-control form-control-sm" value={namespace} onChange={(e) => setNamespace(e.target.value)} disabled={isReadonly} /></div>
-        <div className="col-md-auto"><button className="btn btn-primary btn-sm" disabled={saving || isReadonly} onClick={() => void save()}>保存</button></div>
+      <div className="extensions-tab-toolbar">
+        <div className="extensions-namespace-field"><label className="form-label small fw-semibold">namespace</label><input className="form-control form-control-sm" value={namespace} onChange={(e) => setNamespace(e.target.value)} disabled={isReadonly} /></div>
+        <div className="extensions-toolbar-actions"><button className="btn btn-primary btn-sm" disabled={saving || isReadonly} onClick={() => void save()}>保存</button></div>
       </div>
       {error ? <div className="alert alert-danger py-2">JSON パース失敗: {error}</div> : null}
+      {rows.length === 0 ? <div className="extensions-empty">レスポンス型は未登録です。</div> : null}
       {rows.map((row, index) => (
-        <div className="border rounded p-2 mb-2" key={index}>
-          <div className="row g-2">
-            <div className="col-md-3"><input className="form-control form-control-sm" placeholder="ApiError" value={row.key} onChange={(e) => setRows(rows.map((r, i) => i === index ? { ...r, key: e.target.value } : r))} disabled={isReadonly} /></div>
-            <div className="col-md-7"><input className="form-control form-control-sm" placeholder="説明" value={row.description} onChange={(e) => setRows(rows.map((r, i) => i === index ? { ...r, description: e.target.value } : r))} disabled={isReadonly} /></div>
-            <div className="col-md-2 text-end"><button className="btn btn-outline-danger btn-sm" onClick={() => setRows(rows.filter((_, i) => i !== index))} disabled={isReadonly}>削除</button></div>
-            <div className="col-12"><textarea className="form-control form-control-sm font-monospace response-type-schema" rows={5} value={row.schemaText} onChange={(e) => setRows(rows.map((r, i) => i === index ? { ...r, schemaText: e.target.value } : r))} disabled={isReadonly} /></div>
+        <div className="extensions-entry-card" key={index}>
+          <div className="extensions-response-grid">
+            <input className="form-control form-control-sm extensions-mono-input" placeholder="ApiError" value={row.key} onChange={(e) => setRows(rows.map((r, i) => i === index ? { ...r, key: e.target.value } : r))} disabled={isReadonly} />
+            <input className="form-control form-control-sm" placeholder="説明" value={row.description} onChange={(e) => setRows(rows.map((r, i) => i === index ? { ...r, description: e.target.value } : r))} disabled={isReadonly} />
+            <button className="btn btn-outline-danger btn-sm extensions-delete-button" onClick={() => setRows(rows.filter((_, i) => i !== index))} disabled={isReadonly}>削除</button>
+            <textarea className="form-control form-control-sm font-monospace response-type-schema extensions-json-editor" rows={5} value={row.schemaText} onChange={(e) => setRows(rows.map((r, i) => i === index ? { ...r, schemaText: e.target.value } : r))} disabled={isReadonly} />
           </div>
         </div>
       ))}
-      <button className="btn btn-outline-primary btn-sm" onClick={() => setRows([...rows, { key: "", description: "", schemaText: '{\n  "type": "object",\n  "properties": {}\n}' }])} disabled={isReadonly}>
-        追加
-      </button>
+      <div className="extensions-footer-actions">
+        <button className="btn btn-outline-primary btn-sm" onClick={() => setRows([...rows, { key: "", description: "", schemaText: '{\n  "type": "object",\n  "properties": {}\n}' }])} disabled={isReadonly}>
+          追加
+        </button>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/extensions/StepsTab.tsx
+++ b/frontend/src/components/extensions/StepsTab.tsx
@@ -56,12 +56,12 @@ export function StepsTab({ bundle, saving, onSave, isReadonly }: ExtensionTabPro
 
   return (
     <div className="extensions-steps-tab">
-      <div className="row g-2 align-items-end mb-3">
-        <div className="col-md-3">
+      <div className="extensions-tab-toolbar">
+        <div className="extensions-namespace-field">
           <label className="form-label small fw-semibold">namespace</label>
           <input className="form-control form-control-sm" value={namespace} onChange={(e) => setNamespace(e.target.value)} disabled={isReadonly} />
         </div>
-        <div className="col-md-auto">
+        <div className="extensions-toolbar-actions">
           <button className="btn btn-primary btn-sm" disabled={saving || isReadonly} onClick={() => void save()}>
             保存
           </button>
@@ -69,20 +69,22 @@ export function StepsTab({ bundle, saving, onSave, isReadonly }: ExtensionTabPro
       </div>
       {error ? <div className="alert alert-danger py-2">{error}</div> : null}
       {rows.map((row, index) => (
-        <div className="border rounded p-2 mb-2" key={index}>
-          <div className="row g-2">
-            <div className="col-md-2"><input className="form-control form-control-sm" placeholder="key" value={row.key} onChange={(e) => setRows(rows.map((r, i) => i === index ? { ...r, key: e.target.value } : r))} disabled={isReadonly} /></div>
-            <div className="col-md-2"><input className="form-control form-control-sm" placeholder="label" value={row.label} onChange={(e) => setRows(rows.map((r, i) => i === index ? { ...r, label: e.target.value } : r))} disabled={isReadonly} /></div>
-            <div className="col-md-2"><input className="form-control form-control-sm" placeholder="bi-puzzle" value={row.icon} onChange={(e) => setRows(rows.map((r, i) => i === index ? { ...r, icon: e.target.value } : r))} disabled={isReadonly} /></div>
-            <div className="col-md-4"><input className="form-control form-control-sm" placeholder="description" value={row.description} onChange={(e) => setRows(rows.map((r, i) => i === index ? { ...r, description: e.target.value } : r))} disabled={isReadonly} /></div>
-            <div className="col-md-2 text-end"><button className="btn btn-outline-danger btn-sm" onClick={() => setRows(rows.filter((_, i) => i !== index))} disabled={isReadonly}>削除</button></div>
-            <div className="col-12"><textarea className="form-control form-control-sm font-monospace" rows={5} value={row.schemaText} onChange={(e) => setRows(rows.map((r, i) => i === index ? { ...r, schemaText: e.target.value } : r))} disabled={isReadonly} /></div>
+        <div className="extensions-entry-card" key={index}>
+          <div className="extensions-step-grid">
+            <input className="form-control form-control-sm extensions-mono-input" placeholder="key" value={row.key} onChange={(e) => setRows(rows.map((r, i) => i === index ? { ...r, key: e.target.value } : r))} disabled={isReadonly} />
+            <input className="form-control form-control-sm" placeholder="label" value={row.label} onChange={(e) => setRows(rows.map((r, i) => i === index ? { ...r, label: e.target.value } : r))} disabled={isReadonly} />
+            <input className="form-control form-control-sm extensions-mono-input" placeholder="bi-puzzle" value={row.icon} onChange={(e) => setRows(rows.map((r, i) => i === index ? { ...r, icon: e.target.value } : r))} disabled={isReadonly} />
+            <input className="form-control form-control-sm" placeholder="description" value={row.description} onChange={(e) => setRows(rows.map((r, i) => i === index ? { ...r, description: e.target.value } : r))} disabled={isReadonly} />
+            <button className="btn btn-outline-danger btn-sm extensions-delete-button" onClick={() => setRows(rows.filter((_, i) => i !== index))} disabled={isReadonly}>削除</button>
+            <textarea className="form-control form-control-sm font-monospace extensions-json-editor" rows={5} value={row.schemaText} onChange={(e) => setRows(rows.map((r, i) => i === index ? { ...r, schemaText: e.target.value } : r))} disabled={isReadonly} />
           </div>
         </div>
       ))}
-      <button className="btn btn-outline-primary btn-sm" onClick={() => setRows([...rows, { key: "", label: "", icon: "bi-puzzle", description: "", schemaText: '{\n  "type": "object",\n  "properties": {}\n}' }])} disabled={isReadonly}>
-        追加
-      </button>
+      <div className="extensions-footer-actions">
+        <button className="btn btn-outline-primary btn-sm" onClick={() => setRows([...rows, { key: "", label: "", icon: "bi-puzzle", description: "", schemaText: '{\n  "type": "object",\n  "properties": {}\n}' }])} disabled={isReadonly}>
+          追加
+        </button>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/extensions/TriggersTab.tsx
+++ b/frontend/src/components/extensions/TriggersTab.tsx
@@ -15,19 +15,22 @@ export function TriggersTab({ bundle, saving, onSave, isReadonly }: ExtensionTab
   const [rows, setRows] = useState<Row[]>(Array.isArray(file.triggers) ? file.triggers : []);
 
   return (
-    <div>
-      <div className="row g-2 align-items-end mb-3">
-        <div className="col-md-3"><label className="form-label small fw-semibold">namespace</label><input className="form-control form-control-sm" value={namespace} onChange={(e) => setNamespace(e.target.value)} disabled={isReadonly} /></div>
-        <div className="col-md-auto"><button className="btn btn-primary btn-sm" disabled={saving || isReadonly} onClick={() => void onSave("triggers", { namespace, triggers: rows.filter((r) => r.value.trim() && r.label.trim()) })}>保存</button></div>
+    <div className="extensions-simple-tab">
+      <div className="extensions-tab-toolbar">
+        <div className="extensions-namespace-field"><label className="form-label small fw-semibold">namespace</label><input className="form-control form-control-sm" value={namespace} onChange={(e) => setNamespace(e.target.value)} disabled={isReadonly} /></div>
+        <div className="extensions-toolbar-actions"><button className="btn btn-primary btn-sm" disabled={saving || isReadonly} onClick={() => void onSave("triggers", { namespace, triggers: rows.filter((r) => r.value.trim() && r.label.trim()) })}>保存</button></div>
       </div>
+      {rows.length === 0 ? <div className="extensions-empty">トリガーは未登録です。</div> : null}
       {rows.map((row, index) => (
-        <div className="row g-2 mb-2" key={index}>
-          <div className="col-md-4"><input className="form-control form-control-sm" placeholder="value" value={row.value} onChange={(e) => setRows(rows.map((r, i) => i === index ? { ...r, value: e.target.value } : r))} disabled={isReadonly} /></div>
-          <div className="col-md-6"><input className="form-control form-control-sm" placeholder="label" value={row.label} onChange={(e) => setRows(rows.map((r, i) => i === index ? { ...r, label: e.target.value } : r))} disabled={isReadonly} /></div>
-          <div className="col-md-2 text-end"><button className="btn btn-outline-danger btn-sm" onClick={() => setRows(rows.filter((_, i) => i !== index))} disabled={isReadonly}>削除</button></div>
+        <div className="extensions-simple-row" key={index}>
+          <input className="form-control form-control-sm extensions-mono-input" placeholder="value" value={row.value} onChange={(e) => setRows(rows.map((r, i) => i === index ? { ...r, value: e.target.value } : r))} disabled={isReadonly} />
+          <input className="form-control form-control-sm" placeholder="label" value={row.label} onChange={(e) => setRows(rows.map((r, i) => i === index ? { ...r, label: e.target.value } : r))} disabled={isReadonly} />
+          <button className="btn btn-outline-danger btn-sm extensions-delete-button" onClick={() => setRows(rows.filter((_, i) => i !== index))} disabled={isReadonly}>削除</button>
         </div>
       ))}
-      <button className="btn btn-outline-primary btn-sm" onClick={() => setRows([...rows, { value: "", label: "" }])} disabled={isReadonly}>追加</button>
+      <div className="extensions-footer-actions">
+        <button className="btn btn-outline-primary btn-sm" onClick={() => setRows([...rows, { value: "", label: "" }])} disabled={isReadonly}>追加</button>
+      </div>
     </div>
   );
 }

--- a/frontend/src/styles/extensions.css
+++ b/frontend/src/styles/extensions.css
@@ -1,0 +1,233 @@
+.extensions-panel {
+  height: calc(100vh - var(--common-header-h, 0px) - var(--tabbar-h, 0px));
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: #f8f9fa;
+  color: #1f2937;
+}
+
+.extensions-session-row {
+  display: flex;
+  justify-content: flex-end;
+  padding: 6px 14px 4px;
+  background: #fff;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.extensions-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 16px;
+  background: #fff;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.extensions-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 2px;
+  font-size: 1.08rem;
+  font-weight: 700;
+  color: #111827;
+}
+
+.extensions-title .bi {
+  color: #2563eb;
+}
+
+.extensions-description {
+  font-size: 0.82rem;
+  color: #64748b;
+}
+
+.extensions-tabs {
+  display: flex;
+  gap: 0;
+  margin: 0;
+  padding: 0 14px;
+  overflow-x: auto;
+  list-style: none;
+  background: #fff;
+  border-bottom: 2px solid #e2e8f0;
+}
+
+.extensions-tab-item {
+  flex: 0 0 auto;
+}
+
+.extensions-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 38px;
+  padding: 8px 14px;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+  background: transparent;
+  color: #64748b;
+  font-size: 0.86rem;
+  font-weight: 600;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.extensions-tab:hover {
+  color: #1f2937;
+  background: #f8fafc;
+}
+
+.extensions-tab.active {
+  color: #2563eb;
+  border-bottom-color: #2563eb;
+  background: #fff;
+}
+
+.extensions-content {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  padding: 12px 14px 20px;
+}
+
+.extensions-tab-toolbar {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+  padding: 10px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+}
+
+.extensions-namespace-field {
+  flex: 1 1 280px;
+  max-width: 420px;
+}
+
+.extensions-namespace-field .form-label {
+  margin-bottom: 4px;
+  color: #475569;
+}
+
+.extensions-toolbar-actions,
+.extensions-footer-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.extensions-entry-card {
+  margin-bottom: 10px;
+  padding: 10px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+}
+
+.extensions-step-grid,
+.extensions-response-grid {
+  display: grid;
+  gap: 8px;
+  align-items: start;
+}
+
+.extensions-step-grid {
+  grid-template-columns: minmax(10rem, 1.1fr) minmax(10rem, 1fr) minmax(9rem, 0.8fr) minmax(16rem, 2fr) auto;
+}
+
+.extensions-response-grid {
+  grid-template-columns: minmax(12rem, 1fr) minmax(18rem, 2fr) auto;
+}
+
+.extensions-json-editor {
+  grid-column: 1 / -1;
+  min-height: 132px;
+  resize: vertical;
+  line-height: 1.45;
+  background: #0f172a;
+  color: #e5e7eb;
+  border-color: #1e293b;
+  tab-size: 2;
+}
+
+.extensions-json-editor:focus {
+  background: #0f172a;
+  color: #fff;
+  border-color: #60a5fa;
+  box-shadow: 0 0 0 0.15rem rgba(37, 99, 235, 0.2);
+}
+
+.extensions-simple-tab {
+  max-width: 980px;
+}
+
+.extensions-simple-row {
+  display: grid;
+  grid-template-columns: minmax(12rem, 1fr) minmax(18rem, 1.6fr) auto;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 8px;
+  padding: 8px 10px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+}
+
+.extensions-mono-input {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+.extensions-delete-button {
+  min-width: 4.5rem;
+}
+
+.extensions-empty {
+  margin-bottom: 10px;
+  padding: 18px;
+  color: #64748b;
+  text-align: center;
+  background: #fff;
+  border: 1px dashed #cbd5e1;
+  border-radius: 6px;
+  font-size: 0.86rem;
+}
+
+.extensions-content .alert {
+  border-radius: 6px;
+}
+
+.extensions-content .form-control-sm {
+  min-height: 30px;
+  font-size: 0.84rem;
+}
+
+@media (max-width: 900px) {
+  .extensions-header,
+  .extensions-tab-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .extensions-toolbar-actions,
+  .extensions-header > .btn {
+    justify-content: flex-start;
+  }
+
+  .extensions-step-grid,
+  .extensions-response-grid,
+  .extensions-simple-row {
+    grid-template-columns: 1fr;
+  }
+
+  .extensions-delete-button {
+    justify-self: start;
+  }
+}


### PR DESCRIPTION
## Summary

- Add dedicated `extensions.css` for the `/extensions` management screen
- Apply stable page, tab, toolbar, row, card, and JSON editor classes across extension tabs
- Keep the change scoped to frontend presentation; no schema changes

## Root Cause

`ExtensionsPanel` emitted classes such as `extensions-panel`, `extensions-steps-tab`, and `extensions-response-types-tab`, but only imported `editMode.css`. There was no stylesheet defining the extension management layout, so the screen relied on raw Bootstrap grid snippets and looked effectively unstyled compared with the other management views.

## Validation

- `npm run test:unit --workspace=frontend -- ExtensionsPanel.test.tsx`
- `npm run build --workspace=frontend`
- `npm run lint --workspace=frontend`
- Confirmed no `schemas/` diff

Closes #1440
