### PR TITLE
feat: add PageLayout manager UI

### DIFF
--- a/docs/user-guide/ui-reference/page-layout-designer.md
+++ b/docs/user-guide/ui-reference/page-layout-designer.md
@@ -6,7 +6,7 @@
 
 ## 概要
 
-PageLayout の **ビジュアル編集**画面。WYSIWYG で header / sidebar / footer / main-content 等の slot を配置し、各 slot にデフォルトガジェットをドラッグして埋め込む。Screen Designer (GrapesJS / Puck) に似た UX で、レイアウト本体を編集する。
+PageLayout の **ビジュアル編集**画面。上部の PageLayout Manager で header / sidebar / footer / main-content 等の slot を俯瞰し、各 slot の gadget 割り当てを変更する。下部には既存の GrapesJS / Puck Designer があり、PageLayout 自体の visual design payload を編集できる。
 
 ## 到達経路
 
@@ -20,19 +20,19 @@ PageLayout の **ビジュアル編集**画面。WYSIWYG で header / sidebar / 
 
 ### 主要エリア
 
-1. **EditorHeader** — レイアウト名 + 保存 + 「構造編集へ」
-2. **左サイドバー** — Gadget Manager (利用可能なガジェット一覧、ドラッグ元)
-3. **中央 Canvas** — レイアウトプレビュー (header / sidebar / main / footer 領域を区分表示)
-4. **右サイドバー** — 選択中 slot / gadget の設定 (サイズ / position / class 等)
+1. **PageLayout Manager header** — レイアウト名 / slot 数 / assignment 数 / editorKind / cssFramework / 「構造編集」 / 「割り当て保存」
+2. **Slot Canvas** — `regions` に基づく header / sidebar / main / footer / custom slot の俯瞰表示
+3. **Slot assignments** — `main` 以外の region に gadget Screen を割り当てる selector
+4. **Design editor** — GrapesJS / Puck による PageLayout design payload 編集
 
 ## 主要操作
 
 | 操作 | 手段 | 結果 |
 |---|---|---|
-| gadget 配置 | 左パレットから Canvas の slot にドラッグ | デフォルトガジェットとして保存 |
-| slot サイズ調整 | slot 境界をドラッグ | レスポンシブ breakpoint 毎に保存 |
-| gadget 設定 | gadget クリック → 右パネル | props / 表示条件 / class を編集 |
-| 構造編集へ | 「構造編集へ」 | `/page-layout/edit/:id` (`PageLayoutEditor`) を新タブ |
+| gadget 割り当て | Slot assignments の selector | region → gadget Screen の割り当てを変更 |
+| 割り当て保存 | 「割り当て保存」 | PageLayout 本体 (`assignments`) を保存 |
+| slot 構成変更 | 「構造編集」 | `PageLayoutEditor` で `regions` を追加 / 削除 / 並び替え |
+| 外部更新から復帰 | conflict banner の「再読み込み」 | 最新 PageLayout を読み直し、未保存 assignment draft を破棄 |
 | 保存 / 破棄 | `Ctrl+S` / 「破棄」 | edit-session 経由 |
 
 ## データ前提
@@ -51,6 +51,6 @@ PageLayout の **ビジュアル編集**画面。WYSIWYG で header / sidebar / 
 
 ## 既知の制約・注意
 
-- **構造 (slot 定義) は `PageLayoutEditor` で先に作る**のが推奨。本 Designer は配置 + 見た目の調整に特化
+- **構造 (slot 定義) は `PageLayoutEditor` で先に作る**のが推奨。本 Designer は slot の俯瞰 + gadget 割り当て + visual design payload 編集に特化
 - gadget は事前に `/gadget/list` で定義済みのもののみ配置可
-- レスポンシブ breakpoint (xs/sm/md/lg/xl) 毎に layout が分かれる場合、breakpoint 切替を必ず確認
+- `main` は page Screen 本文が入る content slot のため、gadget assignment selector は表示されない

