### PR TITLE
fix: gate Puck screenChanged handling for PageLayout Designer (#1459)

### DIFF
--- a/frontend/src/components/Designer.tsx
+++ b/frontend/src/components/Designer.tsx
@@ -20,7 +20,7 @@ import { useSessionUrlSync } from "../hooks/useSessionUrlSync";
 import { PuckBackend } from "../editor/PuckBackend";
 import { GrapesJSBackend } from "../editor/GrapesJSBackend";
 import type { DesignerResourceKind, EditorApi, EditorState } from "../editor/EditorBackend";
-import { DESIGNER_REFERENCE_RELOAD_EVENTS, isReloadBroadcast, shouldNotifyScreenChanged } from "../editor/reloadEvents";
+import { DESIGNER_REFERENCE_RELOAD_EVENTS, isReloadBroadcast, shouldNotifyDesignerScreenChanged } from "../editor/reloadEvents";
 // #1388 sub-section A 派生 2 件 (Option 1): renderEditor 呼び出しと props 構築を host に隔離して
 // react-hooks/refs (Designer scope 内 ref 含む closure が props 経由で渡される) を解消。
 import { PuckEditorHost } from "./designer/PuckEditorHost";
@@ -839,11 +839,13 @@ export function Designer({
         setServerChanged(true);
       }
     });
-    // screenChanged は rename payload (oldId / reload) も Puck path で扱う
-    const unsubScreenChanged = mcpBridge.onBroadcast("screenChanged", (data) => {
-      if (!shouldNotifyScreenChanged(data, screenId)) return;
-      setServerChanged(true);
-    });
+    // screenChanged は screen resource の rename / reload payload のみ Puck path で扱う。
+    const unsubScreenChanged = isScreenResource
+      ? mcpBridge.onBroadcast("screenChanged", (data) => {
+          if (!shouldNotifyDesignerScreenChanged(resourceKind, data, screenId)) return;
+          setServerChanged(true);
+        })
+      : (() => undefined);
     // 参照側 entity の reload:true broadcast を購読 (cache 無効化のみ、id filter なし)
     const unsubReloadEvents = DESIGNER_REFERENCE_RELOAD_EVENTS.map((ev) =>
       mcpBridge.onBroadcast(ev, (data) => {
@@ -855,7 +857,7 @@ export function Designer({
       unsubScreenChanged();
       unsubReloadEvents.forEach((fn) => fn());
     };
-  }, [editorKind, isScreenResource, screenId]);
+  }, [editorKind, isScreenResource, resourceKind, screenId]);
 
   // ---------------------------------------------------------------------------
   // 共通ダイアログ群 (GrapesJS / Puck 両方で使う)

--- a/frontend/src/editor/GrapesJSBackend.reload.test.ts
+++ b/frontend/src/editor/GrapesJSBackend.reload.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect } from "vitest";
 import {
   DESIGNER_REFERENCE_RELOAD_EVENTS,
   isReloadBroadcast,
+  shouldNotifyDesignerScreenChanged,
   shouldNotifyScreenChanged,
 } from "./reloadEvents";
 
@@ -65,5 +66,13 @@ describe("Designer Puck RELOAD_EVENTS filter (I-7 Round 8 C)", () => {
     expect(isReloadBroadcast({})).toBe(false);
     expect(isReloadBroadcast({ reload: false })).toBe(false);
     expect(isReloadBroadcast(undefined)).toBe(false);
+  });
+
+  it("PageLayout resource では screenChanged reload:true を無視する (#1459 review follow-up)", () => {
+    expect(shouldNotifyDesignerScreenChanged("pageLayout", { reload: true }, "page-layout:main-layout")).toBe(false);
+  });
+
+  it("Screen resource では screenChanged reload:true を扱う", () => {
+    expect(shouldNotifyDesignerScreenChanged("screen", { reload: true }, "user-list")).toBe(true);
   });
 });

--- a/frontend/src/editor/reloadEvents.ts
+++ b/frontend/src/editor/reloadEvents.ts
@@ -20,6 +20,14 @@ export function shouldNotifyScreenChanged(data: unknown, screenId: string): bool
   return d.screenId === screenId && !d.deleted;
 }
 
+export function shouldNotifyDesignerScreenChanged(
+  resourceKind: "screen" | "pageLayout",
+  data: unknown,
+  screenId: string,
+): boolean {
+  return resourceKind === "screen" && shouldNotifyScreenChanged(data, screenId);
+}
+
 export function isReloadBroadcast(data: unknown): boolean {
   return ((data ?? {}) as { reload?: boolean }).reload === true;
 }


### PR DESCRIPTION
## Summary

Follow-up for the review comment on #1460 / #1459.

- Gate Puck-path `screenChanged` handling so it only subscribes for real screen resources.
- Add `shouldNotifyDesignerScreenChanged()` to make the resource boundary explicit.
- Add regression coverage that `resourceKind=pageLayout` ignores `screenChanged { reload:true }`, while real screens still handle it.

## Verification

- `npm run test:unit --workspace=frontend -- GrapesJSBackend.reload.test.ts`
- `npm run build --workspace=frontend`
- `npm run lint --workspace=frontend` (passes with existing `Designer.tsx:330` warning)
- `git diff --name-only -- schemas/` returned no schema changes

Refs #1459