### PR TITLE
fix: harden responsive core UI (#1446)

### DIFF
--- a/frontend/src/components/TabBar.tsx
+++ b/frontend/src/components/TabBar.tsx
@@ -86,6 +86,7 @@ function TabItem({
   return (
     <div
       ref={setNodeRef}
+      data-tab-id={tab.id}
       style={style}
       {...attributes}
       {...listeners}
@@ -119,7 +120,10 @@ function TabItem({
 export function TabBar() {
   const { tabs, activeTabId } = useTabs();
   const [contextMenu, setContextMenu] = useState<ContextMenu | null>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
   const contextMenuRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 4 } })
@@ -158,19 +162,77 @@ export function TabBar() {
     return () => document.removeEventListener("mousedown", handleClick);
   }, [contextMenu]);
 
+  const updateScrollAffordance = useCallback(() => {
+    const list = listRef.current;
+    if (!list) return;
+    const maxScrollLeft = list.scrollWidth - list.clientWidth;
+    setCanScrollLeft(list.scrollLeft > 1);
+    setCanScrollRight(list.scrollLeft < maxScrollLeft - 1);
+  }, []);
+
+  useEffect(() => {
+    const list = listRef.current;
+    if (!list) return;
+    updateScrollAffordance();
+    list.addEventListener("scroll", updateScrollAffordance, { passive: true });
+    const resizeObserver = typeof ResizeObserver === "undefined"
+      ? null
+      : new ResizeObserver(updateScrollAffordance);
+    resizeObserver?.observe(list);
+    return () => {
+      list.removeEventListener("scroll", updateScrollAffordance);
+      resizeObserver?.disconnect();
+    };
+  }, [tabs.length, updateScrollAffordance]);
+
+  useEffect(() => {
+    const list = listRef.current;
+    if (!list || !activeTabId) return;
+    const active = Array.from(list.querySelectorAll<HTMLElement>(".tabbar-tab"))
+      .find((el) => el.dataset.tabId === activeTabId);
+    active?.scrollIntoView({ block: "nearest", inline: "nearest" });
+    requestAnimationFrame(updateScrollAffordance);
+  }, [activeTabId, updateScrollAffordance]);
+
+  const handleScrollTabs = (direction: "left" | "right") => {
+    const list = listRef.current;
+    if (!list) return;
+    list.scrollBy({
+      left: direction === "left" ? -Math.max(160, list.clientWidth * 0.6) : Math.max(160, list.clientWidth * 0.6),
+      behavior: "smooth",
+    });
+  };
+
   if (tabs.length === 0) return null;
 
   const ctxTab = contextMenu ? tabs.find((t) => t.id === contextMenu.tabId) : null;
 
   return (
     <>
-      <div className="tabbar">
+      <div
+        className={[
+          "tabbar",
+          canScrollLeft ? "tabbar-can-scroll-left" : "",
+          canScrollRight ? "tabbar-can-scroll-right" : "",
+        ].filter(Boolean).join(" ")}
+      >
+        {canScrollLeft && (
+          <button
+            type="button"
+            className="tabbar-scroll-btn tabbar-scroll-btn-left"
+            onClick={() => handleScrollTabs("left")}
+            title="左のタブへスクロール"
+            aria-label="左のタブへスクロール"
+          >
+            <i className="bi bi-chevron-left" />
+          </button>
+        )}
         <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
           <SortableContext
             items={tabs.map((t) => t.id)}
             strategy={horizontalListSortingStrategy}
           >
-            <div className="tabbar-list">
+            <div ref={listRef} className="tabbar-list">
               {tabs.map((tab) => (
                 <TabItem
                   key={tab.id}
@@ -183,6 +245,17 @@ export function TabBar() {
             </div>
           </SortableContext>
         </DndContext>
+        {canScrollRight && (
+          <button
+            type="button"
+            className="tabbar-scroll-btn tabbar-scroll-btn-right"
+            onClick={() => handleScrollTabs("right")}
+            title="右のタブへスクロール"
+            aria-label="右のタブへスクロール"
+          >
+            <i className="bi bi-chevron-right" />
+          </button>
+        )}
       </div>
 
       {contextMenu && ctxTab && (

--- a/frontend/src/components/editing/EditModeToolbar.tsx
+++ b/frontend/src/components/editing/EditModeToolbar.tsx
@@ -25,7 +25,7 @@ export function EditModeToolbar({
       <div className="edit-mode-toolbar edit-mode-toolbar--readonly">
         <button
           type="button"
-          className="btn btn-primary btn-sm"
+          className="edit-mode-btn edit-mode-btn-primary"
           onClick={onStartEditing}
           data-testid="edit-mode-start"
         >
@@ -41,7 +41,7 @@ export function EditModeToolbar({
       <div className="edit-mode-toolbar edit-mode-toolbar--editing">
         <button
           type="button"
-          className="btn btn-success btn-sm"
+          className="edit-mode-btn edit-mode-btn-success"
           onClick={onSave}
           disabled={saving}
           data-testid="edit-mode-save"
@@ -60,7 +60,7 @@ export function EditModeToolbar({
         </button>
         <button
           type="button"
-          className="btn btn-outline-secondary btn-sm"
+          className="edit-mode-btn edit-mode-btn-secondary"
           onClick={onDiscardClick}
           disabled={saving}
           data-testid="edit-mode-discard"
@@ -82,7 +82,7 @@ export function EditModeToolbar({
         </span>
         <button
           type="button"
-          className="btn btn-warning btn-sm"
+          className="edit-mode-btn edit-mode-btn-warning"
           onClick={onForceReleaseClick}
           data-testid="edit-mode-force-release"
         >

--- a/frontend/src/components/screen-items/ScreenItemsView.tsx
+++ b/frontend/src/components/screen-items/ScreenItemsView.tsx
@@ -961,7 +961,7 @@ export function ScreenItemsView() {
                 <col style={{ width: "5em" }} />
                 <col style={{ width: "12em" }} />
                 <col />
-                <col style={{ width: 76 }} />
+                <col style={{ width: 164 }} />
               </colgroup>
               <thead>
                 <tr>

--- a/frontend/src/components/workspace/WorkspaceIndicator.tsx
+++ b/frontend/src/components/workspace/WorkspaceIndicator.tsx
@@ -73,10 +73,12 @@ export function WorkspaceIndicator() {
 
   return (
     <div
+      className="workspace-indicator"
       ref={dropdownRef}
       style={{ position: "relative", display: "inline-flex", alignItems: "center" }}
     >
       <button
+        className="workspace-indicator-toggle"
         onClick={() => setOpen((v) => !v)}
         title={
           lockdown
@@ -108,6 +110,7 @@ export function WorkspaceIndicator() {
           <i className="bi bi-folder2" style={{ color: "#4dabf7" }} />
         )}
         <span
+          className="workspace-indicator-name"
           data-testid="workspace-indicator-name"
           style={{
             overflow: "hidden",

--- a/frontend/src/styles/common.css
+++ b/frontend/src/styles/common.css
@@ -345,8 +345,33 @@ body:has(.form-footer) {
   gap: 8px;
   padding: 8px 12px;
   border-bottom: 1px solid var(--app-border);
+  min-width: 0;
+  flex-wrap: wrap;
 }
-.data-table-toolbar .spacer { flex: 1 1 auto; }
+.data-table-toolbar .spacer { flex: 1 1 auto; min-width: 16px; }
+.data-table-toolbar :where(.btn, button, input, select) {
+  max-width: 100%;
+}
+
+@media (max-width: 640px) {
+  .data-table-toolbar {
+    align-items: stretch;
+  }
+
+  .data-table-toolbar .spacer {
+    display: none;
+  }
+
+  .data-table-toolbar :where(.btn, button) {
+    min-width: max-content;
+    white-space: nowrap;
+  }
+
+  .search-area .search-buttons {
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+}
 .data-table {
   width: 100%;
   border-collapse: collapse;

--- a/frontend/src/styles/commonHeader.css
+++ b/frontend/src/styles/commonHeader.css
@@ -6,13 +6,19 @@
   background: #1a1a2e;
   border-bottom: 1px solid #2d2d44;
   padding: 0 16px;
+  gap: 10px;
+  min-width: 0;
+  max-width: 100vw;
+  overflow: hidden;
+  box-sizing: border-box;
 }
 
 .common-header-left {
   display: flex;
   align-items: center;
   gap: 8px;
-  flex: 1;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .common-header-logo {
@@ -25,22 +31,28 @@
   font-weight: 700;
   color: #e4e6f0;
   white-space: nowrap;
+  flex: 0 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .common-header-center {
-  flex: 2;
+  flex: 1 1 120px;
   display: flex;
   align-items: center;
   justify-content: center;
   min-height: 28px;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .common-header-right {
   display: flex;
   align-items: center;
   gap: 8px;
-  flex: 1;
+  flex: 0 0 auto;
   justify-content: flex-end;
+  min-width: 0;
 }
 
 .common-header-user {
@@ -60,4 +72,62 @@
 
 .common-header-user-label {
   opacity: 0.7;
+  max-width: 8em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspace-indicator {
+  min-width: 0;
+  max-width: min(220px, 36vw);
+}
+
+.workspace-indicator-toggle {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.workspace-indicator-name {
+  min-width: 0;
+}
+
+@media (max-width: 640px) {
+  .common-header {
+    padding: 0 8px;
+    gap: 6px;
+  }
+
+  .common-header-left {
+    gap: 6px;
+  }
+
+  .common-header-logo,
+  .common-header-title,
+  .common-header-center,
+  .common-header-user-label {
+    display: none;
+  }
+
+  .workspace-indicator {
+    max-width: min(46vw, 180px);
+  }
+
+  .common-header-right {
+    gap: 4px;
+  }
+
+  .common-header-user {
+    padding: 3px 6px;
+  }
+}
+
+@media (max-width: 420px) {
+  .workspace-indicator {
+    max-width: 42vw;
+  }
+
+  .codex-indicator {
+    padding-inline: 6px;
+  }
 }

--- a/frontend/src/styles/commonHeader.css
+++ b/frontend/src/styles/commonHeader.css
@@ -9,8 +9,9 @@
   gap: 10px;
   min-width: 0;
   max-width: 100vw;
-  overflow: hidden;
   box-sizing: border-box;
+  position: relative;
+  z-index: 20;
 }
 
 .common-header-left {

--- a/frontend/src/styles/editMode.css
+++ b/frontend/src/styles/editMode.css
@@ -5,6 +5,8 @@
   padding: 6px 8px;
   background: #f8f9fa;
   border-bottom: 1px solid #dee2e6;
+  min-width: 0;
+  flex-wrap: wrap;
 }
 
 .edit-mode-toolbar--locked {
@@ -27,6 +29,67 @@
   font-size: 0.875rem;
   color: #842029;
   font-weight: 500;
+}
+
+.edit-mode-btn {
+  min-height: 30px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  border: 1px solid #cbd5e1;
+  border-radius: 7px;
+  background: #fff;
+  color: #334155;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+  font-size: 0.8rem;
+  font-weight: 650;
+  line-height: 1.2;
+  padding: 5px 10px;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: border-color 0.14s, background-color 0.14s, color 0.14s, box-shadow 0.14s, filter 0.14s;
+}
+
+.edit-mode-btn:hover:not(:disabled) {
+  border-color: #2563eb;
+  background: #eaf1ff;
+  color: #1d4ed8;
+}
+
+.edit-mode-btn:disabled {
+  opacity: 0.58;
+  cursor: not-allowed;
+}
+
+.edit-mode-btn-primary {
+  border-color: #2563eb;
+  background: #2563eb;
+  color: #fff;
+}
+
+.edit-mode-btn-success {
+  border-color: #16a34a;
+  background: #16a34a;
+  color: #fff;
+}
+
+.edit-mode-btn-warning {
+  border-color: #d97706;
+  background: #f59e0b;
+  color: #111827;
+}
+
+.edit-mode-btn-primary:hover:not(:disabled),
+.edit-mode-btn-success:hover:not(:disabled) {
+  filter: brightness(0.96);
+  color: #fff;
+}
+
+.edit-mode-btn-warning:hover:not(:disabled) {
+  border-color: #b45309;
+  background: #fbbf24;
+  color: #111827;
 }
 
 .readonly-mode input,

--- a/frontend/src/styles/editorHeader.css
+++ b/frontend/src/styles/editorHeader.css
@@ -11,6 +11,7 @@
   min-height: 48px;
   padding: 0 16px;
   gap: 16px;
+  min-width: 0;
   flex-shrink: 0;
   border-bottom: 1px solid;
   box-sizing: border-box;
@@ -47,6 +48,11 @@
   display: flex;
   align-items: center;
   gap: 8px;
+  min-width: 0;
+}
+
+.editor-header :where(.btn, button) {
+  white-space: nowrap;
 }
 
 /* ── Back button ─────────────────────────── */
@@ -155,4 +161,34 @@
 .editor-header-dark .editor-header-undo-btn:hover:not(:disabled) {
   background: var(--dz-bg-3, #30334a);
   border-color: var(--dz-border, #3b3e55);
+}
+
+@media (max-width: 640px) {
+  .editor-header {
+    align-items: flex-start;
+    flex-wrap: wrap;
+    gap: 8px 12px;
+    height: auto;
+    padding: 8px 12px;
+  }
+
+  .editor-header-left {
+    flex: 1 1 100%;
+  }
+
+  .editor-header-right {
+    flex: 1 1 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .editor-header-center {
+    order: 3;
+    flex: 1 1 100%;
+    justify-content: flex-start;
+  }
+
+  .editor-header-extra {
+    flex-wrap: wrap;
+  }
 }

--- a/frontend/src/styles/flow.css
+++ b/frontend/src/styles/flow.css
@@ -663,6 +663,8 @@
   display: flex;
   align-items: center;
   gap: 12px;
+  min-width: 0;
+  flex-wrap: wrap;
 }
 
 .screen-table-search {
@@ -675,6 +677,7 @@
   gap: 6px;
   flex: 1;
   max-width: 400px;
+  min-width: 180px;
 }
 
 .screen-table-search i {
@@ -842,6 +845,27 @@
 .screen-table-actions {
   display: flex;
   gap: 4px;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 640px) {
+  .screen-table-view {
+    padding: 12px;
+  }
+
+  .screen-table-toolbar {
+    align-items: stretch;
+  }
+
+  .screen-table-search {
+    flex: 1 1 100%;
+    max-width: none;
+    min-width: 0;
+  }
+
+  .screen-table-count {
+    order: 3;
+  }
 }
 
 .screen-table-btn {

--- a/frontend/src/styles/processFlow.css
+++ b/frontend/src/styles/processFlow.css
@@ -23,6 +23,8 @@
   justify-content: space-between;
   align-items: center;
   margin-bottom: 16px;
+  gap: 12px;
+  min-width: 0;
 }
 
 .process-flow-list-header h5 {
@@ -35,11 +37,13 @@
   gap: 8px;
   margin-bottom: 16px;
   flex-wrap: wrap;
+  min-width: 0;
 }
 
 .process-flow-list-filters .btn {
   font-size: 0.82rem;
   padding: 4px 12px;
+  white-space: nowrap;
 }
 
 .process-flow-list-filters .btn.active {
@@ -51,6 +55,9 @@
   display: flex;
   align-items: center;
   gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  min-width: 0;
 }
 
 /* ─── 種別バッジ (list/table 共通) ────────────────────────────────── */
@@ -155,6 +162,7 @@
   color: #475569;
   cursor: pointer;
   user-select: none;
+  white-space: nowrap;
 }
 
 /* ─── 処理フロー編集 ─────────────────────────────────────────────── */
@@ -720,7 +728,6 @@
 }
 
 .process-flow-page .editor-header .btn,
-.process-flow-page .edit-mode-toolbar .btn,
 .process-flow-page .save-reset-buttons .btn,
 .process-flow-page .edit-session-dropdown-toggle {
   min-height: 30px;
@@ -740,7 +747,6 @@
 }
 
 .process-flow-page .editor-header .btn:hover,
-.process-flow-page .edit-mode-toolbar .btn:hover,
 .process-flow-page .save-reset-buttons .btn:hover,
 .process-flow-page .edit-session-dropdown-toggle:hover {
   border-color: #2563eb;
@@ -749,14 +755,12 @@
 }
 
 .process-flow-page .editor-header .btn-primary,
-.process-flow-page .edit-mode-toolbar .btn-primary,
 .process-flow-page .save-reset-buttons .btn-primary {
   border-color: #2563eb;
   background: #2563eb;
   color: #fff;
 }
 
-.process-flow-page .edit-mode-toolbar .btn-success,
 .process-flow-page .save-reset-buttons .btn-success {
   border-color: #16a34a;
   background: #16a34a;
@@ -764,12 +768,30 @@
 }
 
 .process-flow-page .editor-header .btn-primary:hover,
-.process-flow-page .edit-mode-toolbar .btn-primary:hover,
 .process-flow-page .save-reset-buttons .btn-primary:hover,
-.process-flow-page .edit-mode-toolbar .btn-success:hover,
 .process-flow-page .save-reset-buttons .btn-success:hover {
   filter: brightness(0.96);
   color: #fff;
+}
+
+@media (max-width: 640px) {
+  .process-flow-content {
+    padding: 12px;
+  }
+
+  .process-flow-list-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .process-flow-list-header-right {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .process-flow-list-filter-sep {
+    display: none;
+  }
 }
 
 .process-flow-page .edit-mode-toolbar--editing::before {

--- a/frontend/src/styles/screen-items.css
+++ b/frontend/src/styles/screen-items.css
@@ -12,8 +12,9 @@
 
 .screen-items-content {
   flex: 1;
-  overflow-y: auto;
+  overflow: auto;
   padding: 8px 14px;
+  min-width: 0;
 }
 
 .screen-items-empty {
@@ -27,25 +28,27 @@
   border: 1px solid #e2e8f0;
   border-radius: 6px;
   padding: 8px;
+  overflow-x: auto;
 }
 
 .screen-items-table {
   width: 100%;
+  min-width: 1280px;
   table-layout: fixed;
   border-collapse: collapse;
 }
 
 .screen-items-table thead th {
-  font-size: 0.7rem;
+  font-size: 0.72rem;
   font-weight: 600;
   color: #64748b;
-  padding: 4px 6px;
+  padding: 7px 8px;
   border-bottom: 1px solid #cbd5e1;
   text-align: left;
 }
 
 .screen-items-table tbody td {
-  padding: 3px 6px;
+  padding: 6px 8px;
   vertical-align: middle;
   border-bottom: 1px solid #f1f5f9;
 }
@@ -56,11 +59,10 @@
 
 .screen-items-table input.form-control {
   width: 100%;
-  padding: 2px 6px;
-  font-size: 0.8rem;
+  padding: 4px 8px;
+  font-size: 0.82rem;
   min-width: 0;
-  min-height: 26px;
-  height: 28px;
+  min-height: 30px;
 }
 
 .screen-items-no {
@@ -77,7 +79,16 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 2px;
+  gap: 4px;
+}
+
+.screen-items-actions-cell .btn {
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 5px;
 }
 
 .screen-items-empty-row {
@@ -93,9 +104,11 @@
   gap: 8px;
   margin-top: 8px;
   flex-wrap: wrap;
+  align-items: center;
 }
 .screen-items-add {
   font-size: 0.82rem;
+  white-space: nowrap;
 }
 .screen-items-screen-select {
   min-width: 14em;
@@ -178,7 +191,7 @@
   display: flex;
   flex-direction: column;
   gap: 2px;
-  min-width: 13em;
+  min-width: min(100%, 16em);
   flex: 1;
 }
 .screen-items-detail-label {
@@ -214,7 +227,7 @@
   display: flex;
   flex-direction: column;
   gap: 2px;
-  min-width: 14em;
+  min-width: min(100%, 16em);
   flex: 1;
 }
 .screen-items-event-label {

--- a/frontend/src/styles/screenList.css
+++ b/frontend/src/styles/screenList.css
@@ -20,6 +20,7 @@
   justify-content: space-between;
   gap: 12px;
   flex-wrap: wrap;
+  min-width: 0;
 }
 
 .screen-list-title {
@@ -44,12 +45,16 @@
   display: flex;
   align-items: center;
   gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  min-width: 0;
 }
 
 .screen-list-search {
   position: relative;
   display: flex;
   align-items: center;
+  min-width: 0;
 }
 
 .screen-list-search > i {
@@ -189,4 +194,38 @@
   font-size: 12px;
   color: #64748b;
   font-variant-numeric: tabular-nums;
+}
+
+@media (max-width: 640px) {
+  .screen-list-page {
+    padding: 12px;
+  }
+
+  .screen-list-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .screen-list-header-tools {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .screen-list-search {
+    flex: 1 1 100%;
+    width: 100%;
+  }
+
+  .screen-list-search input {
+    min-width: 0;
+    width: 100%;
+  }
+
+  .screen-list-header-tools .flow-btn {
+    white-space: nowrap;
+  }
+
+  .screen-list-saveline-sep {
+    display: none;
+  }
 }

--- a/frontend/src/styles/tabbar.css
+++ b/frontend/src/styles/tabbar.css
@@ -15,6 +15,8 @@
   overflow: hidden;
   flex-shrink: 0;
   user-select: none;
+  min-width: 0;
+  position: relative;
 }
 
 .tabbar-list {
@@ -23,7 +25,9 @@
   flex: 1 1 auto;
   overflow-x: auto;
   overflow-y: hidden;
+  min-width: 0;
   scrollbar-width: none;
+  scroll-behavior: smooth;
 }
 .tabbar-list::-webkit-scrollbar {
   display: none;
@@ -136,6 +140,45 @@
 .tabbar-overflow-btn:hover {
   background-color: var(--dz-bg-2);
   color: var(--dz-text);
+}
+
+.tabbar-scroll-btn {
+  width: 28px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  border: 0;
+  background: var(--dz-bg-2);
+  color: var(--dz-text);
+  cursor: pointer;
+  box-shadow: 0 0 12px rgba(0, 0, 0, 0.24);
+  z-index: 1;
+}
+
+.tabbar-scroll-btn:hover {
+  background: var(--dz-bg-3);
+}
+
+.tabbar-scroll-btn-left {
+  border-right: 1px solid var(--dz-border);
+}
+
+.tabbar-scroll-btn-right {
+  border-left: 1px solid var(--dz-border);
+}
+
+.tabbar-can-scroll-left .tabbar-list {
+  mask-image: linear-gradient(to right, transparent 0, #000 24px, #000 100%);
+}
+
+.tabbar-can-scroll-right .tabbar-list {
+  mask-image: linear-gradient(to right, #000 0, #000 calc(100% - 24px), transparent 100%);
+}
+
+.tabbar-can-scroll-left.tabbar-can-scroll-right .tabbar-list {
+  mask-image: linear-gradient(to right, transparent 0, #000 24px, #000 calc(100% - 24px), transparent 100%);
 }
 
 /* Drag ghost */

--- a/frontend/src/styles/table.css
+++ b/frontend/src/styles/table.css
@@ -62,6 +62,8 @@
   align-items: center;
   justify-content: space-between;
   margin-bottom: 24px;
+  gap: 12px;
+  min-width: 0;
 }
 
 .table-list-title {
@@ -87,6 +89,9 @@
 .table-list-actions {
   display: flex;
   gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  min-width: 0;
 }
 
 /* ── テーブル一覧 検索ボックス ───────────────────────────────────── */
@@ -95,6 +100,7 @@
   position: relative;
   display: flex;
   align-items: center;
+  min-width: 0;
 }
 
 .table-list-search > i {
@@ -118,6 +124,28 @@
 
 .table-list-search input:focus {
   border-color: #7c6bff;
+}
+
+@media (max-width: 640px) {
+  .table-list-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .table-list-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .table-list-search {
+    flex: 1 1 100%;
+    width: 100%;
+  }
+
+  .table-list-search input {
+    min-width: 0;
+    width: 100%;
+  }
 }
 
 .table-list-search .clear-btn {


### PR DESCRIPTION
## Summary

Closes #1446

- Harden common header flex sizing so mobile width does not push the right-side AI/user controls outside the viewport.
- Add tabbar overflow affordance with left/right scroll buttons and active-tab scrollIntoView behavior.
- Normalize EditModeToolbar button styling with dedicated classes instead of Bootstrap parent overrides.
- Improve responsive wrapping for list toolbars across screen/table/process-flow list views.
- Improve screen-items readability and touch targets with a wider internal table scroller and action column, plus mobile EditorHeader wrapping.

## Verification

- `npm run build --workspace=frontend`
- Playwright smoke on `http://127.0.0.1:5183/` with existing backend `:5179`:
  - 390x844: dashboard, screen list, process-flow list, screen-items
  - 1440x900: screen-items
  - Result: console errors 0, `document.documentElement.scrollWidth <= innerWidth` for all checked routes
- Tab overflow smoke at 390x844 with 8 open tabs: left/right scroll buttons visible, document horizontal overflow false
- `git diff origin/main..HEAD -- schemas/` returns no schema changes

## Screenshots

Smoke screenshots were written under `.tmp/screenshots/issue-1446/` in the worktree for local review.