--- a/frontend/src/components/page-layout/PageLayoutDesigner.test.tsx
+++ b/frontend/src/components/page-layout/PageLayoutDesigner.test.tsx
@@ -4,13 +4,14 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
 import type { PageLayout } from "../../store/pageLayoutStore";
 
 const mockState = vi.hoisted(() => {
   const componentAddHandlers = new Set<() => void>();
   const broadcastHandlers = new Map<string, Set<(data: unknown) => void>>();
+  const statusHandlers = new Set<(status: string) => void>();
   const editor = {
     Canvas: {
       getDocument: () => document,
@@ -25,9 +26,11 @@ const mockState = vi.hoisted(() => {
   return {
     componentAddHandlers,
     broadcastHandlers,
+    statusHandlers,
     editor,
     pageLayout: null as PageLayout | null,
     designerProps: null as Record<string, unknown> | null,
+    savePageLayout: vi.fn(),
   };
 });
 
@@ -35,7 +38,10 @@ vi.mock("../../mcp/mcpBridge", () => ({
   mcpBridge: {
     getSessionId: () => "test-session-id",
     startWithoutEditor: vi.fn(),
-    onStatusChange: vi.fn(() => () => {}),
+    onStatusChange: vi.fn((handler: (status: string) => void) => {
+      mockState.statusHandlers.add(handler);
+      return () => mockState.statusHandlers.delete(handler);
+    }),
     onBroadcast: vi.fn((event: string, handler: (data: unknown) => void) => {
       if (!mockState.broadcastHandlers.has(event)) {
         mockState.broadcastHandlers.set(event, new Set());
@@ -53,14 +59,15 @@ vi.mock("../../store/pageLayoutStore", async () => {
   return {
     ...actual,
     loadPageLayout: vi.fn().mockImplementation(() => Promise.resolve(mockState.pageLayout)),
+    savePageLayout: mockState.savePageLayout,
   };
 });
 
 vi.mock("../../store/flowStore", () => ({
   loadProject: vi.fn().mockResolvedValue({
     screens: [
-      { id: "gadget-1", name: "Gadget 1" },
-      { id: "gadget-2", name: "Gadget 2" },
+      { id: "gadget-1", name: "Gadget 1", purpose: "gadget" },
+      { id: "gadget-2", name: "Gadget 2", purpose: "gadget" },
     ],
   }),
 }));
@@ -82,6 +89,7 @@ vi.mock("../Designer", () => ({
 import { mcpBridge } from "../../mcp/mcpBridge";
 import { loadProject } from "../../store/flowStore";
 import { loadCustomPuckComponents } from "../../store/puckComponentsStore";
+import { loadPageLayout, savePageLayout } from "../../store/pageLayoutStore";
 import { PageLayoutDesigner } from "./PageLayoutDesigner";
 
 const defaultPageLayout = ({
@@ -114,10 +122,18 @@ describe("PageLayoutDesigner", () => {
     vi.clearAllMocks();
     mockState.componentAddHandlers.clear();
     mockState.broadcastHandlers.clear();
+    mockState.statusHandlers.clear();
     mockState.pageLayout = defaultPageLayout;
     mockState.designerProps = null;
+    mockState.savePageLayout.mockResolvedValue(undefined);
     vi.mocked(mcpBridge.request).mockResolvedValue({ sessions: [] });
     vi.mocked(mcpBridge.loadPuckData).mockResolvedValue(null);
+    vi.mocked(loadProject).mockResolvedValue({
+      screens: [
+        { id: "gadget-1", name: "Gadget 1", purpose: "gadget" },
+        { id: "gadget-2", name: "Gadget 2", purpose: "gadget" },
+      ],
+    } as never);
     vi.mocked(loadCustomPuckComponents).mockResolvedValue([]);
     localStorage.clear();
   });
@@ -142,6 +158,141 @@ describe("PageLayoutDesigner", () => {
         expect(body).toContain("Main Layout");
       }
     }, { timeout: 3000 });
+  });
+
+  it("renders visual slots and treats main as the content slot", async () => {
+    renderDesigner();
+
+    expect(await screen.findByTestId("page-layout-manager-canvas")).toBeInTheDocument();
+    expect(screen.getByTestId("page-layout-slot-header")).toHaveTextContent("Header");
+    expect(screen.getByTestId("page-layout-slot-main")).toHaveTextContent("page Screen content");
+    expect(screen.getByTestId("page-layout-slot-footer")).toHaveTextContent("Footer");
+    expect(screen.queryByTestId("page-layout-assignment-main")).not.toBeInTheDocument();
+  });
+
+  it("saves gadget assignments from the visual manager", async () => {
+    renderDesigner();
+
+    const headerSelect = await screen.findByTestId("page-layout-assignment-header");
+    fireEvent.change(headerSelect, { target: { value: "gadget-1" } });
+    fireEvent.click(screen.getByRole("button", { name: /割り当て保存/ }));
+
+    await waitFor(() => {
+      expect(savePageLayout).toHaveBeenCalledWith(expect.objectContaining({
+        id: "pl-design-001",
+        assignments: { header: "gadget-1" },
+      }));
+    });
+  });
+
+  it("merges assignments into the latest PageLayout before saving", async () => {
+    renderDesigner();
+    await screen.findByTestId("page-layout-assignment-header");
+
+    mockState.pageLayout = {
+      ...defaultPageLayout,
+      name: "Renamed Layout",
+      maturity: "committed",
+      processFlowId: "layout-orchestrator",
+    } as unknown as PageLayout;
+
+    fireEvent.change(screen.getByTestId("page-layout-assignment-header"), { target: { value: "gadget-2" } });
+    fireEvent.click(screen.getByRole("button", { name: /割り当て保存/ }));
+
+    await waitFor(() => {
+      expect(savePageLayout).toHaveBeenCalledWith(expect.objectContaining({
+        id: "pl-design-001",
+        name: "Renamed Layout",
+        maturity: "committed",
+        processFlowId: "layout-orchestrator",
+        assignments: { header: "gadget-2" },
+      }));
+    });
+    expect(loadPageLayout).toHaveBeenCalledTimes(2);
+  });
+
+  it("reloads PageLayout manager on pageLayoutChanged when clean", async () => {
+    renderDesigner();
+    expect(await screen.findByRole("heading", { name: "Main Layout" })).toBeInTheDocument();
+
+    mockState.pageLayout = {
+      ...defaultPageLayout,
+      name: "Updated Layout",
+      assignments: { footer: "gadget-1" } as unknown as Record<string, never>,
+    };
+    mockState.broadcastHandlers.get("pageLayoutChanged")?.forEach((handler) => handler({ pageLayoutId: "pl-design-001" }));
+
+    expect(await screen.findByRole("heading", { name: "Updated Layout" })).toBeInTheDocument();
+    expect(screen.getByTestId("page-layout-slot-footer")).toHaveTextContent("Gadget 1");
+  });
+
+  it("blocks assignment save after external pageLayoutChanged while dirty", async () => {
+    renderDesigner();
+
+    fireEvent.change(await screen.findByTestId("page-layout-assignment-header"), { target: { value: "gadget-1" } });
+    mockState.broadcastHandlers.get("pageLayoutChanged")?.forEach((handler) => handler({ pageLayoutId: "pl-design-001" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("別セッションで更新");
+    expect(screen.getByRole("button", { name: /割り当て保存/ })).toBeDisabled();
+    expect(savePageLayout).not.toHaveBeenCalled();
+  });
+
+  it("keeps the external update banner visible after selector changes and reloads from it", async () => {
+    renderDesigner();
+
+    fireEvent.change(await screen.findByTestId("page-layout-assignment-header"), { target: { value: "gadget-1" } });
+    mockState.broadcastHandlers.get("pageLayoutChanged")?.forEach((handler) => handler({ pageLayoutId: "pl-design-001" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("再読み込み");
+
+    fireEvent.change(screen.getByTestId("page-layout-assignment-header"), { target: { value: "gadget-2" } });
+    expect(screen.getByRole("alert")).toHaveTextContent("再読み込み");
+    expect(screen.getByRole("button", { name: /割り当て保存/ })).toBeDisabled();
+
+    mockState.pageLayout = {
+      ...defaultPageLayout,
+      name: "Reloaded Layout",
+      assignments: { header: "gadget-2" } as unknown as Record<string, never>,
+    };
+    fireEvent.click(screen.getByRole("button", { name: /再読み込み/ }));
+
+    expect(await screen.findByRole("heading", { name: "Reloaded Layout" })).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /割り当て保存/ })).toBeDisabled();
+  });
+
+  it("keeps dirty assignment draft on reconnect and asks the user to reload", async () => {
+    renderDesigner();
+
+    const headerSelect = await screen.findByTestId("page-layout-assignment-header");
+    fireEvent.change(headerSelect, { target: { value: "gadget-1" } });
+    mockState.pageLayout = {
+      ...defaultPageLayout,
+      name: "Server Reload Would Replace Draft",
+      assignments: {},
+    } as unknown as PageLayout;
+
+    mockState.statusHandlers.forEach((handler) => handler("connected"));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("接続が復旧");
+    expect(screen.getByRole("heading", { name: "Main Layout" })).toBeInTheDocument();
+    expect(screen.getByTestId("page-layout-assignment-header")).toHaveValue("gadget-1");
+    expect(screen.getByRole("button", { name: /割り当て保存/ })).toBeDisabled();
+  });
+
+  it("reloads gadget options on projectChanged", async () => {
+    renderDesigner();
+    expect(await screen.findByTestId("page-layout-assignment-header")).toBeInTheDocument();
+
+    vi.mocked(loadProject).mockResolvedValue({
+      screens: [
+        { id: "gadget-3", name: "Gadget 3", purpose: "gadget" },
+      ],
+    } as never);
+    mockState.broadcastHandlers.get("projectChanged")?.forEach((handler) => handler({}));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("page-layout-assignment-header")).toHaveTextContent("Gadget 3");
+    });
   });
 
   it("passes PageLayout design metadata and dedicated committed loader to Designer", async () => {
@@ -194,7 +345,7 @@ describe("PageLayoutDesigner", () => {
     renderDesigner();
 
     await waitFor(() => {
-      expect(loadProject).toHaveBeenCalledTimes(1);
+      expect(loadProject).toHaveBeenCalledTimes(2);
     });
 
     for (let i = 0; i < 100; i += 1) {
@@ -204,11 +355,11 @@ describe("PageLayoutDesigner", () => {
     await waitFor(() => {
       expect(mcpBridge.request).toHaveBeenCalledTimes(101);
     });
-    expect(loadProject).toHaveBeenCalledTimes(1);
+    expect(loadProject).toHaveBeenCalledTimes(2);
 
     mockState.broadcastHandlers.get("projectChanged")?.forEach((handler) => handler({}));
     await waitFor(() => {
-      expect(loadProject).toHaveBeenCalledTimes(2);
+      expect(loadProject).toHaveBeenCalledTimes(4);
     });
   });
 
@@ -223,7 +374,8 @@ describe("PageLayoutDesigner", () => {
     let active = 0;
     let maxActive = 0;
     const resolvers: Array<() => void> = [];
-    vi.mocked(mcpBridge.request).mockImplementation(() => {
+    vi.mocked(mcpBridge.request).mockImplementation((method) => {
+      if (method !== "loadScreen") return Promise.resolve(null);
       active += 1;
       maxActive = Math.max(maxActive, active);
       return new Promise((resolve) => {

--- a/frontend/src/components/page-layout/PageLayoutDesigner.tsx
+++ b/frontend/src/components/page-layout/PageLayoutDesigner.tsx
@@ -9,8 +9,9 @@
 import { useParams, useNavigate } from "react-router-dom";
 import { useWorkspacePath } from "../../hooks/useWorkspacePath";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { loadPageLayout } from "../../store/pageLayoutStore";
+import { loadPageLayout, savePageLayout } from "../../store/pageLayoutStore";
 import type { PageLayout } from "../../store/pageLayoutStore";
+import type { ScreenId } from "../../types/v3";
 import { mcpBridge } from "../../mcp/mcpBridge";
 import { loadProject } from "../../store/flowStore";
 import { Designer } from "../Designer";
@@ -20,11 +21,15 @@ import { RegionProvider } from "../../puck/primitives/RegionContext";
 import { buildConfigWithCustomComponents } from "../../puck/buildConfig";
 import { loadCustomPuckComponents } from "../../store/puckComponentsStore";
 import type { RegionContextValue } from "../../puck/primitives/RegionContext";
+import "../../styles/pageLayoutDesigner.css";
 
 const GADGET_DATA_LOAD_CONCURRENCY = 4;
 
 type ScreenNameIndex = Array<{ id: string; name: string }>;
 type ScreenNameIndexLoader = () => Promise<ScreenNameIndex>;
+type GadgetOption = { id: string; name: string };
+
+const RESERVED_REGION_ORDER = ["header", "sidebar", "main", "footer"];
 
 export function PageLayoutDesigner() {
   const { pageLayoutId } = useParams<{ pageLayoutId: string }>();
@@ -32,10 +37,17 @@ export function PageLayoutDesigner() {
   const { wsPath } = useWorkspacePath();
 
   const [pl, setPl] = useState<PageLayout | null | undefined>(undefined); // undefined = loading
+  const [gadgetOptions, setGadgetOptions] = useState<GadgetOption[]>([]);
+  const [assignmentDraft, setAssignmentDraft] = useState<Record<string, string>>({});
+  const [assignmentDirty, setAssignmentDirty] = useState(false);
+  const [assignmentSaving, setAssignmentSaving] = useState(false);
+  const [assignmentError, setAssignmentError] = useState<string | null>(null);
+  const [externalPageLayoutChanged, setExternalPageLayoutChanged] = useState(false);
 
   // GrapesJS editor ref (region injection 用、pl-5)
   const grapesEditorRef = useRef<GEditor | null>(null);
   const plRef = useRef<PageLayout | null>(null);
+  const assignmentDirtyRef = useRef(false);
   const screenNameIndexPromiseRef = useRef<Promise<ScreenNameIndex> | null>(null);
   // RFC #1021 pl-6 (Codex B-5): component:add listener cleanup ref
   const componentAddCleanupRef = useRef<(() => void) | null>(null);
@@ -67,6 +79,21 @@ export function PageLayoutDesigner() {
     puckConfig,
   });
 
+  const refreshCompositionPreview = useCallback((data: PageLayout) => {
+    plRef.current = data;
+    if (grapesEditorRef.current) {
+      clearGadgetPreviews(grapesEditorRef.current);
+      _injectWithEditor(grapesEditorRef.current, data, getScreenNameIndex);
+    }
+    _loadGadgetData(data.assignments ?? {}).then((gadgetData) => {
+      setRegionContextValue((prev) => ({
+        ...prev,
+        assignments: data.assignments ?? {},
+        gadgetData,
+      }));
+    }).catch(console.warn);
+  }, [getScreenNameIndex]);
+
   const reloadPuckConfig = useCallback(async () => {
     try {
       const customComponents = await loadCustomPuckComponents();
@@ -81,6 +108,33 @@ export function PageLayoutDesigner() {
     if (!pageLayoutId) return null;
     return await mcpBridge.request("loadPageLayoutDesign", { pageLayoutId });
   }, [pageLayoutId]);
+
+  useEffect(() => {
+    assignmentDirtyRef.current = assignmentDirty;
+  }, [assignmentDirty]);
+
+  const reloadGadgetOptions = useCallback(async () => {
+    setGadgetOptions(await loadGadgetOptions());
+  }, []);
+
+  const reloadPageLayout = useCallback(async () => {
+    if (!pageLayoutId) {
+      setPl(null);
+      return;
+    }
+    const data = await loadPageLayout(pageLayoutId);
+    if (!data) {
+      setPl(null);
+      plRef.current = null;
+      return;
+    }
+    setPl(data);
+    setAssignmentDraft(data.assignments ?? {});
+    setAssignmentDirty(false);
+    setAssignmentError(null);
+    setExternalPageLayoutChanged(false);
+    refreshCompositionPreview(data);
+  }, [pageLayoutId, refreshCompositionPreview]);
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- server-side custom Puck components are external state.
@@ -100,60 +154,66 @@ export function PageLayoutDesigner() {
 
     let mounted = true;
 
-    const doLoad = () => {
-      loadPageLayout(pageLayoutId).then((data) => {
-        if (!mounted) return;
-        setPl(data ?? null);
-        plRef.current = data ?? null;
-        // assignments が変わったら再 inject (GrapesJS)
-        if (grapesEditorRef.current && data) {
-          _injectWithEditor(grapesEditorRef.current, data, getScreenNameIndex);
-        }
-        // Puck composition preview: assignments が変わったら gadget data を再ロード
-        // RFC #1021 pl-6 (Codex 2nd review Should-fix): setRegionContextValue で
-        // assignments/gadgetData を入れ替える際、puckConfig も保持する (旧実装は puckConfig を omit して
-        // 上書きしていたため H-2 nested Render が assignments load 後に壊れていた)
-        if (data?.assignments) {
-          _loadGadgetData(data.assignments).then((gadgetData) => {
-            if (!mounted) return;
-            setRegionContextValue((prev) => ({
-              ...prev,
-              assignments: data.assignments ?? {},
-              gadgetData,
-            }));
-          }).catch(console.warn);
-        }
-      }).catch(() => { if (mounted) setPl(null); });
-    };
-
     const unsubStatus = mcpBridge.onStatusChange((status) => {
-      if (status === "connected" && mounted) doLoad();
+      if (status === "connected" && mounted) {
+        if (assignmentDirtyRef.current) {
+          setExternalPageLayoutChanged(true);
+          setAssignmentError("接続が復旧しました。未保存の割り当てがあります。再読み込みして最新 PageLayout を確認してください。");
+        } else {
+          void reloadPageLayout();
+        }
+        void reloadGadgetOptions();
+      }
     });
 
     mcpBridge.startWithoutEditor();
-    doLoad();
+    reloadPageLayout().catch(() => { if (mounted) setPl(null); });
 
     return () => {
       mounted = false;
       unsubStatus();
     };
-  }, [getScreenNameIndex, pageLayoutId]);
+  }, [pageLayoutId, reloadGadgetOptions, reloadPageLayout]);
+
+  useEffect(() => {
+    let mounted = true;
+    loadGadgetOptions().then((options) => {
+      if (!mounted) return;
+      setGadgetOptions(options);
+    }).catch(console.warn);
+    return () => { mounted = false; };
+  }, []);
 
   useEffect(() => {
     const unsubProjectChanged = mcpBridge.onBroadcast("projectChanged", () => {
       screenNameIndexPromiseRef.current = null;
+      void reloadGadgetOptions();
       if (grapesEditorRef.current && plRef.current) {
         _injectWithEditor(grapesEditorRef.current, plRef.current, getScreenNameIndex);
       }
     });
     return () => unsubProjectChanged();
-  }, [getScreenNameIndex]);
+  }, [getScreenNameIndex, reloadGadgetOptions]);
+
+  useEffect(() => {
+    const unsubPageLayoutChanged = mcpBridge.onBroadcast("pageLayoutChanged", (data) => {
+      if (!isTargetPageLayoutBroadcast(data, pageLayoutId)) return;
+      if (assignmentDirty) {
+        setExternalPageLayoutChanged(true);
+        setAssignmentError("ページレイアウトが別セッションで更新されました。再読み込みしてから割り当てを保存してください。");
+        return;
+      }
+      void reloadPageLayout();
+    });
+    return () => unsubPageLayoutChanged();
+  }, [assignmentDirty, pageLayoutId, reloadPageLayout]);
 
   /**
    * GrapesJS editor ready 後に region injection を実行する。
    * component:add イベントで region が後から追加された場合にも再 inject する。
    */
   const handleGrapesEditorReady = useCallback((editor: GEditor) => {
+    if (grapesEditorRef.current === editor) return;
     grapesEditorRef.current = editor;
     if (plRef.current) {
       // canvas 初期 load 完了を待ってから inject (component 描画が settleするまで少し待つ)
@@ -225,44 +285,256 @@ export function PageLayoutDesigner() {
 
   const editorKind = pl.design?.editorKind ?? "grapesjs";
   const cssFramework = pl.design?.cssFramework ?? "bootstrap";
+  const visualRegions = buildVisualRegions(pl);
+  const assignedGadgetIds = new Set(Object.values(assignmentDraft).filter(Boolean));
+  const gadgetOptionMap = new Map(gadgetOptions.map((gadget) => [gadget.id, gadget.name]));
+  const selectOptions = [
+    ...gadgetOptions,
+    ...[...assignedGadgetIds]
+      .filter((id) => !gadgetOptionMap.has(id))
+      .map((id) => ({ id, name: `不明な gadget (${id})` })),
+  ];
 
-  // editorKind='grapesjs': GrapesJS Designer に region drop slot ブロックを追加済み
-  // (frontend/src/grapes/blocks.ts の CAT_REGIONS カテゴリ)
-  // pl-5: onGrapesEditorReady で gadget injection を実行
-  if (editorKind === "grapesjs") {
-    return (
-      <Designer
-        screenId={`page-layout:${pageLayoutId}`}
-        resourceKind="pageLayout"
-        screenName={pl.name}
-        editSessionResourceType="page-layout-design"
-        editSessionResourceId={pageLayoutId}
-        designEditorKind={editorKind}
-        designCssFramework={cssFramework}
-        loadCommittedDesign={loadCommittedPageLayoutDesign}
-        onBack={() => navigate(wsPath(`/page-layout/edit/${encodeURIComponent(pageLayoutId)}`))}
-        onGrapesEditorReady={handleGrapesEditorReady}
-      />
-    );
-  }
+  const handleAssignmentChange = (regionName: string, screenId: string) => {
+    if (regionName === "main") return;
+    setAssignmentDraft((prev) => {
+      const next = { ...prev };
+      if (screenId) {
+        next[regionName] = screenId;
+      } else {
+        delete next[regionName];
+      }
+      return next;
+    });
+    setAssignmentDirty(true);
+    if (!externalPageLayoutChanged) {
+      setAssignmentError(null);
+    }
+  };
 
-  // editorKind='puck': Puck Editor + composition preview (pl-5 follow-up: feature parity)
-  // RegionProvider で Designer を wrap し、Region primitives が assignments + gadget data を参照できるようにする。
-  return (
-    <RegionProvider value={regionContextValue}>
-      <Designer
-        screenId={`page-layout:${pageLayoutId}`}
-        resourceKind="pageLayout"
-        screenName={pl.name}
-        editSessionResourceType="page-layout-design"
-        editSessionResourceId={pageLayoutId}
-        designEditorKind={editorKind}
-        designCssFramework={cssFramework}
-        loadCommittedDesign={loadCommittedPageLayoutDesign}
-        onBack={() => navigate(wsPath(`/page-layout/edit/${encodeURIComponent(pageLayoutId)}`))}
-      />
-    </RegionProvider>
+  const handleReloadPageLayout = () => {
+    void reloadPageLayout();
+  };
+
+  const handleSaveAssignments = async () => {
+    if (!assignmentDirty || assignmentSaving) return;
+    if (externalPageLayoutChanged) {
+      setAssignmentError("ページレイアウトが別セッションで更新されています。再読み込みしてから割り当てを保存してください。");
+      return;
+    }
+    setAssignmentSaving(true);
+    setAssignmentError(null);
+    try {
+      const latest = await loadPageLayout(pageLayoutId);
+      if (!latest) throw new Error(`PageLayout not found: ${pageLayoutId}`);
+      const next: PageLayout = {
+        ...latest,
+        assignments: assignmentDraft as Record<string, ScreenId>,
+      };
+      await savePageLayout(next);
+      setPl(next);
+      setAssignmentDirty(false);
+      refreshCompositionPreview(next);
+    } catch (e) {
+      console.error("[PageLayoutDesigner] assignment save failed:", e);
+      setAssignmentError("割り当てを保存できませんでした");
+    } finally {
+      setAssignmentSaving(false);
+    }
+  };
+
+  const editor = (
+    editorKind === "grapesjs"
+      ? (
+        <Designer
+          screenId={`page-layout:${pageLayoutId}`}
+          resourceKind="pageLayout"
+          screenName={pl.name}
+          editSessionResourceType="page-layout-design"
+          editSessionResourceId={pageLayoutId}
+          designEditorKind={editorKind}
+          designCssFramework={cssFramework}
+          loadCommittedDesign={loadCommittedPageLayoutDesign}
+          onBack={() => navigate(wsPath(`/page-layout/edit/${encodeURIComponent(pageLayoutId)}`))}
+          onGrapesEditorReady={handleGrapesEditorReady}
+        />
+      )
+      : (
+        <RegionProvider value={regionContextValue}>
+          <Designer
+            screenId={`page-layout:${pageLayoutId}`}
+            resourceKind="pageLayout"
+            screenName={pl.name}
+            editSessionResourceType="page-layout-design"
+            editSessionResourceId={pageLayoutId}
+            designEditorKind={editorKind}
+            designCssFramework={cssFramework}
+            loadCommittedDesign={loadCommittedPageLayoutDesign}
+            onBack={() => navigate(wsPath(`/page-layout/edit/${encodeURIComponent(pageLayoutId)}`))}
+          />
+        </RegionProvider>
+      )
   );
+
+  return (
+    <div className="pld-page">
+      <section className="pld-manager" aria-label="ページレイアウトマネージャ">
+        <div className="pld-manager-header">
+          <div>
+            <div className="pld-kicker">PageLayout Manager</div>
+            <h1>{pl.name}</h1>
+            <div className="pld-meta">
+              <span><i className="bi bi-layout-wtf" /> {visualRegions.length} slots</span>
+              <span><i className="bi bi-puzzle" /> {Object.keys(assignmentDraft).length} assignments</span>
+              <span><i className="bi bi-brush" /> {editorKind} / {cssFramework}</span>
+            </div>
+          </div>
+          <div className="pld-manager-actions">
+            <button
+              type="button"
+              className="pld-btn pld-btn-secondary"
+              onClick={() => navigate(wsPath(`/page-layout/edit/${encodeURIComponent(pageLayoutId)}`))}
+            >
+              <i className="bi bi-diagram-3" /> 構造編集
+            </button>
+            <button
+              type="button"
+              className="pld-btn pld-btn-primary"
+              onClick={handleSaveAssignments}
+              disabled={!assignmentDirty || assignmentSaving || externalPageLayoutChanged}
+            >
+              <i className="bi bi-save" /> {assignmentSaving ? "保存中..." : "割り当て保存"}
+            </button>
+          </div>
+        </div>
+
+        {assignmentError && (
+          <div className="pld-alert" role="alert">
+            <span>
+              <i className="bi bi-exclamation-triangle" /> {assignmentError}
+            </span>
+            {externalPageLayoutChanged && (
+              <button type="button" className="pld-alert-action" onClick={handleReloadPageLayout}>
+                <i className="bi bi-arrow-clockwise" /> 再読み込み
+              </button>
+            )}
+          </div>
+        )}
+
+        <div className="pld-manager-grid">
+          <div className="pld-canvas" data-testid="page-layout-manager-canvas">
+            {visualRegions.map((region) => {
+              const assignedId = assignmentDraft[region.name];
+              const assignedName = assignedId ? gadgetOptionMap.get(assignedId) ?? assignedId : "";
+              return (
+                <section
+                  key={region.name}
+                  className={`pld-slot pld-slot-${region.role}`}
+                  data-testid={`page-layout-slot-${region.name}`}
+                >
+                  <div className="pld-slot-head">
+                    <span className="pld-slot-label">{region.label}</span>
+                    <code>{region.name}</code>
+                  </div>
+                  {region.description && <p>{region.description}</p>}
+                  {region.name === "main" ? (
+                    <div className="pld-content-slot">
+                      <i className="bi bi-window" />
+                      <span>page Screen content</span>
+                    </div>
+                  ) : (
+                    <div className={assignedId ? "pld-gadget-chip assigned" : "pld-gadget-chip"}>
+                      <i className={assignedId ? "bi bi-puzzle-fill" : "bi bi-plus-square-dotted"} />
+                      <span>{assignedName || "未割り当て"}</span>
+                    </div>
+                  )}
+                </section>
+              );
+            })}
+          </div>
+
+          <aside className="pld-side-panel" aria-label="slot assignments">
+            <div className="pld-side-title">
+              <i className="bi bi-ui-checks-grid" />
+              <span>Slot assignments</span>
+            </div>
+            <div className="pld-assignment-list">
+              {visualRegions.map((region) => (
+                <label key={region.name} className="pld-assignment-row">
+                  <span>
+                    <code>{region.name}</code>
+                    <small>{region.label}</small>
+                  </span>
+                  {region.name === "main" ? (
+                    <span className="pld-main-lock">
+                      <i className="bi bi-lock" /> content slot
+                    </span>
+                  ) : (
+                    <select
+                      value={assignmentDraft[region.name] ?? ""}
+                      onChange={(e) => handleAssignmentChange(region.name, e.target.value)}
+                      data-testid={`page-layout-assignment-${region.name}`}
+                    >
+                      <option value="">未割り当て</option>
+                      {selectOptions.map((gadget) => (
+                        <option key={gadget.id} value={gadget.id}>{gadget.name}</option>
+                      ))}
+                    </select>
+                  )}
+                </label>
+              ))}
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      <section className="pld-designer-shell" aria-label="ページレイアウトデザイン詳細">
+        {editor}
+      </section>
+    </div>
+  );
+}
+
+function buildVisualRegions(pl: PageLayout) {
+  const regions = pl.regions ?? [];
+  return [...regions].sort((a, b) => {
+    const ai = RESERVED_REGION_ORDER.indexOf(a.name);
+    const bi = RESERVED_REGION_ORDER.indexOf(b.name);
+    if (ai === -1 && bi === -1) return 0;
+    if (ai === -1) return 1;
+    if (bi === -1) return -1;
+    return ai - bi;
+  }).map((region) => {
+    const role = RESERVED_REGION_ORDER.includes(region.name) ? region.name : "custom";
+    return {
+      ...region,
+      role,
+      label: role === "header"
+        ? "Header"
+        : role === "sidebar"
+        ? "Sidebar"
+        : role === "main"
+        ? "Main content"
+        : role === "footer"
+        ? "Footer"
+        : "Custom slot",
+    };
+  });
+}
+
+function isTargetPageLayoutBroadcast(data: unknown, pageLayoutId: string | undefined): boolean {
+  if (!pageLayoutId) return false;
+  if (!data || typeof data !== "object") return true;
+  const payload = data as { pageLayoutId?: unknown; id?: unknown };
+  const broadcastId = payload.pageLayoutId ?? payload.id;
+  return broadcastId === undefined || String(broadcastId) === pageLayoutId;
+}
+
+async function loadGadgetOptions(): Promise<GadgetOption[]> {
+  const project = await loadProject();
+  return (project.screens ?? [])
+    .filter((screen) => screen.purpose === "gadget")
+    .map((screen) => ({ id: screen.id, name: screen.name }));
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/styles/pageLayoutDesigner.css
+++ b/frontend/src/styles/pageLayoutDesigner.css
@@ -1,0 +1,339 @@
+.pld-page {
+  min-height: 100vh;
+  overflow: auto;
+  background: #f4f6f8;
+  color: #1f2937;
+}
+
+.pld-manager {
+  padding: 18px 20px 20px;
+  background: #f9fafb;
+  border-bottom: 1px solid #d8dee6;
+}
+
+.pld-manager-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 16px;
+}
+
+.pld-kicker {
+  margin-bottom: 3px;
+  color: #526071;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.pld-manager h1 {
+  margin: 0;
+  color: #111827;
+  font-size: 24px;
+  line-height: 1.2;
+}
+
+.pld-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 8px;
+  color: #596679;
+  font-size: 13px;
+}
+
+.pld-meta span {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.pld-manager-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.pld-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 34px;
+  padding: 7px 12px;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.pld-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.pld-btn-primary {
+  color: #ffffff;
+  background: #166534;
+  border-color: #14532d;
+}
+
+.pld-btn-secondary {
+  color: #243244;
+  background: #ffffff;
+  border-color: #c7d0dc;
+}
+
+.pld-alert {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 14px;
+  padding: 9px 12px;
+  border: 1px solid #f59e0b;
+  border-radius: 6px;
+  background: #fffbeb;
+  color: #92400e;
+  font-size: 13px;
+}
+
+.pld-alert span {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.pld-alert-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-height: 28px;
+  padding: 4px 9px;
+  border: 1px solid #d97706;
+  border-radius: 6px;
+  background: #ffffff;
+  color: #92400e;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.pld-manager-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 340px);
+  gap: 16px;
+  align-items: stretch;
+}
+
+.pld-canvas {
+  display: grid;
+  grid-template-columns: minmax(150px, 240px) minmax(0, 1fr);
+  grid-template-rows: auto minmax(190px, 1fr) auto;
+  gap: 10px;
+  min-height: 360px;
+  padding: 12px;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.pld-slot {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+  min-height: 86px;
+  padding: 12px;
+  border: 1px solid #c6d1de;
+  border-radius: 6px;
+  background: #f8fafc;
+}
+
+.pld-slot-header {
+  grid-column: 1 / -1;
+  background: #eef6ff;
+  border-color: #93c5fd;
+}
+
+.pld-slot-sidebar {
+  grid-column: 1;
+  grid-row: 2;
+  background: #f5f3ff;
+  border-color: #c4b5fd;
+}
+
+.pld-slot-main {
+  grid-column: 2;
+  grid-row: 2;
+  background: #ecfdf5;
+  border-color: #86efac;
+}
+
+.pld-slot-footer {
+  grid-column: 1 / -1;
+  background: #fff7ed;
+  border-color: #fdba74;
+}
+
+.pld-slot-custom {
+  grid-column: 1 / -1;
+  background: #f7fee7;
+  border-color: #bef264;
+}
+
+.pld-slot-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.pld-slot-label {
+  font-size: 14px;
+  font-weight: 700;
+  color: #172033;
+}
+
+.pld-slot code,
+.pld-assignment-row code {
+  overflow-wrap: anywhere;
+  color: #334155;
+  font-size: 12px;
+}
+
+.pld-slot p {
+  margin: 0;
+  color: #526071;
+  font-size: 12px;
+}
+
+.pld-content-slot,
+.pld-gadget-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  align-self: flex-start;
+  max-width: 100%;
+  min-height: 30px;
+  padding: 5px 9px;
+  border-radius: 999px;
+  border: 1px solid #d1d5db;
+  background: #ffffff;
+  color: #4b5563;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.pld-content-slot {
+  border-color: #22c55e;
+  color: #166534;
+}
+
+.pld-gadget-chip.assigned {
+  border-color: #2563eb;
+  color: #1d4ed8;
+}
+
+.pld-content-slot span,
+.pld-gadget-chip span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pld-side-panel {
+  min-width: 0;
+  padding: 13px;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.pld-side-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+  color: #172033;
+  font-weight: 700;
+}
+
+.pld-assignment-list {
+  display: grid;
+  gap: 10px;
+}
+
+.pld-assignment-row {
+  display: grid;
+  gap: 6px;
+}
+
+.pld-assignment-row > span:first-child {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.pld-assignment-row small {
+  color: #667085;
+  font-size: 12px;
+}
+
+.pld-assignment-row select {
+  width: 100%;
+  min-height: 34px;
+  padding: 6px 8px;
+  border: 1px solid #c7d0dc;
+  border-radius: 6px;
+  background: #ffffff;
+  color: #1f2937;
+}
+
+.pld-main-lock {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 34px;
+  padding: 6px 9px;
+  border: 1px solid #bbf7d0;
+  border-radius: 6px;
+  background: #f0fdf4;
+  color: #166534;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.pld-designer-shell {
+  height: min(760px, 86vh);
+  min-height: 560px;
+  border-top: 1px solid #d8dee6;
+  background: #ffffff;
+}
+
+@media (max-width: 960px) {
+  .pld-manager-header,
+  .pld-manager-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .pld-manager-grid,
+  .pld-canvas {
+    grid-template-columns: 1fr;
+  }
+
+  .pld-slot-header,
+  .pld-slot-sidebar,
+  .pld-slot-main,
+  .pld-slot-footer,
+  .pld-slot-custom {
+    grid-column: 1;
+    grid-row: auto;
+  }
+}


### PR DESCRIPTION
## Summary

- Add a PageLayout Manager panel above the existing PageLayout Designer so slots are visible as header / sidebar / main / footer / custom regions.
- Add gadget assignment controls for non-main regions, with explicit save via the existing PageLayout store.
- Keep the existing GrapesJS / Puck design editor available below the manager and update the UI reference to match the implemented UX.

## Validation

- `npm run test:unit --workspace=frontend -- PageLayoutDesigner.test.tsx`
- `npm run lint --workspace=frontend` (passes with existing `Designer.tsx` warning)
- `npm run build --workspace=frontend`
- `git diff --name-only origin/main..HEAD -- schemas/` => no schema changes

Closes #1468
