### PR TITLE
[codex] fix frontend sequence CSS imports

### DIFF
--- a/frontend/src/components/sequence/SequenceEditor.tsx
+++ b/frontend/src/components/sequence/SequenceEditor.tsx
@@ -30,6 +30,7 @@ import { ResumeOrDiscardDialog } from "../editing/ResumeOrDiscardDialog";
 import { setDirty as setTabDirty, makeTabId } from "../../store/tabStore";
 import { generateSequenceDdl } from "./generateSequenceDdl";
 import type { Table, NumberingEntry } from "../../types/v3";
+import "../../styles/table.css";
 import "../../styles/editMode.css";
 
 interface TableColumnOption {

--- a/frontend/src/components/sequence/SequenceListView.tsx
+++ b/frontend/src/components/sequence/SequenceListView.tsx
@@ -23,6 +23,7 @@ import { usePersistentState } from "../../hooks/usePersistentState";
 import { renumber } from "../../utils/listOrder";
 import { makeDuplicatedEntityId } from "../../utils/entityIdSuggestion";
 import { useDraftRegistry } from "../../hooks/useDraftRegistry";
+import "../../styles/table.css";
 import "../../styles/editMode.css";
 
 const STORAGE_KEY = "list-view-mode:sequence-list";


### PR DESCRIPTION
## Summary

- Import `table.css` in `SequenceListView`
- Import `table.css` in `SequenceEditor`

## Root Cause

The sequence list/editor screens use `table-list-*`, `table-editor-*`, `tbl-*`, and `seq-*` classes that are defined in `frontend/src/styles/table.css`, but both route components only imported `editMode.css`. Those screens therefore missed the existing table/sequence layout styles.

## Validation

- `npm run lint --workspace=frontend`
- `npm run build --workspace=frontend`
- Confirmed no `schemas/` diff

Closes #1442
