### PR TITLE
fix: isolate PageLayout Designer from screen-only paths (#1459)

### DIFF
--- a/backend/src/aiRename.test.ts
+++ b/backend/src/aiRename.test.ts
@@ -11,7 +11,7 @@
 
 import { describe, it, expect, vi } from "vitest";
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { handlePropose } from "./aiRename.js";
+import { handleAuthCheck, handlePropose } from "./aiRename.js";
 
 vi.mock("node:child_process", () => ({
   execFileSync: vi.fn(() => { throw new Error("not authenticated in unit test"); }),
@@ -122,5 +122,18 @@ describe("handlePropose — screenId validation (I-7 Round 8 B)", () => {
     const res = makeRes();
     await handlePropose(req, res);
     expect(res._status).toBe(403);
+  });
+});
+
+describe("handleAuthCheck — status endpoint semantics (#1459)", () => {
+  it("未認証でも 200 + authenticated:false を返す", async () => {
+    const req = makeReq({
+      method: "GET",
+      origin: "http://localhost:5173",
+    });
+    const res = makeRes();
+    await handleAuthCheck(req, res);
+    expect(res._status).toBe(200);
+    expect(JSON.parse(res._body ?? "{}")).toMatchObject({ authenticated: false });
   });
 });

--- a/backend/src/aiRename.ts
+++ b/backend/src/aiRename.ts
@@ -88,7 +88,7 @@ export async function handleAuthCheck(req: IncomingMessage, res: ServerResponse)
   }
 
   const authenticated = checkAuth();
-  jsonBody(res, authenticated ? 200 : 503, {
+  jsonBody(res, 200, {
     authenticated,
     message: authenticated
       ? "claude CLI に認証されています"

--- a/frontend/src/components/Designer.tsx
+++ b/frontend/src/components/Designer.tsx
@@ -19,7 +19,7 @@ import { useEditSession } from "../hooks/useEditSession";
 import { useSessionUrlSync } from "../hooks/useSessionUrlSync";
 import { PuckBackend } from "../editor/PuckBackend";
 import { GrapesJSBackend } from "../editor/GrapesJSBackend";
-import type { EditorApi, EditorState } from "../editor/EditorBackend";
+import type { DesignerResourceKind, EditorApi, EditorState } from "../editor/EditorBackend";
 import { DESIGNER_REFERENCE_RELOAD_EVENTS, isReloadBroadcast, shouldNotifyScreenChanged } from "../editor/reloadEvents";
 // #1388 sub-section A 派生 2 件 (Option 1): renderEditor 呼び出しと props 構築を host に隔離して
 // react-hooks/refs (Designer scope 内 ref 含む closure が props 経由で渡される) を解消。
@@ -49,6 +49,7 @@ export type ThemeId = "standard" | "card" | "compact" | "dark";
 
 export interface DesignerProps {
   screenId: string;
+  resourceKind?: DesignerResourceKind;
   screenName?: string;
   editSessionResourceType?: DesignerDraftResourceType;
   editSessionResourceId?: string;
@@ -90,6 +91,7 @@ export interface DesignerProps {
 
 export function Designer({
   screenId,
+  resourceKind = "screen",
   screenName,
   editSessionResourceType,
   editSessionResourceId,
@@ -109,6 +111,7 @@ export function Designer({
   pageLayoutCss,
   gadgetCssMap,
 }: DesignerProps) {
+  const isScreenResource = resourceKind === "screen";
   const [isDirty, setIsDirtyState] = useState(false);
   // RFC #1021 pl-6 (Codex C-1): GrapesJS editor の生インスタンス参照 / composition preview modal の表示状態は
   // #1388 sub-section A 派生 2 件で GrapesEditorHost 内に移動。Designer scope では保持しない。
@@ -177,7 +180,7 @@ export function Designer({
   const { wsPath, wsId } = useWorkspacePath();
   const [showRenameDialog, setShowRenameDialog] = useState(false);
   // Phase M Codex SF-1 (#1298 round 8): wsId scoped key で workspace 切替時の metadata 混在を防ぐ
-  const [renameUndoToast, setRenameUndoToast] = useRenameEntityUndoToast("screen", screenId, wsId);
+  const [renameUndoToast, setRenameUndoToast] = useRenameEntityUndoToast("screen", isScreenResource ? screenId : undefined, wsId);
   const [allScreenIds, setAllScreenIds] = useState<string[]>([]);
   const [gadgetBlocks, setGadgetBlocks] = useState<GadgetBlockScreen[]>([]);
   const reloadDesignerProjectMetadata = useCallback(async () => {
@@ -333,7 +336,7 @@ export function Designer({
     }
     Promise.all([
       loadRawProject(),
-      loadScreenEntity(screenId),
+      isScreenResource ? loadScreenEntity(screenId) : Promise.resolve({ design: undefined }),
     ]).then(([raw, screen]) => {
       if (cancelled) return;
       const fw = resolveCssFramework(screen.design, raw.techStack);
@@ -352,7 +355,7 @@ export function Designer({
       if (!cancelled) setEditorKindResolved(true);
     });
     return () => { cancelled = true; };
-  }, [designCssFramework, designEditorKind, editSessionResourceType, screenId]);
+  }, [designCssFramework, designEditorKind, editSessionResourceType, isScreenResource, screenId]);
 
   // cssFrameworkRef を cssFramework state と同期 (onReady closure から参照するため)
   useEffect(() => {
@@ -483,8 +486,8 @@ export function Designer({
     editorApiRef.current = api;
     // 初期 theme 適用 (multi-editor-puck.md § 3 — Backend onReady 後に Designer.tsx が theme を当てる)
     api.applyTheme(activeTheme, cssFrameworkRef.current);
-    // localStorage 救済チェック (mount 1 回のみ)
-    if (!legacyRescueCheckedRef.current) {
+    // localStorage 救済チェック (mount 1 回のみ、screen resource のみ)
+    if (isScreenResource && !legacyRescueCheckedRef.current) {
       legacyRescueCheckedRef.current = true;
       checkLegacyLocalStorage(screenId).then((result) => {
         if (result.hasLegacy) {
@@ -493,7 +496,7 @@ export function Designer({
         }
       }).catch(console.error);
     }
-  }, [activeTheme, screenId]);
+  }, [activeTheme, isScreenResource, screenId]);
 
   // GrapesJS の screenChanged broadcast 受信通知 — dirty 中はバナー、clean なら即時 reload
   const handleGrapesServerChanged = useCallback(() => {
@@ -538,10 +541,10 @@ export function Designer({
     isDirtyRef.current = false;
     setDirty(tabId, false);
     setServerChanged(false);
-    await acknowledgeServerMtime("screen", screenId);
+    if (isScreenResource) await acknowledgeServerMtime("screen", screenId);
     // サムネイル生成 (GrapesJS のみ — Puck は API.captureThumbnail() が null を返す)
     const api = editorApiRef.current;
-    if (api && !api.isCanvasEmpty()) {
+    if (isScreenResource && api && !api.isCanvasEmpty()) {
       api.captureThumbnail().then(async (thumbnail) => {
         if (!thumbnail) return;
         try {
@@ -552,7 +555,7 @@ export function Designer({
         }
       });
     }
-  }, [screenId, tabId]);
+  }, [isScreenResource, screenId, tabId]);
 
   /** 保存: 保留中の debounce を flush してから editSession.save */
   const handleSave = useCallback(async () => {
@@ -613,7 +616,7 @@ export function Designer({
       isDirtyRef.current = false;
       setDirty(tabId, false);
       setServerChanged(false);
-      await acknowledgeServerMtime("screen", screenId);
+      if (isScreenResource) await acknowledgeServerMtime("screen", screenId);
     } catch (e) {
       console.error("[Designer] discard failed:", e);
       showError({
@@ -622,7 +625,7 @@ export function Designer({
         context: { screenId, tabId },
       });
     }
-  }, [screenId, tabId, editActions, showError]);
+  }, [isScreenResource, screenId, tabId, editActions, showError]);
 
   const handleForceRelease = useCallback(async () => {
     setShowForceReleaseDialog(false);
@@ -650,11 +653,11 @@ export function Designer({
       isDirtyRef.current = false;
       setDirty(tabId, false);
       setServerChanged(false);
-      await acknowledgeServerMtime("screen", screenId);
+      if (isScreenResource) await acknowledgeServerMtime("screen", screenId);
     } catch (e) {
       console.error("[Designer] server change reload failed:", e);
     }
-  }, [screenId, tabId]);
+  }, [isScreenResource, screenId, tabId]);
 
   // localStorage 救済: 採用
   const handleLegacyRescueAdopt = useCallback(async () => {
@@ -852,7 +855,7 @@ export function Designer({
       unsubScreenChanged();
       unsubReloadEvents.forEach((fn) => fn());
     };
-  }, [editorKind, screenId]);
+  }, [editorKind, isScreenResource, screenId]);
 
   // ---------------------------------------------------------------------------
   // 共通ダイアログ群 (GrapesJS / Puck 両方で使う)
@@ -920,7 +923,7 @@ export function Designer({
         onClose: () => setShowAiGenerateDialog(false),
       }}
       rename={{
-        show: showRenameDialog,
+        show: isScreenResource && showRenameDialog,
         screenId,
         screenName,
         allScreenIds,
@@ -991,6 +994,7 @@ export function Designer({
         isReadonly={isReadonly}
         panelMode={panelMode}
         screenId={screenId}
+        resourceKind={resourceKind}
         screenName={screenName}
         mcpStatus={mcpStatus}
         isDirty={isDirty}
@@ -1009,7 +1013,7 @@ export function Designer({
         onViewerAttached={syncSessionToUrl}
         onAttachAsView={editAttach}
         onTakeOver={editTakeOver}
-        onOpenRenameDialog={() => setShowRenameDialog(true)}
+        onOpenRenameDialog={isScreenResource ? () => setShowRenameDialog(true) : undefined}
         onChange={handlePuckChange}
         onReady={handlePuckReady}
         reloadPayload={puckReloadPayload}
@@ -1044,6 +1048,7 @@ export function Designer({
       isReadonly={isReadonly}
       panelMode={panelMode}
       screenId={screenId}
+      resourceKind={resourceKind}
       screenName={screenName}
       mcpStatus={mcpStatus}
       isDirty={isDirty}
@@ -1062,7 +1067,7 @@ export function Designer({
       onViewerAttached={syncSessionToUrl}
       onAttachAsView={editAttach}
       onTakeOver={editTakeOver}
-      onOpenRenameDialog={() => setShowRenameDialog(true)}
+      onOpenRenameDialog={isScreenResource ? () => setShowRenameDialog(true) : undefined}
       onChange={handleGrapesChange}
       onReady={handleGrapesReady}
       onServerChanged={handleGrapesServerChanged}

--- a/frontend/src/components/design/DesignSubToolbar.test.tsx
+++ b/frontend/src/components/design/DesignSubToolbar.test.tsx
@@ -60,6 +60,22 @@ const baseProps = {
 };
 
 describe("DesignSubToolbar — editor prop 化 refactor (#824)", () => {
+  it("enableScreenRename=false では auth-check を呼ばず AI rename UI も出さない", () => {
+    render(
+      <DesignSubToolbar
+        {...baseProps}
+        mcpStatus="connected"
+        screenId="page-layout:main-layout"
+        enableScreenRename={false}
+        editor={undefined}
+      />,
+    );
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(screen.queryByTitle("ID を AI で再命名")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("rename-entity-open-btn-screen")).not.toBeInTheDocument();
+  });
+
   it("editor=undefined (Puck 経路) — Provider 不在環境で crash せず render される", () => {
     // 旧実装は <GjsEditor> ancestor 不在で useEditorMaybe が throw → useEditorOptional が catch
     // 新実装は editor prop で受けるので Provider 不要、かつ try/catch 不要

--- a/frontend/src/components/design/DesignSubToolbar.tsx
+++ b/frontend/src/components/design/DesignSubToolbar.tsx
@@ -64,6 +64,8 @@ interface Props {
   onReset?: () => Promise<void>;
   onAiGenerate?: () => void;
   screenId?: string;
+  /** screen 専用の AI rename / id rename UI を有効にする。PageLayout Designer では false。 */
+  enableScreenRename?: boolean;
   /** 読み取り専用モードの場合 true — 保存/リセットボタンを非表示にする */
   isReadonly?: boolean;
   /**
@@ -102,7 +104,7 @@ interface Props {
   onOpenRenameDialog?: () => void;
 }
 
-export function DesignSubToolbar({ panelMode, onOpenPanel, activeTheme, onThemeChange, mcpStatus, backLink, isDirty, isSaving, onSaveToFile, onReset, onAiGenerate, screenId, isReadonly, editor, sessionMode, sessionId, onStartEditing, onViewerAttached, onAttachAsView, onTakeOver, onOpenRenameDialog }: Props) {
+export function DesignSubToolbar({ panelMode, onOpenPanel, activeTheme, onThemeChange, mcpStatus, backLink, isDirty, isSaving, onSaveToFile, onReset, onAiGenerate, screenId, enableScreenRename = true, isReadonly, editor, sessionMode, sessionId, onStartEditing, onViewerAttached, onAttachAsView, onTakeOver, onOpenRenameDialog }: Props) {
   const [themeMenuOpen, setThemeMenuOpen] = useState(false);
 
   // ── AI 命名 (#337) ───────────────────────────────────────────────────────
@@ -116,15 +118,16 @@ export function DesignSubToolbar({ panelMode, onOpenPanel, activeTheme, onThemeC
 
   // auth-check: MCP 接続時に 1 回だけ実行
   useEffect(() => {
-    if (mcpStatus !== "connected" || !screenId) return;
+    if (!enableScreenRename || mcpStatus !== "connected" || !screenId) return;
     fetch(`${MCP_HTTP_BASE}/ai/rename-screen-ids/auth-check`)
       .then((r) => r.json())
       .then((d: unknown) => { setAiRenameAuthOk((d as { authenticated: boolean }).authenticated); })
       .catch(() => { setAiRenameAuthOk(false); });
-  }, [mcpStatus, screenId]);
+  }, [enableScreenRename, mcpStatus, screenId]);
 
   // aiRenameProgress イベントを購読（セッション ID が一致するイベントのみ処理）
   useEffect(() => {
+    if (!enableScreenRename) return;
     const unsub = mcpBridge.onBroadcast("aiRenameProgress", (data) => {
       const ev = data as AiRenameProgress & { sessionId?: string };
       if (ev.sessionId && ev.sessionId !== aiRenameSessionRef.current) return;
@@ -134,7 +137,7 @@ export function DesignSubToolbar({ panelMode, onOpenPanel, activeTheme, onThemeC
       }
     });
     return unsub;
-  }, []);
+  }, [enableScreenRename]);
 
   useEffect(() => () => { if (toastTimerRef.current) clearTimeout(toastTimerRef.current); }, []);
 
@@ -145,7 +148,7 @@ export function DesignSubToolbar({ panelMode, onOpenPanel, activeTheme, onThemeC
   }, []);
 
   const handleAiRename = useCallback(async () => {
-    if (!screenId) return;
+    if (!enableScreenRename || !screenId) return;
     const sessionId = generateUUID();
     aiRenameSessionRef.current = sessionId;
     const abort = new AbortController();
@@ -168,7 +171,7 @@ export function DesignSubToolbar({ panelMode, onOpenPanel, activeTheme, onThemeC
         setAiRenameProgress({ stage: "error", message: "通信エラー", error: String(e) });
       }
     }
-  }, [screenId]);
+  }, [enableScreenRename, screenId]);
 
   const handleAiRenameCancel = useCallback(() => {
     aiRenameSessionRef.current = null;
@@ -178,7 +181,7 @@ export function DesignSubToolbar({ panelMode, onOpenPanel, activeTheme, onThemeC
   }, []);
 
   const handleAiRenameApply = useCallback(async () => {
-    if (!screenId || !aiRenameMapping) return;
+    if (!enableScreenRename || !screenId || !aiRenameMapping) return;
     const entries = Object.entries(aiRenameMapping);
     if (entries.length === 0) {
       setAiRenameProgress(null);
@@ -201,7 +204,7 @@ export function DesignSubToolbar({ panelMode, onOpenPanel, activeTheme, onThemeC
     setAiRenameMapping(null);
     setTimeout(() => setAiRenameProgress(null), 800);
     showToast(`リネーム完了: 成功 ${succeeded} 件、失敗 ${failed} 件`, failed > 0);
-  }, [screenId, aiRenameMapping, showToast]);
+  }, [enableScreenRename, screenId, aiRenameMapping, showToast]);
   const [saveState, setSaveState] = useState<"idle" | "saving" | "saved">("idle");
   const [canUndo, setCanUndo] = useState(false);
   const [canRedo, setCanRedo] = useState(false);
@@ -440,22 +443,24 @@ ${html}
                     <i className="bi bi-magic" />
                   </button>
                 )}
-                <button
-                  className="icon-btn"
-                  onClick={() => { void handleAiRename(); }}
-                  disabled={!aiRenameAuthOk || aiRenameProgress !== null}
-                  title={
-                    aiRenameAuthOk === false
-                      ? "claude CLI が未認証です (claude login を実行してください)"
-                      : aiRenameAuthOk === null
-                      ? "認証を確認中..."
-                      : "ID を AI で再命名"
-                  }
-                >
-                  <i className="bi bi-stars" />
-                </button>
+                {enableScreenRename && (
+                  <button
+                    className="icon-btn"
+                    onClick={() => { void handleAiRename(); }}
+                    disabled={!aiRenameAuthOk || aiRenameProgress !== null}
+                    title={
+                      aiRenameAuthOk === false
+                        ? "claude CLI が未認証です (claude login を実行してください)"
+                        : aiRenameAuthOk === null
+                        ? "認証を確認中..."
+                        : "ID を AI で再命名"
+                    }
+                  >
+                    <i className="bi bi-stars" />
+                  </button>
+                )}
                 {/* #1298 I-6 (RFC #1284): 画面 id 変更 (rename refactor) */}
-                {onOpenRenameDialog && (
+                {enableScreenRename && onOpenRenameDialog && (
                   <button
                     className="icon-btn"
                     onClick={onOpenRenameDialog}

--- a/frontend/src/components/designer/GrapesEditorHost.tsx
+++ b/frontend/src/components/designer/GrapesEditorHost.tsx
@@ -9,6 +9,7 @@ import type { ReactNode } from "react";
 import { DesignSubToolbarGrapesJSBridge } from "../design/DesignSubToolbar";
 import type { GrapesJSBackend } from "../../editor/GrapesJSBackend";
 import type {
+  DesignerResourceKind,
   EditorApi,
   EditorState,
   GrapesJSRenderEditorProps,
@@ -34,6 +35,7 @@ export interface GrapesEditorHostProps {
   isReadonly: boolean;
   panelMode: PanelMode;
   screenId: string;
+  resourceKind?: DesignerResourceKind;
   screenName?: string;
 
   mcpStatus: McpStatus;
@@ -58,7 +60,7 @@ export interface GrapesEditorHostProps {
   onViewerAttached: (editSessionId: string) => void;
   onAttachAsView: (editSessionId: string) => Promise<void>;
   onTakeOver: (editSessionId: string) => Promise<void>;
-  onOpenRenameDialog: () => void;
+  onOpenRenameDialog?: () => void;
 
   onChange: GrapesJSRenderEditorProps["onChange"];
   onReady: (api: EditorApi) => void;
@@ -115,6 +117,7 @@ export function GrapesEditorHost(props: GrapesEditorHostProps) {
       onAiGenerate={props.onAiGenerate}
       backLink={props.onBack ? { label: props.screenName ?? "画面デザイン", onClick: props.onBack } : undefined}
       screenId={props.screenId}
+      enableScreenRename={props.resourceKind !== "pageLayout"}
       isReadonly={props.isReadonly}
       sessionMode={props.sessionMode}
       sessionId={props.sessionId}
@@ -137,6 +140,7 @@ export function GrapesEditorHost(props: GrapesEditorHostProps) {
     onTogglePin: props.onTogglePin,
     onClosePanel: props.onClosePanel,
     screenId: props.screenId,
+    resourceKind: props.resourceKind,
     onChange: props.onChange,
     onReady: props.onReady,
     onServerChanged: props.onServerChanged,

--- a/frontend/src/components/designer/PuckEditorHost.tsx
+++ b/frontend/src/components/designer/PuckEditorHost.tsx
@@ -7,6 +7,7 @@ import type { ReactNode } from "react";
 import { DesignSubToolbar } from "../design/DesignSubToolbar";
 import type { PuckBackend } from "../../editor/PuckBackend";
 import type {
+  DesignerResourceKind,
   EditorApi,
   EditorState,
   PanelMode,
@@ -26,6 +27,7 @@ export interface PuckEditorHostProps {
   isReadonly: boolean;
   panelMode: PanelMode;
   screenId: string;
+  resourceKind?: DesignerResourceKind;
   screenName?: string;
 
   mcpStatus: McpStatus;
@@ -50,7 +52,7 @@ export interface PuckEditorHostProps {
   onViewerAttached: (editSessionId: string) => void;
   onAttachAsView: (editSessionId: string) => Promise<void>;
   onTakeOver: (editSessionId: string) => Promise<void>;
-  onOpenRenameDialog: () => void;
+  onOpenRenameDialog?: () => void;
 
   onChange: PuckRenderEditorProps["onChange"];
   onReady: (api: EditorApi) => void;
@@ -74,6 +76,7 @@ export function PuckEditorHost(props: PuckEditorHostProps) {
       onAiGenerate={props.onAiGenerate}
       backLink={props.onBack ? { label: props.screenName ?? "画面デザイン", onClick: props.onBack } : undefined}
       screenId={props.screenId}
+      enableScreenRename={props.resourceKind !== "pageLayout"}
       isReadonly={props.isReadonly}
       editor={undefined}
       sessionMode={props.sessionMode}
@@ -97,6 +100,7 @@ export function PuckEditorHost(props: PuckEditorHostProps) {
     onTogglePin: props.onTogglePin,
     onClosePanel: props.onClosePanel,
     screenId: props.screenId,
+    resourceKind: props.resourceKind,
     onChange: props.onChange,
     onReady: props.onReady,
     reloadPayload: props.reloadPayload,

--- a/frontend/src/components/page-layout/PageLayoutDesigner.test.tsx
+++ b/frontend/src/components/page-layout/PageLayoutDesigner.test.tsx
@@ -155,9 +155,10 @@ describe("PageLayoutDesigner", () => {
     renderDesigner();
 
     await waitFor(() => {
-      expect(mockState.designerProps).toMatchObject({
-        screenId: "page-layout:pl-design-001",
-        editSessionResourceType: "page-layout-design",
+	      expect(mockState.designerProps).toMatchObject({
+	        screenId: "page-layout:pl-design-001",
+	        resourceKind: "pageLayout",
+	        editSessionResourceType: "page-layout-design",
         editSessionResourceId: "pl-design-001",
         designEditorKind: "puck",
         designCssFramework: "bootstrap",

--- a/frontend/src/components/page-layout/PageLayoutDesigner.tsx
+++ b/frontend/src/components/page-layout/PageLayoutDesigner.tsx
@@ -233,6 +233,7 @@ export function PageLayoutDesigner() {
     return (
       <Designer
         screenId={`page-layout:${pageLayoutId}`}
+        resourceKind="pageLayout"
         screenName={pl.name}
         editSessionResourceType="page-layout-design"
         editSessionResourceId={pageLayoutId}
@@ -251,6 +252,7 @@ export function PageLayoutDesigner() {
     <RegionProvider value={regionContextValue}>
       <Designer
         screenId={`page-layout:${pageLayoutId}`}
+        resourceKind="pageLayout"
         screenName={pl.name}
         editSessionResourceType="page-layout-design"
         editSessionResourceId={pageLayoutId}

--- a/frontend/src/editor/EditorBackend.ts
+++ b/frontend/src/editor/EditorBackend.ts
@@ -17,6 +17,7 @@ import type { GadgetBlockScreen } from "../grapes/blocks";
 
 export type ThemeId = "standard" | "card" | "compact" | "dark";
 export type PanelMode = "pinned" | "autohide" | "hidden";
+export type DesignerResourceKind = "screen" | "pageLayout";
 
 /**
  * エディタの永続化状態。Backend 実装ごとの payload を保持する。
@@ -96,6 +97,8 @@ export interface RenderEditorBaseProps {
 
   /** 編集対象 screenId (RightPanel 等で利用) */
   screenId: string;
+  /** Designer の対象 resource 種別。screen 専用同期や rename UI の境界に使う。 */
+  resourceKind?: DesignerResourceKind;
 
   /** 編集中変更通知 — Backend は user 編集を検出したら呼ぶ */
   onChange?: (newState: EditorState) => void;

--- a/frontend/src/editor/GrapesJSBackend.tsx
+++ b/frontend/src/editor/GrapesJSBackend.tsx
@@ -36,6 +36,7 @@ import GjsEditor, {
 import html2canvas from "html2canvas";
 
 import type {
+  DesignerResourceKind,
   EditorApi,
   EditorBackend,
   EditorState,
@@ -295,6 +296,7 @@ async function captureThumbnail(editor: GEditor): Promise<string | null> {
  */
 interface GrapesJSEditorPaneProps {
   screenId: string;
+  resourceKind?: DesignerResourceKind;
   isReadonly: boolean;
   panelMode: PanelMode;
   cssFramework: CssFramework;
@@ -330,6 +332,7 @@ interface GrapesJSEditorPaneProps {
 function GrapesJSEditorPane(props: GrapesJSEditorPaneProps) {
   const {
     screenId,
+    resourceKind = "screen",
     isReadonly,
     panelMode,
     cssFramework,
@@ -348,6 +351,7 @@ function GrapesJSEditorPane(props: GrapesJSEditorPaneProps) {
     onGrapesEditorInstance,
     gadgetBlocks = [],
   } = props;
+  const isScreenResource = resourceKind === "screen";
 
   const editorRef = useRef<GEditor | null>(null);
   const gadgetBlocksRef = useRef(gadgetBlocks);
@@ -452,7 +456,9 @@ function GrapesJSEditorPane(props: GrapesJSEditorPaneProps) {
       const unsubDataItemId = attachDataItemIdAutoAssign(editor);
 
       // #358: canvas ↔ screen-items 双方向同期
-      const unsubScreenItemsSync = attachScreenItemsSync(editor, screenId, isInternalLoadRef);
+      const unsubScreenItemsSync = isScreenResource
+        ? attachScreenItemsSync(editor, screenId, isInternalLoadRef)
+        : (() => undefined);
 
       // mcpBridge 起動
       const unsubStatus = mcpBridge.onStatusChange((status) => {
@@ -461,7 +467,7 @@ function GrapesJSEditorPane(props: GrapesJSEditorPaneProps) {
       mcpBridge.setThemeHandler((themeId) => {
         onExternalThemeChangeRef.current?.(themeId as ThemeId);
       });
-      mcpBridge.setCurrentScreenId(screenId);
+      if (isScreenResource) mcpBridge.setCurrentScreenId(screenId);
       mcpBridge.start(editor);
 
       // 他タブ / 別クライアントの screenChanged broadcast 購読
@@ -472,13 +478,15 @@ function GrapesJSEditorPane(props: GrapesJSEditorPaneProps) {
       // - `reload: true` → 全件 invalidation シグナル (id filter より先に処理)
       // - `oldId === screenId` → 自身が rename された場合
       // - 通常の screenChanged → 旧 filter 条件
-      const unsubScreenChanged = mcpBridge.onBroadcast("screenChanged", (data) => {
-        if (shouldNotifyScreenChanged(data, screenId)) {
-          onServerChangedRef.current?.();
-          return;
-        }
-        scheduleGadgetPreviewSync();
-      });
+      const unsubScreenChanged = isScreenResource
+        ? mcpBridge.onBroadcast("screenChanged", (data) => {
+            if (shouldNotifyScreenChanged(data, screenId)) {
+              onServerChangedRef.current?.();
+              return;
+            }
+            scheduleGadgetPreviewSync();
+          })
+        : (() => undefined);
       const unsubProjectChanged = mcpBridge.onBroadcast("projectChanged", scheduleGadgetPreviewSync);
 
       return () => {
@@ -494,11 +502,11 @@ function GrapesJSEditorPane(props: GrapesJSEditorPaneProps) {
         unsubScreenChanged();
         unsubProjectChanged();
         mcpBridge.setThemeHandler(null);
-        mcpBridge.setCurrentScreenId(null);
-        clearItemsFromCache(screenId);
+        if (isScreenResource) mcpBridge.setCurrentScreenId(null);
+        if (isScreenResource) clearItemsFromCache(screenId);
       };
     },
-    [screenId],
+    [isScreenResource, screenId],
   );
 
   useEffect(() => {
@@ -529,7 +537,7 @@ function GrapesJSEditorPane(props: GrapesJSEditorPaneProps) {
       // 次のマクロタスクでガードを下げる (#131)。同タイミングで canvas ↔ screen-items 初回突合 (#358)。
       setTimeout(() => {
         isInternalLoadRef.current = false;
-        if (editorRef.current) reconcileScreenItems(editorRef.current, screenId);
+        if (isScreenResource && editorRef.current) reconcileScreenItems(editorRef.current, screenId);
       }, 0);
 
       // framework × variant の 2 軸 CSS を注入 (#793 子 5)
@@ -571,7 +579,7 @@ function GrapesJSEditorPane(props: GrapesJSEditorPaneProps) {
           } finally {
             setTimeout(() => {
               isInternalLoadRef.current = false;
-              if (editorRef.current) reconcileScreenItems(editorRef.current, screenId);
+              if (isScreenResource && editorRef.current) reconcileScreenItems(editorRef.current, screenId);
             }, 0);
           }
         },
@@ -594,7 +602,7 @@ function GrapesJSEditorPane(props: GrapesJSEditorPaneProps) {
           } finally {
             setTimeout(() => {
               isInternalLoadRef.current = false;
-              if (editorRef.current) reconcileScreenItems(editorRef.current, screenId);
+              if (isScreenResource && editorRef.current) reconcileScreenItems(editorRef.current, screenId);
             }, 0);
           }
         },
@@ -606,7 +614,7 @@ function GrapesJSEditorPane(props: GrapesJSEditorPaneProps) {
     }
   // initialPayload は mount 時点の値を使う (再 mount しないため依存に含めない)
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [screenId]);
+  }, [isScreenResource, screenId]);
 
   // canvas-empty 状態を追跡
   useEffect(() => {


### PR DESCRIPTION
## Summary

Closes #1459

- Add an explicit Designer resource kind (`screen` / `pageLayout`) and pass `resourceKind=\"pageLayout\"` from PageLayoutDesigner.
- Gate screen-only Designer/GrapesJS side effects so PageLayout pseudo ids do not reach screen-items sync, `setCurrentScreenId`, `screenChanged` handling, legacy localStorage rescue, thumbnail/mtime screen cleanup, or screen rename dialog state.
- Disable only screen rename/auth-check UI for PageLayout Designer while preserving the existing design toolbar surface.
- Change `GET /ai/rename-screen-ids/auth-check` to return `200 + authenticated:false` when Claude CLI is not authenticated; `POST /propose` still rejects unauthenticated calls.

## Verification

- `npm run build --workspace=frontend`
- `npm run test:unit --workspace=frontend -- DesignSubToolbar.test.tsx PageLayoutDesigner.test.tsx`
- `npm run lint --workspace=frontend` (passes with existing `Designer.tsx:330` warning)
- `npm run build --workspace=backend`
- `npm run test --workspace=backend -- aiRename.test.ts`
- `git diff --name-only -- schemas/` returned no schema changes