### PR TITLE
fix(workspace): gate child routes until workspace session is ready

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -532,6 +532,8 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
         })
         .catch((err) => {
           console.error("[workspace] initial per-session restore failed:", err);
+          const guard = checkRedirect("/workspace/select");
+          if (guard.allow) navigate("/workspace/select", { replace: true });
         })
         .finally(() => {
           if (__recoveryPendingWsId === activeId) __recoveryPendingWsId = null;
@@ -551,7 +553,10 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
         // backend の workspace.changed broadcast は requester を除外する (wsBridge.ts excludeClientId)。
         // 自セッション側は broadcast を受けないため、明示的に loadWorkspaces で state.active を更新する。
         // (#956 / puck-editor:67 reload 復元 race の真因対応)
-        .then(() => loadWorkspaces())
+        .then(() => {
+          __initialRestoreDoneWsIds.add(action.id);
+          return loadWorkspaces();
+        })
         .catch((err) => {
           console.error("[workspace] workspace.open from routing guard failed:", err);
           const guard = checkRedirect("/workspace/select");

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -68,7 +68,7 @@ import { recordError } from "../utils/errorLog";
 import { isValidUuid } from "../utils/entityIdValidation";
 import { checkRedirect, subscribeRedirectGuardTrip, isRedirectGuardTripped } from "../utils/redirectGuard";
 import { uiInfo, uiWarn, setupServerLogFlush } from "../utils/uiLog";
-import { evaluateRoutingGuard } from "../routing/workspaceRouting";
+import { evaluateRoutingGuard, isWorkspaceChildRouteReady } from "../routing/workspaceRouting";
 
 function useTabs() {
   const [tabs, setTabs] = useState<readonly TabItem[]>(getTabs);
@@ -523,11 +523,13 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
       wsId === workspaceState.active.id &&
       __recoveryPendingWsId === null
     ) {
-      __initialRestoreDoneWsIds.add(wsId);
       const activeId = workspaceState.active.id;
       __recoveryPendingWsId = activeId;
       mcpBridge.request("workspace.open", { id: activeId })
-        .then(() => loadWorkspaces())
+        .then(() => {
+          __initialRestoreDoneWsIds.add(wsId);
+          return loadWorkspaces();
+        })
         .catch((err) => {
           console.error("[workspace] initial per-session restore failed:", err);
         })
@@ -998,6 +1000,23 @@ function AppShellInner({ wsId }: { wsId: string | undefined }) {
       }}>
         <i className="bi bi-hourglass-split" style={{ fontSize: "1.5rem" }} />
         <p style={{ margin: 0 }}>ワークスペース情報を読み込み中...</p>
+      </div>
+    );
+  }
+
+  // routing guard の workspace.open / per-session restore は effect で走るため、
+  // その完了前に子 Route を描画すると loadProject / editSession.list 等が
+  // workspace 未選択の backend session に向けて発火する。URL の wsId と
+  // active workspace が一致し、必要な restore が完了するまで child mount を遅延する。
+  if (!isWorkspaceChildRouteReady(workspaceState, wsId, __initialRestoreDoneWsIds, __recoveryPendingWsId)) {
+    return (
+      <div style={{
+        display: "flex", alignItems: "center", justifyContent: "center",
+        height: "100vh", flexDirection: "column", gap: "8px",
+        color: "var(--muted-text, #888)",
+      }}>
+        <i className="bi bi-hourglass-split" style={{ fontSize: "1.5rem" }} />
+        <p style={{ margin: 0 }}>ワークスペースを開いています...</p>
       </div>
     );
   }

--- a/frontend/src/components/AppShell.workspaceRestore.test.tsx
+++ b/frontend/src/components/AppShell.workspaceRestore.test.tsx
@@ -1,0 +1,142 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const bridgeMock = vi.hoisted(() => ({
+  request: vi.fn(),
+  statusCallbacks: [] as Array<(status: string) => void>,
+  broadcastCallbacks: [] as Array<(data: unknown) => void>,
+}));
+
+vi.mock("../mcp/mcpBridge", () => ({
+  mcpBridge: {
+    request: bridgeMock.request,
+    onStatusChange: vi.fn((cb: (status: string) => void) => {
+      bridgeMock.statusCallbacks.push(cb);
+      return () => {};
+    }),
+    onBroadcast: vi.fn((_event: string, cb: (data: unknown) => void) => {
+      bridgeMock.broadcastCallbacks.push(cb);
+      return () => {};
+    }),
+    startWithoutEditor: vi.fn(),
+    markFailed: vi.fn(),
+  },
+}));
+
+vi.mock("./flow/FlowEditor", () => ({ FlowEditor: () => <div data-testid="flow-editor" /> }));
+vi.mock("./flow/ScreenListView", () => ({ ScreenListView: () => <div data-testid="screen-list" /> }));
+vi.mock("./table/TableListView", () => ({ TableListView: () => <div /> }));
+vi.mock("./table/TableEditor", () => ({ TableEditor: () => <div /> }));
+vi.mock("./table/ErDiagram", () => ({ ErDiagram: () => <div /> }));
+vi.mock("./process-flow/ProcessFlowListView", () => ({ ProcessFlowListView: () => <div /> }));
+vi.mock("./process-flow/ProcessFlowEditor", () => ({ ProcessFlowEditor: () => <div /> }));
+vi.mock("./extensions/ExtensionsPanel", () => ({ ExtensionsPanel: () => <div /> }));
+vi.mock("./conventions/ConventionsCatalogView", () => ({ ConventionsCatalogView: () => <div /> }));
+vi.mock("./screen-items/ScreenItemsView", () => ({ ScreenItemsView: () => <div /> }));
+vi.mock("./sequence/SequenceListView", () => ({ SequenceListView: () => <div /> }));
+vi.mock("./sequence/SequenceEditor", () => ({ SequenceEditor: () => <div /> }));
+vi.mock("./view/ViewListView", () => ({ ViewListView: () => <div /> }));
+vi.mock("./view/ViewEditor", () => ({ ViewEditor: () => <div /> }));
+vi.mock("./view-definition/ViewDefinitionListView", () => ({ ViewDefinitionListView: () => <div /> }));
+vi.mock("./view-definition/ViewDefinitionEditor", () => ({ ViewDefinitionEditor: () => <div /> }));
+vi.mock("./page-layout/PageLayoutListView", () => ({ PageLayoutListView: () => <div /> }));
+vi.mock("./page-layout/PageLayoutEditor", () => ({ PageLayoutEditor: () => <div /> }));
+vi.mock("./page-layout/PageLayoutDesigner", () => ({ PageLayoutDesigner: () => <div /> }));
+vi.mock("./gadget/GadgetListView", () => ({ GadgetListView: () => <div /> }));
+vi.mock("./generic-definition/GenericDefinitionCatalogView", () => ({ GenericDefinitionCatalogView: () => <div /> }));
+vi.mock("./generic-definition/GenericDefinitionListView", () => ({ GenericDefinitionListView: () => <div /> }));
+vi.mock("./generic-definition/GenericDefinitionEditor", () => ({ GenericDefinitionEditor: () => <div /> }));
+vi.mock("./workspace/WorkspaceListView", () => ({ WorkspaceListView: () => <div data-testid="workspace-list" /> }));
+vi.mock("./workspace/WorkspaceSelectView", () => ({ WorkspaceSelectView: () => <div data-testid="workspace-select" /> }));
+vi.mock("./project/TechStackView", () => ({ TechStackView: () => <div /> }));
+vi.mock("./DesignerTabHost", () => ({ DesignerTabHost: () => <div /> }));
+vi.mock("./codex/CodexSettingsView", () => ({ CodexSettingsView: () => <div /> }));
+vi.mock("./dashboard/DashboardView", () => ({ DashboardView: () => <div data-testid="dashboard" /> }));
+vi.mock("./TabBar", () => ({ TabBar: () => <div /> }));
+vi.mock("./CommonHeader", () => ({ CommonHeader: () => <div /> }));
+vi.mock("./common/ErrorBoundary", () => ({ ErrorBoundary: ({ children }: { children: ReactNode }) => <>{children}</> }));
+vi.mock("./common/ErrorFallback", () => ({ TabErrorFallback: () => <div /> }));
+vi.mock("./common/ResourceLoading", () => ({ ResourceLoading: () => <div /> }));
+vi.mock("./common/ErrorDialogProvider", () => ({ useErrorDialog: () => ({ showError: vi.fn() }) }));
+vi.mock("../hooks/useTabKeyboard", () => ({ useTabKeyboard: vi.fn() }));
+vi.mock("../store/flowStore", () => ({ loadProject: vi.fn() }));
+vi.mock("../store/tableStore", () => ({ loadTable: vi.fn() }));
+vi.mock("../store/processFlowStore", () => ({ loadProcessFlow: vi.fn() }));
+vi.mock("../store/sequenceStore", () => ({ loadSequence: vi.fn() }));
+vi.mock("../store/viewStore", () => ({ loadView: vi.fn() }));
+vi.mock("../store/viewDefinitionStore", () => ({ loadViewDefinition: vi.fn() }));
+vi.mock("../store/pageLayoutStore", () => ({ loadPageLayout: vi.fn() }));
+vi.mock("../store/genericDefinitionStore", () => ({ loadGenericDefinition: vi.fn() }));
+vi.mock("../store/tabStore", () => ({
+  getTabs: vi.fn(() => []),
+  getActiveTabId: vi.fn(() => null),
+  subscribe: vi.fn(() => () => {}),
+  openTab: vi.fn(),
+  setActiveTab: vi.fn(),
+  closeTab: vi.fn(),
+  makeTabId: vi.fn((type: string, id: string) => `${type}:${id}`),
+  clearPersistedTabs: vi.fn(),
+}));
+vi.mock("../utils/redirectGuard", () => ({
+  checkRedirect: vi.fn(() => ({ allow: true })),
+  subscribeRedirectGuardTrip: vi.fn(() => () => {}),
+  isRedirectGuardTripped: vi.fn(() => false),
+}));
+vi.mock("../utils/uiLog", () => ({
+  uiInfo: vi.fn(),
+  uiWarn: vi.fn(),
+  setupServerLogFlush: vi.fn(() => () => {}),
+}));
+vi.mock("../utils/errorLog", () => ({ recordError: vi.fn() }));
+
+describe("AppShell workspace initial restore", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    bridgeMock.statusCallbacks.length = 0;
+    bridgeMock.broadcastCallbacks.length = 0;
+    const workspaceStore = await import("../store/workspaceStore");
+    workspaceStore.__resetStateForTest();
+    workspaceStore.__resetLoadChainForTest();
+    bridgeMock.request.mockImplementation(async (method: string) => {
+      if (method === "workspace.list") {
+        return {
+          workspaces: [{ id: "ws-aaa", path: "/data/ws-aaa", name: "WS A", lastOpenedAt: null }],
+          lastActiveId: "ws-aaa",
+          active: { id: "ws-aaa", path: "/data/ws-aaa", name: "WS A" },
+          lockdown: false,
+          lockdownPath: null,
+        };
+      }
+      if (method === "workspace.open") {
+        throw new Error("open failed");
+      }
+      return {};
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("initial restore が失敗したら spinner 固定ではなく workspace select へ戻す", async () => {
+    const { AppShell } = await import("./AppShell");
+    render(
+      <MemoryRouter initialEntries={["/w/ws-aaa/screen/list"]}>
+        <AppShell />
+      </MemoryRouter>,
+    );
+
+    bridgeMock.statusCallbacks.forEach((cb) => cb("connected"));
+
+    await waitFor(() => {
+      expect(bridgeMock.request).toHaveBeenCalledWith("workspace.open", { id: "ws-aaa" });
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("workspace-select")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("ワークスペースを開いています...")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/routing/workspaceRouting.test.ts
+++ b/frontend/src/routing/workspaceRouting.test.ts
@@ -17,6 +17,7 @@ import { describe, it, expect } from "vitest";
 import {
   wsPath,
   evaluateRoutingGuard,
+  isWorkspaceChildRouteReady,
   type RoutingGuardWorkspaceState,
 } from "./workspaceRouting";
 
@@ -114,6 +115,53 @@ describe("evaluateRoutingGuard (AppShellInner)", () => {
   it("wsId が undefined のとき何もしない (active あり)", () => {
     const result = evaluateRoutingGuard(baseState, undefined);
     expect(result).toEqual({ type: "none" });
+  });
+});
+
+// ─── child route mount readiness ─────────────────────────────────────────────
+
+describe("isWorkspaceChildRouteReady (AppShellInner child mount gate)", () => {
+  const baseState: RoutingGuardWorkspaceState = {
+    active: { id: "ws-aaa", path: "/data/ws-aaa", name: "テストWS" },
+    workspaces: [
+      { id: "ws-aaa", path: "/data/ws-aaa", name: "テストWS" },
+    ],
+    loading: false,
+    lockdown: false,
+    error: null,
+  };
+
+  it("workspace.open pending 中は child route を mount しない", () => {
+    expect(
+      isWorkspaceChildRouteReady(baseState, "ws-aaa", new Set(), "ws-aaa"),
+    ).toBe(false);
+  });
+
+  it("workspace.open 成功後のみ child route を mount する", () => {
+    expect(
+      isWorkspaceChildRouteReady(baseState, "ws-aaa", new Set(["ws-aaa"]), null),
+    ).toBe(true);
+  });
+
+  it("workspace.open 失敗後は success set 未登録なので child route を mount しない", () => {
+    expect(
+      isWorkspaceChildRouteReady(baseState, "ws-aaa", new Set(), null),
+    ).toBe(false);
+  });
+
+  it("URL wsId と active workspace が未同期なら child route を mount しない", () => {
+    expect(
+      isWorkspaceChildRouteReady(baseState, "ws-bbb", new Set(["ws-bbb"]), null),
+    ).toBe(false);
+  });
+
+  it("lockdown / error 状態は既存 routing 側に委ねるため mount gate で止めない", () => {
+    expect(
+      isWorkspaceChildRouteReady({ ...baseState, lockdown: true }, "ws-aaa", new Set(), null),
+    ).toBe(true);
+    expect(
+      isWorkspaceChildRouteReady({ ...baseState, error: "e2e bypass" }, "ws-aaa", new Set(), null),
+    ).toBe(true);
   });
 });
 

--- a/frontend/src/routing/workspaceRouting.ts
+++ b/frontend/src/routing/workspaceRouting.ts
@@ -103,3 +103,29 @@ export function evaluateRoutingGuard(
 
   return { type: "none" };
 }
+
+/**
+ * workspace-scoped child route を mount してよいかを判定する。
+ *
+ * AppShell の routing guard は useEffect で workspace.open / per-session restore を
+ * 発行するため、render 時点では active workspace と backend session の同期が
+ * まだ完了していない場合がある。その間に child route を mount すると、
+ * loadProject / editSession.list 等が workspace 未選択 session に向けて発火する。
+ */
+export function isWorkspaceChildRouteReady(
+  state: RoutingGuardWorkspaceState,
+  wsId: string | undefined,
+  restoredWsIds: ReadonlySet<string>,
+  recoveryPendingWsId: string | null,
+): boolean {
+  if (state.loading) return false;
+  if (state.lockdown) return true;
+  if (state.error !== null) return true;
+
+  const activeId = state.active?.id;
+  if (activeId === undefined) return false;
+  if (wsId && activeId !== wsId) return false;
+  if (!wsId) return true;
+
+  return restoredWsIds.has(wsId) && recoveryPendingWsId !== wsId;
+}


### PR DESCRIPTION
## Summary

Closes #1470

- Delay rendering workspace-scoped child routes until the URL workspace id and active workspace are synchronized.
- Also wait for initial per-session restore to finish before mounting children that call `loadProject`, `editSession.list`, `loadScreenEntity`, or `getExtensions`.
- Keep the existing routing guard effect active so `workspace.open` / restore can still run.

## Verification

- `git diff --name-only origin/main..HEAD -- schemas` -> no schema changes
- `npm run build --workspace=frontend` -> failed before compiling this change because current installed/package-locked TypeScript is 5.5.4 and does not support existing `erasableSyntaxOnly` tsconfig option
- `npx --yes --package typescript@5.9.3 tsc -b frontend/tsconfig.app.json --pretty false` -> failed on pre-existing errors in unrelated files (`ActionHttpContractPanel.tsx`, `ActionMetaTabBar.tsx`, `externalComponents.ts`, `loadExtensions.ts`, `screenItemViewerValidator.ts`, `pageLayoutStore.ts`); no `AppShell.tsx` errors reported

## Notes

This PR intentionally does not change global schemas.
