### PR TITLE
fix: make mcpBridge start idempotent

### DIFF
--- a/frontend/src/mcp/mcpBridge.status.test.ts
+++ b/frontend/src/mcp/mcpBridge.status.test.ts
@@ -38,11 +38,13 @@ class FakeWebSocket extends EventTarget {
   static CONNECTING = 0;
   static CLOSING = 2;
   static CLOSED = 3;
+  static instances: FakeWebSocket[] = [];
 
   readyState: number = FakeWebSocket.CONNECTING;
 
   constructor(_url: string) {
     super();
+    FakeWebSocket.instances.push(this);
   }
 
   send(_data: string): void {}
@@ -57,6 +59,7 @@ class FakeWebSocket extends EventTarget {
 const originalWebSocket = globalThis.WebSocket;
 
 beforeEach(() => {
+  FakeWebSocket.instances = [];
   // @ts-expect-error test stub
   globalThis.WebSocket = FakeWebSocket;
 
@@ -146,5 +149,36 @@ describe("McpStatus 状態遷移ロジック (#795-C)", () => {
     bridge.startWithoutEditor(); // no-op
     expect(bridge.getConnectAttempts()).toBe(countAfterFirst);
     expect(bridge.getStatus()).toBe("connecting");
+  });
+
+  it("connecting 中に start(editor) を再呼び出ししても connectAttempts は増えない", async () => {
+    const bridge = await getFreshBridge();
+    const editor = {} as Parameters<typeof bridge.start>[0];
+
+    bridge.start(editor);
+    const countAfterFirst = bridge.getConnectAttempts();
+
+    bridge.start({} as Parameters<typeof bridge.start>[0]);
+
+    expect(bridge.getConnectAttempts()).toBe(countAfterFirst);
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(bridge.getStatus()).toBe("connecting");
+  });
+
+  it("open 済みの start(editor) 再呼び出しでも connectAttempts は増えない", async () => {
+    const bridge = await getFreshBridge();
+    const editor = {} as Parameters<typeof bridge.start>[0];
+
+    bridge.start(editor);
+    const ws = FakeWebSocket.instances[0];
+    ws.readyState = FakeWebSocket.OPEN;
+    ws.dispatchEvent(new Event("open"));
+    const countAfterOpen = bridge.getConnectAttempts();
+
+    bridge.start({} as Parameters<typeof bridge.start>[0]);
+
+    expect(bridge.getConnectAttempts()).toBe(countAfterOpen);
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(bridge.getStatus()).toBe("connected");
   });
 });

--- a/frontend/src/mcp/mcpBridge.ts
+++ b/frontend/src/mcp/mcpBridge.ts
@@ -247,12 +247,11 @@ class McpBridgeImpl {
   start(editor: GEditor): void {
     this.editor = editor;
     this.stopped = false;
-    uiInfo("ws-broadcast", "mcpBridge starting...");
-    // 既存の接続が生きていればそのまま再利用（FlowEditor からの遷移時にエディターだけ差し替え）
-    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
-      uiInfo("ws-broadcast", "mcpBridge reusing existing connection");
+    // 既存接続が生きていれば editor 参照の差し替えだけ行う。
+    if (this._hasActiveConnection()) {
       return;
     }
+    uiInfo("ws-broadcast", "mcpBridge starting...");
     this._connect();
   }
 
@@ -328,8 +327,13 @@ class McpBridgeImpl {
     this.statusCallbacks.forEach((cb) => cb(s));
   }
 
+  private _hasActiveConnection(): boolean {
+    return this.ws?.readyState === WebSocket.OPEN || this.ws?.readyState === WebSocket.CONNECTING;
+  }
+
   private _connect(): void {
     if (this.stopped) return;
+    if (this._hasActiveConnection()) return;
     this.connectAttempts++;
     this._setStatus("connecting");
     uiInfo("ws-broadcast", `mcpBridge connecting to ${WS_URL} (attempt ${this.connectAttempts})`);


### PR DESCRIPTION
## Summary
- make `mcpBridge.start(editor)` no-op while an existing WebSocket is OPEN or CONNECTING, while still replacing the editor reference
- add the same active-connection guard inside `_connect()` to prevent direct duplicate connection attempts
- add focused status tests for CONNECTING and OPEN duplicate `start(editor)` calls

Closes #1464

## Verification
- `npm run test:unit --workspace=frontend -- src/mcp/mcpBridge.status.test.ts` ✅
- `npm run lint --workspace=frontend` ✅ (existing warning in `frontend/src/components/Designer.tsx:330`)
- `npm run build --workspace=frontend` ⚠️ fails before app build because the current installed root TypeScript is 5.5.4 while frontend config/deps require TS 6-era options such as `erasableSyntaxOnly`; no schema changes in this PR