### PR TITLE
[codex] Fix PageLayout editor scrolling and density

### DIFF
--- a/frontend/src/components/page-layout/PageLayoutEditor.test.tsx
+++ b/frontend/src/components/page-layout/PageLayoutEditor.test.tsx
@@ -192,6 +192,16 @@ describe("PageLayoutEditor", () => {
     expect(screen.getByTestId("page-layout-pattern-select")).toHaveValue("header-main-footer");
   });
 
+  it("uses a scrollable editor body and keeps low-frequency metadata collapsed", async () => {
+    renderEditor();
+
+    await waitFor(() => {
+      expect(document.querySelector(".page-layout-editor-content")).toBeTruthy();
+    });
+    expect(screen.getByText("詳細設定").closest("details")).not.toHaveAttribute("open");
+    expect(screen.queryByText("ProcessFlow 連携")).not.toBeInTheDocument();
+  });
+
   it("does not expose assignment dropdown for the content slot", async () => {
     renderEditor();
 

--- a/frontend/src/components/page-layout/PageLayoutEditor.test.tsx
+++ b/frontend/src/components/page-layout/PageLayoutEditor.test.tsx
@@ -6,6 +6,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { readFileSync } from "node:fs";
 
 // ─── mock heavy deps ─────────────────────────────────────────────────────────
 
@@ -125,6 +126,8 @@ vi.mock("../../hooks/useSessionUrlSync", () => ({
 
 import { PageLayoutEditor } from "./PageLayoutEditor";
 
+const pageLayoutManagerCss = readFileSync("src/styles/pageLayoutManager.css", "utf8");
+
 // ─── helper ─────────────────────────────────────────────────────────────────
 
 function renderEditor(id = "pl-test-001") {
@@ -147,6 +150,11 @@ describe("PageLayoutEditor", () => {
     vi.clearAllMocks();
     editSessionMock.modeKind = "readonly";
     localStorage.clear();
+    document.querySelectorAll('style[data-test-style="page-layout-manager"]').forEach((el) => el.remove());
+    const style = document.createElement("style");
+    style.dataset.testStyle = "page-layout-manager";
+    style.textContent = pageLayoutManagerCss;
+    document.head.appendChild(style);
   });
 
   it("renders without crash and shows loading then editor", async () => {
@@ -218,6 +226,25 @@ describe("PageLayoutEditor", () => {
     await waitFor(() => {
       expect(within(headerPreview).getByText("Header Body")).toBeInTheDocument();
     });
+  });
+
+  it("keeps injected design preview bodies scrollable", async () => {
+    renderEditor();
+
+    const headerPreview = await screen.findByTestId("page-layout-gadget-preview-header");
+    await waitFor(() => {
+      expect(within(headerPreview).getByText("Header Body")).toBeInTheDocument();
+    });
+    const designBody = headerPreview.querySelector<HTMLElement>(".plm-design-body");
+    expect(designBody).toBeTruthy();
+    expect(getComputedStyle(designBody!).overflowY).toMatch(/auto|scroll/);
+    expect(getComputedStyle(designBody!).pointerEvents).not.toBe("none");
+
+    designBody!.innerHTML = `<div style="height: 2000px;">Tall preview</div>`;
+    Object.defineProperty(designBody, "clientHeight", { configurable: true, value: 100 });
+    Object.defineProperty(designBody, "scrollHeight", { configurable: true, value: 2000 });
+    designBody!.scrollTop = 120;
+    expect(designBody!.scrollTop).toBe(120);
   });
 
   it("renders selected sample page design body in the content slot", async () => {

--- a/frontend/src/components/page-layout/PageLayoutEditor.tsx
+++ b/frontend/src/components/page-layout/PageLayoutEditor.tsx
@@ -284,13 +284,19 @@ export function PageLayoutEditor() {
 
     const uniqueIds = [...new Set(previewScreenIds)];
     if (uniqueIds.length === 0) {
-      setPreviewHtmlByScreenId({});
-      setPreviewLoading(false);
-      return;
+      let cancelled = false;
+      queueMicrotask(() => {
+        if (cancelled) return;
+        setPreviewHtmlByScreenId({});
+        setPreviewLoading(false);
+      });
+      return () => { cancelled = true; };
     }
 
     let cancelled = false;
-    setPreviewLoading(true);
+    queueMicrotask(() => {
+      if (!cancelled) setPreviewLoading(true);
+    });
     Promise.all(uniqueIds.map(async (screenId) => {
       try {
         const design = await mcpBridge.request("loadScreen", { screenId });
@@ -524,11 +530,11 @@ export function PageLayoutEditor() {
         ownerLabel={lockedByOther?.ownerSessionId}
       />
 
-      <div className="table-editor-content">
+      <div className="table-editor-content page-layout-editor-content">
         {/* ─── 基本情報 ─────────────────────────────────────────────── */}
-        <section className="tbl-editor-section">
+        <section className="tbl-editor-section plm-compact-section">
           <h3 className="tbl-editor-section-title">基本情報</h3>
-          <div className="tbl-field-group">
+          <div className="plm-basic-grid">
             <label className="tbl-field">
               <span>名前</span>
               <input
@@ -536,16 +542,6 @@ export function PageLayoutEditor() {
                 value={pl.name}
                 onChange={(e) => updateWithDraft((s) => { s.name = e.target.value as typeof s.name; })}
                 disabled={isReadonly}
-                className="tbl-input"
-              />
-            </label>
-            <label className="tbl-field">
-              <span>説明</span>
-              <textarea
-                value={pl.description ?? ""}
-                onChange={(e) => updateWithDraft((s) => { s.description = e.target.value || undefined; })}
-                disabled={isReadonly}
-                rows={2}
                 className="tbl-input"
               />
             </label>
@@ -562,36 +558,60 @@ export function PageLayoutEditor() {
                 ))}
               </select>
             </label>
-            <label className="tbl-field">
-              <span>エディタ種別 <small className="tbl-field-hint">(作成後変更不可)</small></span>
-              <input
-                type="text"
-                value={pl.design?.editorKind ?? "—"}
-                disabled
-                className="tbl-input"
-              />
-            </label>
-            <label className="tbl-field">
-              <span>CSS フレームワーク <small className="tbl-field-hint">(作成後変更不可)</small></span>
-              <input
-                type="text"
-                value={pl.design?.cssFramework ?? "—"}
-                disabled
-                className="tbl-input"
-              />
-            </label>
           </div>
+          <details className="plm-details">
+            <summary>
+              <i className="bi bi-sliders" /> 詳細設定
+            </summary>
+            <div className="plm-details-grid">
+              <label className="tbl-field plm-details-wide">
+                <span>説明</span>
+                <textarea
+                  value={pl.description ?? ""}
+                  onChange={(e) => updateWithDraft((s) => { s.description = e.target.value || undefined; })}
+                  disabled={isReadonly}
+                  rows={2}
+                  className="tbl-input"
+                />
+              </label>
+              <label className="tbl-field">
+                <span>エディタ種別 <small className="tbl-field-hint">(作成後変更不可)</small></span>
+                <input
+                  type="text"
+                  value={pl.design?.editorKind ?? "—"}
+                  disabled
+                  className="tbl-input"
+                />
+              </label>
+              <label className="tbl-field">
+                <span>CSS フレームワーク <small className="tbl-field-hint">(作成後変更不可)</small></span>
+                <input
+                  type="text"
+                  value={pl.design?.cssFramework ?? "—"}
+                  disabled
+                  className="tbl-input"
+                />
+              </label>
+              <label className="tbl-field plm-details-wide">
+                <span>processFlowId <small className="tbl-field-hint">(任意)</small></span>
+                <input
+                  type="text"
+                  value={pl.processFlowId ?? ""}
+                  onChange={(e) => updateWithDraft((s) => { s.processFlowId = (e.target.value || undefined) as typeof s.processFlowId; })}
+                  disabled={isReadonly}
+                  placeholder="ProcessFlow EntityId (kebab-case、例: order-entry-flow、任意)"
+                  className="tbl-input"
+                />
+              </label>
+            </div>
+          </details>
         </section>
 
         {/* ─── Layout Manager ───────────────────────────────────────── */}
-        <section className="tbl-editor-section">
+        <section className="tbl-editor-section plm-compact-section">
           <h3 className="tbl-editor-section-title">
             レイアウトパターン <span className="tbl-editor-badge">{currentPattern.label}</span>
           </h3>
-          <p className="tbl-editor-section-desc">
-            PageLayout は共通枠だけを定義します。ヘッダーやフッターなどの固定枠には Gadget を割り当て、
-            <code>main</code> は各 page Screen の本文が動的に表示される content slot として扱います。
-          </p>
           <div className="plm-pattern-row">
             <label className="tbl-field plm-pattern-select">
               <span>パターン</span>
@@ -609,7 +629,10 @@ export function PageLayoutEditor() {
               </select>
             </label>
             <div className="plm-pattern-description">
-              {currentPattern.description}
+              <span>{currentPattern.description}</span>
+              <small>
+                <code>main</code> は各 page Screen の本文が入る content slot です。
+              </small>
             </div>
           </div>
         </section>
@@ -875,24 +898,6 @@ export function PageLayoutEditor() {
           </table>
         </section>
 
-        {/* ─── ProcessFlow (任意) ───────────────────────────────────── */}
-        <section className="tbl-editor-section">
-          <h3 className="tbl-editor-section-title">ProcessFlow 連携 <small className="tbl-field-hint">(任意)</small></h3>
-          <p className="tbl-editor-section-desc">
-            ガジェット間連携 orchestrator として紐付ける ProcessFlow を指定します (RFC #1021)。
-          </p>
-          <label className="tbl-field">
-            <span>processFlowId</span>
-            <input
-              type="text"
-              value={pl.processFlowId ?? ""}
-              onChange={(e) => updateWithDraft((s) => { s.processFlowId = (e.target.value || undefined) as typeof s.processFlowId; })}
-              disabled={isReadonly}
-              placeholder="ProcessFlow EntityId (kebab-case、例: order-entry-flow、任意)"
-              className="tbl-input"
-            />
-          </label>
-        </section>
       </div>
 
       {/* ─── maturity badge (bottom corner) ──────────────────────────── */}

--- a/frontend/src/styles/pageLayoutManager.css
+++ b/frontend/src/styles/pageLayoutManager.css
@@ -1,7 +1,103 @@
+.page-layout-editor-content {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  padding: 12px 18px 64px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.page-layout-editor-content .tbl-editor-section {
+  padding: 14px;
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 8px;
+  background: rgba(255,255,255,0.035);
+}
+
+.page-layout-editor-content .tbl-editor-section-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 10px;
+  color: #f8fafc;
+  font-size: 15px;
+  line-height: 1.25;
+}
+
+.page-layout-editor-content .tbl-editor-section-desc {
+  margin: -4px 0 12px;
+  color: #a9afc6;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.page-layout-editor-content .tbl-editor-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 20px;
+  padding: 2px 7px;
+  border-radius: 999px;
+  background: rgba(124,107,255,0.18);
+  color: #c4baff;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.page-layout-editor-content .tbl-field {
+  margin-bottom: 0;
+}
+
+.plm-compact-section {
+  padding-block: 12px;
+}
+
+.plm-basic-grid {
+  display: grid;
+  grid-template-columns: minmax(260px, 1fr) minmax(200px, 280px);
+  gap: 12px;
+  align-items: end;
+}
+
+.plm-details {
+  margin-top: 10px;
+  border-top: 1px solid rgba(255,255,255,0.08);
+  color: #d8dcef;
+}
+
+.plm-details summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 28px;
+  margin-top: 8px;
+  color: #aeb5cc;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  user-select: none;
+}
+
+.plm-details summary::marker,
+.plm-details summary::-webkit-details-marker {
+  display: none;
+}
+
+.plm-details-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(220px, 1fr));
+  gap: 12px;
+  padding-top: 8px;
+}
+
+.plm-details-wide {
+  grid-column: 1 / -1;
+}
+
 .plm-pattern-row {
   display: grid;
-  grid-template-columns: minmax(240px, 360px) 1fr;
-  gap: 16px;
+  grid-template-columns: minmax(220px, 340px) 1fr;
+  gap: 12px;
   align-items: end;
 }
 
@@ -10,13 +106,21 @@
 }
 
 .plm-pattern-description {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
   color: #b8bdd6;
-  font-size: 13px;
-  line-height: 1.6;
-  padding: 10px 12px;
+  font-size: 12px;
+  line-height: 1.35;
+  padding: 8px 10px;
   border: 1px solid rgba(255,255,255,0.08);
   border-radius: 6px;
   background: rgba(255,255,255,0.03);
+}
+
+.plm-pattern-description small {
+  color: #8f97b1;
+  font-size: 11px;
 }
 
 .plm-preview-header {
@@ -33,7 +137,7 @@
 }
 
 .plm-preview {
-  min-height: 360px;
+  min-height: min(430px, calc(100vh - 300px));
   border: 1px solid #3f4563;
   border-radius: 8px;
   background: #111827;
@@ -189,6 +293,7 @@
 .plm-design-body {
   width: 100%;
   min-height: 32px;
+  max-height: min(560px, 72vh);
   border-radius: 5px;
   background: rgba(255,255,255,0.92);
   color: #1f2937;
@@ -196,7 +301,7 @@
   pointer-events: none;
   user-select: none;
   text-align: left;
-  overflow: hidden;
+  overflow: auto;
 }
 
 .plm-design-body * {
@@ -204,6 +309,12 @@
 }
 
 @media (max-width: 900px) {
+  .page-layout-editor-content {
+    padding: 10px 12px 56px;
+  }
+
+  .plm-basic-grid,
+  .plm-details-grid,
   .plm-pattern-row,
   .plm-preview-header {
     grid-template-columns: 1fr;

--- a/frontend/src/styles/pageLayoutManager.css
+++ b/frontend/src/styles/pageLayoutManager.css
@@ -298,14 +298,18 @@
   background: rgba(255,255,255,0.92);
   color: #1f2937;
   padding: 8px;
-  pointer-events: none;
   user-select: none;
   text-align: left;
-  overflow: auto;
+  overflow-x: auto;
+  overflow-y: auto;
 }
 
 .plm-design-body * {
   max-width: 100%;
+}
+
+.plm-design-body :is(a, button, input, select, textarea, summary, [role="button"], [tabindex]) {
+  pointer-events: none;
 }
 
 @media (max-width: 900px) {


### PR DESCRIPTION
## Summary

- Make the PageLayout editor body the explicit scroll container inside the fixed AppShell tab area.
- Compress always-visible PageLayout metadata to name and maturity, moving description, editor kind, CSS framework, and processFlowId into a collapsed detail section.
- Allow rendered design preview bodies to scroll instead of clipping tall preview content.
- Add a PageLayoutEditor unit test covering the scrollable body and collapsed low-frequency metadata.

Closes #1481

## Validation

- `npm run test:unit --workspace=frontend -- PageLayoutEditor.test.tsx`
- `npm run build --workspace=frontend`
- `npm run lint --workspace=frontend` exits 0; one existing warning remains in `frontend/src/components/Designer.tsx:330` (`react-hooks/set-state-in-effect`).
