### PR TITLE
fix: format componentsRef companion HTML (#1462)

### DIFF
--- a/backend/src/designPayloadStorage.test.ts
+++ b/backend/src/designPayloadStorage.test.ts
@@ -93,6 +93,20 @@ describe("design payload component companion storage", () => {
     await expect(fs.readFile(path.join(tmpDir, "mixed-screen.components.html"), "utf-8")).resolves.toBe(html);
   });
 
+  it("does not format top-level mixed text and element fragments", async () => {
+    const html = "<span>Hello</span>, <span>world</span>";
+
+    await deflateDesignComponents({
+      data: {
+        pages: [{ frames: [{ component: { components: html } }] }],
+      },
+      baseDir: tmpDir,
+      baseName: "top-level-mixed-screen",
+    });
+
+    await expect(fs.readFile(path.join(tmpDir, "top-level-mixed-screen.components.html"), "utf-8")).resolves.toBe(html);
+  });
+
   it("inflates formatted companion HTML without changing the componentsRef round-trip", async () => {
     const stored = await deflateDesignComponents({
       data: {

--- a/backend/src/designPayloadStorage.test.ts
+++ b/backend/src/designPayloadStorage.test.ts
@@ -172,6 +172,40 @@ describe("design payload component companion storage", () => {
     );
   });
 
+  it("does not format top-level adjacent inline replaced element fragments", async () => {
+    const html = "<canvas width=\"10\" height=\"10\"></canvas><span>Label</span>";
+
+    await deflateDesignComponents({
+      data: {
+        pages: [{ frames: [{ component: { components: html } }] }],
+      },
+      baseDir: tmpDir,
+      baseName: "inline-canvas-screen",
+    });
+
+    await expect(fs.readFile(path.join(tmpDir, "inline-canvas-screen.components.html"), "utf-8")).resolves.toBe(html);
+  });
+
+  it("keeps nested adjacent inline replaced elements on the same line", async () => {
+    await deflateDesignComponents({
+      data: {
+        pages: [{ frames: [{ component: { components: "<div><p><canvas width=\"10\" height=\"10\"></canvas><span>Label</span></p><section><h2>Next</h2></section></div>" } }] }],
+      },
+      baseDir: tmpDir,
+      baseName: "nested-inline-canvas-screen",
+    });
+
+    await expect(fs.readFile(path.join(tmpDir, "nested-inline-canvas-screen.components.html"), "utf-8")).resolves.toBe(
+      `<div>
+  <p><canvas width="10" height="10"></canvas><span>Label</span></p>
+  <section>
+    <h2>Next</h2>
+  </section>
+</div>
+`,
+    );
+  });
+
   it("inflates formatted companion HTML without changing the componentsRef round-trip", async () => {
     const stored = await deflateDesignComponents({
       data: {

--- a/backend/src/designPayloadStorage.test.ts
+++ b/backend/src/designPayloadStorage.test.ts
@@ -186,6 +186,82 @@ describe("design payload component companion storage", () => {
     await expect(fs.readFile(path.join(tmpDir, "inline-canvas-screen.components.html"), "utf-8")).resolves.toBe(html);
   });
 
+  it("does not format top-level adjacent embedded media fragments", async () => {
+    const html = "<audio controls></audio><span>Label</span>";
+
+    await deflateDesignComponents({
+      data: {
+        pages: [{ frames: [{ component: { components: html } }] }],
+      },
+      baseDir: tmpDir,
+      baseName: "inline-audio-screen",
+    });
+
+    await expect(fs.readFile(path.join(tmpDir, "inline-audio-screen.components.html"), "utf-8")).resolves.toBe(html);
+  });
+
+  it("does not format top-level inline fragments separated by comments", async () => {
+    const html = "<span>A</span><!--c--><span>B</span>";
+
+    await deflateDesignComponents({
+      data: {
+        pages: [{ frames: [{ component: { components: html } }] }],
+      },
+      baseDir: tmpDir,
+      baseName: "inline-comment-screen",
+    });
+
+    await expect(fs.readFile(path.join(tmpDir, "inline-comment-screen.components.html"), "utf-8")).resolves.toBe(html);
+  });
+
+  it("keeps nested inline fragments separated by comments on the same line", async () => {
+    await deflateDesignComponents({
+      data: {
+        pages: [{ frames: [{ component: { components: "<div><p><span>A</span><!--c--><span>B</span></p><section><h2>Next</h2></section></div>" } }] }],
+      },
+      baseDir: tmpDir,
+      baseName: "nested-inline-comment-screen",
+    });
+
+    await expect(fs.readFile(path.join(tmpDir, "nested-inline-comment-screen.components.html"), "utf-8")).resolves.toBe(
+      `<div>
+  <p><span>A</span><!--c--><span>B</span></p>
+  <section>
+    <h2>Next</h2>
+  </section>
+</div>
+`,
+    );
+  });
+
+  it("does not format top-level adjacent custom element fragments", async () => {
+    const html = "<my-icon></my-icon><span>Label</span>";
+
+    await deflateDesignComponents({
+      data: {
+        pages: [{ frames: [{ component: { components: html } }] }],
+      },
+      baseDir: tmpDir,
+      baseName: "custom-element-screen",
+    });
+
+    await expect(fs.readFile(path.join(tmpDir, "custom-element-screen.components.html"), "utf-8")).resolves.toBe(html);
+  });
+
+  it("does not format top-level adjacent MathML fragments", async () => {
+    const html = "<math><mi>x</mi></math><span>Label</span>";
+
+    await deflateDesignComponents({
+      data: {
+        pages: [{ frames: [{ component: { components: html } }] }],
+      },
+      baseDir: tmpDir,
+      baseName: "mathml-screen",
+    });
+
+    await expect(fs.readFile(path.join(tmpDir, "mathml-screen.components.html"), "utf-8")).resolves.toBe(html);
+  });
+
   it("keeps nested adjacent inline replaced elements on the same line", async () => {
     await deflateDesignComponents({
       data: {

--- a/backend/src/designPayloadStorage.test.ts
+++ b/backend/src/designPayloadStorage.test.ts
@@ -43,10 +43,7 @@ describe("design payload component companion storage", () => {
       `<div class="container">
   <section>
     <h1>Title</h1>
-    <div class="row">
-      <label for="name">Name</label>
-      <input id="name" class="form-control">
-    </div>
+    <div class="row"><label for="name">Name</label><input id="name" class="form-control"></div>
   </section>
 </div>
 `,
@@ -105,6 +102,40 @@ describe("design payload component companion storage", () => {
     });
 
     await expect(fs.readFile(path.join(tmpDir, "top-level-mixed-screen.components.html"), "utf-8")).resolves.toBe(html);
+  });
+
+  it("does not format top-level adjacent inline element fragments", async () => {
+    const html = "<span>Hello</span><span>world</span>";
+
+    await deflateDesignComponents({
+      data: {
+        pages: [{ frames: [{ component: { components: html } }] }],
+      },
+      baseDir: tmpDir,
+      baseName: "inline-siblings-screen",
+    });
+
+    await expect(fs.readFile(path.join(tmpDir, "inline-siblings-screen.components.html"), "utf-8")).resolves.toBe(html);
+  });
+
+  it("keeps nested adjacent inline elements on the same line while formatting their parent", async () => {
+    await deflateDesignComponents({
+      data: {
+        pages: [{ frames: [{ component: { components: "<div><p><span>Hello</span><span>world</span></p><section><h2>Next</h2></section></div>" } }] }],
+      },
+      baseDir: tmpDir,
+      baseName: "nested-inline-siblings-screen",
+    });
+
+    await expect(fs.readFile(path.join(tmpDir, "nested-inline-siblings-screen.components.html"), "utf-8")).resolves.toBe(
+      `<div>
+  <p><span>Hello</span><span>world</span></p>
+  <section>
+    <h2>Next</h2>
+  </section>
+</div>
+`,
+    );
   });
 
   it("inflates formatted companion HTML without changing the componentsRef round-trip", async () => {

--- a/backend/src/designPayloadStorage.test.ts
+++ b/backend/src/designPayloadStorage.test.ts
@@ -65,6 +65,34 @@ describe("design payload component companion storage", () => {
     await expect(fs.readFile(path.join(tmpDir, "simple-screen.components.html"), "utf-8")).resolves.toBe("<span>Total</span>");
   });
 
+  it("does not format whitespace-sensitive HTML content", async () => {
+    const html = "<div><pre>a  b  c</pre><span>Hello</span></div>";
+
+    await deflateDesignComponents({
+      data: {
+        pages: [{ frames: [{ component: { components: html } }] }],
+      },
+      baseDir: tmpDir,
+      baseName: "pre-screen",
+    });
+
+    await expect(fs.readFile(path.join(tmpDir, "pre-screen.components.html"), "utf-8")).resolves.toBe(html);
+  });
+
+  it("does not format mixed text and element content", async () => {
+    const html = "<p>Hello <strong>customer</strong>, welcome back.</p>";
+
+    await deflateDesignComponents({
+      data: {
+        pages: [{ frames: [{ component: { components: html } }] }],
+      },
+      baseDir: tmpDir,
+      baseName: "mixed-screen",
+    });
+
+    await expect(fs.readFile(path.join(tmpDir, "mixed-screen.components.html"), "utf-8")).resolves.toBe(html);
+  });
+
   it("inflates formatted companion HTML without changing the componentsRef round-trip", async () => {
     const stored = await deflateDesignComponents({
       data: {

--- a/backend/src/designPayloadStorage.test.ts
+++ b/backend/src/designPayloadStorage.test.ts
@@ -1,0 +1,88 @@
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { deflateDesignComponents, inflateDesignComponents } from "./designPayloadStorage.js";
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "harmony-design-payload-"));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("design payload component companion storage", () => {
+  it("formats complex single-line HTML fragments before writing componentsRef companions", async () => {
+    const data = {
+      pages: [{
+        frames: [{
+          component: {
+            type: "wrapper",
+            components: "<div class=\"container\"><section><h1>Title</h1><div class=\"row\"><label for=\"name\">Name</label><input id=\"name\" class=\"form-control\"></div></section></div>",
+          },
+        }],
+      }],
+    };
+
+    const stored = await deflateDesignComponents({
+      data,
+      baseDir: tmpDir,
+      baseName: "complex-screen",
+    }) as any;
+
+    expect(stored.pages[0].frames[0].component).toMatchObject({
+      type: "wrapper",
+      componentsRef: "complex-screen.components.html",
+    });
+    expect(stored.pages[0].frames[0].component).not.toHaveProperty("components");
+
+    await expect(fs.readFile(path.join(tmpDir, "complex-screen.components.html"), "utf-8")).resolves.toBe(
+      `<div class="container">
+  <section>
+    <h1>Title</h1>
+    <div class="row">
+      <label for="name">Name</label>
+      <input id="name" class="form-control">
+    </div>
+  </section>
+</div>
+`,
+    );
+  });
+
+  it("keeps simple single-element text fragments on one line", async () => {
+    await deflateDesignComponents({
+      data: {
+        pages: [{ frames: [{ component: { components: "<span>Total</span>" } }] }],
+      },
+      baseDir: tmpDir,
+      baseName: "simple-screen",
+    });
+
+    await expect(fs.readFile(path.join(tmpDir, "simple-screen.components.html"), "utf-8")).resolves.toBe("<span>Total</span>");
+  });
+
+  it("inflates formatted companion HTML without changing the componentsRef round-trip", async () => {
+    const stored = await deflateDesignComponents({
+      data: {
+        pages: [{ frames: [{ component: { components: "<main><h1>Dashboard</h1><p>Ready</p></main>" } }] }],
+      },
+      baseDir: tmpDir,
+      baseName: "round-trip",
+    }) as any;
+
+    const inflated = await inflateDesignComponents(stored, tmpDir) as any;
+
+    expect(inflated.pages[0].frames[0].component.componentsRef).toBe("round-trip.components.html");
+    expect(inflated.pages[0].frames[0].component.components).toBe(
+      `<main>
+  <h1>Dashboard</h1>
+  <p>Ready</p>
+</main>
+`,
+    );
+  });
+});

--- a/backend/src/designPayloadStorage.test.ts
+++ b/backend/src/designPayloadStorage.test.ts
@@ -138,6 +138,40 @@ describe("design payload component companion storage", () => {
     );
   });
 
+  it("does not format top-level adjacent inline SVG fragments", async () => {
+    const html = "<svg viewBox=\"0 0 10 10\"><path d=\"M0 0h10v10H0z\"></path></svg><span>Label</span>";
+
+    await deflateDesignComponents({
+      data: {
+        pages: [{ frames: [{ component: { components: html } }] }],
+      },
+      baseDir: tmpDir,
+      baseName: "inline-svg-screen",
+    });
+
+    await expect(fs.readFile(path.join(tmpDir, "inline-svg-screen.components.html"), "utf-8")).resolves.toBe(html);
+  });
+
+  it("keeps nested adjacent inline SVG elements on the same line", async () => {
+    await deflateDesignComponents({
+      data: {
+        pages: [{ frames: [{ component: { components: "<div><p><svg viewBox=\"0 0 10 10\"><path d=\"M0 0h10v10H0z\"></path></svg><span>Label</span></p><section><h2>Next</h2></section></div>" } }] }],
+      },
+      baseDir: tmpDir,
+      baseName: "nested-inline-svg-screen",
+    });
+
+    await expect(fs.readFile(path.join(tmpDir, "nested-inline-svg-screen.components.html"), "utf-8")).resolves.toBe(
+      `<div>
+  <p><svg viewBox="0 0 10 10"><path d="M0 0h10v10H0z"></path></svg><span>Label</span></p>
+  <section>
+    <h2>Next</h2>
+  </section>
+</div>
+`,
+    );
+  });
+
   it("inflates formatted companion HTML without changing the componentsRef round-trip", async () => {
     const stored = await deflateDesignComponents({
       data: {

--- a/backend/src/designPayloadStorage.ts
+++ b/backend/src/designPayloadStorage.ts
@@ -1,6 +1,20 @@
 import fs from "fs/promises";
 import path from "path";
+import { parseDocument } from "htmlparser2";
 import { assertPathContained } from "./security/idValidator.js";
+
+interface HtmlNode {
+  type: string;
+  name?: string;
+  attribs?: Record<string, string>;
+  children?: HtmlNode[];
+  data?: string;
+}
+
+const VOID_ELEMENTS = new Set([
+  "area", "base", "br", "col", "embed", "hr", "img", "input",
+  "link", "meta", "param", "source", "track", "wbr",
+]);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -26,6 +40,83 @@ async function readTextIfExists(filePath: string): Promise<string | null> {
 
 function componentRefName(baseName: string, index: number): string {
   return index === 0 ? `${baseName}.components.html` : `${baseName}.${index + 1}.components.html`;
+}
+
+function isElementNode(node: HtmlNode): boolean {
+  return node.type === "tag" || node.type === "script" || node.type === "style";
+}
+
+function isMeaningfulNode(node: HtmlNode): boolean {
+  return isElementNode(node) || node.type === "comment" || Boolean(node.data?.trim());
+}
+
+function escapeAttribute(value: string): string {
+  return value.replace(/"/g, "&quot;");
+}
+
+function attributeText(attribs: Record<string, string> | undefined): string {
+  if (!attribs || Object.keys(attribs).length === 0) return "";
+  const parts = Object.entries(attribs).map(([name, value]) => (
+    value === "" ? name : `${name}="${escapeAttribute(value)}"`
+  ));
+  return ` ${parts.join(" ")}`;
+}
+
+function hasNestedElement(node: HtmlNode): boolean {
+  return (node.children ?? []).some((child) => isElementNode(child) || hasNestedElement(child));
+}
+
+function shouldFormatHtmlFragment(nodes: HtmlNode[]): boolean {
+  const meaningfulNodes = nodes.filter(isMeaningfulNode);
+  const elementNodes = meaningfulNodes.filter(isElementNode);
+  if (elementNodes.length === 0) return false;
+  if (meaningfulNodes.length > 1) return true;
+  return hasNestedElement(elementNodes[0]);
+}
+
+function formatHtmlNode(node: HtmlNode, depth: number): string[] {
+  const indent = "  ".repeat(depth);
+
+  if (node.type === "comment") {
+    return [`${indent}<!--${node.data ?? ""}-->`];
+  }
+
+  if (!isElementNode(node)) {
+    const text = node.data?.replace(/\s+/g, " ").trim();
+    return text ? [`${indent}${text}`] : [];
+  }
+
+  const tagName = node.name ?? "";
+  const openTag = `<${tagName}${attributeText(node.attribs)}>`;
+  if (VOID_ELEMENTS.has(tagName.toLowerCase())) {
+    return [`${indent}${openTag}`];
+  }
+
+  const childLines = (node.children ?? []).flatMap((child) => formatHtmlNode(child, depth + 1));
+  if (childLines.length === 0) {
+    return [`${indent}${openTag}</${tagName}>`];
+  }
+
+  if (childLines.length === 1 && !isElementNode((node.children ?? []).find(isMeaningfulNode) ?? { type: "text" })) {
+    return [`${indent}${openTag}${childLines[0].trim()}</${tagName}>`];
+  }
+
+  return [
+    `${indent}${openTag}`,
+    ...childLines,
+    `${indent}</${tagName}>`,
+  ];
+}
+
+function formatComponentHtml(html: string): string {
+  if (html.includes("\n")) return html;
+  const doc = parseDocument(html, {
+    decodeEntities: false,
+    lowerCaseAttributeNames: false,
+  }) as unknown as { children: HtmlNode[] };
+  const nodes = doc.children ?? [];
+  if (!shouldFormatHtmlFragment(nodes)) return html;
+  return `${nodes.flatMap((node) => formatHtmlNode(node, 0)).join("\n")}\n`;
 }
 
 async function cleanupComponentCompanions(baseDir: string, baseName: string): Promise<void> {
@@ -115,7 +206,7 @@ export async function deflateDesignComponents(params: {
     const ref = componentRefName(baseName, i);
     const filePath = path.join(baseDir, ref);
     assertPathContained(filePath, baseDir);
-    await fs.writeFile(filePath, html, "utf-8");
+    await fs.writeFile(filePath, formatComponentHtml(html), "utf-8");
     delete target.components;
     target.componentsRef = ref;
   }

--- a/backend/src/designPayloadStorage.ts
+++ b/backend/src/designPayloadStorage.ts
@@ -21,7 +21,7 @@ const WHITESPACE_SENSITIVE_ELEMENTS = new Set(["pre", "script", "style", "textar
 const INLINE_ELEMENTS = new Set([
   "a", "abbr", "b", "bdi", "bdo", "br", "button", "cite", "code", "data", "dfn", "em",
   "i", "img", "input", "kbd", "label", "mark", "output", "q", "s", "samp", "select",
-  "small", "span", "strong", "sub", "sup", "textarea", "time", "u", "var",
+  "small", "span", "strong", "sub", "sup", "svg", "text", "textarea", "time", "tspan", "u", "var",
 ]);
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/backend/src/designPayloadStorage.ts
+++ b/backend/src/designPayloadStorage.ts
@@ -96,16 +96,12 @@ function hasMixedTopLevelTextAndElement(nodes: HtmlNode[]): boolean {
   return hasText && hasElement;
 }
 
-function isInlineElementNode(node: HtmlNode): boolean {
-  return isElementNode(node) && !BLOCK_ELEMENTS.has((node.name ?? "").toLowerCase());
+function isKnownBlockElementNode(node: HtmlNode): boolean {
+  return isElementNode(node) && BLOCK_ELEMENTS.has((node.name ?? "").toLowerCase());
 }
 
-function containsOnlyInlineElements(nodes: HtmlNode[]): boolean {
-  return nodes.length > 0 && nodes.every(isInlineElementNode);
-}
-
-function containsAnyInlineElement(nodes: HtmlNode[]): boolean {
-  return nodes.some(isInlineElementNode);
+function containsOnlyKnownBlockElements(nodes: HtmlNode[]): boolean {
+  return nodes.length > 0 && nodes.every(isKnownBlockElementNode);
 }
 
 function shouldFormatHtmlFragment(nodes: HtmlNode[]): boolean {
@@ -113,7 +109,7 @@ function shouldFormatHtmlFragment(nodes: HtmlNode[]): boolean {
   const elementNodes = meaningfulNodes.filter(isElementNode);
   if (elementNodes.length === 0) return false;
   if (hasMixedTopLevelTextAndElement(meaningfulNodes)) return false;
-  if (containsAnyInlineElement(meaningfulNodes)) return false;
+  if (!containsOnlyKnownBlockElements(meaningfulNodes)) return false;
   if (elementNodes.some((node) => hasWhitespaceSensitiveElement(node) || hasMixedTextAndElementChildren(node))) {
     return false;
   }
@@ -158,7 +154,7 @@ function formatHtmlNode(node: HtmlNode, depth: number): string[] {
   if (meaningfulChildren.length === 1 && meaningfulChildren[0].type === "text") {
     return [`${indent}${openTag}${meaningfulChildren[0].data ?? ""}</${tagName}>`];
   }
-  if (containsAnyInlineElement(meaningfulChildren)) {
+  if (!containsOnlyKnownBlockElements(meaningfulChildren)) {
     return [`${indent}${openTag}${meaningfulChildren.map(compactHtmlNode).join("")}</${tagName}>`];
   }
 

--- a/backend/src/designPayloadStorage.ts
+++ b/backend/src/designPayloadStorage.ts
@@ -18,10 +18,12 @@ const VOID_ELEMENTS = new Set([
 
 const WHITESPACE_SENSITIVE_ELEMENTS = new Set(["pre", "script", "style", "textarea"]);
 
-const INLINE_ELEMENTS = new Set([
-  "a", "abbr", "b", "bdi", "bdo", "br", "button", "cite", "code", "data", "dfn", "em",
-  "i", "img", "input", "kbd", "label", "mark", "output", "q", "s", "samp", "select",
-  "small", "span", "strong", "sub", "sup", "svg", "text", "textarea", "time", "tspan", "u", "var",
+const BLOCK_ELEMENTS = new Set([
+  "address", "article", "aside", "blockquote", "body", "caption", "colgroup", "dd", "details",
+  "dialog", "div", "dl", "dt", "fieldset", "figcaption", "figure", "footer", "form", "h1",
+  "h2", "h3", "h4", "h5", "h6", "head", "header", "hgroup", "hr", "html", "legend", "li",
+  "main", "menu", "nav", "ol", "optgroup", "option", "p", "pre", "section", "summary", "table",
+  "tbody", "td", "tfoot", "th", "thead", "tr", "ul",
 ]);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -95,11 +97,15 @@ function hasMixedTopLevelTextAndElement(nodes: HtmlNode[]): boolean {
 }
 
 function isInlineElementNode(node: HtmlNode): boolean {
-  return isElementNode(node) && INLINE_ELEMENTS.has((node.name ?? "").toLowerCase());
+  return isElementNode(node) && !BLOCK_ELEMENTS.has((node.name ?? "").toLowerCase());
 }
 
 function containsOnlyInlineElements(nodes: HtmlNode[]): boolean {
   return nodes.length > 0 && nodes.every(isInlineElementNode);
+}
+
+function containsAnyInlineElement(nodes: HtmlNode[]): boolean {
+  return nodes.some(isInlineElementNode);
 }
 
 function shouldFormatHtmlFragment(nodes: HtmlNode[]): boolean {
@@ -107,7 +113,7 @@ function shouldFormatHtmlFragment(nodes: HtmlNode[]): boolean {
   const elementNodes = meaningfulNodes.filter(isElementNode);
   if (elementNodes.length === 0) return false;
   if (hasMixedTopLevelTextAndElement(meaningfulNodes)) return false;
-  if (containsOnlyInlineElements(meaningfulNodes)) return false;
+  if (containsAnyInlineElement(meaningfulNodes)) return false;
   if (elementNodes.some((node) => hasWhitespaceSensitiveElement(node) || hasMixedTextAndElementChildren(node))) {
     return false;
   }
@@ -152,7 +158,7 @@ function formatHtmlNode(node: HtmlNode, depth: number): string[] {
   if (meaningfulChildren.length === 1 && meaningfulChildren[0].type === "text") {
     return [`${indent}${openTag}${meaningfulChildren[0].data ?? ""}</${tagName}>`];
   }
-  if (containsOnlyInlineElements(meaningfulChildren)) {
+  if (containsAnyInlineElement(meaningfulChildren)) {
     return [`${indent}${openTag}${meaningfulChildren.map(compactHtmlNode).join("")}</${tagName}>`];
   }
 

--- a/backend/src/designPayloadStorage.ts
+++ b/backend/src/designPayloadStorage.ts
@@ -82,10 +82,17 @@ function hasMixedTextAndElementChildren(node: HtmlNode): boolean {
   return (hasText && hasElement) || children.some(hasMixedTextAndElementChildren);
 }
 
+function hasMixedTopLevelTextAndElement(nodes: HtmlNode[]): boolean {
+  const hasText = nodes.some((node) => node.type === "text" && (node.data ?? "").length > 0);
+  const hasElement = nodes.some(isElementNode);
+  return hasText && hasElement;
+}
+
 function shouldFormatHtmlFragment(nodes: HtmlNode[]): boolean {
   const meaningfulNodes = nodes.filter(isMeaningfulNode);
   const elementNodes = meaningfulNodes.filter(isElementNode);
   if (elementNodes.length === 0) return false;
+  if (hasMixedTopLevelTextAndElement(meaningfulNodes)) return false;
   if (elementNodes.some((node) => hasWhitespaceSensitiveElement(node) || hasMixedTextAndElementChildren(node))) {
     return false;
   }

--- a/backend/src/designPayloadStorage.ts
+++ b/backend/src/designPayloadStorage.ts
@@ -18,6 +18,12 @@ const VOID_ELEMENTS = new Set([
 
 const WHITESPACE_SENSITIVE_ELEMENTS = new Set(["pre", "script", "style", "textarea"]);
 
+const INLINE_ELEMENTS = new Set([
+  "a", "abbr", "b", "bdi", "bdo", "br", "button", "cite", "code", "data", "dfn", "em",
+  "i", "img", "input", "kbd", "label", "mark", "output", "q", "s", "samp", "select",
+  "small", "span", "strong", "sub", "sup", "textarea", "time", "u", "var",
+]);
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -88,16 +94,35 @@ function hasMixedTopLevelTextAndElement(nodes: HtmlNode[]): boolean {
   return hasText && hasElement;
 }
 
+function isInlineElementNode(node: HtmlNode): boolean {
+  return isElementNode(node) && INLINE_ELEMENTS.has((node.name ?? "").toLowerCase());
+}
+
+function containsOnlyInlineElements(nodes: HtmlNode[]): boolean {
+  return nodes.length > 0 && nodes.every(isInlineElementNode);
+}
+
 function shouldFormatHtmlFragment(nodes: HtmlNode[]): boolean {
   const meaningfulNodes = nodes.filter(isMeaningfulNode);
   const elementNodes = meaningfulNodes.filter(isElementNode);
   if (elementNodes.length === 0) return false;
   if (hasMixedTopLevelTextAndElement(meaningfulNodes)) return false;
+  if (containsOnlyInlineElements(meaningfulNodes)) return false;
   if (elementNodes.some((node) => hasWhitespaceSensitiveElement(node) || hasMixedTextAndElementChildren(node))) {
     return false;
   }
   if (meaningfulNodes.length > 1) return true;
   return hasNestedElement(elementNodes[0]);
+}
+
+function compactHtmlNode(node: HtmlNode): string {
+  if (node.type === "comment") return `<!--${node.data ?? ""}-->`;
+  if (!isElementNode(node)) return node.data ?? "";
+
+  const tagName = node.name ?? "";
+  const openTag = `<${tagName}${attributeText(node.attribs)}>`;
+  if (VOID_ELEMENTS.has(tagName.toLowerCase())) return openTag;
+  return `${openTag}${(node.children ?? []).map(compactHtmlNode).join("")}</${tagName}>`;
 }
 
 function formatHtmlNode(node: HtmlNode, depth: number): string[] {
@@ -126,6 +151,9 @@ function formatHtmlNode(node: HtmlNode, depth: number): string[] {
   const meaningfulChildren = (node.children ?? []).filter(isMeaningfulNode);
   if (meaningfulChildren.length === 1 && meaningfulChildren[0].type === "text") {
     return [`${indent}${openTag}${meaningfulChildren[0].data ?? ""}</${tagName}>`];
+  }
+  if (containsOnlyInlineElements(meaningfulChildren)) {
+    return [`${indent}${openTag}${meaningfulChildren.map(compactHtmlNode).join("")}</${tagName}>`];
   }
 
   return [

--- a/backend/src/designPayloadStorage.ts
+++ b/backend/src/designPayloadStorage.ts
@@ -16,6 +16,8 @@ const VOID_ELEMENTS = new Set([
   "link", "meta", "param", "source", "track", "wbr",
 ]);
 
+const WHITESPACE_SENSITIVE_ELEMENTS = new Set(["pre", "script", "style", "textarea"]);
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -66,10 +68,27 @@ function hasNestedElement(node: HtmlNode): boolean {
   return (node.children ?? []).some((child) => isElementNode(child) || hasNestedElement(child));
 }
 
+function hasWhitespaceSensitiveElement(node: HtmlNode): boolean {
+  if (isElementNode(node) && WHITESPACE_SENSITIVE_ELEMENTS.has((node.name ?? "").toLowerCase())) {
+    return true;
+  }
+  return (node.children ?? []).some(hasWhitespaceSensitiveElement);
+}
+
+function hasMixedTextAndElementChildren(node: HtmlNode): boolean {
+  const children = node.children ?? [];
+  const hasText = children.some((child) => child.type === "text" && (child.data ?? "").length > 0);
+  const hasElement = children.some(isElementNode);
+  return (hasText && hasElement) || children.some(hasMixedTextAndElementChildren);
+}
+
 function shouldFormatHtmlFragment(nodes: HtmlNode[]): boolean {
   const meaningfulNodes = nodes.filter(isMeaningfulNode);
   const elementNodes = meaningfulNodes.filter(isElementNode);
   if (elementNodes.length === 0) return false;
+  if (elementNodes.some((node) => hasWhitespaceSensitiveElement(node) || hasMixedTextAndElementChildren(node))) {
+    return false;
+  }
   if (meaningfulNodes.length > 1) return true;
   return hasNestedElement(elementNodes[0]);
 }
@@ -82,8 +101,8 @@ function formatHtmlNode(node: HtmlNode, depth: number): string[] {
   }
 
   if (!isElementNode(node)) {
-    const text = node.data?.replace(/\s+/g, " ").trim();
-    return text ? [`${indent}${text}`] : [];
+    if (!node.data || !node.data.trim()) return [];
+    return [`${indent}${node.data}`];
   }
 
   const tagName = node.name ?? "";
@@ -97,8 +116,9 @@ function formatHtmlNode(node: HtmlNode, depth: number): string[] {
     return [`${indent}${openTag}</${tagName}>`];
   }
 
-  if (childLines.length === 1 && !isElementNode((node.children ?? []).find(isMeaningfulNode) ?? { type: "text" })) {
-    return [`${indent}${openTag}${childLines[0].trim()}</${tagName}>`];
+  const meaningfulChildren = (node.children ?? []).filter(isMeaningfulNode);
+  if (meaningfulChildren.length === 1 && meaningfulChildren[0].type === "text") {
+    return [`${indent}${openTag}${meaningfulChildren[0].data ?? ""}</${tagName}>`];
   }
 
   return [


### PR DESCRIPTION
## Summary

Closes #1462.

- Format complex single-line GrapesJS `components` HTML before writing `*.components.html` companions.
- Preserve simple single-element text fragments as single-line output to avoid unnecessary diff churn.
- Skip formatting for whitespace-sensitive content (`pre` / `script` / `style` / `textarea`), mixed text+element content, and top-level inline-like fragments so save does not alter user-visible HTML text.
- Treat known block/container elements as format-safe boundaries and compact unknown/phrasing/replaced elements inside a subtree to avoid inserting display whitespace.
- Add focused coverage for complex formatting, simple fragment preservation, sensitive/mixed/inline sibling/SVG/canvas content preservation, and inflate/deflate round-trip behavior.

## Verification

- `npm test --workspace=backend -- designPayloadStorage.test.ts`
- `npm test --workspace=backend -- projectStorageDataDir.test.ts pageLayoutStorage.test.ts draftHistoryStore.test.ts editSessionStore.test.ts wsBridge.editSession.test.ts wsBridge/editSessionService.test.ts`
- `npm run build --workspace=backend`
- `git diff --check`
- `git diff --name-only -- schemas/` returned no schema changes
