### PR TITLE
fix: guard gadget preview sync before canvas init (#1463)

### DIFF
--- a/frontend/src/grapes/gadgetInstancePreview.test.ts
+++ b/frontend/src/grapes/gadgetInstancePreview.test.ts
@@ -23,6 +23,18 @@ describe("syncGadgetInstancePreviews", () => {
     vi.mocked(mcpBridge.request).mockReset();
   });
 
+  it("no-ops while the GrapesJS canvas document is not initialized yet", async () => {
+    const editor = {
+      Canvas: {
+        getDocument: () => null,
+      },
+    } as unknown as Editor;
+
+    await expect(syncGadgetInstancePreviews(editor, [{ id: "message-area", name: "Message Area" }])).resolves.toBeUndefined();
+
+    expect(mcpBridge.request).not.toHaveBeenCalled();
+  });
+
   it("expands placed gadget references with the referenced gadget design HTML", async () => {
     vi.mocked(mcpBridge.request).mockResolvedValue({
       pages: [{ frames: [{ component: { components: '<section class="message-card"><strong>Gadget Body</strong></section>' } }] }],

--- a/frontend/src/grapes/gadgetInstancePreview.ts
+++ b/frontend/src/grapes/gadgetInstancePreview.ts
@@ -74,7 +74,7 @@ export async function syncGadgetInstancePreviews(
   editor: GEditor,
   gadgets: GadgetBlockScreen[],
 ): Promise<void> {
-  const canvasDoc = editor.Canvas.getDocument();
+  const canvasDoc = editor.Canvas?.getDocument?.();
   if (!canvasDoc) return;
 
   const instances = Array.from(canvasDoc.querySelectorAll<HTMLElement>(GADGET_INSTANCE_SELECTOR));


### PR DESCRIPTION
## Summary
- Guard gadget preview sync when the GrapesJS Canvas document is not initialized yet
- Add a regression test proving the sync no-ops without loading gadget designs

## Verification
- npm run test:unit --workspace=frontend -- gadgetInstancePreview.test.ts
- npm run build --workspace=frontend

Closes #1463