### PR TITLE
Fix panel scroll clipping

### DIFF
--- a/frontend/src/components/BlocksPanel.test.tsx
+++ b/frontend/src/components/BlocksPanel.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { BlocksPanel } from "./BlocksPanel";
+import "../styles/app.css";
+
+vi.mock("@grapesjs/react", () => ({
+  useEditorMaybe: () => null,
+}));
+
+vi.mock("../store/customBlockStore", () => ({
+  deleteCustomBlock: vi.fn(),
+}));
+
+vi.mock("./SharedBlockSyncModal", () => ({
+  SharedBlockSyncModal: () => null,
+}));
+
+type FakeBlock = {
+  getId: () => string;
+  get: (key: string) => unknown;
+};
+
+function makeBlock(id: string, label: string): FakeBlock {
+  return {
+    getId: () => id,
+    get: (key: string) => {
+      if (key === "label") return label;
+      if (key === "media") return "<svg viewBox=\"0 0 16 16\"><rect width=\"16\" height=\"16\" /></svg>";
+      if (key === "content") return `<div>${label}</div>`;
+      return undefined;
+    },
+  };
+}
+
+describe("BlocksPanel", () => {
+  it("keeps the high-count block palette scroll contract in DOM and CSS", () => {
+    const mapCategoryBlocks = new Map<string, FakeBlock[]>();
+    mapCategoryBlocks.set(
+      "大量ブロック",
+      Array.from({ length: 120 }, (_, i) => makeBlock(`block-${i + 1}`, `ブロック ${i + 1}`)),
+    );
+
+    const { container } = render(
+      <BlocksPanel
+        mapCategoryBlocks={mapCategoryBlocks as never}
+        blocks={[] as never}
+        Container={({ children }: { children: ReactNode }) => <>{children}</>}
+        dragStart={vi.fn()}
+        dragStop={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("ブロック 120")).toBeInTheDocument();
+    expect(container.querySelector(".blocks-list-scroll-end")).toBeInTheDocument();
+    expect(container.querySelector(".blocks-list-scroll-end")).toHaveAttribute("aria-hidden", "true");
+
+    const appCss = readFileSync(join(process.cwd(), "src/styles/app.css"), "utf8");
+    expect(appCss).toMatch(/\.blocks-list\s*{[^}]*overflow-y:\s*auto;/s);
+    expect(appCss).toMatch(/\.blocks-list\s*{[^}]*overscroll-behavior:\s*contain;/s);
+    expect(appCss).toMatch(/\.blocks-list\s*{[^}]*scrollbar-gutter:\s*stable;/s);
+    expect(appCss).toMatch(/\.blocks-list-scroll-end\s*{[^}]*height:\s*max\(56px,\s*env\(safe-area-inset-bottom\)\);/s);
+  });
+});

--- a/frontend/src/components/BlocksPanel.tsx
+++ b/frontend/src/components/BlocksPanel.tsx
@@ -155,6 +155,7 @@ export function BlocksPanel({ mapCategoryBlocks, dragStart, dragStop }: BlocksRe
             </section>
           );
         })}
+        <div className="blocks-list-scroll-end" aria-hidden="true" />
       </div>
 
       <SharedBlockSyncModal

--- a/frontend/src/components/process-flow/ProcessFlowEditor.tsx
+++ b/frontend/src/components/process-flow/ProcessFlowEditor.tsx
@@ -1088,6 +1088,7 @@ export function ProcessFlowEditor() {
               handlePickScreenItem={handlePickScreenItem}
             />
             {/* InspectorPanel (#1145 Phase-3 で抽出): AI 依頼 / Meta / HTTP contract / SLA / I/O */}
+            <div className="process-flow-workbench-scroll-end" aria-hidden="true" />
           </div>
         </DndContext>
       </div>

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -348,7 +348,34 @@ body[data-gjs-dragging] .panel-left-wrapper.is-autohide .panel-left {
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
-  padding: 8px 0 16px;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+  scrollbar-color: #4b4f6c var(--dz-bg-2);
+  scrollbar-width: thin;
+  padding: 8px 0 0;
+  background:
+    linear-gradient(var(--dz-bg-2), var(--dz-bg-2)) top / 100% 8px no-repeat,
+    linear-gradient(rgba(0, 0, 0, 0.28), transparent) top / 100% 10px no-repeat,
+    linear-gradient(transparent, rgba(0, 0, 0, 0.34)) bottom / 100% 18px no-repeat;
+}
+.blocks-list::-webkit-scrollbar {
+  width: 8px;
+}
+.blocks-list::-webkit-scrollbar-track {
+  background: var(--dz-bg-2);
+}
+.blocks-list::-webkit-scrollbar-thumb {
+  background: #4b4f6c;
+  border-radius: 999px;
+  border: 2px solid var(--dz-bg-2);
+}
+.blocks-list::-webkit-scrollbar-thumb:hover {
+  background: #646888;
+}
+
+.blocks-list-scroll-end {
+  height: max(56px, env(safe-area-inset-bottom));
+  pointer-events: none;
 }
 
 .blocks-category {

--- a/frontend/src/styles/processFlow.css
+++ b/frontend/src/styles/processFlow.css
@@ -506,6 +506,10 @@
   overflow: hidden;
 }
 
+.process-flow-workbench-scroll-end {
+  display: none;
+}
+
 .process-flow-palette-pane,
 .process-flow-canvas-pane,
 .process-flow-inspector-pane {
@@ -1599,20 +1603,39 @@
   .process-flow-workbench-grid {
     grid-template-columns: 1fr;
     overflow-y: auto;
+    overscroll-behavior: contain;
+    scrollbar-gutter: stable;
+    padding-bottom: max(40px, env(safe-area-inset-bottom));
+    scroll-padding-bottom: max(40px, env(safe-area-inset-bottom));
+  }
+
+  .process-flow-workbench-scroll-end {
+    display: block;
+    grid-column: 1 / -1;
+    height: max(56px, env(safe-area-inset-bottom));
+    pointer-events: none;
   }
 
   .process-flow-palette-pane,
   .process-flow-inspector-pane {
-    min-height: 220px;
+    min-height: min(360px, 58vh);
     border-right: 0;
     border-left: 0;
     border-bottom: 1px solid #d8dee7;
+  }
+
+  .process-flow-inspector-scroll {
+    padding-bottom: max(28px, env(safe-area-inset-bottom));
+    overscroll-behavior: contain;
+    scrollbar-gutter: stable;
   }
 
   .step-toolbar {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(132px, 1fr));
     max-height: 260px;
+    overscroll-behavior: contain;
+    scrollbar-gutter: stable;
   }
 
   .process-flow-palette-section,


### PR DESCRIPTION
## Summary

Closes #1447

- Add an explicit scroll-end spacer to the GrapesJS `BlocksPanel` so high-count block palettes can scroll past the final block instead of pinning it to the viewport edge.
- Improve block palette scroll affordance with contained wheel behavior, stable scrollbar gutter, visible thin scrollbar styling, and bottom-safe spacing.
- Add mobile ProcessFlow workbench scroll-end spacing and contained nested scroll behavior to avoid clipped lower inspector content on narrow viewports.
- Add a focused `BlocksPanel` regression test with 120 mock blocks that fixes both the spacer DOM and the CSS scroll contract (`overflow-y`, `overscroll-behavior`, `scrollbar-gutter`, spacer height).

## Verification

- `npm --prefix frontend run test:unit -- BlocksPanel.test.tsx`
- `node .tmp/panel-scroll-audit.mjs` (no suspect panels after fix)
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`
- `git diff --check`

## Schema

- No `schemas/` changes.
